### PR TITLE
Fixed text when a new note is created within app

### DIFF
--- a/editor/osm_editor.cpp
+++ b/editor/osm_editor.cpp
@@ -1250,7 +1250,7 @@ bool Editor::IsFeatureUploadedImpl(FeaturesContainer const & features, MwmSet::M
 }
 
 const char * const Editor::kPlaceDoesNotExistMessage =
-    "The place has gone or never existed. This is an auto-generated note from OMaps application: "
+    "The place has gone or never existed. This is an auto-generated note from Oragnic Maps application: "
     "a user reports a POI that is visible on a map (which can be outdated), but cannot be found on "
     "the ground.";
 


### PR DESCRIPTION
The old "OMaps" wording was still present when a map was created with the app; I replaced it with "Organic Maps".