### PR TITLE
[ios] Display fractional download progress

### DIFF
--- a/iphone/Maps/Classes/Widgets/MWMMapDownloadDialog.mm
+++ b/iphone/Maps/Classes/Widgets/MWMMapDownloadDialog.mm
@@ -195,7 +195,7 @@ using namespace storage;
 - (void)showDownloading:(CGFloat)progress {
   self.nodeSize.textColor = [UIColor blackSecondaryText];
   self.nodeSize.text =
-    [NSString stringWithFormat:@"%@ %@%%", L(@"downloader_downloading"), @((NSInteger)(progress * 100.f))];
+    [NSString stringWithFormat:@"%@ %.2f%%", L(@"downloader_downloading"), progress * 100.f];
   self.downloadButton.hidden = YES;
   self.progressWrapper.hidden = NO;
   self.progress.progress = progress;


### PR DESCRIPTION
Instead of 0% now user sees 0.14%

Rationale: for very slow connections it helps to see that download is not stale.

Unfortunately, on Android, it's not that easy. The current implementation stores an integer.