### PR TITLE
[iOS] Add more keyboard shortcuts

### DIFF
--- a/iphone/Maps/Classes/MapViewController.mm
+++ b/iphone/Maps/Classes/MapViewController.mm
@@ -851,9 +851,14 @@ NSString *const kPP2BookmarkEditingSegue = @"PP2BookmarkEditing";
 }
 
 - (NSArray *)keyCommands {
-   return @[[UIKeyCommand keyCommandWithInput:UIKeyInputDownArrow modifierFlags:0 action:@selector(zoomOut) discoverabilityTitle:@"Zoom Out"],
-    [UIKeyCommand keyCommandWithInput:UIKeyInputUpArrow modifierFlags:0 action:@selector(zoomIn) discoverabilityTitle:@"Zoom In"],
-    [UIKeyCommand keyCommandWithInput:UIKeyInputEscape modifierFlags:0 action:@selector(goBack) discoverabilityTitle:@"Go Back"]];
+   return @[[UIKeyCommand keyCommandWithInput:UIKeyInputDownArrow modifierFlags:0 action:@selector(zoomOut)], // Alternative, not shown when holding CMD
+    [UIKeyCommand keyCommandWithInput:@"-" modifierFlags:UIKeyModifierCommand action:@selector(zoomOut) discoverabilityTitle:@"Zoom Out"],
+    [UIKeyCommand keyCommandWithInput:UIKeyInputUpArrow modifierFlags:0 action:@selector(zoomIn)], // Alternative, not shown when holding CMD
+    [UIKeyCommand keyCommandWithInput:@"=" modifierFlags:UIKeyModifierCommand action:@selector(zoomIn)], // Alternative, not shown when holding CMD
+    [UIKeyCommand keyCommandWithInput:@"+" modifierFlags:UIKeyModifierCommand action:@selector(zoomIn) discoverabilityTitle:@"Zoom In"],
+    [UIKeyCommand keyCommandWithInput:UIKeyInputEscape modifierFlags:0 action:@selector(goBack) discoverabilityTitle:@"Go Back"],
+    [UIKeyCommand keyCommandWithInput:@"0" modifierFlags:UIKeyModifierCommand action:@selector(switchPositionMode) discoverabilityTitle:@"Switch position mode"]
+   ];
 }
 
 - (void)zoomOut {
@@ -862,6 +867,10 @@ NSString *const kPP2BookmarkEditingSegue = @"PP2BookmarkEditing";
 
 - (void)zoomIn {
   GetFramework().Scale(Framework::SCALE_MAG, true);
+}
+
+- (void)switchPositionMode {
+  GetFramework().SwitchMyPositionNextMode();
 }
 
 - (void)goBack {


### PR DESCRIPTION
As per: https://github.com/mapsme/omim/pull/14102

History: #108 

## Why?:
Lots of apps seem to implement their own shortcuts which creates confusion for the end-user. Zooming on an Apple Mac or iOS app has always used CMD + and CMD -.

So to be more in line with Apples defaults from apps (like Apple Maps) which use CMD + and CMD - I have added these as defaults.

A dedicated re-center button it useful when the map was moved or zoomed to quickly get back to the current location and default zoom level.

## Added:

`CMD +` for Zoom In (With an alternative of CMD = to also make it work on non numeric keyboards without much confusion.
`CMD -` for Zoom Out
`CMD 0` for recentering the map / switching to next position mode. (Will re-center if clicked enough)

## Changed:
The original zoom in and zoom out on the arrow keys are still active but not shown in the help popup when holding down CMD for backwards compatibility. We might want to re-use these keys to move the map around sometime in the future.