### PR TITLE
[android] Streamline SplashScreen

### DIFF
--- a/android/src/com/mapswithme/maps/DownloadResourcesLegacyActivity.java
+++ b/android/src/com/mapswithme/maps/DownloadResourcesLegacyActivity.java
@@ -28,6 +28,7 @@ import com.mapswithme.maps.intent.MapTask;
 import com.mapswithme.maps.location.LocationHelper;
 import com.mapswithme.maps.location.LocationListener;
 import com.mapswithme.util.ConnectionState;
+import com.mapswithme.util.Counters;
 import com.mapswithme.util.StringUtils;
 import com.mapswithme.util.UiUtils;
 import com.mapswithme.util.Utils;
@@ -446,8 +447,8 @@ public class DownloadResourcesLegacyActivity extends BaseMwmFragmentActivity imp
     if (intent == null)
       return null;
 
-    MwmApplication application = MwmApplication.from(this);
-    intent.putExtra(Factory.EXTRA_IS_FIRST_LAUNCH, application.isFirstLaunch());
+    boolean isFirstLaunch = Counters.isFirstLaunch(this);
+    intent.putExtra(Factory.EXTRA_IS_FIRST_LAUNCH, isFirstLaunch);
     if (intent.getData() == null)
     {
       /* Sic: the deep link library has been removed */

--- a/android/src/com/mapswithme/maps/MapFragment.java
+++ b/android/src/com/mapswithme/maps/MapFragment.java
@@ -20,6 +20,8 @@ import androidx.appcompat.app.AlertDialog;
 import com.mapswithme.maps.base.BaseMwmFragment;
 import com.mapswithme.maps.location.LocationHelper;
 import com.mapswithme.util.Config;
+import com.mapswithme.util.Counters;
+import com.mapswithme.util.PermissionsUtils;
 import com.mapswithme.util.UiUtils;
 import com.mapswithme.util.concurrency.UiThread;
 import com.mapswithme.util.log.Logger;
@@ -186,7 +188,7 @@ public class MapFragment extends BaseMwmFragment
     requireActivity().getWindowManager().getDefaultDisplay().getMetrics(metrics);
     final float exactDensityDpi = metrics.densityDpi;
 
-    final boolean firstStart = MwmApplication.from(requireActivity()).isFirstLaunch();
+    final boolean firstStart = LocationHelper.INSTANCE.isInFirstRun();
     if (!nativeCreateEngine(surface, (int) exactDensityDpi, firstStart, mLaunchByDeepLink,
                             BuildConfig.VERSION_CODE))
     {

--- a/android/src/com/mapswithme/maps/MwmActivity.java
+++ b/android/src/com/mapswithme/maps/MwmActivity.java
@@ -99,6 +99,7 @@ import com.mapswithme.maps.widget.placepage.PlacePageController;
 import com.mapswithme.maps.widget.placepage.PlacePageData;
 import com.mapswithme.maps.widget.placepage.PlacePageFactory;
 import com.mapswithme.maps.widget.placepage.RoutingModeListener;
+import com.mapswithme.util.Counters;
 import com.mapswithme.util.InputUtils;
 import com.mapswithme.util.PermissionsUtils;
 import com.mapswithme.util.SharingUtils;
@@ -455,10 +456,11 @@ public class MwmActivity extends BaseMwmFragmentActivity
     initViews(isLaunchByDeepLink);
 
     boolean isConsumed = savedInstanceState == null && processIntent(getIntent());
+    boolean isFirstLaunch = Counters.isFirstLaunch(this);
     // If the map activity is launched by any incoming intent (deeplink, update maps event, etc)
     // or it's the first launch (onboarding) we haven't to try restoring the route,
     // showing the tips, etc.
-    if (isConsumed || MwmApplication.from(this).isFirstLaunch())
+    if (isConsumed || isFirstLaunch)
       return;
 
     if (savedInstanceState == null && RoutingController.get().hasSavedRoute())

--- a/android/src/com/mapswithme/maps/MwmBroadcastReceiver.java
+++ b/android/src/com/mapswithme/maps/MwmBroadcastReceiver.java
@@ -11,6 +11,8 @@ import com.mapswithme.util.CrashlyticsUtils;
 import com.mapswithme.util.log.Logger;
 import com.mapswithme.util.log.LoggerFactory;
 
+import java.io.IOException;
+
 public abstract class MwmBroadcastReceiver extends BroadcastReceiver
 {
   private static final Logger LOGGER = LoggerFactory.INSTANCE.getLogger(LoggerFactory.Type.MISC);
@@ -30,13 +32,15 @@ public abstract class MwmBroadcastReceiver extends BroadcastReceiver
     String msg = "onReceive: " + intent;
     LOGGER.i(getTag(), msg);
     CrashlyticsUtils.INSTANCE.log(Log.INFO, getTag(), msg);
-    if (!app.arePlatformAndCoreInitialized() && !app.initCore())
+    try
     {
-      LOGGER.w(getTag(), "Application is not initialized, ignoring " + intent);
+      app.ensureCoreInitialized();
+    } catch (IOException e)
+    {
+      LOGGER.e(getTag(), "Failed to initialize application, ignoring " + intent);
       return;
     }
+
     onReceiveInitialized(context, intent);
   }
-
-
 }

--- a/android/src/com/mapswithme/maps/MwmJobIntentService.java
+++ b/android/src/com/mapswithme/maps/MwmJobIntentService.java
@@ -10,6 +10,8 @@ import com.mapswithme.util.CrashlyticsUtils;
 import com.mapswithme.util.log.Logger;
 import com.mapswithme.util.log.LoggerFactory;
 
+import java.io.IOException;
+
 public abstract class MwmJobIntentService extends JobIntentService
 {
   private static final Logger LOGGER = LoggerFactory.INSTANCE.getLogger(LoggerFactory.Type.MISC);
@@ -29,11 +31,15 @@ public abstract class MwmJobIntentService extends JobIntentService
     String msg = "onHandleWork: " + intent;
     LOGGER.i(getTag(), msg);
     CrashlyticsUtils.INSTANCE.log(Log.INFO, getTag(), msg);
-    if (!app.arePlatformAndCoreInitialized() && !app.initCore())
+    try
     {
-      LOGGER.w(getTag(), "Application is not initialized, ignoring " + intent);
+      app.ensureCoreInitialized();
+    } catch (IOException e)
+    {
+      LOGGER.e(getTag(), "Failed to initialize application, ignoring " + intent);
       return;
     }
+
     onHandleWorkInitialized(intent);
   }
 }

--- a/android/src/com/mapswithme/maps/background/UpgradeReceiver.java
+++ b/android/src/com/mapswithme/maps/background/UpgradeReceiver.java
@@ -1,28 +1,18 @@
 package com.mapswithme.maps.background;
 
-import static com.mapswithme.maps.MwmApplication.backgroundTracker;
-
-import android.content.BroadcastReceiver;
 import android.content.Context;
 import android.content.Intent;
-import android.util.Log;
+
+import androidx.annotation.NonNull;
 
 import com.mapswithme.maps.MwmApplication;
-import com.mapswithme.util.CrashlyticsUtils;
-import com.mapswithme.util.log.Logger;
-import com.mapswithme.util.log.LoggerFactory;
+import com.mapswithme.maps.MwmBroadcastReceiver;
 
-public class UpgradeReceiver extends BroadcastReceiver
+public class UpgradeReceiver extends MwmBroadcastReceiver
 {
-  private static final Logger LOGGER = LoggerFactory.INSTANCE.getLogger(LoggerFactory.Type.MISC);
-  private static final String TAG = UpgradeReceiver.class.getSimpleName();
   @Override
-  public void onReceive(Context context, Intent intent)
+  protected void onReceiveInitialized(@NonNull Context context, @NonNull Intent intent)
   {
-    String msg = "onReceive: " + intent + " app in background = "
-                 + !backgroundTracker(context).isForeground();
-    LOGGER.i(TAG, msg);
-    CrashlyticsUtils.INSTANCE.log(Log.INFO, TAG, msg);
     MwmApplication.onUpgrade(context);
   }
 }

--- a/android/src/com/mapswithme/maps/location/LocationHelper.java
+++ b/android/src/com/mapswithme/maps/location/LocationHelper.java
@@ -586,6 +586,12 @@ public enum LocationHelper implements Initializable<Context>
   }
 
   @UiThread
+  public boolean isInFirstRun()
+  {
+    return mInFirstRun;
+  }
+
+  @UiThread
   public void onEnteredIntoFirstRun()
   {
     mLogger.i(TAG, "onEnteredIntoFirstRun");

--- a/android/src/com/mapswithme/util/Counters.java
+++ b/android/src/com/mapswithme/util/Counters.java
@@ -6,6 +6,7 @@ import android.text.format.DateUtils;
 
 import androidx.annotation.NonNull;
 import androidx.fragment.app.DialogFragment;
+import androidx.fragment.app.FragmentManager;
 import androidx.preference.PreferenceManager;
 
 import com.mapswithme.maps.BuildConfig;
@@ -24,8 +25,6 @@ public final class Counters
   static final String KEY_LIKES_LAST_RATED_SESSION = "LastRatedSession";
 
   private static final String KEY_LIKES_RATED_DIALOG = "RatedDialog";
-  private static final String KEY_SHOW_REVIEW_FOR_OLD_USER = "ShowReviewForOldUser";
-  private static final String KEY_MIGRATION_EXECUTED = "MigrationExecuted";
 
   private Counters() {}
 
@@ -40,26 +39,17 @@ public final class Counters
     return MwmApplication.prefs(context).getInt(KEY_APP_FIRST_INSTALL_VERSION, 0);
   }
 
-  public static boolean isFirstStartDialogSeen(@NonNull Context context)
+  public static boolean isFirstLaunch(@NonNull Context context)
   {
-    return MwmApplication.prefs(context).getBoolean(KEY_MISC_FIRST_START_DIALOG_SEEN, false);
+    return !MwmApplication.prefs(context).getBoolean(KEY_MISC_FIRST_START_DIALOG_SEEN, false);
   }
 
   public static void setFirstStartDialogSeen(@NonNull Context context)
   {
     MwmApplication.prefs(context)
-                  .edit()
-                  .putBoolean(KEY_MISC_FIRST_START_DIALOG_SEEN, true)
-                  .apply();
-  }
-
-
-  public static void setWhatsNewShown(@NonNull Context context)
-  {
-    MwmApplication.prefs(context)
-                  .edit()
-                  .putInt(KEY_MISC_NEWS_LAST_VERSION, BuildConfig.VERSION_CODE)
-                  .apply();
+        .edit()
+        .putBoolean(KEY_MISC_FIRST_START_DIALOG_SEEN, true)
+        .apply();
   }
 
   public static void resetAppSessionCounters(@NonNull Context context)
@@ -169,29 +159,5 @@ public final class Counters
                   .putInt(key, ++value)
                   .apply();
     return value;
-  }
-
-  public static void setShowReviewForOldUser(@NonNull Context context, boolean value)
-  {
-    MwmApplication.prefs(context).edit()
-                  .putBoolean(KEY_SHOW_REVIEW_FOR_OLD_USER, value)
-                  .apply();
-  }
-
-  public static boolean isShowReviewForOldUser(@NonNull Context context)
-  {
-    return MwmApplication.prefs(context).getBoolean(KEY_SHOW_REVIEW_FOR_OLD_USER, false);
-  }
-
-  public static boolean isMigrationNeeded(@NonNull Context context)
-  {
-    return !MwmApplication.prefs(context).getBoolean(KEY_MIGRATION_EXECUTED, false);
-  }
-
-  public static void setMigrationExecuted(@NonNull Context context)
-  {
-    MwmApplication.prefs(context).edit()
-                  .putBoolean(KEY_MIGRATION_EXECUTED, true)
-                  .apply();
   }
 }

--- a/android/src/com/mapswithme/util/PermissionsUtils.java
+++ b/android/src/com/mapswithme/util/PermissionsUtils.java
@@ -57,8 +57,9 @@ public final class PermissionsUtils
     Map<String, Boolean> result = new HashMap<>();
     for (String permission: PERMISSIONS)
     {
-      result.put(permission, Build.VERSION.SDK_INT < Build.VERSION_CODES.M
-                 || appContext.checkSelfPermission(permission) == PackageManager.PERMISSION_GRANTED);
+      boolean granted = Build.VERSION.SDK_INT < Build.VERSION_CODES.M
+          || appContext.checkSelfPermission(permission) == PackageManager.PERMISSION_GRANTED;
+      result.put(permission, granted);
     }
 
     return getPermissionsResult(result);
@@ -72,11 +73,6 @@ public final class PermissionsUtils
                               || (result.containsKey(ACCESS_FINE_LOCATION)
                                   ? result.get(ACCESS_FINE_LOCATION) : false);
     return new PermissionsResult(locationGranted);
-  }
-
-  public static void requestPermissions(@NonNull Activity activity, int code)
-  {
-    ActivityCompat.requestPermissions(activity, PERMISSIONS, code);
   }
 
   public static void requestLocationPermission(@NonNull Activity activity, int code)

--- a/android/src/com/mapswithme/util/SharedPropertiesUtils.java
+++ b/android/src/com/mapswithme/util/SharedPropertiesUtils.java
@@ -13,6 +13,7 @@ import com.mapswithme.maps.MwmApplication;
 import com.mapswithme.maps.R;
 import com.mapswithme.maps.maplayer.Mode;
 
+import java.io.IOException;
 import java.util.Locale;
 
 public final class SharedPropertiesUtils
@@ -63,12 +64,18 @@ public final class SharedPropertiesUtils
     return prefs.getBoolean(PREFS_SHOW_EMULATE_BAD_STORAGE_SETTING, false);
   }
 
-  public static boolean shouldEmulateBadExternalStorage(@NonNull Context context)
+  /**
+   * @param context context
+   * @throws IOException if "Emulate bad storage" is enabled in preferences
+   */
+  public static void emulateBadExternalStorage(@NonNull Context context) throws IOException
   {
     SharedPreferences prefs = PreferenceManager
         .getDefaultSharedPreferences(MwmApplication.from(context));
     String key = MwmApplication.from(context).getString(R.string.pref_emulate_bad_external_storage);
-    return prefs.getBoolean(key, false);
+    if (prefs.getBoolean(key, false)) {
+      throw new IOException("Bad external storage error injection");
+    }
   }
 
   public static boolean shouldShowNewMarkerForLayerMode(@NonNull Context context,

--- a/android/src/com/mapswithme/util/StorageUtils.java
+++ b/android/src/com/mapswithme/util/StorageUtils.java
@@ -17,6 +17,7 @@ import com.mapswithme.util.log.Logger;
 import com.mapswithme.util.log.LoggerFactory;
 
 import java.io.File;
+import java.io.IOException;
 
 public class StorageUtils
 {
@@ -138,17 +139,16 @@ public class StorageUtils
     return addTrailingSeparator(application.getCacheDir().getAbsolutePath());
   }
 
-  public static boolean createDirectory(@NonNull Context context, @NonNull String path)
+  public static void createDirectory(@NonNull String path) throws IOException
   {
     File directory = new File(path);
     if (!directory.exists() && !directory.mkdirs())
     {
-      Throwable error = new IllegalStateException("Can't create directories for: " + path);
+      IOException error = new IOException("Can't create directories for: " + path);
       LOGGER.e(TAG, "Can't create directories for: " + path);
       CrashlyticsUtils.INSTANCE.logException(error);
-      return false;
+      throw error;
     }
-    return true;
   }
 
   static long getFileSize(@NonNull String path)


### PR DESCRIPTION
- Fix a crash if location permission is not granted.
- Use exceptions instead of boolean for I/O errors.
- Handle the first run properly.
- Fix UpgradeReceiver.

Closes #340

Signed-off-by: Roman Tsisyk <roman@tsisyk.com>