### PR TITLE
[android] Remove rudimental cache dir from /sdcard

### DIFF
--- a/android/src/com/mapswithme/util/StorageUtils.java
+++ b/android/src/com/mapswithme/util/StorageUtils.java
@@ -145,10 +145,6 @@ public class StorageUtils
   @NonNull
   public static String getTempPath(@NonNull Application application)
   {
-    final File cacheDir = application.getExternalCacheDir();
-    if (cacheDir != null)
-      return addTrailingSeparator(cacheDir.getAbsolutePath());
-
     return addTrailingSeparator(application.getCacheDir().getAbsolutePath());
   }
 


### PR DESCRIPTION
Use internal storage for tempDir. Currently tempDir contains only one
file - vulkan_dump.bin. There is no need to create misleading external
/sdcard/Android/data/app.organicmaps directory just for one file.

Fixes #534

Signed-off-by: Roman Tsisyk <roman@tsisyk.com>