### PR TITLE
Update "kiosk" and "newsagent" categories

### DIFF
--- a/data/categories.txt
+++ b/data/categories.txt
@@ -1800,7 +1800,7 @@ fi:Kioski
 fr:Kiosque
 de:Kiosk
 hu:Trafik
-it:Chiosco
+it:Edicola|Giornalaio
 ja:1キオスク|売店
 ko:키오스크
 pl:Kiosk|gazety|prasa
@@ -8917,7 +8917,7 @@ fi:Lehtikioski
 fr:Kiosque à journaux
 hu:Újságárus
 id:Kios Surat Kabar
-it:Edicola
+it:Edicola|Giornalaio
 ja:新聞販売店
 ko:신문 가판대
 nb:Aviskiosk

--- a/data/categories.txt
+++ b/data/categories.txt
@@ -1800,7 +1800,7 @@ fi:Kioski
 fr:Kiosque
 de:Kiosk
 hu:Trafik
-it:Edicola|Giornalaio
+it:Chiosco|Edicola|Giornalaio
 ja:1キオスク|売店
 ko:키오스크
 pl:Kiosk|gazety|prasa


### PR DESCRIPTION
Update italian translation of "kiosk" and "newsagent". All places selling newspapers/magazines in Italy are mapped as kiosk or newsagent, so when searching for "Edicola" or "Giornalaio" the app will show both of them. The word "Chiosco" refers to a place that sells food, drinks etc.. These places are mapped as cafes, bars, etc..