### PR TITLE
Fix layout on route preview screen.

### DIFF
--- a/iphone/Maps/Classes/CustomViews/NavigationDashboard/Views/RoutePreview/MWMiPhoneRoutePreview.xib
+++ b/iphone/Maps/Classes/CustomViews/NavigationDashboard/Views/RoutePreview/MWMiPhoneRoutePreview.xib
@@ -252,7 +252,7 @@
                             <rect key="frame" x="228" y="8" width="80" height="32"/>
                             <accessibility key="accessibilityConfiguration" identifier="goButton"/>
                             <constraints>
-                                <constraint firstAttribute="width" constant="80" id="5fJ-hA-Bme"/>
+                                <constraint firstAttribute="width" relation="greaterThanOrEqual" constant="80" id="5fJ-hA-Bme"/>
                                 <constraint firstAttribute="height" constant="32" id="b2e-N4-xY6"/>
                             </constraints>
                             <inset key="contentEdgeInsets" minX="8" minY="0.0" maxX="8" maxY="0.0"/>


### PR DESCRIPTION
The "Go" button has a hardcoded size, so in some languages, the title of the button is truncated. 

Before the fix:
<img width="439" alt="Screenshot 2021-06-18 at 7 48 58 PM" src="https://user-images.githubusercontent.com/1976216/122594094-3db2b000-d06f-11eb-986e-5328c26abb03.png">

After the fix:
<img width="444" alt="Screenshot 2021-06-18 at 7 44 57 PM" src="https://user-images.githubusercontent.com/1976216/122594114-43a89100-d06f-11eb-8f28-3d3a4daacaf9.png">
