### PR TITLE
[editor]: Use the production OSM servers even for DEBUG

### DIFF
--- a/editor/osm_auth.cpp
+++ b/editor/osm_auth.cpp
@@ -76,11 +76,7 @@ OsmOAuth::OsmOAuth(string const & consumerKey, string const & consumerSecret,
 // static
 OsmOAuth OsmOAuth::ServerAuth() noexcept
 {
-#ifdef DEBUG
-  return DevServerAuth();
-#else
   return ProductionServerAuth();
-#endif
 }
 // static
 OsmOAuth OsmOAuth::ServerAuth(KeySecret const & userKeySecret) noexcept


### PR DESCRIPTION
Previously the staging OSM servers were used for DEBUG.
This behaviour was confusing and misleading.

Signed-off-by: Roman Tsisyk <roman@tsisyk.com>