### PR TITLE
[desktop][ios] Enable Metal for MacOS and iPhone Simulator

### DIFF
--- a/drape/drape_global.hpp
+++ b/drape/drape_global.hpp
@@ -10,7 +10,7 @@
 
 #include <cstdint>
 
-#if defined(OMIM_OS_IPHONE) && !defined(OMIM_OS_IPHONE_SIMULATOR) && !defined(OMIM_OS_MAC)
+#if defined(__APPLE__) && !defined(OMIM_OS_MAC)
 #define OMIM_METAL_AVAILABLE
 #endif
 

--- a/drape/hw_texture.cpp
+++ b/drape/hw_texture.cpp
@@ -273,7 +273,7 @@ drape_ptr<HWTextureAllocator> CreateAllocator(ref_ptr<dp::GraphicsContext> conte
   if (apiVersion == dp::ApiVersion::OpenGLES3)
     return make_unique_dp<OpenGLHWTextureAllocator>();
 
-#if defined(OMIM_METAL_AVAILABLE)
+#if defined(OMIM_OS_IPHONE)
   return make_unique_dp<HWTextureAllocatorApple>();
 #else
   return make_unique_dp<OpenGLHWTextureAllocator>();

--- a/iphone/Maps/Maps.xcodeproj/project.pbxproj
+++ b/iphone/Maps/Maps.xcodeproj/project.pbxproj
@@ -185,7 +185,6 @@
 		34D3B0481E389D05004100F9 /* MWMNoteCell.m in Sources */ = {isa = PBXBuildFile; fileRef = 34D3B0151E389D05004100F9 /* MWMNoteCell.m */; };
 		34D3B04B1E389D05004100F9 /* MWMNoteCell.xib in Resources */ = {isa = PBXBuildFile; fileRef = 34D3B0161E389D05004100F9 /* MWMNoteCell.xib */; };
 		34D3B04F1E38A20C004100F9 /* Bundle+Init.swift in Sources */ = {isa = PBXBuildFile; fileRef = 34D3B04D1E38A20C004100F9 /* Bundle+Init.swift */; };
-		34E6F2DB1F459C05008E14F9 /* GLKit.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 34E6F2DA1F459C05008E14F9 /* GLKit.framework */; };
 		34E776101F14B165003040B3 /* VisibleArea.swift in Sources */ = {isa = PBXBuildFile; fileRef = 34E7760E1F14B165003040B3 /* VisibleArea.swift */; };
 		34E776141F14B17F003040B3 /* AvailableArea.swift in Sources */ = {isa = PBXBuildFile; fileRef = 34E776121F14B17F003040B3 /* AvailableArea.swift */; };
 		34E7761F1F14DB48003040B3 /* PlacePageArea.swift in Sources */ = {isa = PBXBuildFile; fileRef = 34E7761D1F14DB48003040B3 /* PlacePageArea.swift */; };
@@ -951,7 +950,6 @@
 		34D3B0151E389D05004100F9 /* MWMNoteCell.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = MWMNoteCell.m; sourceTree = "<group>"; };
 		34D3B0161E389D05004100F9 /* MWMNoteCell.xib */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = file.xib; path = MWMNoteCell.xib; sourceTree = "<group>"; };
 		34D3B04D1E38A20C004100F9 /* Bundle+Init.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "Bundle+Init.swift"; sourceTree = "<group>"; };
-		34E6F2DA1F459C05008E14F9 /* GLKit.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = GLKit.framework; path = System/Library/Frameworks/GLKit.framework; sourceTree = SDKROOT; };
 		34E7270820444A7A009E4CED /* MWMAlertViewController+CPP.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = "MWMAlertViewController+CPP.h"; sourceTree = "<group>"; };
 		34E7270920444B95009E4CED /* MWMAlert+CPP.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = "MWMAlert+CPP.h"; sourceTree = "<group>"; };
 		34E7760E1F14B165003040B3 /* VisibleArea.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = VisibleArea.swift; sourceTree = "<group>"; };
@@ -1634,7 +1632,6 @@
 				56EE14D11FE804550036F20C /* libtransit.a in Frameworks */,
 				4586D0E71F4813AB00DF9CE5 /* libmwm_diff.a in Frameworks */,
 				4586D0C41F48121A00DF9CE5 /* libbsdiff.a in Frameworks */,
-				34E6F2DB1F459C05008E14F9 /* GLKit.framework in Frameworks */,
 				3488B03B1E9D13EF0068AFD8 /* UserNotifications.framework in Frameworks */,
 				34D1B6F11E95096B0057E9C7 /* libicu.a in Frameworks */,
 				671E78D31E6A423300B2859B /* librouting_common.a in Frameworks */,
@@ -2113,7 +2110,6 @@
 		3462FD8A1DC1DF3A00906FD7 /* SDK */ = {
 			isa = PBXGroup;
 			children = (
-				34E6F2DA1F459C05008E14F9 /* GLKit.framework */,
 				67B78B3C1E422BF60018E590 /* CoreData.framework */,
 				FACE202725ED913A00518E88 /* CoreServices.framework */,
 				67B78B401E422C360018E590 /* CoreSpotlight.framework */,
@@ -4454,8 +4450,6 @@
 				CURRENT_PROJECT_VERSION = 0;
 				DEBUG_INFORMATION_FORMAT = dwarf;
 				DEVELOPMENT_TEAM = 9Z6432XD7L;
-				"EXCLUDED_SOURCE_FILE_NAMES[sdk=iphonesimulator*]" = MetalContextFactory.mm;
-				"EXCLUDED_SOURCE_FILE_NAMES[sdk=macosx*]" = MetalContextFactory.mm;
 				FRAMEWORK_SEARCH_PATHS = "$(inherited)";
 				LD_RUNPATH_SEARCH_PATHS = (
 					"$(inherited)",
@@ -4477,8 +4471,6 @@
 				CURRENT_PROJECT_VERSION = 0;
 				DEBUG_INFORMATION_FORMAT = "dwarf-with-dsym";
 				DEVELOPMENT_TEAM = 9Z6432XD7L;
-				"EXCLUDED_SOURCE_FILE_NAMES[sdk=iphonesimulator*]" = MetalContextFactory.mm;
-				"EXCLUDED_SOURCE_FILE_NAMES[sdk=macosx*]" = MetalContextFactory.mm;
 				FRAMEWORK_SEARCH_PATHS = "$(inherited)";
 				LD_RUNPATH_SEARCH_PATHS = (
 					"$(inherited)",

--- a/xcode/common.xcconfig
+++ b/xcode/common.xcconfig
@@ -80,5 +80,5 @@ PRODUCT_NAME = $(TARGET_NAME)
 SKIP_INSTALL = YES
 SWIFT_VERSION = 5.0
 VALID_ARCHS = arm64
-VALID_ARCHS[sdk=iphonesimulator*] = x86_64
-VALID_ARCHS[sdk=macosx*] = x86_64
+VALID_ARCHS[sdk=iphonesimulator*] = x86_64 arm64
+VALID_ARCHS[sdk=macosx*] = x86_64 arm64

--- a/xcode/drape/drape.xcodeproj/project.pbxproj
+++ b/xcode/drape/drape.xcodeproj/project.pbxproj
@@ -769,27 +769,6 @@
 			isa = XCBuildConfiguration;
 			buildSettings = {
 				EXCLUDED_SOURCE_FILE_NAMES = "";
-				"EXCLUDED_SOURCE_FILE_NAMES[sdk=iphonesimulator*]" = (
-					metal_base_context.mm,
-					metal_gpu_buffer_impl.mm,
-					metal_mesh_object_impl.mm,
-					metal_states.mm,
-					metal_texture.mm,
-					metal_vertex_array_buffer_impl.mm,
-					render_state_metal.mm,
-					metal_cleaner.mm,
-				);
-				"EXCLUDED_SOURCE_FILE_NAMES[sdk=macosx*]" = (
-					hw_texture_ios.mm,
-					metal_base_context.mm,
-					metal_gpu_buffer_impl.mm,
-					metal_mesh_object_impl.mm,
-					metal_states.mm,
-					metal_texture.mm,
-					metal_vertex_array_buffer_impl.mm,
-					render_state_metal.mm,
-					metal_cleaner.mm,
-				);
 				EXECUTABLE_PREFIX = lib;
 				GCC_PREFIX_HEADER = "$(OMIM_ROOT)/precompiled_headers.hpp";
 				PRODUCT_NAME = "$(TARGET_NAME)";
@@ -800,27 +779,6 @@
 			isa = XCBuildConfiguration;
 			buildSettings = {
 				EXCLUDED_SOURCE_FILE_NAMES = "";
-				"EXCLUDED_SOURCE_FILE_NAMES[sdk=iphonesimulator*]" = (
-					metal_base_context.mm,
-					metal_gpu_buffer_impl.mm,
-					metal_mesh_object_impl.mm,
-					metal_states.mm,
-					metal_texture.mm,
-					metal_vertex_array_buffer_impl.mm,
-					render_state_metal.mm,
-					metal_cleaner.mm,
-				);
-				"EXCLUDED_SOURCE_FILE_NAMES[sdk=macosx*]" = (
-					hw_texture_ios.mm,
-					metal_base_context.mm,
-					metal_gpu_buffer_impl.mm,
-					metal_mesh_object_impl.mm,
-					metal_states.mm,
-					metal_texture.mm,
-					metal_vertex_array_buffer_impl.mm,
-					render_state_metal.mm,
-					metal_cleaner.mm,
-				);
 				EXECUTABLE_PREFIX = lib;
 				GCC_PREFIX_HEADER = "$(OMIM_ROOT)/precompiled_headers.hpp";
 				PRODUCT_NAME = "$(TARGET_NAME)";

--- a/xcode/shaders/shaders.xcodeproj/project.pbxproj
+++ b/xcode/shaders/shaders.xcodeproj/project.pbxproj
@@ -739,16 +739,6 @@
 		4566607820E254060085E8C1 /* Debug */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
-				"EXCLUDED_SOURCE_FILE_NAMES[sdk=iphonesimulator*]" = (
-					metal_program_params.mm,
-					metal_program_pool.mm,
-					program_manager_metal.mm,
-				);
-				"EXCLUDED_SOURCE_FILE_NAMES[sdk=macosx*]" = (
-					metal_program_params.mm,
-					metal_program_pool.mm,
-					program_manager_metal.mm,
-				);
 			};
 			name = Debug;
 		};
@@ -756,16 +746,6 @@
 			isa = XCBuildConfiguration;
 			buildSettings = {
 				EXCLUDED_SOURCE_FILE_NAMES = "";
-				"EXCLUDED_SOURCE_FILE_NAMES[sdk=iphonesimulator*]" = (
-					metal_program_params.mm,
-					metal_program_pool.mm,
-					program_manager_metal.mm,
-				);
-				"EXCLUDED_SOURCE_FILE_NAMES[sdk=macosx*]" = (
-					metal_program_params.mm,
-					metal_program_pool.mm,
-					program_manager_metal.mm,
-				);
 			};
 			name = Release;
 		};
@@ -807,7 +787,6 @@
 				MTL_ENABLE_DEBUG_INFO = INCLUDE_SOURCE;
 				MTL_FAST_MATH = YES;
 				MTL_OPTIMIZATION_LEVEL = 0;
-				SUPPORTED_PLATFORMS = "macosx iphoneos";
 			};
 			name = Debug;
 		};
@@ -816,7 +795,6 @@
 			buildSettings = {
 				MTL_FAST_MATH = YES;
 				MTL_OPTIMIZATION_LEVEL = 3;
-				SUPPORTED_PLATFORMS = "macosx iphoneos";
 			};
 			name = Release;
 		};


### PR DESCRIPTION
Metal is supported since MacOS El Captain.
This patch fixes Simulator on M1.

[1]: https://support.apple.com/en-us/HT205073

Please help to fix problem with `NSString * libPath = [[NSBundle mainBundle] pathForResource:@"shaders_metal" ofType:@"metallib"];` (missing resource file on Simulator)