### PR TITLE
[drape] Add scale factor for POI extending

### DIFF
--- a/drape_frontend/apply_feature_functors.cpp
+++ b/drape_frontend/apply_feature_functors.cpp
@@ -516,9 +516,12 @@ void ApplyPointFeature::Finish(ref_ptr<dp::TextureManager> texMng)
   }
 
   bool const hasPOI = m_symbolRule != nullptr;
-  double const mainScale = df::VisualParams::Instance().GetVisualScale();
+  auto const & visualParams = df::VisualParams::Instance();
+  double const mainScale = visualParams.GetVisualScale();
   if (hasPOI)
   {
+    double const poiExtendScale = visualParams.GetPoiExtendScale();
+
     PoiSymbolViewParams params;
     params.m_featureId = m_id;
     params.m_tileCenter = m_tileRect.Center();
@@ -529,7 +532,7 @@ void ApplyPointFeature::Finish(ref_ptr<dp::TextureManager> texMng)
     params.m_minVisibleScale = m_minVisibleScale;
     params.m_rank = m_rank;
     params.m_symbolName = m_symbolRule->name();
-    params.m_extendingSize = static_cast<uint32_t>(mainScale * m_symbolRule->min_distance());
+    params.m_extendingSize = static_cast<uint32_t>(mainScale * m_symbolRule->min_distance() * poiExtendScale);
     params.m_posZ = m_posZ;
     params.m_hasArea = m_hasArea;
     params.m_prioritized = m_createdByEditor;

--- a/drape_frontend/visual_params.cpp
+++ b/drape_frontend/visual_params.cpp
@@ -38,6 +38,7 @@ double const VisualParams::kXxxhdpiScale = 3.5;
 VisualParams::VisualParams()
   : m_tileSize(0)
   , m_visualScale(0.0)
+  , m_poiExtendScale(0.1) // found empirically
   , m_fontScale(1.0)
 {}
 
@@ -138,6 +139,12 @@ double VisualParams::GetVisualScale() const
 {
   ASSERT_INITED;
   return m_visualScale;
+}
+
+double VisualParams::GetPoiExtendScale() const
+{
+  ASSERT_INITED;
+  return m_poiExtendScale;
 }
 
 uint32_t VisualParams::GetTileSize() const

--- a/drape_frontend/visual_params.hpp
+++ b/drape_frontend/visual_params.hpp
@@ -31,6 +31,8 @@ public:
   std::string const & GetResourcePostfix() const;
 
   double GetVisualScale() const;
+  /// This is a scale factor to decrease extending of bbox for POI icons. It could be removed with new style
+  double GetPoiExtendScale() const;
   uint32_t GetTileSize() const;
 
   /// How many pixels around touch point are used to get bookmark or POI in consideration of visual scale.
@@ -64,6 +66,7 @@ private:
 
   uint32_t m_tileSize;
   double m_visualScale;
+  double m_poiExtendScale;
   GlyphVisualParams m_glyphVisualParams;
   std::atomic<double> m_fontScale;
 
@@ -99,7 +102,7 @@ uint32_t CalculateTileSize(uint32_t screenWidth, uint32_t screenHeight);
 
 void ExtractZoomFactors(ScreenBase const & s, double & zoom, int & index, float & lerpCoef);
 float InterpolateByZoomLevelsImpl(int index, float lerpCoef, float const * values,
-				  size_t valuesSize);
+                                  size_t valuesSize);
 template <typename Array>
 inline float InterpolateByZoomLevels(int index, float lerpCoef, Array const & values)
 {


### PR DESCRIPTION
Goal is to increase number of POI's on the screen.
<img width="697" alt="Screenshot 2021-06-19 at 15 06 11" src="https://user-images.githubusercontent.com/727817/122643443-8b372780-d118-11eb-99af-81de3087899c.png">

Now each rect of POI icon extends by specified attribute from style - `icon-min-distance` ~240 in the file `Icons.mapcss`

There are two ways to decrease that extending:
- change style
- implement global scale factor for these extendings

I did second one. It is easy to remove it later, when style will be redone. It is placed in `VisualParams` class.
This is screenshot after introducing this scale factor:
<img width="595" alt="Screenshot 2021-06-19 at 15 07 14" src="https://user-images.githubusercontent.com/727817/122643540-04367f00-d119-11eb-91c4-ed2f427476ce.png">
