### PR TITLE
[ios] MapView's leading constraint fixed for CarPlay

### DIFF
--- a/iphone/Maps/UI/CarPlay/CarPlayMapViewController.swift
+++ b/iphone/Maps/UI/CarPlay/CarPlayMapViewController.swift
@@ -35,7 +35,7 @@ final class CarPlayMapViewController: MWMViewController {
     view.insertSubview(mapView, at: 0)
     mapView.topAnchor.constraint(equalTo: view.topAnchor).isActive = true
     mapView.bottomAnchor.constraint(equalTo: view.bottomAnchor).isActive = true
-    mapView.leadingAnchor.constraint(equalTo: view.leadingAnchor).isActive = true
+    mapView.leadingAnchor.constraint(equalTo: view.safeAreaLayoutGuide.leadingAnchor).isActive = true
     mapView.trailingAnchor.constraint(equalTo: view.trailingAnchor).isActive = true
     speedInfoView.trailingAnchor.constraint(equalTo: mapButtonSafeAreaLayoutGuide.trailingAnchor).isActive = true
   }


### PR DESCRIPTION
Changed MapView's leading constraint to be equal to safeArea's leading anchor instead of superview's leading anchor. Closes #804
![Simulator Screen Shot - iPhone 12 - 2021-07-16 at 22 43 07](https://user-images.githubusercontent.com/6124551/126000955-b10a5be1-9eb9-4239-a83d-da3f75e0a748.png)
