### PR TITLE
[android] Don't ignore /storage/emulated

### DIFF
--- a/android/src/com/mapswithme/maps/settings/StoragePathManager.java
+++ b/android/src/com/mapswithme/maps/settings/StoragePathManager.java
@@ -158,7 +158,18 @@ public class StoragePathManager
       // then there is little benefit to apps storing data here instead of the private directories
       // returned by Context#getFilesDir(), etc.
       //
-      if (!Environment.isExternalStorageEmulated(dir))
+      boolean isStorageEmulated;
+      try
+      {
+        isStorageEmulated = Environment.isExternalStorageEmulated(dir);
+      }
+      catch (IllegalArgumentException e)
+      {
+        // isExternalStorageEmulated may throw IllegalArgumentException
+        // https://github.com/organicmaps/organicmaps/issues/538
+        isStorageEmulated = false;
+      }
+      if (!isStorageEmulated)
         candidates.add(dir);
     }
 


### PR DESCRIPTION
Environment.isExternalStorageEmulated() throws IllegalArgumentException
on some Androids.

Don't call isExternalStorageEmulated() and don't ignore emulated storage.

Fixes #538 

Signed-off-by: Roman Tsisyk <roman@tsisyk.com>