### PR TITLE
std::vector -> std::array for constant

### DIFF
--- a/drape/support_manager.cpp
+++ b/drape/support_manager.cpp
@@ -10,8 +10,8 @@
 #include "std/target_os.hpp"
 
 #include <algorithm>
+#include <array>
 #include <string>
-#include <vector>
 
 namespace dp
 {
@@ -42,7 +42,7 @@ void SupportManager::Init(ref_ptr<GraphicsContext> context)
 
   if (m_rendererName.find("Adreno") != std::string::npos)
   {
-    std::vector<std::string> const models = { "200", "203", "205", "220", "225" };
+    std::array<std::string, 5> const models = { "200", "203", "205", "220", "225" };
     for (auto const & model : models)
     {
       if (m_rendererName.find(model) != std::string::npos)
@@ -114,14 +114,14 @@ bool SupportManager::IsVulkanForbidden() const
 bool SupportManager::IsVulkanForbidden(std::string const & deviceName,
                                        Version apiVersion, Version driverVersion) const
 {
-  static std::vector<std::string> const kBannedDevices = {"PowerVR Rogue GE8100",
-                                                          "PowerVR Rogue GE8300"};
+  static std::array<std::string ,2> const kBannedDevices = {"PowerVR Rogue GE8100",
+                                                            "PowerVR Rogue GE8300"};
 
   // On these configurations we've detected fatal driver-specific Vulkan errors.
-  static std::vector<Configuration> const kBannedConfigurations = {
-    {"Adreno (TM) 506", {1, 0, 31}, {42, 264, 975}},
-    {"Adreno (TM) 506", {1, 1, 66}, {512, 313, 0}},
-    {"Adreno (TM) 530", {1, 1, 66}, {512, 313, 0}},
+  static std::array<Configuration, 3> const kBannedConfigurations = {
+      Configuration{"Adreno (TM) 506", {1, 0, 31}, {42, 264, 975}},
+      Configuration{"Adreno (TM) 506", {1, 1, 66}, {512, 313, 0}},
+      Configuration{"Adreno (TM) 530", {1, 1, 66}, {512, 313, 0}}
   };
 
   for (auto const & d : kBannedDevices)
@@ -151,7 +151,7 @@ bool SupportManager::IsVulkanTexturePartialUpdateBuggy(int sdkVersion,
     return true;
 
   // For these configurations partial updates of texture clears whole texture except part updated
-  static std::vector<Configuration> const kBadConfigurations = {
+  static std::array<Configuration, 1> const kBadConfigurations = {
       {"Mali-G76", {1, 1, 97}, {18, 0, 0}},
   };
 

--- a/drape/vulkan/vulkan_pipeline.cpp
+++ b/drape/vulkan/vulkan_pipeline.cpp
@@ -12,6 +12,7 @@
 #include "base/assert.hpp"
 #include "base/file_name_utils.hpp"
 
+#include <array>
 #include <string>
 #include <utility>
 #include <vector>
@@ -326,7 +327,7 @@ VkPipeline VulkanPipeline::GetPipeline(VkDevice device, PipelineKey const & key)
   multisampleStateCreateInfo.rasterizationSamples = VK_SAMPLE_COUNT_1_BIT;
 
   // Dynamic.
-  static std::vector<VkDynamicState> dynamicState = {
+  static std::array<VkDynamicState, 4> dynamicState = {
     VK_DYNAMIC_STATE_VIEWPORT, VK_DYNAMIC_STATE_SCISSOR, VK_DYNAMIC_STATE_LINE_WIDTH,
     VK_DYNAMIC_STATE_STENCIL_REFERENCE};
   VkPipelineDynamicStateCreateInfo dynamicStateCreateInfo = {};

--- a/drape_frontend/frontend_renderer.cpp
+++ b/drape_frontend/frontend_renderer.cpp
@@ -38,6 +38,7 @@
 #include "std/target_os.hpp"
 
 #include <algorithm>
+#include <array>
 #include <chrono>
 #include <cmath>
 #include <functional>
@@ -1884,12 +1885,12 @@ void FrontendRenderer::RenderFrame()
 
 void FrontendRenderer::BuildOverlayTree(ScreenBase const & modelView)
 {
-  static std::vector<DepthLayer> layers = {DepthLayer::OverlayLayer,
-                                           DepthLayer::NavigationLayer,
-                                           DepthLayer::RoutingBottomMarkLayer,
-                                           DepthLayer::RoutingMarkLayer};
+  static std::array<DepthLayer, 4> layers = {DepthLayer::OverlayLayer,
+                                             DepthLayer::NavigationLayer,
+                                             DepthLayer::RoutingBottomMarkLayer,
+                                             DepthLayer::RoutingMarkLayer};
   BeginUpdateOverlayTree(modelView);
-  for (auto const & layerId : layers)
+  for (auto const layerId : layers)
   {
     RenderLayer & overlay = m_layers[static_cast<size_t>(layerId)];
     overlay.Sort(make_ref(m_overlayTree));

--- a/drape_frontend/my_position_controller.cpp
+++ b/drape_frontend/my_position_controller.cpp
@@ -15,6 +15,7 @@
 
 
 #include <algorithm>
+#include <array>
 #include <chrono>
 #include <string>
 #include <vector>
@@ -55,7 +56,7 @@ int GetZoomLevel(ScreenBase const & screen, m2::PointD const & position, double 
 double CalculateZoomBySpeed(double speed, bool isPerspectiveAllowed)
 {
   using TSpeedScale = std::pair<double, double>;
-  static std::vector<TSpeedScale> const scales3d = {
+  static std::array<TSpeedScale, 6> const scales3d = {
     std::make_pair(20.0, 0.25),
     std::make_pair(40.0, 0.75),
     std::make_pair(60.0, 1.5),
@@ -64,7 +65,7 @@ double CalculateZoomBySpeed(double speed, bool isPerspectiveAllowed)
     std::make_pair(95.0, 6.0),
   };
 
-  static std::vector<TSpeedScale> const scales2d = {
+  static std::array<TSpeedScale, 6> const scales2d = {
     std::make_pair(20.0, 0.7),
     std::make_pair(40.0, 1.25),
     std::make_pair(60.0, 2.25),
@@ -73,7 +74,7 @@ double CalculateZoomBySpeed(double speed, bool isPerspectiveAllowed)
     std::make_pair(95.0, 6.0),
   };
 
-  std::vector<TSpeedScale> const & scales = isPerspectiveAllowed ? scales3d : scales2d;
+  std::array<TSpeedScale, 6> const & scales = isPerspectiveAllowed ? scales3d : scales2d;
 
   double const kDefaultSpeed = 80.0;
   if (speed < 0.0)

--- a/drape_frontend/rule_drawer.cpp
+++ b/drape_frontend/rule_drawer.cpp
@@ -31,6 +31,7 @@
 #include "base/string_utils.hpp"
 #endif
 
+#include <array>
 #include <functional>
 #include <utility>
 #include <vector>
@@ -41,7 +42,7 @@ namespace
 {
 // The first zoom level in kAverageSegmentsCount.
 int constexpr kFirstZoomInAverageSegments = 10;
-std::vector<size_t> const kAverageSegmentsCount =
+std::array<size_t, 10> const kAverageSegmentsCount =
 {
   // 10  11    12     13    14    15    16    17    18   19
   10000, 5000, 10000, 5000, 2500, 5000, 2000, 1000, 500, 500
@@ -115,8 +116,8 @@ void ExtractTrafficGeometry(FeatureType const & f, df::RoadClass const & roadCla
   if (!oneWay)
     twoWayOffset = pixelToGlobalScale * df::TrafficRenderer::GetTwoWayOffset(roadClass, zoomLevel);
 
-  static std::vector<uint8_t> directions = {traffic::TrafficInfo::RoadSegmentId::kForwardDirection,
-                                            traffic::TrafficInfo::RoadSegmentId::kReverseDirection};
+  static std::array<uint8_t, 2> const directions = {traffic::TrafficInfo::RoadSegmentId::kForwardDirection,
+                                                    traffic::TrafficInfo::RoadSegmentId::kReverseDirection};
   auto & segments = geometry[f.GetID().m_mwmId];
 
   int const index = zoomLevel - kFirstZoomInAverageSegments;

--- a/drape_frontend/traffic_generator.cpp
+++ b/drape_frontend/traffic_generator.cpp
@@ -18,6 +18,7 @@
 #include "base/logging.hpp"
 
 #include <algorithm>
+#include <array>
 #include <memory>
 
 using namespace std::placeholders;
@@ -144,7 +145,7 @@ void TrafficGenerator::GenerateSegmentsGeometry(ref_ptr<dp::GraphicsContext> con
                                                 traffic::TrafficInfo::Coloring const & coloring,
                                                 ref_ptr<dp::TextureManager> texturesMgr)
 {
-  static std::vector<int> const kGenerateCirclesZoomLevel = {14, 14, 16};
+  static std::array<int, 3> const kGenerateCirclesZoomLevel = {14, 14, 16};
 
   ASSERT(m_colorsCacheValid, ());
   auto const colorTexture = m_colorsCache[static_cast<size_t>(traffic::SpeedGroup::G0)].GetTexture();
@@ -167,7 +168,7 @@ void TrafficGenerator::GenerateSegmentsGeometry(ref_ptr<dp::GraphicsContext> con
     isLeftHand = (regionData.Get(feature::RegionData::RD_DRIVING) == "l");
   }
 
-  static std::vector<float> const kRoadClassDepths = {30.0f, 20.0f, 10.0f};
+  static std::array<float, 3> const kRoadClassDepths = {30.0f, 20.0f, 10.0f};
 
   for (auto const & geomPair : geometry)
   {
@@ -237,7 +238,7 @@ void TrafficGenerator::FlushSegmentsGeometry(ref_ptr<dp::GraphicsContext> contex
 {
   FillColorsCache(textures);
 
-  static std::vector<RoadClass> const kRoadClasses = {RoadClass::Class0, RoadClass::Class1,
+  static std::array<RoadClass, 3> const kRoadClasses = {RoadClass::Class0, RoadClass::Class1,
                                                       RoadClass::Class2};
   for (auto const & g : geom)
   {

--- a/routing/routing_quality/routing_quality_tool/utils.cpp
+++ b/routing/routing_quality/routing_quality_tool/utils.cpp
@@ -13,6 +13,7 @@
 #include "base/file_name_utils.hpp"
 #include "base/logging.hpp"
 
+#include <array>
 #include <iomanip>
 #include <utility>
 
@@ -70,7 +71,7 @@ void SaveKmlFileDataTo(RoutesBuilder::Result const & mapsmeResult,
                        AnotherResult const & apiResult,
                        std::string const & kmlFile)
 {
-  static std::vector<uint32_t> const kColors = {
+  static std::array<uint32_t, 5> const kColors = {
       0xff0000ff,  // Red
       0x0000ffff,  // Blue
       0x00ff00ff,  // Green


### PR DESCRIPTION
`std::vector` is not very well suited for static, constant arrays.
Since creating it from a `std::initializer_list` requires memory allocation,
modern C++ compilers miss out on many optimizations.
In particular, compilers are forced to insert a call to a global
atomic variable and a bunch of code for initialization at the place of
its use. Plus access to heap memory cause cache misses
For example for this function:
bool f(const int *arr, int x)
{
    static std::vector<Foo> const values = {A, B, C};

    for (auto v : values) {
        if (arr[static_cast<size_t>(v)] == x)
            return true;
    }
    return false;
}

compiler generates ~60 instructions (gcc 10.2 -O3 -march=native),
if replace `std::vector` with `std::array` the result code contains only 9 instructions.