### PR TITLE
[android] removed redundant validation dialog for case, when user renames bookmark list to the same name as before.

### DIFF
--- a/android/src/com/mapswithme/maps/bookmarks/BookmarkCategorySettingsFragment.java
+++ b/android/src/com/mapswithme/maps/bookmarks/BookmarkCategorySettingsFragment.java
@@ -92,6 +92,13 @@ public class BookmarkCategorySettingsFragment extends BaseMwmToolbarFragment
   private void onEditDoneClicked()
   {
     final String newCategoryName = getEditableCategoryName();
+
+    if (newCategoryName.equals(mCategory.getName()))
+    {
+      requireActivity().finish();
+      return;
+    }
+
     if (!validateCategoryName(newCategoryName))
       return;
 


### PR DESCRIPTION
Resolves issue, that @rtsisyk reproduced in #308

Signed-off-by: Dzmitry Yarmolenka <dzmitry.yarmolenka.1986@gmail.com>