### PR TITLE
[android] fix for validation during bookmark list renaming

### DIFF
--- a/android/src/com/mapswithme/maps/bookmarks/BookmarkCategorySettingsFragment.java
+++ b/android/src/com/mapswithme/maps/bookmarks/BookmarkCategorySettingsFragment.java
@@ -119,7 +119,7 @@ public class BookmarkCategorySettingsFragment extends BaseMwmToolbarFragment
       return false;
     }
 
-    if (BookmarkManager.INSTANCE.isUsedCategoryName(name))
+    if (BookmarkManager.INSTANCE.isUsedCategoryName(name) && !TextUtils.equals(name, mCategory.getName()))
     {
       DialogUtils.showAlertDialog(requireContext(), R.string.bookmarks_error_title_list_name_already_taken,
                                   R.string.bookmarks_error_message_list_name_already_taken);


### PR DESCRIPTION
fix for #308 
removed redundant validation dialog for case, when user renames bookmark list to the same name as before.

Signed-off-by: Dzmitry Yarmolenka <dzmitry.yarmolenka.1986@gmail.com>