### PR TITLE
[strings] Clean strings.txt and add CI job for it

### DIFF
--- a/.github/workflows/strings-check.yaml
+++ b/.github/workflows/strings-check.yaml
@@ -1,0 +1,22 @@
+name: strings.txt check
+on:
+  pull_request:
+    paths:
+      - 'data/strings/strings.txt'
+
+jobs:
+  check-strings-txt:
+    name: Check strings.txt format
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v2
+      - uses: actions/setup-python@v2
+        with:
+          python-version: '3'
+
+      - name: Check strings.txt
+        shell: bash
+        run: |
+          ./tools/python/clean_strings_txt.py -s
+          git diff --quiet HEAD

--- a/android/res/values-ar/strings.xml
+++ b/android/res/values-ar/strings.xml
@@ -12,15 +12,11 @@
 	<string name="cancel_download">إلغاء التنزيل</string>
 	<!-- Button which deletes downloaded country -->
 	<string name="delete">حذف</string>
-	<!-- Button "do not interrupt download" if user touched actively downloading country -->
-	<string name="do_nothing">استمرار</string>
 	<string name="download_maps">تنزيل الخرائط</string>
 	<!-- Settings/Downloader - info for country when download fails -->
 	<string name="download_has_failed">فشلت عملية التنزيل، انقر مرة أخرى لإعداة المحاولة</string>
 	<!-- Settings/Downloader - info for country which started downloading -->
 	<string name="downloading">جاري التنزيل…</string>
-	<!-- Settings/Downloader - size string, only strings different from English should be translated -->
-	<string name="kb">ك.ب.</string>
 	<!-- Choose measurement on first launch alert - choose metric system button -->
 	<string name="kilometres">كيلومتر</string>
 	<!-- Leave Review dialog - Review button -->
@@ -35,45 +31,31 @@
 	<string name="core_my_position">موقعي</string>
 	<!-- Update maps later/Buy pro version later button text -->
 	<string name="later">لاحقا</string>
-	<!-- Don't show some dialog any more -->
-	<string name="never">أبدا</string>
 	<!-- View and button titles for accessibility -->
 	<string name="search">البحث</string>
 	<!-- Search box placeholder text -->
 	<string name="search_map">ابحث في الخريطة</string>
-	<!-- Settings/Downloader - info for not downloaded country -->
-	<string name="touch_to_download">انقر للتنزيل</string>
 	<!-- Settings/Downloader - 3G download warning dialog confirm button -->
 	<string name="use_cellular_data">نعم</string>
 	<!-- Location services are disabled by user alert - message -->
 	<string name="location_is_disabled_long_text">التطبيق أو جميع خدمات تحديد المواقع معطلة لديك في الوقت الحالي. الرجاء تفعيلها في الإعدادات.</string>
-	<!-- Location Services are not available on the device alert - message -->
-	<string name="device_doesnot_support_location_services">جهازك لا يدعم خدمات تحديد المواقع.</string>
 	<!-- View and button titles for accessibility -->
 	<string name="zoom_to_country">عرض على الخريطة</string>
-	<!-- Button text for the button at the center of the screen when the country is not downloaded -->
-	<string name="country_status_download">(^ ^)\nتحميل الخريطة</string>
 	<!-- Button text for the button at the center of the screen when the country is not downloaded and the size should not be shown -->
 	<string name="country_status_download_without_size">تحميل الخريطة</string>
-	<!-- Button text for the button at the center of the screen when the country is not downloaded -->
-	<string name="country_status_download_without_routing">(^ ^)\nتنزيل خريطة بدون تحديد خط السير</string>
 	<!-- Message to display at the center of the screen when the country download has failed -->
 	<string name="country_status_download_failed">فشلت عملية تنزيل</string>
 	<!-- Button text for the button under the country_status_download_failed message -->
 	<string name="try_again">محاولة مرة أخرى</string>
 	<string name="about_menu_title">حول Organic Maps</string>
-	<string name="downloaded_touch_to_delete">تم تنزيل (%s)، انقر للحذف</string>
 	<string name="connection_settings">اعدادات الاتصال</string>
-	<string name="download_mb_or_kb">تنزيل %s</string>
 	<string name="close">اغلاق</string>
 	<string name="unsupported_phone">أنت بحاجة الى OpenGL بأجهزة تسريع. لسوء الحظ جهازك لا يدعم هذه الخاصية.</string>
 	<string name="download">تنزيل</string>
-	<string name="external_storage_is_not_available">خاصية التخزين بواسطة البطاقة الرقمية الآمنة\الناقل التسلسلي الشامل غير متاحة مع الخرائط التي تم تنزيلها.</string>
 	<string name="disconnect_usb_cable">الرجاء فصل كابل الناقل التسلسلي الشامل أو إدخال بطاقة الذاكرة من أجل استخدام Organic Maps.</string>
 	<string name="not_enough_free_space_on_sdcard">الرجاء إخلاء بعض المساحة في تخزين البطاقة الرقمية الآمنة\الناقل التسلسلي الشامل أولا من أجل استخدام هذا التطبيق.</string>
 	<string name="not_enough_memory">لا يوجد ذاكرة كافية لتشغيل التطبيق.</string>
 	<string name="download_resources">قبل أن تبدأ، دعنا نقوم بتنزيل خريطة العالم العامة على جهازك.\nانها بحاجة الى %s من البيانات.</string>
-	<string name="getting_position">الحصول على الموقع الحالي</string>
 	<string name="download_resources_continue">الذهاب الى الخريطة</string>
 	<string name="downloading_country_can_proceed">تنزيل %s. يمكنك الآن\nالمتابعة الى الخريطة.</string>
 	<string name="download_country_ask">هل تريد تنزيل %s؟</string>
@@ -86,30 +68,20 @@
 	<string name="download_country_failed">فشلت عملية تنزيل %s</string>
 	<!-- Add New Bookmark Set dialog title -->
 	<string name="add_new_set">إضافة مجموعة جديدة</string>
-	<!-- Place Page - Add To Bookmarks button -->
-	<string name="add_to_bookmarks">إضافة الى الإشارات المرجعية</string>
 	<!-- Bookmark Color dialog title -->
 	<string name="bookmark_color">لون الإشارة المرجعية</string>
 	<!-- Add Bookmark Set dialog - hint when set name is empty -->
 	<string name="bookmark_set_name">اسم مجموعة الإشارات المرجعية</string>
-	<!-- Bookmark Sets dialog title -->
-	<string name="bookmark_sets">مجموعات الإشارات المرجعية</string>
 	<!-- Bookmarks - dialog title -->
 	<string name="bookmarks">الإشارات المرجعية</string>
-	<!-- Add bookmark dialog - bookmark color -->
-	<string name="color">اللون</string>
 	<!-- Default bookmarks set name -->
 	<string name="core_my_places">أماكني</string>
 	<!-- Add bookmark dialog - bookmark name -->
 	<string name="name">الاسم</string>
 	<!-- Editor title above street and house number -->
 	<string name="address">العنوان</string>
-	<!-- Place Page - Remove Pin button -->
-	<string name="remove_pin">إزالة الدبوس</string>
 	<!-- Add bookmark dialog - bookmark set, Bookmarks dialog - Bookmark set cell -->
 	<string name="set">المجموعة</string>
-	<!-- Text hint in Bookmarks dialog when no any bookmarks are added -->
-	<string name="bookmarks_usage_hint">ليس لديك أي إشارات مرجعية بعد.\nانقر على أي مكان على الخريطة لإضافة إشارة مرجعية.\nيمكنك أيضا استيراد الإشارات المرجعية من المصادر الأخرى وعرضها في Organic Maps. افتح ملف KML/KMZ الذي يحتوي على الدبابيس المحفوظة من البريد الالكتروني، دروب بوكس أو ويب لينك.</string>
 	<!-- Settings button in system menu -->
 	<string name="settings">الإعدادات</string>
 	<!-- Header of settings activity where user defines storage path -->
@@ -120,20 +92,10 @@
 	<string name="move_maps">هل تريد نقل الخرائط؟</string>
 	<!-- Ask to wait user several minutes (some long process in modal dialog). -->
 	<string name="wait_several_minutes">يمكن أن تستغرق هذه العملية عدة دقائق.\nالرجاء الانتظار…</string>
-	<!-- Show bookmarks from this category on a map or not -->
-	<string name="visible">مرئي</string>
-	<!-- Toast which is displayed when GPS has been deactivated -->
-	<string name="gps_is_disabled_long_text">تم تعطيل خاصية نظام تحديد المواقع العالمي. الرجاء تفعيله في الاعدادات.</string>
 	<!-- Measurement units title in settings activity -->
 	<string name="measurement_units">وحدات القياس.</string>
 	<!-- Detailed description of Measurement Units settings button -->
 	<string name="measurement_units_summary">اختر من بين الأميال و الكيلو مترات.</string>
-	<!-- Do search in all sources -->
-	<string name="search_mode_all">كل مكان</string>
-	<!-- Do search near my position only -->
-	<string name="search_mode_nearme">بجواري</string>
-	<!-- Do search in current viewport only -->
-	<string name="search_mode_viewport">على الشاشة</string>
 	<!-- Search category for cafes, bars, restaurants -->
 	<string name="eat">مكان لتناول الطعام</string>
 	<!-- Search category for grocery stores -->
@@ -170,12 +132,8 @@
 	<string name="post">بريد</string>
 	<!-- Search category -->
 	<string name="police">شرطة</string>
-	<!-- String in search result list, when nothing found -->
-	<string name="no_search_results_found">لم يتم العثور على أي نتائج</string>
 	<!-- Notes field in Bookmarks view -->
 	<string name="description">ملاحظات</string>
-	<!-- Button text -->
-	<string name="share_by_email">مشاركة بواسطة البريد الالكتروني</string>
 	<!-- Email Subject when sharing bookmarks category -->
 	<string name="share_bookmarks_email_subject">تم مشاركة اشارات Organic Maps المرجعية معك</string>
 	<!-- message title of loading file -->
@@ -188,20 +146,10 @@
 	<string name="edit">تعديل</string>
 	<!-- Warning message when doing search around current position -->
 	<string name="unknown_current_position">لم يتم التعرف على موقعك بعد.</string>
-	<!-- Warning message when location country isn't downloaded during search (see also download_location_map_proposal). -->
-	<string name="download_location_country">تنزيل دولة (%s) موقعك الحالي</string>
-	<!-- Warning message when viewport country isn't downloaded during search -->
-	<string name="download_viewport_country_to_search">تنزيل الدولة (%s) التي تبحث فيها</string>
 	<!-- Alert message that we can't run Map Storage settings due to some reasons. -->
 	<string name="cant_change_this_setting">نأسف، اعدادات تخزين الخرائط معطلة حالياً.</string>
 	<!-- Alert message that downloading is in progress. -->
 	<string name="downloading_is_active">جاري الآن تنزيل الدولة</string>
-	<!-- Message that will be shown in alert view, when we ask user to leave review on App Store -->
-	<string name="appStore_message">نأمل أن تكون قد استمتعت باستخدام Organic Maps! إذا كان الأمر كذلك، الرجاء تقييم التطبيق في App Store. يستغرق ذلك أقل من دقيقة لكنه يفيدنا بالفعل. شكرا لك على دعمك!</string>
-	<!-- No, thanks -->
-	<string name="no_thanks">لا، شكرا</string>
-	<!-- Share one specific bookmark using SMS, %1$@ contains om:// and %2$@ https://omaps.app link. @NOTE non-ascii symbols in the link will result in max 70 characters SMS instead of 140. -->
-	<string name="bookmark_share_sms">هاي، تفقد الدبوس الخاص بي على Organic Maps! %1$s أو %2$s. ليس لديك أي خرائط تعمل بدون الاتصال مع الانترنت مثبتة على جهازك؟ قم بتحميلها من هنا: https://omaps.app/get</string>
 	<!-- Share my position using SMS, %1$@ contains om:// and %2$@ https://omaps.app link WITHOUT NAME. @NOTE non-ascii symbols in the link will result in max 70 characters SMS instead of 140. -->
 	<string name="my_position_share_sms">هاي، تفقد الموقع الخاص بي على Organic Maps! %1$s أو %2$s. ليس لديك أي خرائط تعمل بدون الاتصال مع الانترنت مثبتة على جهازك؟ قم بتحميلها من هنا: https://omaps.app/get</string>
 	<!-- Subject for emailed bookmark -->
@@ -210,30 +158,16 @@
 	<string name="my_position_share_email_subject">يا هلا، تحقق من موقعي الحالي على خريطة Organic Maps!</string>
 	<!-- Share my position using EMail, %1$@ is om:// and %2$@ is https://omaps.app link WITHOUT NAME -->
 	<string name="my_position_share_email">مرحبا،\n\nأنا هنا الآن: %1$s. انقر على هذا الرابط %2$s أو ذلك الرابط %3$s لمشاهدة المكان على الخريطة.\n\nشكرا لك.</string>
-	<!-- Android share by Message/SMS button text (including SMS) -->
-	<string name="share_by_message">مشاركة بواسطة رسالة</string>
 	<!-- Share button text which opens menu with more buttons, like Message, EMail, Facebook etc. -->
 	<string name="share">مشاركة</string>
-	<!-- iOS share by Message button text (including SMS) -->
-	<string name="message">رسالة</string>
 	<!-- Share by email button text, also used in editor. -->
 	<string name="email">البريد الالكتروني</string>
-	<!-- Copy Link -->
-	<string name="copy_link">نسخ الرابط</string>
-	<!-- Text for the button that returns to caller application -->
-	<string name="more_info">إظهار مزيد من المعلومات</string>
 	<!-- Text for message when used successfully copied something -->
 	<string name="copied_to_clipboard">تم النسخ الى الحافظة: %1$s</string>
 	<!-- place preview title -->
 	<string name="info">المعلومات</string>
 	<!-- Used for bookmark editing -->
 	<string name="done">تم</string>
-	<!-- Summary for preferences in MWM -->
-	<string name="yopme_pref_summary">اختر اعدادات الشاشة الخلفية</string>
-	<!-- Title for yopme preferences in MWM -->
-	<string name="yopme_pref_title">اعدادات الشاشة الخلفية</string>
-	<!-- Hint for upper-right icon p2b -->
-	<string name="show_on_backscreen">إظهار في الشاشة الخلفية</string>
 	<!-- Prints version number in About dialog -->
 	<string name="version">الاصدار: %s</string>
 	<!-- Confirmation in downloading countries dialog -->
@@ -243,11 +177,6 @@
 	<!-- Length of track in cell that describes route -->
 	<string name="length">الطول</string>
 	<string name="share_my_location">مشاركة موقعي</string>
-	<string name="menu_search">بحث</string>
-	<!-- Settings screen: "Map" category title -->
-	<string name="prefs_group_map">الخريطة</string>
-	<!-- Settings screen: "Miscellaneous" category title -->
-	<string name="prefs_group_misc">مُتَنَوّعة</string>
 	<string name="prefs_group_route">الملاحة</string>
 	<string name="pref_zoom_title">أزرار التكبير</string>
 	<string name="pref_zoom_summary">عرض على الشاشة</string>
@@ -263,8 +192,6 @@
 	<string name="pref_map_3d_title">العرض المنظوري</string>
 	<!-- Settings «Map» category: «3D buildings» title -->
 	<string name="pref_map_3d_buildings_title">مباني ثلاثية الأبعاد</string>
-	<!-- Settings «Map» category: «3D buildings» summary -->
-	<string name="pref_map_3d_buildings_subtitle">تؤثر على عمر البطارية</string>
 	<!-- Settings «Route» category: «Tts enabled» title -->
 	<string name="pref_tts_enable_title">تعليمات صوتية</string>
 	<!-- Settings «Route» category: «Tts language» title -->
@@ -273,7 +200,6 @@
 	<string name="pref_tts_unavailable">غير متاح</string>
 	<!-- Title for "Other" section in TTS settings. -->
 	<string name="pref_tts_other_section_title">آخر</string>
-	<string name="pref_tts_how_to_set_up_voice">كيفية ضبط الصوت</string>
 	<!-- Settings «Map» category: «Record track» title -->
 	<string name="pref_track_record_title">المسار الأخير</string>
 	<string name="pref_map_auto_zoom">تكبير تلقائي</string>
@@ -284,46 +210,11 @@
 	<string name="duration_12_hours">12 ساعة</string>
 	<string name="duration_1_day">1 يوم</string>
 	<string name="recent_track_help_text">يتيح لك تسجيل مسار السفر لفترة معينة وعرضه على الخريطة. الرجاء ملاحظة: يؤدي تنشيط هذه الوظيفة إلى زيادة استهلاك البطارية. سوف تتم إزالة المسار تلقائيًا من الخريطة بعد انتهاء الفاصل الزمني.</string>
-	<string name="pref_track_ios_caption">يُظهر المسار الأخير مسار سفرك.</string>
-	<string name="pref_track_ios_subcaption">يرجى تحديد نطاق وقت حفظ المسار.</string>
-	<string name="placepage_distance">المسافة</string>
-	<string name="placepage_coordinates">الإحداثيات</string>
-	<string name="placepage_unsorted">لم يتم فرزها</string>
 	<string name="search_show_on_map">مشاهدة على الخريطة</string>
-	<!-- Used to warn user when fixing KitKat issue -->
-	<string name="bookmark_move_fail">نحن بحاجة لنقل الإشارات المرجعية الخاصة بك الى الذاكرة الداخلية، لكن لا يوجد حيز كافٍ لها. الرجاء إخلاء الذاكرة، وإلا لن تكون  الإشارات المرجعية متاحة.</string>
-	<!-- Used in More Apps menu -->
-	<string name="free">مجاني</string>
-	<!-- Used in More Apps menu -->
-	<string name="buy">شراء</string>
-	<!-- 1st search button-like result -->
-	<string name="search_on_map">البحث في الخريطة</string>
-	<!-- toast with an error -->
-	<string name="no_route_found">لم يتم العثور على أي مسار</string>
-	<!-- route title -->
-	<string name="route">المسار</string>
-	<!-- category title -->
-	<string name="routes">المسارات</string>
-	<!-- text of notification -->
-	<string name="download_map_notification">تنزيل خريطة المكان الذي توجد فيه</string>
-	<!-- text of notification -->
-	<string name="pro_version_is_free_today">تطبيق Organic Maps مجاني اليوم! قم بتنزيله الآن وأخبر أصدقائك.</string>
-	<!-- Dialog for transferring maps from lite to pro. -->
-	<string name="move_lite_maps_to_pro">نحن ننقل خرائط التنزيلات الخاصة بك من Organic Maps Lite إلى Organic Maps. يمكن أن يستغرق بضع دقائق</string>
-	<!-- Message to display when maps moved. -->
-	<string name="move_lite_maps_to_pro_ok">تم بنجاح نقل خرائطك التي تم تنزيلها إلى Organic Maps.</string>
-	<!-- Message to display when maps move failed. -->
-	<string name="move_lite_maps_to_pro_failed">فشل نقل خرائطك يُرجى حذف Organic Maps Lite وتنزيل الخرائط مرة أخرى.</string>
-	<!-- Text in menu -->
-	<string name="settings_and_more">الإعدادات والمزيد</string>
 	<!-- Text in menu -->
 	<string name="website">الموقع الإلكتروني</string>
-	<!-- Text in menu -->
-	<string name="contact_us">أتصل بنا</string>
 	<!-- Settings: Send feedback button and dialog title -->
 	<string name="feedback">تعقيب</string>
-	<!-- Text in menu -->
-	<string name="subscribe_to_news">أشترك في نشرتنا الإخبارية</string>
 	<!-- Text in menu -->
 	<string name="rate_the_app">تقييم التطبيق</string>
 	<!-- Text in menu -->
@@ -332,12 +223,6 @@
 	<string name="copyright">حقوق الطبع والنشر</string>
 	<!-- Text in menu -->
 	<string name="report_a_bug">الإبلاغ عن خطأ</string>
-	<!-- Email subject -->
-	<string name="subscribe_me_subject">يرجى اشتراكي في النشرة البريدية لدى Organic Maps</string>
-	<!-- Email body -->
-	<string name="subscribe_me_body">أريد أن أكون أول من يعرف آخر الأخبار والتحديثات والترقيات. يمكنني إلغاء اشتراكي في أي وقت.</string>
-	<!-- About text -->
-	<string name="about_text">توفر لكم Organic Maps أحدث الخرائط دون الاتصال بالإنترنت لكافة دول وكافة مدن العالم. سافر وتمتع بالثقة التامة: إينما كنت، تساعدك Organic Maps على تحديد مكانك على الخريطة، والعثور على أقرب مطعم أو فندق أو بنك أو محطة غاز الخ لا يتطلب الاتصال بالإنترنت.\n\nنحن نعمل دوماً على إدخال مزايا جديدة على التطبيق ونود أن نسمع منك رأيك عن الكيفية التي يمكن بها تحسين تطبيق Organic Maps في رأيك. إذا واجهتك أي مشاكل مع التطبيق، لا تتردد في الاتصال بنا على support\@organicmaps.app. نحن نرد على كافة الطلبات.\n\nهل أعجبك تطبيق Organic Maps وترغب في دعمنا؟ هناك بعض الطرق السهلة والمجانية بالكامل لعمل ذلك.\n\n- انشر رأيك على متجر التطبيقات الخاص بك\n- اعجب بصفحتنا على موقع Facebook http://www.facebook.com/OrganicMaps\n- أو أخبر والدتك وأصدقائك وزملائك عن تطبيق Organic Maps :)\n\nشكراً لك على وجودك معنا. نحن نقدر جداً دعمك لنا!\n\nيُرجى ملاحظة نحن نستقي بيانات الخرائط من OpenStreetMap، مشروع خرائط يشبه موسوعة Wikipedia ويتيح هذا المشروع للمستخدمين إنشاء وتحرير الخرائط. إذا كنت ترى أن هناك خطأ ما أو شيء غير موجود على الخريطة، يمكنك تصحيح الخرائط مباشرة على https://www.openstreetmap.org، وسوف تظهر تغييراتك على تطبيق Organic Maps في الإصدار القادم للتطبيق.</string>
 	<!-- Alert text -->
 	<string name="email_error_body">لم يتم تعيين البريد الإلكتروني للعميل. يرجى تكوينه أو استخدام أي وسيلة أخرى للاتصال بنا على %s</string>
 	<!-- Alert title -->
@@ -346,137 +231,56 @@
 	<string name="pref_calibration_title">معايرة البوصلة</string>
 	<!-- Search category -->
 	<string name="wifi">واي-فاي</string>
-	<!-- Update map suggestion -->
-	<string name="routing_map_outdated">يرجى تحديث الخريطة لإنشاء مسار.</string>
-	<!-- Update maps suggestion -->
-	<string name="routing_update_maps">إصدار Organic Maps الجديد يسمح بإنشاء مسارات انطلاقاً من موقعك الحالي نحو المكان الذي تتجه إليه. يرجى تحديث الخرائط لاستخدام هذه الميزة.</string>
 	<!-- Update all button text -->
 	<string name="downloader_update_all_button">تحديث الكل</string>
 	<!-- Cancel all button text -->
 	<string name="downloader_cancel_all">إلغاء الكل</string>
 	<!-- Downloaded maps category -->
 	<string name="downloader_downloaded_subtitle">تم تنزيلها</string>
-	<!-- Downloaded maps category -->
-	<string name="downloader_available_maps">متاح</string>
 	<!-- Country queued for download -->
 	<string name="downloader_queued">مَصْفوف</string>
 	<string name="downloader_near_me_subtitle">بالقرب مني</string>
 	<string name="downloader_status_maps">الخرائط</string>
 	<string name="downloader_download_all_button">تنزيل الكل</string>
 	<string name="downloader_downloading">يتم تنزيل:</string>
-	<string name="downloader_search_results">تم العثور على</string>
-	<!-- Disclaimer message -->
-	<string name="routing_disclaimer">عند إنشاء مسارات الطرق في تطبيق Organic Maps، يرجى أخذ التالي في الحسبان:\n\n  - المسارات المقترحة تعتبر مجرد اقتراحات فقط.\n - حالة الطريق وقوانينه والإشارات الموجودة فيه لها الأولولية أثناء تقديم نصائح الملاحة.\n - قد تكون الخريطة خاطئة أو قديمة، لذا فإنه يمكن ألا تُرسم المسارات بالشكل الأمثل.\n\n  كن آمنا على الطريق وانتبه لتفسك!</string>
-	<!-- Outdated maps category -->
-	<string name="downloader_outdated_maps">انتهت صلاحيته</string>
-	<!-- Up to date maps category -->
-	<string name="downloader_uptodate_maps">محدّث</string>
 	<!-- Status of outdated country in the list -->
 	<string name="downloader_status_outdated">تحديث</string>
 	<!-- Status of failed country in the list -->
 	<string name="downloader_status_failed">فشل</string>
 	<!-- Displayed in a dialog that appears when a user tries to delete a map while the app is in the follow route mode -->
 	<string name="downloader_delete_map_while_routing_dialog">لحذف الخريطة يرجى إيقاف الملاحة.</string>
-	<!-- Show when user try build route, but we don't know where he -->
-	<string name="routing_failed_unknown_my_position">الموقع الحالي غير مُعَرّف. يرجى تحديد موقع لإنشاء مسار.</string>
-	<!-- Show if use has not routing file, or InconsistentMWMandRoute -->
-	<string name="routing_failed_has_no_routing_file">هناك حاجة إلى بيانات إضافية لإنشاء مسار. بدء التحميل؟</string>
-	<!-- StartPointNotFound -->
-	<string name="routing_failed_start_point_not_found">لا يمكن حساب المسار. لا توجد طرق قرب نقطة البداية لديك.</string>
-	<!-- EndPointNotFound -->
-	<string name="routing_failed_dst_point_not_found">لا يمكن حساب المسار. لا توجد طرق بالقرب من وجهتك المقصودة.</string>
 	<!-- PointsInDifferentMWM -->
 	<string name="routing_failed_cross_mwm_building">يمكن فقط إنشاء المسارات التي توجد بشكل كامل ضمن خريطة واحدة.</string>
-	<!-- RouteNotFound -->
-	<string name="routing_failed_route_not_found">لم يتم العثور على مسار بين المنشأ والوُجْهَة المحددة. الرجاء تحديد نقطة بداية أو نهاية مختلفة.</string>
-	<!-- InternalError -->
-	<string name="routing_failed_internal_error">حدث خطأ داخلي. يرجى محاولة حذف الخريطة وإعادة تنزيلها مرة أخرى. إذا استمرت المشكلة يرجى الاتصال بنا على support\@organicmaps.app.</string>
-	<!-- Context menu item for downloader. -->
-	<string name="downloader_download_map_and_routing">تنزيل الخريطة + تحديد المسار</string>
-	<!-- Context menu item for downloader. -->
-	<string name="downloader_download_routing">تنزيل تحديد المسار</string>
-	<!-- Context menu item for downloader. -->
-	<string name="downloader_delete_routing">إزالة تحديد المسار</string>
 	<!-- Context menu item for downloader. -->
 	<string name="downloader_download_map">تنزيل الخريطة</string>
-	<string name="downloader_download_map_no_routing">تنزيل خريطة بدون تحديد خط السير</string>
-	<!-- Button for routing. -->
-	<string name="routing_go">انطلق!</string>
 	<!-- Item status in downloader. -->
 	<string name="downloader_retry">تكرار</string>
-	<!-- Item in context menu. -->
-	<string name="downloader_map_and_routing">الخريطة + تحديد المسار</string>
 	<!-- Item in context menu. -->
 	<string name="downloader_delete_map">حذف الخريطة</string>
 	<!-- Item in context menu. -->
 	<string name="downloader_update_map">تحديث الخريطة</string>
-	<!-- Item in context menu. -->
-	<string name="downloader_update_map_and_routing">تحديث الخريطة + تحديد المسار</string>
-	<!-- Item in context menu. -->
-	<string name="downloader_map_only">الخريطة فقط</string>
-	<!-- Toolbar title -->
-	<string name="toolbar_application_menu">قائمة التطبيق</string>
 	<!-- Preference text -->
 	<string name="pref_use_google_play">استخدم خدمات جوجل بلاي لتتعرف على موقعك الحالي</string>
 	<!-- Text for rating dialog -->
 	<string name="rating_just_rated">لقد قمت بتقييم تطبيقك للتو</string>
-	<!-- Text for rating dialog -->
-	<string name="rating_user_since">أنا مستخدم لتطبيق Organic Maps منذ %s</string>
-	<!-- Text for rating dialog -->
-	<string name="rating_do_like_maps">هل تطبيق Organic Maps يعجبك؟</string>
-	<!-- Text for rating dialog -->
-	<string name="rating_tap_star">انقر على النجمة لتقييم التطبيق.</string>
 	<!-- Text for rating dialog -->
 	<string name="rating_thanks">شكرا لك!</string>
 	<!-- Text for rating dialog -->
 	<string name="rating_share_ideas">شارك أي أفكار أو مشاكل، حتى نتمكن من تحسين التطبيق من أجلك.</string>
 	<!-- Text for rating dialog -->
 	<string name="rating_send_feedback">إرسال التعليق</string>
-	<!-- Text for g+ dialog -->
-	<string name="rating_google_plus">اضغط على g+ لتخبر أصدقاءك عن التطبيق.</string>
 	<!-- Text for routing error dialog -->
 	<string name="routing_download_maps_along">تنزيل الخرائط على طول الطريق</string>
-	<!-- Text for routing error dialog -->
-	<string name="routing_download_map">Scarica la mappa</string>
-	<!-- Text for routing error dialog -->
-	<string name="routing_download_map_and_routing">Scarica la mappa aggiornata e i dati del percorso per ottenere tutte le funzionalità Organic Maps.</string>
-	<!-- Text for routing error dialog -->
-	<string name="routing_get_routing_data">Ottieni i dati del percorso</string>
-	<!-- Text for routing error dialog -->
-	<string name="routing_get_additional_data">dati aggiuntivi richiesti per creare i percorsi dalla tua posizione.</string>
 	<!-- Text for routing error dialog -->
 	<string name="routing_requires_all_map">Creare un percorso necessita la presenza di tutte le mappe scaricate e aggiornate dalla tua posizione alla destinazione.</string>
 	<!-- Text for routing error dialog -->
 	<string name="routing_not_enough_space">Spazio non sufficiente</string>
-	<!-- Text for routing error dialog -->
-	<string name="routing_download_more_than_avail">Devi scaricare %1$s MB, ma lo spazio disponibile è di soli %2$s MB.</string>
-	<!-- Text for routing error dialog -->
-	<string name="routing_download_roaming">أنت على وشك تنزيل %s م.ب باستخدام البيانات المتنقلة (في وضع التجوال). وهذا قد يؤدي إلى مصاريف إضافية اعتمادا على خطة البيانات المتنقلة الخاصة بالمشغل الخاص بك.</string>
 	<!-- bookmark button text -->
 	<string name="bookmark">إشارة مرجعية</string>
-	<!-- map is not downloaded -->
-	<string name="not_found_map">الخريطة الخاصة بالمكان الذي تتواجد فيه لا يتم تنزيلها</string>
 	<!-- location service disabled -->
 	<string name="enable_location_services">الرجاء تفعيل خدمة تحديد المواقع</string>
-	<!-- download map -->
-	<string name="download_map">قم بتنزيل الخريطة الخاصة بموقعك</string>
-	<!-- download map on iPhone -->
-	<string name="download_map_iphone">قم بتنزيل خريطة الموقع الحالي على جهاز آيفون الخاص بك</string>
-	<!-- clear pin -->
-	<string name="nearby">قريب</string>
-	<!-- clear pin -->
-	<string name="clear_pin">مسح الرقم السري</string>
-	<!-- location is undefined -->
-	<string name="undefined_location">الموقع الحالي غير مُعَرّف</string>
-	<!-- download country of your location -->
-	<string name="download_country">تنزيل دولة موقعك الحالي</string>
-	<!-- download failed -->
-	<string name="download_failed">فشلت عملية تنزيل</string>
-	<!-- get the map -->
-	<string name="get_the_map">احصل على الخريطة</string>
 	<string name="save">حفظ</string>
 	<string name="edit_description_hint">أوصافك (نصّ أو html)</string>
-	<string name="new_group">مجموعة جديدة</string>
 	<string name="create">إنشاء</string>
 	<!-- red color -->
 	<string name="red">أحمر</string>
@@ -494,22 +298,6 @@
 	<string name="brown">بني</string>
 	<!-- pink color -->
 	<string name="pink">وردي</string>
-	<!-- deep purple color -->
-	<string name="deep_purple">أرجواني داكن</string>
-	<!-- light blue color -->
-	<string name="light_blue">أزرق فاتح</string>
-	<!-- cyan color -->
-	<string name="cyan">أزرق سماوي</string>
-	<!-- teal color -->
-	<string name="teal">أخضر فاتح</string>
-	<!-- lime color -->
-	<string name="lime">ليموني</string>
-	<!-- deep orange color -->
-	<string name="deep_orange">برتقالي داكن</string>
-	<!-- gray color -->
-	<string name="gray">رمادي</string>
-	<!-- blue gray color -->
-	<string name="blue_gray">رمادي أزرق</string>
 	<!-- Wi-Fi available -->
 	<string name="WiFi_available">نعم</string>
 
@@ -525,10 +313,8 @@
 	<string name="dialog_routing_location_turn_wifi">يُرجى التحقق من إشارة GPS لديك. ويساعد تمكين خدمة Wi-Fi في تحسين دقة تحديد موقعك.</string>
 	<string name="dialog_routing_location_turn_on">تمكين خدمات المواقع</string>
 	<string name="dialog_routing_location_unknown_turn_on">تعذر تحديد إحداثيات نظام تحديد المواقع العالمي GPS الحالية. قم بتمكين خدمات المواقع لحساب المسار.</string>
-	<string name="dialog_routing_location_unknown">تعذر تحديد مواقع إحداثيات نظام تحديد المواقع العالمي GPS الحالية.</string>
 	<string name="dialog_routing_download_files">تنزيل الملفات المطلوبة</string>
 	<string name="dialog_routing_download_and_update_all">قم بتنزيل وتحديث كافة الخرائط ومعلومات التوجيه على طول الطريق المتوقع لحساب المسار.</string>
-	<string name="dialog_routing_routes_size">ملفات معلومات التوجيه</string>
 	<string name="dialog_routing_unable_locate_route">تعذر تحديد موقع المسار</string>
 	<string name="dialog_routing_cant_build_route">تعذر إنشاء مسار.</string>
 	<string name="dialog_routing_change_start_or_end">برجاء تعديل نقطة بدء وجهتك.</string>
@@ -543,33 +329,23 @@
 	<string name="dialog_routing_system_error">خطأ في النظام</string>
 	<string name="dialog_routing_application_error">تعذر إنشاء مسار نتيجة وجود خطأ في التطبيق.</string>
 	<string name="dialog_routing_try_again">برجاء إعادة المحاولة</string>
-	<string name="dialog_routing_send_error">الإبلاغ عن المشكلة</string>
-	<string name="dialog_routing_if_get_cross_route">هل تريد إنشاء مسار مباشر بشكل أكبر يمتد عبر أكثر من خريطة؟</string>
-	<string name="dialog_routing_cross_route_is_optimal">هناك مسار أفضل يعبر حافة هذه الخريطة.</string>
 	<string name="not_now">ليس الآن</string>
-	<string name="dialog_routing_build_route">إنشاء</string>
 	<string name="dialog_routing_download_and_build_cross_route">هل ترغب في تنزيل الخريطة وإنشاء مسار أفضل يمتد عبر أكثر من خريطة؟</string>
 	<string name="dialog_routing_download_cross_route">تنزيل الخريطة لإنشاء مسار أفضل يعبر حافة هذه الخريطة.</string>
-	<string name="dialog_routing_cross_route_always">اعبر هذه الحدود دائمًا</string>
 
 	<!-- SECTION: Strings for downloading map from search -->
 	<string name="search_without_internet_advertisement">لبدء البحث وإنشاء الطرق، يرجى تنزيل الخريطة، وسوف لن تحتاج إلى اتصال بالإنترنت بعد الآن.</string>
 	<string name="search_select_map">اختيار الخريطة</string>
-	<string name="search_select_other_map">اختيار خريطة أخرى</string>
 	<!-- «Show» context menu -->
 	<string name="show">عرض</string>
 	<!-- «Hide» context menu -->
 	<string name="hide">إخفاء</string>
 	<!-- «Rename» context menu -->
 	<string name="rename">إعادة تسمية</string>
-	<!-- Bottom sheet: expand button (should be short) -->
-	<string name="bottom_sheet_more">المزيد…</string>
 	<!-- Failed planning route message in navigation view -->
 	<string name="routing_planning_error">فشل في تخطيط المسار</string>
 	<!-- Arrive routing message in navigation view -->
 	<string name="routing_arrive">الوصول: %s</string>
-	<!-- Text for routing::RouterResultCode::FileTooOld dialog. -->
-	<string name="dialog_routing_download_and_update_maps">لإنشاء مسار، يرجى تنزيل وتحديث جميع الخرائط على امتداد الطريق.</string>
 	<string name="rate_alert_title">يعجبك التطبيق؟</string>
 	<string name="rate_alert_default_message">شكرا لاستخدامك Organic Maps. من فضلك، أَعْطِ تقييمك للتطبيق. ملاحظاتك تساعدنا على أن نصبح أفضل.</string>
 	<string name="rate_alert_five_star_message">مرحا! نحن أيضا نحبك!</string>
@@ -577,24 +353,14 @@
 	<string name="rate_alert_less_than_four_star_message">لديك أي فكرة حول كيف يمكننا أن نجعله أفضل؟</string>
 	<string name="categories">التصنيفات</string>
 	<string name="history">السجل</string>
-	<string name="next_turn_then">ثم</string>
 	<string name="closed">مغلق</string>
-	<string name="back_to">العودة إلى %s</string>
 	<string name="search_not_found">المعذرة، لم أعثر على أي شيء.</string>
 	<string name="search_not_found_query">يرجى تجربة استعلام آخر.</string>
-	<string name="search_not_found_map">فضلا، قم بتنزيل الخريطة التي تبحث فيها.</string>
-	<string name="search_not_found_location">قم بتنزيل الخريطة الخاصة بموقعك الجغرافي.</string>
 	<string name="search_history_title">سجل البحث</string>
 	<string name="search_history_text">الوصول إلى استعلامات البحث الحديثة بسرعة.</string>
 	<string name="clear_search">مسح تاريخ البحث</string>
-	<!-- Title for settings to enable/disable showcase menu button -->
-	<string name="showcase_settings_title">رؤية العروض</string>
-	<string name="p2p_route_planning">تخطيط الطريق</string>
 	<string name="p2p_your_location">موقعك</string>
-	<string name="p2p_from">نقطة المغادرة</string>
-	<string name="p2p_to">نقطة الوصول</string>
 	<string name="p2p_start">البداية</string>
-	<string name="p2p_planning">جار التخطيط…</string>
 	<string name="p2p_from_here">من</string>
 	<string name="p2p_to_here">الطريق إلى</string>
 	<string name="p2p_only_from_current">تتوافر إمكانية التنقل فقط من خلال موقعك الحالي. هل تريد أن نخطط لك طريقاً بديلاً؟</string>
@@ -614,11 +380,8 @@
 	<string name="editor_hours_closed">ساعات الراحة</string>
 	<string name="editor_example_values">أمثلة على القيم</string>
 	<string name="editor_correct_mistake">تصحيح الخطأ</string>
-	<string name="editor_correct_mistake_message">قمت بخطأ في التحرير. يرجى تصحيح الخطأ أو التبديل إلى الوضع البسيط.</string>
 	<string name="editor_add_select_location">الموقع</string>
 	<string name="editor_done_dialog_1">لقد غيرت خريطة العالم. لا تخفي ذلك! اخبر أصدقاءك، وغيروها معا.</string>
-	<string name="editor_done_dialog_2">هذا هو تعديلك الثاني بالخريطة. أنت الآن في الترتيب رقم %d في قائمة محرري الخريطة. اخبر أصدقاءك عن ذلك.</string>
-	<string name="editor_done_dialog_3">لقد عدلت الخريطة، اخبر أصدقائك عن ذلك، وعدلوا الخريطة معا.</string>
 	<string name="share_with_friends">شارك مع الأصدقاء</string>
 	<string name="editor_report_problem_desription_1">يرجى وصف المشكلة بالتفاصيل حتى يتسنى لفريق OpenStreeMap إصلاح الخطأ.</string>
 	<string name="editor_report_problem_desription_2">أو افعل ذلك بنفسك من خلال الموقع https://www.openstreetmap.org/</string>
@@ -627,14 +390,7 @@
 	<string name="editor_report_problem_no_place_title">المكان غير موجودٍ</string>
 	<string name="editor_report_problem_under_construction_title">مغلق للصيانة</string>
 	<string name="editor_report_problem_duplicate_place_title">مكان متكرر</string>
-	<string name="first_launch_congrats_title">Organic Maps جاهز للاستخدام</string>
-	<string name="first_launch_congrats_text">ابحث وتصفح كل مكان في العالم بدون اتصال, مجانا.</string>
-	<string name="migrate_title">هام!</string>
-	<!-- Android uses image instead of text. -->
-	<string name="download_all">تنزيل الكل</string>
-	<string name="delete_all">حذف الكل</string>
 	<string name="autodownload">التنزيل التلقائي</string>
-	<string name="disable_autodownload">تعطيل التنزيل التلقائي</string>
 	<!-- Place Page opening hours text -->
 	<string name="closed_now">مغلق الآن</string>
 	<!-- Place Page opening hours text -->
@@ -643,8 +399,6 @@
 	<string name="day_off_today">مغلق اليوم</string>
 	<string name="day_off">مغلق</string>
 	<string name="today">اليوم</string>
-	<string name="sunrise_to_sunset">من الشروق إلى المغيب</string>
-	<string name="sunset_to_sunrise">من غروب الشمس وحتى الشروق</string>
 	<string name="add_opening_hours">اضف ساعات عمل</string>
 	<string name="edit_opening_hours">حرر ساعات عمل</string>
 	<string name="no_osm_account">ليس لديك حساب في OpenStreetMap؟</string>
@@ -654,29 +408,13 @@
 	<string name="login">تسجيل الدخول</string>
 	<string name="password">كلمة المرور</string>
 	<string name="forgot_password">هل نسيت كلمة المرور؟</string>
-	<!-- Forgot Password dialog title -->
-	<string name="restore_password">استعادة كلمة المرور</string>
-	<string name="enter_email_address_to_reset_password">أدخل عنوان البريد الإلكتروني الذي استخدمته عند التسجيل وسنرسل لك رابط لتجديد كلمة المرور</string>
-	<string name="reset_password">إعادة تعيين كلمة المرور</string>
-	<string name="username">اسم المستخدم</string>
 	<string name="osm_account">حساب OSM</string>
 	<string name="logout">تسجيل الخروج</string>
-	<string name="login_and_edit_map_motivation_message">قم بتسجيل الدخول وعدل البيانات الخاصة بالمكان على الخريطة وسنجعلها متاحة لملايين المستخدمين الآخرين. لنجعل العالم أفضل معا.</string>
 	<!-- Information text: "Last upload 11.01.2016" -->
 	<string name="last_upload">آخر تحميل</string>
-	<!-- Motivates user to login/register, title above login buttons. -->
-	<string name="you_have_edited_your_first_object">لقد قمت بتعديلك الأول!</string>
 	<string name="thank_you">شكرا لك</string>
-	<string name="login_with_google">تسجيل الدخول عبر جوجل</string>
-	<string name="login_with_openstreetmap">قم بتسجيل الدخول في www.openstreetmap.org</string>
 	<string name="edit_place">تعديل المكان</string>
 	<string name="place_name">اسم المكان</string>
-	<!-- title above languages list cells in the editor, below editable name text field. -->
-	<string name="other_languages">لغات أخرى</string>
-	<!-- small button to open list with names in different languages -->
-	<string name="show_more">إظهار أكثر</string>
-	<!-- small button to close list with names in different languages -->
-	<string name="show_less">إظهار أقل</string>
 	<string name="add_language">إضافة لغة</string>
 	<string name="street">الشارع</string>
 	<!-- Editable House Number text field (in address block). -->
@@ -693,25 +431,16 @@
 	<string name="email_or_username">البريد الإلكتروني أو اسم المستخدم</string>
 	<string name="phone">الهاتف</string>
 	<string name="please_note">يرجى العلم أنه،</string>
-	<string name="common_no_wifi_dialog">لا يوجد اتصال واي فاي. هل ترغب في استخدام بيانات الهاتف للاتصال؟</string>
 	<string name="downloader_delete_map_dialog">سيتم حذف جميع التغييرات بالخريطة بالإضافة إلى حذف الخريطة نفسها.</string>
 	<string name="downloader_update_maps">تحديث الخرائط</string>
 	<string name="downloader_mwm_migration_dialog">لإنشاء مسار، فأنت تحتاج إلى تحديث كافة الخرائط ثم إعادة تخطيط المسار مرة أخرى.</string>
 	<string name="downloader_search_field_hint">اعثر على الخريطة</string>
-	<string name="migration_update_all_button">تحديث جميع الخرائط</string>
-	<string name="migration_delete_all_download_current_button">تنزيل الخريطة الحالية وحذف الخرائط القديمة</string>
 	<string name="migration_download_error_dialog">خطأ بالتنزيل</string>
 	<string name="common_check_internet_connection_dialog">يرجى التحقق من الإعدادات والتأكد من اتصال جهازك بالإنترنت.</string>
 	<string name="downloader_no_space_title">مساحة غير كافية</string>
 	<string name="downloader_no_space_message">من فضلك، قم بإزالة البيانات غير الضرورية</string>
-	<string name="editor_general_auth_error_dialog">خطأ بتسجيل الدخول العام.</string>
 	<string name="editor_login_error_dialog">خطأ في تسجيل الدخول.</string>
-	<string name="editor_login_failed_dialog">فشل تسجيل الدخول</string>
-	<string name="editor_username_error_dialog">اسم المستخدم غير صحيح</string>
-	<string name="editor_place_edited_dialog">لقد قمت بتعديل هدف!</string>
-	<string name="editor_login_with_osm">تسجيل الدخول عبر OpenStreetMap</string>
 	<string name="editor_profile_changes">التغييرات التي تم التحقق منها</string>
-	<string name="editor_profile_unsent_changes">لم ترسل:</string>
 	<string name="editor_focus_map_on_location">اسحب الخريطة لتحدد الموقع الصحيح للهدف.</string>
 	<string name="editor_add_select_category">اختر الفئة</string>
 	<string name="editor_add_select_category_popular_subtitle">شائع</string>
@@ -722,19 +451,14 @@
 	<string name="editor_edit_place_category_title">الفئة</string>
 	<string name="detailed_problem_description">وصف مفصل للمشكلة</string>
 	<string name="editor_report_problem_other_title">مشكلة مختلفة</string>
-	<string name="placepage_report_problem_button">الإبلاغ عن مشكلة</string>
 	<string name="placepage_add_business_button">إضافة مؤسسة</string>
 	<string name="whatsnew_editor_message_1">قم بإضافة أماكن جديدة للخريطة، وعدل أماكن حالية مباشرة من التطبيق.</string>
-	<string name="whatsnew_editor_message_2">*تستخدم Organic Maps البيانات الخاصة بخريطة OpenStreetMap.</string>
 	<string name="dialog_incorrect_feature_position">تغيير الموقع</string>
 	<string name="message_invalid_feature_position">لا يمكن تحديد موقع الكائن هنا</string>
 	<string name="login_to_make_edits_visible">قم بتسجيل الدخول حتى يتمكن باقي المستخدمين من رؤية التغييرات التي قمت بها.</string>
-	<string name="no_migration_during_navigation">التحديث ممنوع أثناء الملاحة.</string>
 	<!-- Error dialog no space -->
 	<string name="migration_no_space_message">للتنزيل، فأنت تحتاج إلى توفير مساحة أكبر. من فضلك، احذف البيانات غير الضرورية.</string>
 	<string name="editor_sharing_title">لقد قمت بتحديث خرائط تطبيق Organic Maps</string>
-	<string name="editor_comment_will_be_sent">سوف نرسل تعليقك إلى فريق رسم الخرائط.</string>
-	<string name="editor_unsupported_category_message">لقد قمت بإضافة مكان ينتمي لفئة غير متوفرة لدينا بعد. سوف تظهر على الخريطة لاحقا.</string>
 	<!-- Downloaded 10 **of** 20 <- it is that "of" -->
 	<string name="downloader_of">%1$d من%2$d</string>
 	<string name="download_over_mobile_header">تنزيل باستخدام اتصال الشبكة الخلوية؟</string>
@@ -752,15 +476,8 @@
 	<string name="editor_detailed_description">سيتم إرسال التغييرات التي اقترحتها إلى مجتمع OpenStreetMap. اذكر التفاصيل التي لا يمكن تحريرها في Organic Maps</string>
 	<string name="editor_more_about_osm">المزيد عن OpenStreetMap</string>
 	<string name="editor_operator">معامل</string>
-	<string name="editor_tag_description">أدخل الشركة أو المؤسسة أو الشخص المسؤول عن المنشآت.</string>
-	<string name="editor_no_local_edits_title">ليست لديك تعديلات محلية</string>
-	<string name="editor_no_local_edits_description">يوضح هذا عدد التغييرات المقترحة على الخريطة والتي يمكن الوصول إليها حاليًا فقط من على جهازك.</string>
-	<string name="editor_send_to_osm">إرسال الى OSM</string>
-	<string name="editor_remove">إزالة</string>
-	<string name="downloader_my_maps_title">خرائطي</string>
 	<string name="downloader_no_downloaded_maps_title">لم تقم بتنزيل أية خرائط</string>
 	<string name="downloader_no_downloaded_maps_message">قم بتنزيل خرائط للبحث عن مكان والتنقل بدون اتصال بالإنترنت.</string>
-	<string name="downloader_find_place_hint">البحث في المدينة أو البلد</string>
 	<!-- Error title that appears after certain time without location. -->
 	<string name="current_location_unknown_title">هل تريد متابعة اكتشاف موقعك الحالي؟</string>
 	<!-- Error that appears after certain time without location. -->
@@ -775,27 +492,10 @@
 	<string name="location_services_disabled_2">2. انقر على الموقع</string>
 	<!-- iOS Dialog for the case when the location permission is not granted -->
 	<string name="location_services_disabled_3">3. اختيار أثناء استخدام التطبيق</string>
-	<string name="placepage_parking_surface">سطح</string>
-	<string name="placepage_parking_multistorey">متعدد الطوابق</string>
-	<string name="placepage_parking_underground">تحت الارض</string>
-	<string name="placepage_parking_rooftop">سطح المبنى</string>
-	<string name="placepage_parking_sheds">حظائر</string>
-	<string name="placepage_parking_carports">مظلات سيارات</string>
-	<string name="placepage_parking_boxes">صناديق جراج</string>
-	<string name="placepage_parking_pay">دفع</string>
-	<string name="placepage_parking_free">مجانًا</string>
-	<string name="placepage_parking_interval">دفع عن فترة</string>
-	<string name="placepage_entrance_number">رقم</string>
-	<string name="placepage_entrance_type">المدخل</string>
-	<string name="placepage_flat">تطبيق</string>
-	<string name="placepage_open_24_7">24 / 7</string>
 	<string name="meter">م</string>
 	<string name="kilometer">كم</string>
-	<string name="kilometers_per_hour">كم/ساعة</string>
 	<string name="mile">ميل</string>
 	<string name="foot">قدم</string>
-	<string name="miles_per_hour">ميل/ساعة</string>
-	<string name="day">ي</string>
 	<string name="hour">س</string>
 	<string name="minute">د</string>
 	<string name="placepage_place_description">الوصف</string>
@@ -805,46 +505,30 @@
 	<string name="placepage_call_button">اتصال</string>
 	<string name="placepage_edit_bookmark_button">تحرير العلامة المرجعية</string>
 	<string name="placepage_bookmark_name_hint">اسم العلامة المرجعية</string>
-	<string name="placepage_personal_notes_hint">ملاحظات شخصية</string>
-	<string name="placepage_delete_bookmark_button">حذف العلامة المرجعية</string>
 	<string name="editor_edits_sent_message">لقد تم إرسال التغييرات التي اقترحتها</string>
 	<string name="editor_comment_hint">تعليق…</string>
 	<string name="editor_reset_edits_message">هل تريد مسح كافة التغييرات المحلية؟</string>
 	<string name="editor_reset_edits_button">مسح</string>
 	<string name="editor_remove_place_message">إزالة مكان تمت إضافته؟</string>
 	<string name="editor_remove_place_button">إزالة</string>
-	<string name="editor_status_sending">جارِ الإرسال…</string>
 	<string name="editor_place_doesnt_exist">المكان غير موجود</string>
 	<string name="text_more_button">…المزيد</string>
 	<!-- Phone number error message -->
 	<string name="error_enter_correct_phone">أدخل رقم هاتف صحيح</string>
 	<string name="error_enter_correct_web">أدخل عنوان ويب صالح</string>
 	<string name="error_enter_correct_email">أدخل بريدا إلكترونيا صالحا</string>
-	<string name="error_enter_correct">أدخل قيمة صالحة</string>
 	<string name="refresh">تحديث</string>
-	<string name="last_update">أخر تحديث: %s</string>
 	<string name="placepage_add_place_button">إضافة مكان ما للخريطة</string>
 	<!-- Displayed when saving some edits to the map to warn against publishing personal data -->
 	<string name="editor_share_to_all_dialog_title">هل ترغب في إرساله لجميع المستخدمين؟</string>
 	<!-- iOS Dialog before publishing the modifications to the public map. -->
 	<string name="editor_share_to_all_dialog_message_1">تأكد من أنك لم تقم بإدخال أي بيانات شخصية.</string>
 	<string name="editor_share_to_all_dialog_message_2">سنقوم بمراجعة هذه التغييرات. إذا كانت لدينا أي أسئلة فسوف نتصل بك عبر البريد الإلكتروني.</string>
-	<string name="navigation_overview_button">استعراض</string>
-	<string name="navigation_stop_button">توقف</string>
-	<!-- Text on an empty bookmark page -->
-	<string name="bookmarks_empty_title">حفظ الإشارات المرجعية</string>
-	<string name="bookmarks_empty_message_1">انقر على ★ لحفظ الأماكن المفضلة من أجل إمكانية الوصول السريع.</string>
-	<string name="bookmarks_empty_message_2">جلب العلامات المرجعية من البريد الإلكتروني والإنترنت.</string>
-	<string name="bookmarks_empty_message_3">غادر: %s</string>
-	<!-- Name of the group for booked hotels -->
-	<string name="bookmarks_group_name">فنادق تم حجزها</string>
-	<string name="place_page_button_read_descriprion">اقرأ</string>
 	<!-- iOS dialog for the case when recent track recording is on and the app comes back from background -->
 	<string name="recent_track_background_dialog_title">تريد تعطيل التسجيل الخاص بمسار سفرك الأخير؟</string>
 	<string name="off_recent_track_background_button">تعطيل</string>
 	<!-- For sharing via SMS and so on -->
 	<string name="sharing_call_action_look">انظر</string>
-	<string name="continue_recent_track_background_button">استمرار</string>
 	<string name="recent_track_background_dialog_message">يستخدم Organic Maps موقعك الجغرافي في الخلفية لتسجيل مسار سفرك الأخير.</string>
 	<!-- Rate on Google Play (Android only) -->
 	<string name="rate_gp">تصنيف على Google Play</string>
@@ -854,21 +538,11 @@
 	<string name="tell_friends_text">مرحبًا! تثبيت Organic Maps!</string>
 	<!-- About short text (below logo) -->
 	<string name="about_description">Organic Maps هو تطبيق أساسي للسفر بدون اتصال بالإنترنت. يعتمد برنامج Organic Maps على بيانات OpenStreetMap ويتيح تحريرها.</string>
-	<!-- Text in menu -->
-	<string name="blog">المدونة</string>
 	<string name="general_settings">إعدادات عامة</string>
-	<string name="date">التاريخ %d</string>
-	<!-- "Report a bug" -> "Generaal Feedback" -> "Something is not working" -->
-	<string name="something_is_not_working">شيء ما لا يعمل</string>
 	<!-- For the first routing -->
 	<string name="accept">قبول</string>
 	<!-- For the first routing -->
 	<string name="decline">رفض</string>
-	<string name="install_app">تثبيت</string>
-	<string name="search_no_results_title">لم يتم العثور على نتائج</string>
-	<string name="search_no_results_message">جرب مصطلح بحث أكثر عمومية أو التصغير أو إعادة تعيين عامل التصفية.</string>
-	<string name="search_no_results_expand_area_button">تصغير</string>
-	<string name="search_no_results_reset_button">إعادة تعيين عامل التصفية</string>
 	<!-- noun -->
 	<string name="search_in_table">قائمة</string>
 	<string name="mobile_data_dialog">استخدام إنترنت المحمول لإظهار المعلومات التفصيلية؟</string>
@@ -880,18 +554,13 @@
 	<string name="mobile_data_option_never">عدم الاستخدام مطلقًا</string>
 	<string name="mobile_data_option_ask">السؤال دوماً</string>
 	<string name="traffic_update_maps_text">لعرض البيانات المرورية، يجب تحديث الخرائط.</string>
-	<string name="traffic_outdated">البيانات المرورية قديمة.</string>
 	<string name="big_font">زيادة حجم الخط على الخريطة</string>
 	<string name="traffic_update_app">الرجاء تحديث Organic Maps</string>
 	<!-- "traffic" as in road congestion -->
 	<string name="traffic_update_app_message">لعرض البيانات المرورية، يجب تحديث التطبيق.</string>
 	<!-- "traffic" as in "road congestion" -->
 	<string name="traffic_data_unavailable">البيانات المرورية غير متاحة</string>
-	<!-- Simplified colour scheme for traffic information, fewer colours are used to display traffic jams on the map. The string should be kept as short as possible -->
-	<string name="pref_traffic_simplified_colors_title">ألوان مرور مبسطة</string>
 	<string name="enable_logging">تمكين التسجيل</string>
-	<string name="offline_place_page_more_information">اتصل بالإنترنت للحصول على مزيد من التفاصيل حول المكان.</string>
-	<string name="failed_load_information">فشل تحميل المعلومات.</string>
 	<!-- Settings: "Send general feedback" button -->
 	<string name="feedback_general">تعقيب عام</string>
 	<string name="on">تشغيل</string>
@@ -905,57 +574,26 @@
 	<string name="routing_add_start_point">أضف نقطة البداية لتخطيط المسار</string>
 	<string name="routing_add_finish_point">أضف النهاية لتخطيط المسار</string>
 	<string name="button_exit">خروج</string>
-	<string name="settings_device_memory">ذاكرة الجهاز</string>
-	<string name="settings_card_memory">بطاقة الذاكرة</string>
-	<string name="settings_storage_available">%s متوفر</string>
-	<string name="toast_location_permission_denied">تم رفض إذن الموقع للتطبيق</string>
-	<string name="button_use">استخدام</string>
 	<string name="planning_route_manage_route">إدارة المسار</string>
 	<string name="button_plan">خطة</string>
-	<string name="button_add">إضافة</string>
 	<string name="placepage_remove_stop">إزالة</string>
 	<string name="planning_route_remove_title">اسحب هنا للإزالة</string>
-	<string name="dialog_change_start_point_message">استبدال نقطة البدء إلى الموقع الحالي؟</string>
-	<string name="button_replace">استبدال</string>
 	<string name="placepage_add_stop">إضافة نقطة توقف</string>
-	<string name="add_my_position">إضافة موضعي</string>
-	<string name="choose_start_point">اختيار نقطة البداية</string>
-	<string name="choose_destination">اختيار الوجهة</string>
 	<string name="preloader_viator_button">تعلم المزيد</string>
-	<string name="start_from_my_position">بدء من</string>
-	<string name="profile_authorization_title">تسجيل الدخول باستخدام</string>
-	<string name="profile_authorization_message">تسجيل الدخول بسهولة بدون اسم مستخدم وكلمة مرور في غضون بضع ثوان</string>
 	<string name="profile_authorization_error">عفوًا، كان هناك خطأ. حاول تسجيل الدخول مرة اخرى.</string>
-	<string name="service">الخدمة</string>
-	<string name="atmosphere">المناخ</string>
-	<string name="value_for_money">القيمة مقابل المال</string>
-	<string name="experience">التجربة</string>
-	<string name="assortment">التصنيف</string>
-	<string name="expertise">الخبرة</string>
-	<string name="equipment">المعدات</string>
-	<string name="quality">الجودة</string>
 	<string name="dialog_error_storage_title">مشكلة الوصول للتخزين</string>
 	<string name="dialog_error_storage_message">التخزين الخارجي غير متوفر، ربما تمت إزالة بطاقة SD، أو أنها تالفة أو ملف النظام للقراءة فقط. افحصه واتصل بنا على support\@organicmaps.app</string>
 	<string name="setting_emulate_bad_storage">محاكاة التخزين السيء</string>
-	<string name="directions_finish">الوجهة</string>
-	<string name="directions_on_foot">سيرًا %s</string>
 	<string name="core_entrance">المدخل</string>
-	<string name="coffee">قهوة</string>
-	<string name="cleanliness">نظافة</string>
-	<string name="crowdedness">اكتظاظ</string>
 	<string name="error_enter_correct_name">الرجاء إدخال اسم صحيح</string>
 	<string name="bookmarks_groups">قوائم</string>
 	<string name="bookmarks_groups_hide_all">إخفاء الكل</string>
 	<string name="bookmarks_groups_show_all">إظهار الكل</string>
-	<plurals name="bookmarks_places">
-	  <item quantity="other">%d من الإشارات المرجعية</item>
-	</plurals>
 	<string name="bookmarks_create_new_group">إنشاء قائمة جديدة</string>
 	<string name="downloader_hide_screen">إخفاء الشاشة</string>
 	<string name="downloader_percent">%1$s (%2$s من %3$s)</string>
-	<string name="downloader_process">جار تنزيل %s...</string>
-	<string name="downloader_applying">جار تطبيق %s...</string>
-	<string name="dialog_message_transit_not_found_connection">خطط المسار داخل شبكة عبور واحدة</string>
+	<string name="downloader_process">جار تنزيل %s…</string>
+	<string name="downloader_applying">جار تطبيق %s…</string>
 	<string name="bookmarks_error_message_share_general">تعذرت المشاركة بسبب خطأ في التطبيق</string>
 	<string name="bookmarks_error_title_share_empty">خطأ في المشاركة</string>
 	<string name="bookmarks_error_message_share_empty">لا يمكن مشاركة قائمة فارغة</string>
@@ -964,12 +602,7 @@
 	<string name="bookmarks_new_list_hint">قائمة جديدة</string>
 	<string name="bookmarks_error_title_list_name_already_taken">هذا الاسم أخذ سابقا</string>
 	<string name="bookmarks_error_message_list_name_already_taken">يرجى اختيار اسم آخر</string>
-	<string name="bookmarks_error_title_list_name_too_long">هذا الاسم طويل للغاية</string>
-	<string name="bookmarks_error_message_list_name_too_long">يرجى اختيار اسم آخر</string>
-	<string name="please_wait">أرجو الإنتظار...</string>
-	<string name="phone_number">رقم الهاتف</string>
-	<string name="notification_unsent_reviews_title">لديك عدة تعليقات غير مرغوب فيها</string>
-	<string name="notification_unsent_reviews_message">الرجاء تسجيل الدخول لمشاركة التعليقات مع المسافرين الآخرين</string>
+	<string name="please_wait">أرجو الإنتظار…</string>
 	<string name="profile">الملف الشخصي OpenStreetMap</string>
 	<string name="place_page_search_similar_hotel">ابحث عن فنادق مماثلة</string>
 	<string name="bookmarks_detect_title">تم اكتشاف ملفات جديدة</string>
@@ -979,31 +612,10 @@
 	<string name="button_convert">تحول</string>
 	<string name="bookmarks_convert_error_title">خطأ</string>
 	<string name="bookmarks_convert_error_message">لم يتم تحويل بعض الملفات.</string>
-	<string name="converting">تحويل...</string>
-	<string name="wn_reinvented_bookmarks_title">لقد قمنا بإعادة اختراع العناوين!</string>
-	<string name="wn_reinvented_bookmarks_message">يمكنك الاحتفاظ بنسخة احتياطية منها وإنشاء قوائم... إنه أمر مذهل...</string>
-	<string name="bookmarks_restore">استعادة الإشارات المرجعية</string>
-	<string name="bookmarks_restore_process">استعادة...</string>
 	<string name="bookmarks_restore_title">استعادة هذا الإصدار؟</string>
-	<string name="bookmarks_restore_message">ستستعيد إشاراتك المرجعية من %1$s (%2$s)</string>
-	<string name="bookmarks_restore_empty_title">ليس لديك نسخة احتياطية</string>
-	<string name="bookmarks_restore_empty_message">لم يعثر الخادم على نسخ احتياطية سابقة</string>
 	<string name="common_check_internet_connection_dialog_title">لا يوجد اتصال بالإنترنت</string>
-	<string name="error_server_title">خطأ في الخادم</string>
-	<string name="error_server_message">حدث خطأ على الخادم ، يرجى المحاولة مرة أخرى في وقت لاحق</string>
 	<string name="error_system_message">حدث خطأ غير معروف</string>
 	<string name="restore">استعادة</string>
-	<string name="bookmarks_page_downloaded">تم تحميل</string>
-	<string name="bookmarks_page_my">الخاص بي</string>
-	<string name="routes_and_bookmarks">الطرق والإشارات</string>
-	<string name="bookmarks_webview_success_toast">تم تحميل الإشارات بنجاح</string>
-	<string name="cached_bookmarks_placeholder_title">تحميل أماكن جديدة</string>
-	<string name="cached_bookmarks_placeholder_subtitle">اضغط على الزر لتحميل الآلاف من الأماكن المثيرة للاهتمام والطرق التي تم إنشاؤها من قبل لمستخدمين Organic Maps. سوف تحتاج إلى اتصال بالإنترنت.</string>
-	<string name="downloader_download_routers">تحميل الإشارات</string>
-	<string name="bookmarks_groups_cached">القوائم التي تم تنزيلها</string>
-	<plurals name="bookmarks_objects">
-	  <item quantity="other">%s العنصر</item>
-	</plurals>
 	<plurals name="objects">
 	  <item quantity="other">المكان %d</item>
 	</plurals>
@@ -1016,62 +628,32 @@
 	<string name="subtittle_opt_out">إعدادات التتبع</string>
 	<string name="crash_reports">تقرير الحادث</string>
 	<string name="crash_reports_description">قد نستخدم بياناتك لتحسين تجربة Organic Maps. سوف تكون التغييرات نافذة المفعول بعد إعادة تشغيل التطبيق.</string>
-	<string name="opt_out_help_ios_1">يمكن أن يوفر جهازك الجوّال إعداد \"\"تقييد الإعلان المخصص\"\" أو \"\"تعطيل الإعلان الذي يستهدف الاهتمامات\"\".</string>
-	<string name="opt_out_help_ios_2">نظام تشغيل آي 9 فما فوق</string>
-	<string name="opt_out_help_ios_3">انتقل إلى إعداداتك ← الخصوصية ← الإعلانات ← تمكين إعداد \"\"تحديد تتبع الإعلانات\"\"</string>
-	<string name="opt_out_help_android">قد يوفر جهازك الجوّال إعداد \"\"الحد من تتبع الإعلان\"\" أو \"\"إلغاء الاشتراك من الإعلانات التي تستهدف الاهتمامات\"\". \ n \ n للحصول على الإصدار 4.0 من نظام التشغيل Android و Google Play: \ n الإعدادات → Google ← الإعلانات ← إلغاء الاشتراك في تخصيص الإعلانات \ أو \ n الإعدادات → Google → Google Account → المعلومات الشخصية والخصوصية → إعدادات الإعلانات → تخصيص الإعلانات</string>
 	<string name="privacy_policy">سياسة الخصوصية</string>
 	<string name="terms_of_use">شروط الاستخدام</string>
-	<string name="backup_notification_failed">قد تم تعليق احتياطي المواقع المفضلة لديك. سجل الدخول لإعادة تشغيله.</string>
 	<string name="button_layer_traffic">حركة مرور</string>
 	<string name="button_layer_subway">مترو الانفاق</string>
 	<string name="layers_title">طبقات الخريطة</string>
-	<string name="layers_message">استخدم طبقات الخريطة لعرض حركة المرور ، وخريطة مترو الأنفاق ، وغيرها من المعلومات المفيدة</string>
-	<string name="button_layer_got_it">حصلت عليه</string>
 	<string name="subway_data_unavailable">خريطة مترو الانفاق غير متوفرة</string>
 	<string name="bookmarks_empty_list_title">هذه اللائحة شاغرة</string>
 	<string name="bookmarks_empty_list_message">لإضافة إشارة مرجعية ، اضغط على مكان على الخريطة ثم انقر فوق رمز النجمة</string>
 	<string name="category_desc_more">…المزيد</string>
 	<string name="title_error_downloading_bookmarks">حدث خطأ</string>
-	<string name="subtitle_error_downloading_bookmarks">لم يتم تنزيل الإشارات</string>
-	<string name="error_already_downloaded">تم بالفعل تنزيل هذه القائمة</string>
-	<string name="why_support">لماذا تدعم Organic Maps؟</string>
-	<string name="why_support_item2">أنت تساعدنا على تحسين Organic Maps</string>
-	<string name="why_support_item3">يمكنك مساعدتنا في تحسين خرائط مفتوحة OpenStreetMap.org</string>
-	<string name="channels_map_update">تحديثات الخريطة</string>
-	<string name="server_unavailable_title">الخدمة غير متوفرة</string>
-	<string name="sharing_options">خيارات المشاركة</string>
 	<string name="export_file">ملف التصدير</string>
 	<string name="list_settings">قائمة الإعدادات</string>
 	<string name="delete_list">حذف القائمة</string>
-	<string name="hide_from_map">إخفاء من الخريطة</string>
 	<string name="public_access">إطلاع الجمهور</string>
 	<string name="limited_access">محدودية فرص حصول</string>
 	<string name="bookmark_category_name">الفئة</string>
 	<string name="bookmark_category_description_hint">اكتب وصفًا (نص أو html)</string>
 	<string name="not_shared">خاص</string>
-	<string name="direct_link_progress_text">جارٍ تحميل ملفك…</string>
-	<string name="direct_link_success">لقد تم إنشاء الرابط</string>
-	<string name="send_a_link_btn">ارسل لي رابط</string>
-	<string name="upload_error_toast">حدث خطأ أثناء تحميل ملفك</string>
 	<string name="tags_loading_error_subtitle">حدث خطأ أثناء تحميل العلامات ، يرجى المحاولة مرة أخرى</string>
-	<string name="unable_upload_errorr_title">فشل تحميل الملف</string>
-	<string name="unable_upload_error_subtitle_edited">تم تحرير هذا الملف عبر تطبيق الويب</string>
-	<string name="unable_upload_error_subtitle_broken">هذا الملف تالف ولا يمكن تحميله. يرجى تحميل ملف آخر.</string>
-	<string name="contact">الاتصال</string>
-	<string name="download_button">تحميل</string>
 	<string name="speedcams_alert_title">كاميرات السرعة</string>
-	<string name="speedcams_alert_subtitle">التحذير من حدود السرعة</string>
 	<string name="speedcam_option_auto">السيارات</string>
 	<string name="speedcam_option_always">دائما</string>
 	<string name="speedcam_option_never">مطلقا</string>
-	<string name="bookmark_description_title">وصف الإشارة المرجعية</string>
 	<string name="place_description_title">وصف المكان</string>
 	<!-- this text will be shown in application notification preferences opposite checkbox which enable/disable downloader notifications. Devices on Android 8+ are affected. -->
 	<string name="notification_channel_downloader">محمل الخريطة</string>
-	<string name="share_bookmarks_email_body_link">مرحبًا!\n\nللوصول إلى التطبيق: https://omaps.app/get?kmzهذا هو الرابط الذي يمكنك من خلاله تنزيل إشاراتك المرجعية: %s. افتح القائمة عبر Organic Maps واستمتع برحلتك!\n\n</string>
-	<string name="warning_speedcams_title">سوف يحذرك المستكشف من الكاميرات عندما تتجاوز الحد الأقصى للسرعة %d كم / س</string>
-	<string name="warning_speedcams_subtitle">يرجى مراعاة قواعد القيادة في البلد الذي تنوي السفر إليه.</string>
 	<string name="speedcams_notice_message">السيارات- تحذير على الرادارات إذا كان هناك خطر تجاوز الحد الأقصى للسرعة\nدائما - احذر دائما من كاميرات السرعة\nمطلقا - أبدا تحذير من كاميرات السرعة</string>
 	<string name="power_managment_title">وضع توفير الطاقة</string>
 	<string name="power_managment_description">عندما يتم اختيار الوضع التلقائي، يبدأ التطبيق بتعطيل الخصائص التي تستهلك البطارية بناءً على مستوى شحن البطارية</string>
@@ -1079,14 +661,7 @@
 	<string name="power_managment_setting_auto">تلقائي</string>
 	<string name="power_managment_setting_manual_max">توفير الطاقة القصوى</string>
 	<string name="enable_logging_warning_message">يتحول الخيار إلى التسجيل لإغراض التشخيص. يمكن أن يكون مفيدًا لفريق الدعم الخاص بنا الذين يعملون على استكشاف أخطاء التطبيق وإصلاحها. قم بتفعيل هذا الخيار فقط في حالة طلب الدعم من Organic Maps.</string>
-	<string name="html_error_upload_message_try_again">يرجى التحقق من إعدادات الشبكة الخاصة بك و حاول مرة أخرى</string>
-	<string name="html_error_upload_title_try_again">لا يوجد اتصال بالانترنت</string>
-	<string name="notification_leave_review_v2_android_short_title">ضع تعليق وساعد المسافرين!</string>
-	<string name="notifications_illegal_alert_disable_button">تعطيل الإشعارات</string>
 	<string name="access_rules_author_only">التحرير على الإنترنت</string>
-	<string name="privacy_settings_menu">إعدادات الخصوصية</string>
-	<string name="unable_upadate_error_title">فشل تحديث الملف</string>
-	<string name="unable_upadate_error_message">حدثت بعض الأخطاء أثناء التحديث يرجى التحقق من التغييرات و حاول مرة أخرى</string>
 	<string name="driving_options_title">خيارات قيادة</string>
 	<string name="driving_options_subheader">تجنب على كل الطرق</string>
 	<string name="avoid_tolls">نقطة تحصيل رسوم</string>
@@ -1097,52 +672,14 @@
 	<string name="unable_to_calc_alert_subtitle">نأسف، لم نعثر على الطريق ربما بسبب الخيارات التي قمت بتحديدها. يرجى تغيير الاعدادات والمحاولة مجددًا</string>
 	<string name="define_to_avoid_btn">حدد الطرق التي يجب تجنبها</string>
 	<string name="change_driving_options_btn">تم تفعيل خيارات الطريق</string>
-	<string name="toll_road">نقطة تحصيل رسوم</string>
-	<string name="unpaved_road">طريق غير ممهدة</string>
-	<string name="ferry_crossing">تقاطع عبارة</string>
-	<string name="operated_by">تدرا بواسطة \"%s\"</string>
 	<string name="avoid_toll_roads_placepage">تجنب نقاط تحصيل الرسوم</string>
 	<string name="avoid_unpaved_roads_placepage">تجنب الطرق الغير ممهدة</string>
 	<string name="avoid_ferry_crossing_placepage">تجنب تقاطع العبارات</string>
-	<string name="type.cuisine.uzbek">مطعم أوزبكي</string>
-	<string name="trip_start">هيا بنا</string>
-	<string name="pick_destination">جهة الوصول</string>
-	<string name="follow_my_position">العودة إلى الوسط</string>
-	<string name="search_results">نتائج البحث</string>
-	<string name="then_turn">ثم</string>
-	<string name="redirect_route_alert">هل تريد إعادة تحديد الطريق?</string>
-	<string name="redirect_route_yes">نعم</string>
-	<string name="redirect_route_no">لا</string>
-	<string name="trip_finished">لقد وصلت!</string>
-	<string name="keyboard_availability_alert">لوحة الكتابة غير متاحة أثناء القيادة</string>
-	<string name="dialog_routing_change_start_carplay">لا يمكن تحديد طريق من موقعك الحالي</string>
-	<string name="dialog_routing_change_end_carplay">لا يمكن تحديد طريق لجهة الوصول. يرجي اختيار مكان آخر</string>
-	<string name="dialog_routing_check_gps_carplay">لا وجد إشارة GPS. يرجى التحرك لمكان مفتوح</string>
-	<string name="dialog_routing_unable_locate_route_carplay">لا يمكن تحديد طريق. يرجى تحديد أماكن أخرى على الطريق</string>
-	<string name="dialog_routing_download_files_carplay">كي تُنشئ مساراً، يجب أن تحمل الخرائط المفقودة على جهازك</string>
-	<string name="dialog_routing_system_error_carplay">حدث خطأ. يرجى إعادة تشغيل التطبيق</string>
-	<string name="dialog_routing_rebuild_from_current_location_carplay">سيتم اعادة تحديد الطريق من موقعك الحالي</string>
-	<string name="dialog_routing_rebuild_for_vehicle_carplay">سيتم تعديل الطريق لتكون خاصة بالسيارة</string>
 	<string name="ok">موافق</string>
-	<string name="avoid_unpaved_carplay_1">غير ترابي</string>
-	<string name="avoid_unpaved_carplay_2">تجنب غير الممهد</string>
-	<string name="avoid_ferry_carplay_1">بدون عبََارة</string>
-	<string name="avoid_ferry_carplay_2">تجنب العبََارة</string>
-	<string name="avoid_tolls_carplay_1">بدون رسوم</string>
-	<string name="avoid_tolls_carplay_2">تجنب الرسوم</string>
-	<string name="speedcams_alert_title_carplay_1">كاميرا سريعة</string>
-	<string name="speedcams_alert_title_carplay_2">تحذير سريع</string>
-	<string name="download_map_carplay">يُرجى تحميل الخرائط في تطبيق Organic Maps على جهازك</string>
-	<string name="carplay_roundabout_exit">المخرج رقم %s</string>
 	<!-- max. 10 symbols, both iOS and Android -->
 	<string name="sort">تريتب…</string>
 	<!-- Android, title, max 20-22 symbols -->
 	<string name="sort_bookmarks">رتب العلامات المرجعية</string>
-	<!-- iOS -->
-	<string name="sort_default">رتب افتراضي</string>
-	<string name="sort_type">رتب حسب النوع</string>
-	<string name="sort_distance">رتب حسب المسافة</string>
-	<string name="sort_date">رتب حسب التاريخ</string>
 	<!-- Android -->
 	<string name="by_default">افتراضي</string>
 	<!-- Android -->
@@ -1151,65 +688,23 @@
 	<string name="by_distance">حسب المسافة</string>
 	<!-- Android -->
 	<string name="by_date">حسب التاريخ</string>
-	<string name="week_ago_sorttype">منذ أسبوع</string>
-	<string name="month_ago_sorttype">منذ شهر</string>
-	<string name="moremonth_ago_sorttype">منذ أكثر من شهر</string>
-	<string name="moreyear_ago_sorttype">منذ أكثر من سنة</string>
-	<string name="near_me_sorttype">قريب مني</string>
-	<string name="others_sorttype">أخرى</string>
-	<string name="food_places">طعام</string>
-	<string name="tourist_places">مشاهد</string>
-	<string name="museums">متاحف</string>
-	<string name="parks">حدائق</string>
-	<string name="swim_places">سباحة</string>
-	<string name="mountains">جبال</string>
-	<string name="animals">حيوانات</string>
-	<string name="hotels">فنادق</string>
-	<string name="buildings">بنايات</string>
-	<string name="money">نقود</string>
-	<string name="shops">متاجر</string>
-	<string name="parkings">مواقف سيارات</string>
-	<string name="fuel_places">محطات وقود</string>
-	<string name="water">ماء</string>
-	<string name="medicine">دواء</string>
 	<string name="search_in_the_list">بحث في القائمة</string>
-	<string name="view_on_map_bookmarks">على الخريطة</string>
-	<string name="more_bookmarks">المزيد…</string>
-	<string name="no_items_found">لم يتم العثور على عناصر</string>
-	<!-- Android, max 18 symbols -->
-	<string name="bookmarks_edit_list">تحرير القائمة</string>
-	<!-- Android, max 18 symbols -->
-	<string name="bookmarks_delete_list">حذف القائمة</string>
-	<string name="religious_places">أماكن دينية</string>
 	<string name="select_list">اختر القائمة</string>
 	<string name="transit_not_found">التنقل باستخدام مترو الأنفاق في هذه المنطقة غير متاح حتى الآن</string>
 	<string name="dialog_pedestrian_route_is_long_header">لم يتم العثور على مترو الانفاق</string>
 	<string name="dialog_pedestrian_route_is_long_message">يرجى اختيار نقطة بداية أو نهاية أقرب لمحطة المترو</string>
-	<!-- Failed planning SUBWAY route message in navigation view -->
-	<string name="routing_planning_error_subway_special">فشل تخطيط طريق لمترو الانفاق</string>
 	<string name="button_layer_isolines">تضاريس</string>
-	<string name="tips_map_layers_title_countour">الجديد في Organic Maps: طبقة طبوغرافية بدون انترنت!</string>
-	<string name="tips_map_layers_message_countour">خطط و استمتع برحلاتك في الطبيعة و أنت متأكد من أنك تعرف كل شيء عن المنطقة</string>
 	<string name="isolines_activation_error_dialog">لتفعيل الطبقة الطبوغرافية واستخدامها ، يرجى تحديث أوتنزيل خريطة المنطقة</string>
 	<string name="isolines_location_error_dialog">الطبقة الطبوغرافية ليست متاحة بعد في هذه المنطقة</string>
 	<string name="elevation_profile_diff_level">مستوى الصعوبة</string>
-	<string name="elevation_profile_diff_level_easy">سهل</string>
-	<string name="elevation_profile_diff_level_moderate">معتدل</string>
-	<string name="elevation_profile_diff_level_hard">صعب</string>
 	<string name="elevation_profile_ascent">تصاعدي</string>
 	<string name="elevation_profile_descent">تنازلي</string>
 	<string name="elevation_profile_minaltitude">الحد الأدنى للارتفاع</string>
 	<string name="elevation_profile_maxaltitude">الحد الأقصى للارتفاع</string>
-	<string name="elevation_profile_m">م</string>
 	<string name="elevation_profile_difficulty">درجة الصعوبة</string>
 	<string name="elevation_profile_distance">المسافة:</string>
-	<string name="elevation_profile_km">كم</string>
 	<string name="elevation_profile_time">مدة:</string>
-	<string name="elevation_profile_hours">ساعة</string>
-	<string name="elevation_profile_minutes">دقيقة</string>
 	<string name="isolines_toast_zooms_1_10">قرب لتكتشف خطوط الكنتور</string>
-	<string name="downloader_updating_ios">جار التحديث</string>
-	<string name="downloader_loading_ios">جار التحميل</string>
 	<string name="key_information_title">معلومات رئيسية</string>
 	<string name="enable_screen_sleep">اسمح للشاشة بالنوم</string>
 	<!-- Description in preferences -->

--- a/android/res/values-cs/strings.xml
+++ b/android/res/values-cs/strings.xml
@@ -12,8 +12,6 @@
 	<string name="cancel_download">Zrušit stahování</string>
 	<!-- Button which deletes downloaded country -->
 	<string name="delete">Smazat</string>
-	<!-- Button "do not interrupt download" if user touched actively downloading country -->
-	<string name="do_nothing">Pokračovat</string>
 	<string name="download_maps">Stáhnout mapy</string>
 	<!-- Settings/Downloader - info for country when download fails -->
 	<string name="download_has_failed">Stahování selhalo, zkuste to znovu.</string>
@@ -31,45 +29,31 @@
 	<string name="core_my_position">Moje poloha</string>
 	<!-- Update maps later/Buy pro version later button text -->
 	<string name="later">Později</string>
-	<!-- Don't show some dialog any more -->
-	<string name="never">Nikdy</string>
 	<!-- View and button titles for accessibility -->
 	<string name="search">Hledat</string>
 	<!-- Search box placeholder text -->
 	<string name="search_map">Prohledat mapu</string>
-	<!-- Settings/Downloader - info for not downloaded country -->
-	<string name="touch_to_download">Klepněte pro stažení</string>
 	<!-- Settings/Downloader - 3G download warning dialog confirm button -->
 	<string name="use_cellular_data">Ano</string>
 	<!-- Location services are disabled by user alert - message -->
 	<string name="location_is_disabled_long_text">Aktuálně máte všechny možnosti pro určování polohy vypnuté. Prosím, povolte je v Nastavení.</string>
-	<!-- Location Services are not available on the device alert - message -->
-	<string name="device_doesnot_support_location_services">Vaše zařízení nepodporuje služby pro určování polohy</string>
 	<!-- View and button titles for accessibility -->
 	<string name="zoom_to_country">Ukázat na mapě</string>
-	<!-- Button text for the button at the center of the screen when the country is not downloaded -->
-	<string name="country_status_download">Stáhnout mapu\n(^ ^)</string>
 	<!-- Button text for the button at the center of the screen when the country is not downloaded and the size should not be shown -->
 	<string name="country_status_download_without_size">Stáhnout mapu</string>
-	<!-- Button text for the button at the center of the screen when the country is not downloaded -->
-	<string name="country_status_download_without_routing">Stáhnout mapy\nbez tras (^ ^)</string>
 	<!-- Message to display at the center of the screen when the country download has failed -->
 	<string name="country_status_download_failed">Stahování selhalo</string>
 	<!-- Button text for the button under the country_status_download_failed message -->
 	<string name="try_again">Zkusit znovu</string>
 	<string name="about_menu_title">O aplikaci Organic Maps</string>
-	<string name="downloaded_touch_to_delete">Staženo (%s), klepněte pro smazání</string>
 	<string name="connection_settings">Nastavení připojení</string>
-	<string name="download_mb_or_kb">Stáhnout %s</string>
 	<string name="close">Zavřít</string>
 	<string name="unsupported_phone">Je vyžadována hardwarová akcelerace OpenGL. Bohužel, vaše zařízení není podporováno.</string>
 	<string name="download">Stáhnout</string>
-	<string name="external_storage_is_not_available">SD karta/USB uložiště s uloženými mapami není k dispozici</string>
 	<string name="disconnect_usb_cable">Prosím, odpojte USB kabel nebo vložte paměťovou kartu pro použití s Organic Maps</string>
 	<string name="not_enough_free_space_on_sdcard">Prosím, uvolněte nejprve místo na SD kartě/USB uložišti</string>
 	<string name="not_enough_memory">Nedostatek paměti ke spuštění aplikace</string>
 	<string name="download_resources">Ještě než začnete, bude třeba stáhnout obecnou mapu světa.\nZabere to %s.</string>
-	<string name="getting_position">Získávání aktuální polohy</string>
 	<string name="download_resources_continue">Přejít na mapu</string>
 	<string name="downloading_country_can_proceed">Stahování %s. Nyní můžete\npřejít na mapu.</string>
 	<string name="download_country_ask">Stáhnout %s?</string>
@@ -82,30 +66,20 @@
 	<string name="download_country_failed">Stahování selhalo: %s</string>
 	<!-- Add New Bookmark Set dialog title -->
 	<string name="add_new_set">Přidat novou skupinu záložek</string>
-	<!-- Place Page - Add To Bookmarks button -->
-	<string name="add_to_bookmarks">Přidat k záložkám</string>
 	<!-- Bookmark Color dialog title -->
 	<string name="bookmark_color">Barva záložky</string>
 	<!-- Add Bookmark Set dialog - hint when set name is empty -->
 	<string name="bookmark_set_name">Název záložky</string>
-	<!-- Bookmark Sets dialog title -->
-	<string name="bookmark_sets">Skupiny záložek</string>
 	<!-- Bookmarks - dialog title -->
 	<string name="bookmarks">Záložky</string>
-	<!-- Add bookmark dialog - bookmark color -->
-	<string name="color">Barva</string>
 	<!-- Default bookmarks set name -->
 	<string name="core_my_places">Moje místa</string>
 	<!-- Add bookmark dialog - bookmark name -->
 	<string name="name">Název</string>
 	<!-- Editor title above street and house number -->
 	<string name="address">Adresa</string>
-	<!-- Place Page - Remove Pin button -->
-	<string name="remove_pin">Odstranit špendlík</string>
 	<!-- Add bookmark dialog - bookmark set, Bookmarks dialog - Bookmark set cell -->
 	<string name="set">Skupina</string>
-	<!-- Text hint in Bookmarks dialog when no any bookmarks are added -->
-	<string name="bookmarks_usage_hint">Zatím nemáte žádné záložky.\nZáložku můžete přidat přidržením libovolného místa na mapě.\nV Organic Maps také umí importovat záložky z jiných zdrojů. Soubor ve formátu KML/KMZ s uloženými záložkami otevřete např. z emailu, Dropboxu nebo webového odkazu v Organic Maps.</string>
 	<!-- Settings button in system menu -->
 	<string name="settings">Nastavení</string>
 	<!-- Header of settings activity where user defines storage path -->
@@ -116,20 +90,10 @@
 	<string name="move_maps">Přesunout mapy?</string>
 	<!-- Ask to wait user several minutes (some long process in modal dialog). -->
 	<string name="wait_several_minutes">Tato akce může trvat několik minut.\nProsím čekejte…</string>
-	<!-- Show bookmarks from this category on a map or not -->
-	<string name="visible">Viditelné</string>
-	<!-- Toast which is displayed when GPS has been deactivated -->
-	<string name="gps_is_disabled_long_text">Navigace GPS deaktivována. Prosím, povolte ji v Nastavení.</string>
 	<!-- Measurement units title in settings activity -->
 	<string name="measurement_units">Měřicí jednotky</string>
 	<!-- Detailed description of Measurement Units settings button -->
 	<string name="measurement_units_summary">Vyberte si míle nebo kilometry</string>
-	<!-- Do search in all sources -->
-	<string name="search_mode_all">Všude</string>
-	<!-- Do search near my position only -->
-	<string name="search_mode_nearme">V mé blízkosti</string>
-	<!-- Do search in current viewport only -->
-	<string name="search_mode_viewport">Na obrazovce</string>
 	<!-- Search category for cafes, bars, restaurants -->
 	<string name="eat">Kde se najíst</string>
 	<!-- Search category for grocery stores -->
@@ -166,12 +130,8 @@
 	<string name="post">Pošta</string>
 	<!-- Search category -->
 	<string name="police">Policie</string>
-	<!-- String in search result list, when nothing found -->
-	<string name="no_search_results_found">Žádné výsledky</string>
 	<!-- Notes field in Bookmarks view -->
 	<string name="description">Poznámky</string>
-	<!-- Button text -->
-	<string name="share_by_email">Sdílet emailem</string>
 	<!-- Email Subject when sharing bookmarks category -->
 	<string name="share_bookmarks_email_subject">Sdílené záložky Organic Maps</string>
 	<!-- message title of loading file -->
@@ -184,20 +144,10 @@
 	<string name="edit">Upravit</string>
 	<!-- Warning message when doing search around current position -->
 	<string name="unknown_current_position">Vaše poloha zatím nebyla určena</string>
-	<!-- Warning message when location country isn't downloaded during search (see also download_location_map_proposal). -->
-	<string name="download_location_country">Stahování země vaší aktuální polohy (%s)</string>
-	<!-- Warning message when viewport country isn't downloaded during search -->
-	<string name="download_viewport_country_to_search">Stahování země, v níž hledáte (%s)</string>
 	<!-- Alert message that we can't run Map Storage settings due to some reasons. -->
 	<string name="cant_change_this_setting">Omlouváme se, nastavení uložení map je dočasně nedostupné.</string>
 	<!-- Alert message that downloading is in progress. -->
 	<string name="downloading_is_active">Právě probíhá stahování země.</string>
-	<!-- Message that will be shown in alert view, when we ask user to leave review on App Store -->
-	<string name="appStore_message">Doufáme, že se vám používání Organic Maps líbí! Je-li tomu tak, ohodnoťte, prosím, naši aplikaci nebo na ni napište recenzi v obchodu s aplikacemi. Nezabere to ani minutu, ale opravdu nám tím pomůžete. Děkujeme za vaši podporu!</string>
-	<!-- No, thanks -->
-	<string name="no_thanks">Ne, díky</string>
-	<!-- Share one specific bookmark using SMS, %1$@ contains om:// and %2$@ https://omaps.app link. @NOTE non-ascii symbols in the link will result in max 70 characters SMS instead of 140. -->
-	<string name="bookmark_share_sms">Koukni na mou značku na mapě. Otevři odkaz: %1$s nebo %2$s</string>
 	<!-- Share my position using SMS, %1$@ contains om:// and %2$@ https://omaps.app link WITHOUT NAME. @NOTE non-ascii symbols in the link will result in max 70 characters SMS instead of 140. -->
 	<string name="my_position_share_sms">Koukni kde jsem. Otevři odkaz: %1$s nebo %2$s</string>
 	<!-- Subject for emailed bookmark -->
@@ -206,30 +156,16 @@
 	<string name="my_position_share_email_subject">Podívej se na mou aktuální polohu na mapě na Organic Maps</string>
 	<!-- Share my position using EMail, %1$@ is om:// and %2$@ is https://omaps.app link WITHOUT NAME -->
 	<string name="my_position_share_email">Ahoj,\n\nPrávě jsem tady: %1$s. Klepni na jeden z těchto odkazů %2$s, %3$s a uvidíš toto místo na mapě.\n\nDíky.</string>
-	<!-- Android share by Message/SMS button text (including SMS) -->
-	<string name="share_by_message">Sdílet pomocí zprávy</string>
 	<!-- Share button text which opens menu with more buttons, like Message, EMail, Facebook etc. -->
 	<string name="share">Sdílet</string>
-	<!-- iOS share by Message button text (including SMS) -->
-	<string name="message">Zpráva</string>
 	<!-- Share by email button text, also used in editor. -->
 	<string name="email">Email</string>
-	<!-- Copy Link -->
-	<string name="copy_link">Zkopírovat odkaz</string>
-	<!-- Text for the button that returns to caller application -->
-	<string name="more_info">Zobrazit další informace</string>
 	<!-- Text for message when used successfully copied something -->
 	<string name="copied_to_clipboard">Zkopírováno do schránky: %1$s</string>
 	<!-- place preview title -->
 	<string name="info">Více informací</string>
 	<!-- Used for bookmark editing -->
 	<string name="done">Hotovo</string>
-	<!-- Summary for preferences in MWM -->
-	<string name="yopme_pref_summary">Zvolit nastavení zadní obrazovky</string>
-	<!-- Title for yopme preferences in MWM -->
-	<string name="yopme_pref_title">Nastavení zadní obrazovky</string>
-	<!-- Hint for upper-right icon p2b -->
-	<string name="show_on_backscreen">Zobrazit na zadní obrazovce</string>
 	<!-- Prints version number in About dialog -->
 	<string name="version">Verze: %s</string>
 	<!-- Confirmation in downloading countries dialog -->
@@ -239,11 +175,6 @@
 	<!-- Length of track in cell that describes route -->
 	<string name="length">Délka</string>
 	<string name="share_my_location">Sdílet mé umístění</string>
-	<string name="menu_search">Vyhledávání</string>
-	<!-- Settings screen: "Map" category title -->
-	<string name="prefs_group_map">Mapa</string>
-	<!-- Settings screen: "Miscellaneous" category title -->
-	<string name="prefs_group_misc">Jiné</string>
 	<string name="prefs_group_route">Navigace</string>
 	<string name="pref_zoom_title">Tlačítka přiblížení/oddálení</string>
 	<string name="pref_zoom_summary">Zobrazit na obrazovce</string>
@@ -259,8 +190,6 @@
 	<string name="pref_map_3d_title">Zobrazení perspektivy</string>
 	<!-- Settings «Map» category: «3D buildings» title -->
 	<string name="pref_map_3d_buildings_title">3D budovy</string>
-	<!-- Settings «Map» category: «3D buildings» summary -->
-	<string name="pref_map_3d_buildings_subtitle">Ovlivňuje výdrž baterie</string>
 	<!-- Settings «Route» category: «Tts enabled» title -->
 	<string name="pref_tts_enable_title">Hlasové instrukce</string>
 	<!-- Settings «Route» category: «Tts language» title -->
@@ -269,7 +198,6 @@
 	<string name="pref_tts_unavailable">Není dostupná</string>
 	<!-- Title for "Other" section in TTS settings. -->
 	<string name="pref_tts_other_section_title">Ostatní</string>
-	<string name="pref_tts_how_to_set_up_voice">Jak nastavit hlas</string>
 	<!-- Settings «Map» category: «Record track» title -->
 	<string name="pref_track_record_title">Historie polohy</string>
 	<string name="pref_map_auto_zoom">Automatické zvětšení</string>
@@ -280,46 +208,11 @@
 	<string name="duration_12_hours">12 hodin</string>
 	<string name="duration_1_day">1 den</string>
 	<string name="recent_track_help_text">To vám umožňuje zaznamenávat ujetou cestu po určitou dobu a vidět ji na mapě. Poznámka: aktivace této funkce způsobuje zvýšenou spotřebu baterie. Trať bude automaticky odebrána z mapy poté, co vyprší časový interval.</string>
-	<string name="pref_track_ios_caption">Nedávná trasa zobrazuje cestu, po které jste cestovali.</string>
-	<string name="pref_track_ios_subcaption">Vyberte prosím časový rozsah uložené trasy.</string>
-	<string name="placepage_distance">Vzdálenost</string>
-	<string name="placepage_coordinates">Souřadnice</string>
-	<string name="placepage_unsorted">Nezařazené</string>
 	<string name="search_show_on_map">Zobrazit na mapě</string>
-	<!-- Used to warn user when fixing KitKat issue -->
-	<string name="bookmark_move_fail">Potřebujeme přesunout tvé záložky do vnitřní paměti zařízení, ale není pro ně volné místo. Prosím, uvolněte paměť, jinak nebudou záložky dostupné.</string>
-	<!-- Used in More Apps menu -->
-	<string name="free">Zdarma</string>
-	<!-- Used in More Apps menu -->
-	<string name="buy">Koupit</string>
-	<!-- 1st search button-like result -->
-	<string name="search_on_map">Hledat na mapě</string>
-	<!-- toast with an error -->
-	<string name="no_route_found">Nebyla nalezena žádná trasa</string>
-	<!-- route title -->
-	<string name="route">Trasa</string>
-	<!-- category title -->
-	<string name="routes">Trasy</string>
-	<!-- text of notification -->
-	<string name="download_map_notification">Stáhněte si mapu místa, kde právě jste</string>
-	<!-- text of notification -->
-	<string name="pro_version_is_free_today">Plná verze Organic Maps je dnes zdarma! Stáhněte si ji nyní a dejte vědět přátelům.</string>
-	<!-- Dialog for transferring maps from lite to pro. -->
-	<string name="move_lite_maps_to_pro">Právě přenášíme vaše stažené mapy z Organic Maps Lite do Organic Maps. Může to několik minut trvat.</string>
-	<!-- Message to display when maps moved. -->
-	<string name="move_lite_maps_to_pro_ok">Vaše stažené mapy byly úspěšně přeneseny do Organic Maps.</string>
-	<!-- Message to display when maps move failed. -->
-	<string name="move_lite_maps_to_pro_failed">Vaše mapy se nepodařilo přenést. Prosím, odstraňte Organic Maps Lite a stáhněte si mapy znovu.</string>
-	<!-- Text in menu -->
-	<string name="settings_and_more">Nastavení a další</string>
 	<!-- Text in menu -->
 	<string name="website">Webové stránky</string>
-	<!-- Text in menu -->
-	<string name="contact_us">Kontaktovat nás</string>
 	<!-- Settings: Send feedback button and dialog title -->
 	<string name="feedback">Zpětná vazba</string>
-	<!-- Text in menu -->
-	<string name="subscribe_to_news">Přihlásit se k newsletteru</string>
 	<!-- Text in menu -->
 	<string name="rate_the_app">Ohodnotit aplikaci</string>
 	<!-- Text in menu -->
@@ -328,12 +221,6 @@
 	<string name="copyright">Autorská práva</string>
 	<!-- Text in menu -->
 	<string name="report_a_bug">Nahlásit chybu</string>
-	<!-- Email subject -->
-	<string name="subscribe_me_subject">Přihlaste mě, prosím, k odběru zpravodaje Organic Maps</string>
-	<!-- Email body -->
-	<string name="subscribe_me_body">Chci se vždy jako první dozvídat o nejnovějších zprávách, aktualizacích a akčních nabídkách. Své přihlášení k odběru mohu kdykoli zrušit.</string>
-	<!-- About text -->
-	<string name="about_text">Organic Maps nabízí nejrychlejší offline mapy všech měst a zemí po celém světě. Cestujte s naprostou důvěrou: kdekoliv jste, Organic Maps vám pomůže se najít na mapě, vyhledat nejbližší restauraci, hotel, banku, benzínovou pumpu atd. Nevyžaduje připojení k Internetu.\n\nNeustále pracujeme na nových funkcích a rádi bychom slyšeli také váš názor, jak můžeme Organic Maps vylepšit. Pokud máte s touto aplikací jakékoliv problémy, pak nás neváhejte kontaktovat na support\@organicmaps.app. Odpovídáme na každý požadavek!\n\nLíbí se vám Organic Maps a chcete nás podpořit? Existuje několik snadných způsobů zcela zdarma:\n\n• napište recenzi ve svém obchodu s aplikacemi\n• označte naši facebookovou stránku http://www.facebook.com/OrganicMaps pomocí To se mi líbí\n• nebo jen řekněte o Organic Maps své mámě, kamarádům a kolegům :)\n\nDěkujeme, že jste s námi. Velmi si ceníme vaší podpory!\n\nP.S. Mapové podklady získáváme z OpenStreetMap, což je mapový projekt podobný Wikipedii, který umožňuje uživatelům vytvářet a upravovat mapy. Pokud zjistíte, že na mapě něco chybí nebo je špatně, pak můžete mapy opravit přímo na https://www.openstreetmap.org, a vaše změny se objeví v příští verzi Organic Maps. Díky!</string>
 	<!-- Alert text -->
 	<string name="email_error_body">Emailový klient nebyl ještě nakonfigurován. Nastavte ho, prosím, nebo použijte jiný způsob k našemu kontaktování na %s</string>
 	<!-- Alert title -->
@@ -342,137 +229,56 @@
 	<string name="pref_calibration_title">Kalibrace kompasu</string>
 	<!-- Search category -->
 	<string name="wifi">WiFi</string>
-	<!-- Update map suggestion -->
-	<string name="routing_map_outdated">Pro funkci vytváření tras je nutné aktualizovat mapu.</string>
-	<!-- Update maps suggestion -->
-	<string name="routing_update_maps">Nová verze Organic Maps umožňuje vytvářet trasy z vaší aktuální polohy do cílového bodu. Chcete-li tuto funkci používat, aktualizujte mapy.</string>
 	<!-- Update all button text -->
 	<string name="downloader_update_all_button">Aktualizovat vše</string>
 	<!-- Cancel all button text -->
 	<string name="downloader_cancel_all">Zrušit vše</string>
 	<!-- Downloaded maps category -->
 	<string name="downloader_downloaded_subtitle">Staženo</string>
-	<!-- Downloaded maps category -->
-	<string name="downloader_available_maps">Dostupné</string>
 	<!-- Country queued for download -->
 	<string name="downloader_queued">Ve frontě</string>
 	<string name="downloader_near_me_subtitle">Poblíž mě</string>
 	<string name="downloader_status_maps">Mapy</string>
 	<string name="downloader_download_all_button">Stáhnout vše</string>
 	<string name="downloader_downloading">Probíhá stahování:</string>
-	<string name="downloader_search_results">Nalezeno</string>
-	<!-- Disclaimer message -->
-	<string name="routing_disclaimer">Při vytváření tras v aplikaci Organic Maps mějte, prosím, na paměti následující:\n\n • Navrhované trasy lze brát jen jako doporučení.\n • Pravidla silničního provozu, aktuální podmínky na silnici a dopravní značení mají přednost před údaji z navigace.\n • Mapa může být nepřesná nebo zastaralá a navržené cesty nemusí být ideální.\n\nCestujte bezpečně a ohleduplně. Šťastnou cestu!</string>
-	<!-- Outdated maps category -->
-	<string name="downloader_outdated_maps">Zastaralé</string>
-	<!-- Up to date maps category -->
-	<string name="downloader_uptodate_maps">Aktuální</string>
 	<!-- Status of outdated country in the list -->
 	<string name="downloader_status_outdated">Aktualizace</string>
 	<!-- Status of failed country in the list -->
 	<string name="downloader_status_failed">Selhalo</string>
 	<!-- Displayed in a dialog that appears when a user tries to delete a map while the app is in the follow route mode -->
 	<string name="downloader_delete_map_while_routing_dialog">Chcete-li odstranit mapu, pak prosím zastavte navigaci.</string>
-	<!-- Show when user try build route, but we don't know where he -->
-	<string name="routing_failed_unknown_my_position">Aktuální poloha nebyla zatím zjištěna. Chcete-li naplánovat trasu, zadejte prosím umístění.</string>
-	<!-- Show if use has not routing file, or InconsistentMWMandRoute -->
-	<string name="routing_failed_has_no_routing_file">K vytvoření trasy jsou zapotřebí další data. Chcete je stáhnout nyní?</string>
-	<!-- StartPointNotFound -->
-	<string name="routing_failed_start_point_not_found">Trasu nelze vypočítat. Poblíž výchozího bodu nejsou žádné cesty.</string>
-	<!-- EndPointNotFound -->
-	<string name="routing_failed_dst_point_not_found">Trasu nelze vypočítat. Poblíž cílového bodu nejsou žádné cesty.</string>
 	<!-- PointsInDifferentMWM -->
 	<string name="routing_failed_cross_mwm_building">Lze vytvářet jen takové trasy, které se nachází na území jediné mapy.</string>
-	<!-- RouteNotFound -->
-	<string name="routing_failed_route_not_found">Mezi zvoleným počátkem a cílem nebyla nalezena žádná trasa. Vyberte jiný počáteční nebo koncový bod.</string>
-	<!-- InternalError -->
-	<string name="routing_failed_internal_error">Došlo k vnitřní chybě. Zkuste, prosím, mapu smazat a znovu stáhnout. Jestliže problém přetrvává, kontaktujte nás na support\@organicmaps.app.</string>
-	<!-- Context menu item for downloader. -->
-	<string name="downloader_download_map_and_routing">Stáhnout mapu + trasy</string>
-	<!-- Context menu item for downloader. -->
-	<string name="downloader_download_routing">Stáhnout trasy</string>
-	<!-- Context menu item for downloader. -->
-	<string name="downloader_delete_routing">Smazat trasy</string>
 	<!-- Context menu item for downloader. -->
 	<string name="downloader_download_map">Stáhnout mapu</string>
-	<string name="downloader_download_map_no_routing">Stáhnout mapy bez tras</string>
-	<!-- Button for routing. -->
-	<string name="routing_go">Jet!</string>
 	<!-- Item status in downloader. -->
 	<string name="downloader_retry">Opakovat</string>
-	<!-- Item in context menu. -->
-	<string name="downloader_map_and_routing">Mapa + trasy</string>
 	<!-- Item in context menu. -->
 	<string name="downloader_delete_map">Smazat mapu</string>
 	<!-- Item in context menu. -->
 	<string name="downloader_update_map">Aktualizovat mapu</string>
-	<!-- Item in context menu. -->
-	<string name="downloader_update_map_and_routing">Aktualizovat mapu + trasy</string>
-	<!-- Item in context menu. -->
-	<string name="downloader_map_only">Pouze mapa</string>
-	<!-- Toolbar title -->
-	<string name="toolbar_application_menu">Nabídka aplikace</string>
 	<!-- Preference text -->
 	<string name="pref_use_google_play">Používat Služby Google Play pro získání aktuální polohy</string>
 	<!-- Text for rating dialog -->
 	<string name="rating_just_rated">Právě jsem ohodnotil(a) vaši aplikaci</string>
-	<!-- Text for rating dialog -->
-	<string name="rating_user_since">Uživatelem Organic Maps jsem od roku %s</string>
-	<!-- Text for rating dialog -->
-	<string name="rating_do_like_maps">Líbí se vám aplikace Organic Maps?</string>
-	<!-- Text for rating dialog -->
-	<string name="rating_tap_star">Klepnutím na hvězdičku naši aplikaci ohodnotíte.</string>
 	<!-- Text for rating dialog -->
 	<string name="rating_thanks">Děkujeme vám!</string>
 	<!-- Text for rating dialog -->
 	<string name="rating_share_ideas">Podělte se s námi o své nápady nebo problémy, abychom mohli aplikaci vylepšit.</string>
 	<!-- Text for rating dialog -->
 	<string name="rating_send_feedback">Odeslat názor</string>
-	<!-- Text for g+ dialog -->
-	<string name="rating_google_plus">Klikněte na g+ a povězte o aplikaci svým přátelům.</string>
 	<!-- Text for routing error dialog -->
 	<string name="routing_download_maps_along">Stahovat mapy podél cesty</string>
-	<!-- Text for routing error dialog -->
-	<string name="routing_download_map">Získejte mapu</string>
-	<!-- Text for routing error dialog -->
-	<string name="routing_download_map_and_routing">Stáhněte si aktualizovanou mapu a data tras, ať můžete využít všechny funkce Organic Maps.</string>
-	<!-- Text for routing error dialog -->
-	<string name="routing_get_routing_data">Získejte data tras</string>
-	<!-- Text for routing error dialog -->
-	<string name="routing_get_additional_data">Další data potřebná k plánování tras z vašeho umístění.</string>
 	<!-- Text for routing error dialog -->
 	<string name="routing_requires_all_map">Naplánování trasy vyžaduje stažení a aktualizaci všech map z vašeho umístění do cílového umístění.</string>
 	<!-- Text for routing error dialog -->
 	<string name="routing_not_enough_space">Nedostatek místa</string>
-	<!-- Text for routing error dialog -->
-	<string name="routing_download_more_than_avail">Je třeba stáhnout %1$s MB, ale dostupných je pouze %2$s MB.</string>
-	<!-- Text for routing error dialog -->
-	<string name="routing_download_roaming">Chystáte se stáhnout %s MB pomocí mobilních dat (v roamingu). To může mít za následek další poplatky v závislosti na vašem mobilním datovém tarifu.</string>
 	<!-- bookmark button text -->
 	<string name="bookmark">uložit</string>
-	<!-- map is not downloaded -->
-	<string name="not_found_map">Mapa vaší polohy není stažena</string>
 	<!-- location service disabled -->
 	<string name="enable_location_services">Prosím, povolte Služby určování polohy</string>
-	<!-- download map -->
-	<string name="download_map">Stáhněte si mapu své polohy</string>
-	<!-- download map on iPhone -->
-	<string name="download_map_iphone">Stáhněte si do svého iPhonu mapu své současné polohy</string>
-	<!-- clear pin -->
-	<string name="nearby">V okolí</string>
-	<!-- clear pin -->
-	<string name="clear_pin">Odebrat špendlík</string>
-	<!-- location is undefined -->
-	<string name="undefined_location">Aktuální poloha zatím nebyla zjištěna.</string>
-	<!-- download country of your location -->
-	<string name="download_country">Stahování země vyší aktuální polohy</string>
-	<!-- download failed -->
-	<string name="download_failed">Stahování selhalo</string>
-	<!-- get the map -->
-	<string name="get_the_map">Získejte mapu</string>
 	<string name="save">Uložit</string>
 	<string name="edit_description_hint">Popis (HTML nebo text)</string>
-	<string name="new_group">Nová skupina</string>
 	<string name="create">vytvořit</string>
 	<!-- red color -->
 	<string name="red">Červená</string>
@@ -490,22 +296,6 @@
 	<string name="brown">Hnědá</string>
 	<!-- pink color -->
 	<string name="pink">Růžová</string>
-	<!-- deep purple color -->
-	<string name="deep_purple">Tmavě fialová</string>
-	<!-- light blue color -->
-	<string name="light_blue">Světle modrá</string>
-	<!-- cyan color -->
-	<string name="cyan">Cyan</string>
-	<!-- teal color -->
-	<string name="teal">Teal</string>
-	<!-- lime color -->
-	<string name="lime">Limeta</string>
-	<!-- deep orange color -->
-	<string name="deep_orange">Tmavě oranžová</string>
-	<!-- gray color -->
-	<string name="gray">Šedá</string>
-	<!-- blue gray color -->
-	<string name="blue_gray">Modrošedá</string>
 	<!-- Wi-Fi available -->
 	<string name="WiFi_available">Ano</string>
 
@@ -521,10 +311,8 @@
 	<string name="dialog_routing_location_turn_wifi">Zkontrolujte signál GPS. Povolením připojení WiFi zpřesníte určení vaší polohy.</string>
 	<string name="dialog_routing_location_turn_on">Povolit služby určování polohy</string>
 	<string name="dialog_routing_location_unknown_turn_on">Aktuální souřadnice GPS se nepodařilo zjistit. Pro výpočet trasy povolte služby určování polohy.</string>
-	<string name="dialog_routing_location_unknown">Aktuální souřadnice GPS se nepodařilo zjistit.</string>
 	<string name="dialog_routing_download_files">Stáhnout požadované soubory</string>
 	<string name="dialog_routing_download_and_update_all">Stáhnout a aktualizovat všechny mapy a data tras pro výpočet trasy podél navrhované cesty.</string>
-	<string name="dialog_routing_routes_size">Soubory s informacemi o trasách</string>
 	<string name="dialog_routing_unable_locate_route">Trasu se nepodařilo zjistit</string>
 	<string name="dialog_routing_cant_build_route">Trasu se nepodařilo vytvořit.</string>
 	<string name="dialog_routing_change_start_or_end">Upravte výchozí nebo cílový bod.</string>
@@ -539,33 +327,23 @@
 	<string name="dialog_routing_system_error">Systémová chyba</string>
 	<string name="dialog_routing_application_error">Trasu se nepodařilo vytvořit z důvodu chyby aplikace.</string>
 	<string name="dialog_routing_try_again">Prosím, zkuste to znovu</string>
-	<string name="dialog_routing_send_error">Nahlásit problém</string>
-	<string name="dialog_routing_if_get_cross_route">Chcete vytvořit přímější trasu, která vede přes více než jednu mapu?</string>
-	<string name="dialog_routing_cross_route_is_optimal">K dispozici je optimálnější trasa, která překračuje hranice této mapy.</string>
 	<string name="not_now">Nyní ne</string>
-	<string name="dialog_routing_build_route">Vytvořit</string>
 	<string name="dialog_routing_download_and_build_cross_route">Chcete mapu stáhnout a vytvořit optimálnější trasu, která vede přes více než jednu mapu?</string>
 	<string name="dialog_routing_download_cross_route">Stáhnout mapu a vytvořit optimálnější trasu, která překračuje hranice této mapy.</string>
-	<string name="dialog_routing_cross_route_always">Vždy překročit tuto hranici</string>
 
 	<!-- SECTION: Strings for downloading map from search -->
 	<string name="search_without_internet_advertisement">Chcete-li začít hledat a vytvářet trasy, pak si prosím stáhněte mapu a nebudete již potřebovat připojení.</string>
 	<string name="search_select_map">Vybrat mapu</string>
-	<string name="search_select_other_map">Vybrat jinou mapu</string>
 	<!-- «Show» context menu -->
 	<string name="show">Ukázat</string>
 	<!-- «Hide» context menu -->
 	<string name="hide">Skrýt</string>
 	<!-- «Rename» context menu -->
 	<string name="rename">Přejmenovat</string>
-	<!-- Bottom sheet: expand button (should be short) -->
-	<string name="bottom_sheet_more">Více…</string>
 	<!-- Failed planning route message in navigation view -->
 	<string name="routing_planning_error">Naplánování trasy se nezdařilo</string>
 	<!-- Arrive routing message in navigation view -->
 	<string name="routing_arrive">Příjezd: %s</string>
-	<!-- Text for routing::RouterResultCode::FileTooOld dialog. -->
-	<string name="dialog_routing_download_and_update_maps">Pro vytvoření trasy si prosím stáhněte a aktualizujte všechny mapy podél očekávané cesty.</string>
 	<string name="rate_alert_title">Líbí se vám aplikace?</string>
 	<string name="rate_alert_default_message">Děkujeme, že používáte Organic Maps. Ohodnoťte, prosím, tuto aplikaci. Váš komentář nám pomůže ji ještě zlepšit.</string>
 	<string name="rate_alert_five_star_message">Hurá! Také vás zbožňujeme!</string>
@@ -573,24 +351,14 @@
 	<string name="rate_alert_less_than_four_star_message">Nějaké nápady, co můžeme udělat lépe?</string>
 	<string name="categories">Kategorie</string>
 	<string name="history">Historie</string>
-	<string name="next_turn_then">Poté</string>
 	<string name="closed">Zavřeno</string>
-	<string name="back_to">Zpět na %s</string>
 	<string name="search_not_found">Omlouvám se, nic nenalezeno.</string>
 	<string name="search_not_found_query">Zkuste zadat jiný hledaný výraz.</string>
-	<string name="search_not_found_map">Stáhněte si mapu, ve které hledáte.</string>
-	<string name="search_not_found_location">Stáhněte si mapu své aktuální pozice.</string>
 	<string name="search_history_title">Prohledat historii</string>
 	<string name="search_history_text">Získejte rychlý přístup k hledaným výrazům.</string>
 	<string name="clear_search">Vymazat historii vyhledávání</string>
-	<!-- Title for settings to enable/disable showcase menu button -->
-	<string name="showcase_settings_title">Zobrazit nabídky</string>
-	<string name="p2p_route_planning">Plánování trasy</string>
 	<string name="p2p_your_location">Vaše umístění</string>
-	<string name="p2p_from">Počátek cesty</string>
-	<string name="p2p_to">Místo určení</string>
 	<string name="p2p_start">Start</string>
-	<string name="p2p_planning">Plánování…</string>
 	<string name="p2p_from_here">Trasa z</string>
 	<string name="p2p_to_here">Trasa do</string>
 	<string name="p2p_only_from_current">Navigovat lze pouze z současného umístění.</string>
@@ -610,11 +378,8 @@
 	<string name="editor_hours_closed">Doba, kdy je zavřeno</string>
 	<string name="editor_example_values">Vzorové hodnoty</string>
 	<string name="editor_correct_mistake">Opravit chybu</string>
-	<string name="editor_correct_mistake_message">Při úpravách jste udělali chybu. Opravte ji prosím, nebo přepněte do jednoduchého režimu.</string>
 	<string name="editor_add_select_location">Umístění</string>
 	<string name="editor_done_dialog_1">Změnili jste světovou mapu. Neskrývejte to! Řekněte o tom svým kamarádům a upravujte ji společně.</string>
-	<string name="editor_done_dialog_2">Toto je vaše druhé vylepšení mapy. Nyní jste na %d. místě na seznamu editorů map. Řekněte o tom svým kamarádům.</string>
-	<string name="editor_done_dialog_3">Vylepšili jste mapu. Řekněte o tom svým kamarádům a upravujte mapu společně.</string>
 	<string name="share_with_friends">Sdílejte s kamarády</string>
 	<string name="editor_report_problem_desription_1">Popište prosím detailně problém, aby vám komunita OpenStreeMap mohla pomoct opravit chybu.</string>
 	<string name="editor_report_problem_desription_2">Nebo to udělejte sami na https://www.openstreetmap.org/</string>
@@ -623,14 +388,7 @@
 	<string name="editor_report_problem_no_place_title">Místo neexistuje</string>
 	<string name="editor_report_problem_under_construction_title">Zavřeno kvůli údržbě</string>
 	<string name="editor_report_problem_duplicate_place_title">Duplicitní místo</string>
-	<string name="first_launch_congrats_title">Organic Maps jsou připraveny k použití</string>
-	<string name="first_launch_congrats_text">Prohledávejte a navigujte offline zdarma kdekoliv na světě.</string>
-	<string name="migrate_title">Důležité!</string>
-	<!-- Android uses image instead of text. -->
-	<string name="download_all">Stáhnout vše</string>
-	<string name="delete_all">Odstranit vše</string>
 	<string name="autodownload">Automaticky stahovat</string>
-	<string name="disable_autodownload">Zakázat automatické stahování</string>
 	<!-- Place Page opening hours text -->
 	<string name="closed_now">Nyní je zavřeno</string>
 	<!-- Place Page opening hours text -->
@@ -639,8 +397,6 @@
 	<string name="day_off_today">Dnes zavřeno</string>
 	<string name="day_off">Zavřeno</string>
 	<string name="today">Dnes</string>
-	<string name="sunrise_to_sunset">Od úsvitu do soumraku</string>
-	<string name="sunset_to_sunrise">Od západu do východu slunce</string>
 	<string name="add_opening_hours">Přidat otevírací dobu</string>
 	<string name="edit_opening_hours">Upravit otevírací dobu</string>
 	<string name="no_osm_account">Nemáte účet u OpenStreetMap?</string>
@@ -650,29 +406,13 @@
 	<string name="login">Přihlásit se</string>
 	<string name="password">Heslo</string>
 	<string name="forgot_password">Zapomenuté heslo?</string>
-	<!-- Forgot Password dialog title -->
-	<string name="restore_password">Obnovit heslo</string>
-	<string name="enter_email_address_to_reset_password">Zadejte emailovou adresu, kterou jste používali během registrace a my Vám pošleme odkaz, abyste mohli obnovit svoje heslo.</string>
-	<string name="reset_password">Resetovat heslo</string>
-	<string name="username">Uživatelské jméno</string>
 	<string name="osm_account">Účet OSM</string>
 	<string name="logout">Odhlášení</string>
-	<string name="login_and_edit_map_motivation_message">Přihlaste se a editujte informace o objektech na mapě a my je zpřístupníme miliónům dalších uživatelů. Udělejme společně svět dokonalejším místem.</string>
 	<!-- Information text: "Last upload 11.01.2016" -->
 	<string name="last_upload">Poslední nahrání</string>
-	<!-- Motivates user to login/register, title above login buttons. -->
-	<string name="you_have_edited_your_first_object">Editovali jste svůj první objekt!</string>
 	<string name="thank_you">Děkujeme Vám</string>
-	<string name="login_with_google">Přihlásit se pomocí účtu Google</string>
-	<string name="login_with_openstreetmap">Přihlásit se pomocí účtu www.openstreetmap.org</string>
 	<string name="edit_place">Upravit místo</string>
 	<string name="place_name">Název místa</string>
-	<!-- title above languages list cells in the editor, below editable name text field. -->
-	<string name="other_languages">Další jazyky</string>
-	<!-- small button to open list with names in different languages -->
-	<string name="show_more">Zobrazit méně</string>
-	<!-- small button to close list with names in different languages -->
-	<string name="show_less">Zobrazit více</string>
 	<string name="add_language">Přidat jazyk</string>
 	<string name="street">Ulice</string>
 	<!-- Editable House Number text field (in address block). -->
@@ -689,25 +429,16 @@
 	<string name="email_or_username">Email nebo uživatelské jméno</string>
 	<string name="phone">Telefon</string>
 	<string name="please_note">Vezměte prosím na vědomí</string>
-	<string name="common_no_wifi_dialog">Žádné Wi-Fi připojení. Chcete pokračovat s mobilními daty?</string>
 	<string name="downloader_delete_map_dialog">Zároveň s touto mapou budou odstraněny také všechny změny na této mapě.</string>
 	<string name="downloader_update_maps">Aktualizujte mapy</string>
 	<string name="downloader_mwm_migration_dialog">Chcete-li vytvořit trasu, pak musíte aktualizovat všechny mapy a poté trasu naplánovat znovu.</string>
 	<string name="downloader_search_field_hint">Najít mapu</string>
-	<string name="migration_update_all_button">Aktualizovat všechny mapy</string>
-	<string name="migration_delete_all_download_current_button">Stáhněte si aktuální mapu a odstraňte staré</string>
 	<string name="migration_download_error_dialog">Chyba při stahování</string>
 	<string name="common_check_internet_connection_dialog">Zkontrolujte prosím své nastavení a ujistěte se, že je vaše zařízení připojeno k internetu.</string>
 	<string name="downloader_no_space_title">Nedostatek místa</string>
 	<string name="downloader_no_space_message">Odstraňte prosím nepotřebná data</string>
-	<string name="editor_general_auth_error_dialog">Obecná chyba při přihlašování.</string>
 	<string name="editor_login_error_dialog">Chyba při přihlašování.</string>
-	<string name="editor_login_failed_dialog">Přihlašování selhalo</string>
-	<string name="editor_username_error_dialog">Uživatelské jméno není platné</string>
-	<string name="editor_place_edited_dialog">Upravili jste objekt!</string>
-	<string name="editor_login_with_osm">Přihlásit se pomocí OpenStreetMap</string>
 	<string name="editor_profile_changes">Oveřené změny</string>
-	<string name="editor_profile_unsent_changes">Neodesláno:</string>
 	<string name="editor_focus_map_on_location">Táhněte mapu, abyste vybrali správné umístění objektu.</string>
 	<string name="editor_add_select_category">Vyberte kategorii</string>
 	<string name="editor_add_select_category_popular_subtitle">Populární</string>
@@ -718,19 +449,14 @@
 	<string name="editor_edit_place_category_title">Kategorie</string>
 	<string name="detailed_problem_description">Detailní popis problému</string>
 	<string name="editor_report_problem_other_title">Jiný problém</string>
-	<string name="placepage_report_problem_button">Nahlásit problém</string>
 	<string name="placepage_add_business_button">Přidat organizaci</string>
 	<string name="whatsnew_editor_message_1">Přidejte na mapu nová místa a upravte existující místa přímo z aplikace.</string>
-	<string name="whatsnew_editor_message_2">* Organic Maps používá komunitní data OpenStreetMap.</string>
 	<string name="dialog_incorrect_feature_position">Změnit umístění</string>
 	<string name="message_invalid_feature_position">Objekt zde nemůže být umístěn</string>
 	<string name="login_to_make_edits_visible">Přihlaste se, aby ostatní uživatelé mohli vidět změny, které jste provedli.</string>
-	<string name="no_migration_during_navigation">Aktualizace jsou během navigování zakázány.</string>
 	<!-- Error dialog no space -->
 	<string name="migration_no_space_message">Ke stažení potřebujete více volného místa. Odstraňte prosím nepotřebná data.</string>
 	<string name="editor_sharing_title">Vylepšil jsem mapy Organic Maps</string>
-	<string name="editor_comment_will_be_sent">Váš komentář pošleme kartografům.</string>
-	<string name="editor_unsupported_category_message">Přidali jste místo kategorie, kterou zatím nepodporujeme. Na mapě se objeví za nějaký čas.</string>
 	<!-- Downloaded 10 **of** 20 <- it is that "of" -->
 	<string name="downloader_of">%1$d z %2$d</string>
 	<string name="download_over_mobile_header">Stáhnout pomocí připojení přes mobilní síť?</string>
@@ -748,15 +474,8 @@
 	<string name="editor_detailed_description">Vámi navržené změny odešleme do komunity OpenStreetMap. Popište podrobnosti, které nelze upravit v Organic Maps.</string>
 	<string name="editor_more_about_osm">Více o projektu OpenStreetMap</string>
 	<string name="editor_operator">Operátor</string>
-	<string name="editor_tag_description">Zadejte osobu, společnost nebo organizaci, která zodpovídá za zařízení.</string>
-	<string name="editor_no_local_edits_title">Neprovedli jste žádné místní úpravy</string>
-	<string name="editor_no_local_edits_description">Zde vidíte počet navržených změn, které jsou v tuto chvíli dostupné pouze na Vašem zařízení.</string>
-	<string name="editor_send_to_osm">Odeslat do OSM</string>
-	<string name="editor_remove">Odstranit</string>
-	<string name="downloader_my_maps_title">Mé mapy</string>
 	<string name="downloader_no_downloaded_maps_title">Nemáte stažené žádné mapy</string>
 	<string name="downloader_no_downloaded_maps_message">Stáhněte si mapy a hledejte cestu a její cíl, i když jste offline.</string>
-	<string name="downloader_find_place_hint">Prohledat město nebo zemi</string>
 	<!-- Error title that appears after certain time without location. -->
 	<string name="current_location_unknown_title">Pokračovat se zjišťováním současné polohy?</string>
 	<!-- Error that appears after certain time without location. -->
@@ -771,27 +490,10 @@
 	<string name="location_services_disabled_2">2. Klepněte na položku Poloha</string>
 	<!-- iOS Dialog for the case when the location permission is not granted -->
 	<string name="location_services_disabled_3">3. Vyberte při používání aplikace</string>
-	<string name="placepage_parking_surface">Povrch</string>
-	<string name="placepage_parking_multistorey">Vícepatrové</string>
-	<string name="placepage_parking_underground">Podzemní</string>
-	<string name="placepage_parking_rooftop">Na střeše</string>
-	<string name="placepage_parking_sheds">Samostatné</string>
-	<string name="placepage_parking_carports">Přístřešek</string>
-	<string name="placepage_parking_boxes">Garáž</string>
-	<string name="placepage_parking_pay">Placené</string>
-	<string name="placepage_parking_free">Zdarma</string>
-	<string name="placepage_parking_interval">Placeno za čas</string>
-	<string name="placepage_entrance_number">Č.</string>
-	<string name="placepage_entrance_type">Vchod</string>
-	<string name="placepage_flat">byt</string>
-	<string name="placepage_open_24_7">Nonstop</string>
 	<string name="meter">m</string>
 	<string name="kilometer">km</string>
-	<string name="kilometers_per_hour">km/h</string>
 	<string name="mile">mil</string>
 	<string name="foot">stopa</string>
-	<string name="miles_per_hour">mil/h</string>
-	<string name="day">dní</string>
 	<string name="hour">hod</string>
 	<string name="minute">min</string>
 	<string name="placepage_place_description">Popis</string>
@@ -801,46 +503,30 @@
 	<string name="placepage_call_button">Volat</string>
 	<string name="placepage_edit_bookmark_button">Upravit záložku</string>
 	<string name="placepage_bookmark_name_hint">Název záložky</string>
-	<string name="placepage_personal_notes_hint">Vlastní poznámka</string>
-	<string name="placepage_delete_bookmark_button">Smazat záložku</string>
 	<string name="editor_edits_sent_message">Odeslali jsme Vámi navržené změny</string>
 	<string name="editor_comment_hint">Poznámka…</string>
 	<string name="editor_reset_edits_message">Vymazat všechny místní změny?</string>
 	<string name="editor_reset_edits_button">Vymazat</string>
 	<string name="editor_remove_place_message">Odstranit přidané místo?</string>
 	<string name="editor_remove_place_button">Odstranit</string>
-	<string name="editor_status_sending">Odesílání…</string>
 	<string name="editor_place_doesnt_exist">Místo neexistuje</string>
 	<string name="text_more_button">…dále</string>
 	<!-- Phone number error message -->
 	<string name="error_enter_correct_phone">Zadejte správné telefonní číslo</string>
 	<string name="error_enter_correct_web">Zadat platnou webovou adresu</string>
 	<string name="error_enter_correct_email">Zadat platný email</string>
-	<string name="error_enter_correct">Zadat platnou hodnotu</string>
 	<string name="refresh">Aktualizovat</string>
-	<string name="last_update">Poslední aktualizace: %s</string>
 	<string name="placepage_add_place_button">Přidat místo na mapu</string>
 	<!-- Displayed when saving some edits to the map to warn against publishing personal data -->
 	<string name="editor_share_to_all_dialog_title">Chcete jej poslat všem uživatelům?</string>
 	<!-- iOS Dialog before publishing the modifications to the public map. -->
 	<string name="editor_share_to_all_dialog_message_1">Ujistěte se, že jste nezadali žádná osobní data.</string>
 	<string name="editor_share_to_all_dialog_message_2">Změny ověříme. Budeme-li k vám mít jakékoli dotazy, budeme vás kontaktovat prostřednictvím emailu.</string>
-	<string name="navigation_overview_button">přehled</string>
-	<string name="navigation_stop_button">stop</string>
-	<!-- Text on an empty bookmark page -->
-	<string name="bookmarks_empty_title">Uložte si své záložky</string>
-	<string name="bookmarks_empty_message_1">Klikněte na ★ pro uložení oblíbených míst pro rychlý přístup.</string>
-	<string name="bookmarks_empty_message_2">Importovat záložky z emailu a webu.</string>
-	<string name="bookmarks_empty_message_3">odjezd: %s</string>
-	<!-- Name of the group for booked hotels -->
-	<string name="bookmarks_group_name">Zarezervované hotely</string>
-	<string name="place_page_button_read_descriprion">Číst</string>
 	<!-- iOS dialog for the case when recent track recording is on and the app comes back from background -->
 	<string name="recent_track_background_dialog_title">Zakázat zaznamenávání vaší nedávno ujeté trasy?</string>
 	<string name="off_recent_track_background_button">Zakázat</string>
 	<!-- For sharing via SMS and so on -->
 	<string name="sharing_call_action_look">Odjezd</string>
-	<string name="continue_recent_track_background_button">Pokračovat</string>
 	<string name="recent_track_background_dialog_message">Organic Maps používají geopozici na pozadí, aby se zaznamenala vaše nedávno ujetá trasa.</string>
 	<!-- Rate on Google Play (Android only) -->
 	<string name="rate_gp">Ohodnotit na Google Play</string>
@@ -850,21 +536,11 @@
 	<string name="tell_friends_text">Ahoj! Naisntalujte si Organic Maps!</string>
 	<!-- About short text (below logo) -->
 	<string name="about_description">Organic Maps je základní aplikace pro každého cestovatele. Organic Maps je založena na datech z OpenStreetMap a umožňuje je upravovat.</string>
-	<!-- Text in menu -->
-	<string name="blog">Blog</string>
 	<string name="general_settings">Obecná nastavení</string>
-	<string name="date">Datum %d</string>
-	<!-- "Report a bug" -> "Generaal Feedback" -> "Something is not working" -->
-	<string name="something_is_not_working">Něco nefunguje</string>
 	<!-- For the first routing -->
 	<string name="accept">Přijmout</string>
 	<!-- For the first routing -->
 	<string name="decline">Odmítnout</string>
-	<string name="install_app">Instalovat</string>
-	<string name="search_no_results_title">Nebyly nalezeny žádné výsledky</string>
-	<string name="search_no_results_message">Zkuste obecnější hledaný výraz, oddálit nebo obnovit filtr.</string>
-	<string name="search_no_results_expand_area_button">Oddálit</string>
-	<string name="search_no_results_reset_button">Resetovat filtr</string>
 	<!-- noun -->
 	<string name="search_in_table">Seznam</string>
 	<string name="mobile_data_dialog">Použít mobilní data k zobrazení podrobnějších informací?</string>
@@ -876,18 +552,13 @@
 	<string name="mobile_data_option_never">Nikdy nepoužívat</string>
 	<string name="mobile_data_option_ask">Vždy se zeptat</string>
 	<string name="traffic_update_maps_text">Ke zobrazení údajů o provozu musí být aktualizovány mapy.</string>
-	<string name="traffic_outdated">Data o provozu jsou zastaralá.</string>
 	<string name="big_font">Zvětšit velikost písma na mapě</string>
 	<string name="traffic_update_app">Aktualizujte MAPS. ME</string>
 	<!-- "traffic" as in road congestion -->
 	<string name="traffic_update_app_message">Ke zobrazení dat o provozu je nutné aplikaci aktualizovat.</string>
 	<!-- "traffic" as in "road congestion" -->
 	<string name="traffic_data_unavailable">Data o provozu nejsou k dispozici</string>
-	<!-- Simplified colour scheme for traffic information, fewer colours are used to display traffic jams on the map. The string should be kept as short as possible -->
-	<string name="pref_traffic_simplified_colors_title">Zjednodušené barvy provozu</string>
 	<string name="enable_logging">Povolit protokolování</string>
-	<string name="offline_place_page_more_information">Připojte se k Internetu a získejte více informací o tomto místě.</string>
-	<string name="failed_load_information">Nepodařilo se načíst informace.</string>
 	<!-- Settings: "Send general feedback" button -->
 	<string name="feedback_general">Všeobecné připomínky</string>
 	<string name="on">Zapnout</string>
@@ -901,57 +572,26 @@
 	<string name="routing_add_start_point">Zadejte výchozí bod pro plánování trasy</string>
 	<string name="routing_add_finish_point">Zadejte cílový bod pro plánování trasy</string>
 	<string name="button_exit">Ukončit</string>
-	<string name="settings_device_memory">Paměť zařízení</string>
-	<string name="settings_card_memory">Paměťovou kartu</string>
-	<string name="settings_storage_available">%s k dispozici</string>
-	<string name="toast_location_permission_denied">Povolení k určení polohy bylo zamítnuto</string>
-	<string name="button_use">Použít</string>
 	<string name="planning_route_manage_route">Spravovat trasu</string>
 	<string name="button_plan">Naplánovat</string>
-	<string name="button_add">Přidat</string>
 	<string name="placepage_remove_stop">Odstranit</string>
 	<string name="planning_route_remove_title">Pro odebrání přetáhněte sem</string>
-	<string name="dialog_change_start_point_message">Nastavit aktuální polohu jako výchozí bod?</string>
-	<string name="button_replace">Nastavit</string>
 	<string name="placepage_add_stop">Přidat zastávku</string>
-	<string name="add_my_position">Přidat moji polohu</string>
-	<string name="choose_start_point">Vybrat počáteční bod</string>
-	<string name="choose_destination">Vybrat cílové místo</string>
 	<string name="preloader_viator_button">Zjistit více</string>
-	<string name="start_from_my_position">Začít z</string>
-	<string name="profile_authorization_title">Přihlásit se s</string>
-	<string name="profile_authorization_message">Snadné přihlášení bez uživatelského jména a hesla během několika sekund</string>
 	<string name="profile_authorization_error">Jejda, došlo k chybě. Zkuste se přihlásit znovu.</string>
-	<string name="service">Služba</string>
-	<string name="atmosphere">Atmosféra</string>
-	<string name="value_for_money">Poměr hodnoty a ceny</string>
-	<string name="experience">Zážitek</string>
-	<string name="assortment">Sortiment</string>
-	<string name="expertise">Odborné znalosti</string>
-	<string name="equipment">Vybavení</string>
-	<string name="quality">Kvalita</string>
 	<string name="dialog_error_storage_title">Problém s přístupem k úložišti</string>
 	<string name="dialog_error_storage_message">Externí úložiště není k dispozici, pravděpodobně byla vyjmuta nebo poškozena SD karta, nebo je systém souborů pouze pro čtení. Zkontrolujte to prosím a kontaktujte nás na support\@organicmaps.app</string>
 	<string name="setting_emulate_bad_storage">Emulovat špatné úložiště</string>
-	<string name="directions_finish">Cíl</string>
-	<string name="directions_on_foot">Chůze %s</string>
 	<string name="core_entrance">Vstup</string>
-	<string name="coffee">Káva</string>
-	<string name="cleanliness">Čistota</string>
-	<string name="crowdedness">Přelidnění</string>
 	<string name="error_enter_correct_name">Zadejte prosím správný název</string>
 	<string name="bookmarks_groups">Seznamy</string>
 	<string name="bookmarks_groups_hide_all">Skrýt vše</string>
 	<string name="bookmarks_groups_show_all">Zobrazit vše</string>
-	<plurals name="bookmarks_places">
-	  <item quantity="other">%d záložek</item>
-	</plurals>
 	<string name="bookmarks_create_new_group">Vytvořte nový seznam</string>
 	<string name="downloader_hide_screen">Skrýt obrazovku</string>
 	<string name="downloader_percent">%1$s (%2$s z %3$s)</string>
-	<string name="downloader_process">Stahování %s...</string>
-	<string name="downloader_applying">Aplikuji %s...</string>
-	<string name="dialog_message_transit_not_found_connection">Naplánovat trasu s jednou tranzitní sítí</string>
+	<string name="downloader_process">Stahování %s…</string>
+	<string name="downloader_applying">Aplikuji %s…</string>
 	<string name="bookmarks_error_message_share_general">Nelze sdílet kvůli chybě aplikace</string>
 	<string name="bookmarks_error_title_share_empty">Chyba sdílení</string>
 	<string name="bookmarks_error_message_share_empty">Nelze sdílet s prázdným seznamem</string>
@@ -960,48 +600,22 @@
 	<string name="bookmarks_new_list_hint">Nový seznam</string>
 	<string name="bookmarks_error_title_list_name_already_taken">Toto jméno již bylo provedeno</string>
 	<string name="bookmarks_error_message_list_name_already_taken">Zvolte jiný název</string>
-	<string name="bookmarks_error_title_list_name_too_long">Tento název je příliš dlouhý</string>
-	<string name="bookmarks_error_message_list_name_too_long">Zvolte jiný název</string>
-	<string name="please_wait">Prosím, čekejte...</string>
-	<string name="phone_number">Telefonní číslo</string>
-	<string name="notification_unsent_reviews_title">Máte několik recenzí</string>
-	<string name="notification_unsent_reviews_message">Přihlaste se a sdílejte recenze s ostatními cestovateli</string>
+	<string name="please_wait">Prosím, čekejte…</string>
 	<string name="profile">Profil OpenStreetMap</string>
 	<string name="place_page_search_similar_hotel">Hledat podobné hotely</string>
 	<string name="bookmarks_detect_title">Byly zjištěny nové soubory</string>
 	<plurals name="bookmarks_detect_message">
-	  <item quantity="one">%d soubor byl nalezen. Uvidíte ji po konverzi.</item>
 	  <item quantity="few">%d byly nalezeny soubory. Uvidíte je po konverzi.</item>
+	  <item quantity="one">%d soubor byl nalezen. Uvidíte ji po konverzi.</item>
 	  <item quantity="other">Bylo nalezeno %d souborů. Uvidíte je po konverzi.</item>
 	</plurals>
 	<string name="button_convert">Konvertovat</string>
 	<string name="bookmarks_convert_error_title">Chyba</string>
 	<string name="bookmarks_convert_error_message">Některé soubory nebyly převedeny.</string>
-	<string name="converting">Převádění...</string>
-	<string name="wn_reinvented_bookmarks_title">Znovu jsme vytvořili záložky!</string>
-	<string name="wn_reinvented_bookmarks_message">Můžete je zálohovat, vytvářet seznamy... Je to úžasné...</string>
-	<string name="bookmarks_restore">Obnovit záložky</string>
-	<string name="bookmarks_restore_process">Obnovení...</string>
 	<string name="bookmarks_restore_title">Obnovit tuto verzi?</string>
-	<string name="bookmarks_restore_message">Záložky se obnoví z %1$s (%2$s)</string>
-	<string name="bookmarks_restore_empty_title">Nemáte zálohu</string>
-	<string name="bookmarks_restore_empty_message">Server nenalezl dříve vytvořené zálohy</string>
 	<string name="common_check_internet_connection_dialog_title">Žádné internetové připojení</string>
-	<string name="error_server_title">Chyba serveru</string>
-	<string name="error_server_message">Na serveru došlo k chybě, zkuste to prosím znovu později</string>
 	<string name="error_system_message">Nastala neznámá chyba</string>
 	<string name="restore">Obnovit</string>
-	<string name="bookmarks_page_downloaded">Nahrané</string>
-	<string name="bookmarks_page_my">Moje</string>
-	<string name="routes_and_bookmarks">Trasy a značky</string>
-	<string name="bookmarks_webview_success_toast">Značky byly úspěšně nahrány</string>
-	<string name="cached_bookmarks_placeholder_title">Nahrajte nová místa</string>
-	<string name="cached_bookmarks_placeholder_subtitle">Klikněte pro nahrání tisíce zajímavých míst a tras vytvořených uživateli Organic Maps. Nutné připojení k internetu.</string>
-	<string name="downloader_download_routers">Nahrát značky</string>
-	<string name="bookmarks_groups_cached">Nahrané seznamy</string>
-	<plurals name="bookmarks_objects">
-	  <item quantity="other">%s objekt</item>
-	</plurals>
 	<plurals name="objects">
 	  <item quantity="other">%d místo</item>
 	</plurals>
@@ -1014,62 +628,32 @@
 	<string name="subtittle_opt_out">Natavení doprovodu</string>
 	<string name="crash_reports">Zprávy o chybách</string>
 	<string name="crash_reports_description">Můžeme používat vaše údaje pro vývoj a zlepšení Organic Maps. Změny se projeví po restartování aplikace.</string>
-	<string name="opt_out_help_ios_1">Cílovou reklamu můžete vypnout v nastavení vašeho zařízení.</string>
-	<string name="opt_out_help_ios_2">iOS 9 nebo vyšší</string>
-	<string name="opt_out_help_ios_3">Otevřete Nastavení → Důvěrnost → Reklama → Zapněte „Omezení trackingu“</string>
-	<string name="opt_out_help_android">Cílovou reklamu můžete vypnout v nastavení vašeho zařízení.\nAndroid a Google Play Servisy 4.0 a vyšší\n\nNastavení telefonu → Google → Reklama → Vypnout personalizaci reklamy\n nebo\nNastavení telefonu → Google → Účet Google → Důvěrnost → Nastavení reklamních preferencí → Personalizace reklamy</string>
 	<string name="privacy_policy">Politika důvěrnosti</string>
 	<string name="terms_of_use">Podmínky užívání</string>
-	<string name="backup_notification_failed">Zálohování značek bylo pozastaveno. Pro zapnutí zálohování vejděte.</string>
 	<string name="button_layer_traffic">Zácpy</string>
 	<string name="button_layer_subway">Metro</string>
 	<string name="layers_title">Úrovně mapy</string>
-	<string name="layers_message">Pro zobrazení situace na silnici, schématu metra či jiné užitečné informace můžete přepínat úrovně mapy.</string>
-	<string name="button_layer_got_it">Rozumím</string>
 	<string name="subway_data_unavailable">Mapa metra není dostupná</string>
 	<string name="bookmarks_empty_list_title">Seznam je prázdný</string>
 	<string name="bookmarks_empty_list_message">Pro přidání nové značky klikněte na symbol hvězdičky na obrázku objektu</string>
 	<string name="category_desc_more">…ještě</string>
 	<string name="title_error_downloading_bookmarks">Někde se stala chyba</string>
-	<string name="subtitle_error_downloading_bookmarks">Značky se nenahrály</string>
-	<string name="error_already_downloaded">Tento seznam byl již stažen</string>
-	<string name="why_support">Proč podporovat Organic Maps?</string>
-	<string name="why_support_item2">Pomáháte nám zlepšovat Organic Maps</string>
-	<string name="why_support_item3">Pomáháte nám zlepšovat mapy OpenStreetMap.org</string>
-	<string name="channels_map_update">Aktualizace map</string>
-	<string name="server_unavailable_title">Sever je nedostupný</string>
-	<string name="sharing_options">Nastavení přístupu</string>
 	<string name="export_file">Exportovat soubor</string>
 	<string name="list_settings">Nástroje seznamu</string>
 	<string name="delete_list">Smazat seznam</string>
-	<string name="hide_from_map">Neukazovat na mapě</string>
 	<string name="public_access">Veřejně přístupné</string>
 	<string name="limited_access">Soukromé</string>
 	<string name="bookmark_category_name">Kategorie</string>
 	<string name="bookmark_category_description_hint">Přidejte popis (text nebo html)</string>
 	<string name="not_shared">Osobní účet</string>
-	<string name="direct_link_progress_text">Váš soubor se nahrává…</string>
-	<string name="direct_link_success">Odkaz byl vytvořen</string>
-	<string name="send_a_link_btn">Poslat odkaz</string>
-	<string name="upload_error_toast">Během nahrávání souboru se stala chyba</string>
 	<string name="tags_loading_error_subtitle">Během nahrávání tagů se stala chyba, zkuste to prosím ještě jednou</string>
-	<string name="unable_upload_errorr_title">Soubor se nepodařilo nahrát</string>
-	<string name="unable_upload_error_subtitle_edited">Soubor byl upraven pomocí webové aplikace</string>
-	<string name="unable_upload_error_subtitle_broken">Soubor je poškozen a nemůže být nahrán. Nahrajte prosím jiný soubor.</string>
-	<string name="contact">Napsat</string>
-	<string name="download_button">Stáhnout</string>
 	<string name="speedcams_alert_title">Detektory rychlosti</string>
-	<string name="speedcams_alert_subtitle">Upozorňovat o omezeních rychlosti</string>
 	<string name="speedcam_option_auto">Automaticky</string>
 	<string name="speedcam_option_always">Vždy</string>
 	<string name="speedcam_option_never">Nikdy</string>
-	<string name="bookmark_description_title">Popis značky</string>
 	<string name="place_description_title">Popis místa</string>
 	<!-- this text will be shown in application notification preferences opposite checkbox which enable/disable downloader notifications. Devices on Android 8+ are affected. -->
 	<string name="notification_channel_downloader">Nahrávání map</string>
-	<string name="share_bookmarks_email_body_link">Dobrý den!\n\nVaše značky můžete stáhnout zde: %s. Otevírejte seznam s pomocí Organic Maps a užívejte si cesty!\n\nStáhnout aplikaci: https://omaps.app/get?kmz</string>
-	<string name="warning_speedcams_title">Navigátor vás při překročení rychlosti o %d km/h upozorní na všechny radary</string>
-	<string name="warning_speedcams_subtitle">Nezapomeňte se seznámit s dopravními předpisy země, do které cestujete.</string>
 	<string name="speedcams_notice_message">Automaticky - Upozorňovat na rychlostní radary, pokud hrozí riziko překročení rychlosti\nVždy - Vždy upozorňovat na rychlostní radary\nNikdy - Nikdy neupozorňovat na rychlostní radary</string>
 	<string name="power_managment_title">Nízkoenergetický režim</string>
 	<string name="power_managment_description">Pokud je nízkoenergetický režim zapojen, příloha bude vypínat funkce, které mrhají energii v závislosti na nynější nabíjení telefonu</string>
@@ -1077,14 +661,7 @@
 	<string name="power_managment_setting_auto">Auto</string>
 	<string name="power_managment_setting_manual_max">Maximální šetření energií</string>
 	<string name="enable_logging_warning_message">Daná možnost se zapojuje pro protokolování činností za účelem diagnostiky. To pomáhá týmu odhalit problémy s přílohou. Zapojujte možnost jenom na požádání podržení Organic Maps.</string>
-	<string name="html_error_upload_message_try_again">Zkontrolujte přístup k síti a zopakujte pokus</string>
-	<string name="html_error_upload_title_try_again">Není přípojení na internet</string>
-	<string name="notification_leave_review_v2_android_short_title">Ponechávejte ohlas a pomáhejte cestovatelům!</string>
-	<string name="notifications_illegal_alert_disable_button">Vypnout oznámení</string>
 	<string name="access_rules_author_only">Upravujte on-line</string>
-	<string name="privacy_settings_menu">Naladění důvěrnosti</string>
-	<string name="unable_upadate_error_title">Nepovedlo se obnovit trasu</string>
-	<string name="unable_upadate_error_message">Objevily se chyby pří obnovení. Zkontrolujte změny a zopakujte pokus</string>
 	<string name="driving_options_title">Možnosti řízení</string>
 	<string name="driving_options_subheader">Vyhněte se na každé trase</string>
 	<string name="avoid_tolls">Silnice s mýtným</string>
@@ -1095,52 +672,14 @@
 	<string name="unable_to_calc_alert_subtitle">Bohužel jsme nemohli nalézt trasu pravděpodobně kvůli vámi definovaným možnostem. Změňte prosím nastavení a zkuste to znovu</string>
 	<string name="define_to_avoid_btn">Definovat silnice, kterým se vyhnout</string>
 	<string name="change_driving_options_btn">Možnosti směrování byly povoleny</string>
-	<string name="toll_road">Silnice s mýtným</string>
-	<string name="unpaved_road">Nezpevněná silnice</string>
-	<string name="ferry_crossing">Přejezd trajektů</string>
-	<string name="operated_by">Provozován \"%s\"</string>
 	<string name="avoid_toll_roads_placepage">Vyhnout se silnicím s mýtným</string>
 	<string name="avoid_unpaved_roads_placepage">Vyhnout se nezpevněným silnicím</string>
 	<string name="avoid_ferry_crossing_placepage">Vyhnout se přejezdům trajektů</string>
-	<string name="type.cuisine.uzbek">Uzbecká kuchyně</string>
-	<string name="trip_start">Pojďme</string>
-	<string name="pick_destination">Destinace</string>
-	<string name="follow_my_position">Znovu vystředit</string>
-	<string name="search_results">Prohledat výsledky</string>
-	<string name="then_turn">Poté</string>
-	<string name="redirect_route_alert">Chcete přestavět trasu?</string>
-	<string name="redirect_route_yes">Ano</string>
-	<string name="redirect_route_no">Ne</string>
-	<string name="trip_finished">Přijeli jste!</string>
-	<string name="keyboard_availability_alert">Při řízení není klávesnice dostupná</string>
-	<string name="dialog_routing_change_start_carplay">Od vaší aktuální polohy nelze vystavět trasu</string>
-	<string name="dialog_routing_change_end_carplay">Nelze vystavět trasu k vaší destinaci. Zvolte prosím další bod</string>
-	<string name="dialog_routing_check_gps_carplay">Signál GPS neexistuje. Přesuňte se prosím do otevřeného prostoru</string>
-	<string name="dialog_routing_unable_locate_route_carplay">Nelze sestavit trasu. Specifikujte prosím další body trasy</string>
-	<string name="dialog_routing_download_files_carplay">K vytvoření trasy si stáhněte chybějící mapy do vašeho zařízení</string>
-	<string name="dialog_routing_system_error_carplay">Vyskytla se chyba. Restartujte prosím aplikaci</string>
-	<string name="dialog_routing_rebuild_from_current_location_carplay">Trasa bude přestavěna od vaší aktuální polohy</string>
-	<string name="dialog_routing_rebuild_for_vehicle_carplay">Trasa bude upravena k autu jedna</string>
 	<string name="ok">Ok</string>
-	<string name="avoid_unpaved_carplay_1">Bez pr. cest</string>
-	<string name="avoid_unpaved_carplay_2">Vyhnout se nezp</string>
-	<string name="avoid_ferry_carplay_1">Bez trajektů</string>
-	<string name="avoid_ferry_carplay_2">Vyh. se traj.</string>
-	<string name="avoid_tolls_carplay_1">Bez pl.sil.</string>
-	<string name="avoid_tolls_carplay_2">Vyh. se pl. sil</string>
-	<string name="speedcams_alert_title_carplay_1">Rych. kam.</string>
-	<string name="speedcams_alert_title_carplay_2">Rych. varování</string>
-	<string name="download_map_carplay">Stáhněte si prosím mapy do aplikace Organic Maps ve vašem zařízení</string>
-	<string name="carplay_roundabout_exit">%s výjezd</string>
 	<!-- max. 10 symbols, both iOS and Android -->
 	<string name="sort">Třídit…</string>
 	<!-- Android, title, max 20-22 symbols -->
 	<string name="sort_bookmarks">Třídit záložky</string>
-	<!-- iOS -->
-	<string name="sort_default">Třídit ve výchozím nastavení</string>
-	<string name="sort_type">Třídit dle typu</string>
-	<string name="sort_distance">Třídit dle vzdálenosti</string>
-	<string name="sort_date">Třídit dle data</string>
 	<!-- Android -->
 	<string name="by_default">Podle výchozího stavu</string>
 	<!-- Android -->
@@ -1149,65 +688,23 @@
 	<string name="by_distance">Podle vzdálenosti</string>
 	<!-- Android -->
 	<string name="by_date">Podle data</string>
-	<string name="week_ago_sorttype">Před týdnem</string>
-	<string name="month_ago_sorttype">Před měsícem</string>
-	<string name="moremonth_ago_sorttype">Více než před měsícem</string>
-	<string name="moreyear_ago_sorttype">Více než před rokem</string>
-	<string name="near_me_sorttype">Blízko mě</string>
-	<string name="others_sorttype">Ostatní</string>
-	<string name="food_places">Jídlo</string>
-	<string name="tourist_places">Památky</string>
-	<string name="museums">Muzea</string>
-	<string name="parks">Parky</string>
-	<string name="swim_places">Plavat</string>
-	<string name="mountains">Hory</string>
-	<string name="animals">Zvířata</string>
-	<string name="hotels">Hotely</string>
-	<string name="buildings">Budovy</string>
-	<string name="money">Peníze</string>
-	<string name="shops">Obchody</string>
-	<string name="parkings">Parkoviště</string>
-	<string name="fuel_places">Čerpací stanice</string>
-	<string name="water">Voda</string>
-	<string name="medicine">Medicína</string>
 	<string name="search_in_the_list">Vyhledat v seznamu</string>
-	<string name="view_on_map_bookmarks">Na mapě</string>
-	<string name="more_bookmarks">Více…</string>
-	<string name="no_items_found">Nebyly nalezeny žádné položky</string>
-	<!-- Android, max 18 symbols -->
-	<string name="bookmarks_edit_list">Upravit seznam</string>
-	<!-- Android, max 18 symbols -->
-	<string name="bookmarks_delete_list">Odstranit seznam</string>
-	<string name="religious_places">Posvátná místa</string>
 	<string name="select_list">Vybrat seznam</string>
 	<string name="transit_not_found">Navigace metra v této oblasti zatím není k dispozici</string>
 	<string name="dialog_pedestrian_route_is_long_header">Trasa metra nebyla nalezena</string>
 	<string name="dialog_pedestrian_route_is_long_message">Zvolte prosím počáteční nebo koncový bod blíže k stanici metra</string>
-	<!-- Failed planning SUBWAY route message in navigation view -->
-	<string name="routing_planning_error_subway_special">Plánování trasy metra selhalo</string>
 	<string name="button_layer_isolines">Terén</string>
-	<string name="tips_map_layers_title_countour">Novinka v Organic Maps: offline topografická vrstva!</string>
-	<string name="tips_map_layers_message_countour">Naplánujte si a užijte si své výlety do přírody s jistotou, že víte vše o této oblasti</string>
 	<string name="isolines_activation_error_dialog">Chcete-li aktivovat a používat topografickou vrstvu, prosím aktualizujte nebo si stáhněte mapu oblasti</string>
 	<string name="isolines_location_error_dialog">Topografická vrstva není v této oblasti ještě dostupná</string>
 	<string name="elevation_profile_diff_level">Stupeň obtížnosti</string>
-	<string name="elevation_profile_diff_level_easy">Snadný</string>
-	<string name="elevation_profile_diff_level_moderate">Mírný</string>
-	<string name="elevation_profile_diff_level_hard">Těžký</string>
 	<string name="elevation_profile_ascent">Stoupání</string>
 	<string name="elevation_profile_descent">Klesání</string>
 	<string name="elevation_profile_minaltitude">Min. nadmořská výška</string>
 	<string name="elevation_profile_maxaltitude">Max. nadmořská výška</string>
-	<string name="elevation_profile_m">m</string>
 	<string name="elevation_profile_difficulty">Obtížnost</string>
 	<string name="elevation_profile_distance">Vzdál.:</string>
-	<string name="elevation_profile_km">km</string>
 	<string name="elevation_profile_time">Čas:</string>
-	<string name="elevation_profile_hours">hod.</string>
-	<string name="elevation_profile_minutes">min</string>
 	<string name="isolines_toast_zooms_1_10">Přiblížit pro prozkoumání izolinií</string>
-	<string name="downloader_updating_ios">Probíhá aktualizace</string>
-	<string name="downloader_loading_ios">Probíhá stahování</string>
 	<string name="key_information_title">Klíčové informace</string>
 	<string name="enable_screen_sleep">Nechte obrazovku spát</string>
 	<!-- Description in preferences -->

--- a/android/res/values-da/strings.xml
+++ b/android/res/values-da/strings.xml
@@ -12,8 +12,6 @@
 	<string name="cancel_download">Annuller download</string>
 	<!-- Button which deletes downloaded country -->
 	<string name="delete">Slet</string>
-	<!-- Button "do not interrupt download" if user touched actively downloading country -->
-	<string name="do_nothing">Fortsæt</string>
 	<string name="download_maps">Download kort</string>
 	<!-- Settings/Downloader - info for country when download fails -->
 	<string name="download_has_failed">Der skete en fejl ved download, tryk for at prøve igen.</string>
@@ -33,45 +31,31 @@
 	<string name="core_my_position">Min position</string>
 	<!-- Update maps later/Buy pro version later button text -->
 	<string name="later">Senere</string>
-	<!-- Don't show some dialog any more -->
-	<string name="never">Aldrig</string>
 	<!-- View and button titles for accessibility -->
 	<string name="search">Søg</string>
 	<!-- Search box placeholder text -->
 	<string name="search_map">Søg kort</string>
-	<!-- Settings/Downloader - info for not downloaded country -->
-	<string name="touch_to_download">Tryk for at downloade</string>
 	<!-- Settings/Downloader - 3G download warning dialog confirm button -->
 	<string name="use_cellular_data">Ja</string>
 	<!-- Location services are disabled by user alert - message -->
 	<string name="location_is_disabled_long_text">Du har alle lokationstjenester for denne enhed eller applikation slukket. Slå dem venligst til i Indstillinger.</string>
-	<!-- Location Services are not available on the device alert - message -->
-	<string name="device_doesnot_support_location_services">Din enhed understøtter ikke lokationstjenester</string>
 	<!-- View and button titles for accessibility -->
 	<string name="zoom_to_country">Vis på kortet</string>
-	<!-- Button text for the button at the center of the screen when the country is not downloaded -->
-	<string name="country_status_download">Download kort\n(^ ^)</string>
 	<!-- Button text for the button at the center of the screen when the country is not downloaded and the size should not be shown -->
 	<string name="country_status_download_without_size">Download kort</string>
-	<!-- Button text for the button at the center of the screen when the country is not downloaded -->
-	<string name="country_status_download_without_routing">Download kort uden\nruteplanlægning (^ ^)</string>
 	<!-- Message to display at the center of the screen when the country download has failed -->
 	<string name="country_status_download_failed">Download mislykket</string>
 	<!-- Button text for the button under the country_status_download_failed message -->
 	<string name="try_again">Prøv igen</string>
 	<string name="about_menu_title">Om Organic Maps</string>
-	<string name="downloaded_touch_to_delete">Downloaded (%s), tryk for at slette</string>
 	<string name="connection_settings">Forbindelsesindstillinger</string>
-	<string name="download_mb_or_kb">Download %s</string>
 	<string name="close">Luk</string>
 	<string name="unsupported_phone">En hardware accelereret OpenGL er påkrævet. Din enhed er desværre ikke understøttet.</string>
 	<string name="download">Download</string>
-	<string name="external_storage_is_not_available">SD-kort/USB lagring med de downloadede kort er ikke tilgængeligt</string>
 	<string name="disconnect_usb_cable">Frakobl venligst USB-kabel eller indsæt et memory kort for at bruge Organic Maps</string>
 	<string name="not_enough_free_space_on_sdcard">Frigør venligst plads på dit SD-kort/USB lager først for at bruge denne app</string>
 	<string name="not_enough_memory">Ikke nok hukommelse til at åbne app</string>
 	<string name="download_resources">Før du starter, så lad os downloade det generelle verdenskort til din enhed.\nIt behøver %s af data.</string>
-	<string name="getting_position">Henter nuværende lokation</string>
 	<string name="download_resources_continue">Gå til kort</string>
 	<string name="downloading_country_can_proceed">Downloader %s. Du kan nu\nfortsætte til kortet.</string>
 	<string name="download_country_ask">Download %s?</string>
@@ -84,30 +68,20 @@
 	<string name="download_country_failed">%s download mislykkedes</string>
 	<!-- Add New Bookmark Set dialog title -->
 	<string name="add_new_set">Tilføj nyt sæt</string>
-	<!-- Place Page - Add To Bookmarks button -->
-	<string name="add_to_bookmarks">Tilføj til Bogmærker</string>
 	<!-- Bookmark Color dialog title -->
 	<string name="bookmark_color">Bogmærke Farve</string>
 	<!-- Add Bookmark Set dialog - hint when set name is empty -->
 	<string name="bookmark_set_name">Indstil bogmærkenavn</string>
-	<!-- Bookmark Sets dialog title -->
-	<string name="bookmark_sets">Bogmærk sæt</string>
 	<!-- Bookmarks - dialog title -->
 	<string name="bookmarks">Bogmærker</string>
-	<!-- Add bookmark dialog - bookmark color -->
-	<string name="color">Farve</string>
 	<!-- Default bookmarks set name -->
 	<string name="core_my_places">Mine Steder</string>
 	<!-- Add bookmark dialog - bookmark name -->
 	<string name="name">Navn</string>
 	<!-- Editor title above street and house number -->
 	<string name="address">Adresse</string>
-	<!-- Place Page - Remove Pin button -->
-	<string name="remove_pin">Fjern knappenål</string>
 	<!-- Add bookmark dialog - bookmark set, Bookmarks dialog - Bookmark set cell -->
 	<string name="set">Sæt</string>
-	<!-- Text hint in Bookmarks dialog when no any bookmarks are added -->
-	<string name="bookmarks_usage_hint">Du har ingen bogmærker endnu.\nTryk på et sted på kortet for at kunne tilføje det til bogmærker. Bogmærker fra andre kilder kan også blive importeret og vist i Organic Maps.\nÅbn en KML/KMZ fil med gemte bogmærker/knappenåle på i Mail, Dropbox eller på et link.</string>
 	<!-- Settings button in system menu -->
 	<string name="settings">Indstillinger</string>
 	<!-- Header of settings activity where user defines storage path -->
@@ -118,20 +92,10 @@
 	<string name="move_maps">Flyt kort?</string>
 	<!-- Ask to wait user several minutes (some long process in modal dialog). -->
 	<string name="wait_several_minutes">Dette kan tage flere minutter.\nVent venligst…</string>
-	<!-- Show bookmarks from this category on a map or not -->
-	<string name="visible">Synligt</string>
-	<!-- Toast which is displayed when GPS has been deactivated -->
-	<string name="gps_is_disabled_long_text">GPS er deaktiveret. Aktiver venligst i Indstillinger.</string>
 	<!-- Measurement units title in settings activity -->
 	<string name="measurement_units">Måleenhed</string>
 	<!-- Detailed description of Measurement Units settings button -->
 	<string name="measurement_units_summary">Vælg mellem mil eller kilometer</string>
-	<!-- Do search in all sources -->
-	<string name="search_mode_all">Overalt</string>
-	<!-- Do search near my position only -->
-	<string name="search_mode_nearme">Tæt på mig</string>
-	<!-- Do search in current viewport only -->
-	<string name="search_mode_viewport">På skærmen</string>
 	<!-- Search category for cafes, bars, restaurants -->
 	<string name="eat">Spisesteder</string>
 	<!-- Search category for grocery stores -->
@@ -168,12 +132,8 @@
 	<string name="post">Post</string>
 	<!-- Search category -->
 	<string name="police">Politi</string>
-	<!-- String in search result list, when nothing found -->
-	<string name="no_search_results_found">Ingen resultater</string>
 	<!-- Notes field in Bookmarks view -->
 	<string name="description">Noter</string>
-	<!-- Button text -->
-	<string name="share_by_email">Del via email</string>
 	<!-- Email Subject when sharing bookmarks category -->
 	<string name="share_bookmarks_email_subject">Organic Maps bogmærker er blevet delt med dig</string>
 	<!-- message title of loading file -->
@@ -186,20 +146,10 @@
 	<string name="edit">Rediger</string>
 	<!-- Warning message when doing search around current position -->
 	<string name="unknown_current_position">Din lokation er ikke blevet bestemt endnu</string>
-	<!-- Warning message when location country isn't downloaded during search (see also download_location_map_proposal). -->
-	<string name="download_location_country">Download landet bestemt ud fra din nuværende lokation (%s)</string>
-	<!-- Warning message when viewport country isn't downloaded during search -->
-	<string name="download_viewport_country_to_search">Download landet som du har søgt på (%s)</string>
 	<!-- Alert message that we can't run Map Storage settings due to some reasons. -->
 	<string name="cant_change_this_setting">Beklager, Kort Lagring er ikke slået til i indstillinger.</string>
 	<!-- Alert message that downloading is in progress. -->
 	<string name="downloading_is_active">Download af kort over land er i gang nu.</string>
-	<!-- Message that will be shown in alert view, when we ask user to leave review on App Store -->
-	<string name="appStore_message">Vi håber du er glad for at bruge Organic Maps! Hvis du er, vil du så overveje at bedømme og måske skrive en anmeldelse på App Store? Det tager under et minut, men det kan virkelig hjælpe os. Tak for din hjælp!</string>
-	<!-- No, thanks -->
-	<string name="no_thanks">Nej, tak</string>
-	<!-- Share one specific bookmark using SMS, %1$@ contains om:// and %2$@ https://omaps.app link. @NOTE non-ascii symbols in the link will result in max 70 characters SMS instead of 140. -->
-	<string name="bookmark_share_sms">Hey, tjek min knappenål på Organic Maps ud! %1$s or %2$s Har du ikke offline kort? Download her: https://omaps.app/get</string>
 	<!-- Share my position using SMS, %1$@ contains om:// and %2$@ https://omaps.app link WITHOUT NAME. @NOTE non-ascii symbols in the link will result in max 70 characters SMS instead of 140. -->
 	<string name="my_position_share_sms">Hey, tjek min nuværende lokation ud på Organic Maps! %1$s or %2$s. Har du ikke offline kort? Download her: https://omaps.app/get</string>
 	<!-- Subject for emailed bookmark -->
@@ -208,30 +158,16 @@
 	<string name="my_position_share_email_subject">Hey, tjek min nuværende lokation ud på Organic Maps kortet!</string>
 	<!-- Share my position using EMail, %1$@ is om:// and %2$@ is https://omaps.app link WITHOUT NAME -->
 	<string name="my_position_share_email">Hey, her er jeg nu: %1$s. Tryk på dette link %2$s eller dette %3$s for at se stedet på kortet. Tak.</string>
-	<!-- Android share by Message/SMS button text (including SMS) -->
-	<string name="share_by_message">Del via besked</string>
 	<!-- Share button text which opens menu with more buttons, like Message, EMail, Facebook etc. -->
 	<string name="share">Del</string>
-	<!-- iOS share by Message button text (including SMS) -->
-	<string name="message">Besked</string>
 	<!-- Share by email button text, also used in editor. -->
 	<string name="email">Email</string>
-	<!-- Copy Link -->
-	<string name="copy_link">Kopier link</string>
-	<!-- Text for the button that returns to caller application -->
-	<string name="more_info">Vis mere info</string>
 	<!-- Text for message when used successfully copied something -->
 	<string name="copied_to_clipboard">Kopieret til udklipsholderen: %1$s</string>
 	<!-- place preview title -->
 	<string name="info">Info</string>
 	<!-- Used for bookmark editing -->
 	<string name="done">Færdig</string>
-	<!-- Summary for preferences in MWM -->
-	<string name="yopme_pref_summary">Vælg bagskærmsindstillinger</string>
-	<!-- Title for yopme preferences in MWM -->
-	<string name="yopme_pref_title">Bagskærmsindstillinger</string>
-	<!-- Hint for upper-right icon p2b -->
-	<string name="show_on_backscreen">Vis på bagskærm</string>
 	<!-- Prints version number in About dialog -->
 	<string name="version">Version: %s</string>
 	<!-- Confirmation in downloading countries dialog -->
@@ -241,11 +177,6 @@
 	<!-- Length of track in cell that describes route -->
 	<string name="length">Længde</string>
 	<string name="share_my_location">Del min lokation</string>
-	<string name="menu_search">Søg</string>
-	<!-- Settings screen: "Map" category title -->
-	<string name="prefs_group_map">Kort</string>
-	<!-- Settings screen: "Miscellaneous" category title -->
-	<string name="prefs_group_misc">Forskelligt</string>
 	<string name="prefs_group_route">Navigation</string>
 	<string name="pref_zoom_title">Zoom knapper</string>
 	<string name="pref_zoom_summary">Vis på skærmen</string>
@@ -261,8 +192,6 @@
 	<string name="pref_map_3d_title">Perspektivvisning</string>
 	<!-- Settings «Map» category: «3D buildings» title -->
 	<string name="pref_map_3d_buildings_title">3D-bygninger</string>
-	<!-- Settings «Map» category: «3D buildings» summary -->
-	<string name="pref_map_3d_buildings_subtitle">Påvirker batteriets levetid</string>
 	<!-- Settings «Route» category: «Tts enabled» title -->
 	<string name="pref_tts_enable_title">Stemmeinstruktioner</string>
 	<!-- Settings «Route» category: «Tts language» title -->
@@ -271,7 +200,6 @@
 	<string name="pref_tts_unavailable">Ikke til rådighed</string>
 	<!-- Title for "Other" section in TTS settings. -->
 	<string name="pref_tts_other_section_title">Andet</string>
-	<string name="pref_tts_how_to_set_up_voice">Sådan indstiller du tale</string>
 	<!-- Settings «Map» category: «Record track» title -->
 	<string name="pref_track_record_title">Seneste sti</string>
 	<string name="pref_map_auto_zoom">Auto zoom</string>
@@ -282,46 +210,11 @@
 	<string name="duration_12_hours">12 timer</string>
 	<string name="duration_1_day">1 dag</string>
 	<string name="recent_track_help_text">Det giver dig mulighed at optage en rejsterute for en bestemt periode og se den på kortet. Bemærk: aktivering af denne funktion forårsager øget batteriforbrug. Sporet vil blive fjernet automatisk fra kortet efter at tidsintervallet er udløbet.</string>
-	<string name="pref_track_ios_caption">Seneste spor viser din rejste vej.</string>
-	<string name="pref_track_ios_subcaption">Vælg tidsinterval for at gemme sporet.</string>
-	<string name="placepage_distance">Afstand</string>
-	<string name="placepage_coordinates">Koordinater</string>
-	<string name="placepage_unsorted">Usorteret</string>
 	<string name="search_show_on_map">Vis på kortet</string>
-	<!-- Used to warn user when fixing KitKat issue -->
-	<string name="bookmark_move_fail">Vi er nødsaget til at flytte dine bogmærker til intern hukommelse, men der er ikke nok plads til dem der. Frigør venligst noget plads, ellers vil dine bogmærker ikke være tilgængelige.</string>
-	<!-- Used in More Apps menu -->
-	<string name="free">Gratis</string>
-	<!-- Used in More Apps menu -->
-	<string name="buy">Køb</string>
-	<!-- 1st search button-like result -->
-	<string name="search_on_map">Søg på kort</string>
-	<!-- toast with an error -->
-	<string name="no_route_found">Ingen rute blev fundet</string>
-	<!-- route title -->
-	<string name="route">Rute</string>
-	<!-- category title -->
-	<string name="routes">Ruter</string>
-	<!-- text of notification -->
-	<string name="download_map_notification">Download kortet over det sted, hvor du befinder dig</string>
-	<!-- text of notification -->
-	<string name="pro_version_is_free_today">Fuld version af Organic Maps er gratis i dag! Download nu og fortæl dine venner om det.</string>
-	<!-- Dialog for transferring maps from lite to pro. -->
-	<string name="move_lite_maps_to_pro">Vi overfører dine downloadede kort fra Organic Maps Lite til Organic Maps. Det kan tage et par minutter.</string>
-	<!-- Message to display when maps moved. -->
-	<string name="move_lite_maps_to_pro_ok">Dine downloadede kort er blevet succesfuldt overført til Organic Maps.</string>
-	<!-- Message to display when maps move failed. -->
-	<string name="move_lite_maps_to_pro_failed">Det lykkedes ikke at overføre dine kort. Slet venligst Organic Maps Lite og download kortene igen.</string>
-	<!-- Text in menu -->
-	<string name="settings_and_more">Indstillinger &amp; Mere</string>
 	<!-- Text in menu -->
 	<string name="website">Hjemmeside</string>
-	<!-- Text in menu -->
-	<string name="contact_us">Kontakt os</string>
 	<!-- Settings: Send feedback button and dialog title -->
 	<string name="feedback">Feedback</string>
-	<!-- Text in menu -->
-	<string name="subscribe_to_news">Abonnér på vores nyheder</string>
 	<!-- Text in menu -->
 	<string name="rate_the_app">Bedøm appen</string>
 	<!-- Text in menu -->
@@ -330,12 +223,6 @@
 	<string name="copyright">Copyright</string>
 	<!-- Text in menu -->
 	<string name="report_a_bug">Rapportér fejl</string>
-	<!-- Email subject -->
-	<string name="subscribe_me_subject">Tilmeld mig Organic Maps-nyhedsbrev</string>
-	<!-- Email body -->
-	<string name="subscribe_me_body">Jeg vil være den første til at høre om de seneste nyheder opdateringer og tilbud. Jeg kan opsige abonnementet når som helst.</string>
-	<!-- About text -->
-	<string name="about_text">Organic Maps tilbyder de hurtigste offline-kort over alle byer og alle lande i verden. Rejs med tillid: Hvor end du befinder dig, hjælper Organic Maps med at lokalisere din placering på kortet, finde den nærmeste restaurant, hotel, bank, benzintank og så videre. Det er ikke nødvendigt at have forbindelse til internettet.\n\nVi arbejder altid på nye funktioner, og vi vil meget gerne høre fra dig, hvis du har forslag til, hvordan vi kan forbedre Organic Maps. Hvis du oplever problemer med appen, er du meget velkommen til at kontakte os på support\@organicmaps.app. Vi besvarer alle henvendelser!\n\nSynes du om Organic Maps, og har du lyst til at støtte os? Her er nogle simple og helt gratis metoder:\n\n-post en anmeldelse i din App Store\n-like vores facebook-side http://www.facebook.com/OrganicMaps\n-neller fortæl din mor, venner og kollegaer om Organic Maps :)\n\nTak fordi du støtter os. Vi sætter stor pris på din støtte!\n\nPS: Vi får vores kortdata fra OpenStreetMap, som er et kortprojekt, der minder om Wikipedia, og som gør brugere i stand til at oprette og rette kort. Hvis du oplever, at noget mangler eller er forkert på kortet, kan du rette kortene direkte på https://www.openstreetmap.org, og dine ændringer vil figurere på Organic Maps-appen i forbindelse med frigivelsen af den næste version.</string>
 	<!-- Alert text -->
 	<string name="email_error_body">Emailklienten er ikke blevet sat op. Venligst konfigurér den eller brug en anden måde til at kontakte os på %s</string>
 	<!-- Alert title -->
@@ -344,137 +231,56 @@
 	<string name="pref_calibration_title">Kalibrering af kompas</string>
 	<!-- Search category -->
 	<string name="wifi">WiFi</string>
-	<!-- Update map suggestion -->
-	<string name="routing_map_outdated">Venligst opdatér kortet for at oprette en rute.</string>
-	<!-- Update maps suggestion -->
-	<string name="routing_update_maps">Den nye version af Organic Maps gør det muligt at oprette ruter fra din nuværende position til et destinationspunkt. Venligst opdatér kortene for at bruge denne funktion.</string>
 	<!-- Update all button text -->
 	<string name="downloader_update_all_button">Opdatér alle</string>
 	<!-- Cancel all button text -->
 	<string name="downloader_cancel_all">Aflys Alt</string>
 	<!-- Downloaded maps category -->
 	<string name="downloader_downloaded_subtitle">Downloadet</string>
-	<!-- Downloaded maps category -->
-	<string name="downloader_available_maps">Tilgængelige</string>
 	<!-- Country queued for download -->
 	<string name="downloader_queued">I kø</string>
 	<string name="downloader_near_me_subtitle">I nærheden</string>
 	<string name="downloader_status_maps">Kort</string>
 	<string name="downloader_download_all_button">Download alle</string>
 	<string name="downloader_downloading">Downloader:</string>
-	<string name="downloader_search_results">Fundet</string>
-	<!-- Disclaimer message -->
-	<string name="routing_disclaimer">Ved oprettelse af ruter i Organic Maps appen, venligst tænk over følgende:\n\n- Anbefalede ruter kan kun betragtes som anbefalinger.\n- Vejtilstande, trafikregler og skilte har højere prioritet end navigationsråd.\n Kortet kan være ukorrekt eller forældet, og ruter kan muligvis ikke være oprettet på den bedste måde.\n\nVær sikker på vejene og pas på dig selv!</string>
-	<!-- Outdated maps category -->
-	<string name="downloader_outdated_maps">Uddateret</string>
-	<!-- Up to date maps category -->
-	<string name="downloader_uptodate_maps">Up-to-date</string>
 	<!-- Status of outdated country in the list -->
 	<string name="downloader_status_outdated">Opdater</string>
 	<!-- Status of failed country in the list -->
 	<string name="downloader_status_failed">Mislykkedes</string>
 	<!-- Displayed in a dialog that appears when a user tries to delete a map while the app is in the follow route mode -->
 	<string name="downloader_delete_map_while_routing_dialog">For at slette kortet skal du stoppe navigeringen.</string>
-	<!-- Show when user try build route, but we don't know where he -->
-	<string name="routing_failed_unknown_my_position">Den nuværende placering er ikke defineret. Venligst angiv placering for at oprette en rute.</string>
-	<!-- Show if use has not routing file, or InconsistentMWMandRoute -->
-	<string name="routing_failed_has_no_routing_file">Yderligere data er nødvendig, for at oprette en rute. Begynde download?</string>
-	<!-- StartPointNotFound -->
-	<string name="routing_failed_start_point_not_found">Kan ikke beregne ruten. Ingen veje nær dit startpunkt.</string>
-	<!-- EndPointNotFound -->
-	<string name="routing_failed_dst_point_not_found">Kan ikke beregne ruten. Ingen veje nær din destination.</string>
 	<!-- PointsInDifferentMWM -->
 	<string name="routing_failed_cross_mwm_building">Ruter kan kun oprettes, hvis de er fuldt indeholdt i ét enkelt kort.</string>
-	<!-- RouteNotFound -->
-	<string name="routing_failed_route_not_found">Der blev ikke fundet en rute mellem det valgte begyndelsespunkt og destinationen. Venligst vælg et andet start- eller slutpunkt.</string>
-	<!-- InternalError -->
-	<string name="routing_failed_internal_error">Intern fejl opstod. Venligt prøv at slette og downloade kortet igen. Hvis problemet vare ved, venligst kontakt os på support\@organicmaps.app.</string>
-	<!-- Context menu item for downloader. -->
-	<string name="downloader_download_map_and_routing">Hent kort + ruteangivelse</string>
-	<!-- Context menu item for downloader. -->
-	<string name="downloader_download_routing">Hent ruteangivelse</string>
-	<!-- Context menu item for downloader. -->
-	<string name="downloader_delete_routing">Slet ruteangivelse</string>
 	<!-- Context menu item for downloader. -->
 	<string name="downloader_download_map">Download kortet</string>
-	<string name="downloader_download_map_no_routing">Download kort uden ruteplanlægning</string>
-	<!-- Button for routing. -->
-	<string name="routing_go">Kør!</string>
 	<!-- Item status in downloader. -->
 	<string name="downloader_retry">Gentag</string>
-	<!-- Item in context menu. -->
-	<string name="downloader_map_and_routing">Kort og rutevejledning</string>
 	<!-- Item in context menu. -->
 	<string name="downloader_delete_map">Slet kort</string>
 	<!-- Item in context menu. -->
 	<string name="downloader_update_map">Opdater kort</string>
-	<!-- Item in context menu. -->
-	<string name="downloader_update_map_and_routing">Opdater kort og rutevejledning</string>
-	<!-- Item in context menu. -->
-	<string name="downloader_map_only">Kun kort</string>
-	<!-- Toolbar title -->
-	<string name="toolbar_application_menu">Programmenu</string>
 	<!-- Preference text -->
 	<string name="pref_use_google_play">Anvend Google Play Services til at få din aktuelle placering</string>
 	<!-- Text for rating dialog -->
 	<string name="rating_just_rated">Jeg har netop bedømt jeres app</string>
-	<!-- Text for rating dialog -->
-	<string name="rating_user_since">Jeg er Organic Maps bruger siden %s</string>
-	<!-- Text for rating dialog -->
-	<string name="rating_do_like_maps">Kan du lide Organic Maps?</string>
-	<!-- Text for rating dialog -->
-	<string name="rating_tap_star">Tryk på en stjerne for at bedømme vores app.</string>
 	<!-- Text for rating dialog -->
 	<string name="rating_thanks">Mange tak!</string>
 	<!-- Text for rating dialog -->
 	<string name="rating_share_ideas">Del dine ideer eller problemer med os, så vi kan forbedre appen for dig.</string>
 	<!-- Text for rating dialog -->
 	<string name="rating_send_feedback">Send feedback</string>
-	<!-- Text for g+ dialog -->
-	<string name="rating_google_plus">Klik g+ for at fortælle dine venner om app\'en.</string>
 	<!-- Text for routing error dialog -->
 	<string name="routing_download_maps_along">Download kort på vejen</string>
-	<!-- Text for routing error dialog -->
-	<string name="routing_download_map">Få kort</string>
-	<!-- Text for routing error dialog -->
-	<string name="routing_download_map_and_routing">Download opdaterede kort og routing data for at få alle Organic Maps funktioner.</string>
-	<!-- Text for routing error dialog -->
-	<string name="routing_get_routing_data">Få routing data</string>
-	<!-- Text for routing error dialog -->
-	<string name="routing_get_additional_data">Yderligere data er påkrævet for at oprette ruter fra din placering.</string>
 	<!-- Text for routing error dialog -->
 	<string name="routing_requires_all_map">Ved at oprette en rute kræver det, at alle kort fra din placering til destination er downloadede og opdaterede.</string>
 	<!-- Text for routing error dialog -->
 	<string name="routing_not_enough_space">Ikke nok plads</string>
-	<!-- Text for routing error dialog -->
-	<string name="routing_download_more_than_avail">Du skal downloade %1$s MB, men kun %2$s MB er tilgængeligt.</string>
-	<!-- Text for routing error dialog -->
-	<string name="routing_download_roaming">Du kommer til at downloade %s MB ved at bruge mobilt data (i roaming). Dette kan resultere i yderligere omkostninger alt afhængigt din operatørs mobile dataplan.</string>
 	<!-- bookmark button text -->
 	<string name="bookmark">bogmærke</string>
-	<!-- map is not downloaded -->
-	<string name="not_found_map">Kortet for dit område er ikke downloadet</string>
 	<!-- location service disabled -->
 	<string name="enable_location_services">Aktiver venligst lokationstjenester</string>
-	<!-- download map -->
-	<string name="download_map">Download kortet for dit område</string>
-	<!-- download map on iPhone -->
-	<string name="download_map_iphone">Download kortet for din placering til din iPhone</string>
-	<!-- clear pin -->
-	<string name="nearby">I nærheden</string>
-	<!-- clear pin -->
-	<string name="clear_pin">Slet nål</string>
-	<!-- location is undefined -->
-	<string name="undefined_location">Den nuværende placering er ikke defineret.</string>
-	<!-- download country of your location -->
-	<string name="download_country">Download landet bestemt ud fra din nuværende lokation</string>
-	<!-- download failed -->
-	<string name="download_failed">download mislykkedes</string>
-	<!-- get the map -->
-	<string name="get_the_map">Få kort</string>
 	<string name="save">Gem</string>
 	<string name="edit_description_hint">Dine beskrivelser (tekst eller html)</string>
-	<string name="new_group">ny gruppe</string>
 	<string name="create">skabe</string>
 	<!-- red color -->
 	<string name="red">Rød</string>
@@ -492,22 +298,6 @@
 	<string name="brown">Brun</string>
 	<!-- pink color -->
 	<string name="pink">Pink</string>
-	<!-- deep purple color -->
-	<string name="deep_purple">Mørkelilla</string>
-	<!-- light blue color -->
-	<string name="light_blue">Lyseblå</string>
-	<!-- cyan color -->
-	<string name="cyan">Cyan</string>
-	<!-- teal color -->
-	<string name="teal">Blågrøn</string>
-	<!-- lime color -->
-	<string name="lime">Lime</string>
-	<!-- deep orange color -->
-	<string name="deep_orange">Dyb orange</string>
-	<!-- gray color -->
-	<string name="gray">Grå</string>
-	<!-- blue gray color -->
-	<string name="blue_gray">Blågrå</string>
 	<!-- Wi-Fi available -->
 	<string name="WiFi_available">Ja</string>
 
@@ -523,10 +313,8 @@
 	<string name="dialog_routing_location_turn_wifi">Tjek venligst dit GPS-signal. Din placering registreres mere præcist, hvis wi-fi er slået til.</string>
 	<string name="dialog_routing_location_turn_on">Slå lokaliseringstjenester til</string>
 	<string name="dialog_routing_location_unknown_turn_on">Det lykkedes ikke at finde de aktuelle GPS-koordinater. Slå lokaliseringstjenester til for at beregne en rute.</string>
-	<string name="dialog_routing_location_unknown">Det lykkedes ikke at finde de aktuelle GPS-koordinater.</string>
 	<string name="dialog_routing_download_files">Download de nødvendige filer</string>
 	<string name="dialog_routing_download_and_update_all">Download og opdatér alle kort og ruteoplysninger for at beregne en rute.</string>
-	<string name="dialog_routing_routes_size">Filer med ruteoplysninger</string>
 	<string name="dialog_routing_unable_locate_route">Der blev ikke fundet en rute</string>
 	<string name="dialog_routing_cant_build_route">Der blev ikke planlagt en rute.</string>
 	<string name="dialog_routing_change_start_or_end">Prøv at angive et andet startpunkt eller en anden destination.</string>
@@ -541,33 +329,23 @@
 	<string name="dialog_routing_system_error">Systemfejl</string>
 	<string name="dialog_routing_application_error">Det lykkedes ikke at planlægge en rute. Der opstod en fejl i systemet.</string>
 	<string name="dialog_routing_try_again">Prøv igen</string>
-	<string name="dialog_routing_send_error">Anmeld problemet</string>
-	<string name="dialog_routing_if_get_cross_route">Ønsker du at planlægge en mere direkte rute, der strækker sig over mere end ét kort?</string>
-	<string name="dialog_routing_cross_route_is_optimal">Der findes en mere optimal rute, som strækker sig ud over dette korts grænser.</string>
 	<string name="not_now">Ikke nu</string>
-	<string name="dialog_routing_build_route">Opret</string>
 	<string name="dialog_routing_download_and_build_cross_route">Ønsker du at downloade kortet og planlægge en mere optimal rute, der strækker sig over mere end ét kort?</string>
 	<string name="dialog_routing_download_cross_route">Download kortet for at planlægge en mere optimal rute, der strækker sig ud over dette korts grænser.</string>
-	<string name="dialog_routing_cross_route_always">Kryds altid denne grænse</string>
 
 	<!-- SECTION: Strings for downloading map from search -->
 	<string name="search_without_internet_advertisement">For at begynde at søge efter og oprette ruter bedes du downloade kortet, så du ikke længere har behov for en internetforbindelse.</string>
 	<string name="search_select_map">Vælk kortet</string>
-	<string name="search_select_other_map">Vælg et andet kort</string>
 	<!-- «Show» context menu -->
 	<string name="show">Vis</string>
 	<!-- «Hide» context menu -->
 	<string name="hide">Skjul</string>
 	<!-- «Rename» context menu -->
 	<string name="rename">Omdøb</string>
-	<!-- Bottom sheet: expand button (should be short) -->
-	<string name="bottom_sheet_more">Mere…</string>
 	<!-- Failed planning route message in navigation view -->
 	<string name="routing_planning_error">Ruteplanlægning mislykkedes</string>
 	<!-- Arrive routing message in navigation view -->
 	<string name="routing_arrive">Ankomst: %s</string>
-	<!-- Text for routing::RouterResultCode::FileTooOld dialog. -->
-	<string name="dialog_routing_download_and_update_maps">For at oprette en rute skal du hente og opdatere alle kort langs ruten.</string>
 	<string name="rate_alert_title">Kan du lide appen?</string>
 	<string name="rate_alert_default_message">Tak for at du bruger Organic Maps. Venligst bedøm appen. Din feedback hjælper os med at blive bedre.</string>
 	<string name="rate_alert_five_star_message">Hurra! Vi elsker også dig!</string>
@@ -575,24 +353,14 @@
 	<string name="rate_alert_less_than_four_star_message">Har du en idé om, hvordan vi kan gøre den bedre?</string>
 	<string name="categories">Kategorier</string>
 	<string name="history">Historik</string>
-	<string name="next_turn_then">Så</string>
 	<string name="closed">Lukket</string>
-	<string name="back_to">Tilbage til %s</string>
 	<string name="search_not_found">Desværre, jeg fandt ikke noget.</string>
 	<string name="search_not_found_query">Prøv en anden forespørgsel.</string>
-	<string name="search_not_found_map">Download kortet, som du søger i.</string>
-	<string name="search_not_found_location">Download kortet for din nuværende placering.</string>
 	<string name="search_history_title">Søgehistorik</string>
 	<string name="search_history_text">Gå hurtigt ind på seneste forespørgsel.</string>
 	<string name="clear_search">Ryd historiksøgning</string>
-	<!-- Title for settings to enable/disable showcase menu button -->
-	<string name="showcase_settings_title">Vis tilbud</string>
-	<string name="p2p_route_planning">Ruteplanlægning</string>
 	<string name="p2p_your_location">Din lokalitet</string>
-	<string name="p2p_from">Afgangssted</string>
-	<string name="p2p_to">Bestemmelsesstedet</string>
 	<string name="p2p_start">Start</string>
-	<string name="p2p_planning">Planlægger…</string>
 	<string name="p2p_from_here">Fra</string>
 	<string name="p2p_to_here">Rute til</string>
 	<string name="p2p_only_from_current">Navigation er kun tilgængelig fra din nuværende lokalitet.</string>
@@ -612,11 +380,8 @@
 	<string name="editor_hours_closed">Lukket-timer</string>
 	<string name="editor_example_values">Eksempelværdier</string>
 	<string name="editor_correct_mistake">Ret fejl</string>
-	<string name="editor_correct_mistake_message">Du har lavet en redigeringsfejl. Ret den, eller skift til enkel tilstand.</string>
 	<string name="editor_add_select_location">Sted</string>
 	<string name="editor_done_dialog_1">Du har ændret verdenskortet. Lad andre det vide! Fortæl dine venner og redigér det sammen.</string>
-	<string name="editor_done_dialog_2">Dette er din anden kortforbedring. Nu er du på en %d. plads på listen over kortredaktører. Fortæl dine venner om det.</string>
-	<string name="editor_done_dialog_3">Du har forbedret kortet, fortæl dine venner om det og redigér kortet sammen.</string>
 	<string name="share_with_friends">Del med venner</string>
 	<string name="editor_report_problem_desription_1">Beskriv problemet i detaljer, så OpenStreetMap-fællesskabet kan løse fejlen.</string>
 	<string name="editor_report_problem_desription_2">Eller gør det selv på https://www.openstreetmap.org/</string>
@@ -625,14 +390,7 @@
 	<string name="editor_report_problem_no_place_title">Stedet findes ikke</string>
 	<string name="editor_report_problem_under_construction_title">Lukket for vedligeholdelse</string>
 	<string name="editor_report_problem_duplicate_place_title">Duplikeret sted</string>
-	<string name="first_launch_congrats_title">Organic Maps er klart til brug</string>
-	<string name="first_launch_congrats_text">Søg og navigér i kort over alle verdens lande gratis.</string>
-	<string name="migrate_title">Vigtigt!</string>
-	<!-- Android uses image instead of text. -->
-	<string name="download_all">Download alle</string>
-	<string name="delete_all">Slet alle</string>
 	<string name="autodownload">Automatisk download</string>
-	<string name="disable_autodownload">Deaktiver automatisk download</string>
 	<!-- Place Page opening hours text -->
 	<string name="closed_now">Lukket nu</string>
 	<!-- Place Page opening hours text -->
@@ -641,8 +399,6 @@
 	<string name="day_off_today">Fridag i dag</string>
 	<string name="day_off">Fridag</string>
 	<string name="today">I dag</string>
-	<string name="sunrise_to_sunset">Fra solopgang til solnedgang</string>
-	<string name="sunset_to_sunrise">Fra solnedgang til solopgang</string>
 	<string name="add_opening_hours">Tilføj arbejdstid</string>
 	<string name="edit_opening_hours">Rediger arbejdstid</string>
 	<string name="no_osm_account">Ingen konto på OpenStreetMap?</string>
@@ -652,29 +408,13 @@
 	<string name="login">Log ind</string>
 	<string name="password">Adgangskode</string>
 	<string name="forgot_password">Glemt adgangskode?</string>
-	<!-- Forgot Password dialog title -->
-	<string name="restore_password">Genopret adgangskode</string>
-	<string name="enter_email_address_to_reset_password">Indtast den emailadresse du anvendte under tilmelding, så sender vi dig linket til at forny din adgangskode.</string>
-	<string name="reset_password">Nulstil adgangskode</string>
-	<string name="username">Brugernavn</string>
 	<string name="osm_account">OSM-konto</string>
 	<string name="logout">Log ud</string>
-	<string name="login_and_edit_map_motivation_message">Log ind og rediger oplysninger for objekter på kortet, så sørger vi for, at de er tilgængelige for millioner af andre brugere. Lad os sammen gøre verden bedre.</string>
 	<!-- Information text: "Last upload 11.01.2016" -->
 	<string name="last_upload">Sidste overførsel</string>
-	<!-- Motivates user to login/register, title above login buttons. -->
-	<string name="you_have_edited_your_first_object">Du har redigeret dit første objekt!</string>
 	<string name="thank_you">Mange tak</string>
-	<string name="login_with_google">Log ind med Google</string>
-	<string name="login_with_openstreetmap">Log ind med www.openstreetmap.org</string>
 	<string name="edit_place">Redigér stedet</string>
 	<string name="place_name">Navn på sted</string>
-	<!-- title above languages list cells in the editor, below editable name text field. -->
-	<string name="other_languages">Andre sprog</string>
-	<!-- small button to open list with names in different languages -->
-	<string name="show_more">Vis mere</string>
-	<!-- small button to close list with names in different languages -->
-	<string name="show_less">Vis mindre</string>
 	<string name="add_language">Tilføj et sprog</string>
 	<string name="street">Gade</string>
 	<!-- Editable House Number text field (in address block). -->
@@ -691,25 +431,16 @@
 	<string name="email_or_username">Email eller brugernavn</string>
 	<string name="phone">Telefon</string>
 	<string name="please_note">Bemærk venligst</string>
-	<string name="common_no_wifi_dialog">Ingen WiFi-forbindelse. Vil du fortsætte med mobildata?</string>
 	<string name="downloader_delete_map_dialog">Alle kortændringer vil blive slettet sammen med kortet.</string>
 	<string name="downloader_update_maps">Opdatér kort</string>
 	<string name="downloader_mwm_migration_dialog">For at oprette en rute skal du opdatere alle kort og så planlægge ruten igen.</string>
 	<string name="downloader_search_field_hint">Find kortet</string>
-	<string name="migration_update_all_button">Opdatér alle kort</string>
-	<string name="migration_delete_all_download_current_button">Download aktuelt kort og slet de gamle</string>
 	<string name="migration_download_error_dialog">Fejl ved download</string>
 	<string name="common_check_internet_connection_dialog">Tjek dine indstillinger og sørg for, din enhed er forbundet til internettet.</string>
 	<string name="downloader_no_space_title">Ikke nok plads</string>
 	<string name="downloader_no_space_message">Fjern unødvendig data</string>
-	<string name="editor_general_auth_error_dialog">Generel fejl ved login.</string>
 	<string name="editor_login_error_dialog">Login-fejl.</string>
-	<string name="editor_login_failed_dialog">Login mislykkedes</string>
-	<string name="editor_username_error_dialog">Ugyldigt brugernavn</string>
-	<string name="editor_place_edited_dialog">Du har redigeret et objekt!</string>
-	<string name="editor_login_with_osm">Login med OpenStreetMap</string>
 	<string name="editor_profile_changes">Bekræftede ændringer</string>
-	<string name="editor_profile_unsent_changes">Ikke sendt:</string>
 	<string name="editor_focus_map_on_location">Træk kortet for at vælge objektets korrekte placering.</string>
 	<string name="editor_add_select_category">Vælg kategori</string>
 	<string name="editor_add_select_category_popular_subtitle">Populær</string>
@@ -720,19 +451,14 @@
 	<string name="editor_edit_place_category_title">Kategori</string>
 	<string name="detailed_problem_description">Detaljeret beskrivelse af problemet</string>
 	<string name="editor_report_problem_other_title">Et anderledes problem</string>
-	<string name="placepage_report_problem_button">Anmeld et problem</string>
 	<string name="placepage_add_business_button">Tilføj organisationen</string>
 	<string name="whatsnew_editor_message_1">Tilføj nye steder til kortet og redigér eksisterende direkte fra app\'en.</string>
-	<string name="whatsnew_editor_message_2">* Organic Maps bruger fællesskabsdata fra OpenStreetMap.</string>
 	<string name="dialog_incorrect_feature_position">Skift lokation</string>
 	<string name="message_invalid_feature_position">Et objekt kan ikke placeres her</string>
 	<string name="login_to_make_edits_visible">Log på så andre brugere kan se ændringerne som du har foretaget.</string>
-	<string name="no_migration_during_navigation">Opdatering er ikke tilladt under navigering.</string>
 	<!-- Error dialog no space -->
 	<string name="migration_no_space_message">For at opdatere app\'en skal du bruge mere plads. Slet unødvendig data.</string>
 	<string name="editor_sharing_title">Jeg forbedrede Organic Maps kortene</string>
-	<string name="editor_comment_will_be_sent">Vi vil sende dine kommentarer til kartograferne.</string>
-	<string name="editor_unsupported_category_message">Du har tilføjet en placering i en kategori som vi ikke understøtter på nuværende tidspunkt. Den vil vises på kortet på et senere tidspunkt.</string>
 	<!-- Downloaded 10 **of** 20 <- it is that "of" -->
 	<string name="downloader_of">%1$d af %2$d</string>
 	<string name="download_over_mobile_header">Download ved brug af mobilnetværksforbindelse?</string>
@@ -750,15 +476,8 @@
 	<string name="editor_detailed_description">Dine foreslåede ændringer vil blive sendt til OpenStreetMap fællesskabet. Beskrive detaljer, som ikke kan redigeres i Organic Maps.</string>
 	<string name="editor_more_about_osm">Mere om OpenStreetMap</string>
 	<string name="editor_operator">Bruger</string>
-	<string name="editor_tag_description">Angiv firmaet, organisationen eller personen som er ansvarlig for faciliteterne.</string>
-	<string name="editor_no_local_edits_title">Du har ikke lokale ændringer</string>
-	<string name="editor_no_local_edits_description">Den viser antallet af dine foreslåede ændringer på kortet, der kun er tilgængelige på din enhed.</string>
-	<string name="editor_send_to_osm">Send til OSM</string>
-	<string name="editor_remove">Fjern</string>
-	<string name="downloader_my_maps_title">Mine kort</string>
 	<string name="downloader_no_downloaded_maps_title">Du har ikke hentet alle kort</string>
 	<string name="downloader_no_downloaded_maps_message">Download kort for at finde position og navigere offline.</string>
-	<string name="downloader_find_place_hint">Søg by eller land</string>
 	<!-- Error title that appears after certain time without location. -->
 	<string name="current_location_unknown_title">Fortsæt med at registrere din aktuelle position?</string>
 	<!-- Error that appears after certain time without location. -->
@@ -773,27 +492,10 @@
 	<string name="location_services_disabled_2">2. Tryk på Placering</string>
 	<!-- iOS Dialog for the case when the location permission is not granted -->
 	<string name="location_services_disabled_3">3. Vælg Mens app\'en bruges</string>
-	<string name="placepage_parking_surface">Overflade</string>
-	<string name="placepage_parking_multistorey">Flere etager</string>
-	<string name="placepage_parking_underground">Underjordisk</string>
-	<string name="placepage_parking_rooftop">Tagterrasse</string>
-	<string name="placepage_parking_sheds">Skure</string>
-	<string name="placepage_parking_carports">Carporte</string>
-	<string name="placepage_parking_boxes">Garagekasser</string>
-	<string name="placepage_parking_pay">Betal</string>
-	<string name="placepage_parking_free">Gratis</string>
-	<string name="placepage_parking_interval">Intervalbetaling</string>
-	<string name="placepage_entrance_number">Nr.</string>
-	<string name="placepage_entrance_type">Indgang</string>
-	<string name="placepage_flat">app.</string>
-	<string name="placepage_open_24_7">24 / 7</string>
 	<string name="meter">m</string>
 	<string name="kilometer">km</string>
-	<string name="kilometers_per_hour">km/t</string>
 	<string name="mile">mil</string>
 	<string name="foot">fod</string>
-	<string name="miles_per_hour">mph</string>
-	<string name="day">dag</string>
 	<string name="hour">time</string>
 	<string name="minute">min</string>
 	<string name="placepage_place_description">Beskrivelse</string>
@@ -803,46 +505,30 @@
 	<string name="placepage_call_button">Ring</string>
 	<string name="placepage_edit_bookmark_button">Rediger bogmærke</string>
 	<string name="placepage_bookmark_name_hint">Bogmærke</string>
-	<string name="placepage_personal_notes_hint">Personlige notater</string>
-	<string name="placepage_delete_bookmark_button">Slet bogmærke</string>
 	<string name="editor_edits_sent_message">Dine foreslåede ændringer er blevet sendt</string>
 	<string name="editor_comment_hint">Kommentar…</string>
 	<string name="editor_reset_edits_message">Nulstil alle lokale ændringer?</string>
 	<string name="editor_reset_edits_button">Nulstil</string>
 	<string name="editor_remove_place_message">Fjern en ekstra plads?</string>
 	<string name="editor_remove_place_button">Fjern</string>
-	<string name="editor_status_sending">Send…</string>
 	<string name="editor_place_doesnt_exist">Stedet eksisterer ikke</string>
 	<string name="text_more_button">…mere</string>
 	<!-- Phone number error message -->
 	<string name="error_enter_correct_phone">Indtast korrekt telefonnummer</string>
 	<string name="error_enter_correct_web">Indtast en gyldig webadresse</string>
 	<string name="error_enter_correct_email">Indtast en gyldig emailadresse</string>
-	<string name="error_enter_correct">Indtast en gyldig værdi</string>
 	<string name="refresh">Opdater</string>
-	<string name="last_update">Sidste opdatering: %s</string>
 	<string name="placepage_add_place_button">Tilføj et sted på kortet</string>
 	<!-- Displayed when saving some edits to the map to warn against publishing personal data -->
 	<string name="editor_share_to_all_dialog_title">Ønsker du at sende det til alle brugere?</string>
 	<!-- iOS Dialog before publishing the modifications to the public map. -->
 	<string name="editor_share_to_all_dialog_message_1">Sørg for at du ikke indtastede personlige oplysninger.</string>
 	<string name="editor_share_to_all_dialog_message_2">Vi vil kigge på ændringerne. Hvis vi har spørgsmål, vil vi kontakte dig via email.</string>
-	<string name="navigation_overview_button">oversigt</string>
-	<string name="navigation_stop_button">stop</string>
-	<!-- Text on an empty bookmark page -->
-	<string name="bookmarks_empty_title">Gem bogmærker</string>
-	<string name="bookmarks_empty_message_1">Tryk på ★ for at gemme foretrukne steder til hurtig adgang.</string>
-	<string name="bookmarks_empty_message_2">Importer bogmærker fra email og web.</string>
-	<string name="bookmarks_empty_message_3">tjek ud: %s</string>
-	<!-- Name of the group for booked hotels -->
-	<string name="bookmarks_group_name">Bookede hoteller</string>
-	<string name="place_page_button_read_descriprion">Læs</string>
 	<!-- iOS dialog for the case when recent track recording is on and the app comes back from background -->
 	<string name="recent_track_background_dialog_title">Vil du deaktivere gemningen af din seneste rejserute?</string>
 	<string name="off_recent_track_background_button">Deaktiver</string>
 	<!-- For sharing via SMS and so on -->
 	<string name="sharing_call_action_look">Tjek</string>
-	<string name="continue_recent_track_background_button">Fortsæt</string>
 	<string name="recent_track_background_dialog_message">Organic Maps anvender din geoposition i baggrunden til at gemme din seneste rejserute.</string>
 	<!-- Rate on Google Play (Android only) -->
 	<string name="rate_gp">Bedøm på Google Play</string>
@@ -852,21 +538,11 @@
 	<string name="tell_friends_text">Hej! Installer Organic Maps!</string>
 	<!-- About short text (below logo) -->
 	<string name="about_description">Organic Maps er en essentiel offline-app for rejsende. Organic Maps er baseret på data fra OpenStreetMap, og gør det muligt at redigere disse data.</string>
-	<!-- Text in menu -->
-	<string name="blog">Blog</string>
 	<string name="general_settings">Generelle indstillinger</string>
-	<string name="date">Dato %d</string>
-	<!-- "Report a bug" -> "Generaal Feedback" -> "Something is not working" -->
-	<string name="something_is_not_working">Der er noget der ikke fungerer</string>
 	<!-- For the first routing -->
 	<string name="accept">Accepter</string>
 	<!-- For the first routing -->
 	<string name="decline">Afvis</string>
-	<string name="install_app">Installer</string>
-	<string name="search_no_results_title">Ingen resultater fundet</string>
-	<string name="search_no_results_message">Prøv et mere generelt søgeudtryk, zoom ud eller nulstil filteret.</string>
-	<string name="search_no_results_expand_area_button">Zoom ud</string>
-	<string name="search_no_results_reset_button">Nulstil Filter</string>
 	<!-- noun -->
 	<string name="search_in_table">Liste</string>
 	<string name="mobile_data_dialog">Skal mobilt internet bruges til at vise detaljerede oplysninger?</string>
@@ -878,18 +554,13 @@
 	<string name="mobile_data_option_never">Brug aldrig</string>
 	<string name="mobile_data_option_ask">Spørg altid</string>
 	<string name="traffic_update_maps_text">Kortet opdateres for kunne vise trafikdata.</string>
-	<string name="traffic_outdated">Trafikdata er forældede.</string>
 	<string name="big_font">Forøg skriftstørrelsen på kortet</string>
 	<string name="traffic_update_app">Opdater Organic Maps</string>
 	<!-- "traffic" as in road congestion -->
 	<string name="traffic_update_app_message">Appen skal opdateres for at kunne vise trafikdata.</string>
 	<!-- "traffic" as in "road congestion" -->
 	<string name="traffic_data_unavailable">Trafikdata er ikke tilgængelige</string>
-	<!-- Simplified colour scheme for traffic information, fewer colours are used to display traffic jams on the map. The string should be kept as short as possible -->
-	<string name="pref_traffic_simplified_colors_title">Forenklede trafikfarver</string>
 	<string name="enable_logging">Aktiver logføring</string>
-	<string name="offline_place_page_more_information">Opret forbindelse til internettet for at få flere oplysninger om stedet.</string>
-	<string name="failed_load_information">Kunne ikke indlæse oplysningerne.</string>
 	<!-- Settings: "Send general feedback" button -->
 	<string name="feedback_general">Generel feedback</string>
 	<string name="on">Til</string>
@@ -903,57 +574,26 @@
 	<string name="routing_add_start_point">Tilføj startpunkt for at planlægge en rute</string>
 	<string name="routing_add_finish_point">Tilføj slutpunkt for at planlægge en rute</string>
 	<string name="button_exit">Afslut</string>
-	<string name="settings_device_memory">Enhedens hukommelse</string>
-	<string name="settings_card_memory">Kortets hukommelse</string>
-	<string name="settings_storage_available">%s tilgængelig</string>
-	<string name="toast_location_permission_denied">App-position tilladelse nægtet</string>
-	<string name="button_use">Brug</string>
 	<string name="planning_route_manage_route">Administrer rute</string>
 	<string name="button_plan">Planlæg</string>
-	<string name="button_add">Tilføj</string>
 	<string name="placepage_remove_stop">Fjern</string>
 	<string name="planning_route_remove_title">Træk herhen for at fjerne</string>
-	<string name="dialog_change_start_point_message">Flyt startpunktet til den aktuelle placering?</string>
-	<string name="button_replace">Flyt</string>
 	<string name="placepage_add_stop">Tilføj stop</string>
-	<string name="add_my_position">Tilføj min position</string>
-	<string name="choose_start_point">Vælg et udgangspunkt</string>
-	<string name="choose_destination">Vælg en destination</string>
 	<string name="preloader_viator_button">Flere oplysninger</string>
-	<string name="start_from_my_position">Start fra</string>
-	<string name="profile_authorization_title">Log ind med</string>
-	<string name="profile_authorization_message">Nemt login på et par sekunder uden brugernavn og adgangskode</string>
 	<string name="profile_authorization_error">Ups, der skete en fejl. Prøv at logge på igen.</string>
-	<string name="service">Service</string>
-	<string name="atmosphere">Atmosfære</string>
-	<string name="value_for_money">Værdi for pengene</string>
-	<string name="experience">Erfaring</string>
-	<string name="assortment">Udvalg</string>
-	<string name="expertise">Ekspertise</string>
-	<string name="equipment">Udstyr</string>
-	<string name="quality">Kvalitet</string>
 	<string name="dialog_error_storage_title">Problem med lageradgang</string>
 	<string name="dialog_error_storage_message">Eksternt lager er ikke tilgængeligt, formentlig er SD-kortet blevet fjernet eller beskadiget, eller filsystemet er skrivebeskyttet. Kontroller det og kontakt os på support\@organicmaps.app</string>
 	<string name="setting_emulate_bad_storage">Emulere beskadiget lager</string>
-	<string name="directions_finish">Destination</string>
-	<string name="directions_on_foot">Gå %s</string>
 	<string name="core_entrance">Indgang</string>
-	<string name="coffee">Kaffe</string>
-	<string name="cleanliness">Renlighed</string>
-	<string name="crowdedness">Trængsel</string>
 	<string name="error_enter_correct_name">Angiv et korrekt navn</string>
 	<string name="bookmarks_groups">Lister</string>
 	<string name="bookmarks_groups_hide_all">Skjul alle</string>
 	<string name="bookmarks_groups_show_all">Vis alle</string>
-	<plurals name="bookmarks_places">
-	  <item quantity="other">%d bogmærker</item>
-	</plurals>
 	<string name="bookmarks_create_new_group">Opret ny liste</string>
 	<string name="downloader_hide_screen">Skjul skærm</string>
 	<string name="downloader_percent">%1$s (%2$s af %3$s)</string>
-	<string name="downloader_process">Downloader %s...</string>
-	<string name="downloader_applying">Anvender %s...</string>
-	<string name="dialog_message_transit_not_found_connection">Planlæg en rute inden for et transitnetværk</string>
+	<string name="downloader_process">Downloader %s…</string>
+	<string name="downloader_applying">Anvender %s…</string>
 	<string name="bookmarks_error_message_share_general">Ikke i stand til at dele på grund af en programfejl</string>
 	<string name="bookmarks_error_title_share_empty">Delingsfejl</string>
 	<string name="bookmarks_error_message_share_empty">Kan ikke dele en tom liste</string>
@@ -962,12 +602,7 @@
 	<string name="bookmarks_new_list_hint">Ny liste</string>
 	<string name="bookmarks_error_title_list_name_already_taken">Dette navn er allerede taget</string>
 	<string name="bookmarks_error_message_list_name_already_taken">Vælg venligst et andet navn</string>
-	<string name="bookmarks_error_title_list_name_too_long">Dette navn er for langt</string>
-	<string name="bookmarks_error_message_list_name_too_long">Vælg venligst et andet navn</string>
-	<string name="please_wait">Vent venligst...</string>
-	<string name="phone_number">Telefonnummer</string>
-	<string name="notification_unsent_reviews_title">Du har flere usendte anmeldelser</string>
-	<string name="notification_unsent_reviews_message">Venligst log ind for at dele anmeldelser med andre rejsende</string>
+	<string name="please_wait">Vent venligst…</string>
 	<string name="profile">OpenStreetMap profil</string>
 	<string name="place_page_search_similar_hotel">Søg lignende hoteller</string>
 	<string name="bookmarks_detect_title">Nye filer registreret</string>
@@ -978,31 +613,10 @@
 	<string name="button_convert">Konvertere</string>
 	<string name="bookmarks_convert_error_title">Fejl</string>
 	<string name="bookmarks_convert_error_message">Nogle filer blev ikke konverteret.</string>
-	<string name="converting">Konvertering...</string>
-	<string name="wn_reinvented_bookmarks_title">Vi genopfandt bogmærker!</string>
-	<string name="wn_reinvented_bookmarks_message">Du kan sikkerhedskopiere bogmærker, oprette lister... Det er fantastisk...</string>
-	<string name="bookmarks_restore">Gendan bogmærker</string>
-	<string name="bookmarks_restore_process">Gendannelse...</string>
 	<string name="bookmarks_restore_title">Gendan denne version?</string>
-	<string name="bookmarks_restore_message">Dine bogmærker gendannes fra %1$s (%2$s)</string>
-	<string name="bookmarks_restore_empty_title">Du har ikke en sikkerhedskopi</string>
-	<string name="bookmarks_restore_empty_message">Serveren fandt ikke tidligere sikkerhedskopier</string>
 	<string name="common_check_internet_connection_dialog_title">Ingen internetforbindelse</string>
-	<string name="error_server_title">Server Fejl</string>
-	<string name="error_server_message">Der opstod en fejl på serveren, prøv igen senere</string>
 	<string name="error_system_message">Der opstod en ukendt fejl</string>
 	<string name="restore">Gendan</string>
-	<string name="bookmarks_page_downloaded">Downloadet</string>
-	<string name="bookmarks_page_my">Mine</string>
-	<string name="routes_and_bookmarks">Ruter og bogmærker</string>
-	<string name="bookmarks_webview_success_toast">Bogmærker er downloadet</string>
-	<string name="cached_bookmarks_placeholder_title">Download nye steder</string>
-	<string name="cached_bookmarks_placeholder_subtitle">Tryk på knappen for at downloade tusindvis af interessanter steder og ruter oprettet af brugerne på Organic Maps. Du skal bruge en internetforbindelse.</string>
-	<string name="downloader_download_routers">Download bogmærker</string>
-	<string name="bookmarks_groups_cached">Downloadede lister</string>
-	<plurals name="bookmarks_objects">
-	  <item quantity="other">%s objekt</item>
-	</plurals>
 	<plurals name="objects">
 	  <item quantity="other">%d sted</item>
 	</plurals>
@@ -1015,62 +629,32 @@
 	<string name="subtittle_opt_out">Tracking-indstillinger</string>
 	<string name="crash_reports">Nedbrudsrapport</string>
 	<string name="crash_reports_description">Vi kan anvende dine data til at forbedre brugeroplevelsen på Organic Maps. Ændringerne træder i kraft, når du har genstartet appen.</string>
-	<string name="opt_out_help_ios_1">Din mobilenhed kan indeholde en »Begræns reklamesporing« eller »Afmeld Tilpasset annoncering« indstiling.</string>
-	<string name="opt_out_help_ios_2">iOS 9 eller højere</string>
-	<string name="opt_out_help_ios_3">Gå til Indstillinger → Generelt → Begræsninger → Reklamer → Aktiver »Begræns reklamesporing« funktionen</string>
-	<string name="opt_out_help_android">Din mobilenhed kan indeholde en »Begræns reklamesporing« eller »Afmeld Tilpasset annoncering« indstilling.\n\nPå Android og Google Play Services version 4.0 og op:\nIndstillinger → Google → Annoncer→ Afmeld Tilpasset annoncering\nor\nIndstillinger → Google → Google Account → Data og tilpasning → Annoncetilpasning → Annoncetilpasning</string>
 	<string name="privacy_policy">Privatlivspolitik</string>
 	<string name="terms_of_use">Vilkår for bruger</string>
-	<string name="backup_notification_failed">Backup af dine bogmærker er blevet suspenderet. Log ind for at slå til igen.</string>
 	<string name="button_layer_traffic">Trafik</string>
 	<string name="button_layer_subway">Undergrundsbane</string>
 	<string name="layers_title">Kortlag</string>
-	<string name="layers_message">Brug kortlag til at vise trafik, kort over undergrundbaner og andre nyttige oplysninger</string>
-	<string name="button_layer_got_it">Ok</string>
 	<string name="subway_data_unavailable">Kort over undergrundsbaner er ikke tilgængeligt</string>
 	<string name="bookmarks_empty_list_title">Listen er tom</string>
 	<string name="bookmarks_empty_list_message">For at tilføje et bogmærke, så tryk et sted på kort og så på stjerneikonet</string>
 	<string name="category_desc_more">…mere</string>
 	<string name="title_error_downloading_bookmarks">Der er opstået en fejl</string>
-	<string name="subtitle_error_downloading_bookmarks">Bogmærker er ikke blevet downloadet</string>
-	<string name="error_already_downloaded">Denne liste er allerede blevet downloadet</string>
-	<string name="why_support">Hvorfor støtte Organic Maps?</string>
-	<string name="why_support_item2">Du hjælper os med at forbedre Organic Maps</string>
-	<string name="why_support_item3">Du hjælper os med at forbedre de åbne kort på OpenStreetMap.org</string>
-	<string name="channels_map_update">Kortopdateringer</string>
-	<string name="server_unavailable_title">Server er utilgængelig</string>
-	<string name="sharing_options">Deling</string>
 	<string name="export_file">Eksporter fil</string>
 	<string name="list_settings">Listeindstillinger</string>
 	<string name="delete_list">Slet liste</string>
-	<string name="hide_from_map">Skjul på kort</string>
 	<string name="public_access">Offentlig adgang</string>
 	<string name="limited_access">Begrænset adgang</string>
 	<string name="bookmark_category_name">Kategori</string>
 	<string name="bookmark_category_description_hint">Lav en beskrivelse (tekst eller html)</string>
 	<string name="not_shared">Privat</string>
-	<string name="direct_link_progress_text">Uploader din fil…</string>
-	<string name="direct_link_success">Linket er blevet oprettet</string>
-	<string name="send_a_link_btn">Send mig et link</string>
-	<string name="upload_error_toast">Der skete en fejl under upload af filen</string>
 	<string name="tags_loading_error_subtitle">Der skete en fejl under hentning af tags, prøv igen</string>
-	<string name="unable_upload_errorr_title">Upload af fil fejlede</string>
-	<string name="unable_upload_error_subtitle_edited">Denne fil er redigeret ved hjælp af web-appen</string>
-	<string name="unable_upload_error_subtitle_broken">Denne fil er beskadiget og kunne ikke uploades. Upload venligst en anden fil.</string>
-	<string name="contact">Kontakt</string>
-	<string name="download_button">Download</string>
 	<string name="speedcams_alert_title">Fartkameraer</string>
-	<string name="speedcams_alert_subtitle">Advar om hastighedsgrænser</string>
 	<string name="speedcam_option_auto">Auto</string>
 	<string name="speedcam_option_always">Altid</string>
 	<string name="speedcam_option_never">Aldrig</string>
-	<string name="bookmark_description_title">Beskrivelse af bogmærke</string>
 	<string name="place_description_title">Beskrivelse af sted</string>
 	<!-- this text will be shown in application notification preferences opposite checkbox which enable/disable downloader notifications. Devices on Android 8+ are affected. -->
 	<string name="notification_channel_downloader">Korthenter</string>
-	<string name="share_bookmarks_email_body_link">Hej!\n\nHer er et link, hvor du kan hente dine bogmærker: %s. Åben listen via Organic Maps og nyd turen!\n\nHent applikation: https://omaps.app/get?kmz</string>
-	<string name="warning_speedcams_title">Navigator advarer dig om kameraer, når du overskrider hastighedsgrænsen på %d km/t</string>
-	<string name="warning_speedcams_subtitle">Vær opmærksom på færdselsreglerne i det land, du rejser til.</string>
 	<string name="speedcams_notice_message">Auto - Advar om fartkameraer, hvis der er en risiko for, at hastighedsgrænsen overskrides\nAltid - Advar altid om fartkameraer\nAldrig - Advar aldrig om fartkameraer</string>
 	<string name="power_managment_title">Strømsparetilstand</string>
 	<string name="power_managment_description">Når automatisk tilstand er valgt, begynder applikationen at deaktivere funktioner, med højt batteri-strømforbrug, afhængigt af det aktuelle batteriniveau</string>
@@ -1078,14 +662,7 @@
 	<string name="power_managment_setting_auto">Automatisk</string>
 	<string name="power_managment_setting_manual_max">Maksimum strømbesparelse</string>
 	<string name="enable_logging_warning_message">Indstillingen aktiverer logning til diagnostiske formål. Det kan være nyttigt for vores supportere, der fejlfinder problemer med appen. Aktiver kun denne mulighed på anmodning fra Organic Maps support.</string>
-	<string name="html_error_upload_message_try_again">Kontroller dine netværksindstillinger, og prøv igen</string>
-	<string name="html_error_upload_title_try_again">Ingen internetforbindelse</string>
-	<string name="notification_leave_review_v2_android_short_title">Anmeld og hjælpe rejsende!</string>
-	<string name="notifications_illegal_alert_disable_button">Slå fra meddelelser</string>
 	<string name="access_rules_author_only">Online redigering</string>
-	<string name="privacy_settings_menu">Indstillinger for beskyttelse af personlige oplysninger</string>
-	<string name="unable_upadate_error_title">Fil opdatering fejlede</string>
-	<string name="unable_upadate_error_message">Der opstod nogle fejl under opdatering. Kontroller ændringerne, og prøv igen</string>
 	<string name="driving_options_title">Køre muligheder</string>
 	<string name="driving_options_subheader">Undgå på enhver rute</string>
 	<string name="avoid_tolls">Betalingsveje</string>
@@ -1096,52 +673,14 @@
 	<string name="unable_to_calc_alert_subtitle">Desværre kunne vi ikke finde en rute med den aktuelle opsætning. Ændre opsætningen, og prøv igen</string>
 	<string name="define_to_avoid_btn">Definer veje du vil undgå</string>
 	<string name="change_driving_options_btn">Køre muligheder aktiveret</string>
-	<string name="toll_road">Betalingsvej</string>
-	<string name="unpaved_road">Grusvej</string>
-	<string name="ferry_crossing">Færgeoverfart</string>
-	<string name="operated_by">Drives af \"%s\"</string>
 	<string name="avoid_toll_roads_placepage">Undgå betalingsveje</string>
 	<string name="avoid_unpaved_roads_placepage">Undgå grusveje</string>
 	<string name="avoid_ferry_crossing_placepage">Undgå færgeoverfarter</string>
-	<string name="type.cuisine.uzbek">Usbekisk køkken</string>
-	<string name="trip_start">Lad os komme i gang</string>
-	<string name="pick_destination">Destination</string>
-	<string name="follow_my_position">Centrer igen</string>
-	<string name="search_results">Søgeresultater</string>
-	<string name="then_turn">Derefter</string>
-	<string name="redirect_route_alert">Vil du genopbygge en rute igen?</string>
-	<string name="redirect_route_yes">Ja</string>
-	<string name="redirect_route_no">Nej</string>
-	<string name="trip_finished">Du er ankommet!</string>
-	<string name="keyboard_availability_alert">Keyboard er ikke tilgængelig under kørsel</string>
-	<string name="dialog_routing_change_start_carplay">Det er ikke muligt at beregne rute fra din nuværende position</string>
-	<string name="dialog_routing_change_end_carplay">Det er ikke muligt at beregne rute til din destination. Vælg en anden destination</string>
-	<string name="dialog_routing_check_gps_carplay">Intet GPS signal. Flyt til et område med dækning</string>
-	<string name="dialog_routing_unable_locate_route_carplay">Det er ikke muligt at beregne rute. Vælg andre forbindelses-punkter for ruten</string>
-	<string name="dialog_routing_download_files_carplay">Download manglende kort til din enhed, for at lave ruten</string>
-	<string name="dialog_routing_system_error_carplay">Der opstod en fejl. Genstart programmet</string>
-	<string name="dialog_routing_rebuild_from_current_location_carplay">Rute vil blive beregnet igen, ud fra din nuværende position</string>
-	<string name="dialog_routing_rebuild_for_vehicle_carplay">Rute vil blive ændret til en kørselsrute</string>
 	<string name="ok">Ok</string>
-	<string name="avoid_unpaved_carplay_1">Ingen grus</string>
-	<string name="avoid_unpaved_carplay_2">Undgå grus</string>
-	<string name="avoid_ferry_carplay_1">Ingen færger</string>
-	<string name="avoid_ferry_carplay_2">Undgå færger</string>
-	<string name="avoid_tolls_carplay_1">Ingen betal.</string>
-	<string name="avoid_tolls_carplay_2">Undgå betaling</string>
-	<string name="speedcams_alert_title_carplay_1">Radarkontrol</string>
-	<string name="speedcams_alert_title_carplay_2">Radar advarsel</string>
-	<string name="download_map_carplay">Download kort i Organic Maps appen, på din enhed</string>
-	<string name="carplay_roundabout_exit">%s exit</string>
 	<!-- max. 10 symbols, both iOS and Android -->
 	<string name="sort">Sort…</string>
 	<!-- Android, title, max 20-22 symbols -->
 	<string name="sort_bookmarks">Sort (bookmaarks)</string>
-	<!-- iOS -->
-	<string name="sort_default">Sortér (std)</string>
-	<string name="sort_type">Sort (type)</string>
-	<string name="sort_distance">Sort (Afs)</string>
-	<string name="sort_date">Sort (dato)</string>
 	<!-- Android -->
 	<string name="by_default">Som standard</string>
 	<!-- Android -->
@@ -1150,65 +689,23 @@
 	<string name="by_distance">Efter afstand</string>
 	<!-- Android -->
 	<string name="by_date">Efter dato</string>
-	<string name="week_ago_sorttype">En uge siden</string>
-	<string name="month_ago_sorttype">En måned siden</string>
-	<string name="moremonth_ago_sorttype">Mere end en måned siden</string>
-	<string name="moreyear_ago_sorttype">Mere end et år siden</string>
-	<string name="near_me_sorttype">I nærheden</string>
-	<string name="others_sorttype">Andre</string>
-	<string name="food_places">Mad</string>
-	<string name="tourist_places">Seværdigheder</string>
-	<string name="museums">Museer</string>
-	<string name="parks">Parker</string>
-	<string name="swim_places">Svøm</string>
-	<string name="mountains">Bjerge</string>
-	<string name="animals">Dyr</string>
-	<string name="hotels">Hoteller</string>
-	<string name="buildings">Bygninger</string>
-	<string name="money">Penge</string>
-	<string name="shops">Butikker</string>
-	<string name="parkings">Parkering</string>
-	<string name="fuel_places">Benzintankstationer</string>
-	<string name="water">Vand</string>
-	<string name="medicine">Medicin</string>
 	<string name="search_in_the_list">Søg i listen</string>
-	<string name="view_on_map_bookmarks">På kort</string>
-	<string name="more_bookmarks">Mere…</string>
-	<string name="no_items_found">Der blev ikke fundet nogen elementer</string>
-	<!-- Android, max 18 symbols -->
-	<string name="bookmarks_edit_list">Redigér liste</string>
-	<!-- Android, max 18 symbols -->
-	<string name="bookmarks_delete_list">Slet liste</string>
-	<string name="religious_places">Religiøse steder</string>
 	<string name="select_list">Væg liste</string>
 	<string name="transit_not_found">Metro-navigation er endnu ikke tilgængelig i denne region</string>
 	<string name="dialog_pedestrian_route_is_long_header">Metro-rute blev ikke fundet</string>
 	<string name="dialog_pedestrian_route_is_long_message">Vælg venligst et start- eller stoppunkt, tættere på metrostationen</string>
-	<!-- Failed planning SUBWAY route message in navigation view -->
-	<string name="routing_planning_error_subway_special">Planlægning af metro-rute mislykkedes</string>
 	<string name="button_layer_isolines">Terræn</string>
-	<string name="tips_map_layers_title_countour">Nyt på Organic Maps: offline topografiske lag!</string>
-	<string name="tips_map_layers_message_countour">Planlæg og nyd din naturtur ved at være sikker på, at du ved alt om området</string>
 	<string name="isolines_activation_error_dialog">For at aktivere og bruge de topografiske lag, opdater venligst eller download kortet for området</string>
 	<string name="isolines_location_error_dialog">Det topografiske lag er endnu ikke tilgængeligt i dette område</string>
 	<string name="elevation_profile_diff_level">Sværhedsgrad</string>
-	<string name="elevation_profile_diff_level_easy">Let</string>
-	<string name="elevation_profile_diff_level_moderate">Middel</string>
-	<string name="elevation_profile_diff_level_hard">Svær</string>
 	<string name="elevation_profile_ascent">Stige op</string>
 	<string name="elevation_profile_descent">Stige ned</string>
 	<string name="elevation_profile_minaltitude">Min. højde</string>
 	<string name="elevation_profile_maxaltitude">Maks. højde</string>
-	<string name="elevation_profile_m">m</string>
 	<string name="elevation_profile_difficulty">Vanskelighed</string>
 	<string name="elevation_profile_distance">Afs.:</string>
-	<string name="elevation_profile_km">km</string>
 	<string name="elevation_profile_time">Tid:</string>
-	<string name="elevation_profile_hours">t.</string>
-	<string name="elevation_profile_minutes">min</string>
 	<string name="isolines_toast_zooms_1_10">Zoom ind for at udforske isolinjekort</string>
-	<string name="downloader_updating_ios">Opdaterer</string>
-	<string name="downloader_loading_ios">Downloader</string>
 	<string name="key_information_title">Central information</string>
 	<string name="enable_screen_sleep">Lad skærmen sove</string>
 	<!-- Description in preferences -->

--- a/android/res/values-de/strings.xml
+++ b/android/res/values-de/strings.xml
@@ -12,15 +12,11 @@
 	<string name="cancel_download">Herunterladen abbrechen</string>
 	<!-- Button which deletes downloaded country -->
 	<string name="delete">Löschen</string>
-	<!-- Button "do not interrupt download" if user touched actively downloading country -->
-	<string name="do_nothing">Herunterladen fortsetzen</string>
 	<string name="download_maps">Karten herunterladen</string>
 	<!-- Settings/Downloader - info for country when download fails -->
 	<string name="download_has_failed">Herunterladen fehlgeschlagen. Antippen für einen neuen Versuch.</string>
 	<!-- Settings/Downloader - info for country which started downloading -->
 	<string name="downloading">Wird heruntergeladen…</string>
-	<!-- Settings/Downloader - size string, only strings different from English should be translated -->
-	<string name="kb">kB</string>
 	<!-- Choose measurement on first launch alert - choose metric system button -->
 	<string name="kilometres">Kilometer</string>
 	<!-- Leave Review dialog - Review button -->
@@ -35,45 +31,31 @@
 	<string name="core_my_position">Mein Standort</string>
 	<!-- Update maps later/Buy pro version later button text -->
 	<string name="later">Später</string>
-	<!-- Don't show some dialog any more -->
-	<string name="never">Nie</string>
 	<!-- View and button titles for accessibility -->
 	<string name="search">Suche</string>
 	<!-- Search box placeholder text -->
 	<string name="search_map">Auf der Karte suchen</string>
-	<!-- Settings/Downloader - info for not downloaded country -->
-	<string name="touch_to_download">Antippen, um herunterzuladen</string>
 	<!-- Settings/Downloader - 3G download warning dialog confirm button -->
 	<string name="use_cellular_data">Ja</string>
 	<!-- Location services are disabled by user alert - message -->
 	<string name="location_is_disabled_long_text">Ortungsdienste sind für dieses Gerät oder die App deaktiviert. Bitte aktivieren Sie diese in den Einstellungen.</string>
-	<!-- Location Services are not available on the device alert - message -->
-	<string name="device_doesnot_support_location_services">Ihr Gerät unterstützt keine Ortungsdienste</string>
 	<!-- View and button titles for accessibility -->
 	<string name="zoom_to_country">Auf der Karte anzeigen</string>
-	<!-- Button text for the button at the center of the screen when the country is not downloaded -->
-	<string name="country_status_download">Karte herunterladen\n(^ ^)</string>
 	<!-- Button text for the button at the center of the screen when the country is not downloaded and the size should not be shown -->
 	<string name="country_status_download_without_size">Karte herunterladen</string>
-	<!-- Button text for the button at the center of the screen when the country is not downloaded -->
-	<string name="country_status_download_without_routing">Karte ohne Routenplanung\nherunterladen (^ ^)</string>
 	<!-- Message to display at the center of the screen when the country download has failed -->
 	<string name="country_status_download_failed">Herunterladen fehlgeschlagen</string>
 	<!-- Button text for the button under the country_status_download_failed message -->
 	<string name="try_again">Erneut versuchen</string>
 	<string name="about_menu_title">Über Organic Maps</string>
-	<string name="downloaded_touch_to_delete">Heruntergeladen (%s). Antippen, um zu löschen</string>
 	<string name="connection_settings">Verbindungseinstellungen</string>
-	<string name="download_mb_or_kb">Herunterladen %s</string>
 	<string name="close">Schließen</string>
 	<string name="unsupported_phone">Das Programm benötigt OpenGL, um zu funktionieren. Leider wird Ihr Gerät nicht unterstützt.</string>
 	<string name="download">Herunterladen</string>
-	<string name="external_storage_is_not_available">SD-Karte/USB-Speicher mit heruntergeladenen Karten nicht verfügbar</string>
 	<string name="disconnect_usb_cable">Bitte USB-Kabel entfernen oder Speicherkarte einsetzen, um Organic Maps zu verwenden</string>
 	<string name="not_enough_free_space_on_sdcard">Bitte zuerst Speicherplatz auf SD-Karte/USB-Speicher freigeben, um die Anwendung zu nutzen</string>
 	<string name="not_enough_memory">Nicht genügend Speicher, um die Anwendung zu starten</string>
 	<string name="download_resources">Bevor Sie starten, laden Sie die allgemeine Weltkarte auf Ihr Gerät herunter.\nEs wird %s Speicherplatz benötigt.</string>
-	<string name="getting_position">Ermittle momentane Position</string>
 	<string name="download_resources_continue">Zur Karte</string>
 	<string name="downloading_country_can_proceed">%s wird heruntergeladen. Sie können jetzt\nzur Karte weitergehen.</string>
 	<string name="download_country_ask">%s herunterladen?</string>
@@ -86,30 +68,20 @@
 	<string name="download_country_failed">%s Herunterladen fehlgeschlagen</string>
 	<!-- Add New Bookmark Set dialog title -->
 	<string name="add_new_set">Neue Gruppe hinzufügen</string>
-	<!-- Place Page - Add To Bookmarks button -->
-	<string name="add_to_bookmarks">Zu den Lesezeichen hinzufügen</string>
 	<!-- Bookmark Color dialog title -->
 	<string name="bookmark_color">Lesezeichen-Farbe</string>
 	<!-- Add Bookmark Set dialog - hint when set name is empty -->
 	<string name="bookmark_set_name">Name des Lesezeichens</string>
-	<!-- Bookmark Sets dialog title -->
-	<string name="bookmark_sets">Lesezeichenmappe</string>
 	<!-- Bookmarks - dialog title -->
 	<string name="bookmarks">Lesezeichengruppen</string>
-	<!-- Add bookmark dialog - bookmark color -->
-	<string name="color">Farbe</string>
 	<!-- Default bookmarks set name -->
 	<string name="core_my_places">Meine Orte</string>
 	<!-- Add bookmark dialog - bookmark name -->
 	<string name="name">Name</string>
 	<!-- Editor title above street and house number -->
 	<string name="address">Adresse</string>
-	<!-- Place Page - Remove Pin button -->
-	<string name="remove_pin">Stecknadel entfernen</string>
 	<!-- Add bookmark dialog - bookmark set, Bookmarks dialog - Bookmark set cell -->
 	<string name="set">Gruppe</string>
-	<!-- Text hint in Bookmarks dialog when no any bookmarks are added -->
-	<string name="bookmarks_usage_hint">Sie haben bislang noch keine Lesezeichen gesetzt.\nTippen Sie auf der Karte auf irgendeinen Punkt, um ein Lesezeichen hinzuzufügen.\nLesezeichen von anderen Quellen können ebenfalls importiert und in der Organic Maps-App angezeigt werden. KML-/KMZ-Datei mit gespeicherten Stecknadeln aus einer Email, Dropbox oder einem Weblink öffnen.</string>
 	<!-- Settings button in system menu -->
 	<string name="settings">Einstellungen</string>
 	<!-- Header of settings activity where user defines storage path -->
@@ -120,20 +92,10 @@
 	<string name="move_maps">Karten verschieben?</string>
 	<!-- Ask to wait user several minutes (some long process in modal dialog). -->
 	<string name="wait_several_minutes">Dies kann einige Minuten in Anspruch nehmen.\nBitte warten…</string>
-	<!-- Show bookmarks from this category on a map or not -->
-	<string name="visible">Sichtbar</string>
-	<!-- Toast which is displayed when GPS has been deactivated -->
-	<string name="gps_is_disabled_long_text">GPS ist deaktiviert. Bitte aktivieren Sie es in den Einstellungen.</string>
 	<!-- Measurement units title in settings activity -->
 	<string name="measurement_units">Maßeinheiten</string>
 	<!-- Detailed description of Measurement Units settings button -->
 	<string name="measurement_units_summary">Wählen Sie zwischen Kilometern und Meilen</string>
-	<!-- Do search in all sources -->
-	<string name="search_mode_all">Überall</string>
-	<!-- Do search near my position only -->
-	<string name="search_mode_nearme">In meiner Nähe</string>
-	<!-- Do search in current viewport only -->
-	<string name="search_mode_viewport">Auf dem Bildschirm</string>
 	<!-- Search category for cafes, bars, restaurants -->
 	<string name="eat">Essmöglichkeiten</string>
 	<!-- Search category for grocery stores -->
@@ -170,12 +132,8 @@
 	<string name="post">Post</string>
 	<!-- Search category -->
 	<string name="police">Polizeistation</string>
-	<!-- String in search result list, when nothing found -->
-	<string name="no_search_results_found">Keine Ergebnisse gefunden</string>
 	<!-- Notes field in Bookmarks view -->
 	<string name="description">Notizen</string>
-	<!-- Button text -->
-	<string name="share_by_email">Per Email teilen</string>
 	<!-- Email Subject when sharing bookmarks category -->
 	<string name="share_bookmarks_email_subject">Organic Maps-Lesezeichen mit Ihnen geteilt</string>
 	<!-- message title of loading file -->
@@ -188,20 +146,10 @@
 	<string name="edit">Bearbeiten</string>
 	<!-- Warning message when doing search around current position -->
 	<string name="unknown_current_position">Ihr Standort konnte noch nicht ermittelt werden</string>
-	<!-- Warning message when location country isn't downloaded during search (see also download_location_map_proposal). -->
-	<string name="download_location_country">Land Ihres derzeitigen Standorts herunterladen (%s)</string>
-	<!-- Warning message when viewport country isn't downloaded during search -->
-	<string name="download_viewport_country_to_search">Land herunterladen, in dem Sie suchen (%s)</string>
 	<!-- Alert message that we can't run Map Storage settings due to some reasons. -->
 	<string name="cant_change_this_setting">Leider sind die Einstellungen für die Kartenspeicherung deaktiviert.</string>
 	<!-- Alert message that downloading is in progress. -->
 	<string name="downloading_is_active">Das Land wird gerade heruntergeladen.</string>
-	<!-- Message that will be shown in alert view, when we ask user to leave review on App Store -->
-	<string name="appStore_message">Wir hoffen, dass Ihnen die Verwendung von Organic Maps Freude bereitet! Wenn ja, geben Sie bitte eine Bewertung oder einen Bericht für die App im App Store ab. Es dauert weniger als eine Minute, kann uns aber wirklich helfen. Danke für Ihre Unterstützung!</string>
-	<!-- No, thanks -->
-	<string name="no_thanks">Nein danke</string>
-	<!-- Share one specific bookmark using SMS, %1$@ contains om:// and %2$@ https://omaps.app link. @NOTE non-ascii symbols in the link will result in max 70 characters SMS instead of 140. -->
-	<string name="bookmark_share_sms">Siehe meine Markierung auf Organic Maps an. %1$s oder %2$s - Keine Offline-Karten installiert? Hier herunterladen: https://omaps.app/get</string>
 	<!-- Share my position using SMS, %1$@ contains om:// and %2$@ https://omaps.app link WITHOUT NAME. @NOTE non-ascii symbols in the link will result in max 70 characters SMS instead of 140. -->
 	<string name="my_position_share_sms">Schau wo ich gerade bin. Klicke auf den Link %1$s oder %2$s - Keine Offline-Karten installiert? Hier herunterladen: https://omaps.app/get</string>
 	<!-- Subject for emailed bookmark -->
@@ -210,30 +158,16 @@
 	<string name="my_position_share_email_subject">Sieh dir meinen aktuellen Standort auf der Organic Maps-Karte an</string>
 	<!-- Share my position using EMail, %1$@ is om:// and %2$@ is https://omaps.app link WITHOUT NAME -->
 	<string name="my_position_share_email">Hi,\n\nich bin gerade hier: %1$s. Klicke den Link %2$s oder %3$s, um den Ort auf der Karte anzuzeigen.\n\nVielen Dank.</string>
-	<!-- Android share by Message/SMS button text (including SMS) -->
-	<string name="share_by_message">Als Nachricht teilen</string>
 	<!-- Share button text which opens menu with more buttons, like Message, EMail, Facebook etc. -->
 	<string name="share">Teilen</string>
-	<!-- iOS share by Message button text (including SMS) -->
-	<string name="message">Nachricht</string>
 	<!-- Share by email button text, also used in editor. -->
 	<string name="email">Email</string>
-	<!-- Copy Link -->
-	<string name="copy_link">Link kopieren</string>
-	<!-- Text for the button that returns to caller application -->
-	<string name="more_info">Weitere Infos anzeigen</string>
 	<!-- Text for message when used successfully copied something -->
 	<string name="copied_to_clipboard">In die Zwischenablage kopiert: %1$s</string>
 	<!-- place preview title -->
 	<string name="info">Info</string>
 	<!-- Used for bookmark editing -->
 	<string name="done">Fertig</string>
-	<!-- Summary for preferences in MWM -->
-	<string name="yopme_pref_summary">Einstellungen für den rückseitigen Bildschirm wählen</string>
-	<!-- Title for yopme preferences in MWM -->
-	<string name="yopme_pref_title">Einstellungen für rückseitigen Bildschirm</string>
-	<!-- Hint for upper-right icon p2b -->
-	<string name="show_on_backscreen">Auf dem rückseitigen Bildschirm anzeigen</string>
 	<!-- Prints version number in About dialog -->
 	<string name="version">Version: %s</string>
 	<!-- Data version in «About» screen -->
@@ -245,11 +179,6 @@
 	<!-- Length of track in cell that describes route -->
 	<string name="length">Länge</string>
 	<string name="share_my_location">Meinen Standort teilen</string>
-	<string name="menu_search">Suche</string>
-	<!-- Settings screen: "Map" category title -->
-	<string name="prefs_group_map">Karte</string>
-	<!-- Settings screen: "Miscellaneous" category title -->
-	<string name="prefs_group_misc">Verschiedenes</string>
 	<string name="prefs_group_route">Navigation</string>
 	<string name="pref_zoom_title">Zoom-Tasten</string>
 	<string name="pref_zoom_summary">Auf dem Bildschirm anzeigen</string>
@@ -265,8 +194,6 @@
 	<string name="pref_map_3d_title">Perspektivische Ansicht</string>
 	<!-- Settings «Map» category: «3D buildings» title -->
 	<string name="pref_map_3d_buildings_title">3D-Gebäude</string>
-	<!-- Settings «Map» category: «3D buildings» summary -->
-	<string name="pref_map_3d_buildings_subtitle">Beeinträchtigt die Akkulaufzeit</string>
 	<!-- Settings «Route» category: «Tts enabled» title -->
 	<string name="pref_tts_enable_title">Sprachführung</string>
 	<!-- Settings «Route» category: «Tts language» title -->
@@ -275,7 +202,6 @@
 	<string name="pref_tts_unavailable">Nicht verfügbar</string>
 	<!-- Title for "Other" section in TTS settings. -->
 	<string name="pref_tts_other_section_title">Weitere</string>
-	<string name="pref_tts_how_to_set_up_voice">Navi-Stimme konfigurieren</string>
 	<!-- Settings «Map» category: «Record track» title -->
 	<string name="pref_track_record_title">Letzte Strecke</string>
 	<string name="pref_map_auto_zoom">Auto-Zoom</string>
@@ -286,46 +212,11 @@
 	<string name="duration_12_hours">12 Stunden</string>
 	<string name="duration_1_day">1 Tag</string>
 	<string name="recent_track_help_text">So können Sie die zurückgelegte Strecke für einen bestimmten Zeitraum aufzeichnen und auf der Karte sehen. Hinweis: Die Aktivierung dieser Funktion führt zu erhöhtem Batterieverbrauch. Die Aufzeichnung wird nach Ablauf des Zeitintervalls automatisch von der Karte entfernt.</string>
-	<string name="pref_track_ios_caption">Letzte Strecke zeigt den von Ihnen zurückgelegten Weg.</string>
-	<string name="pref_track_ios_subcaption">Bitte wählen Sie die Zeitspanne, für die die Strecke gespeichert wird.</string>
-	<string name="placepage_distance">Entfernung</string>
-	<string name="placepage_coordinates">Koordinaten</string>
-	<string name="placepage_unsorted">Unsortiert</string>
 	<string name="search_show_on_map">Auf der Karte ansehen</string>
-	<!-- Used to warn user when fixing KitKat issue -->
-	<string name="bookmark_move_fail">Wir müssen Ihre Lesezeichen in den internen Speicher verschieben, aber es steht dafür keinen Speicherplatz zur Verfügung. Bitte geben Sie Speicherplatz frei, sonst werden Ihre Lesezeichen nicht verfügbar sein.</string>
-	<!-- Used in More Apps menu -->
-	<string name="free">Kostenlos</string>
-	<!-- Used in More Apps menu -->
-	<string name="buy">Kaufen</string>
-	<!-- 1st search button-like result -->
-	<string name="search_on_map">Auf der Karte anzeigen</string>
-	<!-- toast with an error -->
-	<string name="no_route_found">Keine Route gefunden</string>
-	<!-- route title -->
-	<string name="route">Route</string>
-	<!-- category title -->
-	<string name="routes">Routen</string>
-	<!-- text of notification -->
-	<string name="download_map_notification">Laden Sie die Karte Ihres Standortes herunter</string>
-	<!-- text of notification -->
-	<string name="pro_version_is_free_today">Organic Maps heute gratis! Jetzt runterladen &amp; Ihre Freunde informieren</string>
-	<!-- Dialog for transferring maps from lite to pro. -->
-	<string name="move_lite_maps_to_pro">Wir übertragen Ihre heruntergeladenen Karten von Organic Maps Lite zu Organic Maps. Dieser Vorgang kann einige Minuten in Anspruch nehmen.</string>
-	<!-- Message to display when maps moved. -->
-	<string name="move_lite_maps_to_pro_ok">Ihre heruntergeladenen Karten wurden erfolgreich zu Organic Maps übertragen.</string>
-	<!-- Message to display when maps move failed. -->
-	<string name="move_lite_maps_to_pro_failed">Ihre Karten konnten nicht übertragen werden. Bitte löschen Sie Organic Maps Lite und laden Sie die Karten erneut herunter.</string>
-	<!-- Text in menu -->
-	<string name="settings_and_more">Einstellungen &amp; mehr</string>
 	<!-- Text in menu -->
 	<string name="website">Webseite</string>
-	<!-- Text in menu -->
-	<string name="contact_us">Kontaktieren Sie uns</string>
 	<!-- Settings: Send feedback button and dialog title -->
 	<string name="feedback">Feedback</string>
-	<!-- Text in menu -->
-	<string name="subscribe_to_news">Abonnieren Sie unsere News</string>
 	<!-- Text in menu -->
 	<string name="rate_the_app">Bewerten Sie die App</string>
 	<!-- Text in menu -->
@@ -334,12 +225,6 @@
 	<string name="copyright">Copyright</string>
 	<!-- Text in menu -->
 	<string name="report_a_bug">Fehler melden</string>
-	<!-- Email subject -->
-	<string name="subscribe_me_subject">Ich möchte gerne den Organic Maps-Newsletter abonnieren</string>
-	<!-- Email body -->
-	<string name="subscribe_me_body">Gerne möchte ich zu den Ersten gehören, die aktuelle Neuigkeiten erfahren und über neueste Aktualisierungen und Werbeangebote informiert werden. Mein Abo kann ich jederzeit kündigen.</string>
-	<!-- About text -->
-	<string name="about_text">Organic Maps bietet die schnellsten Offline-Karten aller Städte weltweit. Reisen Sie mit Vertrauen: wo immer Sie sind hilft Ihnen Organic Maps, sich auf der Karte zurecht zu finden. Finden Sie das nächstgelegene Restaurant, Hotel, Bank, Tankstelle usw. Es ist keine Internet-Verbindung erforderlich.\n\nWir arbeiten ständig an neuen Funktionen und freuen uns, von Ihnen zu hören, wie wir Organic Maps verbessern können. Wenn Sie Probleme mit der App haben, zögern Sie nicht, mit uns über support\@organicmaps.app in Verbindung zu treten. Wir reagieren auf jede Anfrage!\n\nMögen Sie Organic Maps und wollen Sie uns unterstützen? Es gibt einige einfache und absolut kostenlose Möglichkeiten:\n\n- Veröffentlichen Sie eine Bewertung auf Ihrem App-Store\n- Liken Sie unsere Facebook-Seite http://www.facebook.com/OrganicMaps\n- Oder erzählen einfach nur Ihrer Mutter, Freunden und Kollegen von Organic Maps:)\n\nDanke, dass Sie bei uns sind. Wir freuen uns sehr über Ihre Unterstützung!\n\nPS: Wir nutzen die Kartendaten von OpenStreetMap, einem Kartierungs-Projekt ähnlich Wikipedia, bei welchem Mitglieder Kartendaten erfassen. Wenn Sie sehen, dass auf der Karte etwas fehlt oder falsch ist, können Sie die Karten direkt auf https://www.openstreetmap.org korrigieren und die Änderungen erscheinen in der nächsten Version der Organic Maps-App.</string>
 	<!-- Alert text -->
 	<string name="email_error_body">Der Email-Client ist noch nicht eingerichtet worden. Konfigurieren Sie ihn bitte oder nutzen Sie eine andere Möglichkeit, uns unter %s zu erreichen.</string>
 	<!-- Alert title -->
@@ -348,137 +233,56 @@
 	<string name="pref_calibration_title">Kompass-Kalibrierung</string>
 	<!-- Search category -->
 	<string name="wifi">WLAN</string>
-	<!-- Update map suggestion -->
-	<string name="routing_map_outdated">Bitte aktualisieren Sie die Karte, um eine Route zu erstellen.</string>
-	<!-- Update maps suggestion -->
-	<string name="routing_update_maps">Die neue Version von Organic Maps ermöglicht das Erzeugen von Routen von Ihrem aktuellen Standort bis zum gewünschten Ziel. Bitte aktualisieren Sie Karten, um diese Funktion nutzen zu können.</string>
 	<!-- Update all button text -->
 	<string name="downloader_update_all_button">Alle aktualisieren</string>
 	<!-- Cancel all button text -->
 	<string name="downloader_cancel_all">Alle abbrechen</string>
 	<!-- Downloaded maps category -->
 	<string name="downloader_downloaded_subtitle">Heruntergeladen</string>
-	<!-- Downloaded maps category -->
-	<string name="downloader_available_maps">Verfügbar</string>
 	<!-- Country queued for download -->
 	<string name="downloader_queued">In der Warteschlange</string>
 	<string name="downloader_near_me_subtitle">In meiner Nähe</string>
 	<string name="downloader_status_maps">Karten</string>
 	<string name="downloader_download_all_button">Alle herunterladen</string>
 	<string name="downloader_downloading">Wird heruntergeladen:</string>
-	<string name="downloader_search_results">Gefunden</string>
-	<!-- Disclaimer message -->
-	<string name="routing_disclaimer">Beim Erstellen von Routen mit der Organic Maps-App sollten Sie Folgendes beachten:\n\n  - Vorgeschlagenen Routen können nur als Empfehlungen angesehen werden.\n - Straßenbedingungen, Verkehrsregeln und Schilder haben höhere Priorität als Navigationsratschläge.\n - Die Karte kann falsch oder veraltet sein und Routen könnten somit nicht auf die bestmögliche Weise erstellt worden sein.\n\n  Bleiben Sie auf der Straße sicher und achten Sie auf sich selbst!</string>
-	<!-- Outdated maps category -->
-	<string name="downloader_outdated_maps">Veraltet</string>
-	<!-- Up to date maps category -->
-	<string name="downloader_uptodate_maps">Aktuell</string>
 	<!-- Status of outdated country in the list -->
 	<string name="downloader_status_outdated">Aktualisieren</string>
 	<!-- Status of failed country in the list -->
 	<string name="downloader_status_failed">Fehlgeschlagen</string>
 	<!-- Displayed in a dialog that appears when a user tries to delete a map while the app is in the follow route mode -->
 	<string name="downloader_delete_map_while_routing_dialog">Um die Karte zu löschen, die Navigation unterbrechen.</string>
-	<!-- Show when user try build route, but we don't know where he -->
-	<string name="routing_failed_unknown_my_position">Der aktuelle Standort ist nicht bekannt. Bitte geben Sie den Standort ein, um eine Route zu erstellen.</string>
-	<!-- Show if use has not routing file, or InconsistentMWMandRoute -->
-	<string name="routing_failed_has_no_routing_file">Zusätzliche Daten werden zum Erstellen der Route benötigt. Mit dem Herunterladen beginnen?</string>
-	<!-- StartPointNotFound -->
-	<string name="routing_failed_start_point_not_found">Die Route kann nicht berechnet werden. Es gibt keine Straßen in der Nähe Ihres Ausgangspunkts.</string>
-	<!-- EndPointNotFound -->
-	<string name="routing_failed_dst_point_not_found">Die Route kann nicht berechnet werden. Es gibt keine Straßen in der Nähe Ihres Ziels.</string>
 	<!-- PointsInDifferentMWM -->
 	<string name="routing_failed_cross_mwm_building">Es können nur Routen erstellt werden, die vollständig in einer einzigen Karte enthalten sind.</string>
-	<!-- RouteNotFound -->
-	<string name="routing_failed_route_not_found">Es wurde keine Route zwischen dem ausgewählten Ausgangspunkt und Ziel gefunden. Bitte wählen Sie einen anderen Start- oder Endpunkt.</string>
-	<!-- InternalError -->
-	<string name="routing_failed_internal_error">Es ist ein interner Fehler aufgetreten. Bitte versuchen Sie, die Karte zu löschen und erneut herunterzuladen.</string>
-	<!-- Context menu item for downloader. -->
-	<string name="downloader_download_map_and_routing">Karte + Routenplanung herunterladen</string>
-	<!-- Context menu item for downloader. -->
-	<string name="downloader_download_routing">Routenplanung herunterladen</string>
-	<!-- Context menu item for downloader. -->
-	<string name="downloader_delete_routing">Routenplanung löschen</string>
 	<!-- Context menu item for downloader. -->
 	<string name="downloader_download_map">Karte herunterladen</string>
-	<string name="downloader_download_map_no_routing">Karte ohne Routenplanung herunterladen</string>
-	<!-- Button for routing. -->
-	<string name="routing_go">Los!</string>
 	<!-- Item status in downloader. -->
 	<string name="downloader_retry">Wiederholen</string>
-	<!-- Item in context menu. -->
-	<string name="downloader_map_and_routing">Karte + Routenplanung</string>
 	<!-- Item in context menu. -->
 	<string name="downloader_delete_map">Karte löschen</string>
 	<!-- Item in context menu. -->
 	<string name="downloader_update_map">Karte aktualisieren</string>
-	<!-- Item in context menu. -->
-	<string name="downloader_update_map_and_routing">Karte + Routenplanung aktualisieren</string>
-	<!-- Item in context menu. -->
-	<string name="downloader_map_only">Nur Karte</string>
-	<!-- Toolbar title -->
-	<string name="toolbar_application_menu">Anwendungs-Menü</string>
 	<!-- Preference text -->
 	<string name="pref_use_google_play">Nutzen Sie die Google Play-Dienste, um Ihren aktuellen Standort zu erhalten</string>
 	<!-- Text for rating dialog -->
 	<string name="rating_just_rated">Ich habe gerade Ihre App bewertet</string>
-	<!-- Text for rating dialog -->
-	<string name="rating_user_since">Ich bin Organic Maps-Nutzer seit %s</string>
-	<!-- Text for rating dialog -->
-	<string name="rating_do_like_maps">Mögen Sie Organic Maps?</string>
-	<!-- Text for rating dialog -->
-	<string name="rating_tap_star">Tippen Sie auf einen Stern, um unsere App zu bewerten.</string>
 	<!-- Text for rating dialog -->
 	<string name="rating_thanks">Vielen Dank!</string>
 	<!-- Text for rating dialog -->
 	<string name="rating_share_ideas">Teilen Sie uns Ihre Anregungen und Probleme mit, so dass wir die App für Sie verbessern können.</string>
 	<!-- Text for rating dialog -->
 	<string name="rating_send_feedback">Rückmeldung senden</string>
-	<!-- Text for g+ dialog -->
-	<string name="rating_google_plus">Klick auf G+, um deinen Freunden über die App zu erzählen.</string>
 	<!-- Text for routing error dialog -->
 	<string name="routing_download_maps_along">Karten entlang der Route herunterladen</string>
-	<!-- Text for routing error dialog -->
-	<string name="routing_download_map">Karte abrufen</string>
-	<!-- Text for routing error dialog -->
-	<string name="routing_download_map_and_routing">Laden Sie die aktualisierte Karte und Daten der Routenplanung herunter, um alle Organic Maps-Funktionen zu nutzen.</string>
-	<!-- Text for routing error dialog -->
-	<string name="routing_get_routing_data">Daten für Routenplanung abrufen</string>
-	<!-- Text for routing error dialog -->
-	<string name="routing_get_additional_data">Es sind Zusatzdaten erforderlich, um die Route ab Ihrem Standort zu erstellen.</string>
 	<!-- Text for routing error dialog -->
 	<string name="routing_requires_all_map">Zum Erstellen einer Route müssen alle Karten von Ihrem Standort bis zum Ziel heruntergeladen und aktualisiert worden sein.</string>
 	<!-- Text for routing error dialog -->
 	<string name="routing_not_enough_space">Nicht genug Speicherplatz</string>
-	<!-- Text for routing error dialog -->
-	<string name="routing_download_more_than_avail">Sie wollen %1$s MB herunterladen, der Speicherplatz reicht aber nur für %2$s MB.</string>
-	<!-- Text for routing error dialog -->
-	<string name="routing_download_roaming">Sie sind im Begriff, %s MB unter Nutzung einer mobilen Datenverbindung (mit Roaming) herunterzuladen. Dies kann je nach Anbieter Ihres mobilen Datentarifs zusätzliche Kosten verursachen.</string>
 	<!-- bookmark button text -->
 	<string name="bookmark">Lesezeichen</string>
-	<!-- map is not downloaded -->
-	<string name="not_found_map">Es gibt keine Karte für Ihren Standort</string>
 	<!-- location service disabled -->
 	<string name="enable_location_services">Aktivieren Sie bitte Ortungsdienste</string>
-	<!-- download map -->
-	<string name="download_map">Laden Sie die Karte für Ihren Standort herunter</string>
-	<!-- download map on iPhone -->
-	<string name="download_map_iphone">Laden Sie eine Karte für Ihre aktuelle Position auf Ihrem iPhone herunter</string>
-	<!-- clear pin -->
-	<string name="nearby">In der Nähe</string>
-	<!-- clear pin -->
-	<string name="clear_pin">Stecknadel löschen</string>
-	<!-- location is undefined -->
-	<string name="undefined_location">Der aktuelle Standort ist nicht definiert.</string>
-	<!-- download country of your location -->
-	<string name="download_country">Land Ihres derzeitigen Standorts herunterladen</string>
-	<!-- download failed -->
-	<string name="download_failed">Herunterladen fehlgeschlagen</string>
-	<!-- get the map -->
-	<string name="get_the_map">Karte abrufen</string>
 	<string name="save">Speichern</string>
 	<string name="edit_description_hint">Ihre Beschreibungen (Text oder HTML)</string>
-	<string name="new_group">Neue Gruppe</string>
 	<string name="create">erstellen</string>
 	<!-- red color -->
 	<string name="red">Rot</string>
@@ -496,22 +300,6 @@
 	<string name="brown">Braun</string>
 	<!-- pink color -->
 	<string name="pink">Rosa</string>
-	<!-- deep purple color -->
-	<string name="deep_purple">Dunkelpurpur</string>
-	<!-- light blue color -->
-	<string name="light_blue">Hellblau</string>
-	<!-- cyan color -->
-	<string name="cyan">Blaugrün</string>
-	<!-- teal color -->
-	<string name="teal">Smaragdgrün</string>
-	<!-- lime color -->
-	<string name="lime">Limette</string>
-	<!-- deep orange color -->
-	<string name="deep_orange">Dunkelorange</string>
-	<!-- gray color -->
-	<string name="gray">Grau</string>
-	<!-- blue gray color -->
-	<string name="blue_gray">Graublau</string>
 	<!-- Wi-Fi available -->
 	<string name="WiFi_available">Ja</string>
 
@@ -527,10 +315,8 @@
 	<string name="dialog_routing_location_turn_wifi">Bitte prüfen Sie Ihr GPS-Signal. WLAN verbessert Ihre Standortgenauigkeit.</string>
 	<string name="dialog_routing_location_turn_on">Ortungsdienste aktivieren</string>
 	<string name="dialog_routing_location_unknown_turn_on">Aktuelle GPS-Koordinaten können nicht ermittelt werden. Aktivieren Sie Ortungsdienste, um die Route zu berechnen.</string>
-	<string name="dialog_routing_location_unknown">Aktuelle GPS-Koordinaten können nicht ermittelt werden.</string>
 	<string name="dialog_routing_download_files">Erforderliche Dateien herunterladen</string>
 	<string name="dialog_routing_download_and_update_all">Laden Sie alle Karten- und Routeninformationen für den geplanten Weg herunter und aktualisieren Sie sie, um die Route zu berechnen.</string>
-	<string name="dialog_routing_routes_size">Routeninformationsdateien</string>
 	<string name="dialog_routing_unable_locate_route">Route kann nicht ermittelt werden</string>
 	<string name="dialog_routing_cant_build_route">Route kann nicht erstellt werden.</string>
 	<string name="dialog_routing_change_start_or_end">Bitte passen Sie Ihren Startpunkt oder Ihr Ziel an.</string>
@@ -545,33 +331,23 @@
 	<string name="dialog_routing_system_error">Systemfehler</string>
 	<string name="dialog_routing_application_error">Route kann wegen eines Anwendungsfehlers nicht erstellt werden.</string>
 	<string name="dialog_routing_try_again">Bitte versuchen Sie es erneut</string>
-	<string name="dialog_routing_send_error">Dieses Problem melden</string>
-	<string name="dialog_routing_if_get_cross_route">Möchten Sie eine direktere Route erstellen, die mehr als eine Karte umfasst?</string>
-	<string name="dialog_routing_cross_route_is_optimal">Es ist eine bessere Route verfügbar, die den Rand dieser Karte überschreitet.</string>
 	<string name="not_now">Nicht jetzt</string>
-	<string name="dialog_routing_build_route">Erstellen</string>
 	<string name="dialog_routing_download_and_build_cross_route">Möchten Sie die Karte herunterladen und eine bessere Route erstellen, die mehr als eine Karte umfasst?</string>
 	<string name="dialog_routing_download_cross_route">Laden Sie die Karte herunter, um eine bessere Route zu erstellen, die den Rand dieser Karte überschreitet.</string>
-	<string name="dialog_routing_cross_route_always">Diese Grenze immer überschreiten</string>
 
 	<!-- SECTION: Strings for downloading map from search -->
 	<string name="search_without_internet_advertisement">Um mit der Suche und dem Erstellen von Routen zu beginnen, laden Sie bitte die Karte herunter. Sie benötigen danach keine Internetverbindung mehr.</string>
 	<string name="search_select_map">Karte auswählen</string>
-	<string name="search_select_other_map">Eine andere Karte auswählen</string>
 	<!-- «Show» context menu -->
 	<string name="show">Anzeigen</string>
 	<!-- «Hide» context menu -->
 	<string name="hide">Ausblenden</string>
 	<!-- «Rename» context menu -->
 	<string name="rename">Umbenennen</string>
-	<!-- Bottom sheet: expand button (should be short) -->
-	<string name="bottom_sheet_more">Mehr…</string>
 	<!-- Failed planning route message in navigation view -->
 	<string name="routing_planning_error">Routenplanung fehlgeschlagen</string>
 	<!-- Arrive routing message in navigation view -->
 	<string name="routing_arrive">Ankunft: %s</string>
-	<!-- Text for routing::RouterResultCode::FileTooOld dialog. -->
-	<string name="dialog_routing_download_and_update_maps">Zum Erstellen einer Route müssen Sie alle Karten herunterladen und aktualisieren, auf der die Route liegt.</string>
 	<string name="rate_alert_title">Gefällt Ihnen die App?</string>
 	<string name="rate_alert_default_message">Danke, dass Sie Organic Maps nutzen. Bitte bewerten Sie die App. Ihre Rückmeldung hilft uns, besser zu werden.</string>
 	<string name="rate_alert_five_star_message">Hurra! Wir lieben Sie auch!</string>
@@ -579,24 +355,14 @@
 	<string name="rate_alert_less_than_four_star_message">Haben Sie eine Idee, wie wir besser werden können?</string>
 	<string name="categories">Kategorien</string>
 	<string name="history">Verlauf</string>
-	<string name="next_turn_then">Dann</string>
 	<string name="closed">Geschlossen</string>
-	<string name="back_to">Zurück zu %s</string>
 	<string name="search_not_found">Leider wurde nichts gefunden.</string>
 	<string name="search_not_found_query">Versuchen Sie bitte eine andere Suchanfrage.</string>
-	<string name="search_not_found_map">Laden Sie bitte die Karte herunter, auf der Sie suchen.</string>
-	<string name="search_not_found_location">Laden Sie die Karte Ihres aktuellen Standorts herunter.</string>
 	<string name="search_history_title">Suchverlauf</string>
 	<string name="search_history_text">Hier werden Ihre letzten Suchanfragen angezeigt.</string>
 	<string name="clear_search">Suchverlauf löschen</string>
-	<!-- Title for settings to enable/disable showcase menu button -->
-	<string name="showcase_settings_title">Angebote anzeigen</string>
-	<string name="p2p_route_planning">Routenplanung</string>
 	<string name="p2p_your_location">Ihr Standort</string>
-	<string name="p2p_from">Startpunkt</string>
-	<string name="p2p_to">Zielort</string>
 	<string name="p2p_start">Start</string>
-	<string name="p2p_planning">Route wird geplant…</string>
 	<string name="p2p_from_here">Von</string>
 	<string name="p2p_to_here">Nach</string>
 	<string name="p2p_only_from_current">Die Navigation ist nur von Ihrem aktuellen Standort verfügbar.</string>
@@ -616,11 +382,8 @@
 	<string name="editor_hours_closed">Schließzeiten</string>
 	<string name="editor_example_values">Beispiele</string>
 	<string name="editor_correct_mistake">Fehler korrigieren</string>
-	<string name="editor_correct_mistake_message">Es ist ein Bearbeitungsfehler aufgetreten. Bitte korrigieren oder zum Einfachmodus wechseln.</string>
 	<string name="editor_add_select_location">Position</string>
 	<string name="editor_done_dialog_1">Sie haben die Weltkarte geändert. Blenden Sie das nicht aus! Erzählen Sie Ihren Freunden davon und bearbeiten Sie sie zusammen.</string>
-	<string name="editor_done_dialog_2">Das ist Ihre zweite Kartenverbesserung. Sie befinden sich jetzt auf Platz %d auf der Liste der Personen, die die Karte bearbeitet haben. Erzählen Sie Ihren Freunden davon.</string>
-	<string name="editor_done_dialog_3">Sie haben die Karte verbessert, erzählen Sie Ihren Freunden davon und bearbeiten Sie die Karte zusammen.</string>
 	<string name="share_with_friends">Mit Freunden teilen</string>
 	<string name="editor_report_problem_desription_1">Bitte beschreiben Sie das Problem detailliert, damit die OpenStreeMap-Gemeinschaft den Fehler beheben kann.</string>
 	<string name="editor_report_problem_desription_2">Oder kümmern Sie sich selbst darum auf https://www.openstreetmap.org/</string>
@@ -629,14 +392,7 @@
 	<string name="editor_report_problem_no_place_title">Der Ort existiert nicht</string>
 	<string name="editor_report_problem_under_construction_title">Wegen Wartung geschlossen</string>
 	<string name="editor_report_problem_duplicate_place_title">Doppelter Ort</string>
-	<string name="first_launch_congrats_title">Organic Maps kann verwendet werden</string>
-	<string name="first_launch_congrats_text">Suche und Navigation weltweit offline verfügbar, völlig kostenfrei.</string>
-	<string name="migrate_title">Wichtig!</string>
-	<!-- Android uses image instead of text. -->
-	<string name="download_all">Alle herunterladen</string>
-	<string name="delete_all">Alle löschen</string>
 	<string name="autodownload">Automatisch herunterladen</string>
-	<string name="disable_autodownload">Automatischen Download deaktivieren</string>
 	<!-- Place Page opening hours text -->
 	<string name="closed_now">Jetzt geschlossen</string>
 	<!-- Place Page opening hours text -->
@@ -645,8 +401,6 @@
 	<string name="day_off_today">Heute geschlossen</string>
 	<string name="day_off">Geschlossen</string>
 	<string name="today">Heute</string>
-	<string name="sunrise_to_sunset">Von Sonnenauf- bis Sonnenuntergang</string>
-	<string name="sunset_to_sunrise">Von Sonnenuntergang bis Sonnenaufgang</string>
 	<string name="add_opening_hours">Geschäftszeiten hinzufügen</string>
 	<string name="edit_opening_hours">Geschäftszeiten bearbeiten</string>
 	<string name="no_osm_account">Kein Konto bei OpenStreetMap?</string>
@@ -656,29 +410,13 @@
 	<string name="login">Anmelden</string>
 	<string name="password">Passwort</string>
 	<string name="forgot_password">Passwort vergessen?</string>
-	<!-- Forgot Password dialog title -->
-	<string name="restore_password">Passwort wiederherstellen</string>
-	<string name="enter_email_address_to_reset_password">Geben Sie bitte die Email-Adresse ein, die Sie zur Registrierung verwendet haben. Wir senden Ihnen dann den Link zur Erneuerung Ihres Passworts.</string>
-	<string name="reset_password">Passwort zurücksetzen</string>
-	<string name="username">Benutzername</string>
 	<string name="osm_account">OSM Konto</string>
 	<string name="logout">Abmelden</string>
-	<string name="login_and_edit_map_motivation_message">Anmelden und Informationen zu den Objekten auf der Karte bearbeiten. Wir werden sie für Millionen von anderen Nutzern verfügbar machen. Lassen Sie uns zusammen die Welt verbessern.</string>
 	<!-- Information text: "Last upload 11.01.2016" -->
 	<string name="last_upload">Zuletzt hochgeladen</string>
-	<!-- Motivates user to login/register, title above login buttons. -->
-	<string name="you_have_edited_your_first_object">Sie haben Ihr erstes Objekt bearbeitet!</string>
 	<string name="thank_you">Danke</string>
-	<string name="login_with_google">Mit Google anmelden</string>
-	<string name="login_with_openstreetmap">Mit www.openstreetmap.org anmelden</string>
 	<string name="edit_place">Platz bearbeiten</string>
 	<string name="place_name">Name des Platzes</string>
-	<!-- title above languages list cells in the editor, below editable name text field. -->
-	<string name="other_languages">Andere Sprachen</string>
-	<!-- small button to open list with names in different languages -->
-	<string name="show_more">Mehr anzeigen</string>
-	<!-- small button to close list with names in different languages -->
-	<string name="show_less">Weniger anzeigen</string>
 	<string name="add_language">Eine Sprache hinzufügen</string>
 	<string name="street">Straße</string>
 	<!-- Editable House Number text field (in address block). -->
@@ -695,25 +433,16 @@
 	<string name="email_or_username">Email oder Benutzername</string>
 	<string name="phone">Telefon</string>
 	<string name="please_note">Bitte beachten</string>
-	<string name="common_no_wifi_dialog">Keine WLAN-Verbindung. Möchten Sie mit mobilen Daten fortfahren?</string>
 	<string name="downloader_delete_map_dialog">Alle Kartenänderungen werden zusammen mit der Karte gelöscht.</string>
 	<string name="downloader_update_maps">Karten aktualisieren</string>
 	<string name="downloader_mwm_migration_dialog">Um eine Strecke zu erstellen, müssen Sie alle Karten aktualisieren und dann die Strecken erneut planen.</string>
 	<string name="downloader_search_field_hint">Karte finden</string>
-	<string name="migration_update_all_button">Alle Karten aktualisieren</string>
-	<string name="migration_delete_all_download_current_button">Laden Sie die aktuelle Karte herunter und löschen Sie alte Karten</string>
 	<string name="migration_download_error_dialog">Fehler beim Herunterladen</string>
 	<string name="common_check_internet_connection_dialog">Bitte überprüfen Sie Ihre Einstellungen und stellen Sie sicher, dass Ihr Gerät mit dem Internet verbunden ist.</string>
 	<string name="downloader_no_space_title">Nicht genug Speicherplatz</string>
 	<string name="downloader_no_space_message">Bitte entfernen Sie unnötige Daten</string>
-	<string name="editor_general_auth_error_dialog">Allgemeiner Login-Fehler.</string>
 	<string name="editor_login_error_dialog">Login-Fehler.</string>
-	<string name="editor_login_failed_dialog">Login fehlgeschlagen</string>
-	<string name="editor_username_error_dialog">Benutzername ist ungültig</string>
-	<string name="editor_place_edited_dialog">Sie haben ein Objekt bearbeitet!</string>
-	<string name="editor_login_with_osm">Mit OpenStreetMap anmelden</string>
 	<string name="editor_profile_changes">Bestätigte Änderungen der Karte</string>
-	<string name="editor_profile_unsent_changes">Nicht gesendet:</string>
 	<string name="editor_focus_map_on_location">Ziehen Sie die Karte, um den Standort des Objektes zu korrigieren.</string>
 	<string name="editor_add_select_category">Kategorie auswählen</string>
 	<string name="editor_add_select_category_popular_subtitle">Beliebt</string>
@@ -724,19 +453,14 @@
 	<string name="editor_edit_place_category_title">Kategorie</string>
 	<string name="detailed_problem_description">Detaillierte Beschreibung eines Problems</string>
 	<string name="editor_report_problem_other_title">Ein anderes Problem</string>
-	<string name="placepage_report_problem_button">Problem melden</string>
 	<string name="placepage_add_business_button">Organisation hinzufügen</string>
 	<string name="whatsnew_editor_message_1">Fügen Sie auf der Karte einen neuen Ort hinzu und bearbeiten Sie existierende Ort direkt in der App.</string>
-	<string name="whatsnew_editor_message_2">* Organic Maps verwendet Community-Daten von OpenStreetMap.</string>
 	<string name="dialog_incorrect_feature_position">Standort wechseln</string>
 	<string name="message_invalid_feature_position">Ein Objekt kann hier nicht positioniert werden</string>
 	<string name="login_to_make_edits_visible">Melden Sie sich an, damit andere Benutzer Ihre Änderungen sehen können.</string>
-	<string name="no_migration_during_navigation">Aktualisieren ist während der Navigation verboten.</string>
 	<!-- Error dialog no space -->
 	<string name="migration_no_space_message">Zum Herunterladen benötigen Sie mehr Platz. Bitte löschen Sie unnötige Daten.</string>
 	<string name="editor_sharing_title">Ich habe die Organic Maps-Karten verbessert</string>
-	<string name="editor_comment_will_be_sent">Wir werden Ihren Kommentar an die Kartografierer weiterleiten.</string>
-	<string name="editor_unsupported_category_message">Sie haben einen Ort in einer Kategorie hinzugefügt, die wir noch nicht unterstützten. Er wird zu einem späteren Zeitpunkt auf der Karte erscheinen.</string>
 	<!-- Downloaded 10 **of** 20 <- it is that "of" -->
 	<string name="downloader_of">%1$d von %2$d</string>
 	<string name="download_over_mobile_header">Über eine Mobilfunknetzverbindung herunterladen?</string>
@@ -754,15 +478,8 @@
 	<string name="editor_detailed_description">Ihre Änderungsvorschläge für die Karte werden an OpenStreetMap gesendet: Beschreiben Sie die Details der Objekte, die Sie in Organic Maps nicht bearbeiten können.</string>
 	<string name="editor_more_about_osm">Mehr Informationen über OpenStreetMap</string>
 	<string name="editor_operator">Betreiber oder Eigentümer</string>
-	<string name="editor_tag_description">Geben Sie die Firma, die Organisation oder die Person an, die den Betrieb des Objekts gewährleistet.</string>
-	<string name="editor_no_local_edits_title">Sie haben keine lokalen Korrekturen</string>
-	<string name="editor_no_local_edits_description">Hier erscheint die Anzahl Ihrer Änderungsvorschläge für die Karte, auf die Sie bislang nur von Ihrem Gerät aus zugreifen können.</string>
-	<string name="editor_send_to_osm">An OSM senden</string>
-	<string name="editor_remove">Löschen</string>
-	<string name="downloader_my_maps_title">Meine Karten</string>
 	<string name="downloader_no_downloaded_maps_title">Keine Karten geladen</string>
 	<string name="downloader_no_downloaded_maps_message">Laden Sie die für die Suche nach Orten erforderlichen Karten und verwenden Sie die Navigation offline.</string>
-	<string name="downloader_find_place_hint">Stadt oder Land suchen</string>
 	<!-- Error title that appears after certain time without location. -->
 	<string name="current_location_unknown_title">Standortsuche fortsetzen?</string>
 	<!-- Error that appears after certain time without location. -->
@@ -777,27 +494,10 @@
 	<string name="location_services_disabled_2">2. Auf Standort tippen</string>
 	<!-- iOS Dialog for the case when the location permission is not granted -->
 	<string name="location_services_disabled_3">3. Wählen Sie „Beim Verwenden der App“</string>
-	<string name="placepage_parking_surface">Öffentlicher Parkplatz</string>
-	<string name="placepage_parking_multistorey">Tiefgarage mit mehreren Etagen</string>
-	<string name="placepage_parking_underground">Tiefgarage</string>
-	<string name="placepage_parking_rooftop">Parkdeck</string>
-	<string name="placepage_parking_sheds">Privater Carport</string>
-	<string name="placepage_parking_carports">Parkhalle</string>
-	<string name="placepage_parking_boxes">Garagenbox</string>
-	<string name="placepage_parking_pay">Gebührenpflichtig</string>
-	<string name="placepage_parking_free">Gebührenfrei</string>
-	<string name="placepage_parking_interval">Teilweise gebührenpflichtig</string>
-	<string name="placepage_entrance_number">Nr. der Einfahrt</string>
-	<string name="placepage_entrance_type">Typ der Einfahrt</string>
-	<string name="placepage_flat">Wohnung</string>
-	<string name="placepage_open_24_7">Durchgehend geöffnet</string>
 	<string name="meter">m</string>
 	<string name="kilometer">km</string>
-	<string name="kilometers_per_hour">km / h</string>
 	<string name="mile">mi</string>
 	<string name="foot">ft</string>
-	<string name="miles_per_hour">mph</string>
-	<string name="day">d</string>
 	<string name="hour">h</string>
 	<string name="minute">min</string>
 	<string name="placepage_place_description">Beschreibung</string>
@@ -807,46 +507,30 @@
 	<string name="placepage_call_button">Anruf</string>
 	<string name="placepage_edit_bookmark_button">Lesezeichen bearbeiten</string>
 	<string name="placepage_bookmark_name_hint">Name des Lesezeichens</string>
-	<string name="placepage_personal_notes_hint">Anmerkung</string>
-	<string name="placepage_delete_bookmark_button">Lesezeichen löschen</string>
 	<string name="editor_edits_sent_message">Ihre Änderungsvorschläge wurden gesendet</string>
 	<string name="editor_comment_hint">Kommentar…</string>
 	<string name="editor_reset_edits_message">Alle lokalen Korrekturen verwerfen</string>
 	<string name="editor_reset_edits_button">Verwerfen</string>
 	<string name="editor_remove_place_message">Hinzugefügtes Objekt löschen?</string>
 	<string name="editor_remove_place_button">Löschen</string>
-	<string name="editor_status_sending">Senden…</string>
 	<string name="editor_place_doesnt_exist">Dieser Ort existiert nicht</string>
 	<string name="text_more_button">…Mehr</string>
 	<!-- Phone number error message -->
 	<string name="error_enter_correct_phone">Geben Sie die richtige Telefonnummer ein</string>
 	<string name="error_enter_correct_web">Geben Sie eine gültige Internetadresse ein</string>
 	<string name="error_enter_correct_email">Geben Sie eine gültige Email-Adresse ein</string>
-	<string name="error_enter_correct">Geben Sie einen gültigen Wert ein</string>
 	<string name="refresh">Aktualisieren</string>
-	<string name="last_update">Letzte Aktualisierung: %s</string>
 	<string name="placepage_add_place_button">Einen Ort zur Karte hinzufügen</string>
 	<!-- Displayed when saving some edits to the map to warn against publishing personal data -->
 	<string name="editor_share_to_all_dialog_title">Wollen Sie sie an alle Benutzer senden?</string>
 	<!-- iOS Dialog before publishing the modifications to the public map. -->
 	<string name="editor_share_to_all_dialog_message_1">Stellen Sie sicher, dass Sie keine persönlichen Daten eingegeben haben.</string>
 	<string name="editor_share_to_all_dialog_message_2">Wir werden die Änderungen prüfen. Wenn wir Fragen haben, werden wir Sie per Email kontaktieren.</string>
-	<string name="navigation_overview_button">Überblick</string>
-	<string name="navigation_stop_button">Stop</string>
-	<!-- Text on an empty bookmark page -->
-	<string name="bookmarks_empty_title">Lesezeichen speichern</string>
-	<string name="bookmarks_empty_message_1">Tippen Sie auf ★, um Ihre Lieblingsorte für den Schnellzugriff zu speichern.</string>
-	<string name="bookmarks_empty_message_2">Lesezeichen aus Mail und Web importieren.</string>
-	<string name="bookmarks_empty_message_3">Auschecken: %s</string>
-	<!-- Name of the group for booked hotels -->
-	<string name="bookmarks_group_name">Gebuchte Hotels</string>
-	<string name="place_page_button_read_descriprion">Lesen</string>
 	<!-- iOS dialog for the case when recent track recording is on and the app comes back from background -->
 	<string name="recent_track_background_dialog_title">Aufzeichnung Ihrer kürzlich gefahrenen Route deaktivieren?</string>
 	<string name="off_recent_track_background_button">Deaktivieren</string>
 	<!-- For sharing via SMS and so on -->
 	<string name="sharing_call_action_look">Nachsehen</string>
-	<string name="continue_recent_track_background_button">Fortsetzen</string>
 	<string name="recent_track_background_dialog_message">Organic Maps verwendet Ihre Geoposition im Hintergrund, um Ihre kürzlich gefahrene Route aufzunehmen.</string>
 	<!-- Rate on Google Play (Android only) -->
 	<string name="rate_gp">Bei Google Play bewerten</string>
@@ -856,21 +540,11 @@
 	<string name="tell_friends_text">Hallo! Installiere dir Organic Maps!</string>
 	<!-- About short text (below logo) -->
 	<string name="about_description">Organic Maps ist eine wichtige Offline-App zum Reisen. Organic Maps basiert auf OpenStreetMap-Daten und ermöglicht das Bearbeiten dieser.</string>
-	<!-- Text in menu -->
-	<string name="blog">Blog</string>
 	<string name="general_settings">Allgemeine Einstellungen</string>
-	<string name="date">Datum %d</string>
-	<!-- "Report a bug" -> "Generaal Feedback" -> "Something is not working" -->
-	<string name="something_is_not_working">Etwas funktioniert nicht</string>
 	<!-- For the first routing -->
 	<string name="accept">Annehmen</string>
 	<!-- For the first routing -->
 	<string name="decline">Ablehnen</string>
-	<string name="install_app">Installieren</string>
-	<string name="search_no_results_title">Keine Ergebnisse gefunden</string>
-	<string name="search_no_results_message">Versuchen Sie es mit einem allgemeineren Suchbegriff, zoomen Sie heraus oder setzen Sie den Filter zurück.</string>
-	<string name="search_no_results_expand_area_button">Herauszoomen</string>
-	<string name="search_no_results_reset_button">Filter zurücksetzen</string>
 	<!-- noun -->
 	<string name="search_in_table">Liste</string>
 	<string name="mobile_data_dialog">Mobiles Internet verwenden, um genauere Informationen anzuzeigen?</string>
@@ -882,18 +556,13 @@
 	<string name="mobile_data_option_never">Nie verwenden</string>
 	<string name="mobile_data_option_ask">Immer fragen</string>
 	<string name="traffic_update_maps_text">Um Verkehrsdaten anzuzeigen, müssen die Karten aktualisiert werden.</string>
-	<string name="traffic_outdated">Verkehrsdaten sind veraltet.</string>
 	<string name="big_font">Schriftgröße auf der Karte erhöhen</string>
 	<string name="traffic_update_app">Bitte aktualisieren Sie Organic Maps</string>
 	<!-- "traffic" as in road congestion -->
 	<string name="traffic_update_app_message">Um Verkehrsdaten anzuzeigen, muss die Anwendung aktualisiert werden.</string>
 	<!-- "traffic" as in "road congestion" -->
 	<string name="traffic_data_unavailable">Verkehrsdaten sind nicht verfügbar</string>
-	<!-- Simplified colour scheme for traffic information, fewer colours are used to display traffic jams on the map. The string should be kept as short as possible -->
-	<string name="pref_traffic_simplified_colors_title">Vereinfachte Verkehrsfarben</string>
 	<string name="enable_logging">Protokollierung aktivieren</string>
-	<string name="offline_place_page_more_information">Stellen Sie eine Verbindung zum Internet her, um weitere Informationen über den Ort zu erhalten.</string>
-	<string name="failed_load_information">Informationen konnten nicht geladen werden.</string>
 	<!-- Settings: "Send general feedback" button -->
 	<string name="feedback_general">Allgemeines Feedback</string>
 	<string name="on">An</string>
@@ -907,57 +576,26 @@
 	<string name="routing_add_start_point">Fügen Sie einen Startpunkt hinzu, um eine Route zu planen</string>
 	<string name="routing_add_finish_point">Fügen Sie ein Ziel hinzu, um eine Route zu planen</string>
 	<string name="button_exit">Beenden</string>
-	<string name="settings_device_memory">Gerätespeicher</string>
-	<string name="settings_card_memory">Speicherkarte</string>
-	<string name="settings_storage_available">%s verfügbar</string>
-	<string name="toast_location_permission_denied">App-Zugriff auf Standort verweigert</string>
-	<string name="button_use">Nutzen</string>
 	<string name="planning_route_manage_route">Route verwalten</string>
 	<string name="button_plan">Planen</string>
-	<string name="button_add">Hinzufügen</string>
 	<string name="placepage_remove_stop">Entfernen</string>
 	<string name="planning_route_remove_title">Hierher ziehen zum Entfernen</string>
-	<string name="dialog_change_start_point_message">Startpunkt durch aktuellen Standort ersetzen?</string>
-	<string name="button_replace">Ersetzen</string>
 	<string name="placepage_add_stop">Zwischenstopp hinzufügen</string>
-	<string name="add_my_position">Meinen Standort hinzufügen</string>
-	<string name="choose_start_point">Startpunkt auswählen</string>
-	<string name="choose_destination">Ziel auswählen</string>
 	<string name="preloader_viator_button">Weitere Informationen</string>
-	<string name="start_from_my_position">Starten von</string>
-	<string name="profile_authorization_title">Anmelden mit</string>
-	<string name="profile_authorization_message">Einfaches Anmelden ohne Anmeldename und Passwort in nur wenigen Sekunden</string>
 	<string name="profile_authorization_error">Hoppla, es ist ein Fehler aufgetreten. Versuchen Sie erneut, sich anzumelden.</string>
-	<string name="service">Service</string>
-	<string name="atmosphere">Atmosphäre</string>
-	<string name="value_for_money">Preis-Leis­tungs-Ver­hält­nis</string>
-	<string name="experience">Erfahrung</string>
-	<string name="assortment">Sortiment</string>
-	<string name="expertise">Kompetenz</string>
-	<string name="equipment">Ausstattung</string>
-	<string name="quality">Qualität</string>
 	<string name="dialog_error_storage_title">Problem mit dem Zugreifen auf den Speicher</string>
 	<string name="dialog_error_storage_message">Der externe Speicher ist nicht verfügbar, möglicherweise wurde die SD-Karte entfernt oder sie ist beschädigt oder das Dateisystem ist schreibgeschützt. Überprüfen Sie das bitte und kontaktieren Sie uns unter support\@organicmaps.app</string>
 	<string name="setting_emulate_bad_storage">Fehlerhaften Speicher emulieren</string>
-	<string name="directions_finish">Ziel</string>
-	<string name="directions_on_foot">%s zu Fuß gehen</string>
 	<string name="core_entrance">Eingang</string>
-	<string name="coffee">Kaffee</string>
-	<string name="cleanliness">Sauberkeit</string>
-	<string name="crowdedness">Gedrängtheit</string>
 	<string name="error_enter_correct_name">Bitte geben Sie einen korrekten Namen ein</string>
 	<string name="bookmarks_groups">Listen</string>
 	<string name="bookmarks_groups_hide_all">Alle verbergen</string>
 	<string name="bookmarks_groups_show_all">Alle anzeigen</string>
-	<plurals name="bookmarks_places">
-	  <item quantity="other">%d Lesezeichen</item>
-	</plurals>
 	<string name="bookmarks_create_new_group">Erstelle eine neue Liste</string>
 	<string name="downloader_hide_screen">Bildschirm verbergen</string>
 	<string name="downloader_percent">%1$s (%2$s von %3$s)</string>
-	<string name="downloader_process">%s heruntergeladen...</string>
-	<string name="downloader_applying">%s anwenden...</string>
-	<string name="dialog_message_transit_not_found_connection">Eine Route innerhalb eines Transitnetzes planen</string>
+	<string name="downloader_process">%s heruntergeladen…</string>
+	<string name="downloader_applying">%s anwenden…</string>
 	<string name="bookmarks_error_message_share_general">Freigabe wegen eines Anwendungsfehlers nicht möglich</string>
 	<string name="bookmarks_error_title_share_empty">Fehler bei der Freigabe</string>
 	<string name="bookmarks_error_message_share_empty">Es kann keine leere Liste freigegeben werden</string>
@@ -966,12 +604,7 @@
 	<string name="bookmarks_new_list_hint">Neue Liste</string>
 	<string name="bookmarks_error_title_list_name_already_taken">Dieser Name ist bereits vergeben</string>
 	<string name="bookmarks_error_message_list_name_already_taken">Bitte wähle einen anderen Namen</string>
-	<string name="bookmarks_error_title_list_name_too_long">Dieser Name ist zu lang</string>
-	<string name="bookmarks_error_message_list_name_too_long">Bitte wähle einen anderen Namen</string>
-	<string name="please_wait">Warten Sie mal...</string>
-	<string name="phone_number">Telefonnummer</string>
-	<string name="notification_unsent_reviews_title">Sie haben mehrere nicht gesendete Bewertungen</string>
-	<string name="notification_unsent_reviews_message">Bitte melde dich an, um Bewertungen mit anderen Reisenden zu teilen</string>
+	<string name="please_wait">Warten Sie mal…</string>
 	<string name="profile">OpenStreetMap-Profil</string>
 	<string name="place_page_search_similar_hotel">Nach ähnlichen Hotels suchen</string>
 	<string name="bookmarks_detect_title">Neue Dateien erkannt</string>
@@ -982,31 +615,10 @@
 	<string name="button_convert">Konvertieren</string>
 	<string name="bookmarks_convert_error_title">Error</string>
 	<string name="bookmarks_convert_error_message">Einige Dateien wurden nicht konvertiert.</string>
-	<string name="converting">Konvertieren...</string>
-	<string name="wn_reinvented_bookmarks_title">Wir haben Lesezeichen neu erfunden!</string>
-	<string name="wn_reinvented_bookmarks_message">Sie können Lesezeichen sichern, Listen erstellen... Es ist erstaunlich...</string>
-	<string name="bookmarks_restore">Lesezeichen wiederherstellen</string>
-	<string name="bookmarks_restore_process">Wiederherstellen...</string>
 	<string name="bookmarks_restore_title">Diese Version wiederherstellen?</string>
-	<string name="bookmarks_restore_message">Ihre Lesezeichen werden von %1$s (%2$s) wiederhergestellt</string>
-	<string name="bookmarks_restore_empty_title">Sie haben kein Backup</string>
-	<string name="bookmarks_restore_empty_message">Der Server hat zuvor erstellte Sicherungen nicht gefunden</string>
 	<string name="common_check_internet_connection_dialog_title">Keine Internetverbindung</string>
-	<string name="error_server_title">Serverfehler</string>
-	<string name="error_server_message">Auf dem Server ist ein Fehler aufgetreten. Bitte versuchen Sie es später erneut.</string>
 	<string name="error_system_message">Ein unbekannter Fehler ist aufgetreten</string>
 	<string name="restore">Wiederherstellen</string>
-	<string name="bookmarks_page_downloaded">Geladene</string>
-	<string name="bookmarks_page_my">Meine</string>
-	<string name="routes_and_bookmarks">Routen und Markierungen</string>
-	<string name="bookmarks_webview_success_toast">Die Markierungen wurden erfolgreich hochgeladen</string>
-	<string name="cached_bookmarks_placeholder_title">Laden Sie neue Plätze hoch</string>
-	<string name="cached_bookmarks_placeholder_subtitle">Klicken Sie auf die Schaltfläche, um Tausende von interessanten Orten und Routen, die von den Anwendern von Organic Maps erstellt wurden, zu laden. Sie werden eine Internetverbindung benötigen.</string>
-	<string name="downloader_download_routers">Markierungen laden</string>
-	<string name="bookmarks_groups_cached">Heruntergeladene Listen</string>
-	<plurals name="bookmarks_objects">
-	  <item quantity="other">%s Objekt</item>
-	</plurals>
 	<plurals name="objects">
 	  <item quantity="other">%d Platz</item>
 	</plurals>
@@ -1019,62 +631,32 @@
 	<string name="subtittle_opt_out">Einstellungen der Begleitung</string>
 	<string name="crash_reports">Berichte über die Fehler</string>
 	<string name="crash_reports_description">Wir können Ihre Daten benutzen, um Organic Maps zu entwickeln und zu verbessern. Die Änderungen werden nach dem Neustart der App in Kraft treten.</string>
-	<string name="opt_out_help_ios_1">Sie können der Erhalt von gezielter Werbung in den Einstellungen des Geräts verbieten.</string>
-	<string name="opt_out_help_ios_2">iOS 9 oder höher</string>
-	<string name="opt_out_help_ios_3">Öffnen Sie die Einstellungen → Vertraulichkeit → Werbung → Schalten Sie „Tracking einschränken“ ein</string>
-	<string name="opt_out_help_android">Sie können den Erhalt von gezielter Werbung in den Geräteeinstellungen ausschalten. \nAndroid und Google Play Services 4.0 und höher\n\nTelefoneinstellungen → Google → Werbung→ Personalisierung ausschalten\noder\nTelefoneinstellungen → Google → Benutzerkonto von Google → Vertraulichkeit → Einstellungen von Werbevorzügen → Personalisierung der Werbung</string>
 	<string name="privacy_policy">Datenschutzerklärung</string>
 	<string name="terms_of_use">Nutzungsbedingungen</string>
-	<string name="backup_notification_failed">Das Reservekopieren von Markierungen wurde angehalten. Loggen Sie sich ein, um das Reservekopieren einzuschalten.</string>
 	<string name="button_layer_traffic">Staus</string>
 	<string name="button_layer_subway">U-Bahn</string>
 	<string name="layers_title">Kartenschichten</string>
-	<string name="layers_message">Schalten Sie die Schichten auf der Karte ein, um die Verkehrssituation, den U-Bahnplan oder sonstige nützlichen Informationen einzublenden</string>
-	<string name="button_layer_got_it">Alles klar</string>
 	<string name="subway_data_unavailable">Die U-Bahnkarte steht nicht zur Verfügung</string>
 	<string name="bookmarks_empty_list_title">Die Liste ist leer</string>
 	<string name="bookmarks_empty_list_message">Um eine neue Markierung hinzuzufügen, drücken Sie auf das Sternzeichen in der Karte des Objekts</string>
 	<string name="category_desc_more">…mehr</string>
 	<string name="title_error_downloading_bookmarks">Es ist ein Fehler aufgetreten</string>
-	<string name="subtitle_error_downloading_bookmarks">Die Markierungen wurden nicht geladen</string>
-	<string name="error_already_downloaded">Diese Liste wurde bereits heruntergeladen</string>
-	<string name="why_support">Warum Organic Maps unterstützen?</string>
-	<string name="why_support_item2">Sie helfen uns Organic Maps zu verbesern</string>
-	<string name="why_support_item3">Sie helfen uns die Karten OpenStreetMap.org zu verbessern</string>
-	<string name="channels_map_update">Kartenaktualisierungen</string>
-	<string name="server_unavailable_title">Server unzugänglich</string>
-	<string name="sharing_options">Zugriffseinstellungen</string>
 	<string name="export_file">Datei exportieren</string>
 	<string name="list_settings">Listeneinstellungen</string>
 	<string name="delete_list">Liste löschen</string>
-	<string name="hide_from_map">Auf der Karte ausblenden</string>
 	<string name="public_access">Öffentlicher Zugriff</string>
 	<string name="limited_access">Privater Zugriff</string>
 	<string name="bookmark_category_name">Kategorie</string>
 	<string name="bookmark_category_description_hint">Fügen Sie die Beschreibung hinzu (Text oder html)</string>
 	<string name="not_shared">Persönlich</string>
-	<string name="direct_link_progress_text">Ihre Datei wird geladen…</string>
-	<string name="direct_link_success">Link erstellt</string>
-	<string name="send_a_link_btn">Link senden</string>
-	<string name="upload_error_toast">Während des Ladeprozesses ist ein Fehler aufgetreten</string>
 	<string name="tags_loading_error_subtitle">Während dem Laden der Tags ist ein Fehler aufgetreten, bitte, versuchen Sie es erneut</string>
-	<string name="unable_upload_errorr_title">Laden der Datei fehlgeschlagen</string>
-	<string name="unable_upload_error_subtitle_edited">Datei wurde per WebApp bearbeitet</string>
-	<string name="unable_upload_error_subtitle_broken">Datei ist beschädigt und kann nicht geladen werden. Bitte laden Sie eine andere Datei.</string>
-	<string name="contact">Schreiben</string>
-	<string name="download_button">Downloaden</string>
 	<string name="speedcams_alert_title">Geschwindigkeitskameras</string>
-	<string name="speedcams_alert_subtitle">Über Geschwindigkeitsbegrenzungen warnen</string>
 	<string name="speedcam_option_auto">Auto</string>
 	<string name="speedcam_option_always">Immer</string>
 	<string name="speedcam_option_never">Niemals</string>
-	<string name="bookmark_description_title">Markierungsbeschreibung</string>
 	<string name="place_description_title">Ortsbeschreibung</string>
 	<!-- this text will be shown in application notification preferences opposite checkbox which enable/disable downloader notifications. Devices on Android 8+ are affected. -->
 	<string name="notification_channel_downloader">Karten werden geladen</string>
-	<string name="share_bookmarks_email_body_link">Guten Tag!\n\nIhre Markierungen stehen unter folgendem Link zum Download bereit: %s. Öffnen Sie die Liste mit Organic Maps und genießen Sie die Reise!\n\nApp downloaden: https://omaps.app/get?kmz</string>
-	<string name="warning_speedcams_title">Der Navigator wird Sie über Geschwindigkeitskameras bei Geschwindigkeitsüberschreitung von %d km/h informieren</string>
-	<string name="warning_speedcams_subtitle">Vergessen Sie nicht sich mit den Verkehrsregeln im Reisezielland vertraut zu machen.</string>
 	<string name="speedcams_notice_message">Auto - Über Geschwindigkeitskameras bei Risiko einer Geschwindigkeitsüberschreitung informieren\nImmer - Immer über Geschwindigkeitskameras informieren\nNiemals - Nie über Geschwindigkeitskameras informieren</string>
 	<string name="power_managment_title">Stromsparmodus</string>
 	<string name="power_managment_description">Falls der Stromsparmodus aktiviert ist, wird die App stromintensive Prozesse je nach dem aktuellen Ladezustand deaktivieren</string>
@@ -1082,14 +664,7 @@
 	<string name="power_managment_setting_auto">Auto</string>
 	<string name="power_managment_setting_manual_max">Maximale Stromsparung</string>
 	<string name="enable_logging_warning_message">Diese Option wird aktiviert, um Aktivitäten zwecks Diagnostik zu loggen. Das hilft unserem Team Probleme mit der App zu erkennen. Aktivieren Sie diese Option nur auf Ersuchen des Organic Maps-Supports.</string>
-	<string name="html_error_upload_message_try_again">Überprüfen Sie die Internetverbindung und versuchen Sie es noch einmal</string>
-	<string name="html_error_upload_title_try_again">Keine Internetverbindung</string>
-	<string name="notification_leave_review_v2_android_short_title">Hinterlassen Sie Ihr Feedback und helfen Sie damit den Reisenden!</string>
-	<string name="notifications_illegal_alert_disable_button">Benachrichtigungen deaktivieren</string>
 	<string name="access_rules_author_only">Online bearbeiten</string>
-	<string name="privacy_settings_menu">Datenschutzeinstellungen</string>
-	<string name="unable_upadate_error_title">Die Aktualisierung der Route konnte nicht durchgeführt werden</string>
-	<string name="unable_upadate_error_message">Bei der Aktualisierung sind Fehler aufgetreten. Überprüfen Sie die Änderungen und versuchen Sie es noch einmal</string>
 	<string name="driving_options_title">Einstellungen des Umweges</string>
 	<string name="driving_options_subheader">In jeder Reiseroute vermeiden</string>
 	<string name="avoid_tolls">Mautstraßen</string>
@@ -1100,52 +675,14 @@
 	<string name="unable_to_calc_alert_subtitle">Leider konnten wir keine Route mit ausgewählten Optionen planen. Ändern Sie die Einstellungen und versuchen Sie den Versuch erneut</string>
 	<string name="define_to_avoid_btn">Umwege einstellen</string>
 	<string name="change_driving_options_btn">Einstellung des Umweges aktiv</string>
-	<string name="toll_road">Mautstraße</string>
-	<string name="unpaved_road">Erdweg</string>
-	<string name="ferry_crossing">Fährstelle</string>
-	<string name="operated_by">Gesteuert \"%s\"</string>
 	<string name="avoid_toll_roads_placepage">Mautstraßen vermeiden</string>
 	<string name="avoid_unpaved_roads_placepage">Erdwege vermeiden</string>
 	<string name="avoid_ferry_crossing_placepage">Fährstellen vermeiden</string>
-	<string name="type.cuisine.uzbek">Usbekische Küche</string>
-	<string name="trip_start">Fahren wir</string>
-	<string name="pick_destination">Ziel</string>
-	<string name="follow_my_position">Zentrieren</string>
-	<string name="search_results">Suchergebnisse</string>
-	<string name="then_turn">Danach</string>
-	<string name="redirect_route_alert">Möchten Sie die Route neu erstellen?</string>
-	<string name="redirect_route_yes">Ja</string>
-	<string name="redirect_route_no">Nein</string>
-	<string name="trip_finished">Sie sind angekommen!</string>
-	<string name="keyboard_availability_alert">Die Tastatur ist während der Bewegung nicht zugänglich</string>
-	<string name="dialog_routing_change_start_carplay">Es ist unmöglich eine Reiseroute vom aktuellen Standort planen</string>
-	<string name="dialog_routing_change_end_carplay">Es ist unmöglich eine Reiseroute bis zum Endpunkt planen. Wählen Sie einen anderen</string>
-	<string name="dialog_routing_check_gps_carplay">Kein GPS-Signal. Gehen Sie in das offene Gelände</string>
-	<string name="dialog_routing_unable_locate_route_carplay">Es ist unmöglich, eine Route zu planen. Wählen Sie andere Routenpunkte</string>
-	<string name="dialog_routing_download_files_carplay">Laden Sie die fehlenden Karten hoch, um die Route zu erstellen</string>
-	<string name="dialog_routing_system_error_carplay">Fehler aufgetreten. Starten Sie Applikation neu</string>
-	<string name="dialog_routing_rebuild_from_current_location_carplay">Die Route wird von Ihrem derzeitigen Standpunkt geplant werden</string>
-	<string name="dialog_routing_rebuild_for_vehicle_carplay">Reiseroute wird zur Route für Fahrzeug geändert sein</string>
 	<string name="ok">Ok</string>
-	<string name="avoid_unpaved_carplay_1">Ohne Landstr</string>
-	<string name="avoid_unpaved_carplay_2">Ohne Landstr.</string>
-	<string name="avoid_ferry_carplay_1">Ohne Fähren</string>
-	<string name="avoid_ferry_carplay_2">Ohne Fähren</string>
-	<string name="avoid_tolls_carplay_1">Ohne kpf Str</string>
-	<string name="avoid_tolls_carplay_2">Ohne kpfl. Str.</string>
-	<string name="speedcams_alert_title_carplay_1">Blitzer</string>
-	<string name="speedcams_alert_title_carplay_2">Blitzerwarnung</string>
-	<string name="download_map_carplay">Laden Sie Karten in der App Organic Maps auf Ihrem Gerät herunter</string>
-	<string name="carplay_roundabout_exit">%s Ausfahrt</string>
 	<!-- max. 10 symbols, both iOS and Android -->
 	<string name="sort">Sortieren…</string>
 	<!-- Android, title, max 20-22 symbols -->
 	<string name="sort_bookmarks">Lesezeichen sortieren</string>
-	<!-- iOS -->
-	<string name="sort_default">Default Sortierung</string>
-	<string name="sort_type">Sortierung nach Kategorien</string>
-	<string name="sort_distance">Sortieren nach Entfernung</string>
-	<string name="sort_date">Sortieren nach Datum</string>
 	<!-- Android -->
 	<string name="by_default">Default</string>
 	<!-- Android -->
@@ -1154,65 +691,23 @@
 	<string name="by_distance">Nach Entfernung</string>
 	<!-- Android -->
 	<string name="by_date">Nach Datum</string>
-	<string name="week_ago_sorttype">Vor einer Woche</string>
-	<string name="month_ago_sorttype">Vor einem Monat</string>
-	<string name="moremonth_ago_sorttype">Vor über einem Monat</string>
-	<string name="moreyear_ago_sorttype">Vor über einem Jahr</string>
-	<string name="near_me_sorttype">In der Nähe</string>
-	<string name="others_sorttype">Sonstiges</string>
-	<string name="food_places">Essen</string>
-	<string name="tourist_places">Sehenswürdigkeiten</string>
-	<string name="museums">Museen</string>
-	<string name="parks">Parks</string>
-	<string name="swim_places">Schwimmmöglichkeiten</string>
-	<string name="mountains">Berge</string>
-	<string name="animals">Tiere</string>
-	<string name="hotels">Hotels</string>
-	<string name="buildings">Gebäude</string>
-	<string name="money">Geld</string>
-	<string name="shops">Ladengeschäfte</string>
-	<string name="parkings">Parkplätze</string>
-	<string name="fuel_places">Tankstellen</string>
-	<string name="water">Wasser</string>
-	<string name="medicine">Medizin</string>
 	<string name="search_in_the_list">In der Liste suchen</string>
-	<string name="view_on_map_bookmarks">Auf der Karte</string>
-	<string name="more_bookmarks">Mehr…</string>
-	<string name="no_items_found">Keine Einträge gefunden</string>
-	<!-- Android, max 18 symbols -->
-	<string name="bookmarks_edit_list">Korrigieren</string>
-	<!-- Android, max 18 symbols -->
-	<string name="bookmarks_delete_list">Liste löschen</string>
-	<string name="religious_places">Heilige Orte</string>
 	<string name="select_list">Wählen Sie die Liste</string>
 	<string name="transit_not_found">Die U-Bahn-Navigation ist in dieser Region noch nicht verfügbar</string>
 	<string name="dialog_pedestrian_route_is_long_header">Keine U-Bahn-Route gefunden</string>
 	<string name="dialog_pedestrian_route_is_long_message">Wählen Sie den Start- und Endpunkt der Route, die am nächsten zur U-Bahn-Station liegen</string>
-	<!-- Failed planning SUBWAY route message in navigation view -->
-	<string name="routing_planning_error_subway_special">Fehler bei der Erstellung der U-Bahn-Route</string>
 	<string name="button_layer_isolines">Terrain</string>
-	<string name="tips_map_layers_title_countour">Neu in Organic Maps: Topographie-Layer offline!</string>
-	<string name="tips_map_layers_message_countour">Der Topographie-Layer hilft Ihnen Ihre Reise in die Natur zu planen und sich in der Gegen zurechtzufinden</string>
 	<string name="isolines_activation_error_dialog">Um den Topographie-Layer benutzen zu können, aktualisieren oder laden Sie die Karte der benötigten Gegend herunter</string>
 	<string name="isolines_location_error_dialog">Topographie-Layer sind in dieser Region noch nicht verfügbar</string>
 	<string name="elevation_profile_diff_level">Komplexitätsniveau</string>
-	<string name="elevation_profile_diff_level_easy">Leicht</string>
-	<string name="elevation_profile_diff_level_moderate">Mittel</string>
-	<string name="elevation_profile_diff_level_hard">Schwer</string>
 	<string name="elevation_profile_ascent">Bergauf</string>
 	<string name="elevation_profile_descent">Bergab</string>
 	<string name="elevation_profile_minaltitude">Min. Höhe</string>
 	<string name="elevation_profile_maxaltitude">Max. Höhe</string>
-	<string name="elevation_profile_m">m</string>
 	<string name="elevation_profile_difficulty">Schwierigkeitsgrad</string>
 	<string name="elevation_profile_distance">Entf.:</string>
-	<string name="elevation_profile_km">km</string>
 	<string name="elevation_profile_time">Dauer:</string>
-	<string name="elevation_profile_hours">St.</string>
-	<string name="elevation_profile_minutes">Min</string>
 	<string name="isolines_toast_zooms_1_10">Karte vergrößern, um Isolinien zu sehen</string>
-	<string name="downloader_updating_ios">Update</string>
-	<string name="downloader_loading_ios">Download</string>
 	<string name="key_information_title">Wichtige Informationen</string>
 	<string name="enable_screen_sleep">Bildschirm schlafen lassen</string>
 	<!-- Description in preferences -->

--- a/android/res/values-el/strings.xml
+++ b/android/res/values-el/strings.xml
@@ -42,12 +42,8 @@
 	<string name="location_is_disabled_long_text">Οι υπηρεσίες εντοπισμού τοποθεσίας είναι προς το παρόν απενεργοποιημένες σε αυτή τη συσκευή ή για αυτή την εφαρμογή. Ενεργοποιήστε τις από τις Ρυθμίσεις.</string>
 	<!-- View and button titles for accessibility -->
 	<string name="zoom_to_country">Εμφάνιση στο χάρτη</string>
-	<!-- Button text for the button at the center of the screen when the country is not downloaded -->
-	<string name="country_status_download">Λήψη Χάρτη\n(^ ^)</string>
 	<!-- Button text for the button at the center of the screen when the country is not downloaded and the size should not be shown -->
 	<string name="country_status_download_without_size">Λήψη χάρτη</string>
-	<!-- Button text for the button at the center of the screen when the country is not downloaded -->
-	<string name="country_status_download_without_routing">Λήχη χάρτη\nχωρίς δρομολόγηση (^ ^)</string>
 	<!-- Message to display at the center of the screen when the country download has failed -->
 	<string name="country_status_download_failed">Η λήψη απέτυχε</string>
 	<!-- Button text for the button under the country_status_download_failed message -->
@@ -61,7 +57,6 @@
 	<string name="not_enough_free_space_on_sdcard">Ελευθερώσετε  χώρο αποθήκευσης στην SD κάρτα/USB πρώτα προκειμένου να χρησιμοποιήσετε την εφαρμογή</string>
 	<string name="not_enough_memory">Δεν υπάρχει αρκετή μνήμη για την έναρξη εφαρμογής</string>
 	<string name="download_resources">Πριν ξεκινήσετε τη χρήση της εφαρμογής, επιτρέψτε μας να κατεβάσουμε το γενικό παγκόσμιο χάρτη στη συσκευή σας. \nIt θα χρησιμοποιήσει %s αποθηκευτικού χώρου.</string>
-	<string name="getting_position">Λήψη τρέχουσας τοποθεσίας</string>
 	<string name="download_resources_continue">Μετάβαση στο χάρτη</string>
 	<string name="downloading_country_can_proceed">Λήψη %s. Μπορείτε τώρα να\nμεταβείτε στο χάρτη.</string>
 	<string name="download_country_ask">Να γίνει λήψη %s;</string>
@@ -78,8 +73,6 @@
 	<string name="bookmark_color">Χρώμα αγαπημένου</string>
 	<!-- Add Bookmark Set dialog - hint when set name is empty -->
 	<string name="bookmark_set_name">Όνομα συνόλου αγαπημένων</string>
-	<!-- Bookmark Sets dialog title -->
-	<string name="bookmark_sets">Σύνολα αγαπημένων</string>
 	<!-- Bookmarks - dialog title -->
 	<string name="bookmarks">Αγαπημένα</string>
 	<!-- Default bookmarks set name -->
@@ -90,8 +83,6 @@
 	<string name="address">Διεύθυνση</string>
 	<!-- Add bookmark dialog - bookmark set, Bookmarks dialog - Bookmark set cell -->
 	<string name="set">Σύνολο</string>
-	<!-- Text hint in Bookmarks dialog when no any bookmarks are added -->
-	<string name="bookmarks_usage_hint">Δεν έχετε αγαπημένα ακόμα.\nΠατήστε σε οποιοδήποτε σημείο στο χάρτη για να προσθέσετε αγαπημένο.\nΜπορείτε επίσης να εισάγετε αγαπημένα από άλλες πηγές και να τα εμφανίσετε στο Organic Maps. Ανοίξτε το αρχείο KML/KMZ με τα αποθηκευμένα αγαπημένα από το email, το Dropbox ή τους υπερσυνδέσμους.</string>
 	<!-- Settings button in system menu -->
 	<string name="settings">Ρυθμίσεις</string>
 	<!-- Header of settings activity where user defines storage path -->
@@ -102,8 +93,6 @@
 	<string name="move_maps">Να γίνει μετακίνηση χαρτών;</string>
 	<!-- Ask to wait user several minutes (some long process in modal dialog). -->
 	<string name="wait_several_minutes">Αυτό μπορεί να διαρκέσει αρκετά λεπτά. \nΠαρακαλώ περιμένετε…</string>
-	<!-- Show bookmarks from this category on a map or not -->
-	<string name="visible">Ορατό</string>
 	<!-- Measurement units title in settings activity -->
 	<string name="measurement_units">Μονάδες μέτρησης</string>
 	<!-- Detailed description of Measurement Units settings button -->
@@ -146,8 +135,6 @@
 	<string name="police">Αστυνομία</string>
 	<!-- Notes field in Bookmarks view -->
 	<string name="description">Σημειώσεις</string>
-	<!-- Button text -->
-	<string name="share_by_email">Κοινοποίηση μέσω ηλεκτρονικού ταχυδρομείου</string>
 	<!-- Email Subject when sharing bookmarks category -->
 	<string name="share_bookmarks_email_subject">Κοινοποιήθηκαν αγαπημένα Organic Maps με σας</string>
 	<!-- message title of loading file -->
@@ -160,14 +147,10 @@
 	<string name="edit">Επεξεργασία</string>
 	<!-- Warning message when doing search around current position -->
 	<string name="unknown_current_position">Η τοποθεσία σας δεν έχει καθοριστεί ακόμη</string>
-	<!-- Warning message when location country isn't downloaded during search (see also download_location_map_proposal). -->
-	<string name="download_location_country">Κατεβάστε τον χάρτη για την τρέχουσα τοποθεσία σας (%s)</string>
 	<!-- Alert message that we can't run Map Storage settings due to some reasons. -->
 	<string name="cant_change_this_setting">Λυπούμαστε, η αποθήκευση του χάρτη είναι προς το παρόν απενεργοποιημένη.</string>
 	<!-- Alert message that downloading is in progress. -->
 	<string name="downloading_is_active">Λήψη χάρτη σε εξέλιξη.</string>
-	<!-- Share one specific bookmark using SMS, %1$@ contains om:// and %2$@ https://omaps.app link. @NOTE non-ascii symbols in the link will result in max 70 characters SMS instead of 140. -->
-	<string name="bookmark_share_sms">Έλεγξε τις τοποθεσίες που έχω καρφιτσώσει στο Organic Maps! %1$s ή %2$s εάν δεν έχεις εγκαταστήσει χάρτες εκτός σύνδεσης, μπορείς να τους κατεβάσεις εδώ: https://omaps.app/get</string>
 	<!-- Share my position using SMS, %1$@ contains om:// and %2$@ https://omaps.app link WITHOUT NAME. @NOTE non-ascii symbols in the link will result in max 70 characters SMS instead of 140. -->
 	<string name="my_position_share_sms">Έλεγξε την τρέχουσα τοποθεσία μου στο Organic Maps! %1$s ή %2$s στην περίπτωση που δεν έχεις εγκαταστήσει χάρτες εκτός σύνδεσης, μπορείς να τους κατεβάσεις εδώ: https://omaps.app/get</string>
 	<!-- Subject for emailed bookmark -->
@@ -176,8 +159,6 @@
 	<string name="my_position_share_email_subject">Έλεγξε την τρέχουσα τοποθεσία μου στο χάρτη Organic Maps!</string>
 	<!-- Share my position using EMail, %1$@ is om:// and %2$@ is https://omaps.app link WITHOUT NAME -->
 	<string name="my_position_share_email">Γεια,\n\nείμαι εδώ τώρα: %1$s. Κάνε κλικ σε αυτό το σύνδεσμο %2$s ή σε αυτόν %3$s για να δεις την τοποθεσία στο χάρτη.\n\nΕυχαριστώ.</string>
-	<!-- Android share by Message/SMS button text (including SMS) -->
-	<string name="share_by_message">Κοινοποίηση μέσω μηνύματος</string>
 	<!-- Share button text which opens menu with more buttons, like Message, EMail, Facebook etc. -->
 	<string name="share">Κοινοποίηση</string>
 	<!-- Share by email button text, also used in editor. -->
@@ -199,10 +180,6 @@
 	<!-- Length of track in cell that describes route -->
 	<string name="length">Μήκος</string>
 	<string name="share_my_location">Κοινοποίηση της τοποθεσίας μου</string>
-	<!-- Settings screen: "Map" category title -->
-	<string name="prefs_group_map">Χάρτης</string>
-	<!-- Settings screen: "Miscellaneous" category title -->
-	<string name="prefs_group_misc">Διάφορα</string>
 	<string name="prefs_group_route">Πλοήγηση</string>
 	<string name="pref_zoom_title">Πλήκτρα μεγέθυνσης</string>
 	<string name="pref_zoom_summary">Εμφάνιση στο χάρτη</string>
@@ -226,7 +203,6 @@
 	<string name="pref_tts_unavailable">Δεν είναι διαθέσιμη</string>
 	<!-- Title for "Other" section in TTS settings. -->
 	<string name="pref_tts_other_section_title">Άλλα</string>
-	<string name="pref_tts_how_to_set_up_voice">Ρύθμιση φωνής</string>
 	<!-- Settings «Map» category: «Record track» title -->
 	<string name="pref_track_record_title">Πρόσφατη διαδρομή</string>
 	<string name="pref_map_auto_zoom">Αυτόματη μεγέθυνση</string>
@@ -238,24 +214,10 @@
 	<string name="duration_1_day">1 ημέρα</string>
 	<string name="recent_track_help_text">Σας επιτρέπει να καταγράψετε τη διαδρομή που έχει διανυθεί για συγκεκριμένο χρονικό διάστημα και να την δείτε στο χάρτη. Λάβετε υπόψη: η ενεργοποίηση αυτής της λειτουργίας κάνει έντονη χρήση της μπαταρίας. Το τμήμα θα αφαιρεθεί αυτόματα από το χάρτη μετά τη λήξη του μεσοδιαστήματος.</string>
 	<string name="search_show_on_map">Προβολή στο χάρτη</string>
-	<!-- 1st search button-like result -->
-	<string name="search_on_map">Αναζήτηση στο χάρτη</string>
-	<!-- toast with an error -->
-	<string name="no_route_found">Δεν βρέθηκε διαδρομή</string>
-	<!-- route title -->
-	<string name="route">Διαδρομή</string>
-	<!-- category title -->
-	<string name="routes">Διαδρομές</string>
-	<!-- text of notification -->
-	<string name="download_map_notification">Κατεβάστε τον χάρτη της τοποθεσίας που βρίσκεστε</string>
 	<!-- Text in menu -->
 	<string name="website">Ιστότοπος</string>
-	<!-- Text in menu -->
-	<string name="contact_us">Επικοινωνήστε μαζί μας</string>
 	<!-- Settings: Send feedback button and dialog title -->
 	<string name="feedback">Σχόλια</string>
-	<!-- Text in menu -->
-	<string name="subscribe_to_news">Εγγραφή στο ενημερωτικό μας δελτίο</string>
 	<!-- Text in menu -->
 	<string name="rate_the_app">Βαθμολογήστε την εφαρμογή</string>
 	<!-- Text in menu -->
@@ -264,10 +226,6 @@
 	<string name="copyright">Πνευματικά δικαιώματα</string>
 	<!-- Text in menu -->
 	<string name="report_a_bug">Αναφορά σφάλματος</string>
-	<!-- Email subject -->
-	<string name="subscribe_me_subject">Εγγράψτε με στο ενημερωτικό δελτίο Organic Maps</string>
-	<!-- Email body -->
-	<string name="subscribe_me_body">Θέλω να μαθαίνω πρώτος(η) τις τελευταίες ειδήσεις, ενημερώσεις εφαρμογών και προωθητικές ενέργειεςς. Καταλαβαίνω ότι μπορώ να ακυρώσω τη συνδρομή μου ανά πάσα στιγμή.</string>
 	<!-- Alert text -->
 	<string name="email_error_body">Το πρόγραμμα-client ηλεκτρονικού ταχυδρομείου έχει δεν έχει ρυθμιστεί. Ρυθμίστε το ή χρησιμοποιήστε άλλο τρόπο να επικοινωνήσετε μαζί μας στη διεύθυνση %s</string>
 	<!-- Alert title -->
@@ -282,35 +240,20 @@
 	<string name="downloader_cancel_all">Ακύρωση όλων</string>
 	<!-- Downloaded maps category -->
 	<string name="downloader_downloaded_subtitle">Έγινε λήψη</string>
-	<!-- Downloaded maps category -->
-	<string name="downloader_available_maps">Διαθέσιμη</string>
 	<!-- Country queued for download -->
 	<string name="downloader_queued">στην ουρά</string>
 	<string name="downloader_near_me_subtitle">Κοντά μου</string>
 	<string name="downloader_status_maps">Χάρτες</string>
 	<string name="downloader_download_all_button">Λήψη όλων</string>
 	<string name="downloader_downloading">Λήψη:</string>
-	<string name="downloader_search_results">Βρέθηκαν</string>
 	<!-- Status of outdated country in the list -->
 	<string name="downloader_status_outdated">Ενημέρωση</string>
 	<!-- Status of failed country in the list -->
 	<string name="downloader_status_failed">Απέτυχε</string>
 	<!-- Displayed in a dialog that appears when a user tries to delete a map while the app is in the follow route mode -->
 	<string name="downloader_delete_map_while_routing_dialog">Για να διαγράψετε το χάρτη, σταματήστε την πλοήγηση.</string>
-	<!-- Show when user try build route, but we don't know where he -->
-	<string name="routing_failed_unknown_my_position">Η τρέχουσα τοποθεσία δεν έχει οριστεί. Προσδιορίστε τοποθεσίας για να δημιουργήσετε διαδρομή.</string>
-	<!-- Show if use has not routing file, or InconsistentMWMandRoute -->
-	<string name="routing_failed_has_no_routing_file">Απαιτούνται πρόσθετα δεδομένα για να δημιουργήσετε τη διαδρομή. Λήψη δεδομένων τώρα;</string>
-	<!-- StartPointNotFound -->
-	<string name="routing_failed_start_point_not_found">Δεν μπορεί να υπολογιστεί η διαδρομή. Δεν υπάρχουν δρόμοι κοντά στο σημείο εκκίνησης.</string>
-	<!-- EndPointNotFound -->
-	<string name="routing_failed_dst_point_not_found">Δεν μπορεί να υπολογιστεί η διαδρομή. Δεν υπάρχουν δρόμοι κοντά στον προορισμό σας.</string>
 	<!-- PointsInDifferentMWM -->
 	<string name="routing_failed_cross_mwm_building">Μπορούν να δημιουργηθούν μόνο διαδρομές που περιέχονται πλήρως μέσα σε ένα χάρτη σε μια ενιαία περιοχή.</string>
-	<!-- RouteNotFound -->
-	<string name="routing_failed_route_not_found">Δεν βρέθηκε καμία διαδρομή μεταξύ της επιλεγμένης προέλευσης και προορισμού. Επιλέξτε ένα διαφορετικό σημείο έναρξης ή λήξης.</string>
-	<!-- InternalError -->
-	<string name="routing_failed_internal_error">Παρουσιάστηκε εσωτερικό σφάλμα. Δοκιμάστε να διαγράψετε και να κατεβάσετε το χάρτη ξανά. Εάν το πρόβλημα παραμένει, επικοινωνήστε μαζί μας στη διεύθυνση support\@organicmaps.app.</string>
 	<!-- Context menu item for downloader. -->
 	<string name="downloader_download_map">Λήψη χάρτη</string>
 	<!-- Item status in downloader. -->
@@ -324,44 +267,23 @@
 	<!-- Text for rating dialog -->
 	<string name="rating_just_rated">Μόλις βαθμολόγησα την εφαρμογή σας</string>
 	<!-- Text for rating dialog -->
-	<string name="rating_user_since">Χρησιμοποιώ το Organic Maps από τις %s</string>
-	<!-- Text for rating dialog -->
-	<string name="rating_do_like_maps">Σας αρέσει το Organic Maps;</string>
-	<!-- Text for rating dialog -->
-	<string name="rating_tap_star">Πατήστε ένα αστέρι να βαθμολογήσετε την εφαρμογή μας.</string>
-	<!-- Text for rating dialog -->
 	<string name="rating_thanks">Σας ευχαριστούμε!</string>
 	<!-- Text for rating dialog -->
 	<string name="rating_share_ideas">Μοιραστείτε ιδέες ή προβλήματα για να βελτιώσουμε την εφαρμογή.</string>
 	<!-- Text for rating dialog -->
 	<string name="rating_send_feedback">Αποστολή σχολίου</string>
-	<!-- Text for g+ dialog -->
-	<string name="rating_google_plus">Κάντε κλικ στο g+ να ενημερώσετε τους φίλους σας σχετικά με την εφαρμογή.</string>
 	<!-- Text for routing error dialog -->
 	<string name="routing_download_maps_along">Κατεβάστε όλους τους χάρτες για ολόκληρο το μήκος της διαδρομής σας</string>
-	<!-- Text for routing error dialog -->
-	<string name="routing_download_map">Λήψη χάρτη</string>
-	<!-- Text for routing error dialog -->
-	<string name="routing_download_map_and_routing">Κάντε λήψη ενημερωμένου χάρτη και δεδομένων πλοήγησης για να έχετε όλα τα χαρακτηριστικά του Organic Maps.</string>
-	<!-- Text for routing error dialog -->
-	<string name="routing_get_routing_data">Λήψη δεδομένων πλοήγησης</string>
-	<!-- Text for routing error dialog -->
-	<string name="routing_get_additional_data">Απαιτούνται επιπλέον δεδομένα για τη δημιουργία διαδρομών από την τοποθεσία σας.</string>
 	<!-- Text for routing error dialog -->
 	<string name="routing_requires_all_map">Για να δημιουργήσετε μια διαδρομή, πρέπει να κατεβάσετε και να ενημερώσετε όλους τους χάρτες από τη θέση σας στον προορισμό σας.</string>
 	<!-- Text for routing error dialog -->
 	<string name="routing_not_enough_space">Δεν υπάρχει αρκετός χώρος</string>
-	<!-- Text for routing error dialog -->
-	<string name="routing_download_more_than_avail">Πρέπει να κάνετε λήψη %1$s MB, αλλά μόνο %2$s MB είναι διαθέσιμα.</string>
-	<!-- Text for routing error dialog -->
-	<string name="routing_download_roaming">Πρόκειται να κάνετε λήψη %s MB χρησιμοποιώντας Δεδομένα Δικτύου Κινητής Τηλεφωνίας (σε Περιαγωγή). Αυτό μπορεί να προκαλέσει επιπρόσθετες χρεώσεις, που εξαρτώνται από το πρόγραμμα δεδομένων δικτύου κινητής τηλεφωνίας του παρόχου σας.</string>
 	<!-- bookmark button text -->
 	<string name="bookmark">αγαπημένο</string>
 	<!-- location service disabled -->
 	<string name="enable_location_services">Ενεργοποιήστε τις υπηρεσίες εντοπισμού τοποθεσίας</string>
 	<string name="save">Αποθήκευση</string>
 	<string name="edit_description_hint">Οι περιγραφές σας (κείμενο ή html)</string>
-	<string name="new_group">νέα ομάδα</string>
 	<string name="create">δημιουργήστε</string>
 	<!-- red color -->
 	<string name="red">Κόκκινο</string>
@@ -379,22 +301,6 @@
 	<string name="brown">Καφέ</string>
 	<!-- pink color -->
 	<string name="pink">Ροζ</string>
-	<!-- deep purple color -->
-	<string name="deep_purple">Βαθύ πορφυρό</string>
-	<!-- light blue color -->
-	<string name="light_blue">Γαλάζιο</string>
-	<!-- cyan color -->
-	<string name="cyan">Κυανό</string>
-	<!-- teal color -->
-	<string name="teal">Σμαραγδένιο</string>
-	<!-- lime color -->
-	<string name="lime">Κιτρινοπράσινο</string>
-	<!-- deep orange color -->
-	<string name="deep_orange">Βαθύ πορτοκαλί</string>
-	<!-- gray color -->
-	<string name="gray">Γκρι</string>
-	<!-- blue gray color -->
-	<string name="blue_gray">Γκρίζο μπλε</string>
 	<!-- Wi-Fi available -->
 	<string name="WiFi_available">Ναι</string>
 
@@ -451,21 +357,15 @@
 	<string name="categories">Κατηγορίες</string>
 	<string name="history">Ιστορικό</string>
 	<string name="closed">Κλειστό</string>
-	<string name="back_to">Επιστροφή στο %s</string>
 	<string name="search_not_found">Ωχ, δεν βρέθηκαν αποτελέσματα.</string>
 	<string name="search_not_found_query">Δοκιμάστε να αλλάξετε τα κριτήρια αναζήτησής σας.</string>
 	<string name="search_history_title">Ιστορικό αναζήτησης</string>
 	<string name="search_history_text">Προβολή πρόσφατων αναζητήσεων.</string>
 	<string name="clear_search">Εκκαθάριση ιστορικού αναζήτησης</string>
-	<!-- Title for settings to enable/disable showcase menu button -->
-	<string name="showcase_settings_title">Εμφάνιση προσφορών</string>
 	<!-- Place Page link to Wikipedia article (if map object has it). -->
 	<string name="read_in_wikipedia">Wikipedia</string>
 	<string name="p2p_your_location">Η τοποθεσία σας</string>
-	<string name="p2p_from">Από</string>
-	<string name="p2p_to">Έως</string>
 	<string name="p2p_start">Έναρξη</string>
-	<string name="p2p_planning">Σχεδιασμός…</string>
 	<string name="p2p_from_here">Διαδρομή από</string>
 	<string name="p2p_to_here">Διαδρομή στο</string>
 	<string name="p2p_only_from_current">Η πλοήγηση είναι διαθέσιμη μόνο από την τρέχουσα τοποθεσία σας.</string>
@@ -487,7 +387,6 @@
 	<string name="editor_correct_mistake">Διόρθωση λάθους</string>
 	<string name="editor_add_select_location">Τοποθεσία</string>
 	<string name="editor_done_dialog_1">Έχετε αλλάξει τον παγκόμιο χάρτη. Μην το κρατάτε για τον εαυτό σας! Πείτε το στους φίλους σας και κάντε τις αλλαγές μαζί.</string>
-	<string name="editor_done_dialog_2">Αυτή είναι η δεύτερη φορά που επεξεργαστήκατε το χάρτη. Είστε πλέον %d στην κατάταξη των επεξεργαστών του χάρτη. Πείτε το στους φίλους σας.</string>
 	<string name="share_with_friends">Μοιραστείτε με φίλους</string>
 	<string name="editor_report_problem_desription_1">Περιγράψτε το πρόβλημα αναλυτικά ώστε η Κοινότητα OpenStreeMap να διορθώσει το σφάλμα.</string>
 	<string name="editor_report_problem_desription_2">Ή κάντε το μόνοι σας στη διεύθυνση https://www.openstreetmap.org/</string>
@@ -496,9 +395,6 @@
 	<string name="editor_report_problem_no_place_title">Η τοποθεσία δεν υπάρχει</string>
 	<string name="editor_report_problem_under_construction_title">Εκτός λειτουργίας για συντήρηση</string>
 	<string name="editor_report_problem_duplicate_place_title">Διπλότυπη τοποθεσία</string>
-	<string name="first_launch_congrats_title">Το Organic Maps είναι έτοιμο για χρήση</string>
-	<string name="first_launch_congrats_text">Κάντε αναζήτηση και πλοηγηθείτε παντού στον κόσμο χωρίς σύνδεση και χωρίς χρέωση.</string>
-	<string name="migrate_title">Σημαντικό!</string>
 	<string name="autodownload">Αυτόματη λήψη</string>
 	<!-- Place Page opening hours text -->
 	<string name="closed_now">Τώρα είναι κλειστό</string>
@@ -524,10 +420,6 @@
 	<string name="thank_you">Σας ευχαριστούμε</string>
 	<string name="edit_place">Επεξεργασία μέρους</string>
 	<string name="place_name">Όνομα μέρους</string>
-	<!-- small button to open list with names in different languages -->
-	<string name="show_more">Περισσότερα</string>
-	<!-- small button to close list with names in different languages -->
-	<string name="show_less">Λιγότερα</string>
 	<string name="add_language">Προσθήκη γλώσσας</string>
 	<string name="street">Οδός</string>
 	<!-- Editable House Number text field (in address block). -->
@@ -547,8 +439,6 @@
 	<string name="downloader_update_maps">Ενημέρωση χαρτών</string>
 	<string name="downloader_mwm_migration_dialog">Για να δημιουργήσετε μια διαδρομή, πρέπει να ενημερώσετε όλους τους χάρτες και στη συνέχεια να σχεδιάσετε τη διαδρομή ξανά.</string>
 	<string name="downloader_search_field_hint">Ανεύρεση χάρτη</string>
-	<string name="migration_update_all_button">Ενημέρωση όλων των χαρτών</string>
-	<string name="migration_delete_all_download_current_button">Κατεβάστε τον τρέχον χάρτη και διαγράψτε όλους τους παλιούς</string>
 	<string name="migration_download_error_dialog">Σφάλμα λήψης</string>
 	<string name="common_check_internet_connection_dialog">Ελέγξτε τις ρυθμίσεις σας και βεβαιωθείτε ότι η συσκευή σας είναι συνδεδεμένη στο Internet.</string>
 	<string name="downloader_no_space_title">Δεν υπάρχει αρκετός χώρος</string>
@@ -567,11 +457,9 @@
 	<string name="editor_report_problem_other_title">Διαφορετικό πρόβλημα</string>
 	<string name="placepage_add_business_button">Προσθήκη επιχείρησης</string>
 	<string name="whatsnew_editor_message_1">Προσθέστε νέες τοποθεσίες στο χάρτη, και επεξεργαστείτε τις υπάρχουσες απευθείας από την εφαρμογή.</string>
-	<string name="whatsnew_editor_message_2">* Το Organic Maps χρησιμοποιεί δεδομένα της κοινότητας OpenStreetMap.</string>
 	<string name="dialog_incorrect_feature_position">Αλλαγή τοποθεσίας</string>
 	<string name="message_invalid_feature_position">Δε μπορεί να εντοπιστεί αντικείμενο εδώ</string>
 	<string name="login_to_make_edits_visible">Συνδεθείτε ώστε άλλοι χρήστες να μπορούν να δουν τις αλλαγές που έχετε κάνει</string>
-	<string name="no_migration_during_navigation">Δεν επιτρέπεται η ενημέρωση κατά τη διάρκεια της πλοήγησης.</string>
 	<!-- Error dialog no space -->
 	<string name="migration_no_space_message">Για να το κατεβάσετε, χρειάζεστε περισσότερο χώρο. Διαγράψτε τυχόν μη απαραίτητα δεδομένα.</string>
 	<string name="editor_sharing_title">Βελτίωσα τους χάρτες Organic Maps</string>
@@ -592,7 +480,6 @@
 	<string name="editor_detailed_description">Οι προτεινόμενες αλλαγές χάρτη θα σταλούν στην Κοινότητα του OpenStreetMap. Περιγράψτε τυχόν πρόσθετα στοιχεία που δεν μπορείτε να επεξεργαστείτε στο Organic Maps.</string>
 	<string name="editor_more_about_osm">Περισσότερα σχετικά με το OpenStreetMap</string>
 	<string name="editor_operator">Ιδιοκτήτης</string>
-	<string name="downloader_my_maps_title">Οι χάρτες μου</string>
 	<string name="downloader_no_downloaded_maps_title">Δεν έχετε κατεβάσει χάρτες</string>
 	<string name="downloader_no_downloaded_maps_message">Κατεβάστε χάρτες για να αναζητήσετε μια τοποθεσία και να χρησιμοποιήσετε την πλοήγησης χωρίς σύνδεση.</string>
 	<!-- Error title that appears after certain time without location. -->
@@ -614,8 +501,6 @@
 	<string name="placepage_call_button">Κλήση</string>
 	<string name="placepage_edit_bookmark_button">Επεξεργασία αγαπημένου</string>
 	<string name="placepage_bookmark_name_hint">Όνομα αγαπημένου</string>
-	<string name="placepage_personal_notes_hint">Προσωπικές σημειώσεις</string>
-	<string name="placepage_delete_bookmark_button">Διαγραφή αγαπημένου</string>
 	<string name="editor_edits_sent_message">Οι προτεινόμενες αλλαγές σας έχουν σταλεί</string>
 	<string name="editor_comment_hint">Σχόλιο…</string>
 	<string name="editor_reset_edits_message">Απόρριψη όλων των τοπικών αλλαγών;</string>
@@ -629,7 +514,6 @@
 	<string name="error_enter_correct_web">Εισάγετε μια έγκυρη διεύθυνση ιστοτόπου</string>
 	<string name="error_enter_correct_email">Εισάγετε ένα έγκυρο email</string>
 	<string name="refresh">Ενημέρωση</string>
-	<string name="last_update">Τελευταία ενημέρωση: %s</string>
 	<string name="placepage_add_place_button">Να προστεθεί η τοποθεσία στο χάρτη</string>
 	<!-- Displayed when saving some edits to the map to warn against publishing personal data -->
 	<string name="editor_share_to_all_dialog_title">Θέλετε να το στείλετε σε όλους τους χρήστες;</string>
@@ -650,21 +534,11 @@
 	<string name="tell_friends_text">Γεια σας! Εγκαταστήστε το Organic Maps!</string>
 	<!-- About short text (below logo) -->
 	<string name="about_description">Το Organic Maps είναι η απαραίτητη εφαρμογή γα ταξίδια που λειτουργεί εκτός σύνδεσης. Το Organic Maps βασίζεται σε δεδομένα OpenStreetMap και σας επιτρέπει να τα επεξεργαστείτε.</string>
-	<!-- Text in menu -->
-	<string name="blog">Ιστολόγιο</string>
 	<string name="general_settings">Γενικές ρυθμίσεις</string>
-	<string name="date">Ημερομηνία %d</string>
-	<!-- "Report a bug" -> "Generaal Feedback" -> "Something is not working" -->
-	<string name="something_is_not_working">Κάτι δεν λειτουργεί</string>
 	<!-- For the first routing -->
 	<string name="accept">Συμφωνώ</string>
 	<!-- For the first routing -->
 	<string name="decline">Διαφωνώ</string>
-	<string name="install_app">Εγκατάσταση</string>
-	<string name="search_no_results_title">Δεν βρέθηκαν αποτελέσματα</string>
-	<string name="search_no_results_message">Δοκιμάστε ένα γενικότερο όρο αναζήτησης, κάντε σμίκρυνση ή μηδενίστε το φίλτρο.</string>
-	<string name="search_no_results_expand_area_button">Σμίκρυνση</string>
-	<string name="search_no_results_reset_button">Μηδενισμός φίλτρου</string>
 	<!-- noun -->
 	<string name="search_in_table">Λίστα</string>
 	<string name="mobile_data_dialog">Θέλετε να χρησιμοποιήσετε το δίκτυο κινητής τηλεφωνίας για να εμφανίσετε αναλυτικές πληροφορίες;</string>
@@ -676,18 +550,13 @@
 	<string name="mobile_data_option_never">Να μην χρησιμοποιείται ποτέ</string>
 	<string name="mobile_data_option_ask">Να γίνεται ερώτηση πάντα</string>
 	<string name="traffic_update_maps_text">Για να εμφανίσετε πληροφορίες για την κίνηση, πρέπει να ενημερωθούν οι χάρτες.</string>
-	<string name="traffic_outdated">Οι πληροφορίες για την κίνηση είναι παλιές.</string>
 	<string name="big_font">Αύξηση μεγέθους γραμματοσειράς στο χάρτη</string>
 	<string name="traffic_update_app">Κάντε ενημέρωση του Organic Maps</string>
 	<!-- "traffic" as in road congestion -->
 	<string name="traffic_update_app_message">Για να εμφανιστούν πληροφορίες για την κίνηση, πρέπει να γίνει ενημέρωση της εφαρμογής.</string>
 	<!-- "traffic" as in "road congestion" -->
 	<string name="traffic_data_unavailable">Οι πληροφορίες για την κίνηση δεν είναι διαθέσιμες</string>
-	<!-- Simplified colour scheme for traffic information, fewer colours are used to display traffic jams on the map. The string should be kept as short as possible -->
-	<string name="pref_traffic_simplified_colors_title">Εύκολα χρώματα για την κίνηση</string>
 	<string name="enable_logging">Ενεργοποίηση δυνατότητας καταγραφής</string>
-	<string name="offline_place_page_more_information">Συνδεθείτε στο Internet για να λάβετε περισσότερες πληροφορίες για αυτό το μέρος.</string>
-	<string name="failed_load_information">Η φόρτωση πληροφοριών απέτυχε.</string>
 	<!-- Settings: "Send general feedback" button -->
 	<string name="feedback_general">Γενικό σχόλιο</string>
 	<string name="on">Ενεργ.</string>
@@ -701,57 +570,26 @@
 	<string name="routing_add_start_point">Προσθέστε αφετηρία για να σχεδιάσετε μια διαδρομή</string>
 	<string name="routing_add_finish_point">Προσθέστε τελικό προορισμό, για να σχεδιάσετε μια διαδρομή</string>
 	<string name="button_exit">Έξοδος</string>
-	<string name="settings_device_memory">Μνήμη συσκευής</string>
-	<string name="settings_card_memory">Κάρτα μνήμης</string>
-	<string name="settings_storage_available">%s διαθέσιμα</string>
-	<string name="toast_location_permission_denied">Άρνηση πρόσβασης εφαρμογής στον εντοπισμό τοποθεσίας</string>
-	<string name="button_use">Χρήση</string>
 	<string name="planning_route_manage_route">Διαχείριση διαδρομής</string>
 	<string name="button_plan">Σχέδιο</string>
-	<string name="button_add">Προσθήκη</string>
 	<string name="placepage_remove_stop">Κατάργηση</string>
 	<string name="planning_route_remove_title">Σύρετε εδώ για κατάργηση</string>
-	<string name="dialog_change_start_point_message">Θέλετε να αλλάξετε την αφετηρία στην τρέχουσα θέση;</string>
-	<string name="button_replace">Αλλαγή</string>
 	<string name="placepage_add_stop">Προσθήκη στάσης</string>
-	<string name="add_my_position">Πρόσθεσε τη θέση μου</string>
-	<string name="choose_start_point">Επιλέξτε αφετηρία</string>
-	<string name="choose_destination">Επιλέξτε προορισμό</string>
 	<string name="preloader_viator_button">Μάθετε περισσότερα</string>
-	<string name="start_from_my_position">Έναρξη από</string>
-	<string name="profile_authorization_title">Συνδεθείτε με</string>
-	<string name="profile_authorization_message">Εύκολη σύνδεση χωρίς όνομα χρήστη και κωδικό πρόσβασης σε λίγα δευτερόλεπτα</string>
 	<string name="profile_authorization_error">Ωχ, παρουσιάστηκε σφάλμα. Προσπαθήστε να συνδεθείτε ξανά.</string>
-	<string name="service">Εξυπηρέτηση</string>
-	<string name="atmosphere">Ατμόσφαιρα</string>
-	<string name="value_for_money">Αξία για τα χρήματα</string>
-	<string name="experience">Εμπειρία</string>
-	<string name="assortment">Κατάταξη</string>
-	<string name="expertise">Τεχνογνωσία</string>
-	<string name="equipment">Εξοπλισμός</string>
-	<string name="quality">Ποιότητα</string>
 	<string name="dialog_error_storage_title">Πρόβλημα πρόσβασης στον αποθηκευτικό χώρο</string>
 	<string name="dialog_error_storage_message">Ο εξωτερικός απθηκευτικός χώρος δεν είναι διαθέσιμος, πιθανότατα έχει αφαιρεθεί η κάρτα SD, είναι κατεστραμμένη ή το σύστημα αρχείων είναι μόνο για ανάγνωση. Ελέγξτε το και επικοινωνήστε μαζί μας στη διεύθυνση support\@organicmaps.app</string>
 	<string name="setting_emulate_bad_storage">Εξομείωση κακού αποθηκευτικού χώρου</string>
-	<string name="directions_finish">Προορισμός</string>
-	<string name="directions_on_foot">Βάδισμα %s</string>
 	<string name="core_entrance">Είσοδος</string>
-	<string name="coffee">Καφές</string>
-	<string name="cleanliness">Καθαριότητα</string>
-	<string name="crowdedness">Συνωστισμός</string>
 	<string name="error_enter_correct_name">Εισάγετε ένα σωστό όνομα</string>
 	<string name="bookmarks_groups">Τόπος αγώνων</string>
 	<string name="bookmarks_groups_hide_all">Απόκρυψη όλων</string>
 	<string name="bookmarks_groups_show_all">Εμφάνιση όλων</string>
-	<plurals name="bookmarks_places">
-	  <item quantity="other">%d αγαπημένα</item>
-	</plurals>
 	<string name="bookmarks_create_new_group">Δημιουργία νέας λίστας</string>
 	<string name="downloader_hide_screen">Απόκρυψη οθόνης</string>
 	<string name="downloader_percent">%1$s (%2$s από %3$s)</string>
-	<string name="downloader_process">Λήψη %s...</string>
-	<string name="downloader_applying">Εφαρμογή %s...</string>
-	<string name="dialog_message_transit_not_found_connection">Σχεδιάστε μια διαδρομή εντός δικτύου μεταφοράς</string>
+	<string name="downloader_process">Λήψη %s…</string>
+	<string name="downloader_applying">Εφαρμογή %s…</string>
 	<string name="bookmarks_error_message_share_general">Αδυναμία κοινής χρήσης λόγω σφάλματος εφαρμογής</string>
 	<string name="bookmarks_error_title_share_empty">Σφάλμα κοινής χρήσης</string>
 	<string name="bookmarks_error_message_share_empty">Αδύνατη η κοινή χρήση κενής λίστας</string>
@@ -760,12 +598,7 @@
 	<string name="bookmarks_new_list_hint">Νέα λίστα</string>
 	<string name="bookmarks_error_title_list_name_already_taken">Αυτό το όνομα έχει ήδη ληφθεί</string>
 	<string name="bookmarks_error_message_list_name_already_taken">Επιλέξτε άλλο όνομα</string>
-	<string name="bookmarks_error_title_list_name_too_long">Αυτό το όνομα είναι πολύ μεγάλο</string>
-	<string name="bookmarks_error_message_list_name_too_long">Επιλέξτε άλλο όνομα</string>
-	<string name="please_wait">Παρακαλώ περιμένετε...</string>
-	<string name="phone_number">Τηλεφωνικό νούμερο</string>
-	<string name="notification_unsent_reviews_title">Έχετε αρκετές κριτικές</string>
-	<string name="notification_unsent_reviews_message">Παρακαλώ συνδεθείτε για να μοιραστείτε κριτικές με άλλους ταξιδιώτες</string>
+	<string name="please_wait">Παρακαλώ περιμένετε…</string>
 	<string name="profile">Προφίλ OpenStreetMap</string>
 	<string name="place_page_search_similar_hotel">Αναζήτηση παρόμοιων ξενοδοχείων</string>
 	<string name="bookmarks_detect_title">Εντοπίστηκαν νέα αρχεία</string>
@@ -776,31 +609,10 @@
 	<string name="button_convert">Μετατρέπω</string>
 	<string name="bookmarks_convert_error_title">Λάθος</string>
 	<string name="bookmarks_convert_error_message">Ορισμένα αρχεία δεν μετατράπηκαν.</string>
-	<string name="converting">Μετατροπή...</string>
-	<string name="wn_reinvented_bookmarks_title">Επεκτείνασαμε σελιδοδείκτες!</string>
-	<string name="wn_reinvented_bookmarks_message">You can back up them and create lists - just look at them on the map! They are gorgeous!</string>
-	<string name="bookmarks_restore">Επαναφορά των σελιδοδεικτών</string>
-	<string name="bookmarks_restore_process">Επαναφορά...</string>
 	<string name="bookmarks_restore_title">Επαναφορά αυτής της έκδοσης;</string>
-	<string name="bookmarks_restore_message">Οι σελιδοδείκτες σας θα αποκατασταθούν από το %1$s (%2$s)</string>
-	<string name="bookmarks_restore_empty_title">Δεν διαθέτετε αντίγραφο ασφαλείας</string>
-	<string name="bookmarks_restore_empty_message">Ο διακομιστής δεν βρήκε προηγουμένως δημιουργημένα αντίγραφα ασφαλείας</string>
 	<string name="common_check_internet_connection_dialog_title">Δεν υπάρχει σύνδεση στο διαδίκτυο</string>
-	<string name="error_server_title">Σφάλμα Διακομιστή</string>
-	<string name="error_server_message">Παρουσιάστηκε σφάλμα στο διακομιστή, δοκιμάστε ξανά αργότερα</string>
 	<string name="error_system_message">Συνέβη ένα άγνωστο σφάλμα</string>
 	<string name="restore">Επαναφορά</string>
-	<string name="bookmarks_page_downloaded">Κατέβηκε</string>
-	<string name="bookmarks_page_my">Μου</string>
-	<string name="routes_and_bookmarks">Διαδρομές και σελιδοδείκτες</string>
-	<string name="bookmarks_webview_success_toast">Οι σελιδοδείκτες κατέβηκαν επιτυχώς</string>
-	<string name="cached_bookmarks_placeholder_title">Κατεβάστε νέα μέρη</string>
-	<string name="cached_bookmarks_placeholder_subtitle">Πιέστε το κουμπί για να κατεβάστε χιλιάδες ενδιαφέροντα μέρη και διαδρομές που δημιουργήθηκαν από τους χρήστες του Organic Maps. Θα χρειαστείτε σύνδεση στο διαδίκτυο.</string>
-	<string name="downloader_download_routers">Κατεβάστε σελιδοδείκτες</string>
-	<string name="bookmarks_groups_cached">Κατεβάστε λίστες</string>
-	<plurals name="bookmarks_objects">
-	  <item quantity="other">%s αντικέιμενο</item>
-	</plurals>
 	<plurals name="objects">
 	  <item quantity="other">%d μέρος</item>
 	</plurals>
@@ -813,62 +625,32 @@
 	<string name="subtittle_opt_out">Ρυθμίσεις διαδρομών</string>
 	<string name="crash_reports">Αναφορά σφάλματος</string>
 	<string name="crash_reports_description">Μπορεί να χρησιμοποιήσουμε τα δεδομένα σας για να βελτιώσουμε την εμπειρία του Organic Maps. Οι αλλαγές θα ενεργοποιηθούν μετά την επανεκκίνηση της εφαρμογής.</string>
-	<string name="opt_out_help_ios_1">Η συσκευή σας μπορεί να παρέχει μια ρύθμιση «Περιορισμένη παρακολούθηση διαφημίσεων» ή «Αποκλεισμό διαφημίσεων με βάση το ενδιαφέρον».</string>
-	<string name="opt_out_help_ios_2">iOS 9 ή υψηλότερο</string>
-	<string name="opt_out_help_ios_3">Πηγαίνετε στις ρυθμίσεις → Απόρρητο → Διαφήμιση → Ενεργοποιήστε την επιλογή «Περιορισμένη παρακολούθηση διαφημίσεων»</string>
-	<string name="opt_out_help_android">Η συσκευή σας μπορεί να παρέχει μια ρύθμιση «Περιορισμένη παρακολούθηση διαφημίσεων» ή «Αποκλεισμό διαφημίσεων με βάση το ενδιαφέρον».\n\n Για Android και υπηρεσίες Google Play εκδοχής 4.0 και πάνω:\n Ρυθμίσεις → Google → Διαφημίσεις → Αποκλεισμός προσωποποίησης διαφημίσεων\n ή \n Ρυθμίσεις → Google → Λογαριασμός Google → Προσωπικές πληροφορίες και ασφάλεια → Προσωποποίηση Διαφημίσεων</string>
 	<string name="privacy_policy">Πολιτική απορρήτου</string>
 	<string name="terms_of_use">Όροι χρήσης</string>
-	<string name="backup_notification_failed">Η αποθήκευση των σελιδοδεικτών έχει διακοπεί. Συνδεθείτε για να το ξανανοίξετε.</string>
 	<string name="button_layer_traffic">Κίνηση</string>
 	<string name="button_layer_subway">Μετρό</string>
 	<string name="layers_title">Επίπεδα του χάρτη</string>
-	<string name="layers_message">Χρησιμοποιήστε τα επίπεδα χάρτη για να δείτε την κίνηση, το χάρτη του μετρό και άλλες χρήσιμες πληροφορίες</string>
-	<string name="button_layer_got_it">Κατάλαβα</string>
 	<string name="subway_data_unavailable">Ο χάρτης μετρό δεν είναι διαθέσιμος</string>
 	<string name="bookmarks_empty_list_title">Η λίστα είναι άδεια</string>
 	<string name="bookmarks_empty_list_message">Για να προσθέσετε σελιδοδείκτη, πατήστε ένα μέρος στο χάρτη και μετά πατήστε το αστεράκι</string>
 	<string name="category_desc_more">…περισσότερα</string>
 	<string name="title_error_downloading_bookmarks">Συνέβη σφάλμα</string>
-	<string name="subtitle_error_downloading_bookmarks">Οι σελιδοδείκτες δεν κατέβηκαν</string>
-	<string name="error_already_downloaded">Έχει γίνει ήδη λήψη αυτής της λίστας</string>
-	<string name="why_support">Γιατί να υποστηρίξετε το Organic Maps?</string>
-	<string name="why_support_item2">Μας βοηθάτε να βελτιώσουμε το Organic Maps</string>
-	<string name="why_support_item3">Μας βοηθάτε να βελτιώσουμε ανοιχτούς χάρτες στο OpenStreetMap.org</string>
-	<string name="channels_map_update">Ενημερώσεις χάρτη</string>
-	<string name="server_unavailable_title">Ο εξυπηρετητής δεν είναι διαθέσιμος</string>
-	<string name="sharing_options">Επιλογές κοινοποίησης</string>
 	<string name="export_file">Αρχείο Εξαγωγής</string>
 	<string name="list_settings">Ρυθμίσεις Λίστας</string>
 	<string name="delete_list">Διαγραφή λίστας</string>
-	<string name="hide_from_map">Κρύψε από τον χάρτη</string>
 	<string name="public_access">Δημόσια πρόσβαση</string>
 	<string name="limited_access">Περιορισμένη πρόσβαση</string>
 	<string name="bookmark_category_name">Κατηγορία</string>
 	<string name="bookmark_category_description_hint">Πληκτρολογήστε μια περιγραφή (κείμενο ή html)</string>
 	<string name="not_shared">Προσωπικός</string>
-	<string name="direct_link_progress_text">Ανεβάζουμε το αρχείο σας…</string>
-	<string name="direct_link_success">Ο σύνδεσμος δημιουργήθηκε</string>
-	<string name="send_a_link_btn">Στείλε μου έναν σύνδεσμο</string>
-	<string name="upload_error_toast">Ένα σφάλμα συνέβη στο ανέβασμα του αρχείου σας</string>
 	<string name="tags_loading_error_subtitle">Ένα σφάλμα συνέβη στο φόρτωμα των ετικετών, παρακαλώ ξαναπροσπαθήστε</string>
-	<string name="unable_upload_errorr_title">Το ανέβασμα του αρχείου απέτυχε</string>
-	<string name="unable_upload_error_subtitle_edited">Το αρχείο επεξεργάστηκε μέσω της εφαρμογής</string>
-	<string name="unable_upload_error_subtitle_broken">Το αρχείο είναι κατεστραμμένο και δεν μπόρεσε να ανέβει. Παρακαλώ ανεβάστε ένα άλλο αρχείο.</string>
-	<string name="contact">Επικοινωνία</string>
-	<string name="download_button">Κατέβασμα</string>
 	<string name="speedcams_alert_title">Κάμερες Ταχύτητας</string>
-	<string name="speedcams_alert_subtitle">Ειδοποίηση για όρια ταχύτητας</string>
 	<string name="speedcam_option_auto">Αυτόματο</string>
 	<string name="speedcam_option_always">Πάντα</string>
 	<string name="speedcam_option_never">Ποτέ</string>
-	<string name="bookmark_description_title">Περιγραφή Σελιδοδείκτη</string>
 	<string name="place_description_title">Περιγραφή μέρους</string>
 	<!-- this text will be shown in application notification preferences opposite checkbox which enable/disable downloader notifications. Devices on Android 8+ are affected. -->
 	<string name="notification_channel_downloader">Κατέβασμα χαρτών</string>
-	<string name="share_bookmarks_email_body_link">Γεια!\n\nΕδώ είναι ο σύνδεσμος που μπορείς να κατεβάσεις τους σελιδοδείκτες σου: %s. Ανοίξτε τη λίστα μέσω Organic Maps και απολαύστε το ταξίδι σας!\n\nΚατεβάστε την εφαρμογή: https://omaps.app/get?kmz</string>
-	<string name="warning_speedcams_title">Ο πλοηγός θα σας ειδοποιεί για κάμερες όταν υπερβαίνετε το όριο ταχύτητας των %d km/h</string>
-	<string name="warning_speedcams_subtitle">Παρακαλώ να προσέχετε τους κανόνες οδήγησης της χώρας στην οποία ταξιδεύετε.</string>
 	<string name="speedcams_notice_message">Αυτόματο- Να ειδοποιούμαι για κάμερες αν υπάρχει κίνδυνος να υπερβώ το όριο ταχύτητας\nΠάντα- Πάντα να ειδοποιούμαι για κάμερες\nΠοτέ- Ποτέ να μην ειδοποιούμαι για κάμερες</string>
 	<string name="power_managment_title">Λειτουργία εξοικονόμησης ενέργειας</string>
 	<string name="power_managment_description">Εάν η λειτουργία εξοικονόμησης ενέργειας είναι ενεργοποιημένη, η εφαρμογή θα κλείνει τις λειτουργίες που καταναλώνουν ενέργεια ανάλογα με την τρέχουσα φόρτιση του τηλεφώνου</string>
@@ -876,14 +658,7 @@
 	<string name="power_managment_setting_auto">Αυτόματα</string>
 	<string name="power_managment_setting_manual_max">Μέγιστη εξοικονόμηση ενέργειας</string>
 	<string name="enable_logging_warning_message">Αυτή η λειτουργία είναι ενεργοποιημένη για την καταγραφή ενεργειών για διαγνωστικούς σκοπούς. Αυτό βοηθά την ομάδα να εντοπίζει προβλήματα με την εφαρμογή. Να ενεργοποιείτε τη λειτουργία μόνο κατόπιν αιτήματος της υποστήριξης του Organic Maps.</string>
-	<string name="html_error_upload_message_try_again">Ελέγξτε την πρόσβαση στο δίκτυο και δοκιμάστε ξανά</string>
-	<string name="html_error_upload_title_try_again">Δεν υπάρχει σύνδεση με το διαδίκτυο</string>
-	<string name="notification_leave_review_v2_android_short_title">Αφήνετε τα σχόλιά σας και βοηθάτε τους ταξιδιώτες!</string>
-	<string name="notifications_illegal_alert_disable_button">Απενεργοποίηση των ειδοποιήσεων</string>
 	<string name="access_rules_author_only">Επεξεργάζεται online</string>
-	<string name="privacy_settings_menu">Ρυθμίσεις απορρήτου</string>
-	<string name="unable_upadate_error_title">Δεν ήταν δυνατή η ενημέρωση της διαδρομής</string>
-	<string name="unable_upadate_error_message">Παρουσιάστηκαν σφάλματα κατά την ενημέρωση. Ελέγξτε τις αλλαγές και δοκιμάστε ξανά</string>
 	<string name="driving_options_title">Ρυθμίσεις παράκαμψης</string>
 	<string name="driving_options_subheader">Αποφυγή σε κάθε διαδρομή</string>
 	<string name="avoid_tolls">Δρόμοι με διόδια</string>
@@ -894,52 +669,14 @@
 	<string name="unable_to_calc_alert_subtitle">Δυστυχώς, δεν μπορούσαμε να δημιουργήσουμε μια διαδρομή με τις καθορισμένες επιλογές. Αλλάξτε τις ρυθμίσεις και δοκιμάστε πάλι</string>
 	<string name="define_to_avoid_btn">Ρύθμιση της διαδρομής παράκαμψης</string>
 	<string name="change_driving_options_btn">Ρυθμίσεις δραστηριοποιούνται</string>
-	<string name="toll_road">Δρόμος με διόδια</string>
-	<string name="unpaved_road">Χωματόδρομος</string>
-	<string name="ferry_crossing">Πορθμείο</string>
-	<string name="operated_by">Χειρίζεται από \"%s\"</string>
 	<string name="avoid_toll_roads_placepage">Αποφυγή των δρόμων με διόδια</string>
 	<string name="avoid_unpaved_roads_placepage">Αποφυγή των χωματόδρομων</string>
 	<string name="avoid_ferry_crossing_placepage">Αποφυγή των πορθμείων</string>
-	<string name="type.cuisine.uzbek">Ουζμπεκική κουζίνα</string>
-	<string name="trip_start">Πάμε</string>
-	<string name="pick_destination">Προορισμός</string>
-	<string name="follow_my_position">Επανατοποθέτηση</string>
-	<string name="search_results">Αποτελέσματα αναζήτησης</string>
-	<string name="then_turn">Μετά</string>
-	<string name="redirect_route_alert">Θα θέλατε να τροποποιήσετε τη διαδρομή;</string>
-	<string name="redirect_route_yes">Ναι</string>
-	<string name="redirect_route_no">Όχι</string>
-	<string name="trip_finished">Έχετε φτάσει!</string>
-	<string name="keyboard_availability_alert">Το πληκτρολόγιο δεν είναι διαθέσιμο κατά τη διάρκεια οδήγησης</string>
-	<string name="dialog_routing_change_start_carplay">Δεν είναι δυνατή η δημιουργία διαδρομής από την τρέχουσα τοποθεσία σας</string>
-	<string name="dialog_routing_change_end_carplay">Δεν είναι δυνατή η δημιουργία διαδρομής μέχρι τον προορισμό σας. Επιλέξτε ένα άλλο σημείο</string>
-	<string name="dialog_routing_check_gps_carplay">Δεν υπάρχει σήμα GPS. Μετακινήστε σε μια ανοικτή τοποθεσία</string>
-	<string name="dialog_routing_unable_locate_route_carplay">Δεν είναι δυνατή η δημιουργία διαδρομής. Επιλέξτε άλλα σημεία διαδρομής</string>
-	<string name="dialog_routing_download_files_carplay">Για να χτίσετε διαδρομή, κατεβάστε χάρτες που λείπουν στη συσκευή</string>
-	<string name="dialog_routing_system_error_carplay">Παρουσιάστηκε σφάλμα. Κάντε επανεκκίνηση της εφαρμογής</string>
-	<string name="dialog_routing_rebuild_from_current_location_carplay">Η διαδρομή θα ξαναδημιουργηθεί από την τρέχουσα τοποθεσία σας</string>
-	<string name="dialog_routing_rebuild_for_vehicle_carplay">Η διαδρομή θα αντικατασταθεί με τη διαδρομή με αυτοκίνητο</string>
 	<string name="ok">Καλώς</string>
-	<string name="avoid_unpaved_carplay_1">Χ/χωματόδρ.</string>
-	<string name="avoid_unpaved_carplay_2">Χ/χωματόδρομους</string>
-	<string name="avoid_ferry_carplay_1">Χ/πορθμεία</string>
-	<string name="avoid_ferry_carplay_2">Χωρίς πορθμεία</string>
-	<string name="avoid_tolls_carplay_1">Χωρίς διόδια</string>
-	<string name="avoid_tolls_carplay_2">Χωρίς διόδια</string>
-	<string name="speedcams_alert_title_carplay_1">Κάμερες</string>
-	<string name="speedcams_alert_title_carplay_2">Πληροφ. γιαόρια</string>
-	<string name="download_map_carplay">Κάντε λήψη χαρτών στην εφαρμογή Organic Maps στη συσκευή σας</string>
-	<string name="carplay_roundabout_exit">%s έξοδος</string>
 	<!-- max. 10 symbols, both iOS and Android -->
 	<string name="sort">Ταξινόμηση</string>
 	<!-- Android, title, max 20-22 symbols -->
 	<string name="sort_bookmarks">Ταξινόμηση σελιδοδ/τών</string>
-	<!-- iOS -->
-	<string name="sort_default">Ταξινόμηση κατά προεπιλογή</string>
-	<string name="sort_type">Ταξινόμηση ανά τύπο</string>
-	<string name="sort_distance">Ταξινόμηση κατά απόσταση</string>
-	<string name="sort_date">Ταξινόμηση κατά ημερομηνία</string>
 	<!-- Android -->
 	<string name="by_default">Προεπιλογή</string>
 	<!-- Android -->
@@ -948,65 +685,23 @@
 	<string name="by_distance">Κατά απόσταση</string>
 	<!-- Android -->
 	<string name="by_date">Κατά ημερομηνία</string>
-	<string name="week_ago_sorttype">Μια βδομάδα πριν</string>
-	<string name="month_ago_sorttype">Ένας μήνας πριν</string>
-	<string name="moremonth_ago_sorttype">Περισσότερο από έναν μήνα πριν</string>
-	<string name="moreyear_ago_sorttype">Περισσότερο από ένα έτος πριν</string>
-	<string name="near_me_sorttype">Δίπλα μου</string>
-	<string name="others_sorttype">Άλλα</string>
-	<string name="food_places">Εστίαση</string>
-	<string name="tourist_places">Αξιοθέατα</string>
-	<string name="museums">Μουσεία</string>
-	<string name="parks">Πάρκα</string>
-	<string name="swim_places">Κολύμβηση</string>
-	<string name="mountains">Βουνά</string>
-	<string name="animals">Ζώα</string>
-	<string name="hotels">Διαμονή</string>
-	<string name="buildings">Κτήρια</string>
-	<string name="money">Χρήματα</string>
-	<string name="shops">Καταστήματα</string>
-	<string name="parkings">Χώροι στάθμευσης</string>
-	<string name="fuel_places">Πρατήρια βενζίνης</string>
-	<string name="water">Νερό</string>
-	<string name="medicine">Γιατρική βοήθεια</string>
 	<string name="search_in_the_list">Αναζήτηση στη λίστα</string>
-	<string name="view_on_map_bookmarks">Στον χάρτη</string>
-	<string name="more_bookmarks">Περισσότερα…</string>
-	<string name="no_items_found">Δεν βρέθηκε τίποτα</string>
-	<!-- Android, max 18 symbols -->
-	<string name="bookmarks_edit_list">Επεξεργασία</string>
-	<!-- Android, max 18 symbols -->
-	<string name="bookmarks_delete_list">Διαγραφή λίστας</string>
-	<string name="religious_places">Άγιοι τόποι</string>
 	<string name="select_list">Επιλογή λίστας</string>
 	<string name="transit_not_found">Η πλοήγηση στο μετρό γι\' αυτή την περιοχή δεν είναι ακόμα διαθέσιμη</string>
 	<string name="dialog_pedestrian_route_is_long_header">Η διαδρομή του μετρό δεν βρέθηκε</string>
 	<string name="dialog_pedestrian_route_is_long_message">Επιλέξτε το σημείο έναρξης ή τέλους διαδρομής πιο κοντά στο σταθμό του μετρό</string>
-	<!-- Failed planning SUBWAY route message in navigation view -->
-	<string name="routing_planning_error_subway_special">Σφάλμα κατά την δημιουργία διαδρομής του μετρό</string>
 	<string name="button_layer_isolines">Υψόμετρα</string>
-	<string name="tips_map_layers_title_countour">Τοπογραφικά στρώματα εκτός σύνδεσης στο Organic Maps!</string>
-	<string name="tips_map_layers_message_countour">Τα τοπογραφικά στρώματα θα σας βοηθήσουν να σχεδιάσετε το ταξίδι σας στη φύση και να μην χαθείτε στην περιοχή</string>
 	<string name="isolines_activation_error_dialog">Για να χρησιμοποιήσετε τοπογραφικά στρώματα, ενημερώστε ή κατεβάστε τον χάρτη της επιθυμητής περιοχής</string>
 	<string name="isolines_location_error_dialog">Τα τοπογραφικά στρώματα δεν είναι ακόμα διαθέσιμα σε αυτή την περιοχή</string>
 	<string name="elevation_profile_diff_level">Επίπεδο δυσκολίας</string>
-	<string name="elevation_profile_diff_level_easy">Εύκολο</string>
-	<string name="elevation_profile_diff_level_moderate">Μέτριο</string>
-	<string name="elevation_profile_diff_level_hard">Δύσκολο</string>
 	<string name="elevation_profile_ascent">Άνοδος</string>
 	<string name="elevation_profile_descent">Κάθοδος</string>
 	<string name="elevation_profile_minaltitude">Ελ. υψόμετρο</string>
 	<string name="elevation_profile_maxaltitude">Μέγ. υψόμετρο</string>
-	<string name="elevation_profile_m">μ</string>
 	<string name="elevation_profile_difficulty">Δυσκολία</string>
 	<string name="elevation_profile_distance">Απόστ.:</string>
-	<string name="elevation_profile_km">χλμ</string>
 	<string name="elevation_profile_time">Διαρκ:</string>
-	<string name="elevation_profile_hours">ω.</string>
-	<string name="elevation_profile_minutes">λ.</string>
 	<string name="isolines_toast_zooms_1_10">Μεγεθύνετε για να δείτε περιγράμματα</string>
-	<string name="downloader_updating_ios">Ενημέρωση</string>
-	<string name="downloader_loading_ios">Φόρτωση</string>
 	<string name="key_information_title">Βασικές πληροφορίες</string>
 	<string name="enable_screen_sleep">Αφήστε την οθόνη να κοιμηθεί</string>
 	<!-- Description in preferences -->

--- a/android/res/values-es/strings.xml
+++ b/android/res/values-es/strings.xml
@@ -12,8 +12,6 @@
 	<string name="cancel_download">Cancelar descarga</string>
 	<!-- Button which deletes downloaded country -->
 	<string name="delete">Eliminar</string>
-	<!-- Button "do not interrupt download" if user touched actively downloading country -->
-	<string name="do_nothing">Seguir descarga</string>
 	<string name="download_maps">Descargar mapas</string>
 	<!-- Settings/Downloader - info for country when download fails -->
 	<string name="download_has_failed">Error durante la descarga, iniciar otra vez</string>
@@ -35,39 +33,27 @@
 	<string name="search">Buscar</string>
 	<!-- Search box placeholder text -->
 	<string name="search_map">Buscar en el mapa</string>
-	<!-- Settings/Downloader - info for not downloaded country -->
-	<string name="touch_to_download">Presionar para descargar</string>
 	<!-- Settings/Downloader - 3G download warning dialog confirm button -->
 	<string name="use_cellular_data">Sí</string>
 	<!-- Location services are disabled by user alert - message -->
 	<string name="location_is_disabled_long_text">No se puede acceder a los servicios de localización. Por favor, activelo en los ajustes.</string>
-	<!-- Location Services are not available on the device alert - message -->
-	<string name="device_doesnot_support_location_services">Su dispositivo no es compatible con los servicios de localización</string>
 	<!-- View and button titles for accessibility -->
 	<string name="zoom_to_country">Mostrar en el mapa</string>
-	<!-- Button text for the button at the center of the screen when the country is not downloaded -->
-	<string name="country_status_download">Descargar mapa\n(^ ^)</string>
 	<!-- Button text for the button at the center of the screen when the country is not downloaded and the size should not be shown -->
 	<string name="country_status_download_without_size">Descargar mapa</string>
-	<!-- Button text for the button at the center of the screen when the country is not downloaded -->
-	<string name="country_status_download_without_routing">Descargar mapa\nsin ruta (^ ^)</string>
 	<!-- Message to display at the center of the screen when the country download has failed -->
 	<string name="country_status_download_failed">Error durante la descarga</string>
 	<!-- Button text for the button under the country_status_download_failed message -->
 	<string name="try_again">Intentarla otra vez</string>
 	<string name="about_menu_title">Sobre Organic Maps</string>
-	<string name="downloaded_touch_to_delete">Descargado (%s), presionar para eliminar</string>
 	<string name="connection_settings">Ajustes de conexión</string>
-	<string name="download_mb_or_kb">Descargar %s</string>
 	<string name="close">Cerrar</string>
 	<string name="unsupported_phone">Un acelerador de hardware OpenGL se requiere. Desafortunadamente, su dispositivo móvil no es compatible.</string>
 	<string name="download">Descargar</string>
-	<string name="external_storage_is_not_available">La memoria SD/almacenamiento USB con los mapas descargados no está disponible</string>
 	<string name="disconnect_usb_cable">Por favor desconectar el cable USB o insertar la memoria SD para usar Organic Maps</string>
 	<string name="not_enough_free_space_on_sdcard">Por favor liberar espacio en la memoria SD/almacenamiento USB para usar la aplicación</string>
 	<string name="not_enough_memory">No hay suficiente memoria para iniciar la aplicación</string>
 	<string name="download_resources">Antes de comenzar, permite que descarguemos en tu dispositivo un mapamundi general.\nSe requieren %s de datos.</string>
-	<string name="getting_position">Buscando su ubicación actual</string>
 	<string name="download_resources_continue">Ir al mapa</string>
 	<string name="downloading_country_can_proceed">Descargando %s. Puede ahora\nproceder al mapa</string>
 	<string name="download_country_ask">Descargar %s?</string>
@@ -80,14 +66,10 @@
 	<string name="download_country_failed">%s la descarga ha fallado</string>
 	<!-- Add New Bookmark Set dialog title -->
 	<string name="add_new_set">Agregar un grupo nuevo</string>
-	<!-- Place Page - Add To Bookmarks button -->
-	<string name="add_to_bookmarks">Añadir a Favoritos</string>
 	<!-- Bookmark Color dialog title -->
 	<string name="bookmark_color">Color del marcador</string>
 	<!-- Add Bookmark Set dialog - hint when set name is empty -->
 	<string name="bookmark_set_name">Nombre del grupo de marcadores</string>
-	<!-- Bookmark Sets dialog title -->
-	<string name="bookmark_sets">Grupos de marcadores</string>
 	<!-- Bookmarks - dialog title -->
 	<string name="bookmarks">Marcadores</string>
 	<!-- Default bookmarks set name -->
@@ -96,12 +78,8 @@
 	<string name="name">Nombre</string>
 	<!-- Editor title above street and house number -->
 	<string name="address">Dirección</string>
-	<!-- Place Page - Remove Pin button -->
-	<string name="remove_pin">Quitar la etiqueta</string>
 	<!-- Add bookmark dialog - bookmark set, Bookmarks dialog - Bookmark set cell -->
 	<string name="set">Grupo</string>
-	<!-- Text hint in Bookmarks dialog when no any bookmarks are added -->
-	<string name="bookmarks_usage_hint">Todavía no tienes favoritos.\nToca en cualquier lugar del mapa y añade favoritos.\nTambién se pueden importar y mostrar marcadores de otras fuentes en la aplicación Organic Maps. Abre el archivo KML/KMZ con los alfileres guardados desde el correo, Dropbox o Weblink.</string>
 	<!-- Settings button in system menu -->
 	<string name="settings">Configuración</string>
 	<!-- Header of settings activity where user defines storage path -->
@@ -112,18 +90,10 @@
 	<string name="move_maps">¿Mover mapas?</string>
 	<!-- Ask to wait user several minutes (some long process in modal dialog). -->
 	<string name="wait_several_minutes">Esto podría tardar varios minutos.\nPor favor, espera…</string>
-	<!-- Toast which is displayed when GPS has been deactivated -->
-	<string name="gps_is_disabled_long_text">El GPS está inhabilitado. Por favor, activelo en los ajustes.</string>
 	<!-- Measurement units title in settings activity -->
 	<string name="measurement_units">Unidades de medida</string>
 	<!-- Detailed description of Measurement Units settings button -->
 	<string name="measurement_units_summary">Elija entre millas y kilómetros</string>
-	<!-- Do search in all sources -->
-	<string name="search_mode_all">Todos</string>
-	<!-- Do search near my position only -->
-	<string name="search_mode_nearme">Cerca de mí</string>
-	<!-- Do search in current viewport only -->
-	<string name="search_mode_viewport">En la pantalla</string>
 	<!-- Search category for cafes, bars, restaurants -->
 	<string name="eat">Dónde comer</string>
 	<!-- Search category for grocery stores -->
@@ -160,12 +130,8 @@
 	<string name="post">Oficina de correos</string>
 	<!-- Search category -->
 	<string name="police">Policía</string>
-	<!-- String in search result list, when nothing found -->
-	<string name="no_search_results_found">No se han encontrado resultados</string>
 	<!-- Notes field in Bookmarks view -->
 	<string name="description">Notas</string>
-	<!-- Button text -->
-	<string name="share_by_email">Enviar por email</string>
 	<!-- Email Subject when sharing bookmarks category -->
 	<string name="share_bookmarks_email_subject">Marcapáginas de Organic Maps compartidos contigo</string>
 	<!-- message title of loading file -->
@@ -176,20 +142,10 @@
 	<string name="load_kmz_failed">La carga de favoritos ha fallado. El archivo puede estar corrupto o ser defectuoso.</string>
 	<!-- Warning message when doing search around current position -->
 	<string name="unknown_current_position">Tu ubicación aún no ha sido determinada</string>
-	<!-- Warning message when location country isn't downloaded during search (see also download_location_map_proposal). -->
-	<string name="download_location_country">Descargar país de tu ubicación actual (%s)</string>
-	<!-- Warning message when viewport country isn't downloaded during search -->
-	<string name="download_viewport_country_to_search">Descargar país en el que estás buscando (%s)</string>
 	<!-- Alert message that we can't run Map Storage settings due to some reasons. -->
 	<string name="cant_change_this_setting">Lo sentimos, la configuración de Guardar Mapa está desactivada.</string>
 	<!-- Alert message that downloading is in progress. -->
 	<string name="downloading_is_active">Se está descargando un país.</string>
-	<!-- Message that will be shown in alert view, when we ask user to leave review on App Store -->
-	<string name="appStore_message">¡Ojalá disfrute mucho con Organic Maps! Si le gusta, le agradeceremos que puntúe nuestra aplicación en el App Store. Es menos de un minuto y nos sería de gran ayuda. ¡Gracias por su apoyo!</string>
-	<!-- No, thanks -->
-	<string name="no_thanks">No, gracias</string>
-	<!-- Share one specific bookmark using SMS, %1$@ contains om:// and %2$@ https://omaps.app link. @NOTE non-ascii symbols in the link will result in max 70 characters SMS instead of 140. -->
-	<string name="bookmark_share_sms">Ve mi alfiler en mapa. Abre %1$s o %2$s</string>
 	<!-- Share my position using SMS, %1$@ contains om:// and %2$@ https://omaps.app link WITHOUT NAME. @NOTE non-ascii symbols in the link will result in max 70 characters SMS instead of 140. -->
 	<string name="my_position_share_sms">Mira dónde estoy. Abre %1$s o %2$s</string>
 	<!-- Subject for emailed bookmark -->
@@ -198,30 +154,16 @@
 	<string name="my_position_share_email_subject">Mira mi ubicación actual en el mapa en Organic Maps</string>
 	<!-- Share my position using EMail, %1$@ is om:// and %2$@ is https://omaps.app link WITHOUT NAME -->
 	<string name="my_position_share_email">Hola:\n\nAhora estoy aquí: %1$s. Haz clic en este enlace %2$s o esta %3$s para verlo en el mapa.\n\nGracias.</string>
-	<!-- Android share by Message/SMS button text (including SMS) -->
-	<string name="share_by_message">Compartir por mensaje</string>
 	<!-- Share button text which opens menu with more buttons, like Message, EMail, Facebook etc. -->
 	<string name="share">Compartir</string>
-	<!-- iOS share by Message button text (including SMS) -->
-	<string name="message">Mensaje</string>
 	<!-- Share by email button text, also used in editor. -->
 	<string name="email">Correo electrónico</string>
-	<!-- Copy Link -->
-	<string name="copy_link">Copiar enlace</string>
-	<!-- Text for the button that returns to caller application -->
-	<string name="more_info">Mostrar más información</string>
 	<!-- Text for message when used successfully copied something -->
 	<string name="copied_to_clipboard">Copiado al portapapeles: %1$s</string>
 	<!-- place preview title -->
 	<string name="info">Información</string>
 	<!-- Used for bookmark editing -->
 	<string name="done">Hecho</string>
-	<!-- Summary for preferences in MWM -->
-	<string name="yopme_pref_summary">Seleccione la сonfiguración de la pantalla trasera</string>
-	<!-- Title for yopme preferences in MWM -->
-	<string name="yopme_pref_title">Configuración de la pantalla trasera</string>
-	<!-- Hint for upper-right icon p2b -->
-	<string name="show_on_backscreen">Mostrar en la pantalla trasera</string>
 	<!-- Prints version number in About dialog -->
 	<string name="version">Versión: %s</string>
 	<!-- Confirmation in downloading countries dialog -->
@@ -231,11 +173,6 @@
 	<!-- Length of track in cell that describes route -->
 	<string name="length">Longitud</string>
 	<string name="share_my_location">Compartir mi ubicación</string>
-	<string name="menu_search">Buscar</string>
-	<!-- Settings screen: "Map" category title -->
-	<string name="prefs_group_map">Mapa</string>
-	<!-- Settings screen: "Miscellaneous" category title -->
-	<string name="prefs_group_misc">Varios</string>
 	<string name="prefs_group_route">Navegación</string>
 	<string name="pref_zoom_title">Botones de zoom</string>
 	<string name="pref_zoom_summary">Visualización en la pantalla</string>
@@ -251,8 +188,6 @@
 	<string name="pref_map_3d_title">Vista de perspectiva</string>
 	<!-- Settings «Map» category: «3D buildings» title -->
 	<string name="pref_map_3d_buildings_title">Edificios en 3D</string>
-	<!-- Settings «Map» category: «3D buildings» summary -->
-	<string name="pref_map_3d_buildings_subtitle">Afecta a la duración de la batería</string>
 	<!-- Settings «Route» category: «Tts enabled» title -->
 	<string name="pref_tts_enable_title">Instrucciones de voz</string>
 	<!-- Settings «Route» category: «Tts language» title -->
@@ -261,7 +196,6 @@
 	<string name="pref_tts_unavailable">No disponible</string>
 	<!-- Title for "Other" section in TTS settings. -->
 	<string name="pref_tts_other_section_title">Otros</string>
-	<string name="pref_tts_how_to_set_up_voice">Cómo configurar la voz</string>
 	<!-- Settings «Map» category: «Record track» title -->
 	<string name="pref_track_record_title">Trayecto reciente</string>
 	<string name="pref_map_auto_zoom">Zoom automático</string>
@@ -272,46 +206,11 @@
 	<string name="duration_12_hours">12 horas</string>
 	<string name="duration_1_day">1 día</string>
 	<string name="recent_track_help_text">Permite registrar el recorrido realizado durante un determinado periodo de tiempo y verlo en el mapa. Tenga en cuenta que la activación de esta función aumenta el consumo de la batería. El registro del recorrido se eliminará automáticamente del mapa una vez vencido dicho periodo de tiempo.</string>
-	<string name="pref_track_ios_caption">El trayecto reciente muestra tu recorrido de viaje.</string>
-	<string name="pref_track_ios_subcaption">Por favor, selecciona la periodicidad para guardar el trayecto.</string>
-	<string name="placepage_distance">Distancia</string>
-	<string name="placepage_coordinates">Coordenadas</string>
-	<string name="placepage_unsorted">Sin clasificar</string>
 	<string name="search_show_on_map">Ver en el mapa</string>
-	<!-- Used to warn user when fixing KitKat issue -->
-	<string name="bookmark_move_fail">Tenemos que mover tus marcadores a la memoria interna, pero no hay espacio disponible para ellos. Por favor, libera memoria, en caso contrario, los marcadores no estarán disponibles.</string>
-	<!-- Used in More Apps menu -->
-	<string name="free">Gratis</string>
-	<!-- Used in More Apps menu -->
-	<string name="buy">Comprar</string>
-	<!-- 1st search button-like result -->
-	<string name="search_on_map">Buscar en mapa</string>
-	<!-- toast with an error -->
-	<string name="no_route_found">No se ha encontrado ninguna ruta</string>
-	<!-- route title -->
-	<string name="route">Ruta</string>
-	<!-- category title -->
-	<string name="routes">Rutas</string>
-	<!-- text of notification -->
-	<string name="download_map_notification">Descarga el mapa del lugar en que te encuentras</string>
-	<!-- text of notification -->
-	<string name="pro_version_is_free_today">¡Versión completa de Organic Maps gratis hoy! Descárgalo ahora y dilo a tus amigos.</string>
-	<!-- Dialog for transferring maps from lite to pro. -->
-	<string name="move_lite_maps_to_pro">Estamos transfiriendo tus mapas descargados de Organic Maps Lite a Organic Maps, lo cual puede llevar unos minutos.</string>
-	<!-- Message to display when maps moved. -->
-	<string name="move_lite_maps_to_pro_ok">Tus mapas descargados se han transferido correctamente a Organic Maps.</string>
-	<!-- Message to display when maps move failed. -->
-	<string name="move_lite_maps_to_pro_failed">No se han podido transferir tus mapas. Por favor, elimina Organic Maps Lite y descarga los mapas de nuevo.</string>
-	<!-- Text in menu -->
-	<string name="settings_and_more">Ajustes y más</string>
 	<!-- Text in menu -->
 	<string name="website">Sitio web</string>
-	<!-- Text in menu -->
-	<string name="contact_us">Contacta con nosotros</string>
 	<!-- Settings: Send feedback button and dialog title -->
 	<string name="feedback">Comentarios</string>
-	<!-- Text in menu -->
-	<string name="subscribe_to_news">Suscríbete a nuestras noticias</string>
 	<!-- Text in menu -->
 	<string name="rate_the_app">Valora la aplicación</string>
 	<!-- Text in menu -->
@@ -320,12 +219,6 @@
 	<string name="copyright">Copyright</string>
 	<!-- Text in menu -->
 	<string name="report_a_bug">Hay un error</string>
-	<!-- Email subject -->
-	<string name="subscribe_me_subject">Por favor quiero suscribirme al boletín de Organic Maps</string>
-	<!-- Email body -->
-	<string name="subscribe_me_body">Quiero ser el primero en conocer las últimas noticias actualizaciones y promociones. Puedo cancelar mi suscripción en cualquier momento.</string>
-	<!-- About text -->
-	<string name="about_text">Organic Maps ofrece los mapas sin conexión más rápidos de todas las ciudades y todos los países del mundo. Viaja con plena confianza: estés donde estés, Organic Maps te ayuda a ubicarte en el mapa, encontrar el restaurante, hotel, banco o gasolinera más próximo, etc. No requiere conexión a Internet.\n\nTrabajamos continuamente en el desarrollo de nuevas funcionalidades y nos encantaría conocer tu opinión sobre cómo podríamos mejorar Organic Maps. Si tienes cualquier problema con la aplicación, no dudes en contactar con nosotros en support\@organicmaps.app. ¡Respondemos a todas las solicitudes!\n\n¿Te gusta Organic Maps y quieres apoyarnos? Estas son algunas formas simples y totalmente gratis:\n\n- Publica una opinión en tu App Market\n- Dale a me gusta a nuestra página de Facebook http://www.facebook.com/OrganicMaps\n- O simplemente habla sobre Organic Maps a tu madre, amigos y colegas :)\n\nGracias por estar a nuestro lado. ¡Agradecemos mucho tu apoyo!\n\nPD: obtenemos datos de los mapas de OpenStreetMap, un proyecto de mapeo similar a Wikipedia, que permite a los usuarios crear y editar mapas. Si crees que falta algo o hay cualquier error en el mapa, puedes corregir los mapas directamente en https://www.openstreetmap.org y los cambios aparecerán en la aplicación Organic Maps en el próximo lanzamiento de la versión.</string>
 	<!-- Alert text -->
 	<string name="email_error_body">No se ha configurado el cliente de correo electrónico. Por favor, configúralo o utiliza alguna otra forma de ponerte en contacto con nosotros en %s</string>
 	<!-- Alert title -->
@@ -334,137 +227,56 @@
 	<string name="pref_calibration_title">Calibrado de la brújula</string>
 	<!-- Search category -->
 	<string name="wifi">WiFi</string>
-	<!-- Update map suggestion -->
-	<string name="routing_map_outdated">Por favor, actualiza el mapa para crear una ruta.</string>
-	<!-- Update maps suggestion -->
-	<string name="routing_update_maps">La nueva versión de Organic Maps permite crear rutas desde tu ubicación actual hasta un punto de destino. Por favor, actualiza los mapas para utilizar esta característica.</string>
 	<!-- Update all button text -->
 	<string name="downloader_update_all_button">Actualizar todos</string>
 	<!-- Cancel all button text -->
 	<string name="downloader_cancel_all">Cancelar todo</string>
 	<!-- Downloaded maps category -->
 	<string name="downloader_downloaded_subtitle">Descargado</string>
-	<!-- Downloaded maps category -->
-	<string name="downloader_available_maps">Disponible</string>
 	<!-- Country queued for download -->
 	<string name="downloader_queued">En cola</string>
 	<string name="downloader_near_me_subtitle">Cerca de mí</string>
 	<string name="downloader_status_maps">Mapas</string>
 	<string name="downloader_download_all_button">Descargar todos</string>
 	<string name="downloader_downloading">Descargando:</string>
-	<string name="downloader_search_results">Encontrado</string>
-	<!-- Disclaimer message -->
-	<string name="routing_disclaimer">Creando rutas en la aplicación Organic Maps, por favor, tenga en cuenta lo siguiente:\n\n  - Las rutas sugeridas se pueden considerar únicamente como recomendaciones.\n - Las condiciones de la carretera, las normas y las señales de tráfico tienen mayor prioridad que el consejo de navegación.\n - El mapa podría ser incorrecto o estar obsoleto y las rutas pueden no crear el mejor camino posible.\n\n  ¡Esté seguro en las carreteras y cuídese!</string>
-	<!-- Outdated maps category -->
-	<string name="downloader_outdated_maps">Anticuado</string>
-	<!-- Up to date maps category -->
-	<string name="downloader_uptodate_maps">Actualizado</string>
 	<!-- Status of outdated country in the list -->
 	<string name="downloader_status_outdated">Actualizar</string>
 	<!-- Status of failed country in the list -->
 	<string name="downloader_status_failed">Fallo</string>
 	<!-- Displayed in a dialog that appears when a user tries to delete a map while the app is in the follow route mode -->
 	<string name="downloader_delete_map_while_routing_dialog">Para eliminar el mapa, por favor, detén la navegación.</string>
-	<!-- Show when user try build route, but we don't know where he -->
-	<string name="routing_failed_unknown_my_position">La ubicación actual no está definida. Por favor, especifique la ubicación para crear la ruta.</string>
-	<!-- Show if use has not routing file, or InconsistentMWMandRoute -->
-	<string name="routing_failed_has_no_routing_file">Son necesarios datos adicionales para crear la ruta. ¿Empezar la descarga?</string>
-	<!-- StartPointNotFound -->
-	<string name="routing_failed_start_point_not_found">No se puede calcular la ruta. No hay carreteras cerca de su punto de partida.</string>
-	<!-- EndPointNotFound -->
-	<string name="routing_failed_dst_point_not_found">No se puede calcular la ruta. No hay carreteras cerca de su destino.</string>
 	<!-- PointsInDifferentMWM -->
 	<string name="routing_failed_cross_mwm_building">Solo se pueden crear rutas que estén totalmente incluidas en un mapa único.</string>
-	<!-- RouteNotFound -->
-	<string name="routing_failed_route_not_found">No se ha encontrado ninguna ruta entre el origen seleccionado y el destino. Por favor, seleccione un punto de partida o destino diferente.</string>
-	<!-- InternalError -->
-	<string name="routing_failed_internal_error">Se ha producido un error interno. Por favor, intente eliminar y descargar el mapa otra vez. Si el problema persiste, por favor contáctenos en support\@organicmaps.app.</string>
-	<!-- Context menu item for downloader. -->
-	<string name="downloader_download_map_and_routing">Descargar mapa + itinerario</string>
-	<!-- Context menu item for downloader. -->
-	<string name="downloader_download_routing">Descargar itinerario</string>
-	<!-- Context menu item for downloader. -->
-	<string name="downloader_delete_routing">Eliminar itinerario</string>
 	<!-- Context menu item for downloader. -->
 	<string name="downloader_download_map">Descargar el mapa</string>
-	<string name="downloader_download_map_no_routing">Descargar mapa sin ruta</string>
-	<!-- Button for routing. -->
-	<string name="routing_go">¡Listo!</string>
 	<!-- Item status in downloader. -->
 	<string name="downloader_retry">Repetir</string>
-	<!-- Item in context menu. -->
-	<string name="downloader_map_and_routing">Mapa + itinerario</string>
 	<!-- Item in context menu. -->
 	<string name="downloader_delete_map">Eliminar mapa</string>
 	<!-- Item in context menu. -->
 	<string name="downloader_update_map">Actualizar mapa</string>
-	<!-- Item in context menu. -->
-	<string name="downloader_update_map_and_routing">Actualizar mapa + itinerario</string>
-	<!-- Item in context menu. -->
-	<string name="downloader_map_only">Solo mapa</string>
-	<!-- Toolbar title -->
-	<string name="toolbar_application_menu">Menú de aplicación</string>
 	<!-- Preference text -->
 	<string name="pref_use_google_play">Usar los servicios de Google Play para obtener tu ubicación actual</string>
 	<!-- Text for rating dialog -->
 	<string name="rating_just_rated">Acabo de puntuar tu aplicación</string>
-	<!-- Text for rating dialog -->
-	<string name="rating_user_since">Soy usuario de Organic Maps desde %s</string>
-	<!-- Text for rating dialog -->
-	<string name="rating_do_like_maps">¿Te gusta Organic Maps?</string>
-	<!-- Text for rating dialog -->
-	<string name="rating_tap_star">Pulsa una estrella para puntuar tu aplicación.</string>
 	<!-- Text for rating dialog -->
 	<string name="rating_thanks">¡Gracias!</string>
 	<!-- Text for rating dialog -->
 	<string name="rating_share_ideas">Comparte ideas o informa de problemas para que podamos mejorar la aplicación para ti.</string>
 	<!-- Text for rating dialog -->
 	<string name="rating_send_feedback">Enviar comentarios</string>
-	<!-- Text for g+ dialog -->
-	<string name="rating_google_plus">Haz clic en g+ para hablar a tus amigos acerca de la app.</string>
 	<!-- Text for routing error dialog -->
 	<string name="routing_download_maps_along">Descarga mapas a lo largo de la ruta</string>
-	<!-- Text for routing error dialog -->
-	<string name="routing_download_map">Obtén el mapa</string>
-	<!-- Text for routing error dialog -->
-	<string name="routing_download_map_and_routing">Descarga el mapa actualizado y los datos de enrutamiento para conseguir todas las funciones de Organic Maps.</string>
-	<!-- Text for routing error dialog -->
-	<string name="routing_get_routing_data">Obtén datos de enrutamiento</string>
-	<!-- Text for routing error dialog -->
-	<string name="routing_get_additional_data">Datos adicionales necesarios para crear rutas desde tu ubicación.</string>
 	<!-- Text for routing error dialog -->
 	<string name="routing_requires_all_map">Para crear una ruta es necesario descargar y actualizar todos los mapas de la ubicación de destino.</string>
 	<!-- Text for routing error dialog -->
 	<string name="routing_not_enough_space">No hay suficiente espacio</string>
-	<!-- Text for routing error dialog -->
-	<string name="routing_download_more_than_avail">Necesitas descargar %1$s MB, pero solo hay %2$s MB disponibles.</string>
-	<!-- Text for routing error dialog -->
-	<string name="routing_download_roaming">Vas a descargar %s MB usando datos móviles (en itinerancia). Esto puede dar lugar a cargos adicionales, dependiendo del plan de datos móviles de tu operador.</string>
 	<!-- bookmark button text -->
 	<string name="bookmark">marcador</string>
-	<!-- map is not downloaded -->
-	<string name="not_found_map">El mapa de tu ubicación no se ha descargado</string>
 	<!-- location service disabled -->
 	<string name="enable_location_services">Por favor, permite los servicios de localización</string>
-	<!-- download map -->
-	<string name="download_map">Descarga el mapa de tu ubicación</string>
-	<!-- download map on iPhone -->
-	<string name="download_map_iphone">Descarga el mapa para la ubicación actual en tu iPhone</string>
-	<!-- clear pin -->
-	<string name="nearby">Cerca</string>
-	<!-- clear pin -->
-	<string name="clear_pin">Borrar alfiler</string>
-	<!-- location is undefined -->
-	<string name="undefined_location">La ubicación actual no está definida.</string>
-	<!-- download country of your location -->
-	<string name="download_country">Descargar país de tu ubicación actual</string>
-	<!-- download failed -->
-	<string name="download_failed">la descarga ha fallado</string>
-	<!-- get the map -->
-	<string name="get_the_map">Obtén el mapa</string>
 	<string name="save">Guardar</string>
 	<string name="edit_description_hint">Tus descripciones (texto o html)</string>
-	<string name="new_group">nuevo grupo</string>
 	<string name="create">crear</string>
 	<!-- red color -->
 	<string name="red">Rojo</string>
@@ -482,22 +294,6 @@
 	<string name="brown">Marrón</string>
 	<!-- pink color -->
 	<string name="pink">Rosa</string>
-	<!-- deep purple color -->
-	<string name="deep_purple">Morado oscuro</string>
-	<!-- light blue color -->
-	<string name="light_blue">Azul Claro</string>
-	<!-- cyan color -->
-	<string name="cyan">Cian</string>
-	<!-- teal color -->
-	<string name="teal">Verde azulado</string>
-	<!-- lime color -->
-	<string name="lime">Lima</string>
-	<!-- deep orange color -->
-	<string name="deep_orange">Naranja oscuro</string>
-	<!-- gray color -->
-	<string name="gray">Gris</string>
-	<!-- blue gray color -->
-	<string name="blue_gray">Gris azulado</string>
 	<!-- Wi-Fi available -->
 	<string name="WiFi_available">Sí</string>
 
@@ -513,10 +309,8 @@
 	<string name="dialog_routing_location_turn_wifi">Verifique la señal del GPS. Activar Wi-Fi mejorará la precisión de su ubicación.</string>
 	<string name="dialog_routing_location_turn_on">Activar servicios de ubicación</string>
 	<string name="dialog_routing_location_unknown_turn_on">No se pueden encontrar las coordenadas del GPS. Active los servicios de ubicación para calcular la ruta.</string>
-	<string name="dialog_routing_location_unknown">No se pueden encontrar las coordenadas actuales del GPS.</string>
 	<string name="dialog_routing_download_files">Descargar archivos requeridos</string>
 	<string name="dialog_routing_download_and_update_all">Descargue y actualice toda la información de mapas y rutas junto con el trayecto proyectado para calcular la ruta.</string>
-	<string name="dialog_routing_routes_size">Archivos de información de ruta</string>
 	<string name="dialog_routing_unable_locate_route">Imposible encontrar ruta</string>
 	<string name="dialog_routing_cant_build_route">No se puede crear la ruta.</string>
 	<string name="dialog_routing_change_start_or_end">Ajuste su punto de inicio o su destino.</string>
@@ -531,33 +325,23 @@
 	<string name="dialog_routing_system_error">Error del sistema</string>
 	<string name="dialog_routing_application_error">No se pudo crear la ruta debido a un error en la aplicación.</string>
 	<string name="dialog_routing_try_again">Intentar nuevamente</string>
-	<string name="dialog_routing_send_error">Informar el problema</string>
-	<string name="dialog_routing_if_get_cross_route">¿Desea crear una ruta más directa que abarca más de un mapa?</string>
-	<string name="dialog_routing_cross_route_is_optimal">Está disponible una ruta mejor que cruza los límites de este mapa.</string>
 	<string name="not_now">No ahora</string>
-	<string name="dialog_routing_build_route">Crear</string>
 	<string name="dialog_routing_download_and_build_cross_route">¿Desea descargar el mapa y crear una ruta mejor que abarca más de un mapa?</string>
 	<string name="dialog_routing_download_cross_route">Descargar el mapa para crear una ruta mejor que cruza los límites de este mapa.</string>
-	<string name="dialog_routing_cross_route_always">Cruzar siempre este límite</string>
 
 	<!-- SECTION: Strings for downloading map from search -->
 	<string name="search_without_internet_advertisement">Para empezar a buscar y crear rutas, por favor, descarga el mapa y no necesitarás conexión a Internet nunca más para usarlo.</string>
 	<string name="search_select_map">Seleccionar el mapa</string>
-	<string name="search_select_other_map">Seleccionar otro mapa</string>
 	<!-- «Show» context menu -->
 	<string name="show">Mostrar</string>
 	<!-- «Hide» context menu -->
 	<string name="hide">Ocultar</string>
 	<!-- «Rename» context menu -->
 	<string name="rename">Renombrar</string>
-	<!-- Bottom sheet: expand button (should be short) -->
-	<string name="bottom_sheet_more">Más…</string>
 	<!-- Failed planning route message in navigation view -->
 	<string name="routing_planning_error">Error al planificar la ruta</string>
 	<!-- Arrive routing message in navigation view -->
 	<string name="routing_arrive">Llegada: %s</string>
-	<!-- Text for routing::RouterResultCode::FileTooOld dialog. -->
-	<string name="dialog_routing_download_and_update_maps">Para crear una ruta, por favor, descarga y actualiza todos los mapas a lo largo de la ruta.</string>
 	<string name="rate_alert_title">¿Te gusta la aplicación?</string>
 	<string name="rate_alert_default_message">Gracias por usar Organic Maps. Por favor, puntúa la aplicación. Tus comentarios nos ayudan a mejorar.</string>
 	<string name="rate_alert_five_star_message">¡Genial! ¡Nosotros también te queremos!</string>
@@ -565,24 +349,14 @@
 	<string name="rate_alert_less_than_four_star_message">¿Alguna idea de cómo podemos mejorarla?</string>
 	<string name="categories">Categorías</string>
 	<string name="history">Historial</string>
-	<string name="next_turn_then">Luego</string>
 	<string name="closed">Cerrado</string>
-	<string name="back_to">Volver a %s</string>
 	<string name="search_not_found">Lo siento, no he encontrado nada.</string>
 	<string name="search_not_found_query">Por favor, prueba con otra consulta.</string>
-	<string name="search_not_found_map">Por favor, descarga el mapa en el que estás buscando.</string>
-	<string name="search_not_found_location">Descarga el mapa de tu ubicación actual.</string>
 	<string name="search_history_title">Historial de búsquedas</string>
 	<string name="search_history_text">Acceder rápidamente a las consultas de búsquedas recientes.</string>
 	<string name="clear_search">Eliminar el historial de búsqueda</string>
-	<!-- Title for settings to enable/disable showcase menu button -->
-	<string name="showcase_settings_title">Mostrar ofertas</string>
-	<string name="p2p_route_planning">Planificación de ruta</string>
 	<string name="p2p_your_location">Tu ubicación</string>
-	<string name="p2p_from">El punto de origen</string>
-	<string name="p2p_to">El punto de destino</string>
 	<string name="p2p_start">Empezar</string>
-	<string name="p2p_planning">Planeando…</string>
 	<string name="p2p_from_here">Desde</string>
 	<string name="p2p_to_here">Ruta hacia</string>
 	<string name="p2p_only_from_current">La navegación solo está disponible desde tu ubicación actual.</string>
@@ -602,11 +376,8 @@
 	<string name="editor_hours_closed">Horas de cierre</string>
 	<string name="editor_example_values">Valores de ejemplo</string>
 	<string name="editor_correct_mistake">Corregir error</string>
-	<string name="editor_correct_mistake_message">Ha cometido un error de edición. Por favor, corríjalo o cambie a modo sencillo.</string>
 	<string name="editor_add_select_location">Ubicación</string>
 	<string name="editor_done_dialog_1">Has cambiado el mapa del mundo. ¡No ocultarlo! Cuéntaselo a tus amigos y editadlo juntos.</string>
-	<string name="editor_done_dialog_2">Esta es tu segunda mejora del mapa. Ahora estás en el puesto %dº de la lista de editores de mapa. Cuéntaselo a tus amigos.</string>
-	<string name="editor_done_dialog_3">Has mejorado el mapa: cuéntaselo a tus amigos y editadlo juntos.</string>
 	<string name="share_with_friends">Compartir con amigos</string>
 	<string name="editor_report_problem_desription_1">Por favor, describe el problema en detalle para que la comunidad de OpenStreeMap pueda corregir el error.</string>
 	<string name="editor_report_problem_desription_2">O hazlo tú mismo en https://www.openstreetmap.org/</string>
@@ -615,14 +386,7 @@
 	<string name="editor_report_problem_no_place_title">El lugar no existe</string>
 	<string name="editor_report_problem_under_construction_title">Сerrado por mantenimiento</string>
 	<string name="editor_report_problem_duplicate_place_title">Lugar duplicado</string>
-	<string name="first_launch_congrats_title">Organic Maps está listo para usar</string>
-	<string name="first_launch_congrats_text">Busca y navega sin conexión por cualquier parte del mundo, sin cargos.</string>
-	<string name="migrate_title">¡Importante!</string>
-	<!-- Android uses image instead of text. -->
-	<string name="download_all">Descargar todos</string>
-	<string name="delete_all">Eliminar todos</string>
 	<string name="autodownload">Descarga automática</string>
-	<string name="disable_autodownload">Desactivar descarga automática</string>
 	<!-- Place Page opening hours text -->
 	<string name="closed_now">Cerrado ahora</string>
 	<!-- Place Page opening hours text -->
@@ -631,8 +395,6 @@
 	<string name="day_off_today">Día libre hoy</string>
 	<string name="day_off">Día libre</string>
 	<string name="today">Hoy</string>
-	<string name="sunrise_to_sunset">Del amanecer al atardecer</string>
-	<string name="sunset_to_sunrise">Del amanecer al anochecer</string>
 	<string name="add_opening_hours">Añadir horas comerciales</string>
 	<string name="edit_opening_hours">Editar las horas comerciales</string>
 	<string name="no_osm_account">¿No tienes cuenta en OpenStreetMap?</string>
@@ -642,29 +404,13 @@
 	<string name="login">Iniciar sesión</string>
 	<string name="password">Contraseña</string>
 	<string name="forgot_password">¿Has olvidado tu contraseña?</string>
-	<!-- Forgot Password dialog title -->
-	<string name="restore_password">Restaurar contraseña</string>
-	<string name="enter_email_address_to_reset_password">Introduce la dirección de correo electrónico que utilizaste durante el registro y te enviaremos el enlace para restaurar tu contraseña.</string>
-	<string name="reset_password">Restablecer contraseña</string>
-	<string name="username">Usuario</string>
 	<string name="osm_account">Cuenta OSM</string>
 	<string name="logout">Cerrar sesión</string>
-	<string name="login_and_edit_map_motivation_message">Inicia sesión y edita la información de los objetos en el mapa y los pondremos a disposición de millones de otros usuarios. Hagamos de este mundo un lugar mejor.</string>
 	<!-- Information text: "Last upload 11.01.2016" -->
 	<string name="last_upload">Última carga</string>
-	<!-- Motivates user to login/register, title above login buttons. -->
-	<string name="you_have_edited_your_first_object">¡Has editado tu primer objeto!</string>
 	<string name="thank_you">Gracias</string>
-	<string name="login_with_google">Iniciar sesión con Google</string>
-	<string name="login_with_openstreetmap">Iniciar sesión con www.openstreetmap.org</string>
 	<string name="edit_place">Editar el lugar</string>
 	<string name="place_name">Nombre del lugar</string>
-	<!-- title above languages list cells in the editor, below editable name text field. -->
-	<string name="other_languages">Otros idiomas</string>
-	<!-- small button to open list with names in different languages -->
-	<string name="show_more">Mostrar más</string>
-	<!-- small button to close list with names in different languages -->
-	<string name="show_less">Mostrar menos</string>
 	<string name="add_language">Añadir un idioma</string>
 	<string name="street">Calle</string>
 	<!-- Editable House Number text field (in address block). -->
@@ -681,25 +427,16 @@
 	<string name="email_or_username">Correo electrónico o usuario</string>
 	<string name="phone">Teléfono</string>
 	<string name="please_note">Aviso</string>
-	<string name="common_no_wifi_dialog">No hay conexión Wi-Fi. ¿Quieres continuar con los datos móviles?</string>
 	<string name="downloader_delete_map_dialog">Todos los cambios en los mapas se borrarán junto con el mapa.</string>
 	<string name="downloader_update_maps">Autodescarga de mapas</string>
 	<string name="downloader_mwm_migration_dialog">Los mapas empiezan a descargarse automáticamente cuando te aproximas al mapa.</string>
 	<string name="downloader_search_field_hint">Encontrar el mapa</string>
-	<string name="migration_update_all_button">Actualizar todos los mapas</string>
-	<string name="migration_delete_all_download_current_button">Descargar el mapa actual y eliminar los mapas antiguos</string>
 	<string name="migration_download_error_dialog">Error de descarga</string>
 	<string name="common_check_internet_connection_dialog">Por favor, verifica la configuración y asegúrate de que tu dispositivo está conectado a Internet.</string>
 	<string name="downloader_no_space_title">Sin espacio suficiente</string>
 	<string name="downloader_no_space_message">Por favor, elimina los datos innecesarios</string>
-	<string name="editor_general_auth_error_dialog">Error general de inicio de sesión.</string>
 	<string name="editor_login_error_dialog">Error de inicio de sesión.</string>
-	<string name="editor_login_failed_dialog">Error al iniciar sesión</string>
-	<string name="editor_username_error_dialog">Usuario no válido</string>
-	<string name="editor_place_edited_dialog">¡Has editado un objeto!</string>
-	<string name="editor_login_with_osm">Iniciar sesión con OpenStreetMap</string>
 	<string name="editor_profile_changes">Cambios verificados</string>
-	<string name="editor_profile_unsent_changes">No enviado:</string>
 	<string name="editor_focus_map_on_location">Arrastra el mapa para seleccionar la ubicación correcta del objeto.</string>
 	<string name="editor_add_select_category">Seleccionar categoría</string>
 	<string name="editor_add_select_category_popular_subtitle">Popular</string>
@@ -710,19 +447,14 @@
 	<string name="editor_edit_place_category_title">Categoría</string>
 	<string name="detailed_problem_description">Descripción al detalle del problema</string>
 	<string name="editor_report_problem_other_title">Un problema diferente</string>
-	<string name="placepage_report_problem_button">Informar de un problema</string>
 	<string name="placepage_add_business_button">Añadir organización</string>
 	<string name="whatsnew_editor_message_1">Añadir lugares nuevos al mapa y editar los lugares actuales directamente desde la aplicación.</string>
-	<string name="whatsnew_editor_message_2">* Organic Maps utiliza datos de la comunidad de OpenStreetMap.</string>
 	<string name="dialog_incorrect_feature_position">Cambiar ubicación</string>
 	<string name="message_invalid_feature_position">No se puede ubicar ningún objeto aquí</string>
 	<string name="login_to_make_edits_visible">Inicia sesión para que otros usuarios puedan ver los cambios que has efectuado.</string>
-	<string name="no_migration_during_navigation">No se permite la actualización durante la navegación.</string>
 	<!-- Error dialog no space -->
 	<string name="migration_no_space_message">Necesitas más espacio para descargar. Por favor, elimina los datos innecesarios.</string>
 	<string name="editor_sharing_title">He mejorado los mapas de Organic Maps</string>
-	<string name="editor_comment_will_be_sent">Enviaremos tus comentarios a los cartógrafos.</string>
-	<string name="editor_unsupported_category_message">Has añadido un lugar de una categoría que no hemos incluido aún. Aparecerá en el mapa en unos momentos.</string>
 	<!-- Downloaded 10 **of** 20 <- it is that "of" -->
 	<string name="downloader_of">%1$d de %2$d</string>
 	<string name="download_over_mobile_header">¿Descargar con conexión de red móvil?</string>
@@ -740,15 +472,8 @@
 	<string name="editor_detailed_description">Los cambios que ha sugerido se enviarán a la comunidad de OpenStreetMap. Describa los detalles que no pueden editarse en Organic Maps.</string>
 	<string name="editor_more_about_osm">Más acerca de OpenStreetMap</string>
 	<string name="editor_operator">Operador</string>
-	<string name="editor_tag_description">Introduzca la empresa, organización o individuo responsable de las instalaciones.</string>
-	<string name="editor_no_local_edits_title">No tiene ediciones locales</string>
-	<string name="editor_no_local_edits_description">Esto muestra el número de sus cambios sugeridos en el mapa que actualmente solo son accesibles desde su dispositivo.</string>
-	<string name="editor_send_to_osm">Enviar a OSM</string>
-	<string name="editor_remove">Eliminar</string>
-	<string name="downloader_my_maps_title">Mis mapas</string>
 	<string name="downloader_no_downloaded_maps_title">No ha descargado ningún mapa</string>
 	<string name="downloader_no_downloaded_maps_message">Descargue mapas para encontrar la ubicación y navegar sin conexión.</string>
-	<string name="downloader_find_place_hint">Buscar ciudad o país</string>
 	<!-- Error title that appears after certain time without location. -->
 	<string name="current_location_unknown_title">¿Continuar detectando su ubicación actual?</string>
 	<!-- Error that appears after certain time without location. -->
@@ -763,27 +488,10 @@
 	<string name="location_services_disabled_2">2. Pulsa \"Ubicación\"</string>
 	<!-- iOS Dialog for the case when the location permission is not granted -->
 	<string name="location_services_disabled_3">3. Seleccionar Al usar la aplicación</string>
-	<string name="placepage_parking_surface">Superficie</string>
-	<string name="placepage_parking_multistorey">Varias plantas</string>
-	<string name="placepage_parking_underground">Subterráneo</string>
-	<string name="placepage_parking_rooftop">Azotea</string>
-	<string name="placepage_parking_sheds">Cobertizos</string>
-	<string name="placepage_parking_carports">Cochera</string>
-	<string name="placepage_parking_boxes">Garaje</string>
-	<string name="placepage_parking_pay">De pago</string>
-	<string name="placepage_parking_free">Gratuito</string>
-	<string name="placepage_parking_interval">Pago por intervalos</string>
-	<string name="placepage_entrance_number">N.º</string>
-	<string name="placepage_entrance_type">Entrada</string>
-	<string name="placepage_flat">aplicación</string>
-	<string name="placepage_open_24_7">24 / 7</string>
 	<string name="meter">m</string>
 	<string name="kilometer">km</string>
-	<string name="kilometers_per_hour">km/h</string>
 	<string name="mile">mile</string>
 	<string name="foot">pie</string>
-	<string name="miles_per_hour">mph</string>
-	<string name="day">d</string>
 	<string name="hour">h</string>
 	<string name="minute">min</string>
 	<string name="placepage_place_description">Descripción</string>
@@ -793,46 +501,30 @@
 	<string name="placepage_call_button">Llamar</string>
 	<string name="placepage_edit_bookmark_button">Editar marcador</string>
 	<string name="placepage_bookmark_name_hint">Nombre del marcador</string>
-	<string name="placepage_personal_notes_hint">Notas personales</string>
-	<string name="placepage_delete_bookmark_button">Eliminar marcador</string>
 	<string name="editor_edits_sent_message">Se han enviado sus cambios sugeridos</string>
 	<string name="editor_comment_hint">Comentario…</string>
 	<string name="editor_reset_edits_message">¿Restablecer todos los cambios locales?</string>
 	<string name="editor_reset_edits_button">Restablecer</string>
 	<string name="editor_remove_place_message">¿Eliminar el lugar añadido?</string>
 	<string name="editor_remove_place_button">Eliminar</string>
-	<string name="editor_status_sending">Enviando…</string>
 	<string name="editor_place_doesnt_exist">El lugar no existe</string>
 	<string name="text_more_button">…más</string>
 	<!-- Phone number error message -->
 	<string name="error_enter_correct_phone">Introduce un número de teléfono correcto</string>
 	<string name="error_enter_correct_web">Introduce una dirección web válida</string>
 	<string name="error_enter_correct_email">Introduce un email válido</string>
-	<string name="error_enter_correct">Introduce un valor válido</string>
 	<string name="refresh">Actualizar</string>
-	<string name="last_update">Última actualización: %s</string>
 	<string name="placepage_add_place_button">Añadir un lugar al mapa</string>
 	<!-- Displayed when saving some edits to the map to warn against publishing personal data -->
 	<string name="editor_share_to_all_dialog_title">¿Quieres enviarlo a todos los usuarios?</string>
 	<!-- iOS Dialog before publishing the modifications to the public map. -->
 	<string name="editor_share_to_all_dialog_message_1">Asegúrate de que no has introducido ningún dato personal.</string>
 	<string name="editor_share_to_all_dialog_message_2">Comprobaremos los cambios. Si tenemos cualquier pregunta, te contactaremos por correo electrónico.</string>
-	<string name="navigation_overview_button">resumen</string>
-	<string name="navigation_stop_button">parada</string>
-	<!-- Text on an empty bookmark page -->
-	<string name="bookmarks_empty_title">Guardar marcadores</string>
-	<string name="bookmarks_empty_message_1">Pulsa ★ para guardar los lugares favoritos a los que podrás acceder rápidamente.</string>
-	<string name="bookmarks_empty_message_2">Importar marcadores desde Mail y la web.</string>
-	<string name="bookmarks_empty_message_3">hora de salida: %s</string>
-	<!-- Name of the group for booked hotels -->
-	<string name="bookmarks_group_name">Hoteles reservados</string>
-	<string name="place_page_button_read_descriprion">Leer</string>
 	<!-- iOS dialog for the case when recent track recording is on and the app comes back from background -->
 	<string name="recent_track_background_dialog_title">¿Deshabilitar registro de ruta recorrida recientemente?</string>
 	<string name="off_recent_track_background_button">Deshabilitar</string>
 	<!-- For sharing via SMS and so on -->
 	<string name="sharing_call_action_look">Comprueba</string>
-	<string name="continue_recent_track_background_button">Continuar</string>
 	<string name="recent_track_background_dialog_message">Organic Maps usa tu geolocalización en segundo plano para registrar tu ruta recorrida recientemente.</string>
 	<!-- Rate on Google Play (Android only) -->
 	<string name="rate_gp">Valorar en Google Play</string>
@@ -842,21 +534,11 @@
 	<string name="tell_friends_text">¡Hola! ¡Instala Organic Maps!</string>
 	<!-- About short text (below logo) -->
 	<string name="about_description">Organic Maps es una aplicación esencial offline para viajar. Organic Maps se basa en datos de OpenStreetMap y permite editarla.</string>
-	<!-- Text in menu -->
-	<string name="blog">Blog</string>
 	<string name="general_settings">Ajustes generales</string>
-	<string name="date">Fecha %d</string>
-	<!-- "Report a bug" -> "Generaal Feedback" -> "Something is not working" -->
-	<string name="something_is_not_working">Algo no funciona</string>
 	<!-- For the first routing -->
 	<string name="accept">Aceptar</string>
 	<!-- For the first routing -->
 	<string name="decline">Declinar</string>
-	<string name="install_app">Instalar</string>
-	<string name="search_no_results_title">No se han encontrado resultados</string>
-	<string name="search_no_results_message">Pruebe un término de búsqueda general, aléjese o restablezca el filtro.</string>
-	<string name="search_no_results_expand_area_button">Alejarse</string>
-	<string name="search_no_results_reset_button">Restablecer filtro</string>
 	<!-- noun -->
 	<string name="search_in_table">Lista</string>
 	<string name="mobile_data_dialog">¿Usar Internet móvil para mostrar información detallada?</string>
@@ -868,18 +550,13 @@
 	<string name="mobile_data_option_never">No usar nunca</string>
 	<string name="mobile_data_option_ask">Preguntar siempre</string>
 	<string name="traffic_update_maps_text">Para mostrar los datos de tráfico, deben actualizarse los mapas.</string>
-	<string name="traffic_outdated">Los datos de tráfico están obsoletos.</string>
 	<string name="big_font">Aumentar el tamaño de fuente en el mapa</string>
 	<string name="traffic_update_app">Por favor, actualice Organic Maps</string>
 	<!-- "traffic" as in road congestion -->
 	<string name="traffic_update_app_message">Para mostrar los datos de tráfico, debe actualizar la aplicación.</string>
 	<!-- "traffic" as in "road congestion" -->
 	<string name="traffic_data_unavailable">Los datos de tráfico no están disponibles</string>
-	<!-- Simplified colour scheme for traffic information, fewer colours are used to display traffic jams on the map. The string should be kept as short as possible -->
-	<string name="pref_traffic_simplified_colors_title">Colores simples para tráfico</string>
 	<string name="enable_logging">Habilitar historial</string>
-	<string name="offline_place_page_more_information">Conéctese a internet para obtener más información sobre este lugar.</string>
-	<string name="failed_load_information">No se ha podido cargar la información.</string>
 	<!-- Settings: "Send general feedback" button -->
 	<string name="feedback_general">Opinión general</string>
 	<string name="on">Act.</string>
@@ -893,57 +570,26 @@
 	<string name="routing_add_start_point">Buscar un origen para el plan de ruta</string>
 	<string name="routing_add_finish_point">Buscar un destino para el plan de ruta</string>
 	<string name="button_exit">Salir</string>
-	<string name="settings_device_memory">Memoria del dispositivo</string>
-	<string name="settings_card_memory">Tarjeta de memoria</string>
-	<string name="settings_storage_available">%s disponible</string>
-	<string name="toast_location_permission_denied">A la aplicación se le ha denegado el permiso de acceso a la ubicación</string>
-	<string name="button_use">Utilizar</string>
 	<string name="planning_route_manage_route">Administrar ruta</string>
 	<string name="button_plan">Planificar</string>
-	<string name="button_add">Añadir</string>
 	<string name="placepage_remove_stop">Eliminar</string>
 	<string name="planning_route_remove_title">Arrastre aquí para eliminar</string>
-	<string name="dialog_change_start_point_message">¿Cambiar el punto de inicio por la ubicación actual?</string>
-	<string name="button_replace">Cambiar</string>
 	<string name="placepage_add_stop">Añadir parada</string>
-	<string name="add_my_position">Añadir mi posición</string>
-	<string name="choose_start_point">Elegir un punto de partida</string>
-	<string name="choose_destination">Elegir un destino</string>
 	<string name="preloader_viator_button">Más información</string>
-	<string name="start_from_my_position">Empezar desde</string>
-	<string name="profile_authorization_title">Iniciar sesión con</string>
-	<string name="profile_authorization_message">Inicie sesión fácilmente sin nombre de usuario ni contraseña en un par de segundos</string>
 	<string name="profile_authorization_error">Vaya, se ha producido un error. Intente iniciar sesión de nuevo.</string>
-	<string name="service">Servicio</string>
-	<string name="atmosphere">Ambiente</string>
-	<string name="value_for_money">Relación calidad-precio</string>
-	<string name="experience">Experiencia</string>
-	<string name="assortment">Variedad</string>
-	<string name="expertise">Conocimiento</string>
-	<string name="equipment">Equipamiento</string>
-	<string name="quality">Calidad</string>
 	<string name="dialog_error_storage_title">Problema de acceso al almacenamiento</string>
 	<string name="dialog_error_storage_message">El almacenamiento externo no está disponible; puede que se haya quitado o dañado la tarjeta SD, o el sistema de archivos solo permite lectura. Por favor, compruébelo y escríbanos a support\@organicmaps.app</string>
 	<string name="setting_emulate_bad_storage">Emular almacenamiento dañado</string>
-	<string name="directions_finish">Destino</string>
-	<string name="directions_on_foot">%s a pie</string>
 	<string name="core_entrance">Entrada</string>
-	<string name="coffee">Café</string>
-	<string name="cleanliness">Limpieza</string>
-	<string name="crowdedness">Lugar concurrido</string>
 	<string name="error_enter_correct_name">Por favor, introduzca el nombre correcto</string>
 	<string name="bookmarks_groups">Listas</string>
 	<string name="bookmarks_groups_hide_all">Ocultar todo</string>
 	<string name="bookmarks_groups_show_all">Mostrar todo</string>
-	<plurals name="bookmarks_places">
-	  <item quantity="other">%d marcadores</item>
-	</plurals>
 	<string name="bookmarks_create_new_group">Crear nueva lista</string>
 	<string name="downloader_hide_screen">Ocultar pantalla</string>
 	<string name="downloader_percent">%1$s (%2$s de %3$s)</string>
-	<string name="downloader_process">Descargando %s...</string>
-	<string name="downloader_applying">Aplicando %s...</string>
-	<string name="dialog_message_transit_not_found_connection">Planea una ruta en una red de tránsito</string>
+	<string name="downloader_process">Descargando %s…</string>
+	<string name="downloader_applying">Aplicando %s…</string>
 	<string name="bookmarks_error_message_share_general">No se puede compartir debido a un error de la aplicación</string>
 	<string name="bookmarks_error_title_share_empty">Error al compartir</string>
 	<string name="bookmarks_error_message_share_empty">No se puede compartir una lista vacía</string>
@@ -952,12 +598,7 @@
 	<string name="bookmarks_new_list_hint">Lista nueva</string>
 	<string name="bookmarks_error_title_list_name_already_taken">Este nombre ya ha sido tomado</string>
 	<string name="bookmarks_error_message_list_name_already_taken">Por favor elige otro nombre</string>
-	<string name="bookmarks_error_title_list_name_too_long">Este nombre es demasiado largo</string>
-	<string name="bookmarks_error_message_list_name_too_long">Por favor elige otro nombre</string>
-	<string name="please_wait">Por favor espera...</string>
-	<string name="phone_number">Número de teléfono</string>
-	<string name="notification_unsent_reviews_title">Tienes varias reseñas sin enviar</string>
-	<string name="notification_unsent_reviews_message">Inicia sesión para compartir comentarios con otros viajeros</string>
+	<string name="please_wait">Por favor espera…</string>
 	<string name="profile">Perfil de OpenStreetMap</string>
 	<string name="place_page_search_similar_hotel">Buscar hoteles similares</string>
 	<string name="bookmarks_detect_title">Nuevos archivos detectados</string>
@@ -968,31 +609,10 @@
 	<string name="button_convert">Convertir</string>
 	<string name="bookmarks_convert_error_title">Error</string>
 	<string name="bookmarks_convert_error_message">Algunos archivos no fueron convertidos.</string>
-	<string name="converting">Mudado...</string>
-	<string name="wn_reinvented_bookmarks_title">¡Hemos reinventado marcadores!</string>
-	<string name="wn_reinvented_bookmarks_message">Puede hacer una copia de seguridad de los marcadores, crear listas... Es increíble...</string>
-	<string name="bookmarks_restore">Restaurar marcadores</string>
-	<string name="bookmarks_restore_process">Restaurando...</string>
 	<string name="bookmarks_restore_title">Restaurar esta versión?</string>
-	<string name="bookmarks_restore_message">Tus marcadores se restaurarán desde %1$s (%2$s)</string>
-	<string name="bookmarks_restore_empty_title">No tienes una copia de seguridad</string>
-	<string name="bookmarks_restore_empty_message">El servidor no encontró copias de seguridad previamente hechas</string>
 	<string name="common_check_internet_connection_dialog_title">Sin conexión a Internet</string>
-	<string name="error_server_title">Error del Servidor</string>
-	<string name="error_server_message">Hubo un error en el servidor, intente de nuevo más tarde</string>
 	<string name="error_system_message">Un error desconocido ocurrió</string>
 	<string name="restore">Restaurar</string>
-	<string name="bookmarks_page_downloaded">Descargado</string>
-	<string name="bookmarks_page_my">Mis</string>
-	<string name="routes_and_bookmarks">Rutas y marcadores</string>
-	<string name="bookmarks_webview_success_toast">Marcadores descargados exitosamente</string>
-	<string name="cached_bookmarks_placeholder_title">Descargar nuevos lugares</string>
-	<string name="cached_bookmarks_placeholder_subtitle">Presione el botón para descargar miles de lugares y rutas interesantes creadas por usuarios de Organic Maps. Necesitará una conexión a Internet.</string>
-	<string name="downloader_download_routers">Descargar marcadores</string>
-	<string name="bookmarks_groups_cached">Listas descargadas</string>
-	<plurals name="bookmarks_objects">
-	  <item quantity="other">%s objeto</item>
-	</plurals>
 	<plurals name="objects">
 	  <item quantity="other">%d lugar</item>
 	</plurals>
@@ -1005,62 +625,32 @@
 	<string name="subtittle_opt_out">Configuraciones de seguimiento</string>
 	<string name="crash_reports">Informe de incidentes</string>
 	<string name="crash_reports_description">Puede que utilicemos vuestros datos para mejorar la experiencia de Organic Maps. Los cambios tendrán efecto después que reinicie la aplicación.</string>
-	<string name="opt_out_help_ios_1">Su dispositivo móvil puede tener una opción de «Limitar el seguimiento de anuncios» o «Excluir anuncios basados en intereses».</string>
-	<string name="opt_out_help_ios_2">iOS 9 o más reciente</string>
-	<string name="opt_out_help_ios_3">Diríjase a su Configuración → Privacidad → Publicidad → Habilite la opción «Limitar seguimiento»</string>
-	<string name="opt_out_help_android">Su dispositivo móvil puede proporcionar una configuración para «Limitar el seguimiento de anuncios» o «Excluir anuncios basados en intereses». \n\nPara la versión 4.0 o más reciente de Android y Servicios de Google Play :\nConfiguración → Google → Anuncios → Excluir Personalización de Anuncios\nor\nConfiguración → Google → Cuenta de Google → Información personal y privacidad → Configuración de Anuncios → Personalización de Anuncios</string>
 	<string name="privacy_policy">Política de Privacidad</string>
 	<string name="terms_of_use">Condiciones de uso</string>
-	<string name="backup_notification_failed">La copia de suguridad de sus marcadores ha sido suspendida. Inicie sesión para volverla a iniciar.</string>
 	<string name="button_layer_traffic">Tráfico</string>
 	<string name="button_layer_subway">Metro</string>
 	<string name="layers_title">Capas del mapa</string>
-	<string name="layers_message">Utilice las capas del mapa para mostrar el tráfico, el mapa del metro, y otra información útil</string>
-	<string name="button_layer_got_it">Listo</string>
 	<string name="subway_data_unavailable">El mapa del metro no está disponible</string>
 	<string name="bookmarks_empty_list_title">Esta lista está vacía</string>
 	<string name="bookmarks_empty_list_message">Para agregar un marcador, toque un lugar en el mapa y después toque el ícono de estrella</string>
 	<string name="category_desc_more">…más</string>
 	<string name="title_error_downloading_bookmarks">Se ha producido un error</string>
-	<string name="subtitle_error_downloading_bookmarks">Los marcadores no se descargaron</string>
-	<string name="error_already_downloaded">Esta lista ya se ha descargado</string>
-	<string name="why_support">¿Por qué apoyar a Organic Maps?</string>
-	<string name="why_support_item2">Usted nos ayuda a mejorar a Organic Maps</string>
-	<string name="why_support_item3">Nos está ayudando a mejorar los mapas de OpenStreetMap.org</string>
-	<string name="channels_map_update">Actualización de los mapas</string>
-	<string name="server_unavailable_title">Servidor no disponible</string>
-	<string name="sharing_options">Configuración de acceso</string>
 	<string name="export_file">Exportar como archivo</string>
 	<string name="list_settings">Configurar lista</string>
 	<string name="delete_list">Eliminar lista</string>
-	<string name="hide_from_map">Ocultar en el mapa</string>
 	<string name="public_access">Acceso público</string>
 	<string name="limited_access">Acceso privado</string>
 	<string name="bookmark_category_name">Categoría</string>
 	<string name="bookmark_category_description_hint">Agregue una descripción (texto o html)</string>
 	<string name="not_shared">Personal</string>
-	<string name="direct_link_progress_text">Cargando su archivo…</string>
-	<string name="direct_link_success">Enlace creado</string>
-	<string name="send_a_link_btn">Enviar enlace</string>
-	<string name="upload_error_toast">Se produjo un error durante la carga del archivo</string>
 	<string name="tags_loading_error_subtitle">Durante la carga de las etiquetas, se produjo un error, por favor inténtelo de nuevo</string>
-	<string name="unable_upload_errorr_title">No se pudo cargar el archivo</string>
-	<string name="unable_upload_error_subtitle_edited">El archivo fue editado a través de la aplicación web</string>
-	<string name="unable_upload_error_subtitle_broken">El archivo está dañado y no se puede cargar. Por favor, suba otro archivo.</string>
-	<string name="contact">Escribir</string>
-	<string name="download_button">Descargar</string>
 	<string name="speedcams_alert_title">Cámaras de la velocidad</string>
-	<string name="speedcams_alert_subtitle">Advertencia de límites de velocidad</string>
 	<string name="speedcam_option_auto">Auto</string>
 	<string name="speedcam_option_always">Siempre</string>
 	<string name="speedcam_option_never">Nunca</string>
-	<string name="bookmark_description_title">Descripción de la etiqueta</string>
 	<string name="place_description_title">Descripción del lugar</string>
 	<!-- this text will be shown in application notification preferences opposite checkbox which enable/disable downloader notifications. Devices on Android 8+ are affected. -->
 	<string name="notification_channel_downloader">Cargando mapas</string>
-	<string name="share_bookmarks_email_body_link">Hola!\n\nSus etiquetas se pueden descargar desde el enlace: %s. Abra la lista con la ayuda de Organic Maps y disfrute del viaje!\n\nDescargar la aplicación: https://omaps.app/get?kmz</string>
-	<string name="warning_speedcams_title">El navegador le notificará de las cámaras cuando se exceda el límite de velocidad en %d km/h</string>
-	<string name="warning_speedcams_subtitle">No de olvide de leer las reglas de carretera en el país de viaje.</string>
 	<string name="speedcams_notice_message">Auto - advierte sobre las cámaras de velocidad si existe el riesgo de exceder el límite de velocidad\nSiempre - siempre alerta sobre las cámaras\nNunca - nunca advierte acerca de las cámaras</string>
 	<string name="power_managment_title">Modo de ahorro de energía</string>
 	<string name="power_managment_description">Si el modo de ahorro de energía está activado, la aplicación desactivará las funciones que consumen energía, según la carga actual del teléfono</string>
@@ -1068,14 +658,7 @@
 	<string name="power_managment_setting_auto">Automático</string>
 	<string name="power_managment_setting_manual_max">Ahorro de energía máximo</string>
 	<string name="enable_logging_warning_message">Esta opción está habilitada para las acciones de registro con fines de diagnóstico. Esto ayuda a nuestro equipo a identificar problemas con la aplicación. Habilite la opción solo a petición del apoyo de Organic Maps.</string>
-	<string name="html_error_upload_message_try_again">Comprueba el acceso a la red y vuelve a intentarlo</string>
-	<string name="html_error_upload_title_try_again">No hay conexión a internet</string>
-	<string name="notification_leave_review_v2_android_short_title">¡Escribe un comentario y ayuda a los viajeros!</string>
-	<string name="notifications_illegal_alert_disable_button">Desactivar notificaciones</string>
 	<string name="access_rules_author_only">Se edita en línea</string>
-	<string name="privacy_settings_menu">Configuración de privacidad</string>
-	<string name="unable_upadate_error_title">No se pudo actualizar la ruta</string>
-	<string name="unable_upadate_error_message">Hubo errores al actualizar. Comprueba los cambios y vuelve a intentarlo</string>
 	<string name="driving_options_title">Configuración de desvío</string>
 	<string name="driving_options_subheader">Evitar en todas las rutas</string>
 	<string name="avoid_tolls">Carreteras de pago</string>
@@ -1086,52 +669,14 @@
 	<string name="unable_to_calc_alert_subtitle">Desafortunadamente, no pudimos construir una ruta con las opciones seleccionadas. Cambia la configuración y vuelve a intentarlo</string>
 	<string name="define_to_avoid_btn">Personaliza la ruta de desvío</string>
 	<string name="change_driving_options_btn">Configuración de desvío activada</string>
-	<string name="toll_road">Carretera con pago de peaje</string>
-	<string name="unpaved_road">Camino sin pavimento</string>
-	<string name="ferry_crossing">Cruce de ferri</string>
-	<string name="operated_by">Operado por \"%s\"</string>
 	<string name="avoid_toll_roads_placepage">Evitar las carreteras con pago de peaje</string>
 	<string name="avoid_unpaved_roads_placepage">Evitar los caminos sin pavimento</string>
 	<string name="avoid_ferry_crossing_placepage">Evitar ferries</string>
-	<string name="type.cuisine.uzbek">Cocina uzbeka</string>
-	<string name="trip_start">Vamos</string>
-	<string name="pick_destination">Objetivo</string>
-	<string name="follow_my_position">Centrar</string>
-	<string name="search_results">Resultados de búsqueda</string>
-	<string name="then_turn">Después</string>
-	<string name="redirect_route_alert">¿Quieres reconstruir la ruta?</string>
-	<string name="redirect_route_yes">Si</string>
-	<string name="redirect_route_no">No</string>
-	<string name="trip_finished">¡Llegaste!</string>
-	<string name="keyboard_availability_alert">Teclado no disponible durante el movimiento</string>
-	<string name="dialog_routing_change_start_carplay">No se puede construir la ruta desde la ubicación actual</string>
-	<string name="dialog_routing_change_end_carplay">No se puede construir la ruta al punto final. Elige otra</string>
-	<string name="dialog_routing_check_gps_carplay">No hay señal GPS. Ve a una zona abierta</string>
-	<string name="dialog_routing_unable_locate_route_carplay">No se puede construir una ruta. Elige otros puntos de ruta</string>
-	<string name="dialog_routing_download_files_carplay">Al construir ruta, descarga los mapas ausentes en tu dispositivo</string>
-	<string name="dialog_routing_system_error_carplay">Ocurrió un error. Reinicia la aplicación</string>
-	<string name="dialog_routing_rebuild_from_current_location_carplay">La ruta se reconstruirá desde tu ubicación actual</string>
-	<string name="dialog_routing_rebuild_for_vehicle_carplay">La ruta se cambiará a coche</string>
 	<string name="ok">Ok</string>
-	<string name="avoid_unpaved_carplay_1">Sin de grava</string>
-	<string name="avoid_unpaved_carplay_2">Sin de grava</string>
-	<string name="avoid_ferry_carplay_1">Sin ferri</string>
-	<string name="avoid_ferry_carplay_2">Sin ferri</string>
-	<string name="avoid_tolls_carplay_1">Sin peaje</string>
-	<string name="avoid_tolls_carplay_2">Sin peaje</string>
-	<string name="speedcams_alert_title_carplay_1">Cám.velocid.</string>
-	<string name="speedcams_alert_title_carplay_2">Alerta velocid.</string>
-	<string name="download_map_carplay">Descarga mapas en la aplicación Organic Maps en tu dispositivo</string>
-	<string name="carplay_roundabout_exit">%s desviación</string>
 	<!-- max. 10 symbols, both iOS and Android -->
 	<string name="sort">Ordenar…</string>
 	<!-- Android, title, max 20-22 symbols -->
 	<string name="sort_bookmarks">Ordenar etiquetas</string>
-	<!-- iOS -->
-	<string name="sort_default">Ordenar por defecto</string>
-	<string name="sort_type">Ordenar por tipo</string>
-	<string name="sort_distance">Ordenar por distancia</string>
-	<string name="sort_date">Ordenar por fecha</string>
 	<!-- Android -->
 	<string name="by_default">Por defecto</string>
 	<!-- Android -->
@@ -1140,65 +685,23 @@
 	<string name="by_distance">Por distancia</string>
 	<!-- Android -->
 	<string name="by_date">Por fecha</string>
-	<string name="week_ago_sorttype">Hace una semana</string>
-	<string name="month_ago_sorttype">Hace un mes</string>
-	<string name="moremonth_ago_sorttype">Hace más de un mes</string>
-	<string name="moreyear_ago_sorttype">Hace más de un año</string>
-	<string name="near_me_sorttype">Cerca a mí</string>
-	<string name="others_sorttype">Otros</string>
-	<string name="food_places">Comida</string>
-	<string name="tourist_places">Sitios de interés</string>
-	<string name="museums">Museos</string>
-	<string name="parks">Parques</string>
-	<string name="swim_places">Natación</string>
-	<string name="mountains">Montañas</string>
-	<string name="animals">Animales</string>
-	<string name="hotels">Hoteles</string>
-	<string name="buildings">Edificios</string>
-	<string name="money">Dinero</string>
-	<string name="shops">Tiendas</string>
-	<string name="parkings">Estacionamiento</string>
-	<string name="fuel_places">Gasolinera</string>
-	<string name="water">Agua</string>
-	<string name="medicine">Medicina</string>
 	<string name="search_in_the_list">Buscar en la lista</string>
-	<string name="view_on_map_bookmarks">En el mapa</string>
-	<string name="more_bookmarks">Más…</string>
-	<string name="no_items_found">No encontrado</string>
-	<!-- Android, max 18 symbols -->
-	<string name="bookmarks_edit_list">Editar</string>
-	<!-- Android, max 18 symbols -->
-	<string name="bookmarks_delete_list">Eliminar lista</string>
-	<string name="religious_places">Lugares sagrados</string>
 	<string name="select_list">Seleccionar lista</string>
 	<string name="transit_not_found">Navegación en Metro aún no disponible en esta región</string>
 	<string name="dialog_pedestrian_route_is_long_header">Ruta de metro no encontrada</string>
 	<string name="dialog_pedestrian_route_is_long_message">Elige el punto de inicio o fin de ruta más cercano al metro</string>
-	<!-- Failed planning SUBWAY route message in navigation view -->
-	<string name="routing_planning_error_subway_special">Error al construir la ruta en metro</string>
 	<string name="button_layer_isolines">Alturas</string>
-	<string name="tips_map_layers_title_countour">¡Altitud de relieve sin conexión en Organic Maps!</string>
-	<string name="tips_map_layers_message_countour">La altitud de relieve te ayudará a planificar un viaje a la naturaleza y no perderte en la zona</string>
 	<string name="isolines_activation_error_dialog">Para usar la altitud de relieve, actualiza o descarga el mapa del área deseada</string>
 	<string name="isolines_location_error_dialog">La altitud de relieve aún no está disponible en esta región</string>
 	<string name="elevation_profile_diff_level">Nivel de dificultad</string>
-	<string name="elevation_profile_diff_level_easy">Fácil</string>
-	<string name="elevation_profile_diff_level_moderate">Moderado</string>
-	<string name="elevation_profile_diff_level_hard">Difícil</string>
 	<string name="elevation_profile_ascent">Ascenso</string>
 	<string name="elevation_profile_descent">Descenso</string>
 	<string name="elevation_profile_minaltitude">Altura mínima</string>
 	<string name="elevation_profile_maxaltitude">Altura máxima</string>
-	<string name="elevation_profile_m">m</string>
 	<string name="elevation_profile_difficulty">Dificultad</string>
 	<string name="elevation_profile_distance">Distancia</string>
-	<string name="elevation_profile_km">km</string>
 	<string name="elevation_profile_time">Lapso:</string>
-	<string name="elevation_profile_hours">h.</string>
-	<string name="elevation_profile_minutes">min</string>
 	<string name="isolines_toast_zooms_1_10">Amplía el mapa para ver las isolíneas</string>
-	<string name="downloader_updating_ios">Actualización</string>
-	<string name="downloader_loading_ios">Cargando</string>
 	<string name="key_information_title">Información clave</string>
 	<string name="enable_screen_sleep">Permitir que la pantalla duerma</string>
 	<!-- Description in preferences -->

--- a/android/res/values-fa/strings.xml
+++ b/android/res/values-fa/strings.xml
@@ -12,15 +12,11 @@
 	<string name="cancel_download">لغو دانلود</string>
 	<!-- Button which deletes downloaded country -->
 	<string name="delete">حذف</string>
-	<!-- Button "do not interrupt download" if user touched actively downloading country -->
-	<string name="do_nothing">ادامه</string>
 	<string name="download_maps">دانلود نقشه ها</string>
 	<!-- Settings/Downloader - info for country when download fails -->
 	<string name="download_has_failed">دانلود ناموفق بود . برای تلاش مجدد لمس کنید</string>
 	<!-- Settings/Downloader - info for country which started downloading -->
 	<string name="downloading">درحال دانلود</string>
-	<!-- Settings/Downloader - size string, only strings different from English should be translated -->
-	<string name="kb">کیلوبایت</string>
 	<!-- Choose measurement on first launch alert - choose metric system button -->
 	<string name="kilometres">کیلومتر</string>
 	<!-- Leave Review dialog - Review button -->
@@ -36,24 +32,16 @@
 	<string name="core_my_position">مکان من</string>
 	<!-- Update maps later/Buy pro version later button text -->
 	<string name="later">بعداً</string>
-	<!-- Don't show some dialog any more -->
-	<string name="never">هرگز</string>
 	<!-- View and button titles for accessibility -->
 	<string name="search">جست‌وجو</string>
 	<!-- Search box placeholder text -->
 	<string name="search_map">جست‌وجوی نقشه</string>
-	<!-- Settings/Downloader - info for not downloaded country -->
-	<string name="touch_to_download">برای دانلود لمس کنید</string>
 	<!-- Settings/Downloader - 3G download warning dialog confirm button -->
 	<string name="use_cellular_data">بله</string>
 	<!-- Location services are disabled by user alert - message -->
 	<string name="location_is_disabled_long_text">سرویس موقعیت مکانی شما غیر فعال است .لطفا جهت کارکرد صحیح نرم افزار ان را فعال کنید.</string>
-	<!-- Location Services are not available on the device alert - message -->
-	<string name="device_doesnot_support_location_services">دستگاه شماازسرویس موقعیت مکانی پشتیبانی نمی کند</string>
 	<!-- View and button titles for accessibility -->
 	<string name="zoom_to_country">بر روی نقشه نمایش بده</string>
-	<!-- Button text for the button at the center of the screen when the country is not downloaded -->
-	<string name="country_status_download">دانلود نقشه\n(^ ^)</string>
 	<!-- Button text for the button at the center of the screen when the country is not downloaded and the size should not be shown -->
 	<string name="country_status_download_without_size">دانلود نقشه</string>
 	<!-- Message to display at the center of the screen when the country download has failed -->
@@ -61,17 +49,13 @@
 	<!-- Button text for the button under the country_status_download_failed message -->
 	<string name="try_again">تلاش مجدد</string>
 	<string name="about_menu_title">Organic Maps درباره‌ی</string>
-	<string name="downloaded_touch_to_delete">دانلود شده (%s),  برای حذف لمس کنید</string>
 	<string name="connection_settings">تنظیمات اتصال</string>
-	<string name="download_mb_or_kb">دانلود %s</string>
 	<string name="close">بستن</string>
 	<string name="unsupported_phone">نیازمند است. متاسفانه دستگاه شما از ان پشتیبانی نمی کندOpenGLبرنامه برای اجرا به</string>
 	<string name="download">دانلود</string>
-	<string name="external_storage_is_not_available">حافظه خارجی که نقشه ها در ان دانلود شده موجود نیست</string>
 	<string name="not_enough_free_space_on_sdcard">لطفا مقداری از فضای ذخیره سازی را آزاد نمایید</string>
 	<string name="not_enough_memory">حافظه کافی برای اجرای برنامه وجود ندارد</string>
 	<string name="download_resources">قبل از استفاده از اپلیکیشن, اجازه دهید تا ما نقشه جهانی را بر روی موبایل شما دانلود کنیم.\nمقدار %s از حافظه شما اشغال می شود.</string>
-	<string name="getting_position">درحال دریافت موقعیت مکانی شما</string>
 	<string name="download_resources_continue">برو به نقشه</string>
 	<string name="downloading_country_can_proceed">درحال دانلود %s. شما اکنون می توانید\nبه نقشه بروید.</string>
 	<string name="download_country_ask">دانلود  %s?</string>
@@ -84,26 +68,18 @@
 	<string name="download_country_failed">%s دانلود با شکست مواجه شد</string>
 	<!-- Add New Bookmark Set dialog title -->
 	<string name="add_new_set">اضافه کردن مجموعه جدید</string>
-	<!-- Place Page - Add To Bookmarks button -->
-	<string name="add_to_bookmarks">اضافه کردن به نشانه ها</string>
 	<!-- Bookmark Color dialog title -->
 	<string name="bookmark_color">رنگ نشانه</string>
 	<!-- Bookmarks - dialog title -->
 	<string name="bookmarks">نشانه ها</string>
-	<!-- Add bookmark dialog - bookmark color -->
-	<string name="color">رنگ</string>
 	<!-- Default bookmarks set name -->
 	<string name="core_my_places">مکان من</string>
 	<!-- Add bookmark dialog - bookmark name -->
 	<string name="name">نام</string>
 	<!-- Editor title above street and house number -->
 	<string name="address">ادرس</string>
-	<!-- Place Page - Remove Pin button -->
-	<string name="remove_pin">برچیدن سنجاق</string>
 	<!-- Add bookmark dialog - bookmark set, Bookmarks dialog - Bookmark set cell -->
 	<string name="set">مجموعه</string>
-	<!-- Text hint in Bookmarks dialog when no any bookmarks are added -->
-	<string name="bookmarks_usage_hint">شما تا کنون نشانه ای نداشته اید.\nبر روی مکانی از نقشه لمس کنید تا نشانه ای افزوده شود.\nنشانه ها را می توانید از جایی دیگر وارد کرده و در Organic Maps نمایش دهید.Open KML/KMZ file with saved bookmarks from email, Dropbox or weblink.</string>
 	<!-- Settings button in system menu -->
 	<string name="settings">تنظیمات</string>
 	<!-- Header of settings activity where user defines storage path -->
@@ -113,21 +89,11 @@
 	<!-- Question dialog for transferring maps from one storage to another -->
 	<string name="move_maps">ایا نقشه ها جابه جا شود؟</string>
 	<!-- Ask to wait user several minutes (some long process in modal dialog). -->
-	<string name="wait_several_minutes">ممکن است چند دقیقه طول بکشد.\nلطفا صبر کنید...</string>
-	<!-- Show bookmarks from this category on a map or not -->
-	<string name="visible">قابل مشاهده</string>
-	<!-- Toast which is displayed when GPS has been deactivated -->
-	<string name="gps_is_disabled_long_text">سرویس موقعیت مکانی شما غیر فعال است.لطفا ان را در تنظیمات فعال کنید</string>
+	<string name="wait_several_minutes">ممکن است چند دقیقه طول بکشد.\nلطفا صبر کنید…</string>
 	<!-- Measurement units title in settings activity -->
 	<string name="measurement_units">واحد اندازه گیری</string>
 	<!-- Detailed description of Measurement Units settings button -->
 	<string name="measurement_units_summary">بین مایل و کیلومتر انتخاب کنید</string>
-	<!-- Do search in all sources -->
-	<string name="search_mode_all">همه جا</string>
-	<!-- Do search near my position only -->
-	<string name="search_mode_nearme">اطراف من</string>
-	<!-- Do search in current viewport only -->
-	<string name="search_mode_viewport">روی صفحه نمایش بده</string>
 	<!-- Search category for cafes, bars, restaurants -->
 	<string name="eat">کجا غذا بخوریم</string>
 	<!-- Search category for grocery stores -->
@@ -164,12 +130,8 @@
 	<string name="post">صندوق پست</string>
 	<!-- Search category -->
 	<string name="police">پلیس</string>
-	<!-- String in search result list, when nothing found -->
-	<string name="no_search_results_found">نتیجه ای یافت نشد</string>
 	<!-- Notes field in Bookmarks view -->
 	<string name="description">یادداشت ها</string>
-	<!-- Button text -->
-	<string name="share_by_email">اشتراک گذاری به وسیله ایمیل</string>
 	<!-- message title of loading file -->
 	<string name="load_kmz_title">در حال بارگیری نشانه ها</string>
 	<!-- Kmz file successful loading -->
@@ -180,40 +142,20 @@
 	<string name="edit">ویرایش</string>
 	<!-- Warning message when doing search around current position -->
 	<string name="unknown_current_position">مکان شما هنوز مشخص نشده است</string>
-	<!-- Warning message when location country isn't downloaded during search (see also download_location_map_proposal). -->
-	<string name="download_location_country">دانلود نقشه مکان فعلی شما (%s)</string>
 	<!-- Alert message that we can't run Map Storage settings due to some reasons. -->
 	<string name="cant_change_this_setting">متاسفانه,تنظیمات ذخیره سازی نقشه در حال حاظر غیر فعال است</string>
 	<!-- Alert message that downloading is in progress. -->
 	<string name="downloading_is_active">دانلود نقشه اکنون در حال انجام است</string>
-	<!-- Message that will be shown in alert view, when we ask user to leave review on App Store -->
-	<string name="appStore_message">امیدواریم از استفاده از این اپ لذت برده باشد!اگر اینطور است به این اپ در استور ستاره بدهید و نظر خود را بنویسید.این کار کمتر از یک دقیقه زمان می برد اما حقیقتا می تواند به ما کمک کند.از حمایت صمیمانه تان متشکریم.</string>
-	<!-- No, thanks -->
-	<string name="no_thanks">نه ,متشکرم</string>
-	<!-- Android share by Message/SMS button text (including SMS) -->
-	<string name="share_by_message">اشتراک گذاری از طریق پیامک</string>
 	<!-- Share button text which opens menu with more buttons, like Message, EMail, Facebook etc. -->
 	<string name="share">اشتراک گذاری</string>
-	<!-- iOS share by Message button text (including SMS) -->
-	<string name="message">پیامک</string>
 	<!-- Share by email button text, also used in editor. -->
 	<string name="email">ایمیل</string>
-	<!-- Copy Link -->
-	<string name="copy_link">کپی لینک</string>
-	<!-- Text for the button that returns to caller application -->
-	<string name="more_info">نمایش اطلاعات بیشتر</string>
 	<!-- Text for message when used successfully copied something -->
 	<string name="copied_to_clipboard">کپی در کلیپ برد :%1$s</string>
 	<!-- place preview title -->
 	<string name="info">اطلاعات</string>
 	<!-- Used for bookmark editing -->
 	<string name="done">انجام شد</string>
-	<!-- Summary for preferences in MWM -->
-	<string name="yopme_pref_summary">انتخاب تنظیمات پس ضمینه</string>
-	<!-- Title for yopme preferences in MWM -->
-	<string name="yopme_pref_title">تنظیمات پس ضمینه</string>
-	<!-- Hint for upper-right icon p2b -->
-	<string name="show_on_backscreen">نمایش در پس زمینه</string>
 	<!-- Prints version number in About dialog -->
 	<string name="version">ورژن: %s</string>
 	<!-- Data version in «About» screen -->
@@ -225,15 +167,10 @@
 	<!-- Length of track in cell that describes route -->
 	<string name="length">طول</string>
 	<string name="share_my_location">به اشتراک گذاری موقعیت مکانی من</string>
-	<string name="menu_search">جست‌وجو</string>
 	<!-- Settings general group in settings screen -->
 	<string name="prefs_group_general">تنظیمات عمومی</string>
 	<!-- Settings information group in settings screen -->
 	<string name="prefs_group_information">اطلاعات</string>
-	<!-- Settings screen: "Map" category title -->
-	<string name="prefs_group_map">نقشه</string>
-	<!-- Settings screen: "Miscellaneous" category title -->
-	<string name="prefs_group_misc">متفرقه</string>
 	<string name="prefs_group_route">مسیریابی</string>
 	<string name="pref_zoom_title">دکمه های درشت نمایی</string>
 	<string name="pref_zoom_summary">نمایش بر روی نقشه</string>
@@ -249,8 +186,6 @@
 	<string name="pref_map_3d_title">نمای چشم انداز</string>
 	<!-- Settings «Map» category: «3D buildings» title -->
 	<string name="pref_map_3d_buildings_title">ساختمان های سه بعدی</string>
-	<!-- Settings «Map» category: «3D buildings» summary -->
-	<string name="pref_map_3d_buildings_subtitle">تاثیر بر روی عمر باطری</string>
 	<!-- Settings «Route» category: «Tts enabled» title -->
 	<string name="pref_tts_enable_title">دستور العمل صوتی</string>
 	<!-- Settings «Route» category: «Tts language» title -->
@@ -259,7 +194,6 @@
 	<string name="pref_tts_unavailable">موجود نیست</string>
 	<!-- Title for "Other" section in TTS settings. -->
 	<string name="pref_tts_other_section_title">بیشتر</string>
-	<string name="pref_tts_how_to_set_up_voice">نحو راه اندازی صدا</string>
 	<!-- Settings «Map» category: «Record track» title -->
 	<string name="pref_track_record_title">مسیر اخیر</string>
 	<string name="pref_map_auto_zoom">بزرگ نمایی خودکار</string>
@@ -270,43 +204,11 @@
 	<string name="duration_12_hours">12 ساعت</string>
 	<string name="duration_1_day">1 روز</string>
 	<string name="recent_track_help_text">با این قابلیت شما می توانید مسیری که می پیمایید را در یک دوره مشخص ضبط نماید و ان را بر روی نقشه ببینید.لطفا توجه نمایید:فعال سازی این قابلیت باعث افزایش مصرف باتری موبایل شما می شود.مسیر به طور خودکار بعد از مدت مشخص شده حذف خواهد شد</string>
-	<string name="pref_track_ios_subcaption">لطفا محدوده زمانی برای ذخیره مسیر را انتخاب کنید</string>
-	<string name="placepage_distance">مسافت</string>
-	<string name="placepage_coordinates">مختصات</string>
-	<string name="placepage_unsorted">نا منظم</string>
 	<string name="search_show_on_map">مشاهده بر روی نقشه</string>
-	<!-- Used in More Apps menu -->
-	<string name="free">رایگان</string>
-	<!-- Used in More Apps menu -->
-	<string name="buy">خرید</string>
-	<!-- 1st search button-like result -->
-	<string name="search_on_map">جست‌وجو بر روی نقشه</string>
-	<!-- toast with an error -->
-	<string name="no_route_found">مسیری یافت نشد</string>
-	<!-- route title -->
-	<string name="route">مسیر</string>
-	<!-- category title -->
-	<string name="routes">مسیر ها</string>
-	<!-- text of notification -->
-	<string name="download_map_notification">دانلود نقشه جایی که هستید</string>
-	<!-- text of notification -->
-	<string name="pro_version_is_free_today">نسخه کامل Organic Maps امروز رایگان است!دانلود کنید و به دوستان خود نیز بگویید</string>
-	<!-- Dialog for transferring maps from lite to pro. -->
-	<string name="move_lite_maps_to_pro">ما در حال انتقال نقشه های دانلود شده شما از Organic Maps Lite به Organic Maps هستیم. ممکن است چند دقیقه طول بکشد.</string>
-	<!-- Message to display when maps moved. -->
-	<string name="move_lite_maps_to_pro_ok">نقشه های دانلود شده شما با موفقیت به Organic Maps منتقل شد.</string>
-	<!-- Message to display when maps move failed. -->
-	<string name="move_lite_maps_to_pro_failed">انتقال نقشه با شکست مواجه شد.لطفا Organic Maps Lite حذف کرده و نقشه ها را دوباره دانلود نماید</string>
-	<!-- Text in menu -->
-	<string name="settings_and_more">تنظیمات و بیشتر</string>
 	<!-- Text in menu -->
 	<string name="website">وب سایت</string>
-	<!-- Text in menu -->
-	<string name="contact_us">تماس با ما</string>
 	<!-- Settings: Send feedback button and dialog title -->
 	<string name="feedback">بازخورد</string>
-	<!-- Text in menu -->
-	<string name="subscribe_to_news">اشتراک در خبرنامه ما</string>
 	<!-- Text in menu -->
 	<string name="rate_the_app">امتیاز به این اپلیکیشن</string>
 	<!-- Text in menu -->
@@ -315,12 +217,6 @@
 	<string name="copyright">حق نشر و کپی رایت</string>
 	<!-- Text in menu -->
 	<string name="report_a_bug">گزارش خطا</string>
-	<!-- Email subject -->
-	<string name="subscribe_me_subject">لطفا من را در خبرنامه Organic Maps مشترک کنید</string>
-	<!-- Email body -->
-	<string name="subscribe_me_body">من می خواهم اولین نفری باشم که در جریان اخرین اخبار واپدیت های نرم افزار قرار می گیرم.می دانم در هر زمان میتوان این اشتراک را لغو کرد.</string>
-	<!-- About text -->
-	<string name="about_text">Organic Maps  به شما سریع ترین نقشه های تمامی شهر ها و کشور های جهان را پیشنهاد می دهد. در هرجایی که هستید با اطمینان کامل سفر کنید. Organic Maps کمک می مند تا موقعیت خود و نزدیک ترین هتل ها,بانک ها,جایگاه های سوخت و چیز های دیگر را بر روی نقشه بیابید.وای کارهیچ نیازی به اتصال اینترنتی ندارد. \n\nما همیشه بر روی قابلیت های جدید کار می کنیم و دوست داریم که از طرف شما بشنویم که چطور می توانیم این نرم افزار مسیر یابی را بهتر از قبل نماییم. اگر هر مشکلی با برنامه داشتید تردید نکنید و در support\@organicmaps.app با ما تماس بگیرید.ما به تمامی درخواست ها پاسخ می دهیم! \n\n از Organic Maps راضی هستید و می خواهید از ما حمایت کنید؟ چند راه کاملا رایگان وجود دارد\n- برای ما یک نظر در فروشگاه نرم افزاری بنویسید \n- صفحه فیسبوک ما را http://www.facebook.com/OrganicMaps لایک کنید \n- یا از Organic Maps به مادرتان دوستانتان وهم دانشگاهیانتان بگویید:))\n\n متشکروسپاس گذاریم که با ما همکاری می کنید\n\nP.S. مانقشه های خود را از OpenStreetMap دریافت می کنیم این سایت همانند ویکیپدیا برای نقشه برداری است و به تمام کاربران خود اجازه می دهد تا در تکمیل نقشه ها کمک کنند اگر در نقشه مشاهده نمودید چیزی اشتباه بود یا وجود نداشت شما می توانید ان را مستقیما در سایت https://www.openstreetmap.org تصحیح یا اضافه کنید  و تغییرات ای را که ایجاد کرده اید را در اپدیت بعدی Organic Maps ببینید</string>
 	<!-- Alert text -->
 	<string name="email_error_body">کلاینت ایمیل شما پیکربندی نشده است.لطفا ان را پیکربندی کنید یا از طریق دیگر با ما تماس بگیرید %s</string>
 	<!-- Alert title -->
@@ -329,131 +225,54 @@
 	<string name="pref_calibration_title">تنظیم کردن قظب نما</string>
 	<!-- Search category -->
 	<string name="wifi">وای فای</string>
-	<!-- Update map suggestion -->
-	<string name="routing_map_outdated">لطفا نقشه خود را برای ایجاد مسیر اپدیت نمایید</string>
-	<!-- Update maps suggestion -->
-	<string name="routing_update_maps">نسخه جدید Organic Maps به شما اجازه ایجاد یک مسیر از موقعیت فعلیتان به مقصدتان را می دهد.لطفابرای استفاده از این ویژگی نقشه خود را اپدیت نمایید.</string>
 	<!-- Update all button text -->
 	<string name="downloader_update_all_button">اپدیت همه</string>
 	<!-- Cancel all button text -->
 	<string name="downloader_cancel_all">لغو همه</string>
 	<!-- Downloaded maps category -->
 	<string name="downloader_downloaded_subtitle">دانلود شده</string>
-	<!-- Downloaded maps category -->
-	<string name="downloader_available_maps">موجود</string>
 	<!-- Country queued for download -->
 	<string name="downloader_queued">صف</string>
 	<string name="downloader_near_me_subtitle">نزدیک من</string>
 	<string name="downloader_status_maps">نقشه ها</string>
 	<string name="downloader_download_all_button">دانلود همه</string>
 	<string name="downloader_downloading">درحال دانلود:</string>
-	<string name="downloader_search_results">یافت شد</string>
-	<!-- Outdated maps category -->
-	<string name="downloader_outdated_maps">منسوخ شده</string>
-	<!-- Up to date maps category -->
-	<string name="downloader_uptodate_maps">به روز</string>
 	<!-- Status of outdated country in the list -->
 	<string name="downloader_status_outdated">به روز رسانی</string>
 	<!-- Status of failed country in the list -->
 	<string name="downloader_status_failed">ناموفق</string>
 	<!-- Displayed in a dialog that appears when a user tries to delete a map while the app is in the follow route mode -->
 	<string name="downloader_delete_map_while_routing_dialog">برای حذف نقشه لطفا مسیر یابی را متوقف کنید</string>
-	<!-- Show when user try build route, but we don't know where he -->
-	<string name="routing_failed_unknown_my_position">مکان شما نا مشخص است,لطفا قبل از ایجاد مسیر مکان خود را مشخص کنید.</string>
-	<!-- Show if use has not routing file, or InconsistentMWMandRoute -->
-	<string name="routing_failed_has_no_routing_file">برای ایجاد مسیر به دیتای اضافی نیاز است.اکنون ان را دانلود می کنید؟</string>
-	<!-- StartPointNotFound -->
-	<string name="routing_failed_start_point_not_found">نمی توان مسیر را محاسبه کرد.در نزدیکی نقطه شروع شما جاده ای نیست.</string>
-	<!-- EndPointNotFound -->
-	<string name="routing_failed_dst_point_not_found">نمی توان مسیر را محاسبه کرد.در نزدیکی مقصد مورد نظر شما جاده ای نیست.</string>
 	<!-- PointsInDifferentMWM -->
 	<string name="routing_failed_cross_mwm_building">تنها مسیر هایی می توانند ایجاد شوند که به طور کامل در یک نقشه از یک منطقه واحد قرار داشته باشند.</string>
-	<!-- RouteNotFound -->
-	<string name="routing_failed_route_not_found">مسیری بین مبدا و مقصد انتخابی یافت نشد.لطفا مبدا یا مقصد دیگری را انتخاب کنید</string>
-	<!-- InternalError -->
-	<string name="routing_failed_internal_error">خطای داخلی اتفاق افتاد.لطفا تلاش کنید نقشه را حذف و مجددا دانلود کنید.اگر همچنان مشکل پابرجاست لطفا با ما تماس بگیرید support\@organicmaps.app.</string>
-	<!-- Context menu item for downloader. -->
-	<string name="downloader_download_map_and_routing">دانلود نقشه + مسیریابی</string>
-	<!-- Context menu item for downloader. -->
-	<string name="downloader_download_routing">دانلود  مسیریابی</string>
-	<!-- Context menu item for downloader. -->
-	<string name="downloader_delete_routing">حذف مسیریابی</string>
 	<!-- Context menu item for downloader. -->
 	<string name="downloader_download_map">دانلود نقشه</string>
-	<string name="downloader_download_map_no_routing">دانلود نقشه بدون مسیریابی</string>
-	<!-- Button for routing. -->
-	<string name="routing_go">برو!</string>
 	<!-- Item status in downloader. -->
 	<string name="downloader_retry">تلاش مجدد</string>
-	<!-- Item in context menu. -->
-	<string name="downloader_map_and_routing">نقشه + مسیریابی</string>
 	<!-- Item in context menu. -->
 	<string name="downloader_delete_map">حذف نقشه</string>
 	<!-- Item in context menu. -->
 	<string name="downloader_update_map">به روز رسانی نقشه</string>
-	<!-- Item in context menu. -->
-	<string name="downloader_update_map_and_routing">به روز رسانی نقشه + مسیریابی</string>
-	<!-- Item in context menu. -->
-	<string name="downloader_map_only">فقط نقشه</string>
-	<!-- Toolbar title -->
-	<string name="toolbar_application_menu">منوی برنامه</string>
 	<!-- Preference text -->
 	<string name="pref_use_google_play">استفاده از Google Play Services برای تعیین موقعیت کنونی شما</string>
-	<!-- Text for rating dialog -->
-	<string name="rating_do_like_maps">Organic Maps را می پسندید؟</string>
-	<!-- Text for rating dialog -->
-	<string name="rating_tap_star">بر روی ستاره ها لمس کنید تا به این اپ رای بدهید</string>
 	<!-- Text for rating dialog -->
 	<string name="rating_thanks">متشکریم!</string>
 	<!-- Text for rating dialog -->
 	<string name="rating_share_ideas">ایده ها و نقطه نظرات تان را با ما در میان بگذارید ما برنامه را مطابق میلتان توسعه می دهیم</string>
 	<!-- Text for rating dialog -->
 	<string name="rating_send_feedback">ارسال بازخورد</string>
-	<!-- Text for g+ dialog -->
-	<string name="rating_google_plus">بر روی g+ کلیک کنید و از این برنامه برایشان بگویید.</string>
 	<!-- Text for routing error dialog -->
 	<string name="routing_download_maps_along">دانلود تمامی نقشه ها در طول مسیر تان</string>
-	<!-- Text for routing error dialog -->
-	<string name="routing_download_map">دریافت نقشه</string>
-	<!-- Text for routing error dialog -->
-	<string name="routing_download_map_and_routing">برای داشتن تمامی ویژگی های Organic Maps نقشه ها و داده های مسیریابی را اپدیت نمایید.</string>
-	<!-- Text for routing error dialog -->
-	<string name="routing_get_routing_data">دریافت داده های مسیریابی</string>
-	<!-- Text for routing error dialog -->
-	<string name="routing_get_additional_data">مقداری دیتای اضافی برای ایجاد مسیر در موقعیت شما نیاز است.</string>
 	<!-- Text for routing error dialog -->
 	<string name="routing_requires_all_map">به منظور ایجاد مسیر ما نیاز داریم تا تمامی نقشه های شما از مبدا تا مقصد را به روز رسانی کنیم.</string>
 	<!-- Text for routing error dialog -->
 	<string name="routing_not_enough_space">فضای کافی موجود نیست</string>
-	<!-- Text for routing error dialog -->
-	<string name="routing_download_more_than_avail">شما نیاز به دانلود %1$s مگابایت دارید, اما تنها %2$s مگابایت موجود است.</string>
-	<!-- Text for routing error dialog -->
-	<string name="routing_download_roaming">شما قصد دانلود %s MB و استفاده از دیتای موبایل را دارید.این کار ممکن است بر حسب اپراتور موبایلتان هزینه های اضافی برای شما در بر داشته باشد</string>
 	<!-- bookmark button text -->
 	<string name="bookmark">نشانه ها</string>
-	<!-- map is not downloaded -->
-	<string name="not_found_map">نقشه ای برای موقعیت مکانی شما دانلود نشده است</string>
 	<!-- location service disabled -->
 	<string name="enable_location_services">لطفا موقعیت مکانی(GPS)خود را فعال کنید.</string>
-	<!-- download map -->
-	<string name="download_map">دانلود نقشه برای موقعیت مکانی شما</string>
-	<!-- download map on iPhone -->
-	<string name="download_map_iphone">دانلود نقشه برای موقعیت مکانی شما بر روی ایفون تان</string>
-	<!-- clear pin -->
-	<string name="nearby">در این نزدیکی</string>
-	<!-- clear pin -->
-	<string name="clear_pin">پاک کردن نشانه</string>
-	<!-- location is undefined -->
-	<string name="undefined_location">موقعیت مکانی شما یافت نشد.</string>
-	<!-- download country of your location -->
-	<string name="download_country">دانلود نقشه کشور مقعیت کنونی شما</string>
-	<!-- download failed -->
-	<string name="download_failed">دانلود ناموفق</string>
-	<!-- get the map -->
-	<string name="get_the_map">دریافت نقشه</string>
 	<string name="save">ذخیره</string>
 	<string name="edit_description_hint">توضیحات شما (متن یا  (html</string>
-	<string name="new_group">مجموعه جدید</string>
 	<string name="create">ایجاد</string>
 	<!-- red color -->
 	<string name="red">قرمز</string>
@@ -471,22 +290,6 @@
 	<string name="brown">قهوای</string>
 	<!-- pink color -->
 	<string name="pink">صورتی</string>
-	<!-- deep purple color -->
-	<string name="deep_purple">ارغوانی سیر</string>
-	<!-- light blue color -->
-	<string name="light_blue">آبی کمرنگ</string>
-	<!-- cyan color -->
-	<string name="cyan">فیروزه ای</string>
-	<!-- teal color -->
-	<string name="teal">آبی سیر</string>
-	<!-- lime color -->
-	<string name="lime">زرد لیویی</string>
-	<!-- deep orange color -->
-	<string name="deep_orange">نارنجی سیر</string>
-	<!-- gray color -->
-	<string name="gray">خاکستری</string>
-	<!-- blue gray color -->
-	<string name="blue_gray">خاکستری کبود</string>
 	<!-- Wi-Fi available -->
 	<string name="WiFi_available">بلی</string>
 
@@ -502,9 +305,7 @@
 	<string name="dialog_routing_location_turn_wifi">لطفا سیگنال GPS موبایتان راچک کنید.و WiFi موبایلتان را جهت دقت بیشتر در موقعیت یابی فعال کنید.</string>
 	<string name="dialog_routing_location_turn_on">فعال کردن سرویس موقعیت مکانی  (GPS)</string>
 	<string name="dialog_routing_location_unknown_turn_on">ناتوان از مشخص کردن موقعیت مکانی شما.لطفا سرویس موقعیت مکانی خود را فعال کنید.</string>
-	<string name="dialog_routing_location_unknown">ناتوان از مشخص کردن موقعیت مکانی شما.</string>
 	<string name="dialog_routing_download_files">دانلود فایل های مورد نیاز</string>
-	<string name="dialog_routing_routes_size">فایل های اطلاعات مسیر یابی</string>
 	<string name="dialog_routing_unable_locate_route">ناتوان در تعیین مسیر</string>
 	<string name="dialog_routing_cant_build_route">ناتوان در ایجاد مسیر</string>
 	<string name="dialog_routing_change_start_or_end">لطفا مبدا یا مقصد خود را تنظیم کنید.</string>
@@ -519,27 +320,19 @@
 	<string name="dialog_routing_system_error">خطای سیستم</string>
 	<string name="dialog_routing_application_error">ناتوان در ایجاد مسیر به علت خطای برنامه.</string>
 	<string name="dialog_routing_try_again">لطفا دوباره تلاش کنید</string>
-	<string name="dialog_routing_send_error">گزارش مشکل</string>
-	<string name="dialog_routing_if_get_cross_route">ایا می خواهید یک مسیر مستقیم تر که بیش از یک نقشه را شامل می شود ایجاد کنید؟</string>
-	<string name="dialog_routing_cross_route_is_optimal">مسیر های بهینه بیشتری موجود است که حاشیه این نقشه را رد می کند .</string>
 	<string name="not_now">اکنون خیر</string>
-	<string name="dialog_routing_build_route">ایجاد کردن</string>
 	<string name="dialog_routing_download_and_build_cross_route">ایا مایل به دانلود نقشه و ایجاد مسیر های بهینه بیشتری که نقشه های بیشتری را پوشش میدهد هستید؟</string>
 	<string name="dialog_routing_download_cross_route">دانلود نقشه های اضافی برای ایجاد مسیری بهتر که حاشیه های این نقشه را رد می کند.</string>
-	<string name="dialog_routing_cross_route_always">همیشه این مرز را رد کن</string>
 
 	<!-- SECTION: Strings for downloading map from search -->
 	<string name="search_without_internet_advertisement">برای شروع جستوجو و مسیر یابی لطفا نقشه رادانلود کنید بعد از ان دیگر نیازی به اتصال به اینترنت ندارید و برنامه کاملا افلاین اجرا می شود.</string>
 	<string name="search_select_map">انتخاب نقشه</string>
-	<string name="search_select_other_map">انتخاب نقشه ی دیگر</string>
 	<!-- «Show» context menu -->
 	<string name="show">نمایش</string>
 	<!-- «Hide» context menu -->
 	<string name="hide">مخفی کردن</string>
 	<!-- «Rename» context menu -->
 	<string name="rename">تغیر نام</string>
-	<!-- Bottom sheet: expand button (should be short) -->
-	<string name="bottom_sheet_more">بیشتر</string>
 	<!-- Failed planning route message in navigation view -->
 	<string name="routing_planning_error">برنامه ریزی مسیر ناموفق</string>
 	<!-- Arrive routing message in navigation view -->
@@ -551,26 +344,16 @@
 	<string name="rate_alert_less_than_four_star_message">ایا پیشنهاد یا ایده ای دارید که ما بتوانیم بهتر از این باشیم؟</string>
 	<string name="categories">دسته بندی ها</string>
 	<string name="history">تاریخچه</string>
-	<string name="next_turn_then">سپس</string>
 	<string name="closed">تعطیل</string>
-	<string name="back_to">بازگشت به %s</string>
 	<string name="search_not_found">متاسفانه چیزی پیدا نشد</string>
 	<string name="search_not_found_query">با تغییر در معیار های جست و جو دوباره امتحان کنید</string>
-	<string name="search_not_found_map">لطفا نقشه ای را که در ان جست و جو می کنید را دانلود کنید</string>
-	<string name="search_not_found_location">نقشه موقعیت مکانی تان را دانلود کنید</string>
 	<string name="search_history_title">سوابق جست وجو</string>
 	<string name="search_history_text">مشاهده جست وجو های اخیر</string>
 	<string name="clear_search">پاک کردن سابقه جست وجو ها</string>
-	<!-- Title for settings to enable/disable showcase menu button -->
-	<string name="showcase_settings_title">نمایش پیشنهاد ها</string>
 	<!-- Place Page link to Wikipedia article (if map object has it). -->
 	<string name="read_in_wikipedia">ویکی پدیا</string>
-	<string name="p2p_route_planning">برنامه ریزی مسیر</string>
 	<string name="p2p_your_location">موقعیت شما</string>
-	<string name="p2p_from">از</string>
-	<string name="p2p_to">به</string>
 	<string name="p2p_start">شروع</string>
-	<string name="p2p_planning">درحال برنامه ریزی</string>
 	<string name="p2p_from_here">مسیر از</string>
 	<string name="p2p_to_here">مسیر به</string>
 	<string name="p2p_only_from_current">مسیر یابی فقط از موقعیت کنونی شما قابل انجام است.</string>
@@ -590,11 +373,8 @@
 	<string name="editor_hours_closed">ساعات غیر کاری</string>
 	<string name="editor_example_values">مقادیر پیش فرض</string>
 	<string name="editor_correct_mistake">تصحیح خطا</string>
-	<string name="editor_correct_mistake_message">شما یک ویرایش اشتباه انجام دادید.لطفا ان را اصلاح کنید یا به حالت ساده بروید</string>
 	<string name="editor_add_select_location">موقعیت</string>
 	<string name="editor_done_dialog_1">شما نقشه جهان را تغییر دادید.این افتخار را پیش خود نگه ندارید!به دوستانتان درموردش بگویید و با یکدیگر ویرایش کنید.</string>
-	<string name="editor_done_dialog_2">این دومین بار است که نقشه را ویرایش می کنید.اکنون شما شماره %d در رنکینگ ویرایشگران هستید.در موردش به دوستانتان بگویید.</string>
-	<string name="editor_done_dialog_3">شما باعث بهتر شدن نقشه شدید در موردش به دوستانتان بگویید و با یکدیگر بر روی نقشه کار کنید.</string>
 	<string name="share_with_friends">اشتراک گذاری با دوستان</string>
 	<string name="editor_report_problem_desription_1">لطفا مشکلتان را با جزئیات توضیح دهید بطوری که انجمن OSM بتوانند ان را برطرف کنند.</string>
 	<string name="editor_report_problem_desription_2">یا خودتان ان را انجام دهید در وبسایت https://www.openstreetmap.org/</string>
@@ -603,14 +383,7 @@
 	<string name="editor_report_problem_no_place_title">مکان وجود ندارد</string>
 	<string name="editor_report_problem_under_construction_title">به علت تعمییرات بسته است</string>
 	<string name="editor_report_problem_duplicate_place_title">مکان تکراری</string>
-	<string name="first_launch_congrats_title">Organic Maps اماده استفاده است</string>
-	<string name="first_launch_congrats_text">در سرتاسر دنیا جست وجو و مسیریابی کنید بدون نیاز به اینترنت و کاملا رایگان.</string>
-	<string name="migrate_title">مهم!</string>
-	<!-- Android uses image instead of text. -->
-	<string name="download_all">دانلود همه</string>
-	<string name="delete_all">حذف همه</string>
 	<string name="autodownload">دانلود خودکار</string>
-	<string name="disable_autodownload">لغو دانلود خودکار</string>
 	<!-- Place Page opening hours text -->
 	<string name="closed_now">اکنون تعطیل است</string>
 	<!-- Place Page opening hours text -->
@@ -619,8 +392,6 @@
 	<string name="day_off_today">امروز تعطیل است</string>
 	<string name="day_off">تعطیل است</string>
 	<string name="today">امروز</string>
-	<string name="sunrise_to_sunset">از طلوع خورشید تا غروب افتاب</string>
-	<string name="sunset_to_sunrise">از غروب خورشید تا طلوع خورشید</string>
 	<string name="add_opening_hours">اضافه کردن ساعت بازگشایی</string>
 	<string name="edit_opening_hours">ویرایش ساعت کاری</string>
 	<string name="no_osm_account">ایا حساب OpenStreetMap ندارید؟</string>
@@ -630,29 +401,13 @@
 	<string name="login">ورود</string>
 	<string name="password">رمز عبور</string>
 	<string name="forgot_password">رمز عبور خود را فراموش کردید؟</string>
-	<!-- Forgot Password dialog title -->
-	<string name="restore_password">بازیابی رمز عبور</string>
-	<string name="enter_email_address_to_reset_password">ادرس ایمیلی را که در هنگام ثبت نام استفاده کردید را وارد کنید و ما برای شما لینک بازیابی رمز عبور را خواهیم فرستاد.</string>
-	<string name="reset_password">بازیابی رمز عبور</string>
-	<string name="username">نام کاربری</string>
 	<string name="osm_account">حساب OSM</string>
 	<string name="logout">خروج از حساب</string>
-	<string name="login_and_edit_map_motivation_message">وارد شوید و اشیا درون نقشه را ویرایش کنید و ما ان را برای میلیون ها کاربر مهیا می کنیم.بزن بریم و یه دنیای بهتر با هم بسازیم.</string>
 	<!-- Information text: "Last upload 11.01.2016" -->
 	<string name="last_upload">اخرین بروزرسانی</string>
-	<!-- Motivates user to login/register, title above login buttons. -->
-	<string name="you_have_edited_your_first_object">شما اولین ویرایشتان را انجام دادید!</string>
 	<string name="thank_you">متشکریم</string>
-	<string name="login_with_google">ورود با حساب گوگل</string>
-	<string name="login_with_openstreetmap">ورود با حساب www.openstreetmap.org</string>
 	<string name="edit_place">ویرایش مکان</string>
 	<string name="place_name">نام مکان</string>
-	<!-- title above languages list cells in the editor, below editable name text field. -->
-	<string name="other_languages">زبان های دیگر</string>
-	<!-- small button to open list with names in different languages -->
-	<string name="show_more">نمایش بیشتر</string>
-	<!-- small button to close list with names in different languages -->
-	<string name="show_less">نمایش کمتر</string>
 	<string name="add_language">افزودن یک زبان</string>
 	<string name="street">خیابان</string>
 	<!-- Editable House Number text field (in address block). -->
@@ -669,24 +424,16 @@
 	<string name="email_or_username">ایمیل یا نام کاربری</string>
 	<string name="phone">تلفن</string>
 	<string name="please_note">لطفا توجه داشته باشد</string>
-	<string name="common_no_wifi_dialog">اتصال وایفای یافت نشد.ایا می خواهید با اینترنت دیتای موبایل ادامه دهید؟</string>
 	<string name="downloader_delete_map_dialog">تمام ویرایش های که بر روی نقشه انجام داده اید به همراه نقشه حذف شد.</string>
 	<string name="downloader_update_maps">بروزرسانی نقشه ها</string>
 	<string name="downloader_mwm_migration_dialog">برای ایجاد مسیر شما نیازمند بروزرسانی تمامی  نقشه ها هستید سپس می توانید دوباره مسیرتان را برنامه ریزی کنید</string>
 	<string name="downloader_search_field_hint">یافتن نقشه</string>
-	<string name="migration_update_all_button">بروزرسانی تمامی نقشه ها</string>
-	<string name="migration_delete_all_download_current_button">دانلود نقشه کنونی و حذف قدیمی ها</string>
 	<string name="migration_download_error_dialog">خطا در دانلود</string>
 	<string name="common_check_internet_connection_dialog">لطفا تنظیمات خود را بازبینی کنید و مطمئن شوید که ابزار شما به اینترنت متصل است.</string>
 	<string name="downloader_no_space_title">فظای کافی موجود نیست</string>
 	<string name="downloader_no_space_message">لطفا داده های غیر ضروری را از دستگاه خود حذف کنید</string>
 	<string name="editor_login_error_dialog">خطای ورود</string>
-	<string name="editor_login_failed_dialog">ورود ناموفق</string>
-	<string name="editor_username_error_dialog">نام کاربری نامعتبر است</string>
-	<string name="editor_place_edited_dialog">شما یک شئی را ویرایش کردید</string>
-	<string name="editor_login_with_osm">ورود با استفاده از OpenStreetMap</string>
 	<string name="editor_profile_changes">تغییرات تایید شد</string>
-	<string name="editor_profile_unsent_changes">ارسال نشد:</string>
 	<string name="editor_focus_map_on_location">برای انتخاب مکان صحیح شئی نقشه را بکشید.</string>
 	<string name="editor_add_select_category">انتخاب دسته بندی</string>
 	<string name="editor_add_select_category_popular_subtitle">پرطرفدار</string>
@@ -697,19 +444,14 @@
 	<string name="editor_edit_place_category_title">دسته بندی</string>
 	<string name="detailed_problem_description">توضیح مفصل در مورد مشکل</string>
 	<string name="editor_report_problem_other_title">مشکلی دیگر</string>
-	<string name="placepage_report_problem_button">گزارش یک مشکل</string>
 	<string name="placepage_add_business_button">اضافه کردن یک تجارت</string>
 	<string name="whatsnew_editor_message_1">اضافه کردن مکان به نقشه و ویرایش ان مستقیما از طریق این اپلیکیشن.</string>
-	<string name="whatsnew_editor_message_2">* Organic Maps از دیتای انجمن  OpenStreetMap.</string>
 	<string name="dialog_incorrect_feature_position">تغییر موقعیت</string>
 	<string name="message_invalid_feature_position">نمی توان شی ای در این مکان باشد</string>
 	<string name="login_to_make_edits_visible">وارد شوید تا دیگر کاربران نیز بتوانند تغییرات ایجاد شده توسط شما را ببینند</string>
-	<string name="no_migration_during_navigation">بروزرسانی در حین مسیریابی مجاز نیست.</string>
 	<!-- Error dialog no space -->
 	<string name="migration_no_space_message">برای دانلود,شما نیازمند فضای ذخیره سازی بیشتری هستید.لطفا داده های غیر ضروری خود را حذف کنید.</string>
 	<string name="editor_sharing_title">من نقشه های Organic Maps را بهبود بخشیدم</string>
-	<string name="editor_comment_will_be_sent">ما مطمئن خواهیم شد که پیام خود را به ویرایشگران نقشه ارسال خواهید کرد.</string>
-	<string name="editor_unsupported_category_message">شما شی ای را دسته بندی کرده اید که ما تاکنون از ان پشتیبانی نمی کرده ایم.ما ان را در اینده در نقشه نشان خواهیم داد.</string>
 	<!-- Downloaded 10 **of** 20 <- it is that "of" -->
 	<string name="downloader_of">%1$d  از  %2$d</string>
 	<string name="download_over_mobile_header">دانلود بر روی یک شبکه دیتای موبایل؟</string>
@@ -727,14 +469,8 @@
 	<string name="editor_detailed_description">شما یک سری تغییرات در نقشه را برای انجمن OpenStreetMap ارسال کردید.جزئیات اضافی را که نتوانستید در Organic Maps ویرایش کنید را برایشان بنویسید.</string>
 	<string name="editor_more_about_osm">در مورد OpenStreetMap بیشتر بدانید</string>
 	<string name="editor_operator">مالک</string>
-	<string name="editor_tag_description">نام شرکت,سازمان یا اطلاعات قابل قبول برای این ساختمان را وارد کنید.</string>
-	<string name="editor_no_local_edits_title">شما ویرایش محلی ندارید</string>
-	<string name="editor_send_to_osm">ارسال به OSM</string>
-	<string name="editor_remove">پاک کردن</string>
-	<string name="downloader_my_maps_title">نقشه های من</string>
 	<string name="downloader_no_downloaded_maps_title">شما هیچ نقشه دانلود شده ای ندارید</string>
 	<string name="downloader_no_downloaded_maps_message">برای جست وجو یک مکان و استفاده از قابلیت ناوبری, نقشه ها را دانلود کنید.</string>
-	<string name="downloader_find_place_hint">جست وجوی شهر یا کشور</string>
 	<!-- Error title that appears after certain time without location. -->
 	<string name="current_location_unknown_title">ایا یافتن مکان تان را ادامه می دهید؟</string>
 	<!-- Error that appears after certain time without location. -->
@@ -746,25 +482,10 @@
 	<string name="location_services_disabled_header">سرویس موقعیت مکانی شما غیرفعال است</string>
 	<string name="location_services_disabled_message">سرویس موقعیت مکانی خود را در بخش تنظیمات فعال کنید.</string>
 	<string name="location_services_disabled_1">1. بازکردن تنظیمات</string>
-	<string name="placepage_parking_surface">سطح</string>
-	<string name="placepage_parking_multistorey">چند طبقه</string>
-	<string name="placepage_parking_underground">زیرزمین</string>
-	<string name="placepage_parking_rooftop">پشت بام</string>
-	<string name="placepage_parking_sheds">سایبان</string>
-	<string name="placepage_parking_carports">گاراژ بدون سقف</string>
-	<string name="placepage_parking_boxes">گاراژ</string>
-	<string name="placepage_parking_pay">پرداخت</string>
-	<string name="placepage_parking_free">مجانی</string>
-	<string name="placepage_entrance_number">شماره.</string>
-	<string name="placepage_entrance_type">ورودی</string>
-	<string name="placepage_open_24_7">شبانه روزی و هفت روز هفته (24 / 7)</string>
 	<string name="meter">متر</string>
 	<string name="kilometer">کیلومتر</string>
-	<string name="kilometers_per_hour">کیلومتربرساعت (km/h)</string>
 	<string name="mile">مایل</string>
 	<string name="foot">فوت</string>
-	<string name="miles_per_hour">مایل بر ساعت (mph)</string>
-	<string name="day">روز</string>
 	<string name="hour">ساعت</string>
 	<string name="minute">دقیقه</string>
 	<string name="placepage_place_description">توضیحات</string>
@@ -774,46 +495,30 @@
 	<string name="placepage_call_button">تماس</string>
 	<string name="placepage_edit_bookmark_button">ویرایش نشانه ها</string>
 	<string name="placepage_bookmark_name_hint">نام نشانه ها</string>
-	<string name="placepage_personal_notes_hint">یاداشت های شخصی</string>
-	<string name="placepage_delete_bookmark_button">حذف نشانه</string>
 	<string name="editor_edits_sent_message">تغییر پیشنهادی شما ارسال شد</string>
 	<string name="editor_comment_hint">اظهار نظر</string>
 	<string name="editor_reset_edits_message">ایا تغییرات محلی را نادیده می گیرید؟</string>
 	<string name="editor_reset_edits_button">نادیده گرفتن</string>
 	<string name="editor_remove_place_message">ایا مکان ثبت شده حذف شود؟</string>
 	<string name="editor_remove_place_button">حذف</string>
-	<string name="editor_status_sending">درحال ارسال</string>
 	<string name="editor_place_doesnt_exist">مکان وجود ندارد</string>
-	<string name="text_more_button">بیشتر....</string>
+	<string name="text_more_button">بیشتر….</string>
 	<!-- Phone number error message -->
 	<string name="error_enter_correct_phone">شماره تلفن معتبری وارد نمایید</string>
 	<string name="error_enter_correct_web">ادرس وب معتبری وارد نمایید</string>
 	<string name="error_enter_correct_email">ایمیل معتبری وارد نمایید</string>
-	<string name="error_enter_correct">مقادیر معتبری وارد نمایید</string>
 	<string name="refresh">بروزرسانی</string>
-	<string name="last_update">اخرین بروزرسانی: %s</string>
 	<string name="placepage_add_place_button">اضافه کردن یک مکان به نقشه</string>
 	<!-- Displayed when saving some edits to the map to warn against publishing personal data -->
 	<string name="editor_share_to_all_dialog_title">ایا می خواهید ان را برای دیگر کاربران ارسال کنید؟</string>
 	<!-- iOS Dialog before publishing the modifications to the public map. -->
 	<string name="editor_share_to_all_dialog_message_1">مطمئن شوید که هیچ اطلاعات شخصی وارد نکرده باشد.</string>
 	<string name="editor_share_to_all_dialog_message_2">ما تغییرات را بررسی می کنیم.اگر سوالی بود با ایمیل با شما تماس می گیریم.</string>
-	<string name="navigation_overview_button">بررسی اجمالی</string>
-	<string name="navigation_stop_button">توقف</string>
-	<!-- Text on an empty bookmark page -->
-	<string name="bookmarks_empty_title">ذخیره نشانه ها</string>
-	<string name="bookmarks_empty_message_1">برروی ★ کلیک کنید تا در علاقه مندی ها برای دسترسی سریع ذخیره شود.</string>
-	<string name="bookmarks_empty_message_2">وارد کردن نشانه ها از ایمیل یا وب.</string>
-	<string name="bookmarks_empty_message_3">وارسی کنید: %s</string>
-	<!-- Name of the group for booked hotels -->
-	<string name="bookmarks_group_name">رزرو هتل ها</string>
-	<string name="place_page_button_read_descriprion">خواندن</string>
 	<!-- iOS dialog for the case when recent track recording is on and the app comes back from background -->
 	<string name="recent_track_background_dialog_title">غیرفعال سازی ذخیره مسیر اخیرا طی شده</string>
 	<string name="off_recent_track_background_button">غیرفعال</string>
 	<!-- For sharing via SMS and so on -->
 	<string name="sharing_call_action_look">بررسی کنید</string>
-	<string name="continue_recent_track_background_button">ادامه</string>
 	<string name="recent_track_background_dialog_message">Organic Maps  از اطلاعات موقعیت مکانی شما در پس ضمینه برای ذخیره مسیر هایی که اخیرا سفر کرده اید استفاده می کند.</string>
 	<!-- Rate on Google Play (Android only) -->
 	<string name="rate_gp">امتیاز دادن در گوگل پلی</string>
@@ -823,22 +528,11 @@
 	<string name="tell_friends_text">سلام!  Organic Maps را نصب کنید.</string>
 	<!-- About short text (below logo) -->
 	<string name="about_description">Organic Maps یک نرم افزار افلاین مخصوص سفر است. Organic Maps بر پایه دیتای OpenStreetMap است و به شما اجازه ویرایش در ان را می دهد.</string>
-	<!-- Text in menu -->
-	<string name="blog">وبلاگ</string>
 	<string name="general_settings">تنظیمات عمومی</string>
-	<string name="date">تاریخ %d</string>
-	<!-- "Report a bug" -> "Generaal Feedback" -> "Something is not working" -->
-	<string name="something_is_not_working">یه چیزی درست کار نمی کنه</string>
 	<!-- For the first routing -->
 	<string name="accept">موافقم</string>
-	<string name="accept_and_continue">قبول و ادامه</string>
 	<!-- For the first routing -->
 	<string name="decline">کاهش</string>
-	<string name="install_app">نصب</string>
-	<string name="search_no_results_title">چیزی یافت نشد</string>
-	<string name="search_no_results_message">چیز های عمومی تری را جست وجو کنید,کوچک نمایی کنید یا این فیلتر را پاک کنید.</string>
-	<string name="search_no_results_expand_area_button">کوچک نمایی</string>
-	<string name="search_no_results_reset_button">پاک کردن فیلتر</string>
 	<!-- noun -->
 	<string name="search_in_table">لیست</string>
 	<string name="mobile_data_dialog">از دیتای موبایل برای نمایش اطلاعات بیشتر استفاده شود؟</string>
@@ -850,18 +544,13 @@
 	<string name="mobile_data_option_never">هرگز</string>
 	<string name="mobile_data_option_ask">همیشه بپرس</string>
 	<string name="traffic_update_maps_text">برای نمایش ترافیک,نقشه می بایستی بروزرسانی شود.</string>
-	<string name="traffic_outdated">دیتای ترافیک منقضی شده است.</string>
 	<string name="big_font">افزایش اندازه متن بر روی نقشه</string>
 	<string name="traffic_update_app">لطفا Organic Maps را بروزرسانی کنید</string>
 	<!-- "traffic" as in road congestion -->
 	<string name="traffic_update_app_message">برای نمایش ترافیک باید اپلیکیشن را بروزرسانی کنید.</string>
 	<!-- "traffic" as in "road congestion" -->
 	<string name="traffic_data_unavailable">اطلاعات ترافیکی موجود نیست</string>
-	<!-- Simplified colour scheme for traffic information, fewer colours are used to display traffic jams on the map. The string should be kept as short as possible -->
-	<string name="pref_traffic_simplified_colors_title">رنگ های ترافیکی ساده شده</string>
 	<string name="enable_logging">ورود به سیستم را فعال کنید</string>
-	<string name="offline_place_page_more_information">برای کسب اطلاعات بیشتر در مورد مکان، به اینترنت متصل شوید.</string>
-	<string name="failed_load_information">اطلاعات بارگیری نشد.</string>
 	<!-- Settings: "Send general feedback" button -->
 	<string name="feedback_general">\"تنظیمات: دکمه \"ارسال بازخورد کلی</string>
 	<string name="on">روشن</string>
@@ -875,58 +564,26 @@
 	<string name="routing_add_start_point">یک نقطه شروع برای برنامه ریزی یک مسیر اضافه کنید</string>
 	<string name="routing_add_finish_point">یک مقصد برای برنامه ریزی یک مسیر اضافه کنید</string>
 	<string name="button_exit">خروج</string>
-	<string name="settings_device_memory">حافظه دستگاه</string>
-	<string name="settings_card_memory">کارت حافظه</string>
-	<string name="settings_storage_available">%s موجود</string>
-	<string name="toast_location_permission_denied">مجوز مکان برنامه صادر نشد</string>
-	<string name="button_use">استفاده</string>
 	<string name="planning_route_manage_route">مدیریت مسیر</string>
 	<string name="button_plan">برنامه</string>
-	<string name="button_add">افزودن</string>
 	<string name="placepage_remove_stop">حذف</string>
 	<string name="planning_route_remove_title">برای حذف اینجا بکشید</string>
-	<string name="dialog_change_start_point_message">مکان فعلی را به عنوان نقطه شروع تعیین کنید؟</string>
-	<string name="button_replace">جایگزین کردن</string>
 	<string name="placepage_add_stop">اضافه کردن توقف</string>
-	<string name="add_my_position">موقعیت من را اضافه کنید</string>
-	<string name="choose_start_point">نقطه شروع را انتخاب کنید</string>
-	<string name="choose_destination">یک مقصد را انتخاب کنید</string>
 	<string name="preloader_viator_button">بیشتر بدانید</string>
-	<string name="start_from_my_position">شروع از</string>
-	<string name="profile_authorization_title">پیوستن با</string>
-	<string name="profile_authorization_message">وارد شدن آسان بدون ورود به سیستم و رمز عبور در چند ثانیه</string>
 	<string name="profile_authorization_error">اوه، یک خطا وجود داشت سعی کنید دوباره وارد سیستم شوید</string>
-	<string name="service">سرویس</string>
-	<string name="atmosphere">جو</string>
-	<string name="value_for_money">ارزش پول</string>
-	<string name="experience">تجربه</string>
-	<string name="assortment">انتخابی</string>
-	<string name="expertise">تجربه و تخصص</string>
-	<string name="equipment">تجهیزات</string>
-	<string name="quality">کیفیت</string>
 	<string name="dialog_error_storage_title">مشکل دسترسی به ذخیره سازی</string>
 	<string name="dialog_error_storage_message">ذخیره سازی خارجی در دسترس نیست کارت SD ممکن است برداشته شده باشد، آسیب دیده باشد یا سیستم فایل فقط خواندنی باشد. لطفا کارت SD خود را بررسی کنید یا با ما در support\@organicmaps.app تماس بگیرید</string>
 	<string name="setting_emulate_bad_storage">شبیه سازی ذخیره سازی بد</string>
-	<string name="directions_finish">مقصد</string>
-	<string name="directions_on_foot">پیاده روی %s</string>
 	<string name="core_entrance">ورودی</string>
-	<string name="coffee">قهوه</string>
-	<string name="cleanliness">پاکیزگی</string>
-	<string name="crowdedness">ازدحام بیش از حد</string>
 	<string name="error_enter_correct_name">لطفا نام صحیح را وارد کنید</string>
 	<string name="bookmarks_groups">لیست ها</string>
 	<string name="bookmarks_groups_hide_all">پنهان کردن همه</string>
 	<string name="bookmarks_groups_show_all">نمایش همه</string>
-	<plurals name="bookmarks_places">
-	  <item quantity="one">%d نشانه</item>
-	  <item quantity="other">%d نشانه‌ها</item>
-	</plurals>
 	<string name="bookmarks_create_new_group">ایجاد لیست جدید</string>
 	<string name="downloader_hide_screen">پنهان کردن صفحه</string>
 	<string name="downloader_percent">%1$s (%2$s از %3$s)</string>
-	<string name="downloader_process">در حال دانلود %s...</string>
-	<string name="downloader_applying">اعمال %s...</string>
-	<string name="dialog_message_transit_not_found_connection">یک مسیر را در یک شبکه حمل و نقل برنامه ریزی کنید</string>
+	<string name="downloader_process">در حال دانلود %s…</string>
+	<string name="downloader_applying">اعمال %s…</string>
 	<string name="bookmarks_error_message_share_general">با توجه به خطای برنامه، امکان اشتراک گذاری وجود ندارد</string>
 	<string name="bookmarks_error_title_share_empty">خطای اشتراک</string>
 	<string name="bookmarks_error_message_share_empty">یک لیست خالی را نمی توان به اشتراک گذاشت</string>
@@ -935,12 +592,7 @@
 	<string name="bookmarks_new_list_hint">لیست جدید</string>
 	<string name="bookmarks_error_title_list_name_already_taken">این اسم قبلا انتخاب شده است</string>
 	<string name="bookmarks_error_message_list_name_already_taken">لطفا نام دیگری را انتخاب کنید</string>
-	<string name="bookmarks_error_title_list_name_too_long">این نام خیلی طولانی است</string>
-	<string name="bookmarks_error_message_list_name_too_long">لطفا نام دیگری را انتخاب کنید</string>
-	<string name="please_wait">لطفا صبر کنید...</string>
-	<string name="phone_number">شماره تلفن</string>
-	<string name="notification_unsent_reviews_title">شما چند نظر ارسال نشده دارید</string>
-	<string name="notification_unsent_reviews_message">لطفا برای اشتراک‌گذاری نظرات با سایر مسافرین وارد شوید</string>
+	<string name="please_wait">لطفا صبر کنید…</string>
 	<string name="profile">OpenStreetMap نمایه</string>
 	<string name="place_page_search_similar_hotel">جست‌وجوی هتل‌های مشابه</string>
 	<string name="bookmarks_detect_title">فایل‌های جدید پیدا شد</string>
@@ -951,32 +603,10 @@
 	<string name="button_convert">تبدیل</string>
 	<string name="bookmarks_convert_error_title">خطا</string>
 	<string name="bookmarks_convert_error_message">بعضی از فایل‌ها تبدیل نشد.</string>
-	<string name="converting">در حال تبدیل...</string>
-	<string name="wn_reinvented_bookmarks_title">نشانه‌ها را بازآفرینی کردیم!</string>
-	<string name="wn_reinvented_bookmarks_message">می‌توانید از آن‌ها پشتیبان بگیرید، لیست درست کنید... عالی شده...</string>
-	<string name="bookmarks_restore">بازگردانی نشانه‌ها</string>
-	<string name="bookmarks_restore_process">در حال بازگردانی...</string>
 	<string name="bookmarks_restore_title">این نسخه برگردد؟</string>
-	<string name="bookmarks_restore_message">نشانه‌های شما از %1$s (%2$s) بازگردانده می‌شود</string>
-	<string name="bookmarks_restore_empty_title">فایل پشتیبان ندارید</string>
-	<string name="bookmarks_restore_empty_message">سرور پشتیبان‌هایی را که قبلا ساخته شده بودند پیدا نکرد</string>
 	<string name="common_check_internet_connection_dialog_title">اتصال اینترنتی برقرار نیست</string>
-	<string name="error_server_title">خطای سرور</string>
-	<string name="error_server_message">روی سرور خطایی رخ داد. لطفا بعدا امتحان کنید</string>
 	<string name="error_system_message">خطای ناشناخته‌ای رخ داد</string>
 	<string name="restore">بازیابی</string>
-	<string name="bookmarks_page_downloaded">دانلود شد</string>
-	<string name="bookmarks_page_my">مال من</string>
-	<string name="routes_and_bookmarks">مسیرها و نشانه‌ها</string>
-	<string name="bookmarks_webview_success_toast">نشانه‌ها با موفقیت دانلود شد</string>
-	<string name="cached_bookmarks_placeholder_title">دانلود مکان‌های جدید</string>
-	<string name="cached_bookmarks_placeholder_subtitle">دکمه را بزنید تا هزاران مکان و مسیر جالبی که دیگران کاربران Organic Maps ساخته‌اند را ببینید. به اتصال اینترنتی نیاز خواهید داشت.</string>
-	<string name="downloader_download_routers">دانلود نشانه‌ها</string>
-	<string name="bookmarks_groups_cached">لیست‌های دانلودشده</string>
-	<plurals name="bookmarks_objects">
-	  <item quantity="one">%s شیء</item>
-	  <item quantity="other">%s شیء</item>
-	</plurals>
 	<plurals name="objects">
 	  <item quantity="one">%s شیء</item>
 	  <item quantity="other">%s شیء</item>
@@ -992,66 +622,33 @@
 	<string name="subtittle_opt_out">تنظیمات ردیابی</string>
 	<string name="crash_reports">گزارش خرابی</string>
 	<string name="crash_reports_description">ما از داده‌های شما برای بهبود Organic Maps استفاده می‌کنیم. تغییرات پس از راه‌اندازی مجدد برنامه به‌کار می‌افتد.</string>
-	<string name="opt_out_help_ios_1">در دستگاه همراهتان تنظیمی با نام “Limit Ad Tracking” یا “Opt out of interest-based advertising” وجود دارد.</string>
-	<string name="opt_out_help_ios_2">آی‌اواس ۹ یا بالاتر</string>
-	<string name="opt_out_help_ios_3">به تنظیمات خود بروید ← حریم خصوصی ← تبلیغات ← گزینه  «محدود کردن ردیابی آگهی» را فعال کنید</string>
-	<string name="opt_out_help_android">دستگاه تلفن همراه شما ممکن است یک «ردیابی محدود آگهی» یا «لغو تبلیغات مبتنی بر علاقه» ارائه کند. \n \n برای Android و Google Play Services نسخه 4.0 و بالاتر: \n تنظیمات → Google → آگهی → غیرفعال کردن تبلیغات شخصی سازی \ یا \n تنظیمات → Google → حساب Google → اطلاعات شخصی و حریم خصوصی → تنظیمات تبلیغات → شخصی سازی تبلیغات</string>
 	<string name="privacy_policy">سیاست حریم خصوصی</string>
 	<string name="terms_of_use">شرایط استفاده</string>
-	<string name="backup_notification_failed">پشتیبانگیری از نشانکهای شما به حالت تعلیق درآمده است وارد شوید تا آن را دوباره روشن کنید</string>
 	<string name="button_layer_traffic">ترافیک</string>
 	<string name="button_layer_subway">مترو</string>
 	<string name="layers_title">لایه های نقشه</string>
-	<string name="layers_message">از لایه های نقشه برای نمایش ترافیک، نقشه مترو و سایر اطلاعات مفید استفاده کنید</string>
-	<string name="button_layer_got_it">متوجه شدم</string>
 	<string name="subway_data_unavailable">نقشه مترو موجود نیست</string>
 	<string name="bookmarks_empty_list_title">این لیست خالی است</string>
 	<string name="bookmarks_empty_list_message">برای افزودن یک نشانه، روی یک مکان روی نقشه ضربه بزنید و سپس روی نماد ستاره ضربه بزنید</string>
-	<string name="category_desc_more">بیشتر...</string>
+	<string name="category_desc_more">بیشتر…</string>
 	<string name="title_error_downloading_bookmarks">خطایی رخ داد</string>
-	<string name="subtitle_error_downloading_bookmarks">نشانه ها دانلود نشدند</string>
-	<string name="error_already_downloaded">این لیست قبلا دانلود شده است</string>
 	<string name="popular_place">مشهور</string>
-	<string name="download_routes">دانلود مسیر</string>
-	<string name="bookmarks_downloaded_title">نشانکها با موفقیت دانلود شدند</string>
-	<string name="bookmarks_downloaded_subtitle">\'نمایش بر روی نقشه\' را فشار دهید تا مکان های جدید را از لیست کاوش کنید</string>
-	<string name="why_support">چرا پشتیبانی از Organic Maps؟</string>
-	<string name="why_support_item2">شما برای بهبود Organic Maps به ما کمک میکنید</string>
-	<string name="why_support_item3">شما به ما در بهبود نقشه OpenStreetMap.org کمک میکنید.</string>
-	<string name="channels_map_update">بروزرسانی های نقشه</string>
-	<string name="server_unavailable_title">سرویس موجود نیست</string>
-	<string name="sharing_options">گزینه های اشتراک گذاری</string>
 	<string name="export_file">ارسال فایل</string>
 	<string name="list_settings">تنظیمات لیست</string>
 	<string name="delete_list">حذف لیست</string>
-	<string name="hide_from_map">پنهان کردن از نقشه</string>
 	<string name="public_access">دسترسی عمومی</string>
 	<string name="limited_access">دسترسی محدود</string>
 	<string name="bookmark_category_name">دسته بندی</string>
 	<string name="bookmark_category_description_hint">یک توضیح (متن یا html) تایپ نمایید</string>
 	<string name="not_shared">خصوصی</string>
-	<string name="direct_link_progress_text">در حال بارگذاری فایل شما…</string>
-	<string name="direct_link_success">لینک ایجاد شده است</string>
-	<string name="send_a_link_btn">یک لینک برای من ارسال کن</string>
-	<string name="upload_error_toast">هنگام بارگذاری فایل شما خطایی روی داد</string>
 	<string name="tags_loading_error_subtitle">هنگام بارگذاری برچسب خطایی رخ داد، لطفا دوباره امتحان کنید</string>
-	<string name="unable_upload_errorr_title">بارگذاری فایل انجام نشد</string>
-	<string name="unable_upload_error_subtitle_edited">این فایل از طریق برنامه وب ویرایش شده است</string>
-	<string name="unable_upload_error_subtitle_broken">این فایل آسیب دیده است و امکان بارگذاری آن وجود ندارد. لطفا فایل دیگری را بارگذاری نمایید.</string>
-	<string name="contact">تماس</string>
-	<string name="download_button">دانلود</string>
 	<string name="speedcams_alert_title">دوربین های سرعت</string>
-	<string name="speedcams_alert_subtitle">هشدار درباره محدودیت سرعت</string>
 	<string name="speedcam_option_auto">خودکار</string>
 	<string name="speedcam_option_always">همیشه</string>
 	<string name="speedcam_option_never">هرگز</string>
-	<string name="bookmark_description_title">توضیحات نشانه گذاری</string>
 	<string name="place_description_title">توضیحات محل</string>
 	<!-- this text will be shown in application notification preferences opposite checkbox which enable/disable downloader notifications. Devices on Android 8+ are affected. -->
 	<string name="notification_channel_downloader">دانلود کننده نقشه</string>
-	<string name="share_bookmarks_email_body_link">سلام!\n\nاین لینکی است که شما می توانید نشان شده های خود را از آن دانلود نمایید: %s. لیست را از طریق Organic Maps باز کرده و از سفر خود لذت ببرید!\n\nدریافت برنامه: https://omaps.app/get?kmz</string>
-	<string name="warning_speedcams_title">هدایتگر هنگامی که از محدوده سرعت %d کیلومتر بر ساعت تجاوز نمایید، در مورد دوربین هشدار می دهد</string>
-	<string name="warning_speedcams_subtitle">لطفا قوانین رانندگی کشوری که به آن سفر می کنید، را رعایت کنید.</string>
 	<string name="speedcams_notice_message">خودکار- در صورتی که خطر تجاوز از سرعت مجاز وجود داشت، نسبت به دوربین های کنترل سرعت هشدار دهد\nهمیشه-همیشه درباره دوربین های کنترل سرعت هشدار دهد\nهرگز-هرگز درباره دوربین های کنترل سرعت هشدار ندهد</string>
 	<string name="power_managment_title">حالت ذخیره انرژی</string>
 	<string name="power_managment_description">هنگامی که حالت خودکار انتخاب شده‌باشد، برنامه با توجه میزان شارژ باتری شما، ویژگی‌های تخلیه کننده باتری را غیر فعال می‌کند</string>
@@ -1059,14 +656,7 @@
 	<string name="power_managment_setting_auto">خودکار</string>
 	<string name="power_managment_setting_manual_max">حداکثر ذخیره انرژی</string>
 	<string name="enable_logging_warning_message">این گزینه ثبت گزارش را برای اهداف تشخیصی فعال می‌کند. برای کارکنان بخش پشتیبانی که مشکلات برنامه را عیب یابی می‌کنند، مفید باشد. این گزینه را تنها در صورت درخواست پشتیبانی Organic Maps فعال کنید.</string>
-	<string name="html_error_upload_message_try_again">لطفاً تنظیمات شبکه را بررسی و مجدد تلاش کنید</string>
-	<string name="html_error_upload_title_try_again">ارتباط اینترنت برقرار نیست</string>
-	<string name="notification_leave_review_v2_android_short_title">نظر خود را بیان و به مسافران کمک کنید!</string>
-	<string name="notifications_illegal_alert_disable_button">خاموش کردن اعلان‌ها</string>
 	<string name="access_rules_author_only">ویرایش آنلاین</string>
-	<string name="privacy_settings_menu">تنظیمات حریم خصوصی</string>
-	<string name="unable_upadate_error_title">به روز رسانی فایل ناموفق بود</string>
-	<string name="unable_upadate_error_message">هنگام به روز رسانی برخی اشتباهات رخ داده است. لطفاً تغییرات را بررسی و مجدد تلاش کنید</string>
 	<string name="driving_options_title">گزینه های رانندگی</string>
 	<string name="driving_options_subheader">اجتناب از تمامی مسیرها</string>
 	<string name="avoid_tolls">جاده های دارای عوارض</string>
@@ -1077,52 +667,14 @@
 	<string name="unable_to_calc_alert_subtitle">متأسفانه، احتمالاً به دلیل گزینه های تعریف شده شما، مسیری پیدا نشد. لطفاً تنظیمات را تغییر داده و مجدد تلاش کنید</string>
 	<string name="define_to_avoid_btn">جاده های لغو شده را تعریف نمایید</string>
 	<string name="change_driving_options_btn">گزینه های مسیریابی فعال شد</string>
-	<string name="toll_road">جاده دارای عوارض</string>
-	<string name="unpaved_road">جاده آسفالت نشده</string>
-	<string name="ferry_crossing">گذرگاه جاده ای</string>
-	<string name="operated_by">اجرا توسط \"%s\"</string>
 	<string name="avoid_toll_roads_placepage">اجتناب از جاده های دارای عوارض</string>
 	<string name="avoid_unpaved_roads_placepage">اجتناب از جاده های آسفالت نشده</string>
 	<string name="avoid_ferry_crossing_placepage">اجتناب از گذرگاه های کشتی</string>
-	<string name="type.cuisine.uzbek">غذای ازبکستانی</string>
-	<string name="trip_start">برویم</string>
-	<string name="pick_destination">مقصد</string>
-	<string name="follow_my_position">نشان دادن مجدد در مرکز</string>
-	<string name="search_results">نتایج جستجو</string>
-	<string name="then_turn">سپس</string>
-	<string name="redirect_route_alert">آیا می خواهید مسیر را دوباره ایجاد کنید?</string>
-	<string name="redirect_route_yes">بله</string>
-	<string name="redirect_route_no">خیر</string>
-	<string name="trip_finished">شما به مقصد رسیدید!</string>
-	<string name="keyboard_availability_alert">صفحه کلید در هنگام رانندگی در دسترس نیست</string>
-	<string name="dialog_routing_change_start_carplay">امکان ایجاد مسیر از مکان فعلی شما نیست</string>
-	<string name="dialog_routing_change_end_carplay">امکان ایجاد مسیر به مقصد شما نیست. لطفاً نقطه دیگری را انتخاب کنید</string>
-	<string name="dialog_routing_check_gps_carplay">سیگنال GPS وجود ندارد. لطفاً به فضای باز بروید</string>
-	<string name="dialog_routing_unable_locate_route_carplay">امکان ایجاد مسیر نیست. لطفاً نقاط مسیر دیگری را مشخص کنید</string>
-	<string name="dialog_routing_download_files_carplay">برای ایجاد مسیر، نقشه های ناقص را روی دستگاه خود را دانلود کنید</string>
-	<string name="dialog_routing_system_error_carplay">خطایی رخ داد. لطفاً برنامه را دوباره اجرا کنید</string>
-	<string name="dialog_routing_rebuild_from_current_location_carplay">مسیر از مکان فعلی شما بازسازی خواهد شد</string>
-	<string name="dialog_routing_rebuild_for_vehicle_carplay">مسیر به مسیر خودرویی تغییر خواهد کرد</string>
 	<string name="ok">موافقت کردن</string>
-	<string name="avoid_unpaved_carplay_1">بی جاده خاکی</string>
-	<string name="avoid_unpaved_carplay_2">پرهیز از خاکی</string>
-	<string name="avoid_ferry_carplay_1">بدون بزرگراه</string>
-	<string name="avoid_ferry_carplay_2">پرهیز از اتوبان</string>
-	<string name="avoid_tolls_carplay_1">بدون عوارضی</string>
-	<string name="avoid_tolls_carplay_2">اجتناب از عوارض</string>
-	<string name="speedcams_alert_title_carplay_1">دوربین سرعت</string>
-	<string name="speedcams_alert_title_carplay_2">هشدارهای سرعت</string>
-	<string name="download_map_carplay">لطفا نقشه ها را در نرم افزار Organic Maps روی دستگاه خود دانلود کنید</string>
-	<string name="carplay_roundabout_exit">خروجی %s</string>
 	<!-- max. 10 symbols, both iOS and Android -->
 	<string name="sort">مرتب سازی…</string>
 	<!-- Android, title, max 20-22 symbols -->
 	<string name="sort_bookmarks">مرتب سازی نشانهها</string>
-	<!-- iOS -->
-	<string name="sort_default">مرتب سازی بر اساس پیش فرض</string>
-	<string name="sort_type">مرتب سازی بر اساس نوع</string>
-	<string name="sort_distance">مرتب سازی بر اساس فاصله</string>
-	<string name="sort_date">مرتب سازی بر اساس تاریخ</string>
 	<!-- Android -->
 	<string name="by_default">به صورت پیش فرض</string>
 	<!-- Android -->
@@ -1131,65 +683,23 @@
 	<string name="by_distance">بر اساس فاصله</string>
 	<!-- Android -->
 	<string name="by_date">بر اساس تاریخ</string>
-	<string name="week_ago_sorttype">یک هفته قبل</string>
-	<string name="month_ago_sorttype">یک ماه قبل</string>
-	<string name="moremonth_ago_sorttype">بیش از یک ماه قبل</string>
-	<string name="moreyear_ago_sorttype">بیش از یک سال قبل</string>
-	<string name="near_me_sorttype">نزدیک من</string>
-	<string name="others_sorttype">دیگران</string>
-	<string name="food_places">غذا</string>
-	<string name="tourist_places">مناظر</string>
-	<string name="museums">موزهها</string>
-	<string name="parks">پارکها</string>
-	<string name="swim_places">شنا</string>
-	<string name="mountains">کوهها</string>
-	<string name="animals">حیوانات</string>
-	<string name="hotels">هتلها</string>
-	<string name="buildings">ساختمانها</string>
-	<string name="money">پول</string>
-	<string name="shops">مراکز خرید</string>
-	<string name="parkings">پارکینگها</string>
-	<string name="fuel_places">پمپ بنزین</string>
-	<string name="water">آب</string>
-	<string name="medicine">پزشکی</string>
 	<string name="search_in_the_list">جستجو در لیست</string>
-	<string name="view_on_map_bookmarks">روی نقشه</string>
-	<string name="more_bookmarks">بیشتر…</string>
-	<string name="no_items_found">هیچ موردی یافت نشد</string>
-	<!-- Android, max 18 symbols -->
-	<string name="bookmarks_edit_list">ویرایش فهرست</string>
-	<!-- Android, max 18 symbols -->
-	<string name="bookmarks_delete_list">حذف همه</string>
-	<string name="religious_places">اماکن مقدس</string>
 	<string name="select_list">انتخاب فهرست</string>
 	<string name="transit_not_found">راهنمای مترو در این منطقه هنوز دردسترس نیست</string>
 	<string name="dialog_pedestrian_route_is_long_header">مسیر مترو یافت نشد</string>
 	<string name="dialog_pedestrian_route_is_long_message">لطفا نقطه آغاز و پایان نزدیک تری به ایستگاه مترو انتخاب کنید</string>
-	<!-- Failed planning SUBWAY route message in navigation view -->
-	<string name="routing_planning_error_subway_special">برنامه ریزی مسیر مترو ناموفق ماند</string>
 	<string name="button_layer_isolines">ایزومپ</string>
-	<string name="tips_map_layers_title_countour">تازه ها در Organic Maps: لایه توپوگرافی آفلاین!</string>
-	<string name="tips_map_layers_message_countour">با اطمینان از این که همه چیز را در مورد منطقه می دانید طبیعت گردی خود را برنامه ریزی کنید و لذت ببرید</string>
 	<string name="isolines_activation_error_dialog">برای فعال سازی و استفاده از لایه توپوگرافی نقشه منطقه را به روزرسانی یا دانلود کنید</string>
 	<string name="isolines_location_error_dialog">لایه توپوگرافی هنوز برای این منطقه در دسترس نیست</string>
 	<string name="elevation_profile_diff_level">سطح دشواری</string>
-	<string name="elevation_profile_diff_level_easy">آسان</string>
-	<string name="elevation_profile_diff_level_moderate">متوسط</string>
-	<string name="elevation_profile_diff_level_hard">دشوار</string>
 	<string name="elevation_profile_ascent">بالا رفتن</string>
 	<string name="elevation_profile_descent">پایین آمدن</string>
 	<string name="elevation_profile_minaltitude">کمینه ارتفاع</string>
 	<string name="elevation_profile_maxaltitude">بیشینه ارتفاع</string>
-	<string name="elevation_profile_m">متر</string>
 	<string name="elevation_profile_difficulty">دشواری</string>
 	<string name="elevation_profile_distance">مسافت</string>
-	<string name="elevation_profile_km">کیلومتر</string>
 	<string name="elevation_profile_time">زمان:</string>
-	<string name="elevation_profile_hours">ساعت</string>
-	<string name="elevation_profile_minutes">دقیقه</string>
 	<string name="isolines_toast_zooms_1_10">برای بررسی خطوط تراز زوم کنید</string>
-	<string name="downloader_updating_ios">در حال بروزرسانی</string>
-	<string name="downloader_loading_ios">در حال دانلود</string>
 	<string name="key_information_title">اطلاعات کلیدی</string>
 	<string name="enable_screen_sleep">اجازه دهید صفحه نمایش بخوابد</string>
 	<!-- Description in preferences -->

--- a/android/res/values-fi/strings.xml
+++ b/android/res/values-fi/strings.xml
@@ -12,15 +12,11 @@
 	<string name="cancel_download">Peruuta lataus</string>
 	<!-- Button which deletes downloaded country -->
 	<string name="delete">Poista</string>
-	<!-- Button "do not interrupt download" if user touched actively downloading country -->
-	<string name="do_nothing">Jatka</string>
 	<string name="download_maps">Lataa karttoja</string>
 	<!-- Settings/Downloader - info for country when download fails -->
 	<string name="download_has_failed">Lataus epäonnistui, yritä uudelleen koskettamalla</string>
 	<!-- Settings/Downloader - info for country which started downloading -->
 	<string name="downloading">Ladataan…</string>
-	<!-- Settings/Downloader - size string, only strings different from English should be translated -->
-	<string name="kb">Kt</string>
 	<!-- Choose measurement on first launch alert - choose metric system button -->
 	<string name="kilometres">Kilometrit</string>
 	<!-- Leave Review dialog - Review button -->
@@ -35,45 +31,31 @@
 	<string name="core_my_position">Sijaintini</string>
 	<!-- Update maps later/Buy pro version later button text -->
 	<string name="later">Myöhemmin</string>
-	<!-- Don't show some dialog any more -->
-	<string name="never">Ei koskaan</string>
 	<!-- View and button titles for accessibility -->
 	<string name="search">Haku</string>
 	<!-- Search box placeholder text -->
 	<string name="search_map">Hae kartalta</string>
-	<!-- Settings/Downloader - info for not downloaded country -->
-	<string name="touch_to_download">Lataa koskettamalla</string>
 	<!-- Settings/Downloader - 3G download warning dialog confirm button -->
 	<string name="use_cellular_data">Kyllä</string>
 	<!-- Location services are disabled by user alert - message -->
 	<string name="location_is_disabled_long_text">Laitteen tai sovelluksen kaikki sijaintipalvelut ovat tällä hetkellä poissa käytöstä. Ota ne käyttöön Asetukset-valikossa.</string>
-	<!-- Location Services are not available on the device alert - message -->
-	<string name="device_doesnot_support_location_services">Laitteesi ei tue sijaintipalveluita</string>
 	<!-- View and button titles for accessibility -->
 	<string name="zoom_to_country">Näytä kartalla</string>
-	<!-- Button text for the button at the center of the screen when the country is not downloaded -->
-	<string name="country_status_download">Lataa kartta\n(^ ^)</string>
 	<!-- Button text for the button at the center of the screen when the country is not downloaded and the size should not be shown -->
 	<string name="country_status_download_without_size">Lataa kartta</string>
-	<!-- Button text for the button at the center of the screen when the country is not downloaded -->
-	<string name="country_status_download_without_routing">Lataa kartta\nilman reititystä (^ ^)</string>
 	<!-- Message to display at the center of the screen when the country download has failed -->
 	<string name="country_status_download_failed">Lataus epäonnistui</string>
 	<!-- Button text for the button under the country_status_download_failed message -->
 	<string name="try_again">Yritä uudelleen</string>
 	<string name="about_menu_title">Tietoa Organic Maps:stä</string>
-	<string name="downloaded_touch_to_delete">Ladattu (%s), poista koskettamalla</string>
 	<string name="connection_settings">Yhteysasetukset</string>
-	<string name="download_mb_or_kb">Lataa %s</string>
 	<string name="close">Sulje</string>
 	<string name="unsupported_phone">Laitteistokiihdytetty OpenGL vaaditaan. Valitettavasti laitteesi ei ole tuettu.</string>
 	<string name="download">Lataa</string>
-	<string name="external_storage_is_not_available">SD-kortti/USB-massamuisti, jolle kartat on ladattu, ei ole käytettävissä</string>
 	<string name="disconnect_usb_cable">Irrota USB-kaapeli tai syötä muistikortti käyttääksesi Organic Maps -sovellusta</string>
 	<string name="not_enough_free_space_on_sdcard">Vapauta ensin tilaa SD-kortilta/USB-massamuistilta käyttääksesi sovellusta</string>
 	<string name="not_enough_memory">Ei tarpeeksi muistia sovelluksen avaamiseksi</string>
 	<string name="download_resources">Ennen aloitusta laitteelle tulee ladata yleinen maailmankartta.\nSe tarvitsee yhteensä %s dataa.</string>
-	<string name="getting_position">Etsitään sijaintia</string>
 	<string name="download_resources_continue">Siirry karttaan</string>
 	<string name="downloading_country_can_proceed">Ladataan %s. Voit nyt jatkaa kartalle.</string>
 	<string name="download_country_ask">Ladataanko %s?</string>
@@ -86,30 +68,20 @@
 	<string name="download_country_failed">%s lataus epäonnistui</string>
 	<!-- Add New Bookmark Set dialog title -->
 	<string name="add_new_set">Lisää uusi valikoima</string>
-	<!-- Place Page - Add To Bookmarks button -->
-	<string name="add_to_bookmarks">Lisää Kirjanmerkkeihin</string>
 	<!-- Bookmark Color dialog title -->
 	<string name="bookmark_color">Kirjanmerkin väri</string>
 	<!-- Add Bookmark Set dialog - hint when set name is empty -->
 	<string name="bookmark_set_name">Kirjanmerkkivalikoiman nimi</string>
-	<!-- Bookmark Sets dialog title -->
-	<string name="bookmark_sets">Kirjanmerkkivalikoimat</string>
 	<!-- Bookmarks - dialog title -->
 	<string name="bookmarks">Kirjanmerkit</string>
-	<!-- Add bookmark dialog - bookmark color -->
-	<string name="color">Väri</string>
 	<!-- Default bookmarks set name -->
 	<string name="core_my_places">Paikkani</string>
 	<!-- Add bookmark dialog - bookmark name -->
 	<string name="name">Nimi</string>
 	<!-- Editor title above street and house number -->
 	<string name="address">Osoite</string>
-	<!-- Place Page - Remove Pin button -->
-	<string name="remove_pin">Poista nasta</string>
 	<!-- Add bookmark dialog - bookmark set, Bookmarks dialog - Bookmark set cell -->
 	<string name="set">Aseta</string>
-	<!-- Text hint in Bookmarks dialog when no any bookmarks are added -->
-	<string name="bookmarks_usage_hint">Sinulla ei vielä ole kirjanmerkkejä.\nLisää kirjanmerkki napsauttamalla mitä tahansa paikkaa kartalla.\nVoit myös tuoda kirjanmerkkejä muista lähteistä Organic Maps:ssä käytettäviksi avaamalla KML/KMZ-kirjanmerkkitiedoston sähköpostistasi, Dropbox-tililtäsi tai verkko-osoitteesta.</string>
 	<!-- Settings button in system menu -->
 	<string name="settings">Asetukset</string>
 	<!-- Header of settings activity where user defines storage path -->
@@ -120,10 +92,6 @@
 	<string name="move_maps">Siirrä karttoja?</string>
 	<!-- Ask to wait user several minutes (some long process in modal dialog). -->
 	<string name="wait_several_minutes">Tämä voi kestää useita minuutteja.\nOdota hetki…</string>
-	<!-- Show bookmarks from this category on a map or not -->
-	<string name="visible">Näkyvä</string>
-	<!-- Toast which is displayed when GPS has been deactivated -->
-	<string name="gps_is_disabled_long_text">GPS on pois käytöstä. Voit ottaa sen käyttöön asetusvalikosta.</string>
 	<!-- Measurement units title in settings activity -->
 	<string name="measurement_units">Mittayksiköt</string>
 	<!-- Detailed description of Measurement Units settings button -->
@@ -164,12 +132,8 @@
 	<string name="post">Posti</string>
 	<!-- Search category -->
 	<string name="police">Poliisi</string>
-	<!-- String in search result list, when nothing found -->
-	<string name="no_search_results_found">Tuloksia ei löytynyt</string>
 	<!-- Notes field in Bookmarks view -->
 	<string name="description">Muistiinpanot</string>
-	<!-- Button text -->
-	<string name="share_by_email">Jaa sähköpostilla</string>
 	<!-- Email Subject when sharing bookmarks category -->
 	<string name="share_bookmarks_email_subject">Jaetut Organic Maps-kirjanmerkit</string>
 	<!-- message title of loading file -->
@@ -182,20 +146,10 @@
 	<string name="edit">Muokkaa</string>
 	<!-- Warning message when doing search around current position -->
 	<string name="unknown_current_position">Sijaintiasi ei ole vielä määritetty</string>
-	<!-- Warning message when location country isn't downloaded during search (see also download_location_map_proposal). -->
-	<string name="download_location_country">Lataa nykyisen sijainnin (%s) maa</string>
-	<!-- Warning message when viewport country isn't downloaded during search -->
-	<string name="download_viewport_country_to_search">Lataa hakemasi sijainnin (%s) maa</string>
 	<!-- Alert message that we can't run Map Storage settings due to some reasons. -->
 	<string name="cant_change_this_setting">Valitettavasti karttatallennusasetukset ovat pois päältä.</string>
 	<!-- Alert message that downloading is in progress. -->
 	<string name="downloading_is_active">Maata ladataan parhaillaan.</string>
-	<!-- Message that will be shown in alert view, when we ask user to leave review on App Store -->
-	<string name="appStore_message">Toivottavasti nautit Organic Maps -sovelluksen käyttämisestä! Olisimme tyytyväisiä, jos voisit arvioida sovelluksen App Storessa. Se kesää alle minuutin, ja auttaa meitä todella paljon. Kiitos tuestasi!</string>
-	<!-- No, thanks -->
-	<string name="no_thanks">Ei kiitos</string>
-	<!-- Share one specific bookmark using SMS, %1$@ contains om:// and %2$@ https://omaps.app link. @NOTE non-ascii symbols in the link will result in max 70 characters SMS instead of 140. -->
-	<string name="bookmark_share_sms">Hei, katso merkintäni Organic Maps-sovelluksessa! %1$s tai %2$s Eikö sinulla ole offline-karttoja? Lataa ne täältä: https://omaps.app/get</string>
 	<!-- Share my position using SMS, %1$@ contains om:// and %2$@ https://omaps.app link WITHOUT NAME. @NOTE non-ascii symbols in the link will result in max 70 characters SMS instead of 140. -->
 	<string name="my_position_share_sms">Hei, katso sijaintini Organic Maps-sovelluksessa! %1$s tai %2$s Eikö sinulla ole vielä offline-karttoja? Lataa ne täältä: https://omaps.app/get</string>
 	<!-- Subject for emailed bookmark -->
@@ -204,30 +158,16 @@
 	<string name="my_position_share_email_subject">Hei, kurkkaa tämänhetkinen sijaintini Organic Maps:n kartalla!</string>
 	<!-- Share my position using EMail, %1$@ is om:// and %2$@ is https://omaps.app link WITHOUT NAME -->
 	<string name="my_position_share_email">Hei,n\nOlen nyt täällä: %1$s. Klikkaa linkkiä %2$s tai %3$s nähdäksesi paikan kartalla. Kiitos.</string>
-	<!-- Android share by Message/SMS button text (including SMS) -->
-	<string name="share_by_message">Jaa viestillä</string>
 	<!-- Share button text which opens menu with more buttons, like Message, EMail, Facebook etc. -->
 	<string name="share">Jaa</string>
-	<!-- iOS share by Message button text (including SMS) -->
-	<string name="message">Viesti</string>
 	<!-- Share by email button text, also used in editor. -->
 	<string name="email">Sähköposti</string>
-	<!-- Copy Link -->
-	<string name="copy_link">Kopioi linkki</string>
-	<!-- Text for the button that returns to caller application -->
-	<string name="more_info">Näytä lisätietoja</string>
 	<!-- Text for message when used successfully copied something -->
 	<string name="copied_to_clipboard">Kopioitu leikepöydälle: %1$s</string>
 	<!-- place preview title -->
 	<string name="info">Tietoa</string>
 	<!-- Used for bookmark editing -->
 	<string name="done">Valmis</string>
-	<!-- Summary for preferences in MWM -->
-	<string name="yopme_pref_summary">Valitse tausta-asetukset</string>
-	<!-- Title for yopme preferences in MWM -->
-	<string name="yopme_pref_title">Tausta-asetukset</string>
-	<!-- Hint for upper-right icon p2b -->
-	<string name="show_on_backscreen">Näytä taustalla</string>
 	<!-- Prints version number in About dialog -->
 	<string name="version">Versio: %s</string>
 	<!-- Confirmation in downloading countries dialog -->
@@ -237,11 +177,6 @@
 	<!-- Length of track in cell that describes route -->
 	<string name="length">Pituus</string>
 	<string name="share_my_location">Jaa sijaintini</string>
-	<string name="menu_search">Haku</string>
-	<!-- Settings screen: "Map" category title -->
-	<string name="prefs_group_map">Kartta</string>
-	<!-- Settings screen: "Miscellaneous" category title -->
-	<string name="prefs_group_misc">Muut</string>
 	<string name="prefs_group_route">Navigaatio</string>
 	<string name="pref_zoom_title">Zoomauspainikkeet</string>
 	<string name="pref_zoom_summary">Näytä ruudulla</string>
@@ -257,8 +192,6 @@
 	<string name="pref_map_3d_title">Perspektiivinäkymä</string>
 	<!-- Settings «Map» category: «3D buildings» title -->
 	<string name="pref_map_3d_buildings_title">3D-rakennukset</string>
-	<!-- Settings «Map» category: «3D buildings» summary -->
-	<string name="pref_map_3d_buildings_subtitle">Vaikuttaa akun kestoon</string>
 	<!-- Settings «Route» category: «Tts enabled» title -->
 	<string name="pref_tts_enable_title">Ääniohjeistukset</string>
 	<!-- Settings «Route» category: «Tts language» title -->
@@ -267,7 +200,6 @@
 	<string name="pref_tts_unavailable">Ei saatavilla</string>
 	<!-- Title for "Other" section in TTS settings. -->
 	<string name="pref_tts_other_section_title">Muu</string>
-	<string name="pref_tts_how_to_set_up_voice">Kuinka asettaa ääni</string>
 	<!-- Settings «Map» category: «Record track» title -->
 	<string name="pref_track_record_title">Viimeisin reitti</string>
 	<string name="pref_map_auto_zoom">Automaattinen zoomaus</string>
@@ -278,40 +210,11 @@
 	<string name="duration_12_hours">12 tuntia</string>
 	<string name="duration_1_day">1 päivä</string>
 	<string name="recent_track_help_text">Toiminnon avulla voit tallentaa kuljetun reitin tietyltä ajalta ja nähdä sen kartalla: Huomautus: tämän toiminnon aktivoiminen lisää akun käyttöä. Reitti poistetaan kartalta automaattisesti ajanjakson päätyttyä.</string>
-	<string name="pref_track_ios_caption">Viimeisin reitti näyttää kulkemasi matkan.</string>
-	<string name="pref_track_ios_subcaption">Valitse reitin tallennuksen aikaväli.</string>
-	<string name="placepage_distance">Etäisyys</string>
-	<string name="placepage_coordinates">Koordinaatit</string>
-	<string name="placepage_unsorted">Järjestelemätön</string>
 	<string name="search_show_on_map">Näytä kartalla</string>
-	<!-- Used to warn user when fixing KitKat issue -->
-	<string name="bookmark_move_fail">Vapauta muistia, sillä muuten karttoja voidaan käyttää vain lukutilassa. Kirjanmerkkisi pitää siirtää laitteen sisäiseen muistiin, mutta vapaata muistia ei ole tarpeeksi. Vapauta muistia, sillä muuten kirjanmerkkejä ei voida käyttää.</string>
-	<!-- 1st search button-like result -->
-	<string name="search_on_map">Etsi kartalta</string>
-	<!-- toast with an error -->
-	<string name="no_route_found">Reittiä ei löydy</string>
-	<!-- route title -->
-	<string name="route">Reitti</string>
-	<!-- category title -->
-	<string name="routes">Reitit</string>
-	<!-- text of notification -->
-	<string name="download_map_notification">Lataa sijaintisi kartta</string>
-	<!-- Dialog for transferring maps from lite to pro. -->
-	<string name="move_lite_maps_to_pro">Me siirrämme lataamasi kartat Organic Maps Lite:stä Organic Maps:hen. Siirtäminen voi viedä muutaman minuutin.</string>
-	<!-- Message to display when maps moved. -->
-	<string name="move_lite_maps_to_pro_ok">Lataamasi kartat on siirretty onnistuneesti Organic Maps:hen.</string>
-	<!-- Message to display when maps move failed. -->
-	<string name="move_lite_maps_to_pro_failed">Karttoja ei voitu siirtää. Ole hyvä ja poista Organic Maps Lite ja lataa kartat uudelleen.</string>
-	<!-- Text in menu -->
-	<string name="settings_and_more">Asetukset &amp;amp; Lisää</string>
 	<!-- Text in menu -->
 	<string name="website">Kotisivut</string>
-	<!-- Text in menu -->
-	<string name="contact_us">Ota yhteyttä</string>
 	<!-- Settings: Send feedback button and dialog title -->
 	<string name="feedback">Palaute</string>
-	<!-- Text in menu -->
-	<string name="subscribe_to_news">Tilaa uutiskirjeemme</string>
 	<!-- Text in menu -->
 	<string name="rate_the_app">Arvioi sovellus</string>
 	<!-- Text in menu -->
@@ -320,12 +223,6 @@
 	<string name="copyright">Copyright</string>
 	<!-- Text in menu -->
 	<string name="report_a_bug">Ilmoita virheestä</string>
-	<!-- Email subject -->
-	<string name="subscribe_me_subject">Lisätkää minut Organic Maps:n uutiskirjeen tilaajaksi</string>
-	<!-- Email body -->
-	<string name="subscribe_me_body">Liittäkää minut Organic Maps -uutiskirjeen tilaajaksi saadakseni ensimmäisenä tietoa uusista päivityksistä ja TARJOUKSISTA. Voin peruuttaa tilaukseni koska tahansa.</string>
-	<!-- About text -->
-	<string name="about_text">Organic Maps tarjoaa nopeimmat offline-kartat kaikista kaupungeista, kaikissa maissa ympäri maailman. Matkusta luottavaisin mielin - missä ikinä oletkin, Organic Maps auttaa sinua löytämään itsesi kartalta, ohjaamaan sinut lähimpään ravintolaan, hotelliin, pankkiin, huoltoasemalle jne. Internet-yhteyttä ei tarvita.\n\nTyöskentelemme jatkuvasti uusien ominaisuuksien parissa, ja haluammekin kuulla sinulta kuinka voimme parantaa MAPS.me -sovellusta entisestään. Mikäli sinulla on ongelmia sovelluksen kanssa, älä epäröi ottaa yhteyttä asiakaspalveluumme osoitteessa support\@organicmaps.app. Vastaamme jokaiseen yhteydenottoon!\n\nTykkäätkö Organic Maps -sovelluksesta ja haluat tukea meitä? Siihen on muutamia helppoja ja täysin ilmaisia tapoja:\n\n- lisää sovellusarviosi käyttämääsi sovelluskauppaan\n - tykkää Facebook-sivustamme osoitteessa http://www.facebook.com/OrganicMaps\n- kerro MAPS.me:stä äidillesi, ystävillesi ja kollegoillesi :)\n\nKiitos sovelluksen käytöstä. Arvostamme tukeasi todella paljon!\n\nP.S. Kaikki tiedot noudetaan OpenStreetMap-palvelusta, joka on Wikipedian kaltainen karttaprojekti, jossa kuka tahansa voi lisätä ja muokata karttoja. Mikäli havaitset kartoissa virheitä ja puutteita, voit korjata ne osoitteessa https://www.openstreetmap.org, ja muutokset näkyvät sovelluksessa seuraavan Organic Maps -päivityksen jälkeen.</string>
 	<!-- Alert text -->
 	<string name="email_error_body">Sähköpostisovellusta ei ole asetettu. Ole hyvä ja määritä sähköpostiasetukset tai ota meihin yhteyttä toista kautta osoitteessa %s</string>
 	<!-- Alert title -->
@@ -334,137 +231,56 @@
 	<string name="pref_calibration_title">Kompassin kalibrointi</string>
 	<!-- Search category -->
 	<string name="wifi">WiFi</string>
-	<!-- Update map suggestion -->
-	<string name="routing_map_outdated">Päivitä kartta luodaksesi reitin</string>
-	<!-- Update maps suggestion -->
-	<string name="routing_update_maps">Uusi Organic Maps -versio mahdollistaa reittien luonnin nykyisestä sijainnista määränpäähäsi.Päivitä kartat käyttääksesi tätä ominaisuutta.</string>
 	<!-- Update all button text -->
 	<string name="downloader_update_all_button">Päivitä kaikki</string>
 	<!-- Cancel all button text -->
 	<string name="downloader_cancel_all">Peruuta kaikki</string>
 	<!-- Downloaded maps category -->
 	<string name="downloader_downloaded_subtitle">Ladatut</string>
-	<!-- Downloaded maps category -->
-	<string name="downloader_available_maps">Saatavilla</string>
 	<!-- Country queued for download -->
 	<string name="downloader_queued">Jonossa</string>
 	<string name="downloader_near_me_subtitle">Lähelläni</string>
 	<string name="downloader_status_maps">Kartat</string>
 	<string name="downloader_download_all_button">Lataa kaikki</string>
 	<string name="downloader_downloading">Ladataan:</string>
-	<string name="downloader_search_results">Löytyi</string>
-	<!-- Disclaimer message -->
-	<string name="routing_disclaimer">Pidä mielessä seuraavat seikat luodessasi reittejä Organic Maps -sovelluksella:\n\n- Ehdotettuja reittejä tulee pitää vain suosituksina.\n- Teiden kunto, liikennesäännöt ja -merkit on aina otettava huomioon navigointiehdotuksista huolimatta.\n - Kartassa saattaa olla virheitä, tai se saattaa olla vanhentunut, eikä reittejä sen takia voida luoda parhaalla mahdollisella tavalla.\n\nPysy valppaana liikenteessä ja pidä huolta itsestäsi!</string>
-	<!-- Outdated maps category -->
-	<string name="downloader_outdated_maps">Vanhentunut</string>
-	<!-- Up to date maps category -->
-	<string name="downloader_uptodate_maps">Ajan tasalla</string>
 	<!-- Status of outdated country in the list -->
 	<string name="downloader_status_outdated">Päivitä</string>
 	<!-- Status of failed country in the list -->
 	<string name="downloader_status_failed">Epäonnistunut</string>
 	<!-- Displayed in a dialog that appears when a user tries to delete a map while the app is in the follow route mode -->
 	<string name="downloader_delete_map_while_routing_dialog">Pysäytä navigointi poistaaksesi kartan.</string>
-	<!-- Show when user try build route, but we don't know where he -->
-	<string name="routing_failed_unknown_my_position">Tämänhetkinen sijainti ei ole tiedossa. Määritä sijainti luodaksesi reitin.</string>
-	<!-- Show if use has not routing file, or InconsistentMWMandRoute -->
-	<string name="routing_failed_has_no_routing_file">Reitin luomiseksi on ladattava lisää dataa. Ladatataanko data nyt?</string>
-	<!-- StartPointNotFound -->
-	<string name="routing_failed_start_point_not_found">Reittiä ei voida laskea, koska lähtöpisteen lähistöllä ei ole teitä.</string>
-	<!-- EndPointNotFound -->
-	<string name="routing_failed_dst_point_not_found">Reittiä ei voida laskea, koska määränpään lähistöllä ei ole teitä.</string>
 	<!-- PointsInDifferentMWM -->
 	<string name="routing_failed_cross_mwm_building">Vain kokonaisuudessaan yhdelle kartalle mahtuvia reittejä voidaan luoda.</string>
-	<!-- RouteNotFound -->
-	<string name="routing_failed_route_not_found">Lähtöpisteen ja määränpään välillä ei löytynyt reittiä. Valitse toinen lähtöpiste tai määränpää.</string>
-	<!-- InternalError -->
-	<string name="routing_failed_internal_error">Sisäinen virhe. Kokeile asentaa kartta uudelleen. Mikäli ongelma jatkuu, ota yhteyttä asiakaspalveluun osoitteessa support\@organicmaps.app.</string>
-	<!-- Context menu item for downloader. -->
-	<string name="downloader_download_map_and_routing">Lataa kartta + reititys</string>
-	<!-- Context menu item for downloader. -->
-	<string name="downloader_download_routing">Lataa reititys</string>
-	<!-- Context menu item for downloader. -->
-	<string name="downloader_delete_routing">Poista reititys</string>
 	<!-- Context menu item for downloader. -->
 	<string name="downloader_download_map">Lataa kartta</string>
-	<string name="downloader_download_map_no_routing">Lataa kartta ilman reititystä</string>
-	<!-- Button for routing. -->
-	<string name="routing_go">Lähde!</string>
 	<!-- Item status in downloader. -->
 	<string name="downloader_retry">Yritä uudelleen</string>
-	<!-- Item in context menu. -->
-	<string name="downloader_map_and_routing">Kartta + reititys</string>
 	<!-- Item in context menu. -->
 	<string name="downloader_delete_map">Poista kartta</string>
 	<!-- Item in context menu. -->
 	<string name="downloader_update_map">Päivitä kartta</string>
-	<!-- Item in context menu. -->
-	<string name="downloader_update_map_and_routing">Päivitä kartta + reititys</string>
-	<!-- Item in context menu. -->
-	<string name="downloader_map_only">Vain kartta</string>
-	<!-- Toolbar title -->
-	<string name="toolbar_application_menu">Sovellusvalikko</string>
 	<!-- Preference text -->
 	<string name="pref_use_google_play">Käytä Google Play -palveluita sijaintisi selvittämiseksi</string>
 	<!-- Text for rating dialog -->
 	<string name="rating_just_rated">Olen juuri arvostellut sovelluksesi.</string>
-	<!-- Text for rating dialog -->
-	<string name="rating_user_since">Olen Organic Maps käyttäjä vuodesta %s.</string>
-	<!-- Text for rating dialog -->
-	<string name="rating_do_like_maps">Pidätkö Organic Maps sovelluksesta?</string>
-	<!-- Text for rating dialog -->
-	<string name="rating_tap_star">Napauta tähteä arvostellaksesi sovelluksemme.</string>
 	<!-- Text for rating dialog -->
 	<string name="rating_thanks">Kiitos!</string>
 	<!-- Text for rating dialog -->
 	<string name="rating_share_ideas">Jaathan ideasi ja kohtaamasi ongelmat, jotta voimme parantaa sovellusta sinua varten.</string>
 	<!-- Text for rating dialog -->
 	<string name="rating_send_feedback">Lähetä palautetta</string>
-	<!-- Text for g+ dialog -->
-	<string name="rating_google_plus">Napsauta g+ ja kerro ystävillesi sovelluksesta.</string>
 	<!-- Text for routing error dialog -->
 	<string name="routing_download_maps_along">Lataa karttoja matkalla</string>
-	<!-- Text for routing error dialog -->
-	<string name="routing_download_map">Hanki kartta</string>
-	<!-- Text for routing error dialog -->
-	<string name="routing_download_map_and_routing">Lataa päivitetty kartta ja reititysdata saadaksesi kaikki Organic Maps -ominaisuudet.</string>
-	<!-- Text for routing error dialog -->
-	<string name="routing_get_routing_data">Hanki reitityskartta</string>
-	<!-- Text for routing error dialog -->
-	<string name="routing_get_additional_data">Lisädata, jotka vaaditaan reittien luomiseen sijainnistasi.</string>
 	<!-- Text for routing error dialog -->
 	<string name="routing_requires_all_map">Reitin luominen vaatii karttojen lataamisen ja päivityksen oman sijaintisi ja kohteeen väliltä.</string>
 	<!-- Text for routing error dialog -->
 	<string name="routing_not_enough_space">Ei tarpeeksi tilaa</string>
-	<!-- Text for routing error dialog -->
-	<string name="routing_download_more_than_avail">Sinun täytyy ladata %1$s MB, mutta saatavilla on vain %2$s MB.</string>
-	<!-- Text for routing error dialog -->
-	<string name="routing_download_roaming">Olet lataamassa %s MB Mobiilidatan (roaming-lataus) avulla. Tämä voi johtaa lisämaksuihin, riippuen matkapuhelinliittymäsi palveluntarjoajasta.</string>
 	<!-- bookmark button text -->
 	<string name="bookmark">kirjanmerkki</string>
-	<!-- map is not downloaded -->
-	<string name="not_found_map">Nykyisen sijaintisi karttaa ei ole ladattu</string>
 	<!-- location service disabled -->
 	<string name="enable_location_services">Ota sijaintipalvelut käyttöön</string>
-	<!-- download map -->
-	<string name="download_map">Lataa nykyisen sijaintisi kartta</string>
-	<!-- download map on iPhone -->
-	<string name="download_map_iphone">Lataa tämän hetkisen sijaintisi kartta iPhoneesi</string>
-	<!-- clear pin -->
-	<string name="nearby">Lähellä</string>
-	<!-- clear pin -->
-	<string name="clear_pin">Tyhjennä kiinnitys</string>
-	<!-- location is undefined -->
-	<string name="undefined_location">Tämänhetkinen sijainti ei ole tiedossa.</string>
-	<!-- download country of your location -->
-	<string name="download_country">Lataa nykyisen sijainnin maa</string>
-	<!-- download failed -->
-	<string name="download_failed">Lataus epäonnistui</string>
-	<!-- get the map -->
-	<string name="get_the_map">Hanki kartta</string>
 	<string name="save">Tallenna</string>
 	<string name="edit_description_hint">Kuvauksesi (teksti tai html)</string>
-	<string name="new_group">uusi ryhmä</string>
 	<string name="create">luo</string>
 	<!-- red color -->
 	<string name="red">Punainen</string>
@@ -482,22 +298,6 @@
 	<string name="brown">Ruskea</string>
 	<!-- pink color -->
 	<string name="pink">Pinkki</string>
-	<!-- deep purple color -->
-	<string name="deep_purple">Tumman purppuranpunainen</string>
-	<!-- light blue color -->
-	<string name="light_blue">Vaaleansininen</string>
-	<!-- cyan color -->
-	<string name="cyan">Sinivihreä</string>
-	<!-- teal color -->
-	<string name="teal">Smaragdinvihreä</string>
-	<!-- lime color -->
-	<string name="lime">Limen värinen</string>
-	<!-- deep orange color -->
-	<string name="deep_orange">Tumman oranssi</string>
-	<!-- gray color -->
-	<string name="gray">Harmaa</string>
-	<!-- blue gray color -->
-	<string name="blue_gray">Harmaan sininen</string>
 	<!-- Wi-Fi available -->
 	<string name="WiFi_available">Kyllä</string>
 
@@ -513,10 +313,8 @@
 	<string name="dialog_routing_location_turn_wifi">Tarkista GPS-signaali. Wi-Fi-signaalin käyttöönotto parantaa sijainnin tarkkuutta.</string>
 	<string name="dialog_routing_location_turn_on">Ota sijaintipalvelut käyttöön</string>
 	<string name="dialog_routing_location_unknown_turn_on">Tämänhetkisiä GPS-koordinaatteja ei löydy. Ota sijaintipalvelut käyttöön reitin laskemista varten.</string>
-	<string name="dialog_routing_location_unknown">Tämänhetkisiä GPS-koordinaatteja ei löydy.</string>
 	<string name="dialog_routing_download_files">Lataa tarvittavat tiedostot</string>
 	<string name="dialog_routing_download_and_update_all">Lataa ja päivitä kaikki suunnitellun reitin kartta- ja reititystiedot, jotta reitin voi laskea.</string>
-	<string name="dialog_routing_routes_size">Reititystiedostot</string>
 	<string name="dialog_routing_unable_locate_route">Reitin paikannus ei onnistu</string>
 	<string name="dialog_routing_cant_build_route">Reitin luonti ei onnistu.</string>
 	<string name="dialog_routing_change_start_or_end">Muuta aloituskohtaa tai määränpäätä.</string>
@@ -531,33 +329,23 @@
 	<string name="dialog_routing_system_error">Järjestelmävirhe</string>
 	<string name="dialog_routing_application_error">Reittiä ei voi luoda sovellusvirheen vuoksi.</string>
 	<string name="dialog_routing_try_again">Yritä uudelleen</string>
-	<string name="dialog_routing_send_error">Ilmoita ongelmasta</string>
-	<string name="dialog_routing_if_get_cross_route">Haluatko luoda suoremman reitin, joka ylettyy usealle kartalle?</string>
-	<string name="dialog_routing_cross_route_is_optimal">Tarjolla on suorempi reitti, joka ylittää tämän kartan reunan.</string>
 	<string name="not_now">Ei nyt</string>
-	<string name="dialog_routing_build_route">Luo</string>
 	<string name="dialog_routing_download_and_build_cross_route">Haluatko ladata kartan ja luoda paremman reitin, joka ylettyy usealle kartalle?</string>
 	<string name="dialog_routing_download_cross_route">Lataa kartta ja luo parempi reitti, joka ylittää tämän kartan reunan.</string>
-	<string name="dialog_routing_cross_route_always">Ylitä aina tämä raja</string>
 
 	<!-- SECTION: Strings for downloading map from search -->
 	<string name="search_without_internet_advertisement">Lataa kartta jotta voit käyttää hakua ja luoda reittejä. Tämän jälkeen et tarvitse enää Internet-yhteyttä.</string>
 	<string name="search_select_map">Valitse kartta</string>
-	<string name="search_select_other_map">Valitse toinen kartta</string>
 	<!-- «Show» context menu -->
 	<string name="show">Näytä</string>
 	<!-- «Hide» context menu -->
 	<string name="hide">Piilota</string>
 	<!-- «Rename» context menu -->
 	<string name="rename">Nimeä uudelleen</string>
-	<!-- Bottom sheet: expand button (should be short) -->
-	<string name="bottom_sheet_more">Lisää…</string>
 	<!-- Failed planning route message in navigation view -->
 	<string name="routing_planning_error">Reitin suunnittelu epäonnistui</string>
 	<!-- Arrive routing message in navigation view -->
 	<string name="routing_arrive">Saavut: %s</string>
-	<!-- Text for routing::RouterResultCode::FileTooOld dialog. -->
-	<string name="dialog_routing_download_and_update_maps">Lataa ja päivitä kaikki kartat reitin varrella luodaksesi reitin.</string>
 	<string name="rate_alert_title">Pidätkö sovelluksesta?</string>
 	<string name="rate_alert_default_message">Kiitos kun käytät Organic Maps:tä. Voisitko myös arvostella sovelluksen? Palautteesi avulla tulemme vielä paremmiksi.</string>
 	<string name="rate_alert_five_star_message">Hurraa! Mekin rakastamme sinua!</string>
@@ -565,24 +353,14 @@
 	<string name="rate_alert_less_than_four_star_message">Kertoisitko missä voisimme parantaa?</string>
 	<string name="categories">Luokat</string>
 	<string name="history">Historia</string>
-	<string name="next_turn_then">Sitten</string>
 	<string name="closed">Suljettu</string>
-	<string name="back_to">Takaisin sovellukseen %s</string>
 	<string name="search_not_found">Pahoittelut, hakutuloksia ei ole.</string>
 	<string name="search_not_found_query">Yritä jotain toista hakusanaa.</string>
-	<string name="search_not_found_map">Lataa kartat sille alueelle jolta haet.</string>
-	<string name="search_not_found_location">Lataa nykyisen sijaintisi kartta.</string>
 	<string name="search_history_title">Hakuhistoria</string>
 	<string name="search_history_text">Siirry nopeasti aikaisempaan hakuun.</string>
 	<string name="clear_search">Poista hakuhistoria</string>
-	<!-- Title for settings to enable/disable showcase menu button -->
-	<string name="showcase_settings_title">Näytä tarjoukset</string>
-	<string name="p2p_route_planning">Reittisuunnittelu</string>
 	<string name="p2p_your_location">Sijaintisi</string>
-	<string name="p2p_from">Lähtöpiste</string>
-	<string name="p2p_to">Päämäärä</string>
 	<string name="p2p_start">Aloita</string>
-	<string name="p2p_planning">Lasketaan…</string>
 	<string name="p2p_from_here">Lähtöpaikka</string>
 	<string name="p2p_to_here">Reitin loppupiste</string>
 	<string name="p2p_only_from_current">Navigointi onnistuu vain nykyisestä sijainnistasi.</string>
@@ -602,11 +380,8 @@
 	<string name="editor_hours_closed">Suljettuna tunnit</string>
 	<string name="editor_example_values">Esimerkkiarvot</string>
 	<string name="editor_correct_mistake">Korjaa virhe</string>
-	<string name="editor_correct_mistake_message">Teit muokkausvirheen. Korjaa se tai vaihda yksinkertaiseen tilaan.</string>
 	<string name="editor_add_select_location">Sijainti</string>
 	<string name="editor_done_dialog_1">Olet muuttanut maailmankarttaa. Älä piilota tätä! Kerro ystävillesi ja muokatkaa sitä yhdessä.</string>
-	<string name="editor_done_dialog_2">Tämä on toinen kerta, kun paransit karttaa. Nyt olet %d. sijalla kartan muokkaajien listalla. Kerro siitä ystävillesi.</string>
-	<string name="editor_done_dialog_3">Olet parantanut karttaa, kerro siitä ystävillesi ja muokatkaa karttaa yhdessä.</string>
 	<string name="share_with_friends">Jaa kavereille</string>
 	<string name="editor_report_problem_desription_1">Kuvaile ongelmaa yksityiskohtaisesti, jotta OpenStreetMap-yhteisö voi korjata vian.</string>
 	<string name="editor_report_problem_desription_2">Tai tee se itse osoitteessa https://www.openstreetmap.org/</string>
@@ -615,14 +390,7 @@
 	<string name="editor_report_problem_no_place_title">Paikkaa ei ole olemassa</string>
 	<string name="editor_report_problem_under_construction_title">Suljettu huoltoa varten</string>
 	<string name="editor_report_problem_duplicate_place_title">Paikan kaksoiskappale</string>
-	<string name="first_launch_congrats_title">Organic Maps on valmiina käyttöön</string>
-	<string name="first_launch_congrats_text">Etsi ja navigoi ympäri maailman ilman verkkoyhteyttä, ilmaiseksi.</string>
-	<string name="migrate_title">Tärkeää!</string>
-	<!-- Android uses image instead of text. -->
-	<string name="download_all">Lataa kaikki</string>
-	<string name="delete_all">Poista kaikki</string>
 	<string name="autodownload">Lataa automaattisesti</string>
-	<string name="disable_autodownload">Poista käytöstä automaattinen lataus</string>
 	<!-- Place Page opening hours text -->
 	<string name="closed_now">Suljettu nyt</string>
 	<!-- Place Page opening hours text -->
@@ -631,8 +399,6 @@
 	<string name="day_off_today">Suljettu tänään</string>
 	<string name="day_off">Suljettu</string>
 	<string name="today">Tänään</string>
-	<string name="sunrise_to_sunset">Auringonnoususta auringonlaskuun</string>
-	<string name="sunset_to_sunrise">Auringonnoususta auringonlaskuun</string>
 	<string name="add_opening_hours">Lisää aukioloajat</string>
 	<string name="edit_opening_hours">Muokkaa aukioloaikoja</string>
 	<string name="no_osm_account">Eikö sinulla ole OpenStreetMap tiliä?</string>
@@ -642,29 +408,13 @@
 	<string name="login">Kirjaudu sisään</string>
 	<string name="password">Salasana</string>
 	<string name="forgot_password">Unohtuiko salasana?</string>
-	<!-- Forgot Password dialog title -->
-	<string name="restore_password">Palauta salasana</string>
-	<string name="enter_email_address_to_reset_password">Syötä rekisteröitymisessä käyttämäsi sähköpostiosoite, niin lähetämme sinulle linkin salasanasi vaihtamista varten.</string>
-	<string name="reset_password">Aseta salasana uudelleen</string>
-	<string name="username">Käyttäjänimi</string>
 	<string name="osm_account">OSM-tili</string>
 	<string name="logout">Kirjaudu ulos</string>
-	<string name="login_and_edit_map_motivation_message">Kirjaudu sisään ja muokkaa kartan kohteiden tietoja, ja me asetamme kohteet miljoonien muiden käyttäjien saataville. Tehdään maailmasta yhdessä parempi paikka.</string>
 	<!-- Information text: "Last upload 11.01.2016" -->
 	<string name="last_upload">Viimeisin lisäys</string>
-	<!-- Motivates user to login/register, title above login buttons. -->
-	<string name="you_have_edited_your_first_object">Olet muokannut ensimmäistä kohdettasi!</string>
 	<string name="thank_you">Kiitos</string>
-	<string name="login_with_google">Kirjaudu sisään Google-tunnuksillasi</string>
-	<string name="login_with_openstreetmap">Kirjaudu sisään osoitteessa www.openstreetmap.org</string>
 	<string name="edit_place">Muokkaa kohdetta</string>
 	<string name="place_name">Paikan nimi</string>
-	<!-- title above languages list cells in the editor, below editable name text field. -->
-	<string name="other_languages">Muut Kielet</string>
-	<!-- small button to open list with names in different languages -->
-	<string name="show_more">Näytä enemmän</string>
-	<!-- small button to close list with names in different languages -->
-	<string name="show_less">Näytä vähemmän</string>
 	<string name="add_language">Lisää kieli</string>
 	<string name="street">Katu</string>
 	<!-- Editable House Number text field (in address block). -->
@@ -681,25 +431,16 @@
 	<string name="email_or_username">Sähköposti tai käyttäjätunnus</string>
 	<string name="phone">Puhelinnumero</string>
 	<string name="please_note">Huomaathan, että</string>
-	<string name="common_no_wifi_dialog">Ei Wi-Fi -yhteyttä. Haluatko jatkaa mobiilidatan avulla?</string>
 	<string name="downloader_delete_map_dialog">Kaikki karttaan tehdyt muutokset poistetaan kartan mukana.</string>
 	<string name="downloader_update_maps">Päivitä kartat</string>
 	<string name="downloader_mwm_migration_dialog">Sinun täytyy päivittää kaikki kartat ja suunnitella reitti uudelleen luodaksesi uuden reitin.</string>
 	<string name="downloader_search_field_hint">Etsi kartta</string>
-	<string name="migration_update_all_button">Päivitä kaikki kartat</string>
-	<string name="migration_delete_all_download_current_button">Lataa nykyinen kartta ja poista kaikki vanhat kartat</string>
 	<string name="migration_download_error_dialog">Latausvirhe</string>
 	<string name="common_check_internet_connection_dialog">Tarkista asetuksesi ja varmista, että laitteesi on yhteydessä Internetiin.</string>
 	<string name="downloader_no_space_title">Ei tarpeeksi tilaa</string>
 	<string name="downloader_no_space_message">Poista tarpeeton data</string>
-	<string name="editor_general_auth_error_dialog">Yleinen kirjautumisvirhe.</string>
 	<string name="editor_login_error_dialog">Kirjautumisvirhe.</string>
-	<string name="editor_login_failed_dialog">Kirjautuminen epäonnistui</string>
-	<string name="editor_username_error_dialog">Käyttäjätunnus on virheellinen</string>
-	<string name="editor_place_edited_dialog">Olet muokannut kohdetta!</string>
-	<string name="editor_login_with_osm">Kirjaudu sisään OpenStreetMapissa</string>
 	<string name="editor_profile_changes">Vahvistetut karttamuutokset</string>
-	<string name="editor_profile_unsent_changes">Ei lähetetty:</string>
 	<string name="editor_focus_map_on_location">Vedä karttaa valitaksesi kohteelle oikean sijainnin.</string>
 	<string name="editor_add_select_category">Valitse kategoria</string>
 	<string name="editor_add_select_category_popular_subtitle">Suositut</string>
@@ -710,19 +451,14 @@
 	<string name="editor_edit_place_category_title">Kategoria</string>
 	<string name="detailed_problem_description">Ongelman tarkka kuvaus</string>
 	<string name="editor_report_problem_other_title">Eri ongelma</string>
-	<string name="placepage_report_problem_button">Ilmoita ongelmasta</string>
 	<string name="placepage_add_business_button">Lisää organisaatio</string>
 	<string name="whatsnew_editor_message_1">Lisää karttaan uusia paikkoja ja muokkaa sovelluksessa olevia karttoja suoraan sovelluksessa.</string>
-	<string name="whatsnew_editor_message_2">* Organic Maps käyttää OpenStreetMap -yhteisön dataa.</string>
 	<string name="dialog_incorrect_feature_position">Vaihda sijaintia</string>
 	<string name="message_invalid_feature_position">Kohdetta ei voida asettaa tänne</string>
 	<string name="login_to_make_edits_visible">Kirjaudu sisään jotta muut käyttäjät voivat nähdä tekemäsi muokkaukset.</string>
-	<string name="no_migration_during_navigation">Päivittäminen ei ole mahdollista navigoinnin aikana.</string>
 	<!-- Error dialog no space -->
 	<string name="migration_no_space_message">Tarvitset lisää tilaa ladataksesi. Poista tarpeeton data.</string>
 	<string name="editor_sharing_title">Paransin Organic Maps-karttoja</string>
-	<string name="editor_comment_will_be_sent">Lähetämme kommenttisi kartanpiirtäjille.</string>
-	<string name="editor_unsupported_category_message">Olet lisännyt sijainnin katergoriaan jota emme vielä tue. Se tulee näkyviin kartalle hieman myöhemmin.</string>
 	<!-- Downloaded 10 **of** 20 <- it is that "of" -->
 	<string name="downloader_of">%1$d/%2$d</string>
 	<string name="download_over_mobile_header">Lataa käyttämällä puhelinverkkoyhteyttä?</string>
@@ -740,15 +476,8 @@
 	<string name="editor_detailed_description">Ehdottamasi muutokset lähetetään OpenStreetMap-yhteisöön. Kuvaa tiedot, joita ei voi muokata Organic Maps:ssä.</string>
 	<string name="editor_more_about_osm">Lisätietoja OpenStreetMap:ista</string>
 	<string name="editor_operator">Operaattori</string>
-	<string name="editor_tag_description">Syötä tiloista vastuussa oleva yhtiö, organisaatio tai henkilö</string>
-	<string name="editor_no_local_edits_title">Sinulla ei ole paikallisia muokkauksia</string>
-	<string name="editor_no_local_edits_description">Tämä näyttää ehdottamiesi muutosten lukumäärän tällä hetkellä vain sinun laitteessasi saatavissa olevassa kartassa.</string>
-	<string name="editor_send_to_osm">Lähetä OSM:ään</string>
-	<string name="editor_remove">Poista</string>
-	<string name="downloader_my_maps_title">Omat kartat</string>
 	<string name="downloader_no_downloaded_maps_title">Et ole ladannut yhtään karttaa</string>
 	<string name="downloader_no_downloaded_maps_message">Lataa kartattoja löytääksesi paikkoja ja navigoidaksesi offline-tilassa.</string>
-	<string name="downloader_find_place_hint">Etsi kaupunki tai maa</string>
 	<!-- Error title that appears after certain time without location. -->
 	<string name="current_location_unknown_title">Jatketaanko nykyisen sijaintisi havaitsemista?</string>
 	<!-- Error that appears after certain time without location. -->
@@ -763,27 +492,10 @@
 	<string name="location_services_disabled_2">2. Tik op locatie</string>
 	<!-- iOS Dialog for the case when the location permission is not granted -->
 	<string name="location_services_disabled_3">3. Valitse sovellusta käytettäessä</string>
-	<string name="placepage_parking_surface">Pinta</string>
-	<string name="placepage_parking_multistorey">Monikerroksinen</string>
-	<string name="placepage_parking_underground">Maan alla</string>
-	<string name="placepage_parking_rooftop">Katolla</string>
-	<string name="placepage_parking_sheds">Suojat</string>
-	<string name="placepage_parking_carports">Autokatokset</string>
-	<string name="placepage_parking_boxes">Autotalliruudut</string>
-	<string name="placepage_parking_pay">Maksullinen</string>
-	<string name="placepage_parking_free">Ilmainen</string>
-	<string name="placepage_parking_interval">Aikamaksu</string>
-	<string name="placepage_entrance_number">Nro.</string>
-	<string name="placepage_entrance_type">Sisäänkäynti</string>
-	<string name="placepage_flat">sov.</string>
-	<string name="placepage_open_24_7">24 / 7</string>
 	<string name="meter">m</string>
 	<string name="kilometer">km</string>
-	<string name="kilometers_per_hour">km/h</string>
 	<string name="mile">mi</string>
 	<string name="foot">ft</string>
-	<string name="miles_per_hour">mph</string>
-	<string name="day">p</string>
 	<string name="hour">t</string>
 	<string name="minute">min</string>
 	<string name="placepage_place_description">Kuvaus</string>
@@ -793,46 +505,30 @@
 	<string name="placepage_call_button">Soita</string>
 	<string name="placepage_edit_bookmark_button">Muokkaa kirjanmerkkiä</string>
 	<string name="placepage_bookmark_name_hint">Kirjanmerkin nimi</string>
-	<string name="placepage_personal_notes_hint">Henkilökohtaiset merkinnät</string>
-	<string name="placepage_delete_bookmark_button">Poista kirjanmerkki</string>
 	<string name="editor_edits_sent_message">Ehdottamasi muutokset on lähetetty</string>
 	<string name="editor_comment_hint">Kommentti…</string>
 	<string name="editor_reset_edits_message">Nollataanko kaikki paikalliset muutokset?</string>
 	<string name="editor_reset_edits_button">Nollaa</string>
 	<string name="editor_remove_place_message">Poistetaanko lisätty paikka?</string>
 	<string name="editor_remove_place_button">Poista</string>
-	<string name="editor_status_sending">Lähetetään…</string>
 	<string name="editor_place_doesnt_exist">Paikkaa ei ole olemassa</string>
 	<string name="text_more_button">…Näytä</string>
 	<!-- Phone number error message -->
 	<string name="error_enter_correct_phone">Syötä kelvollinen puhelinnumero</string>
 	<string name="error_enter_correct_web">Syötä kelvollinen verkko-osoite</string>
 	<string name="error_enter_correct_email">Syötä kelvollinen sähköpostiosoite</string>
-	<string name="error_enter_correct">Syötä kelvollinen arvo</string>
 	<string name="refresh">Päivitä</string>
-	<string name="last_update">Viimeisin päivitys: %s</string>
 	<string name="placepage_add_place_button">Lisää paikka kartalle</string>
 	<!-- Displayed when saving some edits to the map to warn against publishing personal data -->
 	<string name="editor_share_to_all_dialog_title">Haluatko lähettää sen kaikille käyttäjille?</string>
 	<!-- iOS Dialog before publishing the modifications to the public map. -->
 	<string name="editor_share_to_all_dialog_message_1">Varmistat, ettet syöttänyt henkilökohtaisia tietojasi.</string>
 	<string name="editor_share_to_all_dialog_message_2">Tarkistamme muutokset. Otamme sinuun yhteyttä sähköpostitse, jos meillä on kysyttävää.</string>
-	<string name="navigation_overview_button">yleiskatsaus</string>
-	<string name="navigation_stop_button">lopeta</string>
-	<!-- Text on an empty bookmark page -->
-	<string name="bookmarks_empty_title">Tallenna Kirjanmerkit</string>
-	<string name="bookmarks_empty_message_1">Napsauta ★ tallentaaksesi suosikkipaikkoja.</string>
-	<string name="bookmarks_empty_message_2">Tuo kirjanmerkit sähköpostista ja webistä.</string>
-	<string name="bookmarks_empty_message_3">kirjaudu ulos: %s</string>
-	<!-- Name of the group for booked hotels -->
-	<string name="bookmarks_group_name">Varatut hotellit</string>
-	<string name="place_page_button_read_descriprion">Lue</string>
 	<!-- iOS dialog for the case when recent track recording is on and the app comes back from background -->
 	<string name="recent_track_background_dialog_title">Poistetaanko viimeisen matkareitin tallennus?</string>
 	<string name="off_recent_track_background_button">Poista</string>
 	<!-- For sharing via SMS and so on -->
 	<string name="sharing_call_action_look">Tarkastele</string>
-	<string name="continue_recent_track_background_button">Jatka</string>
 	<string name="recent_track_background_dialog_message">MAPS.SE käyttää taustalla geosijaintia sinun viimeisen matkareitin tallentamiseksi.</string>
 	<!-- Rate on Google Play (Android only) -->
 	<string name="rate_gp">Arvioi Google Playssa</string>
@@ -842,21 +538,11 @@
 	<string name="tell_friends_text">Hei, asenna Organic Maps!</string>
 	<!-- About short text (below logo) -->
 	<string name="about_description">Organic Maps on ehdoton offline-sovellus matkoja varten. Organic Maps perustuu OpenStreetMap-dataan ja sallii sen muokkauksen.</string>
-	<!-- Text in menu -->
-	<string name="blog">Blogi</string>
 	<string name="general_settings">Yleiset asetukset</string>
-	<string name="date">Päivämäärä %d</string>
-	<!-- "Report a bug" -> "Generaal Feedback" -> "Something is not working" -->
-	<string name="something_is_not_working">Jokin ei toimi</string>
 	<!-- For the first routing -->
 	<string name="accept">Hyväksy</string>
 	<!-- For the first routing -->
 	<string name="decline">Hylkää</string>
-	<string name="install_app">Asenna</string>
-	<string name="search_no_results_title">Ei hakutuloksia</string>
-	<string name="search_no_results_message">Kokeile yleisempää hakusanaa, loitonna tai palauta suodatin.</string>
-	<string name="search_no_results_expand_area_button">Loitonna</string>
-	<string name="search_no_results_reset_button">Palauta suodatin</string>
 	<!-- noun -->
 	<string name="search_in_table">Luettelo</string>
 	<string name="mobile_data_dialog">Näytetäänkö lisätiedot mobiili-internetillä?</string>
@@ -868,18 +554,13 @@
 	<string name="mobile_data_option_never">Älä käytä koskaan</string>
 	<string name="mobile_data_option_ask">Kysy aina</string>
 	<string name="traffic_update_maps_text">Liikennetietojen näyttämiseksi kartat on päivitettävä.</string>
-	<string name="traffic_outdated">Liikennetiedot ovat vanhentuneet.</string>
 	<string name="big_font">Suurenna fonttikokoa kartalla</string>
 	<string name="traffic_update_app">Päivitä Organic Maps</string>
 	<!-- "traffic" as in road congestion -->
 	<string name="traffic_update_app_message">Liikennetietojen näyttämiseksi sovellus on päivitettävä.</string>
 	<!-- "traffic" as in "road congestion" -->
 	<string name="traffic_data_unavailable">Liikennetietoja ei ole saatavilla</string>
-	<!-- Simplified colour scheme for traffic information, fewer colours are used to display traffic jams on the map. The string should be kept as short as possible -->
-	<string name="pref_traffic_simplified_colors_title">Simppelit liikennevärit</string>
 	<string name="enable_logging">Ota loki käyttöön</string>
-	<string name="offline_place_page_more_information">Yhdistä internetiin saadaksesi lisätietoa paikasta.</string>
-	<string name="failed_load_information">Tietojen lataaminen epäonnistui.</string>
 	<!-- Settings: "Send general feedback" button -->
 	<string name="feedback_general">Yleinen palaute</string>
 	<string name="on">Käytössä</string>
@@ -893,57 +574,26 @@
 	<string name="routing_add_start_point">Lisää alkupiste reitin suunnittelua varten</string>
 	<string name="routing_add_finish_point">Lisää määränpää reitin suunnittelua varten</string>
 	<string name="button_exit">Poistu</string>
-	<string name="settings_device_memory">Laitteen muisti</string>
-	<string name="settings_card_memory">Muistkortti</string>
-	<string name="settings_storage_available">%s käytettävissä</string>
-	<string name="toast_location_permission_denied">Sovelluksen sijainnin käyttöoikeus evättiin</string>
-	<string name="button_use">Käytä</string>
 	<string name="planning_route_manage_route">Hallitse reittiä</string>
 	<string name="button_plan">Suunnittele</string>
-	<string name="button_add">Lisää</string>
 	<string name="placepage_remove_stop">Poista</string>
 	<string name="planning_route_remove_title">Vedä tähän poistaaksesi</string>
-	<string name="dialog_change_start_point_message">Haluatko korvata alkupisteen nykyisellä sijainnilla?</string>
-	<string name="button_replace">Korvaa</string>
 	<string name="placepage_add_stop">Lisää pysähdys</string>
-	<string name="add_my_position">Lisää oma sijainti</string>
-	<string name="choose_start_point">Valitse aloituspiste</string>
-	<string name="choose_destination">Valitse kohde</string>
 	<string name="preloader_viator_button">Lisätietoja</string>
-	<string name="start_from_my_position">Aloita kohdasta</string>
-	<string name="profile_authorization_title">Kirjaudu sisään käyttämällä palvelua</string>
-	<string name="profile_authorization_message">Helppo sisäänkirjautuminen ilman käyttäjätunnusta ja salasanaa parissa sekunnissa</string>
 	<string name="profile_authorization_error">Tapahtui virhe. Yritä kirjautua sisään uudelleen.</string>
-	<string name="service">Palvelu</string>
-	<string name="atmosphere">Ilmapiiri</string>
-	<string name="value_for_money">Vastinetta rahoille</string>
-	<string name="experience">Kokemus</string>
-	<string name="assortment">Valikoima</string>
-	<string name="expertise">Asiantuntemus</string>
-	<string name="equipment">Laitteet</string>
-	<string name="quality">Laatu</string>
 	<string name="dialog_error_storage_title">Ongelma tallennustilan käyttämisessä</string>
 	<string name="dialog_error_storage_message">Ulkoinen tallennustila ei ole käytettävissä, SD-kortti on luultavasti poistettu tai vahingoittunut tai tiedostojärjestelmä on vain luku -tilassa. Tarkista ja ota yhteyttä osoitteeseen support\@organicmaps.app</string>
 	<string name="setting_emulate_bad_storage">Jäljittele virheellistä tallennustilaa</string>
-	<string name="directions_finish">Kohde</string>
-	<string name="directions_on_foot">Kävele %s</string>
 	<string name="core_entrance">Sisäänkäynti</string>
-	<string name="coffee">Kahvi</string>
-	<string name="cleanliness">Puhtaus</string>
-	<string name="crowdedness">Ahtaus</string>
 	<string name="error_enter_correct_name">Anna oikea nimi</string>
 	<string name="bookmarks_groups">Listat</string>
 	<string name="bookmarks_groups_hide_all">Piilota kaikki</string>
 	<string name="bookmarks_groups_show_all">Näytä kaikki</string>
-	<plurals name="bookmarks_places">
-	  <item quantity="other">%d kirjanmerkkiä</item>
-	</plurals>
 	<string name="bookmarks_create_new_group">Luo uusi luettelo</string>
 	<string name="downloader_hide_screen">Piilota näyttö</string>
 	<string name="downloader_percent">%1$s (%2$s / %3$s)</string>
-	<string name="downloader_process">Ladataan %s...</string>
-	<string name="downloader_applying">%s otetaan käyttöön...</string>
-	<string name="dialog_message_transit_not_found_connection">Suunnittele reitti yhdellä läpikulkuverkolla</string>
+	<string name="downloader_process">Ladataan %s…</string>
+	<string name="downloader_applying">%s otetaan käyttöön…</string>
 	<string name="bookmarks_error_message_share_general">Ei voitu jakaa sovellusvirheen vuoksi</string>
 	<string name="bookmarks_error_title_share_empty">Jakamisvirhe</string>
 	<string name="bookmarks_error_message_share_empty">Tyhjää listaa ei voi jakaa</string>
@@ -952,12 +602,7 @@
 	<string name="bookmarks_new_list_hint">Uusi lista</string>
 	<string name="bookmarks_error_title_list_name_already_taken">Tämä nimi on jo otettu</string>
 	<string name="bookmarks_error_message_list_name_already_taken">Valitse toinen nimi</string>
-	<string name="bookmarks_error_title_list_name_too_long">Tämä nimi on liian pitkä</string>
-	<string name="bookmarks_error_message_list_name_too_long">Valitse toinen nimi</string>
-	<string name="please_wait">Odota...</string>
-	<string name="phone_number">Puhelinnumero</string>
-	<string name="notification_unsent_reviews_title">Sinulla on useita epävirallisia arvosteluja</string>
-	<string name="notification_unsent_reviews_message">Kirjaudu sisään jaa arviot muiden matkustajien kanssa</string>
+	<string name="please_wait">Odota…</string>
 	<string name="profile">OpenStreetMap-profiili</string>
 	<string name="place_page_search_similar_hotel">Etsi samanlaisia ​​hotelleja</string>
 	<string name="bookmarks_detect_title">Uusia tiedostoja havaittiin</string>
@@ -968,31 +613,10 @@
 	<string name="button_convert">Muuntaa</string>
 	<string name="bookmarks_convert_error_title">Virhe</string>
 	<string name="bookmarks_convert_error_message">Joitakin tiedostoja ei muutettu.</string>
-	<string name="converting">Muuntaa...</string>
-	<string name="wn_reinvented_bookmarks_title">Uusimme kirjanmerkit!</string>
-	<string name="wn_reinvented_bookmarks_message">Voit varmuuskopioida kirjanmerkkejä, luoda luetteloita... On hämmästyttävää...</string>
-	<string name="bookmarks_restore">Palauta kirjanmerkit</string>
-	<string name="bookmarks_restore_process">Palautetaan...</string>
 	<string name="bookmarks_restore_title">Palauta tämä versio?</string>
-	<string name="bookmarks_restore_message">Kirjanmerkit palaavat %1$s (%2$s): sta</string>
-	<string name="bookmarks_restore_empty_title">Sinulla ei ole varmuuskopiota</string>
-	<string name="bookmarks_restore_empty_message">Palvelin ei löytänyt aiemmin tehtyjä varmuuskopioita</string>
 	<string name="common_check_internet_connection_dialog_title">Ei Internet-yhteyttä</string>
-	<string name="error_server_title">Palvelinvirhe</string>
-	<string name="error_server_message">Palvelimessa oli virhe, yritä myöhemmin uudelleen</string>
 	<string name="error_system_message">Tuntematon virhe tapahtui</string>
 	<string name="restore">Palauttaa</string>
-	<string name="bookmarks_page_downloaded">Ladattu</string>
-	<string name="bookmarks_page_my">Minun</string>
-	<string name="routes_and_bookmarks">Reitit ja kirjanmerkit</string>
-	<string name="bookmarks_webview_success_toast">Kirjanmerkit ladattu onnistuneesti</string>
-	<string name="cached_bookmarks_placeholder_title">Lataa uudet paikat</string>
-	<string name="cached_bookmarks_placeholder_subtitle">Paina nappulaa ladataksesi tuhansia kiinnostavia paikkoja ja reittejä joita Organic Maps käyttäjät ovat luoneet. Tarvitset internet yhteyden.</string>
-	<string name="downloader_download_routers">Lataa kirjanmerkit</string>
-	<string name="bookmarks_groups_cached">Ladatut lista</string>
-	<plurals name="bookmarks_objects">
-	  <item quantity="other">%s kohde</item>
-	</plurals>
 	<plurals name="objects">
 	  <item quantity="other">%d paikka</item>
 	</plurals>
@@ -1005,62 +629,32 @@
 	<string name="subtittle_opt_out">Seuranta-asetukset</string>
 	<string name="crash_reports">Kaatumisraportti</string>
 	<string name="crash_reports_description">Me saatamme käyttää tietojasi parantaaksemme Organic Maps kokemusta. Muutokset alkavat vaikuttamaan kun käynnistät sovelluksen uudestaan.</string>
-	<string name="opt_out_help_ios_1">Mobiililaitteesi saattaa tarjota ”Rajoittettu Mainos Seuranta” tai ”Poistu internet-perusteisesta mainnonnasta” asetuksia.</string>
-	<string name="opt_out_help_ios_2">iOS 9 tai Korkeampi</string>
-	<string name="opt_out_help_ios_3">Mene Asetuksiisi → Yksityisyys → Mainonta → Salli ”Rajoita Mainos Seurantaa” asetus</string>
-	<string name="opt_out_help_android">Mobiililaitteesi saattaa tarjota ”Rajoittettu Mainos Seuranta” tai ”Poistu internet-perusteisesta mainnonnasta” asetuksia.\n\nAndroidille ja Google Play Palvelut versio 4.0 tai myöhemmin:\nAsetukset → Google → Mainokset → Poistu Mainosten Yksilöinti\ntai\nAsetukset → Google → Google Tili → Henkilökohtaiset tiedot ja yksityisyys → Mainos Asetukset → Mainosten Yksilöinti</string>
 	<string name="privacy_policy">Yksityisyyskäytäntö</string>
 	<string name="terms_of_use">Käyttöehdot</string>
-	<string name="backup_notification_failed">Kirjanmerkkiesi varmuuskopionti on keskeytetty. Kirjaudu sisään ja laita se takaisin päälle.</string>
 	<string name="button_layer_traffic">Liikenne</string>
 	<string name="button_layer_subway">Metro</string>
 	<string name="layers_title">Kartan tasot</string>
-	<string name="layers_message">Käytä kartan tasoja näyttääksesi liikenteen, metrokartan ja muita hyödyllisiä tietoja</string>
-	<string name="button_layer_got_it">Ymmärsin</string>
 	<string name="subway_data_unavailable">Metrokartta ei ole saatavilla</string>
 	<string name="bookmarks_empty_list_title">Lista on tyhjä</string>
 	<string name="bookmarks_empty_list_message">Lisätäksesi kirjanmerkin, paina kartasta ja sitten paina tähden kuvaa</string>
 	<string name="category_desc_more">…lisää</string>
 	<string name="title_error_downloading_bookmarks">Tapahtui virhe</string>
-	<string name="subtitle_error_downloading_bookmarks">Kirjanmerkkejä ei ole ladattu</string>
-	<string name="error_already_downloaded">Tämä lista on jo ladattu</string>
-	<string name="why_support">Miksi tukea Organic Maps?</string>
-	<string name="why_support_item2">Sinä autat meitä parantamaan Organic Maps:tä</string>
-	<string name="why_support_item3">Auta meitä parantamaan avoimia karttoja OpenStreetMap.org</string>
-	<string name="channels_map_update">Kartan päivitykset</string>
-	<string name="server_unavailable_title">Serveri ei ole saatavilla</string>
-	<string name="sharing_options">Käyttöasetukset</string>
 	<string name="export_file">Viedä tiedosto</string>
 	<string name="list_settings">Listan asetukset</string>
 	<string name="delete_list">Poista lista</string>
-	<string name="hide_from_map">Piilottaa kartalta</string>
 	<string name="public_access">Julkinen pääsy</string>
 	<string name="limited_access">Yksityinen pääsy</string>
 	<string name="bookmark_category_name">Kategoria</string>
 	<string name="bookmark_category_description_hint">Lisää kuvaus (teksti tai html)</string>
 	<string name="not_shared">Henkilökohtainen</string>
-	<string name="direct_link_progress_text">Lataamme tiedostoanne…</string>
-	<string name="direct_link_success">Linkki on luotu</string>
-	<string name="send_a_link_btn">Lähetä linkki</string>
-	<string name="upload_error_toast">Tiedoston lataamisen aikana tapahtui virhe</string>
 	<string name="tags_loading_error_subtitle">Tunnisteiden lataamisen aikana tapahtui virhe, yritä uudelleen</string>
-	<string name="unable_upload_errorr_title">Tiedoston lataamisen epäonnistui</string>
-	<string name="unable_upload_error_subtitle_edited">Tiedosto muokattiin web-sovelluksen kautta</string>
-	<string name="unable_upload_error_subtitle_broken">Tiedosto on vioittunut eikä sitä voi ladata. Ole hyvä, lataa toinen tiedosto.</string>
-	<string name="contact">Kirjoita</string>
-	<string name="download_button">Ladata</string>
 	<string name="speedcams_alert_title">Nopeuskamerat</string>
-	<string name="speedcams_alert_subtitle">Varoita nopeusrajoituksista</string>
 	<string name="speedcam_option_auto">Auto</string>
 	<string name="speedcam_option_always">Aina</string>
 	<string name="speedcam_option_never">Ei koskaan</string>
-	<string name="bookmark_description_title">Merkin kuvaus</string>
 	<string name="place_description_title">Paikan kuvaus</string>
 	<!-- this text will be shown in application notification preferences opposite checkbox which enable/disable downloader notifications. Devices on Android 8+ are affected. -->
 	<string name="notification_channel_downloader">Karttojen lataaminen</string>
-	<string name="share_bookmarks_email_body_link">Hei!\n\nMerkkinne voi ladata linkistä: %s. Avaa luettelo Organic Maps: llä ja nauti matkasta!\n\nLataa sovellus: https://omaps.app/get?kmz</string>
-	<string name="warning_speedcams_title">Navigaattori ilmoittaa sinulle kameroista, kun nopeusraja ylittyy %d km/t</string>
-	<string name="warning_speedcams_subtitle">Muista tutustua matkustusmaan liikennesääntöihin.</string>
 	<string name="speedcams_notice_message">Auto - Varoita nopeuskameroista, jos tuntuu siltä, että nopeusrajan ylitys on mahdollista\nAina - Varoita kameroista aina\nEi koskaan - älä koskaan varoita kameroista</string>
 	<string name="power_managment_title">Virransäästötila</string>
 	<string name="power_managment_description">Kun olet valinnut automaattisen tilan, sovellus alkaa sammuttamaan virtaa vieviä ominaisuuksia riippuen kulloisestakin akun latauksesta</string>
@@ -1068,14 +662,7 @@
 	<string name="power_managment_setting_auto">Automaattinen</string>
 	<string name="power_managment_setting_manual_max">Täysi virransäästö</string>
 	<string name="enable_logging_warning_message">Valinta ottaa käyttöön lokikirjaukset diagnostiikkaa varten. Se voi auttaa tukihenkilöstöämme, kun he korjaavat sovelluksen ongelmia. Ota tämä ominaisuus käyttöön vain, jos Organic Maps:n tuki pyytää.</string>
-	<string name="html_error_upload_message_try_again">Tarkista verkkoasetukset ja kokeile uudelleen</string>
-	<string name="html_error_upload_title_try_again">Ei nettiyhteyttä</string>
-	<string name="notification_leave_review_v2_android_short_title">Arvostele ja auta matkailijoita!</string>
-	<string name="notifications_illegal_alert_disable_button">Kytke ilmoitukset pois</string>
 	<string name="access_rules_author_only">Nettimuokkaus</string>
-	<string name="privacy_settings_menu">Yksityisyysasetukset</string>
-	<string name="unable_upadate_error_title">Tiedoston päivitys epäonnistui</string>
-	<string name="unable_upadate_error_message">Päivityksen aikana tapahtui jokin virhe. Tarkista muutokset ja yritä uudelleen</string>
 	<string name="driving_options_title">Kiertotien asetukset</string>
 	<string name="driving_options_subheader">Vältettävä kaikissa reiteissä</string>
 	<string name="avoid_tolls">Maksulliset tiet</string>
@@ -1086,52 +673,14 @@
 	<string name="unable_to_calc_alert_subtitle">Valitettavasti emme voineet luoda reittiä valituilla vaihtoehdoilla. Vaihda asetuksia ja yritä uudelleen</string>
 	<string name="define_to_avoid_btn">Muodosta kiertotietä</string>
 	<string name="change_driving_options_btn">Kiertotien asetukset on päällä</string>
-	<string name="toll_road">Maksullinen tie</string>
-	<string name="unpaved_road">Päällystämätön tie</string>
-	<string name="ferry_crossing">Lauttaliikenne</string>
-	<string name="operated_by">Hallinnoitu \"%s\"</string>
 	<string name="avoid_toll_roads_placepage">Vältä maksullisia teitä</string>
 	<string name="avoid_unpaved_roads_placepage">Vältä maanteitä</string>
 	<string name="avoid_ferry_crossing_placepage">Vältä lautan käyttöä</string>
-	<string name="type.cuisine.uzbek">Uzbekistanilainen ruokaa</string>
-	<string name="trip_start">Mennään</string>
-	<string name="pick_destination">Kohde</string>
-	<string name="follow_my_position">Kohdista</string>
-	<string name="search_results">Hakutulokset</string>
-	<string name="then_turn">Sitten</string>
-	<string name="redirect_route_alert">Haluatko luoda reitin uudelleen?</string>
-	<string name="redirect_route_yes">Kyllä</string>
-	<string name="redirect_route_no">Ei</string>
-	<string name="trip_finished">Olet saapunut!</string>
-	<string name="keyboard_availability_alert">Näppäimistö ei ole käytettävissä ajon aikana</string>
-	<string name="dialog_routing_change_start_carplay">Reittiä ei ole mahdollista luoda nykyisestä sijainnista</string>
-	<string name="dialog_routing_change_end_carplay">Reittiä ei ole mahdollista luoda loppupisteeseen. Valitse toinen</string>
-	<string name="dialog_routing_check_gps_carplay">Ei ole GPS-signaalia. Siirry avaralle alueelle</string>
-	<string name="dialog_routing_unable_locate_route_carplay">Reittiä ei ole mahdollista luoda. Valitse muut reittipisteet</string>
-	<string name="dialog_routing_download_files_carplay">Luodaksesi reitin lataa puutt. kartat</string>
-	<string name="dialog_routing_system_error_carplay">On tapahtunut virhe. Käynnistä sovellus uudelleen</string>
-	<string name="dialog_routing_rebuild_from_current_location_carplay">Reitti luodaan nykyisestä sijainnista</string>
-	<string name="dialog_routing_rebuild_for_vehicle_carplay">Reitti muutetaan autoilijan reitiksi</string>
 	<string name="ok">Ok</string>
-	<string name="avoid_unpaved_carplay_1">Päällyste</string>
-	<string name="avoid_unpaved_carplay_2">Vain päällyste</string>
-	<string name="avoid_ferry_carplay_1">Ei lauttoja</string>
-	<string name="avoid_ferry_carplay_2">Ei lauttoja</string>
-	<string name="avoid_tolls_carplay_1">Ei maksua</string>
-	<string name="avoid_tolls_carplay_2">Ei maksua</string>
-	<string name="speedcams_alert_title_carplay_1">Nopeuskamera</string>
-	<string name="speedcams_alert_title_carplay_2">Nopeuskamerat</string>
-	<string name="download_map_carplay">Lataa kartat laitteesi Organic Maps-sovelluksessa</string>
-	<string name="carplay_roundabout_exit">Poistumisramppi %s</string>
 	<!-- max. 10 symbols, both iOS and Android -->
 	<string name="sort">Järjestä…</string>
 	<!-- Android, title, max 20-22 symbols -->
 	<string name="sort_bookmarks">Järjestä kirjanmerkit</string>
-	<!-- iOS -->
-	<string name="sort_default">Järjestä: oletus</string>
-	<string name="sort_type">Järjestä: tyyppi</string>
-	<string name="sort_distance">Järjestä: etäisyys</string>
-	<string name="sort_date">Järjestä: päivämäärä</string>
 	<!-- Android -->
 	<string name="by_default">Oletus</string>
 	<!-- Android -->
@@ -1140,65 +689,23 @@
 	<string name="by_distance">Etäisyys</string>
 	<!-- Android -->
 	<string name="by_date">Päivämäärä</string>
-	<string name="week_ago_sorttype">Viikko sitten</string>
-	<string name="month_ago_sorttype">Kuukausi sitten</string>
-	<string name="moremonth_ago_sorttype">Yli kuukausi sitten</string>
-	<string name="moreyear_ago_sorttype">Yli vuosi sitten</string>
-	<string name="near_me_sorttype">Lähelläni</string>
-	<string name="others_sorttype">Muut</string>
-	<string name="food_places">Ruoka</string>
-	<string name="tourist_places">Nähtävyydet</string>
-	<string name="museums">Museot</string>
-	<string name="parks">Puistot</string>
-	<string name="swim_places">Uiminen</string>
-	<string name="mountains">Vuoret</string>
-	<string name="animals">Eläimet</string>
-	<string name="hotels">Hotellit</string>
-	<string name="buildings">Rakennukset</string>
-	<string name="money">Raha</string>
-	<string name="shops">Kaupat</string>
-	<string name="parkings">Pysäköinti</string>
-	<string name="fuel_places">Huoltoasemat</string>
-	<string name="water">Vesi</string>
-	<string name="medicine">Apteekki</string>
 	<string name="search_in_the_list">Etsi listalta</string>
-	<string name="view_on_map_bookmarks">Kartalla</string>
-	<string name="more_bookmarks">Lisää…</string>
-	<string name="no_items_found">Kohteita ei löytynyt</string>
-	<!-- Android, max 18 symbols -->
-	<string name="bookmarks_edit_list">Muokkaa listaa</string>
-	<!-- Android, max 18 symbols -->
-	<string name="bookmarks_delete_list">Poista lista</string>
-	<string name="religious_places">Pyhät paikat</string>
 	<string name="select_list">Valitse luettelo</string>
 	<string name="transit_not_found">Metron reittiohjeet eivät ole vielä saatavilla tällä alueella</string>
 	<string name="dialog_pedestrian_route_is_long_header">Metroreittiä ei ole löytynyt</string>
 	<string name="dialog_pedestrian_route_is_long_message">Valitse reitin aloitus- tai loppupiste lähemmäksi metroasemaa</string>
-	<!-- Failed planning SUBWAY route message in navigation view -->
-	<string name="routing_planning_error_subway_special">Virhe metroreitin luomisessa</string>
 	<string name="button_layer_isolines">Korkeudet</string>
-	<string name="tips_map_layers_title_countour">Korkeuslinjat offline-tilassa Organic Maps:ssä!</string>
-	<string name="tips_map_layers_message_countour">Korkeuslinjat auttavat suunnittelemaan luontomatkan etkä enää eksy maastolla</string>
 	<string name="isolines_activation_error_dialog">Päivitä tai lataa haluamasi alueen kartta, voidaksesi käyttää korkeuslinjoja</string>
 	<string name="isolines_location_error_dialog">Korkeus linjat eivät ole vielä saatavilla tällä alueella</string>
 	<string name="elevation_profile_diff_level">Vaikeustaso</string>
-	<string name="elevation_profile_diff_level_easy">Helppo</string>
-	<string name="elevation_profile_diff_level_moderate">Kohtuullinen</string>
-	<string name="elevation_profile_diff_level_hard">Vaikea</string>
 	<string name="elevation_profile_ascent">Nosto</string>
 	<string name="elevation_profile_descent">Lasku</string>
 	<string name="elevation_profile_minaltitude">Min. korkeus</string>
 	<string name="elevation_profile_maxaltitude">Maks. korkeus</string>
-	<string name="elevation_profile_m">m</string>
 	<string name="elevation_profile_difficulty">Vaikeus</string>
 	<string name="elevation_profile_distance">Etäisyys:</string>
-	<string name="elevation_profile_km">km</string>
 	<string name="elevation_profile_time">Aika:</string>
-	<string name="elevation_profile_hours">t.</string>
-	<string name="elevation_profile_minutes">min</string>
 	<string name="isolines_toast_zooms_1_10">Suurenna kartta nähdäksesi korkeuslinjat</string>
-	<string name="downloader_updating_ios">Päivitys</string>
-	<string name="downloader_loading_ios">Lataus</string>
 	<string name="key_information_title">Avaintietoa</string>
 	<string name="enable_screen_sleep">Anna näytön nukkua</string>
 	<!-- Description in preferences -->

--- a/android/res/values-fr/strings.xml
+++ b/android/res/values-fr/strings.xml
@@ -12,15 +12,11 @@
 	<string name="cancel_download">Annuler le téléchargement</string>
 	<!-- Button which deletes downloaded country -->
 	<string name="delete">Supprimer</string>
-	<!-- Button "do not interrupt download" if user touched actively downloading country -->
-	<string name="do_nothing">Continuer</string>
 	<string name="download_maps">Télécharger des cartes</string>
 	<!-- Settings/Downloader - info for country when download fails -->
 	<string name="download_has_failed">Échec lors du téléchargement. Toucher de nouveau pour un essai de plus.</string>
 	<!-- Settings/Downloader - info for country which started downloading -->
 	<string name="downloading">Téléchargement…</string>
-	<!-- Settings/Downloader - size string, only strings different from English should be translated -->
-	<string name="kb">ko</string>
 	<!-- Choose measurement on first launch alert - choose metric system button -->
 	<string name="kilometres">kilomètres</string>
 	<!-- Leave Review dialog - Review button -->
@@ -35,45 +31,31 @@
 	<string name="core_my_position">Ma position</string>
 	<!-- Update maps later/Buy pro version later button text -->
 	<string name="later">Plus tard</string>
-	<!-- Don't show some dialog any more -->
-	<string name="never">Jamais</string>
 	<!-- View and button titles for accessibility -->
 	<string name="search">Recherche</string>
 	<!-- Search box placeholder text -->
 	<string name="search_map">Rechercher sur la carte</string>
-	<!-- Settings/Downloader - info for not downloaded country -->
-	<string name="touch_to_download">Toucher pour télécharger</string>
 	<!-- Settings/Downloader - 3G download warning dialog confirm button -->
 	<string name="use_cellular_data">Oui</string>
 	<!-- Location services are disabled by user alert - message -->
 	<string name="location_is_disabled_long_text">Tous les services de localisation de cet appareil sont désactivés, ou ils le sont pour cette application. Veuillez les activer dans les paramètres.</string>
-	<!-- Location Services are not available on the device alert - message -->
-	<string name="device_doesnot_support_location_services">Votre appareil ne prend pas en charge les services de localisation</string>
 	<!-- View and button titles for accessibility -->
 	<string name="zoom_to_country">Voir sur la carte</string>
-	<!-- Button text for the button at the center of the screen when the country is not downloaded -->
-	<string name="country_status_download">Téléchargez la carte\n(^ ^)</string>
 	<!-- Button text for the button at the center of the screen when the country is not downloaded and the size should not be shown -->
 	<string name="country_status_download_without_size">Téléchargez la carte</string>
-	<!-- Button text for the button at the center of the screen when the country is not downloaded -->
-	<string name="country_status_download_without_routing">Télécharger la carte\nsans itinéraire (^ ^)</string>
 	<!-- Message to display at the center of the screen when the country download has failed -->
 	<string name="country_status_download_failed">Échec lors du téléchargement</string>
 	<!-- Button text for the button under the country_status_download_failed message -->
 	<string name="try_again">Ressayer</string>
 	<string name="about_menu_title">À propos de Organic Maps</string>
-	<string name="downloaded_touch_to_delete">Téléchargé (%s), toucher pour supprimer</string>
 	<string name="connection_settings">Paramètres de connexion</string>
-	<string name="download_mb_or_kb">Télécharger %s</string>
 	<string name="close">Fermer</string>
 	<string name="unsupported_phone">L\'accélération OpenGL matérielle est exigée. Malheureusement, votre appareil n\'est pas pris en charge.</string>
 	<string name="download">Télécharger</string>
-	<string name="external_storage_is_not_available">La carte SD/le stockage USB contenant les cartes téléchargées n\'est pas disponible</string>
 	<string name="disconnect_usb_cable">Veuillez débrancher le câble USB ou insérer la carte SD pour utiliser Organic Maps</string>
 	<string name="not_enough_free_space_on_sdcard">Veuillez d\'abord libérer de l\'espace sur la carte SD/le stockage USB afin d\'utiliser l\'appli</string>
 	<string name="not_enough_memory">Mémoire insuffisante pour lancer l\'appli</string>
 	<string name="download_resources">Avant de commencer, permettez-nous de télécharger la carte générale du monde dans votre appareil.\n%s de données sont nécessaires.</string>
-	<string name="getting_position">Obtention de la position actuelle</string>
 	<string name="download_resources_continue">Aller sur la carte</string>
 	<string name="downloading_country_can_proceed">%s en téléchargement. Vous pouvez\nmaintenant aller sur la carte.</string>
 	<string name="download_country_ask">Télécharger %s ?</string>
@@ -86,30 +68,20 @@
 	<string name="download_country_failed">%s, échec lors du téléchargement</string>
 	<!-- Add New Bookmark Set dialog title -->
 	<string name="add_new_set">Ajouter un nouveau groupe</string>
-	<!-- Place Page - Add To Bookmarks button -->
-	<string name="add_to_bookmarks">Ajouter aux signets</string>
 	<!-- Bookmark Color dialog title -->
 	<string name="bookmark_color">Couleur du signet</string>
 	<!-- Add Bookmark Set dialog - hint when set name is empty -->
 	<string name="bookmark_set_name">Nom du groupe de signets</string>
-	<!-- Bookmark Sets dialog title -->
-	<string name="bookmark_sets">Groupes de signets</string>
 	<!-- Bookmarks - dialog title -->
 	<string name="bookmarks">Signets</string>
-	<!-- Add bookmark dialog - bookmark color -->
-	<string name="color">Couleur</string>
 	<!-- Default bookmarks set name -->
 	<string name="core_my_places">Mes endroits</string>
 	<!-- Add bookmark dialog - bookmark name -->
 	<string name="name">Nom</string>
 	<!-- Editor title above street and house number -->
 	<string name="address">Adresse</string>
-	<!-- Place Page - Remove Pin button -->
-	<string name="remove_pin">Enlever l\'épingle</string>
 	<!-- Add bookmark dialog - bookmark set, Bookmarks dialog - Bookmark set cell -->
 	<string name="set">Groupe</string>
-	<!-- Text hint in Bookmarks dialog when no any bookmarks are added -->
-	<string name="bookmarks_usage_hint">Vous n\'avez encore aucun signet.\nTouchez n\'importe où sur la carte pour en ajouter un.\nLes signets provenant d\'autres sources peuvent aussi être importés et affichés dans Organic Maps. Ouvrez des fichiers KML/KMZ contenant des signets enregistrés, à partir d\'un courriel, de Dropbox ou d\'un lien Web.</string>
 	<!-- Settings button in system menu -->
 	<string name="settings">Paramètres</string>
 	<!-- Header of settings activity where user defines storage path -->
@@ -120,20 +92,10 @@
 	<string name="move_maps">Déplacer les cartes ?</string>
 	<!-- Ask to wait user several minutes (some long process in modal dialog). -->
 	<string name="wait_several_minutes">Ceci peut prendre plusieurs minutes.\nVeuillez patienter…</string>
-	<!-- Show bookmarks from this category on a map or not -->
-	<string name="visible">Visible</string>
-	<!-- Toast which is displayed when GPS has been deactivated -->
-	<string name="gps_is_disabled_long_text">Le GPS est désactivé. Veuillez l\'activer dans les Paramètres.</string>
 	<!-- Measurement units title in settings activity -->
 	<string name="measurement_units">Unités de mesure</string>
 	<!-- Detailed description of Measurement Units settings button -->
 	<string name="measurement_units_summary">Choisir entre miles et kilomètres</string>
-	<!-- Do search in all sources -->
-	<string name="search_mode_all">Partout</string>
-	<!-- Do search near my position only -->
-	<string name="search_mode_nearme">Près de moi</string>
-	<!-- Do search in current viewport only -->
-	<string name="search_mode_viewport">À l\'écran</string>
 	<!-- Search category for cafes, bars, restaurants -->
 	<string name="eat">Un endroit pour manger</string>
 	<!-- Search category for grocery stores -->
@@ -170,12 +132,8 @@
 	<string name="post">Poste</string>
 	<!-- Search category -->
 	<string name="police">Police</string>
-	<!-- String in search result list, when nothing found -->
-	<string name="no_search_results_found">Aucun résultat trouvé</string>
 	<!-- Notes field in Bookmarks view -->
 	<string name="description">Notes</string>
-	<!-- Button text -->
-	<string name="share_by_email">Partager par courriel</string>
 	<!-- Email Subject when sharing bookmarks category -->
 	<string name="share_bookmarks_email_subject">Signets Organic Maps partagés</string>
 	<!-- message title of loading file -->
@@ -188,20 +146,10 @@
 	<string name="edit">Modifier</string>
 	<!-- Warning message when doing search around current position -->
 	<string name="unknown_current_position">Votre position n\'a pas encore été déterminée</string>
-	<!-- Warning message when location country isn't downloaded during search (see also download_location_map_proposal). -->
-	<string name="download_location_country">Télécharger le pays de votre position actuelle (%s)</string>
-	<!-- Warning message when viewport country isn't downloaded during search -->
-	<string name="download_viewport_country_to_search">Télécharger le pays que vous recherchez (%s)</string>
 	<!-- Alert message that we can't run Map Storage settings due to some reasons. -->
 	<string name="cant_change_this_setting">Désolé, les paramètres de stockage des cartes sont présentement désactivés.</string>
 	<!-- Alert message that downloading is in progress. -->
 	<string name="downloading_is_active">Le téléchargement du pays est en cours.</string>
-	<!-- Message that will be shown in alert view, when we ask user to leave review on App Store -->
-	<string name="appStore_message">Nous espérons que vous appréciez l\'utilisation de Organic Maps ! Si oui, veuillez évaluer l\'appli ou laisser une critique sur l\'App Store. Cela prend moins d\'une minute, mais peut vraiment nous aider. Merci pour votre soutien !</string>
-	<!-- No, thanks -->
-	<string name="no_thanks">Non, merci</string>
-	<!-- Share one specific bookmark using SMS, %1$@ contains om:// and %2$@ https://omaps.app link. @NOTE non-ascii symbols in the link will result in max 70 characters SMS instead of 140. -->
-	<string name="bookmark_share_sms">Hé, regarde mon épingle sur Organic Maps ! %1$s ou %2$s. Les cartes hors ligne ne sont pas installées ? Les télécharger ici : https://omaps.app/get</string>
 	<!-- Share my position using SMS, %1$@ contains om:// and %2$@ https://omaps.app link WITHOUT NAME. @NOTE non-ascii symbols in the link will result in max 70 characters SMS instead of 140. -->
 	<string name="my_position_share_sms">Hé, regarde ma position actuelle sur Organic Maps ! %1$s ou %2$s. Les cartes hors ligne ne sont pas installées ? Les télécharger ici : https://omaps.app/get</string>
 	<!-- Subject for emailed bookmark -->
@@ -210,30 +158,16 @@
 	<string name="my_position_share_email_subject">Hé, regarde ma position actuelle sur la carte Organic Maps !</string>
 	<!-- Share my position using EMail, %1$@ is om:// and %2$@ is https://omaps.app link WITHOUT NAME -->
 	<string name="my_position_share_email">Bonjour,\n\nJe suis actuellement ici : %1$s. Clique sur ce lien %2$s ou sur celui-ci %3$s pour voir l\'endroit sur la carte.\n\nMerci.</string>
-	<!-- Android share by Message/SMS button text (including SMS) -->
-	<string name="share_by_message">Partager par message</string>
 	<!-- Share button text which opens menu with more buttons, like Message, EMail, Facebook etc. -->
 	<string name="share">Partager</string>
-	<!-- iOS share by Message button text (including SMS) -->
-	<string name="message">Message</string>
 	<!-- Share by email button text, also used in editor. -->
 	<string name="email">Email</string>
-	<!-- Copy Link -->
-	<string name="copy_link">Copier le lien</string>
-	<!-- Text for the button that returns to caller application -->
-	<string name="more_info">Afficher plus d\'informations</string>
 	<!-- Text for message when used successfully copied something -->
 	<string name="copied_to_clipboard">Copié dans le presse-papiers : %1$s</string>
 	<!-- place preview title -->
 	<string name="info">Infos</string>
 	<!-- Used for bookmark editing -->
 	<string name="done">Terminé</string>
-	<!-- Summary for preferences in MWM -->
-	<string name="yopme_pref_summary">Choisir les réglages de l\'arrière-plan</string>
-	<!-- Title for yopme preferences in MWM -->
-	<string name="yopme_pref_title">Paramètres de l\'arrière-plan</string>
-	<!-- Hint for upper-right icon p2b -->
-	<string name="show_on_backscreen">Afficher sur l\'arrière-plan</string>
 	<!-- Prints version number in About dialog -->
 	<string name="version">Version : %s</string>
 	<!-- Data version in «About» screen -->
@@ -245,13 +179,8 @@
 	<!-- Length of track in cell that describes route -->
 	<string name="length">Longueur</string>
 	<string name="share_my_location">Partager ma position</string>
-	<string name="menu_search">Rechercher</string>
 	<!-- Settings general group in settings screen -->
 	<string name="prefs_group_general">Paramètres généraux</string>
-	<!-- Settings screen: "Map" category title -->
-	<string name="prefs_group_map">Carte</string>
-	<!-- Settings screen: "Miscellaneous" category title -->
-	<string name="prefs_group_misc">Divers</string>
 	<string name="prefs_group_route">Navigation</string>
 	<string name="pref_zoom_title">Boutons de zoom</string>
 	<string name="pref_zoom_summary">Afficher à l\'écran</string>
@@ -267,8 +196,6 @@
 	<string name="pref_map_3d_title">Vue en perspective</string>
 	<!-- Settings «Map» category: «3D buildings» title -->
 	<string name="pref_map_3d_buildings_title">Bâtiments en 3D</string>
-	<!-- Settings «Map» category: «3D buildings» summary -->
-	<string name="pref_map_3d_buildings_subtitle">Affecte la vie de la batterie</string>
 	<!-- Settings «Route» category: «Tts enabled» title -->
 	<string name="pref_tts_enable_title">Instructions vocales</string>
 	<!-- Settings «Route» category: «Tts language» title -->
@@ -277,7 +204,6 @@
 	<string name="pref_tts_unavailable">Non disponible</string>
 	<!-- Title for "Other" section in TTS settings. -->
 	<string name="pref_tts_other_section_title">Autre</string>
-	<string name="pref_tts_how_to_set_up_voice">Comment configurer la voix</string>
 	<!-- Settings «Map» category: «Record track» title -->
 	<string name="pref_track_record_title">Parcours récent</string>
 	<string name="pref_map_auto_zoom">Zoom automatique</string>
@@ -287,47 +213,12 @@
 	<string name="duration_6_hours">6 heures</string>
 	<string name="duration_12_hours">12 heures</string>
 	<string name="duration_1_day">1 jour</string>
-	<string name="recent_track_help_text">Ceci vous permet d’enregistrer le chemin emprunté pendant un certain temps et de le voir sur la carte. Veuillez noter : l’activation de cette fonction entraîne une grande utilisation de la batterie. La route sera supprimée automatiquement de la carte lorsque l’intervalle de temps sera arrivé à expiration.</string>
-	<string name="pref_track_ios_caption">L\'itinéraire récent indique votre chemin parcouru.</string>
-	<string name="pref_track_ios_subcaption">Veuillez sélectionner la période d\'enregistrement du parcours.</string>
-	<string name="placepage_distance">Distance</string>
-	<string name="placepage_coordinates">Coordonnées</string>
-	<string name="placepage_unsorted">Non trié</string>
+	<string name="recent_track_help_text">Ceci vous permet d’enregistrer le chemin emprunté pendant un certain temps et de le voir sur la carte. Veuillez noter : l’activation de cette fonction entraîne une grande utilisation de la batterie. La route sera supprimée automatiquement de la carte lorsque l’intervalle de temps sera arrivé à expiration.</string>
 	<string name="search_show_on_map">Voir sur la carte</string>
-	<!-- Used to warn user when fixing KitKat issue -->
-	<string name="bookmark_move_fail">Nous devons déplacer vos signets vers la mémoire interne, mais il n\'y a pas d\'espace disponible pour eux. Veuillez libérer de la mémoire, sinon les signets ne seront pas disponibles.</string>
-	<!-- Used in More Apps menu -->
-	<string name="free">Gratuit</string>
-	<!-- Used in More Apps menu -->
-	<string name="buy">Acheter</string>
-	<!-- 1st search button-like result -->
-	<string name="search_on_map">Rechercher sur la carte</string>
-	<!-- toast with an error -->
-	<string name="no_route_found">Aucun itinéraire trouvé</string>
-	<!-- route title -->
-	<string name="route">Itinéraire</string>
-	<!-- category title -->
-	<string name="routes">Itinéraires</string>
-	<!-- text of notification -->
-	<string name="download_map_notification">Télécharger la carte de l\'endroit où vous êtes</string>
-	<!-- text of notification -->
-	<string name="pro_version_is_free_today">Version complète de Organic Maps gratuite aujourd\'hui ! Téléchargez-le maintenant et dites-le à vos amis.</string>
-	<!-- Dialog for transferring maps from lite to pro. -->
-	<string name="move_lite_maps_to_pro">Nous transférons vos cartes téléchargées de Organic Maps Lite vers Organic Maps. Cela peut prendre quelques minutes.</string>
-	<!-- Message to display when maps moved. -->
-	<string name="move_lite_maps_to_pro_ok">Vos cartes téléchargées ont été transférées avec succès vers Organic Maps.</string>
-	<!-- Message to display when maps move failed. -->
-	<string name="move_lite_maps_to_pro_failed">Le transfert de vos cartes a échoué. Veuillez supprimer Organic Maps Lite et télécharger les cartes de nouveau.</string>
-	<!-- Text in menu -->
-	<string name="settings_and_more">Paramètres &amp; plus</string>
 	<!-- Text in menu -->
 	<string name="website">Site internet</string>
-	<!-- Text in menu -->
-	<string name="contact_us">Contactez-nous</string>
 	<!-- Settings: Send feedback button and dialog title -->
 	<string name="feedback">Feedback</string>
-	<!-- Text in menu -->
-	<string name="subscribe_to_news">S\'abonner à nos informations</string>
 	<!-- Text in menu -->
 	<string name="rate_the_app">Évaluer l\'appli</string>
 	<!-- Text in menu -->
@@ -336,12 +227,6 @@
 	<string name="copyright">Tous droits réservés</string>
 	<!-- Text in menu -->
 	<string name="report_a_bug">Signaler un bug</string>
-	<!-- Email subject -->
-	<string name="subscribe_me_subject">Veuillez m\'inscrire à la lettre d\'information de Organic Maps</string>
-	<!-- Email body -->
-	<string name="subscribe_me_body">Informez-moi en priorité des dernières nouvelles, des mises à jour et des promotions. Je peux annuler mon abonnement à tout moment.</string>
-	<!-- About text -->
-	<string name="about_text">Organic Maps offre les cartes hors ligne les plus rapides de toutes les villes, de tous les pays du monde. Voyagez en toute confiance : où que vous soyez, Organic Maps permet de vous situer sur la carte, de trouver le restaurant, l\'hôtel, la banque, la station d\'essence, etc. les plus proches. Ceci sans aucune connexion Internet.\n\nNous travaillons toujours sur de nouvelles fonctionnalités et nous aimerions avoir votre avis sur la manière d\'améliorer Organic Maps. Si vous avez quelque problème avec l\'appli, n\'hésitez pas à nous contacter à support\@organicmaps.app. Nous répondons à toutes les demandes !\n\nVous aimez-vous Organic Maps et souhaitez nous soutenir ? Il existe des moyens simples et tout à fait gratuits :\n\n- Publier une critique sur votre boutique d\'applis\n- aimez notre page Facebook http://www.facebook.com/OrganicMaps\n- ou parlez simplement de Organic Maps à votre maman, à vos amis et à vos collègues :)\n\nNous vous remercions de votre fidélité. Nous apprécions beaucoup votre soutien !\n\nP.S. : nous prenons les données cartographiques d\'OpenStreetMap, un projet de cartographie similaire à Wikipédia, qui permet aux utilisateurs de créer et de modifier des cartes. Si vous voyez une omission ou une erreur sur la carte, vous pouvez corriger les cartes directement sur https://www.openstreetmap.org, et vos modifications apparaîtront dans l\'appli Organic Maps lors la prochaine version.</string>
 	<!-- Alert text -->
 	<string name="email_error_body">Le client de courriel n\'a pas été configuré. Veuillez le faire ou employer tout autre moyen pour nous contacter à %s</string>
 	<!-- Alert title -->
@@ -350,137 +235,56 @@
 	<string name="pref_calibration_title">Étalonnage de la boussole</string>
 	<!-- Search category -->
 	<string name="wifi">WiFi</string>
-	<!-- Update map suggestion -->
-	<string name="routing_map_outdated">Veuillez mettre à jour la carte pour créer un itinéraire.</string>
-	<!-- Update maps suggestion -->
-	<string name="routing_update_maps">La nouvelle version de Organic Maps permet de créer des itinéraires à partir de votre position actuelle vers un point de destination. Veuillez mettre à jour les cartes pour utiliser cette fonctionnalité.</string>
 	<!-- Update all button text -->
 	<string name="downloader_update_all_button">Tout mettre à jour</string>
 	<!-- Cancel all button text -->
 	<string name="downloader_cancel_all">Tout annuler</string>
 	<!-- Downloaded maps category -->
 	<string name="downloader_downloaded_subtitle">Téléchargé</string>
-	<!-- Downloaded maps category -->
-	<string name="downloader_available_maps">Disponible</string>
 	<!-- Country queued for download -->
 	<string name="downloader_queued">En file d\'attente</string>
 	<string name="downloader_near_me_subtitle">Près de moi</string>
 	<string name="downloader_status_maps">Cartes</string>
 	<string name="downloader_download_all_button">Télécharger tout</string>
 	<string name="downloader_downloading">Téléchargement en cours :</string>
-	<string name="downloader_search_results">Trouvé</string>
-	<!-- Disclaimer message -->
-	<string name="routing_disclaimer">Quand vous créez des itinéraires sur l\'application Organic Maps, veuillez garder à l\'esprit les points suivants :\n\n  - Les itinéraires suggérés ne doivent être considérés que comme des recommandations.\n\n  - Les conditions des routes, les règlementations de circulations et les panneaux sont prioritaires sur les conseils de navigation.\n\n  - Il est possible qu\'une carte soit incorrecte ou obsolète, et les itinéraires ne sont pas toujours créés de la meilleure façon possible.\n\n  Soyez prudents sur les routes et prenez soin de vous.</string>
-	<!-- Outdated maps category -->
-	<string name="downloader_outdated_maps">Dépassé</string>
-	<!-- Up to date maps category -->
-	<string name="downloader_uptodate_maps">À jour</string>
 	<!-- Status of outdated country in the list -->
 	<string name="downloader_status_outdated">Mettre à jour</string>
 	<!-- Status of failed country in the list -->
 	<string name="downloader_status_failed">A échoué</string>
 	<!-- Displayed in a dialog that appears when a user tries to delete a map while the app is in the follow route mode -->
 	<string name="downloader_delete_map_while_routing_dialog">Veuillez interrompre la navigation pour supprimer la carte.</string>
-	<!-- Show when user try build route, but we don't know where he -->
-	<string name="routing_failed_unknown_my_position">L\'emplacement actuel n\'est pas défini. Veuillez préciser l\'emplacement pour créer l\'itinéraire.</string>
-	<!-- Show if use has not routing file, or InconsistentMWMandRoute -->
-	<string name="routing_failed_has_no_routing_file">Des données supplémentaires sont nécessaires pour créer un itinéraire. Vous désirez lancer le téléchargement ?</string>
-	<!-- StartPointNotFound -->
-	<string name="routing_failed_start_point_not_found">Impossible de calculer l\'itinéraire. Aucune route à proximité de votre point de départ.</string>
-	<!-- EndPointNotFound -->
-	<string name="routing_failed_dst_point_not_found">Impossible de calculer l\'itinéraire. Aucune route à proximité de votre destination.</string>
 	<!-- PointsInDifferentMWM -->
 	<string name="routing_failed_cross_mwm_building">Les itinéraires entièrement contenus sur une seule carte peuvent être créés.</string>
-	<!-- RouteNotFound -->
-	<string name="routing_failed_route_not_found">Il n\'existe aucun itinéraire entre l\'origine et la destination choisie. Veuillez sélectionner un point de départ ou d\'arrivée différent.</string>
-	<!-- InternalError -->
-	<string name="routing_failed_internal_error">Une erreur interne s\'est produite. Veuillez essayer de supprimer la carte et téléchargez la à nouveau. Si le problème persiste, veuillez contacter support\@organicmaps.app.</string>
-	<!-- Context menu item for downloader. -->
-	<string name="downloader_download_map_and_routing">Télécharger Carte + Itinéraire</string>
-	<!-- Context menu item for downloader. -->
-	<string name="downloader_download_routing">Télécharger Itinéraire</string>
-	<!-- Context menu item for downloader. -->
-	<string name="downloader_delete_routing">Supprimer Itinéraire</string>
 	<!-- Context menu item for downloader. -->
 	<string name="downloader_download_map">Télécharger la carte</string>
-	<string name="downloader_download_map_no_routing">Télécharger la carte sans itinéraire</string>
-	<!-- Button for routing. -->
-	<string name="routing_go">Allez-y !</string>
 	<!-- Item status in downloader. -->
 	<string name="downloader_retry">Répéter</string>
-	<!-- Item in context menu. -->
-	<string name="downloader_map_and_routing">Carte + itinéraire</string>
 	<!-- Item in context menu. -->
 	<string name="downloader_delete_map">Supprimer carte</string>
 	<!-- Item in context menu. -->
 	<string name="downloader_update_map">Mise à jour carte</string>
-	<!-- Item in context menu. -->
-	<string name="downloader_update_map_and_routing">Mise à jour carte + itinéraire</string>
-	<!-- Item in context menu. -->
-	<string name="downloader_map_only">Carte uniquement</string>
-	<!-- Toolbar title -->
-	<string name="toolbar_application_menu">Menu principal</string>
 	<!-- Preference text -->
 	<string name="pref_use_google_play">Utilisez l\'application Google Play Services pour obtenir votre emplacement actuel</string>
 	<!-- Text for rating dialog -->
 	<string name="rating_just_rated">Je viens d\'évaluer votre appli</string>
-	<!-- Text for rating dialog -->
-	<string name="rating_user_since">J\'utilise Organic Maps depuis %s</string>
-	<!-- Text for rating dialog -->
-	<string name="rating_do_like_maps">Aimez-vous Organic Maps ?</string>
-	<!-- Text for rating dialog -->
-	<string name="rating_tap_star">Tapotez sur une étoile pour évaluer notre appli</string>
 	<!-- Text for rating dialog -->
 	<string name="rating_thanks">Merci !</string>
 	<!-- Text for rating dialog -->
 	<string name="rating_share_ideas">Partagez vos idées ou vos problèmes de façon à ce que nous puissions améliorer l\'application.</string>
 	<!-- Text for rating dialog -->
 	<string name="rating_send_feedback">Envoyez vos commentaires</string>
-	<!-- Text for g+ dialog -->
-	<string name="rating_google_plus">Clique sur g+ pour parler de l\'appli à tes amis.</string>
 	<!-- Text for routing error dialog -->
 	<string name="routing_download_maps_along">Téléchargez des cartes le long du trajet</string>
-	<!-- Text for routing error dialog -->
-	<string name="routing_download_map">Téléchargez des cartes</string>
-	<!-- Text for routing error dialog -->
-	<string name="routing_download_map_and_routing">Des cartes actualisées et des données de routage pour obtenir toutes les fonctionnalités de Organic Maps.</string>
-	<!-- Text for routing error dialog -->
-	<string name="routing_get_routing_data">Recevez des données de routage</string>
-	<!-- Text for routing error dialog -->
-	<string name="routing_get_additional_data">Des données supplémentaires nécessaires pour créer des itinéraires depuis votre localisation.</string>
 	<!-- Text for routing error dialog -->
 	<string name="routing_requires_all_map">La création d\'un itinéraire nécessite que toutes les cartes de votre localisation vers votre destination soient téléchargées et actualisées.</string>
 	<!-- Text for routing error dialog -->
 	<string name="routing_not_enough_space">Pas assez d\'espace</string>
-	<!-- Text for routing error dialog -->
-	<string name="routing_download_more_than_avail">Vous devez télécharger %1$s Mo, mais seulement %2$s Mo sont disponibles.</string>
-	<!-- Text for routing error dialog -->
-	<string name="routing_download_roaming">Vous allez télécharger %s Mo à l\'aide de données mobiles (frais d\'itinérance). Cela peut entraîner des frais additionnels, en fonction du plan de données mobiles proposé par votre opérateur.</string>
 	<!-- bookmark button text -->
 	<string name="bookmark">signet</string>
-	<!-- map is not downloaded -->
-	<string name="not_found_map">La carte pour votre emplacement n\'est pas téléchargée</string>
 	<!-- location service disabled -->
 	<string name="enable_location_services">Veuillez activer les services de localisation</string>
-	<!-- download map -->
-	<string name="download_map">Télécharger la carte de l\'endroit où vous êtes</string>
-	<!-- download map on iPhone -->
-	<string name="download_map_iphone">Téléchargez la carte de l\'endroit où vous vous trouvez sur votre iPhone</string>
-	<!-- clear pin -->
-	<string name="nearby">À proximité</string>
-	<!-- clear pin -->
-	<string name="clear_pin">Effacer Pin</string>
-	<!-- location is undefined -->
-	<string name="undefined_location">L\'emplacement actuel n\'est pas défini.</string>
-	<!-- download country of your location -->
-	<string name="download_country">Téléchargez la carte pour votre emplacement</string>
-	<!-- download failed -->
-	<string name="download_failed">échec lors du téléchargement</string>
-	<!-- get the map -->
-	<string name="get_the_map">Téléchargez des cartes</string>
 	<string name="save">Sauvegarder</string>
 	<string name="edit_description_hint">Vos descriptions (version texte ou html)</string>
-	<string name="new_group">nouveau groupe</string>
 	<string name="create">créer</string>
 	<!-- red color -->
 	<string name="red">Rouge</string>
@@ -498,22 +302,6 @@
 	<string name="brown">Marron</string>
 	<!-- pink color -->
 	<string name="pink">Rose</string>
-	<!-- deep purple color -->
-	<string name="deep_purple">Pourpre foncé</string>
-	<!-- light blue color -->
-	<string name="light_blue">Bleu ciel</string>
-	<!-- cyan color -->
-	<string name="cyan">Cyan</string>
-	<!-- teal color -->
-	<string name="teal">Émeraude</string>
-	<!-- lime color -->
-	<string name="lime">Vert citron</string>
-	<!-- deep orange color -->
-	<string name="deep_orange">Orange foncé</string>
-	<!-- gray color -->
-	<string name="gray">Gris</string>
-	<!-- blue gray color -->
-	<string name="blue_gray">Gris-bleu</string>
 	<!-- Wi-Fi available -->
 	<string name="WiFi_available">Oui</string>
 
@@ -529,10 +317,8 @@
 	<string name="dialog_routing_location_turn_wifi">Vérifiez le signal GPS. Activez le Wi-Fi pour améliorer la précision de votre localisation.</string>
 	<string name="dialog_routing_location_turn_on">Activez les services de localisation</string>
 	<string name="dialog_routing_location_unknown_turn_on">Impossible d\'identifier les coordonnées GPS actuelles. Activez les services de localisation pour calculer l\'itinéraire.</string>
-	<string name="dialog_routing_location_unknown">Impossible d\'identifier les coordonnées GPS actuelles.</string>
 	<string name="dialog_routing_download_files">Téléchargez les fichiers requis</string>
 	<string name="dialog_routing_download_and_update_all">Téléchargez et mettez à jour les informations de carte et d\'itinéraire de votre trajet pour calculer l\'itinéraire.</string>
-	<string name="dialog_routing_routes_size">Fichiers d\'itinéraire</string>
 	<string name="dialog_routing_unable_locate_route">Impossible de localiser l\'itinéraire</string>
 	<string name="dialog_routing_cant_build_route">Impossible de créer l\'itinéraire.</string>
 	<string name="dialog_routing_change_start_or_end">Modifiez votre point de départ ou votre destination.</string>
@@ -547,33 +333,23 @@
 	<string name="dialog_routing_system_error">Erreur système</string>
 	<string name="dialog_routing_application_error">Impossible de créer l\'itinéraire à cause d\'une erreur dans l\'application.</string>
 	<string name="dialog_routing_try_again">Réessayer</string>
-	<string name="dialog_routing_send_error">Signaler le problème</string>
-	<string name="dialog_routing_if_get_cross_route">Voulez-vous créer un itinéraire plus direct s\'étendant sur plus d\'une carte ?</string>
-	<string name="dialog_routing_cross_route_is_optimal">Un itinéraire plus direct sortant du cadre de cette carte est disponible.</string>
 	<string name="not_now">Pas maintenant</string>
-	<string name="dialog_routing_build_route">Créer</string>
 	<string name="dialog_routing_download_and_build_cross_route">Voulez-vous télécharger la carte et créer un itinéraire plus direct s\'étendant sur plus d\'une carte?</string>
 	<string name="dialog_routing_download_cross_route">Téléchargez la carte pour créer un itinéraire plus direct sortant du cadre de cette carte.</string>
-	<string name="dialog_routing_cross_route_always">Toujours dépasser ce cadre</string>
 
 	<!-- SECTION: Strings for downloading map from search -->
 	<string name="search_without_internet_advertisement">Pour commencer à rechercher et à créer des itinéraires, veuillez télécharger la carte, et vous n\'aurez plus besoin de connexion Internet.</string>
 	<string name="search_select_map">Sélectionner la carte</string>
-	<string name="search_select_other_map">Sélectionner une autre carte</string>
 	<!-- «Show» context menu -->
 	<string name="show">Afficher</string>
 	<!-- «Hide» context menu -->
 	<string name="hide">Masquer</string>
 	<!-- «Rename» context menu -->
 	<string name="rename">Renommer</string>
-	<!-- Bottom sheet: expand button (should be short) -->
-	<string name="bottom_sheet_more">Plus…</string>
 	<!-- Failed planning route message in navigation view -->
 	<string name="routing_planning_error">La planification de l\'itinéraire a échoué</string>
 	<!-- Arrive routing message in navigation view -->
 	<string name="routing_arrive">Arrivée: %s</string>
-	<!-- Text for routing::RouterResultCode::FileTooOld dialog. -->
-	<string name="dialog_routing_download_and_update_maps">Pour créer un trajet, veuillez télécharger et mettre à jour toutes les cartes concernant ce trajet.</string>
 	<string name="rate_alert_title">Vous aimez l’application ?</string>
 	<string name="rate_alert_default_message">Merci d’avoir utilisé Organic Maps. Pourriez-vous, s’il vous plaît, noter cette application ? Vos commentaires nous aideront à nous améliorer.</string>
 	<string name="rate_alert_five_star_message">Super ! Nous vous aimons aussi !</string>
@@ -581,26 +357,16 @@
 	<string name="rate_alert_less_than_four_star_message">Avez-vous une idée de ce que nous pourrions améliorer ?</string>
 	<string name="categories">Catégories</string>
 	<string name="history">Historique</string>
-	<string name="next_turn_then">Ensuite</string>
 	<string name="closed">Fermé</string>
-	<string name="back_to">Revenir à %s</string>
 	<string name="search_not_found">Désolé, je n\'ai rien trouvé.</string>
 	<string name="search_not_found_query">Veuillez essayer un autre mot-clé.</string>
-	<string name="search_not_found_map">Veuillez télécharger la carte dans laquelle vous recherchez.</string>
-	<string name="search_not_found_location">Téléchargez la carte de votre emplacement actuel.</string>
 	<string name="search_history_title">Historique de recherche</string>
 	<string name="search_history_text">Accédez rapidement aux dernières recherches.</string>
 	<string name="clear_search">Effacer l\'historique de recherche</string>
-	<!-- Title for settings to enable/disable showcase menu button -->
-	<string name="showcase_settings_title">Afficher les offres</string>
 	<!-- Place Page link to Wikipedia article (if map object has it). -->
 	<string name="read_in_wikipedia">Wikipédia</string>
-	<string name="p2p_route_planning">Planification d’itinéraire</string>
 	<string name="p2p_your_location">Votre emplacement</string>
-	<string name="p2p_from">Le lieu de départ</string>
-	<string name="p2p_to">Le lieu de destination</string>
 	<string name="p2p_start">Démarrer</string>
-	<string name="p2p_planning">En cours de planification…</string>
 	<string name="p2p_from_here">Depuis</string>
 	<string name="p2p_to_here">Itinéraire vers</string>
 	<string name="p2p_only_from_current">La navigation est uniquement disponible à partir de votre emplacement actuel.</string>
@@ -620,11 +386,8 @@
 	<string name="editor_hours_closed">Heures de fermeture</string>
 	<string name="editor_example_values">Exemple de valeurs</string>
 	<string name="editor_correct_mistake">Corriger l\'erreur</string>
-	<string name="editor_correct_mistake_message">Vous avez fait une erreur d\'édition. Veuillez la corriger ou passer en mode simple.</string>
 	<string name="editor_add_select_location">Emplacement</string>
 	<string name="editor_done_dialog_1">Vous avez modifié la carte du monde ! Ne le cachez pas ! Dites-le à vos amis, et modifiez-le ensemble.</string>
-	<string name="editor_done_dialog_2">Ceci est votre seconde amélioration de carte. Vous êtes maintenant à la %de place dans la liste des éditeurs de cartes. Dites-le à vos amis.</string>
-	<string name="editor_done_dialog_3">Vous avez amélioré la carte, dites-le à vos amis et modifiez la carte ensemble.</string>
 	<string name="share_with_friends">Partagez avec vos amis</string>
 	<string name="editor_report_problem_desription_1">Veuillez décrire le problème en détail pour permettre à la communauté OpenStreeMap de réparer l\'erreur.</string>
 	<string name="editor_report_problem_desription_2">Ou faites-le vous-même à https://www.openstreetmap.org/</string>
@@ -633,14 +396,7 @@
 	<string name="editor_report_problem_no_place_title">Le lieu n\'existe pas</string>
 	<string name="editor_report_problem_under_construction_title">Fermé pour cause de maintenance</string>
 	<string name="editor_report_problem_duplicate_place_title">Lieu doublon</string>
-	<string name="first_launch_congrats_title">Organic Maps est prêt à l\'utilisation</string>
-	<string name="first_launch_congrats_text">Cherchez et trouvez la bonne direction partout dans le monde, en mode hors-connexion, gratuitement.</string>
-	<string name="migrate_title">Important !</string>
-	<!-- Android uses image instead of text. -->
-	<string name="download_all">Tout télécharger</string>
-	<string name="delete_all">Supprimer tout</string>
 	<string name="autodownload">Téléchargement automatique</string>
-	<string name="disable_autodownload">Désactiver téléchargement automatique</string>
 	<!-- Place Page opening hours text -->
 	<string name="closed_now">Fermé actuellement</string>
 	<!-- Place Page opening hours text -->
@@ -649,8 +405,6 @@
 	<string name="day_off_today">Fermé aujourd\'hui</string>
 	<string name="day_off">Fermé</string>
 	<string name="today">Aujourd\'hui</string>
-	<string name="sunrise_to_sunset">Du lever au coucher du soleil</string>
-	<string name="sunset_to_sunrise">Du coucher au lever du soleil</string>
 	<string name="add_opening_hours">Ajouter les heures d\'ouverture</string>
 	<string name="edit_opening_hours">Modifier les heures d\'ouverture</string>
 	<string name="no_osm_account">Vous n\'avez pas de compte sur OpenStreetMap?</string>
@@ -660,29 +414,13 @@
 	<string name="login">Connexion</string>
 	<string name="password">Mot de passe</string>
 	<string name="forgot_password">Mot de passe oublié ?</string>
-	<!-- Forgot Password dialog title -->
-	<string name="restore_password">Réinitialiser le mot de passe</string>
-	<string name="enter_email_address_to_reset_password">Entrez l\'adresse email que vous avez utilisé lors de l\'inscription et nous vous ferons parvenir le lien pour renouveler votre mot de passe.</string>
-	<string name="reset_password">Réinitialiser le mot de passe</string>
-	<string name="username">Nom d\'utilisateur</string>
 	<string name="osm_account">Compte OSM</string>
 	<string name="logout">Déconnexion</string>
-	<string name="login_and_edit_map_motivation_message">Connectez-vous et modifiez les informations des objets présents sur la carte et nous allons les rendre disponibles pour des millions d\'autres utilisateurs. Rendons le monde meilleur ensemble.</string>
 	<!-- Information text: "Last upload 11.01.2016" -->
 	<string name="last_upload">Dernier téléchargement</string>
-	<!-- Motivates user to login/register, title above login buttons. -->
-	<string name="you_have_edited_your_first_object">Vous avez modifié votre premier objet!</string>
 	<string name="thank_you">Merci</string>
-	<string name="login_with_google">Connectez-vous avec Google</string>
-	<string name="login_with_openstreetmap">Connectez-vous sur www.openstreetmap.org</string>
 	<string name="edit_place">Modifier le lieu</string>
 	<string name="place_name">Nom du lieu</string>
-	<!-- title above languages list cells in the editor, below editable name text field. -->
-	<string name="other_languages">Autres langues</string>
-	<!-- small button to open list with names in different languages -->
-	<string name="show_more">Montrer plus</string>
-	<!-- small button to close list with names in different languages -->
-	<string name="show_less">Montrer moins</string>
 	<string name="add_language">Ajouter une langue</string>
 	<string name="street">Rue</string>
 	<!-- Editable House Number text field (in address block). -->
@@ -699,25 +437,16 @@
 	<string name="email_or_username">Email ou nom d\'utilisateur</string>
 	<string name="phone">Numéro de téléphone</string>
 	<string name="please_note">À noter</string>
-	<string name="common_no_wifi_dialog">Aucune connexion Wi-Fi. Voulez-vous continuer avec les données mobiles ?</string>
 	<string name="downloader_delete_map_dialog">Toutes les modifications de la carte seront supprimées avec elle.</string>
 	<string name="downloader_update_maps">Mettre à jour les cartes</string>
 	<string name="downloader_mwm_migration_dialog">Pour créer un itinéraire, vous devez mettre à jour toutes les cartes puis reprogrammer l\'itinéraire.</string>
 	<string name="downloader_search_field_hint">Trouver la carte</string>
-	<string name="migration_update_all_button">Mettre à jour toutes les cartes</string>
-	<string name="migration_delete_all_download_current_button">Téléchargez la carte actuelle et supprimez les anciennes</string>
 	<string name="migration_download_error_dialog">Erreur de téléchargement</string>
 	<string name="common_check_internet_connection_dialog">Veuillez vérifier vos paramètres et vous assurer que votre appareil est bien connecté à Internet.</string>
 	<string name="downloader_no_space_title">Espace insuffisant</string>
 	<string name="downloader_no_space_message">Veuillez supprimer les données inutiles</string>
-	<string name="editor_general_auth_error_dialog">Erreur générale de connexion.</string>
 	<string name="editor_login_error_dialog">Erreur de connexion.</string>
-	<string name="editor_login_failed_dialog">La connexion a échoué</string>
-	<string name="editor_username_error_dialog">Le nom d\'utilisateur est invalide</string>
-	<string name="editor_place_edited_dialog">Vous avez modifié un objet !</string>
-	<string name="editor_login_with_osm">Connexion avec OpenStreetMap</string>
 	<string name="editor_profile_changes">Modifications vérifiées</string>
-	<string name="editor_profile_unsent_changes">Non envoyé :</string>
 	<string name="editor_focus_map_on_location">Tirez la carte pour sélectionner la bonne position de l\'objet.</string>
 	<string name="editor_add_select_category">Sélectionner une catégorie</string>
 	<string name="editor_add_select_category_popular_subtitle">Populaire</string>
@@ -728,19 +457,14 @@
 	<string name="editor_edit_place_category_title">Catégorie</string>
 	<string name="detailed_problem_description">Description détaillée d\'un problème</string>
 	<string name="editor_report_problem_other_title">Un problème différent</string>
-	<string name="placepage_report_problem_button">Signaler un problème</string>
 	<string name="placepage_add_business_button">Ajouter une organisation</string>
 	<string name="whatsnew_editor_message_1">Ajoutez de nouveaux lieux sur la carte et modifiez les lieux existants directement depuis l\'appli.</string>
-	<string name="whatsnew_editor_message_2">* Organic Maps utilise les données de la communauté OpenStreetMap.</string>
 	<string name="dialog_incorrect_feature_position">Modifier l\'emplacement</string>
 	<string name="message_invalid_feature_position">Aucun objet ne peut être localisé ici</string>
 	<string name="login_to_make_edits_visible">Se connecter pour que d\'autres utilisateurs puissent voir les changements que vous avez effectués.</string>
-	<string name="no_migration_during_navigation">La mise à jour est interdite pendant la navigation.</string>
 	<!-- Error dialog no space -->
 	<string name="migration_no_space_message">Pour télécharger, vous avez besoin de plus d\'espace. Veuillez supprimer les données non nécessaires.</string>
 	<string name="editor_sharing_title">J\'ai amélioré les cartes de Organic Maps</string>
-	<string name="editor_comment_will_be_sent">Nous transmettrons votre commentaire aux cartographes.</string>
-	<string name="editor_unsupported_category_message">Vous avez ajouté un lieu appartenant à une catégorie que nous ne prenons pas encore en charge. Il apparaîtra sur la carte prochainement.</string>
 	<!-- Downloaded 10 **of** 20 <- it is that "of" -->
 	<string name="downloader_of">%1$d de %2$d</string>
 	<string name="download_over_mobile_header">Téléchargement avec une connexion réseau cellulaire ?</string>
@@ -758,15 +482,8 @@
 	<string name="editor_detailed_description">Vos modifications suggérées ont été envoyées à la communauté OpenStreetMap. Décrivez les détails qui ne peuvent pas être modifiés dans Organic Maps.</string>
 	<string name="editor_more_about_osm">En savoir plus sur OpenStreetMap</string>
 	<string name="editor_operator">Opérateur</string>
-	<string name="editor_tag_description">Entrer la société, l\'organisation ou l\'individu responsable des installations.</string>
-	<string name="editor_no_local_edits_title">Vous n\'avez pas de modifications locales</string>
-	<string name="editor_no_local_edits_description">Affiche le nombre de modifications suggérées dans la carte actuellement uniquement accessible sur votre périphérique.</string>
-	<string name="editor_send_to_osm">Envoyer à OSM</string>
-	<string name="editor_remove">Supprimer</string>
-	<string name="downloader_my_maps_title">Mes cartes</string>
 	<string name="downloader_no_downloaded_maps_title">Vous n\'avez téléchargé aucune carte</string>
 	<string name="downloader_no_downloaded_maps_message">Téléchargez des cartes pour rechercher l\'emplacement et naviguer hors ligne</string>
-	<string name="downloader_find_place_hint">Rechercher ville ou pays</string>
 	<!-- Error title that appears after certain time without location. -->
 	<string name="current_location_unknown_title">Continuer la détection de votre emplacement actuel ?</string>
 	<!-- Error that appears after certain time without location. -->
@@ -781,27 +498,10 @@
 	<string name="location_services_disabled_2">2. Appuyer sur Localisation</string>
 	<!-- iOS Dialog for the case when the location permission is not granted -->
 	<string name="location_services_disabled_3">3. Sélectionner tout en utilisant l\'app</string>
-	<string name="placepage_parking_surface">Surface</string>
-	<string name="placepage_parking_multistorey">Multi-niveaux</string>
-	<string name="placepage_parking_underground">Souterrain</string>
-	<string name="placepage_parking_rooftop">Toit</string>
-	<string name="placepage_parking_sheds">Hangars</string>
-	<string name="placepage_parking_carports">Abris auto</string>
-	<string name="placepage_parking_boxes">Box de garage</string>
-	<string name="placepage_parking_pay">Payer</string>
-	<string name="placepage_parking_free">Gratuit</string>
-	<string name="placepage_parking_interval">Période de paiement</string>
-	<string name="placepage_entrance_number">N°</string>
-	<string name="placepage_entrance_type">Entrée</string>
-	<string name="placepage_flat">app.</string>
-	<string name="placepage_open_24_7">24h/24 et 7j/7</string>
 	<string name="meter">m</string>
 	<string name="kilometer">km</string>
-	<string name="kilometers_per_hour">km/h</string>
 	<string name="mile">mi</string>
 	<string name="foot">pied</string>
-	<string name="miles_per_hour">mph</string>
-	<string name="day">j</string>
 	<string name="hour">h</string>
 	<string name="minute">min</string>
 	<string name="placepage_place_description">Description</string>
@@ -811,46 +511,30 @@
 	<string name="placepage_call_button">Appeler</string>
 	<string name="placepage_edit_bookmark_button">Éditer le signet</string>
 	<string name="placepage_bookmark_name_hint">Nom du signet</string>
-	<string name="placepage_personal_notes_hint">Remarques personnelles</string>
-	<string name="placepage_delete_bookmark_button">Supprimer signet</string>
 	<string name="editor_edits_sent_message">Vos modifications suggérées ont été envoyées</string>
 	<string name="editor_comment_hint">Commentaire…</string>
 	<string name="editor_reset_edits_message">Réinitialiser toutes les modifications locales ?</string>
 	<string name="editor_reset_edits_button">Réinitialiser</string>
 	<string name="editor_remove_place_message">Supprimer une place ajoutée ?</string>
 	<string name="editor_remove_place_button">Supprimer</string>
-	<string name="editor_status_sending">Envoyer…</string>
 	<string name="editor_place_doesnt_exist">La place n\'existe pas</string>
 	<string name="text_more_button">…Afficher la suite</string>
 	<!-- Phone number error message -->
 	<string name="error_enter_correct_phone">Saisissez un numéro de téléphone valide</string>
 	<string name="error_enter_correct_web">Saisir une adresse Internet valide</string>
 	<string name="error_enter_correct_email">Saisir un email valide</string>
-	<string name="error_enter_correct">Saisir une valeur correcte</string>
 	<string name="refresh">Mettre à jour</string>
-	<string name="last_update">Dernière mise à jour à %s</string>
 	<string name="placepage_add_place_button">Ajouter un lieu sur la carte</string>
 	<!-- Displayed when saving some edits to the map to warn against publishing personal data -->
 	<string name="editor_share_to_all_dialog_title">Souhaitez-vous l’envoyer à tous les utilisateurs ?</string>
 	<!-- iOS Dialog before publishing the modifications to the public map. -->
 	<string name="editor_share_to_all_dialog_message_1">Assurez-vous de n’avoir saisi aucunes données personnelles.</string>
 	<string name="editor_share_to_all_dialog_message_2">Nous vérifierons les changements. Si nous avons des questions quelles qu’elles soient, nous vous contacterons par courriel.</string>
-	<string name="navigation_overview_button">aperçu</string>
-	<string name="navigation_stop_button">stop</string>
-	<!-- Text on an empty bookmark page -->
-	<string name="bookmarks_empty_title">Enregistrez des signets</string>
-	<string name="bookmarks_empty_message_1">Tapez sur ★ pour enregistrer vos lieux préférés pour un accès rapide.</string>
-	<string name="bookmarks_empty_message_2">Importez des signets à partir d\'un email et du Web.</string>
-	<string name="bookmarks_empty_message_3">départ : %s</string>
-	<!-- Name of the group for booked hotels -->
-	<string name="bookmarks_group_name">Hôtels réservés</string>
-	<string name="place_page_button_read_descriprion">Lire</string>
 	<!-- iOS dialog for the case when recent track recording is on and the app comes back from background -->
 	<string name="recent_track_background_dialog_title">Souhaitez-vous désactiver l\'enregistrement de vos itinéraires récents ?</string>
 	<string name="off_recent_track_background_button">Désactiver</string>
 	<!-- For sharing via SMS and so on -->
 	<string name="sharing_call_action_look">Consultez</string>
-	<string name="continue_recent_track_background_button">Continuer</string>
 	<string name="recent_track_background_dialog_message">Organic Maps utilise votre géolocalisation en arrière-plan pour enregistrer vos itinéraires récents.</string>
 	<!-- Rate on Google Play (Android only) -->
 	<string name="rate_gp">Noter sur Google Play</string>
@@ -860,22 +544,11 @@
 	<string name="tell_friends_text">Salut! Installe Organic Maps!</string>
 	<!-- About short text (below logo) -->
 	<string name="about_description">Organic Maps est une application hors ligne essentielle pour les voyages. Organic Maps se base sur les données OpenStreetMap et permet de les modifier.</string>
-	<!-- Text in menu -->
-	<string name="blog">Blog</string>
 	<string name="general_settings">Paramètres généraux</string>
-	<string name="date">Date %d</string>
-	<!-- "Report a bug" -> "Generaal Feedback" -> "Something is not working" -->
-	<string name="something_is_not_working">Quelque chose ne fonctionne pas</string>
 	<!-- For the first routing -->
 	<string name="accept">Accepter</string>
-	<string name="accept_and_continue">Accepter et continuer</string>
 	<!-- For the first routing -->
 	<string name="decline">Refuser</string>
-	<string name="install_app">Installer</string>
-	<string name="search_no_results_title">Aucun résultat trouvé</string>
-	<string name="search_no_results_message">Essayez un terme de recherche plus général , effectuez un zoom arrière ou réinitialisez le filtre.</string>
-	<string name="search_no_results_expand_area_button">Zoom arrière</string>
-	<string name="search_no_results_reset_button">Réinitialiser le filtre</string>
 	<!-- noun -->
 	<string name="search_in_table">Liste</string>
 	<string name="mobile_data_dialog">Utiliser l\'Internet mobile pour afficher les informations détaillées?</string>
@@ -887,18 +560,13 @@
 	<string name="mobile_data_option_never">Ne jamais utiliser</string>
 	<string name="mobile_data_option_ask">Toujours demander</string>
 	<string name="traffic_update_maps_text">Pour afficher les données de circulation, les cartes doivent être actualisées.</string>
-	<string name="traffic_outdated">Les données de circulation ne sont pas actuelles.</string>
 	<string name="big_font">Augmenter la taille de police sur la carte</string>
 	<string name="traffic_update_app">Veuillez mettre à jour Organic Maps</string>
 	<!-- "traffic" as in road congestion -->
 	<string name="traffic_update_app_message">Pour afficher les données de circulation, l\'application doit être actualisée.</string>
 	<!-- "traffic" as in "road congestion" -->
 	<string name="traffic_data_unavailable">Les données de circulation ne sont pas disponibles</string>
-	<!-- Simplified colour scheme for traffic information, fewer colours are used to display traffic jams on the map. The string should be kept as short as possible -->
-	<string name="pref_traffic_simplified_colors_title">Couleurs circulation simplifiées</string>
 	<string name="enable_logging">Activer le journal</string>
-	<string name="offline_place_page_more_information">Connectez-vous à Internet pour obtenir plus d’informations sur ce lieu.</string>
-	<string name="failed_load_information">Impossible de charger les informations.</string>
 	<!-- Settings: "Send general feedback" button -->
 	<string name="feedback_general">Feedback général</string>
 	<string name="on">On</string>
@@ -912,57 +580,26 @@
 	<string name="routing_add_start_point">Ajouter un point de départ pour planifier un itinéraire</string>
 	<string name="routing_add_finish_point">Ajouter un point d\'arrivée pour planifier un itinéraire</string>
 	<string name="button_exit">Quitter</string>
-	<string name="settings_device_memory">Mémoire de l’appareil</string>
-	<string name="settings_card_memory">Mémoire carte</string>
-	<string name="settings_storage_available">%s disponible</string>
-	<string name="toast_location_permission_denied">Autorisation de localisation refusée à l\'application</string>
-	<string name="button_use">Utiliser</string>
 	<string name="planning_route_manage_route">Gérer l’itinéraire</string>
 	<string name="button_plan">Planifier</string>
-	<string name="button_add">Ajouter</string>
 	<string name="placepage_remove_stop">Supprimer</string>
 	<string name="planning_route_remove_title">Faire glisser ici pour supprimer</string>
-	<string name="dialog_change_start_point_message">Remplacer le point de départ par l’emplacement actuel ?</string>
-	<string name="button_replace">Remplacer</string>
 	<string name="placepage_add_stop">Ajouter un arrêt</string>
-	<string name="add_my_position">Ajouter ma position</string>
-	<string name="choose_start_point">Choisissez un point de départ</string>
-	<string name="choose_destination">Choisissez une destination</string>
 	<string name="preloader_viator_button">En savoir plus</string>
-	<string name="start_from_my_position">Commencer à partir de</string>
-	<string name="profile_authorization_title">Se connecter avec</string>
-	<string name="profile_authorization_message">Connexion facile sans identifiant ni mot de passe en quelques secondes</string>
 	<string name="profile_authorization_error">Oups, une erreur s\'est produite. Essayez de vous connecter à nouveau.</string>
-	<string name="service">Service</string>
-	<string name="atmosphere">Ambiance</string>
-	<string name="value_for_money">Rapport qualité/prix</string>
-	<string name="experience">Expérience</string>
-	<string name="assortment">Assortiment</string>
-	<string name="expertise">Expertise</string>
-	<string name="equipment">Équipement</string>
-	<string name="quality">Qualité</string>
 	<string name="dialog_error_storage_title">Problème d\'accès au stockage</string>
 	<string name="dialog_error_storage_message">Le stockage externe n\'est pas disponible. La carte SD a probablement été enlevée, endommagée ou le système est en lecture seule. Veuillez vérifier et nous contacter via support\@organicmaps.app</string>
 	<string name="setting_emulate_bad_storage">Émuler le mauvais stockage</string>
-	<string name="directions_finish">Destination</string>
-	<string name="directions_on_foot">Marcher %s</string>
 	<string name="core_entrance">Entrée</string>
-	<string name="coffee">Café</string>
-	<string name="cleanliness">Propreté</string>
-	<string name="crowdedness">Affluence</string>
 	<string name="error_enter_correct_name">Veuillez entrer un nom correct</string>
 	<string name="bookmarks_groups">Listes</string>
 	<string name="bookmarks_groups_hide_all">Tout masquer</string>
 	<string name="bookmarks_groups_show_all">Tout afficher</string>
-	<plurals name="bookmarks_places">
-	  <item quantity="other">%d signets</item>
-	</plurals>
 	<string name="bookmarks_create_new_group">Créer une nouvelle liste</string>
 	<string name="downloader_hide_screen">Masquer l’écran</string>
 	<string name="downloader_percent">%1$s (%2$s de %3$s)</string>
-	<string name="downloader_process">Téléchargement de %s...</string>
-	<string name="downloader_applying">Application de %s...</string>
-	<string name="dialog_message_transit_not_found_connection">Planifier un itinéraire dans un réseau de transport en commun</string>
+	<string name="downloader_process">Téléchargement de %s…</string>
+	<string name="downloader_applying">Application de %s…</string>
 	<string name="bookmarks_error_message_share_general">Impossible de partager en raison d\'une erreur d\'application</string>
 	<string name="bookmarks_error_title_share_empty">Erreur de partage</string>
 	<string name="bookmarks_error_message_share_empty">Impossible de partager une liste vide</string>
@@ -971,48 +608,22 @@
 	<string name="bookmarks_new_list_hint">Nouvelle liste</string>
 	<string name="bookmarks_error_title_list_name_already_taken">Ce nom est déjà pris</string>
 	<string name="bookmarks_error_message_list_name_already_taken">Merci de choisir un autre nom</string>
-	<string name="bookmarks_error_title_list_name_too_long">Ce nom est trop long</string>
-	<string name="bookmarks_error_message_list_name_too_long">Merci de choisir un autre nom</string>
-	<string name="please_wait">S\'il vous plaît, attendez...</string>
-	<string name="phone_number">Numéro de téléphone</string>
-	<string name="notification_unsent_reviews_title">Vous avez plusieurs avis non envoyés</string>
-	<string name="notification_unsent_reviews_message">Veuillez vous connecter pour partager des avis avec d\'autres voyageurs</string>
+	<string name="please_wait">S\'il vous plaît, attendez…</string>
 	<string name="profile">Profil OpenStreetMap</string>
 	<string name="place_page_search_similar_hotel">Rechercher des hôtels similaires</string>
 	<string name="bookmarks_detect_title">Nouveaux fichiers détectés</string>
 	<plurals name="bookmarks_detect_message">
-	  <item quantity="zero">%d fichier a été trouvé. Vous le verrez après la conversion.</item>
 	  <item quantity="one">%d fichier a été trouvé. Vous le verrez après la conversion.</item>
 	  <item quantity="other">%d fichiers ont été trouvés. Vous les verrez après la conversion.</item>
+	  <item quantity="zero">%d fichier a été trouvé. Vous le verrez après la conversion.</item>
 	</plurals>
 	<string name="button_convert">Convertir</string>
 	<string name="bookmarks_convert_error_title">Erreur</string>
 	<string name="bookmarks_convert_error_message">Certains fichiers n\'ont pas été convertis.</string>
-	<string name="converting">Conversion...</string>
-	<string name="wn_reinvented_bookmarks_title">Nous avons réinventé les signets!</string>
-	<string name="wn_reinvented_bookmarks_message">Vous pouvez sauvegarder des signets, créer des listes... C\'est incroyable...</string>
-	<string name="bookmarks_restore">Restaurer les favoris</string>
-	<string name="bookmarks_restore_process">Restaurer...</string>
 	<string name="bookmarks_restore_title">Restaurer cette version?</string>
-	<string name="bookmarks_restore_message">Vos marque-pages restaureront à partir de %1$s (%2$s)</string>
-	<string name="bookmarks_restore_empty_title">Vous n\'avez pas de sauvegarde</string>
-	<string name="bookmarks_restore_empty_message">Le serveur n\'a pas trouvé de sauvegardes effectuées précédemment</string>
 	<string name="common_check_internet_connection_dialog_title">Pas de connexion Internet</string>
-	<string name="error_server_title">Erreur du serveur</string>
-	<string name="error_server_message">Une erreur s\'est produite sur le serveur. Veuillez réessayer plus tard.</string>
 	<string name="error_system_message">Une erreur inconnue est survenue</string>
 	<string name="restore">Restaurer</string>
-	<string name="bookmarks_page_downloaded">Téléchargé</string>
-	<string name="bookmarks_page_my">Mes</string>
-	<string name="routes_and_bookmarks">Itinéraires et favoris</string>
-	<string name="bookmarks_webview_success_toast">Favoris enregistrés avec succès</string>
-	<string name="cached_bookmarks_placeholder_title">Télécharger de nouveaux lieux</string>
-	<string name="cached_bookmarks_placeholder_subtitle">Appuyez sur le bouton pour télécharger des milliers de lieux et d\'itinéraires intéressants créés par les utilisateurs de Organic Maps. Vous aurez besoin d\'une connexion Internet.</string>
-	<string name="downloader_download_routers">Télécharger les favoris</string>
-	<string name="bookmarks_groups_cached">Listes téléchargées</string>
-	<plurals name="bookmarks_objects">
-	  <item quantity="other">objet %s</item>
-	</plurals>
 	<plurals name="objects">
 	  <item quantity="other">lieu %d</item>
 	</plurals>
@@ -1025,66 +636,33 @@
 	<string name="subtittle_opt_out">Paramètres de suivi</string>
 	<string name="crash_reports">Rapport d\'accident</string>
 	<string name="crash_reports_description">Nous pouvons utiliser vos données pour améliorer l\'expérience de Organic Maps. Les modifications prendront effet après le redémarrage de l\'application.</string>
-	<string name="opt_out_help_ios_1">Votre appareil mobile peut fournir un paramètre «Limiter le suivi des annonces» ou «Désactiver la publicité ciblée par centres d\'intérêt».</string>
-	<string name="opt_out_help_ios_2">iOS 9 ou plus récent</string>
-	<string name="opt_out_help_ios_3">Accédez à vos paramètres → Confidentialité → Publicité → Activer le paramètre «Limiter le suivi des annonces»</string>
-	<string name="opt_out_help_android">Votre appareil mobile peut proposer un paramètre «Limiter le suivi des annonces\"\" ou «Désactiver la publicité ciblée par centres d\'intérêt».\n\n Pour Android et les services Google Play version 4.0 et ultérieure :\n Réglages → Google → Annonces → Désactiver la personnalisation des annonces\ni\n Paramètres → Google → Compte Google → Informations personnelles et confidentialité → Paramètres des annonces → Personnalisation des annonces</string>
 	<string name="privacy_policy">Politique de confidentialité</string>
 	<string name="terms_of_use">Conditions d\'utilisation</string>
-	<string name="backup_notification_failed">La sauvegarde de vos favoris a été suspendue. Connectez-vous pour la réactiver.</string>
 	<string name="button_layer_traffic">Trafic</string>
 	<string name="button_layer_subway">Métro</string>
 	<string name="layers_title">Couches de carte</string>
-	<string name="layers_message">Utiliser des couches de carte pour afficher le trafic, la carte de métro et d\'autres informations utiles</string>
-	<string name="button_layer_got_it">J\'ai compris</string>
 	<string name="subway_data_unavailable">La carte du métro n\'est pas disponible</string>
 	<string name="bookmarks_empty_list_title">Cette liste est vide</string>
 	<string name="bookmarks_empty_list_message">Pour ajouter un signet, appuyez sur un lieu sur la carte, puis appuyez sur l\'icône étoile</string>
 	<string name="category_desc_more">…plus</string>
 	<string name="title_error_downloading_bookmarks">Une erreur est survenue</string>
-	<string name="subtitle_error_downloading_bookmarks">Les signets n\'ont pas été téléchargés</string>
-	<string name="error_already_downloaded">Cette liste a déjà été téléchargée</string>
 	<string name="popular_place">Populaire</string>
-	<string name="download_routes">Télécharger itinéraires</string>
-	<string name="bookmarks_downloaded_title">Signets téléchargés avec succès</string>
-	<string name="bookmarks_downloaded_subtitle">Appuyez sur \'Rechercher sur la carte\' pour explorer les endroits sur la liste</string>
-	<string name="why_support">Pourquoi soutenir Organic Maps ?</string>
-	<string name="why_support_item2">Vous nous aidez à améliorer Organic Maps</string>
-	<string name="why_support_item3">Vous nous aidez à améliorer les cartes ouvertes OpenStreetMap.org</string>
-	<string name="channels_map_update">Mises à jour de la carte</string>
-	<string name="server_unavailable_title">Le serveur n\'est pas disponible</string>
-	<string name="sharing_options">Options de partage</string>
 	<string name="export_file">Fichier d\'exportation</string>
 	<string name="list_settings">Paramètres liste</string>
 	<string name="delete_list">Supprimer liste</string>
-	<string name="hide_from_map">Masquer de la carte</string>
 	<string name="public_access">Accès publique</string>
 	<string name="limited_access">Accès limité</string>
 	<string name="bookmark_category_name">Catégorie</string>
 	<string name="bookmark_category_description_hint">Tapez une description (texte ou html)</string>
 	<string name="not_shared">Personnel</string>
-	<string name="direct_link_progress_text">Télécharger votre fichier…</string>
-	<string name="direct_link_success">Le lien a été créé</string>
-	<string name="send_a_link_btn">Envoyez moi un lien</string>
-	<string name="upload_error_toast">Une erreur s\'est produite lors du téléchargement de votre fichier</string>
 	<string name="tags_loading_error_subtitle">Une erreur s\'est produite lors du chargement des tags, veuillez réessayer</string>
-	<string name="unable_upload_errorr_title">Échec du téléchargement du fichier</string>
-	<string name="unable_upload_error_subtitle_edited">Ce fichier a été édité via l\'application Web</string>
-	<string name="unable_upload_error_subtitle_broken">Ce fichier est endommagé et n\'a pas pu être téléchargé. S\'il vous plaît télécharger un autre fichier.</string>
-	<string name="contact">Contactez</string>
-	<string name="download_button">Téléchargez</string>
 	<string name="speedcams_alert_title">Vitesse de caméras</string>
-	<string name="speedcams_alert_subtitle">Prévenir concernant les limites de vitesse</string>
 	<string name="speedcam_option_auto">Auto</string>
 	<string name="speedcam_option_always">Toujours</string>
 	<string name="speedcam_option_never">Jamais</string>
-	<string name="bookmark_description_title">Description du signet</string>
 	<string name="place_description_title">Description d\'endroit</string>
 	<!-- this text will be shown in application notification preferences opposite checkbox which enable/disable downloader notifications. Devices on Android 8+ are affected. -->
 	<string name="notification_channel_downloader">Téléchargeur carte</string>
-	<string name="share_bookmarks_email_body_link">Bonjour !\n\nVoici le lien où vous pouvez télécharger vos signets : %s. Ouvrez la liste via Organic Maps et profitez de votre voyage !\n\nInstaller l\'application : https://omaps.app/get?kmz</string>
-	<string name="warning_speedcams_title">Navigator vous avertira des caméras lorsque vous dépassez la limite de vitesse de %d km/h</string>
-	<string name="warning_speedcams_subtitle">Veuillez respecter les réglementations de conduite du pays dans lequel vous vous rendez.</string>
 	<string name="speedcams_notice_message">Auto - Alerte sur les radars en cas de risque de dépassement de la limite de vitesse\nToujours - Toujours avertir des radars\nJamais - Jamais avertir à propos des radars</string>
 	<string name="power_managment_title">Mode économie d\'énergie</string>
 	<string name="power_managment_description">Si le mode d\'économie d\'énergie est activé, l\'application désactive les fonctions consommant de l\'énergie en fonction de la charge actuelle du téléphone</string>
@@ -1092,14 +670,7 @@
 	<string name="power_managment_setting_auto">Automatique</string>
 	<string name="power_managment_setting_manual_max">Économie d\'énergie maximale</string>
 	<string name="enable_logging_warning_message">Cette option est activée pour l\'identification des actions à des fins de diagnostic. Cela aide l’équipe à identifier les problèmes liés à l’application. Activez cette option uniquement à la demande du support Organic Maps.</string>
-	<string name="html_error_upload_message_try_again">Vérifiez l\'accès au réseau et réessayez</string>
-	<string name="html_error_upload_title_try_again">Il n\'y a pas de connexion internet</string>
-	<string name="notification_leave_review_v2_android_short_title">Laissez vos commentaire et aidez les voyageurs !</string>
-	<string name="notifications_illegal_alert_disable_button">Désactiver les notifications</string>
 	<string name="access_rules_author_only">Édition en ligne</string>
-	<string name="privacy_settings_menu">Paramètres de confidentialité</string>
-	<string name="unable_upadate_error_title">Impossible de mettre à jour l\'itinéraire</string>
-	<string name="unable_upadate_error_message">Il y a eu des erreurs pendant la mise à jour. Veuilelz revérifiez les modifications et réessayez</string>
 	<string name="driving_options_title">Réglages de détour</string>
 	<string name="driving_options_subheader">Éviter sur tous les itinéraires</string>
 	<string name="avoid_tolls">Routes à péage</string>
@@ -1110,52 +681,14 @@
 	<string name="unable_to_calc_alert_subtitle">Malheureusement, nous n\'avons pas pu créer l\'itinéraire avec les options sélectionnées. Modifiez les paramètres et réessayez</string>
 	<string name="define_to_avoid_btn">Configurer la route de détour</string>
 	<string name="change_driving_options_btn">Paramètres de détour activés</string>
-	<string name="toll_road">Route à péage</string>
-	<string name="unpaved_road">Routes non revêtues</string>
-	<string name="ferry_crossing">Passage d\'un cours d\'eau</string>
-	<string name="operated_by">Géré par \"%s\"</string>
 	<string name="avoid_toll_roads_placepage">Éviter les routes à péage</string>
 	<string name="avoid_unpaved_roads_placepage">Éviter les routes non revêtues</string>
 	<string name="avoid_ferry_crossing_placepage">Éviter les passages d\'un cours d\'eau</string>
-	<string name="type.cuisine.uzbek">Cuisine ouzbek</string>
-	<string name="trip_start">On y va</string>
-	<string name="pick_destination">Point d\'arrivée</string>
-	<string name="follow_my_position">Préciser</string>
-	<string name="search_results">Résultats de recherche</string>
-	<string name="then_turn">Ensuite</string>
-	<string name="redirect_route_alert">Voulez-vous reconstruire l\'itinéraire ?</string>
-	<string name="redirect_route_yes">Oui</string>
-	<string name="redirect_route_no">Non</string>
-	<string name="trip_finished">Vous êtes arrivé !</string>
-	<string name="keyboard_availability_alert">Clavier non disponible en conduisant</string>
-	<string name="dialog_routing_change_start_carplay">Impossible de créer un itinéraire à partir de lieux actuel</string>
-	<string name="dialog_routing_change_end_carplay">Impossible de créer un itinéraire jusqu\'au point final. Choisissez un autre</string>
-	<string name="dialog_routing_check_gps_carplay">Pas de signal GPS. Passez sur le site ouvert</string>
-	<string name="dialog_routing_unable_locate_route_carplay">Impossible de calculer l\'itinéraire. Sélectionnez les autres points d\'itinéraire</string>
-	<string name="dialog_routing_download_files_carplay">Pour créer la route, téléchargez les cartes sur votre appareil</string>
-	<string name="dialog_routing_system_error_carplay">Une erreur est survenue. Redémarrez l\'application</string>
-	<string name="dialog_routing_rebuild_from_current_location_carplay">L\'itinéraire sera reconstruit à partir de votre position actuelle</string>
-	<string name="dialog_routing_rebuild_for_vehicle_carplay">L\'itinéraire sera changé en mode Voiture</string>
 	<string name="ok">Ok</string>
-	<string name="avoid_unpaved_carplay_1">Route de ter</string>
-	<string name="avoid_unpaved_carplay_2">Route de terre</string>
-	<string name="avoid_ferry_carplay_1">Sans navires</string>
-	<string name="avoid_ferry_carplay_2">Sans navires</string>
-	<string name="avoid_tolls_carplay_1">Sans péage</string>
-	<string name="avoid_tolls_carplay_2">Sans péage</string>
-	<string name="speedcams_alert_title_carplay_1">Caméras</string>
-	<string name="speedcams_alert_title_carplay_2">Info Caméras</string>
-	<string name="download_map_carplay">Téléchargez des cartes dans l\'application Organic Maps sur votre appareil</string>
-	<string name="carplay_roundabout_exit">%s sortie</string>
 	<!-- max. 10 symbols, both iOS and Android -->
 	<string name="sort">Trier…</string>
 	<!-- Android, title, max 20-22 symbols -->
 	<string name="sort_bookmarks">Trier les signets</string>
-	<!-- iOS -->
-	<string name="sort_default">Trier par défaut</string>
-	<string name="sort_type">Trier par type</string>
-	<string name="sort_distance">Trier par distance</string>
-	<string name="sort_date">Classer pa date</string>
 	<!-- Android -->
 	<string name="by_default">Par défaut</string>
 	<!-- Android -->
@@ -1164,65 +697,23 @@
 	<string name="by_distance">Par distance</string>
 	<!-- Android -->
 	<string name="by_date">Par date</string>
-	<string name="week_ago_sorttype">Il y a une semaine</string>
-	<string name="month_ago_sorttype">Il y a un mois</string>
-	<string name="moremonth_ago_sorttype">Il y a plus d\'un mois</string>
-	<string name="moreyear_ago_sorttype">Il y a plus d\'un an</string>
-	<string name="near_me_sorttype">Près de moi</string>
-	<string name="others_sorttype">Autres</string>
-	<string name="food_places">Aliments</string>
-	<string name="tourist_places">Choses à voir</string>
-	<string name="museums">Musées</string>
-	<string name="parks">Parcs</string>
-	<string name="swim_places">Natation</string>
-	<string name="mountains">Montagnes</string>
-	<string name="animals">Animaux</string>
-	<string name="hotels">Hotels</string>
-	<string name="buildings">Batiments</string>
-	<string name="money">Argent</string>
-	<string name="shops">Magasins</string>
-	<string name="parkings">Parkings</string>
-	<string name="fuel_places">Stations d\'essence</string>
-	<string name="water">Eau</string>
-	<string name="medicine">Médicament</string>
 	<string name="search_in_the_list">Chercher dans la liste</string>
-	<string name="view_on_map_bookmarks">Sur plan</string>
-	<string name="more_bookmarks">Plus…</string>
-	<string name="no_items_found">Aucun article trouvé</string>
-	<!-- Android, max 18 symbols -->
-	<string name="bookmarks_edit_list">Modifier la liste</string>
-	<!-- Android, max 18 symbols -->
-	<string name="bookmarks_delete_list">Supprimer la liste</string>
-	<string name="religious_places">Lieux saints</string>
 	<string name="select_list">Sélectionner une liste</string>
 	<string name="transit_not_found">La navigation en métro n\'est pas encore disponible dans la région</string>
 	<string name="dialog_pedestrian_route_is_long_header">Itinéraire de métro non trouvé</string>
 	<string name="dialog_pedestrian_route_is_long_message">Choisissez le point de départ ou d\'arrivée de l\'itinéraire le plus proche de la station de métro</string>
-	<!-- Failed planning SUBWAY route message in navigation view -->
-	<string name="routing_planning_error_subway_special">Erreur dans le tracé de l\'itinéraire du métro</string>
 	<string name="button_layer_isolines">Terrain</string>
-	<string name="tips_map_layers_title_countour">Lignes d\'altitude hors-ligne dans Organic Maps !</string>
-	<string name="tips_map_layers_message_countour">Les lignes d\'altitude vous aideront à planifier votre voyage à la campagne sans vous perdre dans les champs</string>
 	<string name="isolines_activation_error_dialog">Pour utiliser les lignes d\'altitude, mettez à jour ou téléchargez la carte de l\'endroit désiré</string>
 	<string name="isolines_location_error_dialog">Les lignes d\'élévation ne sont pas encore disponibles dans cette région</string>
 	<string name="elevation_profile_diff_level">Niveau de difficulté</string>
-	<string name="elevation_profile_diff_level_easy">Faible</string>
-	<string name="elevation_profile_diff_level_moderate">Moyen</string>
-	<string name="elevation_profile_diff_level_hard">Haut</string>
 	<string name="elevation_profile_ascent">Montée</string>
 	<string name="elevation_profile_descent">Descente</string>
 	<string name="elevation_profile_minaltitude">Hauteur minimale</string>
 	<string name="elevation_profile_maxaltitude">Hauteur maximale</string>
-	<string name="elevation_profile_m">m</string>
 	<string name="elevation_profile_difficulty">Difficulté</string>
 	<string name="elevation_profile_distance">Russe :</string>
-	<string name="elevation_profile_km">km</string>
 	<string name="elevation_profile_time">Temps:</string>
-	<string name="elevation_profile_hours">h</string>
-	<string name="elevation_profile_minutes">mn</string>
 	<string name="isolines_toast_zooms_1_10">Zoomez pour voir les courbes de niveaux</string>
-	<string name="downloader_updating_ios">Misе à jour</string>
-	<string name="downloader_loading_ios">Téléchargement</string>
 	<string name="key_information_title">Informations clés</string>
 	<string name="enable_screen_sleep">Autoriser l\'écran à dormir</string>
 	<!-- Description in preferences -->

--- a/android/res/values-hu/strings.xml
+++ b/android/res/values-hu/strings.xml
@@ -12,8 +12,6 @@
 	<string name="cancel_download">Letöltés megszakítása</string>
 	<!-- Button which deletes downloaded country -->
 	<string name="delete">Törlés</string>
-	<!-- Button "do not interrupt download" if user touched actively downloading country -->
-	<string name="do_nothing">Folytatás</string>
 	<string name="download_maps">Térképek letöltése</string>
 	<!-- Settings/Downloader - info for country when download fails -->
 	<string name="download_has_failed">Letöltés sikertelen. Kérjük próbálja újra!</string>
@@ -31,45 +29,31 @@
 	<string name="core_my_position">Saját helyzet</string>
 	<!-- Update maps later/Buy pro version later button text -->
 	<string name="later">Később</string>
-	<!-- Don't show some dialog any more -->
-	<string name="never">Soha</string>
 	<!-- View and button titles for accessibility -->
 	<string name="search">Keresés</string>
 	<!-- Search box placeholder text -->
 	<string name="search_map">Keresés a térképen</string>
-	<!-- Settings/Downloader - info for not downloaded country -->
-	<string name="touch_to_download">Érintse meg letöltéshez</string>
 	<!-- Settings/Downloader - 3G download warning dialog confirm button -->
 	<string name="use_cellular_data">Igen</string>
 	<!-- Location services are disabled by user alert - message -->
 	<string name="location_is_disabled_long_text">Ezen az eszközön jelenleg minden helyzetmeghatározó szolgáltatás ki van kapcsolva. Kérjük kapcsolja be ezeket a Beállítások között.</string>
-	<!-- Location Services are not available on the device alert - message -->
-	<string name="device_doesnot_support_location_services">Az eszköz nem támogatja a helyzetmeghatározó szolgáltatásokat</string>
 	<!-- View and button titles for accessibility -->
 	<string name="zoom_to_country">Megjelenítés a térképen</string>
-	<!-- Button text for the button at the center of the screen when the country is not downloaded -->
-	<string name="country_status_download">Térkép letöltése\n(^ ^)</string>
 	<!-- Button text for the button at the center of the screen when the country is not downloaded and the size should not be shown -->
 	<string name="country_status_download_without_size">Térkép letöltése</string>
-	<!-- Button text for the button at the center of the screen when the country is not downloaded -->
-	<string name="country_status_download_without_routing">Térkép letöltése\nútvonal nélkül (^ ^)</string>
 	<!-- Message to display at the center of the screen when the country download has failed -->
 	<string name="country_status_download_failed">Letöltése sikertelen</string>
 	<!-- Button text for the button under the country_status_download_failed message -->
 	<string name="try_again">Újrapróbálkozás</string>
 	<string name="about_menu_title">A Organic Maps programról</string>
-	<string name="downloaded_touch_to_delete">Letöltve (%s), érintse meg törléshez</string>
 	<string name="connection_settings">Kapcsolat beállítások</string>
-	<string name="download_mb_or_kb">Letöltés %s</string>
 	<string name="close">Bezár</string>
 	<string name="unsupported_phone">Hardware-s gyorsítású OpenGL szükséges. Sajnos az Ön eszköze nem támogatott.</string>
 	<string name="download">Letöltés</string>
-	<string name="external_storage_is_not_available">Nem található téképeket tartalmazó SD kártya / USB tároló</string>
 	<string name="disconnect_usb_cable">Kérjük bontsa az USB kapcsolatot vagy helyezzen be memóriakártyát a Organic Maps használatához</string>
 	<string name="not_enough_free_space_on_sdcard">Kérjük szabadítson fel helyet az SD kártyán / USB tárolón az alkalmazás használatához!</string>
 	<string name="not_enough_memory">Nincs elegendő memória az alkalmazás futtatásához</string>
 	<string name="download_resources">Első használat előtt letöltjük a világtérképet.\n%s tárolóhely szükséges.</string>
-	<string name="getting_position">Aktuális pozíció meghatározása…</string>
 	<string name="download_resources_continue">Térképhez ugrás</string>
 	<string name="downloading_country_can_proceed">%s letöltése. Mos továbbléphet\na térképhez.</string>
 	<string name="download_country_ask">Letöltsem %s-t?</string>
@@ -82,30 +66,20 @@
 	<string name="download_country_failed">%s letöltése sikertelen</string>
 	<!-- Add New Bookmark Set dialog title -->
 	<string name="add_new_set">Új csoport létrehozása</string>
-	<!-- Place Page - Add To Bookmarks button -->
-	<string name="add_to_bookmarks">Könyvjelzőkhöz hozzáadás</string>
 	<!-- Bookmark Color dialog title -->
 	<string name="bookmark_color">Könyvjelző színe</string>
 	<!-- Add Bookmark Set dialog - hint when set name is empty -->
 	<string name="bookmark_set_name">Könyvjelzőcsoport neve</string>
-	<!-- Bookmark Sets dialog title -->
-	<string name="bookmark_sets">Könyvjelzőcsoportok</string>
 	<!-- Bookmarks - dialog title -->
 	<string name="bookmarks">Könyvjelzők</string>
-	<!-- Add bookmark dialog - bookmark color -->
-	<string name="color">Szín</string>
 	<!-- Default bookmarks set name -->
 	<string name="core_my_places">Saját helyeim</string>
 	<!-- Add bookmark dialog - bookmark name -->
 	<string name="name">Név</string>
 	<!-- Editor title above street and house number -->
 	<string name="address">Cím</string>
-	<!-- Place Page - Remove Pin button -->
-	<string name="remove_pin">Jelző törlése</string>
 	<!-- Add bookmark dialog - bookmark set, Bookmarks dialog - Bookmark set cell -->
 	<string name="set">Csoport</string>
-	<!-- Text hint in Bookmarks dialog when no any bookmarks are added -->
-	<string name="bookmarks_usage_hint">Nincsenek megjelölt helyeid.\nHely megjelöléséhez koppints a térkép bármelyik pontjára.\nSzintén más forrásokból származó könyvjelzőket is beolvashat a Organic Maps programba. Nyisson meg KML/KMZ fájlt egy levélből, Dropbox-ból vagy internetről.</string>
 	<!-- Settings button in system menu -->
 	<string name="settings">Beállítások</string>
 	<!-- Header of settings activity where user defines storage path -->
@@ -116,20 +90,10 @@
 	<string name="move_maps">Áthelyezzük a térképeket?</string>
 	<!-- Ask to wait user several minutes (some long process in modal dialog). -->
 	<string name="wait_several_minutes">Ez több percig is eltarthat.\nKérjük várjon…</string>
-	<!-- Show bookmarks from this category on a map or not -->
-	<string name="visible">látható</string>
-	<!-- Toast which is displayed when GPS has been deactivated -->
-	<string name="gps_is_disabled_long_text">GPS kikapcsolva. Kérjük kapcsolja be a Beállítások között.</string>
 	<!-- Measurement units title in settings activity -->
 	<string name="measurement_units">Mértékegységek</string>
 	<!-- Detailed description of Measurement Units settings button -->
 	<string name="measurement_units_summary">Válasszon kilométer és mérföld között</string>
-	<!-- Do search in all sources -->
-	<string name="search_mode_all">Mindenütt</string>
-	<!-- Do search near my position only -->
-	<string name="search_mode_nearme">A közelben</string>
-	<!-- Do search in current viewport only -->
-	<string name="search_mode_viewport">A képernyőn</string>
 	<!-- Search category for cafes, bars, restaurants -->
 	<string name="eat">Hol lehet enni valamit</string>
 	<!-- Search category for grocery stores -->
@@ -166,12 +130,8 @@
 	<string name="post">Posta</string>
 	<!-- Search category -->
 	<string name="police">Rendőrség</string>
-	<!-- String in search result list, when nothing found -->
-	<string name="no_search_results_found">Nincs keresési találat</string>
 	<!-- Notes field in Bookmarks view -->
 	<string name="description">Jegyzetek</string>
-	<!-- Button text -->
-	<string name="share_by_email">Megosztás email-en</string>
 	<!-- Email Subject when sharing bookmarks category -->
 	<string name="share_bookmarks_email_subject">Egy Organic Maps könyvjelzőt osztottak meg Önnel</string>
 	<!-- message title of loading file -->
@@ -184,20 +144,10 @@
 	<string name="edit">Szerkeszt</string>
 	<!-- Warning message when doing search around current position -->
 	<string name="unknown_current_position">Még nem határoztuk meg az aktuális helyzetét</string>
-	<!-- Warning message when location country isn't downloaded during search (see also download_location_map_proposal). -->
-	<string name="download_location_country">Töltse le az aktuális helyzet országát (%s)</string>
-	<!-- Warning message when viewport country isn't downloaded during search -->
-	<string name="download_viewport_country_to_search">Töltse le a keresés országát (%s)</string>
 	<!-- Alert message that we can't run Map Storage settings due to some reasons. -->
 	<string name="cant_change_this_setting">Sajnáljuk, a térképek tárolása jelenleg ki van kapcsolva.</string>
 	<!-- Alert message that downloading is in progress. -->
 	<string name="downloading_is_active">Országletöltés folyamatban.</string>
-	<!-- Message that will be shown in alert view, when we ask user to leave review on App Store -->
-	<string name="appStore_message">Reméljük élvezi a Organic Maps használatát. Ha igen, kérjük írjon ajánlást az App Store-ban! Kevesebb mint egy perc, és valóban segít nekünk. Köszönjük!</string>
-	<!-- No, thanks -->
-	<string name="no_thanks">Köszönöm, nem</string>
-	<!-- Share one specific bookmark using SMS, %1$@ contains om:// and %2$@ https://omaps.app link. @NOTE non-ascii symbols in the link will result in max 70 characters SMS instead of 140. -->
-	<string name="bookmark_share_sms">Nézd meg a Organic Maps jelzőt! %1$s vagy %2$s A program letöltése: https://omaps.app/get</string>
 	<!-- Share my position using SMS, %1$@ contains om:// and %2$@ https://omaps.app link WITHOUT NAME. @NOTE non-ascii symbols in the link will result in max 70 characters SMS instead of 140. -->
 	<string name="my_position_share_sms">Nézd meg a Organic Maps helyzetemet! %1$s vagy %2$s A program letöltése: https://omaps.app/get</string>
 	<!-- Subject for emailed bookmark -->
@@ -206,30 +156,16 @@
 	<string name="my_position_share_email_subject">Nézze meg a helyzetemet a Organic Maps térképen!</string>
 	<!-- Share my position using EMail, %1$@ is om:// and %2$@ is https://omaps.app link WITHOUT NAME -->
 	<string name="my_position_share_email">Üdvözlöm!\n\nJelenleg itt vagyok: %1$s Kattintson erre a hivatkozásra %2$s vagy erre %3$s, hogy lássa a helyet a térképen.\n\nKöszönöm.</string>
-	<!-- Android share by Message/SMS button text (including SMS) -->
-	<string name="share_by_message">Megosztás üzenetben</string>
 	<!-- Share button text which opens menu with more buttons, like Message, EMail, Facebook etc. -->
 	<string name="share">Megosztás</string>
-	<!-- iOS share by Message button text (including SMS) -->
-	<string name="message">Üzenet</string>
 	<!-- Share by email button text, also used in editor. -->
 	<string name="email">Email</string>
-	<!-- Copy Link -->
-	<string name="copy_link">Hivatkozás másolása</string>
-	<!-- Text for the button that returns to caller application -->
-	<string name="more_info">Mutasson több adatot</string>
 	<!-- Text for message when used successfully copied something -->
 	<string name="copied_to_clipboard">A vágólapra másolva: %1$s</string>
 	<!-- place preview title -->
 	<string name="info">Info</string>
 	<!-- Used for bookmark editing -->
 	<string name="done">Kész</string>
-	<!-- Summary for preferences in MWM -->
-	<string name="yopme_pref_summary">Válassza ki a hátoldali képernyő-beállításokat</string>
-	<!-- Title for yopme preferences in MWM -->
-	<string name="yopme_pref_title">Hátoldali képernyő-beállítások</string>
-	<!-- Hint for upper-right icon p2b -->
-	<string name="show_on_backscreen">Mutassa a vissza képernyőn</string>
 	<!-- Prints version number in About dialog -->
 	<string name="version">Verzió: %s</string>
 	<!-- Confirmation in downloading countries dialog -->
@@ -239,11 +175,6 @@
 	<!-- Length of track in cell that describes route -->
 	<string name="length">Hossz</string>
 	<string name="share_my_location">Helyzetem megosztása</string>
-	<string name="menu_search">Keresés</string>
-	<!-- Settings screen: "Map" category title -->
-	<string name="prefs_group_map">Térkép</string>
-	<!-- Settings screen: "Miscellaneous" category title -->
-	<string name="prefs_group_misc">Egyéb</string>
 	<string name="prefs_group_route">Navigáció</string>
 	<string name="pref_zoom_title">Nagyítás/kicsinyítés gombok</string>
 	<string name="pref_zoom_summary">Mutassa a kijelzőn</string>
@@ -259,8 +190,6 @@
 	<string name="pref_map_3d_title">Távlati kép</string>
 	<!-- Settings «Map» category: «3D buildings» title -->
 	<string name="pref_map_3d_buildings_title">3D-s épületek</string>
-	<!-- Settings «Map» category: «3D buildings» summary -->
-	<string name="pref_map_3d_buildings_subtitle">Akkumulátor élettartamára hat</string>
 	<!-- Settings «Route» category: «Tts enabled» title -->
 	<string name="pref_tts_enable_title">Hangutasítások</string>
 	<!-- Settings «Route» category: «Tts language» title -->
@@ -269,7 +198,6 @@
 	<string name="pref_tts_unavailable">Nem áll rendelkezésre</string>
 	<!-- Title for "Other" section in TTS settings. -->
 	<string name="pref_tts_other_section_title">Egyéb</string>
-	<string name="pref_tts_how_to_set_up_voice">Így állítsd be a hangot</string>
 	<!-- Settings «Map» category: «Record track» title -->
 	<string name="pref_track_record_title">Legutolsó útvonal</string>
 	<string name="pref_map_auto_zoom">Auto-zoom</string>
@@ -280,46 +208,11 @@
 	<string name="duration_12_hours">12 óra</string>
 	<string name="duration_1_day">1 nap</string>
 	<string name="recent_track_help_text">Ez lehetővé teszi a bejárt útvonal rögzítését és megtekintését a térképen bizonyos időre. Kérjük, vegye figyelembe, hogy ezen funkció aktiválásával megnöveli az akkumulátor használatát. Az útvonal automatikusan törlődik a térképről az időtartam lejártával.</string>
-	<string name="pref_track_ios_caption">A legutolsó útvonal megmutatja, hogy milyen útvonalon haladtál.</string>
-	<string name="pref_track_ios_subcaption">Válaszd ki az útvonalak elmentésének időtartamát!</string>
-	<string name="placepage_distance">Távolság</string>
-	<string name="placepage_coordinates">Koordináták</string>
-	<string name="placepage_unsorted">Osztályozatlan</string>
 	<string name="search_show_on_map">Megtekintés a térképen</string>
-	<!-- Used to warn user when fixing KitKat issue -->
-	<string name="bookmark_move_fail">A könyvjelzőit át kell helyeznünk a belső memóriába, azonban ehhez nincs elegendő szabad tárhely. Kérjük, szabadítson fel lemezterületet, ellenkező esetben a könyvjelzői nem lesznek elérhetőek.</string>
-	<!-- Used in More Apps menu -->
-	<string name="free">Ingyenes</string>
-	<!-- Used in More Apps menu -->
-	<string name="buy">Megvásárlás</string>
-	<!-- 1st search button-like result -->
-	<string name="search_on_map">Keresés a térképen</string>
-	<!-- toast with an error -->
-	<string name="no_route_found">Nem található útvonal</string>
-	<!-- route title -->
-	<string name="route">Útvonal</string>
-	<!-- category title -->
-	<string name="routes">Útvonalak</string>
-	<!-- text of notification -->
-	<string name="download_map_notification">Töltsd le annak a helynek a térképét, ahol most vagy</string>
-	<!-- text of notification -->
-	<string name="pro_version_is_free_today">A teljes verzió Organic Maps ma ingyenes! Töltsd le most és meséld el barátaidnak.</string>
-	<!-- Dialog for transferring maps from lite to pro. -->
-	<string name="move_lite_maps_to_pro">Letöltött térképeidet áthelyezzük a Organic Maps Lite-ból a Organic Maps-be. Ez eltarthat pár percig.</string>
-	<!-- Message to display when maps moved. -->
-	<string name="move_lite_maps_to_pro_ok">Letöltött térképeidet sikeresen áthelyeztük a Organic Maps-be.</string>
-	<!-- Message to display when maps move failed. -->
-	<string name="move_lite_maps_to_pro_failed">Térképeid áthelyezése nem sikerült. Kérjük, töröld a Organic Maps Lite-t és töltsd le a térképet megint.</string>
-	<!-- Text in menu -->
-	<string name="settings_and_more">Beállítások és egyéb</string>
 	<!-- Text in menu -->
 	<string name="website">Honlap</string>
-	<!-- Text in menu -->
-	<string name="contact_us">Kapcsolat</string>
 	<!-- Settings: Send feedback button and dialog title -->
 	<string name="feedback">Visszajelzés</string>
-	<!-- Text in menu -->
-	<string name="subscribe_to_news">Iratkozz fel hírlevelünkre</string>
 	<!-- Text in menu -->
 	<string name="rate_the_app">Értékeld az alkalmazást</string>
 	<!-- Text in menu -->
@@ -328,12 +221,6 @@
 	<string name="copyright">Szerzői jog</string>
 	<!-- Text in menu -->
 	<string name="report_a_bug">Hibabejelentés</string>
-	<!-- Email subject -->
-	<string name="subscribe_me_subject">Fel szeretnék iratkozni a Organic Maps hírlevelére</string>
-	<!-- Email body -->
-	<string name="subscribe_me_body">Elsőként szeretnék értesülni a legújabb hírekről frissítésekről és promóciókról. A feliratkozásom bármikor törölhetem.</string>
-	<!-- About text -->
-	<string name="about_text">A Organic Maps kínálja a leggyorsabb offline térképeket, a világ összes városáról és országáról. Utazz magabiztosan: bárhol is vagy, a Organic Maps segít, hogy megtaláld magad a térképen, valamint segít a legközelebbi étterem, hotel, bank, benzinkút stb. felkutatásában is. Nem igényel internet kapcsolatot.\n\nMindig dolgozunk új fejlesztéseken és örömmel vennénk a te véleményedet is arról, hogyan tudnánk tovább fejleszteni a Organic Maps-t. Bármely probléma esetén írj nekünk a support\@organicmaps.app email címre. Minden levélre válaszolunk!\n\nSzereted a Organic Maps-t és szeretnél támogatni minket? Van erre pár egyszerű és teljesen ingyenes lehetőséged:\n\n- írj rólunk értékelést az App Market-en\n- kedveld a Facebook oldalunkat: http://www.facebook.com/OrganicMaps\n- vagy csak mesélj a Organic Maps-ről anyukádnak, barátaidnak és munkatársaidnak :)\n\nKöszönjük, hogy velünk vagy. Nagyra értékeljük támogatásodat!\n\nU.i: Adatainkat az OpenStreetMap-ről vesszük, ami egy, a Wikipedia-hoz hasonló térképes projekt, ami megengedi felhasználóinak a térképek létrehozását és szerkesztését. Ha bármi hiányzik vagy rossz a térképpel, közvetlenül te is kijavíthatod a https://www.openstreetmap.org-on és változtatásaid a Organic Maps következő verziójában már meg fognak jelenni.</string>
 	<!-- Alert text -->
 	<string name="email_error_body">Az email kliens nincs beállítva. Kérjük, konfiguráld vagy próbálj meg valamilyen más módon kapcsolatba lépni velünk a %s email címen keresztül.</string>
 	<!-- Alert title -->
@@ -342,137 +229,56 @@
 	<string name="pref_calibration_title">Iránytű kalibrálás</string>
 	<!-- Search category -->
 	<string name="wifi">WiFi</string>
-	<!-- Update map suggestion -->
-	<string name="routing_map_outdated">Kérjük, útvonal létrehozásához frissítsd a térképet.</string>
-	<!-- Update maps suggestion -->
-	<string name="routing_update_maps">A Organic Maps új verziójában már útvonalakt is létrehozhatsz tartózkodási helyedtől az úticélodig. Kérjük, ennek a funkciónak a használatához frissítsd a térképeket.</string>
 	<!-- Update all button text -->
 	<string name="downloader_update_all_button">Mindegyik frissítése</string>
 	<!-- Cancel all button text -->
 	<string name="downloader_cancel_all">Mindent visszavon</string>
 	<!-- Downloaded maps category -->
 	<string name="downloader_downloaded_subtitle">Letöltve</string>
-	<!-- Downloaded maps category -->
-	<string name="downloader_available_maps">Elérhető</string>
 	<!-- Country queued for download -->
 	<string name="downloader_queued">Várólistás</string>
 	<string name="downloader_near_me_subtitle">A közelemben</string>
 	<string name="downloader_status_maps">Térképek</string>
 	<string name="downloader_download_all_button">Mindegyik letöltése</string>
 	<string name="downloader_downloading">Letöltés:</string>
-	<string name="downloader_search_results">Megtalálva</string>
-	<!-- Disclaimer message -->
-	<string name="routing_disclaimer">Amikor útvonalakat készít a Organic Maps appban, kérjük, vegye figyelembe a következőket:\n\n  - Az ajánlott útvonalak csak javaslatoknak tekintendők.\n - Az utak kondíciója, a forgalmi szabályok és jelzőtáblák magasabb prioritásúak, mint a navigációs javaslatok.\n - A térkép lehet, hogy hibás vagy idejétmúlt, az útvonalak pedig lehet, hogy nem a lehető legjobb módon készülnek el.\n\n  Legyen óvatos az utakon és vigyázzon magára!</string>
-	<!-- Outdated maps category -->
-	<string name="downloader_outdated_maps">Elavult</string>
-	<!-- Up to date maps category -->
-	<string name="downloader_uptodate_maps">Friss</string>
 	<!-- Status of outdated country in the list -->
 	<string name="downloader_status_outdated">Frissítés</string>
 	<!-- Status of failed country in the list -->
 	<string name="downloader_status_failed">Sikertelen</string>
 	<!-- Displayed in a dialog that appears when a user tries to delete a map while the app is in the follow route mode -->
 	<string name="downloader_delete_map_while_routing_dialog">Kérjük, állítsa le a navigációt a térkép törléséhez.</string>
-	<!-- Show when user try build route, but we don't know where he -->
-	<string name="routing_failed_unknown_my_position">Nem meghatározott a jelenlegi helyszín. Kérjük, határozza meg a helyszínt, hogy útvonal készülhessen.</string>
-	<!-- Show if use has not routing file, or InconsistentMWMandRoute -->
-	<string name="routing_failed_has_no_routing_file">Útvonaltervezéshez további adatok is szükségesek. Elkezded a letöltést?</string>
-	<!-- StartPointNotFound -->
-	<string name="routing_failed_start_point_not_found">Az útvonal nem tervezhető meg. Nincsenek utak a kiindulópontja közelében.</string>
-	<!-- EndPointNotFound -->
-	<string name="routing_failed_dst_point_not_found">Az útvonal nem tervezhető meg. Nincsenek utak az úti céljának közelében.</string>
 	<!-- PointsInDifferentMWM -->
 	<string name="routing_failed_cross_mwm_building">Útvonalakat csak akkor lehet készíteni, ha teljesen rajta vannak egy térképen.</string>
-	<!-- RouteNotFound -->
-	<string name="routing_failed_route_not_found">Nem találtunk útvonalat a kiválasztott kiindulópont és az úti cél között. Kérjük, válasszon másik kiinduló- vagy végpontot.</string>
-	<!-- InternalError -->
-	<string name="routing_failed_internal_error">Belső hiba történt. Kérjük, próbálja meg kitörölni és újra letölteni a térképet. Ha a probléma továbbra is fennáll, kérjük, vegye fel velünk a kapcsolatot a support\@organicmaps.app email címen.</string>
-	<!-- Context menu item for downloader. -->
-	<string name="downloader_download_map_and_routing">Térkép + útvonal letöltése</string>
-	<!-- Context menu item for downloader. -->
-	<string name="downloader_download_routing">Útvonal letöltése</string>
-	<!-- Context menu item for downloader. -->
-	<string name="downloader_delete_routing">Útvonal törlése</string>
 	<!-- Context menu item for downloader. -->
 	<string name="downloader_download_map">Töltsd le a térképet</string>
-	<string name="downloader_download_map_no_routing">Térkép letöltése útvonal nélkül</string>
-	<!-- Button for routing. -->
-	<string name="routing_go">Indulás!</string>
 	<!-- Item status in downloader. -->
 	<string name="downloader_retry">Ismétlés</string>
-	<!-- Item in context menu. -->
-	<string name="downloader_map_and_routing">Térkép + útvonal megállapítása</string>
 	<!-- Item in context menu. -->
 	<string name="downloader_delete_map">Térkép törlése</string>
 	<!-- Item in context menu. -->
 	<string name="downloader_update_map">Térkép frissítése</string>
-	<!-- Item in context menu. -->
-	<string name="downloader_update_map_and_routing">Térkép frissítése + útvonal megállapítása</string>
-	<!-- Item in context menu. -->
-	<string name="downloader_map_only">Csak térkép</string>
-	<!-- Toolbar title -->
-	<string name="toolbar_application_menu">Menü</string>
 	<!-- Preference text -->
 	<string name="pref_use_google_play">Használja a Google Play szolgáltatást, hogy szert tegyen aktuális helyszínéről</string>
 	<!-- Text for rating dialog -->
 	<string name="rating_just_rated">Most értékeltem az alkalmazásodat</string>
-	<!-- Text for rating dialog -->
-	<string name="rating_user_since">Organic Maps felhasználó vagyok %s óta</string>
-	<!-- Text for rating dialog -->
-	<string name="rating_do_like_maps">Szereted a Organic Maps-t?</string>
-	<!-- Text for rating dialog -->
-	<string name="rating_tap_star">Érints meg egy csillagot az alkalmazás értékeléséhez.</string>
 	<!-- Text for rating dialog -->
 	<string name="rating_thanks">Köszönjük!</string>
 	<!-- Text for rating dialog -->
 	<string name="rating_share_ideas">Az alkalmazás fejlesztése érdekében ossz meg bármilyen ötletet vagy problémát.</string>
 	<!-- Text for rating dialog -->
 	<string name="rating_send_feedback">Visszajelzés elküldése</string>
-	<!-- Text for g+ dialog -->
-	<string name="rating_google_plus">Kattints a g+-ra és mesélj barátaidnak az alkalmazásról</string>
 	<!-- Text for routing error dialog -->
 	<string name="routing_download_maps_along">Tölts le térképeket az útvonal mellett</string>
-	<!-- Text for routing error dialog -->
-	<string name="routing_download_map">Térkép megszerzése</string>
-	<!-- Text for routing error dialog -->
-	<string name="routing_download_map_and_routing">Frissített térkép és útvonaltervezési adatok letöltése az összes Organic Maps tulajdonság megszerzése érdekében.</string>
-	<!-- Text for routing error dialog -->
-	<string name="routing_get_routing_data">Útvonaltervezési adatok megszerzése</string>
-	<!-- Text for routing error dialog -->
-	<string name="routing_get_additional_data">További adatok szükségesek a kiinduló pontról történő útvonaltervezéshez</string>
 	<!-- Text for routing error dialog -->
 	<string name="routing_requires_all_map">Útvonal tervezéséhez a kiindulási pont és a célútvonal összes térképét szükséges letölteni és frissíteni.</string>
 	<!-- Text for routing error dialog -->
 	<string name="routing_not_enough_space">Nincs elég hely</string>
-	<!-- Text for routing error dialog -->
-	<string name="routing_download_more_than_avail">%1$s MB-t kell letöltened, de csak %2$s MB hely szabad.</string>
-	<!-- Text for routing error dialog -->
-	<string name="routing_download_roaming">%s MB-nyi adatot készül letölteni mobilján (roamingon) keresztül. Ez további költségekkel járhat, a mobilcsomagjától függően.</string>
 	<!-- bookmark button text -->
 	<string name="bookmark">könyvjelző</string>
-	<!-- map is not downloaded -->
-	<string name="not_found_map">A helyszínéhez tartozó térképet letöltöttük</string>
 	<!-- location service disabled -->
 	<string name="enable_location_services">Kérjük kapcsolja be a helyzetmeghatározó szolgáltatást</string>
-	<!-- download map -->
-	<string name="download_map">Töltse le a térképet a helyszínéhez</string>
-	<!-- download map on iPhone -->
-	<string name="download_map_iphone">Töltse le a térképet iPhone-jára jelenlegi helyzetének meghatározásához</string>
-	<!-- clear pin -->
-	<string name="nearby">A közelben</string>
-	<!-- clear pin -->
-	<string name="clear_pin">Pin törlése</string>
-	<!-- location is undefined -->
-	<string name="undefined_location">Nem meghatározott a jelenlegi helyszín.</string>
-	<!-- download country of your location -->
-	<string name="download_country">Töltse le az aktuális helyzet országát</string>
-	<!-- download failed -->
-	<string name="download_failed">letöltése sikertelen</string>
-	<!-- get the map -->
-	<string name="get_the_map">Térkép megszerzése</string>
 	<string name="save">Simpan</string>
 	<string name="edit_description_hint">Az ön leírásai (sima szöveg vagy html)</string>
-	<string name="new_group">új csoport</string>
 	<string name="create">létrehoz</string>
 	<!-- red color -->
 	<string name="red">Piros</string>
@@ -490,22 +296,6 @@
 	<string name="brown">Barna</string>
 	<!-- pink color -->
 	<string name="pink">Rózsaszín</string>
-	<!-- deep purple color -->
-	<string name="deep_purple">Sötét lila</string>
-	<!-- light blue color -->
-	<string name="light_blue">Világoskék</string>
-	<!-- cyan color -->
-	<string name="cyan">Cián</string>
-	<!-- teal color -->
-	<string name="teal">Zöldeskék</string>
-	<!-- lime color -->
-	<string name="lime">Lime</string>
-	<!-- deep orange color -->
-	<string name="deep_orange">Sötét Narancs</string>
-	<!-- gray color -->
-	<string name="gray">Szürke</string>
-	<!-- blue gray color -->
-	<string name="blue_gray">Kékes Szürke</string>
 	<!-- Wi-Fi available -->
 	<string name="WiFi_available">Igen</string>
 
@@ -521,10 +311,8 @@
 	<string name="dialog_routing_location_turn_wifi">Kérjük, ellenőrizze a GPS jelet. A Wi-Fi engedélyezése javítja a helyszín meghatározásának pontosságát.</string>
 	<string name="dialog_routing_location_turn_on">Engedélyezze a helyszíni szolgáltatásokat</string>
 	<string name="dialog_routing_location_unknown_turn_on">Nem sikerült lokalizálni a jelenlegi GPS koordinátákat. Az útvonaltervezéshez engedélyezze a helyszíni szolgáltatásokat.</string>
-	<string name="dialog_routing_location_unknown">Nem sikerült lokalizálni a jelenlegi GPS koordinátákat.</string>
 	<string name="dialog_routing_download_files">Töltse le a szükséges fájlokat</string>
 	<string name="dialog_routing_download_and_update_all">Útvonaltervezéshez töltse le és frissítse az összes térkép- és útvonal-információt a tervezett út mentén.</string>
-	<string name="dialog_routing_routes_size">Útvonal-információs fájlok</string>
 	<string name="dialog_routing_unable_locate_route">Nem sikerült meghatározni az útvonalat</string>
 	<string name="dialog_routing_cant_build_route">Nem sikerült létrehozni az útvonalat.</string>
 	<string name="dialog_routing_change_start_or_end">Kérjük, pontosítsa indulási helyét, vagy célállomását.</string>
@@ -539,33 +327,23 @@
 	<string name="dialog_routing_system_error">Rendszerhiba</string>
 	<string name="dialog_routing_application_error">Egy alkalmazáshiba miatt nem sikerült az útvonal létrehozása.</string>
 	<string name="dialog_routing_try_again">Kérjük, próbálja újra</string>
-	<string name="dialog_routing_send_error">Probléma bejelentése</string>
-	<string name="dialog_routing_if_get_cross_route">Szeretne egy közvetlenebb útvonalat létrehozni, amely több, mint egy térképen terül el?</string>
-	<string name="dialog_routing_cross_route_is_optimal">Elérhető egy optimálisabb útvonal, amely áthalad a jelenlegi térkép szélén.</string>
 	<string name="not_now">Most nem</string>
-	<string name="dialog_routing_build_route">Létrehozás</string>
 	<string name="dialog_routing_download_and_build_cross_route">Szeretné letölteni a térképet és létrehozni egy optimálisabb útvonalat, amely több, mint egy térképen terül el?</string>
 	<string name="dialog_routing_download_cross_route">Töltse le a térképet, hogy létrehozzon egy optimálisabb útvonalat, amely áthalad a jelenlegi térkép szélén.</string>
-	<string name="dialog_routing_cross_route_always">Mindig haladjon át ezen a határon</string>
 
 	<!-- SECTION: Strings for downloading map from search -->
 	<string name="search_without_internet_advertisement">Útvonalak kereséséhez és létrehozásához, kérjük, töltsd le a térképet és többé nem lesz szükséged internetkapcsolatra.</string>
 	<string name="search_select_map">Jelöld ki a térképet</string>
-	<string name="search_select_other_map">Jelölj ki másik térképet</string>
 	<!-- «Show» context menu -->
 	<string name="show">Mutat</string>
 	<!-- «Hide» context menu -->
 	<string name="hide">Elrejt</string>
 	<!-- «Rename» context menu -->
 	<string name="rename">Átnevez</string>
-	<!-- Bottom sheet: expand button (should be short) -->
-	<string name="bottom_sheet_more">Továbbiak…</string>
 	<!-- Failed planning route message in navigation view -->
 	<string name="routing_planning_error">Sikertelen útvonaltervezés</string>
 	<!-- Arrive routing message in navigation view -->
 	<string name="routing_arrive">Megérkezik: %s</string>
-	<!-- Text for routing::RouterResultCode::FileTooOld dialog. -->
-	<string name="dialog_routing_download_and_update_maps">Útvonal létrehozásához kérjük, töltse le és frissítse az összes térképet az útvonal mentén.</string>
 	<string name="rate_alert_title">Tetszik az app?</string>
 	<string name="rate_alert_default_message">Köszönjük, hogy a Organic Maps-t használta. Kérjük, értékelje az appot. A visszajelzéseik segítenek bennünket abban, hogy jobbá váljunk.</string>
 	<string name="rate_alert_five_star_message">Hurrá! Mi is szeretjük magát!</string>
@@ -573,24 +351,14 @@
 	<string name="rate_alert_less_than_four_star_message">Van valami ötlete, amivel jobbá tehetnénk?</string>
 	<string name="categories">Kategóriák</string>
 	<string name="history">Előzmények</string>
-	<string name="next_turn_then">Aztán</string>
 	<string name="closed">Zárva</string>
-	<string name="back_to">Vissza ide %s</string>
 	<string name="search_not_found">Sajnos, semmit nem találtam.</string>
 	<string name="search_not_found_query">Próbáljon másik lekérdezést.</string>
-	<string name="search_not_found_map">Töltse le azt a térképet, amelyen keres.</string>
-	<string name="search_not_found_location">Töltse le a jelenlegi tartózkodási helye térképét.</string>
 	<string name="search_history_title">Előző keresések</string>
 	<string name="search_history_text">Aktuális keresés gyors elérése.</string>
 	<string name="clear_search">A keresési előzmények törlése</string>
-	<!-- Title for settings to enable/disable showcase menu button -->
-	<string name="showcase_settings_title">Ajánlatok mutatása</string>
-	<string name="p2p_route_planning">Útvonaltervezés</string>
 	<string name="p2p_your_location">Az Ön helyzete</string>
-	<string name="p2p_from">Az indulás helye</string>
-	<string name="p2p_to">Az érkezés helye</string>
 	<string name="p2p_start">Indítás</string>
-	<string name="p2p_planning">Tervezés…</string>
 	<string name="p2p_from_here">Innen</string>
 	<string name="p2p_to_here">Ide</string>
 	<string name="p2p_only_from_current">A navigáció csak a jelenlegi helyzetéből érhető el.</string>
@@ -610,11 +378,8 @@
 	<string name="editor_hours_closed">Zárvatartási órák</string>
 	<string name="editor_example_values">Példa értékek</string>
 	<string name="editor_correct_mistake">Hiba javítása</string>
-	<string name="editor_correct_mistake_message">Szerkesztési hibát vétett. Javítsa ki vagy váltson egyszerű módba.</string>
 	<string name="editor_add_select_location">Elhelyezkedés</string>
 	<string name="editor_done_dialog_1">Megváltoztattad a világ térképét. Ne titkold el mások elől! Mondd el a barátaidnak, és szerkesszétek közösen!</string>
-	<string name="editor_done_dialog_2">Ez a második térképjavításod. Most már te is rajta vagy a térképszerkesztők listáján, az %d. helyen. Mesélj erről a barátaidnak is.</string>
-	<string name="editor_done_dialog_3">Javítottál a térképen! Mondd el a barátaidnak is és szerkesszétek közösen!</string>
 	<string name="share_with_friends">Oszd meg az ismerőseiddel</string>
 	<string name="editor_report_problem_desription_1">Kérjük, írd le részletesen a problémát, hogy az OpenStreeMap csapata kijavíthassa.</string>
 	<string name="editor_report_problem_desription_2">Vagy végezd el te magad a javítást itt: https://www.openstreetmap.org/</string>
@@ -623,14 +388,7 @@
 	<string name="editor_report_problem_no_place_title">A hely nem létezik</string>
 	<string name="editor_report_problem_under_construction_title">Karbantartás miatt nem elérhető</string>
 	<string name="editor_report_problem_duplicate_place_title">Duplikált hely</string>
-	<string name="first_launch_congrats_title">A Organic Maps használatra készen áll</string>
-	<string name="first_launch_congrats_text">Keress és navigálj offline a világon mindenhol, térítésmentesen.</string>
-	<string name="migrate_title">Fontos!</string>
-	<!-- Android uses image instead of text. -->
-	<string name="download_all">Összes letöltése</string>
-	<string name="delete_all">Összes térkép törlése</string>
 	<string name="autodownload">Automatikus letöltés</string>
-	<string name="disable_autodownload">Automatikus letöltés tiltása</string>
 	<!-- Place Page opening hours text -->
 	<string name="closed_now">Most zárva</string>
 	<!-- Place Page opening hours text -->
@@ -639,8 +397,6 @@
 	<string name="day_off_today">Ma zárva</string>
 	<string name="day_off">Zárva</string>
 	<string name="today">Ma</string>
-	<string name="sunrise_to_sunset">Napkeltétől napnyugtáig</string>
-	<string name="sunset_to_sunrise">Napkeltétől napnyugtáig</string>
 	<string name="add_opening_hours">Nyitvatartás hozzáadása</string>
 	<string name="edit_opening_hours">Nyitvatartás szerkesztése</string>
 	<string name="no_osm_account">Nem rendelkezel még OpenStreetMap-felhasználói fiókkal?</string>
@@ -650,29 +406,13 @@
 	<string name="login">Bejelentkezés</string>
 	<string name="password">Jelszó</string>
 	<string name="forgot_password">Elfelejtett jelszó?</string>
-	<!-- Forgot Password dialog title -->
-	<string name="restore_password">Jelszó visszaállítása</string>
-	<string name="enter_email_address_to_reset_password">Add meg a regisztrációkor használt email-címedet és elküldjük neked a jelszavad megújításához szükséges linket.</string>
-	<string name="reset_password">Jelszó visszaállítása</string>
-	<string name="username">Felhasználónév</string>
 	<string name="osm_account">OSM-felhasználói fiók</string>
 	<string name="logout">Kijelentkezés</string>
-	<string name="login_and_edit_map_motivation_message">Jelentkezz be és szerkeszd az egyes objektumokhoz tartozó információkat a térképen, valamint tedd őket elérhetővé több millió felhasználó számára.</string>
 	<!-- Information text: "Last upload 11.01.2016" -->
 	<string name="last_upload">Utolsó frissítés</string>
-	<!-- Motivates user to login/register, title above login buttons. -->
-	<string name="you_have_edited_your_first_object">Szerkesztetted az első objektumod!</string>
 	<string name="thank_you">Köszönjük</string>
-	<string name="login_with_google">Bejelentkezés Google- vel</string>
-	<string name="login_with_openstreetmap">Jelentkezz be a www.openstreetmap.org oldalon</string>
 	<string name="edit_place">Hely szerkesztése</string>
 	<string name="place_name">Hely neve</string>
-	<!-- title above languages list cells in the editor, below editable name text field. -->
-	<string name="other_languages">Más nyelv</string>
-	<!-- small button to open list with names in different languages -->
-	<string name="show_more">Több mutatása</string>
-	<!-- small button to close list with names in different languages -->
-	<string name="show_less">Kevesebb mutatása</string>
 	<string name="add_language">Nyelv hozzáadása</string>
 	<string name="street">Utca</string>
 	<!-- Editable House Number text field (in address block). -->
@@ -689,25 +429,16 @@
 	<string name="email_or_username">Email vagy felhasználónév</string>
 	<string name="phone">Telefonszám</string>
 	<string name="please_note">Megjegyzés</string>
-	<string name="common_no_wifi_dialog">Nincs WiFi-kapcsolat. Szeretnéd folytatni mobil adatforgalom használatával?</string>
 	<string name="downloader_delete_map_dialog">A térképekkel együtt minden rajtuk végzett módosítás is törlésre kerül.</string>
 	<string name="downloader_update_maps">Térképek frissítése</string>
 	<string name="downloader_mwm_migration_dialog">Útvonal létrehozásához frissítsd az összes térképet, majd tervezd meg újra az útvonalat.</string>
 	<string name="downloader_search_field_hint">Térkép keresése</string>
-	<string name="migration_update_all_button">Minden térkép frissítése</string>
-	<string name="migration_delete_all_download_current_button">Töltsd le a jelenlegi térképet és töröld a régieket</string>
 	<string name="migration_download_error_dialog">Letöltési hiba</string>
 	<string name="common_check_internet_connection_dialog">Kérjük, ellenőrizd a beállításaid és győződj meg arról, hogy a készüléked kapcsolódik az internethez.</string>
 	<string name="downloader_no_space_title">Nincs elegendő tárhely</string>
 	<string name="downloader_no_space_message">Kérjük, töröld a szükségtelen adatokat</string>
-	<string name="editor_general_auth_error_dialog">Általános bejelentkezési hiba.</string>
 	<string name="editor_login_error_dialog">Bejelentkezési hiba.</string>
-	<string name="editor_login_failed_dialog">Sikertelen bejelentkezés</string>
-	<string name="editor_username_error_dialog">Érvénytelen felhasználónév</string>
-	<string name="editor_place_edited_dialog">Szerkesztettél egy objektumot!</string>
-	<string name="editor_login_with_osm">Bejelentkezés OpenStreetMappel</string>
 	<string name="editor_profile_changes">Jóváhagyott változtatások</string>
-	<string name="editor_profile_unsent_changes">Nincs elküldve:</string>
 	<string name="editor_focus_map_on_location">Húzd a térképet a megfelelő helyre az objektum helyes helyszínének kiválasztásához.</string>
 	<string name="editor_add_select_category">Válassz kategóriát</string>
 	<string name="editor_add_select_category_popular_subtitle">Népszerűek</string>
@@ -718,19 +449,14 @@
 	<string name="editor_edit_place_category_title">Kategória</string>
 	<string name="detailed_problem_description">A probléma részletes leírása</string>
 	<string name="editor_report_problem_other_title">Különböző probléma</string>
-	<string name="placepage_report_problem_button">Hibabejelentés</string>
 	<string name="placepage_add_business_button">Szervezet hozzáadása</string>
 	<string name="whatsnew_editor_message_1">Adj hozzá új helyeket a térképhez, és szerkeszd a meglévőket közvetlenül az alkalmazásból.</string>
-	<string name="whatsnew_editor_message_2">* A Organic Maps az OpenStreetMap közösség adatait használja.</string>
 	<string name="dialog_incorrect_feature_position">Helyszín megváltoztatása</string>
 	<string name="message_invalid_feature_position">Célpont áthelyezése ide nem lehetséges</string>
 	<string name="login_to_make_edits_visible">Jelentkezz be, hogy más felhasználók is láthassák a változtatásaidat.</string>
-	<string name="no_migration_during_navigation">Navigáció közbeni módosítás nem engedélyezett.</string>
 	<!-- Error dialog no space -->
 	<string name="migration_no_space_message">A letöltéshez több szabad tárhelyre van szükség. Kérjük, töröld a szükségtelen adatokat.</string>
 	<string name="editor_sharing_title">Én fejlesztettem a Organic Maps térképeket</string>
-	<string name="editor_comment_will_be_sent">Megjegyzését elküldjük a térképészeknek.</string>
-	<string name="editor_unsupported_category_message">Olyan kategóriához adott helyet, amelyet még nem támogatunk. Ez a kategória később fog megjelenni a térképen.</string>
 	<!-- Downloaded 10 **of** 20 <- it is that "of" -->
 	<string name="downloader_of">%1$d/%2$d</string>
 	<string name="download_over_mobile_header">Letöltés mobilhálózati kapcsolat segítségével?</string>
@@ -748,15 +474,8 @@
 	<string name="editor_detailed_description">Javasolt változtatásait elküldjük az OpenStreetMap közösségnek. Írja le a további információkat, amelyek nem szerkeszthetők a Organic Maps-ben.</string>
 	<string name="editor_more_about_osm">További részletek az OpenStreetMap-ról</string>
 	<string name="editor_operator">Üzemeltető</string>
-	<string name="editor_tag_description">Írja ide a működtetésért felelős cég, szervezet vagy magánszemély nevét.</string>
-	<string name="editor_no_local_edits_title">Nincsenek helyi módosításai</string>
-	<string name="editor_no_local_edits_description">Itt a pillanatnyilag csak az Ön készülékén elérhető térképek javasolt módosításainak száma látható.</string>
-	<string name="editor_send_to_osm">Küldés az OSM-nek</string>
-	<string name="editor_remove">Eltávolítás</string>
-	<string name="downloader_my_maps_title">Térképeim</string>
 	<string name="downloader_no_downloaded_maps_title">Még nem töltött le térképet</string>
 	<string name="downloader_no_downloaded_maps_message">Töltse le a szükséges térképeket, hogy megtalálja a helyet és internet nélkül is navigálhasson.</string>
-	<string name="downloader_find_place_hint">Város vagy ország keresése</string>
 	<!-- Error title that appears after certain time without location. -->
 	<string name="current_location_unknown_title">Folytatja tartózkodási helyének keresését?</string>
 	<!-- Error that appears after certain time without location. -->
@@ -770,27 +489,10 @@
 	<string name="location_services_disabled_2">2. Érintse meg a Helyzet gombot</string>
 	<!-- iOS Dialog for the case when the location permission is not granted -->
 	<string name="location_services_disabled_3">3. Kiválaszt az alkalmazás használata alatt</string>
-	<string name="placepage_parking_surface">Szabadtéri parkoló</string>
-	<string name="placepage_parking_multistorey">Parkolóház</string>
-	<string name="placepage_parking_underground">Föld alatti parkoló</string>
-	<string name="placepage_parking_rooftop">Tetőparkoló</string>
-	<string name="placepage_parking_sheds">Fedett parkolóállás</string>
-	<string name="placepage_parking_carports">Nagyobb fedett parkoló</string>
-	<string name="placepage_parking_boxes">Garázsbox</string>
-	<string name="placepage_parking_pay">Fizetős</string>
-	<string name="placepage_parking_free">Díjmentes</string>
-	<string name="placepage_parking_interval">Idősávos fizetős</string>
-	<string name="placepage_entrance_number">Szám</string>
-	<string name="placepage_entrance_type">Bejárat</string>
-	<string name="placepage_flat">lakás</string>
-	<string name="placepage_open_24_7">24 órás</string>
 	<string name="meter">m</string>
 	<string name="kilometer">km</string>
-	<string name="kilometers_per_hour">km/h</string>
 	<string name="mile">mf</string>
 	<string name="foot">ft</string>
-	<string name="miles_per_hour">mph</string>
-	<string name="day">n</string>
 	<string name="hour">ó</string>
 	<string name="minute">p</string>
 	<string name="placepage_place_description">Leírás</string>
@@ -800,46 +502,30 @@
 	<string name="placepage_call_button">Hívás</string>
 	<string name="placepage_edit_bookmark_button">Könyvjelző szerkesztése</string>
 	<string name="placepage_bookmark_name_hint">Könyvjelző neve</string>
-	<string name="placepage_personal_notes_hint">Jegyzet</string>
-	<string name="placepage_delete_bookmark_button">Könyvjelző törlése</string>
 	<string name="editor_edits_sent_message">Javasolt változtatásainak elküldése sikerült</string>
 	<string name="editor_comment_hint">Megjegyzés…</string>
 	<string name="editor_reset_edits_message">Elveti az összes helyi módosítást?</string>
 	<string name="editor_reset_edits_button">Elvetés</string>
 	<string name="editor_remove_place_message">Eltávolít egy hozzáadott objektumot?</string>
 	<string name="editor_remove_place_button">Eltávolítás</string>
-	<string name="editor_status_sending">Küldés…</string>
 	<string name="editor_place_doesnt_exist">A hely nem létezik</string>
 	<string name="text_more_button">…tovább</string>
 	<!-- Phone number error message -->
 	<string name="error_enter_correct_phone">Adja meg a helyes telefonszámot</string>
 	<string name="error_enter_correct_web">Adj meg egy érvényes weboldalcímet</string>
 	<string name="error_enter_correct_email">Adj meg egy érvényes email-címet</string>
-	<string name="error_enter_correct">Adj meg egy érvényes értéket</string>
 	<string name="refresh">Frissítés</string>
-	<string name="last_update">Utolsó frissítés: %s</string>
 	<string name="placepage_add_place_button">Hely hozzáadása a térképhez</string>
 	<!-- Displayed when saving some edits to the map to warn against publishing personal data -->
 	<string name="editor_share_to_all_dialog_title">Szeretnéd elküldeni az összes felhasználónak?</string>
 	<!-- iOS Dialog before publishing the modifications to the public map. -->
 	<string name="editor_share_to_all_dialog_message_1">Győződj meg arról, hogy nem adsz meg semmilyen személyes információt.</string>
 	<string name="editor_share_to_all_dialog_message_2">Ellenőrizni fogjuk a változásokat. Ha bármilyen kérdésünk van, emailben keresünk.</string>
-	<string name="navigation_overview_button">áttekintés</string>
-	<string name="navigation_stop_button">megállítás</string>
-	<!-- Text on an empty bookmark page -->
-	<string name="bookmarks_empty_title">Könyvjelzők mentése</string>
-	<string name="bookmarks_empty_message_1">Koppintson a ★-ra a kedvenc helyei mentéséhez, gyors eléréséhez.</string>
-	<string name="bookmarks_empty_message_2">Importálja a könyvjelzőket a levelezésből és a böngészőből.</string>
-	<string name="bookmarks_empty_message_3">kijelentkezés: %s</string>
-	<!-- Name of the group for booked hotels -->
-	<string name="bookmarks_group_name">Hotelfoglalások</string>
-	<string name="place_page_button_read_descriprion">Olvassa el</string>
 	<!-- iOS dialog for the case when recent track recording is on and the app comes back from background -->
 	<string name="recent_track_background_dialog_title">Megszakítod a legutóbb megtett utad rögzítését?</string>
 	<string name="off_recent_track_background_button">Megszakítás</string>
 	<!-- For sharing via SMS and so on -->
 	<string name="sharing_call_action_look">Tekintse meg</string>
-	<string name="continue_recent_track_background_button">Folytatás</string>
 	<string name="recent_track_background_dialog_message">A Organic Maps a geopozíciód használatával a háttérben rögzíti a legutóbb megtett utad.</string>
 	<!-- Rate on Google Play (Android only) -->
 	<string name="rate_gp">Arány a Google Play-n</string>
@@ -849,21 +535,11 @@
 	<string name="tell_friends_text">Szia! Telepítsd a Organic Maps alkalmazást!</string>
 	<!-- About short text (below logo) -->
 	<string name="about_description">A Organic Maps egy nélkülözhetetlen alkalmazás utazáshoz. A Organic Maps az OpenStreetMap adataira épül, és lehetővé teszi ezek szerkesztését.</string>
-	<!-- Text in menu -->
-	<string name="blog">Blog</string>
 	<string name="general_settings">Általános beállítások</string>
-	<string name="date">Dátum %d</string>
-	<!-- "Report a bug" -> "Generaal Feedback" -> "Something is not working" -->
-	<string name="something_is_not_working">Valami nem működik</string>
 	<!-- For the first routing -->
 	<string name="accept">Elfogadja</string>
 	<!-- For the first routing -->
 	<string name="decline">Elutasítja</string>
-	<string name="install_app">Telepítés</string>
-	<string name="search_no_results_title">Nincs találat</string>
-	<string name="search_no_results_message">Próbálkozzon általánosabb kereső kifejezéssel, tágítsa vagy törölje a szűrőt.</string>
-	<string name="search_no_results_expand_area_button">Kicsinyítés</string>
-	<string name="search_no_results_reset_button">Szűrő nullázása</string>
 	<!-- noun -->
 	<string name="search_in_table">Lista</string>
 	<string name="mobile_data_dialog">Részletes információk megjelenítése a mobil internet segítségével?</string>
@@ -875,18 +551,13 @@
 	<string name="mobile_data_option_never">Soha se használja</string>
 	<string name="mobile_data_option_ask">Mindig kérdezze meg</string>
 	<string name="traffic_update_maps_text">Forgalmi adatok megjelenítéséhez a térképeket frissíteni kell.</string>
-	<string name="traffic_outdated">A forgalmi adatok elavultak.</string>
 	<string name="big_font">Betűméret növelése a térképen</string>
 	<string name="traffic_update_app">Kérjük, frissítse a Organic Maps alkalmazást</string>
 	<!-- "traffic" as in road congestion -->
 	<string name="traffic_update_app_message">A forgalmi adatok megjelenítéséhez frissíteni kell az alkalmazást.</string>
 	<!-- "traffic" as in "road congestion" -->
 	<string name="traffic_data_unavailable">Forgalmi adatok nem állnak rendelkezésre</string>
-	<!-- Simplified colour scheme for traffic information, fewer colours are used to display traffic jams on the map. The string should be kept as short as possible -->
-	<string name="pref_traffic_simplified_colors_title">Egyszerűsített forgalmi színek</string>
 	<string name="enable_logging">Naplózás engedélyezése</string>
-	<string name="offline_place_page_more_information">A helyszínről további tájékoztatást kaphat, ha csatlakozik az internethez.</string>
-	<string name="failed_load_information">Nem sikerült betölteni az adatokat.</string>
 	<!-- Settings: "Send general feedback" button -->
 	<string name="feedback_general">Általános visszajelzés</string>
 	<string name="on">Be</string>
@@ -900,57 +571,26 @@
 	<string name="routing_add_start_point">Adjon hozzá kiindulási pontot az útvonal megtervezéséhez</string>
 	<string name="routing_add_finish_point">Adjon hozzá végpontot az útvonal tervezéséhez</string>
 	<string name="button_exit">Kilépés</string>
-	<string name="settings_device_memory">Készülék memóriája</string>
-	<string name="settings_card_memory">Memóriakártya</string>
-	<string name="settings_storage_available">%s rendelkezésre áll</string>
-	<string name="toast_location_permission_denied">Alkalmazás helymeghatározási engedélye megtagadva</string>
-	<string name="button_use">Használat</string>
 	<string name="planning_route_manage_route">Útvonal kezelése</string>
 	<string name="button_plan">Terv</string>
-	<string name="button_add">Hozzáad</string>
 	<string name="placepage_remove_stop">Eltávolítja</string>
 	<string name="planning_route_remove_title">Húzza ide az eltávolításhoz</string>
-	<string name="dialog_change_start_point_message">Kicseréli a kiindulási pontot az aktuális pozícióval?</string>
-	<string name="button_replace">Csere</string>
 	<string name="placepage_add_stop">Hozzáad megállót</string>
-	<string name="add_my_position">Add hozzá saját pozíciómat</string>
-	<string name="choose_start_point">Válasszon egy kiindulási pontot</string>
-	<string name="choose_destination">Válassza ki a célt</string>
 	<string name="preloader_viator_button">Tudjon meg többet</string>
-	<string name="start_from_my_position">Elkezdi innen:</string>
-	<string name="profile_authorization_title">Bejelentkezés ezzel</string>
-	<string name="profile_authorization_message">Egyszerű bejelentkezés jelszó és bejelentkezési név nélkül, pár másodperc alatt</string>
 	<string name="profile_authorization_error">Hoppá, volt egy hiba. Próbáljon meg újra bejelentkezni.</string>
-	<string name="service">Szolgáltatások</string>
-	<string name="atmosphere">Légkör</string>
-	<string name="value_for_money">Ár-érték arány</string>
-	<string name="experience">Tapasztalat</string>
-	<string name="assortment">Választék</string>
-	<string name="expertise">Szakértelem</string>
-	<string name="equipment">Berendezések</string>
-	<string name="quality">Minőség</string>
 	<string name="dialog_error_storage_title">Tároló hozzáférési hiba</string>
 	<string name="dialog_error_storage_message">Külső tároló nem áll rendelkezésre, valószínűleg az SD-kártyát eltávolították vagy sérült, vagy rendszerfájl csak olvasható. Ellenőrizze, és lépjen kapcsolatba velünk a support\@organicmaps.app címen</string>
 	<string name="setting_emulate_bad_storage">Sérült tároló emulálása</string>
-	<string name="directions_finish">Rendeltetési hely</string>
-	<string name="directions_on_foot">%s séta</string>
 	<string name="core_entrance">Bejárat</string>
-	<string name="coffee">Kávé</string>
-	<string name="cleanliness">Tisztaság</string>
-	<string name="crowdedness">Zsúfoltság</string>
 	<string name="error_enter_correct_name">Kérjük adja meg a helyes nevet</string>
 	<string name="bookmarks_groups">List</string>
 	<string name="bookmarks_groups_hide_all">Összes elrejtése</string>
 	<string name="bookmarks_groups_show_all">Összes megjelenítése</string>
-	<plurals name="bookmarks_places">
-	  <item quantity="other">könyvjelzők %d</item>
-	</plurals>
 	<string name="bookmarks_create_new_group">Új lista létrehozása</string>
 	<string name="downloader_hide_screen">Képernyő elrejtése</string>
 	<string name="downloader_percent">%1$s (%2$s / %3$s)</string>
-	<string name="downloader_process">%s letöltése...</string>
-	<string name="downloader_applying">%s alkalmazása...</string>
-	<string name="dialog_message_transit_not_found_connection">Útvonaltervezés egy összekötő hálózaton belül</string>
+	<string name="downloader_process">%s letöltése…</string>
+	<string name="downloader_applying">%s alkalmazása…</string>
 	<string name="bookmarks_error_message_share_general">Nem lehet megosztani alkalmazáshiba miatt</string>
 	<string name="bookmarks_error_title_share_empty">Megosztási hiba</string>
 	<string name="bookmarks_error_message_share_empty">Üres lista nem osztható meg</string>
@@ -959,12 +599,7 @@
 	<string name="bookmarks_new_list_hint">Új lista</string>
 	<string name="bookmarks_error_title_list_name_already_taken">Ez a név már foglalt</string>
 	<string name="bookmarks_error_message_list_name_already_taken">Kérjük, válasszon másik nevet</string>
-	<string name="bookmarks_error_title_list_name_too_long">Ez a név túl hosszú</string>
-	<string name="bookmarks_error_message_list_name_too_long">Kérjük, válasszon másik nevet</string>
-	<string name="please_wait">Kérlek várj...</string>
-	<string name="phone_number">Telefonszám</string>
-	<string name="notification_unsent_reviews_title">Több elküldött véleménye is van</string>
-	<string name="notification_unsent_reviews_message">Kérjük, jelentkezzen be, hogy megoszthassa véleményét más utazókkal</string>
+	<string name="please_wait">Kérlek várj…</string>
 	<string name="profile">OpenStreetMap profil</string>
 	<string name="place_page_search_similar_hotel">Hasonló szálláshelyek keresése</string>
 	<string name="bookmarks_detect_title">Új fájlokat észleltek</string>
@@ -975,31 +610,10 @@
 	<string name="button_convert">Alakítani</string>
 	<string name="bookmarks_convert_error_title">Hiba</string>
 	<string name="bookmarks_convert_error_message">Egyes fájlok nem konvertáltak.</string>
-	<string name="converting">Átalakítás...</string>
-	<string name="wn_reinvented_bookmarks_title">Új könyveket készítettünk!</string>
-	<string name="wn_reinvented_bookmarks_message">Könyvjelzőket menthet, listákat hozhat létre... Hihetetlen...</string>
-	<string name="bookmarks_restore">Könyvjelzők visszaállítása</string>
-	<string name="bookmarks_restore_process">Visszaállítása ...</string>
 	<string name="bookmarks_restore_title">A verzió visszaállítása?</string>
-	<string name="bookmarks_restore_message">Könyvjelzői %1$s (%2$s)-ból visszaállnak</string>
-	<string name="bookmarks_restore_empty_title">Nincs biztonsági mentése</string>
-	<string name="bookmarks_restore_empty_message">A szerver nem találta a korábban készített biztonsági másolatokat</string>
 	<string name="common_check_internet_connection_dialog_title">Nincs internetkapcsolat</string>
-	<string name="error_server_title">Szerver hiba</string>
-	<string name="error_server_message">Hiba történt a szerveren, próbálkozzon később</string>
 	<string name="error_system_message">Ismeretlen hiba történt</string>
 	<string name="restore">Visszaállítás</string>
-	<string name="bookmarks_page_downloaded">Letöltött</string>
-	<string name="bookmarks_page_my">Az én</string>
-	<string name="routes_and_bookmarks">Útvonalaim és könyvjelzőim</string>
-	<string name="bookmarks_webview_success_toast">Könyvjelzők sikeresen letöltve</string>
-	<string name="cached_bookmarks_placeholder_title">Új helyek letöltése</string>
-	<string name="cached_bookmarks_placeholder_subtitle">Nyomja meg a gombot, hogy Organic Maps felhasználók ezrei által gyűjtött érdekes helyet és útvonalat tölthessen le. Ehhez internetkapcsolatra van szükség.</string>
-	<string name="downloader_download_routers">Könyvjelzők letöltése</string>
-	<string name="bookmarks_groups_cached">Letöltött listák</string>
-	<plurals name="bookmarks_objects">
-	  <item quantity="other">%s tárgy</item>
-	</plurals>
 	<plurals name="objects">
 	  <item quantity="other">%d hely</item>
 	</plurals>
@@ -1012,62 +626,32 @@
 	<string name="subtittle_opt_out">Követési beállítások</string>
 	<string name="crash_reports">Hibajelentés</string>
 	<string name="crash_reports_description">A Organic Maps fejlesztéséhez felhasználhatjuk az adatait. A változtatások az alkalmazás újraindítása után lépnek életbe.</string>
-	<string name="opt_out_help_ios_1">A mobileszköz „Reklámkövetés korlátozása” vagy „Érdeklődési kör alapú reklámozás” beállítással rendelkezhet.</string>
-	<string name="opt_out_help_ios_2">iOS 9 vagy újabb</string>
-	<string name="opt_out_help_ios_3">Nyissa meg a Beállítások → Adatvédelem→ Reklámok→ és engedélyezze a “Reklámkövetés korlátozása” beállítást</string>
-	<string name="opt_out_help_android">A mobileszköz „Reklámkövetés korlátozása” vagy „Érdeklődési kör alapú reklámozás” beállítással rendelkezhet.\n\nAndroidban és Google Play szolgáltatások 4.0 vagy újabb verzió:\nBeállítások → Google → Google fiók → Személyes és adatvédelem → Reklámok → Reklámok személyre szabása</string>
 	<string name="privacy_policy">Adatvédelmi irányelvek</string>
 	<string name="terms_of_use">Felhasználási feltételek</string>
-	<string name="backup_notification_failed">A könyvjelzői biztonsági mentése felfüggesztésre került. Jelentkezz be a visszakapcsoláshoz.</string>
 	<string name="button_layer_traffic">Forgalom</string>
 	<string name="button_layer_subway">Metró</string>
 	<string name="layers_title">Térképrétegek</string>
-	<string name="layers_message">Használjon térképrétegeket a forgalom, metrótérkép és más hasznos információ megjelenítéséhez</string>
-	<string name="button_layer_got_it">Értem</string>
 	<string name="subway_data_unavailable">A metrótérkép nem elérhető</string>
 	<string name="bookmarks_empty_list_title">A lista üres</string>
 	<string name="bookmarks_empty_list_message">A könyvjelző hozzáadásához, érintsen meg a térképen egy helyet majd érintse meg a csillag ikont</string>
 	<string name="category_desc_more">…tovább</string>
 	<string name="title_error_downloading_bookmarks">Hiba történt</string>
-	<string name="subtitle_error_downloading_bookmarks">Nem került letöltésre könyvjelző</string>
-	<string name="error_already_downloaded">Ezt a listát már letöltötték</string>
-	<string name="why_support">Miért éri meg támogatni a Organic Maps-t?</string>
-	<string name="why_support_item2">Ön segít a Organic Maps-t fejleszteni</string>
-	<string name="why_support_item3">Segítsen a térkép fejlesztésében az OpenStreetMap.org-on</string>
-	<string name="channels_map_update">Térképfrissítések</string>
-	<string name="server_unavailable_title">A szerver nem elérhető</string>
-	<string name="sharing_options">A hozzáférés beállításai</string>
 	<string name="export_file">Fájl exportálása</string>
 	<string name="list_settings">Lista beállításai</string>
 	<string name="delete_list">Törölni a listát</string>
-	<string name="hide_from_map">Lefedés a térképen</string>
 	<string name="public_access">Nyílt hozzáférés</string>
 	<string name="limited_access">Személyes hozzáférés</string>
 	<string name="bookmark_category_name">Kategória</string>
 	<string name="bookmark_category_description_hint">Leírás hozzáadása (szöveg vagy html)</string>
 	<string name="not_shared">Privát</string>
-	<string name="direct_link_progress_text">Betöltjük az Ön fájlát…</string>
-	<string name="direct_link_success">A hivatkozás létre van hozva</string>
-	<string name="send_a_link_btn">Hivatkozás küldése</string>
-	<string name="upload_error_toast">A fájl feltöltésekor hiba történt</string>
 	<string name="tags_loading_error_subtitle">A tag-ek feltöltésekor hiba történt, kérjük próbálja meg még egyszer</string>
-	<string name="unable_upload_errorr_title">Nem sikerült a fájl feltöltése</string>
-	<string name="unable_upload_error_subtitle_edited">A fájl a web alkalmazáson keresztül volt újraszerkesztve</string>
-	<string name="unable_upload_error_subtitle_broken">A fájl sérült és nem lehet feltölteni. Kérjük, más fájlt töltsön fel.</string>
-	<string name="contact">Írás</string>
-	<string name="download_button">Letöltés</string>
 	<string name="speedcams_alert_title">Sebességmérő kamerák</string>
-	<string name="speedcams_alert_subtitle">Figyelmeztetés a sebessség korlátozására</string>
 	<string name="speedcam_option_auto">Autó</string>
 	<string name="speedcam_option_always">Mindig</string>
 	<string name="speedcam_option_never">Soha</string>
-	<string name="bookmark_description_title">A jel ismertetése</string>
 	<string name="place_description_title">A hely ismertetése</string>
 	<!-- this text will be shown in application notification preferences opposite checkbox which enable/disable downloader notifications. Devices on Android 8+ are affected. -->
 	<string name="notification_channel_downloader">Kártyák letöltése</string>
-	<string name="share_bookmarks_email_body_link">Üdvözlöm!\n\nA jeleit le lehet tölteni ezzel a linkkel: %s. Nyíssa meg a listát Organic Maps segítségével és élvezze az utazását!\n\nAlkalmazás letöltése: https://omaps.app/get?kmz</string>
-	<string name="warning_speedcams_title">Navigátor értesít a kamerákról sebességkorlátozás megsértésénél %d km/óra-ra</string>
-	<string name="warning_speedcams_subtitle">Ne felejtse el megismerkedni a cél ország közlekedési szabályaival.</string>
 	<string name="speedcams_notice_message">Autó - Figyelmeztetés a sebesség kamerákról, ha van kockázat a sebesség korlátozás megsértéséről\nMindig - Mindig figyelmeztet a kamerákról\nSoha - Soha ne figyelmezet a kamerákról</string>
 	<string name="power_managment_title">Energiatakarékos mód</string>
 	<string name="power_managment_description">Amikor az automatikus mód van kiválasztva, az alkalmazás elkezdi kikapcsolni az akkumulátort merítő funkciókat a jelenlegi akkumulátor töltöttség alapján</string>
@@ -1075,14 +659,7 @@
 	<string name="power_managment_setting_auto">Automatikus</string>
 	<string name="power_managment_setting_manual_max">Maximális energiatakarékosság</string>
 	<string name="enable_logging_warning_message">Az opció bekapcsolja a diagnosztikai célú naplózást. Hasznos lehet a support csapatunknak, akik elhárítják az alkalmazás hibáit. Csak a Organic Maps support kérésére kapcsold be ezt az opciót.</string>
-	<string name="html_error_upload_message_try_again">Kérjük ellenőrizd a hálózati beállításaidat és próbáld újra</string>
-	<string name="html_error_upload_title_try_again">Nincs internetkapcsolat</string>
-	<string name="notification_leave_review_v2_android_short_title">Értékelj és segítsd az utazókat!</string>
-	<string name="notifications_illegal_alert_disable_button">Értesítések kikapcsolása</string>
 	<string name="access_rules_author_only">Online szerkesztés</string>
-	<string name="privacy_settings_menu">Adatvédelmi beállítások</string>
-	<string name="unable_upadate_error_title">Fájl frissítés sikertelen</string>
-	<string name="unable_upadate_error_message">Néhány hiba történt frissítés közben. Kérjük ellenőrizd a változtatásokat és próbáld újra</string>
 	<string name="driving_options_title">Vezetési lehetőségek</string>
 	<string name="driving_options_subheader">Elkerülés minden útvonalon</string>
 	<string name="avoid_tolls">Fizetős utak</string>
@@ -1093,52 +670,14 @@
 	<string name="unable_to_calc_alert_subtitle">Sajnos nem találunk útvonalat, valószínűleg az általad meghatározott lehetőségek miatt. Kérjük változtass a beállításokon és próbáld újra</string>
 	<string name="define_to_avoid_btn">Elkerülendő utak meghatározása</string>
 	<string name="change_driving_options_btn">Vezetési lehetőségek bekapcsolva</string>
-	<string name="toll_road">Fizetős utak</string>
-	<string name="unpaved_road">Kövezetlen utak</string>
-	<string name="ferry_crossing">Kompátkelők</string>
-	<string name="operated_by">\"%s\" működteti</string>
 	<string name="avoid_toll_roads_placepage">Fizetős utak elkerülése</string>
 	<string name="avoid_unpaved_roads_placepage">Kövezetlen utak elkerülése</string>
 	<string name="avoid_ferry_crossing_placepage">Kompátkelők elkerülése</string>
-	<string name="type.cuisine.uzbek">Üzbég konyha</string>
-	<string name="trip_start">Gyerünk</string>
-	<string name="pick_destination">Cél</string>
-	<string name="follow_my_position">Középre</string>
-	<string name="search_results">Keresési eredmények</string>
-	<string name="then_turn">Utána</string>
-	<string name="redirect_route_alert">Szeretnél újratervezni egy útvonalat?</string>
-	<string name="redirect_route_yes">Igen</string>
-	<string name="redirect_route_no">Nem</string>
-	<string name="trip_finished">Megérkeztél!</string>
-	<string name="keyboard_availability_alert">A billentyűzet nem elérhető vezetés közben</string>
-	<string name="dialog_routing_change_start_carplay">Nem lehet útvonalat tervezni a jelenlegi helyedről</string>
-	<string name="dialog_routing_change_end_carplay">Nem lehet útvonalat tervezni a célodhoz. Kérjük válassz egy másik pontot</string>
-	<string name="dialog_routing_check_gps_carplay">Nincs GPS-jel. Kérjük menj egy nyílt területre</string>
-	<string name="dialog_routing_unable_locate_route_carplay">Nem lehet útvonalat tervezni. Kérjük határozz meg más útvonal lehetőségeket</string>
-	<string name="dialog_routing_download_files_carplay">Útvonal létrehozásához töltsd le a hiányzó térképeket az eszközre</string>
-	<string name="dialog_routing_system_error_carplay">Hiba történt. Kérjük indítsd újra az alkalmazást</string>
-	<string name="dialog_routing_rebuild_from_current_location_carplay">Az útvonal újra lesz tervezve a jelenlegi helyzetedről</string>
-	<string name="dialog_routing_rebuild_for_vehicle_carplay">Az útvonal módosítva lesz egy autó számára</string>
 	<string name="ok">Oké</string>
-	<string name="avoid_unpaved_carplay_1">Nem földút</string>
-	<string name="avoid_unpaved_carplay_2">Földút kerülése</string>
-	<string name="avoid_ferry_carplay_1">Komp nélkül</string>
-	<string name="avoid_ferry_carplay_2">Kompok kerülése</string>
-	<string name="avoid_tolls_carplay_1">Nincs útdíj</string>
-	<string name="avoid_tolls_carplay_2">Útdíj kerülése</string>
-	<string name="speedcams_alert_title_carplay_1">Traffipaxok</string>
-	<string name="speedcams_alert_title_carplay_2">Sebességjelzés</string>
-	<string name="download_map_carplay">Kérjük, töltsd le a térképeket a Organic Maps alkalmazásban az eszközödre</string>
-	<string name="carplay_roundabout_exit">%s kijárat</string>
 	<!-- max. 10 symbols, both iOS and Android -->
 	<string name="sort">Rendezd…</string>
 	<!-- Android, title, max 20-22 symbols -->
 	<string name="sort_bookmarks">Könyvelzők rendezése</string>
-	<!-- iOS -->
-	<string name="sort_default">Alapértelmezés szerint</string>
-	<string name="sort_type">Típus szerint</string>
-	<string name="sort_distance">Távolság szerint</string>
-	<string name="sort_date">Dátum szerint</string>
 	<!-- Android -->
 	<string name="by_default">Alapértelmezés szerint</string>
 	<!-- Android -->
@@ -1147,65 +686,23 @@
 	<string name="by_distance">Távolság szerint</string>
 	<!-- Android -->
 	<string name="by_date">Dátum szerint</string>
-	<string name="week_ago_sorttype">Egy hete</string>
-	<string name="month_ago_sorttype">Egy hónapja</string>
-	<string name="moremonth_ago_sorttype">Több mint egy hónapja</string>
-	<string name="moreyear_ago_sorttype">Több mint egy éve</string>
-	<string name="near_me_sorttype">Hozzám közel</string>
-	<string name="others_sorttype">Más</string>
-	<string name="food_places">Étel</string>
-	<string name="tourist_places">Látnivalók</string>
-	<string name="museums">Múzeumok</string>
-	<string name="parks">Parkok</string>
-	<string name="swim_places">Úszás</string>
-	<string name="mountains">Hegyek</string>
-	<string name="animals">Állatok</string>
-	<string name="hotels">Hotelek</string>
-	<string name="buildings">Épületek</string>
-	<string name="money">Pénz</string>
-	<string name="shops">Üzletek</string>
-	<string name="parkings">Parkolók</string>
-	<string name="fuel_places">Benzinkutak</string>
-	<string name="water">Víz</string>
-	<string name="medicine">Gyógyszer</string>
 	<string name="search_in_the_list">Keresés a listában</string>
-	<string name="view_on_map_bookmarks">Térképen</string>
-	<string name="more_bookmarks">Továbbiak…</string>
-	<string name="no_items_found">Nincs találat</string>
-	<!-- Android, max 18 symbols -->
-	<string name="bookmarks_edit_list">Lista szerkesztése</string>
-	<!-- Android, max 18 symbols -->
-	<string name="bookmarks_delete_list">Lista törlése</string>
-	<string name="religious_places">Vallási helyek</string>
 	<string name="select_list">Lista kiválasztása</string>
 	<string name="transit_not_found">Metró navigáció ebben a régióban még nem érhető el</string>
 	<string name="dialog_pedestrian_route_is_long_header">Metró útvonal nem található</string>
 	<string name="dialog_pedestrian_route_is_long_message">Válasszon indulási vagy végpontot közelebb a metróállomáshoz</string>
-	<!-- Failed planning SUBWAY route message in navigation view -->
-	<string name="routing_planning_error_subway_special">A metró útvonaltervezése sikertelen</string>
 	<string name="button_layer_isolines">Terep</string>
-	<string name="tips_map_layers_title_countour">Újdonság a Organic Maps-n: offline topográfiai réteg!</string>
-	<string name="tips_map_layers_message_countour">Tervezze meg és élvezze a természetjáró kirándulásait, és tudjon meg mindent a környékről</string>
 	<string name="isolines_activation_error_dialog">A topográfiai réteg aktiválásához és használatához kérjük frissítse vagy töltse le az adott terület térképét</string>
 	<string name="isolines_location_error_dialog">Ezen a területen a topográfiai réteg még nem elérhető</string>
 	<string name="elevation_profile_diff_level">Nehézségi szint</string>
-	<string name="elevation_profile_diff_level_easy">Könnyű</string>
-	<string name="elevation_profile_diff_level_moderate">Mérsékelt</string>
-	<string name="elevation_profile_diff_level_hard">Nehéz</string>
 	<string name="elevation_profile_ascent">Felemelkedés</string>
 	<string name="elevation_profile_descent">Leereszkedés</string>
 	<string name="elevation_profile_minaltitude">Min. magasság</string>
 	<string name="elevation_profile_maxaltitude">Max. magasság</string>
-	<string name="elevation_profile_m">m</string>
 	<string name="elevation_profile_difficulty">Nehézség</string>
 	<string name="elevation_profile_distance">Táv.:</string>
-	<string name="elevation_profile_km">km</string>
 	<string name="elevation_profile_time">Idő</string>
-	<string name="elevation_profile_hours">ó.</string>
-	<string name="elevation_profile_minutes">p.</string>
 	<string name="isolines_toast_zooms_1_10">Nagyítás az isovonalak felfedezéséhez</string>
-	<string name="downloader_updating_ios">Feltöltés</string>
-	<string name="downloader_loading_ios">Letöltés</string>
 	<string name="key_information_title">Kulcs információ</string>
 	<string name="enable_screen_sleep">Hagyja aludni a képernyőt</string>
 	<!-- Description in preferences -->

--- a/android/res/values-in/strings.xml
+++ b/android/res/values-in/strings.xml
@@ -12,15 +12,11 @@
 	<string name="cancel_download">Batalkan Pengunduhan</string>
 	<!-- Button which deletes downloaded country -->
 	<string name="delete">Hapus</string>
-	<!-- Button "do not interrupt download" if user touched actively downloading country -->
-	<string name="do_nothing">Lanjutkan</string>
 	<string name="download_maps">Unduh Peta</string>
 	<!-- Settings/Downloader - info for country when download fails -->
 	<string name="download_has_failed">Pengunduhan gagal, sentuh untuk mencoba sekali lagi</string>
 	<!-- Settings/Downloader - info for country which started downloading -->
 	<string name="downloading">Sedang mengunduh…</string>
-	<!-- Settings/Downloader - size string, only strings different from English should be translated -->
-	<string name="kb">kB</string>
 	<!-- Choose measurement on first launch alert - choose metric system button -->
 	<string name="kilometres">Kilometer</string>
 	<!-- Leave Review dialog - Review button -->
@@ -35,45 +31,31 @@
 	<string name="core_my_position">Posisi Saya</string>
 	<!-- Update maps later/Buy pro version later button text -->
 	<string name="later">Nanti</string>
-	<!-- Don't show some dialog any more -->
-	<string name="never">Tidak akan pernah</string>
 	<!-- View and button titles for accessibility -->
 	<string name="search">Cari</string>
 	<!-- Search box placeholder text -->
 	<string name="search_map">Cari Peta</string>
-	<!-- Settings/Downloader - info for not downloaded country -->
-	<string name="touch_to_download">Sentuh untuk mengunduh</string>
 	<!-- Settings/Downloader - 3G download warning dialog confirm button -->
 	<string name="use_cellular_data">Ya</string>
 	<!-- Location services are disabled by user alert - message -->
 	<string name="location_is_disabled_long_text">Saat ini semua Layanan Lokasi untuk perangkat atau aplikasi ini non-aktif. Mohon aktifkan lewat Setelan.</string>
-	<!-- Location Services are not available on the device alert - message -->
-	<string name="device_doesnot_support_location_services">Perangkat Anda tidak mendukung Layanan Lokasi</string>
 	<!-- View and button titles for accessibility -->
 	<string name="zoom_to_country">Tampilkan di peta</string>
-	<!-- Button text for the button at the center of the screen when the country is not downloaded -->
-	<string name="country_status_download">Unduh Peta\n(^ ^)</string>
 	<!-- Button text for the button at the center of the screen when the country is not downloaded and the size should not be shown -->
 	<string name="country_status_download_without_size">Unduh Peta</string>
-	<!-- Button text for the button at the center of the screen when the country is not downloaded -->
-	<string name="country_status_download_without_routing">Unduh peta tanpa\nperutean (^ ^)</string>
 	<!-- Message to display at the center of the screen when the country download has failed -->
 	<string name="country_status_download_failed">Sedang Mengunduh telah gagal</string>
 	<!-- Button text for the button under the country_status_download_failed message -->
 	<string name="try_again">Coba Lagi</string>
 	<string name="about_menu_title">Tentang Organic Maps</string>
-	<string name="downloaded_touch_to_delete">(%s) telah diunduh, sentuh untuk menghapus</string>
 	<string name="connection_settings">Pengaturan Koneksi</string>
-	<string name="download_mb_or_kb">Unduh %s</string>
 	<string name="close">Tutup</string>
 	<string name="unsupported_phone">OpenGL yang dipercepat oleh OpenGL diperlukan. Sayangnya, perangkat Anda tidak mendukung.</string>
 	<string name="download">Unduh</string>
-	<string name="external_storage_is_not_available">Penyimpanan kartu SD/USB dengan peta terunduh tidak tersedia</string>
 	<string name="disconnect_usb_cable">Mohon lepas kabel USB atau masukkan kartu memori untuk menggunakan Organic Maps</string>
 	<string name="not_enough_free_space_on_sdcard">Mohon bebaskan sejumlah ruang pada kartu SD/penyimpanan USB terlebih dahulu untuk menggunakan aplikasi</string>
 	<string name="not_enough_memory">Memori tidak cukup untuk meluncurkan aplikasi</string>
 	<string name="download_resources">Sebelum Anda mulai izinkan kami mengunduh peta dunia secara umum ke perangkat Anda.\nHal ini memerlukan data %s.</string>
-	<string name="getting_position">Sedang mencari lokasi saat ini</string>
 	<string name="download_resources_continue">Pergi ke Peta</string>
 	<string name="downloading_country_can_proceed">Sedang mengunduh %s. Sekarang Anda dapat melanjutkan ke peta.</string>
 	<string name="download_country_ask">Unduh %s?</string>
@@ -86,30 +68,20 @@
 	<string name="download_country_failed">%s gagal diunduh</string>
 	<!-- Add New Bookmark Set dialog title -->
 	<string name="add_new_set">Tambahkan Set baru</string>
-	<!-- Place Page - Add To Bookmarks button -->
-	<string name="add_to_bookmarks">Tambahkan ke Penanda</string>
 	<!-- Bookmark Color dialog title -->
 	<string name="bookmark_color">Warna Penanda</string>
 	<!-- Add Bookmark Set dialog - hint when set name is empty -->
 	<string name="bookmark_set_name">Nama Set Penanda</string>
-	<!-- Bookmark Sets dialog title -->
-	<string name="bookmark_sets">Set Penanda</string>
 	<!-- Bookmarks - dialog title -->
 	<string name="bookmarks">Penanda</string>
-	<!-- Add bookmark dialog - bookmark color -->
-	<string name="color">Warna</string>
 	<!-- Default bookmarks set name -->
 	<string name="core_my_places">Tempat-tempat Saya</string>
 	<!-- Add bookmark dialog - bookmark name -->
 	<string name="name">Nama</string>
 	<!-- Editor title above street and house number -->
 	<string name="address">Alamat</string>
-	<!-- Place Page - Remove Pin button -->
-	<string name="remove_pin">Hapus Pin</string>
 	<!-- Add bookmark dialog - bookmark set, Bookmarks dialog - Bookmark set cell -->
 	<string name="set">Set</string>
-	<!-- Text hint in Bookmarks dialog when no any bookmarks are added -->
-	<string name="bookmarks_usage_hint">Belum ada yang ditandai.\nSentuh lokasi apa pun pada peta untuk menandai.\nPenanda dari sumber lainnya juga dapat di impor dan ditampilkan pada Organic Maps. Buka berkas KML/KMZ tersebut dengan penanda yang disimpan dari surel, Dropbox atau tautan jaringan.</string>
 	<!-- Settings button in system menu -->
 	<string name="settings">Pengaturan</string>
 	<!-- Header of settings activity where user defines storage path -->
@@ -120,10 +92,6 @@
 	<string name="move_maps">Pindahkan peta?</string>
 	<!-- Ask to wait user several minutes (some long process in modal dialog). -->
 	<string name="wait_several_minutes">Ini akan memakan waktu beberapa menit.\nMohon tunggu…</string>
-	<!-- Show bookmarks from this category on a map or not -->
-	<string name="visible">Tampak</string>
-	<!-- Toast which is displayed when GPS has been deactivated -->
-	<string name="gps_is_disabled_long_text">GPS dinon-aktifkan. Mohon aktifkan lewat Pengaturan.</string>
 	<!-- Measurement units title in settings activity -->
 	<string name="measurement_units">Unit Pengukuran</string>
 	<!-- Detailed description of Measurement Units settings button -->
@@ -164,12 +132,8 @@
 	<string name="post">Pos</string>
 	<!-- Search category -->
 	<string name="police">Polisi</string>
-	<!-- String in search result list, when nothing found -->
-	<string name="no_search_results_found">Tidak ada hasil yang ditemukan</string>
 	<!-- Notes field in Bookmarks view -->
 	<string name="description">Catatan</string>
-	<!-- Button text -->
-	<string name="share_by_email">Bagikan menggunakan surel</string>
 	<!-- Email Subject when sharing bookmarks category -->
 	<string name="share_bookmarks_email_subject">Bagikan penanda Organic Maps</string>
 	<!-- message title of loading file -->
@@ -182,20 +146,10 @@
 	<string name="edit">Edit</string>
 	<!-- Warning message when doing search around current position -->
 	<string name="unknown_current_position">Lokasi Anda belum ditentukan</string>
-	<!-- Warning message when location country isn't downloaded during search (see also download_location_map_proposal). -->
-	<string name="download_location_country">Unduh negara di mana Anda berada saat ini (%s)</string>
-	<!-- Warning message when viewport country isn't downloaded during search -->
-	<string name="download_viewport_country_to_search">Unduh negara yang lokasinya sedang Anda cari (%s)</string>
 	<!-- Alert message that we can't run Map Storage settings due to some reasons. -->
 	<string name="cant_change_this_setting">Maaf, pengaturan Penyimpanan Peta saat ini sedang non-aktif.</string>
 	<!-- Alert message that downloading is in progress. -->
 	<string name="downloading_is_active">Pengunduhan negara sedang berjalan.</string>
-	<!-- Message that will be shown in alert view, when we ask user to leave review on App Store -->
-	<string name="appStore_message">Kami harap Anda senang menggunakan Organic Maps! Jika ya, mohon beri nilai atau ulasan untuk aplikasi ini di App Store. Hanya memakan waktu kurang dari satu menit tetapi hal itu dapat benar-benar membantu kami. Terima kasih atas dukungan Anda!</string>
-	<!-- No, thanks -->
-	<string name="no_thanks">Tidak, terima kasih</string>
-	<!-- Share one specific bookmark using SMS, %1$@ contains om:// and %2$@ https://omaps.app link. @NOTE non-ascii symbols in the link will result in max 70 characters SMS instead of 140. -->
-	<string name="bookmark_share_sms">Hei, lihat pinku di Organic Maps! %1$s atau %2$s belum memiliki peta offline? Unduh di sini: https://omaps.app/get</string>
 	<!-- Share my position using SMS, %1$@ contains om:// and %2$@ https://omaps.app link WITHOUT NAME. @NOTE non-ascii symbols in the link will result in max 70 characters SMS instead of 140. -->
 	<string name="my_position_share_sms">Hei, lihat lokasiku saat ini di Organic Maps! %1$s atau %2$s belum memiliki peta offline? Unduh di sini: https://omaps.app/get</string>
 	<!-- Subject for emailed bookmark -->
@@ -204,30 +158,16 @@
 	<string name="my_position_share_email_subject">Hei, lihat lokasiku saat ini di peta Organic Maps!</string>
 	<!-- Share my position using EMail, %1$@ is om:// and %2$@ is https://omaps.app link WITHOUT NAME -->
 	<string name="my_position_share_email">Hai,\n\nSekarang saya ada di sini: %1$s. Klik tautan ini %2$s atau yang ini %3$s untuk melihat tempatnya di peta.\n\nTerima kasih.</string>
-	<!-- Android share by Message/SMS button text (including SMS) -->
-	<string name="share_by_message">Bagikan menggunakan pesan</string>
 	<!-- Share button text which opens menu with more buttons, like Message, EMail, Facebook etc. -->
 	<string name="share">Bagikan</string>
-	<!-- iOS share by Message button text (including SMS) -->
-	<string name="message">Pesan</string>
 	<!-- Share by email button text, also used in editor. -->
 	<string name="email">Surel</string>
-	<!-- Copy Link -->
-	<string name="copy_link">Salin Tautan</string>
-	<!-- Text for the button that returns to caller application -->
-	<string name="more_info">Tampilkan Lebih Banyak Info</string>
 	<!-- Text for message when used successfully copied something -->
 	<string name="copied_to_clipboard">Telah Disalin ke Papan Klip: %1$s</string>
 	<!-- place preview title -->
 	<string name="info">Info</string>
 	<!-- Used for bookmark editing -->
 	<string name="done">Selesai</string>
-	<!-- Summary for preferences in MWM -->
-	<string name="yopme_pref_summary">Pilih pengaturan Layar Belakang</string>
-	<!-- Title for yopme preferences in MWM -->
-	<string name="yopme_pref_title">Pengaturan Layar Belakang</string>
-	<!-- Hint for upper-right icon p2b -->
-	<string name="show_on_backscreen">Tampilkan pada layar Belakang</string>
 	<!-- Prints version number in About dialog -->
 	<string name="version">Versi: %s</string>
 	<!-- Confirmation in downloading countries dialog -->
@@ -237,11 +177,6 @@
 	<!-- Length of track in cell that describes route -->
 	<string name="length">Panjang</string>
 	<string name="share_my_location">Bagikan Lokasi Saya</string>
-	<string name="menu_search">Cari</string>
-	<!-- Settings screen: "Map" category title -->
-	<string name="prefs_group_map">Peta</string>
-	<!-- Settings screen: "Miscellaneous" category title -->
-	<string name="prefs_group_misc">Lain-Lain</string>
 	<string name="prefs_group_route">Navigasi</string>
 	<string name="pref_zoom_title">Tombol perbesaran</string>
 	<string name="pref_zoom_summary">Tampilkan pada layar</string>
@@ -257,8 +192,6 @@
 	<string name="pref_map_3d_title">Pandangan perspektif</string>
 	<!-- Settings «Map» category: «3D buildings» title -->
 	<string name="pref_map_3d_buildings_title">Bangunan 3D</string>
-	<!-- Settings «Map» category: «3D buildings» summary -->
-	<string name="pref_map_3d_buildings_subtitle">Memengaruhi daya baterai</string>
 	<!-- Settings «Route» category: «Tts enabled» title -->
 	<string name="pref_tts_enable_title">Petunjuk Suara</string>
 	<!-- Settings «Route» category: «Tts language» title -->
@@ -267,7 +200,6 @@
 	<string name="pref_tts_unavailable">Tidak Tersedia</string>
 	<!-- Title for "Other" section in TTS settings. -->
 	<string name="pref_tts_other_section_title">Lainnya</string>
-	<string name="pref_tts_how_to_set_up_voice">Cara mengatur suara</string>
 	<!-- Settings «Map» category: «Record track» title -->
 	<string name="pref_track_record_title">Jalur terkini</string>
 	<string name="pref_map_auto_zoom">Perbesar otomatis</string>
@@ -278,40 +210,11 @@
 	<string name="duration_12_hours">12 jam</string>
 	<string name="duration_1_day">1 hari</string>
 	<string name="recent_track_help_text">Ini memungkinkan Anda untuk merekam jalur yang telah dilalui selama jangka waktu tertentu dan melihatnya pada peta. Harap ketahui: aktivasi fungsi ini menyebabkan peningkatan penggunaan baterai. Trek akan dihapus secara otomatis dari peta setelah selang waktu berakhir.</string>
-	<string name="pref_track_ios_caption">Jalur terakhir menunjukkan jalur yang sudah Anda lalui.</string>
-	<string name="pref_track_ios_subcaption">Silakan pilih jangka waktu penyimpanan jalur.</string>
-	<string name="placepage_distance">Jarak</string>
-	<string name="placepage_coordinates">Koordinat</string>
-	<string name="placepage_unsorted">Tidak diurutkan</string>
 	<string name="search_show_on_map">Tampilkan pada peta</string>
-	<!-- Used to warn user when fixing KitKat issue -->
-	<string name="bookmark_move_fail">Kami perlu memindahkan penanda lokasi Anda ke memori internal, tetapi tidak ada ruang yang tersedia. Mohon bebaskan memori, atau penanda lokasi tidak akan tersedia.</string>
-	<!-- 1st search button-like result -->
-	<string name="search_on_map">Cari ada peta</string>
-	<!-- toast with an error -->
-	<string name="no_route_found">Tidak ada rute yang ditemukan</string>
-	<!-- route title -->
-	<string name="route">Rute</string>
-	<!-- category title -->
-	<string name="routes">Rute</string>
-	<!-- text of notification -->
-	<string name="download_map_notification">Unduh peta tempat di mana Anda berada sekarang</string>
-	<!-- Dialog for transferring maps from lite to pro. -->
-	<string name="move_lite_maps_to_pro">Kami sedang mentransfer peta unduhan Anda dari Organic Maps Lite ke Organic Maps. Proses ini mungkin membutuhkan waktu beberapa menit.</string>
-	<!-- Message to display when maps moved. -->
-	<string name="move_lite_maps_to_pro_ok">Peta unduhan Anda berhasil ditransfer ke Organic Maps.</string>
-	<!-- Message to display when maps move failed. -->
-	<string name="move_lite_maps_to_pro_failed">Peta Anda gagal ditransfer. Silakan hapus Organic Maps Lite dan unduh peta lagi.</string>
-	<!-- Text in menu -->
-	<string name="settings_and_more">Setelan &amp;amp; Lebih Banyak</string>
 	<!-- Text in menu -->
 	<string name="website">Situs Web</string>
-	<!-- Text in menu -->
-	<string name="contact_us">Hubungi kami</string>
 	<!-- Settings: Send feedback button and dialog title -->
 	<string name="feedback">Umpan balik</string>
-	<!-- Text in menu -->
-	<string name="subscribe_to_news">Berlangganan berita kami</string>
 	<!-- Text in menu -->
 	<string name="rate_the_app">Beri nilai aplikasi</string>
 	<!-- Text in menu -->
@@ -320,12 +223,6 @@
 	<string name="copyright">Hak cipta</string>
 	<!-- Text in menu -->
 	<string name="report_a_bug">Laporkan gangguan</string>
-	<!-- Email subject -->
-	<string name="subscribe_me_subject">Mohon daftarkan saya untuk berlangganan berita Organic Maps</string>
-	<!-- Email body -->
-	<string name="subscribe_me_body">Saya ingin menjadi yang pertama untuk mengetahui kabar dan promosi terbaru. Saya dapat membatalkan langganan saya kapan saja.</string>
-	<!-- About text -->
-	<string name="about_text">Organic Maps menawarkan peta offline tercepat dari semua kota, semua negara di dunia. Berpergianlah dengan kepercayaan diri yang penuh: di nana pun Anda berada, Organic Maps akan membantu Anda mengetahui posisi Anda pada peta, menemukan restoran, hotel, bank, stasiun bahan bakar terdekat, dll. Tidak perlu koneksi internet.Kami selalu membuat fitur-fitur baru dan ingin mendengar pendapat Anda mengenai bagaimana kami dapat membuat Organic Maps menjadi lebih baik. Jika Anda memiliki masalah apa pun dengan aplikasinya, jangan segan untuk menghubungi kami di support\@organicmaps.app. Kami akan merespons setiap permintaan!Apakah Anda menyukai Organic Maps an ingin membantu kami? Terdapat beberapa cara yang mudah dan sepenuhnya gratis:- tulis ulasan di App Market Anda</string>
 	<!-- Alert text -->
 	<string name="email_error_body">Surel pelanggan belum diatur. Mohon konfigurasikan atau gunakan cara lain untuk menghubungi kami di %s</string>
 	<!-- Alert title -->
@@ -334,136 +231,55 @@
 	<string name="pref_calibration_title">Kalibrasi kompas</string>
 	<!-- Search category -->
 	<string name="wifi">WiFi</string>
-	<!-- Update map suggestion -->
-	<string name="routing_map_outdated">Mohon perbarui peta untuk membuat rute</string>
-	<!-- Update maps suggestion -->
-	<string name="routing_update_maps">Versi Organic Maps yang terbaru memungkinkan pembuatan rute dari posisi Anda saat itu ke titik tujuan. Mohon perbarui peta untuk menggunakan fitur ini.</string>
 	<!-- Update all button text -->
 	<string name="downloader_update_all_button">Perbarui semua</string>
 	<!-- Cancel all button text -->
 	<string name="downloader_cancel_all">Batalkan Semuanya</string>
 	<!-- Downloaded maps category -->
 	<string name="downloader_downloaded_subtitle">Diunduh</string>
-	<!-- Downloaded maps category -->
-	<string name="downloader_available_maps">Tersedia</string>
 	<!-- Country queued for download -->
 	<string name="downloader_queued">Telah diantrekan</string>
 	<string name="downloader_near_me_subtitle">Dekat saya</string>
 	<string name="downloader_status_maps">Peta</string>
 	<string name="downloader_download_all_button">Unduh semua</string>
 	<string name="downloader_downloading">Mengunduh:</string>
-	<string name="downloader_search_results">Ditemukan</string>
-	<!-- Disclaimer message -->
-	<string name="routing_disclaimer">Dalam membuat rute di aplikasi Organic Maps, mohon ingat:\n\n- Rute yang disarankan hanya dapat dianggap sebagai rekomendasi.\n- Kondisi jalan, peraturan dan tanda-tanda lalu lintas memiliki prioritas yang lebih tinggi daripada saran navigasi.\n- Kondisi jalan, peraturan dan tanda-tanda lalu lintas memiliki prioritas yang lebih tinggi daripada saran navigasi.\n- Peta bisa saja salah atau sudah usang, dan rute yang dibuat mungkin bukan yang terbaik.\n\nBerhati-hatilah di jalan dan jagalah diri Anda sendiri!</string>
-	<!-- Outdated maps category -->
-	<string name="downloader_outdated_maps">Usang</string>
-	<!-- Up to date maps category -->
-	<string name="downloader_uptodate_maps">Terkini</string>
 	<!-- Status of outdated country in the list -->
 	<string name="downloader_status_outdated">Perbarui</string>
 	<!-- Status of failed country in the list -->
 	<string name="downloader_status_failed">Gagal</string>
 	<!-- Displayed in a dialog that appears when a user tries to delete a map while the app is in the follow route mode -->
 	<string name="downloader_delete_map_while_routing_dialog">Untuk menghapus peta, silakan hentikan navigasi.</string>
-	<!-- Show when user try build route, but we don't know where he -->
-	<string name="routing_failed_unknown_my_position">Lokasi saat ini tidak diketahui. Mohon masukkan lokasi untuk membuat rute.</string>
-	<!-- Show if use has not routing file, or InconsistentMWMandRoute -->
-	<string name="routing_failed_has_no_routing_file">Data tambahan yang diperlukan untuk membuat rute dari lokasi Anda.</string>
-	<!-- StartPointNotFound -->
-	<string name="routing_failed_start_point_not_found">Tidak dapat memperhitungkan rute. Tidak ada jalan di dekat titik Anda mulai.</string>
-	<!-- EndPointNotFound -->
-	<string name="routing_failed_dst_point_not_found">Tidak dapat memperhitungkan rute. Tidak ada jalan di dekat tujuan Anda.</string>
 	<!-- PointsInDifferentMWM -->
 	<string name="routing_failed_cross_mwm_building">Rute hanya dapat dibuat dengan yang seluruhnya ada di dalam peta tunggal.</string>
-	<!-- RouteNotFound -->
-	<string name="routing_failed_route_not_found">Tidak ada rute yang ditemukan antara tempat asal dan tujuan yang dipilih. Mohon pilih titik mulai atau tujuan yang berbeda.</string>
-	<!-- InternalError -->
-	<string name="routing_failed_internal_error">Terjadi gangguan internal. Mohon coba menghapus dan mengunduh petanya lagi. Jika masih terjadi masalah mohon hubungi kami di support\@organicmaps.app.</string>
-	<!-- Context menu item for downloader. -->
-	<string name="downloader_download_map_and_routing">Untuh Peta + Rute</string>
-	<!-- Context menu item for downloader. -->
-	<string name="downloader_download_routing">Unduh Rute</string>
-	<!-- Context menu item for downloader. -->
-	<string name="downloader_delete_routing">Hapus Rute</string>
 	<!-- Context menu item for downloader. -->
 	<string name="downloader_download_map">Unduh peta</string>
-	<string name="downloader_download_map_no_routing">Unduh peta tanpa perutean</string>
-	<!-- Button for routing. -->
-	<string name="routing_go">Mulai!</string>
 	<!-- Item status in downloader. -->
 	<string name="downloader_retry">Ulangi</string>
-	<!-- Item in context menu. -->
-	<string name="downloader_map_and_routing">Peta + Rute</string>
 	<!-- Item in context menu. -->
 	<string name="downloader_delete_map">Hapus Peta</string>
 	<!-- Item in context menu. -->
 	<string name="downloader_update_map">Perbarui Peta</string>
-	<!-- Item in context menu. -->
-	<string name="downloader_update_map_and_routing">Perbarui Peta + Rute</string>
-	<!-- Item in context menu. -->
-	<string name="downloader_map_only">Hanya Peta</string>
-	<!-- Toolbar title -->
-	<string name="toolbar_application_menu">Menu aplikasi</string>
 	<!-- Preference text -->
 	<string name="pref_use_google_play">Gunakan Layanan Google Play untuk mendapatkan lokasi Anda saat ini</string>
 	<!-- Text for rating dialog -->
 	<string name="rating_just_rated">Saya baru saja menilai app Anda</string>
-	<!-- Text for rating dialog -->
-	<string name="rating_user_since">Saya pengguna Organic Maps sejak %s</string>
-	<!-- Text for rating dialog -->
-	<string name="rating_do_like_maps">Anda suka Organic Maps?</string>
-	<!-- Text for rating dialog -->
-	<string name="rating_tap_star">Ketuk bintang untuk menilai app kami.</string>
 	<!-- Text for rating dialog -->
 	<string name="rating_thanks">Terima kasih!</string>
 	<!-- Text for rating dialog -->
 	<string name="rating_share_ideas">Bagikan ide atau masalah, sehingga kami dapat meningkatkan app ini untuk Anda.</string>
 	<!-- Text for rating dialog -->
 	<string name="rating_send_feedback">Kirim umpan balik</string>
-	<!-- Text for g+ dialog -->
-	<string name="rating_google_plus">Klik g+ untuk memberi tahu teman-teman tentang aplikasi tersebut.</string>
 	<!-- Text for routing error dialog -->
 	<string name="routing_download_maps_along">Unduh peta bersama rute</string>
-	<!-- Text for routing error dialog -->
-	<string name="routing_download_map">Dapatkan peta</string>
-	<!-- Text for routing error dialog -->
-	<string name="routing_download_map_and_routing">Unduh peta yang diperbarui dan data perutean untuk mendapatkan semua fitur Organic Maps.</string>
-	<!-- Text for routing error dialog -->
-	<string name="routing_get_routing_data">Dapatkan data perutean</string>
-	<!-- Text for routing error dialog -->
-	<string name="routing_get_additional_data">Data tambahan yang diperlukan untuk membuat rute dari lokasi Anda.</string>
 	<!-- Text for routing error dialog -->
 	<string name="routing_requires_all_map">Membuat rute memerlukan semua peta dari lokasi Anda ke tujuan yang diunduh dan diperbarui.</string>
 	<!-- Text for routing error dialog -->
 	<string name="routing_not_enough_space">Ruang simpan tidak cukup</string>
-	<!-- Text for routing error dialog -->
-	<string name="routing_download_more_than_avail">Anda harus mengunduh %1$s MB, tetapi hanya %2$s MB yang tersedia.</string>
-	<!-- Text for routing error dialog -->
-	<string name="routing_download_roaming">Anda akan mengunduh %s MB menggunakan Data Seluler (dalam Roaming). Hal ini dapat mengakibatkan biaya tambahan, tergantung pada paket data seluler operator.</string>
 	<!-- bookmark button text -->
 	<string name="bookmark">bookmark</string>
-	<!-- map is not downloaded -->
-	<string name="not_found_map">Peta untuk lokasi Anda tidak diunduh</string>
 	<!-- location service disabled -->
 	<string name="enable_location_services">Mohon aktifkan Layanan Lokasi</string>
-	<!-- download map -->
-	<string name="download_map">Unduh peta untuk lokasi Anda</string>
-	<!-- download map on iPhone -->
-	<string name="download_map_iphone">Unduh peta lokasi saat ini pada iPhone Anda</string>
-	<!-- clear pin -->
-	<string name="nearby">Terdekat</string>
-	<!-- clear pin -->
-	<string name="clear_pin">Kosongkan Pin</string>
-	<!-- location is undefined -->
-	<string name="undefined_location">Lokasi saat ini tidak diketahui.</string>
-	<!-- download country of your location -->
-	<string name="download_country">Unduh negara di mana Anda berada saat ini</string>
-	<!-- download failed -->
-	<string name="download_failed">gagal diunduh</string>
-	<!-- get the map -->
-	<string name="get_the_map">Dapatkan peta</string>
 	<string name="save">Simpan</string>
-	<string name="new_group">grup baru</string>
 	<string name="create">buat</string>
 	<!-- red color -->
 	<string name="red">Đỏ</string>
@@ -481,22 +297,6 @@
 	<string name="brown">Nâu</string>
 	<!-- pink color -->
 	<string name="pink">Hồng</string>
-	<!-- deep purple color -->
-	<string name="deep_purple">Ungu Gelap</string>
-	<!-- light blue color -->
-	<string name="light_blue">Biru Muda</string>
-	<!-- cyan color -->
-	<string name="cyan">Biru Kehijauan</string>
-	<!-- teal color -->
-	<string name="teal">Biru Gelap</string>
-	<!-- lime color -->
-	<string name="lime">Kuning Gelap</string>
-	<!-- deep orange color -->
-	<string name="deep_orange">Oranye Gelap</string>
-	<!-- gray color -->
-	<string name="gray">Abu-abu</string>
-	<!-- blue gray color -->
-	<string name="blue_gray">Biru Keabu-abuan</string>
 	<!-- Wi-Fi available -->
 	<string name="WiFi_available">Ya</string>
 
@@ -512,10 +312,8 @@
 	<string name="dialog_routing_location_turn_wifi">Mohon periksa sinyal GPS Anda. Mengaktifkan Wi-Fi akan meningkatkan akurasi lokasi Anda.</string>
 	<string name="dialog_routing_location_turn_on">Aktifkan layanan lokasi</string>
 	<string name="dialog_routing_location_unknown_turn_on">TIdak dapat menemukan koordinat GPS saat ini. Aktifkan layanan lokasi untuk mengalkulasi rute.</string>
-	<string name="dialog_routing_location_unknown">TIdak dapat menemukan koordinat GPS saat ini.</string>
 	<string name="dialog_routing_download_files">Unduh file yang diperlukan</string>
 	<string name="dialog_routing_download_and_update_all">Unduh dan perbarui semua informasi peta dan perutean di sepanjang proyeksi jalan untuk mengalkulasi rute.</string>
-	<string name="dialog_routing_routes_size">File informasi rute</string>
 	<string name="dialog_routing_unable_locate_route">Tidak dapat menemukan rute</string>
 	<string name="dialog_routing_cant_build_route">Tidak dapat membuat rute.</string>
 	<string name="dialog_routing_change_start_or_end">Sesuaikan titik mula atau tujuan Anda.</string>
@@ -530,33 +328,23 @@
 	<string name="dialog_routing_system_error">Kesalahan sistem</string>
 	<string name="dialog_routing_application_error">Tidak dapat membuat rute karena kesalahan aplikasi.</string>
 	<string name="dialog_routing_try_again">Mohon coba lagi</string>
-	<string name="dialog_routing_send_error">Laporkan Masalah</string>
-	<string name="dialog_routing_if_get_cross_route">Apakah Anda ingin membuat rute yang lebih langsung yang meliputi lebih dari satu peta?</string>
-	<string name="dialog_routing_cross_route_is_optimal">Ada rute yang lebih optimal yang melewati ujung peta ini.</string>
 	<string name="not_now">Jangan Sekarang</string>
-	<string name="dialog_routing_build_route">Buat</string>
 	<string name="dialog_routing_download_and_build_cross_route">Apakah Anda ingin mengunduh peta dan membuat rute yang lebih optimal yang meliputi lebih dari satu peta?</string>
 	<string name="dialog_routing_download_cross_route">Unduh peta untuk membuat rute yang lebih optimal yang melewati ujung peta ini.</string>
-	<string name="dialog_routing_cross_route_always">Selalu lewati batas ini</string>
 
 	<!-- SECTION: Strings for downloading map from search -->
 	<string name="search_without_internet_advertisement">Untuk mulai mencari dan membuat rute, silakan unduh peta, dan Anda tidak akan membutuhkan koneksi internet lagi.</string>
 	<string name="search_select_map">Pilih Peta</string>
-	<string name="search_select_other_map">Pilih Peta Lain</string>
 	<!-- «Show» context menu -->
 	<string name="show">Tampilkan</string>
 	<!-- «Hide» context menu -->
 	<string name="hide">Sembunyikan</string>
 	<!-- «Rename» context menu -->
 	<string name="rename">Ubah nama</string>
-	<!-- Bottom sheet: expand button (should be short) -->
-	<string name="bottom_sheet_more">Lainnya…</string>
 	<!-- Failed planning route message in navigation view -->
 	<string name="routing_planning_error">Sudah sampai di tujuan</string>
 	<!-- Arrive routing message in navigation view -->
 	<string name="routing_arrive">Kedatangan: %s</string>
-	<!-- Text for routing::RouterResultCode::FileTooOld dialog. -->
-	<string name="dialog_routing_download_and_update_maps">Untuk membuat rute, silakan unduh dan perbarui semua peta sepanjang rute.</string>
 	<string name="rate_alert_title">Suka aplikasi ini?</string>
 	<string name="rate_alert_default_message">Terima kasih karena menggunakan Organic Maps. Mohon beri peringkat untuk aplikasi ini. Masukan dari Anda membantu kami untuk menjadi lebih baik.</string>
 	<string name="rate_alert_five_star_message">Hore! Kami juga sangat menyukai Anda!</string>
@@ -564,24 +352,14 @@
 	<string name="rate_alert_less_than_four_star_message">Anda punya ide agar kami bisa membuatnya menjadi lebih baik?</string>
 	<string name="categories">Kategori</string>
 	<string name="history">Riwayat</string>
-	<string name="next_turn_then">Lalu</string>
 	<string name="closed">Tutup</string>
-	<string name="back_to">Kembali ke %s</string>
 	<string name="search_not_found">Maaf, saya tidak menemukan apa pun.</string>
 	<string name="search_not_found_query">Silakan coba kueri lainnya.</string>
-	<string name="search_not_found_map">Silakan unduh peta yang Anda gunakan dalam pencarian Anda.</string>
-	<string name="search_not_found_location">Unduh peta dari lokasi Anda saat ini.</string>
 	<string name="search_history_title">Riwayat Pencarian</string>
 	<string name="search_history_text">Akses kueri pencarian terbaru dengan cepat.</string>
 	<string name="clear_search">Bersihkan riwayat pencarian</string>
-	<!-- Title for settings to enable/disable showcase menu button -->
-	<string name="showcase_settings_title">Tampilkan penawaran</string>
-	<string name="p2p_route_planning">Perencana Rute</string>
 	<string name="p2p_your_location">Lokasi Anda</string>
-	<string name="p2p_from">Titik keberangkatan</string>
-	<string name="p2p_to">Titik tujuan</string>
 	<string name="p2p_start">Mulai</string>
-	<string name="p2p_planning">Merencanakan…</string>
 	<string name="p2p_from_here">Dari</string>
 	<string name="p2p_to_here">Rute ke</string>
 	<string name="p2p_only_from_current">Navigasi tersedia hanya dari lokasi Anda saat ini.</string>
@@ -601,11 +379,8 @@
 	<string name="editor_hours_closed">Jam Tutup</string>
 	<string name="editor_example_values">Contoh Nilai</string>
 	<string name="editor_correct_mistake">Koreksi kesalahan</string>
-	<string name="editor_correct_mistake_message">Pengeditan salah. Koreksi atau ubah ke mode sederhana.</string>
 	<string name="editor_add_select_location">Lokasi</string>
 	<string name="editor_done_dialog_1">Anda telah mengubah peta dunia. Jangan menyembunyikan ini! Katakan kepada teman-teman Anda, dan edit bersama.</string>
-	<string name="editor_done_dialog_2">ini peningkatan peta kedua Anda. Sekarang Anda di tempat yang ke-%d di daftar editor peta. Katakan kepada teman-teman Anda tentang hal ini.</string>
-	<string name="editor_done_dialog_3">Anda telah meningkatkan peta, katakan kepada teman-teman Anda tentang hal ini, dan edit peta bersama.</string>
 	<string name="share_with_friends">Bagikan dengan teman-teman</string>
 	<string name="editor_report_problem_desription_1">Harap menggambarkan masalah secara rinci sehingga komunitas OpenStreeMap dapat memperbaiki kesalahan.</string>
 	<string name="editor_report_problem_desription_2">Atau Anda bisa melakukan sendiri di https://www.openstreetmap.org/</string>
@@ -614,14 +389,7 @@
 	<string name="editor_report_problem_no_place_title">Tempat tidak ada</string>
 	<string name="editor_report_problem_under_construction_title">Ditutup karena pemeliharaan</string>
 	<string name="editor_report_problem_duplicate_place_title">Tempat ganda</string>
-	<string name="first_launch_congrats_title">Organic Maps siap digunakan</string>
-	<string name="first_launch_congrats_text">Cari dan bernavigasilah ke mana saja di dunia secara offline, bebas biaya.</string>
-	<string name="migrate_title">Penting!</string>
-	<!-- Android uses image instead of text. -->
-	<string name="download_all">Unduh semua</string>
-	<string name="delete_all">Hapus semua</string>
 	<string name="autodownload">Unduhan otomatis</string>
-	<string name="disable_autodownload">Nonaktifkan unduh otomatis</string>
 	<!-- Place Page opening hours text -->
 	<string name="closed_now">Sekarang Tutup</string>
 	<!-- Place Page opening hours text -->
@@ -630,8 +398,6 @@
 	<string name="day_off_today">Tutup hari ini</string>
 	<string name="day_off">Tutup</string>
 	<string name="today">Hari ini</string>
-	<string name="sunrise_to_sunset">Dari matahari terbit sampai matahari terbenam</string>
-	<string name="sunset_to_sunrise">Dari matahari terbenam sampai matahari terbit</string>
 	<string name="add_opening_hours">Tambah jam kerja</string>
 	<string name="edit_opening_hours">Sunting jam kerja</string>
 	<string name="no_osm_account">Tidak ada akun di OpenStreetMap?</string>
@@ -641,29 +407,13 @@
 	<string name="login">Masuk</string>
 	<string name="password">Kata sandi</string>
 	<string name="forgot_password">Lupa kata sandi?</string>
-	<!-- Forgot Password dialog title -->
-	<string name="restore_password">Pulihkan kata sandi</string>
-	<string name="enter_email_address_to_reset_password">Masukkan alamat surek yang Anda gunakan pada saat pendaftaran dan kami akan mengirim tautan untuk memperbarui kata sandi Anda.</string>
-	<string name="reset_password">Atur ulang kata sandi</string>
-	<string name="username">Nama pengguna</string>
 	<string name="osm_account">Akun OSM</string>
 	<string name="logout">Keluar</string>
-	<string name="login_and_edit_map_motivation_message">Masuk dan sunting informasi objek pada peta dan kami akan membuatnya tersedia bagi jutaan pengguna lain. Mari kita menjadikan dunia lebih baik bersama-sama.</string>
 	<!-- Information text: "Last upload 11.01.2016" -->
 	<string name="last_upload">Pengunggahan terakhir</string>
-	<!-- Motivates user to login/register, title above login buttons. -->
-	<string name="you_have_edited_your_first_object">Anda menyunting objek pertama Anda!</string>
 	<string name="thank_you">Terima kasih</string>
-	<string name="login_with_google">Masuk menggunakan Google</string>
-	<string name="login_with_openstreetmap">Masuk menggunakan www.openstreetmap.org</string>
 	<string name="edit_place">Sunting tempat</string>
 	<string name="place_name">Nama tempat</string>
-	<!-- title above languages list cells in the editor, below editable name text field. -->
-	<string name="other_languages">Bahasa lainnya</string>
-	<!-- small button to open list with names in different languages -->
-	<string name="show_more">Tampilkan lebih banyak</string>
-	<!-- small button to close list with names in different languages -->
-	<string name="show_less">Tampilkan lebih sedikit</string>
 	<string name="add_language">Tambahkan bahasa</string>
 	<string name="street">Jalan</string>
 	<!-- Editable House Number text field (in address block). -->
@@ -680,25 +430,16 @@
 	<string name="email_or_username">Surel atau nama pengguna</string>
 	<string name="phone">Telepon</string>
 	<string name="please_note">Harap diperhatikan</string>
-	<string name="common_no_wifi_dialog">Tidak ada koneksi WiFi. Apakah Anda ingin melanjutkan dengan data seluler?</string>
 	<string name="downloader_delete_map_dialog">Semua perubahan peta akan dihapus bersama dengan peta.</string>
 	<string name="downloader_update_maps">Perbarui peta</string>
 	<string name="downloader_mwm_migration_dialog">Untuk membuat rute, Anda perlu memperbarui semua peta dan kemudian merencanakan rute tersebut lagi.</string>
 	<string name="downloader_search_field_hint">Temukan peta</string>
-	<string name="migration_update_all_button">Perbarui semua peta</string>
-	<string name="migration_delete_all_download_current_button">Unduh peta sekarang dan hapus peta lama</string>
 	<string name="migration_download_error_dialog">Unduh kesalahan</string>
 	<string name="common_check_internet_connection_dialog">Harap memeriksa pengaturan Anda dan pastikan perangkat Anda terhubung dengan internet.</string>
 	<string name="downloader_no_space_title">Tidak cukup ruang</string>
 	<string name="downloader_no_space_message">Harap menghapus data yang tidak diperlukan</string>
-	<string name="editor_general_auth_error_dialog">Kesalahan masuk umum.</string>
 	<string name="editor_login_error_dialog">Kesalahan masuk.</string>
-	<string name="editor_login_failed_dialog">Masuk gagal</string>
-	<string name="editor_username_error_dialog">Nama pengguna tidak benar</string>
-	<string name="editor_place_edited_dialog">Anda telah mengedit sebuah obyek!</string>
-	<string name="editor_login_with_osm">Masuk dengan OpenStreetMap</string>
 	<string name="editor_profile_changes">Perubahan Terverifikasi</string>
-	<string name="editor_profile_unsent_changes">Tidak terkirim:</string>
 	<string name="editor_focus_map_on_location">Tarik peta untuk memilih lokasi yang benar dari obyek.</string>
 	<string name="editor_add_select_category">Pilih kategori</string>
 	<string name="editor_add_select_category_popular_subtitle">Populer</string>
@@ -709,19 +450,14 @@
 	<string name="editor_edit_place_category_title">Kategori</string>
 	<string name="detailed_problem_description">Gambaran terperinci tentang masalah</string>
 	<string name="editor_report_problem_other_title">Masalah yang berbeda</string>
-	<string name="placepage_report_problem_button">Laporkan masalah</string>
 	<string name="placepage_add_business_button">Tambahkan organisasi</string>
 	<string name="whatsnew_editor_message_1">Tambahkan tempat-tempat baru di peta, dan edit peta-peta yang ada langsung dari aplikasi.</string>
-	<string name="whatsnew_editor_message_2">* Organic Maps menggunakan data komunitas OpenStreetMap.</string>
 	<string name="dialog_incorrect_feature_position">Ubah lokasi</string>
 	<string name="message_invalid_feature_position">Objek tidak dapat diletakkan di sini</string>
 	<string name="login_to_make_edits_visible">Masuk agar pengguna lain dapat melihat perubahan yang Anda buat.</string>
-	<string name="no_migration_during_navigation">Memperbarui tidak diperbolehkan selama navigasi.</string>
 	<!-- Error dialog no space -->
 	<string name="migration_no_space_message">Untuk mengunduh, Anda perlu ruang lebih banyak. Harap menghapus data yang tidak diperlukan.</string>
 	<string name="editor_sharing_title">Saya meningkatkan peta Organic Maps</string>
-	<string name="editor_comment_will_be_sent">Kami akan mengirim komen Anda ke pembuat peta.</string>
-	<string name="editor_unsupported_category_message">Anda telah menambahkan sebuah tempat kategori yang belum kami dukung. Tempat itu akan muncul di peta beberapa saat kemudian.</string>
 	<!-- Downloaded 10 **of** 20 <- it is that "of" -->
 	<string name="downloader_of">%1$d dari %2$d</string>
 	<string name="download_over_mobile_header">Unduh dengan menggunakan koneksi jaringan seluler?</string>
@@ -739,15 +475,8 @@
 	<string name="editor_detailed_description">Saran perubahan Anda akan dikirimkan ke komunitas OpenStreetMap. Jelaskan detail yang tidak dapat diedit di Organic Maps.</string>
 	<string name="editor_more_about_osm">Selengkapnya tentang OpenStreetMap</string>
 	<string name="editor_operator">Pemilik</string>
-	<string name="editor_tag_description">Masukkan perusahaan, organisasi, atau individu yang bertanggung jawab atas fasilitas tersebut.</string>
-	<string name="editor_no_local_edits_title">Anda tidak memiliki pengeditan lokal</string>
-	<string name="editor_no_local_edits_description">Ini menunjukkan jumlah saran perubahan dalam peta yang saat ini hanya dapat diakses di perangkat Anda.</string>
-	<string name="editor_send_to_osm">Kirim ke OSM</string>
-	<string name="editor_remove">Hapus</string>
-	<string name="downloader_my_maps_title">Peta saya</string>
 	<string name="downloader_no_downloaded_maps_title">Tidak ada peta apa pun yang diunduh</string>
 	<string name="downloader_no_downloaded_maps_message">Unduh peta untuk menemukan lokasi dan bernavigasi secara offline.</string>
-	<string name="downloader_find_place_hint">Cari kota atau negara</string>
 	<!-- Error title that appears after certain time without location. -->
 	<string name="current_location_unknown_title">Terus mendeteksi lokasi Anda saat ini?</string>
 	<!-- Error that appears after certain time without location. -->
@@ -762,27 +491,10 @@
 	<string name="location_services_disabled_2">2. Ketuk Lokasi</string>
 	<!-- iOS Dialog for the case when the location permission is not granted -->
 	<string name="location_services_disabled_3">3. Pilih While Using the App</string>
-	<string name="placepage_parking_surface">Parkir Luar</string>
-	<string name="placepage_parking_multistorey">Bertingkat</string>
-	<string name="placepage_parking_underground">Bawah Tanah</string>
-	<string name="placepage_parking_rooftop">Atap</string>
-	<string name="placepage_parking_sheds">Gudang</string>
-	<string name="placepage_parking_carports">Parkir Beratap</string>
-	<string name="placepage_parking_boxes">Sasana tinju</string>
-	<string name="placepage_parking_pay">Berbayar</string>
-	<string name="placepage_parking_free">Gratis</string>
-	<string name="placepage_parking_interval">Biaya Rutin</string>
-	<string name="placepage_entrance_number">Nomor</string>
-	<string name="placepage_entrance_type">Gerbang Masuk</string>
-	<string name="placepage_flat">persegi</string>
-	<string name="placepage_open_24_7">24 jam sehari, 7 hari seminggu</string>
 	<string name="meter">m</string>
 	<string name="kilometer">km</string>
-	<string name="kilometers_per_hour">km/j</string>
 	<string name="mile">mil</string>
 	<string name="foot">kaki</string>
-	<string name="miles_per_hour">mpj</string>
-	<string name="day">h</string>
 	<string name="hour">j</string>
 	<string name="minute">mnt</string>
 	<string name="placepage_place_description">Deskripsi</string>
@@ -792,46 +504,30 @@
 	<string name="placepage_call_button">Hubungi</string>
 	<string name="placepage_edit_bookmark_button">Edit Bookmark</string>
 	<string name="placepage_bookmark_name_hint">Nama Bookmark</string>
-	<string name="placepage_personal_notes_hint">Catatan pribadi</string>
-	<string name="placepage_delete_bookmark_button">Hapus Bookmark</string>
 	<string name="editor_edits_sent_message">Saran perubahan Anda telah dikirim</string>
 	<string name="editor_comment_hint">Komentar…</string>
 	<string name="editor_reset_edits_message">Atur ulang perubahan lokal?</string>
 	<string name="editor_reset_edits_button">Atur Ulang</string>
 	<string name="editor_remove_place_message">Hapus tempat yang ditambahkan?</string>
 	<string name="editor_remove_place_button">Hapus</string>
-	<string name="editor_status_sending">Mengirim…</string>
 	<string name="editor_place_doesnt_exist">Tempat tidak ada</string>
 	<string name="text_more_button">…selebihnya</string>
 	<!-- Phone number error message -->
 	<string name="error_enter_correct_phone">Masukkan nomor telepon yang benar</string>
 	<string name="error_enter_correct_web">Masukkan alamat web valid</string>
 	<string name="error_enter_correct_email">Masukkan surel valid</string>
-	<string name="error_enter_correct">Masukkan nilai valid</string>
 	<string name="refresh">Memperbarui</string>
-	<string name="last_update">Pembaruan terakhir: %s</string>
 	<string name="placepage_add_place_button">Tambahkan tempat ke peta</string>
 	<!-- Displayed when saving some edits to the map to warn against publishing personal data -->
 	<string name="editor_share_to_all_dialog_title">Apakah Anda ingin mengirimkannya ke semua pengguna?</string>
 	<!-- iOS Dialog before publishing the modifications to the public map. -->
 	<string name="editor_share_to_all_dialog_message_1">Pastikan Anda tidak memasukkan data pribadi apa pun.</string>
 	<string name="editor_share_to_all_dialog_message_2">Kami akan memeriksa perubahan tersebut. Jika kami memiliki pertanyaan maka kami akan menghubungi Anda melalui surel.</string>
-	<string name="navigation_overview_button">ikhtisar</string>
-	<string name="navigation_stop_button">berhenti</string>
-	<!-- Text on an empty bookmark page -->
-	<string name="bookmarks_empty_title">Simpan Penanda</string>
-	<string name="bookmarks_empty_message_1">Ketuk pada ★ untuk menyimpan tempat-tempat favorit untuk akses cepat.</string>
-	<string name="bookmarks_empty_message_2">Impor penanda dari email dan web.</string>
-	<string name="bookmarks_empty_message_3">check-out: %s</string>
-	<!-- Name of the group for booked hotels -->
-	<string name="bookmarks_group_name">Hotel yang dipesan</string>
-	<string name="place_page_button_read_descriprion">Baca</string>
 	<!-- iOS dialog for the case when recent track recording is on and the app comes back from background -->
 	<string name="recent_track_background_dialog_title">Nonaktifkan rekaman dari rute yang baru Anda lalui?</string>
 	<string name="off_recent_track_background_button">Nonaktifkan</string>
 	<!-- For sharing via SMS and so on -->
 	<string name="sharing_call_action_look">Lihat</string>
-	<string name="continue_recent_track_background_button">Teruskan</string>
 	<string name="recent_track_background_dialog_message">Organic Maps menggunakan geoposisi di latar belakang untuk merekam rute yang baru Anda lalui.</string>
 	<!-- Rate on Google Play (Android only) -->
 	<string name="rate_gp">Beri nilai di Google Play</string>
@@ -841,21 +537,11 @@
 	<string name="tell_friends_text">Hai! Instal Organic Maps yuk!</string>
 	<!-- About short text (below logo) -->
 	<string name="about_description">Organic Maps adalah aplikasi offline yang sangat berguna untuk bepergian. Organic Maps didasarkan pada data OpenStreetMap dan memungkinkan kita untuk mengeditnya.</string>
-	<!-- Text in menu -->
-	<string name="blog">Blog</string>
 	<string name="general_settings">Setelan umum</string>
-	<string name="date">Tanggal %d</string>
-	<!-- "Report a bug" -> "Generaal Feedback" -> "Something is not working" -->
-	<string name="something_is_not_working">Ada yang tidak berfungsi</string>
 	<!-- For the first routing -->
 	<string name="accept">Terima</string>
 	<!-- For the first routing -->
 	<string name="decline">Tolak</string>
-	<string name="install_app">Pasang</string>
-	<string name="search_no_results_title">Tidak Ada Hasil</string>
-	<string name="search_no_results_message">Cobalah dengan istilah pencarian yang lebih umum, perkecil atau atur ulang filter.</string>
-	<string name="search_no_results_expand_area_button">Perkecil</string>
-	<string name="search_no_results_reset_button">Atur Ulang Filter</string>
 	<!-- noun -->
 	<string name="search_in_table">Daftar</string>
 	<string name="mobile_data_dialog">Gunakan internet seluler untuk memperlihatkan informasi terperinci?</string>
@@ -867,18 +553,13 @@
 	<string name="mobile_data_option_never">Jangan Gunakan</string>
 	<string name="mobile_data_option_ask">Selalu Tanya</string>
 	<string name="traffic_update_maps_text">Untuk memperlihatkan data lalu lintas, peta harus diperbarui.</string>
-	<string name="traffic_outdated">Data lalu lintas belum diperbarui.</string>
 	<string name="big_font">Perbesar ukuran huruf pada peta</string>
 	<string name="traffic_update_app">Perbarui Organic Maps</string>
 	<!-- "traffic" as in road congestion -->
 	<string name="traffic_update_app_message">Untuk menampilkan data lalu lintas, aplikasi ini harus diperbarui.</string>
 	<!-- "traffic" as in "road congestion" -->
 	<string name="traffic_data_unavailable">Data lalu lintas tidak tersedia</string>
-	<!-- Simplified colour scheme for traffic information, fewer colours are used to display traffic jams on the map. The string should be kept as short as possible -->
-	<string name="pref_traffic_simplified_colors_title">Warna lalu lintas sederhana</string>
 	<string name="enable_logging">Aktifkan pencatatan</string>
-	<string name="offline_place_page_more_information">Sambungkan ke internet untuk mendapatkan informasi selengkapnya tentang tempat ini.</string>
-	<string name="failed_load_information">Gagal memuat informasi.</string>
 	<!-- Settings: "Send general feedback" button -->
 	<string name="feedback_general">Umpan Balik Umum</string>
 	<string name="on">On</string>
@@ -892,57 +573,26 @@
 	<string name="routing_add_start_point">Tambahkan titik awal untuk merencanakan rute</string>
 	<string name="routing_add_finish_point">Tambahkan titik akhir untuk merencanakan rute</string>
 	<string name="button_exit">Keluar</string>
-	<string name="settings_device_memory">Memori perangkat</string>
-	<string name="settings_card_memory">Memori kartu</string>
-	<string name="settings_storage_available">%s tersedia</string>
-	<string name="toast_location_permission_denied">Izin lokasi aplikasi ditolak</string>
-	<string name="button_use">Gunakan</string>
 	<string name="planning_route_manage_route">Kelola rute</string>
 	<string name="button_plan">Rencana</string>
-	<string name="button_add">Tambah</string>
 	<string name="placepage_remove_stop">Hapus</string>
 	<string name="planning_route_remove_title">Seret ke sini untuk menghapus</string>
-	<string name="dialog_change_start_point_message">Ganti titik awal ke lokasi saat ini?</string>
-	<string name="button_replace">Ganti</string>
 	<string name="placepage_add_stop">Tambah perhentian</string>
-	<string name="add_my_position">Tambahkan posisi saya</string>
-	<string name="choose_start_point">Pilih titik awal</string>
-	<string name="choose_destination">Pilih destinasi</string>
 	<string name="preloader_viator_button">Pelajari selengkapnya</string>
-	<string name="start_from_my_position">Mulai dari</string>
-	<string name="profile_authorization_title">Masuk dengan</string>
-	<string name="profile_authorization_message">Masuk dengan mudah tanpa kredensial dan kata sandi dalam beberapa detik</string>
 	<string name="profile_authorization_error">Ah, tadi ada kesalahan. Coba masuk kembali.</string>
-	<string name="service">Layanan</string>
-	<string name="atmosphere">Suasana</string>
-	<string name="value_for_money">Kepantasan harga</string>
-	<string name="experience">Pengalaman</string>
-	<string name="assortment">Lain-Lain</string>
-	<string name="expertise">Keahlian</string>
-	<string name="equipment">Perlengkapan</string>
-	<string name="quality">Mutu</string>
 	<string name="dialog_error_storage_title">Masalah akses penyimpanan</string>
 	<string name="dialog_error_storage_message">Penyimpanan eksternal tidak tersedia, mungkin Kartu SD sudah dilepaskan, rusak, atau sistem berkasnya hanya dapat dibaca. Silakan periksa dan beri tahu kami di alamat support\@ maps.me</string>
 	<string name="setting_emulate_bad_storage">Emulasi penyimpanan yang buruk</string>
-	<string name="directions_finish">Destinasi</string>
-	<string name="directions_on_foot">Berjalan %s</string>
 	<string name="core_entrance">Tempat masuk</string>
-	<string name="coffee">Kopi</string>
-	<string name="cleanliness">Kebersihan</string>
-	<string name="crowdedness">Keramaian</string>
 	<string name="error_enter_correct_name">Harap masukkan nama yang benar</string>
 	<string name="bookmarks_groups">Daftar</string>
 	<string name="bookmarks_groups_hide_all">Sembunyikan semua</string>
 	<string name="bookmarks_groups_show_all">Perlihatkan semua</string>
-	<plurals name="bookmarks_places">
-	  <item quantity="other">%d markah</item>
-	</plurals>
 	<string name="bookmarks_create_new_group">Buat daftar baru</string>
 	<string name="downloader_hide_screen">Sembunyikan Layar</string>
 	<string name="downloader_percent">%1$s (%2$s dari %3$s)</string>
-	<string name="downloader_process">Mengunduh %s...</string>
-	<string name="downloader_applying">Menerapkan %s...</string>
-	<string name="dialog_message_transit_not_found_connection">Rencanakan rute dalam satu jaringan transit</string>
+	<string name="downloader_process">Mengunduh %s…</string>
+	<string name="downloader_applying">Menerapkan %s…</string>
 	<string name="bookmarks_error_message_share_general">Tidak dapat berbagi karena kesalahan aplikasi</string>
 	<string name="bookmarks_error_title_share_empty">Kesalahan dalam membagikan</string>
 	<string name="bookmarks_error_message_share_empty">Tidak dapat membagikan daftar kosong</string>
@@ -951,12 +601,7 @@
 	<string name="bookmarks_new_list_hint">Daftar baru</string>
 	<string name="bookmarks_error_title_list_name_already_taken">Nama ini sudah dipakai</string>
 	<string name="bookmarks_error_message_list_name_already_taken">Silakan pilih nama lain</string>
-	<string name="bookmarks_error_title_list_name_too_long">Nama ini terlalu panjang</string>
-	<string name="bookmarks_error_message_list_name_too_long">Silakan pilih nama lain</string>
-	<string name="please_wait">Mohon tunggu...</string>
-	<string name="phone_number">Nomor telepon</string>
-	<string name="notification_unsent_reviews_title">Anda memiliki beberapa ulasan yang tidak terkirim</string>
-	<string name="notification_unsent_reviews_message">Harap masuk untuk berbagi ulasan dengan wisatawan lain</string>
+	<string name="please_wait">Mohon tunggu…</string>
 	<string name="profile">Profil OpenStreetMap</string>
 	<string name="place_page_search_similar_hotel">Cari hotel serupa</string>
 	<string name="bookmarks_detect_title">File baru terdeteksi</string>
@@ -967,31 +612,10 @@
 	<string name="button_convert">Mengubah</string>
 	<string name="bookmarks_convert_error_title">Kesalahan</string>
 	<string name="bookmarks_convert_error_message">Beberapa file tidak dikonversi.</string>
-	<string name="converting">Mengkonversi...</string>
-	<string name="wn_reinvented_bookmarks_title">Kami menemukan kembali bookmark!</string>
-	<string name="wn_reinvented_bookmarks_message">Anda dapat mencadangkan bookmark, membuat daftar... Sungguh menakjubkan...</string>
-	<string name="bookmarks_restore">Kembalikan bookmark</string>
-	<string name="bookmarks_restore_process">Memulihkan...</string>
 	<string name="bookmarks_restore_title">Kembalikan versi ini?</string>
-	<string name="bookmarks_restore_message">Bookmark Anda akan memulihkan dari %1$s (%2$s)</string>
-	<string name="bookmarks_restore_empty_title">Anda tidak memiliki cadangan</string>
-	<string name="bookmarks_restore_empty_message">Server tidak menemukan cadangan yang dibuat sebelumnya</string>
 	<string name="common_check_internet_connection_dialog_title">Tidak ada koneksi internet</string>
-	<string name="error_server_title">Server error</string>
-	<string name="error_server_message">Terjadi kesalahan pada server, coba lagi nanti</string>
 	<string name="error_system_message">Terjadi kesalahan yang tidak diketahui</string>
 	<string name="restore">Mengembalikan</string>
-	<string name="bookmarks_page_downloaded">Diunduh</string>
-	<string name="bookmarks_page_my">Milik saya</string>
-	<string name="routes_and_bookmarks">Rute dan bookmark</string>
-	<string name="bookmarks_webview_success_toast">Bookmark berhasil diunduh</string>
-	<string name="cached_bookmarks_placeholder_title">Unduh tempat baru</string>
-	<string name="cached_bookmarks_placeholder_subtitle">Tekan tombol untuk mengunduh ribuan tempat dan rute menarik yang dibuat oleh pengguna Organic Maps. Anda akan memerlukan koneksi internet.</string>
-	<string name="downloader_download_routers">Unduh bookmark</string>
-	<string name="bookmarks_groups_cached">Daftar yang telah diunduh.</string>
-	<plurals name="bookmarks_objects">
-	  <item quantity="other">obyek %s</item>
-	</plurals>
 	<plurals name="objects">
 	  <item quantity="other">tempat %d</item>
 	</plurals>
@@ -1004,62 +628,32 @@
 	<string name="subtittle_opt_out">Pengaturan treking</string>
 	<string name="crash_reports">Laporan tabrakan</string>
 	<string name="crash_reports_description">Kami dapat menggunakan data Anda untuk meningkatkan pengalaman Organic Maps. Perubahan akan berlaku setelah Anda memulai ulang aplikasi.</string>
-	<string name="opt_out_help_ios_1">Perangkat seluler Anda mungkin menyediakan pengaturan \"\"Batasi Treking Iklan\"\" atau \"\"Keluar dari iklan berbasis ketertarikan\"\".</string>
-	<string name="opt_out_help_ios_2">iOS 9 atau Lebih Tinggi</string>
-	<string name="opt_out_help_ios_3">Ke Pengaturan → Privasi → Iklan → Aktifkan pengaturan \"\"Batasi Treking Iklan\"\"</string>
-	<string name="opt_out_help_android">Perangkat seluler Anda mungkin menyediakan pengaturan \"\"Batasi treking iklan\"\" atau \"\"Keluar dari iklan berbasis ketertarikan\"\".\n\nUntuk Android dan Google Play Services versi 4.0 dan ke atas:\nPengaturan → Google → Iklan → Keluar dari Personalisasi Iklan\nor\nPengaturan → Google → Akun Google → Informasi personal &amp; privasi → Pengaturan Iklan → Personalisasi Iklan</string>
 	<string name="privacy_policy">Kebijakan privasi</string>
 	<string name="terms_of_use">Ketentuan penggunaan</string>
-	<string name="backup_notification_failed">Mencadangkan bookmark Anda telah dihentikan. Masuk untuk kembali mengaktifkannya.</string>
 	<string name="button_layer_traffic">Lalu lintas</string>
 	<string name="button_layer_subway">Kereta bawah tanah</string>
 	<string name="layers_title">Lapisan peta</string>
-	<string name="layers_message">Gunakan lapisan peta untuk menampilkan lalu lintas, peta kereta bawah tanah, dan informasi berguna lainnya</string>
-	<string name="button_layer_got_it">Mengerti</string>
 	<string name="subway_data_unavailable">Peta bawah tanah tidak tersedia</string>
 	<string name="bookmarks_empty_list_title">Daftar ini kosong</string>
 	<string name="bookmarks_empty_list_message">Untuk menambahkan bookmark, ketuk satu tempat di peta lalu ketuk ikon bintang</string>
 	<string name="category_desc_more">…selengkapnya</string>
 	<string name="title_error_downloading_bookmarks">Terjadi kesalahan</string>
-	<string name="subtitle_error_downloading_bookmarks">Bookmark tidak terunduh</string>
-	<string name="error_already_downloaded">Daftar ini sudah diunduh</string>
-	<string name="why_support">Kenapa dukungan Organic Maps?</string>
-	<string name="why_support_item2">Anda membantu kami meningkatkan Organic Maps</string>
-	<string name="why_support_item3">Anda membantu kami meningkatkan peta terbuka OpenStreetMap.org</string>
-	<string name="channels_map_update">Pembaruan peta</string>
-	<string name="server_unavailable_title">Server tidak tersedia</string>
-	<string name="sharing_options">Opsi berbagi</string>
 	<string name="export_file">File ekspor</string>
 	<string name="list_settings">Pengaturan Daftar</string>
 	<string name="delete_list">Hapus Daftar</string>
-	<string name="hide_from_map">Sembunyikan dari peta</string>
 	<string name="public_access">Akses umum</string>
 	<string name="limited_access">Akses terbatas</string>
 	<string name="bookmark_category_name">Kategori</string>
 	<string name="bookmark_category_description_hint">Ketikkan deskripsi (teks atau html)</string>
 	<string name="not_shared">Pribadi</string>
-	<string name="direct_link_progress_text">Mengunggah file Anda…</string>
-	<string name="direct_link_success">Tautan telah dibuat</string>
-	<string name="send_a_link_btn">Kirim tautan ke saya</string>
-	<string name="upload_error_toast">Kesalahan terjadi saat mengunggah file Anda</string>
 	<string name="tags_loading_error_subtitle">Kesalahan terjadi saat memuat tag, silakan coba lagi</string>
-	<string name="unable_upload_errorr_title">Gagal mengunggah file</string>
-	<string name="unable_upload_error_subtitle_edited">File telah diedit melalui aplikasi web</string>
-	<string name="unable_upload_error_subtitle_broken">File rusak dan tidak dapat diunggah. Silakan unggah file lain.</string>
-	<string name="contact">Kontak</string>
-	<string name="download_button">Unduh</string>
 	<string name="speedcams_alert_title">Kamera cepat</string>
-	<string name="speedcams_alert_subtitle">Peringatan tentang batas kecepatan</string>
 	<string name="speedcam_option_auto">Auto</string>
 	<string name="speedcam_option_always">Selalu</string>
 	<string name="speedcam_option_never">Tidak pernah</string>
-	<string name="bookmark_description_title">Deskripsi Bookmark</string>
 	<string name="place_description_title">Deskripsi Tempat</string>
 	<!-- this text will be shown in application notification preferences opposite checkbox which enable/disable downloader notifications. Devices on Android 8+ are affected. -->
 	<string name="notification_channel_downloader">Pengunduh peta</string>
-	<string name="share_bookmarks_email_body_link">Halo!\n\nBerikut tautan untuk mengunduh bookmark Anda: %s. Buka daftar melalui Organic Maps dan nikmati perjalanan Anda!\n\nDapatkan aplikasi: https://omaps.app/get?kmz</string>
-	<string name="warning_speedcams_title">Navigator akan memberi Anda peringatan tentang adanya kamera saat Anda melebihi batas kecepatan %d km/jam</string>
-	<string name="warning_speedcams_subtitle">Harap perhatikan aturan berkendara di negara tempat Anda bepergian.</string>
 	<string name="speedcams_notice_message">Auto - Peringatkan tentang kamera kecepatan saat terdapat risiko melebihi batas kecepatan\nSelalu - Selalu peringatkan tentang kamera kecepatan\nTidak pernah - Jangan pernah peringatkan tentang kamera kecepatan</string>
 	<string name="power_managment_title">Mode hemat daya</string>
 	<string name="power_managment_description">Saat mode otomatis dipilih, aplikasi mulai menonaktifkan fitur yang menghabiskan daya baterai, bergantung pada tingkat daya baterai saat ini</string>
@@ -1067,14 +661,7 @@
 	<string name="power_managment_setting_auto">Otomatis</string>
 	<string name="power_managment_setting_manual_max">Hemat daya maksimum</string>
 	<string name="enable_logging_warning_message">Opsi ini mengaktifkan pencatatan untuk tujuan diagnostik. Bisa amat membantu bagi staf dukungan kami yang memecahkan masalah dalam aplikasi. Aktifkan opsi ini hanya saat diminta oleh dukungan Organic Maps.</string>
-	<string name="html_error_upload_message_try_again">Periksa pengaturan jaringan Anda dan coba lagi</string>
-	<string name="html_error_upload_title_try_again">Tidak ada koneksi internet</string>
-	<string name="notification_leave_review_v2_android_short_title">Ulas dan bantu traveler!</string>
-	<string name="notifications_illegal_alert_disable_button">Nonaktifkan pemberitahuan</string>
 	<string name="access_rules_author_only">Pengeditan online</string>
-	<string name="privacy_settings_menu">Pengaturan privasi</string>
-	<string name="unable_upadate_error_title">Pembaruan file gagal</string>
-	<string name="unable_upadate_error_message">Beberapa kesalahan terjadi saat memperbarui. Periksa perubahan dan coba lagi</string>
 	<string name="driving_options_title">Pilihan berkendara</string>
 	<string name="driving_options_subheader">Hindari di setiap rute</string>
 	<string name="avoid_tolls">Jalan tol</string>
@@ -1085,52 +672,14 @@
 	<string name="unable_to_calc_alert_subtitle">Sayangnya kami tidak dapat menemukan rute karena opsi pilihan Anda. Harap ubah pengaturan lalu coba lagi</string>
 	<string name="define_to_avoid_btn">Tentukan jalan yang dihindari</string>
 	<string name="change_driving_options_btn">Opsi perutean diaktifkan</string>
-	<string name="toll_road">Jalan tol</string>
-	<string name="unpaved_road">Jalan tanah</string>
-	<string name="ferry_crossing">Penyeberangan kapal feri</string>
-	<string name="operated_by">Dioperasikan oleh \"%s\"</string>
 	<string name="avoid_toll_roads_placepage">Hindari jalan tol</string>
 	<string name="avoid_unpaved_roads_placepage">Hindari jalan tanah</string>
 	<string name="avoid_ferry_crossing_placepage">Hindari penyeberangan kapal feri</string>
-	<string name="type.cuisine.uzbek">Masakan Uzbek</string>
-	<string name="trip_start">Ayo</string>
-	<string name="pick_destination">Tujuan</string>
-	<string name="follow_my_position">Pusatkan ulang</string>
-	<string name="search_results">Hasil pencarian</string>
-	<string name="then_turn">Lalu</string>
-	<string name="redirect_route_alert">Anda ingin membuat ulang rute?</string>
-	<string name="redirect_route_yes">Ya</string>
-	<string name="redirect_route_no">Tidak</string>
-	<string name="trip_finished">Anda telah tiba!</string>
-	<string name="keyboard_availability_alert">Papan ketik tidak tersedia saat berkendara</string>
-	<string name="dialog_routing_change_start_carplay">Tidak dapat membuat rute dari lokasi saat ini</string>
-	<string name="dialog_routing_change_end_carplay">Tidak dapat membuat rute ke tujuan Anda. Pilih titik lainnya</string>
-	<string name="dialog_routing_check_gps_carplay">Tidak ada sinyal GPS. Harap pindah ke area terbuka</string>
-	<string name="dialog_routing_unable_locate_route_carplay">Tidak dapat membuat rute. Harap tentukan titik rute lainnya</string>
-	<string name="dialog_routing_download_files_carplay">Untuk membuat rute, unduh peta baru di perangkat anda</string>
-	<string name="dialog_routing_system_error_carplay">Terjadi kesalahan. Harap mulai ulang aplikasi</string>
-	<string name="dialog_routing_rebuild_from_current_location_carplay">Rute akan dibuat ulang dari lokasi saat ini</string>
-	<string name="dialog_routing_rebuild_for_vehicle_carplay">Rute akan diubah untuk mobil</string>
 	<string name="ok">Oke</string>
-	<string name="avoid_unpaved_carplay_1">Jalan aspal</string>
-	<string name="avoid_unpaved_carplay_2">Hindari tanah</string>
-	<string name="avoid_ferry_carplay_1">Tanpa feri</string>
-	<string name="avoid_ferry_carplay_2">Hindari feri</string>
-	<string name="avoid_tolls_carplay_1">Tanpa tol</string>
-	<string name="avoid_tolls_carplay_2">Hindari tol</string>
-	<string name="speedcams_alert_title_carplay_1">Speedcam</string>
-	<string name="speedcams_alert_title_carplay_2">Info kecepatan</string>
-	<string name="download_map_carplay">Silakan unduh peta di apl Organic Maps pada perangkat Anda</string>
-	<string name="carplay_roundabout_exit">Jalan keluar ke %s</string>
 	<!-- max. 10 symbols, both iOS and Android -->
 	<string name="sort">Urutkan…</string>
 	<!-- Android, title, max 20-22 symbols -->
 	<string name="sort_bookmarks">Urutkan bookmark</string>
-	<!-- iOS -->
-	<string name="sort_default">Urutkan standar</string>
-	<string name="sort_type">Urutkan per tipe</string>
-	<string name="sort_distance">Urutkan per jarak</string>
-	<string name="sort_date">Urutkan per tanggal</string>
 	<!-- Android -->
 	<string name="by_default">Standar</string>
 	<!-- Android -->
@@ -1139,65 +688,23 @@
 	<string name="by_distance">Per jarak</string>
 	<!-- Android -->
 	<string name="by_date">Per tanggal</string>
-	<string name="week_ago_sorttype">Seminggu yang lalu</string>
-	<string name="month_ago_sorttype">Sebulan yang lalu</string>
-	<string name="moremonth_ago_sorttype">Lebih dari sebulan yang lalu</string>
-	<string name="moreyear_ago_sorttype">Lebih dari setahun yang lalu</string>
-	<string name="near_me_sorttype">Dekat dengan saya</string>
-	<string name="others_sorttype">Lainnya</string>
-	<string name="food_places">Makanan</string>
-	<string name="tourist_places">Tempat Rekreasi</string>
-	<string name="museums">Museum</string>
-	<string name="parks">Taman</string>
-	<string name="swim_places">Kolam renang</string>
-	<string name="mountains">Pegunungan</string>
-	<string name="animals">Kebun binatang</string>
-	<string name="hotels">Hotel</string>
-	<string name="buildings">Gedung</string>
-	<string name="money">Uang</string>
-	<string name="shops">Pusat perbelanjaan</string>
-	<string name="parkings">Parkir</string>
-	<string name="fuel_places">SPBU</string>
-	<string name="water">Air</string>
-	<string name="medicine">Obat</string>
 	<string name="search_in_the_list">Cari dalam daftar</string>
-	<string name="view_on_map_bookmarks">Di peta</string>
-	<string name="more_bookmarks">Lainnya…</string>
-	<string name="no_items_found">Item tidak ditemukan</string>
-	<!-- Android, max 18 symbols -->
-	<string name="bookmarks_edit_list">Ubah daftar</string>
-	<!-- Android, max 18 symbols -->
-	<string name="bookmarks_delete_list">Hapus daftar</string>
-	<string name="religious_places">Tempat ibadah</string>
 	<string name="select_list">Pilih daftar</string>
 	<string name="transit_not_found">Navigasi kereta bawah tanah di wilayah ini belum tersedia</string>
 	<string name="dialog_pedestrian_route_is_long_header">Jalur kereta bawah tanah tidak ditemukan</string>
 	<string name="dialog_pedestrian_route_is_long_message">Silakan pilih titik awal atau akhir yang lebih dekat ke stasiun kereta bawah tanah</string>
-	<!-- Failed planning SUBWAY route message in navigation view -->
-	<string name="routing_planning_error_subway_special">Perencanaan jalur kereta bawah tanah gagal</string>
 	<string name="button_layer_isolines">Isometrik</string>
-	<string name="tips_map_layers_title_countour">Yang baru di Organic Maps: lapisan topografi offline!</string>
-	<string name="tips_map_layers_message_countour">Rencanakan dan nikmati perjalanan alam Anda dan pastikan Anda tahu segalanya tentang daerah tersebut</string>
 	<string name="isolines_activation_error_dialog">Untuk mengaktifkan dan menggunakan lapisan topografi, silakan perbarui atau unduh peta area</string>
 	<string name="isolines_location_error_dialog">Lapisan topografi belum tersedia untuk wilayah ini</string>
 	<string name="elevation_profile_diff_level">Tingkat kesulitan</string>
-	<string name="elevation_profile_diff_level_easy">Mudah</string>
-	<string name="elevation_profile_diff_level_moderate">Sedang</string>
-	<string name="elevation_profile_diff_level_hard">Sulit</string>
 	<string name="elevation_profile_ascent">Menanjak</string>
 	<string name="elevation_profile_descent">Menurun</string>
 	<string name="elevation_profile_minaltitude">Ketinggian Min.</string>
 	<string name="elevation_profile_maxaltitude">Ketinggian Maks.</string>
-	<string name="elevation_profile_m">m</string>
 	<string name="elevation_profile_difficulty">Kesulitan</string>
 	<string name="elevation_profile_distance">Jarak:</string>
-	<string name="elevation_profile_km">km</string>
 	<string name="elevation_profile_time">Waktu:</string>
-	<string name="elevation_profile_hours">j.</string>
-	<string name="elevation_profile_minutes">mnt</string>
 	<string name="isolines_toast_zooms_1_10">Perbesar untuk menjelajahi garis kontur</string>
-	<string name="downloader_updating_ios">Memperbarui</string>
-	<string name="downloader_loading_ios">Mengunduh</string>
 	<string name="key_information_title">Informasi kunci</string>
 	<string name="enable_screen_sleep">Izinkan layar untuk tidur</string>
 	<!-- Description in preferences -->

--- a/android/res/values-it/strings.xml
+++ b/android/res/values-it/strings.xml
@@ -12,8 +12,6 @@
 	<string name="cancel_download">Annulla il download</string>
 	<!-- Button which deletes downloaded country -->
 	<string name="delete">Cancella</string>
-	<!-- Button "do not interrupt download" if user touched actively downloading country -->
-	<string name="do_nothing">Continua</string>
 	<string name="download_maps">Scarica le mappe</string>
 	<!-- Settings/Downloader - info for country when download fails -->
 	<string name="download_has_failed">Download fallito, tocca di nuovo per un altro tentativo</string>
@@ -31,45 +29,31 @@
 	<string name="core_my_position">La mia posizione</string>
 	<!-- Update maps later/Buy pro version later button text -->
 	<string name="later">Più tardi</string>
-	<!-- Don't show some dialog any more -->
-	<string name="never">Mai</string>
 	<!-- View and button titles for accessibility -->
 	<string name="search">Cerca</string>
 	<!-- Search box placeholder text -->
 	<string name="search_map">Ricerca Mappa</string>
-	<!-- Settings/Downloader - info for not downloaded country -->
-	<string name="touch_to_download">Tocca per scaricare</string>
 	<!-- Settings/Downloader - 3G download warning dialog confirm button -->
 	<string name="use_cellular_data">Sì</string>
 	<!-- Location services are disabled by user alert - message -->
 	<string name="location_is_disabled_long_text">Attualmente hai disattivati tutti i servizi di locazione per questo dispositivo o applicazione. Cortesemente abilitali nelle Impostazioni.</string>
-	<!-- Location Services are not available on the device alert - message -->
-	<string name="device_doesnot_support_location_services">Il tuo dispositivo non supporta i servizi di localizzazione</string>
 	<!-- View and button titles for accessibility -->
 	<string name="zoom_to_country">Mostra sulla mappa</string>
-	<!-- Button text for the button at the center of the screen when the country is not downloaded -->
-	<string name="country_status_download">Scarica Map\n(^ ^)</string>
 	<!-- Button text for the button at the center of the screen when the country is not downloaded and the size should not be shown -->
 	<string name="country_status_download_without_size">Scarica Map</string>
-	<!-- Button text for the button at the center of the screen when the country is not downloaded -->
-	<string name="country_status_download_without_routing">Scarica mappa\nsenza percorsi (^ ^)</string>
 	<!-- Message to display at the center of the screen when the country download has failed -->
 	<string name="country_status_download_failed">Lo scaricamento è fallito</string>
 	<!-- Button text for the button under the country_status_download_failed message -->
 	<string name="try_again">Riprova</string>
 	<string name="about_menu_title">Informazioni su Organic Maps</string>
-	<string name="downloaded_touch_to_delete">Scaricato (%s), tocca per cancellare</string>
 	<string name="connection_settings">Impostazioni di connessione</string>
-	<string name="download_mb_or_kb">Scarica %s</string>
 	<string name="close">Chiudi</string>
 	<string name="unsupported_phone">È necessaria una accelerazione hardware OpenGL. Purtroppo, il tuo dispositivo non è supportato.</string>
 	<string name="download">Carica</string>
-	<string name="external_storage_is_not_available">La scheda/USB/di memoria SD con le mappe scaricate non è disponibile</string>
 	<string name="disconnect_usb_cable">Coortesemente scollega il cavo USB oppure inserisci la scheda di memoria per l\'usco dell\'app</string>
 	<string name="not_enough_free_space_on_sdcard">Libera prima dello spazio sulla scheda Sd/ memoria USB per usare l\'app</string>
 	<string name="not_enough_memory">Memoria insufficiente per lanciare l\'app</string>
 	<string name="download_resources">Prima di iniziare è necessario scaricare la mappa generale del mondo sul tuo dispositivo.\nLa dimensione del download è di %s.</string>
-	<string name="getting_position">Ottieni la posizione corrente</string>
 	<string name="download_resources_continue">Vai alla mappa</string>
 	<string name="downloading_country_can_proceed">Sto scaricando %s. Puoi ora\nprocedere con la mappa.</string>
 	<string name="download_country_ask">Vuoi scaricare %s?</string>
@@ -82,28 +66,18 @@
 	<string name="download_country_failed">Il trasferimento di %s non è riuscito</string>
 	<!-- Add New Bookmark Set dialog title -->
 	<string name="add_new_set">Aggiungi un nuovo Set</string>
-	<!-- Place Page - Add To Bookmarks button -->
-	<string name="add_to_bookmarks">Aggiungi al Segnalibri</string>
 	<!-- Bookmark Color dialog title -->
 	<string name="bookmark_color">Colore del Segnalibro</string>
 	<!-- Add Bookmark Set dialog - hint when set name is empty -->
 	<string name="bookmark_set_name">Seleziona un nome del segnalibro</string>
-	<!-- Bookmark Sets dialog title -->
-	<string name="bookmark_sets">Seleziona un segnalibro</string>
 	<!-- Bookmarks - dialog title -->
 	<string name="bookmarks">Segnalibri</string>
-	<!-- Add bookmark dialog - bookmark color -->
-	<string name="color">Colore</string>
 	<!-- Default bookmarks set name -->
 	<string name="core_my_places">I miei luoghi</string>
 	<!-- Editor title above street and house number -->
 	<string name="address">Indirizzo</string>
-	<!-- Place Page - Remove Pin button -->
-	<string name="remove_pin">Rimuovi il Pin</string>
 	<!-- Add bookmark dialog - bookmark set, Bookmarks dialog - Bookmark set cell -->
 	<string name="set">Seleziona</string>
-	<!-- Text hint in Bookmarks dialog when no any bookmarks are added -->
-	<string name="bookmarks_usage_hint">Non hai ancora nessun segnalibro.\nTocca qualsiasi luogo sulla cartina per aggiungere un segnalibro.\nPossono essere anche importati Preferiti da altre fonti e visualizzate nell\'app Organic Maps. Apri il file KML/KMZ con i pin salvati da una casella di posta, Dropbox o un link web.</string>
 	<!-- Settings button in system menu -->
 	<string name="settings">Impostazioni</string>
 	<!-- Header of settings activity where user defines storage path -->
@@ -114,20 +88,10 @@
 	<string name="move_maps">Vuoi spostare le mappe?</string>
 	<!-- Ask to wait user several minutes (some long process in modal dialog). -->
 	<string name="wait_several_minutes">Questo può richiedere diversi minuti.\ncortesemente attendi…</string>
-	<!-- Show bookmarks from this category on a map or not -->
-	<string name="visible">Visibile</string>
-	<!-- Toast which is displayed when GPS has been deactivated -->
-	<string name="gps_is_disabled_long_text">Il GPS è disabilitato. Cortesemente abilitalo nelle Impostazioni.</string>
 	<!-- Measurement units title in settings activity -->
 	<string name="measurement_units">Unità di misura</string>
 	<!-- Detailed description of Measurement Units settings button -->
 	<string name="measurement_units_summary">Scegli tra miglia e chilometri</string>
-	<!-- Do search in all sources -->
-	<string name="search_mode_all">Ovunque</string>
-	<!-- Do search near my position only -->
-	<string name="search_mode_nearme">Vicino a me</string>
-	<!-- Do search in current viewport only -->
-	<string name="search_mode_viewport">Nella schermata</string>
 	<!-- Search category for cafes, bars, restaurants -->
 	<string name="eat">Dove mangiare</string>
 	<!-- Search category for grocery stores -->
@@ -164,12 +128,8 @@
 	<string name="post">Posta</string>
 	<!-- Search category -->
 	<string name="police">Polizia</string>
-	<!-- String in search result list, when nothing found -->
-	<string name="no_search_results_found">Nessun risultato trovato</string>
 	<!-- Notes field in Bookmarks view -->
 	<string name="description">Note</string>
-	<!-- Button text -->
-	<string name="share_by_email">Condividi via email</string>
 	<!-- Email Subject when sharing bookmarks category -->
 	<string name="share_bookmarks_email_subject">Il segnalibri Organic Maps è stato condiviso con te</string>
 	<!-- message title of loading file -->
@@ -182,20 +142,10 @@
 	<string name="edit">Copia link</string>
 	<!-- Warning message when doing search around current position -->
 	<string name="unknown_current_position">La tua posizione non è stata ancora stabilita</string>
-	<!-- Warning message when location country isn't downloaded during search (see also download_location_map_proposal). -->
-	<string name="download_location_country">Scarica il paese della tua posizione attuale (%s)</string>
-	<!-- Warning message when viewport country isn't downloaded during search -->
-	<string name="download_viewport_country_to_search">Scarica il paese che stai cercando (%s)</string>
 	<!-- Alert message that we can't run Map Storage settings due to some reasons. -->
 	<string name="cant_change_this_setting">Siamo spiacenti, ma le impostazioni di archiviazione delle mappe sono disabilitate.</string>
 	<!-- Alert message that downloading is in progress. -->
 	<string name="downloading_is_active">Il download della nazione è in corso.</string>
-	<!-- Message that will be shown in alert view, when we ask user to leave review on App Store -->
-	<string name="appStore_message">Confidiamo nel fatto che sia piacevole utilizzare Organic Maps! In caso positivo, ti preghiamo di valutare o recensire l\'app all\'interno dell\'app store. Ti porterà via meno di un minuto e la cosa ci aiuterebbe tantissimo. Grazie per il tuo sostegno!</string>
-	<!-- No, thanks -->
-	<string name="no_thanks">No, grazie</string>
-	<!-- Share one specific bookmark using SMS, %1$@ contains om:// and %2$@ https://omaps.app link. @NOTE non-ascii symbols in the link will result in max 70 characters SMS instead of 140. -->
-	<string name="bookmark_share_sms">Vedi pin sulla mappa. Apri %1$s o %2$s</string>
 	<!-- Share my position using SMS, %1$@ contains om:// and %2$@ https://omaps.app link WITHOUT NAME. @NOTE non-ascii symbols in the link will result in max 70 characters SMS instead of 140. -->
 	<string name="my_position_share_sms">Vedi dove sono ora. Apri %1$s o %2$s</string>
 	<!-- Subject for emailed bookmark -->
@@ -204,30 +154,16 @@
 	<string name="my_position_share_email_subject">Guarda dove mi trovo attualmente sulla mappa Organic Maps</string>
 	<!-- Share my position using EMail, %1$@ is om:// and %2$@ is https://omaps.app link WITHOUT NAME -->
 	<string name="my_position_share_email">Ciao,\n\nSono qui adesso: %1$s. Clicca su questo link %2$s oppure su questo %3$s per vedere il posto sulla mappa.\n\nGrazie.</string>
-	<!-- Android share by Message/SMS button text (including SMS) -->
-	<string name="share_by_message">Condividi con un messaggio</string>
 	<!-- Share button text which opens menu with more buttons, like Message, EMail, Facebook etc. -->
 	<string name="share">Condividi</string>
-	<!-- iOS share by Message button text (including SMS) -->
-	<string name="message">Messaggio</string>
 	<!-- Share by email button text, also used in editor. -->
 	<string name="email">Email</string>
-	<!-- Copy Link -->
-	<string name="copy_link">Copia link</string>
-	<!-- Text for the button that returns to caller application -->
-	<string name="more_info">Mostra più informazioni</string>
 	<!-- Text for message when used successfully copied something -->
 	<string name="copied_to_clipboard">Copiato sugli Appunti: %1$s</string>
 	<!-- place preview title -->
 	<string name="info">Informazioni</string>
 	<!-- Used for bookmark editing -->
 	<string name="done">Fine</string>
-	<!-- Summary for preferences in MWM -->
-	<string name="yopme_pref_summary">Selezionate le impostazioni Sfondo</string>
-	<!-- Title for yopme preferences in MWM -->
-	<string name="yopme_pref_title">Impostazioni Sfondo</string>
-	<!-- Hint for upper-right icon p2b -->
-	<string name="show_on_backscreen">Mostra Sfondo</string>
 	<!-- Prints version number in About dialog -->
 	<string name="version">Versione: %s</string>
 	<!-- Confirmation in downloading countries dialog -->
@@ -237,11 +173,6 @@
 	<!-- Length of track in cell that describes route -->
 	<string name="length">Lunghezza</string>
 	<string name="share_my_location">Condividi la mia location</string>
-	<string name="menu_search">Cerca</string>
-	<!-- Settings screen: "Map" category title -->
-	<string name="prefs_group_map">Mappa</string>
-	<!-- Settings screen: "Miscellaneous" category title -->
-	<string name="prefs_group_misc">Miscellanea</string>
 	<string name="prefs_group_route">Navigazione</string>
 	<string name="pref_zoom_title">Pulsanti per lo zoom</string>
 	<string name="pref_zoom_summary">Condividi la mia location</string>
@@ -257,8 +188,6 @@
 	<string name="pref_map_3d_title">Vista in prospettiva</string>
 	<!-- Settings «Map» category: «3D buildings» title -->
 	<string name="pref_map_3d_buildings_title">Edifici in 3D</string>
-	<!-- Settings «Map» category: «3D buildings» summary -->
-	<string name="pref_map_3d_buildings_subtitle">Diminuisce la durata della batteria</string>
 	<!-- Settings «Route» category: «Tts enabled» title -->
 	<string name="pref_tts_enable_title">Istruzioni vocali</string>
 	<!-- Settings «Route» category: «Tts language» title -->
@@ -267,7 +196,6 @@
 	<string name="pref_tts_unavailable">Non disponibile</string>
 	<!-- Title for "Other" section in TTS settings. -->
 	<string name="pref_tts_other_section_title">Altro</string>
-	<string name="pref_tts_how_to_set_up_voice">Come impostare la voce</string>
 	<!-- Settings «Map» category: «Record track» title -->
 	<string name="pref_track_record_title">Percorso recente</string>
 	<string name="pref_map_auto_zoom">Zoom automatico</string>
@@ -278,46 +206,11 @@
 	<string name="duration_12_hours">12 ore</string>
 	<string name="duration_1_day">1 giorno</string>
 	<string name="recent_track_help_text">Consente di registrare il tratto percorso in un determinato periodo di tempo e vedere lo stesso sulla mappa. Nota: l\'attivazione di questa funzione incrementa l\'uso della batteria. Il tratto viene rimosso automaticamente dalla mappa allo scadere dell\'intervallo di tempo.</string>
-	<string name="pref_track_ios_caption">Il percorso recente mostra il tragitto effettuato.</string>
-	<string name="pref_track_ios_subcaption">Seleziona un intervallo temporale per la registrazione del percorso.</string>
-	<string name="placepage_distance">Distanza</string>
-	<string name="placepage_coordinates">Coordinate</string>
-	<string name="placepage_unsorted">Non classificato</string>
 	<string name="search_show_on_map">Visualizza sulla mappa</string>
-	<!-- Used to warn user when fixing KitKat issue -->
-	<string name="bookmark_move_fail">Abbiamo bisogno di trasferire i tuoi preferiti nella memoria interna, ma non c\'è abbastanza spazio disponibile. Ti preghiamo di liberare la memoria, altrimenti i preferiti non saranno disponibili.</string>
-	<!-- Used in More Apps menu -->
-	<string name="free">Gratis</string>
-	<!-- Used in More Apps menu -->
-	<string name="buy">Acquista</string>
-	<!-- 1st search button-like result -->
-	<string name="search_on_map">Cerca sulla mappa</string>
-	<!-- toast with an error -->
-	<string name="no_route_found">Nessun percorso trovato</string>
-	<!-- route title -->
-	<string name="route">Linea</string>
-	<!-- category title -->
-	<string name="routes">Percorsi</string>
-	<!-- text of notification -->
-	<string name="download_map_notification">Scarica la mappa del luogo in cui ti trovi</string>
-	<!-- text of notification -->
-	<string name="pro_version_is_free_today">Versione completa di Organic Maps è oggi gratis! Scaricala ora e dillo ai tuoi amici!</string>
-	<!-- Dialog for transferring maps from lite to pro. -->
-	<string name="move_lite_maps_to_pro">Stiamo trasferendo le tue mappe scaricate da Organic Maps Lite a Organic Maps. Potrebbe richiedere alcuni minuti.</string>
-	<!-- Message to display when maps moved. -->
-	<string name="move_lite_maps_to_pro_ok">Le mappe che hai scaricato sono state trasferite con successo a Organic Maps.</string>
-	<!-- Message to display when maps move failed. -->
-	<string name="move_lite_maps_to_pro_failed">Non è stato possibile trasferire le tue mappe. Cancella Organic Maps Lite e scarica le mappe di nuovo.</string>
-	<!-- Text in menu -->
-	<string name="settings_and_more">Impostazioni e Altro</string>
 	<!-- Text in menu -->
 	<string name="website">Sito web</string>
-	<!-- Text in menu -->
-	<string name="contact_us">Contattaci</string>
 	<!-- Settings: Send feedback button and dialog title -->
 	<string name="feedback">Feedback</string>
-	<!-- Text in menu -->
-	<string name="subscribe_to_news">Iscriviti alle nostre notizie</string>
 	<!-- Text in menu -->
 	<string name="rate_the_app">Vota l\'app</string>
 	<!-- Text in menu -->
@@ -326,12 +219,6 @@
 	<string name="copyright">Copyright</string>
 	<!-- Text in menu -->
 	<string name="report_a_bug">Riporta un bug</string>
-	<!-- Email subject -->
-	<string name="subscribe_me_subject">Iscrivimi alla newsletter di Organic Maps</string>
-	<!-- Email body -->
-	<string name="subscribe_me_body">Voglio essere tra i primi a sapere delle ultime novità aggiornamenti e promozioni. Potrò annullare l\'iscrizione in ogni momento.</string>
-	<!-- About text -->
-	<string name="about_text">Organic Maps offre le più veloci mappe offline di tutte le città, di tutti i paesi del mondo. Viaggia con piena fiducia: ovunque ti trovi, Organic Maps ti aiuta a localizzarti sulla mappa, trovare ristoranti, hotel, banche, distributori di benzina ecc.., e non richiede la connessione a internet.\n\nLavoriamo sempre su nuove funzionalità e ci piacerebbe sapere da te in cosa potremmo migliorare Organic Maps. Se avessi problemi con l\'app, non esitare a contattarci a support\@organicmaps.app. Rispondiamo ad ogni richiesta!\n\nTi piace Organic Maps e vuoi sostenerci? Ci sono alcuni modi semplici e assolutamente gratuiti:\n\n- Invia una recensione al tuo App Market\n- Metti mi piace sulla nostra pagina di Facebook http://www.facebook.com/OrganicMaps\n- O semplicemente fai pubblicità a Organic Maps con la tua mamma, i tuoi amici e colleghi :)\n\nGrazie per essere stato con noi. Apprezziamo molto il tuo supporto!\n\nP.S. Prendiamo i dati delle mappe da OpenStreetMap, un progetto di mappatura simile a Wikipedia, che permette agli utenti di creare e modificare le mappe. Se vedi che manca qualcosa o se c\'è qualcosa di sbagliato sulla mappa, puoi correggere le mappe direttamente su https://www.openstreetmap.org, e le modifiche appariranno nella prossima versione dell\'app Organic Maps.</string>
 	<!-- Alert text -->
 	<string name="email_error_body">Il client email non è stato configurato. Si prega di configurarlo o di usare qualsiasi altro metodo per contattarci all\'indirizzo %s</string>
 	<!-- Alert title -->
@@ -340,137 +227,56 @@
 	<string name="pref_calibration_title">Calibrazione del compasso</string>
 	<!-- Search category -->
 	<string name="wifi">WiFi</string>
-	<!-- Update map suggestion -->
-	<string name="routing_map_outdated">Aggiorna la mappa per creare un itinerario.</string>
-	<!-- Update maps suggestion -->
-	<string name="routing_update_maps">La nuova versione di Organic Maps ti permette di creare itinerari dalla tua posizione attuale a un punto di destinazione. Aggiorna le mappe per utilizzare questa funzione.</string>
 	<!-- Update all button text -->
 	<string name="downloader_update_all_button">Aggiorna tutte</string>
 	<!-- Cancel all button text -->
 	<string name="downloader_cancel_all">Annulla tutto</string>
 	<!-- Downloaded maps category -->
 	<string name="downloader_downloaded_subtitle">Scaricate</string>
-	<!-- Downloaded maps category -->
-	<string name="downloader_available_maps">Disponibile</string>
 	<!-- Country queued for download -->
 	<string name="downloader_queued">In coda</string>
 	<string name="downloader_near_me_subtitle">Vicino a me</string>
 	<string name="downloader_status_maps">Mappe</string>
 	<string name="downloader_download_all_button">Scarica tutte</string>
 	<string name="downloader_downloading">In scaricamento:</string>
-	<string name="downloader_search_results">Trovate</string>
-	<!-- Disclaimer message -->
-	<string name="routing_disclaimer">Creando percorsi nell\'app Organic Maps tieni a mente quanto segue:\n\n  - I percorsi suggeriti possono essere considerati solo come consigliati.\n - Le condizioni della strada, le regole del traffico e i segnali hanno una priorità maggiore rispetto ai consigli sulla circolazione.\n - La mappa potrebbe essere scorretta o datata e i percorsi potrebbero non aver creato la strada migliore possibile.\n\n  Stai attento sulle strade e prenditi cura di te!</string>
-	<!-- Outdated maps category -->
-	<string name="downloader_outdated_maps">Obsoleto</string>
-	<!-- Up to date maps category -->
-	<string name="downloader_uptodate_maps">Aggiornato</string>
 	<!-- Status of outdated country in the list -->
 	<string name="downloader_status_outdated">Aggiorna</string>
 	<!-- Status of failed country in the list -->
 	<string name="downloader_status_failed">Fallito</string>
 	<!-- Displayed in a dialog that appears when a user tries to delete a map while the app is in the follow route mode -->
 	<string name="downloader_delete_map_while_routing_dialog">Per eliminare una mappa interrompi la navigazione.</string>
-	<!-- Show when user try build route, but we don't know where he -->
-	<string name="routing_failed_unknown_my_position">La posizione attuale non è definita. Specifica la posizione per creare il percorso.</string>
-	<!-- Show if use has not routing file, or InconsistentMWMandRoute -->
-	<string name="routing_failed_has_no_routing_file">Ulteriori dati sono necessari per creare un percorso. Inizio a scaricarli?</string>
-	<!-- StartPointNotFound -->
-	<string name="routing_failed_start_point_not_found">Impossibile calcolare il percorso. Nessuna strada vicina al tuo punto di partenza.</string>
-	<!-- EndPointNotFound -->
-	<string name="routing_failed_dst_point_not_found">Impossibile calcolare il percorso. Nessuna strada vicina al tuo punto di arrivo.</string>
 	<!-- PointsInDifferentMWM -->
 	<string name="routing_failed_cross_mwm_building">I percorsi possono essere creati solo se interamente presenti in una singola mappa.</string>
-	<!-- RouteNotFound -->
-	<string name="routing_failed_route_not_found">Non è stata trovata alcuna strada fra il punto di partenza e d\'arrivo selezionati. Seleziona un punto di partenza e d\'arrivo diversi.</string>
-	<!-- InternalError -->
-	<string name="routing_failed_internal_error">Si è verificato un errore interno. Prova ad eliminare la mappa e a scaricarla nuovamente. Se il problema dovesse persistere, contattaci all\'indirizzo support\@organicmaps.app.</string>
-	<!-- Context menu item for downloader. -->
-	<string name="downloader_download_map_and_routing">Scarica mappa e percorso</string>
-	<!-- Context menu item for downloader. -->
-	<string name="downloader_download_routing">Scarica percorso</string>
-	<!-- Context menu item for downloader. -->
-	<string name="downloader_delete_routing">Elimina il percorso</string>
 	<!-- Context menu item for downloader. -->
 	<string name="downloader_download_map">Scarica mappa</string>
-	<string name="downloader_download_map_no_routing">Scarica mappa senza percorsi</string>
-	<!-- Button for routing. -->
-	<string name="routing_go">Andare!</string>
 	<!-- Item status in downloader. -->
 	<string name="downloader_retry">Ripeti</string>
-	<!-- Item in context menu. -->
-	<string name="downloader_map_and_routing">Mappa + percorso</string>
 	<!-- Item in context menu. -->
 	<string name="downloader_delete_map">Elimina mappa</string>
 	<!-- Item in context menu. -->
 	<string name="downloader_update_map">Aggiorna mappa</string>
-	<!-- Item in context menu. -->
-	<string name="downloader_update_map_and_routing">Aggiorna mappa + percorso</string>
-	<!-- Item in context menu. -->
-	<string name="downloader_map_only">Solo mappa</string>
-	<!-- Toolbar title -->
-	<string name="toolbar_application_menu">Menu applicazione</string>
 	<!-- Preference text -->
 	<string name="pref_use_google_play">Usa i servizi Google Play per ottenere la tua posizione attuale</string>
 	<!-- Text for rating dialog -->
 	<string name="rating_just_rated">Ho appena valutato la tua app</string>
-	<!-- Text for rating dialog -->
-	<string name="rating_user_since">Sono un utente Organic Maps dal %s</string>
-	<!-- Text for rating dialog -->
-	<string name="rating_do_like_maps">Ti piace Organic Maps?</string>
-	<!-- Text for rating dialog -->
-	<string name="rating_tap_star">Fai tap sulla stella per valutare la nostra app.</string>
 	<!-- Text for rating dialog -->
 	<string name="rating_thanks">Grazie!</string>
 	<!-- Text for rating dialog -->
 	<string name="rating_share_ideas">Condividi le tue idee o problemi così che possiamo migliorare l\'app per te.</string>
 	<!-- Text for rating dialog -->
 	<string name="rating_send_feedback">Invia feedback</string>
-	<!-- Text for g+ dialog -->
-	<string name="rating_google_plus">Clicca su g+ per far conoscere l\'app ai tuoi amici.</string>
 	<!-- Text for routing error dialog -->
 	<string name="routing_download_maps_along">Scarica le mappe lungo il percorso</string>
-	<!-- Text for routing error dialog -->
-	<string name="routing_download_map">Scarica la mappa</string>
-	<!-- Text for routing error dialog -->
-	<string name="routing_download_map_and_routing">Scarica la mappa aggiornata e i dati del percorso per ottenere tutte le funzionalità Organic Maps.</string>
-	<!-- Text for routing error dialog -->
-	<string name="routing_get_routing_data">Ottieni i dati del percorso</string>
-	<!-- Text for routing error dialog -->
-	<string name="routing_get_additional_data">dati aggiuntivi richiesti per creare i percorsi dalla tua posizione.</string>
 	<!-- Text for routing error dialog -->
 	<string name="routing_requires_all_map">Creare un percorso necessita la presenza di tutte le mappe scaricate e aggiornate dalla tua posizione alla destinazione.</string>
 	<!-- Text for routing error dialog -->
 	<string name="routing_not_enough_space">Spazio non sufficiente</string>
-	<!-- Text for routing error dialog -->
-	<string name="routing_download_more_than_avail">Devi scaricare %1$s MB, ma lo spazio disponibile è di soli %2$s MB.</string>
-	<!-- Text for routing error dialog -->
-	<string name="routing_download_roaming">Stai per scaricare %s MB tramite la rete cellulare (in roaming). Questo potrebbe comportare costi aggiuntivi, in base al piano dati del tuo operatore mobile.</string>
 	<!-- bookmark button text -->
 	<string name="bookmark">segnalibro</string>
-	<!-- map is not downloaded -->
-	<string name="not_found_map">La mappa del tuo posto non è stata trovata</string>
 	<!-- location service disabled -->
 	<string name="enable_location_services">Cortesemente abilita i servizi di localizzazione</string>
-	<!-- download map -->
-	<string name="download_map">Scarica la mappa per il tuo paese</string>
-	<!-- download map on iPhone -->
-	<string name="download_map_iphone">Scarica la mappa per la tua posizione corrente sul tuo iPhone</string>
-	<!-- clear pin -->
-	<string name="nearby">Nelle vicinanze</string>
-	<!-- clear pin -->
-	<string name="clear_pin">Annulla pin</string>
-	<!-- location is undefined -->
-	<string name="undefined_location">La posizione attuale non è definita.</string>
-	<!-- download country of your location -->
-	<string name="download_country">Scarica il paese della tua posizione attuale</string>
-	<!-- download failed -->
-	<string name="download_failed">Il trasferimento di non è riuscito</string>
-	<!-- get the map -->
-	<string name="get_the_map">Scarica la mappa</string>
 	<string name="save">Salva</string>
 	<string name="edit_description_hint">Le tue descrizioni (formato testo o html)</string>
-	<string name="new_group">nuovo gruppo</string>
 	<string name="create">crea</string>
 	<!-- red color -->
 	<string name="red">Rosso</string>
@@ -488,22 +294,6 @@
 	<string name="brown">Marrone</string>
 	<!-- pink color -->
 	<string name="pink">Rosa</string>
-	<!-- deep purple color -->
-	<string name="deep_purple">Viola scuro</string>
-	<!-- light blue color -->
-	<string name="light_blue">Azzurro</string>
-	<!-- cyan color -->
-	<string name="cyan">Cyan</string>
-	<!-- teal color -->
-	<string name="teal">Verde smeraldo</string>
-	<!-- lime color -->
-	<string name="lime">Verde fluo</string>
-	<!-- deep orange color -->
-	<string name="deep_orange">Arancione scuro</string>
-	<!-- gray color -->
-	<string name="gray">Grigio</string>
-	<!-- blue gray color -->
-	<string name="blue_gray">Grigiazzurro</string>
 	<!-- Wi-Fi available -->
 	<string name="WiFi_available">Sì</string>
 
@@ -519,10 +309,8 @@
 	<string name="dialog_routing_location_turn_wifi">Controlla il segnale GPS. Se abiliti il Wi-Fi, migliorerà la precisione della posizione.</string>
 	<string name="dialog_routing_location_turn_on">Abilita i servizi di localizzazione</string>
 	<string name="dialog_routing_location_unknown_turn_on">Impossibile individuare le coordinate GPS attuali. Per calcolare il percorso, abilita i servizi di localizzazione.</string>
-	<string name="dialog_routing_location_unknown">Impossibile individuare le coordinate GPS attuali.</string>
 	<string name="dialog_routing_download_files">Scarica i file necessari</string>
 	<string name="dialog_routing_download_and_update_all">Per calcolare il percorso, scarica e aggiorna tutte le mappe e le informazioni di itinerario lungo la strada prevista.</string>
-	<string name="dialog_routing_routes_size">File di informazioni di itinerario</string>
 	<string name="dialog_routing_unable_locate_route">Impossibile individuare il percorso</string>
 	<string name="dialog_routing_cant_build_route">Impossibile creare il percorso.</string>
 	<string name="dialog_routing_change_start_or_end">Modifica il punto di partenza o la destinazione.</string>
@@ -537,33 +325,23 @@
 	<string name="dialog_routing_system_error">Errore di sistema</string>
 	<string name="dialog_routing_application_error">Impossibile creare il percorso a causa di un errore dell\'applicazione.</string>
 	<string name="dialog_routing_try_again">Riprova</string>
-	<string name="dialog_routing_send_error">Segnala il problema</string>
-	<string name="dialog_routing_if_get_cross_route">Vuoi creare un percorso più diretto che si estende su più mappe?</string>
-	<string name="dialog_routing_cross_route_is_optimal">È disponibile un percorso migliore che oltrepassa il limite di questa mappa.</string>
 	<string name="not_now">Non ora</string>
-	<string name="dialog_routing_build_route">Crea</string>
 	<string name="dialog_routing_download_and_build_cross_route">Vuoi scaricare la mappa e creare un percorso migliore che si estende su più mappe?</string>
 	<string name="dialog_routing_download_cross_route">Per creare un percorso migliore che oltrepassa il limite di questa mappa, scarica la mappa.</string>
-	<string name="dialog_routing_cross_route_always">Oltrepassa sempre questo limite</string>
 
 	<!-- SECTION: Strings for downloading map from search -->
 	<string name="search_without_internet_advertisement">Per iniziare a cercare e a creare i percorsi, scarica la mappa e non avrai più bisogno di una connessione a internet.</string>
 	<string name="search_select_map">Seleziona mappa</string>
-	<string name="search_select_other_map">Seleziona un\'altra mappa</string>
 	<!-- «Show» context menu -->
 	<string name="show">Mostra</string>
 	<!-- «Hide» context menu -->
 	<string name="hide">Nascondi</string>
 	<!-- «Rename» context menu -->
 	<string name="rename">Rinomina</string>
-	<!-- Bottom sheet: expand button (should be short) -->
-	<string name="bottom_sheet_more">Altro…</string>
 	<!-- Failed planning route message in navigation view -->
 	<string name="routing_planning_error">Pianificazione del percorso fallito</string>
 	<!-- Arrive routing message in navigation view -->
 	<string name="routing_arrive">Arrivo: %s</string>
-	<!-- Text for routing::RouterResultCode::FileTooOld dialog. -->
-	<string name="dialog_routing_download_and_update_maps">Per creare un percorso, scaricare e aggiornare tutte le mappe interessate dal percorso.</string>
 	<string name="rate_alert_title">Ti piace l’app?</string>
 	<string name="rate_alert_default_message">Grazie per aver utilizzato Organic Maps. Valuta l’app. Il tuo feedback ci permette di migliorare.</string>
 	<string name="rate_alert_five_star_message">Hooray! Anche noi amiamo i nostri utenti!</string>
@@ -571,24 +349,14 @@
 	<string name="rate_alert_less_than_four_star_message">Hai qualche idea su come migliorarla?</string>
 	<string name="categories">Categorie</string>
 	<string name="history">Cronologia</string>
-	<string name="next_turn_then">Poi</string>
 	<string name="closed">Chiuso</string>
-	<string name="back_to">Torna a %s</string>
 	<string name="search_not_found">Spiacente, non ho trovato nulla.</string>
 	<string name="search_not_found_query">Prova con un\'altra ricerca.</string>
-	<string name="search_not_found_map">Scarica la mappa nella quale stai cercando.</string>
-	<string name="search_not_found_location">Scarica la mappa del luogo in cui ti trovi.</string>
 	<string name="search_history_title">Cerca nella cronologia</string>
 	<string name="search_history_text">Accedi velocemente alle stringhe di ricerca recenti.</string>
 	<string name="clear_search">Cancella сronologia ricerche</string>
-	<!-- Title for settings to enable/disable showcase menu button -->
-	<string name="showcase_settings_title">Mostra offerte</string>
-	<string name="p2p_route_planning">Pianificazione percorso</string>
 	<string name="p2p_your_location">La tua posizione</string>
-	<string name="p2p_from">Il punto di partenza</string>
-	<string name="p2p_to">Il punto di destinazione</string>
 	<string name="p2p_start">Inizia</string>
-	<string name="p2p_planning">Pianificazione…</string>
 	<string name="p2p_from_here">Da</string>
 	<string name="p2p_to_here">Percorso per</string>
 	<string name="p2p_only_from_current">La navigazione è disponibile solo dalla tua posizione attuale.</string>
@@ -608,11 +376,8 @@
 	<string name="editor_hours_closed">Orari di chiusura</string>
 	<string name="editor_example_values">Valori esemplificativi</string>
 	<string name="editor_correct_mistake">Correggi errore</string>
-	<string name="editor_correct_mistake_message">Hai commesso un errore nella modifica. Correggerlo o passare alla modalità semplice.</string>
 	<string name="editor_add_select_location">Posizione</string>
 	<string name="editor_done_dialog_1">Hai modificato la mappa del mondo. Non tenerlo per te! Dillo ai tuoi amici e modificatela insieme.</string>
-	<string name="editor_done_dialog_2">Questa è la tua seconda modifica alla mappa. Adesso sei al %d° posto nella lista di chi ha modificato la mappa. Dillo ai tuoi amici.</string>
-	<string name="editor_done_dialog_3">Hai migliorato la mappa. Dillo ai tuoi amici e modificate la mappa insieme.</string>
 	<string name="share_with_friends">Condividi con gli amici</string>
 	<string name="editor_report_problem_desription_1">Si prega di descrivere il problema in dettaglio in modo che la community OpenStreeMap possa riparare l’errore.</string>
 	<string name="editor_report_problem_desription_2">O fallo tu stesso su https://www.openstreetmap.org/</string>
@@ -621,14 +386,7 @@
 	<string name="editor_report_problem_no_place_title">Questo luogo non esiste</string>
 	<string name="editor_report_problem_under_construction_title">Chiuso per manutenzione</string>
 	<string name="editor_report_problem_duplicate_place_title">Luogo duplicato</string>
-	<string name="first_launch_congrats_title">Organic Maps è pronto per essere usato</string>
-	<string name="first_launch_congrats_text">Cerca e naviga offline, ovunque ti trovi nel mondo, gratis.</string>
-	<string name="migrate_title">Importante!</string>
-	<!-- Android uses image instead of text. -->
-	<string name="download_all">Scarica tutto</string>
-	<string name="delete_all">Elimina tutti</string>
 	<string name="autodownload">Scaricamento automatico</string>
-	<string name="disable_autodownload">Disattiva download automatico</string>
 	<!-- Place Page opening hours text -->
 	<string name="closed_now">Ora chiuso</string>
 	<!-- Place Page opening hours text -->
@@ -637,8 +395,6 @@
 	<string name="day_off_today">Oggi chiuso</string>
 	<string name="day_off">Chiuso</string>
 	<string name="today">Oggi</string>
-	<string name="sunrise_to_sunset">Dall\'alba al tramonto</string>
-	<string name="sunset_to_sunrise">Dal tramonto all\'alba</string>
 	<string name="add_opening_hours">Aggiungi orari di apertura</string>
 	<string name="edit_opening_hours">Modifica orari di apertura</string>
 	<string name="no_osm_account">Non hai un account su OpenStreetMap?</string>
@@ -648,29 +404,13 @@
 	<string name="login">Accedi</string>
 	<string name="password">Password</string>
 	<string name="forgot_password">Hai dimenticato la password?</string>
-	<!-- Forgot Password dialog title -->
-	<string name="restore_password">Ripristina password</string>
-	<string name="enter_email_address_to_reset_password">Inserisci l\'indirizzo email utilizzato durante la registrazione e ti invieremo un link per recuperare la password.</string>
-	<string name="reset_password">Reimpostare password</string>
-	<string name="username">Nome utente</string>
 	<string name="osm_account">Account OSM</string>
 	<string name="logout">Esci</string>
-	<string name="login_and_edit_map_motivation_message">Accedi e modifica le informazioni degli oggetti sulla mappa e noi provvederemo a renderli disponibili a milioni di altri utenti. Creiamo un mondo migliore assieme.</string>
 	<!-- Information text: "Last upload 11.01.2016" -->
 	<string name="last_upload">Ultimo caricamento</string>
-	<!-- Motivates user to login/register, title above login buttons. -->
-	<string name="you_have_edited_your_first_object">Hai modificato il tuo primo oggetto!</string>
 	<string name="thank_you">Grazie</string>
-	<string name="login_with_google">Accedi con Google</string>
-	<string name="login_with_openstreetmap">Accedi con www.openstreetmap.org</string>
 	<string name="edit_place">Modifica il luogo</string>
 	<string name="place_name">Nome del luogo</string>
-	<!-- title above languages list cells in the editor, below editable name text field. -->
-	<string name="other_languages">Altre lingue</string>
-	<!-- small button to open list with names in different languages -->
-	<string name="show_more">Mostra più</string>
-	<!-- small button to close list with names in different languages -->
-	<string name="show_less">Mostra meno</string>
 	<string name="add_language">Aggiungi una lingua</string>
 	<string name="street">Via</string>
 	<!-- Editable House Number text field (in address block). -->
@@ -687,25 +427,16 @@
 	<string name="email_or_username">Email o nome utente</string>
 	<string name="phone">Telefono</string>
 	<string name="please_note">Si prega di notare</string>
-	<string name="common_no_wifi_dialog">Nessuna connessione WiFi. Vuoi continuare con la connessione dati?</string>
 	<string name="downloader_delete_map_dialog">Tutti i cambiamenti nella mappa saranno cancellati insieme alla mappa.</string>
 	<string name="downloader_update_maps">Aggiorna mappe</string>
 	<string name="downloader_mwm_migration_dialog">Per creare un percorso, devi aggiornare tutte le mappe e pianificare nuovamente il percorso.</string>
 	<string name="downloader_search_field_hint">Trova la mappa</string>
-	<string name="migration_update_all_button">Aggiorna tutte le mappe</string>
-	<string name="migration_delete_all_download_current_button">Scarica la mappa attuale e cancella quelle vecchie</string>
 	<string name="migration_download_error_dialog">Errore nel download</string>
 	<string name="common_check_internet_connection_dialog">Sei pregato di verificare le tue impostazioni e assicurarti che il tuo dispositivo sia connesso a internet.</string>
 	<string name="downloader_no_space_title">Spazio insufficiente</string>
 	<string name="downloader_no_space_message">Si prega di rimuovere i dati non necessari</string>
-	<string name="editor_general_auth_error_dialog">Errore generale di accesso.</string>
 	<string name="editor_login_error_dialog">Errore accesso.</string>
-	<string name="editor_login_failed_dialog">Accesso fallito</string>
-	<string name="editor_username_error_dialog">Nome utente non valido</string>
-	<string name="editor_place_edited_dialog">Hai modificato un oggetto!</string>
-	<string name="editor_login_with_osm">Accedi con OpenStreetMap</string>
 	<string name="editor_profile_changes">Modifiche approvate</string>
-	<string name="editor_profile_unsent_changes">Non inviato:</string>
 	<string name="editor_focus_map_on_location">Sposta la mappa per selezionare l’esatta posizione dell’oggetto.</string>
 	<string name="editor_add_select_category">Seleziona categoria</string>
 	<string name="editor_add_select_category_popular_subtitle">Popolari</string>
@@ -716,19 +447,14 @@
 	<string name="editor_edit_place_category_title">Categoria</string>
 	<string name="detailed_problem_description">Descrizione dettagliata di un problema</string>
 	<string name="editor_report_problem_other_title">Un problema diverso</string>
-	<string name="placepage_report_problem_button">Riporta un problema</string>
 	<string name="placepage_add_business_button">Aggiungi organizzazione</string>
 	<string name="whatsnew_editor_message_1">Aggiungi nuovi luoghi alla mappa, e modifica quelli già esistenti direttamente dall’app.</string>
-	<string name="whatsnew_editor_message_2">* Organic Maps usa i dati della community OpenStreetMap.</string>
 	<string name="dialog_incorrect_feature_position">Cambia posizione</string>
 	<string name="message_invalid_feature_position">Un oggetto non può essere posizionato qui</string>
 	<string name="login_to_make_edits_visible">Accedi per consentire ad altri utenti di vedere le modifiche apportate.</string>
-	<string name="no_migration_during_navigation">Non è possibile effettuare aggiornamenti durante la navigazione.</string>
 	<!-- Error dialog no space -->
 	<string name="migration_no_space_message">Per scaricare, hai bisogno di più spazio. Sei pregato di eliminare i dati non necessari.</string>
 	<string name="editor_sharing_title">Ho migliorato le mappe Organic Maps</string>
-	<string name="editor_comment_will_be_sent">Invieremo i tuoi commenti ai cartografi.</string>
-	<string name="editor_unsupported_category_message">Hai aggiunto un luogo di una categoria che non è ancora disponibile. Apparirà sulla mappa in futuro.</string>
 	<!-- Downloaded 10 **of** 20 <- it is that "of" -->
 	<string name="downloader_of">%1$d di %2$d</string>
 	<string name="download_over_mobile_header">Vuoi scaricare utilizzando una connessione di rete cellulare?</string>
@@ -746,15 +472,8 @@
 	<string name="editor_detailed_description">Le modifiche suggerite saranno inviate alla community OpenStreetMap. Descrivere i dettagli che non è possibile modificare in Organic Maps.</string>
 	<string name="editor_more_about_osm">Ulteriori informazioni su OpenStreetMap</string>
 	<string name="editor_operator">Titolare</string>
-	<string name="editor_tag_description">Inserire la società, organizzazione o soggetto responsabile per la struttura.</string>
-	<string name="editor_no_local_edits_title">Non vi sono modifiche locali</string>
-	<string name="editor_no_local_edits_description">Qui è visualizzato il numero di modifiche suggerite sulla mappa che sono attualmente solo accessibili sul tuo dispositivo.</string>
-	<string name="editor_send_to_osm">Invia a OSM</string>
-	<string name="editor_remove">Rimuovi</string>
-	<string name="downloader_my_maps_title">Le mie mappe</string>
 	<string name="downloader_no_downloaded_maps_title">Non hai scaricato mappe</string>
 	<string name="downloader_no_downloaded_maps_message">Scarica mappe per trovare il luogo e navigare offline.</string>
-	<string name="downloader_find_place_hint">Cerca città o paese</string>
 	<!-- Error title that appears after certain time without location. -->
 	<string name="current_location_unknown_title">Continuare a rilevare la posizione attuale?</string>
 	<!-- Error that appears after certain time without location. -->
@@ -769,27 +488,10 @@
 	<string name="location_services_disabled_2">2. Tocca su Localizzazione</string>
 	<!-- iOS Dialog for the case when the location permission is not granted -->
 	<string name="location_services_disabled_3">3. Seleziona mentre usi l\'app</string>
-	<string name="placepage_parking_surface">Superficie</string>
-	<string name="placepage_parking_multistorey">Su più piani</string>
-	<string name="placepage_parking_underground">Sotterraneo</string>
-	<string name="placepage_parking_rooftop">Su terrazza</string>
-	<string name="placepage_parking_sheds">Coperto</string>
-	<string name="placepage_parking_carports">Tettoia</string>
-	<string name="placepage_parking_boxes">Box</string>
-	<string name="placepage_parking_pay">A pagamento</string>
-	<string name="placepage_parking_free">Gratis</string>
-	<string name="placepage_parking_interval">Pagamento a tempo</string>
-	<string name="placepage_entrance_number">N.</string>
-	<string name="placepage_entrance_type">Ingresso</string>
-	<string name="placepage_flat">app.</string>
-	<string name="placepage_open_24_7">24 / 7</string>
 	<string name="meter">m</string>
 	<string name="kilometer">km</string>
-	<string name="kilometers_per_hour">chilometri orari (km/h)</string>
 	<string name="mile">mi</string>
 	<string name="foot">ft</string>
-	<string name="miles_per_hour">mph</string>
-	<string name="day">g</string>
 	<string name="hour">h</string>
 	<string name="minute">min</string>
 	<string name="placepage_place_description">Descrizione</string>
@@ -799,46 +501,30 @@
 	<string name="placepage_call_button">Chiama</string>
 	<string name="placepage_edit_bookmark_button">Modifica segnalibro</string>
 	<string name="placepage_bookmark_name_hint">Nome segnalibro</string>
-	<string name="placepage_personal_notes_hint">Note personali</string>
-	<string name="placepage_delete_bookmark_button">Elimina segnalibro</string>
 	<string name="editor_edits_sent_message">Le modifiche suggerite sono state inviate</string>
 	<string name="editor_comment_hint">Commenta…</string>
 	<string name="editor_reset_edits_message">Reimpostare tutte le modifiche locali?</string>
 	<string name="editor_reset_edits_button">Reimposta</string>
 	<string name="editor_remove_place_message">Rimuovere il luogo aggiunto?</string>
 	<string name="editor_remove_place_button">Rimuovi</string>
-	<string name="editor_status_sending">Invio…</string>
 	<string name="editor_place_doesnt_exist">Luogo inesistente</string>
 	<string name="text_more_button">…continua</string>
 	<!-- Phone number error message -->
 	<string name="error_enter_correct_phone">Inserisci un numero di telefono corretto</string>
 	<string name="error_enter_correct_web">Inserisci un indirizzo web valido</string>
 	<string name="error_enter_correct_email">Inserisci un\'email valida</string>
-	<string name="error_enter_correct">Inserisci un valore valido</string>
 	<string name="refresh">Aggiornare</string>
-	<string name="last_update">Ultimo aggiornamento: %s</string>
 	<string name="placepage_add_place_button">Aggiungi un luogo sulla mappa</string>
 	<!-- Displayed when saving some edits to the map to warn against publishing personal data -->
 	<string name="editor_share_to_all_dialog_title">Vuoi inviarlo a tutti gli utenti?</string>
 	<!-- iOS Dialog before publishing the modifications to the public map. -->
 	<string name="editor_share_to_all_dialog_message_1">Assicurati di non aver inserito alcun dato personale.</string>
 	<string name="editor_share_to_all_dialog_message_2">Controlleremo le modifiche. Se avremo delle domande, ti contatteremo via email.</string>
-	<string name="navigation_overview_button">panoramica</string>
-	<string name="navigation_stop_button">ferma</string>
-	<!-- Text on an empty bookmark page -->
-	<string name="bookmarks_empty_title">Salva i Segnalibri</string>
-	<string name="bookmarks_empty_message_1">Tocca su ★ per salvare i luoghi preferiti e accedervi rapidamente.</string>
-	<string name="bookmarks_empty_message_2">Importa i segnalibri dalla posta elettronica e dal web.</string>
-	<string name="bookmarks_empty_message_3">check out: %s</string>
-	<!-- Name of the group for booked hotels -->
-	<string name="bookmarks_group_name">Hotel prenotati</string>
-	<string name="place_page_button_read_descriprion">Leggi</string>
 	<!-- iOS dialog for the case when recent track recording is on and the app comes back from background -->
 	<string name="recent_track_background_dialog_title">Disattivare la registrazione del tuo percorso effettuato di recente?</string>
 	<string name="off_recent_track_background_button">Disattiva</string>
 	<!-- For sharing via SMS and so on -->
 	<string name="sharing_call_action_look">Dai uno sguardo</string>
-	<string name="continue_recent_track_background_button">Continua</string>
 	<string name="recent_track_background_dialog_message">Organic Maps usa la tua posizione geografica in background per registrare il tuo percorso effettuato più di recente.</string>
 	<!-- Rate on Google Play (Android only) -->
 	<string name="rate_gp">Vota su Google Play</string>
@@ -848,21 +534,11 @@
 	<string name="tell_friends_text">Ciao! Installa Organic Maps!</string>
 	<!-- About short text (below logo) -->
 	<string name="about_description">Organic Maps è un\'applicazione offline essenziale per chi ama viaggiare. Organic Maps si basa sui dati OpenStreetMap e consente di apportare modifiche.</string>
-	<!-- Text in menu -->
-	<string name="blog">Blog</string>
 	<string name="general_settings">Impostazioni generali</string>
-	<string name="date">Data %d</string>
-	<!-- "Report a bug" -> "Generaal Feedback" -> "Something is not working" -->
-	<string name="something_is_not_working">Qualcosa non funziona</string>
 	<!-- For the first routing -->
 	<string name="accept">Accetta</string>
 	<!-- For the first routing -->
 	<string name="decline">Rifiuta</string>
-	<string name="install_app">Installa</string>
-	<string name="search_no_results_title">Nessun risultato trovato</string>
-	<string name="search_no_results_message">Prova con un termine di ricerca più generale, fai lo zoom indietro o reimposta il filtro.</string>
-	<string name="search_no_results_expand_area_button">Zoom indietro</string>
-	<string name="search_no_results_reset_button">Reimposta filtro</string>
 	<!-- noun -->
 	<string name="search_in_table">Elenco</string>
 	<string name="mobile_data_dialog">Usare l\'Internet mobile per mostrare le informazioni dettagliate?</string>
@@ -874,18 +550,13 @@
 	<string name="mobile_data_option_never">Non usare mai</string>
 	<string name="mobile_data_option_ask">Chiedi sempre</string>
 	<string name="traffic_update_maps_text">Per visualizzare i dati sul traffico, le mappe devono essere aggiornate.</string>
-	<string name="traffic_outdated">Dati sul traffico non aggiornati.</string>
 	<string name="big_font">Aumenta dimensione carattere sulla mappa</string>
 	<string name="traffic_update_app">Aggiorna Organic Maps</string>
 	<!-- "traffic" as in road congestion -->
 	<string name="traffic_update_app_message">Per visualizzare i dati sul traffico, l\'applicazione deve essere aggiornata.</string>
 	<!-- "traffic" as in "road congestion" -->
 	<string name="traffic_data_unavailable">Dati sul traffico non disponibili</string>
-	<!-- Simplified colour scheme for traffic information, fewer colours are used to display traffic jams on the map. The string should be kept as short as possible -->
-	<string name="pref_traffic_simplified_colors_title">Colori traffico semplificati</string>
 	<string name="enable_logging">Abilita registrazione</string>
-	<string name="offline_place_page_more_information">Connettiti a Internet per ottenere maggiori informazioni sul luogo.</string>
-	<string name="failed_load_information">Impossibile caricare le informazioni.</string>
 	<!-- Settings: "Send general feedback" button -->
 	<string name="feedback_general">Feedback generale</string>
 	<string name="on">On</string>
@@ -899,57 +570,26 @@
 	<string name="routing_add_start_point">Aggiungi un punto di partenza per pianificare un percorso</string>
 	<string name="routing_add_finish_point">Aggiungi un punto di arrivo per pianificare un percorso</string>
 	<string name="button_exit">Esci</string>
-	<string name="settings_device_memory">Memoria del dispositivo</string>
-	<string name="settings_card_memory">Scheda di memoria</string>
-	<string name="settings_storage_available">%s disponibile</string>
-	<string name="toast_location_permission_denied">Autorizzazione a posizione app negata</string>
-	<string name="button_use">Usa</string>
 	<string name="planning_route_manage_route">Gestisci percorso</string>
 	<string name="button_plan">Pianifica</string>
-	<string name="button_add">Aggiungi</string>
 	<string name="placepage_remove_stop">Rimuovi</string>
 	<string name="planning_route_remove_title">Trascina qui per rimuovere</string>
-	<string name="dialog_change_start_point_message">Sostituire il punto di partenza con la posizione corrente?</string>
-	<string name="button_replace">Sostituisci</string>
 	<string name="placepage_add_stop">Aggiungi sosta</string>
-	<string name="add_my_position">Aggiungi mia posizione</string>
-	<string name="choose_start_point">Scegli un punto di partenza</string>
-	<string name="choose_destination">Scegli una destinazione</string>
 	<string name="preloader_viator_button">Ulteriori informazioni</string>
-	<string name="start_from_my_position">Parti da</string>
-	<string name="profile_authorization_title">Accedi con</string>
-	<string name="profile_authorization_message">Semplice accesso senza login e password in un paio di secondi</string>
 	<string name="profile_authorization_error">Ops, si è verificato un errore. Prova a ripetere l\'accesso più tardi.</string>
-	<string name="service">Servizio</string>
-	<string name="atmosphere">Atmosfera</string>
-	<string name="value_for_money">Rapporto qualità/prezzo</string>
-	<string name="experience">Esperienza</string>
-	<string name="assortment">Assortimento</string>
-	<string name="expertise">Competenza</string>
-	<string name="equipment">Attrezzature</string>
-	<string name="quality">Qualità</string>
 	<string name="dialog_error_storage_title">Problema di accesso all\'archivio</string>
 	<string name="dialog_error_storage_message">Archivio esterno non disponibile, probabilmente la scheda SD è stata rimossa, è danneggiata o il file system è di sola lettura. Controllala e contattaci su support\@organicmaps.app</string>
 	<string name="setting_emulate_bad_storage">Simula archivio danneggiato</string>
-	<string name="directions_finish">Destinazione</string>
-	<string name="directions_on_foot">Percorri %s</string>
 	<string name="core_entrance">Ingresso</string>
-	<string name="coffee">Caffè</string>
-	<string name="cleanliness">Pulizia</string>
-	<string name="crowdedness">Clientela</string>
 	<string name="error_enter_correct_name">Inserisci un nome corretto</string>
 	<string name="bookmarks_groups">Elenchi</string>
 	<string name="bookmarks_groups_hide_all">Nascondi tutto</string>
 	<string name="bookmarks_groups_show_all">Mostra tutto</string>
-	<plurals name="bookmarks_places">
-	  <item quantity="other">%d preferiti</item>
-	</plurals>
 	<string name="bookmarks_create_new_group">Crea una nuova lista</string>
 	<string name="downloader_hide_screen">Nascondi schermata</string>
 	<string name="downloader_percent">%1$s (%2$s di %3$s)</string>
-	<string name="downloader_process">Download di %s...</string>
-	<string name="downloader_applying">Applicazione di %s...</string>
-	<string name="dialog_message_transit_not_found_connection">Pianifica un percorso all\'interno di una rete di transito</string>
+	<string name="downloader_process">Download di %s…</string>
+	<string name="downloader_applying">Applicazione di %s…</string>
 	<string name="bookmarks_error_message_share_general">Impossibile condividere a causa di un errore dell\'applicazione</string>
 	<string name="bookmarks_error_title_share_empty">Errore di condivisione</string>
 	<string name="bookmarks_error_message_share_empty">Impossibile condividere una lista vuota</string>
@@ -958,12 +598,7 @@
 	<string name="bookmarks_new_list_hint">Nuova lista</string>
 	<string name="bookmarks_error_title_list_name_already_taken">Questo nome è già stato scelto</string>
 	<string name="bookmarks_error_message_list_name_already_taken">Si prega di scegliere un altro nome</string>
-	<string name="bookmarks_error_title_list_name_too_long">Questo nome è troppo lungo</string>
-	<string name="bookmarks_error_message_list_name_too_long">Si prega di scegliere un altro nome</string>
-	<string name="please_wait">Attendere prego...</string>
-	<string name="phone_number">Numero di telefono</string>
-	<string name="notification_unsent_reviews_title">Hai diverse recensioni non inviate</string>
-	<string name="notification_unsent_reviews_message">Accedi per condividere recensioni con altri viaggiatori</string>
+	<string name="please_wait">Attendere prego…</string>
 	<string name="profile">Profilo OpenStreetMap</string>
 	<string name="place_page_search_similar_hotel">Cerca hotel simili</string>
 	<string name="bookmarks_detect_title">Nuovi file rilevati</string>
@@ -974,31 +609,10 @@
 	<string name="button_convert">Convertire</string>
 	<string name="bookmarks_convert_error_title">Errore</string>
 	<string name="bookmarks_convert_error_message">Alcuni file non sono stati convertiti.</string>
-	<string name="converting">Conversione...</string>
-	<string name="wn_reinvented_bookmarks_title">Abbiamo reinventato i segnalibri!</string>
-	<string name="wn_reinvented_bookmarks_message">Puoi fare il backup dei segnalibri, creare liste... È incredibile...</string>
-	<string name="bookmarks_restore">Ripristina segnalibri</string>
-	<string name="bookmarks_restore_process">Ripristino...</string>
 	<string name="bookmarks_restore_title">Ripristina questa versione?</string>
-	<string name="bookmarks_restore_message">I tuoi segnalibri verranno ripristinati da %1$s (%2$s)</string>
-	<string name="bookmarks_restore_empty_title">Non hai un backup</string>
-	<string name="bookmarks_restore_empty_message">Il server non ha trovato i backup creati in precedenza</string>
 	<string name="common_check_internet_connection_dialog_title">Nessuna connessione internet</string>
-	<string name="error_server_title">Errore del server</string>
-	<string name="error_server_message">Si è verificato un errore sul server, riprova più tardi</string>
 	<string name="error_system_message">Si è verificato un errore sconosciuto</string>
 	<string name="restore">Ristabilire</string>
-	<string name="bookmarks_page_downloaded">Scaricati</string>
-	<string name="bookmarks_page_my">I miei</string>
-	<string name="routes_and_bookmarks">Percorsi e segnalibri</string>
-	<string name="bookmarks_webview_success_toast">Segnalibri scaricati con successo</string>
-	<string name="cached_bookmarks_placeholder_title">Scarica nuovi posti</string>
-	<string name="cached_bookmarks_placeholder_subtitle">Premi il pulsante per scaricare migliaia di luoghi e percorsi interessanti creati dagli utenti di Organic Maps. Avrai bisogno della connessione internet.</string>
-	<string name="downloader_download_routers">Scarica i segnalibri</string>
-	<string name="bookmarks_groups_cached">Elenchi scaricati da</string>
-	<plurals name="bookmarks_objects">
-	  <item quantity="other">%s oggetto</item>
-	</plurals>
 	<plurals name="objects">
 	  <item quantity="other">%d luogo</item>
 	</plurals>
@@ -1011,62 +625,32 @@
 	<string name="subtittle_opt_out">Impostazioni di tracciamento</string>
 	<string name="crash_reports">Rapporto incidenti</string>
 	<string name="crash_reports_description">Potremmo utilizzare i tuoi dati per migliorare l\'esperienza Organic Maps. Le modifiche avranno effetto dopo il riavvio dell\'applicazione.</string>
-	<string name="opt_out_help_ios_1">Il tuo dispositivo mobile potrebbe fornire un\'impostazione «Limita monitoraggio annunci» o «Disattiva la pubblicità mirata».</string>
-	<string name="opt_out_help_ios_2">iOS 9 o versioni successive</string>
-	<string name="opt_out_help_ios_3">Vai a Impostazioni → Privacy → Pubblicità → Abilita l\'impostazione «Limita monitoraggio degli annunci»</string>
-	<string name="opt_out_help_android">Il tuo dispositivo mobile potrebbe fornire un\'impostazione «Limita monitoraggio annunci» o «Disattiva pubblicità mirata». \n\nPer Android e Google Play Services versione 4.0 e successive:\nImpostazioni → Google → Annunci → Disattiva personalizzazione annunci \né\nImpostazioni → Google → Account Google → Informazioni personali e privacy → Impostazioni annunci → Personalizzazione annunci</string>
 	<string name="privacy_policy">Politica sulla riservatezza</string>
 	<string name="terms_of_use">Condizioni d\'uso</string>
-	<string name="backup_notification_failed">Il backup dei segnalibri è stato sospeso. Accedi per riaccenderlo.</string>
 	<string name="button_layer_traffic">Traffico</string>
 	<string name="button_layer_subway">Metropolitana</string>
 	<string name="layers_title">Livelli mappa</string>
-	<string name="layers_message">Usa i livelli mappa per visualizzare il traffico, la mappa della metropolitana e altre informazioni utili</string>
-	<string name="button_layer_got_it">Fatto</string>
 	<string name="subway_data_unavailable">La mappa della metropolitana non è disponibile</string>
 	<string name="bookmarks_empty_list_title">Questa lista è vuota</string>
 	<string name="bookmarks_empty_list_message">Per aggiungere un segnalibro, toccare un punto sulla mappa e successivamente toccare l\'icona a forma di stella</string>
 	<string name="category_desc_more">…altro</string>
 	<string name="title_error_downloading_bookmarks">Si è verificato un errore</string>
-	<string name="subtitle_error_downloading_bookmarks">I segnalibri non sono stati scaricati</string>
-	<string name="error_already_downloaded">Questa lista è già stata scaricata</string>
-	<string name="why_support">Perché sostenere Organic Maps?</string>
-	<string name="why_support_item2">Voi ci aiutate a migliorare Organic Maps</string>
-	<string name="why_support_item3">Ci aiutate a migliorare le mappe OpenStreetMap.org</string>
-	<string name="channels_map_update">Rinnovare la carta</string>
-	<string name="server_unavailable_title">Server non è disponibile</string>
-	<string name="sharing_options">Impostazione accesso</string>
 	<string name="export_file">Esportare il file</string>
 	<string name="list_settings">Impostazioni elenco</string>
 	<string name="delete_list">Cancella elenco</string>
-	<string name="hide_from_map">Nascondere sulla mappa</string>
 	<string name="public_access">Accesso pubblico</string>
 	<string name="limited_access">Accesso privato</string>
 	<string name="bookmark_category_name">Categoria</string>
 	<string name="bookmark_category_description_hint">Aggiungere la descrizione (testo o html)</string>
 	<string name="not_shared">Personale</string>
-	<string name="direct_link_progress_text">Il file si sta caricando…</string>
-	<string name="direct_link_success">Il link è stato creato</string>
-	<string name="send_a_link_btn">Mandare il link</string>
-	<string name="upload_error_toast">Errore durante il caricamento</string>
 	<string name="tags_loading_error_subtitle">Si è verificato un errore durante il caricamento dei tag. Si prega di riprovare</string>
-	<string name="unable_upload_errorr_title">Il file non è stato caricato</string>
-	<string name="unable_upload_error_subtitle_edited">Il file è stato modificato tramite web App</string>
-	<string name="unable_upload_error_subtitle_broken">Il file è danneggiato e non può essere caricato. Si prega di caricare un altro file.</string>
-	<string name="contact">Scrivere</string>
-	<string name="download_button">Scaricare</string>
 	<string name="speedcams_alert_title">Autovelox o Tutor</string>
-	<string name="speedcams_alert_subtitle">Avvisare sul limite della velocità</string>
 	<string name="speedcam_option_auto">Auto</string>
 	<string name="speedcam_option_always">Sempre</string>
 	<string name="speedcam_option_never">Mai</string>
-	<string name="bookmark_description_title">Descrizione tag</string>
 	<string name="place_description_title">Descrizione luogo</string>
 	<!-- this text will be shown in application notification preferences opposite checkbox which enable/disable downloader notifications. Devices on Android 8+ are affected. -->
 	<string name="notification_channel_downloader">Caricamento mappe</string>
-	<string name="share_bookmarks_email_body_link">Ciao,\n\npuoi scaricare i tag dal seguente link: %s. Aprire elenco tramite Organic Maps e godersi viaggio!\n\nScaricare l\'App: https://omaps.app/get?kmz</string>
-	<string name="warning_speedcams_title">Il navigatore avvisa della presenza della telecamere in caso di eccesso velocità di %d km/o</string>
-	<string name="warning_speedcams_subtitle">Ricorda di informarti sul Codice della Strada del paese che visiti.</string>
 	<string name="speedcams_notice_message">Auto - Avvisare di autovelox in caso di rischio eccesso velocità\nSempre - avvisare sempre di autovelox\nMai - Non avvisare mai di autovelox</string>
 	<string name="power_managment_title">Modalità di risparmio energetico</string>
 	<string name="power_managment_description">In modalità di risparmio energetico l\'applicazione disattiva alcuni funzioni che hanno un impatto sulla batteria a secondo della carica restante</string>
@@ -1074,14 +658,7 @@
 	<string name="power_managment_setting_auto">Auto</string>
 	<string name="power_managment_setting_manual_max">Massimo risparmio energetico</string>
 	<string name="enable_logging_warning_message">Questa opzione si attiva per registrare tutte le azioni ai fini diagnostici. Ciò aiuta il nostro staff ad ottimizzare il funzionamento dell\'applicazione. Attiva l\'opzione sulla richiesta dello staff di suporto di Organic Maps.</string>
-	<string name="html_error_upload_message_try_again">Controllare la connessione e riprova</string>
-	<string name="html_error_upload_title_try_again">Nessuna connessione a internet</string>
-	<string name="notification_leave_review_v2_android_short_title">Scrivi il commento ed aiuta altri viaggiatori!</string>
-	<string name="notifications_illegal_alert_disable_button">Disattiva le notifiche</string>
 	<string name="access_rules_author_only">Modifica online</string>
-	<string name="privacy_settings_menu">Impostazioni della privacy</string>
-	<string name="unable_upadate_error_title">Non siamo riusciti ad aggiornare l\'itinerario</string>
-	<string name="unable_upadate_error_message">Si sono verificati errori durante l\'aggiornamento. Controlla le modifiche e riprova</string>
 	<string name="driving_options_title">Impostazioni di deviazione</string>
 	<string name="driving_options_subheader">Evitare in tutti i percorsi</string>
 	<string name="avoid_tolls">Strade a pedaggio</string>
@@ -1092,52 +669,14 @@
 	<string name="unable_to_calc_alert_subtitle">Impossibile creare percorso con modalità prescelte. Modifica impostazioni e riprova</string>
 	<string name="define_to_avoid_btn">Impostare modalità di deviazione</string>
 	<string name="change_driving_options_btn">Impostazioni di deviazione abilitate</string>
-	<string name="toll_road">Strada a pedaggio</string>
-	<string name="unpaved_road">Strada sterrata</string>
-	<string name="ferry_crossing">Traghetto</string>
-	<string name="operated_by">Gestita da \"%s\"</string>
 	<string name="avoid_toll_roads_placepage">Evitare strade a pedaggio</string>
 	<string name="avoid_unpaved_roads_placepage">Evitare strade sterrate</string>
 	<string name="avoid_ferry_crossing_placepage">Evitare i traghetti</string>
-	<string name="type.cuisine.uzbek">Cucina uzbeka</string>
-	<string name="trip_start">Si parte</string>
-	<string name="pick_destination">Meta</string>
-	<string name="follow_my_position">Centrare</string>
-	<string name="search_results">Risultati di ricerca</string>
-	<string name="then_turn">Avanti</string>
-	<string name="redirect_route_alert">Vuoi modificare il percorso?</string>
-	<string name="redirect_route_yes">Sì</string>
-	<string name="redirect_route_no">No</string>
-	<string name="trip_finished">Sei giunto a destinazione!</string>
-	<string name="keyboard_availability_alert">Tastiera non disponibile in movimento</string>
-	<string name="dialog_routing_change_start_carplay">Impossibile creare percorso dal punto di partenza selezionato</string>
-	<string name="dialog_routing_change_end_carplay">Impossibile creare percorso per raggiungere la destinazione Scegli un\'altra destinazione</string>
-	<string name="dialog_routing_check_gps_carplay">Segnale GPS assente. Procedi su terreno aperto</string>
-	<string name="dialog_routing_unable_locate_route_carplay">Impossibile trovare percorso. Scegli altre tappe</string>
-	<string name="dialog_routing_download_files_carplay">Per creare percorso scarica mappe mancanti sul proprio dispositivo</string>
-	<string name="dialog_routing_system_error_carplay">Si è verificato un errore. Riavviare l\'applicazione</string>
-	<string name="dialog_routing_rebuild_from_current_location_carplay">Il percorso verrà impostato dalla tua posizione corrente</string>
-	<string name="dialog_routing_rebuild_for_vehicle_carplay">Il percorso verrà modificato in modalità Auto</string>
 	<string name="ok">Ok</string>
-	<string name="avoid_unpaved_carplay_1">No sterrati</string>
-	<string name="avoid_unpaved_carplay_2">No sterrati</string>
-	<string name="avoid_ferry_carplay_1">No traghetti</string>
-	<string name="avoid_ferry_carplay_2">No traghetti</string>
-	<string name="avoid_tolls_carplay_1">No pedaggi</string>
-	<string name="avoid_tolls_carplay_2">Senza pedaggi</string>
-	<string name="speedcams_alert_title_carplay_1">Autovelox</string>
-	<string name="speedcams_alert_title_carplay_2">Info autovelox</string>
-	<string name="download_map_carplay">Scarica l\'applicazione Organic Maps sul tuo smartphone</string>
-	<string name="carplay_roundabout_exit">%s uscita</string>
 	<!-- max. 10 symbols, both iOS and Android -->
 	<string name="sort">Ordina…</string>
 	<!-- Android, title, max 20-22 symbols -->
 	<string name="sort_bookmarks">Ordina i segnalibri</string>
-	<!-- iOS -->
-	<string name="sort_default">Ordina per default</string>
-	<string name="sort_type">Ordina per tipo</string>
-	<string name="sort_distance">Ordina per distanza</string>
-	<string name="sort_date">Ordina per data</string>
 	<!-- Android -->
 	<string name="by_default">Per default</string>
 	<!-- Android -->
@@ -1146,65 +685,23 @@
 	<string name="by_distance">Per distanza</string>
 	<!-- Android -->
 	<string name="by_date">Per data</string>
-	<string name="week_ago_sorttype">Una settimana fa</string>
-	<string name="month_ago_sorttype">Un mese fa</string>
-	<string name="moremonth_ago_sorttype">Più di un mese fa</string>
-	<string name="moreyear_ago_sorttype">Più di un anno fa</string>
-	<string name="near_me_sorttype">Vicino a me</string>
-	<string name="others_sorttype">Altri</string>
-	<string name="food_places">Cibo</string>
-	<string name="tourist_places">Luoghi d\'interesse</string>
-	<string name="museums">Musei</string>
-	<string name="parks">Parchi</string>
-	<string name="swim_places">Nuoto</string>
-	<string name="mountains">Montagne</string>
-	<string name="animals">Animali</string>
-	<string name="hotels">Alberghi</string>
-	<string name="buildings">Edifici</string>
-	<string name="money">Denaro</string>
-	<string name="shops">Negozi</string>
-	<string name="parkings">Parcheggi</string>
-	<string name="fuel_places">Stazione di servizio</string>
-	<string name="water">Acqua</string>
-	<string name="medicine">Farmacia</string>
 	<string name="search_in_the_list">Cerca nella lista</string>
-	<string name="view_on_map_bookmarks">Sulla mappa</string>
-	<string name="more_bookmarks">Ecc…</string>
-	<string name="no_items_found">Nessun risultato trovato</string>
-	<!-- Android, max 18 symbols -->
-	<string name="bookmarks_edit_list">Modifica</string>
-	<!-- Android, max 18 symbols -->
-	<string name="bookmarks_delete_list">Cancella la lista</string>
-	<string name="religious_places">Luoghi di culto</string>
 	<string name="select_list">Scegli la lista</string>
 	<string name="transit_not_found">L\'utilizzo della metro non è ancora disponibile in questa regione</string>
 	<string name="dialog_pedestrian_route_is_long_header">Percorso della metro non trovato</string>
 	<string name="dialog_pedestrian_route_is_long_message">Seleziona il punto iniziale o finale del percorso più vicino alla stazione della metro</string>
-	<!-- Failed planning SUBWAY route message in navigation view -->
-	<string name="routing_planning_error_subway_special">Errore di creazione del percorso della metro</string>
 	<string name="button_layer_isolines">Terreno</string>
-	<string name="tips_map_layers_title_countour">Novità su Organic Maps modalità topografica offline!</string>
-	<string name="tips_map_layers_message_countour">La modalità topografica aiuta a programmare il viaggio nella natura e a non perdersi</string>
 	<string name="isolines_activation_error_dialog">Per utilizzare la modalità topografica, aggiornate o scaricate la mappa dell\'area interessata</string>
 	<string name="isolines_location_error_dialog">La modalità topografica per questa regione non è ancora disponibile</string>
 	<string name="elevation_profile_diff_level">Livello di difficoltà</string>
-	<string name="elevation_profile_diff_level_easy">Facile</string>
-	<string name="elevation_profile_diff_level_moderate">Moderato</string>
-	<string name="elevation_profile_diff_level_hard">Difficile</string>
 	<string name="elevation_profile_ascent">Ascesa</string>
 	<string name="elevation_profile_descent">Discesa</string>
 	<string name="elevation_profile_minaltitude">Altitudine minima</string>
 	<string name="elevation_profile_maxaltitude">Altitudine massima</string>
-	<string name="elevation_profile_m">m</string>
 	<string name="elevation_profile_difficulty">Difficoltà</string>
 	<string name="elevation_profile_distance">Dist.</string>
-	<string name="elevation_profile_km">km</string>
 	<string name="elevation_profile_time">Tempo:</string>
-	<string name="elevation_profile_hours">ore</string>
-	<string name="elevation_profile_minutes">min</string>
 	<string name="isolines_toast_zooms_1_10">Ingrandisci mappa per vedere l\'isolinea</string>
-	<string name="downloader_updating_ios">Aggiornamento in corso</string>
-	<string name="downloader_loading_ios">Caricamento</string>
 	<string name="key_information_title">Informazioni importanti</string>
 	<string name="enable_screen_sleep">Consenti allo schermo di dormire</string>
 	<!-- Description in preferences -->

--- a/android/res/values-ja/strings.xml
+++ b/android/res/values-ja/strings.xml
@@ -12,8 +12,6 @@
 	<string name="cancel_download">ダウンロードをキャンセル</string>
 	<!-- Button which deletes downloaded country -->
 	<string name="delete">削除</string>
-	<!-- Button "do not interrupt download" if user touched actively downloading country -->
-	<string name="do_nothing">何もしない</string>
 	<string name="download_maps">マップをダウンロード</string>
 	<!-- Settings/Downloader - info for country when download fails -->
 	<string name="download_has_failed">ダウンロードが失敗しました。もう一度試すには画面をタッチしてください。</string>
@@ -31,45 +29,31 @@
 	<string name="core_my_position">現在地</string>
 	<!-- Update maps later/Buy pro version later button text -->
 	<string name="later">次の機会に</string>
-	<!-- Don't show some dialog any more -->
-	<string name="never">今後表示しない</string>
 	<!-- View and button titles for accessibility -->
 	<string name="search">検索</string>
 	<!-- Search box placeholder text -->
 	<string name="search_map">マップを検索</string>
-	<!-- Settings/Downloader - info for not downloaded country -->
-	<string name="touch_to_download">タッチしてダウンロード</string>
 	<!-- Settings/Downloader - 3G download warning dialog confirm button -->
 	<string name="use_cellular_data">はい</string>
 	<!-- Location services are disabled by user alert - message -->
 	<string name="location_is_disabled_long_text">端末の位置情報サービスが無効になっているか、このアプリケーションからの位置情報利用が制限されています。端末の設定を有効化してください。</string>
-	<!-- Location Services are not available on the device alert - message -->
-	<string name="device_doesnot_support_location_services">ご使用中の端末は位置情報サービスをサポートしていません。</string>
 	<!-- View and button titles for accessibility -->
 	<string name="zoom_to_country">地図に表示</string>
-	<!-- Button text for the button at the center of the screen when the country is not downloaded -->
-	<string name="country_status_download">地図をダウンロード\n(^ ^)</string>
 	<!-- Button text for the button at the center of the screen when the country is not downloaded and the size should not be shown -->
 	<string name="country_status_download_without_size">地図をダウンロード</string>
-	<!-- Button text for the button at the center of the screen when the country is not downloaded -->
-	<string name="country_status_download_without_routing">ルートなしで地図をダウンロード\n(^ ^)</string>
 	<!-- Message to display at the center of the screen when the country download has failed -->
 	<string name="country_status_download_failed">のダウンロードに失敗しました</string>
 	<!-- Button text for the button under the country_status_download_failed message -->
 	<string name="try_again">再実行</string>
 	<string name="about_menu_title">Organic Mapsについて</string>
-	<string name="downloaded_touch_to_delete">(%s)をダウンロードしました。削除するには画面をタッチしてください。</string>
 	<string name="connection_settings">接続設定</string>
-	<string name="download_mb_or_kb">%sをダウンロード</string>
 	<string name="close">閉じる</string>
 	<string name="unsupported_phone">ハードウェアアクセラレーションされたOpenGLが必要です。残念ながらご利用中のデバイスではサポートされていません。</string>
 	<string name="download">ダウンロード</string>
-	<string name="external_storage_is_not_available">マップをダウンロードしたSDカード/USBストレージへ接続できません</string>
 	<string name="disconnect_usb_cable">Organic Mapsを利用するにはUSBケーブルを抜くかメモリーカードを挿入してください</string>
 	<string name="not_enough_free_space_on_sdcard">アプリを起動するにはSDカード/USBストレージの空き容量を確保する必要があります</string>
 	<string name="not_enough_memory">メモリ不足のためアプリを起動できません</string>
 	<string name="download_resources">利用を開始する前におおまかな世界地図をダウンロードします。これには%sの空き容量が必要です。</string>
-	<string name="getting_position">現在地を取得中</string>
 	<string name="download_resources_continue">マップを表示</string>
 	<string name="downloading_country_can_proceed">%sをダウンロードしました\nマップを表示可能です</string>
 	<string name="download_country_ask">%sをダウンロードしますか？</string>
@@ -82,30 +66,20 @@
 	<string name="download_country_failed">%sのダウンロードが失敗しました</string>
 	<!-- Add New Bookmark Set dialog title -->
 	<string name="add_new_set">新しいセットを作成</string>
-	<!-- Place Page - Add To Bookmarks button -->
-	<string name="add_to_bookmarks">ブックマークに追加</string>
 	<!-- Bookmark Color dialog title -->
 	<string name="bookmark_color">ブックマーク表示色</string>
 	<!-- Add Bookmark Set dialog - hint when set name is empty -->
 	<string name="bookmark_set_name">ブックマークセット名称</string>
-	<!-- Bookmark Sets dialog title -->
-	<string name="bookmark_sets">ブックマークセット</string>
 	<!-- Bookmarks - dialog title -->
 	<string name="bookmarks">ブックマーク</string>
-	<!-- Add bookmark dialog - bookmark color -->
-	<string name="color">表示色</string>
 	<!-- Default bookmarks set name -->
 	<string name="core_my_places">マイロケーション</string>
 	<!-- Add bookmark dialog - bookmark name -->
 	<string name="name">名称</string>
 	<!-- Editor title above street and house number -->
 	<string name="address">住所</string>
-	<!-- Place Page - Remove Pin button -->
-	<string name="remove_pin">ピンを削除</string>
 	<!-- Add bookmark dialog - bookmark set, Bookmarks dialog - Bookmark set cell -->
 	<string name="set">セット</string>
-	<!-- Text hint in Bookmarks dialog when no any bookmarks are added -->
-	<string name="bookmarks_usage_hint">未だブックマークがありません。\nマップ上をタップすればブックマークを追加できます。\nOrganic Maps以外のアプリで作成したブックマークの表示も可能です。KML/KMZ形式のピン情報をメールやDropbox、URLから取得してください。</string>
 	<!-- Settings button in system menu -->
 	<string name="settings">設定</string>
 	<!-- Header of settings activity where user defines storage path -->
@@ -116,20 +90,10 @@
 	<string name="move_maps">マップを移動させますか？</string>
 	<!-- Ask to wait user several minutes (some long process in modal dialog). -->
 	<string name="wait_several_minutes">数分かかる場合があります。\nしばらくお待ち下さい…</string>
-	<!-- Show bookmarks from this category on a map or not -->
-	<string name="visible">マップに表示</string>
-	<!-- Toast which is displayed when GPS has been deactivated -->
-	<string name="gps_is_disabled_long_text">GPS機能が無効です。端末の設定画面から有効にしてください。</string>
 	<!-- Measurement units title in settings activity -->
 	<string name="measurement_units">距離計測単位</string>
 	<!-- Detailed description of Measurement Units settings button -->
 	<string name="measurement_units_summary">マイルまたはキロメートルを選択</string>
-	<!-- Do search in all sources -->
-	<string name="search_mode_all">全マップから検索</string>
-	<!-- Do search near my position only -->
-	<string name="search_mode_nearme">現在地周辺</string>
-	<!-- Do search in current viewport only -->
-	<string name="search_mode_viewport">マップ表示範囲</string>
 	<!-- Search category for cafes, bars, restaurants -->
 	<string name="eat">食事場所</string>
 	<!-- Search category for grocery stores -->
@@ -166,12 +130,8 @@
 	<string name="post">郵便局</string>
 	<!-- Search category -->
 	<string name="police">警察</string>
-	<!-- String in search result list, when nothing found -->
-	<string name="no_search_results_found">検索結果が見つかりませんでした</string>
 	<!-- Notes field in Bookmarks view -->
 	<string name="description">メモ</string>
-	<!-- Button text -->
-	<string name="share_by_email">Eメールで共有</string>
 	<!-- Email Subject when sharing bookmarks category -->
 	<string name="share_bookmarks_email_subject">Organic Mapsの位置情報シェア</string>
 	<!-- message title of loading file -->
@@ -182,20 +142,10 @@
 	<string name="load_kmz_failed">ブックマークのアップロードに失敗しました。ファイルが破損していた、または問題があった可能性があります。</string>
 	<!-- Warning message when doing search around current position -->
 	<string name="unknown_current_position">現在の座標が未確定です</string>
-	<!-- Warning message when location country isn't downloaded during search (see also download_location_map_proposal). -->
-	<string name="download_location_country">現在の地域をダウンロード(%s)</string>
-	<!-- Warning message when viewport country isn't downloaded during search -->
-	<string name="download_viewport_country_to_search">現在マップで検索している国をダウンロード(%s)</string>
 	<!-- Alert message that we can't run Map Storage settings due to some reasons. -->
 	<string name="cant_change_this_setting">恐れ入ります、マップストレージ設定が無効になっています。</string>
 	<!-- Alert message that downloading is in progress. -->
 	<string name="downloading_is_active">ダウンロードを実行中です</string>
-	<!-- Message that will be shown in alert view, when we ask user to leave review on App Store -->
-	<string name="appStore_message">Organic Mapsの使い心地はいかがでしょうか。もしよろしければ、App Storeでレビューや評価をお知らせください。皆様からいただく一言が開発の励みになります。ご支援をよろしくお願いいたします！</string>
-	<!-- No, thanks -->
-	<string name="no_thanks">いいえ</string>
-	<!-- Share one specific bookmark using SMS, %1$@ contains om:// and %2$@ https://omaps.app link. @NOTE non-ascii symbols in the link will result in max 70 characters SMS instead of 140. -->
-	<string name="bookmark_share_sms">私のピン情報はこの位置です。リンク: %1$s, %2$s</string>
 	<!-- Share my position using SMS, %1$@ contains om:// and %2$@ https://omaps.app link WITHOUT NAME. @NOTE non-ascii symbols in the link will result in max 70 characters SMS instead of 140. -->
 	<string name="my_position_share_sms">私は今ここにいます。リンク: %1$s, %2$s</string>
 	<!-- Subject for emailed bookmark -->
@@ -204,18 +154,10 @@
 	<string name="my_position_share_email_subject">Organic Mapsで現在地を確認</string>
 	<!-- Share my position using EMail, %1$@ is om:// and %2$@ is https://omaps.app link WITHOUT NAME -->
 	<string name="my_position_share_email">私は今ここにいます: %1$s\n\nリンクをクリックすると詳細がマップに表示されます。\n\n%2$s\n\n%3$s</string>
-	<!-- Android share by Message/SMS button text (including SMS) -->
-	<string name="share_by_message">メッセージで共有</string>
 	<!-- Share button text which opens menu with more buttons, like Message, EMail, Facebook etc. -->
 	<string name="share">共有</string>
-	<!-- iOS share by Message button text (including SMS) -->
-	<string name="message">メッセージ</string>
 	<!-- Share by email button text, also used in editor. -->
 	<string name="email">Eメール</string>
-	<!-- Copy Link -->
-	<string name="copy_link">リンクをコピー</string>
-	<!-- Text for the button that returns to caller application -->
-	<string name="more_info">詳細情報を表示</string>
 	<!-- Text for message when used successfully copied something -->
 	<string name="copied_to_clipboard">クリップボードにコピーしました: %1$s</string>
 	<!-- place preview title -->
@@ -231,11 +173,6 @@
 	<!-- Length of track in cell that describes route -->
 	<string name="length">距離</string>
 	<string name="share_my_location">位置情報を共有する</string>
-	<string name="menu_search">検索</string>
-	<!-- Settings screen: "Map" category title -->
-	<string name="prefs_group_map">地図</string>
-	<!-- Settings screen: "Miscellaneous" category title -->
-	<string name="prefs_group_misc">その他</string>
 	<string name="prefs_group_route">ナビゲーション</string>
 	<string name="pref_zoom_title">ズームボタン</string>
 	<string name="pref_zoom_summary">画面上に表示</string>
@@ -251,8 +188,6 @@
 	<string name="pref_map_3d_title">パースペクティブ表示</string>
 	<!-- Settings «Map» category: «3D buildings» title -->
 	<string name="pref_map_3d_buildings_title">3Dビルディング</string>
-	<!-- Settings «Map» category: «3D buildings» summary -->
-	<string name="pref_map_3d_buildings_subtitle">電池の持ち時間に影響します</string>
 	<!-- Settings «Route» category: «Tts enabled» title -->
 	<string name="pref_tts_enable_title">音声指示</string>
 	<!-- Settings «Route» category: «Tts language» title -->
@@ -261,7 +196,6 @@
 	<string name="pref_tts_unavailable">利用不可</string>
 	<!-- Title for "Other" section in TTS settings. -->
 	<string name="pref_tts_other_section_title">その他</string>
-	<string name="pref_tts_how_to_set_up_voice">音声設定の仕方</string>
 	<!-- Settings «Map» category: «Record track» title -->
 	<string name="pref_track_record_title">最近の移動経路</string>
 	<string name="pref_map_auto_zoom">自動ズーム</string>
@@ -272,46 +206,11 @@
 	<string name="duration_12_hours">12時間</string>
 	<string name="duration_1_day">1日</string>
 	<string name="recent_track_help_text">移動経路を一定期間記録し、地図上で確認できるようにします。注意：この機能を有効にすると、バッテリーの消費量が増えます。表示期間が終了すると、走行軌跡は地図から自動的に削除されます。</string>
-	<string name="pref_track_ios_caption">最近ルートは、使用した道のりを表示する機能です。</string>
-	<string name="pref_track_ios_subcaption">ルートを保存する期間を選択してください。</string>
-	<string name="placepage_distance">距離</string>
-	<string name="placepage_coordinates">コーディネート</string>
-	<string name="placepage_unsorted">未分類</string>
 	<string name="search_show_on_map">地図に表示</string>
-	<!-- Used to warn user when fixing KitKat issue -->
-	<string name="bookmark_move_fail">ブックマークを内部メモリに移動させなければなりませんが、メモリの空き容量がありません。空き容量を増やさなければ、ブックマークをご利用いただくことができません。</string>
-	<!-- Used in More Apps menu -->
-	<string name="free">無料</string>
-	<!-- Used in More Apps menu -->
-	<string name="buy">購入</string>
-	<!-- 1st search button-like result -->
-	<string name="search_on_map">地図を検索</string>
-	<!-- toast with an error -->
-	<string name="no_route_found">一致する経路がありません</string>
-	<!-- route title -->
-	<string name="route">経路</string>
-	<!-- category title -->
-	<string name="routes">ルート</string>
-	<!-- text of notification -->
-	<string name="download_map_notification">あなたがいる場所のマップをダウンロードしよう</string>
-	<!-- text of notification -->
-	<string name="pro_version_is_free_today">Organic Mapsのフルバージョンが本日無料！今すぐダウンロードして友達に教えてあげましょう。</string>
-	<!-- Dialog for transferring maps from lite to pro. -->
-	<string name="move_lite_maps_to_pro">ダウンロード済みの地図をOrganic Maps LiteからOrganic Mapsに転送します。完了までに数分かかるかもしれません。</string>
-	<!-- Message to display when maps moved. -->
-	<string name="move_lite_maps_to_pro_ok">ダウンロード済みの地図は無事Organic Mapsに転送されました</string>
-	<!-- Message to display when maps move failed. -->
-	<string name="move_lite_maps_to_pro_failed">地図の転送に失敗しました。Organic Maps Liteを削除してから地図を再度ダウンロードしてください。</string>
-	<!-- Text in menu -->
-	<string name="settings_and_more">設定&amp;その他</string>
 	<!-- Text in menu -->
 	<string name="website">ウェブサイト</string>
-	<!-- Text in menu -->
-	<string name="contact_us">お問い合わせ</string>
 	<!-- Settings: Send feedback button and dialog title -->
 	<string name="feedback">フィードバック</string>
-	<!-- Text in menu -->
-	<string name="subscribe_to_news">当社のニュースに登録</string>
 	<!-- Text in menu -->
 	<string name="rate_the_app">アプリを評価</string>
 	<!-- Text in menu -->
@@ -320,12 +219,6 @@
 	<string name="copyright">著作権</string>
 	<!-- Text in menu -->
 	<string name="report_a_bug">バグを報告</string>
-	<!-- Email subject -->
-	<string name="subscribe_me_subject">Organic Mapsニュースレターを購読します</string>
-	<!-- Email body -->
-	<string name="subscribe_me_body">最新ニュース、アップデートとプロモーションにすいてまず知りたいです。いつでも購読をキャンセル出来ます。</string>
-	<!-- About text -->
-	<string name="about_text">Organic Mapsは世界の全ての国、全ての都市が載っている最速のオフラインマップ。どこにいてもOrganic Mapsの地図上でユーザーの現在地が分かり、付近のレストラン、ホテル、銀行、ガソリンスタンドなどが見つけられるので、自信を持って旅行ができます。インターネット接続は必要ありません。\n\n弊社では常に新機能の開発に取り組んでいるので、Organic Mapsの改善についてユーザーの皆様からのご意見やご感想をお待ちしています。アプリで問題点が見つかった際は、お気軽にsupport\@organicmaps.appまでご連絡ください。どのようなリクエストにでも対応いたします!\n\nOrganic Mapsが好きでサポートしていただけますか。シンプルで完全無料の方法がいくつかあります。\n\n- お使いのアプリマーケットでレビューを投稿\n- 弊社のFacebookページで「いいね!」をクリック：http://www.facebook.com/OrganicMaps\n- Organic Mapsのことをお母様、お友達、同僚の皆様に話す (^_^)\n\n弊社アプリをご利用いただきありがとうございます。皆様からのサポートに大変感謝しております!\n\n追伸：ウィキペディアのようにユーザーによる作成や編集が可能なマッピングプロジェクトOpenStreetMapの地図データを使用しています。地図上で欠けているものや誤りを見つけた場合、https://www.openstreetmap.orgでユーザーが直接修正ができます。このような変更はOrganic Mapsのその後のバージョンリリースの際に反映されます。</string>
 	<!-- Alert text -->
 	<string name="email_error_body">このメールクライアントはセットアップされていません。設定するか、他の方法で%sにご連絡ください。</string>
 	<!-- Alert title -->
@@ -334,137 +227,56 @@
 	<string name="pref_calibration_title">コンパスの調整</string>
 	<!-- Search category -->
 	<string name="wifi">無線LAN</string>
-	<!-- Update map suggestion -->
-	<string name="routing_map_outdated">ルートを作成するためにマップを更新してください。</string>
-	<!-- Update maps suggestion -->
-	<string name="routing_update_maps">新バージョンのOrganic Mapsは現在地から目的地までのルートを作成可能です。 この機能を使うためにマップを更新してください。</string>
 	<!-- Update all button text -->
 	<string name="downloader_update_all_button">全てをアップデート</string>
 	<!-- Cancel all button text -->
 	<string name="downloader_cancel_all">すべてキャンセル</string>
 	<!-- Downloaded maps category -->
 	<string name="downloader_downloaded_subtitle">ダウンロード済み</string>
-	<!-- Downloaded maps category -->
-	<string name="downloader_available_maps">利用可能</string>
 	<!-- Country queued for download -->
 	<string name="downloader_queued">待ち行列型の</string>
 	<string name="downloader_near_me_subtitle">付近</string>
 	<string name="downloader_status_maps">地図</string>
 	<string name="downloader_download_all_button">全てをダウンロード</string>
 	<string name="downloader_downloading">ダウンロード中：</string>
-	<string name="downloader_search_results">見つかりました</string>
-	<!-- Disclaimer message -->
-	<string name="routing_disclaimer">Organic Mapsアプリでルートを作成する時は、以下のことに留意してください：\n\n  - 提案されたルートは推奨するだけです。\n - 道路状況、交通規則と標識はナビゲーションのアドバイスより優先度が高くなっています。\n - マップが不正確または古くなっている場合や、ルートが最適な方法で作成されていないことがあります。\n\n  安全運転でご自愛ください！</string>
-	<!-- Outdated maps category -->
-	<string name="downloader_outdated_maps">旧式</string>
-	<!-- Up to date maps category -->
-	<string name="downloader_uptodate_maps">最新</string>
 	<!-- Status of outdated country in the list -->
 	<string name="downloader_status_outdated">を更新</string>
 	<!-- Status of failed country in the list -->
 	<string name="downloader_status_failed">失敗</string>
 	<!-- Displayed in a dialog that appears when a user tries to delete a map while the app is in the follow route mode -->
 	<string name="downloader_delete_map_while_routing_dialog">地図を削除するにはナビゲーションを停止してください。</string>
-	<!-- Show when user try build route, but we don't know where he -->
-	<string name="routing_failed_unknown_my_position">現在地が設定されていません。ルートを作成するには現在地を設定してください。</string>
-	<!-- Show if use has not routing file, or InconsistentMWMandRoute -->
-	<string name="routing_failed_has_no_routing_file">ルートを作成するには追加のデータが必要です。ダウンロードを開始しますか？</string>
-	<!-- StartPointNotFound -->
-	<string name="routing_failed_start_point_not_found">ルートを計算できません。出発地点の近くに道路がありません。</string>
-	<!-- EndPointNotFound -->
-	<string name="routing_failed_dst_point_not_found">ルートを計算できません。目的地の近くに道路がありません。</string>
 	<!-- PointsInDifferentMWM -->
 	<string name="routing_failed_cross_mwm_building">一つの地図に完全に収まるルートのみ作成可能です。</string>
-	<!-- RouteNotFound -->
-	<string name="routing_failed_route_not_found">選択した出発地と目的地との間にルートが見つかりません。別の出発地点と到着地点を選択してください。</string>
-	<!-- InternalError -->
-	<string name="routing_failed_internal_error">内部エラーが発生しました。もう一度地図をダウンロードしてください。問題が解決しない場合は、support\@organicmaps.appまでご連絡ください。</string>
-	<!-- Context menu item for downloader. -->
-	<string name="downloader_download_map_and_routing">地図とルートをダウンロード</string>
-	<!-- Context menu item for downloader. -->
-	<string name="downloader_download_routing">ルートをダウンロード</string>
-	<!-- Context menu item for downloader. -->
-	<string name="downloader_delete_routing">ルートを削除</string>
 	<!-- Context menu item for downloader. -->
 	<string name="downloader_download_map">地図をダウンロード</string>
-	<string name="downloader_download_map_no_routing">ルートなしで地図をダウンロード</string>
-	<!-- Button for routing. -->
-	<string name="routing_go">開始！</string>
 	<!-- Item status in downloader. -->
 	<string name="downloader_retry">リピート</string>
-	<!-- Item in context menu. -->
-	<string name="downloader_map_and_routing">地図とルート</string>
 	<!-- Item in context menu. -->
 	<string name="downloader_delete_map">地図を削除</string>
 	<!-- Item in context menu. -->
 	<string name="downloader_update_map">地図を更新</string>
-	<!-- Item in context menu. -->
-	<string name="downloader_update_map_and_routing">地図とルートを更新</string>
-	<!-- Item in context menu. -->
-	<string name="downloader_map_only">地図のみ</string>
-	<!-- Toolbar title -->
-	<string name="toolbar_application_menu">アプリケーションメニュー</string>
 	<!-- Preference text -->
 	<string name="pref_use_google_play">現在のロケーションを取得するためにGoogle Playのサービスを使う</string>
 	<!-- Text for rating dialog -->
 	<string name="rating_just_rated">たった今アプリを評価したところです</string>
-	<!-- Text for rating dialog -->
-	<string name="rating_user_since">私は%s年からOrganic Mapsのユーザーです</string>
-	<!-- Text for rating dialog -->
-	<string name="rating_do_like_maps">Organic Mapsをお気に入りいただいていますか？</string>
-	<!-- Text for rating dialog -->
-	<string name="rating_tap_star">星印をタップしてアプリを評価してください。</string>
 	<!-- Text for rating dialog -->
 	<string name="rating_thanks">よろしくお願いします！</string>
 	<!-- Text for rating dialog -->
 	<string name="rating_share_ideas">皆様のためにアプリを改善できるよう、アイディアや問題点を教えてください。</string>
 	<!-- Text for rating dialog -->
 	<string name="rating_send_feedback">フィードバックを送信</string>
-	<!-- Text for g+ dialog -->
-	<string name="rating_google_plus">g+をクリックして友達にこのアプリを教えてあげましょう。</string>
 	<!-- Text for routing error dialog -->
 	<string name="routing_download_maps_along">ルート上の地図をダウンロード</string>
-	<!-- Text for routing error dialog -->
-	<string name="routing_download_map">地図を入手</string>
-	<!-- Text for routing error dialog -->
-	<string name="routing_download_map_and_routing">最新の地図とルートデータを入手して、Organic Mapsの全機能をご利用ください。</string>
-	<!-- Text for routing error dialog -->
-	<string name="routing_get_routing_data">ルートデータを入手</string>
-	<!-- Text for routing error dialog -->
-	<string name="routing_get_additional_data">現在位置からのルート作成に必要な追加データです。</string>
 	<!-- Text for routing error dialog -->
 	<string name="routing_requires_all_map">ルートの作成には現在位置から目的地までのすべての地図をダウンロードし、最新のものにする必要があります。</string>
 	<!-- Text for routing error dialog -->
 	<string name="routing_not_enough_space">空き容量が足りません</string>
-	<!-- Text for routing error dialog -->
-	<string name="routing_download_more_than_avail">%1$s MBダウンロードする必要がありますが、%2$s MBしか空いていません。</string>
-	<!-- Text for routing error dialog -->
-	<string name="routing_download_roaming">携帯のデータ通信（ローミング）を使用して%s MBダウンロードしようとしています。これにより、ご利用の通信会社の携帯データプランによっては追加料金が発生する可能性があります。</string>
 	<!-- bookmark button text -->
 	<string name="bookmark">お気に入り</string>
-	<!-- map is not downloaded -->
-	<string name="not_found_map">現在地の地図が見つかりません</string>
 	<!-- location service disabled -->
 	<string name="enable_location_services">位置情報サービスを有効化してください</string>
-	<!-- download map -->
-	<string name="download_map">あなたがいる場所のマップをダウンロードしよう</string>
-	<!-- download map on iPhone -->
-	<string name="download_map_iphone">iPhoneに現在位置の地図をダウンロード</string>
-	<!-- clear pin -->
-	<string name="nearby">近くに</string>
-	<!-- clear pin -->
-	<string name="clear_pin">ピンをクリア</string>
-	<!-- location is undefined -->
-	<string name="undefined_location">現在地が設定されていません。</string>
-	<!-- download country of your location -->
-	<string name="download_country">現在の地域をダウンロード</string>
-	<!-- download failed -->
-	<string name="download_failed">のダウンロードが失敗しました</string>
-	<!-- get the map -->
-	<string name="get_the_map">地図を入手</string>
 	<string name="save">保存</string>
 	<string name="edit_description_hint">説明（テキストまたはHTML）</string>
-	<string name="new_group">新規グループ</string>
 	<string name="create">作成</string>
 	<!-- red color -->
 	<string name="red">赤</string>
@@ -482,22 +294,6 @@
 	<string name="brown">茶色</string>
 	<!-- pink color -->
 	<string name="pink">ピンク</string>
-	<!-- deep purple color -->
-	<string name="deep_purple">ディープパープル</string>
-	<!-- light blue color -->
-	<string name="light_blue">ライトブルー</string>
-	<!-- cyan color -->
-	<string name="cyan">シアン</string>
-	<!-- teal color -->
-	<string name="teal">ティール</string>
-	<!-- lime color -->
-	<string name="lime">ライム</string>
-	<!-- deep orange color -->
-	<string name="deep_orange">ディープオレンジ</string>
-	<!-- gray color -->
-	<string name="gray">グレイ</string>
-	<!-- blue gray color -->
-	<string name="blue_gray">ブルーグレイ</string>
 	<!-- Wi-Fi available -->
 	<string name="WiFi_available">はい</string>
 
@@ -513,10 +309,8 @@
 	<string name="dialog_routing_location_turn_wifi">GPS信号をご確認ください。Wi-Fiを有効にするとより正確な位置情報を取得できます。</string>
 	<string name="dialog_routing_location_turn_on">位置情報サービスを有効にしてください</string>
 	<string name="dialog_routing_location_unknown_turn_on">現在地のGPSコードを確認できません。案内ルートを作成するには、位置情報サービスを有効にしてください。</string>
-	<string name="dialog_routing_location_unknown">現在地のGPSコードを確認できません。</string>
 	<string name="dialog_routing_download_files">必要なファイルをダウンロードしてください</string>
 	<string name="dialog_routing_download_and_update_all">案内ルートを作成するには、表示されたパスに従ってすべてのマップ、ルート情報をダウンロード、アップデートしてください。</string>
-	<string name="dialog_routing_routes_size">ルート情報ファイル</string>
 	<string name="dialog_routing_unable_locate_route">ルートの位置を確認できません</string>
 	<string name="dialog_routing_cant_build_route">案内ルートを作成できません。</string>
 	<string name="dialog_routing_change_start_or_end">出発地または目的地の位置調整をしてください。</string>
@@ -531,33 +325,23 @@
 	<string name="dialog_routing_system_error">システムエラー</string>
 	<string name="dialog_routing_application_error">アプリケーションのエラーにより案内ルートを作成できませんでした。</string>
 	<string name="dialog_routing_try_again">もう一度お試しください</string>
-	<string name="dialog_routing_send_error">問題を報告する</string>
-	<string name="dialog_routing_if_get_cross_route">複数マップを利用してより最適なルートを作成しますか？</string>
-	<string name="dialog_routing_cross_route_is_optimal">このマップの境界を越えて複数マップを利用すると、より最適なルートを作成できます。</string>
 	<string name="not_now">あとで</string>
-	<string name="dialog_routing_build_route">作成する</string>
 	<string name="dialog_routing_download_and_build_cross_route">マップをダウンロードし、複数マップを利用してより最適なルートを作成しますか？</string>
 	<string name="dialog_routing_download_cross_route">このマップの境界を越えて複数マップを利用し、より最適なルートを作成するには、マップをダウンロードしてください。</string>
-	<string name="dialog_routing_cross_route_always">常にこの境界を越える</string>
 
 	<!-- SECTION: Strings for downloading map from search -->
 	<string name="search_without_internet_advertisement">検索とルート作成を開始するには、地図をダウンロードしてください。地図をダウンロードすると、インターネット接続は必要なくなります。</string>
 	<string name="search_select_map">地図を選択</string>
-	<string name="search_select_other_map">別の地図を選択</string>
 	<!-- «Show» context menu -->
 	<string name="show">表示する</string>
 	<!-- «Hide» context menu -->
 	<string name="hide">隠す</string>
 	<!-- «Rename» context menu -->
 	<string name="rename">名前を変更する</string>
-	<!-- Bottom sheet: expand button (should be short) -->
-	<string name="bottom_sheet_more">さらに…</string>
 	<!-- Failed planning route message in navigation view -->
 	<string name="routing_planning_error">ルート検索に失敗</string>
 	<!-- Arrive routing message in navigation view -->
 	<string name="routing_arrive">到着予定: %s</string>
-	<!-- Text for routing::RouterResultCode::FileTooOld dialog. -->
-	<string name="dialog_routing_download_and_update_maps">ルートを作成するには、ルートの通過する地図を全てダウンロード・アップデートしてください。</string>
 	<string name="rate_alert_title">このアプリが好きですか?</string>
 	<string name="rate_alert_default_message">Organic Mapsをご使用いただきありがとうございます。アプリの評価をお願いいたします。皆様からのフィードバックはアプリの改善に役立つものです。</string>
 	<string name="rate_alert_five_star_message">やったー! 相思相愛!</string>
@@ -565,24 +349,14 @@
 	<string name="rate_alert_less_than_four_star_message">改善のためのアイデアはございますか?</string>
 	<string name="categories">カテゴリー</string>
 	<string name="history">履歴</string>
-	<string name="next_turn_then">その後</string>
 	<string name="closed">閉鎖</string>
-	<string name="back_to">%sに戻る</string>
 	<string name="search_not_found">申し訳ありませんが該当するものは見つかりませんでした。</string>
 	<string name="search_not_found_query">別のクエリをお試しください。</string>
-	<string name="search_not_found_map">検索する地図をダウンロードしてください。</string>
-	<string name="search_not_found_location">現在地の地図をダウンロードしてください。</string>
 	<string name="search_history_title">検索履歴</string>
 	<string name="search_history_text">最近の検索クエリに素早くアクセス。</string>
 	<string name="clear_search">検索履歴を消去</string>
-	<!-- Title for settings to enable/disable showcase menu button -->
-	<string name="showcase_settings_title">オファーを表示</string>
-	<string name="p2p_route_planning">ルート作成</string>
 	<string name="p2p_your_location">現在位置</string>
-	<string name="p2p_from">出発地</string>
-	<string name="p2p_to">目的地</string>
 	<string name="p2p_start">開始</string>
-	<string name="p2p_planning">作成中…</string>
 	<string name="p2p_from_here">出発地</string>
 	<string name="p2p_to_here">目的地</string>
 	<string name="p2p_only_from_current">ナビゲーションは現在位置からのみ利用できます。</string>
@@ -602,11 +376,8 @@
 	<string name="editor_hours_closed">閉店時間</string>
 	<string name="editor_example_values">値の例</string>
 	<string name="editor_correct_mistake">間違いの訂正</string>
-	<string name="editor_correct_mistake_message">編集の間違いがあります。訂正するか、シンプルモードに切り替えてください。</string>
 	<string name="editor_add_select_location">現在位置</string>
 	<string name="editor_done_dialog_1">世界地図を変更しました。この変更を秘密にしないでください! 友達に教えて一緒に編集しましょう。</string>
-	<string name="editor_done_dialog_2">これは2回目の地図改善。現在地図編集者リストで%d位です。</string>
-	<string name="editor_done_dialog_3">地図を改善したので、友達に教えて一緒に編集しましょう。</string>
 	<string name="share_with_friends">友達にシェア</string>
 	<string name="editor_report_problem_desription_1">OpenStreeMapコミュニティがエラーを修正できるよう、問題の詳細を説明してください。</string>
 	<string name="editor_report_problem_desription_2">または、このURLでご自身で修正してください https://www.openstreetmap.org/</string>
@@ -615,14 +386,7 @@
 	<string name="editor_report_problem_no_place_title">この場所は存在しません</string>
 	<string name="editor_report_problem_under_construction_title">メンテナンスのため使えません</string>
 	<string name="editor_report_problem_duplicate_place_title">重複している場所</string>
-	<string name="first_launch_congrats_title">Organic Mapsを使用する準備が整いました</string>
-	<string name="first_launch_congrats_text">世界中どこでも無料で検索・ナビゲーションできます。</string>
-	<string name="migrate_title">重要！</string>
-	<!-- Android uses image instead of text. -->
-	<string name="download_all">全てをダウンロード</string>
-	<string name="delete_all">すべて削除</string>
 	<string name="autodownload">自動ダウンロード</string>
-	<string name="disable_autodownload">自動ダウンロードを無効にする</string>
 	<!-- Place Page opening hours text -->
 	<string name="closed_now">現在閉店</string>
 	<!-- Place Page opening hours text -->
@@ -631,8 +395,6 @@
 	<string name="day_off_today">本日終業</string>
 	<string name="day_off">終業</string>
 	<string name="today">今日は</string>
-	<string name="sunrise_to_sunset">日の出から日没まで</string>
-	<string name="sunset_to_sunrise">日の出から日没まで</string>
 	<string name="add_opening_hours">営業時間を追加</string>
 	<string name="edit_opening_hours">営業時間を編集</string>
 	<string name="no_osm_account">OpenStreetMapのアカウントがありませんか？</string>
@@ -642,29 +404,13 @@
 	<string name="login">ログイン</string>
 	<string name="password">パスワード</string>
 	<string name="forgot_password">パスワードをお忘れですか？</string>
-	<!-- Forgot Password dialog title -->
-	<string name="restore_password">パスワードを復元</string>
-	<string name="enter_email_address_to_reset_password">登録の際に使用したメールアドレスを入力してください。パスワードを更新するリンクをお送りします。</string>
-	<string name="reset_password">パスワードをリセット</string>
-	<string name="username">ユーザー名</string>
 	<string name="osm_account">OSMアカウント</string>
 	<string name="logout">ログアウト</string>
-	<string name="login_and_edit_map_motivation_message">ログインしてマップ上のオブジェクトの詳細を編集すると、何百万人もの他のユーザーがその情報を利用できるようになります。一緒により良い世界を作りましょう。</string>
 	<!-- Information text: "Last upload 11.01.2016" -->
 	<string name="last_upload">最終更新</string>
-	<!-- Motivates user to login/register, title above login buttons. -->
-	<string name="you_have_edited_your_first_object">初めてオブジェクトを編集しました！</string>
 	<string name="thank_you">ありがとうございます</string>
-	<string name="login_with_google">Googleでログイン</string>
-	<string name="login_with_openstreetmap">www.openstreetmap.orgでログインしてください</string>
 	<string name="edit_place">場所を編集</string>
 	<string name="place_name">場所の名前</string>
-	<!-- title above languages list cells in the editor, below editable name text field. -->
-	<string name="other_languages">その他の言語</string>
-	<!-- small button to open list with names in different languages -->
-	<string name="show_more">もっと表示</string>
-	<!-- small button to close list with names in different languages -->
-	<string name="show_less">少なく表示</string>
 	<string name="add_language">言語を追加</string>
 	<string name="street">通り</string>
 	<!-- Editable House Number text field (in address block). -->
@@ -681,25 +427,16 @@
 	<string name="email_or_username">メールアドレスまたはユーザー名</string>
 	<string name="phone">電話</string>
 	<string name="please_note">ご注意ください</string>
-	<string name="common_no_wifi_dialog">WiFi接続がありません。モバイルデータ通信を続行しますか?</string>
 	<string name="downloader_delete_map_dialog">この地図を削除すると、今まで行った変更の全ても一緒に削除されます。</string>
 	<string name="downloader_update_maps">地図をアップデート</string>
 	<string name="downloader_mwm_migration_dialog">ルートを作成するには、全ての地図をアップデートした後で再びルート計画を行う必要があります。</string>
 	<string name="downloader_search_field_hint">地図を検索</string>
-	<string name="migration_update_all_button">全ての地図をアップデート</string>
-	<string name="migration_delete_all_download_current_button">現在の地図をダウンロードして古い地図を削除</string>
 	<string name="migration_download_error_dialog">ダウンロードエラー</string>
 	<string name="common_check_internet_connection_dialog">設定をチェックし、デバイスがインターネットに接続されているか確認してください。</string>
 	<string name="downloader_no_space_title">十分な空き容量がありません</string>
 	<string name="downloader_no_space_message">不必要なデータを削除してください</string>
-	<string name="editor_general_auth_error_dialog">一般的なログインエラー。</string>
 	<string name="editor_login_error_dialog">ログインエラー。</string>
-	<string name="editor_login_failed_dialog">ログインに失敗しました</string>
-	<string name="editor_username_error_dialog">ユーザー名が無効です</string>
-	<string name="editor_place_edited_dialog">オブジェクトを編集しました!</string>
-	<string name="editor_login_with_osm">OpenStreetMapを使ってログイン</string>
 	<string name="editor_profile_changes">確認された変更</string>
-	<string name="editor_profile_unsent_changes">未送信：</string>
 	<string name="editor_focus_map_on_location">地図を操作してオブジェクトの正しい場所を選択します。</string>
 	<string name="editor_add_select_category">カテゴリを選択</string>
 	<string name="editor_add_select_category_popular_subtitle">人気</string>
@@ -710,19 +447,14 @@
 	<string name="editor_edit_place_category_title">カテゴリ</string>
 	<string name="detailed_problem_description">問題の詳細な説明</string>
 	<string name="editor_report_problem_other_title">異なる問題</string>
-	<string name="placepage_report_problem_button">問題を報告</string>
 	<string name="placepage_add_business_button">団体を追加</string>
 	<string name="whatsnew_editor_message_1">アプリから直接地図に新しい場所を追加したり、既存の場所を編集できます。</string>
-	<string name="whatsnew_editor_message_2">* Organic MapsはOpenStreetMapコミュニティのデータを使用しています。</string>
 	<string name="dialog_incorrect_feature_position">位置を変更してください</string>
 	<string name="message_invalid_feature_position">ここにはオブジェクトを配置できません</string>
 	<string name="login_to_make_edits_visible">他のユーザーにも変更が表示されるようログインしてください。</string>
-	<string name="no_migration_during_navigation">ナビゲーション中は更新できません。</string>
 	<!-- Error dialog no space -->
 	<string name="migration_no_space_message">ダウンロードするには空き容量がさらに必要です。不必要なデータを削除してください。</string>
 	<string name="editor_sharing_title">Organic Mapsの地図を改善しました</string>
-	<string name="editor_comment_will_be_sent">いただいたコメントを地図製作者に送ります。</string>
-	<string name="editor_unsupported_category_message">現在未対応のカテゴリーの場所を追加しました。地図には後程表示されるようになります。</string>
 	<!-- Downloaded 10 **of** 20 <- it is that "of" -->
 	<string name="downloader_of">%2$d中%1$d</string>
 	<string name="download_over_mobile_header">携帯通信ネットワークで接続してダウンロードしますか？</string>
@@ -740,15 +472,8 @@
 	<string name="editor_detailed_description">あなたが提案した変更は、OpenStreetMapのコミュニティに送信されます。Organic Mapsで編集できない詳細を説明してください。</string>
 	<string name="editor_more_about_osm">OpenStreetMapについての詳細</string>
 	<string name="editor_operator">オペレーター</string>
-	<string name="editor_tag_description">施設を管理する企業、組織または個人を入力してください。</string>
-	<string name="editor_no_local_edits_title">ローカル編集はできません</string>
-	<string name="editor_no_local_edits_description">これは、現在お使いのデバイスでのみアクセス可能な、マップ上に提案された変更の数を示しています。</string>
-	<string name="editor_send_to_osm">OSMに送信</string>
-	<string name="editor_remove">削除</string>
-	<string name="downloader_my_maps_title">マイマップ</string>
 	<string name="downloader_no_downloaded_maps_title">マップをダウンロードしていません</string>
 	<string name="downloader_no_downloaded_maps_message">ロケーションの検索とオフラインナビゲートのためにマップをダウンロードしてください。</string>
-	<string name="downloader_find_place_hint">都市や国を検索</string>
 	<!-- Error title that appears after certain time without location. -->
 	<string name="current_location_unknown_title">あなたの現在地を検出し続けますか？</string>
 	<!-- Error that appears after certain time without location. -->
@@ -763,27 +488,10 @@
 	<string name="location_services_disabled_2">2. 位置情報をタップします</string>
 	<!-- iOS Dialog for the case when the location permission is not granted -->
 	<string name="location_services_disabled_3">3. アプリの使用中を選択してください</string>
-	<string name="placepage_parking_surface">表面</string>
-	<string name="placepage_parking_multistorey">複数階</string>
-	<string name="placepage_parking_underground">地下</string>
-	<string name="placepage_parking_rooftop">屋上</string>
-	<string name="placepage_parking_sheds">小屋</string>
-	<string name="placepage_parking_carports">カーポート</string>
-	<string name="placepage_parking_boxes">ガレージボックス</string>
-	<string name="placepage_parking_pay">支払い</string>
-	<string name="placepage_parking_free">無料</string>
-	<string name="placepage_parking_interval">支払間隔</string>
-	<string name="placepage_entrance_number">番号</string>
-	<string name="placepage_entrance_type">エントランス</string>
-	<string name="placepage_flat">アプリ</string>
-	<string name="placepage_open_24_7">24時間体制</string>
 	<string name="meter">m</string>
 	<string name="kilometer">km</string>
-	<string name="kilometers_per_hour">キロメートル毎時</string>
 	<string name="mile">マイル</string>
 	<string name="foot">フィート</string>
-	<string name="miles_per_hour">マイル毎時</string>
-	<string name="day">日</string>
 	<string name="hour">時間</string>
 	<string name="minute">分</string>
 	<string name="placepage_place_description">説明</string>
@@ -793,46 +501,30 @@
 	<string name="placepage_call_button">コール</string>
 	<string name="placepage_edit_bookmark_button">ブックマークを編集</string>
 	<string name="placepage_bookmark_name_hint">ブックマーク名</string>
-	<string name="placepage_personal_notes_hint">パーソナルメモ</string>
-	<string name="placepage_delete_bookmark_button">ブックマークを削除</string>
 	<string name="editor_edits_sent_message">あなたの提案の変更が送信されました</string>
 	<string name="editor_comment_hint">コメント…</string>
 	<string name="editor_reset_edits_message">すべてのローカルの変更をリセットしますか？</string>
 	<string name="editor_reset_edits_button">リセット</string>
 	<string name="editor_remove_place_message">追加された場所を削除しますか？</string>
 	<string name="editor_remove_place_button">削除</string>
-	<string name="editor_status_sending">送信中…</string>
 	<string name="editor_place_doesnt_exist">存在しない場所</string>
 	<string name="text_more_button">…続き</string>
 	<!-- Phone number error message -->
 	<string name="error_enter_correct_phone">正しい電話番号を入力してください</string>
 	<string name="error_enter_correct_web">有効なウェブアドレスを入力してください</string>
 	<string name="error_enter_correct_email">有効なメールアドレスを入力してください</string>
-	<string name="error_enter_correct">有効な値を入力してください</string>
 	<string name="refresh">更新</string>
-	<string name="last_update">最終更新日: %s</string>
 	<string name="placepage_add_place_button">地図上に場所を追加</string>
 	<!-- Displayed when saving some edits to the map to warn against publishing personal data -->
 	<string name="editor_share_to_all_dialog_title">全てのユーザーに送信しますか？</string>
 	<!-- iOS Dialog before publishing the modifications to the public map. -->
 	<string name="editor_share_to_all_dialog_message_1">個人情報を入力していないことを確認してください。</string>
 	<string name="editor_share_to_all_dialog_message_2">弊社で変更を確認します。質問がある場合はメールでご連絡します。</string>
-	<string name="navigation_overview_button">概要</string>
-	<string name="navigation_stop_button">停止</string>
-	<!-- Text on an empty bookmark page -->
-	<string name="bookmarks_empty_title">ブックマークを保存</string>
-	<string name="bookmarks_empty_message_1">★をタップしてお気に入りの場所にクイックアクセス。</string>
-	<string name="bookmarks_empty_message_2">メールやウェブからブックマークをインポートする。</string>
-	<string name="bookmarks_empty_message_3">チェックアウト：%s</string>
-	<!-- Name of the group for booked hotels -->
-	<string name="bookmarks_group_name">予約したホテル</string>
-	<string name="place_page_button_read_descriprion">詳細</string>
 	<!-- iOS dialog for the case when recent track recording is on and the app comes back from background -->
 	<string name="recent_track_background_dialog_title">最近の走行ルートの記録を無効にしますか？</string>
 	<string name="off_recent_track_background_button">無効にする</string>
 	<!-- For sharing via SMS and so on -->
 	<string name="sharing_call_action_look">ご覧ください</string>
-	<string name="continue_recent_track_background_button">続行</string>
 	<string name="recent_track_background_dialog_message">Organic Mapsは、あなたの位置情報をバックグラウンドで使用して最近の走行ルートを記録します。</string>
 	<!-- Rate on Google Play (Android only) -->
 	<string name="rate_gp">Google Play で評価</string>
@@ -842,21 +534,11 @@
 	<string name="tell_friends_text">こんにちは！Organic Maps をインストールしましょう！</string>
 	<!-- About short text (below logo) -->
 	<string name="about_description">Organic Maps は旅に必要不可欠なオフラインアプリケーションです。Organic Maps は OpenStreetMap データに基づいており、データを編集することができます。</string>
-	<!-- Text in menu -->
-	<string name="blog">ブログ</string>
 	<string name="general_settings">一般設定</string>
-	<string name="date">日付 %d</string>
-	<!-- "Report a bug" -> "Generaal Feedback" -> "Something is not working" -->
-	<string name="something_is_not_working">動作が変です</string>
 	<!-- For the first routing -->
 	<string name="accept">了解</string>
 	<!-- For the first routing -->
 	<string name="decline">拒否</string>
-	<string name="install_app">インストール</string>
-	<string name="search_no_results_title">結果が見つかりません</string>
-	<string name="search_no_results_message">一般的な検索語句や、フィルター範囲を広げたりリセットしたりしてください。</string>
-	<string name="search_no_results_expand_area_button">広げる</string>
-	<string name="search_no_results_reset_button">フィルターをリセット</string>
 	<!-- noun -->
 	<string name="search_in_table">一覧</string>
 	<string name="mobile_data_dialog">モバイルインターネットを使用して詳細な情報を表示しますか？</string>
@@ -868,18 +550,13 @@
 	<string name="mobile_data_option_never">使用しない</string>
 	<string name="mobile_data_option_ask">常に確認</string>
 	<string name="traffic_update_maps_text">交通データを表示するには、地図を更新する必要があります。</string>
-	<string name="traffic_outdated">交通データが古くなっています。</string>
 	<string name="big_font">地図上のフォントサイズを大きく</string>
 	<string name="traffic_update_app">Organic Maps をアップデートしてください</string>
 	<!-- "traffic" as in road congestion -->
 	<string name="traffic_update_app_message">交通データを表示するには、アプリケーションをアップデートする必要があります。</string>
 	<!-- "traffic" as in "road congestion" -->
 	<string name="traffic_data_unavailable">交通データは利用できません</string>
-	<!-- Simplified colour scheme for traffic information, fewer colours are used to display traffic jams on the map. The string should be kept as short as possible -->
-	<string name="pref_traffic_simplified_colors_title">簡易的な交通状況色</string>
 	<string name="enable_logging">ログを有効化</string>
-	<string name="offline_place_page_more_information">この場所に関する詳細情報を取得するには、インターネットに接続してください。</string>
-	<string name="failed_load_information">情報の読み込みに失敗しました。</string>
 	<!-- Settings: "Send general feedback" button -->
 	<string name="feedback_general">一般的なフィードバック</string>
 	<string name="on">オン</string>
@@ -893,57 +570,26 @@
 	<string name="routing_add_start_point">ルートを計画するには出発地点を追加してください</string>
 	<string name="routing_add_finish_point">ルートを計画するには到着地点を追加してください</string>
 	<string name="button_exit">終了</string>
-	<string name="settings_device_memory">デバイスのメモリ</string>
-	<string name="settings_card_memory">カードのメモリ</string>
-	<string name="settings_storage_available">%s 使用可能</string>
-	<string name="toast_location_permission_denied">アプリの位置情報へのアクセスが拒否されました</string>
-	<string name="button_use">使う</string>
 	<string name="planning_route_manage_route">ルートを編集</string>
 	<string name="button_plan">適用する</string>
-	<string name="button_add">追加</string>
 	<string name="placepage_remove_stop">削除</string>
 	<string name="planning_route_remove_title">ここにドラッグして削除</string>
-	<string name="dialog_change_start_point_message">出発地点を現在の場所に変更しますか？</string>
-	<string name="button_replace">変更する</string>
 	<string name="placepage_add_stop">経由地点を追加</string>
-	<string name="add_my_position">自分の場所を追加</string>
-	<string name="choose_start_point">出発地点を選択</string>
-	<string name="choose_destination">目的地を選択</string>
 	<string name="preloader_viator_button">詳細情報</string>
-	<string name="start_from_my_position">開始位置</string>
-	<string name="profile_authorization_title">サインイン方法</string>
-	<string name="profile_authorization_message">ログイン名とパスワードなしですぐに簡単にサインインできます</string>
 	<string name="profile_authorization_error">エラーが発生しました。もう一度サインインしてみてください。</string>
-	<string name="service">サービス</string>
-	<string name="atmosphere">雰囲気</string>
-	<string name="value_for_money">金額に見合う価値</string>
-	<string name="experience">経験</string>
-	<string name="assortment">品揃え</string>
-	<string name="expertise">専門知識</string>
-	<string name="equipment">設備</string>
-	<string name="quality">品質</string>
 	<string name="dialog_error_storage_title">ストレージアクセスの問題</string>
 	<string name="dialog_error_storage_message">外部ストレージは使用できません。おそらく SD カードが取り外されたか、破損している、あるいはファイルシステムが読み取り専用になっています。確認後、support\@organicmaps.app までご連絡ください。</string>
 	<string name="setting_emulate_bad_storage">壊れたストレージをエミュレート</string>
-	<string name="directions_finish">目的地</string>
-	<string name="directions_on_foot">徒歩 %s</string>
 	<string name="core_entrance">入口</string>
-	<string name="coffee">コーヒー</string>
-	<string name="cleanliness">清潔さ</string>
-	<string name="crowdedness">混雑度</string>
 	<string name="error_enter_correct_name">正しい名前を入力してください</string>
 	<string name="bookmarks_groups">リスト</string>
 	<string name="bookmarks_groups_hide_all">すべて非表示</string>
 	<string name="bookmarks_groups_show_all">すべて表示</string>
-	<plurals name="bookmarks_places">
-	  <item quantity="other">%d個のブックマーク</item>
-	</plurals>
 	<string name="bookmarks_create_new_group">新しいリストを作成する</string>
 	<string name="downloader_hide_screen">画面を非表示</string>
 	<string name="downloader_percent">%1$s (%2$s / %3$s)</string>
-	<string name="downloader_process">%s をダウンロードしています...</string>
-	<string name="downloader_applying">%s を適用中です...</string>
-	<string name="dialog_message_transit_not_found_connection">1つの交通ネットワーク内でルートを作成</string>
+	<string name="downloader_process">%s をダウンロードしています…</string>
+	<string name="downloader_applying">%s を適用中です…</string>
 	<string name="bookmarks_error_message_share_general">アプリケーションエラーのため共有できません</string>
 	<string name="bookmarks_error_title_share_empty">共有エラー</string>
 	<string name="bookmarks_error_message_share_empty">空のリストは共有できません</string>
@@ -952,12 +598,7 @@
 	<string name="bookmarks_new_list_hint">新しいリスト</string>
 	<string name="bookmarks_error_title_list_name_already_taken">この名前はすでに使用されています</string>
 	<string name="bookmarks_error_message_list_name_already_taken">別の名前を選んでください</string>
-	<string name="bookmarks_error_title_list_name_too_long">この名前は長すぎます</string>
-	<string name="bookmarks_error_message_list_name_too_long">別の名前を選んでください</string>
-	<string name="please_wait">お待ちください...</string>
-	<string name="phone_number">電話番号</string>
-	<string name="notification_unsent_reviews_title">あなたはいくつかの未送信のレビューを持っています</string>
-	<string name="notification_unsent_reviews_message">他の旅行者とレビューを共有するにはログインしてください</string>
+	<string name="please_wait">お待ちください…</string>
 	<string name="profile">OpenStreetMap プロフィール</string>
 	<string name="place_page_search_similar_hotel">類似のホテルを検索</string>
 	<string name="bookmarks_detect_title">新しいファイルが検出されました</string>
@@ -967,31 +608,10 @@
 	<string name="button_convert">変換</string>
 	<string name="bookmarks_convert_error_title">エラー</string>
 	<string name="bookmarks_convert_error_message">一部のファイルは変換されませんでした。</string>
-	<string name="converting">変換中...</string>
-	<string name="wn_reinvented_bookmarks_title">ブックマークを作り直しました！</string>
-	<string name="wn_reinvented_bookmarks_message">あなたはブックマークをバックアップし、リストを作成することができます...それは素晴らしいです...</string>
-	<string name="bookmarks_restore">ブックマークを復元する</string>
-	<string name="bookmarks_restore_process">復元中...</string>
 	<string name="bookmarks_restore_title">このバージョンを復元しますか？</string>
-	<string name="bookmarks_restore_message">ブックマークは%1$s (%2$s)から復元されます</string>
-	<string name="bookmarks_restore_empty_title">あなたはバックアップを持っていません</string>
-	<string name="bookmarks_restore_empty_message">サーバーは以前に作成したバックアップを見つけられませんでした</string>
 	<string name="common_check_internet_connection_dialog_title">インターネット接続なし</string>
-	<string name="error_server_title">サーバーエラー</string>
-	<string name="error_server_message">サーバーにエラーがありました。後でもう一度お試しください</string>
 	<string name="error_system_message">不明なエラーが発生しました</string>
 	<string name="restore">リストア</string>
-	<string name="bookmarks_page_downloaded">ダウンロード済み</string>
-	<string name="bookmarks_page_my">私の</string>
-	<string name="routes_and_bookmarks">ルートとブックマーク</string>
-	<string name="bookmarks_webview_success_toast">ブックマークが正常にダウンロードされました</string>
-	<string name="cached_bookmarks_placeholder_title">新しい場所をダウンロード</string>
-	<string name="cached_bookmarks_placeholder_subtitle">Organic Mapsユーザーが作成した数千ものおもしろい場所やルートをダウンロードするには、このボタンを押します。インターネット接続が必要です。</string>
-	<string name="downloader_download_routers">ブックマークをダウンロード</string>
-	<string name="bookmarks_groups_cached">ダウンロード済みリスト</string>
-	<plurals name="bookmarks_objects">
-	  <item quantity="other">%sのオブジェクト</item>
-	</plurals>
 	<plurals name="objects">
 	  <item quantity="other">%dの場所</item>
 	</plurals>
@@ -1004,62 +624,32 @@
 	<string name="subtittle_opt_out">追跡の設定</string>
 	<string name="crash_reports">クラッシュレポート</string>
 	<string name="crash_reports_description">Organic Maps体験を向上させるため、お客様のデータを使用する可能性があります。変更は、アプリを再起動した後に、反映されます。</string>
-	<string name="opt_out_help_ios_1">お使いの携帯端末には、「追跡型広告を制限」または「関心に基づく広告を非表示」の設定があるかもしれません。</string>
-	<string name="opt_out_help_ios_2">iOS 9以降</string>
-	<string name="opt_out_help_ios_3">設定→プライバシー→広告に進み、「追跡型広告を制限」を有効にします</string>
-	<string name="opt_out_help_android">お使いの携帯端末には、「追跡型広告を制限」または「関心に基づく広告を非表示」の設定があるかもしれません。\n\nAndroid、Google Play Servicesバージョン4.0以降：\n設定→Google→広告→広告パーソナライゼーションの提供停止\nor\n設定→Google→Googleアカウント→個人情報とプライバシー→広告設定→広告パーソナライゼーション</string>
 	<string name="privacy_policy">個人情報保護方針</string>
 	<string name="terms_of_use">ご利用規約</string>
-	<string name="backup_notification_failed">ブックマークのバックアップが中断されました。ログインして、元に戻します。</string>
 	<string name="button_layer_traffic">交通状況</string>
 	<string name="button_layer_subway">地下鉄</string>
 	<string name="layers_title">マップレイヤー</string>
-	<string name="layers_message">マップレイヤーを使用して、交通状況、地下鉄路線図、その他の有益な情報を表示</string>
-	<string name="button_layer_got_it">了解</string>
 	<string name="subway_data_unavailable">地下鉄路線図はご利用いただけません</string>
 	<string name="bookmarks_empty_list_title">このリストは空です</string>
 	<string name="bookmarks_empty_list_message">ブックマークを追加するには、地図上の場所をタップし、星のアイコンをタップします。</string>
 	<string name="category_desc_more">詳細</string>
 	<string name="title_error_downloading_bookmarks">エラーが発生しました</string>
-	<string name="subtitle_error_downloading_bookmarks">ブックマークはダウンロードされませんでした</string>
-	<string name="error_already_downloaded">このリストは既にダウンロード済みです</string>
-	<string name="why_support">Organic Mapsをサポートする理由？</string>
-	<string name="why_support_item2">Organic Mapsの改善にご協力いただいております</string>
-	<string name="why_support_item3">オープンマップOpenStreetMap.orgの改善にご協力いただいております</string>
-	<string name="channels_map_update">地図の更新</string>
-	<string name="server_unavailable_title">サーバーは利用できません</string>
-	<string name="sharing_options">オプションの共有</string>
 	<string name="export_file">ファイルのエクスポート</string>
 	<string name="list_settings">リスト設定</string>
 	<string name="delete_list">リスト削除</string>
-	<string name="hide_from_map">マップから隠す</string>
 	<string name="public_access">パブリック・アクセス</string>
 	<string name="limited_access">制限されたアクセス</string>
 	<string name="bookmark_category_name">カテゴリ</string>
 	<string name="bookmark_category_description_hint">説明(テキストまたはhtml)を記入してください</string>
 	<string name="not_shared">非公開</string>
-	<string name="direct_link_progress_text">あなたのファイルをアップロードしています…</string>
-	<string name="direct_link_success">リンクが作成されました</string>
-	<string name="send_a_link_btn">リンクを自分に送る</string>
-	<string name="upload_error_toast">ファイルのアップロード中にエラーが起きました</string>
 	<string name="tags_loading_error_subtitle">タグのロード中にエラーが起きました。もう一度やり直してください</string>
-	<string name="unable_upload_errorr_title">ファイルのアップロードができませんでした</string>
-	<string name="unable_upload_error_subtitle_edited">このファイルはウェブアプリで編集されました</string>
-	<string name="unable_upload_error_subtitle_broken">このファイルは損傷しており、アップロードできませんでした。別のファイルをアップロードしてください。</string>
-	<string name="contact">連絡</string>
-	<string name="download_button">ダウンロード</string>
 	<string name="speedcams_alert_title">自動速度違反取締装置</string>
-	<string name="speedcams_alert_subtitle">速度制限警告</string>
 	<string name="speedcam_option_auto">自動</string>
 	<string name="speedcam_option_always">常時</string>
 	<string name="speedcam_option_never">無効</string>
-	<string name="bookmark_description_title">ブックマークの説明</string>
 	<string name="place_description_title">場所の説明</string>
 	<!-- this text will be shown in application notification preferences opposite checkbox which enable/disable downloader notifications. Devices on Android 8+ are affected. -->
 	<string name="notification_channel_downloader">マップダウンローダー</string>
-	<string name="share_bookmarks_email_body_link">こんにちは!\n\nこれはあなたのブックマークをダウンロードできるリンクです:%s。Organic Mapsを通じてリストを開いて旅をお楽しみください!\n\nアプリの入手: https://omaps.app/get?kmz</string>
-	<string name="warning_speedcams_title">%d km/hの速度制限を超えているときナビゲーターが自動速度違反取締装置について警告します</string>
-	<string name="warning_speedcams_subtitle">旅行先の国の道路交通法を考慮してください。</string>
 	<string name="speedcams_notice_message">自動－速度制限超過の危険性がある場合には、自動速度違反取締装置について警告します\n常時－自動速度違反取締装置について常に警告します\n無効－自動速度違反取締装置を警告しません</string>
 	<string name="power_managment_title">電力節約モード</string>
 	<string name="power_managment_description">自動モードが選択されている場合、このアプリケーションは現在のバッテリーの充電状態に応じてバッテリー消費の激しい機能の無効化を開始します</string>
@@ -1067,14 +657,7 @@
 	<string name="power_managment_setting_auto">自動</string>
 	<string name="power_managment_setting_manual_max">最大電力節約</string>
 	<string name="enable_logging_warning_message">このオプションは診断目的でのデータ記録を有効にします。これはこのアプリケーションのトラブルシューティングを担当する当社のサポートスタッフの助けになります。このオプションはOrganic Mapsにリクエストされた場合にのみ有効にしてください。</string>
-	<string name="html_error_upload_message_try_again">ネットワーク設定をチェックして、もう一度お試しください</string>
-	<string name="html_error_upload_title_try_again">インターネットに接続していません</string>
-	<string name="notification_leave_review_v2_android_short_title">レビューして旅行者を助けましょう！</string>
-	<string name="notifications_illegal_alert_disable_button">通知を無効化</string>
 	<string name="access_rules_author_only">オンライン編集</string>
-	<string name="privacy_settings_menu">プライバシー設定</string>
-	<string name="unable_upadate_error_title">ファイルが更新できませんでした</string>
-	<string name="unable_upadate_error_message">更新中に何かミスが発生しました。変更を確認して、もう一度お試しください</string>
 	<string name="driving_options_title">運転オプション</string>
 	<string name="driving_options_subheader">すべてのルートで回避</string>
 	<string name="avoid_tolls">有料道路</string>
@@ -1085,52 +668,14 @@
 	<string name="unable_to_calc_alert_subtitle">残念ながら恐らく設定されたオプションのためにルートが見つけられませんでした。設定を変更し、もう一度お試しください</string>
 	<string name="define_to_avoid_btn">回避するために道を設定</string>
 	<string name="change_driving_options_btn">運転オプションはアクティブです</string>
-	<string name="toll_road">有料道路</string>
-	<string name="unpaved_road">未舗装道路</string>
-	<string name="ferry_crossing">フェリー航路</string>
-	<string name="operated_by">\"%s\"で稼働</string>
 	<string name="avoid_toll_roads_placepage">有料道路を回避</string>
 	<string name="avoid_unpaved_roads_placepage">未舗装道路を回避</string>
 	<string name="avoid_ferry_crossing_placepage">フェリー航路を回避</string>
-	<string name="type.cuisine.uzbek">ウズベキスタン料理</string>
-	<string name="trip_start">レッツゴー</string>
-	<string name="pick_destination">目的地</string>
-	<string name="follow_my_position">リセンター</string>
-	<string name="search_results">検索結果</string>
-	<string name="then_turn">その後</string>
-	<string name="redirect_route_alert">ルートを再構築しますか?</string>
-	<string name="redirect_route_yes">はい</string>
-	<string name="redirect_route_no">いいえ</string>
-	<string name="trip_finished">到着しました!</string>
-	<string name="keyboard_availability_alert">運転中はキーボードを使用する事はできません</string>
-	<string name="dialog_routing_change_start_carplay">現在位置からはルートを構築できません</string>
-	<string name="dialog_routing_change_end_carplay">目的地へのルートは構築できません。別の地点を選択してください</string>
-	<string name="dialog_routing_check_gps_carplay">GPS信号がありません。開けた場所へ移動してください</string>
-	<string name="dialog_routing_unable_locate_route_carplay">ルートが構築できません。別のルート地点を設定して下さい</string>
-	<string name="dialog_routing_download_files_carplay">ルートを作成するには、地図に表示されていない部分を端末でダウンロードします</string>
-	<string name="dialog_routing_system_error_carplay">エラーが発生しました。アプリを再起動してください</string>
-	<string name="dialog_routing_rebuild_from_current_location_carplay">ルートは現在位置から再構築されます</string>
-	<string name="dialog_routing_rebuild_for_vehicle_carplay">ルートは自動車用として修正されます</string>
 	<string name="ok">OK</string>
-	<string name="avoid_unpaved_carplay_1">未舗装道路無し</string>
-	<string name="avoid_unpaved_carplay_2">未舗装道路無し</string>
-	<string name="avoid_ferry_carplay_1">フェリー無し</string>
-	<string name="avoid_ferry_carplay_2">フェリーを回避</string>
-	<string name="avoid_tolls_carplay_1">有料道路無し</string>
-	<string name="avoid_tolls_carplay_2">有料道路を回避</string>
-	<string name="speedcams_alert_title_carplay_1">速度警告</string>
-	<string name="speedcams_alert_title_carplay_2">速度警告</string>
-	<string name="download_map_carplay">あなたの機器のOrganic Mapsのアプリにマップをダウンロードしてください</string>
-	<string name="carplay_roundabout_exit">第%s出口</string>
 	<!-- max. 10 symbols, both iOS and Android -->
 	<string name="sort">並び替え中…</string>
 	<!-- Android, title, max 20-22 symbols -->
 	<string name="sort_bookmarks">ブックマークの並び替え</string>
-	<!-- iOS -->
-	<string name="sort_default">デフォルトで並び替え</string>
-	<string name="sort_type">タイプで並び替え</string>
-	<string name="sort_distance">距離で並び替え</string>
-	<string name="sort_date">日付で並び替え</string>
 	<!-- Android -->
 	<string name="by_default">デフォルトで</string>
 	<!-- Android -->
@@ -1139,65 +684,23 @@
 	<string name="by_distance">距離で</string>
 	<!-- Android -->
 	<string name="by_date">日付で</string>
-	<string name="week_ago_sorttype">1週間前</string>
-	<string name="month_ago_sorttype">1ケ月前</string>
-	<string name="moremonth_ago_sorttype">1ケ月以上前</string>
-	<string name="moreyear_ago_sorttype">1年以上前</string>
-	<string name="near_me_sorttype">近隣</string>
-	<string name="others_sorttype">その他</string>
-	<string name="food_places">食べ物</string>
-	<string name="tourist_places">観光地</string>
-	<string name="museums">博物館</string>
-	<string name="parks">公園</string>
-	<string name="swim_places">水泳</string>
-	<string name="mountains">山</string>
-	<string name="animals">動物園</string>
-	<string name="hotels">ホテル</string>
-	<string name="buildings">ビル</string>
-	<string name="money">金銭</string>
-	<string name="shops">ショップ</string>
-	<string name="parkings">駐車場</string>
-	<string name="fuel_places">ガソリンスタンド</string>
-	<string name="water">水</string>
-	<string name="medicine">医薬品</string>
 	<string name="search_in_the_list">リスト内で検索</string>
-	<string name="view_on_map_bookmarks">マップ上</string>
-	<string name="more_bookmarks">更に…</string>
-	<string name="no_items_found">何も見つかりませんでした</string>
-	<!-- Android, max 18 symbols -->
-	<string name="bookmarks_edit_list">リストの編集</string>
-	<!-- Android, max 18 symbols -->
-	<string name="bookmarks_delete_list">リストの削除</string>
-	<string name="religious_places">宗教に関連した場所</string>
 	<string name="select_list">リストを選択</string>
 	<string name="transit_not_found">この地域の地下鉄ナビはまだ利用できません</string>
 	<string name="dialog_pedestrian_route_is_long_header">地下鉄ルートが見つかりませんでした</string>
 	<string name="dialog_pedestrian_route_is_long_message">もっと地下鉄駅に近い出発地または目的地を選択してください</string>
-	<!-- Failed planning SUBWAY route message in navigation view -->
-	<string name="routing_planning_error_subway_special">地下鉄ルートの計画ができませんでした</string>
 	<string name="button_layer_isolines">地形</string>
-	<string name="tips_map_layers_title_countour">Organic Mapsの新要素：オフラインのトポグラフィーレイヤー！</string>
-	<string name="tips_map_layers_message_countour">自然の旅で訪れる地域を全てを把握しながら計画を立て楽しみましょう</string>
 	<string name="isolines_activation_error_dialog">トポグラフィーレイヤーを有効化して使用するには、このエリアのマップを更新もしくはダウンロードしてください</string>
 	<string name="isolines_location_error_dialog">トポグラフィーレイヤーはこの地域ではまだ利用できません</string>
 	<string name="elevation_profile_diff_level">難易度</string>
-	<string name="elevation_profile_diff_level_easy">イージー</string>
-	<string name="elevation_profile_diff_level_moderate">ノーマル</string>
-	<string name="elevation_profile_diff_level_hard">ハード</string>
 	<string name="elevation_profile_ascent">上昇</string>
 	<string name="elevation_profile_descent">下降</string>
 	<string name="elevation_profile_minaltitude">最小高度</string>
 	<string name="elevation_profile_maxaltitude">最大高度</string>
-	<string name="elevation_profile_m">m</string>
 	<string name="elevation_profile_difficulty">難易度</string>
 	<string name="elevation_profile_distance">距離：</string>
-	<string name="elevation_profile_km">㎞</string>
 	<string name="elevation_profile_time">時間：</string>
-	<string name="elevation_profile_hours">時間</string>
-	<string name="elevation_profile_minutes">分</string>
 	<string name="isolines_toast_zooms_1_10">等高線を調べるためにズームインしましょう</string>
-	<string name="downloader_updating_ios">更新中</string>
-	<string name="downloader_loading_ios">ダウンロード中</string>
 	<string name="key_information_title">重要情報</string>
 	<string name="enable_screen_sleep">画面をスリープ状態にする</string>
 	<!-- Description in preferences -->

--- a/android/res/values-ko/strings.xml
+++ b/android/res/values-ko/strings.xml
@@ -12,8 +12,6 @@
 	<string name="cancel_download">다운로드 취소하기</string>
 	<!-- Button which deletes downloaded country -->
 	<string name="delete">삭제하기</string>
-	<!-- Button "do not interrupt download" if user touched actively downloading country -->
-	<string name="do_nothing">아무것도 하지 마세요</string>
 	<string name="download_maps">지도 다운로드받기</string>
 	<!-- Settings/Downloader - info for country when download fails -->
 	<string name="download_has_failed">다운로드에 실패하였습니다. 다시 두드려 시도하여 주십시요.</string>
@@ -31,45 +29,31 @@
 	<string name="core_my_position">나의 위치</string>
 	<!-- Update maps later/Buy pro version later button text -->
 	<string name="later">후</string>
-	<!-- Don't show some dialog any more -->
-	<string name="never">거절</string>
 	<!-- View and button titles for accessibility -->
 	<string name="search">검색하기</string>
 	<!-- Search box placeholder text -->
 	<string name="search_map">지도 검색하기</string>
-	<!-- Settings/Downloader - info for not downloaded country -->
-	<string name="touch_to_download">두드려 다운로드하세요</string>
 	<!-- Settings/Downloader - 3G download warning dialog confirm button -->
 	<string name="use_cellular_data">네</string>
 	<!-- Location services are disabled by user alert - message -->
 	<string name="location_is_disabled_long_text">현재 이 장치나 애플리케이션을 위한 전 위치 서비스를 불능시키셨습니다. 설정에서 이를 작동시켜 주시기 바랍니다.</string>
-	<!-- Location Services are not available on the device alert - message -->
-	<string name="device_doesnot_support_location_services">귀하의장치가 위치 서비스를 지원하지 않습니다.</string>
 	<!-- View and button titles for accessibility -->
 	<string name="zoom_to_country">지도에 표시</string>
-	<!-- Button text for the button at the center of the screen when the country is not downloaded -->
-	<string name="country_status_download">지도 다운로드\n(^ ^)</string>
 	<!-- Button text for the button at the center of the screen when the country is not downloaded and the size should not be shown -->
 	<string name="country_status_download_without_size">지도 다운로드</string>
-	<!-- Button text for the button at the center of the screen when the country is not downloaded -->
-	<string name="country_status_download_without_routing">라우팅없이 지도 다운로드\n(^ ^)</string>
 	<!-- Message to display at the center of the screen when the country download has failed -->
 	<string name="country_status_download_failed">다운로드에 실패하였습니다</string>
 	<!-- Button text for the button under the country_status_download_failed message -->
 	<string name="try_again">다시 시도</string>
 	<string name="about_menu_title">소개</string>
-	<string name="downloaded_touch_to_delete">(%s)가 다운로드 되었습니다, 두드려 삭제하십시요.</string>
 	<string name="connection_settings">연결 설정</string>
-	<string name="download_mb_or_kb">%s 다운로드하기</string>
 	<string name="close">닫기</string>
 	<string name="unsupported_phone">하드웨어 촉진 OpenGL이 요구됩니다. 애석하게도 귀하의 장치는 지원되지 않습니다.</string>
 	<string name="download">다운로드</string>
-	<string name="external_storage_is_not_available">다운로드된지도와 SD 카드 / USB 저장 장치를 사용할 수 없습니다</string>
 	<string name="disconnect_usb_cable">Organic Maps를 사용하려면 USB 케이블이나 삽입 메모리 카드를 분리하십시오</string>
 	<string name="not_enough_free_space_on_sdcard">응용 프로그램을 사용하기 위해서는 첫째 SD 카드 / USB 저장 장치에 여유 공간을 확보하십시오</string>
 	<string name="not_enough_memory">응용 프로그램을 실행하기위한 메모리가 충분하지 않다</string>
 	<string name="download_resources">시작하시기 전에 일반 세계 지도를 귀하의 장치로 다운로드하겠습니다.\n%s 데이터가 필요합니다.</string>
-	<string name="getting_position">현재 위치 얻기</string>
 	<string name="download_resources_continue">지도로 이동</string>
 	<string name="downloading_country_can_proceed">%s다운로드. 이제지도를 진행할 수 있습니다.</string>
 	<string name="download_country_ask">%s다운로드?</string>
@@ -82,30 +66,20 @@
 	<string name="download_country_failed">%s다운로드가 실패했습니다</string>
 	<!-- Add New Bookmark Set dialog title -->
 	<string name="add_new_set">새로운 세트 추가</string>
-	<!-- Place Page - Add To Bookmarks button -->
-	<string name="add_to_bookmarks">즐겨찾기에 추가</string>
 	<!-- Bookmark Color dialog title -->
 	<string name="bookmark_color">색상 즐겨찾기에 추가</string>
 	<!-- Add Bookmark Set dialog - hint when set name is empty -->
 	<string name="bookmark_set_name">집합 이름을 즐겨찾기에 추가</string>
-	<!-- Bookmark Sets dialog title -->
-	<string name="bookmark_sets">세트를 즐겨찾기에 추가</string>
 	<!-- Bookmarks - dialog title -->
 	<string name="bookmarks">북마크</string>
-	<!-- Add bookmark dialog - bookmark color -->
-	<string name="color">색깔</string>
 	<!-- Default bookmarks set name -->
 	<string name="core_my_places">내 장소</string>
 	<!-- Add bookmark dialog - bookmark name -->
 	<string name="name">이름</string>
 	<!-- Editor title above street and house number -->
 	<string name="address">주소</string>
-	<!-- Place Page - Remove Pin button -->
-	<string name="remove_pin">핀 제거</string>
 	<!-- Add bookmark dialog - bookmark set, Bookmarks dialog - Bookmark set cell -->
 	<string name="set">집합</string>
-	<!-- Text hint in Bookmarks dialog when no any bookmarks are added -->
-	<string name="bookmarks_usage_hint">즐겨찾기가 없습니다.\n즐겨찾기를 추가하도록 지도에 어떤 장소를 누릅니다.\n다른 소스에서 북마크는 Organic Maps 앱에서 가져와서 표시할 수 있습니다. 메일, 드롭박스 또는 웹링크에서 저장한 핀으로 KML/KMZ 파일을 열 수 있습니다.</string>
 	<!-- Settings button in system menu -->
 	<string name="settings">설정</string>
 	<!-- Header of settings activity where user defines storage path -->
@@ -116,20 +90,10 @@
 	<string name="move_maps">지도를 이동합니까?</string>
 	<!-- Ask to wait user several minutes (some long process in modal dialog). -->
 	<string name="wait_several_minutes">이 작업은 수 분 소요될 수 있습니다.\n잠시 기다리세요…</string>
-	<!-- Show bookmarks from this category on a map or not -->
-	<string name="visible">눈에 보이는</string>
-	<!-- Toast which is displayed when GPS has been deactivated -->
-	<string name="gps_is_disabled_long_text">GPS가 사용 중지되었습니다. 설정에서 이를 작동시켜 주시기 바랍니다.</string>
 	<!-- Measurement units title in settings activity -->
 	<string name="measurement_units">측정 단위</string>
 	<!-- Detailed description of Measurement Units settings button -->
 	<string name="measurement_units_summary">마일과 킬로미터 중에서 선택하십시오</string>
-	<!-- Do search in all sources -->
-	<string name="search_mode_all">모든 곳</string>
-	<!-- Do search near my position only -->
-	<string name="search_mode_nearme">근처 검색</string>
-	<!-- Do search in current viewport only -->
-	<string name="search_mode_viewport">화면에</string>
 	<!-- Search category for cafes, bars, restaurants -->
 	<string name="eat">어디서먹을까</string>
 	<!-- Search category for grocery stores -->
@@ -166,12 +130,8 @@
 	<string name="post">우편</string>
 	<!-- Search category -->
 	<string name="police">치안대</string>
-	<!-- String in search result list, when nothing found -->
-	<string name="no_search_results_found">결과 없음</string>
 	<!-- Notes field in Bookmarks view -->
 	<string name="description">메모</string>
-	<!-- Button text -->
-	<string name="share_by_email">이메일로 공유</string>
 	<!-- Email Subject when sharing bookmarks category -->
 	<string name="share_bookmarks_email_subject">귀하와 공유된 Organic Maps 즐겨찾기</string>
 	<!-- message title of loading file -->
@@ -184,20 +144,10 @@
 	<string name="edit">편집</string>
 	<!-- Warning message when doing search around current position -->
 	<string name="unknown_current_position">귀하의 위치를 아직 알아내지 못 했습니다</string>
-	<!-- Warning message when location country isn't downloaded during search (see also download_location_map_proposal). -->
-	<string name="download_location_country">귀하께서 현재 계신 국가인 을(를) 다운로드 (%s)</string>
-	<!-- Warning message when viewport country isn't downloaded during search -->
-	<string name="download_viewport_country_to_search">귀하께서 검색 중인 국가인 을(를) 다운로드 (%s)</string>
 	<!-- Alert message that we can't run Map Storage settings due to some reasons. -->
 	<string name="cant_change_this_setting">죄송합니다, 지도 스토리지 설정이 비활성화되어 있습니다.</string>
 	<!-- Alert message that downloading is in progress. -->
 	<string name="downloading_is_active">국가 다운로드가 지금 진행 중입니다.</string>
-	<!-- Message that will be shown in alert view, when we ask user to leave review on App Store -->
-	<string name="appStore_message">Organic Maps로 즐거운 시간을 보내시기 바랍니다! Organic Maps가 마음에 드신다면 앱스토어에서 평가를 남겨 주시기 바랍니다. 평가하는 데는 1분이 채 걸리지 않지만 저희에게 큰 도움이 됩니다. 성원해 주셔서 감사합니다!</string>
-	<!-- No, thanks -->
-	<string name="no_thanks">평가하지 않겠습니다</string>
-	<!-- Share one specific bookmark using SMS, %1$@ contains om:// and %2$@ https://omaps.app link. @NOTE non-ascii symbols in the link will result in max 70 characters SMS instead of 140. -->
-	<string name="bookmark_share_sms">지도에서 내 PIN을 참조하십시오. %1$s 또는 %2$s 열기</string>
 	<!-- Share my position using SMS, %1$@ contains om:// and %2$@ https://omaps.app link WITHOUT NAME. @NOTE non-ascii symbols in the link will result in max 70 characters SMS instead of 140. -->
 	<string name="my_position_share_sms">현재 위치를 알아 보십시오. %1$s 또는 %2$s 열기</string>
 	<!-- Subject for emailed bookmark -->
@@ -206,18 +156,10 @@
 	<string name="my_position_share_email_subject">Organic Maps 지도에서 제 현재 위치를 살펴 보시기 바랍니다</string>
 	<!-- Share my position using EMail, %1$@ is om:// and %2$@ is https://omaps.app link WITHOUT NAME -->
 	<string name="my_position_share_email">안녕하세요.\n\n지금 다음 위치에 있습니다: %1$s. %2$s 또는 %3$s 링크를 클릭하여 지도상에서 해당 장소를 살펴보시기 바랍니다.\n\n감사합니다.</string>
-	<!-- Android share by Message/SMS button text (including SMS) -->
-	<string name="share_by_message">메시지로 공유</string>
 	<!-- Share button text which opens menu with more buttons, like Message, EMail, Facebook etc. -->
 	<string name="share">공유</string>
-	<!-- iOS share by Message button text (including SMS) -->
-	<string name="message">메시지</string>
 	<!-- Share by email button text, also used in editor. -->
 	<string name="email">이메일</string>
-	<!-- Copy Link -->
-	<string name="copy_link">링크 복사하기</string>
-	<!-- Text for the button that returns to caller application -->
-	<string name="more_info">추가 정보 보기</string>
 	<!-- Text for message when used successfully copied something -->
 	<string name="copied_to_clipboard">클립보드에 복사됨: %1$s</string>
 	<!-- place preview title -->
@@ -233,11 +175,6 @@
 	<!-- Length of track in cell that describes route -->
 	<string name="length">길이</string>
 	<string name="share_my_location">내 위치 공유</string>
-	<string name="menu_search">검색</string>
-	<!-- Settings screen: "Map" category title -->
-	<string name="prefs_group_map">지도</string>
-	<!-- Settings screen: "Miscellaneous" category title -->
-	<string name="prefs_group_misc">기타</string>
 	<string name="prefs_group_route">네비게이션</string>
 	<string name="pref_zoom_title">확대/축소 버튼</string>
 	<string name="pref_zoom_summary">화면에 표시</string>
@@ -253,8 +190,6 @@
 	<string name="pref_map_3d_title">원근 보기</string>
 	<!-- Settings «Map» category: «3D buildings» title -->
 	<string name="pref_map_3d_buildings_title">주변 건물 3D</string>
-	<!-- Settings «Map» category: «3D buildings» summary -->
-	<string name="pref_map_3d_buildings_subtitle">배터리 수명에 영향</string>
 	<!-- Settings «Route» category: «Tts enabled» title -->
 	<string name="pref_tts_enable_title">음성 지침</string>
 	<!-- Settings «Route» category: «Tts language» title -->
@@ -263,7 +198,6 @@
 	<string name="pref_tts_unavailable">사용할 수 없음</string>
 	<!-- Title for "Other" section in TTS settings. -->
 	<string name="pref_tts_other_section_title">다른 언어</string>
-	<string name="pref_tts_how_to_set_up_voice">음성 설정 방법</string>
 	<!-- Settings «Map» category: «Record track» title -->
 	<string name="pref_track_record_title">최근 추적</string>
 	<string name="pref_map_auto_zoom">자동 줌</string>
@@ -274,46 +208,11 @@
 	<string name="duration_12_hours">12시간</string>
 	<string name="duration_1_day">1일</string>
 	<string name="recent_track_help_text">특정 기간 동안 이동된 경로를 기록하고 지도에서 그 경로를 볼 수 있습니다. 참고: 이 기능을 활성화하면 배터리 사용량이 증가하게 됩니다. 시간 간격이 만료된 후 지도에서 해당 트랙이 자동으로 제거됩니다.</string>
-	<string name="pref_track_ios_caption">최근 추적은 여행한 경로를 보여줍니다.</string>
-	<string name="pref_track_ios_subcaption">추적을 저장하는 시간 범위를 선택하십시오.</string>
-	<string name="placepage_distance">거리</string>
-	<string name="placepage_coordinates">좌표</string>
-	<string name="placepage_unsorted">분류되지 않음</string>
 	<string name="search_show_on_map">지도 보기</string>
-	<!-- Used to warn user when fixing KitKat issue -->
-	<string name="bookmark_move_fail">우리는 내부 메모리로 북마크를 이동해야 하지만, 이에 대한 사용 가능한 공간이 없습니다. 메모리를 확보하지 않으면, 북마크를 사용할 수 없습니다.</string>
-	<!-- Used in More Apps menu -->
-	<string name="free">무료</string>
-	<!-- Used in More Apps menu -->
-	<string name="buy">구입</string>
-	<!-- 1st search button-like result -->
-	<string name="search_on_map">지도에서 검색</string>
-	<!-- toast with an error -->
-	<string name="no_route_found">경로를 찾을 수 없음</string>
-	<!-- route title -->
-	<string name="route">경로</string>
-	<!-- category title -->
-	<string name="routes">경로</string>
-	<!-- text of notification -->
-	<string name="download_map_notification">당신이 있는 장소의지도를 다운로드 하십시오</string>
-	<!-- text of notification -->
-	<string name="pro_version_is_free_today">Organic Maps의 전체 버전 오늘 무료! 지금 다운로드하고 친구들에게 알리세요.</string>
-	<!-- Dialog for transferring maps from lite to pro. -->
-	<string name="move_lite_maps_to_pro">우리는 Organic Maps. Lite에서 Organic Maps로 다운로드된 지도를 전송하고 있습니다. 이는 몇 분 정도 걸릴 수 있습니다.</string>
-	<!-- Message to display when maps moved. -->
-	<string name="move_lite_maps_to_pro_ok">다운로드된 지도가 성공적으로 Organic Maps에 전송됨</string>
-	<!-- Message to display when maps move failed. -->
-	<string name="move_lite_maps_to_pro_failed">지도를 전송하지 못했습니다. Organic Maps Lite를 삭제하고 다시지도를 다운로드하십시오.</string>
-	<!-- Text in menu -->
-	<string name="settings_and_more">설정 및 기타</string>
 	<!-- Text in menu -->
 	<string name="website">웹사이트</string>
-	<!-- Text in menu -->
-	<string name="contact_us">연락처</string>
 	<!-- Settings: Send feedback button and dialog title -->
 	<string name="feedback">피드백</string>
-	<!-- Text in menu -->
-	<string name="subscribe_to_news">우리 뉴스 구독</string>
 	<!-- Text in menu -->
 	<string name="rate_the_app">앱 평가</string>
 	<!-- Text in menu -->
@@ -322,12 +221,6 @@
 	<string name="copyright">저작권</string>
 	<!-- Text in menu -->
 	<string name="report_a_bug">오류 신고</string>
-	<!-- Email subject -->
-	<string name="subscribe_me_subject">Organic Maps 뉴스 레터로 나를 구독해 주십시오.</string>
-	<!-- Email body -->
-	<string name="subscribe_me_body">나는 최신 뉴스 업데이트 및 프로모션에 대해 알게될 첫번째 사람이 되고 싶습니다. 나는 언제나 구독을 취소할 수 있습니다.</string>
-	<!-- About text -->
-	<string name="about_text">Organic Maps는 가장 빠른 전 세계 모든 국가 및 도시의 오프라인 지도를 제공하고 있습니다. 자신있게 여행하세요. 계신 곳이 어디이든 Organic Maps는 지도상에서 위치하고 계신 곳이 어디 있지 알려 주고 가장 가까운 식당, 호텔 및 주유소 등을 찾아 줍니다. 인터넷 접속이 필요없는 서비스입니다.\n\nOrganic Maps는 항상 새로운 기능들에 대해 연구하고 있습니다. Organic Maps가 더 훌륭한 서비스를 제공할 수 있도록 많은 의견 주시면 감사하겠습니다. 앱을 사용하시다 불편한 점이 있으시면, 주저 마시고 support\@organicmaps.app으로 문의해 주세요. Organic Maps는 어떤 요청에도 기꺼이 응답할 것입니다.\n\nOrganic Maps가 좋은 앱이라고 생각하시나요? Organic Maps을 후원할 수 있는 간단하면서도 비용이 전혀 들지 않는 몇 가지 방법을 소개합니다.\n\n- 앱 마켓에 리뷰를 올려주세요.\n- Organic Maps의 페이스북 페이지 http://www.facebook.com/OrganicMaps 에 “좋아요”를 남겨 주세요.\n- 가족, 친구 및 동료들에게 Organic Maps를 자랑해 주세요.\n\nOrganic Maps와 함께 해 주셔서 감사합니다. 여러분의 후원에 정말 감사드립니다!\n\nP.S. Organic Maps는 OpenStreetMap으로부터 맵 데이터를 수집하고 있습니다. OpenStreetMap은 위키피디아처럼 유저들이 맵을 만들고 편집할 수 있는 맵핑 프로젝트입니다.\n\n혹 맵에서 누락된 곳이나 잘못된 점을 발견하실 경우, https://www.openstreetmap.org에서 직접 맵을 수정하실 수 있습니다. 수정한 부분은 다음 버전으로 출시되는 Organic Maps 앱에 반영될 것입니다.</string>
 	<!-- Alert text -->
 	<string name="email_error_body">이메일 클라이언트가 설정되지 않았습니다. 이를 구성하거나 %s로 연락할 다른 방법을 사용하십시오.</string>
 	<!-- Alert title -->
@@ -336,137 +229,56 @@
 	<string name="pref_calibration_title">나침반 보정</string>
 	<!-- Search category -->
 	<string name="wifi">WiFi 인터넷</string>
-	<!-- Update map suggestion -->
-	<string name="routing_map_outdated">경로를 생성하도록 지도를 업데이트하십시오.</string>
-	<!-- Update maps suggestion -->
-	<string name="routing_update_maps">Organic Maps의 새로운 버전으로 당신의 현재 위치에서 목적지 지점으로 경로를 생성할 수 있습니다. 이 기능을 사용하려면 지도를 업데이트하십시오.</string>
 	<!-- Update all button text -->
 	<string name="downloader_update_all_button">모두 업데이트</string>
 	<!-- Cancel all button text -->
 	<string name="downloader_cancel_all">모두 취소</string>
 	<!-- Downloaded maps category -->
 	<string name="downloader_downloaded_subtitle">다운로드</string>
-	<!-- Downloaded maps category -->
-	<string name="downloader_available_maps">사용 가능</string>
 	<!-- Country queued for download -->
 	<string name="downloader_queued">대기</string>
 	<string name="downloader_near_me_subtitle">내 근처</string>
 	<string name="downloader_status_maps">지도</string>
 	<string name="downloader_download_all_button">모두 다운로드</string>
 	<string name="downloader_downloading">다운로드 중:</string>
-	<string name="downloader_search_results">검색 결과</string>
-	<!-- Disclaimer message -->
-	<string name="routing_disclaimer">Organic Maps 앱에서 경로를 작성할 때, 다음에 유의하시기 바랍니다:\n\n  - 추천 루트는 권장 사항으로만 간주될 수 있습니다.\n - 도로 조건, 교통 규칙 및 징후는 탐색 조언보다 더 높은 우선 순위를 갖습니다.\n -지도는 잘못되었거나 만료되었을 수 있으며, 경로는 최상의 방법을 만들어지지 않을 수 있습니다.\n\n  도로에서 안전하게 몸조심하세요!</string>
-	<!-- Outdated maps category -->
-	<string name="downloader_outdated_maps">만료됨</string>
-	<!-- Up to date maps category -->
-	<string name="downloader_uptodate_maps">최신</string>
 	<!-- Status of outdated country in the list -->
 	<string name="downloader_status_outdated">업데이트</string>
 	<!-- Status of failed country in the list -->
 	<string name="downloader_status_failed">실패함</string>
 	<!-- Displayed in a dialog that appears when a user tries to delete a map while the app is in the follow route mode -->
 	<string name="downloader_delete_map_while_routing_dialog">지도를 삭제하시려면 길 찾기를 멈추세요.</string>
-	<!-- Show when user try build route, but we don't know where he -->
-	<string name="routing_failed_unknown_my_position">현재 위치는 정의되지 않습니다. 경로를 생성할 위치를 지정하십시오.</string>
-	<!-- Show if use has not routing file, or InconsistentMWMandRoute -->
-	<string name="routing_failed_has_no_routing_file">추가 데이터는 경로를 생성하기 위해 필요합니다. 다운로드를 시작하시겠습니까?</string>
-	<!-- StartPointNotFound -->
-	<string name="routing_failed_start_point_not_found">경로를 계산할 수 없습니다. 시작 지점 근처에 도로가 없습니다.</string>
-	<!-- EndPointNotFound -->
-	<string name="routing_failed_dst_point_not_found">경로를 계산할 수 없습니다. 목적지 근처에 도로가 없습니다.</string>
 	<!-- PointsInDifferentMWM -->
 	<string name="routing_failed_cross_mwm_building">경로는 하나의 지도에 완전히 포함되도록만 생성할 수 있습니다.</string>
-	<!-- RouteNotFound -->
-	<string name="routing_failed_route_not_found">선택한 출발지와 목적지 사이에서 발견있는 경로가 없습니다. 다른 출발지 또는 도착지를 선택하십시오.</string>
-	<!-- InternalError -->
-	<string name="routing_failed_internal_error">내부 오류가 발생했습니다. 다시지도를 삭제하고 다운로드하도록 시도하십시오. 문제가 지속되면 support\@organicmaps.app로 문의하시기 바랍니다.</string>
-	<!-- Context menu item for downloader. -->
-	<string name="downloader_download_map_and_routing">지도 + 라우팅 다운로드</string>
-	<!-- Context menu item for downloader. -->
-	<string name="downloader_download_routing">라우팅 다운로드</string>
-	<!-- Context menu item for downloader. -->
-	<string name="downloader_delete_routing">라우팅 삭제</string>
 	<!-- Context menu item for downloader. -->
 	<string name="downloader_download_map">지도 다운로드</string>
-	<string name="downloader_download_map_no_routing">라우팅없이 지도 다운로드</string>
-	<!-- Button for routing. -->
-	<string name="routing_go">이동!</string>
 	<!-- Item status in downloader. -->
 	<string name="downloader_retry">반복</string>
-	<!-- Item in context menu. -->
-	<string name="downloader_map_and_routing">지도 + 라우팅</string>
 	<!-- Item in context menu. -->
 	<string name="downloader_delete_map">지도 삭제</string>
 	<!-- Item in context menu. -->
 	<string name="downloader_update_map">지도 업데이트</string>
-	<!-- Item in context menu. -->
-	<string name="downloader_update_map_and_routing">지도 + 라우팅 업데이트</string>
-	<!-- Item in context menu. -->
-	<string name="downloader_map_only">지도만</string>
-	<!-- Toolbar title -->
-	<string name="toolbar_application_menu">애플리케이션 메뉴</string>
 	<!-- Preference text -->
 	<string name="pref_use_google_play">Google Play 서비스를 사용하여 현재 위치 정보 얻기</string>
 	<!-- Text for rating dialog -->
 	<string name="rating_just_rated">앱 평가 완료</string>
-	<!-- Text for rating dialog -->
-	<string name="rating_user_since">%s 이후로 Organic Maps 사용자임</string>
-	<!-- Text for rating dialog -->
-	<string name="rating_do_like_maps">Organic Maps를 좋아하나요?</string>
-	<!-- Text for rating dialog -->
-	<string name="rating_tap_star">별을 눌러 우리의 앱을 평가하세요.</string>
 	<!-- Text for rating dialog -->
 	<string name="rating_thanks">감사합니다!</string>
 	<!-- Text for rating dialog -->
 	<string name="rating_share_ideas">모든 아이디어나 문제를 공유하여, 사용자를 위한 앱을 향상시킬 수 있습니다.</string>
 	<!-- Text for rating dialog -->
 	<string name="rating_send_feedback">의견 보내기</string>
-	<!-- Text for g+ dialog -->
-	<string name="rating_google_plus">g+를 클릭하여 이 앱에 대해 친구들에게 말하세요.</string>
 	<!-- Text for routing error dialog -->
 	<string name="routing_download_maps_along">경로를 따라 지도 다운로드</string>
-	<!-- Text for routing error dialog -->
-	<string name="routing_download_map">지도 가져오기</string>
-	<!-- Text for routing error dialog -->
-	<string name="routing_download_map_and_routing">업데이트된 지도와 라우팅 데이터를 다운로드하여 모든 Organic Maps 기능을 가져옵니다.</string>
-	<!-- Text for routing error dialog -->
-	<string name="routing_get_routing_data">라우팅 데이터 가져오기</string>
-	<!-- Text for routing error dialog -->
-	<string name="routing_get_additional_data">추가 데이터는 사용자의 위치에서 경로를 생성하도록 필요합니다.</string>
 	<!-- Text for routing error dialog -->
 	<string name="routing_requires_all_map">경로를 만드는 것은 사용자의 위치에서의 모든 지도를 다운로드되고 업데이트된 대상으로 필요합니다.</string>
 	<!-- Text for routing error dialog -->
 	<string name="routing_not_enough_space">여유 공간 부족</string>
-	<!-- Text for routing error dialog -->
-	<string name="routing_download_more_than_avail">%1$s MB를 다운로드해야 하지만 %2$s MB만 사용할 수 있습니다.</string>
-	<!-- Text for routing error dialog -->
-	<string name="routing_download_roaming">모바일 데이터(로밍시)를 사용하여 %s MB를 다운로드할 것입니다. 이는 운영자 모바일 데이터 계획에 따라 추가 요금이 발생할 수 있습니다.</string>
 	<!-- bookmark button text -->
 	<string name="bookmark">북마크</string>
-	<!-- map is not downloaded -->
-	<string name="not_found_map">위치에 대한 지도가 다운로드되지 않음</string>
 	<!-- location service disabled -->
 	<string name="enable_location_services">위치 서비스를 작동시켜 주십시요.</string>
-	<!-- download map -->
-	<string name="download_map">위치에 대한 지도 다운로드</string>
-	<!-- download map on iPhone -->
-	<string name="download_map_iphone">아이폰에서 현재 위치의 지도 다운로드</string>
-	<!-- clear pin -->
-	<string name="nearby">근처에</string>
-	<!-- clear pin -->
-	<string name="clear_pin">핀 지우기</string>
-	<!-- location is undefined -->
-	<string name="undefined_location">현재 위치는 정의되지 않습니다.</string>
-	<!-- download country of your location -->
-	<string name="download_country">귀하께서 현재 계신 국가인 을(를) 다운로드</string>
-	<!-- download failed -->
-	<string name="download_failed">다운로드가 실패했습니다</string>
-	<!-- get the map -->
-	<string name="get_the_map">지도 가져오기</string>
 	<string name="save">저장</string>
 	<string name="edit_description_hint">설명(텍스트 또는 HTML)</string>
-	<string name="new_group">새 그룹</string>
 	<string name="create">만들기기</string>
 	<!-- red color -->
 	<string name="red">빨간색</string>
@@ -484,22 +296,6 @@
 	<string name="brown">갈색</string>
 	<!-- pink color -->
 	<string name="pink">분홍색</string>
-	<!-- deep purple color -->
-	<string name="deep_purple">진보라색</string>
-	<!-- light blue color -->
-	<string name="light_blue">하늘색</string>
-	<!-- cyan color -->
-	<string name="cyan">시안</string>
-	<!-- teal color -->
-	<string name="teal">틸</string>
-	<!-- lime color -->
-	<string name="lime">라임</string>
-	<!-- deep orange color -->
-	<string name="deep_orange">진주황색</string>
-	<!-- gray color -->
-	<string name="gray">회색</string>
-	<!-- blue gray color -->
-	<string name="blue_gray">청회색</string>
 	<!-- Wi-Fi available -->
 	<string name="WiFi_available">네</string>
 
@@ -515,10 +311,8 @@
 	<string name="dialog_routing_location_turn_wifi">GPS 신호를 확인해주세요. Wi-Fi를 켜면 위치 정확도가 높아집니다.</string>
 	<string name="dialog_routing_location_turn_on">위치 서비스 활성화</string>
 	<string name="dialog_routing_location_unknown_turn_on">현재 GPS 좌표를 찾을 수 없습니다. 경로를 계산하려면 위치 서비스를 활성화하세요.</string>
-	<string name="dialog_routing_location_unknown">현재 GPS 좌표를 찾을 수 없습니다.</string>
 	<string name="dialog_routing_download_files">필수 파일 다운로드</string>
 	<string name="dialog_routing_download_and_update_all">경로를 계산하려면 모든 지도와 예상 경로 정보를 다운로드하고 업데이트하세요.</string>
-	<string name="dialog_routing_routes_size">경로 정보 파일</string>
 	<string name="dialog_routing_unable_locate_route">경로를 찾을 수 없습니다</string>
 	<string name="dialog_routing_cant_build_route">경로를 찾을 수 없습니다.</string>
 	<string name="dialog_routing_change_start_or_end">출발지나 목적지를 조정하세요.</string>
@@ -533,33 +327,23 @@
 	<string name="dialog_routing_system_error">시스템 오류</string>
 	<string name="dialog_routing_application_error">애플리케이션 오류로 인해 경로를 설정하지 못했습니다.</string>
 	<string name="dialog_routing_try_again">다시 시도해주세요.</string>
-	<string name="dialog_routing_send_error">문제 신고</string>
-	<string name="dialog_routing_if_get_cross_route">두 개 이상의 지도를 통과하는 더 직접적인 경로를 설정하시겠습니까?</string>
-	<string name="dialog_routing_cross_route_is_optimal">이 지도의 경계를 통과하는 더 최적화된 경로를 사용할 수 있습니다.</string>
 	<string name="not_now">나중에</string>
-	<string name="dialog_routing_build_route">만들기</string>
 	<string name="dialog_routing_download_and_build_cross_route">지도를 다운로드하여, 두 개 이상의 지도를 통과하는 더 최적화된 경로를 설정하시겠습니까?</string>
 	<string name="dialog_routing_download_cross_route">이 지도의 경계를 통과하는 더 최적화된 경로를 설정하려면 지도를 다운로드하세요.</string>
-	<string name="dialog_routing_cross_route_always">항상 이 경계 통과</string>
 
 	<!-- SECTION: Strings for downloading map from search -->
 	<string name="search_without_internet_advertisement">경로를 검색하고 만들기시작하려면, 지도를 다운로드하십시오. 그러면, 더 이상 인터넷 연결이 필요하지 않습니다.</string>
 	<string name="search_select_map">지도 선택</string>
-	<string name="search_select_other_map">다른 지도 선택</string>
 	<!-- «Show» context menu -->
 	<string name="show">표시</string>
 	<!-- «Hide» context menu -->
 	<string name="hide">숨기기</string>
 	<!-- «Rename» context menu -->
 	<string name="rename">다른 이름으로 변경</string>
-	<!-- Bottom sheet: expand button (should be short) -->
-	<string name="bottom_sheet_more">기타…</string>
 	<!-- Failed planning route message in navigation view -->
 	<string name="routing_planning_error">경로 계획 실패</string>
 	<!-- Arrive routing message in navigation view -->
 	<string name="routing_arrive">도착: %s</string>
-	<!-- Text for routing::RouterResultCode::FileTooOld dialog. -->
-	<string name="dialog_routing_download_and_update_maps">경로를 만들려면, 경로를 따라 모든 지도를 다운로드하고 업데이트하십시오.</string>
 	<string name="rate_alert_title">앱을 좋아하나요?</string>
 	<string name="rate_alert_default_message">Organic Maps를 사용해 주셔서 감사합니다. 이 앱을 평가해 주십시오. 당신의 피드백은 이 앱을 더 낫게 만드는데 도움을 줍니다.</string>
 	<string name="rate_alert_five_star_message">야호! 저희는 당신도 사랑합니다!</string>
@@ -567,24 +351,14 @@
 	<string name="rate_alert_less_than_four_star_message">더 낫게 만드는 아이디어가 있습니까?</string>
 	<string name="categories">범주</string>
 	<string name="history">내역</string>
-	<string name="next_turn_then">그런 다음</string>
 	<string name="closed">닫음</string>
-	<string name="back_to">%s(으)로 복귀</string>
 	<string name="search_not_found">죄송합니다. 아무것도 찾지 못했습니다.</string>
 	<string name="search_not_found_query">다른 쿼리를 시도하십시오.</string>
-	<string name="search_not_found_map">검색할 지도를 다운로드하십시오.</string>
-	<string name="search_not_found_location">현재 위치의 지도를 다운로드하십시오.</string>
 	<string name="search_history_title">검색 기록</string>
 	<string name="search_history_text">최근 검색 쿼리에 신속하게 액세스할 수 있습니다.</string>
 	<string name="clear_search">이력 검색 지우기</string>
-	<!-- Title for settings to enable/disable showcase menu button -->
-	<string name="showcase_settings_title">추천 보기</string>
-	<string name="p2p_route_planning">경로 계획 중</string>
 	<string name="p2p_your_location">위치</string>
-	<string name="p2p_from">출발 지점</string>
-	<string name="p2p_to">도착 지점</string>
 	<string name="p2p_start">시작</string>
-	<string name="p2p_planning">계획 중…</string>
 	<string name="p2p_from_here">출발지</string>
 	<string name="p2p_to_here">목적지</string>
 	<string name="p2p_only_from_current">현재 위치에서만 네비게이션을 사용할 수 있습니다.</string>
@@ -604,11 +378,8 @@
 	<string name="editor_hours_closed">폐점 시간</string>
 	<string name="editor_example_values">예제</string>
 	<string name="editor_correct_mistake">입력 수정</string>
-	<string name="editor_correct_mistake_message">잘못 입력했습니다. 수정하거나 기본 모드로 전환하세요.</string>
 	<string name="editor_add_select_location">위치</string>
 	<string name="editor_done_dialog_1">세계 지도를 변경했습니다. 이를 숨기지 마십시오! 친구에게 말하고, 이를 함께 편집합니다.</string>
-	<string name="editor_done_dialog_2">이는 두 번째 지도의 개선 사항입니다. 지금 지도 편집기의 목록에서 %d번째 장소에 있습니다. 친구들에게 이에 대해 말하십시오.</string>
-	<string name="editor_done_dialog_3">지도를 개선했으며, 친구들에게 이에 대해 말하고, 함께 지도를 편집할 수 있습니다.</string>
 	<string name="share_with_friends">친구들과 공유</string>
 	<string name="editor_report_problem_desription_1">OpenStreeMap 커뮤니티가 오류를 수정할 수 있도록 상세하게 문제를 설명하십시오.</string>
 	<string name="editor_report_problem_desription_2">아니면, 다음에서 스스로 가능: https://www.openstreetmap.org/</string>
@@ -617,14 +388,7 @@
 	<string name="editor_report_problem_no_place_title">장소가 존재하지 않음</string>
 	<string name="editor_report_problem_under_construction_title">유지 보수를 위해 닫음</string>
 	<string name="editor_report_problem_duplicate_place_title">중복된 장소</string>
-	<string name="first_launch_congrats_title">Organic Maps를 사용할 준비가 완료되었습니다</string>
-	<string name="first_launch_congrats_text">무료로 세계 어디에서나 오프라인으로 검색하고 탐색할 수 있습니다.</string>
-	<string name="migrate_title">중요!</string>
-	<!-- Android uses image instead of text. -->
-	<string name="download_all">모두 다운로드</string>
-	<string name="delete_all">모두 삭제</string>
 	<string name="autodownload">자동 다운로드</string>
-	<string name="disable_autodownload">자동 다운로드 해제</string>
 	<!-- Place Page opening hours text -->
 	<string name="closed_now">지금 닫힘</string>
 	<!-- Place Page opening hours text -->
@@ -633,8 +397,6 @@
 	<string name="day_off_today">오늘 영업 종료됨</string>
 	<string name="day_off">종료됨</string>
 	<string name="today">오늘</string>
-	<string name="sunrise_to_sunset">일출에서 일몰로</string>
-	<string name="sunset_to_sunrise">일출에서 일몰까지</string>
 	<string name="add_opening_hours">영업일 추가</string>
 	<string name="edit_opening_hours">영업일 편집</string>
 	<string name="no_osm_account">OpenStreetMap에서 계정이 없습니까?</string>
@@ -644,29 +406,13 @@
 	<string name="login">로그인</string>
 	<string name="password">암호</string>
 	<string name="forgot_password">암호를 잊으 셨나요?</string>
-	<!-- Forgot Password dialog title -->
-	<string name="restore_password">암호 복원</string>
-	<string name="enter_email_address_to_reset_password">등록시 사용한 이메일 주소를 입력하면 암호를 갱신하도록 링크를 전송할 것입니다.</string>
-	<string name="reset_password">비밀번호 재 설정</string>
-	<string name="username">사용자 이름</string>
 	<string name="osm_account">OSM 계정</string>
 	<string name="logout">로그 아웃</string>
-	<string name="login_and_edit_map_motivation_message">로그인하고 지도 상의 개체 정보를 편집하면 다른 수백만 명의 사용자가 사용할 수 있도록 하겠습니다. 함께 더 나은 세상으로 만들어 봅시다.</string>
 	<!-- Information text: "Last upload 11.01.2016" -->
 	<string name="last_upload">마지막 업로드</string>
-	<!-- Motivates user to login/register, title above login buttons. -->
-	<string name="you_have_edited_your_first_object">로그인하고 전 세계 수백만 사람들을 위해 변화를 더하십시오!</string>
 	<string name="thank_you">고맙습니다.</string>
-	<string name="login_with_google">Google로 로그인</string>
-	<string name="login_with_openstreetmap">www.openstreetmap.org에 로그인</string>
 	<string name="edit_place">장소 편집</string>
 	<string name="place_name">지명</string>
-	<!-- title above languages list cells in the editor, below editable name text field. -->
-	<string name="other_languages">다른 언어</string>
-	<!-- small button to open list with names in different languages -->
-	<string name="show_more">더 많이 표시</string>
-	<!-- small button to close list with names in different languages -->
-	<string name="show_less">더 적게 표시</string>
 	<string name="add_language">언어 추가</string>
 	<string name="street">거리</string>
 	<!-- Editable House Number text field (in address block). -->
@@ -683,25 +429,16 @@
 	<string name="email_or_username">이메일 또는 사용자 이름</string>
 	<string name="phone">전화</string>
 	<string name="please_note">참고 사항</string>
-	<string name="common_no_wifi_dialog">WiFi 연결이 없습니다. 모바일 데이터를 계속하시겠습니까?</string>
 	<string name="downloader_delete_map_dialog">모든 지도의 변경 사항은 지도와 함께 삭제됩니다.</string>
 	<string name="downloader_update_maps">지도 업데이트</string>
 	<string name="downloader_mwm_migration_dialog">경로를 만들려면, 모든 지도를 업데이트한 다음, 다시 경로를 계획해야 합니다.</string>
 	<string name="downloader_search_field_hint">지도 찾기</string>
-	<string name="migration_update_all_button">모든지도 업데이트</string>
-	<string name="migration_delete_all_download_current_button">현재 지도 다운로드 및 기존 지도 삭제</string>
 	<string name="migration_download_error_dialog">다운로드 오류</string>
 	<string name="common_check_internet_connection_dialog">설정을 확인하고 장치가 인터넷에 연결되어 있는지 확인하십시오.</string>
 	<string name="downloader_no_space_title">충분하지 않은 여유 공간</string>
 	<string name="downloader_no_space_message">불필요한 데이터를 제거하십시오.</string>
-	<string name="editor_general_auth_error_dialog">일반 로그인 오류.</string>
 	<string name="editor_login_error_dialog">로그인 오류.</string>
-	<string name="editor_login_failed_dialog">로그인 실패</string>
-	<string name="editor_username_error_dialog">잘못된 사용자 이름</string>
-	<string name="editor_place_edited_dialog">개체를 편집했습니다!</string>
-	<string name="editor_login_with_osm">OpenStreetMap으로 로그인</string>
 	<string name="editor_profile_changes">변경사항 승인</string>
-	<string name="editor_profile_unsent_changes">전송되지 않음:</string>
 	<string name="editor_focus_map_on_location">개체의 정확한 위치를 선택하려면 지도를 당깁니다.</string>
 	<string name="editor_add_select_category">범주 선택</string>
 	<string name="editor_add_select_category_popular_subtitle">인기있는</string>
@@ -712,19 +449,14 @@
 	<string name="editor_edit_place_category_title">범주</string>
 	<string name="detailed_problem_description">문제에 대한 자세한 설명</string>
 	<string name="editor_report_problem_other_title">다른 문제</string>
-	<string name="placepage_report_problem_button">문제 신고</string>
 	<string name="placepage_add_business_button">조직 추가</string>
 	<string name="whatsnew_editor_message_1">지도에 새로운 장소를 추가하고 응용 프로그램에서 직접 기존 편집 할 수 있습니다.</string>
-	<string name="whatsnew_editor_message_2">* Organic Maps는 OpenStreetMap 커뮤니티 데이터를 사용합니다.</string>
 	<string name="dialog_incorrect_feature_position">위치 변경</string>
 	<string name="message_invalid_feature_position">목적지를 이곳에서 찾을 수 없습니다</string>
 	<string name="login_to_make_edits_visible">로그인하여 다른 사용자가 변경한 내용을 볼 수 있도록 하십시오.</string>
-	<string name="no_migration_during_navigation">업데이트는 탐색 중 금지되어 있습니다.</string>
 	<!-- Error dialog no space -->
 	<string name="migration_no_space_message">다운로드하려면, 더 많은 여유 공간이 필요합니다. 불필요한 데이터를 삭제하십시오.</string>
 	<string name="editor_sharing_title">나는 Organic Maps 지도를 향상함</string>
-	<string name="editor_comment_will_be_sent">지도 제작자에게 의견을 보낼 것입니다.</string>
-	<string name="editor_unsupported_category_message">아직 지원하지 않는 카테고리의 장소를 추가했습니다. 시간이 좀 흐른 나중에 이 지도에 표시될 것입니다.</string>
 	<!-- Downloaded 10 **of** 20 <- it is that "of" -->
 	<string name="downloader_of">%2$d중의 %1$d</string>
 	<string name="download_over_mobile_header">셀룰러 네트워크 접속을 사용하여 다운로드하시겠습니까?</string>
@@ -742,15 +474,8 @@
 	<string name="editor_detailed_description">귀하가 제안한 변경 사항은 OpenStreetMap 커뮤니티로 전송됩니다. Organic Maps에서 편집할 수 없는 세부정보를 작성해 주세요.</string>
 	<string name="editor_more_about_osm">OpenStreetMap 정보</string>
 	<string name="editor_operator">소유자</string>
-	<string name="editor_tag_description">회사, 조직 또는 시설 책임자를 입력하세요.</string>
-	<string name="editor_no_local_edits_title">편집한 지역정보가 없습니다</string>
-	<string name="editor_no_local_edits_description">이는 현재 귀하의 장치에서만 액세스할 수 있으며, 지도에서 만든 변경사항를 보여줍니다.</string>
-	<string name="editor_send_to_osm">OSM에 전송</string>
-	<string name="editor_remove">삭제</string>
-	<string name="downloader_my_maps_title">내 지도</string>
 	<string name="downloader_no_downloaded_maps_title">지도를 다운로드하지 않았습니다</string>
 	<string name="downloader_no_downloaded_maps_message">오프라인으로 위치를 검색하려면 지도를 다운로드하세요.</string>
-	<string name="downloader_find_place_hint">도시/국가 검색</string>
 	<!-- Error title that appears after certain time without location. -->
 	<string name="current_location_unknown_title">현재 위치검색을 계속하시겠습니까?</string>
 	<!-- Error that appears after certain time without location. -->
@@ -765,27 +490,10 @@
 	<string name="location_services_disabled_2">2. 위치 누르기</string>
 	<!-- iOS Dialog for the case when the location permission is not granted -->
 	<string name="location_services_disabled_3">3. 앱 사용 중에 선택</string>
-	<string name="placepage_parking_surface">주차공간</string>
-	<string name="placepage_parking_multistorey">주차장 건물</string>
-	<string name="placepage_parking_underground">지하</string>
-	<string name="placepage_parking_rooftop">옥상</string>
-	<string name="placepage_parking_sheds">창고</string>
-	<string name="placepage_parking_carports">간이 차고</string>
-	<string name="placepage_parking_boxes">차고</string>
-	<string name="placepage_parking_pay">유료</string>
-	<string name="placepage_parking_free">무료</string>
-	<string name="placepage_parking_interval">주차요금 간격</string>
-	<string name="placepage_entrance_number">번호</string>
-	<string name="placepage_entrance_type">입구</string>
-	<string name="placepage_flat">앱</string>
-	<string name="placepage_open_24_7">연중무휴</string>
 	<string name="meter">m</string>
 	<string name="kilometer">km</string>
-	<string name="kilometers_per_hour">km/시</string>
 	<string name="mile">mi</string>
 	<string name="foot">풋</string>
-	<string name="miles_per_hour">mph</string>
-	<string name="day">d</string>
 	<string name="hour">t</string>
 	<string name="minute">min</string>
 	<string name="placepage_place_description">설명</string>
@@ -795,46 +503,30 @@
 	<string name="placepage_call_button">전화</string>
 	<string name="placepage_edit_bookmark_button">즐겨찾기 편집</string>
 	<string name="placepage_bookmark_name_hint">즐겨찾기 이름</string>
-	<string name="placepage_personal_notes_hint">개인 메모</string>
-	<string name="placepage_delete_bookmark_button">즐겨찾기 삭제</string>
 	<string name="editor_edits_sent_message">귀하의 제안 변경사항이 전송되었습니다</string>
 	<string name="editor_comment_hint">설명…</string>
 	<string name="editor_reset_edits_message">지역 변경 사항을 재설정하시겠습니까?</string>
 	<string name="editor_reset_edits_button">재설정</string>
 	<string name="editor_remove_place_message">추가한 장소를 삭제하시겠습니까?</string>
 	<string name="editor_remove_place_button">삭제</string>
-	<string name="editor_status_sending">보내는 중…</string>
 	<string name="editor_place_doesnt_exist">존재하지 않는 장소입니다.</string>
 	<string name="text_more_button">…기타</string>
 	<!-- Phone number error message -->
 	<string name="error_enter_correct_phone">올바른 전화 번호 입력</string>
 	<string name="error_enter_correct_web">유효한 웹 주소 입력</string>
 	<string name="error_enter_correct_email">유효한 이메일 주소 입력</string>
-	<string name="error_enter_correct">유효한 값 입력</string>
 	<string name="refresh">최신 정보</string>
-	<string name="last_update">마지막 업데이트: %s</string>
 	<string name="placepage_add_place_button">지도에 장소 추가</string>
 	<!-- Displayed when saving some edits to the map to warn against publishing personal data -->
 	<string name="editor_share_to_all_dialog_title">이를 모든 사용자에게 전송하시겠습니까?</string>
 	<!-- iOS Dialog before publishing the modifications to the public map. -->
 	<string name="editor_share_to_all_dialog_message_1">개인 정보를 입력하지 않았는지 확인하십시오.</string>
 	<string name="editor_share_to_all_dialog_message_2">저희가 변경 사항을 확인할 것입니다. 질문이 있으신 경우, 저희에게 이메일을 통해 연락하십시오.</string>
-	<string name="navigation_overview_button">개요</string>
-	<string name="navigation_stop_button">중지</string>
-	<!-- Text on an empty bookmark page -->
-	<string name="bookmarks_empty_title">북마크 저장</string>
-	<string name="bookmarks_empty_message_1">빠른 액세스를 위해 즐겨찾는 장소에 저장하기 위해 ★를 누릅니다.</string>
-	<string name="bookmarks_empty_message_2">이메일 및 웹에서 북마크를 가져옵니다.</string>
-	<string name="bookmarks_empty_message_3">체크아웃: %s</string>
-	<!-- Name of the group for booked hotels -->
-	<string name="bookmarks_group_name">호텔 예약함</string>
-	<string name="place_page_button_read_descriprion">읽기</string>
 	<!-- iOS dialog for the case when recent track recording is on and the app comes back from background -->
 	<string name="recent_track_background_dialog_title">최근 여행한 경로 녹음을 비활성화하시겠습니까?</string>
 	<string name="off_recent_track_background_button">비활성화</string>
 	<!-- For sharing via SMS and so on -->
 	<string name="sharing_call_action_look">체크아웃</string>
-	<string name="continue_recent_track_background_button">계속</string>
 	<string name="recent_track_background_dialog_message">Organic Maps는 최근 여행한 경로를 녹음하기 위해 배경 화면에서 지역 위치 서비스를 사용합니다.</string>
 	<!-- Rate on Google Play (Android only) -->
 	<string name="rate_gp">Google Play에서 평가</string>
@@ -844,21 +536,11 @@
 	<string name="tell_friends_text">안녕하세요! Organic Maps를 설치하세요!</string>
 	<!-- About short text (below logo) -->
 	<string name="about_description">Organic Maps는 여행용 필수 오프라인 응용 프로그램입니다. Organic Maps는 OpenStreetMap 데이터를 기반으로 하며 이 데이터 편집을 허용합니다.</string>
-	<!-- Text in menu -->
-	<string name="blog">블로그</string>
 	<string name="general_settings">일반 설정</string>
-	<string name="date">날짜 %d</string>
-	<!-- "Report a bug" -> "Generaal Feedback" -> "Something is not working" -->
-	<string name="something_is_not_working">문제가 발생했습니다.</string>
 	<!-- For the first routing -->
 	<string name="accept">동의</string>
 	<!-- For the first routing -->
 	<string name="decline">거부</string>
-	<string name="install_app">설치</string>
-	<string name="search_no_results_title">결과 찾지 못함</string>
-	<string name="search_no_results_message">보다 일반적인 검색어로 시도하거나, 축소하거나, 필터를 재설정하세요.</string>
-	<string name="search_no_results_expand_area_button">축소</string>
-	<string name="search_no_results_reset_button">필터 재설정</string>
 	<!-- noun -->
 	<string name="search_in_table">목록</string>
 	<string name="mobile_data_dialog">모바일 인터넷을 사용하여 자세한 정보를 표시하시겠습니까?</string>
@@ -870,18 +552,13 @@
 	<string name="mobile_data_option_never">전혀 사용 안 함</string>
 	<string name="mobile_data_option_ask">항상 표시</string>
 	<string name="traffic_update_maps_text">교통 데이터를 표시하려면 지도를 업데이트해야 합니다.</string>
-	<string name="traffic_outdated">교통 데이터가 오래되었습니다.</string>
 	<string name="big_font">지도에서 글꼴 크기 늘리기</string>
 	<string name="traffic_update_app">Organic Maps를 업데이트하세요.</string>
 	<!-- "traffic" as in road congestion -->
 	<string name="traffic_update_app_message">교통 데이터를 표시하려면 응용 프로그램을 업데이트해야 합니다.</string>
 	<!-- "traffic" as in "road congestion" -->
 	<string name="traffic_data_unavailable">교통 데이터를 사용할 수 없습니다</string>
-	<!-- Simplified colour scheme for traffic information, fewer colours are used to display traffic jams on the map. The string should be kept as short as possible -->
-	<string name="pref_traffic_simplified_colors_title">단순화된 트래픽 색상</string>
 	<string name="enable_logging">로깅 사용</string>
-	<string name="offline_place_page_more_information">인터넷에 연결하여 그곳에 대한 자세한 정보를 얻으세요.</string>
-	<string name="failed_load_information">정보를 로드하지 못했습니다.</string>
 	<!-- Settings: "Send general feedback" button -->
 	<string name="feedback_general">일반 피드백</string>
 	<string name="on">켜기</string>
@@ -895,57 +572,26 @@
 	<string name="routing_add_start_point">경로 계획을 세우기 위한 시작 지점을 추가하세요</string>
 	<string name="routing_add_finish_point">경로 계획을 세우기 위한 끝 지점을 추가하세요</string>
 	<string name="button_exit">끝내기</string>
-	<string name="settings_device_memory">장치 메모리</string>
-	<string name="settings_card_memory">카드 메모리</string>
-	<string name="settings_storage_available">%s 사용 가능</string>
-	<string name="toast_location_permission_denied">앱 위치 권한 거부됨</string>
-	<string name="button_use">사용</string>
 	<string name="planning_route_manage_route">경로 관리</string>
 	<string name="button_plan">계획</string>
-	<string name="button_add">추가</string>
 	<string name="placepage_remove_stop">제거</string>
 	<string name="planning_route_remove_title">여기로 끌어와서 제거</string>
-	<string name="dialog_change_start_point_message">시작 지점을 현재 위치로 바꾸시겠습니까?</string>
-	<string name="button_replace">바꾸기</string>
 	<string name="placepage_add_stop">스톱 추가</string>
-	<string name="add_my_position">내 위치 추가</string>
-	<string name="choose_start_point">시작 지점 선택</string>
-	<string name="choose_destination">목적지 선택</string>
 	<string name="preloader_viator_button">자세히 알아보기</string>
-	<string name="start_from_my_position">시작 위치:</string>
-	<string name="profile_authorization_title">로그인</string>
-	<string name="profile_authorization_message">로그인 및 암호 없이 몇 초 내에 간편하게 로그인</string>
 	<string name="profile_authorization_error">죄송합니다. 오류가 발생했습니다. 다시 로그인해 보세요.</string>
-	<string name="service">서비스</string>
-	<string name="atmosphere">분위기</string>
-	<string name="value_for_money">가성비</string>
-	<string name="experience">경험</string>
-	<string name="assortment">구색</string>
-	<string name="expertise">전문성</string>
-	<string name="equipment">장비</string>
-	<string name="quality">품질</string>
 	<string name="dialog_error_storage_title">저장소 액세스 문제</string>
 	<string name="dialog_error_storage_message">외부 저장소를 사용할 수 없습니다. SD 카드가 제거되었거나 손상되었거나 파일 시스템이 읽기 전용일 수 있습니다. 확인 후 support\@organicmaps.app로 문의하세요.</string>
 	<string name="setting_emulate_bad_storage">불량 저장소 에뮬레이션</string>
-	<string name="directions_finish">목적지</string>
-	<string name="directions_on_foot">%s 걷기</string>
 	<string name="core_entrance">입구</string>
-	<string name="coffee">커피</string>
-	<string name="cleanliness">청결</string>
-	<string name="crowdedness">혼잡</string>
 	<string name="error_enter_correct_name">올바른 이름을 입력하세요.</string>
 	<string name="bookmarks_groups">기울기</string>
 	<string name="bookmarks_groups_hide_all">모두 숨기기</string>
 	<string name="bookmarks_groups_show_all">모두 표시</string>
-	<plurals name="bookmarks_places">
-	  <item quantity="other">%d 북마크</item>
-	</plurals>
 	<string name="bookmarks_create_new_group">새 목록 만들기</string>
 	<string name="downloader_hide_screen">화면 숨기기</string>
 	<string name="downloader_percent">%1$s(%2$s / %3$s)</string>
-	<string name="downloader_process">%s 다운로드 중...</string>
-	<string name="downloader_applying">%s 적용 중...</string>
-	<string name="dialog_message_transit_not_found_connection">대중 교통망 내에서 하나의 경로를 계획하세요</string>
+	<string name="downloader_process">%s 다운로드 중…</string>
+	<string name="downloader_applying">%s 적용 중…</string>
 	<string name="bookmarks_error_message_share_general">애플리케이션 오류로 인해 공유할 수 없습니다</string>
 	<string name="bookmarks_error_title_share_empty">공유 오류</string>
 	<string name="bookmarks_error_message_share_empty">빈 목록을 공유 할 수 없습니다</string>
@@ -954,12 +600,7 @@
 	<string name="bookmarks_new_list_hint">새 목록</string>
 	<string name="bookmarks_error_title_list_name_already_taken">이 이름은 이미 사용 중입니다.</string>
 	<string name="bookmarks_error_message_list_name_already_taken">다른 이름을 선택하십시오.</string>
-	<string name="bookmarks_error_title_list_name_too_long">이 이름이 너무 깁니다.</string>
-	<string name="bookmarks_error_message_list_name_too_long">다른 이름을 선택하십시오.</string>
-	<string name="please_wait">잠시만 기다려주십시오...</string>
-	<string name="phone_number">전화 번호</string>
-	<string name="notification_unsent_reviews_title">보내지 않은 리뷰가 여러 개 있습니다.</string>
-	<string name="notification_unsent_reviews_message">다른 여행자와 리뷰를 공유하려면 로그인하십시오.</string>
+	<string name="please_wait">잠시만 기다려주십시오…</string>
 	<string name="profile">OpenStreetMap 프로필</string>
 	<string name="place_page_search_similar_hotel">비슷한 호텔 검색</string>
 	<string name="bookmarks_detect_title">새 파일이 감지되었습니다.</string>
@@ -969,31 +610,10 @@
 	<string name="button_convert">변하게 하다</string>
 	<string name="bookmarks_convert_error_title">오류</string>
 	<string name="bookmarks_convert_error_message">일부 파일은 변환되지 않았습니다.</string>
-	<string name="converting">변환 중...</string>
-	<string name="wn_reinvented_bookmarks_title">우리는 북마크를 재발 명했습니다!</string>
-	<string name="wn_reinvented_bookmarks_message">당신은 북마크를 백업하고, 목록을 만들 수 있습니다... 그것은 놀랍습니다...</string>
-	<string name="bookmarks_restore">북마크 복원</string>
-	<string name="bookmarks_restore_process">복원 중...</string>
 	<string name="bookmarks_restore_title">이 버전을 복원 하시겠습니까?</string>
-	<string name="bookmarks_restore_message">북마크가 %1$s (%2$s)에서 복원됩니다.</string>
-	<string name="bookmarks_restore_empty_title">백업이 없습니다.</string>
-	<string name="bookmarks_restore_empty_message">서버가 이전에 만들어진 백업을 찾지 못했습니다.</string>
 	<string name="common_check_internet_connection_dialog_title">인터넷에 연결되지 않음</string>
-	<string name="error_server_title">서버 오류</string>
-	<string name="error_server_message">서버에 오류가 발생했습니다. 잠시 후 다시 시도하십시오</string>
 	<string name="error_system_message">알 수없는 오류가 발생했습니다</string>
 	<string name="restore">복원</string>
-	<string name="bookmarks_page_downloaded">다운로드 되었습니다.</string>
-	<string name="bookmarks_page_my">나의</string>
-	<string name="routes_and_bookmarks">경로 및 북마크</string>
-	<string name="bookmarks_webview_success_toast">성공적으로 북마크를 다운로드 하였습니다.</string>
-	<string name="cached_bookmarks_placeholder_title">새로운 장소를 다운로드 하세요.</string>
-	<string name="cached_bookmarks_placeholder_subtitle">버튼을 눌러 Organic Maps 사용자들이 작성한 수천 개의 흥미로운 장소와 경로를 다운로드 하세요. 인터넷 연결이 필요합니다.</string>
-	<string name="downloader_download_routers">북마크를 다운로드 하세요.</string>
-	<string name="bookmarks_groups_cached">목록을 다운로드 하세요.</string>
-	<plurals name="bookmarks_objects">
-	  <item quantity="other">%s 대상</item>
-	</plurals>
 	<plurals name="objects">
 	  <item quantity="other">%d 장소</item>
 	</plurals>
@@ -1006,62 +626,32 @@
 	<string name="subtittle_opt_out">추적 설정</string>
 	<string name="crash_reports">오류 보고서</string>
 	<string name="crash_reports_description">당사는 Organic Maps 경험을 개선하기 위해 귀하의 데이터를 활용할 수 있습니다. 앱을 다시 시작한 후 변경사항이 적용됩니다.</string>
-	<string name="opt_out_help_ios_1">귀하의 모바일 장치는 \"\"광고 추적 제한\"\" 혹은 \"\"관심 기반의 광고의 옵트아웃\"\" 설정을 제공할 수 있습니다.</string>
-	<string name="opt_out_help_ios_2">iOS 9 혹은 이상</string>
-	<string name="opt_out_help_ios_3">설정 → 개인정보 → 광고 → “광고 추적 제한” 설정을 활성화합니다.</string>
-	<string name="opt_out_help_android">귀하의 모바일 장치는 \"\"광고 추적 제한\"\" 혹은 \"\"관심 기반의 광고의 옵트아웃\"\" 설정을 제공할 수 있습니다.\n\n안드로이드와 구글 플레이 서비스 버전 4.0 혹은 이상은\n설정 → 구글 → 광고 → 광고 개별 맞춤 설정 옵트아웃\nor\n설정 → 구글 → 구글 계정 → 개인 정보 및 보호 → 광고 설정 → 광고 개별 맞춤 설정</string>
 	<string name="privacy_policy">개인정보 보호 방침</string>
 	<string name="terms_of_use">사용 약관</string>
-	<string name="backup_notification_failed">북마크의 백업이 중단되었습니다. 다시 작동시키려면 로그인하세요.</string>
 	<string name="button_layer_traffic">트래픽</string>
 	<string name="button_layer_subway">지하철</string>
 	<string name="layers_title">맵 레이어</string>
-	<string name="layers_message">트래픽, 지하철 지도 그리고 기타 유용한 정보를 표시하려면 맵 레이어를 사용하세요.</string>
-	<string name="button_layer_got_it">알겠습니다.</string>
 	<string name="subway_data_unavailable">지하철 지도가 가용하지 않습니다.</string>
 	<string name="bookmarks_empty_list_title">이 목록은 비어있습니다.</string>
 	<string name="bookmarks_empty_list_message">북마크를 추가하려면 맵에서 장소를 탭하고 별 모양 아이콘을 탭하세요.</string>
 	<string name="category_desc_more">…기타 정보</string>
 	<string name="title_error_downloading_bookmarks">오류가 발생했습니다.</string>
-	<string name="subtitle_error_downloading_bookmarks">북마크가 다운로드 되지 않았습니다.</string>
-	<string name="error_already_downloaded">해당 목록을 이미 다운로드 하였습니다.</string>
-	<string name="why_support">왜 Organic Maps를 지원하죠?</string>
-	<string name="why_support_item2">당신은 Organic Maps를 개선하는데 우리를 도와주세요</string>
-	<string name="why_support_item3">오픈 지도들 OpenStreetMap.org를 개선하는데 도와주세요</string>
-	<string name="channels_map_update">지도 업데이트</string>
-	<string name="server_unavailable_title">서버를 사용할 수 없습니다</string>
-	<string name="sharing_options">옵션 공유</string>
 	<string name="export_file">파일 내보내기</string>
 	<string name="list_settings">목록 세팅</string>
 	<string name="delete_list">리스트 삭제</string>
-	<string name="hide_from_map">지도에서 숨기기</string>
 	<string name="public_access">일반 접근</string>
 	<string name="limited_access">제한 접근</string>
 	<string name="bookmark_category_name">범주</string>
 	<string name="bookmark_category_description_hint">묘사를 적으세요 (글자 혹은 html)</string>
 	<string name="not_shared">개인</string>
-	<string name="direct_link_progress_text">당신의 파일을 업로드 중…</string>
-	<string name="direct_link_success">링크가 만들어졌습니다</string>
-	<string name="send_a_link_btn">나에게 링크 보내기</string>
-	<string name="upload_error_toast">당신의 파일을 업로드 중에 에러가 발생했습니다</string>
 	<string name="tags_loading_error_subtitle">태그를 불러오는 중 에러가 발생했습니다. 다시 시도해보세요</string>
-	<string name="unable_upload_errorr_title">파일 업로드 실패</string>
-	<string name="unable_upload_error_subtitle_edited">이 파일은 웹 앱을 통해 수정되었습니다</string>
-	<string name="unable_upload_error_subtitle_broken">파일이 망가져서 업로드를 할 수 없습니다. 다른 파일을 업로드하세요.</string>
-	<string name="contact">연락</string>
-	<string name="download_button">다운로드</string>
 	<string name="speedcams_alert_title">속도 감시 카메라</string>
-	<string name="speedcams_alert_subtitle">속도 제한에 대한 경고</string>
 	<string name="speedcam_option_auto">자동</string>
 	<string name="speedcam_option_always">항상</string>
 	<string name="speedcam_option_never">안함</string>
-	<string name="bookmark_description_title">즐겨찾기 묘사</string>
 	<string name="place_description_title">장소 묘사</string>
 	<!-- this text will be shown in application notification preferences opposite checkbox which enable/disable downloader notifications. Devices on Android 8+ are affected. -->
 	<string name="notification_channel_downloader">맵 다운로더</string>
-	<string name="share_bookmarks_email_body_link">안녕하세요!\n\n여기 즐겨찾기들을 다운로드 받을 수 있는 링크입니다: %s. Organic Maps 를 통해 리스트를 열고 당신의 여행을 즐기세요!\n\n어플리케이션을 받으세요: https://omaps.app/get?kmz</string>
-	<string name="warning_speedcams_title">네비게이터가 %d km/h의 속도 제한을 초과시 카메라에 대해 경고 할 것입니다</string>
-	<string name="warning_speedcams_subtitle">여행하시는 나라의 운전 법규를 준수하시길 바랍니다.</string>
 	<string name="speedcams_notice_message">자동 - 속도 제한 초과 위험이 있을때 스피드캠에 대해 경고하기\n항상 - 스피드캠에 대해 항상 경고하기\n절대 아님 - 스피드캠에 대해 경고하지 않기</string>
 	<string name="power_managment_title">전력 절약 모드</string>
 	<string name="power_managment_description">자동 모드가 선택되면 어플리케이션은 현재 배터리 충전 정도에 따라 배터리를 많이 쓰는 기능이 불가하게 됩니다</string>
@@ -1069,14 +659,7 @@
 	<string name="power_managment_setting_auto">자동</string>
 	<string name="power_managment_setting_manual_max">최대 전력 절약</string>
 	<string name="enable_logging_warning_message">이 옵션은 진단을 목적으로 로그를 엽니다 이를 통해 앱에 대한 문제를 분석하는 우리의 스탭을 도울 수 있습니다 이 옵션은 오직 Organic Maps 지원 요청에서만 가능합니다.</string>
-	<string name="html_error_upload_message_try_again">네트워크 설정을 확인하신 후 다시 시도해주세요</string>
-	<string name="html_error_upload_title_try_again">인터넷이 연결되지 않았습니다</string>
-	<string name="notification_leave_review_v2_android_short_title">리뷰하고 여행객들을 도우세요!</string>
-	<string name="notifications_illegal_alert_disable_button">알림 끄기</string>
 	<string name="access_rules_author_only">온라인 수정</string>
-	<string name="privacy_settings_menu">개인정보 설정</string>
-	<string name="unable_upadate_error_title">파일 업데이트 실패</string>
-	<string name="unable_upadate_error_message">업데이트 중 무언가 실수가 일어났습니다. 변경점들을 확인하시고 다시 시도해주세요</string>
 	<string name="driving_options_title">운전 옵션</string>
 	<string name="driving_options_subheader">모든 길에서 피하기</string>
 	<string name="avoid_tolls">유로 도로</string>
@@ -1087,52 +670,14 @@
 	<string name="unable_to_calc_alert_subtitle">아쉽게도 귀하가 정의한 옵션으로는 루트를 찾을 수가 없습니다. 설정을 바꾸신다음 다시 시도해주세요</string>
 	<string name="define_to_avoid_btn">피할 도로 정의하기</string>
 	<string name="change_driving_options_btn">운전 옵션이 가능합니다</string>
-	<string name="toll_road">유료 도로</string>
-	<string name="unpaved_road">비포장 도로</string>
-	<string name="ferry_crossing">여객선 횡단길</string>
-	<string name="operated_by">\"%s\" 로 운용됨</string>
 	<string name="avoid_toll_roads_placepage">유료 도로 피하기</string>
 	<string name="avoid_unpaved_roads_placepage">비포장 도로 피하기</string>
 	<string name="avoid_ferry_crossing_placepage">여객선 횡단길 피하기</string>
-	<string name="type.cuisine.uzbek">우즈벡 요리</string>
-	<string name="trip_start">가자</string>
-	<string name="pick_destination">목적지</string>
-	<string name="follow_my_position">내 위치 조정하기</string>
-	<string name="search_results">검색 결과</string>
-	<string name="then_turn">그 다음</string>
-	<string name="redirect_route_alert">루트를 재구축하길 원하시나요?</string>
-	<string name="redirect_route_yes">네</string>
-	<string name="redirect_route_no">아니오</string>
-	<string name="trip_finished">도착했습니다!</string>
-	<string name="keyboard_availability_alert">운전 중에는 키보드를 사용할 수 없습니다</string>
-	<string name="dialog_routing_change_start_carplay">현재 위치에서 루트를 만들 수 없습니다</string>
-	<string name="dialog_routing_change_end_carplay">목적지 경로를 만들 수 없습니다. 다른 지점을 선택해주세요</string>
-	<string name="dialog_routing_check_gps_carplay">GPS 신호가 없습니다. 열린 장소로 이동해주세요</string>
-	<string name="dialog_routing_unable_locate_route_carplay">루트를 만들 수 없습니다. 또 다른 루트 지점을 지정해주세요</string>
-	<string name="dialog_routing_download_files_carplay">루트를 만들려면, 빠진 맵을 기기에 다운로드하세요</string>
-	<string name="dialog_routing_system_error_carplay">오류 발생. 어플리케이션을 재실행해주시길 바랍니다</string>
-	<string name="dialog_routing_rebuild_from_current_location_carplay">루트가 귀하의 현재 위치로부터 재생성됩니다</string>
-	<string name="dialog_routing_rebuild_for_vehicle_carplay">루트가 차량에 맞춰 수정됩니다</string>
 	<string name="ok">OK</string>
-	<string name="avoid_unpaved_carplay_1">비포장 도로 없음</string>
-	<string name="avoid_unpaved_carplay_2">비포장 도로 없음</string>
-	<string name="avoid_ferry_carplay_1">여객선 없음</string>
-	<string name="avoid_ferry_carplay_2">여객선 없음</string>
-	<string name="avoid_tolls_carplay_1">유료 도로 없음</string>
-	<string name="avoid_tolls_carplay_2">유료 도로 없음</string>
-	<string name="speedcams_alert_title_carplay_1">속도단속 카메라</string>
-	<string name="speedcams_alert_title_carplay_2">속도단속 카메라</string>
-	<string name="download_map_carplay">Organic Maps 앱 안의 지도들을 디바이스에 다운로드하세요</string>
-	<string name="carplay_roundabout_exit">%s번 출구</string>
 	<!-- max. 10 symbols, both iOS and Android -->
 	<string name="sort">분류…</string>
 	<!-- Android, title, max 20-22 symbols -->
 	<string name="sort_bookmarks">북마크 분류하기</string>
-	<!-- iOS -->
-	<string name="sort_default">기본 값으로 분류</string>
-	<string name="sort_type">유형으로 분류</string>
-	<string name="sort_distance">거리로 분류</string>
-	<string name="sort_date">날짜로 분류</string>
 	<!-- Android -->
 	<string name="by_default">기본 값</string>
 	<!-- Android -->
@@ -1141,65 +686,23 @@
 	<string name="by_distance">거리 별</string>
 	<!-- Android -->
 	<string name="by_date">날짜 별</string>
-	<string name="week_ago_sorttype">일주일 전</string>
-	<string name="month_ago_sorttype">한달 전</string>
-	<string name="moremonth_ago_sorttype">한달 그 이상 전</string>
-	<string name="moreyear_ago_sorttype">1년 그 이상 전</string>
-	<string name="near_me_sorttype">나와 가까운 곳</string>
-	<string name="others_sorttype">기타</string>
-	<string name="food_places">음식</string>
-	<string name="tourist_places">명소</string>
-	<string name="museums">박물관</string>
-	<string name="parks">공원</string>
-	<string name="swim_places">수영</string>
-	<string name="mountains">산</string>
-	<string name="animals">동물원</string>
-	<string name="hotels">호텔</string>
-	<string name="buildings">빌딩</string>
-	<string name="money">돈</string>
-	<string name="shops">상점</string>
-	<string name="parkings">주차장</string>
-	<string name="fuel_places">주유소</string>
-	<string name="water">물</string>
-	<string name="medicine">의료</string>
 	<string name="search_in_the_list">리스트에서 검색</string>
-	<string name="view_on_map_bookmarks">맵에서</string>
-	<string name="more_bookmarks">더…</string>
-	<string name="no_items_found">발견 없음</string>
-	<!-- Android, max 18 symbols -->
-	<string name="bookmarks_edit_list">리스트 수정</string>
-	<!-- Android, max 18 symbols -->
-	<string name="bookmarks_delete_list">리스트 삭제</string>
-	<string name="religious_places">종교적 장소</string>
 	<string name="select_list">목록 선택</string>
 	<string name="transit_not_found">이 지역의 지하철 노선 기능이 아직 없습니다</string>
 	<string name="dialog_pedestrian_route_is_long_header">지하철 루트가 발견되지 않았습니다</string>
 	<string name="dialog_pedestrian_route_is_long_message">지하철역에서 가까운 출발점 또는 종점을 선택하세요</string>
-	<!-- Failed planning SUBWAY route message in navigation view -->
-	<string name="routing_planning_error_subway_special">지하철 루트 계획 생성 실패</string>
 	<string name="button_layer_isolines">지형</string>
-	<string name="tips_map_layers_title_countour">Organic Maps의 새 기능: 오프라인 지형 레이어!</string>
-	<string name="tips_map_layers_message_countour">이 지역에 대한 모든 것을 알고 있는지 확인하면서 자연 여행을 계획하고 즐기세요</string>
 	<string name="isolines_activation_error_dialog">지형 레이어를 활성화하고 사용하려면 해당 지역의 지도를 업데이트하거나 다운로드하십시오</string>
 	<string name="isolines_location_error_dialog">이 지역의 지형 레이어는 아직 사용할 수 없습니다</string>
 	<string name="elevation_profile_diff_level">난이도</string>
-	<string name="elevation_profile_diff_level_easy">쉬움</string>
-	<string name="elevation_profile_diff_level_moderate">보통</string>
-	<string name="elevation_profile_diff_level_hard">어려움</string>
 	<string name="elevation_profile_ascent">올라가기</string>
 	<string name="elevation_profile_descent">내려가기</string>
 	<string name="elevation_profile_minaltitude">산 최소 높이</string>
 	<string name="elevation_profile_maxaltitude">산 최대 높이</string>
-	<string name="elevation_profile_m">m</string>
 	<string name="elevation_profile_difficulty">난이도</string>
 	<string name="elevation_profile_distance">거리:</string>
-	<string name="elevation_profile_km">km</string>
 	<string name="elevation_profile_time">소비 시간:</string>
-	<string name="elevation_profile_hours">시간</string>
-	<string name="elevation_profile_minutes">분</string>
 	<string name="isolines_toast_zooms_1_10">등치선 탐색을 위한 확대</string>
-	<string name="downloader_updating_ios">업데이트 중</string>
-	<string name="downloader_loading_ios">다운로드 중</string>
 	<string name="key_information_title">핵심 정보</string>
 	<string name="enable_screen_sleep">화면 절전 모드 허용</string>
 	<!-- Description in preferences -->

--- a/android/res/values-nb/strings.xml
+++ b/android/res/values-nb/strings.xml
@@ -12,15 +12,11 @@
 	<string name="cancel_download">Avbryt nedlasting</string>
 	<!-- Button which deletes downloaded country -->
 	<string name="delete">Slett</string>
-	<!-- Button "do not interrupt download" if user touched actively downloading country -->
-	<string name="do_nothing">Ikke spør meg igjen</string>
 	<string name="download_maps">Last ned kart</string>
 	<!-- Settings/Downloader - info for country when download fails -->
 	<string name="download_has_failed">Nedlastingen mislyktes – trykk på nytt for å prøve en gang til</string>
 	<!-- Settings/Downloader - info for country which started downloading -->
 	<string name="downloading">Laster ned …</string>
-	<!-- Settings/Downloader - size string, only strings different from English should be translated -->
-	<string name="kb">kB</string>
 	<!-- Choose measurement on first launch alert - choose metric system button -->
 	<string name="kilometres">Kilometer</string>
 	<!-- Leave Review dialog - Review button -->
@@ -35,45 +31,31 @@
 	<string name="core_my_position">Min posisjon</string>
 	<!-- Update maps later/Buy pro version later button text -->
 	<string name="later">Senere</string>
-	<!-- Don't show some dialog any more -->
-	<string name="never">Aldri</string>
 	<!-- View and button titles for accessibility -->
 	<string name="search">Søk</string>
 	<!-- Search box placeholder text -->
 	<string name="search_map">Søk kart</string>
-	<!-- Settings/Downloader - info for not downloaded country -->
-	<string name="touch_to_download">Trykk for å laste ned</string>
 	<!-- Settings/Downloader - 3G download warning dialog confirm button -->
 	<string name="use_cellular_data">Ja</string>
 	<!-- Location services are disabled by user alert - message -->
 	<string name="location_is_disabled_long_text">Du har for øyeblikket deaktivert alle posisjonstjenester for denne enheten eller applikasjonen. Slå dem på i «Innstillinger».</string>
-	<!-- Location Services are not available on the device alert - message -->
-	<string name="device_doesnot_support_location_services">Enheten din støtter ikke posisjonstjenester</string>
 	<!-- View and button titles for accessibility -->
 	<string name="zoom_to_country">Vis på kartet</string>
-	<!-- Button text for the button at the center of the screen when the country is not downloaded -->
-	<string name="country_status_download">Last ned kart\n(^ ^)</string>
 	<!-- Button text for the button at the center of the screen when the country is not downloaded and the size should not be shown -->
 	<string name="country_status_download_without_size">Last ned kart</string>
-	<!-- Button text for the button at the center of the screen when the country is not downloaded -->
-	<string name="country_status_download_without_routing">Last ned kart\nuten veiviserfunksjon (^ ^)</string>
 	<!-- Message to display at the center of the screen when the country download has failed -->
 	<string name="country_status_download_failed">Laster ned mislyktes</string>
 	<!-- Button text for the button under the country_status_download_failed message -->
 	<string name="try_again">Prøv på nytt</string>
 	<string name="about_menu_title">Om Organic Maps</string>
-	<string name="downloaded_touch_to_delete">Lastet ned (%s) – trykk for å slette</string>
 	<string name="connection_settings">Tilkoblingsinnstillinger</string>
-	<string name="download_mb_or_kb">Last ned %s</string>
 	<string name="close">Lukk</string>
 	<string name="unsupported_phone">En maskinvareakselerert OpenGL kreves. Dessverre støttes ikke enheten din.</string>
 	<string name="download">Last ned</string>
-	<string name="external_storage_is_not_available">SD-kort/USB-enhet med nedlastede kart er ikke tilgjengelig</string>
 	<string name="disconnect_usb_cable">Koble fra USB-kabelen eller sett inn minnekortet for å bruke Organic Maps</string>
 	<string name="not_enough_free_space_on_sdcard">Frigjør plass på SD-kortet/USB-enheten først for å bruke appen</string>
 	<string name="not_enough_memory">Ikke nok minne til å starte appen</string>
 	<string name="download_resources">Før du begynner, la oss laste ned det generelle verdenskartet til enheten. Det trengs %s med data.</string>
-	<string name="getting_position">Henter nåværende posisjon</string>
 	<string name="download_resources_continue">Gå til kart</string>
 	<string name="downloading_country_can_proceed">Laster ned %s. Du kan nå\nfortsette til kartet.</string>
 	<string name="download_country_ask">Vil du laste ned %s?</string>
@@ -86,30 +68,20 @@
 	<string name="download_country_failed">Nedlasting av %s mislyktes</string>
 	<!-- Add New Bookmark Set dialog title -->
 	<string name="add_new_set">Legg til nytt sett</string>
-	<!-- Place Page - Add To Bookmarks button -->
-	<string name="add_to_bookmarks">Legg til i bokmerker</string>
 	<!-- Bookmark Color dialog title -->
 	<string name="bookmark_color">Bokmerk farge</string>
 	<!-- Add Bookmark Set dialog - hint when set name is empty -->
 	<string name="bookmark_set_name">Bokmerk settnavn</string>
-	<!-- Bookmark Sets dialog title -->
-	<string name="bookmark_sets">Bokmerk sett</string>
 	<!-- Bookmarks - dialog title -->
 	<string name="bookmarks">Bokmerker</string>
-	<!-- Add bookmark dialog - bookmark color -->
-	<string name="color">Farge</string>
 	<!-- Default bookmarks set name -->
 	<string name="core_my_places">Mine steder</string>
 	<!-- Add bookmark dialog - bookmark name -->
 	<string name="name">Navn</string>
 	<!-- Editor title above street and house number -->
 	<string name="address">Adresse</string>
-	<!-- Place Page - Remove Pin button -->
-	<string name="remove_pin">Fjern merke</string>
 	<!-- Add bookmark dialog - bookmark set, Bookmarks dialog - Bookmark set cell -->
 	<string name="set">Sett</string>
-	<!-- Text hint in Bookmarks dialog when no any bookmarks are added -->
-	<string name="bookmarks_usage_hint">Du har ingen bokmerker enda.\nTrykk på et hvilket som helst sted på kartet for å legge til et bokmerke.\nBokmerker fra andre kilder kan også importeres og vises i Organic Maps. Åpne KML-/KMZ-filer med lagrede bokmerker fra e-post, Dropbox eller internettkobling.</string>
 	<!-- Settings button in system menu -->
 	<string name="settings">Innstillinger</string>
 	<!-- Header of settings activity where user defines storage path -->
@@ -120,10 +92,6 @@
 	<string name="move_maps">Flytt kart?</string>
 	<!-- Ask to wait user several minutes (some long process in modal dialog). -->
 	<string name="wait_several_minutes">Dette kan ta flere minutter. Vent et øyeblikk …</string>
-	<!-- Show bookmarks from this category on a map or not -->
-	<string name="visible">Synlig</string>
-	<!-- Toast which is displayed when GPS has been deactivated -->
-	<string name="gps_is_disabled_long_text">GPS er deaktivert. Dette kan aktiveres i «Innstillinger».</string>
 	<!-- Measurement units title in settings activity -->
 	<string name="measurement_units">Måleenheter</string>
 	<!-- Detailed description of Measurement Units settings button -->
@@ -164,12 +132,8 @@
 	<string name="post">Post</string>
 	<!-- Search category -->
 	<string name="police">Politi</string>
-	<!-- String in search result list, when nothing found -->
-	<string name="no_search_results_found">Ingen resultater funnet</string>
 	<!-- Notes field in Bookmarks view -->
 	<string name="description">Merknader</string>
-	<!-- Button text -->
-	<string name="share_by_email">Del på e-post</string>
 	<!-- Email Subject when sharing bookmarks category -->
 	<string name="share_bookmarks_email_subject">Delte Organic Maps-bokmerker</string>
 	<!-- message title of loading file -->
@@ -182,20 +146,10 @@
 	<string name="edit">Rediger</string>
 	<!-- Warning message when doing search around current position -->
 	<string name="unknown_current_position">Posisjonen din har ikke blitt fastslått enda</string>
-	<!-- Warning message when location country isn't downloaded during search (see also download_location_map_proposal). -->
-	<string name="download_location_country">Last ned det landet du befinner deg i (%s)</string>
-	<!-- Warning message when viewport country isn't downloaded during search -->
-	<string name="download_viewport_country_to_search">Last ned det landet du søker på (%s)</string>
 	<!-- Alert message that we can't run Map Storage settings due to some reasons. -->
 	<string name="cant_change_this_setting">Beklager, innstillingene for kartlagring er for øyeblikket deaktivert.</string>
 	<!-- Alert message that downloading is in progress. -->
 	<string name="downloading_is_active">Nedlasting av land pågår nå.</string>
-	<!-- Message that will be shown in alert view, when we ask user to leave review on App Store -->
-	<string name="appStore_message">Håper du liker å bruke Organic Maps! Hvis du gjør det er det flott om du rangerer eller vurderer appen på App Store. Det tar deg mindre enn ett minutt, men kan virkelig hjelpe oss. Takk for støtten!</string>
-	<!-- No, thanks -->
-	<string name="no_thanks">Nei takk</string>
-	<!-- Share one specific bookmark using SMS, %1$@ contains om:// and %2$@ https://omaps.app link. @NOTE non-ascii symbols in the link will result in max 70 characters SMS instead of 140. -->
-	<string name="bookmark_share_sms">Hei, se merket mitt på Organic Maps! %1$s eller %2$s Har du ikke installert offline-kart? Last dem ned her: https://omaps.app/get</string>
 	<!-- Share my position using SMS, %1$@ contains om:// and %2$@ https://omaps.app link WITHOUT NAME. @NOTE non-ascii symbols in the link will result in max 70 characters SMS instead of 140. -->
 	<string name="my_position_share_sms">Hei, se posisjonen min på Organic Maps! %1$s eller %2$s Har du ikke offline-kart? Last dem ned her: https://omaps.app/get</string>
 	<!-- Subject for emailed bookmark -->
@@ -204,30 +158,16 @@
 	<string name="my_position_share_email_subject">Hei, se posisjonen min på Organic Maps-kartet!</string>
 	<!-- Share my position using EMail, %1$@ is om:// and %2$@ is https://omaps.app link WITHOUT NAME -->
 	<string name="my_position_share_email">Hei,Jeg er her nå: %1$s. Klikk på denne koblingen %2$s eller denne %3$s for å se stedet på kartet.\n\nTakk.</string>
-	<!-- Android share by Message/SMS button text (including SMS) -->
-	<string name="share_by_message">Del med melding</string>
 	<!-- Share button text which opens menu with more buttons, like Message, EMail, Facebook etc. -->
 	<string name="share">Del</string>
-	<!-- iOS share by Message button text (including SMS) -->
-	<string name="message">Melding</string>
 	<!-- Share by email button text, also used in editor. -->
 	<string name="email">E-post</string>
-	<!-- Copy Link -->
-	<string name="copy_link">Kopier kobling</string>
-	<!-- Text for the button that returns to caller application -->
-	<string name="more_info">Vis mer info</string>
 	<!-- Text for message when used successfully copied something -->
 	<string name="copied_to_clipboard">Kopiert til utklippstavlen: %1$s</string>
 	<!-- place preview title -->
 	<string name="info">Informasjon</string>
 	<!-- Used for bookmark editing -->
 	<string name="done">Ferdig</string>
-	<!-- Summary for preferences in MWM -->
-	<string name="yopme_pref_summary">Velg innstillinger for tilbakeskjerm</string>
-	<!-- Title for yopme preferences in MWM -->
-	<string name="yopme_pref_title">Innstillinger for tilbakeskjerm</string>
-	<!-- Hint for upper-right icon p2b -->
-	<string name="show_on_backscreen">Vis på tilbakeskjermen</string>
 	<!-- Prints version number in About dialog -->
 	<string name="version">Versjon: %s</string>
 	<!-- Confirmation in downloading countries dialog -->
@@ -237,11 +177,6 @@
 	<!-- Length of track in cell that describes route -->
 	<string name="length">Lengde</string>
 	<string name="share_my_location">Del posisjonen min</string>
-	<string name="menu_search">Søk</string>
-	<!-- Settings screen: "Map" category title -->
-	<string name="prefs_group_map">Kart</string>
-	<!-- Settings screen: "Miscellaneous" category title -->
-	<string name="prefs_group_misc">Diverse</string>
 	<string name="prefs_group_route">Navigasjon</string>
 	<string name="pref_zoom_title">Zoom-knapper</string>
 	<string name="pref_zoom_summary">Vis på skjermen</string>
@@ -257,8 +192,6 @@
 	<string name="pref_map_3d_title">Perspektivvisning</string>
 	<!-- Settings «Map» category: «3D buildings» title -->
 	<string name="pref_map_3d_buildings_title">Bygninger i 3D</string>
-	<!-- Settings «Map» category: «3D buildings» summary -->
-	<string name="pref_map_3d_buildings_subtitle">Påvirker batteriets levetid</string>
 	<!-- Settings «Route» category: «Tts enabled» title -->
 	<string name="pref_tts_enable_title">Taleinstrukser</string>
 	<!-- Settings «Route» category: «Tts language» title -->
@@ -267,7 +200,6 @@
 	<string name="pref_tts_unavailable">Ikke tilgjengelig</string>
 	<!-- Title for "Other" section in TTS settings. -->
 	<string name="pref_tts_other_section_title">Andre</string>
-	<string name="pref_tts_how_to_set_up_voice">Slik installerer du stemme</string>
 	<!-- Settings «Map» category: «Record track» title -->
 	<string name="pref_track_record_title">Siste rute</string>
 	<string name="pref_map_auto_zoom">Automatisk zooming</string>
@@ -278,40 +210,11 @@
 	<string name="duration_12_hours">12 timer</string>
 	<string name="duration_1_day">1 dag</string>
 	<string name="recent_track_help_text">Det lar deg lagre ruten du har reist i en spesifikk periode og se den på kartet. Merk: Aktivering av funksjonen øker batteriforbruket. Ruten fjernes automatisk fra kartet når tidsintervallet utløper.</string>
-	<string name="pref_track_ios_caption">Nylig rute viser ruten du har fulgt.</string>
-	<string name="pref_track_ios_subcaption">Velg en tidsperiode for rutelagring.</string>
-	<string name="placepage_distance">Avstand</string>
-	<string name="placepage_coordinates">Koordinater</string>
-	<string name="placepage_unsorted">Usortert</string>
 	<string name="search_show_on_map">Vis på kartet</string>
-	<!-- Used to warn user when fixing KitKat issue -->
-	<string name="bookmark_move_fail">Vi må flytte bokmerkene til internminnet, men det er ingen ledig plass til dem. Du må frigjøre minne, ellers vil ikke bokmerkene være tilgjengelige.</string>
-	<!-- 1st search button-like result -->
-	<string name="search_on_map">Søk på kartet</string>
-	<!-- toast with an error -->
-	<string name="no_route_found">Finner ingen rute</string>
-	<!-- route title -->
-	<string name="route">Rute</string>
-	<!-- category title -->
-	<string name="routes">Ruter</string>
-	<!-- text of notification -->
-	<string name="download_map_notification">Last ned kart over stedet der du befinner deg</string>
-	<!-- Dialog for transferring maps from lite to pro. -->
-	<string name="move_lite_maps_to_pro">Vi overfører dine nedlastede kart fra Organic Maps Lite til Organic Maps. Det kan ta noen minutter.</string>
-	<!-- Message to display when maps moved. -->
-	<string name="move_lite_maps_to_pro_ok">Nedlastede kart er overført til Organic Maps.</string>
-	<!-- Message to display when maps move failed. -->
-	<string name="move_lite_maps_to_pro_failed">Kartene dine ble ikke overført. Slett Organic Maps Lite og last ned kartene på nytt.</string>
-	<!-- Text in menu -->
-	<string name="settings_and_more">Innstillinger med mer</string>
 	<!-- Text in menu -->
 	<string name="website">Nettside</string>
-	<!-- Text in menu -->
-	<string name="contact_us">Kontakt oss</string>
 	<!-- Settings: Send feedback button and dialog title -->
 	<string name="feedback">Tilbakemelding</string>
-	<!-- Text in menu -->
-	<string name="subscribe_to_news">Abonner på nyheter fra oss</string>
 	<!-- Text in menu -->
 	<string name="rate_the_app">Ranger appen</string>
 	<!-- Text in menu -->
@@ -320,12 +223,6 @@
 	<string name="copyright">Opphavsrett</string>
 	<!-- Text in menu -->
 	<string name="report_a_bug">Rapporter en feil</string>
-	<!-- Email subject -->
-	<string name="subscribe_me_subject">Jeg vil abonnere på Organic Maps-nyhetsbrevet</string>
-	<!-- Email body -->
-	<string name="subscribe_me_body">Jeg ønsker å være den første som får vite om siste nytt og nye kampanjer. Jeg kan avbestille abonnementet når som helst.</string>
-	<!-- About text -->
-	<string name="about_text">Organic Maps tilbyr de raskeste offline-kartene over alle byer i alle land i verden. Reis trygt: Uansett hvor du er, kan Organic Maps hjelpe deg med å finne ut hvor du er på kartet eller finne nærmeste restaurant, hotell, bank, bensinstasjon osv. Det kreves ingen internettforbindelse.\n\nVi jobber alltid med å legge inn nye funksjoner, og vi vil gjerne høre hvordan du synes at vi kan forbedre Organic Maps. Hvis du får problemer med appen, ikke nøl med å kontakte oss på support\@organicmaps.app. Vi svarer på alle forespørsler!\n\nLiker du Organic Maps og ønsker å støtte oss? Det er noen enkle og helt gratis måter å gjøre det på:\n\n- Legg inn en vurdering på app-butikken\n- Lik Facebook-siden vår på http://www.facebook.com/OrganicMaps\n- Eller bare fortell mamma, venner og kolleger om Organic Maps :)\n\nTakk for at du er med oss. Vi setter stor pris på støtten!\n\nPS! Vi henter kartdata fra OpenStreetMap, et kartprosjekt som ligner på Wikipedia, der brukerne selv kan opprette og redigere kart. Hvis du finner mangler eller feil på kartet, kan du korrigere kartet direkte på https://www.openstreetmap.org, og endringene vil vises i Organic Maps-appen når neste versjon kommer.</string>
 	<!-- Alert text -->
 	<string name="email_error_body">E-postklienten har ikke blitt konfigurert. Konfigurer den eller bruk en annen måte å kontakte oss på %s</string>
 	<!-- Alert title -->
@@ -334,137 +231,56 @@
 	<string name="pref_calibration_title">Kompasskalibrering</string>
 	<!-- Search category -->
 	<string name="wifi">WiFi</string>
-	<!-- Update map suggestion -->
-	<string name="routing_map_outdated">Oppdater kartet for å opprette en rute</string>
-	<!-- Update maps suggestion -->
-	<string name="routing_update_maps">Med den nye versjonen av Organic Maps kan du opprette ruter fra din nåværende posisjon til et ankomststed på kartet. Oppdater kartene for å bruke denne funksjonen.</string>
 	<!-- Update all button text -->
 	<string name="downloader_update_all_button">Oppdater alle</string>
 	<!-- Cancel all button text -->
 	<string name="downloader_cancel_all">Avbryt alle</string>
 	<!-- Downloaded maps category -->
 	<string name="downloader_downloaded_subtitle">Lastet ned</string>
-	<!-- Downloaded maps category -->
-	<string name="downloader_available_maps">Tilgjengelig</string>
 	<!-- Country queued for download -->
 	<string name="downloader_queued">Lagt i kø</string>
 	<string name="downloader_near_me_subtitle">I nærheten</string>
 	<string name="downloader_status_maps">Kart</string>
 	<string name="downloader_download_all_button">Last ned alle</string>
 	<string name="downloader_downloading">Laster ned:</string>
-	<string name="downloader_search_results">Funnet</string>
-	<!-- Disclaimer message -->
-	<string name="routing_disclaimer">Når du oppretter ruter i Organic Maps-appen må du huske på følgende:\n\n- Foreslåtte ruter må bare betraktes som anbefalinger.\n- Veiforhold, trafikkregler og skilt må gis høyere prioritet enn navigasjonsråd.\n- Kartet kan være feil eller utdatert, og det er ikke sikkert at rutene opprettes på best mulig måte.\n\nVær nøye med veisikkerheten og pass på deg selv!</string>
-	<!-- Outdated maps category -->
-	<string name="downloader_outdated_maps">Utdatert</string>
-	<!-- Up to date maps category -->
-	<string name="downloader_uptodate_maps">Oppdatert</string>
 	<!-- Status of outdated country in the list -->
 	<string name="downloader_status_outdated">Oppdatering</string>
 	<!-- Status of failed country in the list -->
 	<string name="downloader_status_failed">Mislyktes</string>
 	<!-- Displayed in a dialog that appears when a user tries to delete a map while the app is in the follow route mode -->
 	<string name="downloader_delete_map_while_routing_dialog">Stans navigeringen for å slette kartet.</string>
-	<!-- Show when user try build route, but we don't know where he -->
-	<string name="routing_failed_unknown_my_position">Nåværende posisjon er udefinert. Oppgi en posisjon for å opprette en rute.</string>
-	<!-- Show if use has not routing file, or InconsistentMWMandRoute -->
-	<string name="routing_failed_has_no_routing_file">Tilleggsinformasjon som er nødvendig for å opprette ruter fra ditt ståsted.</string>
-	<!-- StartPointNotFound -->
-	<string name="routing_failed_start_point_not_found">Klarer ikke å beregne ruten. Ingen veier i nærheten av startpunktet.</string>
-	<!-- EndPointNotFound -->
-	<string name="routing_failed_dst_point_not_found">Klarer ikke å beregne ruten. Ingen veier i nærheten av reisemålet.</string>
 	<!-- PointsInDifferentMWM -->
 	<string name="routing_failed_cross_mwm_building">Det kan bare opprettes ruter som passer fullstendig innenfor ett enkelt kart.</string>
-	<!-- RouteNotFound -->
-	<string name="routing_failed_route_not_found">Finner ingen rute mellom valgt startsted og destinasjon. Velg et annet start- eller sluttpunkt.</string>
-	<!-- InternalError -->
-	<string name="routing_failed_internal_error">Det oppsto en intern feil. Prøv å slette og laste ned kartet på nytt. Hvis problemet vedvarer kan du kontakte oss på support\@organicmaps.app.</string>
-	<!-- Context menu item for downloader. -->
-	<string name="downloader_download_map_and_routing">Last ned kart + rutetilordning</string>
-	<!-- Context menu item for downloader. -->
-	<string name="downloader_download_routing">Last ned rutetilordning</string>
-	<!-- Context menu item for downloader. -->
-	<string name="downloader_delete_routing">Slett rutetilordning</string>
 	<!-- Context menu item for downloader. -->
 	<string name="downloader_download_map">Last ned kartet</string>
-	<string name="downloader_download_map_no_routing">Last ned kart uten veiviserfunksjon</string>
-	<!-- Button for routing. -->
-	<string name="routing_go">Kjør!</string>
 	<!-- Item status in downloader. -->
 	<string name="downloader_retry">Gjenta</string>
-	<!-- Item in context menu. -->
-	<string name="downloader_map_and_routing">Kart + rutetilordning</string>
 	<!-- Item in context menu. -->
 	<string name="downloader_delete_map">Slett kart</string>
 	<!-- Item in context menu. -->
 	<string name="downloader_update_map">Oppdater kart</string>
-	<!-- Item in context menu. -->
-	<string name="downloader_update_map_and_routing">Oppdater kart + rutetilordning</string>
-	<!-- Item in context menu. -->
-	<string name="downloader_map_only">Bare kart</string>
-	<!-- Toolbar title -->
-	<string name="toolbar_application_menu">Applikasjonsmeny</string>
 	<!-- Preference text -->
 	<string name="pref_use_google_play">Bruk Google Play Services for å hente din nåværende posisjon</string>
 	<!-- Text for rating dialog -->
 	<string name="rating_just_rated">Jeg har nettopp vurdert appen</string>
-	<!-- Text for rating dialog -->
-	<string name="rating_user_since">Jeg har vært Organic Maps-bruker siden %s</string>
-	<!-- Text for rating dialog -->
-	<string name="rating_do_like_maps">Liker du Organic Maps?</string>
-	<!-- Text for rating dialog -->
-	<string name="rating_tap_star">Trykk på en stjerne for å vurdere appen.</string>
 	<!-- Text for rating dialog -->
 	<string name="rating_thanks">Tusen takk!</string>
 	<!-- Text for rating dialog -->
 	<string name="rating_share_ideas">Del ideer med oss eller still spørsmål, slik at vi kan forbedre appen for deg.</string>
 	<!-- Text for rating dialog -->
 	<string name="rating_send_feedback">Send tilbakemelding</string>
-	<!-- Text for g+ dialog -->
-	<string name="rating_google_plus">Klikk på g+ for å fortelle vennene dine om denne appen.</string>
 	<!-- Text for routing error dialog -->
 	<string name="routing_download_maps_along">Last ned kart langs ruten</string>
-	<!-- Text for routing error dialog -->
-	<string name="routing_download_map">Skaff kart</string>
-	<!-- Text for routing error dialog -->
-	<string name="routing_download_map_and_routing">Last ned oppdatert kart og ruteinformasjon for å få alle Organic Maps funksjonene</string>
-	<!-- Text for routing error dialog -->
-	<string name="routing_get_routing_data">Skaff ruteinformasjon</string>
-	<!-- Text for routing error dialog -->
-	<string name="routing_get_additional_data">Tilleggsinformasjon som er nødvendig for å opprette ruter fra ditt ståsted.</string>
 	<!-- Text for routing error dialog -->
 	<string name="routing_requires_all_map">Når du skal opprette en rute må du ha oppdatert alle kartene fra ditt ståsted til din destinasjon.</string>
 	<!-- Text for routing error dialog -->
 	<string name="routing_not_enough_space">Ikke nok ledig minne</string>
-	<!-- Text for routing error dialog -->
-	<string name="routing_download_more_than_avail">Du vil laste ned %1$s MB, men du har kun %2$s MB tilgjengelig.</string>
-	<!-- Text for routing error dialog -->
-	<string name="routing_download_roaming">Du er på vei til å laste ned %s MB via mobildata (under \'roaming\'). Dette kan resultere i påløpende ekstragebyrer, avhengig av din mobiloperatørløsning.</string>
 	<!-- bookmark button text -->
 	<string name="bookmark">bokmerk</string>
-	<!-- map is not downloaded -->
-	<string name="not_found_map">Kartet for posisjonen din er ikke lastet ned</string>
 	<!-- location service disabled -->
 	<string name="enable_location_services">Aktiver posisjonstjenester</string>
-	<!-- download map -->
-	<string name="download_map">Last ned kartet for posisjonen din</string>
-	<!-- download map on iPhone -->
-	<string name="download_map_iphone">Last ned kartet for en aktuell posisjon til iPhone</string>
-	<!-- clear pin -->
-	<string name="nearby">I nærheten</string>
-	<!-- clear pin -->
-	<string name="clear_pin">Fjern merke</string>
-	<!-- location is undefined -->
-	<string name="undefined_location">Nåværende posisjon er udefinert.</string>
-	<!-- download country of your location -->
-	<string name="download_country">Last ned kartet for posisjonen din</string>
-	<!-- download failed -->
-	<string name="download_failed">Nedlasting mislyktes</string>
-	<!-- get the map -->
-	<string name="get_the_map">Hent kartet</string>
 	<string name="save">Lagre</string>
 	<string name="edit_description_hint">Dine beskrivelser (tekst eller html)</string>
-	<string name="new_group">ny gruppe</string>
 	<string name="create">opprett</string>
 	<!-- red color -->
 	<string name="red">Rød</string>
@@ -482,22 +298,6 @@
 	<string name="brown">Brun</string>
 	<!-- pink color -->
 	<string name="pink">Rosa</string>
-	<!-- deep purple color -->
-	<string name="deep_purple">Mørkepurpur</string>
-	<!-- light blue color -->
-	<string name="light_blue">Lyseblå</string>
-	<!-- cyan color -->
-	<string name="cyan">Blågrønn</string>
-	<!-- teal color -->
-	<string name="teal">Smaragdgrønn</string>
-	<!-- lime color -->
-	<string name="lime">Limegrønn</string>
-	<!-- deep orange color -->
-	<string name="deep_orange">Mørkeoransje</string>
-	<!-- gray color -->
-	<string name="gray">Grå</string>
-	<!-- blue gray color -->
-	<string name="blue_gray">Gråblå</string>
 	<!-- Wi-Fi available -->
 	<string name="WiFi_available">Ja</string>
 
@@ -513,10 +313,8 @@
 	<string name="dialog_routing_location_turn_wifi">Sjekk GPS-signalet. Resultatet blir mer nøyaktig når du bruker wi-fi.</string>
 	<string name="dialog_routing_location_turn_on">Aktiver stedstjenester</string>
 	<string name="dialog_routing_location_unknown_turn_on">Nåværende GPS-koordinater ble ikke funnet. Aktiver stedstjenester for å beregne en rute.</string>
-	<string name="dialog_routing_location_unknown">Nåværende GPS-koordinater ble ikke funnet.</string>
 	<string name="dialog_routing_download_files">Last ned nødvendige filer</string>
 	<string name="dialog_routing_download_and_update_all">Last ned og oppdater all kart- og ruteinformasjon langs den foreslåtte veien for å beregne ruten.</string>
-	<string name="dialog_routing_routes_size">Ruteinformasjonsfiler</string>
 	<string name="dialog_routing_unable_locate_route">Kunne ikke finne rute</string>
 	<string name="dialog_routing_cant_build_route">Kunne ikke finne rute.</string>
 	<string name="dialog_routing_change_start_or_end">Endre startpunkt eller bestemmelsessted.</string>
@@ -531,33 +329,23 @@
 	<string name="dialog_routing_system_error">Systemfeil</string>
 	<string name="dialog_routing_application_error">En applikasjonsfeil førte til at ruten ikke kunne opprettes.</string>
 	<string name="dialog_routing_try_again">Vennligst prøv igjen</string>
-	<string name="dialog_routing_send_error">Rapporter problemet</string>
-	<string name="dialog_routing_if_get_cross_route">Vil du opprette en mer direkte rute som går over flere kart?</string>
-	<string name="dialog_routing_cross_route_is_optimal">En mer optimal rute som går utenfor dette kartet er tilgjengelig.</string>
 	<string name="not_now">Ikke nå</string>
-	<string name="dialog_routing_build_route">Opprett</string>
 	<string name="dialog_routing_download_and_build_cross_route">Vil du laste ned kartet og lage en mer optimal rute som går over flere kart?</string>
 	<string name="dialog_routing_download_cross_route">Last ned kartet for å opprette en mer optimal rute som går utenfor dette kartet.</string>
-	<string name="dialog_routing_cross_route_always">Kryss alltid denne grensen</string>
 
 	<!-- SECTION: Strings for downloading map from search -->
 	<string name="search_without_internet_advertisement">Last vennligst ned kartet for å begynne å søke og opprette ruter - så slipper du i fremtiden å være avhengig av å ha internettforbindelse.</string>
 	<string name="search_select_map">Velg kartet</string>
-	<string name="search_select_other_map">Velg et annet kart</string>
 	<!-- «Show» context menu -->
 	<string name="show">Vis</string>
 	<!-- «Hide» context menu -->
 	<string name="hide">Skjul</string>
 	<!-- «Rename» context menu -->
 	<string name="rename">Nytt navn</string>
-	<!-- Bottom sheet: expand button (should be short) -->
-	<string name="bottom_sheet_more">Mer…</string>
 	<!-- Failed planning route message in navigation view -->
 	<string name="routing_planning_error">Mislykket ruteplanlegging</string>
 	<!-- Arrive routing message in navigation view -->
 	<string name="routing_arrive">Ankomme: %s</string>
-	<!-- Text for routing::RouterResultCode::FileTooOld dialog. -->
-	<string name="dialog_routing_download_and_update_maps">Hvis du vil oppprette en rute, last ned og oppdater alle kartene langs ruten.</string>
 	<string name="rate_alert_title">Liker du appen?</string>
 	<string name="rate_alert_default_message">Takk for at du bruker Organic Maps. Vi setter stor pris på om du rangerer appen. Tilbakemeldinger hjelper oss med å bli bedre.</string>
 	<string name="rate_alert_five_star_message">Hurra! Vi elsker deg også!</string>
@@ -565,24 +353,14 @@
 	<string name="rate_alert_less_than_four_star_message">Noen tanker om hvordan vi kan forbedre den?</string>
 	<string name="categories">Kategorier</string>
 	<string name="history">Historikk</string>
-	<string name="next_turn_then">Deretter</string>
 	<string name="closed">Stengt</string>
-	<string name="back_to">Tilbake til %s</string>
 	<string name="search_not_found">Beklager, jeg fant ingenting.</string>
 	<string name="search_not_found_query">Vennligst prøv et annet søk.</string>
-	<string name="search_not_found_map">Vennligst last ned kartet du søker i.</string>
-	<string name="search_not_found_location">Last ned kartet til din nåværende beliggenhet.</string>
 	<string name="search_history_title">Søkehistorikk</string>
 	<string name="search_history_text">Vis de siste søkene raskt.</string>
 	<string name="clear_search">Tøm søkehistorikk</string>
-	<!-- Title for settings to enable/disable showcase menu button -->
-	<string name="showcase_settings_title">Vis tilbud</string>
-	<string name="p2p_route_planning">Ruteplanlegging</string>
 	<string name="p2p_your_location">Din beliggenhet</string>
-	<string name="p2p_from">Avreisested</string>
-	<string name="p2p_to">Destinasjonssted</string>
 	<string name="p2p_start">Start</string>
-	<string name="p2p_planning">Planlegger…</string>
 	<string name="p2p_from_here">Fra</string>
 	<string name="p2p_to_here">Rute til</string>
 	<string name="p2p_only_from_current">Navigering er kun tilgjengelig fra din nåværende beliggenhet.</string>
@@ -602,11 +380,8 @@
 	<string name="editor_hours_closed">Stengt</string>
 	<string name="editor_example_values">Eksempelverdier</string>
 	<string name="editor_correct_mistake">Rett feil</string>
-	<string name="editor_correct_mistake_message">Du har gjort en redigeringsfeil. Rett den eller bytt til enkel modus.</string>
 	<string name="editor_add_select_location">Plassering</string>
 	<string name="editor_done_dialog_1">Du har endret verdenskartet. Ikke skjul denne! Fortell vennene dine, og rediger det sammen.</string>
-	<string name="editor_done_dialog_2">Dette er din andre forbedring av kartet. Nå er du på %d. plass i listen av kart-forbedrere. Fortell vennene dine om dette.</string>
-	<string name="editor_done_dialog_3">Du har forbedret kartet, fortell vennene dine om det, og rediger kartet sammen.</string>
 	<string name="share_with_friends">Del med venner</string>
 	<string name="editor_report_problem_desription_1">Beskriv problemet detaljert slik at OpenStreetMap-samfunnet kan fikse feilen.</string>
 	<string name="editor_report_problem_desription_2">Eller gjør det selv på https://www.openstreetmap.org/</string>
@@ -615,14 +390,7 @@
 	<string name="editor_report_problem_no_place_title">Stedet finnes ikke</string>
 	<string name="editor_report_problem_under_construction_title">Stengt pga. vedlikehold</string>
 	<string name="editor_report_problem_duplicate_place_title">Duplisert sted</string>
-	<string name="first_launch_congrats_title">Organic Maps er klar til bruk</string>
-	<string name="first_launch_congrats_text">Søk og naviger i frakoblet status, hvor som helst i verden, helt gratis.</string>
-	<string name="migrate_title">Viktig!</string>
-	<!-- Android uses image instead of text. -->
-	<string name="download_all">Last ned alle</string>
-	<string name="delete_all">Slett alle</string>
 	<string name="autodownload">Automatisk nedlasting</string>
-	<string name="disable_autodownload">Deaktiver automatisk nedlasting</string>
 	<!-- Place Page opening hours text -->
 	<string name="closed_now">Lukket nå</string>
 	<!-- Place Page opening hours text -->
@@ -631,8 +399,6 @@
 	<string name="day_off_today">Fridag i dag</string>
 	<string name="day_off">Fridag</string>
 	<string name="today">I dag</string>
-	<string name="sunrise_to_sunset">Fra morgen til kveld</string>
-	<string name="sunset_to_sunrise">Fra solnedgang til soloppgang</string>
 	<string name="add_opening_hours">Legg til åpningstider</string>
 	<string name="edit_opening_hours">Rediger åpningstider</string>
 	<string name="no_osm_account">Har du ingen konto hos OpenStreetMap?</string>
@@ -642,29 +408,13 @@
 	<string name="login">Logg inn</string>
 	<string name="password">Passord</string>
 	<string name="forgot_password">Glemt passordet?</string>
-	<!-- Forgot Password dialog title -->
-	<string name="restore_password">Gjenopprett passordet</string>
-	<string name="enter_email_address_to_reset_password">Skriv inn e-postadressen du brukte ved registreringen, så vil vi sende deg en kobling for å fornye passordet ditt.</string>
-	<string name="reset_password">Tilbakestill passord</string>
-	<string name="username">Brukernavn</string>
 	<string name="osm_account">OSM-konto</string>
 	<string name="logout">Logg ut</string>
-	<string name="login_and_edit_map_motivation_message">Logg deg inn og rediger informasjonen til objektene på kartet, så vil vi gjøre den tilgjengelig for millioner av andre brukere. La oss gjøre verden bedre sammen.</string>
 	<!-- Information text: "Last upload 11.01.2016" -->
 	<string name="last_upload">Siste opplasting</string>
-	<!-- Motivates user to login/register, title above login buttons. -->
-	<string name="you_have_edited_your_first_object">Du har redigert ditt første objekt!</string>
 	<string name="thank_you">Takk skal du ha</string>
-	<string name="login_with_google">Logg inn med Google</string>
-	<string name="login_with_openstreetmap">Logg inn med www.openstreetmap.org</string>
 	<string name="edit_place">Rediger stedet</string>
 	<string name="place_name">Stedsnavn</string>
-	<!-- title above languages list cells in the editor, below editable name text field. -->
-	<string name="other_languages">Andre språk</string>
-	<!-- small button to open list with names in different languages -->
-	<string name="show_more">Vis mer</string>
-	<!-- small button to close list with names in different languages -->
-	<string name="show_less">Vis mindre</string>
 	<string name="add_language">Legg til et språk</string>
 	<string name="street">Gate</string>
 	<!-- Editable House Number text field (in address block). -->
@@ -681,25 +431,16 @@
 	<string name="email_or_username">E-postadresse eller brukernavn</string>
 	<string name="phone">Telefon</string>
 	<string name="please_note">Vær oppmerksom på at</string>
-	<string name="common_no_wifi_dialog">Ingen trådløs forbindelse. Vil du fortsette med mobildata?</string>
 	<string name="downloader_delete_map_dialog">Alle endringer i kartet vil slettes sammen med kartet.</string>
 	<string name="downloader_update_maps">Oppdater kart</string>
 	<string name="downloader_mwm_migration_dialog">For å opprette en reiserute må du oppdatere alle kartene og deretter planlegge reiseruten på nytt.</string>
 	<string name="downloader_search_field_hint">Finn kartet</string>
-	<string name="migration_update_all_button">Oppdater alle kart</string>
-	<string name="migration_delete_all_download_current_button">Last ned det oppdaterte kartet og slett de gamle</string>
 	<string name="migration_download_error_dialog">Nedlastningsfeil</string>
 	<string name="common_check_internet_connection_dialog">Kontroller innstillingene dine og sørg for at enheten din er koblet til internett.</string>
 	<string name="downloader_no_space_title">Ikke nok plass</string>
 	<string name="downloader_no_space_message">Fjern unødvendig data</string>
-	<string name="editor_general_auth_error_dialog">Generell innloggingsfeil.</string>
 	<string name="editor_login_error_dialog">Innloggingsfeil.</string>
-	<string name="editor_login_failed_dialog">Innloggingen mislyktes</string>
-	<string name="editor_username_error_dialog">Brukernavnet er ugyldig</string>
-	<string name="editor_place_edited_dialog">Du har redigert et objekt!</string>
-	<string name="editor_login_with_osm">Logg inn med OpenStreetMat</string>
 	<string name="editor_profile_changes">Bekreftede endringer</string>
-	<string name="editor_profile_unsent_changes">Ikke sendt:</string>
 	<string name="editor_focus_map_on_location">Dra kartet for å velge riktig beliggenhet for objektet.</string>
 	<string name="editor_add_select_category">Velg kategori</string>
 	<string name="editor_add_select_category_popular_subtitle">Populære</string>
@@ -710,19 +451,14 @@
 	<string name="editor_edit_place_category_title">Kategori</string>
 	<string name="detailed_problem_description">Detaljert beskrivelse av problemet</string>
 	<string name="editor_report_problem_other_title">Et annet problem</string>
-	<string name="placepage_report_problem_button">Rapporter et problem</string>
 	<string name="placepage_add_business_button">Legg til organisasjon</string>
 	<string name="whatsnew_editor_message_1">Legg til nye steder i kartet og rediger eksisterende steder direkte fra appen.</string>
-	<string name="whatsnew_editor_message_2">* Organic Maps bruker data fra OpenStreetMap-samfunnet.</string>
 	<string name="dialog_incorrect_feature_position">Endre plassering</string>
 	<string name="message_invalid_feature_position">Et objekt kan ikke plasseres her</string>
 	<string name="login_to_make_edits_visible">Logg inn slik at andre brukere kan se endringene du har utført.</string>
-	<string name="no_migration_during_navigation">Det er ikke mulig å oppdatere under navigering.</string>
 	<!-- Error dialog no space -->
 	<string name="migration_no_space_message">Du må frigjøre mer lagringsplass for å laste ned. Slett unødvendig data.</string>
 	<string name="editor_sharing_title">Jeg har forbedret Organic Maps kartene</string>
-	<string name="editor_comment_will_be_sent">Vi vil sende kommentaren din til kartografene.</string>
-	<string name="editor_unsupported_category_message">Du har lagt til et sted i en kategori som enda ikke har støtte. Den vil vises på kartet senere.</string>
 	<!-- Downloaded 10 **of** 20 <- it is that "of" -->
 	<string name="downloader_of">%1$d av %2$d</string>
 	<string name="error_enter_correct_house_number">Skriv riktig husnummer</string>
@@ -738,15 +474,8 @@
 	<string name="editor_detailed_description">De foreslåtte endringene vil sendes til OpenStreetMap-gruppen. Beskriv detaljene som ikke kan redigeres i Organic Maps.</string>
 	<string name="editor_more_about_osm">Mer om OpenStreetMap</string>
 	<string name="editor_operator">Eier</string>
-	<string name="editor_tag_description">Angi firma, organisasjon eller enkeltperson som er ansvarlig for anlegget.</string>
-	<string name="editor_no_local_edits_title">Du har ikke lokale redigeringer</string>
-	<string name="editor_no_local_edits_description">Dette viser antallet foreslåtte endringer på kartet som i øyeblikket bare er tilgjengelige på enheten din.</string>
-	<string name="editor_send_to_osm">Send til OSM</string>
-	<string name="editor_remove">Fjern</string>
-	<string name="downloader_my_maps_title">Mine kart</string>
 	<string name="downloader_no_downloaded_maps_title">Du har ikke lastet ned noen kart</string>
 	<string name="downloader_no_downloaded_maps_message">Last ned kart for å finne plasseringen og navigere frakoblet.</string>
-	<string name="downloader_find_place_hint">Søk etter by eller land</string>
 	<!-- Error title that appears after certain time without location. -->
 	<string name="current_location_unknown_title">Fortsette å oppdage din gjeldende plassering?</string>
 	<!-- Error that appears after certain time without location. -->
@@ -761,27 +490,10 @@
 	<string name="location_services_disabled_2">2. Trykk Lokalisering</string>
 	<!-- iOS Dialog for the case when the location permission is not granted -->
 	<string name="location_services_disabled_3">3.Velg når appen er i bruk</string>
-	<string name="placepage_parking_surface">Åpen plass</string>
-	<string name="placepage_parking_multistorey">Fleretasjers</string>
-	<string name="placepage_parking_underground">Undergrunns</string>
-	<string name="placepage_parking_rooftop">På taket</string>
-	<string name="placepage_parking_sheds">Skur</string>
-	<string name="placepage_parking_carports">Carport</string>
-	<string name="placepage_parking_boxes">Garasjebokser</string>
-	<string name="placepage_parking_pay">Betaling</string>
-	<string name="placepage_parking_free">Gratis</string>
-	<string name="placepage_parking_interval">Intervallbetaling</string>
-	<string name="placepage_entrance_number">Nr.</string>
-	<string name="placepage_entrance_type">Vindfang</string>
-	<string name="placepage_flat">leil.</string>
-	<string name="placepage_open_24_7">Døgnåpen</string>
 	<string name="meter">m</string>
 	<string name="kilometer">km</string>
-	<string name="kilometers_per_hour">km/t</string>
 	<string name="mile">mi</string>
 	<string name="foot">fot</string>
-	<string name="miles_per_hour">mph</string>
-	<string name="day">d</string>
 	<string name="hour">t</string>
 	<string name="minute">min</string>
 	<string name="placepage_place_description">Beskrivelse</string>
@@ -791,46 +503,30 @@
 	<string name="placepage_call_button">Ring</string>
 	<string name="placepage_edit_bookmark_button">Rediger bokmerke</string>
 	<string name="placepage_bookmark_name_hint">Bokmerkenavn</string>
-	<string name="placepage_personal_notes_hint">Personlige notater</string>
-	<string name="placepage_delete_bookmark_button">Slett bokmerke</string>
 	<string name="editor_edits_sent_message">De foreslåtte endringene er sendt</string>
 	<string name="editor_comment_hint">Kommentar…</string>
 	<string name="editor_reset_edits_message">Nullstille alle lokale endringer?</string>
 	<string name="editor_reset_edits_button">Nullstill</string>
 	<string name="editor_remove_place_message">Fjerne et tilføyd sted?</string>
 	<string name="editor_remove_place_button">Fjern</string>
-	<string name="editor_status_sending">Sender…</string>
 	<string name="editor_place_doesnt_exist">Sted finnes ikke</string>
 	<string name="text_more_button">…mer</string>
 	<!-- Phone number error message -->
 	<string name="error_enter_correct_phone">Skriv riktig telefonnummer</string>
 	<string name="error_enter_correct_web">Oppgi en gyldig nettadresse</string>
 	<string name="error_enter_correct_email">Oppgi en gyldig epostadresse</string>
-	<string name="error_enter_correct">Oppgi en gyldig verdi</string>
 	<string name="refresh">Oppdatere</string>
-	<string name="last_update">Sist oppdatert: %s</string>
 	<string name="placepage_add_place_button">Legg til en plass på kartet</string>
 	<!-- Displayed when saving some edits to the map to warn against publishing personal data -->
 	<string name="editor_share_to_all_dialog_title">Vil du sende det til alle brukere?</string>
 	<!-- iOS Dialog before publishing the modifications to the public map. -->
 	<string name="editor_share_to_all_dialog_message_1">Sørg for at du ikke har skrevet noe personlig informasjon.</string>
 	<string name="editor_share_to_all_dialog_message_2">Vi vil sjekke endringene. Vi kontakter deg via e-post dersom vi har spørsmål.</string>
-	<string name="navigation_overview_button">oversikt</string>
-	<string name="navigation_stop_button">stopp</string>
-	<!-- Text on an empty bookmark page -->
-	<string name="bookmarks_empty_title">Lagre bokmerker</string>
-	<string name="bookmarks_empty_message_1">Trykk på ★ for å lagre favorittsteder og få rask tilgang.</string>
-	<string name="bookmarks_empty_message_2">Importer bokmerker fra e-post og nettet.</string>
-	<string name="bookmarks_empty_message_3">sjekk ut: %s</string>
-	<!-- Name of the group for booked hotels -->
-	<string name="bookmarks_group_name">Bestilte hoteller</string>
-	<string name="place_page_button_read_descriprion">Les</string>
 	<!-- iOS dialog for the case when recent track recording is on and the app comes back from background -->
 	<string name="recent_track_background_dialog_title">Deaktivere opptak av nylig reiste rute?</string>
 	<string name="off_recent_track_background_button">Deaktiver</string>
 	<!-- For sharing via SMS and so on -->
 	<string name="sharing_call_action_look">Sjekk ut</string>
-	<string name="continue_recent_track_background_button">Fortsett</string>
 	<string name="recent_track_background_dialog_message">Organic Maps bruker geografiske funksjoner i bakgrunnen for å registrere din nylig reiste rute.</string>
 	<!-- Rate on Google Play (Android only) -->
 	<string name="rate_gp">Gi vurdering på Google Play</string>
@@ -840,21 +536,11 @@
 	<string name="tell_friends_text">Hei! Installer Organic Maps!</string>
 	<!-- About short text (below logo) -->
 	<string name="about_description">Organic Maps er en offline app for reising. Organic Maps bygger på OpenStreetMap-data og tillater redigering av den.</string>
-	<!-- Text in menu -->
-	<string name="blog">Blogg</string>
 	<string name="general_settings">Generelle innstillinger</string>
-	<string name="date">Dato %d</string>
-	<!-- "Report a bug" -> "Generaal Feedback" -> "Something is not working" -->
-	<string name="something_is_not_working">Noe fungerer ikke som det skal</string>
 	<!-- For the first routing -->
 	<string name="accept">Godta</string>
 	<!-- For the first routing -->
 	<string name="decline">Avvis</string>
-	<string name="install_app">Installer</string>
-	<string name="search_no_results_title">Fant ingen resultater</string>
-	<string name="search_no_results_message">Prøv et mer generelt søkeord, zoom ut eller tilbakestill filteret.</string>
-	<string name="search_no_results_expand_area_button">Zoom ut</string>
-	<string name="search_no_results_reset_button">Tilbakestill filter</string>
 	<!-- noun -->
 	<string name="search_in_table">Liste</string>
 	<string name="mobile_data_dialog">Bruke mobilt Internett til å vise detaljert informasjon?</string>
@@ -866,18 +552,13 @@
 	<string name="mobile_data_option_never">Aldri bruk</string>
 	<string name="mobile_data_option_ask">Alltid spør</string>
 	<string name="traffic_update_maps_text">For å vise trafikkdata må kartene i appen være oppdaterte.</string>
-	<string name="traffic_outdated">Trafikkdata er utdatert.</string>
 	<string name="big_font">Forstørr skriften på kartet</string>
 	<string name="traffic_update_app">Vennligst oppdater Organic Maps</string>
 	<!-- "traffic" as in road congestion -->
 	<string name="traffic_update_app_message">Du må oppdatere applikasjonen for å kunne se trafikkdata.</string>
 	<!-- "traffic" as in "road congestion" -->
 	<string name="traffic_data_unavailable">Trafikkdata er ikke tilgjengelig</string>
-	<!-- Simplified colour scheme for traffic information, fewer colours are used to display traffic jams on the map. The string should be kept as short as possible -->
-	<string name="pref_traffic_simplified_colors_title">Enkelt trafikkfargeoppsett</string>
 	<string name="enable_logging">Aktiver loggføring</string>
-	<string name="offline_place_page_more_information">Koble til internett for å få mer informasjon om stedet.</string>
-	<string name="failed_load_information">Kunne ikke laste inn informasjon.</string>
 	<!-- Settings: "Send general feedback" button -->
 	<string name="feedback_general">Generell tilbakemelding</string>
 	<string name="on">På</string>
@@ -891,57 +572,26 @@
 	<string name="routing_add_start_point">Angi startpunkt for å planlegge rute</string>
 	<string name="routing_add_finish_point">Angi sluttpunkt for å planlegge rute</string>
 	<string name="button_exit">Avslutt</string>
-	<string name="settings_device_memory">Enhetsminnet</string>
-	<string name="settings_card_memory">Minnekort</string>
-	<string name="settings_storage_available">%s tilgjengelig</string>
-	<string name="toast_location_permission_denied">App-plasseringstillatelse avvist</string>
-	<string name="button_use">Bruk</string>
 	<string name="planning_route_manage_route">Administrere rute</string>
 	<string name="button_plan">Planlegge</string>
-	<string name="button_add">Angi</string>
 	<string name="placepage_remove_stop">Fjern</string>
 	<string name="planning_route_remove_title">Dra hit for å fjerne</string>
-	<string name="dialog_change_start_point_message">Plassére startpunkt til nåværende plassering?</string>
-	<string name="button_replace">Plassére</string>
 	<string name="placepage_add_stop">Angi stopp</string>
-	<string name="add_my_position">Legg til min posisjon</string>
-	<string name="choose_start_point">Velg startpunkt</string>
-	<string name="choose_destination">Velg destinasjon</string>
 	<string name="preloader_viator_button">Finn ut mer</string>
-	<string name="start_from_my_position">Start fra</string>
-	<string name="profile_authorization_title">Logg inn med</string>
-	<string name="profile_authorization_message">Enkel innlogging uten innloggingsinfo og passord på bare noen sekunder</string>
 	<string name="profile_authorization_error">Oops, en feil oppstod. Prøv å logge inn på nytt.</string>
-	<string name="service">Service</string>
-	<string name="atmosphere">Atmosfære</string>
-	<string name="value_for_money">Valuta for pengene</string>
-	<string name="experience">Erfaren</string>
-	<string name="assortment">Utvalg</string>
-	<string name="expertise">Kompetanse</string>
-	<string name="equipment">Utstyr</string>
-	<string name="quality">Kvalitet</string>
 	<string name="dialog_error_storage_title">Problemer med tilgang til lagring</string>
 	<string name="dialog_error_storage_message">Ekstern lagring er ikke tilgjengelig. Sannsynligvis er SD-kortet fjernet eller skadet eller så er filsystemet skrivebeskyttet. Undersøk og kontakt oss på support\@organicmaps.app</string>
 	<string name="setting_emulate_bad_storage">Emulere skadet lagring</string>
-	<string name="directions_finish">Destinasjon</string>
-	<string name="directions_on_foot">Gå %s</string>
 	<string name="core_entrance">Inngang</string>
-	<string name="coffee">Kaffe</string>
-	<string name="cleanliness">Renslighet</string>
-	<string name="crowdedness">Mye folk</string>
 	<string name="error_enter_correct_name">Skriv inn korrekt navn</string>
 	<string name="bookmarks_groups">Lister</string>
 	<string name="bookmarks_groups_hide_all">Skjul alle</string>
 	<string name="bookmarks_groups_show_all">Vis alle</string>
-	<plurals name="bookmarks_places">
-	  <item quantity="other">%d bokmerker</item>
-	</plurals>
 	<string name="bookmarks_create_new_group">Opprett ny liste</string>
 	<string name="downloader_hide_screen">Skjul skjerm</string>
 	<string name="downloader_percent">%1$s (%2$s av %3$s)</string>
-	<string name="downloader_process">Laster ned %s ...</string>
-	<string name="downloader_applying">Bruker %s ...</string>
-	<string name="dialog_message_transit_not_found_connection">Planlegg en rute innenfor transittnettverket</string>
+	<string name="downloader_process">Laster ned %s …</string>
+	<string name="downloader_applying">Bruker %s …</string>
 	<string name="bookmarks_error_message_share_general">Kan ikke dele på grunn av en programfeil</string>
 	<string name="bookmarks_error_title_share_empty">Delingsfeil</string>
 	<string name="bookmarks_error_message_share_empty">Kan ikke dele en tom liste</string>
@@ -950,12 +600,7 @@
 	<string name="bookmarks_new_list_hint">Ny liste</string>
 	<string name="bookmarks_error_title_list_name_already_taken">Dette navnet er allerede tatt</string>
 	<string name="bookmarks_error_message_list_name_already_taken">Vennligst velg et annet navn</string>
-	<string name="bookmarks_error_title_list_name_too_long">Dette navnet er for langt</string>
-	<string name="bookmarks_error_message_list_name_too_long">Vennligst velg et annet navn</string>
-	<string name="please_wait">Vennligst vent...</string>
-	<string name="phone_number">Telefonnummer</string>
-	<string name="notification_unsent_reviews_title">Du har flere usendte anmeldelser</string>
-	<string name="notification_unsent_reviews_message">Vennligst logg inn for å dele anmeldelser med andre reisende</string>
+	<string name="please_wait">Vennligst vent…</string>
 	<string name="profile">OpenStreetMap profil</string>
 	<string name="place_page_search_similar_hotel">Søk lignende hoteller</string>
 	<string name="bookmarks_detect_title">Nye filer oppdaget</string>
@@ -966,52 +611,26 @@
 	<string name="button_convert">Konvertere</string>
 	<string name="bookmarks_convert_error_title">Feil</string>
 	<string name="bookmarks_convert_error_message">Noen filer ble ikke konvertert.</string>
-	<string name="converting">Konvertere...</string>
-	<string name="wn_reinvented_bookmarks_title">Vi gjenoppfunnet bokmerker!</string>
-	<string name="wn_reinvented_bookmarks_message">Du kan sikkerhetskopiere bokmerker, lage lister... Det er utrolig...</string>
-	<string name="bookmarks_restore">Gjenopprett bokmerker</string>
-	<string name="bookmarks_restore_process">Gjenopprette...</string>
 	<string name="bookmarks_restore_title">Gjenopprett denne versjonen?</string>
-	<string name="bookmarks_restore_message">Bokmerkene dine gjenopprettes fra %1$s (%2$s)</string>
-	<string name="bookmarks_restore_empty_title">Du har ikke en sikkerhetskopi</string>
-	<string name="bookmarks_restore_empty_message">Serveren fant ikke tidligere sikkerhetskopier</string>
 	<string name="common_check_internet_connection_dialog_title">Ingen internettforbindelse</string>
-	<string name="error_server_title">Serverfeil</string>
-	<string name="error_server_message">Det oppsto en feil på serveren, prøv igjen senere</string>
 	<string name="error_system_message">En ukjent feil oppstod</string>
 	<string name="restore">Restaurere</string>
-	<string name="sharing_options">Delemuligheter</string>
 	<string name="export_file">Eksporter fil</string>
 	<string name="list_settings">Liste Innstillinger</string>
 	<string name="delete_list">Slett liste</string>
-	<string name="hide_from_map">Skjul fra kart</string>
 	<string name="public_access">Offentlig tilgang</string>
 	<string name="limited_access">Begrenset adgang</string>
 	<string name="bookmark_category_name">Kategori</string>
 	<string name="bookmark_category_description_hint">Lag en beskrivelse (text or html)</string>
 	<string name="not_shared">Privat</string>
-	<string name="direct_link_progress_text">Laster opp filen din…</string>
-	<string name="direct_link_success">Lenken er opprettet</string>
-	<string name="send_a_link_btn">Send meg en link</string>
-	<string name="upload_error_toast">Det oppsto en feil under opplasting av filen</string>
 	<string name="tags_loading_error_subtitle">Det oppsto en feil under lasting av emneknagger, prøv igjen</string>
-	<string name="unable_upload_errorr_title">Filopplasting mislyktes</string>
-	<string name="unable_upload_error_subtitle_edited">Denne filen har blitt redigert via nettappappen</string>
-	<string name="unable_upload_error_subtitle_broken">Denne filen er skadet og kan ikke lastes opp. Vennligst last opp en annen fil.</string>
-	<string name="contact">Kontakt</string>
-	<string name="download_button">Last ned</string>
 	<string name="speedcams_alert_title">Fartskamera</string>
-	<string name="speedcams_alert_subtitle">Advar om fartsgrenser</string>
 	<string name="speedcam_option_auto">Auto</string>
 	<string name="speedcam_option_always">Alltid</string>
 	<string name="speedcam_option_never">Aldri</string>
-	<string name="bookmark_description_title">Beskrivelse av bokmerke</string>
 	<string name="place_description_title">Plasser beskrivelse</string>
 	<!-- this text will be shown in application notification preferences opposite checkbox which enable/disable downloader notifications. Devices on Android 8+ are affected. -->
 	<string name="notification_channel_downloader">Nedlast kart</string>
-	<string name="share_bookmarks_email_body_link">Hei!\n\nHer er lenken der du kan laste ned bokmerkene dine: %s. Åpne listen via Organic Maps og nyt reisen!\n\nFå tak i app: https://omaps.app/get?kmz</string>
-	<string name="warning_speedcams_title">Navigatøren vil advare deg om kameraer når du overskrider fartsgrensen på %d km/t</string>
-	<string name="warning_speedcams_subtitle">Vær oppmerksom på kjøreregler for landet du reiser til.</string>
 	<string name="speedcams_notice_message">Auto - Advarsel om fartskamera hvis det er fare for å overskride fartsgrensen\nAlltid - Advar alltid om farskameraer\nAldri - Advar aldri om fartskameraer</string>
 	<string name="power_managment_title">Strømsparemodus</string>
 	<string name="power_managment_description">Når automatisk modus er valgt, begynner programmet å deaktivere batteridriftfunksjonene avhengig av det nåværende batterinivået</string>
@@ -1019,14 +638,7 @@
 	<string name="power_managment_setting_auto">Automatisk</string>
 	<string name="power_managment_setting_manual_max">Maksimum strømsparing</string>
 	<string name="enable_logging_warning_message">Alternativet slår på logging for diagnostiske formål. Det kan være nyttig for våre supportpersonale som feilsøker problemer med appen. Aktiver dette alternativet bare på forespørsel fra Organic Maps-brukerstøtte.</string>
-	<string name="html_error_upload_message_try_again">Vennligst sjekk nettverksinnstillingene og prøv igjen</string>
-	<string name="html_error_upload_title_try_again">Ingen internettforbindelse</string>
-	<string name="notification_leave_review_v2_android_short_title">Anmeld og hjelp reisende!</string>
-	<string name="notifications_illegal_alert_disable_button">Skru av notefikasjoner</string>
 	<string name="access_rules_author_only">Redigering på nett</string>
-	<string name="privacy_settings_menu">Pesonverninstillinger</string>
-	<string name="unable_upadate_error_title">Feil ved fil-oppdatering</string>
-	<string name="unable_upadate_error_message">Feil oppstod ved oppdatering. Sjekk forandringer og prøv igjen</string>
 	<string name="driving_options_title">Kjørealternativer</string>
 	<string name="driving_options_subheader">Unngå ved hver rute</string>
 	<string name="avoid_tolls">Bompengeveier</string>
@@ -1037,52 +649,14 @@
 	<string name="unable_to_calc_alert_subtitle">Dessverre kunne vi ikke finne en rute sannsynligvis på grunn av dine definerte alternativer. Vennligst endre innstillingene og prøv igjen</string>
 	<string name="define_to_avoid_btn">Definer veier som skal unngås</string>
 	<string name="change_driving_options_btn">Kjørealternativer aktivert</string>
-	<string name="toll_road">Bompengevei</string>
-	<string name="unpaved_road">Uasfaltert vei</string>
-	<string name="ferry_crossing">Fergeovergang</string>
-	<string name="operated_by">Bemannet av \"%s\"</string>
 	<string name="avoid_toll_roads_placepage">Unngå bompengeveier</string>
 	<string name="avoid_unpaved_roads_placepage">Unngå uasfalterte veier</string>
 	<string name="avoid_ferry_crossing_placepage">Unngå fergeoverganger</string>
-	<string name="type.cuisine.uzbek">Usbekisk mat</string>
-	<string name="trip_start">La oss begynne</string>
-	<string name="pick_destination">Destinasjon</string>
-	<string name="follow_my_position">Sentrer</string>
-	<string name="search_results">Søkeresultater</string>
-	<string name="then_turn">Deretter</string>
-	<string name="redirect_route_alert">Vil du planlegge en rute på nytt?</string>
-	<string name="redirect_route_yes">Ja</string>
-	<string name="redirect_route_no">Nei</string>
-	<string name="trip_finished">Du har ankommet!</string>
-	<string name="keyboard_availability_alert">Tastatur er ikke tilgjengelig mens en kjører</string>
-	<string name="dialog_routing_change_start_carplay">Kan ikke planlegge rute fra din nåværende posisjon</string>
-	<string name="dialog_routing_change_end_carplay">Kan ikke planlegge rute til din nåværende posisjon. Vennligst velg en annen posisjon</string>
-	<string name="dialog_routing_check_gps_carplay">Ingen GPS-signal. Vennligst gå til et åpent område</string>
-	<string name="dialog_routing_unable_locate_route_carplay">Kan ikke planlegge rute. Vennligst spesifiser en annen posisjon for rute</string>
-	<string name="dialog_routing_download_files_carplay">For å beregne rute last ned manglende kart på enheten din</string>
-	<string name="dialog_routing_system_error_carplay">Feil oppstod. Vennligst restart appen</string>
-	<string name="dialog_routing_rebuild_from_current_location_carplay">Rute vil planlegges fra din nåværende posisjon</string>
-	<string name="dialog_routing_rebuild_for_vehicle_carplay">Rute vil oppdateres til kjørerute</string>
 	<string name="ok">Ok</string>
-	<string name="avoid_unpaved_carplay_1">Ikke grusvei</string>
-	<string name="avoid_unpaved_carplay_2">Ikke uasfaltert</string>
-	<string name="avoid_ferry_carplay_1">Ingen ferger</string>
-	<string name="avoid_ferry_carplay_2">Unngå ferger</string>
-	<string name="avoid_tolls_carplay_1">Ingen bomvei</string>
-	<string name="avoid_tolls_carplay_2">Unngå bomvei</string>
-	<string name="speedcams_alert_title_carplay_1">Kamera-info</string>
-	<string name="speedcams_alert_title_carplay_2">Kamera-advarsel</string>
-	<string name="download_map_carplay">Vennligst last ned kart i Organic Maps appen på enheten din</string>
-	<string name="carplay_roundabout_exit">%s avkjøring</string>
 	<!-- max. 10 symbols, both iOS and Android -->
 	<string name="sort">Sortere…</string>
 	<!-- Android, title, max 20-22 symbols -->
 	<string name="sort_bookmarks">Sortere merker</string>
-	<!-- iOS -->
-	<string name="sort_default">Sortere som standard</string>
-	<string name="sort_type">Sortere etter type</string>
-	<string name="sort_distance">Sortere etter avstand</string>
-	<string name="sort_date">Sortere etter dato</string>
 	<!-- Android -->
 	<string name="by_default">Som standard</string>
 	<!-- Android -->
@@ -1091,65 +665,23 @@
 	<string name="by_distance">Etter avstand</string>
 	<!-- Android -->
 	<string name="by_date">Etter dato</string>
-	<string name="week_ago_sorttype">For en uke siden</string>
-	<string name="month_ago_sorttype">For en måned siden</string>
-	<string name="moremonth_ago_sorttype">Mer enn en måned siden</string>
-	<string name="moreyear_ago_sorttype">Mer enn ett år siden</string>
-	<string name="near_me_sorttype">Nær meg</string>
-	<string name="others_sorttype">Andre</string>
-	<string name="food_places">Mat</string>
-	<string name="tourist_places">Severdigheter</string>
-	<string name="museums">Museer</string>
-	<string name="parks">Parker</string>
-	<string name="swim_places">Svømming</string>
-	<string name="mountains">Fjell</string>
-	<string name="animals">Dyr</string>
-	<string name="hotels">Hoteller</string>
-	<string name="buildings">Bygninger</string>
-	<string name="money">Penger</string>
-	<string name="shops">Butikker</string>
-	<string name="parkings">Parkeringer</string>
-	<string name="fuel_places">Bensinstasjoner</string>
-	<string name="water">Vann</string>
-	<string name="medicine">Medisin</string>
 	<string name="search_in_the_list">Søk på lista</string>
-	<string name="view_on_map_bookmarks">På kartet</string>
-	<string name="more_bookmarks">Mer…</string>
-	<string name="no_items_found">Ingenting funnet</string>
-	<!-- Android, max 18 symbols -->
-	<string name="bookmarks_edit_list">Endre</string>
-	<!-- Android, max 18 symbols -->
-	<string name="bookmarks_delete_list">Slette lista</string>
-	<string name="religious_places">Hellige steder</string>
 	<string name="select_list">Velge liste</string>
 	<string name="transit_not_found">T-bane navigasjon er ikke tilgjengelig i denne regionen ennå</string>
 	<string name="dialog_pedestrian_route_is_long_header">T-bane rute ikke funnet</string>
 	<string name="dialog_pedestrian_route_is_long_message">Velg utgangspunkt eller destinasjon som befinner seg nærmere en T-bane stasjon</string>
-	<!-- Failed planning SUBWAY route message in navigation view -->
-	<string name="routing_planning_error_subway_special">Feil ved ruteplanlegging</string>
 	<string name="button_layer_isolines">Høyder</string>
-	<string name="tips_map_layers_title_countour">Høydekurver uten nett med Organic Maps!</string>
-	<string name="tips_map_layers_message_countour">Høydekurver hjelper deg å planlegge turen din og ikke gå seg vill</string>
 	<string name="isolines_activation_error_dialog">For å bruke høydekurver oppdater eller last opp kartet til nødvendig område</string>
 	<string name="isolines_location_error_dialog">Høydekurver er ikke tilgjengelige i dette området ennå</string>
 	<string name="elevation_profile_diff_level">Vanskelighetsgrad</string>
-	<string name="elevation_profile_diff_level_easy">Lett</string>
-	<string name="elevation_profile_diff_level_moderate">Middels</string>
-	<string name="elevation_profile_diff_level_hard">Vanskelig</string>
 	<string name="elevation_profile_ascent">Stigning</string>
 	<string name="elevation_profile_descent">Nedstigning</string>
 	<string name="elevation_profile_minaltitude">Min. høyde</string>
 	<string name="elevation_profile_maxaltitude">Maks. høyde</string>
-	<string name="elevation_profile_m">m</string>
 	<string name="elevation_profile_difficulty">Vanskelighet</string>
 	<string name="elevation_profile_distance">Avstand:</string>
-	<string name="elevation_profile_km">km</string>
 	<string name="elevation_profile_time">I rute</string>
-	<string name="elevation_profile_hours">t.</string>
-	<string name="elevation_profile_minutes">min</string>
 	<string name="isolines_toast_zooms_1_10">Forstørr kartet for å se høydekurver</string>
-	<string name="downloader_updating_ios">Oppdatering</string>
-	<string name="downloader_loading_ios">Nedlasting</string>
 	<string name="key_information_title">Nøkkelinformasjon</string>
 	<string name="enable_screen_sleep">La skjermen sove</string>
 	<!-- Description in preferences -->

--- a/android/res/values-nl/strings.xml
+++ b/android/res/values-nl/strings.xml
@@ -12,15 +12,11 @@
 	<string name="cancel_download">Download annuleer</string>
 	<!-- Button which deletes downloaded country -->
 	<string name="delete">Verwijder</string>
-	<!-- Button "do not interrupt download" if user touched actively downloading country -->
-	<string name="do_nothing">Doorgaan</string>
 	<string name="download_maps">Gedownloade Kaarten</string>
 	<!-- Settings/Downloader - info for country when download fails -->
 	<string name="download_has_failed">Download is afgebroken, klik om nog een keer te proberen</string>
 	<!-- Settings/Downloader - info for country which started downloading -->
 	<string name="downloading">Downloaden…</string>
-	<!-- Settings/Downloader - size string, only strings different from English should be translated -->
-	<string name="kb">KB</string>
 	<!-- Choose measurement on first launch alert - choose metric system button -->
 	<string name="kilometres">Kilometers</string>
 	<!-- Leave Review dialog - Review button -->
@@ -31,44 +27,30 @@
 	<string name="miles">Mijlen</string>
 	<!-- View and button titles for accessibility -->
 	<string name="core_my_position">Mijn Locatie</string>
-	<!-- Don't show some dialog any more -->
-	<string name="never">Nooit</string>
 	<!-- View and button titles for accessibility -->
 	<string name="search">Zoeken</string>
 	<!-- Search box placeholder text -->
 	<string name="search_map">Zoek Kaart</string>
-	<!-- Settings/Downloader - info for not downloaded country -->
-	<string name="touch_to_download">Klik om te downloaden</string>
 	<!-- Settings/Downloader - 3G download warning dialog confirm button -->
 	<string name="use_cellular_data">Ja</string>
 	<!-- Location services are disabled by user alert - message -->
 	<string name="location_is_disabled_long_text">U heeft momenteel alle Locatie Services voor dit apparaat of deze app uitgeschakeld. Schakel ze in bij Instellingen</string>
-	<!-- Location Services are not available on the device alert - message -->
-	<string name="device_doesnot_support_location_services">Uw apparaat ondersteunt geen Locatie Services</string>
 	<!-- View and button titles for accessibility -->
 	<string name="zoom_to_country">Op de kaart tonen</string>
-	<!-- Button text for the button at the center of the screen when the country is not downloaded -->
-	<string name="country_status_download">Kaart downloaden\n(^ ^)</string>
 	<!-- Button text for the button at the center of the screen when the country is not downloaded and the size should not be shown -->
 	<string name="country_status_download_without_size">Kaart downloaden</string>
-	<!-- Button text for the button at the center of the screen when the country is not downloaded -->
-	<string name="country_status_download_without_routing">Download kaart\nzonder routeplanning (^ ^)</string>
 	<!-- Message to display at the center of the screen when the country download has failed -->
 	<string name="country_status_download_failed">Downloaden is niet gelukt</string>
 	<!-- Button text for the button under the country_status_download_failed message -->
 	<string name="try_again">Probeer opnieuw</string>
 	<string name="about_menu_title">Over Organic Maps</string>
-	<string name="downloaded_touch_to_delete">Downloaded (%s), klik om te verwijderen</string>
 	<string name="connection_settings">Verbindingsinstellingen</string>
-	<string name="download_mb_or_kb">Download %s</string>
 	<string name="close">Sluiten</string>
 	<string name="unsupported_phone">Een hardware geaccellereerde OpenGL is nodig. Jammer genoeg wordt uw apparaat niet ondersteund.</string>
-	<string name="external_storage_is_not_available">SD kaart/USB opslag met gedownloade kaarten is niet beschikbaar</string>
 	<string name="disconnect_usb_cable">Verwijder de USB kabel of plaats een geheugen kaart om Organic Maps te gebruiken</string>
 	<string name="not_enough_free_space_on_sdcard">Maak eerst ruimte vrij op de SD kaart/USB opslag om de app te gebruiken</string>
 	<string name="not_enough_memory">Not genoeg geheugen om app te starten</string>
 	<string name="download_resources">Voor u van start gaat downloaden we een wereldkaart naar uw apparaat.\nDe kaart neemt %s in beslag.</string>
-	<string name="getting_position">Huidige locatie opvragen</string>
 	<string name="download_resources_continue">Ga naar de Kaart</string>
 	<string name="downloading_country_can_proceed">%s aan het downloaden. U kunt doorgaan\nnaar de kaart</string>
 	<string name="download_country_ask">%s downloaden?</string>
@@ -81,30 +63,20 @@
 	<string name="download_country_failed">%s download is afgebroken</string>
 	<!-- Add New Bookmark Set dialog title -->
 	<string name="add_new_set">Voeg nieuwe Groep toe</string>
-	<!-- Place Page - Add To Bookmarks button -->
-	<string name="add_to_bookmarks">Toevoegen aan Bladwijzers</string>
 	<!-- Bookmark Color dialog title -->
 	<string name="bookmark_color">Bladwijzer Kleur</string>
 	<!-- Add Bookmark Set dialog - hint when set name is empty -->
 	<string name="bookmark_set_name">Bladwijzer Groep Naam</string>
-	<!-- Bookmark Sets dialog title -->
-	<string name="bookmark_sets">Bladwijzer groepen</string>
 	<!-- Bookmarks - dialog title -->
 	<string name="bookmarks">Bladwijzers</string>
-	<!-- Add bookmark dialog - bookmark color -->
-	<string name="color">Kleur</string>
 	<!-- Default bookmarks set name -->
 	<string name="core_my_places">Mijn Plaatsen</string>
 	<!-- Add bookmark dialog - bookmark name -->
 	<string name="name">Naam</string>
 	<!-- Editor title above street and house number -->
 	<string name="address">Adres</string>
-	<!-- Place Page - Remove Pin button -->
-	<string name="remove_pin">Verwijder speld</string>
 	<!-- Add bookmark dialog - bookmark set, Bookmarks dialog - Bookmark set cell -->
 	<string name="set">Groep</string>
-	<!-- Text hint in Bookmarks dialog when no any bookmarks are added -->
-	<string name="bookmarks_usage_hint">Je hebt nog geen bladwijzers.\nTik op een plek op de kaart om een bladwijzer toe te voegen.\nBladwijzers uit andere bronnen kunnen ook worden geïmporteerd en weergegeven in de Organic Maps app. Open KML/KMZ bestand met opgeslagen speldjes uit mail, Dropbox of weblink.</string>
 	<!-- Settings button in system menu -->
 	<string name="settings">Instellingen</string>
 	<!-- Header of settings activity where user defines storage path -->
@@ -115,20 +87,10 @@
 	<string name="move_maps">Kaarten verplaatsen?</string>
 	<!-- Ask to wait user several minutes (some long process in modal dialog). -->
 	<string name="wait_several_minutes">Dit kan enkele minuten duren.\nEven geduld…</string>
-	<!-- Show bookmarks from this category on a map or not -->
-	<string name="visible">Zichtbaar</string>
-	<!-- Toast which is displayed when GPS has been deactivated -->
-	<string name="gps_is_disabled_long_text">GPS is uitgeschakeld. Schakel ze in bij Instellingen.</string>
 	<!-- Measurement units title in settings activity -->
 	<string name="measurement_units">Afstandseenheid</string>
 	<!-- Detailed description of Measurement Units settings button -->
 	<string name="measurement_units_summary">Kies tussen mijlen en kilometers</string>
-	<!-- Do search in all sources -->
-	<string name="search_mode_all">Overal</string>
-	<!-- Do search near my position only -->
-	<string name="search_mode_nearme">Dichtbij mij</string>
-	<!-- Do search in current viewport only -->
-	<string name="search_mode_viewport">Op het scherm</string>
 	<!-- Search category for cafes, bars, restaurants -->
 	<string name="eat">Waar iets gaan eten</string>
 	<!-- Search category for grocery stores -->
@@ -165,12 +127,8 @@
 	<string name="post">Post</string>
 	<!-- Search category -->
 	<string name="police">Politie</string>
-	<!-- String in search result list, when nothing found -->
-	<string name="no_search_results_found">Geen resultaten gevonden</string>
 	<!-- Notes field in Bookmarks view -->
 	<string name="description">Notities</string>
-	<!-- Button text -->
-	<string name="share_by_email">Delen via email</string>
 	<!-- Email Subject when sharing bookmarks category -->
 	<string name="share_bookmarks_email_subject">Bladwijzers van Organic Maps met u gedeeld</string>
 	<!-- message title of loading file -->
@@ -183,20 +141,10 @@
 	<string name="edit">Wijzigen</string>
 	<!-- Warning message when doing search around current position -->
 	<string name="unknown_current_position">Je plaats werd nog niet vastgesteld</string>
-	<!-- Warning message when location country isn't downloaded during search (see also download_location_map_proposal). -->
-	<string name="download_location_country">Download land waar je nu bent (%s)</string>
-	<!-- Warning message when viewport country isn't downloaded during search -->
-	<string name="download_viewport_country_to_search">Download land waar je op wilt zoeken (%s)</string>
 	<!-- Alert message that we can't run Map Storage settings due to some reasons. -->
 	<string name="cant_change_this_setting">Sorry, instellingen voor kaartopslag uitgeschakeld.</string>
 	<!-- Alert message that downloading is in progress. -->
 	<string name="downloading_is_active">Het downloaden van het land is nu aan de gang.</string>
-	<!-- Message that will be shown in alert view, when we ask user to leave review on App Store -->
-	<string name="appStore_message">Ik hoop dat u veel plezier hebt met Organic Maps! Zo ja, geef de app dan een cijfer in de App Store of schrijf een recensie. Dit duurt minder dan een minuut, maar kan ons echt helpen. Bedankt voor uw steun!</string>
-	<!-- No, thanks -->
-	<string name="no_thanks">Nee, bedankt</string>
-	<!-- Share one specific bookmark using SMS, %1$@ contains om:// and %2$@ https://omaps.app link. @NOTE non-ascii symbols in the link will result in max 70 characters SMS instead of 140. -->
-	<string name="bookmark_share_sms">Bekijk mijn pin op de kaart. Open %1$s of %2$s</string>
 	<!-- Share my position using SMS, %1$@ contains om:// and %2$@ https://omaps.app link WITHOUT NAME. @NOTE non-ascii symbols in the link will result in max 70 characters SMS instead of 140. -->
 	<string name="my_position_share_sms">Kijk waar ik nu ben. Open %1$s of %2$s</string>
 	<!-- Subject for emailed bookmark -->
@@ -205,30 +153,16 @@
 	<string name="my_position_share_email_subject">Kijk naar mijn huidige locatie op Organic Maps kaart</string>
 	<!-- Share my position using EMail, %1$@ is om:// and %2$@ is https://omaps.app link WITHOUT NAME -->
 	<string name="my_position_share_email">Hoi,\n\nMomenteel ben ik hier: %1$s. Klik op deze %2$s of deze %3$s om de plaats op de kaart te zien.\n\nBedankt.</string>
-	<!-- Android share by Message/SMS button text (including SMS) -->
-	<string name="share_by_message">Delen via bericht</string>
 	<!-- Share button text which opens menu with more buttons, like Message, EMail, Facebook etc. -->
 	<string name="share">Delen</string>
-	<!-- iOS share by Message button text (including SMS) -->
-	<string name="message">Bericht</string>
 	<!-- Share by email button text, also used in editor. -->
 	<string name="email">Email</string>
-	<!-- Copy Link -->
-	<string name="copy_link">Kopieer koppeling</string>
-	<!-- Text for the button that returns to caller application -->
-	<string name="more_info">Toon meer info</string>
 	<!-- Text for message when used successfully copied something -->
 	<string name="copied_to_clipboard">Op het klembord gekopieerd: %1$s</string>
 	<!-- place preview title -->
 	<string name="info">Info</string>
 	<!-- Used for bookmark editing -->
 	<string name="done">Gedaan</string>
-	<!-- Summary for preferences in MWM -->
-	<string name="yopme_pref_summary">Kies instellingen voor achtergrondscherm</string>
-	<!-- Title for yopme preferences in MWM -->
-	<string name="yopme_pref_title">Instellingen voor achtergrondscherm</string>
-	<!-- Hint for upper-right icon p2b -->
-	<string name="show_on_backscreen">Toon op achtergrondscherm</string>
 	<!-- Prints version number in About dialog -->
 	<string name="version">Versie: %s</string>
 	<!-- Confirmation in downloading countries dialog -->
@@ -238,11 +172,6 @@
 	<!-- Length of track in cell that describes route -->
 	<string name="length">Lengte</string>
 	<string name="share_my_location">Deel mijn locatie</string>
-	<string name="menu_search">Zoek</string>
-	<!-- Settings screen: "Map" category title -->
-	<string name="prefs_group_map">Kaart</string>
-	<!-- Settings screen: "Miscellaneous" category title -->
-	<string name="prefs_group_misc">Diversen</string>
 	<string name="prefs_group_route">Navigatie</string>
 	<string name="pref_zoom_title">Zoomknoppen</string>
 	<string name="pref_zoom_summary">Weergave op het scherm</string>
@@ -258,8 +187,6 @@
 	<string name="pref_map_3d_title">Perspectiefbeeld</string>
 	<!-- Settings «Map» category: «3D buildings» title -->
 	<string name="pref_map_3d_buildings_title">3D-gebouwen</string>
-	<!-- Settings «Map» category: «3D buildings» summary -->
-	<string name="pref_map_3d_buildings_subtitle">Beïnvloedt batterijduur</string>
 	<!-- Settings «Route» category: «Tts enabled» title -->
 	<string name="pref_tts_enable_title">Gesproken instructies</string>
 	<!-- Settings «Route» category: «Tts language» title -->
@@ -268,7 +195,6 @@
 	<string name="pref_tts_unavailable">Niet beschikbaar</string>
 	<!-- Title for "Other" section in TTS settings. -->
 	<string name="pref_tts_other_section_title">Andere</string>
-	<string name="pref_tts_how_to_set_up_voice">Hoe stel je de stem in</string>
 	<!-- Settings «Map» category: «Record track» title -->
 	<string name="pref_track_record_title">Recente route</string>
 	<string name="pref_map_auto_zoom">Automatisch zoomen</string>
@@ -279,46 +205,11 @@
 	<string name="duration_12_hours">12 uur</string>
 	<string name="duration_1_day">1 dag</string>
 	<string name="recent_track_help_text">Dit laat u toe het afgelegde traject voor een bepaalde periode te registreren en te bekijken op de kaart. Merk op: activatie van deze functie veroorzaakt een hoger batterijverbruik. Het traject wordt automatisch van de kaart verwijderd nadat het tijdsinterval verloopt.</string>
-	<string name="pref_track_ios_caption">Recente route geeft uw gebruikte route weer.</string>
-	<string name="pref_track_ios_subcaption">Selecteer de tijdperiode voor het opslaan van route.</string>
-	<string name="placepage_distance">Afstand</string>
-	<string name="placepage_coordinates">Coördinaten</string>
-	<string name="placepage_unsorted">Ongeclassificeerd</string>
 	<string name="search_show_on_map">Op kaart bekijken</string>
-	<!-- Used to warn user when fixing KitKat issue -->
-	<string name="bookmark_move_fail">We moeten uw bladwijzers naar het interne geheugen verplaatsen, maar er is geen ruimte beschikbaar voor ze. Maak alstublieft geheugen vrij, anders zullen de bladwijzers niet beschikbaar zijn.</string>
-	<!-- Used in More Apps menu -->
-	<string name="free">Gratis</string>
-	<!-- Used in More Apps menu -->
-	<string name="buy">Koop</string>
-	<!-- 1st search button-like result -->
-	<string name="search_on_map">Op kaart zoeken</string>
-	<!-- toast with an error -->
-	<string name="no_route_found">Geen route gevonden</string>
-	<!-- route title -->
-	<string name="route">Route</string>
-	<!-- category title -->
-	<string name="routes">Routes</string>
-	<!-- text of notification -->
-	<string name="download_map_notification">Download de kaart van de plaats waar u bent</string>
-	<!-- text of notification -->
-	<string name="pro_version_is_free_today">Volledige versie van Organic Maps is nu gratis! Download nu en vertel het je vrienden.</string>
-	<!-- Dialog for transferring maps from lite to pro. -->
-	<string name="move_lite_maps_to_pro">We verplaatsen uw gedownloade kaarten van Organic Maps Lite naar Organic Maps. Dit kan enkele minuten duren.</string>
-	<!-- Message to display when maps moved. -->
-	<string name="move_lite_maps_to_pro_ok">Uw gedownloade kaarten werden met succes verplaatst naar Organic Maps.</string>
-	<!-- Message to display when maps move failed. -->
-	<string name="move_lite_maps_to_pro_failed">Verplaatsing van uw kaarten mislukt. Gelieve Organic Maps Lite te verwijderen en de kaarten opnieuw te downloaden.</string>
-	<!-- Text in menu -->
-	<string name="settings_and_more">Instellingen &amp; meer</string>
 	<!-- Text in menu -->
 	<string name="website">Website</string>
-	<!-- Text in menu -->
-	<string name="contact_us">Contact met ons opnemen</string>
 	<!-- Settings: Send feedback button and dialog title -->
 	<string name="feedback">Feedback</string>
-	<!-- Text in menu -->
-	<string name="subscribe_to_news">Aanmelden voor onze nieuwtjes</string>
 	<!-- Text in menu -->
 	<string name="rate_the_app">App beoordelen</string>
 	<!-- Text in menu -->
@@ -327,12 +218,6 @@
 	<string name="copyright">Auteursrechten</string>
 	<!-- Text in menu -->
 	<string name="report_a_bug">Meld een fout</string>
-	<!-- Email subject -->
-	<string name="subscribe_me_subject">Ik meld mij aan voor de nieuwsbrief Organic Maps</string>
-	<!-- Email body -->
-	<string name="subscribe_me_body">Ik wil graag als eerste horen over het laatste nieuws updates en acties. Ik kan mijn abonnement te allen tijde annuleren.</string>
-	<!-- About text -->
-	<string name="about_text">Organic Maps biedt de snelste offline kaarten van alle steden en alle landen ter wereld. Reis vol vertrouwen: waar je ook bent,\n\nOrganic Maps zal je helpen om jezelf op de kaart terug te vinden en het dichstbijzijnde restaurant, hotel, bank, benzinestation etc. te vinden. Er is geen internetverbinding voor nodig.\n\nWe werken voortdurend aan nieuwe functies en we zouden graag van je willen horen hoe we Organic Maps volgens jou zouden kunnen verbeteren. Als je eventueel problemen hebt met de app, aarzel dan niet om contact met ons op te nemen op support\@organicmaps.app. We reageren op elke aanvraag!\n\nVindt je Organic Maps leuk en wil je ons steunen? Dat kan op een aantal simpele en absoluut gratis manieren:\n- plaats een beoordeling op je App Market\n- like onze Facebook-pagina http://www.facebook.com/OrganicMaps\n- of vertel gewoon je ma, vrienden en collega’s over Organic Maps :) Dank je dat je ons steunt. Wij waarderen dit heel erg!\n\nP.S. We halen onze kaartgegevens van OpenStreetMap, een kaartproject dat lijkt op Wikipedia, waarbij gebruikers kaarten kunnen maken en aanpassen. Als je ziet dat er iets ontbreekt of een fout ontdekt in een kaart, dan kun je de kaart direct verbeteren op https://www.openstreetmap.org, en dan zullen je verbeteringen bij het uitbrengen van de volgende versie in Organic Maps verschijnen.</string>
 	<!-- Alert text -->
 	<string name="email_error_body">De emailcliënt is niet ingesteld. Gelieve de cliënt te configureren of op een andere manier contact met ons op te nemen op %s</string>
 	<!-- Alert title -->
@@ -341,137 +226,56 @@
 	<string name="pref_calibration_title">Kompascalibratie</string>
 	<!-- Search category -->
 	<string name="wifi">WiFi</string>
-	<!-- Update map suggestion -->
-	<string name="routing_map_outdated">Werk de kaart bij om een route te maken.</string>
-	<!-- Update maps suggestion -->
-	<string name="routing_update_maps">Met de nieuwe versie van Organic Maps kunt u routes maken vanaf uw huidige positie naar een punt van bestemming. Werk kaarten bij om deze functie te gebruiken.</string>
 	<!-- Update all button text -->
 	<string name="downloader_update_all_button">Update alles</string>
 	<!-- Cancel all button text -->
 	<string name="downloader_cancel_all">Alles annuleren</string>
 	<!-- Downloaded maps category -->
 	<string name="downloader_downloaded_subtitle">Gedownload</string>
-	<!-- Downloaded maps category -->
-	<string name="downloader_available_maps">Beschikbaar</string>
 	<!-- Country queued for download -->
 	<string name="downloader_queued">In de wachtrij</string>
 	<string name="downloader_near_me_subtitle">Bij mij in de buurt</string>
 	<string name="downloader_status_maps">Kaarten</string>
 	<string name="downloader_download_all_button">Alles downloaden</string>
 	<string name="downloader_downloading">Aan het downloaden:</string>
-	<string name="downloader_search_results">Gevonden</string>
-	<!-- Disclaimer message -->
-	<string name="routing_disclaimer">Bij het creëren van routes in Organic Maps-app, dient u rekening te houden met het volgende:\n\n  - Voorgestelde routes kunnen uitsluitend als aanbevelingen beschouwd worden.\n - Wegconditie, verkeersregels en borden hebben een hogere prioriteit dan het navigatie-advies.\n - De kaart kan onjuist of verouderd zijn en de routes kunnen niet op de beste mogelijke manier gecreëerd zijn.\n\n  Wees veilig op wegen en zorg goed voor uzelf!</string>
-	<!-- Outdated maps category -->
-	<string name="downloader_outdated_maps">Verouderd</string>
-	<!-- Up to date maps category -->
-	<string name="downloader_uptodate_maps">Up-to-date</string>
 	<!-- Status of outdated country in the list -->
 	<string name="downloader_status_outdated">Bijwerken</string>
 	<!-- Status of failed country in the list -->
 	<string name="downloader_status_failed">Mislukt</string>
 	<!-- Displayed in a dialog that appears when a user tries to delete a map while the app is in the follow route mode -->
 	<string name="downloader_delete_map_while_routing_dialog">Stop de navigatie om de kaart te verwijderen.</string>
-	<!-- Show when user try build route, but we don't know where he -->
-	<string name="routing_failed_unknown_my_position">Huidige locatie is niet gedefinieerd. Gelieve de locatie te specificeren om de route te creëren.</string>
-	<!-- Show if use has not routing file, or InconsistentMWMandRoute -->
-	<string name="routing_failed_has_no_routing_file">Er zijn extra gegevens nodig om een ​​route te creëren. Beginnen met downloaden?</string>
-	<!-- StartPointNotFound -->
-	<string name="routing_failed_start_point_not_found">Kan de route niet berekenen. Geen wegen in de buurt van uw beginpunt.</string>
-	<!-- EndPointNotFound -->
-	<string name="routing_failed_dst_point_not_found">Kan de route niet berekenen. Geen wegen in de buurt van uw bestemming.</string>
 	<!-- PointsInDifferentMWM -->
 	<string name="routing_failed_cross_mwm_building">Slechts de routes die volledig opgenomen zijn in één kaart kunnen gecreëerd worden.</string>
-	<!-- RouteNotFound -->
-	<string name="routing_failed_route_not_found">Er is geen route gevonden tussen het geselecteerde beginpunt en de bestemming. Gelieve een andere beginpunt of een eindbestemming te kiezen.</string>
-	<!-- InternalError -->
-	<string name="routing_failed_internal_error">Er is een interne fout opgetreden. Probeer het kaart te verwijderen en opnieuw te downloaden. Indien het probleem blijft optreden, neem dan contact met ons op support\@organicmaps.app.</string>
-	<!-- Context menu item for downloader. -->
-	<string name="downloader_download_map_and_routing">Download kaart + routering</string>
-	<!-- Context menu item for downloader. -->
-	<string name="downloader_download_routing">Download routering</string>
-	<!-- Context menu item for downloader. -->
-	<string name="downloader_delete_routing">Verwijder routering</string>
 	<!-- Context menu item for downloader. -->
 	<string name="downloader_download_map">Download de kaart</string>
-	<string name="downloader_download_map_no_routing">Download kaart zonder routeplanning</string>
-	<!-- Button for routing. -->
-	<string name="routing_go">Starten!</string>
 	<!-- Item status in downloader. -->
 	<string name="downloader_retry">Herhalen</string>
-	<!-- Item in context menu. -->
-	<string name="downloader_map_and_routing">Kaart + route</string>
 	<!-- Item in context menu. -->
 	<string name="downloader_delete_map">Kaart verwijderen</string>
 	<!-- Item in context menu. -->
 	<string name="downloader_update_map">Kaart bijwerken</string>
-	<!-- Item in context menu. -->
-	<string name="downloader_update_map_and_routing">Kaart bijwerken + route</string>
-	<!-- Item in context menu. -->
-	<string name="downloader_map_only">Alleen de kaart</string>
-	<!-- Toolbar title -->
-	<string name="toolbar_application_menu">Applicatiemenu</string>
 	<!-- Preference text -->
 	<string name="pref_use_google_play">Gebruik de diensten van Google Play om uw huidige locatie te bepalen</string>
 	<!-- Text for rating dialog -->
 	<string name="rating_just_rated">Ik heb je app zojuist gewaardeerd</string>
-	<!-- Text for rating dialog -->
-	<string name="rating_user_since">Ik ben een Organic Maps-gebruiker vanaf %s</string>
-	<!-- Text for rating dialog -->
-	<string name="rating_do_like_maps">Vind je Organic Maps leuk?</string>
-	<!-- Text for rating dialog -->
-	<string name="rating_tap_star">Druk op een ster om onze app te waarderen.</string>
 	<!-- Text for rating dialog -->
 	<string name="rating_thanks">Dank je!</string>
 	<!-- Text for rating dialog -->
 	<string name="rating_share_ideas">Deel alle ideeën of problemen zodat we de app voor je kunnen verbeteren.</string>
 	<!-- Text for rating dialog -->
 	<string name="rating_send_feedback">Feedback verzenden</string>
-	<!-- Text for g+ dialog -->
-	<string name="rating_google_plus">Klik op g+ om je vrienden te informeren over de app.</string>
 	<!-- Text for routing error dialog -->
 	<string name="routing_download_maps_along">Download kaarten op de route</string>
-	<!-- Text for routing error dialog -->
-	<string name="routing_download_map">Krijg kaart</string>
-	<!-- Text for routing error dialog -->
-	<string name="routing_download_map_and_routing">Download bijgewerkte kaart en routegegevens om alle functies van Organic Maps te krijgen.</string>
-	<!-- Text for routing error dialog -->
-	<string name="routing_get_routing_data">Krijg routegegevens</string>
-	<!-- Text for routing error dialog -->
-	<string name="routing_get_additional_data">Aanvullende gegevens die nodig zijn om routes te maken vanaf uw locatie.</string>
 	<!-- Text for routing error dialog -->
 	<string name="routing_requires_all_map">Voor het creëren van een route is het nodig dat alle kaarten van uw locatie naar uw bestemming gedownload en bijgewerkt zijn.</string>
 	<!-- Text for routing error dialog -->
 	<string name="routing_not_enough_space">Niet genoeg ruimte</string>
-	<!-- Text for routing error dialog -->
-	<string name="routing_download_more_than_avail">U dient %1$s MB te downloaden, maar er is slechts %2$s MB beschikbaar.</string>
-	<!-- Text for routing error dialog -->
-	<string name="routing_download_roaming">U gaat %s MB downloaden met behulp van mobiele data (roaming). Dit kan leiden tot extra kosten, afhankelijk van het mobiele data-abonnement van uw aanbieder.</string>
 	<!-- bookmark button text -->
 	<string name="bookmark">markeren</string>
-	<!-- map is not downloaded -->
-	<string name="not_found_map">De kaart voor uw locatie is niet gedownload</string>
 	<!-- location service disabled -->
 	<string name="enable_location_services">Schakel Locatie Services in</string>
-	<!-- download map -->
-	<string name="download_map">Download de kaart voor uw locatie</string>
-	<!-- download map on iPhone -->
-	<string name="download_map_iphone">Download de kaart van uw huidige lokatie op uw iPhone</string>
-	<!-- clear pin -->
-	<string name="nearby">In de buurt</string>
-	<!-- clear pin -->
-	<string name="clear_pin">Speld wissen</string>
-	<!-- location is undefined -->
-	<string name="undefined_location">Huidige locatie is niet gedefinieerd.</string>
-	<!-- download country of your location -->
-	<string name="download_country">Download land waar je nu bent</string>
-	<!-- download failed -->
-	<string name="download_failed">download is afgebroken</string>
-	<!-- get the map -->
-	<string name="get_the_map">Krijg kaart</string>
 	<string name="save">Opslaan</string>
 	<string name="edit_description_hint">Uw omschrijvingen (tekst of html)</string>
-	<string name="new_group">nieuwe groep</string>
 	<string name="create">aanmaken</string>
 	<!-- red color -->
 	<string name="red">Rood</string>
@@ -489,22 +293,6 @@
 	<string name="brown">Bruin</string>
 	<!-- pink color -->
 	<string name="pink">Roze</string>
-	<!-- deep purple color -->
-	<string name="deep_purple">Donker paars</string>
-	<!-- light blue color -->
-	<string name="light_blue">Lichtblauw</string>
-	<!-- cyan color -->
-	<string name="cyan">Blauwgroen</string>
-	<!-- teal color -->
-	<string name="teal">Smaragdgroen</string>
-	<!-- lime color -->
-	<string name="lime">Lime</string>
-	<!-- deep orange color -->
-	<string name="deep_orange">Donkeroranje</string>
-	<!-- gray color -->
-	<string name="gray">Grijs</string>
-	<!-- blue gray color -->
-	<string name="blue_gray">Grijsblauw</string>
 	<!-- Wi-Fi available -->
 	<string name="WiFi_available">Ja</string>
 
@@ -520,10 +308,8 @@
 	<string name="dialog_routing_location_turn_wifi">Controleer uw gps-signaal. Schakel wifi in voor een betere locatiebepaling.</string>
 	<string name="dialog_routing_location_turn_on">Schakel locatiediensten in</string>
 	<string name="dialog_routing_location_unknown_turn_on">De huidige gps-coördinaten kunnen niet worden gevonden. Schakel locatiediensten in om de route te berekenen.</string>
-	<string name="dialog_routing_location_unknown">De huidige gps-coördinaten kunnen niet worden gevonden.</string>
 	<string name="dialog_routing_download_files">Download vereiste bestanden</string>
 	<string name="dialog_routing_download_and_update_all">Download de kaart en route-informatie voor het ingestelde traject en werk deze bij om de route te berekenen.</string>
-	<string name="dialog_routing_routes_size">Route-informatiebestanden</string>
 	<string name="dialog_routing_unable_locate_route">Route vinden mislukt</string>
 	<string name="dialog_routing_cant_build_route">Route samenstellen mislukt.</string>
 	<string name="dialog_routing_change_start_or_end">Kies een ander startpunt of andere bestemming.</string>
@@ -538,33 +324,23 @@
 	<string name="dialog_routing_system_error">Systeemfout</string>
 	<string name="dialog_routing_application_error">Route samenstellen mislukt door een applicatiefout.</string>
 	<string name="dialog_routing_try_again">Probeer het opnieuw</string>
-	<string name="dialog_routing_send_error">Meld het probleem</string>
-	<string name="dialog_routing_if_get_cross_route">Wilt u een rechtstreeksere route samenstellen die meer dan één kaart beslaat?</string>
-	<string name="dialog_routing_cross_route_is_optimal">Er is een betere route beschikbaar die de grenzen van deze kaart overschrijdt.</string>
 	<string name="not_now">Niet nu</string>
-	<string name="dialog_routing_build_route">Samenstellen</string>
 	<string name="dialog_routing_download_and_build_cross_route">Wilt u de kaart downloaden en een betere route samenstellen die meer dan één kaart beslaat?</string>
 	<string name="dialog_routing_download_cross_route">Download de kaart om een betere route samen te stellen die de grenzen van deze kaart overschrijdt.</string>
-	<string name="dialog_routing_cross_route_always">Deze grens altijd overschrijden</string>
 
 	<!-- SECTION: Strings for downloading map from search -->
 	<string name="search_without_internet_advertisement">Om te beginnen met zoeken en om routebeschrijvingen te kunnen maken, moet u de kaart downloaden. U heeft vervolgens geen internetverbinding meer nodig.</string>
 	<string name="search_select_map">Selecteer de kaart</string>
-	<string name="search_select_other_map">Selecteer een andere kaart</string>
 	<!-- «Show» context menu -->
 	<string name="show">Tonen</string>
 	<!-- «Hide» context menu -->
 	<string name="hide">Verbergen</string>
 	<!-- «Rename» context menu -->
 	<string name="rename">Naam wijzigen</string>
-	<!-- Bottom sheet: expand button (should be short) -->
-	<string name="bottom_sheet_more">Meer…</string>
 	<!-- Failed planning route message in navigation view -->
 	<string name="routing_planning_error">Routeberekening mislukt</string>
 	<!-- Arrive routing message in navigation view -->
 	<string name="routing_arrive">Aankomst: %s</string>
-	<!-- Text for routing::RouterResultCode::FileTooOld dialog. -->
-	<string name="dialog_routing_download_and_update_maps">Om een route te maken, download en update alle kaarten rondom de route.</string>
 	<string name="rate_alert_title">Vindt u de app leuk?</string>
 	<string name="rate_alert_default_message">Bedankt om Organic Maps te gebruiken. Gelieve de app te beoordelen. Uw feedback helpt ons beter te worden.</string>
 	<string name="rate_alert_five_star_message">Hoera! Wij houden ook van u!</string>
@@ -572,24 +348,14 @@
 	<string name="rate_alert_less_than_four_star_message">Heeft u suggesties voor verbeteringen?</string>
 	<string name="categories">Categorieën</string>
 	<string name="history">Geschiedenis</string>
-	<string name="next_turn_then">Dan</string>
 	<string name="closed">Gesloten</string>
-	<string name="back_to">Terug naar %s</string>
 	<string name="search_not_found">Sorry, ik heb niets gevonden.</string>
 	<string name="search_not_found_query">Probeer een andere zoekopdracht.</string>
-	<string name="search_not_found_map">Download de kaart waarin u zoekt, alstublieft.</string>
-	<string name="search_not_found_location">Download de kaart van uw huidige locatie.</string>
 	<string name="search_history_title">Zoekgeschiedenis</string>
 	<string name="search_history_text">Snel toegang tot recente zoekopdrachten.</string>
 	<string name="clear_search">Zoekgeschiedenis wissen</string>
-	<!-- Title for settings to enable/disable showcase menu button -->
-	<string name="showcase_settings_title">Aanbiedingen weergeven</string>
-	<string name="p2p_route_planning">Routeberekening</string>
 	<string name="p2p_your_location">Uw locatie</string>
-	<string name="p2p_from">Vertrekpunt</string>
-	<string name="p2p_to">Bestemmingspunt</string>
 	<string name="p2p_start">Beginnen</string>
-	<string name="p2p_planning">Aan het plannen…</string>
 	<string name="p2p_from_here">Van</string>
 	<string name="p2p_to_here">Route naar</string>
 	<string name="p2p_only_from_current">Navigatie is uitsluitend beschikbaar vanuit uw huidige locatie.</string>
@@ -609,11 +375,8 @@
 	<string name="editor_hours_closed">Sluitingstijden</string>
 	<string name="editor_example_values">Voorbeeldwaarden</string>
 	<string name="editor_correct_mistake">Fout corrigeren</string>
-	<string name="editor_correct_mistake_message">U hebt een bewerkingsfout gemaakt. Corrigeer deze of schakel over naar de eenvoudige modus.</string>
 	<string name="editor_add_select_location">Locatie</string>
 	<string name="editor_done_dialog_1">Je hebt de wereldkaart gewijzigd. Verberg dit niet! Vertel het je vrienden en bewerk het samen.</string>
-	<string name="editor_done_dialog_2">Dit is je tweede kaartverbetering. Nu sta je op de %de plaats in de lijst van de kaartbewerkers. Vertel je vrienden erover.</string>
-	<string name="editor_done_dialog_3">Je hebt de kaart verbeterd, vertel je vrienden erover en bewerk samen de kaart.</string>
 	<string name="share_with_friends">Deel met je vrienden</string>
 	<string name="editor_report_problem_desription_1">Beschrijf het probleem gedetailleerd, zodat de OpenStreetMap-community de fout kan oplossen.</string>
 	<string name="editor_report_problem_desription_2">Of doe het zelf op https://www.openstreetmap.org/</string>
@@ -622,14 +385,7 @@
 	<string name="editor_report_problem_no_place_title">De plaats bestaat niet</string>
 	<string name="editor_report_problem_under_construction_title">Gesloten voor onderhoud</string>
 	<string name="editor_report_problem_duplicate_place_title">Dubbele plaats</string>
-	<string name="first_launch_congrats_title">Organic Maps is klaar voor gebruik</string>
-	<string name="first_launch_congrats_text">Zoek en navigeer overal ter wereld offline, gratis.</string>
-	<string name="migrate_title">Belangrijk!</string>
-	<!-- Android uses image instead of text. -->
-	<string name="download_all">Alles downloaden</string>
-	<string name="delete_all">Alles verwijderen</string>
 	<string name="autodownload">Automatische download</string>
-	<string name="disable_autodownload">Automatisch downloaden uitschakelen</string>
 	<!-- Place Page opening hours text -->
 	<string name="closed_now">Nu gesloten</string>
 	<!-- Place Page opening hours text -->
@@ -638,8 +394,6 @@
 	<string name="day_off_today">Vrije dag vandaag</string>
 	<string name="day_off">Vrije dag</string>
 	<string name="today">Vandaag</string>
-	<string name="sunrise_to_sunset">Van zonsopgang tot zonsondergang</string>
-	<string name="sunset_to_sunrise">Van zonsondergang tot zonsopgang</string>
 	<string name="add_opening_hours">Openingsuren toevoegen</string>
 	<string name="edit_opening_hours">Openingsuren bewerken</string>
 	<string name="no_osm_account">Geen account bij OpenStreetMap?</string>
@@ -649,29 +403,13 @@
 	<string name="login">Log in</string>
 	<string name="password">Wachtwoord</string>
 	<string name="forgot_password">Wachtwoord vergeten?</string>
-	<!-- Forgot Password dialog title -->
-	<string name="restore_password">Wachtwoord herstellen</string>
-	<string name="enter_email_address_to_reset_password">Voer het emailadres in dat u heeft gebruikt tijdens de registratie, dan sturen wij u de link om uw wachtwoord te vernieuwen.</string>
-	<string name="reset_password">Wachtwoord resetten</string>
-	<string name="username">Gebruikersnaam</string>
 	<string name="osm_account">OSM-account</string>
 	<string name="logout">Uitloggen</string>
-	<string name="login_and_edit_map_motivation_message">Log in en bewerk gegevens van de objecten op de kaart, dan zullen wij ze beschikbaar maken voor miljoenen andere gebruikers. Laten we samen de wereld beter maken.</string>
 	<!-- Information text: "Last upload 11.01.2016" -->
 	<string name="last_upload">Laatste upload</string>
-	<!-- Motivates user to login/register, title above login buttons. -->
-	<string name="you_have_edited_your_first_object">Je hebt je eerste object aangepast!</string>
 	<string name="thank_you">Dank je wel</string>
-	<string name="login_with_google">Aanmelden met Google</string>
-	<string name="login_with_openstreetmap">Aanmelden met www.openstreetmap.org</string>
 	<string name="edit_place">De locatie bewerken</string>
 	<string name="place_name">Locatienaam</string>
-	<!-- title above languages list cells in the editor, below editable name text field. -->
-	<string name="other_languages">Overige talen</string>
-	<!-- small button to open list with names in different languages -->
-	<string name="show_more">Laat meer zien</string>
-	<!-- small button to close list with names in different languages -->
-	<string name="show_less">Laat minder zien</string>
 	<string name="add_language">Een taal toevoegen</string>
 	<string name="street">Straat</string>
 	<!-- Editable House Number text field (in address block). -->
@@ -688,25 +426,16 @@
 	<string name="email_or_username">Emailadres of gebruikersnaam</string>
 	<string name="phone">Telefoonnummer</string>
 	<string name="please_note">Opgelet</string>
-	<string name="common_no_wifi_dialog">Geen WiFi-verbinding. Wil je doorgaan via mobiele data?</string>
 	<string name="downloader_delete_map_dialog">Alle wijzigingen aan de kaart zullen samen met de kaart worden verwijderd.</string>
 	<string name="downloader_update_maps">Kaarten updaten</string>
 	<string name="downloader_mwm_migration_dialog">Om een route te creëren, moet je alle kaarten updaten en dan de route opnieuw plannen.</string>
 	<string name="downloader_search_field_hint">Vind de kaart</string>
-	<string name="migration_update_all_button">Update alle kaarten</string>
-	<string name="migration_delete_all_download_current_button">Download de huidige kaart en verwijder de oude</string>
 	<string name="migration_download_error_dialog">Downloadfout</string>
 	<string name="common_check_internet_connection_dialog">Controleer je instellingen en zorg ervoor dat het apparaat is verbonden met het internet.</string>
 	<string name="downloader_no_space_title">Niet genoeg ruimte</string>
 	<string name="downloader_no_space_message">Verwijder overbodige gegevens</string>
-	<string name="editor_general_auth_error_dialog">Algemene inlogfout.</string>
 	<string name="editor_login_error_dialog">Inlogfout.</string>
-	<string name="editor_login_failed_dialog">Inloggen mislukt</string>
-	<string name="editor_username_error_dialog">Gebruikersnaam is ongeldig</string>
-	<string name="editor_place_edited_dialog">Je hebt een object bewerkt!</string>
-	<string name="editor_login_with_osm">Log in met OpenStreetMap</string>
 	<string name="editor_profile_changes">Gecontroleerde wijzigingen</string>
-	<string name="editor_profile_unsent_changes">Niet verzonden:</string>
 	<string name="editor_focus_map_on_location">Trek aan de kaart om de juiste locatie van het object te selecteren.</string>
 	<string name="editor_add_select_category">Selecteer categorie</string>
 	<string name="editor_add_select_category_popular_subtitle">Populair</string>
@@ -717,19 +446,14 @@
 	<string name="editor_edit_place_category_title">Categorie</string>
 	<string name="detailed_problem_description">Gedetailleerde probleemomschrijving</string>
 	<string name="editor_report_problem_other_title">Een ander probleem</string>
-	<string name="placepage_report_problem_button">Meld een probleem</string>
 	<string name="placepage_add_business_button">Een organisatie toevoegen</string>
 	<string name="whatsnew_editor_message_1">Voeg nieuwe plaatsen toe aan de kaart en bewerk de bestaande rechtstreeks vanuit de app.</string>
-	<string name="whatsnew_editor_message_2">* Organic Maps gebruikt OpenStreetMap-communitiedata.</string>
 	<string name="dialog_incorrect_feature_position">Locatie wijzigen</string>
 	<string name="message_invalid_feature_position">Hier kan geen object worden geplaatst</string>
 	<string name="login_to_make_edits_visible">Log in zodat andere gebruikers kunnen zien wat u hebt gewijzigd.</string>
-	<string name="no_migration_during_navigation">Updaten tijdens navigatie is niet toegestaan.</string>
 	<!-- Error dialog no space -->
 	<string name="migration_no_space_message">Om te kunnen downloaden, heb je meer ruimte nodig. Verwijder overbodige gegevens.</string>
 	<string name="editor_sharing_title">Ik heb de Organic Maps-kaarten verbeterd</string>
-	<string name="editor_comment_will_be_sent">We zullen uw opmerking doorsturen naar de kaartmakers.</string>
-	<string name="editor_unsupported_category_message">U hebt een plaats of categorie toegevoegd die we nog niet ondersteunen. Het zal enige tijd duren voordat deze op de kaart verschijnt.</string>
 	<!-- Downloaded 10 **of** 20 <- it is that "of" -->
 	<string name="downloader_of">%1$d van %2$d</string>
 	<string name="download_over_mobile_header">Downloaden via een mobiele gegevensverbinding?</string>
@@ -747,15 +471,8 @@
 	<string name="editor_detailed_description">Uw voorgestelde wijzigingen worden verzonden naar de OpenStreetMap-community. Beschrijf de details die niet kunnen worden bewerkt in Organic Maps.</string>
 	<string name="editor_more_about_osm">Meer over OpenStreetMap</string>
 	<string name="editor_operator">Uitvoerder</string>
-	<string name="editor_tag_description">Voer het bedrijf, de organisatie of het individu in dat verantwoordelijk is voor de faciliteiten.</string>
-	<string name="editor_no_local_edits_title">U hebt geen lokale bewerkingen</string>
-	<string name="editor_no_local_edits_description">Dit toont het aantal voorgestelde wijzigingen voor de kaart die momenteel alleen toegankelijk zijn op uw apparaat.</string>
-	<string name="editor_send_to_osm">Naar OSM sturen</string>
-	<string name="editor_remove">Verwijderen</string>
-	<string name="downloader_my_maps_title">Mijn kaarten</string>
 	<string name="downloader_no_downloaded_maps_title">U hebt geen kaarten gedownload</string>
 	<string name="downloader_no_downloaded_maps_message">Download kaarten om de locatie te zoeken en offline te navigeren.</string>
-	<string name="downloader_find_place_hint">Stad of land zoeken</string>
 	<!-- Error title that appears after certain time without location. -->
 	<string name="current_location_unknown_title">Doorgaan met het detecteren van uw huidige locatie?</string>
 	<!-- Error that appears after certain time without location. -->
@@ -770,27 +487,10 @@
 	<string name="location_services_disabled_2">2. Tik op locatie</string>
 	<!-- iOS Dialog for the case when the location permission is not granted -->
 	<string name="location_services_disabled_3">3. Selecteer Terwijl Je de App Gebruikt</string>
-	<string name="placepage_parking_surface">Boven de grond</string>
-	<string name="placepage_parking_multistorey">Meerlaags</string>
-	<string name="placepage_parking_underground">Onder de grond</string>
-	<string name="placepage_parking_rooftop">Dak</string>
-	<string name="placepage_parking_sheds">Afdak</string>
-	<string name="placepage_parking_carports">Carports</string>
-	<string name="placepage_parking_boxes">Garageboxen</string>
-	<string name="placepage_parking_pay">Betalen</string>
-	<string name="placepage_parking_free">Gratis</string>
-	<string name="placepage_parking_interval">Intervalbetaling</string>
-	<string name="placepage_entrance_number">Nr.</string>
-	<string name="placepage_entrance_type">Ingang</string>
-	<string name="placepage_flat">app.</string>
-	<string name="placepage_open_24_7">Dag en nacht</string>
 	<string name="meter">m</string>
 	<string name="kilometer">km</string>
-	<string name="kilometers_per_hour">km/h</string>
 	<string name="mile">mijl</string>
 	<string name="foot">voet</string>
-	<string name="miles_per_hour">mph</string>
-	<string name="day">d</string>
 	<string name="hour">u</string>
 	<string name="minute">min</string>
 	<string name="placepage_place_description">Beschrijving</string>
@@ -800,46 +500,30 @@
 	<string name="placepage_call_button">Bellen</string>
 	<string name="placepage_edit_bookmark_button">Bladwijzer bewerken</string>
 	<string name="placepage_bookmark_name_hint">Bladwijzernaam</string>
-	<string name="placepage_personal_notes_hint">Persoonlijke aantekeningen</string>
-	<string name="placepage_delete_bookmark_button">Bladwijzer verwijderen</string>
 	<string name="editor_edits_sent_message">Uw voorgestelde wijzigingen zijn verzonden</string>
 	<string name="editor_comment_hint">Reactie…</string>
 	<string name="editor_reset_edits_message">Alle lokale wijzigingen herstellen?</string>
 	<string name="editor_reset_edits_button">Herstellen</string>
 	<string name="editor_remove_place_message">Een toegevoegde locatie verwijderen?</string>
 	<string name="editor_remove_place_button">Verwijderen</string>
-	<string name="editor_status_sending">Verzenden…</string>
 	<string name="editor_place_doesnt_exist">Locatie bestaat niet</string>
 	<string name="text_more_button">…meer</string>
 	<!-- Phone number error message -->
 	<string name="error_enter_correct_phone">Voer het juiste telefoonnummer in</string>
 	<string name="error_enter_correct_web">Voer een geldig webadres in</string>
 	<string name="error_enter_correct_email">Voer een geldig emailadres in</string>
-	<string name="error_enter_correct">Voer een geldige waarde in</string>
 	<string name="refresh">Updaten</string>
-	<string name="last_update">Laatste update: %s</string>
 	<string name="placepage_add_place_button">Een plek toevoegen aan de kaart</string>
 	<!-- Displayed when saving some edits to the map to warn against publishing personal data -->
 	<string name="editor_share_to_all_dialog_title">Wil je het naar alle gebruikers sturen?</string>
 	<!-- iOS Dialog before publishing the modifications to the public map. -->
 	<string name="editor_share_to_all_dialog_message_1">Controleer dat je geen persoonlijke gegevens hebt ingevoerd.</string>
 	<string name="editor_share_to_all_dialog_message_2">We zullen de wijzigingen controleren. Als we nog vragen hebben, zullen we contact met je opnemen via email.</string>
-	<string name="navigation_overview_button">overzicht</string>
-	<string name="navigation_stop_button">stoppen</string>
-	<!-- Text on an empty bookmark page -->
-	<string name="bookmarks_empty_title">Bladwijzers opslaan</string>
-	<string name="bookmarks_empty_message_1">Tik op ★ om favoriete plaatsen op te slaan voor snelle toegang.</string>
-	<string name="bookmarks_empty_message_2">Importeer bladwijzers vanuit email en het internet.</string>
-	<string name="bookmarks_empty_message_3">uitchecken: %s</string>
-	<!-- Name of the group for booked hotels -->
-	<string name="bookmarks_group_name">Geboekte hotels</string>
-	<string name="place_page_button_read_descriprion">Lezen</string>
 	<!-- iOS dialog for the case when recent track recording is on and the app comes back from background -->
 	<string name="recent_track_background_dialog_title">Vastleggen van uw onlangs afgelegde route uitschakelen?</string>
 	<string name="off_recent_track_background_button">Uitschakelen</string>
 	<!-- For sharing via SMS and so on -->
 	<string name="sharing_call_action_look">Bekijk</string>
-	<string name="continue_recent_track_background_button">Verdergaan</string>
 	<string name="recent_track_background_dialog_message">Organic Maps gebruikt uw geografische positie op de achtergrond om uw onlangs afgelegde route vast te leggen.</string>
 	<!-- Rate on Google Play (Android only) -->
 	<string name="rate_gp">Beoordeel op Google Play</string>
@@ -849,21 +533,11 @@
 	<string name="tell_friends_text">Hallo! Installeer Organic Maps!</string>
 	<!-- About short text (below logo) -->
 	<string name="about_description">Organic Maps is een essentiële offline applicatie om te reizen. Organic Maps is gebaseerd op OpenStreetMap gegevens en laat bewerking toe.</string>
-	<!-- Text in menu -->
-	<string name="blog">Blog</string>
 	<string name="general_settings">Algemene instellingen</string>
-	<string name="date">Datum %d</string>
-	<!-- "Report a bug" -> "Generaal Feedback" -> "Something is not working" -->
-	<string name="something_is_not_working">Er werkt iets niet</string>
 	<!-- For the first routing -->
 	<string name="accept">Aanvaarden</string>
 	<!-- For the first routing -->
 	<string name="decline">Weigeren</string>
-	<string name="install_app">Installeer</string>
-	<string name="search_no_results_title">Geen Resultaten Gevonden</string>
-	<string name="search_no_results_message">Probeer een meer algemene zoekterm, zoom uit of reset de filter.</string>
-	<string name="search_no_results_expand_area_button">Uitzoomen</string>
-	<string name="search_no_results_reset_button">Filter Resetten</string>
 	<!-- noun -->
 	<string name="search_in_table">Lijst</string>
 	<string name="mobile_data_dialog">Mobiel internet gebruiken om gedetailleerde informatie weer te geven?</string>
@@ -875,18 +549,13 @@
 	<string name="mobile_data_option_never">Nooit Gebruiken</string>
 	<string name="mobile_data_option_ask">Altijd Vragen</string>
 	<string name="traffic_update_maps_text">Om verkeersgegevens weer te geven, moeten de kaarten bijgewerkt worden.</string>
-	<string name="traffic_outdated">Verkeersgegevens zijn verouderd.</string>
 	<string name="big_font">Lettergrootte op de kaart vergroten</string>
 	<string name="traffic_update_app">Gelieve Organic Maps bij te werken</string>
 	<!-- "traffic" as in road congestion -->
 	<string name="traffic_update_app_message">Om de verkeersgegevens weer te geven, moet de applicatie bijgewerkt worden.</string>
 	<!-- "traffic" as in "road congestion" -->
 	<string name="traffic_data_unavailable">Verkeersgegevens zijn niet beschikbaar</string>
-	<!-- Simplified colour scheme for traffic information, fewer colours are used to display traffic jams on the map. The string should be kept as short as possible -->
-	<string name="pref_traffic_simplified_colors_title">Eenvoudige verkeerskleuren</string>
 	<string name="enable_logging">Logboekregistratie inschakelen</string>
-	<string name="offline_place_page_more_information">Maak verbinding met het internet om meer informatie over de plaats te krijgen.</string>
-	<string name="failed_load_information">Informatie laden mislukt.</string>
 	<!-- Settings: "Send general feedback" button -->
 	<string name="feedback_general">Algemene Feedback</string>
 	<string name="on">Aan</string>
@@ -900,57 +569,26 @@
 	<string name="routing_add_start_point">Voeg beginpunt toe om een route te plannen</string>
 	<string name="routing_add_finish_point">Voeg eindpunt toe om een route te plannen</string>
 	<string name="button_exit">Verlaten</string>
-	<string name="settings_device_memory">Apparaatgeheugen</string>
-	<string name="settings_card_memory">Kaartgeheugen</string>
-	<string name="settings_storage_available">%s beschikbaar</string>
-	<string name="toast_location_permission_denied">App toelating locatie geweigerd</string>
-	<string name="button_use">Gebruiken</string>
 	<string name="planning_route_manage_route">Route beheren</string>
 	<string name="button_plan">Plannen</string>
-	<string name="button_add">Toevoegen</string>
 	<string name="placepage_remove_stop">Verwijderen</string>
 	<string name="planning_route_remove_title">Sleep hier om te verwijderen</string>
-	<string name="dialog_change_start_point_message">Het beginpunt vervangen met de huidige locatie?</string>
-	<string name="button_replace">Vervangen</string>
 	<string name="placepage_add_stop">Tussenstop toevoegen</string>
-	<string name="add_my_position">Voeg mijn positie toe</string>
-	<string name="choose_start_point">Kies een vertrekpunt</string>
-	<string name="choose_destination">Kies een bestemming</string>
 	<string name="preloader_viator_button">Meer leren</string>
-	<string name="start_from_my_position">Start vanaf</string>
-	<string name="profile_authorization_title">Aanmelden met</string>
-	<string name="profile_authorization_message">Eenvoudig aanmelden zonder gebruikersnaam en wachtwoord in enkele seconden</string>
 	<string name="profile_authorization_error">Oeps, er is een fout opgetreden. Probeer opnieuw aan te melden.</string>
-	<string name="service">Dienst</string>
-	<string name="atmosphere">Sfeer</string>
-	<string name="value_for_money">Waarde voor geld</string>
-	<string name="experience">Ervaring</string>
-	<string name="assortment">Assortiment</string>
-	<string name="expertise">Expertise</string>
-	<string name="equipment">Uitrusting</string>
-	<string name="quality">Kwaliteit</string>
 	<string name="dialog_error_storage_title">Probleem met opslagtoegang</string>
 	<string name="dialog_error_storage_message">Externe opslag is niet beschikbaar, wellicht is de SD-kaart verwijderd, beschadigd of is het bestandssysteem alleen-lezen. Gelieve het te controleren en ons te contacteren via support\@organicmaps.app</string>
 	<string name="setting_emulate_bad_storage">Slechte opslag emuleren</string>
-	<string name="directions_finish">Bestemming</string>
-	<string name="directions_on_foot">Wandel %s</string>
 	<string name="core_entrance">Ingang</string>
-	<string name="coffee">Koffie</string>
-	<string name="cleanliness">Netheid</string>
-	<string name="crowdedness">Drukte</string>
 	<string name="error_enter_correct_name">Voer een juiste naam in</string>
 	<string name="bookmarks_groups">lijsten</string>
 	<string name="bookmarks_groups_hide_all">Alles verbergen</string>
 	<string name="bookmarks_groups_show_all">Alles weergeven</string>
-	<plurals name="bookmarks_places">
-	  <item quantity="other">%d bladwijzers</item>
-	</plurals>
 	<string name="bookmarks_create_new_group">Nieuwe lijst maken</string>
 	<string name="downloader_hide_screen">Scherm Verbergen</string>
 	<string name="downloader_percent">%1$s (%2$s van %3$s)</string>
-	<string name="downloader_process">%s downloaden...</string>
-	<string name="downloader_applying">%s toepassen...</string>
-	<string name="dialog_message_transit_not_found_connection">Plan een route binnen één vervoersnetwerk</string>
+	<string name="downloader_process">%s downloaden…</string>
+	<string name="downloader_applying">%s toepassen…</string>
 	<string name="bookmarks_error_message_share_general">Delen is onmogelijk wegens een toepassingsfout</string>
 	<string name="bookmarks_error_title_share_empty">Deelfout</string>
 	<string name="bookmarks_error_message_share_empty">Een lege lijst kan niet gedeeld worden</string>
@@ -959,12 +597,7 @@
 	<string name="bookmarks_new_list_hint">Nieuwe lijst</string>
 	<string name="bookmarks_error_title_list_name_already_taken">Deze naam is al in gebruik</string>
 	<string name="bookmarks_error_message_list_name_already_taken">Kies alstublieft een andere naam</string>
-	<string name="bookmarks_error_title_list_name_too_long">Deze naam is te lang</string>
-	<string name="bookmarks_error_message_list_name_too_long">Kies alstublieft een andere naam</string>
-	<string name="please_wait">Even geduld aub...</string>
-	<string name="phone_number">Telefoonnummer</string>
-	<string name="notification_unsent_reviews_title">U heeft verschillende niet-verzonden recensies</string>
-	<string name="notification_unsent_reviews_message">Meld u aan om recensies te delen met andere reizigers</string>
+	<string name="please_wait">Even geduld aub…</string>
 	<string name="profile">OpenStreetMap-profiel</string>
 	<string name="place_page_search_similar_hotel">Zoek vergelijkbare hotels</string>
 	<string name="bookmarks_detect_title">Nieuwe bestanden gedetecteerd</string>
@@ -975,31 +608,10 @@
 	<string name="button_convert">Omzetten</string>
 	<string name="bookmarks_convert_error_title">Fout</string>
 	<string name="bookmarks_convert_error_message">Sommige bestanden waren niet geconverteerd.</string>
-	<string name="converting">Het omzetten van...</string>
-	<string name="wn_reinvented_bookmarks_title">We hebben bladwijzers opnieuw uitgevonden!</string>
-	<string name="wn_reinvented_bookmarks_message">U kunt een back-up maken van bladwijzers, lijsten maken... Het is verbazingwekkend...</string>
-	<string name="bookmarks_restore">Bladwijzers herstellen</string>
-	<string name="bookmarks_restore_process">Herstel van...</string>
 	<string name="bookmarks_restore_title">Deze versie herstellen?</string>
-	<string name="bookmarks_restore_message">Je bladwijzers worden hersteld vanaf %1$s (%2$s)</string>
-	<string name="bookmarks_restore_empty_title">U hebt geen back-up</string>
-	<string name="bookmarks_restore_empty_message">De server heeft eerder gemaakte back-ups niet gevonden</string>
 	<string name="common_check_internet_connection_dialog_title">Geen internet verbinding</string>
-	<string name="error_server_title">Serverfout</string>
-	<string name="error_server_message">Der var en fejl på serveren, prøv igen senere</string>
 	<string name="error_system_message">Er is een onbekende fout opgetreden</string>
 	<string name="restore">Herstellen</string>
-	<string name="bookmarks_page_downloaded">Gedownload</string>
-	<string name="bookmarks_page_my">Mijn</string>
-	<string name="routes_and_bookmarks">Routes en Bladwijzers</string>
-	<string name="bookmarks_webview_success_toast">Bladwijzers succesvol gedownload</string>
-	<string name="cached_bookmarks_placeholder_title">Download nieuwe plaatsen</string>
-	<string name="cached_bookmarks_placeholder_subtitle">Druk op de knop om duizenden interessante plaatsen en routes te downloaden, gecreëerd door Organic Maps-gebruikers. U hebt een internet-verbinding nodig.</string>
-	<string name="downloader_download_routers">Download bladwijzers</string>
-	<string name="bookmarks_groups_cached">Download lijsten</string>
-	<plurals name="bookmarks_objects">
-	  <item quantity="other">%s object</item>
-	</plurals>
 	<plurals name="objects">
 	  <item quantity="other">%d plaats</item>
 	</plurals>
@@ -1012,62 +624,32 @@
 	<string name="subtittle_opt_out">Tracking-instellingen</string>
 	<string name="crash_reports">Crash rapport</string>
 	<string name="crash_reports_description">Wij kunnen uw gegevens gebruiken om Organic Maps te verbeteren. Wijzigingen treden in werking na het opnieuw opstarten van de app.</string>
-	<string name="opt_out_help_ios_1">Uw mobiele apparaat kan voorzien zijn van een instelling voor „Gelimiteerde advertentie-tracking” of „afmelden voor op interesses gebaseerd adverteren”.</string>
-	<string name="opt_out_help_ios_2">iOS 9 of hoger</string>
-	<string name="opt_out_help_ios_3">Ga naar uw Instellingen → Privacy → Advertenties → Inschakelen van de „Gelimiteerde advertentie-tracking” - instelling</string>
-	<string name="opt_out_help_android">Uw mobiele apparaat kan voorzien zijn van een instelling voor „Gelimiteerde advertentie-tracking” of „Afmelden voor op interesses gebaseerd adverteren”. \n\nVoor Android en Google Play Services versie 4. 0 en hoger:\nInstellingen → Google → Advertenties → Afmelden voor personalisatie van advertenties \n of \nInstellingen → Google → Google-Account → Gegevens &amp; personalisatie → Advertentiepersonalisatie</string>
 	<string name="privacy_policy">Privacy beleid</string>
 	<string name="terms_of_use">Gebruiksvoorwaarden</string>
-	<string name="backup_notification_failed">Een back-up van uw bladwijzers werd opgeschort. Log in om weer op te starten.</string>
 	<string name="button_layer_traffic">Verkeer</string>
 	<string name="button_layer_subway">Metro</string>
 	<string name="layers_title">Map layers</string>
-	<string name="layers_message">Gebruik „Map layers” voor het weergeven van verkeer, metro, en andere nuttige informatie</string>
-	<string name="button_layer_got_it">Ik begrijp het</string>
 	<string name="subway_data_unavailable">Metrokaart is niet beschikbaar</string>
 	<string name="bookmarks_empty_list_title">Deze lijst is leeg</string>
 	<string name="bookmarks_empty_list_message">Om een bladwijzer toe te voegen, tikt u op een plaats op de kaart en vervolgens op het sterpictogram</string>
 	<string name="category_desc_more">…meer</string>
 	<string name="title_error_downloading_bookmarks">Er is een fout opgetreden</string>
-	<string name="subtitle_error_downloading_bookmarks">Bladwijzers werden niet gedownload</string>
-	<string name="error_already_downloaded">Deze lijst is al gedownload</string>
-	<string name="why_support">Waarom Organic Maps ondersteunen?</string>
-	<string name="why_support_item2">U helpt ons Organic Maps te verbeteren</string>
-	<string name="why_support_item3">U helpt ons de kaarten van OpenStreetMap.org te verbeteren</string>
-	<string name="channels_map_update">Kaartupdates</string>
-	<string name="server_unavailable_title">Server niet beschikbaar</string>
-	<string name="sharing_options">Opties voor delen</string>
 	<string name="export_file">Bestand exporteren</string>
 	<string name="list_settings">Lijst Instellingen</string>
 	<string name="delete_list">Lijst verwijderen</string>
-	<string name="hide_from_map">Van de kaart verbergen</string>
 	<string name="public_access">Publiek toegang</string>
 	<string name="limited_access">Beperkte toegang</string>
 	<string name="bookmark_category_name">Categorie</string>
 	<string name="bookmark_category_description_hint">Maak een beschrijving aan (tekst of html)</string>
 	<string name="not_shared">Privé</string>
-	<string name="direct_link_progress_text">Uw bestand aan het uploaden…</string>
-	<string name="direct_link_success">De link is aangemaakt</string>
-	<string name="send_a_link_btn">Stuur mij een link</string>
-	<string name="upload_error_toast">Er is een fout opgetreden tijdens het uploaden van uw bestand</string>
 	<string name="tags_loading_error_subtitle">Er is een fout opgetreden tijdens het laden van tags, probeer het opnieuw</string>
-	<string name="unable_upload_errorr_title">Bestand uploaden mislukt</string>
-	<string name="unable_upload_error_subtitle_edited">Dit bestand is bewerkt via de web app</string>
-	<string name="unable_upload_error_subtitle_broken">Dit bestand is beschadigd en kon niet worden geüpload. Gelieve een ander bestand te uploaden.</string>
-	<string name="contact">Contact</string>
-	<string name="download_button">Downloaden</string>
 	<string name="speedcams_alert_title">Snelheidscamera\'s</string>
-	<string name="speedcams_alert_subtitle">Waarschuw voor snelheidsbeperkingen</string>
 	<string name="speedcam_option_auto">Auto</string>
 	<string name="speedcam_option_always">Altijd</string>
 	<string name="speedcam_option_never">Nooit</string>
-	<string name="bookmark_description_title">Bladwijzer Beschrijving</string>
 	<string name="place_description_title">Plaats Beschrijving</string>
 	<!-- this text will be shown in application notification preferences opposite checkbox which enable/disable downloader notifications. Devices on Android 8+ are affected. -->
 	<string name="notification_channel_downloader">Kaart downloader</string>
-	<string name="share_bookmarks_email_body_link">Hello!\n\nHier is de link waar u uw bladwijzers kunt downloaden: %s. Open de lijst via Organic Maps en geniet van uw reis!\n\nHaal de applicatie op: https://omaps.app/get?kmz</string>
-	<string name="warning_speedcams_title">Navigator waarschuwt u over camera\'s wanneer u de maximumsnelheid van %d km/h overschrijdt</string>
-	<string name="warning_speedcams_subtitle">Let op de rijvoorschriften van het land waar u naartoe reist.</string>
 	<string name="speedcams_notice_message">Auto - Waarschuw voor speedcams als er een risico bestaat dat de snelheidslimiet wordt overschreden\nAltijd - Waarschuw altijd voor flitspalen\nNooit - Waarschuw nooit over flitspalen</string>
 	<string name="power_managment_title">Energiebesparende modus</string>
 	<string name="power_managment_description">Als de energiebesparende modus is ingeschakeld, schakelt de app de energieverbruikende functies uit afhankelijk van de huidige lading van de mobiele telefoon</string>
@@ -1075,14 +657,7 @@
 	<string name="power_managment_setting_auto">Auto</string>
 	<string name="power_managment_setting_manual_max">Maximale energiebesparing</string>
 	<string name="enable_logging_warning_message">Deze optie is ingeschakeld voor logboekregistraties voor diagnostische doeleinden. Het helpt bij het identificeren van problemen met de applicatie. Schakel de optie alleen in op verzoek van Organic Maps-ondersteuning.</string>
-	<string name="html_error_upload_message_try_again">Controleer de netwerktoegang en probeer het opnieuw</string>
-	<string name="html_error_upload_title_try_again">Geen internetverbinding</string>
-	<string name="notification_leave_review_v2_android_short_title">Laat een feedback achter en help reizigers!</string>
-	<string name="notifications_illegal_alert_disable_button">Meldingen uitschakelen</string>
 	<string name="access_rules_author_only">Wordt online bewerkt</string>
-	<string name="privacy_settings_menu">Privacy instellingen</string>
-	<string name="unable_upadate_error_title">Kan de route niet bijwerken</string>
-	<string name="unable_upadate_error_message">Er zijn fouten opgetreden tijdens het updaten. Controleer de wijzigingen en probeer het opnieuw</string>
 	<string name="driving_options_title">Omweginstellingen</string>
 	<string name="driving_options_subheader">Vermijden op elke route</string>
 	<string name="avoid_tolls">Tolwegen</string>
@@ -1093,52 +668,14 @@
 	<string name="unable_to_calc_alert_subtitle">Helaas konden we geen route opbouwen met de gekozen opties. Wijzig de instellingen en probeer het opnieuw</string>
 	<string name="define_to_avoid_btn">Omwegen configureren</string>
 	<string name="change_driving_options_btn">Omweginstellingen ingeschakeld</string>
-	<string name="toll_road">Tolweg</string>
-	<string name="unpaved_road">Aardeweg</string>
-	<string name="ferry_crossing">Ferry</string>
-	<string name="operated_by">Gecontroleerd door \"%s\"</string>
 	<string name="avoid_toll_roads_placepage">Tolwegen vermijden</string>
 	<string name="avoid_unpaved_roads_placepage">Aardewegen vermijden</string>
 	<string name="avoid_ferry_crossing_placepage">Ferries vermijden</string>
-	<string name="type.cuisine.uzbek">Oezbeekse keuken</string>
-	<string name="trip_start">Kom op</string>
-	<string name="pick_destination">Doel</string>
-	<string name="follow_my_position">Centreren</string>
-	<string name="search_results">Zoekresultaten</string>
-	<string name="then_turn">Dan</string>
-	<string name="redirect_route_alert">Wilt u de route wijzigen?</string>
-	<string name="redirect_route_yes">Ja</string>
-	<string name="redirect_route_no">Nee</string>
-	<string name="trip_finished">U bent aangekomen!</string>
-	<string name="keyboard_availability_alert">Toetsenbord is niet beschikbaar tijdens het rijden</string>
-	<string name="dialog_routing_change_start_carplay">Kan route vanaf huidige positie niet opbouwen</string>
-	<string name="dialog_routing_change_end_carplay">Kan route naar het eindpunt niet opbouwen. Kies een andere punt</string>
-	<string name="dialog_routing_check_gps_carplay">Geen GPS-signaal. Ga naar het open veld</string>
-	<string name="dialog_routing_unable_locate_route_carplay">Kan route niet bouwen. Selecteer andere tussenpunten</string>
-	<string name="dialog_routing_download_files_carplay">Om een route te bouwen, download u ontbrekende kaarten</string>
-	<string name="dialog_routing_system_error_carplay">Lets fout gegaan. Start de app opnieuw</string>
-	<string name="dialog_routing_rebuild_from_current_location_carplay">De route wordt opnieuw opgebouwd vanaf uw huidige positie</string>
-	<string name="dialog_routing_rebuild_for_vehicle_carplay">De route wordt gewijzigd in de autoroute</string>
 	<string name="ok">Goed</string>
-	<string name="avoid_unpaved_carplay_1">Geen aardew.</string>
-	<string name="avoid_unpaved_carplay_2">Geen aardewegen</string>
-	<string name="avoid_ferry_carplay_1">Geen ferry\'s</string>
-	<string name="avoid_ferry_carplay_2">Geen ferry\'s</string>
-	<string name="avoid_tolls_carplay_1">Zonder tol</string>
-	<string name="avoid_tolls_carplay_2">Zonder tol</string>
-	<string name="speedcams_alert_title_carplay_1">Cameras</string>
-	<string name="speedcams_alert_title_carplay_2">Over cameras</string>
-	<string name="download_map_carplay">Download kaarten in de Organic Maps app op uw apparaat</string>
-	<string name="carplay_roundabout_exit">Afrit nr. %s</string>
 	<!-- max. 10 symbols, both iOS and Android -->
 	<string name="sort">Sorteer…</string>
 	<!-- Android, title, max 20-22 symbols -->
 	<string name="sort_bookmarks">Bladwijzers sorteren</string>
-	<!-- iOS -->
-	<string name="sort_default">Standaard sorteren</string>
-	<string name="sort_type">Sorteren op type</string>
-	<string name="sort_distance">Sorteer op afstand</string>
-	<string name="sort_date">Sorteer op datum</string>
 	<!-- Android -->
 	<string name="by_default">Standaard</string>
 	<!-- Android -->
@@ -1147,65 +684,23 @@
 	<string name="by_distance">Op afstand</string>
 	<!-- Android -->
 	<string name="by_date">Op datum</string>
-	<string name="week_ago_sorttype">Een week geleden</string>
-	<string name="month_ago_sorttype">Een maand geleden</string>
-	<string name="moremonth_ago_sorttype">Meer dan een maand geleden</string>
-	<string name="moreyear_ago_sorttype">Meer dan een jaar geleden</string>
-	<string name="near_me_sorttype">Naast mij</string>
-	<string name="others_sorttype">Andere</string>
-	<string name="food_places">Eten</string>
-	<string name="tourist_places">Bezienswaardigheden</string>
-	<string name="museums">Musea</string>
-	<string name="parks">Parken</string>
-	<string name="swim_places">Zwemmen</string>
-	<string name="mountains">Bergen</string>
-	<string name="animals">Dieren</string>
-	<string name="hotels">Hotels</string>
-	<string name="buildings">Gebouwen</string>
-	<string name="money">Geld</string>
-	<string name="shops">Winkels</string>
-	<string name="parkings">Parkeerplaatsen</string>
-	<string name="fuel_places">Benzinestations</string>
-	<string name="water">Water</string>
-	<string name="medicine">Geneeskunde</string>
 	<string name="search_in_the_list">In de lijst zoeken</string>
-	<string name="view_on_map_bookmarks">Op de kaart</string>
-	<string name="more_bookmarks">Meer…</string>
-	<string name="no_items_found">Niets gevonden</string>
-	<!-- Android, max 18 symbols -->
-	<string name="bookmarks_edit_list">Bewerken</string>
-	<!-- Android, max 18 symbols -->
-	<string name="bookmarks_delete_list">Lijst verwijderen</string>
-	<string name="religious_places">Religieuze plaatsen</string>
 	<string name="select_list">Lijst kiezen</string>
 	<string name="transit_not_found">Metro-navigatie is nog niet beschikbaar in deze regio</string>
 	<string name="dialog_pedestrian_route_is_long_header">Metroroute niet gevonden</string>
 	<string name="dialog_pedestrian_route_is_long_message">Kies een begin- of eindpunt dichter bij het metrostation</string>
-	<!-- Failed planning SUBWAY route message in navigation view -->
-	<string name="routing_planning_error_subway_special">Routeplanner per metro is mislukt</string>
 	<string name="button_layer_isolines">Hoogtes</string>
-	<string name="tips_map_layers_title_countour">Hoogtelijnen offline in Organic Maps!</string>
-	<string name="tips_map_layers_message_countour">Dankzij de hoogtelijnen kunt u probleemloos natuurreizen plannen en er zeker van zijn dat u niet verdwalen zult</string>
 	<string name="isolines_activation_error_dialog">Als u gebruik wilt maken van hoogtelijnen, moet u een kaart van het gewenste gebied bijwerken of downloaden</string>
 	<string name="isolines_location_error_dialog">De hoogtelijnen zijn nog niet beschikbaar in deze regio</string>
 	<string name="elevation_profile_diff_level">Moeilijkheidsgraad</string>
-	<string name="elevation_profile_diff_level_easy">Gemakkelijk</string>
-	<string name="elevation_profile_diff_level_moderate">Middelmatig</string>
-	<string name="elevation_profile_diff_level_hard">Moeilijk</string>
 	<string name="elevation_profile_ascent">Opstijging</string>
 	<string name="elevation_profile_descent">Afdaling</string>
 	<string name="elevation_profile_minaltitude">Min. hoogte</string>
 	<string name="elevation_profile_maxaltitude">Max. hoogte</string>
-	<string name="elevation_profile_m">m</string>
 	<string name="elevation_profile_difficulty">Moeilijkheid</string>
 	<string name="elevation_profile_distance">Afst.:</string>
-	<string name="elevation_profile_km">km</string>
 	<string name="elevation_profile_time">Op weg</string>
-	<string name="elevation_profile_hours">uur</string>
-	<string name="elevation_profile_minutes">min</string>
 	<string name="isolines_toast_zooms_1_10">Zoom in om isolijnen te bekijken</string>
-	<string name="downloader_updating_ios">Updaten</string>
-	<string name="downloader_loading_ios">Downloaden</string>
 	<string name="key_information_title">Belangrijke informatie</string>
 	<string name="enable_screen_sleep">Laat het scherm slapen</string>
 	<!-- Description in preferences -->

--- a/android/res/values-pl/strings.xml
+++ b/android/res/values-pl/strings.xml
@@ -12,15 +12,11 @@
 	<string name="cancel_download">Anuluj pobieranie</string>
 	<!-- Button which deletes downloaded country -->
 	<string name="delete">Usuń</string>
-	<!-- Button "do not interrupt download" if user touched actively downloading country -->
-	<string name="do_nothing">Kontynuuj</string>
 	<string name="download_maps">Pobierz mapy</string>
 	<!-- Settings/Downloader - info for country when download fails -->
 	<string name="download_has_failed">Nie udało się pobrać. Proszę nacisnąć, aby spróbować ponownie.</string>
 	<!-- Settings/Downloader - info for country which started downloading -->
 	<string name="downloading">Pobieranie…</string>
-	<!-- Settings/Downloader - size string, only strings different from English should be translated -->
-	<string name="kb">KB</string>
 	<!-- Choose measurement on first launch alert - choose metric system button -->
 	<string name="kilometres">Kilometry</string>
 	<!-- Leave Review dialog - Review button -->
@@ -33,45 +29,31 @@
 	<string name="core_my_position">Moje położenie</string>
 	<!-- Update maps later/Buy pro version later button text -->
 	<string name="later">Później</string>
-	<!-- Don't show some dialog any more -->
-	<string name="never">Nigdy</string>
 	<!-- View and button titles for accessibility -->
 	<string name="search">Wyszukaj</string>
 	<!-- Search box placeholder text -->
 	<string name="search_map">Wyszukaj mapy</string>
-	<!-- Settings/Downloader - info for not downloaded country -->
-	<string name="touch_to_download">Proszę nacisnąć, aby pobrać.</string>
 	<!-- Settings/Downloader - 3G download warning dialog confirm button -->
 	<string name="use_cellular_data">Tak</string>
 	<!-- Location services are disabled by user alert - message -->
 	<string name="location_is_disabled_long_text">Usługi lokalizacji są aktualnie wyłączone dla tego urządzenia lub aplikacji. Proszę włączyć je w ustawieniach.</string>
-	<!-- Location Services are not available on the device alert - message -->
-	<string name="device_doesnot_support_location_services">Urządzenie nie obsługuje usług lokalizacji</string>
 	<!-- View and button titles for accessibility -->
 	<string name="zoom_to_country">Wyświetl na mapie</string>
-	<!-- Button text for the button at the center of the screen when the country is not downloaded -->
-	<string name="country_status_download">Pobierz mapę\n(^ ^)</string>
 	<!-- Button text for the button at the center of the screen when the country is not downloaded and the size should not be shown -->
 	<string name="country_status_download_without_size">Pobierz mapę</string>
-	<!-- Button text for the button at the center of the screen when the country is not downloaded -->
-	<string name="country_status_download_without_routing">Pobierz mapę bez\noznaczania tras (^ ^)</string>
 	<!-- Message to display at the center of the screen when the country download has failed -->
 	<string name="country_status_download_failed">Nie udało się pobrać</string>
 	<!-- Button text for the button under the country_status_download_failed message -->
 	<string name="try_again">Spróbuj ponownie</string>
 	<string name="about_menu_title">O aplikacji Organic Maps</string>
-	<string name="downloaded_touch_to_delete">Pobrano (%s). Proszę nacisnąć, aby usunąć.</string>
 	<string name="connection_settings">Ustawienia połączenia</string>
-	<string name="download_mb_or_kb">Pobierz %s</string>
 	<string name="close">Zamknij</string>
 	<string name="unsupported_phone">Wymagana jest sprzętowa akceleracja OpenGL. Aktualne urządzenie nie jest obsługiwane.</string>
 	<string name="download">Pobierz</string>
-	<string name="external_storage_is_not_available">Karta SD/Pamięć USB z pobranymi mapami nie jest dostępna</string>
 	<string name="disconnect_usb_cable">Proszę odłączyć kabel USB albo włożyć kartę pamięci, aby korzystać z Organic Maps</string>
 	<string name="not_enough_free_space_on_sdcard">Proszę zwolnić trochę pamięci na karcie SD/pamięci USB, aby korzystać z aplikacji</string>
 	<string name="not_enough_memory">Za mało pamięci, aby uruchomić aplikację</string>
 	<string name="download_resources">Przed rozpoczęciem prosimy o pobranie ogólnej mapy świata na urządzenie.\nWymaga to %s danych.</string>
-	<string name="getting_position">Określanie aktualnego położenia</string>
 	<string name="download_resources_continue">Przejdź do mapy</string>
 	<string name="downloading_country_can_proceed">Pobieranie %s. Można teraz\nprzejść do mapy.</string>
 	<string name="download_country_ask">Pobrać %s?</string>
@@ -84,30 +66,20 @@
 	<string name="download_country_failed">Nie udało się pobrać %s</string>
 	<!-- Add New Bookmark Set dialog title -->
 	<string name="add_new_set">Dodaj nowy zestaw</string>
-	<!-- Place Page - Add To Bookmarks button -->
-	<string name="add_to_bookmarks">Dodaj zakładkę</string>
 	<!-- Bookmark Color dialog title -->
 	<string name="bookmark_color">Kolor zakładki</string>
 	<!-- Add Bookmark Set dialog - hint when set name is empty -->
 	<string name="bookmark_set_name">Nazwa zestawu zakładek</string>
-	<!-- Bookmark Sets dialog title -->
-	<string name="bookmark_sets">Zestawy zakładek</string>
 	<!-- Bookmarks - dialog title -->
 	<string name="bookmarks">Zakładki</string>
-	<!-- Add bookmark dialog - bookmark color -->
-	<string name="color">Kolor</string>
 	<!-- Default bookmarks set name -->
 	<string name="core_my_places">Moje miejsca</string>
 	<!-- Add bookmark dialog - bookmark name -->
 	<string name="name">Nazwa</string>
 	<!-- Editor title above street and house number -->
 	<string name="address">Adres</string>
-	<!-- Place Page - Remove Pin button -->
-	<string name="remove_pin">Usuń znacznik</string>
 	<!-- Add bookmark dialog - bookmark set, Bookmarks dialog - Bookmark set cell -->
 	<string name="set">Zestaw</string>
-	<!-- Text hint in Bookmarks dialog when no any bookmarks are added -->
-	<string name="bookmarks_usage_hint">Nie oznaczono jeszcze żadnych zakładek.\nProszę dotknąć dowolnego miejsca na mapie, aby dodać zakładkę.\nMożna importować i wyświetlać zakładki z innych zasobów. Program otwiera pliki KML/KMZ z zapisanymi zakładkami, pochodzące z wiadomości email, Dropboxa lub odnośników internetowych.</string>
 	<!-- Settings button in system menu -->
 	<string name="settings">Ustawienia</string>
 	<!-- Header of settings activity where user defines storage path -->
@@ -118,20 +90,10 @@
 	<string name="move_maps">Przenieść mapy?</string>
 	<!-- Ask to wait user several minutes (some long process in modal dialog). -->
 	<string name="wait_several_minutes">To może zająć kilka minut.\nProszę czekać…</string>
-	<!-- Show bookmarks from this category on a map or not -->
-	<string name="visible">Widoczne</string>
-	<!-- Toast which is displayed when GPS has been deactivated -->
-	<string name="gps_is_disabled_long_text">GPS jest wyłączony. Proszę włączyć go w ustawieniach.</string>
 	<!-- Measurement units title in settings activity -->
 	<string name="measurement_units">Jednostki miary</string>
 	<!-- Detailed description of Measurement Units settings button -->
 	<string name="measurement_units_summary">Wybiera pomiędzy milami, a kilometrami</string>
-	<!-- Do search in all sources -->
-	<string name="search_mode_all">Wszędzie</string>
-	<!-- Do search near my position only -->
-	<string name="search_mode_nearme">W pobliżu mnie</string>
-	<!-- Do search in current viewport only -->
-	<string name="search_mode_viewport">Na ekranie</string>
 	<!-- Search category for cafes, bars, restaurants -->
 	<string name="eat">Gdzie zjeść</string>
 	<!-- Search category for grocery stores -->
@@ -168,12 +130,8 @@
 	<string name="post">Poczta</string>
 	<!-- Search category -->
 	<string name="police">Policja</string>
-	<!-- String in search result list, when nothing found -->
-	<string name="no_search_results_found">Nie odnaleziono</string>
 	<!-- Notes field in Bookmarks view -->
 	<string name="description">Notatki</string>
-	<!-- Button text -->
-	<string name="share_by_email">Udostępnij przez email</string>
 	<!-- Email Subject when sharing bookmarks category -->
 	<string name="share_bookmarks_email_subject">Udostępnione zakładki z Organic Maps</string>
 	<!-- message title of loading file -->
@@ -186,20 +144,10 @@
 	<string name="edit">Edytuj</string>
 	<!-- Warning message when doing search around current position -->
 	<string name="unknown_current_position">Nie określono jeszcze aktualnego położenia</string>
-	<!-- Warning message when location country isn't downloaded during search (see also download_location_map_proposal). -->
-	<string name="download_location_country">Pobierz mapę kraju, w którym aktualnie przebywasz (%s)</string>
-	<!-- Warning message when viewport country isn't downloaded during search -->
-	<string name="download_viewport_country_to_search">Pobierz mapę kraju, którego aktualnie poszukujesz (%s)</string>
 	<!-- Alert message that we can't run Map Storage settings due to some reasons. -->
 	<string name="cant_change_this_setting">Przepraszamy, ustawienia pamięci mapy są aktualnie wyłączone.</string>
 	<!-- Alert message that downloading is in progress. -->
 	<string name="downloading_is_active">Trwa pobieranie mapy kraju.</string>
-	<!-- Message that will be shown in alert view, when we ask user to leave review on App Store -->
-	<string name="appStore_message">Mamy nadzieję, że podoba ci się aplikacja Organic Maps! Jeśli tak to proszę oceń ją lub napisz recenzję w AppStore. To zajmie mniej niż minutę, a bardzo nam pomoże. Dziękujemy za wsparcie!</string>
-	<!-- No, thanks -->
-	<string name="no_thanks">Nie, dziękuję</string>
-	<!-- Share one specific bookmark using SMS, %1$@ contains om:// and %2$@ https://omaps.app link. @NOTE non-ascii symbols in the link will result in max 70 characters SMS instead of 140. -->
-	<string name="bookmark_share_sms">Mój znacznik w Organic Maps %1$s i %2$s</string>
 	<!-- Share my position using SMS, %1$@ contains om:// and %2$@ https://omaps.app link WITHOUT NAME. @NOTE non-ascii symbols in the link will result in max 70 characters SMS instead of 140. -->
 	<string name="my_position_share_sms">Zobacz gdzie jestem. Link %1$s lub %2$s</string>
 	<!-- Subject for emailed bookmark -->
@@ -208,30 +156,16 @@
 	<string name="my_position_share_email_subject">Zobacz moją aktualną lokalizację na mapie przy użyciu Organic Maps</string>
 	<!-- Share my position using EMail, %1$@ is om:// and %2$@ is https://omaps.app link WITHOUT NAME -->
 	<string name="my_position_share_email">Cześć,\n\nJestem teraz tutaj: %1$s. Naciśnij na ten link %2$s lub ten %3$s, aby zobaczyć to miejsce na mapie.\n\nDziękuję.</string>
-	<!-- Android share by Message/SMS button text (including SMS) -->
-	<string name="share_by_message">Udostępnij przez wiadomość</string>
 	<!-- Share button text which opens menu with more buttons, like Message, EMail, Facebook etc. -->
 	<string name="share">Udostępnij</string>
-	<!-- iOS share by Message button text (including SMS) -->
-	<string name="message">Wiadomość</string>
 	<!-- Share by email button text, also used in editor. -->
 	<string name="email">Email</string>
-	<!-- Copy Link -->
-	<string name="copy_link">Skopiuj odnośnik</string>
-	<!-- Text for the button that returns to caller application -->
-	<string name="more_info">Pokaż więcej informacji</string>
 	<!-- Text for message when used successfully copied something -->
 	<string name="copied_to_clipboard">Skopiowano do schowka: %1$s</string>
 	<!-- place preview title -->
 	<string name="info">Informacje</string>
 	<!-- Used for bookmark editing -->
 	<string name="done">Gotowe</string>
-	<!-- Summary for preferences in MWM -->
-	<string name="yopme_pref_summary">Wybierz ustawienia tylnego ekranu</string>
-	<!-- Title for yopme preferences in MWM -->
-	<string name="yopme_pref_title">Ustawienia tylnego ekranu</string>
-	<!-- Hint for upper-right icon p2b -->
-	<string name="show_on_backscreen">Pokaż na tylnym ekranie</string>
 	<!-- Prints version number in About dialog -->
 	<string name="version">Wersja: %s</string>
 	<!-- Data version in «About» screen -->
@@ -243,15 +177,10 @@
 	<!-- Length of track in cell that describes route -->
 	<string name="length">Długość</string>
 	<string name="share_my_location">Udostępnij aktualne położenie</string>
-	<string name="menu_search">Wyszukaj</string>
 	<!-- Settings general group in settings screen -->
 	<string name="prefs_group_general">Ustawienia ogólne</string>
 	<!-- Settings information group in settings screen -->
 	<string name="prefs_group_information">Informacje</string>
-	<!-- Settings screen: "Map" category title -->
-	<string name="prefs_group_map">Mapa</string>
-	<!-- Settings screen: "Miscellaneous" category title -->
-	<string name="prefs_group_misc">Różne</string>
 	<string name="prefs_group_route">Nawigacja</string>
 	<string name="pref_zoom_title">Przyciski przybliżania</string>
 	<string name="pref_zoom_summary">Wyświetla na ekranie</string>
@@ -267,8 +196,6 @@
 	<string name="pref_map_3d_title">Widok z perspektywy</string>
 	<!-- Settings «Map» category: «3D buildings» title -->
 	<string name="pref_map_3d_buildings_title">Budynki w 3D</string>
-	<!-- Settings «Map» category: «3D buildings» summary -->
-	<string name="pref_map_3d_buildings_subtitle">Wpływa na czas pracy baterii</string>
 	<!-- Settings «Route» category: «Tts enabled» title -->
 	<string name="pref_tts_enable_title">Komunikaty głosowe</string>
 	<!-- Settings «Route» category: «Tts language» title -->
@@ -277,7 +204,6 @@
 	<string name="pref_tts_unavailable">Niedostępne</string>
 	<!-- Title for "Other" section in TTS settings. -->
 	<string name="pref_tts_other_section_title">Inny</string>
-	<string name="pref_tts_how_to_set_up_voice">Jak skonfigurować usługę głosową</string>
 	<!-- Settings «Map» category: «Record track» title -->
 	<string name="pref_track_record_title">Ostatnia trasa</string>
 	<string name="pref_map_auto_zoom">Automatyczne powiększanie</string>
@@ -288,46 +214,11 @@
 	<string name="duration_12_hours">12 godzin</string>
 	<string name="duration_1_day">1 dzień</string>
 	<string name="recent_track_help_text">Umożliwia na pewien okres zapisanie przebytej trasy i obejrzenie jej na mapie. Uwaga: włączenie tej funkcji spowoduje większe zużycie baterii. Trasa zostanie usunięta z mapy automatycznie po upływie określonego czasu.</string>
-	<string name="pref_track_ios_caption">Ostatnia trasa pokazuje pokonaną przez Ciebie ścieżkę.</string>
-	<string name="pref_track_ios_subcaption">Wybierz zakres czasowy dla zapisywanej trasy.</string>
-	<string name="placepage_distance">Dystans</string>
-	<string name="placepage_coordinates">Współrzędne</string>
-	<string name="placepage_unsorted">Niesklasyfikowane</string>
 	<string name="search_show_on_map">Wyświetl na mapie</string>
-	<!-- Used to warn user when fixing KitKat issue -->
-	<string name="bookmark_move_fail">Musimy przenieść Twoje zakładki do pamięci wewnętrznej, ale nie ma tam dla nich wolnego miejsca. Prosimy zwolnić pamięć, inaczej zakładki nie będą dostępne.</string>
-	<!-- Used in More Apps menu -->
-	<string name="free">Darmowy</string>
-	<!-- Used in More Apps menu -->
-	<string name="buy">Kup</string>
-	<!-- 1st search button-like result -->
-	<string name="search_on_map">Szukaj na mapie</string>
-	<!-- toast with an error -->
-	<string name="no_route_found">Nie znaleziono trasy</string>
-	<!-- route title -->
-	<string name="route">Trasa</string>
-	<!-- category title -->
-	<string name="routes">Marszruty</string>
-	<!-- text of notification -->
-	<string name="download_map_notification">Pobierz mapę miejsca, w którym się zajdujesz</string>
-	<!-- text of notification -->
-	<string name="pro_version_is_free_today">Pełna wersja Organic Maps jest dziś za darmo! Pobierz teraz i powiedz znajomym.</string>
-	<!-- Dialog for transferring maps from lite to pro. -->
-	<string name="move_lite_maps_to_pro">Przenosimy twoje pobrane mapy z Organic Maps Lite do Organic Maps. Może to zająć kilka minut.</string>
-	<!-- Message to display when maps moved. -->
-	<string name="move_lite_maps_to_pro_ok">Pomyślnie przeniesiono twoje pobrane mapy do Organic Maps.</string>
-	<!-- Message to display when maps move failed. -->
-	<string name="move_lite_maps_to_pro_failed">Nie udało się przenieść twoich map. Proszę skasować Organic Maps Lite i pobrać mapy ponownie.</string>
-	<!-- Text in menu -->
-	<string name="settings_and_more">Ustawienia i inne</string>
 	<!-- Text in menu -->
 	<string name="website">Strona internetowa</string>
-	<!-- Text in menu -->
-	<string name="contact_us">Skontaktuj się z nami</string>
 	<!-- Settings: Send feedback button and dialog title -->
 	<string name="feedback">Opinia</string>
-	<!-- Text in menu -->
-	<string name="subscribe_to_news">Subskrybuj nasze wiadomości</string>
 	<!-- Text in menu -->
 	<string name="rate_the_app">Oceń aplikację</string>
 	<!-- Text in menu -->
@@ -336,12 +227,6 @@
 	<string name="copyright">Prawa autorskie</string>
 	<!-- Text in menu -->
 	<string name="report_a_bug">Zgłoś błąd</string>
-	<!-- Email subject -->
-	<string name="subscribe_me_subject">Chcę subskrybować biuletyn Organic Maps</string>
-	<!-- Email body -->
-	<string name="subscribe_me_body">Chcę w pierwszej kolejności otrzymywać powiadomienia o nowościach aktualizacjach i promocjach. Mogę w każdej chwili anulować swoją subskrypcję.</string>
-	<!-- About text -->
-	<string name="about_text">Organic Maps oferuje najszybsze mapy offline wszystkich miast we wszystkich krajach świata. Podróżuj bez obaw: gdziekolwiek jesteś, Organic Maps pomoże Ci odszukać się na mapie, znaleźć najbliższą restaurację, hotel, bank, stację benzynową itp. Aplikacja nie wymaga połączenia z Internetem.\n\nNieustannie pracujemy nad nowymi funkcjami i chcielibyśmy dowiedzieć się, jak Twoim zdaniem moglibyśmy poprawić Organic Maps. Jeśli masz jakieś problemy z aplikacją, skontaktuj się z nami, pisząc na adres support\@organicmaps.app. Odpowiemy na każde zapytanie!\n\nLubisz aplikację Organic Maps i chcesz udzielić nam wsparcia? Istnieje kilka prostych i absolutnie darmowych sposobów, jak to zrobić:\n\n- napisz recenzję w swoim sklepie z aplikacjami\n- polub naszą stronę na Facebooku: http://www.facebook.com/OrganicMaps\n- albo po prostu opowiedz o Organic Maps swojej mamie, znajomym i kolegom :)\n\nDziękujemy, że jesteś z nami. Jesteśmy bardzo wdzięczni za Twoje wsparcie!\n\nP.S. Dane mapy pochodzą z OpenStreetMap, projektu kartograficznego podobnego do Wikipedii, który umożliwia użytkownikom tworzenie i edytowanie map. Jeśli zauważysz, że na mapie czegoś brakuje albo jest błąd, możesz nanieść poprawki bezpośrednio na stronie https://www.openstreetmap.org, a Twoje zmiany pojawią się w aplikacji Organic Maps po wydaniu kolejnej wersji.</string>
 	<!-- Alert text -->
 	<string name="email_error_body">Email klienta nie został założony. Proszę skonfigurować adres email, bądź skorzystać z innych opcji, aby się z nami skontaktować na %s</string>
 	<!-- Alert title -->
@@ -350,137 +235,56 @@
 	<string name="pref_calibration_title">Kalibracja kompasu</string>
 	<!-- Search category -->
 	<string name="wifi">WiFi</string>
-	<!-- Update map suggestion -->
-	<string name="routing_map_outdated">Proszę zaktualizować mapę, by utworzyć trasę.</string>
-	<!-- Update maps suggestion -->
-	<string name="routing_update_maps">Nowa wersja aplikacji Organic Maps pozwala na tworzenie tras z Twojej bieżącej lokalizacji do punktu docelowego. Proszę zaktualizować mapy, by móc korzystać z tej funkcji.</string>
 	<!-- Update all button text -->
 	<string name="downloader_update_all_button">Aktualizuj wszystkie</string>
 	<!-- Cancel all button text -->
 	<string name="downloader_cancel_all">Anuluj wszystko</string>
 	<!-- Downloaded maps category -->
 	<string name="downloader_downloaded_subtitle">Pobrane</string>
-	<!-- Downloaded maps category -->
-	<string name="downloader_available_maps">Dostępne</string>
 	<!-- Country queued for download -->
 	<string name="downloader_queued">W kolejce</string>
 	<string name="downloader_near_me_subtitle">Blisko mnie</string>
 	<string name="downloader_status_maps">Mapy</string>
 	<string name="downloader_download_all_button">Pobierz wszystkie</string>
 	<string name="downloader_downloading">Pobieranie:</string>
-	<string name="downloader_search_results">Znaleziono</string>
-	<!-- Disclaimer message -->
-	<string name="routing_disclaimer">Podczas tworzenia tras w aplikacji Organic Maps pamiętaj o poniższych zasadach:\n\n  - Sugerowane trasy mogą być traktowane jedynie jako propozycje.\n - Warunki na drodze, przepisy ruchu drogowego i znaki mają większy priorytet niż wskazówki nawigacyjne.\n - Mapa może okazać się nieprawidłowa lub nieaktualna a trasy mogą nie zostać utworzone w sposób najlepszy z możliwych.\n\n  Szerokiej drogi, uważaj na siebie!</string>
-	<!-- Outdated maps category -->
-	<string name="downloader_outdated_maps">Nieaktualne</string>
-	<!-- Up to date maps category -->
-	<string name="downloader_uptodate_maps">Najnowsze</string>
 	<!-- Status of outdated country in the list -->
 	<string name="downloader_status_outdated">Aktualizacja</string>
 	<!-- Status of failed country in the list -->
 	<string name="downloader_status_failed">Nieudane</string>
 	<!-- Displayed in a dialog that appears when a user tries to delete a map while the app is in the follow route mode -->
 	<string name="downloader_delete_map_while_routing_dialog">Aby usunąć mapę, zatrzymaj nawigację.</string>
-	<!-- Show when user try build route, but we don't know where he -->
-	<string name="routing_failed_unknown_my_position">Bieżąca lokalizacja nie została zdefiniowana. Aby utworzyć trasę, określ lokalizację.</string>
-	<!-- Show if use has not routing file, or InconsistentMWMandRoute -->
-	<string name="routing_failed_has_no_routing_file">Aby stworzyć trasę, potrzebne są dodatkowe dane. Rozpocząć pobieranie?</string>
-	<!-- StartPointNotFound -->
-	<string name="routing_failed_start_point_not_found">Nie można obliczyć trasy. Brak dróg w pobliżu punktu rozpoczęcia podróży.</string>
-	<!-- EndPointNotFound -->
-	<string name="routing_failed_dst_point_not_found">Nie można obliczyć trasy. Brak dróg w pobliżu celu podróży.</string>
 	<!-- PointsInDifferentMWM -->
 	<string name="routing_failed_cross_mwm_building">Trasy można tworzyć tylko pod warunkiem, że zawarte będą w ramach pojedynczej mapy.</string>
-	<!-- RouteNotFound -->
-	<string name="routing_failed_route_not_found">Nie znaleziono trasy pomiędzy wybranym punktem rozpoczęcia podróży a jej celem. Wybierz inny punkt początkowy lub końcowy.</string>
-	<!-- InternalError -->
-	<string name="routing_failed_internal_error">Wystąpił wewnętrzny błąd. Spróbuj usunąć mapę i pobrać ją ponownie. Jeśli problem będzie się nadal powtarzał, skontaktuj się z nami pod adresem support\@organicmaps.app.</string>
-	<!-- Context menu item for downloader. -->
-	<string name="downloader_download_map_and_routing">Pobierz mapę + wyznaczanie tras</string>
-	<!-- Context menu item for downloader. -->
-	<string name="downloader_download_routing">Pobierz wyznaczanie tras</string>
-	<!-- Context menu item for downloader. -->
-	<string name="downloader_delete_routing">Skasuj wyznaczanie tras</string>
 	<!-- Context menu item for downloader. -->
 	<string name="downloader_download_map">Pobierz mapę</string>
-	<string name="downloader_download_map_no_routing">Pobierz mapę bez oznaczania tras</string>
-	<!-- Button for routing. -->
-	<string name="routing_go">Przejdź!</string>
 	<!-- Item status in downloader. -->
 	<string name="downloader_retry">Powtórz</string>
-	<!-- Item in context menu. -->
-	<string name="downloader_map_and_routing">Mapa + trasy</string>
 	<!-- Item in context menu. -->
 	<string name="downloader_delete_map">Usuń mapę</string>
 	<!-- Item in context menu. -->
 	<string name="downloader_update_map">Aktualizuj mapę</string>
-	<!-- Item in context menu. -->
-	<string name="downloader_update_map_and_routing">Aktualizuj mapę + trasy</string>
-	<!-- Item in context menu. -->
-	<string name="downloader_map_only">Tylko mapa</string>
-	<!-- Toolbar title -->
-	<string name="toolbar_application_menu">Menu aplikacji</string>
 	<!-- Preference text -->
 	<string name="pref_use_google_play">Używa usług Google Play do ustalenia aktualnego położenia</string>
 	<!-- Text for rating dialog -->
 	<string name="rating_just_rated">Właśnie oceniłem Waszą aplikację</string>
-	<!-- Text for rating dialog -->
-	<string name="rating_user_since">Jestem użytkownikiem Organic Maps od %s r.</string>
-	<!-- Text for rating dialog -->
-	<string name="rating_do_like_maps">Lubisz Organic Maps?</string>
-	<!-- Text for rating dialog -->
-	<string name="rating_tap_star">Stuknij gwiazdkę, by ocenić naszą aplikację.</string>
 	<!-- Text for rating dialog -->
 	<string name="rating_thanks">Dziękujemy!</string>
 	<!-- Text for rating dialog -->
 	<string name="rating_share_ideas">Podziel się z nami pomysłami lub problemami, a pozwoli to nam usprawnić aplikację.</string>
 	<!-- Text for rating dialog -->
 	<string name="rating_send_feedback">Wyślij opinię</string>
-	<!-- Text for g+ dialog -->
-	<string name="rating_google_plus">Kliknij g+, aby powiedzieć swoim znajomym o tej apce.</string>
 	<!-- Text for routing error dialog -->
 	<string name="routing_download_maps_along">Pobierz mapy wzdłuż trasy</string>
-	<!-- Text for routing error dialog -->
-	<string name="routing_download_map">Pobierz mapę</string>
-	<!-- Text for routing error dialog -->
-	<string name="routing_download_map_and_routing">Pobierz zaktualizowaną mapę i dane ustalania tras, by mieć dostęp do wszystkich funkcji Organic Maps.</string>
-	<!-- Text for routing error dialog -->
-	<string name="routing_get_routing_data">Pobierz dane ustalania tras</string>
-	<!-- Text for routing error dialog -->
-	<string name="routing_get_additional_data">Dodatkowe dane wymagane do tworzenia tras z Twojej lokalizacji.</string>
 	<!-- Text for routing error dialog -->
 	<string name="routing_requires_all_map">Tworzenie tras wymaga pobrania i zaktualizowania wszystkich map od Twojej lokalizacji do celu podróży.</string>
 	<!-- Text for routing error dialog -->
 	<string name="routing_not_enough_space">Brak wolnego miejsca</string>
-	<!-- Text for routing error dialog -->
-	<string name="routing_download_more_than_avail">Musisz pobrać %1$s MB, lecz dostępne jest tylko %2$s MB.</string>
-	<!-- Text for routing error dialog -->
-	<string name="routing_download_roaming">%s MB do pobrania przy wykorzystaniu danych mobilnych (w roamingu). Może to oznaczać dodatkowe opłaty w zależności od planu danych mobilnych Twojego dostawcy usług.</string>
 	<!-- bookmark button text -->
 	<string name="bookmark">zakładka</string>
-	<!-- map is not downloaded -->
-	<string name="not_found_map">Nie znaleziono mapy Twojej lokalizacji</string>
 	<!-- location service disabled -->
 	<string name="enable_location_services">Proszę włączyć usługi lokalizacji</string>
-	<!-- download map -->
-	<string name="download_map">Pobierz mapę dla swojej lokalizacji</string>
-	<!-- download map on iPhone -->
-	<string name="download_map_iphone">Pobierz na swojego iPhone\'a mapę dla bieżącej lokalizacji</string>
-	<!-- clear pin -->
-	<string name="nearby">W pobliżu</string>
-	<!-- clear pin -->
-	<string name="clear_pin">Wyczyść pinezkę</string>
-	<!-- location is undefined -->
-	<string name="undefined_location">Bieżąca lokalizacja nie została zdefiniowana.</string>
-	<!-- download country of your location -->
-	<string name="download_country">Pobierz mapę kraju, w którym aktualnie przebywasz</string>
-	<!-- download failed -->
-	<string name="download_failed">pobieranie nie powiodło się</string>
-	<!-- get the map -->
-	<string name="get_the_map">Pobierz mapę</string>
 	<string name="save">Zapisz</string>
 	<string name="edit_description_hint">Twoje opisy (tekst lub html)</string>
-	<string name="new_group">nowa grupa</string>
 	<string name="create">utwórz</string>
 	<!-- red color -->
 	<string name="red">Czerwony</string>
@@ -498,22 +302,6 @@
 	<string name="brown">Brązowy</string>
 	<!-- pink color -->
 	<string name="pink">Różowy</string>
-	<!-- deep purple color -->
-	<string name="deep_purple">Ciemnopurpurowy</string>
-	<!-- light blue color -->
-	<string name="light_blue">Jasnoniebieski</string>
-	<!-- cyan color -->
-	<string name="cyan">Niebieskozielony</string>
-	<!-- teal color -->
-	<string name="teal">Szmaragdowy</string>
-	<!-- lime color -->
-	<string name="lime">Lima</string>
-	<!-- deep orange color -->
-	<string name="deep_orange">Ciemnopomarańczowy</string>
-	<!-- gray color -->
-	<string name="gray">Szary</string>
-	<!-- blue gray color -->
-	<string name="blue_gray">Szaroniebieski</string>
 	<!-- Wi-Fi available -->
 	<string name="WiFi_available">Tak</string>
 
@@ -529,10 +317,8 @@
 	<string name="dialog_routing_location_turn_wifi">Sprawdź sygnał GPS. Aktywacja Wi-Fi pomoże w precyzyjnym określeniu położenia.</string>
 	<string name="dialog_routing_location_turn_on">Włącz usługi określania lokalizacji</string>
 	<string name="dialog_routing_location_unknown_turn_on">Nie można ustalić współrzędnych GPS. Włącz usługi określania lokalizacji, aby wyznaczyć trasę.</string>
-	<string name="dialog_routing_location_unknown">Nie można ustalić współrzędnych GPS.</string>
 	<string name="dialog_routing_download_files">Pobierz wymagane pliki</string>
 	<string name="dialog_routing_download_and_update_all">Pobierz i zaktualizuj dane mapy i wyznaczania trasy wzdłuż planowanej drogi, aby wyznaczyć trasę.</string>
-	<string name="dialog_routing_routes_size">Pliki wyznaczania trasy</string>
 	<string name="dialog_routing_unable_locate_route">Nie można zlokalizować trasy</string>
 	<string name="dialog_routing_cant_build_route">Nie można wyznaczyć trasy.</string>
 	<string name="dialog_routing_change_start_or_end">Zmień punkt początkowy lub docelowy.</string>
@@ -547,33 +333,23 @@
 	<string name="dialog_routing_system_error">Błąd systemowy</string>
 	<string name="dialog_routing_application_error">Nie można wyznaczyć trasy z powodu błędu aplikacji.</string>
 	<string name="dialog_routing_try_again">Spróbuj ponownie</string>
-	<string name="dialog_routing_send_error">Zgłoś problem</string>
-	<string name="dialog_routing_if_get_cross_route">Chcesz wyznaczyć lepszą trasę, obejmującą więcej map?</string>
-	<string name="dialog_routing_cross_route_is_optimal">Dostępna jest lepsza trasa, wykraczająca poza granice bieżącej mapy.</string>
 	<string name="not_now">Nie teraz</string>
-	<string name="dialog_routing_build_route">Wyznacz</string>
 	<string name="dialog_routing_download_and_build_cross_route">Chcesz pobrać mapę i wyznaczyć lepszą trasę, obejmującą więcej map?</string>
 	<string name="dialog_routing_download_cross_route">Pobierz mapę i wyznacz lepszą trasę, wykraczającą poza granice bieżącej mapy.</string>
-	<string name="dialog_routing_cross_route_always">Zawsze przekraczaj tę granicę</string>
 
 	<!-- SECTION: Strings for downloading map from search -->
 	<string name="search_without_internet_advertisement">Aby rozpocząć wyszukiwanie i tworzenie tras, pobierz mapę, a nie będzie ci już potrzebne połączenie z Internetem.</string>
 	<string name="search_select_map">Wybierz mapę</string>
-	<string name="search_select_other_map">Wybierz inną mapę</string>
 	<!-- «Show» context menu -->
 	<string name="show">Pokaż</string>
 	<!-- «Hide» context menu -->
 	<string name="hide">Ukryj</string>
 	<!-- «Rename» context menu -->
 	<string name="rename">Zmień nazwę</string>
-	<!-- Bottom sheet: expand button (should be short) -->
-	<string name="bottom_sheet_more">Więcej…</string>
 	<!-- Failed planning route message in navigation view -->
 	<string name="routing_planning_error">Planowanie trasy nieudane</string>
 	<!-- Arrive routing message in navigation view -->
 	<string name="routing_arrive">Przybycie: %s</string>
-	<!-- Text for routing::RouterResultCode::FileTooOld dialog. -->
-	<string name="dialog_routing_download_and_update_maps">Aby utworzyć trasę, pobierz i zaktualizuj wszystkie właściwe dla niej mapy.</string>
 	<string name="rate_alert_title">Lubisz tę aplikację?</string>
 	<string name="rate_alert_default_message">Dziękujemy za korzystanie z Organic Maps. Prosimy wystawić aplikacji ocenę. Twoja opinia pozwoli nam udoskonalać nasze produkty.</string>
 	<string name="rate_alert_five_star_message">Hurra! My też Cię uwielbiamy!</string>
@@ -581,24 +357,14 @@
 	<string name="rate_alert_less_than_four_star_message">Czy masz pomysł, w jaki sposób możemy dokonać ulepszeń?</string>
 	<string name="categories">Kategorie</string>
 	<string name="history">Historia</string>
-	<string name="next_turn_then">Potem</string>
 	<string name="closed">Zamknięte</string>
-	<string name="back_to">Powróć do %s</string>
 	<string name="search_not_found">Przepraszamy, nic nie znaleziono.</string>
 	<string name="search_not_found_query">Wpisz inne zapytanie.</string>
-	<string name="search_not_found_map">Pobierz mapę interesującego cię obszaru.</string>
-	<string name="search_not_found_location">Pobierz mapę swojej bieżącej lokalizacji.</string>
 	<string name="search_history_title">Historia wyszukiwania</string>
 	<string name="search_history_text">Uzyskaj szybki dostęp do ostatniego hasła wyszukiwania.</string>
 	<string name="clear_search">Wyczyść historię wyszukiwania</string>
-	<!-- Title for settings to enable/disable showcase menu button -->
-	<string name="showcase_settings_title">Oferty</string>
-	<string name="p2p_route_planning">Planowanie trasy</string>
 	<string name="p2p_your_location">Twoja lokalizacja</string>
-	<string name="p2p_from">Miejsce wyjazdu</string>
-	<string name="p2p_to">Miejsce docelowe</string>
 	<string name="p2p_start">Start</string>
-	<string name="p2p_planning">Planowanie…</string>
 	<string name="p2p_from_here">Z</string>
 	<string name="p2p_to_here">Droga do</string>
 	<string name="p2p_only_from_current">Nawigacja jest dostępna tylko od twojej bieżącej lokalizacji.</string>
@@ -618,11 +384,8 @@
 	<string name="editor_hours_closed">Godziny zamknięcia</string>
 	<string name="editor_example_values">Przykładowe wartości</string>
 	<string name="editor_correct_mistake">Popraw błąd</string>
-	<string name="editor_correct_mistake_message">Popełniono błąd podczas edycji. Popraw go lub przełącz się na tryb prosty.</string>
 	<string name="editor_add_select_location">Lokalizacja</string>
 	<string name="editor_done_dialog_1">Dokonałeś zmian na mapie świata. Nie kryj się z tym! Powiadom znajomych i edytujcie mapę razem.</string>
-	<string name="editor_done_dialog_2">Po raz drugi dokonałeś poprawek na mapie. Aktualnie znajdujesz się na %d miejscu na liście osób edytujących mapy. Opowiedz o tym znajomym.</string>
-	<string name="editor_done_dialog_3">Dokonałeś poprawek na mapie. Opowiedz o tym znajomym i razem ją edytujcie.</string>
 	<string name="share_with_friends">Udostępnij znajomym</string>
 	<string name="editor_report_problem_desription_1">Prosimy o szczegółowe opisanie problemu, aby użytkownicy OpenStreetMap mogli naprawić błąd.</string>
 	<string name="editor_report_problem_desription_2">Albo zrób to sam na https://www.openstreetmap.org/</string>
@@ -631,14 +394,7 @@
 	<string name="editor_report_problem_no_place_title">To miejsce nie istnieje</string>
 	<string name="editor_report_problem_under_construction_title">Zamknięte z powodu prac konserwacyjnych</string>
 	<string name="editor_report_problem_duplicate_place_title">Powielone miejsce</string>
-	<string name="first_launch_congrats_title">Aplikacja Organic Maps jest gotowa</string>
-	<string name="first_launch_congrats_text">Wyszukuj i nawiguj w każdym zakątku świata — offline i bezpłatnie.</string>
-	<string name="migrate_title">Ważne!</string>
-	<!-- Android uses image instead of text. -->
-	<string name="download_all">Pobierz wszystko</string>
-	<string name="delete_all">Usuń wszystkie</string>
 	<string name="autodownload">Automatyczne pobieranie</string>
-	<string name="disable_autodownload">Wyłącz automatyczne pobieranie</string>
 	<!-- Place Page opening hours text -->
 	<string name="closed_now">Nieczynne</string>
 	<!-- Place Page opening hours text -->
@@ -647,8 +403,6 @@
 	<string name="day_off_today">Dziś nieczynne</string>
 	<string name="day_off">Nieczynne</string>
 	<string name="today">Dzisiaj</string>
-	<string name="sunrise_to_sunset">Od wschodu do zachodu słońca</string>
-	<string name="sunset_to_sunrise">Od zachodu do wschodu słońca</string>
 	<string name="add_opening_hours">Dodaj godziny otwarcia</string>
 	<string name="edit_opening_hours">Edytuj godziny otwarcia</string>
 	<string name="no_osm_account">Nie masz konta w OpenStreetMap?</string>
@@ -658,29 +412,13 @@
 	<string name="login">Zaloguj się</string>
 	<string name="password">Hasło</string>
 	<string name="forgot_password">Nie pamiętasz hasła?</string>
-	<!-- Forgot Password dialog title -->
-	<string name="restore_password">Przypomnij hasło</string>
-	<string name="enter_email_address_to_reset_password">Wpisz adres email, którego użyto podczas rejestracji, a prześlemy Ci link do ponownego utworzenia hasła.</string>
-	<string name="reset_password">Resetuj hasło</string>
-	<string name="username">Nazwa użytkownika</string>
 	<string name="osm_account">Konto OSM</string>
 	<string name="logout">Wyloguj</string>
-	<string name="login_and_edit_map_motivation_message">Zaloguj się i edytuj dane obiektów na mapie, a my udostępnimy je milionom innych użytkowników. Razem możemy poprawić świat.</string>
 	<!-- Information text: "Last upload 11.01.2016" -->
 	<string name="last_upload">Ostatnio przesłane</string>
-	<!-- Motivates user to login/register, title above login buttons. -->
-	<string name="you_have_edited_your_first_object">Edycja Twojego pierwszego obiektu zakończona!</string>
 	<string name="thank_you">Dziękujemy</string>
-	<string name="login_with_google">Zaloguj się przez Google</string>
-	<string name="login_with_openstreetmap">Zaloguj się przez www.openstreetmap.org</string>
 	<string name="edit_place">Edytuj miejsce</string>
 	<string name="place_name">Nazwa miejsca</string>
-	<!-- title above languages list cells in the editor, below editable name text field. -->
-	<string name="other_languages">Inne języki</string>
-	<!-- small button to open list with names in different languages -->
-	<string name="show_more">Pokaż więcej</string>
-	<!-- small button to close list with names in different languages -->
-	<string name="show_less">Pokaż mniej</string>
 	<string name="add_language">Dodaj język</string>
 	<string name="street">Ulica</string>
 	<!-- Editable House Number text field (in address block). -->
@@ -697,25 +435,16 @@
 	<string name="email_or_username">Email lub nazwa użytkownika</string>
 	<string name="phone">Telefon</string>
 	<string name="please_note">Uwaga!</string>
-	<string name="common_no_wifi_dialog">Brak połączenia Wi-Fi. Czy chcesz kontynuować z użyciem danych pakietowych?</string>
 	<string name="downloader_delete_map_dialog">Wszystkie zmiany dotyczące mapy zostaną usunięte wraz z nią.</string>
 	<string name="downloader_update_maps">Aktualizuj mapy</string>
 	<string name="downloader_mwm_migration_dialog">Aby utworzyć trasę, należy zaktualizować wszystkie mapy, a następnie ponownie zaplanować trasę.</string>
 	<string name="downloader_search_field_hint">Znajdź mapę</string>
-	<string name="migration_update_all_button">Aktualizuj wszystkie mapy</string>
-	<string name="migration_delete_all_download_current_button">Pobierz bieżącą mapę i usuń stare</string>
 	<string name="migration_download_error_dialog">Błąd pobierania</string>
 	<string name="common_check_internet_connection_dialog">Sprawdź swoje ustawienia i upewnij się, że urządzenie ma połączenie z Internetem.</string>
 	<string name="downloader_no_space_title">Brak wolnego miejsca</string>
 	<string name="downloader_no_space_message">Usuń niepotrzebne dane</string>
-	<string name="editor_general_auth_error_dialog">Ogólny błąd logowania.</string>
 	<string name="editor_login_error_dialog">Błąd logowania.</string>
-	<string name="editor_login_failed_dialog">Nieudane logowanie</string>
-	<string name="editor_username_error_dialog">Nieprawidłowa nazwa użytkownika</string>
-	<string name="editor_place_edited_dialog">Obiekt był edytowany!</string>
-	<string name="editor_login_with_osm">Zaloguj się z OpenStreetMap</string>
 	<string name="editor_profile_changes">Zmiany zweryfikowane</string>
-	<string name="editor_profile_unsent_changes">Nie wysłano:</string>
 	<string name="editor_focus_map_on_location">Przeciągnij mapę, aby wybrać poprawną lokalizację obiektu.</string>
 	<string name="editor_add_select_category">Wybierz kategorię</string>
 	<string name="editor_add_select_category_popular_subtitle">Popularne</string>
@@ -726,19 +455,14 @@
 	<string name="editor_edit_place_category_title">Kategoria</string>
 	<string name="detailed_problem_description">Szczegółowy opis problemu</string>
 	<string name="editor_report_problem_other_title">Inny problem</string>
-	<string name="placepage_report_problem_button">Zgłoś problem</string>
 	<string name="placepage_add_business_button">Dodaj organizację</string>
 	<string name="whatsnew_editor_message_1">Dodawaj nowe miejsca do mapy i edytuj już istniejące bezpośrednio z poziomu aplikacji.</string>
-	<string name="whatsnew_editor_message_2">* Organic Maps korzysta z danych społeczności OpenStreetMap.</string>
 	<string name="dialog_incorrect_feature_position">Zmień lokalizację</string>
 	<string name="message_invalid_feature_position">Obiekt nie może znajdować się tutaj</string>
 	<string name="login_to_make_edits_visible">Zaloguj się, by inni użytkownicy mogli zobaczyć Twoje zmiany.</string>
-	<string name="no_migration_during_navigation">Podczas nawigacji aktualizacja jest niemożliwa.</string>
 	<!-- Error dialog no space -->
 	<string name="migration_no_space_message">Aby pobrać, potrzebujesz więcej miejsca. Usuń niepotrzebne dane.</string>
 	<string name="editor_sharing_title">Dokonałem poprawek map na Organic Maps</string>
-	<string name="editor_comment_will_be_sent">Prześlemy Twoje komentarze kartografom.</string>
-	<string name="editor_unsupported_category_message">Dodałeś miejsce w kategorii, której jeszcze nie obsługujemy. Pojawi się ono na mapie za jakiś czas.</string>
 	<!-- Downloaded 10 **of** 20 <- it is that "of" -->
 	<string name="downloader_of">%1$d z %2$d</string>
 	<string name="download_over_mobile_header">Czy pobrać, używając połączenia z siecią komórkową?</string>
@@ -756,15 +480,8 @@
 	<string name="editor_detailed_description">Twoje sugestie zmian zostaną wysłane do społeczności OpenStreetMap. Opisz szczegóły, których nie można edytować w Organic Maps.</string>
 	<string name="editor_more_about_osm">Więcej o OpenStreetMap</string>
 	<string name="editor_operator">Operator</string>
-	<string name="editor_tag_description">Wprowadź nazwę firmy, organizacji lub osoby odpowiedzialnej za obiekty.</string>
-	<string name="editor_no_local_edits_title">Nie masz lokalnych edycji</string>
-	<string name="editor_no_local_edits_description">Jest to liczba sugerowanych przez ciebie zmian na mapie, które aktualnie dostępne są tylko na twoim urządzeniu.</string>
-	<string name="editor_send_to_osm">Wyślij do OSM</string>
-	<string name="editor_remove">Usuń</string>
-	<string name="downloader_my_maps_title">Moje mapy</string>
 	<string name="downloader_no_downloaded_maps_title">Nie pobrano żadnych map</string>
 	<string name="downloader_no_downloaded_maps_message">Aby znajdować miejsca i nawigować bez połączenia z internetem, musisz pobrać mapy.</string>
-	<string name="downloader_find_place_hint">Szukaj miasta lub kraju</string>
 	<!-- Error title that appears after certain time without location. -->
 	<string name="current_location_unknown_title">Kontynuować wykrywanie bieżącej lokalizacji?</string>
 	<!-- Error that appears after certain time without location. -->
@@ -779,27 +496,10 @@
 	<string name="location_services_disabled_2">2. Dotknij „Lokalizacja”</string>
 	<!-- iOS Dialog for the case when the location permission is not granted -->
 	<string name="location_services_disabled_3">3. Zaznacz Podczas korzystania z aplikacji</string>
-	<string name="placepage_parking_surface">Powierzchnia</string>
-	<string name="placepage_parking_multistorey">Wielopoziomowy</string>
-	<string name="placepage_parking_underground">Podziemny</string>
-	<string name="placepage_parking_rooftop">Na dachu</string>
-	<string name="placepage_parking_sheds">Wiaty</string>
-	<string name="placepage_parking_carports">Zadaszenia dla samochodów</string>
-	<string name="placepage_parking_boxes">Miejsca parkingowe w garażu</string>
-	<string name="placepage_parking_pay">Płatny</string>
-	<string name="placepage_parking_free">Darmowy</string>
-	<string name="placepage_parking_interval">Płatny na godziny</string>
-	<string name="placepage_entrance_number">Nr</string>
-	<string name="placepage_entrance_type">Wejście</string>
-	<string name="placepage_flat">Mieszkanie</string>
-	<string name="placepage_open_24_7">24 / 7</string>
 	<string name="meter">m</string>
 	<string name="kilometer">km</string>
-	<string name="kilometers_per_hour">km/h</string>
 	<string name="mile">mi</string>
 	<string name="foot">ft</string>
-	<string name="miles_per_hour">mph</string>
-	<string name="day">d</string>
 	<string name="hour">godz</string>
 	<string name="minute">min</string>
 	<string name="placepage_place_description">Opis</string>
@@ -809,46 +509,30 @@
 	<string name="placepage_call_button">Zadzwoń</string>
 	<string name="placepage_edit_bookmark_button">Edytuj zakładkę</string>
 	<string name="placepage_bookmark_name_hint">Nazwa zakładki</string>
-	<string name="placepage_personal_notes_hint">Notatki osobiste</string>
-	<string name="placepage_delete_bookmark_button">Usuń zakładkę</string>
 	<string name="editor_edits_sent_message">Twoje sugestie zostały wysłane</string>
 	<string name="editor_comment_hint">Komentarz…</string>
 	<string name="editor_reset_edits_message">Usunąć wszystkie lokalne zmiany?</string>
 	<string name="editor_reset_edits_button">Usuń</string>
 	<string name="editor_remove_place_message">Usunąć dodane miejsce?</string>
 	<string name="editor_remove_place_button">Usuń</string>
-	<string name="editor_status_sending">Wysyłanie…</string>
 	<string name="editor_place_doesnt_exist">Takie miejsce nie istnieje</string>
 	<string name="text_more_button">…więcej</string>
 	<!-- Phone number error message -->
 	<string name="error_enter_correct_phone">Wprowadź poprawny numer telefonu</string>
 	<string name="error_enter_correct_web">Wpisz prawidłowy adres strony internetowej</string>
 	<string name="error_enter_correct_email">Wpisz prawidłowy email</string>
-	<string name="error_enter_correct">Wpisz prawidłową wartość</string>
 	<string name="refresh">Uaktualnić</string>
-	<string name="last_update">Ostatnia aktualizacja: %s</string>
 	<string name="placepage_add_place_button">Dodaj miejsce do mapy</string>
 	<!-- Displayed when saving some edits to the map to warn against publishing personal data -->
 	<string name="editor_share_to_all_dialog_title">Czy chcesz wysłać je wszystkim użytkownikom?</string>
 	<!-- iOS Dialog before publishing the modifications to the public map. -->
 	<string name="editor_share_to_all_dialog_message_1">Upewnij się, że nie podałeś osobistych danych.</string>
 	<string name="editor_share_to_all_dialog_message_2">Zapoznamy się ze zmianami. W przypadku pytań skontaktujemy się z Tobą przez email.</string>
-	<string name="navigation_overview_button">przegląd</string>
-	<string name="navigation_stop_button">stop</string>
-	<!-- Text on an empty bookmark page -->
-	<string name="bookmarks_empty_title">Zapisz zakładki</string>
-	<string name="bookmarks_empty_message_1">Stuknij ★, aby zapisać ulubione miejsca w celu szybkiego dostępu.</string>
-	<string name="bookmarks_empty_message_2">Importuj zakładki z aplikacji Mail i z Sieci.</string>
-	<string name="bookmarks_empty_message_3">wymeldowanie: %s</string>
-	<!-- Name of the group for booked hotels -->
-	<string name="bookmarks_group_name">Zarezerwowane hotele</string>
-	<string name="place_page_button_read_descriprion">Czytaj</string>
 	<!-- iOS dialog for the case when recent track recording is on and the app comes back from background -->
 	<string name="recent_track_background_dialog_title">Wyłączyć rejestrowanie niedawno przebytej trasy?</string>
 	<string name="off_recent_track_background_button">Wyłącz</string>
 	<!-- For sharing via SMS and so on -->
 	<string name="sharing_call_action_look">Sprawdź</string>
-	<string name="continue_recent_track_background_button">Kontynuuj</string>
 	<string name="recent_track_background_dialog_message">Organic Maps używa w tle geolokalizacji w celu rejestrowania niedawno przebytej trasy.</string>
 	<!-- Rate on Google Play (Android only) -->
 	<string name="rate_gp">Oceń w Google Play</string>
@@ -858,21 +542,11 @@
 	<string name="tell_friends_text">Cześć! Zainstaluj Organic Maps!</string>
 	<!-- About short text (below logo) -->
 	<string name="about_description">Organic Maps to niezbędna aplikacja do podróży działająca w trybie offline. Organic Maps opiera się o dane OpenStreetMap oraz umożliwia ich edycję.</string>
-	<!-- Text in menu -->
-	<string name="blog">Blog</string>
 	<string name="general_settings">Ustawienia ogólne</string>
-	<string name="date">Data %d</string>
-	<!-- "Report a bug" -> "Generaal Feedback" -> "Something is not working" -->
-	<string name="something_is_not_working">Coś nie działa</string>
 	<!-- For the first routing -->
 	<string name="accept">Zaakceptuj</string>
 	<!-- For the first routing -->
 	<string name="decline">Odrzuć</string>
-	<string name="install_app">Zainstaluj</string>
-	<string name="search_no_results_title">Nie znaleziono wyników</string>
-	<string name="search_no_results_message">Spróbuj szerszego terminu wyszukiwania, zawęzić lub resetować filtr.</string>
-	<string name="search_no_results_expand_area_button">Zawęź</string>
-	<string name="search_no_results_reset_button">Resetuj filtr</string>
 	<!-- noun -->
 	<string name="search_in_table">Lista</string>
 	<string name="mobile_data_dialog">Wykorzystać internet mobilny, aby wyświetlić dane szczegółowe?</string>
@@ -884,18 +558,13 @@
 	<string name="mobile_data_option_never">Nigdy nie stosuj</string>
 	<string name="mobile_data_option_ask">Zawsze pytaj</string>
 	<string name="traffic_update_maps_text">Aby wyświetlić dane o ruchu, muszą zostać zaktualizowane mapy.</string>
-	<string name="traffic_outdated">Dane o ruchu są przestarzałe.</string>
 	<string name="big_font">Powiększ rozmiar czcionki na mapie</string>
 	<string name="traffic_update_app">Zaktualizuj Organic Maps</string>
 	<!-- "traffic" as in road congestion -->
 	<string name="traffic_update_app_message">Aby wyświetlić dane o ruchu, należy zaktualizować aplikację.</string>
 	<!-- "traffic" as in "road congestion" -->
 	<string name="traffic_data_unavailable">Dane o ruchu są niedostępne</string>
-	<!-- Simplified colour scheme for traffic information, fewer colours are used to display traffic jams on the map. The string should be kept as short as possible -->
-	<string name="pref_traffic_simplified_colors_title">Uproszczone kolory sygnalizacji</string>
 	<string name="enable_logging">Włącz logowanie</string>
-	<string name="offline_place_page_more_information">Połącz się z Internetem, aby uzyskać więcej informacji na temat miejsca.</string>
-	<string name="failed_load_information">Nie można załadować informacji.</string>
 	<!-- Settings: "Send general feedback" button -->
 	<string name="feedback_general">Ogólne uwagi</string>
 	<string name="on">Wł.</string>
@@ -909,57 +578,26 @@
 	<string name="routing_add_start_point">Aby zaplanować trasę, dodaj punkt początkowy</string>
 	<string name="routing_add_finish_point">Aby zaplanować trasę, dodaj punkt końcowy</string>
 	<string name="button_exit">Wyjdź</string>
-	<string name="settings_device_memory">Pamięć urządzenia</string>
-	<string name="settings_card_memory">Pamięć na karcie</string>
-	<string name="settings_storage_available">dostępne %s</string>
-	<string name="toast_location_permission_denied">Odmowa dla aplikacji uprawnień do lokalizacji</string>
-	<string name="button_use">Użyj</string>
 	<string name="planning_route_manage_route">Zarządzaj trasą</string>
 	<string name="button_plan">Zaplanuj</string>
-	<string name="button_add">Dodaj</string>
 	<string name="placepage_remove_stop">Usuń</string>
 	<string name="planning_route_remove_title">Przeciągnij tu, aby usunąć</string>
-	<string name="dialog_change_start_point_message">Zamienić punkt początkowy na bieżącą lokalizację?</string>
-	<string name="button_replace">Zamień</string>
 	<string name="placepage_add_stop">Dodaj postój</string>
-	<string name="add_my_position">Dodaj moją pozycję</string>
-	<string name="choose_start_point">Wybierz punkty początkowy</string>
-	<string name="choose_destination">Wybierz punkt docelowy</string>
 	<string name="preloader_viator_button">Dowiedz się więcej</string>
-	<string name="start_from_my_position">Zacznij od</string>
-	<string name="profile_authorization_title">Zaloguj się za pomocą</string>
-	<string name="profile_authorization_message">Łatwe logowanie w kilka sekund bez podawania loginu i hasła</string>
 	<string name="profile_authorization_error">Ups, nastąpił błąd. Spróbuj zalogować się ponownie.</string>
-	<string name="service">Usługa</string>
-	<string name="atmosphere">Atmosfera</string>
-	<string name="value_for_money">Stosunek jakości do ceny</string>
-	<string name="experience">Doświadczenie</string>
-	<string name="assortment">Asortyment</string>
-	<string name="expertise">Fachowość</string>
-	<string name="equipment">Wyposażenie</string>
-	<string name="quality">Jakość</string>
 	<string name="dialog_error_storage_title">Problem z dostępem do pamięci masowej</string>
 	<string name="dialog_error_storage_message">Zewnętrzny nośnik pamięci masowej jest niedostępny. Prawdopodobnie usunięto lub uszkodzono kartę SD bądź jej system plików służy tylko do odczytu. Zweryfikuj to i skontaktuj się z nami pod adresem support\@organicmaps.app</string>
 	<string name="setting_emulate_bad_storage">Emuluj wadliwą pamięć masową</string>
-	<string name="directions_finish">Punkt docelowy</string>
-	<string name="directions_on_foot">Przejdź %s</string>
 	<string name="core_entrance">Wejście</string>
-	<string name="coffee">Kawa</string>
-	<string name="cleanliness">Czystość</string>
-	<string name="crowdedness">Zatłoczenie</string>
 	<string name="error_enter_correct_name">Wprowadź poprawną nazwę</string>
 	<string name="bookmarks_groups">Listy</string>
 	<string name="bookmarks_groups_hide_all">Ukryj wszystkie</string>
 	<string name="bookmarks_groups_show_all">Pokaż wszystkie</string>
-	<plurals name="bookmarks_places">
-	  <item quantity="other">Zakładki: %d</item>
-	</plurals>
 	<string name="bookmarks_create_new_group">Utwórz nową listę</string>
 	<string name="downloader_hide_screen">Ukryj ekran</string>
 	<string name="downloader_percent">%1$s (%2$s z %3$s)</string>
-	<string name="downloader_process">Pobieranie %s...</string>
-	<string name="downloader_applying">Stosowanie zmian %s...</string>
-	<string name="dialog_message_transit_not_found_connection">Zaplanuj trasę w ramach jednej sieci transportowej</string>
+	<string name="downloader_process">Pobieranie %s…</string>
+	<string name="downloader_applying">Stosowanie zmian %s…</string>
 	<string name="bookmarks_error_message_share_general">Nie można udostępnić z powodu błędu aplikacji</string>
 	<string name="bookmarks_error_title_share_empty">Błąd udostępniania</string>
 	<string name="bookmarks_error_message_share_empty">Nie można udostępnić pustej listy</string>
@@ -968,48 +606,22 @@
 	<string name="bookmarks_new_list_hint">Nowa lista</string>
 	<string name="bookmarks_error_title_list_name_already_taken">Ta nazwa jest już zajęta</string>
 	<string name="bookmarks_error_message_list_name_already_taken">Wybierz inną nazwę</string>
-	<string name="bookmarks_error_title_list_name_too_long">Ta nazwa jest za długa</string>
-	<string name="bookmarks_error_message_list_name_too_long">Wybierz inną nazwę</string>
-	<string name="please_wait">Proszę czekać...</string>
-	<string name="phone_number">Numer telefonu</string>
-	<string name="notification_unsent_reviews_title">Masz kilka niewysłanych recenzji</string>
-	<string name="notification_unsent_reviews_message">Zaloguj się, aby udostępniać recenzje innym podróżnym</string>
+	<string name="please_wait">Proszę czekać…</string>
 	<string name="profile">Profil OpenStreetMap</string>
 	<string name="place_page_search_similar_hotel">Wyszukaj podobne hotele</string>
 	<string name="bookmarks_detect_title">Wykryto nowe pliki</string>
 	<plurals name="bookmarks_detect_message">
 	  <item quantity="one">Znaleziono %d plik. Zobaczysz to po konwersji.</item>
-	  <item quantity="two">Znaleziono %d pliki. Zobaczysz je po konwersji.</item>
 	  <item quantity="other">Znaleziono %d plików. Zobaczysz je po konwersji.</item>
+	  <item quantity="two">Znaleziono %d pliki. Zobaczysz je po konwersji.</item>
 	</plurals>
 	<string name="button_convert">konwertować</string>
 	<string name="bookmarks_convert_error_title">błąd</string>
 	<string name="bookmarks_convert_error_message">Sommige bestanden waren niet geconverteerd.</string>
-	<string name="converting">Przekształcanie...</string>
-	<string name="wn_reinvented_bookmarks_title">Odnowiliśmy zakładki!</string>
-	<string name="wn_reinvented_bookmarks_message">Możesz tworzyć kopie zapasowe zakładek, tworzyć listy... To niesamowite...</string>
-	<string name="bookmarks_restore">Przywróć zakładki</string>
-	<string name="bookmarks_restore_process">Przywracanie...</string>
 	<string name="bookmarks_restore_title">Przywróć tę wersję?</string>
-	<string name="bookmarks_restore_message">Twoje zakładki zostaną przywrócone z %1$s (%2$s)</string>
-	<string name="bookmarks_restore_empty_title">Nie masz kopii zapasowej</string>
-	<string name="bookmarks_restore_empty_message">Serwer nie znalazł wcześniej utworzonych kopii zapasowych</string>
 	<string name="common_check_internet_connection_dialog_title">Brak połączenia z internetem</string>
-	<string name="error_server_title">Błąd serwera</string>
-	<string name="error_server_message">Der var en fejl på serveren, prøv igen senere</string>
 	<string name="error_system_message">Wystąpił nieznany błąd</string>
 	<string name="restore">Przywracać</string>
-	<string name="bookmarks_page_downloaded">Pobrane</string>
-	<string name="bookmarks_page_my">Moje</string>
-	<string name="routes_and_bookmarks">Trasy i zakładki</string>
-	<string name="bookmarks_webview_success_toast">Zakładki pobrane pomyślnie</string>
-	<string name="cached_bookmarks_placeholder_title">Pobierz nowe miejsca</string>
-	<string name="cached_bookmarks_placeholder_subtitle">Naciśnij przycisk, aby pobrać tysiące interesujących miejsc i tras utworzonych przez użytkowników Organic Maps. Wymagane jest połączenie internetowe.</string>
-	<string name="downloader_download_routers">Pobierz zakładki</string>
-	<string name="bookmarks_groups_cached">Pobrane listy</string>
-	<plurals name="bookmarks_objects">
-	  <item quantity="other">%s obiekt</item>
-	</plurals>
 	<plurals name="objects">
 	  <item quantity="other">%d miejsce</item>
 	</plurals>
@@ -1022,62 +634,32 @@
 	<string name="subtittle_opt_out">Ustawienia śledzenia</string>
 	<string name="crash_reports">Raport o błędzie</string>
 	<string name="crash_reports_description">Możemy używać Twoich danych do usprawnienia działania Organic Maps. Zmiany zostaną zastosowane po ponownym uruchomieniu aplikacji.</string>
-	<string name="opt_out_help_ios_1">W Twoim urządzeniu mobilnym może być dostępne ustawienie „Limit Ad Tracking” lub „Opt out of interest-based advertising”.</string>
-	<string name="opt_out_help_ios_2">iOS 9 lub nowszy</string>
-	<string name="opt_out_help_ios_3">Przejdź do Ustawień → Prywatność→ Reklamy→ Włącz ustawienie „Limit Ad Tracking”</string>
-	<string name="opt_out_help_android">W Twoim urządzeniu mobilnym może być dostępne ustawienie „Limit Ad Tracking” lub „Opt out of interest-based advertising”.\n\nW przypadku systemu Android i Google Play Services w wersji 4.0 i nowszych:\nUstawienia → Google → Reklamy→ Rezygnacja z personalizacji reklam\nlub\nUstawienia→ Google → Konto Google→ Dane i personalizacja→ Personalizacja reklam→ Personalizacja reklam</string>
 	<string name="privacy_policy">Polityka prywatności</string>
 	<string name="terms_of_use">Warunki użytkowania</string>
-	<string name="backup_notification_failed">Tworzenie kopii zapasowych Twoich zakładek zostało zawieszone. Zaloguj się, aby włączyć je ponownie.</string>
 	<string name="button_layer_traffic">Ruch drogowy</string>
 	<string name="button_layer_subway">Metro</string>
 	<string name="layers_title">Warstwy map</string>
-	<string name="layers_message">Użyj warstw map, aby wyświetlić ruch drogowy, mapę metra i inne przydatne informacje</string>
-	<string name="button_layer_got_it">Rozumiem</string>
 	<string name="subway_data_unavailable">Mapa metra jest niedostępna</string>
 	<string name="bookmarks_empty_list_title">Lista jest pusta</string>
 	<string name="bookmarks_empty_list_message">Aby dodać zakładkę, dotknij miejsca na mapie, a następnie dotknij ikony gwiazdy.</string>
 	<string name="category_desc_more">…więcej</string>
 	<string name="title_error_downloading_bookmarks">Wystąpił błąd</string>
-	<string name="subtitle_error_downloading_bookmarks">Zakładki nie zostały pobrane</string>
-	<string name="error_already_downloaded">Ta lista została już pobrana</string>
-	<string name="why_support">Po co wspierać Organic Maps?</string>
-	<string name="why_support_item2">Pomagasz nam udoskonalać Organic Maps</string>
-	<string name="why_support_item3">Pomagasz nam udoskonalać mapy OpenStreetMap.org</string>
-	<string name="channels_map_update">Aktualizacja map</string>
-	<string name="server_unavailable_title">Serwer jest niedostępny</string>
-	<string name="sharing_options">Ustawienia dostępu</string>
 	<string name="export_file">Eksportuj plik</string>
 	<string name="list_settings">Ustawienia listy</string>
 	<string name="delete_list">Usuń listę</string>
-	<string name="hide_from_map">Ukryj mapy</string>
 	<string name="public_access">Dostęp publiczny</string>
 	<string name="limited_access">Dostęp prywatny</string>
 	<string name="bookmark_category_name">Kategoria</string>
 	<string name="bookmark_category_description_hint">Dodaj opis (tekst lub html)</string>
 	<string name="not_shared">Osobisty</string>
-	<string name="direct_link_progress_text">Trwa pobieranie Twojego pliku…</string>
-	<string name="direct_link_success">Link został utworzony</string>
-	<string name="send_a_link_btn">Wyślij link</string>
-	<string name="upload_error_toast">Wystąpił błąd podczas pobierania pliku</string>
 	<string name="tags_loading_error_subtitle">Wystąpił błąd podczas pobierania tagów, spróbuj ponownie</string>
-	<string name="unable_upload_errorr_title">Nie udało się przesłać pliku</string>
-	<string name="unable_upload_error_subtitle_edited">Plik edytowano za pomocą aplikacji internetowej</string>
-	<string name="unable_upload_error_subtitle_broken">Plik jest uszkodzony i nie można go załadować. Proszę przesłać inny plik.</string>
-	<string name="contact">Napisz</string>
-	<string name="download_button">Pobierz</string>
 	<string name="speedcams_alert_title">Fotoradary</string>
-	<string name="speedcams_alert_subtitle">Ostrzegać o ograniczeniach prędkości</string>
 	<string name="speedcam_option_auto">Auto</string>
 	<string name="speedcam_option_always">Zawsze</string>
 	<string name="speedcam_option_never">Nigdy</string>
-	<string name="bookmark_description_title">Opis znacznika</string>
 	<string name="place_description_title">Opis miejsca</string>
 	<!-- this text will be shown in application notification preferences opposite checkbox which enable/disable downloader notifications. Devices on Android 8+ are affected. -->
 	<string name="notification_channel_downloader">Pobieranie map</string>
-	<string name="share_bookmarks_email_body_link">Witaj!\n\nTwoje znaczniki można pobrać, używając link: %s. Otwórz listę, używając Organic Maps i ciesz się podrożą!\n\nPobierz aplikację: https://omaps.app/get?kmz</string>
-	<string name="warning_speedcams_title">Nawigator powiadomi Cibie o kamerach, gdy przekrocz prędkość na %d km/h</string>
-	<string name="warning_speedcams_subtitle">Nie zapomnij zapoznać się z zasadami ruchu drogowego w kraju podróży.</string>
 	<string name="speedcams_notice_message">Auto – Ostrzegać o kamerach, jeśli istnieje ryzyko przekroczenia ograniczenia prędkości\nZawsze – Zawsze ostrzegaj o kamerach\nNigdy – Nigdy nie ostrzegaj o kamerach</string>
 	<string name="power_managment_title">Tryb oszczędzania energii</string>
 	<string name="power_managment_description">Jeśli jest włączony tryb oszczędzania energii, wtedy aplikacja wyłączy funkcje energochłonne, zależnie od bieżącego poziomu załadowania telefonu</string>
@@ -1085,14 +667,7 @@
 	<string name="power_managment_setting_auto">Auto</string>
 	<string name="power_managment_setting_manual_max">Maksymalna oszczędność energii</string>
 	<string name="enable_logging_warning_message">Ta opcja zostaje włączona do logowania działań w celach diagnostycznych. Pomaga to zespołowi zidentyfikować problemy z aplikacją. Włączaj opcję tylko na żądanie wsparcia technicznego Organic Maps.</string>
-	<string name="html_error_upload_message_try_again">Sprawdź dostęp do sieci i spróbuj ponownie</string>
-	<string name="html_error_upload_title_try_again">Brak połączenia z Internetem</string>
-	<string name="notification_leave_review_v2_android_short_title">Pozostaw komentarze i pomóż podróżującym!</string>
-	<string name="notifications_illegal_alert_disable_button">Wyłącz powiadomienia</string>
 	<string name="access_rules_author_only">Edytowane online</string>
-	<string name="privacy_settings_menu">Ustawienia prywatności</string>
-	<string name="unable_upadate_error_title">Nieudana próba aktualizacji trasy</string>
-	<string name="unable_upadate_error_message">Podczas aktualizacji wystąpiły błędy. Sprawdź zmiany i spróbuj ponownie</string>
 	<string name="driving_options_title">Ustawienia objazdu</string>
 	<string name="driving_options_subheader">Unikaj na każdej trasie</string>
 	<string name="avoid_tolls">Drogi płatne</string>
@@ -1103,52 +678,14 @@
 	<string name="unable_to_calc_alert_subtitle">Niestety, nie udało nam się zbudować trasy, która posiada obrane opcje. Zmień ustawienia i spróbuj ponownie</string>
 	<string name="define_to_avoid_btn">Dostosuj ścieżkę objazdu</string>
 	<string name="change_driving_options_btn">Ustawienia objazdu są włączone</string>
-	<string name="toll_road">Droga płatna</string>
-	<string name="unpaved_road">Droga gruntowa</string>
-	<string name="ferry_crossing">Przeprawa promowa</string>
-	<string name="operated_by">Zarządzany przez \"%s\"</string>
 	<string name="avoid_toll_roads_placepage">Unikać dróg płatnych</string>
 	<string name="avoid_unpaved_roads_placepage">Unikać dróg gruntowych</string>
 	<string name="avoid_ferry_crossing_placepage">Unikać przepraw promowych</string>
-	<string name="type.cuisine.uzbek">Kuchnia uzbecka</string>
-	<string name="trip_start">Jedźmy</string>
-	<string name="pick_destination">Meta</string>
-	<string name="follow_my_position">Wyśrodkuj</string>
-	<string name="search_results">Wyniki wyszukiwania</string>
-	<string name="then_turn">Dalej</string>
-	<string name="redirect_route_alert">Czy chcesz przebudować trasę?</string>
-	<string name="redirect_route_yes">Tak</string>
-	<string name="redirect_route_no">Nie</string>
-	<string name="trip_finished">Jesteś na miejscu!</string>
-	<string name="keyboard_availability_alert">Klawiatura nie jest dostępna podczas ruchu</string>
-	<string name="dialog_routing_change_start_carplay">Brak możliwości zbudowania trasy od bieżącej lokalizacji</string>
-	<string name="dialog_routing_change_end_carplay">Brak możliwości zbudowania trasy do punktu końcowego. Wybierz inny</string>
-	<string name="dialog_routing_check_gps_carplay">Brak sygnału GPS. Dostań się do terenu otwartego</string>
-	<string name="dialog_routing_unable_locate_route_carplay">Brak możliwości zbudowania trasy. Wybierz inne punkty trasy</string>
-	<string name="dialog_routing_download_files_carplay">Aby wyznaczyć trasę, pobierz brakujące mapy na Twoim urządzeniu</string>
-	<string name="dialog_routing_system_error_carplay">Wystąpił błąd. Uruchom aplikację ponownie</string>
-	<string name="dialog_routing_rebuild_from_current_location_carplay">Trasa zostanie przebudowana z Twojej bieżącej lokalizacji</string>
-	<string name="dialog_routing_rebuild_for_vehicle_carplay">Trasa zostanie zmieniona na samochodową</string>
 	<string name="ok">Ok</string>
-	<string name="avoid_unpaved_carplay_1">Bez gruntow.</string>
-	<string name="avoid_unpaved_carplay_2">Bez gruntowych</string>
-	<string name="avoid_ferry_carplay_1">Bez promów</string>
-	<string name="avoid_ferry_carplay_2">Bez promów</string>
-	<string name="avoid_tolls_carplay_1">Wył. płatne</string>
-	<string name="avoid_tolls_carplay_2">Wyłącz płatne</string>
-	<string name="speedcams_alert_title_carplay_1">Kamery</string>
-	<string name="speedcams_alert_title_carplay_2">Info o kamerach</string>
-	<string name="download_map_carplay">Pobierz mapy do aplikacji Organic Maps na swoje urządzenie</string>
-	<string name="carplay_roundabout_exit">%s zjazd</string>
 	<!-- max. 10 symbols, both iOS and Android -->
 	<string name="sort">Sortuj…</string>
 	<!-- Android, title, max 20-22 symbols -->
 	<string name="sort_bookmarks">Sortuj znaczniki</string>
-	<!-- iOS -->
-	<string name="sort_default">Sortuj domyślnie</string>
-	<string name="sort_type">Sortuj wg rodzaju</string>
-	<string name="sort_distance">Sortuj wg odległości</string>
-	<string name="sort_date">Sortuj wg daty</string>
 	<!-- Android -->
 	<string name="by_default">Domyślnie</string>
 	<!-- Android -->
@@ -1157,65 +694,23 @@
 	<string name="by_distance">Wg odległości</string>
 	<!-- Android -->
 	<string name="by_date">Wg daty</string>
-	<string name="week_ago_sorttype">Tydzień wstecz</string>
-	<string name="month_ago_sorttype">Miesiąc wstecz</string>
-	<string name="moremonth_ago_sorttype">Ponad miesiąc wstecz</string>
-	<string name="moreyear_ago_sorttype">Ponad rok wstecz</string>
-	<string name="near_me_sorttype">Obok mnie</string>
-	<string name="others_sorttype">Inne</string>
-	<string name="food_places">Jedzenie</string>
-	<string name="tourist_places">Zabytki</string>
-	<string name="museums">Muzea</string>
-	<string name="parks">Parki</string>
-	<string name="swim_places">Pływanie</string>
-	<string name="mountains">Góry</string>
-	<string name="animals">Zwierzęta</string>
-	<string name="hotels">Hotele</string>
-	<string name="buildings">Budynki</string>
-	<string name="money">Pieniądze</string>
-	<string name="shops">Sklepy</string>
-	<string name="parkings">Parkingi</string>
-	<string name="fuel_places">Stacje paliw</string>
-	<string name="water">Woda</string>
-	<string name="medicine">Lecznictwo</string>
 	<string name="search_in_the_list">Wyszukaj na liście</string>
-	<string name="view_on_map_bookmarks">Na mapie</string>
-	<string name="more_bookmarks">Więcej…</string>
-	<string name="no_items_found">Brak wyników</string>
-	<!-- Android, max 18 symbols -->
-	<string name="bookmarks_edit_list">Redaguj</string>
-	<!-- Android, max 18 symbols -->
-	<string name="bookmarks_delete_list">Usuń listę</string>
-	<string name="religious_places">Święte miejsca</string>
 	<string name="select_list">Wybierz listę</string>
 	<string name="transit_not_found">Nawigacja metrem nie jest jeszcze tutaj dostępna</string>
 	<string name="dialog_pedestrian_route_is_long_header">Nie znaleziono trasy metra</string>
 	<string name="dialog_pedestrian_route_is_long_message">Wybierz punkt początkowy lub końcowy trasy najbliżej do stacji metra</string>
-	<!-- Failed planning SUBWAY route message in navigation view -->
-	<string name="routing_planning_error_subway_special">Błąd tworzenia trasy metra</string>
 	<string name="button_layer_isolines">Wysokości</string>
-	<string name="tips_map_layers_title_countour">Linie wysokości w trybie offline w Organic Maps!</string>
-	<string name="tips_map_layers_message_countour">Linie wysokości pomogą zaplanować podróż i nie zgubić się w terenie</string>
 	<string name="isolines_activation_error_dialog">Do skorzystania z linii wysokości, zaktualizuj lub pobierz mapę obszaru, który potrzebujesz</string>
 	<string name="isolines_location_error_dialog">W tej chwili nie są dostępne linie wysokości w tym regionie</string>
 	<string name="elevation_profile_diff_level">Poziom trudności</string>
-	<string name="elevation_profile_diff_level_easy">Łatwy</string>
-	<string name="elevation_profile_diff_level_moderate">Umiarkowany</string>
-	<string name="elevation_profile_diff_level_hard">Skomplikowany</string>
 	<string name="elevation_profile_ascent">Wejście</string>
 	<string name="elevation_profile_descent">Zejście</string>
 	<string name="elevation_profile_minaltitude">Min. wysokość</string>
 	<string name="elevation_profile_maxaltitude">Maks. wysokość</string>
-	<string name="elevation_profile_m">m</string>
 	<string name="elevation_profile_difficulty">Trudność</string>
 	<string name="elevation_profile_distance">Odległ.:</string>
-	<string name="elevation_profile_km">km</string>
 	<string name="elevation_profile_time">Trasa:</string>
-	<string name="elevation_profile_hours">godz.</string>
-	<string name="elevation_profile_minutes">min</string>
 	<string name="isolines_toast_zooms_1_10">Powiększ mapę, aby zobaczyć izolinie</string>
-	<string name="downloader_updating_ios">Aktualizacja</string>
-	<string name="downloader_loading_ios">Pobieranie</string>
 	<string name="key_information_title">Kluczowe informacje</string>
 	<string name="enable_screen_sleep">Pozwól ekranowi spać</string>
 	<!-- Description in preferences -->

--- a/android/res/values-pt/strings.xml
+++ b/android/res/values-pt/strings.xml
@@ -12,8 +12,6 @@
 	<string name="cancel_download">Cancelar Descarga</string>
 	<!-- Button which deletes downloaded country -->
 	<string name="delete">Eliminar</string>
-	<!-- Button "do not interrupt download" if user touched actively downloading country -->
-	<string name="do_nothing">Continuar</string>
 	<string name="download_maps">Descarregar mapas</string>
 	<!-- Settings/Downloader - info for country when download fails -->
 	<string name="download_has_failed">A descarga falhou, toque novamente para tentar uma vez mais.</string>
@@ -31,45 +29,31 @@
 	<string name="core_my_position">A minha posição</string>
 	<!-- Update maps later/Buy pro version later button text -->
 	<string name="later">Mais tarde</string>
-	<!-- Don't show some dialog any more -->
-	<string name="never">Nunca</string>
 	<!-- View and button titles for accessibility -->
 	<string name="search">Procura</string>
 	<!-- Search box placeholder text -->
 	<string name="search_map">Procurar mapa</string>
-	<!-- Settings/Downloader - info for not downloaded country -->
-	<string name="touch_to_download">Toque para descarregar</string>
 	<!-- Settings/Downloader - 3G download warning dialog confirm button -->
 	<string name="use_cellular_data">Sim</string>
 	<!-- Location services are disabled by user alert - message -->
 	<string name="location_is_disabled_long_text">Atualmente tem todos os Serviços de Localização para este dispositivo ou aplicação desativados. Por favor ative-os nas Definições.</string>
-	<!-- Location Services are not available on the device alert - message -->
-	<string name="device_doesnot_support_location_services">Os Serviços de Localização não estão disponíveis em seu dispositivo</string>
 	<!-- View and button titles for accessibility -->
 	<string name="zoom_to_country">Mostrar no mapa</string>
-	<!-- Button text for the button at the center of the screen when the country is not downloaded -->
-	<string name="country_status_download">Descarregar Mapa\n(^ ^)</string>
 	<!-- Button text for the button at the center of the screen when the country is not downloaded and the size should not be shown -->
 	<string name="country_status_download_without_size">Descarregar Mapa</string>
-	<!-- Button text for the button at the center of the screen when the country is not downloaded -->
-	<string name="country_status_download_without_routing">Baixar mapa\nsem roteamento (^ ^)</string>
 	<!-- Message to display at the center of the screen when the country download has failed -->
 	<string name="country_status_download_failed">A descarga falhou</string>
 	<!-- Button text for the button under the country_status_download_failed message -->
 	<string name="try_again">Tente de novo</string>
 	<string name="about_menu_title">Sobre o Organic Maps</string>
-	<string name="downloaded_touch_to_delete">(%s) descarregados, toque para eliminar</string>
 	<string name="connection_settings">Definições de Ligação</string>
-	<string name="download_mb_or_kb">Descarga %s</string>
 	<string name="close">Fechar</string>
 	<string name="unsupported_phone">É necessário OpenGL acelerado por hardware. Infelizmente o seu dispositivo não é compatível.</string>
 	<string name="download">Descarga</string>
-	<string name="external_storage_is_not_available">Não está disponível um cartão SD/armazenamento USB com os mapas descarregados</string>
 	<string name="disconnect_usb_cable">Por favor desligue o cabo USB ou introduza um cartão de memória para utilizar Organic Maps</string>
 	<string name="not_enough_free_space_on_sdcard">Por favor liberte primeiro algum espaço no cartão SD/armazenamento USB para utilizar a app</string>
 	<string name="not_enough_memory">Não há memória suficiente para executar a app</string>
 	<string name="download_resources">Antes de começar, permita-nos que descarreguemos um mapa mundial geral para o seu dispositivo.\nÉ necessário %s de dados.</string>
-	<string name="getting_position">A obter a posição atual</string>
 	<string name="download_resources_continue">Ir para o mapa</string>
 	<string name="downloading_country_can_proceed">A descarregar %s. Pode agora\ncontinuar para o mapa.</string>
 	<string name="download_country_ask">Descarregar %s?</string>
@@ -82,30 +66,20 @@
 	<string name="download_country_failed">%s descarga falhou</string>
 	<!-- Add New Bookmark Set dialog title -->
 	<string name="add_new_set">Adicionar novo conjunto</string>
-	<!-- Place Page - Add To Bookmarks button -->
-	<string name="add_to_bookmarks">Adicionar aos Favoritos</string>
 	<!-- Bookmark Color dialog title -->
 	<string name="bookmark_color">Cor de favoritos</string>
 	<!-- Add Bookmark Set dialog - hint when set name is empty -->
 	<string name="bookmark_set_name">Nome do conjunto dos favoritos</string>
-	<!-- Bookmark Sets dialog title -->
-	<string name="bookmark_sets">Conjuntos de favoritos</string>
 	<!-- Bookmarks - dialog title -->
 	<string name="bookmarks">Favoritos</string>
-	<!-- Add bookmark dialog - bookmark color -->
-	<string name="color">Cor</string>
 	<!-- Default bookmarks set name -->
 	<string name="core_my_places">Os meus locais</string>
 	<!-- Add bookmark dialog - bookmark name -->
 	<string name="name">Nome</string>
 	<!-- Editor title above street and house number -->
 	<string name="address">Endereço</string>
-	<!-- Place Page - Remove Pin button -->
-	<string name="remove_pin">Retirar o marcador</string>
 	<!-- Add bookmark dialog - bookmark set, Bookmarks dialog - Bookmark set cell -->
 	<string name="set">Conjunto</string>
-	<!-- Text hint in Bookmarks dialog when no any bookmarks are added -->
-	<string name="bookmarks_usage_hint">Ainda não tem marcadores.\nToque em qualquer lugar no mapa para adicionar um marcador.\nOs marcadores de outras fontes também podem ser importados e exibidos na aplicação Organic Maps. Abrir ficheiro KML/KMZ com pinos guardados a partir do mail, Dropbox ou ligação web.</string>
 	<!-- Settings button in system menu -->
 	<string name="settings">Configurações</string>
 	<!-- Header of settings activity where user defines storage path -->
@@ -116,20 +90,10 @@
 	<string name="move_maps">Mover mapas?</string>
 	<!-- Ask to wait user several minutes (some long process in modal dialog). -->
 	<string name="wait_several_minutes">Isto pode demorar alguns minutos.\nPor favor aguarde…</string>
-	<!-- Show bookmarks from this category on a map or not -->
-	<string name="visible">Visível</string>
-	<!-- Toast which is displayed when GPS has been deactivated -->
-	<string name="gps_is_disabled_long_text">O GPS está desativado. Por favor ative-o nas Definições.</string>
 	<!-- Measurement units title in settings activity -->
 	<string name="measurement_units">Unidades de medida</string>
 	<!-- Detailed description of Measurement Units settings button -->
 	<string name="measurement_units_summary">Escolha entre milhas e quilómetros</string>
-	<!-- Do search in all sources -->
-	<string name="search_mode_all">Em toda a parte</string>
-	<!-- Do search near my position only -->
-	<string name="search_mode_nearme">Perto de mim</string>
-	<!-- Do search in current viewport only -->
-	<string name="search_mode_viewport">No ecrã</string>
 	<!-- Search category for cafes, bars, restaurants -->
 	<string name="eat">Onde lanchar</string>
 	<!-- Search category for grocery stores -->
@@ -166,12 +130,8 @@
 	<string name="post">Correios</string>
 	<!-- Search category -->
 	<string name="police">Polícia</string>
-	<!-- String in search result list, when nothing found -->
-	<string name="no_search_results_found">Não foram encontrados resultados</string>
 	<!-- Notes field in Bookmarks view -->
 	<string name="description">Notas</string>
-	<!-- Button text -->
-	<string name="share_by_email">Partilhar por email</string>
 	<!-- Email Subject when sharing bookmarks category -->
 	<string name="share_bookmarks_email_subject">Os favoritos do Organic Maps foram partilhados consigo</string>
 	<!-- message title of loading file -->
@@ -184,20 +144,10 @@
 	<string name="edit">Editar</string>
 	<!-- Warning message when doing search around current position -->
 	<string name="unknown_current_position">A sua localização ainda não foi determinada</string>
-	<!-- Warning message when location country isn't downloaded during search (see also download_location_map_proposal). -->
-	<string name="download_location_country">Descarregue o país da sua localização atual (%s)</string>
-	<!-- Warning message when viewport country isn't downloaded during search -->
-	<string name="download_viewport_country_to_search">Descarregue o país em que está a fazer a procura (%s)</string>
 	<!-- Alert message that we can't run Map Storage settings due to some reasons. -->
 	<string name="cant_change_this_setting">Lamentamos, as definições do Map Storage estão atualmente desativadas.</string>
 	<!-- Alert message that downloading is in progress. -->
 	<string name="downloading_is_active">A descarga do país está atualmente em progresso.</string>
-	<!-- Message that will be shown in alert view, when we ask user to leave review on App Store -->
-	<string name="appStore_message">Esperamos que esteja a disfrutar da utilização do Organic Maps! Se assim for, por favor classifique ou dê a sua opinião sobre a app na App Store. Vai demorar menos de um minuto mas pode mesmo ajudar-nos. Obrigado pelo seu apoio!</string>
-	<!-- No, thanks -->
-	<string name="no_thanks">Não, obrigado</string>
-	<!-- Share one specific bookmark using SMS, %1$@ contains om:// and %2$@ https://omaps.app link. @NOTE non-ascii symbols in the link will result in max 70 characters SMS instead of 140. -->
-	<string name="bookmark_share_sms">Veja o meu marcador no mapa do Organic Maps. Abra a hiperligação: %1$s ou %2$s</string>
 	<!-- Share my position using SMS, %1$@ contains om:// and %2$@ https://omaps.app link WITHOUT NAME. @NOTE non-ascii symbols in the link will result in max 70 characters SMS instead of 140. -->
 	<string name="my_position_share_sms">Veja onde estou agora. Abra a hiperligação: %1$s ou %2$s</string>
 	<!-- Subject for emailed bookmark -->
@@ -206,30 +156,16 @@
 	<string name="my_position_share_email_subject">Veja a minha localização atual no mapa Organic Maps!</string>
 	<!-- Share my position using EMail, %1$@ is om:// and %2$@ is https://omaps.app link WITHOUT NAME -->
 	<string name="my_position_share_email">Olá,\n\nEstou aqui agora: %1$s. Clique nesta ligação %2$s ou nesta %3$s para ver o local no mapa.\n\nObrigado.</string>
-	<!-- Android share by Message/SMS button text (including SMS) -->
-	<string name="share_by_message">Partilhar por mensagem</string>
 	<!-- Share button text which opens menu with more buttons, like Message, EMail, Facebook etc. -->
 	<string name="share">Partilhar</string>
-	<!-- iOS share by Message button text (including SMS) -->
-	<string name="message">Mensagem</string>
 	<!-- Share by email button text, also used in editor. -->
 	<string name="email">Email</string>
-	<!-- Copy Link -->
-	<string name="copy_link">Copiar hiperligação</string>
-	<!-- Text for the button that returns to caller application -->
-	<string name="more_info">Mostrar informação adicional</string>
 	<!-- Text for message when used successfully copied something -->
 	<string name="copied_to_clipboard">Copiado para a Área de Transferência: %1$s</string>
 	<!-- place preview title -->
 	<string name="info">Info</string>
 	<!-- Used for bookmark editing -->
 	<string name="done">Feito</string>
-	<!-- Summary for preferences in MWM -->
-	<string name="yopme_pref_summary">Escolha as definições de Ecrã Posterior</string>
-	<!-- Title for yopme preferences in MWM -->
-	<string name="yopme_pref_title">Configurações do Ecrã Posterior</string>
-	<!-- Hint for upper-right icon p2b -->
-	<string name="show_on_backscreen">Mostrar no Ecrã Posterior</string>
 	<!-- Prints version number in About dialog -->
 	<string name="version">Versão: %s</string>
 	<!-- Confirmation in downloading countries dialog -->
@@ -239,11 +175,6 @@
 	<!-- Length of track in cell that describes route -->
 	<string name="length">Comprimento</string>
 	<string name="share_my_location">Partilhar a minha localização</string>
-	<string name="menu_search">Pesquisar</string>
-	<!-- Settings screen: "Map" category title -->
-	<string name="prefs_group_map">Mapa</string>
-	<!-- Settings screen: "Miscellaneous" category title -->
-	<string name="prefs_group_misc">Diversos</string>
 	<string name="prefs_group_route">Navegação</string>
 	<string name="pref_zoom_title">Botões de zoom</string>
 	<string name="pref_zoom_summary">Mostrar no ecrã</string>
@@ -259,8 +190,6 @@
 	<string name="pref_map_3d_title">Visão em Perspectiva</string>
 	<!-- Settings «Map» category: «3D buildings» title -->
 	<string name="pref_map_3d_buildings_title">Prédios em 3D</string>
-	<!-- Settings «Map» category: «3D buildings» summary -->
-	<string name="pref_map_3d_buildings_subtitle">Afeta a vida da bateria</string>
 	<!-- Settings «Route» category: «Tts enabled» title -->
 	<string name="pref_tts_enable_title">Instruções de voz</string>
 	<!-- Settings «Route» category: «Tts language» title -->
@@ -269,7 +198,6 @@
 	<string name="pref_tts_unavailable">Não disponível</string>
 	<!-- Title for "Other" section in TTS settings. -->
 	<string name="pref_tts_other_section_title">Outro</string>
-	<string name="pref_tts_how_to_set_up_voice">Como configurar a voz</string>
 	<!-- Settings «Map» category: «Record track» title -->
 	<string name="pref_track_record_title">Trajeto recente</string>
 	<string name="pref_map_auto_zoom">Zoom automático</string>
@@ -280,46 +208,11 @@
 	<string name="duration_12_hours">12 horas</string>
 	<string name="duration_1_day">1 dia</string>
 	<string name="recent_track_help_text">Permite-lhe gravar um caminho percorrido durante um determinado período e vê-lo no papa. Nota: esta funcionalidade provoca uma maior utilização da bateria. A rota será automaticamente removida do mapa após o intervalo de tempo expirar.</string>
-	<string name="pref_track_ios_caption">O trajeto recente mostra o seu caminho percorrido.</string>
-	<string name="pref_track_ios_subcaption">Por favor, selecione o intervalo de tempo para gravação do percurso.</string>
-	<string name="placepage_distance">Distância</string>
-	<string name="placepage_coordinates">Coordenadas</string>
-	<string name="placepage_unsorted">Não classificado</string>
 	<string name="search_show_on_map">Ver no mapa</string>
-	<!-- Used to warn user when fixing KitKat issue -->
-	<string name="bookmark_move_fail">É necessário mover os seus marcadores para a memória interna, mas não há espaço disponível para eles. Por favor, liberte a memória, caso contrário, os marcadores não estarão disponíveis.</string>
-	<!-- Used in More Apps menu -->
-	<string name="free">Grátis</string>
-	<!-- Used in More Apps menu -->
-	<string name="buy">Comprar</string>
-	<!-- 1st search button-like result -->
-	<string name="search_on_map">Pesquisar no mapa</string>
-	<!-- toast with an error -->
-	<string name="no_route_found">Não foi encontrado nenhum trajecto</string>
-	<!-- route title -->
-	<string name="route">Trajeto</string>
-	<!-- category title -->
-	<string name="routes">Trajetos</string>
-	<!-- text of notification -->
-	<string name="download_map_notification">Descarregue o mapa do local onde estiver</string>
-	<!-- text of notification -->
-	<string name="pro_version_is_free_today">A versão completa do Organic Maps é hoje grátis! Descarregue e conte aos seus amigos.</string>
-	<!-- Dialog for transferring maps from lite to pro. -->
-	<string name="move_lite_maps_to_pro">Estamos a transferir os seus mapas descarregados da Organic Maps Lite para a Organic Maps. Isto pode demorar alguns minutos.</string>
-	<!-- Message to display when maps moved. -->
-	<string name="move_lite_maps_to_pro_ok">Os seus mapas descarregados estão transferidos com sucesso para a Organic Maps.</string>
-	<!-- Message to display when maps move failed. -->
-	<string name="move_lite_maps_to_pro_failed">Falhou a transferência dos seus mapas. Por favor, elimine a Organic Maps Lite e descarregue os mapas novamente.</string>
-	<!-- Text in menu -->
-	<string name="settings_and_more">Definições e Mais</string>
 	<!-- Text in menu -->
 	<string name="website">Site</string>
-	<!-- Text in menu -->
-	<string name="contact_us">Contacte-nos</string>
 	<!-- Settings: Send feedback button and dialog title -->
 	<string name="feedback">Comentários</string>
-	<!-- Text in menu -->
-	<string name="subscribe_to_news">Subscreva as nossas notícias</string>
 	<!-- Text in menu -->
 	<string name="rate_the_app">Classificar o aplicativo</string>
 	<!-- Text in menu -->
@@ -328,12 +221,6 @@
 	<string name="copyright">Direitos de Autor</string>
 	<!-- Text in menu -->
 	<string name="report_a_bug">Relatar um problema</string>
-	<!-- Email subject -->
-	<string name="subscribe_me_subject">Por favor inscrevam-me na newsletter da Organic Maps</string>
-	<!-- Email body -->
-	<string name="subscribe_me_body">Quero ser o(a) primeiro(a) a saber sobre as últimas notícias, actualizações e promoções. Posso cancelar a minha subscrição a qualquer altura.</string>
-	<!-- About text -->
-	<string name="about_text">A Organic Maps oferece os mapas offline mais rápidos de todas as cidades, de todos os países do mundo. Viaje com plena confiança: onde estiver, a Organic Maps ajuda a localizar-se no mapa, a encontrar o restaurante, hotel, banco, posto de gasolina, etc. mais próximos. Não requer ligação à Internet.\n\nEstamos sempre a trabalhar em novas funcionalidades e gostaríamos de saber a sua opinião sobre como poderíamos melhorar a Organic Maps. Se tiver algum problema com a app, não hesite em contactar-nos em support\@organicmaps.app. Respondemos a cada pedido!\n\nGosta da Organic Maps e quer apoiar-nos? Há algumas maneiras simples e absolutamente gratuitas:\n\n- publique um comentário no seu App Market\n- faça \"gosto\" na nossa página do Facebook http://www.facebook.com/OrganicMaps\n- ou fale da Organic Maps à sua mãe, amigos e colegas :)\n\nObrigado por estar connosco. Agradecemos imenso o seu apoio!\n\nP. S. Tiramos os dados do OpenStreetMap, um projeto de mapeamento semelhante à Wikipedia, que permite aos utilizadores criarem e editarem mapas. Se vir que algo está em falta ou errado no mapa, pode corrigir diretamente os mapas em https://www.openstreetmap.org e as suas alterações irão aparecer na app Organic Maps com o lançamento da próxima versão.</string>
 	<!-- Alert text -->
 	<string name="email_error_body">O cliente de email não está configurado. Por favor, configure-o ou utilize qualquer outro modo para nos contactar através de %s</string>
 	<!-- Alert title -->
@@ -342,137 +229,56 @@
 	<string name="pref_calibration_title">Calibração de bússola</string>
 	<!-- Search category -->
 	<string name="wifi">WiFi</string>
-	<!-- Update map suggestion -->
-	<string name="routing_map_outdated">Por favor, atualize o mapa para criar uma rota.</string>
-	<!-- Update maps suggestion -->
-	<string name="routing_update_maps">A nova versão do Organic Maps permite criar rotas a partir da sua posição atual até um ponto de destino. Por favor, atualize o maps para utilizar esta funcionalidade.</string>
 	<!-- Update all button text -->
 	<string name="downloader_update_all_button">Atualizar tudo</string>
 	<!-- Cancel all button text -->
 	<string name="downloader_cancel_all">Cancelar Tudo</string>
 	<!-- Downloaded maps category -->
 	<string name="downloader_downloaded_subtitle">Descarregado</string>
-	<!-- Downloaded maps category -->
-	<string name="downloader_available_maps">Disponível</string>
 	<!-- Country queued for download -->
 	<string name="downloader_queued">Na fila</string>
 	<string name="downloader_near_me_subtitle">Perto de mim</string>
 	<string name="downloader_status_maps">Mapas</string>
 	<string name="downloader_download_all_button">Descarregar tudo</string>
 	<string name="downloader_downloading">Descarregando:</string>
-	<string name="downloader_search_results">Encontrado</string>
-	<!-- Disclaimer message -->
-	<string name="routing_disclaimer">Ao criar rotas no app Organic Maps, por favor, lembre-se do seguinte:\n\n  - As rotas sugeridas podem apenas ser consideradas como recomendações.\n - As condições da estrada, regras de trânsito e sinais têm maior prioridade do que os conselhos de navegação.\n - O mapa poderá estar errado, ou desatualizado, e as rotas poderão não ser criadas da melhor forma possível.\n\n  Circule em segurança nas estradas e cuide do seu bem estar!</string>
-	<!-- Outdated maps category -->
-	<string name="downloader_outdated_maps">Desatualizado</string>
-	<!-- Up to date maps category -->
-	<string name="downloader_uptodate_maps">Atualizado</string>
 	<!-- Status of outdated country in the list -->
 	<string name="downloader_status_outdated">Atualizar</string>
 	<!-- Status of failed country in the list -->
 	<string name="downloader_status_failed">Falhou</string>
 	<!-- Displayed in a dialog that appears when a user tries to delete a map while the app is in the follow route mode -->
 	<string name="downloader_delete_map_while_routing_dialog">Favor parar a navegação para apagar o mapa.</string>
-	<!-- Show when user try build route, but we don't know where he -->
-	<string name="routing_failed_unknown_my_position">A localização atual não foi definida. Por favor especifique a localização para criar o trajeto.</string>
-	<!-- Show if use has not routing file, or InconsistentMWMandRoute -->
-	<string name="routing_failed_has_no_routing_file">São necessários dados adicionais para criar uma rota. Descarregar os dados agora?</string>
-	<!-- StartPointNotFound -->
-	<string name="routing_failed_start_point_not_found">Impossível calcular o trajeto. Não há estradas próximas ao seu ponto de partida.</string>
-	<!-- EndPointNotFound -->
-	<string name="routing_failed_dst_point_not_found">Impossível calcular o trajeto. Não há estradas próximas ao seu destino.</string>
 	<!-- PointsInDifferentMWM -->
 	<string name="routing_failed_cross_mwm_building">Só podem ser criados trajetos que estejam completamente contidos num único mapa.</string>
-	<!-- RouteNotFound -->
-	<string name="routing_failed_route_not_found">Não foi encontrado um trajeto entre a origem e o destino selecionados. Por favor selecione um ponto de partida ou de chegada diferente.</string>
-	<!-- InternalError -->
-	<string name="routing_failed_internal_error">Ocorreu um erro interno. Por favor experimente apagar o mapa e depois descarregue-o novamente. Se o problema persistir, contacte-nos através de support\@organicmaps.app.</string>
-	<!-- Context menu item for downloader. -->
-	<string name="downloader_download_map_and_routing">Descarregar Mapa + Roteamento</string>
-	<!-- Context menu item for downloader. -->
-	<string name="downloader_download_routing">Descarregar Roteamento</string>
-	<!-- Context menu item for downloader. -->
-	<string name="downloader_delete_routing">Apagar Roteamento</string>
 	<!-- Context menu item for downloader. -->
 	<string name="downloader_download_map">Baixar o mapa</string>
-	<string name="downloader_download_map_no_routing">Baixar mapa sem roteamento</string>
-	<!-- Button for routing. -->
-	<string name="routing_go">Avançar!</string>
 	<!-- Item status in downloader. -->
 	<string name="downloader_retry">Repetir</string>
-	<!-- Item in context menu. -->
-	<string name="downloader_map_and_routing">Mapa + Criação de Trajeto</string>
 	<!-- Item in context menu. -->
 	<string name="downloader_delete_map">Apagar Mapa</string>
 	<!-- Item in context menu. -->
 	<string name="downloader_update_map">Atualizar Mapa</string>
-	<!-- Item in context menu. -->
-	<string name="downloader_update_map_and_routing">Atualizar Mapa + Criação de Trajeto</string>
-	<!-- Item in context menu. -->
-	<string name="downloader_map_only">Apenas Mapa</string>
-	<!-- Toolbar title -->
-	<string name="toolbar_application_menu">Menu de Aplicação</string>
 	<!-- Preference text -->
 	<string name="pref_use_google_play">Use o Google Play Serviços para determinar a sua localização actual</string>
 	<!-- Text for rating dialog -->
 	<string name="rating_just_rated">Acabei de avaliar o seu app</string>
-	<!-- Text for rating dialog -->
-	<string name="rating_user_since">Sou usuário do Organic Maps desde %s</string>
-	<!-- Text for rating dialog -->
-	<string name="rating_do_like_maps">Você gosta de Organic Maps?</string>
-	<!-- Text for rating dialog -->
-	<string name="rating_tap_star">Toque em alguma estrela para classificar o nosso app.</string>
 	<!-- Text for rating dialog -->
 	<string name="rating_thanks">Obrigado!</string>
 	<!-- Text for rating dialog -->
 	<string name="rating_share_ideas">Compartilhe quaisquer ideias ou problemas para que possamos melhorar o app para você.</string>
 	<!-- Text for rating dialog -->
 	<string name="rating_send_feedback">Envie seu comentário</string>
-	<!-- Text for g+ dialog -->
-	<string name="rating_google_plus">Clique em g+ para contar aos seus amigos sobre o app.</string>
 	<!-- Text for routing error dialog -->
 	<string name="routing_download_maps_along">Descarregar todos os mapas ao longo do trajeto</string>
-	<!-- Text for routing error dialog -->
-	<string name="routing_download_map">Obter mapa</string>
-	<!-- Text for routing error dialog -->
-	<string name="routing_download_map_and_routing">Descarregue o mapa e os dados de itinerário atualizados para acessar todos os recursos do Organic Maps.</string>
-	<!-- Text for routing error dialog -->
-	<string name="routing_get_routing_data">Obter dados de itinerário</string>
-	<!-- Text for routing error dialog -->
-	<string name="routing_get_additional_data">São necessários dados adicionais para criar rotas a partir da sua localização.</string>
 	<!-- Text for routing error dialog -->
 	<string name="routing_requires_all_map">É necessário baixar e atualizar todos os mapas entre sua localização e o destino para criar uma rota.</string>
 	<!-- Text for routing error dialog -->
 	<string name="routing_not_enough_space">Espaço insuficiente</string>
-	<!-- Text for routing error dialog -->
-	<string name="routing_download_more_than_avail">É necessário descarregar %1$s MB, mas há apenas %2$s MB disponíveis.</string>
-	<!-- Text for routing error dialog -->
-	<string name="routing_download_roaming">Você fará o download de %s MB através de Dados Móveis (em Roaming). Isto poderá resultar em cobranças adicionais, dependendo do seu plano de dados móveis.</string>
 	<!-- bookmark button text -->
 	<string name="bookmark">favorito</string>
-	<!-- map is not downloaded -->
-	<string name="not_found_map">O mapa para a sua localização não foi descarregado</string>
 	<!-- location service disabled -->
 	<string name="enable_location_services">Por favor active os Serviços de Localização</string>
-	<!-- download map -->
-	<string name="download_map">Descarregue o mapa para a sua localização</string>
-	<!-- download map on iPhone -->
-	<string name="download_map_iphone">Descarregue o mapa da localização atual para o seu iPhone</string>
-	<!-- clear pin -->
-	<string name="nearby">Próximo</string>
-	<!-- clear pin -->
-	<string name="clear_pin">Limpar marcação</string>
-	<!-- location is undefined -->
-	<string name="undefined_location">A localização actual não foi definida.</string>
-	<!-- download country of your location -->
-	<string name="download_country">Descarregue o país da sua localização actual</string>
-	<!-- download failed -->
-	<string name="download_failed">descarga falhou</string>
-	<!-- get the map -->
-	<string name="get_the_map">Obter mapa</string>
 	<string name="save">Salvar</string>
 	<string name="edit_description_hint">Suas descrições (texto ou html)</string>
-	<string name="new_group">novo grupo</string>
 	<string name="create">criar</string>
 	<!-- red color -->
 	<string name="red">Vermelho</string>
@@ -490,22 +296,6 @@
 	<string name="brown">Marrom</string>
 	<!-- pink color -->
 	<string name="pink">Rosa</string>
-	<!-- deep purple color -->
-	<string name="deep_purple">Purpúreo escuro</string>
-	<!-- light blue color -->
-	<string name="light_blue">Azul Claro</string>
-	<!-- cyan color -->
-	<string name="cyan">Azul-verde</string>
-	<!-- teal color -->
-	<string name="teal">Esmeralda</string>
-	<!-- lime color -->
-	<string name="lime">Lima</string>
-	<!-- deep orange color -->
-	<string name="deep_orange">Laranja escuro</string>
-	<!-- gray color -->
-	<string name="gray">Cinza</string>
-	<!-- blue gray color -->
-	<string name="blue_gray">Azul-cinza</string>
 	<!-- Wi-Fi available -->
 	<string name="WiFi_available">Sim</string>
 
@@ -521,10 +311,8 @@
 	<string name="dialog_routing_location_turn_wifi">Verifique o sinal do GPS. Ative o Wi-Fi para melhorar a precisão da localização.</string>
 	<string name="dialog_routing_location_turn_on">Ative os serviços de localização</string>
 	<string name="dialog_routing_location_unknown_turn_on">Não foi possível localizar as coordenadas do GPS. Ative os serviços de localização para que a rota seja traçada.</string>
-	<string name="dialog_routing_location_unknown">Não foi possível obter as coordenadas GPS.</string>
 	<string name="dialog_routing_download_files">Descarregar os arquivos necessários</string>
 	<string name="dialog_routing_download_and_update_all">Descarregue e actualize todos os dados de mapa e roteamento ao longo do trajeto desejado para que a rota seja traçada.</string>
-	<string name="dialog_routing_routes_size">Arquivos de dados de roteamento</string>
 	<string name="dialog_routing_unable_locate_route">Não foi possível encontrar uma rota</string>
 	<string name="dialog_routing_cant_build_route">Não foi possível traçar uma rota.</string>
 	<string name="dialog_routing_change_start_or_end">Ajuste o ponto de partida ou o ponto de chegada.</string>
@@ -539,33 +327,23 @@
 	<string name="dialog_routing_system_error">Erro de sistema</string>
 	<string name="dialog_routing_application_error">Não foi possível traçar uma rota devido a um erro no aplicativo.</string>
 	<string name="dialog_routing_try_again">Tente novamente</string>
-	<string name="dialog_routing_send_error">Relatar o Problema</string>
-	<string name="dialog_routing_if_get_cross_route">Deseja traçar uma rota mais direta, mas que se estenda por mais de um mapa?</string>
-	<string name="dialog_routing_cross_route_is_optimal">Há uma rota disponível que vai além dos limites deste mapa.</string>
 	<string name="not_now">Agora Não</string>
-	<string name="dialog_routing_build_route">Traçar</string>
 	<string name="dialog_routing_download_and_build_cross_route">Deseja descarregar o mapa e traçar uma rota melhor, mas que se estenda por mais de um mapa?</string>
 	<string name="dialog_routing_download_cross_route">Descarregue o mapa para traçar uma rota melhor que vai além dos limites desse mapa.</string>
-	<string name="dialog_routing_cross_route_always">Sempre cruzar esse limite</string>
 
 	<!-- SECTION: Strings for downloading map from search -->
 	<string name="search_without_internet_advertisement">Para começar a pesquisar e criar rotas, por favor, descarregue o mapa. Assim, não precisará mais de uma conexão com a internet.</string>
 	<string name="search_select_map">Selecionar Mapa</string>
-	<string name="search_select_other_map">Selecionar Outro Mapa</string>
 	<!-- «Show» context menu -->
 	<string name="show">Mostrar</string>
 	<!-- «Hide» context menu -->
 	<string name="hide">Ocultar</string>
 	<!-- «Rename» context menu -->
 	<string name="rename">Renomear</string>
-	<!-- Bottom sheet: expand button (should be short) -->
-	<string name="bottom_sheet_more">Mais…</string>
 	<!-- Failed planning route message in navigation view -->
 	<string name="routing_planning_error">Falhou o Planeamento da Rota</string>
 	<!-- Arrive routing message in navigation view -->
 	<string name="routing_arrive">Chegada: %s</string>
-	<!-- Text for routing::RouterResultCode::FileTooOld dialog. -->
-	<string name="dialog_routing_download_and_update_maps">Para criar uma rota, por favor, baixe e atualize todos os mapas ao longo do trajeto.</string>
 	<string name="rate_alert_title">Gosta do aplicativo?</string>
 	<string name="rate_alert_default_message">Obrigado por usar Organic Maps. Por favor, classifique o aplicativo. Seu feedback nos ajuda a melhorar.</string>
 	<string name="rate_alert_five_star_message">Viva! Também amamos você!</string>
@@ -573,26 +351,16 @@
 	<string name="rate_alert_less_than_four_star_message">Alguma ideia sobre como podemos melhorar?</string>
 	<string name="categories">Categorias</string>
 	<string name="history">Histórico</string>
-	<string name="next_turn_then">Em seguida</string>
 	<string name="closed">Fechado</string>
-	<string name="back_to">Voltar para %s</string>
 	<string name="search_not_found">Lamento, mas não encontrei nada.</string>
 	<string name="search_not_found_query">Por favor, tente outro termo de busca.</string>
-	<string name="search_not_found_map">Por favor, descarregue o mapa em que está pesquisando.</string>
-	<string name="search_not_found_location">Descarregue o mapa da sua localização atual.</string>
 	<string name="search_history_title">Histórico de Busca</string>
 	<string name="search_history_text">Visualizar as buscas recentes.</string>
 	<string name="clear_search">Limpar histórico de pesquisa</string>
-	<!-- Title for settings to enable/disable showcase menu button -->
-	<string name="showcase_settings_title">Mostrar ofertas</string>
 	<!-- Place Page link to Wikipedia article (if map object has it). -->
 	<string name="read_in_wikipedia">Wikipédia</string>
-	<string name="p2p_route_planning">Planejar rota</string>
 	<string name="p2p_your_location">Localização atual</string>
-	<string name="p2p_from">Ponto de partida</string>
-	<string name="p2p_to">Ponto de destino</string>
 	<string name="p2p_start">Iniciar</string>
-	<string name="p2p_planning">Planejando…</string>
 	<string name="p2p_from_here">De</string>
 	<string name="p2p_to_here">Itinerário para</string>
 	<string name="p2p_only_from_current">Só é possível navegar a partir da sua localização actual.</string>
@@ -612,11 +380,8 @@
 	<string name="editor_hours_closed">Horas Sem Funcionamento</string>
 	<string name="editor_example_values">Valores de exemplo</string>
 	<string name="editor_correct_mistake">Corrigir erro</string>
-	<string name="editor_correct_mistake_message">Fez um erro de edição. Corrija-o ou mude para o modo simples.</string>
 	<string name="editor_add_select_location">Local</string>
 	<string name="editor_done_dialog_1">Modificou o mapa-múndi. Não esconda isto! Diga aos seus amigos e editem-no juntos.</string>
-	<string name="editor_done_dialog_2">Esta é a sua segunda melhoria ao mapa. Agora, está no %dº lugar na lista de editores de mapas. Fale disto aos seus amigos.</string>
-	<string name="editor_done_dialog_3">Melhorou o mapa, fale disto aos seus amigos e editem o mapa juntos.</string>
 	<string name="share_with_friends">Compartilhar com amigos</string>
 	<string name="editor_report_problem_desription_1">Por favor, descreva o problema ao pormenor para que a comunidade OpenStreeMap possa corrigir o erro.</string>
 	<string name="editor_report_problem_desription_2">Ou faça-o sozinho em https://www.openstreetmap.org/</string>
@@ -625,14 +390,7 @@
 	<string name="editor_report_problem_no_place_title">O lugar não existe</string>
 	<string name="editor_report_problem_under_construction_title">Encerrado para manutenção</string>
 	<string name="editor_report_problem_duplicate_place_title">Lugar em duplicado</string>
-	<string name="first_launch_congrats_title">Organic Maps está pronto para utilização</string>
-	<string name="first_launch_congrats_text">Busque qualquer lugar do mundo e navegue offline, gratuitamente.</string>
-	<string name="migrate_title">Importante!</string>
-	<!-- Android uses image instead of text. -->
-	<string name="download_all">Descarregar tudo</string>
-	<string name="delete_all">Excluir todos</string>
 	<string name="autodownload">Download automático</string>
-	<string name="disable_autodownload">Desativar o download automático</string>
 	<!-- Place Page opening hours text -->
 	<string name="closed_now">Fechado agora</string>
 	<!-- Place Page opening hours text -->
@@ -641,8 +399,6 @@
 	<string name="day_off_today">Dia de folga hoje</string>
 	<string name="day_off">Dia de folga</string>
 	<string name="today">Hoje</string>
-	<string name="sunrise_to_sunset">Do amanhecer ao anoitecer</string>
-	<string name="sunset_to_sunrise">Do pôr do sol ao amanhecer</string>
 	<string name="add_opening_hours">Adicionar horário de funcionamento</string>
 	<string name="edit_opening_hours">Editar horário de funcionamento</string>
 	<string name="no_osm_account">Sem conta no OpenStreetMap?</string>
@@ -652,29 +408,13 @@
 	<string name="login">Acessar</string>
 	<string name="password">Senha</string>
 	<string name="forgot_password">Esqueceu sua senha?</string>
-	<!-- Forgot Password dialog title -->
-	<string name="restore_password">Recuperar senha</string>
-	<string name="enter_email_address_to_reset_password">Digite o endereço de email que você usou ao cadastrar-se, e nós lhe enviaremos o link para redefinir a sua senha.</string>
-	<string name="reset_password">Redefinir senha</string>
-	<string name="username">Nome de usuário</string>
 	<string name="osm_account">Conta OSM</string>
 	<string name="logout">Encerrar sessão</string>
-	<string name="login_and_edit_map_motivation_message">Acesse e edite informações dos objetos no mapa e eles serão disponibilizados para milhões de outros usuários. Vamos melhorar o mundo juntos.</string>
 	<!-- Information text: "Last upload 11.01.2016" -->
 	<string name="last_upload">Último upload</string>
-	<!-- Motivates user to login/register, title above login buttons. -->
-	<string name="you_have_edited_your_first_object">Você editou o seu primeiro objeto!</string>
 	<string name="thank_you">Obrigado</string>
-	<string name="login_with_google">Entrar com Google</string>
-	<string name="login_with_openstreetmap">Entrar com www.openstreetmap.org</string>
 	<string name="edit_place">Editar o local</string>
 	<string name="place_name">Nome do local</string>
-	<!-- title above languages list cells in the editor, below editable name text field. -->
-	<string name="other_languages">Outros idiomas</string>
-	<!-- small button to open list with names in different languages -->
-	<string name="show_more">Mostrar mais</string>
-	<!-- small button to close list with names in different languages -->
-	<string name="show_less">Mostrar menos</string>
 	<string name="add_language">Adicionar um idioma</string>
 	<string name="street">Rua</string>
 	<!-- Editable House Number text field (in address block). -->
@@ -691,25 +431,16 @@
 	<string name="email_or_username">Email ou nome de usuário</string>
 	<string name="phone">Telefone</string>
 	<string name="please_note">Aviso</string>
-	<string name="common_no_wifi_dialog">Nenhuma ligação Wi-Fi. Deseja continuar com os dados móveis?</string>
 	<string name="downloader_delete_map_dialog">Todas as alterações ao mapa serão eliminadas juntamente com o mapa.</string>
 	<string name="downloader_update_maps">Atualizar mapas</string>
 	<string name="downloader_mwm_migration_dialog">Para criar um itinerário é necessário actualizar todos os mapas e, em seguida, planejá-lo novamente.</string>
 	<string name="downloader_search_field_hint">Encontrar o mapa</string>
-	<string name="migration_update_all_button">Atualizar todos os mapas</string>
-	<string name="migration_delete_all_download_current_button">Descarregue o mapa atual e elimine os antigos</string>
 	<string name="migration_download_error_dialog">Erro de download</string>
 	<string name="common_check_internet_connection_dialog">Por favor, verifique as suas opções e certifique-se de que o dispositivo está ligado à Internet.</string>
 	<string name="downloader_no_space_title">Não há espaço suficiente</string>
 	<string name="downloader_no_space_message">Por favor, remova os dados desnecessários</string>
-	<string name="editor_general_auth_error_dialog">Erro genérico de início de sessão.</string>
 	<string name="editor_login_error_dialog">Erro de início de sessão.</string>
-	<string name="editor_login_failed_dialog">O início de sessão falhou</string>
-	<string name="editor_username_error_dialog">O nome de utilizador é inválido</string>
-	<string name="editor_place_edited_dialog">Editou um objeto!</string>
-	<string name="editor_login_with_osm">Iniciar sessão com a OpenStreetMap</string>
 	<string name="editor_profile_changes">Alterações verificadas</string>
-	<string name="editor_profile_unsent_changes">Não enviado:</string>
 	<string name="editor_focus_map_on_location">Mova o mapa para selecionar o lugar correto do objeto.</string>
 	<string name="editor_add_select_category">Selecionar categoria</string>
 	<string name="editor_add_select_category_popular_subtitle">Popular</string>
@@ -720,19 +451,14 @@
 	<string name="editor_edit_place_category_title">Categoria</string>
 	<string name="detailed_problem_description">Descrição detalhada do problema</string>
 	<string name="editor_report_problem_other_title">Um problema diferente</string>
-	<string name="placepage_report_problem_button">Comunicar um problema</string>
 	<string name="placepage_add_business_button">Adicionar uma organização</string>
 	<string name="whatsnew_editor_message_1">Adicione novos lugares ao mapa e edite os já existentes diretamente a partir do app.</string>
-	<string name="whatsnew_editor_message_2">* A Organic Maps utiliza dados da comunidade OpenStreetMap.</string>
 	<string name="dialog_incorrect_feature_position">Mudar local</string>
 	<string name="message_invalid_feature_position">Um objeto não pode ser posicionado aqui</string>
 	<string name="login_to_make_edits_visible">Inicie sessão para que outros usuários vejam as mudanças que você fez.</string>
-	<string name="no_migration_during_navigation">Actualização não é permitida durante a navegação.</string>
 	<!-- Error dialog no space -->
 	<string name="migration_no_space_message">Para descarregar, é necessário mais espaço. Por favor, elimine os dados desnecessários.</string>
 	<string name="editor_sharing_title">Melhorei os mapas do Organic Maps</string>
-	<string name="editor_comment_will_be_sent">Encaminharemos o seu comentário aos cartógrafos.</string>
-	<string name="editor_unsupported_category_message">Você adicionou um local de uma categoria para a qual ainda não temos suporte. Ele aparecerá no mapa no futuro.</string>
 	<!-- Downloaded 10 **of** 20 <- it is that "of" -->
 	<string name="downloader_of">%1$d de %2$d</string>
 	<string name="download_over_mobile_header">Descarregar usando uma conexão de rede celular?</string>
@@ -750,15 +476,8 @@
 	<string name="editor_detailed_description">As suas alterações sugeridas irão ser enviadas para a comunidade OpenStreetMap. Descreva os dados que não podem ser editados no Organic Maps</string>
 	<string name="editor_more_about_osm">Mais sobre o OpenStreetMap</string>
 	<string name="editor_operator">Operador</string>
-	<string name="editor_tag_description">Introduza a empresa, organização ou indivíduo responsável pelas instalações.</string>
-	<string name="editor_no_local_edits_title">Não tem edições locais</string>
-	<string name="editor_no_local_edits_description">Isto demonstra o número das suas alterações sugeridas no mapa que atualmente só são acessíveis no seu dispositivo.</string>
-	<string name="editor_send_to_osm">Enviar para OSM</string>
-	<string name="editor_remove">Remover</string>
-	<string name="downloader_my_maps_title">Os meus mapas</string>
 	<string name="downloader_no_downloaded_maps_title">Não descarregou quaisquer mapas</string>
 	<string name="downloader_no_downloaded_maps_message">Descarregar mapas para encontrar a localização e navegar offline.</string>
-	<string name="downloader_find_place_hint">Pesquisar cidade ou país</string>
 	<!-- Error title that appears after certain time without location. -->
 	<string name="current_location_unknown_title">Continuar a detetar a sua localização atual?</string>
 	<!-- Error that appears after certain time without location. -->
@@ -773,27 +492,10 @@
 	<string name="location_services_disabled_2">2. Toque em \"Localização\"</string>
 	<!-- iOS Dialog for the case when the location permission is not granted -->
 	<string name="location_services_disabled_3">3. Selecione Durante Uso do Aplicativo</string>
-	<string name="placepage_parking_surface">Superfície</string>
-	<string name="placepage_parking_multistorey">Vários andares</string>
-	<string name="placepage_parking_underground">Local desconhecido</string>
-	<string name="placepage_parking_rooftop">Terraço</string>
-	<string name="placepage_parking_sheds">Abrigos</string>
-	<string name="placepage_parking_carports">Garagens</string>
-	<string name="placepage_parking_boxes">Garagens</string>
-	<string name="placepage_parking_pay">Pagamento</string>
-	<string name="placepage_parking_free">Gratuito</string>
-	<string name="placepage_parking_interval">Pagamento intervalado</string>
-	<string name="placepage_entrance_number">N.º</string>
-	<string name="placepage_entrance_type">Entrada</string>
-	<string name="placepage_flat">apto.</string>
-	<string name="placepage_open_24_7">24 / 7</string>
 	<string name="meter">m</string>
 	<string name="kilometer">Km</string>
-	<string name="kilometers_per_hour">km/h</string>
 	<string name="mile">M</string>
 	<string name="foot">ft</string>
-	<string name="miles_per_hour">mph</string>
-	<string name="day">d</string>
 	<string name="hour">h</string>
 	<string name="minute">min</string>
 	<string name="placepage_place_description">Descrição</string>
@@ -803,46 +505,30 @@
 	<string name="placepage_call_button">Chamada</string>
 	<string name="placepage_edit_bookmark_button">Editar marcador</string>
 	<string name="placepage_bookmark_name_hint">Nome do marcador</string>
-	<string name="placepage_personal_notes_hint">Notas pessoais</string>
-	<string name="placepage_delete_bookmark_button">Eliminar marcador</string>
 	<string name="editor_edits_sent_message">As suas alterações sugeridas foram enviadas</string>
 	<string name="editor_comment_hint">Comentário…</string>
 	<string name="editor_reset_edits_message">Descartar todas as alterações locais?</string>
 	<string name="editor_reset_edits_button">Descartar</string>
 	<string name="editor_remove_place_message">Remover local adicionado?</string>
 	<string name="editor_remove_place_button">Remover</string>
-	<string name="editor_status_sending">A enviar…</string>
 	<string name="editor_place_doesnt_exist">O local não existe</string>
 	<string name="text_more_button">…mais</string>
 	<!-- Phone number error message -->
 	<string name="error_enter_correct_phone">Insira o número correto do telefone</string>
 	<string name="error_enter_correct_web">Preencha com um endereço válido na internet</string>
 	<string name="error_enter_correct_email">Preencha com um endereço válido de email</string>
-	<string name="error_enter_correct">Preencha com um valor válido</string>
 	<string name="refresh">Atualizar</string>
-	<string name="last_update">Última atualização: %s</string>
 	<string name="placepage_add_place_button">Adicionar um local ao mapa</string>
 	<!-- Displayed when saving some edits to the map to warn against publishing personal data -->
 	<string name="editor_share_to_all_dialog_title">Deseja enviar para todos os usuários?</string>
 	<!-- iOS Dialog before publishing the modifications to the public map. -->
 	<string name="editor_share_to_all_dialog_message_1">Certifique-se de não ter incluído nenhum dado pessoal.</string>
 	<string name="editor_share_to_all_dialog_message_2">Verificaremos as alterações. Se tivermos perguntas, entraremos em contato com você por email.</string>
-	<string name="navigation_overview_button">visão geral</string>
-	<string name="navigation_stop_button">parar</string>
-	<!-- Text on an empty bookmark page -->
-	<string name="bookmarks_empty_title">Salvar Favoritos</string>
-	<string name="bookmarks_empty_message_1">Toque em ★ para salvar locais favoritos para rápido acesso.</string>
-	<string name="bookmarks_empty_message_2">Importe favoritos do Mail e da web.</string>
-	<string name="bookmarks_empty_message_3">check out: %s</string>
-	<!-- Name of the group for booked hotels -->
-	<string name="bookmarks_group_name">Hotéis reservados</string>
-	<string name="place_page_button_read_descriprion">Leia</string>
 	<!-- iOS dialog for the case when recent track recording is on and the app comes back from background -->
 	<string name="recent_track_background_dialog_title">Desabilitar registro de sua rota recente?</string>
 	<string name="off_recent_track_background_button">Desabilitar</string>
 	<!-- For sharing via SMS and so on -->
 	<string name="sharing_call_action_look">Procure</string>
-	<string name="continue_recent_track_background_button">Continuar</string>
 	<string name="recent_track_background_dialog_message">O Organic Maps usa sua localização geográfica em segundo plano para registrar sua rota recente.</string>
 	<!-- Rate on Google Play (Android only) -->
 	<string name="rate_gp">Classificar em Google Play</string>
@@ -852,21 +538,11 @@
 	<string name="tell_friends_text">Olá! Instale o Organic Maps!</string>
 	<!-- About short text (below logo) -->
 	<string name="about_description">O Organic Maps é uma aplicação offline essencial para viajar. O Organic Maps baseia-se nos dados do OpenStreetMap e permite editá-los.</string>
-	<!-- Text in menu -->
-	<string name="blog">Blogue</string>
 	<string name="general_settings">Configurações gerais</string>
-	<string name="date">Data %d</string>
-	<!-- "Report a bug" -> "Generaal Feedback" -> "Something is not working" -->
-	<string name="something_is_not_working">Algo não está a funcionar</string>
 	<!-- For the first routing -->
 	<string name="accept">Aceitar</string>
 	<!-- For the first routing -->
 	<string name="decline">Declinar</string>
-	<string name="install_app">Instalar</string>
-	<string name="search_no_results_title">Nenhum resultado encontrado</string>
-	<string name="search_no_results_message">Tente um termo de pesquisa mais geral, diminuir o zoom ou redefinir o filtro.</string>
-	<string name="search_no_results_expand_area_button">Diminuir o zoom</string>
-	<string name="search_no_results_reset_button">Redefinir o filtro</string>
 	<!-- noun -->
 	<string name="search_in_table">Lista</string>
 	<string name="mobile_data_dialog">Utilizar a internet móvel para mostrar informações detalhadas?</string>
@@ -878,18 +554,13 @@
 	<string name="mobile_data_option_never">Nunca Utilizar</string>
 	<string name="mobile_data_option_ask">Perguntar Sempre</string>
 	<string name="traffic_update_maps_text">Para ver os dados de tráfego, os mapas devem ser atualizados.</string>
-	<string name="traffic_outdated">Os dados sobre o tráfego estão desatualizados.</string>
 	<string name="big_font">Aumentar tamanho da fonte no mapa</string>
 	<string name="traffic_update_app">Atualize o MAPS. ME</string>
 	<!-- "traffic" as in road congestion -->
 	<string name="traffic_update_app_message">Para mostrar os dados de tráfego, a aplicação deve ser atualizada.</string>
 	<!-- "traffic" as in "road congestion" -->
 	<string name="traffic_data_unavailable">Não existem dados de tráfego</string>
-	<!-- Simplified colour scheme for traffic information, fewer colours are used to display traffic jams on the map. The string should be kept as short as possible -->
-	<string name="pref_traffic_simplified_colors_title">Cores de trânsito simplificadas</string>
 	<string name="enable_logging">Ativar o histórico</string>
-	<string name="offline_place_page_more_information">Efetue ligação à internet para obter mais informações sobre o local.</string>
-	<string name="failed_load_information">Falha ao carregar informações.</string>
 	<!-- Settings: "Send general feedback" button -->
 	<string name="feedback_general">Opinão geral</string>
 	<string name="on">Lig.</string>
@@ -903,57 +574,26 @@
 	<string name="routing_add_start_point">Adicionar ponto de partida para planear uma rota</string>
 	<string name="routing_add_finish_point">Adicionar final da viagem para planear uma rota</string>
 	<string name="button_exit">Sair</string>
-	<string name="settings_device_memory">Memória do dispositivo</string>
-	<string name="settings_card_memory">Memória do cartão</string>
-	<string name="settings_storage_available">%s disponível</string>
-	<string name="toast_location_permission_denied">Permissão de localização da aplicação não autorizada</string>
-	<string name="button_use">Utilizar</string>
 	<string name="planning_route_manage_route">Gerir rota</string>
 	<string name="button_plan">Planear</string>
-	<string name="button_add">Adicionar</string>
 	<string name="placepage_remove_stop">Remover</string>
 	<string name="planning_route_remove_title">Arraste aqui para remover</string>
-	<string name="dialog_change_start_point_message">Substituir ponto de partida pela localização atual?</string>
-	<string name="button_replace">Substituir</string>
 	<string name="placepage_add_stop">Adicionar paragem</string>
-	<string name="add_my_position">Adicionar a minha posição</string>
-	<string name="choose_start_point">Escolher um ponto de partida</string>
-	<string name="choose_destination">Escolher um destino</string>
 	<string name="preloader_viator_button">Saiba Mais</string>
-	<string name="start_from_my_position">Iniciar a partir de</string>
-	<string name="profile_authorization_title">Iniciar sessao com</string>
-	<string name="profile_authorization_message">Início de sessão fácil e em apenas alguns segundos, sem dados de acesso e palavra-passe</string>
 	<string name="profile_authorization_error">Ups, ocorreu um erro. Tente iniciar sessão novamente.</string>
-	<string name="service">Serviço</string>
-	<string name="atmosphere">Atmosfera</string>
-	<string name="value_for_money">Relação qualidade-preço</string>
-	<string name="experience">Experiência</string>
-	<string name="assortment">Variedade</string>
-	<string name="expertise">Especialidade</string>
-	<string name="equipment">Equipamento</string>
-	<string name="quality">Qualidade</string>
 	<string name="dialog_error_storage_title">Problema de acesso ao armazenamento</string>
 	<string name="dialog_error_storage_message">Armazenamento externo não disponível. Provavelmente porque o Cartão SD foi removido, danificado ou o sistema de ficheiros é apenas para leitura. Verifique e entre em contacto conosco através do email support\@organicmaps.app</string>
 	<string name="setting_emulate_bad_storage">Emular o mau armazenamento</string>
-	<string name="directions_finish">Destino</string>
-	<string name="directions_on_foot">Caminhar %s</string>
 	<string name="core_entrance">Entrada</string>
-	<string name="coffee">Café</string>
-	<string name="cleanliness">Limpeza</string>
-	<string name="crowdedness">Lotado</string>
 	<string name="error_enter_correct_name">Introduza um nome correto</string>
 	<string name="bookmarks_groups">Listas</string>
 	<string name="bookmarks_groups_hide_all">Ocultar tudo</string>
 	<string name="bookmarks_groups_show_all">Mostrar tudo</string>
-	<plurals name="bookmarks_places">
-	  <item quantity="other">%d favoritos</item>
-	</plurals>
 	<string name="bookmarks_create_new_group">Criar nova lista</string>
 	<string name="downloader_hide_screen">Ocultar ecrã</string>
 	<string name="downloader_percent">%1$s (%2$s de %3$s)</string>
-	<string name="downloader_process">A transferir %s...</string>
-	<string name="downloader_applying">A aplicar %s...</string>
-	<string name="dialog_message_transit_not_found_connection">Planeie uma rota dentro de uma rede de tráfego</string>
+	<string name="downloader_process">A transferir %s…</string>
+	<string name="downloader_applying">A aplicar %s…</string>
 	<string name="bookmarks_error_message_share_general">A partilha não foi possível devido a um erro da aplicação</string>
 	<string name="bookmarks_error_title_share_empty">Erro de partilha</string>
 	<string name="bookmarks_error_message_share_empty">Não pode partilhar uma lista vazia</string>
@@ -962,12 +602,7 @@
 	<string name="bookmarks_new_list_hint">Nova lista</string>
 	<string name="bookmarks_error_title_list_name_already_taken">Esse nome já foi levado</string>
 	<string name="bookmarks_error_message_list_name_already_taken">Por favor, escolha outro nome</string>
-	<string name="bookmarks_error_title_list_name_too_long">Este nome é muito longo</string>
-	<string name="bookmarks_error_message_list_name_too_long">Por favor, escolha outro nome</string>
-	<string name="please_wait">Por favor, espere...</string>
-	<string name="phone_number">Número de telefone</string>
-	<string name="notification_unsent_reviews_title">Você tem vários comentários não enviados</string>
-	<string name="notification_unsent_reviews_message">Por favor, faça o login para compartilhar opiniões com outros viajantes</string>
+	<string name="please_wait">Por favor, espere…</string>
 	<string name="profile">Perfil do OpenStreetMap</string>
 	<string name="place_page_search_similar_hotel">Pesquisar hotéis semelhantes</string>
 	<string name="bookmarks_detect_title">Novos arquivos detectados</string>
@@ -978,31 +613,10 @@
 	<string name="button_convert">Converter</string>
 	<string name="bookmarks_convert_error_title">Erro</string>
 	<string name="bookmarks_convert_error_message">Alguns arquivos não foram convertidos.</string>
-	<string name="converting">Convertendo...</string>
-	<string name="wn_reinvented_bookmarks_title">Nós reinventamos os marcadores!</string>
-	<string name="wn_reinvented_bookmarks_message">Você pode fazer backup de favoritos, criar listas... É incrível...</string>
-	<string name="bookmarks_restore">Restaurar marcadores</string>
-	<string name="bookmarks_restore_process">Restaurando...</string>
 	<string name="bookmarks_restore_title">Restaurar esta versão?</string>
-	<string name="bookmarks_restore_message">Seus favoritos serão restaurados a partir de %1$s (%2$s)</string>
-	<string name="bookmarks_restore_empty_title">Você não tem um backup</string>
-	<string name="bookmarks_restore_empty_message">O servidor não encontrou backups feitos anteriormente</string>
 	<string name="common_check_internet_connection_dialog_title">Sem conexão com a internet</string>
-	<string name="error_server_title">Erro de servidor</string>
-	<string name="error_server_message">Houve um erro no servidor, tente novamente mais tarde</string>
 	<string name="error_system_message">Ocorreu um erro desconhecido</string>
 	<string name="restore">Restaurar</string>
-	<string name="bookmarks_page_downloaded">Baixado</string>
-	<string name="bookmarks_page_my">Minhas</string>
-	<string name="routes_and_bookmarks">Rotas e favoritos</string>
-	<string name="bookmarks_webview_success_toast">Favoritos baixados com sucesso</string>
-	<string name="cached_bookmarks_placeholder_title">Baixar novos lugares</string>
-	<string name="cached_bookmarks_placeholder_subtitle">Aperte o botão para baixar milhares de lugares e rotas interessantes criados pelos usuários de Organic Maps. Você precisará de conexão com a internet.</string>
-	<string name="downloader_download_routers">Baixar favoritos</string>
-	<string name="bookmarks_groups_cached">Listas baixadas</string>
-	<plurals name="bookmarks_objects">
-	  <item quantity="other">%s objeto</item>
-	</plurals>
 	<plurals name="objects">
 	  <item quantity="other">%d lugar</item>
 	</plurals>
@@ -1015,62 +629,32 @@
 	<string name="subtittle_opt_out">Configurações de rastreamento</string>
 	<string name="crash_reports">Relatório de erros</string>
 	<string name="crash_reports_description">Podemos utilizar seus dados para melhorar a experiência no Organic Maps. As mudanças entrarão em vigor após você reiniciar o aplicativo.</string>
-	<string name="opt_out_help_ios_1">O seu dispositivo móvel pode fornecer as opções de «Limitar rastreamento de anúncios» ou «Desativar publicidade baseada em interesse».</string>
-	<string name="opt_out_help_ios_2">iOS 9 ou Superior</string>
-	<string name="opt_out_help_ios_3">Vá para: Configurações → Privacidade → Anúncios → Habilitar «Limitar Rastreamento de Anúncios»</string>
-	<string name="opt_out_help_android">O seu dispositivo móvel pode fornecer as opções de «Limitar rastreamento de anúncios» ou «Desativar publicidade baseada em interesse».\n\nPara versões de Android e Google Play Services superiores a 4.0:\nConfigurações → Google → Anúncios → Desativar publicidade baseada em interesse\nor\n nConfigurações → Google → Anúncios → Informações pessoais &amp; privacidade → Configurações de Anúncios → Personalização de Anúncios</string>
 	<string name="privacy_policy">Política de privacidade</string>
 	<string name="terms_of_use">Termos de uso</string>
-	<string name="backup_notification_failed">O back-up dos seus favoritos foi suspenso. É preciso logar para ligá-lo de volta.</string>
 	<string name="button_layer_traffic">Tráfego</string>
 	<string name="button_layer_subway">Metrô</string>
 	<string name="layers_title">Map Layers</string>
-	<string name="layers_message">Utilize o Map Layers para exibir tráfego, mapa do metrô e outras informações úteis</string>
-	<string name="button_layer_got_it">Entendi</string>
 	<string name="subway_data_unavailable">Mapa de metrô está indisponível</string>
 	<string name="bookmarks_empty_list_title">Esta lista está vazia</string>
 	<string name="bookmarks_empty_list_message">Para adicionar um favorito, toque em algum lugar do mapa e em seguida no ícone da estrela</string>
 	<string name="category_desc_more">…mais</string>
 	<string name="title_error_downloading_bookmarks">Ocorreu um erro</string>
-	<string name="subtitle_error_downloading_bookmarks">Favoritos não foram baixados</string>
-	<string name="error_already_downloaded">Esta lista já foi transferida</string>
-	<string name="why_support">Porquê apoiar o Organic Maps?</string>
-	<string name="why_support_item2">Ajude-nos a melhorar o Organic Maps</string>
-	<string name="why_support_item3">Ajude-nos a melhorar mapas livres em OpenStreeMap.org</string>
-	<string name="channels_map_update">Atualizações de mapa</string>
-	<string name="server_unavailable_title">O servidor está indisponível</string>
-	<string name="sharing_options">Definições de acesso</string>
 	<string name="export_file">Exportar o arquivo</string>
 	<string name="list_settings">Lista de configurações</string>
 	<string name="delete_list">Apagar lista</string>
-	<string name="hide_from_map">Remover do mapa</string>
 	<string name="public_access">Acesso público</string>
 	<string name="limited_access">Acesso privado</string>
 	<string name="bookmark_category_name">Categoria</string>
 	<string name="bookmark_category_description_hint">Adicionar uma descrição (texto ou html)</string>
 	<string name="not_shared">Personal</string>
-	<string name="direct_link_progress_text">A carregar o seu arquivo…</string>
-	<string name="direct_link_success">Link criado</string>
-	<string name="send_a_link_btn">Enviar link</string>
-	<string name="upload_error_toast">Ocorreu um erro ao carregar o arquivo</string>
 	<string name="tags_loading_error_subtitle">Ocorreu um erro ao carregar tags, por favor tente de novo</string>
-	<string name="unable_upload_errorr_title">Não foi possível carregar arquivo</string>
-	<string name="unable_upload_error_subtitle_edited">O arquivo foi editado através da uma aplicação web</string>
-	<string name="unable_upload_error_subtitle_broken">Arquivo corrompido e não pode ser carregado. Por favor, carregue outro arquivo.</string>
-	<string name="contact">Escrever</string>
-	<string name="download_button">Baixar</string>
 	<string name="speedcams_alert_title">Câmeras de velocidade</string>
-	<string name="speedcams_alert_subtitle">Avisar sobre limites de velocidade</string>
 	<string name="speedcam_option_auto">Auto</string>
 	<string name="speedcam_option_always">Sempre</string>
 	<string name="speedcam_option_never">Nunca</string>
-	<string name="bookmark_description_title">Descrição da marca</string>
 	<string name="place_description_title">Descrição do local</string>
 	<!-- this text will be shown in application notification preferences opposite checkbox which enable/disable downloader notifications. Devices on Android 8+ are affected. -->
 	<string name="notification_channel_downloader">A carregar mapas</string>
-	<string name="share_bookmarks_email_body_link">Olá!\n\nSeus rótulos podem ser baixado aqui: %s. Abra a lista usando Organic Maps e desfrute do passeio!\n\nBaixar aplicação: https://omaps.app/get?kmz</string>
-	<string name="warning_speedcams_title">O navegador irá notificá-lo sobre as câmeras quando o limite de velocidade for excedido em %d km/h</string>
-	<string name="warning_speedcams_subtitle">Não esqueça de ler as regras da estrada no país de viagem.</string>
 	<string name="speedcams_notice_message">Auto - Avisa sobre radares de velocidade se houver risco de exceder o limite de velocidade\nSempre - Sempre alerta sobre câmeras\nNunca - nunca avisar sobre câmeras</string>
 	<string name="power_managment_title">Modo de economia de energia</string>
 	<string name="power_managment_description">Se o modo de economia de energia estiver ativado, aplicação vai desligar as funções que consomem energia, dependendo da carga atual do telefone</string>
@@ -1078,14 +662,7 @@
 	<string name="power_managment_setting_auto">Auto</string>
 	<string name="power_managment_setting_manual_max">Máxima economia de energia</string>
 	<string name="enable_logging_warning_message">Esta opção é ativada para registro das ações para fins de diagnóstico. Isso permite que a equipe localiza problemas com aplicação. Ative opção apenas a pedido do suporte da Organic Maps.</string>
-	<string name="html_error_upload_message_try_again">Verifique o acesso à rede e volte a tentar</string>
-	<string name="html_error_upload_title_try_again">Sem conexão a internet</string>
-	<string name="notification_leave_review_v2_android_short_title">Deixe um comentário e ajude aos viajantes!</string>
-	<string name="notifications_illegal_alert_disable_button">Ativar notificações</string>
 	<string name="access_rules_author_only">Editado Online</string>
-	<string name="privacy_settings_menu">Configurações de privacidade</string>
-	<string name="unable_upadate_error_title">Erro na atualização do percurso</string>
-	<string name="unable_upadate_error_message">Ocorreram uns erros durante a atualização. Verifique as alterações e volte a tentar</string>
 	<string name="driving_options_title">Configurações de desvio</string>
 	<string name="driving_options_subheader">Evite em todos os percursos</string>
 	<string name="avoid_tolls">Estradas com portagem</string>
@@ -1096,52 +673,14 @@
 	<string name="unable_to_calc_alert_subtitle">Infelizmente, não conseguimos criar o percurso com as opções selecionadas. Altere as opções e tente novamente</string>
 	<string name="define_to_avoid_btn">Personalizar o caminho do desvio</string>
 	<string name="change_driving_options_btn">Configurações de desvio ativadas</string>
-	<string name="toll_road">Estrada com portagem</string>
-	<string name="unpaved_road">Estrada rural</string>
-	<string name="ferry_crossing">Ferryboat</string>
-	<string name="operated_by">Operado por \"%s\"</string>
 	<string name="avoid_toll_roads_placepage">Evitar as estradas com portagem</string>
 	<string name="avoid_unpaved_roads_placepage">Evitar as estradas rurais</string>
 	<string name="avoid_ferry_crossing_placepage">Evitar ferryboat</string>
-	<string name="type.cuisine.uzbek">Cozinha uzbeque</string>
-	<string name="trip_start">Vamos</string>
-	<string name="pick_destination">Objetivo</string>
-	<string name="follow_my_position">Centrar</string>
-	<string name="search_results">Resultados da pesquisa</string>
-	<string name="then_turn">A seguir</string>
-	<string name="redirect_route_alert">Deseja personalizar o percurso?</string>
-	<string name="redirect_route_yes">Sim</string>
-	<string name="redirect_route_no">Não</string>
-	<string name="trip_finished">Chegou!</string>
-	<string name="keyboard_availability_alert">Teclado indisponível durante o movimento</string>
-	<string name="dialog_routing_change_start_carplay">Impossível criar percurso a partir da localização atual</string>
-	<string name="dialog_routing_change_end_carplay">Impossível criar percurso para o ponto final. Escolher outro</string>
-	<string name="dialog_routing_check_gps_carplay">Sem GPS. Siga para uma área aberta</string>
-	<string name="dialog_routing_unable_locate_route_carplay">Impossível criar percurso. Escolher outros pontos do percurso</string>
-	<string name="dialog_routing_download_files_carplay">Para construir percurso falta carregar os mapas no seu dispositivo</string>
-	<string name="dialog_routing_system_error_carplay">Ocorreu um erro. Reiniciar aplicação</string>
-	<string name="dialog_routing_rebuild_from_current_location_carplay">O percurso será reconstruído a partir da sua localização atual</string>
-	<string name="dialog_routing_rebuild_for_vehicle_carplay">O percurso será reconstruído para o rodoviário</string>
 	<string name="ok">Ok</string>
-	<string name="avoid_unpaved_carplay_1">Sem rurais</string>
-	<string name="avoid_unpaved_carplay_2">Sem rurais</string>
-	<string name="avoid_ferry_carplay_1">Sem ferry</string>
-	<string name="avoid_ferry_carplay_2">Sem ferry</string>
-	<string name="avoid_tolls_carplay_1">Sem pedágio</string>
-	<string name="avoid_tolls_carplay_2">Sem pedágio</string>
-	<string name="speedcams_alert_title_carplay_1">Radares</string>
-	<string name="speedcams_alert_title_carplay_2">Avisos de radar</string>
-	<string name="download_map_carplay">Baixar mapas de aplicação Organic Maps para o seu dispositivo</string>
-	<string name="carplay_roundabout_exit">%s saída</string>
 	<!-- max. 10 symbols, both iOS and Android -->
 	<string name="sort">Ordenar…</string>
 	<!-- Android, title, max 20-22 symbols -->
 	<string name="sort_bookmarks">Ordenar tags</string>
-	<!-- iOS -->
-	<string name="sort_default">Ordenar por predefinição</string>
-	<string name="sort_type">Ordenar por tipo</string>
-	<string name="sort_distance">Ordenar por distância</string>
-	<string name="sort_date">Ordenar por data</string>
 	<!-- Android -->
 	<string name="by_default">Por predefinição</string>
 	<!-- Android -->
@@ -1150,65 +689,23 @@
 	<string name="by_distance">Por distância</string>
 	<!-- Android -->
 	<string name="by_date">Por data</string>
-	<string name="week_ago_sorttype">Uma semana atrás</string>
-	<string name="month_ago_sorttype">Um mês atrás</string>
-	<string name="moremonth_ago_sorttype">Mais de um mês atrás</string>
-	<string name="moreyear_ago_sorttype">Mais de um ano atrás</string>
-	<string name="near_me_sorttype">Perto de mim</string>
-	<string name="others_sorttype">Outro</string>
-	<string name="food_places">Alimento</string>
-	<string name="tourist_places">Pontos turísticos</string>
-	<string name="museums">Museus</string>
-	<string name="parks">Jardins</string>
-	<string name="swim_places">Natação</string>
-	<string name="mountains">Montanhas</string>
-	<string name="animals">Animais</string>
-	<string name="hotels">Hotéis</string>
-	<string name="buildings">Prédios</string>
-	<string name="money">Dinheiro</string>
-	<string name="shops">Lojas</string>
-	<string name="parkings">Estacionamentos</string>
-	<string name="fuel_places">Postos de gasolina</string>
-	<string name="water">Água</string>
-	<string name="medicine">Medicina</string>
 	<string name="search_in_the_list">Pesquisar na lista</string>
-	<string name="view_on_map_bookmarks">No mapa</string>
-	<string name="more_bookmarks">Mais…</string>
-	<string name="no_items_found">Nada encontrado</string>
-	<!-- Android, max 18 symbols -->
-	<string name="bookmarks_edit_list">Editar</string>
-	<!-- Android, max 18 symbols -->
-	<string name="bookmarks_delete_list">Eliminar a lista</string>
-	<string name="religious_places">Lugares sagrados</string>
 	<string name="select_list">Escolher a lista</string>
 	<string name="transit_not_found">Navegação de metro ainda indisponível nesta região</string>
 	<string name="dialog_pedestrian_route_is_long_header">Percurso de metro não encontrado</string>
 	<string name="dialog_pedestrian_route_is_long_message">Escolhe ponto inicial ou final de percurso próximo da estação de metro</string>
-	<!-- Failed planning SUBWAY route message in navigation view -->
-	<string name="routing_planning_error_subway_special">Erro ao construir o percurso de metro</string>
 	<string name="button_layer_isolines">Alturas</string>
-	<string name="tips_map_layers_title_countour">Linhas de alturas offline na Organic Maps!</string>
-	<string name="tips_map_layers_message_countour">As linhas de alturas offline ajudarão planejar sua viagem à natureza e não se perder no local</string>
 	<string name="isolines_activation_error_dialog">Para usar as linhas de alturas, atualize ou carregue o mapa da área desejada</string>
 	<string name="isolines_location_error_dialog">A linhas de alturas ainda não está disponível em sua região</string>
 	<string name="elevation_profile_diff_level">Nível de complexidade</string>
-	<string name="elevation_profile_diff_level_easy">Fácil</string>
-	<string name="elevation_profile_diff_level_moderate">Moderado</string>
-	<string name="elevation_profile_diff_level_hard">Complicado</string>
 	<string name="elevation_profile_ascent">Subida</string>
 	<string name="elevation_profile_descent">Descida</string>
 	<string name="elevation_profile_minaltitude">Altura min.</string>
 	<string name="elevation_profile_maxaltitude">Altura max.</string>
-	<string name="elevation_profile_m">m</string>
 	<string name="elevation_profile_difficulty">Complexidade</string>
 	<string name="elevation_profile_distance">Distância:</string>
-	<string name="elevation_profile_km">km</string>
 	<string name="elevation_profile_time">Ida:</string>
-	<string name="elevation_profile_hours">h.</string>
-	<string name="elevation_profile_minutes">min</string>
 	<string name="isolines_toast_zooms_1_10">Ampliar mapa para ver as curvas de nível</string>
-	<string name="downloader_updating_ios">Atualização</string>
-	<string name="downloader_loading_ios">Carregamento</string>
 	<string name="key_information_title">Informações principais</string>
 	<string name="enable_screen_sleep">Permitir que a tela hiberne</string>
 	<!-- Description in preferences -->

--- a/android/res/values-ro/strings.xml
+++ b/android/res/values-ro/strings.xml
@@ -12,15 +12,11 @@
 	<string name="cancel_download">Anulare descărcare</string>
 	<!-- Button which deletes downloaded country -->
 	<string name="delete">Ștergere</string>
-	<!-- Button "do not interrupt download" if user touched actively downloading country -->
-	<string name="do_nothing">Continuare</string>
 	<string name="download_maps">Descărcare hărți</string>
 	<!-- Settings/Downloader - info for country when download fails -->
 	<string name="download_has_failed">Descărcarea a eșuat. Atingeți pentru a încerca din nou.</string>
 	<!-- Settings/Downloader - info for country which started downloading -->
 	<string name="downloading">Se descarcă…</string>
-	<!-- Settings/Downloader - size string, only strings different from English should be translated -->
-	<string name="kb">kB</string>
 	<!-- Choose measurement on first launch alert - choose metric system button -->
 	<string name="kilometres">Kilometri</string>
 	<!-- Leave Review dialog - Review button -->
@@ -35,45 +31,31 @@
 	<string name="core_my_position">Poziția mea</string>
 	<!-- Update maps later/Buy pro version later button text -->
 	<string name="later">Mai târziu</string>
-	<!-- Don't show some dialog any more -->
-	<string name="never">Niciodată</string>
 	<!-- View and button titles for accessibility -->
 	<string name="search">Căutare</string>
 	<!-- Search box placeholder text -->
 	<string name="search_map">Căutare hartă</string>
-	<!-- Settings/Downloader - info for not downloaded country -->
-	<string name="touch_to_download">Atingeți pentru a descărca.</string>
 	<!-- Settings/Downloader - 3G download warning dialog confirm button -->
 	<string name="use_cellular_data">Da</string>
 	<!-- Location services are disabled by user alert - message -->
 	<string name="location_is_disabled_long_text">În acest moment aveți dezactivate toate serviciile de localizare pentru acest dispozitiv sau aplicație. Vă rugăm să le activați la setări.</string>
-	<!-- Location Services are not available on the device alert - message -->
-	<string name="device_doesnot_support_location_services">Dispozitivul dvs. nu acceptă servicii de localizare.</string>
 	<!-- View and button titles for accessibility -->
 	<string name="zoom_to_country">Afișare pe hartă</string>
-	<!-- Button text for the button at the center of the screen when the country is not downloaded -->
-	<string name="country_status_download">Descărcare hartă\n(^ ^)</string>
 	<!-- Button text for the button at the center of the screen when the country is not downloaded and the size should not be shown -->
 	<string name="country_status_download_without_size">Descărcare hartă</string>
-	<!-- Button text for the button at the center of the screen when the country is not downloaded -->
-	<string name="country_status_download_without_routing">Descărcare hartă\nfără rutare (^ ^)</string>
 	<!-- Message to display at the center of the screen when the country download has failed -->
 	<string name="country_status_download_failed">Se descarcă a eșuat</string>
 	<!-- Button text for the button under the country_status_download_failed message -->
 	<string name="try_again">Încercați din nou</string>
 	<string name="about_menu_title">Despre Organic Maps</string>
-	<string name="downloaded_touch_to_delete">Descărcat (%s). Atingeți pentru a șterge.</string>
 	<string name="connection_settings">Setări conexiune</string>
-	<string name="download_mb_or_kb">Descărcare %s</string>
 	<string name="close">Închidere</string>
 	<string name="unsupported_phone">Este necesar un OpenGL accelerat din hardware. Din păcate, dispozitivul nu este acceptat.</string>
 	<string name="download">Descărcare</string>
-	<string name="external_storage_is_not_available">Cartela SD/dispozitivul de stocare USB cu hărțile descărcate nu este disponibil.</string>
 	<string name="disconnect_usb_cable">Vă rugăm să deconectați cablul USB sau să introduceți cartela de memorie pentru a putea utiliza Organic Maps.</string>
 	<string name="not_enough_free_space_on_sdcard">Vă rugăm să eliberați spațiu pe cartela SD/dispozitivul de stocare USB pentru a putea utiliza aplicația.</string>
 	<string name="not_enough_memory">Nu este suficientă memorie pentru a lansa aplicația.</string>
 	<string name="download_resources">Înainte de a începe, permiteți-ne să descărcăm harta generală a lumii pe dispozitivul dvs.\nAre nevoie de %s de date.</string>
-	<string name="getting_position">Se obține poziția actuală</string>
 	<string name="download_resources_continue">Mergeți la hartă.</string>
 	<string name="downloading_country_can_proceed">Se descarcă %s. Puteți\ntrece la hartă.</string>
 	<string name="download_country_ask">Descărcați %s?</string>
@@ -86,30 +68,20 @@
 	<string name="download_country_failed">%s - descărcarea a eșuat</string>
 	<!-- Add New Bookmark Set dialog title -->
 	<string name="add_new_set">Adăugare la „Marcaje”</string>
-	<!-- Place Page - Add To Bookmarks button -->
-	<string name="add_to_bookmarks">Adăugare la „Marcaje”</string>
 	<!-- Bookmark Color dialog title -->
 	<string name="bookmark_color">Culoare marcaj</string>
 	<!-- Add Bookmark Set dialog - hint when set name is empty -->
 	<string name="bookmark_set_name">Nume set marcaje</string>
-	<!-- Bookmark Sets dialog title -->
-	<string name="bookmark_sets">Seturi marcaje</string>
 	<!-- Bookmarks - dialog title -->
 	<string name="bookmarks">Marcaje</string>
-	<!-- Add bookmark dialog - bookmark color -->
-	<string name="color">Culoare</string>
 	<!-- Default bookmarks set name -->
 	<string name="core_my_places">Locurile mele</string>
 	<!-- Add bookmark dialog - bookmark name -->
 	<string name="name">Nume</string>
 	<!-- Editor title above street and house number -->
 	<string name="address">Adresă</string>
-	<!-- Place Page - Remove Pin button -->
-	<string name="remove_pin">Poziție eliminată</string>
 	<!-- Add bookmark dialog - bookmark set, Bookmarks dialog - Bookmark set cell -->
 	<string name="set">Set</string>
-	<!-- Text hint in Bookmarks dialog when no any bookmarks are added -->
-	<string name="bookmarks_usage_hint">Încă nu aveți niciun marcaj.\nAtingeți orice loc de pe hartă pentru a adăuga un marcaj.\nPot fi importate și afișate pe Organic Maps și marcaje din alte surse. Deschideți fișierul KML/KMZ, cu marcajele salvate din email, Dropbox sau de la un link web.</string>
 	<!-- Settings button in system menu -->
 	<string name="settings">Setări</string>
 	<!-- Header of settings activity where user defines storage path -->
@@ -120,10 +92,6 @@
 	<string name="move_maps">Mutare hărți?</string>
 	<!-- Ask to wait user several minutes (some long process in modal dialog). -->
 	<string name="wait_several_minutes">Aceasta poate dura câteva minute.\nVă rugăm să așteptați…</string>
-	<!-- Show bookmarks from this category on a map or not -->
-	<string name="visible">Vizibil</string>
-	<!-- Toast which is displayed when GPS has been deactivated -->
-	<string name="gps_is_disabled_long_text">GPS-ul este dezactivat. Vă rugăm să îl activați din setări.</string>
 	<!-- Measurement units title in settings activity -->
 	<string name="measurement_units">Unități de măsură</string>
 	<!-- Detailed description of Measurement Units settings button -->
@@ -164,12 +132,8 @@
 	<string name="post">Poştă</string>
 	<!-- Search category -->
 	<string name="police">Poliție</string>
-	<!-- String in search result list, when nothing found -->
-	<string name="no_search_results_found">Nu s-a găsit niciun rezultat.</string>
 	<!-- Notes field in Bookmarks view -->
 	<string name="description">Note</string>
-	<!-- Button text -->
-	<string name="share_by_email">Partajare prin email</string>
 	<!-- Email Subject when sharing bookmarks category -->
 	<string name="share_bookmarks_email_subject">Marcaje Organic Maps partajate</string>
 	<!-- message title of loading file -->
@@ -182,20 +146,10 @@
 	<string name="edit">Editare</string>
 	<!-- Warning message when doing search around current position -->
 	<string name="unknown_current_position">Poziția dvs. nu a fost stabilită încă.</string>
-	<!-- Warning message when location country isn't downloaded during search (see also download_location_map_proposal). -->
-	<string name="download_location_country">Descărcați hărțile pentru țara în care vă aflați (%s).</string>
-	<!-- Warning message when viewport country isn't downloaded during search -->
-	<string name="download_viewport_country_to_search">Descărcați hărțile pentru țara pe care o căutați pe (%s).</string>
 	<!-- Alert message that we can't run Map Storage settings due to some reasons. -->
 	<string name="cant_change_this_setting">Ne pare rău. Setările pentru stocarea hărților sunt dezactivate în acest moment.</string>
 	<!-- Alert message that downloading is in progress. -->
 	<string name="downloading_is_active">Descărcarea hărților pentru țara dorită este în curs.</string>
-	<!-- Message that will be shown in alert view, when we ask user to leave review on App Store -->
-	<string name="appStore_message">Sperăm că vă place Organic Maps! Dacă da, vă rugăm să o votați sau să scrieți o recenzie în App Store. Durează mai puțin de un minut, dar pe noi ne ajută foarte mult. Vă mulțumim pentru susținere!</string>
-	<!-- No, thanks -->
-	<string name="no_thanks">Nu, mulțumesc</string>
-	<!-- Share one specific bookmark using SMS, %1$@ contains om:// and %2$@ https://omaps.app link. @NOTE non-ascii symbols in the link will result in max 70 characters SMS instead of 140. -->
-	<string name="bookmark_share_sms">Hei, poți vedea care este poziția mea pe Organic Maps! %1$s sau %2$s Nu ai instalate hărțile offline? Descarcă de aici: https://omaps.app/get</string>
 	<!-- Share my position using SMS, %1$@ contains om:// and %2$@ https://omaps.app link WITHOUT NAME. @NOTE non-ascii symbols in the link will result in max 70 characters SMS instead of 140. -->
 	<string name="my_position_share_sms">Hei, îmi poți vedea poziția actuală pe Organic Maps! %1$s sau %2$s Nu ai hărțile offline? Descarcă de aici: https://omaps.app/get</string>
 	<!-- Subject for emailed bookmark -->
@@ -204,30 +158,16 @@
 	<string name="my_position_share_email_subject">Hei, îmi poți vedea poziția actuală pe harta Organic Maps!</string>
 	<!-- Share my position using EMail, %1$@ is om:// and %2$@ is https://omaps.app link WITHOUT NAME -->
 	<string name="my_position_share_email">Chào,\n\nTôi hiện đang ở đây: %1$s. Hãy nhấn vào liên kết này %2$s hoặc liên kết này %3$s để xem địa điểm trên bản đồ.\n\nCám ơn.</string>
-	<!-- Android share by Message/SMS button text (including SMS) -->
-	<string name="share_by_message">Partajare ca mesaj</string>
 	<!-- Share button text which opens menu with more buttons, like Message, EMail, Facebook etc. -->
 	<string name="share">Partajare</string>
-	<!-- iOS share by Message button text (including SMS) -->
-	<string name="message">Tin nhắn</string>
 	<!-- Share by email button text, also used in editor. -->
 	<string name="email">Email</string>
-	<!-- Copy Link -->
-	<string name="copy_link">Copiați link-ul</string>
-	<!-- Text for the button that returns to caller application -->
-	<string name="more_info">Afișează mai multe informații</string>
 	<!-- Text for message when used successfully copied something -->
 	<string name="copied_to_clipboard">Copiat în clipboard: %1$s</string>
 	<!-- place preview title -->
 	<string name="info">Informații</string>
 	<!-- Used for bookmark editing -->
 	<string name="done">Gata</string>
-	<!-- Summary for preferences in MWM -->
-	<string name="yopme_pref_summary">Alegeți setările pentru ecranul din spate</string>
-	<!-- Title for yopme preferences in MWM -->
-	<string name="yopme_pref_title">Setări ecran spate</string>
-	<!-- Hint for upper-right icon p2b -->
-	<string name="show_on_backscreen">Afișare pe ecranul din spate</string>
 	<!-- Prints version number in About dialog -->
 	<string name="version">Versiune: %s</string>
 	<!-- Confirmation in downloading countries dialog -->
@@ -237,11 +177,6 @@
 	<!-- Length of track in cell that describes route -->
 	<string name="length">Lungime</string>
 	<string name="share_my_location">Partajează-mi poziția</string>
-	<string name="menu_search">Căutare</string>
-	<!-- Settings screen: "Map" category title -->
-	<string name="prefs_group_map">Hartă</string>
-	<!-- Settings screen: "Miscellaneous" category title -->
-	<string name="prefs_group_misc">Diverse</string>
 	<string name="prefs_group_route">Navigație</string>
 	<string name="pref_zoom_title">Butoane zoom</string>
 	<string name="pref_zoom_summary">Afișare pe ecran</string>
@@ -257,8 +192,6 @@
 	<string name="pref_map_3d_title">Vizualizare în perspectivă</string>
 	<!-- Settings «Map» category: «3D buildings» title -->
 	<string name="pref_map_3d_buildings_title">Clădiri 3D</string>
-	<!-- Settings «Map» category: «3D buildings» summary -->
-	<string name="pref_map_3d_buildings_subtitle">Afectează durata de funcționare a bateriei</string>
 	<!-- Settings «Route» category: «Tts enabled» title -->
 	<string name="pref_tts_enable_title">Instrucțiuni vocale</string>
 	<!-- Settings «Route» category: «Tts language» title -->
@@ -267,7 +200,6 @@
 	<string name="pref_tts_unavailable">Nu există</string>
 	<!-- Title for "Other" section in TTS settings. -->
 	<string name="pref_tts_other_section_title">Alta</string>
-	<string name="pref_tts_how_to_set_up_voice">Modalitatea de configurare a vocii</string>
 	<!-- Settings «Map» category: «Record track» title -->
 	<string name="pref_track_record_title">Rute recente</string>
 	<string name="pref_map_auto_zoom">Zoom automat</string>
@@ -278,38 +210,11 @@
 	<string name="duration_12_hours">12 ore</string>
 	<string name="duration_1_day">1 zi</string>
 	<string name="recent_track_help_text">Vă permite să înregistrați traseul parcurs pentru o anumită perioadă și să îl vedeți pe hartă. Rețineți: activarea acestei funcții crește consumul bateriei. Traseul va fi eliminat automat de pe hartă după expirarea intervalului de timp.</string>
-	<string name="pref_track_ios_caption">Opțiunea Rută recentă vă afișează ruta folosită anterior.</string>
-	<string name="pref_track_ios_subcaption">Vă rugăm să selectați intervalul orar corespunzător salvării rutei.</string>
-	<string name="placepage_distance">Distanță</string>
-	<string name="placepage_coordinates">Coordonate</string>
-	<string name="placepage_unsorted">Nesortate</string>
 	<string name="search_show_on_map">Vizualizare pe hartă</string>
-	<!-- Used to warn user when fixing KitKat issue -->
-	<string name="bookmark_move_fail">Trebuie să vă mutăm marcajele în memoria internă, dar nu există spațiu suficient pentru ele. Vă rugăm să eliberați memoria, altfel marcajele nu vor fi disponibile.</string>
-	<!-- 1st search button-like result -->
-	<string name="search_on_map">Căutare pe hartă</string>
-	<!-- toast with an error -->
-	<string name="no_route_found">Nu a fost găsit nici un traseu</string>
-	<!-- route title -->
-	<string name="route">Traseu</string>
-	<!-- category title -->
-	<string name="routes">Trasee</string>
-	<!-- text of notification -->
-	<string name="download_map_notification">Descărcați harta locului în care vă aflați</string>
-	<!-- Dialog for transferring maps from lite to pro. -->
-	<string name="move_lite_maps_to_pro">Transferăm hărțile dvs. descărcate din Organic Maps Lite în Organic Maps. Acest lucru poate dura câteva minute.</string>
-	<!-- Message to display when maps moved. -->
-	<string name="move_lite_maps_to_pro_ok">Hărțile dvs. descărcate sunt transferate cu succes către Organic Maps.</string>
-	<!-- Text in menu -->
-	<string name="settings_and_more">Setări și altele</string>
 	<!-- Text in menu -->
 	<string name="website">Site web</string>
-	<!-- Text in menu -->
-	<string name="contact_us">Contactați-ne</string>
 	<!-- Settings: Send feedback button and dialog title -->
 	<string name="feedback">Feedback</string>
-	<!-- Text in menu -->
-	<string name="subscribe_to_news">Abonați-vă la știrile noastre</string>
 	<!-- Text in menu -->
 	<string name="rate_the_app">Votați-ne aplicația</string>
 	<!-- Text in menu -->
@@ -318,12 +223,6 @@
 	<string name="copyright">Copyright</string>
 	<!-- Text in menu -->
 	<string name="report_a_bug">Raportați o eroare</string>
-	<!-- Email subject -->
-	<string name="subscribe_me_subject">Abonează-mă la buletinul informativ Organic Maps.</string>
-	<!-- Email body -->
-	<string name="subscribe_me_body">Vreau să fiu primul care află despre cele mai recente actualizări și promoții. Îmi pot anula abonamentul în orice moment.</string>
-	<!-- About text -->
-	<string name="about_text">Organic Maps oferă cele mai rapide hărți offline ale tuturor orașelor, tuturor țărilor din lume. Călătoriți cu încredere deplină: oriunde v-ați afla, Organic Maps vă ajută să vă reperați poziția pe hartă, să găsiți cel mai apropiat restaurant sau hotel, cea mai apropiată bancă sau benzinărie etc. Nu necesită conexiune la internet.\n\nLucrăm încontinuu să introducem funcții noi și ne-ar face mare plăcere să ne comunicați cum credeți dvs. că am putea îmbunătăți Organic Maps. Dacă aveți probleme cu aplicația, nu ezitați să ne contactați la adresa support\@organicmaps.app. Răspundem la fiecare solicitare!\n\nVă place Organic Maps și doriți să ne susțineți? Iată câteva moduri simple și complet gratuite:\n- publicați o recenzie în magazinul de aplicații\n- apreciați-ne pagina de Facebook: http://www.facebook.com/OrganicMaps\n- sau spuneți și mamei, prietenilor și colegilor despre Organic Maps. :)\n\nVă mulțumim că ne sunteți alături. Vă apreciem foarte mult susținerea!\n\nP.S. Noi preluăm datele din OpenStreetMap, un proiect de cartografiere similar Wikipediei, ce permite utilizatorilor să creeze și să editeze hărți. Dacă vedeți că ceva lipsește sau este greșit pe hartă, puteți corecta hărțile direct la adresa: https://www.openstreetmap.org, iar modificările dvs. vor apărea în aplicația Organic Maps atunci când va fi lansată versiunea următoare.</string>
 	<!-- Alert text -->
 	<string name="email_error_body">Nu a fost setat clientul de email. Vă rugăm să o configurați sau să utilizați un alt mod de a ne contacta la %s.</string>
 	<!-- Alert title -->
@@ -332,136 +231,55 @@
 	<string name="pref_calibration_title">Calibrare busolă</string>
 	<!-- Search category -->
 	<string name="wifi">WiFi</string>
-	<!-- Update map suggestion -->
-	<string name="routing_map_outdated">Vă rugăm să actualizați harta pentru a crea o rută.</string>
-	<!-- Update maps suggestion -->
-	<string name="routing_update_maps">Noua versiune a Organic Maps vă permite să creați rute din poziția dvs. actuală către un punct de destinație. Vă rugăm să actualizați harta pentru a utiliza această funcție.</string>
 	<!-- Update all button text -->
 	<string name="downloader_update_all_button">Actualizați toate</string>
 	<!-- Cancel all button text -->
 	<string name="downloader_cancel_all">Anulare toate</string>
 	<!-- Downloaded maps category -->
 	<string name="downloader_downloaded_subtitle">Descărcat</string>
-	<!-- Downloaded maps category -->
-	<string name="downloader_available_maps">Disponibil</string>
 	<!-- Country queued for download -->
 	<string name="downloader_queued">În lista de așteptare</string>
 	<string name="downloader_near_me_subtitle">Aproape de mine</string>
 	<string name="downloader_status_maps">Hărți</string>
 	<string name="downloader_download_all_button">Descărcați toate</string>
 	<string name="downloader_downloading">Descărcare:</string>
-	<string name="downloader_search_results">S-au găsit</string>
-	<!-- Disclaimer message -->
-	<string name="routing_disclaimer">Atunci când creați rute în aplicația Organic Maps, vă rugăm să nu uitați următoarele:\n\n- Rutele sugerate pot fi luate în considerare numai ca recomandări.\n- Harta poate fi incorectă sau neactualizată, iar rutele pot să nu fie create în cel mai bun mod posibil.\n- Condițiile de trafic, regulile și semnele de circulație au prioritate mai mare decât sugestiile de navigare.\n\nCirculați cu atenție și aveți grijă de dvs.!</string>
-	<!-- Outdated maps category -->
-	<string name="downloader_outdated_maps">Neactualizată</string>
-	<!-- Up to date maps category -->
-	<string name="downloader_uptodate_maps">Actualizată</string>
 	<!-- Status of outdated country in the list -->
 	<string name="downloader_status_outdated">Actualizare</string>
 	<!-- Status of failed country in the list -->
 	<string name="downloader_status_failed">Eșuată</string>
 	<!-- Displayed in a dialog that appears when a user tries to delete a map while the app is in the follow route mode -->
 	<string name="downloader_delete_map_while_routing_dialog">Pentru a șterge harta, vă rugăm să opriți navigarea.</string>
-	<!-- Show when user try build route, but we don't know where he -->
-	<string name="routing_failed_unknown_my_position">Poziția dvs. curentă este nedefinită. Vă rugăm să specificați poziția, pentru a crea o rută.</string>
-	<!-- Show if use has not routing file, or InconsistentMWMandRoute -->
-	<string name="routing_failed_has_no_routing_file">Datele suplimentare necesare pentru a crea trasee de la locația dvs.</string>
-	<!-- StartPointNotFound -->
-	<string name="routing_failed_start_point_not_found">Nu se poate calcula ruta. Nu există drumuri în apropierea punctului de pornire.</string>
-	<!-- EndPointNotFound -->
-	<string name="routing_failed_dst_point_not_found">Nu se poate calcula ruta. Nu există drumuri în apropierea punctului de destinație.</string>
 	<!-- PointsInDifferentMWM -->
 	<string name="routing_failed_cross_mwm_building">Pot fi create doar rutele ce se află în întregime într-o singură hartă.</string>
-	<!-- RouteNotFound -->
-	<string name="routing_failed_route_not_found">Nu am găsit nicio rută între punctul de pornire și destinația selectată. Vă rugăm să alegeți un alt punct de pornire sau de destinație.</string>
-	<!-- InternalError -->
-	<string name="routing_failed_internal_error">A survenit o eroare internă. Vă rugăm să încercați să ștergeți și să descărcați harta din nou. Dacă problema persistă, vă rugăm să ne contactați la adresa support\@organicmaps.app.</string>
-	<!-- Context menu item for downloader. -->
-	<string name="downloader_download_map_and_routing">Descărcare hartă + traseu</string>
-	<!-- Context menu item for downloader. -->
-	<string name="downloader_download_routing">Descărcare traseu</string>
-	<!-- Context menu item for downloader. -->
-	<string name="downloader_delete_routing">Ștergere traseu</string>
 	<!-- Context menu item for downloader. -->
 	<string name="downloader_download_map">Descărcați harta</string>
-	<string name="downloader_download_map_no_routing">Descărcare hartă fără rutare</string>
-	<!-- Button for routing. -->
-	<string name="routing_go">Pornește!</string>
 	<!-- Item status in downloader. -->
 	<string name="downloader_retry">Repetare</string>
-	<!-- Item in context menu. -->
-	<string name="downloader_map_and_routing">Hartă + trasee</string>
 	<!-- Item in context menu. -->
 	<string name="downloader_delete_map">Ștergere hartă</string>
 	<!-- Item in context menu. -->
 	<string name="downloader_update_map">Actualizare hartă</string>
-	<!-- Item in context menu. -->
-	<string name="downloader_update_map_and_routing">Actualizare hartă + trasee</string>
-	<!-- Item in context menu. -->
-	<string name="downloader_map_only">Doar harta</string>
-	<!-- Toolbar title -->
-	<string name="toolbar_application_menu">Meniu aplicație</string>
 	<!-- Preference text -->
 	<string name="pref_use_google_play">Utilizați serviciile Google Play, pentru a vă obține poziția actuală.</string>
 	<!-- Text for rating dialog -->
 	<string name="rating_just_rated">Tocmai ți-am votat aplicația</string>
-	<!-- Text for rating dialog -->
-	<string name="rating_user_since">Sunt utilizator Organic Maps din %s</string>
-	<!-- Text for rating dialog -->
-	<string name="rating_do_like_maps">Îți place Organic Maps?</string>
-	<!-- Text for rating dialog -->
-	<string name="rating_tap_star">Apasă pe una dintre stele pentru a ne vota aplicația</string>
 	<!-- Text for rating dialog -->
 	<string name="rating_thanks">Îți mulțumim!</string>
 	<!-- Text for rating dialog -->
 	<string name="rating_share_ideas">Comunică-ne ideile tale și problemele aplicației, astfel încât să o putem îmbunătăți pentru tine.</string>
 	<!-- Text for rating dialog -->
 	<string name="rating_send_feedback">Trimitere feedback</string>
-	<!-- Text for g+ dialog -->
-	<string name="rating_google_plus">Clic pe g+ pentru a le spune prietenilor tăi despre aplicație.</string>
 	<!-- Text for routing error dialog -->
 	<string name="routing_download_maps_along">Descarcă hărțile adiacente rutei</string>
-	<!-- Text for routing error dialog -->
-	<string name="routing_download_map">Descărcați harta</string>
-	<!-- Text for routing error dialog -->
-	<string name="routing_download_map_and_routing">Descărcați harta actualizată și informațiile pentru direcționare, pentru a beneficia de toate funcțiile Organic Maps.</string>
-	<!-- Text for routing error dialog -->
-	<string name="routing_get_routing_data">Descărcați informațiile pentru direcționare</string>
-	<!-- Text for routing error dialog -->
-	<string name="routing_get_additional_data">Datele suplimentare necesare pentru a crea trasee de la locația dvs.</string>
 	<!-- Text for routing error dialog -->
 	<string name="routing_requires_all_map">Crearea unui traseu necesită ca toate hărțile de la locația dvs. până la destinație să fie descărcate și actualizate.</string>
 	<!-- Text for routing error dialog -->
 	<string name="routing_not_enough_space">Nu există spațiu suficient</string>
-	<!-- Text for routing error dialog -->
-	<string name="routing_download_more_than_avail">Trebuie să descărcați %1$s MB, dar numai un spațiu de %2$s MB este disponibil.</string>
-	<!-- Text for routing error dialog -->
-	<string name="routing_download_roaming">Urmează să descărcați %s MB folosind abonamentul de date pentru mobil (în roaming). Acest lucru poate genera costuri suplimentare, în funcție de abonamentul dvs. de date, activat de operatorul de telefonie mobilă.</string>
 	<!-- bookmark button text -->
 	<string name="bookmark">marcaj</string>
-	<!-- map is not downloaded -->
-	<string name="not_found_map">Harta pentru poziția dvs. nu este descărcată</string>
 	<!-- location service disabled -->
 	<string name="enable_location_services">Vă rugăm să activați serviciile de localizare</string>
-	<!-- download map -->
-	<string name="download_map">Descărcați harta pentru poziția dvs.</string>
-	<!-- download map on iPhone -->
-	<string name="download_map_iphone">Descărcați o hartă pentru poziția dvs. actuală pe iPhone-ul dvs.</string>
-	<!-- clear pin -->
-	<string name="nearby">În apropiere</string>
-	<!-- clear pin -->
-	<string name="clear_pin">Ștergeți semnul de poziție</string>
-	<!-- location is undefined -->
-	<string name="undefined_location">Poziția dvs. curentă este nedefinită.</string>
-	<!-- download country of your location -->
-	<string name="download_country">Descărcați hărțile pentru țara în care vă aflați</string>
-	<!-- download failed -->
-	<string name="download_failed">descărcarea a eșuat</string>
-	<!-- get the map -->
-	<string name="get_the_map">Obțineți harta</string>
 	<string name="save">Salvare</string>
-	<string name="new_group">grup nou</string>
 	<string name="create">creează</string>
 	<!-- red color -->
 	<string name="red">Roșu</string>
@@ -479,22 +297,6 @@
 	<string name="brown">Maro</string>
 	<!-- pink color -->
 	<string name="pink">Roz</string>
-	<!-- deep purple color -->
-	<string name="deep_purple">Purpuriu închis</string>
-	<!-- light blue color -->
-	<string name="light_blue">Albastru deschis</string>
-	<!-- cyan color -->
-	<string name="cyan">Albastru-verziu</string>
-	<!-- teal color -->
-	<string name="teal">Smarald</string>
-	<!-- lime color -->
-	<string name="lime">Var</string>
-	<!-- deep orange color -->
-	<string name="deep_orange">Portocaliu închis</string>
-	<!-- gray color -->
-	<string name="gray">Gri</string>
-	<!-- blue gray color -->
-	<string name="blue_gray">Gri albăstriu</string>
 	<!-- Wi-Fi available -->
 	<string name="WiFi_available">Da</string>
 
@@ -510,10 +312,8 @@
 	<string name="dialog_routing_location_turn_wifi">Verificaţi semnalul GPS. Pentru a îmbunătăţi precizia localizării, activaţi Wi-Fi.</string>
 	<string name="dialog_routing_location_turn_on">Activaţi serviciile de localizare</string>
 	<string name="dialog_routing_location_unknown_turn_on">Localizarea coordonatelor GPS curente a eşuat. Pentru a calcula traseul, activaţi serviciile de localizare.</string>
-	<string name="dialog_routing_location_unknown">Localizarea coordonatelor GPS curente a eşuat.</string>
 	<string name="dialog_routing_download_files">Descărcaţi fişierele necesare</string>
 	<string name="dialog_routing_download_and_update_all">Pentru calcularea traseului, descărcaţi şi actualizaţi toate hărţile şi informaţiile de stabilire a traseului pentru calea estimată.</string>
-	<string name="dialog_routing_routes_size">Fişiere cu informaţii de stabilire a traseului</string>
 	<string name="dialog_routing_unable_locate_route">Localizarea traseului a eşuat</string>
 	<string name="dialog_routing_cant_build_route">Crearea traseului a eşuat.</string>
 	<string name="dialog_routing_change_start_or_end">Ajustaţi punctul iniţial sau destinaţia.</string>
@@ -528,33 +328,23 @@
 	<string name="dialog_routing_system_error">Eroare sistem</string>
 	<string name="dialog_routing_application_error">Crearea traseului a eşuat din cauza unei erori a aplicaţiei.</string>
 	<string name="dialog_routing_try_again">Încercaţi din nou</string>
-	<string name="dialog_routing_send_error">Raportaţi problema</string>
-	<string name="dialog_routing_if_get_cross_route">Doriţi să creaţi un traseu mai direct care include mai mult decât o hartă?</string>
-	<string name="dialog_routing_cross_route_is_optimal">Este disponibil un traseu mai adecvat care trece de limita acestei hărţi.</string>
 	<string name="not_now">Nu acum</string>
-	<string name="dialog_routing_build_route">Creare</string>
 	<string name="dialog_routing_download_and_build_cross_route">Doriţi să descărcaţi harta şi să creaţi un traseu mai direct care include mai mult decât o hartă?</string>
 	<string name="dialog_routing_download_cross_route">Pentru a crea un traseu mai adecvat care trece de limita acestei hărţi, descărcaţi harta.</string>
-	<string name="dialog_routing_cross_route_always">Întotdeauna să se treacă această limită</string>
 
 	<!-- SECTION: Strings for downloading map from search -->
 	<string name="search_without_internet_advertisement">Pentru a putea începe căutarea și crearea unor rute, vă rugăm să descărcați harta, iar apoi nu veți mai avea nevoie de conexiune la internet.</string>
 	<string name="search_select_map">Selectați harta</string>
-	<string name="search_select_other_map">Selectați altă hartă</string>
 	<!-- «Show» context menu -->
 	<string name="show">Afișare</string>
 	<!-- «Hide» context menu -->
 	<string name="hide">Ascundere</string>
 	<!-- «Rename» context menu -->
 	<string name="rename">Redenumire</string>
-	<!-- Bottom sheet: expand button (should be short) -->
-	<string name="bottom_sheet_more">Mai multe…</string>
 	<!-- Failed planning route message in navigation view -->
 	<string name="routing_planning_error">Planificarea rutei a eșuat</string>
 	<!-- Arrive routing message in navigation view -->
 	<string name="routing_arrive">Sosire: %s</string>
-	<!-- Text for routing::RouterResultCode::FileTooOld dialog. -->
-	<string name="dialog_routing_download_and_update_maps">Pentru a crea o rută, vă rugăm să descărcați și să actualizați toate hărțile de pe parcursul rutei.</string>
 	<string name="rate_alert_title">Vă place aplicația?</string>
 	<string name="rate_alert_default_message">Vă mulțumim că folosiți Organic Maps. Vă rugăm să dați o notă aplicației. Comentariile dvs. ne ajută să devenim mai buni.</string>
 	<string name="rate_alert_five_star_message">Ura! Și noi vă iubim!</string>
@@ -562,24 +352,14 @@
 	<string name="rate_alert_less_than_four_star_message">Aveți vreo idee prin care putem să îmbunătățim aplicația?</string>
 	<string name="categories">Categorii</string>
 	<string name="history">Istoric</string>
-	<string name="next_turn_then">Apoi</string>
 	<string name="closed">Închis</string>
-	<string name="back_to">Înapoi la %s</string>
 	<string name="search_not_found">Ne pare rău, nu s-au găsit rezultate.</string>
 	<string name="search_not_found_query">Vă rugăm să încercați altă căutare.</string>
-	<string name="search_not_found_map">Vă rugăm să descărcați harta pe care doriți să căutați.</string>
-	<string name="search_not_found_location">Descărcați harta locului în care vă aflați acum.</string>
 	<string name="search_history_title">Istoricul căutărilor</string>
 	<string name="search_history_text">Accesare rapidă a căutărilor recente.</string>
 	<string name="clear_search">Ștergere istoric de căutare</string>
-	<!-- Title for settings to enable/disable showcase menu button -->
-	<string name="showcase_settings_title">Afișare oferte</string>
-	<string name="p2p_route_planning">Planificare rută</string>
 	<string name="p2p_your_location">Locația dvs.</string>
-	<string name="p2p_from">Punctul de plecare</string>
-	<string name="p2p_to">Punctul de sosire</string>
 	<string name="p2p_start">Start</string>
-	<string name="p2p_planning">Se planifică…</string>
 	<string name="p2p_from_here">Din</string>
 	<string name="p2p_to_here">Ruta la</string>
 	<string name="p2p_only_from_current">Navigația este disponibilă doar având ca punct de pornire locațiacctuală.</string>
@@ -599,11 +379,8 @@
 	<string name="editor_hours_closed">Ora închiderii</string>
 	<string name="editor_example_values">Exemple de valori</string>
 	<string name="editor_correct_mistake">Corectare greșeală</string>
-	<string name="editor_correct_mistake_message">Ați efectuat o eroare de editare. Corectați eroarea sau treceți în modul Simplu.</string>
 	<string name="editor_add_select_location">Locație</string>
 	<string name="editor_done_dialog_1">Ați modificat harta lumii. Nu ascundeți acest lucru! Spuneți-le prietenilor dvs. și modificați-o împreună.</string>
-	<string name="editor_done_dialog_2">Aceasta este a doua modificare a hărții. Acum sunteți pe locul %d în lista editorilor de hărți. Spuneți prietenilor dvs. despre aceasta.</string>
-	<string name="editor_done_dialog_3">Ați modificat harta, spuneți prietenilor dvs. despre aceasta și modificați-o împreună.</string>
 	<string name="share_with_friends">Partajează cu prietenii</string>
 	<string name="editor_report_problem_desription_1">Vă rugăm să descrieți problema în detaliu, astfel încât comunitatea OpenStreeMap să poată remedia eroarea.</string>
 	<string name="editor_report_problem_desription_2">Sau faceți-o pe https://www.openstreetmap.org/</string>
@@ -612,14 +389,7 @@
 	<string name="editor_report_problem_no_place_title">Această locație nu există</string>
 	<string name="editor_report_problem_under_construction_title">Închis pentru întreținere</string>
 	<string name="editor_report_problem_duplicate_place_title">Locație dublată</string>
-	<string name="first_launch_congrats_title">Organic Maps este gata pentru utilizare</string>
-	<string name="first_launch_congrats_text">Căutați și navigați în regim offline oriunde în lume, în mod gratuit.</string>
-	<string name="migrate_title">Important!</string>
-	<!-- Android uses image instead of text. -->
-	<string name="download_all">Descarcă toate</string>
-	<string name="delete_all">Ștergere toate</string>
 	<string name="autodownload">Descărcare automată</string>
-	<string name="disable_autodownload">Dezactivare descărcare automată</string>
 	<!-- Place Page opening hours text -->
 	<string name="closed_now">Închis acum</string>
 	<!-- Place Page opening hours text -->
@@ -628,8 +398,6 @@
 	<string name="day_off_today">Astăzi închis</string>
 	<string name="day_off">Închis</string>
 	<string name="today">Azi</string>
-	<string name="sunrise_to_sunset">De la răsărit până la apus</string>
-	<string name="sunset_to_sunrise">De la apus până la răsărit</string>
 	<string name="add_opening_hours">Adăugare ore de funcționare</string>
 	<string name="edit_opening_hours">Editare ore de funcționare</string>
 	<string name="no_osm_account">Nu aveți un cont în OpenStreetMap?</string>
@@ -639,29 +407,13 @@
 	<string name="login">Autentificare</string>
 	<string name="password">Parolă</string>
 	<string name="forgot_password">Ați uitat parola?</string>
-	<!-- Forgot Password dialog title -->
-	<string name="restore_password">Recuperare parolă</string>
-	<string name="enter_email_address_to_reset_password">Introduceți adresa de email pe care ați utilizat-o în momentul înregistrării, iar noi vă vom trimite link-ul pentru a vă reînnoi parola.</string>
-	<string name="reset_password">Resetare parolă</string>
-	<string name="username">Nume de utilizator</string>
 	<string name="osm_account">Cont OSM</string>
 	<string name="logout">Ieșire</string>
-	<string name="login_and_edit_map_motivation_message">Autentificați-vă și editați informația despre obiectele de pe hartă, iar noi le vom face disponibile pentru milioane de alți utilizatori. Să facem împreună lumea mai bună.</string>
 	<!-- Information text: "Last upload 11.01.2016" -->
 	<string name="last_upload">Ultima încărcare</string>
-	<!-- Motivates user to login/register, title above login buttons. -->
-	<string name="you_have_edited_your_first_object">Ați editat primul dvs. obiect!</string>
 	<string name="thank_you">Vă mulțumim</string>
-	<string name="login_with_google">Logați-vă cu contul de Google</string>
-	<string name="login_with_openstreetmap">Logați-vă cu contul de www.openstreetmap.org</string>
 	<string name="edit_place">Editați loc</string>
 	<string name="place_name">Denumire loc</string>
-	<!-- title above languages list cells in the editor, below editable name text field. -->
-	<string name="other_languages">Alte limbi</string>
-	<!-- small button to open list with names in different languages -->
-	<string name="show_more">Afișează mai mult</string>
-	<!-- small button to close list with names in different languages -->
-	<string name="show_less">Afișează mai puțin</string>
 	<string name="add_language">Adăugare limbă</string>
 	<string name="street">Stradă</string>
 	<!-- Editable House Number text field (in address block). -->
@@ -678,25 +430,16 @@
 	<string name="email_or_username">Adresa de email sau numele de utilizator</string>
 	<string name="phone">Telefon</string>
 	<string name="please_note">Actualizați hărțile</string>
-	<string name="common_no_wifi_dialog">Nu există conexiune WiFi. Doriți să continuați cu conexiunea de pe mobil?</string>
 	<string name="downloader_delete_map_dialog">Pentru a crea un traseu, trebuie să actualizați toate hărțile, iar apoi să planificați traseul încă o dată.</string>
 	<string name="downloader_update_maps">Actualizați hărțile</string>
 	<string name="downloader_mwm_migration_dialog">Pentru a crea un traseu, trebuie să actualizați toate hărțile, iar apoi să planificați traseul încă o dată.</string>
 	<string name="downloader_search_field_hint">Găsiți harta</string>
-	<string name="migration_update_all_button">Actualizați toate hărțile</string>
-	<string name="migration_delete_all_download_current_button">Descărcați harta actuală și ștergeți toate hărțile vechi</string>
 	<string name="migration_download_error_dialog">Eroare de descărcare</string>
 	<string name="common_check_internet_connection_dialog">Vă rugăm să vă verificați setările și să vă asigurați că dispozitivul dvs. este conectat la Internet.</string>
 	<string name="downloader_no_space_title">Spațiu insuficient</string>
 	<string name="downloader_no_space_message">Vă rugăm să ștergeți datele care nu sunt necesare</string>
-	<string name="editor_general_auth_error_dialog">Eroare generală de conectare.</string>
 	<string name="editor_login_error_dialog">Eroare de conectare.</string>
-	<string name="editor_login_failed_dialog">Conectare eșuată</string>
-	<string name="editor_username_error_dialog">Nume de utilizator nevalid</string>
-	<string name="editor_place_edited_dialog">Ați editat un obiect!</string>
-	<string name="editor_login_with_osm">Conectați-vă cu OpenStreetMap</string>
 	<string name="editor_profile_changes">Modificări confirmate</string>
-	<string name="editor_profile_unsent_changes">Netrimis:</string>
 	<string name="editor_focus_map_on_location">Trageți de hartă pentru a selecta locația corectă a obiectului.</string>
 	<string name="editor_add_select_category">Selectați categoria</string>
 	<string name="editor_add_select_category_popular_subtitle">Popular</string>
@@ -707,19 +450,14 @@
 	<string name="editor_edit_place_category_title">Categorie</string>
 	<string name="detailed_problem_description">Descrierea detaliată a problemei</string>
 	<string name="editor_report_problem_other_title">O problemă diferită</string>
-	<string name="placepage_report_problem_button">Raportați o problemă</string>
 	<string name="placepage_add_business_button">Adăugare organizație</string>
 	<string name="whatsnew_editor_message_1">Adăugați locuri noi pe hartă și modificați-le pe cele existente direct din aplicație.</string>
-	<string name="whatsnew_editor_message_2">* Organic Maps folosește datele comunității OpenStreetMap community.</string>
 	<string name="dialog_incorrect_feature_position">Schimbare locație</string>
 	<string name="message_invalid_feature_position">În acest loc nu poate fi localizat un obiect</string>
 	<string name="login_to_make_edits_visible">Autentificați-vă pentru ca modificările pe care le-ați efectuat să poată fi văzute și de alți utilizatori.</string>
-	<string name="no_migration_during_navigation">În timpul navigării, actualizarea este interzisă.</string>
 	<!-- Error dialog no space -->
 	<string name="migration_no_space_message">Aveți nevoie de mai mult spațiu ca să descărcați. Vă rugăm să ștergeți toate informațiile inutile.</string>
 	<string name="editor_sharing_title">Am îmbunătățit hărțile Organic Maps</string>
-	<string name="editor_comment_will_be_sent">Vom trimite comentariul dumneavoastră cartografilor.</string>
-	<string name="editor_unsupported_category_message">Ați adăugat o locație pentru care nu avem încă o categorie creată. Aceasta va apărea pe hartă în viitorul apropiat.</string>
 	<!-- Downloaded 10 **of** 20 <- it is that "of" -->
 	<string name="downloader_of">%1$d din %2$d</string>
 	<string name="download_over_mobile_header">Descărcați utilizând o conexiune prin rețeaua de telefonie mobilă?</string>
@@ -737,15 +475,8 @@
 	<string name="editor_detailed_description">Modificările sugerate vor trimise către comunitatea OpenStreetMap. Descrieți detalii ce nu pot fi adăugate în be the details which cannot be edited in Organic Maps.</string>
 	<string name="editor_more_about_osm">Mai multe despre OpenStreetMap</string>
 	<string name="editor_operator">Operator</string>
-	<string name="editor_tag_description">Introduceți compania, organizația sau persoana responsabilă de facilități.</string>
-	<string name="editor_no_local_edits_title">Nu aveți modificări locale</string>
-	<string name="editor_no_local_edits_description">Acesta arată numărul de modificări sugerate pe hartă care sunt momentan accesibile doar pe dispozitivul dvs.</string>
-	<string name="editor_send_to_osm">Trimitere la OSM</string>
-	<string name="editor_remove">Eliminare</string>
-	<string name="downloader_my_maps_title">Hărțile mele</string>
 	<string name="downloader_no_downloaded_maps_title">Nu ați descărcat nicio hartă</string>
 	<string name="downloader_no_downloaded_maps_message">Descărcați hărți pt. a găsi locația și navigați offline.</string>
-	<string name="downloader_find_place_hint">Căutare oraș sau țară</string>
 	<!-- Error title that appears after certain time without location. -->
 	<string name="current_location_unknown_title">Continuați cu detectarea locației dvs. curente?</string>
 	<!-- Error that appears after certain time without location. -->
@@ -760,26 +491,10 @@
 	<string name="location_services_disabled_2">2. Apăsați pe Localizare</string>
 	<!-- iOS Dialog for the case when the location permission is not granted -->
 	<string name="location_services_disabled_3">3. Selectați în timp ce folosiți aplicația</string>
-	<string name="placepage_parking_surface">Suprafață</string>
-	<string name="placepage_parking_multistorey">Multi-etajat</string>
-	<string name="placepage_parking_underground">Subteran</string>
-	<string name="placepage_parking_rooftop">Pe acoperiș</string>
-	<string name="placepage_parking_sheds">Garaj</string>
-	<string name="placepage_parking_carports">Garaje</string>
-	<string name="placepage_parking_pay">Cu plată</string>
-	<string name="placepage_parking_free">Gratuit</string>
-	<string name="placepage_parking_interval">Interval de plată</string>
-	<string name="placepage_entrance_number">Nr.</string>
-	<string name="placepage_entrance_type">Intrare</string>
-	<string name="placepage_flat">ap.</string>
-	<string name="placepage_open_24_7">24 / 7</string>
 	<string name="meter">m</string>
 	<string name="kilometer">km</string>
-	<string name="kilometers_per_hour">km/h</string>
 	<string name="mile">mi</string>
 	<string name="foot">picior</string>
-	<string name="miles_per_hour">mph</string>
-	<string name="day">z</string>
 	<string name="hour">o</string>
 	<string name="minute">min</string>
 	<string name="placepage_place_description">Descriere</string>
@@ -789,46 +504,30 @@
 	<string name="placepage_call_button">Apel</string>
 	<string name="placepage_edit_bookmark_button">Editare marcaj</string>
 	<string name="placepage_bookmark_name_hint">Nume marcaj</string>
-	<string name="placepage_personal_notes_hint">Note personale</string>
-	<string name="placepage_delete_bookmark_button">Ștergere marcaj</string>
 	<string name="editor_edits_sent_message">Modificările sugerate au fost trimise</string>
 	<string name="editor_comment_hint">Comentariu…</string>
 	<string name="editor_reset_edits_message">Resetați toate modificările locale?</string>
 	<string name="editor_reset_edits_button">Resetare</string>
 	<string name="editor_remove_place_message">Eliminați locul adăugat?</string>
 	<string name="editor_remove_place_button">Eliminare</string>
-	<string name="editor_status_sending">Se trimite…</string>
 	<string name="editor_place_doesnt_exist">Locul nu există</string>
 	<string name="text_more_button">…mai multe</string>
 	<!-- Phone number error message -->
 	<string name="error_enter_correct_phone">Introduceți numărul de telefon corect</string>
 	<string name="error_enter_correct_web">Introduceți o adresă web validă</string>
 	<string name="error_enter_correct_email">Introduceți o adresă de email validă</string>
-	<string name="error_enter_correct">Introduceți o valoare validă</string>
 	<string name="refresh">Actualizați</string>
-	<string name="last_update">Ultima actualizare: %s</string>
 	<string name="placepage_add_place_button">Adăugați un loc pe hartă</string>
 	<!-- Displayed when saving some edits to the map to warn against publishing personal data -->
 	<string name="editor_share_to_all_dialog_title">Doriți să îl trimiteți tuturor utilizatorilor?</string>
 	<!-- iOS Dialog before publishing the modifications to the public map. -->
 	<string name="editor_share_to_all_dialog_message_1">Asigurați-vă că nu ați introdus niciun fel de date personale.</string>
 	<string name="editor_share_to_all_dialog_message_2">Vom verifica modificările. Dacă vor apărea întrebări, vă vom contacta prin email.</string>
-	<string name="navigation_overview_button">rezumat</string>
-	<string name="navigation_stop_button">stop</string>
-	<!-- Text on an empty bookmark page -->
-	<string name="bookmarks_empty_title">Salvare marcaje</string>
-	<string name="bookmarks_empty_message_1">Atingeți ★ pentru a salva locurile preferate, pentru un acces rapid.</string>
-	<string name="bookmarks_empty_message_2">Importare marcaje din Mail și web.</string>
-	<string name="bookmarks_empty_message_3">check out: %s</string>
-	<!-- Name of the group for booked hotels -->
-	<string name="bookmarks_group_name">Hoteluri rezervate</string>
-	<string name="place_page_button_read_descriprion">Citiți</string>
 	<!-- iOS dialog for the case when recent track recording is on and the app comes back from background -->
 	<string name="recent_track_background_dialog_title">Dezactivați înregistrarea celui mai recent traseu urmat?</string>
 	<string name="off_recent_track_background_button">Dezactivare</string>
 	<!-- For sharing via SMS and so on -->
 	<string name="sharing_call_action_look">Aruncați o privire</string>
-	<string name="continue_recent_track_background_button">Continuare</string>
 	<string name="recent_track_background_dialog_message">Organic Maps folosește în fundal geo-locația pentru a înregistra cel mai recent traseu urmat.</string>
 	<!-- Rate on Google Play (Android only) -->
 	<string name="rate_gp">Dați un calificativ pe Google Play</string>
@@ -838,21 +537,11 @@
 	<string name="tell_friends_text">Bună! Instalați Organic Maps!</string>
 	<!-- About short text (below logo) -->
 	<string name="about_description">Organic Maps este o aplicație offline esențială când călătoriți. Organic Maps utilizează datele OpenStreeMap și permite editarea acestora.</string>
-	<!-- Text in menu -->
-	<string name="blog">Blog</string>
 	<string name="general_settings">Setări generale</string>
-	<string name="date">Data %d</string>
-	<!-- "Report a bug" -> "Generaal Feedback" -> "Something is not working" -->
-	<string name="something_is_not_working">Ceva nu funcționează corect</string>
 	<!-- For the first routing -->
 	<string name="accept">Acceptați</string>
 	<!-- For the first routing -->
 	<string name="decline">Refuzați</string>
-	<string name="install_app">Instalați</string>
-	<string name="search_no_results_title">Nu au fost găsite rezultate</string>
-	<string name="search_no_results_message">Încercați un termen mai general, micșorați sau resetați filtrul.</string>
-	<string name="search_no_results_expand_area_button">Micșorare</string>
-	<string name="search_no_results_reset_button">Resetare filtru</string>
 	<!-- noun -->
 	<string name="search_in_table">Listă</string>
 	<string name="mobile_data_dialog">Folosiți internetul mobil pentru a afişa informaţii detaliate?</string>
@@ -864,18 +553,13 @@
 	<string name="mobile_data_option_never">Nu utilizați niciodată</string>
 	<string name="mobile_data_option_ask">Întrebați întotdeauna</string>
 	<string name="traffic_update_maps_text">Pentru a afişa datele privind traficul, hărțile trebuie actualizate.</string>
-	<string name="traffic_outdated">Datele privind traficul sunt învechite.</string>
 	<string name="big_font">Măriți dimensiunea fontului pe hartă</string>
 	<string name="traffic_update_app">Vă rugăm să actualizaţi Organic Maps</string>
 	<!-- "traffic" as in road congestion -->
 	<string name="traffic_update_app_message">Pentru a afişa datele privind traficul, aplicația trebuie actualizată.</string>
 	<!-- "traffic" as in "road congestion" -->
 	<string name="traffic_data_unavailable">Datele privind traficul nu sunt disponibile</string>
-	<!-- Simplified colour scheme for traffic information, fewer colours are used to display traffic jams on the map. The string should be kept as short as possible -->
-	<string name="pref_traffic_simplified_colors_title">Culori trafic simplificate</string>
 	<string name="enable_logging">Activare jurnalizare</string>
-	<string name="offline_place_page_more_information">Conectați-vă la internet pentru a primi mai multe informații despre locație.</string>
-	<string name="failed_load_information">Încărcarea informațiilor a eșuat.</string>
 	<!-- Settings: "Send general feedback" button -->
 	<string name="feedback_general">Feedback general</string>
 	<string name="on">Activat</string>
@@ -889,57 +573,26 @@
 	<string name="routing_add_start_point">Adăugați punctul de plecare pentru a planifica un traseu</string>
 	<string name="routing_add_finish_point">Adăugați punctul de sosire pentru a planifica un traseu</string>
 	<string name="button_exit">Ieșire</string>
-	<string name="settings_device_memory">Memoria dispozitivului</string>
-	<string name="settings_card_memory">Card</string>
-	<string name="settings_storage_available">%s disponibil</string>
-	<string name="toast_location_permission_denied">Permisiune de accesare a locației respinsă</string>
-	<string name="button_use">Utilizare</string>
 	<string name="planning_route_manage_route">Administrare traseu</string>
 	<string name="button_plan">Planificare</string>
-	<string name="button_add">Adăugare</string>
 	<string name="placepage_remove_stop">Eliminare</string>
 	<string name="planning_route_remove_title">Trageți aici pentru a elimina</string>
-	<string name="dialog_change_start_point_message">Înlocuiți punctul de plecare cu locația curentă?</string>
-	<string name="button_replace">Înlocuire</string>
 	<string name="placepage_add_stop">Adăugare oprire</string>
-	<string name="add_my_position">Adaugă poziția mea</string>
-	<string name="choose_start_point">Alege un punct de plecare</string>
-	<string name="choose_destination">Alege o destinație</string>
 	<string name="preloader_viator_button">Află mai multe</string>
-	<string name="start_from_my_position">Începând de la</string>
-	<string name="profile_authorization_title">Conectare cu</string>
-	<string name="profile_authorization_message">Conectare rapidă în câteva secunde, fără autentificare și parolă</string>
 	<string name="profile_authorization_error">Ups, a survenit o eroare. Încercați să vă conectați din nou.</string>
-	<string name="service">Servicii</string>
-	<string name="atmosphere">Atmosferă</string>
-	<string name="value_for_money">Raport calitate/preț</string>
-	<string name="experience">Experiență</string>
-	<string name="assortment">Varietate</string>
-	<string name="expertise">Expertiză</string>
-	<string name="equipment">Echipamente</string>
-	<string name="quality">Calitate</string>
 	<string name="dialog_error_storage_title">Problemă de accesare spațiu de stocare</string>
 	<string name="dialog_error_storage_message">Spațiul de stocare extern nu este disponibil. Probabil cardul SD nu este introdus, este deteriorat sau sistemul de fișiere este read-only. Verifică și contactează-ne la support\@organicmaps.app</string>
 	<string name="setting_emulate_bad_storage">Emulare stocare eronată</string>
-	<string name="directions_finish">Destinație</string>
-	<string name="directions_on_foot">%s de mers</string>
 	<string name="core_entrance">Intrare</string>
-	<string name="coffee">Cafea</string>
-	<string name="cleanliness">Curățenie</string>
-	<string name="crowdedness">Aglomerație</string>
 	<string name="error_enter_correct_name">Introdu un nume corect</string>
 	<string name="bookmarks_groups">Liste</string>
 	<string name="bookmarks_groups_hide_all">Ascundere toate</string>
 	<string name="bookmarks_groups_show_all">Afișare toate</string>
-	<plurals name="bookmarks_places">
-	  <item quantity="other">%d semne de carte</item>
-	</plurals>
 	<string name="bookmarks_create_new_group">Creați o listă nouă</string>
 	<string name="downloader_hide_screen">Ascundere ecran</string>
 	<string name="downloader_percent">%1$s (%2$s din %3$s)</string>
-	<string name="downloader_process">Descărcare %s...</string>
-	<string name="downloader_applying">Aplicare %s...</string>
-	<string name="dialog_message_transit_not_found_connection">Planifică o rută într-o singură rețea de tranzit</string>
+	<string name="downloader_process">Descărcare %s…</string>
+	<string name="downloader_applying">Aplicare %s…</string>
 	<string name="bookmarks_error_message_share_general">Imposibil de distribuit din cauza unei erori a aplicației</string>
 	<string name="bookmarks_error_title_share_empty">Eroare la distribuire</string>
 	<string name="bookmarks_error_message_share_empty">Nu se poate distribui o listă goală</string>
@@ -948,12 +601,7 @@
 	<string name="bookmarks_new_list_hint">Lista nouă</string>
 	<string name="bookmarks_error_title_list_name_already_taken">Acest nume este deja luat</string>
 	<string name="bookmarks_error_message_list_name_already_taken">Alegeți un alt nume</string>
-	<string name="bookmarks_error_title_list_name_too_long">Acest nume este prea lung</string>
-	<string name="bookmarks_error_message_list_name_too_long">Alegeți un alt nume</string>
-	<string name="please_wait">Te rog asteapta...</string>
-	<string name="phone_number">Numar de telefon</string>
-	<string name="notification_unsent_reviews_title">Aveți mai multe recenzii nesoluționate</string>
-	<string name="notification_unsent_reviews_message">Vă rugăm să vă conectați pentru a trimite recenzii altor călătorii</string>
+	<string name="please_wait">Te rog asteapta…</string>
 	<string name="profile">Profil OpenStreetMap</string>
 	<string name="place_page_search_similar_hotel">Căutați hoteluri similare</string>
 	<string name="bookmarks_detect_title">Au fost detectate fișiere noi</string>
@@ -964,31 +612,10 @@
 	<string name="button_convert">Convertit</string>
 	<string name="bookmarks_convert_error_title">Eroare</string>
 	<string name="bookmarks_convert_error_message">Unele fișiere nu au fost convertite.</string>
-	<string name="converting">Conversia...</string>
-	<string name="wn_reinvented_bookmarks_title">Am reinventat marcaje!</string>
-	<string name="wn_reinvented_bookmarks_message">Aveți posibilitatea să copiați marcajele de rezervă, să creați liste... Este uimitor...</string>
-	<string name="bookmarks_restore">Restaurați marcajele</string>
-	<string name="bookmarks_restore_process">Restaurarea...</string>
 	<string name="bookmarks_restore_title">Restabiliți această versiune?</string>
-	<string name="bookmarks_restore_message">Marcajele dvs. vor fi restabilite de la %1$s (%2$s)</string>
-	<string name="bookmarks_restore_empty_title">Nu aveți o copie de rezervă</string>
-	<string name="bookmarks_restore_empty_message">Serverul nu a găsit copii de rezervă create anterior</string>
 	<string name="common_check_internet_connection_dialog_title">Fără conexiune internet</string>
-	<string name="error_server_title">Eroare de server</string>
-	<string name="error_server_message">A apărut o eroare la server, încercați din nou mai târziu</string>
 	<string name="error_system_message">O eroare necunoscută s-a întamplat</string>
 	<string name="restore">Restabili</string>
-	<string name="bookmarks_page_downloaded">Fișierele descărcate</string>
-	<string name="bookmarks_page_my">Al mele</string>
-	<string name="routes_and_bookmarks">Rute și tag-uri</string>
-	<string name="bookmarks_webview_success_toast">Locațiile au fost descărcate cu succes</string>
-	<string name="cached_bookmarks_placeholder_title">Încărcați locuri noi</string>
-	<string name="cached_bookmarks_placeholder_subtitle">Faceți clic pe butonul pentru a descărca mii de locuri interesante și rute create de utilizatori Organic Maps. Veți avea nevoie de o conexiune la Internet.</string>
-	<string name="downloader_download_routers">Descărcați tag-urile</string>
-	<string name="bookmarks_groups_cached">Listele descărcate</string>
-	<plurals name="bookmarks_objects">
-	  <item quantity="other">%s obiect</item>
-	</plurals>
 	<plurals name="objects">
 	  <item quantity="other">%d localitate</item>
 	</plurals>
@@ -1001,62 +628,32 @@
 	<string name="subtittle_opt_out">Setări de servire</string>
 	<string name="crash_reports">Rapoarte de eroare</string>
 	<string name="crash_reports_description">Putem folosi datele dvs. pentru a dezvolta și de a îmbunătăți Organic Maps. Modificările vor intra în vigoare după repornirea aplicației.</string>
-	<string name="opt_out_help_ios_1">Puteți renunța la primirea de publicitate țintă în setările aparatului.</string>
-	<string name="opt_out_help_ios_2">iOS 9 sau mai sus</string>
-	<string name="opt_out_help_ios_3">Deschideți Setări → Confidențialitate → Publicitate → „Activați Limitarea trackking”</string>
-	<string name="opt_out_help_android">Puteți renunța la primirea de publicitate țintă în setările aparatului.\n Android și Google Play Servicii 4.0 și mai sus\n\n Setări de telefon → Google → Publicitate → Dezactivarea personalizării publicității \n sau \n Setări de telefon → Google → un Cont Google → Confidențialitate → Setări pentru anunțuri → Personalizarea publicității</string>
 	<string name="privacy_policy">Politica de confidențialitate</string>
 	<string name="terms_of_use">Termeni de utilizare</string>
-	<string name="backup_notification_failed">Copierea de rezervă a tag-uri lor a fost suspendată. Conectați-vă pentru a activa copierea de rezervă.</string>
 	<string name="button_layer_traffic">Dopuri</string>
 	<string name="button_layer_subway">Metrou</string>
 	<string name="layers_title">Straturile hărții</string>
-	<string name="layers_message">Conectați straturile pe hartă pentru a afișa rutierele medii, schema de metrou sau alte informații utile</string>
-	<string name="button_layer_got_it">Clar</string>
 	<string name="subway_data_unavailable">Harta de metrou nu este disponibilă</string>
 	<string name="bookmarks_empty_list_title">Lista este goală</string>
 	<string name="bookmarks_empty_list_message">Pentru a adăuga un nou tag, faceți clic pe pictograma stea în fișa de obiect</string>
 	<string name="category_desc_more">…mai mult</string>
 	<string name="title_error_downloading_bookmarks">A apărut o eroare</string>
-	<string name="subtitle_error_downloading_bookmarks">Tag-urile nu au fost încărcate</string>
-	<string name="error_already_downloaded">Lista aceasta a fost descărcată deja</string>
-	<string name="why_support">Pentru ce să susțineți Organic Maps?</string>
-	<string name="why_support_item2">Voi ne ajutați să îmbunătățim Organic Maps</string>
-	<string name="why_support_item3">Voi ne ajutați să îmbunătățim hărțile OpenStreetMap.org</string>
-	<string name="channels_map_update">Actualizarea hărților</string>
-	<string name="server_unavailable_title">Serverul nu este disponibil</string>
-	<string name="sharing_options">Setările accesului</string>
 	<string name="export_file">Exportați fișierul</string>
 	<string name="list_settings">Elaborarea listei</string>
 	<string name="delete_list">Ștergerea listei</string>
-	<string name="hide_from_map">Ascundeți de pe hartă</string>
 	<string name="public_access">Acces public</string>
 	<string name="limited_access">Acces privat</string>
 	<string name="bookmark_category_name">Categorie</string>
 	<string name="bookmark_category_description_hint">Adăugați o descriere (text sau html)</string>
 	<string name="not_shared">Personal</string>
-	<string name="direct_link_progress_text">Încărcăm fișierul dumneavoastră…</string>
-	<string name="direct_link_success">Linkul a fost creat</string>
-	<string name="send_a_link_btn">Trimiteți linkul</string>
-	<string name="upload_error_toast">În timpul încărcării fișierului s-a produs o eroare</string>
 	<string name="tags_loading_error_subtitle">În timpul încărcării tag-urilor s-a produs o eroare, vă rugăm să încercați încă odată</string>
-	<string name="unable_upload_errorr_title">Încărcarea fișierului nu s-a primit</string>
-	<string name="unable_upload_error_subtitle_edited">Fișierul a fost editat prin intermediul aplicației web</string>
-	<string name="unable_upload_error_subtitle_broken">Fișierul a fost deteriorat și nu poate fi încărcat. Vă rugăm, alegeți alt fișier.</string>
-	<string name="contact">Scrie</string>
-	<string name="download_button">Descărcați</string>
 	<string name="speedcams_alert_title">Camere de supraveghere video a vitezei</string>
-	<string name="speedcams_alert_subtitle">Avertizați despre limitele de viteză</string>
 	<string name="speedcam_option_auto">Auto</string>
 	<string name="speedcam_option_always">Mereu</string>
 	<string name="speedcam_option_never">Niciodată</string>
-	<string name="bookmark_description_title">Descrierea semnului</string>
 	<string name="place_description_title">Descrierea locului</string>
 	<!-- this text will be shown in application notification preferences opposite checkbox which enable/disable downloader notifications. Devices on Android 8+ are affected. -->
 	<string name="notification_channel_downloader">Încărcarea hărților</string>
-	<string name="share_bookmarks_email_body_link">Bună ziua!\n\nEtichetele dvs. le puteți descărca de pe linki-ul: %s. Deschideți lista cu ajutorul Organic Maps și primiți plăcere de la călătorie!\n\nDescărcați aplicația: https://omaps.app/get?kmz</string>
-	<string name="warning_speedcams_title">Navigatorul o să avertizeze despre camerele video în cazul depășirii limitei de viteză cu %d km/h</string>
-	<string name="warning_speedcams_subtitle">Nu uitați să faceți cunoștință cu regulele de circulație în țara unde călătoriți.</string>
 	<string name="speedcams_notice_message">Auto - De avertizat despre camerele video de înregistrare a vitezei, dacă există riscul depășirii limitei de viteză\nMereu - De avertizat întotdeauna despre camerele video\nNiciodată - De nu avertizat niciodată despre camerele video</string>
 	<string name="power_managment_title">Modul de economisire a energiei</string>
 	<string name="power_managment_description">Dacă este pornit modul de economisire a energiei, aplicația va deconecta funcțiile care consumă multă energie în dependență de încărcarea bateriei telefonice</string>
@@ -1064,14 +661,7 @@
 	<string name="power_managment_setting_auto">Auto</string>
 	<string name="power_managment_setting_manual_max">Economisire maximă a energiei</string>
 	<string name="enable_logging_warning_message">Aceasta opțiune se pornește pentru logarea acțiunii în scopul diagnosticării. Aceasta va ajuta echipei să găsească problemele legate de aplicație. Conectați opțiunea numai la solicitarea serviciului de suport Organic Maps.</string>
-	<string name="html_error_upload_message_try_again">Verificați accesul la rețea și încercați încă o dată</string>
-	<string name="html_error_upload_title_try_again">Aveți o problemă cu conexiunea dvs. la internet</string>
-	<string name="notification_leave_review_v2_android_short_title">Lăsați un comentariu și ajutați călătorii!</string>
-	<string name="notifications_illegal_alert_disable_button">Porniți notificarea</string>
 	<string name="access_rules_author_only">Se editează online</string>
-	<string name="privacy_settings_menu">Setarea confidențialității</string>
-	<string name="unable_upadate_error_title">Nu s-a actualizat traseul</string>
-	<string name="unable_upadate_error_message">Au intervenit erori de actualizare. Verificați modificările și încercați încă o dată</string>
 	<string name="driving_options_title">Setarea ocolirii</string>
 	<string name="driving_options_subheader">De evitat pe orice traseu</string>
 	<string name="avoid_tolls">Drumuri cu plată</string>
@@ -1082,52 +672,14 @@
 	<string name="unable_to_calc_alert_subtitle">Din păcate, nu reușim să elaborăm un traseu cu opțiunile alese. Modificați setările și încercați încă o dată</string>
 	<string name="define_to_avoid_btn">Setați căile de ocolire</string>
 	<string name="change_driving_options_btn">Setarea ocolirii este activată</string>
-	<string name="toll_road">Drum cu plată</string>
-	<string name="unpaved_road">Drum de țară</string>
-	<string name="ferry_crossing">Trecere cu bac</string>
-	<string name="operated_by">Se gestionează \"%s\"</string>
 	<string name="avoid_toll_roads_placepage">De evitat drumurile cu plată</string>
 	<string name="avoid_unpaved_roads_placepage">De evitat drumurile de țară</string>
 	<string name="avoid_ferry_crossing_placepage">De evitat trecerile cu bac</string>
-	<string name="type.cuisine.uzbek">Bucătărie uzbecă</string>
-	<string name="trip_start">Mergem</string>
-	<string name="pick_destination">Scop</string>
-	<string name="follow_my_position">Centrați</string>
-	<string name="search_results">Rezultatul căutării</string>
-	<string name="then_turn">După</string>
-	<string name="redirect_route_alert">Doriți să refaceți traseul?</string>
-	<string name="redirect_route_yes">Da</string>
-	<string name="redirect_route_no">Nu</string>
-	<string name="trip_finished">Ați sosit!</string>
-	<string name="keyboard_availability_alert">Tastiera nu este accesibilă în timpul deplasării</string>
-	<string name="dialog_routing_change_start_carplay">Este imposibil de elabora traseul de la punctul de aflare</string>
-	<string name="dialog_routing_change_end_carplay">Este imposibil de elaborat traseu până la punctul de sosire. Selectați altul</string>
-	<string name="dialog_routing_check_gps_carplay">Nu este semnal GPS. Mergeți la loc deschis</string>
-	<string name="dialog_routing_unable_locate_route_carplay">Este imposibil de elaborat un traseu. Selectați alte puncte ale traseului</string>
-	<string name="dialog_routing_download_files_carplay">Pentru noi trasee, încărcați hărțile lipsa pe dispozitivul dvs.</string>
-	<string name="dialog_routing_system_error_carplay">Eroare. Restartați aplicația</string>
-	<string name="dialog_routing_rebuild_from_current_location_carplay">Traseul se va reface de la locul actual al aflării dvs</string>
-	<string name="dialog_routing_rebuild_for_vehicle_carplay">Traseul va fi modificat cu unul automobilistic</string>
 	<string name="ok">Ok</string>
-	<string name="avoid_unpaved_carplay_1">Fără neasfal</string>
-	<string name="avoid_unpaved_carplay_2">Fără neasfaltat</string>
-	<string name="avoid_ferry_carplay_1">Fără bacuri</string>
-	<string name="avoid_ferry_carplay_2">Fără bacuri</string>
-	<string name="avoid_tolls_carplay_1">Gratis</string>
-	<string name="avoid_tolls_carplay_2">Gratis</string>
-	<string name="speedcams_alert_title_carplay_1">Cameră video</string>
-	<string name="speedcams_alert_title_carplay_2">Info camere</string>
-	<string name="download_map_carplay">Vă rugăm să descărcați hărțile în aplicația Organic Maps de pe dispozitivul dvs.</string>
-	<string name="carplay_roundabout_exit">%s ieșire</string>
 	<!-- max. 10 symbols, both iOS and Android -->
 	<string name="sort">Sortați…</string>
 	<!-- Android, title, max 20-22 symbols -->
 	<string name="sort_bookmarks">Sortați inscripțiile</string>
-	<!-- iOS -->
-	<string name="sort_default">Sortați la modul implicit</string>
-	<string name="sort_type">Sortați după dip</string>
-	<string name="sort_distance">Sortați după distanță</string>
-	<string name="sort_date">Sortați după dată</string>
 	<!-- Android -->
 	<string name="by_default">Mod implicit</string>
 	<!-- Android -->
@@ -1136,65 +688,23 @@
 	<string name="by_distance">După distanță</string>
 	<!-- Android -->
 	<string name="by_date">După dată</string>
-	<string name="week_ago_sorttype">O săptămână în urmă</string>
-	<string name="month_ago_sorttype">O lună în urmă</string>
-	<string name="moremonth_ago_sorttype">Mai mult de o lună în urmă</string>
-	<string name="moreyear_ago_sorttype">Mai mult de un an în urmă</string>
-	<string name="near_me_sorttype">Alături de mine</string>
-	<string name="others_sorttype">Altele</string>
-	<string name="food_places">Mâncare</string>
-	<string name="tourist_places">Locuri faimoase</string>
-	<string name="museums">Muzeu</string>
-	<string name="parks">Parcuri</string>
-	<string name="swim_places">Înot</string>
-	<string name="mountains">Munți</string>
-	<string name="animals">Animale</string>
-	<string name="hotels">Hoteluri</string>
-	<string name="buildings">Clădiri</string>
-	<string name="money">Bani</string>
-	<string name="shops">Magazine</string>
-	<string name="parkings">Parcări</string>
-	<string name="fuel_places">Benzinării</string>
-	<string name="water">Apă</string>
-	<string name="medicine">Medicină</string>
 	<string name="search_in_the_list">Căutați în listă</string>
-	<string name="view_on_map_bookmarks">Pe hartă</string>
-	<string name="more_bookmarks">Încă…</string>
-	<string name="no_items_found">Nu a fost găsit nimic</string>
-	<!-- Android, max 18 symbols -->
-	<string name="bookmarks_edit_list">Redactați</string>
-	<!-- Android, max 18 symbols -->
-	<string name="bookmarks_delete_list">Ștergeți lista</string>
-	<string name="religious_places">Locuri sfinte</string>
 	<string name="select_list">Alegeți lista</string>
 	<string name="transit_not_found">Navigarea pentru metrou nu este încă disponibilă în această regiune</string>
 	<string name="dialog_pedestrian_route_is_long_header">Ruta metroului nu a fost găsită</string>
 	<string name="dialog_pedestrian_route_is_long_message">Selectați punctul de început sau de sfârșit al rutei mai aproape de stația de metrou</string>
-	<!-- Failed planning SUBWAY route message in navigation view -->
-	<string name="routing_planning_error_subway_special">Eroare la construirea rutei metroului</string>
 	<string name="button_layer_isolines">Înălțimi</string>
-	<string name="tips_map_layers_title_countour">Linii de înălțimi offline pe Organic Maps!</string>
-	<string name="tips_map_layers_message_countour">Liniile de înălțimi vă vor ajuta să planificați o călătorie în natură și să nu vă pierdeți</string>
 	<string name="isolines_activation_error_dialog">Pentru a utiliza liniile de înălțimi, actualizați sau descărcați harta zonei dorite</string>
 	<string name="isolines_location_error_dialog">Liniile de înălțimi pană ce nu sunt disponibile în această regiune</string>
 	<string name="elevation_profile_diff_level">Nivel de dificultate</string>
-	<string name="elevation_profile_diff_level_easy">Ușor</string>
-	<string name="elevation_profile_diff_level_moderate">Mediu</string>
-	<string name="elevation_profile_diff_level_hard">Dificil</string>
 	<string name="elevation_profile_ascent">Urcare</string>
 	<string name="elevation_profile_descent">Coborâre</string>
 	<string name="elevation_profile_minaltitude">Înălțime min.</string>
 	<string name="elevation_profile_maxaltitude">Înălțime max.</string>
-	<string name="elevation_profile_m">m</string>
 	<string name="elevation_profile_difficulty">Dificultate</string>
 	<string name="elevation_profile_distance">Dist.:</string>
-	<string name="elevation_profile_km">km</string>
 	<string name="elevation_profile_time">Timp:</string>
-	<string name="elevation_profile_hours">ore</string>
-	<string name="elevation_profile_minutes">min</string>
 	<string name="isolines_toast_zooms_1_10">Măriți harta pentru a vedea contururile</string>
-	<string name="downloader_updating_ios">Actualizare</string>
-	<string name="downloader_loading_ios">Încărcare</string>
 	<string name="key_information_title">Informații cheie</string>
 	<string name="enable_screen_sleep">Permiteți ecranului să doarmă</string>
 	<!-- Description in preferences -->

--- a/android/res/values-ru/strings.xml
+++ b/android/res/values-ru/strings.xml
@@ -12,15 +12,11 @@
 	<string name="cancel_download">Отменить загрузку</string>
 	<!-- Button which deletes downloaded country -->
 	<string name="delete">Удалить</string>
-	<!-- Button "do not interrupt download" if user touched actively downloading country -->
-	<string name="do_nothing">Продолжить загрузку</string>
 	<string name="download_maps">Загрузить карты</string>
 	<!-- Settings/Downloader - info for country when download fails -->
 	<string name="download_has_failed">Ошибка загрузки. Нажмите, чтобы повторить попытку</string>
 	<!-- Settings/Downloader - info for country which started downloading -->
 	<string name="downloading">Загружается…</string>
-	<!-- Settings/Downloader - size string, only strings different from English should be translated -->
-	<string name="kb">кБ</string>
 	<!-- Choose measurement on first launch alert - choose metric system button -->
 	<string name="kilometres">Километры</string>
 	<!-- Leave Review dialog - Review button -->
@@ -36,45 +32,31 @@
 	<string name="core_my_position">Мое местоположение</string>
 	<!-- Update maps later/Buy pro version later button text -->
 	<string name="later">Не сейчас</string>
-	<!-- Don't show some dialog any more -->
-	<string name="never">Не показывать</string>
 	<!-- View and button titles for accessibility -->
 	<string name="search">Поиск</string>
 	<!-- Search box placeholder text -->
 	<string name="search_map">Поиск на карте</string>
-	<!-- Settings/Downloader - info for not downloaded country -->
-	<string name="touch_to_download">Нажмите для загрузки</string>
 	<!-- Settings/Downloader - 3G download warning dialog confirm button -->
 	<string name="use_cellular_data">Да</string>
 	<!-- Location services are disabled by user alert - message -->
 	<string name="location_is_disabled_long_text">Геолокация выключена в настройках устройства. Пожалуйста, включите её для удобного использования программы.</string>
-	<!-- Location Services are not available on the device alert - message -->
-	<string name="device_doesnot_support_location_services">Ваше устройство не поддерживает геолокацию</string>
 	<!-- View and button titles for accessibility -->
 	<string name="zoom_to_country">Показать на карте</string>
-	<!-- Button text for the button at the center of the screen when the country is not downloaded -->
-	<string name="country_status_download">Загрузить карту\n(^ ^)</string>
 	<!-- Button text for the button at the center of the screen when the country is not downloaded and the size should not be shown -->
 	<string name="country_status_download_without_size">Загрузить карту</string>
-	<!-- Button text for the button at the center of the screen when the country is not downloaded -->
-	<string name="country_status_download_without_routing">Загрузить карту\nбез маршрутов (^ ^)</string>
 	<!-- Message to display at the center of the screen when the country download has failed -->
 	<string name="country_status_download_failed">Ошибка загрузки</string>
 	<!-- Button text for the button under the country_status_download_failed message -->
 	<string name="try_again">Попробуйте еще раз</string>
 	<string name="about_menu_title">О программе</string>
-	<string name="downloaded_touch_to_delete">Загружено (%s), нажмите для удаления</string>
 	<string name="connection_settings">Настройки подключения</string>
-	<string name="download_mb_or_kb">Загрузить %s</string>
 	<string name="close">Закрыть</string>
 	<string name="unsupported_phone">Для работы приложения необходим аппаратно ускоренный OpenGL. К сожалению, ваше устройство не поддерживается.</string>
 	<string name="download">Загрузить</string>
-	<string name="external_storage_is_not_available">Загруженные карты недоступны</string>
 	<string name="disconnect_usb_cable">Отключите USB кабель или вставьте SD-карту</string>
 	<string name="not_enough_free_space_on_sdcard">Недостаточно свободного места на SD карте/в памяти устройства для использования программы</string>
 	<string name="not_enough_memory">Недостаточно памяти для запуска программы</string>
 	<string name="download_resources">Перед началом работы разрешите нам загрузить общую карту мира на ваше устройство.\nЭто потребует %s данных.</string>
-	<string name="getting_position">Получаем местоположение</string>
 	<string name="download_resources_continue">Перейти на карту</string>
 	<string name="downloading_country_can_proceed">Пока загружается %s,\nвы можете пользоваться картой.</string>
 	<string name="download_country_ask">Загрузить %s?</string>
@@ -87,30 +69,20 @@
 	<string name="download_country_failed">Не удалось загрузить %s</string>
 	<!-- Add New Bookmark Set dialog title -->
 	<string name="add_new_set">Добавить группу</string>
-	<!-- Place Page - Add To Bookmarks button -->
-	<string name="add_to_bookmarks">Сохранить метку</string>
 	<!-- Bookmark Color dialog title -->
 	<string name="bookmark_color">Цвет метки</string>
 	<!-- Add Bookmark Set dialog - hint when set name is empty -->
 	<string name="bookmark_set_name">Название группы</string>
-	<!-- Bookmark Sets dialog title -->
-	<string name="bookmark_sets">Группы меток</string>
 	<!-- Bookmarks - dialog title -->
 	<string name="bookmarks">Метки</string>
-	<!-- Add bookmark dialog - bookmark color -->
-	<string name="color">Цвет</string>
 	<!-- Default bookmarks set name -->
 	<string name="core_my_places">Мои Метки</string>
 	<!-- Add bookmark dialog - bookmark name -->
 	<string name="name">Название</string>
 	<!-- Editor title above street and house number -->
 	<string name="address">Адрес</string>
-	<!-- Place Page - Remove Pin button -->
-	<string name="remove_pin">Удалить метку</string>
 	<!-- Add bookmark dialog - bookmark set, Bookmarks dialog - Bookmark set cell -->
 	<string name="set">Группа</string>
-	<!-- Text hint in Bookmarks dialog when no any bookmarks are added -->
-	<string name="bookmarks_usage_hint">У вас пока нет меток.\nВыберите любое место на карте, чтобы добавить его.\nТакже метки можно импортировать из Organic Maps либо других приложений и сайтов. Для этого откройте KML/KMZ файл из Dropbox, почты или по веб-ссылке.</string>
 	<!-- Settings button in system menu -->
 	<string name="settings">Настройки</string>
 	<!-- Header of settings activity where user defines storage path -->
@@ -121,20 +93,10 @@
 	<string name="move_maps">Переместить карты?</string>
 	<!-- Ask to wait user several minutes (some long process in modal dialog). -->
 	<string name="wait_several_minutes">Это может занять несколько минут.\nПожалуйста, подождите…</string>
-	<!-- Show bookmarks from this category on a map or not -->
-	<string name="visible">Показывать на карте</string>
-	<!-- Toast which is displayed when GPS has been deactivated -->
-	<string name="gps_is_disabled_long_text">GPS-позиционирование выключено. Пожалуйста, включите его в настройках для удобного использования программы.</string>
 	<!-- Measurement units title in settings activity -->
 	<string name="measurement_units">Единицы измерения</string>
 	<!-- Detailed description of Measurement Units settings button -->
 	<string name="measurement_units_summary">Использовать километры или мили</string>
-	<!-- Do search in all sources -->
-	<string name="search_mode_all">Везде</string>
-	<!-- Do search near my position only -->
-	<string name="search_mode_nearme">Возле меня</string>
-	<!-- Do search in current viewport only -->
-	<string name="search_mode_viewport">На экране</string>
 	<!-- Search category for cafes, bars, restaurants -->
 	<string name="eat">Где поесть</string>
 	<!-- Search category for grocery stores -->
@@ -171,12 +133,8 @@
 	<string name="post">Почта</string>
 	<!-- Search category -->
 	<string name="police">Полиция</string>
-	<!-- String in search result list, when nothing found -->
-	<string name="no_search_results_found">Нет результатов поиска</string>
 	<!-- Notes field in Bookmarks view -->
 	<string name="description">Примечание</string>
-	<!-- Button text -->
-	<string name="share_by_email">Послать по email</string>
 	<!-- Email Subject when sharing bookmarks category -->
 	<string name="share_bookmarks_email_subject">С вами поделились метками Organic Maps</string>
 	<string name="share_bookmarks_email_body">Здравствуйте!\n\nВ прикрепленном файле мои метки из офлайновых карт Organic Maps. Для того чтобы открыть этот файл, вам потребуется приложение Organic Maps, которое можно установить по ссылке: https://omaps.app/get?kmz\n\nСпасибо!</string>
@@ -190,20 +148,10 @@
 	<string name="edit">Редактировать</string>
 	<!-- Warning message when doing search around current position -->
 	<string name="unknown_current_position">Ваше местоположение еще не определено</string>
-	<!-- Warning message when location country isn't downloaded during search (see also download_location_map_proposal). -->
-	<string name="download_location_country">Скачайте страну вашего текущего местоположения (%s)</string>
-	<!-- Warning message when viewport country isn't downloaded during search -->
-	<string name="download_viewport_country_to_search">Скачайте страну, на которой вы ищете (%s)</string>
 	<!-- Alert message that we can't run Map Storage settings due to some reasons. -->
 	<string name="cant_change_this_setting">Извините, настройки места хранения карт сейчас недоступны.</string>
 	<!-- Alert message that downloading is in progress. -->
 	<string name="downloading_is_active">Идет процесс загрузки карт.</string>
-	<!-- Message that will be shown in alert view, when we ask user to leave review on App Store -->
-	<string name="appStore_message">Надеемся, вам нравится пользоваться Organic Maps! Если так, то оставьте, пожалуйста, отзыв в магазине приложений. Это занимает меньше минуты, но может нам реально помочь. Спасибо вам за поддержку!</string>
-	<!-- No, thanks -->
-	<string name="no_thanks">Нет, спасибо</string>
-	<!-- Share one specific bookmark using SMS, %1$@ contains om:// and %2$@ https://omaps.app link. @NOTE non-ascii symbols in the link will result in max 70 characters SMS instead of 140. -->
-	<string name="bookmark_share_sms">Моя метка на карте. Жми %1$s или %2$s</string>
 	<!-- Share my position using SMS, %1$@ contains om:// and %2$@ https://omaps.app link WITHOUT NAME. @NOTE non-ascii symbols in the link will result in max 70 characters SMS instead of 140. -->
 	<string name="my_position_share_sms">Смотри где я сейчас. Жми %1$s или %2$s</string>
 	<!-- Subject for emailed bookmark -->
@@ -212,30 +160,16 @@
 	<string name="my_position_share_email_subject">Посмотри на карте Organic Maps, где я сейчас нахожусь</string>
 	<!-- Share my position using EMail, %1$@ is om:// and %2$@ is https://omaps.app link WITHOUT NAME -->
 	<string name="my_position_share_email">Привет!\n\nЯ сейчас здесь: %1$s. Чтобы увидеть это место на карте Organic Maps, открой эту ссылку %2$s или эту %3$s\n\nСпасибо.</string>
-	<!-- Android share by Message/SMS button text (including SMS) -->
-	<string name="share_by_message">Отправить сообщением</string>
 	<!-- Share button text which opens menu with more buttons, like Message, EMail, Facebook etc. -->
 	<string name="share">Поделиться</string>
-	<!-- iOS share by Message button text (including SMS) -->
-	<string name="message">Сообщение</string>
 	<!-- Share by email button text, also used in editor. -->
 	<string name="email">Email</string>
-	<!-- Copy Link -->
-	<string name="copy_link">Скопировать ссылку</string>
-	<!-- Text for the button that returns to caller application -->
-	<string name="more_info">Подробнее</string>
 	<!-- Text for message when used successfully copied something -->
 	<string name="copied_to_clipboard">Скопировано в буфер обмена: %1$s</string>
 	<!-- place preview title -->
 	<string name="info">Информация</string>
 	<!-- Used for bookmark editing -->
 	<string name="done">Готово</string>
-	<!-- Summary for preferences in MWM -->
-	<string name="yopme_pref_summary">Выберите настройки второго экрана</string>
-	<!-- Title for yopme preferences in MWM -->
-	<string name="yopme_pref_title">Настройки второго экрана</string>
-	<!-- Hint for upper-right icon p2b -->
-	<string name="show_on_backscreen">Показать на втором экране</string>
 	<!-- Prints version number in About dialog -->
 	<string name="version">Версия: %s</string>
 	<!-- Data version in «About» screen -->
@@ -247,15 +181,10 @@
 	<!-- Length of track in cell that describes route -->
 	<string name="length">Длина</string>
 	<string name="share_my_location">Поделиться местоположением</string>
-	<string name="menu_search">Поиск</string>
 	<!-- Settings general group in settings screen -->
 	<string name="prefs_group_general">Общие настройки</string>
 	<!-- Settings information group in settings screen -->
 	<string name="prefs_group_information">Информация</string>
-	<!-- Settings screen: "Map" category title -->
-	<string name="prefs_group_map">Карта</string>
-	<!-- Settings screen: "Miscellaneous" category title -->
-	<string name="prefs_group_misc">Прочее</string>
 	<string name="prefs_group_route">Навигация</string>
 	<string name="pref_zoom_title">Кнопки масштаба</string>
 	<string name="pref_zoom_summary">Показать на карте</string>
@@ -271,8 +200,6 @@
 	<string name="pref_map_3d_title">Перспективный вид</string>
 	<!-- Settings «Map» category: «3D buildings» title -->
 	<string name="pref_map_3d_buildings_title">3D здания</string>
-	<!-- Settings «Map» category: «3D buildings» summary -->
-	<string name="pref_map_3d_buildings_subtitle">Увеличивает расход батареи</string>
 	<!-- Settings «Route» category: «Tts enabled» title -->
 	<string name="pref_tts_enable_title">Голосовые инструкции</string>
 	<!-- Settings «Route» category: «Tts language» title -->
@@ -281,7 +208,6 @@
 	<string name="pref_tts_unavailable">Не доступны</string>
 	<!-- Title for "Other" section in TTS settings. -->
 	<string name="pref_tts_other_section_title">Другой</string>
-	<string name="pref_tts_how_to_set_up_voice">Как настроить голос</string>
 	<!-- Settings «Map» category: «Record track» title -->
 	<string name="pref_track_record_title">Недавний путь</string>
 	<string name="pref_map_auto_zoom">Автозум</string>
@@ -292,46 +218,11 @@
 	<string name="duration_12_hours">12 часов</string>
 	<string name="duration_1_day">1 сутки</string>
 	<string name="recent_track_help_text">Эта функция позволяет записывать пройденный путь за определенный период времени и видеть его на карте. Внимание: активация этой функции может привести к повышенному расходу батареи. Записанный трек будет удален с карты по истечении этого срока.</string>
-	<string name="pref_track_ios_caption">История пути покажет недавно пройденный маршрут.</string>
-	<string name="pref_track_ios_subcaption">Выберите длительность записи истории.</string>
-	<string name="placepage_distance">Расстояние</string>
-	<string name="placepage_coordinates">Координаты</string>
-	<string name="placepage_unsorted">Без категории</string>
 	<string name="search_show_on_map">Посмотреть на карте</string>
-	<!-- Used to warn user when fixing KitKat issue -->
-	<string name="bookmark_move_fail">Для оптимизации хранения данных нам нужно переместить метки во внутреннюю память, но там сейчас нет свободного места. Пожалуйста, освободите место, иначе метки вам будут недоступны.</string>
-	<!-- Used in More Apps menu -->
-	<string name="free">Бесплатно</string>
-	<!-- Used in More Apps menu -->
-	<string name="buy">Купить</string>
-	<!-- 1st search button-like result -->
-	<string name="search_on_map">Искать на карте</string>
-	<!-- toast with an error -->
-	<string name="no_route_found">Маршрут не найден</string>
-	<!-- route title -->
-	<string name="route">Маршрут</string>
-	<!-- category title -->
-	<string name="routes">Маршруты</string>
-	<!-- text of notification -->
-	<string name="download_map_notification">Скачайте карту места, где вы находитесь</string>
-	<!-- text of notification -->
-	<string name="pro_version_is_free_today">Полная версия Organic Maps сегодня бесплатна! Скачай сейчас и расскажи друзьям.</string>
-	<!-- Dialog for transferring maps from lite to pro. -->
-	<string name="move_lite_maps_to_pro">Мы переносим загруженные карты из Organic Maps Lite в Organic Maps. Это может занять несколько минут.</string>
-	<!-- Message to display when maps moved. -->
-	<string name="move_lite_maps_to_pro_ok">Ваши карты успешно перенесены в Organic Maps.</string>
-	<!-- Message to display when maps move failed. -->
-	<string name="move_lite_maps_to_pro_failed">При переносе карт возникла ошибка. Пожалуйста, удалите Organic Maps Lite и загрузите карты заново.</string>
-	<!-- Text in menu -->
-	<string name="settings_and_more">Настройки и другое</string>
 	<!-- Text in menu -->
 	<string name="website">Вебсайт</string>
-	<!-- Text in menu -->
-	<string name="contact_us">Свяжитесь с нами</string>
 	<!-- Settings: Send feedback button and dialog title -->
 	<string name="feedback">Связаться с нами</string>
-	<!-- Text in menu -->
-	<string name="subscribe_to_news">Подписаться на новости</string>
 	<!-- Text in menu -->
 	<string name="rate_the_app">Оценить приложение</string>
 	<!-- Text in menu -->
@@ -340,12 +231,6 @@
 	<string name="copyright">Копирайт</string>
 	<!-- Text in menu -->
 	<string name="report_a_bug">Сообщить о проблеме</string>
-	<!-- Email subject -->
-	<string name="subscribe_me_subject">Подпишите меня на email-рассылку Organic Maps</string>
-	<!-- Email body -->
-	<string name="subscribe_me_body">Я хочу первым узнавать обо всех новостях, обновлениях приложения и акциях. Я могу отписаться от рассылки в любой момент.</string>
-	<!-- About text -->
-	<string name="about_text">Organic Maps предлагает карты всех городов, всех стран мира, которые работают без подключения к интернету. Путешествуйте с уверенностью: где бы вы ни находились, Organic Maps помогут решить любую вашу проблему - помогут определить ваше местоположение, найти ресторан, отель, заправку, банк, туалет и т.д.\n\nМы постоянно работаем над добавлением новых функций, поэтому если у вас есть идеи или предложения по улучшению Organic Maps, пишите нам. Если у вас возникла проблема с приложением, сообщите нам, пожалуйста, о ней. Наш емэйл support\@organicmaps.app. Мы отвечаем на все письма! Если вам нравится приложение и вы хотите поддержать нас, есть несколько простых и абсолютно бесплатных способов:\n\n- оставьте отзыв в вашем магазине приложений\n- подпишитесь на наши новости на Facebook странице http://www.facebook.com/OrganicMaps\n- или просто расскажите о Organic Maps своей маме, друзьям и коллегам :)\n\nСпасибо за вашу поддержку!\n\nP.S. В приложении мы используем картографические данные проекта OpenStreetMap, который работает по принципу Википедии, давая возможность пользователям со всего мира создавать и редактировать карты. Если вы заметили, что на карте что-то не соответствует действительности либо отсутствует, вы можете откорректировать это прямо на сайте https://www.openstreetmap.org, и эти исправления появятся во время следующего обновления Organic Maps.</string>
 	<!-- Alert text -->
 	<string name="email_error_body">Почтовый клиент не настроен. Настройте его или используйте другие способы для связи. Наш адрес - %s.</string>
 	<!-- Alert title -->
@@ -354,137 +239,56 @@
 	<string name="pref_calibration_title">Калибровка компаса</string>
 	<!-- Search category -->
 	<string name="wifi">WiFi</string>
-	<!-- Update map suggestion -->
-	<string name="routing_map_outdated">Пожалуйста, обновите карту для того, чтобы проложить маршрут.</string>
-	<!-- Update maps suggestion -->
-	<string name="routing_update_maps">В новой версии Organic Maps вы сможете строить маршруты от текущего местоположения до точки назначения. Чтобы воспользоваться этой функцией, обновите, пожалуйста, карты.</string>
 	<!-- Update all button text -->
 	<string name="downloader_update_all_button">Обновить все</string>
 	<!-- Cancel all button text -->
 	<string name="downloader_cancel_all">Отменить все</string>
 	<!-- Downloaded maps category -->
 	<string name="downloader_downloaded_subtitle">Загруженные</string>
-	<!-- Downloaded maps category -->
-	<string name="downloader_available_maps">Доступные</string>
 	<!-- Country queued for download -->
 	<string name="downloader_queued">В очереди</string>
 	<string name="downloader_near_me_subtitle">Возле меня</string>
 	<string name="downloader_status_maps">Карт</string>
 	<string name="downloader_download_all_button">Загрузить все</string>
 	<string name="downloader_downloading">Загружается:</string>
-	<string name="downloader_search_results">Найдено</string>
-	<!-- Disclaimer message -->
-	<string name="routing_disclaimer">Используя маршруты в приложении Organic Maps, пожалуйста, учитывайте следующее:\n\n  - Предлагаемые маршруты могут рассматриваться только в качестве рекомендации.\n - Дорожная обстановка, правила дорожного движения, знаки являются более приоритетными по сравнению с советами навигационной программы.\n - Карта может быть неточной или неактуальной, а предложенный маршрут не самым оптимальным.\n\n  Будьте внимательны на дорогах и берегите себя!</string>
-	<!-- Outdated maps category -->
-	<string name="downloader_outdated_maps">Неактуальные</string>
-	<!-- Up to date maps category -->
-	<string name="downloader_uptodate_maps">Обновленные</string>
 	<!-- Status of outdated country in the list -->
 	<string name="downloader_status_outdated">Обновить</string>
 	<!-- Status of failed country in the list -->
 	<string name="downloader_status_failed">Ошибка</string>
 	<!-- Displayed in a dialog that appears when a user tries to delete a map while the app is in the follow route mode -->
 	<string name="downloader_delete_map_while_routing_dialog">Чтобы удалить карту, пожалуйста, остановите навигацию.</string>
-	<!-- Show when user try build route, but we don't know where he -->
-	<string name="routing_failed_unknown_my_position">Невозможно проложить маршрут. Не определено текущее местоположение.</string>
-	<!-- Show if use has not routing file, or InconsistentMWMandRoute -->
-	<string name="routing_failed_has_no_routing_file">Для построения маршрута необходимы дополнительные данные. Перейти к загрузке?</string>
-	<!-- StartPointNotFound -->
-	<string name="routing_failed_start_point_not_found">Невозможно проложить маршрут. Нет дорог рядом с пунктом отправления.</string>
-	<!-- EndPointNotFound -->
-	<string name="routing_failed_dst_point_not_found">Невозможно проложить маршрут. Нет дорог рядом с пунктом назначения.</string>
 	<!-- PointsInDifferentMWM -->
 	<string name="routing_failed_cross_mwm_building">Маршрут может быть проложен только внутри карты одного региона.</string>
-	<!-- RouteNotFound -->
-	<string name="routing_failed_route_not_found">Невозможно проложить маршрут между выбранными точками. Пожалуйста, измените начало или конец маршрута.</string>
-	<!-- InternalError -->
-	<string name="routing_failed_internal_error">Внутренняя ошибка. Пожалуйста, удалите карту и скачайте её еще раз. Если это не помогло, напишите нам на support\@organicmaps.app</string>
-	<!-- Context menu item for downloader. -->
-	<string name="downloader_download_map_and_routing">Загрузить карту + маршруты</string>
-	<!-- Context menu item for downloader. -->
-	<string name="downloader_download_routing">Загрузить маршруты</string>
-	<!-- Context menu item for downloader. -->
-	<string name="downloader_delete_routing">Удалить маршруты</string>
 	<!-- Context menu item for downloader. -->
 	<string name="downloader_download_map">Загрузить карту</string>
-	<string name="downloader_download_map_no_routing">Загрузить карту без маршрутов</string>
-	<!-- Button for routing. -->
-	<string name="routing_go">Поехали!</string>
 	<!-- Item status in downloader. -->
 	<string name="downloader_retry">Повторить</string>
-	<!-- Item in context menu. -->
-	<string name="downloader_map_and_routing">Карта + Маршруты</string>
 	<!-- Item in context menu. -->
 	<string name="downloader_delete_map">Удалить карту</string>
 	<!-- Item in context menu. -->
 	<string name="downloader_update_map">Обновить карту</string>
-	<!-- Item in context menu. -->
-	<string name="downloader_update_map_and_routing">Обновить карту + Маршруты</string>
-	<!-- Item in context menu. -->
-	<string name="downloader_map_only">Только карта</string>
-	<!-- Toolbar title -->
-	<string name="toolbar_application_menu">Меню приложения</string>
 	<!-- Preference text -->
 	<string name="pref_use_google_play">Использовать Google Play Services для определения позиции</string>
 	<!-- Text for rating dialog -->
 	<string name="rating_just_rated">Я только что оценил Organic Maps</string>
-	<!-- Text for rating dialog -->
-	<string name="rating_user_since">Я пользуюсь Organic Maps c %s</string>
-	<!-- Text for rating dialog -->
-	<string name="rating_do_like_maps">Нравится приложение?</string>
-	<!-- Text for rating dialog -->
-	<string name="rating_tap_star">Оцените Organic Maps.</string>
 	<!-- Text for rating dialog -->
 	<string name="rating_thanks">Спасибо!</string>
 	<!-- Text for rating dialog -->
 	<string name="rating_share_ideas">Что-то не так?  Расскажите, что бы мы могли исправить или улучшить в приложении.</string>
 	<!-- Text for rating dialog -->
 	<string name="rating_send_feedback">Напишите нам</string>
-	<!-- Text for g+ dialog -->
-	<string name="rating_google_plus">Нажмите g+, чтобы рассказать друзьям о приложении</string>
 	<!-- Text for routing error dialog -->
 	<string name="routing_download_maps_along">Загрузите все карты по пути следования</string>
-	<!-- Text for routing error dialog -->
-	<string name="routing_download_map">Загрузите карту</string>
-	<!-- Text for routing error dialog -->
-	<string name="routing_download_map_and_routing">Загрузите карту и маршруты, чтобы получить доступ ко всем возможностям приложения.</string>
-	<!-- Text for routing error dialog -->
-	<string name="routing_get_routing_data">Загрузите маршруты</string>
-	<!-- Text for routing error dialog -->
-	<string name="routing_get_additional_data">Загрузите данные для построения маршрутов</string>
 	<!-- Text for routing error dialog -->
 	<string name="routing_requires_all_map">Для создания маршрута необходимо загрузить и обновить все карты на пути следования.</string>
 	<!-- Text for routing error dialog -->
 	<string name="routing_not_enough_space">Недостаточно места</string>
-	<!-- Text for routing error dialog -->
-	<string name="routing_download_more_than_avail">Необходимо загрузить %1$s МБ, но есть место только для %2$s МБ</string>
-	<!-- Text for routing error dialog -->
-	<string name="routing_download_roaming">Будет загружено %s MB с использованием сотовой связи (мобильный интернет). В зависимости от тарифного плана оператора это может повлечь списание значительной суммы с телефонного счета</string>
 	<!-- bookmark button text -->
 	<string name="bookmark">метка</string>
-	<!-- map is not downloaded -->
-	<string name="not_found_map">Карта вашего местоположения не загружена</string>
 	<!-- location service disabled -->
 	<string name="enable_location_services">Пожалуйста, включите геолокацию</string>
-	<!-- download map -->
-	<string name="download_map">Скачайте карту места, где вы находитесь</string>
-	<!-- download map on iPhone -->
-	<string name="download_map_iphone">Скачайте на вашем iPhone карту места, где вы находитесь</string>
-	<!-- clear pin -->
-	<string name="nearby">поблизости</string>
-	<!-- clear pin -->
-	<string name="clear_pin">убрать метку</string>
-	<!-- location is undefined -->
-	<string name="undefined_location">Не определено текущее местоположение.</string>
-	<!-- download country of your location -->
-	<string name="download_country">Скачайте страну вашего местоположения</string>
-	<!-- download failed -->
-	<string name="download_failed">Не удалось загрузить</string>
-	<!-- get the map -->
-	<string name="get_the_map">Загрузить карту</string>
 	<string name="save">Сохранить</string>
 	<string name="edit_description_hint">Ваше описание (текст или html)</string>
-	<string name="new_group">новая группа</string>
 	<string name="create">создать</string>
 	<!-- red color -->
 	<string name="red">Красный</string>
@@ -502,22 +306,6 @@
 	<string name="brown">Коричневый</string>
 	<!-- pink color -->
 	<string name="pink">Розовый</string>
-	<!-- deep purple color -->
-	<string name="deep_purple">Тёмно-пурпурный</string>
-	<!-- light blue color -->
-	<string name="light_blue">Голубой</string>
-	<!-- cyan color -->
-	<string name="cyan">Сине-зелёный</string>
-	<!-- teal color -->
-	<string name="teal">Изумрудный</string>
-	<!-- lime color -->
-	<string name="lime">Лайм</string>
-	<!-- deep orange color -->
-	<string name="deep_orange">Тёмно-оранжевый</string>
-	<!-- gray color -->
-	<string name="gray">Серый</string>
-	<!-- blue gray color -->
-	<string name="blue_gray">Серо-голубой</string>
 	<!-- Wi-Fi available -->
 	<string name="WiFi_available">Есть</string>
 
@@ -533,10 +321,8 @@
 	<string name="dialog_routing_location_turn_wifi">Пожалуйста, проверьте сигнал GPS. Для улучшения точности геопозиции включите Wi-Fi.</string>
 	<string name="dialog_routing_location_turn_on">Включите режим определения геопозиции</string>
 	<string name="dialog_routing_location_unknown_turn_on">Текущая геопозиция не определена. Для построения маршрута включите режим определения геопозиции.</string>
-	<string name="dialog_routing_location_unknown">Текущая геопозиция не определена.</string>
 	<string name="dialog_routing_download_files">Загрузите необходимые файлы</string>
 	<string name="dialog_routing_download_and_update_all">Для построения маршрута загрузите и обновите все карты и файлы маршрутов по пути следования.</string>
-	<string name="dialog_routing_routes_size">Файлы маршрутов</string>
 	<string name="dialog_routing_unable_locate_route">Маршрут не найден</string>
 	<string name="dialog_routing_cant_build_route">Не получилось построить маршрут.</string>
 	<string name="dialog_routing_change_start_or_end">Пожалуйста, измените начальную или конечную точку маршрута.</string>
@@ -551,33 +337,23 @@
 	<string name="dialog_routing_system_error">Системная ошибка</string>
 	<string name="dialog_routing_application_error">Не удалось проложить маршрут из-за ошибки приложения.</string>
 	<string name="dialog_routing_try_again">Попробуйте снова</string>
-	<string name="dialog_routing_send_error">Сообщить об ошибке</string>
-	<string name="dialog_routing_if_get_cross_route">Построить более оптимальный маршрут с пересечением границы карты?</string>
-	<string name="dialog_routing_cross_route_is_optimal">Маршрут с пересечением границы карты более оптимальный.</string>
 	<string name="not_now">Не сейчас</string>
-	<string name="dialog_routing_build_route">Построить</string>
 	<string name="dialog_routing_download_and_build_cross_route">Загрузить карту и построить более оптимальный маршрут с пересечением границы карты?</string>
 	<string name="dialog_routing_download_cross_route">Для построения более оптимального маршрута с пересечением границы требуется загрузить карту.</string>
-	<string name="dialog_routing_cross_route_always">Всегда пересекать эту границу</string>
 
 	<!-- SECTION: Strings for downloading map from search -->
 	<string name="search_without_internet_advertisement">Для поиска мест и построения маршрутов скачайте карту, и интернет вам больше не понадобится.</string>
 	<string name="search_select_map">Выбрать карту</string>
-	<string name="search_select_other_map">Выбрать другую карту</string>
 	<!-- «Show» context menu -->
 	<string name="show">Показать</string>
 	<!-- «Hide» context menu -->
 	<string name="hide">Скрыть</string>
 	<!-- «Rename» context menu -->
 	<string name="rename">Переименовать</string>
-	<!-- Bottom sheet: expand button (should be short) -->
-	<string name="bottom_sheet_more">Ещё…</string>
 	<!-- Failed planning route message in navigation view -->
 	<string name="routing_planning_error">Ошибка построения маршрута</string>
 	<!-- Arrive routing message in navigation view -->
 	<string name="routing_arrive">Прибытие в %s</string>
-	<!-- Text for routing::RouterResultCode::FileTooOld dialog. -->
-	<string name="dialog_routing_download_and_update_maps">Для построения маршрута загрузите и обновите все карты по пути следования.</string>
 	<string name="rate_alert_title">Нравится приложение?</string>
 	<string name="rate_alert_default_message">Спасибо что пользуетесь картами Organic Maps. Пожалуйста, оцените приложение. Ваши оценки и отзывы помогают нам становиться лучше.</string>
 	<string name="rate_alert_five_star_message">Ура! Мы вас тоже любим!</string>
@@ -585,24 +361,14 @@
 	<string name="rate_alert_less_than_four_star_message">Расскажите, что мы могли бы улучшить?</string>
 	<string name="categories">Категории</string>
 	<string name="history">История</string>
-	<string name="next_turn_then">Далее</string>
 	<string name="closed">Закрыто</string>
-	<string name="back_to">Назад к %s</string>
 	<string name="search_not_found">К сожалению, мы ничего не нашли.</string>
 	<string name="search_not_found_query">Попробуйте изменить условия поиска.</string>
-	<string name="search_not_found_map">Убедитесь, что карта области поиска загружена.</string>
-	<string name="search_not_found_location">Скачайте карту текущего местоположения.</string>
 	<string name="search_history_title">История поиска</string>
 	<string name="search_history_text">Быстрый доступ к последним поисковым запросам.</string>
 	<string name="clear_search">Очистить историю поиска</string>
-	<!-- Title for settings to enable/disable showcase menu button -->
-	<string name="showcase_settings_title">Показывать предложения</string>
-	<string name="p2p_route_planning">Планирование маршрута</string>
 	<string name="p2p_your_location">Ваше местоположение</string>
-	<string name="p2p_from">Пункт отправления</string>
-	<string name="p2p_to">Пункт назначения</string>
 	<string name="p2p_start">Начать</string>
-	<string name="p2p_planning">Планируем…</string>
 	<string name="p2p_from_here">Отсюда</string>
 	<string name="p2p_to_here">Сюда</string>
 	<string name="p2p_only_from_current">Навигация возможна только из текущего местоположения.</string>
@@ -622,11 +388,8 @@
 	<string name="editor_hours_closed">Перерыв</string>
 	<string name="editor_example_values">Примеры значений</string>
 	<string name="editor_correct_mistake">Исправьте ошибку</string>
-	<string name="editor_correct_mistake_message">При редактировании времени работы вы допустили ошибку. Исправьте её или переключитесь в простой режим.</string>
 	<string name="editor_add_select_location">Местоположение</string>
 	<string name="editor_done_dialog_1">Вы изменили карту мира. Не скрывайте это, расскажите друзьям и редактируйте вместе.</string>
-	<string name="editor_done_dialog_2">Вы улучшили карту уже два раза. Вы теперь %d в рейтинге редакторов карты. Расскажите друзьям.</string>
-	<string name="editor_done_dialog_3">Вы улучшили карту, расскажите об этом друзьям и редактируйте карту вместе.</string>
 	<string name="share_with_friends">Поделиться с друзьями</string>
 	<string name="editor_report_problem_desription_1">Пожалуйста, напишите подробно о проблеме, чтобы сообщество OpenStreetMap исправило ошибку.</string>
 	<string name="editor_report_problem_desription_2">Или сделайте это самостоятельно на сайте https://www.openstreetmap.org/</string>
@@ -635,14 +398,7 @@
 	<string name="editor_report_problem_no_place_title">Места не существует</string>
 	<string name="editor_report_problem_under_construction_title">Закрыто на ремонт</string>
 	<string name="editor_report_problem_duplicate_place_title">Повторяющееся место</string>
-	<string name="first_launch_congrats_title">Organic Maps готов к работе</string>
-	<string name="first_launch_congrats_text">Пользуйтесь поиском и навигацией по всему миру без интернета и бесплатно.</string>
-	<string name="migrate_title">Важно!</string>
-	<!-- Android uses image instead of text. -->
-	<string name="download_all">Загрузить все</string>
-	<string name="delete_all">Удалить все</string>
 	<string name="autodownload">Автоматическая загрузка</string>
-	<string name="disable_autodownload">Запретить автозагрузку</string>
 	<!-- Place Page opening hours text -->
 	<string name="closed_now">Сейчас закрыто</string>
 	<!-- Place Page opening hours text -->
@@ -651,8 +407,6 @@
 	<string name="day_off_today">Сегодня закрыто</string>
 	<string name="day_off">Закрыто</string>
 	<string name="today">Сегодня</string>
-	<string name="sunrise_to_sunset">От рассвета до заката</string>
-	<string name="sunset_to_sunrise">От заката до рассвета</string>
 	<string name="add_opening_hours">Добавить время работы</string>
 	<string name="edit_opening_hours">Редактировать время работы</string>
 	<string name="no_osm_account">Не зарегистрированы в OpenStreetMap?</string>
@@ -662,29 +416,13 @@
 	<string name="login">Войти</string>
 	<string name="password">Пароль</string>
 	<string name="forgot_password">Забыли пароль?</string>
-	<!-- Forgot Password dialog title -->
-	<string name="restore_password">Восстановление пароля</string>
-	<string name="enter_email_address_to_reset_password">Введите почтовый ящик, который вы использовали для регистрации, и мы вышлем на него ссылку для сброса пароля.</string>
-	<string name="reset_password">Cбросить пароль</string>
-	<string name="username">Имя пользователя</string>
 	<string name="osm_account">OSM Аккаунт</string>
 	<string name="logout">Выйти</string>
-	<string name="login_and_edit_map_motivation_message">Авторизуйтесь и редактируйте информацию об объектах на карте. А мы сделаем её доступной для миллионов пользователей. Улучшим мир вместе!</string>
 	<!-- Information text: "Last upload 11.01.2016" -->
 	<string name="last_upload">Последняя отправка</string>
-	<!-- Motivates user to login/register, title above login buttons. -->
-	<string name="you_have_edited_your_first_object">Вы отредактировали свой первый объект!</string>
 	<string name="thank_you">Спасибо</string>
-	<string name="login_with_google">Войти через Google</string>
-	<string name="login_with_openstreetmap">Войти через www.openstreetmap.org</string>
 	<string name="edit_place">Редактировать место</string>
 	<string name="place_name">Название</string>
-	<!-- title above languages list cells in the editor, below editable name text field. -->
-	<string name="other_languages">Другие языки</string>
-	<!-- small button to open list with names in different languages -->
-	<string name="show_more">Показать больше</string>
-	<!-- small button to close list with names in different languages -->
-	<string name="show_less">Показать меньше</string>
 	<string name="add_language">Добавить язык</string>
 	<string name="street">Улица</string>
 	<!-- Editable House Number text field (in address block). -->
@@ -701,25 +439,16 @@
 	<string name="email_or_username">Эл. почта или имя пользователя</string>
 	<string name="phone">Телефон</string>
 	<string name="please_note">Обратите внимание</string>
-	<string name="common_no_wifi_dialog">Нет WiFi соединения. Вы хотите продолжить работу через мобильный интернет?</string>
 	<string name="downloader_delete_map_dialog">Вместе с картой удалятся и внесенные вами правки на этой карте.</string>
 	<string name="downloader_update_maps">Обновите карты</string>
 	<string name="downloader_mwm_migration_dialog">Для построения маршрутов необходимо обновить все карты и построить маршрут заново.</string>
 	<string name="downloader_search_field_hint">Найти карту</string>
-	<string name="migration_update_all_button">Обновить все карты</string>
-	<string name="migration_delete_all_download_current_button">Скачать текущую и удалить все старые карты</string>
 	<string name="migration_download_error_dialog">Ошибка загрузки</string>
 	<string name="common_check_internet_connection_dialog">Проверьте настройки и убедитесь, что устройство подключено к интернету.</string>
 	<string name="downloader_no_space_title">Недостаточно места</string>
 	<string name="downloader_no_space_message">Удалите ненужные данные</string>
-	<string name="editor_general_auth_error_dialog">Общая ошибка авторизации.</string>
 	<string name="editor_login_error_dialog">Произошла ошибка при авторизации.</string>
-	<string name="editor_login_failed_dialog">Войти не удалось</string>
-	<string name="editor_username_error_dialog">Неверное имя пользователя</string>
-	<string name="editor_place_edited_dialog">Вы отредактировали объект!</string>
-	<string name="editor_login_with_osm">Войти через OpenStreetMap</string>
 	<string name="editor_profile_changes">Учтённые правки</string>
-	<string name="editor_profile_unsent_changes">Не отправлено:</string>
 	<string name="editor_focus_map_on_location">Потяните карту, чтобы выбрать правильное местоположение объекта.</string>
 	<string name="editor_add_select_category">Выбрать категорию</string>
 	<string name="editor_add_select_category_popular_subtitle">Популярные</string>
@@ -730,19 +459,14 @@
 	<string name="editor_edit_place_category_title">Категория</string>
 	<string name="detailed_problem_description">Подробное описание проблемы</string>
 	<string name="editor_report_problem_other_title">Другая проблема</string>
-	<string name="placepage_report_problem_button">Сообщить о проблеме</string>
 	<string name="placepage_add_business_button">Добавить организацию</string>
 	<string name="whatsnew_editor_message_1">Добавляйте новые объекты и редактируйте старые прямо из приложения.</string>
-	<string name="whatsnew_editor_message_2">* Organic Maps использует данные открытых карт сообщества OpenStreetMap.</string>
 	<string name="dialog_incorrect_feature_position">Измените местоположение</string>
 	<string name="message_invalid_feature_position">Объект не может находиться в этом месте</string>
 	<string name="login_to_make_edits_visible">Войдите, чтобы ваши изменения увидели другие пользователи.</string>
-	<string name="no_migration_during_navigation">Во время навигации обновление запрещено.</string>
 	<!-- Error dialog no space -->
 	<string name="migration_no_space_message">Для загрузки требуется больше свободного места. Пожалуйста, удалите ненужные данные.</string>
 	<string name="editor_sharing_title">Я улучшил карты Organic Maps</string>
-	<string name="editor_comment_will_be_sent">Мы обязательно отправим ваш комментарий картографам.</string>
-	<string name="editor_unsupported_category_message">Вы добавили объект, категорию которого мы пока не поддерживаем. В будущем он появится на карте.</string>
 	<!-- Downloaded 10 **of** 20 <- it is that "of" -->
 	<string name="downloader_of">%1$d из %2$d</string>
 	<string name="download_over_mobile_header">Загрузить через сотовую связь?</string>
@@ -760,15 +484,8 @@
 	<string name="editor_detailed_description">Предложенные вами изменения на карте будут отправлены в OpenStreetMap. Опишите дополнительные сведения об объекте, которые Organic Maps не позволяет отредактировать.</string>
 	<string name="editor_more_about_osm">Подробнее об OpenStreetMap</string>
 	<string name="editor_operator">Владелец</string>
-	<string name="editor_tag_description">Укажите компанию, организацию или лицо, которое отвечает за работоспособность объекта.</string>
-	<string name="editor_no_local_edits_title">У вас пока нет локальных правок</string>
-	<string name="editor_no_local_edits_description">Здесь отображается количество предложенных вами изменений на карте, которые доступны пока только на вашем устройстве.</string>
-	<string name="editor_send_to_osm">Отправить в OSM</string>
-	<string name="editor_remove">Удалить</string>
-	<string name="downloader_my_maps_title">Мои карты</string>
 	<string name="downloader_no_downloaded_maps_title">У вас нет загруженных карт</string>
 	<string name="downloader_no_downloaded_maps_message">Загрузите необходимые карты, чтобы находить места и пользоваться навигацией без интернета.</string>
-	<string name="downloader_find_place_hint">Найти город или страну</string>
 	<!-- Error title that appears after certain time without location. -->
 	<string name="current_location_unknown_title">Продолжить поиск местоположения?</string>
 	<!-- Error that appears after certain time without location. -->
@@ -783,27 +500,10 @@
 	<string name="location_services_disabled_2">2. Нажмите Геопозиция</string>
 	<!-- iOS Dialog for the case when the location permission is not granted -->
 	<string name="location_services_disabled_3">3. Выберите «При использовании программы»</string>
-	<string name="placepage_parking_surface">Открытая парковка</string>
-	<string name="placepage_parking_multistorey">Многоэтажная наземная парковка</string>
-	<string name="placepage_parking_underground">Подземная парковка</string>
-	<string name="placepage_parking_rooftop">Парковка на крыше здания</string>
-	<string name="placepage_parking_sheds">Частное легкое укрытие для автомобилей</string>
-	<string name="placepage_parking_carports">Капитальный навес</string>
-	<string name="placepage_parking_boxes">Гаражный бокс</string>
-	<string name="placepage_parking_pay">Платная</string>
-	<string name="placepage_parking_free">Бесплатная</string>
-	<string name="placepage_parking_interval">Переменно платная</string>
-	<string name="placepage_entrance_number">№</string>
-	<string name="placepage_entrance_type">Подъезд</string>
-	<string name="placepage_flat">кв.</string>
-	<string name="placepage_open_24_7">Круглосуточно</string>
 	<string name="meter">м</string>
 	<string name="kilometer">км</string>
-	<string name="kilometers_per_hour">км/ч</string>
 	<string name="mile">ми</string>
 	<string name="foot">фут</string>
-	<string name="miles_per_hour">ми/ч</string>
-	<string name="day">д</string>
 	<string name="hour">ч</string>
 	<string name="minute">мин</string>
 	<string name="placepage_place_description">Описание</string>
@@ -813,46 +513,30 @@
 	<string name="placepage_call_button">Позвонить</string>
 	<string name="placepage_edit_bookmark_button">Редактировать метку</string>
 	<string name="placepage_bookmark_name_hint">Название метки</string>
-	<string name="placepage_personal_notes_hint">Примечание</string>
-	<string name="placepage_delete_bookmark_button">Удалить метку</string>
 	<string name="editor_edits_sent_message">Предложенные вами изменения отправлены</string>
 	<string name="editor_comment_hint">Коментарий…</string>
 	<string name="editor_reset_edits_message">Сбросить все локальные правки?</string>
 	<string name="editor_reset_edits_button">Сбросить</string>
 	<string name="editor_remove_place_message">Удалить добавленный вами объект?</string>
 	<string name="editor_remove_place_button">Удалить</string>
-	<string name="editor_status_sending">Отправка…</string>
 	<string name="editor_place_doesnt_exist">Места не существует</string>
 	<string name="text_more_button">…ещё</string>
 	<!-- Phone number error message -->
 	<string name="error_enter_correct_phone">Введите корректный номер телефона</string>
 	<string name="error_enter_correct_web">Введите корректный веб-адрес</string>
 	<string name="error_enter_correct_email">Введите корректный email</string>
-	<string name="error_enter_correct">Введите корректное значение</string>
 	<string name="refresh">Обновить</string>
-	<string name="last_update">Последнее обновление: %s</string>
 	<string name="placepage_add_place_button">Добавить место на карту</string>
 	<!-- Displayed when saving some edits to the map to warn against publishing personal data -->
 	<string name="editor_share_to_all_dialog_title">Отправить всем пользователям?</string>
 	<!-- iOS Dialog before publishing the modifications to the public map. -->
 	<string name="editor_share_to_all_dialog_message_1">Убедитесь, что вы не ввели личные данные.</string>
 	<string name="editor_share_to_all_dialog_message_2">Если при проверке изменений возникнут вопросы, мы напишем вам на email.</string>
-	<string name="navigation_overview_button">обзор</string>
-	<string name="navigation_stop_button">стоп</string>
-	<!-- Text on an empty bookmark page -->
-	<string name="bookmarks_empty_title">Сохраняйте метки</string>
-	<string name="bookmarks_empty_message_1">Нажмите ★, чтобы сохранить любимые места для быстрого доступа к ним.</string>
-	<string name="bookmarks_empty_message_2">Импортируйте метки из почты и интернета.</string>
-	<string name="bookmarks_empty_message_3">выезд: %s</string>
-	<!-- Name of the group for booked hotels -->
-	<string name="bookmarks_group_name">Забронированные отели</string>
-	<string name="place_page_button_read_descriprion">Прочитать</string>
 	<!-- iOS dialog for the case when recent track recording is on and the app comes back from background -->
 	<string name="recent_track_background_dialog_title">Выключить запись недавно пройденого пути?</string>
 	<string name="off_recent_track_background_button">Выключить</string>
 	<!-- For sharing via SMS and so on -->
 	<string name="sharing_call_action_look">Посмотри</string>
-	<string name="continue_recent_track_background_button">Продолжить</string>
 	<string name="recent_track_background_dialog_message">Organic Maps использует вашу геопозицию в фоновом режиме для записи недавно пройденного пути.</string>
 	<!-- Rate on Google Play (Android only) -->
 	<string name="rate_gp">Оценить в Google Play</string>
@@ -862,22 +546,11 @@
 	<string name="tell_friends_text">Привет! Установи Organic Maps!</string>
 	<!-- About short text (below logo) -->
 	<string name="about_description">Organic Maps — незаменимое приложение для путешествий, работающее без подключения к интернету. Organic Maps использует данные OpenStreetMap и позволяет их улучшать.</string>
-	<!-- Text in menu -->
-	<string name="blog">Блог</string>
 	<string name="general_settings">Общие настройки</string>
-	<string name="date">Дата %d</string>
-	<!-- "Report a bug" -> "Generaal Feedback" -> "Something is not working" -->
-	<string name="something_is_not_working">Что-то не работает</string>
 	<!-- For the first routing -->
 	<string name="accept">Принять</string>
-	<string name="accept_and_continue">Принять и продолжить</string>
 	<!-- For the first routing -->
 	<string name="decline">Отклонить</string>
-	<string name="install_app">Установить</string>
-	<string name="search_no_results_title">Поиск не дал результатов</string>
-	<string name="search_no_results_message">Попробуйте задать более общий запрос, уменьшить масштаб карты или сбросить фильтр.</string>
-	<string name="search_no_results_expand_area_button">Уменьшить масштаб карты</string>
-	<string name="search_no_results_reset_button">Сбросить фильтр</string>
 	<!-- noun -->
 	<string name="search_in_table">Список</string>
 	<string name="mobile_data_dialog">Загружать дополнительную информацию через мобильный интернет?</string>
@@ -889,18 +562,13 @@
 	<string name="mobile_data_option_never">Никогда не использовать</string>
 	<string name="mobile_data_option_ask">Всегда спрашивать</string>
 	<string name="traffic_update_maps_text">Для отображения пробок необходимо обновить карты.</string>
-	<string name="traffic_outdated">Данные о пробках устарели.</string>
 	<string name="big_font">Увеличить шрифт на карте</string>
 	<string name="traffic_update_app">Обновите Organic Maps</string>
 	<!-- "traffic" as in road congestion -->
 	<string name="traffic_update_app_message">Для отображения пробок необходимо обновить приложение.</string>
 	<!-- "traffic" as in "road congestion" -->
 	<string name="traffic_data_unavailable">Данные о пробках недоступны</string>
-	<!-- Simplified colour scheme for traffic information, fewer colours are used to display traffic jams on the map. The string should be kept as short as possible -->
-	<string name="pref_traffic_simplified_colors_title">Простые цвета пробок</string>
 	<string name="enable_logging">Включить запись логов</string>
-	<string name="offline_place_page_more_information">Подключитесь к интернету, чтобы получить больше информации о месте.</string>
-	<string name="failed_load_information">Не удалось загрузить информацию.</string>
 	<!-- Settings: "Send general feedback" button -->
 	<string name="feedback_general">Отправить отзыв</string>
 	<string name="on">Вкл.</string>
@@ -909,67 +577,26 @@
 	<string name="prefs_languages_information_off">Для некоторых языков, возможно, необходимо установить дополнительный синтезатор речи (TTS) из магазина приложений (Google Play Market, Samsung Apps).\nЧтобы настроить синтезатор речи, перейдите в Настройки → Язык и ввод → Синтез речи.\nЗдесь можно установить дополнительные языковые пакеты или выбрать синтезатор речи.</string>
 	<string name="prefs_languages_information_off_link">Более подробная информация — в этом руководстве.</string>
 	<string name="whatsnew_transliteration_title">Латинская транслитерация</string>
-	<string name="yandex_taxi_title">Яндекс.Такси</string>
 	<string name="learn_more">Узнать больше</string>
 	<string name="core_exit">Выход</string>
 	<string name="routing_add_start_point">Добавьте стартовую точку, чтобы построить маршрут</string>
 	<string name="routing_add_finish_point">Добавьте конечную точку, чтобы построить маршрут</string>
 	<string name="button_exit">Выход</string>
-	<string name="settings_device_memory">Память устроства</string>
-	<string name="settings_card_memory">Карта памяти</string>
-	<string name="settings_storage_available">%s доступно</string>
-	<string name="toast_location_permission_denied">Определение местоположения запрещено</string>
-	<string name="button_use">Использовать</string>
 	<string name="planning_route_manage_route">Изменить маршрут</string>
 	<string name="button_plan">Построить</string>
-	<string name="button_add">Добавить</string>
 	<string name="placepage_remove_stop">Удалить</string>
 	<string name="planning_route_remove_title">Перетяните сюда, чтобы удалить</string>
-	<string name="dialog_change_start_point_message">Заменить стартовую точку на текущее местоположение?</string>
-	<string name="button_replace">Заменить</string>
 	<string name="placepage_add_stop">Заехать</string>
-	<!-- Only ru/en are needed -->
-	<string name="subtitle_rent">Аренда</string>
-	<!-- Only ru/en are needed -->
-	<string name="rub_month">руб./мес.</string>
-	<!-- Only ru/en are needed -->
-	<string name="room">%s-комн. кв.</string>
-	<!-- Only ru/en are needed -->
-	<string name="real_estate">Недвижимость</string>
-	<string name="add_my_position">Добавить мое местоположение</string>
-	<string name="choose_start_point">Выберите начало маршрута</string>
-	<string name="choose_destination">Выберите конец маршрута</string>
 	<string name="preloader_viator_button">Посмотреть</string>
-	<string name="start_from_my_position">Начать от</string>
-	<string name="profile_authorization_title">Авторизуйтесь с помощью</string>
-	<string name="profile_authorization_message">Простая авторизация за пару секунд без логина и пароля</string>
 	<string name="profile_authorization_error">Упс, произошла ошибка. Попробуйте авторизоваться повторно.</string>
-	<string name="service">Обслуживание</string>
-	<string name="atmosphere">Атмосфера</string>
-	<string name="value_for_money">Цена / качество</string>
-	<string name="experience">Впечатления</string>
-	<string name="assortment">Ассортимент</string>
-	<string name="expertise">Профессионализм</string>
-	<string name="equipment">Оборудование</string>
-	<string name="quality">Качество</string>
 	<string name="dialog_error_storage_title">Проблема с доступом к хранилищу</string>
 	<string name="dialog_error_storage_message">Внешняя память устройства недоступна, возможно SD карта была удалена, повреждена или файловая система доступна только для чтения. Проверьте это и свяжитесь, пожалуйста, с нами support\@organicmaps.app</string>
 	<string name="setting_emulate_bad_storage">Эмуляция ошибки с внешней памятью</string>
-	<string name="directions_finish">Место назначения</string>
-	<string name="directions_on_foot">Пешком %s</string>
 	<string name="core_entrance">Вход</string>
-	<string name="coffee">Кофе</string>
-	<string name="cleanliness">Чистота</string>
-	<string name="crowdedness">Многолюдность</string>
 	<string name="error_enter_correct_name">Пожалуйста, введите название правильно</string>
 	<string name="bookmarks_groups">Списки</string>
 	<string name="bookmarks_groups_hide_all">Спрятать все</string>
 	<string name="bookmarks_groups_show_all">Показать все</string>
-	<plurals name="bookmarks_places">
-	  <item quantity="one">%d метка</item>
-	  <item quantity="few">%d метки</item>
-	  <item quantity="other">%d меток</item>
-	</plurals>
 	<string name="bookmarks_create_new_group">Создать новый список</string>
 	<!-- Bookmark categories screen -->
 	<string name="bookmarks_import">Импортировать метки</string>
@@ -977,7 +604,6 @@
 	<string name="downloader_percent">%1$s (%2$s из %3$s)</string>
 	<string name="downloader_process">Загрузка %s…</string>
 	<string name="downloader_applying">Применение %s…</string>
-	<string name="dialog_message_transit_not_found_connection">Постройте маршрут в пределах одной транспортной сети</string>
 	<string name="bookmarks_error_message_share_general">Не удалось поделиться из-за ошибки приложения</string>
 	<string name="bookmarks_error_title_share_empty">Ошибка при попытке поделиться</string>
 	<string name="bookmarks_error_message_share_empty">Нельзя делиться пустыми списками</string>
@@ -986,133 +612,70 @@
 	<string name="bookmarks_new_list_hint">Новый список</string>
 	<string name="bookmarks_error_title_list_name_already_taken">Такое имя уже занято</string>
 	<string name="bookmarks_error_message_list_name_already_taken">Выберите, пожалуйста, другое имя</string>
-	<string name="bookmarks_error_title_list_name_too_long">Слишком длинное название</string>
-	<string name="bookmarks_error_message_list_name_too_long">Выберите, пожалуйста, другое имя</string>
-	<string name="please_wait">Пожалуйста, подождите...</string>
-	<string name="phone_number">Номер телефона</string>
-	<string name="notification_unsent_reviews_title">У вас есть неотправленные отзывы</string>
-	<string name="notification_unsent_reviews_message">Пожалуйста, авторизуйтесь, чтобы поделиться своими отзывами с другими путешественниками</string>
+	<string name="please_wait">Пожалуйста, подождите…</string>
 	<string name="profile">Профиль OpenStreetMap</string>
 	<string name="place_page_search_similar_hotel">Найти похожие отели</string>
 	<string name="bookmarks_detect_title">Обнаружены новые файлы</string>
 	<plurals name="bookmarks_detect_message">
-	  <item quantity="one">%d файл был найден. Вы увидете его после конвертации.</item>
 	  <item quantity="few">%d файла были найдены. Вы увидете их после конвертации.</item>
+	  <item quantity="one">%d файл был найден. Вы увидете его после конвертации.</item>
 	  <item quantity="other">%d файлов было найдено. Вы увидете их после конвертации.</item>
 	</plurals>
 	<string name="button_convert">Конвертировать</string>
 	<string name="bookmarks_convert_error_title">Ошибка</string>
 	<string name="bookmarks_convert_error_message">Некоторые файлы не конвертировались.</string>
-	<string name="converting">Конвертация...</string>
-	<string name="wn_reinvented_bookmarks_title">Мы улучшили функционал меток!</string>
-	<string name="wn_reinvented_bookmarks_message">Теперь вы можете сделать резервное копирование меток, создать списки. А как круто они смотрятся на карте!</string>
-	<string name="bookmarks_restore">Восстановить метки</string>
-	<string name="bookmarks_restore_process">Восстановление...</string>
 	<string name="bookmarks_restore_title">Восстановить эту версию?</string>
-	<string name="bookmarks_restore_message">Ваши закладки будут восстановлены от %1$s (%2$s)</string>
-	<string name="bookmarks_restore_empty_title">У вас нет резервных копий</string>
-	<string name="bookmarks_restore_empty_message">Сервер не нашел ранее сделанные резервные копии</string>
 	<string name="common_check_internet_connection_dialog_title">Нет интернет соединения</string>
-	<string name="error_server_title">Ошибка сервера</string>
-	<string name="error_server_message">На сервере произошла ошибка, повторите попытку позже</string>
 	<string name="error_system_message">Произошла неизвестная ошибка</string>
 	<string name="restore">Восстановить</string>
-	<string name="bookmarks_page_downloaded">Загруженные</string>
-	<string name="bookmarks_page_my">Мои</string>
-	<string name="routes_and_bookmarks">Маршруты и метки</string>
-	<string name="bookmarks_webview_success_toast">Метки успешно загружены</string>
-	<string name="cached_bookmarks_placeholder_title">Загрузите новые места</string>
-	<string name="cached_bookmarks_placeholder_subtitle">Нажмите кнопку, чтобы загрузить тысячи интересных мест и маршрутов, созданных пользователями Organic Maps. Вам понадобится подключение к интернету.</string>
-	<string name="downloader_download_routers">Загрузить метки</string>
-	<string name="bookmarks_groups_cached">Загруженные списки</string>
-	<plurals name="bookmarks_objects">
-	  <item quantity="one">%s объект</item>
-	  <item quantity="two">%d объекта</item>
-	  <item quantity="few">%d объекта</item>
-	  <item quantity="other">%s объектов</item>
-	</plurals>
 	<plurals name="objects">
-	  <item quantity="one">%d объект</item>
-	  <item quantity="two">%d объекта</item>
 	  <item quantity="few">%d объекта</item>
+	  <item quantity="one">%d объект</item>
 	  <item quantity="other">%d объектов</item>
+	  <item quantity="two">%d объекта</item>
 	</plurals>
 	<plurals name="places">
-	  <item quantity="one">%d место</item>
-	  <item quantity="two">%d места</item>
 	  <item quantity="few">%d места</item>
+	  <item quantity="one">%d место</item>
 	  <item quantity="other">%d мест</item>
+	  <item quantity="two">%d места</item>
 	</plurals>
 	<plurals name="tracks">
-	  <item quantity="one">%d трек</item>
-	  <item quantity="two">%d трека</item>
 	  <item quantity="few">%d трека</item>
+	  <item quantity="one">%d трек</item>
 	  <item quantity="other">%d треков</item>
+	  <item quantity="two">%d трека</item>
 	</plurals>
 	<string name="subtittle_opt_out">Настройки сопровождения</string>
 	<string name="crash_reports">Отчеты об ошибках</string>
 	<string name="crash_reports_description">Мы можем использовать ваши данные, чтобы развивать и улучшать Organic Maps. Изменения вступят в силу после перезапуска приложения.</string>
-	<string name="opt_out_help_ios_1">Вы можете отказаться от получения целевой рекламы в настройках устройства.</string>
-	<string name="opt_out_help_ios_2">iOS 9 или выше</string>
-	<string name="opt_out_help_ios_3">Откройте Настройки → Конфиденциальность → Реклама → Включите «Ограничение трекинга»</string>
-	<string name="opt_out_help_android">Вы можете отказаться от получения целевой рекламы в настройках устройства.\nAndroid и Google Play Сервисы 4.0 и выше\n\nНастройки телефона → Google → Реклама → Отключить персонализацию рекламы\nили\nНастройки телефона → Google → Аккаунт Google → Конфиденциальность → Настройки рекламных предпочтений → Персонализация рекламы</string>
 	<string name="privacy_policy">Политика конфиденциальности</string>
 	<string name="terms_of_use">Условия использования</string>
-	<string name="backup_notification_failed">Резервное копирование меток было приостановлено. Войдите, чтобы включить резервное копирование.</string>
 	<string name="button_layer_traffic">Пробки</string>
 	<string name="button_layer_subway">Метро</string>
 	<string name="layers_title">Слои карты</string>
-	<string name="layers_message">Включайте слои на карте для отображения дорожной обстановки, схемы метро или другой полезной информации</string>
-	<string name="button_layer_got_it">Понятно</string>
 	<string name="subway_data_unavailable">Карта метро недоступна</string>
 	<string name="bookmarks_empty_list_title">Список пустой</string>
 	<string name="bookmarks_empty_list_message">Чтобы добавить новую метку, нажмите на значок звездочки в карточке объекта</string>
 	<string name="category_desc_more">…еще</string>
 	<string name="title_error_downloading_bookmarks">Произошла ошибка</string>
-	<string name="subtitle_error_downloading_bookmarks">Метки не были загружены</string>
-	<string name="error_already_downloaded">Этот список уже был загружен</string>
 	<string name="popular_place">Популярно</string>
-	<string name="download_routes">Загрузить маршруты</string>
-	<string name="bookmarks_downloaded_title">Метки были успешно загружены</string>
-	<string name="bookmarks_downloaded_subtitle">Нажмите «Посмотреть на карте» чтобы посмотреть новые места из списка</string>
-	<string name="why_support">Зачем поддерживать Organic Maps?</string>
-	<string name="why_support_item1">Мы никому не отсылаем ваши личные данные, а исходный код нашего приложения открыт</string>
-	<string name="why_support_item2">Вы помогаете нам улучшать Organic Maps</string>
-	<string name="why_support_item3">Вы помогаете нам улучшать карты OpenStreetMap.org</string>
-	<string name="channels_map_update">Обновления карт</string>
-	<string name="server_unavailable_title">Сервер недоступен</string>
-	<string name="sharing_options">Настройки доступа</string>
 	<string name="export_file">Экспортировать файл</string>
 	<string name="list_settings">Настройки списка</string>
 	<string name="delete_list">Удалить список</string>
-	<string name="hide_from_map">Скрыть с карты</string>
 	<string name="public_access">Публичный доступ</string>
 	<string name="limited_access">Ограниченный доступ</string>
 	<string name="bookmark_category_name">Категория</string>
 	<string name="bookmark_category_description_hint">Добавьте описание (текст или html)</string>
 	<string name="not_shared">Личный</string>
-	<string name="direct_link_progress_text">Загружаем ваш файл…</string>
-	<string name="direct_link_success">Ссылка создана</string>
-	<string name="send_a_link_btn">Отправить ссылку</string>
-	<string name="upload_error_toast">Во время загрузки файла произошла ошибка</string>
 	<string name="tags_loading_error_subtitle">Во время загрузки тегов произошла ошибка, пожалуйста, попробуйте еще раз</string>
-	<string name="unable_upload_errorr_title">Не удалось загрузить файл</string>
-	<string name="unable_upload_error_subtitle_edited">Файл был отредактирован через веб-приложение</string>
-	<string name="unable_upload_error_subtitle_broken">Файл поврежден и не может быть загружен. Пожалуйста, загрузите другой файл.</string>
-	<string name="contact">Написать</string>
-	<string name="download_button">Скачать</string>
 	<string name="speedcams_alert_title">Камеры скорости</string>
-	<string name="speedcams_alert_subtitle">Предупреждать об ограничениях скорости</string>
 	<string name="speedcam_option_auto">Авто</string>
 	<string name="speedcam_option_always">Всегда</string>
 	<string name="speedcam_option_never">Никогда</string>
-	<string name="bookmark_description_title">Описание метки</string>
 	<string name="place_description_title">Описание места</string>
 	<!-- this text will be shown in application notification preferences opposite checkbox which enable/disable downloader notifications. Devices on Android 8+ are affected. -->
 	<string name="notification_channel_downloader">Загрузка карт</string>
-	<string name="share_bookmarks_email_body_link">Здравствуйте!\n\nМетки можно скачать по ссылке: %s. Открывайте список с помощью Organic Maps и наслаждайтесь поездкой!\n\nСкачать приложение: https://omaps.app/get?kmz</string>
-	<string name="warning_speedcams_title">Навигатор оповестит вас о камерах при превышении скоростного лимита на %d км/ч</string>
-	<string name="warning_speedcams_subtitle">Не забудьте ознакомиться с правилами дорожного движения в стране путешествия.</string>
 	<string name="speedcams_notice_message">Авто - Предупреждать о камерах скорости, если есть риск превышения скоростного лимита\nВсегда - Всегда предупреждать о камерах\nНикогда - Никогда не предупреждать о камерах</string>
 	<string name="power_managment_title">Режим энергосбережения</string>
 	<string name="power_managment_description">Если режим энергосбережения включен, приложение будет отключать энергозатратные функции в зависимости от текущего заряда телефона</string>
@@ -1120,15 +683,7 @@
 	<string name="power_managment_setting_auto">Авто</string>
 	<string name="power_managment_setting_manual_max">Максимальное энергосбережение</string>
 	<string name="enable_logging_warning_message">Данная настройка включается для записи действий в целях диагностики, чтобы помочь нашей команде выявить проблемы с приложением. Временно включайте эту настройку только для отправки детальной информации о найденной вами проблеме в приложении.</string>
-	<string name="html_error_upload_message_try_again">Проверьте доступ к сети и повторите попытку</string>
-	<string name="html_error_upload_title_try_again">Нет соединения с Интернетом</string>
-	<string name="notification_leave_review_v2_android_short_title">Оставляйте отзыв и помогайте путешественникам!</string>
-	<string name="megafon">Роуминг, гудбай!</string>
-	<string name="notifications_illegal_alert_disable_button">Выключить уведомления</string>
 	<string name="access_rules_author_only">Редактируется онлайн</string>
-	<string name="privacy_settings_menu">Настройки конфиденциальности</string>
-	<string name="unable_upadate_error_title">Не удалось обновить маршрут</string>
-	<string name="unable_upadate_error_message">Возникли ошибки при обновлении. Проверьте изменения и повторите попытку</string>
 	<string name="driving_options_title">Настройки объезда</string>
 	<string name="driving_options_subheader">Избегать в каждом маршруте</string>
 	<string name="avoid_tolls">Платные дороги</string>
@@ -1139,52 +694,14 @@
 	<string name="unable_to_calc_alert_subtitle">К сожалению, мы не смогли построить маршрут с выбранными опциями. Измените настройки и повторите попытку</string>
 	<string name="define_to_avoid_btn">Настроить пути объезда</string>
 	<string name="change_driving_options_btn">Настройки объезда включены</string>
-	<string name="toll_road">Платная дорога</string>
-	<string name="unpaved_road">Грунтовая дорога</string>
-	<string name="ferry_crossing">Паромная переправа</string>
-	<string name="operated_by">Управляется оператором \"%s\"</string>
 	<string name="avoid_toll_roads_placepage">Избегать платных дорог</string>
 	<string name="avoid_unpaved_roads_placepage">Избегать грунтовых дорог</string>
 	<string name="avoid_ferry_crossing_placepage">Избегать паромных переправ</string>
-	<string name="type.cuisine.uzbek">Узбекская кухня</string>
-	<string name="trip_start">Поехали</string>
-	<string name="pick_destination">Цель</string>
-	<string name="follow_my_position">Отцентровать</string>
-	<string name="search_results">Результаты поиска</string>
-	<string name="then_turn">Затем</string>
-	<string name="redirect_route_alert">Хотите перестроить маршрут?</string>
-	<string name="redirect_route_yes">Да</string>
-	<string name="redirect_route_no">Нет</string>
-	<string name="trip_finished">Вы прибыли!</string>
-	<string name="keyboard_availability_alert">Клавиатура недоступна во время движения</string>
-	<string name="dialog_routing_change_start_carplay">Невозможно построить маршрут от текущего местоположения</string>
-	<string name="dialog_routing_change_end_carplay">Невозможно построить маршрут до конечной точки. Выберите другую</string>
-	<string name="dialog_routing_check_gps_carplay">Нет сигнала GPS. Проследуйте на открытую местность</string>
-	<string name="dialog_routing_unable_locate_route_carplay">Невозможно построить маршрут. Выберите другие точки маршрута</string>
-	<string name="dialog_routing_download_files_carplay">Чтобы построить маршрут, загрузите недостающие карты на своем устройстве</string>
-	<string name="dialog_routing_system_error_carplay">Произошла ошибка. Перезапустите приложение</string>
-	<string name="dialog_routing_rebuild_from_current_location_carplay">Маршрут будет перестроен от вашего текущего местоположения</string>
-	<string name="dialog_routing_rebuild_for_vehicle_carplay">Маршрут будет изменен на автомобильный</string>
 	<string name="ok">Ок</string>
-	<string name="avoid_unpaved_carplay_1">Без грунт.</string>
-	<string name="avoid_unpaved_carplay_2">Без грунтовых</string>
-	<string name="avoid_ferry_carplay_1">Без паромов</string>
-	<string name="avoid_ferry_carplay_2">Без паромов</string>
-	<string name="avoid_tolls_carplay_1">Без платных</string>
-	<string name="avoid_tolls_carplay_2">Без платных</string>
-	<string name="speedcams_alert_title_carplay_1">Камеры</string>
-	<string name="speedcams_alert_title_carplay_2">Инфо о камерах</string>
-	<string name="download_map_carplay">Скачайте карты в приложении Organic Maps на своем устройстве</string>
-	<string name="carplay_roundabout_exit">%s съезд</string>
 	<!-- max. 10 symbols, both iOS and Android -->
 	<string name="sort">Сортировать…</string>
 	<!-- Android, title, max 20-22 symbols -->
 	<string name="sort_bookmarks">Сортировать метки</string>
-	<!-- iOS -->
-	<string name="sort_default">Сортировать по умолчанию</string>
-	<string name="sort_type">Сортировать по типу</string>
-	<string name="sort_distance">Сортировать по расстоянию</string>
-	<string name="sort_date">Сортировать по дате</string>
 	<!-- Android -->
 	<string name="by_default">По умолчанию</string>
 	<!-- Android -->
@@ -1193,65 +710,23 @@
 	<string name="by_distance">По расстоянию</string>
 	<!-- Android -->
 	<string name="by_date">По дате</string>
-	<string name="week_ago_sorttype">Неделю назад</string>
-	<string name="month_ago_sorttype">Месяц назад</string>
-	<string name="moremonth_ago_sorttype">Больше месяца назад</string>
-	<string name="moreyear_ago_sorttype">Больше года назад</string>
-	<string name="near_me_sorttype">Рядом со мной</string>
-	<string name="others_sorttype">Другие</string>
-	<string name="food_places">Еда</string>
-	<string name="tourist_places">Достопримечательности</string>
-	<string name="museums">Музеи</string>
-	<string name="parks">Парки</string>
-	<string name="swim_places">Плавание</string>
-	<string name="mountains">Горы</string>
-	<string name="animals">Животные</string>
-	<string name="hotels">Отели</string>
-	<string name="buildings">Здания</string>
-	<string name="money">Деньги</string>
-	<string name="shops">Магазины</string>
-	<string name="parkings">Парковки</string>
-	<string name="fuel_places">Заправки</string>
-	<string name="water">Вода</string>
-	<string name="medicine">Медицина</string>
 	<string name="search_in_the_list">Искать в списке</string>
-	<string name="view_on_map_bookmarks">На карте</string>
-	<string name="more_bookmarks">Еще…</string>
-	<string name="no_items_found">Ничего не найдено</string>
-	<!-- Android, max 18 symbols -->
-	<string name="bookmarks_edit_list">Редактировать</string>
-	<!-- Android, max 18 symbols -->
-	<string name="bookmarks_delete_list">Удалить список</string>
-	<string name="religious_places">Святые места</string>
 	<string name="select_list">Выбрать список</string>
 	<string name="transit_not_found">Навигация на метро ещё недоступна в данном регионе</string>
 	<string name="dialog_pedestrian_route_is_long_header">Маршрут метро не найден</string>
 	<string name="dialog_pedestrian_route_is_long_message">Выберите начальную или конечную точку маршрута ближе к станции метро</string>
-	<!-- Failed planning SUBWAY route message in navigation view -->
-	<string name="routing_planning_error_subway_special">Ошибка построения маршрута метро</string>
 	<string name="button_layer_isolines">Высоты</string>
-	<string name="tips_map_layers_title_countour">Линии высот офлайн в Organic Maps!</string>
-	<string name="tips_map_layers_message_countour">Линии высот помогут спланировать путешествие на природу и не потеряться на местности</string>
 	<string name="isolines_activation_error_dialog">Чтобы воспользоваться линиями высот, обновите или загрузите карту нужной местности</string>
 	<string name="isolines_location_error_dialog">Линии высот пока не доступны в этом регионе</string>
 	<string name="elevation_profile_diff_level">Уровень сложности</string>
-	<string name="elevation_profile_diff_level_easy">Лёгкий</string>
-	<string name="elevation_profile_diff_level_moderate">Умеренный</string>
-	<string name="elevation_profile_diff_level_hard">Сложный</string>
 	<string name="elevation_profile_ascent">Подъём</string>
 	<string name="elevation_profile_descent">Спуск</string>
 	<string name="elevation_profile_minaltitude">Мин. высота</string>
 	<string name="elevation_profile_maxaltitude">Макс. высота</string>
-	<string name="elevation_profile_m">м</string>
 	<string name="elevation_profile_difficulty">Сложность</string>
 	<string name="elevation_profile_distance">Расст.:</string>
-	<string name="elevation_profile_km">км</string>
 	<string name="elevation_profile_time">В пути:</string>
-	<string name="elevation_profile_hours">ч.</string>
-	<string name="elevation_profile_minutes">мин</string>
 	<string name="isolines_toast_zooms_1_10">Увеличьте карту, чтобы увидеть изолинии</string>
-	<string name="downloader_updating_ios">Обновление</string>
-	<string name="downloader_loading_ios">Загрузка</string>
 	<string name="key_information_title">Ключевая информация</string>
 	<string name="download_map_title">Скачать карту мира</string>
 	<string name="connection_failure">Ошибка подключения</string>

--- a/android/res/values-sk/strings.xml
+++ b/android/res/values-sk/strings.xml
@@ -12,8 +12,6 @@
 	<string name="cancel_download">Zrušiť sťahovanie</string>
 	<!-- Button which deletes downloaded country -->
 	<string name="delete">Zmazať</string>
-	<!-- Button "do not interrupt download" if user touched actively downloading country -->
-	<string name="do_nothing">Pokračovať</string>
 	<string name="download_maps">Stiahnuť mapy</string>
 	<!-- Settings/Downloader - info for country when download fails -->
 	<string name="download_has_failed">Sťahovanie zlyhalo, skúste to znova.</string>
@@ -31,45 +29,31 @@
 	<string name="core_my_position">Moja poloha</string>
 	<!-- Update maps later/Buy pro version later button text -->
 	<string name="later">Neskôr</string>
-	<!-- Don't show some dialog any more -->
-	<string name="never">Nikdy</string>
 	<!-- View and button titles for accessibility -->
 	<string name="search">Hľadať</string>
 	<!-- Search box placeholder text -->
 	<string name="search_map">Prehľadať mapu</string>
-	<!-- Settings/Downloader - info for not downloaded country -->
-	<string name="touch_to_download">Stlačte pre stiahnutie</string>
 	<!-- Settings/Downloader - 3G download warning dialog confirm button -->
 	<string name="use_cellular_data">Áno</string>
 	<!-- Location services are disabled by user alert - message -->
 	<string name="location_is_disabled_long_text">Aktuálne máte všetky možnosti pre určovanie polohy vypnuté. Prosím, povoľte ich v Nastaveniach.</string>
-	<!-- Location Services are not available on the device alert - message -->
-	<string name="device_doesnot_support_location_services">Vaše zariadenie nepodporuje služby pre určovanie polohy</string>
 	<!-- View and button titles for accessibility -->
 	<string name="zoom_to_country">Ukázať na mape</string>
-	<!-- Button text for the button at the center of the screen when the country is not downloaded -->
-	<string name="country_status_download">Stiahnite si Mapu\n(^ ^)</string>
 	<!-- Button text for the button at the center of the screen when the country is not downloaded and the size should not be shown -->
 	<string name="country_status_download_without_size">Stiahnite si Mapu</string>
-	<!-- Button text for the button at the center of the screen when the country is not downloaded -->
-	<string name="country_status_download_without_routing">Stiahnite si mapu\nbez smerovania (^ ^)</string>
 	<!-- Message to display at the center of the screen when the country download has failed -->
 	<string name="country_status_download_failed">Sťahovanie zlyhalo</string>
 	<!-- Button text for the button under the country_status_download_failed message -->
 	<string name="try_again">Skúsiť znova</string>
 	<string name="about_menu_title">O aplikácii Organic Maps</string>
-	<string name="downloaded_touch_to_delete">Stiahnuté (%s), stlačte pre zmazanie</string>
 	<string name="connection_settings">Nastavenie pripojenia</string>
-	<string name="download_mb_or_kb">Stiahnuť %s</string>
 	<string name="close">Zavrieť</string>
 	<string name="unsupported_phone">Je vyžadovaná hardwarová akcelerácia OpenGL. Bohužial, vaše zariadenie nie je podporované.</string>
 	<string name="download">Stiahnuť</string>
-	<string name="external_storage_is_not_available">SD karta/USB úložisko s uloženými mapami nie je k dispozícii</string>
 	<string name="disconnect_usb_cable">Prosím, odpojte USB kábel alebo vložte pamäťovú kartu pre použitie s Organic Maps</string>
 	<string name="not_enough_free_space_on_sdcard">Prosím, uvoľnite najprv miesto na SD karte/USB úložisku</string>
 	<string name="not_enough_memory">Nedostatok pamäti k spusteniu aplikácie</string>
 	<string name="download_resources">Skôr ako začnete, bude treba stiahnuť základnú mapu sveta.\nZaberie to %s.</string>
-	<string name="getting_position">Získavanie aktuálnej polohy</string>
 	<string name="download_resources_continue">Prejsť na mapu</string>
 	<string name="downloading_country_can_proceed">Sťahovanie %s. Teraz môžete\nprejsť na mapu.</string>
 	<string name="download_country_ask">Stiahnuť %s?</string>
@@ -82,30 +66,20 @@
 	<string name="download_country_failed">Sťahovanie zlyhalo: %s</string>
 	<!-- Add New Bookmark Set dialog title -->
 	<string name="add_new_set">Pridať novú skupinu záložiek</string>
-	<!-- Place Page - Add To Bookmarks button -->
-	<string name="add_to_bookmarks">Pridať k záložkám</string>
 	<!-- Bookmark Color dialog title -->
 	<string name="bookmark_color">Farba záložky</string>
 	<!-- Add Bookmark Set dialog - hint when set name is empty -->
 	<string name="bookmark_set_name">Meno záložky</string>
-	<!-- Bookmark Sets dialog title -->
-	<string name="bookmark_sets">Skupiny záložiek</string>
 	<!-- Bookmarks - dialog title -->
 	<string name="bookmarks">Záložky</string>
-	<!-- Add bookmark dialog - bookmark color -->
-	<string name="color">Farba</string>
 	<!-- Default bookmarks set name -->
 	<string name="core_my_places">Moje miesta</string>
 	<!-- Add bookmark dialog - bookmark name -->
 	<string name="name">Názov</string>
 	<!-- Editor title above street and house number -->
 	<string name="address">Adresa</string>
-	<!-- Place Page - Remove Pin button -->
-	<string name="remove_pin">Odstrániť špendlík</string>
 	<!-- Add bookmark dialog - bookmark set, Bookmarks dialog - Bookmark set cell -->
 	<string name="set">Skupina</string>
-	<!-- Text hint in Bookmarks dialog when no any bookmarks are added -->
-	<string name="bookmarks_usage_hint">Zatiaľ nemáte žiadne záložky.\nZáložku môžete pridať pridržaním ľubovolného miesta na mape.\nV Organic Maps môžu byť tiež zobrazené importované záložky z iných zdrojov. Súbor vo formáte KML/KMZ s uloženými záložkami môžete otvoriť napr. z emailu, Dropboxu alebo z webového odkazu.</string>
 	<!-- Settings button in system menu -->
 	<string name="settings">Nastavenia</string>
 	<!-- Header of settings activity where user defines storage path -->
@@ -116,20 +90,10 @@
 	<string name="move_maps">Presunúť mapy?</string>
 	<!-- Ask to wait user several minutes (some long process in modal dialog). -->
 	<string name="wait_several_minutes">Táto akcia môže trvať niekoľko minút.\nProsím čakajte…</string>
-	<!-- Show bookmarks from this category on a map or not -->
-	<string name="visible">Viditeľné</string>
-	<!-- Toast which is displayed when GPS has been deactivated -->
-	<string name="gps_is_disabled_long_text">Navigácia GPS deaktivovaná. Prosím, povoľte ju v Nastaveniach.</string>
 	<!-- Measurement units title in settings activity -->
 	<string name="measurement_units">Meracie jednotky</string>
 	<!-- Detailed description of Measurement Units settings button -->
 	<string name="measurement_units_summary">Vyberte si míle alebo kilometre</string>
-	<!-- Do search in all sources -->
-	<string name="search_mode_all">Všade</string>
-	<!-- Do search near my position only -->
-	<string name="search_mode_nearme">V mojom okolí</string>
-	<!-- Do search in current viewport only -->
-	<string name="search_mode_viewport">Na obrazovke</string>
 	<!-- Search category for cafes, bars, restaurants -->
 	<string name="eat">Kde sa najesť</string>
 	<!-- Search category for grocery stores -->
@@ -166,8 +130,6 @@
 	<string name="post">Pošta</string>
 	<!-- Search category -->
 	<string name="police">Polícia</string>
-	<!-- String in search result list, when nothing found -->
-	<string name="no_search_results_found">Žiadne výsledky</string>
 	<!-- Notes field in Bookmarks view -->
 	<string name="description">Poznámky</string>
 	<!-- Email Subject when sharing bookmarks category -->
@@ -182,20 +144,10 @@
 	<string name="edit">Upraviť</string>
 	<!-- Warning message when doing search around current position -->
 	<string name="unknown_current_position">Vaša poloha zatiaľ nebola určená</string>
-	<!-- Warning message when location country isn't downloaded during search (see also download_location_map_proposal). -->
-	<string name="download_location_country">Sťahovanie krajiny vašej aktuálnej polohy (%s)</string>
-	<!-- Warning message when viewport country isn't downloaded during search -->
-	<string name="download_viewport_country_to_search">Sťahovanie krajiny, v ktorej hľadáte (%s)</string>
 	<!-- Alert message that we can't run Map Storage settings due to some reasons. -->
 	<string name="cant_change_this_setting">Prepáčte, nastavenie uloženia máp je dočasne nedostupné.</string>
 	<!-- Alert message that downloading is in progress. -->
 	<string name="downloading_is_active">Práve prebieha sťahovanie krajiny.</string>
-	<!-- Message that will be shown in alert view, when we ask user to leave review on App Store -->
-	<string name="appStore_message">Dúfame, že sa vám používánie Organic Maps páči! Ak to je tak, ohodnoťte prosím našu aplikáciu alebo napíšte na ňu recenziu v Obchode s aplikáciami. Nezaberie vám to ani minútu času, ale nám s tým môžete veľmi pomôoť. Ďakujeme vám za vašu podporu!</string>
-	<!-- No, thanks -->
-	<string name="no_thanks">Nie, ďakujem</string>
-	<!-- Share one specific bookmark using SMS, %1$@ contains om:// and %2$@ https://omaps.app link. @NOTE non-ascii symbols in the link will result in max 70 characters SMS instead of 140. -->
-	<string name="bookmark_share_sms">Pozrite na moju značku na mape. Otvoriť odkaz: %1$s alebo %2$s</string>
 	<!-- Share my position using SMS, %1$@ contains om:// and %2$@ https://omaps.app link WITHOUT NAME. @NOTE non-ascii symbols in the link will result in max 70 characters SMS instead of 140. -->
 	<string name="my_position_share_sms">Pozri kde som. Otvor odkaz: %1$s alebo %2$s</string>
 	<!-- Subject for emailed bookmark -->
@@ -204,30 +156,16 @@
 	<string name="my_position_share_email_subject">Pozrite si moju aktuálnu polohu na mape Organic Maps</string>
 	<!-- Share my position using EMail, %1$@ is om:// and %2$@ is https://omaps.app link WITHOUT NAME -->
 	<string name="my_position_share_email">Ahoj,\n\nPráve som tu: %1$s. Stlačte jeden z týchto odkazov %2$s, %3$s a uvidíte toto miesto na mape.\n\nVďaka</string>
-	<!-- Android share by Message/SMS button text (including SMS) -->
-	<string name="share_by_message">Zdielať pomocou správy</string>
 	<!-- Share button text which opens menu with more buttons, like Message, EMail, Facebook etc. -->
 	<string name="share">Zdielať</string>
-	<!-- iOS share by Message button text (including SMS) -->
-	<string name="message">Správa</string>
 	<!-- Share by email button text, also used in editor. -->
 	<string name="email">Email</string>
-	<!-- Copy Link -->
-	<string name="copy_link">Skopírovať odkaz</string>
-	<!-- Text for the button that returns to caller application -->
-	<string name="more_info">Zobraziť ďaľšie informácie</string>
 	<!-- Text for message when used successfully copied something -->
 	<string name="copied_to_clipboard">Skopírované do schránky: %1$s</string>
 	<!-- place preview title -->
 	<string name="info">Viacej informácií</string>
 	<!-- Used for bookmark editing -->
 	<string name="done">Hotovo</string>
-	<!-- Summary for preferences in MWM -->
-	<string name="yopme_pref_summary">Zvoliť nastavenie Zadnej obrazovky</string>
-	<!-- Title for yopme preferences in MWM -->
-	<string name="yopme_pref_title">Nastavenie Zadnej obrazovky</string>
-	<!-- Hint for upper-right icon p2b -->
-	<string name="show_on_backscreen">Zobraziť na Zadnej obrazovke</string>
 	<!-- Prints version number in About dialog -->
 	<string name="version">Verzia: %s</string>
 	<!-- Confirmation in downloading countries dialog -->
@@ -237,11 +175,6 @@
 	<!-- Length of track in cell that describes route -->
 	<string name="length">Diaľka</string>
 	<string name="share_my_location">Zdielať moje umiestnenie</string>
-	<string name="menu_search">Vyhľadávanie</string>
-	<!-- Settings screen: "Map" category title -->
-	<string name="prefs_group_map">Mapa</string>
-	<!-- Settings screen: "Miscellaneous" category title -->
-	<string name="prefs_group_misc">Iné</string>
 	<string name="prefs_group_route">Navigácia</string>
 	<string name="pref_zoom_title">Tlačítka priblíženia/oddialenia</string>
 	<string name="pref_zoom_summary">Zobraziť na obrazovke</string>
@@ -257,8 +190,6 @@
 	<string name="pref_map_3d_title">Perspektívne zobrazenie</string>
 	<!-- Settings «Map» category: «3D buildings» title -->
 	<string name="pref_map_3d_buildings_title">3D budovy</string>
-	<!-- Settings «Map» category: «3D buildings» summary -->
-	<string name="pref_map_3d_buildings_subtitle">Ovplyvňuje životnosť batérie</string>
 	<!-- Settings «Route» category: «Tts enabled» title -->
 	<string name="pref_tts_enable_title">Hlasové povely</string>
 	<!-- Settings «Route» category: «Tts language» title -->
@@ -267,7 +198,6 @@
 	<string name="pref_tts_unavailable">Nie je k dispozícii</string>
 	<!-- Title for "Other" section in TTS settings. -->
 	<string name="pref_tts_other_section_title">Iný</string>
-	<string name="pref_tts_how_to_set_up_voice">Ako nastaviť hlas</string>
 	<!-- Settings «Map» category: «Record track» title -->
 	<string name="pref_track_record_title">Posledná trasa</string>
 	<string name="pref_map_auto_zoom">Automatický zoom</string>
@@ -278,46 +208,11 @@
 	<string name="duration_12_hours">12 hodín</string>
 	<string name="duration_1_day">1 deň</string>
 	<string name="recent_track_help_text">Umožňuje zaznamenať precestovanú trasu za určité obdobie a zobraziť ju na mape. Upozornenie: zapnutie tejto funkcie spôsobí vyššiu spotrebu batérie. Trasa sa z mapy automaticky odstráni po uplynutí časového intervalu.</string>
-	<string name="pref_track_ios_caption">Funkcia Čerstvá stopa zobrazuje trasu, ktorú ste prešli.</string>
-	<string name="pref_track_ios_subcaption">Prosím, vyberte si, po akú dobu má aplikácia zaznamenávať vašu trasu.</string>
-	<string name="placepage_distance">Vzdialenosť</string>
-	<string name="placepage_coordinates">Súradnice</string>
-	<string name="placepage_unsorted">Nezaradené</string>
 	<string name="search_show_on_map">Zobraziť na mape</string>
-	<!-- Used to warn user when fixing KitKat issue -->
-	<string name="bookmark_move_fail">Potrebujeme presunúť vaše záložky do internej pamäti zariadenia, ale nie je pre ne voľné miesto. Prosím, uvoľnite pamäť, inak nebudú záložky dostupné.</string>
-	<!-- Used in More Apps menu -->
-	<string name="free">Zadarmo</string>
-	<!-- Used in More Apps menu -->
-	<string name="buy">Kúpiť</string>
-	<!-- 1st search button-like result -->
-	<string name="search_on_map">Hľadať na mape</string>
-	<!-- toast with an error -->
-	<string name="no_route_found">Nebola nájdená žiadna trasa</string>
-	<!-- route title -->
-	<string name="route">Trasa</string>
-	<!-- category title -->
-	<string name="routes">Trasy</string>
-	<!-- text of notification -->
-	<string name="download_map_notification">Stiahnite si mapu miesta, kde sa práve nachádzate</string>
-	<!-- text of notification -->
-	<string name="pro_version_is_free_today">Plná verzia Organic Maps dnes zadarmo! Stiahnite si teraz a povedzte to svojim priateľom.</string>
-	<!-- Dialog for transferring maps from lite to pro. -->
-	<string name="move_lite_maps_to_pro">Práve prenášame Vaše stiahnuté mapy z Organic Maps lite na Organic Maps. Môže to trvať niekoľko minút.</string>
-	<!-- Message to display when maps moved. -->
-	<string name="move_lite_maps_to_pro_ok">Vaše stiahnuté mapy sú úspešne prenesené na Organic Maps.</string>
-	<!-- Message to display when maps move failed. -->
-	<string name="move_lite_maps_to_pro_failed">Vaše mapy sa nepodarilo preniesť. Vymažte prosím Organic Maps Lite a stiahnite si mapy znova.</string>
-	<!-- Text in menu -->
-	<string name="settings_and_more">Nastavenia a viac</string>
 	<!-- Text in menu -->
 	<string name="website">Webové stránky</string>
-	<!-- Text in menu -->
-	<string name="contact_us">Kontaktovať nás</string>
 	<!-- Settings: Send feedback button and dialog title -->
 	<string name="feedback">Spätná väzba</string>
-	<!-- Text in menu -->
-	<string name="subscribe_to_news">Prihlásiť sa k našim novinkám</string>
 	<!-- Text in menu -->
 	<string name="rate_the_app">Ohodnotiť aplikáciu</string>
 	<!-- Text in menu -->
@@ -326,12 +221,6 @@
 	<string name="copyright">Autorské práva</string>
 	<!-- Text in menu -->
 	<string name="report_a_bug">Nahlásiť chybu</string>
-	<!-- Email subject -->
-	<string name="subscribe_me_subject">Prihláste ma prosím k odberu spravodaja Organic Maps</string>
-	<!-- Email body -->
-	<string name="subscribe_me_body">Chcem sa vždy ako prvý dozvedať o najnovších správach, aktualizáciách a akčných ponukách. Svoje prihlásenie k odberu môžem kedykoľvek zrušiť.</string>
-	<!-- About text -->
-	<string name="about_text">Organic Maps ponúka najrýchlejšie offline mapy všetkých miest a krajín po celom svete. Cestujte s úplnou dôverou: kdekoľvek ste, Organic Maps vám pomôže sa nájsť na mape, nájsť najbližšiu reštauráciu, hotel, banku, benzínovú pumpu atď. Nevyžaduje pripojenie k internetu.\n\nNeustále pracujeme na nových funkciách a radi by sme počuli váš názor, ako môžeme vylepšiť Organic Maps. Pokiaľ máte s touto aplikáciou akékoľvek problémy, tak nás neváhajte kontaktovať na support\@organicmaps.app. Odpovedáme na každú požiadavku!\n\nPáči sa vám Organic Maps a chceli by ste nás podporiť? Existuje niekoľko ľahkých spôsobov celkom zadarmo:\n\n-napíšte recenziu vo svojom obchode s aplikáciami\n-označte našu stránku http://www.facebook.com/OrganicMaps pomocou Páči sa mi to\n- alebo len povedzte o Organic Maps svojej mame, priateľom a kolegom :)\n\nĎakujeme, že ste s nami. Veľmi oceňujeme vašu podporu!\n\nP.S. Mapové dáta získavame z OpenStreetMap, čo je mapový projekt podobný Wikipédii, ktorý umožňuje užívateľom vytvárať a upravovať mapy. Pokiaľ zistíte, že na mape niečo chýba alebo je nesprávné, môžete to opraviť priamo na https://www.openstreetmap.org, a vaše zmeny sa objavia v budúcej verzii Organic Maps.</string>
 	<!-- Alert text -->
 	<string name="email_error_body">Emailový klient nebol nastavený. Nakonfigurujte ho prosím alebo použite iný spôsob k tomu, abyste nás kontaktovali na %s</string>
 	<!-- Alert title -->
@@ -340,135 +229,54 @@
 	<string name="pref_calibration_title">Compass kalibrácia</string>
 	<!-- Search category -->
 	<string name="wifi">WiFi</string>
-	<!-- Update map suggestion -->
-	<string name="routing_map_outdated">Pre vytvorenie trasy si, prosím, aktualizujte mapu.</string>
-	<!-- Update maps suggestion -->
-	<string name="routing_update_maps">Nová verzia aplikácie Organic Maps umožňuje vytvárať trasy z vašej aktuálnej polohy do cieľového bodu. Pre použitie tejto funkcie si, prosím, aktualizujte mapy.</string>
 	<!-- Update all button text -->
 	<string name="downloader_update_all_button">Aktualizovať všetko</string>
 	<!-- Cancel all button text -->
 	<string name="downloader_cancel_all">Zrušiť všetko</string>
 	<!-- Downloaded maps category -->
 	<string name="downloader_downloaded_subtitle">Stiahnuté</string>
-	<!-- Downloaded maps category -->
-	<string name="downloader_available_maps">Dostupné</string>
 	<!-- Country queued for download -->
 	<string name="downloader_queued">V rade</string>
 	<string name="downloader_near_me_subtitle">Neďaleko mňa</string>
 	<string name="downloader_status_maps">Mapy</string>
 	<string name="downloader_download_all_button">Stiahnuť všetko</string>
 	<string name="downloader_downloading">Sťahovanie:</string>
-	<string name="downloader_search_results">Nájdených</string>
-	<!-- Disclaimer message -->
-	<string name="routing_disclaimer">Tvorenie trás v aplikácii Organic Maps, prosím, majte na pamäti nasledovné:\n\n  - Navrhnuté trasy možno považovať iba za odporúčanie.\n - Stav vozovky, dopravné predpisy a značenie majú vyššiu prioritu, ako navigačné rady.\n - Mapa môže byť nesprávna alebo zastaraná a trasy nemusia byť vytvorené tým najlepším možným spôsobom.\n\n  Buďte na cestách v bezpečí a postarajte sa o seba!</string>
-	<!-- Outdated maps category -->
-	<string name="downloader_outdated_maps">Zastarané</string>
-	<!-- Up to date maps category -->
-	<string name="downloader_uptodate_maps">Aktualizované</string>
 	<!-- Status of outdated country in the list -->
 	<string name="downloader_status_outdated">Aktualizácia</string>
 	<!-- Status of failed country in the list -->
 	<string name="downloader_status_failed">Zlyhalo</string>
 	<!-- Displayed in a dialog that appears when a user tries to delete a map while the app is in the follow route mode -->
 	<string name="downloader_delete_map_while_routing_dialog">Ak chcete odstrániť mapy, prosím, zastavte navigáciu.</string>
-	<!-- Show when user try build route, but we don't know where he -->
-	<string name="routing_failed_unknown_my_position">Aktuálna lokácia nie je definovaná. Prosím, špecifikujte lokáciu pre vytvorenie trasy.</string>
-	<!-- Show if use has not routing file, or InconsistentMWMandRoute -->
-	<string name="routing_failed_has_no_routing_file">Na vytvorenie trasy sú potrebné ďalšie dáta. Začať sťahovanie?</string>
-	<!-- StartPointNotFound -->
-	<string name="routing_failed_start_point_not_found">Nedá sa vypočítať trasa. Žiadne cesty v blízkosti východiskového bodu.</string>
-	<!-- EndPointNotFound -->
-	<string name="routing_failed_dst_point_not_found">Nedá sa vypočítať trasa. Žiadne cesty v blízkosti cieľa.</string>
 	<!-- PointsInDifferentMWM -->
 	<string name="routing_failed_cross_mwm_building">Cesty môžu byť vytvorené len tak, že sú plne obsiahnuté v jednej mape.</string>
-	<!-- RouteNotFound -->
-	<string name="routing_failed_route_not_found">Nebol nájdená trasa medzi vybraným východiskom a cieľom. Prosím vyberte iný počiatočný a koncový bod.</string>
-	<!-- InternalError -->
-	<string name="routing_failed_internal_error">Došlo k vnútornej chybe. Prosím, skúste zmazať a znovu stiahnuť mapu. Ak problém pretrvá, prosím, kontaktujte nás na support\@organicmaps.app.</string>
-	<!-- Context menu item for downloader. -->
-	<string name="downloader_download_map_and_routing">Na stiahnutie Mapa + Trasa</string>
-	<!-- Context menu item for downloader. -->
-	<string name="downloader_download_routing">Trasa na stiahnutie</string>
-	<!-- Context menu item for downloader. -->
-	<string name="downloader_delete_routing">Zmazať Trasu</string>
 	<!-- Context menu item for downloader. -->
 	<string name="downloader_download_map">Stiahnuť mapu</string>
-	<string name="downloader_download_map_no_routing">Stiahnite si mapu bez smerovania</string>
-	<!-- Button for routing. -->
-	<string name="routing_go">Štart!</string>
 	<!-- Item status in downloader. -->
 	<string name="downloader_retry">Zopakovať</string>
-	<!-- Item in context menu. -->
-	<string name="downloader_map_and_routing">Mapa + Smerovanie</string>
 	<!-- Item in context menu. -->
 	<string name="downloader_delete_map">Zmazať mapu</string>
 	<!-- Item in context menu. -->
 	<string name="downloader_update_map">Aktualizovať mapu</string>
-	<!-- Item in context menu. -->
-	<string name="downloader_update_map_and_routing">Aktualizovať mapu + Smerovanie</string>
-	<!-- Item in context menu. -->
-	<string name="downloader_map_only">Iba mapa</string>
-	<!-- Toolbar title -->
-	<string name="toolbar_application_menu">Ponuka aplikácie</string>
 	<!-- Preference text -->
 	<string name="pref_use_google_play">Pomocou Google Play služieb získajte svoju aktuálnu polohu</string>
 	<!-- Text for rating dialog -->
 	<string name="rating_just_rated">Práve som hodnotil vašu aplikáciu</string>
-	<!-- Text for rating dialog -->
-	<string name="rating_user_since">Som používateľ Organic Maps od roku %s</string>
-	<!-- Text for rating dialog -->
-	<string name="rating_do_like_maps">Páči sa vám Organic Maps?</string>
-	<!-- Text for rating dialog -->
-	<string name="rating_tap_star">Kliknutím na hviezdu ohodnotíte našu aplikáciu.</string>
 	<!-- Text for rating dialog -->
 	<string name="rating_thanks">Ďakujeme vám!</string>
 	<!-- Text for rating dialog -->
 	<string name="rating_share_ideas">Podeľte sa o svoje nápady alebo problémy, aby sme pre vás mohli vylepšiť aplikáciu.</string>
 	<!-- Text for rating dialog -->
 	<string name="rating_send_feedback">Odoslať spätnú väzbu</string>
-	<!-- Text for g+ dialog -->
-	<string name="rating_google_plus">Kliknutím na tlačidlo g + povedzte o aplikácii svojim priateľom.</string>
 	<!-- Text for routing error dialog -->
 	<string name="routing_download_maps_along">Stiahnite si mapy pozdĺž trasy</string>
 	<!-- Text for routing error dialog -->
-	<string name="routing_download_map">Stiahnuť mapu</string>
-	<!-- Text for routing error dialog -->
-	<string name="routing_download_map_and_routing">Aktualizovať mapu a trasové dáta na to aby ste mohli získajte všetky funkcie Organic Maps.</string>
-	<!-- Text for routing error dialog -->
-	<string name="routing_get_routing_data">Získať trasové dáta</string>
-	<!-- Text for routing error dialog -->
-	<string name="routing_get_additional_data">Dodatočné údaje potrebné na vytvorenie trasy zo vašej polohy.</string>
-	<!-- Text for routing error dialog -->
 	<string name="routing_not_enough_space">Nedostatok miesta</string>
-	<!-- Text for routing error dialog -->
-	<string name="routing_download_more_than_avail">Musíte stiahnuť %1$s MB, ale k dispozícií máte len %2$s MB.</string>
-	<!-- Text for routing error dialog -->
-	<string name="routing_download_roaming">Veľkosť súboru je %s MB, ktoré stiahnete prostredníctvom Mobilných Dát (v Roamingu). Toto môže mať za následok dodatočné poplatky, v závislosti od dátových taríf vášho mobilného operátora.</string>
 	<!-- bookmark button text -->
 	<string name="bookmark">záložka</string>
-	<!-- map is not downloaded -->
-	<string name="not_found_map">Mapa vašej polohy nebola nájdená</string>
 	<!-- location service disabled -->
 	<string name="enable_location_services">Prosím, povoľte Služby určovania polohy</string>
-	<!-- download map -->
-	<string name="download_map">Stiahnite si mapu miesta, kde sa práve nachádzate</string>
-	<!-- download map on iPhone -->
-	<string name="download_map_iphone">Stiahnite si mapu pre aktuálnu polohu na vašom iPhone</string>
-	<!-- clear pin -->
-	<string name="nearby">V blízkosti</string>
-	<!-- clear pin -->
-	<string name="clear_pin">Vymazať špendlík</string>
-	<!-- location is undefined -->
-	<string name="undefined_location">Aktuálna lokácia nie je definovaná.</string>
-	<!-- download country of your location -->
-	<string name="download_country">Sťahovanie krajiny vašej aktuálnej polohy</string>
-	<!-- download failed -->
-	<string name="download_failed">Sťahovanie zlyhalo</string>
-	<!-- get the map -->
-	<string name="get_the_map">Stiahnuť mapu</string>
 	<string name="save">Uložiť</string>
 	<string name="edit_description_hint">Váš popis (text alebo html)</string>
-	<string name="new_group">nová skupina</string>
 	<string name="create">vytvoriť</string>
 	<!-- red color -->
 	<string name="red">Červená</string>
@@ -486,22 +294,6 @@
 	<string name="brown">Hnedá</string>
 	<!-- pink color -->
 	<string name="pink">Ružová</string>
-	<!-- deep purple color -->
-	<string name="deep_purple">Tmavofialová</string>
-	<!-- light blue color -->
-	<string name="light_blue">Svetlo modrá</string>
-	<!-- cyan color -->
-	<string name="cyan">Tyrkysová</string>
-	<!-- teal color -->
-	<string name="teal">Modrozelená</string>
-	<!-- lime color -->
-	<string name="lime">Limetková</string>
-	<!-- deep orange color -->
-	<string name="deep_orange">Tmavo oranžová</string>
-	<!-- gray color -->
-	<string name="gray">Sivá</string>
-	<!-- blue gray color -->
-	<string name="blue_gray">Modro sivá</string>
 	<!-- Wi-Fi available -->
 	<string name="WiFi_available">Áno</string>
 
@@ -517,10 +309,8 @@
 	<string name="dialog_routing_location_turn_wifi">Skontrolujte signál GPS. Zapnutie Wi-Fi zlepší presnosť vašej lokalizácie.</string>
 	<string name="dialog_routing_location_turn_on">Zapnite lokalizačné služby</string>
 	<string name="dialog_routing_location_unknown_turn_on">Aktuálne súradnice GPS sa nedajú lokalizovať. Aktivujte lokalizačné služby na výpočet trasy.</string>
-	<string name="dialog_routing_location_unknown">Nedajú sa lokalizovať aktuálne súradnice GPS.</string>
 	<string name="dialog_routing_download_files">Prevezmite si požadované súbory</string>
 	<string name="dialog_routing_download_and_update_all">Prevezmite si a aktualizujte všetky mapy a informácie o trase pozdĺž naplánovanej trasy na výpočet trasy.</string>
-	<string name="dialog_routing_routes_size">Súbory s informáciami o trase</string>
 	<string name="dialog_routing_unable_locate_route">Trasa sa nedá lokalizovať</string>
 	<string name="dialog_routing_cant_build_route">Trasa sa nedá vytvoriť.</string>
 	<string name="dialog_routing_change_start_or_end">Prosím, upravte váš východiskový bod alebo cieľové miesto.</string>
@@ -535,33 +325,23 @@
 	<string name="dialog_routing_system_error">Systémová chyba</string>
 	<string name="dialog_routing_application_error">Nedá sa vytvoriť trasa z dôvodu aplikačnej chyby.</string>
 	<string name="dialog_routing_try_again">Skúste znova, prosím</string>
-	<string name="dialog_routing_send_error">Nahláste problém</string>
-	<string name="dialog_routing_if_get_cross_route">Chceli by ste vytvoriť priamejšiu trasu, ktorá zahŕňa viac ako jednu mapu?</string>
-	<string name="dialog_routing_cross_route_is_optimal">K dispozícii je optimálnejšia trasa, ktorá presahuje hranice tejto mapy.</string>
 	<string name="not_now">Nie teraz</string>
-	<string name="dialog_routing_build_route">Vytvoriť</string>
 	<string name="dialog_routing_download_and_build_cross_route">Chcete si prevziať mapu a vytvoriť optimálnejšiu trasu, ktorá si vyžaduje viac ako jednu mapu?</string>
 	<string name="dialog_routing_download_cross_route">Prevezmite si mapu na vytvorenie optimálnejšej trasy, ktorá prekračuje okraje tejto mapy.</string>
-	<string name="dialog_routing_cross_route_always">Vždy prekročiť túto hranicu</string>
 
 	<!-- SECTION: Strings for downloading map from search -->
 	<string name="search_without_internet_advertisement">Stiahnutím mapy už nebudete potrebovať pripojenie k internetu a môžete si začať vyhľadávať a vytvárať trasy.</string>
 	<string name="search_select_map">Vybrať mapu</string>
-	<string name="search_select_other_map">Vybrať inú mapu</string>
 	<!-- «Show» context menu -->
 	<string name="show">Ukázať</string>
 	<!-- «Hide» context menu -->
 	<string name="hide">Skryť</string>
 	<!-- «Rename» context menu -->
 	<string name="rename">Premenovať</string>
-	<!-- Bottom sheet: expand button (should be short) -->
-	<string name="bottom_sheet_more">Viac…</string>
 	<!-- Failed planning route message in navigation view -->
 	<string name="routing_planning_error">Plánovanie trasy zlyhalo</string>
 	<!-- Arrive routing message in navigation view -->
 	<string name="routing_arrive">Pricestovať: %s</string>
-	<!-- Text for routing::RouterResultCode::FileTooOld dialog. -->
-	<string name="dialog_routing_download_and_update_maps">Prosím, pre vytvorenie trasy si stiahnite a aktualizujte všetky mapy pozdĺž trasy.</string>
 	<string name="rate_alert_title">Páči sa vám aplikácia?</string>
 	<string name="rate_alert_default_message">Ďakujeme, že používate Organic Maps. Prosím, ohodnoťte aplikáciu. Vaše názory nám pomôžu zlepšiť sa.</string>
 	<string name="rate_alert_five_star_message">Hurá! Aj my vás taky páči!</string>
@@ -569,24 +349,14 @@
 	<string name="rate_alert_less_than_four_star_message">Nejaký nápad, ako ju môžeme vylepšiť?</string>
 	<string name="categories">Kategórie</string>
 	<string name="history">Archív</string>
-	<string name="next_turn_then">Potom</string>
 	<string name="closed">Zatvorené</string>
-	<string name="back_to">Späť do %s</string>
 	<string name="search_not_found">Ľutujeme, ale nič sme nenašli.</string>
 	<string name="search_not_found_query">Vyskúšajte, prosím, iný hľadaný výraz.</string>
-	<string name="search_not_found_map">Prosím, stiahnite si mapu, na ktorej vyhľadávate.</string>
-	<string name="search_not_found_location">Stiahnite si mapu svojej súčasnej polohy.</string>
 	<string name="search_history_title">História vyhľadávania</string>
 	<string name="search_history_text">Rýchlo pristupujte k nedávnym hľadaným výrazom.</string>
 	<string name="clear_search">Vymazať históriu vyhľadávania</string>
-	<!-- Title for settings to enable/disable showcase menu button -->
-	<string name="showcase_settings_title">Zobraziť akcie</string>
-	<string name="p2p_route_planning">Plánovanie trasy</string>
 	<string name="p2p_your_location">Vaša poloha</string>
-	<string name="p2p_from">Východiskový bod</string>
-	<string name="p2p_to">Cieľový bod</string>
 	<string name="p2p_start">Štart</string>
-	<string name="p2p_planning">Plánovanie…</string>
 	<string name="p2p_from_here">Cesta z</string>
 	<string name="p2p_to_here">Cesta do</string>
 	<string name="p2p_only_from_current">Navigácia je dostupná iba z vašej aktuálnej polohy.</string>
@@ -606,11 +376,8 @@
 	<string name="editor_hours_closed">Hodiny zatvorenia</string>
 	<string name="editor_example_values">Príklady hodnôt</string>
 	<string name="editor_correct_mistake">Opraviť chybu</string>
-	<string name="editor_correct_mistake_message">Chyba pri úprave. Opravte chybu, alebo sa prepnite do jednoduchého režimu.</string>
 	<string name="editor_add_select_location">Poloha</string>
 	<string name="editor_done_dialog_1">Zmenili ste mapu sveta. Nemusíte to skrývať! Povedzte o tom svojim priateľom a začnite ju spolu upravovať.</string>
-	<string name="editor_done_dialog_2">Toto je vaša druhá vylepšená mapa. Momentálne ste na %d. mieste zoznamu editorov máp. Povedzte o tom svojim priateľom.</string>
-	<string name="editor_done_dialog_3">Práve ste vylepšili mapu. Povedzte o tom svojim priateľom a môžete mapu upraviť aj spolu.</string>
 	<string name="share_with_friends">Zdieľaj s priateľmi</string>
 	<string name="editor_report_problem_desription_1">Prosím, pridajte detailný popis problému, aby mohla komunita OpenStreetMap opraviť danú chybu.</string>
 	<string name="editor_report_problem_desription_2">K oprave môžete prispieť aj vy na stránke https://www.openstreetmap.org/</string>
@@ -619,14 +386,7 @@
 	<string name="editor_report_problem_no_place_title">Dané miesto neexistuje</string>
 	<string name="editor_report_problem_under_construction_title">Zatvorené kvôli prebiehajúcej údržbe</string>
 	<string name="editor_report_problem_duplicate_place_title">Duplicitné miesto</string>
-	<string name="first_launch_congrats_title">Aplikácia Organic Maps je pripravená na použitie</string>
-	<string name="first_launch_congrats_text">Vyhľadávajte a určujte trasu bez pripojenia všade na svete bez poplatkov.</string>
-	<string name="migrate_title">Dôležité!</string>
-	<!-- Android uses image instead of text. -->
-	<string name="download_all">Stiahnuť všetko</string>
-	<string name="delete_all">Vymazať všetky</string>
 	<string name="autodownload">Automaticky stiahnuť</string>
-	<string name="disable_autodownload">Zrušiť automatické preberanie</string>
 	<!-- Place Page opening hours text -->
 	<string name="closed_now">Teraz zatvorené</string>
 	<!-- Place Page opening hours text -->
@@ -635,8 +395,6 @@
 	<string name="day_off_today">Dnes deň voľna</string>
 	<string name="day_off">Deň voľna</string>
 	<string name="today">Dnes</string>
-	<string name="sunrise_to_sunset">Od východu do západu slnka</string>
-	<string name="sunset_to_sunrise">Od západu do východu slnka</string>
 	<string name="add_opening_hours">Pridať otváracie hodiny</string>
 	<string name="edit_opening_hours">Upraviť otváracie hodiny</string>
 	<string name="no_osm_account">Nemáte účet v OpenStreetMap?</string>
@@ -646,29 +404,13 @@
 	<string name="login">Prihlásiť sa</string>
 	<string name="password">Heslo</string>
 	<string name="forgot_password">Zabudli ste heslo?</string>
-	<!-- Forgot Password dialog title -->
-	<string name="restore_password">Obnovenie hesla</string>
-	<string name="enter_email_address_to_reset_password">Zadajte emailovú adresu, ktorú ste použili pri registrácii, a my Vám zašleme odkaz na obnovenie hesla.</string>
-	<string name="reset_password">Obnoviť heslo</string>
-	<string name="username">Používateľské meno</string>
 	<string name="osm_account">OSM účet</string>
 	<string name="logout">Odhlásiť sa</string>
-	<string name="login_and_edit_map_motivation_message">Prihláste sa a upravte informácie o objektoch na mape, a my ich sprístupníme miliónom ďalších používateľov. Urobme svet spoločne lepším.</string>
 	<!-- Information text: "Last upload 11.01.2016" -->
 	<string name="last_upload">Posledné nahrávanie</string>
-	<!-- Motivates user to login/register, title above login buttons. -->
-	<string name="you_have_edited_your_first_object">Upravili ste svoj prvý objekt!</string>
 	<string name="thank_you">Ďakujeme Vám</string>
-	<string name="login_with_google">Prihlásiť sa cez Google</string>
-	<string name="login_with_openstreetmap">Prihlásiť sa cez www.openstreetmap.org</string>
 	<string name="edit_place">Upraviť miesto</string>
 	<string name="place_name">Názov miesta</string>
-	<!-- title above languages list cells in the editor, below editable name text field. -->
-	<string name="other_languages">Iné jazyky</string>
-	<!-- small button to open list with names in different languages -->
-	<string name="show_more">Zobraziť viac</string>
-	<!-- small button to close list with names in different languages -->
-	<string name="show_less">Zobraziť menej</string>
 	<string name="add_language">Pridať jazyk</string>
 	<string name="street">Ulica</string>
 	<!-- Editable House Number text field (in address block). -->
@@ -685,25 +427,16 @@
 	<string name="email_or_username">Email alebo používateľské meno</string>
 	<string name="phone">Telefón</string>
 	<string name="please_note">Upozorňujeme vás, že</string>
-	<string name="common_no_wifi_dialog">Pripojenie k WiFi nie je k dispozícii. Chcete pokračovať s využitím mobilných dát?</string>
 	<string name="downloader_delete_map_dialog">Všetky zmeny týkajúce sa mapy budú vymazané spolu s mapou.</string>
 	<string name="downloader_update_maps">Aktualizovať mapy</string>
 	<string name="downloader_mwm_migration_dialog">Ak chcete vytvoriť cestu, musíte najskôr aktualizovať všetky mapy a potom odznova naplánovať trasu.</string>
 	<string name="downloader_search_field_hint">Nájsť mapu</string>
-	<string name="migration_update_all_button">Aktualizovať všetky mapy</string>
-	<string name="migration_delete_all_download_current_button">Stiahnite si aktuálnu mapu a odstráňte neaktuálne mapy</string>
 	<string name="migration_download_error_dialog">Chyba pri sťahovaní</string>
 	<string name="common_check_internet_connection_dialog">Prosím, skontrolujte svoje nastavenia a uistite sa, že váš počítač je pripojený k internetu.</string>
 	<string name="downloader_no_space_title">Nemáte dostatok miesta</string>
 	<string name="downloader_no_space_message">Prosím, odstráňte prebytočné dáta</string>
-	<string name="editor_general_auth_error_dialog">Pri prihlasovaní sa vyskytla všeobecná chyba.</string>
 	<string name="editor_login_error_dialog">Pri prihlasovaní sa vyskytla chyba.</string>
-	<string name="editor_login_failed_dialog">Prihlasovanie bolo neúspešné</string>
-	<string name="editor_username_error_dialog">Používateľské meno je neplatné</string>
-	<string name="editor_place_edited_dialog">Práve ste upravili objekt!</string>
-	<string name="editor_login_with_osm">Prihlásiť sa prostredníctvom OpenStreetMap</string>
 	<string name="editor_profile_changes">Overené zmeny</string>
-	<string name="editor_profile_unsent_changes">Neodoslané:</string>
 	<string name="editor_focus_map_on_location">Ak chcete nastaviť správnu polohu objektu, posuňte mapu.</string>
 	<string name="editor_add_select_category">Vybrať kategóriu</string>
 	<string name="editor_add_select_category_popular_subtitle">Obľúbené</string>
@@ -714,19 +447,14 @@
 	<string name="editor_edit_place_category_title">Kategória</string>
 	<string name="detailed_problem_description">Podrobný popis problému</string>
 	<string name="editor_report_problem_other_title">Iný problém</string>
-	<string name="placepage_report_problem_button">Nahlásiť problém</string>
 	<string name="placepage_add_business_button">Pridať organizáciu</string>
 	<string name="whatsnew_editor_message_1">Na mapu môžete pridávať nové miesta a upravovať tie, ktoré sú už pridané.</string>
-	<string name="whatsnew_editor_message_2">* Organic Maps využíva dáta komunity OpenStreetMap.</string>
 	<string name="dialog_incorrect_feature_position">Zmeniť polohu</string>
 	<string name="message_invalid_feature_position">Objekt sa tu nedá umiestniť</string>
 	<string name="login_to_make_edits_visible">Prihláste sa, aby mohli ostatní užívatelia vidieť Vami vykonané zmeny.</string>
-	<string name="no_migration_during_navigation">Počas hľadania trasy nie je možné vykonať aktualizáciu.</string>
 	<!-- Error dialog no space -->
 	<string name="migration_no_space_message">Ak chcete pokračovať v sťahovaní, musíte uvoľniť viac miesta na ukladacom priestore. Prosím, odstráňte prebytočné dáta.</string>
 	<string name="editor_sharing_title">Vďaka mne sú mapy na Organic Maps lepšie</string>
-	<string name="editor_comment_will_be_sent">Pošleme Váš príspevok kartografom.</string>
-	<string name="editor_unsupported_category_message">Pridali ste miesto z kategórie, ktorú zatiaľ nepodporujeme. Na mape sa zobrazí až za istú dobu.</string>
 	<!-- Downloaded 10 **of** 20 <- it is that "of" -->
 	<string name="downloader_of">%1$d z %2$d</string>
 	<string name="download_over_mobile_header">Sťahovať prostredníctvom pripojenia na mobilnú sieť?</string>
@@ -744,15 +472,8 @@
 	<string name="editor_detailed_description">Vami navrhované zmeny sa odošlú do komunity OpenStreetMap. Popíšte detaily, ktoré sa nedajú upraviť v Organic Maps.</string>
 	<string name="editor_more_about_osm">Viac o OpenStreetMap</string>
 	<string name="editor_operator">Prevádzkovateľ</string>
-	<string name="editor_tag_description">Zadajte spoločnosť, organizáciu alebo osobu zodpovednú za prevádzku.</string>
-	<string name="editor_no_local_edits_title">Nemáte miestne poznámky</string>
-	<string name="editor_no_local_edits_description">Tu sa zobrazuje počet navrhovaných zmien na mape momentálne dostupných len vo vašom zariadení.</string>
-	<string name="editor_send_to_osm">Odoslať do OSM</string>
-	<string name="editor_remove">Odstrániť</string>
-	<string name="downloader_my_maps_title">Moje mapy</string>
 	<string name="downloader_no_downloaded_maps_title">Neprevzali ste žiadne mapy</string>
 	<string name="downloader_no_downloaded_maps_message">Prevziať mapy na nájdenie pozície a navigovanie off-line.</string>
-	<string name="downloader_find_place_hint">Hľadať mesto alebo krajinu</string>
 	<!-- Error title that appears after certain time without location. -->
 	<string name="current_location_unknown_title">Pokračovať v mazaní vašej súčasnej pozície?</string>
 	<!-- Error that appears after certain time without location. -->
@@ -767,27 +488,10 @@
 	<string name="location_services_disabled_2">2. Kliknite na položku Lokalita</string>
 	<!-- iOS Dialog for the case when the location permission is not granted -->
 	<string name="location_services_disabled_3">3. Vyberte si počas používania aplikácie</string>
-	<string name="placepage_parking_surface">Typ parkoviska</string>
-	<string name="placepage_parking_multistorey">Viacpodlažné</string>
-	<string name="placepage_parking_underground">Podzemné</string>
-	<string name="placepage_parking_rooftop">Na streche</string>
-	<string name="placepage_parking_sheds">Garáž</string>
-	<string name="placepage_parking_carports">Otvorené garáže</string>
-	<string name="placepage_parking_boxes">Hromadné garáže</string>
-	<string name="placepage_parking_pay">Platené</string>
-	<string name="placepage_parking_free">Zdarma</string>
-	<string name="placepage_parking_interval">Platba v intervaloch</string>
-	<string name="placepage_entrance_number">Číslo</string>
-	<string name="placepage_entrance_type">Vstup</string>
-	<string name="placepage_flat">Byt</string>
-	<string name="placepage_open_24_7">24 / 7</string>
 	<string name="meter">m</string>
 	<string name="kilometer">km</string>
-	<string name="kilometers_per_hour">km/h</string>
 	<string name="mile">mi</string>
 	<string name="foot">stopa</string>
-	<string name="miles_per_hour">mph</string>
-	<string name="day">d</string>
 	<string name="hour">hod</string>
 	<string name="minute">min</string>
 	<string name="placepage_place_description">Popis</string>
@@ -797,46 +501,30 @@
 	<string name="placepage_call_button">Zavolať</string>
 	<string name="placepage_edit_bookmark_button">Upraviť záložku</string>
 	<string name="placepage_bookmark_name_hint">Názov záložky</string>
-	<string name="placepage_personal_notes_hint">Osobné poznámky</string>
-	<string name="placepage_delete_bookmark_button">Zmazať záložku</string>
 	<string name="editor_edits_sent_message">Vykonali sa vami odporúčané zmeny</string>
 	<string name="editor_comment_hint">Poznámka…</string>
 	<string name="editor_reset_edits_message">Resetovať všetky miestne časy?</string>
 	<string name="editor_reset_edits_button">Resetovať</string>
 	<string name="editor_remove_place_message">Odstrániť pridané miesto?</string>
 	<string name="editor_remove_place_button">Odstrániť</string>
-	<string name="editor_status_sending">Odosiela sa…</string>
 	<string name="editor_place_doesnt_exist">Miesto neexistuje</string>
 	<string name="text_more_button">…viac</string>
 	<!-- Phone number error message -->
 	<string name="error_enter_correct_phone">Zadajte správne telefónne číslo</string>
 	<string name="error_enter_correct_web">Zadajte platnú webovú adresu</string>
 	<string name="error_enter_correct_email">Zadajte platný email</string>
-	<string name="error_enter_correct">Zadajte platnú hodnotu</string>
 	<string name="refresh">Aktualizovať</string>
-	<string name="last_update">Naposledy aktualizované: %s</string>
 	<string name="placepage_add_place_button">Pridať miesto na mape</string>
 	<!-- Displayed when saving some edits to the map to warn against publishing personal data -->
 	<string name="editor_share_to_all_dialog_title">Odoslať všetkým používateľom?</string>
 	<!-- iOS Dialog before publishing the modifications to the public map. -->
 	<string name="editor_share_to_all_dialog_message_1">Nezadávajte žiadne osobné udaje.</string>
 	<string name="editor_share_to_all_dialog_message_2">Skontrolujeme zmeny. V prípade otázok vás budeme kontaktovať emailom.</string>
-	<string name="navigation_overview_button">zhrnutie</string>
-	<string name="navigation_stop_button">stop</string>
-	<!-- Text on an empty bookmark page -->
-	<string name="bookmarks_empty_title">Uložiť záložky</string>
-	<string name="bookmarks_empty_message_1">Ak si chcete uložiť obľúbené miesta pre rýchly prístup, klepnite na ★.</string>
-	<string name="bookmarks_empty_message_2">Importujte si záložky z emailu a webu.</string>
-	<string name="bookmarks_empty_message_3">odchod: %s</string>
-	<!-- Name of the group for booked hotels -->
-	<string name="bookmarks_group_name">Rezervované hotely</string>
-	<string name="place_page_button_read_descriprion">Prečítajte si</string>
 	<!-- iOS dialog for the case when recent track recording is on and the app comes back from background -->
 	<string name="recent_track_background_dialog_title">Znemožniť nahrávanie vami nedávno precestovanej trasy?</string>
 	<string name="off_recent_track_background_button">Znemožniť</string>
 	<!-- For sharing via SMS and so on -->
 	<string name="sharing_call_action_look">Pozrite si</string>
-	<string name="continue_recent_track_background_button">Pokračovať</string>
 	<string name="recent_track_background_dialog_message">Organic Maps používa vašu geopozíciu na pozadí pre zaznamenávanie vami nedávno precestovanej trasy.</string>
 	<!-- Rate on Google Play (Android only) -->
 	<string name="rate_gp">Ohodnotiť v službe Google Play</string>
@@ -846,21 +534,11 @@
 	<string name="tell_friends_text">Ahoj! Nainštaluj si aplikáciu Organic Maps</string>
 	<!-- About short text (below logo) -->
 	<string name="about_description">Organic Maps je offine aplikácia na cestovanie. Základom aplikácie Organic Maps sú dáta OpenStreetMap, pričom aplikácia nám ich umožňuje upravovať.</string>
-	<!-- Text in menu -->
-	<string name="blog">Blog</string>
 	<string name="general_settings">Všeobecné nastavenia</string>
-	<string name="date">Dátum %d</string>
-	<!-- "Report a bug" -> "Generaal Feedback" -> "Something is not working" -->
-	<string name="something_is_not_working">Niečo nefunguje</string>
 	<!-- For the first routing -->
 	<string name="accept">Prijať</string>
 	<!-- For the first routing -->
 	<string name="decline">Odmietnuť</string>
-	<string name="install_app">Nainštalovať</string>
-	<string name="search_no_results_title">Nenašli sa žiadne výsledky</string>
-	<string name="search_no_results_message">Skúste vyhľadávať všeobecnejší výraz, vzdialiť alebo obnoviť nastavenie filtra.</string>
-	<string name="search_no_results_expand_area_button">Vzdialiť</string>
-	<string name="search_no_results_reset_button">Obnoviť filter</string>
 	<!-- noun -->
 	<string name="search_in_table">Zoznam</string>
 	<string name="mobile_data_dialog">Použiť mobilný internet na zobrazenie podrobnejších informácií?</string>
@@ -872,18 +550,13 @@
 	<string name="mobile_data_option_never">Nikdy nepoužiť</string>
 	<string name="mobile_data_option_ask">Vždy sa opýtať</string>
 	<string name="traffic_update_maps_text">Na zobrazenie dopravných informácií je potrebné aktualizovať mapy.</string>
-	<string name="traffic_outdated">Dopravné informácie sú neaktuálne.</string>
 	<string name="big_font">Zväčšiť veľkosť písma na mape</string>
 	<string name="traffic_update_app">Aktualizujte si aplikáciu Organic Maps</string>
 	<!-- "traffic" as in road congestion -->
 	<string name="traffic_update_app_message">Ak chcete zobraziť dopravné informácie, musíte si aktualizovať aplikáciu.</string>
 	<!-- "traffic" as in "road congestion" -->
 	<string name="traffic_data_unavailable">Dopravné informácie nie sú k dispozícii</string>
-	<!-- Simplified colour scheme for traffic information, fewer colours are used to display traffic jams on the map. The string should be kept as short as possible -->
-	<string name="pref_traffic_simplified_colors_title">Zjednodušené farby dopravy</string>
 	<string name="enable_logging">Zapnúť zaznamenávanie</string>
-	<string name="offline_place_page_more_information">Viac informácií o mieste získate po pripojení na internet.</string>
-	<string name="failed_load_information">Nepodarilo sa načítať informácie.</string>
 	<!-- Settings: "Send general feedback" button -->
 	<string name="feedback_general">Všeobecné pripomienky</string>
 	<string name="on">Zap.</string>
@@ -897,57 +570,26 @@
 	<string name="routing_add_start_point">Pridaním počiatočného bodu začnite plánovať trasu</string>
 	<string name="routing_add_finish_point">Pridaním cieľového bodu naplánujete trasu</string>
 	<string name="button_exit">Ukončiť</string>
-	<string name="settings_device_memory">Pamäť zariadenia</string>
-	<string name="settings_card_memory">Pamäť na karte</string>
-	<string name="settings_storage_available">K dispozícii %s</string>
-	<string name="toast_location_permission_denied">Zamietnutý prístup aplikácie k lokalite</string>
-	<string name="button_use">Použiť</string>
 	<string name="planning_route_manage_route">Spravovať trasu</string>
 	<string name="button_plan">Naplánovať</string>
-	<string name="button_add">Pridať</string>
 	<string name="placepage_remove_stop">Odstrániť</string>
 	<string name="planning_route_remove_title">Presunutím sem odstránite</string>
-	<string name="dialog_change_start_point_message">Nahradiť štart na aktuálnou polohou?</string>
-	<string name="button_replace">Nahradiť</string>
 	<string name="placepage_add_stop">Pridať zastávku</string>
-	<string name="add_my_position">Pridať moju polohu</string>
-	<string name="choose_start_point">Vyberte počiatočný bod</string>
-	<string name="choose_destination">Vyberte cieľ</string>
 	<string name="preloader_viator_button">Zistiť viac</string>
-	<string name="start_from_my_position">Začať od</string>
-	<string name="profile_authorization_title">Prihlásiť sa pomocou</string>
-	<string name="profile_authorization_message">Jednoduché prihlásenie bez zadávania mena a hesla za pár sekúnd</string>
 	<string name="profile_authorization_error">Ups, vyskytla sa chyba. Skúste sa prihlásiť znova.</string>
-	<string name="service">Služba</string>
-	<string name="atmosphere">Atmosféra</string>
-	<string name="value_for_money">Hodnota za peniaze</string>
-	<string name="experience">Skúsenosti</string>
-	<string name="assortment">Sortiment</string>
-	<string name="expertise">Odbornosť</string>
-	<string name="equipment">Vybavenie</string>
-	<string name="quality">Kvalita</string>
 	<string name="dialog_error_storage_title">Problém s prístupom k úložisku</string>
 	<string name="dialog_error_storage_message">Externý úložný priestor nie je dostupný, pravdepodobne je vytiahnutá alebo poškodená SD karta alebo je systém súborov určený iba na čítanie. Skontrolujte to, prosím, a kontaktujte nás na support\@organicmaps.app</string>
 	<string name="setting_emulate_bad_storage">Imitovať poškodené úložisko</string>
-	<string name="directions_finish">Ciel</string>
-	<string name="directions_on_foot">Chôdza %s</string>
 	<string name="core_entrance">Vchod  | vjazd</string>
-	<string name="coffee">Káva</string>
-	<string name="cleanliness">Čistota</string>
-	<string name="crowdedness">Preplnenosť</string>
 	<string name="error_enter_correct_name">Prosím, zadajte správne meno</string>
 	<string name="bookmarks_groups">Zoznamy</string>
 	<string name="bookmarks_groups_hide_all">Skryť všetko</string>
 	<string name="bookmarks_groups_show_all">Zobraziť všetko</string>
-	<plurals name="bookmarks_places">
-	  <item quantity="other">%d záložiek</item>
-	</plurals>
 	<string name="bookmarks_create_new_group">Vytvoriť nový zoznam</string>
 	<string name="downloader_hide_screen">Skryť obrazovku</string>
 	<string name="downloader_percent">%1$s (%2$s z %3$s)</string>
-	<string name="downloader_process">Sťahovanie %s...</string>
-	<string name="downloader_applying">Použitie %s...</string>
-	<string name="dialog_message_transit_not_found_connection">Naplánujte si trasu v jednej sieti verejnej dopravy</string>
+	<string name="downloader_process">Sťahovanie %s…</string>
+	<string name="downloader_applying">Použitie %s…</string>
 	<string name="bookmarks_error_message_share_general">Pre chybu aplikácie nie je zdieľanie možné</string>
 	<string name="bookmarks_error_title_share_empty">Chyba zdieľania</string>
 	<string name="bookmarks_error_message_share_empty">Prázdny zoznam nie je možné zdieľať</string>
@@ -956,48 +598,22 @@
 	<string name="bookmarks_new_list_hint">Nový zoznam</string>
 	<string name="bookmarks_error_title_list_name_already_taken">Tento názov už bol prijatý</string>
 	<string name="bookmarks_error_message_list_name_already_taken">Vyberte iné meno</string>
-	<string name="bookmarks_error_title_list_name_too_long">Tento názov je príliš dlhý</string>
-	<string name="bookmarks_error_message_list_name_too_long">Vyberte iné meno</string>
-	<string name="please_wait">Prosím čakajte...</string>
-	<string name="phone_number">Telefónne číslo</string>
-	<string name="notification_unsent_reviews_title">Máte niekoľko neoslaných recenzií</string>
-	<string name="notification_unsent_reviews_message">Prihláste sa a zdieľajte recenzie s ostatnými cestujúcimi</string>
+	<string name="please_wait">Prosím čakajte…</string>
 	<string name="profile">Profil OpenStreetMap</string>
 	<string name="place_page_search_similar_hotel">Vyhľadať podobné hotely</string>
 	<string name="bookmarks_detect_title">Zistené nové súbory</string>
 	<plurals name="bookmarks_detect_message">
-	  <item quantity="one">Bol nájdený %d súbor. Uvidíte to po konverzii.</item>
 	  <item quantity="few">Boli nájdené %d súbory. Uvidíte ich po konverzii.</item>
+	  <item quantity="one">Bol nájdený %d súbor. Uvidíte to po konverzii.</item>
 	  <item quantity="other">Bolo nájdených %d súborov. Uvidíte ich po konverzii.</item>
 	</plurals>
 	<string name="button_convert">Premeniť</string>
 	<string name="bookmarks_convert_error_title">Chyba</string>
 	<string name="bookmarks_convert_error_message">Niektoré súbory neboli konvertované.</string>
-	<string name="converting">Konverziu...</string>
-	<string name="wn_reinvented_bookmarks_title">Znovu sme vytvorili záložky!</string>
-	<string name="wn_reinvented_bookmarks_message">Môžete zálohovať záložky, vytvárať zoznamy... Je to úžasné...</string>
-	<string name="bookmarks_restore">Obnoviť záložky</string>
-	<string name="bookmarks_restore_process">Obnovenie...</string>
 	<string name="bookmarks_restore_title">Obnoviť túto verziu?</string>
-	<string name="bookmarks_restore_message">Záložky sa obnovia z %1$s (%2$s)</string>
-	<string name="bookmarks_restore_empty_title">Nemáte zálohu</string>
-	<string name="bookmarks_restore_empty_message">Server nenašiel predtým vytvorené zálohy</string>
 	<string name="common_check_internet_connection_dialog_title">Žiadne internetové pripojenie</string>
-	<string name="error_server_title">Chyba servera</string>
-	<string name="error_server_message">Na serveri sa vyskytla chyba, skúste to znova neskôr</string>
 	<string name="error_system_message">Vyskytla sa neznáma chyba</string>
 	<string name="restore">Obnoviť</string>
-	<string name="bookmarks_page_downloaded">Prevzaté</string>
-	<string name="bookmarks_page_my">Moje</string>
-	<string name="routes_and_bookmarks">Trasy a záložky</string>
-	<string name="bookmarks_webview_success_toast">Záložky úspešne prevzaté</string>
-	<string name="cached_bookmarks_placeholder_title">Prevziať nové miesta</string>
-	<string name="cached_bookmarks_placeholder_subtitle">Stlačením tlačidla stiahnete tisíce zaujímavých miest a trás vytvorených používateľmi Organic Maps. Budete potrebovať internetové pripojenie.</string>
-	<string name="downloader_download_routers">Prevziať záložky</string>
-	<string name="bookmarks_groups_cached">Prevziať zoznamy</string>
-	<plurals name="bookmarks_objects">
-	  <item quantity="other">%s objekt</item>
-	</plurals>
 	<plurals name="objects">
 	  <item quantity="other">%d miesto</item>
 	</plurals>
@@ -1010,62 +626,32 @@
 	<string name="subtittle_opt_out">Nastavenie sledovania</string>
 	<string name="crash_reports">Hlásenie chýb</string>
 	<string name="crash_reports_description">Vaše údaje môžeme použiť na zlepšenie skúseností s programom Organic Maps. Zmeny sa prejavia po reštartovaní aplikácie.</string>
-	<string name="opt_out_help_ios_1">Vaše mobilné zariadenie môže poskytnúť nastavenie „Obmedziť reklamné sledovanie“ alebo „Zrušiť inzerciu založenú na záujmoch“.</string>
-	<string name="opt_out_help_ios_2">iOS 9 alebo vyšší</string>
-	<string name="opt_out_help_ios_3">Prejdite do nastavenia → Ochrana osobných údajov → Reklama → Povolenie nastavenia „Obmedziť reklamné sledovanie“</string>
-	<string name="opt_out_help_android">Vaše mobilné zariadenie môže obsahovať nastavenie „Obmedziť reklamné sledovanie“ alebo „Zrušiť inzerciu založenú na záujmoch“. \n\nPre Android a služby Google Play verzie 4.0 a vyššie: \nNastavenia → Google → Reklamy → Zrušiť inzerciu založenú na záujmoch \nalebo\nNastavenia → Google → Google Účet → Osobné informácie a ochrana osobných údajov → Nastavenia reklamy → Personalizácia reklám</string>
 	<string name="privacy_policy">Zásady ochrany osobných údajov</string>
 	<string name="terms_of_use">Podmienky používania</string>
-	<string name="backup_notification_failed">Zálohovanie záložiek bolo pozastavené. Pre opätovné zapnutie sa prihláste.</string>
 	<string name="button_layer_traffic">Vyťaženie</string>
 	<string name="button_layer_subway">Metro</string>
 	<string name="layers_title">Vrstvy mapy</string>
-	<string name="layers_message">Na zobrazenie návštevnosti, mapy metra a ďalších užitočných informácií použite vrstvy mapy</string>
-	<string name="button_layer_got_it">Mám to</string>
 	<string name="subway_data_unavailable">Mapa metra nie je dostupná</string>
 	<string name="bookmarks_empty_list_title">Tento zoznam je prázdny</string>
 	<string name="bookmarks_empty_list_message">Pre pridanie záložky kliknite na miesto na mape a potom na ikonu hviezdy</string>
 	<string name="category_desc_more">…viac</string>
 	<string name="title_error_downloading_bookmarks">Vyskytla sa chyba</string>
-	<string name="subtitle_error_downloading_bookmarks">Záložky neboli stiahnuté</string>
-	<string name="error_already_downloaded">Tento zoznam už bol stiahnutý</string>
-	<string name="why_support">Prečo podporiť Organic Maps?</string>
-	<string name="why_support_item2">Pomôžete nám zlepšiť Organic Maps</string>
-	<string name="why_support_item3">Pomôžete nám vylepšiť otvorené mapy OpenStreetMap.org</string>
-	<string name="channels_map_update">Aktualizácia máp</string>
-	<string name="server_unavailable_title">Server je nedostupný</string>
-	<string name="sharing_options">Možnosti zdieľania</string>
 	<string name="export_file">Exportovať súbor</string>
 	<string name="list_settings">Nastavenie zoznamu</string>
 	<string name="delete_list">Vymazať zoznam</string>
-	<string name="hide_from_map">Skryť z mapy</string>
 	<string name="public_access">Verejný prístup</string>
 	<string name="limited_access">Obmedzený prístup</string>
 	<string name="bookmark_category_name">Kategória</string>
 	<string name="bookmark_category_description_hint">Zadajte popis (text alebo html)</string>
 	<string name="not_shared">Súkromné</string>
-	<string name="direct_link_progress_text">Nahrávanie váľho súboru…</string>
-	<string name="direct_link_success">Odkaz bol vytvorený</string>
-	<string name="send_a_link_btn">Poslať mi odkaz</string>
-	<string name="upload_error_toast">Počas nahrávania súboru sa vyskytla chyba</string>
 	<string name="tags_loading_error_subtitle">Počas načítavania značiek sa vyskytla chyba, skúste to znova</string>
-	<string name="unable_upload_errorr_title">Nahrávanie súboru zlyhalo</string>
-	<string name="unable_upload_error_subtitle_edited">Tento súbor bol upravený prostredníctvom webovej aplikácie</string>
-	<string name="unable_upload_error_subtitle_broken">Tento súbor je poškodený a nedá sa nahrať. Prosím nahrajte iný súbor.</string>
-	<string name="contact">Kontakt</string>
-	<string name="download_button">Stiahnuť</string>
 	<string name="speedcams_alert_title">Rýchlostné kamery</string>
-	<string name="speedcams_alert_subtitle">Upozornenie na rýchlostné obmedzenia</string>
 	<string name="speedcam_option_auto">Automaticky</string>
 	<string name="speedcam_option_always">Vždy</string>
 	<string name="speedcam_option_never">Nikdy</string>
-	<string name="bookmark_description_title">Popis záložiek</string>
 	<string name="place_description_title">Popis miesta</string>
 	<!-- this text will be shown in application notification preferences opposite checkbox which enable/disable downloader notifications. Devices on Android 8+ are affected. -->
 	<string name="notification_channel_downloader">Sťahovač máp</string>
-	<string name="share_bookmarks_email_body_link">Dobrý deň!\n\nTu je odkaz, kde si môžete stiahnuť svoje záložky: %s. Otvorte zoznam prostredníctvom služby Organic Maps a užite si výlet!\n\nZískajte aplikáciu: https://omaps.app/get?kmz</string>
-	<string name="warning_speedcams_title">Navigátor vás upozorní na kamery, keď prekročíte rýchlostný limit %d km/h</string>
-	<string name="warning_speedcams_subtitle">Dodržujte pravidlá cestnej premávky v krajine, do ktorej cestujete.</string>
 	<string name="speedcams_notice_message">Automaticky - Upozornenie na rýchlostné kamery, ak existuje riziko prekročenia rýchlostného limitu\nVždy - Vždy upozorniť na rýchlostné kamery\nNikdy - Nikdy neupozorňovať na rýchlostné kamery</string>
 	<string name="power_managment_title">Úsporný režim</string>
 	<string name="power_managment_description">Keď je zvolený automatický režim, aplikácia začne vypínať funkcie, ktoré vybíjajú batériu v závislosti od aktuálnej úrovne nabitia batérie</string>
@@ -1073,14 +659,7 @@
 	<string name="power_managment_setting_auto">Automaticky</string>
 	<string name="power_managment_setting_manual_max">Maximálna úspora batérie</string>
 	<string name="enable_logging_warning_message">Táto možnosť zapína zaznamenávanie na diagnostické účely. Môže to byť užitočné pre našu technickú podporu, ktorá rieši problémy s aplikáciou. Povoliť túto možnosť iba na požiadanie podpory Organic Maps.</string>
-	<string name="html_error_upload_message_try_again">Skontrolujte svoje sieťové nastavenia a skúste to znova</string>
-	<string name="html_error_upload_title_try_again">Žiadne internetové pripojenie</string>
-	<string name="notification_leave_review_v2_android_short_title">Ohodnotiť a pomôcť cestujúcim!</string>
-	<string name="notifications_illegal_alert_disable_button">Vypnite upozornenia</string>
 	<string name="access_rules_author_only">Online úprava</string>
-	<string name="privacy_settings_menu">Nastavenia ochrany osobných údajov</string>
-	<string name="unable_upadate_error_title">Aktualizácia súboru zlyhala</string>
-	<string name="unable_upadate_error_message">Počas aktualizácie sa vyskytli určité chyby. Skontrolujte zmeny a skúste to znova</string>
 	<string name="driving_options_title">Možnosti jazdy</string>
 	<string name="driving_options_subheader">Vyhnúť sa na každej trase</string>
 	<string name="avoid_tolls">Spoplatnené cesty</string>
@@ -1091,52 +670,14 @@
 	<string name="unable_to_calc_alert_subtitle">Bohužiaľ sme nemohli nájsť trasu pravdepodobne z dôvodu definovaných možností. Zmeňte nastavenia a skúste to prosím znova</string>
 	<string name="define_to_avoid_btn">Definovať cesty, ktorým sa treba vyhnúť</string>
 	<string name="change_driving_options_btn">Možnosti trasy povolené</string>
-	<string name="toll_road">Spoplatnená cesta</string>
-	<string name="unpaved_road">Nespevnená cesta</string>
-	<string name="ferry_crossing">Prechod trajektom</string>
-	<string name="operated_by">Prevádzkuje \"%s\"</string>
 	<string name="avoid_toll_roads_placepage">Vyhnúť sa spoplatneným cestám</string>
 	<string name="avoid_unpaved_roads_placepage">Vyhnúť sa nespevneným cestám</string>
 	<string name="avoid_ferry_crossing_placepage">Vyhnúť sa prechodom na trajekte</string>
-	<string name="type.cuisine.uzbek">Uzbecká kuchyňa</string>
-	<string name="trip_start">Poďme</string>
-	<string name="pick_destination">Cieľ</string>
-	<string name="follow_my_position">Vycentrovať</string>
-	<string name="search_results">Výsledky vyhľadávania</string>
-	<string name="then_turn">Potom</string>
-	<string name="redirect_route_alert">Chcete znova vytvoriť trasu?</string>
-	<string name="redirect_route_yes">Áno</string>
-	<string name="redirect_route_no">Nie</string>
-	<string name="trip_finished">Prišli ste do cieľa!</string>
-	<string name="keyboard_availability_alert">Počas jazdy nie je klávesnica k dispozícii</string>
-	<string name="dialog_routing_change_start_carplay">Z vašej aktuálnej polohy nie je možné vytvoriť trasu</string>
-	<string name="dialog_routing_change_end_carplay">Nie je možné vytvoriť trasu do cieľa. Prosím vyberte iný bod</string>
-	<string name="dialog_routing_check_gps_carplay">Žiaden GPS signál. Presuňte sa na otvorené priestranstvo</string>
-	<string name="dialog_routing_unable_locate_route_carplay">Nie je možné vytvoriť trasu. Prosím zadajte iné body trasy</string>
-	<string name="dialog_routing_download_files_carplay">Pre vytvorenie trasy si stiahnite do zariadenia chýbajúce mapy</string>
-	<string name="dialog_routing_system_error_carplay">Vyskytla sa chyba. Prosím reštartujte aplikáciu</string>
-	<string name="dialog_routing_rebuild_from_current_location_carplay">Trasa bude obnovená z vašej aktuálnej polohy</string>
-	<string name="dialog_routing_rebuild_for_vehicle_carplay">Trasa bude upravená na jazdu autom</string>
 	<string name="ok">Ok</string>
-	<string name="avoid_unpaved_carplay_1">Nespevn. NIE</string>
-	<string name="avoid_unpaved_carplay_2">Nespevnené ÁNO</string>
-	<string name="avoid_ferry_carplay_1">Trajekty NIE</string>
-	<string name="avoid_ferry_carplay_2">Trajekty ÁNO</string>
-	<string name="avoid_tolls_carplay_1">Spoplat. NIE</string>
-	<string name="avoid_tolls_carplay_2">Spoplatnené ÁNO</string>
-	<string name="speedcams_alert_title_carplay_1">Radary</string>
-	<string name="speedcams_alert_title_carplay_2">Rýchl. upozorn.</string>
-	<string name="download_map_carplay">Prosím stiahnite si mapy v aplikácii Organic Maps vo vašom zariadení</string>
-	<string name="carplay_roundabout_exit">%s výjazd</string>
 	<!-- max. 10 symbols, both iOS and Android -->
 	<string name="sort">Zoradiť…</string>
 	<!-- Android, title, max 20-22 symbols -->
 	<string name="sort_bookmarks">Zoradiť záložky</string>
-	<!-- iOS -->
-	<string name="sort_default">Zoradiť Predvolené</string>
-	<string name="sort_type">Zoradiť podľa typu</string>
-	<string name="sort_distance">Zoradiť podľa vzdialenosti</string>
-	<string name="sort_date">Zoradiť podľa dátumu</string>
 	<!-- Android -->
 	<string name="by_default">Podľa predvoleného</string>
 	<!-- Android -->
@@ -1145,65 +686,23 @@
 	<string name="by_distance">Podľa vzdialenosti</string>
 	<!-- Android -->
 	<string name="by_date">Podľa dátumu</string>
-	<string name="week_ago_sorttype">Pred týždňom</string>
-	<string name="month_ago_sorttype">Pred mesiacom</string>
-	<string name="moremonth_ago_sorttype">Pred viac ako mesiacom</string>
-	<string name="moreyear_ago_sorttype">Pred viac ako rokom</string>
-	<string name="near_me_sorttype">Blízko mňa</string>
-	<string name="others_sorttype">Iné</string>
-	<string name="food_places">Jedlo</string>
-	<string name="tourist_places">Pamiatky</string>
-	<string name="museums">Múzeá</string>
-	<string name="parks">Parky</string>
-	<string name="swim_places">Plávanie</string>
-	<string name="mountains">Hory</string>
-	<string name="animals">Zvieratá</string>
-	<string name="hotels">Hotely</string>
-	<string name="buildings">Budovy</string>
-	<string name="money">Peniaze</string>
-	<string name="shops">Obchody</string>
-	<string name="parkings">Parkovanie</string>
-	<string name="fuel_places">Čerpacie stanice</string>
-	<string name="water">Voda</string>
-	<string name="medicine">Medicína</string>
 	<string name="search_in_the_list">Vyhľadať v zozname</string>
-	<string name="view_on_map_bookmarks">Na mape</string>
-	<string name="more_bookmarks">Viac…</string>
-	<string name="no_items_found">Žiadne položky nenájdené</string>
-	<!-- Android, max 18 symbols -->
-	<string name="bookmarks_edit_list">Upraviť zoznam</string>
-	<!-- Android, max 18 symbols -->
-	<string name="bookmarks_delete_list">Vymazať zoznam</string>
-	<string name="religious_places">Náboženské miesta</string>
 	<string name="select_list">Vybrať zoznam</string>
 	<string name="transit_not_found">Navigácia metra v tejto oblasti ešte nie je k dispozícii</string>
 	<string name="dialog_pedestrian_route_is_long_header">Trasa metra sa nenašla</string>
 	<string name="dialog_pedestrian_route_is_long_message">Vyberte počiatočný alebo konečný bod bližšie k stanici metra</string>
-	<!-- Failed planning SUBWAY route message in navigation view -->
-	<string name="routing_planning_error_subway_special">Plánovanie trasy metra zlyhalo</string>
 	<string name="button_layer_isolines">Terén</string>
-	<string name="tips_map_layers_title_countour">Nové v Organic Maps: offline topografická vrstva!</string>
-	<string name="tips_map_layers_message_countour">Naplánujte a užite si výlety do prírody s istotou, že viete o tejto oblasti všetko</string>
 	<string name="isolines_activation_error_dialog">Ak chcete aktivovať a používať topografickú vrstvu, aktualizujte alebo stiahnite mapu oblasti</string>
 	<string name="isolines_location_error_dialog">Topografická vrstva ešte nie je v tejto oblasti k dispozícii</string>
 	<string name="elevation_profile_diff_level">Level obtiažnosti</string>
-	<string name="elevation_profile_diff_level_easy">Jednoduchá</string>
-	<string name="elevation_profile_diff_level_moderate">Mierna</string>
-	<string name="elevation_profile_diff_level_hard">Náročná</string>
 	<string name="elevation_profile_ascent">Výstup</string>
 	<string name="elevation_profile_descent">Zostup</string>
 	<string name="elevation_profile_minaltitude">Min. nadmorská výška</string>
 	<string name="elevation_profile_maxaltitude">Max. nadmorská výška</string>
-	<string name="elevation_profile_m">m</string>
 	<string name="elevation_profile_difficulty">Obtiažnosť</string>
 	<string name="elevation_profile_distance">Vzdial.:</string>
-	<string name="elevation_profile_km">km</string>
 	<string name="elevation_profile_time">Čas:</string>
-	<string name="elevation_profile_hours">h.</string>
-	<string name="elevation_profile_minutes">min</string>
 	<string name="isolines_toast_zooms_1_10">Priblížením preskúmajte izočiary</string>
-	<string name="downloader_updating_ios">Aktualizovanie</string>
-	<string name="downloader_loading_ios">Sťahovanie</string>
 	<string name="key_information_title">Kľúčová informácia</string>
 	<string name="enable_screen_sleep">Nechajte obrazovku spať</string>
 	<!-- Description in preferences -->

--- a/android/res/values-sv/strings.xml
+++ b/android/res/values-sv/strings.xml
@@ -12,8 +12,6 @@
 	<string name="cancel_download">Avbryt nedladdning</string>
 	<!-- Button which deletes downloaded country -->
 	<string name="delete">Ta bort</string>
-	<!-- Button "do not interrupt download" if user touched actively downloading country -->
-	<string name="do_nothing">Fortsätt</string>
 	<string name="download_maps">Ladda ner kartor</string>
 	<!-- Settings/Downloader - info for country when download fails -->
 	<string name="download_has_failed">Nedladdningen misslyckades, tryck för att försöka igen</string>
@@ -31,45 +29,31 @@
 	<string name="core_my_position">Min position</string>
 	<!-- Update maps later/Buy pro version later button text -->
 	<string name="later">Senare</string>
-	<!-- Don't show some dialog any more -->
-	<string name="never">Aldrig</string>
 	<!-- View and button titles for accessibility -->
 	<string name="search">Sök</string>
 	<!-- Search box placeholder text -->
 	<string name="search_map">Sök karta</string>
-	<!-- Settings/Downloader - info for not downloaded country -->
-	<string name="touch_to_download">Trycka för att ladda ner</string>
 	<!-- Settings/Downloader - 3G download warning dialog confirm button -->
 	<string name="use_cellular_data">Ja</string>
 	<!-- Location services are disabled by user alert - message -->
 	<string name="location_is_disabled_long_text">Du har inaktiverat alla platstjänster för denna enhet eller program. Vänligen aktivera dem i Inställningar.</string>
-	<!-- Location Services are not available on the device alert - message -->
-	<string name="device_doesnot_support_location_services">Din enhet stöder inte platstjänster</string>
 	<!-- View and button titles for accessibility -->
 	<string name="zoom_to_country">Visa på kartan</string>
-	<!-- Button text for the button at the center of the screen when the country is not downloaded -->
-	<string name="country_status_download">Ladda ner karta\n(^ ^)</string>
 	<!-- Button text for the button at the center of the screen when the country is not downloaded and the size should not be shown -->
 	<string name="country_status_download_without_size">Ladda ner karta</string>
-	<!-- Button text for the button at the center of the screen when the country is not downloaded -->
-	<string name="country_status_download_without_routing">Hämta karta\nutan rutter (^ ^)</string>
 	<!-- Message to display at the center of the screen when the country download has failed -->
 	<string name="country_status_download_failed">Downloading har misslyckats</string>
 	<!-- Button text for the button under the country_status_download_failed message -->
 	<string name="try_again">Försök igen</string>
 	<string name="about_menu_title">Om Organic Maps</string>
-	<string name="downloaded_touch_to_delete">Nedladdad (%s), tryck för att ta bort</string>
 	<string name="connection_settings">Anslutningsinställningar</string>
-	<string name="download_mb_or_kb">Ladda ner %s</string>
 	<string name="close">Stäng</string>
 	<string name="unsupported_phone">Hårdvaruaccelererad OpenGL krävs. Din enhet stöds tyvärr inte.</string>
 	<string name="download">Ladda ner</string>
-	<string name="external_storage_is_not_available">SD-kort/USB-lagring med nedladdade kartor är inte tillgänglig.</string>
 	<string name="disconnect_usb_cable">Vänligen koppla ifrån USB-kabeln eller sätt in ett minneskort för att använda Organic Maps</string>
 	<string name="not_enough_free_space_on_sdcard">Vänligen frigör utrymme på SD-kortet/USB-lagringen först för att använda denna app.</string>
 	<string name="not_enough_memory">Inte tillräckligt med utrymme för att starta appen</string>
 	<string name="download_resources">Innan du startar, låt oss ladda ner den generella världskartan på din enhet.\nDen behöver %s data.</string>
-	<string name="getting_position">Hämtar nuvarande position</string>
 	<string name="download_resources_continue">Gå till karta</string>
 	<string name="downloading_country_can_proceed">Laddar ner %s. Du kan nu\n fortsätta till kartan.</string>
 	<string name="download_country_ask">Ladda ner %s?</string>
@@ -82,30 +66,20 @@
 	<string name="download_country_failed">%s nedladdning misslyckades</string>
 	<!-- Add New Bookmark Set dialog title -->
 	<string name="add_new_set">Lägg till ny samling</string>
-	<!-- Place Page - Add To Bookmarks button -->
-	<string name="add_to_bookmarks">Lägg till till bokmärken</string>
 	<!-- Bookmark Color dialog title -->
 	<string name="bookmark_color">Bokmärkesfärg</string>
 	<!-- Add Bookmark Set dialog - hint when set name is empty -->
 	<string name="bookmark_set_name">Bokmärkessamlingens namn</string>
-	<!-- Bookmark Sets dialog title -->
-	<string name="bookmark_sets">Bokmärkessamlingar</string>
 	<!-- Bookmarks - dialog title -->
 	<string name="bookmarks">Bokmärken</string>
-	<!-- Add bookmark dialog - bookmark color -->
-	<string name="color">Färg</string>
 	<!-- Default bookmarks set name -->
 	<string name="core_my_places">Mina Platser</string>
 	<!-- Add bookmark dialog - bookmark name -->
 	<string name="name">Namn</string>
 	<!-- Editor title above street and house number -->
 	<string name="address">Adress</string>
-	<!-- Place Page - Remove Pin button -->
-	<string name="remove_pin">Ta bort knappnål</string>
 	<!-- Add bookmark dialog - bookmark set, Bookmarks dialog - Bookmark set cell -->
 	<string name="set">Samling</string>
-	<!-- Text hint in Bookmarks dialog when no any bookmarks are added -->
-	<string name="bookmarks_usage_hint">Du har inga bokmärken än.\nTryck var som helst på kartan för att lägga till ett bokmärke.\nBokmärken från andra källor kan också importeras och visas i Organic Maps. Öppna KML/KMZ filer med sparade bokmärken från mail, Dropbox eller webadress.</string>
 	<!-- Settings button in system menu -->
 	<string name="settings">Inställningar</string>
 	<!-- Header of settings activity where user defines storage path -->
@@ -116,20 +90,10 @@
 	<string name="move_maps">Flytta kartor?</string>
 	<!-- Ask to wait user several minutes (some long process in modal dialog). -->
 	<string name="wait_several_minutes">Detta kan ta flera minuter.\nVänligen vänta…</string>
-	<!-- Show bookmarks from this category on a map or not -->
-	<string name="visible">Synliga</string>
-	<!-- Toast which is displayed when GPS has been deactivated -->
-	<string name="gps_is_disabled_long_text">GPS har inaktiverats. Vänligen aktivera den i Inställningar.</string>
 	<!-- Measurement units title in settings activity -->
 	<string name="measurement_units">Längdenheter</string>
 	<!-- Detailed description of Measurement Units settings button -->
 	<string name="measurement_units_summary">Välj mellan mil och kilometer</string>
-	<!-- Do search in all sources -->
-	<string name="search_mode_all">Överallt</string>
-	<!-- Do search near my position only -->
-	<string name="search_mode_nearme">I närheten</string>
-	<!-- Do search in current viewport only -->
-	<string name="search_mode_viewport">På skärmen</string>
 	<!-- Search category for cafes, bars, restaurants -->
 	<string name="eat">Var att äta</string>
 	<!-- Search category for grocery stores -->
@@ -166,12 +130,8 @@
 	<string name="post">Post</string>
 	<!-- Search category -->
 	<string name="police">Polis</string>
-	<!-- String in search result list, when nothing found -->
-	<string name="no_search_results_found">Inga resultat</string>
 	<!-- Notes field in Bookmarks view -->
 	<string name="description">Anteckningar</string>
-	<!-- Button text -->
-	<string name="share_by_email">Dela via email</string>
 	<!-- Email Subject when sharing bookmarks category -->
 	<string name="share_bookmarks_email_subject">Organic Maps bokmärken har delats med dig</string>
 	<!-- message title of loading file -->
@@ -184,20 +144,10 @@
 	<string name="edit">Redigera</string>
 	<!-- Warning message when doing search around current position -->
 	<string name="unknown_current_position">Din position har inte bestämts ännu</string>
-	<!-- Warning message when location country isn't downloaded during search (see also download_location_map_proposal). -->
-	<string name="download_location_country">Ladda ner landet vid din nuvarande position (%s)</string>
-	<!-- Warning message when viewport country isn't downloaded during search -->
-	<string name="download_viewport_country_to_search">Ladda ner landet du söker på (%s)</string>
 	<!-- Alert message that we can't run Map Storage settings due to some reasons. -->
 	<string name="cant_change_this_setting">Ledsen, Kartlagring är inaktiverat i inställningar</string>
 	<!-- Alert message that downloading is in progress. -->
 	<string name="downloading_is_active">Nedladdning av landet är startat nu.</string>
-	<!-- Message that will be shown in alert view, when we ask user to leave review on App Store -->
-	<string name="appStore_message">Hoppas du gillar att använda Organic Maps! I så fall, skriv en recension eller ge ett betyg på App Store. Det tar mindre än en minut men kan verkligen hjälpa oss. Tack för din hjälp!</string>
-	<!-- No, thanks -->
-	<string name="no_thanks">Nej, tack</string>
-	<!-- Share one specific bookmark using SMS, %1$@ contains om:// and %2$@ https://omaps.app link. @NOTE non-ascii symbols in the link will result in max 70 characters SMS instead of 140. -->
-	<string name="bookmark_share_sms">Hej, kolla på min pin på Organic Maps! %1$s eller %2$s Har du inte offline-kartor installerat? Ladda ner här: https://omaps.app/get</string>
 	<!-- Share my position using SMS, %1$@ contains om:// and %2$@ https://omaps.app link WITHOUT NAME. @NOTE non-ascii symbols in the link will result in max 70 characters SMS instead of 140. -->
 	<string name="my_position_share_sms">Hej, kolla på min nuvarande position på Organic Maps! %1$s eller %2$s Har du inte offline-kartor? Ladda ner här: https://omaps.app/get</string>
 	<!-- Subject for emailed bookmark -->
@@ -206,30 +156,16 @@
 	<string name="my_position_share_email_subject">Hej, kolla på min nuvarande position på Organic Maps kartan!</string>
 	<!-- Share my position using EMail, %1$@ is om:// and %2$@ is https://omaps.app link WITHOUT NAME -->
 	<string name="my_position_share_email">Hej,\n\nJag är här nu: %1$s. Klicka på denna länk %2$s eller denna %3$s för att se platsen på kartan.\n\nTack.</string>
-	<!-- Android share by Message/SMS button text (including SMS) -->
-	<string name="share_by_message">Dela via meddelande</string>
 	<!-- Share button text which opens menu with more buttons, like Message, EMail, Facebook etc. -->
 	<string name="share">Dela</string>
-	<!-- iOS share by Message button text (including SMS) -->
-	<string name="message">Meddelande</string>
 	<!-- Share by email button text, also used in editor. -->
 	<string name="email">E-post</string>
-	<!-- Copy Link -->
-	<string name="copy_link">Kopiera Länk</string>
-	<!-- Text for the button that returns to caller application -->
-	<string name="more_info">Visa Mer Info</string>
 	<!-- Text for message when used successfully copied something -->
 	<string name="copied_to_clipboard">Kopierat till urklippsbordet: %1$s</string>
 	<!-- place preview title -->
 	<string name="info">Info</string>
 	<!-- Used for bookmark editing -->
 	<string name="done">Klar</string>
-	<!-- Summary for preferences in MWM -->
-	<string name="yopme_pref_summary">Välj bakskärmsinställningar</string>
-	<!-- Title for yopme preferences in MWM -->
-	<string name="yopme_pref_title">Bakskärmsinställningar</string>
-	<!-- Hint for upper-right icon p2b -->
-	<string name="show_on_backscreen">Visa på bakskärm</string>
 	<!-- Prints version number in About dialog -->
 	<string name="version">Version: %s</string>
 	<!-- Confirmation in downloading countries dialog -->
@@ -239,11 +175,6 @@
 	<!-- Length of track in cell that describes route -->
 	<string name="length">Längd</string>
 	<string name="share_my_location">Dela Min Plats</string>
-	<string name="menu_search">Sök</string>
-	<!-- Settings screen: "Map" category title -->
-	<string name="prefs_group_map">Karta</string>
-	<!-- Settings screen: "Miscellaneous" category title -->
-	<string name="prefs_group_misc">Diverse</string>
 	<string name="prefs_group_route">Navigering</string>
 	<string name="pref_zoom_title">Zoom-knappar</string>
 	<string name="pref_zoom_summary">Visa på skärmen</string>
@@ -259,8 +190,6 @@
 	<string name="pref_map_3d_title">Perspektivvy</string>
 	<!-- Settings «Map» category: «3D buildings» title -->
 	<string name="pref_map_3d_buildings_title">3D-byggnader</string>
-	<!-- Settings «Map» category: «3D buildings» summary -->
-	<string name="pref_map_3d_buildings_subtitle">Påverkar batteriets livslängd</string>
 	<!-- Settings «Route» category: «Tts enabled» title -->
 	<string name="pref_tts_enable_title">Röstinstruktioner</string>
 	<!-- Settings «Route» category: «Tts language» title -->
@@ -269,7 +198,6 @@
 	<string name="pref_tts_unavailable">Inte tillgängligt</string>
 	<!-- Title for "Other" section in TTS settings. -->
 	<string name="pref_tts_other_section_title">Övrigt</string>
-	<string name="pref_tts_how_to_set_up_voice">Hur man ställer in ljud</string>
 	<!-- Settings «Map» category: «Record track» title -->
 	<string name="pref_track_record_title">Senaste resväg</string>
 	<string name="pref_map_auto_zoom">Automatisk zoom</string>
@@ -280,46 +208,11 @@
 	<string name="duration_12_hours">12 timmar</string>
 	<string name="duration_1_day">1 dag</string>
 	<string name="recent_track_help_text">Detta gör att du kan spara en resväg för en viss tidsperiod och visa den på kartan. Obs: aktivering av den här funktionen ökar batterianvändningen. Spåret tas bort automatiskt från kartan när tidsintervallet slutar gälla.</string>
-	<string name="pref_track_ios_caption">Senaste resväg visar den väg du rest.</string>
-	<string name="pref_track_ios_subcaption">Välj tidsintervall för att spara resvägen.</string>
-	<string name="placepage_distance">Avstånd</string>
-	<string name="placepage_coordinates">Koordinater</string>
-	<string name="placepage_unsorted">Osorterade</string>
 	<string name="search_show_on_map">Visa på kartan</string>
-	<!-- Used to warn user when fixing KitKat issue -->
-	<string name="bookmark_move_fail">Vi behöver flytta dina bokmärken till internminnet, men det finns inte tillräckligt med utrymme för dem. Vänligen frigör mer minne, annars kommer bokmärkena inte finnas tillgängliga.</string>
-	<!-- Used in More Apps menu -->
-	<string name="free">Gratis</string>
-	<!-- Used in More Apps menu -->
-	<string name="buy">Köp</string>
-	<!-- 1st search button-like result -->
-	<string name="search_on_map">Sök på kartan</string>
-	<!-- toast with an error -->
-	<string name="no_route_found">Ingen rutt hittades</string>
-	<!-- route title -->
-	<string name="route">Rutt</string>
-	<!-- category title -->
-	<string name="routes">Rutter</string>
-	<!-- text of notification -->
-	<string name="download_map_notification">Ladda ner kartan över din nuvarande plats</string>
-	<!-- text of notification -->
-	<string name="pro_version_is_free_today">Fullständig version av Organic Maps är gratis idag! Ladda ner den nu och berätta för dina vänner.</string>
-	<!-- Dialog for transferring maps from lite to pro. -->
-	<string name="move_lite_maps_to_pro">Vi flyttar dina nedladdade kartor från Organic Maps Lite till Organic Maps. Det kan ta några minuter.</string>
-	<!-- Message to display when maps moved. -->
-	<string name="move_lite_maps_to_pro_ok">Dina nedladdade kartor flyttades till Organic Maps.</string>
-	<!-- Message to display when maps move failed. -->
-	<string name="move_lite_maps_to_pro_failed">Flytten av dina kartor misslyckades. Vänligen ta bort Organic Maps Lite och ladda ner kartorna igen.</string>
-	<!-- Text in menu -->
-	<string name="settings_and_more">Inställningar &amp; Mer</string>
 	<!-- Text in menu -->
 	<string name="website">Webbplats</string>
-	<!-- Text in menu -->
-	<string name="contact_us">Kontakta oss</string>
 	<!-- Settings: Send feedback button and dialog title -->
 	<string name="feedback">Feedback</string>
-	<!-- Text in menu -->
-	<string name="subscribe_to_news">Prenumerera på våra nyheter</string>
 	<!-- Text in menu -->
 	<string name="rate_the_app">Ge appen ett betyg</string>
 	<!-- Text in menu -->
@@ -328,149 +221,62 @@
 	<string name="copyright">Copyright</string>
 	<!-- Text in menu -->
 	<string name="report_a_bug">Rapportera en bugg</string>
-	<!-- Email subject -->
-	<string name="subscribe_me_subject">Anmäl mig till Organic Maps nyhetsbrev</string>
-	<!-- Email body -->
-	<string name="subscribe_me_body">Jag vill bli först att veta om de senaste uppdateringarna och erbjudandena. Jag kan avbryta min prenumeration när som helst.</string>
-	<!-- About text -->
-	<string name="about_text">Organic Maps erbjuder de snabbaste offline-kartorna över alla städer och länder i hela världen. Res med förtroende: oavsett var du är hjälper Organic Maps dig att placera dig på kartan, hitta den närmaste restaurangen, hotellet, banken, bensinstationen m.m. Den kräver inte internetanslutning.\n\nVi arbetar ständigt med nya funktioner och vill gärna veta hur du tycker att vi kan förbättra Organic Maps. Ifall du har problem med appen, tveka inte att kontakta oss på support\@organicmaps.app. Vi svarar på alla mail!\n\nGillar du Organic Maps och vill hjälpa oss? Det finns några enkla och kostnadsfria sätt:\n\n- posta en recension på din Appmarknad\n- gilla vår Facebooksida http://www.facebook.com/OrganicMaps\n- eller berätta bara om Organic Maps för din mamma, vänner eller kollegor :)\n\nTack för att du är med oss. Vi uppskattar ditt stöd väldigt mycket!\n\nP.S. Vi använder oss av kartdata från OpenStreetMap, ett kartprojket som liknar Wikipedia och som tillåter användare att skapa och redigera kartor. Ifall du ser något som saknas eller är fel på kartan så kan du korrigera kartan direkt på https://www.openstreetmap.org och dina ändringar kommer att finns i Organic Maps appen när nästa version släpps.</string>
 	<!-- Alert text -->
 	<string name="email_error_body">Emailklienten har inte konfigurerats. Konfigurera den eller använd ett annat sätt att kontakta oss på %s</string>
 	<!-- Alert title -->
 	<string name="email_error_title">Fel när mailet skulle skickas</string>
 	<!-- Settings item title -->
 	<string name="pref_calibration_title">Kompasskalibrering</string>
-	<!-- Update map suggestion -->
-	<string name="routing_map_outdated">Uppdatera kartan för att skapa en rutt.</string>
-	<!-- Update maps suggestion -->
-	<string name="routing_update_maps">Den nya versionen av Organic Maps låter dig skapa rutter från din nuvarande position till en destinationspunkt. Uppdatera kartan för att använda den här funktionen.</string>
 	<!-- Update all button text -->
 	<string name="downloader_update_all_button">Uppdatera alla</string>
 	<!-- Cancel all button text -->
 	<string name="downloader_cancel_all">Avbryt alla</string>
 	<!-- Downloaded maps category -->
 	<string name="downloader_downloaded_subtitle">Nedladdade</string>
-	<!-- Downloaded maps category -->
-	<string name="downloader_available_maps">Tillgänglig</string>
 	<!-- Country queued for download -->
 	<string name="downloader_queued">Köade</string>
 	<string name="downloader_near_me_subtitle">Nära mig</string>
 	<string name="downloader_status_maps">Kartor</string>
 	<string name="downloader_download_all_button">Ladda ned alla</string>
 	<string name="downloader_downloading">Ladda ner:</string>
-	<string name="downloader_search_results">Hittat</string>
-	<!-- Disclaimer message -->
-	<string name="routing_disclaimer">När du skapar rutter i appen Organic Maps, vänligen tänk på följande:\n\n  - Föreslagna rutter kan endast ses som rekommendationer.\n - Vägskick, trafikregler och skyltar har högre prioritet än navigeringsråd.\n - Kartan kan vara felaktig eller förlegad, och rutter skapas inte alltid på bästa tänkbara sätt.\n\n  Kör säkert på vägarna och ta hand om dig själv!</string>
-	<!-- Outdated maps category -->
-	<string name="downloader_outdated_maps">Gammal</string>
-	<!-- Up to date maps category -->
-	<string name="downloader_uptodate_maps">Aktuell</string>
 	<!-- Status of outdated country in the list -->
 	<string name="downloader_status_outdated">Uppdatera</string>
 	<!-- Status of failed country in the list -->
 	<string name="downloader_status_failed">Misslyckades</string>
 	<!-- Displayed in a dialog that appears when a user tries to delete a map while the app is in the follow route mode -->
 	<string name="downloader_delete_map_while_routing_dialog">Avsluta navigering för att radera kartan.</string>
-	<!-- Show when user try build route, but we don't know where he -->
-	<string name="routing_failed_unknown_my_position">Nuvarande plats är inte definierad. Ange din plats för att skapa rutt.</string>
-	<!-- Show if use has not routing file, or InconsistentMWMandRoute -->
-	<string name="routing_failed_has_no_routing_file">Ytterligare data behövs för att skapa en rutt. Påbörja nedladdning?</string>
-	<!-- StartPointNotFound -->
-	<string name="routing_failed_start_point_not_found">Rutten kan inte beräknas. Det finns inga vägar vid startpunkten.</string>
-	<!-- EndPointNotFound -->
-	<string name="routing_failed_dst_point_not_found">Rutten kan inte beräknas. Det finns inga vägar vid målet.</string>
 	<!-- PointsInDifferentMWM -->
 	<string name="routing_failed_cross_mwm_building">Rutter kan endast skapas om de finns inom en enda karta.</string>
-	<!-- RouteNotFound -->
-	<string name="routing_failed_route_not_found">Ingen rutt hittades mellan vald startpunkt och målet. Välj en annan start- eller slutpunkt.</string>
-	<!-- InternalError -->
-	<string name="routing_failed_internal_error">Ett internt fel inträffade. Försök att radera och ladda ner kartan igen. Kontakta oss på support\@organicmaps.app om problemet kvarstår.</string>
-	<!-- Context menu item for downloader. -->
-	<string name="downloader_download_map_and_routing">Ladda ner karta + anvisningar</string>
-	<!-- Context menu item for downloader. -->
-	<string name="downloader_download_routing">Ladda ner anvisningar</string>
-	<!-- Context menu item for downloader. -->
-	<string name="downloader_delete_routing">Radera anvisningar</string>
 	<!-- Context menu item for downloader. -->
 	<string name="downloader_download_map">Ladda ner kartan</string>
-	<string name="downloader_download_map_no_routing">Hämta karta utan rutter</string>
-	<!-- Button for routing. -->
-	<string name="routing_go">Kör!</string>
 	<!-- Item status in downloader. -->
 	<string name="downloader_retry">Repetera</string>
-	<!-- Item in context menu. -->
-	<string name="downloader_map_and_routing">Karta + Navigering</string>
 	<!-- Item in context menu. -->
 	<string name="downloader_delete_map">Radera karta</string>
 	<!-- Item in context menu. -->
 	<string name="downloader_update_map">Uppdatera karta</string>
-	<!-- Item in context menu. -->
-	<string name="downloader_update_map_and_routing">Uppdatera karta + Navigering</string>
-	<!-- Item in context menu. -->
-	<string name="downloader_map_only">Endast karta</string>
-	<!-- Toolbar title -->
-	<string name="toolbar_application_menu">Programmeny</string>
 	<!-- Preference text -->
 	<string name="pref_use_google_play">Använd Google Play Services för att bestämma din aktuella position</string>
 	<!-- Text for rating dialog -->
 	<string name="rating_just_rated">Jag har precis betygsatt er app</string>
-	<!-- Text for rating dialog -->
-	<string name="rating_user_since">Jag har använt Organic Maps sedan %s</string>
-	<!-- Text for rating dialog -->
-	<string name="rating_do_like_maps">Gillar du Organic Maps?</string>
-	<!-- Text for rating dialog -->
-	<string name="rating_tap_star">Tryck på en stjärna för att betygsätta vår app.</string>
 	<!-- Text for rating dialog -->
 	<string name="rating_thanks">Tack!</string>
 	<!-- Text for rating dialog -->
 	<string name="rating_share_ideas">Dela med dig av dina idéer eller problem så att vi kan förbättra appen åt dig.</string>
 	<!-- Text for rating dialog -->
 	<string name="rating_send_feedback">Skicka återkoppling</string>
-	<!-- Text for g+ dialog -->
-	<string name="rating_google_plus">Klicka på g+ för att berätta om appen för dina vänner.</string>
 	<!-- Text for routing error dialog -->
 	<string name="routing_download_maps_along">Ladda ned kartor längs vägen</string>
-	<!-- Text for routing error dialog -->
-	<string name="routing_download_map">Hämta karta</string>
-	<!-- Text for routing error dialog -->
-	<string name="routing_download_map_and_routing">Ladda ner uppdaterad karta och navigeringsdata för att få tillgång till alla Organic Maps funktioner.</string>
-	<!-- Text for routing error dialog -->
-	<string name="routing_get_routing_data">Hämta navigeringsdata</string>
-	<!-- Text for routing error dialog -->
-	<string name="routing_get_additional_data">Ytterligare data krävs för att skapa navigeringsvägar från din plats</string>
 	<!-- Text for routing error dialog -->
 	<string name="routing_requires_all_map">Att kunna skapa en navigeringsväg kräver att alla kartorna från din plats till din destination är nerladdade och uppdaterade.</string>
 	<!-- Text for routing error dialog -->
 	<string name="routing_not_enough_space">För lite utrymme kvar</string>
-	<!-- Text for routing error dialog -->
-	<string name="routing_download_more_than_avail">Du behöver ladda ner %1$s MB men du har bara %2$s MB tillgänglig</string>
-	<!-- Text for routing error dialog -->
-	<string name="routing_download_roaming">Du kommer ladda ner %s MB med mobildata (i roamingläge). Detta kan resultera i extra kostnader beroende på din operatörs mobildataplan.</string>
 	<!-- bookmark button text -->
 	<string name="bookmark">bokmärke</string>
-	<!-- map is not downloaded -->
-	<string name="not_found_map">Kartan för din plats hittas inte</string>
 	<!-- location service disabled -->
 	<string name="enable_location_services">Vänligen aktivera platstjänster</string>
-	<!-- download map -->
-	<string name="download_map">Ladda ner kartan över din nuvarande plats</string>
-	<!-- download map on iPhone -->
-	<string name="download_map_iphone">Ladda ner kartan för aktuell plats på din iPhone</string>
-	<!-- clear pin -->
-	<string name="nearby">I närheten</string>
-	<!-- clear pin -->
-	<string name="clear_pin">Rensa Pin</string>
-	<!-- location is undefined -->
-	<string name="undefined_location">Nuvarande plats är inte definierad.</string>
-	<!-- download country of your location -->
-	<string name="download_country">Ladda ner landet vid din nuvarande position</string>
-	<!-- download failed -->
-	<string name="download_failed">nedladdning misslyckades</string>
-	<!-- get the map -->
-	<string name="get_the_map">Hämta karta</string>
 	<string name="save">Spara</string>
 	<string name="edit_description_hint">Dina beskrivningar (text eller html)</string>
-	<string name="new_group">ny grupp</string>
 	<string name="create">skapa</string>
 	<!-- red color -->
 	<string name="red">Röd</string>
@@ -488,22 +294,6 @@
 	<string name="brown">Brun</string>
 	<!-- pink color -->
 	<string name="pink">Rosa</string>
-	<!-- deep purple color -->
-	<string name="deep_purple">Mörk purpur</string>
-	<!-- light blue color -->
-	<string name="light_blue">Ljusblå</string>
-	<!-- cyan color -->
-	<string name="cyan">Blågrön</string>
-	<!-- teal color -->
-	<string name="teal">Smaragdgrön</string>
-	<!-- lime color -->
-	<string name="lime">Limefärg</string>
-	<!-- deep orange color -->
-	<string name="deep_orange">Mörkorange</string>
-	<!-- gray color -->
-	<string name="gray">Grå</string>
-	<!-- blue gray color -->
-	<string name="blue_gray">Ljusblå grå</string>
 	<!-- Wi-Fi available -->
 	<string name="WiFi_available">Ja</string>
 
@@ -519,10 +309,8 @@
 	<string name="dialog_routing_location_turn_wifi">Kontrollera din GPS-signal. Aktivera Wi-Fi-anslutning för att förbättra platsprecisionen.</string>
 	<string name="dialog_routing_location_turn_on">Aktivera platstjänster</string>
 	<string name="dialog_routing_location_unknown_turn_on">Kan inte lokalisera nuvarande GPS-koordinater. Aktivera platstjänster för att beräkna väg.</string>
-	<string name="dialog_routing_location_unknown">Kan inte lokalisera nuvarande GPS-koordinater.</string>
 	<string name="dialog_routing_download_files">Ladda ned nödvändiga filer</string>
 	<string name="dialog_routing_download_and_update_all">Ladda ned och uppdatera all kart- och väginformation längs den beräknade vägbanan för att beräkna vägen.</string>
-	<string name="dialog_routing_routes_size">Väginformationsfiler</string>
 	<string name="dialog_routing_unable_locate_route">Kan inte lokalisera väg</string>
 	<string name="dialog_routing_cant_build_route">Kan inte skapa väg.</string>
 	<string name="dialog_routing_change_start_or_end">Justera din startpunkt eller din destination.</string>
@@ -537,33 +325,23 @@
 	<string name="dialog_routing_system_error">Systemfel</string>
 	<string name="dialog_routing_application_error">Kan inte skapa väg på grund av ett programfel.</string>
 	<string name="dialog_routing_try_again">Försök igen</string>
-	<string name="dialog_routing_send_error">Rapportera problem</string>
-	<string name="dialog_routing_if_get_cross_route">Vill du skapa en mer direkt väg som sträcker sig över fler än en karta?</string>
-	<string name="dialog_routing_cross_route_is_optimal">En optimalare väg som sträcker sig utanför den här kartan är tillgänglig.</string>
 	<string name="not_now">Inte nu</string>
-	<string name="dialog_routing_build_route">Skapa</string>
 	<string name="dialog_routing_download_and_build_cross_route">Vill du ladda ned kartan och skapa en optimalare väg som sträcker sig över fler än en karta?</string>
 	<string name="dialog_routing_download_cross_route">Ladda ned kartan för att skapa en optimalare väg som sträcker sig utanför den här kartan.</string>
-	<string name="dialog_routing_cross_route_always">Korsa alltid den här gränsen</string>
 
 	<!-- SECTION: Strings for downloading map from search -->
 	<string name="search_without_internet_advertisement">För att börja söka och skapa rutter, ladda ner kartan, och du behöver inte Internet-anslutning längre.</string>
 	<string name="search_select_map">Välj kartan</string>
-	<string name="search_select_other_map">Välj en annan karta</string>
 	<!-- «Show» context menu -->
 	<string name="show">Visa</string>
 	<!-- «Hide» context menu -->
 	<string name="hide">Göm</string>
 	<!-- «Rename» context menu -->
 	<string name="rename">Byt namn</string>
-	<!-- Bottom sheet: expand button (should be short) -->
-	<string name="bottom_sheet_more">Mer…</string>
 	<!-- Failed planning route message in navigation view -->
 	<string name="routing_planning_error">Ruttplanering misslyckades</string>
 	<!-- Arrive routing message in navigation view -->
 	<string name="routing_arrive">Ankomst: %s</string>
-	<!-- Text for routing::RouterResultCode::FileTooOld dialog. -->
-	<string name="dialog_routing_download_and_update_maps">För att skapa en rutt, ladda ner och uppdatera alla kartor längs rutten.</string>
 	<string name="rate_alert_title">Gillar du appen?</string>
 	<string name="rate_alert_default_message">Tack för att du använder Organic Maps. Betygsätt gärna appen. Din feedback hjälper oss att bli bättre.</string>
 	<string name="rate_alert_five_star_message">Hurra! Vi älskar dig också!</string>
@@ -571,24 +349,14 @@
 	<string name="rate_alert_less_than_four_star_message">Har du någon idé om hur vi ska bli bättre?</string>
 	<string name="categories">Kategorier</string>
 	<string name="history">Historik</string>
-	<string name="next_turn_then">Sedan</string>
 	<string name="closed">Stängt</string>
-	<string name="back_to">Tillbaka till %s</string>
 	<string name="search_not_found">Ledsen, jag hittade ingenting.</string>
 	<string name="search_not_found_query">Försök med en annan sökförfrågan.</string>
-	<string name="search_not_found_map">Ladda ner kartan du söker på.</string>
-	<string name="search_not_found_location">Ladda ner kartan över din nuvarande position.</string>
 	<string name="search_history_title">Sökhistorik</string>
 	<string name="search_history_text">Få snabbare åtkomst till senaste sökförfrågan.</string>
 	<string name="clear_search">Rensa sökhistorik</string>
-	<!-- Title for settings to enable/disable showcase menu button -->
-	<string name="showcase_settings_title">Visa erbjudanden</string>
-	<string name="p2p_route_planning">Ruttplanering</string>
 	<string name="p2p_your_location">Din plats</string>
-	<string name="p2p_from">Startplats</string>
-	<string name="p2p_to">Målplats</string>
 	<string name="p2p_start">Start</string>
-	<string name="p2p_planning">Planerar…</string>
 	<string name="p2p_from_here">Från</string>
 	<string name="p2p_to_here">Rutt till</string>
 	<string name="p2p_only_from_current">Navigering är endast tillgänglig från din aktuella plats.</string>
@@ -608,11 +376,8 @@
 	<string name="editor_hours_closed">Stängda timmar</string>
 	<string name="editor_example_values">Exempelvärden</string>
 	<string name="editor_correct_mistake">Korrigera fel</string>
-	<string name="editor_correct_mistake_message">Du har gjort ett fel i redigeringen. Var vänlig korrigera det eller byt till enkelt läge.</string>
 	<string name="editor_add_select_location">Plats</string>
 	<string name="editor_done_dialog_1">Du har ändrat världskartan. Dölj inte detta! Berätta för dina vänner och redigera den tillsammans.</string>
-	<string name="editor_done_dialog_2">Detta är din andra kartförbättring. Du är nu på plats %d i listan över kartredigerare. Berätta för dina vänner om det.</string>
-	<string name="editor_done_dialog_3">Du har förbättrat kartan, berätta för dina vänner om det och redigera kartan tillsammans.</string>
 	<string name="share_with_friends">Dela med vänner</string>
 	<string name="editor_report_problem_desription_1">Beskriv problemet i detalj så att OpenStreeMaps community kan lösa felet.</string>
 	<string name="editor_report_problem_desription_2">Eller gör det själv på https://www.openstreetmap.org/</string>
@@ -621,14 +386,7 @@
 	<string name="editor_report_problem_no_place_title">Platsen existerar inte</string>
 	<string name="editor_report_problem_under_construction_title">Stängd för underhåll</string>
 	<string name="editor_report_problem_duplicate_place_title">Duplicerad plats</string>
-	<string name="first_launch_congrats_title">Du kan nu använda Organic Maps</string>
-	<string name="first_launch_congrats_text">Sök och navigera offline var som helst i världen, helt gratis.</string>
-	<string name="migrate_title">Viktigt!</string>
-	<!-- Android uses image instead of text. -->
-	<string name="download_all">Ladda ner alla</string>
-	<string name="delete_all">Radera alla</string>
 	<string name="autodownload">Automatisk nedladdning</string>
-	<string name="disable_autodownload">Avaktivera automatisk nedladdning</string>
 	<!-- Place Page opening hours text -->
 	<string name="closed_now">Stängt just nu</string>
 	<!-- Place Page opening hours text -->
@@ -637,8 +395,6 @@
 	<string name="day_off_today">Stängt idag</string>
 	<string name="day_off">Stängt</string>
 	<string name="today">Idag</string>
-	<string name="sunrise_to_sunset">Från gryning till skymning</string>
-	<string name="sunset_to_sunrise">Från soluppgång till solnedgång</string>
 	<string name="add_opening_hours">Lägg till öppettider</string>
 	<string name="edit_opening_hours">Redigera öppettider</string>
 	<string name="no_osm_account">Inget konto hos OpenStreetMap?</string>
@@ -648,29 +404,13 @@
 	<string name="login">Logga in</string>
 	<string name="password">Lösenord</string>
 	<string name="forgot_password">Glömt lösenord?</string>
-	<!-- Forgot Password dialog title -->
-	<string name="restore_password">Återställ lösenord?</string>
-	<string name="enter_email_address_to_reset_password">Mata in e-postadressen som du använde vid registrering så skickar vi en återställningslänk till dig.</string>
-	<string name="reset_password">återställ lösenord</string>
-	<string name="username">Användarnamn</string>
 	<string name="osm_account">OSM-konto</string>
 	<string name="logout">Logga ut</string>
-	<string name="login_and_edit_map_motivation_message">Logga in och redigera informationen om objekten på kartan så kommer vi att göra ändringarna tillgängliga för miljontals andra användare. Låt oss göra världen bättre tillsammans.</string>
 	<!-- Information text: "Last upload 11.01.2016" -->
 	<string name="last_upload">Senast uppladdad</string>
-	<!-- Motivates user to login/register, title above login buttons. -->
-	<string name="you_have_edited_your_first_object">Du har redigerat ditt första objekt!</string>
 	<string name="thank_you">Tack</string>
-	<string name="login_with_google">Logga in med Google</string>
-	<string name="login_with_openstreetmap">Logga in med www.openstreetmap.org</string>
 	<string name="edit_place">Ändra platsen</string>
 	<string name="place_name">Platsens namn</string>
-	<!-- title above languages list cells in the editor, below editable name text field. -->
-	<string name="other_languages">Övriga språk</string>
-	<!-- small button to open list with names in different languages -->
-	<string name="show_more">Visa mer</string>
-	<!-- small button to close list with names in different languages -->
-	<string name="show_less">Visa mindre</string>
 	<string name="add_language">Lägg till ett språk</string>
 	<string name="street">Gata</string>
 	<!-- Editable House Number text field (in address block). -->
@@ -687,25 +427,16 @@
 	<string name="email_or_username">E-postadress eller användarnamn</string>
 	<string name="phone">Telefon</string>
 	<string name="please_note">Observera</string>
-	<string name="common_no_wifi_dialog">Ingen wifi-anslutning. Vill du fortsätta med mobildata?</string>
 	<string name="downloader_delete_map_dialog">Alla kartändringar kommer att raderas tillsammans med kartan.</string>
 	<string name="downloader_update_maps">Uppdatera kartor</string>
 	<string name="downloader_mwm_migration_dialog">För att skapa en rutt måste du uppdatera alla kartor och sedan planera rutten igen.</string>
 	<string name="downloader_search_field_hint">Hitta kartan</string>
-	<string name="migration_update_all_button">Uppdatera alla kartor</string>
-	<string name="migration_delete_all_download_current_button">Ladda ned senaste kartan och radera de gamla</string>
 	<string name="migration_download_error_dialog">Nedladdningsfel</string>
 	<string name="common_check_internet_connection_dialog">Kontrollera dina inställningar och se till att din enhet är ansluten till internet.</string>
 	<string name="downloader_no_space_title">Ej tillräckligt utrymme</string>
 	<string name="downloader_no_space_message">Ta bort onödig data</string>
-	<string name="editor_general_auth_error_dialog">Allmänt fel vid inloggning.</string>
 	<string name="editor_login_error_dialog">Inloggningsfel.</string>
-	<string name="editor_login_failed_dialog">Inloggningen misslyckades</string>
-	<string name="editor_username_error_dialog">Användarnamnet är ogiltigt</string>
-	<string name="editor_place_edited_dialog">Du har redigerat ett objekt!</string>
-	<string name="editor_login_with_osm">Logga in med OpenStreetMap</string>
 	<string name="editor_profile_changes">Verifierade ändringar</string>
-	<string name="editor_profile_unsent_changes">Inte skickade:</string>
 	<string name="editor_focus_map_on_location">Dra på kartan för att välja objektets rätta plats.</string>
 	<string name="editor_add_select_category">Välj kategori</string>
 	<string name="editor_add_select_category_popular_subtitle">Populära</string>
@@ -716,19 +447,14 @@
 	<string name="editor_edit_place_category_title">Kategori</string>
 	<string name="detailed_problem_description">Detaljerad beskrivning av ett problem</string>
 	<string name="editor_report_problem_other_title">Ett annat problem</string>
-	<string name="placepage_report_problem_button">Rapportera ett problem</string>
 	<string name="placepage_add_business_button">Lägg till organisation</string>
 	<string name="whatsnew_editor_message_1">Lägg till nya platser till kartan och redigera de befintliga direkt från appen.</string>
-	<string name="whatsnew_editor_message_2">* Organic Maps använder data från OpenStreetMaps community.</string>
 	<string name="dialog_incorrect_feature_position">Ändra placering</string>
 	<string name="message_invalid_feature_position">Ett objekt kan inte placeras här</string>
 	<string name="login_to_make_edits_visible">Logga in så att andra användare kan se de ändringar du gjort.</string>
-	<string name="no_migration_during_navigation">Att uppdatera är förbjudet under navigering.</string>
 	<!-- Error dialog no space -->
 	<string name="migration_no_space_message">Du behöver mer utrymme för att ladda ned. Radera onödig data.</string>
 	<string name="editor_sharing_title">Jag förbättrade kartorna hos Organic Maps</string>
-	<string name="editor_comment_will_be_sent">Vi vidarebefordrar din kommentar till kartritarna.</string>
-	<string name="editor_unsupported_category_message">Du har lagt till en plats i en kategori vi ännu inte stödjer. Den kommer att finnas på kartan vid ett senare tillfälle.</string>
 	<!-- Downloaded 10 **of** 20 <- it is that "of" -->
 	<string name="downloader_of">%1$d av %2$d</string>
 	<string name="download_over_mobile_header">Ladda ned med mobildata?</string>
@@ -746,15 +472,8 @@
 	<string name="editor_detailed_description">Dina föreslagna ändringar kommer att skcikas till OpenStreetMap-communityt. Beskriv detaljerna som inte kan redigeras i Organic Maps.</string>
 	<string name="editor_more_about_osm">Mer om OpenStreetMap</string>
 	<string name="editor_operator">Användare</string>
-	<string name="editor_tag_description">Ange företag, organisation eller person som är ansvarig för lokalerna.</string>
-	<string name="editor_no_local_edits_title">Du har inga lokala redigeraingar</string>
-	<string name="editor_no_local_edits_description">Detta visar antalet föreslagna förändringar på kartan som som endast är tillgängliga på din enhet.</string>
-	<string name="editor_send_to_osm">Skicka till OSM</string>
-	<string name="editor_remove">Ta bord</string>
-	<string name="downloader_my_maps_title">Mina kartor</string>
 	<string name="downloader_no_downloaded_maps_title">Du har inte laddat ner några kartor</string>
 	<string name="downloader_no_downloaded_maps_message">Ladda ner kartor för att hitta platsen och navigera offline.</string>
-	<string name="downloader_find_place_hint">Sök stad eller land</string>
 	<!-- Error title that appears after certain time without location. -->
 	<string name="current_location_unknown_title">Fortsätt detektera din nuvarande plats?</string>
 	<!-- Error that appears after certain time without location. -->
@@ -769,27 +488,10 @@
 	<string name="location_services_disabled_2">2. Tryck på Plats</string>
 	<!-- iOS Dialog for the case when the location permission is not granted -->
 	<string name="location_services_disabled_3">3. Välj Medan appen används</string>
-	<string name="placepage_parking_surface">Yta</string>
-	<string name="placepage_parking_multistorey">Flera våningar</string>
-	<string name="placepage_parking_underground">Under mark</string>
-	<string name="placepage_parking_rooftop">Hustak</string>
-	<string name="placepage_parking_sheds">Skjul</string>
-	<string name="placepage_parking_carports">Garage</string>
-	<string name="placepage_parking_boxes">Garageboxar</string>
-	<string name="placepage_parking_pay">Kostnadsbelagd</string>
-	<string name="placepage_parking_free">Gratis</string>
-	<string name="placepage_parking_interval">Delvis kostnadsbelagd</string>
-	<string name="placepage_entrance_number">Nr</string>
-	<string name="placepage_entrance_type">Entré</string>
-	<string name="placepage_flat">lgh</string>
-	<string name="placepage_open_24_7">Døgnet rundt</string>
 	<string name="meter">m</string>
 	<string name="kilometer">km</string>
-	<string name="kilometers_per_hour">km/h</string>
 	<string name="mile">mile</string>
 	<string name="foot">fot</string>
-	<string name="miles_per_hour">mph</string>
-	<string name="day">d</string>
 	<string name="hour">h</string>
 	<string name="minute">min</string>
 	<string name="placepage_place_description">Beskrivning</string>
@@ -799,46 +501,30 @@
 	<string name="placepage_call_button">Ring</string>
 	<string name="placepage_edit_bookmark_button">Redigera bokmärke</string>
 	<string name="placepage_bookmark_name_hint">Namn bokmärke</string>
-	<string name="placepage_personal_notes_hint">Personlig anteckning</string>
-	<string name="placepage_delete_bookmark_button">Radera bokmärke</string>
 	<string name="editor_edits_sent_message">Dina föreslagna ändringar har skickats</string>
 	<string name="editor_comment_hint">kommentar…</string>
 	<string name="editor_reset_edits_message">Återställ alla lokala ändringar?</string>
 	<string name="editor_reset_edits_button">Återställ</string>
 	<string name="editor_remove_place_message">Ta bort en tillagd plats?</string>
 	<string name="editor_remove_place_button">Ta bort</string>
-	<string name="editor_status_sending">Skickar…</string>
 	<string name="editor_place_doesnt_exist">Platsen finns inte</string>
 	<string name="text_more_button">…mer</string>
 	<!-- Phone number error message -->
 	<string name="error_enter_correct_phone">Ange korrekt telefonnummer</string>
 	<string name="error_enter_correct_web">Ange en giltig webadress</string>
 	<string name="error_enter_correct_email">Ange en giltig e-postadress</string>
-	<string name="error_enter_correct">Ange ett giltigt värde</string>
 	<string name="refresh">Uppdatera</string>
-	<string name="last_update">Senast uppdaterad: %s</string>
 	<string name="placepage_add_place_button">Lägg till en plats på kartan</string>
 	<!-- Displayed when saving some edits to the map to warn against publishing personal data -->
 	<string name="editor_share_to_all_dialog_title">Vill du skicka det till alla användare?</string>
 	<!-- iOS Dialog before publishing the modifications to the public map. -->
 	<string name="editor_share_to_all_dialog_message_1">Se till att du inte angett någon personinformation</string>
 	<string name="editor_share_to_all_dialog_message_2">Vi kommer att kontrollera ändringar. Om vi har några frågor kontaktar vi dig via e-post.</string>
-	<string name="navigation_overview_button">översikt</string>
-	<string name="navigation_stop_button">stopp</string>
-	<!-- Text on an empty bookmark page -->
-	<string name="bookmarks_empty_title">Spara bokmärken</string>
-	<string name="bookmarks_empty_message_1">Knacka på ★ för att spara favoritplatser för snabb åtkomst.</string>
-	<string name="bookmarks_empty_message_2">Importera bokmärken från Mail och webben.</string>
-	<string name="bookmarks_empty_message_3">utcheckning: %s</string>
-	<!-- Name of the group for booked hotels -->
-	<string name="bookmarks_group_name">Bokade hotell</string>
-	<string name="place_page_button_read_descriprion">Läs</string>
 	<!-- iOS dialog for the case when recent track recording is on and the app comes back from background -->
 	<string name="recent_track_background_dialog_title">Avaktivera inspelning av din senaste resta rutt?</string>
 	<string name="off_recent_track_background_button">Avaktivera</string>
 	<!-- For sharing via SMS and so on -->
 	<string name="sharing_call_action_look">Kolla in</string>
-	<string name="continue_recent_track_background_button">Fortsätt</string>
 	<string name="recent_track_background_dialog_message">Organic Maps använder din geografiska position i bakgrunden för att spela in din senaste resta rutt.</string>
 	<!-- Rate on Google Play (Android only) -->
 	<string name="rate_gp">Betygsätt på Google Play</string>
@@ -848,21 +534,11 @@
 	<string name="tell_friends_text">Hej! Installera Organic Maps!</string>
 	<!-- About short text (below logo) -->
 	<string name="about_description">Organic Maps är en offline-applikation som du behöver när du reser. Organic Maps baseras på OpenStreetMap-data och tillåter redigering i den.</string>
-	<!-- Text in menu -->
-	<string name="blog">Blogg</string>
 	<string name="general_settings">Allmänna inställningar</string>
-	<string name="date">Datum %d</string>
-	<!-- "Report a bug" -> "Generaal Feedback" -> "Something is not working" -->
-	<string name="something_is_not_working">Något fungerar inte</string>
 	<!-- For the first routing -->
 	<string name="accept">Acceptera</string>
 	<!-- For the first routing -->
 	<string name="decline">Neka</string>
-	<string name="install_app">Installera</string>
-	<string name="search_no_results_title">Inga resultat hittades</string>
-	<string name="search_no_results_message">Försök med en mer allmän sökterm, zooma ut eller återställ filtret.</string>
-	<string name="search_no_results_expand_area_button">Zooma ut</string>
-	<string name="search_no_results_reset_button">Återställ filtret</string>
 	<!-- noun -->
 	<string name="search_in_table">Lista</string>
 	<string name="mobile_data_dialog">Använd mobilt nätverk för att visa detaljerad information?</string>
@@ -874,18 +550,13 @@
 	<string name="mobile_data_option_never">Använd aldrig</string>
 	<string name="mobile_data_option_ask">Fråga alltid</string>
 	<string name="traffic_update_maps_text">Kartor måste uppdateras för att visa trafikdata.</string>
-	<string name="traffic_outdated">Trafikdata är inaktuellt.</string>
 	<string name="big_font">Öka teckenstorlek på kartan</string>
 	<string name="traffic_update_app">Uppdatera Organic Maps</string>
 	<!-- "traffic" as in road congestion -->
 	<string name="traffic_update_app_message">Applikationen måste uppdateras för att trafikdata ska kunna visas.</string>
 	<!-- "traffic" as in "road congestion" -->
 	<string name="traffic_data_unavailable">Trafikdata är inte tillgänglig</string>
-	<!-- Simplified colour scheme for traffic information, fewer colours are used to display traffic jams on the map. The string should be kept as short as possible -->
-	<string name="pref_traffic_simplified_colors_title">Enkla trafikfärger</string>
 	<string name="enable_logging">Aktivera loggning</string>
-	<string name="offline_place_page_more_information">Anslut till internet för att hämta mer information om platsen.</string>
-	<string name="failed_load_information">Det gick inte att ladda informationen.</string>
 	<!-- Settings: "Send general feedback" button -->
 	<string name="feedback_general">Allmän feedback</string>
 	<string name="on">På</string>
@@ -899,57 +570,26 @@
 	<string name="routing_add_start_point">Lägg till startpunkt för att planera en rutt</string>
 	<string name="routing_add_finish_point">Lägg till slutpunkt för att planera en rutt</string>
 	<string name="button_exit">Avsluta</string>
-	<string name="settings_device_memory">Enhetens minne</string>
-	<string name="settings_card_memory">Kortets minne</string>
-	<string name="settings_storage_available">%s tillgängligt</string>
-	<string name="toast_location_permission_denied">Behörighet till appens plats nekades</string>
-	<string name="button_use">Använd</string>
 	<string name="planning_route_manage_route">Hantera rutt</string>
 	<string name="button_plan">Planera</string>
-	<string name="button_add">Lägg till</string>
 	<string name="placepage_remove_stop">Ta bort</string>
 	<string name="planning_route_remove_title">Dra här för att ta bort</string>
-	<string name="dialog_change_start_point_message">Ersätt startpunkt för den aktuella platsen?</string>
-	<string name="button_replace">Ersätt</string>
 	<string name="placepage_add_stop">Lägg till stopp</string>
-	<string name="add_my_position">Lägg till min position</string>
-	<string name="choose_start_point">Välj en startpunkt</string>
-	<string name="choose_destination">Välj en destination</string>
 	<string name="preloader_viator_button">Läs mer</string>
-	<string name="start_from_my_position">Starta från</string>
-	<string name="profile_authorization_title">Logga in med</string>
-	<string name="profile_authorization_message">Enkelt att logga in utan inloggning och lösenord inom ett par sekunder</string>
 	<string name="profile_authorization_error">Hoppsan, ett fel har inträffat. Försök att logga in igen.</string>
-	<string name="service">Service</string>
-	<string name="atmosphere">Atmosfär</string>
-	<string name="value_for_money">Valuta för pengarna</string>
-	<string name="experience">Erfarenhet</string>
-	<string name="assortment">Urval</string>
-	<string name="expertise">Expertis</string>
-	<string name="equipment">Utrustning</string>
-	<string name="quality">Kvalitet</string>
 	<string name="dialog_error_storage_title">Lagringsåtkomstproblem</string>
 	<string name="dialog_error_storage_message">Extern lagring är inte tillgänglig. SD-kortet är borttaget, skadat eller så är filsystemet är skrivskyddat. Kontrollera det och kontakta oss på support\@organicmaps.app</string>
 	<string name="setting_emulate_bad_storage">Emulera dålig lagring</string>
-	<string name="directions_finish">Destination</string>
-	<string name="directions_on_foot">Gå %s</string>
 	<string name="core_entrance">Ingång</string>
-	<string name="coffee">Kaffe</string>
-	<string name="cleanliness">Rent</string>
-	<string name="crowdedness">Fullt</string>
 	<string name="error_enter_correct_name">Ange ett korrekt namn</string>
 	<string name="bookmarks_groups">Listor</string>
 	<string name="bookmarks_groups_hide_all">Dölj alla</string>
 	<string name="bookmarks_groups_show_all">Visa alla</string>
-	<plurals name="bookmarks_places">
-	  <item quantity="other">%d bokmärken</item>
-	</plurals>
 	<string name="bookmarks_create_new_group">Skapa ny lista</string>
 	<string name="downloader_hide_screen">Dölj skärm</string>
 	<string name="downloader_percent">%1$s (%2$s av %3$s)</string>
-	<string name="downloader_process">Ladda ned %s...</string>
-	<string name="downloader_applying">Tillämpar %s...</string>
-	<string name="dialog_message_transit_not_found_connection">Planera en rutt inom ett transportnätverk</string>
+	<string name="downloader_process">Ladda ned %s…</string>
+	<string name="downloader_applying">Tillämpar %s…</string>
 	<string name="bookmarks_error_message_share_general">Kunde inte delas på grund av ett applikationsfel</string>
 	<string name="bookmarks_error_title_share_empty">Delningsfel</string>
 	<string name="bookmarks_error_message_share_empty">Kan inte dela en tom lista</string>
@@ -958,12 +598,7 @@
 	<string name="bookmarks_new_list_hint">Ny lista</string>
 	<string name="bookmarks_error_title_list_name_already_taken">Det här namnet är redan taget</string>
 	<string name="bookmarks_error_message_list_name_already_taken">Vänligen välj ett annat namn</string>
-	<string name="bookmarks_error_title_list_name_too_long">Det här namnet är för långt</string>
-	<string name="bookmarks_error_message_list_name_too_long">Vänligen välj ett annat namn</string>
-	<string name="please_wait">Vänligen vänta...</string>
-	<string name="phone_number">Telefonnummer</string>
-	<string name="notification_unsent_reviews_title">Du har flera unsent recensioner</string>
-	<string name="notification_unsent_reviews_message">Vänligen logga in för att dela omdömen med andra resenärer</string>
+	<string name="please_wait">Vänligen vänta…</string>
 	<string name="profile">OpenStreetMap profil</string>
 	<string name="place_page_search_similar_hotel">Sök liknande hotell</string>
 	<string name="bookmarks_detect_title">Nya filer upptäcktes</string>
@@ -974,31 +609,10 @@
 	<string name="button_convert">Konvertera</string>
 	<string name="bookmarks_convert_error_title">Fel</string>
 	<string name="bookmarks_convert_error_message">Vissa filer konverterades inte.</string>
-	<string name="converting">Konvertera...</string>
-	<string name="wn_reinvented_bookmarks_title">Vi återuppfinde bokmärken!</string>
-	<string name="wn_reinvented_bookmarks_message">Du kan säkerhetskopiera bokmärken, skapa listor... Det är fantastiskt...</string>
-	<string name="bookmarks_restore">Återställ bokmärken</string>
-	<string name="bookmarks_restore_process">Återställer...</string>
 	<string name="bookmarks_restore_title">Återställ den här versionen?</string>
-	<string name="bookmarks_restore_message">Dina bokmärken återställs från %1$s (%2$s)</string>
-	<string name="bookmarks_restore_empty_title">Du har ingen säkerhetskopia</string>
-	<string name="bookmarks_restore_empty_message">Servern hittade inte tidigare säkerhetskopior</string>
 	<string name="common_check_internet_connection_dialog_title">Ingen internetanslutning</string>
-	<string name="error_server_title">Serverfel</string>
-	<string name="error_server_message">Det uppstod ett fel på servern, försök igen senare</string>
 	<string name="error_system_message">Ett okänt fel uppstod</string>
 	<string name="restore">Återställa</string>
-	<string name="bookmarks_page_downloaded">Ladda ner</string>
-	<string name="bookmarks_page_my">Min</string>
-	<string name="routes_and_bookmarks">Rutt och bokmärken</string>
-	<string name="bookmarks_webview_success_toast">Bokmärkena har laddats ner</string>
-	<string name="cached_bookmarks_placeholder_title">Ladda ner nya platser</string>
-	<string name="cached_bookmarks_placeholder_subtitle">Tryck på knappen för att ladda ner tusentals intressanta platser och rutter skapade av Organic Maps användare. Du behöver internetanslutning.</string>
-	<string name="downloader_download_routers">Ladda ner bokmärken</string>
-	<string name="bookmarks_groups_cached">Nedladdade listor</string>
-	<plurals name="bookmarks_objects">
-	  <item quantity="other">%s objekt</item>
-	</plurals>
 	<plurals name="objects">
 	  <item quantity="other">%d plats</item>
 	</plurals>
@@ -1011,62 +625,32 @@
 	<string name="subtittle_opt_out">Spårningsinställningar</string>
 	<string name="crash_reports">Olycksrapport</string>
 	<string name="crash_reports_description">Vi kan komma att använda din data för att förbättra Organic Maps upplevelsen. Ändringarna kommer träda i kraft när du startar om appen.</string>
-	<string name="opt_out_help_ios_1">Din mobila enhet kan tillhandahålla en ”Begränsad annonsspårning” eller ”Välj bort intressebaserad annonsering” inställning.</string>
-	<string name="opt_out_help_ios_2">iOS 9 eller nyare</string>
-	<string name="opt_out_help_ios_3">Gå till Inställningar → Integritet → Annonsering → Tillåt inställningen ”Begränsad annonsspårning”</string>
-	<string name="opt_out_help_android">Din mobila enhet kan tillhandahålla en ”Begränsad annonsspårning” eller ”Välj bort intressebaserad annonsering” -inställning.\n\nFör Android och Google Play tjänster version 4.0 och nyare:\nInställningar → Google → Annonsering → Välj bort personlig annonsering\eller\nInställningar→ Google → Google konto → Personlig information och integritet → Annonseringsinställningar → Personlig annonsering</string>
 	<string name="privacy_policy">Integritetspolicy</string>
 	<string name="terms_of_use">Allmänna villkor</string>
-	<string name="backup_notification_failed">Säkerhetskopiering av dina bokmärken har avbrutits. Logga in för att starta det igen.</string>
 	<string name="button_layer_traffic">Trafik</string>
 	<string name="button_layer_subway">Tunnelbana</string>
 	<string name="layers_title">Kartlager</string>
-	<string name="layers_message">Använd kartlager för att visa trafik, karta över tunnelbanan och annan användbar information</string>
-	<string name="button_layer_got_it">Förstått</string>
 	<string name="subway_data_unavailable">Kartor över tunnelbana är otillgänglig</string>
 	<string name="bookmarks_empty_list_title">Listan är tom</string>
 	<string name="bookmarks_empty_list_message">För att lägga till bokmärken, tryck på kartan och sedan på stjärnikonen</string>
 	<string name="category_desc_more">…mer</string>
 	<string name="title_error_downloading_bookmarks">Ett fel har uppstått</string>
-	<string name="subtitle_error_downloading_bookmarks">Bokmärkena laddades inte ner</string>
-	<string name="error_already_downloaded">Den här listan har redan laddats ned</string>
-	<string name="why_support">Varför stödja Organic Maps?</string>
-	<string name="why_support_item2">Du hjälper oss att förbättra Organic Maps</string>
-	<string name="why_support_item3">Du hjälper oss att förbättra de offentliga kartorna OpenStreetMap.org</string>
-	<string name="channels_map_update">Uppdatering av kartor</string>
-	<string name="server_unavailable_title">Servern är inte tillgänglig</string>
-	<string name="sharing_options">Åtkomstinställningar</string>
 	<string name="export_file">Exportera fil</string>
 	<string name="list_settings">Listinställningar</string>
 	<string name="delete_list">Radera listan</string>
-	<string name="hide_from_map">Dölj från kort</string>
 	<string name="public_access">Allmänhetens åtkomst</string>
 	<string name="limited_access">Privat åtkomst</string>
 	<string name="bookmark_category_name">Kategori</string>
 	<string name="bookmark_category_description_hint">Lägg till en beskrivning (text eller html)</string>
 	<string name="not_shared">Personlig</string>
-	<string name="direct_link_progress_text">Laddar upp din fil…</string>
-	<string name="direct_link_success">Länk skapad</string>
-	<string name="send_a_link_btn">Skicka länk</string>
-	<string name="upload_error_toast">Ett fel uppstod när du laddar filen</string>
 	<string name="tags_loading_error_subtitle">Ett fel uppstod när du laddar taggarna, försök igen</string>
-	<string name="unable_upload_errorr_title">Det gick inte att ladda upp filen</string>
-	<string name="unable_upload_error_subtitle_edited">Filen har redigerats via webbapplikation</string>
-	<string name="unable_upload_error_subtitle_broken">Filen är skadad och kan inte laddas upp. Var vänlig ladda upp en annan fil.</string>
-	<string name="contact">Kontakta</string>
-	<string name="download_button">Nedladdning</string>
 	<string name="speedcams_alert_title">Hastighetskameror</string>
-	<string name="speedcams_alert_subtitle">Varna om hastighetsbegränsningar</string>
 	<string name="speedcam_option_auto">Auto</string>
 	<string name="speedcam_option_always">Alltid</string>
 	<string name="speedcam_option_never">Aldrig</string>
-	<string name="bookmark_description_title">Etikettbeskrivning</string>
 	<string name="place_description_title">Beskrivning av platsen</string>
 	<!-- this text will be shown in application notification preferences opposite checkbox which enable/disable downloader notifications. Devices on Android 8+ are affected. -->
 	<string name="notification_channel_downloader">Kartladdning</string>
-	<string name="share_bookmarks_email_body_link">Hej!\n\nDina etiketter kan laddas ner från länken: %s. Öppna listan med hjälp av Organic Maps och njut av resan!\n\nLadda ner appen: https://omaps.app/get?kmz</string>
-	<string name="warning_speedcams_title">Navigatören ska meddela dig om kameror när hastighetsgränsen överskrids med %d km/h</string>
-	<string name="warning_speedcams_subtitle">Glöm inte att bekanta sig med trafikregler i landet av resan.</string>
 	<string name="speedcams_notice_message">Auto - Varna om fartkameror om det finns risk att överskrida hastighetsgränsen\nAlltid - Varna alltid om kameror\nAldrig - Varna aldrig om kameror</string>
 	<string name="power_managment_title">Energisparläge</string>
 	<string name="power_managment_description">Om energisparläget är på, ska appen stänga av energikrävande funktioner beroende på telefonens nuvarande laddning</string>
@@ -1074,14 +658,7 @@
 	<string name="power_managment_setting_auto">Automatiskt</string>
 	<string name="power_managment_setting_manual_max">Maximal energibesparing</string>
 	<string name="enable_logging_warning_message">Denna funktion aktiveras för loggning av åtgärder för diagnostiska ändamål. Detta hjälper laget att identifiera problem med applikationen. Slå på funktionen endast på begäran av Organic Maps supporttjänst.</string>
-	<string name="html_error_upload_message_try_again">Kontrollera nätverksåtkomst och försök igen</string>
-	<string name="html_error_upload_title_try_again">Ingen internetanslutning</string>
-	<string name="notification_leave_review_v2_android_short_title">Lämna en recension och hjälp resenärer!</string>
-	<string name="notifications_illegal_alert_disable_button">Stäng av meddelanden</string>
 	<string name="access_rules_author_only">Redigeras online</string>
-	<string name="privacy_settings_menu">Sekretessinställningar</string>
-	<string name="unable_upadate_error_title">Det gick inte att uppdatera resrutten</string>
-	<string name="unable_upadate_error_message">Det uppstod några fel vid uppdatering. Kontrollera ändringarna och försök igen</string>
 	<string name="driving_options_title">Omvägsinställningar</string>
 	<string name="driving_options_subheader">Undvik på varje rutten</string>
 	<string name="avoid_tolls">Betalväg</string>
@@ -1092,52 +669,14 @@
 	<string name="unable_to_calc_alert_subtitle">Tyvärr kunde vi inte bygga en rutt med de valda alternativen. Ändra inställningar och försök igen</string>
 	<string name="define_to_avoid_btn">Anpassa omvägsbana</string>
 	<string name="change_driving_options_btn">Omvägsinställningar aktiverade</string>
-	<string name="toll_road">Betalvägen</string>
-	<string name="unpaved_road">Kärrvägen</string>
-	<string name="ferry_crossing">Färjetrafik</string>
-	<string name="operated_by">Kontrolleras \"%s\"</string>
 	<string name="avoid_toll_roads_placepage">Undvik betalvägar</string>
 	<string name="avoid_unpaved_roads_placepage">Undvik kärrvägar</string>
 	<string name="avoid_ferry_crossing_placepage">Undvik färjetrafik</string>
-	<string name="type.cuisine.uzbek">Uzbekiska mat</string>
-	<string name="trip_start">Kom igen</string>
-	<string name="pick_destination">Målet</string>
-	<string name="follow_my_position">Placera i mitten</string>
-	<string name="search_results">Sökresultat</string>
-	<string name="then_turn">Vidare</string>
-	<string name="redirect_route_alert">Räknar om rutten?</string>
-	<string name="redirect_route_yes">Ja</string>
-	<string name="redirect_route_no">Nej</string>
-	<string name="trip_finished">Du är framme!</string>
-	<string name="keyboard_availability_alert">Tangentbordet är inte tillgängligt vid rörelsen</string>
-	<string name="dialog_routing_change_start_carplay">Det gick inte att bygga rutten från nuvarande plats</string>
-	<string name="dialog_routing_change_end_carplay">Det går inte att bygga rutten till slutpunkten. Välj en annan</string>
-	<string name="dialog_routing_check_gps_carplay">Ingen GPS-signal. Följ till öppna området</string>
-	<string name="dialog_routing_unable_locate_route_carplay">Det går inte att bygga ruten. Välj andra rutenspunkter</string>
-	<string name="dialog_routing_download_files_carplay">För att skapa en rutt, ladda ner saknade kartor på din enhet</string>
-	<string name="dialog_routing_system_error_carplay">Ett fel uppstod. Starta om appen</string>
-	<string name="dialog_routing_rebuild_from_current_location_carplay">Ruten kommer att byggas om från din nuvarande plats</string>
-	<string name="dialog_routing_rebuild_for_vehicle_carplay">Ruten kommer att ändras till bil</string>
 	<string name="ok">Ok</string>
-	<string name="avoid_unpaved_carplay_1">Utan kärrväg</string>
-	<string name="avoid_unpaved_carplay_2">Utan kärrvägar</string>
-	<string name="avoid_ferry_carplay_1">Utan färjor</string>
-	<string name="avoid_ferry_carplay_2">Utan färjor</string>
-	<string name="avoid_tolls_carplay_1">Utan betalda</string>
-	<string name="avoid_tolls_carplay_2">Utan betalda</string>
-	<string name="speedcams_alert_title_carplay_1">Kameror</string>
-	<string name="speedcams_alert_title_carplay_2">Info om kameror</string>
-	<string name="download_map_carplay">Ladda ner kartor i applikation Organic Maps på din enhet</string>
-	<string name="carplay_roundabout_exit">%s utgången</string>
 	<!-- max. 10 symbols, both iOS and Android -->
 	<string name="sort">Sortera…</string>
 	<!-- Android, title, max 20-22 symbols -->
 	<string name="sort_bookmarks">Sortera bokmärken</string>
-	<!-- iOS -->
-	<string name="sort_default">Sortera som standard</string>
-	<string name="sort_type">Sortera efter typ</string>
-	<string name="sort_distance">Sortera efter avstånd</string>
-	<string name="sort_date">Sortera efter datum</string>
 	<!-- Android -->
 	<string name="by_default">Som standard</string>
 	<!-- Android -->
@@ -1146,65 +685,23 @@
 	<string name="by_distance">Efter avstånd</string>
 	<!-- Android -->
 	<string name="by_date">Efter datum</string>
-	<string name="week_ago_sorttype">För en vecka sedan</string>
-	<string name="month_ago_sorttype">För en månad sedan</string>
-	<string name="moremonth_ago_sorttype">För över en månad sedan</string>
-	<string name="moreyear_ago_sorttype">För över ett år sedan</string>
-	<string name="near_me_sorttype">Bredvid mig</string>
-	<string name="others_sorttype">Andra</string>
-	<string name="food_places">Mat</string>
-	<string name="tourist_places">Sevärdheter</string>
-	<string name="museums">Museer</string>
-	<string name="parks">Parker</string>
-	<string name="swim_places">Simning</string>
-	<string name="mountains">Berg</string>
-	<string name="animals">Djur</string>
-	<string name="hotels">Hotell</string>
-	<string name="buildings">Byggnader</string>
-	<string name="money">Pengar</string>
-	<string name="shops">Butiker</string>
-	<string name="parkings">Parkeringsplatser</string>
-	<string name="fuel_places">Bensinstationer</string>
-	<string name="water">Vatten</string>
-	<string name="medicine">Medicin</string>
 	<string name="search_in_the_list">Söka i listan</string>
-	<string name="view_on_map_bookmarks">På kartan</string>
-	<string name="more_bookmarks">Mer…</string>
-	<string name="no_items_found">Ingenting hittades</string>
-	<!-- Android, max 18 symbols -->
-	<string name="bookmarks_edit_list">Redigera</string>
-	<!-- Android, max 18 symbols -->
-	<string name="bookmarks_delete_list">Ta bort listan</string>
-	<string name="religious_places">Heliga platser</string>
 	<string name="select_list">Välja lista</string>
 	<string name="transit_not_found">Metro-navigering är ännu inte tillgänglig i denna region</string>
 	<string name="dialog_pedestrian_route_is_long_header">Metro rutt hittades inte</string>
 	<string name="dialog_pedestrian_route_is_long_message">Välj ruttens start- eller slutpunkt närmare till tunnelbanestation</string>
-	<!-- Failed planning SUBWAY route message in navigation view -->
-	<string name="routing_planning_error_subway_special">Fel vid byggande av metro rutt</string>
 	<string name="button_layer_isolines">Terräng</string>
-	<string name="tips_map_layers_title_countour">Höjningslinjer offline i Organic Maps!</string>
-	<string name="tips_map_layers_message_countour">Höjdlinjer hjälper dig att planera din resa till naturen och inte gå vilse på marken</string>
 	<string name="isolines_activation_error_dialog">Om du vill använda höjdlinjer, uppdatera eller ladda ner en karta över önskat område</string>
 	<string name="isolines_location_error_dialog">Höjningslinjer är ännu inte tillgängligt i den här regionen</string>
 	<string name="elevation_profile_diff_level">Svårighetsgrad</string>
-	<string name="elevation_profile_diff_level_easy">Lätt</string>
-	<string name="elevation_profile_diff_level_moderate">Måttlig</string>
-	<string name="elevation_profile_diff_level_hard">Svår</string>
 	<string name="elevation_profile_ascent">Stigning</string>
 	<string name="elevation_profile_descent">Backe</string>
 	<string name="elevation_profile_minaltitude">Min. höjd</string>
 	<string name="elevation_profile_maxaltitude">Max. höjd</string>
-	<string name="elevation_profile_m">m</string>
 	<string name="elevation_profile_difficulty">Komplexitet</string>
 	<string name="elevation_profile_distance">Avst.:</string>
-	<string name="elevation_profile_km">km</string>
 	<string name="elevation_profile_time">Tid:</string>
-	<string name="elevation_profile_hours">h.</string>
-	<string name="elevation_profile_minutes">min</string>
 	<string name="isolines_toast_zooms_1_10">Förstora kartan för att se isolinjer</string>
-	<string name="downloader_updating_ios">Uppdatering</string>
-	<string name="downloader_loading_ios">Nedladdning</string>
 	<string name="key_information_title">Nyckelinformation</string>
 	<string name="enable_screen_sleep">Låt skärmen sova</string>
 	<!-- Description in preferences -->

--- a/android/res/values-th/strings.xml
+++ b/android/res/values-th/strings.xml
@@ -12,15 +12,11 @@
 	<string name="cancel_download">ยกเลิกการดาวน์โหลด</string>
 	<!-- Button which deletes downloaded country -->
 	<string name="delete">ลบ</string>
-	<!-- Button "do not interrupt download" if user touched actively downloading country -->
-	<string name="do_nothing">ดำเนินการต่อ</string>
 	<string name="download_maps">ดาวน์โหลดแผนที่</string>
 	<!-- Settings/Downloader - info for country when download fails -->
 	<string name="download_has_failed">การดาวน์โหลดล้มเหลว แตะอีกครั้งเพื่อลองใหม่</string>
 	<!-- Settings/Downloader - info for country which started downloading -->
 	<string name="downloading">กำลังดาวน์โหลด…</string>
-	<!-- Settings/Downloader - size string, only strings different from English should be translated -->
-	<string name="kb">กิโลไบต์</string>
 	<!-- Choose measurement on first launch alert - choose metric system button -->
 	<string name="kilometres">กิโลเมตร</string>
 	<!-- Leave Review dialog - Review button -->
@@ -35,45 +31,31 @@
 	<string name="core_my_position">ตำแหน่งของฉัน</string>
 	<!-- Update maps later/Buy pro version later button text -->
 	<string name="later">ภายหลัง</string>
-	<!-- Don't show some dialog any more -->
-	<string name="never">ไม่ต้องเตือนอีก</string>
 	<!-- View and button titles for accessibility -->
 	<string name="search">ค้นหา</string>
 	<!-- Search box placeholder text -->
 	<string name="search_map">ค้นหาแผนที่</string>
-	<!-- Settings/Downloader - info for not downloaded country -->
-	<string name="touch_to_download">แตะเพื่อดาวน์โหลด</string>
 	<!-- Settings/Downloader - 3G download warning dialog confirm button -->
 	<string name="use_cellular_data">ใช่</string>
 	<!-- Location services are disabled by user alert - message -->
 	<string name="location_is_disabled_long_text">ในปัจจุบันนี้มีการปิดการใช้งานการบริการตำแหน่งที่ตั้งสำหรับอุปกรณ์หรือแอปพลิเคชันนี้ โปรดเปิดใช้งานในการตั้งค่า</string>
-	<!-- Location Services are not available on the device alert - message -->
-	<string name="device_doesnot_support_location_services">อุปกรณ์ของคุณไม่รองรับการบริการตำแหน่งที่ตั้ง</string>
 	<!-- View and button titles for accessibility -->
 	<string name="zoom_to_country">แสดงบนแผนที่</string>
-	<!-- Button text for the button at the center of the screen when the country is not downloaded -->
-	<string name="country_status_download">ดาวน์โหลดแผนที่\n(^ ^)</string>
 	<!-- Button text for the button at the center of the screen when the country is not downloaded and the size should not be shown -->
 	<string name="country_status_download_without_size">ดาวน์โหลดแผนที่</string>
-	<!-- Button text for the button at the center of the screen when the country is not downloaded -->
-	<string name="country_status_download_without_routing">ดาวน์โหลดแผนที่โดยไม่กำหนดเส้นทาง\n(^ ^)</string>
 	<!-- Message to display at the center of the screen when the country download has failed -->
 	<string name="country_status_download_failed">การดาวน์โหลดล้มเหลว</string>
 	<!-- Button text for the button under the country_status_download_failed message -->
 	<string name="try_again">ลองอีกครั้ง</string>
 	<string name="about_menu_title">เกี่ยวกับ Organic Maps</string>
-	<string name="downloaded_touch_to_delete">ดาวน์โหลดแล้ว (%s), แตะเพื่อลบ</string>
 	<string name="connection_settings">การตั้งค่าการเชื่อมต่อ</string>
-	<string name="download_mb_or_kb">ดาวน์โหลด %s</string>
 	<string name="close">ปิด</string>
 	<string name="unsupported_phone">จำเป็นต้องใช้ฮาร์ดแวร์ที่เพิ่มความเร็ว OpenGL โชคไม่ดีที่อุปกรณ์ของคุณไม่รองรับ</string>
 	<string name="download">ดาวน์โหลด</string>
-	<string name="external_storage_is_not_available">ไม่สามารถใช้การ์ด SD /พื้นที่จัดเก็บ USB ที่มีดาวน์โหลดแผนที่ได้</string>
 	<string name="disconnect_usb_cable">โปรดยกเลิกการเชื่อมต่อสาย USB หรือใส่การ์ดหน่วยความจำเพื่อใช้ Organic Maps</string>
 	<string name="not_enough_free_space_on_sdcard">โปรดเพิ่มพื้นที่บางส่วนบนการ์ด SD /พื้นที่จัดเก็บ USB ก่อนเพื่อใช้แอป</string>
 	<string name="not_enough_memory">มีหน่วยความจำไม่เพียงพอสำหรับการเปิดแอป</string>
 	<string name="download_resources">ก่อนที่คุณจะเริ่มต้น โปรดให้เราดาวน์โหลดแผนที่โลกลงในอุปกรณ์ของคุณ\nจำเป็นต้องใช้ %s ของข้อมูล</string>
-	<string name="getting_position">กำลังรับตำแหน่งปัจจุบัน</string>
 	<string name="download_resources_continue">ไปยังแผนที่</string>
 	<string name="downloading_country_can_proceed">กำลังดาวน์โหลด %s ตอนนี้คุณสามารถ\nดำเนินการต่อไปยังแผนที่</string>
 	<string name="download_country_ask">ดาวน์โหลด %s?</string>
@@ -86,30 +68,20 @@
 	<string name="download_country_failed">การดาวน์โหลด %s ล้มเหลว</string>
 	<!-- Add New Bookmark Set dialog title -->
 	<string name="add_new_set">เพิ่มชุดใหม่</string>
-	<!-- Place Page - Add To Bookmarks button -->
-	<string name="add_to_bookmarks">เพิ่มไปยังบุ๊กมาร์ก</string>
 	<!-- Bookmark Color dialog title -->
 	<string name="bookmark_color">สีของบุ๊กมาร์ก</string>
 	<!-- Add Bookmark Set dialog - hint when set name is empty -->
 	<string name="bookmark_set_name">ชื่อของชุดบุ๊กมาร์ก</string>
-	<!-- Bookmark Sets dialog title -->
-	<string name="bookmark_sets">ชุดของบุ๊กมาร์ก</string>
 	<!-- Bookmarks - dialog title -->
 	<string name="bookmarks">บุ๊กมาร์ก</string>
-	<!-- Add bookmark dialog - bookmark color -->
-	<string name="color">สี</string>
 	<!-- Default bookmarks set name -->
 	<string name="core_my_places">สถานที่ของฉัน</string>
 	<!-- Add bookmark dialog - bookmark name -->
 	<string name="name">ชื่อ</string>
 	<!-- Editor title above street and house number -->
 	<string name="address">ที่อยู่</string>
-	<!-- Place Page - Remove Pin button -->
-	<string name="remove_pin">ลบหมุด</string>
 	<!-- Add bookmark dialog - bookmark set, Bookmarks dialog - Bookmark set cell -->
 	<string name="set">ชุด</string>
-	<!-- Text hint in Bookmarks dialog when no any bookmarks are added -->
-	<string name="bookmarks_usage_hint">คุณยังไม่มีบุ๊กมาร์ก\nแตะที่ใด ๆ บนแผนที่เพื่อเพิ่มบุ๊กมาร์ก\nสามารถนำเข้าบุ๊กมาร์กจากแหล่งอื่น ๆ และแสดงบน Organic Maps เปิดไฟล์ KML/KMZ ด้วยหมุดที่บันทึกไว้จากอีเมล ดรอปบ็อกซ์ หรือเว็บลิงก์</string>
 	<!-- Settings button in system menu -->
 	<string name="settings">การตั้งค่า</string>
 	<!-- Header of settings activity where user defines storage path -->
@@ -120,20 +92,10 @@
 	<string name="move_maps">ลบแผนที่?</string>
 	<!-- Ask to wait user several minutes (some long process in modal dialog). -->
 	<string name="wait_several_minutes">นี่อาจจะใช้เวลาสองสามนาที\nโปรดรอ…</string>
-	<!-- Show bookmarks from this category on a map or not -->
-	<string name="visible">มองเห็นได้</string>
-	<!-- Toast which is displayed when GPS has been deactivated -->
-	<string name="gps_is_disabled_long_text">มีการปิดใช้งาน GPS โปรดเปิดใช้งานในการตั้งค่า</string>
 	<!-- Measurement units title in settings activity -->
 	<string name="measurement_units">หน่วยการวัด</string>
 	<!-- Detailed description of Measurement Units settings button -->
 	<string name="measurement_units_summary">เลือกระหว่างไมล์และกิโลเมตร</string>
-	<!-- Do search in all sources -->
-	<string name="search_mode_all">ทุกที่</string>
-	<!-- Do search near my position only -->
-	<string name="search_mode_nearme">ใกล้ฉัน</string>
-	<!-- Do search in current viewport only -->
-	<string name="search_mode_viewport">บนหน้าจอ</string>
 	<!-- Search category for cafes, bars, restaurants -->
 	<string name="eat">กินร้านไหนดี</string>
 	<!-- Search category for grocery stores -->
@@ -170,12 +132,8 @@
 	<string name="post">ไปรษณีย์</string>
 	<!-- Search category -->
 	<string name="police">ตำรวจ</string>
-	<!-- String in search result list, when nothing found -->
-	<string name="no_search_results_found">ไม่พบผลลัพธ์</string>
 	<!-- Notes field in Bookmarks view -->
 	<string name="description">บันทึก</string>
-	<!-- Button text -->
-	<string name="share_by_email">แชร์จากอีเมล</string>
 	<!-- Email Subject when sharing bookmarks category -->
 	<string name="share_bookmarks_email_subject">แชร์บุ๊กมาร์กของ Organic Maps แล้ว</string>
 	<!-- message title of loading file -->
@@ -188,20 +146,10 @@
 	<string name="edit">แก้ไข</string>
 	<!-- Warning message when doing search around current position -->
 	<string name="unknown_current_position">ตำแหน่งที่ตั้งของคุณยังไม่ได้รับการกำหนด</string>
-	<!-- Warning message when location country isn't downloaded during search (see also download_location_map_proposal). -->
-	<string name="download_location_country">ดาวน์โหลด (%s) ประเทศของตำแหน่งที่ตั้งปัจจุบันของคุณ</string>
-	<!-- Warning message when viewport country isn't downloaded during search -->
-	<string name="download_viewport_country_to_search">ดาวน์โหลดประเทศ (%s) ที่คุณกำลังค้นหา</string>
 	<!-- Alert message that we can't run Map Storage settings due to some reasons. -->
 	<string name="cant_change_this_setting">ขออภัย ไม่มีการเปิดใช้งานการตั้งค่าพื้นที่จัดเก็บแผนที่ในปัจจุบัน</string>
 	<!-- Alert message that downloading is in progress. -->
 	<string name="downloading_is_active">กำลังดำเนินการดาวน์โหลดประเทศในตอนนี้</string>
-	<!-- Message that will be shown in alert view, when we ask user to leave review on App Store -->
-	<string name="appStore_message">หวังว่าคุณจะสนุกกับการใช้ Organic Maps! หากเป็นเช่นนั้น โปรดให้คะแนนหรือวิจารณ์แอปได้ที่แอปสโตร์ (App Store) มันจะใช้เวลาไม่เกินหนึ่งนาทีแต่สามารถช่วยเหลือเราได้ ขอบคุณสำหรับการสนับสนุนของคุณ!</string>
-	<!-- No, thanks -->
-	<string name="no_thanks">ไม่ ขอบคุณ</string>
-	<!-- Share one specific bookmark using SMS, %1$@ contains om:// and %2$@ https://omaps.app link. @NOTE non-ascii symbols in the link will result in max 70 characters SMS instead of 140. -->
-	<string name="bookmark_share_sms">เฮ้ ตรวจสอบหมุดของฉันที่ Organic Maps! %1$s หรือ %2$s</string>
 	<!-- Share my position using SMS, %1$@ contains om:// and %2$@ https://omaps.app link WITHOUT NAME. @NOTE non-ascii symbols in the link will result in max 70 characters SMS instead of 140. -->
 	<string name="my_position_share_sms">เฮ้อ ตรวจสอบตำแหน่งที่ตั้งปัจจุบันของฉันที่ Organic Maps! %1$s หรือ %2$s ไม่มีการติดตั้งแผนที่แบบออฟไลน์? ดาวน์โหลดที่นี่: https://omaps.app/get</string>
 	<!-- Subject for emailed bookmark -->
@@ -210,30 +158,16 @@
 	<string name="my_position_share_email_subject">นี่ มาดูตำแหน่งปัจจุบันของฉันที่แผนที่ Organic Maps สิ!</string>
 	<!-- Share my position using EMail, %1$@ is om:// and %2$@ is https://omaps.app link WITHOUT NAME -->
 	<string name="my_position_share_email">หวัดดี\n\nฉันอยู่ที่นี่ตอนนี้: %1$s. คลิกลิงก์นี้ %2$s หรือลิงก์นี้ %3$s เพื่อดูสถานที่บนแผนที่\n\nขอบคุณ</string>
-	<!-- Android share by Message/SMS button text (including SMS) -->
-	<string name="share_by_message">แชร์จากข้อความ</string>
 	<!-- Share button text which opens menu with more buttons, like Message, EMail, Facebook etc. -->
 	<string name="share">แชร์</string>
-	<!-- iOS share by Message button text (including SMS) -->
-	<string name="message">ข้อความ</string>
 	<!-- Share by email button text, also used in editor. -->
 	<string name="email">อีเมล</string>
-	<!-- Copy Link -->
-	<string name="copy_link">คัดลอกลิงก์</string>
-	<!-- Text for the button that returns to caller application -->
-	<string name="more_info">แสดงข้อมูลเพิ่มเติม</string>
 	<!-- Text for message when used successfully copied something -->
 	<string name="copied_to_clipboard">คัดลอกไปยังคลิปบอร์ด: %1$s</string>
 	<!-- place preview title -->
 	<string name="info">ข้อมูล</string>
 	<!-- Used for bookmark editing -->
 	<string name="done">เสร็จแล้ว</string>
-	<!-- Summary for preferences in MWM -->
-	<string name="yopme_pref_summary">เลือกการตั้งค่าหน้าจอส่วนหลัง</string>
-	<!-- Title for yopme preferences in MWM -->
-	<string name="yopme_pref_title">การตั้งค่าหน้าจอส่วนหลัง</string>
-	<!-- Hint for upper-right icon p2b -->
-	<string name="show_on_backscreen">แสดงหน้าจอส่วนหลัง</string>
 	<!-- Prints version number in About dialog -->
 	<string name="version">เวอร์ชัน: %s</string>
 	<!-- Confirmation in downloading countries dialog -->
@@ -243,11 +177,6 @@
 	<!-- Length of track in cell that describes route -->
 	<string name="length">ระยะเวลา</string>
 	<string name="share_my_location">แชร์ตำแหน่งที่ตั้งของฉัน</string>
-	<string name="menu_search">ค้นหา</string>
-	<!-- Settings screen: "Map" category title -->
-	<string name="prefs_group_map">แผนที่</string>
-	<!-- Settings screen: "Miscellaneous" category title -->
-	<string name="prefs_group_misc">เบ็ดเตล็ด</string>
 	<string name="prefs_group_route">การนำทาง</string>
 	<string name="pref_zoom_title">ปุ่มซูม</string>
 	<string name="pref_zoom_summary">แสดงบนหน้าจอ</string>
@@ -263,8 +192,6 @@
 	<string name="pref_map_3d_title">มุมมองเพอร์สเปกทีฟ</string>
 	<!-- Settings «Map» category: «3D buildings» title -->
 	<string name="pref_map_3d_buildings_title">ตึก 3D</string>
-	<!-- Settings «Map» category: «3D buildings» summary -->
-	<string name="pref_map_3d_buildings_subtitle">มีผลกระทบต่ออายุการใช้งานแบตเตอรี่</string>
 	<!-- Settings «Route» category: «Tts enabled» title -->
 	<string name="pref_tts_enable_title">คำแนะนำด้วยเสียง</string>
 	<!-- Settings «Route» category: «Tts language» title -->
@@ -273,7 +200,6 @@
 	<string name="pref_tts_unavailable">ไม่สามารถใช้ได้</string>
 	<!-- Title for "Other" section in TTS settings. -->
 	<string name="pref_tts_other_section_title">อื่น ๆ</string>
-	<string name="pref_tts_how_to_set_up_voice">วิธีตั้งค่าเสียง</string>
 	<!-- Settings «Map» category: «Record track» title -->
 	<string name="pref_track_record_title">เส้นทางล่าสุด</string>
 	<string name="pref_map_auto_zoom">ซูมอัตโนมัติ</string>
@@ -284,46 +210,11 @@
 	<string name="duration_12_hours">12 ชั่วโมง</string>
 	<string name="duration_1_day">1 วัน</string>
 	<string name="recent_track_help_text">ช่วยให้คุณบันทึกเส้นทางที่คุณเดินทางในช่วงระยะเวลาหนึ่งแล้วดูบนแผนที่ได้ โปรดทราบว่า: การเปิดใช้งานฟังก์ชั่นนี้จะทำให้การใช้งานแบตเตอรี่เพิ่มมากขึ้น การติดตามจะถูกเอาออกไปโดยอัตโนมัติจากแผนที่หลังจากผ่านช่วงเวลาที่กำหนด</string>
-	<string name="pref_track_ios_caption">เส้นทางล่าสุดแสดงให้เห็นถึงเส้นทางที่เดินทางแล้วของคุณ</string>
-	<string name="pref_track_ios_subcaption">โปรดเลือกช่วงเวลาในการบันทึกการติดตาม</string>
-	<string name="placepage_distance">ระยะห่าง</string>
-	<string name="placepage_coordinates">พิกัด</string>
-	<string name="placepage_unsorted">ไม่เรียงลำดับ</string>
 	<string name="search_show_on_map">ดูบนแผนที่</string>
-	<!-- Used to warn user when fixing KitKat issue -->
-	<string name="bookmark_move_fail">เราจำเป็นต้องลบบุ๊กมาร์กของคุณไปยังหน่วยความจำภายใน แต่ไม่มีพื้นที่ที่สามารถใช้ได้ โปรดเพิ่มหน่วยความจำ มิฉะนั้นจะไม่สามารถใช้บุ๊กมาร์กได้</string>
-	<!-- Used in More Apps menu -->
-	<string name="free">ฟรี</string>
-	<!-- Used in More Apps menu -->
-	<string name="buy">ซื้อ</string>
-	<!-- 1st search button-like result -->
-	<string name="search_on_map">ค้นหาแผนที่</string>
-	<!-- toast with an error -->
-	<string name="no_route_found">ไม่พบเส้นทาง</string>
-	<!-- route title -->
-	<string name="route">เส้นทาง</string>
-	<!-- category title -->
-	<string name="routes">เส้นทาง</string>
-	<!-- text of notification -->
-	<string name="download_map_notification">ดาวน์โหลดแผนที่เกี่ยวกับสถานที่ที่คุณอยู่</string>
-	<!-- text of notification -->
-	<string name="pro_version_is_free_today">เวอร์ชันเต็มของ Organic Maps วันนี้ฟรี! ดาวน์โหลดตอนนี้แล้วบอกเพื่อน ๆ ของคุณ</string>
-	<!-- Dialog for transferring maps from lite to pro. -->
-	<string name="move_lite_maps_to_pro">เรากำลังโอนแผนที่ที่ดาวน์โหลดของคุณจาก Organic Maps Lite ไปยัง Organic Maps อาจใช้เวลาสองสามวินาที</string>
-	<!-- Message to display when maps moved. -->
-	<string name="move_lite_maps_to_pro_ok">แผนที่ที่ดาวน์โหลดของคุณโอนไปยัง Organic Maps สำเร็จ</string>
-	<!-- Message to display when maps move failed. -->
-	<string name="move_lite_maps_to_pro_failed">ล้มเหลวในการโอนแผนที่ของคุณ โปรดลบ Organic Maps Lite และดาวน์โหลดแผนที่อีกครั้ง</string>
-	<!-- Text in menu -->
-	<string name="settings_and_more">การตั้งค่า &amp; อื่น ๆ</string>
 	<!-- Text in menu -->
 	<string name="website">เว็บไซต์</string>
-	<!-- Text in menu -->
-	<string name="contact_us">ติดต่อเรา</string>
 	<!-- Settings: Send feedback button and dialog title -->
 	<string name="feedback">ข้อเสนอแนะ</string>
-	<!-- Text in menu -->
-	<string name="subscribe_to_news">สมัครรับข่าวของเรา</string>
 	<!-- Text in menu -->
 	<string name="rate_the_app">ให้คะแนนแอป</string>
 	<!-- Text in menu -->
@@ -332,12 +223,6 @@
 	<string name="copyright">ลิขสิทธิ์</string>
 	<!-- Text in menu -->
 	<string name="report_a_bug">แจ้งข้อผิดพลาด</string>
-	<!-- Email subject -->
-	<string name="subscribe_me_subject">โปรดลงชื่อฉันเพื่อรับจดหมายข่าว Organic Maps</string>
-	<!-- Email body -->
-	<string name="subscribe_me_body">ฉันอยากเป็นคนแรกที่รู้เกี่ยวกับข่าว อัปเดตและโปรโมชั่นล่าสุด ฉันสามารถยกเลิกการเป็นสมาชิกของฉันได้ตลอดเวลา</string>
-	<!-- About text -->
-	<string name="about_text">Organic Maps ขอเสนอแผนที่ออฟไลน์ของทุกเมือง ทุกประเทศในโลกที่รวดเร็วที่สุด เดินทางด้วยความมั่นใจ: ไม่ว่าคุณจะอยู่ที่ไหน Organic Maps จะช่วยระบุตำแหน่งที่ตั้งของตัวคุณบนแผนที่ ค้นหาร้านอาหาร โรงแรม ธนาคาร ปั๊มน้ำมัน และอื่น ๆ ที่ใกล้ที่สุด โดยไม่จำเป็นต้องใช้การเชื่อมต่ออินเทอร์เน็ต\n\nเราทำงานเพื่อพัฒนาฟีเจอร์ใหม่ ๆ อยู่เสมอและยินดีรับฟังว่าคุณมีความคิดเห็นว่าเราจะพัฒนา Organic Maps ได้อย่างไร หากคุณมีปัญหาใด ๆ กับแอป อย่าลังเลที่จะติดต่อเราที่ support\@organicmaps.app โดยเราจะตอบรับทุกคำขอ!\n\nคุณชอบ Organic Maps และต้องการสนับสนุนเราหรือไม่? มีวิธีง่าย ๆ และฟรีอยู่บ้าง:\n\n- โพสต์คำวิจารณ์ของคุณที่ ตลาดแอป (App Market)\n- ถูกใจเพจ Facebook ของเรา http://www.facebook.com/OrganicMaps\n- หรือเพียงแค่บอกแม่ เพื่อน ๆ และเพื่อนร่วมงานของคุณเกี่ยวกับ Organic Maps :)\n\nขอบคุณที่ใช้บริการของเรา เราซาบซึ้งในการสนับสนุนของคุณมาก!\n\nป.ล. เรานำข้อมูลแผนที่มาจาก OpenStreetMap ซึ่งเป็นโครงการจัดทำแผนที่ที่เหมือนกับ Wikipedia ที่ช่วยให้ผู้ใช้สามารถสร้างและแก้ไขแผนที่ได้ หากคุณเห็นว่ามีสิ่งใดที่ขาดหายหรือไม่ถูกต้องบนแผนที่ คุณสามารถแก้ไขแผนที่ได้โดยตรงที่ https://www.openstreetmap.org และการเปลี่ยนแปลงของคุณจะปรากฏในแอป Organic Maps ในการปล่อยเวอร์ชันถัดไป</string>
 	<!-- Alert text -->
 	<string name="email_error_body">อีเมลลูกค้ายังไม่ได้รับการจัดตั้งขึ้น กรุณาตั้งค่าหรือใช้วิธีอื่นที่จะติดต่อเราที่ %s</string>
 	<!-- Alert title -->
@@ -346,137 +231,56 @@
 	<string name="pref_calibration_title">การปรับเทียบเข็มทิศ</string>
 	<!-- Search category -->
 	<string name="wifi">WiFi</string>
-	<!-- Update map suggestion -->
-	<string name="routing_map_outdated">โปรดอัปเดตแผนที่เพื่อสร้างเส้นทาง</string>
-	<!-- Update maps suggestion -->
-	<string name="routing_update_maps">เวอร์ชันใหม่ของ Organic Maps อนุญาติให้สร้างเส้นทางจากตำแหน่งปัจจุบันของคุณไปยังจุดปลายทาง โปรดอัปเดตแผนเพื่อใช้ฟีเจอร์นี้</string>
 	<!-- Update all button text -->
 	<string name="downloader_update_all_button">อัปเดตทั้งหมด</string>
 	<!-- Cancel all button text -->
 	<string name="downloader_cancel_all">ยกเลิกทั้งหมด</string>
 	<!-- Downloaded maps category -->
 	<string name="downloader_downloaded_subtitle">ดาวน์โหลดแล้ว</string>
-	<!-- Downloaded maps category -->
-	<string name="downloader_available_maps">มีให้ใช้</string>
 	<!-- Country queued for download -->
 	<string name="downloader_queued">ต่อแถว</string>
 	<string name="downloader_near_me_subtitle">ใกล้ฉัน</string>
 	<string name="downloader_status_maps">แผนที่</string>
 	<string name="downloader_download_all_button">ดาวน์โหลดทั้งหมด</string>
 	<string name="downloader_downloading">กำลังดาวน์โหลด:</string>
-	<string name="downloader_search_results">พบ</string>
-	<!-- Disclaimer message -->
-	<string name="routing_disclaimer">การสร้างเส้นทางในแอป Organic Maps มีสิ่งที่ควรทราบดังต่อไปนี้:\n\n  - พึงพิจารณาเส้นทางที่แนะนำไว้ในฐานะที่เป็นการแนะนำเท่านั้น\n - สภาพถนน กฎจราจรและป้ายมีความสำคัญมากกว่าคำแนะนำในการนำทาง\n - แผนที่อาจไม่ถูกต้องหรือล้าสมัย และอาจไม่ได้มีการสร้างเส้นทางในรูปแบบพอจะเป็นไปได้ที่ดีที่สุด\n\n  ขอให้ปลอดภัยบนท้องถนนและดูแลตัวคุณเองด้วย!</string>
-	<!-- Outdated maps category -->
-	<string name="downloader_outdated_maps">ล้าสมัย</string>
-	<!-- Up to date maps category -->
-	<string name="downloader_uptodate_maps">ทันสมัย</string>
 	<!-- Status of outdated country in the list -->
 	<string name="downloader_status_outdated">ปรับปรุง</string>
 	<!-- Status of failed country in the list -->
 	<string name="downloader_status_failed">ล้มเหลว</string>
 	<!-- Displayed in a dialog that appears when a user tries to delete a map while the app is in the follow route mode -->
 	<string name="downloader_delete_map_while_routing_dialog">เพื่อลบแผนที่ โปรดหยุดใช้การนำทาง</string>
-	<!-- Show when user try build route, but we don't know where he -->
-	<string name="routing_failed_unknown_my_position">ไม่มีการกำหนดสถานที่ปัจจุบัน โปรดระบุสถานที่ตั้งเพื่อสร้างเส้นทาง</string>
-	<!-- Show if use has not routing file, or InconsistentMWMandRoute -->
-	<string name="routing_failed_has_no_routing_file">ข้อมูลเพิ่มเติมเป็นต้องมีเพื่อสร้างเส้นทาง เริ่มต้นการดาวน์โหลด?</string>
-	<!-- StartPointNotFound -->
-	<string name="routing_failed_start_point_not_found">ไม่สามารถคำนวณเส้นทางได้ ไม่มีถนนที่อยู่ใกล้เคียงกับจุดเริ่มต้นของคุณ</string>
-	<!-- EndPointNotFound -->
-	<string name="routing_failed_dst_point_not_found">ไม่สามารถคำนวณเส้นทางได้ ไม่มีถนนที่อยู่ใกล้กับปลายทางของคุณ</string>
 	<!-- PointsInDifferentMWM -->
 	<string name="routing_failed_cross_mwm_building">สามารถสร้างเส้นทางแบบสมบูรณ์ได้เฉพาะที่มีอยู่ในแผนที่เดียวเท่านั้น</string>
-	<!-- RouteNotFound -->
-	<string name="routing_failed_route_not_found">ไม่พบเส้นทางที่อยู่ระหว่างต้นทางและปลายทางที่เลือก โปรดเลือกจุดเริ่มต้นและจุดสิ้นสุดอื่น</string>
-	<!-- InternalError -->
-	<string name="routing_failed_internal_error">เกิดข้อผิดพลาดขึ้นภายใน โปรดลองลบและดาวน์โหลดแผนที่อีกครั้ง โปรดติดต่อเราได้ที่ support\@organicmaps.app.</string>
-	<!-- Context menu item for downloader. -->
-	<string name="downloader_download_map_and_routing">ดาวน์โหลดแผนที่ + การเลือกเส้นทาง</string>
-	<!-- Context menu item for downloader. -->
-	<string name="downloader_download_routing">ดาวน์โหลดการเลือกเส้นทาง</string>
-	<!-- Context menu item for downloader. -->
-	<string name="downloader_delete_routing">ลบการเลือกเส้นทาง</string>
 	<!-- Context menu item for downloader. -->
 	<string name="downloader_download_map">ดาวน์โหลดแผนที่</string>
-	<string name="downloader_download_map_no_routing">ดาวน์โหลดแผนที่โดยไม่กำหนดเส้นทาง</string>
-	<!-- Button for routing. -->
-	<string name="routing_go">ไป!</string>
 	<!-- Item status in downloader. -->
 	<string name="downloader_retry">ทำซ้ำ</string>
-	<!-- Item in context menu. -->
-	<string name="downloader_map_and_routing">แผนที่ + เส้นทาง</string>
 	<!-- Item in context menu. -->
 	<string name="downloader_delete_map">ลบแผนที่</string>
 	<!-- Item in context menu. -->
 	<string name="downloader_update_map">อัปเดตแผนที่</string>
-	<!-- Item in context menu. -->
-	<string name="downloader_update_map_and_routing">อัปเดตแผนที่ + เส้นทาง</string>
-	<!-- Item in context menu. -->
-	<string name="downloader_map_only">แผนที่เท่านั้น</string>
-	<!-- Toolbar title -->
-	<string name="toolbar_application_menu">เมนูของแอปพลิเคชัน</string>
 	<!-- Preference text -->
 	<string name="pref_use_google_play">ใช้บริการ Google Play เพื่อรับตำแหน่งปัจจุบันของคุณ</string>
 	<!-- Text for rating dialog -->
 	<string name="rating_just_rated">ฉันเพิ่งให้คะแนนแอปของคุณ</string>
-	<!-- Text for rating dialog -->
-	<string name="rating_user_since">ฉันคือผู้ใช้ MAPS. ME ตั้งแต่ปี %s</string>
-	<!-- Text for rating dialog -->
-	<string name="rating_do_like_maps">คุณชอบ MAPS. ME หรือไม่?</string>
-	<!-- Text for rating dialog -->
-	<string name="rating_tap_star">แตะดาวเพื่อให้คะแนนแอปของเรา</string>
 	<!-- Text for rating dialog -->
 	<string name="rating_thanks">ขอบคุณ!</string>
 	<!-- Text for rating dialog -->
 	<string name="rating_share_ideas">แชร์ความคิดเห็นหรือปัญหาใด ๆ เพื่อให้เราสามารถปรับปรุงแอปสำหรับคุณได้</string>
 	<!-- Text for rating dialog -->
 	<string name="rating_send_feedback">ส่งข้อเสนอแนะ</string>
-	<!-- Text for g+ dialog -->
-	<string name="rating_google_plus">คลิก g+ เพื่อบอกเพื่อน ๆ ของคุณเกี่ยวกับแอป</string>
 	<!-- Text for routing error dialog -->
 	<string name="routing_download_maps_along">ดาวน์โหลดแผนที่ตามเส้นทาง</string>
-	<!-- Text for routing error dialog -->
-	<string name="routing_download_map">รับแผนที่</string>
-	<!-- Text for routing error dialog -->
-	<string name="routing_download_map_and_routing">ดาวน์โหลดแผนที่มีการอัปเดตและการกำหนดเส้นทางข้อมูลเพื่อรับฟีเจอร์ Organic Maps ทั้งหมด</string>
-	<!-- Text for routing error dialog -->
-	<string name="routing_get_routing_data">รับข้อมูลการกำหนดเส้นทาง</string>
-	<!-- Text for routing error dialog -->
-	<string name="routing_get_additional_data">ข้อมูลเพิ่มเติมที่จำเป็นสำหรับการสร้างเส้นทางจากสถานที่ตั้งของคุณ</string>
 	<!-- Text for routing error dialog -->
 	<string name="routing_requires_all_map">การสร้างเส้นทางจำเป็นต้องใช้แผนที่จากสถานที่ตั้งของคุณไปยังปลายทางที่มีการดาวน์โหลดและอัปเดต</string>
 	<!-- Text for routing error dialog -->
 	<string name="routing_not_enough_space">มีพื้นที่ไม่เพียงพอ</string>
-	<!-- Text for routing error dialog -->
-	<string name="routing_download_more_than_avail">คุณจำเป็นต้องดาวน์โหลด %1$s MB แต่สามารถใช้ได้เพียง %2$s MB เท่านั้น</string>
-	<!-- Text for routing error dialog -->
-	<string name="routing_download_roaming">คุณกำลังจะดาวน์โหลด %s MB โดยการใช้ข้อมูลโทรศัพท์มือถือ (ในการใช้งานข้ามเขต) นี่อาจส่งผลในการคิดค่าบริการเพิ่มเติมโดยขึ้นอยู่กับแผนการใช้ข้อมูลโทรศัพท์มือถือของผู้ให้บริการของคุณ</string>
 	<!-- bookmark button text -->
 	<string name="bookmark">บุ๊กมาร์ก</string>
-	<!-- map is not downloaded -->
-	<string name="not_found_map">ไม่พบแผนที่ของตำแหน่งของคุณ</string>
 	<!-- location service disabled -->
 	<string name="enable_location_services">โปรดเปิดการใช้งานการบริการตำแหน่งที่ตั้ง</string>
-	<!-- download map -->
-	<string name="download_map">ดาวน์โหลดแผนที่เกี่ยวกับสถานที่ที่คุณอยู่</string>
-	<!-- download map on iPhone -->
-	<string name="download_map_iphone">ดาวน์โหลดแผนที่สำหรับตำแหน่งปัจจุบันบน iPhone ของคุณ</string>
-	<!-- clear pin -->
-	<string name="nearby">ใกล้เคียง</string>
-	<!-- clear pin -->
-	<string name="clear_pin">ล้างปักหมุด</string>
-	<!-- location is undefined -->
-	<string name="undefined_location">ไม่มีการกำหนดสถานที่ปัจจุบัน</string>
-	<!-- download country of your location -->
-	<string name="download_country">ดาวน์โหลด ประเทศของตำแหน่งที่ตั้งปัจจุบันของคุณ</string>
-	<!-- download failed -->
-	<string name="download_failed">การดาวน์โหลด  ล้มเหลว</string>
-	<!-- get the map -->
-	<string name="get_the_map">รับแผนที่</string>
 	<string name="save">บันทึก</string>
 	<string name="edit_description_hint">คำอธิบายของคุณ (ข้อความหรือ html)</string>
-	<string name="new_group">กลุ่มใหม่</string>
 	<string name="create">สร้าง</string>
 	<!-- red color -->
 	<string name="red">สีแดง</string>
@@ -494,22 +298,6 @@
 	<string name="brown">สีน้ำตาล</string>
 	<!-- pink color -->
 	<string name="pink">สีชมพู</string>
-	<!-- deep purple color -->
-	<string name="deep_purple">สีม่วงเข้ม</string>
-	<!-- light blue color -->
-	<string name="light_blue">สีฟ้าอ่อน</string>
-	<!-- cyan color -->
-	<string name="cyan">สีฟ้าอมเขียว</string>
-	<!-- teal color -->
-	<string name="teal">สีเขียวนกเป็ดน้ำ</string>
-	<!-- lime color -->
-	<string name="lime">สีเขียวอมเหลือง</string>
-	<!-- deep orange color -->
-	<string name="deep_orange">สีส้มเข้ม</string>
-	<!-- gray color -->
-	<string name="gray">สีเทา</string>
-	<!-- blue gray color -->
-	<string name="blue_gray">สีฟ้าอมเทา</string>
 	<!-- Wi-Fi available -->
 	<string name="WiFi_available">ใช่</string>
 
@@ -525,10 +313,8 @@
 	<string name="dialog_routing_location_turn_wifi">กรุณาตรวจสอบสัญญาณ GPS ของคุณ การเปิดใช้ Wi-Fi จะช่วยเพิ่มความแม่นยำในการระบุตำแหน่งของคุณ</string>
 	<string name="dialog_routing_location_turn_on">เปิดใช้บริการหาตำแหน่ง</string>
 	<string name="dialog_routing_location_unknown_turn_on">ไม่สามารถหาตำแหน่งพิกัด GPS ปัจจุบันได้ เปิดใช้บริการหาตำแหน่งเพื่อคำนวณเส้นทาง</string>
-	<string name="dialog_routing_location_unknown">ไม่สามารถหาตำแหน่งพิกัด GPS ปัจจุบันได้</string>
 	<string name="dialog_routing_download_files">ดาวน์โหลดไฟล์ที่จำเป็น</string>
 	<string name="dialog_routing_download_and_update_all">ดาวน์โหลดและอัปเดตแผนที่กับข้อมูลเส้นทางทั้งหมดตามเส้นทางที่คาดหมายเพื่อคำนวณเส้นทาง</string>
-	<string name="dialog_routing_routes_size">ไฟล์ข้อมูลเส้นทาง</string>
 	<string name="dialog_routing_unable_locate_route">ไม่สามารถหาเส้นทางได้</string>
 	<string name="dialog_routing_cant_build_route">ไม่สามารถสร้างเส้นทางได้</string>
 	<string name="dialog_routing_change_start_or_end">กรุณาปรับจุดเริ่มต้นหรือที่หมายของคุณ</string>
@@ -543,33 +329,23 @@
 	<string name="dialog_routing_system_error">ระบบเกิดข้อผิดพลาด</string>
 	<string name="dialog_routing_application_error">ไม่สามารถสร้างเส้นทางได้เนื่องจากเกิดข้อผิดพลาดของแอปพลิเคชัน</string>
 	<string name="dialog_routing_try_again">กรุณาลองอีกครั้ง</string>
-	<string name="dialog_routing_send_error">รายงานปัญหา</string>
-	<string name="dialog_routing_if_get_cross_route">คุณต้องการสร้างเส้นทางที่อ้อมน้อยลงซึ่งข้ามเกินหนึ่งแผนที่หรือไม่?</string>
-	<string name="dialog_routing_cross_route_is_optimal">มีเส้นทางที่เหมาะสมกว่าซึ่งข้ามเลยขอบของแผนที่นี้</string>
 	<string name="not_now">ไว้คราวหลัง</string>
-	<string name="dialog_routing_build_route">สร้าง</string>
 	<string name="dialog_routing_download_and_build_cross_route">คุณต้องการดาวน์โหลดแผนที่และสร้างเส้นทางที่เหมาะสมกว่าซึ่งข้ามเกินหนึ่งแผนที่หรือไม่?</string>
 	<string name="dialog_routing_download_cross_route">ดาวน์โหลดแผนที่เพื่อสร้างเส้นทางที่เหมาะสมกว่าซึ่งข้ามเลยขอบของแผนที่นี้</string>
-	<string name="dialog_routing_cross_route_always">ข้ามขอบเขตนี้เสมอ</string>
 
 	<!-- SECTION: Strings for downloading map from search -->
 	<string name="search_without_internet_advertisement">เพื่อเริ่มต้นการค้นหาและสร้างเส้นทาง โปรดดาวน์โหลดแผนที่ และคุณจะไม่จำเป็นต้องทำการเชื่อมต่ออินเทอร์เน็ตอีกต่อไป</string>
 	<string name="search_select_map">เลือกแผนที่</string>
-	<string name="search_select_other_map">เลือกแผนที่อื่น</string>
 	<!-- «Show» context menu -->
 	<string name="show">แสดง</string>
 	<!-- «Hide» context menu -->
 	<string name="hide">ซ่อน</string>
 	<!-- «Rename» context menu -->
 	<string name="rename">เปลี่ยนชื่อ</string>
-	<!-- Bottom sheet: expand button (should be short) -->
-	<string name="bottom_sheet_more">เพิ่มเติม…</string>
 	<!-- Failed planning route message in navigation view -->
 	<string name="routing_planning_error">การวางแผนเส้นทางล้มเหลว</string>
 	<!-- Arrive routing message in navigation view -->
 	<string name="routing_arrive">มาถึง: %s</string>
-	<!-- Text for routing::RouterResultCode::FileTooOld dialog. -->
-	<string name="dialog_routing_download_and_update_maps">เพื่อสร้างเส้นทาง โปรดดาวน์โหลดและอัปเดตแผนที่ทั้งหมดตลอดเส้นทาง</string>
 	<string name="rate_alert_title">ชอบแอปหรือไม่?</string>
 	<string name="rate_alert_default_message">ขอบพระคุณสำหรับการใช้ Organic Maps โปรดให้คะแนนแอป ข้อเสนอแนะของคุณจะช่วยทำให้เราทำได้ดียิ่งขึ้น</string>
 	<string name="rate_alert_five_star_message">ฮูเร่! เราก็รักคุณเช่นกัน!</string>
@@ -577,24 +353,14 @@
 	<string name="rate_alert_less_than_four_star_message">มีไอเดียถึงวิธีที่จะทำให้เราสามารถทำให้มันดีขึ้นหรือไม่?</string>
 	<string name="categories">หมวดหมู่</string>
 	<string name="history">ประวัติ</string>
-	<string name="next_turn_then">จากนั้น</string>
 	<string name="closed">ปิด</string>
-	<string name="back_to">กลับไป %s</string>
 	<string name="search_not_found">ขออภัย ฉันไม่พบสิ่งใด</string>
 	<string name="search_not_found_query">โปรดลองใช้คำถามอื่น</string>
-	<string name="search_not_found_map">กรุณาดาวน์โหลดแผนที่ที่คุณกำลังค้นหา</string>
-	<string name="search_not_found_location">ดาวน์โหลดแผนที่ของตำแหน่งปัจจุบันของคุณ</string>
 	<string name="search_history_title">ประวัติการค้นหา</string>
 	<string name="search_history_text">เข้าถึงคำถามที่ใช้ในการค้นหาเมื่อเร็ว ๆ นี้ได้อย่างรวดเร็ว</string>
 	<string name="clear_search">ล้างการค้นหาประวัติ</string>
-	<!-- Title for settings to enable/disable showcase menu button -->
-	<string name="showcase_settings_title">แสดงข้อเสนอ</string>
-	<string name="p2p_route_planning">การวางแผนเส้นทาง</string>
 	<string name="p2p_your_location">ตำแหน่งที่ตั้งของคุณ</string>
-	<string name="p2p_from">จุดที่ออกเดินทาง</string>
-	<string name="p2p_to">จุดที่เป็นปลายทาง</string>
 	<string name="p2p_start">เริ่มต้น</string>
-	<string name="p2p_planning">กำลังวางแผน…</string>
 	<string name="p2p_from_here">จาก</string>
 	<string name="p2p_to_here">เส้นทางถึง</string>
 	<string name="p2p_only_from_current">สามารถใช้การนำทางได้เฉพาะจากตำแหน่งที่ตั้งปัจจุบันของคุณเท่านั้น</string>
@@ -614,11 +380,8 @@
 	<string name="editor_hours_closed">ปิดเวลา</string>
 	<string name="editor_example_values">ตัวอย่างของค่าที่ตั้งไว้</string>
 	<string name="editor_correct_mistake">แก้ไขข้อผิดพลาด</string>
-	<string name="editor_correct_mistake_message">มีข้อผิดพลาดเกิดขึ้นจากการแก้ไขของคุณ โปรดแก้ไขให้ถูกต้อง หรือ สลับไปใช้ในโหมดแบบง่าย</string>
 	<string name="editor_add_select_location">ตำแหน่ง</string>
 	<string name="editor_done_dialog_1">คุณได้เปลี่ยนแผนที่โลก อย่าซ่อนมันไว้! บอกเพื่อนคุณ แล้วมาแก้ไขมันไปด้วยกัน</string>
-	<string name="editor_done_dialog_2">มันเป็นการปรับปรุงแผนที่ครั้งที่สองของคุณ ตอนนี้คุณอยู่ในอันดับที่ %d ของรายการผู้แก้ไขแผนที่ บอกให้เพื่อนคุณรู้</string>
-	<string name="editor_done_dialog_3">คุณได้ปรับปรุงแผนที่ บอกให้เพื่อนคุณรู้ แล้วมาแก้ไขแผนที่ไปด้วยกัน</string>
 	<string name="share_with_friends">แชร์กับเพื่อน</string>
 	<string name="editor_report_problem_desription_1">กรุณาอธิบายปัญหาโดยละเอียดเพื่อที่ชุมชน OpenStreeMap จะสามารถแก้ไขข้อผิดพลาดได้</string>
 	<string name="editor_report_problem_desription_2">หรือทำด้วยตัวคุณเองที่ https://www.openstreetmap.org/</string>
@@ -627,14 +390,7 @@
 	<string name="editor_report_problem_no_place_title">ไม่มีสถานที่นี้อยู่</string>
 	<string name="editor_report_problem_under_construction_title">ปิดปรับปรุง</string>
 	<string name="editor_report_problem_duplicate_place_title">สถานที่ซ้ำ</string>
-	<string name="first_launch_congrats_title">Organic Maps พร้อมใช้งานแล้ว</string>
-	<string name="first_launch_congrats_text">ค้นหาและนำทางไปทุกที่ในโลกแบบออฟไลน์ ไม่มีค่าใช้จ่าย</string>
-	<string name="migrate_title">สำคัญ!</string>
-	<!-- Android uses image instead of text. -->
-	<string name="download_all">ดาวน์โหลดทั้งหมด</string>
-	<string name="delete_all">ลบทั้งหมด</string>
 	<string name="autodownload">ดาวน์โหลดอัตโนมัติ</string>
-	<string name="disable_autodownload">หยุดการดาวน์โหลดแบบอัตโนมัติ</string>
 	<!-- Place Page opening hours text -->
 	<string name="closed_now">ปิดตอนนี้</string>
 	<!-- Place Page opening hours text -->
@@ -643,8 +399,6 @@
 	<string name="day_off_today">วันนี้ปิด</string>
 	<string name="day_off">ปิด</string>
 	<string name="today">วันนี้</string>
-	<string name="sunrise_to_sunset">ตั้งแต่พระอาทิตย์ขึ้นจนพระอาทิตย์ตก</string>
-	<string name="sunset_to_sunrise">ตั้งแต่พระอาทิตย์ตกจนพระอาทิตย์ขึ้น</string>
 	<string name="add_opening_hours">เพิ่มชั่วโมงทำการ</string>
 	<string name="edit_opening_hours">แก้ไขชั่วโมงทำการ</string>
 	<string name="no_osm_account">ไม่มีบัญชีใน OpenStreetMap?</string>
@@ -654,29 +408,13 @@
 	<string name="login">ล็อกอิน</string>
 	<string name="password">รหัสผ่าน</string>
 	<string name="forgot_password">ลืมรหัสผ่าน?</string>
-	<!-- Forgot Password dialog title -->
-	<string name="restore_password">เรียกคืนรหัสผ่าน</string>
-	<string name="enter_email_address_to_reset_password">ใส่ที่อยู่อีเมลที่คุณใช้ระหว่างการลงทะเบียนแล้วเราจะส่งลิงก์ไปยังคุณเพื่อต่ออายุรหัสผ่านของคุณ</string>
-	<string name="reset_password">ตั้งรหัสผ่านใหม่</string>
-	<string name="username">ชื่อผู้ใช้</string>
 	<string name="osm_account">บัญชี OSM</string>
 	<string name="logout">ออกจากระบบ</string>
-	<string name="login_and_edit_map_motivation_message">ล็อกอินและแก้ไขข้อมูลวัตถุบนแผนที่ และเราจะทำให้มันสามารถใช้งานได้สำหรับผู้ใช้ท่านอื่น ๆ อีกนับล้าน มาช่วยกันทำให้โลกดียิ่งขึ้นร่วมกัน</string>
 	<!-- Information text: "Last upload 11.01.2016" -->
 	<string name="last_upload">อัปโหลดครั้งสุดท้าย</string>
-	<!-- Motivates user to login/register, title above login buttons. -->
-	<string name="you_have_edited_your_first_object">คุณได้แก้ไขวัตถุแรกของคุณ!</string>
 	<string name="thank_you">ขอบพระคุณ</string>
-	<string name="login_with_google">ล็อกอินด้วย Google</string>
-	<string name="login_with_openstreetmap">ล็อกอินที่ www.openstreetmap.org</string>
 	<string name="edit_place">แก้ไขสถานที่</string>
 	<string name="place_name">ชื่อสถานที่</string>
-	<!-- title above languages list cells in the editor, below editable name text field. -->
-	<string name="other_languages">ภาษาอื่น ๆ</string>
-	<!-- small button to open list with names in different languages -->
-	<string name="show_more">แสดงมากขึ้น</string>
-	<!-- small button to close list with names in different languages -->
-	<string name="show_less">แสดงน้อยลง</string>
 	<string name="add_language">เพิ่มภาษา</string>
 	<string name="street">ถนน</string>
 	<!-- Editable House Number text field (in address block). -->
@@ -693,25 +431,16 @@
 	<string name="email_or_username">อีเมลหรือชื่อผู้ใช้</string>
 	<string name="phone">โทรศัพท์</string>
 	<string name="please_note">โปรดทราบ</string>
-	<string name="common_no_wifi_dialog">ไม่มีการเชื่อมต่อ WiFi คุณต้องการดำเนินการต่อโดยใช้ข้อมูลมือถือหรือไม่?</string>
 	<string name="downloader_delete_map_dialog">การเปลี่ยนแปลงแผนที่ทั้งหมดจะถูกลบไปพร้อมกับแผนที่</string>
 	<string name="downloader_update_maps">อัปเดตแผนที่</string>
 	<string name="downloader_mwm_migration_dialog">ในการสร้างเส้นทาง คุณต้องอัปเดตแผนที่ทั้งหมดแล้ววางแผนเส้นทางอีกครั้ง</string>
 	<string name="downloader_search_field_hint">ค้นหาแผนที่</string>
-	<string name="migration_update_all_button">อัปเดตแผนที่ทั้งหมด</string>
-	<string name="migration_delete_all_download_current_button">ดาวน์โหลดแผนที่ปัจจุบันและลบแผนที่เก่า</string>
 	<string name="migration_download_error_dialog">ข้อผิดพลาดในการดาวน์โหลด</string>
 	<string name="common_check_internet_connection_dialog">กรุณาตรวจสอบการตั้งค่าของคุณแล้วทำให้แน่ใจว่าอุปกรณ์ของคุณได้รับการเชื่อมต่ออินเทอร์เน็ต</string>
 	<string name="downloader_no_space_title">มีพื้นที่ไม่เพียงพอ</string>
 	<string name="downloader_no_space_message">กรุณาลบข้อมูลที่ไม่จำเป็น</string>
-	<string name="editor_general_auth_error_dialog">ข้อผิดพลาดในการล็อกอินทั่วไป</string>
 	<string name="editor_login_error_dialog">ข้อผิดพลาดในการล็อกอิน</string>
-	<string name="editor_login_failed_dialog">การล็อกอินล้มเหลว</string>
-	<string name="editor_username_error_dialog">ชื่อผู้ใช้ไม่ถูกต้อง</string>
-	<string name="editor_place_edited_dialog">คุณได้แก้ไขวัตถุ!</string>
-	<string name="editor_login_with_osm">ล็อกอินด้วย OpenStreetMap</string>
 	<string name="editor_profile_changes">การเปลี่ยนแปลงที่อนุมัติแล้ว</string>
-	<string name="editor_profile_unsent_changes">ไม่ได้ส่ง:</string>
 	<string name="editor_focus_map_on_location">ดึงแผนที่เพื่อเลือกตำแหน่งวัตถุที่ถูกต้อง</string>
 	<string name="editor_add_select_category">เลือกหมวดหมู่</string>
 	<string name="editor_add_select_category_popular_subtitle">ยอดนิยม</string>
@@ -722,19 +451,14 @@
 	<string name="editor_edit_place_category_title">หมวดหมู่</string>
 	<string name="detailed_problem_description">คำอธิบายปัญหาอย่างละเอียด</string>
 	<string name="editor_report_problem_other_title">ปัญหาอีกอย่างหนึ่ง</string>
-	<string name="placepage_report_problem_button">แจ้งปัญหา</string>
 	<string name="placepage_add_business_button">เพิ่มองค์กร</string>
 	<string name="whatsnew_editor_message_1">เพิ่มสถานที่ใหม่ ๆ ไปยังแผนที่ และแก้ไขสถานที่ที่มีอยู่เดิมจากแอปโดยตรง</string>
-	<string name="whatsnew_editor_message_2">* Organic Maps ใช้ข้อมูลจากชุมชน OpenStreetMap</string>
 	<string name="dialog_incorrect_feature_position">เปลี่ยนสถานที่ตั้ง</string>
 	<string name="message_invalid_feature_position">ไม่สามารถตั้งวัตถุได้ที่นี่</string>
 	<string name="login_to_make_edits_visible">ล็อกอินเพื่อให้ผู้ใช้คนอื่นสามารถเห็นการเปลี่ยนแปลงของคุณได้</string>
-	<string name="no_migration_during_navigation">ห้ามอัปเดตระหว่างการนำทาง</string>
 	<!-- Error dialog no space -->
 	<string name="migration_no_space_message">ในการดาวน์โหลด คุณต้องมีพื้นที่มากขึ้น กรุณาลบเนื้อหาที่ไม่จำเป็นออกไป</string>
 	<string name="editor_sharing_title">ฉันได้ปรับปรุงแผนที่ Organic Maps</string>
-	<string name="editor_comment_will_be_sent">เราจะส่งความคิดเห็นของคุณไปให้กับนักเขียนแผนที่</string>
-	<string name="editor_unsupported_category_message">คุณได้เพิ่มสถานที่ในหมวดหมู่ที่เรายังไม่รองรับ มันจะปรากฏบนแผนที่หลังจากนี้สักพักหนึ่ง</string>
 	<!-- Downloaded 10 **of** 20 <- it is that "of" -->
 	<string name="downloader_of">%1$d จาก %2$d</string>
 	<string name="download_over_mobile_header">ดาวน์โหลดโดยใช้การเชื่อมต่อเครือข่ายมือถือ?</string>
@@ -752,15 +476,8 @@
 	<string name="editor_detailed_description">คำแนะนำการเปลี่ยนแปลงของคุณจะถูกส่งไปยังกลุ่ม OpenStreetMap โปรดอธิบายรายละเอียดที่ Organic Maps ไม่สามารถแก้ไขได้</string>
 	<string name="editor_more_about_osm">ข้อมูลเพิ่มเติมเกี่ยวกับ OpenStreetMap</string>
 	<string name="editor_operator">เจ้าของ</string>
-	<string name="editor_tag_description">ใส่ชื่อบริษัท, องค์กร หรือ บุคคลที่เป็นผู้รับผิดชอบสถานที่นี้</string>
-	<string name="editor_no_local_edits_title">คุณไม่มีการแก้ไขท้องถิ่น</string>
-	<string name="editor_no_local_edits_description">หมายเลขที่แสดงอยู่ คือ หมายเลขที่คุณได้ทำการแนะนำการเปลี่ยนแปลงบนแผนที่ที่สามารถเข้าถึงได้โดยอุปกรณ์ของคุณท่านั้น</string>
-	<string name="editor_send_to_osm">ส่งไปที่ OSM</string>
-	<string name="editor_remove">ลบออก</string>
-	<string name="downloader_my_maps_title">แผนที่ของฉัน</string>
 	<string name="downloader_no_downloaded_maps_title">คุณยังไม่ได้ดาวน์โหลดแผนที่</string>
 	<string name="downloader_no_downloaded_maps_message">ดาวน์โหลดแผนที่เพื่อค้นหาสถานที่ และนำทางแบบออฟไลน์</string>
-	<string name="downloader_find_place_hint">ค้นหาชื่อเมือง หรือ ประเทศ</string>
 	<!-- Error title that appears after certain time without location. -->
 	<string name="current_location_unknown_title">ค้นหาที่ตั้งปัจจุบันต่อไปหรือไม่?</string>
 	<!-- Error that appears after certain time without location. -->
@@ -775,27 +492,10 @@
 	<string name="location_services_disabled_2">2. แตะตำแหน่งที่ตั้ง</string>
 	<!-- iOS Dialog for the case when the location permission is not granted -->
 	<string name="location_services_disabled_3">3. เลือกในขณะใช้แอป</string>
-	<string name="placepage_parking_surface">กลางแจ้ง</string>
-	<string name="placepage_parking_multistorey">หลายชั้น</string>
-	<string name="placepage_parking_underground">ชั้นใต้ดิน</string>
-	<string name="placepage_parking_rooftop">ดาดฟ้า</string>
-	<string name="placepage_parking_sheds">ในร่ม</string>
-	<string name="placepage_parking_carports">โรงรถ</string>
-	<string name="placepage_parking_boxes">โรงรถแบบกล่อง</string>
-	<string name="placepage_parking_pay">เสียเงิน</string>
-	<string name="placepage_parking_free">ฟรี</string>
-	<string name="placepage_parking_interval">จ่ายตามช่วงเวลา</string>
-	<string name="placepage_entrance_number">หมายเลข</string>
-	<string name="placepage_entrance_type">ทางเข้า</string>
-	<string name="placepage_flat">ห้อง</string>
-	<string name="placepage_open_24_7">24 ชั่วโมง</string>
 	<string name="meter">ม.</string>
 	<string name="kilometer">กม.</string>
-	<string name="kilometers_per_hour">กม./ชม.</string>
 	<string name="mile">ไมล์</string>
 	<string name="foot">ฟุต</string>
-	<string name="miles_per_hour">ไมล์/ชม.</string>
-	<string name="day">ว.</string>
 	<string name="hour">ชม.</string>
 	<string name="minute">น.</string>
 	<string name="placepage_place_description">คำอธิบาย</string>
@@ -805,46 +505,30 @@
 	<string name="placepage_call_button">โทร</string>
 	<string name="placepage_edit_bookmark_button">แก้ไข Bookmark</string>
 	<string name="placepage_bookmark_name_hint">ชื่อของ Bookmark</string>
-	<string name="placepage_personal_notes_hint">ข้อความส่วนตัว</string>
-	<string name="placepage_delete_bookmark_button">ลบ Bookmark</string>
 	<string name="editor_edits_sent_message">คำแนะนำการเปลี่ยนแปลงของคุณถูกส่งไปแล้ว</string>
 	<string name="editor_comment_hint">ข้อคิดเห็น</string>
 	<string name="editor_reset_edits_message">ตั้งค่าการเปลี่ยนแปลงท้องถิ่นทั้งหมด</string>
 	<string name="editor_reset_edits_button">ตั้งค่าใหม่</string>
 	<string name="editor_remove_place_message">ลบที่ที่เพิ่มออก</string>
 	<string name="editor_remove_place_button">ลบออก</string>
-	<string name="editor_status_sending">กำลังส่ง…</string>
 	<string name="editor_place_doesnt_exist">ไม่พบสถานที่นี้</string>
 	<string name="text_more_button">…เพิ่มเติม</string>
 	<!-- Phone number error message -->
 	<string name="error_enter_correct_phone">กรอกหมายเลขโทรศัพท์ที่ถูกต้อง</string>
 	<string name="error_enter_correct_web">กรอกที่อยู่เว็บที่ถูกต้อง</string>
 	<string name="error_enter_correct_email">กรอกอีเมลที่ถูกต้อง</string>
-	<string name="error_enter_correct">กรอกค่าที่ถูกต้อง</string>
 	<string name="refresh">อัปเดต</string>
-	<string name="last_update">การอัปเดตล่าสุด: %s</string>
 	<string name="placepage_add_place_button">เพิ่มสถานที่ไปยังแผนที่</string>
 	<!-- Displayed when saving some edits to the map to warn against publishing personal data -->
 	<string name="editor_share_to_all_dialog_title">คุณต้องการส่งมันให้ผู้ใช้ทั้งหมดหรือไม่?</string>
 	<!-- iOS Dialog before publishing the modifications to the public map. -->
 	<string name="editor_share_to_all_dialog_message_1">ตรวจสอบว่าคุณไม่ได้กรอกข้อมูลส่วนตัวใด ๆ</string>
 	<string name="editor_share_to_all_dialog_message_2">เราจะตรวจสอบการเปลี่ยนแปลง หากเรามีคำถามใด ๆ เราจะติดต่อคุณผ่านทางอีเมล</string>
-	<string name="navigation_overview_button">ภาพรวม</string>
-	<string name="navigation_stop_button">หยุด</string>
-	<!-- Text on an empty bookmark page -->
-	<string name="bookmarks_empty_title">บันทึกบุ๊กมาร์ก</string>
-	<string name="bookmarks_empty_message_1">แตะ ★ เพื่อบันทึกสถานที่โปรดเพื่อให้เข้าถึงได้อย่างรวดเร็ว</string>
-	<string name="bookmarks_empty_message_2">นำเข้าบุ๊กมาร์กจาก Mail และเว็บ</string>
-	<string name="bookmarks_empty_message_3">เช็คเอาท์: %s</string>
-	<!-- Name of the group for booked hotels -->
-	<string name="bookmarks_group_name">โรงแรมที่จอง</string>
-	<string name="place_page_button_read_descriprion">อ่าน</string>
 	<!-- iOS dialog for the case when recent track recording is on and the app comes back from background -->
 	<string name="recent_track_background_dialog_title">ปิดการใช้งานการบันทึกเส้นทางที่คุณเดินทางเมื่อเร็ว ๆ นี้?</string>
 	<string name="off_recent_track_background_button">ปิดการใช้งาน</string>
 	<!-- For sharing via SMS and so on -->
 	<string name="sharing_call_action_look">ตรวจชม</string>
-	<string name="continue_recent_track_background_button">ดำเนินการต่อ</string>
 	<string name="recent_track_background_dialog_message">Organic Maps ใช้ตำแหน่งทางภูมิศาสตร์ของคุณในพื้นหลังเพื่อบันทึกเส้นทางที่คุณเดินทางเมื่อเร็ว ๆ นี้</string>
 	<!-- Rate on Google Play (Android only) -->
 	<string name="rate_gp">ให้คะแนนบน Google Play</string>
@@ -854,21 +538,11 @@
 	<string name="tell_friends_text">สวัสดี! ติดตั้ง Organic Maps กันเถอะ!</string>
 	<!-- About short text (below logo) -->
 	<string name="about_description">Organic Maps เป็นแอปพลิเคชั่นออฟไลน์ที่จำเป็นสำหรับการท่องเที่ยว Organic Maps นั้นใช้งานบนพื้นฐานของข้อมูล OpenStreetMap และใช้แก้ไขได้ด้วย</string>
-	<!-- Text in menu -->
-	<string name="blog">บล็อก</string>
 	<string name="general_settings">การตั้งค่าทั่วไป</string>
-	<string name="date">วันที่ %d</string>
-	<!-- "Report a bug" -> "Generaal Feedback" -> "Something is not working" -->
-	<string name="something_is_not_working">มีบางอย่างไม่ทำงาน</string>
 	<!-- For the first routing -->
 	<string name="accept">ยอมรับ</string>
 	<!-- For the first routing -->
 	<string name="decline">ปฏิเสธ</string>
-	<string name="install_app">ติดตั้ง</string>
-	<string name="search_no_results_title">ไม่พบผลลัพธ์</string>
-	<string name="search_no_results_message">ลองค้นหาด้วยคำทั่ว ๆ ไปดู ซูมออกหรือรีเซ็ตตัวกรอง</string>
-	<string name="search_no_results_expand_area_button">ซูมออก</string>
-	<string name="search_no_results_reset_button">รีเซ็ตตัวกรอง</string>
 	<!-- noun -->
 	<string name="search_in_table">รายการ</string>
 	<string name="mobile_data_dialog">ใช้อินเทอร์เน็ตมือถือแสดงข้อมูลโดยรายละเอียดหรือไม่?</string>
@@ -880,18 +554,13 @@
 	<string name="mobile_data_option_never">ไม่ใช้เลย</string>
 	<string name="mobile_data_option_ask">ถามก่อนเสมอ</string>
 	<string name="traffic_update_maps_text">ต้องอัปเดตแผนที่เพื่อแสดงข้อมูลการจราจร</string>
-	<string name="traffic_outdated">ข้อมูลการจราจรเก่าเกินไปแล้ว</string>
 	<string name="big_font">เพิ่มขนาดฟอนต์บนแผนที่</string>
 	<string name="traffic_update_app">กรุณาอัปเดต Organic Maps</string>
 	<!-- "traffic" as in road congestion -->
 	<string name="traffic_update_app_message">ในการแสดงข้อมูลการจราจร แอปพลิเคชั่นจะต้องอัปเดตก่อน</string>
 	<!-- "traffic" as in "road congestion" -->
 	<string name="traffic_data_unavailable">ไม่มีข้อมูลการจราจร</string>
-	<!-- Simplified colour scheme for traffic information, fewer colours are used to display traffic jams on the map. The string should be kept as short as possible -->
-	<string name="pref_traffic_simplified_colors_title">ไฟจราจรแบบง่าย</string>
 	<string name="enable_logging">เปิดใช้งานการเก็บล็อก</string>
-	<string name="offline_place_page_more_information">เชื่อมต่ออินเทอร์เน็ตเพื่อรับข้อมูลเพิ่มเติมเกี่ยวกับสถานที่</string>
-	<string name="failed_load_information">ไม่สามารถโหลดข้อมูลได้</string>
 	<!-- Settings: "Send general feedback" button -->
 	<string name="feedback_general">ข้อเสนอแนะทั่วไป</string>
 	<string name="on">เปิด</string>
@@ -905,57 +574,26 @@
 	<string name="routing_add_start_point">เพิ่มจุดเริ่มต้นเพื่อวางแผนเส้นทาง</string>
 	<string name="routing_add_finish_point">เพิ่มจุดสิ้นสุดเพื่อวางแผนเส้นทาง</string>
 	<string name="button_exit">ออก</string>
-	<string name="settings_device_memory">หน่วยความจำเครื่อง</string>
-	<string name="settings_card_memory">หน่วยความจำการ์ด</string>
-	<string name="settings_storage_available">เหลือให้ใช้ได้ %s</string>
-	<string name="toast_location_permission_denied">สิทธิ์ตำแหน่งที่ตั้งของแอปถูกปฏิเสธ</string>
-	<string name="button_use">ใช้</string>
 	<string name="planning_route_manage_route">จัดการเส้นทาง</string>
 	<string name="button_plan">วางแผน</string>
-	<string name="button_add">เพิ่ม</string>
 	<string name="placepage_remove_stop">เอาออก</string>
 	<string name="planning_route_remove_title">ลากมาที่นี่เพื่อเอาออก</string>
-	<string name="dialog_change_start_point_message">แทนที่จุดเริ่มต้นไปยังตำแหน่งปัจจุบันหรือไม่?</string>
-	<string name="button_replace">แทนที่</string>
 	<string name="placepage_add_stop">เพิ่มจุดแวะพัก</string>
-	<string name="add_my_position">เพิ่มตำแหน่งของฉัน</string>
-	<string name="choose_start_point">เลือกจุดเริ่มต้น</string>
-	<string name="choose_destination">เลือกปลายทาง</string>
 	<string name="preloader_viator_button">เรียนรู้เพิ่มเติม</string>
-	<string name="start_from_my_position">เริ่มจาก</string>
-	<string name="profile_authorization_title">ลงชื่อเข้าใช้ด้วย</string>
-	<string name="profile_authorization_message">ลงชื่อเข้าใช้อย่างง่ายโดยไม่ต้องใช้ชื่อเข้าสู่ระบบและรหัสผ่านเพียงไม่กี่วินาที</string>
 	<string name="profile_authorization_error">โอ๊ะ มีข้อผิดพลาดเกิดขึ้น ลองลงชื่อเข้าใช้อีกครั้ง</string>
-	<string name="service">บริการ</string>
-	<string name="atmosphere">บรรยากาศ</string>
-	<string name="value_for_money">คุ้มค่าเงิน</string>
-	<string name="experience">ประสบการณ์</string>
-	<string name="assortment">การแบ่งประเภท</string>
-	<string name="expertise">ความเชี่ยวชาญ</string>
-	<string name="equipment">อุปกรณ์</string>
-	<string name="quality">คุณภาพ</string>
 	<string name="dialog_error_storage_title">ปัญหาการเข้าถึงที่เก็บข้อมูล</string>
 	<string name="dialog_error_storage_message">ที่เก็บข้อมูลภายนอกไม่พร้อมใช้งาน อาจเป็นเพราะการ์ด SD ถูกถอดออกไป ได้รับความเสียหาย หรือระบบไฟล์ให้เขียนได้อย่างเดียว กรุณาตรวจสอบและติดต่อเราได้ที่ support\@organicmaps.app</string>
 	<string name="setting_emulate_bad_storage">จำลองแบบที่เก็บข้อมูลที่ไม่ดี</string>
-	<string name="directions_finish">จุดหมายปลายทาง</string>
-	<string name="directions_on_foot">เดินเท้า %s</string>
 	<string name="core_entrance">ทางเข้า</string>
-	<string name="coffee">กาแฟ</string>
-	<string name="cleanliness">ความสะอาด</string>
-	<string name="crowdedness">ความแออัด</string>
 	<string name="error_enter_correct_name">กรุณาใส่ชื่อที่ถูกต้อง</string>
 	<string name="bookmarks_groups">รายการ</string>
 	<string name="bookmarks_groups_hide_all">ซ่อนทั้งหมด</string>
 	<string name="bookmarks_groups_show_all">แสดงทั้งหมด</string>
-	<plurals name="bookmarks_places">
-	  <item quantity="other">%d บุ๊กมาร์ก</item>
-	</plurals>
 	<string name="bookmarks_create_new_group">สร้างรายการใหม่</string>
 	<string name="downloader_hide_screen">ซ่อนหน้าจอ</string>
 	<string name="downloader_percent">%1$s (%2$s จาก %3$s)</string>
-	<string name="downloader_process">กำลังดาวน์โหลด %s...</string>
-	<string name="downloader_applying">กำลังนำ %s ไปใช้งาน...</string>
-	<string name="dialog_message_transit_not_found_connection">วางแผนเส้นทางภายในเครือข่ายการเดินทางเดียว</string>
+	<string name="downloader_process">กำลังดาวน์โหลด %s…</string>
+	<string name="downloader_applying">กำลังนำ %s ไปใช้งาน…</string>
 	<string name="bookmarks_error_message_share_general">ไม่สามารถแชร์ได้เนื่องจากเกิดข้อผิดพลาดในแอปพลิเคชัน</string>
 	<string name="bookmarks_error_title_share_empty">ข้อผิดพลาดในการแชร์</string>
 	<string name="bookmarks_error_message_share_empty">ไม่สามารถแชร์รายการที่ว่างเปล่าได้</string>
@@ -964,12 +602,7 @@
 	<string name="bookmarks_new_list_hint">รายการใหม่</string>
 	<string name="bookmarks_error_title_list_name_already_taken">ชื่อนี้ถูกนำมาใช้แล้ว</string>
 	<string name="bookmarks_error_message_list_name_already_taken">โปรดเลือกชื่ออื่น</string>
-	<string name="bookmarks_error_title_list_name_too_long">ชื่อนี้ยาวเกินไป</string>
-	<string name="bookmarks_error_message_list_name_too_long">โปรดเลือกชื่ออื่น</string>
-	<string name="please_wait">โปรดรอสักครู่ ...</string>
-	<string name="phone_number">หมายเลขโทรศัพท์</string>
-	<string name="notification_unsent_reviews_title">คุณมีรีวิวที่ยังไม่ได้อ่านหลายฉบับ</string>
-	<string name="notification_unsent_reviews_message">โปรดลงชื่อเข้าใช้เพื่อแบ่งปันความเห็นกับผู้อื่น</string>
+	<string name="please_wait">โปรดรอสักครู่ …</string>
 	<string name="profile">โปรไฟล์ OpenStreetMap</string>
 	<string name="place_page_search_similar_hotel">ค้นหาโรงแรมที่คล้ายกัน</string>
 	<string name="bookmarks_detect_title">พบไฟล์ใหม่แล้ว</string>
@@ -979,31 +612,10 @@
 	<string name="button_convert">แปลง</string>
 	<string name="bookmarks_convert_error_title">ความผิดพลาด</string>
 	<string name="bookmarks_convert_error_message">ไฟล์บางไฟล์ไม่ได้รับการแปลง</string>
-	<string name="converting">กำลังแปลง...</string>
-	<string name="wn_reinvented_bookmarks_title">เราสร้างสรรค์บุ๊กมาร์กใหม่!</string>
-	<string name="wn_reinvented_bookmarks_message">คุณสามารถสำรองบุ๊คมาร์คสร้างรายการ... มันน่าทึ่ง...</string>
-	<string name="bookmarks_restore">เรียกคืนบุ๊กมาร์ก</string>
-	<string name="bookmarks_restore_process">กำลังกู้คืน...</string>
 	<string name="bookmarks_restore_title">เรียกคืนเวอร์ชันนี้หรือไม่?</string>
-	<string name="bookmarks_restore_message">บุ๊กมาร์กของคุณจะคืนค่าจาก %1$s (%2$s)</string>
-	<string name="bookmarks_restore_empty_title">คุณไม่มีข้อมูลสำรอง</string>
-	<string name="bookmarks_restore_empty_message">เซิร์ฟเวอร์ไม่พบการสำรองข้อมูลก่อนหน้านี้</string>
 	<string name="common_check_internet_connection_dialog_title">ไม่มีการเชื่อมต่ออินเทอร์เน็ต</string>
-	<string name="error_server_title">ข้อผิดพลาดของเซิร์ฟเวอร์</string>
-	<string name="error_server_message">เกิดข้อผิดพลาดบนเซิร์ฟเวอร์โปรดลองอีกครั้งในภายหลัง</string>
 	<string name="error_system_message">เกิดข้อผิดพลาดที่ไม่ทราบสาเหตุ</string>
 	<string name="restore">ฟื้นฟู</string>
-	<string name="bookmarks_page_downloaded">ดาวน์โหลด</string>
-	<string name="bookmarks_page_my">ของฉัน</string>
-	<string name="routes_and_bookmarks">เส้นทาง และบุ๊กมาร์ก</string>
-	<string name="bookmarks_webview_success_toast">ดาวน์โหลดบุ๊กมาร์กสำเร็จแล้ว</string>
-	<string name="cached_bookmarks_placeholder_title">ดาวน์โหลดสถานที่ใหม่</string>
-	<string name="cached_bookmarks_placeholder_subtitle">กดปุ่มเพื่อดาวน์โหลดหลายพันสถานที่ และเส้นทางที่น่าสนใจต่าง ๆ ซึ่งสร้างขึ้นโดยผู้ใช้งานของ Organic Maps คุณจำเป็นต้องเชื่อมต่อกับอินเตอร์เน็ต</string>
-	<string name="downloader_download_routers">ดาวน์โหลดบุ๊กมาร์ก</string>
-	<string name="bookmarks_groups_cached">ดาวน์โหลดรายการต่าง ๆ แล้ว</string>
-	<plurals name="bookmarks_objects">
-	  <item quantity="other">%s วัตถุประสงค์</item>
-	</plurals>
 	<plurals name="objects">
 	  <item quantity="other">%d สถานที่</item>
 	</plurals>
@@ -1016,62 +628,32 @@
 	<string name="subtittle_opt_out">การตั้งค่าการติดตาม</string>
 	<string name="crash_reports">รายงานข้อขัดข้อง</string>
 	<string name="crash_reports_description">เราอาจใช้ข้อมูลของคุณเพื่อพัฒนาประสบการณ์ของ Organic Maps การเปลี่ยนแปลงจะมีผลหลังจากที่คุณเปิดแอพฯ ขึ้นใหม่</string>
-	<string name="opt_out_help_ios_1">อุปกรณ์มือถือของคุณอาจมีการตั้งค่า \"\"จำกัดการติดตามโฆษณา\"\" หรือ \"\"เลือกไม่ใช้การโฆษณาตามความสนใจ\"\"</string>
-	<string name="opt_out_help_ios_2">iOS 9 หรือสูงกว่า</string>
-	<string name="opt_out_help_ios_3">ไปที่การตั้งค่าของคุณ → ความเป็นส่วนตัว → การโฆษณา → เปิดใช้งานการตั้งค่า “จำกัดการติดตามโฆษณา”</string>
-	<string name="opt_out_help_android">อุปกรณ์มือถือของคุณอาจมีการตั้งค่า \"\"จำกัดการติดตามโฆษณา\"\" หรือ \"\"เลือกไม่ใช้การโฆษณาตามความสนใจ\"\"\n\nสำหรับ Android และบริการ Google Play เวอร์ชั่น 4.0 และสูงกว่า:\nการตั้งค่า → Google → โฆษณา → เลือกไม่ใช้การโฆษณา ในแบบของคุณ\หรือ\nการตั้งค่า → Google → Google Account → ข้อมูลส่วนตัว และส่วนบุคคล → การตั้งค่าโฆษณา → โฆษณาในแบบของคุณ</string>
 	<string name="privacy_policy">นโยบายความเป็นส่วนตัว</string>
 	<string name="terms_of_use">ข้อกำหนดในการใช้งาน</string>
-	<string name="backup_notification_failed">การเก็บสำรองบุ๊กมาร์กของคุณได้ถูกระงับ เข้าสู่ระบบเพื่อเปิดใช้งานอีกครั้ง</string>
 	<string name="button_layer_traffic">การจราจร</string>
 	<string name="button_layer_subway">รถไฟใต้ดิน</string>
 	<string name="layers_title">ชั้นแผนที่</string>
-	<string name="layers_message">ใช้ชั้นแผนที่เพื่อแสดงแผนที่ข้อมูลด้านการจราจร รถไฟใต้ดิน และข้อมูลอื่น ๆ ที่เป็นประโยชน์</string>
-	<string name="button_layer_got_it">เข้าใจแล้ว</string>
 	<string name="subway_data_unavailable">แผนที่รถไฟใต้ดินไม่พร้อมใช้งาน</string>
 	<string name="bookmarks_empty_list_title">รายการนี้ว่างเปล่า</string>
 	<string name="bookmarks_empty_list_message">เพื่อเพิ่มบุ๊กมาร์ก โปรดแตะที่สถานที่บนแผนที่ แล้วจากนั้นแตะที่ไอคอนรูปดาว</string>
 	<string name="category_desc_more">…เพิ่มเติม</string>
 	<string name="title_error_downloading_bookmarks">มีข้อผิดพลาดเกิดขึ้น</string>
-	<string name="subtitle_error_downloading_bookmarks">ไม่ได้ดาวน์โหลดบุ๊กมาร์ก</string>
-	<string name="error_already_downloaded">มีการดาวน์โหลดรายการนี้แล้ว</string>
-	<string name="why_support">ทำไมถึงควรใช้บริการ Organic Maps?</string>
-	<string name="why_support_item2">คุณช่วยเราพัฒนา Organic Maps</string>
-	<string name="why_support_item3">คุณช่วยเราพัฒนาแผนที่ที่เปิดให้คนทั่วไปเข้าใช้งานของ OpenStreetMap.org</string>
-	<string name="channels_map_update">อัพเดตโรงแรม</string>
-	<string name="server_unavailable_title">ไม่สามารถเข้าถึงเซิร์ฟเวอร์</string>
-	<string name="sharing_options">ตัวเลือกการแชร์</string>
 	<string name="export_file">ส่งออกไฟล์</string>
 	<string name="list_settings">การตั้งค่ารายการ</string>
 	<string name="delete_list">ลบรายการ</string>
-	<string name="hide_from_map">ซ่อนจากแผนที่</string>
 	<string name="public_access">เข้าถึงได้โดยสาธารณะ</string>
 	<string name="limited_access">จำกัดการเข้าถึง</string>
 	<string name="bookmark_category_name">หมวดหมู่</string>
 	<string name="bookmark_category_description_hint">พิมพ์รายละเอียด (ข้อความหรือ html)</string>
 	<string name="not_shared">ส่วนตัว</string>
-	<string name="direct_link_progress_text">กำลังอัพโหลดไฟล์ของคุณ…</string>
-	<string name="direct_link_success">ลิงค์ถูกสร้างแล้ว</string>
-	<string name="send_a_link_btn">ส่งลิงค์ให้ฉัน</string>
-	<string name="upload_error_toast">เกิดข้อผิดพลาดขณะอัพโหลดไฟล์ของคุณ</string>
 	<string name="tags_loading_error_subtitle">เกิดข้อผิดพลาดขณะโหลดแท็ก โปรดลองใหม่อีกครั้ง</string>
-	<string name="unable_upload_errorr_title">การอัพโหลดไฟล์ล้มเหลว</string>
-	<string name="unable_upload_error_subtitle_edited">ไฟล์นั้นถูกแก้ไขผ่านทางเว็บแอพ</string>
-	<string name="unable_upload_error_subtitle_broken">ไฟล์นั้นเสียหายและไม่สามารถอัพโหลดได้ โปรอัพโหลดไฟล์อื่นแทน</string>
-	<string name="contact">ติดต่อ</string>
-	<string name="download_button">ดาวน์โหลด</string>
 	<string name="speedcams_alert_title">กล้องตรวจจับความเร็ว</string>
-	<string name="speedcams_alert_subtitle">เตือนเรื่องการจำกัดความเร็ว</string>
 	<string name="speedcam_option_auto">อัตโนมัติ</string>
 	<string name="speedcam_option_always">ทุกครั้ง</string>
 	<string name="speedcam_option_never">ไม่ต้องเตือน</string>
-	<string name="bookmark_description_title">รายละเอียดของบุ๊คมาร์ค</string>
 	<string name="place_description_title">รายละเอียดของสถานที่</string>
 	<!-- this text will be shown in application notification preferences opposite checkbox which enable/disable downloader notifications. Devices on Android 8+ are affected. -->
 	<string name="notification_channel_downloader">ตัวดาวน์โหลดแผนที่</string>
-	<string name="share_bookmarks_email_body_link">สวัสดี!\n\nนี่คือลิงค์ที่คุณสามารถดาวน์โหลดบุ๊คมาร์คของคุณ: %s เปิดรายการผ่าน Organic Maps และเพลิดเพลินไปกับการเดินทางของคุณ!\n\nรับแอพพลิเคชัน: https://omaps.app/get?kmz</string>
-	<string name="warning_speedcams_title">เนวิเกเตอร์จะเตือนคุณเกี่ยวกับกล้องถ่ายรูปเมื่อคุณขับเร็วเกินกำหนดโดยอยู่ที่ %d กม./ชม</string>
-	<string name="warning_speedcams_subtitle">โปรดปฏิบัติตามกฎหมายการขับขี่รถยนต์ของประเทศที่คุณกำลังเดินทางไป</string>
 	<string name="speedcams_notice_message">อัตโนมัติ - เตือนเกี่ยวกับกล้องตรวจจับความเร็วหากมีความเป็นได้ว่าจะขับเร็วเกิดกำหนด\nทุกครั้ง - เตือนเกี่ยวกับกล้องตรวจจับความเร็วเสมอ\nไม่ต้องเตือน - ไม่เคยเตือนเกี่ยวกับกล้องตรวจจับความเร็ว</string>
 	<string name="power_managment_title">โหมดประหยัดพลังงาน</string>
 	<string name="power_managment_description">เมื่อโหมดอัตโนมัตินั้นถูกเลือก แอปพลิเคชันจะเริ่มหยุดการใช้พลังงานจากแบตเตอรีขึ้นอยู่กับจำนวนไฟในแบตเตอรีว่าเหลือเท่าไร</string>
@@ -1079,14 +661,7 @@
 	<string name="power_managment_setting_auto">อัตโนมัติ</string>
 	<string name="power_managment_setting_manual_max">ประหยัดพลังงานสูงสุด</string>
 	<string name="enable_logging_warning_message">ออปชันเพื่อเปิดการบันทึกประวัติการทำงานเพื่อการวินิจฉัย ประวัติดังกล่าวอาจเป็นประโยชน์กับทีมงานช่วยเหลือของเราที่คอยจัดการกับปัญหาที่เจอระหว่างแอปทำงาน โปรดเปิดออปชันดังกล่าวจากการร้องข้อการสนับสนุนจาก Organic Maps เท่านั้น</string>
-	<string name="html_error_upload_message_try_again">โปรดเช็คการตั้งค่าเครือข่ายและลองใหม่อีกครั้ง</string>
-	<string name="html_error_upload_title_try_again">ไม่มีการเชื่อมต่ออินเทอร์เน็ต</string>
-	<string name="notification_leave_review_v2_android_short_title">รีวิวและช่วยนักท่องเที่ยวคนอื่น!</string>
-	<string name="notifications_illegal_alert_disable_button">ปิดการแจ้งเตือน</string>
 	<string name="access_rules_author_only">การแก้ไขทางออนไลน์</string>
-	<string name="privacy_settings_menu">การตั้งค่าความเป็นส่วนตัว</string>
-	<string name="unable_upadate_error_title">อัพเดตไฟล์ล้มเหลว</string>
-	<string name="unable_upadate_error_message">มีข้อผิดพลาดบางอย่างเกิดขึ้นขณะอัพเดต โปรดตรวจทานการแก้ไขและลองใหม่อีกครั้ง</string>
 	<string name="driving_options_title">ทางเลือกเส้นทางขับขี่</string>
 	<string name="driving_options_subheader">หลีกเลี่ยงในทุกเส้นทาง</string>
 	<string name="avoid_tolls">ถนนแบบเสียค่าผ่านทาง</string>
@@ -1097,52 +672,14 @@
 	<string name="unable_to_calc_alert_subtitle">ขออภัย เราไม่สามารถค้นหาเส้นทาง โดยสาเหตุอาจมาจากทางเลือกที่คุณกำหนดไว้ โปรดเปลี่ยนการตั้งค่าทางเลือกและลองใหม่อีกครั้ง</string>
 	<string name="define_to_avoid_btn">กำหนดถนนที่ต้องการเลี่ยง</string>
 	<string name="change_driving_options_btn">เปิดใช้การค้นหาเส้นทางขับขี่แล้ว</string>
-	<string name="toll_road">ถนนแบบเสียค่าผ่านทาง</string>
-	<string name="unpaved_road">ถนนดิน</string>
-	<string name="ferry_crossing">เรือข้ามฟาก</string>
-	<string name="operated_by">กำลังทำงานอยู่ที่ \"%s\"</string>
 	<string name="avoid_toll_roads_placepage">เลี่ยงทางที่ต้องเสียเงินทั้งหมด</string>
 	<string name="avoid_unpaved_roads_placepage">เลี่ยงถนนดินทั้งหมด</string>
 	<string name="avoid_ferry_crossing_placepage">เลี่ยงการข้ามฟากด้วยเรือ</string>
-	<string name="type.cuisine.uzbek">อาหารแนวอุซเบค</string>
-	<string name="trip_start">ไปกันเลย</string>
-	<string name="pick_destination">จุดหมาย</string>
-	<string name="follow_my_position">รีเซ็นเตอร์</string>
-	<string name="search_results">ผลการค้นหา</string>
-	<string name="then_turn">จากนั้น</string>
-	<string name="redirect_route_alert">ต้องการสร้างเส้นทางใหม่หรือไม่</string>
-	<string name="redirect_route_yes">ใช่</string>
-	<string name="redirect_route_no">ไม่ใช่</string>
-	<string name="trip_finished">คุณมาถึงแล้ว!</string>
-	<string name="keyboard_availability_alert">คีย์บอร์ดไม่สามารถใช้งานได้ขณะขับขี่</string>
-	<string name="dialog_routing_change_start_carplay">ไม่สามารถสร้างเส้นทางจากตำแหน่งปัจจุบันของคุณ</string>
-	<string name="dialog_routing_change_end_carplay">ไม่สามารถสร้างเส้นทางไปยังจุดหมายของคุณ โปรดเลือกจุดหมายใหม่</string>
-	<string name="dialog_routing_check_gps_carplay">ไม่มีสัญญาณจีพีเอส โปรดไปในที่โล่งเพื่อหาสัญญาณ</string>
-	<string name="dialog_routing_unable_locate_route_carplay">ไม่สามารถคำนวณเส้นทาง โปรดระบุตำแหน่งของเส้นทางอื่น</string>
-	<string name="dialog_routing_download_files_carplay">เพื่อสร้างเส้นทาง โปรดดาวน์โหลดแผนที่บนอุปกรณ์ของคุณ</string>
-	<string name="dialog_routing_system_error_carplay">พบข้อผิดพลาด โปรดปิดและเปิดแอปพลิเคชันใหม่อีกครั้ง</string>
-	<string name="dialog_routing_rebuild_from_current_location_carplay">เส้นทางจะถูกสร้างอีกครั้งจากตำแหน่งปัจจุบันของคุณ</string>
-	<string name="dialog_routing_rebuild_for_vehicle_carplay">เส้นทางของรถยนต์อาจถูกปรับเปลี่ยน</string>
 	<string name="ok">โอเค</string>
-	<string name="avoid_unpaved_carplay_1">ไม่มีลูกรัง</string>
-	<string name="avoid_unpaved_carplay_2">หลีกเลี่ยงทาง</string>
-	<string name="avoid_ferry_carplay_1">ไม่มีเรือ</string>
-	<string name="avoid_ferry_carplay_2">หลีกเลี่ยงเรือ</string>
-	<string name="avoid_tolls_carplay_1">ไม่มีค่าผ่าน</string>
-	<string name="avoid_tolls_carplay_2">เลี่ยงทางด่วน</string>
-	<string name="speedcams_alert_title_carplay_1">จับความเร็ว</string>
-	<string name="speedcams_alert_title_carplay_2">เตือนความเร็ว</string>
-	<string name="download_map_carplay">โปรดดาวน์โหลดแผนที่ในแอพฯ Organic Maps บนอุปกรณ์ของคุณ</string>
-	<string name="carplay_roundabout_exit">ทางออกที่ %s</string>
 	<!-- max. 10 symbols, both iOS and Android -->
 	<string name="sort">เรียง…</string>
 	<!-- Android, title, max 20-22 symbols -->
 	<string name="sort_bookmarks">เรียงบุ๊กมาร์ก</string>
-	<!-- iOS -->
-	<string name="sort_default">เรียงตามค่าเริ่มต้น</string>
-	<string name="sort_type">เรียงตามประเภท</string>
-	<string name="sort_distance">เรียงตามระยะทาง</string>
-	<string name="sort_date">เรียงตามวันที่</string>
 	<!-- Android -->
 	<string name="by_default">ตามค่าเริ่มต้น</string>
 	<!-- Android -->
@@ -1151,65 +688,23 @@
 	<string name="by_distance">ตามระยะทาง</string>
 	<!-- Android -->
 	<string name="by_date">ตามวันที่</string>
-	<string name="week_ago_sorttype">สัปดาห์ที่ผ่านมา</string>
-	<string name="month_ago_sorttype">เดือนที่ผ่านมา</string>
-	<string name="moremonth_ago_sorttype">มากกว่าหนึ่งเดือนที่ผ่านมา</string>
-	<string name="moreyear_ago_sorttype">มากกว่าหนึ่งปีที่ผ่านมา</string>
-	<string name="near_me_sorttype">ใกล้ฉัน</string>
-	<string name="others_sorttype">อื่นๆ</string>
-	<string name="food_places">อาหาร</string>
-	<string name="tourist_places">ที่ท่องเที่ยว</string>
-	<string name="museums">พิพิธภัณฑ์</string>
-	<string name="parks">ที่จอดรถ</string>
-	<string name="swim_places">ว่ายน้ำ</string>
-	<string name="mountains">ภูเขา</string>
-	<string name="animals">สวนสัตว์</string>
-	<string name="hotels">โรงแรม</string>
-	<string name="buildings">สิ่งปลูกสร้าง</string>
-	<string name="money">เงิน</string>
-	<string name="shops">ร้านค้า</string>
-	<string name="parkings">ที่จอดรถ</string>
-	<string name="fuel_places">ปั๊มน้ำมัน/แก๊ส</string>
-	<string name="water">น้ำ</string>
-	<string name="medicine">ยา</string>
 	<string name="search_in_the_list">ค้นหาในรายการ</string>
-	<string name="view_on_map_bookmarks">บนแผนที่</string>
-	<string name="more_bookmarks">เพิ่มเติม…</string>
-	<string name="no_items_found">ไม่พบรายการ</string>
-	<!-- Android, max 18 symbols -->
-	<string name="bookmarks_edit_list">แก้ไขรายการ</string>
-	<!-- Android, max 18 symbols -->
-	<string name="bookmarks_delete_list">ลบรายการ</string>
-	<string name="religious_places">สถานที่ทางศาสนา</string>
 	<string name="select_list">เลือกรายการ</string>
 	<string name="transit_not_found">ยังไม่สามารถใช้การนำทางรถไฟใต้ดินในภูมิภาคนี้ได้</string>
 	<string name="dialog_pedestrian_route_is_long_header">ไม่พบเส้นทางของทางรถไฟใต้ดิน</string>
 	<string name="dialog_pedestrian_route_is_long_message">โปรดเลือกจุดเริ่มต้นและสิ้นสุดที่อยู่ใกล้สถานีรถไฟใต้ดิน</string>
-	<!-- Failed planning SUBWAY route message in navigation view -->
-	<string name="routing_planning_error_subway_special">การวางแผนเส้นทางของทางรถไฟใต้ดินล้มเหลว</string>
 	<string name="button_layer_isolines">ความสูง</string>
-	<string name="tips_map_layers_title_countour">เลเยอร์แผนที่ภูมิประเทศแบบออฟไลน์ ใหม่ในแอป Organic Maps!</string>
-	<string name="tips_map_layers_message_countour">วางแผนและสนุกไปกับทริปท่องธรรมชาติโดยมั่นใจว่าคุณรู้ทุกอย่างเกี่ยวกับพื้นที่นั้น</string>
 	<string name="isolines_activation_error_dialog">ในการเปิดใช้งานเลเยอร์แผนที่ภูมิประเทศโปรดอัปเดตหรือดาวน์โหลดแผนที่ของบริเวณนั้น</string>
 	<string name="isolines_location_error_dialog">เลเยอร์แผนที่ภูมิประเทศยังใช้งานไม่ได้ในพื้นที่นี้</string>
 	<string name="elevation_profile_diff_level">ระดับความยาก</string>
-	<string name="elevation_profile_diff_level_easy">ง่าย</string>
-	<string name="elevation_profile_diff_level_moderate">ปานกลาง</string>
-	<string name="elevation_profile_diff_level_hard">ยาก</string>
 	<string name="elevation_profile_ascent">การขึ้น</string>
 	<string name="elevation_profile_descent">การลง</string>
 	<string name="elevation_profile_minaltitude">ระดับความสูงต่ำสุด</string>
 	<string name="elevation_profile_maxaltitude">ระดับความสูงสูงสุด</string>
-	<string name="elevation_profile_m">ม</string>
 	<string name="elevation_profile_difficulty">ลำบาก</string>
 	<string name="elevation_profile_distance">ระยะทาง</string>
-	<string name="elevation_profile_km">กม</string>
 	<string name="elevation_profile_time">เวลา:</string>
-	<string name="elevation_profile_hours">ชม</string>
-	<string name="elevation_profile_minutes">นาที</string>
 	<string name="isolines_toast_zooms_1_10">ขยายเข้าเพื่อสำรวจเส้นชั้นความสูง</string>
-	<string name="downloader_updating_ios">การอัปเดต</string>
-	<string name="downloader_loading_ios">การดาวน์โหลด</string>
 	<string name="key_information_title">ข้อมูลหลัก</string>
 	<string name="enable_screen_sleep">อนุญาตให้หน้าจอเข้าสู่โหมดสลีป</string>
 	<!-- Description in preferences -->

--- a/android/res/values-tr/strings.xml
+++ b/android/res/values-tr/strings.xml
@@ -12,15 +12,11 @@
 	<string name="cancel_download">İndirme İşlemini İptal Et</string>
 	<!-- Button which deletes downloaded country -->
 	<string name="delete">Sil</string>
-	<!-- Button "do not interrupt download" if user touched actively downloading country -->
-	<string name="do_nothing">Devam</string>
 	<string name="download_maps">Haritaları İndir</string>
 	<!-- Settings/Downloader - info for country when download fails -->
 	<string name="download_has_failed">İndirme işlemi başarısız oldu, bir kez daha denemek için tekrar dokunun</string>
 	<!-- Settings/Downloader - info for country which started downloading -->
 	<string name="downloading">İndiriliyor…</string>
-	<!-- Settings/Downloader - size string, only strings different from English should be translated -->
-	<string name="kb">kB</string>
 	<!-- Choose measurement on first launch alert - choose metric system button -->
 	<string name="kilometres">Kilometre</string>
 	<!-- Leave Review dialog - Review button -->
@@ -35,45 +31,31 @@
 	<string name="core_my_position">Konumum</string>
 	<!-- Update maps later/Buy pro version later button text -->
 	<string name="later">Daha sonra</string>
-	<!-- Don't show some dialog any more -->
-	<string name="never">Asla</string>
 	<!-- View and button titles for accessibility -->
 	<string name="search">Ara</string>
 	<!-- Search box placeholder text -->
 	<string name="search_map">Haritada Ara</string>
-	<!-- Settings/Downloader - info for not downloaded country -->
-	<string name="touch_to_download">İndirmek için dokunun</string>
 	<!-- Settings/Downloader - 3G download warning dialog confirm button -->
 	<string name="use_cellular_data">Evet</string>
 	<!-- Location services are disabled by user alert - message -->
 	<string name="location_is_disabled_long_text">Şu anda bu cihaz için tüm Yer Hizmetleri veya uygulama devre dışı bırakılmış. Lütfen Ayarlar bölümünden etkinleştirin.</string>
-	<!-- Location Services are not available on the device alert - message -->
-	<string name="device_doesnot_support_location_services">Cihazınız Yer Hizmetlerini desteklemiyor</string>
 	<!-- View and button titles for accessibility -->
 	<string name="zoom_to_country">Haritada göster</string>
-	<!-- Button text for the button at the center of the screen when the country is not downloaded -->
-	<string name="country_status_download">Haritayı İndir\n(^ ^)</string>
 	<!-- Button text for the button at the center of the screen when the country is not downloaded and the size should not be shown -->
 	<string name="country_status_download_without_size">Haritayı İndir</string>
-	<!-- Button text for the button at the center of the screen when the country is not downloaded -->
-	<string name="country_status_download_without_routing">Haritayı rota\nolmadan indirin (^ ^)</string>
 	<!-- Message to display at the center of the screen when the country download has failed -->
 	<string name="country_status_download_failed">Indirme işlemi başarısız oldu</string>
 	<!-- Button text for the button under the country_status_download_failed message -->
 	<string name="try_again">Tekrar Deneyin</string>
 	<string name="about_menu_title">Organic Maps Hakkında</string>
-	<string name="downloaded_touch_to_delete">(%s) indirildi, silmek için dokunun</string>
 	<string name="connection_settings">Bağlantı Ayarları</string>
-	<string name="download_mb_or_kb">%s indir</string>
 	<string name="close">Kapat</string>
 	<string name="unsupported_phone">Hızlı donanıma sahip bir OpenGL gerekli. Ne yazık ki cihazınız desteklenmiyor.</string>
 	<string name="download">İndir</string>
-	<string name="external_storage_is_not_available">İndirilen haritalarla SD kart/USB depolama aygıtı kullanılamıyor</string>
 	<string name="disconnect_usb_cable">Organic Maps’yi kullanabilmeniz için lütfen USB kablosunun bağlantısını kesin veya hafıza kartı takın</string>
 	<string name="not_enough_free_space_on_sdcard">Uygulamayı kullanabilmeniz için lütfen SD kart/USB depolama aygıtında biraz alan boşaltın</string>
 	<string name="not_enough_memory">Uygulamayı başlatmak için yeterli hafıza yok</string>
 	<string name="download_resources">Başlamadan önce cihazınıza genel dünya haritasını indirelim.\nVerilerin %s’si gerekli.</string>
-	<string name="getting_position">Geçerli konum alınıyor</string>
 	<string name="download_resources_continue">Haritaya Git</string>
 	<string name="downloading_country_can_proceed">%s indiriliyor. Şimdi haritaya\ngidebilirsiniz.</string>
 	<string name="download_country_ask">%s indir?</string>
@@ -86,30 +68,20 @@
 	<string name="download_country_failed">%s indirme işlemi başarısız oldu</string>
 	<!-- Add New Bookmark Set dialog title -->
 	<string name="add_new_set">Yeni Ayar ekle</string>
-	<!-- Place Page - Add To Bookmarks button -->
-	<string name="add_to_bookmarks">Yer İmlerine Ekle</string>
 	<!-- Bookmark Color dialog title -->
 	<string name="bookmark_color">Yer İmi Rengi</string>
 	<!-- Add Bookmark Set dialog - hint when set name is empty -->
 	<string name="bookmark_set_name">Yer İmi Adını Ayarla</string>
-	<!-- Bookmark Sets dialog title -->
-	<string name="bookmark_sets">Yer İmi Ayarları</string>
 	<!-- Bookmarks - dialog title -->
 	<string name="bookmarks">Yer İmleri</string>
-	<!-- Add bookmark dialog - bookmark color -->
-	<string name="color">Renk</string>
 	<!-- Default bookmarks set name -->
 	<string name="core_my_places">Yerlerim</string>
 	<!-- Add bookmark dialog - bookmark name -->
 	<string name="name">Adı</string>
 	<!-- Editor title above street and house number -->
 	<string name="address">Adres</string>
-	<!-- Place Page - Remove Pin button -->
-	<string name="remove_pin">Pini Kaldır</string>
 	<!-- Add bookmark dialog - bookmark set, Bookmarks dialog - Bookmark set cell -->
 	<string name="set">Ayarla</string>
-	<!-- Text hint in Bookmarks dialog when no any bookmarks are added -->
-	<string name="bookmarks_usage_hint">Henüz hiç yer iminiz yok.\nYer imi eklemek için haritada bir yere dokunun.\nBaşka kaynaklardan da yer imleri alınıp Organic Maps’de gösterilebilir KML/KMZ dosyasını posta, Dropbox veya web bağlantısından kaydedilen pinlerle aç.</string>
 	<!-- Settings button in system menu -->
 	<string name="settings">Ayarlar</string>
 	<!-- Header of settings activity where user defines storage path -->
@@ -120,20 +92,10 @@
 	<string name="move_maps">Haritaları taşı?</string>
 	<!-- Ask to wait user several minutes (some long process in modal dialog). -->
 	<string name="wait_several_minutes">Bu işlem birkaç dakika sürebilir.\nLütfen bekleyin…</string>
-	<!-- Show bookmarks from this category on a map or not -->
-	<string name="visible">Görünür</string>
-	<!-- Toast which is displayed when GPS has been deactivated -->
-	<string name="gps_is_disabled_long_text">GPS devre dışı bırakıldı. Lütfen Ayarlar bölümünden etkinleştirin.</string>
 	<!-- Measurement units title in settings activity -->
 	<string name="measurement_units">Ölçü Birimleri</string>
 	<!-- Detailed description of Measurement Units settings button -->
 	<string name="measurement_units_summary">Mil veya kilometre seçimini yap</string>
-	<!-- Do search in all sources -->
-	<string name="search_mode_all">Her Yerde</string>
-	<!-- Do search near my position only -->
-	<string name="search_mode_nearme">Yakınlarımda</string>
-	<!-- Do search in current viewport only -->
-	<string name="search_mode_viewport">Ekranda</string>
 	<!-- Search category for cafes, bars, restaurants -->
 	<string name="eat">Nerede yenir</string>
 	<!-- Search category for grocery stores -->
@@ -170,12 +132,8 @@
 	<string name="post">Posta</string>
 	<!-- Search category -->
 	<string name="police">Polis</string>
-	<!-- String in search result list, when nothing found -->
-	<string name="no_search_results_found">Sonuç bulunamadı</string>
 	<!-- Notes field in Bookmarks view -->
 	<string name="description">Notlar</string>
-	<!-- Button text -->
-	<string name="share_by_email">E-postayla paylaş</string>
 	<!-- Email Subject when sharing bookmarks category -->
 	<string name="share_bookmarks_email_subject">Paylaşılan Organic Maps yer imleri</string>
 	<!-- message title of loading file -->
@@ -188,20 +146,10 @@
 	<string name="edit">Düzenle</string>
 	<!-- Warning message when doing search around current position -->
 	<string name="unknown_current_position">Yeriniz henüz belirlenmedi</string>
-	<!-- Warning message when location country isn't downloaded during search (see also download_location_map_proposal). -->
-	<string name="download_location_country">Geçerli konumuzun (%s) ülkesini indirin</string>
-	<!-- Warning message when viewport country isn't downloaded during search -->
-	<string name="download_viewport_country_to_search">Aradığınız (%s) ülkesini indirin</string>
 	<!-- Alert message that we can't run Map Storage settings due to some reasons. -->
 	<string name="cant_change_this_setting">Üzgünüz, Harita Depolama ayarları şu anda devre dışı.</string>
 	<!-- Alert message that downloading is in progress. -->
 	<string name="downloading_is_active">Ülke indirme işlemi şu anda sürüyor.</string>
-	<!-- Message that will be shown in alert view, when we ask user to leave review on App Store -->
-	<string name="appStore_message">Organic Maps kullanmaktan keyif aldığınızı umuyoruz! Öyleyse, lütfen App Store’da uygulamaya puan verin veya uygulama hakkında yorum yapın. Bir dakikadan daha kısa sürer ama bize gerçekten yardımcı olabilir. Desteğiniz için teşekkürler!</string>
-	<!-- No, thanks -->
-	<string name="no_thanks">Hayır, teşekkürler</string>
-	<!-- Share one specific bookmark using SMS, %1$@ contains om:// and %2$@ https://omaps.app link. @NOTE non-ascii symbols in the link will result in max 70 characters SMS instead of 140. -->
-	<string name="bookmark_share_sms">Hey, Organic Maps’de pinimi incele! %1$s veya %2$s Çevrimiçi haritalar sende yüklü değil mi? Buradan indir: https://omaps.app/get</string>
 	<!-- Share my position using SMS, %1$@ contains om:// and %2$@ https://omaps.app link WITHOUT NAME. @NOTE non-ascii symbols in the link will result in max 70 characters SMS instead of 140. -->
 	<string name="my_position_share_sms">Hey, Organic Maps’de geçerli konumumu incele! %1$s veya %2$s Çevrimiçi haritalar sende yok mu? Buradan indir: https://omaps.app/get</string>
 	<!-- Subject for emailed bookmark -->
@@ -210,30 +158,16 @@
 	<string name="my_position_share_email_subject">Hey, Organic Maps’de geçerli konumumu incele!</string>
 	<!-- Share my position using EMail, %1$@ is om:// and %2$@ is https://omaps.app link WITHOUT NAME -->
 	<string name="my_position_share_email">Merhaba,\n\nŞu anda bulunduğum yer: %1$s. Yeri haritada görmek için bu bağlantıya %2$s veya şuna %3$s tıkla.\n\nTeşekkürler.</string>
-	<!-- Android share by Message/SMS button text (including SMS) -->
-	<string name="share_by_message">Mesajla paylaş</string>
 	<!-- Share button text which opens menu with more buttons, like Message, EMail, Facebook etc. -->
 	<string name="share">Paylaş</string>
-	<!-- iOS share by Message button text (including SMS) -->
-	<string name="message">Mesaj</string>
 	<!-- Share by email button text, also used in editor. -->
 	<string name="email">E-posta</string>
-	<!-- Copy Link -->
-	<string name="copy_link">Bağlantıyı Kopyala</string>
-	<!-- Text for the button that returns to caller application -->
-	<string name="more_info">Daha Fazla Bilgi Göster</string>
 	<!-- Text for message when used successfully copied something -->
 	<string name="copied_to_clipboard">Panoya Kopyalandı: %1$s</string>
 	<!-- place preview title -->
 	<string name="info">Bilgi</string>
 	<!-- Used for bookmark editing -->
 	<string name="done">Bitti</string>
-	<!-- Summary for preferences in MWM -->
-	<string name="yopme_pref_summary">Arka Ekran ayarlarını seç</string>
-	<!-- Title for yopme preferences in MWM -->
-	<string name="yopme_pref_title">Arka Ekran Ayarları</string>
-	<!-- Hint for upper-right icon p2b -->
-	<string name="show_on_backscreen">Arka ekranda göster</string>
 	<!-- Prints version number in About dialog -->
 	<string name="version">Sürüm: %s</string>
 	<!-- Confirmation in downloading countries dialog -->
@@ -243,11 +177,6 @@
 	<!-- Length of track in cell that describes route -->
 	<string name="length">Uzunluk</string>
 	<string name="share_my_location">Yerimi paylaş</string>
-	<string name="menu_search">Ara</string>
-	<!-- Settings screen: "Map" category title -->
-	<string name="prefs_group_map">Harita</string>
-	<!-- Settings screen: "Miscellaneous" category title -->
-	<string name="prefs_group_misc">Çeşitli</string>
 	<string name="prefs_group_route">Navigasyon</string>
 	<string name="pref_zoom_title">Yakınlaştırma butonları</string>
 	<string name="pref_zoom_summary">Ekranda göster</string>
@@ -263,8 +192,6 @@
 	<string name="pref_map_3d_title">Perspektif görünüm</string>
 	<!-- Settings «Map» category: «3D buildings» title -->
 	<string name="pref_map_3d_buildings_title">3 Boyutlu Binalar</string>
-	<!-- Settings «Map» category: «3D buildings» summary -->
-	<string name="pref_map_3d_buildings_subtitle">Pil ömrünü etkiler</string>
 	<!-- Settings «Route» category: «Tts enabled» title -->
 	<string name="pref_tts_enable_title">Sesli Talimatlar</string>
 	<!-- Settings «Route» category: «Tts language» title -->
@@ -273,7 +200,6 @@
 	<string name="pref_tts_unavailable">Mevcut değil</string>
 	<!-- Title for "Other" section in TTS settings. -->
 	<string name="pref_tts_other_section_title">Diğer</string>
-	<string name="pref_tts_how_to_set_up_voice">Ses nasıl ayarlanır</string>
 	<!-- Settings «Map» category: «Record track» title -->
 	<string name="pref_track_record_title">En son yol</string>
 	<string name="pref_map_auto_zoom">Otomatik yakınlaştırma</string>
@@ -284,46 +210,11 @@
 	<string name="duration_12_hours">12 saat</string>
 	<string name="duration_1_day">1 gün</string>
 	<string name="recent_track_help_text">Bu özellik, belirli bir süre içinde katedilen yolu kaydetmenizi ve harita üzerinde izlemenizi sağlar. Lütfen unutmayın: bu işlevin etkinleştirilmesi pil tüketiminin artmasına neden olur. Takip, zaman aralığının sona ermesinin ardından otomatik olarak haritadan kaldırılacaktır.</string>
-	<string name="pref_track_ios_caption">En son yol seyahat ettiğiniz yolları gösterir.</string>
-	<string name="pref_track_ios_subcaption">Lütfen kaydedilecek yol süresini seçin.</string>
-	<string name="placepage_distance">Mesafe</string>
-	<string name="placepage_coordinates">Koordinatlar</string>
-	<string name="placepage_unsorted">Sıralanmamış</string>
 	<string name="search_show_on_map">Haritada görüntüle</string>
-	<!-- Used to warn user when fixing KitKat issue -->
-	<string name="bookmark_move_fail">Yer imlerinizi dâhili hafızaya taşımamız gerekiyor ancak bunlar için kullanılabilir alan yok. Lütfen hafızayı boşaltın, aksi takdirde yer imleri kullanılamaz olacaktır.</string>
-	<!-- Used in More Apps menu -->
-	<string name="free">Ücretsiz</string>
-	<!-- Used in More Apps menu -->
-	<string name="buy">Satın Al</string>
-	<!-- 1st search button-like result -->
-	<string name="search_on_map">Haritada Ara</string>
-	<!-- toast with an error -->
-	<string name="no_route_found">Rota bulunamadı</string>
-	<!-- route title -->
-	<string name="route">Rota</string>
-	<!-- category title -->
-	<string name="routes">Güzergahlar</string>
-	<!-- text of notification -->
-	<string name="download_map_notification">Bulunduğun yerin haritasını indir</string>
-	<!-- text of notification -->
-	<string name="pro_version_is_free_today">Organic Maps tam sürümü bugün ücretsiz! İndir ve arkadaşlarına haber ver.</string>
-	<!-- Dialog for transferring maps from lite to pro. -->
-	<string name="move_lite_maps_to_pro">Organic Maps Lite\'den indirmiş olduğunuz haritaları Organic Maps\'ye aktarıyoruz. Bu bir kaç dakika sürebilir.</string>
-	<!-- Message to display when maps moved. -->
-	<string name="move_lite_maps_to_pro_ok">İndirmiş olduğunuz haritalar başarılı bir şekilde Organic Maps\'ye aktarıldı.</string>
-	<!-- Message to display when maps move failed. -->
-	<string name="move_lite_maps_to_pro_failed">Haritanızın aktarımı başarısız oldu. Lütfen Organic Maps Lite\'yi silin ve haritaları tekrar indirin.</string>
-	<!-- Text in menu -->
-	<string name="settings_and_more">Ayarlar &amp; Fazlası</string>
 	<!-- Text in menu -->
 	<string name="website">Web Sitesi</string>
-	<!-- Text in menu -->
-	<string name="contact_us">İletişim</string>
 	<!-- Settings: Send feedback button and dialog title -->
 	<string name="feedback">Geri Bildirim</string>
-	<!-- Text in menu -->
-	<string name="subscribe_to_news">Haberlerimize abone ol</string>
 	<!-- Text in menu -->
 	<string name="rate_the_app">Uygulamayı değerlendir</string>
 	<!-- Text in menu -->
@@ -332,12 +223,6 @@
 	<string name="copyright">Telif hakkı</string>
 	<!-- Text in menu -->
 	<string name="report_a_bug">Hata bildir</string>
-	<!-- Email subject -->
-	<string name="subscribe_me_subject">Lütfen Organic Maps haber bültenine beni abone yap</string>
-	<!-- Email body -->
-	<string name="subscribe_me_body">En son haberlerden güncellemelerden ve tanıtımlardan ilk önce haberdar olmak istiyorum. Aboneliğimi herhangi bir zaman iptal edebilirim.</string>
-	<!-- About text -->
-	<string name="about_text">Organic Maps dünyadaki tüm ülkelerdeki şehirlerin en hızlı çevrimdışı haritalarını sunuyor. Tam güven ile seyahat edin: nerede olursanız olun, Organic Maps harita üzerinde nerede olduğunuzu belirlemeye, en yakın restoranı, oteli, bankayı, benzin istasyonunu v.b. bulmaya yardımcı olur. İnternet bağlantısı gerektirmez.\n\nHer zaman yeni özellikler üzerinde çalışıyoruz ve sizlerin Organic Maps\'yi nasıl geliştirebileceğimize dair görüşlerinizi almaktan mutluluk duyuyoruz. Eğer uygulama ile ilgili herhangi bir probleminiz varsa, bizimle support\@organicmaps.app adresinden temasa geçmekten çekinmeyin. Her talebe cevap veriyoruz!\n\nOrganic Maps\'yi beğendiniz ve bize destek olmak ister misiniz? Bunun bazı basit ve tamamıyla ücretsiz yolları var:\n\n- Uygulama Marketinizde bir yorum yazın\n- Facebook sayfamızı beğenin http://www.facebook.com/OrganicMaps\n- veya sadece annenize, arkadaşlarınıza ve iş arkadaşlarınıza Organic Maps\'den bahsedin :)\n\nBizi tercih ettiğiniz için teşekkür ederiz. Desteğinizden dolayı çok memnuniyet duyarız!\n\nNot: Verileri haritaları kullanıcıların yaratmasına ve düzenlemesine olanak veren Wikipedia benzeri bir proje olan OpenStreetMap\'dan almaktayız. Eğer haritada eksik ya da hatalı bir şeyler görürseniz doğrudan haritaları\n\nhttps://www.openstreetmap.org, adresinden düzeltebilirsiniz ve yaptığınız değişiklikler Organic Maps\'de bir sonraki sürüm yayınlandığında görülebilir olacaktır.</string>
 	<!-- Alert text -->
 	<string name="email_error_body">E-posta istemcisi henüz kurulmamış. Lütfen e-posta istemcisini yapılandırın ya da bize %s adresinden ulaşmak için başka bir yöntem deneyin</string>
 	<!-- Alert title -->
@@ -346,137 +231,56 @@
 	<string name="pref_calibration_title">Pusula kalibrasyonu</string>
 	<!-- Search category -->
 	<string name="wifi">WiFi</string>
-	<!-- Update map suggestion -->
-	<string name="routing_map_outdated">Yeni bir rota oluşturmak için lütfen haritayı güncelleyin.</string>
-	<!-- Update maps suggestion -->
-	<string name="routing_update_maps">Organic Maps\'nin yeni sürümü mevcut pozisyonunuzdan varış noktasına rotalar oluşturmanıza imkan verir. Lütfen bu özelliği kullanmak için haritaları güncelleyin.</string>
 	<!-- Update all button text -->
 	<string name="downloader_update_all_button">Hepsini güncelle</string>
 	<!-- Cancel all button text -->
 	<string name="downloader_cancel_all">Tümünü İptal Et</string>
 	<!-- Downloaded maps category -->
 	<string name="downloader_downloaded_subtitle">İndirildi</string>
-	<!-- Downloaded maps category -->
-	<string name="downloader_available_maps">Mevcut</string>
 	<!-- Country queued for download -->
 	<string name="downloader_queued">Sıraya alındı</string>
 	<string name="downloader_near_me_subtitle">Yakınlarımda</string>
 	<string name="downloader_status_maps">Haritalar</string>
 	<string name="downloader_download_all_button">Hepsini indir</string>
 	<string name="downloader_downloading">İndiriliyor:</string>
-	<string name="downloader_search_results">Bulundu</string>
-	<!-- Disclaimer message -->
-	<string name="routing_disclaimer">Organic Maps uygulamasında rota yaratırken lütfen aşağıdakileri dikkate alın:\n\n  - Önerilen rotalar sadece tavsiyeler olarak düşünülmelidir.\n - Yol koşulları, trafik kuralları ve işaretleri navigasyon tavsiyelerden daha önceliklidir.\n - Harita doğru olmayabilir ya da eskimiş olabilir ve rotalar en iyi mümkün yola göre oluşturulmamış olabilir.\n\n  Yollarda güvende olun ve kendinize dikkat edin!</string>
-	<!-- Outdated maps category -->
-	<string name="downloader_outdated_maps">Güncel değil</string>
-	<!-- Up to date maps category -->
-	<string name="downloader_uptodate_maps">Güncel</string>
 	<!-- Status of outdated country in the list -->
 	<string name="downloader_status_outdated">Güncelle</string>
 	<!-- Status of failed country in the list -->
 	<string name="downloader_status_failed">Başarısız</string>
 	<!-- Displayed in a dialog that appears when a user tries to delete a map while the app is in the follow route mode -->
 	<string name="downloader_delete_map_while_routing_dialog">Haritayı silmek için lütfen navigasyonu durdurun.</string>
-	<!-- Show when user try build route, but we don't know where he -->
-	<string name="routing_failed_unknown_my_position">Geçerli konum tanımlı değil. Rota oluşturmak için lütfen konum belirtin.</string>
-	<!-- Show if use has not routing file, or InconsistentMWMandRoute -->
-	<string name="routing_failed_has_no_routing_file">Bir rota oluşturmak için ek bilgiler gereklidir. İndirme işlemini başlat?</string>
-	<!-- StartPointNotFound -->
-	<string name="routing_failed_start_point_not_found">Rota hesaplanamıyor. Başlangıç noktanızın yakınında hiçbir yol yok.</string>
-	<!-- EndPointNotFound -->
-	<string name="routing_failed_dst_point_not_found">Rota hesaplanamıyor. Varış yerinizin yakınında hiçbir yol yok.</string>
 	<!-- PointsInDifferentMWM -->
 	<string name="routing_failed_cross_mwm_building">Rotalar sadece tamamen tek bir harita dâhilinde oluşturulabilir.</string>
-	<!-- RouteNotFound -->
-	<string name="routing_failed_route_not_found">Seçilen kalkış yeriyle varış yeri arasında hiçbir rota bulunamadı. Lütfen farklı bir başlangıç veya bitiş noktası seçin.</string>
-	<!-- InternalError -->
-	<string name="routing_failed_internal_error">Sistem içi hata oluştu. Lütfen haritayı silin ve tekrar yüklemeyi deneyin. Sorun devam ettiği takdirde lütfen support\@organicmaps.app adresinden bize ulaşın.</string>
-	<!-- Context menu item for downloader. -->
-	<string name="downloader_download_map_and_routing">Harita + Rota İndir</string>
-	<!-- Context menu item for downloader. -->
-	<string name="downloader_download_routing">Rota İndir</string>
-	<!-- Context menu item for downloader. -->
-	<string name="downloader_delete_routing">Rotayı Sil</string>
 	<!-- Context menu item for downloader. -->
 	<string name="downloader_download_map">Haritayı indir</string>
-	<string name="downloader_download_map_no_routing">Haritayı rota olmadan indirin</string>
-	<!-- Button for routing. -->
-	<string name="routing_go">Git!</string>
 	<!-- Item status in downloader. -->
 	<string name="downloader_retry">Tekrarla</string>
-	<!-- Item in context menu. -->
-	<string name="downloader_map_and_routing">Harita + Rota</string>
 	<!-- Item in context menu. -->
 	<string name="downloader_delete_map">Haritayı Sil</string>
 	<!-- Item in context menu. -->
 	<string name="downloader_update_map">Haritayı Güncelle</string>
-	<!-- Item in context menu. -->
-	<string name="downloader_update_map_and_routing">Harita + Rota Güncelle</string>
-	<!-- Item in context menu. -->
-	<string name="downloader_map_only">Sadece harita</string>
-	<!-- Toolbar title -->
-	<string name="toolbar_application_menu">Uygulama menüsü</string>
 	<!-- Preference text -->
 	<string name="pref_use_google_play">Şu anki konumunuzu almak için Google Play hizmetlerini kullanın</string>
 	<!-- Text for rating dialog -->
 	<string name="rating_just_rated">Uygulamanıza az önce puan verdim</string>
-	<!-- Text for rating dialog -->
-	<string name="rating_user_since">%s yılından beri Organic Maps kullanıcısıyım</string>
-	<!-- Text for rating dialog -->
-	<string name="rating_do_like_maps">Organic Maps\'yi beğeniyor musunuz?</string>
-	<!-- Text for rating dialog -->
-	<string name="rating_tap_star">Uygulamamıza puan vermek için bir yıldıza dokunun.</string>
 	<!-- Text for rating dialog -->
 	<string name="rating_thanks">Teşekkürler!</string>
 	<!-- Text for rating dialog -->
 	<string name="rating_share_ideas">Uygulamayı geliştirebilmemiz için fikirlerinizi veya sorunlarınızı paylaşın.</string>
 	<!-- Text for rating dialog -->
 	<string name="rating_send_feedback">Geribildirim gönder</string>
-	<!-- Text for g+ dialog -->
-	<string name="rating_google_plus">Arkadaşlarına uygulamayı duyurmak için g+\'ya tıkla.</string>
 	<!-- Text for routing error dialog -->
 	<string name="routing_download_maps_along">Rota üzerindeki haritaları indir</string>
-	<!-- Text for routing error dialog -->
-	<string name="routing_download_map">Harita alın</string>
-	<!-- Text for routing error dialog -->
-	<string name="routing_download_map_and_routing">Tüm Organic Maps özelliklerini edinmek için güncellenmiş harita ve rota verilerini indirin.</string>
-	<!-- Text for routing error dialog -->
-	<string name="routing_get_routing_data">Rota verileri edin</string>
-	<!-- Text for routing error dialog -->
-	<string name="routing_get_additional_data">Konumunuzdan rota oluşturmak için ilave verileri edinin.</string>
 	<!-- Text for routing error dialog -->
 	<string name="routing_requires_all_map">Konumunuzdan bir rota oluşturmak bölgenizdeki tüm haritaların indirilmesini ve güncellenmesini gerektirir.</string>
 	<!-- Text for routing error dialog -->
 	<string name="routing_not_enough_space">Yeterli alan yok</string>
-	<!-- Text for routing error dialog -->
-	<string name="routing_download_more_than_avail">%1$s MB indirmeniz gerekiyor fakat sadece %2$s MB boş alan mevcut.</string>
-	<!-- Text for routing error dialog -->
-	<string name="routing_download_roaming">%s MB boyutunda veriyi Mobil Veri (Roaming) kullanarak indireceksiniz. Bu mobil operatör veri planınıza göre ilave ödeme gerektirebilir.</string>
 	<!-- bookmark button text -->
 	<string name="bookmark">yer i̇mi</string>
-	<!-- map is not downloaded -->
-	<string name="not_found_map">Konum haritası bulunamadı</string>
 	<!-- location service disabled -->
 	<string name="enable_location_services">Lütfen Yer Hizmetlerini etkinleştirin</string>
-	<!-- download map -->
-	<string name="download_map">Konumunuz için haritayı indirin</string>
-	<!-- download map on iPhone -->
-	<string name="download_map_iphone">Mevcut konum için iPhone\'nunuza haritayı indirin</string>
-	<!-- clear pin -->
-	<string name="nearby">Yakında</string>
-	<!-- clear pin -->
-	<string name="clear_pin">İğneyi Temizle</string>
-	<!-- location is undefined -->
-	<string name="undefined_location">Geçerli konum tanımlı değil.</string>
-	<!-- download country of your location -->
-	<string name="download_country">Geçerli konumuzun ülkesini indirin</string>
-	<!-- download failed -->
-	<string name="download_failed">indirme işlemi başarısız oldu</string>
-	<!-- get the map -->
-	<string name="get_the_map">Harita alın</string>
 	<string name="save">Kaydet</string>
 	<string name="edit_description_hint">Açıklamalarınız (metin veya html)</string>
-	<string name="new_group">yeni grup</string>
 	<string name="create">oluştur</string>
 	<!-- red color -->
 	<string name="red">Kırmızı</string>
@@ -494,22 +298,6 @@
 	<string name="brown">Kahverengi</string>
 	<!-- pink color -->
 	<string name="pink">Pembe</string>
-	<!-- deep purple color -->
-	<string name="deep_purple">Koyu Mor</string>
-	<!-- light blue color -->
-	<string name="light_blue">Açık Mavi</string>
-	<!-- cyan color -->
-	<string name="cyan">Cam Göbeği</string>
-	<!-- teal color -->
-	<string name="teal">Deniz Mavisi</string>
-	<!-- lime color -->
-	<string name="lime">Çim Rengi</string>
-	<!-- deep orange color -->
-	<string name="deep_orange">Koyu Turuncu</string>
-	<!-- gray color -->
-	<string name="gray">Gri</string>
-	<!-- blue gray color -->
-	<string name="blue_gray">Mavi Gri</string>
 	<!-- Wi-Fi available -->
 	<string name="WiFi_available">Evet</string>
 
@@ -525,10 +313,8 @@
 	<string name="dialog_routing_location_turn_wifi">Lütfen GPS sinyalinizi kontrol edin. Wi-Fi\'ı etkinleştirmek konum isabetini arttırır.</string>
 	<string name="dialog_routing_location_turn_on">Konum hizmetlerini etkinleştirin</string>
 	<string name="dialog_routing_location_unknown_turn_on">Mevcut GPS koordinatları belirlenemiyor. Güzergah hesaplamak için konum hizmetlerini etkinleştirin.</string>
-	<string name="dialog_routing_location_unknown">Mevcut GPS koordinatları belirlenemiyor.</string>
 	<string name="dialog_routing_download_files">Gerekli dosyaları indirin</string>
 	<string name="dialog_routing_download_and_update_all">Planlanan yoldaki tüm harita ve güzergah bilgilerini indirip güncelleyerek güzergahı hesaplayın.</string>
-	<string name="dialog_routing_routes_size">Güzergah bilgi dosyaları</string>
 	<string name="dialog_routing_unable_locate_route">Güzergah belirlenemiyor</string>
 	<string name="dialog_routing_cant_build_route">Güzergah oluşturulamıyor.</string>
 	<string name="dialog_routing_change_start_or_end">Lütfen başlangıç noktanızı veya hedefinizi ayarlayın.</string>
@@ -543,33 +329,23 @@
 	<string name="dialog_routing_system_error">Sistem hatası</string>
 	<string name="dialog_routing_application_error">Uygulama hatası nedeniyle güzergah oluşturulamadı.</string>
 	<string name="dialog_routing_try_again">Lütfen daha sonra tekrar deneyin</string>
-	<string name="dialog_routing_send_error">Hatayı Bildirin</string>
-	<string name="dialog_routing_if_get_cross_route">Bir haritadan daha fazlasına uzanan doğrudan bir güzergah oluşturmak ister misiniz?</string>
-	<string name="dialog_routing_cross_route_is_optimal">Bu haritanın bir kısmından geçen daha uygun bir güzergah mevcut.</string>
 	<string name="not_now">Şimdi Değil</string>
-	<string name="dialog_routing_build_route">Oluşturun</string>
 	<string name="dialog_routing_download_and_build_cross_route">Haritayı indirerek birden fazla haritaya uzanan daha uygun bir güzergah oluşturmak ister misiniz?</string>
 	<string name="dialog_routing_download_cross_route">Bu haritanın bir kısmından geçen daha uygun bir güzergah oluşturmak için haritayı indirin.</string>
-	<string name="dialog_routing_cross_route_always">Bu sınırı her zaman geçin</string>
 
 	<!-- SECTION: Strings for downloading map from search -->
 	<string name="search_without_internet_advertisement">Rotaları aramak ve oluşturmaya başlamak için lütfen haritayı indirin ve artık internet bağlantısına ihtiyacınız yok.</string>
 	<string name="search_select_map">Haritayi Seçin</string>
-	<string name="search_select_other_map">Başka Bir Harita Seçin</string>
 	<!-- «Show» context menu -->
 	<string name="show">Göster</string>
 	<!-- «Hide» context menu -->
 	<string name="hide">Gizle</string>
 	<!-- «Rename» context menu -->
 	<string name="rename">Yeniden Adlandır</string>
-	<!-- Bottom sheet: expand button (should be short) -->
-	<string name="bottom_sheet_more">Daha Fazla…</string>
 	<!-- Failed planning route message in navigation view -->
 	<string name="routing_planning_error">Rota Planlaması Başarısız</string>
 	<!-- Arrive routing message in navigation view -->
 	<string name="routing_arrive">Varış: %s</string>
-	<!-- Text for routing::RouterResultCode::FileTooOld dialog. -->
-	<string name="dialog_routing_download_and_update_maps">Bir rota oluşturmak için lütfen rota üzerindeki tüm haritaları indirin ve güncelleyin.</string>
 	<string name="rate_alert_title">Uygulamayı beğendiniz mi?</string>
 	<string name="rate_alert_default_message">Organic Maps’yi kullandığınız için teşekkür ederiz. Lütfen uygulamaya puan verin. Geri bildiriminiz daha iyi hale gelebilmemize yardımcı olur.</string>
 	<string name="rate_alert_five_star_message">Yaşasın! Biz de sizi seviyoruz!</string>
@@ -577,24 +353,14 @@
 	<string name="rate_alert_less_than_four_star_message">Daha iyi hale getirebilmemiz için herhangi bir fikriniz var mı?</string>
 	<string name="categories">Kategoriler</string>
 	<string name="history">Geçmiş</string>
-	<string name="next_turn_then">Sonra</string>
 	<string name="closed">Kapatıldı</string>
-	<string name="back_to">Geri Dön %s</string>
 	<string name="search_not_found">Üzgünüz, hiç bir şey bulamadık.</string>
 	<string name="search_not_found_query">Lütfen başka bir sorgu girin.</string>
-	<string name="search_not_found_map">Lütfen arama yaptığınız haritayı indirin.</string>
-	<string name="search_not_found_location">Mevcut konumunuzun haritasını indirin.</string>
 	<string name="search_history_title">Arama Geçmişi</string>
 	<string name="search_history_text">En son yapılan arama sorgularına hızlı erişim.</string>
 	<string name="clear_search">Arama geçmişini temizle</string>
-	<!-- Title for settings to enable/disable showcase menu button -->
-	<string name="showcase_settings_title">Teklifleri göster</string>
-	<string name="p2p_route_planning">Rota planlama</string>
 	<string name="p2p_your_location">Konumunuz</string>
-	<string name="p2p_from">Kalkış noktası</string>
-	<string name="p2p_to">Varış noktası</string>
 	<string name="p2p_start">Başla</string>
-	<string name="p2p_planning">Planlanıyor…</string>
 	<string name="p2p_from_here">Başlangıç</string>
 	<string name="p2p_to_here">Varış yeri:</string>
 	<string name="p2p_only_from_current">Navigasyon sadece şu anki konumunuzdan mevcut.</string>
@@ -614,11 +380,8 @@
 	<string name="editor_hours_closed">Kapalı olduğu saatler</string>
 	<string name="editor_example_values">Örnek Değerler</string>
 	<string name="editor_correct_mistake">Hatayı düzelt</string>
-	<string name="editor_correct_mistake_message">Bir düzenleme hatası yaptınız. Lütfen düzeltin veya basit moda geçin.</string>
 	<string name="editor_add_select_location">Konum</string>
 	<string name="editor_done_dialog_1">Dünya haritasını değiştirdiniz. Bunu gizlemeyin! Arkadaşlarınıza anlatın ve birlikte düzenleyin.</string>
-	<string name="editor_done_dialog_2">Bu sizin ikinci harita iyileştirmeniz. Artık siz harita editörleri arasında %d. sıradasınız. Arkadaşlarınıza bunu anlatın.</string>
-	<string name="editor_done_dialog_3">Haritayı geliştirdiniz, arkadaşlarınıza bunu anlatın ve birlikte haritayı düzenleyin.</string>
 	<string name="share_with_friends">Arkadaşlarınla paylaş</string>
 	<string name="editor_report_problem_desription_1">OpenStreetMap topluluğunun hatayı düzeltmesi için lütfen problemi detaylı bir şekilde tanımlayın.</string>
 	<string name="editor_report_problem_desription_2">Veya bunu adresinden kendiniz yapın https://www.openstreetmap.org/</string>
@@ -627,14 +390,7 @@
 	<string name="editor_report_problem_no_place_title">Yer mevcut değil</string>
 	<string name="editor_report_problem_under_construction_title">Bakım için kapalı</string>
 	<string name="editor_report_problem_duplicate_place_title">Kopyalanmış yer</string>
-	<string name="first_launch_congrats_title">Organic Maps kullanıma hazır</string>
-	<string name="first_launch_congrats_text">Dünyanın her yerinde çevrimdışı olarak ücretsiz arama yapın ve gezinin.</string>
-	<string name="migrate_title">Önemli!</string>
-	<!-- Android uses image instead of text. -->
-	<string name="download_all">Tümünü indir</string>
-	<string name="delete_all">Tümünü sil</string>
 	<string name="autodownload">Otomatik indir</string>
-	<string name="disable_autodownload">Otomatik indirmeyi devre dışı bırak</string>
 	<!-- Place Page opening hours text -->
 	<string name="closed_now">Şu anda kapalı</string>
 	<!-- Place Page opening hours text -->
@@ -643,8 +399,6 @@
 	<string name="day_off_today">Bugün kapalı</string>
 	<string name="day_off">Kapalı</string>
 	<string name="today">Bugün</string>
-	<string name="sunrise_to_sunset">Güneşin doğuşundan batışına kadar</string>
-	<string name="sunset_to_sunrise">Gün doğumundan gün batımına</string>
 	<string name="add_opening_hours">İş saatlerini ekle</string>
 	<string name="edit_opening_hours">İş saatlerini düzenle</string>
 	<string name="no_osm_account">OpenStreetMap\' hesabın yok mu?</string>
@@ -654,29 +408,13 @@
 	<string name="login">Oturum aç</string>
 	<string name="password">Şifre</string>
 	<string name="forgot_password">Şifreni mi unuttun?</string>
-	<!-- Forgot Password dialog title -->
-	<string name="restore_password">Şifreyi yenile</string>
-	<string name="enter_email_address_to_reset_password">Kayıt sırasında kullandığınız e-posta adresini girin ve şifrenizi yenileyeceğiniz bağlantıyı gönderelim.</string>
-	<string name="reset_password">Parolayı sıfırla</string>
-	<string name="username">Kullanıcı Adı</string>
 	<string name="osm_account">OSM Hesabı</string>
 	<string name="logout">Oturumu kapat</string>
-	<string name="login_and_edit_map_motivation_message">Oturum aç ve haritada nesne bilgilerini düzenleyip diğer milyonlarca kullanıcıya aç. Birlikte dünyayı daha iyi bir yer haline getirelim.</string>
 	<!-- Information text: "Last upload 11.01.2016" -->
 	<string name="last_upload">Son yükleme</string>
-	<!-- Motivates user to login/register, title above login buttons. -->
-	<string name="you_have_edited_your_first_object">İlk nesneni düzenledin!</string>
 	<string name="thank_you">Teşekkür ederiz</string>
-	<string name="login_with_google">Google ile giriş</string>
-	<string name="login_with_openstreetmap">www.openstreetmap.org adresinden oturum aç</string>
 	<string name="edit_place">Yeri düzenle</string>
 	<string name="place_name">Yer ismi</string>
-	<!-- title above languages list cells in the editor, below editable name text field. -->
-	<string name="other_languages">Diğer Diller</string>
-	<!-- small button to open list with names in different languages -->
-	<string name="show_more">Daha fazlasını göster</string>
-	<!-- small button to close list with names in different languages -->
-	<string name="show_less">Daha azını göster</string>
 	<string name="add_language">Bir dil ekle</string>
 	<string name="street">Sokak</string>
 	<!-- Editable House Number text field (in address block). -->
@@ -693,25 +431,16 @@
 	<string name="email_or_username">E-posta veya kullanıcı adı</string>
 	<string name="phone">Telefon</string>
 	<string name="please_note">Lütfen dikkat</string>
-	<string name="common_no_wifi_dialog">WiFi bağlantısı yok. Mobil veri ile devam etmek istiyor musunuz?</string>
 	<string name="downloader_delete_map_dialog">Harita ile birlikte tüm harita değişiklikleri de silinecektir.</string>
 	<string name="downloader_update_maps">Haritaları güncelle</string>
 	<string name="downloader_mwm_migration_dialog">Bir rota oluşturmak için tüm haritaları güncellemeli ve ardından rotayı tekrar planlamalısınız.</string>
 	<string name="downloader_search_field_hint">Harita bul</string>
-	<string name="migration_update_all_button">Haritaları güncelle</string>
-	<string name="migration_delete_all_download_current_button">Mevcut haritayı indir ve tüm eski haritaları sil</string>
 	<string name="migration_download_error_dialog">İndirme hatası</string>
 	<string name="common_check_internet_connection_dialog">Lütfen ayarlarınızı kontrol edin ve cihazınızın internete bağlı olduğundan emin olun.</string>
 	<string name="downloader_no_space_title">Yeterli alan yok</string>
 	<string name="downloader_no_space_message">Lütfen gereksiz verileri silin</string>
-	<string name="editor_general_auth_error_dialog">Genel giriş hatası.</string>
 	<string name="editor_login_error_dialog">Giriş hatası</string>
-	<string name="editor_login_failed_dialog">Giriş başarısız</string>
-	<string name="editor_username_error_dialog">Kullanıcı adı geçersiz</string>
-	<string name="editor_place_edited_dialog">Bir objeyi düzenlediniz\'!</string>
-	<string name="editor_login_with_osm">OpenStreetMap ile giriş yapın</string>
 	<string name="editor_profile_changes">Doğrulanan Değişiklikler</string>
-	<string name="editor_profile_unsent_changes">Gönderilmedi:</string>
 	<string name="editor_focus_map_on_location">Objenin doğru konumunu seçmek için haritayı çekin.</string>
 	<string name="editor_add_select_category">Kategori seç</string>
 	<string name="editor_add_select_category_popular_subtitle">Popüler</string>
@@ -722,19 +451,14 @@
 	<string name="editor_edit_place_category_title">Kategori</string>
 	<string name="detailed_problem_description">Sorunun ayrıntılı açıklaması</string>
 	<string name="editor_report_problem_other_title">Farklı bir problem</string>
-	<string name="placepage_report_problem_button">Bir problem bildirin</string>
 	<string name="placepage_add_business_button">Kuruluş ekle</string>
 	<string name="whatsnew_editor_message_1">Doğrudan uygulamadan haritaya yeni yerler ekle ve mevcut yerleri düzenleyin.</string>
-	<string name="whatsnew_editor_message_2">* Organic Maps, OpenStreetMap topluluğu verilerini kullanmaktadır.</string>
 	<string name="dialog_incorrect_feature_position">Konumu değiştir</string>
 	<string name="message_invalid_feature_position">Buraya bir nesne konumlandırılamıyor</string>
 	<string name="login_to_make_edits_visible">Giriş yapın böylelikle diğer kullanıcılar yaptığınız değişiklikleri görebilirler.</string>
-	<string name="no_migration_during_navigation">Navigasyon sırasında güncelleme yasaktır.</string>
 	<!-- Error dialog no space -->
 	<string name="migration_no_space_message">İndirmek için daha fazla alana ihtiyacınız var. Lütfen gereksiz verileri silin.</string>
 	<string name="editor_sharing_title">Organic Maps haritalarını iyileştirdim</string>
-	<string name="editor_comment_will_be_sent">Yorumunuzu haritacılara göndereceğiz.</string>
-	<string name="editor_unsupported_category_message">Henüz desteklemediğimiz bir kategori yeri eklediniz. Bir süre sonra haritada yer alacaktır.</string>
 	<!-- Downloaded 10 **of** 20 <- it is that "of" -->
 	<string name="downloader_of">%1$d/%2$d</string>
 	<string name="download_over_mobile_header">Hücresel bir ağ bağlantısı kullanarak indir?</string>
@@ -752,15 +476,8 @@
 	<string name="editor_detailed_description">Önerdiğiniz değişiklikler OpenStreetMap topluluğuna gönderilecek. Organic Maps’de düzenlenemeyen ayrıntıları açıklayın.</string>
 	<string name="editor_more_about_osm">OpenStreetMap hakkında ek bilgi</string>
 	<string name="editor_operator">İşletmeci</string>
-	<string name="editor_tag_description">Tesislerden sorumlu şirketi, kurumu veya bireyi girin.</string>
-	<string name="editor_no_local_edits_title">Yerel düzenlemeniz yok</string>
-	<string name="editor_no_local_edits_description">Bu, harita üzerinde önerdiğiniz değişikliklerden sadece şu anda cihazınızda erişilebilenlerin sayısını gösterir.</string>
-	<string name="editor_send_to_osm">OSM’ye gönder</string>
-	<string name="editor_remove">Kaldır</string>
-	<string name="downloader_my_maps_title">Haritalarım</string>
 	<string name="downloader_no_downloaded_maps_title">Hiç harita indirmediniz</string>
 	<string name="downloader_no_downloaded_maps_message">Çevrimdışı olarak adres bulmak ve gezinmek için haritaları indirin.</string>
-	<string name="downloader_find_place_hint">Şehirde veya ülkede arama yapın</string>
 	<!-- Error title that appears after certain time without location. -->
 	<string name="current_location_unknown_title">Geçerli konumunuzuz izlenmeye devam edilsin mi</string>
 	<!-- Error that appears after certain time without location. -->
@@ -775,27 +492,10 @@
 	<string name="location_services_disabled_2">2. Konuma Dokunun</string>
 	<!-- iOS Dialog for the case when the location permission is not granted -->
 	<string name="location_services_disabled_3">3. Uygulamayı Kullanırken Seç</string>
-	<string name="placepage_parking_surface">Yüzey</string>
-	<string name="placepage_parking_multistorey">Çok Katlı</string>
-	<string name="placepage_parking_underground">Metro</string>
-	<string name="placepage_parking_rooftop">Çatı üstü</string>
-	<string name="placepage_parking_sheds">Kulübe</string>
-	<string name="placepage_parking_carports">Açık Park Alanları</string>
-	<string name="placepage_parking_boxes">Garaj kutuları</string>
-	<string name="placepage_parking_pay">Ücretli</string>
-	<string name="placepage_parking_free">Ücretsiz</string>
-	<string name="placepage_parking_interval">Süre Ücretli</string>
-	<string name="placepage_entrance_number">No.</string>
-	<string name="placepage_entrance_type">Giriş</string>
-	<string name="placepage_flat">uygulama</string>
-	<string name="placepage_open_24_7">24 / 7</string>
 	<string name="meter">m</string>
 	<string name="kilometer">km</string>
-	<string name="kilometers_per_hour">km/s</string>
 	<string name="mile">mil</string>
 	<string name="foot">fit</string>
-	<string name="miles_per_hour">mph</string>
-	<string name="day">g</string>
 	<string name="hour">sa</string>
 	<string name="minute">dk</string>
 	<string name="placepage_place_description">Açıklama</string>
@@ -805,46 +505,30 @@
 	<string name="placepage_call_button">Çağrı</string>
 	<string name="placepage_edit_bookmark_button">Yer İmini Düzenle</string>
 	<string name="placepage_bookmark_name_hint">Yer İmi Adı</string>
-	<string name="placepage_personal_notes_hint">Kişisel notlar</string>
-	<string name="placepage_delete_bookmark_button">Yer İmini Sil</string>
 	<string name="editor_edits_sent_message">Önerdiğiniz değişiklikler gönderildi</string>
 	<string name="editor_comment_hint">Yorum…</string>
 	<string name="editor_reset_edits_message">Tüm yerel değişiklikler sıfırlansın mı?</string>
 	<string name="editor_reset_edits_button">Sıfırla</string>
 	<string name="editor_remove_place_message">Eklenen bir yer kaldırılsın mı?</string>
 	<string name="editor_remove_place_button">Kaldır</string>
-	<string name="editor_status_sending">Gönderiliyor…</string>
 	<string name="editor_place_doesnt_exist">Bu yer mevcut değil</string>
 	<string name="text_more_button">…daha fazla</string>
 	<!-- Phone number error message -->
 	<string name="error_enter_correct_phone">Doğru telefon numarası gir</string>
 	<string name="error_enter_correct_web">Geçerli bir web adresi girin</string>
 	<string name="error_enter_correct_email">Geçerli bir e-posta girin</string>
-	<string name="error_enter_correct">Geçerli bir değer girin</string>
 	<string name="refresh">Güncelleştirme</string>
-	<string name="last_update">Son güncelleme: %s</string>
 	<string name="placepage_add_place_button">Haritaya bir yer ekleyin</string>
 	<!-- Displayed when saving some edits to the map to warn against publishing personal data -->
 	<string name="editor_share_to_all_dialog_title">Bunu tüm kullanıcılara göndermek ister misiniz?</string>
 	<!-- iOS Dialog before publishing the modifications to the public map. -->
 	<string name="editor_share_to_all_dialog_message_1">Herhangi bir kişisel bilgi girmediğinizden emin olun.</string>
 	<string name="editor_share_to_all_dialog_message_2">Değişikliği kontrol edeceğiz. Eğer herhangi bir sorumuz olursa sizinle e-posta aracılığıyla temasa geçeceğiz.</string>
-	<string name="navigation_overview_button">genel bakış</string>
-	<string name="navigation_stop_button">dur</string>
-	<!-- Text on an empty bookmark page -->
-	<string name="bookmarks_empty_title">Yer İşaretlerini Kaydet</string>
-	<string name="bookmarks_empty_message_1">Hızlı erişim için favori yerlere kaydetmek için ★ dokunun.</string>
-	<string name="bookmarks_empty_message_2">E-postadan ve weben yer işaretlerini içe aktarın.</string>
-	<string name="bookmarks_empty_message_3">çıkış: %s</string>
-	<!-- Name of the group for booked hotels -->
-	<string name="bookmarks_group_name">Ayırtılan oteller</string>
-	<string name="place_page_button_read_descriprion">Oku</string>
 	<!-- iOS dialog for the case when recent track recording is on and the app comes back from background -->
 	<string name="recent_track_background_dialog_title">En son seyahat edilen rotanızı kaydetmeyi devre dışı bırakmak istiyor musunuz?</string>
 	<string name="off_recent_track_background_button">Devre Dışı Bırak</string>
 	<!-- For sharing via SMS and so on -->
 	<string name="sharing_call_action_look">İncele</string>
-	<string name="continue_recent_track_background_button">Devam Et</string>
 	<string name="recent_track_background_dialog_message">Organic Maps, en son seyahat ettiğiniz rotayı kaydetmek için arka planda coğrafi konumunuzu kullanır.</string>
 	<!-- Rate on Google Play (Android only) -->
 	<string name="rate_gp">Google Play\'de Oy Ver</string>
@@ -854,21 +538,11 @@
 	<string name="tell_friends_text">Merhaba! Organic Maps\'yi hemen yükle!</string>
 	<!-- About short text (below logo) -->
 	<string name="about_description">Organic Maps, seyahatler için vazgeçilmez bir çevrimdışı uygulamadır. Organic Maps, OpenStreetMap verilerine dayanmakta ve bu verilerin düzenlenmesini sağlamaktadır.</string>
-	<!-- Text in menu -->
-	<string name="blog">Blog</string>
 	<string name="general_settings">Genel ayarlar</string>
-	<string name="date">Tarih %d</string>
-	<!-- "Report a bug" -> "Generaal Feedback" -> "Something is not working" -->
-	<string name="something_is_not_working">Bir şey çalışmıyor</string>
 	<!-- For the first routing -->
 	<string name="accept">Kabul</string>
 	<!-- For the first routing -->
 	<string name="decline">Ret</string>
-	<string name="install_app">Kur</string>
-	<string name="search_no_results_title">Hiçbir Sonuç Bulunamadı</string>
-	<string name="search_no_results_message">Daha genel bir terimi aramayı deneyin, uzaklaşın veya filtreyi Sıfırlayın.</string>
-	<string name="search_no_results_expand_area_button">Uzaklaş</string>
-	<string name="search_no_results_reset_button">Filtreyi Sıfırla</string>
 	<!-- noun -->
 	<string name="search_in_table">Liste</string>
 	<string name="mobile_data_dialog">Ayrıntılı bilgileri görüntülemek için mobil internet kullanılsın mı?</string>
@@ -880,18 +554,13 @@
 	<string name="mobile_data_option_never">Asla Kullanma</string>
 	<string name="mobile_data_option_ask">Her Zaman Sor</string>
 	<string name="traffic_update_maps_text">Trafik verilerini görüntülemek için haritaların güncellenmesi gerekiyor.</string>
-	<string name="traffic_outdated">Trafik verileri güncel değil.</string>
 	<string name="big_font">Harita üzerindeki yazı tipi boyutunu artır</string>
 	<string name="traffic_update_app">Lütfen Organic Maps uygulamasını güncelleyin</string>
 	<!-- "traffic" as in road congestion -->
 	<string name="traffic_update_app_message">Trafik verilerini görüntülemek için uygulamanın güncellenmesi gerekiyor.</string>
 	<!-- "traffic" as in "road congestion" -->
 	<string name="traffic_data_unavailable">Trafik verileri kullanılamıyor</string>
-	<!-- Simplified colour scheme for traffic information, fewer colours are used to display traffic jams on the map. The string should be kept as short as possible -->
-	<string name="pref_traffic_simplified_colors_title">Sadeleştirilmiş trafik renkleri</string>
 	<string name="enable_logging">Günlüğü etkinleştir</string>
-	<string name="offline_place_page_more_information">Yerle ilgili daha fazla bilgi almak için internete bağlanın.</string>
-	<string name="failed_load_information">Bilgiler yüklenemedi.</string>
 	<!-- Settings: "Send general feedback" button -->
 	<string name="feedback_general">Genel Geribildirim</string>
 	<string name="on">Aç</string>
@@ -905,57 +574,26 @@
 	<string name="routing_add_start_point">Güzergâhı planlamak için bir başlangıç noktası ekleyin</string>
 	<string name="routing_add_finish_point">Güzergâhı planlamak için bir varış noktası ekleyin</string>
 	<string name="button_exit">Çık</string>
-	<string name="settings_device_memory">Cihaz belleği</string>
-	<string name="settings_card_memory">Kart belleği</string>
-	<string name="settings_storage_available">%s kullanılabilir</string>
-	<string name="toast_location_permission_denied">Uygulamanın konum bilgilerine erişim isteği reddedildi</string>
-	<string name="button_use">Kullan</string>
 	<string name="planning_route_manage_route">Güzergâhı yönet</string>
 	<string name="button_plan">Plan</string>
-	<string name="button_add">Ekle</string>
 	<string name="placepage_remove_stop">Kaldır</string>
 	<string name="planning_route_remove_title">Kaldırmak için buraya sürükleyin</string>
-	<string name="dialog_change_start_point_message">Başlangıç noktası mevcut konumla değiştirilsin mi?</string>
-	<string name="button_replace">Değiştir</string>
 	<string name="placepage_add_stop">Ara nokta ekle</string>
-	<string name="add_my_position">Konumumu ekle</string>
-	<string name="choose_start_point">Bir başlangıç noktası seçin</string>
-	<string name="choose_destination">Bir hedef seçin</string>
 	<string name="preloader_viator_button">Daha fazla bilgi edinin</string>
-	<string name="start_from_my_position">Buradan başla</string>
-	<string name="profile_authorization_title">Oturum aç</string>
-	<string name="profile_authorization_message">Kullanıcı adı ve şifreye gerek kalmadan saniyeler içinde kolayca oturum açın</string>
 	<string name="profile_authorization_error">Üzgünüz, bir hata oluştu. Tekrar oturum açmayı deneyin.</string>
-	<string name="service">Hizmet</string>
-	<string name="atmosphere">Ortam</string>
-	<string name="value_for_money">Fiyat/Fayda</string>
-	<string name="experience">Tecrübe</string>
-	<string name="assortment">Ürün çeşitliliği</string>
-	<string name="expertise">Uzmanlık</string>
-	<string name="equipment">Ekipman</string>
-	<string name="quality">Kalite</string>
 	<string name="dialog_error_storage_title">Depolama alanı erişim sorunu</string>
 	<string name="dialog_error_storage_message">Harici bellek kullanılamıyor, muhtemelen SD Kart çıkarılmış, hasarlı veya dosya sistemi salt okunur. Lütfen kontrol edin ve support\@organicmaps.app adresinden bizimle iletişime geçin</string>
 	<string name="setting_emulate_bad_storage">Bozuk depolama alanını taklit et</string>
-	<string name="directions_finish">Varış konumu</string>
-	<string name="directions_on_foot">%s doğru yürüyün</string>
 	<string name="core_entrance">Giriş</string>
-	<string name="coffee">Kahve</string>
-	<string name="cleanliness">Temizlik</string>
-	<string name="crowdedness">Doluluk</string>
 	<string name="error_enter_correct_name">Lütfen, doğru bir isim girin</string>
 	<string name="bookmarks_groups">Listeler</string>
 	<string name="bookmarks_groups_hide_all">Tümünü gizle</string>
 	<string name="bookmarks_groups_show_all">Tümünü göster</string>
-	<plurals name="bookmarks_places">
-	  <item quantity="other">%d yer imi</item>
-	</plurals>
 	<string name="bookmarks_create_new_group">Yeni liste oluştur</string>
 	<string name="downloader_hide_screen">Ekranı Gizle</string>
 	<string name="downloader_percent">%1$s (%2$s / %3$s)</string>
-	<string name="downloader_process">%s indiriliyor...</string>
-	<string name="downloader_applying">%s uygulanıyor...</string>
-	<string name="dialog_message_transit_not_found_connection">Tek transit bir ağda bir rota planla</string>
+	<string name="downloader_process">%s indiriliyor…</string>
+	<string name="downloader_applying">%s uygulanıyor…</string>
 	<string name="bookmarks_error_message_share_general">Bir uygulama hatasından dolayı paylaşılamıyor</string>
 	<string name="bookmarks_error_title_share_empty">Paylaşma hatası</string>
 	<string name="bookmarks_error_message_share_empty">Boş bir liste paylaşılamaz</string>
@@ -964,12 +602,7 @@
 	<string name="bookmarks_new_list_hint">Yeni liste</string>
 	<string name="bookmarks_error_title_list_name_already_taken">Bu isim zaten alınmış</string>
 	<string name="bookmarks_error_message_list_name_already_taken">Lütfen başka bir isim seçiniz</string>
-	<string name="bookmarks_error_title_list_name_too_long">Bu isim çok uzun</string>
-	<string name="bookmarks_error_message_list_name_too_long">Lütfen başka bir isim seçiniz</string>
-	<string name="please_wait">Lütfen bekle...</string>
-	<string name="phone_number">Telefon numarası</string>
-	<string name="notification_unsent_reviews_title">Birkaç onaylanmamış yorumunuz var</string>
-	<string name="notification_unsent_reviews_message">Diğer gezginlerle yorum paylaşmak için lütfen giriş yapın</string>
+	<string name="please_wait">Lütfen bekle…</string>
 	<string name="profile">OpenStreetMap profil</string>
 	<string name="place_page_search_similar_hotel">Benzer otellerde ara</string>
 	<string name="bookmarks_detect_title">Yeni dosyalar algılandı</string>
@@ -979,31 +612,10 @@
 	<string name="button_convert">Dönüştürmek</string>
 	<string name="bookmarks_convert_error_title">Hata</string>
 	<string name="bookmarks_convert_error_message">Bazı dosyalar dönüştürülmedi.</string>
-	<string name="converting">Dönüştürme...</string>
-	<string name="wn_reinvented_bookmarks_title">Yer imlerini yeniden keşfettik!</string>
-	<string name="wn_reinvented_bookmarks_message">Yer imlerini yedekleyebilir, listeler oluşturabilirsin... Harika...</string>
-	<string name="bookmarks_restore">Yer işaretlerini geri yükle</string>
-	<string name="bookmarks_restore_process">Geri yükleniyor...</string>
 	<string name="bookmarks_restore_title">Bu sürümü geri yükle?</string>
-	<string name="bookmarks_restore_message">Yer işaretleriniz %1$s (%2$s)\'dan geri yüklenecek</string>
-	<string name="bookmarks_restore_empty_title">Yedekleme yok</string>
-	<string name="bookmarks_restore_empty_message">Sunucu daha önce yapılmış yedeklemeyi bulamadı</string>
 	<string name="common_check_internet_connection_dialog_title">İnternet bağlantısı yok</string>
-	<string name="error_server_title">Server hatası</string>
-	<string name="error_server_message">Sunucuda bir hata oluştu, lütfen daha sonra tekrar deneyin</string>
 	<string name="error_system_message">Bilinmeyen bir hata oluştu</string>
 	<string name="restore">Restore</string>
-	<string name="bookmarks_page_downloaded">İndirildi</string>
-	<string name="bookmarks_page_my">Bana ait</string>
-	<string name="routes_and_bookmarks">Rotalar ve yer imleri</string>
-	<string name="bookmarks_webview_success_toast">Yer imleri başarıyla indirildi</string>
-	<string name="cached_bookmarks_placeholder_title">Yeni yerler indirin</string>
-	<string name="cached_bookmarks_placeholder_subtitle">Organic Maps kullanıcılarının oluşturduğu binlerce ilgi çekici yeri ve rotayı indirmek için düğmeye basın. İnternet bağlantınızın olması gerekir.</string>
-	<string name="downloader_download_routers">İndirilen yer imleri</string>
-	<string name="bookmarks_groups_cached">İndirilen listeler</string>
-	<plurals name="bookmarks_objects">
-	  <item quantity="other">%s nesne</item>
-	</plurals>
 	<plurals name="objects">
 	  <item quantity="other">%d yer</item>
 	</plurals>
@@ -1016,62 +628,32 @@
 	<string name="subtittle_opt_out">İzleme ayarları</string>
 	<string name="crash_reports">Kilitlenme raporu</string>
 	<string name="crash_reports_description">Organic Maps deneyimini geliştirmek için verilerinizi kullanabiliriz. Değişiklikler, uygulama yeniden başlatıldıktan sonra geçerli olur.</string>
-	<string name="opt_out_help_ios_1">Mobil cihazınız, “Reklam İzlemeyi Sınırla” veya “İlgiye dayalı reklamcılığı devre dışı bırak” ayarı sunar.</string>
-	<string name="opt_out_help_ios_2">iOS 9 veya Üstü</string>
-	<string name="opt_out_help_ios_3">Ayarlar → Gizlilik → Reklamcılık\'a gidin ve “Reklam İzlemeyi Sınırla” ayarını etkinleştirin</string>
-	<string name="opt_out_help_android">Mobil cihazınız, “Reklam İzlemeyi Sınırla” veya “İlgiye dayalı reklamcılığı devre dışı bırak” ayarı sunar.\n\nAndroid ve Google Play Services 4.0 ve üzeri sürümü için:\nAyarlar → Google → Reklamlar → Reklamları Kişiselleştirme\'yi devre dışı bırak\nAyarlar → Google → Google Hesabı → Kişisel bilgiler ve gizlilik → Reklam Ayarları → Reklamları Kişiselleştirme</string>
 	<string name="privacy_policy">Gizlilik politikası</string>
 	<string name="terms_of_use">Kullanım koşulları</string>
-	<string name="backup_notification_failed">Yer imlerinizin yedeklenmesi işlemi askıya alındı. İşlemi devam ettirmek için oturum açın.</string>
 	<string name="button_layer_traffic">Trafik</string>
 	<string name="button_layer_subway">Metro</string>
 	<string name="layers_title">Harita katmanları</string>
-	<string name="layers_message">Trafik, metro haritası ve diğer kullanışlı bilgileri görüntülemek için harita katmanlarını kullanın</string>
-	<string name="button_layer_got_it">Anladım</string>
 	<string name="subway_data_unavailable">Metro haritası mevcut değil</string>
 	<string name="bookmarks_empty_list_title">Bu liste boş</string>
 	<string name="bookmarks_empty_list_message">Yer imi eklemek için önce haritadaki bir yere sonrasında ise yıldız simgesine dokunun</string>
 	<string name="category_desc_more">…daha fazla</string>
 	<string name="title_error_downloading_bookmarks">Bir hata oluştu</string>
-	<string name="subtitle_error_downloading_bookmarks">Yer imleri indirilmedi</string>
-	<string name="error_already_downloaded">Bu liste zaten indirildi</string>
-	<string name="why_support">Organic Maps\'yi neden desteklemeliyim?</string>
-	<string name="why_support_item2">Organic Maps\'yi geliştirmemize yardımcı oldunuz</string>
-	<string name="why_support_item3">OpenStreetMap.org\'daki açık haritaları geliştirmemize yardımcı oldunuz</string>
-	<string name="channels_map_update">Harita güncellemeleri</string>
-	<string name="server_unavailable_title">Hizmet kullanılamıyor</string>
-	<string name="sharing_options">Paylaşma seçenekleri</string>
 	<string name="export_file">Dosyayı dışa aktar</string>
 	<string name="list_settings">Liste Ayarları</string>
 	<string name="delete_list">Listeyi sil</string>
-	<string name="hide_from_map">Haritadan gizle</string>
 	<string name="public_access">Genel erişim</string>
 	<string name="limited_access">Sınırlı erişim</string>
 	<string name="bookmark_category_name">Kategori</string>
 	<string name="bookmark_category_description_hint">Bir açıklama yazın (metin veya html)</string>
 	<string name="not_shared">Şahsi</string>
-	<string name="direct_link_progress_text">Dosyanız yükleniyor…</string>
-	<string name="direct_link_success">Bağlantı oluşturuldu</string>
-	<string name="send_a_link_btn">Bana bir bağlantı gönder</string>
-	<string name="upload_error_toast">Dosyanızı yüklerken bir hata oluştu</string>
 	<string name="tags_loading_error_subtitle">Etiketler yüklenirken bir hata oluştu, lütfen tekrar deneyin</string>
-	<string name="unable_upload_errorr_title">Dosya yükleme başarısız</string>
-	<string name="unable_upload_error_subtitle_edited">Bu dosya web uygulamasıyla düzenlendi</string>
-	<string name="unable_upload_error_subtitle_broken">Bu dosya bozuk olduğundan yüklenemedi. Lütfen başka bir dosya yükleyin.</string>
-	<string name="contact">İletişim</string>
-	<string name="download_button">İndir</string>
 	<string name="speedcams_alert_title">Hız kameraları</string>
-	<string name="speedcams_alert_subtitle">Hız limitleri hakkında uyar</string>
 	<string name="speedcam_option_auto">Otomatik</string>
 	<string name="speedcam_option_always">Her zaman</string>
 	<string name="speedcam_option_never">Asla</string>
-	<string name="bookmark_description_title">Yer İmi Açıklaması</string>
 	<string name="place_description_title">Yer Açıklaması</string>
 	<!-- this text will be shown in application notification preferences opposite checkbox which enable/disable downloader notifications. Devices on Android 8+ are affected. -->
 	<string name="notification_channel_downloader">Harita indiricisi</string>
-	<string name="share_bookmarks_email_body_link">Merhaba!\n\nİşte yer işaretlerinizi indirebileceğiniz bağlantı: %s. Organic Maps ile listeyi açın ve yolculuğunuzun tadını çıkarın!\n\nUygulamayı indir: https://omaps.app/get?kmz</string>
-	<string name="warning_speedcams_title">%d km/sa hız limitini aştığınızda navigasyon, kameralar hakkında sizi uyaracak</string>
-	<string name="warning_speedcams_subtitle">Lütfen bulunduğunuz ülkenin trafik kurallarına dikkat edin.</string>
 	<string name="speedcams_notice_message">Otomatik - Hız sınırını aşma riski varsa hız kameraları hakkında uyar\nHer zaman - Hız kameraları hakkında her zaman uyar\nAsla - Hız kameraları hakkında hiçbir zaman uyarma</string>
 	<string name="power_managment_title">Güç tasarrufu modu</string>
 	<string name="power_managment_description">Otomatik mod seçildiğinde, uygulama geçerli pil seviyesine bağlı olarak şarj harcayan özellikleri devre dışı bırakmaya başlar</string>
@@ -1079,14 +661,7 @@
 	<string name="power_managment_setting_auto">Otomatik</string>
 	<string name="power_managment_setting_manual_max">Maksimum güç tasarrufu</string>
 	<string name="enable_logging_warning_message">Seçenek tanı amaçlı, günlüğe kaydetmeyi açar. Uygulamayla ilgili sorunları gideren destek ekibimiz için yardımcı olabilir. Bu seçeneği yalnızca Organic Maps desteğinin isteği üzerine etkinleştirin.</string>
-	<string name="html_error_upload_message_try_again">Lütfen ağ ayarlarınızı kontrol edip tekrar deneyin</string>
-	<string name="html_error_upload_title_try_again">İnternet bağlantısı yok</string>
-	<string name="notification_leave_review_v2_android_short_title">İnceleyin ve gezginlere yardım edin!</string>
-	<string name="notifications_illegal_alert_disable_button">Bildirimleri kapat</string>
 	<string name="access_rules_author_only">Çevrimiçi düzenleme</string>
-	<string name="privacy_settings_menu">Gizlilik ayarları</string>
-	<string name="unable_upadate_error_title">Dosya güncellemesi başarısız oldu</string>
-	<string name="unable_upadate_error_message">Güncelleme sırasında bazı hatalar oluştu. Lütfen değişiklikleri kontrol edip tekrar deneyin</string>
 	<string name="driving_options_title">Sürüş seçenekleri</string>
 	<string name="driving_options_subheader">Her rotada kaçının</string>
 	<string name="avoid_tolls">Paralı yollar</string>
@@ -1097,52 +672,14 @@
 	<string name="unable_to_calc_alert_subtitle">Maalesef, muhtemelen belirlediğiniz seçeneklerden dolayı bir rota bulamadık. Lütfen seçenekleri değiştirin ve tekrar deneyin</string>
 	<string name="define_to_avoid_btn">Kaçınılması gereken yolları tanımlayın</string>
 	<string name="change_driving_options_btn">Sürüş seçenekleri etkinleştirildi</string>
-	<string name="toll_road">Paralı yol</string>
-	<string name="unpaved_road">Asfaltsız yol</string>
-	<string name="ferry_crossing">Feribot geçişi</string>
-	<string name="operated_by">\"%s\" tarafından işletiliyor</string>
 	<string name="avoid_toll_roads_placepage">Paralı yollardan kaçın</string>
 	<string name="avoid_unpaved_roads_placepage">Asfaltsız yollardan kaçın</string>
 	<string name="avoid_ferry_crossing_placepage">Feribot geçişlerinden kaçın</string>
-	<string name="type.cuisine.uzbek">Özbek mutfağı</string>
-	<string name="trip_start">Hadi gidelim</string>
-	<string name="pick_destination">Hedef</string>
-	<string name="follow_my_position">Tekrar ortala</string>
-	<string name="search_results">Arama sonuçları</string>
-	<string name="then_turn">Sonra</string>
-	<string name="redirect_route_alert">Yeniden bir rota oluşturmak ister misiniz?</string>
-	<string name="redirect_route_yes">Evet</string>
-	<string name="redirect_route_no">Hayır</string>
-	<string name="trip_finished">Vardınız!</string>
-	<string name="keyboard_availability_alert">Klavye, sürüş sırasında kullanılamaz</string>
-	<string name="dialog_routing_change_start_carplay">Mevcut konumunuzdan rota oluşturulamıyor</string>
-	<string name="dialog_routing_change_end_carplay">Hedefinize rota oluşturulamıyor. Lütfen başka bir nokta seçin</string>
-	<string name="dialog_routing_check_gps_carplay">GPS sinyali yok. Lütfen açık bir alana geçin</string>
-	<string name="dialog_routing_unable_locate_route_carplay">Rota oluşturulamıyor. Lütfen başka bir rota noktası belirtin</string>
-	<string name="dialog_routing_download_files_carplay">Rota oluşturmak için cihazınızdaki eksik haritaları indirin</string>
-	<string name="dialog_routing_system_error_carplay">Hata oluştu. Lütfen uygulamayı yeniden başlatın</string>
-	<string name="dialog_routing_rebuild_from_current_location_carplay">Rota, mevcut konumunuzdan yeniden oluşturulacak</string>
-	<string name="dialog_routing_rebuild_for_vehicle_carplay">Rota, bir arabalı seyahat rotasına dönüştürülecek</string>
 	<string name="ok">Tamam</string>
-	<string name="avoid_unpaved_carplay_1">Stabilizesiz</string>
-	<string name="avoid_unpaved_carplay_2">Asfaltsız hariç</string>
-	<string name="avoid_ferry_carplay_1">Feribotsuz</string>
-	<string name="avoid_ferry_carplay_2">Feribot hariç</string>
-	<string name="avoid_tolls_carplay_1">Paralı yok</string>
-	<string name="avoid_tolls_carplay_2">Paralı hariç</string>
-	<string name="speedcams_alert_title_carplay_1">Hız kamerası</string>
-	<string name="speedcams_alert_title_carplay_2">Hız uyarıları</string>
-	<string name="download_map_carplay">Lütfen haritaları cihazınıza Organic Maps uygulamasından indirin</string>
-	<string name="carplay_roundabout_exit">%s çıkış</string>
 	<!-- max. 10 symbols, both iOS and Android -->
 	<string name="sort">Sırala…</string>
 	<!-- Android, title, max 20-22 symbols -->
 	<string name="sort_bookmarks">Yer imlerini sırala</string>
-	<!-- iOS -->
-	<string name="sort_default">Varsayılana göre sırala</string>
-	<string name="sort_type">Türe göre sırala</string>
-	<string name="sort_distance">Mesafeye göre sırala</string>
-	<string name="sort_date">Tarihe göre sırala</string>
 	<!-- Android -->
 	<string name="by_default">Varsayılana göre</string>
 	<!-- Android -->
@@ -1151,65 +688,23 @@
 	<string name="by_distance">Mesafeye göre</string>
 	<!-- Android -->
 	<string name="by_date">Tarihe göre</string>
-	<string name="week_ago_sorttype">Bir hafta önce</string>
-	<string name="month_ago_sorttype">Bir ay önce</string>
-	<string name="moremonth_ago_sorttype">Bir aydan daha önce</string>
-	<string name="moreyear_ago_sorttype">Bir yıldan daha önce</string>
-	<string name="near_me_sorttype">Bana yakın</string>
-	<string name="others_sorttype">Diğerleri</string>
-	<string name="food_places">Yiyecek</string>
-	<string name="tourist_places">Görülecek yerler</string>
-	<string name="museums">Müzeler</string>
-	<string name="parks">Parklar</string>
-	<string name="swim_places">Yüzme</string>
-	<string name="mountains">Dağlar</string>
-	<string name="animals">Hayvanlar</string>
-	<string name="hotels">Oteller</string>
-	<string name="buildings">Binalar</string>
-	<string name="money">Para</string>
-	<string name="shops">Mağazalar</string>
-	<string name="parkings">Otoparklar</string>
-	<string name="fuel_places">Benzin istasyonları</string>
-	<string name="water">Su</string>
-	<string name="medicine">İlaç</string>
 	<string name="search_in_the_list">Listede ara</string>
-	<string name="view_on_map_bookmarks">Haritada</string>
-	<string name="more_bookmarks">Daha fazla…</string>
-	<string name="no_items_found">Hiç bir öğe bulunamadı</string>
-	<!-- Android, max 18 symbols -->
-	<string name="bookmarks_edit_list">Listeyi düzenle</string>
-	<!-- Android, max 18 symbols -->
-	<string name="bookmarks_delete_list">Listeyi sil</string>
-	<string name="religious_places">Dini yerler</string>
 	<string name="select_list">Liste seç</string>
 	<string name="transit_not_found">Metro navigasyonu bu bölgede henüz mevcut değil</string>
 	<string name="dialog_pedestrian_route_is_long_header">Metro güzergahı bulunamadı</string>
 	<string name="dialog_pedestrian_route_is_long_message">Metro istasyonuna en yakın rotanın başlangıç veya bitiş noktasını seçin</string>
-	<!-- Failed planning SUBWAY route message in navigation view -->
-	<string name="routing_planning_error_subway_special">Metro güzergahı oluşturma hatası</string>
 	<string name="button_layer_isolines">Yükseklikler</string>
-	<string name="tips_map_layers_title_countour">Organic Maps\'de yükseklik çizgileri çevrimdışı!</string>
-	<string name="tips_map_layers_message_countour">Yükseklik çizgileri, doğaya bir gezi planlamanıza ve arazide kaybolmamanıza yardımcı olacaktır</string>
 	<string name="isolines_activation_error_dialog">Yükseklik çizgilerini kullanmak için, istediğiniz arazinin haritasını güncelleyin veya indirin</string>
 	<string name="isolines_location_error_dialog">Bu bölgede henüz yükseklik çizgileri mevcut değil</string>
 	<string name="elevation_profile_diff_level">Zorluk seviyesi</string>
-	<string name="elevation_profile_diff_level_easy">Kolay</string>
-	<string name="elevation_profile_diff_level_moderate">Orta</string>
-	<string name="elevation_profile_diff_level_hard">Karmaşık</string>
 	<string name="elevation_profile_ascent">Tırmanış</string>
 	<string name="elevation_profile_descent">İniş</string>
 	<string name="elevation_profile_minaltitude">Min. rakım</string>
 	<string name="elevation_profile_maxaltitude">Maks. rakım</string>
-	<string name="elevation_profile_m">m</string>
 	<string name="elevation_profile_difficulty">Zorluk</string>
 	<string name="elevation_profile_distance">Mesafe:</string>
-	<string name="elevation_profile_km">km</string>
 	<string name="elevation_profile_time">Süre:</string>
-	<string name="elevation_profile_hours">sa.</string>
-	<string name="elevation_profile_minutes">dk.</string>
 	<string name="isolines_toast_zooms_1_10">Konturları görmek için haritayı büyütün</string>
-	<string name="downloader_updating_ios">Güncelleme</string>
-	<string name="downloader_loading_ios">İndir</string>
 	<string name="key_information_title">Anahtar bilgisi</string>
 	<string name="enable_screen_sleep">Ekranın uyumasına izin ver</string>
 	<!-- Description in preferences -->

--- a/android/res/values-uk/strings.xml
+++ b/android/res/values-uk/strings.xml
@@ -12,15 +12,11 @@
 	<string name="cancel_download">Вiдмiнити завантаження</string>
 	<!-- Button which deletes downloaded country -->
 	<string name="delete">Видалити</string>
-	<!-- Button "do not interrupt download" if user touched actively downloading country -->
-	<string name="do_nothing">Продовжити завантаження</string>
 	<string name="download_maps">Завантажити карти</string>
 	<!-- Settings/Downloader - info for country when download fails -->
 	<string name="download_has_failed">Помилка завантаження. Натисніть, щоб повторити спробу</string>
 	<!-- Settings/Downloader - info for country which started downloading -->
 	<string name="downloading">Завантажується…</string>
-	<!-- Settings/Downloader - size string, only strings different from English should be translated -->
-	<string name="kb">кБ</string>
 	<!-- Choose measurement on first launch alert - choose metric system button -->
 	<string name="kilometres">Кілометри</string>
 	<!-- Leave Review dialog - Review button -->
@@ -36,45 +32,31 @@
 	<string name="core_my_position">Моє місце розташування</string>
 	<!-- Update maps later/Buy pro version later button text -->
 	<string name="later">Не зараз</string>
-	<!-- Don't show some dialog any more -->
-	<string name="never">Не показувати</string>
 	<!-- View and button titles for accessibility -->
 	<string name="search">Пошук</string>
 	<!-- Search box placeholder text -->
 	<string name="search_map">Пошук на картi</string>
-	<!-- Settings/Downloader - info for not downloaded country -->
-	<string name="touch_to_download">Натисніть для завантаження</string>
 	<!-- Settings/Downloader - 3G download warning dialog confirm button -->
 	<string name="use_cellular_data">Так</string>
 	<!-- Location services are disabled by user alert - message -->
 	<string name="location_is_disabled_long_text">Геолокація вимкнена в налаштуваннях пристрою. Будь ласка, увімкніть її для зручного використання програми.</string>
-	<!-- Location Services are not available on the device alert - message -->
-	<string name="device_doesnot_support_location_services">Ваш пристрій не підтримує геолокацію</string>
 	<!-- View and button titles for accessibility -->
 	<string name="zoom_to_country">Показати на мапі</string>
-	<!-- Button text for the button at the center of the screen when the country is not downloaded -->
-	<string name="country_status_download">Завантажити мапу\n(^ ^)</string>
 	<!-- Button text for the button at the center of the screen when the country is not downloaded and the size should not be shown -->
 	<string name="country_status_download_without_size">Завантажити мапу</string>
-	<!-- Button text for the button at the center of the screen when the country is not downloaded -->
-	<string name="country_status_download_without_routing">Завантажити карту\nбез маршрутів (^ ^)</string>
 	<!-- Message to display at the center of the screen when the country download has failed -->
 	<string name="country_status_download_failed">Помилка завантаження</string>
 	<!-- Button text for the button under the country_status_download_failed message -->
 	<string name="try_again">Спробуйте ще раз</string>
 	<string name="about_menu_title">Про програму</string>
-	<string name="downloaded_touch_to_delete">Завантажено (%s), натисніть для видалення</string>
 	<string name="connection_settings">Налаштування підключення</string>
-	<string name="download_mb_or_kb">Завантажити %s</string>
 	<string name="close">Закрити</string>
 	<string name="unsupported_phone">Для роботи програми необхідний апаратно прискорений OpenGL. На жаль, ваш пристрій не підтримується.</string>
 	<string name="download">Завантажити</string>
-	<string name="external_storage_is_not_available">Завантажені карти недоступні</string>
 	<string name="disconnect_usb_cable">Вимкніть USB кабель або вставте SD-карту</string>
 	<string name="not_enough_free_space_on_sdcard">Недостатньо вільного місця на SD карті / в пам\'яті пристрою для використання програми</string>
 	<string name="not_enough_memory">Недостатньо пам\'яті для запуску програми</string>
 	<string name="download_resources">Перш ніж розпочати дозвольте нам завантажити карту світу на ваш пристрій.\nВона потребує %s даних.</string>
-	<string name="getting_position">Oтримуємо розташування</string>
 	<string name="download_resources_continue">Перейти на карту</string>
 	<string name="downloading_country_can_proceed">Поки завантажується %s\nви можете користуватися програмою.</string>
 	<string name="download_country_ask">Завантажити %s?</string>
@@ -87,30 +69,20 @@
 	<string name="download_country_failed">Не вдалося завантажити %s</string>
 	<!-- Add New Bookmark Set dialog title -->
 	<string name="add_new_set">Додати групу</string>
-	<!-- Place Page - Add To Bookmarks button -->
-	<string name="add_to_bookmarks">Зберегти мiтку</string>
 	<!-- Bookmark Color dialog title -->
 	<string name="bookmark_color">Колір мiтки</string>
 	<!-- Add Bookmark Set dialog - hint when set name is empty -->
 	<string name="bookmark_set_name">Назва групи</string>
-	<!-- Bookmark Sets dialog title -->
-	<string name="bookmark_sets">Групи мiток</string>
 	<!-- Bookmarks - dialog title -->
 	<string name="bookmarks">Мітки</string>
-	<!-- Add bookmark dialog - bookmark color -->
-	<string name="color">Колір</string>
 	<!-- Default bookmarks set name -->
 	<string name="core_my_places">Мої Мітки</string>
 	<!-- Add bookmark dialog - bookmark name -->
 	<string name="name">Iм\'я</string>
 	<!-- Editor title above street and house number -->
 	<string name="address">Адреса</string>
-	<!-- Place Page - Remove Pin button -->
-	<string name="remove_pin">Видалити мітку</string>
 	<!-- Add bookmark dialog - bookmark set, Bookmarks dialog - Bookmark set cell -->
 	<string name="set">Група</string>
-	<!-- Text hint in Bookmarks dialog when no any bookmarks are added -->
-	<string name="bookmarks_usage_hint">У вас ще немає мiток.\nНатисніть на будь-яке місце на карті, щоб зберегти мiтку.\nМiтки з інших ресурсів також можна імпортувати для застосунка Organic Maps. Відкрийте файл KML/KMZ із збереженими пінами з почти, Dropbox або інтернет посилання.</string>
 	<!-- Settings button in system menu -->
 	<string name="settings">Налаштування</string>
 	<!-- Header of settings activity where user defines storage path -->
@@ -121,20 +93,10 @@
 	<string name="move_maps">Перемістити карти?</string>
 	<!-- Ask to wait user several minutes (some long process in modal dialog). -->
 	<string name="wait_several_minutes">Це може зайняти кілька хвилин.\nБудь ласка, зачекайте…</string>
-	<!-- Show bookmarks from this category on a map or not -->
-	<string name="visible">Показувати на карті</string>
-	<!-- Toast which is displayed when GPS has been deactivated -->
-	<string name="gps_is_disabled_long_text">GPS вимкнено в налаштуваннях пристрою. Будь ласка, увімкніть його для зручного використання програми.</string>
 	<!-- Measurement units title in settings activity -->
 	<string name="measurement_units">Одиниці виміру</string>
 	<!-- Detailed description of Measurement Units settings button -->
 	<string name="measurement_units_summary">Використовувати милі чи кілометри</string>
-	<!-- Do search in all sources -->
-	<string name="search_mode_all">Всюди</string>
-	<!-- Do search near my position only -->
-	<string name="search_mode_nearme">Поруч</string>
-	<!-- Do search in current viewport only -->
-	<string name="search_mode_viewport">На екрані</string>
 	<!-- Search category for cafes, bars, restaurants -->
 	<string name="eat">Де поїсти</string>
 	<!-- Search category for grocery stores -->
@@ -171,12 +133,8 @@
 	<string name="post">Пошта</string>
 	<!-- Search category -->
 	<string name="police">Міліція</string>
-	<!-- String in search result list, when nothing found -->
-	<string name="no_search_results_found">Результатів не знайдено</string>
 	<!-- Notes field in Bookmarks view -->
 	<string name="description">Примітка</string>
-	<!-- Button text -->
-	<string name="share_by_email">Подiлитися по електронній пошті</string>
 	<!-- Email Subject when sharing bookmarks category -->
 	<string name="share_bookmarks_email_subject">З вами поділилися мiтками Organic Maps</string>
 	<!-- message title of loading file -->
@@ -189,20 +147,10 @@
 	<string name="edit">Редаґувати</string>
 	<!-- Warning message when doing search around current position -->
 	<string name="unknown_current_position">Ваше місце розташування не визначено</string>
-	<!-- Warning message when location country isn't downloaded during search (see also download_location_map_proposal). -->
-	<string name="download_location_country">Завантажити країну вашого поточного місця розташування (%s)</string>
-	<!-- Warning message when viewport country isn't downloaded during search -->
-	<string name="download_viewport_country_to_search">Завантажити країну, в якій ви шукаєте (%s)</string>
 	<!-- Alert message that we can't run Map Storage settings due to some reasons. -->
 	<string name="cant_change_this_setting">Вибачте, налаштування папки з картами зараз недоступні.</string>
 	<!-- Alert message that downloading is in progress. -->
 	<string name="downloading_is_active">Зараз відбувається завантаження країни.</string>
-	<!-- Message that will be shown in alert view, when we ask user to leave review on App Store -->
-	<string name="appStore_message">Сподіваємося, що вам сподобалося користуватися Organic Maps! Якщо так, будь ласка, надайте оцінку програмі або залиште свій відгук на app store. Витративши менше хвилини, ви дійсно нам допоможете. Дякуємо за вашу підтримку!</string>
-	<!-- No, thanks -->
-	<string name="no_thanks">Ні, дякую</string>
-	<!-- Share one specific bookmark using SMS, %1$@ contains om:// and %2$@ https://omaps.app link. @NOTE non-ascii symbols in the link will result in max 70 characters SMS instead of 140. -->
-	<string name="bookmark_share_sms">Моя мітка на карті. Іди %1$s або %2$s</string>
 	<!-- Share my position using SMS, %1$@ contains om:// and %2$@ https://omaps.app link WITHOUT NAME. @NOTE non-ascii symbols in the link will result in max 70 characters SMS instead of 140. -->
 	<string name="my_position_share_sms">Глянь де я зараз. Іди %1$s або %2$s</string>
 	<!-- Subject for emailed bookmark -->
@@ -211,30 +159,16 @@
 	<string name="my_position_share_email_subject">Поглянь на моє поточне місцезнаходження на карті Organic Maps</string>
 	<!-- Share my position using EMail, %1$@ is om:// and %2$@ is https://omaps.app link WITHOUT NAME -->
 	<string name="my_position_share_email">Привіт,\n\nЯ зараз тут: %1$s. Натисни на це посилання %2$s або на це посилання %3$s щоб побачити місце на карті.\n\nДякую.</string>
-	<!-- Android share by Message/SMS button text (including SMS) -->
-	<string name="share_by_message">Подiлитися за допомогою повідомлення</string>
 	<!-- Share button text which opens menu with more buttons, like Message, EMail, Facebook etc. -->
 	<string name="share">Подiлитись</string>
-	<!-- iOS share by Message button text (including SMS) -->
-	<string name="message">Повідомлення</string>
 	<!-- Share by email button text, also used in editor. -->
 	<string name="email">Ел. пошта</string>
-	<!-- Copy Link -->
-	<string name="copy_link">Копіювати посилання</string>
-	<!-- Text for the button that returns to caller application -->
-	<string name="more_info">Докладніше</string>
 	<!-- Text for message when used successfully copied something -->
 	<string name="copied_to_clipboard">Скопіювати в буфер обміну: %1$s</string>
 	<!-- place preview title -->
 	<string name="info">Досьє</string>
 	<!-- Used for bookmark editing -->
 	<string name="done">Готово</string>
-	<!-- Summary for preferences in MWM -->
-	<string name="yopme_pref_summary">Оберіть налаштування заднього екрану</string>
-	<!-- Title for yopme preferences in MWM -->
-	<string name="yopme_pref_title">Налаштування заднього екрану</string>
-	<!-- Hint for upper-right icon p2b -->
-	<string name="show_on_backscreen">Показати на задньому екрані</string>
 	<!-- Prints version number in About dialog -->
 	<string name="version">Версія: %s</string>
 	<!-- Confirmation in downloading countries dialog -->
@@ -244,11 +178,6 @@
 	<!-- Length of track in cell that describes route -->
 	<string name="length">Довжина</string>
 	<string name="share_my_location">Поділитися моїм місцезнаходженням</string>
-	<string name="menu_search">Пошук</string>
-	<!-- Settings screen: "Map" category title -->
-	<string name="prefs_group_map">Карта</string>
-	<!-- Settings screen: "Miscellaneous" category title -->
-	<string name="prefs_group_misc">Інше</string>
 	<string name="prefs_group_route">Навігація</string>
 	<string name="pref_zoom_title">Кнопки трансфокації</string>
 	<string name="pref_zoom_summary">Відображення на екрані</string>
@@ -264,8 +193,6 @@
 	<string name="pref_map_3d_title">Перспективний вид</string>
 	<!-- Settings «Map» category: «3D buildings» title -->
 	<string name="pref_map_3d_buildings_title">Будівлі у 3D</string>
-	<!-- Settings «Map» category: «3D buildings» summary -->
-	<string name="pref_map_3d_buildings_subtitle">Негативно впливає на ресурс акумулятора</string>
 	<!-- Settings «Route» category: «Tts enabled» title -->
 	<string name="pref_tts_enable_title">Голосові інструкції</string>
 	<!-- Settings «Route» category: «Tts language» title -->
@@ -274,7 +201,6 @@
 	<string name="pref_tts_unavailable">Не доступнi</string>
 	<!-- Title for "Other" section in TTS settings. -->
 	<string name="pref_tts_other_section_title">Інша</string>
-	<string name="pref_tts_how_to_set_up_voice">Як налаштувати голосовий контроль</string>
 	<!-- Settings «Map» category: «Record track» title -->
 	<string name="pref_track_record_title">Недавній маршрут</string>
 	<string name="pref_map_auto_zoom">Автозум</string>
@@ -285,46 +211,11 @@
 	<string name="duration_12_hours">12 годин</string>
 	<string name="duration_1_day">1 день</string>
 	<string name="recent_track_help_text">Ця функція дозволяє прокласти подоланий маршрут протягом певного проміжку часу та переглянути його на карті. Звертаємо вашу увагу, що вмикання цієї функції пришвидшить розрядження акумулятора. Щойно сплине заданий проміжок часу, прокладений маршрут буде видалено з карти.</string>
-	<string name="pref_track_ios_caption">Останній маршрут показує пройдену відстань.</string>
-	<string name="pref_track_ios_subcaption">Будь ласка, виберіть проміжок часу для збереження маршруту.</string>
-	<string name="placepage_distance">Відстань</string>
-	<string name="placepage_coordinates">Координати</string>
-	<string name="placepage_unsorted">Без категорії</string>
 	<string name="search_show_on_map">Подивитись на карті</string>
-	<!-- Used to warn user when fixing KitKat issue -->
-	<string name="bookmark_move_fail">Для оптимiзацiї збереження данних нам потрiбно перенести мітки до внутрiшньої пам\'ятi, але там немає вiльного мiсця. Будь ласка, звiльнiть мiсце, бо мітки вам не будуть доступнi.</string>
-	<!-- Used in More Apps menu -->
-	<string name="free">Безкоштовно</string>
-	<!-- Used in More Apps menu -->
-	<string name="buy">Придбати</string>
-	<!-- 1st search button-like result -->
-	<string name="search_on_map">Шукати на карті</string>
-	<!-- toast with an error -->
-	<string name="no_route_found">Маршрути не знайдено</string>
-	<!-- route title -->
-	<string name="route">Маршрут</string>
-	<!-- category title -->
-	<string name="routes">Маршрути</string>
-	<!-- text of notification -->
-	<string name="download_map_notification">Завантажуйте карту тієї місцевості, де ви знаходитесь</string>
-	<!-- text of notification -->
-	<string name="pro_version_is_free_today">Повна версія Organic Maps сьогодні безкоштовна! Завантажуй та розкажи друзям.</string>
-	<!-- Dialog for transferring maps from lite to pro. -->
-	<string name="move_lite_maps_to_pro">Ми переносимо завантажені карти з Organic Maps Lite в Organic Maps. Це може зайняти декілька хвилин.</string>
-	<!-- Message to display when maps moved. -->
-	<string name="move_lite_maps_to_pro_ok">Ваші карти успішно перенесено в Organic Maps.</string>
-	<!-- Message to display when maps move failed. -->
-	<string name="move_lite_maps_to_pro_failed">При переносі карт виникла помилка. Будь ласка, видаліть Organic Maps Lite і завантажте карти знову.</string>
-	<!-- Text in menu -->
-	<string name="settings_and_more">Налаштування</string>
 	<!-- Text in menu -->
 	<string name="website">Вебсайт</string>
-	<!-- Text in menu -->
-	<string name="contact_us">Контакти</string>
 	<!-- Settings: Send feedback button and dialog title -->
 	<string name="feedback">Відгук</string>
-	<!-- Text in menu -->
-	<string name="subscribe_to_news">Email-бюлетень</string>
 	<!-- Text in menu -->
 	<string name="rate_the_app">Оцінити застосунок</string>
 	<!-- Text in menu -->
@@ -333,12 +224,6 @@
 	<string name="copyright">Копірайт</string>
 	<!-- Text in menu -->
 	<string name="report_a_bug">Сповістити про помилку</string>
-	<!-- Email subject -->
-	<string name="subscribe_me_subject">Підпишіть мене на email-розсилку Organic Maps</string>
-	<!-- Email body -->
-	<string name="subscribe_me_body">Я хочу першим дізнаватися про всі новини оновлення програм і акції. Я можу відписатися від розсилки в будь-який момент.</string>
-	<!-- About text -->
-	<string name="about_text">Organic Maps пропонує карти всіх міст, всіх країн світу, які працюють без підключення до інтернету. Подорожуйте з впевненістю: де б ви не були, Organic Maps допоможуть вирішити будь-яку вашу проблему - допоможуть визначити ваше місцезнаходження, знайти ресторан, готель, заправку, банк, туалет і т.д.\n\nМи постійно працюємо над додаванням нових функцій, тому, якщо у вас є ідеї або пропозиції з покращення Organic Maps, пишіть нам. Якщо у вам виникла проблема з програмою, сповістіть нас, будь ласка, про неї. Наш емейл support\@organicmaps.app. Ми відповідаємо на всі листи!\n\nЯкщо вам подобається програма і ви хочете підтримати нас, є декілька простих і абсолютно безкоштовних способів:\n\n- залиште відгук у вашому магазині програм\n- підпишіться на наші новини на сторінці у Facebook http://www.facebook.com/OrganicMaps\n- або просто розкажіть про Organic Maps своїй мамі, друзям і колегам :)\n\nДякуємо за вашу підтримку!\n\nP.S. У програмі ми використовуємо картографічні дані проекту OpenStreetMap, який працює за принципом Вікіпедії, надаючи можливість користувачам зі всього світу створювати і редагувати карти. Якщо ви помітили, що на карті щось не відповідає дійсності або відсутнє, ви можете виправити це прямо на сайті https://www.openstreetmap.org, і ці виправлення з\'являться під час наступного оновлення Organic Maps.</string>
 	<!-- Alert text -->
 	<string name="email_error_body">Поштовий клієнт не налаштований. Налаштуйте його або скористайтеся іншими способами зв\'язку. Наша адреса – %s.</string>
 	<!-- Alert title -->
@@ -347,137 +232,56 @@
 	<string name="pref_calibration_title">Калібрування компаса</string>
 	<!-- Search category -->
 	<string name="wifi">WiFi</string>
-	<!-- Update map suggestion -->
-	<string name="routing_map_outdated">Будь ласка, оновіть карту, щоб прокласти маршрут.</string>
-	<!-- Update maps suggestion -->
-	<string name="routing_update_maps">В новій версії Organic Maps ви зможете прокладати маршрут від поточного місця перебування до точки призначення. Щоб скористатися цією функцією, будь ласка, оновіть карти.</string>
 	<!-- Update all button text -->
 	<string name="downloader_update_all_button">Оновити всі</string>
 	<!-- Cancel all button text -->
 	<string name="downloader_cancel_all">Скасувати всі</string>
 	<!-- Downloaded maps category -->
 	<string name="downloader_downloaded_subtitle">Завантажено</string>
-	<!-- Downloaded maps category -->
-	<string name="downloader_available_maps">Доступні</string>
 	<!-- Country queued for download -->
 	<string name="downloader_queued">В черзі</string>
 	<string name="downloader_near_me_subtitle">Поблизу</string>
 	<string name="downloader_status_maps">Карти</string>
 	<string name="downloader_download_all_button">Завантажити всі</string>
 	<string name="downloader_downloading">Завантажується:</string>
-	<string name="downloader_search_results">Знайдено</string>
-	<!-- Disclaimer message -->
-	<string name="routing_disclaimer">Використовуючи маршрути в програмі Organic Maps, будь ласка, враховуйте наступне:\n\n  - Пропоновані маршрути можуть розглядатися тільки в якості рекомендації.\n - Дорожні умови, правила дорожнього руху, знаки являються більш пріоритетними в порівнянні з порадами навігаційної програми.\n - Карта може бути неточною або неактуальною, а запропонований маршрут не найоптимальнішим.\n\n  Будьте уважні на дорозі та бережіть себе!</string>
-	<!-- Outdated maps category -->
-	<string name="downloader_outdated_maps">Неактуальні</string>
-	<!-- Up to date maps category -->
-	<string name="downloader_uptodate_maps">Оновлені</string>
 	<!-- Status of outdated country in the list -->
 	<string name="downloader_status_outdated">Oновити</string>
 	<!-- Status of failed country in the list -->
 	<string name="downloader_status_failed">Помилка</string>
 	<!-- Displayed in a dialog that appears when a user tries to delete a map while the app is in the follow route mode -->
 	<string name="downloader_delete_map_while_routing_dialog">Щоб видалити карту, будь ласка, зупините навiгацiю.</string>
-	<!-- Show when user try build route, but we don't know where he -->
-	<string name="routing_failed_unknown_my_position">Неможливо прокласти маршрут. Не визначено поточне місцезнаходження.</string>
-	<!-- Show if use has not routing file, or InconsistentMWMandRoute -->
-	<string name="routing_failed_has_no_routing_file">Для прокладання маршруту необхідна додаткова інформація. Перейти до завантаження?</string>
-	<!-- StartPointNotFound -->
-	<string name="routing_failed_start_point_not_found">Неможливо прокласти маршрут. Немає доріг поруч з відправною точкою.</string>
-	<!-- EndPointNotFound -->
-	<string name="routing_failed_dst_point_not_found">Неможливо прокласти маршрут. Немає доріг поруч з пунктом призначення.</string>
 	<!-- PointsInDifferentMWM -->
 	<string name="routing_failed_cross_mwm_building">Маршрут бути прокладений всередині мапи тільки одного регіону.</string>
-	<!-- RouteNotFound -->
-	<string name="routing_failed_route_not_found">Неможливо прокласти маршрут між вибраними точками. Будь ласка, змініть початок і кінець маршруту.</string>
-	<!-- InternalError -->
-	<string name="routing_failed_internal_error">Внутрішня помилка. Будь ласка, видаліть мапу і завантажте її ще раз. Якщо це не допомогло, напишіть нам на support\@organicmaps.app</string>
-	<!-- Context menu item for downloader. -->
-	<string name="downloader_download_map_and_routing">Завантажити карту + маршрути</string>
-	<!-- Context menu item for downloader. -->
-	<string name="downloader_download_routing">Завантажити маршрути</string>
-	<!-- Context menu item for downloader. -->
-	<string name="downloader_delete_routing">Видалити маршрути</string>
 	<!-- Context menu item for downloader. -->
 	<string name="downloader_download_map">Завантажити карту</string>
-	<string name="downloader_download_map_no_routing">Завантажити карту без маршрутів</string>
-	<!-- Button for routing. -->
-	<string name="routing_go">Поїхали!</string>
 	<!-- Item status in downloader. -->
 	<string name="downloader_retry">Повторити</string>
-	<!-- Item in context menu. -->
-	<string name="downloader_map_and_routing">Мапа + Маршрути</string>
 	<!-- Item in context menu. -->
 	<string name="downloader_delete_map">Видалити мапу</string>
 	<!-- Item in context menu. -->
 	<string name="downloader_update_map">Оновити мапу</string>
-	<!-- Item in context menu. -->
-	<string name="downloader_update_map_and_routing">Оновити мапу + Маршрути</string>
-	<!-- Item in context menu. -->
-	<string name="downloader_map_only">Тільки карта</string>
-	<!-- Toolbar title -->
-	<string name="toolbar_application_menu">Меню програми</string>
 	<!-- Preference text -->
 	<string name="pref_use_google_play">Щоб визначити ваше поточне місцезнаходження, використовуйте сервіси Google Play</string>
 	<!-- Text for rating dialog -->
 	<string name="rating_just_rated">Я щойно оцінив вашу програму</string>
-	<!-- Text for rating dialog -->
-	<string name="rating_user_since">Я користувач Organic Maps з %s року</string>
-	<!-- Text for rating dialog -->
-	<string name="rating_do_like_maps">Вам подобається Organic Maps?</string>
-	<!-- Text for rating dialog -->
-	<string name="rating_tap_star">Торкніться зірочки, щоб оцінити нашу програму.</string>
 	<!-- Text for rating dialog -->
 	<string name="rating_thanks">Дякуємо!</string>
 	<!-- Text for rating dialog -->
 	<string name="rating_share_ideas">Діліться будь-якими ідеями чи проблемами, щоб ми могли удосконалюватись.</string>
 	<!-- Text for rating dialog -->
 	<string name="rating_send_feedback">Надіслати відгук</string>
-	<!-- Text for g+ dialog -->
-	<string name="rating_google_plus">Щоб розповісти своїм друзям про програму, клацніть g+.</string>
 	<!-- Text for routing error dialog -->
 	<string name="routing_download_maps_along">Завантажити карти з дороги</string>
-	<!-- Text for routing error dialog -->
-	<string name="routing_download_map">Отримати карту</string>
-	<!-- Text for routing error dialog -->
-	<string name="routing_download_map_and_routing">Завантажте оновлену карту та дані про маршрут, щоб отримати всі можливості Organic Maps.</string>
-	<!-- Text for routing error dialog -->
-	<string name="routing_get_routing_data">Отримати дані про маршрут</string>
-	<!-- Text for routing error dialog -->
-	<string name="routing_get_additional_data">Щоб створювати маршрути від вашого місцезнаходження, потрібно додаткові дані</string>
 	<!-- Text for routing error dialog -->
 	<string name="routing_requires_all_map">Для створення маршруту необхідно щоб всі карти, починаючи від вашого місцезнаходження і до пункту призначення, були завантажені та оновлені.</string>
 	<!-- Text for routing error dialog -->
 	<string name="routing_not_enough_space">Недостатньо місця</string>
-	<!-- Text for routing error dialog -->
-	<string name="routing_download_more_than_avail">Вам треба завантажити %1$s Мб, а доступно лише %2$s Мб.</string>
-	<!-- Text for routing error dialog -->
-	<string name="routing_download_roaming">Ви збираєтесь завантажити %s MB з використанням послуги передачі даних (у роумінгу). Це може потребувати додаткової оплати, в залежності від вашого мобільного оператора та умов використання вашого тарифного плану.</string>
 	<!-- bookmark button text -->
 	<string name="bookmark">мітка</string>
-	<!-- map is not downloaded -->
-	<string name="not_found_map">Карту місця, де ви знаходитеся, не завантажено</string>
 	<!-- location service disabled -->
 	<string name="enable_location_services">Будь ласка, увімкніть геолокацію</string>
-	<!-- download map -->
-	<string name="download_map">Завантажуйте карту тієї місцевості, де ви знаходитесь</string>
-	<!-- download map on iPhone -->
-	<string name="download_map_iphone">Завантажити карту вашого місця розташування на iPhone</string>
-	<!-- clear pin -->
-	<string name="nearby">Поруч</string>
-	<!-- clear pin -->
-	<string name="clear_pin">Очисти мітку</string>
-	<!-- location is undefined -->
-	<string name="undefined_location">Не визначено поточне місцезнаходження.</string>
-	<!-- download country of your location -->
-	<string name="download_country">Завантажити країну вашого місця розташування</string>
-	<!-- download failed -->
-	<string name="download_failed">Не вдалося завантажити</string>
-	<!-- get the map -->
-	<string name="get_the_map">Отримати карту</string>
 	<string name="save">Зберегти</string>
 	<string name="edit_description_hint">Ваше описання (текст або html)</string>
-	<string name="new_group">нова група</string>
 	<string name="create">створити</string>
 	<!-- red color -->
 	<string name="red">Червоний</string>
@@ -495,22 +299,6 @@
 	<string name="brown">Коричневий</string>
 	<!-- pink color -->
 	<string name="pink">Рожевий</string>
-	<!-- deep purple color -->
-	<string name="deep_purple">Темно-пурпуровий</string>
-	<!-- light blue color -->
-	<string name="light_blue">Блакитний</string>
-	<!-- cyan color -->
-	<string name="cyan">Синьо-зелений</string>
-	<!-- teal color -->
-	<string name="teal">Смарагдовий</string>
-	<!-- lime color -->
-	<string name="lime">Лайм</string>
-	<!-- deep orange color -->
-	<string name="deep_orange">Темно-помаранчевий</string>
-	<!-- gray color -->
-	<string name="gray">Сірий</string>
-	<!-- blue gray color -->
-	<string name="blue_gray">Сіро-блакитний</string>
 	<!-- Wi-Fi available -->
 	<string name="WiFi_available">Так</string>
 
@@ -526,10 +314,8 @@
 	<string name="dialog_routing_location_turn_wifi">Будь ласка, перевірте сигнал GPS. Для покращання точності геопозиції увімкніть Wi-Fi.</string>
 	<string name="dialog_routing_location_turn_on">Увімкніть режим визначення геопозиції</string>
 	<string name="dialog_routing_location_unknown_turn_on">Поточну геопозицію не визначено. Для побудови маршруту увімкніть режим визначення геопозиції.</string>
-	<string name="dialog_routing_location_unknown">Поточну геопозицію не визначено.</string>
 	<string name="dialog_routing_download_files">Завантажте необхідні файли</string>
 	<string name="dialog_routing_download_and_update_all">Для побудови маршруту завантажте і обновіть всі карти і файли маршрутів на шляху руху.</string>
-	<string name="dialog_routing_routes_size">Файли маршрутів</string>
 	<string name="dialog_routing_unable_locate_route">Маршрут не знайдено</string>
 	<string name="dialog_routing_cant_build_route">Не вдалося побудувати маршрут.</string>
 	<string name="dialog_routing_change_start_or_end">Будь ласка, змініть початкову або кінцеву точку маршруту.</string>
@@ -544,33 +330,23 @@
 	<string name="dialog_routing_system_error">Системна помилка</string>
 	<string name="dialog_routing_application_error">Не вдалося прокласти маршрут через помилки програми.</string>
 	<string name="dialog_routing_try_again">Спробуйте знову</string>
-	<string name="dialog_routing_send_error">Повідомити про помилку</string>
-	<string name="dialog_routing_if_get_cross_route">Побудувати більш оптимальний маршрут з перетином межі карти?</string>
-	<string name="dialog_routing_cross_route_is_optimal">Маршрут з перетином межі карти більш оптимальний.</string>
 	<string name="not_now">Не зараз</string>
-	<string name="dialog_routing_build_route">Побудувати</string>
 	<string name="dialog_routing_download_and_build_cross_route">Завантажити карту і побудувати більш оптимальний маршрут з перетином межі карти?</string>
 	<string name="dialog_routing_download_cross_route">Для побудови більш оптимального маршруту з перетином межі потрібно завантажити карту.</string>
-	<string name="dialog_routing_cross_route_always">Завжди перетинати цю межу</string>
 
 	<!-- SECTION: Strings for downloading map from search -->
 	<string name="search_without_internet_advertisement">Щоб розпочати пошук та створення маршрутів, будь ласка, завантажте карту і вам більше ніколи не знадобиться інтернет-з’єднання.</string>
 	<string name="search_select_map">Вибрати карту</string>
-	<string name="search_select_other_map">Вибрати іншу карту</string>
 	<!-- «Show» context menu -->
 	<string name="show">Показати</string>
 	<!-- «Hide» context menu -->
 	<string name="hide">Приховати</string>
 	<!-- «Rename» context menu -->
 	<string name="rename">Перейменувати</string>
-	<!-- Bottom sheet: expand button (should be short) -->
-	<string name="bottom_sheet_more">Більше…</string>
 	<!-- Failed planning route message in navigation view -->
 	<string name="routing_planning_error">Збій планування маршруту</string>
 	<!-- Arrive routing message in navigation view -->
 	<string name="routing_arrive">Прибуття в %s</string>
-	<!-- Text for routing::RouterResultCode::FileTooOld dialog. -->
-	<string name="dialog_routing_download_and_update_maps">Для створення маршруту, будь ласка, скачайте та обновіть всі карти за ним.</string>
 	<string name="rate_alert_title">Подобається програма?</string>
 	<string name="rate_alert_default_message">Дякуємо за використання Organic Maps. Будь ласка, дайте їй оцінку. Ваш відгук допоможе нам стати краще.</string>
 	<string name="rate_alert_five_star_message">Ура! Ми теж вас любимо!</string>
@@ -578,24 +354,14 @@
 	<string name="rate_alert_less_than_four_star_message">Є пропозиції щодо того, як ми можемо її вдосконалити?</string>
 	<string name="categories">Категорії</string>
 	<string name="history">Історія</string>
-	<string name="next_turn_then">Потім</string>
 	<string name="closed">Зачинено</string>
-	<string name="back_to">Назад до %s</string>
 	<string name="search_not_found">На жаль, нічого не знайдено.</string>
 	<string name="search_not_found_query">Спробуйте змінити запит.</string>
-	<string name="search_not_found_map">Завантажте карту місцевості на якій шукаєте.</string>
-	<string name="search_not_found_location">Завантажте карту вашого місцезнаходження.</string>
 	<string name="search_history_title">Історія пошуку</string>
 	<string name="search_history_text">Швидкий доступ до недавніх результатів пошуку.</string>
 	<string name="clear_search">Очистити історію пошуку</string>
-	<!-- Title for settings to enable/disable showcase menu button -->
-	<string name="showcase_settings_title">Показати пропозиції</string>
-	<string name="p2p_route_planning">Планування маршруту</string>
 	<string name="p2p_your_location">Ваше місцезнаходження</string>
-	<string name="p2p_from">Пункт відправлення</string>
-	<string name="p2p_to">Пункт призначення</string>
 	<string name="p2p_start">Почати рух</string>
-	<string name="p2p_planning">Плануємо…</string>
 	<string name="p2p_from_here">Звідси</string>
 	<string name="p2p_to_here">Сюди</string>
 	<string name="p2p_only_from_current">Маршрут можна прокласти лише з поточного місцезнаходження.</string>
@@ -615,11 +381,8 @@
 	<string name="editor_hours_closed">Перерва</string>
 	<string name="editor_example_values">Приклади значень</string>
 	<string name="editor_correct_mistake">Виправте помилку</string>
-	<string name="editor_correct_mistake_message">Під час редагування часу роботи ви зробили помилку. Виправте її або перейдіть у простий режим.</string>
 	<string name="editor_add_select_location">Місцезнаходження</string>
 	<string name="editor_done_dialog_1">Ви змінили карту світу. Не приховуйте це! Розкажіть своїм друзям і редагуйте разом.</string>
-	<string name="editor_done_dialog_2">Це ваше друге поліпшення карти. Тепер ви на %d місці в списку редакторів карт. Розкажіть своїм друзям про це.</string>
-	<string name="editor_done_dialog_3">Ви покращили карту, розкажіть своїм друзям про це і редагуйте її разом.</string>
 	<string name="share_with_friends">Поділитися з друзями</string>
 	<string name="editor_report_problem_desription_1">Будь-ласка, напишіть детально про проблему, щоб суспільство OpenStreetMap виправило помилку.</string>
 	<string name="editor_report_problem_desription_2">Або зробіть це самостійно на сайті https://www.openstreetmap.org/</string>
@@ -628,14 +391,7 @@
 	<string name="editor_report_problem_no_place_title">Місце не існує</string>
 	<string name="editor_report_problem_under_construction_title">Зачинено на ремонт</string>
 	<string name="editor_report_problem_duplicate_place_title">Дубльовані місця</string>
-	<string name="first_launch_congrats_title">Organic Maps готовий до роботи</string>
-	<string name="first_launch_congrats_text">Користуйтесь пошуком і навігацією по всьому світу без інтернету і безкоштовно.</string>
-	<string name="migrate_title">Важливо!</string>
-	<!-- Android uses image instead of text. -->
-	<string name="download_all">Завантажити всі</string>
-	<string name="delete_all">Видалити всі</string>
 	<string name="autodownload">Автоматичне завантаження</string>
-	<string name="disable_autodownload">Заборонити автозавантаження</string>
 	<!-- Place Page opening hours text -->
 	<string name="closed_now">Зараз закрито</string>
 	<!-- Place Page opening hours text -->
@@ -644,8 +400,6 @@
 	<string name="day_off_today">Сьогодні зачинено</string>
 	<string name="day_off">Зачинено</string>
 	<string name="today">Сьогодні</string>
-	<string name="sunrise_to_sunset">Від світанку до заходу</string>
-	<string name="sunset_to_sunrise">Від заходу до світанку</string>
 	<string name="add_opening_hours">Додати години роботи</string>
 	<string name="edit_opening_hours">Редагувати години роботи</string>
 	<string name="no_osm_account">Не зареєстровані в OpenStreetMap?</string>
@@ -655,29 +409,13 @@
 	<string name="login">Увійти</string>
 	<string name="password">Пароль</string>
 	<string name="forgot_password">Забули пароль?</string>
-	<!-- Forgot Password dialog title -->
-	<string name="restore_password">Відновити пароль</string>
-	<string name="enter_email_address_to_reset_password">Введіть адресу ел. пошти, яку ви використали під час реєстрації і ми надішлемо вам посилання для відновлення паролю.</string>
-	<string name="reset_password">Змінити пароль</string>
-	<string name="username">Ім\'я користувача</string>
 	<string name="osm_account">Обліковий запис OSM</string>
 	<string name="logout">Вийти</string>
-	<string name="login_and_edit_map_motivation_message">Увійдіть та редагуйте інформацію про об\'єкти на карті, і ми зробимо їх доступними для мільйонів інших користувачів. Давайте зробимо світ кращим разом.</string>
 	<!-- Information text: "Last upload 11.01.2016" -->
 	<string name="last_upload">Остання вiдправка</string>
-	<!-- Motivates user to login/register, title above login buttons. -->
-	<string name="you_have_edited_your_first_object">Ви редагували свій перший об\'єкт!</string>
 	<string name="thank_you">Дякуємо</string>
-	<string name="login_with_google">Увійти за допомогою Google</string>
-	<string name="login_with_openstreetmap">Увійти за допомогою www.openstreetmap.org</string>
 	<string name="edit_place">Редагувати місце</string>
 	<string name="place_name">Назва</string>
-	<!-- title above languages list cells in the editor, below editable name text field. -->
-	<string name="other_languages">Інші мови</string>
-	<!-- small button to open list with names in different languages -->
-	<string name="show_more">Показати більше</string>
-	<!-- small button to close list with names in different languages -->
-	<string name="show_less">Показати менше</string>
 	<string name="add_language">Додати мову</string>
 	<string name="street">Вулиця</string>
 	<!-- Editable House Number text field (in address block). -->
@@ -694,25 +432,16 @@
 	<string name="email_or_username">Ел. пошта або ім\'я користувача</string>
 	<string name="phone">Телефон</string>
 	<string name="please_note">Будь ласка, зверніть увагу</string>
-	<string name="common_no_wifi_dialog">Немає WiFi з’єднання. Ви бажаєте продовжити роботу через мобільний інтернет?</string>
 	<string name="downloader_delete_map_dialog">Разом з мапою будуть видалені й внесені Вами правки на цій мапі.</string>
 	<string name="downloader_update_maps">Оновити мапи</string>
 	<string name="downloader_mwm_migration_dialog">Для побудови маршруту необхідно оновити усі мапи та побудувати маршрут заново.</string>
 	<string name="downloader_search_field_hint">Знайти карту</string>
-	<string name="migration_update_all_button">Оновити всі карти</string>
-	<string name="migration_delete_all_download_current_button">Завантажте поточну карту і видаліть старі</string>
 	<string name="migration_download_error_dialog">Помилка завантаження</string>
 	<string name="common_check_internet_connection_dialog">Будь ласка, перевірте свої налаштування і переконайтеся, що ваш пристрій підлючено до Інтернету.</string>
 	<string name="downloader_no_space_title">Недостатньо місця</string>
 	<string name="downloader_no_space_message">Видаліть непотрібні дані</string>
-	<string name="editor_general_auth_error_dialog">Загальна помилка входу.</string>
 	<string name="editor_login_error_dialog">Виникла помилка при авторизації.</string>
-	<string name="editor_login_failed_dialog">Помилка входу</string>
-	<string name="editor_username_error_dialog">Ім\'я користувача є недійсним</string>
-	<string name="editor_place_edited_dialog">Ви відредагували об’єкт!</string>
-	<string name="editor_login_with_osm">Увійти через OpenStreetMap</string>
 	<string name="editor_profile_changes">Виправлення, що ураховані</string>
-	<string name="editor_profile_unsent_changes">Не відправлено:</string>
 	<string name="editor_focus_map_on_location">Потягніть мапу, щоб вибрати правильне місцезнаходження об’єкту.</string>
 	<string name="editor_add_select_category">Вибрати категорію</string>
 	<string name="editor_add_select_category_popular_subtitle">Популярні</string>
@@ -723,19 +452,14 @@
 	<string name="editor_edit_place_category_title">Категорія</string>
 	<string name="detailed_problem_description">Детальний опис проблеми</string>
 	<string name="editor_report_problem_other_title">Інші проблема</string>
-	<string name="placepage_report_problem_button">Повідомити про проблему</string>
 	<string name="placepage_add_business_button">Додати організацію</string>
 	<string name="whatsnew_editor_message_1">Додати нові місця до карти і редагувати існуючі місця прямо з програми.</string>
-	<string name="whatsnew_editor_message_2">* Organic Maps використовує дані спільноти OpenStreetMap.</string>
 	<string name="dialog_incorrect_feature_position">Змініть розташування</string>
 	<string name="message_invalid_feature_position">Об\'єкт не може перебувати в цьому місцезнаходженні</string>
 	<string name="login_to_make_edits_visible">Увійдіть, щоб ваші зміни побачили інші користувачі.</string>
-	<string name="no_migration_during_navigation">Під час навігації оновлення заборонено.</string>
 	<!-- Error dialog no space -->
 	<string name="migration_no_space_message">Для завантаження потрібно більше вільного місця. Будь ласка, видаліть непотрібні дані.</string>
 	<string name="editor_sharing_title">Я покращив мапи Organic Maps</string>
-	<string name="editor_comment_will_be_sent">Ми обов\'язково відправимо ваш коментар картографам.</string>
-	<string name="editor_unsupported_category_message">Ви додали об\'єкт, категорію якого ми поки що не підтримуємо. У майбутньому він з\'явиться на мапі.</string>
 	<!-- Downloaded 10 **of** 20 <- it is that "of" -->
 	<string name="downloader_of">%1$d з %2$d</string>
 	<string name="download_over_mobile_header">Завантажити за допомогою мобільної мережі?</string>
@@ -753,15 +477,8 @@
 	<string name="editor_detailed_description">Зміни, що ви запропонували, буде відправлено до OpenStreetMap. Опишіть подробиці про об\'єкт, які не можна редагувати у Organic Maps.</string>
 	<string name="editor_more_about_osm">Більше про OpenStreetMap</string>
 	<string name="editor_operator">Володар</string>
-	<string name="editor_tag_description">Вкажіть компанію, організацію або особу, що відповідає за працездатність об\'єкта</string>
-	<string name="editor_no_local_edits_title">Поки що ви не маєте локальних виправлень</string>
-	<string name="editor_no_local_edits_description">Тут відображається кількість запропонованих вами змін на карті, які доступні тільки на вашому пристрою</string>
-	<string name="editor_send_to_osm">Відправити до OSM</string>
-	<string name="editor_remove">Видалити</string>
-	<string name="downloader_my_maps_title">Мої мапи</string>
 	<string name="downloader_no_downloaded_maps_title">Ви не маєте завантажених мап</string>
 	<string name="downloader_no_downloaded_maps_message">Завантажте необхідні мапи, щоб знаходити місця та користуватися навігацією без iнтернету.</string>
-	<string name="downloader_find_place_hint">Знайти місто або країну</string>
 	<!-- Error title that appears after certain time without location. -->
 	<string name="current_location_unknown_title">Продовжити пошук місцезнаходження?</string>
 	<!-- Error that appears after certain time without location. -->
@@ -776,27 +493,10 @@
 	<string name="location_services_disabled_2">2. Клацніть «Місцезнаходження»</string>
 	<!-- iOS Dialog for the case when the location permission is not granted -->
 	<string name="location_services_disabled_3">3. Оберіть \"Під час роботи програми\"</string>
-	<string name="placepage_parking_surface">Відкрите паркування</string>
-	<string name="placepage_parking_multistorey">Багатоповерхове наземне паркування</string>
-	<string name="placepage_parking_underground">Підземне паркування</string>
-	<string name="placepage_parking_rooftop">Паркування на даху будівлі</string>
-	<string name="placepage_parking_sheds">Приватне легке укриття для автомобілів</string>
-	<string name="placepage_parking_carports">Капітальний навіс</string>
-	<string name="placepage_parking_boxes">Гаражний бокс</string>
-	<string name="placepage_parking_pay">Платне</string>
-	<string name="placepage_parking_free">Безкоштовне</string>
-	<string name="placepage_parking_interval">Змінно платне</string>
-	<string name="placepage_entrance_number">№</string>
-	<string name="placepage_entrance_type">Під\'їзд</string>
-	<string name="placepage_flat">кв.</string>
-	<string name="placepage_open_24_7">Цілодобово</string>
 	<string name="meter">м</string>
 	<string name="kilometer">км</string>
-	<string name="kilometers_per_hour">км/год</string>
 	<string name="mile">ми</string>
 	<string name="foot">фут</string>
-	<string name="miles_per_hour">ми/год</string>
-	<string name="day">д</string>
 	<string name="hour">год</string>
 	<string name="minute">хв</string>
 	<string name="placepage_place_description">Опис</string>
@@ -806,46 +506,30 @@
 	<string name="placepage_call_button">Подзвонити</string>
 	<string name="placepage_edit_bookmark_button">Редагувати мiтку</string>
 	<string name="placepage_bookmark_name_hint">Назва мiтки</string>
-	<string name="placepage_personal_notes_hint">Примітка</string>
-	<string name="placepage_delete_bookmark_button">Видалити мiтку</string>
 	<string name="editor_edits_sent_message">Зміни, що ви запропонували, відправлено</string>
 	<string name="editor_comment_hint">Коментар…</string>
 	<string name="editor_reset_edits_message">Скинути усі локальні виправлення?</string>
 	<string name="editor_reset_edits_button">Скинути</string>
 	<string name="editor_remove_place_message">Видалити об\'єкт, що ви додали?</string>
 	<string name="editor_remove_place_button">Видалити</string>
-	<string name="editor_status_sending">Відправка…</string>
 	<string name="editor_place_doesnt_exist">Місце не існує</string>
 	<string name="text_more_button">…більше</string>
 	<!-- Phone number error message -->
 	<string name="error_enter_correct_phone">Введіть правильний номер телефону</string>
 	<string name="error_enter_correct_web">Введіть вірну адресу веб-сайту</string>
 	<string name="error_enter_correct_email">Введіть вірниу адресу електронної пошти</string>
-	<string name="error_enter_correct">Введіть вірне значення</string>
 	<string name="refresh">Обновити</string>
-	<string name="last_update">Останнє оновлення: %s</string>
 	<string name="placepage_add_place_button">Додати на карту</string>
 	<!-- Displayed when saving some edits to the map to warn against publishing personal data -->
 	<string name="editor_share_to_all_dialog_title">Надіслати усім користувачам?</string>
 	<!-- iOS Dialog before publishing the modifications to the public map. -->
 	<string name="editor_share_to_all_dialog_message_1">Переконайтеся, що ви не ввели особисті дані.</string>
 	<string name="editor_share_to_all_dialog_message_2">Якщо при перевірці змін виникнуть питання, ми напишемо вам на email.</string>
-	<string name="navigation_overview_button">огляд</string>
-	<string name="navigation_stop_button">стоп</string>
-	<!-- Text on an empty bookmark page -->
-	<string name="bookmarks_empty_title">Зберегти закладки</string>
-	<string name="bookmarks_empty_message_1">Клацніть по ★, щоб зберегти улюблені місця для швидкого доступу.</string>
-	<string name="bookmarks_empty_message_2">Імпортувати закладки з Mail та web.</string>
-	<string name="bookmarks_empty_message_3">виїзд: %s</string>
-	<!-- Name of the group for booked hotels -->
-	<string name="bookmarks_group_name">Заброньовані готелі</string>
-	<string name="place_page_button_read_descriprion">Прочитати</string>
 	<!-- iOS dialog for the case when recent track recording is on and the app comes back from background -->
 	<string name="recent_track_background_dialog_title">Вимкнути запис нещодавно пройденого шляху?</string>
 	<string name="off_recent_track_background_button">Вимкнути</string>
 	<!-- For sharing via SMS and so on -->
 	<string name="sharing_call_action_look">Подивись,</string>
-	<string name="continue_recent_track_background_button">Продовжити</string>
 	<string name="recent_track_background_dialog_message">Organic Maps використовує вашу геопозицію у фоновому режимі для запису нещодавно пройденого шляху.</string>
 	<!-- Rate on Google Play (Android only) -->
 	<string name="rate_gp">Рейтинг на Google Play</string>
@@ -855,21 +539,11 @@
 	<string name="tell_friends_text">Привіт! Встанови Organic Maps!</string>
 	<!-- About short text (below logo) -->
 	<string name="about_description">Organic Maps — це додаток must-have для мандрівників. У Organic Maps використовуються офлайн-дані OpenStreetMap, які можна редагувати.</string>
-	<!-- Text in menu -->
-	<string name="blog">Блог</string>
 	<string name="general_settings">Загальні налаштування</string>
-	<string name="date">Дата %d</string>
-	<!-- "Report a bug" -> "Generaal Feedback" -> "Something is not working" -->
-	<string name="something_is_not_working">Щось пішло не так</string>
 	<!-- For the first routing -->
 	<string name="accept">Прийняти</string>
 	<!-- For the first routing -->
 	<string name="decline">Відхилити</string>
-	<string name="install_app">Встановити</string>
-	<string name="search_no_results_title">Не знайдено жодного результату</string>
-	<string name="search_no_results_message">Спробуйте пошук за більш узагальненим пошуковим виразом, зменшіть масштаб або скиньте фільтри.</string>
-	<string name="search_no_results_expand_area_button">Зменшити масштаб</string>
-	<string name="search_no_results_reset_button">Скинути фільтри</string>
 	<!-- noun -->
 	<string name="search_in_table">Список</string>
 	<string name="mobile_data_dialog">Використовувати мобільні дані для перегляду докладної інформації?</string>
@@ -881,18 +555,13 @@
 	<string name="mobile_data_option_never">Ніколи</string>
 	<string name="mobile_data_option_ask">Завжди питати</string>
 	<string name="traffic_update_maps_text">Для відображення інформації про трафік необхідно оновити карти.</string>
-	<string name="traffic_outdated">Дані про трафік застаріли.</string>
 	<string name="big_font">Збільшити розмір шрифту на карті</string>
 	<string name="traffic_update_app">Будь ласка, встановіть оновлення Organic Maps</string>
 	<!-- "traffic" as in road congestion -->
 	<string name="traffic_update_app_message">Для відображення даних про трафік оновіть додаток.</string>
 	<!-- "traffic" as in "road congestion" -->
 	<string name="traffic_data_unavailable">Дані про трафік недоступні</string>
-	<!-- Simplified colour scheme for traffic information, fewer colours are used to display traffic jams on the map. The string should be kept as short as possible -->
-	<string name="pref_traffic_simplified_colors_title">Спрощені кольори світлофору</string>
 	<string name="enable_logging">Підтримка журналювання</string>
-	<string name="offline_place_page_more_information">Підключіться до мережі Інтернет, щоб отримати більше інформації про місце.</string>
-	<string name="failed_load_information">Не вдалося завантажити інформацію.</string>
 	<!-- Settings: "Send general feedback" button -->
 	<string name="feedback_general">Загальний відгук</string>
 	<string name="on">Увімкн.</string>
@@ -906,57 +575,26 @@
 	<string name="routing_add_start_point">Вкажіть початкову точку для побудови маршруту</string>
 	<string name="routing_add_finish_point">Вкажіть кінцеву точку для побудови маршруту</string>
 	<string name="button_exit">Вихід</string>
-	<string name="settings_device_memory">Вбудована пам\'ять</string>
-	<string name="settings_card_memory">Карта пам\'яті</string>
-	<string name="settings_storage_available">Доступно: %s</string>
-	<string name="toast_location_permission_denied">Відмовлено у доступі до функції визначення геолокації</string>
-	<string name="button_use">Використовувати</string>
 	<string name="planning_route_manage_route">Редагування маршруту</string>
 	<string name="button_plan">Прокласти маршрут</string>
-	<string name="button_add">Додати</string>
 	<string name="placepage_remove_stop">Видалити</string>
 	<string name="planning_route_remove_title">Перетягніть сюди, щоб видалити</string>
-	<string name="dialog_change_start_point_message">Змінити початкову точку на поточне місцезнаходження?</string>
-	<string name="button_replace">Змінити</string>
 	<string name="placepage_add_stop">Додати зупинку</string>
-	<string name="add_my_position">Додати моє розташування</string>
-	<string name="choose_start_point">Вибрати відправну точку</string>
-	<string name="choose_destination">Вибрати пункт призначення</string>
 	<string name="preloader_viator_button">Докладніше</string>
-	<string name="start_from_my_position">Почати з</string>
-	<string name="profile_authorization_title">Увійти за допомогою</string>
-	<string name="profile_authorization_message">Швидкий вхід без логіна та пароля за кілька секунд</string>
 	<string name="profile_authorization_error">Ой, трапилася помилка. Спробуйте ввійти знову.</string>
-	<string name="service">Обслуговування</string>
-	<string name="atmosphere">Атмосфера</string>
-	<string name="value_for_money">Співвідношення ціна/якість</string>
-	<string name="experience">Загальне враження</string>
-	<string name="assortment">Асортимент</string>
-	<string name="expertise">Досвід співробітників</string>
-	<string name="equipment">Обладнання</string>
-	<string name="quality">Якість</string>
 	<string name="dialog_error_storage_title">Не вдалося отримати доступ до сховища</string>
 	<string name="dialog_error_storage_message">Зовнішнє сховище не доступно. Ймовірно, SD-картку пам\'яті було вилучено, пошкоджено, або система файлів доступна тільки для читання. Будь ласка, перевірте та зв\'яжіться з нами, написавши на адресу електронну пошту support\@organicmaps.app</string>
 	<string name="setting_emulate_bad_storage">Емулювати проблемне сховище</string>
-	<string name="directions_finish">Напрямок</string>
-	<string name="directions_on_foot">Піша прогулянка %s</string>
 	<string name="core_entrance">Вхід</string>
-	<string name="coffee">Кава</string>
-	<string name="cleanliness">Чистота</string>
-	<string name="crowdedness">Завантаженість</string>
 	<string name="error_enter_correct_name">Будь ласка, введіть коректне ім\'я</string>
 	<string name="bookmarks_groups">Списки</string>
 	<string name="bookmarks_groups_hide_all">Приховати всі</string>
 	<string name="bookmarks_groups_show_all">Показати всі</string>
-	<plurals name="bookmarks_places">
-	  <item quantity="other">%d закладок</item>
-	</plurals>
 	<string name="bookmarks_create_new_group">Створити новий список</string>
 	<string name="downloader_hide_screen">Приховати екран</string>
 	<string name="downloader_percent">%1$s (%2$s з %3$s)</string>
-	<string name="downloader_process">Завантаження %s...</string>
-	<string name="downloader_applying">Застосування %s...</string>
-	<string name="dialog_message_transit_not_found_connection">Плануйте маршрут в межах однієї транзитної мережі</string>
+	<string name="downloader_process">Завантаження %s…</string>
+	<string name="downloader_applying">Застосування %s…</string>
 	<string name="bookmarks_error_message_share_general">Неможливо поділитися через помилку програми</string>
 	<string name="bookmarks_error_title_share_empty">Помилка обміну</string>
 	<string name="bookmarks_error_message_share_empty">Неможливо поділитися пустим списком</string>
@@ -965,48 +603,22 @@
 	<string name="bookmarks_new_list_hint">Новий список</string>
 	<string name="bookmarks_error_title_list_name_already_taken">Це ім\'я вже зайнято</string>
 	<string name="bookmarks_error_message_list_name_already_taken">Виберіть інше ім\'я</string>
-	<string name="bookmarks_error_title_list_name_too_long">Це ім\'я задовге</string>
-	<string name="bookmarks_error_message_list_name_too_long">Виберіть інше ім\'я</string>
-	<string name="please_wait">Будь ласка, зачекайте...</string>
-	<string name="phone_number">Номер телефону</string>
-	<string name="notification_unsent_reviews_title">У вас є невідправлені відгуки</string>
-	<string name="notification_unsent_reviews_message">Будь ласка, увійдіть, щоб поділитися своїми відгуками з іншими мандрівниками</string>
+	<string name="please_wait">Будь ласка, зачекайте…</string>
 	<string name="profile">Профіль OpenStreetMap</string>
 	<string name="place_page_search_similar_hotel">Шукати схожі готелі</string>
 	<string name="bookmarks_detect_title">Виявлено нові файли</string>
 	<plurals name="bookmarks_detect_message">
 	  <item quantity="one">%d файл був знайдений. Ви побачите його після перетворення.</item>
-	  <item quantity="two">%d файлу були знайдені. Ви побачите їх після конвертації.</item>
 	  <item quantity="other">%d файлів було знайдено. Ви побачите їх після конвертації.</item>
+	  <item quantity="two">%d файлу були знайдені. Ви побачите їх після конвертації.</item>
 	</plurals>
 	<string name="button_convert">Конвертувати</string>
 	<string name="bookmarks_convert_error_title">Помилка</string>
 	<string name="bookmarks_convert_error_message">Деякі файли не конвертувалися.</string>
-	<string name="converting">Конвертація...</string>
-	<string name="wn_reinvented_bookmarks_title">Ми переізобрел мітки!</string>
-	<string name="wn_reinvented_bookmarks_message">Ви можете зробити резервне копіювання міток, створити списки. А як круто вони виглядають на карті!</string>
-	<string name="bookmarks_restore">Відновити закладки</string>
-	<string name="bookmarks_restore_process">Відновлення...</string>
 	<string name="bookmarks_restore_title">Відновити цю версію?</string>
-	<string name="bookmarks_restore_message">Ваші закладки відновлюватимуться з %1$s (%2$s)</string>
-	<string name="bookmarks_restore_empty_title">У вас немає резервної копії</string>
-	<string name="bookmarks_restore_empty_message">Сервер не знайшов раніше створені резервні копії</string>
 	<string name="common_check_internet_connection_dialog_title">Нема інтернет з\'єднання</string>
-	<string name="error_server_title">Помилка серверу</string>
-	<string name="error_server_message">На сервері сталася помилка. Повторіть спробу пізніше</string>
 	<string name="error_system_message">Виникла невідома помилка</string>
 	<string name="restore">Відновити</string>
-	<string name="bookmarks_page_downloaded">Завантажені</string>
-	<string name="bookmarks_page_my">Мої</string>
-	<string name="routes_and_bookmarks">Маршрути та позначки</string>
-	<string name="bookmarks_webview_success_toast">Мітки успішно завантажені</string>
-	<string name="cached_bookmarks_placeholder_title">Завантажте нові місця</string>
-	<string name="cached_bookmarks_placeholder_subtitle">Натисніть кнопку, щоб завантажити тисячі цікавих місць і маршрутів, створених користувачами Organic Maps. Вам знадобиться підключення до Інтернету.</string>
-	<string name="downloader_download_routers">Завантажити позначки</string>
-	<string name="bookmarks_groups_cached">Завантажені списки</string>
-	<plurals name="bookmarks_objects">
-	  <item quantity="other">%s об’єкт</item>
-	</plurals>
 	<plurals name="objects">
 	  <item quantity="other">%d місце</item>
 	</plurals>
@@ -1019,62 +631,32 @@
 	<string name="subtittle_opt_out">Налаштування супроводу</string>
 	<string name="crash_reports">Звіти про помилки</string>
 	<string name="crash_reports_description">Ми можемо використовувати ваші дані, щоб розвивати та покращувати Organic Maps. Зміни вступлять у силу після перезапуску програми</string>
-	<string name="opt_out_help_ios_1">Ви можете відмовитися від отримання цільової реклами в налаштуваннях пристрою.</string>
-	<string name="opt_out_help_ios_2">iOS 9 або вище</string>
-	<string name="opt_out_help_ios_3">Відкрийте Налаштування → Конфіденційність → Реклама → Увімкніть «Обмеження трекінгу»</string>
-	<string name="opt_out_help_android">Ви можете відмовитися від отримання цільової реклами в налаштуваннях пристрою.\ nAndroid і Google Play Сервіси 4.0 і вище\n\nНалаштування телефону → Google → Реклама → Відключити персоналізацію реклами\ nабо\ nНалаштування телефону → Google → Акаунт Google → Конфіденційність → Налаштування рекламних переваг → персоналізація реклами</string>
 	<string name="privacy_policy">Політика конфіденційності</string>
 	<string name="terms_of_use">Умови використання</string>
-	<string name="backup_notification_failed">Резервне копіювання позначок було призупинено. Увійдіть, щоб увімкнути резервне копіювання.</string>
 	<string name="button_layer_traffic">Затор</string>
 	<string name="button_layer_subway">Метрополітен</string>
 	<string name="layers_title">Зображення карти</string>
-	<string name="layers_message">Включайте зображення на карті для відображення дорожнього стану, схеми метрополітену або іншої корисної інформації</string>
-	<string name="button_layer_got_it">Зрозуміло</string>
 	<string name="subway_data_unavailable">Карта метрополітену недоступна</string>
 	<string name="bookmarks_empty_list_title">Список порожній</string>
 	<string name="bookmarks_empty_list_message">Щоб додати нову позначку, натисніть на значок зірочки в картці об’єкта</string>
 	<string name="category_desc_more">…ще</string>
 	<string name="title_error_downloading_bookmarks">Виникла помилка</string>
-	<string name="subtitle_error_downloading_bookmarks">Позначки не були завантажені</string>
-	<string name="error_already_downloaded">Цей список вже завантажений</string>
-	<string name="why_support">Навіщо підтримувати Organic Maps?</string>
-	<string name="why_support_item2">Ви допомагаєте нам покращувати Organic Maps</string>
-	<string name="why_support_item3">Ви допомагаєте нам покращувати карти OpenStreetMap.org</string>
-	<string name="channels_map_update">Оновлення карт</string>
-	<string name="server_unavailable_title">Сервер недоступний</string>
-	<string name="sharing_options">Налаштування доступу</string>
 	<string name="export_file">Експортувати файл</string>
 	<string name="list_settings">Налаштування списку</string>
 	<string name="delete_list">Видалити список</string>
-	<string name="hide_from_map">Приховати з карти</string>
 	<string name="public_access">Публічний доступ</string>
 	<string name="limited_access">Приватний доступ</string>
 	<string name="bookmark_category_name">Категорія</string>
 	<string name="bookmark_category_description_hint">Додайте опис (текст чи html)</string>
 	<string name="not_shared">Особистий</string>
-	<string name="direct_link_progress_text">Завантажуємо ваш файл…</string>
-	<string name="direct_link_success">Посилання створено</string>
-	<string name="send_a_link_btn">Надіслати посилання</string>
-	<string name="upload_error_toast">Під час завантаження файлу сталася помилка</string>
 	<string name="tags_loading_error_subtitle">Під час завантаження тегів сталася помилка, будь ласка, спробуйте ще раз</string>
-	<string name="unable_upload_errorr_title">Не вдалося завантажити файл</string>
-	<string name="unable_upload_error_subtitle_edited">Файл було відредаговано через веб-застосунок</string>
-	<string name="unable_upload_error_subtitle_broken">Файл пошкоджено та не може бути завантажений. Прохання завантажити інший файл.</string>
-	<string name="contact">Написати</string>
-	<string name="download_button">Завантажити</string>
 	<string name="speedcams_alert_title">Камери швидкості</string>
-	<string name="speedcams_alert_subtitle">Попереджати про обмеження швидкості</string>
 	<string name="speedcam_option_auto">Авто</string>
 	<string name="speedcam_option_always">Завжди</string>
 	<string name="speedcam_option_never">Ніколи</string>
-	<string name="bookmark_description_title">Опис мітки</string>
 	<string name="place_description_title">Опис місця</string>
 	<!-- this text will be shown in application notification preferences opposite checkbox which enable/disable downloader notifications. Devices on Android 8+ are affected. -->
 	<string name="notification_channel_downloader">Завантаження мап</string>
-	<string name="share_bookmarks_email_body_link">Вітаємо!\n\nВаші мітки можна завантажити за посиланням: %s. Відкривайте список за допомогою Organic Maps та насолоджуйтесь подорожжю!\n\nЗавантажити додаток: https://omaps.app/get?kmz</string>
-	<string name="warning_speedcams_title">Навігатор вас попередить про камери при перевищенні швидкісного режиму на %d км/г</string>
-	<string name="warning_speedcams_subtitle">Не забудьте ознайомитися з правилами дорожнього руху у країні подорожі.</string>
 	<string name="speedcams_notice_message">Авто - Попереджати про камери швидкості, якщо є ризик перевищення швидкісного ліміту\nЗавжди - Завжди попереджати про камери\nНіколи - Ніколи не попереджати про камери</string>
 	<string name="power_managment_title">Режим енергозбереження</string>
 	<string name="power_managment_description">Якщо увімкнено режим енергозбереження, додаток буде відключати енерговитратні функції в залежності від поточного заряду телефону</string>
@@ -1082,14 +664,7 @@
 	<string name="power_managment_setting_auto">Автоматично</string>
 	<string name="power_managment_setting_manual_max">Максимальне енергозбереження</string>
 	<string name="enable_logging_warning_message">Дана опція вмикається для логування дій з метою діагностики. Це допомагає команді виявити проблеми з додатком. Тимчасово включайте цю настройку тільки для відправки детальної інформації про знайдену вами проблему в додатку.</string>
-	<string name="html_error_upload_message_try_again">Перевірте доступ до мережі та спробуйте ще раз</string>
-	<string name="html_error_upload_title_try_again">Немає з’єднання з Інтернетом</string>
-	<string name="notification_leave_review_v2_android_short_title">Залишайте відгук і допомагайте мандрівникам!</string>
-	<string name="notifications_illegal_alert_disable_button">Вимкнути сповіщення</string>
 	<string name="access_rules_author_only">Редагується онлайн</string>
-	<string name="privacy_settings_menu">Налаштування конфіденційності</string>
-	<string name="unable_upadate_error_title">Не вдалося оновити маршрут</string>
-	<string name="unable_upadate_error_message">Виникли помилки під час оновлення. Перевірте зміни та спробуйте ще раз</string>
 	<string name="driving_options_title">Налаштування об’їзду</string>
 	<string name="driving_options_subheader">Уникати в кожному маршруті</string>
 	<string name="avoid_tolls">Платні дороги</string>
@@ -1100,52 +675,14 @@
 	<string name="unable_to_calc_alert_subtitle">На жаль, ми не змогли побудувати маршрут з вибраними опціями. Змініть налаштування та спробуйте ще раз</string>
 	<string name="define_to_avoid_btn">Налаштувати шляхи об’їзду</string>
 	<string name="change_driving_options_btn">Увімкнено налаштування об’їзду</string>
-	<string name="toll_road">Платна дорога</string>
-	<string name="unpaved_road">Ґрунтова дорога</string>
-	<string name="ferry_crossing">Поромна переправа</string>
-	<string name="operated_by">Керується \"%s\"</string>
 	<string name="avoid_toll_roads_placepage">Уникати платних доріг</string>
 	<string name="avoid_unpaved_roads_placepage">Уникати ґрунтових доріг</string>
 	<string name="avoid_ferry_crossing_placepage">Уникати поромних переправ</string>
-	<string name="type.cuisine.uzbek">Узбецька кухня</string>
-	<string name="trip_start">Поїхали</string>
-	<string name="pick_destination">Ціль</string>
-	<string name="follow_my_position">Відцентрувати</string>
-	<string name="search_results">Результати пошуку</string>
-	<string name="then_turn">Далі</string>
-	<string name="redirect_route_alert">Бажаєте перебудувати маршрут?</string>
-	<string name="redirect_route_yes">Так</string>
-	<string name="redirect_route_no">Ні</string>
-	<string name="trip_finished">Ви прибули!</string>
-	<string name="keyboard_availability_alert">Клавіатура недоступна під час руху</string>
-	<string name="dialog_routing_change_start_carplay">Неможливо побудувати маршрут від поточного місця розташування</string>
-	<string name="dialog_routing_change_end_carplay">Неможливо побудувати маршрут до кінцевої точки. Оберіть іншу</string>
-	<string name="dialog_routing_check_gps_carplay">Немає сигналу GPS. Перейдіть на відкриту місцевість</string>
-	<string name="dialog_routing_unable_locate_route_carplay">Неможливо побудувати маршрут. Оберіть інші точки маршруту</string>
-	<string name="dialog_routing_download_files_carplay">Щоб побудувати маршрут, завантажте відсутні карти на своєму пристрої</string>
-	<string name="dialog_routing_system_error_carplay">Виникла помилка. Перезапустіть додаток</string>
-	<string name="dialog_routing_rebuild_from_current_location_carplay">Маршрут буде перебудовано від вашого поточного місця розташування</string>
-	<string name="dialog_routing_rebuild_for_vehicle_carplay">Маршрут буде змінено на автомобільний</string>
 	<string name="ok">Ок</string>
-	<string name="avoid_unpaved_carplay_1">Без ґрунт.</string>
-	<string name="avoid_unpaved_carplay_2">Без ґрунтових</string>
-	<string name="avoid_ferry_carplay_1">Без поромів</string>
-	<string name="avoid_ferry_carplay_2">Без поромів</string>
-	<string name="avoid_tolls_carplay_1">Без платних</string>
-	<string name="avoid_tolls_carplay_2">Без платних</string>
-	<string name="speedcams_alert_title_carplay_1">Камери</string>
-	<string name="speedcams_alert_title_carplay_2">Інфо о камерах</string>
-	<string name="download_map_carplay">Завантажте карти в додатку Organic Maps на своєму пристрої</string>
-	<string name="carplay_roundabout_exit">%s з’їзд</string>
 	<!-- max. 10 symbols, both iOS and Android -->
 	<string name="sort">Сортувати</string>
 	<!-- Android, title, max 20-22 symbols -->
 	<string name="sort_bookmarks">Сортувати мітки</string>
-	<!-- iOS -->
-	<string name="sort_default">Сортувати за промовчанням</string>
-	<string name="sort_type">Сортувати за типом</string>
-	<string name="sort_distance">Сортувати за відстанню</string>
-	<string name="sort_date">Сортувати за датою</string>
 	<!-- Android -->
 	<string name="by_default">За промовчанням</string>
 	<!-- Android -->
@@ -1154,65 +691,23 @@
 	<string name="by_distance">За відстанню</string>
 	<!-- Android -->
 	<string name="by_date">За датою</string>
-	<string name="week_ago_sorttype">Тиждень тому</string>
-	<string name="month_ago_sorttype">Місяць тому</string>
-	<string name="moremonth_ago_sorttype">Понад місяць тому</string>
-	<string name="moreyear_ago_sorttype">Понад рік тому</string>
-	<string name="near_me_sorttype">Поруч зі мною</string>
-	<string name="others_sorttype">Інші</string>
-	<string name="food_places">Їжа</string>
-	<string name="tourist_places">Пам’ятки</string>
-	<string name="museums">Музеї</string>
-	<string name="parks">Парки</string>
-	<string name="swim_places">Плавання</string>
-	<string name="mountains">Гори</string>
-	<string name="animals">Тварини</string>
-	<string name="hotels">Готелі</string>
-	<string name="buildings">Будівлі</string>
-	<string name="money">Гроші</string>
-	<string name="shops">Магазини</string>
-	<string name="parkings">Парковки</string>
-	<string name="fuel_places">Заправки</string>
-	<string name="water">Вода</string>
-	<string name="medicine">Медицина</string>
 	<string name="search_in_the_list">Шукати в списку</string>
-	<string name="view_on_map_bookmarks">На карті</string>
-	<string name="more_bookmarks">Ще…</string>
-	<string name="no_items_found">Нічого не знайдено</string>
-	<!-- Android, max 18 symbols -->
-	<string name="bookmarks_edit_list">Редагувати</string>
-	<!-- Android, max 18 symbols -->
-	<string name="bookmarks_delete_list">Видалити список</string>
-	<string name="religious_places">Святі місця</string>
 	<string name="select_list">Обрати список</string>
 	<string name="transit_not_found">Навігація на метро ще недоступна в цьому регіоні</string>
 	<string name="dialog_pedestrian_route_is_long_header">Маршрут метро не знайдено</string>
 	<string name="dialog_pedestrian_route_is_long_message">Виберіть початкову чи кінцеву точку маршруту ближче до станції метро</string>
-	<!-- Failed planning SUBWAY route message in navigation view -->
-	<string name="routing_planning_error_subway_special">Не вдалося прокласти маршрут метро</string>
 	<string name="button_layer_isolines">Висоти</string>
-	<string name="tips_map_layers_title_countour">Лінії висот офлайн у Organic Maps!</string>
-	<string name="tips_map_layers_message_countour">Лінії висот допоможуть спланувати подорож на природу та не загубитися на місцевості</string>
 	<string name="isolines_activation_error_dialog">Щоб скористатися лініями висот, оновіть чи завантажте карту потрібної місцевості</string>
 	<string name="isolines_location_error_dialog">Лінії висот ще недоступні в цьому регіоні</string>
 	<string name="elevation_profile_diff_level">Рівень складності</string>
-	<string name="elevation_profile_diff_level_easy">Простий</string>
-	<string name="elevation_profile_diff_level_moderate">Помірний</string>
-	<string name="elevation_profile_diff_level_hard">Складний</string>
 	<string name="elevation_profile_ascent">Підйом</string>
 	<string name="elevation_profile_descent">Спуск</string>
 	<string name="elevation_profile_minaltitude">Мін. висота</string>
 	<string name="elevation_profile_maxaltitude">Макс. висота</string>
-	<string name="elevation_profile_m">м</string>
 	<string name="elevation_profile_difficulty">Складність</string>
 	<string name="elevation_profile_distance">Відст.:</string>
-	<string name="elevation_profile_km">км</string>
 	<string name="elevation_profile_time">Шлях:</string>
-	<string name="elevation_profile_hours">год.</string>
-	<string name="elevation_profile_minutes">хв</string>
 	<string name="isolines_toast_zooms_1_10">Збільште карту, щоб побачити ізолінії</string>
-	<string name="downloader_updating_ios">Оновлення</string>
-	<string name="downloader_loading_ios">Завантаження</string>
 	<string name="key_information_title">Ключова інформація</string>
 	<string name="enable_screen_sleep">Allow screen to sleep</string>
 	<!-- Description in preferences -->

--- a/android/res/values-vi/strings.xml
+++ b/android/res/values-vi/strings.xml
@@ -12,15 +12,11 @@
 	<string name="cancel_download">Huỷ bỏ Tải xuống</string>
 	<!-- Button which deletes downloaded country -->
 	<string name="delete">Xóa</string>
-	<!-- Button "do not interrupt download" if user touched actively downloading country -->
-	<string name="do_nothing">Tiếp tục</string>
 	<string name="download_maps">Tải xuống Bản đồ</string>
 	<!-- Settings/Downloader - info for country when download fails -->
 	<string name="download_has_failed">Tải xuống thất bại, hãy chạm lại để thử một lần nữa</string>
 	<!-- Settings/Downloader - info for country which started downloading -->
 	<string name="downloading">Đang tải xuống…</string>
-	<!-- Settings/Downloader - size string, only strings different from English should be translated -->
-	<string name="kb">kB</string>
 	<!-- Choose measurement on first launch alert - choose metric system button -->
 	<string name="kilometres">Kilômét</string>
 	<!-- Leave Review dialog - Review button -->
@@ -35,45 +31,31 @@
 	<string name="core_my_position">Vị trí của Tôi</string>
 	<!-- Update maps later/Buy pro version later button text -->
 	<string name="later">Để sau</string>
-	<!-- Don't show some dialog any more -->
-	<string name="never">Không bao giờ</string>
 	<!-- View and button titles for accessibility -->
 	<string name="search">Tìm kiếm</string>
 	<!-- Search box placeholder text -->
 	<string name="search_map">Tìm kiếm Bản đồ</string>
-	<!-- Settings/Downloader - info for not downloaded country -->
-	<string name="touch_to_download">Chạm để tải xuống</string>
 	<!-- Settings/Downloader - 3G download warning dialog confirm button -->
 	<string name="use_cellular_data">Có</string>
 	<!-- Location services are disabled by user alert - message -->
 	<string name="location_is_disabled_long_text">Bạn hiện đang tắt tất cả Dịch vụ Định vị cho thiết bị hoặc ứng dụng này. Bạn vui lòng bật lại chúng trong Thiết lập.</string>
-	<!-- Location Services are not available on the device alert - message -->
-	<string name="device_doesnot_support_location_services">Thiết bị của bạn không hỗ trợ Dịch vụ Định vị</string>
 	<!-- View and button titles for accessibility -->
 	<string name="zoom_to_country">Hiển thị trên bản đồ</string>
-	<!-- Button text for the button at the center of the screen when the country is not downloaded -->
-	<string name="country_status_download">Tải xuống Bản đồ\n(^ ^)</string>
 	<!-- Button text for the button at the center of the screen when the country is not downloaded and the size should not be shown -->
 	<string name="country_status_download_without_size">Tải xuống Bản đồ</string>
-	<!-- Button text for the button at the center of the screen when the country is not downloaded -->
-	<string name="country_status_download_without_routing">Tải về bản đồ không\ncó chỉ đường (^ ^)</string>
 	<!-- Message to display at the center of the screen when the country download has failed -->
 	<string name="country_status_download_failed">Tải xuống đã thất bại</string>
 	<!-- Button text for the button under the country_status_download_failed message -->
 	<string name="try_again">Thử lại</string>
 	<string name="about_menu_title">Giới thiệu về Organic Maps</string>
-	<string name="downloaded_touch_to_delete">Đã tải xuống (%s), chạm để xóa</string>
 	<string name="connection_settings">Thiết lập Kết nối</string>
-	<string name="download_mb_or_kb">Tải xuống %s</string>
 	<string name="close">Đóng</string>
 	<string name="unsupported_phone">Cần có OpenGL được tăng tốc phần cứng. Thật không may, thiết bị của bạn không được hỗ trợ.</string>
 	<string name="download">Tải xuống</string>
-	<string name="external_storage_is_not_available">Không hỗ trợ lưu trữ trên thẻ SD/USB với các bản đồ được tải xuống</string>
 	<string name="disconnect_usb_cable">Bạn vui lòng tháo cáp USB hoặc lắp thẻ nhớ vào để sử dụng Organic Maps</string>
 	<string name="not_enough_free_space_on_sdcard">Bạn vui lòng giải phóng dung lượng trên ổ lưu trữ thẻ SD/USB để có thể sử dụng ứng dụng</string>
 	<string name="not_enough_memory">Không đủ bộ nhớ để chạy ứng dụng</string>
 	<string name="download_resources">Trước khi bạn bắt đầu, hãy để chúng tôi tải bản đồ thế giới vào thiết bị của bạn.\nBản đồ này cần %s dữ liệu.</string>
-	<string name="getting_position">Đang tìm vị trí hiện tại</string>
 	<string name="download_resources_continue">Đến Bản đồ</string>
 	<string name="downloading_country_can_proceed">Đang tải xuống %s. Bây giờ bạn đã có thể\nvào bản đồ.</string>
 	<string name="download_country_ask">Tải xuống %s?</string>
@@ -86,30 +68,20 @@
 	<string name="download_country_failed">%s - descărcarea a eșuat</string>
 	<!-- Add New Bookmark Set dialog title -->
 	<string name="add_new_set">Thêm Bộ Mới</string>
-	<!-- Place Page - Add To Bookmarks button -->
-	<string name="add_to_bookmarks">Thêm vào Điểm đánh dấu</string>
 	<!-- Bookmark Color dialog title -->
 	<string name="bookmark_color">Đánh dấu Màu sắc</string>
 	<!-- Add Bookmark Set dialog - hint when set name is empty -->
 	<string name="bookmark_set_name">Đánh dấu Tên Bộ</string>
-	<!-- Bookmark Sets dialog title -->
-	<string name="bookmark_sets">Đánh dấu Bộ</string>
 	<!-- Bookmarks - dialog title -->
 	<string name="bookmarks">Đánh dấu</string>
-	<!-- Add bookmark dialog - bookmark color -->
-	<string name="color">Màu sắc</string>
 	<!-- Default bookmarks set name -->
 	<string name="core_my_places">Các Địa chỉ của Tôi</string>
 	<!-- Add bookmark dialog - bookmark name -->
 	<string name="name">Tên</string>
 	<!-- Editor title above street and house number -->
 	<string name="address">Địa chỉ</string>
-	<!-- Place Page - Remove Pin button -->
-	<string name="remove_pin">Xóa Con Dấu</string>
 	<!-- Add bookmark dialog - bookmark set, Bookmarks dialog - Bookmark set cell -->
 	<string name="set">Đặt</string>
-	<!-- Text hint in Bookmarks dialog when no any bookmarks are added -->
-	<string name="bookmarks_usage_hint">Bạn chưa có điểm đánh dấu.\nChạm vào bất kỳ địa điểm nào trên bản đồ để thêm một điểm đánh dấu.\nĐiểm đánh dấu từ các nguồn khác cũng có thể được nhập và hiển thị trong Organic Maps. Mở tập tin KML/KMZ với các điểm đánh dấu được lưu từ email, Dropbox hoặc liên kết web.</string>
 	<!-- Settings button in system menu -->
 	<string name="settings">Thiết lập</string>
 	<!-- Header of settings activity where user defines storage path -->
@@ -120,10 +92,6 @@
 	<string name="move_maps">Di chuyển bản đồ?</string>
 	<!-- Ask to wait user several minutes (some long process in modal dialog). -->
 	<string name="wait_several_minutes">Việc này có thể mất vài phút.\nVui lòng đợi…</string>
-	<!-- Show bookmarks from this category on a map or not -->
-	<string name="visible">Hiện</string>
-	<!-- Toast which is displayed when GPS has been deactivated -->
-	<string name="gps_is_disabled_long_text">GPS đã bị tắt. Vui lòng bật nó trong Cài đặt.</string>
 	<!-- Measurement units title in settings activity -->
 	<string name="measurement_units">Đơn vị đo</string>
 	<!-- Detailed description of Measurement Units settings button -->
@@ -164,12 +132,8 @@
 	<string name="post">Bưu điện</string>
 	<!-- Search category -->
 	<string name="police">Cảnh sát</string>
-	<!-- String in search result list, when nothing found -->
-	<string name="no_search_results_found">Không tìm thấy kết quả nào</string>
 	<!-- Notes field in Bookmarks view -->
 	<string name="description">Ghi chú</string>
-	<!-- Button text -->
-	<string name="share_by_email">Chia sẻ bằng email</string>
 	<!-- Email Subject when sharing bookmarks category -->
 	<string name="share_bookmarks_email_subject">Điểm đánh dấu Organic Maps được chia sẻ</string>
 	<!-- message title of loading file -->
@@ -182,20 +146,10 @@
 	<string name="edit">Sửa</string>
 	<!-- Warning message when doing search around current position -->
 	<string name="unknown_current_position">Chưa xác định được vị trí của bạn</string>
-	<!-- Warning message when location country isn't downloaded during search (see also download_location_map_proposal). -->
-	<string name="download_location_country">Tải xuống quốc gia của vị trí hiện tại của bạn (%s)</string>
-	<!-- Warning message when viewport country isn't downloaded during search -->
-	<string name="download_viewport_country_to_search">Tải xuống quốc gia bạn đang tìm kiếm trên (%s)</string>
 	<!-- Alert message that we can't run Map Storage settings due to some reasons. -->
 	<string name="cant_change_this_setting">Rất tiếc, cài đặt Lưu trữ Bản đồ hiện đã bị tắt.</string>
 	<!-- Alert message that downloading is in progress. -->
 	<string name="downloading_is_active">Hiện đang tải xuống quốc gia.</string>
-	<!-- Message that will be shown in alert view, when we ask user to leave review on App Store -->
-	<string name="appStore_message">Hi vọng bạn thích sử dụng Organic Maps! Nếu vậy, bạn vui lòng cho điểm hoặc đánh giá ứng dụng trên App Store. Việc này chỉ tốn dưới một phút và sẽ giúp chúng tôi rất nhiều. Cảm ơn bạn đã ủng hộ!</string>
-	<!-- No, thanks -->
-	<string name="no_thanks">Không, cảm ơn</string>
-	<!-- Share one specific bookmark using SMS, %1$@ contains om:// and %2$@ https://omaps.app link. @NOTE non-ascii symbols in the link will result in max 70 characters SMS instead of 140. -->
-	<string name="bookmark_share_sms">Này, hãy xem ghim của tôi tại Organic Maps! %1$s hoặc %2$s Bạn chưa cài đặt bản đồ ngoại tuyến? Tải xuống tại đây: https://omaps.app/get</string>
 	<!-- Share my position using SMS, %1$@ contains om:// and %2$@ https://omaps.app link WITHOUT NAME. @NOTE non-ascii symbols in the link will result in max 70 characters SMS instead of 140. -->
 	<string name="my_position_share_sms">Này, hãy xem vị trí hiện tại của tôi tại Organic Maps! %1$s hoặc %2$s Bạn không có bản đồ ngoại tuyến? Tải xuống tại đây: https://omaps.app/get</string>
 	<!-- Subject for emailed bookmark -->
@@ -204,30 +158,16 @@
 	<string name="my_position_share_email_subject">Này, hãy xem vị trí hiện tại của tôi tại Organic Maps map!</string>
 	<!-- Share my position using EMail, %1$@ is om:// and %2$@ is https://omaps.app link WITHOUT NAME -->
 	<string name="my_position_share_email">Chào,\n\nTôi hiện đang ở đây: %1$s. Hãy nhấn vào liên kết này %2$s hoặc liên kết này %3$s để xem địa điểm trên bản đồ.\n\nCám ơn.</string>
-	<!-- Android share by Message/SMS button text (including SMS) -->
-	<string name="share_by_message">Chia sẻ bằng tin nhắn</string>
 	<!-- Share button text which opens menu with more buttons, like Message, EMail, Facebook etc. -->
 	<string name="share">Chia sẻ</string>
-	<!-- iOS share by Message button text (including SMS) -->
-	<string name="message">Tin nhắn</string>
 	<!-- Share by email button text, also used in editor. -->
 	<string name="email">Email</string>
-	<!-- Copy Link -->
-	<string name="copy_link">Sao chép Liên kết</string>
-	<!-- Text for the button that returns to caller application -->
-	<string name="more_info">Hiển thị thêm thông tin</string>
 	<!-- Text for message when used successfully copied something -->
 	<string name="copied_to_clipboard">Đã sao chép vào Bảng tạm: %1$s</string>
 	<!-- place preview title -->
 	<string name="info">Thông tin</string>
 	<!-- Used for bookmark editing -->
 	<string name="done">Xong</string>
-	<!-- Summary for preferences in MWM -->
-	<string name="yopme_pref_summary">Chọn cài đặt Màn hình Sau</string>
-	<!-- Title for yopme preferences in MWM -->
-	<string name="yopme_pref_title">Cài đặt Màn hình Sau</string>
-	<!-- Hint for upper-right icon p2b -->
-	<string name="show_on_backscreen">Hiển thị trên màn hình Sau</string>
 	<!-- Prints version number in About dialog -->
 	<string name="version">Phiên bản: %s</string>
 	<!-- Confirmation in downloading countries dialog -->
@@ -237,11 +177,6 @@
 	<!-- Length of track in cell that describes route -->
 	<string name="length">Độ dài</string>
 	<string name="share_my_location">Chia sẻ Vị trí của tôi</string>
-	<string name="menu_search">Tìm kiếm</string>
-	<!-- Settings screen: "Map" category title -->
-	<string name="prefs_group_map">Bản đồ</string>
-	<!-- Settings screen: "Miscellaneous" category title -->
-	<string name="prefs_group_misc">Khác</string>
 	<string name="prefs_group_route">Điều hướng</string>
 	<string name="pref_zoom_title">Nút Phóng to/Thu nhỏ</string>
 	<string name="pref_zoom_summary">Hiển thị trên màn hình</string>
@@ -257,8 +192,6 @@
 	<string name="pref_map_3d_title">Góc nhìn phối cảnh</string>
 	<!-- Settings «Map» category: «3D buildings» title -->
 	<string name="pref_map_3d_buildings_title">Nhà cửa 3D</string>
-	<!-- Settings «Map» category: «3D buildings» summary -->
-	<string name="pref_map_3d_buildings_subtitle">Ảnh hưởng tới tuổi thọ của pin</string>
 	<!-- Settings «Route» category: «Tts enabled» title -->
 	<string name="pref_tts_enable_title">Hướng dẫn bằng Giọng nói</string>
 	<!-- Settings «Route» category: «Tts language» title -->
@@ -267,7 +200,6 @@
 	<string name="pref_tts_unavailable">Không có sẵn</string>
 	<!-- Title for "Other" section in TTS settings. -->
 	<string name="pref_tts_other_section_title">Khác</string>
-	<string name="pref_tts_how_to_set_up_voice">Làm thế nào để thiết lập tiếng nói</string>
 	<!-- Settings «Map» category: «Record track» title -->
 	<string name="pref_track_record_title">Tìm kiếm gần đây</string>
 	<string name="pref_map_auto_zoom">Ống dòm tự động</string>
@@ -278,40 +210,11 @@
 	<string name="duration_12_hours">12 giờ</string>
 	<string name="duration_1_day">1 ngày</string>
 	<string name="recent_track_help_text">Chức năng này cho phép bạn ghi lại đường đi trong một khoảng thời gian nhất định và xem nó trên bản đồ. Xin lưu ý: việc kích hoạt chức năng này sẽ tăng mức sử dụng pin. Đường đi sẽ tự động bị xóa khỏi bản đồ sau khi kết thúc khoảng thời gian nói trên.</string>
-	<string name="pref_track_ios_caption">Chức năng theo dấu gần đây hiển thị các đường bạn đã đi.</string>
-	<string name="pref_track_ios_subcaption">Vui lòng chọn khoảng thời gian lưu dấu.</string>
-	<string name="placepage_distance">Khoảng cách</string>
-	<string name="placepage_coordinates">Tọa độ</string>
-	<string name="placepage_unsorted">Chưa phân loại</string>
 	<string name="search_show_on_map">Xem trên bản đồ</string>
-	<!-- Used to warn user when fixing KitKat issue -->
-	<string name="bookmark_move_fail">Chúng tôi cần di chuyển các điểm đánh dấu của bạn vào bộ nhớ trong nhưng không còn dung lượng cho chúng. Vui lòng giải phóng bộ nhớ, nếu không các điểm đánh dấu sẽ không khả dụng.</string>
-	<!-- 1st search button-like result -->
-	<string name="search_on_map">Tìm trên bản đồ</string>
-	<!-- toast with an error -->
-	<string name="no_route_found">Không tìm thấy tuyến đường</string>
-	<!-- route title -->
-	<string name="route">Tuyến đường</string>
-	<!-- category title -->
-	<string name="routes">Tuyến đường</string>
-	<!-- text of notification -->
-	<string name="download_map_notification">Tải xuống bản đồ của vị trí của bạn</string>
-	<!-- Dialog for transferring maps from lite to pro. -->
-	<string name="move_lite_maps_to_pro">Chúng tôi đang chuyển bản đồ đã tải xuống của bạn từ Organic Maps Lite sang Organic Maps. Việc này có thể mất vài phút.</string>
-	<!-- Message to display when maps moved. -->
-	<string name="move_lite_maps_to_pro_ok">Bản đồ đã tải xuống của bạn đã được chuyển thành công sang Organic Maps.</string>
-	<!-- Message to display when maps move failed. -->
-	<string name="move_lite_maps_to_pro_failed">Bản đồ của bạn không chuyển được. Vui lòng xóa Organic Maps Lite và tải xuống lại bản đồ.</string>
-	<!-- Text in menu -->
-	<string name="settings_and_more">Thiết lập &amp;amp; Khác</string>
 	<!-- Text in menu -->
 	<string name="website">Trang web</string>
-	<!-- Text in menu -->
-	<string name="contact_us">Liên hệ với chúng tôi</string>
 	<!-- Settings: Send feedback button and dialog title -->
 	<string name="feedback">Phản hồi</string>
-	<!-- Text in menu -->
-	<string name="subscribe_to_news">Đăng ký nhận tin tức của chúng tôi</string>
 	<!-- Text in menu -->
 	<string name="rate_the_app">Cho điểm ứng dụng</string>
 	<!-- Text in menu -->
@@ -320,12 +223,6 @@
 	<string name="copyright">Bản quyền</string>
 	<!-- Text in menu -->
 	<string name="report_a_bug">Báo cáo lỗi</string>
-	<!-- Email subject -->
-	<string name="subscribe_me_subject">Vui lòng đăng ký tôi vào danh sách nhận thư định kỳ Organic Maps</string>
-	<!-- Email body -->
-	<string name="subscribe_me_body">Tôi muốn là người đầu tiên được biết về các thông tin cập nhật và quảng bá mới nhất. Tôi có thể hủy bỏ đăng ký nhận tin của mình bất cứ lúc nào.</string>
-	<!-- About text -->
-	<string name="about_text">Organic Maps cung cấp bản đồ ngoại tuyến của tất cả các thành phố và quốc gia trên thế giới một cách nhanh nhất. Hoàn toàn tự tin đi du lịch: dù bạn ở đâu, Organic Maps vẫn sẽ giúp bạn định vị bản thân trên bản đồ, tìm các nhà hàng, khách sạn, ngân hàng, trạm xăng, v.v… gần nhất. Ứng dụng này không yêu cầu kết nối Internet.\n\nChúng tôi luôn phát triển các tính năng mới và rất chào đón ý kiến của bạn về cách mà chúng tôi có thể cải thiện Organic Maps. Nếu bạn có bất cứ vấn đề nào với ứng dụng, hãy liên hệ với chúng tôi qua địa chỉ support\@organicmaps.app. Chúng tôi sẽ trả lời mọi yêu cầu!\n\nBạn có thích Organic Maps và muốn hỗ trợ chúng tôi hay không? Sau đây là một số cách đơn giản và hoàn toàn miễn phí:\n\n- viết đánh giá trên Chợ Ứng dụng mà bạn sử dụng\n- thích trang Facebook của chúng tôi http://www.facebook.com/OrganicMaps\n- hoặc chỉ đơn giản là kể về Organic Maps với mẹ, bạn bè và đồng nghiệp của bạn :)\n\nCảm ơn bạn đã ủng hộ chúng tôi. Chúng tôi rất cảm ơn sự giúp đỡ của bạn!\n\nT.B. Chúng tôi lấy dữ liệu bản đồ từ OpenStreetMap, một dự án bản đồ tương đương với Wikipedia, cho phép người dùng có thể tạo và sửa bản đồ. Nếu bạn thấy có thông tin bị thiếu hoặc sai trên bản đồ, bạn có thể sửa trực tiếp tại https://www.openstreetmap.org, và các thay đổi của bạn sẽ xuất hiện trong ứng dụng Organic Maps ở phiên bản kế tiếp.</string>
 	<!-- Alert text -->
 	<string name="email_error_body">Trình khách email này chưa được thiết lập. Bạn vui lòng cấu hình nó hoặc sử dụng một cách khác để liên hệ với chúng tôi tại %s</string>
 	<!-- Alert title -->
@@ -334,137 +231,56 @@
 	<string name="pref_calibration_title">Chuẩn hóa la bàn</string>
 	<!-- Search category -->
 	<string name="wifi">WiFi</string>
-	<!-- Update map suggestion -->
-	<string name="routing_map_outdated">Vui lòng cập nhật bản đồ để tạo tuyến đường</string>
-	<!-- Update maps suggestion -->
-	<string name="routing_update_maps">Phiên bản Organic Maps mới cho phép tạo các tuyến đường từ vị trí hiện tại của bạn đến điểm đến. Vui lòng cập nhật bản đồ để sử dụng tính năng này.</string>
 	<!-- Update all button text -->
 	<string name="downloader_update_all_button">Cập nhật tất cả</string>
 	<!-- Cancel all button text -->
 	<string name="downloader_cancel_all">Hủy tất cả</string>
 	<!-- Downloaded maps category -->
 	<string name="downloader_downloaded_subtitle">Đã tải xuống</string>
-	<!-- Downloaded maps category -->
-	<string name="downloader_available_maps">Đã có</string>
 	<!-- Country queued for download -->
 	<string name="downloader_queued">Đã xếp hàng chờ</string>
 	<string name="downloader_near_me_subtitle">Gần tôi</string>
 	<string name="downloader_status_maps">Bản đồ</string>
 	<string name="downloader_download_all_button">Tải xuống tất cả</string>
 	<string name="downloader_downloading">Đang tải về:</string>
-	<string name="downloader_search_results">Đã tìm thấy</string>
-	<!-- Disclaimer message -->
-	<string name="routing_disclaimer">Tạo các tuyến đường trong ứng dụng Organic Maps, xin lưu ý điều sau:\n\n – Các tuyến đường được gợi ý chỉ có thể được xem là đề xuất.\n – Điều kiện con đường, luật giao thông và biển báo có mức ưu tiên cao hơn lời khuyên dẫn hướng.\n – Bản đồ có thể không chính xác hoặc lỗi thời, tuyến đường có thể không được tạo theo cách tốt nhất có thể.\n\n Hãy lái xe an toàn trên đường và bảo trọng!</string>
-	<!-- Outdated maps category -->
-	<string name="downloader_outdated_maps">Lỗi thời</string>
-	<!-- Up to date maps category -->
-	<string name="downloader_uptodate_maps">Cập nhật</string>
 	<!-- Status of outdated country in the list -->
 	<string name="downloader_status_outdated">Cập nhật</string>
 	<!-- Status of failed country in the list -->
 	<string name="downloader_status_failed">Thất bại</string>
 	<!-- Displayed in a dialog that appears when a user tries to delete a map while the app is in the follow route mode -->
 	<string name="downloader_delete_map_while_routing_dialog">Để xóa bản đồ, vui lòng dừng điều hướng.</string>
-	<!-- Show when user try build route, but we don't know where he -->
-	<string name="routing_failed_unknown_my_position">Không xác định được vị trí hiện tại. Vui lòng xác định vị trí để tạo tuyến đường.</string>
-	<!-- Show if use has not routing file, or InconsistentMWMandRoute -->
-	<string name="routing_failed_has_no_routing_file">số liệu bổ sung cần thiết để tạo ra các tuyến đường đi từ vị trí của bạn.</string>
-	<!-- StartPointNotFound -->
-	<string name="routing_failed_start_point_not_found">Không thể tính toán tuyến đường. Không có con đường nào gần điểm bắt đầu của bạn.</string>
-	<!-- EndPointNotFound -->
-	<string name="routing_failed_dst_point_not_found">Không thể tính toán tuyến đường. Không có con đường nào gần điểm đến của bạn.</string>
 	<!-- PointsInDifferentMWM -->
 	<string name="routing_failed_cross_mwm_building">Tuyến đường chỉ có thể được tạo hoàn toàn được chứa trong một bản đồ.</string>
-	<!-- RouteNotFound -->
-	<string name="routing_failed_route_not_found">Không tìm thấy tuyến đường nào giữa điểm gốc và điểm đến được chọn. Vui lòng chọn điểm bắt đầu hoặc điểm cuối khác.</string>
-	<!-- InternalError -->
-	<string name="routing_failed_internal_error">Đã xảy ra lỗi nội bộ. Vui lòng thử xóa và tải lại xuống bản đồ. Nếu vấn đề vẫn còn tồn tại, vui lòng liên hệ với chúng tôi tại support\@organicmaps.app.</string>
-	<!-- Context menu item for downloader. -->
-	<string name="downloader_download_map_and_routing">Tải xuống Bản đồ + Định tuyến</string>
-	<!-- Context menu item for downloader. -->
-	<string name="downloader_download_routing">Tải xuống Định tuyến</string>
-	<!-- Context menu item for downloader. -->
-	<string name="downloader_delete_routing">Xóa Định tuyến</string>
 	<!-- Context menu item for downloader. -->
 	<string name="downloader_download_map">Tải về bản đồ</string>
-	<string name="downloader_download_map_no_routing">Tải về bản đồ không có chỉ đường</string>
-	<!-- Button for routing. -->
-	<string name="routing_go">Tiến hành!</string>
 	<!-- Item status in downloader. -->
 	<string name="downloader_retry">Lặp lại</string>
-	<!-- Item in context menu. -->
-	<string name="downloader_map_and_routing">Bản đồ + Định tuyến</string>
 	<!-- Item in context menu. -->
 	<string name="downloader_delete_map">Xóa Bản đồ</string>
 	<!-- Item in context menu. -->
 	<string name="downloader_update_map">Cập nhật Bản đồ</string>
-	<!-- Item in context menu. -->
-	<string name="downloader_update_map_and_routing">Cập nhật bản đồ + Định tuyến</string>
-	<!-- Item in context menu. -->
-	<string name="downloader_map_only">Chỉ bản đồ</string>
-	<!-- Toolbar title -->
-	<string name="toolbar_application_menu">Menu ứng dụng</string>
 	<!-- Preference text -->
 	<string name="pref_use_google_play">Sử dụng Dịch vụ Google Play để có được vị trí hiện tại của bạn</string>
 	<!-- Text for rating dialog -->
 	<string name="rating_just_rated">Tôi vừa đánh giá ứng dụng của bạn</string>
-	<!-- Text for rating dialog -->
-	<string name="rating_user_since">Tôi là người dùng Organic Maps từ năm %s</string>
-	<!-- Text for rating dialog -->
-	<string name="rating_do_like_maps">Bạn có thích Organic Maps?</string>
-	<!-- Text for rating dialog -->
-	<string name="rating_tap_star">Chạm vào một ngôi sao để đánh giá ứng dụng của chúng tôi.</string>
 	<!-- Text for rating dialog -->
 	<string name="rating_thanks">Xin cám ơn!</string>
 	<!-- Text for rating dialog -->
 	<string name="rating_share_ideas">Hãy chia sẻ bất kỳ ý tưởng hay vấn đề nào, để chúng tôi cải tiến ứng dụng tốt hơn.</string>
 	<!-- Text for rating dialog -->
 	<string name="rating_send_feedback">Gửi phản hồi</string>
-	<!-- Text for g+ dialog -->
-	<string name="rating_google_plus">Nhấp vào g+ để nói với bạn bè của bạn về ứng dụng.</string>
 	<!-- Text for routing error dialog -->
 	<string name="routing_download_maps_along">Tải xuống bản đồ theo tuyến đường</string>
-	<!-- Text for routing error dialog -->
-	<string name="routing_download_map">Nhận bản đồ</string>
-	<!-- Text for routing error dialog -->
-	<string name="routing_download_map_and_routing">Tải bản đồ và dữ liệu đường đi cập nhật để nhận được tất cả các tính năng của Organic Maps.</string>
-	<!-- Text for routing error dialog -->
-	<string name="routing_get_routing_data">Nhận dữ liệu đường đi</string>
-	<!-- Text for routing error dialog -->
-	<string name="routing_get_additional_data">số liệu bổ sung cần thiết để tạo ra các tuyến đường đi từ vị trí của bạn.</string>
 	<!-- Text for routing error dialog -->
 	<string name="routing_requires_all_map">Tạo một tuyến đường đòi hỏi tất cả các bản đồ từ vị trí của bạn đến điểm đến phải được tải xuống và cập nhật.</string>
 	<!-- Text for routing error dialog -->
 	<string name="routing_not_enough_space">Không đủ không gian</string>
-	<!-- Text for routing error dialog -->
-	<string name="routing_download_more_than_avail">Bạn cần phải tải về %1$s MB, nhưng chỉ có %2$s MB sẵn có.</string>
-	<!-- Text for routing error dialog -->
-	<string name="routing_download_roaming">Bạn sắp tải xuống %s MB sử dụng Dữ liệu Di động (trong dịch vụ Chuyển vùng). Điều này có thể dẫn đến cước phí bổ sung, tùy thuộc vào gói dữ liệu di động của nhà mạng của bạn.</string>
 	<!-- bookmark button text -->
 	<string name="bookmark">yer i̇mi</string>
-	<!-- map is not downloaded -->
-	<string name="not_found_map">Bản đồ cho vị trí của bạn chưa được tải xuống</string>
 	<!-- location service disabled -->
 	<string name="enable_location_services">Bạn vui lòng bật Dịch vụ Định vị</string>
-	<!-- download map -->
-	<string name="download_map">Tải xuống bản đồ cho vị trí của bạn</string>
-	<!-- download map on iPhone -->
-	<string name="download_map_iphone">Tải bản đồ vị trí hiện tại xuống iPhone của bạn</string>
-	<!-- clear pin -->
-	<string name="nearby">Gần kề</string>
-	<!-- clear pin -->
-	<string name="clear_pin">Xóa Pin</string>
-	<!-- location is undefined -->
-	<string name="undefined_location">Không xác định được vị trí hiện tại.</string>
-	<!-- download country of your location -->
-	<string name="download_country">Tải xuống quốc gia bạn đang tìm kiếm trên</string>
-	<!-- download failed -->
-	<string name="download_failed">tải xuống thất bại</string>
-	<!-- get the map -->
-	<string name="get_the_map">Tải bản đồ</string>
 	<string name="save">Lưu</string>
 	<string name="edit_description_hint">Mô tả của bạn (chữ hoặc html)</string>
-	<string name="new_group">nhóm mới</string>
 	<string name="create">tạo</string>
 	<!-- red color -->
 	<string name="red">Đỏ</string>
@@ -482,22 +298,6 @@
 	<string name="brown">Nâu</string>
 	<!-- pink color -->
 	<string name="pink">Hồng</string>
-	<!-- deep purple color -->
-	<string name="deep_purple">Tía thẫm</string>
-	<!-- light blue color -->
-	<string name="light_blue">Xanh da trời</string>
-	<!-- cyan color -->
-	<string name="cyan">Xanh lơ</string>
-	<!-- teal color -->
-	<string name="teal">Lục bảo</string>
-	<!-- lime color -->
-	<string name="lime">Màu xanh chanh</string>
-	<!-- deep orange color -->
-	<string name="deep_orange">Cam đậm</string>
-	<!-- gray color -->
-	<string name="gray">Xám</string>
-	<!-- blue gray color -->
-	<string name="blue_gray">Xám xanh da trời</string>
 	<!-- Wi-Fi available -->
 	<string name="WiFi_available">Có</string>
 
@@ -513,10 +313,8 @@
 	<string name="dialog_routing_location_turn_wifi">Hãy kiểm tra tín hiệu GPS của bạn. Việc kích hoạt Wi-Fi sẽ cải thiện độ chính xác vị trí của bạn.</string>
 	<string name="dialog_routing_location_turn_on">Bật các dịch vụ định vị</string>
 	<string name="dialog_routing_location_unknown_turn_on">Không thể xác định vị trí tọa độ GPS hiện tại. Bật các dịch vụ định vị để tính toán tuyến đường.</string>
-	<string name="dialog_routing_location_unknown">Không thể xác định vị trí tọa độ GPS hiện tại.</string>
 	<string name="dialog_routing_download_files">Tải xuống các tệp yêu cầu</string>
 	<string name="dialog_routing_download_and_update_all">Tải về và cập nhật tất cả các bản đồ và các thông tin tuyến đường dọc theo lộ trình dự kiến để tính toán tuyến đường.</string>
-	<string name="dialog_routing_routes_size">Tệp thông tin tuyến đường</string>
 	<string name="dialog_routing_unable_locate_route">Không thể xác định tuyến đường</string>
 	<string name="dialog_routing_cant_build_route">Không thể tạo tuyến đường.</string>
 	<string name="dialog_routing_change_start_or_end">Hãy điều chỉnh điểm bắt đầu hoặc điểm đến của bạn.</string>
@@ -531,33 +329,23 @@
 	<string name="dialog_routing_system_error">Lỗi hệ thống</string>
 	<string name="dialog_routing_application_error">Không thể tạo tuyến đường do lỗi ứng dụng.</string>
 	<string name="dialog_routing_try_again">Vui lòng thử lại</string>
-	<string name="dialog_routing_send_error">Báo cáo vấn đề</string>
-	<string name="dialog_routing_if_get_cross_route">Bạn có muốn tạo một tuyến đường thẳng hơn mà kéo dài trên nhiều bản đồ không?</string>
-	<string name="dialog_routing_cross_route_is_optimal">Có một tuyến đường tối ưu hơn đi qua cạnh của bản đồ này.</string>
 	<string name="not_now">Lúc khác</string>
-	<string name="dialog_routing_build_route">Tạo</string>
 	<string name="dialog_routing_download_and_build_cross_route">Bạn có muốn tải về bản đồ và tạo một tuyến đường tối ưu hơn kéo dài trên nhiều hơn một bản đồ?</string>
 	<string name="dialog_routing_download_cross_route">Tải về bản đồ để tạo tuyến đường tối ưu hơn mà đi qua cạnh của bản đồ này.</string>
-	<string name="dialog_routing_cross_route_always">Luôn đi qua ranh giới này</string>
 
 	<!-- SECTION: Strings for downloading map from search -->
 	<string name="search_without_internet_advertisement">Để bắt đầu tìm kiếm và tạo đường đi, vui lòng tải về bản đồ, và bạn sẽ không cần đến kết nối Internet nữa.</string>
 	<string name="search_select_map">Chọn bản đồ</string>
-	<string name="search_select_other_map">Chọn bản đồ khác</string>
 	<!-- «Show» context menu -->
 	<string name="show">Hiện</string>
 	<!-- «Hide» context menu -->
 	<string name="hide">Ẩn</string>
 	<!-- «Rename» context menu -->
 	<string name="rename">Đổi tên</string>
-	<!-- Bottom sheet: expand button (should be short) -->
-	<string name="bottom_sheet_more">Thêm…</string>
 	<!-- Failed planning route message in navigation view -->
 	<string name="routing_planning_error">Không thể Lập Lộ trình</string>
 	<!-- Arrive routing message in navigation view -->
 	<string name="routing_arrive">Đến: %s</string>
-	<!-- Text for routing::RouterResultCode::FileTooOld dialog. -->
-	<string name="dialog_routing_download_and_update_maps">Để tạo đường đi, vui lòng tải về và cập nhật tất cả bản đồ dọc theo tuyến đường.</string>
 	<string name="rate_alert_title">Bạn thích ứng dụng chứ?</string>
 	<string name="rate_alert_default_message">Cám ơn bạn đã sử dụng Organic Maps. Vui lòng đánh giá ứng dụng. Phản hồi của bạn giúp chúng tôi trở nên tốt hơn.</string>
 	<string name="rate_alert_five_star_message">Hoan hô! Chúng tôi cũng yêu bạn!</string>
@@ -565,24 +353,14 @@
 	<string name="rate_alert_less_than_four_star_message">Có bất kỳ ý tưởng nào về cách chúng tôi có thể giúp ứng dụng tốt hơn?</string>
 	<string name="categories">Thể loại</string>
 	<string name="history">Lịch sử</string>
-	<string name="next_turn_then">Sau đó</string>
 	<string name="closed">Đã đóng</string>
-	<string name="back_to">Quay lại %s</string>
 	<string name="search_not_found">Xin lỗi, tôi không tìm thấy kết quả nào.</string>
 	<string name="search_not_found_query">Vui lòng thử câu hỏi khác.</string>
-	<string name="search_not_found_map">Vui lòng tải về bản đồ mà bạn đang tìm kiếm trong đó.</string>
-	<string name="search_not_found_location">Tải về bản đồ vị trí hiện tại của bạn.</string>
 	<string name="search_history_title">Lịch sử tìm kiếm</string>
 	<string name="search_history_text">Truy cập nhanh chóng đến câu hỏi tìm kiếm gần đây.</string>
 	<string name="clear_search">Xóa Lịch sử Tìm kiếm</string>
-	<!-- Title for settings to enable/disable showcase menu button -->
-	<string name="showcase_settings_title">Hiển thị lời mời</string>
-	<string name="p2p_route_planning">Hoạch định đường đi</string>
 	<string name="p2p_your_location">Vị trí của bạn</string>
-	<string name="p2p_from">Điểm khởi hành</string>
-	<string name="p2p_to">Điểm đích</string>
 	<string name="p2p_start">Bắt đầu</string>
-	<string name="p2p_planning">Đang hoạch định…</string>
 	<string name="p2p_from_here">Từ</string>
 	<string name="p2p_to_here">Tuyến đến</string>
 	<string name="p2p_only_from_current">Chức năng tìm đường chỉ có sẵn từ vị trí hiện tại của bạn.</string>
@@ -602,11 +380,8 @@
 	<string name="editor_hours_closed">Giờ đóng cửa</string>
 	<string name="editor_example_values">Giá trị ví dụ</string>
 	<string name="editor_correct_mistake">Sửa lỗi</string>
-	<string name="editor_correct_mistake_message">Bạn đã mắc lỗi chỉnh sửa. Vui lòng sửa lỗi hoặc chuyển qua chế độ đơn giản.</string>
 	<string name="editor_add_select_location">Vị trí</string>
 	<string name="editor_done_dialog_1">Bạn đã thay đổi bản đồ thế giới. Đừng giấu điều đó! Hãy cho các bạn khác biết và cùng nhau chỉnh sửa.</string>
-	<string name="editor_done_dialog_2">Đây là lần nâng cấp bản đồ thứ hai của bạn. Giờ bạn xếp hạng %d trong các nhà hiệu chỉnh bản đồ. Hãy nói với các bạn khác về điều đó.</string>
-	<string name="editor_done_dialog_3">Bạn đã nâng cấp bản đồ này, hãy cho các bạn khác biết và cùng nhau chỉnh sửa bản đồ.</string>
 	<string name="share_with_friends">Chia sẻ với bạn bè</string>
 	<string name="editor_report_problem_desription_1">Xin mô tả chi tiết vấn đề để cộng đồng OpenStreeMap có thể sửa lỗi đó.</string>
 	<string name="editor_report_problem_desription_2">Hoặc bạn có thể tự sửa tại https://www.openstreetmap.org/</string>
@@ -615,14 +390,7 @@
 	<string name="editor_report_problem_no_place_title">Địa điểm này không tồn tại</string>
 	<string name="editor_report_problem_under_construction_title">Tạm dừng để bảo trì</string>
 	<string name="editor_report_problem_duplicate_place_title">Địa điểm trùng lặp</string>
-	<string name="first_launch_congrats_title">Organic Maps đã sẵn sàng để sử dụng</string>
-	<string name="first_launch_congrats_text">Tìm kiếm và điều hướng ngoại tuyến, miễn phí khắp mọi nơi trên thế giới.</string>
-	<string name="migrate_title">Quan trọng!</string>
-	<!-- Android uses image instead of text. -->
-	<string name="download_all">Tải về tất cả</string>
-	<string name="delete_all">Xóa tất cả</string>
 	<string name="autodownload">Tự động tải về</string>
-	<string name="disable_autodownload">Tắt chế độ tự động tải xuống</string>
 	<!-- Place Page opening hours text -->
 	<string name="closed_now">Hiện đã đóng</string>
 	<!-- Place Page opening hours text -->
@@ -631,8 +399,6 @@
 	<string name="day_off_today">Nghỉ hôm nay</string>
 	<string name="day_off">Ngày nghỉ</string>
 	<string name="today">Hôm nay</string>
-	<string name="sunrise_to_sunset">Từ bình minh đến hoàng hôn</string>
-	<string name="sunset_to_sunrise">Từ hoàng hôn đến bình minh</string>
 	<string name="add_opening_hours">Thêm giờ làm việc</string>
 	<string name="edit_opening_hours">Sửa giờ làm việc</string>
 	<string name="no_osm_account">Bạn chưa có tài khoản tại OpenStreetMap ư?</string>
@@ -642,29 +408,13 @@
 	<string name="login">Đăng nhập</string>
 	<string name="password">Mật khẩu</string>
 	<string name="forgot_password">Quên mật khẩu?</string>
-	<!-- Forgot Password dialog title -->
-	<string name="restore_password">Khôi phục mật khẩu</string>
-	<string name="enter_email_address_to_reset_password">Nhập địa chỉ email bạn đã sử dụng trong quá trình đăng ký và chúng tôi sẽ gửi cho bạn liên kết để tạo mới mật khẩu của bạn.</string>
-	<string name="reset_password">đặt lại mật khẩu</string>
-	<string name="username">Tên đăng nhập</string>
 	<string name="osm_account">Tài khoản OSM</string>
 	<string name="logout">Đăng xuất</string>
-	<string name="login_and_edit_map_motivation_message">Đăng nhập và chỉnh sửa thông tin của các đối tượng trên bản đồ và chúng tôi sẽ hiển thị chúng cho hàng triệu người dùng khác. Hãy cùng nhau làm cho thế giới tốt đẹp hơn.</string>
 	<!-- Information text: "Last upload 11.01.2016" -->
 	<string name="last_upload">Tải lên mới nhất</string>
-	<!-- Motivates user to login/register, title above login buttons. -->
-	<string name="you_have_edited_your_first_object">Bạn đã chỉnh sửa đối tượng đầu tiên của mình!</string>
 	<string name="thank_you">Cảm ơn bạn</string>
-	<string name="login_with_google">Đăng nhập với Google</string>
-	<string name="login_with_openstreetmap">Đăng nhập với www.openstreetmap.org</string>
 	<string name="edit_place">Chỉnh sửa địa điểm</string>
 	<string name="place_name">Tên địa điểm</string>
-	<!-- title above languages list cells in the editor, below editable name text field. -->
-	<string name="other_languages">Ngôn ngữ khác</string>
-	<!-- small button to open list with names in different languages -->
-	<string name="show_more">Hiển thị nhiều hơn</string>
-	<!-- small button to close list with names in different languages -->
-	<string name="show_less">Hiển thị ít hơn</string>
 	<string name="add_language">Thêm ngôn ngữ</string>
 	<string name="street">Đường</string>
 	<!-- Editable House Number text field (in address block). -->
@@ -681,25 +431,16 @@
 	<string name="email_or_username">Email hoặc tên người dùng</string>
 	<string name="phone">Điện thoại</string>
 	<string name="please_note">Xin lưu ý</string>
-	<string name="common_no_wifi_dialog">Không có Wifi. Bạn có muốn tiếp tục dùng dữ liệu di động?</string>
 	<string name="downloader_delete_map_dialog">Tất cả những thay đổi của bản đồ sẽ bị xóa cùng với bản đồ đó.</string>
 	<string name="downloader_update_maps">Cập nhật các bản đồ</string>
 	<string name="downloader_mwm_migration_dialog">Để tạo một tuyến đường, bạn cần cập nhật tất cả các bản đồ và sau đó lập lại tuyến đường.</string>
 	<string name="downloader_search_field_hint">Tìm bản đồ</string>
-	<string name="migration_update_all_button">Cập nhật tất cả các bản đồ</string>
-	<string name="migration_delete_all_download_current_button">Tải xuống bản đồ hiện tại và xóa những bản đồ cũ</string>
 	<string name="migration_download_error_dialog">Lỗi tải xuống</string>
 	<string name="common_check_internet_connection_dialog">Xin kiểm tra các thiết lập và đảm bảo thiết bị của bạn có kết nối Internet.</string>
 	<string name="downloader_no_space_title">Không đủ dung lượng</string>
 	<string name="downloader_no_space_message">Xin xóa dữ liệu không cần thiết</string>
-	<string name="editor_general_auth_error_dialog">Lỗi đăng nhập chung.</string>
 	<string name="editor_login_error_dialog">Lỗi đăng nhập.</string>
-	<string name="editor_login_failed_dialog">Đăng nhập thất bại</string>
-	<string name="editor_username_error_dialog">Tên đăng nhập không hợp lệ</string>
-	<string name="editor_place_edited_dialog">Bạn đã chỉnh sửa một đối tượng!</string>
-	<string name="editor_login_with_osm">Đăng nhập với OpenStreetMap</string>
 	<string name="editor_profile_changes">Các thay đổi đã được xác thực</string>
-	<string name="editor_profile_unsent_changes">Không gửi được:</string>
 	<string name="editor_focus_map_on_location">Kéo bản đồ để chọn vị trí chính xác của đối tượng</string>
 	<string name="editor_add_select_category">Chọn thể loại</string>
 	<string name="editor_add_select_category_popular_subtitle">Phổ biến</string>
@@ -710,19 +451,14 @@
 	<string name="editor_edit_place_category_title">Thể loại</string>
 	<string name="detailed_problem_description">Mô tả chi tiết của vấn đề</string>
 	<string name="editor_report_problem_other_title">Một vấn đề khác</string>
-	<string name="placepage_report_problem_button">Báo cáo vấn đề</string>
 	<string name="placepage_add_business_button">Thêm tổ chức</string>
 	<string name="whatsnew_editor_message_1">Nhập các địa điểm mới vào bản đồ, và trực tiếp chỉnh sửa những địa điểm hiện có trên ứng dụng.</string>
-	<string name="whatsnew_editor_message_2">* Organic Maps sử dụng dữ liệu của cộng đồng OpenStreetMap.</string>
 	<string name="dialog_incorrect_feature_position">Thay đổi địa điểm</string>
 	<string name="message_invalid_feature_position">Một đối tượng không thể đặt được ở đây</string>
 	<string name="login_to_make_edits_visible">Đăng nhập để người dùng khác có thể nhìn thấy những thay đổi bạn đã thực hiện.</string>
-	<string name="no_migration_during_navigation">Không cho phép cập nhật trong khi điều hướng.</string>
 	<!-- Error dialog no space -->
 	<string name="migration_no_space_message">Để tải xuống, bạn cần thêm dung lượng. Xin xóa mọi dữ liệu không cần thiết.</string>
 	<string name="editor_sharing_title">Tôi đã cải thiện các bản đồ Organic Maps</string>
-	<string name="editor_comment_will_be_sent">Chúng tôi sẽ gửi bình luận của bạn đến những người lập bản đồ.</string>
-	<string name="editor_unsupported_category_message">Bạn đã thêm một địa điểm của một hạng mục mà chúng tôi chưa hỗ trợ. Nó sẽ xuất hiện trên bản đồ một thời gian sau đó.</string>
 	<!-- Downloaded 10 **of** 20 <- it is that "of" -->
 	<string name="downloader_of">%1$d trên %2$d</string>
 	<string name="download_over_mobile_header">Tải xuống qua kết nối mạng di động?</string>
@@ -740,15 +476,8 @@
 	<string name="editor_detailed_description">Những thay đổi đề nghị của bạn sẽ được gửi đến cộng đồng OpenStreetMap. Mô tả các chi tiết không thể sửa trong Organic Maps.</string>
 	<string name="editor_more_about_osm">Thông tin bổ sung về OpenStreetMap</string>
 	<string name="editor_operator">Đơn vị điều hành</string>
-	<string name="editor_tag_description">Nhập công ty, tổ chức hoặc cá nhân phụ trách cơ sở.</string>
-	<string name="editor_no_local_edits_title">Bạn không có những chỗ sửa cục bộ</string>
-	<string name="editor_no_local_edits_description">Thông tin này cho biết số thay đổi đề nghị của bạn trên bản đồ hiện chỉ có thể truy cập trên thiết bị của bạn.</string>
-	<string name="editor_send_to_osm">Gửi đến OSM</string>
-	<string name="editor_remove">Xóa</string>
-	<string name="downloader_my_maps_title">Bản đồ của tôi</string>
 	<string name="downloader_no_downloaded_maps_title">Bạn chưa tải về bất kỳ bản đồ nào</string>
 	<string name="downloader_no_downloaded_maps_message">Tải về bản đồ để tìm địa điểm và định hướng ngoại tuyến.</string>
-	<string name="downloader_find_place_hint">Tìm kiếm thành phố hoặc quốc gia</string>
 	<!-- Error title that appears after certain time without location. -->
 	<string name="current_location_unknown_title">Tiếp tục phát hiện địa điểm hiện tại của bạn?</string>
 	<!-- Error that appears after certain time without location. -->
@@ -763,27 +492,10 @@
 	<string name="location_services_disabled_2">2. Chạm mục Địa điểm</string>
 	<!-- iOS Dialog for the case when the location permission is not granted -->
 	<string name="location_services_disabled_3">3. Chọn Khi Đang Dùng Ứng dụng</string>
-	<string name="placepage_parking_surface">Trên mặt đất</string>
-	<string name="placepage_parking_multistorey">Nhiều tầng</string>
-	<string name="placepage_parking_underground">Dưới mặt đất</string>
-	<string name="placepage_parking_rooftop">Trên mái</string>
-	<string name="placepage_parking_sheds">Chỗ để xe</string>
-	<string name="placepage_parking_carports">Nhà để xe</string>
-	<string name="placepage_parking_boxes">Thùng gara</string>
-	<string name="placepage_parking_pay">Trả phí</string>
-	<string name="placepage_parking_free">Miễn phí</string>
-	<string name="placepage_parking_interval">Trả Phí Cách Quãng</string>
-	<string name="placepage_entrance_number">Số</string>
-	<string name="placepage_entrance_type">Lối vào</string>
-	<string name="placepage_flat">áp dụng</string>
-	<string name="placepage_open_24_7">24 / 7</string>
 	<string name="meter">m</string>
 	<string name="kilometer">km</string>
-	<string name="kilometers_per_hour">km/giờ</string>
 	<string name="mile">dặm</string>
 	<string name="foot">ft</string>
-	<string name="miles_per_hour">mph</string>
-	<string name="day">ngày</string>
 	<string name="hour">giờ</string>
 	<string name="minute">phút</string>
 	<string name="placepage_place_description">Mô tả</string>
@@ -793,46 +505,30 @@
 	<string name="placepage_call_button">Gọi</string>
 	<string name="placepage_edit_bookmark_button">Sửa Dấu Trang</string>
 	<string name="placepage_bookmark_name_hint">Tên Dấu Trang</string>
-	<string name="placepage_personal_notes_hint">Ghi chú cá nhân</string>
-	<string name="placepage_delete_bookmark_button">Xóa Dấu Trang</string>
 	<string name="editor_edits_sent_message">Những thay đổi đề nghị của bạn đã được gửi</string>
 	<string name="editor_comment_hint">Nhận xét…</string>
 	<string name="editor_reset_edits_message">Cài đặt lại tất cả thay đổi cục bộ?</string>
 	<string name="editor_reset_edits_button">Cài đặt lại</string>
 	<string name="editor_remove_place_message">Xóa một địa điểm đã thêm?</string>
 	<string name="editor_remove_place_button">Xóa</string>
-	<string name="editor_status_sending">Đang gửi …</string>
 	<string name="editor_place_doesnt_exist">Địa điểm không tồn tại</string>
 	<string name="text_more_button">…thêm</string>
 	<!-- Phone number error message -->
 	<string name="error_enter_correct_phone">Nhập chính xác số điện thoại</string>
 	<string name="error_enter_correct_web">Nhập địa chỉ trang web hợp lệ</string>
 	<string name="error_enter_correct_email">Nhập email hợp lệ</string>
-	<string name="error_enter_correct">Nhập giá trị hợp lệ</string>
 	<string name="refresh">Cập nhật</string>
-	<string name="last_update">Cập nhật cuối cùng: %s</string>
 	<string name="placepage_add_place_button">Thêm địa điểm vào bản đồ</string>
 	<!-- Displayed when saving some edits to the map to warn against publishing personal data -->
 	<string name="editor_share_to_all_dialog_title">Bạn có muốn gửi cho toàn bộ người dùng?</string>
 	<!-- iOS Dialog before publishing the modifications to the public map. -->
 	<string name="editor_share_to_all_dialog_message_1">Chắc chắn rằng bạn không nhập bất kỳ thông tin cá nhân nào.</string>
 	<string name="editor_share_to_all_dialog_message_2">Chúng tôi sẽ kiểm tra những thay đổi. Nếu chúng tôi có câu hỏi nào, chúng tôi sẽ liên lạc với bạn qua email.</string>
-	<string name="navigation_overview_button">tổng quan</string>
-	<string name="navigation_stop_button">dừng</string>
-	<!-- Text on an empty bookmark page -->
-	<string name="bookmarks_empty_title">Lưu Đánh dấu trang</string>
-	<string name="bookmarks_empty_message_1">Chạm vào ★ để lưu địa điểm yêu thích giúp truy cập nhanh.</string>
-	<string name="bookmarks_empty_message_2">Nhập đánh dấu trang từ Hộp thư và trang web.</string>
-	<string name="bookmarks_empty_message_3">đăng ký ra: %s</string>
-	<!-- Name of the group for booked hotels -->
-	<string name="bookmarks_group_name">Đã đặt trước khách sạn</string>
-	<string name="place_page_button_read_descriprion">Đọc</string>
 	<!-- iOS dialog for the case when recent track recording is on and the app comes back from background -->
 	<string name="recent_track_background_dialog_title">Tắt ghi lại tuyến đường đã đi gần đây của bạn?</string>
 	<string name="off_recent_track_background_button">Tắt</string>
 	<!-- For sharing via SMS and so on -->
 	<string name="sharing_call_action_look">Xem</string>
-	<string name="continue_recent_track_background_button">Tiếp tục</string>
 	<string name="recent_track_background_dialog_message">Organic Maps sử dụng định vị của bạn trong ứng dụng chạy nền để ghi lại tuyến đường đã đi gần đây của bạn.</string>
 	<!-- Rate on Google Play (Android only) -->
 	<string name="rate_gp">Cho điểm trên Google Play</string>
@@ -842,21 +538,11 @@
 	<string name="tell_friends_text">Xin chào! Hãy cài đặt Organic Maps!</string>
 	<!-- About short text (below logo) -->
 	<string name="about_description">Organic Maps là một ứng dụng ngoại tuyến thiết yếu khi đi du lịch. Organic Maps được dựa trên dữ liệu của OpenStreetMap và cho phép bạn hiệu chỉnh nó.</string>
-	<!-- Text in menu -->
-	<string name="blog">Blog</string>
 	<string name="general_settings">Thiết lập chung</string>
-	<string name="date">Ngày %d</string>
-	<!-- "Report a bug" -> "Generaal Feedback" -> "Something is not working" -->
-	<string name="something_is_not_working">Có một vấn đề nào đó</string>
 	<!-- For the first routing -->
 	<string name="accept">Chấp nhận</string>
 	<!-- For the first routing -->
 	<string name="decline">Từ chối</string>
-	<string name="install_app">Cài đặt</string>
-	<string name="search_no_results_title">Không tìm thấy kết quả nào</string>
-	<string name="search_no_results_message">Hãy thử một từ khóa tìm kiếm chung hơn, thu nhỏ hoặc đặt lại bộ lọc.</string>
-	<string name="search_no_results_expand_area_button">Thu nhỏ</string>
-	<string name="search_no_results_reset_button">Đặt lại Bộ lọc</string>
 	<!-- noun -->
 	<string name="search_in_table">Danh sách</string>
 	<string name="mobile_data_dialog">Sử dụng mạng Internet di động để hiển thị thông tin chi tiết?</string>
@@ -868,18 +554,13 @@
 	<string name="mobile_data_option_never">Không bao giờ sử dụng</string>
 	<string name="mobile_data_option_ask">Luôn Hỏi</string>
 	<string name="traffic_update_maps_text">Để hiển thị dữ liệu giao thông, cần cập nhật bản đồ.</string>
-	<string name="traffic_outdated">Dữ liệu giao thông đã lỗi thời.</string>
 	<string name="big_font">Tăng kích cỡ phông chữ trên bản đồ</string>
 	<string name="traffic_update_app">Vui lòng cập nhật Organic Maps</string>
 	<!-- "traffic" as in road congestion -->
 	<string name="traffic_update_app_message">Để hiển thị dữ liệu giao thông, ứng dụng cần phải được cập nhật.</string>
 	<!-- "traffic" as in "road congestion" -->
 	<string name="traffic_data_unavailable">Dữ liệu giao thông không khả dụng</string>
-	<!-- Simplified colour scheme for traffic information, fewer colours are used to display traffic jams on the map. The string should be kept as short as possible -->
-	<string name="pref_traffic_simplified_colors_title">Màu sắc giao thông đơn giản</string>
 	<string name="enable_logging">Bật nhật ký</string>
-	<string name="offline_place_page_more_information">Kết nối đến Internet để xem thêm thông tin về địa điểm này.</string>
-	<string name="failed_load_information">Không thể tải thông tin.</string>
 	<!-- Settings: "Send general feedback" button -->
 	<string name="feedback_general">Phản hồi chung</string>
 	<string name="on">Bật</string>
@@ -893,57 +574,26 @@
 	<string name="routing_add_start_point">Bổ sung điểm bắt đầu để lập kế hoạch lộ trình</string>
 	<string name="routing_add_finish_point">Bổ sung điểm kết thúc để lập kế hoạch lộ trình</string>
 	<string name="button_exit">Thoát</string>
-	<string name="settings_device_memory">Bộ nhớ thiết bị</string>
-	<string name="settings_card_memory">Bộ nhớ thẻ</string>
-	<string name="settings_storage_available">%s trống</string>
-	<string name="toast_location_permission_denied">Quyền định vị của ứng dụng bị từ chối</string>
-	<string name="button_use">Sử dụng</string>
 	<string name="planning_route_manage_route">Quản lý lộ trình</string>
 	<string name="button_plan">Kế hoạch</string>
-	<string name="button_add">Thêm</string>
 	<string name="placepage_remove_stop">Xóa</string>
 	<string name="planning_route_remove_title">Kéo vào đây để xóa</string>
-	<string name="dialog_change_start_point_message">Thay điểm bắt đầu cho vị trí hiện tại?</string>
-	<string name="button_replace">Thay thế</string>
 	<string name="placepage_add_stop">Thêm điểm dừng</string>
-	<string name="add_my_position">Thêm vị trí của tôi</string>
-	<string name="choose_start_point">Chọn một điểm bắt đầu</string>
-	<string name="choose_destination">Chọn một điểm đến</string>
 	<string name="preloader_viator_button">Tìm hiểu thêm</string>
-	<string name="start_from_my_position">Bắt đầu từ</string>
-	<string name="profile_authorization_title">Đăng nhập với</string>
-	<string name="profile_authorization_message">Dễ dàng đăng nhập chỉ trong một vài giây mà không cần tên người dùng và mật khẩu</string>
 	<string name="profile_authorization_error">Rất tiếc, đã có lỗi xảy ra. Hãy thử đăng nhập lại.</string>
-	<string name="service">Dịch vụ</string>
-	<string name="atmosphere">Không khí</string>
-	<string name="value_for_money">Đáng đồng tiền</string>
-	<string name="experience">Trải nghiệm</string>
-	<string name="assortment">Phân loại</string>
-	<string name="expertise">Chuyên môn</string>
-	<string name="equipment">Thiết bị</string>
-	<string name="quality">Chất lượng</string>
 	<string name="dialog_error_storage_title">Vấn đề truy cập ổ lưu trữ</string>
 	<string name="dialog_error_storage_message">Ổ lưu trữ bên ngoài không khả dụng, có thể Thẻ SD đã bị tháo, bị hỏng hoặc hệ thống tập tin được thiết lập chỉ đọc. Hãy kiểm tra và liên hệ với chúng tôi qua support\@organicmaps.app</string>
 	<string name="setting_emulate_bad_storage">Giả lập ổ lưu trữ hỏng</string>
-	<string name="directions_finish">Điểm đến</string>
-	<string name="directions_on_foot">Đi bộ %s</string>
 	<string name="core_entrance">Lối vào</string>
-	<string name="coffee">Cà phê</string>
-	<string name="cleanliness">Sạch sẽ</string>
-	<string name="crowdedness">Đông đúc</string>
 	<string name="error_enter_correct_name">Vui lòng nhập một tên chính xác</string>
 	<string name="bookmarks_groups">Danh sách</string>
 	<string name="bookmarks_groups_hide_all">Ẩn tất cả</string>
 	<string name="bookmarks_groups_show_all">Hiển thị tất cả</string>
-	<plurals name="bookmarks_places">
-	  <item quantity="other">%d dấu trang</item>
-	</plurals>
 	<string name="bookmarks_create_new_group">Tạo danh sách mới</string>
 	<string name="downloader_hide_screen">Ẩn Màn hình</string>
 	<string name="downloader_percent">%1$s (%2$s / %3$s)</string>
-	<string name="downloader_process">Tải về %s...</string>
-	<string name="downloader_applying">Áp dụng %s...</string>
-	<string name="dialog_message_transit_not_found_connection">Xây dựng lộ trình trong một mạng chuyển tiếp</string>
+	<string name="downloader_process">Tải về %s…</string>
+	<string name="downloader_applying">Áp dụng %s…</string>
 	<string name="bookmarks_error_message_share_general">Không thể chia sẻ do lỗi ứng dụng</string>
 	<string name="bookmarks_error_title_share_empty">Lỗi chia sẻ</string>
 	<string name="bookmarks_error_message_share_empty">Không thể chia sẻ một danh sách trống</string>
@@ -952,43 +602,17 @@
 	<string name="bookmarks_new_list_hint">Danh sách mới</string>
 	<string name="bookmarks_error_title_list_name_already_taken">Tên này đã được sử dụng</string>
 	<string name="bookmarks_error_message_list_name_already_taken">Vui lòng chọn một tên khác</string>
-	<string name="bookmarks_error_title_list_name_too_long">Tên này quá dài</string>
-	<string name="bookmarks_error_message_list_name_too_long">Vui lòng chọn một tên khác</string>
-	<string name="please_wait">Vui lòng chờ...</string>
-	<string name="phone_number">Số điện thoại</string>
-	<string name="notification_unsent_reviews_title">Bạn có một số bài đánh giá chưa được đánh giá</string>
-	<string name="notification_unsent_reviews_message">Vui lòng đăng nhập để chia sẻ bài đánh giá với các khách du lịch khác</string>
+	<string name="please_wait">Vui lòng chờ…</string>
 	<string name="profile">Hồ sơ OpenStreetMap</string>
 	<string name="place_page_search_similar_hotel">Tìm kiếm khách sạn</string>
 	<string name="bookmarks_detect_title">Đã phát hiện tệp mới</string>
 	<string name="button_convert">Chuyển đổi</string>
 	<string name="bookmarks_convert_error_title">Lỗi</string>
 	<string name="bookmarks_convert_error_message">Một số tệp không được chuyển đổi.</string>
-	<string name="converting">Đang chuyển đổi...</string>
-	<string name="wn_reinvented_bookmarks_title">Chúng tôi đã tạo lại dấu trang!</string>
-	<string name="wn_reinvented_bookmarks_message">Bạn có thể sao lưu dấu trang, tạo danh sách... Thật tuyệt vời...</string>
-	<string name="bookmarks_restore">Khôi phục dấu trang</string>
-	<string name="bookmarks_restore_process">Đang khôi phục...</string>
 	<string name="bookmarks_restore_title">Khôi phục phiên bản này?</string>
-	<string name="bookmarks_restore_message">Dấu trang của bạn sẽ khôi phục từ %1$s (%2$s)</string>
-	<string name="bookmarks_restore_empty_title">Bạn không có bản sao lưu</string>
-	<string name="bookmarks_restore_empty_message">Máy chủ không tìm thấy các bản sao lưu được tạo trước đó</string>
 	<string name="common_check_internet_connection_dialog_title">Không có kết nối internet</string>
-	<string name="error_server_title">Lỗi máy chủ</string>
-	<string name="error_server_message">Đã xảy ra lỗi trên máy chủ, vui lòng thử lại sau</string>
 	<string name="error_system_message">Đã xảy ra lỗi không xác định</string>
 	<string name="restore">Khôi phục</string>
-	<string name="bookmarks_page_downloaded">Đã tải về</string>
-	<string name="bookmarks_page_my">của tôi</string>
-	<string name="routes_and_bookmarks">Tuyến đường và dấu trang</string>
-	<string name="bookmarks_webview_success_toast">Đã tải xuống thành công dấu trang</string>
-	<string name="cached_bookmarks_placeholder_title">Tải xuống các địa điểm mới</string>
-	<string name="cached_bookmarks_placeholder_subtitle">Nhấn nút để tải xuống hàng ngàn địa điểm và tuyến đường thú vị được tạo bởi người dùng Organic Maps. Bạn sẽ cần kết nối internet.</string>
-	<string name="downloader_download_routers">Tải dấu trang xuống</string>
-	<string name="bookmarks_groups_cached">Danh sách đã tải xuống</string>
-	<plurals name="bookmarks_objects">
-	  <item quantity="other">%s mục tiêu</item>
-	</plurals>
 	<plurals name="objects">
 	  <item quantity="other">%d nơi</item>
 	</plurals>
@@ -1001,62 +625,32 @@
 	<string name="subtittle_opt_out">Thiết lập theo dõi</string>
 	<string name="crash_reports">Báo cáo sự cố</string>
 	<string name="crash_reports_description">Chúng tôi có thể sử dụng dữ liệu của bạn để cải thiện trải nghiệm trên Organic Maps. Thay đổi sẽ có hiệu lực sau khi bạn khởi động lại ứng dụng.</string>
-	<string name="opt_out_help_ios_1">Thiết bị di động của bạn có thể cung cấp cài đặt \"\"Giới hạn theo dõi quảng cáo\"\" hoặc \"\"Chọn không tham gia quảng cáo dựa trên sở thích\"\".</string>
-	<string name="opt_out_help_ios_2">iOS 9 hoặc lớn hơn</string>
-	<string name="opt_out_help_ios_3">Đến Cài đặt → Bảo mật → Quảng cáo → Bật cài đặt \"\"Giới hạn theo dõi quảng cáo\"\"</string>
-	<string name="opt_out_help_android">Thiết bị di động của bạn có thể cung cấp cài đặt \"\"Giới hạn theo dõi quảng cáo\"\" hoặc \"\"Chọn không tham gia quảng cáo dựa trên sở thích\"\".\n\nĐối với Android và Google Play Services phiên bản 4.0 trở lên:\nCài đặt → Google → Quảng cáo → Chọn không tham gia Quảng cáo dựa trên sở thích\ n\nCài đặt → Google → Tài khoản Google → Thông tin cá nhân và bảo mật → Cài đặt quảng cáo → Cá nhân hóa quảng cáo</string>
 	<string name="privacy_policy">Chính sách bảo mật</string>
 	<string name="terms_of_use">Điều khoảng sử dụng</string>
-	<string name="backup_notification_failed">Sao lưu dấu trang của bạn đã bị tạm ngưng. Đăng nhập để bật lại.</string>
 	<string name="button_layer_traffic">Giao thông</string>
 	<string name="button_layer_subway">Xe điện ngầm</string>
 	<string name="layers_title">Các lớp bản đồ</string>
-	<string name="layers_message">Sử dụng các lớp bản đồ để hiển thị tình trạng giao thông, bản đồ tàu điện ngầm và các thông tin hữu ích khác</string>
-	<string name="button_layer_got_it">Đã hiểu</string>
 	<string name="subway_data_unavailable">Bản đồ tàu điện ngầm không khả dụng</string>
 	<string name="bookmarks_empty_list_title">Danh sách trống</string>
 	<string name="bookmarks_empty_list_message">Để thêm dấu trang, hãy nhấn vào một địa điểm trên bản đồ và sau đó nhấn vào biểu tượng dấu sao</string>
 	<string name="category_desc_more">…thêm</string>
 	<string name="title_error_downloading_bookmarks">Đã xảy ra lỗi</string>
-	<string name="subtitle_error_downloading_bookmarks">Dấu trang chưa được tải xuống</string>
-	<string name="error_already_downloaded">Danh sách này đã được tải về</string>
-	<string name="why_support">Tại sao hỗ trợ Organic Maps?</string>
-	<string name="why_support_item2">You help us to improve Organic Maps</string>
-	<string name="why_support_item3">Bạn giúp chúng tôi cải thiện bản đồ mở OpenStreetMap.org</string>
-	<string name="channels_map_update">Cập nhật bản đồ</string>
-	<string name="server_unavailable_title">Máy chủ không khả dụng</string>
-	<string name="sharing_options">Chia sẻ lựa chọn</string>
 	<string name="export_file">Xuất tập tin</string>
 	<string name="list_settings">Cài đặt danh sách</string>
 	<string name="delete_list">Xóa danh sách</string>
-	<string name="hide_from_map">Ẩn từ bản đồ</string>
 	<string name="public_access">Truy cập công khai</string>
 	<string name="limited_access">Truy cập hạn chế</string>
 	<string name="bookmark_category_name">Thể loại</string>
 	<string name="bookmark_category_description_hint">Đánh vào một mô tả (văn bản hoặc html)</string>
 	<string name="not_shared">Riêng tư</string>
-	<string name="direct_link_progress_text">Đang tải tập tin của bạn…</string>
-	<string name="direct_link_success">Liên kết đã được tạo</string>
-	<string name="send_a_link_btn">Gửi cho tôi liên kết</string>
-	<string name="upload_error_toast">Đã xảy ra lỗi trong khi tải lên tập tin của bạn</string>
 	<string name="tags_loading_error_subtitle">Đã xảy ra lỗi khi tải thẻ, vui lòng thử lại</string>
-	<string name="unable_upload_errorr_title">Tải tập tin lên không thành công</string>
-	<string name="unable_upload_error_subtitle_edited">Tập tin này đã được chỉnh sửa qua ứng dụng web</string>
-	<string name="unable_upload_error_subtitle_broken">Tập tin này bị hỏng và không thể tải lên được. Vui lòng tải lên một tập tin khác.</string>
-	<string name="contact">Liên hệ</string>
-	<string name="download_button">Tải</string>
 	<string name="speedcams_alert_title">Tăn tốc độ máy ảnh</string>
-	<string name="speedcams_alert_subtitle">Cảnh báo về giới hạn tốc độ</string>
 	<string name="speedcam_option_auto">Tự động</string>
 	<string name="speedcam_option_always">Luôn luôn</string>
 	<string name="speedcam_option_never">Không bao giờ</string>
-	<string name="bookmark_description_title">Mô tả dấu trang</string>
 	<string name="place_description_title">Mô tả Địa điểm</string>
 	<!-- this text will be shown in application notification preferences opposite checkbox which enable/disable downloader notifications. Devices on Android 8+ are affected. -->
 	<string name="notification_channel_downloader">Trình tải xuống bản đồ</string>
-	<string name="share_bookmarks_email_body_link">Xin chào!\n\nĐây là liên kết nơi bạn có thể tải xuống dấu trang của mình: %s. Mở danh sách qua Organic Maps và tận hưởng chuyến đi của bạn!\n\nNhận đơn đăng ký: https://omaps.app/get?kmz</string>
-	<string name="warning_speedcams_title">Thanh điều hướng sẽ cảnh báo bạn về máy ảnh khi bạn vượt quá giới hạn tốc độ %d km/h</string>
-	<string name="warning_speedcams_subtitle">Hãy nhớ lái xe quy định của đất nước bạn đang đi du lịch đến.</string>
 	<string name="speedcams_notice_message">Tự động - Cảnh báo về speedcam nếu có nguy cơ vượt quá giới hạn tốc độ\nLuôn luôn - Luôn cảnh báo về speedcams\nKhông bao giờ - Không bao giờ cảnh báo về speedcams</string>
 	<string name="power_managment_title">Chế độ tiết kiệm năng lượng</string>
 	<string name="power_managment_description">Nếu chế độ tiết kiệm năng lượng được bật, ứng dụng sẽ tắt các chức năng tiêu thụ năng lượng tùy thuộc vào mức pin hiện tại của điện thoại</string>
@@ -1064,14 +658,7 @@
 	<string name="power_managment_setting_auto">Tự động</string>
 	<string name="power_managment_setting_manual_max">Tiết kiệm năng lượng tối đa</string>
 	<string name="enable_logging_warning_message">Tùy chọn này được kích hoạt để ghi nhật ký đăng nhập cho mục đích chẩn đoán. Điều này sẽ giúp nhóm chúng tôi làm rõ các vấn đề liên quan đến ứng dụng. Hãy bật tùy chọn này chỉ khi nào có yêu cầu hỗ trợ từ Organic Maps.</string>
-	<string name="html_error_upload_message_try_again">Vui lòng kiểm tra kết nối internet và thử lại</string>
-	<string name="html_error_upload_title_try_again">Không có kết nối internet</string>
-	<string name="notification_leave_review_v2_android_short_title">Hãy để lại nhận xét và giúp khách du lịch!</string>
-	<string name="notifications_illegal_alert_disable_button">Tắt thông báo</string>
 	<string name="access_rules_author_only">Chỉnh sửa trực tuyến</string>
-	<string name="privacy_settings_menu">Cài đặt bảo mật</string>
-	<string name="unable_upadate_error_title">Cập nhận hướng dẫn không thành công</string>
-	<string name="unable_upadate_error_message">Xuất hiện lỗi khi cập nhật. Hãy kiểm tra lại những thay đổi và thử lại lần nữa</string>
 	<string name="driving_options_title">Thiết lập đi vòng</string>
 	<string name="driving_options_subheader">Tránh trên mỗi tuyến</string>
 	<string name="avoid_tolls">Đường trả phí</string>
@@ -1082,52 +669,14 @@
 	<string name="unable_to_calc_alert_subtitle">Rất tiếc, chúng không thể tạo tuyến đường với những tùy chọn đã chọn. Hãy thay đổi thiết lập và thử lại</string>
 	<string name="define_to_avoid_btn">Thiết lập đường đi vòng</string>
 	<string name="change_driving_options_btn">Thiết lập đường đi tránh đã được bật</string>
-	<string name="toll_road">Đường trả phí</string>
-	<string name="unpaved_road">Đường đất</string>
-	<string name="ferry_crossing">Bến phà</string>
-	<string name="operated_by">Tạo được \"%s\"</string>
 	<string name="avoid_toll_roads_placepage">Tránh đường trả phí</string>
 	<string name="avoid_unpaved_roads_placepage">Tránh đường đất</string>
 	<string name="avoid_ferry_crossing_placepage">Tránh bến phà</string>
-	<string name="type.cuisine.uzbek">Ẩm thực của Uzbekistan</string>
-	<string name="trip_start">Đi nào</string>
-	<string name="pick_destination">Mục đích</string>
-	<string name="follow_my_position">Định tâm</string>
-	<string name="search_results">Kết quả tìm kiếm</string>
-	<string name="then_turn">Sau đó</string>
-	<string name="redirect_route_alert">Bạn có muốn tạo lại tuyến không?</string>
-	<string name="redirect_route_yes">Có</string>
-	<string name="redirect_route_no">Không</string>
-	<string name="trip_finished">Bạn đã tới nơi!</string>
-	<string name="keyboard_availability_alert">Bàn phím không khả dụng trong thời gian di chuyển</string>
-	<string name="dialog_routing_change_start_carplay">Không thể tạo tuyến đường từ địa điểm hiển tại</string>
-	<string name="dialog_routing_change_end_carplay">Không thể tạo tuyến đường tới điểm kết cuối. Hãy chọn điểm khác</string>
-	<string name="dialog_routing_check_gps_carplay">Không có tín hiệu GPS. Hãy đến vị trí có không gian mở</string>
-	<string name="dialog_routing_unable_locate_route_carplay">Không thể tạo tuyến đường. Hãy chọn những điểm khác cho tuyến đường</string>
-	<string name="dialog_routing_download_files_carplay">Để tạo tuyến đường, hãy tải xuống các bản đồ còn thiếu về thiết bị</string>
-	<string name="dialog_routing_system_error_carplay">Đã xảy ra lỗi. Khởi động lại ứng dụng</string>
-	<string name="dialog_routing_rebuild_from_current_location_carplay">Tuyến đường sẽ được tạo lại từ vị trí hiện tại của bạn</string>
-	<string name="dialog_routing_rebuild_for_vehicle_carplay">Tuyến đường sẽ được thay đổi thành tuyến dành cho xe ô tô</string>
 	<string name="ok">Ok</string>
-	<string name="avoid_unpaved_carplay_1">Trừ đườg đất</string>
-	<string name="avoid_unpaved_carplay_2">Trừ khôg trnhựa</string>
-	<string name="avoid_ferry_carplay_1">Không có phà</string>
-	<string name="avoid_ferry_carplay_2">Trừ phà</string>
-	<string name="avoid_tolls_carplay_1">Khôg đgcóphí</string>
-	<string name="avoid_tolls_carplay_2">Trừ đg có phí</string>
-	<string name="speedcams_alert_title_carplay_1">Сam tốc độ</string>
-	<string name="speedcams_alert_title_carplay_2">Cảnh báo tốc độ</string>
-	<string name="download_map_carplay">Vui lòng tải xuống bản đồ trong ứng dụng Organic Maps trên thiết bị của bạn</string>
-	<string name="carplay_roundabout_exit">Lối ra %s của vòng xuyến</string>
 	<!-- max. 10 symbols, both iOS and Android -->
 	<string name="sort">Sắp xếp…</string>
 	<!-- Android, title, max 20-22 symbols -->
 	<string name="sort_bookmarks">Sắp xếp dấu trang</string>
-	<!-- iOS -->
-	<string name="sort_default">Sắp xếp theo mặc định</string>
-	<string name="sort_type">Sắp xếp theo kiểu</string>
-	<string name="sort_distance">Sắp xếp theo khoảng cách</string>
-	<string name="sort_date">Sắp xếp theo ngày</string>
 	<!-- Android -->
 	<string name="by_default">Theo mặc định</string>
 	<!-- Android -->
@@ -1136,65 +685,23 @@
 	<string name="by_distance">Theo khoảng cách</string>
 	<!-- Android -->
 	<string name="by_date">Theo ngày</string>
-	<string name="week_ago_sorttype">Tuần trước</string>
-	<string name="month_ago_sorttype">Tháng trước</string>
-	<string name="moremonth_ago_sorttype">Hơn một tháng trước</string>
-	<string name="moreyear_ago_sorttype">Hơn một năm trước</string>
-	<string name="near_me_sorttype">Ở gần tôi</string>
-	<string name="others_sorttype">Khác</string>
-	<string name="food_places">Đồ ăn</string>
-	<string name="tourist_places">Danh lam thắng cảnh</string>
-	<string name="museums">Bảo tàng</string>
-	<string name="parks">Công viên</string>
-	<string name="swim_places">Bơi lội</string>
-	<string name="mountains">Núi non</string>
-	<string name="animals">Động vật</string>
-	<string name="hotels">Khách sạn</string>
-	<string name="buildings">Tòa nhà</string>
-	<string name="money">Tiền</string>
-	<string name="shops">Cửa hàng</string>
-	<string name="parkings">Bãi đậu xe</string>
-	<string name="fuel_places">Trạm xăng dầu</string>
-	<string name="water">Nước</string>
-	<string name="medicine">Y tế</string>
 	<string name="search_in_the_list">Tìm trong danh sách</string>
-	<string name="view_on_map_bookmarks">Trên bản đồ</string>
-	<string name="more_bookmarks">Thêm…</string>
-	<string name="no_items_found">Không tìm thấy gì cả</string>
-	<!-- Android, max 18 symbols -->
-	<string name="bookmarks_edit_list">Chỉnh sửa</string>
-	<!-- Android, max 18 symbols -->
-	<string name="bookmarks_delete_list">Xóa dánh sách</string>
-	<string name="religious_places">Những nơi tôn nghiêm</string>
 	<string name="select_list">Chọn danh sách</string>
 	<string name="transit_not_found">Điều hướng đến Metro hiện chưa khả dụng cho khu vực này</string>
 	<string name="dialog_pedestrian_route_is_long_header">Không tìm thấy tuyến Metro</string>
 	<string name="dialog_pedestrian_route_is_long_message">Hãy chọn điểm đầu hoặc điểm cuối của tuyến gần với bến Metro</string>
-	<!-- Failed planning SUBWAY route message in navigation view -->
-	<string name="routing_planning_error_subway_special">Lỗi xây dựng tuyến Metro</string>
 	<string name="button_layer_isolines">Độ cao</string>
-	<string name="tips_map_layers_title_countour">Đường độ cao ngoại tuyến trong Organic Maps!</string>
-	<string name="tips_map_layers_message_countour">Đường độ cao giúp lên kế hoạch du lịch hòa mình với thiên nhiên và không bị lạc khi di chuyển</string>
 	<string name="isolines_activation_error_dialog">Để sử dụng các đường chỉ độ cao, hãy cập nhật hoặc tải xuống bản đồ của khu vực bạn mong muốn</string>
 	<string name="isolines_location_error_dialog">Đường hiển thị độ cao hiện chưa khả dụng tại khu vực này</string>
 	<string name="elevation_profile_diff_level">Mức độ phức tạp</string>
-	<string name="elevation_profile_diff_level_easy">Dễ</string>
-	<string name="elevation_profile_diff_level_moderate">Trung bình</string>
-	<string name="elevation_profile_diff_level_hard">Khó</string>
 	<string name="elevation_profile_ascent">Đi lên</string>
 	<string name="elevation_profile_descent">Đi xuống</string>
 	<string name="elevation_profile_minaltitude">Độ cao tối thiểu</string>
 	<string name="elevation_profile_maxaltitude">Độ cao tối đa</string>
-	<string name="elevation_profile_m">m</string>
 	<string name="elevation_profile_difficulty">Độ khó</string>
 	<string name="elevation_profile_distance">Khoảng cách</string>
-	<string name="elevation_profile_km">km</string>
 	<string name="elevation_profile_time">Giờ:</string>
-	<string name="elevation_profile_hours">h.</string>
-	<string name="elevation_profile_minutes">ph</string>
 	<string name="isolines_toast_zooms_1_10">Phóng bản đồ để nhìn rõ đường đồng mức</string>
-	<string name="downloader_updating_ios">Cập nhật</string>
-	<string name="downloader_loading_ios">Tải xuống</string>
 	<string name="key_information_title">Thông tin chìa khóa</string>
 	<string name="enable_screen_sleep">Cho phép màn hình ở chế độ ngủ</string>
 	<!-- Description in preferences -->

--- a/android/res/values-zh-rTW/strings.xml
+++ b/android/res/values-zh-rTW/strings.xml
@@ -12,8 +12,6 @@
 	<string name="cancel_download">取消下載</string>
 	<!-- Button which deletes downloaded country -->
 	<string name="delete">刪除</string>
-	<!-- Button "do not interrupt download" if user touched actively downloading country -->
-	<string name="do_nothing">繼續</string>
 	<string name="download_maps">下載地圖</string>
 	<!-- Settings/Downloader - info for country when download fails -->
 	<string name="download_has_failed">下載失敗，輕觸以再試一次</string>
@@ -31,45 +29,31 @@
 	<string name="core_my_position">我的位置</string>
 	<!-- Update maps later/Buy pro version later button text -->
 	<string name="later">稍後</string>
-	<!-- Don't show some dialog any more -->
-	<string name="never">不再提醒</string>
 	<!-- View and button titles for accessibility -->
 	<string name="search">搜尋</string>
 	<!-- Search box placeholder text -->
 	<string name="search_map">搜尋地圖</string>
-	<!-- Settings/Downloader - info for not downloaded country -->
-	<string name="touch_to_download">輕觸以下載</string>
 	<!-- Settings/Downloader - 3G download warning dialog confirm button -->
 	<string name="use_cellular_data">是</string>
 	<!-- Location services are disabled by user alert - message -->
 	<string name="location_is_disabled_long_text">您目前裝置所有的定位服務或相關應用程式是處於停用的狀態，請從系統設定中選擇啟用。</string>
-	<!-- Location Services are not available on the device alert - message -->
-	<string name="device_doesnot_support_location_services">您的裝置不支援定位服務</string>
 	<!-- View and button titles for accessibility -->
 	<string name="zoom_to_country">在地圖上顯示</string>
-	<!-- Button text for the button at the center of the screen when the country is not downloaded -->
-	<string name="country_status_download">下載地圖\n(^ ^)</string>
 	<!-- Button text for the button at the center of the screen when the country is not downloaded and the size should not be shown -->
 	<string name="country_status_download_without_size">下載地圖</string>
-	<!-- Button text for the button at the center of the screen when the country is not downloaded -->
-	<string name="country_status_download_without_routing">下載不帶路線的地圖\n(^ ^)</string>
 	<!-- Message to display at the center of the screen when the country download has failed -->
 	<string name="country_status_download_failed">下載失敗</string>
 	<!-- Button text for the button under the country_status_download_failed message -->
 	<string name="try_again">再試一次</string>
 	<string name="about_menu_title">關於 Organic Maps</string>
-	<string name="downloaded_touch_to_delete">已下載的 (%s)，輕觸以刪除</string>
 	<string name="connection_settings">連線設定</string>
-	<string name="download_mb_or_kb">下載 %s</string>
 	<string name="close">關閉</string>
 	<string name="unsupported_phone">需要 OpenGL 硬體加速功能的支援。但很不幸的，您的裝置並不支援此功能！</string>
 	<string name="download">下載</string>
-	<string name="external_storage_is_not_available">SD 卡/USB 無法有效儲存下載的地圖</string>
 	<string name="disconnect_usb_cable">請拔除 USB 線或插入 SD 卡以使用 Organic Maps</string>
 	<string name="not_enough_free_space_on_sdcard">如要繼續使用，請先釋放一些 SD 卡/ USB 儲存空間</string>
 	<string name="not_enough_memory">沒有足夠的記憶體以啟動應用程式</string>
 	<string name="download_resources">在您開始之前，先讓我們下載世界地圖到您的裝置中以便瀏覽。\n這需要資料的 %s。</string>
-	<string name="getting_position">取得目前所在位置</string>
 	<string name="download_resources_continue">跳到地圖</string>
 	<string name="downloading_country_can_proceed">正在下載 %s。您現在 可以繼續使用地圖了</string>
 	<string name="download_country_ask">下載 %s?</string>
@@ -82,30 +66,20 @@
 	<string name="download_country_failed">%s 下載失敗</string>
 	<!-- Add New Bookmark Set dialog title -->
 	<string name="add_new_set">新增收藏夾</string>
-	<!-- Place Page - Add To Bookmarks button -->
-	<string name="add_to_bookmarks">新增到書籤</string>
 	<!-- Bookmark Color dialog title -->
 	<string name="bookmark_color">書籤顏色</string>
 	<!-- Add Bookmark Set dialog - hint when set name is empty -->
 	<string name="bookmark_set_name">收藏夾名稱</string>
-	<!-- Bookmark Sets dialog title -->
-	<string name="bookmark_sets">收藏夾</string>
 	<!-- Bookmarks - dialog title -->
 	<string name="bookmarks">書籤</string>
-	<!-- Add bookmark dialog - bookmark color -->
-	<string name="color">顏色</string>
 	<!-- Default bookmarks set name -->
 	<string name="core_my_places">我的地點</string>
 	<!-- Add bookmark dialog - bookmark name -->
 	<string name="name">名稱</string>
 	<!-- Editor title above street and house number -->
 	<string name="address">位址</string>
-	<!-- Place Page - Remove Pin button -->
-	<string name="remove_pin">移除圖釘</string>
 	<!-- Add bookmark dialog - bookmark set, Bookmarks dialog - Bookmark set cell -->
 	<string name="set">收藏夾</string>
-	<!-- Text hint in Bookmarks dialog when no any bookmarks are added -->
-	<string name="bookmarks_usage_hint">您還沒有任何書籤。\n點擊地圖上的任何地方以新增書籤。\n其他來源的書籤也可導入在 Organic Maps 中顯示。從電子郵件、Dropbox 或網站連結開啟有著已儲存書籤的 KML/KMZ 檔案。</string>
 	<!-- Settings button in system menu -->
 	<string name="settings">設定</string>
 	<!-- Header of settings activity where user defines storage path -->
@@ -116,20 +90,10 @@
 	<string name="move_maps">移動地圖？</string>
 	<!-- Ask to wait user several minutes (some long process in modal dialog). -->
 	<string name="wait_several_minutes">這可能需要幾分鐘\n請稍候…</string>
-	<!-- Show bookmarks from this category on a map or not -->
-	<string name="visible">可見</string>
-	<!-- Toast which is displayed when GPS has been deactivated -->
-	<string name="gps_is_disabled_long_text">GPS 目前是關閉的，請在系統中設定為啟用</string>
 	<!-- Measurement units title in settings activity -->
 	<string name="measurement_units">測量單位</string>
 	<!-- Detailed description of Measurement Units settings button -->
 	<string name="measurement_units_summary">請選擇公里或英哩</string>
-	<!-- Do search in all sources -->
-	<string name="search_mode_all">任何地方</string>
-	<!-- Do search near my position only -->
-	<string name="search_mode_nearme">我的附近</string>
-	<!-- Do search in current viewport only -->
-	<string name="search_mode_viewport">畫面中</string>
 	<!-- Search category for cafes, bars, restaurants -->
 	<string name="eat">在哪兒吃</string>
 	<!-- Search category for grocery stores -->
@@ -166,12 +130,8 @@
 	<string name="post">郵局</string>
 	<!-- Search category -->
 	<string name="police">警察局</string>
-	<!-- String in search result list, when nothing found -->
-	<string name="no_search_results_found">找不到搜尋結果</string>
 	<!-- Notes field in Bookmarks view -->
 	<string name="description">描述說明</string>
-	<!-- Button text -->
-	<string name="share_by_email">以電子郵件分享</string>
 	<!-- Email Subject when sharing bookmarks category -->
 	<string name="share_bookmarks_email_subject">已分享 Organic Maps 書籤</string>
 	<!-- message title of loading file -->
@@ -184,20 +144,10 @@
 	<string name="edit">編輯</string>
 	<!-- Warning message when doing search around current position -->
 	<string name="unknown_current_position">您的位置尚未定位完成</string>
-	<!-- Warning message when location country isn't downloaded during search (see also download_location_map_proposal). -->
-	<string name="download_location_country">下載您目前所在位置的國家 地圖 (%s)</string>
-	<!-- Warning message when viewport country isn't downloaded during search -->
-	<string name="download_viewport_country_to_search">下載您正在搜尋的國家 地圖 (%s)</string>
 	<!-- Alert message that we can't run Map Storage settings due to some reasons. -->
 	<string name="cant_change_this_setting">很抱歉，地圖儲存設定目前已停用。</string>
 	<!-- Alert message that downloading is in progress. -->
 	<string name="downloading_is_active">國家地圖正在進行下載</string>
-	<!-- Message that will be shown in alert view, when we ask user to leave review on App Store -->
-	<string name="appStore_message">祝您使用 Organic Maps 愉快！ 方便的話，請到 App Store 幫我們評分或寫寫評論。在這短短的時間當中卻能夠真正的協助我們改善，再次感謝您的支持！</string>
-	<!-- No, thanks -->
-	<string name="no_thanks">不，謝了</string>
-	<!-- Share one specific bookmark using SMS, %1$@ contains om:// and %2$@ https://omaps.app link. @NOTE non-ascii symbols in the link will result in max 70 characters SMS instead of 140. -->
-	<string name="bookmark_share_sms">嘿，看看我在 Organic Maps 標記的圖釘吧！ %1$s 或%2$s 沒安裝離線地圖？在此下載: https://omaps.app/get</string>
 	<!-- Share my position using SMS, %1$@ contains om:// and %2$@ https://omaps.app link WITHOUT NAME. @NOTE non-ascii symbols in the link will result in max 70 characters SMS instead of 140. -->
 	<string name="my_position_share_sms">嘿，在 Organic Maps 查看我的目前位置吧！ %1$s 或%2$s 沒安裝離線地圖？在此下載: https://omaps.app/get</string>
 	<!-- Subject for emailed bookmark -->
@@ -206,30 +156,16 @@
 	<string name="my_position_share_email_subject">嗨，到 Organic Maps 地圖查看我的目前位置！</string>
 	<!-- Share my position using EMail, %1$@ is om:// and %2$@ is https://omaps.app link WITHOUT NAME -->
 	<string name="my_position_share_email">嗨，\n\n我現在在這：%1$s。點擊此連結 %2$s 或此連結 %3$s 來查看在地圖上的位置。\n\n謝謝。</string>
-	<!-- Android share by Message/SMS button text (including SMS) -->
-	<string name="share_by_message">透過訊息分享</string>
 	<!-- Share button text which opens menu with more buttons, like Message, EMail, Facebook etc. -->
 	<string name="share">分享</string>
-	<!-- iOS share by Message button text (including SMS) -->
-	<string name="message">訊息</string>
 	<!-- Share by email button text, also used in editor. -->
 	<string name="email">電子郵件</string>
-	<!-- Copy Link -->
-	<string name="copy_link">複製連結</string>
-	<!-- Text for the button that returns to caller application -->
-	<string name="more_info">顯示更多資訊</string>
 	<!-- Text for message when used successfully copied something -->
 	<string name="copied_to_clipboard">已複製到剪貼簿：%1$s</string>
 	<!-- place preview title -->
 	<string name="info">簡介</string>
 	<!-- Used for bookmark editing -->
 	<string name="done">完成</string>
-	<!-- Summary for preferences in MWM -->
-	<string name="yopme_pref_summary">選擇第二螢幕設定</string>
-	<!-- Title for yopme preferences in MWM -->
-	<string name="yopme_pref_title">第二螢幕設定</string>
-	<!-- Hint for upper-right icon p2b -->
-	<string name="show_on_backscreen">在第二螢幕上顯示</string>
 	<!-- Prints version number in About dialog -->
 	<string name="version">版本： %s</string>
 	<!-- Data version in «About» screen -->
@@ -241,11 +177,6 @@
 	<!-- Length of track in cell that describes route -->
 	<string name="length">長度</string>
 	<string name="share_my_location">分享我的位置</string>
-	<string name="menu_search">搜尋</string>
-	<!-- Settings screen: "Map" category title -->
-	<string name="prefs_group_map">地圖</string>
-	<!-- Settings screen: "Miscellaneous" category title -->
-	<string name="prefs_group_misc">其他</string>
 	<string name="prefs_group_route">導航</string>
 	<string name="pref_zoom_title">縮放按鈕</string>
 	<string name="pref_zoom_summary">在螢幕上顯示</string>
@@ -261,8 +192,6 @@
 	<string name="pref_map_3d_title">透視圖</string>
 	<!-- Settings «Map» category: «3D buildings» title -->
 	<string name="pref_map_3d_buildings_title">3D 建築</string>
-	<!-- Settings «Map» category: «3D buildings» summary -->
-	<string name="pref_map_3d_buildings_subtitle">增加電池消耗</string>
 	<!-- Settings «Route» category: «Tts enabled» title -->
 	<string name="pref_tts_enable_title">語音指示</string>
 	<!-- Settings «Route» category: «Tts language» title -->
@@ -271,7 +200,6 @@
 	<string name="pref_tts_unavailable">無法使用</string>
 	<!-- Title for "Other" section in TTS settings. -->
 	<string name="pref_tts_other_section_title">其他</string>
-	<string name="pref_tts_how_to_set_up_voice">如何設定語音</string>
 	<!-- Settings «Map» category: «Record track» title -->
 	<string name="pref_track_record_title">最近的軌跡</string>
 	<string name="pref_map_auto_zoom">自動縮放</string>
@@ -282,46 +210,11 @@
 	<string name="duration_12_hours">12小時</string>
 	<string name="duration_1_day">1天</string>
 	<string name="recent_track_help_text">它可讓您記錄特定期間所行經的路徑，並在地圖上看到該路徑。請注意：啟用此項功能會增加電池使用量。在時間間隔過期後，會從地圖中自動移除行進路線。</string>
-	<string name="pref_track_ios_caption">近期軌跡顯示您的行進道路。</string>
-	<string name="pref_track_ios_subcaption">請選擇儲存軌跡的時間範圍。</string>
-	<string name="placepage_distance">距离</string>
-	<string name="placepage_coordinates">座標</string>
-	<string name="placepage_unsorted">未分類</string>
 	<string name="search_show_on_map">在地圖上查看</string>
-	<!-- Used to warn user when fixing KitKat issue -->
-	<string name="bookmark_move_fail">我們需要將您的書籤移至內部記憶體中，但沒有足夠的存儲空間。請釋放一些記憶體，否則，書籤將不可用。</string>
-	<!-- Used in More Apps menu -->
-	<string name="free">免費</string>
-	<!-- Used in More Apps menu -->
-	<string name="buy">購買</string>
-	<!-- 1st search button-like result -->
-	<string name="search_on_map">在地圖上搜尋</string>
-	<!-- toast with an error -->
-	<string name="no_route_found">找不到路線</string>
-	<!-- route title -->
-	<string name="route">路線</string>
-	<!-- category title -->
-	<string name="routes">路線</string>
-	<!-- text of notification -->
-	<string name="download_map_notification">下載您所在地方的地圖</string>
-	<!-- text of notification -->
-	<string name="pro_version_is_free_today">現在完整版 Organic Maps 是免費的！馬上下載並告訴您的朋友。</string>
-	<!-- Dialog for transferring maps from lite to pro. -->
-	<string name="move_lite_maps_to_pro">我們正在將您從 Organic Maps Lite 下載的地圖傳輸至 Organic Maps。這可能需要幾分鐘的時間。</string>
-	<!-- Message to display when maps moved. -->
-	<string name="move_lite_maps_to_pro_ok">您下載的地圖已成功傳輸至 Organic Maps。</string>
-	<!-- Message to display when maps move failed. -->
-	<string name="move_lite_maps_to_pro_failed">您的地圖傳輸失敗。請刪除 Organic Maps Lite，然後再次下載地圖。</string>
-	<!-- Text in menu -->
-	<string name="settings_and_more">設定及更多</string>
 	<!-- Text in menu -->
 	<string name="website">網站</string>
-	<!-- Text in menu -->
-	<string name="contact_us">聯絡我們</string>
 	<!-- Settings: Send feedback button and dialog title -->
 	<string name="feedback">意見反應</string>
-	<!-- Text in menu -->
-	<string name="subscribe_to_news">訂閱我們的新聞</string>
 	<!-- Text in menu -->
 	<string name="rate_the_app">為該應用程式評分</string>
 	<!-- Text in menu -->
@@ -330,12 +223,6 @@
 	<string name="copyright">版權</string>
 	<!-- Text in menu -->
 	<string name="report_a_bug">報告錯誤</string>
-	<!-- Email subject -->
-	<string name="subscribe_me_subject">請幫我訂閱 Organic Maps 新聞郵件、</string>
-	<!-- Email body -->
-	<string name="subscribe_me_body">我想搶先了解最新新聞、更新和促銷活動。我可以隨時取消我的訂閱。</string>
-	<!-- About text -->
-	<string name="about_text">Organic Maps 提供全球所有國家和所有城市的最快速的離線地圖。充滿自信地出行：無論您在哪，Organic Maps都能夠幫助您在地圖上找到您自己的位置，找到最近的餐館、酒店、銀行、加油站，等等。無需網路連接。 我們始終在為增加新功能而努力，並希望能夠聽到您對我們應如何改進 Organic Maps 的想法。若您在使用本應用程式時遇到任何問題，請隨時聯繫我們：support\@organicmaps.app。我們會回覆每一條請求！\n\n您喜歡 Organic Maps 並想支持我們嗎？以下為一些簡單且完全免費的方法：\n- 在您的應用程式商店上發表評論\n- 在我們的 Facebook 頁面 http://www.facebook.com/OrganicMaps 上按讚\n- 或者向您的母親、朋友，以及同事介紹 Organic Maps :)\n\n感謝您與我們在一起。非常感謝您的支持。\n\nP.S.：我們從 OpenStreetMap 獲得地圖資訊，這是一個類似維基百科的地圖繪製專案，能夠讓使用者建立並編輯編輯地圖。若您看到地圖上缺少了什麽或者有什麽錯誤，可以直接在 https://www.openstreetmap.org 上進行糾正。在下一個版本發佈時，您做出的更改便會出現在 Organic Maps 應用程式中。</string>
 	<!-- Alert text -->
 	<string name="email_error_body">電子郵件客戶端尚未建立。請設定或使用任何其他方式與我們聯絡%s</string>
 	<!-- Alert title -->
@@ -344,135 +231,56 @@
 	<string name="pref_calibration_title">指南針校準</string>
 	<!-- Search category -->
 	<string name="wifi">無線網路</string>
-	<!-- Update map suggestion -->
-	<string name="routing_map_outdated">請更新地圖以建立一條路線。</string>
-	<!-- Update maps suggestion -->
-	<string name="routing_update_maps">使用新版本的 Organic Maps 可以建立從您的目前位置至一個目的地的路線。請更新地圖以使用該功能。</string>
 	<!-- Update all button text -->
 	<string name="downloader_update_all_button">更新全部</string>
 	<!-- Cancel all button text -->
 	<string name="downloader_cancel_all">全部取消</string>
 	<!-- Downloaded maps category -->
 	<string name="downloader_downloaded_subtitle">已下載</string>
-	<!-- Downloaded maps category -->
-	<string name="downloader_available_maps">可用</string>
 	<!-- Country queued for download -->
 	<string name="downloader_queued">已佇列</string>
 	<string name="downloader_near_me_subtitle">在我附近</string>
 	<string name="downloader_status_maps">地圖</string>
 	<string name="downloader_download_all_button">下載全部</string>
 	<string name="downloader_downloading">正在下載：</string>
-	<string name="downloader_search_results">已找到</string>
-	<!-- Disclaimer message -->
-	<string name="routing_disclaimer">在 Organic Maps 應用程式中建立路線時請謹記以下幾點：\n\n  - 建議路線僅可當作推薦路線。\n - 路況、交通規則以及標誌應優先於導航建議。\n - 地圖可能會不正確或者過時，路線也可能不是以最佳可能方式建立的。\n\n  行車安全，請照顧好您自己！</string>
-	<!-- Outdated maps category -->
-	<string name="downloader_outdated_maps">過時的</string>
-	<!-- Up to date maps category -->
-	<string name="downloader_uptodate_maps">最新的</string>
 	<!-- Status of outdated country in the list -->
 	<string name="downloader_status_outdated">更新</string>
 	<!-- Status of failed country in the list -->
 	<string name="downloader_status_failed">失敗</string>
 	<!-- Displayed in a dialog that appears when a user tries to delete a map while the app is in the follow route mode -->
 	<string name="downloader_delete_map_while_routing_dialog">如欲刪除地圖，請停止導航。</string>
-	<!-- Show when user try build route, but we don't know where he -->
-	<string name="routing_failed_unknown_my_position">目前地點未定。請等待明確地點以建立路線。</string>
-	<!-- Show if use has not routing file, or InconsistentMWMandRoute -->
-	<string name="routing_failed_has_no_routing_file">需要額外的數據才能建立路線。開始下載嗎？</string>
-	<!-- StartPointNotFound -->
-	<string name="routing_failed_start_point_not_found">無法計算路線。沒有路在您的起點附近。</string>
-	<!-- EndPointNotFound -->
-	<string name="routing_failed_dst_point_not_found">無法計算路線。沒有路在您的終點附近。</string>
 	<!-- PointsInDifferentMWM -->
 	<string name="routing_failed_cross_mwm_building">路程只能完全處在同一地圖裡時才能被建立。</string>
-	<!-- RouteNotFound -->
-	<string name="routing_failed_route_not_found">找不到所選起點和終點間的路程。請選擇不同的起點或終點。</string>
-	<!-- InternalError -->
-	<string name="routing_failed_internal_error">出現內部錯誤。請嘗試刪除並再次下載地圖。如果還有問題請聯絡我們：support\@organicmaps.app。</string>
-	<!-- Context menu item for downloader. -->
-	<string name="downloader_download_map_and_routing">下載地圖 + 路線</string>
-	<!-- Context menu item for downloader. -->
-	<string name="downloader_download_routing">下載路線</string>
-	<!-- Context menu item for downloader. -->
-	<string name="downloader_delete_routing">刪除路線</string>
 	<!-- Context menu item for downloader. -->
 	<string name="downloader_download_map">下載地圖</string>
-	<string name="downloader_download_map_no_routing">下載不帶路線的地圖</string>
-	<!-- Button for routing. -->
-	<string name="routing_go">開始！</string>
 	<!-- Item status in downloader. -->
 	<string name="downloader_retry">重試</string>
-	<!-- Item in context menu. -->
-	<string name="downloader_map_and_routing">地圖 + 路線</string>
 	<!-- Item in context menu. -->
 	<string name="downloader_delete_map">刪除地圖</string>
 	<!-- Item in context menu. -->
 	<string name="downloader_update_map">更新地圖</string>
-	<!-- Item in context menu. -->
-	<string name="downloader_update_map_and_routing">更新地圖 + 路線</string>
-	<!-- Item in context menu. -->
-	<string name="downloader_map_only">只有地圖</string>
 	<!-- Preference text -->
 	<string name="pref_use_google_play">使用 Google Play 服務來獲得您的目前位置</string>
 	<!-- Text for rating dialog -->
 	<string name="rating_just_rated">我剛剛評價了您的應用</string>
-	<!-- Text for rating dialog -->
-	<string name="rating_user_since">我是從 %s 年起的 Organic Maps 使用者</string>
-	<!-- Text for rating dialog -->
-	<string name="rating_do_like_maps">您喜歡 Organic Maps 嗎？</string>
-	<!-- Text for rating dialog -->
-	<string name="rating_tap_star">點擊星星給我們應用程式評分。</string>
 	<!-- Text for rating dialog -->
 	<string name="rating_thanks">謝謝您！</string>
 	<!-- Text for rating dialog -->
 	<string name="rating_share_ideas">分享任何主意或問題，這樣我們可以為您改善應用程式。</string>
 	<!-- Text for rating dialog -->
 	<string name="rating_send_feedback">發送回饋</string>
-	<!-- Text for g+ dialog -->
-	<string name="rating_google_plus">點擊g+向您的朋友們告知這款應用程式。</string>
 	<!-- Text for routing error dialog -->
 	<string name="routing_download_maps_along">下載沿線地圖</string>
-	<!-- Text for routing error dialog -->
-	<string name="routing_download_map">獲取地圖</string>
-	<!-- Text for routing error dialog -->
-	<string name="routing_download_map_and_routing">下載更新的地圖和路線數據，獲取所有 Organic Maps 的特色功能。</string>
-	<!-- Text for routing error dialog -->
-	<string name="routing_get_routing_data">獲取所需的路線數據</string>
-	<!-- Text for routing error dialog -->
-	<string name="routing_get_additional_data">需要更多數據以從您的位置建立路線。</string>
 	<!-- Text for routing error dialog -->
 	<string name="routing_requires_all_map">建立路線需要下載並更新好所有從您的位置到目的地的地圖。</string>
 	<!-- Text for routing error dialog -->
 	<string name="routing_not_enough_space">空間不足</string>
-	<!-- Text for routing error dialog -->
-	<string name="routing_download_more_than_avail">您需要下載%1$s MB，但只有%2$s MB空間。</string>
-	<!-- Text for routing error dialog -->
-	<string name="routing_download_roaming">您將使用行動數據下載%s MB（漫遊）。這取決於您的行動數據方案服務業者，可能會產生額外的費用。</string>
 	<!-- bookmark button text -->
 	<string name="bookmark">書籤</string>
-	<!-- map is not downloaded -->
-	<string name="not_found_map">您地點的地圖尚未下載</string>
 	<!-- location service disabled -->
 	<string name="enable_location_services">請啟用定位服務</string>
-	<!-- download map -->
-	<string name="download_map">為您的地點下載地圖</string>
-	<!-- download map on iPhone -->
-	<string name="download_map_iphone">在您的 iPhone 上下載目前位置的地圖</string>
-	<!-- clear pin -->
-	<string name="nearby">附近的</string>
-	<!-- clear pin -->
-	<string name="clear_pin">清除圖釘</string>
-	<!-- location is undefined -->
-	<string name="undefined_location">目前地點未定。</string>
-	<!-- download country of your location -->
-	<string name="download_country">下載您目前所在位置的國家 地圖</string>
-	<!-- download failed -->
-	<string name="download_failed">下載失敗</string>
-	<!-- get the map -->
-	<string name="get_the_map">獲取地圖</string>
 	<string name="save">儲存</string>
 	<string name="edit_description_hint">您的描述（文字或 html）</string>
-	<string name="new_group">新組</string>
 	<string name="create">建立</string>
 	<!-- red color -->
 	<string name="red">紅色</string>
@@ -490,22 +298,6 @@
 	<string name="brown">棕色</string>
 	<!-- pink color -->
 	<string name="pink">粉色</string>
-	<!-- deep purple color -->
-	<string name="deep_purple">暗紫色</string>
-	<!-- light blue color -->
-	<string name="light_blue">天藍色</string>
-	<!-- cyan color -->
-	<string name="cyan">藍綠色</string>
-	<!-- teal color -->
-	<string name="teal">碧綠色</string>
-	<!-- lime color -->
-	<string name="lime">青檸</string>
-	<!-- deep orange color -->
-	<string name="deep_orange">深橘色</string>
-	<!-- gray color -->
-	<string name="gray">灰色</string>
-	<!-- blue gray color -->
-	<string name="blue_gray">藍灰色</string>
 	<!-- Wi-Fi available -->
 	<string name="WiFi_available">是</string>
 
@@ -521,10 +313,8 @@
 	<string name="dialog_routing_location_turn_wifi">請確認您的 GPS 訊號。啟用 Wi-Fi 將提升地理位置定位準確度。</string>
 	<string name="dialog_routing_location_turn_on">啟用定位服務</string>
 	<string name="dialog_routing_location_unknown_turn_on">無法定位目前 GPS 座標。請啟用定位服務以產生路線。</string>
-	<string name="dialog_routing_location_unknown">無法定位目前 GPS 座標。</string>
 	<string name="dialog_routing_download_files">下載所需檔案</string>
 	<string name="dialog_routing_download_and_update_all">若要產生路線，請下載並更新所有地圖及沿路線的路線檔案。</string>
-	<string name="dialog_routing_routes_size">路線資訊檔案</string>
 	<string name="dialog_routing_unable_locate_route">路線未找到</string>
 	<string name="dialog_routing_cant_build_route">無法產生路線。</string>
 	<string name="dialog_routing_change_start_or_end">請變更起點或最終目的地。</string>
@@ -539,33 +329,23 @@
 	<string name="dialog_routing_system_error">系統錯誤</string>
 	<string name="dialog_routing_application_error">由於此錯誤，尚未建立路線。</string>
 	<string name="dialog_routing_try_again">請再試一次</string>
-	<string name="dialog_routing_send_error">回報問題</string>
-	<string name="dialog_routing_if_get_cross_route">您想產生跨越邊界的更好路線嗎？</string>
-	<string name="dialog_routing_cross_route_is_optimal">有更理想的跨越邊界的路線可用。</string>
 	<string name="not_now">現在不要</string>
-	<string name="dialog_routing_build_route">產生</string>
 	<string name="dialog_routing_download_and_build_cross_route">您是否要下載地圖，產生跨越邊界的更好路線？</string>
 	<string name="dialog_routing_download_cross_route">若要產生跨越邊界的更理想路線，您需要下載地圖。</string>
-	<string name="dialog_routing_cross_route_always">一律跨越此邊界</string>
 
 	<!-- SECTION: Strings for downloading map from search -->
 	<string name="search_without_internet_advertisement">要開始搜索和建立路線，請下載地圖，那您就不再需要網絡連接了。</string>
 	<string name="search_select_map">選擇地圖</string>
-	<string name="search_select_other_map">選擇另一個地圖</string>
 	<!-- «Show» context menu -->
 	<string name="show">顯示</string>
 	<!-- «Hide» context menu -->
 	<string name="hide">隱藏</string>
 	<!-- «Rename» context menu -->
 	<string name="rename">重新命名</string>
-	<!-- Bottom sheet: expand button (should be short) -->
-	<string name="bottom_sheet_more">更多…</string>
 	<!-- Failed planning route message in navigation view -->
 	<string name="routing_planning_error">路線計劃失敗</string>
 	<!-- Arrive routing message in navigation view -->
 	<string name="routing_arrive">抵達:%s</string>
-	<!-- Text for routing::RouterResultCode::FileTooOld dialog. -->
-	<string name="dialog_routing_download_and_update_maps">要建立路線，請下載並更新所有沿線的地圖。</string>
 	<string name="rate_alert_title">喜歡這個應用程式嗎？</string>
 	<string name="rate_alert_default_message">感謝您使用 Organic Maps。請評價此應用程式。您的回饋幫助我們改善我們的產品。</string>
 	<string name="rate_alert_five_star_message">太棒了！我們也愛您！</string>
@@ -573,26 +353,16 @@
 	<string name="rate_alert_less_than_four_star_message">有沒有想法我們能怎麽把它變得更好？</string>
 	<string name="categories">類別</string>
 	<string name="history">記錄</string>
-	<string name="next_turn_then">然後</string>
 	<string name="closed">已關閉</string>
-	<string name="back_to">返回 %s</string>
 	<string name="search_not_found">很抱歉，找不到任何東西。</string>
 	<string name="search_not_found_query">請嘗試其他搜尋字詞。</string>
-	<string name="search_not_found_map">請下載你搜尋的地圖。</string>
-	<string name="search_not_found_location">下載您目前位置的地圖。</string>
 	<string name="search_history_title">搜尋歷史紀錄</string>
 	<string name="search_history_text">檢視最近的搜尋。</string>
 	<string name="clear_search">清除搜尋記錄</string>
-	<!-- Title for settings to enable/disable showcase menu button -->
-	<string name="showcase_settings_title">顯示優惠</string>
 	<!-- Place Page link to Wikipedia article (if map object has it). -->
 	<string name="read_in_wikipedia">維基百科</string>
-	<string name="p2p_route_planning">路線計劃</string>
 	<string name="p2p_your_location">您的位置</string>
-	<string name="p2p_from">出發地點</string>
-	<string name="p2p_to">目的地點</string>
 	<string name="p2p_start">開始</string>
-	<string name="p2p_planning">計劃中…</string>
 	<string name="p2p_from_here">從</string>
 	<string name="p2p_to_here">路線終點</string>
 	<string name="p2p_only_from_current">導航只能從您目前的位置開始。</string>
@@ -612,11 +382,8 @@
 	<string name="editor_hours_closed">休息時間</string>
 	<string name="editor_example_values">範例值</string>
 	<string name="editor_correct_mistake">修正錯誤</string>
-	<string name="editor_correct_mistake_message">編輯時出錯。請修正或切換到簡易模式。</string>
 	<string name="editor_add_select_location">位置</string>
 	<string name="editor_done_dialog_1">您已經改變了世界地圖。別藏私！告訴您的朋友們一起來編輯。</string>
-	<string name="editor_done_dialog_2">這是您的第二次地圖改進。現在您在地圖編輯者排行榜中排在第%d名。把它告訴您的朋友們。</string>
-	<string name="editor_done_dialog_3">您已改進此地圖，請把它告訴您的朋友們，並一起編輯此地圖。</string>
 	<string name="share_with_friends">和朋友分享</string>
 	<string name="editor_report_problem_desription_1">請詳細描述此問題以便 OpenStreeMap 社群修復此錯誤。</string>
 	<string name="editor_report_problem_desription_2">或者在https://www.openstreetmap.org/上親自修復此錯誤</string>
@@ -625,14 +392,7 @@
 	<string name="editor_report_problem_no_place_title">該地點不存在</string>
 	<string name="editor_report_problem_under_construction_title">因維護而關閉</string>
 	<string name="editor_report_problem_duplicate_place_title">重複的地點</string>
-	<string name="first_launch_congrats_title">Organic Maps 已做好使用準備</string>
-	<string name="first_launch_congrats_text">在世界各地離線搜尋和導航，免費。</string>
-	<string name="migrate_title">重要！</string>
-	<!-- Android uses image instead of text. -->
-	<string name="download_all">全部下載</string>
-	<string name="delete_all">刪除全部</string>
 	<string name="autodownload">自動下載</string>
-	<string name="disable_autodownload">停用自動下載</string>
 	<!-- Place Page opening hours text -->
 	<string name="closed_now">現在關門</string>
 	<!-- Place Page opening hours text -->
@@ -641,8 +401,6 @@
 	<string name="day_off_today">今天沒有營業</string>
 	<string name="day_off">沒有營業</string>
 	<string name="today">今天</string>
-	<string name="sunrise_to_sunset">從日出到日落</string>
-	<string name="sunset_to_sunrise">從日落到日出</string>
 	<string name="add_opening_hours">新增營業時間</string>
 	<string name="edit_opening_hours">編輯營業時間</string>
 	<string name="no_osm_account">沒有 OpenStreeMap 帳號嗎？</string>
@@ -652,29 +410,13 @@
 	<string name="login">登入</string>
 	<string name="password">密碼</string>
 	<string name="forgot_password">忘記密碼</string>
-	<!-- Forgot Password dialog title -->
-	<string name="restore_password">恢復密碼</string>
-	<string name="enter_email_address_to_reset_password">輸入您在註冊時所用的電子郵件地址，我們會發送連結給您更新密碼</string>
-	<string name="reset_password">重置密碼</string>
-	<string name="username">使用者名稱</string>
 	<string name="osm_account">OSM 帳號</string>
 	<string name="logout">登出</string>
-	<string name="login_and_edit_map_motivation_message">登錄並編輯地圖上的物件資訊，我們就會讓其他數百萬用戶看到。</string>
 	<!-- Information text: "Last upload 11.01.2016" -->
 	<string name="last_upload">上次上傳</string>
-	<!-- Motivates user to login/register, title above login buttons. -->
-	<string name="you_have_edited_your_first_object">您已編輯您的第一個物件！</string>
 	<string name="thank_you">謝謝您</string>
-	<string name="login_with_google">用 Google 登入</string>
-	<string name="login_with_openstreetmap">登入到 www.openstreetmap.org</string>
 	<string name="edit_place">編輯地點</string>
 	<string name="place_name">地點名稱</string>
-	<!-- title above languages list cells in the editor, below editable name text field. -->
-	<string name="other_languages">其他語言</string>
-	<!-- small button to open list with names in different languages -->
-	<string name="show_more">顯示更多</string>
-	<!-- small button to close list with names in different languages -->
-	<string name="show_less">顯示較少</string>
 	<string name="add_language">新增語言</string>
 	<string name="street">街道</string>
 	<!-- Editable House Number text field (in address block). -->
@@ -691,25 +433,16 @@
 	<string name="email_or_username">電子郵件或使用者名稱</string>
 	<string name="phone">電話</string>
 	<string name="please_note">請註意</string>
-	<string name="common_no_wifi_dialog">無 WiFi 連接。您想繼續使用行動數據進行連接嗎？</string>
 	<string name="downloader_delete_map_dialog">所有對地圖的修改都將與地圖一起被刪除。</string>
 	<string name="downloader_update_maps">更新地圖</string>
 	<string name="downloader_mwm_migration_dialog">為了建立路線，您需要更新全部地圖並重新規劃路線。</string>
 	<string name="downloader_search_field_hint">找到地圖</string>
-	<string name="migration_update_all_button">更新全部地圖</string>
-	<string name="migration_delete_all_download_current_button">下載目前地圖並刪除舊地圖</string>
 	<string name="migration_download_error_dialog">下載錯誤</string>
 	<string name="common_check_internet_connection_dialog">請檢查您的設定並確保您的設備已連接至網路。</string>
 	<string name="downloader_no_space_title">無足夠的空間</string>
 	<string name="downloader_no_space_message">請刪除不必要的資料</string>
-	<string name="editor_general_auth_error_dialog">一般登入錯誤。</string>
 	<string name="editor_login_error_dialog">登入錯誤。</string>
-	<string name="editor_login_failed_dialog">登入失敗</string>
-	<string name="editor_username_error_dialog">使用者名稱不存在</string>
-	<string name="editor_place_edited_dialog">您已編輯了一個物件！</string>
-	<string name="editor_login_with_osm">使用 OpenStreetMap 進行登入</string>
 	<string name="editor_profile_changes">已驗證的變更</string>
-	<string name="editor_profile_unsent_changes">未發送：</string>
 	<string name="editor_focus_map_on_location">拖動地圖以選擇此物件的正確位置。</string>
 	<string name="editor_add_select_category">選擇類別</string>
 	<string name="editor_add_select_category_popular_subtitle">受歡迎的</string>
@@ -720,19 +453,14 @@
 	<string name="editor_edit_place_category_title">類別</string>
 	<string name="detailed_problem_description">問題的詳細描述</string>
 	<string name="editor_report_problem_other_title">一個不同的問題</string>
-	<string name="placepage_report_problem_button">回報問題</string>
 	<string name="placepage_add_business_button">添加組織</string>
 	<string name="whatsnew_editor_message_1">新增新地點到該地圖，並直接通過此應用程式編輯已存在的地點。</string>
-	<string name="whatsnew_editor_message_2">* Organic Maps 使用 OpenStreetMap 社群的數據。</string>
 	<string name="dialog_incorrect_feature_position">改變位置</string>
 	<string name="message_invalid_feature_position">物件無法設置在這裡</string>
 	<string name="login_to_make_edits_visible">登入來讓其他使用者能看到您所作出的修改。</string>
-	<string name="no_migration_during_navigation">導航中禁止更新。</string>
 	<!-- Error dialog no space -->
 	<string name="migration_no_space_message">為了下載，您需要更多的空間。請刪除不必要的數據。</string>
 	<string name="editor_sharing_title">我改進了 Organic Maps 地圖</string>
-	<string name="editor_comment_will_be_sent">我們將把您的評論發送給地圖編輯者。</string>
-	<string name="editor_unsupported_category_message">您已新增了一個我們尚未支援的類別的地點。它未來會顯示在地圖上。</string>
 	<!-- Downloaded 10 **of** 20 <- it is that "of" -->
 	<string name="downloader_of">%1$d個/共%2$d個</string>
 	<string name="download_over_mobile_header">用手機網絡連接下載嗎？</string>
@@ -750,15 +478,8 @@
 	<string name="editor_detailed_description">您建議的變更將傳送至 OpenStreetMap 社群。說明無法在 Organic Maps 中編輯的詳細資料。</string>
 	<string name="editor_more_about_osm">關於 OpenStreetMap 的更多資訊</string>
 	<string name="editor_operator">營運者</string>
-	<string name="editor_tag_description">輸入公司、組織或設施負責人。</string>
-	<string name="editor_no_local_edits_title">您沒有本機編輯</string>
-	<string name="editor_no_local_edits_description">這顯示了對目前僅可在您的裝置上存取的地圖的建議修改數量。</string>
-	<string name="editor_send_to_osm">傳送至 OSM</string>
-	<string name="editor_remove">移除</string>
-	<string name="downloader_my_maps_title">我的地圖</string>
 	<string name="downloader_no_downloaded_maps_title">您尚未下載任何地圖</string>
 	<string name="downloader_no_downloaded_maps_message">下載地圖來尋找位置和離線瀏覽。</string>
-	<string name="downloader_find_place_hint">搜尋城市或國家</string>
 	<!-- Error title that appears after certain time without location. -->
 	<string name="current_location_unknown_title">繼續偵測您的目前位置？</string>
 	<!-- Error that appears after certain time without location. -->
@@ -773,27 +494,10 @@
 	<string name="location_services_disabled_2">2. 點擊位置</string>
 	<!-- iOS Dialog for the case when the location permission is not granted -->
 	<string name="location_services_disabled_3">3. 使用應用時選擇</string>
-	<string name="placepage_parking_surface">表面</string>
-	<string name="placepage_parking_multistorey">多樓層</string>
-	<string name="placepage_parking_underground">未知的位置</string>
-	<string name="placepage_parking_rooftop">樓頂</string>
-	<string name="placepage_parking_sheds">小屋</string>
-	<string name="placepage_parking_carports">屋側車庫</string>
-	<string name="placepage_parking_boxes">停車房</string>
-	<string name="placepage_parking_pay">付款</string>
-	<string name="placepage_parking_free">免費</string>
-	<string name="placepage_parking_interval">間隔付款</string>
-	<string name="placepage_entrance_number">編號</string>
-	<string name="placepage_entrance_type">入口</string>
-	<string name="placepage_flat">公寓</string>
-	<string name="placepage_open_24_7">全天候</string>
 	<string name="meter">米</string>
 	<string name="kilometer">公里</string>
-	<string name="kilometers_per_hour">公里每小時</string>
 	<string name="mile">英里</string>
 	<string name="foot">英尺</string>
-	<string name="miles_per_hour">英里每小時</string>
-	<string name="day">天</string>
 	<string name="hour">小時</string>
 	<string name="minute">分鐘</string>
 	<string name="placepage_place_description">說明</string>
@@ -803,46 +507,30 @@
 	<string name="placepage_call_button">呼叫</string>
 	<string name="placepage_edit_bookmark_button">編輯書籤</string>
 	<string name="placepage_bookmark_name_hint">書籤名稱</string>
-	<string name="placepage_personal_notes_hint">個人備註</string>
-	<string name="placepage_delete_bookmark_button">刪除書籤</string>
 	<string name="editor_edits_sent_message">您的建議已傳送</string>
 	<string name="editor_comment_hint">註解…</string>
 	<string name="editor_reset_edits_message">重設所有本機變更？</string>
 	<string name="editor_reset_edits_button">重設</string>
 	<string name="editor_remove_place_message">移除已新增的位置？</string>
 	<string name="editor_remove_place_button">移除</string>
-	<string name="editor_status_sending">正在傳送…</string>
 	<string name="editor_place_doesnt_exist">位置不存在</string>
 	<string name="text_more_button">…更多</string>
 	<!-- Phone number error message -->
 	<string name="error_enter_correct_phone">輸入正確的電話號碼</string>
 	<string name="error_enter_correct_web">輸入有效網址</string>
 	<string name="error_enter_correct_email">輸入有效電子郵箱</string>
-	<string name="error_enter_correct">輸入有效值</string>
 	<string name="refresh">更新</string>
-	<string name="last_update">上次更新於：%s</string>
 	<string name="placepage_add_place_button">添加地點到地圖上</string>
 	<!-- Displayed when saving some edits to the map to warn against publishing personal data -->
 	<string name="editor_share_to_all_dialog_title">您想要發給所有用戶嗎？</string>
 	<!-- iOS Dialog before publishing the modifications to the public map. -->
 	<string name="editor_share_to_all_dialog_message_1">確保您沒有輸入任何個人數據。</string>
 	<string name="editor_share_to_all_dialog_message_2">我們會檢查更改。如果我們有任何問題，我們會郵件與您聯系。</string>
-	<string name="navigation_overview_button">概覽</string>
-	<string name="navigation_stop_button">停止</string>
-	<!-- Text on an empty bookmark page -->
-	<string name="bookmarks_empty_title">儲存書籤</string>
-	<string name="bookmarks_empty_message_1">按★ 儲存至愛地點以方便存取。</string>
-	<string name="bookmarks_empty_message_2">從 Mail及網上匯入書籤。</string>
-	<string name="bookmarks_empty_message_3">退房： %s</string>
-	<!-- Name of the group for booked hotels -->
-	<string name="bookmarks_group_name">預訂的酒店</string>
-	<string name="place_page_button_read_descriprion">閱讀</string>
 	<!-- iOS dialog for the case when recent track recording is on and the app comes back from background -->
 	<string name="recent_track_background_dialog_title">禁止記錄您最近去過的路徑？</string>
 	<string name="off_recent_track_background_button">禁用</string>
 	<!-- For sharing via SMS and so on -->
 	<string name="sharing_call_action_look">看一看</string>
-	<string name="continue_recent_track_background_button">繼續</string>
 	<string name="recent_track_background_dialog_message">Organic Maps使用背景中的地理位置記錄您最近去過的路徑。</string>
 	<!-- Rate on Google Play (Android only) -->
 	<string name="rate_gp">在 Google Play 評分</string>
@@ -852,21 +540,11 @@
 	<string name="tell_friends_text">嗨！安裝 Organic Maps！</string>
 	<!-- About short text (below logo) -->
 	<string name="about_description">Organic Maps 是一款基本離線旅遊應用程式。Organic Maps 以 OpenStreetMap 數據為基礎，並允許對其進行編輯。</string>
-	<!-- Text in menu -->
-	<string name="blog">部落格</string>
 	<string name="general_settings">一般設定</string>
-	<string name="date">日期 %d</string>
-	<!-- "Report a bug" -> "Generaal Feedback" -> "Something is not working" -->
-	<string name="something_is_not_working">某些地方出錯了</string>
 	<!-- For the first routing -->
 	<string name="accept">接受</string>
 	<!-- For the first routing -->
 	<string name="decline">拒絕</string>
-	<string name="install_app">安裝</string>
-	<string name="search_no_results_title">找不到任何結果</string>
-	<string name="search_no_results_message">嘗試一個更普通的搜尋字詞、縮小顯示或重設篩選條件。</string>
-	<string name="search_no_results_expand_area_button">縮小</string>
-	<string name="search_no_results_reset_button">重設篩選條件</string>
 	<!-- noun -->
 	<string name="search_in_table">清單</string>
 	<string name="mobile_data_dialog">使用手機網路顯示詳細資訊？</string>
@@ -878,18 +556,13 @@
 	<string name="mobile_data_option_never">絕不使用</string>
 	<string name="mobile_data_option_ask">一律詢問</string>
 	<string name="traffic_update_maps_text">若要顯示交通資料，必須更新地圖。</string>
-	<string name="traffic_outdated">交通資料已過時。</string>
 	<string name="big_font">增加地圖上的字體大小</string>
 	<string name="traffic_update_app">請更新 Organic Maps</string>
 	<!-- "traffic" as in road congestion -->
 	<string name="traffic_update_app_message">若要顯示交通資訊，必須更新應用程式。</string>
 	<!-- "traffic" as in "road congestion" -->
 	<string name="traffic_data_unavailable">無法使用交通資訊</string>
-	<!-- Simplified colour scheme for traffic information, fewer colours are used to display traffic jams on the map. The string should be kept as short as possible -->
-	<string name="pref_traffic_simplified_colors_title">簡化的交通狀況顏色</string>
 	<string name="enable_logging">啟用記錄</string>
-	<string name="offline_place_page_more_information">連上網路以取得關於地點的更多資訊。</string>
-	<string name="failed_load_information">無法載入資訊。</string>
 	<!-- Settings: "Send general feedback" button -->
 	<string name="feedback_general">一般反應</string>
 	<string name="on">開</string>
@@ -903,57 +576,26 @@
 	<string name="routing_add_start_point">新增起點以計劃路線</string>
 	<string name="routing_add_finish_point">新增終點以計劃路線</string>
 	<string name="button_exit">退出</string>
-	<string name="settings_device_memory">裝置記憶體</string>
-	<string name="settings_card_memory">卡記憶體</string>
-	<string name="settings_storage_available">%s 可用</string>
-	<string name="toast_location_permission_denied">應用程式地點存取權限被拒絕</string>
-	<string name="button_use">使用</string>
 	<string name="planning_route_manage_route">管理路線</string>
 	<string name="button_plan">計畫</string>
-	<string name="button_add">新增</string>
 	<string name="placepage_remove_stop">移除</string>
 	<string name="planning_route_remove_title">在此拖曳以移除</string>
-	<string name="dialog_change_start_point_message">取代目前位置的起點嗎？</string>
-	<string name="button_replace">取代</string>
 	<string name="placepage_add_stop">新增應用程式</string>
-	<string name="add_my_position">新增我的位置</string>
-	<string name="choose_start_point">選擇起點</string>
-	<string name="choose_destination">選擇目的地</string>
 	<string name="preloader_viator_button">進一步了解</string>
-	<string name="start_from_my_position">起點</string>
-	<string name="profile_authorization_title">登入方式</string>
-	<string name="profile_authorization_message">無須帳號密碼，在幾秒內輕鬆登入。</string>
 	<string name="profile_authorization_error">噢，發生錯誤。請嘗試再次登入。</string>
-	<string name="service">服務</string>
-	<string name="atmosphere">氣氛</string>
-	<string name="value_for_money">物有所值</string>
-	<string name="experience">體驗</string>
-	<string name="assortment">分類</string>
-	<string name="expertise">專業</string>
-	<string name="equipment">設備</string>
-	<string name="quality">品質</string>
 	<string name="dialog_error_storage_title">儲存空間存取問題</string>
 	<string name="dialog_error_storage_message">外部儲存空間不可用，很可能是因為 SD 卡已移除、毀損，或檔案系統處於唯讀狀態。請進行檢查，然後以 support\@organicmaps.app 方式聯繫我們</string>
 	<string name="setting_emulate_bad_storage">模擬不良儲存空間</string>
-	<string name="directions_finish">目的地</string>
-	<string name="directions_on_foot">步行 %s</string>
 	<string name="core_entrance">入口</string>
-	<string name="coffee">咖啡</string>
-	<string name="cleanliness">清潔程度</string>
-	<string name="crowdedness">擁擠程度</string>
 	<string name="error_enter_correct_name">請輸入正確的名稱</string>
 	<string name="bookmarks_groups">列表</string>
 	<string name="bookmarks_groups_hide_all">隱藏全部</string>
 	<string name="bookmarks_groups_show_all">顯示全部</string>
-	<plurals name="bookmarks_places">
-	  <item quantity="other">%d個書籤</item>
-	</plurals>
 	<string name="bookmarks_create_new_group">創建新列表</string>
 	<string name="downloader_hide_screen">隱藏屏幕</string>
 	<string name="downloader_percent">%1$s (%2$s，共%3$s)</string>
 	<string name="downloader_process">下載 %s 中……</string>
 	<string name="downloader_applying">應用 %s 中……</string>
-	<string name="dialog_message_transit_not_found_connection">規劃一個交通網絡內的路線</string>
 	<string name="bookmarks_error_message_share_general">由於應用程序出錯而無法分享</string>
 	<string name="bookmarks_error_title_share_empty">分享錯誤</string>
 	<string name="bookmarks_error_message_share_empty">無法分享空列表</string>
@@ -962,12 +604,7 @@
 	<string name="bookmarks_new_list_hint">新的列表</string>
 	<string name="bookmarks_error_title_list_name_already_taken">這個名字已經被使用了</string>
 	<string name="bookmarks_error_message_list_name_already_taken">請選擇其他名稱</string>
-	<string name="bookmarks_error_title_list_name_too_long">這個名字太長了</string>
-	<string name="bookmarks_error_message_list_name_too_long">請選擇其他名稱</string>
-	<string name="please_wait">請稍候...</string>
-	<string name="phone_number">電話號碼</string>
-	<string name="notification_unsent_reviews_title">你有幾個未發表的評論</string>
-	<string name="notification_unsent_reviews_message">請登錄與其他旅客分享評論</string>
+	<string name="please_wait">請稍候…</string>
 	<string name="profile">OpenStreetMap 資料</string>
 	<string name="place_page_search_similar_hotel">搜索類似的酒店</string>
 	<string name="bookmarks_detect_title">檢測到新文件</string>
@@ -977,31 +614,10 @@
 	<string name="button_convert">兌換</string>
 	<string name="bookmarks_convert_error_title">錯誤</string>
 	<string name="bookmarks_convert_error_message">有些文件未被轉換。</string>
-	<string name="converting">轉換...</string>
-	<string name="wn_reinvented_bookmarks_title">我們改造了書籤！</string>
-	<string name="wn_reinvented_bookmarks_message">你可以備份書籤，創建列表...這太神奇了...</string>
-	<string name="bookmarks_restore">恢復書籤</string>
-	<string name="bookmarks_restore_process">恢復...</string>
 	<string name="bookmarks_restore_title">還原這個版本？</string>
-	<string name="bookmarks_restore_message">您的書籤將從%1$s (%2$s)個恢復</string>
-	<string name="bookmarks_restore_empty_title">你沒有備份</string>
-	<string name="bookmarks_restore_empty_message">服務器沒有找到以前做的備份</string>
 	<string name="common_check_internet_connection_dialog_title">沒有互聯網連接</string>
-	<string name="error_server_title">服務器錯誤</string>
-	<string name="error_server_message">服務器發生錯誤，請稍後重試</string>
 	<string name="error_system_message">出現未知錯誤</string>
 	<string name="restore">恢復</string>
-	<string name="bookmarks_page_downloaded">加載</string>
-	<string name="bookmarks_page_my">我的</string>
-	<string name="routes_and_bookmarks">路線和標籤</string>
-	<string name="bookmarks_webview_success_toast">標籤已成功加載</string>
-	<string name="cached_bookmarks_placeholder_title">上傳新地點</string>
-	<string name="cached_bookmarks_placeholder_subtitle">單擊按鈕下載Organic Maps用戶創建的數千個有趣的地點和路線。您需要網絡連接。</string>
-	<string name="downloader_download_routers">加載標籤</string>
-	<string name="bookmarks_groups_cached">加載的列表</string>
-	<plurals name="bookmarks_objects">
-	  <item quantity="other">%s 對象</item>
-	</plurals>
 	<plurals name="objects">
 	  <item quantity="other">%d 地點</item>
 	</plurals>
@@ -1014,62 +630,32 @@
 	<string name="subtittle_opt_out">跟蹤設置</string>
 	<string name="crash_reports">錯誤報告</string>
 	<string name="crash_reports_description">我們可以使用您的數據來開發和改進Organic Maps。更改將再重新啟動應用程序后生效。</string>
-	<string name="opt_out_help_ios_1">您可以選擇停止在設備設置中接受定向廣告。</string>
-	<string name="opt_out_help_ios_2">iOS 9或更高版本</string>
-	<string name="opt_out_help_ios_3">請打開設置 → 隱私 → 廣告 → 啟用“跟蹤限制”</string>
-	<string name="opt_out_help_android">您可以選擇停止在設備設置中接受定向廣告。Android и Google Play Services 4.0或更高版本\n\n電話設置 → Google → 廣告 → 停用廣告個性化\n或\n電話設置 → Google → Google賬戶 → 隱私 → 首選項設置 → 廣告個性化</string>
 	<string name="privacy_policy">隱私政策</string>
 	<string name="terms_of_use">使用條款</string>
-	<string name="backup_notification_failed">標籤的備份已暫停。請登錄以啟用設備。</string>
 	<string name="button_layer_traffic">堵塞</string>
 	<string name="button_layer_subway">地鐵</string>
 	<string name="layers_title">地圖圖層</string>
-	<string name="layers_message">請打開地圖圖層、地鐵圖及其他有用信息來顯示交通狀況。</string>
-	<string name="button_layer_got_it">明白</string>
 	<string name="subway_data_unavailable">地鐵圖不可用</string>
 	<string name="bookmarks_empty_list_title">列表為空</string>
 	<string name="bookmarks_empty_list_message">要添加新標籤，請單擊對象卡片中的星型圖標</string>
 	<string name="category_desc_more">…更多</string>
 	<string name="title_error_downloading_bookmarks">發生錯誤</string>
-	<string name="subtitle_error_downloading_bookmarks">標籤未加載</string>
-	<string name="error_already_downloaded">這個列表已被下載</string>
-	<string name="why_support">為什麼支持Organic Maps?</string>
-	<string name="why_support_item2">您幫助我們改進Organic Maps</string>
-	<string name="why_support_item3">您幫助我們改進OpenStreetMap.org地圖</string>
-	<string name="channels_map_update">更新地圖</string>
-	<string name="server_unavailable_title">服務不可用</string>
-	<string name="sharing_options">登錄設置</string>
 	<string name="export_file">導出文件</string>
 	<string name="list_settings">列表設置</string>
 	<string name="delete_list">刪除列表</string>
-	<string name="hide_from_map">從卡中隱藏</string>
 	<string name="public_access">公共訪問</string>
 	<string name="limited_access">私人訪問</string>
 	<string name="bookmark_category_name">類別</string>
 	<string name="bookmark_category_description_hint">添加說明(文字或html)</string>
 	<string name="not_shared">個人</string>
-	<string name="direct_link_progress_text">正在上傳您的文件......</string>
-	<string name="direct_link_success">鏈接已創建</string>
-	<string name="send_a_link_btn">發送鏈接</string>
-	<string name="upload_error_toast">加載文件時出錯</string>
 	<string name="tags_loading_error_subtitle">加載代碼時出錯，請重試</string>
-	<string name="unable_upload_errorr_title">無法上傳文件</string>
-	<string name="unable_upload_error_subtitle_edited">文件是通過Web應用程序編輯的</string>
-	<string name="unable_upload_error_subtitle_broken">該文件已損壞，無法上傳。請上傳其他文件。</string>
-	<string name="contact">寫</string>
-	<string name="download_button">下載</string>
 	<string name="speedcams_alert_title">高速相機</string>
-	<string name="speedcams_alert_subtitle">警告速度限制</string>
 	<string name="speedcam_option_auto">自動</string>
 	<string name="speedcam_option_always">總是</string>
 	<string name="speedcam_option_never">從不</string>
-	<string name="bookmark_description_title">標籤說明</string>
 	<string name="place_description_title">地點說明</string>
 	<!-- this text will be shown in application notification preferences opposite checkbox which enable/disable downloader notifications. Devices on Android 8+ are affected. -->
 	<string name="notification_channel_downloader">加載地圖</string>
-	<string name="share_bookmarks_email_body_link">您好！\n\n您的標籤可以從鏈接下載：%s.使用Organic Maps打開列表並享受旅行!\n\n下載應用程序：https://omaps.app/get?kmz</string>
-	<string name="warning_speedcams_title">當速度限制超過%d km / h時，導航會通知您的攝像機</string>
-	<string name="warning_speedcams_subtitle">請不要忘記閱讀旅行國的道路規則。</string>
 	<string name="speedcams_notice_message">自動 - 如果存在超出速度限制的風險，則對速度攝像頭髮出警告\n總是 - 始終提醒攝像頭\n從不 - 永遠不會對攝像頭發出警告</string>
 	<string name="power_managment_title">省電模式</string>
 	<string name="power_managment_description">如果開啟省電模式，應用程序將根據手機的當前電量關耗電功能</string>
@@ -1077,14 +663,7 @@
 	<string name="power_managment_setting_auto">自動</string>
 	<string name="power_managment_setting_manual_max">最大程度省電</string>
 	<string name="enable_logging_warning_message">此選項啟用以記錄操作來進行診斷。這有助於團隊識別應用程序的問題。請僅在Organic Maps支持請求時開啟該選項。</string>
-	<string name="html_error_upload_message_try_again">請檢查網絡訪問，然後再重試</string>
-	<string name="html_error_upload_title_try_again">未連接到網絡</string>
-	<string name="notification_leave_review_v2_android_short_title">請發表評論來幫助旅行者們！</string>
-	<string name="notifications_illegal_alert_disable_button">關閉通知</string>
 	<string name="access_rules_author_only">在線編輯</string>
-	<string name="privacy_settings_menu">隱私設置</string>
-	<string name="unable_upadate_error_title">無法更新路線</string>
-	<string name="unable_upadate_error_message">更新時出錯。請檢查更改，然後再重試</string>
 	<string name="driving_options_title">繞行設置</string>
 	<string name="driving_options_subheader">在每條線路上規避</string>
 	<string name="avoid_tolls">收費公路</string>
@@ -1095,52 +674,14 @@
 	<string name="unable_to_calc_alert_subtitle">很遺憾，我們無法使用所選選項規劃路線。請更改設置，然後重試</string>
 	<string name="define_to_avoid_btn">設置繞行路徑</string>
 	<string name="change_driving_options_btn">绕行设置已开启</string>
-	<string name="toll_road">收費公路</string>
-	<string name="unpaved_road">土路</string>
-	<string name="ferry_crossing">輪渡</string>
-	<string name="operated_by">由\"%s\"管理</string>
 	<string name="avoid_toll_roads_placepage">規避收費公路</string>
 	<string name="avoid_unpaved_roads_placepage">規避土路</string>
 	<string name="avoid_ferry_crossing_placepage">規避輪渡</string>
-	<string name="type.cuisine.uzbek">烏茲別克美食</string>
-	<string name="trip_start">前往</string>
-	<string name="pick_destination">目標</string>
-	<string name="follow_my_position">定好中心</string>
-	<string name="search_results">搜索結果</string>
-	<string name="then_turn">接下來</string>
-	<string name="redirect_route_alert">想重建路線?</string>
-	<string name="redirect_route_yes">是</string>
-	<string name="redirect_route_no">否</string>
-	<string name="trip_finished">您已到達!</string>
-	<string name="keyboard_availability_alert">移動時鍵盤不可用</string>
-	<string name="dialog_routing_change_start_carplay">無法從當前位置構建路線</string>
-	<string name="dialog_routing_change_end_carplay">無法建立到終點的路線。請選擇其他（路線）</string>
-	<string name="dialog_routing_check_gps_carplay">無GPS信號。請沿著空曠區域行駛</string>
-	<string name="dialog_routing_unable_locate_route_carplay">無法建立路線。請選擇其他路線點</string>
-	<string name="dialog_routing_download_files_carplay">爲了創建線路，請在您的設備中下載所缺少的地圖</string>
-	<string name="dialog_routing_system_error_carplay">發生了錯誤。請重新啟動程序</string>
-	<string name="dialog_routing_rebuild_from_current_location_carplay">該路線將從您的當前位置重建</string>
-	<string name="dialog_routing_rebuild_for_vehicle_carplay">該路線將改為汽車（路線）</string>
 	<string name="ok">好的</string>
-	<string name="avoid_unpaved_carplay_1">無土路路段</string>
-	<string name="avoid_unpaved_carplay_2">無土路路段</string>
-	<string name="avoid_ferry_carplay_1">無渡船</string>
-	<string name="avoid_ferry_carplay_2">無渡船</string>
-	<string name="avoid_tolls_carplay_1">無付費路段</string>
-	<string name="avoid_tolls_carplay_2">無付費路段</string>
-	<string name="speedcams_alert_title_carplay_1">攝像頭</string>
-	<string name="speedcams_alert_title_carplay_2">攝像頭信息</string>
-	<string name="download_map_carplay">將Organic Maps軟件中的地圖下載至個人設備中</string>
-	<string name="carplay_roundabout_exit">%s號坡道</string>
 	<!-- max. 10 symbols, both iOS and Android -->
 	<string name="sort">分類……</string>
 	<!-- Android, title, max 20-22 symbols -->
 	<string name="sort_bookmarks">分類標籤</string>
-	<!-- iOS -->
-	<string name="sort_default">默認排序</string>
-	<string name="sort_type">按類型排序</string>
-	<string name="sort_distance">按距離排序</string>
-	<string name="sort_date">按日期排序</string>
 	<!-- Android -->
 	<string name="by_default">默認情況下</string>
 	<!-- Android -->
@@ -1149,65 +690,23 @@
 	<string name="by_distance">按距離</string>
 	<!-- Android -->
 	<string name="by_date">按時間</string>
-	<string name="week_ago_sorttype">一周前</string>
-	<string name="month_ago_sorttype">一月前</string>
-	<string name="moremonth_ago_sorttype">一個多月前</string>
-	<string name="moreyear_ago_sorttype">一年多以前</string>
-	<string name="near_me_sorttype">在我旁邊</string>
-	<string name="others_sorttype">其他</string>
-	<string name="food_places">美食</string>
-	<string name="tourist_places">名勝</string>
-	<string name="museums">博物館</string>
-	<string name="parks">公園</string>
-	<string name="swim_places">游泳</string>
-	<string name="mountains">山</string>
-	<string name="animals">動物</string>
-	<string name="hotels">酒店</string>
-	<string name="buildings">建築物</string>
-	<string name="money">貨幣</string>
-	<string name="shops">商店</string>
-	<string name="parkings">停車場</string>
-	<string name="fuel_places">加油站</string>
-	<string name="water">水</string>
-	<string name="medicine">醫療</string>
 	<string name="search_in_the_list">在列表中搜索</string>
-	<string name="view_on_map_bookmarks">在地圖上</string>
-	<string name="more_bookmarks">更多……</string>
-	<string name="no_items_found">未搜索到內容</string>
-	<!-- Android, max 18 symbols -->
-	<string name="bookmarks_edit_list">編輯</string>
-	<!-- Android, max 18 symbols -->
-	<string name="bookmarks_delete_list">刪除列表</string>
-	<string name="religious_places">聖地</string>
 	<string name="select_list">選擇列表</string>
 	<string name="transit_not_found">本區域的地鐵導航目前不可用</string>
 	<string name="dialog_pedestrian_route_is_long_header">地鐵路線圖未找到</string>
 	<string name="dialog_pedestrian_route_is_long_message">選擇地鐵站附近的起點和終點</string>
-	<!-- Failed planning SUBWAY route message in navigation view -->
-	<string name="routing_planning_error_subway_special">地鐵路線圖設計出錯</string>
 	<string name="button_layer_isolines">高度</string>
-	<string name="tips_map_layers_title_countour">離線高度線在Organic Maps中！</string>
-	<string name="tips_map_layers_message_countour">高度線可以幫您規劃通往大自然地區的路線，不會迷路</string>
 	<string name="isolines_activation_error_dialog">如需使用高度线，请更新或下载所需区域的地图</string>
 	<string name="isolines_location_error_dialog">暫時無法獲取該地區的高低線</string>
 	<string name="elevation_profile_diff_level">難度等級</string>
-	<string name="elevation_profile_diff_level_easy">容易</string>
-	<string name="elevation_profile_diff_level_moderate">中等</string>
-	<string name="elevation_profile_diff_level_hard">困難</string>
 	<string name="elevation_profile_ascent">上坡</string>
 	<string name="elevation_profile_descent">下坡</string>
 	<string name="elevation_profile_minaltitude">最小高度</string>
 	<string name="elevation_profile_maxaltitude">最大高度</string>
-	<string name="elevation_profile_m">米</string>
 	<string name="elevation_profile_difficulty">難度</string>
 	<string name="elevation_profile_distance">距離：</string>
-	<string name="elevation_profile_km">千米</string>
 	<string name="elevation_profile_time">在路上：</string>
-	<string name="elevation_profile_hours">小時</string>
-	<string name="elevation_profile_minutes">分鐘</string>
 	<string name="isolines_toast_zooms_1_10">放大地圖以查看等高線</string>
-	<string name="downloader_updating_ios">更新</string>
-	<string name="downloader_loading_ios">加載</string>
 	<string name="key_information_title">關鍵信息</string>
 	<string name="enable_screen_sleep">允许屏幕进入休眠状态</string>
 	<!-- Description in preferences -->

--- a/android/res/values-zh/strings.xml
+++ b/android/res/values-zh/strings.xml
@@ -12,8 +12,6 @@
 	<string name="cancel_download">取消下载</string>
 	<!-- Button which deletes downloaded country -->
 	<string name="delete">删除</string>
-	<!-- Button "do not interrupt download" if user touched actively downloading country -->
-	<string name="do_nothing">继续</string>
 	<string name="download_maps">下载地图</string>
 	<!-- Settings/Downloader - info for country when download fails -->
 	<string name="download_has_failed">下载失败，重新轻触再试一次</string>
@@ -31,45 +29,31 @@
 	<string name="core_my_position">我的位置</string>
 	<!-- Update maps later/Buy pro version later button text -->
 	<string name="later">稍后</string>
-	<!-- Don't show some dialog any more -->
-	<string name="never">从来不</string>
 	<!-- View and button titles for accessibility -->
 	<string name="search">搜索</string>
 	<!-- Search box placeholder text -->
 	<string name="search_map">搜索地图</string>
-	<!-- Settings/Downloader - info for not downloaded country -->
-	<string name="touch_to_download">轻触下载</string>
 	<!-- Settings/Downloader - 3G download warning dialog confirm button -->
 	<string name="use_cellular_data">是</string>
 	<!-- Location services are disabled by user alert - message -->
 	<string name="location_is_disabled_long_text">您目前有此设备的所有位置服务或应用已禁用。请在设置中启用它们。</string>
-	<!-- Location Services are not available on the device alert - message -->
-	<string name="device_doesnot_support_location_services">您的设备不支持位置服务。</string>
 	<!-- View and button titles for accessibility -->
 	<string name="zoom_to_country">在地图上显示</string>
-	<!-- Button text for the button at the center of the screen when the country is not downloaded -->
-	<string name="country_status_download">下载地图\n(^ ^)</string>
 	<!-- Button text for the button at the center of the screen when the country is not downloaded and the size should not be shown -->
 	<string name="country_status_download_without_size">下载地图</string>
-	<!-- Button text for the button at the center of the screen when the country is not downloaded -->
-	<string name="country_status_download_without_routing">下载不带路线的地图\n(^ ^)</string>
 	<!-- Message to display at the center of the screen when the country download has failed -->
 	<string name="country_status_download_failed">下载失败了</string>
 	<!-- Button text for the button under the country_status_download_failed message -->
 	<string name="try_again">重试</string>
 	<string name="about_menu_title">关于 Organic Maps</string>
-	<string name="downloaded_touch_to_delete">下载了(%s),轻触删除</string>
 	<string name="connection_settings">连接设置</string>
-	<string name="download_mb_or_kb">下载%s</string>
 	<string name="close">关闭</string>
 	<string name="unsupported_phone">硬件加速的 OpenGL 是必需的。遗憾的是您 的设备不支持。</string>
 	<string name="download">下载</string>
-	<string name="external_storage_is_not_available">缺少包含已下载地图的 SD 卡/ USB 储存设备</string>
 	<string name="disconnect_usb_cable">请断开 USB 线或插入存储卡以使用 Organic Maps</string>
 	<string name="not_enough_free_space_on_sdcard">请在 SD 卡/ USB 储存设备上释放一些空间以 使用此应用</string>
 	<string name="not_enough_memory">没有足够的内存来启动应用程序</string>
 	<string name="download_resources">在您开始前请让我们下载通用世界地 图至您的设备中。\n它需要%s的 数据。</string>
-	<string name="getting_position">获取当前位置</string>
 	<string name="download_resources_continue">前往地图</string>
 	<string name="downloading_country_can_proceed">下载 %s。您现在可\n前往地图。</string>
 	<string name="download_country_ask">下载 %s?</string>
@@ -82,30 +66,20 @@
 	<string name="download_country_failed">%s下载失败</string>
 	<!-- Add New Bookmark Set dialog title -->
 	<string name="add_new_set">添加新的集合</string>
-	<!-- Place Page - Add To Bookmarks button -->
-	<string name="add_to_bookmarks">添加至书签</string>
 	<!-- Bookmark Color dialog title -->
 	<string name="bookmark_color">书签颜色</string>
 	<!-- Add Bookmark Set dialog - hint when set name is empty -->
 	<string name="bookmark_set_name">书签集名称</string>
-	<!-- Bookmark Sets dialog title -->
-	<string name="bookmark_sets">书签集</string>
 	<!-- Bookmarks - dialog title -->
 	<string name="bookmarks">书签</string>
-	<!-- Add bookmark dialog - bookmark color -->
-	<string name="color">色彩</string>
 	<!-- Default bookmarks set name -->
 	<string name="core_my_places">我的位置</string>
 	<!-- Add bookmark dialog - bookmark name -->
 	<string name="name">名字</string>
 	<!-- Editor title above street and house number -->
 	<string name="address">地址</string>
-	<!-- Place Page - Remove Pin button -->
-	<string name="remove_pin">移除图钉</string>
 	<!-- Add bookmark dialog - bookmark set, Bookmarks dialog - Bookmark set cell -->
 	<string name="set">集合</string>
-	<!-- Text hint in Bookmarks dialog when no any bookmarks are added -->
-	<string name="bookmarks_usage_hint">您还没有书签。\n在地图任何位置轻触以添 加一个书签。\n其他来源的书签也可载入并 显示在 Organic Maps 中。从邮件、 Dropbox 或 weblink 中打开存储有图钉的 KML/KMZ 文 件。</string>
 	<!-- Settings button in system menu -->
 	<string name="settings">设置</string>
 	<!-- Header of settings activity where user defines storage path -->
@@ -116,20 +90,10 @@
 	<string name="move_maps">移动地图?</string>
 	<!-- Ask to wait user several minutes (some long process in modal dialog). -->
 	<string name="wait_several_minutes">这可能需要几分钟的时间。\n请稍候…</string>
-	<!-- Show bookmarks from this category on a map or not -->
-	<string name="visible">可见</string>
-	<!-- Toast which is displayed when GPS has been deactivated -->
-	<string name="gps_is_disabled_long_text">GPS 已禁用。请在设置中启用它。</string>
 	<!-- Measurement units title in settings activity -->
 	<string name="measurement_units">测量单位</string>
 	<!-- Detailed description of Measurement Units settings button -->
 	<string name="measurement_units_summary">选择英里或公里</string>
-	<!-- Do search in all sources -->
-	<string name="search_mode_all">到处</string>
-	<!-- Do search near my position only -->
-	<string name="search_mode_nearme">靠近我的</string>
-	<!-- Do search in current viewport only -->
-	<string name="search_mode_viewport">在屏幕上</string>
 	<!-- Search category for cafes, bars, restaurants -->
 	<string name="eat">在哪儿吃</string>
 	<!-- Search category for grocery stores -->
@@ -166,12 +130,8 @@
 	<string name="post">邮政</string>
 	<!-- Search category -->
 	<string name="police">警察</string>
-	<!-- String in search result list, when nothing found -->
-	<string name="no_search_results_found">没有找到结果</string>
 	<!-- Notes field in Bookmarks view -->
 	<string name="description">注释</string>
-	<!-- Button text -->
-	<string name="share_by_email">邮件分享</string>
 	<!-- Email Subject when sharing bookmarks category -->
 	<string name="share_bookmarks_email_subject">Organic Maps 书签已与您共享</string>
 	<!-- message title of loading file -->
@@ -184,20 +144,10 @@
 	<string name="edit">编辑</string>
 	<!-- Warning message when doing search around current position -->
 	<string name="unknown_current_position">您的位置尚未确定</string>
-	<!-- Warning message when location country isn't downloaded during search (see also download_location_map_proposal). -->
-	<string name="download_location_country">下载您所在位置的国家 (%s)</string>
-	<!-- Warning message when viewport country isn't downloaded during search -->
-	<string name="download_viewport_country_to_search">下载您所搜索的国家 (%s)</string>
 	<!-- Alert message that we can't run Map Storage settings due to some reasons. -->
 	<string name="cant_change_this_setting">抱歉,地图存储设置目前被禁用</string>
 	<!-- Alert message that downloading is in progress. -->
 	<string name="downloading_is_active">国家下载进行中。</string>
-	<!-- Message that will be shown in alert view, when we ask user to leave review on App Store -->
-	<string name="appStore_message">希望您喜欢使用 Organic Maps! 若确实喜欢, 请在应用商店对此应用进行打分和点评。这 花不了一分钟但却可以实在地帮助我们。感 谢您的支持!</string>
-	<!-- No, thanks -->
-	<string name="no_thanks">不,谢谢</string>
-	<!-- Share one specific bookmark using SMS, %1$@ contains om:// and %2$@ https://omaps.app link. @NOTE non-ascii symbols in the link will result in max 70 characters SMS instead of 140. -->
-	<string name="bookmark_share_sms">嘿,在 Organic Maps 上查看我标注的图钉吧! %1$s 或%2$s 未安装离线地图?在此下 载: https://omaps.app/get</string>
 	<!-- Share my position using SMS, %1$@ contains om:// and %2$@ https://omaps.app link WITHOUT NAME. @NOTE non-ascii symbols in the link will result in max 70 characters SMS instead of 140. -->
 	<string name="my_position_share_sms">嘿,在 Organic Maps 上查看我目前的位置 吧!%1$s 或%2$s 未安装离线地图?在此 下载: https://omaps.app/get</string>
 	<!-- Subject for emailed bookmark -->
@@ -206,30 +156,16 @@
 	<string name="my_position_share_email_subject">嗨，到 Organic Maps 查看我的当前位置！</string>
 	<!-- Share my position using EMail, %1$@ is om:// and %2$@ is https://omaps.app link WITHOUT NAME -->
 	<string name="my_position_share_email">嗨,\n\n我现在在这:%1$s。点击此链 接%2$s或此链接 %3$s来查看在地图上的 位置。\n\n谢谢。</string>
-	<!-- Android share by Message/SMS button text (including SMS) -->
-	<string name="share_by_message">通过消息分享</string>
 	<!-- Share button text which opens menu with more buttons, like Message, EMail, Facebook etc. -->
 	<string name="share">分享</string>
-	<!-- iOS share by Message button text (including SMS) -->
-	<string name="message">消息</string>
 	<!-- Share by email button text, also used in editor. -->
 	<string name="email">邮件</string>
-	<!-- Copy Link -->
-	<string name="copy_link">复制链接</string>
-	<!-- Text for the button that returns to caller application -->
-	<string name="more_info">显示更多资讯</string>
 	<!-- Text for message when used successfully copied something -->
 	<string name="copied_to_clipboard">复制到剪贴板:%1$s</string>
 	<!-- place preview title -->
 	<string name="info">信息</string>
 	<!-- Used for bookmark editing -->
 	<string name="done">完成</string>
-	<!-- Summary for preferences in MWM -->
-	<string name="yopme_pref_summary">选择背屏设置</string>
-	<!-- Title for yopme preferences in MWM -->
-	<string name="yopme_pref_title">背屏设置</string>
-	<!-- Hint for upper-right icon p2b -->
-	<string name="show_on_backscreen">显示在背屏上</string>
 	<!-- Prints version number in About dialog -->
 	<string name="version">版本:%s</string>
 	<!-- Confirmation in downloading countries dialog -->
@@ -239,11 +175,6 @@
 	<!-- Length of track in cell that describes route -->
 	<string name="length">长度</string>
 	<string name="share_my_location">共享我的位置</string>
-	<string name="menu_search">搜索</string>
-	<!-- Settings screen: "Map" category title -->
-	<string name="prefs_group_map">地图</string>
-	<!-- Settings screen: "Miscellaneous" category title -->
-	<string name="prefs_group_misc">其他</string>
 	<string name="prefs_group_route">导航</string>
 	<string name="pref_zoom_title">缩放按钮</string>
 	<string name="pref_zoom_summary">在屏幕上显示</string>
@@ -259,8 +190,6 @@
 	<string name="pref_map_3d_title">透视图</string>
 	<!-- Settings «Map» category: «3D buildings» title -->
 	<string name="pref_map_3d_buildings_title">3D 建筑</string>
-	<!-- Settings «Map» category: «3D buildings» summary -->
-	<string name="pref_map_3d_buildings_subtitle">增加电池消耗</string>
 	<!-- Settings «Route» category: «Tts enabled» title -->
 	<string name="pref_tts_enable_title">语音指导</string>
 	<!-- Settings «Route» category: «Tts language» title -->
@@ -269,7 +198,6 @@
 	<string name="pref_tts_unavailable">无法使用</string>
 	<!-- Title for "Other" section in TTS settings. -->
 	<string name="pref_tts_other_section_title">其他</string>
-	<string name="pref_tts_how_to_set_up_voice">如何设置语音</string>
 	<!-- Settings «Map» category: «Record track» title -->
 	<string name="pref_track_record_title">最近的路径</string>
 	<string name="pref_map_auto_zoom">自动缩放</string>
@@ -280,46 +208,11 @@
 	<string name="duration_12_hours">12小时</string>
 	<string name="duration_1_day">1天</string>
 	<string name="recent_track_help_text">它允许您记录一定时间段内的旅行路径，并在地图上查看。请注意：激活此功能会导致电量消耗加快。过期后，轨迹将从地图中自动移除。</string>
-	<string name="pref_track_ios_caption">近期轨迹显示您的行进道路。</string>
-	<string name="pref_track_ios_subcaption">请选择保存轨迹的时间范围。</string>
-	<string name="placepage_distance">距离</string>
-	<string name="placepage_coordinates">坐标</string>
-	<string name="placepage_unsorted">未分类</string>
 	<string name="search_show_on_map">在地图上查看</string>
-	<!-- Used to warn user when fixing KitKat issue -->
-	<string name="bookmark_move_fail">我们需要移动您的书签到内部存储器,但没 有可用的空间。请释放存储,否则书签将不 可用。</string>
-	<!-- Used in More Apps menu -->
-	<string name="free">免费</string>
-	<!-- Used in More Apps menu -->
-	<string name="buy">购买</string>
-	<!-- 1st search button-like result -->
-	<string name="search_on_map">在地图上搜索</string>
-	<!-- toast with an error -->
-	<string name="no_route_found">未找到路线</string>
-	<!-- route title -->
-	<string name="route">路线</string>
-	<!-- category title -->
-	<string name="routes">路线</string>
-	<!-- text of notification -->
-	<string name="download_map_notification">下载您所在地方的地图</string>
-	<!-- text of notification -->
-	<string name="pro_version_is_free_today">完整版Organic Maps是免费的今天! 立刻下载并告诉您的好友。</string>
-	<!-- Dialog for transferring maps from lite to pro. -->
-	<string name="move_lite_maps_to_pro">我们正在将您从Organic Maps Lite 下载的地图传输至 Organic Maps。这可能需要几分钟的时间。</string>
-	<!-- Message to display when maps moved. -->
-	<string name="move_lite_maps_to_pro_ok">您下载的地图已成功传输至 Organic Maps。</string>
-	<!-- Message to display when maps move failed. -->
-	<string name="move_lite_maps_to_pro_failed">您的地图传输失败。请删除 Organic Maps Lite，然后再次下载地图。</string>
-	<!-- Text in menu -->
-	<string name="settings_and_more">设置及更多</string>
 	<!-- Text in menu -->
 	<string name="website">网站</string>
-	<!-- Text in menu -->
-	<string name="contact_us">联系我们</string>
 	<!-- Settings: Send feedback button and dialog title -->
 	<string name="feedback">反馈</string>
-	<!-- Text in menu -->
-	<string name="subscribe_to_news">订阅我们的新闻</string>
 	<!-- Text in menu -->
 	<string name="rate_the_app">为该应用打分</string>
 	<!-- Text in menu -->
@@ -328,12 +221,6 @@
 	<string name="copyright">版权</string>
 	<!-- Text in menu -->
 	<string name="report_a_bug">报告漏洞</string>
-	<!-- Email subject -->
-	<string name="subscribe_me_subject">请帮我订阅Organic Maps简报</string>
-	<!-- Email body -->
-	<string name="subscribe_me_body">我想率先了解最新新闻、更新及促销活动。订阅可随时取消。</string>
-	<!-- About text -->
-	<string name="about_text">Organic Maps 提供全球所有国家和所有城市的最快速的离线地图。充满自信地出行：无论您在哪，Organic Maps都能够帮助您在地图上找到您自己的位置，找到最近的餐馆、酒店、银行、加油站，等等。无需网络连接。\n\n我们始终在为添加新功能而努力，并希望能够听到您对我们应如何改进Organic Maps的想法。若您在使用本应用时遇到任何问题，请随时联系我们：support\@organicmaps.app。我们会回复每一条请求！\n\n您喜欢Organic Maps并希望支持我们吗？以下为一些简单且完全免费的方法：\n\n- 在您的App Market发表评论\n- 在我们的Facebook页面http://www.facebook.com/OrganicMaps赞我们\n- 或者向您的母亲、朋友，以及同事介绍Organic Maps :)\n\n感谢您与我们在一起。非常感谢您的支持。\n\n附言：我们从OpenStreetMap获取地图信息，这是一个类似于Wikipedia的地图绘制项目，能够让用户创建并编辑地图。若您看到地图上缺少了什么或者有什么错误，可以直接在https://www.openstreetmap.org上进行纠正。在下一个版本发布时，您做出的更改便会出现在Organic Maps应用中。</string>
 	<!-- Alert text -->
 	<string name="email_error_body">电子邮件客户端尚未建立。请配置或使用任何其他方式与我们联系%s</string>
 	<!-- Alert title -->
@@ -342,135 +229,56 @@
 	<string name="pref_calibration_title">指南针校准</string>
 	<!-- Search category -->
 	<string name="wifi">无线网络</string>
-	<!-- Update map suggestion -->
-	<string name="routing_map_outdated">请更新地图以创建一条路线。</string>
-	<!-- Update maps suggestion -->
-	<string name="routing_update_maps">使用新版本的Organic Maps可以创建从您的当前位置至一个目的地的路线。请更新地图以使用该功能。</string>
 	<!-- Update all button text -->
 	<string name="downloader_update_all_button">更新全部</string>
 	<!-- Cancel all button text -->
 	<string name="downloader_cancel_all">全部取消</string>
 	<!-- Downloaded maps category -->
 	<string name="downloader_downloaded_subtitle">已下载</string>
-	<!-- Downloaded maps category -->
-	<string name="downloader_available_maps">可用</string>
 	<!-- Country queued for download -->
 	<string name="downloader_queued">已排队</string>
 	<string name="downloader_near_me_subtitle">在我附近</string>
 	<string name="downloader_status_maps">地图</string>
 	<string name="downloader_download_all_button">下载全部</string>
 	<string name="downloader_downloading">正在下载：</string>
-	<string name="downloader_search_results">找到</string>
-	<!-- Disclaimer message -->
-	<string name="routing_disclaimer">在Organic Maps应用中制定路线时请谨记以下 几点：\n\n  - 建议路线仅可当作推荐路线。\n - 路况、交通规则以及标志应优先于导航建议。\n - 地图可能会不正确或者过时，路线也可能不是以最佳可能方式制定的。\n\n  行车安全，请照顾好您自己！</string>
-	<!-- Outdated maps category -->
-	<string name="downloader_outdated_maps">过时的</string>
-	<!-- Up to date maps category -->
-	<string name="downloader_uptodate_maps">最新的</string>
 	<!-- Status of outdated country in the list -->
 	<string name="downloader_status_outdated">下载</string>
 	<!-- Status of failed country in the list -->
 	<string name="downloader_status_failed">下载失败</string>
 	<!-- Displayed in a dialog that appears when a user tries to delete a map while the app is in the follow route mode -->
 	<string name="downloader_delete_map_while_routing_dialog">要删除地图，请停止导航。</string>
-	<!-- Show when user try build route, but we don't know where he -->
-	<string name="routing_failed_unknown_my_position">当前地点未定。请明确地点以创建路线。</string>
-	<!-- Show if use has not routing file, or InconsistentMWMandRoute -->
-	<string name="routing_failed_has_no_routing_file">需要额外的数据才能创建路线。开始下载吗？</string>
-	<!-- StartPointNotFound -->
-	<string name="routing_failed_start_point_not_found">无法计算路线。没有在您起点附近的路。</string>
-	<!-- EndPointNotFound -->
-	<string name="routing_failed_dst_point_not_found">无法计算路线。没有在您终点附近的路。</string>
 	<!-- PointsInDifferentMWM -->
 	<string name="routing_failed_cross_mwm_building">路程只能完全处在同一地图里时才能被创建。</string>
-	<!-- RouteNotFound -->
-	<string name="routing_failed_route_not_found">找不到所选起点和终点间的路程。请选择不同的起点或终点。</string>
-	<!-- InternalError -->
-	<string name="routing_failed_internal_error">出现内部错误。请尝试删除并再次下载地图。如果还有问题请联系我们：support\@organicmaps.app。</string>
-	<!-- Context menu item for downloader. -->
-	<string name="downloader_download_map_and_routing">下载地图 + 路线</string>
-	<!-- Context menu item for downloader. -->
-	<string name="downloader_download_routing">下载路线</string>
-	<!-- Context menu item for downloader. -->
-	<string name="downloader_delete_routing">删除路线</string>
 	<!-- Context menu item for downloader. -->
 	<string name="downloader_download_map">下载地图</string>
-	<string name="downloader_download_map_no_routing">下载不带路线的地图</string>
-	<!-- Button for routing. -->
-	<string name="routing_go">出发！</string>
 	<!-- Item status in downloader. -->
 	<string name="downloader_retry">重复</string>
-	<!-- Item in context menu. -->
-	<string name="downloader_map_and_routing">地图 + 布置路线</string>
 	<!-- Item in context menu. -->
 	<string name="downloader_delete_map">删除地图</string>
 	<!-- Item in context menu. -->
 	<string name="downloader_update_map">更新地图</string>
-	<!-- Item in context menu. -->
-	<string name="downloader_update_map_and_routing">更新地图 + 布置路线</string>
-	<!-- Item in context menu. -->
-	<string name="downloader_map_only">只有地图</string>
 	<!-- Preference text -->
 	<string name="pref_use_google_play">使用Google Play服务以获取您的当前位置。</string>
 	<!-- Text for rating dialog -->
 	<string name="rating_just_rated">我刚刚评价了您的应用</string>
-	<!-- Text for rating dialog -->
-	<string name="rating_user_since">我是从%s年起的Organic Maps用户</string>
-	<!-- Text for rating dialog -->
-	<string name="rating_do_like_maps">您喜欢Organic Maps吗？</string>
-	<!-- Text for rating dialog -->
-	<string name="rating_tap_star">点击星星给我们应用评分。</string>
 	<!-- Text for rating dialog -->
 	<string name="rating_thanks">谢谢您！</string>
 	<!-- Text for rating dialog -->
 	<string name="rating_share_ideas">分享任何主意或问题，这样我们可以为您改善应用。</string>
 	<!-- Text for rating dialog -->
 	<string name="rating_send_feedback">发送反馈</string>
-	<!-- Text for g+ dialog -->
-	<string name="rating_google_plus">点击g+向您的朋友们告知这款应用。</string>
 	<!-- Text for routing error dialog -->
 	<string name="routing_download_maps_along">下载沿线地图</string>
-	<!-- Text for routing error dialog -->
-	<string name="routing_download_map">获取地图</string>
-	<!-- Text for routing error dialog -->
-	<string name="routing_download_map_and_routing">下载更新的地图和路线数据，获取所有 Organic Maps 的特色功能。</string>
-	<!-- Text for routing error dialog -->
-	<string name="routing_get_routing_data">获取所需的路线数据</string>
-	<!-- Text for routing error dialog -->
-	<string name="routing_get_additional_data">更多数据，从您的位置创建路线。</string>
 	<!-- Text for routing error dialog -->
 	<string name="routing_requires_all_map">创建路线需要下载并更新好所有从您的位置到目的地的地图。</string>
 	<!-- Text for routing error dialog -->
 	<string name="routing_not_enough_space">空间不够</string>
-	<!-- Text for routing error dialog -->
-	<string name="routing_download_more_than_avail">您需要下载%1$s MB，但只有%2$s MB空间。</string>
-	<!-- Text for routing error dialog -->
-	<string name="routing_download_roaming">您将使用移动数据下载%s MB（漫游）。这取决于您的移动数据方案运营商，可能会产生额外的费用。</string>
 	<!-- bookmark button text -->
 	<string name="bookmark">书签</string>
-	<!-- map is not downloaded -->
-	<string name="not_found_map">您地点的地图没有被下载</string>
 	<!-- location service disabled -->
 	<string name="enable_location_services">请启用位置服务</string>
-	<!-- download map -->
-	<string name="download_map">为您的地点下载地图</string>
-	<!-- download map on iPhone -->
-	<string name="download_map_iphone">在您的iPhone上下载当前位置的地图</string>
-	<!-- clear pin -->
-	<string name="nearby">附近的</string>
-	<!-- clear pin -->
-	<string name="clear_pin">清除针</string>
-	<!-- location is undefined -->
-	<string name="undefined_location">当前地点未定。</string>
-	<!-- download country of your location -->
-	<string name="download_country">下载您所在位置的国家</string>
-	<!-- download failed -->
-	<string name="download_failed">下载失败</string>
-	<!-- get the map -->
-	<string name="get_the_map">获取地图</string>
 	<string name="save">保存</string>
 	<string name="edit_description_hint">您的描述（文本或html）</string>
-	<string name="new_group">新群組</string>
 	<string name="create">创建</string>
 	<!-- red color -->
 	<string name="red">红色</string>
@@ -488,22 +296,6 @@
 	<string name="brown">棕色</string>
 	<!-- pink color -->
 	<string name="pink">粉色</string>
-	<!-- deep purple color -->
-	<string name="deep_purple">暗紫色</string>
-	<!-- light blue color -->
-	<string name="light_blue">天蓝色</string>
-	<!-- cyan color -->
-	<string name="cyan">蓝绿色</string>
-	<!-- teal color -->
-	<string name="teal">碧绿色</string>
-	<!-- lime color -->
-	<string name="lime">青柠</string>
-	<!-- deep orange color -->
-	<string name="deep_orange">深橘色</string>
-	<!-- gray color -->
-	<string name="gray">灰色</string>
-	<!-- blue gray color -->
-	<string name="blue_gray">蓝灰色</string>
 	<!-- Wi-Fi available -->
 	<string name="WiFi_available">是</string>
 
@@ -519,10 +311,8 @@
 	<string name="dialog_routing_location_turn_wifi">请检查您的 GPS 信号。启用 Wi-Fi 将改善您的定位精度。</string>
 	<string name="dialog_routing_location_turn_on">启用定位服务</string>
 	<string name="dialog_routing_location_unknown_turn_on">无法定位当前 GPS 坐标。请启用定位服务以计算路线。</string>
-	<string name="dialog_routing_location_unknown">无法定位当前 GPS 坐标。</string>
 	<string name="dialog_routing_download_files">下载所需文件</string>
 	<string name="dialog_routing_download_and_update_all">下载和更新所有地图和预定路径沿途的路线信息，以计算路线。</string>
-	<string name="dialog_routing_routes_size">路线信息文件</string>
 	<string name="dialog_routing_unable_locate_route">无法定位路线</string>
 	<string name="dialog_routing_cant_build_route">无法创建路线。</string>
 	<string name="dialog_routing_change_start_or_end">请调整您的起点或目的地。</string>
@@ -537,33 +327,23 @@
 	<string name="dialog_routing_system_error">系统错误</string>
 	<string name="dialog_routing_application_error">由于应用程序错误，无法创建路线。</string>
 	<string name="dialog_routing_try_again">请重试</string>
-	<string name="dialog_routing_send_error">报告问题</string>
-	<string name="dialog_routing_if_get_cross_route">您是否要创建一条跨越多张地图的更直接路线？</string>
-	<string name="dialog_routing_cross_route_is_optimal">有一条跨越本地图边缘的更佳路线可用。</string>
 	<string name="not_now">现在不用</string>
-	<string name="dialog_routing_build_route">创建</string>
 	<string name="dialog_routing_download_and_build_cross_route">您是否要下载地图并创建一条跨越多张地图的更佳路线？</string>
 	<string name="dialog_routing_download_cross_route">下载地图，创建一条跨越此地图边缘的更佳路线。</string>
-	<string name="dialog_routing_cross_route_always">始终跨越此边界线</string>
 
 	<!-- SECTION: Strings for downloading map from search -->
 	<string name="search_without_internet_advertisement">要开始搜索和创建路线，请下载地图，那您就不再需要网络连接了。</string>
 	<string name="search_select_map">选择地图</string>
-	<string name="search_select_other_map">选择另一个地图</string>
 	<!-- «Show» context menu -->
 	<string name="show">显示</string>
 	<!-- «Hide» context menu -->
 	<string name="hide">隐藏</string>
 	<!-- «Rename» context menu -->
 	<string name="rename">重命名</string>
-	<!-- Bottom sheet: expand button (should be short) -->
-	<string name="bottom_sheet_more">更多…</string>
 	<!-- Failed planning route message in navigation view -->
 	<string name="routing_planning_error">路线计划失败</string>
 	<!-- Arrive routing message in navigation view -->
 	<string name="routing_arrive">抵達:%s</string>
-	<!-- Text for routing::RouterResultCode::FileTooOld dialog. -->
-	<string name="dialog_routing_download_and_update_maps">要创建路线，请下载并更新所有沿路线的地图。</string>
 	<string name="rate_alert_title">喜欢这个应用吗？</string>
 	<string name="rate_alert_default_message">感谢您使用 Organic Maps。请，评价该应用。您的反馈帮助我们变得更好。</string>
 	<string name="rate_alert_five_star_message">太棒了！我们也爱您！</string>
@@ -571,24 +351,14 @@
 	<string name="rate_alert_less_than_four_star_message">有没有想法我们能怎么把它变得更好？</string>
 	<string name="categories">类别</string>
 	<string name="history">历史</string>
-	<string name="next_turn_then">然后</string>
 	<string name="closed">已关闭</string>
-	<string name="back_to">回到 %s</string>
 	<string name="search_not_found">抱歉，没有找到任何东西。</string>
 	<string name="search_not_found_query">请尝试其它查询。</string>
-	<string name="search_not_found_map">请下载您搜索的地图。</string>
-	<string name="search_not_found_location">下载您当前位置的地图。</string>
 	<string name="search_history_title">搜索历史</string>
 	<string name="search_history_text">快速访问最近的搜索查询。</string>
 	<string name="clear_search">清除历史搜索</string>
-	<!-- Title for settings to enable/disable showcase menu button -->
-	<string name="showcase_settings_title">显示优惠</string>
-	<string name="p2p_route_planning">路线计划</string>
 	<string name="p2p_your_location">您的位置</string>
-	<string name="p2p_from">出发地点</string>
-	<string name="p2p_to">目的地点</string>
 	<string name="p2p_start">开始</string>
-	<string name="p2p_planning">计划中…</string>
 	<string name="p2p_from_here">从</string>
 	<string name="p2p_to_here">发送至</string>
 	<string name="p2p_only_from_current">导航只能从您目前的位置开始。</string>
@@ -608,11 +378,8 @@
 	<string name="editor_hours_closed">不营业时间</string>
 	<string name="editor_example_values">示例值</string>
 	<string name="editor_correct_mistake">纠正错误</string>
-	<string name="editor_correct_mistake_message">出现编辑错误，请纠正或切换至简单模式。</string>
 	<string name="editor_add_select_location">位置</string>
 	<string name="editor_done_dialog_1">您已经改变了世界地图。请不要隐藏这一点！告诉您的朋友们并一起编辑它。</string>
-	<string name="editor_done_dialog_2">这是您的第二个地图改进。现在您在地图编辑者排行榜中排在第%d名。把它告诉您的朋友们。</string>
-	<string name="editor_done_dialog_3">您已改进此地图，请把它告诉您的朋友们，并一起编辑此地图。</string>
 	<string name="share_with_friends">与朋友分享</string>
 	<string name="editor_report_problem_desription_1">请详细描述此问题以便OpenStreeMap社区能够修复此错误。</string>
 	<string name="editor_report_problem_desription_2">或者在https://www.openstreetmap.org/上亲自修复此错误。</string>
@@ -621,14 +388,7 @@
 	<string name="editor_report_problem_no_place_title">该地点不存在</string>
 	<string name="editor_report_problem_under_construction_title">因维护而关闭</string>
 	<string name="editor_report_problem_duplicate_place_title">重复的地点</string>
-	<string name="first_launch_congrats_title">Organic Maps已经可用</string>
-	<string name="first_launch_congrats_text">在世界各地离线搜索和导航，免费。</string>
-	<string name="migrate_title">重要！</string>
-	<!-- Android uses image instead of text. -->
-	<string name="download_all">下载所有</string>
-	<string name="delete_all">删除全部</string>
 	<string name="autodownload">自动下载</string>
-	<string name="disable_autodownload">禁用自动下载</string>
 	<!-- Place Page opening hours text -->
 	<string name="closed_now">现在关门</string>
 	<!-- Place Page opening hours text -->
@@ -637,8 +397,6 @@
 	<string name="day_off_today">今天没有营业</string>
 	<string name="day_off">没有营业</string>
 	<string name="today">今天</string>
-	<string name="sunrise_to_sunset">从日出到日落</string>
-	<string name="sunset_to_sunrise">从日落到日出</string>
 	<string name="add_opening_hours">添加工作时间</string>
 	<string name="edit_opening_hours">编辑工作时间</string>
 	<string name="no_osm_account">OpenStreetMap上没有账户吗？</string>
@@ -648,29 +406,13 @@
 	<string name="login">登录</string>
 	<string name="password">密码</string>
 	<string name="forgot_password">忘记密码</string>
-	<!-- Forgot Password dialog title -->
-	<string name="restore_password">恢复密码</string>
-	<string name="enter_email_address_to_reset_password">输入您在注册时所用的邮箱地址，我们会给您发送链接更新密码</string>
-	<string name="reset_password">重置密码</string>
-	<string name="username">用户名</string>
 	<string name="osm_account">OSM账户</string>
 	<string name="logout">登出</string>
-	<string name="login_and_edit_map_motivation_message">登录并编辑地图上的物品信息，我们就会让数百万其他用户看到。</string>
 	<!-- Information text: "Last upload 11.01.2016" -->
 	<string name="last_upload">上次上传</string>
-	<!-- Motivates user to login/register, title above login buttons. -->
-	<string name="you_have_edited_your_first_object">您已编辑您的第一件物品！</string>
 	<string name="thank_you">谢谢您</string>
-	<string name="login_with_google">用谷歌登陆</string>
-	<string name="login_with_openstreetmap">登录到www.openstreetmap.org</string>
 	<string name="edit_place">编辑地点</string>
 	<string name="place_name">地点名</string>
-	<!-- title above languages list cells in the editor, below editable name text field. -->
-	<string name="other_languages">其他语言</string>
-	<!-- small button to open list with names in different languages -->
-	<string name="show_more">显示更多</string>
-	<!-- small button to close list with names in different languages -->
-	<string name="show_less">显示更少</string>
 	<string name="add_language">添加语言</string>
 	<string name="street">街道</string>
 	<!-- Editable House Number text field (in address block). -->
@@ -687,25 +429,16 @@
 	<string name="email_or_username">邮箱或用户名</string>
 	<string name="phone">电话</string>
 	<string name="please_note">请注意</string>
-	<string name="common_no_wifi_dialog">无 WiFi 连接。您想继续使用移动数据进行连接吗？</string>
 	<string name="downloader_delete_map_dialog">所有对地图的修改都将与地图一起被删除。</string>
 	<string name="downloader_update_maps">更新地图</string>
 	<string name="downloader_mwm_migration_dialog">为了创建路线，您需要更新全部地图并重新规划路线。</string>
 	<string name="downloader_search_field_hint">找到地图</string>
-	<string name="migration_update_all_button">更新全部地图</string>
-	<string name="migration_delete_all_download_current_button">下载当前地图并删除旧地图</string>
 	<string name="migration_download_error_dialog">下载错误</string>
 	<string name="common_check_internet_connection_dialog">请检查您的设置并确保您的设备已连接至网络。</string>
 	<string name="downloader_no_space_title">无足够的空间</string>
 	<string name="downloader_no_space_message">请删除不必要的数据</string>
-	<string name="editor_general_auth_error_dialog">一般登录错误。</string>
 	<string name="editor_login_error_dialog">登录错误。</string>
-	<string name="editor_login_failed_dialog">登录失败</string>
-	<string name="editor_username_error_dialog">用户名不存在</string>
-	<string name="editor_place_edited_dialog">您已编辑了一个对象！</string>
-	<string name="editor_login_with_osm">使用OpenStreetMap进行登录</string>
 	<string name="editor_profile_changes">已验证的更改</string>
-	<string name="editor_profile_unsent_changes">未发送：</string>
 	<string name="editor_focus_map_on_location">拖动地图以选择此对象的正确位置。</string>
 	<string name="editor_add_select_category">选择类别</string>
 	<string name="editor_add_select_category_popular_subtitle">受欢迎的</string>
@@ -716,19 +449,14 @@
 	<string name="editor_edit_place_category_title">类别</string>
 	<string name="detailed_problem_description">问题的详细描述</string>
 	<string name="editor_report_problem_other_title">一个不同的问题</string>
-	<string name="placepage_report_problem_button">报告一个问题</string>
 	<string name="placepage_add_business_button">添加组织</string>
 	<string name="whatsnew_editor_message_1">添加新地点到该地图，并直接通过此应用编辑已存在的地点。</string>
-	<string name="whatsnew_editor_message_2">* Organic Maps使用OpenStreetMap社区的数据。</string>
 	<string name="dialog_incorrect_feature_position">改变位置</string>
 	<string name="message_invalid_feature_position">对象无法设置在这里</string>
 	<string name="login_to_make_edits_visible">登陆，让其他用户能看到您所作出的修改。</string>
-	<string name="no_migration_during_navigation">导航中禁止更新。</string>
 	<!-- Error dialog no space -->
 	<string name="migration_no_space_message">为了下载，您需要更多的空间。请删除不必要的数据。</string>
 	<string name="editor_sharing_title">我改进了Organic Maps地图</string>
-	<string name="editor_comment_will_be_sent">我们将把您的评论发送给地图制作者。</string>
-	<string name="editor_unsupported_category_message">您已添加了一个我们尚未支持类别的地点。它将在一段时间之后显示在地图上。</string>
 	<!-- Downloaded 10 **of** 20 <- it is that "of" -->
 	<string name="downloader_of">%1$d个/共%2$d个</string>
 	<string name="download_over_mobile_header">用手机网络连接下载吗？</string>
@@ -746,15 +474,8 @@
 	<string name="editor_detailed_description">您建议的更改将发送至 OpenStreetMap 社区。说明无法在 Organic Maps 编辑的详情。</string>
 	<string name="editor_more_about_osm">关于 OpenStreetMap 的更多信息</string>
 	<string name="editor_operator">运营者</string>
-	<string name="editor_tag_description">输入公司、组织或设施负责人。</string>
-	<string name="editor_no_local_edits_title">您没有本地编辑</string>
-	<string name="editor_no_local_edits_description">这显示了当前仅在您设备上能够访问的对地图建议修改的数量。</string>
-	<string name="editor_send_to_osm">发送至 OSM</string>
-	<string name="editor_remove">删除</string>
-	<string name="downloader_my_maps_title">我的地图</string>
 	<string name="downloader_no_downloaded_maps_title">您尚未下载任何地图</string>
 	<string name="downloader_no_downloaded_maps_message">下载地图来查找位置和离线浏览</string>
-	<string name="downloader_find_place_hint">搜索城市或国家</string>
 	<!-- Error title that appears after certain time without location. -->
 	<string name="current_location_unknown_title">继续检测您的当前位置？</string>
 	<!-- Error that appears after certain time without location. -->
@@ -769,27 +490,10 @@
 	<string name="location_services_disabled_2">2. 点击位置</string>
 	<!-- iOS Dialog for the case when the location permission is not granted -->
 	<string name="location_services_disabled_3">3. 使用应用时选择</string>
-	<string name="placepage_parking_surface">表面</string>
-	<string name="placepage_parking_multistorey">多层</string>
-	<string name="placepage_parking_underground">地下</string>
-	<string name="placepage_parking_rooftop">楼顶</string>
-	<string name="placepage_parking_sheds">小屋</string>
-	<string name="placepage_parking_carports">屋侧车库</string>
-	<string name="placepage_parking_boxes">停车房</string>
-	<string name="placepage_parking_pay">付款</string>
-	<string name="placepage_parking_free">免费</string>
-	<string name="placepage_parking_interval">间隔付款</string>
-	<string name="placepage_entrance_number">编号</string>
-	<string name="placepage_entrance_type">入口</string>
-	<string name="placepage_flat">公寓</string>
-	<string name="placepage_open_24_7">24 / 7</string>
 	<string name="meter">米</string>
 	<string name="kilometer">公里</string>
-	<string name="kilometers_per_hour">公里每小时</string>
 	<string name="mile">英里</string>
 	<string name="foot">英尺</string>
-	<string name="miles_per_hour">英里每小时</string>
-	<string name="day">天</string>
 	<string name="hour">小時</string>
 	<string name="minute">分鐘</string>
 	<string name="placepage_place_description">说明</string>
@@ -799,46 +503,30 @@
 	<string name="placepage_call_button">呼叫</string>
 	<string name="placepage_edit_bookmark_button">编辑书签</string>
 	<string name="placepage_bookmark_name_hint">书签名称</string>
-	<string name="placepage_personal_notes_hint">个人备注</string>
-	<string name="placepage_delete_bookmark_button">删除书签</string>
 	<string name="editor_edits_sent_message">您的建议已发送</string>
 	<string name="editor_comment_hint">备注…</string>
 	<string name="editor_reset_edits_message">重置所有本地更改？</string>
 	<string name="editor_reset_edits_button">重置</string>
 	<string name="editor_remove_place_message">删除已添加的位置？</string>
 	<string name="editor_remove_place_button">删除</string>
-	<string name="editor_status_sending">正在发送…</string>
 	<string name="editor_place_doesnt_exist">位置不存在</string>
 	<string name="text_more_button">…更多</string>
 	<!-- Phone number error message -->
 	<string name="error_enter_correct_phone">输入正确的电话号码</string>
 	<string name="error_enter_correct_web">输入有效网址</string>
 	<string name="error_enter_correct_email">输入有效电子邮箱</string>
-	<string name="error_enter_correct">输入有效值</string>
 	<string name="refresh">更新</string>
-	<string name="last_update">上次更新于：%s</string>
 	<string name="placepage_add_place_button">添加地点到地图上</string>
 	<!-- Displayed when saving some edits to the map to warn against publishing personal data -->
 	<string name="editor_share_to_all_dialog_title">您想要发给所有用户吗？</string>
 	<!-- iOS Dialog before publishing the modifications to the public map. -->
 	<string name="editor_share_to_all_dialog_message_1">确保您没有输入任何个人数据。</string>
 	<string name="editor_share_to_all_dialog_message_2">我们会检查更改。如果我们有任何问题，我们会邮件与您联系。</string>
-	<string name="navigation_overview_button">概览</string>
-	<string name="navigation_stop_button">停止</string>
-	<!-- Text on an empty bookmark page -->
-	<string name="bookmarks_empty_title">保存书签</string>
-	<string name="bookmarks_empty_message_1">点击★保存收藏地点以便快速访问。</string>
-	<string name="bookmarks_empty_message_2">从邮箱和网页导入书签。</string>
-	<string name="bookmarks_empty_message_3">退房： %s</string>
-	<!-- Name of the group for booked hotels -->
-	<string name="bookmarks_group_name">预订的酒店</string>
-	<string name="place_page_button_read_descriprion">阅读</string>
 	<!-- iOS dialog for the case when recent track recording is on and the app comes back from background -->
 	<string name="recent_track_background_dialog_title">禁止记录您最近去过的路径？</string>
 	<string name="off_recent_track_background_button">禁用</string>
 	<!-- For sharing via SMS and so on -->
 	<string name="sharing_call_action_look">来看看</string>
-	<string name="continue_recent_track_background_button">继续</string>
 	<string name="recent_track_background_dialog_message">Organic Maps使用背景中的地理位置记录您最近去过的路径。</string>
 	<!-- Rate on Google Play (Android only) -->
 	<string name="rate_gp">在 Google Play 上的评分</string>
@@ -848,21 +536,11 @@
 	<string name="tell_friends_text">您好！安装 Organic Maps！</string>
 	<!-- About short text (below logo) -->
 	<string name="about_description">Organic Maps 是一款基本的离线旅行应用。Organic Maps 基于 OpenStreetMap 数据并且允许对其进行编辑。</string>
-	<!-- Text in menu -->
-	<string name="blog">博客</string>
 	<string name="general_settings">常规设置</string>
-	<string name="date">日期 %d</string>
-	<!-- "Report a bug" -> "Generaal Feedback" -> "Something is not working" -->
-	<string name="something_is_not_working">某些地方出错了</string>
 	<!-- For the first routing -->
 	<string name="accept">接受</string>
 	<!-- For the first routing -->
 	<string name="decline">拒绝</string>
-	<string name="install_app">安装</string>
-	<string name="search_no_results_title">未找到任何结果</string>
-	<string name="search_no_results_message">尝试一个更普通的搜索词、缩小显示或重置筛选器。</string>
-	<string name="search_no_results_expand_area_button">缩小</string>
-	<string name="search_no_results_reset_button">重置筛选器</string>
 	<!-- noun -->
 	<string name="search_in_table">列表</string>
 	<string name="mobile_data_dialog">使用移动网络显示详细信息？</string>
@@ -874,18 +552,13 @@
 	<string name="mobile_data_option_never">从不使用</string>
 	<string name="mobile_data_option_ask">总是询问</string>
 	<string name="traffic_update_maps_text">要显示交通数据，必须更新地图。</string>
-	<string name="traffic_outdated">交通数据已过时。</string>
 	<string name="big_font">增大地图上的字体大小</string>
 	<string name="traffic_update_app">请更新 Organic Maps</string>
 	<!-- "traffic" as in road congestion -->
 	<string name="traffic_update_app_message">要显示交通数据，必须更新应用。</string>
 	<!-- "traffic" as in "road congestion" -->
 	<string name="traffic_data_unavailable">交通数据不可用</string>
-	<!-- Simplified colour scheme for traffic information, fewer colours are used to display traffic jams on the map. The string should be kept as short as possible -->
-	<string name="pref_traffic_simplified_colors_title">简化的交通状况颜色</string>
 	<string name="enable_logging">启用记录</string>
-	<string name="offline_place_page_more_information">连接到互联网来获取关于地点的更多信息。</string>
-	<string name="failed_load_information">无法加载信息。</string>
 	<!-- Settings: "Send general feedback" button -->
 	<string name="feedback_general">一般反馈</string>
 	<string name="on">开</string>
@@ -899,57 +572,26 @@
 	<string name="routing_add_start_point">添加起点以规划路线</string>
 	<string name="routing_add_finish_point">添加终点以规划路线</string>
 	<string name="button_exit">退出</string>
-	<string name="settings_device_memory">设备内存</string>
-	<string name="settings_card_memory">存储卡</string>
-	<string name="settings_storage_available">%s 可用</string>
-	<string name="toast_location_permission_denied">应用已拒绝地点获取权限</string>
-	<string name="button_use">使用</string>
 	<string name="planning_route_manage_route">管理路线</string>
 	<string name="button_plan">规划</string>
-	<string name="button_add">添加</string>
 	<string name="placepage_remove_stop">移除</string>
 	<string name="planning_route_remove_title">拖动到此处以移除</string>
-	<string name="dialog_change_start_point_message">将起点替换为当前地点？</string>
-	<string name="button_replace">替换</string>
 	<string name="placepage_add_stop">添加经停点</string>
-	<string name="add_my_position">添加我的位置</string>
-	<string name="choose_start_point">选择起点</string>
-	<string name="choose_destination">选择终点</string>
 	<string name="preloader_viator_button">了解更多</string>
-	<string name="start_from_my_position">起点</string>
-	<string name="profile_authorization_title">登录方式</string>
-	<string name="profile_authorization_message">在几秒内轻松登录，无需登录名和密码</string>
 	<string name="profile_authorization_error">糟糕，出错了。请尝试重新登录。</string>
-	<string name="service">服务</string>
-	<string name="atmosphere">氛围</string>
-	<string name="value_for_money">物有所值</string>
-	<string name="experience">经验</string>
-	<string name="assortment">分类</string>
-	<string name="expertise">专业</string>
-	<string name="equipment">设备</string>
-	<string name="quality">质量</string>
 	<string name="dialog_error_storage_title">存储空间访问问题</string>
 	<string name="dialog_error_storage_message">外部存储空间不可用，可能是 SD 卡已移除、损坏，或者文件系统为只读。请检查，然后通过以下方式联系我们：support\@organicmaps.app</string>
 	<string name="setting_emulate_bad_storage">模拟不良存储空间</string>
-	<string name="directions_finish">目的地</string>
-	<string name="directions_on_foot">步行 %s</string>
 	<string name="core_entrance">入口</string>
-	<string name="coffee">咖啡</string>
-	<string name="cleanliness">卫生程度</string>
-	<string name="crowdedness">拥挤程度</string>
 	<string name="error_enter_correct_name">请输入正确的名称</string>
 	<string name="bookmarks_groups">清單</string>
 	<string name="bookmarks_groups_hide_all">全部隱藏</string>
 	<string name="bookmarks_groups_show_all">全部顯示</string>
-	<plurals name="bookmarks_places">
-	  <item quantity="other">%d 個書籤</item>
-	</plurals>
 	<string name="bookmarks_create_new_group">创建新的列表</string>
 	<string name="downloader_hide_screen">隱藏畫面</string>
 	<string name="downloader_percent">%1$s (%2$s / %3$s)</string>
-	<string name="downloader_process">正在下載 %s...</string>
-	<string name="downloader_applying">正在套用 %s...</string>
-	<string name="dialog_message_transit_not_found_connection">规划一个交通网络内的路线</string>
+	<string name="downloader_process">正在下載 %s…</string>
+	<string name="downloader_applying">正在套用 %s…</string>
 	<string name="bookmarks_error_message_share_general">由于应用程序出错而无法分享</string>
 	<string name="bookmarks_error_title_share_empty">分享错误</string>
 	<string name="bookmarks_error_message_share_empty">无法分享空列表</string>
@@ -958,12 +600,7 @@
 	<string name="bookmarks_new_list_hint">新的列表</string>
 	<string name="bookmarks_error_title_list_name_already_taken">这个名字已经被使用了</string>
 	<string name="bookmarks_error_message_list_name_already_taken">请选择其他名称</string>
-	<string name="bookmarks_error_title_list_name_too_long">这个名字太长了</string>
-	<string name="bookmarks_error_message_list_name_too_long">请选择其他名称</string>
-	<string name="please_wait">请稍候...</string>
-	<string name="phone_number">电话号码</string>
-	<string name="notification_unsent_reviews_title">你有几个未发表的评论</string>
-	<string name="notification_unsent_reviews_message">请登录与其他旅客分享评论</string>
+	<string name="please_wait">请稍候…</string>
 	<string name="profile">OpenStreetMap 资料</string>
 	<string name="place_page_search_similar_hotel">搜索类似的酒店</string>
 	<string name="bookmarks_detect_title">检测到新文件</string>
@@ -973,31 +610,10 @@
 	<string name="button_convert">兑换</string>
 	<string name="bookmarks_convert_error_title">错误</string>
 	<string name="bookmarks_convert_error_message">有些文件未被转换。</string>
-	<string name="converting">转换...</string>
-	<string name="wn_reinvented_bookmarks_title">我们改造了书签！</string>
-	<string name="wn_reinvented_bookmarks_message">你可以备份书签，创建列表...这太神奇了...</string>
-	<string name="bookmarks_restore">恢复书签</string>
-	<string name="bookmarks_restore_process">恢复...</string>
 	<string name="bookmarks_restore_title">还原这个版本？</string>
-	<string name="bookmarks_restore_message">您的书签将从%1$s (%2$s)个恢复</string>
-	<string name="bookmarks_restore_empty_title">你没有备份</string>
-	<string name="bookmarks_restore_empty_message">服务器没有找到以前做的备份</string>
 	<string name="common_check_internet_connection_dialog_title">没有互联网连接</string>
-	<string name="error_server_title">服务器错误</string>
-	<string name="error_server_message">服务器发生错误，请稍后重试</string>
 	<string name="error_system_message">出现未知错误</string>
 	<string name="restore">恢复</string>
-	<string name="bookmarks_page_downloaded">加载</string>
-	<string name="bookmarks_page_my">我的</string>
-	<string name="routes_and_bookmarks">路线和标签</string>
-	<string name="bookmarks_webview_success_toast">标签已成功下载</string>
-	<string name="cached_bookmarks_placeholder_title">上传新地点</string>
-	<string name="cached_bookmarks_placeholder_subtitle">单击按钮下载Organic Maps用户创建的数千个有趣的地点和路线。您需要连接网络。</string>
-	<string name="downloader_download_routers">下载标签</string>
-	<string name="bookmarks_groups_cached">上传的列表</string>
-	<plurals name="bookmarks_objects">
-	  <item quantity="other">%s 对象</item>
-	</plurals>
 	<plurals name="objects">
 	  <item quantity="other">%d 地点</item>
 	</plurals>
@@ -1010,62 +626,32 @@
 	<string name="subtittle_opt_out">支持设置</string>
 	<string name="crash_reports">错误报告</string>
 	<string name="crash_reports_description">我们可以使用您的数据来开发和改进Organic Maps.更改将在重新启动应用程序后生效。</string>
-	<string name="opt_out_help_ios_1">您可以选择停止在设备设置中接收定位广告。</string>
-	<string name="opt_out_help_ios_2">iOS 9或更高版本</string>
-	<string name="opt_out_help_ios_3">打开设置→隐私→广告→启用“跟踪限制”</string>
-	<string name="opt_out_help_android">您可以选择不在设备设置中接收定向广告。\ NAndroid和Google Play Services 4.0或更高版本\ n \ n电话设置→Google→广告→停用广告个性化\ n或\ n手机设置→Google→Google帐户→隐私→首选项设置→ 广告的个性化</string>
 	<string name="privacy_policy">隐私政策</string>
 	<string name="terms_of_use">使用条款</string>
-	<string name="backup_notification_failed">标签备份已暂停。登录以启用备份。</string>
 	<string name="button_layer_traffic">堵塞</string>
 	<string name="button_layer_subway">地铁</string>
 	<string name="layers_title">地图图层</string>
-	<string name="layers_message">打开在地图上的图层以显示交通状况、地铁图或其他有用信息</string>
-	<string name="button_layer_got_it">明白</string>
 	<string name="subway_data_unavailable">地铁地图不可用</string>
 	<string name="bookmarks_empty_list_title">该列表为空</string>
 	<string name="bookmarks_empty_list_message">要添加新标签，请单击对象卡中的星形图标</string>
 	<string name="category_desc_more">…更多</string>
 	<string name="title_error_downloading_bookmarks">发生错误</string>
-	<string name="subtitle_error_downloading_bookmarks">标签尚未上传</string>
-	<string name="error_already_downloaded">这个列表已被下载</string>
-	<string name="why_support">为什么支持Organic Maps?</string>
-	<string name="why_support_item2">您帮助我们改进Organic Maps</string>
-	<string name="why_support_item3">您帮助我们改进OpenStreetMap.org地图</string>
-	<string name="channels_map_update">更新地图</string>
-	<string name="server_unavailable_title">服务不可用</string>
-	<string name="sharing_options">登录设置</string>
 	<string name="export_file">导出文件</string>
 	<string name="list_settings">列表设置</string>
 	<string name="delete_list">删除列表</string>
-	<string name="hide_from_map">从卡中隐藏</string>
 	<string name="public_access">公共访问</string>
 	<string name="limited_access">私人访问</string>
 	<string name="bookmark_category_name">类别</string>
 	<string name="bookmark_category_description_hint">请添加说明(文字或html)</string>
 	<string name="not_shared">个人</string>
-	<string name="direct_link_progress_text">正在上传您的文件......</string>
-	<string name="direct_link_success">链接已创建</string>
-	<string name="send_a_link_btn">发送链接</string>
-	<string name="upload_error_toast">加载文件时出错</string>
 	<string name="tags_loading_error_subtitle">加载标签时出错，请重试</string>
-	<string name="unable_upload_errorr_title">无法上传文件</string>
-	<string name="unable_upload_error_subtitle_edited">文件是通过Web应用程序编辑的</string>
-	<string name="unable_upload_error_subtitle_broken">该文件已损坏，无法上传。请上传其他文件。</string>
-	<string name="contact">写</string>
-	<string name="download_button">下载</string>
 	<string name="speedcams_alert_title">高速摄像机</string>
-	<string name="speedcams_alert_subtitle">速度限制警告</string>
 	<string name="speedcam_option_auto">自动</string>
 	<string name="speedcam_option_always">总是</string>
 	<string name="speedcam_option_never">从不</string>
-	<string name="bookmark_description_title">标签说明</string>
 	<string name="place_description_title">地点说明</string>
 	<!-- this text will be shown in application notification preferences opposite checkbox which enable/disable downloader notifications. Devices on Android 8+ are affected. -->
 	<string name="notification_channel_downloader">加载地图</string>
-	<string name="share_bookmarks_email_body_link">您好！\n\n您的标签可以从链接下载：%s.使用Organic Maps打开列表并享受旅行!\n\n下载程序：https://omaps.app/get?kmz</string>
-	<string name="warning_speedcams_title">当速度限制超过%d km / h时，导航会通知您的摄像机</string>
-	<string name="warning_speedcams_subtitle">请不要忘记阅读旅行国的道路规则。</string>
 	<string name="speedcams_notice_message">自动 - 如果存在超出速度限制的风险，则对速度摄像头发出警告\n总是 - 始终提醒摄像头\n从不 - 永远不会对摄像头发出警告</string>
 	<string name="power_managment_title">省电模式</string>
 	<string name="power_managment_description">如果开启省电模式，应用程序将根据手机的当前电量关耗电功能</string>
@@ -1073,14 +659,7 @@
 	<string name="power_managment_setting_auto">自动</string>
 	<string name="power_managment_setting_manual_max">最大程度省电</string>
 	<string name="enable_logging_warning_message">此选项启用以记录操作来进行诊断。这有助于团队识别应用程序的问题。请仅在Organic Maps支持请求时开启该选项。</string>
-	<string name="html_error_upload_message_try_again">请检查网络访问，然后再重试</string>
-	<string name="html_error_upload_title_try_again">未连接到网络</string>
-	<string name="notification_leave_review_v2_android_short_title">请发表评论来帮助旅行者们！</string>
-	<string name="notifications_illegal_alert_disable_button">关闭通知</string>
 	<string name="access_rules_author_only">在线编辑</string>
-	<string name="privacy_settings_menu">隐私设置</string>
-	<string name="unable_upadate_error_title">无法更新路线</string>
-	<string name="unable_upadate_error_message">更新时出错。请检查更改，然后再重试</string>
 	<string name="driving_options_title">绕行设置</string>
 	<string name="driving_options_subheader">在每条线路上规避</string>
 	<string name="avoid_tolls">收费公路</string>
@@ -1091,52 +670,14 @@
 	<string name="unable_to_calc_alert_subtitle">很遗憾，我们无法使用所选选项规划路线。请更改设置，然后重试</string>
 	<string name="define_to_avoid_btn">设置绕行路径</string>
 	<string name="change_driving_options_btn">繞行設置已開啟</string>
-	<string name="toll_road">收费公路</string>
-	<string name="unpaved_road">土路</string>
-	<string name="ferry_crossing">轮渡</string>
-	<string name="operated_by">由\"%s\"管理</string>
 	<string name="avoid_toll_roads_placepage">规避收费公路</string>
 	<string name="avoid_unpaved_roads_placepage">规避土路</string>
 	<string name="avoid_ferry_crossing_placepage">规避轮渡</string>
-	<string name="type.cuisine.uzbek">乌兹别克美食</string>
-	<string name="trip_start">前往</string>
-	<string name="pick_destination">目标</string>
-	<string name="follow_my_position">定好中心</string>
-	<string name="search_results">搜索结果</string>
-	<string name="then_turn">接下来</string>
-	<string name="redirect_route_alert">想重建路线?</string>
-	<string name="redirect_route_yes">是</string>
-	<string name="redirect_route_no">否</string>
-	<string name="trip_finished">您已到达!</string>
-	<string name="keyboard_availability_alert">移动时键盘不可用</string>
-	<string name="dialog_routing_change_start_carplay">无法从当前位置构建路线</string>
-	<string name="dialog_routing_change_end_carplay">无法建立到终点的路线。请选择其他（路线）</string>
-	<string name="dialog_routing_check_gps_carplay">无GPS信号。请沿着空旷区域行驶</string>
-	<string name="dialog_routing_unable_locate_route_carplay">无法建立路线。请选择其他路线点</string>
-	<string name="dialog_routing_download_files_carplay">为了创建线路，请在您的设备中下载所缺少的地图</string>
-	<string name="dialog_routing_system_error_carplay">发生了错误。请重新启动程序</string>
-	<string name="dialog_routing_rebuild_from_current_location_carplay">该路线将从您的当前位置重建</string>
-	<string name="dialog_routing_rebuild_for_vehicle_carplay">该路线将改为汽车（路线）</string>
 	<string name="ok">好的</string>
-	<string name="avoid_unpaved_carplay_1">无土路路段</string>
-	<string name="avoid_unpaved_carplay_2">无土路路段</string>
-	<string name="avoid_ferry_carplay_1">无渡船</string>
-	<string name="avoid_ferry_carplay_2">无渡船</string>
-	<string name="avoid_tolls_carplay_1">无付费路段</string>
-	<string name="avoid_tolls_carplay_2">无付费路段</string>
-	<string name="speedcams_alert_title_carplay_1">摄像头</string>
-	<string name="speedcams_alert_title_carplay_2">摄像头信息</string>
-	<string name="download_map_carplay">将Organic Maps软件中的地图下载至个人设备中</string>
-	<string name="carplay_roundabout_exit">%s号坡道</string>
 	<!-- max. 10 symbols, both iOS and Android -->
 	<string name="sort">分类……</string>
 	<!-- Android, title, max 20-22 symbols -->
 	<string name="sort_bookmarks">分类标签</string>
-	<!-- iOS -->
-	<string name="sort_default">默认排序</string>
-	<string name="sort_type">按类型排序</string>
-	<string name="sort_distance">按距离排序</string>
-	<string name="sort_date">按日期排序</string>
 	<!-- Android -->
 	<string name="by_default">默认情况下</string>
 	<!-- Android -->
@@ -1145,65 +686,23 @@
 	<string name="by_distance">按距离</string>
 	<!-- Android -->
 	<string name="by_date">按时间</string>
-	<string name="week_ago_sorttype">一周前</string>
-	<string name="month_ago_sorttype">一月前</string>
-	<string name="moremonth_ago_sorttype">一个多月前</string>
-	<string name="moreyear_ago_sorttype">一年多以前</string>
-	<string name="near_me_sorttype">在我旁边</string>
-	<string name="others_sorttype">其他</string>
-	<string name="food_places">美食</string>
-	<string name="tourist_places">名胜</string>
-	<string name="museums">博物馆</string>
-	<string name="parks">公园</string>
-	<string name="swim_places">游泳</string>
-	<string name="mountains">山</string>
-	<string name="animals">动物</string>
-	<string name="hotels">酒店</string>
-	<string name="buildings">建筑物</string>
-	<string name="money">货币</string>
-	<string name="shops">商店</string>
-	<string name="parkings">停车场</string>
-	<string name="fuel_places">加油站</string>
-	<string name="water">水</string>
-	<string name="medicine">医疗</string>
 	<string name="search_in_the_list">在列表中搜索</string>
-	<string name="view_on_map_bookmarks">在地图上</string>
-	<string name="more_bookmarks">更多……</string>
-	<string name="no_items_found">未搜索到内容</string>
-	<!-- Android, max 18 symbols -->
-	<string name="bookmarks_edit_list">编辑</string>
-	<!-- Android, max 18 symbols -->
-	<string name="bookmarks_delete_list">删除列表</string>
-	<string name="religious_places">圣地</string>
 	<string name="select_list">选择列表</string>
 	<string name="transit_not_found">本区域的地铁导航目前不可用</string>
 	<string name="dialog_pedestrian_route_is_long_header">地铁路线图未找到</string>
 	<string name="dialog_pedestrian_route_is_long_message">选择地铁站附近的起点和终点</string>
-	<!-- Failed planning SUBWAY route message in navigation view -->
-	<string name="routing_planning_error_subway_special">地铁路线图设计出错</string>
 	<string name="button_layer_isolines">高度</string>
-	<string name="tips_map_layers_title_countour">离线高度线在Organic Maps中！</string>
-	<string name="tips_map_layers_message_countour">高度线可以帮您规划通往大自然地区的路线，不会迷路</string>
 	<string name="isolines_activation_error_dialog">如需使用高度線，請更新或下載所需區域的地圖</string>
 	<string name="isolines_location_error_dialog">暂时无法获取该地区的高低线</string>
 	<string name="elevation_profile_diff_level">难度等级</string>
-	<string name="elevation_profile_diff_level_easy">容易</string>
-	<string name="elevation_profile_diff_level_moderate">中等</string>
-	<string name="elevation_profile_diff_level_hard">困难</string>
 	<string name="elevation_profile_ascent">上坡</string>
 	<string name="elevation_profile_descent">下坡</string>
 	<string name="elevation_profile_minaltitude">最小高度</string>
 	<string name="elevation_profile_maxaltitude">最大高度</string>
-	<string name="elevation_profile_m">米</string>
 	<string name="elevation_profile_difficulty">难度</string>
 	<string name="elevation_profile_distance">距离：</string>
-	<string name="elevation_profile_km">千米</string>
 	<string name="elevation_profile_time">在路上：</string>
-	<string name="elevation_profile_hours">小时</string>
-	<string name="elevation_profile_minutes">分钟</string>
 	<string name="isolines_toast_zooms_1_10">放大地图以查看等高线</string>
-	<string name="downloader_updating_ios">更新</string>
-	<string name="downloader_loading_ios">加载</string>
 	<string name="key_information_title">关键信息</string>
 	<string name="enable_screen_sleep">允许屏幕进入休眠状态</string>
 	<!-- Description in preferences -->

--- a/android/res/values/strings.xml
+++ b/android/res/values/strings.xml
@@ -12,15 +12,11 @@
 	<string name="cancel_download">Cancel Download</string>
 	<!-- Button which deletes downloaded country -->
 	<string name="delete">Delete</string>
-	<!-- Button "do not interrupt download" if user touched actively downloading country -->
-	<string name="do_nothing">Continue</string>
 	<string name="download_maps">Download Maps</string>
 	<!-- Settings/Downloader - info for country when download fails -->
 	<string name="download_has_failed">Download has failed. Touch to try again.</string>
 	<!-- Settings/Downloader - info for country which started downloading -->
 	<string name="downloading">Downloading…</string>
-	<!-- Settings/Downloader - size string, only strings different from English should be translated -->
-	<string name="kb">kB</string>
 	<!-- Choose measurement on first launch alert - choose metric system button -->
 	<string name="kilometres">Kilometers</string>
 	<!-- Leave Review dialog - Review button -->
@@ -36,45 +32,31 @@
 	<string name="core_my_position">My Position</string>
 	<!-- Update maps later/Buy pro version later button text -->
 	<string name="later">Later</string>
-	<!-- Don't show some dialog any more -->
-	<string name="never">Never</string>
 	<!-- View and button titles for accessibility -->
 	<string name="search">Search</string>
 	<!-- Search box placeholder text -->
 	<string name="search_map">Search Map</string>
-	<!-- Settings/Downloader - info for not downloaded country -->
-	<string name="touch_to_download">Touch to download</string>
 	<!-- Settings/Downloader - 3G download warning dialog confirm button -->
 	<string name="use_cellular_data">Yes</string>
 	<!-- Location services are disabled by user alert - message -->
 	<string name="location_is_disabled_long_text">You currently have all Location Services for this device or application disabled. Please enable them in Settings.</string>
-	<!-- Location Services are not available on the device alert - message -->
-	<string name="device_doesnot_support_location_services">Your device doesn\'t support Location Services</string>
 	<!-- View and button titles for accessibility -->
 	<string name="zoom_to_country">Show on the map</string>
-	<!-- Button text for the button at the center of the screen when the country is not downloaded -->
-	<string name="country_status_download">Download Map\n(^ ^)</string>
 	<!-- Button text for the button at the center of the screen when the country is not downloaded and the size should not be shown -->
 	<string name="country_status_download_without_size">Download Map</string>
-	<!-- Button text for the button at the center of the screen when the country is not downloaded -->
-	<string name="country_status_download_without_routing">Download map\nwithout routing (^ ^)</string>
 	<!-- Message to display at the center of the screen when the country download has failed -->
 	<string name="country_status_download_failed">Download has failed</string>
 	<!-- Button text for the button under the country_status_download_failed message -->
 	<string name="try_again">Try Again</string>
 	<string name="about_menu_title">About Organic Maps</string>
-	<string name="downloaded_touch_to_delete">Downloaded (%s), touch to delete</string>
 	<string name="connection_settings">Connection Settings</string>
-	<string name="download_mb_or_kb">Download %s</string>
 	<string name="close">Close</string>
 	<string name="unsupported_phone">The app requires hardware accelerated OpenGL. Unfortunately, your device is not supported.</string>
 	<string name="download">Download</string>
-	<string name="external_storage_is_not_available">SD card/USB storage with downloaded maps is not available</string>
 	<string name="disconnect_usb_cable">Please disconnect USB cable or insert memory card to use Organic Maps</string>
 	<string name="not_enough_free_space_on_sdcard">Please free up some space on the SD card/USB storage first in order to use the app</string>
 	<string name="not_enough_memory">Not enough memory to launch app</string>
 	<string name="download_resources">Before you start using the app, allow us to download the general world map to your device.\nIt will use %s of storage.</string>
-	<string name="getting_position">Getting current position</string>
 	<string name="download_resources_continue">Go to Map</string>
 	<string name="downloading_country_can_proceed">Downloading %s. You can now\nproceed to the map.</string>
 	<string name="download_country_ask">Download %s?</string>
@@ -87,30 +69,20 @@
 	<string name="download_country_failed">%s download has failed</string>
 	<!-- Add New Bookmark Set dialog title -->
 	<string name="add_new_set">Add New Set</string>
-	<!-- Place Page - Add To Bookmarks button -->
-	<string name="add_to_bookmarks">Add to Bookmarks</string>
 	<!-- Bookmark Color dialog title -->
 	<string name="bookmark_color">Bookmark Color</string>
 	<!-- Add Bookmark Set dialog - hint when set name is empty -->
 	<string name="bookmark_set_name">Bookmark Set Name</string>
-	<!-- Bookmark Sets dialog title -->
-	<string name="bookmark_sets">Bookmark Sets</string>
 	<!-- Bookmarks - dialog title -->
 	<string name="bookmarks">Bookmarks</string>
-	<!-- Add bookmark dialog - bookmark color -->
-	<string name="color">Color</string>
 	<!-- Default bookmarks set name -->
 	<string name="core_my_places">My Places</string>
 	<!-- Add bookmark dialog - bookmark name -->
 	<string name="name">Name</string>
 	<!-- Editor title above street and house number -->
 	<string name="address">Address</string>
-	<!-- Place Page - Remove Pin button -->
-	<string name="remove_pin">Remove Pin</string>
 	<!-- Add bookmark dialog - bookmark set, Bookmarks dialog - Bookmark set cell -->
 	<string name="set">Set</string>
-	<!-- Text hint in Bookmarks dialog when no any bookmarks are added -->
-	<string name="bookmarks_usage_hint">You have no bookmarks yet.\nTap on any place on the map to add a bookmark.\nBookmarks from other sources can also be imported and displayed in Organic Maps. Open KML/KMZ file with saved bookmarks from email, Dropbox or weblink.</string>
 	<!-- Settings button in system menu -->
 	<string name="settings">Settings</string>
 	<!-- Header of settings activity where user defines storage path -->
@@ -121,20 +93,10 @@
 	<string name="move_maps">Move maps?</string>
 	<!-- Ask to wait user several minutes (some long process in modal dialog). -->
 	<string name="wait_several_minutes">This can take several minutes.\nPlease wait…</string>
-	<!-- Show bookmarks from this category on a map or not -->
-	<string name="visible">Visible</string>
-	<!-- Toast which is displayed when GPS has been deactivated -->
-	<string name="gps_is_disabled_long_text">GPS is disabled. Please enable it in Settings.</string>
 	<!-- Measurement units title in settings activity -->
 	<string name="measurement_units">Measurement units</string>
 	<!-- Detailed description of Measurement Units settings button -->
 	<string name="measurement_units_summary">Choose between miles and kilometers</string>
-	<!-- Do search in all sources -->
-	<string name="search_mode_all">Everywhere</string>
-	<!-- Do search near my position only -->
-	<string name="search_mode_nearme">Near Me</string>
-	<!-- Do search in current viewport only -->
-	<string name="search_mode_viewport">On the Screen</string>
 	<!-- Search category for cafes, bars, restaurants -->
 	<string name="eat">Where to eat</string>
 	<!-- Search category for grocery stores -->
@@ -171,12 +133,8 @@
 	<string name="post">Post</string>
 	<!-- Search category -->
 	<string name="police">Police</string>
-	<!-- String in search result list, when nothing found -->
-	<string name="no_search_results_found">No results found</string>
 	<!-- Notes field in Bookmarks view -->
 	<string name="description">Notes</string>
-	<!-- Button text -->
-	<string name="share_by_email">Share by email</string>
 	<!-- Email Subject when sharing bookmarks category -->
 	<string name="share_bookmarks_email_subject">Organic Maps bookmarks were shared with you</string>
 	<string name="share_bookmarks_email_body">Hello!\n\nAttached are my bookmarks from Organic Maps app. Please open them if you have Organic Maps installed. Or, if you don\'t, download the app for your iOS or Android device by following this link: https://omaps.app/get?kmz\n\nEnjoy traveling with Organic Maps!</string>
@@ -190,20 +148,10 @@
 	<string name="edit">Edit</string>
 	<!-- Warning message when doing search around current position -->
 	<string name="unknown_current_position">Your location hasn\'t been determined yet</string>
-	<!-- Warning message when location country isn't downloaded during search (see also download_location_map_proposal). -->
-	<string name="download_location_country">Download the map of your current location (%s)</string>
-	<!-- Warning message when viewport country isn't downloaded during search -->
-	<string name="download_viewport_country_to_search">Download the country you are searching on (%s)</string>
 	<!-- Alert message that we can't run Map Storage settings due to some reasons. -->
 	<string name="cant_change_this_setting">Sorry, Map Storage settings are currently disabled.</string>
 	<!-- Alert message that downloading is in progress. -->
 	<string name="downloading_is_active">Map download is in progress now.</string>
-	<!-- Message that will be shown in alert view, when we ask user to leave review on App Store -->
-	<string name="appStore_message">Hope you enjoy using Organic Maps! If so, please rate or review the app at the App Store. It takes less than a minute but can really help us. Thanks for your support!</string>
-	<!-- No, thanks -->
-	<string name="no_thanks">No, thanks</string>
-	<!-- Share one specific bookmark using SMS, %1$@ contains om:// and %2$@ https://omaps.app link. @NOTE non-ascii symbols in the link will result in max 70 characters SMS instead of 140. -->
-	<string name="bookmark_share_sms">Hey, check out my pin at Organic Maps! %1$s or %2$s Don\'t have offline maps installed? Download here: https://omaps.app/get</string>
 	<!-- Share my position using SMS, %1$@ contains om:// and %2$@ https://omaps.app link WITHOUT NAME. @NOTE non-ascii symbols in the link will result in max 70 characters SMS instead of 140. -->
 	<string name="my_position_share_sms">Hey, check out my current location in Organic Maps! %1$s or %2$s Don\'t have offline maps? Download here: https://omaps.app/get</string>
 	<!-- Subject for emailed bookmark -->
@@ -212,30 +160,16 @@
 	<string name="my_position_share_email_subject">Hey, check out my current location on the Organic Maps map!</string>
 	<!-- Share my position using EMail, %1$@ is om:// and %2$@ is https://omaps.app link WITHOUT NAME -->
 	<string name="my_position_share_email">Hi,\n\nI\'m here now: %1$s. Click this link %2$s or this one %3$s to see the place on the map.\n\nThanks.</string>
-	<!-- Android share by Message/SMS button text (including SMS) -->
-	<string name="share_by_message">Share by message</string>
 	<!-- Share button text which opens menu with more buttons, like Message, EMail, Facebook etc. -->
 	<string name="share">Share</string>
-	<!-- iOS share by Message button text (including SMS) -->
-	<string name="message">Message</string>
 	<!-- Share by email button text, also used in editor. -->
 	<string name="email">Email</string>
-	<!-- Copy Link -->
-	<string name="copy_link">Copy Link</string>
-	<!-- Text for the button that returns to caller application -->
-	<string name="more_info">Show More Info</string>
 	<!-- Text for message when used successfully copied something -->
 	<string name="copied_to_clipboard">Copied to clipboard: %1$s</string>
 	<!-- place preview title -->
 	<string name="info">Info</string>
 	<!-- Used for bookmark editing -->
 	<string name="done">Done</string>
-	<!-- Summary for preferences in MWM -->
-	<string name="yopme_pref_summary">Choose Back Screen settings</string>
-	<!-- Title for yopme preferences in MWM -->
-	<string name="yopme_pref_title">Back Screen Settings</string>
-	<!-- Hint for upper-right icon p2b -->
-	<string name="show_on_backscreen">Show on Back screen</string>
 	<!-- Prints version number in About dialog -->
 	<string name="version">Version: %s</string>
 	<!-- Data version in «About» screen -->
@@ -247,15 +181,10 @@
 	<!-- Length of track in cell that describes route -->
 	<string name="length">Length</string>
 	<string name="share_my_location">Share My Location</string>
-	<string name="menu_search">Search</string>
 	<!-- Settings general group in settings screen -->
 	<string name="prefs_group_general">General settings</string>
 	<!-- Settings information group in settings screen -->
 	<string name="prefs_group_information">Information</string>
-	<!-- Settings screen: "Map" category title -->
-	<string name="prefs_group_map">Map</string>
-	<!-- Settings screen: "Miscellaneous" category title -->
-	<string name="prefs_group_misc">Miscellaneous</string>
 	<string name="prefs_group_route">Navigation</string>
 	<string name="pref_zoom_title">Zoom buttons</string>
 	<string name="pref_zoom_summary">Display on the map</string>
@@ -271,8 +200,6 @@
 	<string name="pref_map_3d_title">Perspective view</string>
 	<!-- Settings «Map» category: «3D buildings» title -->
 	<string name="pref_map_3d_buildings_title">3D buildings</string>
-	<!-- Settings «Map» category: «3D buildings» summary -->
-	<string name="pref_map_3d_buildings_subtitle">Affects battery life</string>
 	<!-- Settings «Route» category: «Tts enabled» title -->
 	<string name="pref_tts_enable_title">Voice Instructions</string>
 	<!-- Settings «Route» category: «Tts language» title -->
@@ -281,7 +208,6 @@
 	<string name="pref_tts_unavailable">Not Available</string>
 	<!-- Title for "Other" section in TTS settings. -->
 	<string name="pref_tts_other_section_title">Other</string>
-	<string name="pref_tts_how_to_set_up_voice">How to set up voice</string>
 	<!-- Settings «Map» category: «Record track» title -->
 	<string name="pref_track_record_title">Recent track</string>
 	<string name="pref_map_auto_zoom">Auto zoom</string>
@@ -292,38 +218,7 @@
 	<string name="duration_12_hours">12 hours</string>
 	<string name="duration_1_day">1 day</string>
 	<string name="recent_track_help_text">This option allows you to record traveled path for a certain period and see it on the map. Please note: activation of this function causes increased battery usage. The track will be removed automatically from the map after the time interval will expire.</string>
-	<string name="pref_track_ios_caption">Recent track shows your traveled path.</string>
-	<string name="pref_track_ios_subcaption">Please select the time range of saving the track.</string>
-	<string name="placepage_distance">Distance</string>
-	<string name="placepage_coordinates">Coordinates</string>
-	<string name="placepage_unsorted">Unsorted</string>
 	<string name="search_show_on_map">View on map</string>
-	<!-- Used to warn user when fixing KitKat issue -->
-	<string name="bookmark_move_fail">We need to move your bookmarks to internal memory, but there is no available space for them. Please free up the memory, otherwise bookmarks won’t be available.</string>
-	<!-- Used in More Apps menu -->
-	<string name="free">Free</string>
-	<!-- Used in More Apps menu -->
-	<string name="buy">Buy</string>
-	<!-- 1st search button-like result -->
-	<string name="search_on_map">Search on map</string>
-	<!-- toast with an error -->
-	<string name="no_route_found">No route found</string>
-	<!-- route title -->
-	<string name="route">Route</string>
-	<!-- category title -->
-	<string name="routes">Routes</string>
-	<!-- text of notification -->
-	<string name="download_map_notification">Download the map of the place where you are</string>
-	<!-- text of notification -->
-	<string name="pro_version_is_free_today">Full version of Organic Maps is free today! Download now and tell your friends.</string>
-	<!-- Dialog for transferring maps from lite to pro. -->
-	<string name="move_lite_maps_to_pro">We are transferring your downloaded maps from Organic Maps Lite to Organic Maps. It may take a few minutes.</string>
-	<!-- Message to display when maps moved. -->
-	<string name="move_lite_maps_to_pro_ok">Your downloaded maps are successfully transferred to Organic Maps.</string>
-	<!-- Message to display when maps move failed. -->
-	<string name="move_lite_maps_to_pro_failed">Your maps failed to transfer. Please delete Organic Maps Lite and download the maps again.</string>
-	<!-- Text in menu -->
-	<string name="settings_and_more">Settings &amp; More</string>
 	<!-- Text in menu -->
 	<string name="website">Website</string>
 	<!-- Text in menu -->
@@ -338,12 +233,8 @@
 	<string name="instagram">Instagram</string>
 	<!-- Text in menu -->
 	<string name="openstreetmap">OpenStreetMap</string>
-	<!-- Text in menu -->
-	<string name="contact_us">Contact us</string>
 	<!-- Settings: Send feedback button and dialog title -->
 	<string name="feedback">Feedback</string>
-	<!-- Text in menu -->
-	<string name="subscribe_to_news">Subscribe to our newsletter</string>
 	<!-- Text in menu -->
 	<string name="rate_the_app">Rate the app</string>
 	<!-- Text in menu -->
@@ -352,12 +243,6 @@
 	<string name="copyright">Copyright</string>
 	<!-- Text in menu -->
 	<string name="report_a_bug">Report a bug</string>
-	<!-- Email subject -->
-	<string name="subscribe_me_subject">Please subscribe me to the Organic Maps newsletter</string>
-	<!-- Email body -->
-	<string name="subscribe_me_body">I want to be the first to learn about the latest news, app updates, and promotions. I understand that I can cancel my subscription at any time.</string>
-	<!-- About text -->
-	<string name="about_text">Organic Maps offers the fastest offline maps of all the cities, all countries of the world. Travel with full confidence: wherever you are, Organic Maps helps to locate yourself on the map, find the nearest restaurant, hotel, bank, gas station etc. It doesn’t require internet connection.\n\nWe are always working on new features and would love to hear from you on how you think we could improve Organic Maps. If you have any problems with the app, don\'t hesitate to contact us at support\@organicmaps.app. We respond to every request!\n\nDo you like Organic Maps and want to support us? There are some simple and absolutely free ways:\n\n- post a review at your App Market\n- like our Facebook page http://www.facebook.com/OrganicMaps\n- or just tell about Organic Maps to your mom, friends and colleagues :)\n\nThank you for being with us. We appreciate your support very much!\n\nP.S. We take map data from OpenStreetMap, a mapping project similar to Wikipedia, which allows users to create and edit maps. If you see something is missing or wrong on the map, you can correct the maps directly at https://www.openstreetmap.org, and your changes will appear in Organic Maps app with the next version release.</string>
 	<!-- Alert text -->
 	<string name="email_error_body">The email client has not been set up. Please configure it or use any other way to contact us at %s</string>
 	<!-- Alert title -->
@@ -366,137 +251,56 @@
 	<string name="pref_calibration_title">Compass calibration</string>
 	<!-- Search category -->
 	<string name="wifi">WiFi</string>
-	<!-- Update map suggestion -->
-	<string name="routing_map_outdated">Please update the map to create a route</string>
-	<!-- Update maps suggestion -->
-	<string name="routing_update_maps">The new version of Organic Maps allows creating routes from your current position to a destination point. Please update maps to use this feature.</string>
 	<!-- Update all button text -->
 	<string name="downloader_update_all_button">Update All</string>
 	<!-- Cancel all button text -->
 	<string name="downloader_cancel_all">Cancel All</string>
 	<!-- Downloaded maps category -->
 	<string name="downloader_downloaded_subtitle">Downloaded</string>
-	<!-- Downloaded maps category -->
-	<string name="downloader_available_maps">Available</string>
 	<!-- Country queued for download -->
 	<string name="downloader_queued">Queued</string>
 	<string name="downloader_near_me_subtitle">Near me</string>
 	<string name="downloader_status_maps">Maps</string>
 	<string name="downloader_download_all_button">Download All</string>
 	<string name="downloader_downloading">Downloading:</string>
-	<string name="downloader_search_results">Found</string>
-	<!-- Disclaimer message -->
-	<string name="routing_disclaimer">Creating routes in Organic Maps app, please keep in mind the following:\n\n  - Suggested routes can be considered as recommendations only.\n - Road conditions, traffic rules and signs have higher priority than navigation advice.\n - The map may be incorrect or outdated, and routes may not be created the best possible way.\n\n  Be safe on roads and take care of yourself!</string>
-	<!-- Outdated maps category -->
-	<string name="downloader_outdated_maps">Outdated</string>
-	<!-- Up to date maps category -->
-	<string name="downloader_uptodate_maps">Up-to-date</string>
 	<!-- Status of outdated country in the list -->
 	<string name="downloader_status_outdated">Update</string>
 	<!-- Status of failed country in the list -->
 	<string name="downloader_status_failed">Failed</string>
 	<!-- Displayed in a dialog that appears when a user tries to delete a map while the app is in the follow route mode -->
 	<string name="downloader_delete_map_while_routing_dialog">To delete map, please stop navigation.</string>
-	<!-- Show when user try build route, but we don't know where he -->
-	<string name="routing_failed_unknown_my_position">Current location is undefined. Please specify location to create route.</string>
-	<!-- Show if use has not routing file, or InconsistentMWMandRoute -->
-	<string name="routing_failed_has_no_routing_file">Additional data is required to create the route. Download data now?</string>
-	<!-- StartPointNotFound -->
-	<string name="routing_failed_start_point_not_found">Cannot calculate the route. No roads near your starting point.</string>
-	<!-- EndPointNotFound -->
-	<string name="routing_failed_dst_point_not_found">Cannot calculate the route. No roads near your destination.</string>
 	<!-- PointsInDifferentMWM -->
 	<string name="routing_failed_cross_mwm_building">Routes can only be created that are fully contained within a map of a single region.</string>
-	<!-- RouteNotFound -->
-	<string name="routing_failed_route_not_found">There is no route found between the selected origin and destination. Please select a different start or end point.</string>
-	<!-- InternalError -->
-	<string name="routing_failed_internal_error">Internal error occurred. Please try to delete and download the map again. If the problem persists, please contact us at support\@organicmaps.app.</string>
-	<!-- Context menu item for downloader. -->
-	<string name="downloader_download_map_and_routing">Download Map + Routing</string>
-	<!-- Context menu item for downloader. -->
-	<string name="downloader_download_routing">Download Routing</string>
-	<!-- Context menu item for downloader. -->
-	<string name="downloader_delete_routing">Delete Routing</string>
 	<!-- Context menu item for downloader. -->
 	<string name="downloader_download_map">Download map</string>
-	<string name="downloader_download_map_no_routing">Download map without routing</string>
-	<!-- Button for routing. -->
-	<string name="routing_go">Go!</string>
 	<!-- Item status in downloader. -->
 	<string name="downloader_retry">Retry</string>
-	<!-- Item in context menu. -->
-	<string name="downloader_map_and_routing">Map + Routing</string>
 	<!-- Item in context menu. -->
 	<string name="downloader_delete_map">Delete Map</string>
 	<!-- Item in context menu. -->
 	<string name="downloader_update_map">Update Map</string>
-	<!-- Item in context menu. -->
-	<string name="downloader_update_map_and_routing">Update Map + Routing</string>
-	<!-- Item in context menu. -->
-	<string name="downloader_map_only">Map Only</string>
-	<!-- Toolbar title -->
-	<string name="toolbar_application_menu">Application menu</string>
 	<!-- Preference text -->
 	<string name="pref_use_google_play">Use Google Play Services to determine your current location</string>
 	<!-- Text for rating dialog -->
 	<string name="rating_just_rated">I’ve just rated your app</string>
-	<!-- Text for rating dialog -->
-	<string name="rating_user_since">I’ve been a Organic Maps user since %s</string>
-	<!-- Text for rating dialog -->
-	<string name="rating_do_like_maps">Do you like Organic Maps?</string>
-	<!-- Text for rating dialog -->
-	<string name="rating_tap_star">Tap a star to rate our app.</string>
 	<!-- Text for rating dialog -->
 	<string name="rating_thanks">Thank you!</string>
 	<!-- Text for rating dialog -->
 	<string name="rating_share_ideas">Share any ideas or issues so we can improve the app for you.</string>
 	<!-- Text for rating dialog -->
 	<string name="rating_send_feedback">Send feedback</string>
-	<!-- Text for g+ dialog -->
-	<string name="rating_google_plus">Click g+ to tell your friends about the app.</string>
 	<!-- Text for routing error dialog -->
 	<string name="routing_download_maps_along">Download all of the maps along your route</string>
-	<!-- Text for routing error dialog -->
-	<string name="routing_download_map">Get map</string>
-	<!-- Text for routing error dialog -->
-	<string name="routing_download_map_and_routing">Download updated map and routing data to get all Organic Maps features.</string>
-	<!-- Text for routing error dialog -->
-	<string name="routing_get_routing_data">Get routing data</string>
-	<!-- Text for routing error dialog -->
-	<string name="routing_get_additional_data">Additional data required to create routes from your location.</string>
 	<!-- Text for routing error dialog -->
 	<string name="routing_requires_all_map">In order to create a route, we need to download and update all the maps from your location to your destination.</string>
 	<!-- Text for routing error dialog -->
 	<string name="routing_not_enough_space">Not enough space</string>
-	<!-- Text for routing error dialog -->
-	<string name="routing_download_more_than_avail">You need to download %1$s MB, but only %2$s MB are available.</string>
-	<!-- Text for routing error dialog -->
-	<string name="routing_download_roaming">You are going to download %s MB using Mobile Data (in Roaming). This may result in additional charges, depending on your operator mobile data plan.</string>
 	<!-- bookmark button text -->
 	<string name="bookmark">bookmark</string>
-	<!-- map is not downloaded -->
-	<string name="not_found_map">The map for your location is not downloaded</string>
 	<!-- location service disabled -->
 	<string name="enable_location_services">Please enable Location Services</string>
-	<!-- download map -->
-	<string name="download_map">Download the map for your location</string>
-	<!-- download map on iPhone -->
-	<string name="download_map_iphone">Download a current location map on your iPhone</string>
-	<!-- clear pin -->
-	<string name="nearby">Nearby</string>
-	<!-- clear pin -->
-	<string name="clear_pin">Clear Pin</string>
-	<!-- location is undefined -->
-	<string name="undefined_location">Current location is undefined.</string>
-	<!-- download country of your location -->
-	<string name="download_country">Download the country of your current location</string>
-	<!-- download failed -->
-	<string name="download_failed">download has failed</string>
-	<!-- get the map -->
-	<string name="get_the_map">Get the map</string>
 	<string name="save">Save</string>
 	<string name="edit_description_hint">Your descriptions (text or html)</string>
-	<string name="new_group">new group</string>
 	<string name="create">create</string>
 	<!-- red color -->
 	<string name="red">Red</string>
@@ -514,22 +318,6 @@
 	<string name="brown">Brown</string>
 	<!-- pink color -->
 	<string name="pink">Pink</string>
-	<!-- deep purple color -->
-	<string name="deep_purple">Deep Purple</string>
-	<!-- light blue color -->
-	<string name="light_blue">Light Blue</string>
-	<!-- cyan color -->
-	<string name="cyan">Cyan</string>
-	<!-- teal color -->
-	<string name="teal">Teal</string>
-	<!-- lime color -->
-	<string name="lime">Lime</string>
-	<!-- deep orange color -->
-	<string name="deep_orange">Deep Orange</string>
-	<!-- gray color -->
-	<string name="gray">Gray</string>
-	<!-- blue gray color -->
-	<string name="blue_gray">Blue Gray</string>
 	<!-- Wi-Fi available -->
 	<string name="WiFi_available">Yes</string>
 
@@ -545,10 +333,8 @@
 	<string name="dialog_routing_location_turn_wifi">Please check your GPS signal. Enabling Wi-Fi will improve your location accuracy.</string>
 	<string name="dialog_routing_location_turn_on">Enable location services</string>
 	<string name="dialog_routing_location_unknown_turn_on">Unable to locate current GPS coordinates. Enable location services to calculate route.</string>
-	<string name="dialog_routing_location_unknown">Unable to locate current GPS coordinates.</string>
 	<string name="dialog_routing_download_files">Download required files</string>
 	<string name="dialog_routing_download_and_update_all">Download and update all map and routing information along the projected path to calculate route.</string>
-	<string name="dialog_routing_routes_size">Routing information files</string>
 	<string name="dialog_routing_unable_locate_route">Unable to locate route</string>
 	<string name="dialog_routing_cant_build_route">Unable to create route.</string>
 	<string name="dialog_routing_change_start_or_end">Please adjust your starting point or your destination.</string>
@@ -563,33 +349,23 @@
 	<string name="dialog_routing_system_error">System error</string>
 	<string name="dialog_routing_application_error">Unable to create route due to an application error.</string>
 	<string name="dialog_routing_try_again">Please try again</string>
-	<string name="dialog_routing_send_error">Report the Problem</string>
-	<string name="dialog_routing_if_get_cross_route">Would you like to create a more direct route that spans more than one map?</string>
-	<string name="dialog_routing_cross_route_is_optimal">A more optimal route that crosses the edge of this map is available.</string>
 	<string name="not_now">Not Now</string>
-	<string name="dialog_routing_build_route">Create</string>
 	<string name="dialog_routing_download_and_build_cross_route">Would you like to download the map and create a more optimal route spanning more than one map?</string>
 	<string name="dialog_routing_download_cross_route">Download additional maps to create a better route that crosses the boundaries of this map.</string>
-	<string name="dialog_routing_cross_route_always">Always cross this boundary</string>
 
 	<!-- SECTION: Strings for downloading map from search -->
 	<string name="search_without_internet_advertisement">To start searching and creating routes, please download the map. After that you will no longer need an Internet connection.</string>
 	<string name="search_select_map">Select Map</string>
-	<string name="search_select_other_map">Select Another Map</string>
 	<!-- «Show» context menu -->
 	<string name="show">Show</string>
 	<!-- «Hide» context menu -->
 	<string name="hide">Hide</string>
 	<!-- «Rename» context menu -->
 	<string name="rename">Rename</string>
-	<!-- Bottom sheet: expand button (should be short) -->
-	<string name="bottom_sheet_more">More…</string>
 	<!-- Failed planning route message in navigation view -->
 	<string name="routing_planning_error">Route Planning Failed</string>
 	<!-- Arrive routing message in navigation view -->
 	<string name="routing_arrive">Arrival at %s</string>
-	<!-- Text for routing::RouterResultCode::FileTooOld dialog. -->
-	<string name="dialog_routing_download_and_update_maps">Download and update all map along the projected path to calculate route.</string>
 	<string name="rate_alert_title">Like the app?</string>
 	<string name="rate_alert_default_message">Thank you for using Organic Maps. Please rate the app. Your feedback helps us improve our product.</string>
 	<string name="rate_alert_five_star_message">Hooray! We love you, too!</string>
@@ -597,26 +373,16 @@
 	<string name="rate_alert_less_than_four_star_message">Any idea how we can make it better?</string>
 	<string name="categories">Categories</string>
 	<string name="history">History</string>
-	<string name="next_turn_then">Then</string>
 	<string name="closed">Closed</string>
-	<string name="back_to">Back to %s</string>
 	<string name="search_not_found">Oops, no results found.</string>
 	<string name="search_not_found_query">Try changing your search criteria.</string>
-	<string name="search_not_found_map">Please download the map you are searching in.</string>
-	<string name="search_not_found_location">Download the map of your current location.</string>
 	<string name="search_history_title">Search History</string>
 	<string name="search_history_text">View recent searches.</string>
 	<string name="clear_search">Clear Search History</string>
-	<!-- Title for settings to enable/disable showcase menu button -->
-	<string name="showcase_settings_title">Show offers</string>
 	<!-- Place Page link to Wikipedia article (if map object has it). -->
 	<string name="read_in_wikipedia">Wikipedia</string>
-	<string name="p2p_route_planning">Route Planning</string>
 	<string name="p2p_your_location">Your Location</string>
-	<string name="p2p_from">From</string>
-	<string name="p2p_to">To</string>
 	<string name="p2p_start">Start</string>
-	<string name="p2p_planning">Planning…</string>
 	<string name="p2p_from_here">Route from</string>
 	<string name="p2p_to_here">Route to</string>
 	<string name="p2p_only_from_current">Navigation is available only from your current location.</string>
@@ -636,11 +402,8 @@
 	<string name="editor_hours_closed">Non-Business Hours</string>
 	<string name="editor_example_values">Example Values</string>
 	<string name="editor_correct_mistake">Correct mistake</string>
-	<string name="editor_correct_mistake_message">You made an editing mistake. Please correct it or switch to simple mode.</string>
 	<string name="editor_add_select_location">Location</string>
 	<string name="editor_done_dialog_1">You’ve changed the world map. Do not keep it to yourself! Tell your friends, and edit it together.</string>
-	<string name="editor_done_dialog_2">This is the second time you edited the map. Now you are number %d in the map editors ranking. Tell your friends about it.</string>
-	<string name="editor_done_dialog_3">You’ve improved the map, tell your friends about it, and edit the map together.</string>
 	<string name="share_with_friends">Share with friends</string>
 	<string name="editor_report_problem_desription_1">Please describe the problem in detail so that the OpenStreeMap community can fix the error.</string>
 	<string name="editor_report_problem_desription_2">Or do it yourself at https://www.openstreetmap.org/</string>
@@ -649,14 +412,7 @@
 	<string name="editor_report_problem_no_place_title">The place does not exist</string>
 	<string name="editor_report_problem_under_construction_title">Сlosed for maintenance</string>
 	<string name="editor_report_problem_duplicate_place_title">Duplicated place</string>
-	<string name="first_launch_congrats_title">Organic Maps is ready to use</string>
-	<string name="first_launch_congrats_text">Search and navigate everywhere in the world offline, free of charge.</string>
-	<string name="migrate_title">Important!</string>
-	<!-- Android uses image instead of text. -->
-	<string name="download_all">Download all</string>
-	<string name="delete_all">Delete all</string>
 	<string name="autodownload">Auto-download</string>
-	<string name="disable_autodownload">Disable autodownload</string>
 	<!-- Place Page opening hours text -->
 	<string name="closed_now">Closed now</string>
 	<!-- Place Page opening hours text -->
@@ -665,8 +421,6 @@
 	<string name="day_off_today">Closed today</string>
 	<string name="day_off">Closed</string>
 	<string name="today">Today</string>
-	<string name="sunrise_to_sunset">From sunrise to sunset</string>
-	<string name="sunset_to_sunrise">From sunset to sunrise</string>
 	<string name="add_opening_hours">Add opening hours</string>
 	<string name="edit_opening_hours">Edit business hours</string>
 	<string name="no_osm_account">Don\'t have an OpenStreetMap account?</string>
@@ -676,29 +430,13 @@
 	<string name="login">Log In</string>
 	<string name="password">Password</string>
 	<string name="forgot_password">Forgot your password?</string>
-	<!-- Forgot Password dialog title -->
-	<string name="restore_password">Restore password</string>
-	<string name="enter_email_address_to_reset_password">Enter the email address you used during registration and we will send you the link to reset your password.</string>
-	<string name="reset_password">Reset Password</string>
-	<string name="username">Username</string>
 	<string name="osm_account">OSM Account</string>
 	<string name="logout">Log Out</string>
-	<string name="login_and_edit_map_motivation_message">Log in and edit objects on the map, and we will make them available for millions of users. Let’s make the world better together.</string>
 	<!-- Information text: "Last upload 11.01.2016" -->
 	<string name="last_upload">Last upload</string>
-	<!-- Motivates user to login/register, title above login buttons. -->
-	<string name="you_have_edited_your_first_object">You’ve edited your first object!</string>
 	<string name="thank_you">Thank You</string>
-	<string name="login_with_google">Login with Google</string>
-	<string name="login_with_openstreetmap">Log in with www.openstreetmap.org</string>
 	<string name="edit_place">Edit Place</string>
 	<string name="place_name">Place Name</string>
-	<!-- title above languages list cells in the editor, below editable name text field. -->
-	<string name="other_languages">Other Languages</string>
-	<!-- small button to open list with names in different languages -->
-	<string name="show_more">Show More</string>
-	<!-- small button to close list with names in different languages -->
-	<string name="show_less">Show Less</string>
 	<string name="add_language">Add a language</string>
 	<string name="street">Street</string>
 	<!-- Editable House Number text field (in address block). -->
@@ -715,25 +453,16 @@
 	<string name="email_or_username">Email or username</string>
 	<string name="phone">Phone</string>
 	<string name="please_note">Please note</string>
-	<string name="common_no_wifi_dialog">No WiFi connection. Do you want to continue with mobile data?</string>
 	<string name="downloader_delete_map_dialog">All of your map edits will be deleted together with the map.</string>
 	<string name="downloader_update_maps">Update Maps</string>
 	<string name="downloader_mwm_migration_dialog">To create a route, you need to update all maps and then plan the route again.</string>
 	<string name="downloader_search_field_hint">Find map</string>
-	<string name="migration_update_all_button">Update All Maps</string>
-	<string name="migration_delete_all_download_current_button">Download the current map and delete all of the old ones</string>
 	<string name="migration_download_error_dialog">Download error</string>
 	<string name="common_check_internet_connection_dialog">Please check your settings and make sure your device is connected to the Internet.</string>
 	<string name="downloader_no_space_title">Not enough space</string>
 	<string name="downloader_no_space_message">Please delete any unnecessary data</string>
-	<string name="editor_general_auth_error_dialog">General login error.</string>
 	<string name="editor_login_error_dialog">Login error.</string>
-	<string name="editor_login_failed_dialog">Login failed</string>
-	<string name="editor_username_error_dialog">Username is invalid</string>
-	<string name="editor_place_edited_dialog">You’ve edited an object!</string>
-	<string name="editor_login_with_osm">Login with OpenStreetMap</string>
 	<string name="editor_profile_changes">Verified Changes</string>
-	<string name="editor_profile_unsent_changes">Not sent:</string>
 	<string name="editor_focus_map_on_location">Drag the map to select the correct location of the object.</string>
 	<string name="editor_add_select_category">Select category</string>
 	<string name="editor_add_select_category_popular_subtitle">Popular</string>
@@ -744,19 +473,14 @@
 	<string name="editor_edit_place_category_title">Category</string>
 	<string name="detailed_problem_description">Detailed description of the issue</string>
 	<string name="editor_report_problem_other_title">Different problem</string>
-	<string name="placepage_report_problem_button">Report a problem</string>
 	<string name="placepage_add_business_button">Add business</string>
 	<string name="whatsnew_editor_message_1">Add new places to the map, and edit existing ones directly from the app.</string>
-	<string name="whatsnew_editor_message_2">* Organic Maps uses OpenStreetMap community data.</string>
 	<string name="dialog_incorrect_feature_position">Change location</string>
 	<string name="message_invalid_feature_position">No object can be located here</string>
 	<string name="login_to_make_edits_visible">Log in so other users can see the changes that you have made</string>
-	<string name="no_migration_during_navigation">Updating is not allowed during navigation.</string>
 	<!-- Error dialog no space -->
 	<string name="migration_no_space_message">To download, you need more space. Please delete any unnecessary data.</string>
 	<string name="editor_sharing_title">I improved the Organic Maps maps</string>
-	<string name="editor_comment_will_be_sent">We will make sure to send your comments to the map editors.</string>
-	<string name="editor_unsupported_category_message">You have added an object whose category we do not support yet. It will appear on the map in the future.</string>
 	<!-- Downloaded 10 **of** 20 <- it is that "of" -->
 	<string name="downloader_of">%1$d of %2$d</string>
 	<string name="download_over_mobile_header">Download over a cellular network connection?</string>
@@ -774,15 +498,8 @@
 	<string name="editor_detailed_description">Your suggested map changes will be sent to the OpenStreetMap community. Describe any additional details that cannot be edited in Organic Maps.</string>
 	<string name="editor_more_about_osm">More about OpenStreetMap</string>
 	<string name="editor_operator">Owner</string>
-	<string name="editor_tag_description">Enter company, organization or individual responsible for the facilities.</string>
-	<string name="editor_no_local_edits_title">You don\'t have local edits</string>
-	<string name="editor_no_local_edits_description">This shows the number of your suggested changes on the map that are currently accessible only on your device.</string>
-	<string name="editor_send_to_osm">Send to OSM</string>
-	<string name="editor_remove">Remove</string>
-	<string name="downloader_my_maps_title">My maps</string>
 	<string name="downloader_no_downloaded_maps_title">You haven\'t downloaded any maps</string>
 	<string name="downloader_no_downloaded_maps_message">Download maps to search for a location and use navigation offline.</string>
-	<string name="downloader_find_place_hint">Search city or country</string>
 	<!-- Error title that appears after certain time without location. -->
 	<string name="current_location_unknown_title">Continue detecting your current location?</string>
 	<!-- Error that appears after certain time without location. -->
@@ -797,27 +514,10 @@
 	<string name="location_services_disabled_2">2. Tap Location</string>
 	<!-- iOS Dialog for the case when the location permission is not granted -->
 	<string name="location_services_disabled_3">3. Select While Using the App</string>
-	<string name="placepage_parking_surface">Surface</string>
-	<string name="placepage_parking_multistorey">Multi-storey</string>
-	<string name="placepage_parking_underground">Underground</string>
-	<string name="placepage_parking_rooftop">Rooftop</string>
-	<string name="placepage_parking_sheds">Sheds</string>
-	<string name="placepage_parking_carports">Carports</string>
-	<string name="placepage_parking_boxes">Garage boxes</string>
-	<string name="placepage_parking_pay">Pay</string>
-	<string name="placepage_parking_free">Free</string>
-	<string name="placepage_parking_interval">Interval Pay</string>
-	<string name="placepage_entrance_number">No.</string>
-	<string name="placepage_entrance_type">Entrance</string>
-	<string name="placepage_flat">app.</string>
-	<string name="placepage_open_24_7">24 / 7</string>
 	<string name="meter">m</string>
 	<string name="kilometer">km</string>
-	<string name="kilometers_per_hour">km/h</string>
 	<string name="mile">mi</string>
 	<string name="foot">ft</string>
-	<string name="miles_per_hour">mph</string>
-	<string name="day">d</string>
 	<string name="hour">h</string>
 	<string name="minute">min</string>
 	<string name="placepage_place_description">Description</string>
@@ -827,46 +527,30 @@
 	<string name="placepage_call_button">Call</string>
 	<string name="placepage_edit_bookmark_button">Edit Bookmark</string>
 	<string name="placepage_bookmark_name_hint">Bookmark Name</string>
-	<string name="placepage_personal_notes_hint">Personal notes</string>
-	<string name="placepage_delete_bookmark_button">Delete Bookmark</string>
 	<string name="editor_edits_sent_message">Your suggested changes have been sent</string>
 	<string name="editor_comment_hint">Comment…</string>
 	<string name="editor_reset_edits_message">Discard all local changes?</string>
 	<string name="editor_reset_edits_button">Discard</string>
 	<string name="editor_remove_place_message">Delete added place?</string>
 	<string name="editor_remove_place_button">Delete</string>
-	<string name="editor_status_sending">Sending…</string>
 	<string name="editor_place_doesnt_exist">Place does not exist</string>
 	<string name="text_more_button">…more</string>
 	<!-- Phone number error message -->
 	<string name="error_enter_correct_phone">Enter a valid phone number</string>
 	<string name="error_enter_correct_web">Enter a valid web address</string>
 	<string name="error_enter_correct_email">Enter a valid email</string>
-	<string name="error_enter_correct">Enter a valid value</string>
 	<string name="refresh">Update</string>
-	<string name="last_update">Last update: %s</string>
 	<string name="placepage_add_place_button">Add a place to the map</string>
 	<!-- Displayed when saving some edits to the map to warn against publishing personal data -->
 	<string name="editor_share_to_all_dialog_title">Do you want to send it to all users?</string>
 	<!-- iOS Dialog before publishing the modifications to the public map. -->
 	<string name="editor_share_to_all_dialog_message_1">Make sure you did not enter any personal data.</string>
 	<string name="editor_share_to_all_dialog_message_2">We will check the changes. If we have any questions we will contact you via email.</string>
-	<string name="navigation_overview_button">overview</string>
-	<string name="navigation_stop_button">stop</string>
-	<!-- Text on an empty bookmark page -->
-	<string name="bookmarks_empty_title">Save Bookmarks</string>
-	<string name="bookmarks_empty_message_1">Tap on ★ to save favorite places for quick access.</string>
-	<string name="bookmarks_empty_message_2">Import Bookmarks from email and web.</string>
-	<string name="bookmarks_empty_message_3">check out: %s</string>
-	<!-- Name of the group for booked hotels -->
-	<string name="bookmarks_group_name">Booked hotels</string>
-	<string name="place_page_button_read_descriprion">Read</string>
 	<!-- iOS dialog for the case when recent track recording is on and the app comes back from background -->
 	<string name="recent_track_background_dialog_title">Disable recording of your recently traveled route?</string>
 	<string name="off_recent_track_background_button">Disable</string>
 	<!-- For sharing via SMS and so on -->
 	<string name="sharing_call_action_look">Check out</string>
-	<string name="continue_recent_track_background_button">Continue</string>
 	<string name="recent_track_background_dialog_message">Organic Maps uses your geoposition in the background for recording your recently traveled route.</string>
 	<!-- Rate on Google Play (Android only) -->
 	<string name="rate_gp">Rate on Google Play</string>
@@ -876,22 +560,11 @@
 	<string name="tell_friends_text">Hi! Install Organic Maps!</string>
 	<!-- About short text (below logo) -->
 	<string name="about_description">Organic Maps is an essential offline application for travelling. Organic Maps is based on OpenStreetMap data and allows editing it.</string>
-	<!-- Text in menu -->
-	<string name="blog">Blog</string>
 	<string name="general_settings">General settings</string>
-	<string name="date">Date %d</string>
-	<!-- "Report a bug" -> "Generaal Feedback" -> "Something is not working" -->
-	<string name="something_is_not_working">Something is not working</string>
 	<!-- For the first routing -->
 	<string name="accept">Accept</string>
-	<string name="accept_and_continue">Accept and continue</string>
 	<!-- For the first routing -->
 	<string name="decline">Decline</string>
-	<string name="install_app">Install</string>
-	<string name="search_no_results_title">No Results Found</string>
-	<string name="search_no_results_message">Try a more general search term, zoom out or reset the filter.</string>
-	<string name="search_no_results_expand_area_button">Zoom out</string>
-	<string name="search_no_results_reset_button">Reset Filter</string>
 	<!-- noun -->
 	<string name="search_in_table">List</string>
 	<string name="mobile_data_dialog">Use mobile internet to show detailed information?</string>
@@ -903,20 +576,13 @@
 	<string name="mobile_data_option_never">Never Use</string>
 	<string name="mobile_data_option_ask">Always Ask</string>
 	<string name="traffic_update_maps_text">To display traffic data, maps must be updated.</string>
-	<string name="traffic_outdated">Traffic data is outdated.</string>
 	<string name="big_font">Increase font size on the map</string>
 	<string name="traffic_update_app">Please update Organic Maps</string>
 	<!-- "traffic" as in road congestion -->
 	<string name="traffic_update_app_message">To display traffic data, the application must be updated.</string>
 	<!-- "traffic" as in "road congestion" -->
 	<string name="traffic_data_unavailable">Traffic data is not available</string>
-	<!-- "Translation is no needed, because it's a company name" -->
-	<string name="uber">Uber</string>
-	<!-- Simplified colour scheme for traffic information, fewer colours are used to display traffic jams on the map. The string should be kept as short as possible -->
-	<string name="pref_traffic_simplified_colors_title">Simplified traffic colors</string>
 	<string name="enable_logging">Enable logging</string>
-	<string name="offline_place_page_more_information">Connect to the internet to get more information about the place.</string>
-	<string name="failed_load_information">Failed to load information.</string>
 	<!-- Settings: "Send general feedback" button -->
 	<string name="feedback_general">General Feedback</string>
 	<string name="on">On</string>
@@ -925,74 +591,33 @@
 	<string name="prefs_languages_information_off">For some languages, you will need to install a speech synthesizer or an additional language pack from the app store (Google Play Market, Samsung Apps).\nOpen your device\'s settings → Language and input → Speech → Text to speech output.\nHere you can manage settings for speech synthesis (for example, download language pack for offline use) and select another text-to-speech engine.</string>
 	<string name="prefs_languages_information_off_link">For more information please check this guide.</string>
 	<string name="whatsnew_transliteration_title">Transliteration into Latin</string>
-	<string name="yandex_taxi_title">Yandex.Taxi</string>
 	<string name="learn_more">Learn more</string>
 	<string name="core_exit">Exit</string>
 	<string name="routing_add_start_point">Add a starting point to plan a route</string>
 	<string name="routing_add_finish_point">Add a destination to plan a route</string>
 	<string name="button_exit">Exit</string>
-	<string name="settings_device_memory">Device memory</string>
-	<string name="settings_card_memory">Card memory</string>
-	<string name="settings_storage_available">%s available</string>
-	<string name="toast_location_permission_denied">App location permission denied</string>
-	<string name="button_use">Use</string>
 	<string name="planning_route_manage_route">Manage Route</string>
 	<string name="button_plan">Plan</string>
-	<string name="button_add">Add</string>
 	<string name="placepage_remove_stop">Remove</string>
 	<string name="planning_route_remove_title">Drag here to remove</string>
-	<string name="dialog_change_start_point_message">Set the current location as the starting point?</string>
-	<string name="button_replace">Replace</string>
 	<string name="placepage_add_stop">Add Stop</string>
-	<!-- Only ru/en are needed -->
-	<string name="subtitle_rent">Rent</string>
-	<!-- Only ru/en are needed -->
-	<string name="rub_month">RUB/month</string>
-	<!-- Only ru/en are needed -->
-	<string name="room">%s-room apt.</string>
-	<!-- Only ru/en are needed -->
-	<string name="real_estate">Real estate</string>
-	<string name="add_my_position">Add my position</string>
-	<string name="choose_start_point">Choose a starting point</string>
-	<string name="choose_destination">Choose a destination</string>
 	<string name="preloader_viator_button">Learn more</string>
-	<string name="start_from_my_position">Start from</string>
-	<string name="profile_authorization_title">Sign in with</string>
-	<string name="profile_authorization_message">Easy sign in without login and password in a couple of seconds</string>
 	<string name="profile_authorization_error">Oops, there was an error. Try to sign in again.</string>
-	<string name="service">Service</string>
-	<string name="atmosphere">Atmosphere</string>
-	<string name="value_for_money">Value for money</string>
-	<string name="experience">Experience</string>
-	<string name="assortment">Assortment</string>
-	<string name="expertise">Expertise</string>
-	<string name="equipment">Equipment</string>
-	<string name="quality">Quality</string>
 	<string name="dialog_error_storage_title">Storage access problem</string>
 	<string name="dialog_error_storage_message">External storage is not accessible. The SD Card may have been removed, damaged, or the file system is read-only. Please, check your SD Card or contact us at support\@organicmaps.app</string>
 	<string name="setting_emulate_bad_storage">Emulate bad storage</string>
-	<string name="directions_finish">Destination</string>
-	<string name="directions_on_foot">Walk %s</string>
 	<string name="core_entrance">Entrance</string>
-	<string name="coffee">Coffee</string>
-	<string name="cleanliness">Cleanliness</string>
-	<string name="crowdedness">Crowdedness</string>
 	<string name="error_enter_correct_name">Please, enter a correct name</string>
 	<string name="bookmarks_groups">Lists</string>
 	<string name="bookmarks_groups_hide_all">Hide all</string>
 	<string name="bookmarks_groups_show_all">Show all</string>
-	<plurals name="bookmarks_places">
-	  <item quantity="one">%d bookmark</item>
-	  <item quantity="other">%d bookmarks</item>
-	</plurals>
 	<string name="bookmarks_create_new_group">Create new list</string>
 	<!-- Bookmark categories screen -->
 	<string name="bookmarks_import">Import bookmarks</string>
 	<string name="downloader_hide_screen">Hide Screen</string>
 	<string name="downloader_percent">%1$s (%2$s of %3$s)</string>
-	<string name="downloader_process">Downloading %s...</string>
-	<string name="downloader_applying">Applying %s...</string>
-	<string name="dialog_message_transit_not_found_connection">Plan a route within one transit network</string>
+	<string name="downloader_process">Downloading %s…</string>
+	<string name="downloader_applying">Applying %s…</string>
 	<string name="bookmarks_error_message_share_general">Unable to share due to an application error</string>
 	<string name="bookmarks_error_title_share_empty">Sharing error</string>
 	<string name="bookmarks_error_message_share_empty">Cannot share an empty list</string>
@@ -1001,12 +626,7 @@
 	<string name="bookmarks_new_list_hint">New list</string>
 	<string name="bookmarks_error_title_list_name_already_taken">This name is already taken</string>
 	<string name="bookmarks_error_message_list_name_already_taken">Please choose another name</string>
-	<string name="bookmarks_error_title_list_name_too_long">This name is too long</string>
-	<string name="bookmarks_error_message_list_name_too_long">Please choose another name</string>
-	<string name="please_wait">Please wait...</string>
-	<string name="phone_number">Phone number</string>
-	<string name="notification_unsent_reviews_title"> You have several unsent reviews</string>
-	<string name="notification_unsent_reviews_message"> Please sign in to share reviews with other travellers</string>
+	<string name="please_wait">Please wait…</string>
 	<string name="profile">OpenStreetMap profile</string>
 	<string name="place_page_search_similar_hotel">Search similar hotels</string>
 	<string name="bookmarks_detect_title">New files detected</string>
@@ -1017,32 +637,10 @@
 	<string name="button_convert">Convert</string>
 	<string name="bookmarks_convert_error_title">Error</string>
 	<string name="bookmarks_convert_error_message">Some files were not converted.</string>
-	<string name="converting">Converting...</string>
-	<string name="wn_reinvented_bookmarks_title">We reinvented bookmarks!</string>
-	<string name="wn_reinvented_bookmarks_message">You can backup them, create lists...It’s amazing...</string>
-	<string name="bookmarks_restore"> Restore bookmarks</string>
-	<string name="bookmarks_restore_process"> Restoring...</string>
-	<string name="bookmarks_restore_title"> Restore this version?</string>
-	<string name="bookmarks_restore_message"> Your bookmarks will be restored from %1$s (%2$s)</string>
-	<string name="bookmarks_restore_empty_title"> You don’t have any backups</string>
-	<string name="bookmarks_restore_empty_message"> The server couldn\'t find previously made backups</string>
+	<string name="bookmarks_restore_title">Restore this version?</string>
 	<string name="common_check_internet_connection_dialog_title">No internet connection</string>
-	<string name="error_server_title"> Server error</string>
-	<string name="error_server_message"> There was an error on the server, please try again later</string>
-	<string name="error_system_message"> An unknown error occurred</string>
+	<string name="error_system_message">An unknown error occurred</string>
 	<string name="restore">Restore</string>
-	<string name="bookmarks_page_downloaded">Downloaded</string>
-	<string name="bookmarks_page_my">My</string>
-	<string name="routes_and_bookmarks">Routes and bookmarks</string>
-	<string name="bookmarks_webview_success_toast">Bookmarks succesfully downloaded</string>
-	<string name="cached_bookmarks_placeholder_title">Download new places</string>
-	<string name="cached_bookmarks_placeholder_subtitle">Press the button to download thousands of interesting places and routes created by Organic Maps users. You will need the internet connection.</string>
-	<string name="downloader_download_routers">Download bookmarks</string>
-	<string name="bookmarks_groups_cached">Downloaded lists</string>
-	<plurals name="bookmarks_objects">
-	  <item quantity="one">%s object</item>
-	  <item quantity="other">%s objects</item>
-	</plurals>
 	<plurals name="objects">
 	  <item quantity="one">%d object</item>
 	  <item quantity="other">%d objects</item>
@@ -1058,73 +656,33 @@
 	<string name="subtittle_opt_out">Tracking settings</string>
 	<string name="crash_reports">Crash report</string>
 	<string name="crash_reports_description">We may use your data to improve Organic Maps experience. Changes will take effect after you restart the app.</string>
-	<string name="opt_out_help_ios_1">Your mobile device may provide a “Limit Ad Tracking” or “Opt out of interest-based advertising” setting.</string>
-	<string name="opt_out_help_ios_2">iOS 9 or Higher</string>
-	<string name="opt_out_help_ios_3">Go to your Settings → Privacy → Advertising → Enable the “Limit Ad Tracking” setting</string>
-	<string name="opt_out_help_android">Your mobile device may provide a “Limit Ad Tracking” or “Opt out of interest-based advertising” setting.\n\nFor Android and Google Play Services version 4.0 and up:\nSettings → Google → Ads → Opt out of Ads Personalization\nor\nSettings → Google → Google Account → Personal info &amp; privacy → Ads Settings → Ads Personalization</string>
 	<string name="privacy_policy">Privacy policy</string>
 	<string name="terms_of_use">Terms of use</string>
-	<string name="backup_notification_failed">Backing up your bookmarks has been suspended. Log in to turn it back on.</string>
 	<string name="button_layer_traffic">Traffic</string>
 	<string name="button_layer_subway">Subway</string>
 	<string name="layers_title">Map layers</string>
-	<string name="layers_message">Use map layers to display the traffic, subway map, and other useful information</string>
-	<string name="button_layer_got_it">Got it</string>
 	<string name="subway_data_unavailable">Subway map is unavailable</string>
 	<string name="bookmarks_empty_list_title">This list is empty</string>
 	<string name="bookmarks_empty_list_message">To add a bookmark, tap a place on the map and then tap the star icon</string>
 	<string name="category_desc_more">…more</string>
 	<string name="title_error_downloading_bookmarks">An error occurred</string>
-	<string name="subtitle_error_downloading_bookmarks">Bookmarks were not downloaded</string>
-	<string name="error_already_downloaded">This list has already been downloaded</string>
 	<string name="popular_place">Popular</string>
-	<string name="download_routes">Download routes</string>
-	<string name="bookmarks_downloaded_title">Bookmarks have been downloaded successfully</string>
-	<string name="bookmarks_downloaded_subtitle">Press ‘View on map’ to explore new places from the list</string>
-	<string name="why_support">Why support Organic Maps?</string>
-	<string name="why_support_item1">We respect your privacy: there are zero trackers in the app, and we are open source</string>
-	<string name="why_support_item2">You help us to improve Organic Maps</string>
-	<string name="why_support_item3">You help us improve open maps OpenStreetMap.org</string>
-	<string name="channels_map_update">Map updates</string>
-	<string name="server_unavailable_title">Server is unavailable</string>
-	<string name="sharing_options">Sharing options</string>
 	<string name="export_file">Export file</string>
 	<string name="list_settings">List Settings</string>
 	<string name="delete_list">Delete list</string>
-	<string name="hide_from_map">Hide from map</string>
 	<string name="public_access">Public access</string>
 	<string name="limited_access">Limited access</string>
 	<string name="bookmark_category_name">Category</string>
 	<string name="bookmark_category_description_hint">Type a description (text or html)</string>
-	<!-- FIXME -->
-	<string name="bookmarks_public_access">bookmarks_public_access</string>
-	<!-- FIXME -->
-	<string name="bookmarks_link_access">bookmarks_link_access</string>
-	<!-- FIXME -->
-	<string name="bookmarks_private_access">bookmarks_private_access</string>
 	<string name="not_shared">Private</string>
-	<string name="direct_link_progress_text">Uploading your file…</string>
-	<string name="direct_link_success">The link has been created</string>
-	<string name="send_a_link_btn">Send me a link</string>
-	<string name="upload_error_toast">An error occurred while uploading your file</string>
 	<string name="tags_loading_error_subtitle">An error occurred while loading tags, please try again</string>
-	<string name="unable_upload_errorr_title">File upload failed</string>
-	<string name="unable_upload_error_subtitle_edited">This file has been edited via the web app</string>
-	<string name="unable_upload_error_subtitle_broken">This file is damaged and couldn\'t be uploaded. Please upload another file.</string>
-	<string name="contact">Contact</string>
-	<string name="download_button">Download</string>
 	<string name="speedcams_alert_title">Speed cameras</string>
-	<string name="speedcams_alert_subtitle">Warn about speed limits</string>
 	<string name="speedcam_option_auto">Auto</string>
 	<string name="speedcam_option_always">Always</string>
 	<string name="speedcam_option_never">Never</string>
-	<string name="bookmark_description_title">Bookmark Description</string>
 	<string name="place_description_title">Place Description</string>
 	<!-- this text will be shown in application notification preferences opposite checkbox which enable/disable downloader notifications. Devices on Android 8+ are affected. -->
 	<string name="notification_channel_downloader">Map downloader</string>
-	<string name="share_bookmarks_email_body_link">Hello!\n\nHere is the link where you can download bookmarks: %s. Open the list in Organic Maps and enjoy your trip!\n\nGet application: https://omaps.app/get?kmz</string>
-	<string name="warning_speedcams_title">Navigator will warn you about cameras when you exceed the speed limit of %d km/h</string>
-	<string name="warning_speedcams_subtitle">Please mind driving regulations of the country you are travelling to.</string>
 	<string name="speedcams_notice_message">Auto - Warn about speedcams if there is a risk of exceeding the speed limit\nAlways - Always warn about speedcams\nNever - Never warn about speedcams</string>
 	<string name="power_managment_title">Power saving mode</string>
 	<string name="power_managment_description">When automatic mode is selected the application starts to disable battery draining features depending on the current battery charge level</string>
@@ -1132,15 +690,7 @@
 	<string name="power_managment_setting_auto">Automatic</string>
 	<string name="power_managment_setting_manual_max">Maximum power saving</string>
 	<string name="enable_logging_warning_message">The option turns on logging for diagnostic purposes. It can be helpful for our team to troubleshoot issues with the app. Enable this option temporarily to record and send detailed logs about your issue to us.</string>
-	<string name="html_error_upload_message_try_again">Please check your network settings and try again</string>
-	<string name="html_error_upload_title_try_again">No internet connection</string>
-	<string name="notification_leave_review_v2_android_short_title">Review and help travellers!</string>
-	<string name="megafon">Say goodbye to roaming!</string>
-	<string name="notifications_illegal_alert_disable_button">Turn off notifications</string>
 	<string name="access_rules_author_only">Online editing</string>
-	<string name="privacy_settings_menu">Privacy settings</string>
-	<string name="unable_upadate_error_title">File update failed</string>
-	<string name="unable_upadate_error_message">Some errors occurred while updating. Please check the changes and try again</string>
 	<string name="driving_options_title">Routing options</string>
 	<string name="driving_options_subheader">Avoid on every route</string>
 	<string name="avoid_tolls">Toll roads</string>
@@ -1151,52 +701,14 @@
 	<string name="unable_to_calc_alert_subtitle">Unfortunately, we couldn\'t find a route, probably due to the options you have chosen. Please change the settings and try again.</string>
 	<string name="define_to_avoid_btn">Define roads to avoid</string>
 	<string name="change_driving_options_btn">Routing options enabled</string>
-	<string name="toll_road">Toll road</string>
-	<string name="unpaved_road">Unpaved road</string>
-	<string name="ferry_crossing">Ferry crossing</string>
-	<string name="operated_by">Operated by \"%s\"</string>
 	<string name="avoid_toll_roads_placepage">Avoid toll roads</string>
 	<string name="avoid_unpaved_roads_placepage">Avoid unpaved roads</string>
 	<string name="avoid_ferry_crossing_placepage">Avoid ferry crossings</string>
-	<string name="type.cuisine.uzbek">Uzbek cuisine</string>
-	<string name="trip_start">Let\'s go</string>
-	<string name="pick_destination">Destination</string>
-	<string name="follow_my_position">Re-center</string>
-	<string name="search_results">Search results</string>
-	<string name="then_turn">Then</string>
-	<string name="redirect_route_alert">Do you want to rebuild the route?</string>
-	<string name="redirect_route_yes">Yes</string>
-	<string name="redirect_route_no">No</string>
-	<string name="trip_finished">You have arrived!</string>
-	<string name="keyboard_availability_alert">Keyboard is not available while driving</string>
-	<string name="dialog_routing_change_start_carplay">Unable to build a route from your current location</string>
-	<string name="dialog_routing_change_end_carplay">Unable to build a route to your destination. Please choose another point</string>
-	<string name="dialog_routing_check_gps_carplay">No GPS signal. Please move to an open area</string>
-	<string name="dialog_routing_unable_locate_route_carplay">Unable to build a route. Please specify other route points</string>
-	<string name="dialog_routing_download_files_carplay">To create a route, download missing maps on your device</string>
-	<string name="dialog_routing_system_error_carplay">An error occurred. Please restart the application</string>
-	<string name="dialog_routing_rebuild_from_current_location_carplay">The route will be rebuilt from your current location</string>
-	<string name="dialog_routing_rebuild_for_vehicle_carplay">The route will be converted into an automobile one</string>
 	<string name="ok">Ok</string>
-	<string name="avoid_unpaved_carplay_1">No dirt road</string>
-	<string name="avoid_unpaved_carplay_2">Avoid unpaved</string>
-	<string name="avoid_ferry_carplay_1">No ferries</string>
-	<string name="avoid_ferry_carplay_2">Avoid ferries</string>
-	<string name="avoid_tolls_carplay_1">No toll road</string>
-	<string name="avoid_tolls_carplay_2">Avoid toll road</string>
-	<string name="speedcams_alert_title_carplay_1">Speedсams</string>
-	<string name="speedcams_alert_title_carplay_2">Speed warnings</string>
-	<string name="download_map_carplay">Please download maps in Organic Maps app on your device</string>
-	<string name="carplay_roundabout_exit">%s exit</string>
 	<!-- max. 10 symbols, both iOS and Android -->
 	<string name="sort">Sort…</string>
 	<!-- Android, title, max 20-22 symbols -->
 	<string name="sort_bookmarks">Sort bookmarks</string>
-	<!-- iOS -->
-	<string name="sort_default">Sort by default</string>
-	<string name="sort_type">Sort by type</string>
-	<string name="sort_distance">Sort by distance</string>
-	<string name="sort_date">Sort by date</string>
 	<!-- Android -->
 	<string name="by_default">By default</string>
 	<!-- Android -->
@@ -1205,65 +717,23 @@
 	<string name="by_distance">By distance</string>
 	<!-- Android -->
 	<string name="by_date">By date</string>
-	<string name="week_ago_sorttype">A week ago</string>
-	<string name="month_ago_sorttype">A month ago</string>
-	<string name="moremonth_ago_sorttype">More than a month ago</string>
-	<string name="moreyear_ago_sorttype">More than a year ago</string>
-	<string name="near_me_sorttype">Near me</string>
-	<string name="others_sorttype">Others</string>
-	<string name="food_places">Food</string>
-	<string name="tourist_places">Sights</string>
-	<string name="museums">Museums</string>
-	<string name="parks">Parks</string>
-	<string name="swim_places">Swim</string>
-	<string name="mountains">Mountains</string>
-	<string name="animals">Animals</string>
-	<string name="hotels">Hotels</string>
-	<string name="buildings">Buildings</string>
-	<string name="money">Money</string>
-	<string name="shops">Shops</string>
-	<string name="parkings">Parkings</string>
-	<string name="fuel_places">Gas stations</string>
-	<string name="water">Water</string>
-	<string name="medicine">Medicine</string>
 	<string name="search_in_the_list">Search in the list</string>
-	<string name="view_on_map_bookmarks">On map</string>
-	<string name="more_bookmarks">More…</string>
-	<string name="no_items_found">No items found</string>
-	<!-- Android, max 18 symbols -->
-	<string name="bookmarks_edit_list">Edit list</string>
-	<!-- Android, max 18 symbols -->
-	<string name="bookmarks_delete_list">Delete list</string>
-	<string name="religious_places">Religious places</string>
 	<string name="select_list">Select list</string>
 	<string name="transit_not_found">Subway navigation in this region is not available yet</string>
 	<string name="dialog_pedestrian_route_is_long_header">Subway route is not found</string>
 	<string name="dialog_pedestrian_route_is_long_message">Please choose a start or end point closer to a subway station</string>
-	<!-- Failed planning SUBWAY route message in navigation view -->
-	<string name="routing_planning_error_subway_special">Subway route planning failed</string>
 	<string name="button_layer_isolines">Terrain</string>
-	<string name="tips_map_layers_title_countour">New in Organic Maps: offline topographic layer!</string>
-	<string name="tips_map_layers_message_countour">Plan and enjoy your nature trips being sure you know everything about the area</string>
 	<string name="isolines_activation_error_dialog">To activate and use the topographic layer please update or download the map of the area</string>
 	<string name="isolines_location_error_dialog">The topographic layer is not yet available in this area</string>
 	<string name="elevation_profile_diff_level">Difficulty level</string>
-	<string name="elevation_profile_diff_level_easy">Easy</string>
-	<string name="elevation_profile_diff_level_moderate">Moderate</string>
-	<string name="elevation_profile_diff_level_hard">Hard</string>
 	<string name="elevation_profile_ascent">Ascent</string>
 	<string name="elevation_profile_descent">Descent</string>
 	<string name="elevation_profile_minaltitude">Min. altitude</string>
 	<string name="elevation_profile_maxaltitude">Max. altitude</string>
-	<string name="elevation_profile_m">m</string>
 	<string name="elevation_profile_difficulty">Difficulty</string>
 	<string name="elevation_profile_distance">Dist.:</string>
-	<string name="elevation_profile_km">km</string>
 	<string name="elevation_profile_time">Time:</string>
-	<string name="elevation_profile_hours">h.</string>
-	<string name="elevation_profile_minutes">min</string>
 	<string name="isolines_toast_zooms_1_10">Zoom in to explore isolines</string>
-	<string name="downloader_updating_ios">Updating</string>
-	<string name="downloader_loading_ios">Downloading</string>
 	<string name="key_information_title">Key information</string>
 	<string name="download_map_title">Download the world map</string>
 	<string name="connection_failure">Connection failure</string>

--- a/data/strings/strings.txt
+++ b/data/strings/strings.txt
@@ -2,6 +2,7 @@
 
   [back]
     comment = Button text (should be short)
+    tags = android
     en = Back
     ru = Назад
     ar = رجوع
@@ -30,12 +31,13 @@
     zh-Hans = 返回
     zh-Hant = 返回
     el = Πίσω
+    fa = بازگشت
     he = חזור
     sk = Späť
-    fa = بازگشت
 
   [cancel]
     comment = Button text (should be short)
+    tags = ios, android
     en = Cancel
     ru = Отмена
     ar = إلغاء
@@ -64,12 +66,13 @@
     zh-Hans = 取消
     zh-Hant = 取消
     el = Άκυρο
+    fa = لغو
     he = בטל
     sk = Zrušiť
-    fa = لغو
 
   [cancel_download]
     comment = Button which interrupts country download
+    tags = ios
     en = Cancel Download
     ru = Отменить загрузку
     ar = إلغاء التنزيل
@@ -98,12 +101,13 @@
     zh-Hans = 取消下载
     zh-Hant = 取消下載
     el = Ακύρωση λήψης
+    fa = لغو دانلود
     he = בטל  הורדת הקובץ
     sk = Zrušiť sťahovanie
-    fa = لغو دانلود
 
   [delete]
     comment = Button which deletes downloaded country
+    tags = ios, android
     en = Delete
     ru = Удалить
     ar = حذف
@@ -132,44 +136,12 @@
     zh-Hans = 删除
     zh-Hant = 刪除
     el = Διαγραφή
+    fa = حذف
     he = מחק
     sk = Zmazať
-    fa = حذف
-
-  [do_nothing]
-    comment = Button "do not interrupt download" if user touched actively downloading country
-    en = Continue
-    ru = Продолжить загрузку
-    ar = استمرار
-    cs = Pokračovat
-    da = Fortsæt
-    nl = Doorgaan
-    fi = Jatka
-    fr = Continuer
-    de = Herunterladen fortsetzen
-    hu = Folytatás
-    id = Lanjutkan
-    it = Continua
-    ja = 何もしない
-    ko = 아무것도 하지 마세요
-    nb = Ikke spør meg igjen
-    pl = Kontynuuj
-    pt = Continuar
-    pt-BR = Continuar
-    ro = Continuare
-    es = Seguir descarga
-    sv = Fortsätt
-    th = ดำเนินการต่อ
-    tr = Devam
-    uk = Продовжити завантаження
-    vi = Tiếp tục
-    zh-Hans = 继续
-    zh-Hant = 繼續
-    he = המשך
-    sk = Pokračovať
-    fa = ادامه
 
   [download_maps]
+    tags = ios, android
     en = Download Maps
     ru = Загрузить карты
     ar = تنزيل الخرائط
@@ -198,12 +170,13 @@
     zh-Hans = 下载地图
     zh-Hant = 下載地圖
     el = Λήψη χαρτών
+    fa = دانلود نقشه ها
     he = הורד קבצי מפות
     sk = Stiahnuť mapy
-    fa = دانلود نقشه ها
 
   [download_has_failed]
     comment = Settings/Downloader - info for country when download fails
+    tags = android
     en = Download has failed. Touch to try again.
     ru = Ошибка загрузки. Нажмите, чтобы повторить попытку
     ar = فشلت عملية التنزيل، انقر مرة أخرى لإعداة المحاولة
@@ -232,12 +205,13 @@
     zh-Hans = 下载失败，重新轻触再试一次
     zh-Hant = 下載失敗，輕觸以再試一次
     el = Η λήψη απέτυχε. Αγγίξτε για να προσπαθήσετε ξανά.
+    fa = دانلود ناموفق بود . برای تلاش مجدد لمس کنید
     he = הורדת הקובץ נכשלה. לחץ שוב לניסיון נוסף
     sk = Sťahovanie zlyhalo, skúste to znova.
-    fa = دانلود ناموفق بود . برای تلاش مجدد لمس کنید
 
   [downloading]
     comment = Settings/Downloader - info for country which started downloading
+    tags = ios, android
     en = Downloading…
     ru = Загружается…
     ar = جاري التنزيل…
@@ -266,31 +240,13 @@
     zh-Hans = 下载…
     zh-Hant = 下載中…
     el = Λήψη…
+    fa = درحال دانلود
     he = מוריד….
     sk = Sťahovanie…
-    fa = درحال دانلود
-
-  [kb]
-    comment = Settings/Downloader - size string, only strings different from English should be translated
-    en = kB
-    ru = кБ
-    ar = ك.ب.
-    nl = KB
-    fi = Kt
-    fr = ko
-    de = kB
-    id = kB
-    nb = kB
-    pl = KB
-    ro = kB
-    th = กิโลไบต์
-    tr = kB
-    uk = кБ
-    vi = kB
-    fa = کیلوبایت
 
   [kilometres]
     comment = Choose measurement on first launch alert - choose metric system button
+    tags = ios, android
     en = Kilometers
     en-GB = Kilometres
     ru = Километры
@@ -320,12 +276,13 @@
     zh-Hans = 千米
     zh-Hant = 公里
     el = Χιλιόμετρα
+    fa = کیلومتر
     he = ק"מ
     sk = Kilometre
-    fa = کیلومتر
 
   [leave_a_review]
     comment = Leave Review dialog - Review button
+    tags = ios
     en = Leave a Review
     ru = Написать отзыв
     ar = اترك تعليق
@@ -354,12 +311,13 @@
     zh-Hans = 发表评论
     zh-Hant = 撰寫評論
     el = Αφήστε μια κριτική
+    fa = نظر خود را بیان کنید
     he = הבע דעתך
     sk = Spätná väzba
-    fa = نظر خود را بیان کنید
 
   [maps]
     comment = View and button titles for accessibility
+    tags = ios, android
     en = Maps
     ru = Карты
     ar = الخرائط
@@ -388,12 +346,13 @@
     zh-Hans = 地图
     zh-Hant = 地圖
     el = Χάρτες
+    fa = نقشه ها
     he = מפות
     sk = Mapy
-    fa = نقشه ها
 
   [mb]
     comment = Settings/Downloader - size string, only strings different from English should be translated
+    tags = android
     en = MB
     ru = МБ
     ar = م.ب.
@@ -412,7 +371,7 @@
     fa = مگابایت
 
   [gb]
-    tags = ios, android
+    tags = android
     en = GB
     ru = ГБ
     uk = ГБ
@@ -421,6 +380,7 @@
 
   [miles]
     comment = Choose measurement on first launch alert - choose imperial system button
+    tags = ios, android
     en = Miles
     ru = Мили
     ar = ميل
@@ -449,12 +409,13 @@
     zh-Hans = 英里
     zh-Hant = 英哩
     el = Μίλια
+    fa = مایل
     he = מ"ב
     sk = Míle
-    fa = مایل
 
   [core_my_position]
     comment = View and button titles for accessibility
+    tags = ios, android
     en = My Position
     ru = Мое местоположение
     ar = موقعي
@@ -483,12 +444,13 @@
     zh-Hans = 我的位置
     zh-Hant = 我的位置
     el = Η θέση μου
+    fa = مکان من
     he = מיקומי
     sk = Moja poloha
-    fa = مکان من
 
   [later]
     comment = Update maps later/Buy pro version later button text
+    tags = ios, android
     en = Later
     ru = Не сейчас
     ar = لاحقا
@@ -516,44 +478,13 @@
     zh-Hans = 稍后
     zh-Hant = 稍後
     el = Αργότερα
+    fa = بعداً
     he = מאוחר יותר
     sk = Neskôr
-    fa = بعداً
-
-  [never]
-    comment = Don't show some dialog any more
-    en = Never
-    ru = Не показывать
-    ar = أبدا
-    cs = Nikdy
-    da = Aldrig
-    nl = Nooit
-    fi = Ei koskaan
-    fr = Jamais
-    de = Nie
-    hu = Soha
-    id = Tidak akan pernah
-    it = Mai
-    ja = 今後表示しない
-    ko = 거절
-    nb = Aldri
-    pl = Nigdy
-    pt = Nunca
-    pt-BR = Nunca
-    ro = Niciodată
-    sv = Aldrig
-    th = ไม่ต้องเตือนอีก
-    tr = Asla
-    uk = Не показувати
-    vi = Không bao giờ
-    zh-Hans = 从来不
-    zh-Hant = 不再提醒
-    he = אף פעם
-    sk = Nikdy
-    fa = هرگز
 
   [search]
     comment = View and button titles for accessibility
+    tags = ios, android
     en = Search
     ru = Поиск
     ar = البحث
@@ -582,11 +513,12 @@
     zh-Hans = 搜索
     zh-Hant = 搜尋
     el = Αναζήτηση
-    sk = Hľadať
     fa = جست‌وجو
+    sk = Hľadať
 
   [search_map]
     comment = Search box placeholder text
+    tags = android
     en = Search Map
     ru = Поиск на карте
     ar = ابحث في الخريطة
@@ -615,45 +547,13 @@
     zh-Hans = 搜索地图
     zh-Hant = 搜尋地圖
     el = Αναζήτηση χάρτη
+    fa = جست‌وجوی نقشه
     he = חפש במפה
     sk = Prehľadať mapu
-    fa = جست‌وجوی نقشه
-
-  [touch_to_download]
-    comment = Settings/Downloader - info for not downloaded country
-    en = Touch to download
-    ru = Нажмите для загрузки
-    ar = انقر للتنزيل
-    cs = Klepněte pro stažení
-    da = Tryk for at downloade
-    nl = Klik om te downloaden
-    fi = Lataa koskettamalla
-    fr = Toucher pour télécharger
-    de = Antippen, um herunterzuladen
-    hu = Érintse meg letöltéshez
-    id = Sentuh untuk mengunduh
-    it = Tocca per scaricare
-    ja = タッチしてダウンロード
-    ko = 두드려 다운로드하세요
-    nb = Trykk for å laste ned
-    pl = Proszę nacisnąć, aby pobrać.
-    pt = Toque para descarregar
-    pt-BR = Toque para baixar
-    ro = Atingeți pentru a descărca.
-    es = Presionar para descargar
-    sv = Trycka för att ladda ner
-    th = แตะเพื่อดาวน์โหลด
-    tr = İndirmek için dokunun
-    uk = Натисніть для завантаження
-    vi = Chạm để tải xuống
-    zh-Hans = 轻触下载
-    zh-Hant = 輕觸以下載
-    he = לחץ להוריד
-    sk = Stlačte pre stiahnutie
-    fa = برای دانلود لمس کنید
 
   [use_cellular_data]
     comment = Settings/Downloader - 3G download warning dialog confirm button
+    tags = ios
     en = Yes
     ru = Да
     ar = نعم
@@ -682,12 +582,13 @@
     zh-Hans = 是
     zh-Hant = 是
     el = Ναι
+    fa = بله
     he = כן
     sk = Áno
-    fa = بله
 
   [location_is_disabled_long_text]
     comment = Location services are disabled by user alert - message
+    tags = android
     en = You currently have all Location Services for this device or application disabled. Please enable them in Settings.
     ru = Геолокация выключена в настройках устройства. Пожалуйста, включите её для удобного использования программы.
     ar = التطبيق أو جميع خدمات تحديد المواقع معطلة لديك في الوقت الحالي. الرجاء تفعيلها في الإعدادات.
@@ -716,45 +617,13 @@
     zh-Hans = 您目前有此设备的所有位置服务或应用已禁用。请在设置中启用它们。
     zh-Hant = 您目前裝置所有的定位服務或相關應用程式是處於停用的狀態，請從系統設定中選擇啟用。
     el = Οι υπηρεσίες εντοπισμού τοποθεσίας είναι προς το παρόν απενεργοποιημένες σε αυτή τη συσκευή ή για αυτή την εφαρμογή. Ενεργοποιήστε τις από τις Ρυθμίσεις.
+    fa = سرویس موقعیت مکانی شما غیر فعال است .لطفا جهت کارکرد صحیح نرم افزار ان را فعال کنید.
     he = שרותי המיקום של מכשיר או ישום זה זה כבויים. הכנס ל "הגדרות" Settings)) כדי להדליקם.
     sk = Aktuálne máte všetky možnosti pre určovanie polohy vypnuté. Prosím, povoľte ich v Nastaveniach.
-    fa = سرویس موقعیت مکانی شما غیر فعال است .لطفا جهت کارکرد صحیح نرم افزار ان را فعال کنید.
-
-  [device_doesnot_support_location_services]
-    comment = Location Services are not available on the device alert - message
-    en = Your device doesn't support Location Services
-    ru = Ваше устройство не поддерживает геолокацию
-    ar = جهازك لا يدعم خدمات تحديد المواقع.
-    cs = Vaše zařízení nepodporuje služby pro určování polohy
-    da = Din enhed understøtter ikke lokationstjenester
-    nl = Uw apparaat ondersteunt geen Locatie Services
-    fi = Laitteesi ei tue sijaintipalveluita
-    fr = Votre appareil ne prend pas en charge les services de localisation
-    de = Ihr Gerät unterstützt keine Ortungsdienste
-    hu = Az eszköz nem támogatja a helyzetmeghatározó szolgáltatásokat
-    id = Perangkat Anda tidak mendukung Layanan Lokasi
-    it = Il tuo dispositivo non supporta i servizi di localizzazione
-    ja = ご使用中の端末は位置情報サービスをサポートしていません。
-    ko = 귀하의장치가 위치 서비스를 지원하지 않습니다.
-    nb = Enheten din støtter ikke posisjonstjenester
-    pl = Urządzenie nie obsługuje usług lokalizacji
-    pt = Os Serviços de Localização não estão disponíveis em seu dispositivo
-    pt-BR = Os Serviços de Localização não estão disponíveis em seu dispositivo
-    ro = Dispozitivul dvs. nu acceptă servicii de localizare.
-    es = Su dispositivo no es compatible con los servicios de localización
-    sv = Din enhet stöder inte platstjänster
-    th = อุปกรณ์ของคุณไม่รองรับการบริการตำแหน่งที่ตั้ง
-    tr = Cihazınız Yer Hizmetlerini desteklemiyor
-    uk = Ваш пристрій не підтримує геолокацію
-    vi = Thiết bị của bạn không hỗ trợ Dịch vụ Định vị
-    zh-Hans = 您的设备不支持位置服务。
-    zh-Hant = 您的裝置不支援定位服務
-    he = ב” שרותי מיקום” מכשירך אינו תומך ב
-    sk = Vaše zariadenie nepodporuje služby pre určovanie polohy
-    fa =  دستگاه شماازسرویس موقعیت مکانی پشتیبانی نمی کند
 
   [zoom_to_country]
     comment = View and button titles for accessibility
+    tags = android
     en = Show on the map
     ru = Показать на карте
     ar = عرض على الخريطة
@@ -783,45 +652,12 @@
     zh-Hans = 在地图上显示
     zh-Hant = 在地圖上顯示
     el = Εμφάνιση στο χάρτη
-    sk = Ukázať na mape
     fa = بر روی نقشه نمایش بده
-
-  [country_status_download]
-    comment = Button text for the button at the center of the screen when the country is not downloaded
-    en = Download Map\n(^ ^)
-    ru = Загрузить карту\n(^ ^)
-    ar = (^ ^)\nتحميل الخريطة
-    cs = Stáhnout mapu\n(^ ^)
-    da = Download kort\n(^ ^)
-    nl = Kaart downloaden\n(^ ^)
-    fi = Lataa kartta\n(^ ^)
-    fr = Téléchargez la carte\n(^ ^)
-    de = Karte herunterladen\n(^ ^)
-    hu = Térkép letöltése\n(^ ^)
-    id = Unduh Peta\n(^ ^)
-    it = Scarica Map\n(^ ^)
-    ja = 地図をダウンロード\n(^ ^)
-    ko = 지도 다운로드\n(^ ^)
-    nb = Last ned kart\n(^ ^)
-    pl = Pobierz mapę\n(^ ^)
-    pt = Descarregar Mapa\n(^ ^)
-    pt-BR = Baixar Mapa\n(^ ^)
-    ro = Descărcare hartă\n(^ ^)
-    es = Descargar mapa\n(^ ^)
-    sv = Ladda ner karta\n(^ ^)
-    th = ดาวน์โหลดแผนที่\n(^ ^)
-    tr = Haritayı İndir\n(^ ^)
-    uk = Завантажити мапу\n(^ ^)
-    vi = Tải xuống Bản đồ\n(^ ^)
-    zh-Hans = 下载地图\n(^ ^)
-    zh-Hant = 下載地圖\n(^ ^)
-    el = Λήψη Χάρτη\n(^ ^)
-    he = (^ ^)\nהורידו מפה
-    sk = Stiahnite si Mapu\n(^ ^)
-    fa = دانلود نقشه\n(^ ^)
+    sk = Ukázať na mape
 
   [country_status_download_without_size]
     comment = Button text for the button at the center of the screen when the country is not downloaded and the size should not be shown
+    tags = ios
     en = Download Map
     ru = Загрузить карту
     ar = تحميل الخريطة
@@ -850,45 +686,13 @@
     zh-Hans = 下载地图
     zh-Hant = 下載地圖
     el = Λήψη χάρτη
+    fa = دانلود نقشه
     he = הורידו מפה
     sk = Stiahnite si Mapu
-    fa = دانلود نقشه
-
-  [country_status_download_without_routing]
-    comment = Button text for the button at the center of the screen when the country is not downloaded
-    en = Download map\nwithout routing (^ ^)
-    ru = Загрузить карту\nбез маршрутов (^ ^)
-    ar = (^ ^)\nتنزيل خريطة بدون تحديد خط السير
-    cs = Stáhnout mapy\nbez tras (^ ^)
-    da = Download kort uden\nruteplanlægning (^ ^)
-    nl = Download kaart\nzonder routeplanning (^ ^)
-    fi = Lataa kartta\nilman reititystä (^ ^)
-    fr = Télécharger la carte\nsans itinéraire (^ ^)
-    de = Karte ohne Routenplanung\nherunterladen (^ ^)
-    hu = Térkép letöltése\nútvonal nélkül (^ ^)
-    id = Unduh peta tanpa\nperutean (^ ^)
-    it = Scarica mappa\nsenza percorsi (^ ^)
-    ja = ルートなしで地図をダウンロード\n(^ ^)
-    ko = 라우팅없이 지도 다운로드\n(^ ^)
-    nb = Last ned kart\nuten veiviserfunksjon (^ ^)
-    pl = Pobierz mapę bez\noznaczania tras (^ ^)
-    pt = Baixar mapa\nsem roteamento (^ ^)
-    pt-BR = Baixar mapa\nsem roteamento (^ ^)
-    ro = Descărcare hartă\nfără rutare (^ ^)
-    es = Descargar mapa\nsin ruta (^ ^)
-    sv = Hämta karta\nutan rutter (^ ^)
-    th = ดาวน์โหลดแผนที่โดยไม่กำหนดเส้นทาง\n(^ ^)
-    tr = Haritayı rota\nolmadan indirin (^ ^)
-    uk = Завантажити карту\nбез маршрутів (^ ^)
-    vi = Tải về bản đồ không\ncó chỉ đường (^ ^)
-    zh-Hans = 下载不带路线的地图\n(^ ^)
-    zh-Hant = 下載不帶路線的地圖\n(^ ^)
-    el = Λήχη χάρτη\nχωρίς δρομολόγηση (^ ^)
-    he = (^ ^)\nהורד מפה בלי לקבוע מסלול
-    sk = Stiahnite si mapu\nbez smerovania (^ ^)
 
   [country_status_download_failed]
     comment = Message to display at the center of the screen when the country download has failed
+    tags = ios, android
     en = Download has failed
     ru = Ошибка загрузки
     ar = فشلت عملية تنزيل
@@ -917,12 +721,13 @@
     zh-Hans = 下载失败了
     zh-Hant = 下載失敗
     el = Η λήψη απέτυχε
+    fa = دانلود با شکست مواجه شد
     he = הורדנכשלה
     sk = Sťahovanie zlyhalo
-    fa = دانلود با شکست مواجه شد
 
   [try_again]
     comment = Button text for the button under the country_status_download_failed message
+    tags = android
     en = Try Again
     ru = Попробуйте еще раз
     ar = محاولة مرة أخرى
@@ -951,11 +756,12 @@
     zh-Hans = 重试
     zh-Hant = 再試一次
     el = Δοκιμάστε ξανά
+    fa = تلاش مجدد
     he = נסה שוב
     sk = Skúsiť znova
-    fa = تلاش مجدد
 
   [about_menu_title]
+    tags = ios, android
     en = About Organic Maps
     ru = О программе
     ar = حول Organic Maps
@@ -984,43 +790,12 @@
     zh-Hans = 关于 Organic Maps
     zh-Hant = 關於 Organic Maps
     el = Σχετικά με το Organic Maps
+    fa = Organic Maps درباره‌ی
     he = Organic Maps אודות
     sk = O aplikácii Organic Maps
-    fa = Organic Maps درباره‌ی
-
-  [downloaded_touch_to_delete]
-    en = Downloaded (%@), touch to delete
-    ru = Загружено (%@), нажмите для удаления
-    ar = تم تنزيل (%@)، انقر للحذف
-    cs = Staženo (%@), klepněte pro smazání
-    da = Downloaded (%@), tryk for at slette
-    nl = Downloaded (%@), klik om te verwijderen
-    fi = Ladattu (%@), poista koskettamalla
-    fr = Téléchargé (%@), toucher pour supprimer
-    de = Heruntergeladen (%@). Antippen, um zu löschen
-    hu = Letöltve (%@), érintse meg törléshez
-    id = (%@) telah diunduh, sentuh untuk menghapus
-    it = Scaricato (%@), tocca per cancellare
-    ja = (%@)をダウンロードしました。削除するには画面をタッチしてください。
-    ko = (%@)가 다운로드 되었습니다, 두드려 삭제하십시요.
-    nb = Lastet ned (%@) – trykk for å slette
-    pl = Pobrano (%@). Proszę nacisnąć, aby usunąć.
-    pt = (%@) descarregados, toque para eliminar
-    pt-BR = (%@) baixados, toque para apagar
-    ro = Descărcat (%@). Atingeți pentru a șterge.
-    es = Descargado (%@), presionar para eliminar
-    sv = Nedladdad (%@), tryck för att ta bort
-    th = ดาวน์โหลดแล้ว (%@), แตะเพื่อลบ
-    tr = (%@) indirildi, silmek için dokunun
-    uk = Завантажено (%@), натисніть для видалення
-    vi = Đã tải xuống (%@), chạm để xóa
-    zh-Hans = 下载了(%@),轻触删除
-    zh-Hant = 已下載的 (%@)，輕觸以刪除
-    he = הורדת (%@) בוצעה, לחץ למחיקה
-    sk = Stiahnuté (%@), stlačte pre zmazanie
-    fa = دانلود شده (%@),  برای حذف لمس کنید
 
   [connection_settings]
+    tags = android
     en = Connection Settings
     ru = Настройки подключения
     ar = اعدادات الاتصال
@@ -1049,43 +824,12 @@
     zh-Hans = 连接设置
     zh-Hant = 連線設定
     el = Ρυθμίσεις σύνδεσης
+    fa = تنظیمات اتصال
     he = הגדרות תקשורת
     sk = Nastavenie pripojenia
-    fa = تنظیمات اتصال
-
-  [download_mb_or_kb]
-    en = Download %@
-    ru = Загрузить %@
-    ar = تنزيل %@
-    cs = Stáhnout %@
-    da = Download %@
-    nl = Download %@
-    fi = Lataa %@
-    fr = Télécharger %@
-    de = Herunterladen %@
-    hu = Letöltés %@
-    id = Unduh %@
-    it = Scarica %@
-    ja = %@をダウンロード
-    ko = %@ 다운로드하기
-    nb = Last ned %@
-    pl = Pobierz %@
-    pt = Descarga %@
-    pt-BR = Baixar %@
-    ro = Descărcare %@
-    es = Descargar %@
-    sv = Ladda ner %@
-    th = ดาวน์โหลด %@
-    tr = %@ indir
-    uk = Завантажити %@
-    vi = Tải xuống %@
-    zh-Hans = 下载%@
-    zh-Hant = 下載 %@
-    he = הורד %@
-    sk = Stiahnuť %@
-    fa = دانلود %@
 
   [close]
+    tags = ios, android
     en = Close
     ru = Закрыть
     ar = اغلاق
@@ -1114,11 +858,12 @@
     zh-Hans = 关闭
     zh-Hant = 關閉
     el = Κλείσιμο
+    fa = بستن
     he = סגור
     sk = Zavrieť
-    fa = بستن
 
   [unsupported_phone]
+    tags = android
     en = The app requires hardware accelerated OpenGL. Unfortunately, your device is not supported.
     ru = Для работы приложения необходим аппаратно ускоренный OpenGL. К сожалению, ваше устройство не поддерживается.
     ar = أنت بحاجة الى OpenGL بأجهزة تسريع. لسوء الحظ جهازك لا يدعم هذه الخاصية.
@@ -1147,11 +892,12 @@
     zh-Hans = 硬件加速的 OpenGL 是必需的。遗憾的是您 的设备不支持。
     zh-Hant = 需要 OpenGL 硬體加速功能的支援。但很不幸的，您的裝置並不支援此功能！
     el = Η εφαρμογή απαιτεί OpenGL με επιτάχυνση υλικού. Δυστυχώς, η συσκευή σας δεν το υποστηρίζει.
+    fa = نیازمند است. متاسفانه دستگاه شما از ان پشتیبانی نمی کندOpenGLبرنامه برای اجرا به
     he = נדרש מאיץ חומרה OpenGL. לצערינו מכשיר זה אינו נתמך.
     sk = Je vyžadovaná hardwarová akcelerácia OpenGL. Bohužial, vaše zariadenie nie je podporované.
-    fa = نیازمند است. متاسفانه دستگاه شما از ان پشتیبانی نمی کندOpenGLبرنامه برای اجرا به
 
   [download]
+    tags = ios, android
     en = Download
     ru = Загрузить
     ar = تنزيل
@@ -1179,43 +925,12 @@
     zh-Hans = 下载
     zh-Hant = 下載
     el = Λήψη
+    fa = دانلود
     he = הורד
     sk = Stiahnuť
-    fa = دانلود
-
-  [external_storage_is_not_available]
-    en = SD card/USB storage with downloaded maps is not available
-    ru = Загруженные карты недоступны
-    ar = خاصية التخزين بواسطة البطاقة الرقمية الآمنة\الناقل التسلسلي الشامل غير متاحة مع الخرائط التي تم تنزيلها.
-    cs = SD karta/USB uložiště s uloženými mapami není k dispozici
-    da = SD-kort/USB lagring med de downloadede kort er ikke tilgængeligt
-    nl = SD kaart/USB opslag met gedownloade kaarten is niet beschikbaar
-    fi = SD-kortti/USB-massamuisti, jolle kartat on ladattu, ei ole käytettävissä
-    fr = La carte SD/le stockage USB contenant les cartes téléchargées n'est pas disponible
-    de = SD-Karte/USB-Speicher mit heruntergeladenen Karten nicht verfügbar
-    hu = Nem található téképeket tartalmazó SD kártya / USB tároló
-    id = Penyimpanan kartu SD/USB dengan peta terunduh tidak tersedia
-    it = La scheda/USB/di memoria SD con le mappe scaricate non è disponibile
-    ja = マップをダウンロードしたSDカード/USBストレージへ接続できません
-    ko = 다운로드된지도와 SD 카드 / USB 저장 장치를 사용할 수 없습니다
-    nb = SD-kort/USB-enhet med nedlastede kart er ikke tilgjengelig
-    pl = Karta SD/Pamięć USB z pobranymi mapami nie jest dostępna
-    pt = Não está disponível um cartão SD/armazenamento USB com os mapas descarregados
-    pt-BR = O cartão SD/armazenamento USB com os mapas baixados não está disponível
-    ro = Cartela SD/dispozitivul de stocare USB cu hărțile descărcate nu este disponibil.
-    es = La memoria SD/almacenamiento USB con los mapas descargados no está disponible
-    sv = SD-kort/USB-lagring med nedladdade kartor är inte tillgänglig.
-    th = ไม่สามารถใช้การ์ด SD /พื้นที่จัดเก็บ USB ที่มีดาวน์โหลดแผนที่ได้
-    tr = İndirilen haritalarla SD kart/USB depolama aygıtı kullanılamıyor
-    uk = Завантажені карти недоступні
-    vi = Không hỗ trợ lưu trữ trên thẻ SD/USB với các bản đồ được tải xuống
-    zh-Hans = 缺少包含已下载地图的 SD 卡/ USB 储存设备
-    zh-Hant = SD 卡/USB 無法有效儲存下載的地圖
-    he = המפות המאוחסנות על SD card/USB אינן זמינות.
-    sk = SD karta/USB úložisko s uloženými mapami nie je k dispozícii
-    fa = حافظه خارجی که نقشه ها در ان دانلود شده موجود نیست
 
   [disconnect_usb_cable]
+    tags = android
     en = Please disconnect USB cable or insert memory card to use Organic Maps
     ru = Отключите USB кабель или вставьте SD-карту
     ar = الرجاء فصل كابل الناقل التسلسلي الشامل أو إدخال بطاقة الذاكرة من أجل استخدام Organic Maps.
@@ -1248,6 +963,7 @@
     sk = Prosím, odpojte USB kábel alebo vložte pamäťovú kartu pre použitie s Organic Maps
 
   [not_enough_free_space_on_sdcard]
+    tags = android
     en = Please free up some space on the SD card/USB storage first in order to use the app
     ru = Недостаточно свободного места на SD карте/в памяти устройства для использования программы
     ar = الرجاء إخلاء بعض المساحة في تخزين البطاقة الرقمية الآمنة\الناقل التسلسلي الشامل أولا من أجل استخدام هذا التطبيق.
@@ -1276,11 +992,12 @@
     zh-Hans = 请在 SD 卡/ USB 储存设备上释放一些空间以 使用此应用
     zh-Hant = 如要繼續使用，請先釋放一些 SD 卡/ USB 儲存空間
     el = Ελευθερώσετε  χώρο αποθήκευσης στην SD κάρτα/USB πρώτα προκειμένου να χρησιμοποιήσετε την εφαρμογή
+    fa = لطفا مقداری از فضای ذخیره سازی را آزاد نمایید
     he = אנא פנה שטח אחסון על ה SD card/USB כדי להשתמש בישום
     sk = Prosím, uvoľnite najprv miesto na SD karte/USB úložisku
-    fa = لطفا مقداری از فضای ذخیره سازی را آزاد نمایید
 
   [not_enough_memory]
+    tags = android
     en = Not enough memory to launch app
     ru = Недостаточно памяти для запуска программы
     ar = لا يوجد ذاكرة كافية لتشغيل التطبيق.
@@ -1309,11 +1026,12 @@
     zh-Hans = 没有足够的内存来启动应用程序
     zh-Hant = 沒有足夠的記憶體以啟動應用程式
     el = Δεν υπάρχει αρκετή μνήμη για την έναρξη εφαρμογής
+    fa = حافظه کافی برای اجرای برنامه وجود ندارد
     he = אין מספיק זכרון כדי להפעיל הישום
     sk = Nedostatok pamäti k spusteniu aplikácie
-    fa = حافظه کافی برای اجرای برنامه وجود ندارد
 
   [download_resources]
+    tags = android
     en = Before you start using the app, allow us to download the general world map to your device.\nIt will use %@ of storage.
     ru = Перед началом работы разрешите нам загрузить общую карту мира на ваше устройство.\nЭто потребует %@ данных.
     ar = قبل أن تبدأ، دعنا نقوم بتنزيل خريطة العالم العامة على جهازك.\nانها بحاجة الى %@ من البيانات.
@@ -1342,44 +1060,12 @@
     zh-Hans = 在您开始前请让我们下载通用世界地 图至您的设备中。\n它需要%@的 数据。
     zh-Hant = 在您開始之前，先讓我們下載世界地圖到您的裝置中以便瀏覽。\n這需要資料的 %@。
     el = Πριν ξεκινήσετε τη χρήση της εφαρμογής, επιτρέψτε μας να κατεβάσουμε το γενικό παγκόσμιο χάρτη στη συσκευή σας. \nIt θα χρησιμοποιήσει %@ αποθηκευτικού χώρου.
+    fa = قبل از استفاده از اپلیکیشن, اجازه دهید تا ما نقشه جهانی را بر روی موبایل شما دانلود کنیم.\nمقدار %@ از حافظه شما اشغال می شود.
     he = תחילה, נוריד למכשירך מפה כללית של העולם.\nדורש %@ של נתונים.
     sk = Skôr ako začnete, bude treba stiahnuť základnú mapu sveta.\nZaberie to %@.
-    fa = قبل از استفاده از اپلیکیشن, اجازه دهید تا ما نقشه جهانی را بر روی موبایل شما دانلود کنیم.\nمقدار %@ از حافظه شما اشغال می شود.
-
-  [getting_position]
-    en = Getting current position
-    ru = Получаем местоположение
-    ar = الحصول على الموقع الحالي
-    cs = Získávání aktuální polohy
-    da = Henter nuværende lokation
-    nl = Huidige locatie opvragen
-    fi = Etsitään sijaintia
-    fr = Obtention de la position actuelle
-    de = Ermittle momentane Position
-    hu = Aktuális pozíció meghatározása…
-    id = Sedang mencari lokasi saat ini
-    it = Ottieni la posizione corrente
-    ja = 現在地を取得中
-    ko = 현재 위치 얻기
-    nb = Henter nåværende posisjon
-    pl = Określanie aktualnego położenia
-    pt = A obter a posição atual
-    pt-BR = Obtendo posição atual
-    ro = Se obține poziția actuală
-    es = Buscando su ubicación actual
-    sv = Hämtar nuvarande position
-    th = กำลังรับตำแหน่งปัจจุบัน
-    tr = Geçerli konum alınıyor
-    uk = Oтримуємо розташування
-    vi = Đang tìm vị trí hiện tại
-    zh-Hans = 获取当前位置
-    zh-Hant = 取得目前所在位置
-    el = Λήψη τρέχουσας τοποθεσίας
-    he = מאתר  מיקום נוכחי
-    sk = Získavanie aktuálnej polohy
-    fa = درحال دریافت موقعیت مکانی شما
 
   [download_resources_continue]
+    tags = android
     en = Go to Map
     ru = Перейти на карту
     ar = الذهاب الى الخريطة
@@ -1408,11 +1094,12 @@
     zh-Hans = 前往地图
     zh-Hant = 跳到地圖
     el = Μετάβαση στο χάρτη
+    fa = برو به نقشه
     he = עבור למפה
     sk = Prejsť na mapu
-    fa = برو به نقشه
 
   [downloading_country_can_proceed]
+    tags = android
     en = Downloading %@. You can now\nproceed to the map.
     ru = Пока загружается %@,\nвы можете пользоваться картой.
     ar = تنزيل %@. يمكنك الآن\nالمتابعة الى الخريطة.
@@ -1441,11 +1128,12 @@
     zh-Hans = 下载 %@。您现在可\n前往地图。
     zh-Hant = 正在下載 %@。您現在 可以繼續使用地圖了
     el = Λήψη %@. Μπορείτε τώρα να\nμεταβείτε στο χάρτη.
+    fa = درحال دانلود %@. شما اکنون می توانید\nبه نقشه بروید.
     he = מוריד %@. תוכל עתה\nלהמשיך למפה.
     sk = Sťahovanie %@. Teraz môžete\nprejsť na mapu.
-    fa = درحال دانلود %@. شما اکنون می توانید\nبه نقشه بروید.
 
   [download_country_ask]
+    tags = android
     en = Download %@?
     ru = Загрузить %@?
     ar = هل تريد تنزيل %@؟
@@ -1474,11 +1162,12 @@
     zh-Hans = 下载 %@?
     zh-Hant = 下載 %@?
     el = Να γίνει λήψη %@;
+    fa = دانلود  %@?
     he = להוריד %@?
     sk = Stiahnuť %@?
-    fa = دانلود  %@?
 
   [update_country_ask]
+    tags = android
     en = Update %@?
     ru = Обновить %@?
     ar = هل تريد تحديث %@ ؟
@@ -1507,12 +1196,13 @@
     zh-Hans = 更新 %@?
     zh-Hant = 更新 %@？
     el = Να γίνει ενημέρωση %@;
+    fa = اپدیت %@?
     he = לעדכן %@?
     sk = Aktualizovať %@?
-    fa = اپدیت %@?
 
   [pause]
     comment = REMOVE THIS STRING AFTER REFACTORING
+    tags = android
     en = Pause
     ru = Приостановить
     ar = توقف مؤقت
@@ -1541,12 +1231,13 @@
     zh-Hans = 暂停
     zh-Hant = 暫停
     el = Παύση
+    fa = مکث
     he = הפסק
     sk = Pauza
-    fa = مکث
 
   [continue_download]
     comment = REMOVE THIS STRING AFTER REFACTORING
+    tags = ios, android
     en = Continue
     ru = Продолжить
     ar = استمرار
@@ -1575,9 +1266,9 @@
     zh-Hans = 继续
     zh-Hant = 繼續
     el = Συνέχεια
+    fa = ادامه
     he = המשך
     sk = Pokračovať
-    fa = ادامه
 
   [download_country_failed]
     comment = Show popup notification on top of the map when country download has failed.
@@ -1610,13 +1301,13 @@
     zh-Hans = %@下载失败
     zh-Hant = %@ 下載失敗
     el = η λήψη %@ απέτυχε
+    fa = %@ دانلود با شکست مواجه شد
     he = %@ ההורדה  נכשלה
     sk = Sťahovanie zlyhalo: %@
-    fa = %@ دانلود با شکست مواجه شد
 
   [add_new_set]
     comment = Add New Bookmark Set dialog title
-    tags = ios
+    tags = android
     en = Add New Set
     ru = Добавить группу
     ar = إضافة مجموعة جديدة
@@ -1645,47 +1336,13 @@
     zh-Hans = 添加新的集合
     zh-Hant = 新增收藏夾
     el = Προσθέστε νέο σύνολο
+    fa = اضافه کردن مجموعه جدید
     he = הוסף קבוצה חדשה
     sk = Pridať novú skupinu záložiek
-    fa = اضافه کردن مجموعه جدید
-
-  [add_to_bookmarks]
-    comment = Place Page - Add To Bookmarks button
-    tags = ios,android
-    en = Add to Bookmarks
-    ru = Сохранить метку
-    ar = إضافة الى الإشارات المرجعية
-    cs = Přidat k záložkám
-    da = Tilføj til Bogmærker
-    nl = Toevoegen aan Bladwijzers
-    fi = Lisää Kirjanmerkkeihin
-    fr = Ajouter aux signets
-    de = Zu den Lesezeichen hinzufügen
-    hu = Könyvjelzőkhöz hozzáadás
-    id = Tambahkan ke Penanda
-    it = Aggiungi al Segnalibri
-    ja = ブックマークに追加
-    ko = 즐겨찾기에 추가
-    nb = Legg til i bokmerker
-    pl = Dodaj zakładkę
-    pt = Adicionar aos Favoritos
-    pt-BR = Adicionar aos Favoritos
-    ro = Adăugare la „Marcaje”
-    es = Añadir a Favoritos
-    sv = Lägg till till bokmärken
-    th = เพิ่มไปยังบุ๊กมาร์ก
-    tr = Yer İmlerine Ekle
-    uk = Зберегти мiтку
-    vi = Thêm vào Điểm đánh dấu
-    zh-Hans = 添加至书签
-    zh-Hant = 新增到書籤
-    he = הוסף ל רשימת האתרים
-    sk = Pridať k záložkám
-    fa = اضافه کردن به نشانه ها
 
   [bookmark_color]
     comment = Bookmark Color dialog title
-    tags = ios
+    tags = android
     en = Bookmark Color
     en-GB = Bookmark Colour
     ru = Цвет метки
@@ -1715,13 +1372,13 @@
     zh-Hans = 书签颜色
     zh-Hant = 書籤顏色
     el = Χρώμα αγαπημένου
+    fa = رنگ نشانه
     he = צבע רשימת האתרים
     sk = Farba záložky
-    fa = رنگ نشانه
 
   [bookmark_set_name]
     comment = Add Bookmark Set dialog - hint when set name is empty
-    tags = ios
+    tags = ios, android
     en = Bookmark Set Name
     ru = Название группы
     ar = اسم مجموعة الإشارات المرجعية
@@ -1753,43 +1410,9 @@
     he = שם רשימת האתרים
     sk = Meno záložky
 
-  [bookmark_sets]
-    comment = Bookmark Sets dialog title
-    tags = ios
-    en = Bookmark Sets
-    ru = Группы меток
-    ar = مجموعات الإشارات المرجعية
-    cs = Skupiny záložek
-    da = Bogmærk sæt
-    nl = Bladwijzer groepen
-    fi = Kirjanmerkkivalikoimat
-    fr = Groupes de signets
-    de = Lesezeichenmappe
-    hu = Könyvjelzőcsoportok
-    id = Set Penanda
-    it = Seleziona un segnalibro
-    ja = ブックマークセット
-    ko = 세트를 즐겨찾기에 추가
-    nb = Bokmerk sett
-    pl = Zestawy zakładek
-    pt = Conjuntos de favoritos
-    pt-BR = Conjuntos de favoritos
-    ro = Seturi marcaje
-    es = Grupos de marcadores
-    sv = Bokmärkessamlingar
-    th = ชุดของบุ๊กมาร์ก
-    tr = Yer İmi Ayarları
-    uk = Групи мiток
-    vi = Đánh dấu Bộ
-    zh-Hans = 书签集
-    zh-Hant = 收藏夾
-    el = Σύνολα αγαπημένων
-    he = רשימות אתרים
-    sk = Skupiny záložiek
-
   [bookmarks]
     comment = Bookmarks - dialog title
-    tags = ios, android
+    tags = android
     en = Bookmarks
     ru = Метки
     ar = الإشارات المرجعية
@@ -1818,47 +1441,13 @@
     zh-Hans = 书签
     zh-Hant = 書籤
     el = Αγαπημένα
+    fa = نشانه ها
     he = רשימות אתרים
     sk = Záložky
-    fa = نشانه ها
-
-  [color]
-    comment = Add bookmark dialog - bookmark color
-    tags = ios
-    en = Color
-    en-GB = Colour
-    ru = Цвет
-    ar = اللون
-    cs = Barva
-    da = Farve
-    nl = Kleur
-    fi = Väri
-    fr = Couleur
-    de = Farbe
-    hu = Szín
-    id = Warna
-    it = Colore
-    ja = 表示色
-    ko = 색깔
-    nb = Farge
-    pl = Kolor
-    pt = Cor
-    pt-BR = Cor
-    ro = Culoare
-    sv = Färg
-    th = สี
-    tr = Renk
-    uk = Колір
-    vi = Màu sắc
-    zh-Hans = 色彩
-    zh-Hant = 顏色
-    he = צבע
-    sk = Farba
-    fa = رنگ
 
   [core_my_places]
     comment = Default bookmarks set name
-    tags = ios
+    tags = ios, android
     en = My Places
     ru = Мои Метки
     ar = أماكني
@@ -1887,13 +1476,13 @@
     zh-Hans = 我的位置
     zh-Hant = 我的地點
     el = Οι τοποθεσίες μου
+    fa = مکان من
     he = המקומות שלי
     sk = Moje miesta
-    fa = مکان من
 
   [name]
     comment = Add bookmark dialog - bookmark name
-    tags = ios
+    tags = android
     en = Name
     ru = Название
     ar = الاسم
@@ -1921,14 +1510,14 @@
     zh-Hans = 名字
     zh-Hant = 名稱
     el = Όνομα
+    fa = نام
     he = שם
     if = Nome
     sk = Názov
-    fa = نام
 
   [address]
     comment = Editor title above street and house number
-    tags = ios
+    tags = ios, android
     en = Address
     ru = Адрес
     ar = العنوان
@@ -1957,47 +1546,13 @@
     zh-Hans = 地址
     zh-Hant = 位址
     el = Διεύθυνση
+    fa = ادرس
     he = כתובת
     sk = Adresa
-    fa = ادرس
-
-  [remove_pin]
-    comment = Place Page - Remove Pin button
-    tags = ios
-    en = Remove Pin
-    ru = Удалить метку
-    ar = إزالة الدبوس
-    cs = Odstranit špendlík
-    da = Fjern knappenål
-    nl = Verwijder speld
-    fi = Poista nasta
-    fr = Enlever l'épingle
-    de = Stecknadel entfernen
-    hu = Jelző törlése
-    id = Hapus Pin
-    it = Rimuovi il Pin
-    ja = ピンを削除
-    ko = 핀 제거
-    nb = Fjern merke
-    pl = Usuń znacznik
-    pt = Retirar o marcador
-    pt-BR = Remover o marcador
-    ro = Poziție eliminată
-    es = Quitar la etiqueta
-    sv = Ta bort knappnål
-    th = ลบหมุด
-    tr = Pini Kaldır
-    uk = Видалити мітку
-    vi = Xóa Con Dấu
-    zh-Hans = 移除图钉
-    zh-Hant = 移除圖釘
-    he = הסר סיכה
-    sk = Odstrániť špendlík
-    fa = برچیدن سنجاق
 
   [set]
     comment = Add bookmark dialog - bookmark set, Bookmarks dialog - Bookmark set cell
-    tags = ios
+    tags = android
     en = Set
     ru = Группа
     ar = المجموعة
@@ -2026,48 +1581,13 @@
     zh-Hans = 集合
     zh-Hant = 收藏夾
     el = Σύνολο
+    fa = مجموعه
     he = קבוצה
     sk = Skupina
-    fa = مجموعه
-
-  [bookmarks_usage_hint]
-    comment = Text hint in Bookmarks dialog when no any bookmarks are added
-    tags = ios,android
-    en = You have no bookmarks yet.\nTap on any place on the map to add a bookmark.\nBookmarks from other sources can also be imported and displayed in Organic Maps. Open KML/KMZ file with saved bookmarks from email, Dropbox or weblink.
-    ru = У вас пока нет меток.\nВыберите любое место на карте, чтобы добавить его.\nТакже метки можно импортировать из Organic Maps либо других приложений и сайтов. Для этого откройте KML/KMZ файл из Dropbox, почты или по веб-ссылке.
-    ar = ليس لديك أي إشارات مرجعية بعد.\nانقر على أي مكان على الخريطة لإضافة إشارة مرجعية.\nيمكنك أيضا استيراد الإشارات المرجعية من المصادر الأخرى وعرضها في Organic Maps. افتح ملف KML/KMZ الذي يحتوي على الدبابيس المحفوظة من البريد الالكتروني، دروب بوكس أو ويب لينك.
-    cs = Zatím nemáte žádné záložky.\nZáložku můžete přidat přidržením libovolného místa na mapě.\nV Organic Maps také umí importovat záložky z jiných zdrojů. Soubor ve formátu KML/KMZ s uloženými záložkami otevřete např. z emailu, Dropboxu nebo webového odkazu v Organic Maps.
-    da = Du har ingen bogmærker endnu.\nTryk på et sted på kortet for at kunne tilføje det til bogmærker. Bogmærker fra andre kilder kan også blive importeret og vist i Organic Maps.\nÅbn en KML/KMZ fil med gemte bogmærker/knappenåle på i Mail, Dropbox eller på et link.
-    nl = Je hebt nog geen bladwijzers.\nTik op een plek op de kaart om een bladwijzer toe te voegen.\nBladwijzers uit andere bronnen kunnen ook worden geïmporteerd en weergegeven in de Organic Maps app. Open KML/KMZ bestand met opgeslagen speldjes uit mail, Dropbox of weblink.
-    fi = Sinulla ei vielä ole kirjanmerkkejä.\nLisää kirjanmerkki napsauttamalla mitä tahansa paikkaa kartalla.\nVoit myös tuoda kirjanmerkkejä muista lähteistä Organic Maps:ssä käytettäviksi avaamalla KML/KMZ-kirjanmerkkitiedoston sähköpostistasi, Dropbox-tililtäsi tai verkko-osoitteesta.
-    fr = Vous n'avez encore aucun signet.\nTouchez n'importe où sur la carte pour en ajouter un.\nLes signets provenant d'autres sources peuvent aussi être importés et affichés dans Organic Maps. Ouvrez des fichiers KML/KMZ contenant des signets enregistrés, à partir d'un courriel, de Dropbox ou d'un lien Web.
-    de = Sie haben bislang noch keine Lesezeichen gesetzt.\nTippen Sie auf der Karte auf irgendeinen Punkt, um ein Lesezeichen hinzuzufügen.\nLesezeichen von anderen Quellen können ebenfalls importiert und in der Organic Maps-App angezeigt werden. KML-/KMZ-Datei mit gespeicherten Stecknadeln aus einer Email, Dropbox oder einem Weblink öffnen.
-    hu = Nincsenek megjelölt helyeid.\nHely megjelöléséhez koppints a térkép bármelyik pontjára.\nSzintén más forrásokból származó könyvjelzőket is beolvashat a Organic Maps programba. Nyisson meg KML/KMZ fájlt egy levélből, Dropbox-ból vagy internetről.
-    id = Belum ada yang ditandai.\nSentuh lokasi apa pun pada peta untuk menandai.\nPenanda dari sumber lainnya juga dapat di impor dan ditampilkan pada Organic Maps. Buka berkas KML/KMZ tersebut dengan penanda yang disimpan dari surel, Dropbox atau tautan jaringan.
-    it = Non hai ancora nessun segnalibro.\nTocca qualsiasi luogo sulla cartina per aggiungere un segnalibro.\nPossono essere anche importati Preferiti da altre fonti e visualizzate nell'app Organic Maps. Apri il file KML/KMZ con i pin salvati da una casella di posta, Dropbox o un link web.
-    ja = 未だブックマークがありません。\nマップ上をタップすればブックマークを追加できます。\nOrganic Maps以外のアプリで作成したブックマークの表示も可能です。KML/KMZ形式のピン情報をメールやDropbox、URLから取得してください。
-    ko = 즐겨찾기가 없습니다.\n즐겨찾기를 추가하도록 지도에 어떤 장소를 누릅니다.\n다른 소스에서 북마크는 Organic Maps 앱에서 가져와서 표시할 수 있습니다. 메일, 드롭박스 또는 웹링크에서 저장한 핀으로 KML/KMZ 파일을 열 수 있습니다.
-    nb = Du har ingen bokmerker enda.\nTrykk på et hvilket som helst sted på kartet for å legge til et bokmerke.\nBokmerker fra andre kilder kan også importeres og vises i Organic Maps. Åpne KML-/KMZ-filer med lagrede bokmerker fra e-post, Dropbox eller internettkobling.
-    pl = Nie oznaczono jeszcze żadnych zakładek.\nProszę dotknąć dowolnego miejsca na mapie, aby dodać zakładkę.\nMożna importować i wyświetlać zakładki z innych zasobów. Program otwiera pliki KML/KMZ z zapisanymi zakładkami, pochodzące z wiadomości email, Dropboxa lub odnośników internetowych.
-    pt = Ainda não tem marcadores.\nToque em qualquer lugar no mapa para adicionar um marcador.\nOs marcadores de outras fontes também podem ser importados e exibidos na aplicação Organic Maps. Abrir ficheiro KML/KMZ com pinos guardados a partir do mail, Dropbox ou ligação web.
-    pt-BR = Você ainda não tem marcadores.\nToque em qualquer lugar no mapa para adicionar um marcador.\nOs marcadores de outras fontes também podem ser importados e exibidos no aplicativo Organic Maps. Abrir arquivo KML/KMZ com favoritos salvos em um email, Dropbox ou em um link para download.
-    ro = Încă nu aveți niciun marcaj.\nAtingeți orice loc de pe hartă pentru a adăuga un marcaj.\nPot fi importate și afișate pe Organic Maps și marcaje din alte surse. Deschideți fișierul KML/KMZ, cu marcajele salvate din email, Dropbox sau de la un link web.
-    es = Todavía no tienes favoritos.\nToca en cualquier lugar del mapa y añade favoritos.\nTambién se pueden importar y mostrar marcadores de otras fuentes en la aplicación Organic Maps. Abre el archivo KML/KMZ con los alfileres guardados desde el correo, Dropbox o Weblink.
-    sv = Du har inga bokmärken än.\nTryck var som helst på kartan för att lägga till ett bokmärke.\nBokmärken från andra källor kan också importeras och visas i Organic Maps. Öppna KML/KMZ filer med sparade bokmärken från mail, Dropbox eller webadress.
-    th = คุณยังไม่มีบุ๊กมาร์ก\nแตะที่ใด ๆ บนแผนที่เพื่อเพิ่มบุ๊กมาร์ก\nสามารถนำเข้าบุ๊กมาร์กจากแหล่งอื่น ๆ และแสดงบน Organic Maps เปิดไฟล์ KML/KMZ ด้วยหมุดที่บันทึกไว้จากอีเมล ดรอปบ็อกซ์ หรือเว็บลิงก์
-    tr = Henüz hiç yer iminiz yok.\nYer imi eklemek için haritada bir yere dokunun.\nBaşka kaynaklardan da yer imleri alınıp Organic Maps’de gösterilebilir KML/KMZ dosyasını posta, Dropbox veya web bağlantısından kaydedilen pinlerle aç.
-    uk = У вас ще немає мiток.\nНатисніть на будь-яке місце на карті, щоб зберегти мiтку.\nМiтки з інших ресурсів також можна імпортувати для застосунка Organic Maps. Відкрийте файл KML/KMZ із збереженими пінами з почти, Dropbox або інтернет посилання.
-    vi = Bạn chưa có điểm đánh dấu.\nChạm vào bất kỳ địa điểm nào trên bản đồ để thêm một điểm đánh dấu.\nĐiểm đánh dấu từ các nguồn khác cũng có thể được nhập và hiển thị trong Organic Maps. Mở tập tin KML/KMZ với các điểm đánh dấu được lưu từ email, Dropbox hoặc liên kết web.
-    zh-Hans = 您还没有书签。\n在地图任何位置轻触以添 加一个书签。\n其他来源的书签也可载入并 显示在 Organic Maps 中。从邮件、 Dropbox 或 weblink 中打开存储有图钉的 KML/KMZ 文 件。
-    zh-Hant = 您還沒有任何書籤。\n點擊地圖上的任何地方以新增書籤。\n其他來源的書籤也可導入在 Organic Maps 中顯示。從電子郵件、Dropbox 或網站連結開啟有著已儲存書籤的 KML/KMZ 檔案。
-    el = Δεν έχετε αγαπημένα ακόμα.\nΠατήστε σε οποιοδήποτε σημείο στο χάρτη για να προσθέσετε αγαπημένο.\nΜπορείτε επίσης να εισάγετε αγαπημένα από άλλες πηγές και να τα εμφανίσετε στο Organic Maps. Ανοίξτε το αρχείο KML/KMZ με τα αποθηκευμένα αγαπημένα από το email, το Dropbox ή τους υπερσυνδέσμους.
-    he = לא יצרת רשימת אתרים עדיין. \n הקש במקום כלשהו על המפה כדי להוסיפה לרשימת האתרים.ניתן ליבא ולהציג ב Organic Maps רשימות אתרים ממקורות אחרים. פתח קובץ  KML/KMZ באמצעות סיכות שמורות ממייל, Dropbox, או קישור לרשת.
-    sk = Zatiaľ nemáte žiadne záložky.\nZáložku môžete pridať pridržaním ľubovolného miesta na mape.\nV Organic Maps môžu byť tiež zobrazené importované záložky z iných zdrojov. Súbor vo formáte KML/KMZ s uloženými záložkami môžete otvoriť napr. z emailu, Dropboxu alebo z webového odkazu.
-    fa = شما تا کنون نشانه ای نداشته اید.\nبر روی مکانی از نقشه لمس کنید تا نشانه ای افزوده شود.\nنشانه ها را می توانید از جایی دیگر وارد کرده و در Organic Maps نمایش دهید.Open KML/KMZ file with saved bookmarks from email, Dropbox or weblink.
 
   [settings]
     comment = Settings button in system menu
-    tags = android, ios
+    tags = ios, android
     en = Settings
     ru = Настройки
     ar = الإعدادات
@@ -2096,9 +1616,9 @@
     zh-Hans = 设置
     zh-Hant = 設定
     el = Ρυθμίσεις
+    fa = تنظیمات
     he = הגדרות
     sk = Nastavenia
-    fa = تنظیمات
 
   [maps_storage]
     comment = Header of settings activity where user defines storage path
@@ -2130,9 +1650,9 @@
     zh-Hans = 将地图保存到
     zh-Hant = 將地圖儲存至
     el = Αποθήκευση χαρτών στο
+    fa = ذخیره نقشه ها در
     sk = Uložiť mapy do
     sw = Hifadhi ramani kwenye
-    fa = ذخیره نقشه ها در
 
   [maps_storage_summary]
     comment = Detailed description of Maps Storage settings button
@@ -2165,9 +1685,9 @@
     zh-Hans = 选取地图应该下载的位置
     zh-Hant = 請選擇下載地圖後要放的位置
     el = Επιλέξτε από που θα γίνει λήψη χαρτών
+    fa = مسیری را که نقشه ها باید در ان دانلود شود را انتخاب کنید
     he = בחר הכתובת במחשבך לשמירת המפות שתוריד
     sk = Vyberte miesto, kam by mali byť mapy sťahované
-    fa = مسیری را که نقشه ها باید در ان دانلود شود را انتخاب کنید
 
   [move_maps]
     comment = Question dialog for transferring maps from one storage to another
@@ -2200,9 +1720,9 @@
     zh-Hans = 移动地图?
     zh-Hant = 移動地圖？
     el = Να γίνει μετακίνηση χαρτών;
+    fa = ایا نقشه ها جابه جا شود؟
     he = להעביר המפות?
     sk = Presunúť mapy?
-    fa = ایا نقشه ها جابه جا شود؟
 
   [wait_several_minutes]
     comment = Ask to wait user several minutes (some long process in modal dialog).
@@ -2235,81 +1755,13 @@
     zh-Hans = 这可能需要几分钟的时间。\n请稍候…
     zh-Hant = 這可能需要幾分鐘\n請稍候…
     el = Αυτό μπορεί να διαρκέσει αρκετά λεπτά. \nΠαρακαλώ περιμένετε…
+    fa = ممکن است چند دقیقه طول بکشد.\nلطفا صبر کنید…
     he = פעולה זו יכולה להמשך מספר דקות.\nהמתן בבקשה…
     sk = Táto akcia môže trvať niekoľko minút.\nProsím čakajte…
-    fa = ممکن است چند دقیقه طول بکشد.\nلطفا صبر کنید...
-
-  [visible]
-    comment = Show bookmarks from this category on a map or not
-    tags = ios
-    en = Visible
-    ru = Показывать на карте
-    ar = مرئي
-    cs = Viditelné
-    da = Synligt
-    nl = Zichtbaar
-    fi = Näkyvä
-    fr = Visible
-    de = Sichtbar
-    hu = látható
-    id = Tampak
-    it = Visibile
-    ja = マップに表示
-    ko = 눈에 보이는
-    nb = Synlig
-    pl = Widoczne
-    pt = Visível
-    pt-BR = Visível
-    ro = Vizibil
-    sv = Synliga
-    th = มองเห็นได้
-    tr = Görünür
-    uk = Показувати на карті
-    vi = Hiện
-    zh-Hans = 可见
-    zh-Hant = 可見
-    el = Ορατό
-    he = נראה
-    sk = Viditeľné
-    fa = قابل مشاهده
-
-  [gps_is_disabled_long_text]
-    comment = Toast which is displayed when GPS has been deactivated
-    tags = android
-    en = GPS is disabled. Please enable it in Settings.
-    ru = GPS-позиционирование выключено. Пожалуйста, включите его в настройках для удобного использования программы.
-    ar = تم تعطيل خاصية نظام تحديد المواقع العالمي. الرجاء تفعيله في الاعدادات.
-    cs = Navigace GPS deaktivována. Prosím, povolte ji v Nastavení.
-    da = GPS er deaktiveret. Aktiver venligst i Indstillinger.
-    nl = GPS is uitgeschakeld. Schakel ze in bij Instellingen.
-    fi = GPS on pois käytöstä. Voit ottaa sen käyttöön asetusvalikosta.
-    fr = Le GPS est désactivé. Veuillez l'activer dans les Paramètres.
-    de = GPS ist deaktiviert. Bitte aktivieren Sie es in den Einstellungen.
-    hu = GPS kikapcsolva. Kérjük kapcsolja be a Beállítások között.
-    id = GPS dinon-aktifkan. Mohon aktifkan lewat Pengaturan.
-    it = Il GPS è disabilitato. Cortesemente abilitalo nelle Impostazioni.
-    ja = GPS機能が無効です。端末の設定画面から有効にしてください。
-    ko = GPS가 사용 중지되었습니다. 설정에서 이를 작동시켜 주시기 바랍니다.
-    nb = GPS er deaktivert. Dette kan aktiveres i «Innstillinger».
-    pl = GPS jest wyłączony. Proszę włączyć go w ustawieniach.
-    pt = O GPS está desativado. Por favor ative-o nas Definições.
-    pt-BR = O GPS está desativado. Por favor ative-o nas Configurações.
-    ro = GPS-ul este dezactivat. Vă rugăm să îl activați din setări.
-    es = El GPS está inhabilitado. Por favor, activelo en los ajustes.
-    sv = GPS har inaktiverats. Vänligen aktivera den i Inställningar.
-    th = มีการปิดใช้งาน GPS โปรดเปิดใช้งานในการตั้งค่า
-    tr = GPS devre dışı bırakıldı. Lütfen Ayarlar bölümünden etkinleştirin.
-    uk = GPS вимкнено в налаштуваннях пристрою. Будь ласка, увімкніть його для зручного використання програми.
-    vi = GPS đã bị tắt. Vui lòng bật nó trong Cài đặt.
-    zh-Hans = GPS 已禁用。请在设置中启用它。
-    zh-Hant = GPS 目前是關閉的，請在系統中設定為啟用
-    he = כבוי. אפשר שימוש בו ב – "הגדרות". GPS ה
-    sk = Navigácia GPS deaktivovaná. Prosím, povoľte ju v Nastaveniach.
-    fa = سرویس موقعیت مکانی شما غیر فعال است.لطفا ان را در تنظیمات فعال کنید
 
   [measurement_units]
     comment = Measurement units title in settings activity
-    tags = ios,android
+    tags = ios, android
     en = Measurement units
     ru = Единицы измерения
     ar = وحدات القياس.
@@ -2338,13 +1790,13 @@
     zh-Hans = 测量单位
     zh-Hant = 測量單位
     el = Μονάδες μέτρησης
+    fa = واحد اندازه گیری
     he = יחידות  מדידה
     sk = Meracie jednotky
-    fa = واحد اندازه گیری
 
   [measurement_units_summary]
     comment = Detailed description of Measurement Units settings button
-    tags = ios,android
+    tags = android
     en = Choose between miles and kilometers
     en-GB = Choose between miles and kilometres
     ru = Использовать километры или мили
@@ -2374,101 +1826,13 @@
     zh-Hans = 选择英里或公里
     zh-Hant = 請選擇公里或英哩
     el = Επιλέξετε ανάμεσα σε μίλια και χιλιόμετρα
+    fa = بین مایل و کیلومتر انتخاب کنید
     he = בחר בין מיילים לקילומטרים
     sk = Vyberte si míle alebo kilometre
-    fa = بین مایل و کیلومتر انتخاب کنید
-
-  [search_mode_all]
-    comment = Do search in all sources
-    tags = ios,android
-    en = Everywhere
-    ru = Везде
-    ar = كل مكان
-    cs = Všude
-    da = Overalt
-    nl = Overal
-    fr = Partout
-    de = Überall
-    hu = Mindenütt
-    it = Ovunque
-    ja = 全マップから検索
-    ko = 모든 곳
-    pl = Wszędzie
-    pt = Em toda a parte
-    pt-BR = Em todos os locais
-    es = Todos
-    sv = Överallt
-    th = ทุกที่
-    tr = Her Yerde
-    uk = Всюди
-    zh-Hans = 到处
-    zh-Hant = 任何地方
-    he = בכל מקום
-    sk = Všade
-    fa = همه جا
-
-  [search_mode_nearme]
-    comment = Do search near my position only
-    tags = ios,android
-    en = Near Me
-    ru = Возле меня
-    ar = بجواري
-    cs = V mé blízkosti
-    da = Tæt på mig
-    nl = Dichtbij mij
-    fr = Près de moi
-    de = In meiner Nähe
-    hu = A közelben
-    it = Vicino a me
-    ja = 現在地周辺
-    ko = 근처 검색
-    pl = W pobliżu mnie
-    pt = Perto de mim
-    pt-BR = Perto de mim
-    es = Cerca de mí
-    sv = I närheten
-    th = ใกล้ฉัน
-    tr = Yakınlarımda
-    uk = Поруч
-    zh-Hans = 靠近我的
-    zh-Hant = 我的附近
-    he = בסביבתי
-    sk = V mojom okolí
-    fa = اطراف من
-
-  [search_mode_viewport]
-    comment = Do search in current viewport only
-    tags = ios,android
-    en = On the Screen
-    ru = На экране
-    ar = على الشاشة
-    cs = Na obrazovce
-    da = På skærmen
-    nl = Op het scherm
-    fr = À l'écran
-    de = Auf dem Bildschirm
-    hu = A képernyőn
-    it = Nella schermata
-    ja = マップ表示範囲
-    ko = 화면에
-    pl = Na ekranie
-    pt = No ecrã
-    pt-BR = Na tela
-    es = En la pantalla
-    sv = På skärmen
-    th = บนหน้าจอ
-    tr = Ekranda
-    uk = На екрані
-    zh-Hans = 在屏幕上
-    zh-Hant = 畫面中
-    he = על המסך
-    sk = Na obrazovke
-    fa = روی صفحه نمایش بده
 
   [eat]
-    comment = Search team review required on any change
     comment = Search category for cafes, bars, restaurants
-    tags = ios,android
+    tags = ios, android
     en = Where to eat
     ru = Где поесть
     ar = مكان لتناول الطعام
@@ -2494,16 +1858,16 @@
     tr = Nerede yenir
     uk = Де поїсти
     vi = Ăn ở đâu
-    el = Πού να φάμε
-    sk = Kde sa najesť
-    sw = Sehemu ya kula
     zh-Hans = 在哪儿吃
     zh-Hant = 在哪兒吃
+    el = Πού να φάμε
     fa = کجا غذا بخوریم
+    sk = Kde sa najesť
+    sw = Sehemu ya kula
 
   [food]
     comment = Search category for grocery stores
-    tags = ios,android
+    tags = ios, android
     en = Groceries
     ru = Продукты
     ar = المشتريات
@@ -2529,17 +1893,16 @@
     tr = Bakkaliye
     uk = Продукти
     vi = Cửa hàng tạp hóa
-    el = Παντοπωλεία
-    sk = Potraviny
-    sw = Migahawani
     zh-Hans = 食品
     zh-Hant = 食物
+    el = Παντοπωλεία
     fa = عطاری
+    sk = Potraviny
+    sw = Migahawani
 
   [transport]
-    comment = Search team review required on any change
     comment = Search category
-    tags = ios,android
+    tags = ios
     en = Transport
     ru = Транспорт
     ar = نقل
@@ -2568,14 +1931,13 @@
     zh-Hans = 交通
     zh-Hant = 運輸
     el = Συγκοινωνία
+    fa = حمل و نقل
     he = תחבורה
     sk = Doprava
-    fa = حمل و نقل
 
   [fuel]
-    comment = Search team review required on any change
     comment = Search category
-    tags = ios,android
+    tags = ios, android
     en = Gas
     en-GB = Petrol
     ru = Заправка
@@ -2605,14 +1967,13 @@
     zh-Hans = 汽油
     zh-Hant = 加油站
     el = Βενζίνη
+    fa = سوخت
     he = גז
     sk = Čerpacia stanica
-    fa = سوخت
 
   [parking]
-    comment = Search team review required on any change
     comment = Search category
-    tags = ios,android
+    tags = ios, android
     en = Parking
     ru = Парковка
     ar = الاصطفاف
@@ -2641,14 +2002,13 @@
     zh-Hans = 停车
     zh-Hant = 停車場
     el = Χώρος στάθμευσης
+    fa = پارکینگ
     he = חניה
     sk = Parkovisko
-    fa = پارکینگ
 
   [shopping]
-    comment = Search team review required on any change
     comment = Search category for clothes/shoes/gifts/jewellery/sport shops
-    tags = ios,android
+    tags = ios
     en = Shopping
     ru = Шоппинг
     ar = التسوق
@@ -2674,17 +2034,16 @@
     tr = Alışveriş
     uk = Шопінг
     vi = Đi mua sắm
-    el = Ψώνια
-    sk = Nakupovanie
-    sw = Manunuzi
     zh-Hans = 购物
     zh-Hant = 購物
+    el = Ψώνια
     fa = خرید کردن
+    sk = Nakupovanie
+    sw = Manunuzi
 
   [hotel]
-    comment = Search team review required on any change
     comment = Search category
-    tags = ios,android
+    tags = ios
     en = Hotel
     ru = Гостиница
     ar = فندق
@@ -2713,14 +2072,13 @@
     zh-Hans = 旅店
     zh-Hant = 飯店
     el = Ξενοδοχείο
+    fa = هتل
     he = מלון
     sk = Hotel
-    fa = هتل
 
   [tourism]
-    comment = Search team review required on any change
     comment = Search category
-    tags = ios,android
+    tags = ios
     en = Sights
     ru = Достопримечательность
     ar = سياحة
@@ -2749,14 +2107,13 @@
     zh-Hans = 景点
     zh-Hant = 旅遊景點
     el = Αξιοθέατα
+    fa = منظره
     he = נקודות עיניין
     sk = Pamätihodnosť
-    fa = منظره
 
   [entertainment]
-    comment = Search team review required on any change
     comment = Search category
-    tags = ios,android
+    tags = ios
     en = Entertainment
     ru = Развлечения
     ar = التسلية
@@ -2785,14 +2142,13 @@
     zh-Hans = 娱乐
     zh-Hant = 娛樂
     el = Ψυχαγωγία
+    fa = سرگرمی
     he = בידור
     sk = Zábava
-    fa = سرگرمی
 
   [atm]
-    comment = Search team review required on any change
     comment = Search category
-    tags = ios,android
+    tags = ios, android
     en = ATM
     ru = Банкомат
     ar = ماكينة الصراف الآلي
@@ -2821,14 +2177,13 @@
     zh-Hans = 自动取款机
     zh-Hant = 自動櫃員機
     el = ATM
+    fa = خود پرداز
     he = כספומט
     sk = Bankomat
-    fa = خود پرداز
 
   [nightlife]
-    comment = Search team review required on any change
     comment = Search category for nightclubs/bars
-    tags = ios,android
+    tags = ios
     en = Nightlife
     ru = Ночная жизнь
     ar = أنشطة ترفيه ليلية
@@ -2854,17 +2209,16 @@
     tr = Gece hayatı
     uk = Нічне життя
     vi = Cuộc sống về đêm
-    el = Νυχτερινή Ζωή
-    sk = Nočný život
-    sw = Shughuli za usiku
     zh-Hans = 夜生活
     zh-Hant = 夜生活
+    el = Νυχτερινή Ζωή
     fa = تفریحات شبانه
+    sk = Nočný život
+    sw = Shughuli za usiku
 
   [children]
-    comment = Search team review required on any change
     comment = Search category for water park/disneyland/playground/toys store
-    tags = ios,android
+    tags = ios
     en = Family holiday
     ru = Отдых с детьми
     ar = عطلة عائلية
@@ -2890,17 +2244,16 @@
     tr = Aile tatili
     uk = Відпочинок з дітьми
     vi = Kỳ nghỉ gia đình
-    el = Οικογενειακές Διακοπές
-    sk = Rodinná dovolenka
-    sw = Mapumziko ya familia
     zh-Hans = 亲子休闲
     zh-Hant = 親子休閒
+    el = Οικογενειακές Διακοπές
     fa = تعطیلات خانوادگی
+    sk = Rodinná dovolenka
+    sw = Mapumziko ya familia
 
   [bank]
-    comment = Search team review required on any change
     comment = Search category
-    tags = ios,android
+    tags = ios
     en = Bank
     ru = Банк
     ar = بنك
@@ -2929,14 +2282,13 @@
     zh-Hans = 银行
     zh-Hant = 銀行
     el = Τράπεζα
+    fa = بانک
     he = בנק
     sk = Banka
-    fa = بانک
 
   [pharmacy]
-    comment = Search team review required on any change
     comment = Search category
-    tags = ios,android
+    tags = ios
     en = Pharmacy
     ru = Аптека
     ar = صيدلية
@@ -2965,14 +2317,13 @@
     zh-Hans = 药店
     zh-Hant = 藥局
     el = Φαρμακείο
+    fa = داروخانه
     he = בית מרקחת
     sk = Lekáreň
-    fa = داروخانه
 
   [hospital]
-    comment = Search team review required on any change
     comment = Search category
-    tags = ios,android
+    tags = ios
     en = Hospital
     ru = Больница
     ar = مستشفى
@@ -3001,15 +2352,14 @@
     zh-Hans = 医院
     zh-Hant = 醫院
     el = Νοσοκομείο
+    fa = بیمارستان
     he = בית חולים
     sk = Nemocnica
     sw = Hospitali
-    fa = بیمارستان
 
   [toilet]
-    comment = Search team review required on any change
     comment = Search category
-    tags = ios,android
+    tags = ios
     en = Toilet
     ru = Туалет
     ar = حمام
@@ -3038,14 +2388,13 @@
     zh-Hans = 厕所
     zh-Hant = 廁所
     el = Τουαλέτα
+    fa = توالت
     he = שירותים
     sk = Záchody
-    fa = توالت
 
   [post]
-    comment = Search team review required on any change
     comment = Search category
-    tags = ios,android
+    tags = ios
     en = Post
     ru = Почта
     ar = بريد
@@ -3074,14 +2423,13 @@
     zh-Hans = 邮政
     zh-Hant = 郵局
     el = Ταχυδρομείο
+    fa = صندوق پست
     he = דואר
     sk = Pošta
-    fa = صندوق پست
 
   [police]
-    comment = Search team review required on any change
     comment = Search category
-    tags = ios,android
+    tags = ios
     en = Police
     ru = Полиция
     ar = شرطة
@@ -3110,47 +2458,13 @@
     zh-Hans = 警察
     zh-Hant = 警察局
     el = Αστυνομία
+    fa = پلیس
     he = משטרה
     sk = Polícia
-    fa = پلیس
-
-  [no_search_results_found]
-    comment = String in search result list, when nothing found
-    tags = ios,android
-    en = No results found
-    ru = Нет результатов поиска
-    ar = لم يتم العثور على أي نتائج
-    cs = Žádné výsledky
-    da = Ingen resultater
-    nl = Geen resultaten gevonden
-    fi = Tuloksia ei löytynyt
-    fr = Aucun résultat trouvé
-    de = Keine Ergebnisse gefunden
-    hu = Nincs keresési találat
-    id = Tidak ada hasil yang ditemukan
-    it = Nessun risultato trovato
-    ja = 検索結果が見つかりませんでした
-    ko = 결과 없음
-    nb = Ingen resultater funnet
-    pl = Nie odnaleziono
-    pt = Não foram encontrados resultados
-    pt-BR = Nenhum resultado encontrado
-    ro = Nu s-a găsit niciun rezultat.
-    es = No se han encontrado resultados
-    sv = Inga resultat
-    th = ไม่พบผลลัพธ์
-    tr = Sonuç bulunamadı
-    uk = Результатів не знайдено
-    vi = Không tìm thấy kết quả nào
-    zh-Hans = 没有找到结果
-    zh-Hant = 找不到搜尋結果
-    he = לא נמצאו תוצאות
-    sk = Žiadne výsledky
-    fa = نتیجه ای یافت نشد
 
   [description]
     comment = Notes field in Bookmarks view
-    tags = ios,android
+    tags = android
     en = Notes
     ru = Примечание
     ar = ملاحظات
@@ -3179,47 +2493,13 @@
     zh-Hans = 注释
     zh-Hant = 描述說明
     el = Σημειώσεις
+    fa = یادداشت ها
     he = הערות
     sk = Poznámky
-    fa = یادداشت ها
-
-  [share_by_email]
-    comment = Button text
-    tags = ios,android
-    en = Share by email
-    ru = Послать по email
-    ar = مشاركة بواسطة البريد الالكتروني
-    cs = Sdílet emailem
-    da = Del via email
-    nl = Delen via email
-    fi = Jaa sähköpostilla
-    fr = Partager par courriel
-    de = Per Email teilen
-    hu = Megosztás email-en
-    id = Bagikan menggunakan surel
-    it = Condividi via email
-    ja = Eメールで共有
-    ko = 이메일로 공유
-    nb = Del på e-post
-    pl = Udostępnij przez email
-    pt = Partilhar por email
-    pt-BR = Compartilhar por email
-    ro = Partajare prin email
-    es = Enviar por email
-    sv = Dela via email
-    th = แชร์จากอีเมล
-    tr = E-postayla paylaş
-    uk = Подiлитися по електронній пошті
-    vi = Chia sẻ bằng email
-    zh-Hans = 邮件分享
-    zh-Hant = 以電子郵件分享
-    el = Κοινοποίηση μέσω ηλεκτρονικού ταχυδρομείου
-    he = שתף  במייל
-    fa = اشتراک گذاری به وسیله ایمیل
 
   [share_bookmarks_email_subject]
     comment = Email Subject when sharing bookmarks category
-    tags = ios,android
+    tags = android
     en = Organic Maps bookmarks were shared with you
     ru = С вами поделились метками Organic Maps
     ar = تم مشاركة اشارات Organic Maps المرجعية معك
@@ -3252,12 +2532,13 @@
     sk = Zdielané záložky Organic Maps
 
   [share_bookmarks_email_body]
+    tags = android
     en = Hello!\n\nAttached are my bookmarks from Organic Maps app. Please open them if you have Organic Maps installed. Or, if you don't, download the app for your iOS or Android device by following this link: https://omaps.app/get?kmz\n\nEnjoy traveling with Organic Maps!
     ru = Здравствуйте!\n\nВ прикрепленном файле мои метки из офлайновых карт Organic Maps. Для того чтобы открыть этот файл, вам потребуется приложение Organic Maps, которое можно установить по ссылке: https://omaps.app/get?kmz\n\nСпасибо!
 
   [load_kmz_title]
     comment = message title of loading file
-    tags = ios,android
+    tags = ios, android
     en = Loading Bookmarks
     ru = Загрузка меток
     ar = تحميل الإشارات المرجعية
@@ -3286,13 +2567,13 @@
     zh-Hans = 加载书签
     zh-Hant = 正在載入書籤…
     el = Φόρτωση αγαπημένων
+    fa = در حال بارگیری نشانه ها
     he = טוען רשימות אתרים
     sk = Načítavanie záložiek
-    fa = در حال بارگیری نشانه ها
 
   [load_kmz_successful]
     comment = Kmz file successful loading
-    tags = ios,android
+    tags = ios, android
     en = Bookmarks loaded successfully! You can find them on the map or on the Bookmarks Manager screen.
     ru = Метки успешно загружены! Вы можете увидеть их на карте или в ваших сохраненных метках.
     ar = تم تحميل الإشارات المرجعية بنجاح! يمكنك العثور عليها على الخريطة أو على شاشة إدارة الإشارات المرجعية.
@@ -3321,13 +2602,13 @@
     zh-Hans = 书签加载成功!您可以在地图或书签管理窗 口中找到它们。
     zh-Hant = 書籤上傳成功！ 您可以在地圖上或是書籤管理畫面中找到書籤。
     el = Τα αγαπημένα φορτώθηκαν με επιτυχία! Μπορείτε να τα βρείτε στο χάρτη ή στην οθόνη Διαχείριση αγαπημένων.
+    fa = نشانه ها با موفقیت بارگذاری شد!شما می توانید ان ها را در نقشه یا بخش مدیریت نشانه ها بیابید
     he = רשימת האתרים הועלתה בהצלחה! תוכל למצוא אותה על המפה או במסך נהול רשימות האתרים.
     sk = Záložky boli úspešne načítané! Môžete ich nájst na mape alebo na obrazovke Správca záložiek.
-    fa = نشانه ها با موفقیت بارگذاری شد!شما می توانید ان ها را در نقشه یا بخش مدیریت نشانه ها بیابید
 
   [load_kmz_failed]
     comment = Kml file loading failed
-    tags = ios,android
+    tags = ios, android
     en = Bookmarks upload failed. The file may be corrupted or defective.
     ru = Файл с метками не был загружен. Возможно, файл поврежден или неисправен.
     ar = فشلت عملية تحميل الإشارات المرجعية. قد يكون الملف تالف.
@@ -3356,9 +2637,9 @@
     zh-Hans = 书签上传失败。该文件可能已损坏或有缺陷。
     zh-Hant = 書籤上傳失敗。 檔案可能有毀損或是不完全。
     el = Η μεταφόρτωση των αγαπημένων απέτυχε. Το αρχείο μπορεί να είναι κατεστραμμένο ή ελαττωματικό.
+    fa = بارگذاری نشانه ها با شکست مواجح شد.ممکن است فایل اسیب دیده یا معیوب باشد
     he = טעינת רשימת האתרים נכשלה. יתכן שהקובץ פגום.
     sk = Načítavanie záložiek sa nepodarilo. Súbor môže byť poškodený alebo chybný.
-    fa = بارگذاری نشانه ها با شکست مواجح شد.ممکن است فایل اسیب دیده یا معیوب باشد
 
   [edit]
     comment = resource for context menu
@@ -3389,13 +2670,13 @@
     zh-Hans = 编辑
     zh-Hant = 編輯
     el = Επεξεργασία
+    fa = ویرایش
     he = ערוך
     sk = Upraviť
-    fa = ویرایش
 
   [unknown_current_position]
     comment = Warning message when doing search around current position
-    tags = ios,android
+    tags = android
     en = Your location hasn't been determined yet
     ru = Ваше местоположение еще не определено
     ar = لم يتم التعرف على موقعك بعد.
@@ -3424,77 +2705,9 @@
     zh-Hans = 您的位置尚未确定
     zh-Hant = 您的位置尚未定位完成
     el = Η τοποθεσία σας δεν έχει καθοριστεί ακόμη
+    fa = مکان شما هنوز مشخص نشده است
     he = מיקומך לא אותר עדיין
     sk = Vaša poloha zatiaľ nebola určená
-    fa = مکان شما هنوز مشخص نشده است
-
-  [download_location_country]
-    comment = Warning message when location country isn't downloaded during search (see also download_location_map_proposal).
-    tags = ios,android
-    en = Download the map of your current location (%@)
-    ru = Скачайте страну вашего текущего местоположения (%@)
-    ar = تنزيل دولة (%@) موقعك الحالي
-    cs = Stahování země vaší aktuální polohy (%@)
-    da = Download landet bestemt ud fra din nuværende lokation (%@)
-    nl = Download land waar je nu bent (%@)
-    fi = Lataa nykyisen sijainnin (%@) maa
-    fr = Télécharger le pays de votre position actuelle (%@)
-    de = Land Ihres derzeitigen Standorts herunterladen (%@)
-    hu = Töltse le az aktuális helyzet országát (%@)
-    id = Unduh negara di mana Anda berada saat ini (%@)
-    it = Scarica il paese della tua posizione attuale (%@)
-    ja = 現在の地域をダウンロード(%@)
-    ko = 귀하께서 현재 계신 국가인 을(를) 다운로드 (%@)
-    nb = Last ned det landet du befinner deg i (%@)
-    pl = Pobierz mapę kraju, w którym aktualnie przebywasz (%@)
-    pt = Descarregue o país da sua localização atual (%@)
-    pt-BR = Baixe o país da sua localização atual (%@)
-    ro = Descărcați hărțile pentru țara în care vă aflați (%@).
-    es = Descargar país de tu ubicación actual (%@)
-    sv = Ladda ner landet vid din nuvarande position (%@)
-    th = ดาวน์โหลด (%@) ประเทศของตำแหน่งที่ตั้งปัจจุบันของคุณ
-    tr = Geçerli konumuzun (%@) ülkesini indirin
-    uk = Завантажити країну вашого поточного місця розташування (%@)
-    vi = Tải xuống quốc gia của vị trí hiện tại của bạn (%@)
-    zh-Hans = 下载您所在位置的国家 (%@)
-    zh-Hant = 下載您目前所在位置的國家 地圖 (%@)
-    el = Κατεβάστε τον χάρτη για την τρέχουσα τοποθεσία σας (%@)
-    he = הורד המדינה (%@) בה אתה נמצא כעת
-    sk = Sťahovanie krajiny vašej aktuálnej polohy (%@)
-    fa = دانلود نقشه مکان فعلی شما (%@)
-
-  [download_viewport_country_to_search]
-    comment = Warning message when viewport country isn't downloaded during search
-    tags = ios,android
-    en = Download the country you are searching on (%@)
-    ru = Скачайте страну, на которой вы ищете (%@)
-    ar = تنزيل الدولة (%@) التي تبحث فيها
-    cs = Stahování země, v níž hledáte (%@)
-    da = Download landet som du har søgt på (%@)
-    nl = Download land waar je op wilt zoeken (%@)
-    fi = Lataa hakemasi sijainnin (%@) maa
-    fr = Télécharger le pays que vous recherchez (%@)
-    de = Land herunterladen, in dem Sie suchen (%@)
-    hu = Töltse le a keresés országát (%@)
-    id = Unduh negara yang lokasinya sedang Anda cari (%@)
-    it = Scarica il paese che stai cercando (%@)
-    ja = 現在マップで検索している国をダウンロード(%@)
-    ko = 귀하께서 검색 중인 국가인 을(를) 다운로드 (%@)
-    nb = Last ned det landet du søker på (%@)
-    pl = Pobierz mapę kraju, którego aktualnie poszukujesz (%@)
-    pt = Descarregue o país em que está a fazer a procura (%@)
-    pt-BR = Baixe o país em que você está buscando (%@)
-    ro = Descărcați hărțile pentru țara pe care o căutați pe (%@).
-    es = Descargar país en el que estás buscando (%@)
-    sv = Ladda ner landet du söker på (%@)
-    th = ดาวน์โหลดประเทศ (%@) ที่คุณกำลังค้นหา
-    tr = Aradığınız (%@) ülkesini indirin
-    uk = Завантажити країну, в якій ви шукаєте (%@)
-    vi = Tải xuống quốc gia bạn đang tìm kiếm trên (%@)
-    zh-Hans = 下载您所搜索的国家 (%@)
-    zh-Hant = 下載您正在搜尋的國家 地圖 (%@)
-    he = הורד המדינה (%@) בה אתה מחפש כרגע
-    sk = Sťahovanie krajiny, v ktorej hľadáte (%@)
 
   [cant_change_this_setting]
     comment = Alert message that we can't run Map Storage settings due to some reasons.
@@ -3527,9 +2740,9 @@
     zh-Hans = 抱歉,地图存储设置目前被禁用
     zh-Hant = 很抱歉，地圖儲存設定目前已停用。
     el = Λυπούμαστε, η αποθήκευση του χάρτη είναι προς το παρόν απενεργοποιημένη.
+    fa = متاسفانه,تنظیمات ذخیره سازی نقشه در حال حاظر غیر فعال است
     he = . פעילה כרגע מצטערים, הגדרת "שמירת מפה" אינה
     sk = Prepáčte, nastavenie uloženia máp je dočasne nedostupné.
-    fa = متاسفانه,تنظیمات ذخیره سازی نقشه در حال حاظر غیر فعال است
 
   [downloading_is_active]
     comment = Alert message that downloading is in progress.
@@ -3562,112 +2775,13 @@
     zh-Hans = 国家下载进行中。
     zh-Hant = 國家地圖正在進行下載
     el = Λήψη χάρτη σε εξέλιξη.
+    fa = دانلود نقشه اکنون در حال انجام است
     he = הודת מפת המדינה מתבצעת כרגע.
     sk = Práve prebieha sťahovanie krajiny.
-    fa = دانلود نقشه اکنون در حال انجام است
-
-  [appStore_message]
-    comment = Message that will be shown in alert view, when we ask user to leave review on App Store
-    tags = ios
-    en = Hope you enjoy using Organic Maps! If so, please rate or review the app at the App Store. It takes less than a minute but can really help us. Thanks for your support!
-    ru = Надеемся, вам нравится пользоваться Organic Maps! Если так, то оставьте, пожалуйста, отзыв в магазине приложений. Это занимает меньше минуты, но может нам реально помочь. Спасибо вам за поддержку!
-    ar = نأمل أن تكون قد استمتعت باستخدام Organic Maps! إذا كان الأمر كذلك، الرجاء تقييم التطبيق في App Store. يستغرق ذلك أقل من دقيقة لكنه يفيدنا بالفعل. شكرا لك على دعمك!
-    cs = Doufáme, že se vám používání Organic Maps líbí! Je-li tomu tak, ohodnoťte, prosím, naši aplikaci nebo na ni napište recenzi v obchodu s aplikacemi. Nezabere to ani minutu, ale opravdu nám tím pomůžete. Děkujeme za vaši podporu!
-    da = Vi håber du er glad for at bruge Organic Maps! Hvis du er, vil du så overveje at bedømme og måske skrive en anmeldelse på App Store? Det tager under et minut, men det kan virkelig hjælpe os. Tak for din hjælp!
-    nl = Ik hoop dat u veel plezier hebt met Organic Maps! Zo ja, geef de app dan een cijfer in de App Store of schrijf een recensie. Dit duurt minder dan een minuut, maar kan ons echt helpen. Bedankt voor uw steun!
-    fi = Toivottavasti nautit Organic Maps -sovelluksen käyttämisestä! Olisimme tyytyväisiä, jos voisit arvioida sovelluksen App Storessa. Se kesää alle minuutin, ja auttaa meitä todella paljon. Kiitos tuestasi!
-    fr = Nous espérons que vous appréciez l'utilisation de Organic Maps ! Si oui, veuillez évaluer l'appli ou laisser une critique sur l'App Store. Cela prend moins d'une minute, mais peut vraiment nous aider. Merci pour votre soutien !
-    de = Wir hoffen, dass Ihnen die Verwendung von Organic Maps Freude bereitet! Wenn ja, geben Sie bitte eine Bewertung oder einen Bericht für die App im App Store ab. Es dauert weniger als eine Minute, kann uns aber wirklich helfen. Danke für Ihre Unterstützung!
-    hu = Reméljük élvezi a Organic Maps használatát. Ha igen, kérjük írjon ajánlást az App Store-ban! Kevesebb mint egy perc, és valóban segít nekünk. Köszönjük!
-    id = Kami harap Anda senang menggunakan Organic Maps! Jika ya, mohon beri nilai atau ulasan untuk aplikasi ini di App Store. Hanya memakan waktu kurang dari satu menit tetapi hal itu dapat benar-benar membantu kami. Terima kasih atas dukungan Anda!
-    it = Confidiamo nel fatto che sia piacevole utilizzare Organic Maps! In caso positivo, ti preghiamo di valutare o recensire l'app all'interno dell'app store. Ti porterà via meno di un minuto e la cosa ci aiuterebbe tantissimo. Grazie per il tuo sostegno!
-    ja = Organic Mapsの使い心地はいかがでしょうか。もしよろしければ、App Storeでレビューや評価をお知らせください。皆様からいただく一言が開発の励みになります。ご支援をよろしくお願いいたします！
-    ko = Organic Maps로 즐거운 시간을 보내시기 바랍니다! Organic Maps가 마음에 드신다면 앱스토어에서 평가를 남겨 주시기 바랍니다. 평가하는 데는 1분이 채 걸리지 않지만 저희에게 큰 도움이 됩니다. 성원해 주셔서 감사합니다!
-    nb = Håper du liker å bruke Organic Maps! Hvis du gjør det er det flott om du rangerer eller vurderer appen på App Store. Det tar deg mindre enn ett minutt, men kan virkelig hjelpe oss. Takk for støtten!
-    pl = Mamy nadzieję, że podoba ci się aplikacja Organic Maps! Jeśli tak to proszę oceń ją lub napisz recenzję w AppStore. To zajmie mniej niż minutę, a bardzo nam pomoże. Dziękujemy za wsparcie!
-    pt = Esperamos que esteja a disfrutar da utilização do Organic Maps! Se assim for, por favor classifique ou dê a sua opinião sobre a app na App Store. Vai demorar menos de um minuto mas pode mesmo ajudar-nos. Obrigado pelo seu apoio!
-    pt-BR = Esperamos que você esteja gostando de usar o Organic Maps! Se estiver, por favor nos avalie ou dê a sua opinião sobre a app na App Store. Demora menos de um minuto mas pode nos ajudar muito. Obrigado pelo seu apoio!
-    ro = Sperăm că vă place Organic Maps! Dacă da, vă rugăm să o votați sau să scrieți o recenzie în App Store. Durează mai puțin de un minut, dar pe noi ne ajută foarte mult. Vă mulțumim pentru susținere!
-    es = ¡Ojalá disfrute mucho con Organic Maps! Si le gusta, le agradeceremos que puntúe nuestra aplicación en el App Store. Es menos de un minuto y nos sería de gran ayuda. ¡Gracias por su apoyo!
-    sv = Hoppas du gillar att använda Organic Maps! I så fall, skriv en recension eller ge ett betyg på App Store. Det tar mindre än en minut men kan verkligen hjälpa oss. Tack för din hjälp!
-    th = หวังว่าคุณจะสนุกกับการใช้ Organic Maps! หากเป็นเช่นนั้น โปรดให้คะแนนหรือวิจารณ์แอปได้ที่แอปสโตร์ (App Store) มันจะใช้เวลาไม่เกินหนึ่งนาทีแต่สามารถช่วยเหลือเราได้ ขอบคุณสำหรับการสนับสนุนของคุณ!
-    tr = Organic Maps kullanmaktan keyif aldığınızı umuyoruz! Öyleyse, lütfen App Store’da uygulamaya puan verin veya uygulama hakkında yorum yapın. Bir dakikadan daha kısa sürer ama bize gerçekten yardımcı olabilir. Desteğiniz için teşekkürler!
-    uk = Сподіваємося, що вам сподобалося користуватися Organic Maps! Якщо так, будь ласка, надайте оцінку програмі або залиште свій відгук на app store. Витративши менше хвилини, ви дійсно нам допоможете. Дякуємо за вашу підтримку!
-    vi = Hi vọng bạn thích sử dụng Organic Maps! Nếu vậy, bạn vui lòng cho điểm hoặc đánh giá ứng dụng trên App Store. Việc này chỉ tốn dưới một phút và sẽ giúp chúng tôi rất nhiều. Cảm ơn bạn đã ủng hộ!
-    zh-Hans = 希望您喜欢使用 Organic Maps! 若确实喜欢, 请在应用商店对此应用进行打分和点评。这 花不了一分钟但却可以实在地帮助我们。感 谢您的支持!
-    zh-Hant = 祝您使用 Organic Maps 愉快！ 方便的話，請到 App Store 幫我們評分或寫寫評論。在這短短的時間當中卻能夠真正的協助我們改善，再次感謝您的支持！
-    sk = Dúfame, že sa vám používánie Organic Maps páči! Ak to je tak, ohodnoťte prosím našu aplikáciu alebo napíšte na ňu recenziu v Obchode s aplikáciami. Nezaberie vám to ani minútu času, ale nám s tým môžete veľmi pomôoť. Ďakujeme vám za vašu podporu!
-    fa = امیدواریم از استفاده از این اپ لذت برده باشد!اگر اینطور است به این اپ در استور ستاره بدهید و نظر خود را بنویسید.این کار کمتر از یک دقیقه زمان می برد اما حقیقتا می تواند به ما کمک کند.از حمایت صمیمانه تان متشکریم.
-
-  [no_thanks]
-    comment = No, thanks
-    tags = ios,android
-    en = No, thanks
-    ru = Нет, спасибо
-    ar = لا، شكرا
-    cs = Ne, díky
-    da = Nej, tak
-    nl = Nee, bedankt
-    fi = Ei kiitos
-    fr = Non, merci
-    de = Nein danke
-    hu = Köszönöm, nem
-    id = Tidak, terima kasih
-    it = No, grazie
-    ja = いいえ
-    ko = 평가하지 않겠습니다
-    nb = Nei takk
-    pl = Nie, dziękuję
-    pt = Não, obrigado
-    ro = Nu, mulțumesc
-    es = No, gracias
-    sv = Nej, tack
-    th = ไม่ ขอบคุณ
-    tr = Hayır, teşekkürler
-    uk = Ні, дякую
-    vi = Không, cảm ơn
-    zh-Hans = 不,谢谢
-    zh-Hant = 不，謝了
-    he = לא, תודה
-    sk = Nie, ďakujem
-    fa = نه ,متشکرم
-
-  [bookmark_share_sms]
-    comment = Share one specific bookmark using SMS, %1$@ contains om:// and %2$@ https://omaps.app link. @NOTE non-ascii symbols in the link will result in max 70 characters SMS instead of 140.
-    tags = ios,android
-    en = Hey, check out my pin at Organic Maps! %1$@ or %2$@ Don't have offline maps installed? Download here: https://omaps.app/get
-    ru = Моя метка на карте. Жми %1$@ или %2$@
-    ar = هاي، تفقد الدبوس الخاص بي على Organic Maps! %1$@ أو %2$@. ليس لديك أي خرائط تعمل بدون الاتصال مع الانترنت مثبتة على جهازك؟ قم بتحميلها من هنا: https://omaps.app/get
-    cs = Koukni na mou značku na mapě. Otevři odkaz: %1$@ nebo %2$@
-    da = Hey, tjek min knappenål på Organic Maps ud! %1$@ or %2$@ Har du ikke offline kort? Download her: https://omaps.app/get
-    nl = Bekijk mijn pin op de kaart. Open %1$@ of %2$@
-    fi = Hei, katso merkintäni Organic Maps-sovelluksessa! %1$@ tai %2$@ Eikö sinulla ole offline-karttoja? Lataa ne täältä: https://omaps.app/get
-    fr = Hé, regarde mon épingle sur Organic Maps ! %1$@ ou %2$@. Les cartes hors ligne ne sont pas installées ? Les télécharger ici : https://omaps.app/get
-    de = Siehe meine Markierung auf Organic Maps an. %1$@ oder %2$@ - Keine Offline-Karten installiert? Hier herunterladen: https://omaps.app/get
-    hu = Nézd meg a Organic Maps jelzőt! %1$@ vagy %2$@ A program letöltése: https://omaps.app/get
-    id = Hei, lihat pinku di Organic Maps! %1$@ atau %2$@ belum memiliki peta offline? Unduh di sini: https://omaps.app/get
-    it = Vedi pin sulla mappa. Apri %1$@ o %2$@
-    ja = 私のピン情報はこの位置です。リンク: %1$@, %2$@
-    ko = 지도에서 내 PIN을 참조하십시오. %1$@ 또는 %2$@ 열기
-    nb = Hei, se merket mitt på Organic Maps! %1$@ eller %2$@ Har du ikke installert offline-kart? Last dem ned her: https://omaps.app/get
-    pl = Mój znacznik w Organic Maps %1$@ i %2$@
-    pt = Veja o meu marcador no mapa do Organic Maps. Abra a hiperligação: %1$@ ou %2$@
-    pt-BR = Veja o meu marcador no mapa do Organic Maps. Abra o link: %1$@ ou %2$@ Não tem um mapa offline instalado? Baixe aqui: https://omaps.app/get
-    ro = Hei, poți vedea care este poziția mea pe Organic Maps! %1$@ sau %2$@ Nu ai instalate hărțile offline? Descarcă de aici: https://omaps.app/get
-    es = Ve mi alfiler en mapa. Abre %1$@ o %2$@
-    sv = Hej, kolla på min pin på Organic Maps! %1$@ eller %2$@ Har du inte offline-kartor installerat? Ladda ner här: https://omaps.app/get
-    th = เฮ้ ตรวจสอบหมุดของฉันที่ Organic Maps! %1$@ หรือ %2$@
-    tr = Hey, Organic Maps’de pinimi incele! %1$@ veya %2$@ Çevrimiçi haritalar sende yüklü değil mi? Buradan indir: https://omaps.app/get
-    uk = Моя мітка на карті. Іди %1$@ або %2$@
-    vi = Này, hãy xem ghim của tôi tại Organic Maps! %1$@ hoặc %2$@ Bạn chưa cài đặt bản đồ ngoại tuyến? Tải xuống tại đây: https://omaps.app/get
-    zh-Hans = 嘿,在 Organic Maps 上查看我标注的图钉吧! %1$@ 或%2$@ 未安装离线地图?在此下 载: https://omaps.app/get
-    zh-Hant = 嘿，看看我在 Organic Maps 標記的圖釘吧！ %1$@ 或%2$@ 沒安裝離線地圖？在此下載: https://omaps.app/get
-    el = Έλεγξε τις τοποθεσίες που έχω καρφιτσώσει στο Organic Maps! %1$@ ή %2$@ εάν δεν έχεις εγκαταστήσει χάρτες εκτός σύνδεσης, μπορείς να τους κατεβάσεις εδώ: https://omaps.app/get
-    sk = Pozrite na moju značku na mape. Otvoriť odkaz: %1$@ alebo %2$@
 
   [my_position_share_sms]
     comment = Share my position using SMS, %1$@ contains om:// and %2$@ https://omaps.app link WITHOUT NAME. @NOTE non-ascii symbols in the link will result in max 70 characters SMS instead of 140.
-    tags = ios,android
+    tags = android
     en = Hey, check out my current location in Organic Maps! %1$@ or %2$@ Don't have offline maps? Download here: https://omaps.app/get
     ru = Смотри где я сейчас. Жми %1$@ или %2$@
     ar = هاي، تفقد الموقع الخاص بي على Organic Maps! %1$@ أو %2$@. ليس لديك أي خرائط تعمل بدون الاتصال مع الانترنت مثبتة على جهازك؟ قم بتحميلها من هنا: https://omaps.app/get
@@ -3701,7 +2815,7 @@
 
   [bookmark_share_email_subject]
     comment = Subject for emailed bookmark
-    tags = ios,android
+    tags = ios, android
     en = Hey, check out my pin in Organic Maps!
     ru = Смотри мою метку на карте Organic Maps
     ar = هاي، تفقد الدبوس الخاص بي على خريطة Organic Maps!
@@ -3735,7 +2849,7 @@
 
   [my_position_share_email_subject]
     comment = Subject for emailed position
-    tags = ios,android
+    tags = ios, android
     en = Hey, check out my current location on the Organic Maps map!
     ru = Посмотри на карте Organic Maps, где я сейчас нахожусь
     ar = يا هلا، تحقق من موقعي الحالي على خريطة Organic Maps!
@@ -3769,7 +2883,7 @@
 
   [my_position_share_email]
     comment = Share my position using EMail, %1$@ is om:// and %2$@ is https://omaps.app link WITHOUT NAME
-    tags = ios,android
+    tags = android
     en = Hi,\n\nI'm here now: %1$@. Click this link %2$@ or this one %3$@ to see the place on the map.\n\nThanks.
     ru = Привет!\n\nЯ сейчас здесь: %1$@. Чтобы увидеть это место на карте Organic Maps, открой эту ссылку %2$@ или эту %3$@\n\nСпасибо.
     ar = مرحبا،\n\nأنا هنا الآن: %1$@. انقر على هذا الرابط %2$@ أو ذلك الرابط %3$@ لمشاهدة المكان على الخريطة.\n\nشكرا لك.
@@ -3801,44 +2915,9 @@
     he = הי, n\nI\ אני כאן: %1$@. הקש על הלינק %2$@ או על %3$@ כדי לראות את המקום על המפה. \n\n תודה.
     sk = Ahoj,\n\nPráve som tu: %1$@. Stlačte jeden z týchto odkazov %2$@, %3$@ a uvidíte toto miesto na mape.\n\nVďaka
 
-  [share_by_message]
-    comment = Android share by Message/SMS button text (including SMS)
-    tags = ios,android
-    en = Share by message
-    ru = Отправить сообщением
-    ar = مشاركة بواسطة رسالة
-    cs = Sdílet pomocí zprávy
-    da = Del via besked
-    nl = Delen via bericht
-    fi = Jaa viestillä
-    fr = Partager par message
-    de = Als Nachricht teilen
-    hu = Megosztás üzenetben
-    id = Bagikan menggunakan pesan
-    it = Condividi con un messaggio
-    ja = メッセージで共有
-    ko = 메시지로 공유
-    nb = Del med melding
-    pl = Udostępnij przez wiadomość
-    pt = Partilhar por mensagem
-    pt-BR = Compartilhar por mensagem
-    ro = Partajare ca mesaj
-    es = Compartir por mensaje
-    sv = Dela via meddelande
-    th = แชร์จากข้อความ
-    tr = Mesajla paylaş
-    uk = Подiлитися за допомогою повідомлення
-    vi = Chia sẻ bằng tin nhắn
-    zh-Hans = 通过消息分享
-    zh-Hant = 透過訊息分享
-    el = Κοινοποίηση μέσω μηνύματος
-    he = שתף באמצעות הודעה
-    sk = Zdielať pomocou správy
-    fa = اشتراک گذاری از طریق پیامک
-
   [share]
     comment = Share button text which opens menu with more buttons, like Message, EMail, Facebook etc.
-    tags = ios,android
+    tags = ios, android
     en = Share
     ru = Поделиться
     ar = مشاركة
@@ -3867,47 +2946,13 @@
     zh-Hans = 分享
     zh-Hant = 分享
     el = Κοινοποίηση
+    fa = اشتراک گذاری
     he = הפץ
     sk = Zdielať
-    fa = اشتراک گذاری
-
-  [message]
-    comment = iOS share by Message button text (including SMS)
-    tags = ios,android
-    en = Message
-    ru = Сообщение
-    ar = رسالة
-    cs = Zpráva
-    da = Besked
-    nl = Bericht
-    fi = Viesti
-    fr = Message
-    de = Nachricht
-    hu = Üzenet
-    id = Pesan
-    it = Messaggio
-    ja = メッセージ
-    ko = 메시지
-    nb = Melding
-    pl = Wiadomość
-    pt = Mensagem
-    pt-BR = Mensagem
-    ro = Tin nhắn
-    es = Mensaje
-    sv = Meddelande
-    th = ข้อความ
-    tr = Mesaj
-    uk = Повідомлення
-    vi = Tin nhắn
-    zh-Hans = 消息
-    zh-Hant = 訊息
-    he = הודעה
-    sk = Správa
-    fa = پیامک
 
   [email]
     comment = Share by email button text, also used in editor.
-    tags = ios,android
+    tags = ios, android
     en = Email
     ru = Email
     ar = البريد الالكتروني
@@ -3936,80 +2981,12 @@
     zh-Hans = 邮件
     zh-Hant = 電子郵件
     el = Email
-    sk = Email
     fa = ایمیل
-
-  [copy_link]
-    comment = Copy Link
-    tags = ios
-    en = Copy Link
-    ru = Скопировать ссылку
-    ar = نسخ الرابط
-    cs = Zkopírovat odkaz
-    da = Kopier link
-    nl = Kopieer koppeling
-    fi = Kopioi linkki
-    fr = Copier le lien
-    de = Link kopieren
-    hu = Hivatkozás másolása
-    id = Salin Tautan
-    it = Copia link
-    ja = リンクをコピー
-    ko = 링크 복사하기
-    nb = Kopier kobling
-    pl = Skopiuj odnośnik
-    pt = Copiar hiperligação
-    pt-BR = Copiar link
-    ro = Copiați link-ul
-    es = Copiar enlace
-    sv = Kopiera Länk
-    th = คัดลอกลิงก์
-    tr = Bağlantıyı Kopyala
-    uk = Копіювати посилання
-    vi = Sao chép Liên kết
-    zh-Hans = 复制链接
-    zh-Hant = 複製連結
-    he = העתק קישור
-    sk = Skopírovať odkaz
-    fa = کپی لینک
-
-  [more_info]
-    comment = Text for the button that returns to caller application
-    tags = ios,android
-    en = Show More Info
-    ru = Подробнее
-    ar = إظهار مزيد من المعلومات
-    cs = Zobrazit další informace
-    da = Vis mere info
-    nl = Toon meer info
-    fi = Näytä lisätietoja
-    fr = Afficher plus d'informations
-    de = Weitere Infos anzeigen
-    hu = Mutasson több adatot
-    id = Tampilkan Lebih Banyak Info
-    it = Mostra più informazioni
-    ja = 詳細情報を表示
-    ko = 추가 정보 보기
-    nb = Vis mer info
-    pl = Pokaż więcej informacji
-    pt = Mostrar informação adicional
-    pt-BR = Mostrar mais informações
-    ro = Afișează mai multe informații
-    es = Mostrar más información
-    sv = Visa Mer Info
-    th = แสดงข้อมูลเพิ่มเติม
-    tr = Daha Fazla Bilgi Göster
-    uk = Докладніше
-    vi = Hiển thị thêm thông tin
-    zh-Hans = 显示更多资讯
-    zh-Hant = 顯示更多資訊
-    he = הראה עוד מידע
-    sk = Zobraziť ďaľšie informácie
-    fa = نمایش اطلاعات بیشتر
+    sk = Email
 
   [copied_to_clipboard]
     comment = Text for message when used successfully copied something
-    tags = ios,android
+    tags = android
     en = Copied to clipboard: %1$@
     ru = Скопировано в буфер обмена: %1$@
     ar = تم النسخ الى الحافظة: %1$@
@@ -4038,9 +3015,9 @@
     zh-Hans = 复制到剪贴板:%1$@
     zh-Hant = 已複製到剪貼簿：%1$@
     el = Αντιγράφηκε στο Πρόχειρο: %1$@
+    fa = کپی در کلیپ برد :%1$@
     he = הועתקו לזכרון זמני %1$@
     sk = Skopírované do schránky: %1$@
-    fa = کپی در کلیپ برد :%1$@
 
   [info]
     comment = place preview title
@@ -4073,13 +3050,13 @@
     zh-Hans = 信息
     zh-Hant = 簡介
     el = Πληροφορίες
+    fa = اطلاعات
     he = מידע
     sk = Viacej informácií
-    fa = اطلاعات
 
   [done]
     comment = Used for bookmark editing
-    tags = android
+    tags = ios, android
     en = Done
     ru = Готово
     ar = تم
@@ -4108,109 +3085,13 @@
     zh-Hans = 完成
     zh-Hant = 完成
     el = Ολοκληρώθηκε
+    fa = انجام شد
     he = בוצע
     sk = Hotovo
-    fa = انجام شد
-
-  [yopme_pref_summary]
-    comment = Summary for preferences in MWM
-    tags = android
-    en = Choose Back Screen settings
-    ru = Выберите настройки второго экрана
-    ar = اختر اعدادات الشاشة الخلفية
-    cs = Zvolit nastavení zadní obrazovky
-    da = Vælg bagskærmsindstillinger
-    nl = Kies instellingen voor achtergrondscherm
-    fi = Valitse tausta-asetukset
-    fr = Choisir les réglages de l'arrière-plan
-    de = Einstellungen für den rückseitigen Bildschirm wählen
-    hu = Válassza ki a hátoldali képernyő-beállításokat
-    id = Pilih pengaturan Layar Belakang
-    it = Selezionate le impostazioni Sfondo
-    nb = Velg innstillinger for tilbakeskjerm
-    pl = Wybierz ustawienia tylnego ekranu
-    pt = Escolha as definições de Ecrã Posterior
-    pt-BR = Escolha as configurações da Tela Posterior
-    ro = Alegeți setările pentru ecranul din spate
-    es = Seleccione la сonfiguración de la pantalla trasera
-    sv = Välj bakskärmsinställningar
-    th = เลือกการตั้งค่าหน้าจอส่วนหลัง
-    tr = Arka Ekran ayarlarını seç
-    uk = Оберіть налаштування заднього екрану
-    vi = Chọn cài đặt Màn hình Sau
-    zh-Hans = 选择背屏设置
-    zh-Hant = 選擇第二螢幕設定
-    he = בחר "הגדרות מסך קודם"
-    sk = Zvoliť nastavenie Zadnej obrazovky
-    fa = انتخاب تنظیمات پس ضمینه
-
-  [yopme_pref_title]
-    comment = Title for yopme preferences in MWM
-    tags = android
-    en = Back Screen Settings
-    ru = Настройки второго экрана
-    ar = اعدادات الشاشة الخلفية
-    cs = Nastavení zadní obrazovky
-    da = Bagskærmsindstillinger
-    nl = Instellingen voor achtergrondscherm
-    fi = Tausta-asetukset
-    fr = Paramètres de l'arrière-plan
-    de = Einstellungen für rückseitigen Bildschirm
-    hu = Hátoldali képernyő-beállítások
-    id = Pengaturan Layar Belakang
-    it = Impostazioni Sfondo
-    nb = Innstillinger for tilbakeskjerm
-    pl = Ustawienia tylnego ekranu
-    pt = Configurações do Ecrã Posterior
-    pt-BR = Configurações da Tela Posterior
-    ro = Setări ecran spate
-    es = Configuración de la pantalla trasera
-    sv = Bakskärmsinställningar
-    th = การตั้งค่าหน้าจอส่วนหลัง
-    tr = Arka Ekran Ayarları
-    uk = Налаштування заднього екрану
-    vi = Cài đặt Màn hình Sau
-    zh-Hans = 背屏设置
-    zh-Hant = 第二螢幕設定
-    he = הגדרות מסך קודם
-    sk = Nastavenie Zadnej obrazovky
-    fa = تنظیمات پس ضمینه
-
-  [show_on_backscreen]
-    comment = Hint for upper-right icon p2b
-    tags = android
-    en = Show on Back screen
-    ru = Показать на втором экране
-    ar = إظهار في الشاشة الخلفية
-    cs = Zobrazit na zadní obrazovce
-    da = Vis på bagskærm
-    nl = Toon op achtergrondscherm
-    fi = Näytä taustalla
-    fr = Afficher sur l'arrière-plan
-    de = Auf dem rückseitigen Bildschirm anzeigen
-    hu = Mutassa a vissza képernyőn
-    id = Tampilkan pada layar Belakang
-    it = Mostra Sfondo
-    nb = Vis på tilbakeskjermen
-    pl = Pokaż na tylnym ekranie
-    pt = Mostrar no Ecrã Posterior
-    pt-BR = Mostrar na Tela Posterior
-    ro = Afișare pe ecranul din spate
-    es = Mostrar en la pantalla trasera
-    sv = Visa på bakskärm
-    th = แสดงหน้าจอส่วนหลัง
-    tr = Arka ekranda göster
-    uk = Показати на задньому екрані
-    vi = Hiển thị trên màn hình Sau
-    zh-Hans = 显示在背屏上
-    zh-Hant = 在第二螢幕上顯示
-    he = הצג על המסך הקודם
-    sk = Zobraziť na Zadnej obrazovke
-    fa = نمایش در پس زمینه
 
   [version]
     comment = Prints version number in About dialog
-    tags = android
+    tags = ios, android
     en = Version: %@
     ru = Версия: %@
     ar = الاصدار: %@
@@ -4239,22 +3120,22 @@
     zh-Hans = 版本:%@
     zh-Hant = 版本： %@
     el = Έκδοση: %@
+    fa = ورژن: %@
     he = %@ וורסיה
     sk = Verzia: %@
-    fa = ورژن: %@
 
   [data_version]
     comment = Data version in «About» screen
-    tags = ios,android
+    tags = ios, android
     en = Data version: %d
     ru = Версия данных: %d
+    fr = Version de données: %d
     de = Datenversion: %d
+    pl = Wersja danych: %d
     pt-BR = Versão dos dados: %d
     zh-Hant = 資料版本： %d
     el = Ημερομηνία έκδοσης: %d
     fa = ورژن داده: %d
-    fr = Version de données: %d
-    pl = Wersja danych: %d
 
   [are_you_sure]
     comment = Confirmation in downloading countries dialog
@@ -4287,13 +3168,13 @@
     zh-Hans = 您确定要继续吗?
     zh-Hant = 確定要繼續嗎？
     el = Θέλετε σίγουρα να συνεχίσετε?
+    fa = برای ادامه کار مطمئن اید؟
     he = האם הנך בטוח שרצונך להמשיך?
     sk = Naozaj chcete pokračovať?
-    fa = برای ادامه کار مطمئن اید؟
 
   [tracks_title]
     comment = Title for tracks category in bookmarks manager
-    tags = ios,android
+    tags = android
     en = Tracks
     ru = Треки
     ar = المسارات
@@ -4322,13 +3203,13 @@
     zh-Hans = 轨迹
     zh-Hant = 軌跡
     el = Διαδρομές
+    fa = مسیر
     he = נתיבים
     sk = Stopy
-    fa = مسیر
 
   [length]
     comment = Length of track in cell that describes route
-    tags = ios,android
+    tags = android
     en = Length
     ru = Длина
     ar = الطول
@@ -4357,12 +3238,12 @@
     zh-Hans = 长度
     zh-Hant = 長度
     el = Μήκος
+    fa = طول
     he = אורך
     sk = Diaľka
-    fa = طول
 
   [share_my_location]
-    tags = ios,android
+    tags = android
     en = Share My Location
     ru = Поделиться местоположением
     ar = مشاركة موقعي
@@ -4391,128 +3272,29 @@
     zh-Hans = 共享我的位置
     zh-Hant = 分享我的位置
     el = Κοινοποίηση της τοποθεσίας μου
+    fa = به اشتراک گذاری موقعیت مکانی من
     he = שתף את מקומי
     sk = Zdielať moje umiestnenie
-    fa = به اشتراک گذاری موقعیت مکانی من
-
-  [menu_search]
-    en = Search
-    ru = Поиск
-    ar = بحث
-    cs = Vyhledávání
-    da = Søg
-    nl = Zoek
-    fi = Haku
-    fr = Rechercher
-    de = Suche
-    hu = Keresés
-    id = Cari
-    it = Cerca
-    ja = 検索
-    ko = 검색
-    nb = Søk
-    pl = Wyszukaj
-    pt = Pesquisar
-    pt-BR = Pesquisar
-    ro = Căutare
-    es = Buscar
-    sv = Sök
-    th = ค้นหา
-    tr = Ara
-    uk = Пошук
-    vi = Tìm kiếm
-    zh-Hans = 搜索
-    zh-Hant = 搜尋
-    he = חפוש
-    sk = Vyhľadávanie
-    fa = جست‌وجو
 
   [prefs_group_general]
     comment = Settings general group in settings screen
     tags = android
     en = General settings
     ru = Общие настройки
-    fa = تنظیمات عمومی
     fr = Paramètres généraux
     pl = Ustawienia ogólne
+    fa = تنظیمات عمومی
 
   [prefs_group_information]
     comment = Settings information group in settings screen
     tags = android
     en = Information
     ru = Информация
-    fa = اطلاعات
     pl = Informacje
-
-  [prefs_group_map]
-    comment = Settings screen: "Map" category title
-    tags = android
-    en = Map
-    ru = Карта
-    ar = الخريطة
-    cs = Mapa
-    da = Kort
-    nl = Kaart
-    fi = Kartta
-    fr = Carte
-    de = Karte
-    hu = Térkép
-    id = Peta
-    it = Mappa
-    ja = 地図
-    ko = 지도
-    nb = Kart
-    pl = Mapa
-    pt = Mapa
-    pt-BR = Mapa
-    ro = Hartă
-    es = Mapa
-    sv = Karta
-    th = แผนที่
-    tr = Harita
-    uk = Карта
-    vi = Bản đồ
-    zh-Hans = 地图
-    zh-Hant = 地圖
-    el = Χάρτης
-    sk = Mapa
-    fa = نقشه
-
-  [prefs_group_misc]
-    comment = Settings screen: "Miscellaneous" category title
-    tags = android
-    en = Miscellaneous
-    ru = Прочее
-    ar = مُتَنَوّعة
-    cs = Jiné
-    da = Forskelligt
-    nl = Diversen
-    fi = Muut
-    fr = Divers
-    de = Verschiedenes
-    hu = Egyéb
-    id = Lain-Lain
-    it = Miscellanea
-    ja = その他
-    ko = 기타
-    nb = Diverse
-    pl = Różne
-    pt = Diversos
-    pt-BR = Diversos
-    ro = Diverse
-    es = Varios
-    sv = Diverse
-    th = เบ็ดเตล็ด
-    tr = Çeşitli
-    uk = Інше
-    vi = Khác
-    zh-Hans = 其他
-    zh-Hant = 其他
-    el = Διάφορα
-    sk = Iné
-    fa = متفرقه
+    fa = اطلاعات
 
   [prefs_group_route]
+    tags = ios, android
     en = Navigation
     ru = Навигация
     ar = الملاحة
@@ -4541,11 +3323,11 @@
     zh-Hans = 导航
     zh-Hant = 導航
     el = Πλοήγηση
-    sk = Navigácia
     fa = مسیریابی
+    sk = Navigácia
 
   [pref_zoom_title]
-    tags = android
+    tags = ios, android
     en = Zoom buttons
     ru = Кнопки масштаба
     ar = أزرار التكبير
@@ -4574,9 +3356,9 @@
     zh-Hans = 缩放按钮
     zh-Hant = 縮放按鈕
     el = Πλήκτρα μεγέθυνσης
+    fa = دکمه های درشت نمایی
     he = כפתורי זום
     sk = Tlačítka priblíženia/oddialenia
-    fa = دکمه های درشت نمایی
 
   [pref_zoom_summary]
     tags = android
@@ -4608,13 +3390,13 @@
     zh-Hans = 在屏幕上显示
     zh-Hant = 在螢幕上顯示
     el = Εμφάνιση στο χάρτη
+    fa = نمایش بر روی نقشه
     he = הצג על המסך
     sk = Zobraziť na obrazovke
-    fa = نمایش بر روی نقشه
 
   [pref_map_style_title]
     comment = Settings «Map» category: «Night style» title
-    tags = android
+    tags = ios, android
     en = Night Mode
     ru = Ночной режим
     ar = الوضع الليلي
@@ -4643,12 +3425,12 @@
     zh-Hans = 夜间模式
     zh-Hant = 夜間模式
     el = Νυχτερινή λειτουργία
-    sk = Nočný režim
     fa = حالت شب
+    sk = Nočný režim
 
   [pref_map_style_default]
     comment = «Map style» entry value
-    tags = android
+    tags = ios, android
     en = Off
     ru = Выключен
     ar = إغلاق
@@ -4677,12 +3459,12 @@
     zh-Hans = 关闭
     zh-Hant = 關閉
     el = Απενεργ.
-    sk = Vypnúť
     fa = خاموش
+    sk = Vypnúť
 
   [pref_map_style_night]
     comment = «Map style» entry value
-    tags = android
+    tags = ios, android
     en = On
     ru = Включен
     ar = تشغيل
@@ -4711,12 +3493,12 @@
     zh-Hans = 开启
     zh-Hant = 開啟
     el = Ενεργ.
-    sk = Zapnúť
     fa = روشن
+    sk = Zapnúť
 
   [pref_map_style_auto]
     comment = «Map style» entry value
-    tags = android
+    tags = ios, android
     en = Auto
     ru = Автоматически
     ar = تلقائي
@@ -4745,8 +3527,8 @@
     zh-Hans = 自动
     zh-Hant = 自動
     el = Αυτόματα
-    sk = Automaticky
     fa = خودکار
+    sk = Automaticky
 
   [pref_map_3d_title]
     comment = Settings «Map» category: «Perspective view» title
@@ -4779,8 +3561,8 @@
     zh-Hans = 透视图
     zh-Hant = 透視圖
     el = Προβολή προοπτικής
-    sk = Perspektívne zobrazenie
     fa = نمای چشم انداز
+    sk = Perspektívne zobrazenie
 
   [pref_map_3d_buildings_title]
     comment = Settings «Map» category: «3D buildings» title
@@ -4813,45 +3595,12 @@
     zh-Hans = 3D 建筑
     zh-Hant = 3D 建築
     el = Τρισδιάστατα κτίρια
-    sk = 3D budovy
     fa = ساختمان های سه بعدی
-
-  [pref_map_3d_buildings_subtitle]
-    comment = Settings «Map» category: «3D buildings» summary
-    tags = ios, android
-    en = Affects battery life
-    ru = Увеличивает расход батареи
-    ar = تؤثر على عمر البطارية
-    cs = Ovlivňuje výdrž baterie
-    da = Påvirker batteriets levetid
-    nl = Beïnvloedt batterijduur
-    fi = Vaikuttaa akun kestoon
-    fr = Affecte la vie de la batterie
-    de = Beeinträchtigt die Akkulaufzeit
-    hu = Akkumulátor élettartamára hat
-    id = Memengaruhi daya baterai
-    it = Diminuisce la durata della batteria
-    ja = 電池の持ち時間に影響します
-    ko = 배터리 수명에 영향
-    nb = Påvirker batteriets levetid
-    pl = Wpływa na czas pracy baterii
-    pt = Afeta a vida da bateria
-    pt-BR = Afeta a duração da bateria
-    ro = Afectează durata de funcționare a bateriei
-    es = Afecta a la duración de la batería
-    sv = Påverkar batteriets livslängd
-    th = มีผลกระทบต่ออายุการใช้งานแบตเตอรี่
-    tr = Pil ömrünü etkiler
-    uk = Негативно впливає на ресурс акумулятора
-    vi = Ảnh hưởng tới tuổi thọ của pin
-    zh-Hans = 增加电池消耗
-    zh-Hant = 增加電池消耗
-    sk = Ovplyvňuje životnosť batérie
-    fa = تاثیر بر روی عمر باطری
+    sk = 3D budovy
 
   [pref_tts_enable_title]
     comment = Settings «Route» category: «Tts enabled» title
-    tags = android,ios
+    tags = ios, android
     en = Voice Instructions
     ru = Голосовые инструкции
     ar = تعليمات صوتية
@@ -4880,12 +3629,12 @@
     zh-Hans = 语音指导
     zh-Hant = 語音指示
     el = Φωνητικές οδηγίες
-    sk = Hlasové povely
     fa = دستور العمل صوتی
+    sk = Hlasové povely
 
   [pref_tts_language_title]
     comment = Settings «Route» category: «Tts language» title
-    tags = android,ios
+    tags = ios, android
     en = Voice Language
     ru = Язык подсказок
     ar = لغة الصوت
@@ -4914,12 +3663,12 @@
     zh-Hans = 语音语言
     zh-Hant = 語音語言
     el = Γλώσσα φωνής
-    sk = Nastavenia jazyka povelov
     fa = زبان صوت
+    sk = Nastavenia jazyka povelov
 
   [pref_tts_unavailable]
     comment = Settings «Route» category: «Tts unavailable» subtitle
-    tags = android,ios
+    tags = android
     en = Not Available
     ru = Не доступны
     ar = غير متاح
@@ -4948,8 +3697,8 @@
     zh-Hans = 无法使用
     zh-Hant = 無法使用
     el = Δεν είναι διαθέσιμη
-    sk = Nie je k dispozícii
     fa = موجود نیست
+    sk = Nie je k dispozícii
 
   [pref_tts_other_section_title]
     comment = Title for "Other" section in TTS settings.
@@ -4982,41 +3731,8 @@
     zh-Hans = 其他
     zh-Hant = 其他
     el = Άλλα
-    sk = Iný
     fa = بیشتر
-
-  [pref_tts_how_to_set_up_voice]
-    tags = ios
-    en = How to set up voice
-    ru = Как настроить голос
-    ar = كيفية ضبط الصوت
-    cs = Jak nastavit hlas
-    da = Sådan indstiller du tale
-    nl = Hoe stel je de stem in
-    fi = Kuinka asettaa ääni
-    fr = Comment configurer la voix
-    de = Navi-Stimme konfigurieren
-    hu = Így állítsd be a hangot
-    id = Cara mengatur suara
-    it = Come impostare la voce
-    ja = 音声設定の仕方
-    ko = 음성 설정 방법
-    nb = Slik installerer du stemme
-    pl = Jak skonfigurować usługę głosową
-    pt = Como configurar a voz
-    pt-BR = Como configurar a voz
-    ro = Modalitatea de configurare a vocii
-    es = Cómo configurar la voz
-    sv = Hur man ställer in ljud
-    th = วิธีตั้งค่าเสียง
-    tr = Ses nasıl ayarlanır
-    uk = Як налаштувати голосовий контроль
-    vi = Làm thế nào để thiết lập tiếng nói
-    zh-Hans = 如何设置语音
-    zh-Hant = 如何設定語音
-    el = Ρύθμιση φωνής
-    sk = Ako nastaviť hlas
-    fa = نحو راه اندازی صدا
+    sk = Iný
 
   [pref_track_record_title]
     comment = Settings «Map» category: «Record track» title
@@ -5049,10 +3765,11 @@
     zh-Hans = 最近的路径
     zh-Hant = 最近的軌跡
     el = Πρόσφατη διαδρομή
-    sk = Posledná trasa
     fa = مسیر اخیر
+    sk = Posledná trasa
 
   [pref_map_auto_zoom]
+    tags = ios, android
     en = Auto zoom
     ru = Автозум
     ar = تكبير تلقائي
@@ -5080,11 +3797,11 @@
     zh-Hans = 自动缩放
     zh-Hant = 自動縮放
     el = Αυτόματη μεγέθυνση
-    sk = Automatický zoom
     fa = بزرگ نمایی خودکار
+    sk = Automatický zoom
 
   [duration_disabled]
-    tags = ios,android
+    tags = ios, android
     en = Off
     ru = Выключено
     ar = لا يعمل
@@ -5113,11 +3830,11 @@
     zh-Hans = 关闭
     zh-Hant = 關閉
     el = Απενεργ.
-    sk = Vypnúť
     fa = خاموش
+    sk = Vypnúť
 
   [duration_1_hour]
-    tags = ios,android
+    tags = ios, android
     en = 1 hour
     ru = 1 час
     ar = 1 ساعة
@@ -5146,11 +3863,11 @@
     zh-Hans = 1小时
     zh-Hant = 1小時
     el = 1 ώρα
-    sk = 1 hodina
     fa = 1 ساعت
+    sk = 1 hodina
 
   [duration_2_hours]
-    tags = ios,android
+    tags = ios, android
     en = 2 hours
     ru = 2 часа
     ar = 2 ساعة
@@ -5179,11 +3896,11 @@
     zh-Hans = 2小时
     zh-Hant = 2小時
     el = 2 ώρες
-    sk = 2 hodiny
     fa = 2 ساعت
+    sk = 2 hodiny
 
   [duration_6_hours]
-    tags = ios,android
+    tags = ios, android
     en = 6 hours
     ru = 6 часов
     ar = 6 ساعات
@@ -5212,11 +3929,11 @@
     zh-Hans = 6小时
     zh-Hant = 6小時
     el = 6 ώρες
-    sk = 6 hodín
     fa = 6 ساعت
+    sk = 6 hodín
 
   [duration_12_hours]
-    tags = ios,android
+    tags = ios, android
     en = 12 hours
     ru = 12 часов
     ar = 12 ساعة
@@ -5245,11 +3962,11 @@
     zh-Hans = 12小时
     zh-Hant = 12小時
     el = 12 ώρες
-    sk = 12 hodín
     fa = 12 ساعت
+    sk = 12 hodín
 
   [duration_1_day]
-    tags = ios,android
+    tags = ios, android
     en = 1 day
     ru = 1 сутки
     ar = 1 يوم
@@ -5278,8 +3995,8 @@
     zh-Hans = 1天
     zh-Hant = 1天
     el = 1 ημέρα
-    sk = 1 deň
     fa = 1 روز
+    sk = 1 deň
 
   [recent_track_help_text]
     tags = ios
@@ -5290,7 +4007,7 @@
     da = Det giver dig mulighed at optage en rejsterute for en bestemt periode og se den på kortet. Bemærk: aktivering af denne funktion forårsager øget batteriforbrug. Sporet vil blive fjernet automatisk fra kortet efter at tidsintervallet er udløbet.
     nl = Dit laat u toe het afgelegde traject voor een bepaalde periode te registreren en te bekijken op de kaart. Merk op: activatie van deze functie veroorzaakt een hoger batterijverbruik. Het traject wordt automatisch van de kaart verwijderd nadat het tijdsinterval verloopt.
     fi = Toiminnon avulla voit tallentaa kuljetun reitin tietyltä ajalta ja nähdä sen kartalla: Huomautus: tämän toiminnon aktivoiminen lisää akun käyttöä. Reitti poistetaan kartalta automaattisesti ajanjakson päätyttyä.
-    fr = Ceci vous permet d’enregistrer le chemin emprunté pendant un certain temps et de le voir sur la carte. Veuillez noter : l’activation de cette fonction entraîne une grande utilisation de la batterie. La route sera supprimée automatiquement de la carte lorsque l’intervalle de temps sera arrivé à expiration.
+    fr = Ceci vous permet d’enregistrer le chemin emprunté pendant un certain temps et de le voir sur la carte. Veuillez noter : l’activation de cette fonction entraîne une grande utilisation de la batterie. La route sera supprimée automatiquement de la carte lorsque l’intervalle de temps sera arrivé à expiration.
     de = So können Sie die zurückgelegte Strecke für einen bestimmten Zeitraum aufzeichnen und auf der Karte sehen. Hinweis: Die Aktivierung dieser Funktion führt zu erhöhtem Batterieverbrauch. Die Aufzeichnung wird nach Ablauf des Zeitintervalls automatisch von der Karte entfernt.
     hu = Ez lehetővé teszi a bejárt útvonal rögzítését és megtekintését a térképen bizonyos időre. Kérjük, vegye figyelembe, hogy ezen funkció aktiválásával megnöveli az akkumulátor használatát. Az útvonal automatikusan törlődik a térképről az időtartam lejártával.
     id = Ini memungkinkan Anda untuk merekam jalur yang telah dilalui selama jangka waktu tertentu dan melihatnya pada peta. Harap ketahui: aktivasi fungsi ini menyebabkan peningkatan penggunaan baterai. Trek akan dihapus secara otomatis dari peta setelah selang waktu berakhir.
@@ -5310,170 +4027,12 @@
     zh-Hans = 它允许您记录一定时间段内的旅行路径，并在地图上查看。请注意：激活此功能会导致电量消耗加快。过期后，轨迹将从地图中自动移除。
     zh-Hant = 它可讓您記錄特定期間所行經的路徑，並在地圖上看到該路徑。請注意：啟用此項功能會增加電池使用量。在時間間隔過期後，會從地圖中自動移除行進路線。
     el = Σας επιτρέπει να καταγράψετε τη διαδρομή που έχει διανυθεί για συγκεκριμένο χρονικό διάστημα και να την δείτε στο χάρτη. Λάβετε υπόψη: η ενεργοποίηση αυτής της λειτουργίας κάνει έντονη χρήση της μπαταρίας. Το τμήμα θα αφαιρεθεί αυτόματα από το χάρτη μετά τη λήξη του μεσοδιαστήματος.
+    fa = با این قابلیت شما می توانید مسیری که می پیمایید را در یک دوره مشخص ضبط نماید و ان را بر روی نقشه ببینید.لطفا توجه نمایید:فعال سازی این قابلیت باعث افزایش مصرف باتری موبایل شما می شود.مسیر به طور خودکار بعد از مدت مشخص شده حذف خواهد شد
     sk = Umožňuje zaznamenať precestovanú trasu za určité obdobie a zobraziť ju na mape. Upozornenie: zapnutie tejto funkcie spôsobí vyššiu spotrebu batérie. Trasa sa z mapy automaticky odstráni po uplynutí časového intervalu.
     sw = Inakuwezesha kurekodi njia uliyosafiria kwa kipindi fulani na uione kwenye ramani. Tafadhali kumbuka: ukiwezesha utendaji huu betri itatumika zaidi. Njia hiyo itaondolewa kiotomatiki kwenye ramani baada ya mpishano wa muda kuisha.
-    fa = با این قابلیت شما می توانید مسیری که می پیمایید را در یک دوره مشخص ضبط نماید و ان را بر روی نقشه ببینید.لطفا توجه نمایید:فعال سازی این قابلیت باعث افزایش مصرف باتری موبایل شما می شود.مسیر به طور خودکار بعد از مدت مشخص شده حذف خواهد شد
-
-  [pref_track_ios_caption]
-    tags = ios
-    en = Recent track shows your traveled path.
-    ru = История пути покажет недавно пройденный маршрут.
-    ar = يُظهر المسار الأخير مسار سفرك.
-    cs = Nedávná trasa zobrazuje cestu, po které jste cestovali.
-    da = Seneste spor viser din rejste vej.
-    nl = Recente route geeft uw gebruikte route weer.
-    fi = Viimeisin reitti näyttää kulkemasi matkan.
-    fr = L'itinéraire récent indique votre chemin parcouru.
-    de = Letzte Strecke zeigt den von Ihnen zurückgelegten Weg.
-    hu = A legutolsó útvonal megmutatja, hogy milyen útvonalon haladtál.
-    id = Jalur terakhir menunjukkan jalur yang sudah Anda lalui.
-    it = Il percorso recente mostra il tragitto effettuato.
-    ja = 最近ルートは、使用した道のりを表示する機能です。
-    ko = 최근 추적은 여행한 경로를 보여줍니다.
-    nb = Nylig rute viser ruten du har fulgt.
-    pl = Ostatnia trasa pokazuje pokonaną przez Ciebie ścieżkę.
-    pt = O trajeto recente mostra o seu caminho percorrido.
-    pt-BR = O trajeto recente mostra o seu caminho percorrido.
-    ro = Opțiunea Rută recentă vă afișează ruta folosită anterior.
-    es = El trayecto reciente muestra tu recorrido de viaje.
-    sv = Senaste resväg visar den väg du rest.
-    th = เส้นทางล่าสุดแสดงให้เห็นถึงเส้นทางที่เดินทางแล้วของคุณ
-    tr = En son yol seyahat ettiğiniz yolları gösterir.
-    uk = Останній маршрут показує пройдену відстань.
-    vi = Chức năng theo dấu gần đây hiển thị các đường bạn đã đi.
-    zh-Hans = 近期轨迹显示您的行进道路。
-    zh-Hant = 近期軌跡顯示您的行進道路。
-    sk = Funkcia Čerstvá stopa zobrazuje trasu, ktorú ste prešli.
-
-  [pref_track_ios_subcaption]
-    tags = ios
-    en = Please select the time range of saving the track.
-    ru = Выберите длительность записи истории.
-    ar = يرجى تحديد نطاق وقت حفظ المسار.
-    cs = Vyberte prosím časový rozsah uložené trasy.
-    da = Vælg tidsinterval for at gemme sporet.
-    nl = Selecteer de tijdperiode voor het opslaan van route.
-    fi = Valitse reitin tallennuksen aikaväli.
-    fr = Veuillez sélectionner la période d'enregistrement du parcours.
-    de = Bitte wählen Sie die Zeitspanne, für die die Strecke gespeichert wird.
-    hu = Válaszd ki az útvonalak elmentésének időtartamát!
-    id = Silakan pilih jangka waktu penyimpanan jalur.
-    it = Seleziona un intervallo temporale per la registrazione del percorso.
-    ja = ルートを保存する期間を選択してください。
-    ko = 추적을 저장하는 시간 범위를 선택하십시오.
-    nb = Velg en tidsperiode for rutelagring.
-    pl = Wybierz zakres czasowy dla zapisywanej trasy.
-    pt = Por favor, selecione o intervalo de tempo para gravação do percurso.
-    pt-BR = Por favor, selecione o intervalo de tempo para gravação do percurso.
-    ro = Vă rugăm să selectați intervalul orar corespunzător salvării rutei.
-    es = Por favor, selecciona la periodicidad para guardar el trayecto.
-    sv = Välj tidsintervall för att spara resvägen.
-    th = โปรดเลือกช่วงเวลาในการบันทึกการติดตาม
-    tr = Lütfen kaydedilecek yol süresini seçin.
-    uk = Будь ласка, виберіть проміжок часу для збереження маршруту.
-    vi = Vui lòng chọn khoảng thời gian lưu dấu.
-    zh-Hans = 请选择保存轨迹的时间范围。
-    zh-Hant = 請選擇儲存軌跡的時間範圍。
-    sk = Prosím, vyberte si, po akú dobu má aplikácia zaznamenávať vašu trasu.
-    fa = لطفا محدوده زمانی برای ذخیره مسیر را انتخاب کنید
-
-  [placepage_distance]
-    en = Distance
-    ru = Расстояние
-    ar = المسافة
-    cs = Vzdálenost
-    da = Afstand
-    nl = Afstand
-    fi = Etäisyys
-    fr = Distance
-    de = Entfernung
-    hu = Távolság
-    id = Jarak
-    it = Distanza
-    ja = 距離
-    ko = 거리
-    nb = Avstand
-    pl = Dystans
-    pt = Distância
-    pt-BR = Distância
-    ro = Distanță
-    es = Distancia
-    sv = Avstånd
-    th = ระยะห่าง
-    tr = Mesafe
-    uk = Відстань
-    vi = Khoảng cách
-    zh-Hans = 距离
-    zh-Hant = 距离
-    he = מרחק
-    sk = Vzdialenosť
-    fa = مسافت
-
-  [placepage_coordinates]
-    en = Coordinates
-    ru = Координаты
-    ar = الإحداثيات
-    cs = Souřadnice
-    da = Koordinater
-    nl = Coördinaten
-    fi = Koordinaatit
-    fr = Coordonnées
-    de = Koordinaten
-    hu = Koordináták
-    id = Koordinat
-    it = Coordinate
-    ja = コーディネート
-    ko = 좌표
-    nb = Koordinater
-    pl = Współrzędne
-    pt = Coordenadas
-    pt-BR = Coordenadas
-    ro = Coordonate
-    es = Coordenadas
-    sv = Koordinater
-    th = พิกัด
-    tr = Koordinatlar
-    uk = Координати
-    vi = Tọa độ
-    zh-Hans = 坐标
-    zh-Hant = 座標
-    he = קואורדינטות
-    sk = Súradnice
-    fa = مختصات
-
-  [placepage_unsorted]
-    en = Unsorted
-    ru = Без категории
-    ar = لم يتم فرزها
-    cs = Nezařazené
-    da = Usorteret
-    nl = Ongeclassificeerd
-    fi = Järjestelemätön
-    fr = Non trié
-    de = Unsortiert
-    hu = Osztályozatlan
-    id = Tidak diurutkan
-    it = Non classificato
-    ja = 未分類
-    ko = 분류되지 않음
-    nb = Usortert
-    pl = Niesklasyfikowane
-    pt = Não classificado
-    pt-BR = Não ordenado
-    ro = Nesortate
-    es = Sin clasificar
-    sv = Osorterade
-    th = ไม่เรียงลำดับ
-    tr = Sıralanmamış
-    uk = Без категорії
-    vi = Chưa phân loại
-    zh-Hans = 未分类
-    zh-Hant = 未分類
-    he = לא ממוין
-    sk = Nezaradené
-    fa = نا منظم
 
   [search_show_on_map]
+    tags = ios, android
     en = View on map
     ru = Посмотреть на карте
     ar = مشاهدة على الخريطة
@@ -5502,472 +4061,13 @@
     zh-Hans = 在地图上查看
     zh-Hant = 在地圖上查看
     el = Προβολή στο χάρτη
+    fa = مشاهده بر روی نقشه
     he = ראה במפה
     sk = Zobraziť na mape
-    fa = مشاهده بر روی نقشه
-
-  [bookmark_move_fail]
-    comment = Used to warn user when fixing KitKat issue
-    tags = android
-    en = We need to move your bookmarks to internal memory, but there is no available space for them. Please free up the memory, otherwise bookmarks won’t be available.
-    ru = Для оптимизации хранения данных нам нужно переместить метки во внутреннюю память, но там сейчас нет свободного места. Пожалуйста, освободите место, иначе метки вам будут недоступны.
-    ar = نحن بحاجة لنقل الإشارات المرجعية الخاصة بك الى الذاكرة الداخلية، لكن لا يوجد حيز كافٍ لها. الرجاء إخلاء الذاكرة، وإلا لن تكون  الإشارات المرجعية متاحة.
-    cs = Potřebujeme přesunout tvé záložky do vnitřní paměti zařízení, ale není pro ně volné místo. Prosím, uvolněte paměť, jinak nebudou záložky dostupné.
-    da = Vi er nødsaget til at flytte dine bogmærker til intern hukommelse, men der er ikke nok plads til dem der. Frigør venligst noget plads, ellers vil dine bogmærker ikke være tilgængelige.
-    nl = We moeten uw bladwijzers naar het interne geheugen verplaatsen, maar er is geen ruimte beschikbaar voor ze. Maak alstublieft geheugen vrij, anders zullen de bladwijzers niet beschikbaar zijn.
-    fi = Vapauta muistia, sillä muuten karttoja voidaan käyttää vain lukutilassa. Kirjanmerkkisi pitää siirtää laitteen sisäiseen muistiin, mutta vapaata muistia ei ole tarpeeksi. Vapauta muistia, sillä muuten kirjanmerkkejä ei voida käyttää.
-    fr = Nous devons déplacer vos signets vers la mémoire interne, mais il n'y a pas d'espace disponible pour eux. Veuillez libérer de la mémoire, sinon les signets ne seront pas disponibles.
-    de = Wir müssen Ihre Lesezeichen in den internen Speicher verschieben, aber es steht dafür keinen Speicherplatz zur Verfügung. Bitte geben Sie Speicherplatz frei, sonst werden Ihre Lesezeichen nicht verfügbar sein.
-    hu = A könyvjelzőit át kell helyeznünk a belső memóriába, azonban ehhez nincs elegendő szabad tárhely. Kérjük, szabadítson fel lemezterületet, ellenkező esetben a könyvjelzői nem lesznek elérhetőek.
-    id = Kami perlu memindahkan penanda lokasi Anda ke memori internal, tetapi tidak ada ruang yang tersedia. Mohon bebaskan memori, atau penanda lokasi tidak akan tersedia.
-    it = Abbiamo bisogno di trasferire i tuoi preferiti nella memoria interna, ma non c'è abbastanza spazio disponibile. Ti preghiamo di liberare la memoria, altrimenti i preferiti non saranno disponibili.
-    ja = ブックマークを内部メモリに移動させなければなりませんが、メモリの空き容量がありません。空き容量を増やさなければ、ブックマークをご利用いただくことができません。
-    ko = 우리는 내부 메모리로 북마크를 이동해야 하지만, 이에 대한 사용 가능한 공간이 없습니다. 메모리를 확보하지 않으면, 북마크를 사용할 수 없습니다.
-    nb = Vi må flytte bokmerkene til internminnet, men det er ingen ledig plass til dem. Du må frigjøre minne, ellers vil ikke bokmerkene være tilgjengelige.
-    pl = Musimy przenieść Twoje zakładki do pamięci wewnętrznej, ale nie ma tam dla nich wolnego miejsca. Prosimy zwolnić pamięć, inaczej zakładki nie będą dostępne.
-    pt = É necessário mover os seus marcadores para a memória interna, mas não há espaço disponível para eles. Por favor, liberte a memória, caso contrário, os marcadores não estarão disponíveis.
-    pt-BR = É necessário mover os seus marcadores para a memória interna, mas não há espaço disponível para eles. Por favor, libere memória, caso contrário, os marcadores não estarão disponíveis.
-    ro = Trebuie să vă mutăm marcajele în memoria internă, dar nu există spațiu suficient pentru ele. Vă rugăm să eliberați memoria, altfel marcajele nu vor fi disponibile.
-    es = Tenemos que mover tus marcadores a la memoria interna, pero no hay espacio disponible para ellos. Por favor, libera memoria, en caso contrario, los marcadores no estarán disponibles.
-    sv = Vi behöver flytta dina bokmärken till internminnet, men det finns inte tillräckligt med utrymme för dem. Vänligen frigör mer minne, annars kommer bokmärkena inte finnas tillgängliga.
-    th = เราจำเป็นต้องลบบุ๊กมาร์กของคุณไปยังหน่วยความจำภายใน แต่ไม่มีพื้นที่ที่สามารถใช้ได้ โปรดเพิ่มหน่วยความจำ มิฉะนั้นจะไม่สามารถใช้บุ๊กมาร์กได้
-    tr = Yer imlerinizi dâhili hafızaya taşımamız gerekiyor ancak bunlar için kullanılabilir alan yok. Lütfen hafızayı boşaltın, aksi takdirde yer imleri kullanılamaz olacaktır.
-    uk = Для оптимiзацiї збереження данних нам потрiбно перенести мітки до внутрiшньої пам'ятi, але там немає вiльного мiсця. Будь ласка, звiльнiть мiсце, бо мітки вам не будуть доступнi.
-    vi = Chúng tôi cần di chuyển các điểm đánh dấu của bạn vào bộ nhớ trong nhưng không còn dung lượng cho chúng. Vui lòng giải phóng bộ nhớ, nếu không các điểm đánh dấu sẽ không khả dụng.
-    zh-Hans = 我们需要移动您的书签到内部存储器,但没 有可用的空间。请释放存储,否则书签将不 可用。
-    zh-Hant = 我們需要將您的書籤移至內部記憶體中，但沒有足夠的存儲空間。請釋放一些記憶體，否則，書籤將不可用。
-    sk = Potrebujeme presunúť vaše záložky do internej pamäti zariadenia, ale nie je pre ne voľné miesto. Prosím, uvoľnite pamäť, inak nebudú záložky dostupné.
-
-  [free]
-    comment = Used in More Apps menu
-    tags = ios
-    en = Free
-    ru = Бесплатно
-    ar = مجاني
-    cs = Zdarma
-    da = Gratis
-    nl = Gratis
-    fr = Gratuit
-    de = Kostenlos
-    hu = Ingyenes
-    it = Gratis
-    ja = 無料
-    ko = 무료
-    pl = Darmowy
-    pt = Grátis
-    pt-BR = Grátis
-    es = Gratis
-    sv = Gratis
-    th = ฟรี
-    tr = Ücretsiz
-    uk = Безкоштовно
-    zh-Hans = 免费
-    zh-Hant = 免費
-    he = חופשי
-    sk = Zadarmo
-    fa = رایگان
-
-  [buy]
-    comment = Used in More Apps menu
-    tags = ios
-    en = Buy
-    ru = Купить
-    ar = شراء
-    cs = Koupit
-    da = Køb
-    nl = Koop
-    fr = Acheter
-    de = Kaufen
-    hu = Megvásárlás
-    it = Acquista
-    ja = 購入
-    ko = 구입
-    pl = Kup
-    pt = Comprar
-    pt-BR = Comprar
-    es = Comprar
-    sv = Köp
-    th = ซื้อ
-    tr = Satın Al
-    uk = Придбати
-    zh-Hans = 购买
-    zh-Hant = 購買
-    he = קנה
-    sk = Kúpiť
-    fa = خرید
-
-  [search_on_map]
-    comment = 1st search button-like result
-    tags = ios
-    en = Search on map
-    ru = Искать на карте
-    ar = البحث في الخريطة
-    cs = Hledat na mapě
-    da = Søg på kort
-    nl = Op kaart zoeken
-    fi = Etsi kartalta
-    fr = Rechercher sur la carte
-    de = Auf der Karte anzeigen
-    hu = Keresés a térképen
-    id = Cari ada peta
-    it = Cerca sulla mappa
-    ja = 地図を検索
-    ko = 지도에서 검색
-    nb = Søk på kartet
-    pl = Szukaj na mapie
-    pt = Pesquisar no mapa
-    pt-BR = Pesquisar no mapa
-    ro = Căutare pe hartă
-    es = Buscar en mapa
-    sv = Sök på kartan
-    th = ค้นหาแผนที่
-    tr = Haritada Ara
-    uk = Шукати на карті
-    vi = Tìm trên bản đồ
-    zh-Hans = 在地图上搜索
-    zh-Hant = 在地圖上搜尋
-    el = Αναζήτηση στο χάρτη
-    he = חפש במפה
-    sk = Hľadať na mape
-    fa = جست‌وجو بر روی نقشه
-
-  [no_route_found]
-    comment = toast with an error
-    tags = ios,android
-    en = No route found
-    ru = Маршрут не найден
-    ar = لم يتم العثور على أي مسار
-    cs = Nebyla nalezena žádná trasa
-    da = Ingen rute blev fundet
-    nl = Geen route gevonden
-    fi = Reittiä ei löydy
-    fr = Aucun itinéraire trouvé
-    de = Keine Route gefunden
-    hu = Nem található útvonal
-    id = Tidak ada rute yang ditemukan
-    it = Nessun percorso trovato
-    ja = 一致する経路がありません
-    ko = 경로를 찾을 수 없음
-    nb = Finner ingen rute
-    pl = Nie znaleziono trasy
-    pt = Não foi encontrado nenhum trajecto
-    pt-BR = Nenhuma rota encontrada
-    ro = Nu a fost găsit nici un traseu
-    sl = Poti ni mogoče najti
-    es = No se ha encontrado ninguna ruta
-    sv = Ingen rutt hittades
-    th = ไม่พบเส้นทาง
-    tr = Rota bulunamadı
-    uk = Маршрути не знайдено
-    vi = Không tìm thấy tuyến đường
-    zh-Hans = 未找到路线
-    zh-Hant = 找不到路線
-    bg = Не е намерен маршрут
-    ca = No s'ha trobat cap itinerari
-    el = Δεν βρέθηκε διαδρομή
-    et = Marsruuti ei leitud
-    he = לא נמצא מסלול
-    hr = Ruta nije pronađena
-    lt = Maršruto nerasta
-    lv = Nav atrasts neviens maršruts
-    ms = Tiada jalan ditemui
-    sk = Nebola nájdená žiadna trasa
-    sr = Путања није пронађена
-    tl = Walang ruta na natagpuan
-    fa = مسیری یافت نشد
-
-  [route]
-    comment = route title
-    tags = ios,android
-    en = Route
-    ru = Маршрут
-    ar = المسار
-    cs = Trasa
-    da = Rute
-    nl = Route
-    fi = Reitti
-    fr = Itinéraire
-    de = Route
-    hu = Útvonal
-    id = Rute
-    it = Linea
-    ja = 経路
-    ko = 경로
-    nb = Rute
-    pl = Trasa
-    pt = Trajeto
-    pt-BR = Trajeto
-    ro = Traseu
-    sl = Pot
-    es = Ruta
-    sv = Rutt
-    th = เส้นทาง
-    tr = Rota
-    uk = Маршрут
-    vi = Tuyến đường
-    zh-Hans = 路线
-    zh-Hant = 路線
-    bg = Маршрут
-    ca = Ruta
-    el = Διαδρομή
-    et = Marsruut
-    he = נתיב
-    hr = Ruta
-    lt = Maršrutas
-    lv = Maršruts
-    ms = Laluan
-    sk = Trasa
-    sr = Путања
-    tl = Ruta
-    fa = مسیر
-
-  [routes]
-    comment = category title
-    tags = ios,android
-    en = Routes
-    ru = Маршруты
-    ar = المسارات
-    cs = Trasy
-    da = Ruter
-    nl = Routes
-    fi = Reitit
-    fr = Itinéraires
-    de = Routen
-    hu = Útvonalak
-    id = Rute
-    it = Percorsi
-    ja = ルート
-    ko = 경로
-    nb = Ruter
-    pl = Marszruty
-    pt = Trajetos
-    pt-BR = Rotas
-    ro = Trasee
-    sl = Poti
-    es = Rutas
-    sv = Rutter
-    th = เส้นทาง
-    tr = Güzergahlar
-    uk = Маршрути
-    vi = Tuyến đường
-    zh-Hans = 路线
-    zh-Hant = 路線
-    bg = Маршрути
-    ca = Rutes
-    el = Διαδρομές
-    et = Marsruudid
-    he = מסלולים
-    hr = Rute
-    lt = Maršrutai
-    lv = Maršruti
-    ms = Laluan
-    sk = Trasy
-    sr = Путање
-    tl = Mga Ruta
-    fa = مسیر ها
-
-  [download_map_notification]
-    comment = text of notification
-    tags = ios
-    en = Download the map of the place where you are
-    ru = Скачайте карту места, где вы находитесь
-    ar = تنزيل خريطة المكان الذي توجد فيه
-    cs = Stáhněte si mapu místa, kde právě jste
-    da = Download kortet over det sted, hvor du befinder dig
-    nl = Download de kaart van de plaats waar u bent
-    fi = Lataa sijaintisi kartta
-    fr = Télécharger la carte de l'endroit où vous êtes
-    de = Laden Sie die Karte Ihres Standortes herunter
-    hu = Töltsd le annak a helynek a térképét, ahol most vagy
-    id = Unduh peta tempat di mana Anda berada sekarang
-    it = Scarica la mappa del luogo in cui ti trovi
-    ja = あなたがいる場所のマップをダウンロードしよう
-    ko = 당신이 있는 장소의지도를 다운로드 하십시오
-    nb = Last ned kart over stedet der du befinner deg
-    pl = Pobierz mapę miejsca, w którym się zajdujesz
-    pt = Descarregue o mapa do local onde estiver
-    pt-BR = Baixe o mapa do local onde estiver
-    ro = Descărcați harta locului în care vă aflați
-    es = Descarga el mapa del lugar en que te encuentras
-    sv = Ladda ner kartan över din nuvarande plats
-    th = ดาวน์โหลดแผนที่เกี่ยวกับสถานที่ที่คุณอยู่
-    tr = Bulunduğun yerin haritasını indir
-    uk = Завантажуйте карту тієї місцевості, де ви знаходитесь
-    vi = Tải xuống bản đồ của vị trí của bạn
-    zh-Hans = 下载您所在地方的地图
-    zh-Hant = 下載您所在地方的地圖
-    el = Κατεβάστε τον χάρτη της τοποθεσίας που βρίσκεστε
-    he = הורד המפה של המקום בו אתה נמצא
-    sk = Stiahnite si mapu miesta, kde sa práve nachádzate
-    fa = دانلود نقشه جایی که هستید
-
-  [pro_version_is_free_today]
-    comment = text of notification
-    tags = ios
-    en = Full version of Organic Maps is free today! Download now and tell your friends.
-    ru = Полная версия Organic Maps сегодня бесплатна! Скачай сейчас и расскажи друзьям.
-    ar = تطبيق Organic Maps مجاني اليوم! قم بتنزيله الآن وأخبر أصدقائك.
-    cs = Plná verze Organic Maps je dnes zdarma! Stáhněte si ji nyní a dejte vědět přátelům.
-    da = Fuld version af Organic Maps er gratis i dag! Download nu og fortæl dine venner om det.
-    nl = Volledige versie van Organic Maps is nu gratis! Download nu en vertel het je vrienden.
-    fr = Version complète de Organic Maps gratuite aujourd'hui ! Téléchargez-le maintenant et dites-le à vos amis.
-    de = Organic Maps heute gratis! Jetzt runterladen & Ihre Freunde informieren
-    hu = A teljes verzió Organic Maps ma ingyenes! Töltsd le most és meséld el barátaidnak.
-    it = Versione completa di Organic Maps è oggi gratis! Scaricala ora e dillo ai tuoi amici!
-    ja = Organic Mapsのフルバージョンが本日無料！今すぐダウンロードして友達に教えてあげましょう。
-    ko = Organic Maps의 전체 버전 오늘 무료! 지금 다운로드하고 친구들에게 알리세요.
-    pl = Pełna wersja Organic Maps jest dziś za darmo! Pobierz teraz i powiedz znajomym.
-    pt = A versão completa do Organic Maps é hoje grátis! Descarregue e conte aos seus amigos.
-    pt-BR = A versão completa do Organic Maps está grátis hoje! Baixe e conte aos seus amigos.
-    es = ¡Versión completa de Organic Maps gratis hoy! Descárgalo ahora y dilo a tus amigos.
-    sv = Fullständig version av Organic Maps är gratis idag! Ladda ner den nu och berätta för dina vänner.
-    th = เวอร์ชันเต็มของ Organic Maps วันนี้ฟรี! ดาวน์โหลดตอนนี้แล้วบอกเพื่อน ๆ ของคุณ
-    tr = Organic Maps tam sürümü bugün ücretsiz! İndir ve arkadaşlarına haber ver.
-    uk = Повна версія Organic Maps сьогодні безкоштовна! Завантажуй та розкажи друзям.
-    zh-Hans = 完整版Organic Maps是免费的今天! 立刻下载并告诉您的好友。
-    zh-Hant = 現在完整版 Organic Maps 是免費的！馬上下載並告訴您的朋友。
-    he = גרסה מלאה של Organic Maps היא בחינם היום! הורידו עכשיו וספרו לחבריכם.
-    sk = Plná verzia Organic Maps dnes zadarmo! Stiahnite si teraz a povedzte to svojim priateľom.
-    fa = نسخه کامل Organic Maps امروز رایگان است!دانلود کنید و به دوستان خود نیز بگویید
-
-  [move_lite_maps_to_pro]
-    comment = Dialog for transferring maps from lite to pro.
-    tags = android
-    en = We are transferring your downloaded maps from Organic Maps Lite to Organic Maps. It may take a few minutes.
-    ru = Мы переносим загруженные карты из Organic Maps Lite в Organic Maps. Это может занять несколько минут.
-    ar = نحن ننقل خرائط التنزيلات الخاصة بك من Organic Maps Lite إلى Organic Maps. يمكن أن يستغرق بضع دقائق
-    cs = Právě přenášíme vaše stažené mapy z Organic Maps Lite do Organic Maps. Může to několik minut trvat.
-    da = Vi overfører dine downloadede kort fra Organic Maps Lite til Organic Maps. Det kan tage et par minutter.
-    nl = We verplaatsen uw gedownloade kaarten van Organic Maps Lite naar Organic Maps. Dit kan enkele minuten duren.
-    fi = Me siirrämme lataamasi kartat Organic Maps Lite:stä Organic Maps:hen. Siirtäminen voi viedä muutaman minuutin.
-    fr = Nous transférons vos cartes téléchargées de Organic Maps Lite vers Organic Maps. Cela peut prendre quelques minutes.
-    de = Wir übertragen Ihre heruntergeladenen Karten von Organic Maps Lite zu Organic Maps. Dieser Vorgang kann einige Minuten in Anspruch nehmen.
-    hu = Letöltött térképeidet áthelyezzük a Organic Maps Lite-ból a Organic Maps-be. Ez eltarthat pár percig.
-    id = Kami sedang mentransfer peta unduhan Anda dari Organic Maps Lite ke Organic Maps. Proses ini mungkin membutuhkan waktu beberapa menit.
-    it = Stiamo trasferendo le tue mappe scaricate da Organic Maps Lite a Organic Maps. Potrebbe richiedere alcuni minuti.
-    ja = ダウンロード済みの地図をOrganic Maps LiteからOrganic Mapsに転送します。完了までに数分かかるかもしれません。
-    ko = 우리는 Organic Maps. Lite에서 Organic Maps로 다운로드된 지도를 전송하고 있습니다. 이는 몇 분 정도 걸릴 수 있습니다.
-    nb = Vi overfører dine nedlastede kart fra Organic Maps Lite til Organic Maps. Det kan ta noen minutter.
-    pl = Przenosimy twoje pobrane mapy z Organic Maps Lite do Organic Maps. Może to zająć kilka minut.
-    pt = Estamos a transferir os seus mapas descarregados da Organic Maps Lite para a Organic Maps. Isto pode demorar alguns minutos.
-    pt-BR = Estamos transferindo os seus mapas baixados do Organic Maps Lite para o Organic Maps. Isto pode demorar alguns minutos.
-    ro = Transferăm hărțile dvs. descărcate din Organic Maps Lite în Organic Maps. Acest lucru poate dura câteva minute.
-    es = Estamos transfiriendo tus mapas descargados de Organic Maps Lite a Organic Maps, lo cual puede llevar unos minutos.
-    sv = Vi flyttar dina nedladdade kartor från Organic Maps Lite till Organic Maps. Det kan ta några minuter.
-    th = เรากำลังโอนแผนที่ที่ดาวน์โหลดของคุณจาก Organic Maps Lite ไปยัง Organic Maps อาจใช้เวลาสองสามวินาที
-    tr = Organic Maps Lite'den indirmiş olduğunuz haritaları Organic Maps'ye aktarıyoruz. Bu bir kaç dakika sürebilir.
-    uk = Ми переносимо завантажені карти з Organic Maps Lite в Organic Maps. Це може зайняти декілька хвилин.
-    vi = Chúng tôi đang chuyển bản đồ đã tải xuống của bạn từ Organic Maps Lite sang Organic Maps. Việc này có thể mất vài phút.
-    zh-Hans = 我们正在将您从Organic Maps Lite 下载的地图传输至 Organic Maps。这可能需要几分钟的时间。
-    zh-Hant = 我們正在將您從 Organic Maps Lite 下載的地圖傳輸至 Organic Maps。這可能需要幾分鐘的時間。
-    he = אנו מעבירים את המפות שהורדתם מ- Organic Maps Liteל-Organic Maps. פעולה זו עשויה להימשך מספר דקות.
-    sk = Práve prenášame Vaše stiahnuté mapy z Organic Maps lite na Organic Maps. Môže to trvať niekoľko minút.
-    fa = ما در حال انتقال نقشه های دانلود شده شما از Organic Maps Lite به Organic Maps هستیم. ممکن است چند دقیقه طول بکشد.
-
-  [move_lite_maps_to_pro_ok]
-    comment = Message to display when maps moved.
-    tags = android
-    en = Your downloaded maps are successfully transferred to Organic Maps.
-    ru = Ваши карты успешно перенесены в Organic Maps.
-    ar = تم بنجاح نقل خرائطك التي تم تنزيلها إلى Organic Maps.
-    cs = Vaše stažené mapy byly úspěšně přeneseny do Organic Maps.
-    da = Dine downloadede kort er blevet succesfuldt overført til Organic Maps.
-    nl = Uw gedownloade kaarten werden met succes verplaatst naar Organic Maps.
-    fi = Lataamasi kartat on siirretty onnistuneesti Organic Maps:hen.
-    fr = Vos cartes téléchargées ont été transférées avec succès vers Organic Maps.
-    de = Ihre heruntergeladenen Karten wurden erfolgreich zu Organic Maps übertragen.
-    hu = Letöltött térképeidet sikeresen áthelyeztük a Organic Maps-be.
-    id = Peta unduhan Anda berhasil ditransfer ke Organic Maps.
-    it = Le mappe che hai scaricato sono state trasferite con successo a Organic Maps.
-    ja = ダウンロード済みの地図は無事Organic Mapsに転送されました
-    ko = 다운로드된 지도가 성공적으로 Organic Maps에 전송됨
-    nb = Nedlastede kart er overført til Organic Maps.
-    pl = Pomyślnie przeniesiono twoje pobrane mapy do Organic Maps.
-    pt = Os seus mapas descarregados estão transferidos com sucesso para a Organic Maps.
-    pt-BR = Os seus mapas baixados foram transferidos com sucesso para o Organic Maps.
-    ro = Hărțile dvs. descărcate sunt transferate cu succes către Organic Maps.
-    es = Tus mapas descargados se han transferido correctamente a Organic Maps.
-    sv = Dina nedladdade kartor flyttades till Organic Maps.
-    th = แผนที่ที่ดาวน์โหลดของคุณโอนไปยัง Organic Maps สำเร็จ
-    tr = İndirmiş olduğunuz haritalar başarılı bir şekilde Organic Maps'ye aktarıldı.
-    uk = Ваші карти успішно перенесено в Organic Maps.
-    vi = Bản đồ đã tải xuống của bạn đã được chuyển thành công sang Organic Maps.
-    zh-Hans = 您下载的地图已成功传输至 Organic Maps。
-    zh-Hant = 您下載的地圖已成功傳輸至 Organic Maps。
-    he = המפות שהורדתם הועברו בהצלחה ל-Organic Maps.
-    sk = Vaše stiahnuté mapy sú úspešne prenesené na Organic Maps.
-    fa = نقشه های دانلود شده شما با موفقیت به Organic Maps منتقل شد.
-
-  [move_lite_maps_to_pro_failed]
-    comment = Message to display when maps move failed.
-    tags = android
-    en = Your maps failed to transfer. Please delete Organic Maps Lite and download the maps again.
-    ru = При переносе карт возникла ошибка. Пожалуйста, удалите Organic Maps Lite и загрузите карты заново.
-    ar = فشل نقل خرائطك يُرجى حذف Organic Maps Lite وتنزيل الخرائط مرة أخرى.
-    cs = Vaše mapy se nepodařilo přenést. Prosím, odstraňte Organic Maps Lite a stáhněte si mapy znovu.
-    da = Det lykkedes ikke at overføre dine kort. Slet venligst Organic Maps Lite og download kortene igen.
-    nl = Verplaatsing van uw kaarten mislukt. Gelieve Organic Maps Lite te verwijderen en de kaarten opnieuw te downloaden.
-    fi = Karttoja ei voitu siirtää. Ole hyvä ja poista Organic Maps Lite ja lataa kartat uudelleen.
-    fr = Le transfert de vos cartes a échoué. Veuillez supprimer Organic Maps Lite et télécharger les cartes de nouveau.
-    de = Ihre Karten konnten nicht übertragen werden. Bitte löschen Sie Organic Maps Lite und laden Sie die Karten erneut herunter.
-    hu = Térképeid áthelyezése nem sikerült. Kérjük, töröld a Organic Maps Lite-t és töltsd le a térképet megint.
-    id = Peta Anda gagal ditransfer. Silakan hapus Organic Maps Lite dan unduh peta lagi.
-    it = Non è stato possibile trasferire le tue mappe. Cancella Organic Maps Lite e scarica le mappe di nuovo.
-    ja = 地図の転送に失敗しました。Organic Maps Liteを削除してから地図を再度ダウンロードしてください。
-    ko = 지도를 전송하지 못했습니다. Organic Maps Lite를 삭제하고 다시지도를 다운로드하십시오.
-    nb = Kartene dine ble ikke overført. Slett Organic Maps Lite og last ned kartene på nytt.
-    pl = Nie udało się przenieść twoich map. Proszę skasować Organic Maps Lite i pobrać mapy ponownie.
-    pt = Falhou a transferência dos seus mapas. Por favor, elimine a Organic Maps Lite e descarregue os mapas novamente.
-    pt-BR = A transferência dos seus mapas falhou. Por favor, elimine o Organic Maps Lite e baixe os mapas novamente.
-    es = No se han podido transferir tus mapas. Por favor, elimina Organic Maps Lite y descarga los mapas de nuevo.
-    sv = Flytten av dina kartor misslyckades. Vänligen ta bort Organic Maps Lite och ladda ner kartorna igen.
-    th = ล้มเหลวในการโอนแผนที่ของคุณ โปรดลบ Organic Maps Lite และดาวน์โหลดแผนที่อีกครั้ง
-    tr = Haritanızın aktarımı başarısız oldu. Lütfen Organic Maps Lite'yi silin ve haritaları tekrar indirin.
-    uk = При переносі карт виникла помилка. Будь ласка, видаліть Organic Maps Lite і завантажте карти знову.
-    vi = Bản đồ của bạn không chuyển được. Vui lòng xóa Organic Maps Lite và tải xuống lại bản đồ.
-    zh-Hans = 您的地图传输失败。请删除 Organic Maps Lite，然后再次下载地图。
-    zh-Hant = 您的地圖傳輸失敗。請刪除 Organic Maps Lite，然後再次下載地圖。
-    he = העברת המפות שלכם נכשלה. אנא מחקו את Organic Maps Lite והורידו שוב את המפות.
-    sk = Vaše mapy sa nepodarilo preniesť. Vymažte prosím Organic Maps Lite a stiahnite si mapy znova.
-    fa = انتقال نقشه با شکست مواجه شد.لطفا Organic Maps Lite حذف کرده و نقشه ها را دوباره دانلود نماید
-
-  [settings_and_more]
-    comment = Text in menu
-    tags = ios, android
-    en = Settings & More
-    ru = Настройки и другое
-    ar = الإعدادات والمزيد
-    cs = Nastavení a další
-    da = Indstillinger & Mere
-    nl = Instellingen & meer
-    fi = Asetukset &amp; Lisää
-    fr = Paramètres & plus
-    de = Einstellungen & mehr
-    hu = Beállítások és egyéb
-    id = Setelan &amp; Lebih Banyak
-    it = Impostazioni e Altro
-    ja = 設定&その他
-    ko = 설정 및 기타
-    nb = Innstillinger med mer
-    pl = Ustawienia i inne
-    pt = Definições e Mais
-    pt-BR = Configurações e Mais
-    ro = Setări și altele
-    es = Ajustes y más
-    sv = Inställningar & Mer
-    th = การตั้งค่า & อื่น ๆ
-    tr = Ayarlar & Fazlası
-    uk = Налаштування
-    vi = Thiết lập &amp; Khác
-    zh-Hans = 设置及更多
-    zh-Hant = 設定及更多
-    he = הגדרות ועוד
-    sk = Nastavenia a viac
-    fa = تنظیمات و بیشتر
 
   [website]
     comment = Text in menu
-    tags = android
+    tags = ios, android
     en = Website
     ru = Вебсайт
     ar = الموقع الإلكتروني
@@ -5996,8 +4096,8 @@
     zh-Hans = 网站
     zh-Hant = 網站
     el = Ιστότοπος
-    sk = Webové stránky
     fa = وب سایت
+    sk = Webové stránky
 
   [github]
     comment = Text in menu
@@ -6029,44 +4129,9 @@
     tags = ios, android
     en = OpenStreetMap
 
-  [contact_us]
-    comment = Text in menu
-    tags = ios
-    en = Contact us
-    ru = Свяжитесь с нами
-    ar = أتصل بنا
-    cs = Kontaktovat nás
-    da = Kontakt os
-    nl = Contact met ons opnemen
-    fi = Ota yhteyttä
-    fr = Contactez-nous
-    de = Kontaktieren Sie uns
-    hu = Kapcsolat
-    id = Hubungi kami
-    it = Contattaci
-    ja = お問い合わせ
-    ko = 연락처
-    nb = Kontakt oss
-    pl = Skontaktuj się z nami
-    pt = Contacte-nos
-    pt-BR = Entre em contato
-    ro = Contactați-ne
-    es = Contacta con nosotros
-    sv = Kontakta oss
-    th = ติดต่อเรา
-    tr = İletişim
-    uk = Контакти
-    vi = Liên hệ với chúng tôi
-    zh-Hans = 联系我们
-    zh-Hant = 聯絡我們
-    el = Επικοινωνήστε μαζί μας
-    he = יצירת קשר
-    sk = Kontaktovať nás
-    fa = تماس با ما
-
   [feedback]
     comment = Settings: Send feedback button and dialog title
-    tags = android
+    tags = ios, android
     en = Feedback
     ru = Связаться с нами
     ar = تعقيب
@@ -6095,47 +4160,12 @@
     zh-Hans = 反馈
     zh-Hant = 意見反應
     el = Σχόλια
-    sk = Spätná väzba
     fa = بازخورد
-
-  [subscribe_to_news]
-    comment = Text in menu
-    tags = ios, android
-    en = Subscribe to our newsletter
-    ru = Подписаться на новости
-    ar = أشترك في نشرتنا الإخبارية
-    cs = Přihlásit se k newsletteru
-    da = Abonnér på vores nyheder
-    nl = Aanmelden voor onze nieuwtjes
-    fi = Tilaa uutiskirjeemme
-    fr = S'abonner à nos informations
-    de = Abonnieren Sie unsere News
-    hu = Iratkozz fel hírlevelünkre
-    id = Berlangganan berita kami
-    it = Iscriviti alle nostre notizie
-    ja = 当社のニュースに登録
-    ko = 우리 뉴스 구독
-    nb = Abonner på nyheter fra oss
-    pl = Subskrybuj nasze wiadomości
-    pt = Subscreva as nossas notícias
-    pt-BR = Assine a nossa newsletter
-    ro = Abonați-vă la știrile noastre
-    es = Suscríbete a nuestras noticias
-    sv = Prenumerera på våra nyheter
-    th = สมัครรับข่าวของเรา
-    tr = Haberlerimize abone ol
-    uk = Email-бюлетень
-    vi = Đăng ký nhận tin tức của chúng tôi
-    zh-Hans = 订阅我们的新闻
-    zh-Hant = 訂閱我們的新聞
-    el = Εγγραφή στο ενημερωτικό μας δελτίο
-    he = הירשמו לקבלת חדשות מאיתנו
-    sk = Prihlásiť sa k našim novinkám
-    fa = اشتراک در خبرنامه ما
+    sk = Spätná väzba
 
   [rate_the_app]
     comment = Text in menu
-    tags = ios, android
+    tags = ios
     en = Rate the app
     ru = Оценить приложение
     ar = تقييم التطبيق
@@ -6164,9 +4194,9 @@
     zh-Hans = 为该应用打分
     zh-Hant = 為該應用程式評分
     el = Βαθμολογήστε την εφαρμογή
+    fa = امتیاز به این اپلیکیشن
     he = דרגו את האפליקציה
     sk = Ohodnotiť aplikáciu
-    fa = امتیاز به این اپلیکیشن
 
   [help]
     comment = Text in menu
@@ -6199,9 +4229,9 @@
     zh-Hans = 帮助
     zh-Hant = 幫助
     el = Βοήθεια
+    fa = کمک
     he = עזרה
     sk = Nápoveda
-    fa = کمک
 
   [copyright]
     comment = Text in menu
@@ -6234,13 +4264,13 @@
     zh-Hans = 版权
     zh-Hant = 版權
     el = Πνευματικά δικαιώματα
+    fa = حق نشر و کپی رایت
     he = זכויות יוצרים
     sk = Autorské práva
-    fa = حق نشر و کپی رایت
 
   [report_a_bug]
     comment = Text in menu
-    tags = ios
+    tags = ios, android
     en = Report a bug
     ru = Сообщить о проблеме
     ar = الإبلاغ عن خطأ
@@ -6269,114 +4299,9 @@
     zh-Hans = 报告漏洞
     zh-Hant = 報告錯誤
     el = Αναφορά σφάλματος
+    fa = گزارش خطا
     he = דווחו על באג
     sk = Nahlásiť chybu
-    fa = گزارش خطا
-
-  [subscribe_me_subject]
-    comment = Email subject
-    tags = ios, android
-    en = Please subscribe me to the Organic Maps newsletter
-    ru = Подпишите меня на email-рассылку Organic Maps
-    ar = يرجى اشتراكي في النشرة البريدية لدى Organic Maps
-    cs = Přihlaste mě, prosím, k odběru zpravodaje Organic Maps
-    da = Tilmeld mig Organic Maps-nyhedsbrev
-    nl = Ik meld mij aan voor de nieuwsbrief Organic Maps
-    fi = Lisätkää minut Organic Maps:n uutiskirjeen tilaajaksi
-    fr = Veuillez m'inscrire à la lettre d'information de Organic Maps
-    de = Ich möchte gerne den Organic Maps-Newsletter abonnieren
-    hu = Fel szeretnék iratkozni a Organic Maps hírlevelére
-    id = Mohon daftarkan saya untuk berlangganan berita Organic Maps
-    it = Iscrivimi alla newsletter di Organic Maps
-    ja = Organic Mapsニュースレターを購読します
-    ko = Organic Maps 뉴스 레터로 나를 구독해 주십시오.
-    nb = Jeg vil abonnere på Organic Maps-nyhetsbrevet
-    pl = Chcę subskrybować biuletyn Organic Maps
-    pt = Por favor inscrevam-me na newsletter da Organic Maps
-    pt-BR = Por favor me inscrevam na newsletter do Organic Maps
-    ro = Abonează-mă la buletinul informativ Organic Maps.
-    es = Por favor quiero suscribirme al boletín de Organic Maps
-    sv = Anmäl mig till Organic Maps nyhetsbrev
-    th = โปรดลงชื่อฉันเพื่อรับจดหมายข่าว Organic Maps
-    tr = Lütfen Organic Maps haber bültenine beni abone yap
-    uk = Підпишіть мене на email-розсилку Organic Maps
-    vi = Vui lòng đăng ký tôi vào danh sách nhận thư định kỳ Organic Maps
-    zh-Hans = 请帮我订阅Organic Maps简报
-    zh-Hant = 請幫我訂閱 Organic Maps 新聞郵件、
-    el = Εγγράψτε με στο ενημερωτικό δελτίο Organic Maps
-    he = אנא רשמו אותי לניוזלטר של Organic Maps
-    sk = Prihláste ma prosím k odberu spravodaja Organic Maps
-    fa = لطفا من را در خبرنامه Organic Maps مشترک کنید
-
-  [subscribe_me_body]
-    comment = Email body
-    tags = ios, android
-    en = I want to be the first to learn about the latest news, app updates, and promotions. I understand that I can cancel my subscription at any time.
-    ru = Я хочу первым узнавать обо всех новостях, обновлениях приложения и акциях. Я могу отписаться от рассылки в любой момент.
-    ar = أريد أن أكون أول من يعرف آخر الأخبار والتحديثات والترقيات. يمكنني إلغاء اشتراكي في أي وقت.
-    cs = Chci se vždy jako první dozvídat o nejnovějších zprávách, aktualizacích a akčních nabídkách. Své přihlášení k odběru mohu kdykoli zrušit.
-    da = Jeg vil være den første til at høre om de seneste nyheder opdateringer og tilbud. Jeg kan opsige abonnementet når som helst.
-    nl = Ik wil graag als eerste horen over het laatste nieuws updates en acties. Ik kan mijn abonnement te allen tijde annuleren.
-    fi = Liittäkää minut Organic Maps -uutiskirjeen tilaajaksi saadakseni ensimmäisenä tietoa uusista päivityksistä ja TARJOUKSISTA. Voin peruuttaa tilaukseni koska tahansa.
-    fr = Informez-moi en priorité des dernières nouvelles, des mises à jour et des promotions. Je peux annuler mon abonnement à tout moment.
-    de = Gerne möchte ich zu den Ersten gehören, die aktuelle Neuigkeiten erfahren und über neueste Aktualisierungen und Werbeangebote informiert werden. Mein Abo kann ich jederzeit kündigen.
-    hu = Elsőként szeretnék értesülni a legújabb hírekről frissítésekről és promóciókról. A feliratkozásom bármikor törölhetem.
-    id = Saya ingin menjadi yang pertama untuk mengetahui kabar dan promosi terbaru. Saya dapat membatalkan langganan saya kapan saja.
-    it = Voglio essere tra i primi a sapere delle ultime novità aggiornamenti e promozioni. Potrò annullare l'iscrizione in ogni momento.
-    ja = 最新ニュース、アップデートとプロモーションにすいてまず知りたいです。いつでも購読をキャンセル出来ます。
-    ko = 나는 최신 뉴스 업데이트 및 프로모션에 대해 알게될 첫번째 사람이 되고 싶습니다. 나는 언제나 구독을 취소할 수 있습니다.
-    nb = Jeg ønsker å være den første som får vite om siste nytt og nye kampanjer. Jeg kan avbestille abonnementet når som helst.
-    pl = Chcę w pierwszej kolejności otrzymywać powiadomienia o nowościach aktualizacjach i promocjach. Mogę w każdej chwili anulować swoją subskrypcję.
-    pt = Quero ser o(a) primeiro(a) a saber sobre as últimas notícias, actualizações e promoções. Posso cancelar a minha subscrição a qualquer altura.
-    pt-BR = Quero ser o(a) primeiro(a) a saber sobre as últimas notícias, atualizações e promoções. Posso cancelar a minha inscrição a qualquer momento.
-    ro = Vreau să fiu primul care află despre cele mai recente actualizări și promoții. Îmi pot anula abonamentul în orice moment.
-    es = Quiero ser el primero en conocer las últimas noticias actualizaciones y promociones. Puedo cancelar mi suscripción en cualquier momento.
-    sv = Jag vill bli först att veta om de senaste uppdateringarna och erbjudandena. Jag kan avbryta min prenumeration när som helst.
-    th = ฉันอยากเป็นคนแรกที่รู้เกี่ยวกับข่าว อัปเดตและโปรโมชั่นล่าสุด ฉันสามารถยกเลิกการเป็นสมาชิกของฉันได้ตลอดเวลา
-    tr = En son haberlerden güncellemelerden ve tanıtımlardan ilk önce haberdar olmak istiyorum. Aboneliğimi herhangi bir zaman iptal edebilirim.
-    uk = Я хочу першим дізнаватися про всі новини оновлення програм і акції. Я можу відписатися від розсилки в будь-який момент.
-    vi = Tôi muốn là người đầu tiên được biết về các thông tin cập nhật và quảng bá mới nhất. Tôi có thể hủy bỏ đăng ký nhận tin của mình bất cứ lúc nào.
-    zh-Hans = 我想率先了解最新新闻、更新及促销活动。订阅可随时取消。
-    zh-Hant = 我想搶先了解最新新聞、更新和促銷活動。我可以隨時取消我的訂閱。
-    el = Θέλω να μαθαίνω πρώτος(η) τις τελευταίες ειδήσεις, ενημερώσεις εφαρμογών και προωθητικές ενέργειεςς. Καταλαβαίνω ότι μπορώ να ακυρώσω τη συνδρομή μου ανά πάσα στιγμή.
-    he = אני מעוניין להיות הראשון שיקבל עדכונים על חדשות ומבצעים. אני יכול לבטל את המינוי שלי בכל עת.
-    sk = Chcem sa vždy ako prvý dozvedať o najnovších správach, aktualizáciách a akčných ponukách. Svoje prihlásenie k odberu môžem kedykoľvek zrušiť.
-    fa = من می خواهم اولین نفری باشم که در جریان اخرین اخبار واپدیت های نرم افزار قرار می گیرم.می دانم در هر زمان میتوان این اشتراک را لغو کرد.
-
-  [about_text]
-    comment = About text
-    tags = ios, android
-    en = Organic Maps offers the fastest offline maps of all the cities, all countries of the world. Travel with full confidence: wherever you are, Organic Maps helps to locate yourself on the map, find the nearest restaurant, hotel, bank, gas station etc. It doesn’t require internet connection.\n\nWe are always working on new features and would love to hear from you on how you think we could improve Organic Maps. If you have any problems with the app, don't hesitate to contact us at support@organicmaps.app. We respond to every request!\n\nDo you like Organic Maps and want to support us? There are some simple and absolutely free ways:\n\n- post a review at your App Market\n- like our Facebook page http://www.facebook.com/OrganicMaps\n- or just tell about Organic Maps to your mom, friends and colleagues :)\n\nThank you for being with us. We appreciate your support very much!\n\nP.S. We take map data from OpenStreetMap, a mapping project similar to Wikipedia, which allows users to create and edit maps. If you see something is missing or wrong on the map, you can correct the maps directly at https://www.openstreetmap.org, and your changes will appear in Organic Maps app with the next version release.
-    en-GB = Organic Maps offers the fastest offline maps of all the cities, all countries of the world. Travel with full confidence: wherever you are, Organic Maps helps to locate yourself on the map, find the nearest restaurant, hotel, bank, petrol station etc. It doesn’t require internet connection.\n\nWe are always working on new features and would love to hear from you on how you think we could improve Organic Maps. If you have any problems with the app, don't hesitate to contact us at support@organicmaps.app. We respond to every request!\n\nDo you like Organic Maps and want to support us? There are some simple and absolutely free ways:\n\n- post a review at your App Market\n- like our Facebook page http://www.facebook.com/OrganicMaps\n- or just tell about Organic Maps to your mom, friends and colleagues :)\n\nThank you for being with us. We appreciate your support very much!\n\nP.S. We take map data from OpenStreetMap, a mapping project similar to Wikipedia, which allows users to create and edit maps. If you see something is missing or wrong on the map, you can correct the maps directly at https://www.openstreetmap.org, and your changes will appear in Organic Maps app with the next version release.
-    ru = Organic Maps предлагает карты всех городов, всех стран мира, которые работают без подключения к интернету. Путешествуйте с уверенностью: где бы вы ни находились, Organic Maps помогут решить любую вашу проблему - помогут определить ваше местоположение, найти ресторан, отель, заправку, банк, туалет и т.д.\n\nМы постоянно работаем над добавлением новых функций, поэтому если у вас есть идеи или предложения по улучшению Organic Maps, пишите нам. Если у вас возникла проблема с приложением, сообщите нам, пожалуйста, о ней. Наш емэйл support@organicmaps.app. Мы отвечаем на все письма! Если вам нравится приложение и вы хотите поддержать нас, есть несколько простых и абсолютно бесплатных способов:\n\n- оставьте отзыв в вашем магазине приложений\n- подпишитесь на наши новости на Facebook странице http://www.facebook.com/OrganicMaps\n- или просто расскажите о Organic Maps своей маме, друзьям и коллегам :)\n\nСпасибо за вашу поддержку!\n\nP.S. В приложении мы используем картографические данные проекта OpenStreetMap, который работает по принципу Википедии, давая возможность пользователям со всего мира создавать и редактировать карты. Если вы заметили, что на карте что-то не соответствует действительности либо отсутствует, вы можете откорректировать это прямо на сайте https://www.openstreetmap.org, и эти исправления появятся во время следующего обновления Organic Maps.
-    ar = توفر لكم Organic Maps أحدث الخرائط دون الاتصال بالإنترنت لكافة دول وكافة مدن العالم. سافر وتمتع بالثقة التامة: إينما كنت، تساعدك Organic Maps على تحديد مكانك على الخريطة، والعثور على أقرب مطعم أو فندق أو بنك أو محطة غاز الخ لا يتطلب الاتصال بالإنترنت.\n\nنحن نعمل دوماً على إدخال مزايا جديدة على التطبيق ونود أن نسمع منك رأيك عن الكيفية التي يمكن بها تحسين تطبيق Organic Maps في رأيك. إذا واجهتك أي مشاكل مع التطبيق، لا تتردد في الاتصال بنا على support@organicmaps.app. نحن نرد على كافة الطلبات.\n\nهل أعجبك تطبيق Organic Maps وترغب في دعمنا؟ هناك بعض الطرق السهلة والمجانية بالكامل لعمل ذلك.\n\n- انشر رأيك على متجر التطبيقات الخاص بك\n- اعجب بصفحتنا على موقع Facebook http://www.facebook.com/OrganicMaps\n- أو أخبر والدتك وأصدقائك وزملائك عن تطبيق Organic Maps :)\n\nشكراً لك على وجودك معنا. نحن نقدر جداً دعمك لنا!\n\nيُرجى ملاحظة نحن نستقي بيانات الخرائط من OpenStreetMap، مشروع خرائط يشبه موسوعة Wikipedia ويتيح هذا المشروع للمستخدمين إنشاء وتحرير الخرائط. إذا كنت ترى أن هناك خطأ ما أو شيء غير موجود على الخريطة، يمكنك تصحيح الخرائط مباشرة على https://www.openstreetmap.org، وسوف تظهر تغييراتك على تطبيق Organic Maps في الإصدار القادم للتطبيق.
-    cs = Organic Maps nabízí nejrychlejší offline mapy všech měst a zemí po celém světě. Cestujte s naprostou důvěrou: kdekoliv jste, Organic Maps vám pomůže se najít na mapě, vyhledat nejbližší restauraci, hotel, banku, benzínovou pumpu atd. Nevyžaduje připojení k Internetu.\n\nNeustále pracujeme na nových funkcích a rádi bychom slyšeli také váš názor, jak můžeme Organic Maps vylepšit. Pokud máte s touto aplikací jakékoliv problémy, pak nás neváhejte kontaktovat na support@organicmaps.app. Odpovídáme na každý požadavek!\n\nLíbí se vám Organic Maps a chcete nás podpořit? Existuje několik snadných způsobů zcela zdarma:\n\n• napište recenzi ve svém obchodu s aplikacemi\n• označte naši facebookovou stránku http://www.facebook.com/OrganicMaps pomocí To se mi líbí\n• nebo jen řekněte o Organic Maps své mámě, kamarádům a kolegům :)\n\nDěkujeme, že jste s námi. Velmi si ceníme vaší podpory!\n\nP.S. Mapové podklady získáváme z OpenStreetMap, což je mapový projekt podobný Wikipedii, který umožňuje uživatelům vytvářet a upravovat mapy. Pokud zjistíte, že na mapě něco chybí nebo je špatně, pak můžete mapy opravit přímo na https://www.openstreetmap.org, a vaše změny se objeví v příští verzi Organic Maps. Díky!
-    da = Organic Maps tilbyder de hurtigste offline-kort over alle byer og alle lande i verden. Rejs med tillid: Hvor end du befinder dig, hjælper Organic Maps med at lokalisere din placering på kortet, finde den nærmeste restaurant, hotel, bank, benzintank og så videre. Det er ikke nødvendigt at have forbindelse til internettet.\n\nVi arbejder altid på nye funktioner, og vi vil meget gerne høre fra dig, hvis du har forslag til, hvordan vi kan forbedre Organic Maps. Hvis du oplever problemer med appen, er du meget velkommen til at kontakte os på support@organicmaps.app. Vi besvarer alle henvendelser!\n\nSynes du om Organic Maps, og har du lyst til at støtte os? Her er nogle simple og helt gratis metoder:\n\n-post en anmeldelse i din App Store\n-like vores facebook-side http://www.facebook.com/OrganicMaps\n-neller fortæl din mor, venner og kollegaer om Organic Maps :)\n\nTak fordi du støtter os. Vi sætter stor pris på din støtte!\n\nPS: Vi får vores kortdata fra OpenStreetMap, som er et kortprojekt, der minder om Wikipedia, og som gør brugere i stand til at oprette og rette kort. Hvis du oplever, at noget mangler eller er forkert på kortet, kan du rette kortene direkte på https://www.openstreetmap.org, og dine ændringer vil figurere på Organic Maps-appen i forbindelse med frigivelsen af den næste version.
-    nl = Organic Maps biedt de snelste offline kaarten van alle steden en alle landen ter wereld. Reis vol vertrouwen: waar je ook bent,\n\nOrganic Maps zal je helpen om jezelf op de kaart terug te vinden en het dichstbijzijnde restaurant, hotel, bank, benzinestation etc. te vinden. Er is geen internetverbinding voor nodig.\n\nWe werken voortdurend aan nieuwe functies en we zouden graag van je willen horen hoe we Organic Maps volgens jou zouden kunnen verbeteren. Als je eventueel problemen hebt met de app, aarzel dan niet om contact met ons op te nemen op support@organicmaps.app. We reageren op elke aanvraag!\n\nVindt je Organic Maps leuk en wil je ons steunen? Dat kan op een aantal simpele en absoluut gratis manieren:\n- plaats een beoordeling op je App Market\n- like onze Facebook-pagina http://www.facebook.com/OrganicMaps\n- of vertel gewoon je ma, vrienden en collega’s over Organic Maps :) Dank je dat je ons steunt. Wij waarderen dit heel erg!\n\nP.S. We halen onze kaartgegevens van OpenStreetMap, een kaartproject dat lijkt op Wikipedia, waarbij gebruikers kaarten kunnen maken en aanpassen. Als je ziet dat er iets ontbreekt of een fout ontdekt in een kaart, dan kun je de kaart direct verbeteren op https://www.openstreetmap.org, en dan zullen je verbeteringen bij het uitbrengen van de volgende versie in Organic Maps verschijnen.
-    fi = Organic Maps tarjoaa nopeimmat offline-kartat kaikista kaupungeista, kaikissa maissa ympäri maailman. Matkusta luottavaisin mielin - missä ikinä oletkin, Organic Maps auttaa sinua löytämään itsesi kartalta, ohjaamaan sinut lähimpään ravintolaan, hotelliin, pankkiin, huoltoasemalle jne. Internet-yhteyttä ei tarvita.\n\nTyöskentelemme jatkuvasti uusien ominaisuuksien parissa, ja haluammekin kuulla sinulta kuinka voimme parantaa MAPS.me -sovellusta entisestään. Mikäli sinulla on ongelmia sovelluksen kanssa, älä epäröi ottaa yhteyttä asiakaspalveluumme osoitteessa support@organicmaps.app. Vastaamme jokaiseen yhteydenottoon!\n\nTykkäätkö Organic Maps -sovelluksesta ja haluat tukea meitä? Siihen on muutamia helppoja ja täysin ilmaisia tapoja:\n\n- lisää sovellusarviosi käyttämääsi sovelluskauppaan\n - tykkää Facebook-sivustamme osoitteessa http://www.facebook.com/OrganicMaps\n- kerro MAPS.me:stä äidillesi, ystävillesi ja kollegoillesi :)\n\nKiitos sovelluksen käytöstä. Arvostamme tukeasi todella paljon!\n\nP.S. Kaikki tiedot noudetaan OpenStreetMap-palvelusta, joka on Wikipedian kaltainen karttaprojekti, jossa kuka tahansa voi lisätä ja muokata karttoja. Mikäli havaitset kartoissa virheitä ja puutteita, voit korjata ne osoitteessa https://www.openstreetmap.org, ja muutokset näkyvät sovelluksessa seuraavan Organic Maps -päivityksen jälkeen.
-    fr = Organic Maps offre les cartes hors ligne les plus rapides de toutes les villes, de tous les pays du monde. Voyagez en toute confiance : où que vous soyez, Organic Maps permet de vous situer sur la carte, de trouver le restaurant, l'hôtel, la banque, la station d'essence, etc. les plus proches. Ceci sans aucune connexion Internet.\n\nNous travaillons toujours sur de nouvelles fonctionnalités et nous aimerions avoir votre avis sur la manière d'améliorer Organic Maps. Si vous avez quelque problème avec l'appli, n'hésitez pas à nous contacter à support@organicmaps.app. Nous répondons à toutes les demandes !\n\nVous aimez-vous Organic Maps et souhaitez nous soutenir ? Il existe des moyens simples et tout à fait gratuits :\n\n- Publier une critique sur votre boutique d'applis\n- aimez notre page Facebook http://www.facebook.com/OrganicMaps\n- ou parlez simplement de Organic Maps à votre maman, à vos amis et à vos collègues :)\n\nNous vous remercions de votre fidélité. Nous apprécions beaucoup votre soutien !\n\nP.S. : nous prenons les données cartographiques d'OpenStreetMap, un projet de cartographie similaire à Wikipédia, qui permet aux utilisateurs de créer et de modifier des cartes. Si vous voyez une omission ou une erreur sur la carte, vous pouvez corriger les cartes directement sur https://www.openstreetmap.org, et vos modifications apparaîtront dans l'appli Organic Maps lors la prochaine version.
-    de = Organic Maps bietet die schnellsten Offline-Karten aller Städte weltweit. Reisen Sie mit Vertrauen: wo immer Sie sind hilft Ihnen Organic Maps, sich auf der Karte zurecht zu finden. Finden Sie das nächstgelegene Restaurant, Hotel, Bank, Tankstelle usw. Es ist keine Internet-Verbindung erforderlich.\n\nWir arbeiten ständig an neuen Funktionen und freuen uns, von Ihnen zu hören, wie wir Organic Maps verbessern können. Wenn Sie Probleme mit der App haben, zögern Sie nicht, mit uns über support@organicmaps.app in Verbindung zu treten. Wir reagieren auf jede Anfrage!\n\nMögen Sie Organic Maps und wollen Sie uns unterstützen? Es gibt einige einfache und absolut kostenlose Möglichkeiten:\n\n- Veröffentlichen Sie eine Bewertung auf Ihrem App-Store\n- Liken Sie unsere Facebook-Seite http://www.facebook.com/OrganicMaps\n- Oder erzählen einfach nur Ihrer Mutter, Freunden und Kollegen von Organic Maps:)\n\nDanke, dass Sie bei uns sind. Wir freuen uns sehr über Ihre Unterstützung!\n\nPS: Wir nutzen die Kartendaten von OpenStreetMap, einem Kartierungs-Projekt ähnlich Wikipedia, bei welchem Mitglieder Kartendaten erfassen. Wenn Sie sehen, dass auf der Karte etwas fehlt oder falsch ist, können Sie die Karten direkt auf https://www.openstreetmap.org korrigieren und die Änderungen erscheinen in der nächsten Version der Organic Maps-App.
-    hu = A Organic Maps kínálja a leggyorsabb offline térképeket, a világ összes városáról és országáról. Utazz magabiztosan: bárhol is vagy, a Organic Maps segít, hogy megtaláld magad a térképen, valamint segít a legközelebbi étterem, hotel, bank, benzinkút stb. felkutatásában is. Nem igényel internet kapcsolatot.\n\nMindig dolgozunk új fejlesztéseken és örömmel vennénk a te véleményedet is arról, hogyan tudnánk tovább fejleszteni a Organic Maps-t. Bármely probléma esetén írj nekünk a support@organicmaps.app email címre. Minden levélre válaszolunk!\n\nSzereted a Organic Maps-t és szeretnél támogatni minket? Van erre pár egyszerű és teljesen ingyenes lehetőséged:\n\n- írj rólunk értékelést az App Market-en\n- kedveld a Facebook oldalunkat: http://www.facebook.com/OrganicMaps\n- vagy csak mesélj a Organic Maps-ről anyukádnak, barátaidnak és munkatársaidnak :)\n\nKöszönjük, hogy velünk vagy. Nagyra értékeljük támogatásodat!\n\nU.i: Adatainkat az OpenStreetMap-ről vesszük, ami egy, a Wikipedia-hoz hasonló térképes projekt, ami megengedi felhasználóinak a térképek létrehozását és szerkesztését. Ha bármi hiányzik vagy rossz a térképpel, közvetlenül te is kijavíthatod a https://www.openstreetmap.org-on és változtatásaid a Organic Maps következő verziójában már meg fognak jelenni.
-    id = Organic Maps menawarkan peta offline tercepat dari semua kota, semua negara di dunia. Berpergianlah dengan kepercayaan diri yang penuh: di nana pun Anda berada, Organic Maps akan membantu Anda mengetahui posisi Anda pada peta, menemukan restoran, hotel, bank, stasiun bahan bakar terdekat, dll. Tidak perlu koneksi internet.Kami selalu membuat fitur-fitur baru dan ingin mendengar pendapat Anda mengenai bagaimana kami dapat membuat Organic Maps menjadi lebih baik. Jika Anda memiliki masalah apa pun dengan aplikasinya, jangan segan untuk menghubungi kami di support@organicmaps.app. Kami akan merespons setiap permintaan!Apakah Anda menyukai Organic Maps an ingin membantu kami? Terdapat beberapa cara yang mudah dan sepenuhnya gratis:- tulis ulasan di App Market Anda
-    it = Organic Maps offre le più veloci mappe offline di tutte le città, di tutti i paesi del mondo. Viaggia con piena fiducia: ovunque ti trovi, Organic Maps ti aiuta a localizzarti sulla mappa, trovare ristoranti, hotel, banche, distributori di benzina ecc.., e non richiede la connessione a internet.\n\nLavoriamo sempre su nuove funzionalità e ci piacerebbe sapere da te in cosa potremmo migliorare Organic Maps. Se avessi problemi con l'app, non esitare a contattarci a support@organicmaps.app. Rispondiamo ad ogni richiesta!\n\nTi piace Organic Maps e vuoi sostenerci? Ci sono alcuni modi semplici e assolutamente gratuiti:\n\n- Invia una recensione al tuo App Market\n- Metti mi piace sulla nostra pagina di Facebook http://www.facebook.com/OrganicMaps\n- O semplicemente fai pubblicità a Organic Maps con la tua mamma, i tuoi amici e colleghi :)\n\nGrazie per essere stato con noi. Apprezziamo molto il tuo supporto!\n\nP.S. Prendiamo i dati delle mappe da OpenStreetMap, un progetto di mappatura simile a Wikipedia, che permette agli utenti di creare e modificare le mappe. Se vedi che manca qualcosa o se c'è qualcosa di sbagliato sulla mappa, puoi correggere le mappe direttamente su https://www.openstreetmap.org, e le modifiche appariranno nella prossima versione dell'app Organic Maps.
-    ja = Organic Mapsは世界の全ての国、全ての都市が載っている最速のオフラインマップ。どこにいてもOrganic Mapsの地図上でユーザーの現在地が分かり、付近のレストラン、ホテル、銀行、ガソリンスタンドなどが見つけられるので、自信を持って旅行ができます。インターネット接続は必要ありません。\n\n弊社では常に新機能の開発に取り組んでいるので、Organic Mapsの改善についてユーザーの皆様からのご意見やご感想をお待ちしています。アプリで問題点が見つかった際は、お気軽にsupport@organicmaps.appまでご連絡ください。どのようなリクエストにでも対応いたします!\n\nOrganic Mapsが好きでサポートしていただけますか。シンプルで完全無料の方法がいくつかあります。\n\n- お使いのアプリマーケットでレビューを投稿\n- 弊社のFacebookページで「いいね!」をクリック：http://www.facebook.com/OrganicMaps\n- Organic Mapsのことをお母様、お友達、同僚の皆様に話す (^_^)\n\n弊社アプリをご利用いただきありがとうございます。皆様からのサポートに大変感謝しております!\n\n追伸：ウィキペディアのようにユーザーによる作成や編集が可能なマッピングプロジェクトOpenStreetMapの地図データを使用しています。地図上で欠けているものや誤りを見つけた場合、https://www.openstreetmap.orgでユーザーが直接修正ができます。このような変更はOrganic Mapsのその後のバージョンリリースの際に反映されます。
-    ko = Organic Maps는 가장 빠른 전 세계 모든 국가 및 도시의 오프라인 지도를 제공하고 있습니다. 자신있게 여행하세요. 계신 곳이 어디이든 Organic Maps는 지도상에서 위치하고 계신 곳이 어디 있지 알려 주고 가장 가까운 식당, 호텔 및 주유소 등을 찾아 줍니다. 인터넷 접속이 필요없는 서비스입니다.\n\nOrganic Maps는 항상 새로운 기능들에 대해 연구하고 있습니다. Organic Maps가 더 훌륭한 서비스를 제공할 수 있도록 많은 의견 주시면 감사하겠습니다. 앱을 사용하시다 불편한 점이 있으시면, 주저 마시고 support@organicmaps.app으로 문의해 주세요. Organic Maps는 어떤 요청에도 기꺼이 응답할 것입니다.\n\nOrganic Maps가 좋은 앱이라고 생각하시나요? Organic Maps을 후원할 수 있는 간단하면서도 비용이 전혀 들지 않는 몇 가지 방법을 소개합니다.\n\n- 앱 마켓에 리뷰를 올려주세요.\n- Organic Maps의 페이스북 페이지 http://www.facebook.com/OrganicMaps 에 “좋아요”를 남겨 주세요.\n- 가족, 친구 및 동료들에게 Organic Maps를 자랑해 주세요.\n\nOrganic Maps와 함께 해 주셔서 감사합니다. 여러분의 후원에 정말 감사드립니다!\n\nP.S. Organic Maps는 OpenStreetMap으로부터 맵 데이터를 수집하고 있습니다. OpenStreetMap은 위키피디아처럼 유저들이 맵을 만들고 편집할 수 있는 맵핑 프로젝트입니다.\n\n혹 맵에서 누락된 곳이나 잘못된 점을 발견하실 경우, https://www.openstreetmap.org에서 직접 맵을 수정하실 수 있습니다. 수정한 부분은 다음 버전으로 출시되는 Organic Maps 앱에 반영될 것입니다.
-    nb = Organic Maps tilbyr de raskeste offline-kartene over alle byer i alle land i verden. Reis trygt: Uansett hvor du er, kan Organic Maps hjelpe deg med å finne ut hvor du er på kartet eller finne nærmeste restaurant, hotell, bank, bensinstasjon osv. Det kreves ingen internettforbindelse.\n\nVi jobber alltid med å legge inn nye funksjoner, og vi vil gjerne høre hvordan du synes at vi kan forbedre Organic Maps. Hvis du får problemer med appen, ikke nøl med å kontakte oss på support@organicmaps.app. Vi svarer på alle forespørsler!\n\nLiker du Organic Maps og ønsker å støtte oss? Det er noen enkle og helt gratis måter å gjøre det på:\n\n- Legg inn en vurdering på app-butikken\n- Lik Facebook-siden vår på http://www.facebook.com/OrganicMaps\n- Eller bare fortell mamma, venner og kolleger om Organic Maps :)\n\nTakk for at du er med oss. Vi setter stor pris på støtten!\n\nPS! Vi henter kartdata fra OpenStreetMap, et kartprosjekt som ligner på Wikipedia, der brukerne selv kan opprette og redigere kart. Hvis du finner mangler eller feil på kartet, kan du korrigere kartet direkte på https://www.openstreetmap.org, og endringene vil vises i Organic Maps-appen når neste versjon kommer.
-    pl = Organic Maps oferuje najszybsze mapy offline wszystkich miast we wszystkich krajach świata. Podróżuj bez obaw: gdziekolwiek jesteś, Organic Maps pomoże Ci odszukać się na mapie, znaleźć najbliższą restaurację, hotel, bank, stację benzynową itp. Aplikacja nie wymaga połączenia z Internetem.\n\nNieustannie pracujemy nad nowymi funkcjami i chcielibyśmy dowiedzieć się, jak Twoim zdaniem moglibyśmy poprawić Organic Maps. Jeśli masz jakieś problemy z aplikacją, skontaktuj się z nami, pisząc na adres support@organicmaps.app. Odpowiemy na każde zapytanie!\n\nLubisz aplikację Organic Maps i chcesz udzielić nam wsparcia? Istnieje kilka prostych i absolutnie darmowych sposobów, jak to zrobić:\n\n- napisz recenzję w swoim sklepie z aplikacjami\n- polub naszą stronę na Facebooku: http://www.facebook.com/OrganicMaps\n- albo po prostu opowiedz o Organic Maps swojej mamie, znajomym i kolegom :)\n\nDziękujemy, że jesteś z nami. Jesteśmy bardzo wdzięczni za Twoje wsparcie!\n\nP.S. Dane mapy pochodzą z OpenStreetMap, projektu kartograficznego podobnego do Wikipedii, który umożliwia użytkownikom tworzenie i edytowanie map. Jeśli zauważysz, że na mapie czegoś brakuje albo jest błąd, możesz nanieść poprawki bezpośrednio na stronie https://www.openstreetmap.org, a Twoje zmiany pojawią się w aplikacji Organic Maps po wydaniu kolejnej wersji.
-    pt = A Organic Maps oferece os mapas offline mais rápidos de todas as cidades, de todos os países do mundo. Viaje com plena confiança: onde estiver, a Organic Maps ajuda a localizar-se no mapa, a encontrar o restaurante, hotel, banco, posto de gasolina, etc. mais próximos. Não requer ligação à Internet.\n\nEstamos sempre a trabalhar em novas funcionalidades e gostaríamos de saber a sua opinião sobre como poderíamos melhorar a Organic Maps. Se tiver algum problema com a app, não hesite em contactar-nos em support@organicmaps.app. Respondemos a cada pedido!\n\nGosta da Organic Maps e quer apoiar-nos? Há algumas maneiras simples e absolutamente gratuitas:\n\n- publique um comentário no seu App Market\n- faça "gosto" na nossa página do Facebook http://www.facebook.com/OrganicMaps\n- ou fale da Organic Maps à sua mãe, amigos e colegas :)\n\nObrigado por estar connosco. Agradecemos imenso o seu apoio!\n\nP. S. Tiramos os dados do OpenStreetMap, um projeto de mapeamento semelhante à Wikipedia, que permite aos utilizadores criarem e editarem mapas. Se vir que algo está em falta ou errado no mapa, pode corrigir diretamente os mapas em https://www.openstreetmap.org e as suas alterações irão aparecer na app Organic Maps com o lançamento da próxima versão.
-    pt-BR = A Organic Maps oferece os mapas offline mais rápidos de todas as cidades, em todos os países do mundo. Viaje com plena confiança: onde você estiver, o Organic Maps ajuda a se localizar no mapa, a encontrar o restaurante, hotel, banco ou posto de gasolina, etc. mais próximos. Não requer conexão à Internet.\n\nEstamos sempre trabalhando em novas funcionalidades e gostaríamos de saber a sua opinião sobre como poderíamos melhorar o Organic Maps. Se tiver algum problema com a app, não hesite em entrar em contato pelo email support@organicmaps.app. Respondemos a cada pedido!\n\nGosta do Organic Maps e quer nos apoiar? Há algumas maneiras simples e absolutamente gratuitas:\n\n- publique um comentário na sua App Storet\n- curta a nossa página do Facebook http://www.facebook.com/OrganicMaps\n- ou fale do Organic Maps à sua mãe, amigos e colegas :)\n\nObrigado por estar conosco. Agradecemos imensamente o seu apoio!\n\nPS: Utilizamos os dados do OpenStreetMap, um projeto de mapeamento semelhante à Wikipedia, que permite aos usuários criarem e editarem mapas. Se perceber que algo está errado ou faltando no mapa, pode corrigir diretamente os mapas em https://www.openstreetmap.org e as suas alterações irão aparecer no app Organic Maps no lançamento da próxima versão.
-    ro = Organic Maps oferă cele mai rapide hărți offline ale tuturor orașelor, tuturor țărilor din lume. Călătoriți cu încredere deplină: oriunde v-ați afla, Organic Maps vă ajută să vă reperați poziția pe hartă, să găsiți cel mai apropiat restaurant sau hotel, cea mai apropiată bancă sau benzinărie etc. Nu necesită conexiune la internet.\n\nLucrăm încontinuu să introducem funcții noi și ne-ar face mare plăcere să ne comunicați cum credeți dvs. că am putea îmbunătăți Organic Maps. Dacă aveți probleme cu aplicația, nu ezitați să ne contactați la adresa support@organicmaps.app. Răspundem la fiecare solicitare!\n\nVă place Organic Maps și doriți să ne susțineți? Iată câteva moduri simple și complet gratuite:\n- publicați o recenzie în magazinul de aplicații\n- apreciați-ne pagina de Facebook: http://www.facebook.com/OrganicMaps\n- sau spuneți și mamei, prietenilor și colegilor despre Organic Maps. :)\n\nVă mulțumim că ne sunteți alături. Vă apreciem foarte mult susținerea!\n\nP.S. Noi preluăm datele din OpenStreetMap, un proiect de cartografiere similar Wikipediei, ce permite utilizatorilor să creeze și să editeze hărți. Dacă vedeți că ceva lipsește sau este greșit pe hartă, puteți corecta hărțile direct la adresa: https://www.openstreetmap.org, iar modificările dvs. vor apărea în aplicația Organic Maps atunci când va fi lansată versiunea următoare.
-    es = Organic Maps ofrece los mapas sin conexión más rápidos de todas las ciudades y todos los países del mundo. Viaja con plena confianza: estés donde estés, Organic Maps te ayuda a ubicarte en el mapa, encontrar el restaurante, hotel, banco o gasolinera más próximo, etc. No requiere conexión a Internet.\n\nTrabajamos continuamente en el desarrollo de nuevas funcionalidades y nos encantaría conocer tu opinión sobre cómo podríamos mejorar Organic Maps. Si tienes cualquier problema con la aplicación, no dudes en contactar con nosotros en support@organicmaps.app. ¡Respondemos a todas las solicitudes!\n\n¿Te gusta Organic Maps y quieres apoyarnos? Estas son algunas formas simples y totalmente gratis:\n\n- Publica una opinión en tu App Market\n- Dale a me gusta a nuestra página de Facebook http://www.facebook.com/OrganicMaps\n- O simplemente habla sobre Organic Maps a tu madre, amigos y colegas :)\n\nGracias por estar a nuestro lado. ¡Agradecemos mucho tu apoyo!\n\nPD: obtenemos datos de los mapas de OpenStreetMap, un proyecto de mapeo similar a Wikipedia, que permite a los usuarios crear y editar mapas. Si crees que falta algo o hay cualquier error en el mapa, puedes corregir los mapas directamente en https://www.openstreetmap.org y los cambios aparecerán en la aplicación Organic Maps en el próximo lanzamiento de la versión.
-    sv = Organic Maps erbjuder de snabbaste offline-kartorna över alla städer och länder i hela världen. Res med förtroende: oavsett var du är hjälper Organic Maps dig att placera dig på kartan, hitta den närmaste restaurangen, hotellet, banken, bensinstationen m.m. Den kräver inte internetanslutning.\n\nVi arbetar ständigt med nya funktioner och vill gärna veta hur du tycker att vi kan förbättra Organic Maps. Ifall du har problem med appen, tveka inte att kontakta oss på support@organicmaps.app. Vi svarar på alla mail!\n\nGillar du Organic Maps och vill hjälpa oss? Det finns några enkla och kostnadsfria sätt:\n\n- posta en recension på din Appmarknad\n- gilla vår Facebooksida http://www.facebook.com/OrganicMaps\n- eller berätta bara om Organic Maps för din mamma, vänner eller kollegor :)\n\nTack för att du är med oss. Vi uppskattar ditt stöd väldigt mycket!\n\nP.S. Vi använder oss av kartdata från OpenStreetMap, ett kartprojket som liknar Wikipedia och som tillåter användare att skapa och redigera kartor. Ifall du ser något som saknas eller är fel på kartan så kan du korrigera kartan direkt på https://www.openstreetmap.org och dina ändringar kommer att finns i Organic Maps appen när nästa version släpps.
-    th = Organic Maps ขอเสนอแผนที่ออฟไลน์ของทุกเมือง ทุกประเทศในโลกที่รวดเร็วที่สุด เดินทางด้วยความมั่นใจ: ไม่ว่าคุณจะอยู่ที่ไหน Organic Maps จะช่วยระบุตำแหน่งที่ตั้งของตัวคุณบนแผนที่ ค้นหาร้านอาหาร โรงแรม ธนาคาร ปั๊มน้ำมัน และอื่น ๆ ที่ใกล้ที่สุด โดยไม่จำเป็นต้องใช้การเชื่อมต่ออินเทอร์เน็ต\n\nเราทำงานเพื่อพัฒนาฟีเจอร์ใหม่ ๆ อยู่เสมอและยินดีรับฟังว่าคุณมีความคิดเห็นว่าเราจะพัฒนา Organic Maps ได้อย่างไร หากคุณมีปัญหาใด ๆ กับแอป อย่าลังเลที่จะติดต่อเราที่ support@organicmaps.app โดยเราจะตอบรับทุกคำขอ!\n\nคุณชอบ Organic Maps และต้องการสนับสนุนเราหรือไม่? มีวิธีง่าย ๆ และฟรีอยู่บ้าง:\n\n- โพสต์คำวิจารณ์ของคุณที่ ตลาดแอป (App Market)\n- ถูกใจเพจ Facebook ของเรา http://www.facebook.com/OrganicMaps\n- หรือเพียงแค่บอกแม่ เพื่อน ๆ และเพื่อนร่วมงานของคุณเกี่ยวกับ Organic Maps :)\n\nขอบคุณที่ใช้บริการของเรา เราซาบซึ้งในการสนับสนุนของคุณมาก!\n\nป.ล. เรานำข้อมูลแผนที่มาจาก OpenStreetMap ซึ่งเป็นโครงการจัดทำแผนที่ที่เหมือนกับ Wikipedia ที่ช่วยให้ผู้ใช้สามารถสร้างและแก้ไขแผนที่ได้ หากคุณเห็นว่ามีสิ่งใดที่ขาดหายหรือไม่ถูกต้องบนแผนที่ คุณสามารถแก้ไขแผนที่ได้โดยตรงที่ https://www.openstreetmap.org และการเปลี่ยนแปลงของคุณจะปรากฏในแอป Organic Maps ในการปล่อยเวอร์ชันถัดไป
-    tr = Organic Maps dünyadaki tüm ülkelerdeki şehirlerin en hızlı çevrimdışı haritalarını sunuyor. Tam güven ile seyahat edin: nerede olursanız olun, Organic Maps harita üzerinde nerede olduğunuzu belirlemeye, en yakın restoranı, oteli, bankayı, benzin istasyonunu v.b. bulmaya yardımcı olur. İnternet bağlantısı gerektirmez.\n\nHer zaman yeni özellikler üzerinde çalışıyoruz ve sizlerin Organic Maps'yi nasıl geliştirebileceğimize dair görüşlerinizi almaktan mutluluk duyuyoruz. Eğer uygulama ile ilgili herhangi bir probleminiz varsa, bizimle support@organicmaps.app adresinden temasa geçmekten çekinmeyin. Her talebe cevap veriyoruz!\n\nOrganic Maps'yi beğendiniz ve bize destek olmak ister misiniz? Bunun bazı basit ve tamamıyla ücretsiz yolları var:\n\n- Uygulama Marketinizde bir yorum yazın\n- Facebook sayfamızı beğenin http://www.facebook.com/OrganicMaps\n- veya sadece annenize, arkadaşlarınıza ve iş arkadaşlarınıza Organic Maps'den bahsedin :)\n\nBizi tercih ettiğiniz için teşekkür ederiz. Desteğinizden dolayı çok memnuniyet duyarız!\n\nNot: Verileri haritaları kullanıcıların yaratmasına ve düzenlemesine olanak veren Wikipedia benzeri bir proje olan OpenStreetMap'dan almaktayız. Eğer haritada eksik ya da hatalı bir şeyler görürseniz doğrudan haritaları\n\nhttps://www.openstreetmap.org, adresinden düzeltebilirsiniz ve yaptığınız değişiklikler Organic Maps'de bir sonraki sürüm yayınlandığında görülebilir olacaktır.
-    uk = Organic Maps пропонує карти всіх міст, всіх країн світу, які працюють без підключення до інтернету. Подорожуйте з впевненістю: де б ви не були, Organic Maps допоможуть вирішити будь-яку вашу проблему - допоможуть визначити ваше місцезнаходження, знайти ресторан, готель, заправку, банк, туалет і т.д.\n\nМи постійно працюємо над додаванням нових функцій, тому, якщо у вас є ідеї або пропозиції з покращення Organic Maps, пишіть нам. Якщо у вам виникла проблема з програмою, сповістіть нас, будь ласка, про неї. Наш емейл support@organicmaps.app. Ми відповідаємо на всі листи!\n\nЯкщо вам подобається програма і ви хочете підтримати нас, є декілька простих і абсолютно безкоштовних способів:\n\n- залиште відгук у вашому магазині програм\n- підпишіться на наші новини на сторінці у Facebook http://www.facebook.com/OrganicMaps\n- або просто розкажіть про Organic Maps своїй мамі, друзям і колегам :)\n\nДякуємо за вашу підтримку!\n\nP.S. У програмі ми використовуємо картографічні дані проекту OpenStreetMap, який працює за принципом Вікіпедії, надаючи можливість користувачам зі всього світу створювати і редагувати карти. Якщо ви помітили, що на карті щось не відповідає дійсності або відсутнє, ви можете виправити це прямо на сайті https://www.openstreetmap.org, і ці виправлення з'являться під час наступного оновлення Organic Maps.
-    vi = Organic Maps cung cấp bản đồ ngoại tuyến của tất cả các thành phố và quốc gia trên thế giới một cách nhanh nhất. Hoàn toàn tự tin đi du lịch: dù bạn ở đâu, Organic Maps vẫn sẽ giúp bạn định vị bản thân trên bản đồ, tìm các nhà hàng, khách sạn, ngân hàng, trạm xăng, v.v… gần nhất. Ứng dụng này không yêu cầu kết nối Internet.\n\nChúng tôi luôn phát triển các tính năng mới và rất chào đón ý kiến của bạn về cách mà chúng tôi có thể cải thiện Organic Maps. Nếu bạn có bất cứ vấn đề nào với ứng dụng, hãy liên hệ với chúng tôi qua địa chỉ support@organicmaps.app. Chúng tôi sẽ trả lời mọi yêu cầu!\n\nBạn có thích Organic Maps và muốn hỗ trợ chúng tôi hay không? Sau đây là một số cách đơn giản và hoàn toàn miễn phí:\n\n- viết đánh giá trên Chợ Ứng dụng mà bạn sử dụng\n- thích trang Facebook của chúng tôi http://www.facebook.com/OrganicMaps\n- hoặc chỉ đơn giản là kể về Organic Maps với mẹ, bạn bè và đồng nghiệp của bạn :)\n\nCảm ơn bạn đã ủng hộ chúng tôi. Chúng tôi rất cảm ơn sự giúp đỡ của bạn!\n\nT.B. Chúng tôi lấy dữ liệu bản đồ từ OpenStreetMap, một dự án bản đồ tương đương với Wikipedia, cho phép người dùng có thể tạo và sửa bản đồ. Nếu bạn thấy có thông tin bị thiếu hoặc sai trên bản đồ, bạn có thể sửa trực tiếp tại https://www.openstreetmap.org, và các thay đổi của bạn sẽ xuất hiện trong ứng dụng Organic Maps ở phiên bản kế tiếp.
-    zh-Hans = Organic Maps 提供全球所有国家和所有城市的最快速的离线地图。充满自信地出行：无论您在哪，Organic Maps都能够帮助您在地图上找到您自己的位置，找到最近的餐馆、酒店、银行、加油站，等等。无需网络连接。\n\n我们始终在为添加新功能而努力，并希望能够听到您对我们应如何改进Organic Maps的想法。若您在使用本应用时遇到任何问题，请随时联系我们：support@organicmaps.app。我们会回复每一条请求！\n\n您喜欢Organic Maps并希望支持我们吗？以下为一些简单且完全免费的方法：\n\n- 在您的App Market发表评论\n- 在我们的Facebook页面http://www.facebook.com/OrganicMaps赞我们\n- 或者向您的母亲、朋友，以及同事介绍Organic Maps :)\n\n感谢您与我们在一起。非常感谢您的支持。\n\n附言：我们从OpenStreetMap获取地图信息，这是一个类似于Wikipedia的地图绘制项目，能够让用户创建并编辑地图。若您看到地图上缺少了什么或者有什么错误，可以直接在https://www.openstreetmap.org上进行纠正。在下一个版本发布时，您做出的更改便会出现在Organic Maps应用中。
-    zh-Hant = Organic Maps 提供全球所有國家和所有城市的最快速的離線地圖。充滿自信地出行：無論您在哪，Organic Maps都能夠幫助您在地圖上找到您自己的位置，找到最近的餐館、酒店、銀行、加油站，等等。無需網路連接。 我們始終在為增加新功能而努力，並希望能夠聽到您對我們應如何改進 Organic Maps 的想法。若您在使用本應用程式時遇到任何問題，請隨時聯繫我們：support@organicmaps.app。我們會回覆每一條請求！\n\n您喜歡 Organic Maps 並想支持我們嗎？以下為一些簡單且完全免費的方法：\n- 在您的應用程式商店上發表評論\n- 在我們的 Facebook 頁面 http://www.facebook.com/OrganicMaps 上按讚\n- 或者向您的母親、朋友，以及同事介紹 Organic Maps :)\n\n感謝您與我們在一起。非常感謝您的支持。\n\nP.S.：我們從 OpenStreetMap 獲得地圖資訊，這是一個類似維基百科的地圖繪製專案，能夠讓使用者建立並編輯編輯地圖。若您看到地圖上缺少了什麽或者有什麽錯誤，可以直接在 https://www.openstreetmap.org 上進行糾正。在下一個版本發佈時，您做出的更改便會出現在 Organic Maps 應用程式中。
-    he = Organic Maps מציעה את המפות הלא-מקוונות המהירות ביותר של כל הערים וכל מדינות העולם. טיילו בביטחון מלא: בכל מקום בו תהיו, Organic Maps תסייע לכם למצוא את מיקומכם במפה, לגלות את המסעדה, בית המלון, הבנק ותחנת הדלק הקרובים ביותר ועוד. לא נדרש חיבור לאינטרנט.אנו עובדים כל הזמן על פיתוח תכונות חדשות, ונשמח לשמוע מכם כיצד לדעתכם אנו יכולים לשפר את Organic Maps. אם יש לכם בעיה כלשהי עם האפליקציה, אל תהססו ליצור עמנו קשר בכתובת support@organicmaps.app. אנו מגיבים לכל בקשה!האם אתם אוהבים את Organic Maps ומעוניינים לתמוך בנו? יש מספר דרכים פשוטות וחינמיות לגמרי לעשות זאת:לפרסם ביקורת בחנות האפליקציות שלכםלעשות לייק לדף הפייסבוק שלנו http://www.facebook.com/OrganicMapsאו פשוט לספר לאמכם, לחבריכם ולעמיתיכם על Organic Maps ☺תודה על בחירתכם בנו. אנו מעריכים מאוד את תמיכתכם!נ.ב. אנו מקבלים נתוני מפות מ-OpenStreetMap, שהינו פרויקט מיפוי הדומה לוויקיפדיה, ומאפשר למשתמשים ליצור ולערוך מפות. אם תגלו שמשהו במפה חסר או שגוי, תוכלו לתקן את המפות באופן ישיר ב-https://www.openstreetmap.org, והשינויים שלכם יופיעו באפליקציית Organic Maps עם שחרור הגרסה הבאה שלה.
-    sk = Organic Maps ponúka najrýchlejšie offline mapy všetkých miest a krajín po celom svete. Cestujte s úplnou dôverou: kdekoľvek ste, Organic Maps vám pomôže sa nájsť na mape, nájsť najbližšiu reštauráciu, hotel, banku, benzínovú pumpu atď. Nevyžaduje pripojenie k internetu.\n\nNeustále pracujeme na nových funkciách a radi by sme počuli váš názor, ako môžeme vylepšiť Organic Maps. Pokiaľ máte s touto aplikáciou akékoľvek problémy, tak nás neváhajte kontaktovať na support@organicmaps.app. Odpovedáme na každú požiadavku!\n\nPáči sa vám Organic Maps a chceli by ste nás podporiť? Existuje niekoľko ľahkých spôsobov celkom zadarmo:\n\n-napíšte recenziu vo svojom obchode s aplikáciami\n-označte našu stránku http://www.facebook.com/OrganicMaps pomocou Páči sa mi to\n- alebo len povedzte o Organic Maps svojej mame, priateľom a kolegom :)\n\nĎakujeme, že ste s nami. Veľmi oceňujeme vašu podporu!\n\nP.S. Mapové dáta získavame z OpenStreetMap, čo je mapový projekt podobný Wikipédii, ktorý umožňuje užívateľom vytvárať a upravovať mapy. Pokiaľ zistíte, že na mape niečo chýba alebo je nesprávné, môžete to opraviť priamo na https://www.openstreetmap.org, a vaše zmeny sa objavia v budúcej verzii Organic Maps.
-    fa = Organic Maps  به شما سریع ترین نقشه های تمامی شهر ها و کشور های جهان را پیشنهاد می دهد. در هرجایی که هستید با اطمینان کامل سفر کنید. Organic Maps کمک می مند تا موقعیت خود و نزدیک ترین هتل ها,بانک ها,جایگاه های سوخت و چیز های دیگر را بر روی نقشه بیابید.وای کارهیچ نیازی به اتصال اینترنتی ندارد. \n\nما همیشه بر روی قابلیت های جدید کار می کنیم و دوست داریم که از طرف شما بشنویم که چطور می توانیم این نرم افزار مسیر یابی را بهتر از قبل نماییم. اگر هر مشکلی با برنامه داشتید تردید نکنید و در support@organicmaps.app با ما تماس بگیرید.ما به تمامی درخواست ها پاسخ می دهیم! \n\n از Organic Maps راضی هستید و می خواهید از ما حمایت کنید؟ چند راه کاملا رایگان وجود دارد\n- برای ما یک نظر در فروشگاه نرم افزاری بنویسید \n- صفحه فیسبوک ما را http://www.facebook.com/OrganicMaps لایک کنید \n- یا از Organic Maps به مادرتان دوستانتان وهم دانشگاهیانتان بگویید:))\n\n متشکروسپاس گذاریم که با ما همکاری می کنید\n\nP.S. مانقشه های خود را از OpenStreetMap دریافت می کنیم این سایت همانند ویکیپدیا برای نقشه برداری است و به تمام کاربران خود اجازه می دهد تا در تکمیل نقشه ها کمک کنند اگر در نقشه مشاهده نمودید چیزی اشتباه بود یا وجود نداشت شما می توانید ان را مستقیما در سایت https://www.openstreetmap.org تصحیح یا اضافه کنید  و تغییرات ای را که ایجاد کرده اید را در اپدیت بعدی Organic Maps ببینید
 
   [email_error_body]
     comment = Alert text
@@ -6409,9 +4334,9 @@
     zh-Hans = 电子邮件客户端尚未建立。请配置或使用任何其他方式与我们联系%@
     zh-Hant = 電子郵件客戶端尚未建立。請設定或使用任何其他方式與我們聯絡%@
     el = Το πρόγραμμα-client ηλεκτρονικού ταχυδρομείου έχει δεν έχει ρυθμιστεί. Ρυθμίστε το ή χρησιμοποιήστε άλλο τρόπο να επικοινωνήσετε μαζί μας στη διεύθυνση %@
+    fa = کلاینت ایمیل شما پیکربندی نشده است.لطفا ان را پیکربندی کنید یا از طریق دیگر با ما تماس بگیرید %@
     he = יישום הדוא"ל לא הוגדר. אנא קבעו את תצורתו או השתמשו בכל דרך אחרת על מנת ליצור עמנו קשר בכתובת %@
     sk = Emailový klient nebol nastavený. Nakonfigurujte ho prosím alebo použite iný spôsob k tomu, abyste nás kontaktovali na %@
-    fa = کلاینت ایمیل شما پیکربندی نشده است.لطفا ان را پیکربندی کنید یا از طریق دیگر با ما تماس بگیرید %@
 
   [email_error_title]
     comment = Alert title
@@ -6444,9 +4369,9 @@
     zh-Hans = 电子邮件发送错误
     zh-Hant = 電子郵件發送錯誤
     el = Αποστολή σφάλματος αλληλογραφίας
+    fa = خطا در ارسال ایمیل
     he = שגיאה בשליחת דוא"ל
     sk = Chyba pri odosielaní emailu
-    fa = خطا در ارسال ایمیل
 
   [pref_calibration_title]
     comment = Settings item title
@@ -6479,14 +4404,13 @@
     zh-Hans = 指南针校准
     zh-Hant = 指南針校準
     el = Βαθμονόμηση πυξίδας
+    fa = تنظیم کردن قظب نما
     he = כיול המצפן
     sk = Compass kalibrácia
-    fa = تنظیم کردن قظب نما
 
   [wifi]
-    comment = Search team review required on any change
     comment = Search category
-    tags = ios,android
+    tags = ios, android
     en = WiFi
     ru = WiFi
     ar = واي-فاي
@@ -6514,80 +4438,12 @@
     zh-Hans = 无线网络
     zh-Hant = 無線網路
     el = WiFi
-    sk = WiFi
     fa = وای فای
-
-  [routing_map_outdated]
-    comment = Update map suggestion
-    tags = ios,android
-    en = Please update the map to create a route
-    ru = Пожалуйста, обновите карту для того, чтобы проложить маршрут.
-    ar = يرجى تحديث الخريطة لإنشاء مسار.
-    cs = Pro funkci vytváření tras je nutné aktualizovat mapu.
-    da = Venligst opdatér kortet for at oprette en rute.
-    nl = Werk de kaart bij om een route te maken.
-    fi = Päivitä kartta luodaksesi reitin
-    fr = Veuillez mettre à jour la carte pour créer un itinéraire.
-    de = Bitte aktualisieren Sie die Karte, um eine Route zu erstellen.
-    hu = Kérjük, útvonal létrehozásához frissítsd a térképet.
-    id = Mohon perbarui peta untuk membuat rute
-    it = Aggiorna la mappa per creare un itinerario.
-    ja = ルートを作成するためにマップを更新してください。
-    ko = 경로를 생성하도록 지도를 업데이트하십시오.
-    nb = Oppdater kartet for å opprette en rute
-    pl = Proszę zaktualizować mapę, by utworzyć trasę.
-    pt = Por favor, atualize o mapa para criar uma rota.
-    pt-BR = Por favor, atualize o mapa para criar uma rota.
-    ro = Vă rugăm să actualizați harta pentru a crea o rută.
-    es = Por favor, actualiza el mapa para crear una ruta.
-    sv = Uppdatera kartan för att skapa en rutt.
-    th = โปรดอัปเดตแผนที่เพื่อสร้างเส้นทาง
-    tr = Yeni bir rota oluşturmak için lütfen haritayı güncelleyin.
-    uk = Будь ласка, оновіть карту, щоб прокласти маршрут.
-    vi = Vui lòng cập nhật bản đồ để tạo tuyến đường
-    zh-Hans = 请更新地图以创建一条路线。
-    zh-Hant = 請更新地圖以建立一條路線。
-    he = נא לעדכן את המפה כדי ליצור מסלול.
-    sk = Pre vytvorenie trasy si, prosím, aktualizujte mapu.
-    fa = لطفا نقشه خود را برای ایجاد مسیر اپدیت نمایید
-
-  [routing_update_maps]
-    comment = Update maps suggestion
-    tags = ios,android
-    en = The new version of Organic Maps allows creating routes from your current position to a destination point. Please update maps to use this feature.
-    ru = В новой версии Organic Maps вы сможете строить маршруты от текущего местоположения до точки назначения. Чтобы воспользоваться этой функцией, обновите, пожалуйста, карты.
-    ar = إصدار Organic Maps الجديد يسمح بإنشاء مسارات انطلاقاً من موقعك الحالي نحو المكان الذي تتجه إليه. يرجى تحديث الخرائط لاستخدام هذه الميزة.
-    cs = Nová verze Organic Maps umožňuje vytvářet trasy z vaší aktuální polohy do cílového bodu. Chcete-li tuto funkci používat, aktualizujte mapy.
-    da = Den nye version af Organic Maps gør det muligt at oprette ruter fra din nuværende position til et destinationspunkt. Venligst opdatér kortene for at bruge denne funktion.
-    nl = Met de nieuwe versie van Organic Maps kunt u routes maken vanaf uw huidige positie naar een punt van bestemming. Werk kaarten bij om deze functie te gebruiken.
-    fi = Uusi Organic Maps -versio mahdollistaa reittien luonnin nykyisestä sijainnista määränpäähäsi.Päivitä kartat käyttääksesi tätä ominaisuutta.
-    fr = La nouvelle version de Organic Maps permet de créer des itinéraires à partir de votre position actuelle vers un point de destination. Veuillez mettre à jour les cartes pour utiliser cette fonctionnalité.
-    de = Die neue Version von Organic Maps ermöglicht das Erzeugen von Routen von Ihrem aktuellen Standort bis zum gewünschten Ziel. Bitte aktualisieren Sie Karten, um diese Funktion nutzen zu können.
-    hu = A Organic Maps új verziójában már útvonalakt is létrehozhatsz tartózkodási helyedtől az úticélodig. Kérjük, ennek a funkciónak a használatához frissítsd a térképeket.
-    id = Versi Organic Maps yang terbaru memungkinkan pembuatan rute dari posisi Anda saat itu ke titik tujuan. Mohon perbarui peta untuk menggunakan fitur ini.
-    it = La nuova versione di Organic Maps ti permette di creare itinerari dalla tua posizione attuale a un punto di destinazione. Aggiorna le mappe per utilizzare questa funzione.
-    ja = 新バージョンのOrganic Mapsは現在地から目的地までのルートを作成可能です。 この機能を使うためにマップを更新してください。
-    ko = Organic Maps의 새로운 버전으로 당신의 현재 위치에서 목적지 지점으로 경로를 생성할 수 있습니다. 이 기능을 사용하려면 지도를 업데이트하십시오.
-    nb = Med den nye versjonen av Organic Maps kan du opprette ruter fra din nåværende posisjon til et ankomststed på kartet. Oppdater kartene for å bruke denne funksjonen.
-    pl = Nowa wersja aplikacji Organic Maps pozwala na tworzenie tras z Twojej bieżącej lokalizacji do punktu docelowego. Proszę zaktualizować mapy, by móc korzystać z tej funkcji.
-    pt = A nova versão do Organic Maps permite criar rotas a partir da sua posição atual até um ponto de destino. Por favor, atualize o maps para utilizar esta funcionalidade.
-    pt-BR = A nova versão do Organic Maps permite criar rotas da sua posição atual até um ponto de destino. Por favor, atualize os mapas para utilizar esta funcionalidade.
-    ro = Noua versiune a Organic Maps vă permite să creați rute din poziția dvs. actuală către un punct de destinație. Vă rugăm să actualizați harta pentru a utiliza această funcție.
-    es = La nueva versión de Organic Maps permite crear rutas desde tu ubicación actual hasta un punto de destino. Por favor, actualiza los mapas para utilizar esta característica.
-    sv = Den nya versionen av Organic Maps låter dig skapa rutter från din nuvarande position till en destinationspunkt. Uppdatera kartan för att använda den här funktionen.
-    th = เวอร์ชันใหม่ของ Organic Maps อนุญาติให้สร้างเส้นทางจากตำแหน่งปัจจุบันของคุณไปยังจุดปลายทาง โปรดอัปเดตแผนเพื่อใช้ฟีเจอร์นี้
-    tr = Organic Maps'nin yeni sürümü mevcut pozisyonunuzdan varış noktasına rotalar oluşturmanıza imkan verir. Lütfen bu özelliği kullanmak için haritaları güncelleyin.
-    uk = В новій версії Organic Maps ви зможете прокладати маршрут від поточного місця перебування до точки призначення. Щоб скористатися цією функцією, будь ласка, оновіть карти.
-    vi = Phiên bản Organic Maps mới cho phép tạo các tuyến đường từ vị trí hiện tại của bạn đến điểm đến. Vui lòng cập nhật bản đồ để sử dụng tính năng này.
-    zh-Hans = 使用新版本的Organic Maps可以创建从您的当前位置至一个目的地的路线。请更新地图以使用该功能。
-    zh-Hant = 使用新版本的 Organic Maps 可以建立從您的目前位置至一個目的地的路線。請更新地圖以使用該功能。
-    he = הגרסה החדשה של Organic Maps מאפשרת יצירת מסלולים מהמיקום הנוכחי שלך לנקודת יעד מסוימת. נא לעדכן את המפות כדי להשתמש בפונקציה זו.
-    sk = Nová verzia aplikácie Organic Maps umožňuje vytvárať trasy z vašej aktuálnej polohy do cieľového bodu. Pre použitie tejto funkcie si, prosím, aktualizujte mapy.
-    fa = نسخه جدید Organic Maps به شما اجازه ایجاد یک مسیر از موقعیت فعلیتان به مقصدتان را می دهد.لطفابرای استفاده از این ویژگی نقشه خود را اپدیت نمایید.
+    sk = WiFi
 
   [downloader_update_all_button]
     comment = Update all button text
-    tags = ios,android
+    tags = android
     en = Update All
     ru = Обновить все
     ar = تحديث الكل
@@ -6616,12 +4472,12 @@
     zh-Hans = 更新全部
     zh-Hant = 更新全部
     el = Ενημέρωση όλων
-    sk = Aktualizovať všetko
     fa = اپدیت همه
+    sk = Aktualizovať všetko
 
   [downloader_cancel_all]
     comment = Cancel all button text
-    tags = ios,android
+    tags = android
     en = Cancel All
     ru = Отменить все
     ar = إلغاء الكل
@@ -6650,13 +4506,13 @@
     zh-Hans = 全部取消
     zh-Hant = 全部取消
     el = Ακύρωση όλων
+    fa = لغو همه
     he = בטל הכול
     sk = Zrušiť všetko
-    fa = لغو همه
 
   [downloader_downloaded_subtitle]
     comment = Downloaded maps category
-    tags = ios,android
+    tags = android
     en = Downloaded
     ru = Загруженные
     ar = تم تنزيلها
@@ -6685,45 +4541,12 @@
     zh-Hans = 已下载
     zh-Hant = 已下載
     el = Έγινε λήψη
-    sk = Stiahnuté
     fa = دانلود شده
-
-  [downloader_available_maps]
-    comment = Downloaded maps category
-    en = Available
-    ru = Доступные
-    ar = متاح
-    cs = Dostupné
-    da = Tilgængelige
-    nl = Beschikbaar
-    fi = Saatavilla
-    fr = Disponible
-    de = Verfügbar
-    hu = Elérhető
-    id = Tersedia
-    it = Disponibile
-    ja = 利用可能
-    ko = 사용 가능
-    nb = Tilgjengelig
-    pl = Dostępne
-    pt = Disponível
-    pt-BR = Disponível
-    ro = Disponibil
-    es = Disponible
-    sv = Tillgänglig
-    th = มีให้ใช้
-    tr = Mevcut
-    uk = Доступні
-    vi = Đã có
-    zh-Hans = 可用
-    zh-Hant = 可用
-    el = Διαθέσιμη
-    sk = Dostupné
-    fa = موجود
+    sk = Stiahnuté
 
   [downloader_queued]
     comment = Country queued for download
-    tags = ios,android
+    tags = ios, android
     en = Queued
     ru = В очереди
     ar = مَصْفوف
@@ -6752,12 +4575,12 @@
     zh-Hans = 已排队
     zh-Hant = 已佇列
     el = στην ουρά
+    fa = صف
     he = נוסף/ו לתור
     sk = V rade
-    fa = صف
 
   [downloader_near_me_subtitle]
-    tags = ios,android
+    tags = android
     en = Near me
     ru = Возле меня
     ar = بالقرب مني
@@ -6786,11 +4609,11 @@
     zh-Hans = 在我附近
     zh-Hant = 在我附近
     el = Κοντά μου
-    sk = Neďaleko mňa
     fa = نزدیک من
+    sk = Neďaleko mňa
 
   [downloader_status_maps]
-    tags = ios,android
+    tags = ios, android
     en = Maps
     ru = Карт
     ar = الخرائط
@@ -6819,11 +4642,11 @@
     zh-Hans = 地图
     zh-Hant = 地圖
     el = Χάρτες
-    sk = Mapy
     fa = نقشه ها
+    sk = Mapy
 
   [downloader_download_all_button]
-    tags = ios,android
+    tags = android
     en = Download All
     ru = Загрузить все
     ar = تنزيل الكل
@@ -6852,11 +4675,11 @@
     zh-Hans = 下载全部
     zh-Hant = 下載全部
     el = Λήψη όλων
-    sk = Stiahnuť všetko
     fa = دانلود همه
+    sk = Stiahnuť všetko
 
   [downloader_downloading]
-    tags = ios,android
+    tags = ios, android
     en = Downloading:
     ru = Загружается:
     ar = يتم تنزيل:
@@ -6885,145 +4708,12 @@
     zh-Hans = 正在下载：
     zh-Hant = 正在下載：
     el = Λήψη:
-    sk = Sťahovanie:
     fa = درحال دانلود:
-
-  [downloader_search_results]
-    en = Found
-    ru = Найдено
-    ar = تم العثور على
-    cs = Nalezeno
-    da = Fundet
-    nl = Gevonden
-    fi = Löytyi
-    fr = Trouvé
-    de = Gefunden
-    hu = Megtalálva
-    id = Ditemukan
-    it = Trovate
-    ja = 見つかりました
-    ko = 검색 결과
-    nb = Funnet
-    pl = Znaleziono
-    pt = Encontrado
-    pt-BR = Encontrado
-    ro = S-au găsit
-    es = Encontrado
-    sv = Hittat
-    th = พบ
-    tr = Bulundu
-    uk = Знайдено
-    vi = Đã tìm thấy
-    zh-Hans = 找到
-    zh-Hant = 已找到
-    el = Βρέθηκαν
-    sk = Nájdených
-    fa = یافت شد
-
-  [routing_disclaimer]
-    comment = Disclaimer message
-    tags = ios,android
-    en = Creating routes in Organic Maps app, please keep in mind the following:\n\n  - Suggested routes can be considered as recommendations only.\n - Road conditions, traffic rules and signs have higher priority than navigation advice.\n - The map may be incorrect or outdated, and routes may not be created the best possible way.\n\n  Be safe on roads and take care of yourself!
-    ru = Используя маршруты в приложении Organic Maps, пожалуйста, учитывайте следующее:\n\n  - Предлагаемые маршруты могут рассматриваться только в качестве рекомендации.\n - Дорожная обстановка, правила дорожного движения, знаки являются более приоритетными по сравнению с советами навигационной программы.\n - Карта может быть неточной или неактуальной, а предложенный маршрут не самым оптимальным.\n\n  Будьте внимательны на дорогах и берегите себя!
-    ar = عند إنشاء مسارات الطرق في تطبيق Organic Maps، يرجى أخذ التالي في الحسبان:\n\n  - المسارات المقترحة تعتبر مجرد اقتراحات فقط.\n - حالة الطريق وقوانينه والإشارات الموجودة فيه لها الأولولية أثناء تقديم نصائح الملاحة.\n - قد تكون الخريطة خاطئة أو قديمة، لذا فإنه يمكن ألا تُرسم المسارات بالشكل الأمثل.\n\n  كن آمنا على الطريق وانتبه لتفسك!
-    cs = Při vytváření tras v aplikaci Organic Maps mějte, prosím, na paměti následující:\n\n • Navrhované trasy lze brát jen jako doporučení.\n • Pravidla silničního provozu, aktuální podmínky na silnici a dopravní značení mají přednost před údaji z navigace.\n • Mapa může být nepřesná nebo zastaralá a navržené cesty nemusí být ideální.\n\nCestujte bezpečně a ohleduplně. Šťastnou cestu!
-    da = Ved oprettelse af ruter i Organic Maps appen, venligst tænk over følgende:\n\n- Anbefalede ruter kan kun betragtes som anbefalinger.\n- Vejtilstande, trafikregler og skilte har højere prioritet end navigationsråd.\n Kortet kan være ukorrekt eller forældet, og ruter kan muligvis ikke være oprettet på den bedste måde.\n\nVær sikker på vejene og pas på dig selv!
-    nl = Bij het creëren van routes in Organic Maps-app, dient u rekening te houden met het volgende:\n\n  - Voorgestelde routes kunnen uitsluitend als aanbevelingen beschouwd worden.\n - Wegconditie, verkeersregels en borden hebben een hogere prioriteit dan het navigatie-advies.\n - De kaart kan onjuist of verouderd zijn en de routes kunnen niet op de beste mogelijke manier gecreëerd zijn.\n\n  Wees veilig op wegen en zorg goed voor uzelf!
-    fi = Pidä mielessä seuraavat seikat luodessasi reittejä Organic Maps -sovelluksella:\n\n- Ehdotettuja reittejä tulee pitää vain suosituksina.\n- Teiden kunto, liikennesäännöt ja -merkit on aina otettava huomioon navigointiehdotuksista huolimatta.\n - Kartassa saattaa olla virheitä, tai se saattaa olla vanhentunut, eikä reittejä sen takia voida luoda parhaalla mahdollisella tavalla.\n\nPysy valppaana liikenteessä ja pidä huolta itsestäsi!
-    fr = Quand vous créez des itinéraires sur l'application Organic Maps, veuillez garder à l'esprit les points suivants :\n\n  - Les itinéraires suggérés ne doivent être considérés que comme des recommandations.\n\n  - Les conditions des routes, les règlementations de circulations et les panneaux sont prioritaires sur les conseils de navigation.\n\n  - Il est possible qu'une carte soit incorrecte ou obsolète, et les itinéraires ne sont pas toujours créés de la meilleure façon possible.\n\n  Soyez prudents sur les routes et prenez soin de vous.
-    de = Beim Erstellen von Routen mit der Organic Maps-App sollten Sie Folgendes beachten:\n\n  - Vorgeschlagenen Routen können nur als Empfehlungen angesehen werden.\n - Straßenbedingungen, Verkehrsregeln und Schilder haben höhere Priorität als Navigationsratschläge.\n - Die Karte kann falsch oder veraltet sein und Routen könnten somit nicht auf die bestmögliche Weise erstellt worden sein.\n\n  Bleiben Sie auf der Straße sicher und achten Sie auf sich selbst!
-    hu = Amikor útvonalakat készít a Organic Maps appban, kérjük, vegye figyelembe a következőket:\n\n  - Az ajánlott útvonalak csak javaslatoknak tekintendők.\n - Az utak kondíciója, a forgalmi szabályok és jelzőtáblák magasabb prioritásúak, mint a navigációs javaslatok.\n - A térkép lehet, hogy hibás vagy idejétmúlt, az útvonalak pedig lehet, hogy nem a lehető legjobb módon készülnek el.\n\n  Legyen óvatos az utakon és vigyázzon magára!
-    id = Dalam membuat rute di aplikasi Organic Maps, mohon ingat:\n\n- Rute yang disarankan hanya dapat dianggap sebagai rekomendasi.\n- Kondisi jalan, peraturan dan tanda-tanda lalu lintas memiliki prioritas yang lebih tinggi daripada saran navigasi.\n- Kondisi jalan, peraturan dan tanda-tanda lalu lintas memiliki prioritas yang lebih tinggi daripada saran navigasi.\n- Peta bisa saja salah atau sudah usang, dan rute yang dibuat mungkin bukan yang terbaik.\n\nBerhati-hatilah di jalan dan jagalah diri Anda sendiri!
-    it = Creando percorsi nell'app Organic Maps tieni a mente quanto segue:\n\n  - I percorsi suggeriti possono essere considerati solo come consigliati.\n - Le condizioni della strada, le regole del traffico e i segnali hanno una priorità maggiore rispetto ai consigli sulla circolazione.\n - La mappa potrebbe essere scorretta o datata e i percorsi potrebbero non aver creato la strada migliore possibile.\n\n  Stai attento sulle strade e prenditi cura di te!
-    ja = Organic Mapsアプリでルートを作成する時は、以下のことに留意してください：\n\n  - 提案されたルートは推奨するだけです。\n - 道路状況、交通規則と標識はナビゲーションのアドバイスより優先度が高くなっています。\n - マップが不正確または古くなっている場合や、ルートが最適な方法で作成されていないことがあります。\n\n  安全運転でご自愛ください！
-    ko = Organic Maps 앱에서 경로를 작성할 때, 다음에 유의하시기 바랍니다:\n\n  - 추천 루트는 권장 사항으로만 간주될 수 있습니다.\n - 도로 조건, 교통 규칙 및 징후는 탐색 조언보다 더 높은 우선 순위를 갖습니다.\n -지도는 잘못되었거나 만료되었을 수 있으며, 경로는 최상의 방법을 만들어지지 않을 수 있습니다.\n\n  도로에서 안전하게 몸조심하세요!
-    nb = Når du oppretter ruter i Organic Maps-appen må du huske på følgende:\n\n- Foreslåtte ruter må bare betraktes som anbefalinger.\n- Veiforhold, trafikkregler og skilt må gis høyere prioritet enn navigasjonsråd.\n- Kartet kan være feil eller utdatert, og det er ikke sikkert at rutene opprettes på best mulig måte.\n\nVær nøye med veisikkerheten og pass på deg selv!
-    pl = Podczas tworzenia tras w aplikacji Organic Maps pamiętaj o poniższych zasadach:\n\n  - Sugerowane trasy mogą być traktowane jedynie jako propozycje.\n - Warunki na drodze, przepisy ruchu drogowego i znaki mają większy priorytet niż wskazówki nawigacyjne.\n - Mapa może okazać się nieprawidłowa lub nieaktualna a trasy mogą nie zostać utworzone w sposób najlepszy z możliwych.\n\n  Szerokiej drogi, uważaj na siebie!
-    pt = Ao criar rotas no app Organic Maps, por favor, lembre-se do seguinte:\n\n  - As rotas sugeridas podem apenas ser consideradas como recomendações.\n - As condições da estrada, regras de trânsito e sinais têm maior prioridade do que os conselhos de navegação.\n - O mapa poderá estar errado, ou desatualizado, e as rotas poderão não ser criadas da melhor forma possível.\n\n  Circule em segurança nas estradas e cuide do seu bem estar!
-    pt-BR = Ao criar rotas no aplicativo Organic Maps, por favor, lembre-se do seguinte:\n\n  - As rotas sugeridas devem ser consideradas apenas como recomendações.\n - Condições da estrada, regras de trânsito e sinalização têm maior prioridade do que as sugestões de navegação.\n - O mapa poderá estar errado, ou desatualizado, e as rotas poderão não ser criadas da melhor forma possível.\n\n  Circule com segurança nas estradas e cuide do seu bem estar!
-    ro = Atunci când creați rute în aplicația Organic Maps, vă rugăm să nu uitați următoarele:\n\n- Rutele sugerate pot fi luate în considerare numai ca recomandări.\n- Harta poate fi incorectă sau neactualizată, iar rutele pot să nu fie create în cel mai bun mod posibil.\n- Condițiile de trafic, regulile și semnele de circulație au prioritate mai mare decât sugestiile de navigare.\n\nCirculați cu atenție și aveți grijă de dvs.!
-    es = Creando rutas en la aplicación Organic Maps, por favor, tenga en cuenta lo siguiente:\n\n  - Las rutas sugeridas se pueden considerar únicamente como recomendaciones.\n - Las condiciones de la carretera, las normas y las señales de tráfico tienen mayor prioridad que el consejo de navegación.\n - El mapa podría ser incorrecto o estar obsoleto y las rutas pueden no crear el mejor camino posible.\n\n  ¡Esté seguro en las carreteras y cuídese!
-    sv = När du skapar rutter i appen Organic Maps, vänligen tänk på följande:\n\n  - Föreslagna rutter kan endast ses som rekommendationer.\n - Vägskick, trafikregler och skyltar har högre prioritet än navigeringsråd.\n - Kartan kan vara felaktig eller förlegad, och rutter skapas inte alltid på bästa tänkbara sätt.\n\n  Kör säkert på vägarna och ta hand om dig själv!
-    th = การสร้างเส้นทางในแอป Organic Maps มีสิ่งที่ควรทราบดังต่อไปนี้:\n\n  - พึงพิจารณาเส้นทางที่แนะนำไว้ในฐานะที่เป็นการแนะนำเท่านั้น\n - สภาพถนน กฎจราจรและป้ายมีความสำคัญมากกว่าคำแนะนำในการนำทาง\n - แผนที่อาจไม่ถูกต้องหรือล้าสมัย และอาจไม่ได้มีการสร้างเส้นทางในรูปแบบพอจะเป็นไปได้ที่ดีที่สุด\n\n  ขอให้ปลอดภัยบนท้องถนนและดูแลตัวคุณเองด้วย!
-    tr = Organic Maps uygulamasında rota yaratırken lütfen aşağıdakileri dikkate alın:\n\n  - Önerilen rotalar sadece tavsiyeler olarak düşünülmelidir.\n - Yol koşulları, trafik kuralları ve işaretleri navigasyon tavsiyelerden daha önceliklidir.\n - Harita doğru olmayabilir ya da eskimiş olabilir ve rotalar en iyi mümkün yola göre oluşturulmamış olabilir.\n\n  Yollarda güvende olun ve kendinize dikkat edin!
-    uk = Використовуючи маршрути в програмі Organic Maps, будь ласка, враховуйте наступне:\n\n  - Пропоновані маршрути можуть розглядатися тільки в якості рекомендації.\n - Дорожні умови, правила дорожнього руху, знаки являються більш пріоритетними в порівнянні з порадами навігаційної програми.\n - Карта може бути неточною або неактуальною, а запропонований маршрут не найоптимальнішим.\n\n  Будьте уважні на дорозі та бережіть себе!
-    vi = Tạo các tuyến đường trong ứng dụng Organic Maps, xin lưu ý điều sau:\n\n – Các tuyến đường được gợi ý chỉ có thể được xem là đề xuất.\n – Điều kiện con đường, luật giao thông và biển báo có mức ưu tiên cao hơn lời khuyên dẫn hướng.\n – Bản đồ có thể không chính xác hoặc lỗi thời, tuyến đường có thể không được tạo theo cách tốt nhất có thể.\n\n Hãy lái xe an toàn trên đường và bảo trọng!
-    zh-Hans = 在Organic Maps应用中制定路线时请谨记以下 几点：\n\n  - 建议路线仅可当作推荐路线。\n - 路况、交通规则以及标志应优先于导航建议。\n - 地图可能会不正确或者过时，路线也可能不是以最佳可能方式制定的。\n\n  行车安全，请照顾好您自己！
-    zh-Hant = 在 Organic Maps 應用程式中建立路線時請謹記以下幾點：\n\n  - 建議路線僅可當作推薦路線。\n - 路況、交通規則以及標誌應優先於導航建議。\n - 地圖可能會不正確或者過時，路線也可能不是以最佳可能方式建立的。\n\n  行車安全，請照顧好您自己！
-    he = כשאתם בונים מסלולים באמצעות אפליקציית Organic Maps, שימו לב:\n\n  יש להתייחס למסלולים מוצעים כהמלצות בלבד.\n תנאי הדרך, חוקי התנועה והתמרורים נמצאים בעדיפות גבוהה יותר מאשר עצת הניווט.\n יתכן שהמפה אינה נכונה או\n    אינה מעודכנת, וקיימת אפשרות שהמסלולים לא ייבנו באופן הטוב ביותר.\n\n  נסיעה בטוחה ושמרו על עצמכם!\n\n
-    sk = Tvorenie trás v aplikácii Organic Maps, prosím, majte na pamäti nasledovné:\n\n  - Navrhnuté trasy možno považovať iba za odporúčanie.\n - Stav vozovky, dopravné predpisy a značenie majú vyššiu prioritu, ako navigačné rady.\n - Mapa môže byť nesprávna alebo zastaraná a trasy nemusia byť vytvorené tým najlepším možným spôsobom.\n\n  Buďte na cestách v bezpečí a postarajte sa o seba!
-
-  [downloader_outdated_maps]
-    comment = Outdated maps category
-    tags = ios,android
-    en = Outdated
-    ru = Неактуальные
-    ar = انتهت صلاحيته
-    cs = Zastaralé
-    da = Uddateret
-    nl = Verouderd
-    fi = Vanhentunut
-    fr = Dépassé
-    de = Veraltet
-    hu = Elavult
-    id = Usang
-    it = Obsoleto
-    ja = 旧式
-    ko = 만료됨
-    nb = Utdatert
-    pl = Nieaktualne
-    pt = Desatualizado
-    pt-BR = Desatualizado
-    ro = Neactualizată
-    es = Anticuado
-    sv = Gammal
-    th = ล้าสมัย
-    tr = Güncel değil
-    uk = Неактуальні
-    vi = Lỗi thời
-    zh-Hans = 过时的
-    zh-Hant = 過時的
-    he = מיושן
-    sk = Zastarané
-    fa = منسوخ شده
-
-  [downloader_uptodate_maps]
-    comment = Up to date maps category
-    tags = ios,android
-    en = Up-to-date
-    ru = Обновленные
-    ar = محدّث
-    cs = Aktuální
-    da = Up-to-date
-    nl = Up-to-date
-    fi = Ajan tasalla
-    fr = À jour
-    de = Aktuell
-    hu = Friss
-    id = Terkini
-    it = Aggiornato
-    ja = 最新
-    ko = 최신
-    nb = Oppdatert
-    pl = Najnowsze
-    pt = Atualizado
-    pt-BR = Atualizado
-    ro = Actualizată
-    es = Actualizado
-    sv = Aktuell
-    th = ทันสมัย
-    tr = Güncel
-    uk = Оновлені
-    vi = Cập nhật
-    zh-Hans = 最新的
-    zh-Hant = 最新的
-    he = עדכני
-    sk = Aktualizované
-    fa = به روز
+    sk = Sťahovanie:
 
   [downloader_status_outdated]
     comment = Status of outdated country in the list
-    tags = ios,android
+    tags = ios
     en = Update
     ru = Обновить
     ar = تحديث
@@ -7052,13 +4742,13 @@
     zh-Hans = 下载
     zh-Hant = 更新
     el = Ενημέρωση
+    fa = به روز رسانی
     he = לְעַדְכֵּן
     sk = Aktualizácia
-    fa = به روز رسانی
 
   [downloader_status_failed]
     comment = Status of failed country in the list
-    tags = ios,android
+    tags = ios
     en = Failed
     ru = Ошибка
     ar = فشل
@@ -7087,13 +4777,13 @@
     zh-Hans = 下载失败
     zh-Hant = 失敗
     el = Απέτυχε
+    fa = ناموفق
     he = נכשלה
     sk = Zlyhalo
-    fa = ناموفق
 
   [downloader_delete_map_while_routing_dialog]
     comment = Displayed in a dialog that appears when a user tries to delete a map while the app is in the follow route mode
-    tags = android, ios
+    tags = ios, android
     en = To delete map, please stop navigation.
     ru = Чтобы удалить карту, пожалуйста, остановите навигацию.
     ar = لحذف الخريطة يرجى إيقاف الملاحة.
@@ -7122,152 +4812,12 @@
     zh-Hans = 要删除地图，请停止导航。
     zh-Hant = 如欲刪除地圖，請停止導航。
     el = Για να διαγράψετε το χάρτη, σταματήστε την πλοήγηση.
-    sk = Ak chcete odstrániť mapy, prosím, zastavte navigáciu.
     fa = برای حذف نقشه لطفا مسیر یابی را متوقف کنید
-
-  [routing_failed_unknown_my_position]
-    comment = Show when user try build route, but we don't know where he
-    tags = android, ios
-    en = Current location is undefined. Please specify location to create route.
-    ru = Невозможно проложить маршрут. Не определено текущее местоположение.
-    ar = الموقع الحالي غير مُعَرّف. يرجى تحديد موقع لإنشاء مسار.
-    cs = Aktuální poloha nebyla zatím zjištěna. Chcete-li naplánovat trasu, zadejte prosím umístění.
-    da = Den nuværende placering er ikke defineret. Venligst angiv placering for at oprette en rute.
-    nl = Huidige locatie is niet gedefinieerd. Gelieve de locatie te specificeren om de route te creëren.
-    fi = Tämänhetkinen sijainti ei ole tiedossa. Määritä sijainti luodaksesi reitin.
-    fr = L'emplacement actuel n'est pas défini. Veuillez préciser l'emplacement pour créer l'itinéraire.
-    de = Der aktuelle Standort ist nicht bekannt. Bitte geben Sie den Standort ein, um eine Route zu erstellen.
-    hu = Nem meghatározott a jelenlegi helyszín. Kérjük, határozza meg a helyszínt, hogy útvonal készülhessen.
-    id = Lokasi saat ini tidak diketahui. Mohon masukkan lokasi untuk membuat rute.
-    it = La posizione attuale non è definita. Specifica la posizione per creare il percorso.
-    ja = 現在地が設定されていません。ルートを作成するには現在地を設定してください。
-    ko = 현재 위치는 정의되지 않습니다. 경로를 생성할 위치를 지정하십시오.
-    nb = Nåværende posisjon er udefinert. Oppgi en posisjon for å opprette en rute.
-    pl = Bieżąca lokalizacja nie została zdefiniowana. Aby utworzyć trasę, określ lokalizację.
-    pt = A localização atual não foi definida. Por favor especifique a localização para criar o trajeto.
-    pt-BR = A localização atual não foi definida. Por favor especifique a localização para criar o trajeto.
-    ro = Poziția dvs. curentă este nedefinită. Vă rugăm să specificați poziția, pentru a crea o rută.
-    es = La ubicación actual no está definida. Por favor, especifique la ubicación para crear la ruta.
-    sv = Nuvarande plats är inte definierad. Ange din plats för att skapa rutt.
-    th = ไม่มีการกำหนดสถานที่ปัจจุบัน โปรดระบุสถานที่ตั้งเพื่อสร้างเส้นทาง
-    tr = Geçerli konum tanımlı değil. Rota oluşturmak için lütfen konum belirtin.
-    uk = Неможливо прокласти маршрут. Не визначено поточне місцезнаходження.
-    vi = Không xác định được vị trí hiện tại. Vui lòng xác định vị trí để tạo tuyến đường.
-    zh-Hans = 当前地点未定。请明确地点以创建路线。
-    zh-Hant = 目前地點未定。請等待明確地點以建立路線。
-    el = Η τρέχουσα τοποθεσία δεν έχει οριστεί. Προσδιορίστε τοποθεσίας για να δημιουργήσετε διαδρομή.
-    he = לא הוגדר המיקום הנוכחי. נא לציין מיקום כדי ליצור מסלול.
-    sk = Aktuálna lokácia nie je definovaná. Prosím, špecifikujte lokáciu pre vytvorenie trasy.
-    fa = مکان شما نا مشخص است,لطفا قبل از ایجاد مسیر مکان خود را مشخص کنید.
-
-  [routing_failed_has_no_routing_file]
-    comment = Show if use has not routing file, or InconsistentMWMandRoute
-    tags = ios, android
-    en = Additional data is required to create the route. Download data now?
-    ru = Для построения маршрута необходимы дополнительные данные. Перейти к загрузке?
-    ar = هناك حاجة إلى بيانات إضافية لإنشاء مسار. بدء التحميل؟
-    cs = K vytvoření trasy jsou zapotřebí další data. Chcete je stáhnout nyní?
-    da = Yderligere data er nødvendig, for at oprette en rute. Begynde download?
-    nl = Er zijn extra gegevens nodig om een ​​route te creëren. Beginnen met downloaden?
-    fi = Reitin luomiseksi on ladattava lisää dataa. Ladatataanko data nyt?
-    fr = Des données supplémentaires sont nécessaires pour créer un itinéraire. Vous désirez lancer le téléchargement ?
-    de = Zusätzliche Daten werden zum Erstellen der Route benötigt. Mit dem Herunterladen beginnen?
-    hu = Útvonaltervezéshez további adatok is szükségesek. Elkezded a letöltést?
-    id = Data tambahan yang diperlukan untuk membuat rute dari lokasi Anda.
-    it = Ulteriori dati sono necessari per creare un percorso. Inizio a scaricarli?
-    ja = ルートを作成するには追加のデータが必要です。ダウンロードを開始しますか？
-    ko = 추가 데이터는 경로를 생성하기 위해 필요합니다. 다운로드를 시작하시겠습니까?
-    nb = Tilleggsinformasjon som er nødvendig for å opprette ruter fra ditt ståsted.
-    pl = Aby stworzyć trasę, potrzebne są dodatkowe dane. Rozpocząć pobieranie?
-    pt = São necessários dados adicionais para criar uma rota. Descarregar os dados agora?
-    pt-BR = Dados adicionais são necessários para criar uma rota. Baixar os dados agora?
-    ro = Datele suplimentare necesare pentru a crea trasee de la locația dvs.
-    es = Son necesarios datos adicionales para crear la ruta. ¿Empezar la descarga?
-    sv = Ytterligare data behövs för att skapa en rutt. Påbörja nedladdning?
-    th = ข้อมูลเพิ่มเติมเป็นต้องมีเพื่อสร้างเส้นทาง เริ่มต้นการดาวน์โหลด?
-    tr = Bir rota oluşturmak için ek bilgiler gereklidir. İndirme işlemini başlat?
-    uk = Для прокладання маршруту необхідна додаткова інформація. Перейти до завантаження?
-    vi = số liệu bổ sung cần thiết để tạo ra các tuyến đường đi từ vị trí của bạn.
-    zh-Hans = 需要额外的数据才能创建路线。开始下载吗？
-    zh-Hant = 需要額外的數據才能建立路線。開始下載嗎？
-    el = Απαιτούνται πρόσθετα δεδομένα για να δημιουργήσετε τη διαδρομή. Λήψη δεδομένων τώρα;
-    he = נתונים נוספים נחוצים ליצירת נתיב. להתחיל בהורדה?
-    sk = Na vytvorenie trasy sú potrebné ďalšie dáta. Začať sťahovanie?
-    fa = برای ایجاد مسیر به دیتای اضافی نیاز است.اکنون ان را دانلود می کنید؟
-
-  [routing_failed_start_point_not_found]
-    comment = StartPointNotFound
-    tags = android, ios
-    en = Cannot calculate the route. No roads near your starting point.
-    ru = Невозможно проложить маршрут. Нет дорог рядом с пунктом отправления.
-    ar = لا يمكن حساب المسار. لا توجد طرق قرب نقطة البداية لديك.
-    cs = Trasu nelze vypočítat. Poblíž výchozího bodu nejsou žádné cesty.
-    da = Kan ikke beregne ruten. Ingen veje nær dit startpunkt.
-    nl = Kan de route niet berekenen. Geen wegen in de buurt van uw beginpunt.
-    fi = Reittiä ei voida laskea, koska lähtöpisteen lähistöllä ei ole teitä.
-    fr = Impossible de calculer l'itinéraire. Aucune route à proximité de votre point de départ.
-    de = Die Route kann nicht berechnet werden. Es gibt keine Straßen in der Nähe Ihres Ausgangspunkts.
-    hu = Az útvonal nem tervezhető meg. Nincsenek utak a kiindulópontja közelében.
-    id = Tidak dapat memperhitungkan rute. Tidak ada jalan di dekat titik Anda mulai.
-    it = Impossibile calcolare il percorso. Nessuna strada vicina al tuo punto di partenza.
-    ja = ルートを計算できません。出発地点の近くに道路がありません。
-    ko = 경로를 계산할 수 없습니다. 시작 지점 근처에 도로가 없습니다.
-    nb = Klarer ikke å beregne ruten. Ingen veier i nærheten av startpunktet.
-    pl = Nie można obliczyć trasy. Brak dróg w pobliżu punktu rozpoczęcia podróży.
-    pt = Impossível calcular o trajeto. Não há estradas próximas ao seu ponto de partida.
-    pt-BR = Impossível calcular o trajeto. Não há estradas próximas ao seu ponto de partida.
-    ro = Nu se poate calcula ruta. Nu există drumuri în apropierea punctului de pornire.
-    es = No se puede calcular la ruta. No hay carreteras cerca de su punto de partida.
-    sv = Rutten kan inte beräknas. Det finns inga vägar vid startpunkten.
-    th = ไม่สามารถคำนวณเส้นทางได้ ไม่มีถนนที่อยู่ใกล้เคียงกับจุดเริ่มต้นของคุณ
-    tr = Rota hesaplanamıyor. Başlangıç noktanızın yakınında hiçbir yol yok.
-    uk = Неможливо прокласти маршрут. Немає доріг поруч з відправною точкою.
-    vi = Không thể tính toán tuyến đường. Không có con đường nào gần điểm bắt đầu của bạn.
-    zh-Hans = 无法计算路线。没有在您起点附近的路。
-    zh-Hant = 無法計算路線。沒有路在您的起點附近。
-    el = Δεν μπορεί να υπολογιστεί η διαδρομή. Δεν υπάρχουν δρόμοι κοντά στο σημείο εκκίνησης.
-    he = לא ניתן לחשב את המסלול. אין כבישים ליד נקודת ההתחלה שלך.
-    sk = Nedá sa vypočítať trasa. Žiadne cesty v blízkosti východiskového bodu.
-    fa = نمی توان مسیر را محاسبه کرد.در نزدیکی نقطه شروع شما جاده ای نیست.
-
-  [routing_failed_dst_point_not_found]
-    comment = EndPointNotFound
-    tags = android, ios
-    en = Cannot calculate the route. No roads near your destination.
-    ru = Невозможно проложить маршрут. Нет дорог рядом с пунктом назначения.
-    ar = لا يمكن حساب المسار. لا توجد طرق بالقرب من وجهتك المقصودة.
-    cs = Trasu nelze vypočítat. Poblíž cílového bodu nejsou žádné cesty.
-    da = Kan ikke beregne ruten. Ingen veje nær din destination.
-    nl = Kan de route niet berekenen. Geen wegen in de buurt van uw bestemming.
-    fi = Reittiä ei voida laskea, koska määränpään lähistöllä ei ole teitä.
-    fr = Impossible de calculer l'itinéraire. Aucune route à proximité de votre destination.
-    de = Die Route kann nicht berechnet werden. Es gibt keine Straßen in der Nähe Ihres Ziels.
-    hu = Az útvonal nem tervezhető meg. Nincsenek utak az úti céljának közelében.
-    id = Tidak dapat memperhitungkan rute. Tidak ada jalan di dekat tujuan Anda.
-    it = Impossibile calcolare il percorso. Nessuna strada vicina al tuo punto di arrivo.
-    ja = ルートを計算できません。目的地の近くに道路がありません。
-    ko = 경로를 계산할 수 없습니다. 목적지 근처에 도로가 없습니다.
-    nb = Klarer ikke å beregne ruten. Ingen veier i nærheten av reisemålet.
-    pl = Nie można obliczyć trasy. Brak dróg w pobliżu celu podróży.
-    pt = Impossível calcular o trajeto. Não há estradas próximas ao seu destino.
-    pt-BR = Impossível calcular o trajeto. Não há estradas próximas ao seu destino.
-    ro = Nu se poate calcula ruta. Nu există drumuri în apropierea punctului de destinație.
-    es = No se puede calcular la ruta. No hay carreteras cerca de su destino.
-    sv = Rutten kan inte beräknas. Det finns inga vägar vid målet.
-    th = ไม่สามารถคำนวณเส้นทางได้ ไม่มีถนนที่อยู่ใกล้กับปลายทางของคุณ
-    tr = Rota hesaplanamıyor. Varış yerinizin yakınında hiçbir yol yok.
-    uk = Неможливо прокласти маршрут. Немає доріг поруч з пунктом призначення.
-    vi = Không thể tính toán tuyến đường. Không có con đường nào gần điểm đến của bạn.
-    zh-Hans = 无法计算路线。没有在您终点附近的路。
-    zh-Hant = 無法計算路線。沒有路在您的終點附近。
-    el = Δεν μπορεί να υπολογιστεί η διαδρομή. Δεν υπάρχουν δρόμοι κοντά στον προορισμό σας.
-    he = לא ניתן לחשב את המסלול. אין כבישים ליד היעד שלך.
-    sk = Nedá sa vypočítať trasa. Žiadne cesty v blízkosti cieľa.
-    fa = نمی توان مسیر را محاسبه کرد.در نزدیکی مقصد مورد نظر شما جاده ای نیست.
+    sk = Ak chcete odstrániť mapy, prosím, zastavte navigáciu.
 
   [routing_failed_cross_mwm_building]
     comment = PointsInDifferentMWM
-    tags = android, ios
+    tags = ios, android
     en = Routes can only be created that are fully contained within a map of a single region.
     ru = Маршрут может быть проложен только внутри карты одного региона.
     ar = يمكن فقط إنشاء المسارات التي توجد بشكل كامل ضمن خريطة واحدة.
@@ -7296,185 +4846,13 @@
     zh-Hans = 路程只能完全处在同一地图里时才能被创建。
     zh-Hant = 路程只能完全處在同一地圖裡時才能被建立。
     el = Μπορούν να δημιουργηθούν μόνο διαδρομές που περιέχονται πλήρως μέσα σε ένα χάρτη σε μια ενιαία περιοχή.
+    fa = تنها مسیر هایی می توانند ایجاد شوند که به طور کامل در یک نقشه از یک منطقه واحد قرار داشته باشند.
     he = ניתן ליצור רק מסלולים שמוכלים במלואם בתוך מפה אחת.
     sk = Cesty môžu byť vytvorené len tak, že sú plne obsiahnuté v jednej mape.
-    fa = تنها مسیر هایی می توانند ایجاد شوند که به طور کامل در یک نقشه از یک منطقه واحد قرار داشته باشند.
-
-  [routing_failed_route_not_found]
-    comment = RouteNotFound
-    tags = android, ios
-    en = There is no route found between the selected origin and destination. Please select a different start or end point.
-    ru = Невозможно проложить маршрут между выбранными точками. Пожалуйста, измените начало или конец маршрута.
-    ar = لم يتم العثور على مسار بين المنشأ والوُجْهَة المحددة. الرجاء تحديد نقطة بداية أو نهاية مختلفة.
-    cs = Mezi zvoleným počátkem a cílem nebyla nalezena žádná trasa. Vyberte jiný počáteční nebo koncový bod.
-    da = Der blev ikke fundet en rute mellem det valgte begyndelsespunkt og destinationen. Venligst vælg et andet start- eller slutpunkt.
-    nl = Er is geen route gevonden tussen het geselecteerde beginpunt en de bestemming. Gelieve een andere beginpunt of een eindbestemming te kiezen.
-    fi = Lähtöpisteen ja määränpään välillä ei löytynyt reittiä. Valitse toinen lähtöpiste tai määränpää.
-    fr = Il n'existe aucun itinéraire entre l'origine et la destination choisie. Veuillez sélectionner un point de départ ou d'arrivée différent.
-    de = Es wurde keine Route zwischen dem ausgewählten Ausgangspunkt und Ziel gefunden. Bitte wählen Sie einen anderen Start- oder Endpunkt.
-    hu = Nem találtunk útvonalat a kiválasztott kiindulópont és az úti cél között. Kérjük, válasszon másik kiinduló- vagy végpontot.
-    id = Tidak ada rute yang ditemukan antara tempat asal dan tujuan yang dipilih. Mohon pilih titik mulai atau tujuan yang berbeda.
-    it = Non è stata trovata alcuna strada fra il punto di partenza e d'arrivo selezionati. Seleziona un punto di partenza e d'arrivo diversi.
-    ja = 選択した出発地と目的地との間にルートが見つかりません。別の出発地点と到着地点を選択してください。
-    ko = 선택한 출발지와 목적지 사이에서 발견있는 경로가 없습니다. 다른 출발지 또는 도착지를 선택하십시오.
-    nb = Finner ingen rute mellom valgt startsted og destinasjon. Velg et annet start- eller sluttpunkt.
-    pl = Nie znaleziono trasy pomiędzy wybranym punktem rozpoczęcia podróży a jej celem. Wybierz inny punkt początkowy lub końcowy.
-    pt = Não foi encontrado um trajeto entre a origem e o destino selecionados. Por favor selecione um ponto de partida ou de chegada diferente.
-    pt-BR = Não foi encontrado nenhum trajeto entre a origem e o destino selecionados. Por favor selecione um ponto de partida ou de chegada diferente.
-    ro = Nu am găsit nicio rută între punctul de pornire și destinația selectată. Vă rugăm să alegeți un alt punct de pornire sau de destinație.
-    es = No se ha encontrado ninguna ruta entre el origen seleccionado y el destino. Por favor, seleccione un punto de partida o destino diferente.
-    sv = Ingen rutt hittades mellan vald startpunkt och målet. Välj en annan start- eller slutpunkt.
-    th = ไม่พบเส้นทางที่อยู่ระหว่างต้นทางและปลายทางที่เลือก โปรดเลือกจุดเริ่มต้นและจุดสิ้นสุดอื่น
-    tr = Seçilen kalkış yeriyle varış yeri arasında hiçbir rota bulunamadı. Lütfen farklı bir başlangıç veya bitiş noktası seçin.
-    uk = Неможливо прокласти маршрут між вибраними точками. Будь ласка, змініть початок і кінець маршруту.
-    vi = Không tìm thấy tuyến đường nào giữa điểm gốc và điểm đến được chọn. Vui lòng chọn điểm bắt đầu hoặc điểm cuối khác.
-    zh-Hans = 找不到所选起点和终点间的路程。请选择不同的起点或终点。
-    zh-Hant = 找不到所選起點和終點間的路程。請選擇不同的起點或終點。
-    el = Δεν βρέθηκε καμία διαδρομή μεταξύ της επιλεγμένης προέλευσης και προορισμού. Επιλέξτε ένα διαφορετικό σημείο έναρξης ή λήξης.
-    he = אין מסלול בין המוצא והיעד שנבחרו. נא לבחור נקודת התחלה או יעד שונה.
-    sk = Nebol nájdená trasa medzi vybraným východiskom a cieľom. Prosím vyberte iný počiatočný a koncový bod.
-    fa = مسیری بین مبدا و مقصد انتخابی یافت نشد.لطفا مبدا یا مقصد دیگری را انتخاب کنید
-
-  [routing_failed_internal_error]
-    comment = InternalError
-    tags = android, ios
-    en = Internal error occurred. Please try to delete and download the map again. If the problem persists, please contact us at support@organicmaps.app.
-    ru = Внутренняя ошибка. Пожалуйста, удалите карту и скачайте её еще раз. Если это не помогло, напишите нам на support@organicmaps.app
-    ar = حدث خطأ داخلي. يرجى محاولة حذف الخريطة وإعادة تنزيلها مرة أخرى. إذا استمرت المشكلة يرجى الاتصال بنا على support@organicmaps.app.
-    cs = Došlo k vnitřní chybě. Zkuste, prosím, mapu smazat a znovu stáhnout. Jestliže problém přetrvává, kontaktujte nás na support@organicmaps.app.
-    da = Intern fejl opstod. Venligt prøv at slette og downloade kortet igen. Hvis problemet vare ved, venligst kontakt os på support@organicmaps.app.
-    nl = Er is een interne fout opgetreden. Probeer het kaart te verwijderen en opnieuw te downloaden. Indien het probleem blijft optreden, neem dan contact met ons op support@organicmaps.app.
-    fi = Sisäinen virhe. Kokeile asentaa kartta uudelleen. Mikäli ongelma jatkuu, ota yhteyttä asiakaspalveluun osoitteessa support@organicmaps.app.
-    fr = Une erreur interne s'est produite. Veuillez essayer de supprimer la carte et téléchargez la à nouveau. Si le problème persiste, veuillez contacter support@organicmaps.app.
-    de = Es ist ein interner Fehler aufgetreten. Bitte versuchen Sie, die Karte zu löschen und erneut herunterzuladen.
-    hu = Belső hiba történt. Kérjük, próbálja meg kitörölni és újra letölteni a térképet. Ha a probléma továbbra is fennáll, kérjük, vegye fel velünk a kapcsolatot a support@organicmaps.app email címen.
-    id = Terjadi gangguan internal. Mohon coba menghapus dan mengunduh petanya lagi. Jika masih terjadi masalah mohon hubungi kami di support@organicmaps.app.
-    it = Si è verificato un errore interno. Prova ad eliminare la mappa e a scaricarla nuovamente. Se il problema dovesse persistere, contattaci all'indirizzo support@organicmaps.app.
-    ja = 内部エラーが発生しました。もう一度地図をダウンロードしてください。問題が解決しない場合は、support@organicmaps.appまでご連絡ください。
-    ko = 내부 오류가 발생했습니다. 다시지도를 삭제하고 다운로드하도록 시도하십시오. 문제가 지속되면 support@organicmaps.app로 문의하시기 바랍니다.
-    nb = Det oppsto en intern feil. Prøv å slette og laste ned kartet på nytt. Hvis problemet vedvarer kan du kontakte oss på support@organicmaps.app.
-    pl = Wystąpił wewnętrzny błąd. Spróbuj usunąć mapę i pobrać ją ponownie. Jeśli problem będzie się nadal powtarzał, skontaktuj się z nami pod adresem support@organicmaps.app.
-    pt = Ocorreu um erro interno. Por favor experimente apagar o mapa e depois descarregue-o novamente. Se o problema persistir, contacte-nos através de support@organicmaps.app.
-    pt-BR = Ocorreu um erro interno. Por favor experimente apagar o mapa e depois baixe-o novamente. Se o problema persistir, entre em contato conosco através de support@organicmaps.app.
-    ro = A survenit o eroare internă. Vă rugăm să încercați să ștergeți și să descărcați harta din nou. Dacă problema persistă, vă rugăm să ne contactați la adresa support@organicmaps.app.
-    es = Se ha producido un error interno. Por favor, intente eliminar y descargar el mapa otra vez. Si el problema persiste, por favor contáctenos en support@organicmaps.app.
-    sv = Ett internt fel inträffade. Försök att radera och ladda ner kartan igen. Kontakta oss på support@organicmaps.app om problemet kvarstår.
-    th = เกิดข้อผิดพลาดขึ้นภายใน โปรดลองลบและดาวน์โหลดแผนที่อีกครั้ง โปรดติดต่อเราได้ที่ support@organicmaps.app.
-    tr = Sistem içi hata oluştu. Lütfen haritayı silin ve tekrar yüklemeyi deneyin. Sorun devam ettiği takdirde lütfen support@organicmaps.app adresinden bize ulaşın.
-    uk = Внутрішня помилка. Будь ласка, видаліть мапу і завантажте її ще раз. Якщо це не допомогло, напишіть нам на support@organicmaps.app
-    vi = Đã xảy ra lỗi nội bộ. Vui lòng thử xóa và tải lại xuống bản đồ. Nếu vấn đề vẫn còn tồn tại, vui lòng liên hệ với chúng tôi tại support@organicmaps.app.
-    zh-Hans = 出现内部错误。请尝试删除并再次下载地图。如果还有问题请联系我们：support@organicmaps.app。
-    zh-Hant = 出現內部錯誤。請嘗試刪除並再次下載地圖。如果還有問題請聯絡我們：support@organicmaps.app。
-    el = Παρουσιάστηκε εσωτερικό σφάλμα. Δοκιμάστε να διαγράψετε και να κατεβάσετε το χάρτη ξανά. Εάν το πρόβλημα παραμένει, επικοινωνήστε μαζί μας στη διεύθυνση support@organicmaps.app.
-    he = אירעה שגיאה פנימית. נא לנסות למחוק את המפה להוריד אותה מחדש. אם הבעיה נמשכת, נא לפנות אלינו בכתובת support@organicmaps.app.
-    sk = Došlo k vnútornej chybe. Prosím, skúste zmazať a znovu stiahnuť mapu. Ak problém pretrvá, prosím, kontaktujte nás na support@organicmaps.app.
-    fa = خطای داخلی اتفاق افتاد.لطفا تلاش کنید نقشه را حذف و مجددا دانلود کنید.اگر همچنان مشکل پابرجاست لطفا با ما تماس بگیرید support@organicmaps.app.
-
-  [downloader_download_map_and_routing]
-    comment = Context menu item for downloader.
-    tags = ios,android
-    en = Download Map + Routing
-    ru = Загрузить карту + маршруты
-    ar = تنزيل الخريطة + تحديد المسار
-    cs = Stáhnout mapu + trasy
-    da = Hent kort + ruteangivelse
-    nl = Download kaart + routering
-    fi = Lataa kartta + reititys
-    fr = Télécharger Carte + Itinéraire
-    de = Karte + Routenplanung herunterladen
-    hu = Térkép + útvonal letöltése
-    id = Untuh Peta + Rute
-    it = Scarica mappa e percorso
-    ja = 地図とルートをダウンロード
-    ko = 지도 + 라우팅 다운로드
-    nb = Last ned kart + rutetilordning
-    pl = Pobierz mapę + wyznaczanie tras
-    pt = Descarregar Mapa + Roteamento
-    pt-BR = Baixar Mapa + Roteamento
-    ro = Descărcare hartă + traseu
-    es = Descargar mapa + itinerario
-    sv = Ladda ner karta + anvisningar
-    th = ดาวน์โหลดแผนที่ + การเลือกเส้นทาง
-    tr = Harita + Rota İndir
-    uk = Завантажити карту + маршрути
-    vi = Tải xuống Bản đồ + Định tuyến
-    zh-Hans = 下载地图 + 路线
-    zh-Hant = 下載地圖 + 路線
-    he = הורד מפה + מסלול
-    sk = Na stiahnutie Mapa + Trasa
-    fa = دانلود نقشه + مسیریابی
-
-  [downloader_download_routing]
-    comment = Context menu item for downloader.
-    tags = ios,android
-    en = Download Routing
-    ru = Загрузить маршруты
-    ar = تنزيل تحديد المسار
-    cs = Stáhnout trasy
-    da = Hent ruteangivelse
-    nl = Download routering
-    fi = Lataa reititys
-    fr = Télécharger Itinéraire
-    de = Routenplanung herunterladen
-    hu = Útvonal letöltése
-    id = Unduh Rute
-    it = Scarica percorso
-    ja = ルートをダウンロード
-    ko = 라우팅 다운로드
-    nb = Last ned rutetilordning
-    pl = Pobierz wyznaczanie tras
-    pt = Descarregar Roteamento
-    pt-BR = Baixar Roteamento
-    ro = Descărcare traseu
-    es = Descargar itinerario
-    sv = Ladda ner anvisningar
-    th = ดาวน์โหลดการเลือกเส้นทาง
-    tr = Rota İndir
-    uk = Завантажити маршрути
-    vi = Tải xuống Định tuyến
-    zh-Hans = 下载路线
-    zh-Hant = 下載路線
-    he = הורד מסלול
-    sk = Trasa na stiahnutie
-    fa = دانلود  مسیریابی
-
-  [downloader_delete_routing]
-    comment = Context menu item for downloader.
-    tags = ios,android
-    en = Delete Routing
-    ru = Удалить маршруты
-    ar = إزالة تحديد المسار
-    cs = Smazat trasy
-    da = Slet ruteangivelse
-    nl = Verwijder routering
-    fi = Poista reititys
-    fr = Supprimer Itinéraire
-    de = Routenplanung löschen
-    hu = Útvonal törlése
-    id = Hapus Rute
-    it = Elimina il percorso
-    ja = ルートを削除
-    ko = 라우팅 삭제
-    nb = Slett rutetilordning
-    pl = Skasuj wyznaczanie tras
-    pt = Apagar Roteamento
-    pt-BR = Apagar Roteamento
-    ro = Ștergere traseu
-    es = Eliminar itinerario
-    sv = Radera anvisningar
-    th = ลบการเลือกเส้นทาง
-    tr = Rotayı Sil
-    uk = Видалити маршрути
-    vi = Xóa Định tuyến
-    zh-Hans = 删除路线
-    zh-Hant = 刪除路線
-    he = מחק מסלול
-    sk = Zmazať Trasu
-    fa = حذف مسیریابی
 
   [downloader_download_map]
     comment = Context menu item for downloader.
-    tags = ios,android
+    tags = android
     en = Download map
     ru = Загрузить карту
     ar = تنزيل الخريطة
@@ -7503,80 +4881,13 @@
     zh-Hans = 下载地图
     zh-Hant = 下載地圖
     el = Λήψη χάρτη
+    fa = دانلود نقشه
     he = הורידו את המפה
     sk = Stiahnuť mapu
-    fa = دانلود نقشه
-
-  [downloader_download_map_no_routing]
-    tags = ios,android
-    en = Download map without routing
-    ru = Загрузить карту без маршрутов
-    ar = تنزيل خريطة بدون تحديد خط السير
-    cs = Stáhnout mapy bez tras
-    da = Download kort uden ruteplanlægning
-    nl = Download kaart zonder routeplanning
-    fi = Lataa kartta ilman reititystä
-    fr = Télécharger la carte sans itinéraire
-    de = Karte ohne Routenplanung herunterladen
-    hu = Térkép letöltése útvonal nélkül
-    id = Unduh peta tanpa perutean
-    it = Scarica mappa senza percorsi
-    ja = ルートなしで地図をダウンロード
-    ko = 라우팅없이 지도 다운로드
-    nb = Last ned kart uten veiviserfunksjon
-    pl = Pobierz mapę bez oznaczania tras
-    pt = Baixar mapa sem roteamento
-    pt-BR = Baixar mapa sem roteamento
-    ro = Descărcare hartă fără rutare
-    es = Descargar mapa sin ruta
-    sv = Hämta karta utan rutter
-    th = ดาวน์โหลดแผนที่โดยไม่กำหนดเส้นทาง
-    tr = Haritayı rota olmadan indirin
-    uk = Завантажити карту без маршрутів
-    vi = Tải về bản đồ không có chỉ đường
-    zh-Hans = 下载不带路线的地图
-    zh-Hant = 下載不帶路線的地圖
-    he = הורד מפה בלי לקבוע מסלול
-    sk = Stiahnite si mapu bez smerovania
-    fa = دانلود نقشه بدون مسیریابی
-
-  [routing_go]
-    comment = Button for routing.
-    tags = ios,android
-    en = Go!
-    ru = Поехали!
-    ar = انطلق!
-    cs = Jet!
-    da = Kør!
-    nl = Starten!
-    fi = Lähde!
-    fr = Allez-y !
-    de = Los!
-    hu = Indulás!
-    id = Mulai!
-    it = Andare!
-    ja = 開始！
-    ko = 이동!
-    nb = Kjør!
-    pl = Przejdź!
-    pt = Avançar!
-    pt-BR = Ir!
-    ro = Pornește!
-    es = ¡Listo!
-    sv = Kör!
-    th = ไป!
-    tr = Git!
-    uk = Поїхали!
-    vi = Tiến hành!
-    zh-Hans = 出发！
-    zh-Hant = 開始！
-    he = נווטו!
-    sk = Štart!
-    fa = برو!
 
   [downloader_retry]
     comment = Item status in downloader.
-    tags = ios,android
+    tags = ios, android
     en = Retry
     ru = Повторить
     ar = تكرار
@@ -7605,46 +4916,12 @@
     zh-Hans = 重复
     zh-Hant = 重試
     el = Επανάληψη
-    sk = Zopakovať
     fa = تلاش مجدد
-
-  [downloader_map_and_routing]
-    comment = Item in context menu.
-    tags = ios,android
-    en = Map + Routing
-    ru = Карта + Маршруты
-    ar = الخريطة + تحديد المسار
-    cs = Mapa + trasy
-    da = Kort og rutevejledning
-    nl = Kaart + route
-    fi = Kartta + reititys
-    fr = Carte + itinéraire
-    de = Karte + Routenplanung
-    hu = Térkép + útvonal megállapítása
-    id = Peta + Rute
-    it = Mappa + percorso
-    ja = 地図とルート
-    ko = 지도 + 라우팅
-    nb = Kart + rutetilordning
-    pl = Mapa + trasy
-    pt = Mapa + Criação de Trajeto
-    pt-BR = Mapa + Roteamento
-    ro = Hartă + trasee
-    es = Mapa + itinerario
-    sv = Karta + Navigering
-    th = แผนที่ + เส้นทาง
-    tr = Harita + Rota
-    uk = Мапа + Маршрути
-    vi = Bản đồ + Định tuyến
-    zh-Hans = 地图 + 布置路线
-    zh-Hant = 地圖 + 路線
-    he = מפה + מסלול
-    sk = Mapa + Smerovanie
-    fa = نقشه + مسیریابی
+    sk = Zopakovať
 
   [downloader_delete_map]
     comment = Item in context menu.
-    tags = ios,android
+    tags = ios, android
     en = Delete Map
     ru = Удалить карту
     ar = حذف الخريطة
@@ -7673,13 +4950,13 @@
     zh-Hans = 删除地图
     zh-Hant = 刪除地圖
     el = Διαγραφή χάρτη
+    fa = حذف نقشه
     he = מחק מפה
     sk = Zmazať mapu
-    fa = حذف نقشه
 
   [downloader_update_map]
     comment = Item in context menu.
-    tags = ios,android
+    tags = android
     en = Update Map
     ru = Обновить карту
     ar = تحديث الخريطة
@@ -7708,109 +4985,9 @@
     zh-Hans = 更新地图
     zh-Hant = 更新地圖
     el = Ενημέρωση χάρτη
+    fa = به روز رسانی نقشه
     he = עדכן מפה
     sk = Aktualizovať mapu
-    fa = به روز رسانی نقشه
-
-  [downloader_update_map_and_routing]
-    comment = Item in context menu.
-    tags = ios,android
-    en = Update Map + Routing
-    ru = Обновить карту + Маршруты
-    ar = تحديث الخريطة + تحديد المسار
-    cs = Aktualizovat mapu + trasy
-    da = Opdater kort og rutevejledning
-    nl = Kaart bijwerken + route
-    fi = Päivitä kartta + reititys
-    fr = Mise à jour carte + itinéraire
-    de = Karte + Routenplanung aktualisieren
-    hu = Térkép frissítése + útvonal megállapítása
-    id = Perbarui Peta + Rute
-    it = Aggiorna mappa + percorso
-    ja = 地図とルートを更新
-    ko = 지도 + 라우팅 업데이트
-    nb = Oppdater kart + rutetilordning
-    pl = Aktualizuj mapę + trasy
-    pt = Atualizar Mapa + Criação de Trajeto
-    pt-BR = Atualizar Mapa + Roteamento
-    ro = Actualizare hartă + trasee
-    es = Actualizar mapa + itinerario
-    sv = Uppdatera karta + Navigering
-    th = อัปเดตแผนที่ + เส้นทาง
-    tr = Harita + Rota Güncelle
-    uk = Оновити мапу + Маршрути
-    vi = Cập nhật bản đồ + Định tuyến
-    zh-Hans = 更新地图 + 布置路线
-    zh-Hant = 更新地圖 + 路線
-    he = עדכן מפה + מסלול
-    sk = Aktualizovať mapu + Smerovanie
-    fa = به روز رسانی نقشه + مسیریابی
-
-  [downloader_map_only]
-    comment = Item in context menu.
-    tags = ios,android
-    en = Map Only
-    ru = Только карта
-    ar = الخريطة فقط
-    cs = Pouze mapa
-    da = Kun kort
-    nl = Alleen de kaart
-    fi = Vain kartta
-    fr = Carte uniquement
-    de = Nur Karte
-    hu = Csak térkép
-    id = Hanya Peta
-    it = Solo mappa
-    ja = 地図のみ
-    ko = 지도만
-    nb = Bare kart
-    pl = Tylko mapa
-    pt = Apenas Mapa
-    pt-BR = Apenas Mapa
-    ro = Doar harta
-    es = Solo mapa
-    sv = Endast karta
-    th = แผนที่เท่านั้น
-    tr = Sadece harita
-    uk = Тільки карта
-    vi = Chỉ bản đồ
-    zh-Hans = 只有地图
-    zh-Hant = 只有地圖
-    he = מפה בלבד
-    sk = Iba mapa
-    fa = فقط نقشه
-
-  [toolbar_application_menu]
-    comment = Toolbar title
-    tags = ios,android
-    en = Application menu
-    ru = Меню приложения
-    ar = قائمة التطبيق
-    cs = Nabídka aplikace
-    da = Programmenu
-    nl = Applicatiemenu
-    fi = Sovellusvalikko
-    fr = Menu principal
-    de = Anwendungs-Menü
-    hu = Menü
-    id = Menu aplikasi
-    it = Menu applicazione
-    ja = アプリケーションメニュー
-    ko = 애플리케이션 메뉴
-    nb = Applikasjonsmeny
-    pl = Menu aplikacji
-    pt = Menu de Aplicação
-    pt-BR = Menu do aplicativo
-    ro = Meniu aplicație
-    es = Menú de aplicación
-    sv = Programmeny
-    th = เมนูของแอปพลิเคชัน
-    tr = Uygulama menüsü
-    uk = Меню програми
-    vi = Menu ứng dụng
-    he = תפריט האפליקציה
-    sk = Ponuka aplikácie
-    fa = منوی برنامه
 
   [pref_use_google_play]
     comment = Preference text
@@ -7843,12 +5020,12 @@
     zh-Hans = 使用Google Play服务以获取您的当前位置。
     zh-Hant = 使用 Google Play 服務來獲得您的目前位置
     el = Χρησιμοποιήστε υπηρεσίες Google Play για να προσδιορίσετε την τρέχουσα τοποθεσία σας
-    sk = Pomocou Google Play služieb získajte svoju aktuálnu polohu
     fa = استفاده از Google Play Services برای تعیین موقعیت کنونی شما
+    sk = Pomocou Google Play služieb získajte svoju aktuálnu polohu
 
   [rating_just_rated]
     comment = Text for rating dialog
-    tags = android
+    tags = ios
     en = I’ve just rated your app
     ru = Я только что оценил Organic Maps
     ar = لقد قمت بتقييم تطبيقك للتو
@@ -7879,110 +5056,9 @@
     el = Μόλις βαθμολόγησα την εφαρμογή σας
     sk = Práve som hodnotil vašu aplikáciu
 
-  [rating_user_since]
-    comment = Text for rating dialog
-    tags = android
-    en = I’ve been a Organic Maps user since %@
-    ru = Я пользуюсь Organic Maps c %@
-    ar = أنا مستخدم لتطبيق Organic Maps منذ %@
-    cs = Uživatelem Organic Maps jsem od roku %@
-    da = Jeg er Organic Maps bruger siden %@
-    nl = Ik ben een Organic Maps-gebruiker vanaf %@
-    fi = Olen Organic Maps käyttäjä vuodesta %@.
-    fr = J'utilise Organic Maps depuis %@
-    de = Ich bin Organic Maps-Nutzer seit %@
-    hu = Organic Maps felhasználó vagyok %@ óta
-    id = Saya pengguna Organic Maps sejak %@
-    it = Sono un utente Organic Maps dal %@
-    ja = 私は%@年からOrganic Mapsのユーザーです
-    ko = %@ 이후로 Organic Maps 사용자임
-    nb = Jeg har vært Organic Maps-bruker siden %@
-    pl = Jestem użytkownikiem Organic Maps od %@ r.
-    pt = Sou usuário do Organic Maps desde %@
-    pt-BR = Sou usuário do Organic Maps desde %@
-    ro = Sunt utilizator Organic Maps din %@
-    es = Soy usuario de Organic Maps desde %@
-    sv = Jag har använt Organic Maps sedan %@
-    th = ฉันคือผู้ใช้ MAPS. ME ตั้งแต่ปี %@
-    tr = %@ yılından beri Organic Maps kullanıcısıyım
-    uk = Я користувач Organic Maps з %@ року
-    vi = Tôi là người dùng Organic Maps từ năm %@
-    zh-Hans = 我是从%@年起的Organic Maps用户
-    zh-Hant = 我是從 %@ 年起的 Organic Maps 使用者
-    el = Χρησιμοποιώ το Organic Maps από τις %@
-    sk = Som používateľ Organic Maps od roku %@
-
-  [rating_do_like_maps]
-    comment = Text for rating dialog
-    tags = android
-    en = Do you like Organic Maps?
-    ru = Нравится приложение?
-    ar = هل تطبيق Organic Maps يعجبك؟
-    cs = Líbí se vám aplikace Organic Maps?
-    da = Kan du lide Organic Maps?
-    nl = Vind je Organic Maps leuk?
-    fi = Pidätkö Organic Maps sovelluksesta?
-    fr = Aimez-vous Organic Maps ?
-    de = Mögen Sie Organic Maps?
-    hu = Szereted a Organic Maps-t?
-    id = Anda suka Organic Maps?
-    it = Ti piace Organic Maps?
-    ja = Organic Mapsをお気に入りいただいていますか？
-    ko = Organic Maps를 좋아하나요?
-    nb = Liker du Organic Maps?
-    pl = Lubisz Organic Maps?
-    pt = Você gosta de Organic Maps?
-    pt-BR = Você gosta do Organic Maps?
-    ro = Îți place Organic Maps?
-    es = ¿Te gusta Organic Maps?
-    sv = Gillar du Organic Maps?
-    th = คุณชอบ MAPS. ME หรือไม่?
-    tr = Organic Maps'yi beğeniyor musunuz?
-    uk = Вам подобається Organic Maps?
-    vi = Bạn có thích Organic Maps?
-    zh-Hans = 您喜欢Organic Maps吗？
-    zh-Hant = 您喜歡 Organic Maps 嗎？
-    el = Σας αρέσει το Organic Maps;
-    sk = Páči sa vám Organic Maps?
-    fa = Organic Maps را می پسندید؟
-
-  [rating_tap_star]
-    comment = Text for rating dialog
-    tags = android
-    en = Tap a star to rate our app.
-    ru = Оцените Organic Maps.
-    ar = انقر على النجمة لتقييم التطبيق.
-    cs = Klepnutím na hvězdičku naši aplikaci ohodnotíte.
-    da = Tryk på en stjerne for at bedømme vores app.
-    nl = Druk op een ster om onze app te waarderen.
-    fi = Napauta tähteä arvostellaksesi sovelluksemme.
-    fr = Tapotez sur une étoile pour évaluer notre appli
-    de = Tippen Sie auf einen Stern, um unsere App zu bewerten.
-    hu = Érints meg egy csillagot az alkalmazás értékeléséhez.
-    id = Ketuk bintang untuk menilai app kami.
-    it = Fai tap sulla stella per valutare la nostra app.
-    ja = 星印をタップしてアプリを評価してください。
-    ko = 별을 눌러 우리의 앱을 평가하세요.
-    nb = Trykk på en stjerne for å vurdere appen.
-    pl = Stuknij gwiazdkę, by ocenić naszą aplikację.
-    pt = Toque em alguma estrela para classificar o nosso app.
-    pt-BR = Toque em alguma estrela para avaliar o nosso app.
-    ro = Apasă pe una dintre stele pentru a ne vota aplicația
-    es = Pulsa una estrella para puntuar tu aplicación.
-    sv = Tryck på en stjärna för att betygsätta vår app.
-    th = แตะดาวเพื่อให้คะแนนแอปของเรา
-    tr = Uygulamamıza puan vermek için bir yıldıza dokunun.
-    uk = Торкніться зірочки, щоб оцінити нашу програму.
-    vi = Chạm vào một ngôi sao để đánh giá ứng dụng của chúng tôi.
-    zh-Hans = 点击星星给我们应用评分。
-    zh-Hant = 點擊星星給我們應用程式評分。
-    el = Πατήστε ένα αστέρι να βαθμολογήσετε την εφαρμογή μας.
-    sk = Kliknutím na hviezdu ohodnotíte našu aplikáciu.
-    fa = بر روی ستاره ها لمس کنید تا به این اپ رای بدهید
-
   [rating_thanks]
     comment = Text for rating dialog
-    tags = android
+    tags = ios
     en = Thank you!
     ru = Спасибо!
     ar = شكرا لك!
@@ -8011,12 +5087,12 @@
     zh-Hans = 谢谢您！
     zh-Hant = 謝謝您！
     el = Σας ευχαριστούμε!
-    sk = Ďakujeme vám!
     fa = متشکریم!
+    sk = Ďakujeme vám!
 
   [rating_share_ideas]
     comment = Text for rating dialog
-    tags = android
+    tags = ios
     en = Share any ideas or issues so we can improve the app for you.
     ru = Что-то не так?  Расскажите, что бы мы могли исправить или улучшить в приложении.
     ar = شارك أي أفكار أو مشاكل، حتى نتمكن من تحسين التطبيق من أجلك.
@@ -8045,12 +5121,12 @@
     zh-Hans = 分享任何主意或问题，这样我们可以为您改善应用。
     zh-Hant = 分享任何主意或問題，這樣我們可以為您改善應用程式。
     el = Μοιραστείτε ιδέες ή προβλήματα για να βελτιώσουμε την εφαρμογή.
-    sk = Podeľte sa o svoje nápady alebo problémy, aby sme pre vás mohli vylepšiť aplikáciu.
     fa = ایده ها و نقطه نظرات تان را با ما در میان بگذارید ما برنامه را مطابق میلتان توسعه می دهیم
+    sk = Podeľte sa o svoje nápady alebo problémy, aby sme pre vás mohli vylepšiť aplikáciu.
 
   [rating_send_feedback]
     comment = Text for rating dialog
-    tags = android
+    tags = ios
     en = Send feedback
     ru = Напишите нам
     ar = إرسال التعليق
@@ -8079,46 +5155,12 @@
     zh-Hans = 发送反馈
     zh-Hant = 發送回饋
     el = Αποστολή σχολίου
-    sk = Odoslať spätnú väzbu
     fa = ارسال بازخورد
-
-  [rating_google_plus]
-    comment = Text for g+ dialog
-    tags = android
-    en = Click g+ to tell your friends about the app.
-    ru = Нажмите g+, чтобы рассказать друзьям о приложении
-    ar = اضغط على g+ لتخبر أصدقاءك عن التطبيق.
-    cs = Klikněte na g+ a povězte o aplikaci svým přátelům.
-    da = Klik g+ for at fortælle dine venner om app'en.
-    nl = Klik op g+ om je vrienden te informeren over de app.
-    fi = Napsauta g+ ja kerro ystävillesi sovelluksesta.
-    fr = Clique sur g+ pour parler de l'appli à tes amis.
-    de = Klick auf G+, um deinen Freunden über die App zu erzählen.
-    hu = Kattints a g+-ra és mesélj barátaidnak az alkalmazásról
-    id = Klik g+ untuk memberi tahu teman-teman tentang aplikasi tersebut.
-    it = Clicca su g+ per far conoscere l'app ai tuoi amici.
-    ja = g+をクリックして友達にこのアプリを教えてあげましょう。
-    ko = g+를 클릭하여 이 앱에 대해 친구들에게 말하세요.
-    nb = Klikk på g+ for å fortelle vennene dine om denne appen.
-    pl = Kliknij g+, aby powiedzieć swoim znajomym o tej apce.
-    pt = Clique em g+ para contar aos seus amigos sobre o app.
-    pt-BR = Toque em g+ para contar aos seus amigos sobre o app.
-    ro = Clic pe g+ pentru a le spune prietenilor tăi despre aplicație.
-    es = Haz clic en g+ para hablar a tus amigos acerca de la app.
-    sv = Klicka på g+ för att berätta om appen för dina vänner.
-    th = คลิก g+ เพื่อบอกเพื่อน ๆ ของคุณเกี่ยวกับแอป
-    tr = Arkadaşlarına uygulamayı duyurmak için g+'ya tıkla.
-    uk = Щоб розповісти своїм друзям про програму, клацніть g+.
-    vi = Nhấp vào g+ để nói với bạn bè của bạn về ứng dụng.
-    zh-Hans = 点击g+向您的朋友们告知这款应用。
-    zh-Hant = 點擊g+向您的朋友們告知這款應用程式。
-    el = Κάντε κλικ στο g+ να ενημερώσετε τους φίλους σας σχετικά με την εφαρμογή.
-    sk = Kliknutím na tlačidlo g + povedzte o aplikácii svojim priateľom.
-    fa = بر روی g+ کلیک کنید و از این برنامه برایشان بگویید.
+    sk = Odoslať spätnú väzbu
 
   [routing_download_maps_along]
     comment = Text for routing error dialog
-    tags = android, ios
+    tags = ios, android
     en = Download all of the maps along your route
     ru = Загрузите все карты по пути следования
     ar = تنزيل الخرائط على طول الطريق
@@ -8147,148 +5189,12 @@
     zh-Hans = 下载沿线地图
     zh-Hant = 下載沿線地圖
     el = Κατεβάστε όλους τους χάρτες για ολόκληρο το μήκος της διαδρομής σας
-    sk = Stiahnite si mapy pozdĺž trasy
     fa = دانلود تمامی نقشه ها در طول مسیر تان
-
-  [routing_download_map]
-    comment = Text for routing error dialog
-    tags = android, ios
-    en = Get map
-    ru = Загрузите карту
-    ar = Scarica la mappa
-    cs = Získejte mapu
-    da = Få kort
-    nl = Krijg kaart
-    fi = Hanki kartta
-    fr = Téléchargez des cartes
-    de = Karte abrufen
-    hu = Térkép megszerzése
-    id = Dapatkan peta
-    it = Scarica la mappa
-    ja = 地図を入手
-    ko = 지도 가져오기
-    nb = Skaff kart
-    pl = Pobierz mapę
-    pt = Obter mapa
-    pt-BR = Obter mapa
-    ro = Descărcați harta
-    es = Obtén el mapa
-    sv = Hämta karta
-    th = รับแผนที่
-    tr = Harita alın
-    uk = Отримати карту
-    vi = Nhận bản đồ
-    zh-Hans = 获取地图
-    zh-Hant = 獲取地圖
-    el = Λήψη χάρτη
-    sk = Stiahnuť mapu
-    fa = دریافت نقشه
-
-  [routing_download_map_and_routing]
-    comment = Text for routing error dialog
-    tags = android, ios
-    en = Download updated map and routing data to get all Organic Maps features.
-    ru = Загрузите карту и маршруты, чтобы получить доступ ко всем возможностям приложения.
-    ar = Scarica la mappa aggiornata e i dati del percorso per ottenere tutte le funzionalità Organic Maps.
-    cs = Stáhněte si aktualizovanou mapu a data tras, ať můžete využít všechny funkce Organic Maps.
-    da = Download opdaterede kort og routing data for at få alle Organic Maps funktioner.
-    nl = Download bijgewerkte kaart en routegegevens om alle functies van Organic Maps te krijgen.
-    fi = Lataa päivitetty kartta ja reititysdata saadaksesi kaikki Organic Maps -ominaisuudet.
-    fr = Des cartes actualisées et des données de routage pour obtenir toutes les fonctionnalités de Organic Maps.
-    de = Laden Sie die aktualisierte Karte und Daten der Routenplanung herunter, um alle Organic Maps-Funktionen zu nutzen.
-    hu = Frissített térkép és útvonaltervezési adatok letöltése az összes Organic Maps tulajdonság megszerzése érdekében.
-    id = Unduh peta yang diperbarui dan data perutean untuk mendapatkan semua fitur Organic Maps.
-    it = Scarica la mappa aggiornata e i dati del percorso per ottenere tutte le funzionalità Organic Maps.
-    ja = 最新の地図とルートデータを入手して、Organic Mapsの全機能をご利用ください。
-    ko = 업데이트된 지도와 라우팅 데이터를 다운로드하여 모든 Organic Maps 기능을 가져옵니다.
-    nb = Last ned oppdatert kart og ruteinformasjon for å få alle Organic Maps funksjonene
-    pl = Pobierz zaktualizowaną mapę i dane ustalania tras, by mieć dostęp do wszystkich funkcji Organic Maps.
-    pt = Descarregue o mapa e os dados de itinerário atualizados para acessar todos os recursos do Organic Maps.
-    pt-BR = Baixe o mapa e os dados de roteamento atualizados para acessar todos os recursos do Organic Maps.
-    ro = Descărcați harta actualizată și informațiile pentru direcționare, pentru a beneficia de toate funcțiile Organic Maps.
-    es = Descarga el mapa actualizado y los datos de enrutamiento para conseguir todas las funciones de Organic Maps.
-    sv = Ladda ner uppdaterad karta och navigeringsdata för att få tillgång till alla Organic Maps funktioner.
-    th = ดาวน์โหลดแผนที่มีการอัปเดตและการกำหนดเส้นทางข้อมูลเพื่อรับฟีเจอร์ Organic Maps ทั้งหมด
-    tr = Tüm Organic Maps özelliklerini edinmek için güncellenmiş harita ve rota verilerini indirin.
-    uk = Завантажте оновлену карту та дані про маршрут, щоб отримати всі можливості Organic Maps.
-    vi = Tải bản đồ và dữ liệu đường đi cập nhật để nhận được tất cả các tính năng của Organic Maps.
-    zh-Hans = 下载更新的地图和路线数据，获取所有 Organic Maps 的特色功能。
-    zh-Hant = 下載更新的地圖和路線數據，獲取所有 Organic Maps 的特色功能。
-    el = Κάντε λήψη ενημερωμένου χάρτη και δεδομένων πλοήγησης για να έχετε όλα τα χαρακτηριστικά του Organic Maps.
-    sk = Aktualizovať mapu a trasové dáta na to aby ste mohli získajte všetky funkcie Organic Maps.
-    fa = برای داشتن تمامی ویژگی های Organic Maps نقشه ها و داده های مسیریابی را اپدیت نمایید.
-
-  [routing_get_routing_data]
-    comment = Text for routing error dialog
-    tags = android, ios
-    en = Get routing data
-    ru = Загрузите маршруты
-    ar = Ottieni i dati del percorso
-    cs = Získejte data tras
-    da = Få routing data
-    nl = Krijg routegegevens
-    fi = Hanki reitityskartta
-    fr = Recevez des données de routage
-    de = Daten für Routenplanung abrufen
-    hu = Útvonaltervezési adatok megszerzése
-    id = Dapatkan data perutean
-    it = Ottieni i dati del percorso
-    ja = ルートデータを入手
-    ko = 라우팅 데이터 가져오기
-    nb = Skaff ruteinformasjon
-    pl = Pobierz dane ustalania tras
-    pt = Obter dados de itinerário
-    pt-BR = Obter dados de roteamento
-    ro = Descărcați informațiile pentru direcționare
-    es = Obtén datos de enrutamiento
-    sv = Hämta navigeringsdata
-    th = รับข้อมูลการกำหนดเส้นทาง
-    tr = Rota verileri edin
-    uk = Отримати дані про маршрут
-    vi = Nhận dữ liệu đường đi
-    zh-Hans = 获取所需的路线数据
-    zh-Hant = 獲取所需的路線數據
-    el = Λήψη δεδομένων πλοήγησης
-    sk = Získať trasové dáta
-    fa = دریافت داده های مسیریابی
-
-  [routing_get_additional_data]
-    comment = Text for routing error dialog
-    tags = android, ios
-    en = Additional data required to create routes from your location.
-    ru = Загрузите данные для построения маршрутов
-    ar = dati aggiuntivi richiesti per creare i percorsi dalla tua posizione.
-    cs = Další data potřebná k plánování tras z vašeho umístění.
-    da = Yderligere data er påkrævet for at oprette ruter fra din placering.
-    nl = Aanvullende gegevens die nodig zijn om routes te maken vanaf uw locatie.
-    fi = Lisädata, jotka vaaditaan reittien luomiseen sijainnistasi.
-    fr = Des données supplémentaires nécessaires pour créer des itinéraires depuis votre localisation.
-    de = Es sind Zusatzdaten erforderlich, um die Route ab Ihrem Standort zu erstellen.
-    hu = További adatok szükségesek a kiinduló pontról történő útvonaltervezéshez
-    id = Data tambahan yang diperlukan untuk membuat rute dari lokasi Anda.
-    it = dati aggiuntivi richiesti per creare i percorsi dalla tua posizione.
-    ja = 現在位置からのルート作成に必要な追加データです。
-    ko = 추가 데이터는 사용자의 위치에서 경로를 생성하도록 필요합니다.
-    nb = Tilleggsinformasjon som er nødvendig for å opprette ruter fra ditt ståsted.
-    pl = Dodatkowe dane wymagane do tworzenia tras z Twojej lokalizacji.
-    pt = São necessários dados adicionais para criar rotas a partir da sua localização.
-    pt-BR = São necessários dados adicionais para criar rotas a partir da sua localização.
-    ro = Datele suplimentare necesare pentru a crea trasee de la locația dvs.
-    es = Datos adicionales necesarios para crear rutas desde tu ubicación.
-    sv = Ytterligare data krävs för att skapa navigeringsvägar från din plats
-    th = ข้อมูลเพิ่มเติมที่จำเป็นสำหรับการสร้างเส้นทางจากสถานที่ตั้งของคุณ
-    tr = Konumunuzdan rota oluşturmak için ilave verileri edinin.
-    uk = Щоб створювати маршрути від вашого місцезнаходження, потрібно додаткові дані
-    vi = số liệu bổ sung cần thiết để tạo ra các tuyến đường đi từ vị trí của bạn.
-    zh-Hans = 更多数据，从您的位置创建路线。
-    zh-Hant = 需要更多數據以從您的位置建立路線。
-    el = Απαιτούνται επιπλέον δεδομένα για τη δημιουργία διαδρομών από την τοποθεσία σας.
-    sk = Dodatočné údaje potrebné na vytvorenie trasy zo vašej polohy.
-    fa = مقداری دیتای اضافی برای ایجاد مسیر در موقعیت شما نیاز است.
+    sk = Stiahnite si mapy pozdĺž trasy
 
   [routing_requires_all_map]
     comment = Text for routing error dialog
-    tags = android, ios
+    tags = ios, android
     en = In order to create a route, we need to download and update all the maps from your location to your destination.
     ru = Для создания маршрута необходимо загрузить и обновить все карты на пути следования.
     ar = Creare un percorso necessita la presenza di tutte le mappe scaricate e aggiornate dalla tua posizione alla destinazione.
@@ -8321,7 +5227,7 @@
 
   [routing_not_enough_space]
     comment = Text for routing error dialog
-    tags = android, ios
+    tags = android
     en = Not enough space
     ru = Недостаточно места
     ar = Spazio non sufficiente
@@ -8350,80 +5256,12 @@
     zh-Hans = 空间不够
     zh-Hant = 空間不足
     el = Δεν υπάρχει αρκετός χώρος
-    sk = Nedostatok miesta
     fa = فضای کافی موجود نیست
-
-  [routing_download_more_than_avail]
-    comment = Text for routing error dialog
-    tags = android, ios
-    en = You need to download %@ MB, but only %@ MB are available.
-    ru = Необходимо загрузить %@ МБ, но есть место только для %@ МБ
-    ar = Devi scaricare %@ MB, ma lo spazio disponibile è di soli %@ MB.
-    cs = Je třeba stáhnout %@ MB, ale dostupných je pouze %@ MB.
-    da = Du skal downloade %@ MB, men kun %@ MB er tilgængeligt.
-    nl = U dient %@ MB te downloaden, maar er is slechts %@ MB beschikbaar.
-    fi = Sinun täytyy ladata %@ MB, mutta saatavilla on vain %@ MB.
-    fr = Vous devez télécharger %@ Mo, mais seulement %@ Mo sont disponibles.
-    de = Sie wollen %@ MB herunterladen, der Speicherplatz reicht aber nur für %@ MB.
-    hu = %@ MB-t kell letöltened, de csak %@ MB hely szabad.
-    id = Anda harus mengunduh %@ MB, tetapi hanya %@ MB yang tersedia.
-    it = Devi scaricare %@ MB, ma lo spazio disponibile è di soli %@ MB.
-    ja = %@ MBダウンロードする必要がありますが、%@ MBしか空いていません。
-    ko = %@ MB를 다운로드해야 하지만 %@ MB만 사용할 수 있습니다.
-    nb = Du vil laste ned %@ MB, men du har kun %@ MB tilgjengelig.
-    pl = Musisz pobrać %@ MB, lecz dostępne jest tylko %@ MB.
-    pt = É necessário descarregar %@ MB, mas há apenas %@ MB disponíveis.
-    pt-BR = É necessário baixar %@ MB, mas há apenas %@ MB disponíveis.
-    ro = Trebuie să descărcați %@ MB, dar numai un spațiu de %@ MB este disponibil.
-    es = Necesitas descargar %@ MB, pero solo hay %@ MB disponibles.
-    sv = Du behöver ladda ner %@ MB men du har bara %@ MB tillgänglig
-    th = คุณจำเป็นต้องดาวน์โหลด %@ MB แต่สามารถใช้ได้เพียง %@ MB เท่านั้น
-    tr = %@ MB indirmeniz gerekiyor fakat sadece %@ MB boş alan mevcut.
-    uk = Вам треба завантажити %@ Мб, а доступно лише %@ Мб.
-    vi = Bạn cần phải tải về %@ MB, nhưng chỉ có %@ MB sẵn có.
-    zh-Hans = 您需要下载%@ MB，但只有%@ MB空间。
-    zh-Hant = 您需要下載%@ MB，但只有%@ MB空間。
-    el = Πρέπει να κάνετε λήψη %@ MB, αλλά μόνο %@ MB είναι διαθέσιμα.
-    sk = Musíte stiahnuť %@ MB, ale k dispozícií máte len %@ MB.
-    fa = شما نیاز به دانلود %@ مگابایت دارید, اما تنها %@ مگابایت موجود است.
-
-  [routing_download_roaming]
-    comment = Text for routing error dialog
-    tags = android, ios
-    en = You are going to download %@ MB using Mobile Data (in Roaming). This may result in additional charges, depending on your operator mobile data plan.
-    ru = Будет загружено %@ MB с использованием сотовой связи (мобильный интернет). В зависимости от тарифного плана оператора это может повлечь списание значительной суммы с телефонного счета
-    ar = أنت على وشك تنزيل %@ م.ب باستخدام البيانات المتنقلة (في وضع التجوال). وهذا قد يؤدي إلى مصاريف إضافية اعتمادا على خطة البيانات المتنقلة الخاصة بالمشغل الخاص بك.
-    cs = Chystáte se stáhnout %@ MB pomocí mobilních dat (v roamingu). To může mít za následek další poplatky v závislosti na vašem mobilním datovém tarifu.
-    da = Du kommer til at downloade %@ MB ved at bruge mobilt data (i roaming). Dette kan resultere i yderligere omkostninger alt afhængigt din operatørs mobile dataplan.
-    nl = U gaat %@ MB downloaden met behulp van mobiele data (roaming). Dit kan leiden tot extra kosten, afhankelijk van het mobiele data-abonnement van uw aanbieder.
-    fi = Olet lataamassa %@ MB Mobiilidatan (roaming-lataus) avulla. Tämä voi johtaa lisämaksuihin, riippuen matkapuhelinliittymäsi palveluntarjoajasta.
-    fr = Vous allez télécharger %@ Mo à l'aide de données mobiles (frais d'itinérance). Cela peut entraîner des frais additionnels, en fonction du plan de données mobiles proposé par votre opérateur.
-    de = Sie sind im Begriff, %@ MB unter Nutzung einer mobilen Datenverbindung (mit Roaming) herunterzuladen. Dies kann je nach Anbieter Ihres mobilen Datentarifs zusätzliche Kosten verursachen.
-    hu = %@ MB-nyi adatot készül letölteni mobilján (roamingon) keresztül. Ez további költségekkel járhat, a mobilcsomagjától függően.
-    id = Anda akan mengunduh %@ MB menggunakan Data Seluler (dalam Roaming). Hal ini dapat mengakibatkan biaya tambahan, tergantung pada paket data seluler operator.
-    it = Stai per scaricare %@ MB tramite la rete cellulare (in roaming). Questo potrebbe comportare costi aggiuntivi, in base al piano dati del tuo operatore mobile.
-    ja = 携帯のデータ通信（ローミング）を使用して%@ MBダウンロードしようとしています。これにより、ご利用の通信会社の携帯データプランによっては追加料金が発生する可能性があります。
-    ko = 모바일 데이터(로밍시)를 사용하여 %@ MB를 다운로드할 것입니다. 이는 운영자 모바일 데이터 계획에 따라 추가 요금이 발생할 수 있습니다.
-    nb = Du er på vei til å laste ned %@ MB via mobildata (under 'roaming'). Dette kan resultere i påløpende ekstragebyrer, avhengig av din mobiloperatørløsning.
-    pl = %@ MB do pobrania przy wykorzystaniu danych mobilnych (w roamingu). Może to oznaczać dodatkowe opłaty w zależności od planu danych mobilnych Twojego dostawcy usług.
-    pt = Você fará o download de %@ MB através de Dados Móveis (em Roaming). Isto poderá resultar em cobranças adicionais, dependendo do seu plano de dados móveis.
-    pt-BR = Você fará o download de %@ MB utilizando os Dados Móveis (em Roaming). Isto poderá resultar em cobranças adicionais, dependendo do seu plano de celular.
-    ro = Urmează să descărcați %@ MB folosind abonamentul de date pentru mobil (în roaming). Acest lucru poate genera costuri suplimentare, în funcție de abonamentul dvs. de date, activat de operatorul de telefonie mobilă.
-    es = Vas a descargar %@ MB usando datos móviles (en itinerancia). Esto puede dar lugar a cargos adicionales, dependiendo del plan de datos móviles de tu operador.
-    sv = Du kommer ladda ner %@ MB med mobildata (i roamingläge). Detta kan resultera i extra kostnader beroende på din operatörs mobildataplan.
-    th = คุณกำลังจะดาวน์โหลด %@ MB โดยการใช้ข้อมูลโทรศัพท์มือถือ (ในการใช้งานข้ามเขต) นี่อาจส่งผลในการคิดค่าบริการเพิ่มเติมโดยขึ้นอยู่กับแผนการใช้ข้อมูลโทรศัพท์มือถือของผู้ให้บริการของคุณ
-    tr = %@ MB boyutunda veriyi Mobil Veri (Roaming) kullanarak indireceksiniz. Bu mobil operatör veri planınıza göre ilave ödeme gerektirebilir.
-    uk = Ви збираєтесь завантажити %@ MB з використанням послуги передачі даних (у роумінгу). Це може потребувати додаткової оплати, в залежності від вашого мобільного оператора та умов використання вашого тарифного плану.
-    vi = Bạn sắp tải xuống %@ MB sử dụng Dữ liệu Di động (trong dịch vụ Chuyển vùng). Điều này có thể dẫn đến cước phí bổ sung, tùy thuộc vào gói dữ liệu di động của nhà mạng của bạn.
-    zh-Hans = 您将使用移动数据下载%@ MB（漫游）。这取决于您的移动数据方案运营商，可能会产生额外的费用。
-    zh-Hant = 您將使用行動數據下載%@ MB（漫遊）。這取決於您的行動數據方案服務業者，可能會產生額外的費用。
-    el = Πρόκειται να κάνετε λήψη %@ MB χρησιμοποιώντας Δεδομένα Δικτύου Κινητής Τηλεφωνίας (σε Περιαγωγή). Αυτό μπορεί να προκαλέσει επιπρόσθετες χρεώσεις, που εξαρτώνται από το πρόγραμμα δεδομένων δικτύου κινητής τηλεφωνίας του παρόχου σας.
-    sk = Veľkosť súboru je %@ MB, ktoré stiahnete prostredníctvom Mobilných Dát (v Roamingu). Toto môže mať za následok dodatočné poplatky, v závislosti od dátových taríf vášho mobilného operátora.
-    fa = شما قصد دانلود %@ MB و استفاده از دیتای موبایل را دارید.این کار ممکن است بر حسب اپراتور موبایلتان هزینه های اضافی برای شما در بر داشته باشد
+    sk = Nedostatok miesta
 
   [bookmark]
     comment = bookmark button text
-    tags = android, ios
+    tags = android
     en = bookmark
     ru = метка
     ar = إشارة مرجعية
@@ -8452,47 +5290,14 @@
     zh-Hans = 书签
     zh-Hant = 書籤
     el = αγαπημένο
+    fa = نشانه ها
     he = סימניה
     in = bookmark
     sk = záložka
-    fa = نشانه ها
-
-  [not_found_map]
-    comment = map is not downloaded
-    tags = android, ios
-    en = The map for your location is not downloaded
-    ru = Карта вашего местоположения не загружена
-    ar = الخريطة الخاصة بالمكان الذي تتواجد فيه لا يتم تنزيلها
-    cs = Mapa vaší polohy není stažena
-    da = Kortet for dit område er ikke downloadet
-    nl = De kaart voor uw locatie is niet gedownload
-    fi = Nykyisen sijaintisi karttaa ei ole ladattu
-    fr = La carte pour votre emplacement n'est pas téléchargée
-    de = Es gibt keine Karte für Ihren Standort
-    hu = A helyszínéhez tartozó térképet letöltöttük
-    id = Peta untuk lokasi Anda tidak diunduh
-    it = La mappa del tuo posto non è stata trovata
-    ja = 現在地の地図が見つかりません
-    ko = 위치에 대한 지도가 다운로드되지 않음
-    nb = Kartet for posisjonen din er ikke lastet ned
-    pl = Nie znaleziono mapy Twojej lokalizacji
-    pt = O mapa para a sua localização não foi descarregado
-    pt-BR = O mapa para a sua localização não foi baixado
-    ro = Harta pentru poziția dvs. nu este descărcată
-    es = El mapa de tu ubicación no se ha descargado
-    sv = Kartan för din plats hittas inte
-    th = ไม่พบแผนที่ของตำแหน่งของคุณ
-    tr = Konum haritası bulunamadı
-    uk = Карту місця, де ви знаходитеся, не завантажено
-    vi = Bản đồ cho vị trí của bạn chưa được tải xuống
-    zh-Hans = 您地点的地图没有被下载
-    zh-Hant = 您地點的地圖尚未下載
-    sk = Mapa vašej polohy nebola nájdená
-    fa = نقشه ای برای موقعیت مکانی شما دانلود نشده است
 
   [enable_location_services]
     comment = location service disabled
-    tags = android, ios
+    tags = android
     en = Please enable Location Services
     ru = Пожалуйста, включите геолокацию
     ar = الرجاء تفعيل خدمة تحديد المواقع
@@ -8521,276 +5326,11 @@
     zh-Hans = 请启用位置服务
     zh-Hant = 請啟用定位服務
     el = Ενεργοποιήστε τις υπηρεσίες εντοπισμού τοποθεσίας
-    sk = Prosím, povoľte Služby určovania polohy
     fa = لطفا موقعیت مکانی(GPS)خود را فعال کنید.
-
-  [download_map]
-    comment = download map
-    tags = android, ios
-    en = Download the map for your location
-    ru = Скачайте карту места, где вы находитесь
-    ar = قم بتنزيل الخريطة الخاصة بموقعك
-    cs = Stáhněte si mapu své polohy
-    da = Download kortet for dit område
-    nl = Download de kaart voor uw locatie
-    fi = Lataa nykyisen sijaintisi kartta
-    fr = Télécharger la carte de l'endroit où vous êtes
-    de = Laden Sie die Karte für Ihren Standort herunter
-    hu = Töltse le a térképet a helyszínéhez
-    id = Unduh peta untuk lokasi Anda
-    it = Scarica la mappa per il tuo paese
-    ja = あなたがいる場所のマップをダウンロードしよう
-    ko = 위치에 대한 지도 다운로드
-    nb = Last ned kartet for posisjonen din
-    pl = Pobierz mapę dla swojej lokalizacji
-    pt = Descarregue o mapa para a sua localização
-    pt-BR = Baixe o mapa para a sua localização
-    ro = Descărcați harta pentru poziția dvs.
-    es = Descarga el mapa de tu ubicación
-    sv = Ladda ner kartan över din nuvarande plats
-    th = ดาวน์โหลดแผนที่เกี่ยวกับสถานที่ที่คุณอยู่
-    tr = Konumunuz için haritayı indirin
-    uk = Завантажуйте карту тієї місцевості, де ви знаходитесь
-    vi = Tải xuống bản đồ cho vị trí của bạn
-    zh-Hans = 为您的地点下载地图
-    zh-Hant = 為您的地點下載地圖
-    sk = Stiahnite si mapu miesta, kde sa práve nachádzate
-    fa = دانلود نقشه برای موقعیت مکانی شما
-
-  [download_map_iphone]
-    comment = download map on iPhone
-    tags = ios
-    en = Download a current location map on your iPhone
-    ru = Скачайте на вашем iPhone карту места, где вы находитесь
-    ar = قم بتنزيل خريطة الموقع الحالي على جهاز آيفون الخاص بك
-    cs = Stáhněte si do svého iPhonu mapu své současné polohy
-    da = Download kortet for din placering til din iPhone
-    nl = Download de kaart van uw huidige lokatie op uw iPhone
-    fi = Lataa tämän hetkisen sijaintisi kartta iPhoneesi
-    fr = Téléchargez la carte de l'endroit où vous vous trouvez sur votre iPhone
-    de = Laden Sie eine Karte für Ihre aktuelle Position auf Ihrem iPhone herunter
-    hu = Töltse le a térképet iPhone-jára jelenlegi helyzetének meghatározásához
-    id = Unduh peta lokasi saat ini pada iPhone Anda
-    it = Scarica la mappa per la tua posizione corrente sul tuo iPhone
-    ja = iPhoneに現在位置の地図をダウンロード
-    ko = 아이폰에서 현재 위치의 지도 다운로드
-    nb = Last ned kartet for en aktuell posisjon til iPhone
-    pl = Pobierz na swojego iPhone'a mapę dla bieżącej lokalizacji
-    pt = Descarregue o mapa da localização atual para o seu iPhone
-    pt-BR = Baixe o mapa da localização atual para o seu iPhone
-    ro = Descărcați o hartă pentru poziția dvs. actuală pe iPhone-ul dvs.
-    es = Descarga el mapa para la ubicación actual en tu iPhone
-    sv = Ladda ner kartan för aktuell plats på din iPhone
-    th = ดาวน์โหลดแผนที่สำหรับตำแหน่งปัจจุบันบน iPhone ของคุณ
-    tr = Mevcut konum için iPhone'nunuza haritayı indirin
-    uk = Завантажити карту вашого місця розташування на iPhone
-    vi = Tải bản đồ vị trí hiện tại xuống iPhone của bạn
-    zh-Hans = 在您的iPhone上下载当前位置的地图
-    zh-Hant = 在您的 iPhone 上下載目前位置的地圖
-    sk = Stiahnite si mapu pre aktuálnu polohu na vašom iPhone
-    fa = دانلود نقشه برای موقعیت مکانی شما بر روی ایفون تان
-
-  [nearby]
-    comment = clear pin
-    tags = android, ios
-    en = Nearby
-    ru = поблизости
-    ar = قريب
-    cs = V okolí
-    da = I nærheden
-    nl = In de buurt
-    fi = Lähellä
-    fr = À proximité
-    de = In der Nähe
-    hu = A közelben
-    id = Terdekat
-    it = Nelle vicinanze
-    ja = 近くに
-    ko = 근처에
-    nb = I nærheten
-    pl = W pobliżu
-    pt = Próximo
-    pt-BR = Próximo
-    ro = În apropiere
-    es = Cerca
-    sv = I närheten
-    th = ใกล้เคียง
-    tr = Yakında
-    uk = Поруч
-    vi = Gần kề
-    zh-Hans = 附近的
-    zh-Hant = 附近的
-    sk = V blízkosti
-    fa = در این نزدیکی
-
-  [clear_pin]
-    comment = clear pin
-    tags = android, ios
-    en = Clear Pin
-    ru = убрать метку
-    ar = مسح الرقم السري
-    cs = Odebrat špendlík
-    da = Slet nål
-    nl = Speld wissen
-    fi = Tyhjennä kiinnitys
-    fr = Effacer Pin
-    de = Stecknadel löschen
-    hu = Pin törlése
-    id = Kosongkan Pin
-    it = Annulla pin
-    ja = ピンをクリア
-    ko = 핀 지우기
-    nb = Fjern merke
-    pl = Wyczyść pinezkę
-    pt = Limpar marcação
-    pt-BR = Limpar marcação
-    ro = Ștergeți semnul de poziție
-    es = Borrar alfiler
-    sv = Rensa Pin
-    th = ล้างปักหมุด
-    tr = İğneyi Temizle
-    uk = Очисти мітку
-    vi = Xóa Pin
-    zh-Hans = 清除针
-    zh-Hant = 清除圖釘
-    sk = Vymazať špendlík
-    fa = پاک کردن نشانه
-
-  [undefined_location]
-    comment = location is undefined
-    tags = android, ios
-    en = Current location is undefined.
-    ru = Не определено текущее местоположение.
-    ar = الموقع الحالي غير مُعَرّف
-    cs = Aktuální poloha zatím nebyla zjištěna.
-    da = Den nuværende placering er ikke defineret.
-    nl = Huidige locatie is niet gedefinieerd.
-    fi = Tämänhetkinen sijainti ei ole tiedossa.
-    fr = L'emplacement actuel n'est pas défini.
-    de = Der aktuelle Standort ist nicht definiert.
-    hu = Nem meghatározott a jelenlegi helyszín.
-    id = Lokasi saat ini tidak diketahui.
-    it = La posizione attuale non è definita.
-    ja = 現在地が設定されていません。
-    ko = 현재 위치는 정의되지 않습니다.
-    nb = Nåværende posisjon er udefinert.
-    pl = Bieżąca lokalizacja nie została zdefiniowana.
-    pt = A localização actual não foi definida.
-    pt-BR = A localização atual não foi definida.
-    ro = Poziția dvs. curentă este nedefinită.
-    es = La ubicación actual no está definida.
-    sv = Nuvarande plats är inte definierad.
-    th = ไม่มีการกำหนดสถานที่ปัจจุบัน
-    tr = Geçerli konum tanımlı değil.
-    uk = Не визначено поточне місцезнаходження.
-    vi = Không xác định được vị trí hiện tại.
-    zh-Hans = 当前地点未定。
-    zh-Hant = 目前地點未定。
-    he = לא הוגדר המיקום הנוכחי
-    sk = Aktuálna lokácia nie je definovaná.
-    fa = موقعیت مکانی شما یافت نشد.
-
-  [download_country]
-    comment = download country of your location
-    tags = android, ios
-    en = Download the country of your current location
-    ru = Скачайте страну вашего местоположения
-    ar = تنزيل دولة موقعك الحالي
-    cs = Stahování země vyší aktuální polohy
-    da = Download landet bestemt ud fra din nuværende lokation
-    nl = Download land waar je nu bent
-    fi = Lataa nykyisen sijainnin maa
-    fr = Téléchargez la carte pour votre emplacement
-    de = Land Ihres derzeitigen Standorts herunterladen
-    hu = Töltse le az aktuális helyzet országát
-    id = Unduh negara di mana Anda berada saat ini
-    it = Scarica il paese della tua posizione attuale
-    ja = 現在の地域をダウンロード
-    ko = 귀하께서 현재 계신 국가인 을(를) 다운로드
-    nb = Last ned kartet for posisjonen din
-    pl = Pobierz mapę kraju, w którym aktualnie przebywasz
-    pt = Descarregue o país da sua localização actual
-    pt-BR = Baixe o país da sua localização atual
-    ro = Descărcați hărțile pentru țara în care vă aflați
-    es = Descargar país de tu ubicación actual
-    sv = Ladda ner landet vid din nuvarande position
-    th = ดาวน์โหลด ประเทศของตำแหน่งที่ตั้งปัจจุบันของคุณ
-    tr = Geçerli konumuzun ülkesini indirin
-    uk = Завантажити країну вашого місця розташування
-    vi = Tải xuống quốc gia bạn đang tìm kiếm trên
-    zh-Hans = 下载您所在位置的国家
-    zh-Hant = 下載您目前所在位置的國家 地圖
-    sk = Sťahovanie krajiny vašej aktuálnej polohy
-    fa = دانلود نقشه کشور مقعیت کنونی شما
-
-  [download_failed]
-    comment = download failed
-    tags = android, ios
-    en = download has failed
-    ru = Не удалось загрузить
-    ar = فشلت عملية تنزيل
-    cs = Stahování selhalo
-    da = download mislykkedes
-    nl = download is afgebroken
-    fi = Lataus epäonnistui
-    fr = échec lors du téléchargement
-    de = Herunterladen fehlgeschlagen
-    hu = letöltése sikertelen
-    id = gagal diunduh
-    it = Il trasferimento di non è riuscito
-    ja = のダウンロードが失敗しました
-    ko = 다운로드가 실패했습니다
-    nb = Nedlasting mislyktes
-    pl = pobieranie nie powiodło się
-    pt = descarga falhou
-    pt-BR = download falhou
-    ro = descărcarea a eșuat
-    es = la descarga ha fallado
-    sv = nedladdning misslyckades
-    th = การดาวน์โหลด  ล้มเหลว
-    tr = indirme işlemi başarısız oldu
-    uk = Не вдалося завантажити
-    vi = tải xuống thất bại
-    zh-Hans = 下载失败
-    zh-Hant = 下載失敗
-    sk = Sťahovanie zlyhalo
-    fa = دانلود ناموفق
-
-  [get_the_map]
-    comment = get the map
-    tags = android, ios
-    en = Get the map
-    ru = Загрузить карту
-    ar = احصل على الخريطة
-    cs = Získejte mapu
-    da = Få kort
-    nl = Krijg kaart
-    fi = Hanki kartta
-    fr = Téléchargez des cartes
-    de = Karte abrufen
-    hu = Térkép megszerzése
-    id = Dapatkan peta
-    it = Scarica la mappa
-    ja = 地図を入手
-    ko = 지도 가져오기
-    nb = Hent kartet
-    pl = Pobierz mapę
-    pt = Obter mapa
-    pt-BR = Obter mapa
-    ro = Obțineți harta
-    es = Obtén el mapa
-    sv = Hämta karta
-    th = รับแผนที่
-    tr = Harita alın
-    uk = Отримати карту
-    vi = Tải bản đồ
-    zh-Hans = 获取地图
-    zh-Hant = 獲取地圖
-    sk = Stiahnuť mapu
-    fa = دریافت نقشه
+    sk = Prosím, povoľte Služby určovania polohy
 
   [save]
-    tags = android, ios
+    tags = ios, android
     en = Save
     ru = Сохранить
     ar = حفظ
@@ -8819,11 +5359,11 @@
     zh-Hans = 保存
     zh-Hant = 儲存
     el = Αποθήκευση
-    sk = Uložiť
     fa = ذخیره
+    sk = Uložiť
 
   [edit_description_hint]
-    tags = android, ios
+    tags = android
     en = Your descriptions (text or html)
     ru = Ваше описание (текст или html)
     ar = أوصافك (نصّ أو html)
@@ -8850,45 +5390,12 @@
     zh-Hans = 您的描述（文本或html）
     zh-Hant = 您的描述（文字或 html）
     el = Οι περιγραφές σας (κείμενο ή html)
+    fa = توضیحات شما (متن یا  (html
     in = Deskripsi Anda (teks atau html)
     sk = Váš popis (text alebo html)
-    fa = توضیحات شما (متن یا  (html
-
-  [new_group]
-    tags = android, ios
-    en = new group
-    ru = новая группа
-    ar = مجموعة جديدة
-    cs = Nová skupina
-    da = ny gruppe
-    nl = nieuwe groep
-    fi = uusi ryhmä
-    fr = nouveau groupe
-    de = Neue Gruppe
-    hu = új csoport
-    id = grup baru
-    it = nuovo gruppo
-    ja = 新規グループ
-    ko = 새 그룹
-    nb = ny gruppe
-    pl = nowa grupa
-    pt = novo grupo
-    pt-BR = novo grupo
-    ro = grup nou
-    es = nuevo grupo
-    sv = ny grupp
-    th = กลุ่มใหม่
-    tr = yeni grup
-    uk = нова група
-    vi = nhóm mới
-    zh-Hans = 新群組
-    zh-Hant = 新組
-    el = νέα ομάδα
-    sk = nová skupina
-    fa = مجموعه جدید
 
   [create]
-    tags = android, ios
+    tags = ios, android
     en = create
     ru = создать
     ar = إنشاء
@@ -8917,12 +5424,12 @@
     zh-Hans = 创建
     zh-Hant = 建立
     el = δημιουργήστε
-    sk = vytvoriť
     fa = ایجاد
+    sk = vytvoriť
 
   [red]
     comment = red color
-    tags = android, ios
+    tags = ios
     en = Red
     ru = Красный
     ar = أحمر
@@ -8943,7 +5450,6 @@
     pt-BR = Vermelho
     ro = Roșu
     es = Rojo
-    es-MX = Rojo
     sv = Röd
     th = สีแดง
     tr = Kırmızı
@@ -8952,12 +5458,13 @@
     zh-Hans = 红色
     zh-Hant = 紅色
     el = Κόκκινο
-    sk = Červená
+    es-MX = Rojo
     fa = قرمز
+    sk = Červená
 
   [yellow]
     comment = yellow color
-    tags = android, ios
+    tags = ios
     en = Yellow
     ru = Жёлтый
     ar = أصفر
@@ -8978,7 +5485,6 @@
     pt-BR = Amarelo
     ro = Galben
     es = Amarillo
-    es-MX = Amarillo
     sv = Gul
     th = สีเหลือง
     tr = Sarı
@@ -8987,12 +5493,13 @@
     zh-Hans = 黄色
     zh-Hant = 黃色
     el = Κίτρινο
-    sk = Žltá
+    es-MX = Amarillo
     fa = زرد
+    sk = Žltá
 
   [blue]
     comment = blue color
-    tags = android, ios
+    tags = ios
     en = Blue
     ru = Синий
     ar = أزرق
@@ -9013,7 +5520,6 @@
     pt-BR = Azul
     ro = Albastru
     es = Azul
-    es-MX = Azul
     sv = Blå
     th = สีน้ำเงิน
     tr = Mavi
@@ -9022,12 +5528,13 @@
     zh-Hans = 蓝色
     zh-Hant = 藍色
     el = Μπλε
-    sk = Modrá
+    es-MX = Azul
     fa = ابی
+    sk = Modrá
 
   [green]
     comment = green color
-    tags = android, ios
+    tags = ios
     en = Green
     ru = Зелёный
     ar = أخضر
@@ -9048,7 +5555,6 @@
     pt-BR = Verde
     ro = Verde
     es = Verde
-    es-MX = Verde
     sv = Grön
     th = สีเขียว
     tr = Yeşil
@@ -9057,12 +5563,13 @@
     zh-Hans = 绿色
     zh-Hant = 綠色
     el = Πράσινο
-    sk = Zelená
+    es-MX = Verde
     fa = سبز
+    sk = Zelená
 
   [purple]
     comment = purple color
-    tags = android, ios
+    tags = ios
     en = Purple
     ru = Пурпурный
     ar = أرجواني
@@ -9083,7 +5590,6 @@
     pt-BR = Roxo
     ro = Purpuriu
     es = Morado
-    es-MX = Morado
     sv = Lila
     th = สีม่วง
     tr = Mor
@@ -9092,12 +5598,13 @@
     zh-Hans = 紫色
     zh-Hant = 紫色
     el = Μωβ
-    sk = Purpurová
+    es-MX = Morado
     fa = بنفش
+    sk = Purpurová
 
   [orange]
     comment = orange color
-    tags = android, ios
+    tags = ios
     en = Orange
     ru = Оранжевый
     ar = برتقالي
@@ -9118,7 +5625,6 @@
     pt-BR = Laranja
     ro = Portocaliu
     es = Naranja
-    es-MX = Naranja
     sv = Orange
     th = สีส้ม
     tr = Turuncu
@@ -9127,12 +5633,13 @@
     zh-Hans = 橘红色
     zh-Hant = 橘色
     el = Πορτοκαλί
-    sk = Oranžová
+    es-MX = Naranja
     fa = نارنجی
+    sk = Oranžová
 
   [brown]
     comment = brown color
-    tags = android, ios
+    tags = ios
     en = Brown
     ru = Коричневый
     ar = بني
@@ -9153,7 +5660,6 @@
     pt-BR = Marrom
     ro = Maro
     es = Marrón
-    es-MX = Marrón
     sv = Brun
     th = สีน้ำตาล
     tr = Kahverengi
@@ -9162,12 +5668,13 @@
     zh-Hans = 棕色
     zh-Hant = 棕色
     el = Καφέ
-    sk = Hnedá
+    es-MX = Marrón
     fa = قهوای
+    sk = Hnedá
 
   [pink]
     comment = pink color
-    tags = android, ios
+    tags = ios
     en = Pink
     ru = Розовый
     ar = وردي
@@ -9188,7 +5695,6 @@
     pt-BR = Rosa
     ro = Roz
     es = Rosa
-    es-MX = Rosa
     sv = Rosa
     th = สีชมพู
     tr = Pembe
@@ -9197,300 +5703,13 @@
     zh-Hans = 粉色
     zh-Hant = 粉色
     el = Ροζ
-    sk = Ružová
+    es-MX = Rosa
     fa = صورتی
-
-  [deep_purple]
-    comment = deep purple color
-    tags = android, ios
-    en = Deep Purple
-    ru = Тёмно-пурпурный
-    ar = أرجواني داكن
-    cs = Tmavě fialová
-    da = Mørkelilla
-    nl = Donker paars
-    fi = Tumman purppuranpunainen
-    fr = Pourpre foncé
-    de = Dunkelpurpur
-    hu = Sötét lila
-    id = Ungu Gelap
-    it = Viola scuro
-    ja = ディープパープル
-    ko = 진보라색
-    nb = Mørkepurpur
-    pl = Ciemnopurpurowy
-    pt = Purpúreo escuro
-    pt-BR = Lilás escuro
-    ro = Purpuriu închis
-    es = Morado oscuro
-    es-MX = Morado oscuro
-    sv = Mörk purpur
-    th = สีม่วงเข้ม
-    tr = Koyu Mor
-    uk = Темно-пурпуровий
-    vi = Tía thẫm
-    el = Βαθύ πορφυρό
-    sk = Tmavofialová
-    sw = Zambarau Iliyoiva
-    zh-Hans = 暗紫色
-    zh-Hant = 暗紫色
-    fa = ارغوانی سیر
-
-  [light_blue]
-    comment = light blue color
-    tags = android, ios
-    en = Light Blue
-    ru = Голубой
-    ar = أزرق فاتح
-    cs = Světle modrá
-    da = Lyseblå
-    nl = Lichtblauw
-    fi = Vaaleansininen
-    fr = Bleu ciel
-    de = Hellblau
-    hu = Világoskék
-    id = Biru Muda
-    it = Azzurro
-    ja = ライトブルー
-    ko = 하늘색
-    nb = Lyseblå
-    pl = Jasnoniebieski
-    pt = Azul Claro
-    pt-BR = Azul Claro
-    ro = Albastru deschis
-    es = Azul Claro
-    es-MX = Celeste
-    sv = Ljusblå
-    th = สีฟ้าอ่อน
-    tr = Açık Mavi
-    uk = Блакитний
-    vi = Xanh da trời
-    el = Γαλάζιο
-    sk = Svetlo modrá
-    sw = Buluu Hafifu
-    zh-Hans = 天蓝色
-    zh-Hant = 天藍色
-    fa = آبی کمرنگ
-
-  [cyan]
-    comment = cyan color
-    tags = android, ios
-    en = Cyan
-    ru = Сине-зелёный
-    ar = أزرق سماوي
-    cs = Cyan
-    da = Cyan
-    nl = Blauwgroen
-    fi = Sinivihreä
-    fr = Cyan
-    de = Blaugrün
-    hu = Cián
-    id = Biru Kehijauan
-    it = Cyan
-    ja = シアン
-    ko = 시안
-    nb = Blågrønn
-    pl = Niebieskozielony
-    pt = Azul-verde
-    pt-BR = Ciano
-    ro = Albastru-verziu
-    es = Cian
-    es-MX = Cian
-    sv = Blågrön
-    th = สีฟ้าอมเขียว
-    tr = Cam Göbeği
-    uk = Синьо-зелений
-    vi = Xanh lơ
-    el = Κυανό
-    sk = Tyrkysová
-    sw = Siani
-    zh-Hans = 蓝绿色
-    zh-Hant = 藍綠色
-    fa = فیروزه ای
-
-  [teal]
-    comment = teal color
-    tags = android, ios
-    en = Teal
-    ru = Изумрудный
-    ar = أخضر فاتح
-    cs = Teal
-    da = Blågrøn
-    nl = Smaragdgroen
-    fi = Smaragdinvihreä
-    fr = Émeraude
-    de = Smaragdgrün
-    hu = Zöldeskék
-    id = Biru Gelap
-    it = Verde smeraldo
-    ja = ティール
-    ko = 틸
-    nb = Smaragdgrønn
-    pl = Szmaragdowy
-    pt = Esmeralda
-    pt-BR = Cerceta
-    ro = Smarald
-    es = Verde azulado
-    es-MX = Verde azulado
-    sv = Smaragdgrön
-    th = สีเขียวนกเป็ดน้ำ
-    tr = Deniz Mavisi
-    uk = Смарагдовий
-    vi = Lục bảo
-    el = Σμαραγδένιο
-    sk = Modrozelená
-    sw = Teal
-    zh-Hans = 碧绿色
-    zh-Hant = 碧綠色
-    fa = آبی سیر
-
-  [lime]
-    comment = lime color
-    tags = android, ios
-    en = Lime
-    ru = Лайм
-    ar = ليموني
-    cs = Limeta
-    da = Lime
-    nl = Lime
-    fi = Limen värinen
-    fr = Vert citron
-    de = Limette
-    hu = Lime
-    id = Kuning Gelap
-    it = Verde fluo
-    ja = ライム
-    ko = 라임
-    nb = Limegrønn
-    pl = Lima
-    pt = Lima
-    pt-BR = Lima
-    ro = Var
-    es = Lima
-    es-MX = Lima
-    sv = Limefärg
-    th = สีเขียวอมเหลือง
-    tr = Çim Rengi
-    uk = Лайм
-    vi = Màu xanh chanh
-    el = Κιτρινοπράσινο
-    sk = Limetková
-    sw = Chokaa
-    zh-Hans = 青柠
-    zh-Hant = 青檸
-    fa = زرد لیویی
-
-  [deep_orange]
-    comment = deep orange color
-    tags = android, ios
-    en = Deep Orange
-    ru = Тёмно-оранжевый
-    ar = برتقالي داكن
-    cs = Tmavě oranžová
-    da = Dyb orange
-    nl = Donkeroranje
-    fi = Tumman oranssi
-    fr = Orange foncé
-    de = Dunkelorange
-    hu = Sötét Narancs
-    id = Oranye Gelap
-    it = Arancione scuro
-    ja = ディープオレンジ
-    ko = 진주황색
-    nb = Mørkeoransje
-    pl = Ciemnopomarańczowy
-    pt = Laranja escuro
-    pt-BR = Laranja escuro
-    ro = Portocaliu închis
-    es = Naranja oscuro
-    es-MX = Naranja oscuro
-    sv = Mörkorange
-    th = สีส้มเข้ม
-    tr = Koyu Turuncu
-    uk = Темно-помаранчевий
-    vi = Cam đậm
-    el = Βαθύ πορτοκαλί
-    sk = Tmavo oranžová
-    sw = Chungwa Iliyokoza
-    zh-Hans = 深橘色
-    zh-Hant = 深橘色
-    fa = نارنجی سیر
-
-  [gray]
-    comment = gray color
-    tags = android, ios
-    en = Gray
-    ru = Серый
-    ar = رمادي
-    cs = Šedá
-    da = Grå
-    nl = Grijs
-    fi = Harmaa
-    fr = Gris
-    de = Grau
-    hu = Szürke
-    id = Abu-abu
-    it = Grigio
-    ja = グレイ
-    ko = 회색
-    nb = Grå
-    pl = Szary
-    pt = Cinza
-    pt-BR = Cinza
-    ro = Gri
-    es = Gris
-    es-MX = Gris
-    sv = Grå
-    th = สีเทา
-    tr = Gri
-    uk = Сірий
-    vi = Xám
-    el = Γκρι
-    sk = Sivá
-    sw = Kijivu
-    zh-Hans = 灰色
-    zh-Hant = 灰色
-    fa = خاکستری
-
-  [blue_gray]
-    comment = blue gray color
-    tags = android, ios
-    en = Blue Gray
-    ru = Серо-голубой
-    ar = رمادي أزرق
-    cs = Modrošedá
-    da = Blågrå
-    nl = Grijsblauw
-    fi = Harmaan sininen
-    fr = Gris-bleu
-    de = Graublau
-    hu = Kékes Szürke
-    id = Biru Keabu-abuan
-    it = Grigiazzurro
-    ja = ブルーグレイ
-    ko = 청회색
-    nb = Gråblå
-    pl = Szaroniebieski
-    pt = Azul-cinza
-    pt-BR = Azul escuro
-    ro = Gri albăstriu
-    es = Gris azulado
-    es-MX = Gris azulado
-    sv = Ljusblå grå
-    th = สีฟ้าอมเทา
-    tr = Mavi Gri
-    uk = Сіро-блакитний
-    vi = Xám xanh da trời
-    el = Γκρίζο μπλε
-    sk = Modro sivá
-    sw = Kijivu Buluu
-    zh-Hans = 蓝灰色
-    zh-Hant = 藍灰色
-    fa = خاکستری کبود
+    sk = Ružová
 
   [WiFi_available]
     comment = Wi-Fi available
-    tags = android, ios
+    tags = android
     en = Yes
     ru = Есть
     ar = نعم
@@ -9519,14 +5738,14 @@
     zh-Hans = 是
     zh-Hant = 是
     el = Ναι
+    fa = بلی
     he = כן
     sk = Áno
-    fa = بلی
 
 [[Routing dialogs strings]]
 
   [dialog_routing_disclaimer_title]
-    tags = ios,android
+    tags = ios, android
     en = When following the route, please keep in mind:
     ru = При движении по маршруту помните:
     ar = عند اتباع المسار، يُرجى وضع ما يلي في الاعتبار:
@@ -9555,12 +5774,12 @@
     zh-Hans = 按照路线行进时，请谨记：
     zh-Hant = 依照路線行進時，請牢記：
     el = Όταν ακολουθείτε την διαδρομή, να θυμάστε:
+    fa = زمانی که مسیری را دنبال می کنید لطفا به یاد داشته باشید:
     he = בעת נסיעה לאורך המסלול, שים לב לדברים הבאים:
     sk = Pri sledovaní trasy majte na pamäti nasledujúce:
-    fa = زمانی که مسیری را دنبال می کنید لطفا به یاد داشته باشید:
 
   [dialog_routing_disclaimer_priority]
-    tags = ios,android
+    tags = ios, android
     en = — Road conditions, traffic laws, and road signs always take priority over the navigation hints;
     ru = — Дорожная обстановка, ПДД и знаки приоритетнее советов приложения;
     ar = — دائمًا ما يكون لظروف الطريق وقوانين وإشارات المرور الأولوية على المشورة الملاحية;
@@ -9589,12 +5808,12 @@
     zh-Hans = — 路况、交通法规和路标始终优先于导航建议；
     zh-Hant = — 路況、交通規則及號誌優先於導航意見；
     el = — Οι οδικές συνθήκες, ο κώδικας οδικής κυκλοφορίας και οι σημάνσεις στο δρόμο έχουν πάντα μεγαλύτερη προτεραιότητα από τις συμβουλές πλοήγησης,
+    fa = —شرایط جاده قوانین راهنمایی و رانندگی و علائم جاده همیشه بر نکات مسیریابی اولویت دارند;
     he = — תנאי הכביש, חוקי התנועה והתמרורים תמיד מקבלים עדיפות על פני הנחיות הניווט;
     sk = — Podmienky na ceste, dopravné predpisy a značenie majú vždy prednosť pred pokynmi z navigácie;
-    fa = —شرایط جاده قوانین راهنمایی و رانندگی و علائم جاده همیشه بر نکات مسیریابی اولویت دارند;
 
   [dialog_routing_disclaimer_precision]
-    tags = ios,android
+    tags = ios, android
     en = — The map might be inaccurate, and the suggested route might not always be the most optimal way to reach the destination;
     ru = — Карта может быть неточной, а предложенный маршрут не всегда оптимален;
     ar = — قد تكون الخريطة غير دقيقة وقد لا يكون المسار المقترح هو المسار الأمثل دائمًا للوصول إلى الوجهة.;
@@ -9623,12 +5842,12 @@
     zh-Hans = — 地图可能不准确，建议的路线可能并非总是去往目的地的最佳路径；
     zh-Hant = — 地圖可能不準確，建議的路線不盡然是最佳選擇；
     el = — Ο Χάρτης μπορεί να είναι ανακριβής, και η προτεινόμενη διαδρομή μπορεί να μην είναι πάντα ο βέλτιστος τρόπος να φτάσετε στον προορισμό,
+    fa = —نقشه ممکن است اشتباه باشد و مسیر پیشنهادی همیشه بهترین مسیر برای رسید به مقصد شما نباشد;
     he = — ייתכנו אי-דיוקים במפה, וייתכן כי המסלול המוצע אינו תמיד הדרך המיטבית להגעה אל היעד;
     sk = — Mapa nemusí byť presná a navrhovaná trasa nemusí byť vždy optimálna na dosiahnutie cieľa;
-    fa = —نقشه ممکن است اشتباه باشد و مسیر پیشنهادی همیشه بهترین مسیر برای رسید به مقصد شما نباشد;
 
   [dialog_routing_disclaimer_recommendations]
-    tags = ios,android
+    tags = ios, android
     en = — Suggested routes should only be understood as recommendations;
     ru = — Предлагаемые маршруты — лишь рекомендации;
     ar = — يتم التعامل مع المسارات المقترحة كتوصيات فقط;
@@ -9657,12 +5876,12 @@
     zh-Hans = — 建议的路线仅作为推荐路线供您采纳。；
     zh-Hant = — 建議的路線僅供推薦參考；
     el = — Οι προτεινόμενες διαδρομές πρέπει να ερμηνεύονται μόνο ως συστάσεις·
+    fa = —مسیر پیشنهادی باید فقط به عنوان یک توصیه دانست
     he = — יש לראות במסלולים המוצעים המלצה בלבד;
     sk = — Navrhované trasy by sa mali brať len ako odporúčania;
-    fa = —مسیر پیشنهادی باید فقط به عنوان یک توصیه دانست
 
   [dialog_routing_disclaimer_borders]
-    tags = ios,android
+    tags = ios, android
     en = — Exercise caution with routes in border zones: the routes created by our app may sometimes cross country borders in unauthorized places.
     ru = — Будьте внимательны с маршрутами в приграничных зонах: в построенных программой маршрутах иногда возможны пересечения границ в неположенных местах;
     ar = — تحذير بشأن مسارات في منطقة حدودية: المسارات التي تم إنشاؤها بواسطة تطبيقنا قد تعبر حدود الدولة في أماكن غير مصرح بها في بعض الأحيان;
@@ -9691,11 +5910,11 @@
     zh-Hans = — 小心对待国界区的路线：我们应用创造的路线有时会在未经授权的地方跨越国界;
     zh-Hant = — 小心對待國界區的路線：我們應用程式建立的路線有時會在未經授權的地方跨越國界；
     el = — Προσέχετε τις διαδρομές στις παραμεθόριες ζώνες: οι διαδρομές που δημιουργούνται από την εφαρμογή μας μπορεί μερικές φορές να διαπερνούν τα εθνικά σύνορα σε απαγορευμένες περιοχές.
-    sk = — Buďte opatrní na cestách v pohraničných oblastiach: trasy vytvorené aplikáciou môžu prekročiť hranice štátov na nepovolených miestach;
     fa = —در مسیرهایی که از مناطق مرزی میگذرد احتیاط کنید:مسیر هایی که بوسیله اپلیکیشن ما ایجاد می شود گاهی اوقات ممکن است مرز های کشور ها را رد کند که این در بعضی مناطق غیر مجاز است.
+    sk = — Buďte opatrní na cestách v pohraničných oblastiach: trasy vytvorené aplikáciou môžu prekročiť hranice štátov na nepovolených miestach;
 
   [dialog_routing_disclaimer_beware]
-    tags = ios,android
+    tags = ios, android
     en = Please stay alert and safe on the roads!
     ru = Будьте внимательны на дорогах и берегите себя!
     ar = يجب أن تظل يقظًا وآمنًا على الطريق!
@@ -9724,12 +5943,12 @@
     zh-Hans = 上路时请当心，祝您一路平安！
     zh-Hant = 請保持警戒，一路平安！
     el = Να είστε πάντα σε εγρήγορση και να οδηγείτε με ασφάλεια στους δρόμους!
+    fa = لطفا هوشیار و ایمن در جاده بمانید!
     he = שמור על ערנות ועל הבטיחות בכביש!
     sk = Na cestách buďte vždy ostražitý a dbajte na bezpečnosť!
-    fa = لطفا هوشیار و ایمن در جاده بمانید!
 
   [dialog_routing_check_gps]
-    tags = ios,android
+    tags = ios, android
     en = Check GPS signal
     ru = Проверьте сигнал GPS
     ar = تحقق من إشارة نظام تحديد المواقع العالمي "GPS"
@@ -9758,12 +5977,12 @@
     zh-Hans = 检查 GPS 信号
     zh-Hant = 查看 GPS 訊號
     el = Ελέγξτε το σήμα GPS
+    fa = سیگنال GPS را چک کنید
     he = בדוק אות GPS
     sk = Skontrolujte signál GPS
-    fa = سیگنال GPS را چک کنید
 
   [dialog_routing_error_location_not_found]
-    tags = ios,android
+    tags = ios, android
     en = Unable to create route. Current GPS coordinates could not be identified.
     ru = Маршрут не построен. Текущая геопозиция не определена.
     ar = تعذر إنشاء مسار. لا يمكن تحديد إحداثيات GPS الحالية.
@@ -9792,12 +6011,12 @@
     zh-Hans = 无法创建路线。当前 GPS 坐标无法识别。
     zh-Hant = 無法產生路線。 無法定位目前 GPS 座標。
     el = Δεν είναι δυνατή η δημιουργία διαδρομής. Οι τρέχουσες συντεταγμένες GPS δεν μπορούν να προσδιοριστούν.
+    fa = ناتوان از ایجاد مسیر.موقعیت مکانی شما شناسایی نشد
     he = לא ניתן ליצור מסלול. לא ניתן לזהות את קואורדינטות ה-GPS הנוכחיות.
     sk = Nedá sa vytvoriť trasa. Aktuálne súradnice GPS sa nedajú identifikovať.
-    fa = ناتوان از ایجاد مسیر.موقعیت مکانی شما شناسایی نشد
 
   [dialog_routing_location_turn_wifi]
-    tags = ios,android
+    tags = ios, android
     en = Please check your GPS signal. Enabling Wi-Fi will improve your location accuracy.
     ru = Пожалуйста, проверьте сигнал GPS. Для улучшения точности геопозиции включите Wi-Fi.
     ar = يُرجى التحقق من إشارة GPS لديك. ويساعد تمكين خدمة Wi-Fi في تحسين دقة تحديد موقعك.
@@ -9826,12 +6045,12 @@
     zh-Hans = 请检查您的 GPS 信号。启用 Wi-Fi 将改善您的定位精度。
     zh-Hant = 請確認您的 GPS 訊號。啟用 Wi-Fi 將提升地理位置定位準確度。
     el = Ελέγξτε το σήμα GPS. Η ενεργοποίηση του Wi-Fi θα βελτιώσει την ακρίβεια της τοποθεσίας σας.
+    fa = لطفا سیگنال GPS موبایتان راچک کنید.و WiFi موبایلتان را جهت دقت بیشتر در موقعیت یابی فعال کنید.
     he = בדוק את אות ה-GPS שלך. הפעלת ה-Wi-Fi תשפר את הדיוק בזיהוי המיקום שלך.
     sk = Skontrolujte signál GPS. Zapnutie Wi-Fi zlepší presnosť vašej lokalizácie.
-    fa = لطفا سیگنال GPS موبایتان راچک کنید.و WiFi موبایلتان را جهت دقت بیشتر در موقعیت یابی فعال کنید.
 
   [dialog_routing_location_turn_on]
-    tags = ios,android
+    tags = ios, android
     en = Enable location services
     ru = Включите режим определения геопозиции
     ar = تمكين خدمات المواقع
@@ -9860,12 +6079,12 @@
     zh-Hans = 启用定位服务
     zh-Hant = 啟用定位服務
     el = Ενεργοποιήστε τις υπηρεσίες εντοπισμού τοποθεσίας
+    fa = فعال کردن سرویس موقعیت مکانی  (GPS)
     he = הפעל שירותי מיקום
     sk = Zapnite lokalizačné služby
-    fa = فعال کردن سرویس موقعیت مکانی  (GPS)
 
   [dialog_routing_location_unknown_turn_on]
-    tags = ios,android
+    tags = ios, android
     en = Unable to locate current GPS coordinates. Enable location services to calculate route.
     ru = Текущая геопозиция не определена. Для построения маршрута включите режим определения геопозиции.
     ar = تعذر تحديد إحداثيات نظام تحديد المواقع العالمي GPS الحالية. قم بتمكين خدمات المواقع لحساب المسار.
@@ -9894,45 +6113,12 @@
     zh-Hans = 无法定位当前 GPS 坐标。请启用定位服务以计算路线。
     zh-Hant = 無法定位目前 GPS 座標。請啟用定位服務以產生路線。
     el = Δεν είναι δυνατός ο εντοπισμός των τρεχουσών συντεταγμένων GPS. Ενεργοποιήστε τις υπηρεσίες εντοπισμού τοποθεσίας για τον υπολογισμό της διαδρομής.
+    fa = ناتوان از مشخص کردن موقعیت مکانی شما.لطفا سرویس موقعیت مکانی خود را فعال کنید.
     he = לא ניתן לאתר קואורדינטות GPS נוכחיות. הפעל שירותי מיקום כדי לחשב מסלול.
     sk = Aktuálne súradnice GPS sa nedajú lokalizovať. Aktivujte lokalizačné služby na výpočet trasy.
-    fa = ناتوان از مشخص کردن موقعیت مکانی شما.لطفا سرویس موقعیت مکانی خود را فعال کنید.
-
-  [dialog_routing_location_unknown]
-    tags = ios,android
-    en = Unable to locate current GPS coordinates.
-    ru = Текущая геопозиция не определена.
-    ar = تعذر تحديد مواقع إحداثيات نظام تحديد المواقع العالمي GPS الحالية.
-    cs = Aktuální souřadnice GPS se nepodařilo zjistit.
-    da = Det lykkedes ikke at finde de aktuelle GPS-koordinater.
-    nl = De huidige gps-coördinaten kunnen niet worden gevonden.
-    fi = Tämänhetkisiä GPS-koordinaatteja ei löydy.
-    fr = Impossible d'identifier les coordonnées GPS actuelles.
-    de = Aktuelle GPS-Koordinaten können nicht ermittelt werden.
-    hu = Nem sikerült lokalizálni a jelenlegi GPS koordinátákat.
-    id = TIdak dapat menemukan koordinat GPS saat ini.
-    it = Impossibile individuare le coordinate GPS attuali.
-    ja = 現在地のGPSコードを確認できません。
-    ko = 현재 GPS 좌표를 찾을 수 없습니다.
-    nb = Nåværende GPS-koordinater ble ikke funnet.
-    pl = Nie można ustalić współrzędnych GPS.
-    pt = Não foi possível obter as coordenadas GPS.
-    pt-BR = Não foi possível obter as coordenadas GPS.
-    ro = Localizarea coordonatelor GPS curente a eşuat.
-    es = No se pueden encontrar las coordenadas actuales del GPS.
-    sv = Kan inte lokalisera nuvarande GPS-koordinater.
-    th = ไม่สามารถหาตำแหน่งพิกัด GPS ปัจจุบันได้
-    tr = Mevcut GPS koordinatları belirlenemiyor.
-    uk = Поточну геопозицію не визначено.
-    vi = Không thể xác định vị trí tọa độ GPS hiện tại.
-    zh-Hans = 无法定位当前 GPS 坐标。
-    zh-Hant = 無法定位目前 GPS 座標。
-    he = לא ניתן לאתר קואורדינטות GPS נוכחיות.
-    sk = Nedajú sa lokalizovať aktuálne súradnice GPS.
-    fa = ناتوان از مشخص کردن موقعیت مکانی شما.
 
   [dialog_routing_download_files]
-    tags = ios,android
+    tags = ios
     en = Download required files
     ru = Загрузите необходимые файлы
     ar = تنزيل الملفات المطلوبة
@@ -9961,12 +6147,12 @@
     zh-Hans = 下载所需文件
     zh-Hant = 下載所需檔案
     el = Κατεβάστε τα απαιτούμενα αρχεία
+    fa = دانلود فایل های مورد نیاز
     he = הורד את הקבצים הדרושים
     sk = Prevezmite si požadované súbory
-    fa = دانلود فایل های مورد نیاز
 
   [dialog_routing_download_and_update_all]
-    tags = ios,android
+    tags = ios
     en = Download and update all map and routing information along the projected path to calculate route.
     ru = Для построения маршрута загрузите и обновите все карты и файлы маршрутов по пути следования.
     ar = قم بتنزيل وتحديث كافة الخرائط ومعلومات التوجيه على طول الطريق المتوقع لحساب المسار.
@@ -9998,41 +6184,8 @@
     he = הורד ועדכן את כל מידע המפות ויצירת המסלולים לאורך הנתיב הצפוי, כדי לחשב מסלול.
     sk = Prevezmite si a aktualizujte všetky mapy a informácie o trase pozdĺž naplánovanej trasy na výpočet trasy.
 
-  [dialog_routing_routes_size]
-    tags = ios,android
-    en = Routing information files
-    ru = Файлы маршрутов
-    ar = ملفات معلومات التوجيه
-    cs = Soubory s informacemi o trasách
-    da = Filer med ruteoplysninger
-    nl = Route-informatiebestanden
-    fi = Reititystiedostot
-    fr = Fichiers d'itinéraire
-    de = Routeninformationsdateien
-    hu = Útvonal-információs fájlok
-    id = File informasi rute
-    it = File di informazioni di itinerario
-    ja = ルート情報ファイル
-    ko = 경로 정보 파일
-    nb = Ruteinformasjonsfiler
-    pl = Pliki wyznaczania trasy
-    pt = Arquivos de dados de roteamento
-    pt-BR = Arquivos de dados de roteamento
-    ro = Fişiere cu informaţii de stabilire a traseului
-    es = Archivos de información de ruta
-    sv = Väginformationsfiler
-    th = ไฟล์ข้อมูลเส้นทาง
-    tr = Güzergah bilgi dosyaları
-    uk = Файли маршрутів
-    vi = Tệp thông tin tuyến đường
-    zh-Hans = 路线信息文件
-    zh-Hant = 路線資訊檔案
-    he = קובצי מידע מסלולים
-    sk = Súbory s informáciami o trase
-    fa = فایل های اطلاعات مسیر یابی
-
   [dialog_routing_unable_locate_route]
-    tags = ios,android
+    tags = ios, android
     en = Unable to locate route
     ru = Маршрут не найден
     ar = تعذر تحديد موقع المسار
@@ -10061,12 +6214,12 @@
     zh-Hans = 无法定位路线
     zh-Hant = 路線未找到
     el = Δε μπορεί να εντοπιστεί η διαδρομή
+    fa = ناتوان در تعیین مسیر
     he = לא ניתן לאתר מסלול
     sk = Trasa sa nedá lokalizovať
-    fa = ناتوان در تعیین مسیر
 
   [dialog_routing_cant_build_route]
-    tags = ios,android
+    tags = android
     en = Unable to create route.
     ru = Не получилось построить маршрут.
     ar = تعذر إنشاء مسار.
@@ -10095,12 +6248,12 @@
     zh-Hans = 无法创建路线。
     zh-Hant = 無法產生路線。
     el = Δε μπορεί να δημιουργηθεί η διαδρομή.
+    fa = ناتوان در ایجاد مسیر
     he = לא ניתן ליצור מסלול.
     sk = Trasa sa nedá vytvoriť.
-    fa = ناتوان در ایجاد مسیر
 
   [dialog_routing_change_start_or_end]
-    tags = ios,android
+    tags = ios, android
     en = Please adjust your starting point or your destination.
     ru = Пожалуйста, измените начальную или конечную точку маршрута.
     ar = برجاء تعديل نقطة بدء وجهتك.
@@ -10129,12 +6282,12 @@
     zh-Hans = 请调整您的起点或目的地。
     zh-Hant = 請變更起點或最終目的地。
     el = Ρυθμίστε το σημείο εκκίνησης ή τον προορισμό σας.
+    fa = لطفا مبدا یا مقصد خود را تنظیم کنید.
     he = כוונן את נקודת ההתחלה או היעד שלך.
     sk = Prosím, upravte váš východiskový bod alebo cieľové miesto.
-    fa = لطفا مبدا یا مقصد خود را تنظیم کنید.
 
   [dialog_routing_change_start]
-    tags = ios,android
+    tags = ios, android
     en = Adjust starting point
     ru = Измените начальную точку маршрута
     ar = تعديل نقطة البدء
@@ -10163,12 +6316,12 @@
     zh-Hans = 调整出发点
     zh-Hant = 變更起點
     el = Ρυθμίστε το σημείο εκκίνησης
+    fa = مبدا خود را تنظیم کنید
     he = כוונן נקודת התחלה
     sk = Nastavte východiskový bod
-    fa = مبدا خود را تنظیم کنید
 
   [dialog_routing_start_not_determined]
-    tags = ios,android
+    tags = ios, android
     en = Route was not created. Unable to locate starting point.
     ru = Маршрут не построен. Не определена начальная точка маршрута.
     ar = لم يتم إنشاء المسار. تعذر تحديد موقع نقطة البدء.
@@ -10197,12 +6350,12 @@
     zh-Hans = 路线未创建。无法定位起点。
     zh-Hant = 此路線尚未產生。無法定位起點。
     el = Δεν δημιουργήθηκε διαδρομή. Δεν είναι δυνατός ο εντοπισμός του σημείου εκκίνησης.
+    fa = مسیر ایجاد نشد.ناتوان در تعیین نقطه شروع
     he = לא נוצר מסלול. לא ניתן לאתר את נקודת ההתחלה.
     sk = Trasa nebola vytvorená. Nedá sa lokalizovať východiskový bod.
-    fa = مسیر ایجاد نشد.ناتوان در تعیین نقطه شروع
 
   [dialog_routing_select_closer_start]
-    tags = ios,android
+    tags = ios, android
     en = Please select a starting point closer to a road.
     ru = Пожалуйста, выберите начальную точку маршрута ближе к дороге.
     ar = يُرجى تحديد نقطة بدء أكثر قربًا للطريق.
@@ -10231,12 +6384,12 @@
     zh-Hans = 请选择更靠近公路的起点。
     zh-Hant = 請選擇更接近道路的起點。
     el = Επιλέξτε σημείο εκκίνησης πιο κοντά σε ένα δρόμο.
+    fa = لطفا نقطه شروع رانزدیک تر به جاده انتخاب کنید.
     he = בחר נקודת התחלה הקרובה יותר לכביש כלשהו.
     sk = Vyberte východiskový bod bližšie k ceste.
-    fa = لطفا نقطه شروع رانزدیک تر به جاده انتخاب کنید.
 
   [dialog_routing_change_end]
-    tags = ios,android
+    tags = ios, android
     en = Adjust destination
     ru = Измените конечную точку маршрута
     ar = تعديل الوجهة
@@ -10265,12 +6418,12 @@
     zh-Hans = 调整目的地
     zh-Hant = 變更目的地
     el = Ρύθμιση προορισμού
+    fa = تنظیم مقصد
     he = כוונן יעד
     sk = Nastavte cieľové miesto
-    fa = تنظیم مقصد
 
   [dialog_routing_end_not_determined]
-    tags = ios,android
+    tags = ios, android
     en = Route was not created. Unable to locate the destination.
     ru = Маршрут не построен. Не определена конечная точка маршрута.
     ar = لم يتم إنشاء المسار. تعذر تحديد موقع الوجهة.
@@ -10299,12 +6452,12 @@
     zh-Hans = 路线未创建。无法定位目的地。
     zh-Hant = 未產生路線。無法定位目的地。
     el = Δεν δημιουργήθηκε διαδρομή. Δεν είναι δυνατός ο εντοπισμός του προορισμού.
+    fa = مسیر ایجاد نشد.ناتوان در تعیین مقصد.
     he = לא נוצר מסלול. לא ניתן לאתר את היעד.
     sk = Trasa nebola vytvorená. Nedá sa lokalizovať cieľové miesto.
-    fa = مسیر ایجاد نشد.ناتوان در تعیین مقصد.
 
   [dialog_routing_select_closer_end]
-    tags = ios,android
+    tags = ios, android
     en = Please select a destination point located closer to a road.
     ru = Пожалуйста, выберите конечную точку маршрута ближе к дороге.
     ar = يُرجى تحديد نقطة وجهة تقع أكثر قربًا من الطريق.
@@ -10333,12 +6486,12 @@
     zh-Hans = 请选择更靠近公路的目的地位置。
     zh-Hant = 請選擇更接近道路的目的地。
     el = Επιλέξτε ένα σημείο προορισμού πιο κοντά σε ένα δρόμο.
+    fa = لطفا مقصد تعیین شده را نزدیک تر به جاده انتخاب نمایید.
     he = בחר נקודת יעד הקרובה יותר לכביש כלשהו.
     sk = Vyberte cieľové miesto nachádzajúce sa bližšie k ceste.
-    fa = لطفا مقصد تعیین شده را نزدیک تر به جاده انتخاب نمایید.
 
   [dialog_routing_change_intermediate]
-    tags = ios,android
+    tags = ios, android
     en = Unable to locate the intermediate point.
     ru = Не определена промежуточная точка маршрута.
     ar = تعذر تحديد مكان النقطة الوسيطة.
@@ -10366,12 +6519,12 @@
     zh-Hans = 无法定位中间点。
     zh-Hant = 找不到中途休息站。
     el = Δεν είναι δυνατός ο εντοπισμός ενδιάμεσου σημείου.
+    fa = ناتوان در تعیین نقطه میانی.
     sk = Zastávku sa nepodarilo nájsť.
     sw = Imeshindwa kupata eneo la kati.
-    fa = ناتوان در تعیین نقطه میانی.
 
   [dialog_routing_intermediate_not_determined]
-    tags = ios,android
+    tags = ios, android
     en = Please adjust your intermediate point.
     ru = Пожалуйста, измените промежуточную точку маршрута.
     ar = الرجاء ضبط النقطة الوسيطة الخاصة بك.
@@ -10399,12 +6552,12 @@
     zh-Hans = 请调整您的中间点。
     zh-Hant = 請調整您的中途休息站。
     el = Ρυθμίστε το ενδιάμεσο σημείο.
+    fa = لطفا نقطه میانی را تنظیم کنید.
     sk = Upravte zastávku.
     sw = Tafadhali badilisha eneo lako la kati.
-    fa = لطفا نقطه میانی را تنظیم کنید.
 
   [dialog_routing_system_error]
-    tags = ios,android
+    tags = ios, android
     en = System error
     ru = Системная ошибка
     ar = خطأ في النظام
@@ -10433,12 +6586,12 @@
     zh-Hans = 系统错误
     zh-Hant = 系統錯誤
     el = Σφάλμα συστήματος
+    fa = خطای سیستم
     he = שגיאת מערכת
     sk = Systémová chyba
-    fa = خطای سیستم
 
   [dialog_routing_application_error]
-    tags = ios,android
+    tags = ios, android
     en = Unable to create route due to an application error.
     ru = Не удалось проложить маршрут из-за ошибки приложения.
     ar = تعذر إنشاء مسار نتيجة وجود خطأ في التطبيق.
@@ -10467,12 +6620,12 @@
     zh-Hans = 由于应用程序错误，无法创建路线。
     zh-Hant = 由於此錯誤，尚未建立路線。
     el = Δεν είναι δυνατή η δημιουργία διαδρομής εξαιτίας σφάλματος εφαρμογής.
+    fa = ناتوان در ایجاد مسیر به علت خطای برنامه.
     he = לא ניתן ליצור מסלול עקב שגיאת אפליקציה.
     sk = Nedá sa vytvoriť trasa z dôvodu aplikačnej chyby.
-    fa = ناتوان در ایجاد مسیر به علت خطای برنامه.
 
   [dialog_routing_try_again]
-    tags = ios,android
+    tags = ios, android
     en = Please try again
     ru = Попробуйте снова
     ar = برجاء إعادة المحاولة
@@ -10501,111 +6654,12 @@
     zh-Hans = 请重试
     zh-Hant = 請再試一次
     el = Προσπαθήστε ξανά
+    fa = لطفا دوباره تلاش کنید
     he = נסה שוב
     sk = Skúste znova, prosím
-    fa = لطفا دوباره تلاش کنید
-
-  [dialog_routing_send_error]
-    tags = ios,android
-    en = Report the Problem
-    ru = Сообщить об ошибке
-    ar = الإبلاغ عن المشكلة
-    cs = Nahlásit problém
-    da = Anmeld problemet
-    nl = Meld het probleem
-    fi = Ilmoita ongelmasta
-    fr = Signaler le problème
-    de = Dieses Problem melden
-    hu = Probléma bejelentése
-    id = Laporkan Masalah
-    it = Segnala il problema
-    ja = 問題を報告する
-    ko = 문제 신고
-    nb = Rapporter problemet
-    pl = Zgłoś problem
-    pt = Relatar o Problema
-    pt-BR = Relatar o problema
-    ro = Raportaţi problema
-    es = Informar el problema
-    sv = Rapportera problem
-    th = รายงานปัญหา
-    tr = Hatayı Bildirin
-    uk = Повідомити про помилку
-    vi = Báo cáo vấn đề
-    zh-Hans = 报告问题
-    zh-Hant = 回報問題
-    he = דווח על הבעיה
-    sk = Nahláste problém
-    fa = گزارش مشکل
-
-  [dialog_routing_if_get_cross_route]
-    tags = ios,android
-    en = Would you like to create a more direct route that spans more than one map?
-    ru = Построить более оптимальный маршрут с пересечением границы карты?
-    ar = هل تريد إنشاء مسار مباشر بشكل أكبر يمتد عبر أكثر من خريطة؟
-    cs = Chcete vytvořit přímější trasu, která vede přes více než jednu mapu?
-    da = Ønsker du at planlægge en mere direkte rute, der strækker sig over mere end ét kort?
-    nl = Wilt u een rechtstreeksere route samenstellen die meer dan één kaart beslaat?
-    fi = Haluatko luoda suoremman reitin, joka ylettyy usealle kartalle?
-    fr = Voulez-vous créer un itinéraire plus direct s'étendant sur plus d'une carte ?
-    de = Möchten Sie eine direktere Route erstellen, die mehr als eine Karte umfasst?
-    hu = Szeretne egy közvetlenebb útvonalat létrehozni, amely több, mint egy térképen terül el?
-    id = Apakah Anda ingin membuat rute yang lebih langsung yang meliputi lebih dari satu peta?
-    it = Vuoi creare un percorso più diretto che si estende su più mappe?
-    ja = 複数マップを利用してより最適なルートを作成しますか？
-    ko = 두 개 이상의 지도를 통과하는 더 직접적인 경로를 설정하시겠습니까?
-    nb = Vil du opprette en mer direkte rute som går over flere kart?
-    pl = Chcesz wyznaczyć lepszą trasę, obejmującą więcej map?
-    pt = Deseja traçar uma rota mais direta, mas que se estenda por mais de um mapa?
-    pt-BR = Deseja traçar uma rota mais direta, mas que se estenda por mais de um mapa?
-    ro = Doriţi să creaţi un traseu mai direct care include mai mult decât o hartă?
-    es = ¿Desea crear una ruta más directa que abarca más de un mapa?
-    sv = Vill du skapa en mer direkt väg som sträcker sig över fler än en karta?
-    th = คุณต้องการสร้างเส้นทางที่อ้อมน้อยลงซึ่งข้ามเกินหนึ่งแผนที่หรือไม่?
-    tr = Bir haritadan daha fazlasına uzanan doğrudan bir güzergah oluşturmak ister misiniz?
-    uk = Побудувати більш оптимальний маршрут з перетином межі карти?
-    vi = Bạn có muốn tạo một tuyến đường thẳng hơn mà kéo dài trên nhiều bản đồ không?
-    zh-Hans = 您是否要创建一条跨越多张地图的更直接路线？
-    zh-Hant = 您想產生跨越邊界的更好路線嗎？
-    he = האם ברצונך ליצור מסלול ישיר יותר, הכולל יותר מאשר מפה אחת?
-    sk = Chceli by ste vytvoriť priamejšiu trasu, ktorá zahŕňa viac ako jednu mapu?
-    fa = ایا می خواهید یک مسیر مستقیم تر که بیش از یک نقشه را شامل می شود ایجاد کنید؟
-
-  [dialog_routing_cross_route_is_optimal]
-    tags = ios,android
-    en = A more optimal route that crosses the edge of this map is available.
-    ru = Маршрут с пересечением границы карты более оптимальный.
-    ar = هناك مسار أفضل يعبر حافة هذه الخريطة.
-    cs = K dispozici je optimálnější trasa, která překračuje hranice této mapy.
-    da = Der findes en mere optimal rute, som strækker sig ud over dette korts grænser.
-    nl = Er is een betere route beschikbaar die de grenzen van deze kaart overschrijdt.
-    fi = Tarjolla on suorempi reitti, joka ylittää tämän kartan reunan.
-    fr = Un itinéraire plus direct sortant du cadre de cette carte est disponible.
-    de = Es ist eine bessere Route verfügbar, die den Rand dieser Karte überschreitet.
-    hu = Elérhető egy optimálisabb útvonal, amely áthalad a jelenlegi térkép szélén.
-    id = Ada rute yang lebih optimal yang melewati ujung peta ini.
-    it = È disponibile un percorso migliore che oltrepassa il limite di questa mappa.
-    ja = このマップの境界を越えて複数マップを利用すると、より最適なルートを作成できます。
-    ko = 이 지도의 경계를 통과하는 더 최적화된 경로를 사용할 수 있습니다.
-    nb = En mer optimal rute som går utenfor dette kartet er tilgjengelig.
-    pl = Dostępna jest lepsza trasa, wykraczająca poza granice bieżącej mapy.
-    pt = Há uma rota disponível que vai além dos limites deste mapa.
-    pt-BR = Há uma rota disponível que vai além dos limites deste mapa.
-    ro = Este disponibil un traseu mai adecvat care trece de limita acestei hărţi.
-    es = Está disponible una ruta mejor que cruza los límites de este mapa.
-    sv = En optimalare väg som sträcker sig utanför den här kartan är tillgänglig.
-    th = มีเส้นทางที่เหมาะสมกว่าซึ่งข้ามเลยขอบของแผนที่นี้
-    tr = Bu haritanın bir kısmından geçen daha uygun bir güzergah mevcut.
-    uk = Маршрут з перетином межі карти більш оптимальний.
-    vi = Có một tuyến đường tối ưu hơn đi qua cạnh của bản đồ này.
-    zh-Hans = 有一条跨越本地图边缘的更佳路线可用。
-    zh-Hant = 有更理想的跨越邊界的路線可用。
-    he = זמין מסלול מיטבי יותר החוצה את הגבול של מפה זו.
-    sk = K dispozícii je optimálnejšia trasa, ktorá presahuje hranice tejto mapy.
-    fa = مسیر های بهینه بیشتری موجود است که حاشیه این نقشه را رد می کند .
 
   [not_now]
-    tags = ios,android
+    tags = ios
     en = Not Now
     ru = Не сейчас
     ar = ليس الآن
@@ -10634,45 +6688,12 @@
     zh-Hans = 现在不用
     zh-Hant = 現在不要
     el = Όχι τώρα
+    fa = اکنون خیر
     he = לא עכשיו
     sk = Nie teraz
-    fa = اکنون خیر
-
-  [dialog_routing_build_route]
-    tags = ios,android
-    en = Create
-    ru = Построить
-    ar = إنشاء
-    cs = Vytvořit
-    da = Opret
-    nl = Samenstellen
-    fi = Luo
-    fr = Créer
-    de = Erstellen
-    hu = Létrehozás
-    id = Buat
-    it = Crea
-    ja = 作成する
-    ko = 만들기
-    nb = Opprett
-    pl = Wyznacz
-    pt = Traçar
-    pt-BR = Traçar
-    ro = Creare
-    es = Crear
-    sv = Skapa
-    th = สร้าง
-    tr = Oluşturun
-    uk = Побудувати
-    vi = Tạo
-    zh-Hans = 创建
-    zh-Hant = 產生
-    he = צור
-    sk = Vytvoriť
-    fa = ایجاد کردن
 
   [dialog_routing_download_and_build_cross_route]
-    tags = ios,android
+    tags = android
     en = Would you like to download the map and create a more optimal route spanning more than one map?
     ru = Загрузить карту и построить более оптимальный маршрут с пересечением границы карты?
     ar = هل ترغب في تنزيل الخريطة وإنشاء مسار أفضل يمتد عبر أكثر من خريطة؟
@@ -10701,12 +6722,12 @@
     zh-Hans = 您是否要下载地图并创建一条跨越多张地图的更佳路线？
     zh-Hant = 您是否要下載地圖，產生跨越邊界的更好路線？
     el = Θέλετε να κατεβάσετε το χάρτη και να δημιουργήσετε μια πιο βέλτιστη διαδρομή που εκτείνονται σε περισσότερους από έναν χάρτη;
+    fa = ایا مایل به دانلود نقشه و ایجاد مسیر های بهینه بیشتری که نقشه های بیشتری را پوشش میدهد هستید؟
     he = האם ברצונך להוריד את המפה וליצור מסלול מיטבי יותר, הכולל יותר מאשר מפה אחת?
     sk = Chcete si prevziať mapu a vytvoriť optimálnejšiu trasu, ktorá si vyžaduje viac ako jednu mapu?
-    fa = ایا مایل به دانلود نقشه و ایجاد مسیر های بهینه بیشتری که نقشه های بیشتری را پوشش میدهد هستید؟
 
   [dialog_routing_download_cross_route]
-    tags = ios,android
+    tags = android
     en = Download additional maps to create a better route that crosses the boundaries of this map.
     ru = Для построения более оптимального маршрута с пересечением границы требуется загрузить карту.
     ar = تنزيل الخريطة لإنشاء مسار أفضل يعبر حافة هذه الخريطة.
@@ -10735,47 +6756,14 @@
     zh-Hans = 下载地图，创建一条跨越此地图边缘的更佳路线。
     zh-Hant = 若要產生跨越邊界的更理想路線，您需要下載地圖。
     el = Κατεβάσετε επιπλέον χάρτες για να δημιουργήσετε μια καλύτερη διαδρομή που διασχίζει τα όρια αυτού του χάρτη.
+    fa = دانلود نقشه های اضافی برای ایجاد مسیری بهتر که حاشیه های این نقشه را رد می کند.
     he = הורד את המפה כדי ליצור מסלול מיטבי יותר, החוצה את הגבול של מפה זו.
     sk = Prevezmite si mapu na vytvorenie optimálnejšej trasy, ktorá prekračuje okraje tejto mapy.
-    fa = دانلود نقشه های اضافی برای ایجاد مسیری بهتر که حاشیه های این نقشه را رد می کند.
-
-  [dialog_routing_cross_route_always]
-    tags = ios,android
-    en = Always cross this boundary
-    ru = Всегда пересекать эту границу
-    ar = اعبر هذه الحدود دائمًا
-    cs = Vždy překročit tuto hranici
-    da = Kryds altid denne grænse
-    nl = Deze grens altijd overschrijden
-    fi = Ylitä aina tämä raja
-    fr = Toujours dépasser ce cadre
-    de = Diese Grenze immer überschreiten
-    hu = Mindig haladjon át ezen a határon
-    id = Selalu lewati batas ini
-    it = Oltrepassa sempre questo limite
-    ja = 常にこの境界を越える
-    ko = 항상 이 경계 통과
-    nb = Kryss alltid denne grensen
-    pl = Zawsze przekraczaj tę granicę
-    pt = Sempre cruzar esse limite
-    pt-BR = Sempre cruzar esse limite
-    ro = Întotdeauna să se treacă această limită
-    es = Cruzar siempre este límite
-    sv = Korsa alltid den här gränsen
-    th = ข้ามขอบเขตนี้เสมอ
-    tr = Bu sınırı her zaman geçin
-    uk = Завжди перетинати цю межу
-    vi = Luôn đi qua ranh giới này
-    zh-Hans = 始终跨越此边界线
-    zh-Hant = 一律跨越此邊界
-    he = תמיד חצה גבול זה
-    sk = Vždy prekročiť túto hranicu
-    fa = همیشه این مرز را رد کن
 
 [[Strings for downloading map from search]]
 
   [search_without_internet_advertisement]
-    tags = ios,android
+    tags = android
     en = To start searching and creating routes, please download the map. After that you will no longer need an Internet connection.
     ru = Для поиска мест и построения маршрутов скачайте карту, и интернет вам больше не понадобится.
     ar = لبدء البحث وإنشاء الطرق، يرجى تنزيل الخريطة، وسوف لن تحتاج إلى اتصال بالإنترنت بعد الآن.
@@ -10804,12 +6792,12 @@
     zh-Hans = 要开始搜索和创建路线，请下载地图，那您就不再需要网络连接了。
     zh-Hant = 要開始搜索和建立路線，請下載地圖，那您就不再需要網絡連接了。
     el = Για να ξεκινήσετε την αναζήτηση και τη δημιουργία διαδρομών, κατεβάστε το χάρτη. Μετά από αυτό δεν θα χρειάζεστε πλέον σύνδεση στο Internet.
+    fa = برای شروع جستوجو و مسیر یابی لطفا نقشه رادانلود کنید بعد از ان دیگر نیازی به اتصال به اینترنت ندارید و برنامه کاملا افلاین اجرا می شود.
     he = על מנת להתחיל לחפש וליצור מסלולים, הורידו בבקשה את המפה ולא תזדקקו יותר לחיבור לאינטרנט.
     sk = Stiahnutím mapy už nebudete potrebovať pripojenie k internetu a môžete si začať vyhľadávať a vytvárať trasy.
-    fa = برای شروع جستوجو و مسیر یابی لطفا نقشه رادانلود کنید بعد از ان دیگر نیازی به اتصال به اینترنت ندارید و برنامه کاملا افلاین اجرا می شود.
 
   [search_select_map]
-    tags = ios,android
+    tags = android
     en = Select Map
     ru = Выбрать карту
     ar = اختيار الخريطة
@@ -10838,46 +6826,13 @@
     zh-Hans = 选择地图
     zh-Hant = 選擇地圖
     el = Επιλέξτε χάρτη
+    fa = انتخاب نقشه
     he = בחרו את המפה
     sk = Vybrať mapu
-    fa = انتخاب نقشه
-
-  [search_select_other_map]
-    tags = ios,android
-    en = Select Another Map
-    ru = Выбрать другую карту
-    ar = اختيار خريطة أخرى
-    cs = Vybrat jinou mapu
-    da = Vælg et andet kort
-    nl = Selecteer een andere kaart
-    fi = Valitse toinen kartta
-    fr = Sélectionner une autre carte
-    de = Eine andere Karte auswählen
-    hu = Jelölj ki másik térképet
-    id = Pilih Peta Lain
-    it = Seleziona un'altra mappa
-    ja = 別の地図を選択
-    ko = 다른 지도 선택
-    nb = Velg et annet kart
-    pl = Wybierz inną mapę
-    pt = Selecionar Outro Mapa
-    pt-BR = Selecionar Outro Mapa
-    ro = Selectați altă hartă
-    es = Seleccionar otro mapa
-    sv = Välj en annan karta
-    th = เลือกแผนที่อื่น
-    tr = Başka Bir Harita Seçin
-    uk = Вибрати іншу карту
-    vi = Chọn bản đồ khác
-    zh-Hans = 选择另一个地图
-    zh-Hant = 選擇另一個地圖
-    he = בחרו מפה אחרת
-    sk = Vybrať inú mapu
-    fa = انتخاب نقشه ی دیگر
 
   [show]
     comment = «Show» context menu
-    tags = android
+    tags = ios, android
     en = Show
     ru = Показать
     ar = عرض
@@ -10906,12 +6861,12 @@
     zh-Hans = 显示
     zh-Hant = 顯示
     el = Εμφάνιση
-    sk = Ukázať
     fa = نمایش
+    sk = Ukázať
 
   [hide]
     comment = «Hide» context menu
-    tags = android
+    tags = ios, android
     en = Hide
     ru = Скрыть
     ar = إخفاء
@@ -10940,8 +6895,8 @@
     zh-Hans = 隐藏
     zh-Hant = 隱藏
     el = Απόκρυψη
-    sk = Skryť
     fa = مخفی کردن
+    sk = Skryť
 
   [rename]
     comment = «Rename» context menu
@@ -10974,45 +6929,12 @@
     zh-Hans = 重命名
     zh-Hant = 重新命名
     el = Μετονομασία
-    sk = Premenovať
     fa = تغیر نام
-
-  [bottom_sheet_more]
-    comment = Bottom sheet: expand button (should be short)
-    tags = android
-    en = More…
-    ru = Ещё…
-    ar = المزيد…
-    cs = Více…
-    da = Mere…
-    nl = Meer…
-    fi = Lisää…
-    fr = Plus…
-    de = Mehr…
-    hu = Továbbiak…
-    id = Lainnya…
-    it = Altro…
-    ja = さらに…
-    ko = 기타…
-    nb = Mer…
-    pl = Więcej…
-    pt = Mais…
-    pt-BR = Mais…
-    ro = Mai multe…
-    es = Más…
-    sv = Mer…
-    th = เพิ่มเติม…
-    tr = Daha Fazla…
-    uk = Більше…
-    vi = Thêm…
-    zh-Hans = 更多…
-    zh-Hant = 更多…
-    sk = Viac…
-    fa = بیشتر
+    sk = Premenovať
 
   [routing_planning_error]
     comment = Failed planning route message in navigation view
-    tags = ios,android
+    tags = ios
     en = Route Planning Failed
     ru = Ошибка построения маршрута
     ar = فشل في تخطيط المسار
@@ -11041,12 +6963,12 @@
     zh-Hans = 路线计划失败
     zh-Hant = 路線計劃失敗
     el = Ο σχεδιασμός διαδρομής απέτυχε
-    sk = Plánovanie trasy zlyhalo
     fa = برنامه ریزی مسیر ناموفق
+    sk = Plánovanie trasy zlyhalo
 
   [routing_arrive]
     comment = Arrive routing message in navigation view
-    tags = ios,android
+    tags = android
     en = Arrival at %s
     ru = Прибытие в %s
     ar = الوصول: %s
@@ -11075,43 +6997,11 @@
     zh-Hans = 抵達:%s
     zh-Hant = 抵達:%s
     el = Άφιξη στις %s
-    sk = Pricestovať: %s
     fa = ورود به: %s
-
-  [dialog_routing_download_and_update_maps]
-    comment = Text for routing::RouterResultCode::FileTooOld dialog.
-    tags = ios, android
-    en = Download and update all map along the projected path to calculate route.
-    ru = Для построения маршрута загрузите и обновите все карты по пути следования.
-    ar = لإنشاء مسار، يرجى تنزيل وتحديث جميع الخرائط على امتداد الطريق.
-    cs = Pro vytvoření trasy si prosím stáhněte a aktualizujte všechny mapy podél očekávané cesty.
-    da = For at oprette en rute skal du hente og opdatere alle kort langs ruten.
-    nl = Om een route te maken, download en update alle kaarten rondom de route.
-    fi = Lataa ja päivitä kaikki kartat reitin varrella luodaksesi reitin.
-    fr = Pour créer un trajet, veuillez télécharger et mettre à jour toutes les cartes concernant ce trajet.
-    de = Zum Erstellen einer Route müssen Sie alle Karten herunterladen und aktualisieren, auf der die Route liegt.
-    hu = Útvonal létrehozásához kérjük, töltse le és frissítse az összes térképet az útvonal mentén.
-    id = Untuk membuat rute, silakan unduh dan perbarui semua peta sepanjang rute.
-    it = Per creare un percorso, scaricare e aggiornare tutte le mappe interessate dal percorso.
-    ja = ルートを作成するには、ルートの通過する地図を全てダウンロード・アップデートしてください。
-    ko = 경로를 만들려면, 경로를 따라 모든 지도를 다운로드하고 업데이트하십시오.
-    nb = Hvis du vil oppprette en rute, last ned og oppdater alle kartene langs ruten.
-    pl = Aby utworzyć trasę, pobierz i zaktualizuj wszystkie właściwe dla niej mapy.
-    pt = Para criar uma rota, por favor, baixe e atualize todos os mapas ao longo do trajeto.
-    pt-BR = Para criar uma rota, por favor, baixe e atualize todos os mapas ao longo do trajeto.
-    ro = Pentru a crea o rută, vă rugăm să descărcați și să actualizați toate hărțile de pe parcursul rutei.
-    es = Para crear una ruta, por favor, descarga y actualiza todos los mapas a lo largo de la ruta.
-    sv = För att skapa en rutt, ladda ner och uppdatera alla kartor längs rutten.
-    th = เพื่อสร้างเส้นทาง โปรดดาวน์โหลดและอัปเดตแผนที่ทั้งหมดตลอดเส้นทาง
-    tr = Bir rota oluşturmak için lütfen rota üzerindeki tüm haritaları indirin ve güncelleyin.
-    uk = Для створення маршруту, будь ласка, скачайте та обновіть всі карти за ним.
-    vi = Để tạo đường đi, vui lòng tải về và cập nhật tất cả bản đồ dọc theo tuyến đường.
-    zh-Hans = 要创建路线，请下载并更新所有沿路线的地图。
-    zh-Hant = 要建立路線，請下載並更新所有沿線的地圖。
-    sk = Prosím, pre vytvorenie trasy si stiahnite a aktualizujte všetky mapy pozdĺž trasy.
+    sk = Pricestovať: %s
 
   [rate_alert_title]
-    tags = ios, android
+    tags = ios
     en = Like the app?
     ru = Нравится приложение?
     ar = يعجبك التطبيق؟
@@ -11140,11 +7030,11 @@
     zh-Hans = 喜欢这个应用吗？
     zh-Hant = 喜歡這個應用程式嗎？
     el = Σας αρέσει η εφαρμογή;
-    sk = Páči sa vám aplikácia?
     fa = این اپ را دوست دارید؟
+    sk = Páči sa vám aplikácia?
 
   [rate_alert_default_message]
-    tags = ios, android
+    tags = ios
     en = Thank you for using Organic Maps. Please rate the app. Your feedback helps us improve our product.
     ru = Спасибо что пользуетесь картами Organic Maps. Пожалуйста, оцените приложение. Ваши оценки и отзывы помогают нам становиться лучше.
     ar = شكرا لاستخدامك Organic Maps. من فضلك، أَعْطِ تقييمك للتطبيق. ملاحظاتك تساعدنا على أن نصبح أفضل.
@@ -11173,11 +7063,11 @@
     zh-Hans = 感谢您使用 Organic Maps。请，评价该应用。您的反馈帮助我们变得更好。
     zh-Hant = 感謝您使用 Organic Maps。請評價此應用程式。您的回饋幫助我們改善我們的產品。
     el = Σας ευχαριστούμε που χρησιμοποιείτε το Organic Maps. Βαθμολογήστε την εφαρμογή. Τα σχόλιά σας μας βοηθάνε να βελτιώσουμε το προϊόν μας.
-    sk = Ďakujeme, že používate Organic Maps. Prosím, ohodnoťte aplikáciu. Vaše názory nám pomôžu zlepšiť sa.
     fa = باتشکر از شما بابت استفاده ازOrganic Maps.لطفا به این اپلیکیشن رای بدهید. بازخورد شما باعث پیشرفت اپلیکیشن ما می شود.
+    sk = Ďakujeme, že používate Organic Maps. Prosím, ohodnoťte aplikáciu. Vaše názory nám pomôžu zlepšiť sa.
 
   [rate_alert_five_star_message]
-    tags = ios, android
+    tags = ios
     en = Hooray! We love you, too!
     ru = Ура! Мы вас тоже любим!
     ar = مرحا! نحن أيضا نحبك!
@@ -11206,11 +7096,11 @@
     zh-Hans = 太棒了！我们也爱您！
     zh-Hant = 太棒了！我們也愛您！
     el = Ζήτω! Σας ευχαριστούμε πάρα πολύ!
-    sk = Hurá! Aj my vás taky páči!
     fa = هورا ! ما هم شما را دوست داریم!
+    sk = Hurá! Aj my vás taky páči!
 
   [rate_alert_four_star_message]
-    tags = ios, android
+    tags = ios
     en = Thank you, we will do our best!
     ru = Спасибо, мы будем стараться!
     ar = شكرا لك، سوف نبذل قصارى جهدنا!
@@ -11239,11 +7129,11 @@
     zh-Hans = 谢谢您，我们会尽可能做好！
     zh-Hant = 謝謝您，我們會盡可能做好!
     el = Σας ευχαριστούμε, θα κάνουμε το καλύτερο δυνατό!
-    sk = Ďakujeme vám, urobíme, čo bude v našich silách!
     fa = متشکریم تلاش خود را می کنیم
+    sk = Ďakujeme vám, urobíme, čo bude v našich silách!
 
   [rate_alert_less_than_four_star_message]
-    tags = ios, android
+    tags = ios
     en = Any idea how we can make it better?
     ru = Расскажите, что мы могли бы улучшить?
     ar = لديك أي فكرة حول كيف يمكننا أن نجعله أفضل؟
@@ -11272,11 +7162,11 @@
     zh-Hans = 有没有想法我们能怎么把它变得更好？
     zh-Hant = 有沒有想法我們能怎麽把它變得更好？
     el = Έχετε κάποια ιδέα για το πώς μπορούμε να το κάνουμε καλύτερο;
-    sk = Nejaký nápad, ako ju môžeme vylepšiť?
     fa = ایا پیشنهاد یا ایده ای دارید که ما بتوانیم بهتر از این باشیم؟
+    sk = Nejaký nápad, ako ju môžeme vylepšiť?
 
   [categories]
-    tags = ios, android
+    tags = android
     en = Categories
     ru = Категории
     ar = التصنيفات
@@ -11305,8 +7195,8 @@
     zh-Hans = 类别
     zh-Hant = 類別
     el = Κατηγορίες
-    sk = Kategórie
     fa = دسته بندی ها
+    sk = Kategórie
 
   [history]
     tags = ios, android
@@ -11338,40 +7228,8 @@
     zh-Hans = 历史
     zh-Hant = 記錄
     el = Ιστορικό
-    sk = Archív
     fa = تاریخچه
-
-  [next_turn_then]
-    tags = ios, android
-    en = Then
-    ru = Далее
-    ar = ثم
-    cs = Poté
-    da = Så
-    nl = Dan
-    fi = Sitten
-    fr = Ensuite
-    de = Dann
-    hu = Aztán
-    id = Lalu
-    it = Poi
-    ja = その後
-    ko = 그런 다음
-    nb = Deretter
-    pl = Potem
-    pt = Em seguida
-    pt-BR = Em seguida
-    ro = Apoi
-    es = Luego
-    sv = Sedan
-    th = จากนั้น
-    tr = Sonra
-    uk = Потім
-    vi = Sau đó
-    zh-Hans = 然后
-    zh-Hant = 然後
-    sk = Potom
-    fa = سپس
+    sk = Archív
 
   [closed]
     tags = ios, android
@@ -11403,41 +7261,8 @@
     zh-Hans = 已关闭
     zh-Hant = 已關閉
     el = Κλειστό
-    sk = Zatvorené
     fa = تعطیل
-
-  [back_to]
-    tags = ios, android
-    en = Back to %@
-    ru = Назад к %@
-    ar = العودة إلى %@
-    cs = Zpět na %@
-    da = Tilbage til %@
-    nl = Terug naar %@
-    fi = Takaisin sovellukseen %@
-    fr = Revenir à %@
-    de = Zurück zu %@
-    hu = Vissza ide %@
-    id = Kembali ke %@
-    it = Torna a %@
-    ja = %@に戻る
-    ko = %@(으)로 복귀
-    nb = Tilbake til %@
-    pl = Powróć do %@
-    pt = Voltar para %@
-    pt-BR = Voltar para %@
-    ro = Înapoi la %@
-    es = Volver a %@
-    sv = Tillbaka till %@
-    th = กลับไป %@
-    tr = Geri Dön %@
-    uk = Назад до %@
-    vi = Quay lại %@
-    zh-Hans = 回到 %@
-    zh-Hant = 返回 %@
-    el = Επιστροφή στο %@
-    sk = Späť do %@
-    fa = بازگشت به %@
+    sk = Zatvorené
 
   [search_not_found]
     tags = ios, android
@@ -11469,8 +7294,8 @@
     zh-Hans = 抱歉，没有找到任何东西。
     zh-Hant = 很抱歉，找不到任何東西。
     el = Ωχ, δεν βρέθηκαν αποτελέσματα.
-    sk = Ľutujeme, ale nič sme nenašli.
     fa = متاسفانه چیزی پیدا نشد
+    sk = Ľutujeme, ale nič sme nenašli.
 
   [search_not_found_query]
     tags = ios, android
@@ -11502,75 +7327,11 @@
     zh-Hans = 请尝试其它查询。
     zh-Hant = 請嘗試其他搜尋字詞。
     el = Δοκιμάστε να αλλάξετε τα κριτήρια αναζήτησής σας.
-    sk = Vyskúšajte, prosím, iný hľadaný výraz.
     fa = با تغییر در معیار های جست و جو دوباره امتحان کنید
-
-  [search_not_found_map]
-    tags = ios, android
-    en = Please download the map you are searching in.
-    ru = Убедитесь, что карта области поиска загружена.
-    ar = فضلا، قم بتنزيل الخريطة التي تبحث فيها.
-    cs = Stáhněte si mapu, ve které hledáte.
-    da = Download kortet, som du søger i.
-    nl = Download de kaart waarin u zoekt, alstublieft.
-    fi = Lataa kartat sille alueelle jolta haet.
-    fr = Veuillez télécharger la carte dans laquelle vous recherchez.
-    de = Laden Sie bitte die Karte herunter, auf der Sie suchen.
-    hu = Töltse le azt a térképet, amelyen keres.
-    id = Silakan unduh peta yang Anda gunakan dalam pencarian Anda.
-    it = Scarica la mappa nella quale stai cercando.
-    ja = 検索する地図をダウンロードしてください。
-    ko = 검색할 지도를 다운로드하십시오.
-    nb = Vennligst last ned kartet du søker i.
-    pl = Pobierz mapę interesującego cię obszaru.
-    pt = Por favor, descarregue o mapa em que está pesquisando.
-    pt-BR = Por favor, baixe o mapa em que está pesquisando.
-    ro = Vă rugăm să descărcați harta pe care doriți să căutați.
-    es = Por favor, descarga el mapa en el que estás buscando.
-    sv = Ladda ner kartan du söker på.
-    th = กรุณาดาวน์โหลดแผนที่ที่คุณกำลังค้นหา
-    tr = Lütfen arama yaptığınız haritayı indirin.
-    uk = Завантажте карту місцевості на якій шукаєте.
-    vi = Vui lòng tải về bản đồ mà bạn đang tìm kiếm trong đó.
-    zh-Hans = 请下载您搜索的地图。
-    zh-Hant = 請下載你搜尋的地圖。
-    sk = Prosím, stiahnite si mapu, na ktorej vyhľadávate.
-    fa = لطفا نقشه ای را که در ان جست و جو می کنید را دانلود کنید
-
-  [search_not_found_location]
-    tags = ios, android
-    en = Download the map of your current location.
-    ru = Скачайте карту текущего местоположения.
-    ar = قم بتنزيل الخريطة الخاصة بموقعك الجغرافي.
-    cs = Stáhněte si mapu své aktuální pozice.
-    da = Download kortet for din nuværende placering.
-    nl = Download de kaart van uw huidige locatie.
-    fi = Lataa nykyisen sijaintisi kartta.
-    fr = Téléchargez la carte de votre emplacement actuel.
-    de = Laden Sie die Karte Ihres aktuellen Standorts herunter.
-    hu = Töltse le a jelenlegi tartózkodási helye térképét.
-    id = Unduh peta dari lokasi Anda saat ini.
-    it = Scarica la mappa del luogo in cui ti trovi.
-    ja = 現在地の地図をダウンロードしてください。
-    ko = 현재 위치의 지도를 다운로드하십시오.
-    nb = Last ned kartet til din nåværende beliggenhet.
-    pl = Pobierz mapę swojej bieżącej lokalizacji.
-    pt = Descarregue o mapa da sua localização atual.
-    pt-BR = Baixe o mapa da sua localização atual.
-    ro = Descărcați harta locului în care vă aflați acum.
-    es = Descarga el mapa de tu ubicación actual.
-    sv = Ladda ner kartan över din nuvarande position.
-    th = ดาวน์โหลดแผนที่ของตำแหน่งปัจจุบันของคุณ
-    tr = Mevcut konumunuzun haritasını indirin.
-    uk = Завантажте карту вашого місцезнаходження.
-    vi = Tải về bản đồ vị trí hiện tại của bạn.
-    zh-Hans = 下载您当前位置的地图。
-    zh-Hant = 下載您目前位置的地圖。
-    sk = Stiahnite si mapu svojej súčasnej polohy.
-    fa = نقشه موقعیت مکانی تان را دانلود کنید
+    sk = Vyskúšajte, prosím, iný hľadaný výraz.
 
   [search_history_title]
-    tags = ios, android
+    tags = android
     en = Search History
     ru = История поиска
     ar = سجل البحث
@@ -11599,11 +7360,11 @@
     zh-Hans = 搜索历史
     zh-Hant = 搜尋歷史紀錄
     el = Ιστορικό αναζήτησης
-    sk = História vyhľadávania
     fa = سوابق جست وجو
+    sk = História vyhľadávania
 
   [search_history_text]
-    tags = ios, android
+    tags = android
     en = View recent searches.
     ru = Быстрый доступ к последним поисковым запросам.
     ar = الوصول إلى استعلامات البحث الحديثة بسرعة.
@@ -11632,8 +7393,8 @@
     zh-Hans = 快速访问最近的搜索查询。
     zh-Hant = 檢視最近的搜尋。
     el = Προβολή πρόσφατων αναζητήσεων.
-    sk = Rýchlo pristupujte k nedávnym hľadaným výrazom.
     fa = مشاهده جست وجو های اخیر
+    sk = Rýchlo pristupujte k nedávnym hľadaným výrazom.
 
   [clear_search]
     tags = ios, android
@@ -11665,46 +7426,12 @@
     zh-Hans = 清除历史搜索
     zh-Hant = 清除搜尋記錄
     el = Εκκαθάριση ιστορικού αναζήτησης
-    sk = Vymazať históriu vyhľadávania
     fa = پاک کردن سابقه جست وجو ها
-
-  [showcase_settings_title]
-    comment = Title for settings to enable/disable showcase menu button
-    tags = ios, android
-    en = Show offers
-    ru = Показывать предложения
-    ar = رؤية العروض
-    cs = Zobrazit nabídky
-    da = Vis tilbud
-    nl = Aanbiedingen weergeven
-    fi = Näytä tarjoukset
-    fr = Afficher les offres
-    de = Angebote anzeigen
-    hu = Ajánlatok mutatása
-    id = Tampilkan penawaran
-    it = Mostra offerte
-    ja = オファーを表示
-    ko = 추천 보기
-    nb = Vis tilbud
-    pl = Oferty
-    pt = Mostrar ofertas
-    pt-BR = Mostrar ofertas
-    ro = Afișare oferte
-    es = Mostrar ofertas
-    sv = Visa erbjudanden
-    th = แสดงข้อเสนอ
-    tr = Teklifleri göster
-    uk = Показати пропозиції
-    vi = Hiển thị lời mời
-    zh-Hans = 显示优惠
-    zh-Hant = 顯示優惠
-    el = Εμφάνιση προσφορών
-    sk = Zobraziť akcie
-    fa = نمایش پیشنهاد ها
+    sk = Vymazať históriu vyhľadávania
 
   [read_in_wikipedia]
     comment = Place Page link to Wikipedia article (if map object has it).
-    tags = ios, android
+    tags = android
     en = Wikipedia
     fr = Wikipédia
     pt = Wikipédia
@@ -11712,38 +7439,6 @@
     zh-Hant = 維基百科
     el = Wikipedia
     fa = ویکی پدیا
-
-  [p2p_route_planning]
-    tags = ios, android
-    en = Route Planning
-    ru = Планирование маршрута
-    ar = تخطيط الطريق
-    cs = Plánování trasy
-    da = Ruteplanlægning
-    nl = Routeberekening
-    fi = Reittisuunnittelu
-    fr = Planification d’itinéraire
-    de = Routenplanung
-    hu = Útvonaltervezés
-    id = Perencana Rute
-    it = Pianificazione percorso
-    ja = ルート作成
-    ko = 경로 계획 중
-    nb = Ruteplanlegging
-    pl = Planowanie trasy
-    pt = Planejar rota
-    pt-BR = Planejar rota
-    ro = Planificare rută
-    es = Planificación de ruta
-    sv = Ruttplanering
-    th = การวางแผนเส้นทาง
-    tr = Rota planlama
-    uk = Планування маршруту
-    vi = Hoạch định đường đi
-    zh-Hans = 路线计划
-    zh-Hant = 路線計劃
-    sk = Plánovanie trasy
-    fa = برنامه ریزی مسیر
 
   [p2p_your_location]
     tags = ios, android
@@ -11775,74 +7470,8 @@
     zh-Hans = 您的位置
     zh-Hant = 您的位置
     el = Η τοποθεσία σας
-    sk = Vaša poloha
     fa = موقعیت شما
-
-  [p2p_from]
-    tags = ios, android
-    en = From
-    ru = Пункт отправления
-    ar = نقطة المغادرة
-    cs = Počátek cesty
-    da = Afgangssted
-    nl = Vertrekpunt
-    fi = Lähtöpiste
-    fr = Le lieu de départ
-    de = Startpunkt
-    hu = Az indulás helye
-    id = Titik keberangkatan
-    it = Il punto di partenza
-    ja = 出発地
-    ko = 출발 지점
-    nb = Avreisested
-    pl = Miejsce wyjazdu
-    pt = Ponto de partida
-    pt-BR = Ponto de partida
-    ro = Punctul de plecare
-    es = El punto de origen
-    sv = Startplats
-    th = จุดที่ออกเดินทาง
-    tr = Kalkış noktası
-    uk = Пункт відправлення
-    vi = Điểm khởi hành
-    zh-Hans = 出发地点
-    zh-Hant = 出發地點
-    el = Από
-    sk = Východiskový bod
-    fa = از
-
-  [p2p_to]
-    tags = ios, android
-    en = To
-    ru = Пункт назначения
-    ar = نقطة الوصول
-    cs = Místo určení
-    da = Bestemmelsesstedet
-    nl = Bestemmingspunt
-    fi = Päämäärä
-    fr = Le lieu de destination
-    de = Zielort
-    hu = Az érkezés helye
-    id = Titik tujuan
-    it = Il punto di destinazione
-    ja = 目的地
-    ko = 도착 지점
-    nb = Destinasjonssted
-    pl = Miejsce docelowe
-    pt = Ponto de destino
-    pt-BR = Ponto de destino
-    ro = Punctul de sosire
-    es = El punto de destino
-    sv = Målplats
-    th = จุดที่เป็นปลายทาง
-    tr = Varış noktası
-    uk = Пункт призначення
-    vi = Điểm đích
-    zh-Hans = 目的地点
-    zh-Hant = 目的地點
-    el = Έως
-    sk = Cieľový bod
-    fa = به
+    sk = Vaša poloha
 
   [p2p_start]
     tags = ios, android
@@ -11874,41 +7503,8 @@
     zh-Hans = 开始
     zh-Hant = 開始
     el = Έναρξη
-    sk = Štart
     fa = شروع
-
-  [p2p_planning]
-    tags = ios, android
-    en = Planning…
-    ru = Планируем…
-    ar = جار التخطيط…
-    cs = Plánování…
-    da = Planlægger…
-    nl = Aan het plannen…
-    fi = Lasketaan…
-    fr = En cours de planification…
-    de = Route wird geplant…
-    hu = Tervezés…
-    id = Merencanakan…
-    it = Pianificazione…
-    ja = 作成中…
-    ko = 계획 중…
-    nb = Planlegger…
-    pl = Planowanie…
-    pt = Planejando…
-    pt-BR = Planejando…
-    ro = Se planifică…
-    es = Planeando…
-    sv = Planerar…
-    th = กำลังวางแผน…
-    tr = Planlanıyor…
-    uk = Плануємо…
-    vi = Đang hoạch định…
-    zh-Hans = 计划中…
-    zh-Hant = 計劃中…
-    el = Σχεδιασμός…
-    sk = Plánovanie…
-    fa = درحال برنامه ریزی
+    sk = Štart
 
   [p2p_from_here]
     tags = ios, android
@@ -11940,8 +7536,8 @@
     zh-Hans = 从
     zh-Hant = 從
     el = Διαδρομή από
-    sk = Cesta z
     fa = مسیر از
+    sk = Cesta z
 
   [p2p_to_here]
     tags = ios, android
@@ -11973,8 +7569,8 @@
     zh-Hans = 发送至
     zh-Hant = 路線終點
     el = Διαδρομή στο
-    sk = Cesta do
     fa = مسیر به
+    sk = Cesta do
 
   [p2p_only_from_current]
     tags = ios, android
@@ -12006,8 +7602,8 @@
     zh-Hans = 导航只能从您目前的位置开始。
     zh-Hant = 導航只能從您目前的位置開始。
     el = Η πλοήγηση είναι διαθέσιμη μόνο από την τρέχουσα τοποθεσία σας.
-    sk = Navigácia je dostupná iba z vašej aktuálnej polohy.
     fa = مسیر یابی فقط از موقعیت کنونی شما قابل انجام است.
+    sk = Navigácia je dostupná iba z vašej aktuálnej polohy.
 
   [p2p_reroute_from_current]
     tags = ios, android
@@ -12039,8 +7635,8 @@
     zh-Hans = 你是否想要规划当前位置的路线？
     zh-Hant = 你是否想要規劃目前位置的路線？
     el = Θέλετε να σχεδιάσουμε μια διαδρομή από την τρέχουσα θέση σας;
-    sk = Doriți să vă planificăm o rută având ca punct de pornire locația actuală?
     fa = ایا می خواهید یک مسیر را از موقعیت فعلیتان برنامه ریزی کنیم؟
+    sk = Doriți să vă planificăm o rută având ca punct de pornire locația actuală?
 
   [next_button]
     comment = Edit open hours/set time and minutes dialog
@@ -12073,8 +7669,8 @@
     zh-Hans = 下一页
     zh-Hant = 下一頁
     el = Επόμενη
-    sk = Nasledujúca
     fa = بعدی
+    sk = Nasledujúca
 
   [editor_time_add]
     tags = ios, android
@@ -12106,8 +7702,8 @@
     zh-Hans = 添加计划
     zh-Hant = 新增排程
     el = Προσθέσετε χρονοδιάγραμμα
-    sk = Pridať rozvrh
     fa = اضافه کردن برنامه ریزی
+    sk = Pridať rozvrh
 
   [editor_time_delete]
     tags = ios, android
@@ -12139,8 +7735,8 @@
     zh-Hans = 删除计划
     zh-Hant = 刪除排程
     el = Διαγραφή χρονοδιαγράμματος
-    sk = Zmazať rozvrh
     fa = حذف کردن برنامه ریزی
+    sk = Zmazať rozvrh
 
   [editor_time_allday]
     comment = Text for allday switch.
@@ -12173,8 +7769,8 @@
     zh-Hans = 全天（24小时）
     zh-Hant = 全天 (24 小時)
     el = Όλη την ημέρα (24 ώρες)
-    sk = Nepretržite (24 hodín)
     fa = شبانه روزی (24 ساعته)
+    sk = Nepretržite (24 hodín)
 
   [editor_time_open]
     tags = ios, android
@@ -12206,8 +7802,8 @@
     zh-Hans = 营业中
     zh-Hant = 營業中
     el = Άνοιγμα
-    sk = Otvorené
     fa = باز
+    sk = Otvorené
 
   [editor_time_close]
     tags = ios, android
@@ -12239,8 +7835,8 @@
     zh-Hans = 未营业
     zh-Hant = 休息時間
     el = Κλειστό
-    sk = Zatvorené
     fa = بسته
+    sk = Zatvorené
 
   [editor_time_add_closed]
     tags = ios, android
@@ -12272,8 +7868,8 @@
     zh-Hans = 添加不营业时间
     zh-Hant = 新增休息時間
     el = Προσθήκη μη-εργάσιμων ωρών
-    sk = Pridať hodiny zatvorenia
     fa = اضافه کردن ساعات غیر کاری
+    sk = Pridať hodiny zatvorenia
 
   [editor_time_title]
     tags = ios, android
@@ -12305,8 +7901,8 @@
     zh-Hans = 营业时间
     zh-Hant = 營業時間
     el = Εργάσιμες ώρες
-    sk = Otváracie hodiny
     fa = ساعات کاری
+    sk = Otváracie hodiny
 
   [editor_time_advanced]
     tags = ios, android
@@ -12338,8 +7934,8 @@
     zh-Hans = 高级模式
     zh-Hant = 進階模式
     el = Προηγμένη λειτουργία
-    sk = Rozšírený režim
     fa = حالت پیشرفته
+    sk = Rozšírený režim
 
   [editor_time_simple]
     tags = ios, android
@@ -12371,8 +7967,8 @@
     zh-Hans = 简单模式
     zh-Hant = 簡易模式
     el = Απλή λειτουργία
-    sk = Jednoduchý režim
     fa = حالت ساده
+    sk = Jednoduchý režim
 
   [editor_hours_closed]
     tags = ios, android
@@ -12404,8 +8000,8 @@
     zh-Hans = 不营业时间
     zh-Hant = 休息時間
     el = Μη-εργάσιμες ώρες
-    sk = Hodiny zatvorenia
     fa = ساعات غیر کاری
+    sk = Hodiny zatvorenia
 
   [editor_example_values]
     tags = ios, android
@@ -12437,11 +8033,11 @@
     zh-Hans = 示例值
     zh-Hant = 範例值
     el = Παράδειγμα τιμών
-    sk = Príklady hodnôt
     fa = مقادیر پیش فرض
+    sk = Príklady hodnôt
 
   [editor_correct_mistake]
-    tags = ios, android
+    tags = android
     en = Correct mistake
     ru = Исправьте ошибку
     ar = تصحيح الخطأ
@@ -12470,42 +8066,11 @@
     zh-Hans = 纠正错误
     zh-Hant = 修正錯誤
     el = Διόρθωση λάθους
-    sk = Opraviť chybu
     fa = تصحیح خطا
-
-  [editor_correct_mistake_message]
-    tags = ios, android
-    en = You made an editing mistake. Please correct it or switch to simple mode.
-    ru = При редактировании времени работы вы допустили ошибку. Исправьте её или переключитесь в простой режим.
-    ar = قمت بخطأ في التحرير. يرجى تصحيح الخطأ أو التبديل إلى الوضع البسيط.
-    cs = Při úpravách jste udělali chybu. Opravte ji prosím, nebo přepněte do jednoduchého režimu.
-    da = Du har lavet en redigeringsfejl. Ret den, eller skift til enkel tilstand.
-    nl = U hebt een bewerkingsfout gemaakt. Corrigeer deze of schakel over naar de eenvoudige modus.
-    fi = Teit muokkausvirheen. Korjaa se tai vaihda yksinkertaiseen tilaan.
-    fr = Vous avez fait une erreur d'édition. Veuillez la corriger ou passer en mode simple.
-    de = Es ist ein Bearbeitungsfehler aufgetreten. Bitte korrigieren oder zum Einfachmodus wechseln.
-    hu = Szerkesztési hibát vétett. Javítsa ki vagy váltson egyszerű módba.
-    id = Pengeditan salah. Koreksi atau ubah ke mode sederhana.
-    it = Hai commesso un errore nella modifica. Correggerlo o passare alla modalità semplice.
-    ja = 編集の間違いがあります。訂正するか、シンプルモードに切り替えてください。
-    ko = 잘못 입력했습니다. 수정하거나 기본 모드로 전환하세요.
-    nb = Du har gjort en redigeringsfeil. Rett den eller bytt til enkel modus.
-    pl = Popełniono błąd podczas edycji. Popraw go lub przełącz się na tryb prosty.
-    pt = Fez um erro de edição. Corrija-o ou mude para o modo simples.
-    pt-BR = Há um erro de edição. Corrija-o ou mude para o modo simples.
-    ro = Ați efectuat o eroare de editare. Corectați eroarea sau treceți în modul Simplu.
-    es = Ha cometido un error de edición. Por favor, corríjalo o cambie a modo sencillo.
-    sv = Du har gjort ett fel i redigeringen. Var vänlig korrigera det eller byt till enkelt läge.
-    th = มีข้อผิดพลาดเกิดขึ้นจากการแก้ไขของคุณ โปรดแก้ไขให้ถูกต้อง หรือ สลับไปใช้ในโหมดแบบง่าย
-    tr = Bir düzenleme hatası yaptınız. Lütfen düzeltin veya basit moda geçin.
-    uk = Під час редагування часу роботи ви зробили помилку. Виправте її або перейдіть у простий режим.
-    vi = Bạn đã mắc lỗi chỉnh sửa. Vui lòng sửa lỗi hoặc chuyển qua chế độ đơn giản.
-    zh-Hans = 出现编辑错误，请纠正或切换至简单模式。
-    zh-Hant = 編輯時出錯。請修正或切換到簡易模式。
-    sk = Chyba pri úprave. Opravte chybu, alebo sa prepnite do jednoduchého režimu.
-    fa = شما یک ویرایش اشتباه انجام دادید.لطفا ان را اصلاح کنید یا به حالت ساده بروید
+    sk = Opraviť chybu
 
   [editor_add_select_location]
+    tags = ios, android
     en = Location
     ru = Местоположение
     ar = الموقع
@@ -12534,10 +8099,11 @@
     zh-Hans = 位置
     zh-Hant = 位置
     el = Τοποθεσία
-    sk = Poloha
     fa = موقعیت
+    sk = Poloha
 
   [editor_done_dialog_1]
+    tags = ios
     en = You’ve changed the world map. Do not keep it to yourself! Tell your friends, and edit it together.
     ru = Вы изменили карту мира. Не скрывайте это, расскажите друзьям и редактируйте вместе.
     ar = لقد غيرت خريطة العالم. لا تخفي ذلك! اخبر أصدقاءك، وغيروها معا.
@@ -12566,73 +8132,11 @@
     zh-Hans = 您已经改变了世界地图。请不要隐藏这一点！告诉您的朋友们并一起编辑它。
     zh-Hant = 您已經改變了世界地圖。別藏私！告訴您的朋友們一起來編輯。
     el = Έχετε αλλάξει τον παγκόμιο χάρτη. Μην το κρατάτε για τον εαυτό σας! Πείτε το στους φίλους σας και κάντε τις αλλαγές μαζί.
-    sk = Zmenili ste mapu sveta. Nemusíte to skrývať! Povedzte o tom svojim priateľom a začnite ju spolu upravovať.
     fa = شما نقشه جهان را تغییر دادید.این افتخار را پیش خود نگه ندارید!به دوستانتان درموردش بگویید و با یکدیگر ویرایش کنید.
-
-  [editor_done_dialog_2]
-    en = This is the second time you edited the map. Now you are number %d in the map editors ranking. Tell your friends about it.
-    ru = Вы улучшили карту уже два раза. Вы теперь %d в рейтинге редакторов карты. Расскажите друзьям.
-    ar = هذا هو تعديلك الثاني بالخريطة. أنت الآن في الترتيب رقم %d في قائمة محرري الخريطة. اخبر أصدقاءك عن ذلك.
-    cs = Toto je vaše druhé vylepšení mapy. Nyní jste na %d. místě na seznamu editorů map. Řekněte o tom svým kamarádům.
-    da = Dette er din anden kortforbedring. Nu er du på en %d. plads på listen over kortredaktører. Fortæl dine venner om det.
-    nl = Dit is je tweede kaartverbetering. Nu sta je op de %de plaats in de lijst van de kaartbewerkers. Vertel je vrienden erover.
-    fi = Tämä on toinen kerta, kun paransit karttaa. Nyt olet %d. sijalla kartan muokkaajien listalla. Kerro siitä ystävillesi.
-    fr = Ceci est votre seconde amélioration de carte. Vous êtes maintenant à la %de place dans la liste des éditeurs de cartes. Dites-le à vos amis.
-    de = Das ist Ihre zweite Kartenverbesserung. Sie befinden sich jetzt auf Platz %d auf der Liste der Personen, die die Karte bearbeitet haben. Erzählen Sie Ihren Freunden davon.
-    hu = Ez a második térképjavításod. Most már te is rajta vagy a térképszerkesztők listáján, az %d. helyen. Mesélj erről a barátaidnak is.
-    id = ini peningkatan peta kedua Anda. Sekarang Anda di tempat yang ke-%d di daftar editor peta. Katakan kepada teman-teman Anda tentang hal ini.
-    it = Questa è la tua seconda modifica alla mappa. Adesso sei al %d° posto nella lista di chi ha modificato la mappa. Dillo ai tuoi amici.
-    ja = これは2回目の地図改善。現在地図編集者リストで%d位です。
-    ko = 이는 두 번째 지도의 개선 사항입니다. 지금 지도 편집기의 목록에서 %d번째 장소에 있습니다. 친구들에게 이에 대해 말하십시오.
-    nb = Dette er din andre forbedring av kartet. Nå er du på %d. plass i listen av kart-forbedrere. Fortell vennene dine om dette.
-    pl = Po raz drugi dokonałeś poprawek na mapie. Aktualnie znajdujesz się na %d miejscu na liście osób edytujących mapy. Opowiedz o tym znajomym.
-    pt = Esta é a sua segunda melhoria ao mapa. Agora, está no %dº lugar na lista de editores de mapas. Fale disto aos seus amigos.
-    pt-BR = Esta é a sua segunda melhoria ao mapa. Agora está no %dº lugar na lista de editores de mapas. Fale disto aos seus amigos.
-    ro = Aceasta este a doua modificare a hărții. Acum sunteți pe locul %d în lista editorilor de hărți. Spuneți prietenilor dvs. despre aceasta.
-    es = Esta es tu segunda mejora del mapa. Ahora estás en el puesto %dº de la lista de editores de mapa. Cuéntaselo a tus amigos.
-    sv = Detta är din andra kartförbättring. Du är nu på plats %d i listan över kartredigerare. Berätta för dina vänner om det.
-    th = มันเป็นการปรับปรุงแผนที่ครั้งที่สองของคุณ ตอนนี้คุณอยู่ในอันดับที่ %d ของรายการผู้แก้ไขแผนที่ บอกให้เพื่อนคุณรู้
-    tr = Bu sizin ikinci harita iyileştirmeniz. Artık siz harita editörleri arasında %d. sıradasınız. Arkadaşlarınıza bunu anlatın.
-    uk = Це ваше друге поліпшення карти. Тепер ви на %d місці в списку редакторів карт. Розкажіть своїм друзям про це.
-    vi = Đây là lần nâng cấp bản đồ thứ hai của bạn. Giờ bạn xếp hạng %d trong các nhà hiệu chỉnh bản đồ. Hãy nói với các bạn khác về điều đó.
-    zh-Hans = 这是您的第二个地图改进。现在您在地图编辑者排行榜中排在第%d名。把它告诉您的朋友们。
-    zh-Hant = 這是您的第二次地圖改進。現在您在地圖編輯者排行榜中排在第%d名。把它告訴您的朋友們。
-    el = Αυτή είναι η δεύτερη φορά που επεξεργαστήκατε το χάρτη. Είστε πλέον %d στην κατάταξη των επεξεργαστών του χάρτη. Πείτε το στους φίλους σας.
-    sk = Toto je vaša druhá vylepšená mapa. Momentálne ste na %d. mieste zoznamu editorov máp. Povedzte o tom svojim priateľom.
-    fa = این دومین بار است که نقشه را ویرایش می کنید.اکنون شما شماره %d در رنکینگ ویرایشگران هستید.در موردش به دوستانتان بگویید.
-
-  [editor_done_dialog_3]
-    en = You’ve improved the map, tell your friends about it, and edit the map together.
-    ru = Вы улучшили карту, расскажите об этом друзьям и редактируйте карту вместе.
-    ar = لقد عدلت الخريطة، اخبر أصدقائك عن ذلك، وعدلوا الخريطة معا.
-    cs = Vylepšili jste mapu. Řekněte o tom svým kamarádům a upravujte mapu společně.
-    da = Du har forbedret kortet, fortæl dine venner om det og redigér kortet sammen.
-    nl = Je hebt de kaart verbeterd, vertel je vrienden erover en bewerk samen de kaart.
-    fi = Olet parantanut karttaa, kerro siitä ystävillesi ja muokatkaa karttaa yhdessä.
-    fr = Vous avez amélioré la carte, dites-le à vos amis et modifiez la carte ensemble.
-    de = Sie haben die Karte verbessert, erzählen Sie Ihren Freunden davon und bearbeiten Sie die Karte zusammen.
-    hu = Javítottál a térképen! Mondd el a barátaidnak is és szerkesszétek közösen!
-    id = Anda telah meningkatkan peta, katakan kepada teman-teman Anda tentang hal ini, dan edit peta bersama.
-    it = Hai migliorato la mappa. Dillo ai tuoi amici e modificate la mappa insieme.
-    ja = 地図を改善したので、友達に教えて一緒に編集しましょう。
-    ko = 지도를 개선했으며, 친구들에게 이에 대해 말하고, 함께 지도를 편집할 수 있습니다.
-    nb = Du har forbedret kartet, fortell vennene dine om det, og rediger kartet sammen.
-    pl = Dokonałeś poprawek na mapie. Opowiedz o tym znajomym i razem ją edytujcie.
-    pt = Melhorou o mapa, fale disto aos seus amigos e editem o mapa juntos.
-    pt-BR = Você melhorou o mapa, fale disto aos seus amigos e editem o mapa juntos.
-    ro = Ați modificat harta, spuneți prietenilor dvs. despre aceasta și modificați-o împreună.
-    es = Has mejorado el mapa: cuéntaselo a tus amigos y editadlo juntos.
-    sv = Du har förbättrat kartan, berätta för dina vänner om det och redigera kartan tillsammans.
-    th = คุณได้ปรับปรุงแผนที่ บอกให้เพื่อนคุณรู้ แล้วมาแก้ไขแผนที่ไปด้วยกัน
-    tr = Haritayı geliştirdiniz, arkadaşlarınıza bunu anlatın ve birlikte haritayı düzenleyin.
-    uk = Ви покращили карту, розкажіть своїм друзям про це і редагуйте її разом.
-    vi = Bạn đã nâng cấp bản đồ này, hãy cho các bạn khác biết và cùng nhau chỉnh sửa bản đồ.
-    zh-Hans = 您已改进此地图，请把它告诉您的朋友们，并一起编辑此地图。
-    zh-Hant = 您已改進此地圖，請把它告訴您的朋友們，並一起編輯此地圖。
-    sk = Práve ste vylepšili mapu. Povedzte o tom svojim priateľom a môžete mapu upraviť aj spolu.
-    fa = شما باعث بهتر شدن نقشه شدید در موردش به دوستانتان بگویید و با یکدیگر بر روی نقشه کار کنید.
+    sk = Zmenili ste mapu sveta. Nemusíte to skrývať! Povedzte o tom svojim priateľom a začnite ju spolu upravovať.
 
   [share_with_friends]
+    tags = ios, android
     en = Share with friends
     ru = Поделиться с друзьями
     ar = شارك مع الأصدقاء
@@ -12661,10 +8165,11 @@
     zh-Hans = 与朋友分享
     zh-Hant = 和朋友分享
     el = Μοιραστείτε με φίλους
-    sk = Zdieľaj s priateľmi
     fa = اشتراک گذاری با دوستان
+    sk = Zdieľaj s priateľmi
 
   [editor_report_problem_desription_1]
+    tags = android
     en = Please describe the problem in detail so that the OpenStreeMap community can fix the error.
     ru = Пожалуйста, напишите подробно о проблеме, чтобы сообщество OpenStreetMap исправило ошибку.
     ar = يرجى وصف المشكلة بالتفاصيل حتى يتسنى لفريق OpenStreeMap إصلاح الخطأ.
@@ -12693,10 +8198,11 @@
     zh-Hans = 请详细描述此问题以便OpenStreeMap社区能够修复此错误。
     zh-Hant = 請詳細描述此問題以便 OpenStreeMap 社群修復此錯誤。
     el = Περιγράψτε το πρόβλημα αναλυτικά ώστε η Κοινότητα OpenStreeMap να διορθώσει το σφάλμα.
-    sk = Prosím, pridajte detailný popis problému, aby mohla komunita OpenStreetMap opraviť danú chybu.
     fa = لطفا مشکلتان را با جزئیات توضیح دهید بطوری که انجمن OSM بتوانند ان را برطرف کنند.
+    sk = Prosím, pridajte detailný popis problému, aby mohla komunita OpenStreetMap opraviť danú chybu.
 
   [editor_report_problem_desription_2]
+    tags = android
     en = Or do it yourself at https://www.openstreetmap.org/
     ru = Или сделайте это самостоятельно на сайте https://www.openstreetmap.org/
     ar = أو افعل ذلك بنفسك من خلال الموقع https://www.openstreetmap.org/
@@ -12725,10 +8231,11 @@
     zh-Hans = 或者在https://www.openstreetmap.org/上亲自修复此错误。
     zh-Hant = 或者在https://www.openstreetmap.org/上親自修復此錯誤
     el = Ή κάντε το μόνοι σας στη διεύθυνση https://www.openstreetmap.org/
-    sk = K oprave môžete prispieť aj vy na stránke https://www.openstreetmap.org/
     fa = یا خودتان ان را انجام دهید در وبسایت https://www.openstreetmap.org/
+    sk = K oprave môžete prispieť aj vy na stránke https://www.openstreetmap.org/
 
   [editor_report_problem_send_button]
+    tags = ios, android
     en = Send
     ru = Отправить
     ar = إرسال
@@ -12757,10 +8264,11 @@
     zh-Hans = 发送
     zh-Hant = 發送
     el = Αποστολή
-    sk = Odoslať
     fa = ارسال
+    sk = Odoslať
 
   [editor_report_problem_title]
+    tags = android
     en = Issue
     ru = Проблема
     ar = مشكلة
@@ -12789,10 +8297,11 @@
     zh-Hans = 问题
     zh-Hant = 問題
     el = Πρόβλημα
-    sk = Problém
     fa = مشکل
+    sk = Problém
 
   [editor_report_problem_no_place_title]
+    tags = android
     en = The place does not exist
     ru = Места не существует
     ar = المكان غير موجودٍ
@@ -12821,10 +8330,11 @@
     zh-Hans = 该地点不存在
     zh-Hant = 該地點不存在
     el = Η τοποθεσία δεν υπάρχει
-    sk = Dané miesto neexistuje
     fa = مکان وجود ندارد
+    sk = Dané miesto neexistuje
 
   [editor_report_problem_under_construction_title]
+    tags = android
     en = Сlosed for maintenance
     ru = Закрыто на ремонт
     ar = مغلق للصيانة
@@ -12853,10 +8363,11 @@
     zh-Hans = 因维护而关闭
     zh-Hant = 因維護而關閉
     el = Εκτός λειτουργίας για συντήρηση
-    sk = Zatvorené kvôli prebiehajúcej údržbe
     fa = به علت تعمییرات بسته است
+    sk = Zatvorené kvôli prebiehajúcej údržbe
 
   [editor_report_problem_duplicate_place_title]
+    tags = android
     en = Duplicated place
     ru = Повторяющееся место
     ar = مكان متكرر
@@ -12885,170 +8396,8 @@
     zh-Hans = 重复的地点
     zh-Hant = 重複的地點
     el = Διπλότυπη τοποθεσία
-    sk = Duplicitné miesto
     fa = مکان تکراری
-
-  [first_launch_congrats_title]
-    en = Organic Maps is ready to use
-    ru = Organic Maps готов к работе
-    ar = Organic Maps جاهز للاستخدام
-    cs = Organic Maps jsou připraveny k použití
-    da = Organic Maps er klart til brug
-    nl = Organic Maps is klaar voor gebruik
-    fi = Organic Maps on valmiina käyttöön
-    fr = Organic Maps est prêt à l'utilisation
-    de = Organic Maps kann verwendet werden
-    hu = A Organic Maps használatra készen áll
-    id = Organic Maps siap digunakan
-    it = Organic Maps è pronto per essere usato
-    ja = Organic Mapsを使用する準備が整いました
-    ko = Organic Maps를 사용할 준비가 완료되었습니다
-    nb = Organic Maps er klar til bruk
-    pl = Aplikacja Organic Maps jest gotowa
-    pt = Organic Maps está pronto para utilização
-    pt-BR = Organic Maps está pronto para ser usado
-    ro = Organic Maps este gata pentru utilizare
-    es = Organic Maps está listo para usar
-    sv = Du kan nu använda Organic Maps
-    th = Organic Maps พร้อมใช้งานแล้ว
-    tr = Organic Maps kullanıma hazır
-    uk = Organic Maps готовий до роботи
-    vi = Organic Maps đã sẵn sàng để sử dụng
-    zh-Hans = Organic Maps已经可用
-    zh-Hant = Organic Maps 已做好使用準備
-    el = Το Organic Maps είναι έτοιμο για χρήση
-    sk = Aplikácia Organic Maps je pripravená na použitie
-    fa = Organic Maps اماده استفاده است
-
-  [first_launch_congrats_text]
-    en = Search and navigate everywhere in the world offline, free of charge.
-    ru = Пользуйтесь поиском и навигацией по всему миру без интернета и бесплатно.
-    ar = ابحث وتصفح كل مكان في العالم بدون اتصال, مجانا.
-    cs = Prohledávejte a navigujte offline zdarma kdekoliv na světě.
-    da = Søg og navigér i kort over alle verdens lande gratis.
-    nl = Zoek en navigeer overal ter wereld offline, gratis.
-    fi = Etsi ja navigoi ympäri maailman ilman verkkoyhteyttä, ilmaiseksi.
-    fr = Cherchez et trouvez la bonne direction partout dans le monde, en mode hors-connexion, gratuitement.
-    de = Suche und Navigation weltweit offline verfügbar, völlig kostenfrei.
-    hu = Keress és navigálj offline a világon mindenhol, térítésmentesen.
-    id = Cari dan bernavigasilah ke mana saja di dunia secara offline, bebas biaya.
-    it = Cerca e naviga offline, ovunque ti trovi nel mondo, gratis.
-    ja = 世界中どこでも無料で検索・ナビゲーションできます。
-    ko = 무료로 세계 어디에서나 오프라인으로 검색하고 탐색할 수 있습니다.
-    nb = Søk og naviger i frakoblet status, hvor som helst i verden, helt gratis.
-    pl = Wyszukuj i nawiguj w każdym zakątku świata — offline i bezpłatnie.
-    pt = Busque qualquer lugar do mundo e navegue offline, gratuitamente.
-    pt-BR = Busque qualquer lugar do mundo e navegue offline, gratuitamente.
-    ro = Căutați și navigați în regim offline oriunde în lume, în mod gratuit.
-    es = Busca y navega sin conexión por cualquier parte del mundo, sin cargos.
-    sv = Sök och navigera offline var som helst i världen, helt gratis.
-    th = ค้นหาและนำทางไปทุกที่ในโลกแบบออฟไลน์ ไม่มีค่าใช้จ่าย
-    tr = Dünyanın her yerinde çevrimdışı olarak ücretsiz arama yapın ve gezinin.
-    uk = Користуйтесь пошуком і навігацією по всьому світу без інтернету і безкоштовно.
-    vi = Tìm kiếm và điều hướng ngoại tuyến, miễn phí khắp mọi nơi trên thế giới.
-    zh-Hans = 在世界各地离线搜索和导航，免费。
-    zh-Hant = 在世界各地離線搜尋和導航，免費。
-    el = Κάντε αναζήτηση και πλοηγηθείτε παντού στον κόσμο χωρίς σύνδεση και χωρίς χρέωση.
-    sk = Vyhľadávajte a určujte trasu bez pripojenia všade na svete bez poplatkov.
-    fa = در سرتاسر دنیا جست وجو و مسیریابی کنید بدون نیاز به اینترنت و کاملا رایگان.
-
-  [migrate_title]
-    tags = ios, android
-    en = Important!
-    ru = Важно!
-    ar = هام!
-    cs = Důležité!
-    da = Vigtigt!
-    nl = Belangrijk!
-    fi = Tärkeää!
-    fr = Important !
-    de = Wichtig!
-    hu = Fontos!
-    id = Penting!
-    it = Importante!
-    ja = 重要！
-    ko = 중요!
-    nb = Viktig!
-    pl = Ważne!
-    pt = Importante!
-    pt-BR = Importante!
-    ro = Important!
-    es = ¡Importante!
-    sv = Viktigt!
-    th = สำคัญ!
-    tr = Önemli!
-    uk = Важливо!
-    vi = Quan trọng!
-    zh-Hans = 重要！
-    zh-Hant = 重要！
-    el = Σημαντικό!
-    sk = Dôležité!
-    fa = مهم!
-
-  [download_all]
-    comment = Android uses image instead of text.
-    tags = ios
-    en = Download all
-    ru = Загрузить все
-    ar = تنزيل الكل
-    cs = Stáhnout vše
-    da = Download alle
-    nl = Alles downloaden
-    fi = Lataa kaikki
-    fr = Tout télécharger
-    de = Alle herunterladen
-    hu = Összes letöltése
-    id = Unduh semua
-    it = Scarica tutto
-    ja = 全てをダウンロード
-    ko = 모두 다운로드
-    nb = Last ned alle
-    pl = Pobierz wszystko
-    pt = Descarregar tudo
-    pt-BR = Baixar tudo
-    ro = Descarcă toate
-    es = Descargar todos
-    sv = Ladda ner alla
-    th = ดาวน์โหลดทั้งหมด
-    tr = Tümünü indir
-    uk = Завантажити всі
-    vi = Tải về tất cả
-    zh-Hans = 下载所有
-    zh-Hant = 全部下載
-    sk = Stiahnuť všetko
-    fa = دانلود همه
-
-  [delete_all]
-    tags = ios, android
-    en = Delete all
-    ru = Удалить все
-    ar = حذف الكل
-    cs = Odstranit vše
-    da = Slet alle
-    nl = Alles verwijderen
-    fi = Poista kaikki
-    fr = Supprimer tout
-    de = Alle löschen
-    hu = Összes térkép törlése
-    id = Hapus semua
-    it = Elimina tutti
-    ja = すべて削除
-    ko = 모두 삭제
-    nb = Slett alle
-    pl = Usuń wszystkie
-    pt = Excluir todos
-    pt-BR = Excluir todos
-    ro = Ștergere toate
-    es = Eliminar todos
-    sv = Radera alla
-    th = ลบทั้งหมด
-    tr = Tümünü sil
-    uk = Видалити всі
-    vi = Xóa tất cả
-    zh-Hans = 删除全部
-    zh-Hant = 刪除全部
-    sk = Vymazať všetky
-    fa = حذف همه
+    sk = Duplicitné miesto
 
   [autodownload]
     tags = ios, android
@@ -13080,44 +8429,12 @@
     zh-Hans = 自动下载
     zh-Hant = 自動下載
     el = Αυτόματη λήψη
-    sk = Automaticky stiahnuť
     fa = دانلود خودکار
-
-  [disable_autodownload]
-    tags = ios, android
-    en = Disable autodownload
-    ru = Запретить автозагрузку
-    ar = تعطيل التنزيل التلقائي
-    cs = Zakázat automatické stahování
-    da = Deaktiver automatisk download
-    nl = Automatisch downloaden uitschakelen
-    fi = Poista käytöstä automaattinen lataus
-    fr = Désactiver téléchargement automatique
-    de = Automatischen Download deaktivieren
-    hu = Automatikus letöltés tiltása
-    id = Nonaktifkan unduh otomatis
-    it = Disattiva download automatico
-    ja = 自動ダウンロードを無効にする
-    ko = 자동 다운로드 해제
-    nb = Deaktiver automatisk nedlasting
-    pl = Wyłącz automatyczne pobieranie
-    pt = Desativar o download automático
-    pt-BR = Desativar o download automático
-    ro = Dezactivare descărcare automată
-    es = Desactivar descarga automática
-    sv = Avaktivera automatisk nedladdning
-    th = หยุดการดาวน์โหลดแบบอัตโนมัติ
-    tr = Otomatik indirmeyi devre dışı bırak
-    uk = Заборонити автозавантаження
-    vi = Tắt chế độ tự động tải xuống
-    zh-Hans = 禁用自动下载
-    zh-Hant = 停用自動下載
-    sk = Zrušiť automatické preberanie
-    fa = لغو دانلود خودکار
+    sk = Automaticky stiahnuť
 
   [closed_now]
     comment = Place Page opening hours text
-    tags = ios, android
+    tags = ios
     en = Closed now
     ru = Сейчас закрыто
     ar = مغلق الآن
@@ -13146,8 +8463,8 @@
     zh-Hans = 现在关门
     zh-Hant = 現在關門
     el = Τώρα είναι κλειστό
-    sk = Teraz zatvorené
     fa = اکنون تعطیل است
+    sk = Teraz zatvorené
 
   [daily]
     comment = Place Page opening hours text
@@ -13180,8 +8497,8 @@
     zh-Hans = 每天
     zh-Hant = 每天
     el = Καθημερινά
-    sk = Denne
     fa = روزانه
+    sk = Denne
 
   [twentyfour_seven]
     tags = ios, android
@@ -13213,9 +8530,9 @@
     zh-Hans = 白天和黑夜
     zh-Hant = 全天候
     el = 24/7
+    fa = شبانه روزی
     he = יום ולילה
     sk = Deň a noc
-    fa = شبانه روزی
 
   [day_off_today]
     tags = ios, android
@@ -13247,11 +8564,11 @@
     zh-Hans = 今天没有营业
     zh-Hant = 今天沒有營業
     el = Κλειστό σήμερα
-    sk = Dnes deň voľna
     fa = امروز تعطیل است
+    sk = Dnes deň voľna
 
   [day_off]
-    tags = ios, android
+    tags = ios
     en = Closed
     ru = Закрыто
     ar = مغلق
@@ -13280,8 +8597,8 @@
     zh-Hans = 没有营业
     zh-Hant = 沒有營業
     el = Κλειστό
-    sk = Deň voľna
     fa = تعطیل است
+    sk = Deň voľna
 
   [today]
     tags = ios, android
@@ -13313,75 +8630,11 @@
     zh-Hans = 今天
     zh-Hant = 今天
     el = Σήμερα
-    sk = Dnes
     fa = امروز
-
-  [sunrise_to_sunset]
-    tags = ios, android
-    en = From sunrise to sunset
-    ru = От рассвета до заката
-    ar = من الشروق إلى المغيب
-    cs = Od úsvitu do soumraku
-    da = Fra solopgang til solnedgang
-    nl = Van zonsopgang tot zonsondergang
-    fi = Auringonnoususta auringonlaskuun
-    fr = Du lever au coucher du soleil
-    de = Von Sonnenauf- bis Sonnenuntergang
-    hu = Napkeltétől napnyugtáig
-    id = Dari matahari terbit sampai matahari terbenam
-    it = Dall'alba al tramonto
-    ja = 日の出から日没まで
-    ko = 일출에서 일몰로
-    nb = Fra morgen til kveld
-    pl = Od wschodu do zachodu słońca
-    pt = Do amanhecer ao anoitecer
-    pt-BR = Do amanhecer ao pôr do sol
-    ro = De la răsărit până la apus
-    es = Del amanecer al atardecer
-    sv = Från gryning till skymning
-    th = ตั้งแต่พระอาทิตย์ขึ้นจนพระอาทิตย์ตก
-    tr = Güneşin doğuşundan batışına kadar
-    uk = Від світанку до заходу
-    vi = Từ bình minh đến hoàng hôn
-    zh-Hans = 从日出到日落
-    zh-Hant = 從日出到日落
-    sk = Od východu do západu slnka
-    fa = از طلوع خورشید تا غروب افتاب
-
-  [sunset_to_sunrise]
-    tags = ios, android
-    en = From sunset to sunrise
-    ru = От заката до рассвета
-    ar = من غروب الشمس وحتى الشروق
-    cs = Od západu do východu slunce
-    da = Fra solnedgang til solopgang
-    nl = Van zonsondergang tot zonsopgang
-    fi = Auringonnoususta auringonlaskuun
-    fr = Du coucher au lever du soleil
-    de = Von Sonnenuntergang bis Sonnenaufgang
-    hu = Napkeltétől napnyugtáig
-    id = Dari matahari terbenam sampai matahari terbit
-    it = Dal tramonto all'alba
-    ja = 日の出から日没まで
-    ko = 일출에서 일몰까지
-    nb = Fra solnedgang til soloppgang
-    pl = Od zachodu do wschodu słońca
-    pt = Do pôr do sol ao amanhecer
-    pt-BR = Do pôr do sol ao amanhecer
-    ro = De la apus până la răsărit
-    es = Del amanecer al anochecer
-    sv = Från soluppgång till solnedgång
-    th = ตั้งแต่พระอาทิตย์ตกจนพระอาทิตย์ขึ้น
-    tr = Gün doğumundan gün batımına
-    uk = Від заходу до світанку
-    vi = Từ hoàng hôn đến bình minh
-    zh-Hans = 从日落到日出
-    zh-Hant = 從日落到日出
-    sk = Od západu do východu slnka
-    fa = از غروب خورشید تا طلوع خورشید
+    sk = Dnes
 
   [add_opening_hours]
-    tags = ios, android
+    tags = ios
     en = Add opening hours
     ru = Добавить время работы
     ar = اضف ساعات عمل
@@ -13410,11 +8663,11 @@
     zh-Hans = 添加工作时间
     zh-Hant = 新增營業時間
     el = Προσθέστε ώρες λειτουργίας
-    sk = Pridať otváracie hodiny
     fa = اضافه کردن ساعت بازگشایی
+    sk = Pridať otváracie hodiny
 
   [edit_opening_hours]
-    tags = ios, android
+    tags = android
     en = Edit business hours
     ru = Редактировать время работы
     ar = حرر ساعات عمل
@@ -13443,8 +8696,8 @@
     zh-Hans = 编辑工作时间
     zh-Hant = 編輯營業時間
     el = Επεξεργαστείτε τις ώρες λειτουργίας
-    sk = Upraviť otváracie hodiny
     fa = ویرایش ساعت کاری
+    sk = Upraviť otváracie hodiny
 
   [no_osm_account]
     tags = ios, android
@@ -13476,8 +8729,8 @@
     zh-Hans = OpenStreetMap上没有账户吗？
     zh-Hant = 沒有 OpenStreeMap 帳號嗎？
     el = Δεν έχετε λογαριασμό OpenStreetMap;
-    sk = Nemáte účet v OpenStreetMap?
     fa = ایا حساب OpenStreetMap ندارید؟
+    sk = Nemáte účet v OpenStreetMap?
 
   [register_at_openstreetmap]
     tags = ios, android
@@ -13509,11 +8762,11 @@
     zh-Hans = 注册
     zh-Hant = 註冊
     el = Εγγραφείτε στο OpenStreetMap
-    sk = Zaregistrovať sa
     fa = ثبت نام در OpenStreetMap
+    sk = Zaregistrovať sa
 
   [password_8_chars_min]
-    tags = ios, android
+    tags = ios
     en = Password (8 characters minimum)
     ru = Пароль (минимум 8 символов)
     ar = كلمة المرور (8 أحرف بحد أدنى)
@@ -13542,11 +8795,11 @@
     zh-Hans = 密码（最少8个字符）
     zh-Hant = 密碼（最少8個字母）
     el = Κωδικός πρόσβασης (8 χαρακτήρες ελάχιστο)
-    sk = Heslo (8 minimálne znakov)
     fa = رمز عبور (حداقل 8 عدد یا حرف)
+    sk = Heslo (8 minimálne znakov)
 
   [invalid_username_or_password]
-    tags = ios, android
+    tags = ios
     en = Invalid username or password.
     ru = Неверное имя пользователя или пароль.
     ar = اسم المستخدم أو كلمة المرور غير صالحة.
@@ -13575,8 +8828,8 @@
     zh-Hans = 无效的用户名或密码。
     zh-Hant = 無效的使用者名稱或密碼。
     el = Μη έγκυρο όνομα χρήστη ή κωδικός πρόσβασης.
-    sk = Nesprávne používateľské meno alebo heslo.
     fa = نام کاربری یا رمز عبور نامعتبر است.
+    sk = Nesprávne používateľské meno alebo heslo.
 
   [login]
     tags = ios, android
@@ -13608,11 +8861,11 @@
     zh-Hans = 登录
     zh-Hant = 登入
     el = Σύνδεση
-    sk = Prihlásiť sa
     fa = ورود
+    sk = Prihlásiť sa
 
   [password]
-    tags = ios, android
+    tags = android
     en = Password
     ru = Пароль
     ar = كلمة المرور
@@ -13641,8 +8894,8 @@
     zh-Hans = 密码
     zh-Hant = 密碼
     el = Κωδικός πρόσβασης
-    sk = Heslo
     fa = رمز عبور
+    sk = Heslo
 
   [forgot_password]
     tags = ios, android
@@ -13674,140 +8927,11 @@
     zh-Hans = 忘记密码
     zh-Hant = 忘記密碼
     el = Ξαχάσατε τον κωδικό πρόσβασης;
-    sk = Zabudli ste heslo?
     fa = رمز عبور خود را فراموش کردید؟
-
-  [restore_password]
-    comment = Forgot Password dialog title
-    tags = ios, android
-    en = Restore password
-    ru = Восстановление пароля
-    ar = استعادة كلمة المرور
-    cs = Obnovit heslo
-    da = Genopret adgangskode
-    nl = Wachtwoord herstellen
-    fi = Palauta salasana
-    fr = Réinitialiser le mot de passe
-    de = Passwort wiederherstellen
-    hu = Jelszó visszaállítása
-    id = Pulihkan kata sandi
-    it = Ripristina password
-    ja = パスワードを復元
-    ko = 암호 복원
-    nb = Gjenopprett passordet
-    pl = Przypomnij hasło
-    pt = Recuperar senha
-    pt-BR = Recuperar senha
-    ro = Recuperare parolă
-    es = Restaurar contraseña
-    sv = Återställ lösenord?
-    th = เรียกคืนรหัสผ่าน
-    tr = Şifreyi yenile
-    uk = Відновити пароль
-    vi = Khôi phục mật khẩu
-    zh-Hans = 恢复密码
-    zh-Hant = 恢復密碼
-    sk = Obnovenie hesla
-    fa = بازیابی رمز عبور
-
-  [enter_email_address_to_reset_password]
-    tags = ios, android
-    en = Enter the email address you used during registration and we will send you the link to reset your password.
-    ru = Введите почтовый ящик, который вы использовали для регистрации, и мы вышлем на него ссылку для сброса пароля.
-    ar = أدخل عنوان البريد الإلكتروني الذي استخدمته عند التسجيل وسنرسل لك رابط لتجديد كلمة المرور
-    cs = Zadejte emailovou adresu, kterou jste používali během registrace a my Vám pošleme odkaz, abyste mohli obnovit svoje heslo.
-    da = Indtast den emailadresse du anvendte under tilmelding, så sender vi dig linket til at forny din adgangskode.
-    nl = Voer het emailadres in dat u heeft gebruikt tijdens de registratie, dan sturen wij u de link om uw wachtwoord te vernieuwen.
-    fi = Syötä rekisteröitymisessä käyttämäsi sähköpostiosoite, niin lähetämme sinulle linkin salasanasi vaihtamista varten.
-    fr = Entrez l'adresse email que vous avez utilisé lors de l'inscription et nous vous ferons parvenir le lien pour renouveler votre mot de passe.
-    de = Geben Sie bitte die Email-Adresse ein, die Sie zur Registrierung verwendet haben. Wir senden Ihnen dann den Link zur Erneuerung Ihres Passworts.
-    hu = Add meg a regisztrációkor használt email-címedet és elküldjük neked a jelszavad megújításához szükséges linket.
-    id = Masukkan alamat surek yang Anda gunakan pada saat pendaftaran dan kami akan mengirim tautan untuk memperbarui kata sandi Anda.
-    it = Inserisci l'indirizzo email utilizzato durante la registrazione e ti invieremo un link per recuperare la password.
-    ja = 登録の際に使用したメールアドレスを入力してください。パスワードを更新するリンクをお送りします。
-    ko = 등록시 사용한 이메일 주소를 입력하면 암호를 갱신하도록 링크를 전송할 것입니다.
-    nb = Skriv inn e-postadressen du brukte ved registreringen, så vil vi sende deg en kobling for å fornye passordet ditt.
-    pl = Wpisz adres email, którego użyto podczas rejestracji, a prześlemy Ci link do ponownego utworzenia hasła.
-    pt = Digite o endereço de email que você usou ao cadastrar-se, e nós lhe enviaremos o link para redefinir a sua senha.
-    pt-BR = Digite o endereço de email que você usou ao se cadastrar, e nós enviaremos o link para redefinir a sua senha.
-    ro = Introduceți adresa de email pe care ați utilizat-o în momentul înregistrării, iar noi vă vom trimite link-ul pentru a vă reînnoi parola.
-    es = Introduce la dirección de correo electrónico que utilizaste durante el registro y te enviaremos el enlace para restaurar tu contraseña.
-    sv = Mata in e-postadressen som du använde vid registrering så skickar vi en återställningslänk till dig.
-    th = ใส่ที่อยู่อีเมลที่คุณใช้ระหว่างการลงทะเบียนแล้วเราจะส่งลิงก์ไปยังคุณเพื่อต่ออายุรหัสผ่านของคุณ
-    tr = Kayıt sırasında kullandığınız e-posta adresini girin ve şifrenizi yenileyeceğiniz bağlantıyı gönderelim.
-    uk = Введіть адресу ел. пошти, яку ви використали під час реєстрації і ми надішлемо вам посилання для відновлення паролю.
-    vi = Nhập địa chỉ email bạn đã sử dụng trong quá trình đăng ký và chúng tôi sẽ gửi cho bạn liên kết để tạo mới mật khẩu của bạn.
-    zh-Hans = 输入您在注册时所用的邮箱地址，我们会给您发送链接更新密码
-    zh-Hant = 輸入您在註冊時所用的電子郵件地址，我們會發送連結給您更新密碼
-    sk = Zadajte emailovú adresu, ktorú ste použili pri registrácii, a my Vám zašleme odkaz na obnovenie hesla.
-    fa = ادرس ایمیلی را که در هنگام ثبت نام استفاده کردید را وارد کنید و ما برای شما لینک بازیابی رمز عبور را خواهیم فرستاد.
-
-  [reset_password]
-    tags = ios, android
-    en = Reset Password
-    ru = Cбросить пароль
-    ar = إعادة تعيين كلمة المرور
-    cs = Resetovat heslo
-    da = Nulstil adgangskode
-    nl = Wachtwoord resetten
-    fi = Aseta salasana uudelleen
-    fr = Réinitialiser le mot de passe
-    de = Passwort zurücksetzen
-    hu = Jelszó visszaállítása
-    id = Atur ulang kata sandi
-    it = Reimpostare password
-    ja = パスワードをリセット
-    ko = 비밀번호 재 설정
-    nb = Tilbakestill passord
-    pl = Resetuj hasło
-    pt = Redefinir senha
-    pt-BR = Redefinir senha
-    ro = Resetare parolă
-    es = Restablecer contraseña
-    sv = återställ lösenord
-    th = ตั้งรหัสผ่านใหม่
-    tr = Parolayı sıfırla
-    uk = Змінити пароль
-    vi = đặt lại mật khẩu
-    zh-Hans = 重置密码
-    zh-Hant = 重置密碼
-    sk = Obnoviť heslo
-    fa = بازیابی رمز عبور
-
-  [username]
-    tags = ios, android
-    en = Username
-    ru = Имя пользователя
-    ar = اسم المستخدم
-    cs = Uživatelské jméno
-    da = Brugernavn
-    nl = Gebruikersnaam
-    fi = Käyttäjänimi
-    fr = Nom d'utilisateur
-    de = Benutzername
-    hu = Felhasználónév
-    id = Nama pengguna
-    it = Nome utente
-    ja = ユーザー名
-    ko = 사용자 이름
-    nb = Brukernavn
-    pl = Nazwa użytkownika
-    pt = Nome de usuário
-    pt-BR = Nome de usuário
-    ro = Nume de utilizator
-    es = Usuario
-    sv = Användarnamn
-    th = ชื่อผู้ใช้
-    tr = Kullanıcı Adı
-    uk = Ім'я користувача
-    vi = Tên đăng nhập
-    zh-Hans = 用户名
-    zh-Hant = 使用者名稱
-    sk = Používateľské meno
-    fa = نام کاربری
+    sk = Zabudli ste heslo?
 
   [osm_account]
-    tags = ios, android
+    tags = ios
     en = OSM Account
     ru = OSM Аккаунт
     ar = حساب OSM
@@ -13836,8 +8960,8 @@
     zh-Hans = OSM账户
     zh-Hant = OSM 帳號
     el = `Λογαριασμός OSM  `
-    sk = OSM účet
     fa = حساب OSM
+    sk = OSM účet
 
   [logout]
     tags = ios, android
@@ -13869,44 +8993,12 @@
     zh-Hans = 登出
     zh-Hant = 登出
     el = Αποσύνδεση
-    sk = Odhlásiť sa
     fa = خروج از حساب
-
-  [login_and_edit_map_motivation_message]
-    tags = ios, android
-    en = Log in and edit objects on the map, and we will make them available for millions of users. Let’s make the world better together.
-    ru = Авторизуйтесь и редактируйте информацию об объектах на карте. А мы сделаем её доступной для миллионов пользователей. Улучшим мир вместе!
-    ar = قم بتسجيل الدخول وعدل البيانات الخاصة بالمكان على الخريطة وسنجعلها متاحة لملايين المستخدمين الآخرين. لنجعل العالم أفضل معا.
-    cs = Přihlaste se a editujte informace o objektech na mapě a my je zpřístupníme miliónům dalších uživatelů. Udělejme společně svět dokonalejším místem.
-    da = Log ind og rediger oplysninger for objekter på kortet, så sørger vi for, at de er tilgængelige for millioner af andre brugere. Lad os sammen gøre verden bedre.
-    nl = Log in en bewerk gegevens van de objecten op de kaart, dan zullen wij ze beschikbaar maken voor miljoenen andere gebruikers. Laten we samen de wereld beter maken.
-    fi = Kirjaudu sisään ja muokkaa kartan kohteiden tietoja, ja me asetamme kohteet miljoonien muiden käyttäjien saataville. Tehdään maailmasta yhdessä parempi paikka.
-    fr = Connectez-vous et modifiez les informations des objets présents sur la carte et nous allons les rendre disponibles pour des millions d'autres utilisateurs. Rendons le monde meilleur ensemble.
-    de = Anmelden und Informationen zu den Objekten auf der Karte bearbeiten. Wir werden sie für Millionen von anderen Nutzern verfügbar machen. Lassen Sie uns zusammen die Welt verbessern.
-    hu = Jelentkezz be és szerkeszd az egyes objektumokhoz tartozó információkat a térképen, valamint tedd őket elérhetővé több millió felhasználó számára.
-    id = Masuk dan sunting informasi objek pada peta dan kami akan membuatnya tersedia bagi jutaan pengguna lain. Mari kita menjadikan dunia lebih baik bersama-sama.
-    it = Accedi e modifica le informazioni degli oggetti sulla mappa e noi provvederemo a renderli disponibili a milioni di altri utenti. Creiamo un mondo migliore assieme.
-    ja = ログインしてマップ上のオブジェクトの詳細を編集すると、何百万人もの他のユーザーがその情報を利用できるようになります。一緒により良い世界を作りましょう。
-    ko = 로그인하고 지도 상의 개체 정보를 편집하면 다른 수백만 명의 사용자가 사용할 수 있도록 하겠습니다. 함께 더 나은 세상으로 만들어 봅시다.
-    nb = Logg deg inn og rediger informasjonen til objektene på kartet, så vil vi gjøre den tilgjengelig for millioner av andre brukere. La oss gjøre verden bedre sammen.
-    pl = Zaloguj się i edytuj dane obiektów na mapie, a my udostępnimy je milionom innych użytkowników. Razem możemy poprawić świat.
-    pt = Acesse e edite informações dos objetos no mapa e eles serão disponibilizados para milhões de outros usuários. Vamos melhorar o mundo juntos.
-    pt-BR = Acesse e edite informações dos objetos no mapa e eles serão disponibilizados para milhões de outros usuários. Vamos melhorar o mundo juntos.
-    ro = Autentificați-vă și editați informația despre obiectele de pe hartă, iar noi le vom face disponibile pentru milioane de alți utilizatori. Să facem împreună lumea mai bună.
-    es = Inicia sesión y edita la información de los objetos en el mapa y los pondremos a disposición de millones de otros usuarios. Hagamos de este mundo un lugar mejor.
-    sv = Logga in och redigera informationen om objekten på kartan så kommer vi att göra ändringarna tillgängliga för miljontals andra användare. Låt oss göra världen bättre tillsammans.
-    th = ล็อกอินและแก้ไขข้อมูลวัตถุบนแผนที่ และเราจะทำให้มันสามารถใช้งานได้สำหรับผู้ใช้ท่านอื่น ๆ อีกนับล้าน มาช่วยกันทำให้โลกดียิ่งขึ้นร่วมกัน
-    tr = Oturum aç ve haritada nesne bilgilerini düzenleyip diğer milyonlarca kullanıcıya aç. Birlikte dünyayı daha iyi bir yer haline getirelim.
-    uk = Увійдіть та редагуйте інформацію про об'єкти на карті, і ми зробимо їх доступними для мільйонів інших користувачів. Давайте зробимо світ кращим разом.
-    vi = Đăng nhập và chỉnh sửa thông tin của các đối tượng trên bản đồ và chúng tôi sẽ hiển thị chúng cho hàng triệu người dùng khác. Hãy cùng nhau làm cho thế giới tốt đẹp hơn.
-    zh-Hans = 登录并编辑地图上的物品信息，我们就会让数百万其他用户看到。
-    zh-Hant = 登錄並編輯地圖上的物件資訊，我們就會讓其他數百萬用戶看到。
-    sk = Prihláste sa a upravte informácie o objektoch na mape, a my ich sprístupníme miliónom ďalších používateľov. Urobme svet spoločne lepším.
-    fa = وارد شوید و اشیا درون نقشه را ویرایش کنید و ما ان را برای میلیون ها کاربر مهیا می کنیم.بزن بریم و یه دنیای بهتر با هم بسازیم.
+    sk = Odhlásiť sa
 
   [last_upload]
     comment = Information text: "Last upload 11.01.2016"
-    tags = ios, android
+    tags = ios
     en = Last upload
     ru = Последняя отправка
     ar = آخر تحميل
@@ -13935,41 +9027,8 @@
     zh-Hans = 上次上传
     zh-Hant = 上次上傳
     el = Τελευταία μεταφόρτωση
-    sk = Posledné nahrávanie
     fa = اخرین بروزرسانی
-
-  [you_have_edited_your_first_object]
-    comment = Motivates user to login/register, title above login buttons.
-    tags = ios, android
-    en = You’ve edited your first object!
-    ru = Вы отредактировали свой первый объект!
-    ar = لقد قمت بتعديلك الأول!
-    cs = Editovali jste svůj první objekt!
-    da = Du har redigeret dit første objekt!
-    nl = Je hebt je eerste object aangepast!
-    fi = Olet muokannut ensimmäistä kohdettasi!
-    fr = Vous avez modifié votre premier objet!
-    de = Sie haben Ihr erstes Objekt bearbeitet!
-    hu = Szerkesztetted az első objektumod!
-    id = Anda menyunting objek pertama Anda!
-    it = Hai modificato il tuo primo oggetto!
-    ja = 初めてオブジェクトを編集しました！
-    ko = 로그인하고 전 세계 수백만 사람들을 위해 변화를 더하십시오!
-    nb = Du har redigert ditt første objekt!
-    pl = Edycja Twojego pierwszego obiektu zakończona!
-    pt = Você editou o seu primeiro objeto!
-    pt-BR = Você editou o seu primeiro objeto!
-    ro = Ați editat primul dvs. obiect!
-    es = ¡Has editado tu primer objeto!
-    sv = Du har redigerat ditt första objekt!
-    th = คุณได้แก้ไขวัตถุแรกของคุณ!
-    tr = İlk nesneni düzenledin!
-    uk = Ви редагували свій перший об'єкт!
-    vi = Bạn đã chỉnh sửa đối tượng đầu tiên của mình!
-    zh-Hans = 您已编辑您的第一件物品！
-    zh-Hant = 您已編輯您的第一個物件！
-    sk = Upravili ste svoj prvý objekt!
-    fa = شما اولین ویرایشتان را انجام دادید!
+    sk = Posledné nahrávanie
 
   [thank_you]
     tags = ios, android
@@ -14001,72 +9060,8 @@
     zh-Hans = 谢谢您
     zh-Hant = 謝謝您
     el = Σας ευχαριστούμε
-    sk = Ďakujeme Vám
     fa = متشکریم
-
-  [login_with_google]
-    tags = ios, android
-    en = Login with Google
-    ru = Войти через Google
-    ar = تسجيل الدخول عبر جوجل
-    cs = Přihlásit se pomocí účtu Google
-    da = Log ind med Google
-    nl = Aanmelden met Google
-    fi = Kirjaudu sisään Google-tunnuksillasi
-    fr = Connectez-vous avec Google
-    de = Mit Google anmelden
-    hu = Bejelentkezés Google- vel
-    id = Masuk menggunakan Google
-    it = Accedi con Google
-    ja = Googleでログイン
-    ko = Google로 로그인
-    nb = Logg inn med Google
-    pl = Zaloguj się przez Google
-    pt = Entrar com Google
-    pt-BR = Entrar com Google
-    ro = Logați-vă cu contul de Google
-    es = Iniciar sesión con Google
-    sv = Logga in med Google
-    th = ล็อกอินด้วย Google
-    tr = Google ile giriş
-    uk = Увійти за допомогою Google
-    vi = Đăng nhập với Google
-    zh-Hans = 用谷歌登陆
-    zh-Hant = 用 Google 登入
-    sk = Prihlásiť sa cez Google
-    fa = ورود با حساب گوگل
-
-  [login_with_openstreetmap]
-    tags = ios, android
-    en = Log in with www.openstreetmap.org
-    ru = Войти через www.openstreetmap.org
-    ar = قم بتسجيل الدخول في www.openstreetmap.org
-    cs = Přihlásit se pomocí účtu www.openstreetmap.org
-    da = Log ind med www.openstreetmap.org
-    nl = Aanmelden met www.openstreetmap.org
-    fi = Kirjaudu sisään osoitteessa www.openstreetmap.org
-    fr = Connectez-vous sur www.openstreetmap.org
-    de = Mit www.openstreetmap.org anmelden
-    hu = Jelentkezz be a www.openstreetmap.org oldalon
-    id = Masuk menggunakan www.openstreetmap.org
-    it = Accedi con www.openstreetmap.org
-    ja = www.openstreetmap.orgでログインしてください
-    ko = www.openstreetmap.org에 로그인
-    nb = Logg inn med www.openstreetmap.org
-    pl = Zaloguj się przez www.openstreetmap.org
-    pt = Entrar com www.openstreetmap.org
-    pt-BR = Entrar com www.openstreetmap.org
-    ro = Logați-vă cu contul de www.openstreetmap.org
-    es = Iniciar sesión con www.openstreetmap.org
-    sv = Logga in med www.openstreetmap.org
-    th = ล็อกอินที่ www.openstreetmap.org
-    tr = www.openstreetmap.org adresinden oturum aç
-    uk = Увійти за допомогою www.openstreetmap.org
-    vi = Đăng nhập với www.openstreetmap.org
-    zh-Hans = 登录到www.openstreetmap.org
-    zh-Hant = 登入到 www.openstreetmap.org
-    sk = Prihlásiť sa cez www.openstreetmap.org
-    fa = ورود با حساب www.openstreetmap.org
+    sk = Ďakujeme Vám
 
   [edit_place]
     tags = ios, android
@@ -14098,11 +9093,11 @@
     zh-Hans = 编辑地点
     zh-Hant = 編輯地點
     el = Επεξεργασία μέρους
-    sk = Upraviť miesto
     fa = ویرایش مکان
+    sk = Upraviť miesto
 
   [place_name]
-    tags = ios, android
+    tags = ios
     en = Place Name
     ru = Название
     ar = اسم المكان
@@ -14131,109 +9126,8 @@
     zh-Hans = 地点名
     zh-Hant = 地點名稱
     el = Όνομα μέρους
-    sk = Názov miesta
     fa = نام مکان
-
-  [other_languages]
-    comment = title above languages list cells in the editor, below editable name text field.
-    tags = ios, android
-    en = Other Languages
-    ru = Другие языки
-    ar = لغات أخرى
-    cs = Další jazyky
-    da = Andre sprog
-    nl = Overige talen
-    fi = Muut Kielet
-    fr = Autres langues
-    de = Andere Sprachen
-    hu = Más nyelv
-    id = Bahasa lainnya
-    it = Altre lingue
-    ja = その他の言語
-    ko = 다른 언어
-    nb = Andre språk
-    pl = Inne języki
-    pt = Outros idiomas
-    pt-BR = Outros idiomas
-    ro = Alte limbi
-    es = Otros idiomas
-    sv = Övriga språk
-    th = ภาษาอื่น ๆ
-    tr = Diğer Diller
-    uk = Інші мови
-    vi = Ngôn ngữ khác
-    zh-Hans = 其他语言
-    zh-Hant = 其他語言
-    sk = Iné jazyky
-    fa = زبان های دیگر
-
-  [show_more]
-    comment = small button to open list with names in different languages
-    tags = ios, android
-    en = Show More
-    ru = Показать больше
-    ar = إظهار أكثر
-    cs = Zobrazit méně
-    da = Vis mere
-    nl = Laat meer zien
-    fi = Näytä enemmän
-    fr = Montrer plus
-    de = Mehr anzeigen
-    hu = Több mutatása
-    id = Tampilkan lebih banyak
-    it = Mostra più
-    ja = もっと表示
-    ko = 더 많이 표시
-    nb = Vis mer
-    pl = Pokaż więcej
-    pt = Mostrar mais
-    pt-BR = Mostrar mais
-    ro = Afișează mai mult
-    es = Mostrar más
-    sv = Visa mer
-    th = แสดงมากขึ้น
-    tr = Daha fazlasını göster
-    uk = Показати більше
-    vi = Hiển thị nhiều hơn
-    zh-Hans = 显示更多
-    zh-Hant = 顯示更多
-    el = Περισσότερα
-    sk = Zobraziť viac
-    fa = نمایش بیشتر
-
-  [show_less]
-    comment = small button to close list with names in different languages
-    tags = ios, android
-    en = Show Less
-    ru = Показать меньше
-    ar = إظهار أقل
-    cs = Zobrazit více
-    da = Vis mindre
-    nl = Laat minder zien
-    fi = Näytä vähemmän
-    fr = Montrer moins
-    de = Weniger anzeigen
-    hu = Kevesebb mutatása
-    id = Tampilkan lebih sedikit
-    it = Mostra meno
-    ja = 少なく表示
-    ko = 더 적게 표시
-    nb = Vis mindre
-    pl = Pokaż mniej
-    pt = Mostrar menos
-    pt-BR = Mostrar menos
-    ro = Afișează mai puțin
-    es = Mostrar menos
-    sv = Visa mindre
-    th = แสดงน้อยลง
-    tr = Daha azını göster
-    uk = Показати менше
-    vi = Hiển thị ít hơn
-    zh-Hans = 显示更少
-    zh-Hant = 顯示較少
-    el = Λιγότερα
-    sk = Zobraziť menej
-    fa = نمایش کمتر
+    sk = Názov miesta
 
   [add_language]
     tags = ios, android
@@ -14265,11 +9159,11 @@
     zh-Hans = 添加语言
     zh-Hant = 新增語言
     el = Προσθήκη γλώσσας
-    sk = Pridať jazyk
     fa = افزودن یک زبان
+    sk = Pridať jazyk
 
   [street]
-    tags = ios, android
+    tags = android
     en = Street
     ru = Улица
     ar = الشارع
@@ -14298,8 +9192,8 @@
     zh-Hans = 街道
     zh-Hant = 街道
     el = Οδός
-    sk = Ulica
     fa = خیابان
+    sk = Ulica
 
   [house_number]
     comment = Editable House Number text field (in address block).
@@ -14332,8 +9226,8 @@
     zh-Hans = 门牌号码
     zh-Hant = 門牌號碼
     el = Αριθμός κτιρίου
-    sk = Číslo domu
     fa = شماره ساختمان
+    sk = Číslo domu
 
   [details]
     tags = ios, android
@@ -14365,8 +9259,8 @@
     zh-Hans = 细节
     zh-Hant = 詳細資訊
     el = Λεπτομέρειες
-    sk = Podrobnosti
     fa = جزئیات
+    sk = Podrobnosti
 
   [add_street]
     comment = Text field to enter non-existing street name, below list of known streets around
@@ -14399,8 +9293,8 @@
     zh-Hans = 添加街道
     zh-Hant = 新增街道
     el = Προσθέστε ένα δρόμο
-    sk = Pridať ulicu
     fa = اضافه کردن خیابان
+    sk = Pridať ulicu
 
   [choose_language]
     tags = ios, android
@@ -14432,8 +9326,8 @@
     zh-Hans = 选择语言
     zh-Hant = 選擇語言
     el = Επιλέξτε μια γλώσσα
-    sk = Vybrať jazyk
     fa = انتخاب یک زبان
+    sk = Vybrať jazyk
 
   [choose_street]
     tags = ios, android
@@ -14465,8 +9359,8 @@
     zh-Hans = 选择街道
     zh-Hant = 選擇街道
     el = Επιλέξτε μια οδό
-    sk = Vybrať ulicu
     fa = انتخاب یک خیابان
+    sk = Vybrať ulicu
 
   [postal_code]
     tags = ios, android
@@ -14497,8 +9391,8 @@
     vi = Mã bưu chính
     zh-Hans = 邮政编码
     zh-Hant = 郵遞區號
-    sk = PSČ
     fa = کد پستی
+    sk = PSČ
 
   [cuisine]
     tags = ios, android
@@ -14530,8 +9424,8 @@
     zh-Hans = 菜肴
     zh-Hant = 料理
     el = Κουζίνα
-    sk = Kuchyňa
     fa = غذا خوری
+    sk = Kuchyňa
 
   [select_cuisine]
     tags = ios, android
@@ -14563,8 +9457,8 @@
     zh-Hans = 选择菜肴
     zh-Hant = 選擇料理
     el = Επιλέξτε κουζίνα
-    sk = Vyberte si kuchyňu
     fa = انتخاب غذاخوری
+    sk = Vyberte si kuchyňu
 
   [email_or_username]
     comment = login text field
@@ -14597,8 +9491,8 @@
     zh-Hans = 邮箱或用户名
     zh-Hant = 電子郵件或使用者名稱
     el = Email ή όνομα χρήστη
-    sk = Email alebo používateľské meno
     fa = ایمیل یا نام کاربری
+    sk = Email alebo používateľské meno
 
   [phone]
     tags = ios, android
@@ -14630,11 +9524,11 @@
     zh-Hans = 电话
     zh-Hant = 電話
     el = Τηλέφωνο
-    sk = Telefón
     fa = تلفن
+    sk = Telefón
 
   [please_note]
-    tags = ios, android
+    tags = ios
     en = Please note
     ru = Обратите внимание
     ar = يرجى العلم أنه،
@@ -14663,40 +9557,8 @@
     zh-Hans = 请注意
     zh-Hant = 請註意
     el = Λάβετε υπόψη
-    sk = Upozorňujeme vás, že
     fa = لطفا توجه داشته باشد
-
-  [common_no_wifi_dialog]
-    tags = ios, android
-    en = No WiFi connection. Do you want to continue with mobile data?
-    ru = Нет WiFi соединения. Вы хотите продолжить работу через мобильный интернет?
-    ar = لا يوجد اتصال واي فاي. هل ترغب في استخدام بيانات الهاتف للاتصال؟
-    cs = Žádné Wi-Fi připojení. Chcete pokračovat s mobilními daty?
-    da = Ingen WiFi-forbindelse. Vil du fortsætte med mobildata?
-    nl = Geen WiFi-verbinding. Wil je doorgaan via mobiele data?
-    fi = Ei Wi-Fi -yhteyttä. Haluatko jatkaa mobiilidatan avulla?
-    fr = Aucune connexion Wi-Fi. Voulez-vous continuer avec les données mobiles ?
-    de = Keine WLAN-Verbindung. Möchten Sie mit mobilen Daten fortfahren?
-    hu = Nincs WiFi-kapcsolat. Szeretnéd folytatni mobil adatforgalom használatával?
-    id = Tidak ada koneksi WiFi. Apakah Anda ingin melanjutkan dengan data seluler?
-    it = Nessuna connessione WiFi. Vuoi continuare con la connessione dati?
-    ja = WiFi接続がありません。モバイルデータ通信を続行しますか?
-    ko = WiFi 연결이 없습니다. 모바일 데이터를 계속하시겠습니까?
-    nb = Ingen trådløs forbindelse. Vil du fortsette med mobildata?
-    pl = Brak połączenia Wi-Fi. Czy chcesz kontynuować z użyciem danych pakietowych?
-    pt = Nenhuma ligação Wi-Fi. Deseja continuar com os dados móveis?
-    pt-BR = Nenhuma conexão Wi-Fi. Deseja continuar com os dados móveis?
-    ro = Nu există conexiune WiFi. Doriți să continuați cu conexiunea de pe mobil?
-    es = No hay conexión Wi-Fi. ¿Quieres continuar con los datos móviles?
-    sv = Ingen wifi-anslutning. Vill du fortsätta med mobildata?
-    th = ไม่มีการเชื่อมต่อ WiFi คุณต้องการดำเนินการต่อโดยใช้ข้อมูลมือถือหรือไม่?
-    tr = WiFi bağlantısı yok. Mobil veri ile devam etmek istiyor musunuz?
-    uk = Немає WiFi з’єднання. Ви бажаєте продовжити роботу через мобільний інтернет?
-    vi = Không có Wifi. Bạn có muốn tiếp tục dùng dữ liệu di động?
-    zh-Hans = 无 WiFi 连接。您想继续使用移动数据进行连接吗？
-    zh-Hant = 無 WiFi 連接。您想繼續使用行動數據進行連接嗎？
-    sk = Pripojenie k WiFi nie je k dispozícii. Chcete pokračovať s využitím mobilných dát?
-    fa = اتصال وایفای یافت نشد.ایا می خواهید با اینترنت دیتای موبایل ادامه دهید؟
+    sk = Upozorňujeme vás, že
 
   [downloader_delete_map_dialog]
     tags = ios, android
@@ -14728,11 +9590,11 @@
     zh-Hans = 所有对地图的修改都将与地图一起被删除。
     zh-Hant = 所有對地圖的修改都將與地圖一起被刪除。
     el = Όλες οι αλλαγές που έχετε κάνει στο χάρτη θα διαγραφούν μαζί με το χάρτη.
-    sk = Všetky zmeny týkajúce sa mapy budú vymazané spolu s mapou.
     fa = تمام ویرایش های که بر روی نقشه انجام داده اید به همراه نقشه حذف شد.
+    sk = Všetky zmeny týkajúce sa mapy budú vymazané spolu s mapou.
 
   [downloader_update_maps]
-    tags = ios, android
+    tags = android
     en = Update Maps
     ru = Обновите карты
     ar = تحديث الخرائط
@@ -14761,11 +9623,11 @@
     zh-Hans = 更新地图
     zh-Hant = 更新地圖
     el = Ενημέρωση χαρτών
-    sk = Aktualizovať mapy
     fa = بروزرسانی نقشه ها
+    sk = Aktualizovať mapy
 
   [downloader_mwm_migration_dialog]
-    tags = ios, android
+    tags = android
     en = To create a route, you need to update all maps and then plan the route again.
     ru = Для построения маршрутов необходимо обновить все карты и построить маршрут заново.
     ar = لإنشاء مسار، فأنت تحتاج إلى تحديث كافة الخرائط ثم إعادة تخطيط المسار مرة أخرى.
@@ -14794,11 +9656,11 @@
     zh-Hans = 为了创建路线，您需要更新全部地图并重新规划路线。
     zh-Hant = 為了建立路線，您需要更新全部地圖並重新規劃路線。
     el = Για να δημιουργήσετε μια διαδρομή, πρέπει να ενημερώσετε όλους τους χάρτες και στη συνέχεια να σχεδιάσετε τη διαδρομή ξανά.
-    sk = Ak chcete vytvoriť cestu, musíte najskôr aktualizovať všetky mapy a potom odznova naplánovať trasu.
     fa = برای ایجاد مسیر شما نیازمند بروزرسانی تمامی  نقشه ها هستید سپس می توانید دوباره مسیرتان را برنامه ریزی کنید
+    sk = Ak chcete vytvoriť cestu, musíte najskôr aktualizovať všetky mapy a potom odznova naplánovať trasu.
 
   [downloader_search_field_hint]
-    tags = ios, android
+    tags = android
     en = Find map
     ru = Найти карту
     ar = اعثر على الخريطة
@@ -14827,77 +9689,11 @@
     zh-Hans = 找到地图
     zh-Hant = 找到地圖
     el = Ανεύρεση χάρτη
-    sk = Nájsť mapu
     fa = یافتن نقشه
-
-  [migration_update_all_button]
-    tags = ios, android
-    en = Update All Maps
-    ru = Обновить все карты
-    ar = تحديث جميع الخرائط
-    cs = Aktualizovat všechny mapy
-    da = Opdatér alle kort
-    nl = Update alle kaarten
-    fi = Päivitä kaikki kartat
-    fr = Mettre à jour toutes les cartes
-    de = Alle Karten aktualisieren
-    hu = Minden térkép frissítése
-    id = Perbarui semua peta
-    it = Aggiorna tutte le mappe
-    ja = 全ての地図をアップデート
-    ko = 모든지도 업데이트
-    nb = Oppdater alle kart
-    pl = Aktualizuj wszystkie mapy
-    pt = Atualizar todos os mapas
-    pt-BR = Atualizar todos os mapas
-    ro = Actualizați toate hărțile
-    es = Actualizar todos los mapas
-    sv = Uppdatera alla kartor
-    th = อัปเดตแผนที่ทั้งหมด
-    tr = Haritaları güncelle
-    uk = Оновити всі карти
-    vi = Cập nhật tất cả các bản đồ
-    zh-Hans = 更新全部地图
-    zh-Hant = 更新全部地圖
-    el = Ενημέρωση όλων των χαρτών
-    sk = Aktualizovať všetky mapy
-    fa = بروزرسانی تمامی نقشه ها
-
-  [migration_delete_all_download_current_button]
-    tags = ios, android
-    en = Download the current map and delete all of the old ones
-    ru = Скачать текущую и удалить все старые карты
-    ar = تنزيل الخريطة الحالية وحذف الخرائط القديمة
-    cs = Stáhněte si aktuální mapu a odstraňte staré
-    da = Download aktuelt kort og slet de gamle
-    nl = Download de huidige kaart en verwijder de oude
-    fi = Lataa nykyinen kartta ja poista kaikki vanhat kartat
-    fr = Téléchargez la carte actuelle et supprimez les anciennes
-    de = Laden Sie die aktuelle Karte herunter und löschen Sie alte Karten
-    hu = Töltsd le a jelenlegi térképet és töröld a régieket
-    id = Unduh peta sekarang dan hapus peta lama
-    it = Scarica la mappa attuale e cancella quelle vecchie
-    ja = 現在の地図をダウンロードして古い地図を削除
-    ko = 현재 지도 다운로드 및 기존 지도 삭제
-    nb = Last ned det oppdaterte kartet og slett de gamle
-    pl = Pobierz bieżącą mapę i usuń stare
-    pt = Descarregue o mapa atual e elimine os antigos
-    pt-BR = Baixe o mapa atual e elimine os antigos
-    ro = Descărcați harta actuală și ștergeți toate hărțile vechi
-    es = Descargar el mapa actual y eliminar los mapas antiguos
-    sv = Ladda ned senaste kartan och radera de gamla
-    th = ดาวน์โหลดแผนที่ปัจจุบันและลบแผนที่เก่า
-    tr = Mevcut haritayı indir ve tüm eski haritaları sil
-    uk = Завантажте поточну карту і видаліть старі
-    vi = Tải xuống bản đồ hiện tại và xóa những bản đồ cũ
-    zh-Hans = 下载当前地图并删除旧地图
-    zh-Hant = 下載目前地圖並刪除舊地圖
-    el = Κατεβάστε τον τρέχον χάρτη και διαγράψτε όλους τους παλιούς
-    sk = Stiahnite si aktuálnu mapu a odstráňte neaktuálne mapy
-    fa = دانلود نقشه کنونی و حذف قدیمی ها
+    sk = Nájsť mapu
 
   [migration_download_error_dialog]
-    tags = ios, android
+    tags = ios
     en = Download error
     ru = Ошибка загрузки
     ar = خطأ بالتنزيل
@@ -14926,8 +9722,8 @@
     zh-Hans = 下载错误
     zh-Hant = 下載錯誤
     el = Σφάλμα λήψης
-    sk = Chyba pri sťahovaní
     fa = خطا در دانلود
+    sk = Chyba pri sťahovaní
 
   [common_check_internet_connection_dialog]
     tags = ios, android
@@ -14959,8 +9755,8 @@
     zh-Hans = 请检查您的设置并确保您的设备已连接至网络。
     zh-Hant = 請檢查您的設定並確保您的設備已連接至網路。
     el = Ελέγξτε τις ρυθμίσεις σας και βεβαιωθείτε ότι η συσκευή σας είναι συνδεδεμένη στο Internet.
-    sk = Prosím, skontrolujte svoje nastavenia a uistite sa, že váš počítač je pripojený k internetu.
     fa = لطفا تنظیمات خود را بازبینی کنید و مطمئن شوید که ابزار شما به اینترنت متصل است.
+    sk = Prosím, skontrolujte svoje nastavenia a uistite sa, že váš počítač je pripojený k internetu.
 
   [downloader_no_space_title]
     tags = ios, android
@@ -14992,8 +9788,8 @@
     zh-Hans = 无足够的空间
     zh-Hant = 無足夠的空間
     el = Δεν υπάρχει αρκετός χώρος
-    sk = Nemáte dostatok miesta
     fa = فظای کافی موجود نیست
+    sk = Nemáte dostatok miesta
 
   [downloader_no_space_message]
     tags = ios, android
@@ -15025,42 +9821,11 @@
     zh-Hans = 请删除不必要的数据
     zh-Hant = 請刪除不必要的資料
     el = Διαγράψτε τυχόν μη απαραίτητα δεδομένα
-    sk = Prosím, odstráňte prebytočné dáta
     fa = لطفا داده های غیر ضروری را از دستگاه خود حذف کنید
-
-  [editor_general_auth_error_dialog]
-    tags = ios, android
-    en = General login error.
-    ru = Общая ошибка авторизации.
-    ar = خطأ بتسجيل الدخول العام.
-    cs = Obecná chyba při přihlašování.
-    da = Generel fejl ved login.
-    nl = Algemene inlogfout.
-    fi = Yleinen kirjautumisvirhe.
-    fr = Erreur générale de connexion.
-    de = Allgemeiner Login-Fehler.
-    hu = Általános bejelentkezési hiba.
-    id = Kesalahan masuk umum.
-    it = Errore generale di accesso.
-    ja = 一般的なログインエラー。
-    ko = 일반 로그인 오류.
-    nb = Generell innloggingsfeil.
-    pl = Ogólny błąd logowania.
-    pt = Erro genérico de início de sessão.
-    pt-BR = Erro genérico de login.
-    ro = Eroare generală de conectare.
-    es = Error general de inicio de sesión.
-    sv = Allmänt fel vid inloggning.
-    th = ข้อผิดพลาดในการล็อกอินทั่วไป
-    tr = Genel giriş hatası.
-    uk = Загальна помилка входу.
-    vi = Lỗi đăng nhập chung.
-    zh-Hans = 一般登录错误。
-    zh-Hant = 一般登入錯誤。
-    sk = Pri prihlasovaní sa vyskytla všeobecná chyba.
+    sk = Prosím, odstráňte prebytočné dáta
 
   [editor_login_error_dialog]
-    tags = ios, android
+    tags = android
     en = Login error.
     ru = Произошла ошибка при авторизации.
     ar = خطأ في تسجيل الدخول.
@@ -15089,136 +9854,8 @@
     zh-Hans = 登录错误。
     zh-Hant = 登入錯誤。
     el = Σφάλμα σύνδεσης.
-    sk = Pri prihlasovaní sa vyskytla chyba.
     fa = خطای ورود
-
-  [editor_login_failed_dialog]
-    tags = ios, android
-    en = Login failed
-    ru = Войти не удалось
-    ar = فشل تسجيل الدخول
-    cs = Přihlašování selhalo
-    da = Login mislykkedes
-    nl = Inloggen mislukt
-    fi = Kirjautuminen epäonnistui
-    fr = La connexion a échoué
-    de = Login fehlgeschlagen
-    hu = Sikertelen bejelentkezés
-    id = Masuk gagal
-    it = Accesso fallito
-    ja = ログインに失敗しました
-    ko = 로그인 실패
-    nb = Innloggingen mislyktes
-    pl = Nieudane logowanie
-    pt = O início de sessão falhou
-    pt-BR = O login falhou
-    ro = Conectare eșuată
-    es = Error al iniciar sesión
-    sv = Inloggningen misslyckades
-    th = การล็อกอินล้มเหลว
-    tr = Giriş başarısız
-    uk = Помилка входу
-    vi = Đăng nhập thất bại
-    zh-Hans = 登录失败
-    zh-Hant = 登入失敗
-    sk = Prihlasovanie bolo neúspešné
-    fa = ورود ناموفق
-
-  [editor_username_error_dialog]
-    tags = ios, android
-    en = Username is invalid
-    ru = Неверное имя пользователя
-    ar = اسم المستخدم غير صحيح
-    cs = Uživatelské jméno není platné
-    da = Ugyldigt brugernavn
-    nl = Gebruikersnaam is ongeldig
-    fi = Käyttäjätunnus on virheellinen
-    fr = Le nom d'utilisateur est invalide
-    de = Benutzername ist ungültig
-    hu = Érvénytelen felhasználónév
-    id = Nama pengguna tidak benar
-    it = Nome utente non valido
-    ja = ユーザー名が無効です
-    ko = 잘못된 사용자 이름
-    nb = Brukernavnet er ugyldig
-    pl = Nieprawidłowa nazwa użytkownika
-    pt = O nome de utilizador é inválido
-    pt-BR = O nome de usuário é inválido
-    ro = Nume de utilizator nevalid
-    es = Usuario no válido
-    sv = Användarnamnet är ogiltigt
-    th = ชื่อผู้ใช้ไม่ถูกต้อง
-    tr = Kullanıcı adı geçersiz
-    uk = Ім'я користувача є недійсним
-    vi = Tên đăng nhập không hợp lệ
-    zh-Hans = 用户名不存在
-    zh-Hant = 使用者名稱不存在
-    sk = Používateľské meno je neplatné
-    fa = نام کاربری نامعتبر است
-
-  [editor_place_edited_dialog]
-    tags = ios, android
-    en = You’ve edited an object!
-    ru = Вы отредактировали объект!
-    ar = لقد قمت بتعديل هدف!
-    cs = Upravili jste objekt!
-    da = Du har redigeret et objekt!
-    nl = Je hebt een object bewerkt!
-    fi = Olet muokannut kohdetta!
-    fr = Vous avez modifié un objet !
-    de = Sie haben ein Objekt bearbeitet!
-    hu = Szerkesztettél egy objektumot!
-    id = Anda telah mengedit sebuah obyek!
-    it = Hai modificato un oggetto!
-    ja = オブジェクトを編集しました!
-    ko = 개체를 편집했습니다!
-    nb = Du har redigert et objekt!
-    pl = Obiekt był edytowany!
-    pt = Editou um objeto!
-    pt-BR = Você editou um objeto!
-    ro = Ați editat un obiect!
-    es = ¡Has editado un objeto!
-    sv = Du har redigerat ett objekt!
-    th = คุณได้แก้ไขวัตถุ!
-    tr = Bir objeyi düzenlediniz'!
-    uk = Ви відредагували об’єкт!
-    vi = Bạn đã chỉnh sửa một đối tượng!
-    zh-Hans = 您已编辑了一个对象！
-    zh-Hant = 您已編輯了一個物件！
-    sk = Práve ste upravili objekt!
-    fa = شما یک شئی را ویرایش کردید
-
-  [editor_login_with_osm]
-    tags = ios, android
-    en = Login with OpenStreetMap
-    ru = Войти через OpenStreetMap
-    ar = تسجيل الدخول عبر OpenStreetMap
-    cs = Přihlásit se pomocí OpenStreetMap
-    da = Login med OpenStreetMap
-    nl = Log in met OpenStreetMap
-    fi = Kirjaudu sisään OpenStreetMapissa
-    fr = Connexion avec OpenStreetMap
-    de = Mit OpenStreetMap anmelden
-    hu = Bejelentkezés OpenStreetMappel
-    id = Masuk dengan OpenStreetMap
-    it = Accedi con OpenStreetMap
-    ja = OpenStreetMapを使ってログイン
-    ko = OpenStreetMap으로 로그인
-    nb = Logg inn med OpenStreetMat
-    pl = Zaloguj się z OpenStreetMap
-    pt = Iniciar sessão com a OpenStreetMap
-    pt-BR = Fazer login no OpenStreetMap
-    ro = Conectați-vă cu OpenStreetMap
-    es = Iniciar sesión con OpenStreetMap
-    sv = Logga in med OpenStreetMap
-    th = ล็อกอินด้วย OpenStreetMap
-    tr = OpenStreetMap ile giriş yapın
-    uk = Увійти через OpenStreetMap
-    vi = Đăng nhập với OpenStreetMap
-    zh-Hans = 使用OpenStreetMap进行登录
-    zh-Hant = 使用 OpenStreetMap 進行登入
-    sk = Prihlásiť sa prostredníctvom OpenStreetMap
-    fa = ورود با استفاده از OpenStreetMap
+    sk = Pri prihlasovaní sa vyskytla chyba.
 
   [editor_profile_changes]
     tags = ios, android
@@ -15250,40 +9887,8 @@
     zh-Hans = 已验证的更改
     zh-Hant = 已驗證的變更
     el = Επαληθευμένες αλλαγές
-    sk = Overené zmeny
     fa = تغییرات تایید شد
-
-  [editor_profile_unsent_changes]
-    tags = ios, android
-    en = Not sent:
-    ru = Не отправлено:
-    ar = لم ترسل:
-    cs = Neodesláno:
-    da = Ikke sendt:
-    nl = Niet verzonden:
-    fi = Ei lähetetty:
-    fr = Non envoyé :
-    de = Nicht gesendet:
-    hu = Nincs elküldve:
-    id = Tidak terkirim:
-    it = Non inviato:
-    ja = 未送信：
-    ko = 전송되지 않음:
-    nb = Ikke sendt:
-    pl = Nie wysłano:
-    pt = Não enviado:
-    pt-BR = Não enviado:
-    ro = Netrimis:
-    es = No enviado:
-    sv = Inte skickade:
-    th = ไม่ได้ส่ง:
-    tr = Gönderilmedi:
-    uk = Не відправлено:
-    vi = Không gửi được:
-    zh-Hans = 未发送：
-    zh-Hant = 未發送：
-    sk = Neodoslané:
-    fa = ارسال نشد:
+    sk = Overené zmeny
 
   [editor_focus_map_on_location]
     tags = ios, android
@@ -15315,11 +9920,11 @@
     zh-Hans = 拖动地图以选择此对象的正确位置。
     zh-Hant = 拖動地圖以選擇此物件的正確位置。
     el = Σύρετε τον χάρτη για να επιλέξετε τη σωστή θέση του αντικειμένου.
-    sk = Ak chcete nastaviť správnu polohu objektu, posuňte mapu.
     fa = برای انتخاب مکان صحیح شئی نقشه را بکشید.
+    sk = Ak chcete nastaviť správnu polohu objektu, posuňte mapu.
 
   [editor_add_select_category]
-    tags = ios, android
+    tags = ios
     en = Select category
     ru = Выбрать категорию
     ar = اختر الفئة
@@ -15348,11 +9953,11 @@
     zh-Hans = 选择类别
     zh-Hant = 選擇類別
     el = Επιλέξτε κατηγορία
-    sk = Vybrať kategóriu
     fa = انتخاب دسته بندی
+    sk = Vybrať kategóriu
 
   [editor_add_select_category_popular_subtitle]
-    tags = ios, android
+    tags = ios
     en = Popular
     ru = Популярные
     ar = شائع
@@ -15381,11 +9986,11 @@
     zh-Hans = 受欢迎的
     zh-Hant = 受歡迎的
     el = Δημοφιλή
-    sk = Obľúbené
     fa = پرطرفدار
+    sk = Obľúbené
 
   [editor_add_select_category_all_subtitle]
-    tags = ios, android
+    tags = ios
     en = All Categories
     ru = Все категории
     ar = جميع الفئات
@@ -15414,8 +10019,8 @@
     zh-Hans = 所有类别
     zh-Hant = 所有類別
     el = Όλες οι κατηγορίες
-    sk = Všetky kategórie
     fa = همه دسته بندی ها
+    sk = Všetky kategórie
 
   [editor_edit_place_title]
     tags = ios, android
@@ -15447,8 +10052,8 @@
     zh-Hans = 编辑中
     zh-Hant = 編輯中
     el = Επεξεργασία
-    sk = Úprava
     fa = درحال ویرایش
+    sk = Úprava
 
   [editor_add_place_title]
     tags = ios, android
@@ -15480,8 +10085,8 @@
     zh-Hans = 添加中
     zh-Hant = 新增中
     el = Προσθήκη
-    sk = Nové
     fa = درحال افزودن
+    sk = Nové
 
   [editor_edit_place_name_hint]
     tags = ios, android
@@ -15513,8 +10118,8 @@
     zh-Hans = 该地点的名称
     zh-Hant = 該地點的名稱
     el = Το όνομα του τόπου
-    sk = Názov miesta
     fa = نام مکان
+    sk = Názov miesta
 
   [editor_edit_place_category_title]
     tags = ios, android
@@ -15546,10 +10151,11 @@
     zh-Hans = 类别
     zh-Hant = 類別
     el = Κατηγορία
-    sk = Kategória
     fa = دسته بندی
+    sk = Kategória
 
   [detailed_problem_description]
+    tags = android
     en = Detailed description of the issue
     ru = Подробное описание проблемы
     ar = وصف مفصل للمشكلة
@@ -15578,10 +10184,11 @@
     zh-Hans = 问题的详细描述
     zh-Hant = 問題的詳細描述
     el = Λεπτομερή περιγραφή του θέματος
-    sk = Podrobný popis problému
     fa = توضیح مفصل در مورد مشکل
+    sk = Podrobný popis problému
 
   [editor_report_problem_other_title]
+    tags = android
     en = Different problem
     ru = Другая проблема
     ar = مشكلة مختلفة
@@ -15610,43 +10217,11 @@
     zh-Hans = 一个不同的问题
     zh-Hant = 一個不同的問題
     el = Διαφορετικό πρόβλημα
-    sk = Iný problém
     fa = مشکلی دیگر
-
-  [placepage_report_problem_button]
-    tags = ios, android
-    en = Report a problem
-    ru = Сообщить о проблеме
-    ar = الإبلاغ عن مشكلة
-    cs = Nahlásit problém
-    da = Anmeld et problem
-    nl = Meld een probleem
-    fi = Ilmoita ongelmasta
-    fr = Signaler un problème
-    de = Problem melden
-    hu = Hibabejelentés
-    id = Laporkan masalah
-    it = Riporta un problema
-    ja = 問題を報告
-    ko = 문제 신고
-    nb = Rapporter et problem
-    pl = Zgłoś problem
-    pt = Comunicar um problema
-    pt-BR = Comunicar um problema
-    ro = Raportați o problemă
-    es = Informar de un problema
-    sv = Rapportera ett problem
-    th = แจ้งปัญหา
-    tr = Bir problem bildirin
-    uk = Повідомити про проблему
-    vi = Báo cáo vấn đề
-    zh-Hans = 报告一个问题
-    zh-Hant = 回報問題
-    sk = Nahlásiť problém
-    fa = گزارش یک مشکل
+    sk = Iný problém
 
   [placepage_add_business_button]
-    tags = ios, android
+    tags = android
     en = Add business
     ru = Добавить организацию
     ar = إضافة مؤسسة
@@ -15675,11 +10250,11 @@
     zh-Hans = 添加组织
     zh-Hant = 添加組織
     el = Προσθήκη επιχείρησης
-    sk = Pridať organizáciu
     fa = اضافه کردن یک تجارت
+    sk = Pridať organizáciu
 
   [whatsnew_editor_message_1]
-    tags = ios, android
+    tags = ios
     en = Add new places to the map, and edit existing ones directly from the app.
     ru = Добавляйте новые объекты и редактируйте старые прямо из приложения.
     ar = قم بإضافة أماكن جديدة للخريطة، وعدل أماكن حالية مباشرة من التطبيق.
@@ -15708,43 +10283,11 @@
     zh-Hans = 添加新地点到该地图，并直接通过此应用编辑已存在的地点。
     zh-Hant = 新增新地點到該地圖，並直接通過此應用程式編輯已存在的地點。
     el = Προσθέστε νέες τοποθεσίες στο χάρτη, και επεξεργαστείτε τις υπάρχουσες απευθείας από την εφαρμογή.
-    sk = Na mapu môžete pridávať nové miesta a upravovať tie, ktoré sú už pridané.
     fa = اضافه کردن مکان به نقشه و ویرایش ان مستقیما از طریق این اپلیکیشن.
+    sk = Na mapu môžete pridávať nové miesta a upravovať tie, ktoré sú už pridané.
 
-  [whatsnew_editor_message_2]
-    tags = ios, android
-    en = * Organic Maps uses OpenStreetMap community data.
-    ru = * Organic Maps использует данные открытых карт сообщества OpenStreetMap.
-    ar = *تستخدم Organic Maps البيانات الخاصة بخريطة OpenStreetMap.
-    cs = * Organic Maps používá komunitní data OpenStreetMap.
-    da = * Organic Maps bruger fællesskabsdata fra OpenStreetMap.
-    nl = * Organic Maps gebruikt OpenStreetMap-communitiedata.
-    fi = * Organic Maps käyttää OpenStreetMap -yhteisön dataa.
-    fr = * Organic Maps utilise les données de la communauté OpenStreetMap.
-    de = * Organic Maps verwendet Community-Daten von OpenStreetMap.
-    hu = * A Organic Maps az OpenStreetMap közösség adatait használja.
-    id = * Organic Maps menggunakan data komunitas OpenStreetMap.
-    it = * Organic Maps usa i dati della community OpenStreetMap.
-    ja = * Organic MapsはOpenStreetMapコミュニティのデータを使用しています。
-    ko = * Organic Maps는 OpenStreetMap 커뮤니티 데이터를 사용합니다.
-    nb = * Organic Maps bruker data fra OpenStreetMap-samfunnet.
-    pl = * Organic Maps korzysta z danych społeczności OpenStreetMap.
-    pt = * A Organic Maps utiliza dados da comunidade OpenStreetMap.
-    pt-BR = * Organic Maps utiliza dados da comunidade OpenStreetMap.
-    ro = * Organic Maps folosește datele comunității OpenStreetMap community.
-    es = * Organic Maps utiliza datos de la comunidad de OpenStreetMap.
-    sv = * Organic Maps använder data från OpenStreetMaps community.
-    th = * Organic Maps ใช้ข้อมูลจากชุมชน OpenStreetMap
-    tr = * Organic Maps, OpenStreetMap topluluğu verilerini kullanmaktadır.
-    uk = * Organic Maps використовує дані спільноти OpenStreetMap.
-    vi = * Organic Maps sử dụng dữ liệu của cộng đồng OpenStreetMap.
-    zh-Hans = * Organic Maps使用OpenStreetMap社区的数据。
-    zh-Hant = * Organic Maps 使用 OpenStreetMap 社群的數據。
-    el = * Το Organic Maps χρησιμοποιεί δεδομένα της κοινότητας OpenStreetMap.
-    sk = * Organic Maps využíva dáta komunity OpenStreetMap.
-    fa = * Organic Maps از دیتای انجمن  OpenStreetMap.
-
-   [dialog_incorrect_feature_position]
+  [dialog_incorrect_feature_position]
+    tags = ios
     en = Change location
     ru = Измените местоположение
     ar = تغيير الموقع
@@ -15773,10 +10316,11 @@
     zh-Hans = 改变位置
     zh-Hant = 改變位置
     el = Αλλαγή τοποθεσίας
-    sk = Zmeniť polohu
     fa = تغییر موقعیت
+    sk = Zmeniť polohu
 
   [message_invalid_feature_position]
+    tags = ios, android
     en = No object can be located here
     ru = Объект не может находиться в этом месте
     ar = لا يمكن تحديد موقع الكائن هنا
@@ -15805,10 +10349,11 @@
     zh-Hans = 对象无法设置在这里
     zh-Hant = 物件無法設置在這裡
     el = Δε μπορεί να εντοπιστεί αντικείμενο εδώ
-    sk = Objekt sa tu nedá umiestniť
     fa = نمی توان شی ای در این مکان باشد
+    sk = Objekt sa tu nedá umiestniť
 
   [login_to_make_edits_visible]
+    tags = ios, android
     en = Log in so other users can see the changes that you have made
     ru = Войдите, чтобы ваши изменения увидели другие пользователи.
     ar = قم بتسجيل الدخول حتى يتمكن باقي المستخدمين من رؤية التغييرات التي قمت بها.
@@ -15837,43 +10382,12 @@
     zh-Hans = 登陆，让其他用户能看到您所作出的修改。
     zh-Hant = 登入來讓其他使用者能看到您所作出的修改。
     el = Συνδεθείτε ώστε άλλοι χρήστες να μπορούν να δουν τις αλλαγές που έχετε κάνει
-    sk = Prihláste sa, aby mohli ostatní užívatelia vidieť Vami vykonané zmeny.
     fa = وارد شوید تا دیگر کاربران نیز بتوانند تغییرات ایجاد شده توسط شما را ببینند
-
-  [no_migration_during_navigation]
-    en = Updating is not allowed during navigation.
-    ru = Во время навигации обновление запрещено.
-    ar = التحديث ممنوع أثناء الملاحة.
-    cs = Aktualizace jsou během navigování zakázány.
-    da = Opdatering er ikke tilladt under navigering.
-    nl = Updaten tijdens navigatie is niet toegestaan.
-    fi = Päivittäminen ei ole mahdollista navigoinnin aikana.
-    fr = La mise à jour est interdite pendant la navigation.
-    de = Aktualisieren ist während der Navigation verboten.
-    hu = Navigáció közbeni módosítás nem engedélyezett.
-    id = Memperbarui tidak diperbolehkan selama navigasi.
-    it = Non è possibile effettuare aggiornamenti durante la navigazione.
-    ja = ナビゲーション中は更新できません。
-    ko = 업데이트는 탐색 중 금지되어 있습니다.
-    nb = Det er ikke mulig å oppdatere under navigering.
-    pl = Podczas nawigacji aktualizacja jest niemożliwa.
-    pt = Actualização não é permitida durante a navegação.
-    pt-BR = Atualização não é permitida durante a navegação.
-    ro = În timpul navigării, actualizarea este interzisă.
-    es = No se permite la actualización durante la navegación.
-    sv = Att uppdatera är förbjudet under navigering.
-    th = ห้ามอัปเดตระหว่างการนำทาง
-    tr = Navigasyon sırasında güncelleme yasaktır.
-    uk = Під час навігації оновлення заборонено.
-    vi = Không cho phép cập nhật trong khi điều hướng.
-    zh-Hans = 导航中禁止更新。
-    zh-Hant = 導航中禁止更新。
-    el = Δεν επιτρέπεται η ενημέρωση κατά τη διάρκεια της πλοήγησης.
-    sk = Počas hľadania trasy nie je možné vykonať aktualizáciu.
-    fa = بروزرسانی در حین مسیریابی مجاز نیست.
+    sk = Prihláste sa, aby mohli ostatní užívatelia vidieť Vami vykonané zmeny.
 
   [migration_no_space_message]
     comment = Error dialog no space
+    tags = ios
     en = To download, you need more space. Please delete any unnecessary data.
     ru = Для загрузки требуется больше свободного места. Пожалуйста, удалите ненужные данные.
     ar = للتنزيل، فأنت تحتاج إلى توفير مساحة أكبر. من فضلك، احذف البيانات غير الضرورية.
@@ -15902,10 +10416,11 @@
     zh-Hans = 为了下载，您需要更多的空间。请删除不必要的数据。
     zh-Hant = 為了下載，您需要更多的空間。請刪除不必要的數據。
     el = Για να το κατεβάσετε, χρειάζεστε περισσότερο χώρο. Διαγράψτε τυχόν μη απαραίτητα δεδομένα.
-    sk = Ak chcete pokračovať v sťahovaní, musíte uvoľniť viac miesta na ukladacom priestore. Prosím, odstráňte prebytočné dáta.
     fa = برای دانلود,شما نیازمند فضای ذخیره سازی بیشتری هستید.لطفا داده های غیر ضروری خود را حذف کنید.
+    sk = Ak chcete pokračovať v sťahovaní, musíte uvoľniť viac miesta na ukladacom priestore. Prosím, odstráňte prebytočné dáta.
 
   [editor_sharing_title]
+    tags = ios
     en = I improved the Organic Maps maps
     ru = Я улучшил карты Organic Maps
     ar = لقد قمت بتحديث خرائط تطبيق Organic Maps
@@ -15934,73 +10449,12 @@
     zh-Hans = 我改进了Organic Maps地图
     zh-Hant = 我改進了 Organic Maps 地圖
     el = Βελτίωσα τους χάρτες Organic Maps
-    sk = Vďaka mne sú mapy na Organic Maps lepšie
     fa = من نقشه های Organic Maps را بهبود بخشیدم
-
-  [editor_comment_will_be_sent]
-    en = We will make sure to send your comments to the map editors.
-    ru = Мы обязательно отправим ваш комментарий картографам.
-    ar = سوف نرسل تعليقك إلى فريق رسم الخرائط.
-    cs = Váš komentář pošleme kartografům.
-    da = Vi vil sende dine kommentarer til kartograferne.
-    nl = We zullen uw opmerking doorsturen naar de kaartmakers.
-    fi = Lähetämme kommenttisi kartanpiirtäjille.
-    fr = Nous transmettrons votre commentaire aux cartographes.
-    de = Wir werden Ihren Kommentar an die Kartografierer weiterleiten.
-    hu = Megjegyzését elküldjük a térképészeknek.
-    id = Kami akan mengirim komen Anda ke pembuat peta.
-    it = Invieremo i tuoi commenti ai cartografi.
-    ja = いただいたコメントを地図製作者に送ります。
-    ko = 지도 제작자에게 의견을 보낼 것입니다.
-    nb = Vi vil sende kommentaren din til kartografene.
-    pl = Prześlemy Twoje komentarze kartografom.
-    pt = Encaminharemos o seu comentário aos cartógrafos.
-    pt-BR = Encaminharemos o seu comentário aos editores do mapa.
-    ro = Vom trimite comentariul dumneavoastră cartografilor.
-    es = Enviaremos tus comentarios a los cartógrafos.
-    sv = Vi vidarebefordrar din kommentar till kartritarna.
-    th = เราจะส่งความคิดเห็นของคุณไปให้กับนักเขียนแผนที่
-    tr = Yorumunuzu haritacılara göndereceğiz.
-    uk = Ми обов'язково відправимо ваш коментар картографам.
-    vi = Chúng tôi sẽ gửi bình luận của bạn đến những người lập bản đồ.
-    zh-Hans = 我们将把您的评论发送给地图制作者。
-    zh-Hant = 我們將把您的評論發送給地圖編輯者。
-    sk = Pošleme Váš príspevok kartografom.
-    fa = ما مطمئن خواهیم شد که پیام خود را به ویرایشگران نقشه ارسال خواهید کرد.
-
-  [editor_unsupported_category_message]
-    en = You have added an object whose category we do not support yet. It will appear on the map in the future.
-    ru = Вы добавили объект, категорию которого мы пока не поддерживаем. В будущем он появится на карте.
-    ar = لقد قمت بإضافة مكان ينتمي لفئة غير متوفرة لدينا بعد. سوف تظهر على الخريطة لاحقا.
-    cs = Přidali jste místo kategorie, kterou zatím nepodporujeme. Na mapě se objeví za nějaký čas.
-    da = Du har tilføjet en placering i en kategori som vi ikke understøtter på nuværende tidspunkt. Den vil vises på kortet på et senere tidspunkt.
-    nl = U hebt een plaats of categorie toegevoegd die we nog niet ondersteunen. Het zal enige tijd duren voordat deze op de kaart verschijnt.
-    fi = Olet lisännyt sijainnin katergoriaan jota emme vielä tue. Se tulee näkyviin kartalle hieman myöhemmin.
-    fr = Vous avez ajouté un lieu appartenant à une catégorie que nous ne prenons pas encore en charge. Il apparaîtra sur la carte prochainement.
-    de = Sie haben einen Ort in einer Kategorie hinzugefügt, die wir noch nicht unterstützten. Er wird zu einem späteren Zeitpunkt auf der Karte erscheinen.
-    hu = Olyan kategóriához adott helyet, amelyet még nem támogatunk. Ez a kategória később fog megjelenni a térképen.
-    id = Anda telah menambahkan sebuah tempat kategori yang belum kami dukung. Tempat itu akan muncul di peta beberapa saat kemudian.
-    it = Hai aggiunto un luogo di una categoria che non è ancora disponibile. Apparirà sulla mappa in futuro.
-    ja = 現在未対応のカテゴリーの場所を追加しました。地図には後程表示されるようになります。
-    ko = 아직 지원하지 않는 카테고리의 장소를 추가했습니다. 시간이 좀 흐른 나중에 이 지도에 표시될 것입니다.
-    nb = Du har lagt til et sted i en kategori som enda ikke har støtte. Den vil vises på kartet senere.
-    pl = Dodałeś miejsce w kategorii, której jeszcze nie obsługujemy. Pojawi się ono na mapie za jakiś czas.
-    pt = Você adicionou um local de uma categoria para a qual ainda não temos suporte. Ele aparecerá no mapa no futuro.
-    pt-BR = Você adicionou um local de uma categoria para a qual ainda não temos suporte. Ele aparecerá no mapa no futuro.
-    ro = Ați adăugat o locație pentru care nu avem încă o categorie creată. Aceasta va apărea pe hartă în viitorul apropiat.
-    es = Has añadido un lugar de una categoría que no hemos incluido aún. Aparecerá en el mapa en unos momentos.
-    sv = Du har lagt till en plats i en kategori vi ännu inte stödjer. Den kommer att finnas på kartan vid ett senare tillfälle.
-    th = คุณได้เพิ่มสถานที่ในหมวดหมู่ที่เรายังไม่รองรับ มันจะปรากฏบนแผนที่หลังจากนี้สักพักหนึ่ง
-    tr = Henüz desteklemediğimiz bir kategori yeri eklediniz. Bir süre sonra haritada yer alacaktır.
-    uk = Ви додали об'єкт, категорію якого ми поки що не підтримуємо. У майбутньому він з'явиться на мапі.
-    vi = Bạn đã thêm một địa điểm của một hạng mục mà chúng tôi chưa hỗ trợ. Nó sẽ xuất hiện trên bản đồ một thời gian sau đó.
-    zh-Hans = 您已添加了一个我们尚未支持类别的地点。它将在一段时间之后显示在地图上。
-    zh-Hant = 您已新增了一個我們尚未支援的類別的地點。它未來會顯示在地圖上。
-    sk = Pridali ste miesto z kategórie, ktorú zatiaľ nepodporujeme. Na mape sa zobrazí až za istú dobu.
-    fa = شما شی ای را دسته بندی کرده اید که ما تاکنون از ان پشتیبانی نمی کرده ایم.ما ان را در اینده در نقشه نشان خواهیم داد.
+    sk = Vďaka mne sú mapy na Organic Maps lepšie
 
   [downloader_of]
     comment = Downloaded 10 **of** 20 <- it is that "of"
+    tags = ios, android
     en = %1$d of %2$d
     ru = %1$d из %2$d
     ar = %1$d من%2$d
@@ -16029,10 +10483,11 @@
     zh-Hans = %1$d个/共%2$d个
     zh-Hant = %1$d個/共%2$d個
     el = %1$d από %2$d
-    sk = %1$d z %2$d
     fa = %1$d  از  %2$d
+    sk = %1$d z %2$d
 
   [download_over_mobile_header]
+    tags = ios, android
     en = Download over a cellular network connection?
     ru = Загрузить через сотовую связь?
     ar = تنزيل باستخدام اتصال الشبكة الخلوية؟
@@ -16060,10 +10515,11 @@
     zh-Hans = 用手机网络连接下载吗？
     zh-Hant = 用手機網絡連接下載嗎？
     el = Να γίνει λήψη μέσω δικτύου κινητής τηλεφωνίας;
-    sk = Sťahovať prostredníctvom pripojenia na mobilnú sieť?
     fa = دانلود بر روی یک شبکه دیتای موبایل؟
+    sk = Sťahovať prostredníctvom pripojenia na mobilnú sieť?
 
   [download_over_mobile_message]
+    tags = ios, android
     en = This could be considerably expensive with some plans or if roaming.
     ru = На некоторых тарифных планах или в роуминге это может привести к значительным расходам.
     ar = قد يكون هذا مكلفا جدا لبعض الخطط أو عند التجوال.
@@ -16091,10 +10547,11 @@
     zh-Hans = 用一些方案或漫游的话这可能相当昂贵。
     zh-Hant = 用某些方案或漫遊的話這可能相當昂貴。
     el = Αυτό μπορεί να είναι σημαντικά πιο ακριβό για μερικά πακέτα ή στην περίπτωση περιαγωγής
-    sk = V prípade niektorých plánov alebo použitím roamingu by to mohlo byť značne nákladné.
     fa = این کار می تواند برای شما در بعضی طرح ها و یا حالت رومینگ هزینه اضافی در بر داشته باشد.
+    sk = V prípade niektorých plánov alebo použitím roamingu by to mohlo byť značne nákladné.
 
   [error_enter_correct_house_number]
+    tags = ios, android
     en = Enter a valid building number
     ru = Введите корректный номер дома
     ar = أدخل رقم منزل صحيح
@@ -16123,8 +10580,8 @@
     zh-Hans = 输入正确的房屋号
     zh-Hant = 輸入正確的門牌號碼
     el = Εισαγάγετε έναν έγκυρο αριθμό κτιρίου
-    sk = Zadajte správne číslo domu
     fa = وارد کردن شماره ساختمان معتبر
+    sk = Zadajte správne číslo domu
 
   [editor_storey_number]
     tags = ios, android
@@ -16156,8 +10613,8 @@
     zh-Hans = 楼号 (最大 %d)
     zh-Hant = 樓號（最大 %d）
     el = Αριθμός ορόφων (μέγιστο %d)
-    sk = Počet poschodí (max %d)
     fa = تعداد طبقات ( حداکثر %d )
+    sk = Počet poschodí (max %d)
 
   [error_enter_correct_storey_number]
     comment = Error message in Editor when a user tries to set the number of floors for a building higher than 25
@@ -16190,8 +10647,8 @@
     zh-Hans = 编辑最多 25 层的建筑
     zh-Hant = 編輯最多 25 層的建築
     el = Ο αριθμός των ορόφων δεν πρέπει να υπερβαίνει τους 25
-    sk = Upraviť s maximálne 25 poschodiami
     fa = تعداد طبقات نباید بیش از 25 باشد
+    sk = Upraviť s maximálne 25 poschodiami
 
   [editor_zip_code]
     tags = ios, android
@@ -16223,8 +10680,8 @@
     zh-Hans = 邮编
     zh-Hant = 郵遞區號
     el = Ταχυδρομικός κώδικας
-    sk = PSČ
     fa = کدپستی
+    sk = PSČ
 
   [error_enter_correct_zip_code]
     tags = ios, android
@@ -16256,8 +10713,8 @@
     zh-Hans = 输入正确的邮编
     zh-Hant = 輸入正確的郵遞區號
     el = Πληκτρολογήστε έναν έγκυρο ταχυδρομικό κώδικα
-    sk = Zadajte správne PSČ
     fa = یک کد پستی معتبر وارد کنید
+    sk = Zadajte správne PSČ
 
   [core_placepage_unknown_place]
     comment = Place Page title for long tap
@@ -16290,10 +10747,11 @@
     zh-Hans = 未知位置
     zh-Hant = 未知的位置
     el = Άγνωστο μέρος
-    sk = Neznáme miesto
     fa = مکان ناشناس
+    sk = Neznáme miesto
 
   [editor_other_info]
+    tags = ios, android
     en = Send a note to OSM editors
     ru = Отправить заметку редакторам OSM
     ar = ارسل ملاحظة إلى محرري OSM
@@ -16314,18 +10772,18 @@
     pt-BR = Envie uma nota para os editores OSM
     ro = Trimite o notă editorilor OSM
     es = Enviar nota a los editores de OSM
-    es-MX = Enviar nota a los editores de OSM
     sv = Skicka en not till OSM-redaktörer
     th = ส่งข้อความไปยังตัวปรับแต่ง OSM
     tr = OSM editörlerine bir not gönderin
     uk = Надіслати нотатку редакторам OSM
     vi = Gửi ghi chú cho ban biên tập OSM
-    el = Σημείωμα στους συντάκτες του OSM
-    sk = Odoslať poznámku OSM editorom
-    sw = Tuma ujumbe kwenye vihariri vya OSM
     zh-Hans = 给OSM编辑器发送标记
     zh-Hant = 給OSM編輯器發送標記
+    el = Σημείωμα στους συντάκτες του OSM
+    es-MX = Enviar nota a los editores de OSM
     fa = ارسال یادداشت به ویرایشکنندگان OSM
+    sk = Odoslať poznámku OSM editorom
+    sw = Tuma ujumbe kwenye vihariri vya OSM
 
   [editor_detailed_description_hint]
     tags = ios, android
@@ -16357,8 +10815,8 @@
     zh-Hans = 详细备注
     zh-Hant = 詳細註釋
     el = Αναλυτικό σχόλιο
-    sk = Zmazaná poznámka
     fa = اظهارنظر بیشتر
+    sk = Zmazaná poznámka
 
   [editor_detailed_description]
     tags = ios, android
@@ -16390,8 +10848,8 @@
     zh-Hans = 您建议的更改将发送至 OpenStreetMap 社区。说明无法在 Organic Maps 编辑的详情。
     zh-Hant = 您建議的變更將傳送至 OpenStreetMap 社群。說明無法在 Organic Maps 中編輯的詳細資料。
     el = Οι προτεινόμενες αλλαγές χάρτη θα σταλούν στην Κοινότητα του OpenStreetMap. Περιγράψτε τυχόν πρόσθετα στοιχεία που δεν μπορείτε να επεξεργαστείτε στο Organic Maps.
-    sk = Vami navrhované zmeny sa odošlú do komunity OpenStreetMap. Popíšte detaily, ktoré sa nedajú upraviť v Organic Maps.
     fa = شما یک سری تغییرات در نقشه را برای انجمن OpenStreetMap ارسال کردید.جزئیات اضافی را که نتوانستید در Organic Maps ویرایش کنید را برایشان بنویسید.
+    sk = Vami navrhované zmeny sa odošlú do komunity OpenStreetMap. Popíšte detaily, ktoré sa nedajú upraviť v Organic Maps.
 
   [editor_more_about_osm]
     tags = ios, android
@@ -16423,10 +10881,11 @@
     zh-Hans = 关于 OpenStreetMap 的更多信息
     zh-Hant = 關於 OpenStreetMap 的更多資訊
     el = Περισσότερα σχετικά με το OpenStreetMap
-    sk = Viac o OpenStreetMap
     fa = در مورد OpenStreetMap بیشتر بدانید
+    sk = Viac o OpenStreetMap
 
   [editor_operator]
+    tags = ios, android
     en = Owner
     ru = Владелец
     ar = معامل
@@ -16455,196 +10914,11 @@
     zh-Hans = 运营者
     zh-Hant = 營運者
     el = Ιδιοκτήτης
-    sk = Prevádzkovateľ
     fa = مالک
-
-  [editor_tag_description]
-    en = Enter company, organization or individual responsible for the facilities.
-    ru = Укажите компанию, организацию или лицо, которое отвечает за работоспособность объекта.
-    ar = أدخل الشركة أو المؤسسة أو الشخص المسؤول عن المنشآت.
-    cs = Zadejte osobu, společnost nebo organizaci, která zodpovídá za zařízení.
-    da = Angiv firmaet, organisationen eller personen som er ansvarlig for faciliteterne.
-    nl = Voer het bedrijf, de organisatie of het individu in dat verantwoordelijk is voor de faciliteiten.
-    fi = Syötä tiloista vastuussa oleva yhtiö, organisaatio tai henkilö
-    fr = Entrer la société, l'organisation ou l'individu responsable des installations.
-    de = Geben Sie die Firma, die Organisation oder die Person an, die den Betrieb des Objekts gewährleistet.
-    hu = Írja ide a működtetésért felelős cég, szervezet vagy magánszemély nevét.
-    id = Masukkan perusahaan, organisasi, atau individu yang bertanggung jawab atas fasilitas tersebut.
-    it = Inserire la società, organizzazione o soggetto responsabile per la struttura.
-    ja = 施設を管理する企業、組織または個人を入力してください。
-    ko = 회사, 조직 또는 시설 책임자를 입력하세요.
-    nb = Angi firma, organisasjon eller enkeltperson som er ansvarlig for anlegget.
-    pl = Wprowadź nazwę firmy, organizacji lub osoby odpowiedzialnej za obiekty.
-    pt = Introduza a empresa, organização ou indivíduo responsável pelas instalações.
-    pt-BR = Informe a companhia, a organização ou o indivíduo responsável pelas instalações.
-    ro = Introduceți compania, organizația sau persoana responsabilă de facilități.
-    es = Introduzca la empresa, organización o individuo responsable de las instalaciones.
-    sv = Ange företag, organisation eller person som är ansvarig för lokalerna.
-    th = ใส่ชื่อบริษัท, องค์กร หรือ บุคคลที่เป็นผู้รับผิดชอบสถานที่นี้
-    tr = Tesislerden sorumlu şirketi, kurumu veya bireyi girin.
-    uk = Вкажіть компанію, організацію або особу, що відповідає за працездатність об'єкта
-    vi = Nhập công ty, tổ chức hoặc cá nhân phụ trách cơ sở.
-    zh-Hans = 输入公司、组织或设施负责人。
-    zh-Hant = 輸入公司、組織或設施負責人。
-    sk = Zadajte spoločnosť, organizáciu alebo osobu zodpovednú za prevádzku.
-    fa = نام شرکت,سازمان یا اطلاعات قابل قبول برای این ساختمان را وارد کنید.
-
-  [editor_no_local_edits_title]
-    en = You don't have local edits
-    ru = У вас пока нет локальных правок
-    ar = ليست لديك تعديلات محلية
-    cs = Neprovedli jste žádné místní úpravy
-    da = Du har ikke lokale ændringer
-    nl = U hebt geen lokale bewerkingen
-    fi = Sinulla ei ole paikallisia muokkauksia
-    fr = Vous n'avez pas de modifications locales
-    de = Sie haben keine lokalen Korrekturen
-    hu = Nincsenek helyi módosításai
-    id = Anda tidak memiliki pengeditan lokal
-    it = Non vi sono modifiche locali
-    ja = ローカル編集はできません
-    ko = 편집한 지역정보가 없습니다
-    nb = Du har ikke lokale redigeringer
-    pl = Nie masz lokalnych edycji
-    pt = Não tem edições locais
-    pt-BR = Você não tem edições locais
-    ro = Nu aveți modificări locale
-    es = No tiene ediciones locales
-    sv = Du har inga lokala redigeraingar
-    th = คุณไม่มีการแก้ไขท้องถิ่น
-    tr = Yerel düzenlemeniz yok
-    uk = Поки що ви не маєте локальних виправлень
-    vi = Bạn không có những chỗ sửa cục bộ
-    zh-Hans = 您没有本地编辑
-    zh-Hant = 您沒有本機編輯
-    sk = Nemáte miestne poznámky
-    fa = شما ویرایش محلی ندارید
-
-  [editor_no_local_edits_description]
-    en = This shows the number of your suggested changes on the map that are currently accessible only on your device.
-    ru = Здесь отображается количество предложенных вами изменений на карте, которые доступны пока только на вашем устройстве.
-    ar = يوضح هذا عدد التغييرات المقترحة على الخريطة والتي يمكن الوصول إليها حاليًا فقط من على جهازك.
-    cs = Zde vidíte počet navržených změn, které jsou v tuto chvíli dostupné pouze na Vašem zařízení.
-    da = Den viser antallet af dine foreslåede ændringer på kortet, der kun er tilgængelige på din enhed.
-    nl = Dit toont het aantal voorgestelde wijzigingen voor de kaart die momenteel alleen toegankelijk zijn op uw apparaat.
-    fi = Tämä näyttää ehdottamiesi muutosten lukumäärän tällä hetkellä vain sinun laitteessasi saatavissa olevassa kartassa.
-    fr = Affiche le nombre de modifications suggérées dans la carte actuellement uniquement accessible sur votre périphérique.
-    de = Hier erscheint die Anzahl Ihrer Änderungsvorschläge für die Karte, auf die Sie bislang nur von Ihrem Gerät aus zugreifen können.
-    hu = Itt a pillanatnyilag csak az Ön készülékén elérhető térképek javasolt módosításainak száma látható.
-    id = Ini menunjukkan jumlah saran perubahan dalam peta yang saat ini hanya dapat diakses di perangkat Anda.
-    it = Qui è visualizzato il numero di modifiche suggerite sulla mappa che sono attualmente solo accessibili sul tuo dispositivo.
-    ja = これは、現在お使いのデバイスでのみアクセス可能な、マップ上に提案された変更の数を示しています。
-    ko = 이는 현재 귀하의 장치에서만 액세스할 수 있으며, 지도에서 만든 변경사항를 보여줍니다.
-    nb = Dette viser antallet foreslåtte endringer på kartet som i øyeblikket bare er tilgjengelige på enheten din.
-    pl = Jest to liczba sugerowanych przez ciebie zmian na mapie, które aktualnie dostępne są tylko na twoim urządzeniu.
-    pt = Isto demonstra o número das suas alterações sugeridas no mapa que atualmente só são acessíveis no seu dispositivo.
-    pt-BR = Isto mostra o número de mudanças no mapa sugeridas por você que atualmente estão disponíveis apenas no seu dispositivo.
-    ro = Acesta arată numărul de modificări sugerate pe hartă care sunt momentan accesibile doar pe dispozitivul dvs.
-    es = Esto muestra el número de sus cambios sugeridos en el mapa que actualmente solo son accesibles desde su dispositivo.
-    sv = Detta visar antalet föreslagna förändringar på kartan som som endast är tillgängliga på din enhet.
-    th = หมายเลขที่แสดงอยู่ คือ หมายเลขที่คุณได้ทำการแนะนำการเปลี่ยนแปลงบนแผนที่ที่สามารถเข้าถึงได้โดยอุปกรณ์ของคุณท่านั้น
-    tr = Bu, harita üzerinde önerdiğiniz değişikliklerden sadece şu anda cihazınızda erişilebilenlerin sayısını gösterir.
-    uk = Тут відображається кількість запропонованих вами змін на карті, які доступні тільки на вашому пристрою
-    vi = Thông tin này cho biết số thay đổi đề nghị của bạn trên bản đồ hiện chỉ có thể truy cập trên thiết bị của bạn.
-    zh-Hans = 这显示了当前仅在您设备上能够访问的对地图建议修改的数量。
-    zh-Hant = 這顯示了對目前僅可在您的裝置上存取的地圖的建議修改數量。
-    sk = Tu sa zobrazuje počet navrhovaných zmien na mape momentálne dostupných len vo vašom zariadení.
-
-  [editor_send_to_osm]
-    en = Send to OSM
-    ru = Отправить в OSM
-    ar = إرسال الى OSM
-    cs = Odeslat do OSM
-    da = Send til OSM
-    nl = Naar OSM sturen
-    fi = Lähetä OSM:ään
-    fr = Envoyer à OSM
-    de = An OSM senden
-    hu = Küldés az OSM-nek
-    id = Kirim ke OSM
-    it = Invia a OSM
-    ja = OSMに送信
-    ko = OSM에 전송
-    nb = Send til OSM
-    pl = Wyślij do OSM
-    pt = Enviar para OSM
-    pt-BR = Enviar para o OSM
-    ro = Trimitere la OSM
-    es = Enviar a OSM
-    sv = Skicka till OSM
-    th = ส่งไปที่ OSM
-    tr = OSM’ye gönder
-    uk = Відправити до OSM
-    vi = Gửi đến OSM
-    zh-Hans = 发送至 OSM
-    zh-Hant = 傳送至 OSM
-    sk = Odoslať do OSM
-    fa = ارسال به OSM
-
-  [editor_remove]
-    en = Remove
-    ru = Удалить
-    ar = إزالة
-    cs = Odstranit
-    da = Fjern
-    nl = Verwijderen
-    fi = Poista
-    fr = Supprimer
-    de = Löschen
-    hu = Eltávolítás
-    id = Hapus
-    it = Rimuovi
-    ja = 削除
-    ko = 삭제
-    nb = Fjern
-    pl = Usuń
-    pt = Remover
-    pt-BR = Remover
-    ro = Eliminare
-    es = Eliminar
-    sv = Ta bord
-    th = ลบออก
-    tr = Kaldır
-    uk = Видалити
-    vi = Xóa
-    zh-Hans = 删除
-    zh-Hant = 移除
-    sk = Odstrániť
-    fa = پاک کردن
-
-  [downloader_my_maps_title]
-    en = My maps
-    ru = Мои карты
-    ar = خرائطي
-    cs = Mé mapy
-    da = Mine kort
-    nl = Mijn kaarten
-    fi = Omat kartat
-    fr = Mes cartes
-    de = Meine Karten
-    hu = Térképeim
-    id = Peta saya
-    it = Le mie mappe
-    ja = マイマップ
-    ko = 내 지도
-    nb = Mine kart
-    pl = Moje mapy
-    pt = Os meus mapas
-    pt-BR = Meus mapas
-    ro = Hărțile mele
-    es = Mis mapas
-    sv = Mina kartor
-    th = แผนที่ของฉัน
-    tr = Haritalarım
-    uk = Мої мапи
-    vi = Bản đồ của tôi
-    zh-Hans = 我的地图
-    zh-Hant = 我的地圖
-    el = Οι χάρτες μου
-    sk = Moje mapy
-    fa = نقشه های من
+    sk = Prevádzkovateľ
 
   [downloader_no_downloaded_maps_title]
+    tags = ios, android
     en = You haven't downloaded any maps
     ru = У вас нет загруженных карт
     ar = لم تقم بتنزيل أية خرائط
@@ -16673,10 +10947,11 @@
     zh-Hans = 您尚未下载任何地图
     zh-Hant = 您尚未下載任何地圖
     el = Δεν έχετε κατεβάσει χάρτες
-    sk = Neprevzali ste žiadne mapy
     fa = شما هیچ نقشه دانلود شده ای ندارید
+    sk = Neprevzali ste žiadne mapy
 
   [downloader_no_downloaded_maps_message]
+    tags = ios, android
     en = Download maps to search for a location and use navigation offline.
     ru = Загрузите необходимые карты, чтобы находить места и пользоваться навигацией без интернета.
     ar = قم بتنزيل خرائط للبحث عن مكان والتنقل بدون اتصال بالإنترنت.
@@ -16705,42 +10980,12 @@
     zh-Hans = 下载地图来查找位置和离线浏览
     zh-Hant = 下載地圖來尋找位置和離線瀏覽。
     el = Κατεβάστε χάρτες για να αναζητήσετε μια τοποθεσία και να χρησιμοποιήσετε την πλοήγησης χωρίς σύνδεση.
-    sk = Prevziať mapy na nájdenie pozície a navigovanie off-line.
     fa = برای جست وجو یک مکان و استفاده از قابلیت ناوبری, نقشه ها را دانلود کنید.
-
-  [downloader_find_place_hint]
-    en = Search city or country
-    ru = Найти город или страну
-    ar = البحث في المدينة أو البلد
-    cs = Prohledat město nebo zemi
-    da = Søg by eller land
-    nl = Stad of land zoeken
-    fi = Etsi kaupunki tai maa
-    fr = Rechercher ville ou pays
-    de = Stadt oder Land suchen
-    hu = Város vagy ország keresése
-    id = Cari kota atau negara
-    it = Cerca città o paese
-    ja = 都市や国を検索
-    ko = 도시/국가 검색
-    nb = Søk etter by eller land
-    pl = Szukaj miasta lub kraju
-    pt = Pesquisar cidade ou país
-    pt-BR = Pesquisar cidade ou país
-    ro = Căutare oraș sau țară
-    es = Buscar ciudad o país
-    sv = Sök stad eller land
-    th = ค้นหาชื่อเมือง หรือ ประเทศ
-    tr = Şehirde veya ülkede arama yapın
-    uk = Знайти місто або країну
-    vi = Tìm kiếm thành phố hoặc quốc gia
-    zh-Hans = 搜索城市或国家
-    zh-Hant = 搜尋城市或國家
-    sk = Hľadať mesto alebo krajinu
-    fa = جست وجوی شهر یا کشور
+    sk = Prevziať mapy na nájdenie pozície a navigovanie off-line.
 
   [current_location_unknown_title]
     comment = Error title that appears after certain time without location.
+    tags = ios, android
     en = Continue detecting your current location?
     ru = Продолжить поиск местоположения?
     ar = هل تريد متابعة اكتشاف موقعك الحالي؟
@@ -16769,11 +11014,12 @@
     zh-Hans = 继续检测您的当前位置？
     zh-Hant = 繼續偵測您的目前位置？
     el = Να συνεχίσει να ανιχνεύεται η τρέχουσα θέση σας;
-    sk = Pokračovať v mazaní vašej súčasnej pozície?
     fa = ایا یافتن مکان تان را ادامه می دهید؟
+    sk = Pokračovať v mazaní vašej súčasnej pozície?
 
   [current_location_unknown_message]
     comment = Error that appears after certain time without location.
+    tags = ios, android
     en = Current location is unknown. Maybe you are in a building or in a tunnel.
     ru = Местоположение не найдено. Возможно, вы находитесь в помещении или в туннеле.
     ar = الموقع الحالي غير معروف. ربما تتواجد داخل مبنى أو نفق.
@@ -16802,10 +11048,11 @@
     zh-Hans = 当前位置未知，可能您在建筑内或隧道内。
     zh-Hant = 目前位置未知，可能您在建築物內或隧道內。
     el = Η τρέχουσα τοποθεσία είναι άγνωστη. Ίσως είστε σε ένα κτίριο ή σε μια σήραγγα.
-    sk = Súčasná pozícia je neznáma. Možno sa nachádzate v budove alebo v tuneli.
     fa = مکان شما ناشناس مانده است.ممکن است شما داخل یک ساختمان یا تونل باشید.
+    sk = Súčasná pozícia je neznáma. Možno sa nachádzate v budove alebo v tuneli.
 
   [current_location_unknown_continue_button]
+    tags = ios, android
     en = Continue
     ru = Продолжить
     ar = استمرار
@@ -16834,10 +11081,11 @@
     zh-Hans = 继续
     zh-Hant = 繼續
     el = Συνέχεια
-    sk = Pokračovať
     fa = ادامه
+    sk = Pokračovať
 
   [current_location_unknown_stop_button]
+    tags = ios, android
     en = Stop
     ru = Стоп
     ar = إيقاف
@@ -16866,10 +11114,11 @@
     zh-Hans = 停止
     zh-Hant = 停止
     el = Στοπ
-    sk = Zastaviť
     fa = توقف
+    sk = Zastaviť
 
   [current_location_unknown_error_title]
+    tags = ios
     en = Current location is unknown.
     ru = Местоположение не найдено.
     ar = الموقع الحالي غير معروف.
@@ -16897,10 +11146,11 @@
     zh-Hans = 当前位置未知
     zh-Hant = 目前位置未知。
     el = Η τρέχουσα τοποθεσία είναι άγνωστη.
-    sk = Súčasná pozícia je neznáma.
     fa = مکان فعلیتان ناشناس است.
+    sk = Súčasná pozícia je neznáma.
 
   [current_location_unknown_error_message]
+    tags = ios
     en = An error occurred while searching for your location. Check that your device is working properly and try again later.
     ru = При поиске местоположения произошла неизвестная ошибка. Проверьте работоспособность устройства и попробуйте найти местоположение позднее.
     ar = حدث خطأ أثناء البحث عن موقعك. تأكد من أن جهازك يعمل بشكل صحيح وأعد المحاولة لاحقًا.
@@ -16929,10 +11179,11 @@
     zh-Hans = 搜索您的位置时发生错误。请检查您的设备是否工作正常，然后重试。
     zh-Hant = 搜尋您的位置時發生錯誤。請檢查您的裝置是否正常運作，然後重試。
     el = Παρουσιάστηκε σφάλμα κατά την αναζήτηση της τοποθεσίας σας. Ελέγξτε αν η συσκευή σας λειτουργεί κανονικά και δοκιμάστε ξανά αργότερα.
-    sk = Počas vyhľadávania vašej pozície došlo k chybe. Skontrolujte, či zariadenie pracuje správne a skúste to znova.
     fa = خطایی در هنگام جست وجوی مکان شمارخ داده است.بررسی کنیید دستگاهتان به درستی کار می کند و دوباره تلاش کنید.
+    sk = Počas vyhľadávania vašej pozície došlo k chybe. Skontrolujte, či zariadenie pracuje správne a skúste to znova.
 
   [location_services_disabled_header]
+    tags = ios
     en = Location services are disabled
     ru = Определение местоположения отключено
     ar = تم تعطيل تحديد الموقع
@@ -16961,11 +11212,12 @@
     zh-Hans = 地点定位被禁用
     zh-Hant = 地點定位被禁用
     el = Οι υπηρεσίες εντοπισμού τοποθεσίας είναι απενεργοποιημένες
+    fa = سرویس موقعیت مکانی شما غیرفعال است
     he = זיהוי המיקום אינו מופעל
     sk = Identifikácia lokality je zablokovaná
-    fa = سرویس موقعیت مکانی شما غیرفعال است
 
   [location_services_disabled_message]
+    tags = ios
     en = Enable access to geolocation in the device settings
     ru = Разрешите доступ к геопозиции в настройках устройства.
     ar = قم بتفعيل الوصول إلى الموقع الجغرافي في إعدادات الجهاز
@@ -16994,9 +11246,9 @@
     zh-Hans = 启用设备设置中的地理位置定位
     zh-Hant = 啟用設備設置中的地理位置定位
     el = Ενεργοποίηση πρόσβασης γεωγραφικού εντοπισμού τοποθεσίας στις ρυθμίσεις της συσκευής
+    fa = سرویس موقعیت مکانی خود را در بخش تنظیمات فعال کنید.
     he = אפשרו גישה לגאולוקיישן בהגדרות המכשיר
     sk = Povoliť prístup ku geolokalizácii v nastaveniach prístroja
-    fa = سرویس موقعیت مکانی خود را در بخش تنظیمات فعال کنید.
 
   [location_services_disabled_1]
     tags = ios
@@ -17028,9 +11280,9 @@
     zh-Hans = 1. 打开设置
     zh-Hant = 1. 打開設置
     el = 1. Ανοίξτε τις ρυθμίσεις
+    fa = 1. بازکردن تنظیمات
     he = 1. פתחו את "הגדרות" (Settings)
     sk = 1. Otvorte Nastavenia
-    fa = 1. بازکردن تنظیمات
 
   [location_services_disabled_2]
     tags = ios
@@ -17067,6 +11319,7 @@
 
   [location_services_disabled_3]
     comment = iOS Dialog for the case when the location permission is not granted
+    tags = ios
     en = 3. Select While Using the App
     ru = 3. Выберите «При использовании программы»
     ar = 3. اختيار أثناء استخدام التطبيق
@@ -17097,438 +11350,8 @@
     el = 3. Επιλέξτε ενώ χρησιμοποιείτε την εφαρμογή
     sk = 3. Vyberte si počas používania aplikácie
 
-  [placepage_parking_surface]
-    en = Surface
-    ru = Открытая парковка
-    ar = سطح
-    cs = Povrch
-    da = Overflade
-    nl = Boven de grond
-    fi = Pinta
-    fr = Surface
-    de = Öffentlicher Parkplatz
-    hu = Szabadtéri parkoló
-    id = Parkir Luar
-    it = Superficie
-    ja = 表面
-    ko = 주차공간
-    nb = Åpen plass
-    pl = Powierzchnia
-    pt = Superfície
-    pt-BR = Superfície
-    ro = Suprafață
-    es = Superficie
-    sv = Yta
-    th = กลางแจ้ง
-    tr = Yüzey
-    uk = Відкрите паркування
-    vi = Trên mặt đất
-    zh-Hans = 表面
-    zh-Hant = 表面
-    sk = Typ parkoviska
-    fa = سطح
-
-  [placepage_parking_multistorey]
-    en = Multi-storey
-    ru = Многоэтажная наземная парковка
-    ar = متعدد الطوابق
-    cs = Vícepatrové
-    da = Flere etager
-    nl = Meerlaags
-    fi = Monikerroksinen
-    fr = Multi-niveaux
-    de = Tiefgarage mit mehreren Etagen
-    hu = Parkolóház
-    id = Bertingkat
-    it = Su più piani
-    ja = 複数階
-    ko = 주차장 건물
-    nb = Fleretasjers
-    pl = Wielopoziomowy
-    pt = Vários andares
-    pt-BR = Vários andares
-    ro = Multi-etajat
-    es = Varias plantas
-    sv = Flera våningar
-    th = หลายชั้น
-    tr = Çok Katlı
-    uk = Багатоповерхове наземне паркування
-    vi = Nhiều tầng
-    zh-Hans = 多层
-    zh-Hant = 多樓層
-    sk = Viacpodlažné
-    fa = چند طبقه
-
-  [placepage_parking_underground]
-    en = Underground
-    ru = Подземная парковка
-    ar = تحت الارض
-    cs = Podzemní
-    da = Underjordisk
-    nl = Onder de grond
-    fi = Maan alla
-    fr = Souterrain
-    de = Tiefgarage
-    hu = Föld alatti parkoló
-    id = Bawah Tanah
-    it = Sotterraneo
-    ja = 地下
-    ko = 지하
-    nb = Undergrunns
-    pl = Podziemny
-    pt = Local desconhecido
-    pt-BR = Subsolo
-    ro = Subteran
-    es = Subterráneo
-    sv = Under mark
-    th = ชั้นใต้ดิน
-    tr = Metro
-    uk = Підземне паркування
-    vi = Dưới mặt đất
-    zh-Hans = 地下
-    zh-Hant = 未知的位置
-    sk = Podzemné
-    fa = زیرزمین
-
-  [placepage_parking_rooftop]
-    en = Rooftop
-    ru = Парковка на крыше здания
-    ar = سطح المبنى
-    cs = Na střeše
-    da = Tagterrasse
-    nl = Dak
-    fi = Katolla
-    fr = Toit
-    de = Parkdeck
-    hu = Tetőparkoló
-    id = Atap
-    it = Su terrazza
-    ja = 屋上
-    ko = 옥상
-    nb = På taket
-    pl = Na dachu
-    pt = Terraço
-    pt-BR = Terraço
-    ro = Pe acoperiș
-    es = Azotea
-    sv = Hustak
-    th = ดาดฟ้า
-    tr = Çatı üstü
-    uk = Паркування на даху будівлі
-    vi = Trên mái
-    zh-Hans = 楼顶
-    zh-Hant = 樓頂
-    sk = Na streche
-    fa = پشت بام
-
-  [placepage_parking_sheds]
-    en = Sheds
-    ru = Частное легкое укрытие для автомобилей
-    ar = حظائر
-    cs = Samostatné
-    da = Skure
-    nl = Afdak
-    fi = Suojat
-    fr = Hangars
-    de = Privater Carport
-    hu = Fedett parkolóállás
-    id = Gudang
-    it = Coperto
-    ja = 小屋
-    ko = 창고
-    nb = Skur
-    pl = Wiaty
-    pt = Abrigos
-    pt-BR = Garagens cobertas
-    ro = Garaj
-    es = Cobertizos
-    sv = Skjul
-    th = ในร่ม
-    tr = Kulübe
-    uk = Приватне легке укриття для автомобілів
-    vi = Chỗ để xe
-    zh-Hans = 小屋
-    zh-Hant = 小屋
-    sk = Garáž
-    fa = سایبان
-
-  [placepage_parking_carports]
-    en = Carports
-    ru = Капитальный навес
-    ar = مظلات سيارات
-    cs = Přístřešek
-    da = Carporte
-    nl = Carports
-    fi = Autokatokset
-    fr = Abris auto
-    de = Parkhalle
-    hu = Nagyobb fedett parkoló
-    id = Parkir Beratap
-    it = Tettoia
-    ja = カーポート
-    ko = 간이 차고
-    nb = Carport
-    pl = Zadaszenia dla samochodów
-    pt = Garagens
-    pt-BR = Garagem coberta
-    ro = Garaje
-    es = Cochera
-    sv = Garage
-    th = โรงรถ
-    tr = Açık Park Alanları
-    uk = Капітальний навіс
-    vi = Nhà để xe
-    zh-Hans = 屋侧车库
-    zh-Hant = 屋側車庫
-    sk = Otvorené garáže
-    fa = گاراژ بدون سقف
-
-  [placepage_parking_boxes]
-    en = Garage boxes
-    ru = Гаражный бокс
-    ar = صناديق جراج
-    cs = Garáž
-    da = Garagekasser
-    nl = Garageboxen
-    fi = Autotalliruudut
-    fr = Box de garage
-    de = Garagenbox
-    hu = Garázsbox
-    id = Sasana tinju
-    it = Box
-    ja = ガレージボックス
-    ko = 차고
-    nb = Garasjebokser
-    pl = Miejsca parkingowe w garażu
-    pt = Garagens
-    pt-BR = Vaga de estacionamento
-    es = Garaje
-    sv = Garageboxar
-    th = โรงรถแบบกล่อง
-    tr = Garaj kutuları
-    uk = Гаражний бокс
-    vi = Thùng gara
-    zh-Hans = 停车房
-    zh-Hant = 停車房
-    sk = Hromadné garáže
-    fa = گاراژ
-
-  [placepage_parking_pay]
-    en = Pay
-    ru = Платная
-    ar = دفع
-    cs = Placené
-    da = Betal
-    nl = Betalen
-    fi = Maksullinen
-    fr = Payer
-    de = Gebührenpflichtig
-    hu = Fizetős
-    id = Berbayar
-    it = A pagamento
-    ja = 支払い
-    ko = 유료
-    nb = Betaling
-    pl = Płatny
-    pt = Pagamento
-    pt-BR = Pagamento
-    ro = Cu plată
-    es = De pago
-    sv = Kostnadsbelagd
-    th = เสียเงิน
-    tr = Ücretli
-    uk = Платне
-    vi = Trả phí
-    zh-Hans = 付款
-    zh-Hant = 付款
-    sk = Platené
-    fa = پرداخت
-
-  [placepage_parking_free]
-    en = Free
-    ru = Бесплатная
-    ar = مجانًا
-    cs = Zdarma
-    da = Gratis
-    nl = Gratis
-    fi = Ilmainen
-    fr = Gratuit
-    de = Gebührenfrei
-    hu = Díjmentes
-    id = Gratis
-    it = Gratis
-    ja = 無料
-    ko = 무료
-    nb = Gratis
-    pl = Darmowy
-    pt = Gratuito
-    pt-BR = Gratuito
-    ro = Gratuit
-    es = Gratuito
-    sv = Gratis
-    th = ฟรี
-    tr = Ücretsiz
-    uk = Безкоштовне
-    vi = Miễn phí
-    zh-Hans = 免费
-    zh-Hant = 免費
-    sk = Zdarma
-    fa = مجانی
-
-  [placepage_parking_interval]
-    en = Interval Pay
-    ru = Переменно платная
-    ar = دفع عن فترة
-    cs = Placeno za čas
-    da = Intervalbetaling
-    nl = Intervalbetaling
-    fi = Aikamaksu
-    fr = Période de paiement
-    de = Teilweise gebührenpflichtig
-    hu = Idősávos fizetős
-    id = Biaya Rutin
-    it = Pagamento a tempo
-    ja = 支払間隔
-    ko = 주차요금 간격
-    nb = Intervallbetaling
-    pl = Płatny na godziny
-    pt = Pagamento intervalado
-    pt-BR = Pago por tempo de uso
-    ro = Interval de plată
-    es = Pago por intervalos
-    sv = Delvis kostnadsbelagd
-    th = จ่ายตามช่วงเวลา
-    tr = Süre Ücretli
-    uk = Змінно платне
-    vi = Trả Phí Cách Quãng
-    zh-Hans = 间隔付款
-    zh-Hant = 間隔付款
-    sk = Platba v intervaloch
-
-  [placepage_entrance_number]
-    en = No.
-    ru = №
-    ar = رقم
-    cs = Č.
-    da = Nr.
-    nl = Nr.
-    fi = Nro.
-    fr = N°
-    de = Nr. der Einfahrt
-    hu = Szám
-    id = Nomor
-    it = N.
-    ja = 番号
-    ko = 번호
-    nb = Nr.
-    pl = Nr
-    pt = N.º
-    pt-BR = N.º
-    ro = Nr.
-    es = N.º
-    sv = Nr
-    th = หมายเลข
-    tr = No.
-    uk = №
-    vi = Số
-    zh-Hans = 编号
-    zh-Hant = 編號
-    sk = Číslo
-    fa = شماره.
-
-  [placepage_entrance_type]
-    en = Entrance
-    ru = Подъезд
-    ar = المدخل
-    cs = Vchod
-    da = Indgang
-    nl = Ingang
-    fi = Sisäänkäynti
-    fr = Entrée
-    de = Typ der Einfahrt
-    hu = Bejárat
-    id = Gerbang Masuk
-    it = Ingresso
-    ja = エントランス
-    ko = 입구
-    nb = Vindfang
-    pl = Wejście
-    pt = Entrada
-    pt-BR = Entrada
-    ro = Intrare
-    es = Entrada
-    sv = Entré
-    th = ทางเข้า
-    tr = Giriş
-    uk = Під'їзд
-    vi = Lối vào
-    zh-Hans = 入口
-    zh-Hant = 入口
-    sk = Vstup
-    fa = ورودی
-
-  [placepage_flat]
-    en = app.
-    ru = кв.
-    ar = تطبيق
-    cs = byt
-    da = app.
-    nl = app.
-    fi = sov.
-    fr = app.
-    de = Wohnung
-    hu = lakás
-    id = persegi
-    it = app.
-    ja = アプリ
-    ko = 앱
-    nb = leil.
-    pl = Mieszkanie
-    pt = apto.
-    pt-BR = apto.
-    ro = ap.
-    es = aplicación
-    sv = lgh
-    th = ห้อง
-    tr = uygulama
-    uk = кв.
-    vi = áp dụng
-    zh-Hans = 公寓
-    zh-Hant = 公寓
-    sk = Byt
-
-  [placepage_open_24_7]
-    en = 24 / 7
-    ru = Круглосуточно
-    ar = 24 / 7
-    cs = Nonstop
-    da = 24 / 7
-    nl = Dag en nacht
-    fi = 24 / 7
-    fr = 24h/24 et 7j/7
-    de = Durchgehend geöffnet
-    hu = 24 órás
-    id = 24 jam sehari, 7 hari seminggu
-    it = 24 / 7
-    ja = 24時間体制
-    ko = 연중무휴
-    nb = Døgnåpen
-    pl = 24 / 7
-    pt = 24 / 7
-    pt-BR = 24 / 7
-    ro = 24 / 7
-    es = 24 / 7
-    sv = Døgnet rundt
-    th = 24 ชั่วโมง
-    tr = 24 / 7
-    uk = Цілодобово
-    vi = 24 / 7
-    zh-Hans = 24 / 7
-    zh-Hant = 全天候
-    sk = 24 / 7
-    fa = شبانه روزی و هفت روز هفته (24 / 7)
-
   [meter]
+    tags = ios, android
     en = m
     ru = м
     ar = م
@@ -17556,10 +11379,11 @@
     vi = m
     zh-Hans = 米
     zh-Hant = 米
-    sk = m
     fa = متر
+    sk = m
 
   [kilometer]
+    tags = ios
     en = km
     ru = км
     ar = كم
@@ -17587,40 +11411,11 @@
     vi = km
     zh-Hans = 公里
     zh-Hant = 公里
-    sk = km
     fa = کیلومتر
-
-  [kilometers_per_hour]
-    en = km/h
-    ru = км/ч
-    ar = كم/ساعة
-    cs = km/h
-    da = km/t
-    nl = km/h
-    fi = km/h
-    fr = km/h
-    de = km / h
-    hu = km/h
-    id = km/j
-    it = chilometri orari (km/h)
-    ja = キロメートル毎時
-    ko = km/시
-    nb = km/t
-    pl = km/h
-    pt = km/h
-    ro = km/h
-    es = km/h
-    sv = km/h
-    th = กม./ชม.
-    tr = km/s
-    uk = км/год
-    vi = km/giờ
-    zh-Hans = 公里每小时
-    zh-Hant = 公里每小時
-    sk = km/h
-    fa = کیلومتربرساعت (km/h)
+    sk = km
 
   [mile]
+    tags = ios
     en = mi
     ru = ми
     ar = ميل
@@ -17647,10 +11442,11 @@
     vi = dặm
     zh-Hans = 英里
     zh-Hant = 英里
-    sk = mi
     fa = مایل
+    sk = mi
 
   [foot]
+    tags = ios, android
     en = ft
     ru = фут
     ar = قدم
@@ -17677,70 +11473,11 @@
     vi = ft
     zh-Hans = 英尺
     zh-Hant = 英尺
-    sk = stopa
     fa = فوت
-
-  [miles_per_hour]
-    en = mph
-    ru = ми/ч
-    ar = ميل/ساعة
-    cs = mil/h
-    da = mph
-    nl = mph
-    fi = mph
-    fr = mph
-    de = mph
-    hu = mph
-    id = mpj
-    it = mph
-    ja = マイル毎時
-    ko = mph
-    nb = mph
-    pl = mph
-    pt = mph
-    ro = mph
-    es = mph
-    sv = mph
-    th = ไมล์/ชม.
-    tr = mph
-    uk = ми/год
-    vi = mph
-    zh-Hans = 英里每小时
-    zh-Hant = 英里每小時
-    sk = mph
-    fa = مایل بر ساعت (mph)
-
-  [day]
-    en = d
-    ru = д
-    ar = ي
-    cs = dní
-    da = dag
-    nl = d
-    fi = p
-    fr = j
-    de = d
-    hu = n
-    id = h
-    it = g
-    ja = 日
-    ko = d
-    nb = d
-    pl = d
-    pt = d
-    ro = z
-    es = d
-    sv = d
-    th = ว.
-    tr = g
-    uk = д
-    vi = ngày
-    zh-Hans = 天
-    zh-Hant = 天
-    sk = d
-    fa = روز
+    sk = stopa
 
   [hour]
+    tags = android
     en = h
     ru = ч
     ar = س
@@ -17767,10 +11504,11 @@
     vi = giờ
     zh-Hans = 小時
     zh-Hant = 小時
-    sk = hod
     fa = ساعت
+    sk = hod
 
   [minute]
+    tags = android
     en = min
     ru = мин
     ar = د
@@ -17797,10 +11535,11 @@
     vi = phút
     zh-Hans = 分鐘
     zh-Hant = 分鐘
-    sk = min
     fa = دقیقه
+    sk = min
 
   [placepage_place_description]
+    tags = android
     en = Description
     ru = Описание
     ar = الوصف
@@ -17828,10 +11567,11 @@
     vi = Mô tả
     zh-Hans = 说明
     zh-Hant = 說明
-    sk = Popis
     fa = توضیحات
+    sk = Popis
 
   [placepage_more_button]
+    tags = ios, android
     en = More
     ru = Ещё
     ar = المزيد
@@ -17860,10 +11600,11 @@
     zh-Hans = 更多
     zh-Hant = 更多
     el = Περισσότερα
-    sk = Viac
     fa = بیشتر
+    sk = Viac
 
   [placepage_more_reviews_button]
+    tags = android
     en = More Reviews
     ru = Ещё отзывы
     ar = المزيد من المراجعات
@@ -17884,20 +11625,21 @@
     pt-BR = Mais Avaliações
     ro = Mai multe recenzii
     es = Más comentarios
-    es-MX = Más comentarios
     sv = Fler recensioner
     th = รีวิวอื่น ๆ
     tr = Diğer yorumlar
     uk = Ще відгуки
     vi = Thêm nhận xét
-    el = Περισσότερα σχόλια
-    sk = Ďalšie recenzie
-    sw = Maoni Zaidi
     zh-Hans = 更多评论
     zh-Hant = 更多評論
+    el = Περισσότερα σχόλια
+    es-MX = Más comentarios
     fa = نقدهای دیگر
+    sk = Ďalšie recenzie
+    sw = Maoni Zaidi
 
   [book_button]
+    tags = ios, android
     en = Book
     ru = Забронировать
     ar = حجز
@@ -17925,10 +11667,11 @@
     vi = Đặt trước
     zh-Hans = 预約
     zh-Hant = 預約
-    sk = Rezervovať
     fa = رزرو
+    sk = Rezervovať
 
   [placepage_call_button]
+    tags = ios, android
     en = Call
     ru = Позвонить
     ar = اتصال
@@ -17957,10 +11700,11 @@
     zh-Hans = 呼叫
     zh-Hant = 呼叫
     el = Κλήση
-    sk = Zavolať
     fa = تماس
+    sk = Zavolať
 
   [placepage_edit_bookmark_button]
+    tags = ios, android
     en = Edit Bookmark
     ru = Редактировать метку
     ar = تحرير العلامة المرجعية
@@ -17989,10 +11733,11 @@
     zh-Hans = 编辑书签
     zh-Hant = 編輯書籤
     el = Επεξεργασία αγαπημένου
-    sk = Upraviť záložku
     fa = ویرایش نشانه ها
+    sk = Upraviť záložku
 
   [placepage_bookmark_name_hint]
+    tags = ios
     en = Bookmark Name
     ru = Название метки
     ar = اسم العلامة المرجعية
@@ -18021,74 +11766,11 @@
     zh-Hans = 书签名称
     zh-Hant = 書籤名稱
     el = Όνομα αγαπημένου
-    sk = Názov záložky
     fa = نام نشانه ها
-
-  [placepage_personal_notes_hint]
-    en = Personal notes
-    ru = Примечание
-    ar = ملاحظات شخصية
-    cs = Vlastní poznámka
-    da = Personlige notater
-    nl = Persoonlijke aantekeningen
-    fi = Henkilökohtaiset merkinnät
-    fr = Remarques personnelles
-    de = Anmerkung
-    hu = Jegyzet
-    id = Catatan pribadi
-    it = Note personali
-    ja = パーソナルメモ
-    ko = 개인 메모
-    nb = Personlige notater
-    pl = Notatki osobiste
-    pt = Notas pessoais
-    pt-BR = Anotações pessoais
-    ro = Note personale
-    es = Notas personales
-    sv = Personlig anteckning
-    th = ข้อความส่วนตัว
-    tr = Kişisel notlar
-    uk = Примітка
-    vi = Ghi chú cá nhân
-    zh-Hans = 个人备注
-    zh-Hant = 個人備註
-    el = Προσωπικές σημειώσεις
-    sk = Osobné poznámky
-    fa = یاداشت های شخصی
-
-  [placepage_delete_bookmark_button]
-    en = Delete Bookmark
-    ru = Удалить метку
-    ar = حذف العلامة المرجعية
-    cs = Smazat záložku
-    da = Slet bogmærke
-    nl = Bladwijzer verwijderen
-    fi = Poista kirjanmerkki
-    fr = Supprimer signet
-    de = Lesezeichen löschen
-    hu = Könyvjelző törlése
-    id = Hapus Bookmark
-    it = Elimina segnalibro
-    ja = ブックマークを削除
-    ko = 즐겨찾기 삭제
-    nb = Slett bokmerke
-    pl = Usuń zakładkę
-    pt = Eliminar marcador
-    pt-BR = Apagar marcador
-    ro = Ștergere marcaj
-    es = Eliminar marcador
-    sv = Radera bokmärke
-    th = ลบ Bookmark
-    tr = Yer İmini Sil
-    uk = Видалити мiтку
-    vi = Xóa Dấu Trang
-    zh-Hans = 删除书签
-    zh-Hant = 刪除書籤
-    el = Διαγραφή αγαπημένου
-    sk = Zmazať záložku
-    fa = حذف نشانه
+    sk = Názov záložky
 
   [editor_edits_sent_message]
+    tags = ios
     en = Your suggested changes have been sent
     ru = Предложенные вами изменения отправлены
     ar = لقد تم إرسال التغييرات التي اقترحتها
@@ -18117,10 +11799,11 @@
     zh-Hans = 您的建议已发送
     zh-Hant = 您的建議已傳送
     el = Οι προτεινόμενες αλλαγές σας έχουν σταλεί
-    sk = Vykonali sa vami odporúčané zmeny
     fa = تغییر پیشنهادی شما ارسال شد
+    sk = Vykonali sa vami odporúčané zmeny
 
   [editor_comment_hint]
+    tags = ios, android
     en = Comment…
     ru = Коментарий…
     ar = تعليق…
@@ -18149,10 +11832,11 @@
     zh-Hans = 备注…
     zh-Hant = 註解…
     el = Σχόλιο…
-    sk = Poznámka…
     fa = اظهار نظر
+    sk = Poznámka…
 
   [editor_reset_edits_message]
+    tags = ios, android
     en = Discard all local changes?
     ru = Сбросить все локальные правки?
     ar = هل تريد مسح كافة التغييرات المحلية؟
@@ -18181,10 +11865,11 @@
     zh-Hans = 重置所有本地更改？
     zh-Hant = 重設所有本機變更？
     el = Απόρριψη όλων των τοπικών αλλαγών;
-    sk = Resetovať všetky miestne časy?
     fa = ایا تغییرات محلی را نادیده می گیرید؟
+    sk = Resetovať všetky miestne časy?
 
   [editor_reset_edits_button]
+    tags = ios, android
     en = Discard
     ru = Сбросить
     ar = مسح
@@ -18213,10 +11898,11 @@
     zh-Hans = 重置
     zh-Hant = 重設
     el = Απόρριψη
-    sk = Resetovať
     fa = نادیده گرفتن
+    sk = Resetovať
 
   [editor_remove_place_message]
+    tags = ios, android
     en = Delete added place?
     ru = Удалить добавленный вами объект?
     ar = إزالة مكان تمت إضافته؟
@@ -18245,10 +11931,11 @@
     zh-Hans = 删除已添加的位置？
     zh-Hant = 移除已新增的位置？
     el = Διαγραφή της τοποθεσίας που προστέθηκε;
-    sk = Odstrániť pridané miesto?
     fa = ایا مکان ثبت شده حذف شود؟
+    sk = Odstrániť pridané miesto?
 
   [editor_remove_place_button]
+    tags = ios, android
     en = Delete
     ru = Удалить
     ar = إزالة
@@ -18277,41 +11964,11 @@
     zh-Hans = 删除
     zh-Hant = 移除
     el = Διαγραφή
-    sk = Odstrániť
     fa = حذف
-
-  [editor_status_sending]
-    en = Sending…
-    ru = Отправка…
-    ar = جارِ الإرسال…
-    cs = Odesílání…
-    da = Send…
-    nl = Verzenden…
-    fi = Lähetetään…
-    fr = Envoyer…
-    de = Senden…
-    hu = Küldés…
-    id = Mengirim…
-    it = Invio…
-    ja = 送信中…
-    ko = 보내는 중…
-    nb = Sender…
-    pl = Wysyłanie…
-    pt = A enviar…
-    pt-BR = Enviando…
-    ro = Se trimite…
-    es = Enviando…
-    sv = Skickar…
-    th = กำลังส่ง…
-    tr = Gönderiliyor…
-    uk = Відправка…
-    vi = Đang gửi …
-    zh-Hans = 正在发送…
-    zh-Hant = 正在傳送…
-    sk = Odosiela sa…
-    fa = درحال ارسال
+    sk = Odstrániť
 
   [editor_place_doesnt_exist]
+    tags = ios, android
     en = Place does not exist
     ru = Места не существует
     ar = المكان غير موجود
@@ -18340,10 +11997,11 @@
     zh-Hans = 位置不存在
     zh-Hant = 位置不存在
     el = Η τοποθεσία δεν υπάρχει
-    sk = Miesto neexistuje
     fa = مکان وجود ندارد
+    sk = Miesto neexistuje
 
   [text_more_button]
+    tags = ios
     en = …more
     ru = …ещё
     ar = …المزيد
@@ -18372,11 +12030,12 @@
     zh-Hans = …更多
     zh-Hant = …更多
     el = …περισσότερα
+    fa = بیشتر….
     sk = …viac
-    fa = بیشتر....
 
   [error_enter_correct_phone]
     comment = Phone number error message
+    tags = ios, android
     en = Enter a valid phone number
     ru = Введите корректный номер телефона
     ar = أدخل رقم هاتف صحيح
@@ -18404,10 +12063,11 @@
     zh-Hans = 输入正确的电话号码
     zh-Hant = 輸入正確的電話號碼
     el = Εισάγετε έναν έγκυρο αριθμό τηλεφώνου
-    sk = Zadajte správne telefónne číslo
     fa = شماره تلفن معتبری وارد نمایید
+    sk = Zadajte správne telefónne číslo
 
   [error_enter_correct_web]
+    tags = ios, android
     en = Enter a valid web address
     ru = Введите корректный веб-адрес
     ar = أدخل عنوان ويب صالح
@@ -18435,10 +12095,11 @@
     zh-Hans = 输入有效网址
     zh-Hant = 輸入有效網址
     el = Εισάγετε μια έγκυρη διεύθυνση ιστοτόπου
-    sk = Zadajte platnú webovú adresu
     fa = ادرس وب معتبری وارد نمایید
+    sk = Zadajte platnú webovú adresu
 
   [error_enter_correct_email]
+    tags = ios, android
     en = Enter a valid email
     ru = Введите корректный email
     ar = أدخل بريدا إلكترونيا صالحا
@@ -18466,40 +12127,11 @@
     zh-Hans = 输入有效电子邮箱
     zh-Hant = 輸入有效電子郵箱
     el = Εισάγετε ένα έγκυρο email
-    sk = Zadajte platný email
     fa = ایمیل معتبری وارد نمایید
-
-  [error_enter_correct]
-    en = Enter a valid value
-    ru = Введите корректное значение
-    ar = أدخل قيمة صالحة
-    cs = Zadat platnou hodnotu
-    da = Indtast en gyldig værdi
-    nl = Voer een geldige waarde in
-    fi = Syötä kelvollinen arvo
-    fr = Saisir une valeur correcte
-    de = Geben Sie einen gültigen Wert ein
-    hu = Adj meg egy érvényes értéket
-    id = Masukkan nilai valid
-    it = Inserisci un valore valido
-    ja = 有効な値を入力してください
-    ko = 유효한 값 입력
-    nb = Oppgi en gyldig verdi
-    pl = Wpisz prawidłową wartość
-    pt = Preencha com um valor válido
-    ro = Introduceți o valoare validă
-    es = Introduce un valor válido
-    sv = Ange ett giltigt värde
-    th = กรอกค่าที่ถูกต้อง
-    tr = Geçerli bir değer girin
-    uk = Введіть вірне значення
-    vi = Nhập giá trị hợp lệ
-    zh-Hans = 输入有效值
-    zh-Hant = 輸入有效值
-    sk = Zadajte platnú hodnotu
-    fa = مقادیر معتبری وارد نمایید
+    sk = Zadajte platný email
 
   [refresh]
+    tags = ios
     en = Update
     ru = Обновить
     ar = تحديث
@@ -18528,42 +12160,11 @@
     zh-Hans = 更新
     zh-Hant = 更新
     el = Ενημέρωση
-    sk = Aktualizovať
     fa = بروزرسانی
-
-  [last_update]
-    en = Last update: %s
-    ru = Последнее обновление: %s
-    ar = أخر تحديث: %s
-    cs = Poslední aktualizace: %s
-    da = Sidste opdatering: %s
-    nl = Laatste update: %s
-    fi = Viimeisin päivitys: %s
-    fr = Dernière mise à jour à %s
-    de = Letzte Aktualisierung: %s
-    hu = Utolsó frissítés: %s
-    id = Pembaruan terakhir: %s
-    it = Ultimo aggiornamento: %s
-    ja = 最終更新日: %s
-    ko = 마지막 업데이트: %s
-    nb = Sist oppdatert: %s
-    pl = Ostatnia aktualizacja: %s
-    pt = Última atualização: %s
-    pt-BR = Última atualização: %s
-    ro = Ultima actualizare: %s
-    es = Última actualización: %s
-    sv = Senast uppdaterad: %s
-    th = การอัปเดตล่าสุด: %s
-    tr = Son güncelleme: %s
-    uk = Останнє оновлення: %s
-    vi = Cập nhật cuối cùng: %s
-    zh-Hans = 上次更新于：%s
-    zh-Hant = 上次更新於：%s
-    el = Τελευταία ενημέρωση: %s
-    sk = Naposledy aktualizované: %s
-    fa = اخرین بروزرسانی: %s
+    sk = Aktualizovať
 
   [placepage_add_place_button]
+    tags = ios, android
     en = Add a place to the map
     ru = Добавить место на карту
     ar = إضافة مكان ما للخريطة
@@ -18591,11 +12192,12 @@
     zh-Hans = 添加地点到地图上
     zh-Hant = 添加地點到地圖上
     el = Να προστεθεί η τοποθεσία στο χάρτη
-    sk = Pridať miesto na mape
     fa = اضافه کردن یک مکان به نقشه
+    sk = Pridať miesto na mape
 
   [editor_share_to_all_dialog_title]
     comment = Displayed when saving some edits to the map to warn against publishing personal data
+    tags = ios, android
     en = Do you want to send it to all users?
     ru = Отправить всем пользователям?
     ar = هل ترغب في إرساله لجميع المستخدمين؟
@@ -18623,11 +12225,12 @@
     zh-Hans = 您想要发给所有用户吗？
     zh-Hant = 您想要發給所有用戶嗎？
     el = Θέλετε να το στείλετε σε όλους τους χρήστες;
-    sk = Odoslať všetkým používateľom?
     fa = ایا می خواهید ان را برای دیگر کاربران ارسال کنید؟
+    sk = Odoslať všetkým používateľom?
 
   [editor_share_to_all_dialog_message_1]
     comment = iOS Dialog before publishing the modifications to the public map.
+    tags = ios, android
     en = Make sure you did not enter any personal data.
     ru = Убедитесь, что вы не ввели личные данные.
     ar = تأكد من أنك لم تقم بإدخال أي بيانات شخصية.
@@ -18655,10 +12258,11 @@
     zh-Hans = 确保您没有输入任何个人数据。
     zh-Hant = 確保您沒有輸入任何個人數據。
     el = Βεβαιωθείτε ότι δεν έχετε εισάγει προσωπικά δεδομένα.
-    sk = Nezadávajte žiadne osobné udaje.
     fa = مطمئن شوید که هیچ اطلاعات شخصی وارد نکرده باشد.
+    sk = Nezadávajte žiadne osobné udaje.
 
   [editor_share_to_all_dialog_message_2]
+    tags = ios, android
     en = We will check the changes. If we have any questions we will contact you via email.
     ru = Если при проверке изменений возникнут вопросы, мы напишем вам на email.
     ar = سنقوم بمراجعة هذه التغييرات. إذا كانت لدينا أي أسئلة فسوف نتصل بك عبر البريد الإلكتروني.
@@ -18686,250 +12290,8 @@
     zh-Hans = 我们会检查更改。如果我们有任何问题，我们会邮件与您联系。
     zh-Hant = 我們會檢查更改。如果我們有任何問題，我們會郵件與您聯系。
     el = Θα ελέγξουμε τις αλλαγές. Εάν έχουμε οποιαδήποτε απορία θα επικοινωνήσουμε μαζί σας μέσω email.
-    sk = Skontrolujeme zmeny. V prípade otázok vás budeme kontaktovať emailom.
     fa = ما تغییرات را بررسی می کنیم.اگر سوالی بود با ایمیل با شما تماس می گیریم.
-
-  [navigation_overview_button]
-    en = overview
-    ru = обзор
-    ar = استعراض
-    cs = přehled
-    da = oversigt
-    nl = overzicht
-    fi = yleiskatsaus
-    fr = aperçu
-    de = Überblick
-    hu = áttekintés
-    id = ikhtisar
-    it = panoramica
-    ja = 概要
-    ko = 개요
-    nb = oversikt
-    pl = przegląd
-    pt = visão geral
-    ro = rezumat
-    es = resumen
-    sv = översikt
-    th = ภาพรวม
-    tr = genel bakış
-    uk = огляд
-    vi = tổng quan
-    zh-Hans = 概览
-    zh-Hant = 概覽
-    sk = zhrnutie
-    fa = بررسی اجمالی
-
-  [navigation_stop_button]
-    en = stop
-    ru = стоп
-    ar = توقف
-    cs = stop
-    da = stop
-    nl = stoppen
-    fi = lopeta
-    fr = stop
-    de = Stop
-    hu = megállítás
-    id = berhenti
-    it = ferma
-    ja = 停止
-    ko = 중지
-    nb = stopp
-    pl = stop
-    pt = parar
-    ro = stop
-    es = parada
-    sv = stopp
-    th = หยุด
-    tr = dur
-    uk = стоп
-    vi = dừng
-    zh-Hans = 停止
-    zh-Hant = 停止
-    sk = stop
-    fa = توقف
-
-  [bookmarks_empty_title]
-    comment = Text on an empty bookmark page
-    en = Save Bookmarks
-    ru = Сохраняйте метки
-    ar = حفظ الإشارات المرجعية
-    cs = Uložte si své záložky
-    da = Gem bogmærker
-    nl = Bladwijzers opslaan
-    fi = Tallenna Kirjanmerkit
-    fr = Enregistrez des signets
-    de = Lesezeichen speichern
-    hu = Könyvjelzők mentése
-    id = Simpan Penanda
-    it = Salva i Segnalibri
-    ja = ブックマークを保存
-    ko = 북마크 저장
-    nb = Lagre bokmerker
-    pl = Zapisz zakładki
-    pt = Salvar Favoritos
-    ro = Salvare marcaje
-    es = Guardar marcadores
-    sv = Spara bokmärken
-    th = บันทึกบุ๊กมาร์ก
-    tr = Yer İşaretlerini Kaydet
-    uk = Зберегти закладки
-    vi = Lưu Đánh dấu trang
-    zh-Hans = 保存书签
-    zh-Hant = 儲存書籤
-    sk = Uložiť záložky
-    fa = ذخیره نشانه ها
-
-  [bookmarks_empty_message_1]
-    en = Tap on ★ to save favorite places for quick access.
-    ru = Нажмите ★, чтобы сохранить любимые места для быстрого доступа к ним.
-    ar = انقر على ★ لحفظ الأماكن المفضلة من أجل إمكانية الوصول السريع.
-    cs = Klikněte na ★ pro uložení oblíbených míst pro rychlý přístup.
-    da = Tryk på ★ for at gemme foretrukne steder til hurtig adgang.
-    nl = Tik op ★ om favoriete plaatsen op te slaan voor snelle toegang.
-    fi = Napsauta ★ tallentaaksesi suosikkipaikkoja.
-    fr = Tapez sur ★ pour enregistrer vos lieux préférés pour un accès rapide.
-    de = Tippen Sie auf ★, um Ihre Lieblingsorte für den Schnellzugriff zu speichern.
-    hu = Koppintson a ★-ra a kedvenc helyei mentéséhez, gyors eléréséhez.
-    id = Ketuk pada ★ untuk menyimpan tempat-tempat favorit untuk akses cepat.
-    it = Tocca su ★ per salvare i luoghi preferiti e accedervi rapidamente.
-    ja = ★をタップしてお気に入りの場所にクイックアクセス。
-    ko = 빠른 액세스를 위해 즐겨찾는 장소에 저장하기 위해 ★를 누릅니다.
-    nb = Trykk på ★ for å lagre favorittsteder og få rask tilgang.
-    pl = Stuknij ★, aby zapisać ulubione miejsca w celu szybkiego dostępu.
-    pt = Toque em ★ para salvar locais favoritos para rápido acesso.
-    ro = Atingeți ★ pentru a salva locurile preferate, pentru un acces rapid.
-    es = Pulsa ★ para guardar los lugares favoritos a los que podrás acceder rápidamente.
-    sv = Knacka på ★ för att spara favoritplatser för snabb åtkomst.
-    th = แตะ ★ เพื่อบันทึกสถานที่โปรดเพื่อให้เข้าถึงได้อย่างรวดเร็ว
-    tr = Hızlı erişim için favori yerlere kaydetmek için ★ dokunun.
-    uk = Клацніть по ★, щоб зберегти улюблені місця для швидкого доступу.
-    vi = Chạm vào ★ để lưu địa điểm yêu thích giúp truy cập nhanh.
-    zh-Hans = 点击★保存收藏地点以便快速访问。
-    zh-Hant = 按★ 儲存至愛地點以方便存取。
-    sk = Ak si chcete uložiť obľúbené miesta pre rýchly prístup, klepnite na ★.
-    fa = برروی ★ کلیک کنید تا در علاقه مندی ها برای دسترسی سریع ذخیره شود.
-
-  [bookmarks_empty_message_2]
-    en = Import Bookmarks from email and web.
-    ru = Импортируйте метки из почты и интернета.
-    ar = جلب العلامات المرجعية من البريد الإلكتروني والإنترنت.
-    cs = Importovat záložky z emailu a webu.
-    da = Importer bogmærker fra email og web.
-    nl = Importeer bladwijzers vanuit email en het internet.
-    fi = Tuo kirjanmerkit sähköpostista ja webistä.
-    fr = Importez des signets à partir d'un email et du Web.
-    de = Lesezeichen aus Mail und Web importieren.
-    hu = Importálja a könyvjelzőket a levelezésből és a böngészőből.
-    id = Impor penanda dari email dan web.
-    it = Importa i segnalibri dalla posta elettronica e dal web.
-    ja = メールやウェブからブックマークをインポートする。
-    ko = 이메일 및 웹에서 북마크를 가져옵니다.
-    nb = Importer bokmerker fra e-post og nettet.
-    pl = Importuj zakładki z aplikacji Mail i z Sieci.
-    pt = Importe favoritos do Mail e da web.
-    ro = Importare marcaje din Mail și web.
-    es = Importar marcadores desde Mail y la web.
-    sv = Importera bokmärken från Mail och webben.
-    th = นำเข้าบุ๊กมาร์กจาก Mail และเว็บ
-    tr = E-postadan ve weben yer işaretlerini içe aktarın.
-    uk = Імпортувати закладки з Mail та web.
-    vi = Nhập đánh dấu trang từ Hộp thư và trang web.
-    zh-Hans = 从邮箱和网页导入书签。
-    zh-Hant = 從 Mail及網上匯入書籤。
-    sk = Importujte si záložky z emailu a webu.
-    fa = وارد کردن نشانه ها از ایمیل یا وب.
-
-  [bookmarks_empty_message_3]
-    en = check out: %s
-    ru = выезд: %s
-    ar = غادر: %s
-    cs = odjezd: %s
-    da = tjek ud: %s
-    nl = uitchecken: %s
-    fi = kirjaudu ulos: %s
-    fr = départ : %s
-    de = Auschecken: %s
-    hu = kijelentkezés: %s
-    id = check-out: %s
-    it = check out: %s
-    ja = チェックアウト：%s
-    ko = 체크아웃: %s
-    nb = sjekk ut: %s
-    pl = wymeldowanie: %s
-    pt = check out: %s
-    ro = check out: %s
-    es = hora de salida: %s
-    sv = utcheckning: %s
-    th = เช็คเอาท์: %s
-    tr = çıkış: %s
-    uk = виїзд: %s
-    vi = đăng ký ra: %s
-    zh-Hans = 退房： %s
-    zh-Hant = 退房： %s
-    sk = odchod: %s
-    fa = وارسی کنید: %s
-
-  [bookmarks_group_name]
-    comment = Name of the group for booked hotels
-    en = Booked hotels
-    ru = Забронированные отели
-    ar = فنادق تم حجزها
-    cs = Zarezervované hotely
-    da = Bookede hoteller
-    nl = Geboekte hotels
-    fi = Varatut hotellit
-    fr = Hôtels réservés
-    de = Gebuchte Hotels
-    hu = Hotelfoglalások
-    id = Hotel yang dipesan
-    it = Hotel prenotati
-    ja = 予約したホテル
-    ko = 호텔 예약함
-    nb = Bestilte hoteller
-    pl = Zarezerwowane hotele
-    pt = Hotéis reservados
-    ro = Hoteluri rezervate
-    es = Hoteles reservados
-    sv = Bokade hotell
-    th = โรงแรมที่จอง
-    tr = Ayırtılan oteller
-    uk = Заброньовані готелі
-    vi = Đã đặt trước khách sạn
-    zh-Hans = 预订的酒店
-    zh-Hant = 預訂的酒店
-    sk = Rezervované hotely
-    fa = رزرو هتل ها
-
-  [place_page_button_read_descriprion]
-    en = Read
-    ru = Прочитать
-    ar = اقرأ
-    cs = Číst
-    da = Læs
-    nl = Lezen
-    fi = Lue
-    fr = Lire
-    de = Lesen
-    hu = Olvassa el
-    id = Baca
-    it = Leggi
-    ja = 詳細
-    ko = 읽기
-    nb = Les
-    pl = Czytaj
-    pt = Leia
-    ro = Citiți
-    es = Leer
-    sv = Läs
-    th = อ่าน
-    tr = Oku
-    uk = Прочитати
-    vi = Đọc
-    zh-Hans = 阅读
-    zh-Hant = 閱讀
-    sk = Prečítajte si
-    fa = خواندن
+    sk = Skontrolujeme zmeny. V prípade otázok vás budeme kontaktovať emailom.
 
   [recent_track_background_dialog_title]
     tags = ios
@@ -18961,8 +12323,8 @@
     zh-Hans = 禁止记录您最近去过的路径？
     zh-Hant = 禁止記錄您最近去過的路徑？
     el = Θέλετε να απενεργοποιήσετε την καταγραφή της πρόσφατης διαδρομής σας;
-    sk = Znemožniť nahrávanie vami nedávno precestovanej trasy?
     fa = غیرفعال سازی ذخیره مسیر اخیرا طی شده
+    sk = Znemožniť nahrávanie vami nedávno precestovanej trasy?
 
   [off_recent_track_background_button]
     tags = ios
@@ -18993,11 +12355,12 @@
     zh-Hans = 禁用
     zh-Hant = 禁用
     el = Απενεργοποίηση
-    sk = Znemožniť
     fa = غیرفعال
+    sk = Znemožniť
 
   [sharing_call_action_look]
     comment = For sharing via SMS and so on
+    tags = ios
     en = Check out
     ru = Посмотри
     ar = انظر
@@ -19025,39 +12388,8 @@
     zh-Hans = 来看看
     zh-Hant = 看一看
     el = Αναχώρηση
-    sk = Pozrite si
     fa = بررسی کنید
-
-  [continue_recent_track_background_button]
-    tags = ios
-    en = Continue
-    ru = Продолжить
-    ar = استمرار
-    cs = Pokračovat
-    da = Fortsæt
-    nl = Verdergaan
-    fi = Jatka
-    fr = Continuer
-    de = Fortsetzen
-    hu = Folytatás
-    id = Teruskan
-    it = Continua
-    ja = 続行
-    ko = 계속
-    nb = Fortsett
-    pl = Kontynuuj
-    pt = Continuar
-    ro = Continuare
-    es = Continuar
-    sv = Fortsätt
-    th = ดำเนินการต่อ
-    tr = Devam Et
-    uk = Продовжити
-    vi = Tiếp tục
-    zh-Hans = 继续
-    zh-Hant = 繼續
-    sk = Pokračovať
-    fa = ادامه
+    sk = Pozrite si
 
   [recent_track_background_dialog_message]
     tags = ios
@@ -19088,8 +12420,8 @@
     zh-Hans = Organic Maps使用背景中的地理位置记录您最近去过的路径。
     zh-Hant = Organic Maps使用背景中的地理位置記錄您最近去過的路徑。
     el = Το Organic Maps χρησιμοποιεί τη γεωγραφική σας τοποθεσία στο παρασκήνιο για την καταγραφή των πρόσφατων διαδρομών σας.
-    sk = Organic Maps používa vašu geopozíciu na pozadí pre zaznamenávanie vami nedávno precestovanej trasy.
     fa = Organic Maps  از اطلاعات موقعیت مکانی شما در پس ضمینه برای ذخیره مسیر هایی که اخیرا سفر کرده اید استفاده می کند.
+    sk = Organic Maps používa vašu geopozíciu na pozadí pre zaznamenávanie vami nedávno precestovanej trasy.
 
   [rate_gp]
     comment = Rate on Google Play (Android only)
@@ -19121,8 +12453,8 @@
     zh-Hans = 在 Google Play 上的评分
     zh-Hant = 在 Google Play 評分
     el = Βαθμολογήστε το στο Google Play
-    sk = Ohodnotiť v službe Google Play
     fa = امتیاز دادن در گوگل پلی
+    sk = Ohodnotiť v službe Google Play
 
   [tell_friends]
     comment = Share with friends: menu item title
@@ -19154,8 +12486,8 @@
     zh-Hans = 告诉朋友
     zh-Hant = 告訴朋友
     el = Πείτε το σε ένα φίλο
-    sk = Povedať priateľovi
     fa = به یک دوست بگویید
+    sk = Povedať priateľovi
 
   [tell_friends_text]
     comment = Share with friends: sharing text
@@ -19187,8 +12519,8 @@
     zh-Hans = 您好！安装 Organic Maps！
     zh-Hant = 嗨！安裝 Organic Maps！
     el = Γεια σας! Εγκαταστήστε το Organic Maps!
-    sk = Ahoj! Nainštaluj si aplikáciu Organic Maps
     fa = سلام!  Organic Maps را نصب کنید.
+    sk = Ahoj! Nainštaluj si aplikáciu Organic Maps
 
   [about_description]
     comment = About short text (below logo)
@@ -19220,43 +12552,11 @@
     zh-Hans = Organic Maps 是一款基本的离线旅行应用。Organic Maps 基于 OpenStreetMap 数据并且允许对其进行编辑。
     zh-Hant = Organic Maps 是一款基本離線旅遊應用程式。Organic Maps 以 OpenStreetMap 數據為基礎，並允許對其進行編輯。
     el = Το Organic Maps είναι η απαραίτητη εφαρμογή γα ταξίδια που λειτουργεί εκτός σύνδεσης. Το Organic Maps βασίζεται σε δεδομένα OpenStreetMap και σας επιτρέπει να τα επεξεργαστείτε.
-    sk = Organic Maps je offine aplikácia na cestovanie. Základom aplikácie Organic Maps sú dáta OpenStreetMap, pričom aplikácia nám ich umožňuje upravovať.
     fa = Organic Maps یک نرم افزار افلاین مخصوص سفر است. Organic Maps بر پایه دیتای OpenStreetMap است و به شما اجازه ویرایش در ان را می دهد.
-
-  [blog]
-    comment = Text in menu
-    tags = android
-    en = Blog
-    ru = Блог
-    ar = المدونة
-    cs = Blog
-    da = Blog
-    nl = Blog
-    fi = Blogi
-    fr = Blog
-    de = Blog
-    hu = Blog
-    id = Blog
-    it = Blog
-    ja = ブログ
-    ko = 블로그
-    nb = Blogg
-    pl = Blog
-    pt = Blogue
-    ro = Blog
-    es = Blog
-    sv = Blogg
-    th = บล็อก
-    tr = Blog
-    uk = Блог
-    vi = Blog
-    zh-Hans = 博客
-    zh-Hant = 部落格
-    el = Ιστολόγιο
-    sk = Blog
-    fa = وبلاگ
+    sk = Organic Maps je offine aplikácia na cestovanie. Základom aplikácie Organic Maps sú dáta OpenStreetMap, pričom aplikácia nám ich umožňuje upravovať.
 
   [general_settings]
+    tags = ios
     en = General settings
     ru = Общие настройки
     ar = إعدادات عامة
@@ -19284,74 +12584,12 @@
     zh-Hans = 常规设置
     zh-Hant = 一般設定
     el = Γενικές ρυθμίσεις
-    sk = Všeobecné nastavenia
     fa = تنظیمات عمومی
-
-  [date]
-    en = Date %d
-    ru = Дата %d
-    ar = التاريخ %d
-    cs = Datum %d
-    da = Dato %d
-    nl = Datum %d
-    fi = Päivämäärä %d
-    fr = Date %d
-    de = Datum %d
-    hu = Dátum %d
-    id = Tanggal %d
-    it = Data %d
-    ja = 日付 %d
-    ko = 날짜 %d
-    nb = Dato %d
-    pl = Data %d
-    pt = Data %d
-    ro = Data %d
-    es = Fecha %d
-    sv = Datum %d
-    th = วันที่ %d
-    tr = Tarih %d
-    uk = Дата %d
-    vi = Ngày %d
-    zh-Hans = 日期 %d
-    zh-Hant = 日期 %d
-    el = Ημερομηνία %d
-    sk = Dátum %d
-    fa = تاریخ %d
-
-  [something_is_not_working]
-    comment = "Report a bug" -> "Generaal Feedback" -> "Something is not working"
-    en = Something is not working
-    ru = Что-то не работает
-    ar = شيء ما لا يعمل
-    cs = Něco nefunguje
-    da = Der er noget der ikke fungerer
-    nl = Er werkt iets niet
-    fi = Jokin ei toimi
-    fr = Quelque chose ne fonctionne pas
-    de = Etwas funktioniert nicht
-    hu = Valami nem működik
-    id = Ada yang tidak berfungsi
-    it = Qualcosa non funziona
-    ja = 動作が変です
-    ko = 문제가 발생했습니다.
-    nb = Noe fungerer ikke som det skal
-    pl = Coś nie działa
-    pt = Algo não está a funcionar
-    ro = Ceva nu funcționează corect
-    es = Algo no funciona
-    sv = Något fungerar inte
-    th = มีบางอย่างไม่ทำงาน
-    tr = Bir şey çalışmıyor
-    uk = Щось пішло не так
-    vi = Có một vấn đề nào đó
-    zh-Hans = 某些地方出错了
-    zh-Hant = 某些地方出錯了
-    el = Κάτι δεν λειτουργεί
-    sk = Niečo nefunguje
-    fa = یه چیزی درست کار نمی کنه
+    sk = Všeobecné nastavenia
 
   [accept]
     comment = For the first routing
+    tags = ios, android
     en = Accept
     ru = Принять
     ar = قبول
@@ -19379,17 +12617,12 @@
     zh-Hans = 接受
     zh-Hant = 接受
     el = Συμφωνώ
-    sk = Prijať
     fa = موافقم
-
-  [accept_and_continue]
-    en = Accept and continue
-    ru = Принять и продолжить
-    fa = قبول و ادامه
-    fr = Accepter et continuer
+    sk = Prijať
 
   [decline]
     comment = For the first routing
+    tags = ios, android
     en = Decline
     ru = Отклонить
     ar = رفض
@@ -19417,166 +12650,12 @@
     zh-Hans = 拒绝
     zh-Hant = 拒絕
     el = Διαφωνώ
-    sk = Odmietnuť
     fa = کاهش
-
-  [install_app]
-    en = Install
-    ru = Установить
-    ar = تثبيت
-    cs = Instalovat
-    da = Installer
-    nl = Installeer
-    fi = Asenna
-    fr = Installer
-    de = Installieren
-    hu = Telepítés
-    id = Pasang
-    it = Installa
-    ja = インストール
-    ko = 설치
-    nb = Installer
-    pl = Zainstaluj
-    pt = Instalar
-    ro = Instalați
-    es = Instalar
-    sv = Installera
-    th = ติดตั้ง
-    tr = Kur
-    uk = Встановити
-    vi = Cài đặt
-    zh-Hans = 安装
-    zh-Hant = 安裝
-    el = Εγκατάσταση
-    sk = Nainštalovať
-    fa = نصب
-
-  [search_no_results_title]
-    en = No Results Found
-    ru = Поиск не дал результатов
-    ar = لم يتم العثور على نتائج
-    cs = Nebyly nalezeny žádné výsledky
-    da = Ingen resultater fundet
-    nl = Geen Resultaten Gevonden
-    fi = Ei hakutuloksia
-    fr = Aucun résultat trouvé
-    de = Keine Ergebnisse gefunden
-    hu = Nincs találat
-    id = Tidak Ada Hasil
-    it = Nessun risultato trovato
-    ja = 結果が見つかりません
-    ko = 결과 찾지 못함
-    nb = Fant ingen resultater
-    pl = Nie znaleziono wyników
-    pt = Nenhum resultado encontrado
-    ro = Nu au fost găsite rezultate
-    es = No se han encontrado resultados
-    sv = Inga resultat hittades
-    th = ไม่พบผลลัพธ์
-    tr = Hiçbir Sonuç Bulunamadı
-    uk = Не знайдено жодного результату
-    vi = Không tìm thấy kết quả nào
-    zh-Hans = 未找到任何结果
-    zh-Hant = 找不到任何結果
-    el = Δεν βρέθηκαν αποτελέσματα
-    sk = Nenašli sa žiadne výsledky
-    fa = چیزی یافت نشد
-
-  [search_no_results_message]
-    en = Try a more general search term, zoom out or reset the filter.
-    ru = Попробуйте задать более общий запрос, уменьшить масштаб карты или сбросить фильтр.
-    ar = جرب مصطلح بحث أكثر عمومية أو التصغير أو إعادة تعيين عامل التصفية.
-    cs = Zkuste obecnější hledaný výraz, oddálit nebo obnovit filtr.
-    da = Prøv et mere generelt søgeudtryk, zoom ud eller nulstil filteret.
-    nl = Probeer een meer algemene zoekterm, zoom uit of reset de filter.
-    fi = Kokeile yleisempää hakusanaa, loitonna tai palauta suodatin.
-    fr = Essayez un terme de recherche plus général , effectuez un zoom arrière ou réinitialisez le filtre.
-    de = Versuchen Sie es mit einem allgemeineren Suchbegriff, zoomen Sie heraus oder setzen Sie den Filter zurück.
-    hu = Próbálkozzon általánosabb kereső kifejezéssel, tágítsa vagy törölje a szűrőt.
-    id = Cobalah dengan istilah pencarian yang lebih umum, perkecil atau atur ulang filter.
-    it = Prova con un termine di ricerca più generale, fai lo zoom indietro o reimposta il filtro.
-    ja = 一般的な検索語句や、フィルター範囲を広げたりリセットしたりしてください。
-    ko = 보다 일반적인 검색어로 시도하거나, 축소하거나, 필터를 재설정하세요.
-    nb = Prøv et mer generelt søkeord, zoom ut eller tilbakestill filteret.
-    pl = Spróbuj szerszego terminu wyszukiwania, zawęzić lub resetować filtr.
-    pt = Tente um termo de pesquisa mais geral, diminuir o zoom ou redefinir o filtro.
-    ro = Încercați un termen mai general, micșorați sau resetați filtrul.
-    es = Pruebe un término de búsqueda general, aléjese o restablezca el filtro.
-    sv = Försök med en mer allmän sökterm, zooma ut eller återställ filtret.
-    th = ลองค้นหาด้วยคำทั่ว ๆ ไปดู ซูมออกหรือรีเซ็ตตัวกรอง
-    tr = Daha genel bir terimi aramayı deneyin, uzaklaşın veya filtreyi Sıfırlayın.
-    uk = Спробуйте пошук за більш узагальненим пошуковим виразом, зменшіть масштаб або скиньте фільтри.
-    vi = Hãy thử một từ khóa tìm kiếm chung hơn, thu nhỏ hoặc đặt lại bộ lọc.
-    zh-Hans = 尝试一个更普通的搜索词、缩小显示或重置筛选器。
-    zh-Hant = 嘗試一個更普通的搜尋字詞、縮小顯示或重設篩選條件。
-    el = Δοκιμάστε ένα γενικότερο όρο αναζήτησης, κάντε σμίκρυνση ή μηδενίστε το φίλτρο.
-    sk = Skúste vyhľadávať všeobecnejší výraz, vzdialiť alebo obnoviť nastavenie filtra.
-    fa = چیز های عمومی تری را جست وجو کنید,کوچک نمایی کنید یا این فیلتر را پاک کنید.
-
-  [search_no_results_expand_area_button]
-    en = Zoom out
-    ru = Уменьшить масштаб карты
-    ar = تصغير
-    cs = Oddálit
-    da = Zoom ud
-    nl = Uitzoomen
-    fi = Loitonna
-    fr = Zoom arrière
-    de = Herauszoomen
-    hu = Kicsinyítés
-    id = Perkecil
-    it = Zoom indietro
-    ja = 広げる
-    ko = 축소
-    nb = Zoom ut
-    pl = Zawęź
-    pt = Diminuir o zoom
-    ro = Micșorare
-    es = Alejarse
-    sv = Zooma ut
-    th = ซูมออก
-    tr = Uzaklaş
-    uk = Зменшити масштаб
-    vi = Thu nhỏ
-    zh-Hans = 缩小
-    zh-Hant = 縮小
-    el = Σμίκρυνση
-    sk = Vzdialiť
-    fa = کوچک نمایی
-
-  [search_no_results_reset_button]
-    en = Reset Filter
-    ru = Сбросить фильтр
-    ar = إعادة تعيين عامل التصفية
-    cs = Resetovat filtr
-    da = Nulstil Filter
-    nl = Filter Resetten
-    fi = Palauta suodatin
-    fr = Réinitialiser le filtre
-    de = Filter zurücksetzen
-    hu = Szűrő nullázása
-    id = Atur Ulang Filter
-    it = Reimposta filtro
-    ja = フィルターをリセット
-    ko = 필터 재설정
-    nb = Tilbakestill filter
-    pl = Resetuj filtr
-    pt = Redefinir o filtro
-    ro = Resetare filtru
-    es = Restablecer filtro
-    sv = Återställ filtret
-    th = รีเซ็ตตัวกรอง
-    tr = Filtreyi Sıfırla
-    uk = Скинути фільтри
-    vi = Đặt lại Bộ lọc
-    zh-Hans = 重置筛选器
-    zh-Hant = 重設篩選條件
-    el = Μηδενισμός φίλτρου
-    sk = Obnoviť filter
-    fa = پاک کردن فیلتر
+    sk = Odmietnuť
 
   [search_in_table]
     comment = noun
+    tags = ios, android
     en = List
     ru = Список
     ar = قائمة
@@ -19604,10 +12683,11 @@
     zh-Hans = 列表
     zh-Hant = 清單
     el = Λίστα
-    sk = Zoznam
     fa = لیست
+    sk = Zoznam
 
   [mobile_data_dialog]
+    tags = ios, android
     en = Use mobile internet to show detailed information?
     ru = Загружать дополнительную информацию через мобильный интернет?
     ar = استخدام إنترنت المحمول لإظهار المعلومات التفصيلية؟
@@ -19635,10 +12715,11 @@
     zh-Hans = 使用移动网络显示详细信息？
     zh-Hant = 使用手機網路顯示詳細資訊？
     el = Θέλετε να χρησιμοποιήσετε το δίκτυο κινητής τηλεφωνίας για να εμφανίσετε αναλυτικές πληροφορίες;
-    sk = Použiť mobilný internet na zobrazenie podrobnejších informácií?
     fa = از دیتای موبایل برای نمایش اطلاعات بیشتر استفاده شود؟
+    sk = Použiť mobilný internet na zobrazenie podrobnejších informácií?
 
   [mobile_data_option_always]
+    tags = ios, android
     en = Use Always
     ru = Всегда
     ar = استخدام دائمًا
@@ -19666,10 +12747,11 @@
     zh-Hans = 始终使用
     zh-Hant = 一律使用
     el = Να χρησιμοποιείται πάντα
-    sk = Vždy použiť
     fa = همیشه استفاده کن
+    sk = Vždy použiť
 
   [mobile_data_option_today]
+    tags = ios, android
     en = Only Today
     ru = Только сегодня
     ar = اليوم فقط
@@ -19697,10 +12779,11 @@
     zh-Hans = 仅在今天
     zh-Hant = 僅限今天
     el = Μόνο σήμερα
-    sk = Iba dnes
     fa = فقط امروز
+    sk = Iba dnes
 
   [mobile_data_option_not_today]
+    tags = ios, android
     en = Do not Use Today
     ru = Не сегодня
     ar = عدم الاستخدام اليوم
@@ -19728,10 +12811,11 @@
     zh-Hans = 今天不使用
     zh-Hant = 今天不使用
     el = Να μην χρησιμοποιηθεί σήμερα
-    sk = Dnes nepoužiť
     fa = امروز نه
+    sk = Dnes nepoužiť
 
   [mobile_data]
+    tags = ios, android
     en = Mobile Internet
     ru = Мобильный интернет
     ar = انترنت المحمول
@@ -19759,10 +12843,11 @@
     zh-Hans = 移动网络
     zh-Hant = 手機網路
     el = Ίντερνετ μέσω δικτύου κινητής
-    sk = Mobilný internet
     fa = دیتای موبایل
+    sk = Mobilný internet
 
   [mobile_data_description]
+    tags = ios, android
     en = Mobile internet is required for displaying detailed information about places, such as photographs, prices and reviews.
     ru = Мобильный интернет требуется для отображения более детальной информации о местах: фотографий, цен, отзывов.
     ar = الإنترنت المحمول مطلوب لعرض معلومات تفصيلية عن الأماكن مثل الصور الفوتوغرافية والأسعار والمراجعات.
@@ -19790,10 +12875,11 @@
     zh-Hans = 要显示地点的详细信息（例如照片、价格和评价），需要使用移动网络。
     zh-Hant = 需有手機網路才能顯示相片、價格與評論等詳細資訊和地點。
     el = Απαιτείται πρόσβαση στο Ίντερνετ μέσω δικτύου κινητής για την εμφάνιση αναλυτικών πληροφοριών για τις τοποθεσίες, όπως φωτογραφίες, τιμές και κριτικές.
-    sk = Na zobrazenie podrobnejších informácií o miestach, napríklad fotografií, cien a recenzií, sa vyžaduje mobilný internet.
     fa = برای نمایش جزئیات مکان مانند تصاویر قیمت ها و بازخورد ها به اینترنت همراه نیاز است
+    sk = Na zobrazenie podrobnejších informácií o miestach, napríklad fotografií, cien a recenzií, sa vyžaduje mobilný internet.
 
   [mobile_data_option_never]
+    tags = ios, android
     en = Never Use
     ru = Никогда не использовать
     ar = عدم الاستخدام مطلقًا
@@ -19821,10 +12907,11 @@
     zh-Hans = 从不使用
     zh-Hant = 絕不使用
     el = Να μην χρησιμοποιείται ποτέ
-    sk = Nikdy nepoužiť
     fa = هرگز
+    sk = Nikdy nepoužiť
 
   [mobile_data_option_ask]
+    tags = ios, android
     en = Always Ask
     ru = Всегда спрашивать
     ar = السؤال دوماً
@@ -19852,10 +12939,11 @@
     zh-Hans = 总是询问
     zh-Hant = 一律詢問
     el = Να γίνεται ερώτηση πάντα
-    sk = Vždy sa opýtať
     fa = همیشه بپرس
+    sk = Vždy sa opýtať
 
   [traffic_update_maps_text]
+    tags = ios, android
     en = To display traffic data, maps must be updated.
     ru = Для отображения пробок необходимо обновить карты.
     ar = لعرض البيانات المرورية، يجب تحديث الخرائط.
@@ -19883,41 +12971,11 @@
     zh-Hans = 要显示交通数据，必须更新地图。
     zh-Hant = 若要顯示交通資料，必須更新地圖。
     el = Για να εμφανίσετε πληροφορίες για την κίνηση, πρέπει να ενημερωθούν οι χάρτες.
-    sk = Na zobrazenie dopravných informácií je potrebné aktualizovať mapy.
     fa = برای نمایش ترافیک,نقشه می بایستی بروزرسانی شود.
-
-  [traffic_outdated]
-    en = Traffic data is outdated.
-    ru = Данные о пробках устарели.
-    ar = البيانات المرورية قديمة.
-    cs = Data o provozu jsou zastaralá.
-    da = Trafikdata er forældede.
-    nl = Verkeersgegevens zijn verouderd.
-    fi = Liikennetiedot ovat vanhentuneet.
-    fr = Les données de circulation ne sont pas actuelles.
-    de = Verkehrsdaten sind veraltet.
-    hu = A forgalmi adatok elavultak.
-    id = Data lalu lintas belum diperbarui.
-    it = Dati sul traffico non aggiornati.
-    ja = 交通データが古くなっています。
-    ko = 교통 데이터가 오래되었습니다.
-    nb = Trafikkdata er utdatert.
-    pl = Dane o ruchu są przestarzałe.
-    pt = Os dados sobre o tráfego estão desatualizados.
-    ro = Datele privind traficul sunt învechite.
-    es = Los datos de tráfico están obsoletos.
-    sv = Trafikdata är inaktuellt.
-    th = ข้อมูลการจราจรเก่าเกินไปแล้ว
-    tr = Trafik verileri güncel değil.
-    uk = Дані про трафік застаріли.
-    vi = Dữ liệu giao thông đã lỗi thời.
-    zh-Hans = 交通数据已过时。
-    zh-Hant = 交通資料已過時。
-    el = Οι πληροφορίες για την κίνηση είναι παλιές.
-    sk = Dopravné informácie sú neaktuálne.
-    fa = دیتای ترافیک منقضی شده است.
+    sk = Na zobrazenie dopravných informácií je potrebné aktualizovať mapy.
 
   [big_font]
+    tags = ios, android
     en = Increase font size on the map
     ru = Увеличить шрифт на карте
     ar = زيادة حجم الخط على الخريطة
@@ -19945,10 +13003,11 @@
     zh-Hans = 增大地图上的字体大小
     zh-Hant = 增加地圖上的字體大小
     el = Αύξηση μεγέθους γραμματοσειράς στο χάρτη
-    sk = Zväčšiť veľkosť písma na mape
     fa = افزایش اندازه متن بر روی نقشه
+    sk = Zväčšiť veľkosť písma na mape
 
   [traffic_update_app]
+    tags = android
     en = Please update Organic Maps
     ru = Обновите Organic Maps
     ar = الرجاء تحديث Organic Maps
@@ -19976,11 +13035,12 @@
     zh-Hans = 请更新 Organic Maps
     zh-Hant = 請更新 Organic Maps
     el = Κάντε ενημέρωση του Organic Maps
-    sk = Aktualizujte si aplikáciu Organic Maps
     fa = لطفا Organic Maps را بروزرسانی کنید
+    sk = Aktualizujte si aplikáciu Organic Maps
 
   [traffic_update_app_message]
     comment = "traffic" as in road congestion
+    tags = ios
     en = To display traffic data, the application must be updated.
     ru = Для отображения пробок необходимо обновить приложение.
     ar = لعرض البيانات المرورية، يجب تحديث التطبيق.
@@ -20008,11 +13068,12 @@
     zh-Hans = 要显示交通数据，必须更新应用。
     zh-Hant = 若要顯示交通資訊，必須更新應用程式。
     el = Για να εμφανιστούν πληροφορίες για την κίνηση, πρέπει να γίνει ενημέρωση της εφαρμογής.
-    sk = Ak chcete zobraziť dopravné informácie, musíte si aktualizovať aplikáciu.
     fa = برای نمایش ترافیک باید اپلیکیشن را بروزرسانی کنید.
+    sk = Ak chcete zobraziť dopravné informácie, musíte si aktualizovať aplikáciu.
 
   [traffic_data_unavailable]
     comment = "traffic" as in "road congestion"
+    tags = ios, android
     en = Traffic data is not available
     ru = Данные о пробках недоступны
     ar = البيانات المرورية غير متاحة
@@ -20040,47 +13101,11 @@
     zh-Hans = 交通数据不可用
     zh-Hant = 無法使用交通資訊
     el = Οι πληροφορίες για την κίνηση δεν είναι διαθέσιμες
-    sk = Dopravné informácie nie sú k dispozícii
     fa = اطلاعات ترافیکی موجود نیست
-
-  [uber]
-    comment = "Translation is no needed, because it's a company name"
-    en = Uber
-
-  [pref_traffic_simplified_colors_title]
-    comment = Simplified colour scheme for traffic information, fewer colours are used to display traffic jams on the map. The string should be kept as short as possible
-    en = Simplified traffic colors
-    ru = Простые цвета пробок
-    ar = ألوان مرور مبسطة
-    cs = Zjednodušené barvy provozu
-    da = Forenklede trafikfarver
-    nl = Eenvoudige verkeerskleuren
-    fi = Simppelit liikennevärit
-    fr = Couleurs circulation simplifiées
-    de = Vereinfachte Verkehrsfarben
-    hu = Egyszerűsített forgalmi színek
-    id = Warna lalu lintas sederhana
-    it = Colori traffico semplificati
-    ja = 簡易的な交通状況色
-    ko = 단순화된 트래픽 색상
-    nb = Enkelt trafikkfargeoppsett
-    pl = Uproszczone kolory sygnalizacji
-    pt = Cores de trânsito simplificadas
-    ro = Culori trafic simplificate
-    es = Colores simples para tráfico
-    sv = Enkla trafikfärger
-    th = ไฟจราจรแบบง่าย
-    tr = Sadeleştirilmiş trafik renkleri
-    uk = Спрощені кольори світлофору
-    vi = Màu sắc giao thông đơn giản
-    zh-Hans = 简化的交通状况颜色
-    zh-Hant = 簡化的交通狀況顏色
-    el = Εύκολα χρώματα για την κίνηση
-    en_GB = Simplified traffic colours
-    sk = Zjednodušené farby dopravy
-    fa = رنگ های ترافیکی ساده شده
+    sk = Dopravné informácie nie sú k dispozícii
 
   [enable_logging]
+    tags = android
     en = Enable logging
     ru = Включить запись логов
     ar = تمكين التسجيل
@@ -20108,74 +13133,12 @@
     zh-Hans = 启用记录
     zh-Hant = 啟用記錄
     el = Ενεργοποίηση δυνατότητας καταγραφής
-    sk = Zapnúť zaznamenávanie
     fa = ورود به سیستم را فعال کنید
-
-  [offline_place_page_more_information]
-    en = Connect to the internet to get more information about the place.
-    ru = Подключитесь к интернету, чтобы получить больше информации о месте.
-    ar = اتصل بالإنترنت للحصول على مزيد من التفاصيل حول المكان.
-    cs = Připojte se k Internetu a získejte více informací o tomto místě.
-    da = Opret forbindelse til internettet for at få flere oplysninger om stedet.
-    nl = Maak verbinding met het internet om meer informatie over de plaats te krijgen.
-    fi = Yhdistä internetiin saadaksesi lisätietoa paikasta.
-    fr = Connectez-vous à Internet pour obtenir plus d’informations sur ce lieu.
-    de = Stellen Sie eine Verbindung zum Internet her, um weitere Informationen über den Ort zu erhalten.
-    hu = A helyszínről további tájékoztatást kaphat, ha csatlakozik az internethez.
-    id = Sambungkan ke internet untuk mendapatkan informasi selengkapnya tentang tempat ini.
-    it = Connettiti a Internet per ottenere maggiori informazioni sul luogo.
-    ja = この場所に関する詳細情報を取得するには、インターネットに接続してください。
-    ko = 인터넷에 연결하여 그곳에 대한 자세한 정보를 얻으세요.
-    nb = Koble til internett for å få mer informasjon om stedet.
-    pl = Połącz się z Internetem, aby uzyskać więcej informacji na temat miejsca.
-    pt = Efetue ligação à internet para obter mais informações sobre o local.
-    ro = Conectați-vă la internet pentru a primi mai multe informații despre locație.
-    es = Conéctese a internet para obtener más información sobre este lugar.
-    sv = Anslut till internet för att hämta mer information om platsen.
-    th = เชื่อมต่ออินเทอร์เน็ตเพื่อรับข้อมูลเพิ่มเติมเกี่ยวกับสถานที่
-    tr = Yerle ilgili daha fazla bilgi almak için internete bağlanın.
-    uk = Підключіться до мережі Інтернет, щоб отримати більше інформації про місце.
-    vi = Kết nối đến Internet để xem thêm thông tin về địa điểm này.
-    zh-Hans = 连接到互联网来获取关于地点的更多信息。
-    zh-Hant = 連上網路以取得關於地點的更多資訊。
-    el = Συνδεθείτε στο Internet για να λάβετε περισσότερες πληροφορίες για αυτό το μέρος.
-    sk = Viac informácií o mieste získate po pripojení na internet.
-    fa = برای کسب اطلاعات بیشتر در مورد مکان، به اینترنت متصل شوید.
-
-  [failed_load_information]
-    en = Failed to load information.
-    ru = Не удалось загрузить информацию.
-    ar = فشل تحميل المعلومات.
-    cs = Nepodařilo se načíst informace.
-    da = Kunne ikke indlæse oplysningerne.
-    nl = Informatie laden mislukt.
-    fi = Tietojen lataaminen epäonnistui.
-    fr = Impossible de charger les informations.
-    de = Informationen konnten nicht geladen werden.
-    hu = Nem sikerült betölteni az adatokat.
-    id = Gagal memuat informasi.
-    it = Impossibile caricare le informazioni.
-    ja = 情報の読み込みに失敗しました。
-    ko = 정보를 로드하지 못했습니다.
-    nb = Kunne ikke laste inn informasjon.
-    pl = Nie można załadować informacji.
-    pt = Falha ao carregar informações.
-    ro = Încărcarea informațiilor a eșuat.
-    es = No se ha podido cargar la información.
-    sv = Det gick inte att ladda informationen.
-    th = ไม่สามารถโหลดข้อมูลได้
-    tr = Bilgiler yüklenemedi.
-    uk = Не вдалося завантажити інформацію.
-    vi = Không thể tải thông tin.
-    zh-Hans = 无法加载信息。
-    zh-Hant = 無法載入資訊。
-    el = Η φόρτωση πληροφοριών απέτυχε.
-    sk = Nepodarilo sa načítať informácie.
-    fa = اطلاعات بارگیری نشد.
+    sk = Zapnúť zaznamenávanie
 
   [feedback_general]
     comment = Settings: "Send general feedback" button
-    tags = android
+    tags = ios, android
     en = General Feedback
     ru = Отправить отзыв
     ar = تعقيب عام
@@ -20203,11 +13166,12 @@
     zh-Hans = 一般反馈
     zh-Hant = 一般反應
     el = Γενικό σχόλιο
+    fa = "تنظیمات: دکمه "ارسال بازخورد کلی
     sk = Všeobecné pripomienky
     sw = Maoni Jumla
-    fa =  "تنظیمات: دکمه "ارسال بازخورد کلی
 
   [on]
+    tags = ios, android
     en = On
     ru = Вкл.
     ar = تشغيل
@@ -20235,11 +13199,12 @@
     zh-Hans = 开
     zh-Hant = 開
     el = Ενεργ.
+    fa = روشن
     sk = Zap.
     sw = Washa
-    fa = روشن
 
   [off]
+    tags = ios, android
     en = Off
     ru = Выкл.
     ar = إيقاف
@@ -20267,11 +13232,12 @@
     zh-Hans = 关
     zh-Hant = 關
     el = Απενεργ.
+    fa = خاموش
     sk = Vyp.
     sw = Zima
-    fa = خاموش
 
   [prefs_languages_information]
+    tags = android
     en = We use system TTS for voice instructions. Many Android devices use Google TTS, you can download or update it from Google Play (https://play.google.com/store/apps/details?id=com.google.android.tts)
     ru = Подсказки озвучиваются системным синтезатором речи (TTS). На многих устройствах используется Google TTS, его можно загрузить или обновить в Google Play (https://play.google.com/store/apps/details?id=com.google.android.tts)
     ar = نحن نستخدم نظام النص إلى كلام (TTS) للتعليمات الصوتية. تستخدم العديد من أجهزة Android نظام Google TTS، يمكنك تنزيله من أو تحديثه من Google Play (https://play.google.com/store/apps/details?id=com.google.android.tts)
@@ -20299,11 +13265,12 @@
     zh-Hans = 我们为语音指令使用“文字转语音”系统。许多 Android 设备使用 Google 文字转语音，您可以从 Google Play (https://play.google.com/store/apps/details?id=com.google.android.tts) 下载或更新这一功能
     zh-Hant = 我們使用系統 TTS 提供語音指示。許多 Android 裝置使用 Google TTS，您可從 Google Play 下載或更新 (https://play.google.com/store/apps/details?id=com.google.android.tts)
     el = Χρησιμοποιούμε σύστημα TTS για τις φωνητικές οδηγίες. Αρκετές συσκευές Android χρησιμοποιούν Google TTS, μπορείτε να το κατεβάσετε ή να το ενημερώσετε από το Google Play (https://play.google.com/store/apps/details?id=com.google.android.tts)
+    fa = ما از TTS سیستم برای دستورالعمل های صوتی استفاده می کنیم. بسیاری از دستگاه های Android از Google TTS استفاده می کنند، شما می توانید آن را از Google Play دانلود کنید (https://play.google.com/store/apps/details؟id=com.google.android.tts)
     sk = Na hlasové pokyny používame systém TTS. Mnohé zariadenia s Adroidom používajú Google TTS, ktorý si môžete stiahnuť alebo aktualizovať z obchodu Google Play (https://play.google.com/store/apps/details?id=com.google.android.tts)
     sw = Tunatumia maagizo ya sautii ya TTS ya mfumo. Vifaa vingi vya Android vinatumia Google TTS, unaweza kuipakua au kuisasisha kwenye Google Play (https://play.google.com/store/apps/details?id=com.google.android.tts)
-    fa = ما از TTS سیستم برای دستورالعمل های صوتی استفاده می کنیم. بسیاری از دستگاه های Android از Google TTS استفاده می کنند، شما می توانید آن را از Google Play دانلود کنید (https://play.google.com/store/apps/details؟id=com.google.android.tts)
 
   [prefs_languages_information_off]
+    tags = android
     en = For some languages, you will need to install a speech synthesizer or an additional language pack from the app store (Google Play Market, Samsung Apps).\nOpen your device's settings → Language and input → Speech → Text to speech output.\nHere you can manage settings for speech synthesis (for example, download language pack for offline use) and select another text-to-speech engine.
     ru = Для некоторых языков, возможно, необходимо установить дополнительный синтезатор речи (TTS) из магазина приложений (Google Play Market, Samsung Apps).\nЧтобы настроить синтезатор речи, перейдите в Настройки → Язык и ввод → Синтез речи.\nЗдесь можно установить дополнительные языковые пакеты или выбрать синтезатор речи.
     ar = (TTS) إضافي (حيث إن نظام Google TTS لا يدعم اللغات بعد (من Google Play مثل Vocalizer TTS أو SVOX Classics.\nلإدارة الإعدادات لتخليق الكلام، في الجهاز الخاص بك افتح الإعدادات –> اللغة والإدخال –> الكلام –> إخراج نص إلى كلام. هنا يمكنك تنزيل حزمة لغة إضافية أو تحديد محرك النص إلى كلام المفضل.
@@ -20331,11 +13298,12 @@
     zh-Hans = 对于某些语言，您需要从应用商店（Google Play Market、Samsung Apps）中安装其他语音合成器或语言包。\n打开您的设备的设置 → 语言和输入法 → 语音 → 文字转语音 (TTS) 输出。\n您可以在这里管理语音合成的设置（例如，下载语言包供离线使用）和选择其他文字转语音引擎。
     zh-Hant = 對於某些語言，您將需要從 App 商店 (Google Play Market, Samsung Apps) 安裝其他語音合成器或額外的語言套件。\n開啟您裝置的設定 → 語言與輸入 → 語音 → 文字轉換語音輸出。\n在這裡，您可以管理語音合成器的設定（例如，下載語言套件以供離線使用），並選取其他文字轉換語音引擎。
     el = Για μερικές γλώσσες θα χρειαστεί να εγκαταστήσετε συνθεσάιζερ ομιλίας ή συμπληρωματικό πακέτο γλώσσας από το app store (Google Play Market, Samsung Apps).\nΑνοίξτε τις Ρυθμίσεις της συσκευής σας → Γλώσσα και εισαγωγή → Ομιλία → Μετατροπή κειμένου σε ομιλία.\nΕδώ μπορείτε να διαχειριστείτε τις ρυθμίσεις της σύνθεσης ομιλίας (για παράδειγμα, μπορείτε να κατεβάσετε πακέτο γλώσσας για χρήση εκτός σύνδεσης) και να επιλέξετε άλλη μηχανή μετατροπής κειμένου σε ομιλία.
+    fa = برای بعضی از زبان ها، شما باید speech synthesizer یا یک بسته زبان دیگر را از فروشگاه برنامه (بازار Google Play، Samsung Apps) نصب کنید. \n تنظیمات دستگاه خود را باز کنید. → زبان و ورودی → گفتار → خروجی متن به گفتار. می توانید تنظیمات برای ترکیب گفتار (به عنوان مثال، بسته های زبان را برای استفاده آفلاین دانلود کنید) را مدیریت کنید و یک موتور دیگر متن به گفتار را انتخاب کنید.
     sk = Pre niektoré jazyky bude potrebné nainštalovať syntetizátor reči alebo balík doplnkového jazyka z obchodu s aplikáciami (Google Play, Samsung Apps). Otvorte nastavenia zariadenia → Jazyk a vstup → Reč → Prevod textu na reč. Tu môžete spravovať nastavenia pre syntézu reči (napríklad stiahnuť jazykový balík pre použitie v režime offline) a vybrať iný jazyk.
     sw = Kwa baadhi ya lugha, utahitaji kusakinisha programu nyingine ya kusanidi usemi au kifurushi cha ziada cha lugha kutoka kwenye duka la programu-tumizi (Google Play Market, Samsung Apps).\nFungua mipangilio ya kifaa chako → Lugha na Ingizo → Usemi → Tokeo la maandishi kuwa usemi.\nHapa unaweza kusimamia usanidi wa usemi (kwa mfano, kupakua kifurushi cha lugha ili utumie nje ya mtandao) na uchague injini nyingine ya maandishi-kuwa-usemi.
-    fa = برای بعضی از زبان ها، شما باید speech synthesizer یا یک بسته زبان دیگر را از فروشگاه برنامه (بازار Google Play، Samsung Apps) نصب کنید. \n تنظیمات دستگاه خود را باز کنید. → زبان و ورودی → گفتار → خروجی متن به گفتار. می توانید تنظیمات برای ترکیب گفتار (به عنوان مثال، بسته های زبان را برای استفاده آفلاین دانلود کنید) را مدیریت کنید و یک موتور دیگر متن به گفتار را انتخاب کنید.
 
   [prefs_languages_information_off_link]
+    tags = android
     en = For more information please check this guide.
     ru = Более подробная информация — в этом руководстве.
     ar = لمزيد من المعلومات الرجاء مراجعة هذا الدليل.
@@ -20363,11 +13331,12 @@
     zh-Hans = 如需了解更多信息，请查阅此指南。
     zh-Hant = 如需更多資訊，請參閱本指南。
     el = Για περισσότερες πληροφορίες δείτε αυτό τον οδηγό.
+    fa = برای اطلاعات بیشتر لطفا این راهنما را بررسی کنید.
     sk = Viac informácií nájdete v tomto návode.
     sw = Kwa maelezo zaidi tafadhali tazama mwongozo huu.
-    fa = برای اطلاعات بیشتر لطفا این راهنما را بررسی کنید.
 
   [whatsnew_transliteration_title]
+    tags = ios, android
     en = Transliteration into Latin
     ru = Латинская транслитерация
     ar = كتابة بالحروف اللاتينية
@@ -20399,19 +13368,16 @@
     be = Транслітарацыя лацінкай
     el = Μεταγραφή στα Λατινικά
     es_MX = Transliteración al alfabeto latino
+    fa = ترجمه به لاتین
     fr_CA = Translittération vers l'alphabet latin
     he = תעתיק ללטינית
     hi = लैटिन में लिप्यंतरण
     ms = Transliterasi kepada Latin
     sk = Prepis do latinčiny
     sw = Tafsiri kwa lugha ya Kilatini
-    fa = ترجمه به لاتین
-
-  [yandex_taxi_title]
-    en = Yandex.Taxi
-    ru = Яндекс.Такси
 
   [learn_more]
+    tags = android
     en = Learn more
     ru = Узнать больше
     ar = تعلم المزيد
@@ -20439,11 +13405,12 @@
     zh-Hans = 了解更多
     zh-Hant = 瞭解更多資訊
     el = Μάθετε περισσότερα
+    fa = بیشتر بدانید
     sk = Zistiť viac
     sw = Jua mengi zaidi
-    fa = بیشتر بدانید
 
   [core_exit]
+    tags = ios, android
     en = Exit
     ru = Выход
     ar = خروج
@@ -20471,11 +13438,12 @@
     zh-Hans = 退出
     zh-Hant = 退出
     el = Έξοδος
+    fa = خروج
     sk = Ukončiť
     sw = Toka
-    fa = خروج
 
   [routing_add_start_point]
+    tags = android
     en = Add a starting point to plan a route
     ru = Добавьте стартовую точку, чтобы построить маршрут
     ar = أضف نقطة البداية لتخطيط المسار
@@ -20503,11 +13471,12 @@
     zh-Hans = 添加起点以规划路线
     zh-Hant = 新增起點以計劃路線
     el = Προσθέστε αφετηρία για να σχεδιάσετε μια διαδρομή
+    fa = یک نقطه شروع برای برنامه ریزی یک مسیر اضافه کنید
     sk = Pridaním počiatočného bodu začnite plánovať trasu
     sw = Ongeza eneo la kuanzia ili kupanga njia ya kufuata
-    fa = یک نقطه شروع برای برنامه ریزی یک مسیر اضافه کنید
 
   [routing_add_finish_point]
+    tags = android
     en = Add a destination to plan a route
     ru = Добавьте конечную точку, чтобы построить маршрут
     ar = أضف النهاية لتخطيط المسار
@@ -20535,11 +13504,12 @@
     zh-Hans = 添加终点以规划路线
     zh-Hant = 新增終點以計劃路線
     el = Προσθέστε τελικό προορισμό, για να σχεδιάσετε μια διαδρομή
+    fa = یک مقصد برای برنامه ریزی یک مسیر اضافه کنید
     sk = Pridaním cieľového bodu naplánujete trasu
     sw = Ongeza eneo la kumalizia ili kupanga njia ya kufuata
-    fa = یک مقصد برای برنامه ریزی یک مسیر اضافه کنید
 
   [button_exit]
+    tags = android
     en = Exit
     ru = Выход
     ar = خروج
@@ -20567,171 +13537,12 @@
     zh-Hans = 退出
     zh-Hant = 退出
     el = Έξοδος
+    fa = خروج
     sk = Ukončiť
     sw = Toka
-    fa = خروج
-
-  [settings_device_memory]
-    en = Device memory
-    ru = Память устроства
-    ar = ذاكرة الجهاز
-    cs = Paměť zařízení
-    da = Enhedens hukommelse
-    nl = Apparaatgeheugen
-    fi = Laitteen muisti
-    fr = Mémoire de l’appareil
-    de = Gerätespeicher
-    hu = Készülék memóriája
-    id = Memori perangkat
-    it = Memoria del dispositivo
-    ja = デバイスのメモリ
-    ko = 장치 메모리
-    nb = Enhetsminnet
-    pl = Pamięć urządzenia
-    pt = Memória do dispositivo
-    ro = Memoria dispozitivului
-    es = Memoria del dispositivo
-    sv = Enhetens minne
-    th = หน่วยความจำเครื่อง
-    tr = Cihaz belleği
-    uk = Вбудована пам'ять
-    vi = Bộ nhớ thiết bị
-    zh-Hans = 设备内存
-    zh-Hant = 裝置記憶體
-    el = Μνήμη συσκευής
-    sk = Pamäť zariadenia
-    sw = Kumbukumbu ya kifaa
-    fa = حافظه دستگاه
-
-  [settings_card_memory]
-    en = Card memory
-    ru = Карта памяти
-    ar = بطاقة الذاكرة
-    cs = Paměťovou kartu
-    da = Kortets hukommelse
-    nl = Kaartgeheugen
-    fi = Muistkortti
-    fr = Mémoire carte
-    de = Speicherkarte
-    hu = Memóriakártya
-    id = Memori kartu
-    it = Scheda di memoria
-    ja = カードのメモリ
-    ko = 카드 메모리
-    nb = Minnekort
-    pl = Pamięć na karcie
-    pt = Memória do cartão
-    ro = Card
-    es = Tarjeta de memoria
-    sv = Kortets minne
-    th = หน่วยความจำการ์ด
-    tr = Kart belleği
-    uk = Карта пам'яті
-    vi = Bộ nhớ thẻ
-    zh-Hans = 存储卡
-    zh-Hant = 卡記憶體
-    el = Κάρτα μνήμης
-    sk = Pamäť na karte
-    sw = Kumbukumbu ya kadi
-    fa = کارت حافظه
-
-  [settings_storage_available]
-    en = %s available
-    ru = %s доступно
-    ar = %s متوفر
-    cs = %s k dispozici
-    da = %s tilgængelig
-    nl = %s beschikbaar
-    fi = %s käytettävissä
-    fr = %s disponible
-    de = %s verfügbar
-    hu = %s rendelkezésre áll
-    id = %s tersedia
-    it = %s disponibile
-    ja = %s 使用可能
-    ko = %s 사용 가능
-    nb = %s tilgjengelig
-    pl = dostępne %s
-    pt = %s disponível
-    ro = %s disponibil
-    es = %s disponible
-    sv = %s tillgängligt
-    th = เหลือให้ใช้ได้ %s
-    tr = %s kullanılabilir
-    uk = Доступно: %s
-    vi = %s trống
-    zh-Hans = %s 可用
-    zh-Hant = %s 可用
-    el = %s διαθέσιμα
-    sk = K dispozícii %s
-    sw = %s zinapatikana
-    fa = %s موجود
-
-  [toast_location_permission_denied]
-    en = App location permission denied
-    ru = Определение местоположения запрещено
-    ar = تم رفض إذن الموقع للتطبيق
-    cs = Povolení k určení polohy bylo zamítnuto
-    da = App-position tilladelse nægtet
-    nl = App toelating locatie geweigerd
-    fi = Sovelluksen sijainnin käyttöoikeus evättiin
-    fr = Autorisation de localisation refusée à l'application
-    de = App-Zugriff auf Standort verweigert
-    hu = Alkalmazás helymeghatározási engedélye megtagadva
-    id = Izin lokasi aplikasi ditolak
-    it = Autorizzazione a posizione app negata
-    ja = アプリの位置情報へのアクセスが拒否されました
-    ko = 앱 위치 권한 거부됨
-    nb = App-plasseringstillatelse avvist
-    pl = Odmowa dla aplikacji uprawnień do lokalizacji
-    pt = Permissão de localização da aplicação não autorizada
-    ro = Permisiune de accesare a locației respinsă
-    es = A la aplicación se le ha denegado el permiso de acceso a la ubicación
-    sv = Behörighet till appens plats nekades
-    th = สิทธิ์ตำแหน่งที่ตั้งของแอปถูกปฏิเสธ
-    tr = Uygulamanın konum bilgilerine erişim isteği reddedildi
-    uk = Відмовлено у доступі до функції визначення геолокації
-    vi = Quyền định vị của ứng dụng bị từ chối
-    zh-Hans = 应用已拒绝地点获取权限
-    zh-Hant = 應用程式地點存取權限被拒絕
-    el = Άρνηση πρόσβασης εφαρμογής στον εντοπισμό τοποθεσίας
-    sk = Zamietnutý prístup aplikácie k lokalite
-    sw = Ruhusu ya programu-tumizi kufikia maeneo imekataliwa
-    fa = مجوز مکان برنامه صادر نشد
-
-  [button_use]
-    en = Use
-    ru = Использовать
-    ar = استخدام
-    cs = Použít
-    da = Brug
-    nl = Gebruiken
-    fi = Käytä
-    fr = Utiliser
-    de = Nutzen
-    hu = Használat
-    id = Gunakan
-    it = Usa
-    ja = 使う
-    ko = 사용
-    nb = Bruk
-    pl = Użyj
-    pt = Utilizar
-    ro = Utilizare
-    es = Utilizar
-    sv = Använd
-    th = ใช้
-    tr = Kullan
-    uk = Використовувати
-    vi = Sử dụng
-    zh-Hans = 使用
-    zh-Hant = 使用
-    el = Χρήση
-    sk = Použiť
-    sw = Tumia
-    fa = استفاده
 
   [planning_route_manage_route]
+    tags = ios
     en = Manage Route
     ru = Изменить маршрут
     ar = إدارة المسار
@@ -20759,11 +13570,12 @@
     zh-Hans = 管理路线
     zh-Hant = 管理路線
     el = Διαχείριση διαδρομής
+    fa = مدیریت مسیر
     sk = Spravovať trasu
     sw = Dhibiti njia ya kufuata
-    fa = مدیریت مسیر
 
   [button_plan]
+    tags = ios
     en = Plan
     ru = Построить
     ar = خطة
@@ -20791,43 +13603,12 @@
     zh-Hans = 规划
     zh-Hant = 計畫
     el = Σχέδιο
+    fa = برنامه
     sk = Naplánovať
     sw = Panga
-    fa = برنامه
-
-  [button_add]
-    en = Add
-    ru = Добавить
-    ar = إضافة
-    cs = Přidat
-    da = Tilføj
-    nl = Toevoegen
-    fi = Lisää
-    fr = Ajouter
-    de = Hinzufügen
-    hu = Hozzáad
-    id = Tambah
-    it = Aggiungi
-    ja = 追加
-    ko = 추가
-    nb = Angi
-    pl = Dodaj
-    pt = Adicionar
-    ro = Adăugare
-    es = Añadir
-    sv = Lägg till
-    th = เพิ่ม
-    tr = Ekle
-    uk = Додати
-    vi = Thêm
-    zh-Hans = 添加
-    zh-Hant = 新增
-    el = Προσθήκη
-    sk = Pridať
-    sw = Ongeza
-    fa = افزودن
 
   [placepage_remove_stop]
+    tags = ios, android
     en = Remove
     ru = Удалить
     ar = إزالة
@@ -20855,11 +13636,12 @@
     zh-Hans = 移除
     zh-Hant = 移除
     el = Κατάργηση
+    fa = حذف
     sk = Odstrániť
     sw = Ondoa
-    fa = حذف
 
   [planning_route_remove_title]
+    tags = ios
     en = Drag here to remove
     ru = Перетяните сюда, чтобы удалить
     ar = اسحب هنا للإزالة
@@ -20887,75 +13669,12 @@
     zh-Hans = 拖动到此处以移除
     zh-Hant = 在此拖曳以移除
     el = Σύρετε εδώ για κατάργηση
+    fa = برای حذف اینجا بکشید
     sk = Presunutím sem odstránite
     sw = Vuta hapa ili kuondoa
-    fa = برای حذف اینجا بکشید
-
-  [dialog_change_start_point_message]
-    en = Set the current location as the starting point?
-    ru = Заменить стартовую точку на текущее местоположение?
-    ar = استبدال نقطة البدء إلى الموقع الحالي؟
-    cs = Nastavit aktuální polohu jako výchozí bod?
-    da = Flyt startpunktet til den aktuelle placering?
-    nl = Het beginpunt vervangen met de huidige locatie?
-    fi = Haluatko korvata alkupisteen nykyisellä sijainnilla?
-    fr = Remplacer le point de départ par l’emplacement actuel ?
-    de = Startpunkt durch aktuellen Standort ersetzen?
-    hu = Kicseréli a kiindulási pontot az aktuális pozícióval?
-    id = Ganti titik awal ke lokasi saat ini?
-    it = Sostituire il punto di partenza con la posizione corrente?
-    ja = 出発地点を現在の場所に変更しますか？
-    ko = 시작 지점을 현재 위치로 바꾸시겠습니까?
-    nb = Plassére startpunkt til nåværende plassering?
-    pl = Zamienić punkt początkowy na bieżącą lokalizację?
-    pt = Substituir ponto de partida pela localização atual?
-    ro = Înlocuiți punctul de plecare cu locația curentă?
-    es = ¿Cambiar el punto de inicio por la ubicación actual?
-    sv = Ersätt startpunkt för den aktuella platsen?
-    th = แทนที่จุดเริ่มต้นไปยังตำแหน่งปัจจุบันหรือไม่?
-    tr = Başlangıç noktası mevcut konumla değiştirilsin mi?
-    uk = Змінити початкову точку на поточне місцезнаходження?
-    vi = Thay điểm bắt đầu cho vị trí hiện tại?
-    zh-Hans = 将起点替换为当前地点？
-    zh-Hant = 取代目前位置的起點嗎？
-    el = Θέλετε να αλλάξετε την αφετηρία στην τρέχουσα θέση;
-    sk = Nahradiť štart na aktuálnou polohou?
-    sw = Ungependa kubadilisha eneo la kuanzia liwe eneo lako la sasa?
-    fa = مکان فعلی را به عنوان نقطه شروع تعیین کنید؟
-
-  [button_replace]
-    en = Replace
-    ru = Заменить
-    ar = استبدال
-    cs = Nastavit
-    da = Flyt
-    nl = Vervangen
-    fi = Korvaa
-    fr = Remplacer
-    de = Ersetzen
-    hu = Csere
-    id = Ganti
-    it = Sostituisci
-    ja = 変更する
-    ko = 바꾸기
-    nb = Plassére
-    pl = Zamień
-    pt = Substituir
-    ro = Înlocuire
-    es = Cambiar
-    sv = Ersätt
-    th = แทนที่
-    tr = Değiştir
-    uk = Змінити
-    vi = Thay thế
-    zh-Hans = 替换
-    zh-Hant = 取代
-    el = Αλλαγή
-    sk = Nahradiť
-    sw = Badilisha
-    fa = جایگزین کردن
 
   [placepage_add_stop]
+    tags = ios, android
     en = Add Stop
     ru = Заехать
     ar = إضافة نقطة توقف
@@ -20983,127 +13702,12 @@
     zh-Hans = 添加经停点
     zh-Hant = 新增應用程式
     el = Προσθήκη στάσης
+    fa = اضافه کردن توقف
     sk = Pridať zastávku
     sw = Ongeza eneo la kusimama
-    fa = اضافه کردن توقف
-
-  [subtitle_rent]
-    comment = Only ru/en are needed
-    en = Rent
-    ru = Аренда
-
-  [rub_month]
-    comment = Only ru/en are needed
-    en = RUB/month
-    ru = руб./мес.
-
-  [room]
-    comment = Only ru/en are needed
-    en = %s-room apt.
-    ru = %s-комн. кв.
-
-  [real_estate]
-    comment = Only ru/en are needed
-    en = Real estate
-    ru = Недвижимость
-
-  [add_my_position]
-    en = Add my position
-    ru = Добавить мое местоположение
-    ar = إضافة موضعي
-    cs = Přidat moji polohu
-    da = Tilføj min position
-    nl = Voeg mijn positie toe
-    fi = Lisää oma sijainti
-    fr = Ajouter ma position
-    de = Meinen Standort hinzufügen
-    hu = Add hozzá saját pozíciómat
-    id = Tambahkan posisi saya
-    it = Aggiungi mia posizione
-    ja = 自分の場所を追加
-    ko = 내 위치 추가
-    nb = Legg til min posisjon
-    pl = Dodaj moją pozycję
-    pt = Adicionar a minha posição
-    ro = Adaugă poziția mea
-    es = Añadir mi posición
-    sv = Lägg till min position
-    th = เพิ่มตำแหน่งของฉัน
-    tr = Konumumu ekle
-    uk = Додати моє розташування
-    vi = Thêm vị trí của tôi
-    zh-Hans = 添加我的位置
-    zh-Hant = 新增我的位置
-    el = Πρόσθεσε τη θέση μου
-    sk = Pridať moju polohu
-    sw = Ongeza mahali nipo sasa
-    fa = موقعیت من را اضافه کنید
-
-  [choose_start_point]
-    en = Choose a starting point
-    ru = Выберите начало маршрута
-    ar = اختيار نقطة البداية
-    cs = Vybrat počáteční bod
-    da = Vælg et udgangspunkt
-    nl = Kies een vertrekpunt
-    fi = Valitse aloituspiste
-    fr = Choisissez un point de départ
-    de = Startpunkt auswählen
-    hu = Válasszon egy kiindulási pontot
-    id = Pilih titik awal
-    it = Scegli un punto di partenza
-    ja = 出発地点を選択
-    ko = 시작 지점 선택
-    nb = Velg startpunkt
-    pl = Wybierz punkty początkowy
-    pt = Escolher um ponto de partida
-    ro = Alege un punct de plecare
-    es = Elegir un punto de partida
-    sv = Välj en startpunkt
-    th = เลือกจุดเริ่มต้น
-    tr = Bir başlangıç noktası seçin
-    uk = Вибрати відправну точку
-    vi = Chọn một điểm bắt đầu
-    zh-Hans = 选择起点
-    zh-Hant = 選擇起點
-    el = Επιλέξτε αφετηρία
-    sk = Vyberte počiatočný bod
-    sw = Chagua eneo unakoanzia
-    fa = نقطه شروع را انتخاب کنید
-
-  [choose_destination]
-    en = Choose a destination
-    ru = Выберите конец маршрута
-    ar = اختيار الوجهة
-    cs = Vybrat cílové místo
-    da = Vælg en destination
-    nl = Kies een bestemming
-    fi = Valitse kohde
-    fr = Choisissez une destination
-    de = Ziel auswählen
-    hu = Válassza ki a célt
-    id = Pilih destinasi
-    it = Scegli una destinazione
-    ja = 目的地を選択
-    ko = 목적지 선택
-    nb = Velg destinasjon
-    pl = Wybierz punkt docelowy
-    pt = Escolher um destino
-    ro = Alege o destinație
-    es = Elegir un destino
-    sv = Välj en destination
-    th = เลือกปลายทาง
-    tr = Bir hedef seçin
-    uk = Вибрати пункт призначення
-    vi = Chọn một điểm đến
-    zh-Hans = 选择终点
-    zh-Hant = 選擇目的地
-    el = Επιλέξτε προορισμό
-    sk = Vyberte cieľ
-    sw = Chagua eneo unakoelekea
-    fa = یک مقصد را انتخاب کنید
 
   [preloader_viator_button]
+    tags = android
     en = Learn more
     ru = Посмотреть
     ar = تعلم المزيد
@@ -21131,107 +13735,12 @@
     zh-Hans = 了解更多
     zh-Hant = 進一步了解
     el = Μάθετε περισσότερα
+    fa = بیشتر بدانید
     sk = Zistiť viac
     sw = Jua mengi zaidi
-    fa = بیشتر بدانید
-
-  [start_from_my_position]
-    en = Start from
-    ru = Начать от
-    ar = بدء من
-    cs = Začít z
-    da = Start fra
-    nl = Start vanaf
-    fi = Aloita kohdasta
-    fr = Commencer à partir de
-    de = Starten von
-    hu = Elkezdi innen:
-    id = Mulai dari
-    it = Parti da
-    ja = 開始位置
-    ko = 시작 위치:
-    nb = Start fra
-    pl = Zacznij od
-    pt = Iniciar a partir de
-    ro = Începând de la
-    es = Empezar desde
-    sv = Starta från
-    th = เริ่มจาก
-    tr = Buradan başla
-    uk = Почати з
-    vi = Bắt đầu từ
-    zh-Hans = 起点
-    zh-Hant = 起點
-    el = Έναρξη από
-    sk = Začať od
-    sw = Anzia
-    fa = شروع از
-
-  [profile_authorization_title]
-    en = Sign in with
-    ru = Авторизуйтесь с помощью
-    ar = تسجيل الدخول باستخدام
-    cs = Přihlásit se s
-    da = Log ind med
-    nl = Aanmelden met
-    fi = Kirjaudu sisään käyttämällä palvelua
-    fr = Se connecter avec
-    de = Anmelden mit
-    hu = Bejelentkezés ezzel
-    id = Masuk dengan
-    it = Accedi con
-    ja = サインイン方法
-    ko = 로그인
-    nb = Logg inn med
-    pl = Zaloguj się za pomocą
-    pt = Iniciar sessao com
-    ro = Conectare cu
-    es = Iniciar sesión con
-    sv = Logga in med
-    th = ลงชื่อเข้าใช้ด้วย
-    tr = Oturum aç
-    uk = Увійти за допомогою
-    vi = Đăng nhập với
-    zh-Hans = 登录方式
-    zh-Hant = 登入方式
-    el = Συνδεθείτε με
-    sk = Prihlásiť sa pomocou
-    sw = Ingia ndani ukitumia
-    fa = پیوستن با
-
-  [profile_authorization_message]
-    en = Easy sign in without login and password in a couple of seconds
-    ru = Простая авторизация за пару секунд без логина и пароля
-    ar = تسجيل الدخول بسهولة بدون اسم مستخدم وكلمة مرور في غضون بضع ثوان
-    cs = Snadné přihlášení bez uživatelského jména a hesla během několika sekund
-    da = Nemt login på et par sekunder uden brugernavn og adgangskode
-    nl = Eenvoudig aanmelden zonder gebruikersnaam en wachtwoord in enkele seconden
-    fi = Helppo sisäänkirjautuminen ilman käyttäjätunnusta ja salasanaa parissa sekunnissa
-    fr = Connexion facile sans identifiant ni mot de passe en quelques secondes
-    de = Einfaches Anmelden ohne Anmeldename und Passwort in nur wenigen Sekunden
-    hu = Egyszerű bejelentkezés jelszó és bejelentkezési név nélkül, pár másodperc alatt
-    id = Masuk dengan mudah tanpa kredensial dan kata sandi dalam beberapa detik
-    it = Semplice accesso senza login e password in un paio di secondi
-    ja = ログイン名とパスワードなしですぐに簡単にサインインできます
-    ko = 로그인 및 암호 없이 몇 초 내에 간편하게 로그인
-    nb = Enkel innlogging uten innloggingsinfo og passord på bare noen sekunder
-    pl = Łatwe logowanie w kilka sekund bez podawania loginu i hasła
-    pt = Início de sessão fácil e em apenas alguns segundos, sem dados de acesso e palavra-passe
-    ro = Conectare rapidă în câteva secunde, fără autentificare și parolă
-    es = Inicie sesión fácilmente sin nombre de usuario ni contraseña en un par de segundos
-    sv = Enkelt att logga in utan inloggning och lösenord inom ett par sekunder
-    th = ลงชื่อเข้าใช้อย่างง่ายโดยไม่ต้องใช้ชื่อเข้าสู่ระบบและรหัสผ่านเพียงไม่กี่วินาที
-    tr = Kullanıcı adı ve şifreye gerek kalmadan saniyeler içinde kolayca oturum açın
-    uk = Швидкий вхід без логіна та пароля за кілька секунд
-    vi = Dễ dàng đăng nhập chỉ trong một vài giây mà không cần tên người dùng và mật khẩu
-    zh-Hans = 在几秒内轻松登录，无需登录名和密码
-    zh-Hant = 無須帳號密碼，在幾秒內輕鬆登入。
-    el = Εύκολη σύνδεση χωρίς όνομα χρήστη και κωδικό πρόσβασης σε λίγα δευτερόλεπτα
-    sk = Jednoduché prihlásenie bez zadávania mena a hesla za pár sekúnd
-    sw = Ingia ndani kwa urahisi bila kuweka nenosiri ukicukua sekunde mbili
-    fa = وارد شدن آسان بدون ورود به سیستم و رمز عبور در چند ثانیه
 
   [profile_authorization_error]
+    tags = ios
     en = Oops, there was an error. Try to sign in again.
     ru = Упс, произошла ошибка. Попробуйте авторизоваться повторно.
     ar = عفوًا، كان هناك خطأ. حاول تسجيل الدخول مرة اخرى.
@@ -21259,267 +13768,12 @@
     zh-Hans = 糟糕，出错了。请尝试重新登录。
     zh-Hant = 噢，發生錯誤。請嘗試再次登入。
     el = Ωχ, παρουσιάστηκε σφάλμα. Προσπαθήστε να συνδεθείτε ξανά.
+    fa = اوه، یک خطا وجود داشت سعی کنید دوباره وارد سیستم شوید
     sk = Ups, vyskytla sa chyba. Skúste sa prihlásiť znova.
     sw = Lo, kumekuwa na hitilafu. Jaribu tena kuingia ndani.
-    fa = اوه، یک خطا وجود داشت سعی کنید دوباره وارد سیستم شوید
-
-  [service]
-    en = Service
-    ru = Обслуживание
-    ar = الخدمة
-    cs = Služba
-    da = Service
-    nl = Dienst
-    fi = Palvelu
-    fr = Service
-    de = Service
-    hu = Szolgáltatások
-    id = Layanan
-    it = Servizio
-    ja = サービス
-    ko = 서비스
-    nb = Service
-    pl = Usługa
-    pt = Serviço
-    ro = Servicii
-    es = Servicio
-    sv = Service
-    th = บริการ
-    tr = Hizmet
-    uk = Обслуговування
-    vi = Dịch vụ
-    zh-Hans = 服务
-    zh-Hant = 服務
-    el = Εξυπηρέτηση
-    sk = Služba
-    sw = Huduma
-    fa = سرویس
-
-  [atmosphere]
-    en = Atmosphere
-    ru = Атмосфера
-    ar = المناخ
-    cs = Atmosféra
-    da = Atmosfære
-    nl = Sfeer
-    fi = Ilmapiiri
-    fr = Ambiance
-    de = Atmosphäre
-    hu = Légkör
-    id = Suasana
-    it = Atmosfera
-    ja = 雰囲気
-    ko = 분위기
-    nb = Atmosfære
-    pl = Atmosfera
-    pt = Atmosfera
-    ro = Atmosferă
-    es = Ambiente
-    sv = Atmosfär
-    th = บรรยากาศ
-    tr = Ortam
-    uk = Атмосфера
-    vi = Không khí
-    zh-Hans = 氛围
-    zh-Hant = 氣氛
-    el = Ατμόσφαιρα
-    sk = Atmosféra
-    sw = Hewa
-    fa = جو
-
-  [value_for_money]
-    en = Value for money
-    ru = Цена / качество
-    ar = القيمة مقابل المال
-    cs = Poměr hodnoty a ceny
-    da = Værdi for pengene
-    nl = Waarde voor geld
-    fi = Vastinetta rahoille
-    fr = Rapport qualité/prix
-    de = Preis-Leis­tungs-Ver­hält­nis
-    hu = Ár-érték arány
-    id = Kepantasan harga
-    it = Rapporto qualità/prezzo
-    ja = 金額に見合う価値
-    ko = 가성비
-    nb = Valuta for pengene
-    pl = Stosunek jakości do ceny
-    pt = Relação qualidade-preço
-    ro = Raport calitate/preț
-    es = Relación calidad-precio
-    sv = Valuta för pengarna
-    th = คุ้มค่าเงิน
-    tr = Fiyat/Fayda
-    uk = Співвідношення ціна/якість
-    vi = Đáng đồng tiền
-    zh-Hans = 物有所值
-    zh-Hant = 物有所值
-    el = Αξία για τα χρήματα
-    sk = Hodnota za peniaze
-    sw = Thamani halisi ya pesa
-    fa = ارزش پول
-
-  [experience]
-    en = Experience
-    ru = Впечатления
-    ar = التجربة
-    cs = Zážitek
-    da = Erfaring
-    nl = Ervaring
-    fi = Kokemus
-    fr = Expérience
-    de = Erfahrung
-    hu = Tapasztalat
-    id = Pengalaman
-    it = Esperienza
-    ja = 経験
-    ko = 경험
-    nb = Erfaren
-    pl = Doświadczenie
-    pt = Experiência
-    ro = Experiență
-    es = Experiencia
-    sv = Erfarenhet
-    th = ประสบการณ์
-    tr = Tecrübe
-    uk = Загальне враження
-    vi = Trải nghiệm
-    zh-Hans = 经验
-    zh-Hant = 體驗
-    el = Εμπειρία
-    sk = Skúsenosti
-    sw = Uzoefu
-    fa = تجربه
-
-  [assortment]
-    en = Assortment
-    ru = Ассортимент
-    ar = التصنيف
-    cs = Sortiment
-    da = Udvalg
-    nl = Assortiment
-    fi = Valikoima
-    fr = Assortiment
-    de = Sortiment
-    hu = Választék
-    id = Lain-Lain
-    it = Assortimento
-    ja = 品揃え
-    ko = 구색
-    nb = Utvalg
-    pl = Asortyment
-    pt = Variedade
-    ro = Varietate
-    es = Variedad
-    sv = Urval
-    th = การแบ่งประเภท
-    tr = Ürün çeşitliliği
-    uk = Асортимент
-    vi = Phân loại
-    zh-Hans = 分类
-    zh-Hant = 分類
-    el = Κατάταξη
-    sk = Sortiment
-    sw = Mchanganyiko
-    fa = انتخابی
-
-  [expertise]
-    en = Expertise
-    ru = Профессионализм
-    ar = الخبرة
-    cs = Odborné znalosti
-    da = Ekspertise
-    nl = Expertise
-    fi = Asiantuntemus
-    fr = Expertise
-    de = Kompetenz
-    hu = Szakértelem
-    id = Keahlian
-    it = Competenza
-    ja = 専門知識
-    ko = 전문성
-    nb = Kompetanse
-    pl = Fachowość
-    pt = Especialidade
-    ro = Expertiză
-    es = Conocimiento
-    sv = Expertis
-    th = ความเชี่ยวชาญ
-    tr = Uzmanlık
-    uk = Досвід співробітників
-    vi = Chuyên môn
-    zh-Hans = 专业
-    zh-Hant = 專業
-    el = Τεχνογνωσία
-    sk = Odbornosť
-    sw = Ustadi
-    fa = تجربه و تخصص
-
-  [equipment]
-    en = Equipment
-    ru = Оборудование
-    ar = المعدات
-    cs = Vybavení
-    da = Udstyr
-    nl = Uitrusting
-    fi = Laitteet
-    fr = Équipement
-    de = Ausstattung
-    hu = Berendezések
-    id = Perlengkapan
-    it = Attrezzature
-    ja = 設備
-    ko = 장비
-    nb = Utstyr
-    pl = Wyposażenie
-    pt = Equipamento
-    ro = Echipamente
-    es = Equipamiento
-    sv = Utrustning
-    th = อุปกรณ์
-    tr = Ekipman
-    uk = Обладнання
-    vi = Thiết bị
-    zh-Hans = 设备
-    zh-Hant = 設備
-    el = Εξοπλισμός
-    sk = Vybavenie
-    sw = Vifaa
-    fa = تجهیزات
-
-  [quality]
-    en = Quality
-    ru = Качество
-    ar = الجودة
-    cs = Kvalita
-    da = Kvalitet
-    nl = Kwaliteit
-    fi = Laatu
-    fr = Qualité
-    de = Qualität
-    hu = Minőség
-    id = Mutu
-    it = Qualità
-    ja = 品質
-    ko = 품질
-    nb = Kvalitet
-    pl = Jakość
-    pt = Qualidade
-    ro = Calitate
-    es = Calidad
-    sv = Kvalitet
-    th = คุณภาพ
-    tr = Kalite
-    uk = Якість
-    vi = Chất lượng
-    zh-Hans = 质量
-    zh-Hant = 品質
-    el = Ποιότητα
-    sk = Kvalita
-    sw = Ubora
-    fa = کیفیت
 
   [dialog_error_storage_title]
+    tags = android
     en = Storage access problem
     ru = Проблема с доступом к хранилищу
     ar = مشكلة الوصول للتخزين
@@ -21534,8 +13788,10 @@
     it = Problema di accesso all'archivio
     ja = ストレージアクセスの問題
     ko = 저장소 액세스 문제
+    nb = Problemer med tilgang til lagring
     pl = Problem z dostępem do pamięci masowej
     pt = Problema de acesso ao armazenamento
+    pt-BR = Problema de acesso ao armazenamento
     ro = Problemă de accesare spațiu de stocare
     es = Problema de acceso al almacenamiento
     sv = Lagringsåtkomstproblem
@@ -21547,13 +13803,12 @@
     zh-Hant = 儲存空間存取問題
     el = Πρόβλημα πρόσβασης στον αποθηκευτικό χώρο
     es_MX = Problema de acceso al almacenamiento
-    nb = Problemer med tilgang til lagring
-    pt-BR = Problema de acesso ao armazenamento
+    fa = مشکل دسترسی به ذخیره سازی
     sk = Problém s prístupom k úložisku
     sw = Tatizo la kufikia hifadhi
-    fa = مشکل دسترسی به ذخیره سازی
 
   [dialog_error_storage_message]
+    tags = android
     en = External storage is not accessible. The SD Card may have been removed, damaged, or the file system is read-only. Please, check your SD Card or contact us at support@organicmaps.app
     ru = Внешняя память устройства недоступна, возможно SD карта была удалена, повреждена или файловая система доступна только для чтения. Проверьте это и свяжитесь, пожалуйста, с нами support@organicmaps.app
     ar = التخزين الخارجي غير متوفر، ربما تمت إزالة بطاقة SD، أو أنها تالفة أو ملف النظام للقراءة فقط. افحصه واتصل بنا على support@organicmaps.app
@@ -21568,8 +13823,10 @@
     it = Archivio esterno non disponibile, probabilmente la scheda SD è stata rimossa, è danneggiata o il file system è di sola lettura. Controllala e contattaci su support@organicmaps.app
     ja = 外部ストレージは使用できません。おそらく SD カードが取り外されたか、破損している、あるいはファイルシステムが読み取り専用になっています。確認後、support@organicmaps.app までご連絡ください。
     ko = 외부 저장소를 사용할 수 없습니다. SD 카드가 제거되었거나 손상되었거나 파일 시스템이 읽기 전용일 수 있습니다. 확인 후 support@organicmaps.app로 문의하세요.
+    nb = Ekstern lagring er ikke tilgjengelig. Sannsynligvis er SD-kortet fjernet eller skadet eller så er filsystemet skrivebeskyttet. Undersøk og kontakt oss på support@organicmaps.app
     pl = Zewnętrzny nośnik pamięci masowej jest niedostępny. Prawdopodobnie usunięto lub uszkodzono kartę SD bądź jej system plików służy tylko do odczytu. Zweryfikuj to i skontaktuj się z nami pod adresem support@organicmaps.app
     pt = Armazenamento externo não disponível. Provavelmente porque o Cartão SD foi removido, danificado ou o sistema de ficheiros é apenas para leitura. Verifique e entre em contacto conosco através do email support@organicmaps.app
+    pt-BR = O armazenamento externo não está disponível, é provável que o Cartão SD tenha sido removido, danificado ou o sistema de arquivo seja apenas para leitura. Verifique e entre em contato conosco em support@organicmaps.app
     ro = Spațiul de stocare extern nu este disponibil. Probabil cardul SD nu este introdus, este deteriorat sau sistemul de fișiere este read-only. Verifică și contactează-ne la support@organicmaps.app
     es = El almacenamiento externo no está disponible; puede que se haya quitado o dañado la tarjeta SD, o el sistema de archivos solo permite lectura. Por favor, compruébelo y escríbanos a support@organicmaps.app
     sv = Extern lagring är inte tillgänglig. SD-kortet är borttaget, skadat eller så är filsystemet är skrivskyddat. Kontrollera det och kontakta oss på support@organicmaps.app
@@ -21581,13 +13838,12 @@
     zh-Hant = 外部儲存空間不可用，很可能是因為 SD 卡已移除、毀損，或檔案系統處於唯讀狀態。請進行檢查，然後以 support@organicmaps.app 方式聯繫我們
     el = Ο εξωτερικός απθηκευτικός χώρος δεν είναι διαθέσιμος, πιθανότατα έχει αφαιρεθεί η κάρτα SD, είναι κατεστραμμένη ή το σύστημα αρχείων είναι μόνο για ανάγνωση. Ελέγξτε το και επικοινωνήστε μαζί μας στη διεύθυνση support@organicmaps.app
     es_MX = El almacenamiento externo no está disponible. Es posible que se haya quitado o dañado la tarjeta SD, o que el sistema de archivos solo permita la lectura. Revíselo y escríbanos a support@organicmaps.app
-    nb = Ekstern lagring er ikke tilgjengelig. Sannsynligvis er SD-kortet fjernet eller skadet eller så er filsystemet skrivebeskyttet. Undersøk og kontakt oss på support@organicmaps.app
-    pt-BR = O armazenamento externo não está disponível, é provável que o Cartão SD tenha sido removido, danificado ou o sistema de arquivo seja apenas para leitura. Verifique e entre em contato conosco em support@organicmaps.app
+    fa = ذخیره سازی خارجی در دسترس نیست کارت SD ممکن است برداشته شده باشد، آسیب دیده باشد یا سیستم فایل فقط خواندنی باشد. لطفا کارت SD خود را بررسی کنید یا با ما در support@organicmaps.app تماس بگیرید
     sk = Externý úložný priestor nie je dostupný, pravdepodobne je vytiahnutá alebo poškodená SD karta alebo je systém súborov určený iba na čítanie. Skontrolujte to, prosím, a kontaktujte nás na support@organicmaps.app
     sw = Hifadhi ya nje haipatikani, pengine Kadi ya SD imeondolewa, imeharibika au mfumo wa faili ni wa kusoma pekee. Tafadhali ikague na uwasiliane nasi kwa kutumia support@organicmaps.app
-    fa = ذخیره سازی خارجی در دسترس نیست کارت SD ممکن است برداشته شده باشد، آسیب دیده باشد یا سیستم فایل فقط خواندنی باشد. لطفا کارت SD خود را بررسی کنید یا با ما در support@organicmaps.app تماس بگیرید
 
   [setting_emulate_bad_storage]
+    tags = android
     en = Emulate bad storage
     ru = Эмуляция ошибки с внешней памятью
     ar = محاكاة التخزين السيء
@@ -21602,8 +13858,10 @@
     it = Simula archivio danneggiato
     ja = 壊れたストレージをエミュレート
     ko = 불량 저장소 에뮬레이션
+    nb = Emulere skadet lagring
     pl = Emuluj wadliwą pamięć masową
     pt = Emular o mau armazenamento
+    pt-BR = Emular memória ruim
     ro = Emulare stocare eronată
     es = Emular almacenamiento dañado
     sv = Emulera dålig lagring
@@ -21615,81 +13873,12 @@
     zh-Hant = 模擬不良儲存空間
     el = Εξομείωση κακού αποθηκευτικού χώρου
     es_MX = Emular el almacenamiento dañado
-    nb = Emulere skadet lagring
-    pt-BR = Emular memória ruim
+    fa = شبیه سازی ذخیره سازی بد
     sk = Imitovať poškodené úložisko
     sw = Onyeshana hifadhi mbaya
-    fa = شبیه سازی ذخیره سازی بد
-
-  [directions_finish]
-    en = Destination
-    ru = Место назначения
-    ar = الوجهة
-    cs = Cíl
-    da = Destination
-    nl = Bestemming
-    fi = Kohde
-    fr = Destination
-    de = Ziel
-    hu = Rendeltetési hely
-    id = Destinasi
-    it = Destinazione
-    ja = 目的地
-    ko = 목적지
-    pl = Punkt docelowy
-    pt = Destino
-    ro = Destinație
-    es = Destino
-    sv = Destination
-    th = จุดหมายปลายทาง
-    tr = Varış konumu
-    uk = Напрямок
-    vi = Điểm đến
-    zh-Hans = 目的地
-    zh-Hant = 目的地
-    el = Προορισμός
-    es_MX = Destino
-    nb = Destinasjon
-    pt-BR = Destino
-    sk = Ciel
-    sw = Eneo unakoelekea
-    fa = مقصد
-
-  [directions_on_foot]
-    en = Walk %s
-    ru = Пешком %s
-    ar = سيرًا %s
-    cs = Chůze %s
-    da = Gå %s
-    nl = Wandel %s
-    fi = Kävele %s
-    fr = Marcher %s
-    de = %s zu Fuß gehen
-    hu = %s séta
-    id = Berjalan %s
-    it = Percorri %s
-    ja = 徒歩 %s
-    ko = %s 걷기
-    pl = Przejdź %s
-    pt = Caminhar %s
-    ro = %s de mers
-    es = %s a pie
-    sv = Gå %s
-    th = เดินเท้า %s
-    tr = %s doğru yürüyün
-    uk = Піша прогулянка %s
-    vi = Đi bộ %s
-    zh-Hans = 步行 %s
-    zh-Hant = 步行 %s
-    el = Βάδισμα %s
-    es_MX = %s a pie
-    nb = Gå %s
-    pt-BR = Caminhar %s
-    sk = Chôdza %s
-    sw = Tembea %s
-    fa = پیاده روی %s
 
   [core_entrance]
+    tags = ios, android
     en = Entrance
     ru = Вход
     ar = المدخل
@@ -21704,8 +13893,10 @@
     it = Ingresso
     ja = 入口
     ko = 입구
+    nb = Inngang
     pl = Wejście
     pt = Entrada
+    pt-BR = Entrada
     ro = Intrare
     es = Entrada
     sv = Ingång
@@ -21717,118 +13908,12 @@
     zh-Hant = 入口
     el = Είσοδος
     es_MX = Entrada
-    nb = Inngang
-    pt-BR = Entrada
+    fa = ورودی
     sk = Vchod  | vjazd
     sw = Kiingilio
-    fa = ورودی
-
-  [coffee]
-    en = Coffee
-    ru = Кофе
-    ar = قهوة
-    cs = Káva
-    da = Kaffe
-    nl = Koffie
-    fi = Kahvi
-    fr = Café
-    de = Kaffee
-    hu = Kávé
-    id = Kopi
-    it = Caffè
-    ja = コーヒー
-    ko = 커피
-    pl = Kawa
-    pt = Café
-    ro = Cafea
-    es = Café
-    sv = Kaffe
-    th = กาแฟ
-    tr = Kahve
-    uk = Кава
-    vi = Cà phê
-    zh-Hans = 咖啡
-    zh-Hant = 咖啡
-    el = Καφές
-    es_MX = Café
-    he = קפה
-    hi = कॉफी
-    ms = Kopi
-    nb = Kaffe
-    pt-BR = Café
-    sk = Káva
-    sw = Kahawa
-    fa = قهوه
-
-  [cleanliness]
-    en = Cleanliness
-    ru = Чистота
-    ar = نظافة
-    cs = Čistota
-    da = Renlighed
-    nl = Netheid
-    fi = Puhtaus
-    fr = Propreté
-    de = Sauberkeit
-    hu = Tisztaság
-    id = Kebersihan
-    it = Pulizia
-    ja = 清潔さ
-    ko = 청결
-    pl = Czystość
-    pt = Limpeza
-    ro = Curățenie
-    es = Limpieza
-    sv = Rent
-    th = ความสะอาด
-    tr = Temizlik
-    uk = Чистота
-    vi = Sạch sẽ
-    zh-Hans = 卫生程度
-    zh-Hant = 清潔程度
-    el = Καθαριότητα
-    es_MX = Limpieza
-    nb = Renslighet
-    pt-BR = Limpeza
-    sk = Čistota
-    sw = Usafi
-    fa = پاکیزگی
-
-  [crowdedness]
-    en = Crowdedness
-    ru = Многолюдность
-    ar = اكتظاظ
-    cs = Přelidnění
-    da = Trængsel
-    nl = Drukte
-    fi = Ahtaus
-    fr = Affluence
-    de = Gedrängtheit
-    hu = Zsúfoltság
-    id = Keramaian
-    it = Clientela
-    ja = 混雑度
-    ko = 혼잡
-    pl = Zatłoczenie
-    pt = Lotado
-    ro = Aglomerație
-    es = Lugar concurrido
-    sv = Fullt
-    th = ความแออัด
-    tr = Doluluk
-    uk = Завантаженість
-    vi = Đông đúc
-    zh-Hans = 拥挤程度
-    zh-Hant = 擁擠程度
-    el = Συνωστισμός
-    es_MX = Lugar muy concurrido
-    nb = Mye folk
-    pt-BR = Lotação
-    sk = Preplnenosť
-    sw = Watu kusongamana
-    fa = ازدحام بیش از حد
 
   [error_enter_correct_name]
+    tags = ios, android
     en = Please, enter a correct name
     ru = Пожалуйста, введите название правильно
     ar = الرجاء إدخال اسم صحيح
@@ -21843,8 +13928,10 @@
     it = Inserisci un nome corretto
     ja = 正しい名前を入力してください
     ko = 올바른 이름을 입력하세요.
+    nb = Skriv inn korrekt navn
     pl = Wprowadź poprawną nazwę
     pt = Introduza um nome correto
+    pt-BR = Por favor, digite um nome correto
     ro = Introdu un nume corect
     es = Por favor, introduzca el nombre correcto
     sv = Ange ett korrekt namn
@@ -21856,13 +13943,12 @@
     zh-Hant = 請輸入正確的名稱
     el = Εισάγετε ένα σωστό όνομα
     es_MX = Introduzca el nombre correcto
-    nb = Skriv inn korrekt navn
-    pt-BR = Por favor, digite um nome correto
+    fa = لطفا نام صحیح را وارد کنید
     sk = Prosím, zadajte správne meno
     sw = Tafadhali, weka jina sahihi
-    fa = لطفا نام صحیح را وارد کنید
 
   [bookmarks_groups]
+    tags = android
     en = Lists
     ru = Списки
     ar = قوائم
@@ -21888,15 +13974,16 @@
     tr = Listeler
     uk = Списки
     vi = Danh sách
-    el = Τόπος αγώνων
-    es_MX = Listas
-    sk = Zoznamy
-    sw = Orodha
     zh-Hans = 清單
     zh-Hant = 列表
+    el = Τόπος αγώνων
+    es_MX = Listas
     fa = لیست ها
+    sk = Zoznamy
+    sw = Orodha
 
   [bookmarks_groups_hide_all]
+    tags = android
     en = Hide all
     ru = Спрятать все
     ar = إخفاء الكل
@@ -21922,15 +14009,16 @@
     tr = Tümünü gizle
     uk = Приховати всі
     vi = Ẩn tất cả
-    el = Απόκρυψη όλων
-    es_MX = Ocultar todo
-    sk = Skryť všetko
-    sw = Ficha zote
     zh-Hans = 全部隱藏
     zh-Hant = 隱藏全部
+    el = Απόκρυψη όλων
+    es_MX = Ocultar todo
     fa = پنهان کردن همه
+    sk = Skryť všetko
+    sw = Ficha zote
 
   [bookmarks_groups_show_all]
+    tags = android
     en = Show all
     ru = Показать все
     ar = إظهار الكل
@@ -21956,53 +14044,16 @@
     tr = Tümünü göster
     uk = Показати всі
     vi = Hiển thị tất cả
-    el = Εμφάνιση όλων
-    es_MX = Mostrar todo
-    sk = Zobraziť všetko
-    sw = Onyesha zote
     zh-Hans = 全部顯示
     zh-Hant = 顯示全部
+    el = Εμφάνιση όλων
+    es_MX = Mostrar todo
     fa = نمایش همه
-
-  [bookmarks_places]
-    en:one = %d bookmark
-    en:other = %d bookmarks
-    ru:one = %d метка
-    ru:few = %d метки
-    ru:other = %d меток
-    ar = %d من الإشارات المرجعية
-    cs = %d záložek
-    da = %d bogmærker
-    nl = %d bladwijzers
-    fi = %d kirjanmerkkiä
-    fr = %d signets
-    de = %d Lesezeichen
-    hu = könyvjelzők %d
-    id = %d markah
-    it = %d preferiti
-    ja = %d個のブックマーク
-    ko = %d 북마크
-    nb = %d bokmerker
-    pl = Zakładki: %d
-    pt = %d favoritos
-    pt-BR = %d favoritos
-    ro = %d semne de carte
-    es = %d marcadores
-    sv = %d bokmärken
-    th = %d บุ๊กมาร์ก
-    tr = %d yer imi
-    uk = %d закладок
-    vi = %d dấu trang
-    el = %d αγαπημένα
-    es_MX = %d marcadores
-    sk = %d záložiek
-    sw = Alamisho %d
-    zh-Hans = %d 個書籤
-    zh-Hant = %d個書籤
-    fa:one = %d نشانه
-    fa:other = %d نشانه‌ها
+    sk = Zobraziť všetko
+    sw = Onyesha zote
 
   [bookmarks_create_new_group]
+    tags = ios, android
     en = Create new list
     ru = Создать новый список
     ar = إنشاء قائمة جديدة
@@ -22028,13 +14079,13 @@
     tr = Yeni liste oluştur
     uk = Створити новий список
     vi = Tạo danh sách mới
-    el = Δημιουργία νέας λίστας
-    es_MX = Crear lista nueva
-    sk = Vytvoriť nový zoznam
-    sw = Unda orodha mpya
     zh-Hans = 创建新的列表
     zh-Hant = 創建新列表
+    el = Δημιουργία νέας λίστας
+    es_MX = Crear lista nueva
     fa = ایجاد لیست جدید
+    sk = Vytvoriť nový zoznam
+    sw = Unda orodha mpya
 
   [bookmarks_import]
     tags = android
@@ -22043,6 +14094,7 @@
     ru = Импортировать метки
 
   [downloader_hide_screen]
+    tags = ios
     en = Hide Screen
     ru = Скрыть
     ar = إخفاء الشاشة
@@ -22068,15 +14120,16 @@
     tr = Ekranı Gizle
     uk = Приховати екран
     vi = Ẩn Màn hình
-    el = Απόκρυψη οθόνης
-    es_MX = Ocultar pantalla
-    sk = Skryť obrazovku
-    sw = Ficha skrini
     zh-Hans = 隱藏畫面
     zh-Hant = 隱藏屏幕
+    el = Απόκρυψη οθόνης
+    es_MX = Ocultar pantalla
     fa = پنهان کردن صفحه
+    sk = Skryť obrazovku
+    sw = Ficha skrini
 
   [downloader_percent]
+    tags = ios
     en = %s (%s of %s)
     ru = %s (%s из %s)
     ar = %s (%s من %s)
@@ -22102,118 +14155,86 @@
     tr = %s (%s / %s)
     uk = %s (%s з %s)
     vi = %s (%s / %s)
-    el = %s (%s από %s)
-    es_MX = %s (%s de %s)
-    sk = %s (%s z %s)
-    sw = %s (%s kati ya %s)
     zh-Hans = %s (%s / %s)
     zh-Hant = %s (%s，共%s)
-    fa =  %s (%s از %s)
+    el = %s (%s από %s)
+    es_MX = %s (%s de %s)
+    fa = %s (%s از %s)
+    sk = %s (%s z %s)
+    sw = %s (%s kati ya %s)
 
   [downloader_process]
-    en = Downloading %s...
+    tags = ios
+    en = Downloading %s…
     ru = Загрузка %s…
-    ar = جار تنزيل %s...
-    cs = Stahování %s...
-    da = Downloader %s...
-    nl = %s downloaden...
-    fi = Ladataan %s...
-    fr = Téléchargement de %s...
-    de = %s heruntergeladen...
-    hu = %s letöltése...
-    id = Mengunduh %s...
-    it = Download di %s...
-    ja = %s をダウンロードしています...
-    ko = %s 다운로드 중...
-    nb = Laster ned %s ...
-    pl = Pobieranie %s...
-    pt = A transferir %s...
-    pt-BR = Baixando %s...
-    ro = Descărcare %s...
-    es = Descargando %s...
-    sv = Ladda ned %s...
-    th = กำลังดาวน์โหลด %s...
-    tr = %s indiriliyor...
-    uk = Завантаження %s...
-    vi = Tải về %s...
-    el = Λήψη %s...
-    es_MX = Descargando %s...
-    sk = Sťahovanie %s...
-    sw = Inapakua %s...
-    zh-Hans = 正在下載 %s...
+    ar = جار تنزيل %s…
+    cs = Stahování %s…
+    da = Downloader %s…
+    nl = %s downloaden…
+    fi = Ladataan %s…
+    fr = Téléchargement de %s…
+    de = %s heruntergeladen…
+    hu = %s letöltése…
+    id = Mengunduh %s…
+    it = Download di %s…
+    ja = %s をダウンロードしています…
+    ko = %s 다운로드 중…
+    nb = Laster ned %s …
+    pl = Pobieranie %s…
+    pt = A transferir %s…
+    pt-BR = Baixando %s…
+    ro = Descărcare %s…
+    es = Descargando %s…
+    sv = Ladda ned %s…
+    th = กำลังดาวน์โหลด %s…
+    tr = %s indiriliyor…
+    uk = Завантаження %s…
+    vi = Tải về %s…
+    zh-Hans = 正在下載 %s…
     zh-Hant = 下載 %s 中……
-    fa = در حال دانلود %s...
+    el = Λήψη %s…
+    es_MX = Descargando %s…
+    fa = در حال دانلود %s…
+    sk = Sťahovanie %s…
+    sw = Inapakua %s…
 
   [downloader_applying]
-    en = Applying %s...
+    tags = ios
+    en = Applying %s…
     ru = Применение %s…
-    ar = جار تطبيق %s...
-    cs = Aplikuji %s...
-    da = Anvender %s...
-    nl = %s toepassen...
-    fi = %s otetaan käyttöön...
-    fr = Application de %s...
-    de = %s anwenden...
-    hu = %s alkalmazása...
-    id = Menerapkan %s...
-    it = Applicazione di %s...
-    ja = %s を適用中です...
-    ko = %s 적용 중...
-    nb = Bruker %s ...
-    pl = Stosowanie zmian %s...
-    pt = A aplicar %s...
-    pt-BR = Aplicando %s...
-    ro = Aplicare %s...
-    es = Aplicando %s...
-    sv = Tillämpar %s...
-    th = กำลังนำ %s ไปใช้งาน...
-    tr = %s uygulanıyor...
-    uk = Застосування %s...
-    vi = Áp dụng %s...
-    el = Εφαρμογή %s...
-    es_MX = Aplicando %s...
-    sk = Použitie %s...
-    sw = Inatekeleza %s...
-    zh-Hans = 正在套用 %s...
+    ar = جار تطبيق %s…
+    cs = Aplikuji %s…
+    da = Anvender %s…
+    nl = %s toepassen…
+    fi = %s otetaan käyttöön…
+    fr = Application de %s…
+    de = %s anwenden…
+    hu = %s alkalmazása…
+    id = Menerapkan %s…
+    it = Applicazione di %s…
+    ja = %s を適用中です…
+    ko = %s 적용 중…
+    nb = Bruker %s …
+    pl = Stosowanie zmian %s…
+    pt = A aplicar %s…
+    pt-BR = Aplicando %s…
+    ro = Aplicare %s…
+    es = Aplicando %s…
+    sv = Tillämpar %s…
+    th = กำลังนำ %s ไปใช้งาน…
+    tr = %s uygulanıyor…
+    uk = Застосування %s…
+    vi = Áp dụng %s…
+    zh-Hans = 正在套用 %s…
     zh-Hant = 應用 %s 中……
-    fa = اعمال %s...
-
-  [dialog_message_transit_not_found_connection]
-    tags = ios,android
-    en = Plan a route within one transit network
-    ru = Постройте маршрут в пределах одной транспортной сети
-    ar = خطط المسار داخل شبكة عبور واحدة
-    cs = Naplánovat trasu s jednou tranzitní sítí
-    da = Planlæg en rute inden for et transitnetværk
-    nl = Plan een route binnen één vervoersnetwerk
-    fi = Suunnittele reitti yhdellä läpikulkuverkolla
-    fr = Planifier un itinéraire dans un réseau de transport en commun
-    de = Eine Route innerhalb eines Transitnetzes planen
-    hu = Útvonaltervezés egy összekötő hálózaton belül
-    id = Rencanakan rute dalam satu jaringan transit
-    it = Pianifica un percorso all'interno di una rete di transito
-    ja = 1つの交通ネットワーク内でルートを作成
-    ko = 대중 교통망 내에서 하나의 경로를 계획하세요
-    nb = Planlegg en rute innenfor transittnettverket
-    pl = Zaplanuj trasę w ramach jednej sieci transportowej
-    pt = Planeie uma rota dentro de uma rede de tráfego
-    pt-BR = Planeje uma rota dentro de uma rede de trânsito
-    ro = Planifică o rută într-o singură rețea de tranzit
-    es = Planea una ruta en una red de tránsito
-    sv = Planera en rutt inom ett transportnätverk
-    th = วางแผนเส้นทางภายในเครือข่ายการเดินทางเดียว
-    tr = Tek transit bir ağda bir rota planla
-    uk = Плануйте маршрут в межах однієї транзитної мережі
-    vi = Xây dựng lộ trình trong một mạng chuyển tiếp
-    el = Σχεδιάστε μια διαδρομή εντός δικτύου μεταφοράς
-    es_MX = Proyecte una ruta dentro de una red de tránsito
-    sk = Naplánujte si trasu v jednej sieti verejnej dopravy
-    sw = Panga njia katika mtandao mmoja wa usafiri
-    zh-Hans = 规划一个交通网络内的路线
-    zh-Hant = 規劃一個交通網絡內的路線
-    fa = یک مسیر را در یک شبکه حمل و نقل برنامه ریزی کنید
+    el = Εφαρμογή %s…
+    es_MX = Aplicando %s…
+    fa = اعمال %s…
+    sk = Použitie %s…
+    sw = Inatekeleza %s…
 
   [bookmarks_error_message_share_general]
+    tags = android
     en = Unable to share due to an application error
     ru = Не удалось поделиться из-за ошибки приложения
     ar = تعذرت المشاركة بسبب خطأ في التطبيق
@@ -22239,15 +14260,16 @@
     tr = Bir uygulama hatasından dolayı paylaşılamıyor
     uk = Неможливо поділитися через помилку програми
     vi = Không thể chia sẻ do lỗi ứng dụng
-    el = Αδυναμία κοινής χρήσης λόγω σφάλματος εφαρμογής
-    es_MX = No se puede compartir debido a un error de la aplicación
-    sk = Pre chybu aplikácie nie je zdieľanie možné
-    sw = Haiwezekani kushiriki kutokana na hitilafu ya programu
     zh-Hans = 由于应用程序出错而无法分享
     zh-Hant = 由於應用程序出錯而無法分享
+    el = Αδυναμία κοινής χρήσης λόγω σφάλματος εφαρμογής
+    es_MX = No se puede compartir debido a un error de la aplicación
     fa = با توجه به خطای برنامه، امکان اشتراک گذاری وجود ندارد
+    sk = Pre chybu aplikácie nie je zdieľanie možné
+    sw = Haiwezekani kushiriki kutokana na hitilafu ya programu
 
   [bookmarks_error_title_share_empty]
+    tags = android
     en = Sharing error
     ru = Ошибка при попытке поделиться
     ar = خطأ في المشاركة
@@ -22273,15 +14295,16 @@
     tr = Paylaşma hatası
     uk = Помилка обміну
     vi = Lỗi chia sẻ
-    el = Σφάλμα κοινής χρήσης
-    es_MX = Error al compartir
-    sk = Chyba zdieľania
-    sw = Hitilafu ya kushiriki
     zh-Hans = 分享错误
     zh-Hant = 分享錯誤
+    el = Σφάλμα κοινής χρήσης
+    es_MX = Error al compartir
     fa = خطای اشتراک
+    sk = Chyba zdieľania
+    sw = Hitilafu ya kushiriki
 
   [bookmarks_error_message_share_empty]
+    tags = android
     en = Cannot share an empty list
     ru = Нельзя делиться пустыми списками
     ar = لا يمكن مشاركة قائمة فارغة
@@ -22307,15 +14330,16 @@
     tr = Boş bir liste paylaşılamaz
     uk = Неможливо поділитися пустим списком
     vi = Không thể chia sẻ một danh sách trống
-    el = Αδύνατη η κοινή χρήση κενής λίστας
-    es_MX = No se puede compartir una lista vacía
-    sk = Prázdny zoznam nie je možné zdieľať
-    sw = Haiwezekani kushiriki orodha tupu
     zh-Hans = 无法分享空列表
     zh-Hant = 無法分享空列表
+    el = Αδύνατη η κοινή χρήση κενής λίστας
+    es_MX = No se puede compartir una lista vacía
     fa = یک لیست خالی را نمی توان به اشتراک گذاشت
+    sk = Prázdny zoznam nie je možné zdieľať
+    sw = Haiwezekani kushiriki orodha tupu
 
- [bookmarks_error_title_empty_list_name]
+  [bookmarks_error_title_empty_list_name]
+    tags = android
     en = The name couldn't be empty
     ru = Имя списка не может быть пустым
     ar = الاسم لا يمكن أن يكون فارغًا
@@ -22336,20 +14360,21 @@
     pt-BR = O nome não podia estar vazio
     ro = Numele nu poate fi gol
     es = El nombre no puede estar vacío
-    es_MX = El nombre no puede quedar vacío
     sv = Namnet kunde inte vara tomt
     th = ชื่อต้องไม่ว่างเปล่า
     tr = Isim boş olamaz
     uk = Ім'я не може бути порожнім
     vi = Tên không được để trống
-    el = Το όνομα δεν θα μπορούσε να είναι άδειο
-    sk = Názov nemôže byť prázdny
-    sw = Jina halikuweza kuwa tupu
     zh-Hans = 名字不能为空
     zh-Hant = 名字不能為空
+    el = Το όνομα δεν θα μπορούσε να είναι άδειο
+    es_MX = El nombre no puede quedar vacío
     fa = نام نمیتواند خالی باشد
+    sk = Názov nemôže byť prázdny
+    sw = Jina halikuweza kuwa tupu
 
   [bookmarks_error_message_empty_list_name]
+    tags = android
     en = Please enter the list name
     ru = Введите имя списка, пожалуйста
     ar = يرجى إدخال اسم القائمة
@@ -22370,20 +14395,21 @@
     pt-BR = Por favor insira o nome da lista
     ro = Introduceți numele listei
     es = Por favor ingrese el nombre de la lista
-    es_MX = Escriba el nombre
     sv = Vänligen ange listnamnet
     th = โปรดป้อนชื่อรายการ
     tr = Lütfen liste ismini giriniz
     uk = Будь ласка, введіть назву списку
     vi = Vui lòng nhập tên danh sách
-    el = Εισαγάγετε το όνομα της λίστας
-    sk = Zadajte názov zoznamu
-    sw = Tafadhali ingiza jina la orodha
     zh-Hans = 请输入列表名称
     zh-Hant = 請輸入列表名稱
+    el = Εισαγάγετε το όνομα της λίστας
+    es_MX = Escriba el nombre
     fa = لطفا نام لیست را وارد کنید
+    sk = Zadajte názov zoznamu
+    sw = Tafadhali ingiza jina la orodha
 
   [bookmarks_new_list_hint]
+    tags = android
     en = New list
     ru = Новый список
     ar = قائمة جديدة
@@ -22404,20 +14430,21 @@
     pt-BR = Nova lista
     ro = Lista nouă
     es = Lista nueva
-    es_MX = Lista nueva
     sv = Ny lista
     th = รายการใหม่
     tr = Yeni liste
     uk = Новий список
     vi = Danh sách mới
-    el = Νέα λίστα
-    sk = Nový zoznam
-    sw = Orodha mpya
     zh-Hans = 新的列表
     zh-Hant = 新的列表
+    el = Νέα λίστα
+    es_MX = Lista nueva
     fa = لیست جدید
+    sk = Nový zoznam
+    sw = Orodha mpya
 
   [bookmarks_error_title_list_name_already_taken]
+    tags = android
     en = This name is already taken
     ru = Такое имя уже занято
     ar = هذا الاسم أخذ سابقا
@@ -22438,20 +14465,21 @@
     pt-BR = Esse nome já está sendo usado
     ro = Acest nume este deja luat
     es = Este nombre ya ha sido tomado
-    es_MX = Este nombre ya está en uso
     sv = Det här namnet är redan taget
     th = ชื่อนี้ถูกนำมาใช้แล้ว
     tr = Bu isim zaten alınmış
     uk = Це ім'я вже зайнято
     vi = Tên này đã được sử dụng
-    el = Αυτό το όνομα έχει ήδη ληφθεί
-    sk = Tento názov už bol prijatý
-    sw = Jina hili tayari limechukuliwa
     zh-Hans = 这个名字已经被使用了
     zh-Hant = 這個名字已經被使用了
+    el = Αυτό το όνομα έχει ήδη ληφθεί
+    es_MX = Este nombre ya está en uso
     fa = این اسم قبلا انتخاب شده است
+    sk = Tento názov už bol prijatý
+    sw = Jina hili tayari limechukuliwa
 
   [bookmarks_error_message_list_name_already_taken]
+    tags = android
     en = Please choose another name
     ru = Выберите, пожалуйста, другое имя
     ar = يرجى اختيار اسم آخر
@@ -22472,222 +14500,53 @@
     pt-BR = Por favor, escolha outro nome
     ro = Alegeți un alt nume
     es = Por favor elige otro nombre
-    es_MX = Por favor elige otro nombre
     sv = Vänligen välj ett annat namn
     th = โปรดเลือกชื่ออื่น
     tr = Lütfen başka bir isim seçiniz
     uk = Виберіть інше ім'я
     vi = Vui lòng chọn một tên khác
-    el = Επιλέξτε άλλο όνομα
-    sk = Vyberte iné meno
-    sw = Tafadhali chagua jina lingine
     zh-Hans = 请选择其他名称
     zh-Hant = 請選擇其他名稱
-    fa = لطفا نام دیگری را انتخاب کنید
-
-  [bookmarks_error_title_list_name_too_long]
-    en = This name is too long
-    ru = Слишком длинное название
-    ar = هذا الاسم طويل للغاية
-    cs = Tento název je příliš dlouhý
-    da = Dette navn er for langt
-    nl = Deze naam is te lang
-    fi = Tämä nimi on liian pitkä
-    fr = Ce nom est trop long
-    de = Dieser Name ist zu lang
-    hu = Ez a név túl hosszú
-    id = Nama ini terlalu panjang
-    it = Questo nome è troppo lungo
-    ja = この名前は長すぎます
-    ko = 이 이름이 너무 깁니다.
-    nb = Dette navnet er for langt
-    pl = Ta nazwa jest za długa
-    pt = Este nome é muito longo
-    pt-BR = Este nome é muito longo
-    ro = Acest nume este prea lung
-    es = Este nombre es demasiado largo
-    es_MX = Este nombre es demasiado largo
-    sv = Det här namnet är för långt
-    th = ชื่อนี้ยาวเกินไป
-    tr = Bu isim çok uzun
-    uk = Це ім'я задовге
-    vi = Tên này quá dài
-    el = Αυτό το όνομα είναι πολύ μεγάλο
-    sk = Tento názov je príliš dlhý
-    sw = Jina hili ni muda mrefu sana
-    zh-Hans = 这个名字太长了
-    zh-Hant = 這個名字太長了
-    fa = این نام خیلی طولانی است
-
-  [bookmarks_error_message_list_name_too_long]
-    en = Please choose another name
-    ru = Выберите, пожалуйста, другое имя
-    ar = يرجى اختيار اسم آخر
-    cs = Zvolte jiný název
-    da = Vælg venligst et andet navn
-    nl = Kies alstublieft een andere naam
-    fi = Valitse toinen nimi
-    fr = Merci de choisir un autre nom
-    de = Bitte wähle einen anderen Namen
-    hu = Kérjük, válasszon másik nevet
-    id = Silakan pilih nama lain
-    it = Si prega di scegliere un altro nome
-    ja = 別の名前を選んでください
-    ko = 다른 이름을 선택하십시오.
-    nb = Vennligst velg et annet navn
-    pl = Wybierz inną nazwę
-    pt = Por favor, escolha outro nome
-    pt-BR = Por favor, escolha outro nome
-    ro = Alegeți un alt nume
-    es = Por favor elige otro nombre
+    el = Επιλέξτε άλλο όνομα
     es_MX = Por favor elige otro nombre
-    sv = Vänligen välj ett annat namn
-    th = โปรดเลือกชื่ออื่น
-    tr = Lütfen başka bir isim seçiniz
-    uk = Виберіть інше ім'я
-    vi = Vui lòng chọn một tên khác
-    el = Επιλέξτε άλλο όνομα
+    fa = لطفا نام دیگری را انتخاب کنید
     sk = Vyberte iné meno
     sw = Tafadhali chagua jina lingine
-    zh-Hans = 请选择其他名称
-    zh-Hant = 請選擇其他名稱
-    fa = لطفا نام دیگری را انتخاب کنید
 
   [please_wait]
-    en = Please wait...
-    ru = Пожалуйста, подождите...
-    ar = أرجو الإنتظار...
-    cs = Prosím, čekejte...
-    da = Vent venligst...
-    nl = Even geduld aub...
-    fi = Odota...
-    fr = S'il vous plaît, attendez...
-    de = Warten Sie mal...
-    hu = Kérlek várj...
-    id = Mohon tunggu...
-    it = Attendere prego...
-    ja = お待ちください...
-    ko = 잠시만 기다려주십시오...
-    nb = Vennligst vent...
-    pl = Proszę czekać...
-    pt = Por favor, espere...
-    pt-BR = Espere, por favor...
-    ro = Te rog asteapta...
-    es = Por favor espera...
-    es_MX = Por favor, espere...
-    sv = Vänligen vänta...
-    th = โปรดรอสักครู่ ...
-    tr = Lütfen bekle...
-    uk = Будь ласка, зачекайте...
-    vi = Vui lòng chờ...
-    el = Παρακαλώ περιμένετε...
-    sk = Prosím čakajte...
-    sw = Tafadhali subiri...
-    zh-Hans = 请稍候...
-    zh-Hant = 請稍候...
-    fa = لطفا صبر کنید...
-
-  [phone_number]
-    en = Phone number
-    ru = Номер телефона
-    ar = رقم الهاتف
-    cs = Telefonní číslo
-    da = Telefonnummer
-    nl = Telefoonnummer
-    fi = Puhelinnumero
-    fr = Numéro de téléphone
-    de = Telefonnummer
-    hu = Telefonszám
-    id = Nomor telepon
-    it = Numero di telefono
-    ja = 電話番号
-    ko = 전화 번호
-    nb = Telefonnummer
-    pl = Numer telefonu
-    pt = Número de telefone
-    pt-BR = Número de telefone
-    ro = Numar de telefon
-    es = Número de teléfono
-    es_MX = Número de teléfono
-    sv = Telefonnummer
-    th = หมายเลขโทรศัพท์
-    tr = Telefon numarası
-    uk = Номер телефону
-    vi = Số điện thoại
-    el = Τηλεφωνικό νούμερο
-    sk = Telefónne číslo
-    sw = Nambari ya simu
-    zh-Hans = 电话号码
-    zh-Hant = 電話號碼
-    fa = شماره تلفن
-
-  [notification_unsent_reviews_title]
-    en = You have several unsent reviews
-    ru = У вас есть неотправленные отзывы
-    ar = لديك عدة تعليقات غير مرغوب فيها
-    cs = Máte několik recenzí
-    da = Du har flere usendte anmeldelser
-    nl = U heeft verschillende niet-verzonden recensies
-    fi = Sinulla on useita epävirallisia arvosteluja
-    fr = Vous avez plusieurs avis non envoyés
-    de = Sie haben mehrere nicht gesendete Bewertungen
-    hu = Több elküldött véleménye is van
-    id = Anda memiliki beberapa ulasan yang tidak terkirim
-    it = Hai diverse recensioni non inviate
-    ja = あなたはいくつかの未送信のレビューを持っています
-    ko = 보내지 않은 리뷰가 여러 개 있습니다.
-    nb = Du har flere usendte anmeldelser
-    pl = Masz kilka niewysłanych recenzji
-    pt = Você tem vários comentários não enviados
-    pt-BR = Você tem vários comentários não enviados
-    ro = Aveți mai multe recenzii nesoluționate
-    es = Tienes varias reseñas sin enviar
-    es_MX = Tiene varias reseñas sin enviar
-    sv = Du har flera unsent recensioner
-    th = คุณมีรีวิวที่ยังไม่ได้อ่านหลายฉบับ
-    tr = Birkaç onaylanmamış yorumunuz var
-    uk = У вас є невідправлені відгуки
-    vi = Bạn có một số bài đánh giá chưa được đánh giá
-    el = Έχετε αρκετές κριτικές
-    sk = Máte niekoľko neoslaných recenzií
-    sw = Una maoni mapitio kadhaa
-    zh-Hans = 你有几个未发表的评论
-    zh-Hant = 你有幾個未發表的評論
-    fa = شما چند نظر ارسال نشده دارید
-
-  [notification_unsent_reviews_message]
-    en = Please sign in to share reviews with other travellers
-    ru = Пожалуйста, авторизуйтесь, чтобы поделиться своими отзывами с другими путешественниками
-    ar = الرجاء تسجيل الدخول لمشاركة التعليقات مع المسافرين الآخرين
-    cs = Přihlaste se a sdílejte recenze s ostatními cestovateli
-    da = Venligst log ind for at dele anmeldelser med andre rejsende
-    nl = Meld u aan om recensies te delen met andere reizigers
-    fi = Kirjaudu sisään jaa arviot muiden matkustajien kanssa
-    fr = Veuillez vous connecter pour partager des avis avec d'autres voyageurs
-    de = Bitte melde dich an, um Bewertungen mit anderen Reisenden zu teilen
-    hu = Kérjük, jelentkezzen be, hogy megoszthassa véleményét más utazókkal
-    id = Harap masuk untuk berbagi ulasan dengan wisatawan lain
-    it = Accedi per condividere recensioni con altri viaggiatori
-    ja = 他の旅行者とレビューを共有するにはログインしてください
-    ko = 다른 여행자와 리뷰를 공유하려면 로그인하십시오.
-    nb = Vennligst logg inn for å dele anmeldelser med andre reisende
-    pl = Zaloguj się, aby udostępniać recenzje innym podróżnym
-    pt = Por favor, faça o login para compartilhar opiniões com outros viajantes
-    pt-BR = Por favor, faça o login para compartilhar opiniões com outros viajantes
-    ro = Vă rugăm să vă conectați pentru a trimite recenzii altor călătorii
-    es = Inicia sesión para compartir comentarios con otros viajeros
-    es_MX = Inicie sesión para compartir reseñas con otros viajeros
-    sv = Vänligen logga in för att dela omdömen med andra resenärer
-    th = โปรดลงชื่อเข้าใช้เพื่อแบ่งปันความเห็นกับผู้อื่น
-    tr = Diğer gezginlerle yorum paylaşmak için lütfen giriş yapın
-    uk = Будь ласка, увійдіть, щоб поділитися своїми відгуками з іншими мандрівниками
-    vi = Vui lòng đăng nhập để chia sẻ bài đánh giá với các khách du lịch khác
-    el = Παρακαλώ συνδεθείτε για να μοιραστείτε κριτικές με άλλους ταξιδιώτες
-    sk = Prihláste sa a zdieľajte recenzie s ostatnými cestujúcimi
-    sw = Tafadhali ingia ili ushiriki mapitio na wasafiri wengine
-    zh-Hans = 请登录与其他旅客分享评论
-    zh-Hant = 請登錄與其他旅客分享評論
-    fa = لطفا برای اشتراک‌گذاری نظرات با سایر مسافرین وارد شوید
+    tags = android
+    en = Please wait…
+    ru = Пожалуйста, подождите…
+    ar = أرجو الإنتظار…
+    cs = Prosím, čekejte…
+    da = Vent venligst…
+    nl = Even geduld aub…
+    fi = Odota…
+    fr = S'il vous plaît, attendez…
+    de = Warten Sie mal…
+    hu = Kérlek várj…
+    id = Mohon tunggu…
+    it = Attendere prego…
+    ja = お待ちください…
+    ko = 잠시만 기다려주십시오…
+    nb = Vennligst vent…
+    pl = Proszę czekać…
+    pt = Por favor, espere…
+    pt-BR = Espere, por favor…
+    ro = Te rog asteapta…
+    es = Por favor espera…
+    sv = Vänligen vänta…
+    th = โปรดรอสักครู่ …
+    tr = Lütfen bekle…
+    uk = Будь ласка, зачекайте…
+    vi = Vui lòng chờ…
+    zh-Hans = 请稍候…
+    zh-Hant = 請稍候…
+    el = Παρακαλώ περιμένετε…
+    es_MX = Por favor, espere…
+    fa = لطفا صبر کنید…
+    sk = Prosím čakajte…
+    sw = Tafadhali subiri…
 
   [profile]
     tags = ios, android
@@ -22719,10 +14578,11 @@
     zh-Hans = OpenStreetMap 资料
     zh-Hant = OpenStreetMap 資料
     el = Προφίλ OpenStreetMap
-    sk = Profil OpenStreetMap
     fa = OpenStreetMap نمایه
+    sk = Profil OpenStreetMap
 
   [place_page_search_similar_hotel]
+    tags = android
     en = Search similar hotels
     ru = Найти похожие отели
     ar = ابحث عن فنادق مماثلة
@@ -22743,20 +14603,21 @@
     pt-BR = Pesquisar hotéis semelhantes
     ro = Căutați hoteluri similare
     es = Buscar hoteles similares
-    es_MX = Buscar hoteles similares
     sv = Sök liknande hotell
     th = ค้นหาโรงแรมที่คล้ายกัน
     tr = Benzer otellerde ara
     uk = Шукати схожі готелі
     vi = Tìm kiếm khách sạn
-    el = Αναζήτηση παρόμοιων ξενοδοχείων
-    sk = Vyhľadať podobné hotely
-    sw = Tafuta hoteli sawa
     zh-Hans = 搜索类似的酒店
     zh-Hant = 搜索類似的酒店
+    el = Αναζήτηση παρόμοιων ξενοδοχείων
+    es_MX = Buscar hoteles similares
     fa = جست‌وجوی هتل‌های مشابه
+    sk = Vyhľadať podobné hotely
+    sw = Tafuta hoteli sawa
 
   [bookmarks_detect_title]
+    tags = ios
     en = New files detected
     ru = Обнаружены новые файлы
     ar = تم اكتشاف ملفات جديدة
@@ -22777,85 +14638,87 @@
     pt-BR = Novos arquivos detectados
     ro = Au fost detectate fișiere noi
     es = Nuevos archivos detectados
-    es_MX = Se detectaron archivos nuevos
     sv = Nya filer upptäcktes
     th = พบไฟล์ใหม่แล้ว
     tr = Yeni dosyalar algılandı
     uk = Виявлено нові файли
     vi = Đã phát hiện tệp mới
-    el = Εντοπίστηκαν νέα αρχεία
-    sk = Zistené nové súbory
-    sw = Faili mpya zimegunduliwa
     zh-Hans = 检测到新文件
     zh-Hant = 檢測到新文件
+    el = Εντοπίστηκαν νέα αρχεία
+    es_MX = Se detectaron archivos nuevos
     fa = فایل‌های جدید پیدا شد
+    sk = Zistené nové súbory
+    sw = Faili mpya zimegunduliwa
 
   [bookmarks_detect_message]
-    en:one = %d file was found. You can see it after conversion.
-    en:other = %d files were found. You can see them after conversion.
-    ru:one = %d файл был найден. Вы увидете его после конвертации.
-    ru:few = %d файла были найдены. Вы увидете их после конвертации.
-    ru:other = %d файлов было найдено. Вы увидете их после конвертации.
+    tags = ios, android
     ar = تم العثور على %d ملفات. سوف تراهم بعد التحويل.
-    cs:one = %d soubor byl nalezen. Uvidíte ji po konverzi.
+    ja = %d ファイルが見つかりました。 あなたは変換後にそれらを見るでしょう。
+    ko = %d 파일을 찾았습니다. 회심 후 그들을 볼 수 있습니다.
+    th = %d ไฟล์ที่ค้นพบ คุณจะเห็นพวกเขาหลังจากการแปลง
+    tr = %d dosya bulundu. Dönüşümden sonra onları göreceksiniz.
+    zh-Hans = 找到%d个文件。 转换后你会看到它。
+    zh-Hant = 找到%d個文件。 轉換後你會看到它。
     cs:few = %d byly nalezeny soubory. Uvidíte je po konverzi.
+    cs:one = %d soubor byl nalezen. Uvidíte ji po konverzi.
     cs:other = Bylo nalezeno %d souborů. Uvidíte je po konverzi.
     da:one = %d fil blev fundet. Du vil se det efter konvertering.
     da:other = Der er fundet %d filer. Du vil se dem efter konvertering.
-    nl:one = %d bestand gevonden. Je ziet het na het converteren.
-    nl:other = Er zijn %d bestanden gevonden. Je zult ze na de conversie zien.
-    fi:one = %d tiedosto löydettiin. Näet sen muunnoksen jälkeen.
-    fi:other = %d tiedostoa on löytynyt. Näet heidät muuntamisen jälkeen.
-    fr:zero = %d fichier a été trouvé. Vous le verrez après la conversion.
-    fr:one = %d fichier a été trouvé. Vous le verrez après la conversion.
-    fr:other = %d fichiers ont été trouvés. Vous les verrez après la conversion.
     de:one = %d Datei wurde gefunden. Sie werden es nach der Konvertierung sehen.
     de:other = %d Dateien wurden gefunden. Sie werden sie nach der Konvertierung sehen.
+    el:one = Βρέθηκε %d αρχείο. Θα το δείτε μετά τη μετατροπή.
+    el:other = έχουν βρεθεί %d αρχεία. Θα τα δείτε μετά τη μετατροπή.
+    en:one = %d file was found. You can see it after conversion.
+    en:other = %d files were found. You can see them after conversion.
+    es:one = Se encontró %d archivo. Lo verás después de la conversión.
+    es:other = Se han encontrado %d archivos. Los verás después de la conversión.
+    es_MX:one = Se encontró %d archivo. Lo verás después de la conversión.
+    es_MX:other = Se han encontrado %d archivos. Los verás después de la conversión.
+    fa:one = %d فایل پیدا شد. بعد از تبدیل آن را می‌بینید.
+    fa:other = %d فایل پیدا شد. بعد از تبدیل آن‌ها را می‌بینید.
+    fi:one = %d tiedosto löydettiin. Näet sen muunnoksen jälkeen.
+    fi:other = %d tiedostoa on löytynyt. Näet heidät muuntamisen jälkeen.
+    fr:one = %d fichier a été trouvé. Vous le verrez après la conversion.
+    fr:other = %d fichiers ont été trouvés. Vous les verrez après la conversion.
+    fr:zero = %d fichier a été trouvé. Vous le verrez après la conversion.
     hu:one = %d fájlt találtunk. Látni fogja őket a megtérés után.
     hu:other = %d fájl található. Látni fogja őket a megtérés után.
     id:one = %d file ditemukan. Anda akan melihatnya setelah mengonversi.
     id:other = %d file telah ditemukan. Anda akan melihatnya setelah konversi.
     it:one = %d file è stato trovato. Lo vedrai dopo la conversione.
     it:other = %d file trovati Li vedrai dopo la conversione.
-    ja = %d ファイルが見つかりました。 あなたは変換後にそれらを見るでしょう。
-    ko = %d 파일을 찾았습니다. 회심 후 그들을 볼 수 있습니다.
     nb:one = %d filen ble funnet. Du vil se dem etter konverteringen.
     nb:other = %d filer funnet. Du vil se dem etter konverteringen.
+    nl:one = %d bestand gevonden. Je ziet het na het converteren.
+    nl:other = Er zijn %d bestanden gevonden. Je zult ze na de conversie zien.
     pl:one = Znaleziono %d plik. Zobaczysz to po konwersji.
-    pl:two = Znaleziono %d pliki. Zobaczysz je po konwersji.
     pl:other = Znaleziono %d plików. Zobaczysz je po konwersji.
-    pt:one = %d arquivo foi encontrado. Você vai ver depois da conversão.
-    pt:other = %d arquivos foram encontrados. Você os verá depois da conversão.
+    pl:two = Znaleziono %d pliki. Zobaczysz je po konwersji.
     pt-BR:one = %d arquivo foi encontrado. Você vai ver depois da conversão.
     pt-BR:other = %d arquivos foram encontrados. Você os verá depois da conversão.
+    pt:one = %d arquivo foi encontrado. Você vai ver depois da conversão.
+    pt:other = %d arquivos foram encontrados. Você os verá depois da conversão.
     ro:one = %d fișier a fost găsit. Veți vedea după conversie.
     ro:other = Au fost găsite %d fișiere. Veți vedea după convertire.
-    es:one = Se encontró %d archivo. Lo verás después de la conversión.
-    es:other = Se han encontrado %d archivos. Los verás después de la conversión.
-    es_MX:one = Se encontró %d archivo. Lo verás después de la conversión.
-    es_MX:other = Se han encontrado %d archivos. Los verás después de la conversión.
+    ru:few = %d файла были найдены. Вы увидете их после конвертации.
+    ru:one = %d файл был найден. Вы увидете его после конвертации.
+    ru:other = %d файлов было найдено. Вы увидете их после конвертации.
+    sk:few = Boli nájdené %d súbory. Uvidíte ich po konverzii.
+    sk:one = Bol nájdený %d súbor. Uvidíte to po konverzii.
+    sk:other = Bolo nájdených %d súborov. Uvidíte ich po konverzii.
     sv:one = %d fil hittades. Du kommer att se den efter omvandlingen.
     sv:other = %d filer har hittats. Du kommer att se dem efter omvandlingen.
-    th = %d ไฟล์ที่ค้นพบ คุณจะเห็นพวกเขาหลังจากการแปลง
-    tr = %d dosya bulundu. Dönüşümden sonra onları göreceksiniz.
-    uk:one = %d файл був знайдений. Ви побачите його після перетворення.
-    uk:two = %d файлу були знайдені. Ви побачите їх після конвертації.
-    uk:other = %d файлів було знайдено. Ви побачите їх після конвертації.
-    vi:one = %d dã tìm thấy một tệp. Bạn sẽ thấy nó sau khi chuyển đổi.
-    ve:other = %d tập tin đã được tìm thấy. Bạn sẽ thấy chúng sau khi chuyển đổi.
-    el:one = Βρέθηκε %d αρχείο. Θα το δείτε μετά τη μετατροπή.
-    el:other = έχουν βρεθεί %d αρχεία. Θα τα δείτε μετά τη μετατροπή.
-    sk:one = Bol nájdený %d súbor. Uvidíte to po konverzii.
-    sk:few = Boli nájdené %d súbory. Uvidíte ich po konverzii.
-    sk:other = Bolo nájdených %d súborov. Uvidíte ich po konverzii.
     sw:one = Faili %d ilipatikana. Utaiona baada ya uongofu.
     sw:other = Files %d zimepatikana. Utawaona baada ya uongofu.
-    zh-Hans = 找到%d个文件。 转换后你会看到它。
-    zh-Hant = 找到%d個文件。 轉換後你會看到它。
-    fa:one = %d فایل پیدا شد. بعد از تبدیل آن را می‌بینید.
-    fa:other = %d فایل پیدا شد. بعد از تبدیل آن‌ها را می‌بینید.
+    uk:one = %d файл був знайдений. Ви побачите його після перетворення.
+    uk:other = %d файлів було знайдено. Ви побачите їх після конвертації.
+    uk:two = %d файлу були знайдені. Ви побачите їх після конвертації.
+    ve:other = %d tập tin đã được tìm thấy. Bạn sẽ thấy chúng sau khi chuyển đổi.
+    vi:one = %d dã tìm thấy một tệp. Bạn sẽ thấy nó sau khi chuyển đổi.
 
   [button_convert]
+    tags = ios
     en = Convert
     ru = Конвертировать
     ar = تحول
@@ -22876,20 +14739,21 @@
     pt-BR = Converter
     ro = Convertit
     es = Convertir
-    es_MX = Convertir
     sv = Konvertera
     th = แปลง
     tr = Dönüştürmek
     uk = Конвертувати
     vi = Chuyển đổi
-    el = Μετατρέπω
-    sk = Premeniť
-    sw = Badilisha
     zh-Hans = 兑换
     zh-Hant = 兌換
+    el = Μετατρέπω
+    es_MX = Convertir
     fa = تبدیل
+    sk = Premeniť
+    sw = Badilisha
 
   [bookmarks_convert_error_title]
+    tags = ios
     en = Error
     ru = Ошибка
     ar = خطأ
@@ -22910,20 +14774,21 @@
     pt-BR = Erro
     ro = Eroare
     es = Error
-    es_MX = Error
     sv = Fel
     th = ความผิดพลาด
     tr = Hata
     uk = Помилка
     vi = Lỗi
-    el = Λάθος
-    sk = Chyba
-    sw = Hitilafu
     zh-Hans = 错误
     zh-Hant = 錯誤
+    el = Λάθος
+    es_MX = Error
     fa = خطا
+    sk = Chyba
+    sw = Hitilafu
 
   [bookmarks_convert_error_message]
+    tags = ios
     en = Some files were not converted.
     ru = Некоторые файлы не конвертировались.
     ar = لم يتم تحويل بعض الملفات.
@@ -22944,191 +14809,22 @@
     pt-BR = Alguns arquivos não foram convertidos.
     ro = Unele fișiere nu au fost convertite.
     es = Algunos archivos no fueron convertidos.
-    es_MX = Algunos archivos no se convirtieron.
     sv = Vissa filer konverterades inte.
     th = ไฟล์บางไฟล์ไม่ได้รับการแปลง
     tr = Bazı dosyalar dönüştürülmedi.
     uk = Деякі файли не конвертувалися.
     vi = Một số tệp không được chuyển đổi.
-    el = Ορισμένα αρχεία δεν μετατράπηκαν.
-    sk = Niektoré súbory neboli konvertované.
-    sw = Baadhi ya faili hazibadilishwa.
     zh-Hans = 有些文件未被转换。
     zh-Hant = 有些文件未被轉換。
+    el = Ορισμένα αρχεία δεν μετατράπηκαν.
+    es_MX = Algunos archivos no se convirtieron.
     fa = بعضی از فایل‌ها تبدیل نشد.
-
-  [converting]
-    en = Converting...
-    ru = Конвертация...
-    ar = تحويل...
-    cs = Převádění...
-    da = Konvertering...
-    nl = Het omzetten van...
-    fi = Muuntaa...
-    fr = Conversion...
-    de = Konvertieren...
-    hu = Átalakítás...
-    id = Mengkonversi...
-    it = Conversione...
-    ja = 変換中...
-    ko = 변환 중...
-    nb = Konvertere...
-    pl = Przekształcanie...
-    pt = Convertendo...
-    pt-BR = Convertendo...
-    ro = Conversia...
-    es = Mudado...
-    es_MX = Convirtiendo...
-    sv = Konvertera...
-    th = กำลังแปลง...
-    tr = Dönüştürme...
-    uk = Конвертація...
-    vi = Đang chuyển đổi...
-    el = Μετατροπή...
-    sk = Konverziu...
-    sw = Inabadilisha...
-    zh-Hans = 转换...
-    zh-Hant = 轉換...
-    fa = در حال تبدیل...
-
-  [wn_reinvented_bookmarks_title]
-    en = We reinvented bookmarks!
-    ru = Мы улучшили функционал меток!
-    ar = لقد قمنا بإعادة اختراع العناوين!
-    cs = Znovu jsme vytvořili záložky!
-    da = Vi genopfandt bogmærker!
-    nl = We hebben bladwijzers opnieuw uitgevonden!
-    fi = Uusimme kirjanmerkit!
-    fr = Nous avons réinventé les signets!
-    de = Wir haben Lesezeichen neu erfunden!
-    hu = Új könyveket készítettünk!
-    id = Kami menemukan kembali bookmark!
-    it = Abbiamo reinventato i segnalibri!
-    ja = ブックマークを作り直しました！
-    ko = 우리는 북마크를 재발 명했습니다!
-    nb = Vi gjenoppfunnet bokmerker!
-    pl = Odnowiliśmy zakładki!
-    pt = Nós reinventamos os marcadores!
-    pt-BR = Nós reinventamos os marcadores!
-    ro = Am reinventat marcaje!
-    es = ¡Hemos reinventado marcadores!
-    es_MX = ¡Reinventamos los marcadores!
-    sv = Vi återuppfinde bokmärken!
-    th = เราสร้างสรรค์บุ๊กมาร์กใหม่!
-    tr = Yer imlerini yeniden keşfettik!
-    uk = Ми переізобрел мітки!
-    vi = Chúng tôi đã tạo lại dấu trang!
-    el = Επεκτείνασαμε σελιδοδείκτες!
-    sk = Znovu sme vytvorili záložky!
-    sw = Tuliongeza tena alama za alama!
-    zh-Hans = 我们改造了书签！
-    zh-Hant = 我們改造了書籤！
-    fa = نشانه‌ها را بازآفرینی کردیم!
-
-  [wn_reinvented_bookmarks_message]
-    en = You can backup them, create lists...It’s amazing...
-    ru = Теперь вы можете сделать резервное копирование меток, создать списки. А как круто они смотрятся на карте!
-    ar = يمكنك الاحتفاظ بنسخة احتياطية منها وإنشاء قوائم... إنه أمر مذهل...
-    cs = Můžete je zálohovat, vytvářet seznamy... Je to úžasné...
-    da = Du kan sikkerhedskopiere bogmærker, oprette lister... Det er fantastisk...
-    nl = U kunt een back-up maken van bladwijzers, lijsten maken... Het is verbazingwekkend...
-    fi = Voit varmuuskopioida kirjanmerkkejä, luoda luetteloita... On hämmästyttävää...
-    fr = Vous pouvez sauvegarder des signets, créer des listes... C'est incroyable...
-    de = Sie können Lesezeichen sichern, Listen erstellen... Es ist erstaunlich...
-    hu = Könyvjelzőket menthet, listákat hozhat létre... Hihetetlen...
-    id = Anda dapat mencadangkan bookmark, membuat daftar... Sungguh menakjubkan...
-    it = Puoi fare il backup dei segnalibri, creare liste... È incredibile...
-    ja = あなたはブックマークをバックアップし、リストを作成することができます...それは素晴らしいです...
-    ko = 당신은 북마크를 백업하고, 목록을 만들 수 있습니다... 그것은 놀랍습니다...
-    nb = Du kan sikkerhetskopiere bokmerker, lage lister... Det er utrolig...
-    pl = Możesz tworzyć kopie zapasowe zakładek, tworzyć listy... To niesamowite...
-    pt = Você pode fazer backup de favoritos, criar listas... É incrível...
-    pt-BR = Você pode fazer backup deles, criar listas, basta olhar para eles no mapa! Eles são lindos!
-    ro = Aveți posibilitatea să copiați marcajele de rezervă, să creați liste... Este uimitor...
-    es = Puede hacer una copia de seguridad de los marcadores, crear listas... Es increíble...
-    es_MX = ¡Puede hacer copias de respaldo, crear listas o verlos en un mapa! ¡Son preciosos!
-    sv = Du kan säkerhetskopiera bokmärken, skapa listor... Det är fantastiskt...
-    th = คุณสามารถสำรองบุ๊คมาร์คสร้างรายการ... มันน่าทึ่ง...
-    tr = Yer imlerini yedekleyebilir, listeler oluşturabilirsin... Harika...
-    uk = Ви можете зробити резервне копіювання міток, створити списки. А як круто вони виглядають на карті!
-    vi = Bạn có thể sao lưu dấu trang, tạo danh sách... Thật tuyệt vời...
-    el = You can back up them and create lists - just look at them on the map! They are gorgeous!
-    sk = Môžete zálohovať záložky, vytvárať zoznamy... Je to úžasné...
-    sw = Unaweza kushirikisha alama, unda orodha... Ni ajabu...
-    zh-Hans = 你可以备份书签，创建列表...这太神奇了...
-    zh-Hant = 你可以備份書籤，創建列表...這太神奇了...
-    fa = می‌توانید از آن‌ها پشتیبان بگیرید، لیست درست کنید... عالی شده...
-
-  [bookmarks_restore]
-    en = Restore bookmarks
-    ru = Восстановить метки
-    ar = استعادة الإشارات المرجعية
-    cs = Obnovit záložky
-    da = Gendan bogmærker
-    nl = Bladwijzers herstellen
-    fi = Palauta kirjanmerkit
-    fr = Restaurer les favoris
-    de = Lesezeichen wiederherstellen
-    hu = Könyvjelzők visszaállítása
-    id = Kembalikan bookmark
-    it = Ripristina segnalibri
-    ja = ブックマークを復元する
-    ko = 북마크 복원
-    nb = Gjenopprett bokmerker
-    pl = Przywróć zakładki
-    pt = Restaurar marcadores
-    pt-BR = Restaurar marcadores
-    ro = Restaurați marcajele
-    es = Restaurar marcadores
-    es_MX = Restaurar marcadores
-    sv = Återställ bokmärken
-    th = เรียกคืนบุ๊กมาร์ก
-    tr = Yer işaretlerini geri yükle
-    uk = Відновити закладки
-    vi = Khôi phục dấu trang
-    el = Επαναφορά των σελιδοδεικτών
-    sk = Obnoviť záložky
-    sw = Rejesha marudio
-    zh-Hans = 恢复书签
-    zh-Hant = 恢復書籤
-    fa = بازگردانی نشانه‌ها
-
-  [bookmarks_restore_process]
-    en = Restoring...
-    ru = Восстановление...
-    ar = استعادة...
-    cs = Obnovení...
-    da = Gendannelse...
-    nl = Herstel van...
-    fi = Palautetaan...
-    fr = Restaurer...
-    de = Wiederherstellen...
-    hu = Visszaállítása ...
-    id = Memulihkan...
-    it = Ripristino...
-    ja = 復元中...
-    ko = 복원 중...
-    nb = Gjenopprette...
-    pl = Przywracanie...
-    pt = Restaurando...
-    pt-BR = Restaurando...
-    ro = Restaurarea...
-    es = Restaurando...
-    es_MX = Restaurando...
-    sv = Återställer...
-    th = กำลังกู้คืน...
-    tr = Geri yükleniyor...
-    uk = Відновлення...
-    vi = Đang khôi phục...
-    el = Επαναφορά...
-    sk = Obnovenie...
-    sw = Inarudi...
-    zh-Hans = 恢复...
-    zh-Hant = 恢復...
-    fa = در حال بازگردانی...
+    sk = Niektoré súbory neboli konvertované.
+    sw = Baadhi ya faili hazibadilishwa.
 
   [bookmarks_restore_title]
-    en = Restore this version?
+    tags = ios
+    en = Restore this version?
     ru = Восстановить эту версию?
     ar = استعادة هذا الإصدار؟
     cs = Obnovit tuto verzi?
@@ -23148,122 +14844,21 @@
     pt-BR = Restaurar esta versão?
     ro = Restabiliți această versiune?
     es = Restaurar esta versión?
-    es_MX = ¿Está seguro que desea restaurar esta versión?
     sv = Återställ den här versionen?
     th = เรียกคืนเวอร์ชันนี้หรือไม่?
     tr = Bu sürümü geri yükle?
     uk = Відновити цю версію?
     vi = Khôi phục phiên bản này?
-    el = Επαναφορά αυτής της έκδοσης;
-    sk = Obnoviť túto verziu?
-    sw = Rejesha toleo hili?
     zh-Hans = 还原这个版本？
     zh-Hant = 還原這個版本？
+    el = Επαναφορά αυτής της έκδοσης;
+    es_MX = ¿Está seguro que desea restaurar esta versión?
     fa = این نسخه برگردد؟
-
-  [bookmarks_restore_message]
-    en = Your bookmarks will be restored from %s (%s)
-    ru = Ваши закладки будут восстановлены от %s (%s)
-    ar = ستستعيد إشاراتك المرجعية من %s (%s)
-    cs = Záložky se obnoví z %s (%s)
-    da = Dine bogmærker gendannes fra %s (%s)
-    nl = Je bladwijzers worden hersteld vanaf %s (%s)
-    fi = Kirjanmerkit palaavat %s (%s): sta
-    fr = Vos marque-pages restaureront à partir de %s (%s)
-    de = Ihre Lesezeichen werden von %s (%s) wiederhergestellt
-    hu = Könyvjelzői %s (%s)-ból visszaállnak
-    id = Bookmark Anda akan memulihkan dari %s (%s)
-    it = I tuoi segnalibri verranno ripristinati da %s (%s)
-    ja = ブックマークは%s (%s)から復元されます
-    ko = 북마크가 %s (%s)에서 복원됩니다.
-    nb = Bokmerkene dine gjenopprettes fra %s (%s)
-    pl = Twoje zakładki zostaną przywrócone z %s (%s)
-    pt = Seus favoritos serão restaurados a partir de %s (%s)
-    pt-BR = Seus favoritos serão restaurados desde %s (%s)
-    ro = Marcajele dvs. vor fi restabilite de la %s (%s)
-    es = Tus marcadores se restaurarán desde %s (%s)
-    es_MX = Sus marcadores se restaurarán desde %s (%s)
-    sv = Dina bokmärken återställs från %s (%s)
-    th = บุ๊กมาร์กของคุณจะคืนค่าจาก %s (%s)
-    tr = Yer işaretleriniz %s (%s)'dan geri yüklenecek
-    uk = Ваші закладки відновлюватимуться з %s (%s)
-    vi = Dấu trang của bạn sẽ khôi phục từ %s (%s)
-    el = Οι σελιδοδείκτες σας θα αποκατασταθούν από το %s (%s)
-    sk = Záložky sa obnovia z %s (%s)
-    sw = Vitambulisho vyako vitaburudisha kutoka %s (%s)
-    zh-Hans = 您的书签将从%s (%s)个恢复
-    zh-Hant = 您的書籤將從%s (%s)個恢復
-    fa = نشانه‌های شما از %s (%s) بازگردانده می‌شود
-
-  [bookmarks_restore_empty_title]
-    en = You don’t have any backups
-    ru = У вас нет резервных копий
-    ar = ليس لديك نسخة احتياطية
-    cs = Nemáte zálohu
-    da = Du har ikke en sikkerhedskopi
-    nl = U hebt geen back-up
-    fi = Sinulla ei ole varmuuskopiota
-    fr = Vous n'avez pas de sauvegarde
-    de = Sie haben kein Backup
-    hu = Nincs biztonsági mentése
-    id = Anda tidak memiliki cadangan
-    it = Non hai un backup
-    ja = あなたはバックアップを持っていません
-    ko = 백업이 없습니다.
-    nb = Du har ikke en sikkerhetskopi
-    pl = Nie masz kopii zapasowej
-    pt = Você não tem um backup
-    pt-BR = Você não tem um backup
-    ro = Nu aveți o copie de rezervă
-    es = No tienes una copia de seguridad
-    es_MX = No tiene una copia de seguridad
-    sv = Du har ingen säkerhetskopia
-    th = คุณไม่มีข้อมูลสำรอง
-    tr = Yedekleme yok
-    uk = У вас немає резервної копії
-    vi = Bạn không có bản sao lưu
-    el = Δεν διαθέτετε αντίγραφο ασφαλείας
-    sk = Nemáte zálohu
-    sw = Huna salama
-    zh-Hans = 你没有备份
-    zh-Hant = 你沒有備份
-    fa = فایل پشتیبان ندارید
-
-  [bookmarks_restore_empty_message]
-    en = The server couldn't find previously made backups
-    ru = Сервер не нашел ранее сделанные резервные копии
-    ar = لم يعثر الخادم على نسخ احتياطية سابقة
-    cs = Server nenalezl dříve vytvořené zálohy
-    da = Serveren fandt ikke tidligere sikkerhedskopier
-    nl = De server heeft eerder gemaakte back-ups niet gevonden
-    fi = Palvelin ei löytänyt aiemmin tehtyjä varmuuskopioita
-    fr = Le serveur n'a pas trouvé de sauvegardes effectuées précédemment
-    de = Der Server hat zuvor erstellte Sicherungen nicht gefunden
-    hu = A szerver nem találta a korábban készített biztonsági másolatokat
-    id = Server tidak menemukan cadangan yang dibuat sebelumnya
-    it = Il server non ha trovato i backup creati in precedenza
-    ja = サーバーは以前に作成したバックアップを見つけられませんでした
-    ko = 서버가 이전에 만들어진 백업을 찾지 못했습니다.
-    nb = Serveren fant ikke tidligere sikkerhetskopier
-    pl = Serwer nie znalazł wcześniej utworzonych kopii zapasowych
-    pt = O servidor não encontrou backups feitos anteriormente
-    pt-BR = O servidor não encontrou backups anteriores
-    ro = Serverul nu a găsit copii de rezervă create anterior
-    es = El servidor no encontró copias de seguridad previamente hechas
-    es_MX = El servidor no encontró copias de seguridad anteriores
-    sv = Servern hittade inte tidigare säkerhetskopior
-    th = เซิร์ฟเวอร์ไม่พบการสำรองข้อมูลก่อนหน้านี้
-    tr = Sunucu daha önce yapılmış yedeklemeyi bulamadı
-    uk = Сервер не знайшов раніше створені резервні копії
-    vi = Máy chủ không tìm thấy các bản sao lưu được tạo trước đó
-    el = Ο διακομιστής δεν βρήκε προηγουμένως δημιουργημένα αντίγραφα ασφαλείας
-    sk = Server nenašiel predtým vytvorené zálohy
-    sw = Seva haipata vidokezo vya awali zilizofanywa
-    zh-Hans = 服务器没有找到以前做的备份
-    zh-Hant = 服務器沒有找到以前做的備份
-    fa = سرور پشتیبان‌هایی را که قبلا ساخته شده بودند پیدا نکرد
+    sk = Obnoviť túto verziu?
+    sw = Rejesha toleo hili?
 
   [common_check_internet_connection_dialog_title]
+    tags = android
     en = No internet connection
     ru = Нет интернет соединения
     ar = لا يوجد اتصال بالإنترنت
@@ -23284,89 +14879,22 @@
     pt-BR = Sem conexão com a Internet
     ro = Fără conexiune internet
     es = Sin conexión a Internet
-    es_MX = Sin conexión a Internet
     sv = Ingen internetanslutning
     th = ไม่มีการเชื่อมต่ออินเทอร์เน็ต
     tr = İnternet bağlantısı yok
     uk = Нема інтернет з'єднання
     vi = Không có kết nối internet
-    el = Δεν υπάρχει σύνδεση στο διαδίκτυο
-    sk = Žiadne internetové pripojenie
-    sw = Hakuna uhusiano wa internet
     zh-Hans = 没有互联网连接
     zh-Hant = 沒有互聯網連接
+    el = Δεν υπάρχει σύνδεση στο διαδίκτυο
+    es_MX = Sin conexión a Internet
     fa = اتصال اینترنتی برقرار نیست
-
-  [error_server_title]
-    en = Server error
-    ru = Ошибка сервера
-    ar = خطأ في الخادم
-    cs = Chyba serveru
-    da = Server Fejl
-    nl = Serverfout
-    fi = Palvelinvirhe
-    fr = Erreur du serveur
-    de = Serverfehler
-    hu = Szerver hiba
-    id = Server error
-    it = Errore del server
-    ja = サーバーエラー
-    ko = 서버 오류
-    nb = Serverfeil
-    pl = Błąd serwera
-    pt = Erro de servidor
-    pt-BR = Erro de servidor
-    ro = Eroare de server
-    es = Error del Servidor
-    es_MX = Error del servidor
-    sv = Serverfel
-    th = ข้อผิดพลาดของเซิร์ฟเวอร์
-    tr = Server hatası
-    uk = Помилка серверу
-    vi = Lỗi máy chủ
-    el = Σφάλμα Διακομιστή
-    sk = Chyba servera
-    sw = Hitilafu ya seva
-    zh-Hans = 服务器错误
-    zh-Hant = 服務器錯誤
-    fa = خطای سرور
-
-  [error_server_message]
-    en = There was an error on the server, please try again later
-    ru = На сервере произошла ошибка, повторите попытку позже
-    ar = حدث خطأ على الخادم ، يرجى المحاولة مرة أخرى في وقت لاحق
-    cs = Na serveru došlo k chybě, zkuste to prosím znovu později
-    da = Der opstod en fejl på serveren, prøv igen senere
-    nl = Der var en fejl på serveren, prøv igen senere
-    fi = Palvelimessa oli virhe, yritä myöhemmin uudelleen
-    fr = Une erreur s'est produite sur le serveur. Veuillez réessayer plus tard.
-    de = Auf dem Server ist ein Fehler aufgetreten. Bitte versuchen Sie es später erneut.
-    hu = Hiba történt a szerveren, próbálkozzon később
-    id = Terjadi kesalahan pada server, coba lagi nanti
-    it = Si è verificato un errore sul server, riprova più tardi
-    ja = サーバーにエラーがありました。後でもう一度お試しください
-    ko = 서버에 오류가 발생했습니다. 잠시 후 다시 시도하십시오
-    nb = Det oppsto en feil på serveren, prøv igjen senere
-    pl = Der var en fejl på serveren, prøv igen senere
-    pt = Houve um erro no servidor, tente novamente mais tarde
-    pt-BR = Houve um erro no servidor, por favor, tente novamente mais tarde
-    ro = A apărut o eroare la server, încercați din nou mai târziu
-    es = Hubo un error en el servidor, intente de nuevo más tarde
-    es_MX = Hubo un error en el servidor, intente de nuevo más tarde
-    sv = Det uppstod ett fel på servern, försök igen senare
-    th = เกิดข้อผิดพลาดบนเซิร์ฟเวอร์โปรดลองอีกครั้งในภายหลัง
-    tr = Sunucuda bir hata oluştu, lütfen daha sonra tekrar deneyin
-    uk = На сервері сталася помилка. Повторіть спробу пізніше
-    vi = Đã xảy ra lỗi trên máy chủ, vui lòng thử lại sau
-    el = Παρουσιάστηκε σφάλμα στο διακομιστή, δοκιμάστε ξανά αργότερα
-    sk = Na serveri sa vyskytla chyba, skúste to znova neskôr
-    sw = Kulikuwa na hitilafu kwenye seva, tafadhali jaribu tena baadaye
-    zh-Hans = 服务器发生错误，请稍后重试
-    zh-Hant = 服務器發生錯誤，請稍後重試
-    fa = روی سرور خطایی رخ داد. لطفا بعدا امتحان کنید
+    sk = Žiadne internetové pripojenie
+    sw = Hakuna uhusiano wa internet
 
   [error_system_message]
-    en = An unknown error occurred
+    tags = ios
+    en = An unknown error occurred
     ru = Произошла неизвестная ошибка
     ar = حدث خطأ غير معروف
     cs = Nastala neznámá chyba
@@ -23386,20 +14914,21 @@
     pt-BR = Ocorreu um erro desconhecido
     ro = O eroare necunoscută s-a întamplat
     es = Un error desconocido ocurrió
-    es_MX = Ocurrió un error desconocido
     sv = Ett okänt fel uppstod
     th = เกิดข้อผิดพลาดที่ไม่ทราบสาเหตุ
     tr = Bilinmeyen bir hata oluştu
     uk = Виникла невідома помилка
     vi = Đã xảy ra lỗi không xác định
-    el = Συνέβη ένα άγνωστο σφάλμα
-    sk = Vyskytla sa neznáma chyba
-    sw = Hitilafu isiyojulikana ilitokea
     zh-Hans = 出现未知错误
     zh-Hant = 出現未知錯誤
+    el = Συνέβη ένα άγνωστο σφάλμα
+    es_MX = Ocurrió un error desconocido
     fa = خطای ناشناخته‌ای رخ داد
+    sk = Vyskytla sa neznáma chyba
+    sw = Hitilafu isiyojulikana ilitokea
 
   [restore]
+    tags = ios
     en = Restore
     ru = Восстановить
     ar = استعادة
@@ -23420,337 +14949,21 @@
     pt-BR = Restaurar
     ro = Restabili
     es = Restaurar
-    es_MX = Restaurar
     sv = Återställa
     th = ฟื้นฟู
     tr = Restore
     uk = Відновити
     vi = Khôi phục
-    el = Επαναφορά
-    sk = Obnoviť
-    sw = Rejesha
     zh-Hans = 恢复
     zh-Hant = 恢復
+    el = Επαναφορά
+    es_MX = Restaurar
     fa = بازیابی
-
-  [bookmarks_page_downloaded]
-    en = Downloaded
-    ru = Загруженные
-    ar = تم تحميل
-    cs = Nahrané
-    da = Downloadet
-    nl = Gedownload
-    fi = Ladattu
-    fr = Téléchargé
-    de = Geladene
-    hu = Letöltött
-    id = Diunduh
-    it = Scaricati
-    ja = ダウンロード済み
-    ko = 다운로드 되었습니다.
-    no = Lastet ned
-    pl = Pobrane
-    pt = Baixado
-    pt-BR = Baixado
-    ro = Fișierele descărcate
-    es = Descargado
-    es_MX = Descargado
-    sv = Ladda ner
-    th = ดาวน์โหลด
-    tr = İndirildi
-    uk = Завантажені
-    vi = Đã tải về
-    el = Κατέβηκε
-    sk = Prevzaté
-    sw = Imepakuliwa
-    zh-Hans = 加载
-    zh-Hant = 加載
-    fa = دانلود شد
-
-  [bookmarks_page_my]
-    en = My
-    ru = Мои
-    ar = الخاص بي
-    cs = Moje
-    da = Mine
-    nl = Mijn
-    fi = Minun
-    fr = Mes
-    de = Meine
-    hu = Az én
-    id = Milik saya
-    it = I miei
-    ja = 私の
-    ko = 나의
-    no = Mine
-    pl = Moje
-    pt = Minhas
-    pt-BR = Minhas
-    ro = Al mele
-    es = Mis
-    es_MX = Mis
-    sv = Min
-    th = ของฉัน
-    tr = Bana ait
-    uk = Мої
-    vi = của tôi
-    el = Μου
-    sk = Moje
-    sw = Yangu
-    zh-Hans = 我的
-    zh-Hant = 我的
-    fa = مال من
-
-  [routes_and_bookmarks]
-    en = Routes and bookmarks
-    ru = Маршруты и метки
-    ar = الطرق والإشارات
-    cs = Trasy a značky
-    da = Ruter og bogmærker
-    nl = Routes en Bladwijzers
-    fi = Reitit ja kirjanmerkit
-    fr = Itinéraires et favoris
-    de = Routen und Markierungen
-    hu = Útvonalaim és könyvjelzőim
-    id = Rute dan bookmark
-    it = Percorsi e segnalibri
-    ja = ルートとブックマーク
-    ko = 경로 및 북마크
-    no = Ruter og bokmerker
-    pl = Trasy i zakładki
-    pt = Rotas e favoritos
-    pt-BR = Rotas e favoritos
-    ro = Rute și tag-uri
-    es = Rutas y marcadores
-    es_MX = Rutas y marcadores
-    sv = Rutt och bokmärken
-    th = เส้นทาง และบุ๊กมาร์ก
-    tr = Rotalar ve yer imleri
-    uk = Маршрути та позначки
-    vi = Tuyến đường và dấu trang
-    el = Διαδρομές και σελιδοδείκτες
-    sk = Trasy a záložky
-    sw = Njia na vialamisho
-    zh-Hans = 路线和标签
-    zh-Hant = 路線和標籤
-    fa = مسیرها و نشانه‌ها
-
-  [bookmarks_webview_success_toast]
-    en = Bookmarks succesfully downloaded
-    ru = Метки успешно загружены
-    ar = تم تحميل الإشارات بنجاح
-    cs = Značky byly úspěšně nahrány
-    da = Bogmærker er downloadet
-    nl = Bladwijzers succesvol gedownload
-    fi = Kirjanmerkit ladattu onnistuneesti
-    fr = Favoris enregistrés avec succès
-    de = Die Markierungen wurden erfolgreich hochgeladen
-    hu = Könyvjelzők sikeresen letöltve
-    id = Bookmark berhasil diunduh
-    it = Segnalibri scaricati con successo
-    ja = ブックマークが正常にダウンロードされました
-    ko = 성공적으로 북마크를 다운로드 하였습니다.
-    no = Bokmerker lastet ned
-    pl = Zakładki pobrane pomyślnie
-    pt = Favoritos baixados com sucesso
-    pt-BR = Favoritos baixados com sucesso
-    ro = Locațiile au fost descărcate cu succes
-    es = Marcadores descargados exitosamente
-    es_MX = Marcadores descargados exitosamente
-    sv = Bokmärkena har laddats ner
-    th = ดาวน์โหลดบุ๊กมาร์กสำเร็จแล้ว
-    tr = Yer imleri başarıyla indirildi
-    uk = Мітки успішно завантажені
-    vi = Đã tải xuống thành công dấu trang
-    el = Οι σελιδοδείκτες κατέβηκαν επιτυχώς
-    sk = Záložky úspešne prevzaté
-    sw = Vialamisho vimefanikiwa kupakuliwa
-    zh-Hans = 标签已成功下载
-    zh-Hant = 標籤已成功加載
-    fa = نشانه‌ها با موفقیت دانلود شد
-
-  [cached_bookmarks_placeholder_title]
-    en = Download new places
-    ru = Загрузите новые места
-    ar = تحميل أماكن جديدة
-    cs = Nahrajte nová místa
-    da = Download nye steder
-    nl = Download nieuwe plaatsen
-    fi = Lataa uudet paikat
-    fr = Télécharger de nouveaux lieux
-    de = Laden Sie neue Plätze hoch
-    hu = Új helyek letöltése
-    id = Unduh tempat baru
-    it = Scarica nuovi posti
-    ja = 新しい場所をダウンロード
-    ko = 새로운 장소를 다운로드 하세요.
-    no = Last ned nye steder
-    pl = Pobierz nowe miejsca
-    pt = Baixar novos lugares
-    pt-BR = Baixar novos lugares
-    ro = Încărcați locuri noi
-    es = Descargar nuevos lugares
-    es_MX = Descargar nuevos lugares
-    sv = Ladda ner nya platser
-    th = ดาวน์โหลดสถานที่ใหม่
-    tr = Yeni yerler indirin
-    uk = Завантажте нові місця
-    vi = Tải xuống các địa điểm mới
-    el = Κατεβάστε νέα μέρη
-    sk = Prevziať nové miesta
-    sw = Pakua maeneo mapya
-    zh-Hans = 上传新地点
-    zh-Hant = 上傳新地點
-    fa = دانلود مکان‌های جدید
-
-  [cached_bookmarks_placeholder_subtitle]
-    en = Press the button to download thousands of interesting places and routes created by Organic Maps users. You will need the internet connection.
-    ru = Нажмите кнопку, чтобы загрузить тысячи интересных мест и маршрутов, созданных пользователями Organic Maps. Вам понадобится подключение к интернету.
-    ar = اضغط على الزر لتحميل الآلاف من الأماكن المثيرة للاهتمام والطرق التي تم إنشاؤها من قبل لمستخدمين Organic Maps. سوف تحتاج إلى اتصال بالإنترنت.
-    cs = Klikněte pro nahrání tisíce zajímavých míst a tras vytvořených uživateli Organic Maps. Nutné připojení k internetu.
-    da = Tryk på knappen for at downloade tusindvis af interessanter steder og ruter oprettet af brugerne på Organic Maps. Du skal bruge en internetforbindelse.
-    nl = Druk op de knop om duizenden interessante plaatsen en routes te downloaden, gecreëerd door Organic Maps-gebruikers. U hebt een internet-verbinding nodig.
-    fi = Paina nappulaa ladataksesi tuhansia kiinnostavia paikkoja ja reittejä joita Organic Maps käyttäjät ovat luoneet. Tarvitset internet yhteyden.
-    fr = Appuyez sur le bouton pour télécharger des milliers de lieux et d'itinéraires intéressants créés par les utilisateurs de Organic Maps. Vous aurez besoin d'une connexion Internet.
-    de = Klicken Sie auf die Schaltfläche, um Tausende von interessanten Orten und Routen, die von den Anwendern von Organic Maps erstellt wurden, zu laden. Sie werden eine Internetverbindung benötigen.
-    hu = Nyomja meg a gombot, hogy Organic Maps felhasználók ezrei által gyűjtött érdekes helyet és útvonalat tölthessen le. Ehhez internetkapcsolatra van szükség.
-    id = Tekan tombol untuk mengunduh ribuan tempat dan rute menarik yang dibuat oleh pengguna Organic Maps. Anda akan memerlukan koneksi internet.
-    it = Premi il pulsante per scaricare migliaia di luoghi e percorsi interessanti creati dagli utenti di Organic Maps. Avrai bisogno della connessione internet.
-    ja = Organic Mapsユーザーが作成した数千ものおもしろい場所やルートをダウンロードするには、このボタンを押します。インターネット接続が必要です。
-    ko = 버튼을 눌러 Organic Maps 사용자들이 작성한 수천 개의 흥미로운 장소와 경로를 다운로드 하세요. 인터넷 연결이 필요합니다.
-    no = Trykk på knappen for å laste ned tusenvis av interessante steder og ruter skapt av Organic Maps-brukere. Du må være koblet til internett.
-    pl = Naciśnij przycisk, aby pobrać tysiące interesujących miejsc i tras utworzonych przez użytkowników Organic Maps. Wymagane jest połączenie internetowe.
-    pt = Aperte o botão para baixar milhares de lugares e rotas interessantes criados pelos usuários de Organic Maps. Você precisará de conexão com a internet.
-    pt-BR = Pressione o botão para baixar milhares de lugares interessantes e rotas criadas pelos usuários de Organic Maps. Você precisará de conexão com a internet.
-    ro = Faceți clic pe butonul pentru a descărca mii de locuri interesante și rute create de utilizatori Organic Maps. Veți avea nevoie de o conexiune la Internet.
-    es = Presione el botón para descargar miles de lugares y rutas interesantes creadas por usuarios de Organic Maps. Necesitará una conexión a Internet.
-    es_MX = Presione el botón para descargar miles de lugares y rutas interesantes creadas por usuarios de Organic Maps. Necesitará una conexión a Internet.
-    sv = Tryck på knappen för att ladda ner tusentals intressanta platser och rutter skapade av Organic Maps användare. Du behöver internetanslutning.
-    th = กดปุ่มเพื่อดาวน์โหลดหลายพันสถานที่ และเส้นทางที่น่าสนใจต่าง ๆ ซึ่งสร้างขึ้นโดยผู้ใช้งานของ Organic Maps คุณจำเป็นต้องเชื่อมต่อกับอินเตอร์เน็ต
-    tr = Organic Maps kullanıcılarının oluşturduğu binlerce ilgi çekici yeri ve rotayı indirmek için düğmeye basın. İnternet bağlantınızın olması gerekir.
-    uk = Натисніть кнопку, щоб завантажити тисячі цікавих місць і маршрутів, створених користувачами Organic Maps. Вам знадобиться підключення до Інтернету.
-    vi = Nhấn nút để tải xuống hàng ngàn địa điểm và tuyến đường thú vị được tạo bởi người dùng Organic Maps. Bạn sẽ cần kết nối internet.
-    el = Πιέστε το κουμπί για να κατεβάστε χιλιάδες ενδιαφέροντα μέρη και διαδρομές που δημιουργήθηκαν από τους χρήστες του Organic Maps. Θα χρειαστείτε σύνδεση στο διαδίκτυο.
-    sk = Stlačením tlačidla stiahnete tisíce zaujímavých miest a trás vytvorených používateľmi Organic Maps. Budete potrebovať internetové pripojenie.
-    sw = Bonyeza kitufe ili upakue maelefu ya maeneo na njia za kuvutia zilizoundwa na watumiaji wa Organic Maps Utahitaji muunganisho wa intaneti.
-    zh-Hans = 单击按钮下载Organic Maps用户创建的数千个有趣的地点和路线。您需要连接网络。
-    zh-Hant = 單擊按鈕下載Organic Maps用戶創建的數千個有趣的地點和路線。您需要網絡連接。
-    fa = دکمه را بزنید تا هزاران مکان و مسیر جالبی که دیگران کاربران Organic Maps ساخته‌اند را ببینید. به اتصال اینترنتی نیاز خواهید داشت.
-
-  [downloader_download_routers]
-    en = Download bookmarks
-    ru = Загрузить метки
-    ar = تحميل الإشارات
-    cs = Nahrát značky
-    da = Download bogmærker
-    nl = Download bladwijzers
-    fi = Lataa kirjanmerkit
-    fr = Télécharger les favoris
-    de = Markierungen laden
-    hu = Könyvjelzők letöltése
-    id = Unduh bookmark
-    it = Scarica i segnalibri
-    ja = ブックマークをダウンロード
-    ko = 북마크를 다운로드 하세요.
-    no = Last ned bokmerker
-    pl = Pobierz zakładki
-    pt = Baixar favoritos
-    pt-BR = Baixar favoritos
-    ro = Descărcați tag-urile
-    es = Descargar marcadores
-    es_MX = Descargar marcadores
-    sv = Ladda ner bokmärken
-    th = ดาวน์โหลดบุ๊กมาร์ก
-    tr = İndirilen yer imleri
-    uk = Завантажити позначки
-    vi = Tải dấu trang xuống
-    el = Κατεβάστε σελιδοδείκτες
-    sk = Prevziať záložky
-    sw = Pakua vialamisho
-    zh-Hans = 下载标签
-    zh-Hant = 加載標籤
-    fa = دانلود نشانه‌ها
-
-  [bookmarks_groups_cached]
-    en = Downloaded lists
-    ru = Загруженные списки
-    ar = القوائم التي تم تنزيلها
-    cs = Nahrané seznamy
-    da = Downloadede lister
-    nl = Download lijsten
-    fi = Ladatut lista
-    fr = Listes téléchargées
-    de = Heruntergeladene Listen
-    hu = Letöltött listák
-    id = Daftar yang telah diunduh.
-    it = Elenchi scaricati da
-    ja = ダウンロード済みリスト
-    ko = 목록을 다운로드 하세요.
-    no = Nedlastede lister
-    pl = Pobrane listy
-    pt = Listas baixadas
-    pt-BR = Baixar listas
-    ro = Listele descărcate
-    es = Listas descargadas
-    es_MX = Listas descargadas
-    sv = Nedladdade listor
-    th = ดาวน์โหลดรายการต่าง ๆ แล้ว
-    tr = İndirilen listeler
-    uk = Завантажені списки
-    vi = Danh sách đã tải xuống
-    el = Κατεβάστε λίστες
-    sk = Prevziať zoznamy
-    sw = Orodha zilizopakuliwa
-    zh-Hans = 上传的列表
-    zh-Hant = 加載的列表
-    fa = لیست‌های دانلودشده
-
-  [bookmarks_objects]
-    en:one = %s object
-    en:other = %s objects
-    ru:one = %s объект
-    ru:two = %d объекта
-    ru:few = %d объекта
-    ru:other = %s объектов
-    ar = %s العنصر
-    cs = %s objekt
-    da = %s objekt
-    nl = %s object
-    fi = %s kohde
-    fr = objet %s
-    de = %s Objekt
-    hu = %s tárgy
-    id = obyek %s
-    it = %s oggetto
-    ja = %sのオブジェクト
-    ko = %s 대상
-    no = %s objekt
-    pl = %s obiekt
-    pt = %s objeto
-    pt-BR = %s objeto
-    ro = %s obiect
-    es = %s objeto
-    es_MX = %s objeto
-    sv = %s objekt
-    th = %s วัตถุประสงค์
-    tr = %s nesne
-    uk = %s об’єкт
-    vi = %s mục tiêu
-    el = %s αντικέιμενο
-    sk = %s objekt
-    sw = Kipengee %s
-    zh-Hans = %s 对象
-    zh-Hant = %s 對象
-    fa:one = %s شیء
-    fa:other = %s شیء
+    sk = Obnoviť
+    sw = Rejesha
 
   [objects]
-    en:one = %d object
-    en:other = %d objects
-    ru:one = %d объект
-    ru:two = %d объекта
-    ru:few = %d объекта
-    ru:other = %d объектов
+    tags = android
     ar = المكان %d
     cs = %d místo
     da = %d sted
@@ -23763,33 +14976,34 @@
     it = %d luogo
     ja = %dの場所
     ko = %d 장소
-    no = %d sted
     pl = %d miejsce
     pt = %d lugar
     pt-BR = %d lugar
     ro = %d localitate
     es = %d lugar
-    es_MX = %d lugar
     sv = %d plats
     th = %d สถานที่
     tr = %d yer
     uk = %d місце
     vi = %d nơi
-    el = %d μέρος
-    sk = %d miesto
-    sw = Eneo %d
     zh-Hans = %d 地点
     zh-Hant = %d 地點
+    el = %d μέρος
+    en:one = %d object
+    en:other = %d objects
+    es_MX = %d lugar
     fa:one = %s شیء
     fa:other = %s شیء
+    no = %d sted
+    ru:few = %d объекта
+    ru:one = %d объект
+    ru:other = %d объектов
+    ru:two = %d объекта
+    sk = %d miesto
+    sw = Eneo %d
 
   [places]
-    en:one = %d place
-    en:other = %d places
-    ru:one = %d место
-    ru:two = %d места
-    ru:few = %d места
-    ru:other = %d мест
+    tags = android
     ar = الأماكن %d
     cs = %d míst
     da = %d steder
@@ -23802,33 +15016,34 @@
     it = %d luoghi
     ja = %dの場所
     ko = %d 장소들
-    no = %d steder
     pl = %d miejsc
     pt = %d lugares
     pt-BR = %d lugares
     ro = %d localităti
     es = %d lugares
-    es_MX = %d lugares
     sv = %d platser
     th = %d สถานที่ต่าง ๆ
     tr = %d yer
     uk = %d місць
     vi = %d các nơi
-    el = %d μέρη
-    sk = %d miesta
-    sw = Maeneo %d
     zh-Hans = %d 地点
     zh-Hant = %d 地點
+    el = %d μέρη
+    en:one = %d place
+    en:other = %d places
+    es_MX = %d lugares
     fa:one = %d مکان
     fa:other = %d مکان
+    no = %d steder
+    ru:few = %d места
+    ru:one = %d место
+    ru:other = %d мест
+    ru:two = %d места
+    sk = %d miesta
+    sw = Maeneo %d
 
   [tracks]
-    en:one = %d track
-    en:other = %d tracks
-    ru:one = %d трек
-    ru:two = %d трека
-    ru:few = %d трека
-    ru:other = %d треков
+    tags = android
     ar = المسارات %d
     cs = %d cest
     da = %d ruter
@@ -23841,27 +15056,34 @@
     it = %d tracce
     ja = %dの追跡
     ko = %d 추적
-    no = %d stier
     pl = %d tras
     pt = %d rastreamentos
     pt-BR = %d cursos
     ro = %d bande
     es = %d seguimientos
-    es_MX = %d rastreos
     sv = %d spår
     th = %d ติดตามต่าง ๆ
     tr = %d izleme
     uk = %d треків
     vi = %d các chặn đường
-    el = %d διαδρομές
-    sk = %d sledovania
-    sw = Njia %s
     zh-Hans = %d 跟踪
     zh-Hant = %d 軌跡
+    el = %d διαδρομές
+    en:one = %d track
+    en:other = %d tracks
+    es_MX = %d rastreos
     fa:one = %d رد
     fa:other = %d رد
+    no = %d stier
+    ru:few = %d трека
+    ru:one = %d трек
+    ru:other = %d треков
+    ru:two = %d трека
+    sk = %d sledovania
+    sw = Njia %s
 
   [subtittle_opt_out]
+    tags = android
     en = Tracking settings
     ru = Настройки сопровождения
     ar = إعدادات التتبع
@@ -23876,26 +15098,27 @@
     it = Impostazioni di tracciamento
     ja = 追跡の設定
     ko = 추적 설정
-    no = Turinnstillinger
     pl = Ustawienia śledzenia
     pt = Configurações de rastreamento
     pt-BR = Configurações de rastreamento
     ro = Setări de servire
     es = Configuraciones de seguimiento
-    es_MX = Configuraciones de rastreo
     sv = Spårningsinställningar
     th = การตั้งค่าการติดตาม
     tr = İzleme ayarları
     uk = Налаштування супроводу
     vi = Thiết lập theo dõi
-    el = Ρυθμίσεις διαδρομών
-    sk = Nastavenie sledovania
-    sw = Mipangilio ya ufuatiliaji
     zh-Hans = 支持设置
     zh-Hant = 跟蹤設置
+    el = Ρυθμίσεις διαδρομών
+    es_MX = Configuraciones de rastreo
     fa = تنظیمات ردیابی
+    no = Turinnstillinger
+    sk = Nastavenie sledovania
+    sw = Mipangilio ya ufuatiliaji
 
   [crash_reports]
+    tags = android
     en = Crash report
     ru = Отчеты об ошибках
     ar = تقرير الحادث
@@ -23910,26 +15133,27 @@
     it = Rapporto incidenti
     ja = クラッシュレポート
     ko = 오류 보고서
-    no = Krasjrapport
     pl = Raport o błędzie
     pt = Relatório de erros
     pt-BR = Relatório de erros
     ro = Rapoarte de eroare
     es = Informe de incidentes
-    es_MX = Reporte de fallas
     sv = Olycksrapport
     th = รายงานข้อขัดข้อง
     tr = Kilitlenme raporu
     uk = Звіти про помилки
     vi = Báo cáo sự cố
-    el = Αναφορά σφάλματος
-    sk = Hlásenie chýb
-    sw = Ripoti ya kuharibika
     zh-Hans = 错误报告
     zh-Hant = 錯誤報告
+    el = Αναφορά σφάλματος
+    es_MX = Reporte de fallas
     fa = گزارش خرابی
+    no = Krasjrapport
+    sk = Hlásenie chýb
+    sw = Ripoti ya kuharibika
 
   [crash_reports_description]
+    tags = android
     en = We may use your data to improve Organic Maps experience. Changes will take effect after you restart the app.
     ru = Мы можем использовать ваши данные, чтобы развивать и улучшать Organic Maps. Изменения вступят в силу после перезапуска приложения.
     ar = قد نستخدم بياناتك لتحسين تجربة Organic Maps. سوف تكون التغييرات نافذة المفعول بعد إعادة تشغيل التطبيق.
@@ -23944,162 +15168,27 @@
     it = Potremmo utilizzare i tuoi dati per migliorare l'esperienza Organic Maps. Le modifiche avranno effetto dopo il riavvio dell'applicazione.
     ja = Organic Maps体験を向上させるため、お客様のデータを使用する可能性があります。変更は、アプリを再起動した後に、反映されます。
     ko = 당사는 Organic Maps 경험을 개선하기 위해 귀하의 데이터를 활용할 수 있습니다. 앱을 다시 시작한 후 변경사항이 적용됩니다.
-    no = Vi kan bruke dine data for å forbedre Organic Maps-opplevelsen. Endringer vil bli aktive når du restarter appen.
     pl = Możemy używać Twoich danych do usprawnienia działania Organic Maps. Zmiany zostaną zastosowane po ponownym uruchomieniu aplikacji.
     pt = Podemos utilizar seus dados para melhorar a experiência no Organic Maps. As mudanças entrarão em vigor após você reiniciar o aplicativo.
     pt-BR = Nós podemor utilizar seus dados para melhorar a experiência Organic Maps As mudanças terão efeitos após reiniciar o app.
     ro = Putem folosi datele dvs. pentru a dezvolta și de a îmbunătăți Organic Maps. Modificările vor intra în vigoare după repornirea aplicației.
     es = Puede que utilicemos vuestros datos para mejorar la experiencia de Organic Maps. Los cambios tendrán efecto después que reinicie la aplicación.
-    es_MX = Puede que utilicemos sus datos para mejorar la experiencia de Organic Maps. Los cambios surtirán efecto después de que reinicie la aplicación.
     sv = Vi kan komma att använda din data för att förbättra Organic Maps upplevelsen. Ändringarna kommer träda i kraft när du startar om appen.
     th = เราอาจใช้ข้อมูลของคุณเพื่อพัฒนาประสบการณ์ของ Organic Maps การเปลี่ยนแปลงจะมีผลหลังจากที่คุณเปิดแอพฯ ขึ้นใหม่
     tr = Organic Maps deneyimini geliştirmek için verilerinizi kullanabiliriz. Değişiklikler, uygulama yeniden başlatıldıktan sonra geçerli olur.
     uk = Ми можемо використовувати ваші дані, щоб розвивати та покращувати Organic Maps. Зміни вступлять у силу після перезапуску програми
     vi = Chúng tôi có thể sử dụng dữ liệu của bạn để cải thiện trải nghiệm trên Organic Maps. Thay đổi sẽ có hiệu lực sau khi bạn khởi động lại ứng dụng.
-    el = Μπορεί να χρησιμοποιήσουμε τα δεδομένα σας για να βελτιώσουμε την εμπειρία του Organic Maps. Οι αλλαγές θα ενεργοποιηθούν μετά την επανεκκίνηση της εφαρμογής.
-    sk = Vaše údaje môžeme použiť na zlepšenie skúseností s programom Organic Maps. Zmeny sa prejavia po reštartovaní aplikácie.
-    sw = Tunaweza kutumia data yako kuboresha uzoefu wa Organic Maps Mabadiliko yataanza kutumika baada ya kuwasha upya programu.
     zh-Hans = 我们可以使用您的数据来开发和改进Organic Maps.更改将在重新启动应用程序后生效。
     zh-Hant = 我們可以使用您的數據來開發和改進Organic Maps。更改將再重新啟動應用程序后生效。
+    el = Μπορεί να χρησιμοποιήσουμε τα δεδομένα σας για να βελτιώσουμε την εμπειρία του Organic Maps. Οι αλλαγές θα ενεργοποιηθούν μετά την επανεκκίνηση της εφαρμογής.
+    es_MX = Puede que utilicemos sus datos para mejorar la experiencia de Organic Maps. Los cambios surtirán efecto después de que reinicie la aplicación.
     fa = ما از داده‌های شما برای بهبود Organic Maps استفاده می‌کنیم. تغییرات پس از راه‌اندازی مجدد برنامه به‌کار می‌افتد.
-
-  [opt_out_help_ios_1]
-    en = Your mobile device may provide a “Limit Ad Tracking” or “Opt out of interest-based advertising” setting.
-    ru = Вы можете отказаться от получения целевой рекламы в настройках устройства.
-    ar = يمكن أن يوفر جهازك الجوّال إعداد ""تقييد الإعلان المخصص"" أو ""تعطيل الإعلان الذي يستهدف الاهتمامات"".
-    cs = Cílovou reklamu můžete vypnout v nastavení vašeho zařízení.
-    da = Din mobilenhed kan indeholde en »Begræns reklamesporing« eller »Afmeld Tilpasset annoncering« indstiling.
-    nl = Uw mobiele apparaat kan voorzien zijn van een instelling voor „Gelimiteerde advertentie-tracking” of „afmelden voor op interesses gebaseerd adverteren”.
-    fi = Mobiililaitteesi saattaa tarjota ”Rajoittettu Mainos Seuranta” tai ”Poistu internet-perusteisesta mainnonnasta” asetuksia.
-    fr = Votre appareil mobile peut fournir un paramètre «Limiter le suivi des annonces» ou «Désactiver la publicité ciblée par centres d'intérêt».
-    de = Sie können der Erhalt von gezielter Werbung in den Einstellungen des Geräts verbieten.
-    hu = A mobileszköz „Reklámkövetés korlátozása” vagy „Érdeklődési kör alapú reklámozás” beállítással rendelkezhet.
-    id = Perangkat seluler Anda mungkin menyediakan pengaturan ""Batasi Treking Iklan"" atau ""Keluar dari iklan berbasis ketertarikan"".
-    it = Il tuo dispositivo mobile potrebbe fornire un'impostazione «Limita monitoraggio annunci» o «Disattiva la pubblicità mirata».
-    ja = お使いの携帯端末には、「追跡型広告を制限」または「関心に基づく広告を非表示」の設定があるかもしれません。
-    ko = 귀하의 모바일 장치는 ""광고 추적 제한"" 혹은 ""관심 기반의 광고의 옵트아웃"" 설정을 제공할 수 있습니다.
-    no = Din mobilenhet kan muligens ha en innstilling som «Begrens annonsesporing» eller «Velg bort interessebasert annonsering».
-    pl = W Twoim urządzeniu mobilnym może być dostępne ustawienie „Limit Ad Tracking” lub „Opt out of interest-based advertising”.
-    pt = O seu dispositivo móvel pode fornecer as opções de «Limitar rastreamento de anúncios» ou «Desativar publicidade baseada em interesse».
-    pt-BR = O seu dispositivo móvel pode fornecer um configuração “Limitar Anúncios de Rastreamento” ou “Optar por retirar anúncios fora do interesse”.
-    ro = Puteți renunța la primirea de publicitate țintă în setările aparatului.
-    es = Su dispositivo móvil puede tener una opción de «Limitar el seguimiento de anuncios» o «Excluir anuncios basados en intereses».
-    es_MX = Su dispositivo móvil puede tener una opción de «Limitar el seguimiento de anuncios» o «Excluir anuncios basados en intereses».
-    sv = Din mobila enhet kan tillhandahålla en ”Begränsad annonsspårning” eller ”Välj bort intressebaserad annonsering” inställning.
-    th = อุปกรณ์มือถือของคุณอาจมีการตั้งค่า ""จำกัดการติดตามโฆษณา"" หรือ ""เลือกไม่ใช้การโฆษณาตามความสนใจ""
-    tr = Mobil cihazınız, “Reklam İzlemeyi Sınırla” veya “İlgiye dayalı reklamcılığı devre dışı bırak” ayarı sunar.
-    uk = Ви можете відмовитися від отримання цільової реклами в налаштуваннях пристрою.
-    vi = Thiết bị di động của bạn có thể cung cấp cài đặt ""Giới hạn theo dõi quảng cáo"" hoặc ""Chọn không tham gia quảng cáo dựa trên sở thích"".
-    el = Η συσκευή σας μπορεί να παρέχει μια ρύθμιση «Περιορισμένη παρακολούθηση διαφημίσεων» ή «Αποκλεισμό διαφημίσεων με βάση το ενδιαφέρον».
-    sk = Vaše mobilné zariadenie môže poskytnúť nastavenie „Obmedziť reklamné sledovanie“ alebo „Zrušiť inzerciu založenú na záujmoch“.
-    sw = Huenda kifaa chako cha mkononi kikatoa mpangilio wa 'Zuia Ufuatiliaji wa Matangazo"" au ""Chagua kutoka kwenye utangazaji unaotegemea mapendeleo"".
-    zh-Hans = 您可以选择停止在设备设置中接收定位广告。
-    zh-Hant = 您可以選擇停止在設備設置中接受定向廣告。
-    fa = در دستگاه همراهتان تنظیمی با نام “Limit Ad Tracking” یا “Opt out of interest-based advertising” وجود دارد.
-
-  [opt_out_help_ios_2]
-    en = iOS 9 or Higher
-    ru = iOS 9 или выше
-    ar = نظام تشغيل آي 9 فما فوق
-    cs = iOS 9 nebo vyšší
-    da = iOS 9 eller højere
-    nl = iOS 9 of hoger
-    fi = iOS 9 tai Korkeampi
-    fr = iOS 9 ou plus récent
-    de = iOS 9 oder höher
-    hu = iOS 9 vagy újabb
-    id = iOS 9 atau Lebih Tinggi
-    it = iOS 9 o versioni successive
-    ja = iOS 9以降
-    ko = iOS 9 혹은 이상
-    no = iOS 9 eller høyere
-    pl = iOS 9 lub nowszy
-    pt = iOS 9 ou Superior
-    pt-BR = iOS 9 ou Acima
-    ro = iOS 9 sau mai sus
-    es = iOS 9 o más reciente
-    es_MX = iOS 9 o más reciente
-    sv = iOS 9 eller nyare
-    th = iOS 9 หรือสูงกว่า
-    tr = iOS 9 veya Üstü
-    uk = iOS 9 або вище
-    vi = iOS 9 hoặc lớn hơn
-    el = iOS 9 ή υψηλότερο
-    sk = iOS 9 alebo vyšší
-    sw = iOS 9 au Juu zaidi
-    zh-Hans = iOS 9或更高版本
-    zh-Hant = iOS 9或更高版本
-    fa = آی‌اواس ۹ یا بالاتر
-
-  [opt_out_help_ios_3]
-    en = Go to your Settings → Privacy → Advertising → Enable the “Limit Ad Tracking” setting
-    ru = Откройте Настройки → Конфиденциальность → Реклама → Включите «Ограничение трекинга»
-    ar = انتقل إلى إعداداتك ← الخصوصية ← الإعلانات ← تمكين إعداد ""تحديد تتبع الإعلانات""
-    cs = Otevřete Nastavení → Důvěrnost → Reklama → Zapněte „Omezení trackingu“
-    da = Gå til Indstillinger → Generelt → Begræsninger → Reklamer → Aktiver »Begræns reklamesporing« funktionen
-    nl = Ga naar uw Instellingen → Privacy → Advertenties → Inschakelen van de „Gelimiteerde advertentie-tracking” - instelling
-    fi = Mene Asetuksiisi → Yksityisyys → Mainonta → Salli ”Rajoita Mainos Seurantaa” asetus
-    fr = Accédez à vos paramètres → Confidentialité → Publicité → Activer le paramètre «Limiter le suivi des annonces»
-    de = Öffnen Sie die Einstellungen → Vertraulichkeit → Werbung → Schalten Sie „Tracking einschränken“ ein
-    hu = Nyissa meg a Beállítások → Adatvédelem→ Reklámok→ és engedélyezze a “Reklámkövetés korlátozása” beállítást
-    id = Ke Pengaturan → Privasi → Iklan → Aktifkan pengaturan ""Batasi Treking Iklan""
-    it = Vai a Impostazioni → Privacy → Pubblicità → Abilita l'impostazione «Limita monitoraggio degli annunci»
-    ja = 設定→プライバシー→広告に進み、「追跡型広告を制限」を有効にします
-    ko = 설정 → 개인정보 → 광고 → “광고 추적 제한” 설정을 활성화합니다.
-    no = Gå til Innstillinger → Personvern → Annonser → Slå på «Begrens annonsesporing»-innstillingen
-    pl = Przejdź do Ustawień → Prywatność→ Reklamy→ Włącz ustawienie „Limit Ad Tracking”
-    pt = Vá para: Configurações → Privacidade → Anúncios → Habilitar «Limitar Rastreamento de Anúncios»
-    pt-BR = Vá para Configurações → Privacidade → Anúncio → Habilitar a configuração de “Limitar Anúncios de Rastreamento”
-    ro = Deschideți Setări → Confidențialitate → Publicitate → „Activați Limitarea trackking”
-    es = Diríjase a su Configuración → Privacidad → Publicidad → Habilite la opción «Limitar seguimiento»
-    es_MX = Vaya a su Configuración → Privacidad → Publicidad → Habilite la opción «Limitar seguimiento»
-    sv = Gå till Inställningar → Integritet → Annonsering → Tillåt inställningen ”Begränsad annonsspårning”
-    th = ไปที่การตั้งค่าของคุณ → ความเป็นส่วนตัว → การโฆษณา → เปิดใช้งานการตั้งค่า “จำกัดการติดตามโฆษณา”
-    tr = Ayarlar → Gizlilik → Reklamcılık'a gidin ve “Reklam İzlemeyi Sınırla” ayarını etkinleştirin
-    uk = Відкрийте Налаштування → Конфіденційність → Реклама → Увімкніть «Обмеження трекінгу»
-    vi = Đến Cài đặt → Bảo mật → Quảng cáo → Bật cài đặt ""Giới hạn theo dõi quảng cáo""
-    el = Πηγαίνετε στις ρυθμίσεις → Απόρρητο → Διαφήμιση → Ενεργοποιήστε την επιλογή «Περιορισμένη παρακολούθηση διαφημίσεων»
-    sk = Prejdite do nastavenia → Ochrana osobných údajov → Reklama → Povolenie nastavenia „Obmedziť reklamné sledovanie“
-    sw = Nenda kwenye Mipangilio yako → Faragha→ Utangazaji → Wezesha mpangilio wa “Zuia Ufuatiliaji wa Matangazo”
-    zh-Hans = 打开设置→隐私→广告→启用“跟踪限制”
-    zh-Hant = 請打開設置 → 隱私 → 廣告 → 啟用“跟蹤限制”
-    fa = به تنظیمات خود بروید ← حریم خصوصی ← تبلیغات ← گزینه  «محدود کردن ردیابی آگهی» را فعال کنید
-
-  [opt_out_help_android]
-    en = Your mobile device may provide a “Limit Ad Tracking” or “Opt out of interest-based advertising” setting.\n\nFor Android and Google Play Services version 4.0 and up:\nSettings → Google → Ads → Opt out of Ads Personalization\nor\nSettings → Google → Google Account → Personal info & privacy → Ads Settings → Ads Personalization
-    ru = Вы можете отказаться от получения целевой рекламы в настройках устройства.\nAndroid и Google Play Сервисы 4.0 и выше\n\nНастройки телефона → Google → Реклама → Отключить персонализацию рекламы\nили\nНастройки телефона → Google → Аккаунт Google → Конфиденциальность → Настройки рекламных предпочтений → Персонализация рекламы
-    ar = قد يوفر جهازك الجوّال إعداد ""الحد من تتبع الإعلان"" أو ""إلغاء الاشتراك من الإعلانات التي تستهدف الاهتمامات"". \ n \ n للحصول على الإصدار 4.0 من نظام التشغيل Android و Google Play: \ n الإعدادات → Google ← الإعلانات ← إلغاء الاشتراك في تخصيص الإعلانات \ أو \ n الإعدادات → Google → Google Account → المعلومات الشخصية والخصوصية → إعدادات الإعلانات → تخصيص الإعلانات
-    cs = Cílovou reklamu můžete vypnout v nastavení vašeho zařízení.\nAndroid a Google Play Servisy 4.0 a vyšší\n\nNastavení telefonu → Google → Reklama → Vypnout personalizaci reklamy\n nebo\nNastavení telefonu → Google → Účet Google → Důvěrnost → Nastavení reklamních preferencí → Personalizace reklamy
-    da = Din mobilenhed kan indeholde en »Begræns reklamesporing« eller »Afmeld Tilpasset annoncering« indstilling.\n\nPå Android og Google Play Services version 4.0 og op:\nIndstillinger → Google → Annoncer→ Afmeld Tilpasset annoncering\nor\nIndstillinger → Google → Google Account → Data og tilpasning → Annoncetilpasning → Annoncetilpasning
-    nl = Uw mobiele apparaat kan voorzien zijn van een instelling voor „Gelimiteerde advertentie-tracking” of „Afmelden voor op interesses gebaseerd adverteren”. \n\nVoor Android en Google Play Services versie 4. 0 en hoger:\nInstellingen → Google → Advertenties → Afmelden voor personalisatie van advertenties \n of \nInstellingen → Google → Google-Account → Gegevens & personalisatie → Advertentiepersonalisatie
-    fi = Mobiililaitteesi saattaa tarjota ”Rajoittettu Mainos Seuranta” tai ”Poistu internet-perusteisesta mainnonnasta” asetuksia.\n\nAndroidille ja Google Play Palvelut versio 4.0 tai myöhemmin:\nAsetukset → Google → Mainokset → Poistu Mainosten Yksilöinti\ntai\nAsetukset → Google → Google Tili → Henkilökohtaiset tiedot ja yksityisyys → Mainos Asetukset → Mainosten Yksilöinti
-    fr = Votre appareil mobile peut proposer un paramètre «Limiter le suivi des annonces"" ou «Désactiver la publicité ciblée par centres d'intérêt».\n\n Pour Android et les services Google Play version 4.0 et ultérieure :\n Réglages → Google → Annonces → Désactiver la personnalisation des annonces\ni\n Paramètres → Google → Compte Google → Informations personnelles et confidentialité → Paramètres des annonces → Personnalisation des annonces
-    de = Sie können den Erhalt von gezielter Werbung in den Geräteeinstellungen ausschalten. \nAndroid und Google Play Services 4.0 und höher\n\nTelefoneinstellungen → Google → Werbung→ Personalisierung ausschalten\noder\nTelefoneinstellungen → Google → Benutzerkonto von Google → Vertraulichkeit → Einstellungen von Werbevorzügen → Personalisierung der Werbung
-    hu = A mobileszköz „Reklámkövetés korlátozása” vagy „Érdeklődési kör alapú reklámozás” beállítással rendelkezhet.\n\nAndroidban és Google Play szolgáltatások 4.0 vagy újabb verzió:\nBeállítások → Google → Google fiók → Személyes és adatvédelem → Reklámok → Reklámok személyre szabása
-    id = Perangkat seluler Anda mungkin menyediakan pengaturan ""Batasi treking iklan"" atau ""Keluar dari iklan berbasis ketertarikan"".\n\nUntuk Android dan Google Play Services versi 4.0 dan ke atas:\nPengaturan → Google → Iklan → Keluar dari Personalisasi Iklan\nor\nPengaturan → Google → Akun Google → Informasi personal & privasi → Pengaturan Iklan → Personalisasi Iklan
-    it = Il tuo dispositivo mobile potrebbe fornire un'impostazione «Limita monitoraggio annunci» o «Disattiva pubblicità mirata». \n\nPer Android e Google Play Services versione 4.0 e successive:\nImpostazioni → Google → Annunci → Disattiva personalizzazione annunci \né\nImpostazioni → Google → Account Google → Informazioni personali e privacy → Impostazioni annunci → Personalizzazione annunci
-    ja = お使いの携帯端末には、「追跡型広告を制限」または「関心に基づく広告を非表示」の設定があるかもしれません。\n\nAndroid、Google Play Servicesバージョン4.0以降：\n設定→Google→広告→広告パーソナライゼーションの提供停止\nor\n設定→Google→Googleアカウント→個人情報とプライバシー→広告設定→広告パーソナライゼーション
-    ko = 귀하의 모바일 장치는 ""광고 추적 제한"" 혹은 ""관심 기반의 광고의 옵트아웃"" 설정을 제공할 수 있습니다.\n\n안드로이드와 구글 플레이 서비스 버전 4.0 혹은 이상은\n설정 → 구글 → 광고 → 광고 개별 맞춤 설정 옵트아웃\nor\n설정 → 구글 → 구글 계정 → 개인 정보 및 보호 → 광고 설정 → 광고 개별 맞춤 설정
-    no = Din mobilenhet kan muligens ha en innstilling som «Begrens annonsesporing» eller «Velg bort interessebasert annonsering».\n\nFor Android og Google Play Services versjon 4.0 og nyere:\nInnstillinger → Google → Annonser → Velg bort Personlig tilpasning av annonser\neller\nInnstillinger → Google → Google-konto → Personlig info og personvern → Annonseinnstillinger → Annonseinnstillinger → Personlig tilpasning av annonser
-    pl = W Twoim urządzeniu mobilnym może być dostępne ustawienie „Limit Ad Tracking” lub „Opt out of interest-based advertising”.\n\nW przypadku systemu Android i Google Play Services w wersji 4.0 i nowszych:\nUstawienia → Google → Reklamy→ Rezygnacja z personalizacji reklam\nlub\nUstawienia→ Google → Konto Google→ Dane i personalizacja→ Personalizacja reklam→ Personalizacja reklam
-    pt = O seu dispositivo móvel pode fornecer as opções de «Limitar rastreamento de anúncios» ou «Desativar publicidade baseada em interesse».\n\nPara versões de Android e Google Play Services superiores a 4.0:\nConfigurações → Google → Anúncios → Desativar publicidade baseada em interesse\nor\n nConfigurações → Google → Anúncios → Informações pessoais & privacidade → Configurações de Anúncios → Personalização de Anúncios
-    pt-BR = O seu dispositivo móvel deve fornecer uma configuração de “Limite de Anúncio de Rastreamento” ou “Optar por retirar anúncios fora do interesse”.\n\nPara versões de Android e Google Play Services acima de 4.0:\nConfigurações → Google → Contas Google → Informações pessoais e privacidade → Configurações de Anúncios → Personalização de Anúncios
-    ro = Puteți renunța la primirea de publicitate țintă în setările aparatului.\n Android și Google Play Servicii 4.0 și mai sus\n\n Setări de telefon → Google → Publicitate → Dezactivarea personalizării publicității \n sau \n Setări de telefon → Google → un Cont Google → Confidențialitate → Setări pentru anunțuri → Personalizarea publicității
-    es = Su dispositivo móvil puede proporcionar una configuración para «Limitar el seguimiento de anuncios» o «Excluir anuncios basados en intereses». \n\nPara la versión 4.0 o más reciente de Android y Servicios de Google Play :\nConfiguración → Google → Anuncios → Excluir Personalización de Anuncios\nor\nConfiguración → Google → Cuenta de Google → Información personal y privacidad → Configuración de Anuncios → Personalización de Anuncios
-    es_MX = Su dispositivo móvil puede proporcionar una configuración para «Limitar el seguimiento de anuncios» o «Excluir anuncios basados en intereses». \n\nPara la versión 4.0 o más reciente de Android y Servicios de Google Play :\nConfiguración → Google → Anuncios → Excluir Personalización de Anuncios\nor\nConfiguración → Google → Cuenta de Google → Información personal y privacidad → Configuración de Anuncios → Personalización de Anuncios
-    sv = Din mobila enhet kan tillhandahålla en ”Begränsad annonsspårning” eller ”Välj bort intressebaserad annonsering” -inställning.\n\nFör Android och Google Play tjänster version 4.0 och nyare:\nInställningar → Google → Annonsering → Välj bort personlig annonsering\eller\nInställningar→ Google → Google konto → Personlig information och integritet → Annonseringsinställningar → Personlig annonsering
-    th = อุปกรณ์มือถือของคุณอาจมีการตั้งค่า ""จำกัดการติดตามโฆษณา"" หรือ ""เลือกไม่ใช้การโฆษณาตามความสนใจ""\n\nสำหรับ Android และบริการ Google Play เวอร์ชั่น 4.0 และสูงกว่า:\nการตั้งค่า → Google → โฆษณา → เลือกไม่ใช้การโฆษณา ในแบบของคุณ\หรือ\nการตั้งค่า → Google → Google Account → ข้อมูลส่วนตัว และส่วนบุคคล → การตั้งค่าโฆษณา → โฆษณาในแบบของคุณ
-    tr = Mobil cihazınız, “Reklam İzlemeyi Sınırla” veya “İlgiye dayalı reklamcılığı devre dışı bırak” ayarı sunar.\n\nAndroid ve Google Play Services 4.0 ve üzeri sürümü için:\nAyarlar → Google → Reklamlar → Reklamları Kişiselleştirme'yi devre dışı bırak\nAyarlar → Google → Google Hesabı → Kişisel bilgiler ve gizlilik → Reklam Ayarları → Reklamları Kişiselleştirme
-    uk = Ви можете відмовитися від отримання цільової реклами в налаштуваннях пристрою.\ nAndroid і Google Play Сервіси 4.0 і вище\n\nНалаштування телефону → Google → Реклама → Відключити персоналізацію реклами\ nабо\ nНалаштування телефону → Google → Акаунт Google → Конфіденційність → Налаштування рекламних переваг → персоналізація реклами
-    vi = Thiết bị di động của bạn có thể cung cấp cài đặt ""Giới hạn theo dõi quảng cáo"" hoặc ""Chọn không tham gia quảng cáo dựa trên sở thích"".\n\nĐối với Android và Google Play Services phiên bản 4.0 trở lên:\nCài đặt → Google → Quảng cáo → Chọn không tham gia Quảng cáo dựa trên sở thích\ n\nCài đặt → Google → Tài khoản Google → Thông tin cá nhân và bảo mật → Cài đặt quảng cáo → Cá nhân hóa quảng cáo
-    el = Η συσκευή σας μπορεί να παρέχει μια ρύθμιση «Περιορισμένη παρακολούθηση διαφημίσεων» ή «Αποκλεισμό διαφημίσεων με βάση το ενδιαφέρον».\n\n Για Android και υπηρεσίες Google Play εκδοχής 4.0 και πάνω:\n Ρυθμίσεις → Google → Διαφημίσεις → Αποκλεισμός προσωποποίησης διαφημίσεων\n ή \n Ρυθμίσεις → Google → Λογαριασμός Google → Προσωπικές πληροφορίες και ασφάλεια → Προσωποποίηση Διαφημίσεων
-    sk = Vaše mobilné zariadenie môže obsahovať nastavenie „Obmedziť reklamné sledovanie“ alebo „Zrušiť inzerciu založenú na záujmoch“. \n\nPre Android a služby Google Play verzie 4.0 a vyššie: \nNastavenia → Google → Reklamy → Zrušiť inzerciu založenú na záujmoch \nalebo\nNastavenia → Google → Google Účet → Osobné informácie a ochrana osobných údajov → Nastavenia reklamy → Personalizácia reklám
-    sw = Kifaa chako cha mkononi kinaweza kutoa mpangilio wa “Zuia Ufuatiliaji wa Matangazo” au “Chagua kutoka kwenye utangazaji unaotegemea mapendeleo”.\n\nKwa Huduma za Android na Google Play toleo 4.0 na zaidi:\nMipangilio → Google → Matangazo → Chagua kutoka kwa Ubinafsishaji wa Matangazo\nau\nMipangilio → Google → Akaunti ya Google → Maelezo ya kibinafsi na faragha → Mipangilio ya Matangazo → Ubinafsishaji wa Matangazo
-    zh-Hans = 您可以选择不在设备设置中接收定向广告。\ NAndroid和Google Play Services 4.0或更高版本\ n \ n电话设置→Google→广告→停用广告个性化\ n或\ n手机设置→Google→Google帐户→隐私→首选项设置→ 广告的个性化
-    zh-Hant = 您可以選擇停止在設備設置中接受定向廣告。Android и Google Play Services 4.0或更高版本\n\n電話設置 → Google → 廣告 → 停用廣告個性化\n或\n電話設置 → Google → Google賬戶 → 隱私 → 首選項設置 → 廣告個性化
-    fa = دستگاه تلفن همراه شما ممکن است یک «ردیابی محدود آگهی» یا «لغو تبلیغات مبتنی بر علاقه» ارائه کند. \n \n برای Android و Google Play Services نسخه 4.0 و بالاتر: \n تنظیمات → Google → آگهی → غیرفعال کردن تبلیغات شخصی سازی \ یا \n تنظیمات → Google → حساب Google → اطلاعات شخصی و حریم خصوصی → تنظیمات تبلیغات → شخصی سازی تبلیغات
+    no = Vi kan bruke dine data for å forbedre Organic Maps-opplevelsen. Endringer vil bli aktive når du restarter appen.
+    sk = Vaše údaje môžeme použiť na zlepšenie skúseností s programom Organic Maps. Zmeny sa prejavia po reštartovaní aplikácie.
+    sw = Tunaweza kutumia data yako kuboresha uzoefu wa Organic Maps Mabadiliko yataanza kutumika baada ya kuwasha upya programu.
 
   [privacy_policy]
+    tags = ios, android
     en = Privacy policy
     ru = Политика конфиденциальности
     ar = سياسة الخصوصية
@@ -24114,26 +15203,27 @@
     it = Politica sulla riservatezza
     ja = 個人情報保護方針
     ko = 개인정보 보호 방침
-    no = Personvernpolitikk
     pl = Polityka prywatności
     pt = Política de privacidade
     pt-BR = Política de privacidade
     ro = Politica de confidențialitate
     es = Política de Privacidad
-    es_MX = Política de Privacidad
     sv = Integritetspolicy
     th = นโยบายความเป็นส่วนตัว
     tr = Gizlilik politikası
     uk = Політика конфіденційності
     vi = Chính sách bảo mật
-    el = Πολιτική απορρήτου
-    sk = Zásady ochrany osobných údajov
-    sw = Sera ya faragha
     zh-Hans = 隐私政策
     zh-Hant = 隱私政策
+    el = Πολιτική απορρήτου
+    es_MX = Política de Privacidad
     fa = سیاست حریم خصوصی
+    no = Personvernpolitikk
+    sk = Zásady ochrany osobných údajov
+    sw = Sera ya faragha
 
   [terms_of_use]
+    tags = ios, android
     en = Terms of use
     ru = Условия использования
     ar = شروط الاستخدام
@@ -24148,62 +15238,29 @@
     it = Condizioni d'uso
     ja = ご利用規約
     ko = 사용 약관
-    no = Bruksbetingelser
     pl = Warunki użytkowania
     pt = Termos de uso
     pt-BR = Termos de uso
     ro = Termeni de utilizare
     es = Condiciones de uso
-    es_MX = Términos de uso
     sv = Allmänna villkor
     th = ข้อกำหนดในการใช้งาน
     tr = Kullanım koşulları
     uk = Умови використання
     vi = Điều khoảng sử dụng
-    el = Όροι χρήσης
-    sk = Podmienky používania
-    sw = Masharti ya matumizi
     zh-Hans = 使用条款
     zh-Hant = 使用條款
+    el = Όροι χρήσης
+    es_MX = Términos de uso
     fa = شرایط استفاده
-
-  [backup_notification_failed]
-    ru = Резервное копирование меток было приостановлено. Войдите, чтобы включить резервное копирование.
-    en = Backing up your bookmarks has been suspended. Log in to turn it back on.
-    ar = قد تم تعليق احتياطي المواقع المفضلة لديك. سجل الدخول لإعادة تشغيله.
-    cs = Zálohování značek bylo pozastaveno. Pro zapnutí zálohování vejděte.
-    da = Backup af dine bogmærker er blevet suspenderet. Log ind for at slå til igen.
-    nl = Een back-up van uw bladwijzers werd opgeschort. Log in om weer op te starten.
-    fi = Kirjanmerkkiesi varmuuskopionti on keskeytetty. Kirjaudu sisään ja laita se takaisin päälle.
-    fr = La sauvegarde de vos favoris a été suspendue. Connectez-vous pour la réactiver.
-    de = Das Reservekopieren von Markierungen wurde angehalten. Loggen Sie sich ein, um das Reservekopieren einzuschalten.
-    hu = A könyvjelzői biztonsági mentése felfüggesztésre került. Jelentkezz be a visszakapcsoláshoz.
-    id = Mencadangkan bookmark Anda telah dihentikan. Masuk untuk kembali mengaktifkannya.
-    it = Il backup dei segnalibri è stato sospeso. Accedi per riaccenderlo.
-    ja = ブックマークのバックアップが中断されました。ログインして、元に戻します。
-    ko = 북마크의 백업이 중단되었습니다. 다시 작동시키려면 로그인하세요.
-    no = Sikkerhetslagring av bokmerkene dine er avbrutt. Logg inn for å slå det på.
-    pl = Tworzenie kopii zapasowych Twoich zakładek zostało zawieszone. Zaloguj się, aby włączyć je ponownie.
-    pt = O back-up dos seus favoritos foi suspenso. É preciso logar para ligá-lo de volta.
-    pt-BR = O back up dos seus favoritos foram suspensos. É preciso logar para ligá-lo de volta.
-    ro = Copierea de rezervă a tag-uri lor a fost suspendată. Conectați-vă pentru a activa copierea de rezervă.
-    es = La copia de suguridad de sus marcadores ha sido suspendida. Inicie sesión para volverla a iniciar.
-    es_MX = El respaldo de sus marcadores ha sido suspendido. Inicie sesión para volverlo a iniciar.
-    sv = Säkerhetskopiering av dina bokmärken har avbrutits. Logga in för att starta det igen.
-    th = การเก็บสำรองบุ๊กมาร์กของคุณได้ถูกระงับ เข้าสู่ระบบเพื่อเปิดใช้งานอีกครั้ง
-    tr = Yer imlerinizin yedeklenmesi işlemi askıya alındı. İşlemi devam ettirmek için oturum açın.
-    uk = Резервне копіювання позначок було призупинено. Увійдіть, щоб увімкнути резервне копіювання.
-    vi = Sao lưu dấu trang của bạn đã bị tạm ngưng. Đăng nhập để bật lại.
-    el = Η αποθήκευση των σελιδοδεικτών έχει διακοπεί. Συνδεθείτε για να το ξανανοίξετε.
-    sk = Zálohovanie záložiek bolo pozastavené. Pre opätovné zapnutie sa prihláste.
-    sw = Kucheleza vialamisho vyako kumesitishwa. Ingia ili kuiwasha tena.
-    zh-Hans = 标签备份已暂停。登录以启用备份。
-    zh-Hant = 標籤的備份已暫停。請登錄以啟用設備。
-    fa = پشتیبانگیری از نشانکهای شما به حالت تعلیق درآمده است وارد شوید تا آن را دوباره روشن کنید
+    no = Bruksbetingelser
+    sk = Podmienky používania
+    sw = Masharti ya matumizi
 
   [button_layer_traffic]
-    ru = Пробки
+    tags = android
     en = Traffic
+    ru = Пробки
     ar = حركة مرور
     cs = Zácpy
     da = Trafik
@@ -24216,28 +15273,29 @@
     it = Traffico
     ja = 交通状況
     ko = 트래픽
-    no = Trafikk
     pl = Ruch drogowy
     pt = Tráfego
     pt-BR = Tráfego
     ro = Dopuri
     es = Tráfico
-    es_MX = Tráfico
     sv = Trafik
     th = การจราจร
     tr = Trafik
     uk = Затор
     vi = Giao thông
-    el = Κίνηση
-    sk = Vyťaženie
-    sw = Trafiki
     zh-Hans = 堵塞
     zh-Hant = 堵塞
+    el = Κίνηση
+    es_MX = Tráfico
     fa = ترافیک
+    no = Trafikk
+    sk = Vyťaženie
+    sw = Trafiki
 
   [button_layer_subway]
-    ru = Метро
+    tags = ios, android
     en = Subway
+    ru = Метро
     ar = مترو الانفاق
     cs = Metro
     da = Undergrundsbane
@@ -24250,28 +15308,29 @@
     it = Metropolitana
     ja = 地下鉄
     ko = 지하철
-    no = T-bane
     pl = Metro
     pt = Metrô
     pt-BR = Metro
     ro = Metrou
     es = Metro
-    es_MX = Metro
     sv = Tunnelbana
     th = รถไฟใต้ดิน
     tr = Metro
     uk = Метрополітен
     vi = Xe điện ngầm
-    el = Μετρό
-    sk = Metro
-    sw = Njia ya chini
     zh-Hans = 地铁
     zh-Hant = 地鐵
+    el = Μετρό
+    es_MX = Metro
     fa = مترو
+    no = T-bane
+    sk = Metro
+    sw = Njia ya chini
 
   [layers_title]
-    ru = Слои карты
+    tags = ios, android
     en = Map layers
+    ru = Слои карты
     ar = طبقات الخريطة
     cs = Úrovně mapy
     da = Kortlag
@@ -24284,96 +15343,29 @@
     it = Livelli mappa
     ja = マップレイヤー
     ko = 맵 레이어
-    no = Kartlag
     pl = Warstwy map
     pt = Map Layers
     pt-BR = Camadas de Mapa
     ro = Straturile hărții
     es = Capas del mapa
-    es_MX = Capas del mapa
     sv = Kartlager
     th = ชั้นแผนที่
     tr = Harita katmanları
     uk = Зображення карти
     vi = Các lớp bản đồ
-    el = Επίπεδα του χάρτη
-    sk = Vrstvy mapy
-    sw = Tabaka za ramani
     zh-Hans = 地图图层
     zh-Hant = 地圖圖層
+    el = Επίπεδα του χάρτη
+    es_MX = Capas del mapa
     fa = لایه های نقشه
-
-  [layers_message]
-    ru = Включайте слои на карте для отображения дорожной обстановки, схемы метро или другой полезной информации
-    en = Use map layers to display the traffic, subway map, and other useful information
-    ar = استخدم طبقات الخريطة لعرض حركة المرور ، وخريطة مترو الأنفاق ، وغيرها من المعلومات المفيدة
-    cs = Pro zobrazení situace na silnici, schématu metra či jiné užitečné informace můžete přepínat úrovně mapy.
-    da = Brug kortlag til at vise trafik, kort over undergrundbaner og andre nyttige oplysninger
-    nl = Gebruik „Map layers” voor het weergeven van verkeer, metro, en andere nuttige informatie
-    fi = Käytä kartan tasoja näyttääksesi liikenteen, metrokartan ja muita hyödyllisiä tietoja
-    fr = Utiliser des couches de carte pour afficher le trafic, la carte de métro et d'autres informations utiles
-    de = Schalten Sie die Schichten auf der Karte ein, um die Verkehrssituation, den U-Bahnplan oder sonstige nützlichen Informationen einzublenden
-    hu = Használjon térképrétegeket a forgalom, metrótérkép és más hasznos információ megjelenítéséhez
-    id = Gunakan lapisan peta untuk menampilkan lalu lintas, peta kereta bawah tanah, dan informasi berguna lainnya
-    it = Usa i livelli mappa per visualizzare il traffico, la mappa della metropolitana e altre informazioni utili
-    ja = マップレイヤーを使用して、交通状況、地下鉄路線図、その他の有益な情報を表示
-    ko = 트래픽, 지하철 지도 그리고 기타 유용한 정보를 표시하려면 맵 레이어를 사용하세요.
-    no = Bruk kartlag for å vise trafikk, t-banekart, og annen nyttig informasjon
-    pl = Użyj warstw map, aby wyświetlić ruch drogowy, mapę metra i inne przydatne informacje
-    pt = Utilize o Map Layers para exibir tráfego, mapa do metrô e outras informações úteis
-    pt-BR = Utilize camadas de mapa para exibir o tráfego, mapa de metro e outras informações úteis
-    ro = Conectați straturile pe hartă pentru a afișa rutierele medii, schema de metrou sau alte informații utile
-    es = Utilice las capas del mapa para mostrar el tráfico, el mapa del metro, y otra información útil
-    es_MX = Utilice las capas del mapa para mostrar el tráfico, el mapa del metro, y otra información útil
-    sv = Använd kartlager för att visa trafik, karta över tunnelbanan och annan användbar information
-    th = ใช้ชั้นแผนที่เพื่อแสดงแผนที่ข้อมูลด้านการจราจร รถไฟใต้ดิน และข้อมูลอื่น ๆ ที่เป็นประโยชน์
-    tr = Trafik, metro haritası ve diğer kullanışlı bilgileri görüntülemek için harita katmanlarını kullanın
-    uk = Включайте зображення на карті для відображення дорожнього стану, схеми метрополітену або іншої корисної інформації
-    vi = Sử dụng các lớp bản đồ để hiển thị tình trạng giao thông, bản đồ tàu điện ngầm và các thông tin hữu ích khác
-    el = Χρησιμοποιήστε τα επίπεδα χάρτη για να δείτε την κίνηση, το χάρτη του μετρό και άλλες χρήσιμες πληροφορίες
-    sk = Na zobrazenie návštevnosti, mapy metra a ďalších užitočných informácií použite vrstvy mapy
-    sw = Tumia tabaka za ramani ili kuonyesha trafiki, ramani ya njia ya chini, na maelezo mengine muhimu
-    zh-Hans = 打开在地图上的图层以显示交通状况、地铁图或其他有用信息
-    zh-Hant = 請打開地圖圖層、地鐵圖及其他有用信息來顯示交通狀況。
-    fa = از لایه های نقشه برای نمایش ترافیک، نقشه مترو و سایر اطلاعات مفید استفاده کنید
-
-  [button_layer_got_it]
-    en = Got it
-    ru = Понятно
-    ar = حصلت عليه
-    cs = Rozumím
-    da = Ok
-    nl = Ik begrijp het
-    fi = Ymmärsin
-    fr = J'ai compris
-    de = Alles klar
-    hu = Értem
-    id = Mengerti
-    it = Fatto
-    ja = 了解
-    ko = 알겠습니다.
-    no = Skjønner
-    pl = Rozumiem
-    pt = Entendi
-    pt-BR = Entendi
-    ro = Clar
-    es = Listo
-    es_MX = Listo
-    sv = Förstått
-    th = เข้าใจแล้ว
-    tr = Anladım
-    uk = Зрозуміло
-    vi = Đã hiểu
-    el = Κατάλαβα
-    sk = Mám to
-    sw = Nimeelewa
-    zh-Hans = 明白
-    zh-Hant = 明白
-    fa = متوجه شدم
+    no = Kartlag
+    sk = Vrstvy mapy
+    sw = Tabaka za ramani
 
   [subway_data_unavailable]
-    ru = Карта метро недоступна
+    tags = ios, android
     en = Subway map is unavailable
+    ru = Карта метро недоступна
     ar = خريطة مترو الانفاق غير متوفرة
     cs = Mapa metra není dostupná
     da = Kort over undergrundsbaner er ikke tilgængeligt
@@ -24386,26 +15378,27 @@
     it = La mappa della metropolitana non è disponibile
     ja = 地下鉄路線図はご利用いただけません
     ko = 지하철 지도가 가용하지 않습니다.
-    no = T-banekart er utilgjengelig
     pl = Mapa metra jest niedostępna
     pt = Mapa de metrô está indisponível
     pt-BR = Mapa de metro está indisponível
     ro = Harta de metrou nu este disponibilă
     es = El mapa del metro no está disponible
-    es_MX = El mapa del metro no está disponible
     sv = Kartor över tunnelbana är otillgänglig
     th = แผนที่รถไฟใต้ดินไม่พร้อมใช้งาน
     tr = Metro haritası mevcut değil
     uk = Карта метрополітену недоступна
     vi = Bản đồ tàu điện ngầm không khả dụng
-    el = Ο χάρτης μετρό δεν είναι διαθέσιμος
-    sk = Mapa metra nie je dostupná
-    sw = Ramani ya njia ya chini haipatikani
     zh-Hans = 地铁地图不可用
     zh-Hant = 地鐵圖不可用
+    el = Ο χάρτης μετρό δεν είναι διαθέσιμος
+    es_MX = El mapa del metro no está disponible
     fa = نقشه مترو موجود نیست
+    no = T-banekart er utilgjengelig
+    sk = Mapa metra nie je dostupná
+    sw = Ramani ya njia ya chini haipatikani
 
   [bookmarks_empty_list_title]
+    tags = android
     en = This list is empty
     ru = Список пустой
     ar = هذه اللائحة شاغرة
@@ -24420,26 +15413,27 @@
     it = Questa lista è vuota
     ja = このリストは空です
     ko = 이 목록은 비어있습니다.
-    no = Denne listen er tom
     pl = Lista jest pusta
     pt = Esta lista está vazia
     pt-BR = Esta lista está vazia
     ro = Lista este goală
     es = Esta lista está vacía
-    es_MX = Esta lista está vacía
     sv = Listan är tom
     th = รายการนี้ว่างเปล่า
     tr = Bu liste boş
     uk = Список порожній
     vi = Danh sách trống
-    el = Η λίστα είναι άδεια
-    sk = Tento zoznam je prázdny
-    sw = Orodha hii ni tupu
     zh-Hans = 该列表为空
     zh-Hant = 列表為空
+    el = Η λίστα είναι άδεια
+    es_MX = Esta lista está vacía
     fa = این لیست خالی است
+    no = Denne listen er tom
+    sk = Tento zoznam je prázdny
+    sw = Orodha hii ni tupu
 
   [bookmarks_empty_list_message]
+    tags = android
     en = To add a bookmark, tap a place on the map and then tap the star icon
     ru = Чтобы добавить новую метку, нажмите на значок звездочки в карточке объекта
     ar = لإضافة إشارة مرجعية ، اضغط على مكان على الخريطة ثم انقر فوق رمز النجمة
@@ -24454,26 +15448,27 @@
     it = Per aggiungere un segnalibro, toccare un punto sulla mappa e successivamente toccare l'icona a forma di stella
     ja = ブックマークを追加するには、地図上の場所をタップし、星のアイコンをタップします。
     ko = 북마크를 추가하려면 맵에서 장소를 탭하고 별 모양 아이콘을 탭하세요.
-    no = For å legge til et bokmerke, trykk et sted på kartet og trykk så stjerneikonet
     pl = Aby dodać zakładkę, dotknij miejsca na mapie, a następnie dotknij ikony gwiazdy.
     pt = Para adicionar um favorito, toque em algum lugar do mapa e em seguida no ícone da estrela
     pt-BR = Para adicionar um favorito, toque no mapa e então toque no ícone de estrela
     ro = Pentru a adăuga un nou tag, faceți clic pe pictograma stea în fișa de obiect
     es = Para agregar un marcador, toque un lugar en el mapa y después toque el ícono de estrella
-    es_MX = Para añadir un marcador, toque un lugar en el mapa y después toque el ícono de estrella
     sv = För att lägga till bokmärken, tryck på kartan och sedan på stjärnikonen
     th = เพื่อเพิ่มบุ๊กมาร์ก โปรดแตะที่สถานที่บนแผนที่ แล้วจากนั้นแตะที่ไอคอนรูปดาว
     tr = Yer imi eklemek için önce haritadaki bir yere sonrasında ise yıldız simgesine dokunun
     uk = Щоб додати нову позначку, натисніть на значок зірочки в картці об’єкта
     vi = Để thêm dấu trang, hãy nhấn vào một địa điểm trên bản đồ và sau đó nhấn vào biểu tượng dấu sao
-    el = Για να προσθέσετε σελιδοδείκτη, πατήστε ένα μέρος στο χάρτη και μετά πατήστε το αστεράκι
-    sk = Pre pridanie záložky kliknite na miesto na mape a potom na ikonu hviezdy
-    sw = Ili kuongeza ramani, gusa mahali kwenye ramani na kisha gusa ikoni ya nyota
     zh-Hans = 要添加新标签，请单击对象卡中的星形图标
     zh-Hant = 要添加新標籤，請單擊對象卡片中的星型圖標
+    el = Για να προσθέσετε σελιδοδείκτη, πατήστε ένα μέρος στο χάρτη και μετά πατήστε το αστεράκι
+    es_MX = Para añadir un marcador, toque un lugar en el mapa y después toque el ícono de estrella
     fa = برای افزودن یک نشانه، روی یک مکان روی نقشه ضربه بزنید و سپس روی نماد ستاره ضربه بزنید
+    no = For å legge til et bokmerke, trykk et sted på kartet og trykk så stjerneikonet
+    sk = Pre pridanie záložky kliknite na miesto na mape a potom na ikonu hviezdy
+    sw = Ili kuongeza ramani, gusa mahali kwenye ramani na kisha gusa ikoni ya nyota
 
   [category_desc_more]
+    tags = android
     en = …more
     ru = …еще
     ar = …المزيد
@@ -24488,26 +15483,27 @@
     it = …altro
     ja = 詳細
     ko = …기타 정보
-    no = …mer
     pl = …więcej
     pt = …mais
     pt-BR = …mais
     ro = …mai mult
     es = …más
-    es_MX = …más
     sv = …mer
     th = …เพิ่มเติม
     tr = …daha fazla
     uk = …ще
     vi = …thêm
-    el = …περισσότερα
-    sk = …viac
-    sw = …zaidi
     zh-Hans = …更多
     zh-Hant = …更多
-    fa = بیشتر...
+    el = …περισσότερα
+    es_MX = …más
+    fa = بیشتر…
+    no = …mer
+    sk = …viac
+    sw = …zaidi
 
   [title_error_downloading_bookmarks]
+    tags = ios
     en = An error occurred
     ru = Произошла ошибка
     ar = حدث خطأ
@@ -24522,327 +15518,34 @@
     it = Si è verificato un errore
     ja = エラーが発生しました
     ko = 오류가 발생했습니다.
-    no = Det oppsto en feil
     pl = Wystąpił błąd
     pt = Ocorreu um erro
     pt-BR = Um erro ocorreu
     ro = A apărut o eroare
     es = Se ha producido un error
-    es_MX = Ocurrió un error
     sv = Ett fel har uppstått
     th = มีข้อผิดพลาดเกิดขึ้น
     tr = Bir hata oluştu
     uk = Виникла помилка
     vi = Đã xảy ra lỗi
-    el = Συνέβη σφάλμα
-    sk = Vyskytla sa chyba
-    sw = Kosa limetokea
     zh-Hans = 发生错误
     zh-Hant = 發生錯誤
+    el = Συνέβη σφάλμα
+    es_MX = Ocurrió un error
     fa = خطایی رخ داد
-
-  [subtitle_error_downloading_bookmarks]
-    en = Bookmarks were not downloaded
-    ru = Метки не были загружены
-    ar = لم يتم تنزيل الإشارات
-    cs = Značky se nenahrály
-    da = Bogmærker er ikke blevet downloadet
-    nl = Bladwijzers werden niet gedownload
-    fi = Kirjanmerkkejä ei ole ladattu
-    fr = Les signets n'ont pas été téléchargés
-    de = Die Markierungen wurden nicht geladen
-    hu = Nem került letöltésre könyvjelző
-    id = Bookmark tidak terunduh
-    it = I segnalibri non sono stati scaricati
-    ja = ブックマークはダウンロードされませんでした
-    ko = 북마크가 다운로드 되지 않았습니다.
-    no = Bokmerker ble ikke lastet ned
-    pl = Zakładki nie zostały pobrane
-    pt = Favoritos não foram baixados
-    pt-BR = Favoritos não foram baixados
-    ro = Tag-urile nu au fost încărcate
-    es = Los marcadores no se descargaron
-    es_MX = Los marcadores no se descargaron
-    sv = Bokmärkena laddades inte ner
-    th = ไม่ได้ดาวน์โหลดบุ๊กมาร์ก
-    tr = Yer imleri indirilmedi
-    uk = Позначки не були завантажені
-    vi = Dấu trang chưa được tải xuống
-    el = Οι σελιδοδείκτες δεν κατέβηκαν
-    sk = Záložky neboli stiahnuté
-    sw = Vialamisho havikupakuliwa
-    zh-Hans = 标签尚未上传
-    zh-Hant = 標籤未加載
-    fa = نشانه ها دانلود نشدند
-
-  [error_already_downloaded]
-    en = This list has already been downloaded
-    ru = Этот список уже был загружен
-    ar = تم بالفعل تنزيل هذه القائمة
-    cs = Tento seznam byl již stažen
-    da = Denne liste er allerede blevet downloadet
-    nl = Deze lijst is al gedownload
-    fi = Tämä lista on jo ladattu
-    fr = Cette liste a déjà été téléchargée
-    de = Diese Liste wurde bereits heruntergeladen
-    hu = Ezt a listát már letöltötték
-    id = Daftar ini sudah diunduh
-    it = Questa lista è già stata scaricata
-    ja = このリストは既にダウンロード済みです
-    ko = 해당 목록을 이미 다운로드 하였습니다.
-    no = Denne listen har allerede blitt lastet ned
-    pl = Ta lista została już pobrana
-    pt = Esta lista já foi transferida
-    pt-BR = Essa lista já foi baixada
-    ro = Lista aceasta a fost descărcată deja
-    es = Esta lista ya se ha descargado
-    es_MX = Ya se descargó esta lista
-    sv = Den här listan har redan laddats ned
-    th = มีการดาวน์โหลดรายการนี้แล้ว
-    tr = Bu liste zaten indirildi
-    uk = Цей список вже завантажений
-    vi = Danh sách này đã được tải về
-    el = Έχει γίνει ήδη λήψη αυτής της λίστας
-    sk = Tento zoznam už bol stiahnutý
-    sw = Orodha hii imepakuliwa tayari
-    zh-Hans = 这个列表已被下载
-    zh-Hant =  這個列表已被下載
-    fa = این لیست قبلا دانلود شده است
-
+    no = Det oppsto en feil
+    sk = Vyskytla sa chyba
+    sw = Kosa limetokea
 
   [popular_place]
+    tags = ios
     en = Popular
     ru = Популярно
-    fa = مشهور
     fr = Populaire
-
-  [download_routes]
-    en = Download routes
-    ru = Загрузить маршруты
-    fa = دانلود مسیر
-    fr = Télécharger itinéraires
-
-  [bookmarks_downloaded_title]
-    en = Bookmarks have been downloaded successfully
-    ru = Метки были успешно загружены
-    fa = نشانکها با موفقیت دانلود شدند
-    fr = Signets téléchargés avec succès
-
-  [bookmarks_downloaded_subtitle]
-    en = Press ‘View on map’ to explore new places from the list
-    ru = Нажмите «Посмотреть на карте» чтобы посмотреть новые места из списка
-    fa = 'نمایش بر روی نقشه' را فشار دهید تا مکان های جدید را از لیست کاوش کنید
-    fr = Appuyez sur 'Rechercher sur la carte' pour explorer les endroits sur la liste
-
-  [why_support]
-    en = Why support Organic Maps?
-    ru = Зачем поддерживать Organic Maps?
-    ar = لماذا تدعم Organic Maps؟
-    cs = Proč podporovat Organic Maps?
-    da = Hvorfor støtte Organic Maps?
-    nl = Waarom Organic Maps ondersteunen?
-    fi = Miksi tukea Organic Maps?
-    fr = Pourquoi soutenir Organic Maps ?
-    de = Warum Organic Maps unterstützen?
-    hu = Miért éri meg támogatni a Organic Maps-t?
-    id = Kenapa dukungan Organic Maps?
-    it = Perché sostenere Organic Maps?
-    ja = Organic Mapsをサポートする理由？
-    ko = 왜 Organic Maps를 지원하죠?
-    no = Hvorfor å støtte Organic Maps?
-    pl = Po co wspierać Organic Maps?
-    pt = Porquê apoiar o Organic Maps?
-    pt-BR = Por que apoiar Organic Maps?
-    ro = Pentru ce să susțineți Organic Maps?
-    es = ¿Por qué apoyar a Organic Maps?
-    es_MX = ¿Por qué apoyar Organic Maps?
-    sv = Varför stödja Organic Maps?
-    th = ทำไมถึงควรใช้บริการ Organic Maps?
-    tr = Organic Maps'yi neden desteklemeliyim?
-    uk = Навіщо підтримувати Organic Maps?
-    vi = Tại sao hỗ trợ Organic Maps?
-    el = Γιατί να υποστηρίξετε το Organic Maps?
-    sk = Prečo podporiť Organic Maps?
-    sw = Kwa nini unapenda Organic Maps?
-    zh-Hans = 为什么支持Organic Maps?
-    zh-Hant = 為什麼支持Organic Maps?
-    fa = چرا پشتیبانی از Organic Maps؟
-
-  [why_support_item1]
-    en = We respect your privacy: there are zero trackers in the app, and we are open source
-    ru = Мы никому не отсылаем ваши личные данные, а исходный код нашего приложения открыт
-
-  [why_support_item2]
-    en = You help us to improve Organic Maps
-    ru = Вы помогаете нам улучшать Organic Maps
-    ar = أنت تساعدنا على تحسين Organic Maps
-    cs = Pomáháte nám zlepšovat Organic Maps
-    da = Du hjælper os med at forbedre Organic Maps
-    nl = U helpt ons Organic Maps te verbeteren
-    fi = Sinä autat meitä parantamaan Organic Maps:tä
-    fr = Vous nous aidez à améliorer Organic Maps
-    de = Sie helfen uns Organic Maps zu verbesern
-    hu = Ön segít a Organic Maps-t fejleszteni
-    id = Anda membantu kami meningkatkan Organic Maps
-    it = Voi ci aiutate a migliorare Organic Maps
-    ja = Organic Mapsの改善にご協力いただいております
-    ko = 당신은 Organic Maps를 개선하는데 우리를 도와주세요
-    no = Du hjelper oss o forbedre Organic Maps
-    pl = Pomagasz nam udoskonalać Organic Maps
-    pt = Ajude-nos a melhorar o Organic Maps
-    pt-BR = Você nos ajuda a melhorar o Organic Maps
-    ro = Voi ne ajutați să îmbunătățim Organic Maps
-    es = Usted nos ayuda a mejorar a Organic Maps
-    es_MX = Usted nos ayuda a mejorar Organic Maps
-    sv = Du hjälper oss att förbättra Organic Maps
-    th = คุณช่วยเราพัฒนา Organic Maps
-    tr = Organic Maps'yi geliştirmemize yardımcı oldunuz
-    uk = Ви допомагаєте нам покращувати Organic Maps
-    vi = You help us to improve Organic Maps
-    el = Μας βοηθάτε να βελτιώσουμε το Organic Maps
-    sk = Pomôžete nám zlepšiť Organic Maps
-    sw = Tusaidie kuboresha Organic Maps
-    zh-Hans = 您帮助我们改进Organic Maps
-    zh-Hant = 您幫助我們改進Organic Maps
-    fa = شما برای بهبود Organic Maps به ما کمک میکنید
-
-  [why_support_item3]
-    en = You help us improve open maps OpenStreetMap.org
-    ru = Вы помогаете нам улучшать карты OpenStreetMap.org
-    ar = يمكنك مساعدتنا في تحسين خرائط مفتوحة OpenStreetMap.org
-    cs = Pomáháte nám zlepšovat mapy OpenStreetMap.org
-    da = Du hjælper os med at forbedre de åbne kort på OpenStreetMap.org
-    nl = U helpt ons de kaarten van OpenStreetMap.org te verbeteren
-    fi = Auta meitä parantamaan avoimia karttoja OpenStreetMap.org
-    fr = Vous nous aidez à améliorer les cartes ouvertes OpenStreetMap.org
-    de = Sie helfen uns die Karten OpenStreetMap.org zu verbessern
-    hu = Segítsen a térkép fejlesztésében az OpenStreetMap.org-on
-    id = Anda membantu kami meningkatkan peta terbuka OpenStreetMap.org
-    it = Ci aiutate a migliorare le mappe OpenStreetMap.org
-    ja = オープンマップOpenStreetMap.orgの改善にご協力いただいております
-    ko = 오픈 지도들 OpenStreetMap.org를 개선하는데 도와주세요
-    no = Du hjelper oss å forbedre kart på OpenStreetMap.org
-    pl = Pomagasz nam udoskonalać mapy OpenStreetMap.org
-    pt = Ajude-nos a melhorar mapas livres em OpenStreeMap.org
-    pt-BR = Você nos ajuda a melhorar mapas livres em OpenStreeMap.org
-    ro = Voi ne ajutați să îmbunătățim hărțile OpenStreetMap.org
-    es = Nos está ayudando a mejorar los mapas de OpenStreetMap.org
-    es_MX = Usted nos ayuda a mejorar los mapas abiertos en OpenStreetMap.org
-    sv = Du hjälper oss att förbättra de offentliga kartorna OpenStreetMap.org
-    th = คุณช่วยเราพัฒนาแผนที่ที่เปิดให้คนทั่วไปเข้าใช้งานของ OpenStreetMap.org
-    tr = OpenStreetMap.org'daki açık haritaları geliştirmemize yardımcı oldunuz
-    uk = Ви допомагаєте нам покращувати карти OpenStreetMap.org
-    vi = Bạn giúp chúng tôi cải thiện bản đồ mở OpenStreetMap.org
-    el = Μας βοηθάτε να βελτιώσουμε ανοιχτούς χάρτες στο OpenStreetMap.org
-    sk = Pomôžete nám vylepšiť otvorené mapy OpenStreetMap.org
-    sw = Tusaidie kuboresha ramani huria OpenStreetMap.org
-    zh-Hans = 您帮助我们改进OpenStreetMap.org地图
-    zh-Hant = 您幫助我們改進OpenStreetMap.org地圖
-    fa = شما به ما در بهبود نقشه OpenStreetMap.org کمک میکنید.
-
-  [channels_map_update]
-    en = Map updates
-    ru = Обновления карт
-    ar = تحديثات الخريطة
-    cs = Aktualizace map
-    da = Kortopdateringer
-    nl = Kaartupdates
-    fi = Kartan päivitykset
-    fr = Mises à jour de la carte
-    de = Kartenaktualisierungen
-    hu = Térképfrissítések
-    id = Pembaruan peta
-    it = Rinnovare la carta
-    ja = 地図の更新
-    ko = 지도 업데이트
-    no = Oppdatere kart
-    pl = Aktualizacja map
-    pt = Atualizações de mapa
-    pt-BR = Atualizações de mapa
-    ro = Actualizarea hărților
-    es = Actualización de los mapas
-    es_MX = Actualizaciones de mapas
-    sv = Uppdatering av kartor
-    th = อัพเดตโรงแรม
-    tr = Harita güncellemeleri
-    uk = Оновлення карт
-    vi = Cập nhật bản đồ
-    el = Ενημερώσεις χάρτη
-    sk = Aktualizácia máp
-    sw = Sasisho za ramani
-    zh-Hans = 更新地图
-    zh-Hant = 更新地圖
-    fa = بروزرسانی های نقشه
-
-  [server_unavailable_title]
-    en = Server is unavailable
-    ru = Сервер недоступен
-    ar = الخدمة غير متوفرة
-    cs = Sever je nedostupný
-    da = Server er utilgængelig
-    nl = Server niet beschikbaar
-    fi = Serveri ei ole saatavilla
-    fr = Le serveur n'est pas disponible
-    de = Server unzugänglich
-    hu = A szerver nem elérhető
-    id = Server tidak tersedia
-    it = Server non è disponibile
-    ja = サーバーは利用できません
-    ko = 서버를 사용할 수 없습니다
-    no = Serveren er ikke tilgjengelig
-    pl = Serwer jest niedostępny
-    pt = O servidor está indisponível
-    pt-BR = Servidor está indisponível
-    ro = Serverul nu este disponibil
-    es = Servidor no disponible
-    es_MX = El servidor no está disponible
-    sv = Servern är inte tillgänglig
-    th = ไม่สามารถเข้าถึงเซิร์ฟเวอร์
-    tr = Hizmet kullanılamıyor
-    uk = Сервер недоступний
-    vi = Máy chủ không khả dụng
-    el = Ο εξυπηρετητής δεν είναι διαθέσιμος
-    sk = Server je nedostupný
-    sw = Seva haipatikani
-    zh-Hans = 服务不可用
-    zh-Hant = 服務不可用
-    fa = سرویس موجود نیست
-
-  [sharing_options]
-    en = Sharing options
-    ru = Настройки доступа
-    ar = خيارات المشاركة
-    cs = Nastavení přístupu
-    da = Deling
-    nl = Opties voor delen
-    fi = Käyttöasetukset
-    fr = Options de partage
-    de = Zugriffseinstellungen
-    hu = A hozzáférés beállításai
-    id = Opsi berbagi
-    it = Impostazione accesso
-    ja = オプションの共有
-    ko = 옵션 공유
-    nb = Delemuligheter
-    pl = Ustawienia dostępu
-    pt = Definições de acesso
-    pt-BR = Opções de compartilhamento
-    ro = Setările accesului
-    es = Configuración de acceso
-    es-MX = Opciones para compartir
-    sv = Åtkomstinställningar
-    th = ตัวเลือกการแชร์
-    tr = Paylaşma seçenekleri
-    uk = Налаштування доступу
-    vi = Chia sẻ lựa chọn
-    el = Επιλογές κοινοποίησης
-    sk = Možnosti zdieľania
-    sw = Badilishana machaguo
-    zh-Hans = 登录设置
-    zh-Hant = 登錄設置
-    fa = گزینه های اشتراک گذاری
+    fa = مشهور
 
   [export_file]
+    tags = android
     en = Export file
     ru = Экспортировать файл
     ar = ملف التصدير
@@ -24863,20 +15566,21 @@
     pt-BR = Exportar arquivo
     ro = Exportați fișierul
     es = Exportar como archivo
-    es-MX = Exportar archivo
     sv = Exportera fil
     th = ส่งออกไฟล์
     tr = Dosyayı dışa aktar
     uk = Експортувати файл
     vi = Xuất tập tin
-    el = Αρχείο Εξαγωγής
-    sk = Exportovať súbor
-    sw = Tuma faili
     zh-Hans = 导出文件
     zh-Hant = 導出文件
+    el = Αρχείο Εξαγωγής
+    es-MX = Exportar archivo
     fa = ارسال فایل
+    sk = Exportovať súbor
+    sw = Tuma faili
 
   [list_settings]
+    tags = android
     en = List Settings
     ru = Настройки списка
     ar = قائمة الإعدادات
@@ -24897,20 +15601,21 @@
     pt-BR = Configurações de Lista
     ro = Elaborarea listei
     es = Configurar lista
-    es-MX = Ajustes de lista
     sv = Listinställningar
     th = การตั้งค่ารายการ
     tr = Liste Ayarları
     uk = Налаштування списку
     vi = Cài đặt danh sách
-    el = Ρυθμίσεις Λίστας
-    sk = Nastavenie zoznamu
-    sw = Mipangilio ya Orodhesha
     zh-Hans = 列表设置
     zh-Hant = 列表設置
+    el = Ρυθμίσεις Λίστας
+    es-MX = Ajustes de lista
     fa = تنظیمات لیست
+    sk = Nastavenie zoznamu
+    sw = Mipangilio ya Orodhesha
 
   [delete_list]
+    tags = android
     en = Delete list
     ru = Удалить список
     ar = حذف القائمة
@@ -24931,54 +15636,21 @@
     pt-BR = Deletar lista
     ro = Ștergerea listei
     es = Eliminar lista
-    es-MX = Eliminar lista
     sv = Radera listan
     th = ลบรายการ
     tr = Listeyi sil
     uk = Видалити список
     vi = Xóa danh sách
-    el = Διαγραφή λίστας
-    sk = Vymazať zoznam
-    sw = Futa Orodha
     zh-Hans = 删除列表
     zh-Hant = 刪除列表
+    el = Διαγραφή λίστας
+    es-MX = Eliminar lista
     fa = حذف لیست
-
-  [hide_from_map]
-    en = Hide from map
-    ru = Скрыть с карты
-    ar = إخفاء من الخريطة
-    cs = Neukazovat na mapě
-    da = Skjul på kort
-    nl = Van de kaart verbergen
-    fi = Piilottaa kartalta
-    fr = Masquer de la carte
-    de = Auf der Karte ausblenden
-    hu = Lefedés a térképen
-    id = Sembunyikan dari peta
-    it = Nascondere sulla mappa
-    ja = マップから隠す
-    ko = 지도에서 숨기기
-    nb = Skjul fra kart
-    pl = Ukryj mapy
-    pt = Remover do mapa
-    pt-BR = Esconder do mapa
-    ro = Ascundeți de pe hartă
-    es = Ocultar en el mapa
-    es-MX = Ocultar del mapa
-    sv = Dölj från kort
-    th = ซ่อนจากแผนที่
-    tr = Haritadan gizle
-    uk = Приховати з карти
-    vi = Ẩn từ bản đồ
-    el = Κρύψε από τον χάρτη
-    sk = Skryť z mapy
-    sw = Ficha kwenye ramani
-    zh-Hans = 从卡中隐藏
-    zh-Hant = 從卡中隱藏
-    fa = پنهان کردن از نقشه
+    sk = Vymazať zoznam
+    sw = Futa Orodha
 
   [public_access]
+    tags = android
     en = Public access
     ru = Публичный доступ
     ar = إطلاع الجمهور
@@ -24999,20 +15671,21 @@
     pt-BR = Acesso público
     ro = Acces public
     es = Acceso público
-    es-MX = Acceso público
     sv = Allmänhetens åtkomst
     th = เข้าถึงได้โดยสาธารณะ
     tr = Genel erişim
     uk = Публічний доступ
     vi = Truy cập công khai
-    el = Δημόσια πρόσβαση
-    sk = Verejný prístup
-    sw = Matumizi ya umma
     zh-Hans = 公共访问
     zh-Hant = 公共訪問
+    el = Δημόσια πρόσβαση
+    es-MX = Acceso público
     fa = دسترسی عمومی
+    sk = Verejný prístup
+    sw = Matumizi ya umma
 
   [limited_access]
+    tags = android
     en = Limited access
     ru = Ограниченный доступ
     ar = محدودية فرص حصول
@@ -25033,21 +15706,21 @@
     pt-BR = Acesso limitado
     ro = Acces privat
     es = Acceso privado
-    es-MX = Acceso limitado
     sv = Privat åtkomst
     th = จำกัดการเข้าถึง
     tr = Sınırlı erişim
     uk = Приватний доступ
     vi = Truy cập hạn chế
-    el = Περιορισμένη πρόσβαση
-    sk = Obmedzený prístup
-    sw = Matumizi yenye ukomo
     zh-Hans = 私人访问
     zh-Hant = 私人訪問
+    el = Περιορισμένη πρόσβαση
+    es-MX = Acceso limitado
     fa = دسترسی محدود
+    sk = Obmedzený prístup
+    sw = Matumizi yenye ukomo
 
   [bookmark_category_name]
-    tags = ios, android
+    tags = android
     en = Category
     ru = Категория
     ar = الفئة
@@ -25076,10 +15749,11 @@
     zh-Hans = 类别
     zh-Hant = 類別
     el = Κατηγορία
-    sk = Kategória
     fa = دسته بندی
+    sk = Kategória
 
   [bookmark_category_description_hint]
+    tags = android
     en = Type a description (text or html)
     ru = Добавьте описание (текст или html)
     ar = اكتب وصفًا (نص أو html)
@@ -25100,32 +15774,21 @@
     pt-BR = Digite uma descrição (texto ou html)
     ro = Adăugați o descriere (text sau html)
     es = Agregue una descripción (texto o html)
-    es-MX = Introduzca una descripción (texto o html)
     sv = Lägg till en beskrivning (text eller html)
     th = พิมพ์รายละเอียด (ข้อความหรือ html)
     tr = Bir açıklama yazın (metin veya html)
     uk = Додайте опис (текст чи html)
     vi = Đánh vào một mô tả (văn bản hoặc html)
-    el = Πληκτρολογήστε μια περιγραφή (κείμενο ή html)
-    sk = Zadajte popis (text alebo html)
-    sw = Andika maelezo (maneno au html)
     zh-Hans = 请添加说明(文字或html)
     zh-Hant = 添加說明(文字或html)
+    el = Πληκτρολογήστε μια περιγραφή (κείμενο ή html)
+    es-MX = Introduzca una descripción (texto o html)
     fa = یک توضیح (متن یا html) تایپ نمایید
-
-  [bookmarks_public_access]
-    comment = FIXME
-    en = bookmarks_public_access
-
-  [bookmarks_link_access]
-    comment = FIXME
-    en = bookmarks_link_access
-
-  [bookmarks_private_access]
-    comment = FIXME
-    en = bookmarks_private_access
+    sk = Zadajte popis (text alebo html)
+    sw = Andika maelezo (maneno au html)
 
   [not_shared]
+    tags = android
     en = Private
     ru = Личный
     ar = خاص
@@ -25146,156 +15809,21 @@
     pt-BR = Privado
     ro = Personal
     es = Personal
-    es-MX = Privado
     sv = Personlig
     th = ส่วนตัว
     tr = Şahsi
     uk = Особистий
     vi = Riêng tư
-    el = Προσωπικός
-    sk = Súkromné
-    sw = Faragha
     zh-Hans = 个人
     zh-Hant = 個人
+    el = Προσωπικός
+    es-MX = Privado
     fa = خصوصی
-
-  [direct_link_progress_text]
-    en = Uploading your file…
-    ru = Загружаем ваш файл…
-    ar = جارٍ تحميل ملفك…
-    cs = Váš soubor se nahrává…
-    da = Uploader din fil…
-    nl = Uw bestand aan het uploaden…
-    fi = Lataamme tiedostoanne…
-    fr = Télécharger votre fichier…
-    de = Ihre Datei wird geladen…
-    hu = Betöltjük az Ön fájlát…
-    id = Mengunggah file Anda…
-    it = Il file si sta caricando…
-    ja = あなたのファイルをアップロードしています…
-    ko = 당신의 파일을 업로드 중…
-    nb = Laster opp filen din…
-    pl = Trwa pobieranie Twojego pliku…
-    pt = A carregar o seu arquivo…
-    pt-BR = Carregando seu arquivo…
-    ro = Încărcăm fișierul dumneavoastră…
-    es = Cargando su archivo…
-    es-MX = Cargando su archivo…
-    sv = Laddar upp din fil…
-    th = กำลังอัพโหลดไฟล์ของคุณ…
-    tr = Dosyanız yükleniyor…
-    uk = Завантажуємо ваш файл…
-    vi = Đang tải tập tin của bạn…
-    el = Ανεβάζουμε το αρχείο σας…
-    sk = Nahrávanie váľho súboru…
-    sw = Inapakia faili lako…
-    zh-Hans = 正在上传您的文件......
-    zh-Hant = 正在上傳您的文件......
-    fa = در حال بارگذاری فایل شما…
-
-  [direct_link_success]
-    en = The link has been created
-    ru = Ссылка создана
-    ar = لقد تم إنشاء الرابط
-    cs = Odkaz byl vytvořen
-    da = Linket er blevet oprettet
-    nl = De link is aangemaakt
-    fi = Linkki on luotu
-    fr = Le lien a été créé
-    de = Link erstellt
-    hu = A hivatkozás létre van hozva
-    id = Tautan telah dibuat
-    it = Il link è stato creato
-    ja = リンクが作成されました
-    ko = 링크가 만들어졌습니다
-    nb = Lenken er opprettet
-    pl = Link został utworzony
-    pt = Link criado
-    pt-BR = O link foi criado
-    ro = Linkul a fost creat
-    es = Enlace creado
-    es-MX = El enlace fue creado
-    sv = Länk skapad
-    th = ลิงค์ถูกสร้างแล้ว
-    tr = Bağlantı oluşturuldu
-    uk = Посилання створено
-    vi = Liên kết đã được tạo
-    el = Ο σύνδεσμος δημιουργήθηκε
-    sk = Odkaz bol vytvorený
-    sw = Kiunganishi kimeundwa
-    zh-Hans = 链接已创建
-    zh-Hant = 鏈接已創建
-    fa = لینک ایجاد شده است
-
-  [send_a_link_btn]
-    en = Send me a link
-    ru = Отправить ссылку
-    ar = ارسل لي رابط
-    cs = Poslat odkaz
-    da = Send mig et link
-    nl = Stuur mij een link
-    fi = Lähetä linkki
-    fr = Envoyez moi un lien
-    de = Link senden
-    hu = Hivatkozás küldése
-    id = Kirim tautan ke saya
-    it = Mandare il link
-    ja = リンクを自分に送る
-    ko = 나에게 링크 보내기
-    nb = Send meg en link
-    pl = Wyślij link
-    pt = Enviar link
-    pt-BR = Envie um link para mim
-    ro = Trimiteți linkul
-    es = Enviar enlace
-    es-MX = Envíenme un enlace
-    sv = Skicka länk
-    th = ส่งลิงค์ให้ฉัน
-    tr = Bana bir bağlantı gönder
-    uk = Надіслати посилання
-    vi = Gửi cho tôi liên kết
-    el = Στείλε μου έναν σύνδεσμο
-    sk = Poslať mi odkaz
-    sw = Nitumie kiunganishi
-    zh-Hans = 发送链接
-    zh-Hant = 發送鏈接
-    fa = یک لینک برای من ارسال کن
-
-  [upload_error_toast]
-    en = An error occurred while uploading your file
-    ru = Во время загрузки файла произошла ошибка
-    ar = حدث خطأ أثناء تحميل ملفك
-    cs = Během nahrávání souboru se stala chyba
-    da = Der skete en fejl under upload af filen
-    nl = Er is een fout opgetreden tijdens het uploaden van uw bestand
-    fi = Tiedoston lataamisen aikana tapahtui virhe
-    fr = Une erreur s'est produite lors du téléchargement de votre fichier
-    de = Während des Ladeprozesses ist ein Fehler aufgetreten
-    hu = A fájl feltöltésekor hiba történt
-    id = Kesalahan terjadi saat mengunggah file Anda
-    it = Errore durante il caricamento
-    ja = ファイルのアップロード中にエラーが起きました
-    ko = 당신의 파일을 업로드 중에 에러가 발생했습니다
-    nb = Det oppsto en feil under opplasting av filen
-    pl = Wystąpił błąd podczas pobierania pliku
-    pt = Ocorreu um erro ao carregar o arquivo
-    pt-BR = Um erro ocorreu ao carregar seu arquivo
-    ro = În timpul încărcării fișierului s-a produs o eroare
-    es = Se produjo un error durante la carga del archivo
-    es-MX = Ocurrió un error al cargar su archivo
-    sv = Ett fel uppstod när du laddar filen
-    th = เกิดข้อผิดพลาดขณะอัพโหลดไฟล์ของคุณ
-    tr = Dosyanızı yüklerken bir hata oluştu
-    uk = Під час завантаження файлу сталася помилка
-    vi = Đã xảy ra lỗi trong khi tải lên tập tin của bạn
-    el = Ένα σφάλμα συνέβη στο ανέβασμα του αρχείου σας
-    sk = Počas nahrávania súboru sa vyskytla chyba
-    sw = Kosa limetokea wakati unapakia faili lako
-    zh-Hans = 加载文件时出错
-    zh-Hant = 加載文件時出錯
-    fa = هنگام بارگذاری فایل شما خطایی روی داد
+    sk = Súkromné
+    sw = Faragha
 
   [tags_loading_error_subtitle]
+    tags = ios
     en = An error occurred while loading tags, please try again
     ru = Во время загрузки тегов произошла ошибка, пожалуйста, попробуйте еще раз
     ar = حدث خطأ أثناء تحميل العلامات ، يرجى المحاولة مرة أخرى
@@ -25316,190 +15844,21 @@
     pt-BR = Um erro ocorreu enquanto carregava as tags, por favor, tente novamente
     ro = În timpul încărcării tag-urilor s-a produs o eroare, vă rugăm să încercați încă odată
     es = Durante la carga de las etiquetas, se produjo un error, por favor inténtelo de nuevo
-    es-MX = Ocurrió un error al cargar las etiquetas, por favor intente de nuevo
     sv = Ett fel uppstod när du laddar taggarna, försök igen
     th = เกิดข้อผิดพลาดขณะโหลดแท็ก โปรดลองใหม่อีกครั้ง
     tr = Etiketler yüklenirken bir hata oluştu, lütfen tekrar deneyin
     uk = Під час завантаження тегів сталася помилка, будь ласка, спробуйте ще раз
     vi = Đã xảy ra lỗi khi tải thẻ, vui lòng thử lại
-    el = Ένα σφάλμα συνέβη στο φόρτωμα των ετικετών, παρακαλώ ξαναπροσπαθήστε
-    sk = Počas načítavania značiek sa vyskytla chyba, skúste to znova
-    sw = Kosa limetokea wakati wa kupakua vibandiko, tafadhali jaribu tena
     zh-Hans = 加载标签时出错，请重试
     zh-Hant = 加載代碼時出錯，請重試
+    el = Ένα σφάλμα συνέβη στο φόρτωμα των ετικετών, παρακαλώ ξαναπροσπαθήστε
+    es-MX = Ocurrió un error al cargar las etiquetas, por favor intente de nuevo
     fa = هنگام بارگذاری برچسب خطایی رخ داد، لطفا دوباره امتحان کنید
-
-  [unable_upload_errorr_title]
-    en = File upload failed
-    ru = Не удалось загрузить файл
-    ar = فشل تحميل الملف
-    cs = Soubor se nepodařilo nahrát
-    da = Upload af fil fejlede
-    nl = Bestand uploaden mislukt
-    fi = Tiedoston lataamisen epäonnistui
-    fr = Échec du téléchargement du fichier
-    de = Laden der Datei fehlgeschlagen
-    hu = Nem sikerült a fájl feltöltése
-    id = Gagal mengunggah file
-    it = Il file non è stato caricato
-    ja = ファイルのアップロードができませんでした
-    ko = 파일 업로드 실패
-    nb = Filopplasting mislyktes
-    pl = Nie udało się przesłać pliku
-    pt = Não foi possível carregar arquivo
-    pt-BR = Carregamento de arquivo falhou
-    ro = Încărcarea fișierului nu s-a primit
-    es = No se pudo cargar el archivo
-    es-MX = Error al cargar el archivo
-    sv = Det gick inte att ladda upp filen
-    th = การอัพโหลดไฟล์ล้มเหลว
-    tr = Dosya yükleme başarısız
-    uk = Не вдалося завантажити файл
-    vi = Tải tập tin lên không thành công
-    el = Το ανέβασμα του αρχείου απέτυχε
-    sk = Nahrávanie súboru zlyhalo
-    sw = Kupakia faili kumeshindikana
-    zh-Hans = 无法上传文件
-    zh-Hant = 無法上傳文件
-    fa = بارگذاری فایل انجام نشد
-
-  [unable_upload_error_subtitle_edited]
-    en = This file has been edited via the web app
-    ru = Файл был отредактирован через веб-приложение
-    ar = تم تحرير هذا الملف عبر تطبيق الويب
-    cs = Soubor byl upraven pomocí webové aplikace
-    da = Denne fil er redigeret ved hjælp af web-appen
-    nl = Dit bestand is bewerkt via de web app
-    fi = Tiedosto muokattiin web-sovelluksen kautta
-    fr = Ce fichier a été édité via l'application Web
-    de = Datei wurde per WebApp bearbeitet
-    hu = A fájl a web alkalmazáson keresztül volt újraszerkesztve
-    id = File telah diedit melalui aplikasi web
-    it = Il file è stato modificato tramite web App
-    ja = このファイルはウェブアプリで編集されました
-    ko = 이 파일은 웹 앱을 통해 수정되었습니다
-    nb = Denne filen har blitt redigert via nettappappen
-    pl = Plik edytowano za pomocą aplikacji internetowej
-    pt = O arquivo foi editado através da uma aplicação web
-    pt-BR = Este arquivo foi editado através do aplicativo web
-    ro = Fișierul a fost editat prin intermediul aplicației web
-    es = El archivo fue editado a través de la aplicación web
-    es-MX = Este archivo ha sido editado a través de la aplicación web
-    sv = Filen har redigerats via webbapplikation
-    th = ไฟล์นั้นถูกแก้ไขผ่านทางเว็บแอพ
-    tr = Bu dosya web uygulamasıyla düzenlendi
-    uk = Файл було відредаговано через веб-застосунок
-    vi = Tập tin này đã được chỉnh sửa qua ứng dụng web
-    el = Το αρχείο επεξεργάστηκε μέσω της εφαρμογής
-    sk = Tento súbor bol upravený prostredníctvom webovej aplikácie
-    sw = Faili hili limehaririwa kupitia programu ya mtandaoni
-    zh-Hans = 文件是通过Web应用程序编辑的
-    zh-Hant = 文件是通過Web應用程序編輯的
-    fa = این فایل از طریق برنامه وب ویرایش شده است
-
-  [unable_upload_error_subtitle_broken]
-    en = This file is damaged and couldn't be uploaded. Please upload another file.
-    ru = Файл поврежден и не может быть загружен. Пожалуйста, загрузите другой файл.
-    ar = هذا الملف تالف ولا يمكن تحميله. يرجى تحميل ملف آخر.
-    cs = Soubor je poškozen a nemůže být nahrán. Nahrajte prosím jiný soubor.
-    da = Denne fil er beskadiget og kunne ikke uploades. Upload venligst en anden fil.
-    nl = Dit bestand is beschadigd en kon niet worden geüpload. Gelieve een ander bestand te uploaden.
-    fi = Tiedosto on vioittunut eikä sitä voi ladata. Ole hyvä, lataa toinen tiedosto.
-    fr = Ce fichier est endommagé et n'a pas pu être téléchargé. S'il vous plaît télécharger un autre fichier.
-    de = Datei ist beschädigt und kann nicht geladen werden. Bitte laden Sie eine andere Datei.
-    hu = A fájl sérült és nem lehet feltölteni. Kérjük, más fájlt töltsön fel.
-    id = File rusak dan tidak dapat diunggah. Silakan unggah file lain.
-    it = Il file è danneggiato e non può essere caricato. Si prega di caricare un altro file.
-    ja = このファイルは損傷しており、アップロードできませんでした。別のファイルをアップロードしてください。
-    ko = 파일이 망가져서 업로드를 할 수 없습니다. 다른 파일을 업로드하세요.
-    nb = Denne filen er skadet og kan ikke lastes opp. Vennligst last opp en annen fil.
-    pl = Plik jest uszkodzony i nie można go załadować. Proszę przesłać inny plik.
-    pt = Arquivo corrompido e não pode ser carregado. Por favor, carregue outro arquivo.
-    pt-BR = Este arquivo está danificado e não pode ser carregado. Por favor, carregue outro arquivo.
-    ro = Fișierul a fost deteriorat și nu poate fi încărcat. Vă rugăm, alegeți alt fișier.
-    es = El archivo está dañado y no se puede cargar. Por favor, suba otro archivo.
-    es-MX = Este archivo está dañado y no pudo cargarse. Por favor cargue otro archivo.
-    sv = Filen är skadad och kan inte laddas upp. Var vänlig ladda upp en annan fil.
-    th = ไฟล์นั้นเสียหายและไม่สามารถอัพโหลดได้ โปรอัพโหลดไฟล์อื่นแทน
-    tr = Bu dosya bozuk olduğundan yüklenemedi. Lütfen başka bir dosya yükleyin.
-    uk = Файл пошкоджено та не може бути завантажений. Прохання завантажити інший файл.
-    vi = Tập tin này bị hỏng và không thể tải lên được. Vui lòng tải lên một tập tin khác.
-    el = Το αρχείο είναι κατεστραμμένο και δεν μπόρεσε να ανέβει. Παρακαλώ ανεβάστε ένα άλλο αρχείο.
-    sk = Tento súbor je poškodený a nedá sa nahrať. Prosím nahrajte iný súbor.
-    sw = Faili hili limeharibika na haliwezi kupakiwa. Tafadhali pakia faili jingine.
-    zh-Hans = 该文件已损坏，无法上传。请上传其他文件。
-    zh-Hant = 該文件已損壞，無法上傳。請上傳其他文件。
-    fa = این فایل آسیب دیده است و امکان بارگذاری آن وجود ندارد. لطفا فایل دیگری را بارگذاری نمایید.
-
-  [contact]
-    en = Contact
-    ru = Написать
-    ar = الاتصال
-    cs = Napsat
-    da = Kontakt
-    nl = Contact
-    fi = Kirjoita
-    fr = Contactez
-    de = Schreiben
-    hu = Írás
-    id = Kontak
-    it = Scrivere
-    ja = 連絡
-    ko = 연락
-    nb = Kontakt
-    pl = Napisz
-    pt = Escrever
-    pt-BR = Contato
-    ro = Scrie
-    es = Escribir
-    es-MX = Contacto
-    sv = Kontakta
-    th = ติดต่อ
-    tr = İletişim
-    uk = Написати
-    vi = Liên hệ
-    el = Επικοινωνία
-    sk = Kontakt
-    sw = Mawasiliano
-    zh-Hans = 写
-    zh-Hant = 寫
-    fa = تماس
-
-  [download_button]
-    en = Download
-    ru = Скачать
-    ar = تحميل
-    cs = Stáhnout
-    da = Download
-    nl = Downloaden
-    fi = Ladata
-    fr = Téléchargez
-    de = Downloaden
-    hu = Letöltés
-    id = Unduh
-    it = Scaricare
-    ja = ダウンロード
-    ko = 다운로드
-    nb = Last ned
-    pl = Pobierz
-    pt = Baixar
-    pt-BR = Download
-    ro = Descărcați
-    es = Descargar
-    es-MX = Descargar
-    sv = Nedladdning
-    th = ดาวน์โหลด
-    tr = İndir
-    uk = Завантажити
-    vi = Tải
-    el = Κατέβασμα
-    sk = Stiahnuť
-    sw = Pakua
-    zh-Hans = 下载
-    zh-Hant = 下載
-    fa = دانلود
+    sk = Počas načítavania značiek sa vyskytla chyba, skúste to znova
+    sw = Kosa limetokea wakati wa kupakua vibandiko, tafadhali jaribu tena
 
   [speedcams_alert_title]
+    tags = ios, android
     en = Speed cameras
     ru = Камеры скорости
     ar = كاميرات السرعة
@@ -25520,54 +15879,21 @@
     pt-BR = Câmeras de trânsito
     ro = Camere de supraveghere video a vitezei
     es = Cámaras de la velocidad
-    es-MX = Cámaras de velocidad
     sv = Hastighetskameror
     th = กล้องตรวจจับความเร็ว
     tr = Hız kameraları
     uk = Камери швидкості
     vi = Tăn tốc độ máy ảnh
-    el = Κάμερες Ταχύτητας
-    sk = Rýchlostné kamery
-    sw = Kamera za mwendo-kasi
     zh-Hans = 高速摄像机
     zh-Hant = 高速相機
+    el = Κάμερες Ταχύτητας
+    es-MX = Cámaras de velocidad
     fa = دوربین های سرعت
-
-  [speedcams_alert_subtitle]
-    en = Warn about speed limits
-    ru = Предупреждать об ограничениях скорости
-    ar = التحذير من حدود السرعة
-    cs = Upozorňovat o omezeních rychlosti
-    da = Advar om hastighedsgrænser
-    nl = Waarschuw voor snelheidsbeperkingen
-    fi = Varoita nopeusrajoituksista
-    fr = Prévenir concernant les limites de vitesse
-    de = Über Geschwindigkeitsbegrenzungen warnen
-    hu = Figyelmeztetés a sebessség korlátozására
-    id = Peringatan tentang batas kecepatan
-    it = Avvisare sul limite della velocità
-    ja = 速度制限警告
-    ko = 속도 제한에 대한 경고
-    nb = Advar om fartsgrenser
-    pl = Ostrzegać o ograniczeniach prędkości
-    pt = Avisar sobre limites de velocidade
-    pt-BR = Avisar sobre limites de velocidade
-    ro = Avertizați despre limitele de viteză
-    es = Advertencia de límites de velocidad
-    es-MX = Advertir sobre los límites de velocidad
-    sv = Varna om hastighetsbegränsningar
-    th = เตือนเรื่องการจำกัดความเร็ว
-    tr = Hız limitleri hakkında uyar
-    uk = Попереджати про обмеження швидкості
-    vi = Cảnh báo về giới hạn tốc độ
-    el = Ειδοποίηση για όρια ταχύτητας
-    sk = Upozornenie na rýchlostné obmedzenia
-    sw = Onyo kuhusu ukomo wa mwendo-kasi
-    zh-Hans = 速度限制警告
-    zh-Hant = 警告速度限制
-    fa = هشدار درباره محدودیت سرعت
+    sk = Rýchlostné kamery
+    sw = Kamera za mwendo-kasi
 
   [speedcam_option_auto]
+    tags = ios, android
     en = Auto
     ru = Авто
     ar = السيارات
@@ -25588,20 +15914,21 @@
     pt-BR = Automático
     ro = Auto
     es = Auto
-    es-MX = Automático
     sv = Auto
     th = อัตโนมัติ
     tr = Otomatik
     uk = Авто
     vi = Tự động
-    el = Αυτόματο
-    sk = Automaticky
-    sw = Auto
     zh-Hans = 自动
     zh-Hant = 自動
+    el = Αυτόματο
+    es-MX = Automático
     fa = خودکار
+    sk = Automaticky
+    sw = Auto
 
   [speedcam_option_always]
+    tags = ios, android
     en = Always
     ru = Всегда
     ar = دائما
@@ -25622,20 +15949,21 @@
     pt-BR = Sempre
     ro = Mereu
     es = Siempre
-    es-MX = Siempre
     sv = Alltid
     th = ทุกครั้ง
     tr = Her zaman
     uk = Завжди
     vi = Luôn luôn
-    el = Πάντα
-    sk = Vždy
-    sw = Mara kwa Mara
     zh-Hans = 总是
     zh-Hant = 總是
+    el = Πάντα
+    es-MX = Siempre
     fa = همیشه
+    sk = Vždy
+    sw = Mara kwa Mara
 
   [speedcam_option_never]
+    tags = ios, android
     en = Never
     ru = Никогда
     ar = مطلقا
@@ -25656,54 +15984,21 @@
     pt-BR = Nunca
     ro = Niciodată
     es = Nunca
-    es-MX = Nunca
     sv = Aldrig
     th = ไม่ต้องเตือน
     tr = Asla
     uk = Ніколи
     vi = Không bao giờ
-    el = Ποτέ
-    sk = Nikdy
-    sw = Kamwe
     zh-Hans = 从不
     zh-Hant = 從不
+    el = Ποτέ
+    es-MX = Nunca
     fa = هرگز
-
-  [bookmark_description_title]
-    en = Bookmark Description
-    ru = Описание метки
-    ar = وصف الإشارة المرجعية
-    cs = Popis značky
-    da = Beskrivelse af bogmærke
-    nl = Bladwijzer Beschrijving
-    fi = Merkin kuvaus
-    fr = Description du signet
-    de = Markierungsbeschreibung
-    hu = A jel ismertetése
-    id = Deskripsi Bookmark
-    it = Descrizione tag
-    ja = ブックマークの説明
-    ko = 즐겨찾기 묘사
-    nb = Beskrivelse av bokmerke
-    pl = Opis znacznika
-    pt = Descrição da marca
-    pt-BR = Descrição do Favorito
-    ro = Descrierea semnului
-    es = Descripción de la etiqueta
-    es-MX = Descripción de marcadores
-    sv = Etikettbeskrivning
-    th = รายละเอียดของบุ๊คมาร์ค
-    tr = Yer İmi Açıklaması
-    uk = Опис мітки
-    vi = Mô tả dấu trang
-    el = Περιγραφή Σελιδοδείκτη
-    sk = Popis záložiek
-    sw = Maelezo ya Alamisho
-    zh-Hans = 标签说明
-    zh-Hant = 標籤說明
-    fa = توضیحات نشانه گذاری
+    sk = Nikdy
+    sw = Kamwe
 
   [place_description_title]
+    tags = ios, android
     en = Place Description
     ru = Описание места
     ar = وصف المكان
@@ -25724,21 +16019,22 @@
     pt-BR = Descrição do Lugar
     ro = Descrierea locului
     es = Descripción del lugar
-    es-MX = Descripción de lugares
     sv = Beskrivning av platsen
     th = รายละเอียดของสถานที่
     tr = Yer Açıklaması
     uk = Опис місця
     vi = Mô tả Địa điểm
-    el = Περιγραφή μέρους
-    sk = Popis miesta
-    sw = Maelezo ya Eneo
     zh-Hans = 地点说明
     zh-Hant = 地點說明
+    el = Περιγραφή μέρους
+    es-MX = Descripción de lugares
     fa = توضیحات محل
+    sk = Popis miesta
+    sw = Maelezo ya Eneo
 
   [notification_channel_downloader]
     comment = this text will be shown in application notification preferences opposite checkbox which enable/disable downloader notifications. Devices on Android 8+ are affected.
+    tags = android
     en = Map downloader
     ru = Загрузка карт
     ar = محمل الخريطة
@@ -25759,122 +16055,21 @@
     pt-BR = Downloader do mapa
     ro = Încărcarea hărților
     es = Cargando mapas
-    es-MX = Descargar mapas
     sv = Kartladdning
     th = ตัวดาวน์โหลดแผนที่
     tr = Harita indiricisi
     uk = Завантаження мап
     vi = Trình tải xuống bản đồ
-    el = Κατέβασμα χαρτών
-    sk = Sťahovač máp
-    sw = Kipakua Ramani
     zh-Hans = 加载地图
     zh-Hant = 加載地圖
+    el = Κατέβασμα χαρτών
+    es-MX = Descargar mapas
     fa = دانلود کننده نقشه
-
-  [share_bookmarks_email_body_link]
-    en = Hello!\n\nHere is the link where you can download bookmarks: %s. Open the list in Organic Maps and enjoy your trip!\n\nGet application: https://omaps.app/get?kmz
-    ru = Здравствуйте!\n\nМетки можно скачать по ссылке: %s. Открывайте список с помощью Organic Maps и наслаждайтесь поездкой!\n\nСкачать приложение: https://omaps.app/get?kmz
-    ar = مرحبًا!\n\nللوصول إلى التطبيق: https://omaps.app/get?kmzهذا هو الرابط الذي يمكنك من خلاله تنزيل إشاراتك المرجعية: %s. افتح القائمة عبر Organic Maps واستمتع برحلتك!\n\n
-    cs = Dobrý den!\n\nVaše značky můžete stáhnout zde: %s. Otevírejte seznam s pomocí Organic Maps a užívejte si cesty!\n\nStáhnout aplikaci: https://omaps.app/get?kmz
-    da = Hej!\n\nHer er et link, hvor du kan hente dine bogmærker: %s. Åben listen via Organic Maps og nyd turen!\n\nHent applikation: https://omaps.app/get?kmz
-    nl = Hello!\n\nHier is de link waar u uw bladwijzers kunt downloaden: %s. Open de lijst via Organic Maps en geniet van uw reis!\n\nHaal de applicatie op: https://omaps.app/get?kmz
-    fi = Hei!\n\nMerkkinne voi ladata linkistä: %s. Avaa luettelo Organic Maps: llä ja nauti matkasta!\n\nLataa sovellus: https://omaps.app/get?kmz
-    fr = Bonjour !\n\nVoici le lien où vous pouvez télécharger vos signets : %s. Ouvrez la liste via Organic Maps et profitez de votre voyage !\n\nInstaller l'application : https://omaps.app/get?kmz
-    de = Guten Tag!\n\nIhre Markierungen stehen unter folgendem Link zum Download bereit: %s. Öffnen Sie die Liste mit Organic Maps und genießen Sie die Reise!\n\nApp downloaden: https://omaps.app/get?kmz
-    hu = Üdvözlöm!\n\nA jeleit le lehet tölteni ezzel a linkkel: %s. Nyíssa meg a listát Organic Maps segítségével és élvezze az utazását!\n\nAlkalmazás letöltése: https://omaps.app/get?kmz
-    id = Halo!\n\nBerikut tautan untuk mengunduh bookmark Anda: %s. Buka daftar melalui Organic Maps dan nikmati perjalanan Anda!\n\nDapatkan aplikasi: https://omaps.app/get?kmz
-    it = Ciao,\n\npuoi scaricare i tag dal seguente link: %s. Aprire elenco tramite Organic Maps e godersi viaggio!\n\nScaricare l'App: https://omaps.app/get?kmz
-    ja = こんにちは!\n\nこれはあなたのブックマークをダウンロードできるリンクです:%s。Organic Mapsを通じてリストを開いて旅をお楽しみください!\n\nアプリの入手: https://omaps.app/get?kmz
-    ko = 안녕하세요!\n\n여기 즐겨찾기들을 다운로드 받을 수 있는 링크입니다: %s. Organic Maps 를 통해 리스트를 열고 당신의 여행을 즐기세요!\n\n어플리케이션을 받으세요: https://omaps.app/get?kmz
-    nb = Hei!\n\nHer er lenken der du kan laste ned bokmerkene dine: %s. Åpne listen via Organic Maps og nyt reisen!\n\nFå tak i app: https://omaps.app/get?kmz
-    pl = Witaj!\n\nTwoje znaczniki można pobrać, używając link: %s. Otwórz listę, używając Organic Maps i ciesz się podrożą!\n\nPobierz aplikację: https://omaps.app/get?kmz
-    pt = Olá!\n\nSeus rótulos podem ser baixado aqui: %s. Abra a lista usando Organic Maps e desfrute do passeio!\n\nBaixar aplicação: https://omaps.app/get?kmz
-    pt-BR = Olá!\n\nAqui está o link para baixar seus marcas: %s. Abra a lista através do Organic Maps e curta sua viagem!\n\nBaixe o aplicativo: https://omaps.app/get?kmz
-    ro = Bună ziua!\n\nEtichetele dvs. le puteți descărca de pe linki-ul: %s. Deschideți lista cu ajutorul Organic Maps și primiți plăcere de la călătorie!\n\nDescărcați aplicația: https://omaps.app/get?kmz
-    es = Hola!\n\nSus etiquetas se pueden descargar desde el enlace: %s. Abra la lista con la ayuda de Organic Maps y disfrute del viaje!\n\nDescargar la aplicación: https://omaps.app/get?kmz
-    es-MX = ¡Hola!\n\nAquí esta el enlace donde puede descargar sus marcadores: %s. Abra la lista a través de Organic Maps y disfrute su viaje!\n\nObtenga la aplicación: https://omaps.app/get?kmz
-    sv = Hej!\n\nDina etiketter kan laddas ner från länken: %s. Öppna listan med hjälp av Organic Maps och njut av resan!\n\nLadda ner appen: https://omaps.app/get?kmz
-    th = สวัสดี!\n\nนี่คือลิงค์ที่คุณสามารถดาวน์โหลดบุ๊คมาร์คของคุณ: %s เปิดรายการผ่าน Organic Maps และเพลิดเพลินไปกับการเดินทางของคุณ!\n\nรับแอพพลิเคชัน: https://omaps.app/get?kmz
-    tr = Merhaba!\n\nİşte yer işaretlerinizi indirebileceğiniz bağlantı: %s. Organic Maps ile listeyi açın ve yolculuğunuzun tadını çıkarın!\n\nUygulamayı indir: https://omaps.app/get?kmz
-    uk = Вітаємо!\n\nВаші мітки можна завантажити за посиланням: %s. Відкривайте список за допомогою Organic Maps та насолоджуйтесь подорожжю!\n\nЗавантажити додаток: https://omaps.app/get?kmz
-    vi = Xin chào!\n\nĐây là liên kết nơi bạn có thể tải xuống dấu trang của mình: %s. Mở danh sách qua Organic Maps và tận hưởng chuyến đi của bạn!\n\nNhận đơn đăng ký: https://omaps.app/get?kmz
-    el = Γεια!\n\nΕδώ είναι ο σύνδεσμος που μπορείς να κατεβάσεις τους σελιδοδείκτες σου: %s. Ανοίξτε τη λίστα μέσω Organic Maps και απολαύστε το ταξίδι σας!\n\nΚατεβάστε την εφαρμογή: https://omaps.app/get?kmz
-    sk = Dobrý deň!\n\nTu je odkaz, kde si môžete stiahnuť svoje záložky: %s. Otvorte zoznam prostredníctvom služby Organic Maps a užite si výlet!\n\nZískajte aplikáciu: https://omaps.app/get?kmz
-    sw = Aise!\n\nKiunganishi hiki hapa ambapo unaweza kupakua vialamisho vyako: %s. Funua orodha kupitia Organic Maps na ufurahie safari zako!\n\nPata programu-tumizi: https://omaps.app/get?kmz
-    zh-Hans = 您好！\n\n您的标签可以从链接下载：%s.使用Organic Maps打开列表并享受旅行!\n\n下载程序：https://omaps.app/get?kmz
-    zh-Hant = 您好！\n\n您的標籤可以從鏈接下載：%s.使用Organic Maps打開列表並享受旅行!\n\n下載應用程序：https://omaps.app/get?kmz
-    fa = سلام!\n\nاین لینکی است که شما می توانید نشان شده های خود را از آن دانلود نمایید: %s. لیست را از طریق Organic Maps باز کرده و از سفر خود لذت ببرید!\n\nدریافت برنامه: https://omaps.app/get?kmz
-
-  [warning_speedcams_title]
-    en = Navigator will warn you about cameras when you exceed the speed limit of %d km/h
-    ru = Навигатор оповестит вас о камерах при превышении скоростного лимита на %d км/ч
-    ar = سوف يحذرك المستكشف من الكاميرات عندما تتجاوز الحد الأقصى للسرعة %d كم / س
-    cs = Navigátor vás při překročení rychlosti o %d km/h upozorní na všechny radary
-    da = Navigator advarer dig om kameraer, når du overskrider hastighedsgrænsen på %d km/t
-    nl = Navigator waarschuwt u over camera's wanneer u de maximumsnelheid van %d km/h overschrijdt
-    fi = Navigaattori ilmoittaa sinulle kameroista, kun nopeusraja ylittyy %d km/t
-    fr = Navigator vous avertira des caméras lorsque vous dépassez la limite de vitesse de %d km/h
-    de = Der Navigator wird Sie über Geschwindigkeitskameras bei Geschwindigkeitsüberschreitung von %d km/h informieren
-    hu = Navigátor értesít a kamerákról sebességkorlátozás megsértésénél %d km/óra-ra
-    id = Navigator akan memberi Anda peringatan tentang adanya kamera saat Anda melebihi batas kecepatan %d km/jam
-    it = Il navigatore avvisa della presenza della telecamere in caso di eccesso velocità di %d km/o
-    ja = %d km/hの速度制限を超えているときナビゲーターが自動速度違反取締装置について警告します
-    ko = 네비게이터가 %d km/h의 속도 제한을 초과시 카메라에 대해 경고 할 것입니다
-    nb = Navigatøren vil advare deg om kameraer når du overskrider fartsgrensen på %d km/t
-    pl = Nawigator powiadomi Cibie o kamerach, gdy przekrocz prędkość na %d km/h
-    pt = O navegador irá notificá-lo sobre as câmeras quando o limite de velocidade for excedido em %d km/h
-    pt-BR = O Navegador irá avisá-lo sobre radares quando você ultrapassar o limite de velocidade de %d km/h
-    ro = Navigatorul o să avertizeze despre camerele video în cazul depășirii limitei de viteză cu %d km/h
-    es = El navegador le notificará de las cámaras cuando se exceda el límite de velocidad en %d km/h
-    es-MX = El navegador le avisará de las cámaras cuando exceda el límite de velocidad de %d km/h
-    sv = Navigatören ska meddela dig om kameror när hastighetsgränsen överskrids med %d km/h
-    th = เนวิเกเตอร์จะเตือนคุณเกี่ยวกับกล้องถ่ายรูปเมื่อคุณขับเร็วเกินกำหนดโดยอยู่ที่ %d กม./ชม
-    tr = %d km/sa hız limitini aştığınızda navigasyon, kameralar hakkında sizi uyaracak
-    uk = Навігатор вас попередить про камери при перевищенні швидкісного режиму на %d км/г
-    vi = Thanh điều hướng sẽ cảnh báo bạn về máy ảnh khi bạn vượt quá giới hạn tốc độ %d km/h
-    el = Ο πλοηγός θα σας ειδοποιεί για κάμερες όταν υπερβαίνετε το όριο ταχύτητας των %d km/h
-    sk = Navigátor vás upozorní na kamery, keď prekročíte rýchlostný limit %d km/h
-    sw = Kiongoza-njia kitakuonya kuhusu kamera pindi umepita kikomo cha mwendo-kasi w %d km/h
-    zh-Hans = 当速度限制超过%d km / h时，导航会通知您的摄像机
-    zh-Hant = 當速度限制超過%d km / h時，導航會通知您的攝像機
-    fa = هدایتگر هنگامی که از محدوده سرعت %d کیلومتر بر ساعت تجاوز نمایید، در مورد دوربین هشدار می دهد
-
-  [warning_speedcams_subtitle]
-    en = Please mind driving regulations of the country you are travelling to.
-    ru = Не забудьте ознакомиться с правилами дорожного движения в стране путешествия.
-    ar = يرجى مراعاة قواعد القيادة في البلد الذي تنوي السفر إليه.
-    cs = Nezapomeňte se seznámit s dopravními předpisy země, do které cestujete.
-    da = Vær opmærksom på færdselsreglerne i det land, du rejser til.
-    nl = Let op de rijvoorschriften van het land waar u naartoe reist.
-    fi = Muista tutustua matkustusmaan liikennesääntöihin.
-    fr = Veuillez respecter les réglementations de conduite du pays dans lequel vous vous rendez.
-    de = Vergessen Sie nicht sich mit den Verkehrsregeln im Reisezielland vertraut zu machen.
-    hu = Ne felejtse el megismerkedni a cél ország közlekedési szabályaival.
-    id = Harap perhatikan aturan berkendara di negara tempat Anda bepergian.
-    it = Ricorda di informarti sul Codice della Strada del paese che visiti.
-    ja = 旅行先の国の道路交通法を考慮してください。
-    ko = 여행하시는 나라의 운전 법규를 준수하시길 바랍니다.
-    nb = Vær oppmerksom på kjøreregler for landet du reiser til.
-    pl = Nie zapomnij zapoznać się z zasadami ruchu drogowego w kraju podróży.
-    pt = Não esqueça de ler as regras da estrada no país de viagem.
-    pt-BR = Por favor, obedeça as leis de trânsito do país para o qual irá viajar.
-    ro = Nu uitați să faceți cunoștință cu regulele de circulație în țara unde călătoriți.
-    es = No de olvide de leer las reglas de carretera en el país de viaje.
-    es-MX = Por favor tenga en cuenta los reglamentos del país hacia el cual viaja.
-    sv = Glöm inte att bekanta sig med trafikregler i landet av resan.
-    th = โปรดปฏิบัติตามกฎหมายการขับขี่รถยนต์ของประเทศที่คุณกำลังเดินทางไป
-    tr = Lütfen bulunduğunuz ülkenin trafik kurallarına dikkat edin.
-    uk = Не забудьте ознайомитися з правилами дорожнього руху у країні подорожі.
-    vi = Hãy nhớ lái xe quy định của đất nước bạn đang đi du lịch đến.
-    el = Παρακαλώ να προσέχετε τους κανόνες οδήγησης της χώρας στην οποία ταξιδεύετε.
-    sk = Dodržujte pravidlá cestnej premávky v krajine, do ktorej cestujete.
-    sw = Tafadhali zingatia kanuni za uendeshaji gari za nchi unayoitembelea.
-    zh-Hans = 请不要忘记阅读旅行国的道路规则。
-    zh-Hant = 請不要忘記閱讀旅行國的道路規則。
-    fa = لطفا قوانین رانندگی کشوری که به آن سفر می کنید، را رعایت کنید.
+    sk = Sťahovač máp
+    sw = Kipakua Ramani
 
   [speedcams_notice_message]
+    tags = ios
     en = Auto - Warn about speedcams if there is a risk of exceeding the speed limit\nAlways - Always warn about speedcams\nNever - Never warn about speedcams
     ru = Авто - Предупреждать о камерах скорости, если есть риск превышения скоростного лимита\nВсегда - Всегда предупреждать о камерах\nНикогда - Никогда не предупреждать о камерах
     ar = السيارات- تحذير على الرادارات إذا كان هناك خطر تجاوز الحد الأقصى للسرعة\nدائما - احذر دائما من كاميرات السرعة\nمطلقا - أبدا تحذير من كاميرات السرعة
@@ -25895,20 +16090,21 @@
     pt-BR = Automático - Avisar sobre radar se houver risco de ultrapassar o limite de velocidade\nSempre - Sempre avisar sobre radares\nNunca - Nunca avisar sobre radares
     ro = Auto - De avertizat despre camerele video de înregistrare a vitezei, dacă există riscul depășirii limitei de viteză\nMereu - De avertizat întotdeauna despre camerele video\nNiciodată - De nu avertizat niciodată despre camerele video
     es = Auto - advierte sobre las cámaras de velocidad si existe el riesgo de exceder el límite de velocidad\nSiempre - siempre alerta sobre las cámaras\nNunca - nunca advierte acerca de las cámaras
-    es-MX = Automático - Aviso de las cámaras de velocidad si existe el riesgo de exceder el límite de velocidad\nSiempre - Siempre dar aviso de las cámaras de velocidad\nNunca - Nunca dar aviso de las cámaras de velocidad
     sv = Auto - Varna om fartkameror om det finns risk att överskrida hastighetsgränsen\nAlltid - Varna alltid om kameror\nAldrig - Varna aldrig om kameror
     th = อัตโนมัติ - เตือนเกี่ยวกับกล้องตรวจจับความเร็วหากมีความเป็นได้ว่าจะขับเร็วเกิดกำหนด\nทุกครั้ง - เตือนเกี่ยวกับกล้องตรวจจับความเร็วเสมอ\nไม่ต้องเตือน - ไม่เคยเตือนเกี่ยวกับกล้องตรวจจับความเร็ว
     tr = Otomatik - Hız sınırını aşma riski varsa hız kameraları hakkında uyar\nHer zaman - Hız kameraları hakkında her zaman uyar\nAsla - Hız kameraları hakkında hiçbir zaman uyarma
     uk = Авто - Попереджати про камери швидкості, якщо є ризик перевищення швидкісного ліміту\nЗавжди - Завжди попереджати про камери\nНіколи - Ніколи не попереджати про камери
     vi = Tự động - Cảnh báo về speedcam nếu có nguy cơ vượt quá giới hạn tốc độ\nLuôn luôn - Luôn cảnh báo về speedcams\nKhông bao giờ - Không bao giờ cảnh báo về speedcams
-    el = Αυτόματο- Να ειδοποιούμαι για κάμερες αν υπάρχει κίνδυνος να υπερβώ το όριο ταχύτητας\nΠάντα- Πάντα να ειδοποιούμαι για κάμερες\nΠοτέ- Ποτέ να μην ειδοποιούμαι για κάμερες
-    sk = Automaticky - Upozornenie na rýchlostné kamery, ak existuje riziko prekročenia rýchlostného limitu\nVždy - Vždy upozorniť na rýchlostné kamery\nNikdy - Nikdy neupozorňovať na rýchlostné kamery
-    sw = Auto - Onyo la kuhusu kamera ya mwendo-kasi iwapo kuna hatari yoyote ya kuzidi ukomo wa mwendo-kasi\nMara kwa Mara - Daima onya kuhusu kamera za mwendo-kasi\nKamwe - Kamwe usionye kuhusu kamera za mwendo-kasi
     zh-Hans = 自动 - 如果存在超出速度限制的风险，则对速度摄像头发出警告\n总是 - 始终提醒摄像头\n从不 - 永远不会对摄像头发出警告
     zh-Hant = 自動 - 如果存在超出速度限制的風險，則對速度攝像頭髮出警告\n總是 - 始終提醒攝像頭\n從不 - 永遠不會對攝像頭發出警告
+    el = Αυτόματο- Να ειδοποιούμαι για κάμερες αν υπάρχει κίνδυνος να υπερβώ το όριο ταχύτητας\nΠάντα- Πάντα να ειδοποιούμαι για κάμερες\nΠοτέ- Ποτέ να μην ειδοποιούμαι για κάμερες
+    es-MX = Automático - Aviso de las cámaras de velocidad si existe el riesgo de exceder el límite de velocidad\nSiempre - Siempre dar aviso de las cámaras de velocidad\nNunca - Nunca dar aviso de las cámaras de velocidad
     fa = خودکار- در صورتی که خطر تجاوز از سرعت مجاز وجود داشت، نسبت به دوربین های کنترل سرعت هشدار دهد\nهمیشه-همیشه درباره دوربین های کنترل سرعت هشدار دهد\nهرگز-هرگز درباره دوربین های کنترل سرعت هشدار ندهد
+    sk = Automaticky - Upozornenie na rýchlostné kamery, ak existuje riziko prekročenia rýchlostného limitu\nVždy - Vždy upozorniť na rýchlostné kamery\nNikdy - Nikdy neupozorňovať na rýchlostné kamery
+    sw = Auto - Onyo la kuhusu kamera ya mwendo-kasi iwapo kuna hatari yoyote ya kuzidi ukomo wa mwendo-kasi\nMara kwa Mara - Daima onya kuhusu kamera za mwendo-kasi\nKamwe - Kamwe usionye kuhusu kamera za mwendo-kasi
 
   [power_managment_title]
+    tags = ios, android
     en = Power saving mode
     ru = Режим энергосбережения
     ar = وضع توفير الطاقة
@@ -25929,20 +16125,21 @@
     pt-BR = Modo de economia de energia
     ro = Modul de economisire a energiei
     es = Modo de ahorro de energía
-    es-MX = Modo de ahorro de energía
     sv = Energisparläge
     th = โหมดประหยัดพลังงาน
     tr = Güç tasarrufu modu
     uk = Режим енергозбереження
     vi = Chế độ tiết kiệm năng lượng
-    el = Λειτουργία εξοικονόμησης ενέργειας
-    sk = Úsporný režim
-    sw = Mtindo wa kuokoa nishati
     zh-Hans = 省电模式
     zh-Hant = 省電模式
+    el = Λειτουργία εξοικονόμησης ενέργειας
+    es-MX = Modo de ahorro de energía
     fa = حالت ذخیره انرژی
+    sk = Úsporný režim
+    sw = Mtindo wa kuokoa nishati
 
   [power_managment_description]
+    tags = ios, android
     en = When automatic mode is selected the application starts to disable battery draining features depending on the current battery charge level
     ru = Если режим энергосбережения включен, приложение будет отключать энергозатратные функции в зависимости от текущего заряда телефона
     ar = عندما يتم اختيار الوضع التلقائي، يبدأ التطبيق بتعطيل الخصائص التي تستهلك البطارية بناءً على مستوى شحن البطارية
@@ -25963,20 +16160,21 @@
     pt-BR = Quando o modo automático é selecionado, o aplicativo começa a desativar as características que drenam a bateria dependendo do nível de energia atual
     ro = Dacă este pornit modul de economisire a energiei, aplicația va deconecta funcțiile care consumă multă energie în dependență de încărcarea bateriei telefonice
     es = Si el modo de ahorro de energía está activado, la aplicación desactivará las funciones que consumen energía, según la carga actual del teléfono
-    es-MX = Si el modo de ahorro de energía está activado, la aplicación desactivará las funciones de ahorro de energía, en función de la carga actual del teléfono
     sv = Om energisparläget är på, ska appen stänga av energikrävande funktioner beroende på telefonens nuvarande laddning
     th = เมื่อโหมดอัตโนมัตินั้นถูกเลือก แอปพลิเคชันจะเริ่มหยุดการใช้พลังงานจากแบตเตอรีขึ้นอยู่กับจำนวนไฟในแบตเตอรีว่าเหลือเท่าไร
     tr = Otomatik mod seçildiğinde, uygulama geçerli pil seviyesine bağlı olarak şarj harcayan özellikleri devre dışı bırakmaya başlar
     uk = Якщо увімкнено режим енергозбереження, додаток буде відключати енерговитратні функції в залежності від поточного заряду телефону
     vi = Nếu chế độ tiết kiệm năng lượng được bật, ứng dụng sẽ tắt các chức năng tiêu thụ năng lượng tùy thuộc vào mức pin hiện tại của điện thoại
-    el = Εάν η λειτουργία εξοικονόμησης ενέργειας είναι ενεργοποιημένη, η εφαρμογή θα κλείνει τις λειτουργίες που καταναλώνουν ενέργεια ανάλογα με την τρέχουσα φόρτιση του τηλεφώνου
-    sk = Keď je zvolený automatický režim, aplikácia začne vypínať funkcie, ktoré vybíjajú batériu v závislosti od aktuálnej úrovne nabitia batérie
-    sw = Pindi mtindo wa kiotomatiki unapochaguliwa programu tumizi inaanza kuzima sifa za kumaliza betri kulingana na kiwango cha chaji cha sasa cha betri
     zh-Hans = 如果开启省电模式，应用程序将根据手机的当前电量关耗电功能
     zh-Hant = 如果開啟省電模式，應用程序將根據手機的當前電量關耗電功能
+    el = Εάν η λειτουργία εξοικονόμησης ενέργειας είναι ενεργοποιημένη, η εφαρμογή θα κλείνει τις λειτουργίες που καταναλώνουν ενέργεια ανάλογα με την τρέχουσα φόρτιση του τηλεφώνου
+    es-MX = Si el modo de ahorro de energía está activado, la aplicación desactivará las funciones de ahorro de energía, en función de la carga actual del teléfono
     fa = هنگامی که حالت خودکار انتخاب شده‌باشد، برنامه با توجه میزان شارژ باتری شما، ویژگی‌های تخلیه کننده باتری را غیر فعال می‌کند
+    sk = Keď je zvolený automatický režim, aplikácia začne vypínať funkcie, ktoré vybíjajú batériu v závislosti od aktuálnej úrovne nabitia batérie
+    sw = Pindi mtindo wa kiotomatiki unapochaguliwa programu tumizi inaanza kuzima sifa za kumaliza betri kulingana na kiwango cha chaji cha sasa cha betri
 
   [power_managment_setting_never]
+    tags = ios, android
     en = Never
     ru = Никогда
     ar = أبدًا
@@ -25997,20 +16195,21 @@
     pt-BR = Nunca
     ro = Niciodată
     es = Nunca
-    es-MX = Nunca
     sv = Aldrig
     th = ไม่ใช้
     tr = Asla
     uk = Ніколи
     vi = Không bao giờ
-    el = Ποτέ
-    sk = Nikdy
-    sw = Kamwe
     zh-Hans = 从不
     zh-Hant = 從不
+    el = Ποτέ
+    es-MX = Nunca
     fa = هرگز
+    sk = Nikdy
+    sw = Kamwe
 
   [power_managment_setting_auto]
+    tags = ios, android
     en = Automatic
     ru = Авто
     ar = تلقائي
@@ -26031,20 +16230,21 @@
     pt-BR = Automático
     ro = Auto
     es = Automático
-    es-MX = Automático
     sv = Automatiskt
     th = อัตโนมัติ
     tr = Otomatik
     uk = Автоматично
     vi = Tự động
-    el = Αυτόματα
-    sk = Automaticky
-    sw = Kiotomatiki
     zh-Hans = 自动
     zh-Hant = 自動
+    el = Αυτόματα
+    es-MX = Automático
     fa = خودکار
+    sk = Automaticky
+    sw = Kiotomatiki
 
   [power_managment_setting_manual_max]
+    tags = ios, android
     en = Maximum power saving
     ru = Максимальное энергосбережение
     ar = توفير الطاقة القصوى
@@ -26065,18 +16265,18 @@
     pt-BR = Máxima economia de energia
     ro = Economisire maximă a energiei
     es = Ahorro de energía máximo
-    es-MX = Máximo ahorro de energía
     sv = Maximal energibesparing
     th = ประหยัดพลังงานสูงสุด
     tr = Maksimum güç tasarrufu
     uk = Максимальне енергозбереження
     vi = Tiết kiệm năng lượng tối đa
-    el = Μέγιστη εξοικονόμηση ενέργειας
-    sk = Maximálna úspora batérie
-    sw = Upeo wa kuhifadhi nishati
     zh-Hans = 最大程度省电
     zh-Hant = 最大程度省電
+    el = Μέγιστη εξοικονόμηση ενέργειας
+    es-MX = Máximo ahorro de energía
     fa = حداکثر ذخیره انرژی
+    sk = Maximálna úspora batérie
+    sw = Upeo wa kuhifadhi nishati
 
   [enable_logging_warning_message]
     tags = android
@@ -26100,160 +16300,21 @@
     pt-BR = A opção ativa para realizar diagnósticos. Pode ser útil para nossa equipe de suporte que estão solucionando problemas com o aplicativo. Ative esta opção apenas ao ser solicitado pelo suporte do Organic Maps.
     ro = Aceasta opțiune se pornește pentru logarea acțiunii în scopul diagnosticării. Aceasta va ajuta echipei să găsească problemele legate de aplicație. Conectați opțiunea numai la solicitarea serviciului de suport Organic Maps.
     es = Esta opción está habilitada para las acciones de registro con fines de diagnóstico. Esto ayuda a nuestro equipo a identificar problemas con la aplicación. Habilite la opción solo a petición del apoyo de Organic Maps.
-    es-MX = Esta opción está habilitada para las acciones de registro con fines de diagnóstico. Esto ayuda a nuestro equipo a identificar problemas con la aplicación. Habilite la opción solo a petición del apoyo de Organic Maps.
     sv = Denna funktion aktiveras för loggning av åtgärder för diagnostiska ändamål. Detta hjälper laget att identifiera problem med applikationen. Slå på funktionen endast på begäran av Organic Maps supporttjänst.
     th = ออปชันเพื่อเปิดการบันทึกประวัติการทำงานเพื่อการวินิจฉัย ประวัติดังกล่าวอาจเป็นประโยชน์กับทีมงานช่วยเหลือของเราที่คอยจัดการกับปัญหาที่เจอระหว่างแอปทำงาน โปรดเปิดออปชันดังกล่าวจากการร้องข้อการสนับสนุนจาก Organic Maps เท่านั้น
     tr = Seçenek tanı amaçlı, günlüğe kaydetmeyi açar. Uygulamayla ilgili sorunları gideren destek ekibimiz için yardımcı olabilir. Bu seçeneği yalnızca Organic Maps desteğinin isteği üzerine etkinleştirin.
     uk = Дана опція вмикається для логування дій з метою діагностики. Це допомагає команді виявити проблеми з додатком. Тимчасово включайте цю настройку тільки для відправки детальної інформації про знайдену вами проблему в додатку.
     vi = Tùy chọn này được kích hoạt để ghi nhật ký đăng nhập cho mục đích chẩn đoán. Điều này sẽ giúp nhóm chúng tôi làm rõ các vấn đề liên quan đến ứng dụng. Hãy bật tùy chọn này chỉ khi nào có yêu cầu hỗ trợ từ Organic Maps.
-    el = Αυτή η λειτουργία είναι ενεργοποιημένη για την καταγραφή ενεργειών για διαγνωστικούς σκοπούς. Αυτό βοηθά την ομάδα να εντοπίζει προβλήματα με την εφαρμογή. Να ενεργοποιείτε τη λειτουργία μόνο κατόπιν αιτήματος της υποστήριξης του Organic Maps.
-    sk = Táto možnosť zapína zaznamenávanie na diagnostické účely. Môže to byť užitočné pre našu technickú podporu, ktorá rieši problémy s aplikáciou. Povoliť túto možnosť iba na požiadanie podpory Organic Maps.
-    sw = Chaguo huwasha data kwa madhumuni ya uchunguzi. Itakuwa muhimu kwa wafanyakazi wetu ambao wanatatua matatizo ya programu. Washa chaguo hili kwa maombi ya mhudumu wa Organic Maps tu.
     zh-Hans = 此选项启用以记录操作来进行诊断。这有助于团队识别应用程序的问题。请仅在Organic Maps支持请求时开启该选项。
     zh-Hant = 此選項啟用以記錄操作來進行診斷。這有助於團隊識別應用程序的問題。請僅在Organic Maps支持請求時開啟該選項。
+    el = Αυτή η λειτουργία είναι ενεργοποιημένη για την καταγραφή ενεργειών για διαγνωστικούς σκοπούς. Αυτό βοηθά την ομάδα να εντοπίζει προβλήματα με την εφαρμογή. Να ενεργοποιείτε τη λειτουργία μόνο κατόπιν αιτήματος της υποστήριξης του Organic Maps.
+    es-MX = Esta opción está habilitada para las acciones de registro con fines de diagnóstico. Esto ayuda a nuestro equipo a identificar problemas con la aplicación. Habilite la opción solo a petición del apoyo de Organic Maps.
     fa = این گزینه ثبت گزارش را برای اهداف تشخیصی فعال می‌کند. برای کارکنان بخش پشتیبانی که مشکلات برنامه را عیب یابی می‌کنند، مفید باشد. این گزینه را تنها در صورت درخواست پشتیبانی Organic Maps فعال کنید.
-
-  [html_error_upload_message_try_again]
-    en = Please check your network settings and try again
-    ru = Проверьте доступ к сети и повторите попытку
-    ar = يرجى التحقق من إعدادات الشبكة الخاصة بك و حاول مرة أخرى
-    cs = Zkontrolujte přístup k síti a zopakujte pokus
-    da = Kontroller dine netværksindstillinger, og prøv igen
-    nl = Controleer de netwerktoegang en probeer het opnieuw
-    fi = Tarkista verkkoasetukset ja kokeile uudelleen
-    fr = Vérifiez l'accès au réseau et réessayez
-    de = Überprüfen Sie die Internetverbindung und versuchen Sie es noch einmal
-    hu = Kérjük ellenőrizd a hálózati beállításaidat és próbáld újra
-    id = Periksa pengaturan jaringan Anda dan coba lagi
-    it = Controllare la connessione e riprova
-    ja = ネットワーク設定をチェックして、もう一度お試しください
-    ko = 네트워크 설정을 확인하신 후 다시 시도해주세요
-    nb = Vennligst sjekk nettverksinnstillingene og prøv igjen
-    pl = Sprawdź dostęp do sieci i spróbuj ponownie
-    pt = Verifique o acesso à rede e volte a tentar
-    pt-BR = Por favor, verifique suas configurações de rede e tente novamente
-    ro = Verificați accesul la rețea și încercați încă o dată
-    es = Comprueba el acceso a la red y vuelve a intentarlo
-    es-MX = Compruebe el acceso a la red y vuelva a intentarlo
-    sv = Kontrollera nätverksåtkomst och försök igen
-    th = โปรดเช็คการตั้งค่าเครือข่ายและลองใหม่อีกครั้ง
-    tr = Lütfen ağ ayarlarınızı kontrol edip tekrar deneyin
-    uk = Перевірте доступ до мережі та спробуйте ще раз
-    vi = Vui lòng kiểm tra kết nối internet và thử lại
-    el = Ελέγξτε την πρόσβαση στο δίκτυο και δοκιμάστε ξανά
-    sk = Skontrolujte svoje sieťové nastavenia a skúste to znova
-    sw = Tafadhali angalia mipangilio ya mtandao wako na ujaribu tena
-    zh-Hans = 请检查网络访问，然后再重试
-    zh-Hant = 請檢查網絡訪問，然後再重試
-    fa = لطفاً تنظیمات شبکه را بررسی و مجدد تلاش کنید
-
-  [html_error_upload_title_try_again]
-    en = No internet connection
-    ru = Нет соединения с Интернетом
-    ar = لا يوجد اتصال بالانترنت
-    cs = Není přípojení na internet
-    da = Ingen internetforbindelse
-    nl = Geen internetverbinding
-    fi = Ei nettiyhteyttä
-    fr = Il n'y a pas de connexion internet
-    de = Keine Internetverbindung
-    hu = Nincs internetkapcsolat
-    id = Tidak ada koneksi internet
-    it = Nessuna connessione a internet
-    ja = インターネットに接続していません
-    ko = 인터넷이 연결되지 않았습니다
-    nb = Ingen internettforbindelse
-    pl = Brak połączenia z Internetem
-    pt = Sem conexão a internet
-    pt-BR = Sem conexão com a internet
-    ro = Aveți o problemă cu conexiunea dvs. la internet
-    es = No hay conexión a internet
-    es-MX = No hay conexión a internet
-    sv = Ingen internetanslutning
-    th = ไม่มีการเชื่อมต่ออินเทอร์เน็ต
-    tr = İnternet bağlantısı yok
-    uk = Немає з’єднання з Інтернетом
-    vi = Không có kết nối internet
-    el = Δεν υπάρχει σύνδεση με το διαδίκτυο
-    sk = Žiadne internetové pripojenie
-    sw = Hakuna mawasiliano ya intaneti
-    zh-Hans = 未连接到网络
-    zh-Hant = 未連接到網絡
-    fa = ارتباط اینترنت برقرار نیست
-
-  [notification_leave_review_v2_android_short_title]
-    en = Review and help travellers!
-    ru = Оставляйте отзыв и помогайте путешественникам!
-    ar = ضع تعليق وساعد المسافرين!
-    cs = Ponechávejte ohlas a pomáhejte cestovatelům!
-    da = Anmeld og hjælpe rejsende!
-    nl = Laat een feedback achter en help reizigers!
-    fi = Arvostele ja auta matkailijoita!
-    fr = Laissez vos commentaire et aidez les voyageurs !
-    de = Hinterlassen Sie Ihr Feedback und helfen Sie damit den Reisenden!
-    hu = Értékelj és segítsd az utazókat!
-    id = Ulas dan bantu traveler!
-    it = Scrivi il commento ed aiuta altri viaggiatori!
-    ja = レビューして旅行者を助けましょう！
-    ko = 리뷰하고 여행객들을 도우세요!
-    nb = Anmeld og hjelp reisende!
-    pl = Pozostaw komentarze i pomóż podróżującym!
-    pt = Deixe um comentário e ajude aos viajantes!
-    pt-BR = Avalie e ajude viajantes!
-    ro = Lăsați un comentariu și ajutați călătorii!
-    es = ¡Escribe un comentario y ayuda a los viajeros!
-    es-MX = ¡Escriba un comentario y ayude a los viajeros!
-    sv = Lämna en recension och hjälp resenärer!
-    th = รีวิวและช่วยนักท่องเที่ยวคนอื่น!
-    tr = İnceleyin ve gezginlere yardım edin!
-    uk = Залишайте відгук і допомагайте мандрівникам!
-    vi = Hãy để lại nhận xét và giúp khách du lịch!
-    el = Αφήνετε τα σχόλιά σας και βοηθάτε τους ταξιδιώτες!
-    sk = Ohodnotiť a pomôcť cestujúcim!
-    sw = Andika maoni na uwasaidie wasafiri!
-    zh-Hans = 请发表评论来帮助旅行者们！
-    zh-Hant = 請發表評論來幫助旅行者們！
-    fa = نظر خود را بیان و به مسافران کمک کنید!
-
-  [megafon]
-    en = Say goodbye to roaming!
-    ru = Роуминг, гудбай!
-
-  [notifications_illegal_alert_disable_button]
-    en = Turn off notifications
-    ru = Выключить уведомления
-    ar = تعطيل الإشعارات
-    cs = Vypnout oznámení
-    da = Slå fra meddelelser
-    nl = Meldingen uitschakelen
-    fi = Kytke ilmoitukset pois
-    fr = Désactiver les notifications
-    de = Benachrichtigungen deaktivieren
-    hu = Értesítések kikapcsolása
-    id = Nonaktifkan pemberitahuan
-    it = Disattiva le notifiche
-    ja = 通知を無効化
-    ko = 알림 끄기
-    nb = Skru av notefikasjoner
-    pl = Wyłącz powiadomienia
-    pt = Ativar notificações
-    pt-BR = Desligar notificações
-    ro = Porniți notificarea
-    es = Desactivar notificaciones
-    es-MX = Desactivar notificaciones
-    sv = Stäng av meddelanden
-    th = ปิดการแจ้งเตือน
-    tr = Bildirimleri kapat
-    uk = Вимкнути сповіщення
-    vi = Tắt thông báo
-    el = Απενεργοποίηση των ειδοποιήσεων
-    sk = Vypnite upozornenia
-    sw = Zima taarifa
-    zh-Hans = 关闭通知
-    zh-Hant = 關閉通知
-    fa = خاموش کردن اعلان‌ها
+    sk = Táto možnosť zapína zaznamenávanie na diagnostické účely. Môže to byť užitočné pre našu technickú podporu, ktorá rieši problémy s aplikáciou. Povoliť túto možnosť iba na požiadanie podpory Organic Maps.
+    sw = Chaguo huwasha data kwa madhumuni ya uchunguzi. Itakuwa muhimu kwa wafanyakazi wetu ambao wanatatua matatizo ya programu. Washa chaguo hili kwa maombi ya mhudumu wa Organic Maps tu.
 
   [access_rules_author_only]
+    tags = android
     en = Online editing
     ru = Редактируется онлайн
     ar = التحرير على الإنترنت
@@ -26274,122 +16335,21 @@
     pt-BR = Edição online
     ro = Se editează online
     es = Se edita en línea
-    es-MX = Se edita en línea
     sv = Redigeras online
     th = การแก้ไขทางออนไลน์
     tr = Çevrimiçi düzenleme
     uk = Редагується онлайн
     vi = Chỉnh sửa trực tuyến
-    el = Επεξεργάζεται online
-    sk = Online úprava
-    sw = Uhariri mtandaoni
     zh-Hans = 在线编辑
     zh-Hant = 在線編輯
+    el = Επεξεργάζεται online
+    es-MX = Se edita en línea
     fa = ویرایش آنلاین
-
-  [privacy_settings_menu]
-    en = Privacy settings
-    ru = Настройки конфиденциальности
-    ar = إعدادات الخصوصية
-    cs = Naladění důvěrnosti
-    da = Indstillinger for beskyttelse af personlige oplysninger
-    nl = Privacy instellingen
-    fi = Yksityisyysasetukset
-    fr = Paramètres de confidentialité
-    de = Datenschutzeinstellungen
-    hu = Adatvédelmi beállítások
-    id = Pengaturan privasi
-    it = Impostazioni della privacy
-    ja = プライバシー設定
-    ko = 개인정보 설정
-    nb = Pesonverninstillinger
-    pl = Ustawienia prywatności
-    pt = Configurações de privacidade
-    pt-BR = Configurações de privacidade
-    ro = Setarea confidențialității
-    es = Configuración de privacidad
-    es-MX = Configuración de privacidad
-    sv = Sekretessinställningar
-    th = การตั้งค่าความเป็นส่วนตัว
-    tr = Gizlilik ayarları
-    uk = Налаштування конфіденційності
-    vi = Cài đặt bảo mật
-    el = Ρυθμίσεις απορρήτου
-    sk = Nastavenia ochrany osobných údajov
-    sw = Mpangilio wa Faragha
-    zh-Hans = 隐私设置
-    zh-Hant = 隱私設置
-    fa = تنظیمات حریم خصوصی
-
-  [unable_upadate_error_title]
-    en = File update failed
-    ru = Не удалось обновить маршрут
-    ar = فشل تحديث الملف
-    cs = Nepovedlo se obnovit trasu
-    da = Fil opdatering fejlede
-    nl = Kan de route niet bijwerken
-    fi = Tiedoston päivitys epäonnistui
-    fr = Impossible de mettre à jour l'itinéraire
-    de = Die Aktualisierung der Route konnte nicht durchgeführt werden
-    hu = Fájl frissítés sikertelen
-    id = Pembaruan file gagal
-    it = Non siamo riusciti ad aggiornare l'itinerario
-    ja = ファイルが更新できませんでした
-    ko = 파일 업데이트 실패
-    nb = Feil ved fil-oppdatering
-    pl = Nieudana próba aktualizacji trasy
-    pt = Erro na atualização do percurso
-    pt-BR = Atualização de arquivo falhou
-    ro = Nu s-a actualizat traseul
-    es = No se pudo actualizar la ruta
-    es-MX = No se pudo actualizar la ruta
-    sv = Det gick inte att uppdatera resrutten
-    th = อัพเดตไฟล์ล้มเหลว
-    tr = Dosya güncellemesi başarısız oldu
-    uk = Не вдалося оновити маршрут
-    vi = Cập nhận hướng dẫn không thành công
-    el = Δεν ήταν δυνατή η ενημέρωση της διαδρομής
-    sk = Aktualizácia súboru zlyhala
-    sw = Uboreshaji wa faili umeshindikana
-    zh-Hans = 无法更新路线
-    zh-Hant = 無法更新路線
-    fa = به روز رسانی فایل ناموفق بود
-
-  [unable_upadate_error_message]
-    en = Some errors occurred while updating. Please check the changes and try again
-    ru = Возникли ошибки при обновлении. Проверьте изменения и повторите попытку
-    ar = حدثت بعض الأخطاء أثناء التحديث يرجى التحقق من التغييرات و حاول مرة أخرى
-    cs = Objevily se chyby pří obnovení. Zkontrolujte změny a zopakujte pokus
-    da = Der opstod nogle fejl under opdatering. Kontroller ændringerne, og prøv igen
-    nl = Er zijn fouten opgetreden tijdens het updaten. Controleer de wijzigingen en probeer het opnieuw
-    fi = Päivityksen aikana tapahtui jokin virhe. Tarkista muutokset ja yritä uudelleen
-    fr = Il y a eu des erreurs pendant la mise à jour. Veuilelz revérifiez les modifications et réessayez
-    de = Bei der Aktualisierung sind Fehler aufgetreten. Überprüfen Sie die Änderungen und versuchen Sie es noch einmal
-    hu = Néhány hiba történt frissítés közben. Kérjük ellenőrizd a változtatásokat és próbáld újra
-    id = Beberapa kesalahan terjadi saat memperbarui. Periksa perubahan dan coba lagi
-    it = Si sono verificati errori durante l'aggiornamento. Controlla le modifiche e riprova
-    ja = 更新中に何かミスが発生しました。変更を確認して、もう一度お試しください
-    ko = 업데이트 중 무언가 실수가 일어났습니다. 변경점들을 확인하시고 다시 시도해주세요
-    nb = Feil oppstod ved oppdatering. Sjekk forandringer og prøv igjen
-    pl = Podczas aktualizacji wystąpiły błędy. Sprawdź zmiany i spróbuj ponownie
-    pt = Ocorreram uns erros durante a atualização. Verifique as alterações e volte a tentar
-    pt-BR = Alguns erros ocorreram enquanto atualizavam. Por favor, verifique as mudanças e tente novamente
-    ro = Au intervenit erori de actualizare. Verificați modificările și încercați încă o dată
-    es = Hubo errores al actualizar. Comprueba los cambios y vuelve a intentarlo
-    es-MX = Hubo errores al actualizar. Verifique los cambios y vuelva a intentarlo
-    sv = Det uppstod några fel vid uppdatering. Kontrollera ändringarna och försök igen
-    th = มีข้อผิดพลาดบางอย่างเกิดขึ้นขณะอัพเดต โปรดตรวจทานการแก้ไขและลองใหม่อีกครั้ง
-    tr = Güncelleme sırasında bazı hatalar oluştu. Lütfen değişiklikleri kontrol edip tekrar deneyin
-    uk = Виникли помилки під час оновлення. Перевірте зміни та спробуйте ще раз
-    vi = Xuất hiện lỗi khi cập nhật. Hãy kiểm tra lại những thay đổi và thử lại lần nữa
-    el = Παρουσιάστηκαν σφάλματα κατά την ενημέρωση. Ελέγξτε τις αλλαγές και δοκιμάστε ξανά
-    sk = Počas aktualizácie sa vyskytli určité chyby. Skontrolujte zmeny a skúste to znova
-    sw = Kuna makosa yametokea wakati wa uboreshaji. Tafadhali angalia mabadiliko na ujaribu tena
-    zh-Hans = 更新时出错。请检查更改，然后再重试
-    zh-Hant = 更新時出錯。請檢查更改，然後再重試
-    fa = هنگام به روز رسانی برخی اشتباهات رخ داده است. لطفاً تغییرات را بررسی و مجدد تلاش کنید
+    sk = Online úprava
+    sw = Uhariri mtandaoni
 
   [driving_options_title]
+    tags = ios, android
     en = Routing options
     ru = Настройки объезда
     ar = خيارات قيادة
@@ -26410,20 +16370,21 @@
     pt-BR = Opções de direção
     ro = Setarea ocolirii
     es = Configuración de desvío
-    es-MX = Ajustes de desvío
     sv = Omvägsinställningar
     th = ทางเลือกเส้นทางขับขี่
     tr = Sürüş seçenekleri
     uk = Налаштування об’їзду
     vi = Thiết lập đi vòng
-    el = Ρυθμίσεις παράκαμψης
-    sk = Možnosti jazdy
-    sw = Machaguo ya njia
     zh-Hans = 绕行设置
     zh-Hant = 繞行設置
+    el = Ρυθμίσεις παράκαμψης
+    es-MX = Ajustes de desvío
     fa = گزینه های رانندگی
+    sk = Možnosti jazdy
+    sw = Machaguo ya njia
 
   [driving_options_subheader]
+    tags = android
     en = Avoid on every route
     ru = Избегать в каждом маршруте
     ar = تجنب على كل الطرق
@@ -26444,20 +16405,21 @@
     pt-BR = Evitar em todas as rotas
     ro = De evitat pe orice traseu
     es = Evitar en todas las rutas
-    es-MX = Evitar en cada ruta
     sv = Undvik på varje rutten
     th = หลีกเลี่ยงในทุกเส้นทาง
     tr = Her rotada kaçının
     uk = Уникати в кожному маршруті
     vi = Tránh trên mỗi tuyến
-    el = Αποφυγή σε κάθε διαδρομή
-    sk = Vyhnúť sa na každej trase
-    sw = Epuka kwenye kila njia
     zh-Hans = 在每条线路上规避
     zh-Hant = 在每條線路上規避
+    el = Αποφυγή σε κάθε διαδρομή
+    es-MX = Evitar en cada ruta
     fa = اجتناب از تمامی مسیرها
+    sk = Vyhnúť sa na každej trase
+    sw = Epuka kwenye kila njia
 
   [avoid_tolls]
+    tags = ios, android
     en = Toll roads
     ru = Платные дороги
     ar = نقطة تحصيل رسوم
@@ -26478,20 +16440,21 @@
     pt-BR = Pedágios
     ro = Drumuri cu plată
     es = Carreteras de pago
-    es-MX = Carreteras de peaje
     sv = Betalväg
     th = ถนนแบบเสียค่าผ่านทาง
     tr = Paralı yollar
     uk = Платні дороги
     vi = Đường trả phí
-    el = Δρόμοι με διόδια
-    sk = Spoplatnené cesty
-    sw = Barabara za kulipia
     zh-Hans = 收费公路
     zh-Hant = 收費公路
+    el = Δρόμοι με διόδια
+    es-MX = Carreteras de peaje
     fa = جاده های دارای عوارض
+    sk = Spoplatnené cesty
+    sw = Barabara za kulipia
 
   [avoid_unpaved]
+    tags = ios, android
     en = Unpaved roads
     ru = Грунтовые дороги
     ar = طرق غير ممهدة
@@ -26512,20 +16475,21 @@
     pt-BR = Pistas sem pavimentação
     ro = Drum de țară
     es = Caminos sin pavimento
-    es-MX = Caminos de tierra
     sv = Kärrväg
     th = ถนนดิน
     tr = Asfaltsız yollar
     uk = Ґрунтові дороги
     vi = Đường đất
-    el = Χωματόδρομοι
-    sk = Nespevnené cesty
-    sw = Barabara za vumbi
     zh-Hans = 土路
     zh-Hant = 土路
+    el = Χωματόδρομοι
+    es-MX = Caminos de tierra
     fa = جاده های آسفالت نشده
+    sk = Nespevnené cesty
+    sw = Barabara za vumbi
 
   [avoid_ferry]
+    tags = ios, android
     en = Ferry crossings
     ru = Паромные переправы
     ar = تقاطع عبارات
@@ -26546,20 +16510,21 @@
     pt-BR = Balsa
     ro = Trecere cu bac
     es = Cruces de ferri
-    es-MX = Cruces de ferri
     sv = Färjetrafik
     th = เรือข้ามฟาก
     tr = Feribot geçişleri
     uk = Поромні переправи
     vi = Bến phà
-    el = Πορθμεία
-    sk = Prechody trajektom
-    sw = Vivuko cha feri
     zh-Hans = 渡轮渡口
     zh-Hant = 渡輪渡口
+    el = Πορθμεία
+    es-MX = Cruces de ferri
     fa = گذرگاه های جاده ای
+    sk = Prechody trajektom
+    sw = Vivuko cha feri
 
   [avoid_motorways]
+    tags = ios, android
     en = Motorways
     ru = Магистрали
     ar = طرق سريعة
@@ -26580,20 +16545,21 @@
     pt-BR = Autoestradas
     ro = Magistrale
     es = Autopistas
-    es-MX = Autopistas
     sv = Motorväg
     th = ทางด่วน
     tr = Otoyollar
     uk = Магістралі
     vi = Đường cao tốc
-    el = Αυτοκινητόδρομοι
-    sk = Diaľnice
-    sw = Barabara za mwendo kasi
     zh-Hans = 干线
     zh-Hant = 幹線
+    el = Αυτοκινητόδρομοι
+    es-MX = Autopistas
     fa = بزرگراه ها
+    sk = Diaľnice
+    sw = Barabara za mwendo kasi
 
   [unable_to_calc_alert_title]
+    tags = ios, android
     en = Unable to calculate route
     ru = Невозможно построить маршрут
     ar = لا يمكن حساب الطريق
@@ -26614,20 +16580,21 @@
     pt-BR = Incapaz de calcular rota
     ro = Imposibil de elaborat un traseu
     es = No se puede construir una ruta
-    es-MX = No se puede construir una ruta
     sv = Det går inte att bygga ruttenen
     th = ไม่สามารถคำนวณเส้นทาง
     tr = Rota hesaplanamıyor
     uk = Неможливо побудувати маршрут
     vi = Không thể tạo tuyến đường
-    el = Δεν είναι δυνατή η δημιουργία διαδρομής
-    sk = Nepodarilo sa vypočítať trasu
-    sw = Haiwezi kukokotoa njia
     zh-Hans = 无法规划路线
     zh-Hant = 無法規劃路線
+    el = Δεν είναι δυνατή η δημιουργία διαδρομής
+    es-MX = No se puede construir una ruta
     fa = امکان محاسبه مسیر نیست
+    sk = Nepodarilo sa vypočítať trasu
+    sw = Haiwezi kukokotoa njia
 
   [unable_to_calc_alert_subtitle]
+    tags = ios, android
     en = Unfortunately, we couldn't find a route, probably due to the options you have chosen. Please change the settings and try again.
     ru = К сожалению, мы не смогли построить маршрут с выбранными опциями. Измените настройки и повторите попытку
     ar = نأسف، لم نعثر على الطريق ربما بسبب الخيارات التي قمت بتحديدها. يرجى تغيير الاعدادات والمحاولة مجددًا
@@ -26648,20 +16615,21 @@
     pt-BR = Infelizmente, não não conseguimos encontrar uma rota provavelmente por causa da opção escolhidas. Por favor, altere as configurações e tente novamente
     ro = Din păcate, nu reușim să elaborăm un traseu cu opțiunile alese. Modificați setările și încercați încă o dată
     es = Desafortunadamente, no pudimos construir una ruta con las opciones seleccionadas. Cambia la configuración y vuelve a intentarlo
-    es-MX = Desafortunadamente, no pudimos construir una ruta con las opciones seleccionadas. Cambie la configuración y vuelva a intentarlo
     sv = Tyvärr kunde vi inte bygga en rutt med de valda alternativen. Ändra inställningar och försök igen
     th = ขออภัย เราไม่สามารถค้นหาเส้นทาง โดยสาเหตุอาจมาจากทางเลือกที่คุณกำหนดไว้ โปรดเปลี่ยนการตั้งค่าทางเลือกและลองใหม่อีกครั้ง
     tr = Maalesef, muhtemelen belirlediğiniz seçeneklerden dolayı bir rota bulamadık. Lütfen seçenekleri değiştirin ve tekrar deneyin
     uk = На жаль, ми не змогли побудувати маршрут з вибраними опціями. Змініть налаштування та спробуйте ще раз
     vi = Rất tiếc, chúng không thể tạo tuyến đường với những tùy chọn đã chọn. Hãy thay đổi thiết lập và thử lại
-    el = Δυστυχώς, δεν μπορούσαμε να δημιουργήσουμε μια διαδρομή με τις καθορισμένες επιλογές. Αλλάξτε τις ρυθμίσεις και δοκιμάστε πάλι
-    sk = Bohužiaľ sme nemohli nájsť trasu pravdepodobne z dôvodu definovaných možností. Zmeňte nastavenia a skúste to prosím znova
-    sw = Bahati mbaya hatukuweza kupata njia labda kwa sababu ya machaguo msingi. Tafadhali badili mipangilio na jaribu tena
     zh-Hans = 很遗憾，我们无法使用所选选项规划路线。请更改设置，然后重试
     zh-Hant = 很遺憾，我們無法使用所選選項規劃路線。請更改設置，然後重試
+    el = Δυστυχώς, δεν μπορούσαμε να δημιουργήσουμε μια διαδρομή με τις καθορισμένες επιλογές. Αλλάξτε τις ρυθμίσεις και δοκιμάστε πάλι
+    es-MX = Desafortunadamente, no pudimos construir una ruta con las opciones seleccionadas. Cambie la configuración y vuelva a intentarlo
     fa = متأسفانه، احتمالاً به دلیل گزینه های تعریف شده شما، مسیری پیدا نشد. لطفاً تنظیمات را تغییر داده و مجدد تلاش کنید
+    sk = Bohužiaľ sme nemohli nájsť trasu pravdepodobne z dôvodu definovaných možností. Zmeňte nastavenia a skúste to prosím znova
+    sw = Bahati mbaya hatukuweza kupata njia labda kwa sababu ya machaguo msingi. Tafadhali badili mipangilio na jaribu tena
 
   [define_to_avoid_btn]
+    tags = ios, android
     en = Define roads to avoid
     ru = Настроить пути объезда
     ar = حدد الطرق التي يجب تجنبها
@@ -26682,20 +16650,21 @@
     pt-BR = Definir as estradas a serem evitadas
     ro = Setați căile de ocolire
     es = Personaliza la ruta de desvío
-    es-MX = Configurar rutas de desvío
     sv = Anpassa omvägsbana
     th = กำหนดถนนที่ต้องการเลี่ยง
     tr = Kaçınılması gereken yolları tanımlayın
     uk = Налаштувати шляхи об’їзду
     vi = Thiết lập đường đi vòng
-    el = Ρύθμιση της διαδρομής παράκαμψης
-    sk = Definovať cesty, ktorým sa treba vyhnúť
-    sw = Fafanua njia za kuziepuka
     zh-Hans = 设置绕行路径
     zh-Hant = 設置繞行路徑
+    el = Ρύθμιση της διαδρομής παράκαμψης
+    es-MX = Configurar rutas de desvío
     fa = جاده های لغو شده را تعریف نمایید
+    sk = Definovať cesty, ktorým sa treba vyhnúť
+    sw = Fafanua njia za kuziepuka
 
   [change_driving_options_btn]
+    tags = ios, android
     en = Routing options enabled
     ru = Настройки объезда включены
     ar = تم تفعيل خيارات الطريق
@@ -26716,156 +16685,21 @@
     pt-BR = Opções de direção ativadas
     ro = Setarea ocolirii este activată
     es = Configuración de desvío activada
-    es-MX = Ajustes de desvío habilitados
     sv = Omvägsinställningar aktiverade
     th = เปิดใช้การค้นหาเส้นทางขับขี่แล้ว
     tr = Sürüş seçenekleri etkinleştirildi
     uk = Увімкнено налаштування об’їзду
     vi = Thiết lập đường đi tránh đã được bật
-    el = Ρυθμίσεις δραστηριοποιούνται
-    sk = Možnosti trasy povolené
-    sw = Machaguo ya njia yamewezeshwa
     zh-Hans = 繞行設置已開啟
     zh-Hant = 绕行设置已开启
+    el = Ρυθμίσεις δραστηριοποιούνται
+    es-MX = Ajustes de desvío habilitados
     fa = گزینه های مسیریابی فعال شد
-
-  [toll_road]
-    en = Toll road
-    ru = Платная дорога
-    ar = نقطة تحصيل رسوم
-    cs = Silnice s mýtným
-    da = Betalingsvej
-    nl = Tolweg
-    fi = Maksullinen tie
-    fr = Route à péage
-    de = Mautstraße
-    hu = Fizetős utak
-    id = Jalan tol
-    it = Strada a pedaggio
-    ja = 有料道路
-    ko = 유료 도로
-    nb = Bompengevei
-    pl = Droga płatna
-    pt = Estrada com portagem
-    pt-BR = Pedágio
-    ro = Drum cu plată
-    es = Carretera con pago de peaje
-    es-MX = Carretera de peaje
-    sv = Betalvägen
-    th = ถนนแบบเสียค่าผ่านทาง
-    tr = Paralı yol
-    uk = Платна дорога
-    vi = Đường trả phí
-    el = Δρόμος με διόδια
-    sk = Spoplatnená cesta
-    sw = Barabara ya kulipia
-    zh-Hans = 收费公路
-    zh-Hant = 收費公路
-    fa = جاده دارای عوارض
-
-  [unpaved_road]
-    en = Unpaved road
-    ru = Грунтовая дорога
-    ar = طريق غير ممهدة
-    cs = Nezpevněná silnice
-    da = Grusvej
-    nl = Aardeweg
-    fi = Päällystämätön tie
-    fr = Routes non revêtues
-    de = Erdweg
-    hu = Kövezetlen utak
-    id = Jalan tanah
-    it = Strada sterrata
-    ja = 未舗装道路
-    ko = 비포장 도로
-    nb = Uasfaltert vei
-    pl = Droga gruntowa
-    pt = Estrada rural
-    pt-BR = Pista não pavimentada
-    ro = Drum de țară
-    es = Camino sin pavimento
-    es-MX = Camino de tierra
-    sv = Kärrvägen
-    th = ถนนดิน
-    tr = Asfaltsız yol
-    uk = Ґрунтова дорога
-    vi = Đường đất
-    el = Χωματόδρομος
-    sk = Nespevnená cesta
-    sw = Barabara ya vumbi
-    zh-Hans = 土路
-    zh-Hant = 土路
-    fa = جاده آسفالت نشده
-
-  [ferry_crossing]
-    en = Ferry crossing
-    ru = Паромная переправа
-    ar = تقاطع عبارة
-    cs = Přejezd trajektů
-    da = Færgeoverfart
-    nl = Ferry
-    fi = Lauttaliikenne
-    fr = Passage d'un cours d'eau
-    de = Fährstelle
-    hu = Kompátkelők
-    id = Penyeberangan kapal feri
-    it = Traghetto
-    ja = フェリー航路
-    ko = 여객선 횡단길
-    nb = Fergeovergang
-    pl = Przeprawa promowa
-    pt = Ferryboat
-    pt-BR = Balsa
-    ro = Trecere cu bac
-    es = Cruce de ferri
-    es-MX = Cruce de ferri
-    sv = Färjetrafik
-    th = เรือข้ามฟาก
-    tr = Feribot geçişi
-    uk = Поромна переправа
-    vi = Bến phà
-    el = Πορθμείο
-    sk = Prechod trajektom
-    sw = Kivuko cha feri
-    zh-Hans = 轮渡
-    zh-Hant = 輪渡
-    fa = گذرگاه جاده ای
-
-  [operated_by]
-    en = Operated by "%s"
-    ru = Управляется оператором "%s"
-    ar = تدرا بواسطة "%s"
-    cs = Provozován "%s"
-    da = Drives af "%s"
-    nl = Gecontroleerd door "%s"
-    fi = Hallinnoitu "%s"
-    fr = Géré par "%s"
-    de = Gesteuert "%s"
-    hu = "%s" működteti
-    id = Dioperasikan oleh "%s"
-    it = Gestita da "%s"
-    ja = "%s"で稼働
-    ko = "%s" 로 운용됨
-    nb = Bemannet av "%s"
-    pl = Zarządzany przez "%s"
-    pt = Operado por "%s"
-    pt-BR = Operado por "%s"
-    ro = Se gestionează "%s"
-    es = Operado por "%s"
-    es-MX = Operado por "%s"
-    sv = Kontrolleras "%s"
-    th = กำลังทำงานอยู่ที่ "%s"
-    tr = "%s" tarafından işletiliyor
-    uk = Керується "%s"
-    vi = Tạo được "%s"
-    el = Χειρίζεται από "%s"
-    sk = Prevádzkuje "%s"
-    sw = Inaongozwa na "%s"
-    zh-Hans = 由"%s"管理
-    zh-Hant = 由"%s"管理
-    fa = اجرا توسط "%s"
+    sk = Možnosti trasy povolené
+    sw = Machaguo ya njia yamewezeshwa
 
   [avoid_toll_roads_placepage]
+    tags = ios, android
     en = Avoid toll roads
     ru = Избегать платных дорог
     ar = تجنب نقاط تحصيل الرسوم
@@ -26886,20 +16720,21 @@
     pt-BR = Evitar pedágios
     ro = De evitat drumurile cu plată
     es = Evitar las carreteras con pago de peaje
-    es-MX = Evitar las carreteras de peaje
     sv = Undvik betalvägar
     th = เลี่ยงทางที่ต้องเสียเงินทั้งหมด
     tr = Paralı yollardan kaçın
     uk = Уникати платних доріг
     vi = Tránh đường trả phí
-    el = Αποφυγή των δρόμων με διόδια
-    sk = Vyhnúť sa spoplatneným cestám
-    sw = Epuka barabara za kulipia
     zh-Hans = 规避收费公路
     zh-Hant = 規避收費公路
+    el = Αποφυγή των δρόμων με διόδια
+    es-MX = Evitar las carreteras de peaje
     fa = اجتناب از جاده های دارای عوارض
+    sk = Vyhnúť sa spoplatneným cestám
+    sw = Epuka barabara za kulipia
 
   [avoid_unpaved_roads_placepage]
+    tags = ios, android
     en = Avoid unpaved roads
     ru = Избегать грунтовых дорог
     ar = تجنب الطرق الغير ممهدة
@@ -26920,20 +16755,21 @@
     pt-BR = Evitar pistas sem pavimentação
     ro = De evitat drumurile de țară
     es = Evitar los caminos sin pavimento
-    es-MX = Evitar los caminos de tierra
     sv = Undvik kärrvägar
     th = เลี่ยงถนนดินทั้งหมด
     tr = Asfaltsız yollardan kaçın
     uk = Уникати ґрунтових доріг
     vi = Tránh đường đất
-    el = Αποφυγή των χωματόδρομων
-    sk = Vyhnúť sa nespevneným cestám
-    sw = Epuka barabara za vumbi
     zh-Hans = 规避土路
     zh-Hant = 規避土路
+    el = Αποφυγή των χωματόδρομων
+    es-MX = Evitar los caminos de tierra
     fa = اجتناب از جاده های آسفالت نشده
+    sk = Vyhnúť sa nespevneným cestám
+    sw = Epuka barabara za vumbi
 
   [avoid_ferry_crossing_placepage]
+    tags = ios, android
     en = Avoid ferry crossings
     ru = Избегать паромных переправ
     ar = تجنب تقاطع العبارات
@@ -26954,666 +16790,21 @@
     pt-BR = Evitar balsas
     ro = De evitat trecerile cu bac
     es = Evitar ferries
-    es-MX = Evitar los trasbordadores de ferri
     sv = Undvik färjetrafik
     th = เลี่ยงการข้ามฟากด้วยเรือ
     tr = Feribot geçişlerinden kaçın
     uk = Уникати поромних переправ
     vi = Tránh bến phà
-    el = Αποφυγή των πορθμείων
-    sk = Vyhnúť sa prechodom na trajekte
-    sw = Epuka vivuko vya feri
     zh-Hans = 规避轮渡
     zh-Hant = 規避輪渡
+    el = Αποφυγή των πορθμείων
+    es-MX = Evitar los trasbordadores de ferri
     fa = اجتناب از گذرگاه های کشتی
-
-  [type.cuisine.uzbek]
-    en = Uzbek cuisine
-    ru = Узбекская кухня
-    ar = مطعم أوزبكي
-    cs = Uzbecká kuchyně
-    da = Usbekisk køkken
-    nl = Oezbeekse keuken
-    fi = Uzbekistanilainen ruokaa
-    fr = Cuisine ouzbek
-    de = Usbekische Küche
-    hu = Üzbég konyha
-    id = Masakan Uzbek
-    it = Cucina uzbeka
-    ja = ウズベキスタン料理
-    ko = 우즈벡 요리
-    nb = Usbekisk mat
-    pl = Kuchnia uzbecka
-    pt = Cozinha uzbeque
-    pt-BR = Cozinha uzbeque
-    ro = Bucătărie uzbecă
-    es = Cocina uzbeka
-    es-MX = Cocina uzbeka
-    sv = Uzbekiska mat
-    th = อาหารแนวอุซเบค
-    tr = Özbek mutfağı
-    uk = Узбецька кухня
-    vi = Ẩm thực của Uzbekistan
-    el = Ουζμπεκική κουζίνα
-    sk = Uzbecká kuchyňa
-    sw = Mapishi ya Uzbek
-    zh-Hans = 乌兹别克美食
-    zh-Hant = 烏茲別克美食
-    fa = غذای ازبکستانی
-
-  [trip_start]
-    en = Let's go
-    ru = Поехали
-    ar = هيا بنا
-    cs = Pojďme
-    da = Lad os komme i gang
-    nl = Kom op
-    fi = Mennään
-    fr = On y va
-    de = Fahren wir
-    hu = Gyerünk
-    id = Ayo
-    it = Si parte
-    ja = レッツゴー
-    ko = 가자
-    nb = La oss begynne
-    pl = Jedźmy
-    pt = Vamos
-    pt-BR = Vamos
-    ro = Mergem
-    es = Vamos
-    es-MX = Vamos
-    sv = Kom igen
-    th = ไปกันเลย
-    tr = Hadi gidelim
-    uk = Поїхали
-    vi = Đi nào
-    el = Πάμε
-    sk = Poďme
-    sw = Twende zetu
-    zh-Hans = 前往
-    zh-Hant = 前往
-    fa = برویم
-
-  [pick_destination]
-    en = Destination
-    ru = Цель
-    ar = جهة الوصول
-    cs = Destinace
-    da = Destination
-    nl = Doel
-    fi = Kohde
-    fr = Point d'arrivée
-    de = Ziel
-    hu = Cél
-    id = Tujuan
-    it = Meta
-    ja = 目的地
-    ko = 목적지
-    nb = Destinasjon
-    pl = Meta
-    pt = Objetivo
-    pt-BR = Destino
-    ro = Scop
-    es = Objetivo
-    es-MX = Objetivo
-    sv = Målet
-    th = จุดหมาย
-    tr = Hedef
-    uk = Ціль
-    vi = Mục đích
-    el = Προορισμός
-    sk = Cieľ
-    sw = Mahali
-    zh-Hans = 目标
-    zh-Hant = 目標
-    fa = مقصد
-
-  [follow_my_position]
-    en = Re-center
-    ru = Отцентровать
-    ar = العودة إلى الوسط
-    cs = Znovu vystředit
-    da = Centrer igen
-    nl = Centreren
-    fi = Kohdista
-    fr = Préciser
-    de = Zentrieren
-    hu = Középre
-    id = Pusatkan ulang
-    it = Centrare
-    ja = リセンター
-    ko = 내 위치 조정하기
-    nb = Sentrer
-    pl = Wyśrodkuj
-    pt = Centrar
-    pt-BR = Re-centralizar
-    ro = Centrați
-    es = Centrar
-    es-MX = Centrar
-    sv = Placera i mitten
-    th = รีเซ็นเตอร์
-    tr = Tekrar ortala
-    uk = Відцентрувати
-    vi = Định tâm
-    el = Επανατοποθέτηση
-    sk = Vycentrovať
-    sw = Weka kati tena
-    zh-Hans = 定好中心
-    zh-Hant = 定好中心
-    fa = نشان دادن مجدد در مرکز
-
-  [search_results]
-    en = Search results
-    ru = Результаты поиска
-    ar = نتائج البحث
-    cs = Prohledat výsledky
-    da = Søgeresultater
-    nl = Zoekresultaten
-    fi = Hakutulokset
-    fr = Résultats de recherche
-    de = Suchergebnisse
-    hu = Keresési eredmények
-    id = Hasil pencarian
-    it = Risultati di ricerca
-    ja = 検索結果
-    ko = 검색 결과
-    nb = Søkeresultater
-    pl = Wyniki wyszukiwania
-    pt = Resultados da pesquisa
-    pt-BR = Resultados de pesquisa
-    ro = Rezultatul căutării
-    es = Resultados de búsqueda
-    es-MX = Resultados de la búsqueda
-    sv = Sökresultat
-    th = ผลการค้นหา
-    tr = Arama sonuçları
-    uk = Результати пошуку
-    vi = Kết quả tìm kiếm
-    el = Αποτελέσματα αναζήτησης
-    sk = Výsledky vyhľadávania
-    sw = Matokeo ya utafutaji
-    zh-Hans = 搜索结果
-    zh-Hant = 搜索結果
-    fa = نتایج جستجو
-
-  [then_turn]
-    en = Then
-    ru = Затем
-    ar = ثم
-    cs = Poté
-    da = Derefter
-    nl = Dan
-    fi = Sitten
-    fr = Ensuite
-    de = Danach
-    hu = Utána
-    id = Lalu
-    it = Avanti
-    ja = その後
-    ko = 그 다음
-    nb = Deretter
-    pl = Dalej
-    pt = A seguir
-    pt-BR = Então
-    ro = După
-    es = Después
-    es-MX = Después
-    sv = Vidare
-    th = จากนั้น
-    tr = Sonra
-    uk = Далі
-    vi = Sau đó
-    el = Μετά
-    sk = Potom
-    sw = Kisha
-    zh-Hans = 接下来
-    zh-Hant = 接下來
-    fa = سپس
-
-  [redirect_route_alert]
-    en = Do you want to rebuild the route?
-    ru = Хотите перестроить маршрут?
-    ar = هل تريد إعادة تحديد الطريق?
-    cs = Chcete přestavět trasu?
-    da = Vil du genopbygge en rute igen?
-    nl = Wilt u de route wijzigen?
-    fi = Haluatko luoda reitin uudelleen?
-    fr = Voulez-vous reconstruire l'itinéraire ?
-    de = Möchten Sie die Route neu erstellen?
-    hu = Szeretnél újratervezni egy útvonalat?
-    id = Anda ingin membuat ulang rute?
-    it = Vuoi modificare il percorso?
-    ja = ルートを再構築しますか?
-    ko = 루트를 재구축하길 원하시나요?
-    nb = Vil du planlegge en rute på nytt?
-    pl = Czy chcesz przebudować trasę?
-    pt = Deseja personalizar o percurso?
-    pt-BR = Você deseja retraçar a rota?
-    ro = Doriți să refaceți traseul?
-    es = ¿Quieres reconstruir la ruta?
-    es-MX = ¿Quiere reconstruir la ruta?
-    sv = Räknar om rutten?
-    th = ต้องการสร้างเส้นทางใหม่หรือไม่
-    tr = Yeniden bir rota oluşturmak ister misiniz?
-    uk = Бажаєте перебудувати маршрут?
-    vi = Bạn có muốn tạo lại tuyến không?
-    el = Θα θέλατε να τροποποιήσετε τη διαδρομή;
-    sk = Chcete znova vytvoriť trasu?
-    sw = Je, unataka kuunda upya njia?
-    zh-Hans = 想重建路线?
-    zh-Hant = 想重建路線?
-    fa = آیا می خواهید مسیر را دوباره ایجاد کنید?
-
-  [redirect_route_yes]
-    en = Yes
-    ru = Да
-    ar = نعم
-    cs = Ano
-    da = Ja
-    nl = Ja
-    fi = Kyllä
-    fr = Oui
-    de = Ja
-    hu = Igen
-    id = Ya
-    it = Sì
-    ja = はい
-    ko = 네
-    nb = Ja
-    pl = Tak
-    pt = Sim
-    pt-BR = Sim
-    ro = Da
-    es = Si
-    es-MX = Si
-    sv = Ja
-    th = ใช่
-    tr = Evet
-    uk = Так
-    vi = Có
-    el = Ναι
-    sk = Áno
-    sw = Ndio
-    zh-Hans = 是
-    zh-Hant = 是
-    fa = بله
-
-  [redirect_route_no]
-    en = No
-    ru = Нет
-    ar = لا
-    cs = Ne
-    da = Nej
-    nl = Nee
-    fi = Ei
-    fr = Non
-    de = Nein
-    hu = Nem
-    id = Tidak
-    it = No
-    ja = いいえ
-    ko = 아니오
-    nb = Nei
-    pl = Nie
-    pt = Não
-    pt-BR = Não
-    ro = Nu
-    es = No
-    es-MX = No
-    sv = Nej
-    th = ไม่ใช่
-    tr = Hayır
-    uk = Ні
-    vi = Không
-    el = Όχι
-    sk = Nie
-    sw = Hapana
-    zh-Hans = 否
-    zh-Hant = 否
-    fa = خیر
-
-  [trip_finished]
-    en = You have arrived!
-    ru = Вы прибыли!
-    ar = لقد وصلت!
-    cs = Přijeli jste!
-    da = Du er ankommet!
-    nl = U bent aangekomen!
-    fi = Olet saapunut!
-    fr = Vous êtes arrivé !
-    de = Sie sind angekommen!
-    hu = Megérkeztél!
-    id = Anda telah tiba!
-    it = Sei giunto a destinazione!
-    ja = 到着しました!
-    ko = 도착했습니다!
-    nb = Du har ankommet!
-    pl = Jesteś na miejscu!
-    pt = Chegou!
-    pt-BR = Você chegou!
-    ro = Ați sosit!
-    es = ¡Llegaste!
-    es-MX = ¡Ya llegó!
-    sv = Du är framme!
-    th = คุณมาถึงแล้ว!
-    tr = Vardınız!
-    uk = Ви прибули!
-    vi = Bạn đã tới nơi!
-    el = Έχετε φτάσει!
-    sk = Prišli ste do cieľa!
-    sw = Umefika!
-    zh-Hans = 您已到达!
-    zh-Hant = 您已到達!
-    fa = شما به مقصد رسیدید!
-
-  [keyboard_availability_alert]
-    en = Keyboard is not available while driving
-    ru = Клавиатура недоступна во время движения
-    ar = لوحة الكتابة غير متاحة أثناء القيادة
-    cs = Při řízení není klávesnice dostupná
-    da = Keyboard er ikke tilgængelig under kørsel
-    nl = Toetsenbord is niet beschikbaar tijdens het rijden
-    fi = Näppäimistö ei ole käytettävissä ajon aikana
-    fr = Clavier non disponible en conduisant
-    de = Die Tastatur ist während der Bewegung nicht zugänglich
-    hu = A billentyűzet nem elérhető vezetés közben
-    id = Papan ketik tidak tersedia saat berkendara
-    it = Tastiera non disponibile in movimento
-    ja = 運転中はキーボードを使用する事はできません
-    ko = 운전 중에는 키보드를 사용할 수 없습니다
-    nb = Tastatur er ikke tilgjengelig mens en kjører
-    pl = Klawiatura nie jest dostępna podczas ruchu
-    pt = Teclado indisponível durante o movimento
-    pt-BR = O teclado não está disponível enquanto dirige
-    ro = Tastiera nu este accesibilă în timpul deplasării
-    es = Teclado no disponible durante el movimiento
-    es-MX = El teclado no está disponible durante el movimiento
-    sv = Tangentbordet är inte tillgängligt vid rörelsen
-    th = คีย์บอร์ดไม่สามารถใช้งานได้ขณะขับขี่
-    tr = Klavye, sürüş sırasında kullanılamaz
-    uk = Клавіатура недоступна під час руху
-    vi = Bàn phím không khả dụng trong thời gian di chuyển
-    el = Το πληκτρολόγιο δεν είναι διαθέσιμο κατά τη διάρκεια οδήγησης
-    sk = Počas jazdy nie je klávesnica k dispozícii
-    sw = Mbao-bonye haipatikani wakati wa kuendesha gari
-    zh-Hans = 移动时键盘不可用
-    zh-Hant = 移動時鍵盤不可用
-    fa = صفحه کلید در هنگام رانندگی در دسترس نیست
-
-  [dialog_routing_change_start_carplay]
-    en = Unable to build a route from your current location
-    ru = Невозможно построить маршрут от текущего местоположения
-    ar = لا يمكن تحديد طريق من موقعك الحالي
-    cs = Od vaší aktuální polohy nelze vystavět trasu
-    da = Det er ikke muligt at beregne rute fra din nuværende position
-    nl = Kan route vanaf huidige positie niet opbouwen
-    fi = Reittiä ei ole mahdollista luoda nykyisestä sijainnista
-    fr = Impossible de créer un itinéraire à partir de lieux actuel
-    de = Es ist unmöglich eine Reiseroute vom aktuellen Standort planen
-    hu = Nem lehet útvonalat tervezni a jelenlegi helyedről
-    id = Tidak dapat membuat rute dari lokasi saat ini
-    it = Impossibile creare percorso dal punto di partenza selezionato
-    ja = 現在位置からはルートを構築できません
-    ko = 현재 위치에서 루트를 만들 수 없습니다
-    nb = Kan ikke planlegge rute fra din nåværende posisjon
-    pl = Brak możliwości zbudowania trasy od bieżącej lokalizacji
-    pt = Impossível criar percurso a partir da localização atual
-    pt-BR = Desativar rota demarcada pela sua localização atual
-    ro = Este imposibil de elabora traseul de la punctul de aflare
-    es = No se puede construir la ruta desde la ubicación actual
-    es-MX = No se puede construir una ruta desde la ubicación actual
-    sv = Det gick inte att bygga rutten från nuvarande plats
-    th = ไม่สามารถสร้างเส้นทางจากตำแหน่งปัจจุบันของคุณ
-    tr = Mevcut konumunuzdan rota oluşturulamıyor
-    uk = Неможливо побудувати маршрут від поточного місця розташування
-    vi = Không thể tạo tuyến đường từ địa điểm hiển tại
-    el = Δεν είναι δυνατή η δημιουργία διαδρομής από την τρέχουσα τοποθεσία σας
-    sk = Z vašej aktuálnej polohy nie je možné vytvoriť trasu
-    sw = Haiwezi kuunda njia kutokea kwenye eneo lako la sasa
-    zh-Hans = 无法从当前位置构建路线
-    zh-Hant = 無法從當前位置構建路線
-    fa = امکان ایجاد مسیر از مکان فعلی شما نیست
-
-  [dialog_routing_change_end_carplay]
-    en = Unable to build a route to your destination. Please choose another point
-    ru = Невозможно построить маршрут до конечной точки. Выберите другую
-    ar = لا يمكن تحديد طريق لجهة الوصول. يرجي اختيار مكان آخر
-    cs = Nelze vystavět trasu k vaší destinaci. Zvolte prosím další bod
-    da = Det er ikke muligt at beregne rute til din destination. Vælg en anden destination
-    nl = Kan route naar het eindpunt niet opbouwen. Kies een andere punt
-    fi = Reittiä ei ole mahdollista luoda loppupisteeseen. Valitse toinen
-    fr = Impossible de créer un itinéraire jusqu'au point final. Choisissez un autre
-    de = Es ist unmöglich eine Reiseroute bis zum Endpunkt planen. Wählen Sie einen anderen
-    hu = Nem lehet útvonalat tervezni a célodhoz. Kérjük válassz egy másik pontot
-    id = Tidak dapat membuat rute ke tujuan Anda. Pilih titik lainnya
-    it = Impossibile creare percorso per raggiungere la destinazione Scegli un'altra destinazione
-    ja = 目的地へのルートは構築できません。別の地点を選択してください
-    ko = 목적지 경로를 만들 수 없습니다. 다른 지점을 선택해주세요
-    nb = Kan ikke planlegge rute til din nåværende posisjon. Vennligst velg en annen posisjon
-    pl = Brak możliwości zbudowania trasy do punktu końcowego. Wybierz inny
-    pt = Impossível criar percurso para o ponto final. Escolher outro
-    pt-BR = Incapaz de traçar rota para o seu destino. Por favor, escolha outro ponto de destino
-    ro = Este imposibil de elaborat traseu până la punctul de sosire. Selectați altul
-    es = No se puede construir la ruta al punto final. Elige otra
-    es-MX = No se puede construir una ruta hasta el punto final. Seleccione otra
-    sv = Det går inte att bygga rutten till slutpunkten. Välj en annan
-    th = ไม่สามารถสร้างเส้นทางไปยังจุดหมายของคุณ โปรดเลือกจุดหมายใหม่
-    tr = Hedefinize rota oluşturulamıyor. Lütfen başka bir nokta seçin
-    uk = Неможливо побудувати маршрут до кінцевої точки. Оберіть іншу
-    vi = Không thể tạo tuyến đường tới điểm kết cuối. Hãy chọn điểm khác
-    el = Δεν είναι δυνατή η δημιουργία διαδρομής μέχρι τον προορισμό σας. Επιλέξτε ένα άλλο σημείο
-    sk = Nie je možné vytvoriť trasu do cieľa. Prosím vyberte iný bod
-    sw = Haiwezi kuunda njia kwenda uendako. Tafadhali chagua sehemu nyingine
-    zh-Hans = 无法建立到终点的路线。请选择其他（路线）
-    zh-Hant = 無法建立到終點的路線。請選擇其他（路線）
-    fa = امکان ایجاد مسیر به مقصد شما نیست. لطفاً نقطه دیگری را انتخاب کنید
-
-  [dialog_routing_check_gps_carplay]
-    en = No GPS signal. Please move to an open area
-    ru = Нет сигнала GPS. Проследуйте на открытую местность
-    ar = لا وجد إشارة GPS. يرجى التحرك لمكان مفتوح
-    cs = Signál GPS neexistuje. Přesuňte se prosím do otevřeného prostoru
-    da = Intet GPS signal. Flyt til et område med dækning
-    nl = Geen GPS-signaal. Ga naar het open veld
-    fi = Ei ole GPS-signaalia. Siirry avaralle alueelle
-    fr = Pas de signal GPS. Passez sur le site ouvert
-    de = Kein GPS-Signal. Gehen Sie in das offene Gelände
-    hu = Nincs GPS-jel. Kérjük menj egy nyílt területre
-    id = Tidak ada sinyal GPS. Harap pindah ke area terbuka
-    it = Segnale GPS assente. Procedi su terreno aperto
-    ja = GPS信号がありません。開けた場所へ移動してください
-    ko = GPS 신호가 없습니다. 열린 장소로 이동해주세요
-    nb = Ingen GPS-signal. Vennligst gå til et åpent område
-    pl = Brak sygnału GPS. Dostań się do terenu otwartego
-    pt = Sem GPS. Siga para uma área aberta
-    pt-BR = Sem sinal de GPS. Por favor, vá para uma região aberta
-    ro = Nu este semnal GPS. Mergeți la loc deschis
-    es = No hay señal GPS. Ve a una zona abierta
-    es-MX = No hay señal de GPS. Vaya a una zona abierta
-    sv = Ingen GPS-signal. Följ till öppna området
-    th = ไม่มีสัญญาณจีพีเอส โปรดไปในที่โล่งเพื่อหาสัญญาณ
-    tr = GPS sinyali yok. Lütfen açık bir alana geçin
-    uk = Немає сигналу GPS. Перейдіть на відкриту місцевість
-    vi = Không có tín hiệu GPS. Hãy đến vị trí có không gian mở
-    el = Δεν υπάρχει σήμα GPS. Μετακινήστε σε μια ανοικτή τοποθεσία
-    sk = Žiaden GPS signál. Presuňte sa na otvorené priestranstvo
-    sw = Hakuna ishara ya GPS. Tafadhali sogea katika eneo jingine la wazi
-    zh-Hans = 无GPS信号。请沿着空旷区域行驶
-    zh-Hant = 無GPS信號。請沿著空曠區域行駛
-    fa = سیگنال GPS وجود ندارد. لطفاً به فضای باز بروید
-
-  [dialog_routing_unable_locate_route_carplay]
-    en = Unable to build a route. Please specify other route points
-    ru = Невозможно построить маршрут. Выберите другие точки маршрута
-    ar = لا يمكن تحديد طريق. يرجى تحديد أماكن أخرى على الطريق
-    cs = Nelze sestavit trasu. Specifikujte prosím další body trasy
-    da = Det er ikke muligt at beregne rute. Vælg andre forbindelses-punkter for ruten
-    nl = Kan route niet bouwen. Selecteer andere tussenpunten
-    fi = Reittiä ei ole mahdollista luoda. Valitse muut reittipisteet
-    fr = Impossible de calculer l'itinéraire. Sélectionnez les autres points d'itinéraire
-    de = Es ist unmöglich, eine Route zu planen. Wählen Sie andere Routenpunkte
-    hu = Nem lehet útvonalat tervezni. Kérjük határozz meg más útvonal lehetőségeket
-    id = Tidak dapat membuat rute. Harap tentukan titik rute lainnya
-    it = Impossibile trovare percorso. Scegli altre tappe
-    ja = ルートが構築できません。別のルート地点を設定して下さい
-    ko = 루트를 만들 수 없습니다. 또 다른 루트 지점을 지정해주세요
-    nb = Kan ikke planlegge rute. Vennligst spesifiser en annen posisjon for rute
-    pl = Brak możliwości zbudowania trasy. Wybierz inne punkty trasy
-    pt = Impossível criar percurso. Escolher outros pontos do percurso
-    pt-BR = Incapaz de traçar rota. Por favor, especifique outros pontos para a rota
-    ro = Este imposibil de elaborat un traseu. Selectați alte puncte ale traseului
-    es = No se puede construir una ruta. Elige otros puntos de ruta
-    es-MX = No se puede construir una ruta. Seleccione otros puntos de ruta
-    sv = Det går inte att bygga ruten. Välj andra rutenspunkter
-    th = ไม่สามารถคำนวณเส้นทาง โปรดระบุตำแหน่งของเส้นทางอื่น
-    tr = Rota oluşturulamıyor. Lütfen başka bir rota noktası belirtin
-    uk = Неможливо побудувати маршрут. Оберіть інші точки маршруту
-    vi = Không thể tạo tuyến đường. Hãy chọn những điểm khác cho tuyến đường
-    el = Δεν είναι δυνατή η δημιουργία διαδρομής. Επιλέξτε άλλα σημεία διαδρομής
-    sk = Nie je možné vytvoriť trasu. Prosím zadajte iné body trasy
-    sw = Haiwezi kuunda njia. Tafadhali taja kituo kingine cha njia
-    zh-Hans = 无法建立路线。请选择其他路线点
-    zh-Hant = 無法建立路線。請選擇其他路線點
-    fa = امکان ایجاد مسیر نیست. لطفاً نقاط مسیر دیگری را مشخص کنید
-
-  [dialog_routing_download_files_carplay]
-    en = To create a route, download missing maps on your device
-    ru = Чтобы построить маршрут, загрузите недостающие карты на своем устройстве
-    ar = كي تُنشئ مساراً، يجب أن تحمل الخرائط المفقودة على جهازك
-    cs = K vytvoření trasy si stáhněte chybějící mapy do vašeho zařízení
-    da = Download manglende kort til din enhed, for at lave ruten
-    nl = Om een route te bouwen, download u ontbrekende kaarten
-    fi = Luodaksesi reitin lataa puutt. kartat
-    fr = Pour créer la route, téléchargez les cartes sur votre appareil
-    de = Laden Sie die fehlenden Karten hoch, um die Route zu erstellen
-    hu = Útvonal létrehozásához töltsd le a hiányzó térképeket az eszközre
-    id = Untuk membuat rute, unduh peta baru di perangkat anda
-    it = Per creare percorso scarica mappe mancanti sul proprio dispositivo
-    ja = ルートを作成するには、地図に表示されていない部分を端末でダウンロードします
-    ko = 루트를 만들려면, 빠진 맵을 기기에 다운로드하세요
-    nb = For å beregne rute last ned manglende kart på enheten din
-    pl = Aby wyznaczyć trasę, pobierz brakujące mapy na Twoim urządzeniu
-    pt = Para construir percurso falta carregar os mapas no seu dispositivo
-    pt-BR = Para criar uma rota, baixe os mapas ausentes no seu dispositivo
-    ro = Pentru noi trasee, încărcați hărțile lipsa pe dispozitivul dvs.
-    es = Al construir ruta, descarga los mapas ausentes en tu dispositivo
-    es-MX = Al construir ruta, descargue los mapas ausentes en su dispositivo
-    sv = För att skapa en rutt, ladda ner saknade kartor på din enhet
-    th = เพื่อสร้างเส้นทาง โปรดดาวน์โหลดแผนที่บนอุปกรณ์ของคุณ
-    tr = Rota oluşturmak için cihazınızdaki eksik haritaları indirin
-    uk = Щоб побудувати маршрут, завантажте відсутні карти на своєму пристрої
-    vi = Để tạo tuyến đường, hãy tải xuống các bản đồ còn thiếu về thiết bị
-    el = Για να χτίσετε διαδρομή, κατεβάστε χάρτες που λείπουν στη συσκευή
-    sk = Pre vytvorenie trasy si stiahnite do zariadenia chýbajúce mapy
-    sw = Kuunda njia, pakua ramani zilizokosekana kwenye kifaa chako
-    zh-Hans = 为了创建线路，请在您的设备中下载所缺少的地图
-    zh-Hant = 爲了創建線路，請在您的設備中下載所缺少的地圖
-    fa = برای ایجاد مسیر، نقشه های ناقص را روی دستگاه خود را دانلود کنید
-
-  [dialog_routing_system_error_carplay]
-    en = An error occurred. Please restart the application
-    ru = Произошла ошибка. Перезапустите приложение
-    ar = حدث خطأ. يرجى إعادة تشغيل التطبيق
-    cs = Vyskytla se chyba. Restartujte prosím aplikaci
-    da = Der opstod en fejl. Genstart programmet
-    nl = Lets fout gegaan. Start de app opnieuw
-    fi = On tapahtunut virhe. Käynnistä sovellus uudelleen
-    fr = Une erreur est survenue. Redémarrez l'application
-    de = Fehler aufgetreten. Starten Sie Applikation neu
-    hu = Hiba történt. Kérjük indítsd újra az alkalmazást
-    id = Terjadi kesalahan. Harap mulai ulang aplikasi
-    it = Si è verificato un errore. Riavviare l'applicazione
-    ja = エラーが発生しました。アプリを再起動してください
-    ko = 오류 발생. 어플리케이션을 재실행해주시길 바랍니다
-    nb = Feil oppstod. Vennligst restart appen
-    pl = Wystąpił błąd. Uruchom aplikację ponownie
-    pt = Ocorreu um erro. Reiniciar aplicação
-    pt-BR = Ocorreu um erro. Por favor, reinicie o aplicativo
-    ro = Eroare. Restartați aplicația
-    es = Ocurrió un error. Reinicia la aplicación
-    es-MX = Ocurrió un error. Reinicie la aplicación
-    sv = Ett fel uppstod. Starta om appen
-    th = พบข้อผิดพลาด โปรดปิดและเปิดแอปพลิเคชันใหม่อีกครั้ง
-    tr = Hata oluştu. Lütfen uygulamayı yeniden başlatın
-    uk = Виникла помилка. Перезапустіть додаток
-    vi = Đã xảy ra lỗi. Khởi động lại ứng dụng
-    el = Παρουσιάστηκε σφάλμα. Κάντε επανεκκίνηση της εφαρμογής
-    sk = Vyskytla sa chyba. Prosím reštartujte aplikáciu
-    sw = Hitilafu imetokea. Tafadhali iwashe tena programu
-    zh-Hans = 发生了错误。请重新启动程序
-    zh-Hant = 發生了錯誤。請重新啟動程序
-    fa = خطایی رخ داد. لطفاً برنامه را دوباره اجرا کنید
-
-  [dialog_routing_rebuild_from_current_location_carplay]
-    en = The route will be rebuilt from your current location
-    ru = Маршрут будет перестроен от вашего текущего местоположения
-    ar = سيتم اعادة تحديد الطريق من موقعك الحالي
-    cs = Trasa bude přestavěna od vaší aktuální polohy
-    da = Rute vil blive beregnet igen, ud fra din nuværende position
-    nl = De route wordt opnieuw opgebouwd vanaf uw huidige positie
-    fi = Reitti luodaan nykyisestä sijainnista
-    fr = L'itinéraire sera reconstruit à partir de votre position actuelle
-    de = Die Route wird von Ihrem derzeitigen Standpunkt geplant werden
-    hu = Az útvonal újra lesz tervezve a jelenlegi helyzetedről
-    id = Rute akan dibuat ulang dari lokasi saat ini
-    it = Il percorso verrà impostato dalla tua posizione corrente
-    ja = ルートは現在位置から再構築されます
-    ko = 루트가 귀하의 현재 위치로부터 재생성됩니다
-    nb = Rute vil planlegges fra din nåværende posisjon
-    pl = Trasa zostanie przebudowana z Twojej bieżącej lokalizacji
-    pt = O percurso será reconstruído a partir da sua localização atual
-    pt-BR = A rota sera retraçada a partir de sua localização atual
-    ro = Traseul se va reface de la locul actual al aflării dvs
-    es = La ruta se reconstruirá desde tu ubicación actual
-    es-MX = La ruta se reconstruirá desde su ubicación actual
-    sv = Ruten kommer att byggas om från din nuvarande plats
-    th = เส้นทางจะถูกสร้างอีกครั้งจากตำแหน่งปัจจุบันของคุณ
-    tr = Rota, mevcut konumunuzdan yeniden oluşturulacak
-    uk = Маршрут буде перебудовано від вашого поточного місця розташування
-    vi = Tuyến đường sẽ được tạo lại từ vị trí hiện tại của bạn
-    el = Η διαδρομή θα ξαναδημιουργηθεί από την τρέχουσα τοποθεσία σας
-    sk = Trasa bude obnovená z vašej aktuálnej polohy
-    sw = Njia itaundwa upya kutokea kwenye sehemu yako la sasa
-    zh-Hans = 该路线将从您的当前位置重建
-    zh-Hant = 該路線將從您的當前位置重建
-    fa = مسیر از مکان فعلی شما بازسازی خواهد شد
-
-  [dialog_routing_rebuild_for_vehicle_carplay]
-    en = The route will be converted into an automobile one
-    ru = Маршрут будет изменен на автомобильный
-    ar = سيتم تعديل الطريق لتكون خاصة بالسيارة
-    cs = Trasa bude upravena k autu jedna
-    da = Rute vil blive ændret til en kørselsrute
-    nl = De route wordt gewijzigd in de autoroute
-    fi = Reitti muutetaan autoilijan reitiksi
-    fr = L'itinéraire sera changé en mode Voiture
-    de = Reiseroute wird zur Route für Fahrzeug geändert sein
-    hu = Az útvonal módosítva lesz egy autó számára
-    id = Rute akan diubah untuk mobil
-    it = Il percorso verrà modificato in modalità Auto
-    ja = ルートは自動車用として修正されます
-    ko = 루트가 차량에 맞춰 수정됩니다
-    nb = Rute vil oppdateres til kjørerute
-    pl = Trasa zostanie zmieniona na samochodową
-    pt = O percurso será reconstruído para o rodoviário
-    pt-BR = A rota será alterada para uma de automóvel
-    ro = Traseul va fi modificat cu unul automobilistic
-    es = La ruta se cambiará a coche
-    es-MX = La ruta se cambiará a en auto
-    sv = Ruten kommer att ändras till bil
-    th = เส้นทางของรถยนต์อาจถูกปรับเปลี่ยน
-    tr = Rota, bir arabalı seyahat rotasına dönüştürülecek
-    uk = Маршрут буде змінено на автомобільний
-    vi = Tuyến đường sẽ được thay đổi thành tuyến dành cho xe ô tô
-    el = Η διαδρομή θα αντικατασταθεί με τη διαδρομή με αυτοκίνητο
-    sk = Trasa bude upravená na jazdu autom
-    sw = Njia itaboreshwa kuwa ya gari
-    zh-Hans = 该路线将改为汽车（路线）
-    zh-Hant = 該路線將改為汽車（路線）
-    fa = مسیر به مسیر خودرویی تغییر خواهد کرد
+    sk = Vyhnúť sa prechodom na trajekte
+    sw = Epuka vivuko vya feri
 
   [ok]
+    tags = ios, android
     en = Ok
     ru = Ок
     ar = موافق
@@ -27634,361 +16825,22 @@
     pt-BR = Tudo bem
     ro = Ok
     es = Ok
-    es-MX = Ok
     sv = Ok
     th = โอเค
     tr = Tamam
     uk = Ок
     vi = Ok
-    el = Καλώς
-    sk = Ok
-    sw = Sawa
     zh-Hans = 好的
     zh-Hant = 好的
+    el = Καλώς
+    es-MX = Ok
     fa = موافقت کردن
-
-  [avoid_unpaved_carplay_1]
-    en = No dirt road
-    ru = Без грунт.
-    ar = غير ترابي
-    cs = Bez pr. cest
-    da = Ingen grus
-    nl = Geen aardew.
-    fi = Päällyste
-    fr = Route de ter
-    de = Ohne Landstr
-    hu = Nem földút
-    id = Jalan aspal
-    it = No sterrati
-    ja = 未舗装道路無し
-    ko = 비포장 도로 없음
-    nb = Ikke grusvei
-    pl = Bez gruntow.
-    pt = Sem rurais
-    pt-BR = Não pav.
-    ro = Fără neasfal
-    es = Sin de grava
-    es-MX = Sin de grava
-    sv = Utan kärrväg
-    th = ไม่มีลูกรัง
-    tr = Stabilizesiz
-    uk = Без ґрунт.
-    vi = Trừ đườg đất
-    el = Χ/χωματόδρ.
-    sk = Nespevn. NIE
-    sw = Hamna za vum
-    zh-Hans = 无土路路段
-    zh-Hant = 無土路路段
-    fa = بی جاده خاکی
-
-  [avoid_unpaved_carplay_2]
-    en = Avoid unpaved
-    ru = Без грунтовых
-    ar = تجنب غير الممهد
-    cs = Vyhnout se nezp
-    da = Undgå grus
-    nl = Geen aardewegen
-    fi = Vain päällyste
-    fr = Route de terre
-    de = Ohne Landstr.
-    hu = Földút kerülése
-    id = Hindari tanah
-    it = No sterrati
-    ja = 未舗装道路無し
-    ko = 비포장 도로 없음
-    nb = Ikke uasfaltert
-    pl = Bez gruntowych
-    pt = Sem rurais
-    pt-BR = Evitar não pav.
-    ro = Fără neasfaltat
-    es = Sin de grava
-    es-MX = Sin de grava
-    sv = Utan kärrvägar
-    th = หลีกเลี่ยงทาง
-    tr = Asfaltsız hariç
-    uk = Без ґрунтових
-    vi = Trừ khôg trnhựa
-    el = Χ/χωματόδρομους
-    sk = Nespevnené ÁNO
-    sw = Epuka za vumbi
-    zh-Hans = 无土路路段
-    zh-Hant = 無土路路段
-    fa = پرهیز از خاکی
-
-  [avoid_ferry_carplay_1]
-    en = No ferries
-    ru = Без паромов
-    ar = بدون عبََارة
-    cs = Bez trajektů
-    da = Ingen færger
-    nl = Geen ferry's
-    fi = Ei lauttoja
-    fr = Sans navires
-    de = Ohne Fähren
-    hu = Komp nélkül
-    id = Tanpa feri
-    it = No traghetti
-    ja = フェリー無し
-    ko = 여객선 없음
-    nb = Ingen ferger
-    pl = Bez promów
-    pt = Sem ferry
-    pt-BR = Sem balsas
-    ro = Fără bacuri
-    es = Sin ferri
-    es-MX = Sin ferri
-    sv = Utan färjor
-    th = ไม่มีเรือ
-    tr = Feribotsuz
-    uk = Без поромів
-    vi = Không có phà
-    el = Χ/πορθμεία
-    sk = Trajekty NIE
-    sw = Hamna feri
-    zh-Hans = 无渡船
-    zh-Hant = 無渡船
-    fa = بدون بزرگراه
-
-  [avoid_ferry_carplay_2]
-    en = Avoid ferries
-    ru = Без паромов
-    ar = تجنب العبََارة
-    cs = Vyh. se traj.
-    da = Undgå færger
-    nl = Geen ferry's
-    fi = Ei lauttoja
-    fr = Sans navires
-    de = Ohne Fähren
-    hu = Kompok kerülése
-    id = Hindari feri
-    it = No traghetti
-    ja = フェリーを回避
-    ko = 여객선 없음
-    nb = Unngå ferger
-    pl = Bez promów
-    pt = Sem ferry
-    pt-BR = Evitar balsas
-    ro = Fără bacuri
-    es = Sin ferri
-    es-MX = Sin ferri
-    sv = Utan färjor
-    th = หลีกเลี่ยงเรือ
-    tr = Feribot hariç
-    uk = Без поромів
-    vi = Trừ phà
-    el = Χωρίς πορθμεία
-    sk = Trajekty ÁNO
-    sw = Epuka feri
-    zh-Hans = 无渡船
-    zh-Hant = 無渡船
-    fa = پرهیز از اتوبان
-
-  [avoid_tolls_carplay_1]
-    en = No toll road
-    ru = Без платных
-    ar = بدون رسوم
-    cs = Bez pl.sil.
-    da = Ingen betal.
-    nl = Zonder tol
-    fi = Ei maksua
-    fr = Sans péage
-    de = Ohne kpf Str
-    hu = Nincs útdíj
-    id = Tanpa tol
-    it = No pedaggi
-    ja = 有料道路無し
-    ko = 유료 도로 없음
-    nb = Ingen bomvei
-    pl = Wył. płatne
-    pt = Sem pedágio
-    pt-BR = Sem pedágio
-    ro = Gratis
-    es = Sin peaje
-    es-MX = Sin peaje
-    sv = Utan betalda
-    th = ไม่มีค่าผ่าน
-    tr = Paralı yok
-    uk = Без платних
-    vi = Khôg đgcóphí
-    el = Χωρίς διόδια
-    sk = Spoplat. NIE
-    sw = Hamna za ada
-    zh-Hans = 无付费路段
-    zh-Hant = 無付費路段
-    fa = بدون عوارضی
-
-  [avoid_tolls_carplay_2]
-    en = Avoid toll road
-    ru = Без платных
-    ar = تجنب الرسوم
-    cs = Vyh. se pl. sil
-    da = Undgå betaling
-    nl = Zonder tol
-    fi = Ei maksua
-    fr = Sans péage
-    de = Ohne kpfl. Str.
-    hu = Útdíj kerülése
-    id = Hindari tol
-    it = Senza pedaggi
-    ja = 有料道路を回避
-    ko = 유료 도로 없음
-    nb = Unngå bomvei
-    pl = Wyłącz płatne
-    pt = Sem pedágio
-    pt-BR = Evitar pedágios
-    ro = Gratis
-    es = Sin peaje
-    es-MX = Sin peaje
-    sv = Utan betalda
-    th = เลี่ยงทางด่วน
-    tr = Paralı hariç
-    uk = Без платних
-    vi = Trừ đg có phí
-    el = Χωρίς διόδια
-    sk = Spoplatnené ÁNO
-    sw = Epuka njia-kodi
-    zh-Hans = 无付费路段
-    zh-Hant = 無付費路段
-    fa = اجتناب از عوارض
-
-  [speedcams_alert_title_carplay_1]
-    en = Speedсams
-    ru = Камеры
-    ar = كاميرا سريعة
-    cs = Rych. kam.
-    da = Radarkontrol
-    nl = Cameras
-    fi = Nopeuskamera
-    fr = Caméras
-    de = Blitzer
-    hu = Traffipaxok
-    id = Speedcam
-    it = Autovelox
-    ja = 速度警告
-    ko = 속도단속 카메라
-    nb = Kamera-info
-    pl = Kamery
-    pt = Radares
-    pt-BR = Radares
-    ro = Cameră video
-    es = Cám.velocid.
-    es-MX = Cám.velocid.
-    sv = Kameror
-    th = จับความเร็ว
-    tr = Hız kamerası
-    uk = Камери
-    vi = Сam tốc độ
-    el = Κάμερες
-    sk = Radary
-    sw = Kam za kasi
-    zh-Hans = 摄像头
-    zh-Hant = 攝像頭
-    fa = دوربین سرعت
-
-  [speedcams_alert_title_carplay_2]
-    en = Speed warnings
-    ru = Инфо о камерах
-    ar = تحذير سريع
-    cs = Rych. varování
-    da = Radar advarsel
-    nl = Over cameras
-    fi = Nopeuskamerat
-    fr = Info Caméras
-    de = Blitzerwarnung
-    hu = Sebességjelzés
-    id = Info kecepatan
-    it = Info autovelox
-    ja = 速度警告
-    ko = 속도단속 카메라
-    nb = Kamera-advarsel
-    pl = Info o kamerach
-    pt = Avisos de radar
-    pt-BR = Alertas de vel.
-    ro = Info camere
-    es = Alerta velocid.
-    es-MX = Alerta velocid.
-    sv = Info om kameror
-    th = เตือนความเร็ว
-    tr = Hız uyarıları
-    uk = Інфо о камерах
-    vi = Cảnh báo tốc độ
-    el = Πληροφ. γιαόρια
-    sk = Rýchl. upozorn.
-    sw = Onyo la kasi
-    zh-Hans = 摄像头信息
-    zh-Hant = 攝像頭信息
-    fa = هشدارهای سرعت
-
-  [download_map_carplay]
-    en = Please download maps in Organic Maps app on your device
-    ru = Скачайте карты в приложении Organic Maps на своем устройстве
-    ar = يُرجى تحميل الخرائط في تطبيق Organic Maps على جهازك
-    cs = Stáhněte si prosím mapy do aplikace Organic Maps ve vašem zařízení
-    da = Download kort i Organic Maps appen, på din enhed
-    nl = Download kaarten in de Organic Maps app op uw apparaat
-    fi = Lataa kartat laitteesi Organic Maps-sovelluksessa
-    fr = Téléchargez des cartes dans l'application Organic Maps sur votre appareil
-    de = Laden Sie Karten in der App Organic Maps auf Ihrem Gerät herunter
-    hu = Kérjük, töltsd le a térképeket a Organic Maps alkalmazásban az eszközödre
-    id = Silakan unduh peta di apl Organic Maps pada perangkat Anda
-    it = Scarica l'applicazione Organic Maps sul tuo smartphone
-    ja = あなたの機器のOrganic Mapsのアプリにマップをダウンロードしてください
-    ko = Organic Maps 앱 안의 지도들을 디바이스에 다운로드하세요
-    nb = Vennligst last ned kart i Organic Maps appen på enheten din
-    pl = Pobierz mapy do aplikacji Organic Maps na swoje urządzenie
-    pt = Baixar mapas de aplicação Organic Maps para o seu dispositivo
-    pt-BR = Por favor, baixe mapas no app Organic Maps em seu dispositivo
-    ro = Vă rugăm să descărcați hărțile în aplicația Organic Maps de pe dispozitivul dvs.
-    es = Descarga mapas en la aplicación Organic Maps en tu dispositivo
-    es-MX = Descargue mapas en la aplicación Organic Maps en su dispositivo
-    sv = Ladda ner kartor i applikation Organic Maps på din enhet
-    th = โปรดดาวน์โหลดแผนที่ในแอพฯ Organic Maps บนอุปกรณ์ของคุณ
-    tr = Lütfen haritaları cihazınıza Organic Maps uygulamasından indirin
-    uk = Завантажте карти в додатку Organic Maps на своєму пристрої
-    vi = Vui lòng tải xuống bản đồ trong ứng dụng Organic Maps trên thiết bị của bạn
-    el = Κάντε λήψη χαρτών στην εφαρμογή Organic Maps στη συσκευή σας
-    sk = Prosím stiahnite si mapy v aplikácii Organic Maps vo vašom zariadení
-    sw = Tafadhali pakua ramani katika programu tumizi ya Organic Maps kwenye kifaa chako
-    zh-Hans = 将Organic Maps软件中的地图下载至个人设备中
-    zh-Hant = 將Organic Maps軟件中的地圖下載至個人設備中
-    fa = لطفا نقشه ها را در نرم افزار Organic Maps روی دستگاه خود دانلود کنید
-
-  [carplay_roundabout_exit]
-    en = %s exit
-    ru = %s съезд
-    ar = المخرج رقم %s
-    cs = %s výjezd
-    da = %s exit
-    nl = Afrit nr. %s
-    fi = Poistumisramppi %s
-    fr = %s sortie
-    de = %s Ausfahrt
-    hu = %s kijárat
-    id = Jalan keluar ke %s
-    it = %s uscita
-    ja = 第%s出口
-    ko = %s번 출구
-    nb = %s avkjøring
-    pl = %s zjazd
-    pt = %s saída
-    pt-BR = %s saída
-    ro = %s ieșire
-    es = %s desviación
-    es-MX = %s desviación
-    sv = %s utgången
-    th = ทางออกที่ %s
-    tr = %s çıkış
-    uk = %s з’їзд
-    vi = Lối ra %s của vòng xuyến
-    el = %s έξοδος
-    sk = %s výjazd
-    sw = Kutoka kwa %s
-    zh-Hans = %s号坡道
-    zh-Hant = %s號坡道
-    fa = خروجی %s
+    sk = Ok
+    sw = Sawa
 
   [sort]
     comment = max. 10 symbols, both iOS and Android
+    tags = android
     en = Sort…
     ru = Сортировать…
     ar = تريتب…
@@ -28009,21 +16861,22 @@
     pt-BR = Ordenar…
     ro = Sortați…
     es = Ordenar…
-    es-MX = Ordenar…
     sv = Sortera…
     th = เรียง…
     tr = Sırala…
     uk = Сортувати
     vi = Sắp xếp…
-    el = Ταξινόμηση
-    sk = Zoradiť…
-    sw = Ainisha…
     zh-Hans = 分类……
     zh-Hant = 分類……
+    el = Ταξινόμηση
+    es-MX = Ordenar…
     fa = مرتب سازی…
+    sk = Zoradiť…
+    sw = Ainisha…
 
   [sort_bookmarks]
     comment = Android, title, max 20-22 symbols
+    tags = android
     en = Sort bookmarks
     ru = Сортировать метки
     ar = رتب العلامات المرجعية
@@ -28044,158 +16897,22 @@
     pt-BR = Ordenar favoritos
     ro = Sortați inscripțiile
     es = Ordenar etiquetas
-    es-MX = Ordenar marcadores
     sv = Sortera bokmärken
     th = เรียงบุ๊กมาร์ก
     tr = Yer imlerini sırala
     uk = Сортувати мітки
     vi = Sắp xếp dấu trang
-    el = Ταξινόμηση σελιδοδ/τών
-    sk = Zoradiť záložky
-    sw = Ainisha alamisho
     zh-Hans = 分类标签
     zh-Hant = 分類標籤
+    el = Ταξινόμηση σελιδοδ/τών
+    es-MX = Ordenar marcadores
     fa = مرتب سازی نشانهها
-
-  [sort_default]
-    comment = iOS
-    en = Sort by default
-    ru = Сортировать по умолчанию
-    ar = رتب افتراضي
-    cs = Třídit ve výchozím nastavení
-    da = Sortér (std)
-    nl = Standaard sorteren
-    fi = Järjestä: oletus
-    fr = Trier par défaut
-    de = Default Sortierung
-    hu = Alapértelmezés szerint
-    id = Urutkan standar
-    it = Ordina per default
-    ja = デフォルトで並び替え
-    ko = 기본 값으로 분류
-    nb = Sortere som standard
-    pl = Sortuj domyślnie
-    pt = Ordenar por predefinição
-    pt-BR = Ordenar por padrão
-    ro = Sortați la modul implicit
-    es = Ordenar por defecto
-    es-MX = Ordenar por defecto
-    sv = Sortera som standard
-    th = เรียงตามค่าเริ่มต้น
-    tr = Varsayılana göre sırala
-    uk = Сортувати за промовчанням
-    vi = Sắp xếp theo mặc định
-    el = Ταξινόμηση κατά προεπιλογή
-    sk = Zoradiť Predvolené
-    sw = Ainisha kwa chaguo-msingi
-    zh-Hans = 默认排序
-    zh-Hant = 默認排序
-    fa = مرتب سازی بر اساس پیش فرض
-
-  [sort_type]
-    en = Sort by type
-    ru = Сортировать по типу
-    ar = رتب حسب النوع
-    cs = Třídit dle typu
-    da = Sort (type)
-    nl = Sorteren op type
-    fi = Järjestä: tyyppi
-    fr = Trier par type
-    de = Sortierung nach Kategorien
-    hu = Típus szerint
-    id = Urutkan per tipe
-    it = Ordina per tipo
-    ja = タイプで並び替え
-    ko = 유형으로 분류
-    nb = Sortere etter type
-    pl = Sortuj wg rodzaju
-    pt = Ordenar por tipo
-    pt-BR = Ordenar por tipo
-    ro = Sortați după dip
-    es = Ordenar por tipo
-    es-MX = Ordenar por tipo
-    sv = Sortera efter typ
-    th = เรียงตามประเภท
-    tr = Türe göre sırala
-    uk = Сортувати за типом
-    vi = Sắp xếp theo kiểu
-    el = Ταξινόμηση ανά τύπο
-    sk = Zoradiť podľa typu
-    sw = Ainisha kwa aina
-    zh-Hans = 按类型排序
-    zh-Hant = 按類型排序
-    fa = مرتب سازی بر اساس نوع
-
-  [sort_distance]
-    en = Sort by distance
-    ru = Сортировать по расстоянию
-    ar = رتب حسب المسافة
-    cs = Třídit dle vzdálenosti
-    da = Sort (Afs)
-    nl = Sorteer op afstand
-    fi = Järjestä: etäisyys
-    fr = Trier par distance
-    de = Sortieren nach Entfernung
-    hu = Távolság szerint
-    id = Urutkan per jarak
-    it = Ordina per distanza
-    ja = 距離で並び替え
-    ko = 거리로 분류
-    nb = Sortere etter avstand
-    pl = Sortuj wg odległości
-    pt = Ordenar por distância
-    pt-BR = Ordenar por distância
-    ro = Sortați după distanță
-    es = Ordenar por distancia
-    es-MX = Ordenar por distancia
-    sv = Sortera efter avstånd
-    th = เรียงตามระยะทาง
-    tr = Mesafeye göre sırala
-    uk = Сортувати за відстанню
-    vi = Sắp xếp theo khoảng cách
-    el = Ταξινόμηση κατά απόσταση
-    sk = Zoradiť podľa vzdialenosti
-    sw = Ainisha kwa umbali
-    zh-Hans = 按距离排序
-    zh-Hant = 按距離排序
-    fa = مرتب سازی بر اساس فاصله
-
-  [sort_date]
-    en = Sort by date
-    ru = Сортировать по дате
-    ar = رتب حسب التاريخ
-    cs = Třídit dle data
-    da = Sort (dato)
-    nl = Sorteer op datum
-    fi = Järjestä: päivämäärä
-    fr = Classer pa date
-    de = Sortieren nach Datum
-    hu = Dátum szerint
-    id = Urutkan per tanggal
-    it = Ordina per data
-    ja = 日付で並び替え
-    ko = 날짜로 분류
-    nb = Sortere etter dato
-    pl = Sortuj wg daty
-    pt = Ordenar por data
-    pt-BR = Ordenar por data
-    ro = Sortați după dată
-    es = Ordenar por fecha
-    es-MX = Ordenar por fecha
-    sv = Sortera efter datum
-    th = เรียงตามวันที่
-    tr = Tarihe göre sırala
-    uk = Сортувати за датою
-    vi = Sắp xếp theo ngày
-    el = Ταξινόμηση κατά ημερομηνία
-    sk = Zoradiť podľa dátumu
-    sw = Ainisha kwa tarehe
-    zh-Hans = 按日期排序
-    zh-Hant = 按日期排序
-    fa = مرتب سازی بر اساس تاریخ
+    sk = Zoradiť záložky
+    sw = Ainisha alamisho
 
   [by_default]
     comment = Android
+    tags = android
     en = By default
     ru = По умолчанию
     ar = افتراضي
@@ -28216,21 +16933,22 @@
     pt-BR = Por padrão
     ro = Mod implicit
     es = Por defecto
-    es-MX = Por defecto
     sv = Som standard
     th = ตามค่าเริ่มต้น
     tr = Varsayılana göre
     uk = За промовчанням
     vi = Theo mặc định
-    el = Προεπιλογή
-    sk = Podľa predvoleného
-    sw = Kwa chaguo-msingi
     zh-Hans = 默认情况下
     zh-Hant = 默認情況下
+    el = Προεπιλογή
+    es-MX = Por defecto
     fa = به صورت پیش فرض
+    sk = Podľa predvoleného
+    sw = Kwa chaguo-msingi
 
   [by_type]
     comment = Android
+    tags = android
     en = By type
     ru = По типу
     ar = حسب النوع
@@ -28251,21 +16969,22 @@
     pt-BR = Por tipo
     ro = După tip
     es = Por tipo
-    es-MX = Por tipo
     sv = Efter typ
     th = ตามประเภท
     tr = Türe göre
     uk = За типом
     vi = Theo kiểu
-    el = Ανά τύπο
-    sk = Podľa typu
-    sw = Kwa aina
     zh-Hans = 按类型
     zh-Hant = 按類型
+    el = Ανά τύπο
+    es-MX = Por tipo
     fa = بر اساس تاریخ
+    sk = Podľa typu
+    sw = Kwa aina
 
   [by_distance]
     comment = Android
+    tags = android
     en = By distance
     ru = По расстоянию
     ar = حسب المسافة
@@ -28286,21 +17005,22 @@
     pt-BR = Por distância
     ro = După distanță
     es = Por distancia
-    es-MX = Por distancia
     sv = Efter avstånd
     th = ตามระยะทาง
     tr = Mesafeye göre
     uk = За відстанню
     vi = Theo khoảng cách
-    el = Κατά απόσταση
-    sk = Podľa vzdialenosti
-    sw = Kwa umbali
     zh-Hans = 按距离
     zh-Hant = 按距離
+    el = Κατά απόσταση
+    es-MX = Por distancia
     fa = بر اساس فاصله
+    sk = Podľa vzdialenosti
+    sw = Kwa umbali
 
   [by_date]
     comment = Android
+    tags = android
     en = By date
     ru = По дате
     ar = حسب التاريخ
@@ -28321,734 +17041,21 @@
     pt-BR = Por data
     ro = După dată
     es = Por fecha
-    es-MX = Por fecha
     sv = Efter datum
     th = ตามวันที่
     tr = Tarihe göre
     uk = За датою
     vi = Theo ngày
-    el = Κατά ημερομηνία
-    sk = Podľa dátumu
-    sw = Kwa tarehe
     zh-Hans = 按时间
     zh-Hant = 按時間
+    el = Κατά ημερομηνία
+    es-MX = Por fecha
     fa = بر اساس تاریخ
-
-  [week_ago_sorttype]
-    en = A week ago
-    ru = Неделю назад
-    ar = منذ أسبوع
-    cs = Před týdnem
-    da = En uge siden
-    nl = Een week geleden
-    fi = Viikko sitten
-    fr = Il y a une semaine
-    de = Vor einer Woche
-    hu = Egy hete
-    id = Seminggu yang lalu
-    it = Una settimana fa
-    ja = 1週間前
-    ko = 일주일 전
-    nb = For en uke siden
-    pl = Tydzień wstecz
-    pt = Uma semana atrás
-    pt-BR = Uma semana atrás
-    ro = O săptămână în urmă
-    es = Hace una semana
-    es-MX = Hace una semana
-    sv = För en vecka sedan
-    th = สัปดาห์ที่ผ่านมา
-    tr = Bir hafta önce
-    uk = Тиждень тому
-    vi = Tuần trước
-    el = Μια βδομάδα πριν
-    sk = Pred týždňom
-    sw = Wiki moja iliyopita
-    zh-Hans = 一周前
-    zh-Hant = 一周前
-    fa = یک هفته قبل
-
-  [month_ago_sorttype]
-    en = A month ago
-    ru = Месяц назад
-    ar = منذ شهر
-    cs = Před měsícem
-    da = En måned siden
-    nl = Een maand geleden
-    fi = Kuukausi sitten
-    fr = Il y a un mois
-    de = Vor einem Monat
-    hu = Egy hónapja
-    id = Sebulan yang lalu
-    it = Un mese fa
-    ja = 1ケ月前
-    ko = 한달 전
-    nb = For en måned siden
-    pl = Miesiąc wstecz
-    pt = Um mês atrás
-    pt-BR = Um mês atrás
-    ro = O lună în urmă
-    es = Hace un mes
-    es-MX = Hace un mes
-    sv = För en månad sedan
-    th = เดือนที่ผ่านมา
-    tr = Bir ay önce
-    uk = Місяць тому
-    vi = Tháng trước
-    el = Ένας μήνας πριν
-    sk = Pred mesiacom
-    sw = Mwezi mmoja uliopita
-    zh-Hans = 一月前
-    zh-Hant = 一月前
-    fa = یک ماه قبل
-
-  [moremonth_ago_sorttype]
-    en = More than a month ago
-    ru = Больше месяца назад
-    ar = منذ أكثر من شهر
-    cs = Více než před měsícem
-    da = Mere end en måned siden
-    nl = Meer dan een maand geleden
-    fi = Yli kuukausi sitten
-    fr = Il y a plus d'un mois
-    de = Vor über einem Monat
-    hu = Több mint egy hónapja
-    id = Lebih dari sebulan yang lalu
-    it = Più di un mese fa
-    ja = 1ケ月以上前
-    ko = 한달 그 이상 전
-    nb = Mer enn en måned siden
-    pl = Ponad miesiąc wstecz
-    pt = Mais de um mês atrás
-    pt-BR = Mais de um mês atrás
-    ro = Mai mult de o lună în urmă
-    es = Hace más de un mes
-    es-MX = Hace más de un mes
-    sv = För över en månad sedan
-    th = มากกว่าหนึ่งเดือนที่ผ่านมา
-    tr = Bir aydan daha önce
-    uk = Понад місяць тому
-    vi = Hơn một tháng trước
-    el = Περισσότερο από έναν μήνα πριν
-    sk = Pred viac ako mesiacom
-    sw = Zaidi ya mwezi mmoja uliopita
-    zh-Hans = 一个多月前
-    zh-Hant = 一個多月前
-    fa = بیش از یک ماه قبل
-
-  [moreyear_ago_sorttype]
-    en = More than a year ago
-    ru = Больше года назад
-    ar = منذ أكثر من سنة
-    cs = Více než před rokem
-    da = Mere end et år siden
-    nl = Meer dan een jaar geleden
-    fi = Yli vuosi sitten
-    fr = Il y a plus d'un an
-    de = Vor über einem Jahr
-    hu = Több mint egy éve
-    id = Lebih dari setahun yang lalu
-    it = Più di un anno fa
-    ja = 1年以上前
-    ko = 1년 그 이상 전
-    nb = Mer enn ett år siden
-    pl = Ponad rok wstecz
-    pt = Mais de um ano atrás
-    pt-BR = Mais de um ano atrás
-    ro = Mai mult de un an în urmă
-    es = Hace más de un año
-    es-MX = Hace más de un año
-    sv = För över ett år sedan
-    th = มากกว่าหนึ่งปีที่ผ่านมา
-    tr = Bir yıldan daha önce
-    uk = Понад рік тому
-    vi = Hơn một năm trước
-    el = Περισσότερο από ένα έτος πριν
-    sk = Pred viac ako rokom
-    sw = Zaidi ya mwaka mmoja uliopita
-    zh-Hans = 一年多以前
-    zh-Hant = 一年多以前
-    fa = بیش از یک سال قبل
-
-  [near_me_sorttype]
-    en = Near me
-    ru = Рядом со мной
-    ar = قريب مني
-    cs = Blízko mě
-    da = I nærheden
-    nl = Naast mij
-    fi = Lähelläni
-    fr = Près de moi
-    de = In der Nähe
-    hu = Hozzám közel
-    id = Dekat dengan saya
-    it = Vicino a me
-    ja = 近隣
-    ko = 나와 가까운 곳
-    nb = Nær meg
-    pl = Obok mnie
-    pt = Perto de mim
-    pt-BR = Proximo de mim
-    ro = Alături de mine
-    es = Cerca a mí
-    es-MX = Cerca a mí
-    sv = Bredvid mig
-    th = ใกล้ฉัน
-    tr = Bana yakın
-    uk = Поруч зі мною
-    vi = Ở gần tôi
-    el = Δίπλα μου
-    sk = Blízko mňa
-    sw = Karibu yangu
-    zh-Hans = 在我旁边
-    zh-Hant = 在我旁邊
-    fa = نزدیک من
-
-  [others_sorttype]
-    en = Others
-    ru = Другие
-    ar = أخرى
-    cs = Ostatní
-    da = Andre
-    nl = Andere
-    fi = Muut
-    fr = Autres
-    de = Sonstiges
-    hu = Más
-    id = Lainnya
-    it = Altri
-    ja = その他
-    ko = 기타
-    nb = Andre
-    pl = Inne
-    pt = Outro
-    pt-BR = Outros
-    ro = Altele
-    es = Otros
-    es-MX = Otros
-    sv = Andra
-    th = อื่นๆ
-    tr = Diğerleri
-    uk = Інші
-    vi = Khác
-    el = Άλλα
-    sk = Iné
-    sw = Nyingine
-    zh-Hans = 其他
-    zh-Hant = 其他
-    fa = دیگران
-
-  [food_places]
-    en = Food
-    ru = Еда
-    ar = طعام
-    cs = Jídlo
-    da = Mad
-    nl = Eten
-    fi = Ruoka
-    fr = Aliments
-    de = Essen
-    hu = Étel
-    id = Makanan
-    it = Cibo
-    ja = 食べ物
-    ko = 음식
-    nb = Mat
-    pl = Jedzenie
-    pt = Alimento
-    pt-BR = Comida
-    ro = Mâncare
-    es = Comida
-    es-MX = Comida
-    sv = Mat
-    th = อาหาร
-    tr = Yiyecek
-    uk = Їжа
-    vi = Đồ ăn
-    el = Εστίαση
-    sk = Jedlo
-    sw = Chakula
-    zh-Hans = 美食
-    zh-Hant = 美食
-    fa = غذا
-
-  [tourist_places]
-    en = Sights
-    ru = Достопримечательности
-    ar = مشاهد
-    cs = Památky
-    da = Seværdigheder
-    nl = Bezienswaardigheden
-    fi = Nähtävyydet
-    fr = Choses à voir
-    de = Sehenswürdigkeiten
-    hu = Látnivalók
-    id = Tempat Rekreasi
-    it = Luoghi d'interesse
-    ja = 観光地
-    ko = 명소
-    nb = Severdigheter
-    pl = Zabytki
-    pt = Pontos turísticos
-    pt-BR = Pontos turíticos
-    ro = Locuri faimoase
-    es = Sitios de interés
-    es-MX = Sitios de interés
-    sv = Sevärdheter
-    th = ที่ท่องเที่ยว
-    tr = Görülecek yerler
-    uk = Пам’ятки
-    vi = Danh lam thắng cảnh
-    el = Αξιοθέατα
-    sk = Pamiatky
-    sw = Vivutio
-    zh-Hans = 名胜
-    zh-Hant = 名勝
-    fa = مناظر
-
-  [museums]
-    en = Museums
-    ru = Музеи
-    ar = متاحف
-    cs = Muzea
-    da = Museer
-    nl = Musea
-    fi = Museot
-    fr = Musées
-    de = Museen
-    hu = Múzeumok
-    id = Museum
-    it = Musei
-    ja = 博物館
-    ko = 박물관
-    nb = Museer
-    pl = Muzea
-    pt = Museus
-    pt-BR = Museus
-    ro = Muzeu
-    es = Museos
-    es-MX = Museos
-    sv = Museer
-    th = พิพิธภัณฑ์
-    tr = Müzeler
-    uk = Музеї
-    vi = Bảo tàng
-    el = Μουσεία
-    sk = Múzeá
-    sw = Makumbusho
-    zh-Hans = 博物馆
-    zh-Hant = 博物館
-    fa = موزهها
-
-  [parks]
-    en = Parks
-    ru = Парки
-    ar = حدائق
-    cs = Parky
-    da = Parker
-    nl = Parken
-    fi = Puistot
-    fr = Parcs
-    de = Parks
-    hu = Parkok
-    id = Taman
-    it = Parchi
-    ja = 公園
-    ko = 공원
-    nb = Parker
-    pl = Parki
-    pt = Jardins
-    pt-BR = Parques
-    ro = Parcuri
-    es = Parques
-    es-MX = Parques
-    sv = Parker
-    th = ที่จอดรถ
-    tr = Parklar
-    uk = Парки
-    vi = Công viên
-    el = Πάρκα
-    sk = Parky
-    sw = Hifadhi
-    zh-Hans = 公园
-    zh-Hant = 公園
-    fa = پارکها
-
-  [swim_places]
-    en = Swim
-    ru = Плавание
-    ar = سباحة
-    cs = Plavat
-    da = Svøm
-    nl = Zwemmen
-    fi = Uiminen
-    fr = Natation
-    de = Schwimmmöglichkeiten
-    hu = Úszás
-    id = Kolam renang
-    it = Nuoto
-    ja = 水泳
-    ko = 수영
-    nb = Svømming
-    pl = Pływanie
-    pt = Natação
-    pt-BR = Nado
-    ro = Înot
-    es = Natación
-    es-MX = Natación
-    sv = Simning
-    th = ว่ายน้ำ
-    tr = Yüzme
-    uk = Плавання
-    vi = Bơi lội
-    el = Κολύμβηση
-    sk = Plávanie
-    sw = Kuogelea
-    zh-Hans = 游泳
-    zh-Hant = 游泳
-    fa = شنا
-
-  [mountains]
-    en = Mountains
-    ru = Горы
-    ar = جبال
-    cs = Hory
-    da = Bjerge
-    nl = Bergen
-    fi = Vuoret
-    fr = Montagnes
-    de = Berge
-    hu = Hegyek
-    id = Pegunungan
-    it = Montagne
-    ja = 山
-    ko = 산
-    nb = Fjell
-    pl = Góry
-    pt = Montanhas
-    pt-BR = Montanhas
-    ro = Munți
-    es = Montañas
-    es-MX = Montañas
-    sv = Berg
-    th = ภูเขา
-    tr = Dağlar
-    uk = Гори
-    vi = Núi non
-    el = Βουνά
-    sk = Hory
-    sw = Milima
-    zh-Hans = 山
-    zh-Hant = 山
-    fa = کوهها
-
-  [animals]
-    en = Animals
-    ru = Животные
-    ar = حيوانات
-    cs = Zvířata
-    da = Dyr
-    nl = Dieren
-    fi = Eläimet
-    fr = Animaux
-    de = Tiere
-    hu = Állatok
-    id = Kebun binatang
-    it = Animali
-    ja = 動物園
-    ko = 동물원
-    nb = Dyr
-    pl = Zwierzęta
-    pt = Animais
-    pt-BR = Animais
-    ro = Animale
-    es = Animales
-    es-MX = Animales
-    sv = Djur
-    th = สวนสัตว์
-    tr = Hayvanlar
-    uk = Тварини
-    vi = Động vật
-    el = Ζώα
-    sk = Zvieratá
-    sw = Wanyama
-    zh-Hans = 动物
-    zh-Hant = 動物
-    fa = حیوانات
-
-  [hotels]
-    en = Hotels
-    ru = Отели
-    ar = فنادق
-    cs = Hotely
-    da = Hoteller
-    nl = Hotels
-    fi = Hotellit
-    fr = Hotels
-    de = Hotels
-    hu = Hotelek
-    id = Hotel
-    it = Alberghi
-    ja = ホテル
-    ko = 호텔
-    nb = Hoteller
-    pl = Hotele
-    pt = Hotéis
-    pt-BR = Hotéis
-    ro = Hoteluri
-    es = Hoteles
-    es-MX = Hoteles
-    sv = Hotell
-    th = โรงแรม
-    tr = Oteller
-    uk = Готелі
-    vi = Khách sạn
-    el = Διαμονή
-    sk = Hotely
-    sw = Hoteli
-    zh-Hans = 酒店
-    zh-Hant = 酒店
-    fa = هتلها
-
-  [buildings]
-    en = Buildings
-    ru = Здания
-    ar = بنايات
-    cs = Budovy
-    da = Bygninger
-    nl = Gebouwen
-    fi = Rakennukset
-    fr = Batiments
-    de = Gebäude
-    hu = Épületek
-    id = Gedung
-    it = Edifici
-    ja = ビル
-    ko = 빌딩
-    nb = Bygninger
-    pl = Budynki
-    pt = Prédios
-    pt-BR = Prédios
-    ro = Clădiri
-    es = Edificios
-    es-MX = Edificios
-    sv = Byggnader
-    th = สิ่งปลูกสร้าง
-    tr = Binalar
-    uk = Будівлі
-    vi = Tòa nhà
-    el = Κτήρια
-    sk = Budovy
-    sw = Majengo
-    zh-Hans = 建筑物
-    zh-Hant = 建築物
-    fa = ساختمانها
-
-  [money]
-    en = Money
-    ru = Деньги
-    ar = نقود
-    cs = Peníze
-    da = Penge
-    nl = Geld
-    fi = Raha
-    fr = Argent
-    de = Geld
-    hu = Pénz
-    id = Uang
-    it = Denaro
-    ja = 金銭
-    ko = 돈
-    nb = Penger
-    pl = Pieniądze
-    pt = Dinheiro
-    pt-BR = Dinheiro
-    ro = Bani
-    es = Dinero
-    es-MX = Dinero
-    sv = Pengar
-    th = เงิน
-    tr = Para
-    uk = Гроші
-    vi = Tiền
-    el = Χρήματα
-    sk = Peniaze
-    sw = Fedha
-    zh-Hans = 货币
-    zh-Hant = 貨幣
-    fa = پول
-
-  [shops]
-    en = Shops
-    ru = Магазины
-    ar = متاجر
-    cs = Obchody
-    da = Butikker
-    nl = Winkels
-    fi = Kaupat
-    fr = Magasins
-    de = Ladengeschäfte
-    hu = Üzletek
-    id = Pusat perbelanjaan
-    it = Negozi
-    ja = ショップ
-    ko = 상점
-    nb = Butikker
-    pl = Sklepy
-    pt = Lojas
-    pt-BR = Lojas
-    ro = Magazine
-    es = Tiendas
-    es-MX = Comercio
-    sv = Butiker
-    th = ร้านค้า
-    tr = Mağazalar
-    uk = Магазини
-    vi = Cửa hàng
-    el = Καταστήματα
-    sk = Obchody
-    sw = Maduka
-    zh-Hans = 商店
-    zh-Hant = 商店
-    fa = مراکز خرید
-
-  [parkings]
-    en = Parkings
-    ru = Парковки
-    ar = مواقف سيارات
-    cs = Parkoviště
-    da = Parkering
-    nl = Parkeerplaatsen
-    fi = Pysäköinti
-    fr = Parkings
-    de = Parkplätze
-    hu = Parkolók
-    id = Parkir
-    it = Parcheggi
-    ja = 駐車場
-    ko = 주차장
-    nb = Parkeringer
-    pl = Parkingi
-    pt = Estacionamentos
-    pt-BR = Estacionamentos
-    ro = Parcări
-    es = Estacionamiento
-    es-MX = Aparcamientos
-    sv = Parkeringsplatser
-    th = ที่จอดรถ
-    tr = Otoparklar
-    uk = Парковки
-    vi = Bãi đậu xe
-    el = Χώροι στάθμευσης
-    sk = Parkovanie
-    sw = Maegesho
-    zh-Hans = 停车场
-    zh-Hant = 停車場
-    fa = پارکینگها
-
-  [fuel_places]
-    en = Gas stations
-    ru = Заправки
-    ar = محطات وقود
-    cs = Čerpací stanice
-    da = Benzintankstationer
-    nl = Benzinestations
-    fi = Huoltoasemat
-    fr = Stations d'essence
-    de = Tankstellen
-    hu = Benzinkutak
-    id = SPBU
-    it = Stazione di servizio
-    ja = ガソリンスタンド
-    ko = 주유소
-    nb = Bensinstasjoner
-    pl = Stacje paliw
-    pt = Postos de gasolina
-    pt-BR = Postos de gasolina
-    ro = Benzinării
-    es = Gasolinera
-    es-MX = Gasolinería
-    sv = Bensinstationer
-    th = ปั๊มน้ำมัน/แก๊ส
-    tr = Benzin istasyonları
-    uk = Заправки
-    vi = Trạm xăng dầu
-    el = Πρατήρια βενζίνης
-    sk = Čerpacie stanice
-    sw = Kituo cha gesi
-    zh-Hans = 加油站
-    zh-Hant = 加油站
-    fa = پمپ بنزین
-
-  [water]
-    en = Water
-    ru = Вода
-    ar = ماء
-    cs = Voda
-    da = Vand
-    nl = Water
-    fi = Vesi
-    fr = Eau
-    de = Wasser
-    hu = Víz
-    id = Air
-    it = Acqua
-    ja = 水
-    ko = 물
-    nb = Vann
-    pl = Woda
-    pt = Água
-    pt-BR = Água
-    ro = Apă
-    es = Agua
-    es-MX = Agua
-    sv = Vatten
-    th = น้ำ
-    tr = Su
-    uk = Вода
-    vi = Nước
-    el = Νερό
-    sk = Voda
-    sw = Maji
-    zh-Hans = 水
-    zh-Hant = 水
-    fa = آب
-
-  [medicine]
-    en = Medicine
-    ru = Медицина
-    ar = دواء
-    cs = Medicína
-    da = Medicin
-    nl = Geneeskunde
-    fi = Apteekki
-    fr = Médicament
-    de = Medizin
-    hu = Gyógyszer
-    id = Obat
-    it = Farmacia
-    ja = 医薬品
-    ko = 의료
-    nb = Medisin
-    pl = Lecznictwo
-    pt = Medicina
-    pt-BR = Remédio
-    ro = Medicină
-    es = Medicina
-    es-MX = Medicina
-    sv = Medicin
-    th = ยา
-    tr = İlaç
-    uk = Медицина
-    vi = Y tế
-    el = Γιατρική βοήθεια
-    sk = Medicína
-    sw = Dawa
-    zh-Hans = 医疗
-    zh-Hant = 醫療
-    fa = پزشکی
+    sk = Podľa dátumu
+    sw = Kwa tarehe
 
   [search_in_the_list]
+    tags = android
     en = Search in the list
     ru = Искать в списке
     ar = بحث في القائمة
@@ -29069,226 +17076,21 @@
     pt-BR = Procurar na lista
     ro = Căutați în listă
     es = Buscar en la lista
-    es-MX = Buscar en la lista
     sv = Söka i listan
     th = ค้นหาในรายการ
     tr = Listede ara
     uk = Шукати в списку
     vi = Tìm trong danh sách
-    el = Αναζήτηση στη λίστα
-    sk = Vyhľadať v zozname
-    sw = Tafuta kwenye orodha
     zh-Hans = 在列表中搜索
     zh-Hant = 在列表中搜索
+    el = Αναζήτηση στη λίστα
+    es-MX = Buscar en la lista
     fa = جستجو در لیست
-
-  [view_on_map_bookmarks]
-    en = On map
-    ru = На карте
-    ar = على الخريطة
-    cs = Na mapě
-    da = På kort
-    nl = Op de kaart
-    fi = Kartalla
-    fr = Sur plan
-    de = Auf der Karte
-    hu = Térképen
-    id = Di peta
-    it = Sulla mappa
-    ja = マップ上
-    ko = 맵에서
-    nb = På kartet
-    pl = Na mapie
-    pt = No mapa
-    pt-BR = No mapa
-    ro = Pe hartă
-    es = En el mapa
-    es-MX = En el mapa
-    sv = På kartan
-    th = บนแผนที่
-    tr = Haritada
-    uk = На карті
-    vi = Trên bản đồ
-    el = Στον χάρτη
-    sk = Na mape
-    sw = Kwenye ramani
-    zh-Hans = 在地图上
-    zh-Hant = 在地圖上
-    fa = روی نقشه
-
-  [more_bookmarks]
-    en = More…
-    ru = Еще…
-    ar = المزيد…
-    cs = Více…
-    da = Mere…
-    nl = Meer…
-    fi = Lisää…
-    fr = Plus…
-    de = Mehr…
-    hu = Továbbiak…
-    id = Lainnya…
-    it = Ecc…
-    ja = 更に…
-    ko = 더…
-    nb = Mer…
-    pl = Więcej…
-    pt = Mais…
-    pt-BR = Mais…
-    ro = Încă…
-    es = Más…
-    es-MX = Más…
-    sv = Mer…
-    th = เพิ่มเติม…
-    tr = Daha fazla…
-    uk = Ще…
-    vi = Thêm…
-    el = Περισσότερα…
-    sk = Viac…
-    sw = Zaidi…
-    zh-Hans = 更多……
-    zh-Hant = 更多……
-    fa = بیشتر…
-
-  [no_items_found]
-    en = No items found
-    ru = Ничего не найдено
-    ar = لم يتم العثور على عناصر
-    cs = Nebyly nalezeny žádné položky
-    da = Der blev ikke fundet nogen elementer
-    nl = Niets gevonden
-    fi = Kohteita ei löytynyt
-    fr = Aucun article trouvé
-    de = Keine Einträge gefunden
-    hu = Nincs találat
-    id = Item tidak ditemukan
-    it = Nessun risultato trovato
-    ja = 何も見つかりませんでした
-    ko = 발견 없음
-    nb = Ingenting funnet
-    pl = Brak wyników
-    pt = Nada encontrado
-    pt-BR = Nenhum item encontrado
-    ro = Nu a fost găsit nimic
-    es = No encontrado
-    es-MX = No se encontró nada
-    sv = Ingenting hittades
-    th = ไม่พบรายการ
-    tr = Hiç bir öğe bulunamadı
-    uk = Нічого не знайдено
-    vi = Không tìm thấy gì cả
-    el = Δεν βρέθηκε τίποτα
-    sk = Žiadne položky nenájdené
-    sw = Hakuna kitu kilichopatikana
-    zh-Hans = 未搜索到内容
-    zh-Hant = 未搜索到內容
-    fa = هیچ موردی یافت نشد
-
-  [bookmarks_edit_list]
-    comment = Android, max 18 symbols
-    en = Edit list
-    ru = Редактировать
-    ar = تحرير القائمة
-    cs = Upravit seznam
-    da = Redigér liste
-    nl = Bewerken
-    fi = Muokkaa listaa
-    fr = Modifier la liste
-    de = Korrigieren
-    hu = Lista szerkesztése
-    id = Ubah daftar
-    it = Modifica
-    ja = リストの編集
-    ko = 리스트 수정
-    nb = Endre
-    pl = Redaguj
-    pt = Editar
-    pt-BR = Editar lista
-    ro = Redactați
-    es = Editar
-    es-MX = Corregir
-    sv = Redigera
-    th = แก้ไขรายการ
-    tr = Listeyi düzenle
-    uk = Редагувати
-    vi = Chỉnh sửa
-    el = Επεξεργασία
-    sk = Upraviť zoznam
-    sw = Hariri orodha
-    zh-Hans = 编辑
-    zh-Hant = 編輯
-    fa = ویرایش فهرست
-
-  [bookmarks_delete_list]
-    comment = Android, max 18 symbols
-    en = Delete list
-    ru = Удалить список
-    ar = حذف القائمة
-    cs = Odstranit seznam
-    da = Slet liste
-    nl = Lijst verwijderen
-    fi = Poista lista
-    fr = Supprimer la liste
-    de = Liste löschen
-    hu = Lista törlése
-    id = Hapus daftar
-    it = Cancella la lista
-    ja = リストの削除
-    ko = 리스트 삭제
-    nb = Slette lista
-    pl = Usuń listę
-    pt = Eliminar a lista
-    pt-BR = Deletar lista
-    ro = Ștergeți lista
-    es = Eliminar lista
-    es-MX = Eliminar lista
-    sv = Ta bort listan
-    th = ลบรายการ
-    tr = Listeyi sil
-    uk = Видалити список
-    vi = Xóa dánh sách
-    el = Διαγραφή λίστας
-    sk = Vymazať zoznam
-    sw = Futa orodha
-    zh-Hans = 删除列表
-    zh-Hant = 刪除列表
-    fa = حذف همه
-
-  [religious_places]
-    en = Religious places
-    ru = Святые места
-    ar = أماكن دينية
-    cs = Posvátná místa
-    da = Religiøse steder
-    nl = Religieuze plaatsen
-    fi = Pyhät paikat
-    fr = Lieux saints
-    de = Heilige Orte
-    hu = Vallási helyek
-    id = Tempat ibadah
-    it = Luoghi di culto
-    ja = 宗教に関連した場所
-    ko = 종교적 장소
-    nb = Hellige steder
-    pl = Święte miejsca
-    pt = Lugares sagrados
-    pt-BR = Lugares religiosos
-    ro = Locuri sfinte
-    es = Lugares sagrados
-    es-MX = Sitios religiosos
-    sv = Heliga platser
-    th = สถานที่ทางศาสนา
-    tr = Dini yerler
-    uk = Святі місця
-    vi = Những nơi tôn nghiêm
-    el = Άγιοι τόποι
-    sk = Náboženské miesta
-    sw = Sehemu za ibada
-    zh-Hans = 圣地
-    zh-Hant = 聖地
-    fa = اماکن مقدس
+    sk = Vyhľadať v zozname
+    sw = Tafuta kwenye orodha
 
   [select_list]
+    tags = android
     en = Select list
     ru = Выбрать список
     ar = اختر القائمة
@@ -29309,21 +17111,21 @@
     pt-BR = Escolher a lista
     ro = Alegeți lista
     es = Seleccionar lista
-    es-MX = Seleccionar lista
     sv = Välja lista
     th = เลือกรายการ
     tr = Liste seç
     uk = Обрати список
     vi = Chọn danh sách
-    el = Επιλογή λίστας
-    sk = Vybrať zoznam
-    sw = Chagua orodha
     zh-Hans = 选择列表
     zh-Hant = 選擇列表
+    el = Επιλογή λίστας
+    es-MX = Seleccionar lista
     fa = انتخاب فهرست
+    sk = Vybrať zoznam
+    sw = Chagua orodha
 
   [transit_not_found]
-    tags = ios,android
+    tags = ios, android
     en = Subway navigation in this region is not available yet
     ru = Навигация на метро ещё недоступна в данном регионе
     ar = التنقل باستخدام مترو الأنفاق في هذه المنطقة غير متاح حتى الآن
@@ -29344,21 +17146,21 @@
     pt-BR = A navegação por metrô nesta região ainda não está disponível
     ro = Navigarea pentru metrou nu este încă disponibilă în această regiune
     es = Navegación en Metro aún no disponible en esta región
-    es-MX = Navegación por metro aún no disponible en esta región
     sv = Metro-navigering är ännu inte tillgänglig i denna region
     th = ยังไม่สามารถใช้การนำทางรถไฟใต้ดินในภูมิภาคนี้ได้
     tr = Metro navigasyonu bu bölgede henüz mevcut değil
     uk = Навігація на метро ще недоступна в цьому регіоні
     vi = Điều hướng đến Metro hiện chưa khả dụng cho khu vực này
-    el = Η πλοήγηση στο μετρό γι' αυτή την περιοχή δεν είναι ακόμα διαθέσιμη
-    sk = Navigácia metra v tejto oblasti ešte nie je k dispozícii
-    sw = Uabiri wa njia ya chini kwa chini katika mkoa huu haupatikani bado
     zh-Hans = 本区域的地铁导航目前不可用
     zh-Hant = 本區域的地鐵導航目前不可用
+    el = Η πλοήγηση στο μετρό γι' αυτή την περιοχή δεν είναι ακόμα διαθέσιμη
+    es-MX = Navegación por metro aún no disponible en esta región
     fa = راهنمای مترو در این منطقه هنوز دردسترس نیست
+    sk = Navigácia metra v tejto oblasti ešte nie je k dispozícii
+    sw = Uabiri wa njia ya chini kwa chini katika mkoa huu haupatikani bado
 
   [dialog_pedestrian_route_is_long_header]
-    tags = ios,android
+    tags = ios, android
     en = Subway route is not found
     ru = Маршрут метро не найден
     ar = لم يتم العثور على مترو الانفاق
@@ -29379,21 +17181,21 @@
     pt-BR = Rota por metrô não encontrada
     ro = Ruta metroului nu a fost găsită
     es = Ruta de metro no encontrada
-    es-MX = Ruta de metro no encontrada
     sv = Metro rutt hittades inte
     th = ไม่พบเส้นทางของทางรถไฟใต้ดิน
     tr = Metro güzergahı bulunamadı
     uk = Маршрут метро не знайдено
     vi = Không tìm thấy tuyến Metro
-    el = Η διαδρομή του μετρό δεν βρέθηκε
-    sk = Trasa metra sa nenašla
-    sw = Njia ya chini kwa chini haipatikani
     zh-Hans = 地铁路线图未找到
     zh-Hant = 地鐵路線圖未找到
+    el = Η διαδρομή του μετρό δεν βρέθηκε
+    es-MX = Ruta de metro no encontrada
     fa = مسیر مترو یافت نشد
+    sk = Trasa metra sa nenašla
+    sw = Njia ya chini kwa chini haipatikani
 
   [dialog_pedestrian_route_is_long_message]
-    tags = ios,android
+    tags = ios, android
     en = Please choose a start or end point closer to a subway station
     ru = Выберите начальную или конечную точку маршрута ближе к станции метро
     ar = يرجى اختيار نقطة بداية أو نهاية أقرب لمحطة المترو
@@ -29414,56 +17216,21 @@
     pt-BR = Escolha outro ponto de início ou fim perto da estação de metrô
     ro = Selectați punctul de început sau de sfârșit al rutei mai aproape de stația de metrou
     es = Elige el punto de inicio o fin de ruta más cercano al metro
-    es-MX = Elija el punto de inicio o fin de ruta más cercano al metro
     sv = Välj ruttens start- eller slutpunkt närmare till tunnelbanestation
     th = โปรดเลือกจุดเริ่มต้นและสิ้นสุดที่อยู่ใกล้สถานีรถไฟใต้ดิน
     tr = Metro istasyonuna en yakın rotanın başlangıç veya bitiş noktasını seçin
     uk = Виберіть початкову чи кінцеву точку маршруту ближче до станції метро
     vi = Hãy chọn điểm đầu hoặc điểm cuối của tuyến gần với bến Metro
-    el = Επιλέξτε το σημείο έναρξης ή τέλους διαδρομής πιο κοντά στο σταθμό του μετρό
-    sk = Vyberte počiatočný alebo konečný bod bližšie k stanici metra
-    sw = Chagua nyota au alama ya mwisho karibu ya kituo cha njia ya chini kwa chini
     zh-Hans = 选择地铁站附近的起点和终点
     zh-Hant = 選擇地鐵站附近的起點和終點
+    el = Επιλέξτε το σημείο έναρξης ή τέλους διαδρομής πιο κοντά στο σταθμό του μετρό
+    es-MX = Elija el punto de inicio o fin de ruta más cercano al metro
     fa = لطفا نقطه آغاز و پایان نزدیک تری به ایستگاه مترو انتخاب کنید
-
-  [routing_planning_error_subway_special]
-    comment = Failed planning SUBWAY route message in navigation view
-    tags = ios,android
-    en = Subway route planning failed
-    ru = Ошибка построения маршрута метро
-    ar = فشل تخطيط طريق لمترو الانفاق
-    cs = Plánování trasy metra selhalo
-    da = Planlægning af metro-rute mislykkedes
-    nl = Routeplanner per metro is mislukt
-    fi = Virhe metroreitin luomisessa
-    fr = Erreur dans le tracé de l'itinéraire du métro
-    de = Fehler bei der Erstellung der U-Bahn-Route
-    hu = A metró útvonaltervezése sikertelen
-    id = Perencanaan jalur kereta bawah tanah gagal
-    it = Errore di creazione del percorso della metro
-    ja = 地下鉄ルートの計画ができませんでした
-    ko = 지하철 루트 계획 생성 실패
-    nb = Feil ved ruteplanlegging
-    pl = Błąd tworzenia trasy metra
-    pt = Erro ao construir o percurso de metro
-    pt-BR = O planejamento da rota de metrô falhou
-    ro = Eroare la construirea rutei metroului
-    es = Error al construir la ruta en metro
-    es-MX = Error al construir la ruta en metro
-    sv = Fel vid byggande av metro rutt
-    th = การวางแผนเส้นทางของทางรถไฟใต้ดินล้มเหลว
-    tr = Metro güzergahı oluşturma hatası
-    uk = Не вдалося прокласти маршрут метро
-    vi = Lỗi xây dựng tuyến Metro
-    el = Σφάλμα κατά την δημιουργία διαδρομής του μετρό
-    sk = Plánovanie trasy metra zlyhalo
-    sw = Mpango wa njia ya chini kwa chini umeshindikana
-    zh-Hans = 地铁路线图设计出错
-    zh-Hant = 地鐵路線圖設計出錯
-    fa = برنامه ریزی مسیر مترو ناموفق ماند
+    sk = Vyberte počiatočný alebo konečný bod bližšie k stanici metra
+    sw = Chagua nyota au alama ya mwisho karibu ya kituo cha njia ya chini kwa chini
 
   [button_layer_isolines]
+    tags = ios, android
     en = Terrain
     ru = Высоты
     ar = تضاريس
@@ -29484,88 +17251,21 @@
     pt-BR = Topográfica
     ro = Înălțimi
     es = Alturas
-    es-MX = Alturas
     sv = Terräng
     th = ความสูง
     tr = Yükseklikler
     uk = Висоти
     vi = Độ cao
-    el = Υψόμετρα
-    sk = Terén
-    sw = Topografia
     zh-Hans = 高度
     zh-Hant = 高度
+    el = Υψόμετρα
+    es-MX = Alturas
     fa = ایزومپ
-
-  [tips_map_layers_title_countour]
-    en = New in Organic Maps: offline topographic layer!
-    ru = Линии высот офлайн в Organic Maps!
-    ar = الجديد في Organic Maps: طبقة طبوغرافية بدون انترنت!
-    cs = Novinka v Organic Maps: offline topografická vrstva!
-    da = Nyt på Organic Maps: offline topografiske lag!
-    nl = Hoogtelijnen offline in Organic Maps!
-    fi = Korkeuslinjat offline-tilassa Organic Maps:ssä!
-    fr = Lignes d'altitude hors-ligne dans Organic Maps !
-    de = Neu in Organic Maps: Topographie-Layer offline!
-    hu = Újdonság a Organic Maps-n: offline topográfiai réteg!
-    id = Yang baru di Organic Maps: lapisan topografi offline!
-    it = Novità su Organic Maps modalità topografica offline!
-    ja = Organic Mapsの新要素：オフラインのトポグラフィーレイヤー！
-    ko = Organic Maps의 새 기능: 오프라인 지형 레이어!
-    nb = Høydekurver uten nett med Organic Maps!
-    pl = Linie wysokości w trybie offline w Organic Maps!
-    pt = Linhas de alturas offline na Organic Maps!
-    pt-BR = Novidades no Organic Maps: camada topográfica offline!
-    ro = Linii de înălțimi offline pe Organic Maps!
-    es = ¡Altitud de relieve sin conexión en Organic Maps!
-    es-MX = ¡Altitud de relieve sin conexión en Organic Maps!
-    sv = Höjningslinjer offline i Organic Maps!
-    th = เลเยอร์แผนที่ภูมิประเทศแบบออฟไลน์ ใหม่ในแอป Organic Maps!
-    tr = Organic Maps'de yükseklik çizgileri çevrimdışı!
-    uk = Лінії висот офлайн у Organic Maps!
-    vi = Đường độ cao ngoại tuyến trong Organic Maps!
-    el = Τοπογραφικά στρώματα εκτός σύνδεσης στο Organic Maps!
-    sk = Nové v Organic Maps: offline topografická vrstva!
-    sw = Mpya katika Organic Maps: tabaka la nchi bila mtandao!
-    zh-Hans = 离线高度线在Organic Maps中！
-    zh-Hant = 離線高度線在Organic Maps中！
-    fa = تازه ها در Organic Maps: لایه توپوگرافی آفلاین!
-
-  [tips_map_layers_message_countour]
-    en = Plan and enjoy your nature trips being sure you know everything about the area
-    ru = Линии высот помогут спланировать путешествие на природу и не потеряться на местности
-    ar = خطط و استمتع برحلاتك في الطبيعة و أنت متأكد من أنك تعرف كل شيء عن المنطقة
-    cs = Naplánujte si a užijte si své výlety do přírody s jistotou, že víte vše o této oblasti
-    da = Planlæg og nyd din naturtur ved at være sikker på, at du ved alt om området
-    nl = Dankzij de hoogtelijnen kunt u probleemloos natuurreizen plannen en er zeker van zijn dat u niet verdwalen zult
-    fi = Korkeuslinjat auttavat suunnittelemaan luontomatkan etkä enää eksy maastolla
-    fr = Les lignes d'altitude vous aideront à planifier votre voyage à la campagne sans vous perdre dans les champs
-    de = Der Topographie-Layer hilft Ihnen Ihre Reise in die Natur zu planen und sich in der Gegen zurechtzufinden
-    hu = Tervezze meg és élvezze a természetjáró kirándulásait, és tudjon meg mindent a környékről
-    id = Rencanakan dan nikmati perjalanan alam Anda dan pastikan Anda tahu segalanya tentang daerah tersebut
-    it = La modalità topografica aiuta a programmare il viaggio nella natura e a non perdersi
-    ja = 自然の旅で訪れる地域を全てを把握しながら計画を立て楽しみましょう
-    ko = 이 지역에 대한 모든 것을 알고 있는지 확인하면서 자연 여행을 계획하고 즐기세요
-    nb = Høydekurver hjelper deg å planlegge turen din og ikke gå seg vill
-    pl = Linie wysokości pomogą zaplanować podróż i nie zgubić się w terenie
-    pt = As linhas de alturas offline ajudarão planejar sua viagem à natureza e não se perder no local
-    pt-BR = Planeje e aproveite de suas viagens na natureza tendo certeza que vocÊ sabe tudo sobre a região
-    ro = Liniile de înălțimi vă vor ajuta să planificați o călătorie în natură și să nu vă pierdeți
-    es = La altitud de relieve te ayudará a planificar un viaje a la naturaleza y no perderte en la zona
-    es-MX = La altitud de relieve le ayudará a planificar un viaje a la naturaleza y no perderse en el área
-    sv = Höjdlinjer hjälper dig att planera din resa till naturen och inte gå vilse på marken
-    th = วางแผนและสนุกไปกับทริปท่องธรรมชาติโดยมั่นใจว่าคุณรู้ทุกอย่างเกี่ยวกับพื้นที่นั้น
-    tr = Yükseklik çizgileri, doğaya bir gezi planlamanıza ve arazide kaybolmamanıza yardımcı olacaktır
-    uk = Лінії висот допоможуть спланувати подорож на природу та не загубитися на місцевості
-    vi = Đường độ cao giúp lên kế hoạch du lịch hòa mình với thiên nhiên và không bị lạc khi di chuyển
-    el = Τα τοπογραφικά στρώματα θα σας βοηθήσουν να σχεδιάσετε το ταξίδι σας στη φύση και να μην χαθείτε στην περιοχή
-    sk = Naplánujte a užite si výlety do prírody s istotou, že viete o tejto oblasti všetko
-    sw = Panga na furahia safari zako za ulimwengu ukiwa na uhakika unakijua kila kitu kuhusu eneo hilo
-    zh-Hans = 高度线可以帮您规划通往大自然地区的路线，不会迷路
-    zh-Hant = 高度線可以幫您規劃通往大自然地區的路線，不會迷路
-    fa = با اطمینان از این که همه چیز را در مورد منطقه می دانید طبیعت گردی خود را برنامه ریزی کنید و لذت ببرید
+    sk = Terén
+    sw = Topografia
 
   [isolines_activation_error_dialog]
+    tags = ios, android
     en = To activate and use the topographic layer please update or download the map of the area
     ru = Чтобы воспользоваться линиями высот, обновите или загрузите карту нужной местности
     ar = لتفعيل الطبقة الطبوغرافية واستخدامها ، يرجى تحديث أوتنزيل خريطة المنطقة
@@ -29586,20 +17286,21 @@
     pt-BR = Para ativar e usar a camada topográfica, atualize ou baixe o mapa da região
     ro = Pentru a utiliza liniile de înălțimi, actualizați sau descărcați harta zonei dorite
     es = Para usar la altitud de relieve, actualiza o descarga el mapa del área deseada
-    es-MX = Para usar la altitud de relieve, actualice o descargue el mapa del área deseada
     sv = Om du vill använda höjdlinjer, uppdatera eller ladda ner en karta över önskat område
     th = ในการเปิดใช้งานเลเยอร์แผนที่ภูมิประเทศโปรดอัปเดตหรือดาวน์โหลดแผนที่ของบริเวณนั้น
     tr = Yükseklik çizgilerini kullanmak için, istediğiniz arazinin haritasını güncelleyin veya indirin
     uk = Щоб скористатися лініями висот, оновіть чи завантажте карту потрібної місцевості
     vi = Để sử dụng các đường chỉ độ cao, hãy cập nhật hoặc tải xuống bản đồ của khu vực bạn mong muốn
-    el = Για να χρησιμοποιήσετε τοπογραφικά στρώματα, ενημερώστε ή κατεβάστε τον χάρτη της επιθυμητής περιοχής
-    sk = Ak chcete aktivovať a používať topografickú vrstvu, aktualizujte alebo stiahnite mapu oblasti
-    sw = Kuamilisha na kutumia tabaka la nchi tafadhali sasisha au pakua ramani ya eneo hilo
     zh-Hans = 如需使用高度線，請更新或下載所需區域的地圖
     zh-Hant = 如需使用高度线，请更新或下载所需区域的地图
+    el = Για να χρησιμοποιήσετε τοπογραφικά στρώματα, ενημερώστε ή κατεβάστε τον χάρτη της επιθυμητής περιοχής
+    es-MX = Para usar la altitud de relieve, actualice o descargue el mapa del área deseada
     fa = برای فعال سازی و استفاده از لایه توپوگرافی نقشه منطقه را به روزرسانی یا دانلود کنید
+    sk = Ak chcete aktivovať a používať topografickú vrstvu, aktualizujte alebo stiahnite mapu oblasti
+    sw = Kuamilisha na kutumia tabaka la nchi tafadhali sasisha au pakua ramani ya eneo hilo
 
   [isolines_location_error_dialog]
+    tags = ios, android
     en = The topographic layer is not yet available in this area
     ru = Линии высот пока не доступны в этом регионе
     ar = الطبقة الطبوغرافية ليست متاحة بعد في هذه المنطقة
@@ -29620,20 +17321,21 @@
     pt-BR = A camada topográfica ainda não está disponível para esta região
     ro = Liniile de înălțimi pană ce nu sunt disponibile în această regiune
     es = La altitud de relieve aún no está disponible en esta región
-    es-MX = La altitud de relieve no está aún disponible en esta región
     sv = Höjningslinjer är ännu inte tillgängligt i den här regionen
     th = เลเยอร์แผนที่ภูมิประเทศยังใช้งานไม่ได้ในพื้นที่นี้
     tr = Bu bölgede henüz yükseklik çizgileri mevcut değil
     uk = Лінії висот ще недоступні в цьому регіоні
     vi = Đường hiển thị độ cao hiện chưa khả dụng tại khu vực này
-    el = Τα τοπογραφικά στρώματα δεν είναι ακόμα διαθέσιμα σε αυτή την περιοχή
-    sk = Topografická vrstva ešte nie je v tejto oblasti k dispozícii
-    sw = Tabaka la sura ya nchi bado haipatikani katika eneo hili
     zh-Hans = 暂时无法获取该地区的高低线
     zh-Hant = 暫時無法獲取該地區的高低線
+    el = Τα τοπογραφικά στρώματα δεν είναι ακόμα διαθέσιμα σε αυτή την περιοχή
+    es-MX = La altitud de relieve no está aún disponible en esta región
     fa = لایه توپوگرافی هنوز برای این منطقه در دسترس نیست
+    sk = Topografická vrstva ešte nie je v tejto oblasti k dispozícii
+    sw = Tabaka la sura ya nchi bado haipatikani katika eneo hili
 
   [elevation_profile_diff_level]
+    tags = ios
     en = Difficulty level
     ru = Уровень сложности
     ar = مستوى الصعوبة
@@ -29654,122 +17356,21 @@
     pt-BR = Nível de dificuldade
     ro = Nivel de dificultate
     es = Nivel de dificultad
-    es-MX = Nivel de dificultad
     sv = Svårighetsgrad
     th = ระดับความยาก
     tr = Zorluk seviyesi
     uk = Рівень складності
     vi = Mức độ phức tạp
-    el = Επίπεδο δυσκολίας
-    sk = Level obtiažnosti
-    sw = Usawa mgumu
     zh-Hans = 难度等级
     zh-Hant = 難度等級
+    el = Επίπεδο δυσκολίας
+    es-MX = Nivel de dificultad
     fa = سطح دشواری
-
-  [elevation_profile_diff_level_easy]
-    en = Easy
-    ru = Лёгкий
-    ar = سهل
-    cs = Snadný
-    da = Let
-    nl = Gemakkelijk
-    fi = Helppo
-    fr = Faible
-    de = Leicht
-    hu = Könnyű
-    id = Mudah
-    it = Facile
-    ja = イージー
-    ko = 쉬움
-    nb = Lett
-    pl = Łatwy
-    pt = Fácil
-    pt-BR = Fácil
-    ro = Ușor
-    es = Fácil
-    es-MX = Fácil
-    sv = Lätt
-    th = ง่าย
-    tr = Kolay
-    uk = Простий
-    vi = Dễ
-    el = Εύκολο
-    sk = Jednoduchá
-    sw = Rahisi
-    zh-Hans = 容易
-    zh-Hant = 容易
-    fa = آسان
-
-  [elevation_profile_diff_level_moderate]
-    en = Moderate
-    ru = Умеренный
-    ar = معتدل
-    cs = Mírný
-    da = Middel
-    nl = Middelmatig
-    fi = Kohtuullinen
-    fr = Moyen
-    de = Mittel
-    hu = Mérsékelt
-    id = Sedang
-    it = Moderato
-    ja = ノーマル
-    ko = 보통
-    nb = Middels
-    pl = Umiarkowany
-    pt = Moderado
-    pt-BR = Moderado
-    ro = Mediu
-    es = Moderado
-    es-MX = Moderado
-    sv = Måttlig
-    th = ปานกลาง
-    tr = Orta
-    uk = Помірний
-    vi = Trung bình
-    el = Μέτριο
-    sk = Mierna
-    sw = Wastani
-    zh-Hans = 中等
-    zh-Hant = 中等
-    fa = متوسط
-
-  [elevation_profile_diff_level_hard]
-    en = Hard
-    ru = Сложный
-    ar = صعب
-    cs = Těžký
-    da = Svær
-    nl = Moeilijk
-    fi = Vaikea
-    fr = Haut
-    de = Schwer
-    hu = Nehéz
-    id = Sulit
-    it = Difficile
-    ja = ハード
-    ko = 어려움
-    nb = Vanskelig
-    pl = Skomplikowany
-    pt = Complicado
-    pt-BR = Difícil
-    ro = Dificil
-    es = Difícil
-    es-MX = Difícil
-    sv = Svår
-    th = ยาก
-    tr = Karmaşık
-    uk = Складний
-    vi = Khó
-    el = Δύσκολο
-    sk = Náročná
-    sw = Ngumu
-    zh-Hans = 困难
-    zh-Hant = 困難
-    fa = دشوار
+    sk = Level obtiažnosti
+    sw = Usawa mgumu
 
   [elevation_profile_ascent]
+    tags = android
     en = Ascent
     ru = Подъём
     ar = تصاعدي
@@ -29790,20 +17391,21 @@
     pt-BR = Subida
     ro = Urcare
     es = Ascenso
-    es-MX = Ascenso
     sv = Stigning
     th = การขึ้น
     tr = Tırmanış
     uk = Підйом
     vi = Đi lên
-    el = Άνοδος
-    sk = Výstup
-    sw = Upandaji
     zh-Hans = 上坡
     zh-Hant = 上坡
+    el = Άνοδος
+    es-MX = Ascenso
     fa = بالا رفتن
+    sk = Výstup
+    sw = Upandaji
 
   [elevation_profile_descent]
+    tags = android
     en = Descent
     ru = Спуск
     ar = تنازلي
@@ -29824,20 +17426,21 @@
     pt-BR = Descida
     ro = Coborâre
     es = Descenso
-    es-MX = Descenso
     sv = Backe
     th = การลง
     tr = İniş
     uk = Спуск
     vi = Đi xuống
-    el = Κάθοδος
-    sk = Zostup
-    sw = Ushukaji
     zh-Hans = 下坡
     zh-Hant = 下坡
+    el = Κάθοδος
+    es-MX = Descenso
     fa = پایین آمدن
+    sk = Zostup
+    sw = Ushukaji
 
   [elevation_profile_minaltitude]
+    tags = android
     en = Min. altitude
     ru = Мин. высота
     ar = الحد الأدنى للارتفاع
@@ -29858,20 +17461,21 @@
     pt-BR = Altitude Mín.
     ro = Înălțime min.
     es = Altura mínima
-    es-MX = Altura mínima
     sv = Min. höjd
     th = ระดับความสูงต่ำสุด
     tr = Min. rakım
     uk = Мін. висота
     vi = Độ cao tối thiểu
-    el = Ελ. υψόμετρο
-    sk = Min. nadmorská výška
-    sw = Mwinuko wa chini kabisa
     zh-Hans = 最小高度
     zh-Hant = 最小高度
+    el = Ελ. υψόμετρο
+    es-MX = Altura mínima
     fa = کمینه ارتفاع
+    sk = Min. nadmorská výška
+    sw = Mwinuko wa chini kabisa
 
   [elevation_profile_maxaltitude]
+    tags = android
     en = Max. altitude
     ru = Макс. высота
     ar = الحد الأقصى للارتفاع
@@ -29892,54 +17496,21 @@
     pt-BR = Altiduta Max.
     ro = Înălțime max.
     es = Altura máxima
-    es-MX = Altura máxima
     sv = Max. höjd
     th = ระดับความสูงสูงสุด
     tr = Maks. rakım
     uk = Макс. висота
     vi = Độ cao tối đa
-    el = Μέγ. υψόμετρο
-    sk = Max. nadmorská výška
-    sw = Mwinuko wa juu kabisa
     zh-Hans = 最大高度
     zh-Hant = 最大高度
+    el = Μέγ. υψόμετρο
+    es-MX = Altura máxima
     fa = بیشینه ارتفاع
-
-  [elevation_profile_m]
-    en = m
-    ru = м
-    ar = م
-    cs = m
-    da = m
-    nl = m
-    fi = m
-    fr = m
-    de = m
-    hu = m
-    id = m
-    it = m
-    ja = m
-    ko = m
-    nb = m
-    pl = m
-    pt = m
-    pt-BR = m
-    ro = m
-    es = m
-    es-MX = m
-    sv = m
-    th = ม
-    tr = m
-    uk = м
-    vi = m
-    el = μ
-    sk = m
-    sw = m
-    zh-Hans = 米
-    zh-Hant = 米
-    fa = متر
+    sk = Max. nadmorská výška
+    sw = Mwinuko wa juu kabisa
 
   [elevation_profile_difficulty]
+    tags = ios, android
     en = Difficulty
     ru = Сложность
     ar = درجة الصعوبة
@@ -29960,20 +17531,21 @@
     pt-BR = Dificuldade
     ro = Dificultate
     es = Dificultad
-    es-MX = Dificultad
     sv = Komplexitet
     th = ลำบาก
     tr = Zorluk
     uk = Складність
     vi = Độ khó
-    el = Δυσκολία
-    sk = Obtiažnosť
-    sw = Ugumu
     zh-Hans = 难度
     zh-Hant = 難度
+    el = Δυσκολία
+    es-MX = Dificultad
     fa = دشواری
+    sk = Obtiažnosť
+    sw = Ugumu
 
   [elevation_profile_distance]
+    tags = android
     en = Dist.:
     ru = Расст.:
     ar = المسافة:
@@ -29994,54 +17566,21 @@
     pt-BR = Dist.:
     ro = Dist.:
     es = Distancia
-    es-MX = Distancia
     sv = Avst.:
     th = ระยะทาง
     tr = Mesafe:
     uk = Відст.:
     vi = Khoảng cách
-    el = Απόστ.:
-    sk = Vzdial.:
-    sw = Umbali:
     zh-Hans = 距离：
     zh-Hant = 距離：
+    el = Απόστ.:
+    es-MX = Distancia
     fa = مسافت
-
-  [elevation_profile_km]
-    en = km
-    ru = км
-    ar = كم
-    cs = km
-    da = km
-    nl = km
-    fi = km
-    fr = km
-    de = km
-    hu = km
-    id = km
-    it = km
-    ja = ㎞
-    ko = km
-    nb = km
-    pl = km
-    pt = km
-    pt-BR = km
-    ro = km
-    es = km
-    es-MX = km
-    sv = km
-    th = กม
-    tr = km
-    uk = км
-    vi = km
-    el = χλμ
-    sk = km
-    sw = km
-    zh-Hans = 千米
-    zh-Hant = 千米
-    fa = کیلومتر
+    sk = Vzdial.:
+    sw = Umbali:
 
   [elevation_profile_time]
+    tags = ios, android
     en = Time:
     ru = В пути:
     ar = مدة:
@@ -30062,88 +17601,21 @@
     pt-BR = Tempo:
     ro = Timp:
     es = Lapso:
-    es-MX = Lapso:
     sv = Tid:
     th = เวลา:
     tr = Süre:
     uk = Шлях:
     vi = Giờ:
-    el = Διαρκ:
-    sk = Čas:
-    sw = Muda:
     zh-Hans = 在路上：
     zh-Hant = 在路上：
+    el = Διαρκ:
+    es-MX = Lapso:
     fa = زمان:
-
-  [elevation_profile_hours]
-    en = h.
-    ru = ч.
-    ar = ساعة
-    cs = hod.
-    da = t.
-    nl = uur
-    fi = t.
-    fr = h
-    de = St.
-    hu = ó.
-    id = j.
-    it = ore
-    ja = 時間
-    ko = 시간
-    nb = t.
-    pl = godz.
-    pt = h.
-    pt-BR = h.
-    ro = ore
-    es = h.
-    es-MX = h.
-    sv = h.
-    th = ชม
-    tr = sa.
-    uk = год.
-    vi = h.
-    el = ω.
-    sk = h.
-    sw = saa
-    zh-Hans = 小时
-    zh-Hant = 小時
-    fa = ساعت
-
-  [elevation_profile_minutes]
-    en = min
-    ru = мин
-    ar = دقيقة
-    cs = min
-    da = min
-    nl = min
-    fi = min
-    fr = mn
-    de = Min
-    hu = p.
-    id = mnt
-    it = min
-    ja = 分
-    ko = 분
-    nb = min
-    pl = min
-    pt = min
-    pt-BR = min
-    ro = min
-    es = min
-    es-MX = min
-    sv = min
-    th = นาที
-    tr = dk.
-    uk = хв
-    vi = ph
-    el = λ.
-    sk = min
-    sw = dakika
-    zh-Hans = 分钟
-    zh-Hant = 分鐘
-    fa = دقیقه
+    sk = Čas:
+    sw = Muda:
 
   [isolines_toast_zooms_1_10]
+    tags = ios, android
     en = Zoom in to explore isolines
     ru = Увеличьте карту, чтобы увидеть изолинии
     ar = قرب لتكتشف خطوط الكنتور
@@ -30164,88 +17636,21 @@
     pt-BR = Use o zoom para explorar as isolinhas
     ro = Măriți harta pentru a vedea contururile
     es = Amplía el mapa para ver las isolíneas
-    es-MX = Amplíe el mapa para ver las isolíneas
     sv = Förstora kartan för att se isolinjer
     th = ขยายเข้าเพื่อสำรวจเส้นชั้นความสูง
     tr = Konturları görmek için haritayı büyütün
     uk = Збільште карту, щоб побачити ізолінії
     vi = Phóng bản đồ để nhìn rõ đường đồng mức
-    el = Μεγεθύνετε για να δείτε περιγράμματα
-    sk = Priblížením preskúmajte izočiary
-    sw = Vuta karibu kutalii mistari ya kontua
     zh-Hans = 放大地图以查看等高线
     zh-Hant = 放大地圖以查看等高線
+    el = Μεγεθύνετε για να δείτε περιγράμματα
+    es-MX = Amplíe el mapa para ver las isolíneas
     fa = برای بررسی خطوط تراز زوم کنید
-
-  [downloader_updating_ios]
-    en = Updating
-    ru = Обновление
-    ar = جار التحديث
-    cs = Probíhá aktualizace
-    da = Opdaterer
-    nl = Updaten
-    fi = Päivitys
-    fr = Misе à jour
-    de = Update
-    hu = Feltöltés
-    id = Memperbarui
-    it = Aggiornamento in corso
-    ja = 更新中
-    ko = 업데이트 중
-    nb = Oppdatering
-    pl = Aktualizacja
-    pt = Atualização
-    pt-BR = Atualizando
-    ro = Actualizare
-    es = Actualización
-    es-MX = Actualización
-    sv = Uppdatering
-    th = การอัปเดต
-    tr = Güncelleme
-    uk = Оновлення
-    vi = Cập nhật
-    el = Ενημέρωση
-    sk = Aktualizovanie
-    sw = Inasasisha
-    zh-Hans = 更新
-    zh-Hant = 更新
-    fa = در حال بروزرسانی
-
-  [downloader_loading_ios]
-    en = Downloading
-    ru = Загрузка
-    ar = جار التحميل
-    cs = Probíhá stahování
-    da = Downloader
-    nl = Downloaden
-    fi = Lataus
-    fr = Téléchargement
-    de = Download
-    hu = Letöltés
-    id = Mengunduh
-    it = Caricamento
-    ja = ダウンロード中
-    ko = 다운로드 중
-    nb = Nedlasting
-    pl = Pobieranie
-    pt = Carregamento
-    pt-BR = Baixando
-    ro = Încărcare
-    es = Cargando
-    es-MX = Cargando
-    sv = Nedladdning
-    th = การดาวน์โหลด
-    tr = İndir
-    uk = Завантаження
-    vi = Tải xuống
-    el = Φόρτωση
-    sk = Sťahovanie
-    sw = Inapakua
-    zh-Hans = 加载
-    zh-Hant = 加載
-    fa = در حال دانلود
+    sk = Priblížením preskúmajte izočiary
+    sw = Vuta karibu kutalii mistari ya kontua
 
   [key_information_title]
+    tags = android
     en = Key information
     ru = Ключевая информация
     ar = معلومات رئيسية
@@ -30266,99 +17671,102 @@
     pt-BR = Informação importante
     ro = Informații cheie
     es = Información clave
-    es-MX = Información clave
     sv = Nyckelinformation
     th = ข้อมูลหลัก
     tr = Anahtar bilgisi
     uk = Ключова інформація
     vi = Thông tin chìa khóa
-    el = Βασικές πληροφορίες
-    sk = Kľúčová informácia
-    sw = Habari muhimu
     zh-Hans = 关键信息
     zh-Hant = 關鍵信息
+    el = Βασικές πληροφορίες
+    es-MX = Información clave
     fa = اطلاعات کلیدی
+    sk = Kľúčová informácia
+    sw = Habari muhimu
 
   [download_map_title]
+    tags = android
     en = Download the world map
     ru = Скачать карту мира
 
   [connection_failure]
+    tags = android
     en = Connection failure
     ru = Ошибка подключения
 
   [disconnect_usb_cable_title]
+    tags = android
     en = Disconnect USB cable
     ru = Отсоедините USB кабель
 
   [enable_screen_sleep]
-      en = Allow screen to sleep
-      ru = Разрешить экрану спать
-      ru = Разрешить экрану спать
-      ar = اسمح للشاشة بالنوم
-      cs = Nechte obrazovku spát
-      da = Lad skærmen sove
-      nl = Laat het scherm slapen
-      fi = Anna näytön nukkua
-      fr = Autoriser l'écran à dormir
-      de = Bildschirm schlafen lassen
-      hu = Hagyja aludni a képernyőt
-      id = Izinkan layar untuk tidur
-      it = Consenti allo schermo di dormire
-      ja = 画面をスリープ状態にする
-      ko = 화면 절전 모드 허용
-      nb = La skjermen sove
-      pl = Pozwól ekranowi spać
-      pt = Permitir que a tela hiberne
-      pt-BR = Permitir que a tela hiberne
-      ro = Permiteți ecranului să doarmă
-      es = Permitir que la pantalla duerma
-      sv = Låt skärmen sova
-      th = อนุญาตให้หน้าจอเข้าสู่โหมดสลีป
-      tr = Ekranın uyumasına izin ver
-      uk = Allow screen to sleep
-      vi = Cho phép màn hình ở chế độ ngủ
-      zh-Hans = 允许屏幕进入休眠状态
-      zh-Hant = 允许屏幕进入休眠状态
-      el = Αφήστε την οθόνη να κοιμηθεί
-      he = אפשר למסך לישון
-      sk = Nechajte obrazovku spať
-      fa = اجازه دهید صفحه نمایش بخوابد
+    tags = android
+    en = Allow screen to sleep
+    ru = Разрешить экрану спать
+    ar = اسمح للشاشة بالنوم
+    cs = Nechte obrazovku spát
+    da = Lad skærmen sove
+    nl = Laat het scherm slapen
+    fi = Anna näytön nukkua
+    fr = Autoriser l'écran à dormir
+    de = Bildschirm schlafen lassen
+    hu = Hagyja aludni a képernyőt
+    id = Izinkan layar untuk tidur
+    it = Consenti allo schermo di dormire
+    ja = 画面をスリープ状態にする
+    ko = 화면 절전 모드 허용
+    nb = La skjermen sove
+    pl = Pozwól ekranowi spać
+    pt = Permitir que a tela hiberne
+    pt-BR = Permitir que a tela hiberne
+    ro = Permiteți ecranului să doarmă
+    es = Permitir que la pantalla duerma
+    sv = Låt skärmen sova
+    th = อนุญาตให้หน้าจอเข้าสู่โหมดสลีป
+    tr = Ekranın uyumasına izin ver
+    uk = Allow screen to sleep
+    vi = Cho phép màn hình ở chế độ ngủ
+    zh-Hans = 允许屏幕进入休眠状态
+    zh-Hant = 允许屏幕进入休眠状态
+    el = Αφήστε την οθόνη να κοιμηθεί
+    fa = اجازه دهید صفحه نمایش بخوابد
+    he = אפשר למסך לישון
+    sk = Nechajte obrazovku spať
 
   [enable_screen_sleep_description]
-      comment = Description in preferences
-      tags = android
-      en = When enabled the screen will be allowed to sleep after a period of inactivity.
-      ru = При включении экран может переходить в спящий режим после периода бездействия.
-      ar = عند التمكين ، سيتم السماح للشاشة بالنوم بعد فترة من عدم النشاط.
-      cs = Je-li tato možnost povolena, bude obrazovka po určité době nečinnosti umožněna usnout.
-      da = Når den er aktiveret, får skærmen lov til at sove efter en periode med inaktivitet.
-      nl = Indien ingeschakeld, mag het scherm slapen na een periode van inactiviteit.
-      fi = Kun tämä asetus on käytössä, näytön annetaan nukkua käyttämättömyyden jälkeen.
-      fr = Lorsqu'il est activé, l'écran sera autorisé à dormir après une période d'inactivité.
-      de = Wenn diese Option aktiviert ist, kann der Bildschirm nach einer gewissen Zeit der Inaktivität in den Ruhezustand versetzt werden.
-      hu = Ha engedélyezve van, akkor a képernyő inaktivitás után alszik.
-      id = Jika diaktifkan, layar akan diizinkan untuk tidur setelah beberapa saat tidak aktif.
-      it = Quando abilitato, lo schermo potrà dormire dopo un periodo di inattività.
-      ja = 有効にすると、画面は一定時間非アクティブになった後もスリープ状態になります。
-      ko = 활성화되면 일정 시간 동안 활동이 없으면 화면이 절전 모드로 전환됩니다.
-      nb = Når den er aktivert, får skjermen lov til å sove etter en periode med inaktivitet.
-      pl = Po włączeniu ekran będzie mógł spać po okresie bezczynności.
-      pt = Quando ativada, a tela poderá hibernar após um período de inatividade.
-      pt-BR = Quando ativada, a tela poderá hibernar após um período de inatividade.
-      ro = Când este activat, ecranul va fi lăsat să doarmă după o perioadă de inactivitate.
-      es = Cuando está habilitado, la pantalla podrá dormir después de un período de inactividad.
-      sv = När den är aktiverad får skärmen sova efter en period av inaktivitet.
-      th = เมื่อเปิดใช้งานหน้าจอจะได้รับอนุญาตให้เข้าสู่โหมดสลีปหลังจากไม่มีการใช้งานเป็นระยะเวลาหนึ่ง
-      tr = Etkinleştirildiğinde ekranın bir süre hareketsiz kaldıktan sonra uykuya geçmesine izin verilir.
-      uk = When enabled the screen will be allowed to sleep after a period of inactivity.
-      vi = Khi được bật, màn hình sẽ được phép ở chế độ ngủ sau một thời gian không hoạt động.
-      zh-Hans = 启用后，屏幕将在一段时间不活动后进入休眠状态。
-      zh-Hant = 启用后，屏幕将在一段时间不活动后进入休眠状态。
-      el = Όταν είναι ενεργοποιημένη, η οθόνη θα αφεθεί να κοιμηθεί μετά από περίοδο αδράνειας.
-      he = כאשר מופעל המסך יורשה לישון לאחר תקופה של חוסר פעילות.
-      sk = Ak je táto možnosť povolená, obrazovka bude môcť po určitej dobe nečinnosti spať.
-      fa = درصورت فعال بودن ، بعد از یک دوره عدم فعالیت به صفحه اجازه خواب داده می شود.
+    comment = Description in preferences
+    tags = android
+    en = When enabled the screen will be allowed to sleep after a period of inactivity.
+    ru = При включении экран может переходить в спящий режим после периода бездействия.
+    ar = عند التمكين ، سيتم السماح للشاشة بالنوم بعد فترة من عدم النشاط.
+    cs = Je-li tato možnost povolena, bude obrazovka po určité době nečinnosti umožněna usnout.
+    da = Når den er aktiveret, får skærmen lov til at sove efter en periode med inaktivitet.
+    nl = Indien ingeschakeld, mag het scherm slapen na een periode van inactiviteit.
+    fi = Kun tämä asetus on käytössä, näytön annetaan nukkua käyttämättömyyden jälkeen.
+    fr = Lorsqu'il est activé, l'écran sera autorisé à dormir après une période d'inactivité.
+    de = Wenn diese Option aktiviert ist, kann der Bildschirm nach einer gewissen Zeit der Inaktivität in den Ruhezustand versetzt werden.
+    hu = Ha engedélyezve van, akkor a képernyő inaktivitás után alszik.
+    id = Jika diaktifkan, layar akan diizinkan untuk tidur setelah beberapa saat tidak aktif.
+    it = Quando abilitato, lo schermo potrà dormire dopo un periodo di inattività.
+    ja = 有効にすると、画面は一定時間非アクティブになった後もスリープ状態になります。
+    ko = 활성화되면 일정 시간 동안 활동이 없으면 화면이 절전 모드로 전환됩니다.
+    nb = Når den er aktivert, får skjermen lov til å sove etter en periode med inaktivitet.
+    pl = Po włączeniu ekran będzie mógł spać po okresie bezczynności.
+    pt = Quando ativada, a tela poderá hibernar após um período de inatividade.
+    pt-BR = Quando ativada, a tela poderá hibernar após um período de inatividade.
+    ro = Când este activat, ecranul va fi lăsat să doarmă după o perioadă de inactivitate.
+    es = Cuando está habilitado, la pantalla podrá dormir después de un período de inactividad.
+    sv = När den är aktiverad får skärmen sova efter en period av inaktivitet.
+    th = เมื่อเปิดใช้งานหน้าจอจะได้รับอนุญาตให้เข้าสู่โหมดสลีปหลังจากไม่มีการใช้งานเป็นระยะเวลาหนึ่ง
+    tr = Etkinleştirildiğinde ekranın bir süre hareketsiz kaldıktan sonra uykuya geçmesine izin verilir.
+    uk = When enabled the screen will be allowed to sleep after a period of inactivity.
+    vi = Khi được bật, màn hình sẽ được phép ở chế độ ngủ sau một thời gian không hoạt động.
+    zh-Hans = 启用后，屏幕将在一段时间不活动后进入休眠状态。
+    zh-Hant = 启用后，屏幕将在一段时间不活动后进入休眠状态。
+    el = Όταν είναι ενεργοποιημένη, η οθόνη θα αφεθεί να κοιμηθεί μετά από περίοδο αδράνειας.
+    fa = درصورت فعال بودن ، بعد از یک دوره عدم فعالیت به صفحه اجازه خواب داده می شود.
+    he = כאשר מופעל המסך יורשה לישון לאחר תקופה של חוסר פעילות.
+    sk = Ak je táto možnosť povolená, obrazovka bude môcť po určitej dobe nečinnosti spať.
 
   [whats_new_auto_update_title]
     comment = Autoupdate dialog on start
@@ -30394,12 +17802,12 @@
     be = Абнавіце спампаваныя карты
     el = Θα πρέπει να ενημερώστε τους χάρτες που έχετε κατεβάσει
     es_MX = Debe actualizar sus mapas descargados
+    fa = نقشه های دانلود شده خود را به روز کنید
     fr_CA = Mettez à jour vos cartes téléchargées
     he = עדכן את המפות שהורדת
     hi = अपने डाउनलोड किए गए मानचित्र अपडेट करें
     sk = Aktualizujte svoje stiahnuté mapy
     sw = Sasisha ramani zako ulizopakua
-    fa = نقشه های دانلود شده خود را به روز کنید
 
   [whats_new_auto_update_message]
     comment = Autoupdate dialog on start
@@ -30435,12 +17843,12 @@
     be = Абнаўленне карт падтрымлівае актуальнасць звестак пра аб’екты
     el = Η ενημέρωση των χαρτών διατηρεί τις πληροφορίες των στοιχείων επικαιροποιημένες
     es_MX = Actualizar los mapas mantiene actualizada también la información acerca de los objetos
+    fa = به روز رسانی نقشه ها اطلاعات مربوط به اشیا را به روز نگه می دارد
     fr_CA = La mise à jour des cartes permet d'avoir des informations à jour sur les objets
     he = עדכון המפות שומר על המידע שבהן עדכני
     hi = मानचित्रों का अपडेट होना ऑब्जेक्ट्स के बारे में जानकारी अप टू डेट रखता है
     sk = Vďaka aktualizácii máp budú informácie o objektoch na mape aktualizované
     sw = Kusasisha ramani kunaweka taarifa kuhusu vipengee ikiwa ya hivi sasa zaidi
-    fa = به روز رسانی نقشه ها اطلاعات مربوط به اشیا را به روز نگه می دارد
 
   [whats_new_auto_update_button_size]
     comment = Autoupdate dialog on start
@@ -30476,12 +17884,12 @@
     be = Абнавіць (%s)
     el = Ενημέρωση (%s)
     es_MX = Actualizar (%s)
+    fa = بروزرسانی (%s)
     fr_CA = Mettre à jour (%s)
     he = עדכן (%s)
     hi = (%s) अपडेट करें
     sk = Aktualizovať (%s)
     sw = Sasisha (%s)
-    fa = بروزرسانی (%s)
 
   [whats_new_auto_update_button_later]
     comment = Autoupdate dialog on start
@@ -30517,9 +17925,9 @@
     be = Абнавіць пазней уручную
     el = Χειροκίνητη ενημέρωση αργότερα
     es_MX = Actualizar después manualmente
+    fa = بعدا به صورت دستی به روزرسانی کنید
     fr_CA = Plus tard (manuel)
     he = עדכן ידנית מאוחר יותר
     hi = बाद में मैनुअल रूप से अपडेट करें
     sk = Manuálne aktualizovať neskôr
     sw = Sasisha mwenyewe baadaye
-    fa = بعدا به صورت دستی به روزرسانی کنید

--- a/iphone/Maps/LocalizedStrings/ar.lproj/Localizable.strings
+++ b/iphone/Maps/LocalizedStrings/ar.lproj/Localizable.strings
@@ -18,9 +18,6 @@
 /* Button which deletes downloaded country */
 "delete" = "حذف";
 
-/* Button "do not interrupt download" if user touched actively downloading country */
-"do_nothing" = "استمرار";
-
 "download_maps" = "تنزيل الخرائط";
 
 /* Settings/Downloader - info for country when download fails */
@@ -28,9 +25,6 @@
 
 /* Settings/Downloader - info for country which started downloading */
 "downloading" = "جاري التنزيل…";
-
-/* Settings/Downloader - size string, only strings different from English should be translated */
-"kb" = "ك.ب.";
 
 /* Choose measurement on first launch alert - choose metric system button */
 "kilometres" = "كيلومتر";
@@ -55,17 +49,11 @@
 /* Update maps later/Buy pro version later button text */
 "later" = "لاحقا";
 
-/* Don't show some dialog any more */
-"never" = "أبدا";
-
 /* View and button titles for accessibility */
 "search" = "البحث";
 
 /* Search box placeholder text */
 "search_map" = "ابحث في الخريطة";
-
-/* Settings/Downloader - info for not downloaded country */
-"touch_to_download" = "انقر للتنزيل";
 
 /* Settings/Downloader - 3G download warning dialog confirm button */
 "use_cellular_data" = "نعم";
@@ -73,20 +61,11 @@
 /* Location services are disabled by user alert - message */
 "location_is_disabled_long_text" = "التطبيق أو جميع خدمات تحديد المواقع معطلة لديك في الوقت الحالي. الرجاء تفعيلها في الإعدادات.";
 
-/* Location Services are not available on the device alert - message */
-"device_doesnot_support_location_services" = "جهازك لا يدعم خدمات تحديد المواقع.";
-
 /* View and button titles for accessibility */
 "zoom_to_country" = "عرض على الخريطة";
 
-/* Button text for the button at the center of the screen when the country is not downloaded */
-"country_status_download" = "(^ ^)\nتحميل الخريطة";
-
 /* Button text for the button at the center of the screen when the country is not downloaded and the size should not be shown */
 "country_status_download_without_size" = "تحميل الخريطة";
-
-/* Button text for the button at the center of the screen when the country is not downloaded */
-"country_status_download_without_routing" = "(^ ^)\nتنزيل خريطة بدون تحديد خط السير";
 
 /* Message to display at the center of the screen when the country download has failed */
 "country_status_download_failed" = "فشلت عملية تنزيل";
@@ -96,19 +75,13 @@
 
 "about_menu_title" = "حول Organic Maps";
 
-"downloaded_touch_to_delete" = "تم تنزيل (%@)، انقر للحذف";
-
 "connection_settings" = "اعدادات الاتصال";
-
-"download_mb_or_kb" = "تنزيل %@";
 
 "close" = "اغلاق";
 
 "unsupported_phone" = "أنت بحاجة الى OpenGL بأجهزة تسريع. لسوء الحظ جهازك لا يدعم هذه الخاصية.";
 
 "download" = "تنزيل";
-
-"external_storage_is_not_available" = "خاصية التخزين بواسطة البطاقة الرقمية الآمنة\الناقل التسلسلي الشامل غير متاحة مع الخرائط التي تم تنزيلها.";
 
 "disconnect_usb_cable" = "الرجاء فصل كابل الناقل التسلسلي الشامل أو إدخال بطاقة الذاكرة من أجل استخدام Organic Maps.";
 
@@ -117,8 +90,6 @@
 "not_enough_memory" = "لا يوجد ذاكرة كافية لتشغيل التطبيق.";
 
 "download_resources" = "قبل أن تبدأ، دعنا نقوم بتنزيل خريطة العالم العامة على جهازك.\nانها بحاجة الى %@ من البيانات.";
-
-"getting_position" = "الحصول على الموقع الحالي";
 
 "download_resources_continue" = "الذهاب الى الخريطة";
 
@@ -140,23 +111,14 @@
 /* Add New Bookmark Set dialog title */
 "add_new_set" = "إضافة مجموعة جديدة";
 
-/* Place Page - Add To Bookmarks button */
-"add_to_bookmarks" = "إضافة الى الإشارات المرجعية";
-
 /* Bookmark Color dialog title */
 "bookmark_color" = "لون الإشارة المرجعية";
 
 /* Add Bookmark Set dialog - hint when set name is empty */
 "bookmark_set_name" = "اسم مجموعة الإشارات المرجعية";
 
-/* Bookmark Sets dialog title */
-"bookmark_sets" = "مجموعات الإشارات المرجعية";
-
 /* Bookmarks - dialog title */
 "bookmarks" = "الإشارات المرجعية";
-
-/* Add bookmark dialog - bookmark color */
-"color" = "اللون";
 
 /* Default bookmarks set name */
 "core_my_places" = "أماكني";
@@ -167,14 +129,8 @@
 /* Editor title above street and house number */
 "address" = "العنوان";
 
-/* Place Page - Remove Pin button */
-"remove_pin" = "إزالة الدبوس";
-
 /* Add bookmark dialog - bookmark set, Bookmarks dialog - Bookmark set cell */
 "set" = "المجموعة";
-
-/* Text hint in Bookmarks dialog when no any bookmarks are added */
-"bookmarks_usage_hint" = "ليس لديك أي إشارات مرجعية بعد.\nانقر على أي مكان على الخريطة لإضافة إشارة مرجعية.\nيمكنك أيضا استيراد الإشارات المرجعية من المصادر الأخرى وعرضها في Organic Maps. افتح ملف KML/KMZ الذي يحتوي على الدبابيس المحفوظة من البريد الالكتروني، دروب بوكس أو ويب لينك.";
 
 /* Settings button in system menu */
 "settings" = "الإعدادات";
@@ -191,26 +147,11 @@
 /* Ask to wait user several minutes (some long process in modal dialog). */
 "wait_several_minutes" = "يمكن أن تستغرق هذه العملية عدة دقائق.\nالرجاء الانتظار…";
 
-/* Show bookmarks from this category on a map or not */
-"visible" = "مرئي";
-
-/* Toast which is displayed when GPS has been deactivated */
-"gps_is_disabled_long_text" = "تم تعطيل خاصية نظام تحديد المواقع العالمي. الرجاء تفعيله في الاعدادات.";
-
 /* Measurement units title in settings activity */
 "measurement_units" = "وحدات القياس.";
 
 /* Detailed description of Measurement Units settings button */
 "measurement_units_summary" = "اختر من بين الأميال و الكيلو مترات.";
-
-/* Do search in all sources */
-"search_mode_all" = "كل مكان";
-
-/* Do search near my position only */
-"search_mode_nearme" = "بجواري";
-
-/* Do search in current viewport only */
-"search_mode_viewport" = "على الشاشة";
 
 /* Search category for cafes, bars, restaurants */
 "eat" = "مكان لتناول الطعام";
@@ -266,14 +207,8 @@
 /* Search category */
 "police" = "شرطة";
 
-/* String in search result list, when nothing found */
-"no_search_results_found" = "لم يتم العثور على أي نتائج";
-
 /* Notes field in Bookmarks view */
 "description" = "ملاحظات";
-
-/* Button text */
-"share_by_email" = "مشاركة بواسطة البريد الالكتروني";
 
 /* Email Subject when sharing bookmarks category */
 "share_bookmarks_email_subject" = "تم مشاركة اشارات Organic Maps المرجعية معك";
@@ -295,26 +230,11 @@
 /* Warning message when doing search around current position */
 "unknown_current_position" = "لم يتم التعرف على موقعك بعد.";
 
-/* Warning message when location country isn't downloaded during search (see also download_location_map_proposal). */
-"download_location_country" = "تنزيل دولة (%@) موقعك الحالي";
-
-/* Warning message when viewport country isn't downloaded during search */
-"download_viewport_country_to_search" = "تنزيل الدولة (%@) التي تبحث فيها";
-
 /* Alert message that we can't run Map Storage settings due to some reasons. */
 "cant_change_this_setting" = "نأسف، اعدادات تخزين الخرائط معطلة حالياً.";
 
 /* Alert message that downloading is in progress. */
 "downloading_is_active" = "جاري الآن تنزيل الدولة";
-
-/* Message that will be shown in alert view, when we ask user to leave review on App Store */
-"appStore_message" = "نأمل أن تكون قد استمتعت باستخدام Organic Maps! إذا كان الأمر كذلك، الرجاء تقييم التطبيق في App Store. يستغرق ذلك أقل من دقيقة لكنه يفيدنا بالفعل. شكرا لك على دعمك!";
-
-/* No, thanks */
-"no_thanks" = "لا، شكرا";
-
-/* Share one specific bookmark using SMS, %1$@ contains om:// and %2$@ https://omaps.app link. @NOTE non-ascii symbols in the link will result in max 70 characters SMS instead of 140. */
-"bookmark_share_sms" = "هاي، تفقد الدبوس الخاص بي على Organic Maps! %1$@ أو %2$@. ليس لديك أي خرائط تعمل بدون الاتصال مع الانترنت مثبتة على جهازك؟ قم بتحميلها من هنا: https://omaps.app/get";
 
 /* Share my position using SMS, %1$@ contains om:// and %2$@ https://omaps.app link WITHOUT NAME. @NOTE non-ascii symbols in the link will result in max 70 characters SMS instead of 140. */
 "my_position_share_sms" = "هاي، تفقد الموقع الخاص بي على Organic Maps! %1$@ أو %2$@. ليس لديك أي خرائط تعمل بدون الاتصال مع الانترنت مثبتة على جهازك؟ قم بتحميلها من هنا: https://omaps.app/get";
@@ -328,23 +248,11 @@
 /* Share my position using EMail, %1$@ is om:// and %2$@ is https://omaps.app link WITHOUT NAME */
 "my_position_share_email" = "مرحبا،\n\nأنا هنا الآن: %1$@. انقر على هذا الرابط %2$@ أو ذلك الرابط %3$@ لمشاهدة المكان على الخريطة.\n\nشكرا لك.";
 
-/* Android share by Message/SMS button text (including SMS) */
-"share_by_message" = "مشاركة بواسطة رسالة";
-
 /* Share button text which opens menu with more buttons, like Message, EMail, Facebook etc. */
 "share" = "مشاركة";
 
-/* iOS share by Message button text (including SMS) */
-"message" = "رسالة";
-
 /* Share by email button text, also used in editor. */
 "email" = "البريد الالكتروني";
-
-/* Copy Link */
-"copy_link" = "نسخ الرابط";
-
-/* Text for the button that returns to caller application */
-"more_info" = "إظهار مزيد من المعلومات";
 
 /* Text for message when used successfully copied something */
 "copied_to_clipboard" = "تم النسخ الى الحافظة: %1$@";
@@ -354,15 +262,6 @@
 
 /* Used for bookmark editing */
 "done" = "تم";
-
-/* Summary for preferences in MWM */
-"yopme_pref_summary" = "اختر اعدادات الشاشة الخلفية";
-
-/* Title for yopme preferences in MWM */
-"yopme_pref_title" = "اعدادات الشاشة الخلفية";
-
-/* Hint for upper-right icon p2b */
-"show_on_backscreen" = "إظهار في الشاشة الخلفية";
 
 /* Prints version number in About dialog */
 "version" = "الاصدار: %@";
@@ -381,19 +280,11 @@
 
 "share_my_location" = "مشاركة موقعي";
 
-"menu_search" = "بحث";
-
 /* Settings general group in settings screen */
 "prefs_group_general" = "General settings";
 
 /* Settings information group in settings screen */
 "prefs_group_information" = "Information";
-
-/* Settings screen: "Map" category title */
-"prefs_group_map" = "الخريطة";
-
-/* Settings screen: "Miscellaneous" category title */
-"prefs_group_misc" = "مُتَنَوّعة";
 
 "prefs_group_route" = "الملاحة";
 
@@ -419,9 +310,6 @@
 /* Settings «Map» category: «3D buildings» title */
 "pref_map_3d_buildings_title" = "مباني ثلاثية الأبعاد";
 
-/* Settings «Map» category: «3D buildings» summary */
-"pref_map_3d_buildings_subtitle" = "تؤثر على عمر البطارية";
-
 /* Settings «Route» category: «Tts enabled» title */
 "pref_tts_enable_title" = "تعليمات صوتية";
 
@@ -433,8 +321,6 @@
 
 /* Title for "Other" section in TTS settings. */
 "pref_tts_other_section_title" = "آخر";
-
-"pref_tts_how_to_set_up_voice" = "كيفية ضبط الصوت";
 
 /* Settings «Map» category: «Record track» title */
 "pref_track_record_title" = "المسار الأخير";
@@ -455,56 +341,7 @@
 
 "recent_track_help_text" = "يتيح لك تسجيل مسار السفر لفترة معينة وعرضه على الخريطة. الرجاء ملاحظة: يؤدي تنشيط هذه الوظيفة إلى زيادة استهلاك البطارية. سوف تتم إزالة المسار تلقائيًا من الخريطة بعد انتهاء الفاصل الزمني.";
 
-"pref_track_ios_caption" = "يُظهر المسار الأخير مسار سفرك.";
-
-"pref_track_ios_subcaption" = "يرجى تحديد نطاق وقت حفظ المسار.";
-
-"placepage_distance" = "المسافة";
-
-"placepage_coordinates" = "الإحداثيات";
-
-"placepage_unsorted" = "لم يتم فرزها";
-
 "search_show_on_map" = "مشاهدة على الخريطة";
-
-/* Used to warn user when fixing KitKat issue */
-"bookmark_move_fail" = "نحن بحاجة لنقل الإشارات المرجعية الخاصة بك الى الذاكرة الداخلية، لكن لا يوجد حيز كافٍ لها. الرجاء إخلاء الذاكرة، وإلا لن تكون  الإشارات المرجعية متاحة.";
-
-/* Used in More Apps menu */
-"free" = "مجاني";
-
-/* Used in More Apps menu */
-"buy" = "شراء";
-
-/* 1st search button-like result */
-"search_on_map" = "البحث في الخريطة";
-
-/* toast with an error */
-"no_route_found" = "لم يتم العثور على أي مسار";
-
-/* route title */
-"route" = "المسار";
-
-/* category title */
-"routes" = "المسارات";
-
-/* text of notification */
-"download_map_notification" = "تنزيل خريطة المكان الذي توجد فيه";
-
-/* text of notification */
-"pro_version_is_free_today" = "تطبيق Organic Maps مجاني اليوم! قم بتنزيله الآن وأخبر أصدقائك.";
-
-/* Dialog for transferring maps from lite to pro. */
-"move_lite_maps_to_pro" = "نحن ننقل خرائط التنزيلات الخاصة بك من Organic Maps Lite إلى Organic Maps. يمكن أن يستغرق بضع دقائق";
-
-/* Message to display when maps moved. */
-"move_lite_maps_to_pro_ok" = "تم بنجاح نقل خرائطك التي تم تنزيلها إلى Organic Maps.";
-
-/* Message to display when maps move failed. */
-"move_lite_maps_to_pro_failed" = "فشل نقل خرائطك يُرجى حذف Organic Maps Lite وتنزيل الخرائط مرة أخرى.";
-
-/* Text in menu */
-"settings_and_more" = "الإعدادات والمزيد";
 
 /* Text in menu */
 "website" = "الموقع الإلكتروني";
@@ -527,14 +364,8 @@
 /* Text in menu */
 "openstreetmap" = "OpenStreetMap";
 
-/* Text in menu */
-"contact_us" = "أتصل بنا";
-
 /* Settings: Send feedback button and dialog title */
 "feedback" = "تعقيب";
-
-/* Text in menu */
-"subscribe_to_news" = "أشترك في نشرتنا الإخبارية";
 
 /* Text in menu */
 "rate_the_app" = "تقييم التطبيق";
@@ -548,15 +379,6 @@
 /* Text in menu */
 "report_a_bug" = "الإبلاغ عن خطأ";
 
-/* Email subject */
-"subscribe_me_subject" = "يرجى اشتراكي في النشرة البريدية لدى Organic Maps";
-
-/* Email body */
-"subscribe_me_body" = "أريد أن أكون أول من يعرف آخر الأخبار والتحديثات والترقيات. يمكنني إلغاء اشتراكي في أي وقت.";
-
-/* About text */
-"about_text" = "توفر لكم Organic Maps أحدث الخرائط دون الاتصال بالإنترنت لكافة دول وكافة مدن العالم. سافر وتمتع بالثقة التامة: إينما كنت، تساعدك Organic Maps على تحديد مكانك على الخريطة، والعثور على أقرب مطعم أو فندق أو بنك أو محطة غاز الخ لا يتطلب الاتصال بالإنترنت.\n\nنحن نعمل دوماً على إدخال مزايا جديدة على التطبيق ونود أن نسمع منك رأيك عن الكيفية التي يمكن بها تحسين تطبيق Organic Maps في رأيك. إذا واجهتك أي مشاكل مع التطبيق، لا تتردد في الاتصال بنا على support@organicmaps.app. نحن نرد على كافة الطلبات.\n\nهل أعجبك تطبيق Organic Maps وترغب في دعمنا؟ هناك بعض الطرق السهلة والمجانية بالكامل لعمل ذلك.\n\n- انشر رأيك على متجر التطبيقات الخاص بك\n- اعجب بصفحتنا على موقع Facebook http://www.facebook.com/OrganicMaps\n- أو أخبر والدتك وأصدقائك وزملائك عن تطبيق Organic Maps :)\n\nشكراً لك على وجودك معنا. نحن نقدر جداً دعمك لنا!\n\nيُرجى ملاحظة نحن نستقي بيانات الخرائط من OpenStreetMap، مشروع خرائط يشبه موسوعة Wikipedia ويتيح هذا المشروع للمستخدمين إنشاء وتحرير الخرائط. إذا كنت ترى أن هناك خطأ ما أو شيء غير موجود على الخريطة، يمكنك تصحيح الخرائط مباشرة على https://www.openstreetmap.org، وسوف تظهر تغييراتك على تطبيق Organic Maps في الإصدار القادم للتطبيق.";
-
 /* Alert text */
 "email_error_body" = "لم يتم تعيين البريد الإلكتروني للعميل. يرجى تكوينه أو استخدام أي وسيلة أخرى للاتصال بنا على %@";
 
@@ -569,12 +391,6 @@
 /* Search category */
 "wifi" = "واي-فاي";
 
-/* Update map suggestion */
-"routing_map_outdated" = "يرجى تحديث الخريطة لإنشاء مسار.";
-
-/* Update maps suggestion */
-"routing_update_maps" = "إصدار Organic Maps الجديد يسمح بإنشاء مسارات انطلاقاً من موقعك الحالي نحو المكان الذي تتجه إليه. يرجى تحديث الخرائط لاستخدام هذه الميزة.";
-
 /* Update all button text */
 "downloader_update_all_button" = "تحديث الكل";
 
@@ -583,9 +399,6 @@
 
 /* Downloaded maps category */
 "downloader_downloaded_subtitle" = "تم تنزيلها";
-
-/* Downloaded maps category */
-"downloader_available_maps" = "متاح";
 
 /* Country queued for download */
 "downloader_queued" = "مَصْفوف";
@@ -598,17 +411,6 @@
 
 "downloader_downloading" = "يتم تنزيل:";
 
-"downloader_search_results" = "تم العثور على";
-
-/* Disclaimer message */
-"routing_disclaimer" = "عند إنشاء مسارات الطرق في تطبيق Organic Maps، يرجى أخذ التالي في الحسبان:\n\n  - المسارات المقترحة تعتبر مجرد اقتراحات فقط.\n - حالة الطريق وقوانينه والإشارات الموجودة فيه لها الأولولية أثناء تقديم نصائح الملاحة.\n - قد تكون الخريطة خاطئة أو قديمة، لذا فإنه يمكن ألا تُرسم المسارات بالشكل الأمثل.\n\n  كن آمنا على الطريق وانتبه لتفسك!";
-
-/* Outdated maps category */
-"downloader_outdated_maps" = "انتهت صلاحيته";
-
-/* Up to date maps category */
-"downloader_uptodate_maps" = "محدّث";
-
 /* Status of outdated country in the list */
 "downloader_status_outdated" = "تحديث";
 
@@ -618,49 +420,14 @@
 /* Displayed in a dialog that appears when a user tries to delete a map while the app is in the follow route mode */
 "downloader_delete_map_while_routing_dialog" = "لحذف الخريطة يرجى إيقاف الملاحة.";
 
-/* Show when user try build route, but we don't know where he */
-"routing_failed_unknown_my_position" = "الموقع الحالي غير مُعَرّف. يرجى تحديد موقع لإنشاء مسار.";
-
-/* Show if use has not routing file, or InconsistentMWMandRoute */
-"routing_failed_has_no_routing_file" = "هناك حاجة إلى بيانات إضافية لإنشاء مسار. بدء التحميل؟";
-
-/* StartPointNotFound */
-"routing_failed_start_point_not_found" = "لا يمكن حساب المسار. لا توجد طرق قرب نقطة البداية لديك.";
-
-/* EndPointNotFound */
-"routing_failed_dst_point_not_found" = "لا يمكن حساب المسار. لا توجد طرق بالقرب من وجهتك المقصودة.";
-
 /* PointsInDifferentMWM */
 "routing_failed_cross_mwm_building" = "يمكن فقط إنشاء المسارات التي توجد بشكل كامل ضمن خريطة واحدة.";
-
-/* RouteNotFound */
-"routing_failed_route_not_found" = "لم يتم العثور على مسار بين المنشأ والوُجْهَة المحددة. الرجاء تحديد نقطة بداية أو نهاية مختلفة.";
-
-/* InternalError */
-"routing_failed_internal_error" = "حدث خطأ داخلي. يرجى محاولة حذف الخريطة وإعادة تنزيلها مرة أخرى. إذا استمرت المشكلة يرجى الاتصال بنا على support@organicmaps.app.";
-
-/* Context menu item for downloader. */
-"downloader_download_map_and_routing" = "تنزيل الخريطة + تحديد المسار";
-
-/* Context menu item for downloader. */
-"downloader_download_routing" = "تنزيل تحديد المسار";
-
-/* Context menu item for downloader. */
-"downloader_delete_routing" = "إزالة تحديد المسار";
 
 /* Context menu item for downloader. */
 "downloader_download_map" = "تنزيل الخريطة";
 
-"downloader_download_map_no_routing" = "تنزيل خريطة بدون تحديد خط السير";
-
-/* Button for routing. */
-"routing_go" = "انطلق!";
-
 /* Item status in downloader. */
 "downloader_retry" = "تكرار";
-
-/* Item in context menu. */
-"downloader_map_and_routing" = "الخريطة + تحديد المسار";
 
 /* Item in context menu. */
 "downloader_delete_map" = "حذف الخريطة";
@@ -668,29 +435,11 @@
 /* Item in context menu. */
 "downloader_update_map" = "تحديث الخريطة";
 
-/* Item in context menu. */
-"downloader_update_map_and_routing" = "تحديث الخريطة + تحديد المسار";
-
-/* Item in context menu. */
-"downloader_map_only" = "الخريطة فقط";
-
-/* Toolbar title */
-"toolbar_application_menu" = "قائمة التطبيق";
-
 /* Preference text */
 "pref_use_google_play" = "استخدم خدمات جوجل بلاي لتتعرف على موقعك الحالي";
 
 /* Text for rating dialog */
 "rating_just_rated" = "لقد قمت بتقييم تطبيقك للتو";
-
-/* Text for rating dialog */
-"rating_user_since" = "أنا مستخدم لتطبيق Organic Maps منذ %@";
-
-/* Text for rating dialog */
-"rating_do_like_maps" = "هل تطبيق Organic Maps يعجبك؟";
-
-/* Text for rating dialog */
-"rating_tap_star" = "انقر على النجمة لتقييم التطبيق.";
 
 /* Text for rating dialog */
 "rating_thanks" = "شكرا لك!";
@@ -701,23 +450,8 @@
 /* Text for rating dialog */
 "rating_send_feedback" = "إرسال التعليق";
 
-/* Text for g+ dialog */
-"rating_google_plus" = "اضغط على g+ لتخبر أصدقاءك عن التطبيق.";
-
 /* Text for routing error dialog */
 "routing_download_maps_along" = "تنزيل الخرائط على طول الطريق";
-
-/* Text for routing error dialog */
-"routing_download_map" = "Scarica la mappa";
-
-/* Text for routing error dialog */
-"routing_download_map_and_routing" = "Scarica la mappa aggiornata e i dati del percorso per ottenere tutte le funzionalità Organic Maps.";
-
-/* Text for routing error dialog */
-"routing_get_routing_data" = "Ottieni i dati del percorso";
-
-/* Text for routing error dialog */
-"routing_get_additional_data" = "dati aggiuntivi richiesti per creare i percorsi dalla tua posizione.";
 
 /* Text for routing error dialog */
 "routing_requires_all_map" = "Creare un percorso necessita la presenza di tutte le mappe scaricate e aggiornate dalla tua posizione alla destinazione.";
@@ -725,50 +459,15 @@
 /* Text for routing error dialog */
 "routing_not_enough_space" = "Spazio non sufficiente";
 
-/* Text for routing error dialog */
-"routing_download_more_than_avail" = "Devi scaricare %@ MB, ma lo spazio disponibile è di soli %@ MB.";
-
-/* Text for routing error dialog */
-"routing_download_roaming" = "أنت على وشك تنزيل %@ م.ب باستخدام البيانات المتنقلة (في وضع التجوال). وهذا قد يؤدي إلى مصاريف إضافية اعتمادا على خطة البيانات المتنقلة الخاصة بالمشغل الخاص بك.";
-
 /* bookmark button text */
 "bookmark" = "إشارة مرجعية";
-
-/* map is not downloaded */
-"not_found_map" = "الخريطة الخاصة بالمكان الذي تتواجد فيه لا يتم تنزيلها";
 
 /* location service disabled */
 "enable_location_services" = "الرجاء تفعيل خدمة تحديد المواقع";
 
-/* download map */
-"download_map" = "قم بتنزيل الخريطة الخاصة بموقعك";
-
-/* download map on iPhone */
-"download_map_iphone" = "قم بتنزيل خريطة الموقع الحالي على جهاز آيفون الخاص بك";
-
-/* clear pin */
-"nearby" = "قريب";
-
-/* clear pin */
-"clear_pin" = "مسح الرقم السري";
-
-/* location is undefined */
-"undefined_location" = "الموقع الحالي غير مُعَرّف";
-
-/* download country of your location */
-"download_country" = "تنزيل دولة موقعك الحالي";
-
-/* download failed */
-"download_failed" = "فشلت عملية تنزيل";
-
-/* get the map */
-"get_the_map" = "احصل على الخريطة";
-
 "save" = "حفظ";
 
 "edit_description_hint" = "أوصافك (نصّ أو html)";
-
-"new_group" = "مجموعة جديدة";
 
 "create" = "إنشاء";
 
@@ -795,30 +494,6 @@
 
 /* pink color */
 "pink" = "وردي";
-
-/* deep purple color */
-"deep_purple" = "أرجواني داكن";
-
-/* light blue color */
-"light_blue" = "أزرق فاتح";
-
-/* cyan color */
-"cyan" = "أزرق سماوي";
-
-/* teal color */
-"teal" = "أخضر فاتح";
-
-/* lime color */
-"lime" = "ليموني";
-
-/* deep orange color */
-"deep_orange" = "برتقالي داكن";
-
-/* gray color */
-"gray" = "رمادي";
-
-/* blue gray color */
-"blue_gray" = "رمادي أزرق";
 
 /* Wi-Fi available */
 "WiFi_available" = "نعم";
@@ -848,13 +523,9 @@
 
 "dialog_routing_location_unknown_turn_on" = "تعذر تحديد إحداثيات نظام تحديد المواقع العالمي GPS الحالية. قم بتمكين خدمات المواقع لحساب المسار.";
 
-"dialog_routing_location_unknown" = "تعذر تحديد مواقع إحداثيات نظام تحديد المواقع العالمي GPS الحالية.";
-
 "dialog_routing_download_files" = "تنزيل الملفات المطلوبة";
 
 "dialog_routing_download_and_update_all" = "قم بتنزيل وتحديث كافة الخرائط ومعلومات التوجيه على طول الطريق المتوقع لحساب المسار.";
-
-"dialog_routing_routes_size" = "ملفات معلومات التوجيه";
 
 "dialog_routing_unable_locate_route" = "تعذر تحديد موقع المسار";
 
@@ -884,21 +555,11 @@
 
 "dialog_routing_try_again" = "برجاء إعادة المحاولة";
 
-"dialog_routing_send_error" = "الإبلاغ عن المشكلة";
-
-"dialog_routing_if_get_cross_route" = "هل تريد إنشاء مسار مباشر بشكل أكبر يمتد عبر أكثر من خريطة؟";
-
-"dialog_routing_cross_route_is_optimal" = "هناك مسار أفضل يعبر حافة هذه الخريطة.";
-
 "not_now" = "ليس الآن";
-
-"dialog_routing_build_route" = "إنشاء";
 
 "dialog_routing_download_and_build_cross_route" = "هل ترغب في تنزيل الخريطة وإنشاء مسار أفضل يمتد عبر أكثر من خريطة؟";
 
 "dialog_routing_download_cross_route" = "تنزيل الخريطة لإنشاء مسار أفضل يعبر حافة هذه الخريطة.";
-
-"dialog_routing_cross_route_always" = "اعبر هذه الحدود دائمًا";
 
 
 /********** Strings for downloading map from search **********/
@@ -906,8 +567,6 @@
 "search_without_internet_advertisement" = "لبدء البحث وإنشاء الطرق، يرجى تنزيل الخريطة، وسوف لن تحتاج إلى اتصال بالإنترنت بعد الآن.";
 
 "search_select_map" = "اختيار الخريطة";
-
-"search_select_other_map" = "اختيار خريطة أخرى";
 
 /* «Show» context menu */
 "show" = "عرض";
@@ -918,17 +577,11 @@
 /* «Rename» context menu */
 "rename" = "إعادة تسمية";
 
-/* Bottom sheet: expand button (should be short) */
-"bottom_sheet_more" = "المزيد…";
-
 /* Failed planning route message in navigation view */
 "routing_planning_error" = "فشل في تخطيط المسار";
 
 /* Arrive routing message in navigation view */
 "routing_arrive" = "الوصول: %s";
-
-/* Text for routing::RouterResultCode::FileTooOld dialog. */
-"dialog_routing_download_and_update_maps" = "لإنشاء مسار، يرجى تنزيل وتحديث جميع الخرائط على امتداد الطريق.";
 
 "rate_alert_title" = "يعجبك التطبيق؟";
 
@@ -944,19 +597,11 @@
 
 "history" = "السجل";
 
-"next_turn_then" = "ثم";
-
 "closed" = "مغلق";
-
-"back_to" = "العودة إلى %@";
 
 "search_not_found" = "المعذرة، لم أعثر على أي شيء.";
 
 "search_not_found_query" = "يرجى تجربة استعلام آخر.";
-
-"search_not_found_map" = "فضلا، قم بتنزيل الخريطة التي تبحث فيها.";
-
-"search_not_found_location" = "قم بتنزيل الخريطة الخاصة بموقعك الجغرافي.";
 
 "search_history_title" = "سجل البحث";
 
@@ -964,23 +609,12 @@
 
 "clear_search" = "مسح تاريخ البحث";
 
-/* Title for settings to enable/disable showcase menu button */
-"showcase_settings_title" = "رؤية العروض";
-
 /* Place Page link to Wikipedia article (if map object has it). */
 "read_in_wikipedia" = "Wikipedia";
 
-"p2p_route_planning" = "تخطيط الطريق";
-
 "p2p_your_location" = "موقعك";
 
-"p2p_from" = "نقطة المغادرة";
-
-"p2p_to" = "نقطة الوصول";
-
 "p2p_start" = "البداية";
-
-"p2p_planning" = "جار التخطيط…";
 
 "p2p_from_here" = "من";
 
@@ -1018,15 +652,9 @@
 
 "editor_correct_mistake" = "تصحيح الخطأ";
 
-"editor_correct_mistake_message" = "قمت بخطأ في التحرير. يرجى تصحيح الخطأ أو التبديل إلى الوضع البسيط.";
-
 "editor_add_select_location" = "الموقع";
 
 "editor_done_dialog_1" = "لقد غيرت خريطة العالم. لا تخفي ذلك! اخبر أصدقاءك، وغيروها معا.";
-
-"editor_done_dialog_2" = "هذا هو تعديلك الثاني بالخريطة. أنت الآن في الترتيب رقم %d في قائمة محرري الخريطة. اخبر أصدقاءك عن ذلك.";
-
-"editor_done_dialog_3" = "لقد عدلت الخريطة، اخبر أصدقائك عن ذلك، وعدلوا الخريطة معا.";
 
 "share_with_friends" = "شارك مع الأصدقاء";
 
@@ -1044,20 +672,7 @@
 
 "editor_report_problem_duplicate_place_title" = "مكان متكرر";
 
-"first_launch_congrats_title" = "Organic Maps جاهز للاستخدام";
-
-"first_launch_congrats_text" = "ابحث وتصفح كل مكان في العالم بدون اتصال, مجانا.";
-
-"migrate_title" = "هام!";
-
-/* Android uses image instead of text. */
-"download_all" = "تنزيل الكل";
-
-"delete_all" = "حذف الكل";
-
 "autodownload" = "التنزيل التلقائي";
-
-"disable_autodownload" = "تعطيل التنزيل التلقائي";
 
 /* Place Page opening hours text */
 "closed_now" = "مغلق الآن";
@@ -1072,10 +687,6 @@
 "day_off" = "مغلق";
 
 "today" = "اليوم";
-
-"sunrise_to_sunset" = "من الشروق إلى المغيب";
-
-"sunset_to_sunrise" = "من غروب الشمس وحتى الشروق";
 
 "add_opening_hours" = "اضف ساعات عمل";
 
@@ -1095,45 +706,18 @@
 
 "forgot_password" = "هل نسيت كلمة المرور؟";
 
-/* Forgot Password dialog title */
-"restore_password" = "استعادة كلمة المرور";
-
-"enter_email_address_to_reset_password" = "أدخل عنوان البريد الإلكتروني الذي استخدمته عند التسجيل وسنرسل لك رابط لتجديد كلمة المرور";
-
-"reset_password" = "إعادة تعيين كلمة المرور";
-
-"username" = "اسم المستخدم";
-
 "osm_account" = "حساب OSM";
 
 "logout" = "تسجيل الخروج";
 
-"login_and_edit_map_motivation_message" = "قم بتسجيل الدخول وعدل البيانات الخاصة بالمكان على الخريطة وسنجعلها متاحة لملايين المستخدمين الآخرين. لنجعل العالم أفضل معا.";
-
 /* Information text: "Last upload 11.01.2016" */
 "last_upload" = "آخر تحميل";
 
-/* Motivates user to login/register, title above login buttons. */
-"you_have_edited_your_first_object" = "لقد قمت بتعديلك الأول!";
-
 "thank_you" = "شكرا لك";
-
-"login_with_google" = "تسجيل الدخول عبر جوجل";
-
-"login_with_openstreetmap" = "قم بتسجيل الدخول في www.openstreetmap.org";
 
 "edit_place" = "تعديل المكان";
 
 "place_name" = "اسم المكان";
-
-/* title above languages list cells in the editor, below editable name text field. */
-"other_languages" = "لغات أخرى";
-
-/* small button to open list with names in different languages */
-"show_more" = "إظهار أكثر";
-
-/* small button to close list with names in different languages */
-"show_less" = "إظهار أقل";
 
 "add_language" = "إضافة لغة";
 
@@ -1164,8 +748,6 @@
 
 "please_note" = "يرجى العلم أنه،";
 
-"common_no_wifi_dialog" = "لا يوجد اتصال واي فاي. هل ترغب في استخدام بيانات الهاتف للاتصال؟";
-
 "downloader_delete_map_dialog" = "سيتم حذف جميع التغييرات بالخريطة بالإضافة إلى حذف الخريطة نفسها.";
 
 "downloader_update_maps" = "تحديث الخرائط";
@@ -1173,10 +755,6 @@
 "downloader_mwm_migration_dialog" = "لإنشاء مسار، فأنت تحتاج إلى تحديث كافة الخرائط ثم إعادة تخطيط المسار مرة أخرى.";
 
 "downloader_search_field_hint" = "اعثر على الخريطة";
-
-"migration_update_all_button" = "تحديث جميع الخرائط";
-
-"migration_delete_all_download_current_button" = "تنزيل الخريطة الحالية وحذف الخرائط القديمة";
 
 "migration_download_error_dialog" = "خطأ بالتنزيل";
 
@@ -1186,21 +764,9 @@
 
 "downloader_no_space_message" = "من فضلك، قم بإزالة البيانات غير الضرورية";
 
-"editor_general_auth_error_dialog" = "خطأ بتسجيل الدخول العام.";
-
 "editor_login_error_dialog" = "خطأ في تسجيل الدخول.";
 
-"editor_login_failed_dialog" = "فشل تسجيل الدخول";
-
-"editor_username_error_dialog" = "اسم المستخدم غير صحيح";
-
-"editor_place_edited_dialog" = "لقد قمت بتعديل هدف!";
-
-"editor_login_with_osm" = "تسجيل الدخول عبر OpenStreetMap";
-
 "editor_profile_changes" = "التغييرات التي تم التحقق منها";
-
-"editor_profile_unsent_changes" = "لم ترسل:";
 
 "editor_focus_map_on_location" = "اسحب الخريطة لتحدد الموقع الصحيح للهدف.";
 
@@ -1222,13 +788,9 @@
 
 "editor_report_problem_other_title" = "مشكلة مختلفة";
 
-"placepage_report_problem_button" = "الإبلاغ عن مشكلة";
-
 "placepage_add_business_button" = "إضافة مؤسسة";
 
 "whatsnew_editor_message_1" = "قم بإضافة أماكن جديدة للخريطة، وعدل أماكن حالية مباشرة من التطبيق.";
-
-"whatsnew_editor_message_2" = "*تستخدم Organic Maps البيانات الخاصة بخريطة OpenStreetMap.";
 
 "dialog_incorrect_feature_position" = "تغيير الموقع";
 
@@ -1236,16 +798,10 @@
 
 "login_to_make_edits_visible" = "قم بتسجيل الدخول حتى يتمكن باقي المستخدمين من رؤية التغييرات التي قمت بها.";
 
-"no_migration_during_navigation" = "التحديث ممنوع أثناء الملاحة.";
-
 /* Error dialog no space */
 "migration_no_space_message" = "للتنزيل، فأنت تحتاج إلى توفير مساحة أكبر. من فضلك، احذف البيانات غير الضرورية.";
 
 "editor_sharing_title" = "لقد قمت بتحديث خرائط تطبيق Organic Maps";
-
-"editor_comment_will_be_sent" = "سوف نرسل تعليقك إلى فريق رسم الخرائط.";
-
-"editor_unsupported_category_message" = "لقد قمت بإضافة مكان ينتمي لفئة غير متوفرة لدينا بعد. سوف تظهر على الخريطة لاحقا.";
 
 /* Downloaded 10 **of** 20 <- it is that "of" */
 "downloader_of" = "%1$d من%2$d";
@@ -1278,23 +834,9 @@
 
 "editor_operator" = "معامل";
 
-"editor_tag_description" = "أدخل الشركة أو المؤسسة أو الشخص المسؤول عن المنشآت.";
-
-"editor_no_local_edits_title" = "ليست لديك تعديلات محلية";
-
-"editor_no_local_edits_description" = "يوضح هذا عدد التغييرات المقترحة على الخريطة والتي يمكن الوصول إليها حاليًا فقط من على جهازك.";
-
-"editor_send_to_osm" = "إرسال الى OSM";
-
-"editor_remove" = "إزالة";
-
-"downloader_my_maps_title" = "خرائطي";
-
 "downloader_no_downloaded_maps_title" = "لم تقم بتنزيل أية خرائط";
 
 "downloader_no_downloaded_maps_message" = "قم بتنزيل خرائط للبحث عن مكان والتنقل بدون اتصال بالإنترنت.";
-
-"downloader_find_place_hint" = "البحث في المدينة أو البلد";
 
 /* Error title that appears after certain time without location. */
 "current_location_unknown_title" = "هل تريد متابعة اكتشاف موقعك الحالي؟";
@@ -1321,47 +863,13 @@
 /* iOS Dialog for the case when the location permission is not granted */
 "location_services_disabled_3" = "3. اختيار أثناء استخدام التطبيق";
 
-"placepage_parking_surface" = "سطح";
-
-"placepage_parking_multistorey" = "متعدد الطوابق";
-
-"placepage_parking_underground" = "تحت الارض";
-
-"placepage_parking_rooftop" = "سطح المبنى";
-
-"placepage_parking_sheds" = "حظائر";
-
-"placepage_parking_carports" = "مظلات سيارات";
-
-"placepage_parking_boxes" = "صناديق جراج";
-
-"placepage_parking_pay" = "دفع";
-
-"placepage_parking_free" = "مجانًا";
-
-"placepage_parking_interval" = "دفع عن فترة";
-
-"placepage_entrance_number" = "رقم";
-
-"placepage_entrance_type" = "المدخل";
-
-"placepage_flat" = "تطبيق";
-
-"placepage_open_24_7" = "24 / 7";
-
 "meter" = "م";
 
 "kilometer" = "كم";
 
-"kilometers_per_hour" = "كم/ساعة";
-
 "mile" = "ميل";
 
 "foot" = "قدم";
-
-"miles_per_hour" = "ميل/ساعة";
-
-"day" = "ي";
 
 "hour" = "س";
 
@@ -1381,10 +889,6 @@
 
 "placepage_bookmark_name_hint" = "اسم العلامة المرجعية";
 
-"placepage_personal_notes_hint" = "ملاحظات شخصية";
-
-"placepage_delete_bookmark_button" = "حذف العلامة المرجعية";
-
 "editor_edits_sent_message" = "لقد تم إرسال التغييرات التي اقترحتها";
 
 "editor_comment_hint" = "تعليق…";
@@ -1397,8 +901,6 @@
 
 "editor_remove_place_button" = "إزالة";
 
-"editor_status_sending" = "جارِ الإرسال…";
-
 "editor_place_doesnt_exist" = "المكان غير موجود";
 
 "text_more_button" = "…المزيد";
@@ -1410,11 +912,7 @@
 
 "error_enter_correct_email" = "أدخل بريدا إلكترونيا صالحا";
 
-"error_enter_correct" = "أدخل قيمة صالحة";
-
 "refresh" = "تحديث";
-
-"last_update" = "أخر تحديث: %s";
 
 "placepage_add_place_button" = "إضافة مكان ما للخريطة";
 
@@ -1426,24 +924,6 @@
 
 "editor_share_to_all_dialog_message_2" = "سنقوم بمراجعة هذه التغييرات. إذا كانت لدينا أي أسئلة فسوف نتصل بك عبر البريد الإلكتروني.";
 
-"navigation_overview_button" = "استعراض";
-
-"navigation_stop_button" = "توقف";
-
-/* Text on an empty bookmark page */
-"bookmarks_empty_title" = "حفظ الإشارات المرجعية";
-
-"bookmarks_empty_message_1" = "انقر على ★ لحفظ الأماكن المفضلة من أجل إمكانية الوصول السريع.";
-
-"bookmarks_empty_message_2" = "جلب العلامات المرجعية من البريد الإلكتروني والإنترنت.";
-
-"bookmarks_empty_message_3" = "غادر: %s";
-
-/* Name of the group for booked hotels */
-"bookmarks_group_name" = "فنادق تم حجزها";
-
-"place_page_button_read_descriprion" = "اقرأ";
-
 /* iOS dialog for the case when recent track recording is on and the app comes back from background */
 "recent_track_background_dialog_title" = "تريد تعطيل التسجيل الخاص بمسار سفرك الأخير؟";
 
@@ -1451,8 +931,6 @@
 
 /* For sharing via SMS and so on */
 "sharing_call_action_look" = "انظر";
-
-"continue_recent_track_background_button" = "استمرار";
 
 "recent_track_background_dialog_message" = "يستخدم Organic Maps موقعك الجغرافي في الخلفية لتسجيل مسار سفرك الأخير.";
 
@@ -1468,33 +946,13 @@
 /* About short text (below logo) */
 "about_description" = "Organic Maps هو تطبيق أساسي للسفر بدون اتصال بالإنترنت. يعتمد برنامج Organic Maps على بيانات OpenStreetMap ويتيح تحريرها.";
 
-/* Text in menu */
-"blog" = "المدونة";
-
 "general_settings" = "إعدادات عامة";
-
-"date" = "التاريخ %d";
-
-/* "Report a bug" -> "Generaal Feedback" -> "Something is not working" */
-"something_is_not_working" = "شيء ما لا يعمل";
 
 /* For the first routing */
 "accept" = "قبول";
 
-"accept_and_continue" = "Accept and continue";
-
 /* For the first routing */
 "decline" = "رفض";
-
-"install_app" = "تثبيت";
-
-"search_no_results_title" = "لم يتم العثور على نتائج";
-
-"search_no_results_message" = "جرب مصطلح بحث أكثر عمومية أو التصغير أو إعادة تعيين عامل التصفية.";
-
-"search_no_results_expand_area_button" = "تصغير";
-
-"search_no_results_reset_button" = "إعادة تعيين عامل التصفية";
 
 /* noun */
 "search_in_table" = "قائمة";
@@ -1517,8 +975,6 @@
 
 "traffic_update_maps_text" = "لعرض البيانات المرورية، يجب تحديث الخرائط.";
 
-"traffic_outdated" = "البيانات المرورية قديمة.";
-
 "big_font" = "زيادة حجم الخط على الخريطة";
 
 "traffic_update_app" = "الرجاء تحديث Organic Maps";
@@ -1529,17 +985,7 @@
 /* "traffic" as in "road congestion" */
 "traffic_data_unavailable" = "البيانات المرورية غير متاحة";
 
-/* "Translation is no needed, because it's a company name" */
-"uber" = "Uber";
-
-/* Simplified colour scheme for traffic information, fewer colours are used to display traffic jams on the map. The string should be kept as short as possible */
-"pref_traffic_simplified_colors_title" = "ألوان مرور مبسطة";
-
 "enable_logging" = "تمكين التسجيل";
-
-"offline_place_page_more_information" = "اتصل بالإنترنت للحصول على مزيد من التفاصيل حول المكان.";
-
-"failed_load_information" = "فشل تحميل المعلومات.";
 
 /* Settings: "Send general feedback" button */
 "feedback_general" = "تعقيب عام";
@@ -1556,8 +1002,6 @@
 
 "whatsnew_transliteration_title" = "كتابة بالحروف اللاتينية";
 
-"yandex_taxi_title" = "Yandex.Taxi";
-
 "learn_more" = "تعلم المزيد";
 
 "core_exit" = "خروج";
@@ -1568,75 +1012,19 @@
 
 "button_exit" = "خروج";
 
-"settings_device_memory" = "ذاكرة الجهاز";
-
-"settings_card_memory" = "بطاقة الذاكرة";
-
-"settings_storage_available" = "%s متوفر";
-
-"toast_location_permission_denied" = "تم رفض إذن الموقع للتطبيق";
-
-"button_use" = "استخدام";
-
 "planning_route_manage_route" = "إدارة المسار";
 
 "button_plan" = "خطة";
-
-"button_add" = "إضافة";
 
 "placepage_remove_stop" = "إزالة";
 
 "planning_route_remove_title" = "اسحب هنا للإزالة";
 
-"dialog_change_start_point_message" = "استبدال نقطة البدء إلى الموقع الحالي؟";
-
-"button_replace" = "استبدال";
-
 "placepage_add_stop" = "إضافة نقطة توقف";
-
-/* Only ru/en are needed */
-"subtitle_rent" = "Rent";
-
-/* Only ru/en are needed */
-"rub_month" = "RUB/month";
-
-/* Only ru/en are needed */
-"room" = "%s-room apt.";
-
-/* Only ru/en are needed */
-"real_estate" = "Real estate";
-
-"add_my_position" = "إضافة موضعي";
-
-"choose_start_point" = "اختيار نقطة البداية";
-
-"choose_destination" = "اختيار الوجهة";
 
 "preloader_viator_button" = "تعلم المزيد";
 
-"start_from_my_position" = "بدء من";
-
-"profile_authorization_title" = "تسجيل الدخول باستخدام";
-
-"profile_authorization_message" = "تسجيل الدخول بسهولة بدون اسم مستخدم وكلمة مرور في غضون بضع ثوان";
-
 "profile_authorization_error" = "عفوًا، كان هناك خطأ. حاول تسجيل الدخول مرة اخرى.";
-
-"service" = "الخدمة";
-
-"atmosphere" = "المناخ";
-
-"value_for_money" = "القيمة مقابل المال";
-
-"experience" = "التجربة";
-
-"assortment" = "التصنيف";
-
-"expertise" = "الخبرة";
-
-"equipment" = "المعدات";
-
-"quality" = "الجودة";
 
 "dialog_error_storage_title" = "مشكلة الوصول للتخزين";
 
@@ -1644,17 +1032,7 @@
 
 "setting_emulate_bad_storage" = "محاكاة التخزين السيء";
 
-"directions_finish" = "الوجهة";
-
-"directions_on_foot" = "سيرًا %s";
-
 "core_entrance" = "المدخل";
-
-"coffee" = "قهوة";
-
-"cleanliness" = "نظافة";
-
-"crowdedness" = "اكتظاظ";
 
 "error_enter_correct_name" = "الرجاء إدخال اسم صحيح";
 
@@ -1673,11 +1051,9 @@
 
 "downloader_percent" = "%s (%s من %s)";
 
-"downloader_process" = "جار تنزيل %s...";
+"downloader_process" = "جار تنزيل %s…";
 
-"downloader_applying" = "جار تطبيق %s...";
-
-"dialog_message_transit_not_found_connection" = "خطط المسار داخل شبكة عبور واحدة";
+"downloader_applying" = "جار تطبيق %s…";
 
 "bookmarks_error_message_share_general" = "تعذرت المشاركة بسبب خطأ في التطبيق";
 
@@ -1695,17 +1071,7 @@
 
 "bookmarks_error_message_list_name_already_taken" = "يرجى اختيار اسم آخر";
 
-"bookmarks_error_title_list_name_too_long" = "هذا الاسم طويل للغاية";
-
-"bookmarks_error_message_list_name_too_long" = "يرجى اختيار اسم آخر";
-
-"please_wait" = "أرجو الإنتظار...";
-
-"phone_number" = "رقم الهاتف";
-
-"notification_unsent_reviews_title" = "لديك عدة تعليقات غير مرغوب فيها";
-
-"notification_unsent_reviews_message" = "الرجاء تسجيل الدخول لمشاركة التعليقات مع المسافرين الآخرين";
+"please_wait" = "أرجو الإنتظار…";
 
 "profile" = "الملف الشخصي OpenStreetMap";
 
@@ -1719,49 +1085,13 @@
 
 "bookmarks_convert_error_message" = "لم يتم تحويل بعض الملفات.";
 
-"converting" = "تحويل...";
-
-"wn_reinvented_bookmarks_title" = "لقد قمنا بإعادة اختراع العناوين!";
-
-"wn_reinvented_bookmarks_message" = "يمكنك الاحتفاظ بنسخة احتياطية منها وإنشاء قوائم... إنه أمر مذهل...";
-
-"bookmarks_restore" = "استعادة الإشارات المرجعية";
-
-"bookmarks_restore_process" = "استعادة...";
-
 "bookmarks_restore_title" = "استعادة هذا الإصدار؟";
 
-"bookmarks_restore_message" = "ستستعيد إشاراتك المرجعية من %s (%s)";
-
-"bookmarks_restore_empty_title" = "ليس لديك نسخة احتياطية";
-
-"bookmarks_restore_empty_message" = "لم يعثر الخادم على نسخ احتياطية سابقة";
-
 "common_check_internet_connection_dialog_title" = "لا يوجد اتصال بالإنترنت";
-
-"error_server_title" = "خطأ في الخادم";
-
-"error_server_message" = "حدث خطأ على الخادم ، يرجى المحاولة مرة أخرى في وقت لاحق";
 
 "error_system_message" = "حدث خطأ غير معروف";
 
 "restore" = "استعادة";
-
-"bookmarks_page_downloaded" = "تم تحميل";
-
-"bookmarks_page_my" = "الخاص بي";
-
-"routes_and_bookmarks" = "الطرق والإشارات";
-
-"bookmarks_webview_success_toast" = "تم تحميل الإشارات بنجاح";
-
-"cached_bookmarks_placeholder_title" = "تحميل أماكن جديدة";
-
-"cached_bookmarks_placeholder_subtitle" = "اضغط على الزر لتحميل الآلاف من الأماكن المثيرة للاهتمام والطرق التي تم إنشاؤها من قبل لمستخدمين Organic Maps. سوف تحتاج إلى اتصال بالإنترنت.";
-
-"downloader_download_routers" = "تحميل الإشارات";
-
-"bookmarks_groups_cached" = "القوائم التي تم تنزيلها";
 
 "subtittle_opt_out" = "إعدادات التتبع";
 
@@ -1769,29 +1099,15 @@
 
 "crash_reports_description" = "قد نستخدم بياناتك لتحسين تجربة Organic Maps. سوف تكون التغييرات نافذة المفعول بعد إعادة تشغيل التطبيق.";
 
-"opt_out_help_ios_1" = "يمكن أن يوفر جهازك الجوّال إعداد \"\"تقييد الإعلان المخصص\"\" أو \"\"تعطيل الإعلان الذي يستهدف الاهتمامات\"\".";
-
-"opt_out_help_ios_2" = "نظام تشغيل آي 9 فما فوق";
-
-"opt_out_help_ios_3" = "انتقل إلى إعداداتك ← الخصوصية ← الإعلانات ← تمكين إعداد \"\"تحديد تتبع الإعلانات\"\"";
-
-"opt_out_help_android" = "قد يوفر جهازك الجوّال إعداد \"\"الحد من تتبع الإعلان\"\" أو \"\"إلغاء الاشتراك من الإعلانات التي تستهدف الاهتمامات\"\". \ n \ n للحصول على الإصدار 4.0 من نظام التشغيل Android و Google Play: \ n الإعدادات → Google ← الإعلانات ← إلغاء الاشتراك في تخصيص الإعلانات \ أو \ n الإعدادات → Google → Google Account → المعلومات الشخصية والخصوصية → إعدادات الإعلانات → تخصيص الإعلانات";
-
 "privacy_policy" = "سياسة الخصوصية";
 
 "terms_of_use" = "شروط الاستخدام";
-
-"backup_notification_failed" = "قد تم تعليق احتياطي المواقع المفضلة لديك. سجل الدخول لإعادة تشغيله.";
 
 "button_layer_traffic" = "حركة مرور";
 
 "button_layer_subway" = "مترو الانفاق";
 
 "layers_title" = "طبقات الخريطة";
-
-"layers_message" = "استخدم طبقات الخريطة لعرض حركة المرور ، وخريطة مترو الأنفاق ، وغيرها من المعلومات المفيدة";
-
-"button_layer_got_it" = "حصلت عليه";
 
 "subway_data_unavailable" = "خريطة مترو الانفاق غير متوفرة";
 
@@ -1803,39 +1119,13 @@
 
 "title_error_downloading_bookmarks" = "حدث خطأ";
 
-"subtitle_error_downloading_bookmarks" = "لم يتم تنزيل الإشارات";
-
-"error_already_downloaded" = "تم بالفعل تنزيل هذه القائمة";
-
 "popular_place" = "Popular";
-
-"download_routes" = "Download routes";
-
-"bookmarks_downloaded_title" = "Bookmarks have been downloaded successfully";
-
-"bookmarks_downloaded_subtitle" = "Press ‘View on map’ to explore new places from the list";
-
-"why_support" = "لماذا تدعم Organic Maps؟";
-
-"why_support_item1" = "We respect your privacy: there are zero trackers in the app, and we are open source";
-
-"why_support_item2" = "أنت تساعدنا على تحسين Organic Maps";
-
-"why_support_item3" = "يمكنك مساعدتنا في تحسين خرائط مفتوحة OpenStreetMap.org";
-
-"channels_map_update" = "تحديثات الخريطة";
-
-"server_unavailable_title" = "الخدمة غير متوفرة";
-
-"sharing_options" = "خيارات المشاركة";
 
 "export_file" = "ملف التصدير";
 
 "list_settings" = "قائمة الإعدادات";
 
 "delete_list" = "حذف القائمة";
-
-"hide_from_map" = "إخفاء من الخريطة";
 
 "public_access" = "إطلاع الجمهور";
 
@@ -1845,40 +1135,11 @@
 
 "bookmark_category_description_hint" = "اكتب وصفًا (نص أو html)";
 
-/* FIXME */
-"bookmarks_public_access" = "bookmarks_public_access";
-
-/* FIXME */
-"bookmarks_link_access" = "bookmarks_link_access";
-
-/* FIXME */
-"bookmarks_private_access" = "bookmarks_private_access";
-
 "not_shared" = "خاص";
-
-"direct_link_progress_text" = "جارٍ تحميل ملفك…";
-
-"direct_link_success" = "لقد تم إنشاء الرابط";
-
-"send_a_link_btn" = "ارسل لي رابط";
-
-"upload_error_toast" = "حدث خطأ أثناء تحميل ملفك";
 
 "tags_loading_error_subtitle" = "حدث خطأ أثناء تحميل العلامات ، يرجى المحاولة مرة أخرى";
 
-"unable_upload_errorr_title" = "فشل تحميل الملف";
-
-"unable_upload_error_subtitle_edited" = "تم تحرير هذا الملف عبر تطبيق الويب";
-
-"unable_upload_error_subtitle_broken" = "هذا الملف تالف ولا يمكن تحميله. يرجى تحميل ملف آخر.";
-
-"contact" = "الاتصال";
-
-"download_button" = "تحميل";
-
 "speedcams_alert_title" = "كاميرات السرعة";
-
-"speedcams_alert_subtitle" = "التحذير من حدود السرعة";
 
 "speedcam_option_auto" = "السيارات";
 
@@ -1886,18 +1147,10 @@
 
 "speedcam_option_never" = "مطلقا";
 
-"bookmark_description_title" = "وصف الإشارة المرجعية";
-
 "place_description_title" = "وصف المكان";
 
 /* this text will be shown in application notification preferences opposite checkbox which enable/disable downloader notifications. Devices on Android 8+ are affected. */
 "notification_channel_downloader" = "محمل الخريطة";
-
-"share_bookmarks_email_body_link" = "مرحبًا!\n\nللوصول إلى التطبيق: https://omaps.app/get?kmzهذا هو الرابط الذي يمكنك من خلاله تنزيل إشاراتك المرجعية: %s. افتح القائمة عبر Organic Maps واستمتع برحلتك!\n\n";
-
-"warning_speedcams_title" = "سوف يحذرك المستكشف من الكاميرات عندما تتجاوز الحد الأقصى للسرعة %d كم / س";
-
-"warning_speedcams_subtitle" = "يرجى مراعاة قواعد القيادة في البلد الذي تنوي السفر إليه.";
 
 "speedcams_notice_message" = "السيارات- تحذير على الرادارات إذا كان هناك خطر تجاوز الحد الأقصى للسرعة\nدائما - احذر دائما من كاميرات السرعة\nمطلقا - أبدا تحذير من كاميرات السرعة";
 
@@ -1913,23 +1166,7 @@
 
 "enable_logging_warning_message" = "يتحول الخيار إلى التسجيل لإغراض التشخيص. يمكن أن يكون مفيدًا لفريق الدعم الخاص بنا الذين يعملون على استكشاف أخطاء التطبيق وإصلاحها. قم بتفعيل هذا الخيار فقط في حالة طلب الدعم من Organic Maps.";
 
-"html_error_upload_message_try_again" = "يرجى التحقق من إعدادات الشبكة الخاصة بك و حاول مرة أخرى";
-
-"html_error_upload_title_try_again" = "لا يوجد اتصال بالانترنت";
-
-"notification_leave_review_v2_android_short_title" = "ضع تعليق وساعد المسافرين!";
-
-"megafon" = "Say goodbye to roaming!";
-
-"notifications_illegal_alert_disable_button" = "تعطيل الإشعارات";
-
 "access_rules_author_only" = "التحرير على الإنترنت";
-
-"privacy_settings_menu" = "إعدادات الخصوصية";
-
-"unable_upadate_error_title" = "فشل تحديث الملف";
-
-"unable_upadate_error_message" = "حدثت بعض الأخطاء أثناء التحديث يرجى التحقق من التغييرات و حاول مرة أخرى";
 
 "driving_options_title" = "خيارات قيادة";
 
@@ -1951,94 +1188,19 @@
 
 "change_driving_options_btn" = "تم تفعيل خيارات الطريق";
 
-"toll_road" = "نقطة تحصيل رسوم";
-
-"unpaved_road" = "طريق غير ممهدة";
-
-"ferry_crossing" = "تقاطع عبارة";
-
-"operated_by" = "تدرا بواسطة \"%s\"";
-
 "avoid_toll_roads_placepage" = "تجنب نقاط تحصيل الرسوم";
 
 "avoid_unpaved_roads_placepage" = "تجنب الطرق الغير ممهدة";
 
 "avoid_ferry_crossing_placepage" = "تجنب تقاطع العبارات";
 
-"type.cuisine.uzbek" = "مطعم أوزبكي";
-
-"trip_start" = "هيا بنا";
-
-"pick_destination" = "جهة الوصول";
-
-"follow_my_position" = "العودة إلى الوسط";
-
-"search_results" = "نتائج البحث";
-
-"then_turn" = "ثم";
-
-"redirect_route_alert" = "هل تريد إعادة تحديد الطريق?";
-
-"redirect_route_yes" = "نعم";
-
-"redirect_route_no" = "لا";
-
-"trip_finished" = "لقد وصلت!";
-
-"keyboard_availability_alert" = "لوحة الكتابة غير متاحة أثناء القيادة";
-
-"dialog_routing_change_start_carplay" = "لا يمكن تحديد طريق من موقعك الحالي";
-
-"dialog_routing_change_end_carplay" = "لا يمكن تحديد طريق لجهة الوصول. يرجي اختيار مكان آخر";
-
-"dialog_routing_check_gps_carplay" = "لا وجد إشارة GPS. يرجى التحرك لمكان مفتوح";
-
-"dialog_routing_unable_locate_route_carplay" = "لا يمكن تحديد طريق. يرجى تحديد أماكن أخرى على الطريق";
-
-"dialog_routing_download_files_carplay" = "كي تُنشئ مساراً، يجب أن تحمل الخرائط المفقودة على جهازك";
-
-"dialog_routing_system_error_carplay" = "حدث خطأ. يرجى إعادة تشغيل التطبيق";
-
-"dialog_routing_rebuild_from_current_location_carplay" = "سيتم اعادة تحديد الطريق من موقعك الحالي";
-
-"dialog_routing_rebuild_for_vehicle_carplay" = "سيتم تعديل الطريق لتكون خاصة بالسيارة";
-
 "ok" = "موافق";
-
-"avoid_unpaved_carplay_1" = "غير ترابي";
-
-"avoid_unpaved_carplay_2" = "تجنب غير الممهد";
-
-"avoid_ferry_carplay_1" = "بدون عبََارة";
-
-"avoid_ferry_carplay_2" = "تجنب العبََارة";
-
-"avoid_tolls_carplay_1" = "بدون رسوم";
-
-"avoid_tolls_carplay_2" = "تجنب الرسوم";
-
-"speedcams_alert_title_carplay_1" = "كاميرا سريعة";
-
-"speedcams_alert_title_carplay_2" = "تحذير سريع";
-
-"download_map_carplay" = "يُرجى تحميل الخرائط في تطبيق Organic Maps على جهازك";
-
-"carplay_roundabout_exit" = "المخرج رقم %s";
 
 /* max. 10 symbols, both iOS and Android */
 "sort" = "تريتب…";
 
 /* Android, title, max 20-22 symbols */
 "sort_bookmarks" = "رتب العلامات المرجعية";
-
-/* iOS */
-"sort_default" = "رتب افتراضي";
-
-"sort_type" = "رتب حسب النوع";
-
-"sort_distance" = "رتب حسب المسافة";
-
-"sort_date" = "رتب حسب التاريخ";
 
 /* Android */
 "by_default" = "افتراضي";
@@ -2052,63 +1214,7 @@
 /* Android */
 "by_date" = "حسب التاريخ";
 
-"week_ago_sorttype" = "منذ أسبوع";
-
-"month_ago_sorttype" = "منذ شهر";
-
-"moremonth_ago_sorttype" = "منذ أكثر من شهر";
-
-"moreyear_ago_sorttype" = "منذ أكثر من سنة";
-
-"near_me_sorttype" = "قريب مني";
-
-"others_sorttype" = "أخرى";
-
-"food_places" = "طعام";
-
-"tourist_places" = "مشاهد";
-
-"museums" = "متاحف";
-
-"parks" = "حدائق";
-
-"swim_places" = "سباحة";
-
-"mountains" = "جبال";
-
-"animals" = "حيوانات";
-
-"hotels" = "فنادق";
-
-"buildings" = "بنايات";
-
-"money" = "نقود";
-
-"shops" = "متاجر";
-
-"parkings" = "مواقف سيارات";
-
-"fuel_places" = "محطات وقود";
-
-"water" = "ماء";
-
-"medicine" = "دواء";
-
 "search_in_the_list" = "بحث في القائمة";
-
-"view_on_map_bookmarks" = "على الخريطة";
-
-"more_bookmarks" = "المزيد…";
-
-"no_items_found" = "لم يتم العثور على عناصر";
-
-/* Android, max 18 symbols */
-"bookmarks_edit_list" = "تحرير القائمة";
-
-/* Android, max 18 symbols */
-"bookmarks_delete_list" = "حذف القائمة";
-
-"religious_places" = "أماكن دينية";
 
 "select_list" = "اختر القائمة";
 
@@ -2118,26 +1224,13 @@
 
 "dialog_pedestrian_route_is_long_message" = "يرجى اختيار نقطة بداية أو نهاية أقرب لمحطة المترو";
 
-/* Failed planning SUBWAY route message in navigation view */
-"routing_planning_error_subway_special" = "فشل تخطيط طريق لمترو الانفاق";
-
 "button_layer_isolines" = "تضاريس";
-
-"tips_map_layers_title_countour" = "الجديد في Organic Maps: طبقة طبوغرافية بدون انترنت!";
-
-"tips_map_layers_message_countour" = "خطط و استمتع برحلاتك في الطبيعة و أنت متأكد من أنك تعرف كل شيء عن المنطقة";
 
 "isolines_activation_error_dialog" = "لتفعيل الطبقة الطبوغرافية واستخدامها ، يرجى تحديث أوتنزيل خريطة المنطقة";
 
 "isolines_location_error_dialog" = "الطبقة الطبوغرافية ليست متاحة بعد في هذه المنطقة";
 
 "elevation_profile_diff_level" = "مستوى الصعوبة";
-
-"elevation_profile_diff_level_easy" = "سهل";
-
-"elevation_profile_diff_level_moderate" = "معتدل";
-
-"elevation_profile_diff_level_hard" = "صعب";
 
 "elevation_profile_ascent" = "تصاعدي";
 
@@ -2147,25 +1240,13 @@
 
 "elevation_profile_maxaltitude" = "الحد الأقصى للارتفاع";
 
-"elevation_profile_m" = "م";
-
 "elevation_profile_difficulty" = "درجة الصعوبة";
 
 "elevation_profile_distance" = "المسافة:";
 
-"elevation_profile_km" = "كم";
-
 "elevation_profile_time" = "مدة:";
 
-"elevation_profile_hours" = "ساعة";
-
-"elevation_profile_minutes" = "دقيقة";
-
 "isolines_toast_zooms_1_10" = "قرب لتكتشف خطوط الكنتور";
-
-"downloader_updating_ios" = "جار التحديث";
-
-"downloader_loading_ios" = "جار التحميل";
 
 "key_information_title" = "معلومات رئيسية";
 

--- a/iphone/Maps/LocalizedStrings/ar.lproj/Localizable.stringsdict
+++ b/iphone/Maps/LocalizedStrings/ar.lproj/Localizable.stringsdict
@@ -9,21 +9,6 @@
 
 <!-- ********** Strings for downloading map from search **********/ -->
 
-  <key>bookmarks_places</key>
-  <dict>
-    <key>NSStringLocalizedFormatKey</key>
-    <string>%#@value@</string>
-    <key>value</key>
-    <dict>
-      <key>NSStringFormatSpecTypeKey</key>
-      <string>NSStringPluralRuleType</string>
-      <key>NSStringFormatValueTypeKey</key>
-      <string>d</string>
-      <key>other</key>
-      <string>%d من الإشارات المرجعية</string>
-    </dict>
-  </dict>
-
   <key>bookmarks_detect_message</key>
   <dict>
     <key>NSStringLocalizedFormatKey</key>
@@ -36,21 +21,6 @@
       <string>d</string>
       <key>other</key>
       <string>تم العثور على %d ملفات. سوف تراهم بعد التحويل.</string>
-    </dict>
-  </dict>
-
-  <key>bookmarks_objects</key>
-  <dict>
-    <key>NSStringLocalizedFormatKey</key>
-    <string>%#@value@</string>
-    <key>value</key>
-    <dict>
-      <key>NSStringFormatSpecTypeKey</key>
-      <string>NSStringPluralRuleType</string>
-      <key>NSStringFormatValueTypeKey</key>
-      <string>d</string>
-      <key>other</key>
-      <string>%s العنصر</string>
     </dict>
   </dict>
 

--- a/iphone/Maps/LocalizedStrings/cs.lproj/Localizable.strings
+++ b/iphone/Maps/LocalizedStrings/cs.lproj/Localizable.strings
@@ -18,9 +18,6 @@
 /* Button which deletes downloaded country */
 "delete" = "Smazat";
 
-/* Button "do not interrupt download" if user touched actively downloading country */
-"do_nothing" = "Pokračovat";
-
 "download_maps" = "Stáhnout mapy";
 
 /* Settings/Downloader - info for country when download fails */
@@ -28,9 +25,6 @@
 
 /* Settings/Downloader - info for country which started downloading */
 "downloading" = "Stahování…";
-
-/* Settings/Downloader - size string, only strings different from English should be translated */
-"kb" = "kB";
 
 /* Choose measurement on first launch alert - choose metric system button */
 "kilometres" = "Kilometry";
@@ -55,17 +49,11 @@
 /* Update maps later/Buy pro version later button text */
 "later" = "Později";
 
-/* Don't show some dialog any more */
-"never" = "Nikdy";
-
 /* View and button titles for accessibility */
 "search" = "Hledat";
 
 /* Search box placeholder text */
 "search_map" = "Prohledat mapu";
-
-/* Settings/Downloader - info for not downloaded country */
-"touch_to_download" = "Klepněte pro stažení";
 
 /* Settings/Downloader - 3G download warning dialog confirm button */
 "use_cellular_data" = "Ano";
@@ -73,20 +61,11 @@
 /* Location services are disabled by user alert - message */
 "location_is_disabled_long_text" = "Aktuálně máte všechny možnosti pro určování polohy vypnuté. Prosím, povolte je v Nastavení.";
 
-/* Location Services are not available on the device alert - message */
-"device_doesnot_support_location_services" = "Vaše zařízení nepodporuje služby pro určování polohy";
-
 /* View and button titles for accessibility */
 "zoom_to_country" = "Ukázat na mapě";
 
-/* Button text for the button at the center of the screen when the country is not downloaded */
-"country_status_download" = "Stáhnout mapu\n(^ ^)";
-
 /* Button text for the button at the center of the screen when the country is not downloaded and the size should not be shown */
 "country_status_download_without_size" = "Stáhnout mapu";
-
-/* Button text for the button at the center of the screen when the country is not downloaded */
-"country_status_download_without_routing" = "Stáhnout mapy\nbez tras (^ ^)";
 
 /* Message to display at the center of the screen when the country download has failed */
 "country_status_download_failed" = "Stahování selhalo";
@@ -96,19 +75,13 @@
 
 "about_menu_title" = "O aplikaci Organic Maps";
 
-"downloaded_touch_to_delete" = "Staženo (%@), klepněte pro smazání";
-
 "connection_settings" = "Nastavení připojení";
-
-"download_mb_or_kb" = "Stáhnout %@";
 
 "close" = "Zavřít";
 
 "unsupported_phone" = "Je vyžadována hardwarová akcelerace OpenGL. Bohužel, vaše zařízení není podporováno.";
 
 "download" = "Stáhnout";
-
-"external_storage_is_not_available" = "SD karta/USB uložiště s uloženými mapami není k dispozici";
 
 "disconnect_usb_cable" = "Prosím, odpojte USB kabel nebo vložte paměťovou kartu pro použití s Organic Maps";
 
@@ -117,8 +90,6 @@
 "not_enough_memory" = "Nedostatek paměti ke spuštění aplikace";
 
 "download_resources" = "Ještě než začnete, bude třeba stáhnout obecnou mapu světa.\nZabere to %@.";
-
-"getting_position" = "Získávání aktuální polohy";
 
 "download_resources_continue" = "Přejít na mapu";
 
@@ -140,23 +111,14 @@
 /* Add New Bookmark Set dialog title */
 "add_new_set" = "Přidat novou skupinu záložek";
 
-/* Place Page - Add To Bookmarks button */
-"add_to_bookmarks" = "Přidat k záložkám";
-
 /* Bookmark Color dialog title */
 "bookmark_color" = "Barva záložky";
 
 /* Add Bookmark Set dialog - hint when set name is empty */
 "bookmark_set_name" = "Název záložky";
 
-/* Bookmark Sets dialog title */
-"bookmark_sets" = "Skupiny záložek";
-
 /* Bookmarks - dialog title */
 "bookmarks" = "Záložky";
-
-/* Add bookmark dialog - bookmark color */
-"color" = "Barva";
 
 /* Default bookmarks set name */
 "core_my_places" = "Moje místa";
@@ -167,14 +129,8 @@
 /* Editor title above street and house number */
 "address" = "Adresa";
 
-/* Place Page - Remove Pin button */
-"remove_pin" = "Odstranit špendlík";
-
 /* Add bookmark dialog - bookmark set, Bookmarks dialog - Bookmark set cell */
 "set" = "Skupina";
-
-/* Text hint in Bookmarks dialog when no any bookmarks are added */
-"bookmarks_usage_hint" = "Zatím nemáte žádné záložky.\nZáložku můžete přidat přidržením libovolného místa na mapě.\nV Organic Maps také umí importovat záložky z jiných zdrojů. Soubor ve formátu KML/KMZ s uloženými záložkami otevřete např. z emailu, Dropboxu nebo webového odkazu v Organic Maps.";
 
 /* Settings button in system menu */
 "settings" = "Nastavení";
@@ -191,26 +147,11 @@
 /* Ask to wait user several minutes (some long process in modal dialog). */
 "wait_several_minutes" = "Tato akce může trvat několik minut.\nProsím čekejte…";
 
-/* Show bookmarks from this category on a map or not */
-"visible" = "Viditelné";
-
-/* Toast which is displayed when GPS has been deactivated */
-"gps_is_disabled_long_text" = "Navigace GPS deaktivována. Prosím, povolte ji v Nastavení.";
-
 /* Measurement units title in settings activity */
 "measurement_units" = "Měřicí jednotky";
 
 /* Detailed description of Measurement Units settings button */
 "measurement_units_summary" = "Vyberte si míle nebo kilometry";
-
-/* Do search in all sources */
-"search_mode_all" = "Všude";
-
-/* Do search near my position only */
-"search_mode_nearme" = "V mé blízkosti";
-
-/* Do search in current viewport only */
-"search_mode_viewport" = "Na obrazovce";
 
 /* Search category for cafes, bars, restaurants */
 "eat" = "Kde se najíst";
@@ -266,14 +207,8 @@
 /* Search category */
 "police" = "Policie";
 
-/* String in search result list, when nothing found */
-"no_search_results_found" = "Žádné výsledky";
-
 /* Notes field in Bookmarks view */
 "description" = "Poznámky";
-
-/* Button text */
-"share_by_email" = "Sdílet emailem";
 
 /* Email Subject when sharing bookmarks category */
 "share_bookmarks_email_subject" = "Sdílené záložky Organic Maps";
@@ -295,26 +230,11 @@
 /* Warning message when doing search around current position */
 "unknown_current_position" = "Vaše poloha zatím nebyla určena";
 
-/* Warning message when location country isn't downloaded during search (see also download_location_map_proposal). */
-"download_location_country" = "Stahování země vaší aktuální polohy (%@)";
-
-/* Warning message when viewport country isn't downloaded during search */
-"download_viewport_country_to_search" = "Stahování země, v níž hledáte (%@)";
-
 /* Alert message that we can't run Map Storage settings due to some reasons. */
 "cant_change_this_setting" = "Omlouváme se, nastavení uložení map je dočasně nedostupné.";
 
 /* Alert message that downloading is in progress. */
 "downloading_is_active" = "Právě probíhá stahování země.";
-
-/* Message that will be shown in alert view, when we ask user to leave review on App Store */
-"appStore_message" = "Doufáme, že se vám používání Organic Maps líbí! Je-li tomu tak, ohodnoťte, prosím, naši aplikaci nebo na ni napište recenzi v obchodu s aplikacemi. Nezabere to ani minutu, ale opravdu nám tím pomůžete. Děkujeme za vaši podporu!";
-
-/* No, thanks */
-"no_thanks" = "Ne, díky";
-
-/* Share one specific bookmark using SMS, %1$@ contains om:// and %2$@ https://omaps.app link. @NOTE non-ascii symbols in the link will result in max 70 characters SMS instead of 140. */
-"bookmark_share_sms" = "Koukni na mou značku na mapě. Otevři odkaz: %1$@ nebo %2$@";
 
 /* Share my position using SMS, %1$@ contains om:// and %2$@ https://omaps.app link WITHOUT NAME. @NOTE non-ascii symbols in the link will result in max 70 characters SMS instead of 140. */
 "my_position_share_sms" = "Koukni kde jsem. Otevři odkaz: %1$@ nebo %2$@";
@@ -328,23 +248,11 @@
 /* Share my position using EMail, %1$@ is om:// and %2$@ is https://omaps.app link WITHOUT NAME */
 "my_position_share_email" = "Ahoj,\n\nPrávě jsem tady: %1$@. Klepni na jeden z těchto odkazů %2$@, %3$@ a uvidíš toto místo na mapě.\n\nDíky.";
 
-/* Android share by Message/SMS button text (including SMS) */
-"share_by_message" = "Sdílet pomocí zprávy";
-
 /* Share button text which opens menu with more buttons, like Message, EMail, Facebook etc. */
 "share" = "Sdílet";
 
-/* iOS share by Message button text (including SMS) */
-"message" = "Zpráva";
-
 /* Share by email button text, also used in editor. */
 "email" = "Email";
-
-/* Copy Link */
-"copy_link" = "Zkopírovat odkaz";
-
-/* Text for the button that returns to caller application */
-"more_info" = "Zobrazit další informace";
 
 /* Text for message when used successfully copied something */
 "copied_to_clipboard" = "Zkopírováno do schránky: %1$@";
@@ -354,15 +262,6 @@
 
 /* Used for bookmark editing */
 "done" = "Hotovo";
-
-/* Summary for preferences in MWM */
-"yopme_pref_summary" = "Zvolit nastavení zadní obrazovky";
-
-/* Title for yopme preferences in MWM */
-"yopme_pref_title" = "Nastavení zadní obrazovky";
-
-/* Hint for upper-right icon p2b */
-"show_on_backscreen" = "Zobrazit na zadní obrazovce";
 
 /* Prints version number in About dialog */
 "version" = "Verze: %@";
@@ -381,19 +280,11 @@
 
 "share_my_location" = "Sdílet mé umístění";
 
-"menu_search" = "Vyhledávání";
-
 /* Settings general group in settings screen */
 "prefs_group_general" = "General settings";
 
 /* Settings information group in settings screen */
 "prefs_group_information" = "Information";
-
-/* Settings screen: "Map" category title */
-"prefs_group_map" = "Mapa";
-
-/* Settings screen: "Miscellaneous" category title */
-"prefs_group_misc" = "Jiné";
 
 "prefs_group_route" = "Navigace";
 
@@ -419,9 +310,6 @@
 /* Settings «Map» category: «3D buildings» title */
 "pref_map_3d_buildings_title" = "3D budovy";
 
-/* Settings «Map» category: «3D buildings» summary */
-"pref_map_3d_buildings_subtitle" = "Ovlivňuje výdrž baterie";
-
 /* Settings «Route» category: «Tts enabled» title */
 "pref_tts_enable_title" = "Hlasové instrukce";
 
@@ -433,8 +321,6 @@
 
 /* Title for "Other" section in TTS settings. */
 "pref_tts_other_section_title" = "Ostatní";
-
-"pref_tts_how_to_set_up_voice" = "Jak nastavit hlas";
 
 /* Settings «Map» category: «Record track» title */
 "pref_track_record_title" = "Historie polohy";
@@ -455,56 +341,7 @@
 
 "recent_track_help_text" = "To vám umožňuje zaznamenávat ujetou cestu po určitou dobu a vidět ji na mapě. Poznámka: aktivace této funkce způsobuje zvýšenou spotřebu baterie. Trať bude automaticky odebrána z mapy poté, co vyprší časový interval.";
 
-"pref_track_ios_caption" = "Nedávná trasa zobrazuje cestu, po které jste cestovali.";
-
-"pref_track_ios_subcaption" = "Vyberte prosím časový rozsah uložené trasy.";
-
-"placepage_distance" = "Vzdálenost";
-
-"placepage_coordinates" = "Souřadnice";
-
-"placepage_unsorted" = "Nezařazené";
-
 "search_show_on_map" = "Zobrazit na mapě";
-
-/* Used to warn user when fixing KitKat issue */
-"bookmark_move_fail" = "Potřebujeme přesunout tvé záložky do vnitřní paměti zařízení, ale není pro ně volné místo. Prosím, uvolněte paměť, jinak nebudou záložky dostupné.";
-
-/* Used in More Apps menu */
-"free" = "Zdarma";
-
-/* Used in More Apps menu */
-"buy" = "Koupit";
-
-/* 1st search button-like result */
-"search_on_map" = "Hledat na mapě";
-
-/* toast with an error */
-"no_route_found" = "Nebyla nalezena žádná trasa";
-
-/* route title */
-"route" = "Trasa";
-
-/* category title */
-"routes" = "Trasy";
-
-/* text of notification */
-"download_map_notification" = "Stáhněte si mapu místa, kde právě jste";
-
-/* text of notification */
-"pro_version_is_free_today" = "Plná verze Organic Maps je dnes zdarma! Stáhněte si ji nyní a dejte vědět přátelům.";
-
-/* Dialog for transferring maps from lite to pro. */
-"move_lite_maps_to_pro" = "Právě přenášíme vaše stažené mapy z Organic Maps Lite do Organic Maps. Může to několik minut trvat.";
-
-/* Message to display when maps moved. */
-"move_lite_maps_to_pro_ok" = "Vaše stažené mapy byly úspěšně přeneseny do Organic Maps.";
-
-/* Message to display when maps move failed. */
-"move_lite_maps_to_pro_failed" = "Vaše mapy se nepodařilo přenést. Prosím, odstraňte Organic Maps Lite a stáhněte si mapy znovu.";
-
-/* Text in menu */
-"settings_and_more" = "Nastavení a další";
 
 /* Text in menu */
 "website" = "Webové stránky";
@@ -527,14 +364,8 @@
 /* Text in menu */
 "openstreetmap" = "OpenStreetMap";
 
-/* Text in menu */
-"contact_us" = "Kontaktovat nás";
-
 /* Settings: Send feedback button and dialog title */
 "feedback" = "Zpětná vazba";
-
-/* Text in menu */
-"subscribe_to_news" = "Přihlásit se k newsletteru";
 
 /* Text in menu */
 "rate_the_app" = "Ohodnotit aplikaci";
@@ -548,15 +379,6 @@
 /* Text in menu */
 "report_a_bug" = "Nahlásit chybu";
 
-/* Email subject */
-"subscribe_me_subject" = "Přihlaste mě, prosím, k odběru zpravodaje Organic Maps";
-
-/* Email body */
-"subscribe_me_body" = "Chci se vždy jako první dozvídat o nejnovějších zprávách, aktualizacích a akčních nabídkách. Své přihlášení k odběru mohu kdykoli zrušit.";
-
-/* About text */
-"about_text" = "Organic Maps nabízí nejrychlejší offline mapy všech měst a zemí po celém světě. Cestujte s naprostou důvěrou: kdekoliv jste, Organic Maps vám pomůže se najít na mapě, vyhledat nejbližší restauraci, hotel, banku, benzínovou pumpu atd. Nevyžaduje připojení k Internetu.\n\nNeustále pracujeme na nových funkcích a rádi bychom slyšeli také váš názor, jak můžeme Organic Maps vylepšit. Pokud máte s touto aplikací jakékoliv problémy, pak nás neváhejte kontaktovat na support@organicmaps.app. Odpovídáme na každý požadavek!\n\nLíbí se vám Organic Maps a chcete nás podpořit? Existuje několik snadných způsobů zcela zdarma:\n\n• napište recenzi ve svém obchodu s aplikacemi\n• označte naši facebookovou stránku http://www.facebook.com/OrganicMaps pomocí To se mi líbí\n• nebo jen řekněte o Organic Maps své mámě, kamarádům a kolegům :)\n\nDěkujeme, že jste s námi. Velmi si ceníme vaší podpory!\n\nP.S. Mapové podklady získáváme z OpenStreetMap, což je mapový projekt podobný Wikipedii, který umožňuje uživatelům vytvářet a upravovat mapy. Pokud zjistíte, že na mapě něco chybí nebo je špatně, pak můžete mapy opravit přímo na https://www.openstreetmap.org, a vaše změny se objeví v příští verzi Organic Maps. Díky!";
-
 /* Alert text */
 "email_error_body" = "Emailový klient nebyl ještě nakonfigurován. Nastavte ho, prosím, nebo použijte jiný způsob k našemu kontaktování na %@";
 
@@ -569,12 +391,6 @@
 /* Search category */
 "wifi" = "WiFi";
 
-/* Update map suggestion */
-"routing_map_outdated" = "Pro funkci vytváření tras je nutné aktualizovat mapu.";
-
-/* Update maps suggestion */
-"routing_update_maps" = "Nová verze Organic Maps umožňuje vytvářet trasy z vaší aktuální polohy do cílového bodu. Chcete-li tuto funkci používat, aktualizujte mapy.";
-
 /* Update all button text */
 "downloader_update_all_button" = "Aktualizovat vše";
 
@@ -583,9 +399,6 @@
 
 /* Downloaded maps category */
 "downloader_downloaded_subtitle" = "Staženo";
-
-/* Downloaded maps category */
-"downloader_available_maps" = "Dostupné";
 
 /* Country queued for download */
 "downloader_queued" = "Ve frontě";
@@ -598,17 +411,6 @@
 
 "downloader_downloading" = "Probíhá stahování:";
 
-"downloader_search_results" = "Nalezeno";
-
-/* Disclaimer message */
-"routing_disclaimer" = "Při vytváření tras v aplikaci Organic Maps mějte, prosím, na paměti následující:\n\n • Navrhované trasy lze brát jen jako doporučení.\n • Pravidla silničního provozu, aktuální podmínky na silnici a dopravní značení mají přednost před údaji z navigace.\n • Mapa může být nepřesná nebo zastaralá a navržené cesty nemusí být ideální.\n\nCestujte bezpečně a ohleduplně. Šťastnou cestu!";
-
-/* Outdated maps category */
-"downloader_outdated_maps" = "Zastaralé";
-
-/* Up to date maps category */
-"downloader_uptodate_maps" = "Aktuální";
-
 /* Status of outdated country in the list */
 "downloader_status_outdated" = "Aktualizace";
 
@@ -618,49 +420,14 @@
 /* Displayed in a dialog that appears when a user tries to delete a map while the app is in the follow route mode */
 "downloader_delete_map_while_routing_dialog" = "Chcete-li odstranit mapu, pak prosím zastavte navigaci.";
 
-/* Show when user try build route, but we don't know where he */
-"routing_failed_unknown_my_position" = "Aktuální poloha nebyla zatím zjištěna. Chcete-li naplánovat trasu, zadejte prosím umístění.";
-
-/* Show if use has not routing file, or InconsistentMWMandRoute */
-"routing_failed_has_no_routing_file" = "K vytvoření trasy jsou zapotřebí další data. Chcete je stáhnout nyní?";
-
-/* StartPointNotFound */
-"routing_failed_start_point_not_found" = "Trasu nelze vypočítat. Poblíž výchozího bodu nejsou žádné cesty.";
-
-/* EndPointNotFound */
-"routing_failed_dst_point_not_found" = "Trasu nelze vypočítat. Poblíž cílového bodu nejsou žádné cesty.";
-
 /* PointsInDifferentMWM */
 "routing_failed_cross_mwm_building" = "Lze vytvářet jen takové trasy, které se nachází na území jediné mapy.";
-
-/* RouteNotFound */
-"routing_failed_route_not_found" = "Mezi zvoleným počátkem a cílem nebyla nalezena žádná trasa. Vyberte jiný počáteční nebo koncový bod.";
-
-/* InternalError */
-"routing_failed_internal_error" = "Došlo k vnitřní chybě. Zkuste, prosím, mapu smazat a znovu stáhnout. Jestliže problém přetrvává, kontaktujte nás na support@organicmaps.app.";
-
-/* Context menu item for downloader. */
-"downloader_download_map_and_routing" = "Stáhnout mapu + trasy";
-
-/* Context menu item for downloader. */
-"downloader_download_routing" = "Stáhnout trasy";
-
-/* Context menu item for downloader. */
-"downloader_delete_routing" = "Smazat trasy";
 
 /* Context menu item for downloader. */
 "downloader_download_map" = "Stáhnout mapu";
 
-"downloader_download_map_no_routing" = "Stáhnout mapy bez tras";
-
-/* Button for routing. */
-"routing_go" = "Jet!";
-
 /* Item status in downloader. */
 "downloader_retry" = "Opakovat";
-
-/* Item in context menu. */
-"downloader_map_and_routing" = "Mapa + trasy";
 
 /* Item in context menu. */
 "downloader_delete_map" = "Smazat mapu";
@@ -668,29 +435,11 @@
 /* Item in context menu. */
 "downloader_update_map" = "Aktualizovat mapu";
 
-/* Item in context menu. */
-"downloader_update_map_and_routing" = "Aktualizovat mapu + trasy";
-
-/* Item in context menu. */
-"downloader_map_only" = "Pouze mapa";
-
-/* Toolbar title */
-"toolbar_application_menu" = "Nabídka aplikace";
-
 /* Preference text */
 "pref_use_google_play" = "Používat Služby Google Play pro získání aktuální polohy";
 
 /* Text for rating dialog */
 "rating_just_rated" = "Právě jsem ohodnotil(a) vaši aplikaci";
-
-/* Text for rating dialog */
-"rating_user_since" = "Uživatelem Organic Maps jsem od roku %@";
-
-/* Text for rating dialog */
-"rating_do_like_maps" = "Líbí se vám aplikace Organic Maps?";
-
-/* Text for rating dialog */
-"rating_tap_star" = "Klepnutím na hvězdičku naši aplikaci ohodnotíte.";
 
 /* Text for rating dialog */
 "rating_thanks" = "Děkujeme vám!";
@@ -701,23 +450,8 @@
 /* Text for rating dialog */
 "rating_send_feedback" = "Odeslat názor";
 
-/* Text for g+ dialog */
-"rating_google_plus" = "Klikněte na g+ a povězte o aplikaci svým přátelům.";
-
 /* Text for routing error dialog */
 "routing_download_maps_along" = "Stahovat mapy podél cesty";
-
-/* Text for routing error dialog */
-"routing_download_map" = "Získejte mapu";
-
-/* Text for routing error dialog */
-"routing_download_map_and_routing" = "Stáhněte si aktualizovanou mapu a data tras, ať můžete využít všechny funkce Organic Maps.";
-
-/* Text for routing error dialog */
-"routing_get_routing_data" = "Získejte data tras";
-
-/* Text for routing error dialog */
-"routing_get_additional_data" = "Další data potřebná k plánování tras z vašeho umístění.";
 
 /* Text for routing error dialog */
 "routing_requires_all_map" = "Naplánování trasy vyžaduje stažení a aktualizaci všech map z vašeho umístění do cílového umístění.";
@@ -725,50 +459,15 @@
 /* Text for routing error dialog */
 "routing_not_enough_space" = "Nedostatek místa";
 
-/* Text for routing error dialog */
-"routing_download_more_than_avail" = "Je třeba stáhnout %@ MB, ale dostupných je pouze %@ MB.";
-
-/* Text for routing error dialog */
-"routing_download_roaming" = "Chystáte se stáhnout %@ MB pomocí mobilních dat (v roamingu). To může mít za následek další poplatky v závislosti na vašem mobilním datovém tarifu.";
-
 /* bookmark button text */
 "bookmark" = "uložit";
-
-/* map is not downloaded */
-"not_found_map" = "Mapa vaší polohy není stažena";
 
 /* location service disabled */
 "enable_location_services" = "Prosím, povolte Služby určování polohy";
 
-/* download map */
-"download_map" = "Stáhněte si mapu své polohy";
-
-/* download map on iPhone */
-"download_map_iphone" = "Stáhněte si do svého iPhonu mapu své současné polohy";
-
-/* clear pin */
-"nearby" = "V okolí";
-
-/* clear pin */
-"clear_pin" = "Odebrat špendlík";
-
-/* location is undefined */
-"undefined_location" = "Aktuální poloha zatím nebyla zjištěna.";
-
-/* download country of your location */
-"download_country" = "Stahování země vyší aktuální polohy";
-
-/* download failed */
-"download_failed" = "Stahování selhalo";
-
-/* get the map */
-"get_the_map" = "Získejte mapu";
-
 "save" = "Uložit";
 
 "edit_description_hint" = "Popis (HTML nebo text)";
-
-"new_group" = "Nová skupina";
 
 "create" = "vytvořit";
 
@@ -795,30 +494,6 @@
 
 /* pink color */
 "pink" = "Růžová";
-
-/* deep purple color */
-"deep_purple" = "Tmavě fialová";
-
-/* light blue color */
-"light_blue" = "Světle modrá";
-
-/* cyan color */
-"cyan" = "Cyan";
-
-/* teal color */
-"teal" = "Teal";
-
-/* lime color */
-"lime" = "Limeta";
-
-/* deep orange color */
-"deep_orange" = "Tmavě oranžová";
-
-/* gray color */
-"gray" = "Šedá";
-
-/* blue gray color */
-"blue_gray" = "Modrošedá";
 
 /* Wi-Fi available */
 "WiFi_available" = "Ano";
@@ -848,13 +523,9 @@
 
 "dialog_routing_location_unknown_turn_on" = "Aktuální souřadnice GPS se nepodařilo zjistit. Pro výpočet trasy povolte služby určování polohy.";
 
-"dialog_routing_location_unknown" = "Aktuální souřadnice GPS se nepodařilo zjistit.";
-
 "dialog_routing_download_files" = "Stáhnout požadované soubory";
 
 "dialog_routing_download_and_update_all" = "Stáhnout a aktualizovat všechny mapy a data tras pro výpočet trasy podél navrhované cesty.";
-
-"dialog_routing_routes_size" = "Soubory s informacemi o trasách";
 
 "dialog_routing_unable_locate_route" = "Trasu se nepodařilo zjistit";
 
@@ -884,21 +555,11 @@
 
 "dialog_routing_try_again" = "Prosím, zkuste to znovu";
 
-"dialog_routing_send_error" = "Nahlásit problém";
-
-"dialog_routing_if_get_cross_route" = "Chcete vytvořit přímější trasu, která vede přes více než jednu mapu?";
-
-"dialog_routing_cross_route_is_optimal" = "K dispozici je optimálnější trasa, která překračuje hranice této mapy.";
-
 "not_now" = "Nyní ne";
-
-"dialog_routing_build_route" = "Vytvořit";
 
 "dialog_routing_download_and_build_cross_route" = "Chcete mapu stáhnout a vytvořit optimálnější trasu, která vede přes více než jednu mapu?";
 
 "dialog_routing_download_cross_route" = "Stáhnout mapu a vytvořit optimálnější trasu, která překračuje hranice této mapy.";
-
-"dialog_routing_cross_route_always" = "Vždy překročit tuto hranici";
 
 
 /********** Strings for downloading map from search **********/
@@ -906,8 +567,6 @@
 "search_without_internet_advertisement" = "Chcete-li začít hledat a vytvářet trasy, pak si prosím stáhněte mapu a nebudete již potřebovat připojení.";
 
 "search_select_map" = "Vybrat mapu";
-
-"search_select_other_map" = "Vybrat jinou mapu";
 
 /* «Show» context menu */
 "show" = "Ukázat";
@@ -918,17 +577,11 @@
 /* «Rename» context menu */
 "rename" = "Přejmenovat";
 
-/* Bottom sheet: expand button (should be short) */
-"bottom_sheet_more" = "Více…";
-
 /* Failed planning route message in navigation view */
 "routing_planning_error" = "Naplánování trasy se nezdařilo";
 
 /* Arrive routing message in navigation view */
 "routing_arrive" = "Příjezd: %s";
-
-/* Text for routing::RouterResultCode::FileTooOld dialog. */
-"dialog_routing_download_and_update_maps" = "Pro vytvoření trasy si prosím stáhněte a aktualizujte všechny mapy podél očekávané cesty.";
 
 "rate_alert_title" = "Líbí se vám aplikace?";
 
@@ -944,19 +597,11 @@
 
 "history" = "Historie";
 
-"next_turn_then" = "Poté";
-
 "closed" = "Zavřeno";
-
-"back_to" = "Zpět na %@";
 
 "search_not_found" = "Omlouvám se, nic nenalezeno.";
 
 "search_not_found_query" = "Zkuste zadat jiný hledaný výraz.";
-
-"search_not_found_map" = "Stáhněte si mapu, ve které hledáte.";
-
-"search_not_found_location" = "Stáhněte si mapu své aktuální pozice.";
 
 "search_history_title" = "Prohledat historii";
 
@@ -964,23 +609,12 @@
 
 "clear_search" = "Vymazat historii vyhledávání";
 
-/* Title for settings to enable/disable showcase menu button */
-"showcase_settings_title" = "Zobrazit nabídky";
-
 /* Place Page link to Wikipedia article (if map object has it). */
 "read_in_wikipedia" = "Wikipedia";
 
-"p2p_route_planning" = "Plánování trasy";
-
 "p2p_your_location" = "Vaše umístění";
 
-"p2p_from" = "Počátek cesty";
-
-"p2p_to" = "Místo určení";
-
 "p2p_start" = "Start";
-
-"p2p_planning" = "Plánování…";
 
 "p2p_from_here" = "Trasa z";
 
@@ -1018,15 +652,9 @@
 
 "editor_correct_mistake" = "Opravit chybu";
 
-"editor_correct_mistake_message" = "Při úpravách jste udělali chybu. Opravte ji prosím, nebo přepněte do jednoduchého režimu.";
-
 "editor_add_select_location" = "Umístění";
 
 "editor_done_dialog_1" = "Změnili jste světovou mapu. Neskrývejte to! Řekněte o tom svým kamarádům a upravujte ji společně.";
-
-"editor_done_dialog_2" = "Toto je vaše druhé vylepšení mapy. Nyní jste na %d. místě na seznamu editorů map. Řekněte o tom svým kamarádům.";
-
-"editor_done_dialog_3" = "Vylepšili jste mapu. Řekněte o tom svým kamarádům a upravujte mapu společně.";
 
 "share_with_friends" = "Sdílejte s kamarády";
 
@@ -1044,20 +672,7 @@
 
 "editor_report_problem_duplicate_place_title" = "Duplicitní místo";
 
-"first_launch_congrats_title" = "Organic Maps jsou připraveny k použití";
-
-"first_launch_congrats_text" = "Prohledávejte a navigujte offline zdarma kdekoliv na světě.";
-
-"migrate_title" = "Důležité!";
-
-/* Android uses image instead of text. */
-"download_all" = "Stáhnout vše";
-
-"delete_all" = "Odstranit vše";
-
 "autodownload" = "Automaticky stahovat";
-
-"disable_autodownload" = "Zakázat automatické stahování";
 
 /* Place Page opening hours text */
 "closed_now" = "Nyní je zavřeno";
@@ -1072,10 +687,6 @@
 "day_off" = "Zavřeno";
 
 "today" = "Dnes";
-
-"sunrise_to_sunset" = "Od úsvitu do soumraku";
-
-"sunset_to_sunrise" = "Od západu do východu slunce";
 
 "add_opening_hours" = "Přidat otevírací dobu";
 
@@ -1095,45 +706,18 @@
 
 "forgot_password" = "Zapomenuté heslo?";
 
-/* Forgot Password dialog title */
-"restore_password" = "Obnovit heslo";
-
-"enter_email_address_to_reset_password" = "Zadejte emailovou adresu, kterou jste používali během registrace a my Vám pošleme odkaz, abyste mohli obnovit svoje heslo.";
-
-"reset_password" = "Resetovat heslo";
-
-"username" = "Uživatelské jméno";
-
 "osm_account" = "Účet OSM";
 
 "logout" = "Odhlášení";
 
-"login_and_edit_map_motivation_message" = "Přihlaste se a editujte informace o objektech na mapě a my je zpřístupníme miliónům dalších uživatelů. Udělejme společně svět dokonalejším místem.";
-
 /* Information text: "Last upload 11.01.2016" */
 "last_upload" = "Poslední nahrání";
 
-/* Motivates user to login/register, title above login buttons. */
-"you_have_edited_your_first_object" = "Editovali jste svůj první objekt!";
-
 "thank_you" = "Děkujeme Vám";
-
-"login_with_google" = "Přihlásit se pomocí účtu Google";
-
-"login_with_openstreetmap" = "Přihlásit se pomocí účtu www.openstreetmap.org";
 
 "edit_place" = "Upravit místo";
 
 "place_name" = "Název místa";
-
-/* title above languages list cells in the editor, below editable name text field. */
-"other_languages" = "Další jazyky";
-
-/* small button to open list with names in different languages */
-"show_more" = "Zobrazit méně";
-
-/* small button to close list with names in different languages */
-"show_less" = "Zobrazit více";
 
 "add_language" = "Přidat jazyk";
 
@@ -1164,8 +748,6 @@
 
 "please_note" = "Vezměte prosím na vědomí";
 
-"common_no_wifi_dialog" = "Žádné Wi-Fi připojení. Chcete pokračovat s mobilními daty?";
-
 "downloader_delete_map_dialog" = "Zároveň s touto mapou budou odstraněny také všechny změny na této mapě.";
 
 "downloader_update_maps" = "Aktualizujte mapy";
@@ -1173,10 +755,6 @@
 "downloader_mwm_migration_dialog" = "Chcete-li vytvořit trasu, pak musíte aktualizovat všechny mapy a poté trasu naplánovat znovu.";
 
 "downloader_search_field_hint" = "Najít mapu";
-
-"migration_update_all_button" = "Aktualizovat všechny mapy";
-
-"migration_delete_all_download_current_button" = "Stáhněte si aktuální mapu a odstraňte staré";
 
 "migration_download_error_dialog" = "Chyba při stahování";
 
@@ -1186,21 +764,9 @@
 
 "downloader_no_space_message" = "Odstraňte prosím nepotřebná data";
 
-"editor_general_auth_error_dialog" = "Obecná chyba při přihlašování.";
-
 "editor_login_error_dialog" = "Chyba při přihlašování.";
 
-"editor_login_failed_dialog" = "Přihlašování selhalo";
-
-"editor_username_error_dialog" = "Uživatelské jméno není platné";
-
-"editor_place_edited_dialog" = "Upravili jste objekt!";
-
-"editor_login_with_osm" = "Přihlásit se pomocí OpenStreetMap";
-
 "editor_profile_changes" = "Oveřené změny";
-
-"editor_profile_unsent_changes" = "Neodesláno:";
 
 "editor_focus_map_on_location" = "Táhněte mapu, abyste vybrali správné umístění objektu.";
 
@@ -1222,13 +788,9 @@
 
 "editor_report_problem_other_title" = "Jiný problém";
 
-"placepage_report_problem_button" = "Nahlásit problém";
-
 "placepage_add_business_button" = "Přidat organizaci";
 
 "whatsnew_editor_message_1" = "Přidejte na mapu nová místa a upravte existující místa přímo z aplikace.";
-
-"whatsnew_editor_message_2" = "* Organic Maps používá komunitní data OpenStreetMap.";
 
 "dialog_incorrect_feature_position" = "Změnit umístění";
 
@@ -1236,16 +798,10 @@
 
 "login_to_make_edits_visible" = "Přihlaste se, aby ostatní uživatelé mohli vidět změny, které jste provedli.";
 
-"no_migration_during_navigation" = "Aktualizace jsou během navigování zakázány.";
-
 /* Error dialog no space */
 "migration_no_space_message" = "Ke stažení potřebujete více volného místa. Odstraňte prosím nepotřebná data.";
 
 "editor_sharing_title" = "Vylepšil jsem mapy Organic Maps";
-
-"editor_comment_will_be_sent" = "Váš komentář pošleme kartografům.";
-
-"editor_unsupported_category_message" = "Přidali jste místo kategorie, kterou zatím nepodporujeme. Na mapě se objeví za nějaký čas.";
 
 /* Downloaded 10 **of** 20 <- it is that "of" */
 "downloader_of" = "%1$d z %2$d";
@@ -1278,23 +834,9 @@
 
 "editor_operator" = "Operátor";
 
-"editor_tag_description" = "Zadejte osobu, společnost nebo organizaci, která zodpovídá za zařízení.";
-
-"editor_no_local_edits_title" = "Neprovedli jste žádné místní úpravy";
-
-"editor_no_local_edits_description" = "Zde vidíte počet navržených změn, které jsou v tuto chvíli dostupné pouze na Vašem zařízení.";
-
-"editor_send_to_osm" = "Odeslat do OSM";
-
-"editor_remove" = "Odstranit";
-
-"downloader_my_maps_title" = "Mé mapy";
-
 "downloader_no_downloaded_maps_title" = "Nemáte stažené žádné mapy";
 
 "downloader_no_downloaded_maps_message" = "Stáhněte si mapy a hledejte cestu a její cíl, i když jste offline.";
-
-"downloader_find_place_hint" = "Prohledat město nebo zemi";
 
 /* Error title that appears after certain time without location. */
 "current_location_unknown_title" = "Pokračovat se zjišťováním současné polohy?";
@@ -1321,47 +863,13 @@
 /* iOS Dialog for the case when the location permission is not granted */
 "location_services_disabled_3" = "3. Vyberte při používání aplikace";
 
-"placepage_parking_surface" = "Povrch";
-
-"placepage_parking_multistorey" = "Vícepatrové";
-
-"placepage_parking_underground" = "Podzemní";
-
-"placepage_parking_rooftop" = "Na střeše";
-
-"placepage_parking_sheds" = "Samostatné";
-
-"placepage_parking_carports" = "Přístřešek";
-
-"placepage_parking_boxes" = "Garáž";
-
-"placepage_parking_pay" = "Placené";
-
-"placepage_parking_free" = "Zdarma";
-
-"placepage_parking_interval" = "Placeno za čas";
-
-"placepage_entrance_number" = "Č.";
-
-"placepage_entrance_type" = "Vchod";
-
-"placepage_flat" = "byt";
-
-"placepage_open_24_7" = "Nonstop";
-
 "meter" = "m";
 
 "kilometer" = "km";
 
-"kilometers_per_hour" = "km/h";
-
 "mile" = "mil";
 
 "foot" = "stopa";
-
-"miles_per_hour" = "mil/h";
-
-"day" = "dní";
 
 "hour" = "hod";
 
@@ -1381,10 +889,6 @@
 
 "placepage_bookmark_name_hint" = "Název záložky";
 
-"placepage_personal_notes_hint" = "Vlastní poznámka";
-
-"placepage_delete_bookmark_button" = "Smazat záložku";
-
 "editor_edits_sent_message" = "Odeslali jsme Vámi navržené změny";
 
 "editor_comment_hint" = "Poznámka…";
@@ -1397,8 +901,6 @@
 
 "editor_remove_place_button" = "Odstranit";
 
-"editor_status_sending" = "Odesílání…";
-
 "editor_place_doesnt_exist" = "Místo neexistuje";
 
 "text_more_button" = "…dále";
@@ -1410,11 +912,7 @@
 
 "error_enter_correct_email" = "Zadat platný email";
 
-"error_enter_correct" = "Zadat platnou hodnotu";
-
 "refresh" = "Aktualizovat";
-
-"last_update" = "Poslední aktualizace: %s";
 
 "placepage_add_place_button" = "Přidat místo na mapu";
 
@@ -1426,24 +924,6 @@
 
 "editor_share_to_all_dialog_message_2" = "Změny ověříme. Budeme-li k vám mít jakékoli dotazy, budeme vás kontaktovat prostřednictvím emailu.";
 
-"navigation_overview_button" = "přehled";
-
-"navigation_stop_button" = "stop";
-
-/* Text on an empty bookmark page */
-"bookmarks_empty_title" = "Uložte si své záložky";
-
-"bookmarks_empty_message_1" = "Klikněte na ★ pro uložení oblíbených míst pro rychlý přístup.";
-
-"bookmarks_empty_message_2" = "Importovat záložky z emailu a webu.";
-
-"bookmarks_empty_message_3" = "odjezd: %s";
-
-/* Name of the group for booked hotels */
-"bookmarks_group_name" = "Zarezervované hotely";
-
-"place_page_button_read_descriprion" = "Číst";
-
 /* iOS dialog for the case when recent track recording is on and the app comes back from background */
 "recent_track_background_dialog_title" = "Zakázat zaznamenávání vaší nedávno ujeté trasy?";
 
@@ -1451,8 +931,6 @@
 
 /* For sharing via SMS and so on */
 "sharing_call_action_look" = "Odjezd";
-
-"continue_recent_track_background_button" = "Pokračovat";
 
 "recent_track_background_dialog_message" = "Organic Maps používají geopozici na pozadí, aby se zaznamenala vaše nedávno ujetá trasa.";
 
@@ -1468,33 +946,13 @@
 /* About short text (below logo) */
 "about_description" = "Organic Maps je základní aplikace pro každého cestovatele. Organic Maps je založena na datech z OpenStreetMap a umožňuje je upravovat.";
 
-/* Text in menu */
-"blog" = "Blog";
-
 "general_settings" = "Obecná nastavení";
-
-"date" = "Datum %d";
-
-/* "Report a bug" -> "Generaal Feedback" -> "Something is not working" */
-"something_is_not_working" = "Něco nefunguje";
 
 /* For the first routing */
 "accept" = "Přijmout";
 
-"accept_and_continue" = "Accept and continue";
-
 /* For the first routing */
 "decline" = "Odmítnout";
-
-"install_app" = "Instalovat";
-
-"search_no_results_title" = "Nebyly nalezeny žádné výsledky";
-
-"search_no_results_message" = "Zkuste obecnější hledaný výraz, oddálit nebo obnovit filtr.";
-
-"search_no_results_expand_area_button" = "Oddálit";
-
-"search_no_results_reset_button" = "Resetovat filtr";
 
 /* noun */
 "search_in_table" = "Seznam";
@@ -1517,8 +975,6 @@
 
 "traffic_update_maps_text" = "Ke zobrazení údajů o provozu musí být aktualizovány mapy.";
 
-"traffic_outdated" = "Data o provozu jsou zastaralá.";
-
 "big_font" = "Zvětšit velikost písma na mapě";
 
 "traffic_update_app" = "Aktualizujte MAPS. ME";
@@ -1529,17 +985,7 @@
 /* "traffic" as in "road congestion" */
 "traffic_data_unavailable" = "Data o provozu nejsou k dispozici";
 
-/* "Translation is no needed, because it's a company name" */
-"uber" = "Uber";
-
-/* Simplified colour scheme for traffic information, fewer colours are used to display traffic jams on the map. The string should be kept as short as possible */
-"pref_traffic_simplified_colors_title" = "Zjednodušené barvy provozu";
-
 "enable_logging" = "Povolit protokolování";
-
-"offline_place_page_more_information" = "Připojte se k Internetu a získejte více informací o tomto místě.";
-
-"failed_load_information" = "Nepodařilo se načíst informace.";
 
 /* Settings: "Send general feedback" button */
 "feedback_general" = "Všeobecné připomínky";
@@ -1556,8 +1002,6 @@
 
 "whatsnew_transliteration_title" = "Přepis do latinky";
 
-"yandex_taxi_title" = "Yandex.Taxi";
-
 "learn_more" = "Zjistit více";
 
 "core_exit" = "Ukončit";
@@ -1568,75 +1012,19 @@
 
 "button_exit" = "Ukončit";
 
-"settings_device_memory" = "Paměť zařízení";
-
-"settings_card_memory" = "Paměťovou kartu";
-
-"settings_storage_available" = "%s k dispozici";
-
-"toast_location_permission_denied" = "Povolení k určení polohy bylo zamítnuto";
-
-"button_use" = "Použít";
-
 "planning_route_manage_route" = "Spravovat trasu";
 
 "button_plan" = "Naplánovat";
-
-"button_add" = "Přidat";
 
 "placepage_remove_stop" = "Odstranit";
 
 "planning_route_remove_title" = "Pro odebrání přetáhněte sem";
 
-"dialog_change_start_point_message" = "Nastavit aktuální polohu jako výchozí bod?";
-
-"button_replace" = "Nastavit";
-
 "placepage_add_stop" = "Přidat zastávku";
-
-/* Only ru/en are needed */
-"subtitle_rent" = "Rent";
-
-/* Only ru/en are needed */
-"rub_month" = "RUB/month";
-
-/* Only ru/en are needed */
-"room" = "%s-room apt.";
-
-/* Only ru/en are needed */
-"real_estate" = "Real estate";
-
-"add_my_position" = "Přidat moji polohu";
-
-"choose_start_point" = "Vybrat počáteční bod";
-
-"choose_destination" = "Vybrat cílové místo";
 
 "preloader_viator_button" = "Zjistit více";
 
-"start_from_my_position" = "Začít z";
-
-"profile_authorization_title" = "Přihlásit se s";
-
-"profile_authorization_message" = "Snadné přihlášení bez uživatelského jména a hesla během několika sekund";
-
 "profile_authorization_error" = "Jejda, došlo k chybě. Zkuste se přihlásit znovu.";
-
-"service" = "Služba";
-
-"atmosphere" = "Atmosféra";
-
-"value_for_money" = "Poměr hodnoty a ceny";
-
-"experience" = "Zážitek";
-
-"assortment" = "Sortiment";
-
-"expertise" = "Odborné znalosti";
-
-"equipment" = "Vybavení";
-
-"quality" = "Kvalita";
 
 "dialog_error_storage_title" = "Problém s přístupem k úložišti";
 
@@ -1644,17 +1032,7 @@
 
 "setting_emulate_bad_storage" = "Emulovat špatné úložiště";
 
-"directions_finish" = "Cíl";
-
-"directions_on_foot" = "Chůze %s";
-
 "core_entrance" = "Vstup";
-
-"coffee" = "Káva";
-
-"cleanliness" = "Čistota";
-
-"crowdedness" = "Přelidnění";
 
 "error_enter_correct_name" = "Zadejte prosím správný název";
 
@@ -1673,11 +1051,9 @@
 
 "downloader_percent" = "%s (%s z %s)";
 
-"downloader_process" = "Stahování %s...";
+"downloader_process" = "Stahování %s…";
 
-"downloader_applying" = "Aplikuji %s...";
-
-"dialog_message_transit_not_found_connection" = "Naplánovat trasu s jednou tranzitní sítí";
+"downloader_applying" = "Aplikuji %s…";
 
 "bookmarks_error_message_share_general" = "Nelze sdílet kvůli chybě aplikace";
 
@@ -1695,17 +1071,7 @@
 
 "bookmarks_error_message_list_name_already_taken" = "Zvolte jiný název";
 
-"bookmarks_error_title_list_name_too_long" = "Tento název je příliš dlouhý";
-
-"bookmarks_error_message_list_name_too_long" = "Zvolte jiný název";
-
-"please_wait" = "Prosím, čekejte...";
-
-"phone_number" = "Telefonní číslo";
-
-"notification_unsent_reviews_title" = "Máte několik recenzí";
-
-"notification_unsent_reviews_message" = "Přihlaste se a sdílejte recenze s ostatními cestovateli";
+"please_wait" = "Prosím, čekejte…";
 
 "profile" = "Profil OpenStreetMap";
 
@@ -1719,49 +1085,13 @@
 
 "bookmarks_convert_error_message" = "Některé soubory nebyly převedeny.";
 
-"converting" = "Převádění...";
-
-"wn_reinvented_bookmarks_title" = "Znovu jsme vytvořili záložky!";
-
-"wn_reinvented_bookmarks_message" = "Můžete je zálohovat, vytvářet seznamy... Je to úžasné...";
-
-"bookmarks_restore" = "Obnovit záložky";
-
-"bookmarks_restore_process" = "Obnovení...";
-
 "bookmarks_restore_title" = "Obnovit tuto verzi?";
 
-"bookmarks_restore_message" = "Záložky se obnoví z %s (%s)";
-
-"bookmarks_restore_empty_title" = "Nemáte zálohu";
-
-"bookmarks_restore_empty_message" = "Server nenalezl dříve vytvořené zálohy";
-
 "common_check_internet_connection_dialog_title" = "Žádné internetové připojení";
-
-"error_server_title" = "Chyba serveru";
-
-"error_server_message" = "Na serveru došlo k chybě, zkuste to prosím znovu později";
 
 "error_system_message" = "Nastala neznámá chyba";
 
 "restore" = "Obnovit";
-
-"bookmarks_page_downloaded" = "Nahrané";
-
-"bookmarks_page_my" = "Moje";
-
-"routes_and_bookmarks" = "Trasy a značky";
-
-"bookmarks_webview_success_toast" = "Značky byly úspěšně nahrány";
-
-"cached_bookmarks_placeholder_title" = "Nahrajte nová místa";
-
-"cached_bookmarks_placeholder_subtitle" = "Klikněte pro nahrání tisíce zajímavých míst a tras vytvořených uživateli Organic Maps. Nutné připojení k internetu.";
-
-"downloader_download_routers" = "Nahrát značky";
-
-"bookmarks_groups_cached" = "Nahrané seznamy";
 
 "subtittle_opt_out" = "Natavení doprovodu";
 
@@ -1769,29 +1099,15 @@
 
 "crash_reports_description" = "Můžeme používat vaše údaje pro vývoj a zlepšení Organic Maps. Změny se projeví po restartování aplikace.";
 
-"opt_out_help_ios_1" = "Cílovou reklamu můžete vypnout v nastavení vašeho zařízení.";
-
-"opt_out_help_ios_2" = "iOS 9 nebo vyšší";
-
-"opt_out_help_ios_3" = "Otevřete Nastavení → Důvěrnost → Reklama → Zapněte „Omezení trackingu“";
-
-"opt_out_help_android" = "Cílovou reklamu můžete vypnout v nastavení vašeho zařízení.\nAndroid a Google Play Servisy 4.0 a vyšší\n\nNastavení telefonu → Google → Reklama → Vypnout personalizaci reklamy\n nebo\nNastavení telefonu → Google → Účet Google → Důvěrnost → Nastavení reklamních preferencí → Personalizace reklamy";
-
 "privacy_policy" = "Politika důvěrnosti";
 
 "terms_of_use" = "Podmínky užívání";
-
-"backup_notification_failed" = "Zálohování značek bylo pozastaveno. Pro zapnutí zálohování vejděte.";
 
 "button_layer_traffic" = "Zácpy";
 
 "button_layer_subway" = "Metro";
 
 "layers_title" = "Úrovně mapy";
-
-"layers_message" = "Pro zobrazení situace na silnici, schématu metra či jiné užitečné informace můžete přepínat úrovně mapy.";
-
-"button_layer_got_it" = "Rozumím";
 
 "subway_data_unavailable" = "Mapa metra není dostupná";
 
@@ -1803,39 +1119,13 @@
 
 "title_error_downloading_bookmarks" = "Někde se stala chyba";
 
-"subtitle_error_downloading_bookmarks" = "Značky se nenahrály";
-
-"error_already_downloaded" = "Tento seznam byl již stažen";
-
 "popular_place" = "Popular";
-
-"download_routes" = "Download routes";
-
-"bookmarks_downloaded_title" = "Bookmarks have been downloaded successfully";
-
-"bookmarks_downloaded_subtitle" = "Press ‘View on map’ to explore new places from the list";
-
-"why_support" = "Proč podporovat Organic Maps?";
-
-"why_support_item1" = "We respect your privacy: there are zero trackers in the app, and we are open source";
-
-"why_support_item2" = "Pomáháte nám zlepšovat Organic Maps";
-
-"why_support_item3" = "Pomáháte nám zlepšovat mapy OpenStreetMap.org";
-
-"channels_map_update" = "Aktualizace map";
-
-"server_unavailable_title" = "Sever je nedostupný";
-
-"sharing_options" = "Nastavení přístupu";
 
 "export_file" = "Exportovat soubor";
 
 "list_settings" = "Nástroje seznamu";
 
 "delete_list" = "Smazat seznam";
-
-"hide_from_map" = "Neukazovat na mapě";
 
 "public_access" = "Veřejně přístupné";
 
@@ -1845,40 +1135,11 @@
 
 "bookmark_category_description_hint" = "Přidejte popis (text nebo html)";
 
-/* FIXME */
-"bookmarks_public_access" = "bookmarks_public_access";
-
-/* FIXME */
-"bookmarks_link_access" = "bookmarks_link_access";
-
-/* FIXME */
-"bookmarks_private_access" = "bookmarks_private_access";
-
 "not_shared" = "Osobní účet";
-
-"direct_link_progress_text" = "Váš soubor se nahrává…";
-
-"direct_link_success" = "Odkaz byl vytvořen";
-
-"send_a_link_btn" = "Poslat odkaz";
-
-"upload_error_toast" = "Během nahrávání souboru se stala chyba";
 
 "tags_loading_error_subtitle" = "Během nahrávání tagů se stala chyba, zkuste to prosím ještě jednou";
 
-"unable_upload_errorr_title" = "Soubor se nepodařilo nahrát";
-
-"unable_upload_error_subtitle_edited" = "Soubor byl upraven pomocí webové aplikace";
-
-"unable_upload_error_subtitle_broken" = "Soubor je poškozen a nemůže být nahrán. Nahrajte prosím jiný soubor.";
-
-"contact" = "Napsat";
-
-"download_button" = "Stáhnout";
-
 "speedcams_alert_title" = "Detektory rychlosti";
-
-"speedcams_alert_subtitle" = "Upozorňovat o omezeních rychlosti";
 
 "speedcam_option_auto" = "Automaticky";
 
@@ -1886,18 +1147,10 @@
 
 "speedcam_option_never" = "Nikdy";
 
-"bookmark_description_title" = "Popis značky";
-
 "place_description_title" = "Popis místa";
 
 /* this text will be shown in application notification preferences opposite checkbox which enable/disable downloader notifications. Devices on Android 8+ are affected. */
 "notification_channel_downloader" = "Nahrávání map";
-
-"share_bookmarks_email_body_link" = "Dobrý den!\n\nVaše značky můžete stáhnout zde: %s. Otevírejte seznam s pomocí Organic Maps a užívejte si cesty!\n\nStáhnout aplikaci: https://omaps.app/get?kmz";
-
-"warning_speedcams_title" = "Navigátor vás při překročení rychlosti o %d km/h upozorní na všechny radary";
-
-"warning_speedcams_subtitle" = "Nezapomeňte se seznámit s dopravními předpisy země, do které cestujete.";
 
 "speedcams_notice_message" = "Automaticky - Upozorňovat na rychlostní radary, pokud hrozí riziko překročení rychlosti\nVždy - Vždy upozorňovat na rychlostní radary\nNikdy - Nikdy neupozorňovat na rychlostní radary";
 
@@ -1913,23 +1166,7 @@
 
 "enable_logging_warning_message" = "Daná možnost se zapojuje pro protokolování činností za účelem diagnostiky. To pomáhá týmu odhalit problémy s přílohou. Zapojujte možnost jenom na požádání podržení Organic Maps.";
 
-"html_error_upload_message_try_again" = "Zkontrolujte přístup k síti a zopakujte pokus";
-
-"html_error_upload_title_try_again" = "Není přípojení na internet";
-
-"notification_leave_review_v2_android_short_title" = "Ponechávejte ohlas a pomáhejte cestovatelům!";
-
-"megafon" = "Say goodbye to roaming!";
-
-"notifications_illegal_alert_disable_button" = "Vypnout oznámení";
-
 "access_rules_author_only" = "Upravujte on-line";
-
-"privacy_settings_menu" = "Naladění důvěrnosti";
-
-"unable_upadate_error_title" = "Nepovedlo se obnovit trasu";
-
-"unable_upadate_error_message" = "Objevily se chyby pří obnovení. Zkontrolujte změny a zopakujte pokus";
 
 "driving_options_title" = "Možnosti řízení";
 
@@ -1951,94 +1188,19 @@
 
 "change_driving_options_btn" = "Možnosti směrování byly povoleny";
 
-"toll_road" = "Silnice s mýtným";
-
-"unpaved_road" = "Nezpevněná silnice";
-
-"ferry_crossing" = "Přejezd trajektů";
-
-"operated_by" = "Provozován \"%s\"";
-
 "avoid_toll_roads_placepage" = "Vyhnout se silnicím s mýtným";
 
 "avoid_unpaved_roads_placepage" = "Vyhnout se nezpevněným silnicím";
 
 "avoid_ferry_crossing_placepage" = "Vyhnout se přejezdům trajektů";
 
-"type.cuisine.uzbek" = "Uzbecká kuchyně";
-
-"trip_start" = "Pojďme";
-
-"pick_destination" = "Destinace";
-
-"follow_my_position" = "Znovu vystředit";
-
-"search_results" = "Prohledat výsledky";
-
-"then_turn" = "Poté";
-
-"redirect_route_alert" = "Chcete přestavět trasu?";
-
-"redirect_route_yes" = "Ano";
-
-"redirect_route_no" = "Ne";
-
-"trip_finished" = "Přijeli jste!";
-
-"keyboard_availability_alert" = "Při řízení není klávesnice dostupná";
-
-"dialog_routing_change_start_carplay" = "Od vaší aktuální polohy nelze vystavět trasu";
-
-"dialog_routing_change_end_carplay" = "Nelze vystavět trasu k vaší destinaci. Zvolte prosím další bod";
-
-"dialog_routing_check_gps_carplay" = "Signál GPS neexistuje. Přesuňte se prosím do otevřeného prostoru";
-
-"dialog_routing_unable_locate_route_carplay" = "Nelze sestavit trasu. Specifikujte prosím další body trasy";
-
-"dialog_routing_download_files_carplay" = "K vytvoření trasy si stáhněte chybějící mapy do vašeho zařízení";
-
-"dialog_routing_system_error_carplay" = "Vyskytla se chyba. Restartujte prosím aplikaci";
-
-"dialog_routing_rebuild_from_current_location_carplay" = "Trasa bude přestavěna od vaší aktuální polohy";
-
-"dialog_routing_rebuild_for_vehicle_carplay" = "Trasa bude upravena k autu jedna";
-
 "ok" = "Ok";
-
-"avoid_unpaved_carplay_1" = "Bez pr. cest";
-
-"avoid_unpaved_carplay_2" = "Vyhnout se nezp";
-
-"avoid_ferry_carplay_1" = "Bez trajektů";
-
-"avoid_ferry_carplay_2" = "Vyh. se traj.";
-
-"avoid_tolls_carplay_1" = "Bez pl.sil.";
-
-"avoid_tolls_carplay_2" = "Vyh. se pl. sil";
-
-"speedcams_alert_title_carplay_1" = "Rych. kam.";
-
-"speedcams_alert_title_carplay_2" = "Rych. varování";
-
-"download_map_carplay" = "Stáhněte si prosím mapy do aplikace Organic Maps ve vašem zařízení";
-
-"carplay_roundabout_exit" = "%s výjezd";
 
 /* max. 10 symbols, both iOS and Android */
 "sort" = "Třídit…";
 
 /* Android, title, max 20-22 symbols */
 "sort_bookmarks" = "Třídit záložky";
-
-/* iOS */
-"sort_default" = "Třídit ve výchozím nastavení";
-
-"sort_type" = "Třídit dle typu";
-
-"sort_distance" = "Třídit dle vzdálenosti";
-
-"sort_date" = "Třídit dle data";
 
 /* Android */
 "by_default" = "Podle výchozího stavu";
@@ -2052,63 +1214,7 @@
 /* Android */
 "by_date" = "Podle data";
 
-"week_ago_sorttype" = "Před týdnem";
-
-"month_ago_sorttype" = "Před měsícem";
-
-"moremonth_ago_sorttype" = "Více než před měsícem";
-
-"moreyear_ago_sorttype" = "Více než před rokem";
-
-"near_me_sorttype" = "Blízko mě";
-
-"others_sorttype" = "Ostatní";
-
-"food_places" = "Jídlo";
-
-"tourist_places" = "Památky";
-
-"museums" = "Muzea";
-
-"parks" = "Parky";
-
-"swim_places" = "Plavat";
-
-"mountains" = "Hory";
-
-"animals" = "Zvířata";
-
-"hotels" = "Hotely";
-
-"buildings" = "Budovy";
-
-"money" = "Peníze";
-
-"shops" = "Obchody";
-
-"parkings" = "Parkoviště";
-
-"fuel_places" = "Čerpací stanice";
-
-"water" = "Voda";
-
-"medicine" = "Medicína";
-
 "search_in_the_list" = "Vyhledat v seznamu";
-
-"view_on_map_bookmarks" = "Na mapě";
-
-"more_bookmarks" = "Více…";
-
-"no_items_found" = "Nebyly nalezeny žádné položky";
-
-/* Android, max 18 symbols */
-"bookmarks_edit_list" = "Upravit seznam";
-
-/* Android, max 18 symbols */
-"bookmarks_delete_list" = "Odstranit seznam";
-
-"religious_places" = "Posvátná místa";
 
 "select_list" = "Vybrat seznam";
 
@@ -2118,26 +1224,13 @@
 
 "dialog_pedestrian_route_is_long_message" = "Zvolte prosím počáteční nebo koncový bod blíže k stanici metra";
 
-/* Failed planning SUBWAY route message in navigation view */
-"routing_planning_error_subway_special" = "Plánování trasy metra selhalo";
-
 "button_layer_isolines" = "Terén";
-
-"tips_map_layers_title_countour" = "Novinka v Organic Maps: offline topografická vrstva!";
-
-"tips_map_layers_message_countour" = "Naplánujte si a užijte si své výlety do přírody s jistotou, že víte vše o této oblasti";
 
 "isolines_activation_error_dialog" = "Chcete-li aktivovat a používat topografickou vrstvu, prosím aktualizujte nebo si stáhněte mapu oblasti";
 
 "isolines_location_error_dialog" = "Topografická vrstva není v této oblasti ještě dostupná";
 
 "elevation_profile_diff_level" = "Stupeň obtížnosti";
-
-"elevation_profile_diff_level_easy" = "Snadný";
-
-"elevation_profile_diff_level_moderate" = "Mírný";
-
-"elevation_profile_diff_level_hard" = "Těžký";
 
 "elevation_profile_ascent" = "Stoupání";
 
@@ -2147,25 +1240,13 @@
 
 "elevation_profile_maxaltitude" = "Max. nadmořská výška";
 
-"elevation_profile_m" = "m";
-
 "elevation_profile_difficulty" = "Obtížnost";
 
 "elevation_profile_distance" = "Vzdál.:";
 
-"elevation_profile_km" = "km";
-
 "elevation_profile_time" = "Čas:";
 
-"elevation_profile_hours" = "hod.";
-
-"elevation_profile_minutes" = "min";
-
 "isolines_toast_zooms_1_10" = "Přiblížit pro prozkoumání izolinií";
-
-"downloader_updating_ios" = "Probíhá aktualizace";
-
-"downloader_loading_ios" = "Probíhá stahování";
 
 "key_information_title" = "Klíčové informace";
 

--- a/iphone/Maps/LocalizedStrings/cs.lproj/Localizable.stringsdict
+++ b/iphone/Maps/LocalizedStrings/cs.lproj/Localizable.stringsdict
@@ -9,21 +9,6 @@
 
 <!-- ********** Strings for downloading map from search **********/ -->
 
-  <key>bookmarks_places</key>
-  <dict>
-    <key>NSStringLocalizedFormatKey</key>
-    <string>%#@value@</string>
-    <key>value</key>
-    <dict>
-      <key>NSStringFormatSpecTypeKey</key>
-      <string>NSStringPluralRuleType</string>
-      <key>NSStringFormatValueTypeKey</key>
-      <string>d</string>
-      <key>other</key>
-      <string>%d záložek</string>
-    </dict>
-  </dict>
-
   <key>bookmarks_detect_message</key>
   <dict>
     <key>NSStringLocalizedFormatKey</key>
@@ -34,27 +19,12 @@
       <string>NSStringPluralRuleType</string>
       <key>NSStringFormatValueTypeKey</key>
       <string>d</string>
-      <key>one</key>
-      <string>%d soubor byl nalezen. Uvidíte ji po konverzi.</string>
       <key>few</key>
       <string>%d byly nalezeny soubory. Uvidíte je po konverzi.</string>
+      <key>one</key>
+      <string>%d soubor byl nalezen. Uvidíte ji po konverzi.</string>
       <key>other</key>
       <string>Bylo nalezeno %d souborů. Uvidíte je po konverzi.</string>
-    </dict>
-  </dict>
-
-  <key>bookmarks_objects</key>
-  <dict>
-    <key>NSStringLocalizedFormatKey</key>
-    <string>%#@value@</string>
-    <key>value</key>
-    <dict>
-      <key>NSStringFormatSpecTypeKey</key>
-      <string>NSStringPluralRuleType</string>
-      <key>NSStringFormatValueTypeKey</key>
-      <string>d</string>
-      <key>other</key>
-      <string>%s objekt</string>
     </dict>
   </dict>
 

--- a/iphone/Maps/LocalizedStrings/da.lproj/Localizable.strings
+++ b/iphone/Maps/LocalizedStrings/da.lproj/Localizable.strings
@@ -18,9 +18,6 @@
 /* Button which deletes downloaded country */
 "delete" = "Slet";
 
-/* Button "do not interrupt download" if user touched actively downloading country */
-"do_nothing" = "Fortsæt";
-
 "download_maps" = "Download kort";
 
 /* Settings/Downloader - info for country when download fails */
@@ -28,9 +25,6 @@
 
 /* Settings/Downloader - info for country which started downloading */
 "downloading" = "Downloader…";
-
-/* Settings/Downloader - size string, only strings different from English should be translated */
-"kb" = "kB";
 
 /* Choose measurement on first launch alert - choose metric system button */
 "kilometres" = "Kilometre";
@@ -55,17 +49,11 @@
 /* Update maps later/Buy pro version later button text */
 "later" = "Senere";
 
-/* Don't show some dialog any more */
-"never" = "Aldrig";
-
 /* View and button titles for accessibility */
 "search" = "Søg";
 
 /* Search box placeholder text */
 "search_map" = "Søg kort";
-
-/* Settings/Downloader - info for not downloaded country */
-"touch_to_download" = "Tryk for at downloade";
 
 /* Settings/Downloader - 3G download warning dialog confirm button */
 "use_cellular_data" = "Ja";
@@ -73,20 +61,11 @@
 /* Location services are disabled by user alert - message */
 "location_is_disabled_long_text" = "Du har alle lokationstjenester for denne enhed eller applikation slukket. Slå dem venligst til i Indstillinger.";
 
-/* Location Services are not available on the device alert - message */
-"device_doesnot_support_location_services" = "Din enhed understøtter ikke lokationstjenester";
-
 /* View and button titles for accessibility */
 "zoom_to_country" = "Vis på kortet";
 
-/* Button text for the button at the center of the screen when the country is not downloaded */
-"country_status_download" = "Download kort\n(^ ^)";
-
 /* Button text for the button at the center of the screen when the country is not downloaded and the size should not be shown */
 "country_status_download_without_size" = "Download kort";
-
-/* Button text for the button at the center of the screen when the country is not downloaded */
-"country_status_download_without_routing" = "Download kort uden\nruteplanlægning (^ ^)";
 
 /* Message to display at the center of the screen when the country download has failed */
 "country_status_download_failed" = "Download mislykket";
@@ -96,19 +75,13 @@
 
 "about_menu_title" = "Om Organic Maps";
 
-"downloaded_touch_to_delete" = "Downloaded (%@), tryk for at slette";
-
 "connection_settings" = "Forbindelsesindstillinger";
-
-"download_mb_or_kb" = "Download %@";
 
 "close" = "Luk";
 
 "unsupported_phone" = "En hardware accelereret OpenGL er påkrævet. Din enhed er desværre ikke understøttet.";
 
 "download" = "Download";
-
-"external_storage_is_not_available" = "SD-kort/USB lagring med de downloadede kort er ikke tilgængeligt";
 
 "disconnect_usb_cable" = "Frakobl venligst USB-kabel eller indsæt et memory kort for at bruge Organic Maps";
 
@@ -117,8 +90,6 @@
 "not_enough_memory" = "Ikke nok hukommelse til at åbne app";
 
 "download_resources" = "Før du starter, så lad os downloade det generelle verdenskort til din enhed.\nIt behøver %@ af data.";
-
-"getting_position" = "Henter nuværende lokation";
 
 "download_resources_continue" = "Gå til kort";
 
@@ -140,23 +111,14 @@
 /* Add New Bookmark Set dialog title */
 "add_new_set" = "Tilføj nyt sæt";
 
-/* Place Page - Add To Bookmarks button */
-"add_to_bookmarks" = "Tilføj til Bogmærker";
-
 /* Bookmark Color dialog title */
 "bookmark_color" = "Bogmærke Farve";
 
 /* Add Bookmark Set dialog - hint when set name is empty */
 "bookmark_set_name" = "Indstil bogmærkenavn";
 
-/* Bookmark Sets dialog title */
-"bookmark_sets" = "Bogmærk sæt";
-
 /* Bookmarks - dialog title */
 "bookmarks" = "Bogmærker";
-
-/* Add bookmark dialog - bookmark color */
-"color" = "Farve";
 
 /* Default bookmarks set name */
 "core_my_places" = "Mine Steder";
@@ -167,14 +129,8 @@
 /* Editor title above street and house number */
 "address" = "Adresse";
 
-/* Place Page - Remove Pin button */
-"remove_pin" = "Fjern knappenål";
-
 /* Add bookmark dialog - bookmark set, Bookmarks dialog - Bookmark set cell */
 "set" = "Sæt";
-
-/* Text hint in Bookmarks dialog when no any bookmarks are added */
-"bookmarks_usage_hint" = "Du har ingen bogmærker endnu.\nTryk på et sted på kortet for at kunne tilføje det til bogmærker. Bogmærker fra andre kilder kan også blive importeret og vist i Organic Maps.\nÅbn en KML/KMZ fil med gemte bogmærker/knappenåle på i Mail, Dropbox eller på et link.";
 
 /* Settings button in system menu */
 "settings" = "Indstillinger";
@@ -191,26 +147,11 @@
 /* Ask to wait user several minutes (some long process in modal dialog). */
 "wait_several_minutes" = "Dette kan tage flere minutter.\nVent venligst…";
 
-/* Show bookmarks from this category on a map or not */
-"visible" = "Synligt";
-
-/* Toast which is displayed when GPS has been deactivated */
-"gps_is_disabled_long_text" = "GPS er deaktiveret. Aktiver venligst i Indstillinger.";
-
 /* Measurement units title in settings activity */
 "measurement_units" = "Måleenhed";
 
 /* Detailed description of Measurement Units settings button */
 "measurement_units_summary" = "Vælg mellem mil eller kilometer";
-
-/* Do search in all sources */
-"search_mode_all" = "Overalt";
-
-/* Do search near my position only */
-"search_mode_nearme" = "Tæt på mig";
-
-/* Do search in current viewport only */
-"search_mode_viewport" = "På skærmen";
 
 /* Search category for cafes, bars, restaurants */
 "eat" = "Spisesteder";
@@ -266,14 +207,8 @@
 /* Search category */
 "police" = "Politi";
 
-/* String in search result list, when nothing found */
-"no_search_results_found" = "Ingen resultater";
-
 /* Notes field in Bookmarks view */
 "description" = "Noter";
-
-/* Button text */
-"share_by_email" = "Del via email";
 
 /* Email Subject when sharing bookmarks category */
 "share_bookmarks_email_subject" = "Organic Maps bogmærker er blevet delt med dig";
@@ -295,26 +230,11 @@
 /* Warning message when doing search around current position */
 "unknown_current_position" = "Din lokation er ikke blevet bestemt endnu";
 
-/* Warning message when location country isn't downloaded during search (see also download_location_map_proposal). */
-"download_location_country" = "Download landet bestemt ud fra din nuværende lokation (%@)";
-
-/* Warning message when viewport country isn't downloaded during search */
-"download_viewport_country_to_search" = "Download landet som du har søgt på (%@)";
-
 /* Alert message that we can't run Map Storage settings due to some reasons. */
 "cant_change_this_setting" = "Beklager, Kort Lagring er ikke slået til i indstillinger.";
 
 /* Alert message that downloading is in progress. */
 "downloading_is_active" = "Download af kort over land er i gang nu.";
-
-/* Message that will be shown in alert view, when we ask user to leave review on App Store */
-"appStore_message" = "Vi håber du er glad for at bruge Organic Maps! Hvis du er, vil du så overveje at bedømme og måske skrive en anmeldelse på App Store? Det tager under et minut, men det kan virkelig hjælpe os. Tak for din hjælp!";
-
-/* No, thanks */
-"no_thanks" = "Nej, tak";
-
-/* Share one specific bookmark using SMS, %1$@ contains om:// and %2$@ https://omaps.app link. @NOTE non-ascii symbols in the link will result in max 70 characters SMS instead of 140. */
-"bookmark_share_sms" = "Hey, tjek min knappenål på Organic Maps ud! %1$@ or %2$@ Har du ikke offline kort? Download her: https://omaps.app/get";
 
 /* Share my position using SMS, %1$@ contains om:// and %2$@ https://omaps.app link WITHOUT NAME. @NOTE non-ascii symbols in the link will result in max 70 characters SMS instead of 140. */
 "my_position_share_sms" = "Hey, tjek min nuværende lokation ud på Organic Maps! %1$@ or %2$@. Har du ikke offline kort? Download her: https://omaps.app/get";
@@ -328,23 +248,11 @@
 /* Share my position using EMail, %1$@ is om:// and %2$@ is https://omaps.app link WITHOUT NAME */
 "my_position_share_email" = "Hey, her er jeg nu: %1$@. Tryk på dette link %2$@ eller dette %3$@ for at se stedet på kortet. Tak.";
 
-/* Android share by Message/SMS button text (including SMS) */
-"share_by_message" = "Del via besked";
-
 /* Share button text which opens menu with more buttons, like Message, EMail, Facebook etc. */
 "share" = "Del";
 
-/* iOS share by Message button text (including SMS) */
-"message" = "Besked";
-
 /* Share by email button text, also used in editor. */
 "email" = "Email";
-
-/* Copy Link */
-"copy_link" = "Kopier link";
-
-/* Text for the button that returns to caller application */
-"more_info" = "Vis mere info";
 
 /* Text for message when used successfully copied something */
 "copied_to_clipboard" = "Kopieret til udklipsholderen: %1$@";
@@ -354,15 +262,6 @@
 
 /* Used for bookmark editing */
 "done" = "Færdig";
-
-/* Summary for preferences in MWM */
-"yopme_pref_summary" = "Vælg bagskærmsindstillinger";
-
-/* Title for yopme preferences in MWM */
-"yopme_pref_title" = "Bagskærmsindstillinger";
-
-/* Hint for upper-right icon p2b */
-"show_on_backscreen" = "Vis på bagskærm";
 
 /* Prints version number in About dialog */
 "version" = "Version: %@";
@@ -381,19 +280,11 @@
 
 "share_my_location" = "Del min lokation";
 
-"menu_search" = "Søg";
-
 /* Settings general group in settings screen */
 "prefs_group_general" = "General settings";
 
 /* Settings information group in settings screen */
 "prefs_group_information" = "Information";
-
-/* Settings screen: "Map" category title */
-"prefs_group_map" = "Kort";
-
-/* Settings screen: "Miscellaneous" category title */
-"prefs_group_misc" = "Forskelligt";
 
 "prefs_group_route" = "Navigation";
 
@@ -419,9 +310,6 @@
 /* Settings «Map» category: «3D buildings» title */
 "pref_map_3d_buildings_title" = "3D-bygninger";
 
-/* Settings «Map» category: «3D buildings» summary */
-"pref_map_3d_buildings_subtitle" = "Påvirker batteriets levetid";
-
 /* Settings «Route» category: «Tts enabled» title */
 "pref_tts_enable_title" = "Stemmeinstruktioner";
 
@@ -433,8 +321,6 @@
 
 /* Title for "Other" section in TTS settings. */
 "pref_tts_other_section_title" = "Andet";
-
-"pref_tts_how_to_set_up_voice" = "Sådan indstiller du tale";
 
 /* Settings «Map» category: «Record track» title */
 "pref_track_record_title" = "Seneste sti";
@@ -455,56 +341,7 @@
 
 "recent_track_help_text" = "Det giver dig mulighed at optage en rejsterute for en bestemt periode og se den på kortet. Bemærk: aktivering af denne funktion forårsager øget batteriforbrug. Sporet vil blive fjernet automatisk fra kortet efter at tidsintervallet er udløbet.";
 
-"pref_track_ios_caption" = "Seneste spor viser din rejste vej.";
-
-"pref_track_ios_subcaption" = "Vælg tidsinterval for at gemme sporet.";
-
-"placepage_distance" = "Afstand";
-
-"placepage_coordinates" = "Koordinater";
-
-"placepage_unsorted" = "Usorteret";
-
 "search_show_on_map" = "Vis på kortet";
-
-/* Used to warn user when fixing KitKat issue */
-"bookmark_move_fail" = "Vi er nødsaget til at flytte dine bogmærker til intern hukommelse, men der er ikke nok plads til dem der. Frigør venligst noget plads, ellers vil dine bogmærker ikke være tilgængelige.";
-
-/* Used in More Apps menu */
-"free" = "Gratis";
-
-/* Used in More Apps menu */
-"buy" = "Køb";
-
-/* 1st search button-like result */
-"search_on_map" = "Søg på kort";
-
-/* toast with an error */
-"no_route_found" = "Ingen rute blev fundet";
-
-/* route title */
-"route" = "Rute";
-
-/* category title */
-"routes" = "Ruter";
-
-/* text of notification */
-"download_map_notification" = "Download kortet over det sted, hvor du befinder dig";
-
-/* text of notification */
-"pro_version_is_free_today" = "Fuld version af Organic Maps er gratis i dag! Download nu og fortæl dine venner om det.";
-
-/* Dialog for transferring maps from lite to pro. */
-"move_lite_maps_to_pro" = "Vi overfører dine downloadede kort fra Organic Maps Lite til Organic Maps. Det kan tage et par minutter.";
-
-/* Message to display when maps moved. */
-"move_lite_maps_to_pro_ok" = "Dine downloadede kort er blevet succesfuldt overført til Organic Maps.";
-
-/* Message to display when maps move failed. */
-"move_lite_maps_to_pro_failed" = "Det lykkedes ikke at overføre dine kort. Slet venligst Organic Maps Lite og download kortene igen.";
-
-/* Text in menu */
-"settings_and_more" = "Indstillinger & Mere";
 
 /* Text in menu */
 "website" = "Hjemmeside";
@@ -527,14 +364,8 @@
 /* Text in menu */
 "openstreetmap" = "OpenStreetMap";
 
-/* Text in menu */
-"contact_us" = "Kontakt os";
-
 /* Settings: Send feedback button and dialog title */
 "feedback" = "Feedback";
-
-/* Text in menu */
-"subscribe_to_news" = "Abonnér på vores nyheder";
 
 /* Text in menu */
 "rate_the_app" = "Bedøm appen";
@@ -548,15 +379,6 @@
 /* Text in menu */
 "report_a_bug" = "Rapportér fejl";
 
-/* Email subject */
-"subscribe_me_subject" = "Tilmeld mig Organic Maps-nyhedsbrev";
-
-/* Email body */
-"subscribe_me_body" = "Jeg vil være den første til at høre om de seneste nyheder opdateringer og tilbud. Jeg kan opsige abonnementet når som helst.";
-
-/* About text */
-"about_text" = "Organic Maps tilbyder de hurtigste offline-kort over alle byer og alle lande i verden. Rejs med tillid: Hvor end du befinder dig, hjælper Organic Maps med at lokalisere din placering på kortet, finde den nærmeste restaurant, hotel, bank, benzintank og så videre. Det er ikke nødvendigt at have forbindelse til internettet.\n\nVi arbejder altid på nye funktioner, og vi vil meget gerne høre fra dig, hvis du har forslag til, hvordan vi kan forbedre Organic Maps. Hvis du oplever problemer med appen, er du meget velkommen til at kontakte os på support@organicmaps.app. Vi besvarer alle henvendelser!\n\nSynes du om Organic Maps, og har du lyst til at støtte os? Her er nogle simple og helt gratis metoder:\n\n-post en anmeldelse i din App Store\n-like vores facebook-side http://www.facebook.com/OrganicMaps\n-neller fortæl din mor, venner og kollegaer om Organic Maps :)\n\nTak fordi du støtter os. Vi sætter stor pris på din støtte!\n\nPS: Vi får vores kortdata fra OpenStreetMap, som er et kortprojekt, der minder om Wikipedia, og som gør brugere i stand til at oprette og rette kort. Hvis du oplever, at noget mangler eller er forkert på kortet, kan du rette kortene direkte på https://www.openstreetmap.org, og dine ændringer vil figurere på Organic Maps-appen i forbindelse med frigivelsen af den næste version.";
-
 /* Alert text */
 "email_error_body" = "Emailklienten er ikke blevet sat op. Venligst konfigurér den eller brug en anden måde til at kontakte os på %@";
 
@@ -569,12 +391,6 @@
 /* Search category */
 "wifi" = "WiFi";
 
-/* Update map suggestion */
-"routing_map_outdated" = "Venligst opdatér kortet for at oprette en rute.";
-
-/* Update maps suggestion */
-"routing_update_maps" = "Den nye version af Organic Maps gør det muligt at oprette ruter fra din nuværende position til et destinationspunkt. Venligst opdatér kortene for at bruge denne funktion.";
-
 /* Update all button text */
 "downloader_update_all_button" = "Opdatér alle";
 
@@ -583,9 +399,6 @@
 
 /* Downloaded maps category */
 "downloader_downloaded_subtitle" = "Downloadet";
-
-/* Downloaded maps category */
-"downloader_available_maps" = "Tilgængelige";
 
 /* Country queued for download */
 "downloader_queued" = "I kø";
@@ -598,17 +411,6 @@
 
 "downloader_downloading" = "Downloader:";
 
-"downloader_search_results" = "Fundet";
-
-/* Disclaimer message */
-"routing_disclaimer" = "Ved oprettelse af ruter i Organic Maps appen, venligst tænk over følgende:\n\n- Anbefalede ruter kan kun betragtes som anbefalinger.\n- Vejtilstande, trafikregler og skilte har højere prioritet end navigationsråd.\n Kortet kan være ukorrekt eller forældet, og ruter kan muligvis ikke være oprettet på den bedste måde.\n\nVær sikker på vejene og pas på dig selv!";
-
-/* Outdated maps category */
-"downloader_outdated_maps" = "Uddateret";
-
-/* Up to date maps category */
-"downloader_uptodate_maps" = "Up-to-date";
-
 /* Status of outdated country in the list */
 "downloader_status_outdated" = "Opdater";
 
@@ -618,49 +420,14 @@
 /* Displayed in a dialog that appears when a user tries to delete a map while the app is in the follow route mode */
 "downloader_delete_map_while_routing_dialog" = "For at slette kortet skal du stoppe navigeringen.";
 
-/* Show when user try build route, but we don't know where he */
-"routing_failed_unknown_my_position" = "Den nuværende placering er ikke defineret. Venligst angiv placering for at oprette en rute.";
-
-/* Show if use has not routing file, or InconsistentMWMandRoute */
-"routing_failed_has_no_routing_file" = "Yderligere data er nødvendig, for at oprette en rute. Begynde download?";
-
-/* StartPointNotFound */
-"routing_failed_start_point_not_found" = "Kan ikke beregne ruten. Ingen veje nær dit startpunkt.";
-
-/* EndPointNotFound */
-"routing_failed_dst_point_not_found" = "Kan ikke beregne ruten. Ingen veje nær din destination.";
-
 /* PointsInDifferentMWM */
 "routing_failed_cross_mwm_building" = "Ruter kan kun oprettes, hvis de er fuldt indeholdt i ét enkelt kort.";
-
-/* RouteNotFound */
-"routing_failed_route_not_found" = "Der blev ikke fundet en rute mellem det valgte begyndelsespunkt og destinationen. Venligst vælg et andet start- eller slutpunkt.";
-
-/* InternalError */
-"routing_failed_internal_error" = "Intern fejl opstod. Venligt prøv at slette og downloade kortet igen. Hvis problemet vare ved, venligst kontakt os på support@organicmaps.app.";
-
-/* Context menu item for downloader. */
-"downloader_download_map_and_routing" = "Hent kort + ruteangivelse";
-
-/* Context menu item for downloader. */
-"downloader_download_routing" = "Hent ruteangivelse";
-
-/* Context menu item for downloader. */
-"downloader_delete_routing" = "Slet ruteangivelse";
 
 /* Context menu item for downloader. */
 "downloader_download_map" = "Download kortet";
 
-"downloader_download_map_no_routing" = "Download kort uden ruteplanlægning";
-
-/* Button for routing. */
-"routing_go" = "Kør!";
-
 /* Item status in downloader. */
 "downloader_retry" = "Gentag";
-
-/* Item in context menu. */
-"downloader_map_and_routing" = "Kort og rutevejledning";
 
 /* Item in context menu. */
 "downloader_delete_map" = "Slet kort";
@@ -668,29 +435,11 @@
 /* Item in context menu. */
 "downloader_update_map" = "Opdater kort";
 
-/* Item in context menu. */
-"downloader_update_map_and_routing" = "Opdater kort og rutevejledning";
-
-/* Item in context menu. */
-"downloader_map_only" = "Kun kort";
-
-/* Toolbar title */
-"toolbar_application_menu" = "Programmenu";
-
 /* Preference text */
 "pref_use_google_play" = "Anvend Google Play Services til at få din aktuelle placering";
 
 /* Text for rating dialog */
 "rating_just_rated" = "Jeg har netop bedømt jeres app";
-
-/* Text for rating dialog */
-"rating_user_since" = "Jeg er Organic Maps bruger siden %@";
-
-/* Text for rating dialog */
-"rating_do_like_maps" = "Kan du lide Organic Maps?";
-
-/* Text for rating dialog */
-"rating_tap_star" = "Tryk på en stjerne for at bedømme vores app.";
 
 /* Text for rating dialog */
 "rating_thanks" = "Mange tak!";
@@ -701,23 +450,8 @@
 /* Text for rating dialog */
 "rating_send_feedback" = "Send feedback";
 
-/* Text for g+ dialog */
-"rating_google_plus" = "Klik g+ for at fortælle dine venner om app'en.";
-
 /* Text for routing error dialog */
 "routing_download_maps_along" = "Download kort på vejen";
-
-/* Text for routing error dialog */
-"routing_download_map" = "Få kort";
-
-/* Text for routing error dialog */
-"routing_download_map_and_routing" = "Download opdaterede kort og routing data for at få alle Organic Maps funktioner.";
-
-/* Text for routing error dialog */
-"routing_get_routing_data" = "Få routing data";
-
-/* Text for routing error dialog */
-"routing_get_additional_data" = "Yderligere data er påkrævet for at oprette ruter fra din placering.";
 
 /* Text for routing error dialog */
 "routing_requires_all_map" = "Ved at oprette en rute kræver det, at alle kort fra din placering til destination er downloadede og opdaterede.";
@@ -725,50 +459,15 @@
 /* Text for routing error dialog */
 "routing_not_enough_space" = "Ikke nok plads";
 
-/* Text for routing error dialog */
-"routing_download_more_than_avail" = "Du skal downloade %@ MB, men kun %@ MB er tilgængeligt.";
-
-/* Text for routing error dialog */
-"routing_download_roaming" = "Du kommer til at downloade %@ MB ved at bruge mobilt data (i roaming). Dette kan resultere i yderligere omkostninger alt afhængigt din operatørs mobile dataplan.";
-
 /* bookmark button text */
 "bookmark" = "bogmærke";
-
-/* map is not downloaded */
-"not_found_map" = "Kortet for dit område er ikke downloadet";
 
 /* location service disabled */
 "enable_location_services" = "Aktiver venligst lokationstjenester";
 
-/* download map */
-"download_map" = "Download kortet for dit område";
-
-/* download map on iPhone */
-"download_map_iphone" = "Download kortet for din placering til din iPhone";
-
-/* clear pin */
-"nearby" = "I nærheden";
-
-/* clear pin */
-"clear_pin" = "Slet nål";
-
-/* location is undefined */
-"undefined_location" = "Den nuværende placering er ikke defineret.";
-
-/* download country of your location */
-"download_country" = "Download landet bestemt ud fra din nuværende lokation";
-
-/* download failed */
-"download_failed" = "download mislykkedes";
-
-/* get the map */
-"get_the_map" = "Få kort";
-
 "save" = "Gem";
 
 "edit_description_hint" = "Dine beskrivelser (tekst eller html)";
-
-"new_group" = "ny gruppe";
 
 "create" = "skabe";
 
@@ -795,30 +494,6 @@
 
 /* pink color */
 "pink" = "Pink";
-
-/* deep purple color */
-"deep_purple" = "Mørkelilla";
-
-/* light blue color */
-"light_blue" = "Lyseblå";
-
-/* cyan color */
-"cyan" = "Cyan";
-
-/* teal color */
-"teal" = "Blågrøn";
-
-/* lime color */
-"lime" = "Lime";
-
-/* deep orange color */
-"deep_orange" = "Dyb orange";
-
-/* gray color */
-"gray" = "Grå";
-
-/* blue gray color */
-"blue_gray" = "Blågrå";
 
 /* Wi-Fi available */
 "WiFi_available" = "Ja";
@@ -848,13 +523,9 @@
 
 "dialog_routing_location_unknown_turn_on" = "Det lykkedes ikke at finde de aktuelle GPS-koordinater. Slå lokaliseringstjenester til for at beregne en rute.";
 
-"dialog_routing_location_unknown" = "Det lykkedes ikke at finde de aktuelle GPS-koordinater.";
-
 "dialog_routing_download_files" = "Download de nødvendige filer";
 
 "dialog_routing_download_and_update_all" = "Download og opdatér alle kort og ruteoplysninger for at beregne en rute.";
-
-"dialog_routing_routes_size" = "Filer med ruteoplysninger";
 
 "dialog_routing_unable_locate_route" = "Der blev ikke fundet en rute";
 
@@ -884,21 +555,11 @@
 
 "dialog_routing_try_again" = "Prøv igen";
 
-"dialog_routing_send_error" = "Anmeld problemet";
-
-"dialog_routing_if_get_cross_route" = "Ønsker du at planlægge en mere direkte rute, der strækker sig over mere end ét kort?";
-
-"dialog_routing_cross_route_is_optimal" = "Der findes en mere optimal rute, som strækker sig ud over dette korts grænser.";
-
 "not_now" = "Ikke nu";
-
-"dialog_routing_build_route" = "Opret";
 
 "dialog_routing_download_and_build_cross_route" = "Ønsker du at downloade kortet og planlægge en mere optimal rute, der strækker sig over mere end ét kort?";
 
 "dialog_routing_download_cross_route" = "Download kortet for at planlægge en mere optimal rute, der strækker sig ud over dette korts grænser.";
-
-"dialog_routing_cross_route_always" = "Kryds altid denne grænse";
 
 
 /********** Strings for downloading map from search **********/
@@ -906,8 +567,6 @@
 "search_without_internet_advertisement" = "For at begynde at søge efter og oprette ruter bedes du downloade kortet, så du ikke længere har behov for en internetforbindelse.";
 
 "search_select_map" = "Vælk kortet";
-
-"search_select_other_map" = "Vælg et andet kort";
 
 /* «Show» context menu */
 "show" = "Vis";
@@ -918,17 +577,11 @@
 /* «Rename» context menu */
 "rename" = "Omdøb";
 
-/* Bottom sheet: expand button (should be short) */
-"bottom_sheet_more" = "Mere…";
-
 /* Failed planning route message in navigation view */
 "routing_planning_error" = "Ruteplanlægning mislykkedes";
 
 /* Arrive routing message in navigation view */
 "routing_arrive" = "Ankomst: %s";
-
-/* Text for routing::RouterResultCode::FileTooOld dialog. */
-"dialog_routing_download_and_update_maps" = "For at oprette en rute skal du hente og opdatere alle kort langs ruten.";
 
 "rate_alert_title" = "Kan du lide appen?";
 
@@ -944,19 +597,11 @@
 
 "history" = "Historik";
 
-"next_turn_then" = "Så";
-
 "closed" = "Lukket";
-
-"back_to" = "Tilbage til %@";
 
 "search_not_found" = "Desværre, jeg fandt ikke noget.";
 
 "search_not_found_query" = "Prøv en anden forespørgsel.";
-
-"search_not_found_map" = "Download kortet, som du søger i.";
-
-"search_not_found_location" = "Download kortet for din nuværende placering.";
 
 "search_history_title" = "Søgehistorik";
 
@@ -964,23 +609,12 @@
 
 "clear_search" = "Ryd historiksøgning";
 
-/* Title for settings to enable/disable showcase menu button */
-"showcase_settings_title" = "Vis tilbud";
-
 /* Place Page link to Wikipedia article (if map object has it). */
 "read_in_wikipedia" = "Wikipedia";
 
-"p2p_route_planning" = "Ruteplanlægning";
-
 "p2p_your_location" = "Din lokalitet";
 
-"p2p_from" = "Afgangssted";
-
-"p2p_to" = "Bestemmelsesstedet";
-
 "p2p_start" = "Start";
-
-"p2p_planning" = "Planlægger…";
 
 "p2p_from_here" = "Fra";
 
@@ -1018,15 +652,9 @@
 
 "editor_correct_mistake" = "Ret fejl";
 
-"editor_correct_mistake_message" = "Du har lavet en redigeringsfejl. Ret den, eller skift til enkel tilstand.";
-
 "editor_add_select_location" = "Sted";
 
 "editor_done_dialog_1" = "Du har ændret verdenskortet. Lad andre det vide! Fortæl dine venner og redigér det sammen.";
-
-"editor_done_dialog_2" = "Dette er din anden kortforbedring. Nu er du på en %d. plads på listen over kortredaktører. Fortæl dine venner om det.";
-
-"editor_done_dialog_3" = "Du har forbedret kortet, fortæl dine venner om det og redigér kortet sammen.";
 
 "share_with_friends" = "Del med venner";
 
@@ -1044,20 +672,7 @@
 
 "editor_report_problem_duplicate_place_title" = "Duplikeret sted";
 
-"first_launch_congrats_title" = "Organic Maps er klart til brug";
-
-"first_launch_congrats_text" = "Søg og navigér i kort over alle verdens lande gratis.";
-
-"migrate_title" = "Vigtigt!";
-
-/* Android uses image instead of text. */
-"download_all" = "Download alle";
-
-"delete_all" = "Slet alle";
-
 "autodownload" = "Automatisk download";
-
-"disable_autodownload" = "Deaktiver automatisk download";
 
 /* Place Page opening hours text */
 "closed_now" = "Lukket nu";
@@ -1072,10 +687,6 @@
 "day_off" = "Fridag";
 
 "today" = "I dag";
-
-"sunrise_to_sunset" = "Fra solopgang til solnedgang";
-
-"sunset_to_sunrise" = "Fra solnedgang til solopgang";
 
 "add_opening_hours" = "Tilføj arbejdstid";
 
@@ -1095,45 +706,18 @@
 
 "forgot_password" = "Glemt adgangskode?";
 
-/* Forgot Password dialog title */
-"restore_password" = "Genopret adgangskode";
-
-"enter_email_address_to_reset_password" = "Indtast den emailadresse du anvendte under tilmelding, så sender vi dig linket til at forny din adgangskode.";
-
-"reset_password" = "Nulstil adgangskode";
-
-"username" = "Brugernavn";
-
 "osm_account" = "OSM-konto";
 
 "logout" = "Log ud";
 
-"login_and_edit_map_motivation_message" = "Log ind og rediger oplysninger for objekter på kortet, så sørger vi for, at de er tilgængelige for millioner af andre brugere. Lad os sammen gøre verden bedre.";
-
 /* Information text: "Last upload 11.01.2016" */
 "last_upload" = "Sidste overførsel";
 
-/* Motivates user to login/register, title above login buttons. */
-"you_have_edited_your_first_object" = "Du har redigeret dit første objekt!";
-
 "thank_you" = "Mange tak";
-
-"login_with_google" = "Log ind med Google";
-
-"login_with_openstreetmap" = "Log ind med www.openstreetmap.org";
 
 "edit_place" = "Redigér stedet";
 
 "place_name" = "Navn på sted";
-
-/* title above languages list cells in the editor, below editable name text field. */
-"other_languages" = "Andre sprog";
-
-/* small button to open list with names in different languages */
-"show_more" = "Vis mere";
-
-/* small button to close list with names in different languages */
-"show_less" = "Vis mindre";
 
 "add_language" = "Tilføj et sprog";
 
@@ -1164,8 +748,6 @@
 
 "please_note" = "Bemærk venligst";
 
-"common_no_wifi_dialog" = "Ingen WiFi-forbindelse. Vil du fortsætte med mobildata?";
-
 "downloader_delete_map_dialog" = "Alle kortændringer vil blive slettet sammen med kortet.";
 
 "downloader_update_maps" = "Opdatér kort";
@@ -1173,10 +755,6 @@
 "downloader_mwm_migration_dialog" = "For at oprette en rute skal du opdatere alle kort og så planlægge ruten igen.";
 
 "downloader_search_field_hint" = "Find kortet";
-
-"migration_update_all_button" = "Opdatér alle kort";
-
-"migration_delete_all_download_current_button" = "Download aktuelt kort og slet de gamle";
 
 "migration_download_error_dialog" = "Fejl ved download";
 
@@ -1186,21 +764,9 @@
 
 "downloader_no_space_message" = "Fjern unødvendig data";
 
-"editor_general_auth_error_dialog" = "Generel fejl ved login.";
-
 "editor_login_error_dialog" = "Login-fejl.";
 
-"editor_login_failed_dialog" = "Login mislykkedes";
-
-"editor_username_error_dialog" = "Ugyldigt brugernavn";
-
-"editor_place_edited_dialog" = "Du har redigeret et objekt!";
-
-"editor_login_with_osm" = "Login med OpenStreetMap";
-
 "editor_profile_changes" = "Bekræftede ændringer";
-
-"editor_profile_unsent_changes" = "Ikke sendt:";
 
 "editor_focus_map_on_location" = "Træk kortet for at vælge objektets korrekte placering.";
 
@@ -1222,13 +788,9 @@
 
 "editor_report_problem_other_title" = "Et anderledes problem";
 
-"placepage_report_problem_button" = "Anmeld et problem";
-
 "placepage_add_business_button" = "Tilføj organisationen";
 
 "whatsnew_editor_message_1" = "Tilføj nye steder til kortet og redigér eksisterende direkte fra app'en.";
-
-"whatsnew_editor_message_2" = "* Organic Maps bruger fællesskabsdata fra OpenStreetMap.";
 
 "dialog_incorrect_feature_position" = "Skift lokation";
 
@@ -1236,16 +798,10 @@
 
 "login_to_make_edits_visible" = "Log på så andre brugere kan se ændringerne som du har foretaget.";
 
-"no_migration_during_navigation" = "Opdatering er ikke tilladt under navigering.";
-
 /* Error dialog no space */
 "migration_no_space_message" = "For at opdatere app'en skal du bruge mere plads. Slet unødvendig data.";
 
 "editor_sharing_title" = "Jeg forbedrede Organic Maps kortene";
-
-"editor_comment_will_be_sent" = "Vi vil sende dine kommentarer til kartograferne.";
-
-"editor_unsupported_category_message" = "Du har tilføjet en placering i en kategori som vi ikke understøtter på nuværende tidspunkt. Den vil vises på kortet på et senere tidspunkt.";
 
 /* Downloaded 10 **of** 20 <- it is that "of" */
 "downloader_of" = "%1$d af %2$d";
@@ -1278,23 +834,9 @@
 
 "editor_operator" = "Bruger";
 
-"editor_tag_description" = "Angiv firmaet, organisationen eller personen som er ansvarlig for faciliteterne.";
-
-"editor_no_local_edits_title" = "Du har ikke lokale ændringer";
-
-"editor_no_local_edits_description" = "Den viser antallet af dine foreslåede ændringer på kortet, der kun er tilgængelige på din enhed.";
-
-"editor_send_to_osm" = "Send til OSM";
-
-"editor_remove" = "Fjern";
-
-"downloader_my_maps_title" = "Mine kort";
-
 "downloader_no_downloaded_maps_title" = "Du har ikke hentet alle kort";
 
 "downloader_no_downloaded_maps_message" = "Download kort for at finde position og navigere offline.";
-
-"downloader_find_place_hint" = "Søg by eller land";
 
 /* Error title that appears after certain time without location. */
 "current_location_unknown_title" = "Fortsæt med at registrere din aktuelle position?";
@@ -1321,47 +863,13 @@
 /* iOS Dialog for the case when the location permission is not granted */
 "location_services_disabled_3" = "3. Vælg Mens app'en bruges";
 
-"placepage_parking_surface" = "Overflade";
-
-"placepage_parking_multistorey" = "Flere etager";
-
-"placepage_parking_underground" = "Underjordisk";
-
-"placepage_parking_rooftop" = "Tagterrasse";
-
-"placepage_parking_sheds" = "Skure";
-
-"placepage_parking_carports" = "Carporte";
-
-"placepage_parking_boxes" = "Garagekasser";
-
-"placepage_parking_pay" = "Betal";
-
-"placepage_parking_free" = "Gratis";
-
-"placepage_parking_interval" = "Intervalbetaling";
-
-"placepage_entrance_number" = "Nr.";
-
-"placepage_entrance_type" = "Indgang";
-
-"placepage_flat" = "app.";
-
-"placepage_open_24_7" = "24 / 7";
-
 "meter" = "m";
 
 "kilometer" = "km";
 
-"kilometers_per_hour" = "km/t";
-
 "mile" = "mil";
 
 "foot" = "fod";
-
-"miles_per_hour" = "mph";
-
-"day" = "dag";
 
 "hour" = "time";
 
@@ -1381,10 +889,6 @@
 
 "placepage_bookmark_name_hint" = "Bogmærke";
 
-"placepage_personal_notes_hint" = "Personlige notater";
-
-"placepage_delete_bookmark_button" = "Slet bogmærke";
-
 "editor_edits_sent_message" = "Dine foreslåede ændringer er blevet sendt";
 
 "editor_comment_hint" = "Kommentar…";
@@ -1397,8 +901,6 @@
 
 "editor_remove_place_button" = "Fjern";
 
-"editor_status_sending" = "Send…";
-
 "editor_place_doesnt_exist" = "Stedet eksisterer ikke";
 
 "text_more_button" = "…mere";
@@ -1410,11 +912,7 @@
 
 "error_enter_correct_email" = "Indtast en gyldig emailadresse";
 
-"error_enter_correct" = "Indtast en gyldig værdi";
-
 "refresh" = "Opdater";
-
-"last_update" = "Sidste opdatering: %s";
 
 "placepage_add_place_button" = "Tilføj et sted på kortet";
 
@@ -1426,24 +924,6 @@
 
 "editor_share_to_all_dialog_message_2" = "Vi vil kigge på ændringerne. Hvis vi har spørgsmål, vil vi kontakte dig via email.";
 
-"navigation_overview_button" = "oversigt";
-
-"navigation_stop_button" = "stop";
-
-/* Text on an empty bookmark page */
-"bookmarks_empty_title" = "Gem bogmærker";
-
-"bookmarks_empty_message_1" = "Tryk på ★ for at gemme foretrukne steder til hurtig adgang.";
-
-"bookmarks_empty_message_2" = "Importer bogmærker fra email og web.";
-
-"bookmarks_empty_message_3" = "tjek ud: %s";
-
-/* Name of the group for booked hotels */
-"bookmarks_group_name" = "Bookede hoteller";
-
-"place_page_button_read_descriprion" = "Læs";
-
 /* iOS dialog for the case when recent track recording is on and the app comes back from background */
 "recent_track_background_dialog_title" = "Vil du deaktivere gemningen af din seneste rejserute?";
 
@@ -1451,8 +931,6 @@
 
 /* For sharing via SMS and so on */
 "sharing_call_action_look" = "Tjek";
-
-"continue_recent_track_background_button" = "Fortsæt";
 
 "recent_track_background_dialog_message" = "Organic Maps anvender din geoposition i baggrunden til at gemme din seneste rejserute.";
 
@@ -1468,33 +946,13 @@
 /* About short text (below logo) */
 "about_description" = "Organic Maps er en essentiel offline-app for rejsende. Organic Maps er baseret på data fra OpenStreetMap, og gør det muligt at redigere disse data.";
 
-/* Text in menu */
-"blog" = "Blog";
-
 "general_settings" = "Generelle indstillinger";
-
-"date" = "Dato %d";
-
-/* "Report a bug" -> "Generaal Feedback" -> "Something is not working" */
-"something_is_not_working" = "Der er noget der ikke fungerer";
 
 /* For the first routing */
 "accept" = "Accepter";
 
-"accept_and_continue" = "Accept and continue";
-
 /* For the first routing */
 "decline" = "Afvis";
-
-"install_app" = "Installer";
-
-"search_no_results_title" = "Ingen resultater fundet";
-
-"search_no_results_message" = "Prøv et mere generelt søgeudtryk, zoom ud eller nulstil filteret.";
-
-"search_no_results_expand_area_button" = "Zoom ud";
-
-"search_no_results_reset_button" = "Nulstil Filter";
 
 /* noun */
 "search_in_table" = "Liste";
@@ -1517,8 +975,6 @@
 
 "traffic_update_maps_text" = "Kortet opdateres for kunne vise trafikdata.";
 
-"traffic_outdated" = "Trafikdata er forældede.";
-
 "big_font" = "Forøg skriftstørrelsen på kortet";
 
 "traffic_update_app" = "Opdater Organic Maps";
@@ -1529,17 +985,7 @@
 /* "traffic" as in "road congestion" */
 "traffic_data_unavailable" = "Trafikdata er ikke tilgængelige";
 
-/* "Translation is no needed, because it's a company name" */
-"uber" = "Uber";
-
-/* Simplified colour scheme for traffic information, fewer colours are used to display traffic jams on the map. The string should be kept as short as possible */
-"pref_traffic_simplified_colors_title" = "Forenklede trafikfarver";
-
 "enable_logging" = "Aktiver logføring";
-
-"offline_place_page_more_information" = "Opret forbindelse til internettet for at få flere oplysninger om stedet.";
-
-"failed_load_information" = "Kunne ikke indlæse oplysningerne.";
 
 /* Settings: "Send general feedback" button */
 "feedback_general" = "Generel feedback";
@@ -1556,8 +1002,6 @@
 
 "whatsnew_transliteration_title" = "Translitteration til latinsk";
 
-"yandex_taxi_title" = "Yandex.Taxi";
-
 "learn_more" = "Flere oplysninger";
 
 "core_exit" = "Afslut";
@@ -1568,75 +1012,19 @@
 
 "button_exit" = "Afslut";
 
-"settings_device_memory" = "Enhedens hukommelse";
-
-"settings_card_memory" = "Kortets hukommelse";
-
-"settings_storage_available" = "%s tilgængelig";
-
-"toast_location_permission_denied" = "App-position tilladelse nægtet";
-
-"button_use" = "Brug";
-
 "planning_route_manage_route" = "Administrer rute";
 
 "button_plan" = "Planlæg";
-
-"button_add" = "Tilføj";
 
 "placepage_remove_stop" = "Fjern";
 
 "planning_route_remove_title" = "Træk herhen for at fjerne";
 
-"dialog_change_start_point_message" = "Flyt startpunktet til den aktuelle placering?";
-
-"button_replace" = "Flyt";
-
 "placepage_add_stop" = "Tilføj stop";
-
-/* Only ru/en are needed */
-"subtitle_rent" = "Rent";
-
-/* Only ru/en are needed */
-"rub_month" = "RUB/month";
-
-/* Only ru/en are needed */
-"room" = "%s-room apt.";
-
-/* Only ru/en are needed */
-"real_estate" = "Real estate";
-
-"add_my_position" = "Tilføj min position";
-
-"choose_start_point" = "Vælg et udgangspunkt";
-
-"choose_destination" = "Vælg en destination";
 
 "preloader_viator_button" = "Flere oplysninger";
 
-"start_from_my_position" = "Start fra";
-
-"profile_authorization_title" = "Log ind med";
-
-"profile_authorization_message" = "Nemt login på et par sekunder uden brugernavn og adgangskode";
-
 "profile_authorization_error" = "Ups, der skete en fejl. Prøv at logge på igen.";
-
-"service" = "Service";
-
-"atmosphere" = "Atmosfære";
-
-"value_for_money" = "Værdi for pengene";
-
-"experience" = "Erfaring";
-
-"assortment" = "Udvalg";
-
-"expertise" = "Ekspertise";
-
-"equipment" = "Udstyr";
-
-"quality" = "Kvalitet";
 
 "dialog_error_storage_title" = "Problem med lageradgang";
 
@@ -1644,17 +1032,7 @@
 
 "setting_emulate_bad_storage" = "Emulere beskadiget lager";
 
-"directions_finish" = "Destination";
-
-"directions_on_foot" = "Gå %s";
-
 "core_entrance" = "Indgang";
-
-"coffee" = "Kaffe";
-
-"cleanliness" = "Renlighed";
-
-"crowdedness" = "Trængsel";
 
 "error_enter_correct_name" = "Angiv et korrekt navn";
 
@@ -1673,11 +1051,9 @@
 
 "downloader_percent" = "%s (%s af %s)";
 
-"downloader_process" = "Downloader %s...";
+"downloader_process" = "Downloader %s…";
 
-"downloader_applying" = "Anvender %s...";
-
-"dialog_message_transit_not_found_connection" = "Planlæg en rute inden for et transitnetværk";
+"downloader_applying" = "Anvender %s…";
 
 "bookmarks_error_message_share_general" = "Ikke i stand til at dele på grund af en programfejl";
 
@@ -1695,17 +1071,7 @@
 
 "bookmarks_error_message_list_name_already_taken" = "Vælg venligst et andet navn";
 
-"bookmarks_error_title_list_name_too_long" = "Dette navn er for langt";
-
-"bookmarks_error_message_list_name_too_long" = "Vælg venligst et andet navn";
-
-"please_wait" = "Vent venligst...";
-
-"phone_number" = "Telefonnummer";
-
-"notification_unsent_reviews_title" = "Du har flere usendte anmeldelser";
-
-"notification_unsent_reviews_message" = "Venligst log ind for at dele anmeldelser med andre rejsende";
+"please_wait" = "Vent venligst…";
 
 "profile" = "OpenStreetMap profil";
 
@@ -1719,49 +1085,13 @@
 
 "bookmarks_convert_error_message" = "Nogle filer blev ikke konverteret.";
 
-"converting" = "Konvertering...";
-
-"wn_reinvented_bookmarks_title" = "Vi genopfandt bogmærker!";
-
-"wn_reinvented_bookmarks_message" = "Du kan sikkerhedskopiere bogmærker, oprette lister... Det er fantastisk...";
-
-"bookmarks_restore" = "Gendan bogmærker";
-
-"bookmarks_restore_process" = "Gendannelse...";
-
 "bookmarks_restore_title" = "Gendan denne version?";
 
-"bookmarks_restore_message" = "Dine bogmærker gendannes fra %s (%s)";
-
-"bookmarks_restore_empty_title" = "Du har ikke en sikkerhedskopi";
-
-"bookmarks_restore_empty_message" = "Serveren fandt ikke tidligere sikkerhedskopier";
-
 "common_check_internet_connection_dialog_title" = "Ingen internetforbindelse";
-
-"error_server_title" = "Server Fejl";
-
-"error_server_message" = "Der opstod en fejl på serveren, prøv igen senere";
 
 "error_system_message" = "Der opstod en ukendt fejl";
 
 "restore" = "Gendan";
-
-"bookmarks_page_downloaded" = "Downloadet";
-
-"bookmarks_page_my" = "Mine";
-
-"routes_and_bookmarks" = "Ruter og bogmærker";
-
-"bookmarks_webview_success_toast" = "Bogmærker er downloadet";
-
-"cached_bookmarks_placeholder_title" = "Download nye steder";
-
-"cached_bookmarks_placeholder_subtitle" = "Tryk på knappen for at downloade tusindvis af interessanter steder og ruter oprettet af brugerne på Organic Maps. Du skal bruge en internetforbindelse.";
-
-"downloader_download_routers" = "Download bogmærker";
-
-"bookmarks_groups_cached" = "Downloadede lister";
 
 "subtittle_opt_out" = "Tracking-indstillinger";
 
@@ -1769,29 +1099,15 @@
 
 "crash_reports_description" = "Vi kan anvende dine data til at forbedre brugeroplevelsen på Organic Maps. Ændringerne træder i kraft, når du har genstartet appen.";
 
-"opt_out_help_ios_1" = "Din mobilenhed kan indeholde en »Begræns reklamesporing« eller »Afmeld Tilpasset annoncering« indstiling.";
-
-"opt_out_help_ios_2" = "iOS 9 eller højere";
-
-"opt_out_help_ios_3" = "Gå til Indstillinger → Generelt → Begræsninger → Reklamer → Aktiver »Begræns reklamesporing« funktionen";
-
-"opt_out_help_android" = "Din mobilenhed kan indeholde en »Begræns reklamesporing« eller »Afmeld Tilpasset annoncering« indstilling.\n\nPå Android og Google Play Services version 4.0 og op:\nIndstillinger → Google → Annoncer→ Afmeld Tilpasset annoncering\nor\nIndstillinger → Google → Google Account → Data og tilpasning → Annoncetilpasning → Annoncetilpasning";
-
 "privacy_policy" = "Privatlivspolitik";
 
 "terms_of_use" = "Vilkår for bruger";
-
-"backup_notification_failed" = "Backup af dine bogmærker er blevet suspenderet. Log ind for at slå til igen.";
 
 "button_layer_traffic" = "Trafik";
 
 "button_layer_subway" = "Undergrundsbane";
 
 "layers_title" = "Kortlag";
-
-"layers_message" = "Brug kortlag til at vise trafik, kort over undergrundbaner og andre nyttige oplysninger";
-
-"button_layer_got_it" = "Ok";
 
 "subway_data_unavailable" = "Kort over undergrundsbaner er ikke tilgængeligt";
 
@@ -1803,39 +1119,13 @@
 
 "title_error_downloading_bookmarks" = "Der er opstået en fejl";
 
-"subtitle_error_downloading_bookmarks" = "Bogmærker er ikke blevet downloadet";
-
-"error_already_downloaded" = "Denne liste er allerede blevet downloadet";
-
 "popular_place" = "Popular";
-
-"download_routes" = "Download routes";
-
-"bookmarks_downloaded_title" = "Bookmarks have been downloaded successfully";
-
-"bookmarks_downloaded_subtitle" = "Press ‘View on map’ to explore new places from the list";
-
-"why_support" = "Hvorfor støtte Organic Maps?";
-
-"why_support_item1" = "We respect your privacy: there are zero trackers in the app, and we are open source";
-
-"why_support_item2" = "Du hjælper os med at forbedre Organic Maps";
-
-"why_support_item3" = "Du hjælper os med at forbedre de åbne kort på OpenStreetMap.org";
-
-"channels_map_update" = "Kortopdateringer";
-
-"server_unavailable_title" = "Server er utilgængelig";
-
-"sharing_options" = "Deling";
 
 "export_file" = "Eksporter fil";
 
 "list_settings" = "Listeindstillinger";
 
 "delete_list" = "Slet liste";
-
-"hide_from_map" = "Skjul på kort";
 
 "public_access" = "Offentlig adgang";
 
@@ -1845,40 +1135,11 @@
 
 "bookmark_category_description_hint" = "Lav en beskrivelse (tekst eller html)";
 
-/* FIXME */
-"bookmarks_public_access" = "bookmarks_public_access";
-
-/* FIXME */
-"bookmarks_link_access" = "bookmarks_link_access";
-
-/* FIXME */
-"bookmarks_private_access" = "bookmarks_private_access";
-
 "not_shared" = "Privat";
-
-"direct_link_progress_text" = "Uploader din fil…";
-
-"direct_link_success" = "Linket er blevet oprettet";
-
-"send_a_link_btn" = "Send mig et link";
-
-"upload_error_toast" = "Der skete en fejl under upload af filen";
 
 "tags_loading_error_subtitle" = "Der skete en fejl under hentning af tags, prøv igen";
 
-"unable_upload_errorr_title" = "Upload af fil fejlede";
-
-"unable_upload_error_subtitle_edited" = "Denne fil er redigeret ved hjælp af web-appen";
-
-"unable_upload_error_subtitle_broken" = "Denne fil er beskadiget og kunne ikke uploades. Upload venligst en anden fil.";
-
-"contact" = "Kontakt";
-
-"download_button" = "Download";
-
 "speedcams_alert_title" = "Fartkameraer";
-
-"speedcams_alert_subtitle" = "Advar om hastighedsgrænser";
 
 "speedcam_option_auto" = "Auto";
 
@@ -1886,18 +1147,10 @@
 
 "speedcam_option_never" = "Aldrig";
 
-"bookmark_description_title" = "Beskrivelse af bogmærke";
-
 "place_description_title" = "Beskrivelse af sted";
 
 /* this text will be shown in application notification preferences opposite checkbox which enable/disable downloader notifications. Devices on Android 8+ are affected. */
 "notification_channel_downloader" = "Korthenter";
-
-"share_bookmarks_email_body_link" = "Hej!\n\nHer er et link, hvor du kan hente dine bogmærker: %s. Åben listen via Organic Maps og nyd turen!\n\nHent applikation: https://omaps.app/get?kmz";
-
-"warning_speedcams_title" = "Navigator advarer dig om kameraer, når du overskrider hastighedsgrænsen på %d km/t";
-
-"warning_speedcams_subtitle" = "Vær opmærksom på færdselsreglerne i det land, du rejser til.";
 
 "speedcams_notice_message" = "Auto - Advar om fartkameraer, hvis der er en risiko for, at hastighedsgrænsen overskrides\nAltid - Advar altid om fartkameraer\nAldrig - Advar aldrig om fartkameraer";
 
@@ -1913,23 +1166,7 @@
 
 "enable_logging_warning_message" = "Indstillingen aktiverer logning til diagnostiske formål. Det kan være nyttigt for vores supportere, der fejlfinder problemer med appen. Aktiver kun denne mulighed på anmodning fra Organic Maps support.";
 
-"html_error_upload_message_try_again" = "Kontroller dine netværksindstillinger, og prøv igen";
-
-"html_error_upload_title_try_again" = "Ingen internetforbindelse";
-
-"notification_leave_review_v2_android_short_title" = "Anmeld og hjælpe rejsende!";
-
-"megafon" = "Say goodbye to roaming!";
-
-"notifications_illegal_alert_disable_button" = "Slå fra meddelelser";
-
 "access_rules_author_only" = "Online redigering";
-
-"privacy_settings_menu" = "Indstillinger for beskyttelse af personlige oplysninger";
-
-"unable_upadate_error_title" = "Fil opdatering fejlede";
-
-"unable_upadate_error_message" = "Der opstod nogle fejl under opdatering. Kontroller ændringerne, og prøv igen";
 
 "driving_options_title" = "Køre muligheder";
 
@@ -1951,94 +1188,19 @@
 
 "change_driving_options_btn" = "Køre muligheder aktiveret";
 
-"toll_road" = "Betalingsvej";
-
-"unpaved_road" = "Grusvej";
-
-"ferry_crossing" = "Færgeoverfart";
-
-"operated_by" = "Drives af \"%s\"";
-
 "avoid_toll_roads_placepage" = "Undgå betalingsveje";
 
 "avoid_unpaved_roads_placepage" = "Undgå grusveje";
 
 "avoid_ferry_crossing_placepage" = "Undgå færgeoverfarter";
 
-"type.cuisine.uzbek" = "Usbekisk køkken";
-
-"trip_start" = "Lad os komme i gang";
-
-"pick_destination" = "Destination";
-
-"follow_my_position" = "Centrer igen";
-
-"search_results" = "Søgeresultater";
-
-"then_turn" = "Derefter";
-
-"redirect_route_alert" = "Vil du genopbygge en rute igen?";
-
-"redirect_route_yes" = "Ja";
-
-"redirect_route_no" = "Nej";
-
-"trip_finished" = "Du er ankommet!";
-
-"keyboard_availability_alert" = "Keyboard er ikke tilgængelig under kørsel";
-
-"dialog_routing_change_start_carplay" = "Det er ikke muligt at beregne rute fra din nuværende position";
-
-"dialog_routing_change_end_carplay" = "Det er ikke muligt at beregne rute til din destination. Vælg en anden destination";
-
-"dialog_routing_check_gps_carplay" = "Intet GPS signal. Flyt til et område med dækning";
-
-"dialog_routing_unable_locate_route_carplay" = "Det er ikke muligt at beregne rute. Vælg andre forbindelses-punkter for ruten";
-
-"dialog_routing_download_files_carplay" = "Download manglende kort til din enhed, for at lave ruten";
-
-"dialog_routing_system_error_carplay" = "Der opstod en fejl. Genstart programmet";
-
-"dialog_routing_rebuild_from_current_location_carplay" = "Rute vil blive beregnet igen, ud fra din nuværende position";
-
-"dialog_routing_rebuild_for_vehicle_carplay" = "Rute vil blive ændret til en kørselsrute";
-
 "ok" = "Ok";
-
-"avoid_unpaved_carplay_1" = "Ingen grus";
-
-"avoid_unpaved_carplay_2" = "Undgå grus";
-
-"avoid_ferry_carplay_1" = "Ingen færger";
-
-"avoid_ferry_carplay_2" = "Undgå færger";
-
-"avoid_tolls_carplay_1" = "Ingen betal.";
-
-"avoid_tolls_carplay_2" = "Undgå betaling";
-
-"speedcams_alert_title_carplay_1" = "Radarkontrol";
-
-"speedcams_alert_title_carplay_2" = "Radar advarsel";
-
-"download_map_carplay" = "Download kort i Organic Maps appen, på din enhed";
-
-"carplay_roundabout_exit" = "%s exit";
 
 /* max. 10 symbols, both iOS and Android */
 "sort" = "Sort…";
 
 /* Android, title, max 20-22 symbols */
 "sort_bookmarks" = "Sort (bookmaarks)";
-
-/* iOS */
-"sort_default" = "Sortér (std)";
-
-"sort_type" = "Sort (type)";
-
-"sort_distance" = "Sort (Afs)";
-
-"sort_date" = "Sort (dato)";
 
 /* Android */
 "by_default" = "Som standard";
@@ -2052,63 +1214,7 @@
 /* Android */
 "by_date" = "Efter dato";
 
-"week_ago_sorttype" = "En uge siden";
-
-"month_ago_sorttype" = "En måned siden";
-
-"moremonth_ago_sorttype" = "Mere end en måned siden";
-
-"moreyear_ago_sorttype" = "Mere end et år siden";
-
-"near_me_sorttype" = "I nærheden";
-
-"others_sorttype" = "Andre";
-
-"food_places" = "Mad";
-
-"tourist_places" = "Seværdigheder";
-
-"museums" = "Museer";
-
-"parks" = "Parker";
-
-"swim_places" = "Svøm";
-
-"mountains" = "Bjerge";
-
-"animals" = "Dyr";
-
-"hotels" = "Hoteller";
-
-"buildings" = "Bygninger";
-
-"money" = "Penge";
-
-"shops" = "Butikker";
-
-"parkings" = "Parkering";
-
-"fuel_places" = "Benzintankstationer";
-
-"water" = "Vand";
-
-"medicine" = "Medicin";
-
 "search_in_the_list" = "Søg i listen";
-
-"view_on_map_bookmarks" = "På kort";
-
-"more_bookmarks" = "Mere…";
-
-"no_items_found" = "Der blev ikke fundet nogen elementer";
-
-/* Android, max 18 symbols */
-"bookmarks_edit_list" = "Redigér liste";
-
-/* Android, max 18 symbols */
-"bookmarks_delete_list" = "Slet liste";
-
-"religious_places" = "Religiøse steder";
 
 "select_list" = "Væg liste";
 
@@ -2118,26 +1224,13 @@
 
 "dialog_pedestrian_route_is_long_message" = "Vælg venligst et start- eller stoppunkt, tættere på metrostationen";
 
-/* Failed planning SUBWAY route message in navigation view */
-"routing_planning_error_subway_special" = "Planlægning af metro-rute mislykkedes";
-
 "button_layer_isolines" = "Terræn";
-
-"tips_map_layers_title_countour" = "Nyt på Organic Maps: offline topografiske lag!";
-
-"tips_map_layers_message_countour" = "Planlæg og nyd din naturtur ved at være sikker på, at du ved alt om området";
 
 "isolines_activation_error_dialog" = "For at aktivere og bruge de topografiske lag, opdater venligst eller download kortet for området";
 
 "isolines_location_error_dialog" = "Det topografiske lag er endnu ikke tilgængeligt i dette område";
 
 "elevation_profile_diff_level" = "Sværhedsgrad";
-
-"elevation_profile_diff_level_easy" = "Let";
-
-"elevation_profile_diff_level_moderate" = "Middel";
-
-"elevation_profile_diff_level_hard" = "Svær";
 
 "elevation_profile_ascent" = "Stige op";
 
@@ -2147,25 +1240,13 @@
 
 "elevation_profile_maxaltitude" = "Maks. højde";
 
-"elevation_profile_m" = "m";
-
 "elevation_profile_difficulty" = "Vanskelighed";
 
 "elevation_profile_distance" = "Afs.:";
 
-"elevation_profile_km" = "km";
-
 "elevation_profile_time" = "Tid:";
 
-"elevation_profile_hours" = "t.";
-
-"elevation_profile_minutes" = "min";
-
 "isolines_toast_zooms_1_10" = "Zoom ind for at udforske isolinjekort";
-
-"downloader_updating_ios" = "Opdaterer";
-
-"downloader_loading_ios" = "Downloader";
 
 "key_information_title" = "Central information";
 

--- a/iphone/Maps/LocalizedStrings/da.lproj/Localizable.stringsdict
+++ b/iphone/Maps/LocalizedStrings/da.lproj/Localizable.stringsdict
@@ -9,21 +9,6 @@
 
 <!-- ********** Strings for downloading map from search **********/ -->
 
-  <key>bookmarks_places</key>
-  <dict>
-    <key>NSStringLocalizedFormatKey</key>
-    <string>%#@value@</string>
-    <key>value</key>
-    <dict>
-      <key>NSStringFormatSpecTypeKey</key>
-      <string>NSStringPluralRuleType</string>
-      <key>NSStringFormatValueTypeKey</key>
-      <string>d</string>
-      <key>other</key>
-      <string>%d bogmærker</string>
-    </dict>
-  </dict>
-
   <key>bookmarks_detect_message</key>
   <dict>
     <key>NSStringLocalizedFormatKey</key>
@@ -38,21 +23,6 @@
       <string>%d fil blev fundet. Du vil se det efter konvertering.</string>
       <key>other</key>
       <string>Der er fundet %d filer. Du vil se dem efter konvertering.</string>
-    </dict>
-  </dict>
-
-  <key>bookmarks_objects</key>
-  <dict>
-    <key>NSStringLocalizedFormatKey</key>
-    <string>%#@value@</string>
-    <key>value</key>
-    <dict>
-      <key>NSStringFormatSpecTypeKey</key>
-      <string>NSStringPluralRuleType</string>
-      <key>NSStringFormatValueTypeKey</key>
-      <string>d</string>
-      <key>other</key>
-      <string>%s objekt</string>
     </dict>
   </dict>
 

--- a/iphone/Maps/LocalizedStrings/de.lproj/Localizable.strings
+++ b/iphone/Maps/LocalizedStrings/de.lproj/Localizable.strings
@@ -18,9 +18,6 @@
 /* Button which deletes downloaded country */
 "delete" = "Löschen";
 
-/* Button "do not interrupt download" if user touched actively downloading country */
-"do_nothing" = "Herunterladen fortsetzen";
-
 "download_maps" = "Karten herunterladen";
 
 /* Settings/Downloader - info for country when download fails */
@@ -28,9 +25,6 @@
 
 /* Settings/Downloader - info for country which started downloading */
 "downloading" = "Wird heruntergeladen…";
-
-/* Settings/Downloader - size string, only strings different from English should be translated */
-"kb" = "kB";
 
 /* Choose measurement on first launch alert - choose metric system button */
 "kilometres" = "Kilometer";
@@ -55,17 +49,11 @@
 /* Update maps later/Buy pro version later button text */
 "later" = "Später";
 
-/* Don't show some dialog any more */
-"never" = "Nie";
-
 /* View and button titles for accessibility */
 "search" = "Suche";
 
 /* Search box placeholder text */
 "search_map" = "Auf der Karte suchen";
-
-/* Settings/Downloader - info for not downloaded country */
-"touch_to_download" = "Antippen, um herunterzuladen";
 
 /* Settings/Downloader - 3G download warning dialog confirm button */
 "use_cellular_data" = "Ja";
@@ -73,20 +61,11 @@
 /* Location services are disabled by user alert - message */
 "location_is_disabled_long_text" = "Ortungsdienste sind für dieses Gerät oder die App deaktiviert. Bitte aktivieren Sie diese in den Einstellungen.";
 
-/* Location Services are not available on the device alert - message */
-"device_doesnot_support_location_services" = "Ihr Gerät unterstützt keine Ortungsdienste";
-
 /* View and button titles for accessibility */
 "zoom_to_country" = "Auf der Karte anzeigen";
 
-/* Button text for the button at the center of the screen when the country is not downloaded */
-"country_status_download" = "Karte herunterladen\n(^ ^)";
-
 /* Button text for the button at the center of the screen when the country is not downloaded and the size should not be shown */
 "country_status_download_without_size" = "Karte herunterladen";
-
-/* Button text for the button at the center of the screen when the country is not downloaded */
-"country_status_download_without_routing" = "Karte ohne Routenplanung\nherunterladen (^ ^)";
 
 /* Message to display at the center of the screen when the country download has failed */
 "country_status_download_failed" = "Herunterladen fehlgeschlagen";
@@ -96,19 +75,13 @@
 
 "about_menu_title" = "Über Organic Maps";
 
-"downloaded_touch_to_delete" = "Heruntergeladen (%@). Antippen, um zu löschen";
-
 "connection_settings" = "Verbindungseinstellungen";
-
-"download_mb_or_kb" = "Herunterladen %@";
 
 "close" = "Schließen";
 
 "unsupported_phone" = "Das Programm benötigt OpenGL, um zu funktionieren. Leider wird Ihr Gerät nicht unterstützt.";
 
 "download" = "Herunterladen";
-
-"external_storage_is_not_available" = "SD-Karte/USB-Speicher mit heruntergeladenen Karten nicht verfügbar";
 
 "disconnect_usb_cable" = "Bitte USB-Kabel entfernen oder Speicherkarte einsetzen, um Organic Maps zu verwenden";
 
@@ -117,8 +90,6 @@
 "not_enough_memory" = "Nicht genügend Speicher, um die Anwendung zu starten";
 
 "download_resources" = "Bevor Sie starten, laden Sie die allgemeine Weltkarte auf Ihr Gerät herunter.\nEs wird %@ Speicherplatz benötigt.";
-
-"getting_position" = "Ermittle momentane Position";
 
 "download_resources_continue" = "Zur Karte";
 
@@ -140,23 +111,14 @@
 /* Add New Bookmark Set dialog title */
 "add_new_set" = "Neue Gruppe hinzufügen";
 
-/* Place Page - Add To Bookmarks button */
-"add_to_bookmarks" = "Zu den Lesezeichen hinzufügen";
-
 /* Bookmark Color dialog title */
 "bookmark_color" = "Lesezeichen-Farbe";
 
 /* Add Bookmark Set dialog - hint when set name is empty */
 "bookmark_set_name" = "Name des Lesezeichens";
 
-/* Bookmark Sets dialog title */
-"bookmark_sets" = "Lesezeichenmappe";
-
 /* Bookmarks - dialog title */
 "bookmarks" = "Lesezeichengruppen";
-
-/* Add bookmark dialog - bookmark color */
-"color" = "Farbe";
 
 /* Default bookmarks set name */
 "core_my_places" = "Meine Orte";
@@ -167,14 +129,8 @@
 /* Editor title above street and house number */
 "address" = "Adresse";
 
-/* Place Page - Remove Pin button */
-"remove_pin" = "Stecknadel entfernen";
-
 /* Add bookmark dialog - bookmark set, Bookmarks dialog - Bookmark set cell */
 "set" = "Gruppe";
-
-/* Text hint in Bookmarks dialog when no any bookmarks are added */
-"bookmarks_usage_hint" = "Sie haben bislang noch keine Lesezeichen gesetzt.\nTippen Sie auf der Karte auf irgendeinen Punkt, um ein Lesezeichen hinzuzufügen.\nLesezeichen von anderen Quellen können ebenfalls importiert und in der Organic Maps-App angezeigt werden. KML-/KMZ-Datei mit gespeicherten Stecknadeln aus einer Email, Dropbox oder einem Weblink öffnen.";
 
 /* Settings button in system menu */
 "settings" = "Einstellungen";
@@ -191,26 +147,11 @@
 /* Ask to wait user several minutes (some long process in modal dialog). */
 "wait_several_minutes" = "Dies kann einige Minuten in Anspruch nehmen.\nBitte warten…";
 
-/* Show bookmarks from this category on a map or not */
-"visible" = "Sichtbar";
-
-/* Toast which is displayed when GPS has been deactivated */
-"gps_is_disabled_long_text" = "GPS ist deaktiviert. Bitte aktivieren Sie es in den Einstellungen.";
-
 /* Measurement units title in settings activity */
 "measurement_units" = "Maßeinheiten";
 
 /* Detailed description of Measurement Units settings button */
 "measurement_units_summary" = "Wählen Sie zwischen Kilometern und Meilen";
-
-/* Do search in all sources */
-"search_mode_all" = "Überall";
-
-/* Do search near my position only */
-"search_mode_nearme" = "In meiner Nähe";
-
-/* Do search in current viewport only */
-"search_mode_viewport" = "Auf dem Bildschirm";
 
 /* Search category for cafes, bars, restaurants */
 "eat" = "Essmöglichkeiten";
@@ -266,14 +207,8 @@
 /* Search category */
 "police" = "Polizeistation";
 
-/* String in search result list, when nothing found */
-"no_search_results_found" = "Keine Ergebnisse gefunden";
-
 /* Notes field in Bookmarks view */
 "description" = "Notizen";
-
-/* Button text */
-"share_by_email" = "Per Email teilen";
 
 /* Email Subject when sharing bookmarks category */
 "share_bookmarks_email_subject" = "Organic Maps-Lesezeichen mit Ihnen geteilt";
@@ -295,26 +230,11 @@
 /* Warning message when doing search around current position */
 "unknown_current_position" = "Ihr Standort konnte noch nicht ermittelt werden";
 
-/* Warning message when location country isn't downloaded during search (see also download_location_map_proposal). */
-"download_location_country" = "Land Ihres derzeitigen Standorts herunterladen (%@)";
-
-/* Warning message when viewport country isn't downloaded during search */
-"download_viewport_country_to_search" = "Land herunterladen, in dem Sie suchen (%@)";
-
 /* Alert message that we can't run Map Storage settings due to some reasons. */
 "cant_change_this_setting" = "Leider sind die Einstellungen für die Kartenspeicherung deaktiviert.";
 
 /* Alert message that downloading is in progress. */
 "downloading_is_active" = "Das Land wird gerade heruntergeladen.";
-
-/* Message that will be shown in alert view, when we ask user to leave review on App Store */
-"appStore_message" = "Wir hoffen, dass Ihnen die Verwendung von Organic Maps Freude bereitet! Wenn ja, geben Sie bitte eine Bewertung oder einen Bericht für die App im App Store ab. Es dauert weniger als eine Minute, kann uns aber wirklich helfen. Danke für Ihre Unterstützung!";
-
-/* No, thanks */
-"no_thanks" = "Nein danke";
-
-/* Share one specific bookmark using SMS, %1$@ contains om:// and %2$@ https://omaps.app link. @NOTE non-ascii symbols in the link will result in max 70 characters SMS instead of 140. */
-"bookmark_share_sms" = "Siehe meine Markierung auf Organic Maps an. %1$@ oder %2$@ - Keine Offline-Karten installiert? Hier herunterladen: https://omaps.app/get";
 
 /* Share my position using SMS, %1$@ contains om:// and %2$@ https://omaps.app link WITHOUT NAME. @NOTE non-ascii symbols in the link will result in max 70 characters SMS instead of 140. */
 "my_position_share_sms" = "Schau wo ich gerade bin. Klicke auf den Link %1$@ oder %2$@ - Keine Offline-Karten installiert? Hier herunterladen: https://omaps.app/get";
@@ -328,23 +248,11 @@
 /* Share my position using EMail, %1$@ is om:// and %2$@ is https://omaps.app link WITHOUT NAME */
 "my_position_share_email" = "Hi,\n\nich bin gerade hier: %1$@. Klicke den Link %2$@ oder %3$@, um den Ort auf der Karte anzuzeigen.\n\nVielen Dank.";
 
-/* Android share by Message/SMS button text (including SMS) */
-"share_by_message" = "Als Nachricht teilen";
-
 /* Share button text which opens menu with more buttons, like Message, EMail, Facebook etc. */
 "share" = "Teilen";
 
-/* iOS share by Message button text (including SMS) */
-"message" = "Nachricht";
-
 /* Share by email button text, also used in editor. */
 "email" = "Email";
-
-/* Copy Link */
-"copy_link" = "Link kopieren";
-
-/* Text for the button that returns to caller application */
-"more_info" = "Weitere Infos anzeigen";
 
 /* Text for message when used successfully copied something */
 "copied_to_clipboard" = "In die Zwischenablage kopiert: %1$@";
@@ -354,15 +262,6 @@
 
 /* Used for bookmark editing */
 "done" = "Fertig";
-
-/* Summary for preferences in MWM */
-"yopme_pref_summary" = "Einstellungen für den rückseitigen Bildschirm wählen";
-
-/* Title for yopme preferences in MWM */
-"yopme_pref_title" = "Einstellungen für rückseitigen Bildschirm";
-
-/* Hint for upper-right icon p2b */
-"show_on_backscreen" = "Auf dem rückseitigen Bildschirm anzeigen";
 
 /* Prints version number in About dialog */
 "version" = "Version: %@";
@@ -381,19 +280,11 @@
 
 "share_my_location" = "Meinen Standort teilen";
 
-"menu_search" = "Suche";
-
 /* Settings general group in settings screen */
 "prefs_group_general" = "General settings";
 
 /* Settings information group in settings screen */
 "prefs_group_information" = "Information";
-
-/* Settings screen: "Map" category title */
-"prefs_group_map" = "Karte";
-
-/* Settings screen: "Miscellaneous" category title */
-"prefs_group_misc" = "Verschiedenes";
 
 "prefs_group_route" = "Navigation";
 
@@ -419,9 +310,6 @@
 /* Settings «Map» category: «3D buildings» title */
 "pref_map_3d_buildings_title" = "3D-Gebäude";
 
-/* Settings «Map» category: «3D buildings» summary */
-"pref_map_3d_buildings_subtitle" = "Beeinträchtigt die Akkulaufzeit";
-
 /* Settings «Route» category: «Tts enabled» title */
 "pref_tts_enable_title" = "Sprachführung";
 
@@ -433,8 +321,6 @@
 
 /* Title for "Other" section in TTS settings. */
 "pref_tts_other_section_title" = "Weitere";
-
-"pref_tts_how_to_set_up_voice" = "Navi-Stimme konfigurieren";
 
 /* Settings «Map» category: «Record track» title */
 "pref_track_record_title" = "Letzte Strecke";
@@ -455,56 +341,7 @@
 
 "recent_track_help_text" = "So können Sie die zurückgelegte Strecke für einen bestimmten Zeitraum aufzeichnen und auf der Karte sehen. Hinweis: Die Aktivierung dieser Funktion führt zu erhöhtem Batterieverbrauch. Die Aufzeichnung wird nach Ablauf des Zeitintervalls automatisch von der Karte entfernt.";
 
-"pref_track_ios_caption" = "Letzte Strecke zeigt den von Ihnen zurückgelegten Weg.";
-
-"pref_track_ios_subcaption" = "Bitte wählen Sie die Zeitspanne, für die die Strecke gespeichert wird.";
-
-"placepage_distance" = "Entfernung";
-
-"placepage_coordinates" = "Koordinaten";
-
-"placepage_unsorted" = "Unsortiert";
-
 "search_show_on_map" = "Auf der Karte ansehen";
-
-/* Used to warn user when fixing KitKat issue */
-"bookmark_move_fail" = "Wir müssen Ihre Lesezeichen in den internen Speicher verschieben, aber es steht dafür keinen Speicherplatz zur Verfügung. Bitte geben Sie Speicherplatz frei, sonst werden Ihre Lesezeichen nicht verfügbar sein.";
-
-/* Used in More Apps menu */
-"free" = "Kostenlos";
-
-/* Used in More Apps menu */
-"buy" = "Kaufen";
-
-/* 1st search button-like result */
-"search_on_map" = "Auf der Karte anzeigen";
-
-/* toast with an error */
-"no_route_found" = "Keine Route gefunden";
-
-/* route title */
-"route" = "Route";
-
-/* category title */
-"routes" = "Routen";
-
-/* text of notification */
-"download_map_notification" = "Laden Sie die Karte Ihres Standortes herunter";
-
-/* text of notification */
-"pro_version_is_free_today" = "Organic Maps heute gratis! Jetzt runterladen & Ihre Freunde informieren";
-
-/* Dialog for transferring maps from lite to pro. */
-"move_lite_maps_to_pro" = "Wir übertragen Ihre heruntergeladenen Karten von Organic Maps Lite zu Organic Maps. Dieser Vorgang kann einige Minuten in Anspruch nehmen.";
-
-/* Message to display when maps moved. */
-"move_lite_maps_to_pro_ok" = "Ihre heruntergeladenen Karten wurden erfolgreich zu Organic Maps übertragen.";
-
-/* Message to display when maps move failed. */
-"move_lite_maps_to_pro_failed" = "Ihre Karten konnten nicht übertragen werden. Bitte löschen Sie Organic Maps Lite und laden Sie die Karten erneut herunter.";
-
-/* Text in menu */
-"settings_and_more" = "Einstellungen & mehr";
 
 /* Text in menu */
 "website" = "Webseite";
@@ -527,14 +364,8 @@
 /* Text in menu */
 "openstreetmap" = "OpenStreetMap";
 
-/* Text in menu */
-"contact_us" = "Kontaktieren Sie uns";
-
 /* Settings: Send feedback button and dialog title */
 "feedback" = "Feedback";
-
-/* Text in menu */
-"subscribe_to_news" = "Abonnieren Sie unsere News";
 
 /* Text in menu */
 "rate_the_app" = "Bewerten Sie die App";
@@ -548,15 +379,6 @@
 /* Text in menu */
 "report_a_bug" = "Fehler melden";
 
-/* Email subject */
-"subscribe_me_subject" = "Ich möchte gerne den Organic Maps-Newsletter abonnieren";
-
-/* Email body */
-"subscribe_me_body" = "Gerne möchte ich zu den Ersten gehören, die aktuelle Neuigkeiten erfahren und über neueste Aktualisierungen und Werbeangebote informiert werden. Mein Abo kann ich jederzeit kündigen.";
-
-/* About text */
-"about_text" = "Organic Maps bietet die schnellsten Offline-Karten aller Städte weltweit. Reisen Sie mit Vertrauen: wo immer Sie sind hilft Ihnen Organic Maps, sich auf der Karte zurecht zu finden. Finden Sie das nächstgelegene Restaurant, Hotel, Bank, Tankstelle usw. Es ist keine Internet-Verbindung erforderlich.\n\nWir arbeiten ständig an neuen Funktionen und freuen uns, von Ihnen zu hören, wie wir Organic Maps verbessern können. Wenn Sie Probleme mit der App haben, zögern Sie nicht, mit uns über support@organicmaps.app in Verbindung zu treten. Wir reagieren auf jede Anfrage!\n\nMögen Sie Organic Maps und wollen Sie uns unterstützen? Es gibt einige einfache und absolut kostenlose Möglichkeiten:\n\n- Veröffentlichen Sie eine Bewertung auf Ihrem App-Store\n- Liken Sie unsere Facebook-Seite http://www.facebook.com/OrganicMaps\n- Oder erzählen einfach nur Ihrer Mutter, Freunden und Kollegen von Organic Maps:)\n\nDanke, dass Sie bei uns sind. Wir freuen uns sehr über Ihre Unterstützung!\n\nPS: Wir nutzen die Kartendaten von OpenStreetMap, einem Kartierungs-Projekt ähnlich Wikipedia, bei welchem Mitglieder Kartendaten erfassen. Wenn Sie sehen, dass auf der Karte etwas fehlt oder falsch ist, können Sie die Karten direkt auf https://www.openstreetmap.org korrigieren und die Änderungen erscheinen in der nächsten Version der Organic Maps-App.";
-
 /* Alert text */
 "email_error_body" = "Der Email-Client ist noch nicht eingerichtet worden. Konfigurieren Sie ihn bitte oder nutzen Sie eine andere Möglichkeit, uns unter %@ zu erreichen.";
 
@@ -569,12 +391,6 @@
 /* Search category */
 "wifi" = "WLAN";
 
-/* Update map suggestion */
-"routing_map_outdated" = "Bitte aktualisieren Sie die Karte, um eine Route zu erstellen.";
-
-/* Update maps suggestion */
-"routing_update_maps" = "Die neue Version von Organic Maps ermöglicht das Erzeugen von Routen von Ihrem aktuellen Standort bis zum gewünschten Ziel. Bitte aktualisieren Sie Karten, um diese Funktion nutzen zu können.";
-
 /* Update all button text */
 "downloader_update_all_button" = "Alle aktualisieren";
 
@@ -583,9 +399,6 @@
 
 /* Downloaded maps category */
 "downloader_downloaded_subtitle" = "Heruntergeladen";
-
-/* Downloaded maps category */
-"downloader_available_maps" = "Verfügbar";
 
 /* Country queued for download */
 "downloader_queued" = "In der Warteschlange";
@@ -598,17 +411,6 @@
 
 "downloader_downloading" = "Wird heruntergeladen:";
 
-"downloader_search_results" = "Gefunden";
-
-/* Disclaimer message */
-"routing_disclaimer" = "Beim Erstellen von Routen mit der Organic Maps-App sollten Sie Folgendes beachten:\n\n  - Vorgeschlagenen Routen können nur als Empfehlungen angesehen werden.\n - Straßenbedingungen, Verkehrsregeln und Schilder haben höhere Priorität als Navigationsratschläge.\n - Die Karte kann falsch oder veraltet sein und Routen könnten somit nicht auf die bestmögliche Weise erstellt worden sein.\n\n  Bleiben Sie auf der Straße sicher und achten Sie auf sich selbst!";
-
-/* Outdated maps category */
-"downloader_outdated_maps" = "Veraltet";
-
-/* Up to date maps category */
-"downloader_uptodate_maps" = "Aktuell";
-
 /* Status of outdated country in the list */
 "downloader_status_outdated" = "Aktualisieren";
 
@@ -618,49 +420,14 @@
 /* Displayed in a dialog that appears when a user tries to delete a map while the app is in the follow route mode */
 "downloader_delete_map_while_routing_dialog" = "Um die Karte zu löschen, die Navigation unterbrechen.";
 
-/* Show when user try build route, but we don't know where he */
-"routing_failed_unknown_my_position" = "Der aktuelle Standort ist nicht bekannt. Bitte geben Sie den Standort ein, um eine Route zu erstellen.";
-
-/* Show if use has not routing file, or InconsistentMWMandRoute */
-"routing_failed_has_no_routing_file" = "Zusätzliche Daten werden zum Erstellen der Route benötigt. Mit dem Herunterladen beginnen?";
-
-/* StartPointNotFound */
-"routing_failed_start_point_not_found" = "Die Route kann nicht berechnet werden. Es gibt keine Straßen in der Nähe Ihres Ausgangspunkts.";
-
-/* EndPointNotFound */
-"routing_failed_dst_point_not_found" = "Die Route kann nicht berechnet werden. Es gibt keine Straßen in der Nähe Ihres Ziels.";
-
 /* PointsInDifferentMWM */
 "routing_failed_cross_mwm_building" = "Es können nur Routen erstellt werden, die vollständig in einer einzigen Karte enthalten sind.";
-
-/* RouteNotFound */
-"routing_failed_route_not_found" = "Es wurde keine Route zwischen dem ausgewählten Ausgangspunkt und Ziel gefunden. Bitte wählen Sie einen anderen Start- oder Endpunkt.";
-
-/* InternalError */
-"routing_failed_internal_error" = "Es ist ein interner Fehler aufgetreten. Bitte versuchen Sie, die Karte zu löschen und erneut herunterzuladen.";
-
-/* Context menu item for downloader. */
-"downloader_download_map_and_routing" = "Karte + Routenplanung herunterladen";
-
-/* Context menu item for downloader. */
-"downloader_download_routing" = "Routenplanung herunterladen";
-
-/* Context menu item for downloader. */
-"downloader_delete_routing" = "Routenplanung löschen";
 
 /* Context menu item for downloader. */
 "downloader_download_map" = "Karte herunterladen";
 
-"downloader_download_map_no_routing" = "Karte ohne Routenplanung herunterladen";
-
-/* Button for routing. */
-"routing_go" = "Los!";
-
 /* Item status in downloader. */
 "downloader_retry" = "Wiederholen";
-
-/* Item in context menu. */
-"downloader_map_and_routing" = "Karte + Routenplanung";
 
 /* Item in context menu. */
 "downloader_delete_map" = "Karte löschen";
@@ -668,29 +435,11 @@
 /* Item in context menu. */
 "downloader_update_map" = "Karte aktualisieren";
 
-/* Item in context menu. */
-"downloader_update_map_and_routing" = "Karte + Routenplanung aktualisieren";
-
-/* Item in context menu. */
-"downloader_map_only" = "Nur Karte";
-
-/* Toolbar title */
-"toolbar_application_menu" = "Anwendungs-Menü";
-
 /* Preference text */
 "pref_use_google_play" = "Nutzen Sie die Google Play-Dienste, um Ihren aktuellen Standort zu erhalten";
 
 /* Text for rating dialog */
 "rating_just_rated" = "Ich habe gerade Ihre App bewertet";
-
-/* Text for rating dialog */
-"rating_user_since" = "Ich bin Organic Maps-Nutzer seit %@";
-
-/* Text for rating dialog */
-"rating_do_like_maps" = "Mögen Sie Organic Maps?";
-
-/* Text for rating dialog */
-"rating_tap_star" = "Tippen Sie auf einen Stern, um unsere App zu bewerten.";
 
 /* Text for rating dialog */
 "rating_thanks" = "Vielen Dank!";
@@ -701,23 +450,8 @@
 /* Text for rating dialog */
 "rating_send_feedback" = "Rückmeldung senden";
 
-/* Text for g+ dialog */
-"rating_google_plus" = "Klick auf G+, um deinen Freunden über die App zu erzählen.";
-
 /* Text for routing error dialog */
 "routing_download_maps_along" = "Karten entlang der Route herunterladen";
-
-/* Text for routing error dialog */
-"routing_download_map" = "Karte abrufen";
-
-/* Text for routing error dialog */
-"routing_download_map_and_routing" = "Laden Sie die aktualisierte Karte und Daten der Routenplanung herunter, um alle Organic Maps-Funktionen zu nutzen.";
-
-/* Text for routing error dialog */
-"routing_get_routing_data" = "Daten für Routenplanung abrufen";
-
-/* Text for routing error dialog */
-"routing_get_additional_data" = "Es sind Zusatzdaten erforderlich, um die Route ab Ihrem Standort zu erstellen.";
 
 /* Text for routing error dialog */
 "routing_requires_all_map" = "Zum Erstellen einer Route müssen alle Karten von Ihrem Standort bis zum Ziel heruntergeladen und aktualisiert worden sein.";
@@ -725,50 +459,15 @@
 /* Text for routing error dialog */
 "routing_not_enough_space" = "Nicht genug Speicherplatz";
 
-/* Text for routing error dialog */
-"routing_download_more_than_avail" = "Sie wollen %@ MB herunterladen, der Speicherplatz reicht aber nur für %@ MB.";
-
-/* Text for routing error dialog */
-"routing_download_roaming" = "Sie sind im Begriff, %@ MB unter Nutzung einer mobilen Datenverbindung (mit Roaming) herunterzuladen. Dies kann je nach Anbieter Ihres mobilen Datentarifs zusätzliche Kosten verursachen.";
-
 /* bookmark button text */
 "bookmark" = "Lesezeichen";
-
-/* map is not downloaded */
-"not_found_map" = "Es gibt keine Karte für Ihren Standort";
 
 /* location service disabled */
 "enable_location_services" = "Aktivieren Sie bitte Ortungsdienste";
 
-/* download map */
-"download_map" = "Laden Sie die Karte für Ihren Standort herunter";
-
-/* download map on iPhone */
-"download_map_iphone" = "Laden Sie eine Karte für Ihre aktuelle Position auf Ihrem iPhone herunter";
-
-/* clear pin */
-"nearby" = "In der Nähe";
-
-/* clear pin */
-"clear_pin" = "Stecknadel löschen";
-
-/* location is undefined */
-"undefined_location" = "Der aktuelle Standort ist nicht definiert.";
-
-/* download country of your location */
-"download_country" = "Land Ihres derzeitigen Standorts herunterladen";
-
-/* download failed */
-"download_failed" = "Herunterladen fehlgeschlagen";
-
-/* get the map */
-"get_the_map" = "Karte abrufen";
-
 "save" = "Speichern";
 
 "edit_description_hint" = "Ihre Beschreibungen (Text oder HTML)";
-
-"new_group" = "Neue Gruppe";
 
 "create" = "erstellen";
 
@@ -795,30 +494,6 @@
 
 /* pink color */
 "pink" = "Rosa";
-
-/* deep purple color */
-"deep_purple" = "Dunkelpurpur";
-
-/* light blue color */
-"light_blue" = "Hellblau";
-
-/* cyan color */
-"cyan" = "Blaugrün";
-
-/* teal color */
-"teal" = "Smaragdgrün";
-
-/* lime color */
-"lime" = "Limette";
-
-/* deep orange color */
-"deep_orange" = "Dunkelorange";
-
-/* gray color */
-"gray" = "Grau";
-
-/* blue gray color */
-"blue_gray" = "Graublau";
 
 /* Wi-Fi available */
 "WiFi_available" = "Ja";
@@ -848,13 +523,9 @@
 
 "dialog_routing_location_unknown_turn_on" = "Aktuelle GPS-Koordinaten können nicht ermittelt werden. Aktivieren Sie Ortungsdienste, um die Route zu berechnen.";
 
-"dialog_routing_location_unknown" = "Aktuelle GPS-Koordinaten können nicht ermittelt werden.";
-
 "dialog_routing_download_files" = "Erforderliche Dateien herunterladen";
 
 "dialog_routing_download_and_update_all" = "Laden Sie alle Karten- und Routeninformationen für den geplanten Weg herunter und aktualisieren Sie sie, um die Route zu berechnen.";
-
-"dialog_routing_routes_size" = "Routeninformationsdateien";
 
 "dialog_routing_unable_locate_route" = "Route kann nicht ermittelt werden";
 
@@ -884,21 +555,11 @@
 
 "dialog_routing_try_again" = "Bitte versuchen Sie es erneut";
 
-"dialog_routing_send_error" = "Dieses Problem melden";
-
-"dialog_routing_if_get_cross_route" = "Möchten Sie eine direktere Route erstellen, die mehr als eine Karte umfasst?";
-
-"dialog_routing_cross_route_is_optimal" = "Es ist eine bessere Route verfügbar, die den Rand dieser Karte überschreitet.";
-
 "not_now" = "Nicht jetzt";
-
-"dialog_routing_build_route" = "Erstellen";
 
 "dialog_routing_download_and_build_cross_route" = "Möchten Sie die Karte herunterladen und eine bessere Route erstellen, die mehr als eine Karte umfasst?";
 
 "dialog_routing_download_cross_route" = "Laden Sie die Karte herunter, um eine bessere Route zu erstellen, die den Rand dieser Karte überschreitet.";
-
-"dialog_routing_cross_route_always" = "Diese Grenze immer überschreiten";
 
 
 /********** Strings for downloading map from search **********/
@@ -906,8 +567,6 @@
 "search_without_internet_advertisement" = "Um mit der Suche und dem Erstellen von Routen zu beginnen, laden Sie bitte die Karte herunter. Sie benötigen danach keine Internetverbindung mehr.";
 
 "search_select_map" = "Karte auswählen";
-
-"search_select_other_map" = "Eine andere Karte auswählen";
 
 /* «Show» context menu */
 "show" = "Anzeigen";
@@ -918,17 +577,11 @@
 /* «Rename» context menu */
 "rename" = "Umbenennen";
 
-/* Bottom sheet: expand button (should be short) */
-"bottom_sheet_more" = "Mehr…";
-
 /* Failed planning route message in navigation view */
 "routing_planning_error" = "Routenplanung fehlgeschlagen";
 
 /* Arrive routing message in navigation view */
 "routing_arrive" = "Ankunft: %s";
-
-/* Text for routing::RouterResultCode::FileTooOld dialog. */
-"dialog_routing_download_and_update_maps" = "Zum Erstellen einer Route müssen Sie alle Karten herunterladen und aktualisieren, auf der die Route liegt.";
 
 "rate_alert_title" = "Gefällt Ihnen die App?";
 
@@ -944,19 +597,11 @@
 
 "history" = "Verlauf";
 
-"next_turn_then" = "Dann";
-
 "closed" = "Geschlossen";
-
-"back_to" = "Zurück zu %@";
 
 "search_not_found" = "Leider wurde nichts gefunden.";
 
 "search_not_found_query" = "Versuchen Sie bitte eine andere Suchanfrage.";
-
-"search_not_found_map" = "Laden Sie bitte die Karte herunter, auf der Sie suchen.";
-
-"search_not_found_location" = "Laden Sie die Karte Ihres aktuellen Standorts herunter.";
 
 "search_history_title" = "Suchverlauf";
 
@@ -964,23 +609,12 @@
 
 "clear_search" = "Suchverlauf löschen";
 
-/* Title for settings to enable/disable showcase menu button */
-"showcase_settings_title" = "Angebote anzeigen";
-
 /* Place Page link to Wikipedia article (if map object has it). */
 "read_in_wikipedia" = "Wikipedia";
 
-"p2p_route_planning" = "Routenplanung";
-
 "p2p_your_location" = "Ihr Standort";
 
-"p2p_from" = "Startpunkt";
-
-"p2p_to" = "Zielort";
-
 "p2p_start" = "Start";
-
-"p2p_planning" = "Route wird geplant…";
 
 "p2p_from_here" = "Von";
 
@@ -1018,15 +652,9 @@
 
 "editor_correct_mistake" = "Fehler korrigieren";
 
-"editor_correct_mistake_message" = "Es ist ein Bearbeitungsfehler aufgetreten. Bitte korrigieren oder zum Einfachmodus wechseln.";
-
 "editor_add_select_location" = "Position";
 
 "editor_done_dialog_1" = "Sie haben die Weltkarte geändert. Blenden Sie das nicht aus! Erzählen Sie Ihren Freunden davon und bearbeiten Sie sie zusammen.";
-
-"editor_done_dialog_2" = "Das ist Ihre zweite Kartenverbesserung. Sie befinden sich jetzt auf Platz %d auf der Liste der Personen, die die Karte bearbeitet haben. Erzählen Sie Ihren Freunden davon.";
-
-"editor_done_dialog_3" = "Sie haben die Karte verbessert, erzählen Sie Ihren Freunden davon und bearbeiten Sie die Karte zusammen.";
 
 "share_with_friends" = "Mit Freunden teilen";
 
@@ -1044,20 +672,7 @@
 
 "editor_report_problem_duplicate_place_title" = "Doppelter Ort";
 
-"first_launch_congrats_title" = "Organic Maps kann verwendet werden";
-
-"first_launch_congrats_text" = "Suche und Navigation weltweit offline verfügbar, völlig kostenfrei.";
-
-"migrate_title" = "Wichtig!";
-
-/* Android uses image instead of text. */
-"download_all" = "Alle herunterladen";
-
-"delete_all" = "Alle löschen";
-
 "autodownload" = "Automatisch herunterladen";
-
-"disable_autodownload" = "Automatischen Download deaktivieren";
 
 /* Place Page opening hours text */
 "closed_now" = "Jetzt geschlossen";
@@ -1072,10 +687,6 @@
 "day_off" = "Geschlossen";
 
 "today" = "Heute";
-
-"sunrise_to_sunset" = "Von Sonnenauf- bis Sonnenuntergang";
-
-"sunset_to_sunrise" = "Von Sonnenuntergang bis Sonnenaufgang";
 
 "add_opening_hours" = "Geschäftszeiten hinzufügen";
 
@@ -1095,45 +706,18 @@
 
 "forgot_password" = "Passwort vergessen?";
 
-/* Forgot Password dialog title */
-"restore_password" = "Passwort wiederherstellen";
-
-"enter_email_address_to_reset_password" = "Geben Sie bitte die Email-Adresse ein, die Sie zur Registrierung verwendet haben. Wir senden Ihnen dann den Link zur Erneuerung Ihres Passworts.";
-
-"reset_password" = "Passwort zurücksetzen";
-
-"username" = "Benutzername";
-
 "osm_account" = "OSM Konto";
 
 "logout" = "Abmelden";
 
-"login_and_edit_map_motivation_message" = "Anmelden und Informationen zu den Objekten auf der Karte bearbeiten. Wir werden sie für Millionen von anderen Nutzern verfügbar machen. Lassen Sie uns zusammen die Welt verbessern.";
-
 /* Information text: "Last upload 11.01.2016" */
 "last_upload" = "Zuletzt hochgeladen";
 
-/* Motivates user to login/register, title above login buttons. */
-"you_have_edited_your_first_object" = "Sie haben Ihr erstes Objekt bearbeitet!";
-
 "thank_you" = "Danke";
-
-"login_with_google" = "Mit Google anmelden";
-
-"login_with_openstreetmap" = "Mit www.openstreetmap.org anmelden";
 
 "edit_place" = "Platz bearbeiten";
 
 "place_name" = "Name des Platzes";
-
-/* title above languages list cells in the editor, below editable name text field. */
-"other_languages" = "Andere Sprachen";
-
-/* small button to open list with names in different languages */
-"show_more" = "Mehr anzeigen";
-
-/* small button to close list with names in different languages */
-"show_less" = "Weniger anzeigen";
 
 "add_language" = "Eine Sprache hinzufügen";
 
@@ -1164,8 +748,6 @@
 
 "please_note" = "Bitte beachten";
 
-"common_no_wifi_dialog" = "Keine WLAN-Verbindung. Möchten Sie mit mobilen Daten fortfahren?";
-
 "downloader_delete_map_dialog" = "Alle Kartenänderungen werden zusammen mit der Karte gelöscht.";
 
 "downloader_update_maps" = "Karten aktualisieren";
@@ -1173,10 +755,6 @@
 "downloader_mwm_migration_dialog" = "Um eine Strecke zu erstellen, müssen Sie alle Karten aktualisieren und dann die Strecken erneut planen.";
 
 "downloader_search_field_hint" = "Karte finden";
-
-"migration_update_all_button" = "Alle Karten aktualisieren";
-
-"migration_delete_all_download_current_button" = "Laden Sie die aktuelle Karte herunter und löschen Sie alte Karten";
 
 "migration_download_error_dialog" = "Fehler beim Herunterladen";
 
@@ -1186,21 +764,9 @@
 
 "downloader_no_space_message" = "Bitte entfernen Sie unnötige Daten";
 
-"editor_general_auth_error_dialog" = "Allgemeiner Login-Fehler.";
-
 "editor_login_error_dialog" = "Login-Fehler.";
 
-"editor_login_failed_dialog" = "Login fehlgeschlagen";
-
-"editor_username_error_dialog" = "Benutzername ist ungültig";
-
-"editor_place_edited_dialog" = "Sie haben ein Objekt bearbeitet!";
-
-"editor_login_with_osm" = "Mit OpenStreetMap anmelden";
-
 "editor_profile_changes" = "Bestätigte Änderungen der Karte";
-
-"editor_profile_unsent_changes" = "Nicht gesendet:";
 
 "editor_focus_map_on_location" = "Ziehen Sie die Karte, um den Standort des Objektes zu korrigieren.";
 
@@ -1222,13 +788,9 @@
 
 "editor_report_problem_other_title" = "Ein anderes Problem";
 
-"placepage_report_problem_button" = "Problem melden";
-
 "placepage_add_business_button" = "Organisation hinzufügen";
 
 "whatsnew_editor_message_1" = "Fügen Sie auf der Karte einen neuen Ort hinzu und bearbeiten Sie existierende Ort direkt in der App.";
-
-"whatsnew_editor_message_2" = "* Organic Maps verwendet Community-Daten von OpenStreetMap.";
 
 "dialog_incorrect_feature_position" = "Standort wechseln";
 
@@ -1236,16 +798,10 @@
 
 "login_to_make_edits_visible" = "Melden Sie sich an, damit andere Benutzer Ihre Änderungen sehen können.";
 
-"no_migration_during_navigation" = "Aktualisieren ist während der Navigation verboten.";
-
 /* Error dialog no space */
 "migration_no_space_message" = "Zum Herunterladen benötigen Sie mehr Platz. Bitte löschen Sie unnötige Daten.";
 
 "editor_sharing_title" = "Ich habe die Organic Maps-Karten verbessert";
-
-"editor_comment_will_be_sent" = "Wir werden Ihren Kommentar an die Kartografierer weiterleiten.";
-
-"editor_unsupported_category_message" = "Sie haben einen Ort in einer Kategorie hinzugefügt, die wir noch nicht unterstützten. Er wird zu einem späteren Zeitpunkt auf der Karte erscheinen.";
 
 /* Downloaded 10 **of** 20 <- it is that "of" */
 "downloader_of" = "%1$d von %2$d";
@@ -1278,23 +834,9 @@
 
 "editor_operator" = "Betreiber oder Eigentümer";
 
-"editor_tag_description" = "Geben Sie die Firma, die Organisation oder die Person an, die den Betrieb des Objekts gewährleistet.";
-
-"editor_no_local_edits_title" = "Sie haben keine lokalen Korrekturen";
-
-"editor_no_local_edits_description" = "Hier erscheint die Anzahl Ihrer Änderungsvorschläge für die Karte, auf die Sie bislang nur von Ihrem Gerät aus zugreifen können.";
-
-"editor_send_to_osm" = "An OSM senden";
-
-"editor_remove" = "Löschen";
-
-"downloader_my_maps_title" = "Meine Karten";
-
 "downloader_no_downloaded_maps_title" = "Keine Karten geladen";
 
 "downloader_no_downloaded_maps_message" = "Laden Sie die für die Suche nach Orten erforderlichen Karten und verwenden Sie die Navigation offline.";
-
-"downloader_find_place_hint" = "Stadt oder Land suchen";
 
 /* Error title that appears after certain time without location. */
 "current_location_unknown_title" = "Standortsuche fortsetzen?";
@@ -1321,47 +863,13 @@
 /* iOS Dialog for the case when the location permission is not granted */
 "location_services_disabled_3" = "3. Wählen Sie „Beim Verwenden der App“";
 
-"placepage_parking_surface" = "Öffentlicher Parkplatz";
-
-"placepage_parking_multistorey" = "Tiefgarage mit mehreren Etagen";
-
-"placepage_parking_underground" = "Tiefgarage";
-
-"placepage_parking_rooftop" = "Parkdeck";
-
-"placepage_parking_sheds" = "Privater Carport";
-
-"placepage_parking_carports" = "Parkhalle";
-
-"placepage_parking_boxes" = "Garagenbox";
-
-"placepage_parking_pay" = "Gebührenpflichtig";
-
-"placepage_parking_free" = "Gebührenfrei";
-
-"placepage_parking_interval" = "Teilweise gebührenpflichtig";
-
-"placepage_entrance_number" = "Nr. der Einfahrt";
-
-"placepage_entrance_type" = "Typ der Einfahrt";
-
-"placepage_flat" = "Wohnung";
-
-"placepage_open_24_7" = "Durchgehend geöffnet";
-
 "meter" = "m";
 
 "kilometer" = "km";
 
-"kilometers_per_hour" = "km / h";
-
 "mile" = "mi";
 
 "foot" = "ft";
-
-"miles_per_hour" = "mph";
-
-"day" = "d";
 
 "hour" = "h";
 
@@ -1381,10 +889,6 @@
 
 "placepage_bookmark_name_hint" = "Name des Lesezeichens";
 
-"placepage_personal_notes_hint" = "Anmerkung";
-
-"placepage_delete_bookmark_button" = "Lesezeichen löschen";
-
 "editor_edits_sent_message" = "Ihre Änderungsvorschläge wurden gesendet";
 
 "editor_comment_hint" = "Kommentar…";
@@ -1397,8 +901,6 @@
 
 "editor_remove_place_button" = "Löschen";
 
-"editor_status_sending" = "Senden…";
-
 "editor_place_doesnt_exist" = "Dieser Ort existiert nicht";
 
 "text_more_button" = "…Mehr";
@@ -1410,11 +912,7 @@
 
 "error_enter_correct_email" = "Geben Sie eine gültige Email-Adresse ein";
 
-"error_enter_correct" = "Geben Sie einen gültigen Wert ein";
-
 "refresh" = "Aktualisieren";
-
-"last_update" = "Letzte Aktualisierung: %s";
 
 "placepage_add_place_button" = "Einen Ort zur Karte hinzufügen";
 
@@ -1426,24 +924,6 @@
 
 "editor_share_to_all_dialog_message_2" = "Wir werden die Änderungen prüfen. Wenn wir Fragen haben, werden wir Sie per Email kontaktieren.";
 
-"navigation_overview_button" = "Überblick";
-
-"navigation_stop_button" = "Stop";
-
-/* Text on an empty bookmark page */
-"bookmarks_empty_title" = "Lesezeichen speichern";
-
-"bookmarks_empty_message_1" = "Tippen Sie auf ★, um Ihre Lieblingsorte für den Schnellzugriff zu speichern.";
-
-"bookmarks_empty_message_2" = "Lesezeichen aus Mail und Web importieren.";
-
-"bookmarks_empty_message_3" = "Auschecken: %s";
-
-/* Name of the group for booked hotels */
-"bookmarks_group_name" = "Gebuchte Hotels";
-
-"place_page_button_read_descriprion" = "Lesen";
-
 /* iOS dialog for the case when recent track recording is on and the app comes back from background */
 "recent_track_background_dialog_title" = "Aufzeichnung Ihrer kürzlich gefahrenen Route deaktivieren?";
 
@@ -1451,8 +931,6 @@
 
 /* For sharing via SMS and so on */
 "sharing_call_action_look" = "Nachsehen";
-
-"continue_recent_track_background_button" = "Fortsetzen";
 
 "recent_track_background_dialog_message" = "Organic Maps verwendet Ihre Geoposition im Hintergrund, um Ihre kürzlich gefahrene Route aufzunehmen.";
 
@@ -1468,33 +946,13 @@
 /* About short text (below logo) */
 "about_description" = "Organic Maps ist eine wichtige Offline-App zum Reisen. Organic Maps basiert auf OpenStreetMap-Daten und ermöglicht das Bearbeiten dieser.";
 
-/* Text in menu */
-"blog" = "Blog";
-
 "general_settings" = "Allgemeine Einstellungen";
-
-"date" = "Datum %d";
-
-/* "Report a bug" -> "Generaal Feedback" -> "Something is not working" */
-"something_is_not_working" = "Etwas funktioniert nicht";
 
 /* For the first routing */
 "accept" = "Annehmen";
 
-"accept_and_continue" = "Accept and continue";
-
 /* For the first routing */
 "decline" = "Ablehnen";
-
-"install_app" = "Installieren";
-
-"search_no_results_title" = "Keine Ergebnisse gefunden";
-
-"search_no_results_message" = "Versuchen Sie es mit einem allgemeineren Suchbegriff, zoomen Sie heraus oder setzen Sie den Filter zurück.";
-
-"search_no_results_expand_area_button" = "Herauszoomen";
-
-"search_no_results_reset_button" = "Filter zurücksetzen";
 
 /* noun */
 "search_in_table" = "Liste";
@@ -1517,8 +975,6 @@
 
 "traffic_update_maps_text" = "Um Verkehrsdaten anzuzeigen, müssen die Karten aktualisiert werden.";
 
-"traffic_outdated" = "Verkehrsdaten sind veraltet.";
-
 "big_font" = "Schriftgröße auf der Karte erhöhen";
 
 "traffic_update_app" = "Bitte aktualisieren Sie Organic Maps";
@@ -1529,17 +985,7 @@
 /* "traffic" as in "road congestion" */
 "traffic_data_unavailable" = "Verkehrsdaten sind nicht verfügbar";
 
-/* "Translation is no needed, because it's a company name" */
-"uber" = "Uber";
-
-/* Simplified colour scheme for traffic information, fewer colours are used to display traffic jams on the map. The string should be kept as short as possible */
-"pref_traffic_simplified_colors_title" = "Vereinfachte Verkehrsfarben";
-
 "enable_logging" = "Protokollierung aktivieren";
-
-"offline_place_page_more_information" = "Stellen Sie eine Verbindung zum Internet her, um weitere Informationen über den Ort zu erhalten.";
-
-"failed_load_information" = "Informationen konnten nicht geladen werden.";
 
 /* Settings: "Send general feedback" button */
 "feedback_general" = "Allgemeines Feedback";
@@ -1556,8 +1002,6 @@
 
 "whatsnew_transliteration_title" = "Transliteration ins Lateinische";
 
-"yandex_taxi_title" = "Yandex.Taxi";
-
 "learn_more" = "Weitere Informationen";
 
 "core_exit" = "Beenden";
@@ -1568,75 +1012,19 @@
 
 "button_exit" = "Beenden";
 
-"settings_device_memory" = "Gerätespeicher";
-
-"settings_card_memory" = "Speicherkarte";
-
-"settings_storage_available" = "%s verfügbar";
-
-"toast_location_permission_denied" = "App-Zugriff auf Standort verweigert";
-
-"button_use" = "Nutzen";
-
 "planning_route_manage_route" = "Route verwalten";
 
 "button_plan" = "Planen";
-
-"button_add" = "Hinzufügen";
 
 "placepage_remove_stop" = "Entfernen";
 
 "planning_route_remove_title" = "Hierher ziehen zum Entfernen";
 
-"dialog_change_start_point_message" = "Startpunkt durch aktuellen Standort ersetzen?";
-
-"button_replace" = "Ersetzen";
-
 "placepage_add_stop" = "Zwischenstopp hinzufügen";
-
-/* Only ru/en are needed */
-"subtitle_rent" = "Rent";
-
-/* Only ru/en are needed */
-"rub_month" = "RUB/month";
-
-/* Only ru/en are needed */
-"room" = "%s-room apt.";
-
-/* Only ru/en are needed */
-"real_estate" = "Real estate";
-
-"add_my_position" = "Meinen Standort hinzufügen";
-
-"choose_start_point" = "Startpunkt auswählen";
-
-"choose_destination" = "Ziel auswählen";
 
 "preloader_viator_button" = "Weitere Informationen";
 
-"start_from_my_position" = "Starten von";
-
-"profile_authorization_title" = "Anmelden mit";
-
-"profile_authorization_message" = "Einfaches Anmelden ohne Anmeldename und Passwort in nur wenigen Sekunden";
-
 "profile_authorization_error" = "Hoppla, es ist ein Fehler aufgetreten. Versuchen Sie erneut, sich anzumelden.";
-
-"service" = "Service";
-
-"atmosphere" = "Atmosphäre";
-
-"value_for_money" = "Preis-Leis­tungs-Ver­hält­nis";
-
-"experience" = "Erfahrung";
-
-"assortment" = "Sortiment";
-
-"expertise" = "Kompetenz";
-
-"equipment" = "Ausstattung";
-
-"quality" = "Qualität";
 
 "dialog_error_storage_title" = "Problem mit dem Zugreifen auf den Speicher";
 
@@ -1644,17 +1032,7 @@
 
 "setting_emulate_bad_storage" = "Fehlerhaften Speicher emulieren";
 
-"directions_finish" = "Ziel";
-
-"directions_on_foot" = "%s zu Fuß gehen";
-
 "core_entrance" = "Eingang";
-
-"coffee" = "Kaffee";
-
-"cleanliness" = "Sauberkeit";
-
-"crowdedness" = "Gedrängtheit";
 
 "error_enter_correct_name" = "Bitte geben Sie einen korrekten Namen ein";
 
@@ -1673,11 +1051,9 @@
 
 "downloader_percent" = "%s (%s von %s)";
 
-"downloader_process" = "%s heruntergeladen...";
+"downloader_process" = "%s heruntergeladen…";
 
-"downloader_applying" = "%s anwenden...";
-
-"dialog_message_transit_not_found_connection" = "Eine Route innerhalb eines Transitnetzes planen";
+"downloader_applying" = "%s anwenden…";
 
 "bookmarks_error_message_share_general" = "Freigabe wegen eines Anwendungsfehlers nicht möglich";
 
@@ -1695,17 +1071,7 @@
 
 "bookmarks_error_message_list_name_already_taken" = "Bitte wähle einen anderen Namen";
 
-"bookmarks_error_title_list_name_too_long" = "Dieser Name ist zu lang";
-
-"bookmarks_error_message_list_name_too_long" = "Bitte wähle einen anderen Namen";
-
-"please_wait" = "Warten Sie mal...";
-
-"phone_number" = "Telefonnummer";
-
-"notification_unsent_reviews_title" = "Sie haben mehrere nicht gesendete Bewertungen";
-
-"notification_unsent_reviews_message" = "Bitte melde dich an, um Bewertungen mit anderen Reisenden zu teilen";
+"please_wait" = "Warten Sie mal…";
 
 "profile" = "OpenStreetMap-Profil";
 
@@ -1719,49 +1085,13 @@
 
 "bookmarks_convert_error_message" = "Einige Dateien wurden nicht konvertiert.";
 
-"converting" = "Konvertieren...";
-
-"wn_reinvented_bookmarks_title" = "Wir haben Lesezeichen neu erfunden!";
-
-"wn_reinvented_bookmarks_message" = "Sie können Lesezeichen sichern, Listen erstellen... Es ist erstaunlich...";
-
-"bookmarks_restore" = "Lesezeichen wiederherstellen";
-
-"bookmarks_restore_process" = "Wiederherstellen...";
-
 "bookmarks_restore_title" = "Diese Version wiederherstellen?";
 
-"bookmarks_restore_message" = "Ihre Lesezeichen werden von %s (%s) wiederhergestellt";
-
-"bookmarks_restore_empty_title" = "Sie haben kein Backup";
-
-"bookmarks_restore_empty_message" = "Der Server hat zuvor erstellte Sicherungen nicht gefunden";
-
 "common_check_internet_connection_dialog_title" = "Keine Internetverbindung";
-
-"error_server_title" = "Serverfehler";
-
-"error_server_message" = "Auf dem Server ist ein Fehler aufgetreten. Bitte versuchen Sie es später erneut.";
 
 "error_system_message" = "Ein unbekannter Fehler ist aufgetreten";
 
 "restore" = "Wiederherstellen";
-
-"bookmarks_page_downloaded" = "Geladene";
-
-"bookmarks_page_my" = "Meine";
-
-"routes_and_bookmarks" = "Routen und Markierungen";
-
-"bookmarks_webview_success_toast" = "Die Markierungen wurden erfolgreich hochgeladen";
-
-"cached_bookmarks_placeholder_title" = "Laden Sie neue Plätze hoch";
-
-"cached_bookmarks_placeholder_subtitle" = "Klicken Sie auf die Schaltfläche, um Tausende von interessanten Orten und Routen, die von den Anwendern von Organic Maps erstellt wurden, zu laden. Sie werden eine Internetverbindung benötigen.";
-
-"downloader_download_routers" = "Markierungen laden";
-
-"bookmarks_groups_cached" = "Heruntergeladene Listen";
 
 "subtittle_opt_out" = "Einstellungen der Begleitung";
 
@@ -1769,29 +1099,15 @@
 
 "crash_reports_description" = "Wir können Ihre Daten benutzen, um Organic Maps zu entwickeln und zu verbessern. Die Änderungen werden nach dem Neustart der App in Kraft treten.";
 
-"opt_out_help_ios_1" = "Sie können der Erhalt von gezielter Werbung in den Einstellungen des Geräts verbieten.";
-
-"opt_out_help_ios_2" = "iOS 9 oder höher";
-
-"opt_out_help_ios_3" = "Öffnen Sie die Einstellungen → Vertraulichkeit → Werbung → Schalten Sie „Tracking einschränken“ ein";
-
-"opt_out_help_android" = "Sie können den Erhalt von gezielter Werbung in den Geräteeinstellungen ausschalten. \nAndroid und Google Play Services 4.0 und höher\n\nTelefoneinstellungen → Google → Werbung→ Personalisierung ausschalten\noder\nTelefoneinstellungen → Google → Benutzerkonto von Google → Vertraulichkeit → Einstellungen von Werbevorzügen → Personalisierung der Werbung";
-
 "privacy_policy" = "Datenschutzerklärung";
 
 "terms_of_use" = "Nutzungsbedingungen";
-
-"backup_notification_failed" = "Das Reservekopieren von Markierungen wurde angehalten. Loggen Sie sich ein, um das Reservekopieren einzuschalten.";
 
 "button_layer_traffic" = "Staus";
 
 "button_layer_subway" = "U-Bahn";
 
 "layers_title" = "Kartenschichten";
-
-"layers_message" = "Schalten Sie die Schichten auf der Karte ein, um die Verkehrssituation, den U-Bahnplan oder sonstige nützlichen Informationen einzublenden";
-
-"button_layer_got_it" = "Alles klar";
 
 "subway_data_unavailable" = "Die U-Bahnkarte steht nicht zur Verfügung";
 
@@ -1803,39 +1119,13 @@
 
 "title_error_downloading_bookmarks" = "Es ist ein Fehler aufgetreten";
 
-"subtitle_error_downloading_bookmarks" = "Die Markierungen wurden nicht geladen";
-
-"error_already_downloaded" = "Diese Liste wurde bereits heruntergeladen";
-
 "popular_place" = "Popular";
-
-"download_routes" = "Download routes";
-
-"bookmarks_downloaded_title" = "Bookmarks have been downloaded successfully";
-
-"bookmarks_downloaded_subtitle" = "Press ‘View on map’ to explore new places from the list";
-
-"why_support" = "Warum Organic Maps unterstützen?";
-
-"why_support_item1" = "We respect your privacy: there are zero trackers in the app, and we are open source";
-
-"why_support_item2" = "Sie helfen uns Organic Maps zu verbesern";
-
-"why_support_item3" = "Sie helfen uns die Karten OpenStreetMap.org zu verbessern";
-
-"channels_map_update" = "Kartenaktualisierungen";
-
-"server_unavailable_title" = "Server unzugänglich";
-
-"sharing_options" = "Zugriffseinstellungen";
 
 "export_file" = "Datei exportieren";
 
 "list_settings" = "Listeneinstellungen";
 
 "delete_list" = "Liste löschen";
-
-"hide_from_map" = "Auf der Karte ausblenden";
 
 "public_access" = "Öffentlicher Zugriff";
 
@@ -1845,40 +1135,11 @@
 
 "bookmark_category_description_hint" = "Fügen Sie die Beschreibung hinzu (Text oder html)";
 
-/* FIXME */
-"bookmarks_public_access" = "bookmarks_public_access";
-
-/* FIXME */
-"bookmarks_link_access" = "bookmarks_link_access";
-
-/* FIXME */
-"bookmarks_private_access" = "bookmarks_private_access";
-
 "not_shared" = "Persönlich";
-
-"direct_link_progress_text" = "Ihre Datei wird geladen…";
-
-"direct_link_success" = "Link erstellt";
-
-"send_a_link_btn" = "Link senden";
-
-"upload_error_toast" = "Während des Ladeprozesses ist ein Fehler aufgetreten";
 
 "tags_loading_error_subtitle" = "Während dem Laden der Tags ist ein Fehler aufgetreten, bitte, versuchen Sie es erneut";
 
-"unable_upload_errorr_title" = "Laden der Datei fehlgeschlagen";
-
-"unable_upload_error_subtitle_edited" = "Datei wurde per WebApp bearbeitet";
-
-"unable_upload_error_subtitle_broken" = "Datei ist beschädigt und kann nicht geladen werden. Bitte laden Sie eine andere Datei.";
-
-"contact" = "Schreiben";
-
-"download_button" = "Downloaden";
-
 "speedcams_alert_title" = "Geschwindigkeitskameras";
-
-"speedcams_alert_subtitle" = "Über Geschwindigkeitsbegrenzungen warnen";
 
 "speedcam_option_auto" = "Auto";
 
@@ -1886,18 +1147,10 @@
 
 "speedcam_option_never" = "Niemals";
 
-"bookmark_description_title" = "Markierungsbeschreibung";
-
 "place_description_title" = "Ortsbeschreibung";
 
 /* this text will be shown in application notification preferences opposite checkbox which enable/disable downloader notifications. Devices on Android 8+ are affected. */
 "notification_channel_downloader" = "Karten werden geladen";
-
-"share_bookmarks_email_body_link" = "Guten Tag!\n\nIhre Markierungen stehen unter folgendem Link zum Download bereit: %s. Öffnen Sie die Liste mit Organic Maps und genießen Sie die Reise!\n\nApp downloaden: https://omaps.app/get?kmz";
-
-"warning_speedcams_title" = "Der Navigator wird Sie über Geschwindigkeitskameras bei Geschwindigkeitsüberschreitung von %d km/h informieren";
-
-"warning_speedcams_subtitle" = "Vergessen Sie nicht sich mit den Verkehrsregeln im Reisezielland vertraut zu machen.";
 
 "speedcams_notice_message" = "Auto - Über Geschwindigkeitskameras bei Risiko einer Geschwindigkeitsüberschreitung informieren\nImmer - Immer über Geschwindigkeitskameras informieren\nNiemals - Nie über Geschwindigkeitskameras informieren";
 
@@ -1913,23 +1166,7 @@
 
 "enable_logging_warning_message" = "Diese Option wird aktiviert, um Aktivitäten zwecks Diagnostik zu loggen. Das hilft unserem Team Probleme mit der App zu erkennen. Aktivieren Sie diese Option nur auf Ersuchen des Organic Maps-Supports.";
 
-"html_error_upload_message_try_again" = "Überprüfen Sie die Internetverbindung und versuchen Sie es noch einmal";
-
-"html_error_upload_title_try_again" = "Keine Internetverbindung";
-
-"notification_leave_review_v2_android_short_title" = "Hinterlassen Sie Ihr Feedback und helfen Sie damit den Reisenden!";
-
-"megafon" = "Say goodbye to roaming!";
-
-"notifications_illegal_alert_disable_button" = "Benachrichtigungen deaktivieren";
-
 "access_rules_author_only" = "Online bearbeiten";
-
-"privacy_settings_menu" = "Datenschutzeinstellungen";
-
-"unable_upadate_error_title" = "Die Aktualisierung der Route konnte nicht durchgeführt werden";
-
-"unable_upadate_error_message" = "Bei der Aktualisierung sind Fehler aufgetreten. Überprüfen Sie die Änderungen und versuchen Sie es noch einmal";
 
 "driving_options_title" = "Einstellungen des Umweges";
 
@@ -1951,94 +1188,19 @@
 
 "change_driving_options_btn" = "Einstellung des Umweges aktiv";
 
-"toll_road" = "Mautstraße";
-
-"unpaved_road" = "Erdweg";
-
-"ferry_crossing" = "Fährstelle";
-
-"operated_by" = "Gesteuert \"%s\"";
-
 "avoid_toll_roads_placepage" = "Mautstraßen vermeiden";
 
 "avoid_unpaved_roads_placepage" = "Erdwege vermeiden";
 
 "avoid_ferry_crossing_placepage" = "Fährstellen vermeiden";
 
-"type.cuisine.uzbek" = "Usbekische Küche";
-
-"trip_start" = "Fahren wir";
-
-"pick_destination" = "Ziel";
-
-"follow_my_position" = "Zentrieren";
-
-"search_results" = "Suchergebnisse";
-
-"then_turn" = "Danach";
-
-"redirect_route_alert" = "Möchten Sie die Route neu erstellen?";
-
-"redirect_route_yes" = "Ja";
-
-"redirect_route_no" = "Nein";
-
-"trip_finished" = "Sie sind angekommen!";
-
-"keyboard_availability_alert" = "Die Tastatur ist während der Bewegung nicht zugänglich";
-
-"dialog_routing_change_start_carplay" = "Es ist unmöglich eine Reiseroute vom aktuellen Standort planen";
-
-"dialog_routing_change_end_carplay" = "Es ist unmöglich eine Reiseroute bis zum Endpunkt planen. Wählen Sie einen anderen";
-
-"dialog_routing_check_gps_carplay" = "Kein GPS-Signal. Gehen Sie in das offene Gelände";
-
-"dialog_routing_unable_locate_route_carplay" = "Es ist unmöglich, eine Route zu planen. Wählen Sie andere Routenpunkte";
-
-"dialog_routing_download_files_carplay" = "Laden Sie die fehlenden Karten hoch, um die Route zu erstellen";
-
-"dialog_routing_system_error_carplay" = "Fehler aufgetreten. Starten Sie Applikation neu";
-
-"dialog_routing_rebuild_from_current_location_carplay" = "Die Route wird von Ihrem derzeitigen Standpunkt geplant werden";
-
-"dialog_routing_rebuild_for_vehicle_carplay" = "Reiseroute wird zur Route für Fahrzeug geändert sein";
-
 "ok" = "Ok";
-
-"avoid_unpaved_carplay_1" = "Ohne Landstr";
-
-"avoid_unpaved_carplay_2" = "Ohne Landstr.";
-
-"avoid_ferry_carplay_1" = "Ohne Fähren";
-
-"avoid_ferry_carplay_2" = "Ohne Fähren";
-
-"avoid_tolls_carplay_1" = "Ohne kpf Str";
-
-"avoid_tolls_carplay_2" = "Ohne kpfl. Str.";
-
-"speedcams_alert_title_carplay_1" = "Blitzer";
-
-"speedcams_alert_title_carplay_2" = "Blitzerwarnung";
-
-"download_map_carplay" = "Laden Sie Karten in der App Organic Maps auf Ihrem Gerät herunter";
-
-"carplay_roundabout_exit" = "%s Ausfahrt";
 
 /* max. 10 symbols, both iOS and Android */
 "sort" = "Sortieren…";
 
 /* Android, title, max 20-22 symbols */
 "sort_bookmarks" = "Lesezeichen sortieren";
-
-/* iOS */
-"sort_default" = "Default Sortierung";
-
-"sort_type" = "Sortierung nach Kategorien";
-
-"sort_distance" = "Sortieren nach Entfernung";
-
-"sort_date" = "Sortieren nach Datum";
 
 /* Android */
 "by_default" = "Default";
@@ -2052,63 +1214,7 @@
 /* Android */
 "by_date" = "Nach Datum";
 
-"week_ago_sorttype" = "Vor einer Woche";
-
-"month_ago_sorttype" = "Vor einem Monat";
-
-"moremonth_ago_sorttype" = "Vor über einem Monat";
-
-"moreyear_ago_sorttype" = "Vor über einem Jahr";
-
-"near_me_sorttype" = "In der Nähe";
-
-"others_sorttype" = "Sonstiges";
-
-"food_places" = "Essen";
-
-"tourist_places" = "Sehenswürdigkeiten";
-
-"museums" = "Museen";
-
-"parks" = "Parks";
-
-"swim_places" = "Schwimmmöglichkeiten";
-
-"mountains" = "Berge";
-
-"animals" = "Tiere";
-
-"hotels" = "Hotels";
-
-"buildings" = "Gebäude";
-
-"money" = "Geld";
-
-"shops" = "Ladengeschäfte";
-
-"parkings" = "Parkplätze";
-
-"fuel_places" = "Tankstellen";
-
-"water" = "Wasser";
-
-"medicine" = "Medizin";
-
 "search_in_the_list" = "In der Liste suchen";
-
-"view_on_map_bookmarks" = "Auf der Karte";
-
-"more_bookmarks" = "Mehr…";
-
-"no_items_found" = "Keine Einträge gefunden";
-
-/* Android, max 18 symbols */
-"bookmarks_edit_list" = "Korrigieren";
-
-/* Android, max 18 symbols */
-"bookmarks_delete_list" = "Liste löschen";
-
-"religious_places" = "Heilige Orte";
 
 "select_list" = "Wählen Sie die Liste";
 
@@ -2118,26 +1224,13 @@
 
 "dialog_pedestrian_route_is_long_message" = "Wählen Sie den Start- und Endpunkt der Route, die am nächsten zur U-Bahn-Station liegen";
 
-/* Failed planning SUBWAY route message in navigation view */
-"routing_planning_error_subway_special" = "Fehler bei der Erstellung der U-Bahn-Route";
-
 "button_layer_isolines" = "Terrain";
-
-"tips_map_layers_title_countour" = "Neu in Organic Maps: Topographie-Layer offline!";
-
-"tips_map_layers_message_countour" = "Der Topographie-Layer hilft Ihnen Ihre Reise in die Natur zu planen und sich in der Gegen zurechtzufinden";
 
 "isolines_activation_error_dialog" = "Um den Topographie-Layer benutzen zu können, aktualisieren oder laden Sie die Karte der benötigten Gegend herunter";
 
 "isolines_location_error_dialog" = "Topographie-Layer sind in dieser Region noch nicht verfügbar";
 
 "elevation_profile_diff_level" = "Komplexitätsniveau";
-
-"elevation_profile_diff_level_easy" = "Leicht";
-
-"elevation_profile_diff_level_moderate" = "Mittel";
-
-"elevation_profile_diff_level_hard" = "Schwer";
 
 "elevation_profile_ascent" = "Bergauf";
 
@@ -2147,25 +1240,13 @@
 
 "elevation_profile_maxaltitude" = "Max. Höhe";
 
-"elevation_profile_m" = "m";
-
 "elevation_profile_difficulty" = "Schwierigkeitsgrad";
 
 "elevation_profile_distance" = "Entf.:";
 
-"elevation_profile_km" = "km";
-
 "elevation_profile_time" = "Dauer:";
 
-"elevation_profile_hours" = "St.";
-
-"elevation_profile_minutes" = "Min";
-
 "isolines_toast_zooms_1_10" = "Karte vergrößern, um Isolinien zu sehen";
-
-"downloader_updating_ios" = "Update";
-
-"downloader_loading_ios" = "Download";
 
 "key_information_title" = "Wichtige Informationen";
 

--- a/iphone/Maps/LocalizedStrings/de.lproj/Localizable.stringsdict
+++ b/iphone/Maps/LocalizedStrings/de.lproj/Localizable.stringsdict
@@ -9,21 +9,6 @@
 
 <!-- ********** Strings for downloading map from search **********/ -->
 
-  <key>bookmarks_places</key>
-  <dict>
-    <key>NSStringLocalizedFormatKey</key>
-    <string>%#@value@</string>
-    <key>value</key>
-    <dict>
-      <key>NSStringFormatSpecTypeKey</key>
-      <string>NSStringPluralRuleType</string>
-      <key>NSStringFormatValueTypeKey</key>
-      <string>d</string>
-      <key>other</key>
-      <string>%d Lesezeichen</string>
-    </dict>
-  </dict>
-
   <key>bookmarks_detect_message</key>
   <dict>
     <key>NSStringLocalizedFormatKey</key>
@@ -38,21 +23,6 @@
       <string>%d Datei wurde gefunden. Sie werden es nach der Konvertierung sehen.</string>
       <key>other</key>
       <string>%d Dateien wurden gefunden. Sie werden sie nach der Konvertierung sehen.</string>
-    </dict>
-  </dict>
-
-  <key>bookmarks_objects</key>
-  <dict>
-    <key>NSStringLocalizedFormatKey</key>
-    <string>%#@value@</string>
-    <key>value</key>
-    <dict>
-      <key>NSStringFormatSpecTypeKey</key>
-      <string>NSStringPluralRuleType</string>
-      <key>NSStringFormatValueTypeKey</key>
-      <string>d</string>
-      <key>other</key>
-      <string>%s Objekt</string>
     </dict>
   </dict>
 

--- a/iphone/Maps/LocalizedStrings/el.lproj/Localizable.strings
+++ b/iphone/Maps/LocalizedStrings/el.lproj/Localizable.strings
@@ -18,9 +18,6 @@
 /* Button which deletes downloaded country */
 "delete" = "Διαγραφή";
 
-/* Button "do not interrupt download" if user touched actively downloading country */
-"do_nothing" = "Continue";
-
 "download_maps" = "Λήψη χαρτών";
 
 /* Settings/Downloader - info for country when download fails */
@@ -28,9 +25,6 @@
 
 /* Settings/Downloader - info for country which started downloading */
 "downloading" = "Λήψη…";
-
-/* Settings/Downloader - size string, only strings different from English should be translated */
-"kb" = "kB";
 
 /* Choose measurement on first launch alert - choose metric system button */
 "kilometres" = "Χιλιόμετρα";
@@ -55,17 +49,11 @@
 /* Update maps later/Buy pro version later button text */
 "later" = "Αργότερα";
 
-/* Don't show some dialog any more */
-"never" = "Never";
-
 /* View and button titles for accessibility */
 "search" = "Αναζήτηση";
 
 /* Search box placeholder text */
 "search_map" = "Αναζήτηση χάρτη";
-
-/* Settings/Downloader - info for not downloaded country */
-"touch_to_download" = "Touch to download";
 
 /* Settings/Downloader - 3G download warning dialog confirm button */
 "use_cellular_data" = "Ναι";
@@ -73,20 +61,11 @@
 /* Location services are disabled by user alert - message */
 "location_is_disabled_long_text" = "Οι υπηρεσίες εντοπισμού τοποθεσίας είναι προς το παρόν απενεργοποιημένες σε αυτή τη συσκευή ή για αυτή την εφαρμογή. Ενεργοποιήστε τις από τις Ρυθμίσεις.";
 
-/* Location Services are not available on the device alert - message */
-"device_doesnot_support_location_services" = "Your device doesn't support Location Services";
-
 /* View and button titles for accessibility */
 "zoom_to_country" = "Εμφάνιση στο χάρτη";
 
-/* Button text for the button at the center of the screen when the country is not downloaded */
-"country_status_download" = "Λήψη Χάρτη\n(^ ^)";
-
 /* Button text for the button at the center of the screen when the country is not downloaded and the size should not be shown */
 "country_status_download_without_size" = "Λήψη χάρτη";
-
-/* Button text for the button at the center of the screen when the country is not downloaded */
-"country_status_download_without_routing" = "Λήχη χάρτη\nχωρίς δρομολόγηση (^ ^)";
 
 /* Message to display at the center of the screen when the country download has failed */
 "country_status_download_failed" = "Η λήψη απέτυχε";
@@ -96,19 +75,13 @@
 
 "about_menu_title" = "Σχετικά με το Organic Maps";
 
-"downloaded_touch_to_delete" = "Downloaded (%@), touch to delete";
-
 "connection_settings" = "Ρυθμίσεις σύνδεσης";
-
-"download_mb_or_kb" = "Download %@";
 
 "close" = "Κλείσιμο";
 
 "unsupported_phone" = "Η εφαρμογή απαιτεί OpenGL με επιτάχυνση υλικού. Δυστυχώς, η συσκευή σας δεν το υποστηρίζει.";
 
 "download" = "Λήψη";
-
-"external_storage_is_not_available" = "SD card/USB storage with downloaded maps is not available";
 
 "disconnect_usb_cable" = "Αποσυνδέστε το καλώδιο USB ή τοποθετήστε την κάρτα μνήμης για να χρησιμοποιήσετε το Organic Maps";
 
@@ -117,8 +90,6 @@
 "not_enough_memory" = "Δεν υπάρχει αρκετή μνήμη για την έναρξη εφαρμογής";
 
 "download_resources" = "Πριν ξεκινήσετε τη χρήση της εφαρμογής, επιτρέψτε μας να κατεβάσουμε το γενικό παγκόσμιο χάρτη στη συσκευή σας. \nIt θα χρησιμοποιήσει %@ αποθηκευτικού χώρου.";
-
-"getting_position" = "Λήψη τρέχουσας τοποθεσίας";
 
 "download_resources_continue" = "Μετάβαση στο χάρτη";
 
@@ -140,23 +111,14 @@
 /* Add New Bookmark Set dialog title */
 "add_new_set" = "Προσθέστε νέο σύνολο";
 
-/* Place Page - Add To Bookmarks button */
-"add_to_bookmarks" = "Add to Bookmarks";
-
 /* Bookmark Color dialog title */
 "bookmark_color" = "Χρώμα αγαπημένου";
 
 /* Add Bookmark Set dialog - hint when set name is empty */
 "bookmark_set_name" = "Όνομα συνόλου αγαπημένων";
 
-/* Bookmark Sets dialog title */
-"bookmark_sets" = "Σύνολα αγαπημένων";
-
 /* Bookmarks - dialog title */
 "bookmarks" = "Αγαπημένα";
-
-/* Add bookmark dialog - bookmark color */
-"color" = "Color";
 
 /* Default bookmarks set name */
 "core_my_places" = "Οι τοποθεσίες μου";
@@ -167,14 +129,8 @@
 /* Editor title above street and house number */
 "address" = "Διεύθυνση";
 
-/* Place Page - Remove Pin button */
-"remove_pin" = "Remove Pin";
-
 /* Add bookmark dialog - bookmark set, Bookmarks dialog - Bookmark set cell */
 "set" = "Σύνολο";
-
-/* Text hint in Bookmarks dialog when no any bookmarks are added */
-"bookmarks_usage_hint" = "Δεν έχετε αγαπημένα ακόμα.\nΠατήστε σε οποιοδήποτε σημείο στο χάρτη για να προσθέσετε αγαπημένο.\nΜπορείτε επίσης να εισάγετε αγαπημένα από άλλες πηγές και να τα εμφανίσετε στο Organic Maps. Ανοίξτε το αρχείο KML/KMZ με τα αποθηκευμένα αγαπημένα από το email, το Dropbox ή τους υπερσυνδέσμους.";
 
 /* Settings button in system menu */
 "settings" = "Ρυθμίσεις";
@@ -191,26 +147,11 @@
 /* Ask to wait user several minutes (some long process in modal dialog). */
 "wait_several_minutes" = "Αυτό μπορεί να διαρκέσει αρκετά λεπτά. \nΠαρακαλώ περιμένετε…";
 
-/* Show bookmarks from this category on a map or not */
-"visible" = "Ορατό";
-
-/* Toast which is displayed when GPS has been deactivated */
-"gps_is_disabled_long_text" = "GPS is disabled. Please enable it in Settings.";
-
 /* Measurement units title in settings activity */
 "measurement_units" = "Μονάδες μέτρησης";
 
 /* Detailed description of Measurement Units settings button */
 "measurement_units_summary" = "Επιλέξετε ανάμεσα σε μίλια και χιλιόμετρα";
-
-/* Do search in all sources */
-"search_mode_all" = "Everywhere";
-
-/* Do search near my position only */
-"search_mode_nearme" = "Near Me";
-
-/* Do search in current viewport only */
-"search_mode_viewport" = "On the Screen";
 
 /* Search category for cafes, bars, restaurants */
 "eat" = "Πού να φάμε";
@@ -266,14 +207,8 @@
 /* Search category */
 "police" = "Αστυνομία";
 
-/* String in search result list, when nothing found */
-"no_search_results_found" = "No results found";
-
 /* Notes field in Bookmarks view */
 "description" = "Σημειώσεις";
-
-/* Button text */
-"share_by_email" = "Κοινοποίηση μέσω ηλεκτρονικού ταχυδρομείου";
 
 /* Email Subject when sharing bookmarks category */
 "share_bookmarks_email_subject" = "Κοινοποιήθηκαν αγαπημένα Organic Maps με σας";
@@ -295,26 +230,11 @@
 /* Warning message when doing search around current position */
 "unknown_current_position" = "Η τοποθεσία σας δεν έχει καθοριστεί ακόμη";
 
-/* Warning message when location country isn't downloaded during search (see also download_location_map_proposal). */
-"download_location_country" = "Κατεβάστε τον χάρτη για την τρέχουσα τοποθεσία σας (%@)";
-
-/* Warning message when viewport country isn't downloaded during search */
-"download_viewport_country_to_search" = "Download the country you are searching on (%@)";
-
 /* Alert message that we can't run Map Storage settings due to some reasons. */
 "cant_change_this_setting" = "Λυπούμαστε, η αποθήκευση του χάρτη είναι προς το παρόν απενεργοποιημένη.";
 
 /* Alert message that downloading is in progress. */
 "downloading_is_active" = "Λήψη χάρτη σε εξέλιξη.";
-
-/* Message that will be shown in alert view, when we ask user to leave review on App Store */
-"appStore_message" = "Hope you enjoy using Organic Maps! If so, please rate or review the app at the App Store. It takes less than a minute but can really help us. Thanks for your support!";
-
-/* No, thanks */
-"no_thanks" = "No, thanks";
-
-/* Share one specific bookmark using SMS, %1$@ contains om:// and %2$@ https://omaps.app link. @NOTE non-ascii symbols in the link will result in max 70 characters SMS instead of 140. */
-"bookmark_share_sms" = "Έλεγξε τις τοποθεσίες που έχω καρφιτσώσει στο Organic Maps! %1$@ ή %2$@ εάν δεν έχεις εγκαταστήσει χάρτες εκτός σύνδεσης, μπορείς να τους κατεβάσεις εδώ: https://omaps.app/get";
 
 /* Share my position using SMS, %1$@ contains om:// and %2$@ https://omaps.app link WITHOUT NAME. @NOTE non-ascii symbols in the link will result in max 70 characters SMS instead of 140. */
 "my_position_share_sms" = "Έλεγξε την τρέχουσα τοποθεσία μου στο Organic Maps! %1$@ ή %2$@ στην περίπτωση που δεν έχεις εγκαταστήσει χάρτες εκτός σύνδεσης, μπορείς να τους κατεβάσεις εδώ: https://omaps.app/get";
@@ -328,23 +248,11 @@
 /* Share my position using EMail, %1$@ is om:// and %2$@ is https://omaps.app link WITHOUT NAME */
 "my_position_share_email" = "Γεια,\n\nείμαι εδώ τώρα: %1$@. Κάνε κλικ σε αυτό το σύνδεσμο %2$@ ή σε αυτόν %3$@ για να δεις την τοποθεσία στο χάρτη.\n\nΕυχαριστώ.";
 
-/* Android share by Message/SMS button text (including SMS) */
-"share_by_message" = "Κοινοποίηση μέσω μηνύματος";
-
 /* Share button text which opens menu with more buttons, like Message, EMail, Facebook etc. */
 "share" = "Κοινοποίηση";
 
-/* iOS share by Message button text (including SMS) */
-"message" = "Message";
-
 /* Share by email button text, also used in editor. */
 "email" = "Email";
-
-/* Copy Link */
-"copy_link" = "Copy Link";
-
-/* Text for the button that returns to caller application */
-"more_info" = "Show More Info";
 
 /* Text for message when used successfully copied something */
 "copied_to_clipboard" = "Αντιγράφηκε στο Πρόχειρο: %1$@";
@@ -354,15 +262,6 @@
 
 /* Used for bookmark editing */
 "done" = "Ολοκληρώθηκε";
-
-/* Summary for preferences in MWM */
-"yopme_pref_summary" = "Choose Back Screen settings";
-
-/* Title for yopme preferences in MWM */
-"yopme_pref_title" = "Back Screen Settings";
-
-/* Hint for upper-right icon p2b */
-"show_on_backscreen" = "Show on Back screen";
 
 /* Prints version number in About dialog */
 "version" = "Έκδοση: %@";
@@ -381,19 +280,11 @@
 
 "share_my_location" = "Κοινοποίηση της τοποθεσίας μου";
 
-"menu_search" = "Search";
-
 /* Settings general group in settings screen */
 "prefs_group_general" = "General settings";
 
 /* Settings information group in settings screen */
 "prefs_group_information" = "Information";
-
-/* Settings screen: "Map" category title */
-"prefs_group_map" = "Χάρτης";
-
-/* Settings screen: "Miscellaneous" category title */
-"prefs_group_misc" = "Διάφορα";
 
 "prefs_group_route" = "Πλοήγηση";
 
@@ -419,9 +310,6 @@
 /* Settings «Map» category: «3D buildings» title */
 "pref_map_3d_buildings_title" = "Τρισδιάστατα κτίρια";
 
-/* Settings «Map» category: «3D buildings» summary */
-"pref_map_3d_buildings_subtitle" = "Affects battery life";
-
 /* Settings «Route» category: «Tts enabled» title */
 "pref_tts_enable_title" = "Φωνητικές οδηγίες";
 
@@ -433,8 +321,6 @@
 
 /* Title for "Other" section in TTS settings. */
 "pref_tts_other_section_title" = "Άλλα";
-
-"pref_tts_how_to_set_up_voice" = "Ρύθμιση φωνής";
 
 /* Settings «Map» category: «Record track» title */
 "pref_track_record_title" = "Πρόσφατη διαδρομή";
@@ -455,56 +341,7 @@
 
 "recent_track_help_text" = "Σας επιτρέπει να καταγράψετε τη διαδρομή που έχει διανυθεί για συγκεκριμένο χρονικό διάστημα και να την δείτε στο χάρτη. Λάβετε υπόψη: η ενεργοποίηση αυτής της λειτουργίας κάνει έντονη χρήση της μπαταρίας. Το τμήμα θα αφαιρεθεί αυτόματα από το χάρτη μετά τη λήξη του μεσοδιαστήματος.";
 
-"pref_track_ios_caption" = "Recent track shows your traveled path.";
-
-"pref_track_ios_subcaption" = "Please select the time range of saving the track.";
-
-"placepage_distance" = "Distance";
-
-"placepage_coordinates" = "Coordinates";
-
-"placepage_unsorted" = "Unsorted";
-
 "search_show_on_map" = "Προβολή στο χάρτη";
-
-/* Used to warn user when fixing KitKat issue */
-"bookmark_move_fail" = "We need to move your bookmarks to internal memory, but there is no available space for them. Please free up the memory, otherwise bookmarks won’t be available.";
-
-/* Used in More Apps menu */
-"free" = "Free";
-
-/* Used in More Apps menu */
-"buy" = "Buy";
-
-/* 1st search button-like result */
-"search_on_map" = "Αναζήτηση στο χάρτη";
-
-/* toast with an error */
-"no_route_found" = "Δεν βρέθηκε διαδρομή";
-
-/* route title */
-"route" = "Διαδρομή";
-
-/* category title */
-"routes" = "Διαδρομές";
-
-/* text of notification */
-"download_map_notification" = "Κατεβάστε τον χάρτη της τοποθεσίας που βρίσκεστε";
-
-/* text of notification */
-"pro_version_is_free_today" = "Full version of Organic Maps is free today! Download now and tell your friends.";
-
-/* Dialog for transferring maps from lite to pro. */
-"move_lite_maps_to_pro" = "We are transferring your downloaded maps from Organic Maps Lite to Organic Maps. It may take a few minutes.";
-
-/* Message to display when maps moved. */
-"move_lite_maps_to_pro_ok" = "Your downloaded maps are successfully transferred to Organic Maps.";
-
-/* Message to display when maps move failed. */
-"move_lite_maps_to_pro_failed" = "Your maps failed to transfer. Please delete Organic Maps Lite and download the maps again.";
-
-/* Text in menu */
-"settings_and_more" = "Settings & More";
 
 /* Text in menu */
 "website" = "Ιστότοπος";
@@ -527,14 +364,8 @@
 /* Text in menu */
 "openstreetmap" = "OpenStreetMap";
 
-/* Text in menu */
-"contact_us" = "Επικοινωνήστε μαζί μας";
-
 /* Settings: Send feedback button and dialog title */
 "feedback" = "Σχόλια";
-
-/* Text in menu */
-"subscribe_to_news" = "Εγγραφή στο ενημερωτικό μας δελτίο";
 
 /* Text in menu */
 "rate_the_app" = "Βαθμολογήστε την εφαρμογή";
@@ -548,15 +379,6 @@
 /* Text in menu */
 "report_a_bug" = "Αναφορά σφάλματος";
 
-/* Email subject */
-"subscribe_me_subject" = "Εγγράψτε με στο ενημερωτικό δελτίο Organic Maps";
-
-/* Email body */
-"subscribe_me_body" = "Θέλω να μαθαίνω πρώτος(η) τις τελευταίες ειδήσεις, ενημερώσεις εφαρμογών και προωθητικές ενέργειεςς. Καταλαβαίνω ότι μπορώ να ακυρώσω τη συνδρομή μου ανά πάσα στιγμή.";
-
-/* About text */
-"about_text" = "Organic Maps offers the fastest offline maps of all the cities, all countries of the world. Travel with full confidence: wherever you are, Organic Maps helps to locate yourself on the map, find the nearest restaurant, hotel, bank, gas station etc. It doesn’t require internet connection.\n\nWe are always working on new features and would love to hear from you on how you think we could improve Organic Maps. If you have any problems with the app, don't hesitate to contact us at support@organicmaps.app. We respond to every request!\n\nDo you like Organic Maps and want to support us? There are some simple and absolutely free ways:\n\n- post a review at your App Market\n- like our Facebook page http://www.facebook.com/OrganicMaps\n- or just tell about Organic Maps to your mom, friends and colleagues :)\n\nThank you for being with us. We appreciate your support very much!\n\nP.S. We take map data from OpenStreetMap, a mapping project similar to Wikipedia, which allows users to create and edit maps. If you see something is missing or wrong on the map, you can correct the maps directly at https://www.openstreetmap.org, and your changes will appear in Organic Maps app with the next version release.";
-
 /* Alert text */
 "email_error_body" = "Το πρόγραμμα-client ηλεκτρονικού ταχυδρομείου έχει δεν έχει ρυθμιστεί. Ρυθμίστε το ή χρησιμοποιήστε άλλο τρόπο να επικοινωνήσετε μαζί μας στη διεύθυνση %@";
 
@@ -569,12 +391,6 @@
 /* Search category */
 "wifi" = "WiFi";
 
-/* Update map suggestion */
-"routing_map_outdated" = "Please update the map to create a route";
-
-/* Update maps suggestion */
-"routing_update_maps" = "The new version of Organic Maps allows creating routes from your current position to a destination point. Please update maps to use this feature.";
-
 /* Update all button text */
 "downloader_update_all_button" = "Ενημέρωση όλων";
 
@@ -583,9 +399,6 @@
 
 /* Downloaded maps category */
 "downloader_downloaded_subtitle" = "Έγινε λήψη";
-
-/* Downloaded maps category */
-"downloader_available_maps" = "Διαθέσιμη";
 
 /* Country queued for download */
 "downloader_queued" = "στην ουρά";
@@ -598,17 +411,6 @@
 
 "downloader_downloading" = "Λήψη:";
 
-"downloader_search_results" = "Βρέθηκαν";
-
-/* Disclaimer message */
-"routing_disclaimer" = "Creating routes in Organic Maps app, please keep in mind the following:\n\n  - Suggested routes can be considered as recommendations only.\n - Road conditions, traffic rules and signs have higher priority than navigation advice.\n - The map may be incorrect or outdated, and routes may not be created the best possible way.\n\n  Be safe on roads and take care of yourself!";
-
-/* Outdated maps category */
-"downloader_outdated_maps" = "Outdated";
-
-/* Up to date maps category */
-"downloader_uptodate_maps" = "Up-to-date";
-
 /* Status of outdated country in the list */
 "downloader_status_outdated" = "Ενημέρωση";
 
@@ -618,49 +420,14 @@
 /* Displayed in a dialog that appears when a user tries to delete a map while the app is in the follow route mode */
 "downloader_delete_map_while_routing_dialog" = "Για να διαγράψετε το χάρτη, σταματήστε την πλοήγηση.";
 
-/* Show when user try build route, but we don't know where he */
-"routing_failed_unknown_my_position" = "Η τρέχουσα τοποθεσία δεν έχει οριστεί. Προσδιορίστε τοποθεσίας για να δημιουργήσετε διαδρομή.";
-
-/* Show if use has not routing file, or InconsistentMWMandRoute */
-"routing_failed_has_no_routing_file" = "Απαιτούνται πρόσθετα δεδομένα για να δημιουργήσετε τη διαδρομή. Λήψη δεδομένων τώρα;";
-
-/* StartPointNotFound */
-"routing_failed_start_point_not_found" = "Δεν μπορεί να υπολογιστεί η διαδρομή. Δεν υπάρχουν δρόμοι κοντά στο σημείο εκκίνησης.";
-
-/* EndPointNotFound */
-"routing_failed_dst_point_not_found" = "Δεν μπορεί να υπολογιστεί η διαδρομή. Δεν υπάρχουν δρόμοι κοντά στον προορισμό σας.";
-
 /* PointsInDifferentMWM */
 "routing_failed_cross_mwm_building" = "Μπορούν να δημιουργηθούν μόνο διαδρομές που περιέχονται πλήρως μέσα σε ένα χάρτη σε μια ενιαία περιοχή.";
-
-/* RouteNotFound */
-"routing_failed_route_not_found" = "Δεν βρέθηκε καμία διαδρομή μεταξύ της επιλεγμένης προέλευσης και προορισμού. Επιλέξτε ένα διαφορετικό σημείο έναρξης ή λήξης.";
-
-/* InternalError */
-"routing_failed_internal_error" = "Παρουσιάστηκε εσωτερικό σφάλμα. Δοκιμάστε να διαγράψετε και να κατεβάσετε το χάρτη ξανά. Εάν το πρόβλημα παραμένει, επικοινωνήστε μαζί μας στη διεύθυνση support@organicmaps.app.";
-
-/* Context menu item for downloader. */
-"downloader_download_map_and_routing" = "Download Map + Routing";
-
-/* Context menu item for downloader. */
-"downloader_download_routing" = "Download Routing";
-
-/* Context menu item for downloader. */
-"downloader_delete_routing" = "Delete Routing";
 
 /* Context menu item for downloader. */
 "downloader_download_map" = "Λήψη χάρτη";
 
-"downloader_download_map_no_routing" = "Download map without routing";
-
-/* Button for routing. */
-"routing_go" = "Go!";
-
 /* Item status in downloader. */
 "downloader_retry" = "Επανάληψη";
-
-/* Item in context menu. */
-"downloader_map_and_routing" = "Map + Routing";
 
 /* Item in context menu. */
 "downloader_delete_map" = "Διαγραφή χάρτη";
@@ -668,29 +435,11 @@
 /* Item in context menu. */
 "downloader_update_map" = "Ενημέρωση χάρτη";
 
-/* Item in context menu. */
-"downloader_update_map_and_routing" = "Update Map + Routing";
-
-/* Item in context menu. */
-"downloader_map_only" = "Map Only";
-
-/* Toolbar title */
-"toolbar_application_menu" = "Application menu";
-
 /* Preference text */
 "pref_use_google_play" = "Χρησιμοποιήστε υπηρεσίες Google Play για να προσδιορίσετε την τρέχουσα τοποθεσία σας";
 
 /* Text for rating dialog */
 "rating_just_rated" = "Μόλις βαθμολόγησα την εφαρμογή σας";
-
-/* Text for rating dialog */
-"rating_user_since" = "Χρησιμοποιώ το Organic Maps από τις %@";
-
-/* Text for rating dialog */
-"rating_do_like_maps" = "Σας αρέσει το Organic Maps;";
-
-/* Text for rating dialog */
-"rating_tap_star" = "Πατήστε ένα αστέρι να βαθμολογήσετε την εφαρμογή μας.";
 
 /* Text for rating dialog */
 "rating_thanks" = "Σας ευχαριστούμε!";
@@ -701,23 +450,8 @@
 /* Text for rating dialog */
 "rating_send_feedback" = "Αποστολή σχολίου";
 
-/* Text for g+ dialog */
-"rating_google_plus" = "Κάντε κλικ στο g+ να ενημερώσετε τους φίλους σας σχετικά με την εφαρμογή.";
-
 /* Text for routing error dialog */
 "routing_download_maps_along" = "Κατεβάστε όλους τους χάρτες για ολόκληρο το μήκος της διαδρομής σας";
-
-/* Text for routing error dialog */
-"routing_download_map" = "Λήψη χάρτη";
-
-/* Text for routing error dialog */
-"routing_download_map_and_routing" = "Κάντε λήψη ενημερωμένου χάρτη και δεδομένων πλοήγησης για να έχετε όλα τα χαρακτηριστικά του Organic Maps.";
-
-/* Text for routing error dialog */
-"routing_get_routing_data" = "Λήψη δεδομένων πλοήγησης";
-
-/* Text for routing error dialog */
-"routing_get_additional_data" = "Απαιτούνται επιπλέον δεδομένα για τη δημιουργία διαδρομών από την τοποθεσία σας.";
 
 /* Text for routing error dialog */
 "routing_requires_all_map" = "Για να δημιουργήσετε μια διαδρομή, πρέπει να κατεβάσετε και να ενημερώσετε όλους τους χάρτες από τη θέση σας στον προορισμό σας.";
@@ -725,50 +459,15 @@
 /* Text for routing error dialog */
 "routing_not_enough_space" = "Δεν υπάρχει αρκετός χώρος";
 
-/* Text for routing error dialog */
-"routing_download_more_than_avail" = "Πρέπει να κάνετε λήψη %@ MB, αλλά μόνο %@ MB είναι διαθέσιμα.";
-
-/* Text for routing error dialog */
-"routing_download_roaming" = "Πρόκειται να κάνετε λήψη %@ MB χρησιμοποιώντας Δεδομένα Δικτύου Κινητής Τηλεφωνίας (σε Περιαγωγή). Αυτό μπορεί να προκαλέσει επιπρόσθετες χρεώσεις, που εξαρτώνται από το πρόγραμμα δεδομένων δικτύου κινητής τηλεφωνίας του παρόχου σας.";
-
 /* bookmark button text */
 "bookmark" = "αγαπημένο";
-
-/* map is not downloaded */
-"not_found_map" = "The map for your location is not downloaded";
 
 /* location service disabled */
 "enable_location_services" = "Ενεργοποιήστε τις υπηρεσίες εντοπισμού τοποθεσίας";
 
-/* download map */
-"download_map" = "Download the map for your location";
-
-/* download map on iPhone */
-"download_map_iphone" = "Download a current location map on your iPhone";
-
-/* clear pin */
-"nearby" = "Nearby";
-
-/* clear pin */
-"clear_pin" = "Clear Pin";
-
-/* location is undefined */
-"undefined_location" = "Current location is undefined.";
-
-/* download country of your location */
-"download_country" = "Download the country of your current location";
-
-/* download failed */
-"download_failed" = "download has failed";
-
-/* get the map */
-"get_the_map" = "Get the map";
-
 "save" = "Αποθήκευση";
 
 "edit_description_hint" = "Οι περιγραφές σας (κείμενο ή html)";
-
-"new_group" = "νέα ομάδα";
 
 "create" = "δημιουργήστε";
 
@@ -795,30 +494,6 @@
 
 /* pink color */
 "pink" = "Ροζ";
-
-/* deep purple color */
-"deep_purple" = "Βαθύ πορφυρό";
-
-/* light blue color */
-"light_blue" = "Γαλάζιο";
-
-/* cyan color */
-"cyan" = "Κυανό";
-
-/* teal color */
-"teal" = "Σμαραγδένιο";
-
-/* lime color */
-"lime" = "Κιτρινοπράσινο";
-
-/* deep orange color */
-"deep_orange" = "Βαθύ πορτοκαλί";
-
-/* gray color */
-"gray" = "Γκρι";
-
-/* blue gray color */
-"blue_gray" = "Γκρίζο μπλε";
 
 /* Wi-Fi available */
 "WiFi_available" = "Ναι";
@@ -848,13 +523,9 @@
 
 "dialog_routing_location_unknown_turn_on" = "Δεν είναι δυνατός ο εντοπισμός των τρεχουσών συντεταγμένων GPS. Ενεργοποιήστε τις υπηρεσίες εντοπισμού τοποθεσίας για τον υπολογισμό της διαδρομής.";
 
-"dialog_routing_location_unknown" = "Unable to locate current GPS coordinates.";
-
 "dialog_routing_download_files" = "Κατεβάστε τα απαιτούμενα αρχεία";
 
 "dialog_routing_download_and_update_all" = "Κατεβάσετε και να ενημερώσετε όλους τους χάρτες και τις πληροφορίες δρομολόγησης για όλη την απόσταση της προβαλλόμενης διαδρομής για τον υπολογισμό της.";
-
-"dialog_routing_routes_size" = "Routing information files";
 
 "dialog_routing_unable_locate_route" = "Δε μπορεί να εντοπιστεί η διαδρομή";
 
@@ -884,21 +555,11 @@
 
 "dialog_routing_try_again" = "Προσπαθήστε ξανά";
 
-"dialog_routing_send_error" = "Report the Problem";
-
-"dialog_routing_if_get_cross_route" = "Would you like to create a more direct route that spans more than one map?";
-
-"dialog_routing_cross_route_is_optimal" = "A more optimal route that crosses the edge of this map is available.";
-
 "not_now" = "Όχι τώρα";
-
-"dialog_routing_build_route" = "Create";
 
 "dialog_routing_download_and_build_cross_route" = "Θέλετε να κατεβάσετε το χάρτη και να δημιουργήσετε μια πιο βέλτιστη διαδρομή που εκτείνονται σε περισσότερους από έναν χάρτη;";
 
 "dialog_routing_download_cross_route" = "Κατεβάσετε επιπλέον χάρτες για να δημιουργήσετε μια καλύτερη διαδρομή που διασχίζει τα όρια αυτού του χάρτη.";
-
-"dialog_routing_cross_route_always" = "Always cross this boundary";
 
 
 /********** Strings for downloading map from search **********/
@@ -906,8 +567,6 @@
 "search_without_internet_advertisement" = "Για να ξεκινήσετε την αναζήτηση και τη δημιουργία διαδρομών, κατεβάστε το χάρτη. Μετά από αυτό δεν θα χρειάζεστε πλέον σύνδεση στο Internet.";
 
 "search_select_map" = "Επιλέξτε χάρτη";
-
-"search_select_other_map" = "Select Another Map";
 
 /* «Show» context menu */
 "show" = "Εμφάνιση";
@@ -918,17 +577,11 @@
 /* «Rename» context menu */
 "rename" = "Μετονομασία";
 
-/* Bottom sheet: expand button (should be short) */
-"bottom_sheet_more" = "More…";
-
 /* Failed planning route message in navigation view */
 "routing_planning_error" = "Ο σχεδιασμός διαδρομής απέτυχε";
 
 /* Arrive routing message in navigation view */
 "routing_arrive" = "Άφιξη στις %s";
-
-/* Text for routing::RouterResultCode::FileTooOld dialog. */
-"dialog_routing_download_and_update_maps" = "Download and update all map along the projected path to calculate route.";
 
 "rate_alert_title" = "Σας αρέσει η εφαρμογή;";
 
@@ -944,19 +597,11 @@
 
 "history" = "Ιστορικό";
 
-"next_turn_then" = "Then";
-
 "closed" = "Κλειστό";
-
-"back_to" = "Επιστροφή στο %@";
 
 "search_not_found" = "Ωχ, δεν βρέθηκαν αποτελέσματα.";
 
 "search_not_found_query" = "Δοκιμάστε να αλλάξετε τα κριτήρια αναζήτησής σας.";
-
-"search_not_found_map" = "Please download the map you are searching in.";
-
-"search_not_found_location" = "Download the map of your current location.";
 
 "search_history_title" = "Ιστορικό αναζήτησης";
 
@@ -964,23 +609,12 @@
 
 "clear_search" = "Εκκαθάριση ιστορικού αναζήτησης";
 
-/* Title for settings to enable/disable showcase menu button */
-"showcase_settings_title" = "Εμφάνιση προσφορών";
-
 /* Place Page link to Wikipedia article (if map object has it). */
 "read_in_wikipedia" = "Wikipedia";
 
-"p2p_route_planning" = "Route Planning";
-
 "p2p_your_location" = "Η τοποθεσία σας";
 
-"p2p_from" = "Από";
-
-"p2p_to" = "Έως";
-
 "p2p_start" = "Έναρξη";
-
-"p2p_planning" = "Σχεδιασμός…";
 
 "p2p_from_here" = "Διαδρομή από";
 
@@ -1018,15 +652,9 @@
 
 "editor_correct_mistake" = "Διόρθωση λάθους";
 
-"editor_correct_mistake_message" = "You made an editing mistake. Please correct it or switch to simple mode.";
-
 "editor_add_select_location" = "Τοποθεσία";
 
 "editor_done_dialog_1" = "Έχετε αλλάξει τον παγκόμιο χάρτη. Μην το κρατάτε για τον εαυτό σας! Πείτε το στους φίλους σας και κάντε τις αλλαγές μαζί.";
-
-"editor_done_dialog_2" = "Αυτή είναι η δεύτερη φορά που επεξεργαστήκατε το χάρτη. Είστε πλέον %d στην κατάταξη των επεξεργαστών του χάρτη. Πείτε το στους φίλους σας.";
-
-"editor_done_dialog_3" = "You’ve improved the map, tell your friends about it, and edit the map together.";
 
 "share_with_friends" = "Μοιραστείτε με φίλους";
 
@@ -1044,20 +672,7 @@
 
 "editor_report_problem_duplicate_place_title" = "Διπλότυπη τοποθεσία";
 
-"first_launch_congrats_title" = "Το Organic Maps είναι έτοιμο για χρήση";
-
-"first_launch_congrats_text" = "Κάντε αναζήτηση και πλοηγηθείτε παντού στον κόσμο χωρίς σύνδεση και χωρίς χρέωση.";
-
-"migrate_title" = "Σημαντικό!";
-
-/* Android uses image instead of text. */
-"download_all" = "Download all";
-
-"delete_all" = "Delete all";
-
 "autodownload" = "Αυτόματη λήψη";
-
-"disable_autodownload" = "Disable autodownload";
 
 /* Place Page opening hours text */
 "closed_now" = "Τώρα είναι κλειστό";
@@ -1072,10 +687,6 @@
 "day_off" = "Κλειστό";
 
 "today" = "Σήμερα";
-
-"sunrise_to_sunset" = "From sunrise to sunset";
-
-"sunset_to_sunrise" = "From sunset to sunrise";
 
 "add_opening_hours" = "Προσθέστε ώρες λειτουργίας";
 
@@ -1095,45 +706,18 @@
 
 "forgot_password" = "Ξαχάσατε τον κωδικό πρόσβασης;";
 
-/* Forgot Password dialog title */
-"restore_password" = "Restore password";
-
-"enter_email_address_to_reset_password" = "Enter the email address you used during registration and we will send you the link to reset your password.";
-
-"reset_password" = "Reset Password";
-
-"username" = "Username";
-
 "osm_account" = "Λογαριασμός OSM  ";
 
 "logout" = "Αποσύνδεση";
 
-"login_and_edit_map_motivation_message" = "Log in and edit objects on the map, and we will make them available for millions of users. Let’s make the world better together.";
-
 /* Information text: "Last upload 11.01.2016" */
 "last_upload" = "Τελευταία μεταφόρτωση";
 
-/* Motivates user to login/register, title above login buttons. */
-"you_have_edited_your_first_object" = "You’ve edited your first object!";
-
 "thank_you" = "Σας ευχαριστούμε";
-
-"login_with_google" = "Login with Google";
-
-"login_with_openstreetmap" = "Log in with www.openstreetmap.org";
 
 "edit_place" = "Επεξεργασία μέρους";
 
 "place_name" = "Όνομα μέρους";
-
-/* title above languages list cells in the editor, below editable name text field. */
-"other_languages" = "Other Languages";
-
-/* small button to open list with names in different languages */
-"show_more" = "Περισσότερα";
-
-/* small button to close list with names in different languages */
-"show_less" = "Λιγότερα";
 
 "add_language" = "Προσθήκη γλώσσας";
 
@@ -1164,8 +748,6 @@
 
 "please_note" = "Λάβετε υπόψη";
 
-"common_no_wifi_dialog" = "No WiFi connection. Do you want to continue with mobile data?";
-
 "downloader_delete_map_dialog" = "Όλες οι αλλαγές που έχετε κάνει στο χάρτη θα διαγραφούν μαζί με το χάρτη.";
 
 "downloader_update_maps" = "Ενημέρωση χαρτών";
@@ -1173,10 +755,6 @@
 "downloader_mwm_migration_dialog" = "Για να δημιουργήσετε μια διαδρομή, πρέπει να ενημερώσετε όλους τους χάρτες και στη συνέχεια να σχεδιάσετε τη διαδρομή ξανά.";
 
 "downloader_search_field_hint" = "Ανεύρεση χάρτη";
-
-"migration_update_all_button" = "Ενημέρωση όλων των χαρτών";
-
-"migration_delete_all_download_current_button" = "Κατεβάστε τον τρέχον χάρτη και διαγράψτε όλους τους παλιούς";
 
 "migration_download_error_dialog" = "Σφάλμα λήψης";
 
@@ -1186,21 +764,9 @@
 
 "downloader_no_space_message" = "Διαγράψτε τυχόν μη απαραίτητα δεδομένα";
 
-"editor_general_auth_error_dialog" = "General login error.";
-
 "editor_login_error_dialog" = "Σφάλμα σύνδεσης.";
 
-"editor_login_failed_dialog" = "Login failed";
-
-"editor_username_error_dialog" = "Username is invalid";
-
-"editor_place_edited_dialog" = "You’ve edited an object!";
-
-"editor_login_with_osm" = "Login with OpenStreetMap";
-
 "editor_profile_changes" = "Επαληθευμένες αλλαγές";
-
-"editor_profile_unsent_changes" = "Not sent:";
 
 "editor_focus_map_on_location" = "Σύρετε τον χάρτη για να επιλέξετε τη σωστή θέση του αντικειμένου.";
 
@@ -1222,13 +788,9 @@
 
 "editor_report_problem_other_title" = "Διαφορετικό πρόβλημα";
 
-"placepage_report_problem_button" = "Report a problem";
-
 "placepage_add_business_button" = "Προσθήκη επιχείρησης";
 
 "whatsnew_editor_message_1" = "Προσθέστε νέες τοποθεσίες στο χάρτη, και επεξεργαστείτε τις υπάρχουσες απευθείας από την εφαρμογή.";
-
-"whatsnew_editor_message_2" = "* Το Organic Maps χρησιμοποιεί δεδομένα της κοινότητας OpenStreetMap.";
 
 "dialog_incorrect_feature_position" = "Αλλαγή τοποθεσίας";
 
@@ -1236,16 +798,10 @@
 
 "login_to_make_edits_visible" = "Συνδεθείτε ώστε άλλοι χρήστες να μπορούν να δουν τις αλλαγές που έχετε κάνει";
 
-"no_migration_during_navigation" = "Δεν επιτρέπεται η ενημέρωση κατά τη διάρκεια της πλοήγησης.";
-
 /* Error dialog no space */
 "migration_no_space_message" = "Για να το κατεβάσετε, χρειάζεστε περισσότερο χώρο. Διαγράψτε τυχόν μη απαραίτητα δεδομένα.";
 
 "editor_sharing_title" = "Βελτίωσα τους χάρτες Organic Maps";
-
-"editor_comment_will_be_sent" = "We will make sure to send your comments to the map editors.";
-
-"editor_unsupported_category_message" = "You have added an object whose category we do not support yet. It will appear on the map in the future.";
 
 /* Downloaded 10 **of** 20 <- it is that "of" */
 "downloader_of" = "%1$d από %2$d";
@@ -1278,23 +834,9 @@
 
 "editor_operator" = "Ιδιοκτήτης";
 
-"editor_tag_description" = "Enter company, organization or individual responsible for the facilities.";
-
-"editor_no_local_edits_title" = "You don't have local edits";
-
-"editor_no_local_edits_description" = "This shows the number of your suggested changes on the map that are currently accessible only on your device.";
-
-"editor_send_to_osm" = "Send to OSM";
-
-"editor_remove" = "Remove";
-
-"downloader_my_maps_title" = "Οι χάρτες μου";
-
 "downloader_no_downloaded_maps_title" = "Δεν έχετε κατεβάσει χάρτες";
 
 "downloader_no_downloaded_maps_message" = "Κατεβάστε χάρτες για να αναζητήσετε μια τοποθεσία και να χρησιμοποιήσετε την πλοήγησης χωρίς σύνδεση.";
-
-"downloader_find_place_hint" = "Search city or country";
 
 /* Error title that appears after certain time without location. */
 "current_location_unknown_title" = "Να συνεχίσει να ανιχνεύεται η τρέχουσα θέση σας;";
@@ -1321,47 +863,13 @@
 /* iOS Dialog for the case when the location permission is not granted */
 "location_services_disabled_3" = "3. Επιλέξτε ενώ χρησιμοποιείτε την εφαρμογή";
 
-"placepage_parking_surface" = "Surface";
-
-"placepage_parking_multistorey" = "Multi-storey";
-
-"placepage_parking_underground" = "Underground";
-
-"placepage_parking_rooftop" = "Rooftop";
-
-"placepage_parking_sheds" = "Sheds";
-
-"placepage_parking_carports" = "Carports";
-
-"placepage_parking_boxes" = "Garage boxes";
-
-"placepage_parking_pay" = "Pay";
-
-"placepage_parking_free" = "Free";
-
-"placepage_parking_interval" = "Interval Pay";
-
-"placepage_entrance_number" = "No.";
-
-"placepage_entrance_type" = "Entrance";
-
-"placepage_flat" = "app.";
-
-"placepage_open_24_7" = "24 / 7";
-
 "meter" = "m";
 
 "kilometer" = "km";
 
-"kilometers_per_hour" = "km/h";
-
 "mile" = "mi";
 
 "foot" = "ft";
-
-"miles_per_hour" = "mph";
-
-"day" = "d";
 
 "hour" = "h";
 
@@ -1381,10 +889,6 @@
 
 "placepage_bookmark_name_hint" = "Όνομα αγαπημένου";
 
-"placepage_personal_notes_hint" = "Προσωπικές σημειώσεις";
-
-"placepage_delete_bookmark_button" = "Διαγραφή αγαπημένου";
-
 "editor_edits_sent_message" = "Οι προτεινόμενες αλλαγές σας έχουν σταλεί";
 
 "editor_comment_hint" = "Σχόλιο…";
@@ -1397,8 +901,6 @@
 
 "editor_remove_place_button" = "Διαγραφή";
 
-"editor_status_sending" = "Sending…";
-
 "editor_place_doesnt_exist" = "Η τοποθεσία δεν υπάρχει";
 
 "text_more_button" = "…περισσότερα";
@@ -1410,11 +912,7 @@
 
 "error_enter_correct_email" = "Εισάγετε ένα έγκυρο email";
 
-"error_enter_correct" = "Enter a valid value";
-
 "refresh" = "Ενημέρωση";
-
-"last_update" = "Τελευταία ενημέρωση: %s";
 
 "placepage_add_place_button" = "Να προστεθεί η τοποθεσία στο χάρτη";
 
@@ -1426,24 +924,6 @@
 
 "editor_share_to_all_dialog_message_2" = "Θα ελέγξουμε τις αλλαγές. Εάν έχουμε οποιαδήποτε απορία θα επικοινωνήσουμε μαζί σας μέσω email.";
 
-"navigation_overview_button" = "overview";
-
-"navigation_stop_button" = "stop";
-
-/* Text on an empty bookmark page */
-"bookmarks_empty_title" = "Save Bookmarks";
-
-"bookmarks_empty_message_1" = "Tap on ★ to save favorite places for quick access.";
-
-"bookmarks_empty_message_2" = "Import Bookmarks from email and web.";
-
-"bookmarks_empty_message_3" = "check out: %s";
-
-/* Name of the group for booked hotels */
-"bookmarks_group_name" = "Booked hotels";
-
-"place_page_button_read_descriprion" = "Read";
-
 /* iOS dialog for the case when recent track recording is on and the app comes back from background */
 "recent_track_background_dialog_title" = "Θέλετε να απενεργοποιήσετε την καταγραφή της πρόσφατης διαδρομής σας;";
 
@@ -1451,8 +931,6 @@
 
 /* For sharing via SMS and so on */
 "sharing_call_action_look" = "Αναχώρηση";
-
-"continue_recent_track_background_button" = "Continue";
 
 "recent_track_background_dialog_message" = "Το Organic Maps χρησιμοποιεί τη γεωγραφική σας τοποθεσία στο παρασκήνιο για την καταγραφή των πρόσφατων διαδρομών σας.";
 
@@ -1468,33 +946,13 @@
 /* About short text (below logo) */
 "about_description" = "Το Organic Maps είναι η απαραίτητη εφαρμογή γα ταξίδια που λειτουργεί εκτός σύνδεσης. Το Organic Maps βασίζεται σε δεδομένα OpenStreetMap και σας επιτρέπει να τα επεξεργαστείτε.";
 
-/* Text in menu */
-"blog" = "Ιστολόγιο";
-
 "general_settings" = "Γενικές ρυθμίσεις";
-
-"date" = "Ημερομηνία %d";
-
-/* "Report a bug" -> "Generaal Feedback" -> "Something is not working" */
-"something_is_not_working" = "Κάτι δεν λειτουργεί";
 
 /* For the first routing */
 "accept" = "Συμφωνώ";
 
-"accept_and_continue" = "Accept and continue";
-
 /* For the first routing */
 "decline" = "Διαφωνώ";
-
-"install_app" = "Εγκατάσταση";
-
-"search_no_results_title" = "Δεν βρέθηκαν αποτελέσματα";
-
-"search_no_results_message" = "Δοκιμάστε ένα γενικότερο όρο αναζήτησης, κάντε σμίκρυνση ή μηδενίστε το φίλτρο.";
-
-"search_no_results_expand_area_button" = "Σμίκρυνση";
-
-"search_no_results_reset_button" = "Μηδενισμός φίλτρου";
 
 /* noun */
 "search_in_table" = "Λίστα";
@@ -1517,8 +975,6 @@
 
 "traffic_update_maps_text" = "Για να εμφανίσετε πληροφορίες για την κίνηση, πρέπει να ενημερωθούν οι χάρτες.";
 
-"traffic_outdated" = "Οι πληροφορίες για την κίνηση είναι παλιές.";
-
 "big_font" = "Αύξηση μεγέθους γραμματοσειράς στο χάρτη";
 
 "traffic_update_app" = "Κάντε ενημέρωση του Organic Maps";
@@ -1529,17 +985,7 @@
 /* "traffic" as in "road congestion" */
 "traffic_data_unavailable" = "Οι πληροφορίες για την κίνηση δεν είναι διαθέσιμες";
 
-/* "Translation is no needed, because it's a company name" */
-"uber" = "Uber";
-
-/* Simplified colour scheme for traffic information, fewer colours are used to display traffic jams on the map. The string should be kept as short as possible */
-"pref_traffic_simplified_colors_title" = "Εύκολα χρώματα για την κίνηση";
-
 "enable_logging" = "Ενεργοποίηση δυνατότητας καταγραφής";
-
-"offline_place_page_more_information" = "Συνδεθείτε στο Internet για να λάβετε περισσότερες πληροφορίες για αυτό το μέρος.";
-
-"failed_load_information" = "Η φόρτωση πληροφοριών απέτυχε.";
 
 /* Settings: "Send general feedback" button */
 "feedback_general" = "Γενικό σχόλιο";
@@ -1556,8 +1002,6 @@
 
 "whatsnew_transliteration_title" = "Μεταγραφή στα Λατινικά";
 
-"yandex_taxi_title" = "Yandex.Taxi";
-
 "learn_more" = "Μάθετε περισσότερα";
 
 "core_exit" = "Έξοδος";
@@ -1568,75 +1012,19 @@
 
 "button_exit" = "Έξοδος";
 
-"settings_device_memory" = "Μνήμη συσκευής";
-
-"settings_card_memory" = "Κάρτα μνήμης";
-
-"settings_storage_available" = "%s διαθέσιμα";
-
-"toast_location_permission_denied" = "Άρνηση πρόσβασης εφαρμογής στον εντοπισμό τοποθεσίας";
-
-"button_use" = "Χρήση";
-
 "planning_route_manage_route" = "Διαχείριση διαδρομής";
 
 "button_plan" = "Σχέδιο";
-
-"button_add" = "Προσθήκη";
 
 "placepage_remove_stop" = "Κατάργηση";
 
 "planning_route_remove_title" = "Σύρετε εδώ για κατάργηση";
 
-"dialog_change_start_point_message" = "Θέλετε να αλλάξετε την αφετηρία στην τρέχουσα θέση;";
-
-"button_replace" = "Αλλαγή";
-
 "placepage_add_stop" = "Προσθήκη στάσης";
-
-/* Only ru/en are needed */
-"subtitle_rent" = "Rent";
-
-/* Only ru/en are needed */
-"rub_month" = "RUB/month";
-
-/* Only ru/en are needed */
-"room" = "%s-room apt.";
-
-/* Only ru/en are needed */
-"real_estate" = "Real estate";
-
-"add_my_position" = "Πρόσθεσε τη θέση μου";
-
-"choose_start_point" = "Επιλέξτε αφετηρία";
-
-"choose_destination" = "Επιλέξτε προορισμό";
 
 "preloader_viator_button" = "Μάθετε περισσότερα";
 
-"start_from_my_position" = "Έναρξη από";
-
-"profile_authorization_title" = "Συνδεθείτε με";
-
-"profile_authorization_message" = "Εύκολη σύνδεση χωρίς όνομα χρήστη και κωδικό πρόσβασης σε λίγα δευτερόλεπτα";
-
 "profile_authorization_error" = "Ωχ, παρουσιάστηκε σφάλμα. Προσπαθήστε να συνδεθείτε ξανά.";
-
-"service" = "Εξυπηρέτηση";
-
-"atmosphere" = "Ατμόσφαιρα";
-
-"value_for_money" = "Αξία για τα χρήματα";
-
-"experience" = "Εμπειρία";
-
-"assortment" = "Κατάταξη";
-
-"expertise" = "Τεχνογνωσία";
-
-"equipment" = "Εξοπλισμός";
-
-"quality" = "Ποιότητα";
 
 "dialog_error_storage_title" = "Πρόβλημα πρόσβασης στον αποθηκευτικό χώρο";
 
@@ -1644,17 +1032,7 @@
 
 "setting_emulate_bad_storage" = "Εξομείωση κακού αποθηκευτικού χώρου";
 
-"directions_finish" = "Προορισμός";
-
-"directions_on_foot" = "Βάδισμα %s";
-
 "core_entrance" = "Είσοδος";
-
-"coffee" = "Καφές";
-
-"cleanliness" = "Καθαριότητα";
-
-"crowdedness" = "Συνωστισμός";
 
 "error_enter_correct_name" = "Εισάγετε ένα σωστό όνομα";
 
@@ -1673,11 +1051,9 @@
 
 "downloader_percent" = "%s (%s από %s)";
 
-"downloader_process" = "Λήψη %s...";
+"downloader_process" = "Λήψη %s…";
 
-"downloader_applying" = "Εφαρμογή %s...";
-
-"dialog_message_transit_not_found_connection" = "Σχεδιάστε μια διαδρομή εντός δικτύου μεταφοράς";
+"downloader_applying" = "Εφαρμογή %s…";
 
 "bookmarks_error_message_share_general" = "Αδυναμία κοινής χρήσης λόγω σφάλματος εφαρμογής";
 
@@ -1695,17 +1071,7 @@
 
 "bookmarks_error_message_list_name_already_taken" = "Επιλέξτε άλλο όνομα";
 
-"bookmarks_error_title_list_name_too_long" = "Αυτό το όνομα είναι πολύ μεγάλο";
-
-"bookmarks_error_message_list_name_too_long" = "Επιλέξτε άλλο όνομα";
-
-"please_wait" = "Παρακαλώ περιμένετε...";
-
-"phone_number" = "Τηλεφωνικό νούμερο";
-
-"notification_unsent_reviews_title" = "Έχετε αρκετές κριτικές";
-
-"notification_unsent_reviews_message" = "Παρακαλώ συνδεθείτε για να μοιραστείτε κριτικές με άλλους ταξιδιώτες";
+"please_wait" = "Παρακαλώ περιμένετε…";
 
 "profile" = "Προφίλ OpenStreetMap";
 
@@ -1719,49 +1085,13 @@
 
 "bookmarks_convert_error_message" = "Ορισμένα αρχεία δεν μετατράπηκαν.";
 
-"converting" = "Μετατροπή...";
-
-"wn_reinvented_bookmarks_title" = "Επεκτείνασαμε σελιδοδείκτες!";
-
-"wn_reinvented_bookmarks_message" = "You can back up them and create lists - just look at them on the map! They are gorgeous!";
-
-"bookmarks_restore" = "Επαναφορά των σελιδοδεικτών";
-
-"bookmarks_restore_process" = "Επαναφορά...";
-
 "bookmarks_restore_title" = "Επαναφορά αυτής της έκδοσης;";
 
-"bookmarks_restore_message" = "Οι σελιδοδείκτες σας θα αποκατασταθούν από το %s (%s)";
-
-"bookmarks_restore_empty_title" = "Δεν διαθέτετε αντίγραφο ασφαλείας";
-
-"bookmarks_restore_empty_message" = "Ο διακομιστής δεν βρήκε προηγουμένως δημιουργημένα αντίγραφα ασφαλείας";
-
 "common_check_internet_connection_dialog_title" = "Δεν υπάρχει σύνδεση στο διαδίκτυο";
-
-"error_server_title" = "Σφάλμα Διακομιστή";
-
-"error_server_message" = "Παρουσιάστηκε σφάλμα στο διακομιστή, δοκιμάστε ξανά αργότερα";
 
 "error_system_message" = "Συνέβη ένα άγνωστο σφάλμα";
 
 "restore" = "Επαναφορά";
-
-"bookmarks_page_downloaded" = "Κατέβηκε";
-
-"bookmarks_page_my" = "Μου";
-
-"routes_and_bookmarks" = "Διαδρομές και σελιδοδείκτες";
-
-"bookmarks_webview_success_toast" = "Οι σελιδοδείκτες κατέβηκαν επιτυχώς";
-
-"cached_bookmarks_placeholder_title" = "Κατεβάστε νέα μέρη";
-
-"cached_bookmarks_placeholder_subtitle" = "Πιέστε το κουμπί για να κατεβάστε χιλιάδες ενδιαφέροντα μέρη και διαδρομές που δημιουργήθηκαν από τους χρήστες του Organic Maps. Θα χρειαστείτε σύνδεση στο διαδίκτυο.";
-
-"downloader_download_routers" = "Κατεβάστε σελιδοδείκτες";
-
-"bookmarks_groups_cached" = "Κατεβάστε λίστες";
 
 "subtittle_opt_out" = "Ρυθμίσεις διαδρομών";
 
@@ -1769,29 +1099,15 @@
 
 "crash_reports_description" = "Μπορεί να χρησιμοποιήσουμε τα δεδομένα σας για να βελτιώσουμε την εμπειρία του Organic Maps. Οι αλλαγές θα ενεργοποιηθούν μετά την επανεκκίνηση της εφαρμογής.";
 
-"opt_out_help_ios_1" = "Η συσκευή σας μπορεί να παρέχει μια ρύθμιση «Περιορισμένη παρακολούθηση διαφημίσεων» ή «Αποκλεισμό διαφημίσεων με βάση το ενδιαφέρον».";
-
-"opt_out_help_ios_2" = "iOS 9 ή υψηλότερο";
-
-"opt_out_help_ios_3" = "Πηγαίνετε στις ρυθμίσεις → Απόρρητο → Διαφήμιση → Ενεργοποιήστε την επιλογή «Περιορισμένη παρακολούθηση διαφημίσεων»";
-
-"opt_out_help_android" = "Η συσκευή σας μπορεί να παρέχει μια ρύθμιση «Περιορισμένη παρακολούθηση διαφημίσεων» ή «Αποκλεισμό διαφημίσεων με βάση το ενδιαφέρον».\n\n Για Android και υπηρεσίες Google Play εκδοχής 4.0 και πάνω:\n Ρυθμίσεις → Google → Διαφημίσεις → Αποκλεισμός προσωποποίησης διαφημίσεων\n ή \n Ρυθμίσεις → Google → Λογαριασμός Google → Προσωπικές πληροφορίες και ασφάλεια → Προσωποποίηση Διαφημίσεων";
-
 "privacy_policy" = "Πολιτική απορρήτου";
 
 "terms_of_use" = "Όροι χρήσης";
-
-"backup_notification_failed" = "Η αποθήκευση των σελιδοδεικτών έχει διακοπεί. Συνδεθείτε για να το ξανανοίξετε.";
 
 "button_layer_traffic" = "Κίνηση";
 
 "button_layer_subway" = "Μετρό";
 
 "layers_title" = "Επίπεδα του χάρτη";
-
-"layers_message" = "Χρησιμοποιήστε τα επίπεδα χάρτη για να δείτε την κίνηση, το χάρτη του μετρό και άλλες χρήσιμες πληροφορίες";
-
-"button_layer_got_it" = "Κατάλαβα";
 
 "subway_data_unavailable" = "Ο χάρτης μετρό δεν είναι διαθέσιμος";
 
@@ -1803,39 +1119,13 @@
 
 "title_error_downloading_bookmarks" = "Συνέβη σφάλμα";
 
-"subtitle_error_downloading_bookmarks" = "Οι σελιδοδείκτες δεν κατέβηκαν";
-
-"error_already_downloaded" = "Έχει γίνει ήδη λήψη αυτής της λίστας";
-
 "popular_place" = "Popular";
-
-"download_routes" = "Download routes";
-
-"bookmarks_downloaded_title" = "Bookmarks have been downloaded successfully";
-
-"bookmarks_downloaded_subtitle" = "Press ‘View on map’ to explore new places from the list";
-
-"why_support" = "Γιατί να υποστηρίξετε το Organic Maps?";
-
-"why_support_item1" = "We respect your privacy: there are zero trackers in the app, and we are open source";
-
-"why_support_item2" = "Μας βοηθάτε να βελτιώσουμε το Organic Maps";
-
-"why_support_item3" = "Μας βοηθάτε να βελτιώσουμε ανοιχτούς χάρτες στο OpenStreetMap.org";
-
-"channels_map_update" = "Ενημερώσεις χάρτη";
-
-"server_unavailable_title" = "Ο εξυπηρετητής δεν είναι διαθέσιμος";
-
-"sharing_options" = "Επιλογές κοινοποίησης";
 
 "export_file" = "Αρχείο Εξαγωγής";
 
 "list_settings" = "Ρυθμίσεις Λίστας";
 
 "delete_list" = "Διαγραφή λίστας";
-
-"hide_from_map" = "Κρύψε από τον χάρτη";
 
 "public_access" = "Δημόσια πρόσβαση";
 
@@ -1845,40 +1135,11 @@
 
 "bookmark_category_description_hint" = "Πληκτρολογήστε μια περιγραφή (κείμενο ή html)";
 
-/* FIXME */
-"bookmarks_public_access" = "bookmarks_public_access";
-
-/* FIXME */
-"bookmarks_link_access" = "bookmarks_link_access";
-
-/* FIXME */
-"bookmarks_private_access" = "bookmarks_private_access";
-
 "not_shared" = "Προσωπικός";
-
-"direct_link_progress_text" = "Ανεβάζουμε το αρχείο σας…";
-
-"direct_link_success" = "Ο σύνδεσμος δημιουργήθηκε";
-
-"send_a_link_btn" = "Στείλε μου έναν σύνδεσμο";
-
-"upload_error_toast" = "Ένα σφάλμα συνέβη στο ανέβασμα του αρχείου σας";
 
 "tags_loading_error_subtitle" = "Ένα σφάλμα συνέβη στο φόρτωμα των ετικετών, παρακαλώ ξαναπροσπαθήστε";
 
-"unable_upload_errorr_title" = "Το ανέβασμα του αρχείου απέτυχε";
-
-"unable_upload_error_subtitle_edited" = "Το αρχείο επεξεργάστηκε μέσω της εφαρμογής";
-
-"unable_upload_error_subtitle_broken" = "Το αρχείο είναι κατεστραμμένο και δεν μπόρεσε να ανέβει. Παρακαλώ ανεβάστε ένα άλλο αρχείο.";
-
-"contact" = "Επικοινωνία";
-
-"download_button" = "Κατέβασμα";
-
 "speedcams_alert_title" = "Κάμερες Ταχύτητας";
-
-"speedcams_alert_subtitle" = "Ειδοποίηση για όρια ταχύτητας";
 
 "speedcam_option_auto" = "Αυτόματο";
 
@@ -1886,18 +1147,10 @@
 
 "speedcam_option_never" = "Ποτέ";
 
-"bookmark_description_title" = "Περιγραφή Σελιδοδείκτη";
-
 "place_description_title" = "Περιγραφή μέρους";
 
 /* this text will be shown in application notification preferences opposite checkbox which enable/disable downloader notifications. Devices on Android 8+ are affected. */
 "notification_channel_downloader" = "Κατέβασμα χαρτών";
-
-"share_bookmarks_email_body_link" = "Γεια!\n\nΕδώ είναι ο σύνδεσμος που μπορείς να κατεβάσεις τους σελιδοδείκτες σου: %s. Ανοίξτε τη λίστα μέσω Organic Maps και απολαύστε το ταξίδι σας!\n\nΚατεβάστε την εφαρμογή: https://omaps.app/get?kmz";
-
-"warning_speedcams_title" = "Ο πλοηγός θα σας ειδοποιεί για κάμερες όταν υπερβαίνετε το όριο ταχύτητας των %d km/h";
-
-"warning_speedcams_subtitle" = "Παρακαλώ να προσέχετε τους κανόνες οδήγησης της χώρας στην οποία ταξιδεύετε.";
 
 "speedcams_notice_message" = "Αυτόματο- Να ειδοποιούμαι για κάμερες αν υπάρχει κίνδυνος να υπερβώ το όριο ταχύτητας\nΠάντα- Πάντα να ειδοποιούμαι για κάμερες\nΠοτέ- Ποτέ να μην ειδοποιούμαι για κάμερες";
 
@@ -1913,23 +1166,7 @@
 
 "enable_logging_warning_message" = "Αυτή η λειτουργία είναι ενεργοποιημένη για την καταγραφή ενεργειών για διαγνωστικούς σκοπούς. Αυτό βοηθά την ομάδα να εντοπίζει προβλήματα με την εφαρμογή. Να ενεργοποιείτε τη λειτουργία μόνο κατόπιν αιτήματος της υποστήριξης του Organic Maps.";
 
-"html_error_upload_message_try_again" = "Ελέγξτε την πρόσβαση στο δίκτυο και δοκιμάστε ξανά";
-
-"html_error_upload_title_try_again" = "Δεν υπάρχει σύνδεση με το διαδίκτυο";
-
-"notification_leave_review_v2_android_short_title" = "Αφήνετε τα σχόλιά σας και βοηθάτε τους ταξιδιώτες!";
-
-"megafon" = "Say goodbye to roaming!";
-
-"notifications_illegal_alert_disable_button" = "Απενεργοποίηση των ειδοποιήσεων";
-
 "access_rules_author_only" = "Επεξεργάζεται online";
-
-"privacy_settings_menu" = "Ρυθμίσεις απορρήτου";
-
-"unable_upadate_error_title" = "Δεν ήταν δυνατή η ενημέρωση της διαδρομής";
-
-"unable_upadate_error_message" = "Παρουσιάστηκαν σφάλματα κατά την ενημέρωση. Ελέγξτε τις αλλαγές και δοκιμάστε ξανά";
 
 "driving_options_title" = "Ρυθμίσεις παράκαμψης";
 
@@ -1951,94 +1188,19 @@
 
 "change_driving_options_btn" = "Ρυθμίσεις δραστηριοποιούνται";
 
-"toll_road" = "Δρόμος με διόδια";
-
-"unpaved_road" = "Χωματόδρομος";
-
-"ferry_crossing" = "Πορθμείο";
-
-"operated_by" = "Χειρίζεται από \"%s\"";
-
 "avoid_toll_roads_placepage" = "Αποφυγή των δρόμων με διόδια";
 
 "avoid_unpaved_roads_placepage" = "Αποφυγή των χωματόδρομων";
 
 "avoid_ferry_crossing_placepage" = "Αποφυγή των πορθμείων";
 
-"type.cuisine.uzbek" = "Ουζμπεκική κουζίνα";
-
-"trip_start" = "Πάμε";
-
-"pick_destination" = "Προορισμός";
-
-"follow_my_position" = "Επανατοποθέτηση";
-
-"search_results" = "Αποτελέσματα αναζήτησης";
-
-"then_turn" = "Μετά";
-
-"redirect_route_alert" = "Θα θέλατε να τροποποιήσετε τη διαδρομή;";
-
-"redirect_route_yes" = "Ναι";
-
-"redirect_route_no" = "Όχι";
-
-"trip_finished" = "Έχετε φτάσει!";
-
-"keyboard_availability_alert" = "Το πληκτρολόγιο δεν είναι διαθέσιμο κατά τη διάρκεια οδήγησης";
-
-"dialog_routing_change_start_carplay" = "Δεν είναι δυνατή η δημιουργία διαδρομής από την τρέχουσα τοποθεσία σας";
-
-"dialog_routing_change_end_carplay" = "Δεν είναι δυνατή η δημιουργία διαδρομής μέχρι τον προορισμό σας. Επιλέξτε ένα άλλο σημείο";
-
-"dialog_routing_check_gps_carplay" = "Δεν υπάρχει σήμα GPS. Μετακινήστε σε μια ανοικτή τοποθεσία";
-
-"dialog_routing_unable_locate_route_carplay" = "Δεν είναι δυνατή η δημιουργία διαδρομής. Επιλέξτε άλλα σημεία διαδρομής";
-
-"dialog_routing_download_files_carplay" = "Για να χτίσετε διαδρομή, κατεβάστε χάρτες που λείπουν στη συσκευή";
-
-"dialog_routing_system_error_carplay" = "Παρουσιάστηκε σφάλμα. Κάντε επανεκκίνηση της εφαρμογής";
-
-"dialog_routing_rebuild_from_current_location_carplay" = "Η διαδρομή θα ξαναδημιουργηθεί από την τρέχουσα τοποθεσία σας";
-
-"dialog_routing_rebuild_for_vehicle_carplay" = "Η διαδρομή θα αντικατασταθεί με τη διαδρομή με αυτοκίνητο";
-
 "ok" = "Καλώς";
-
-"avoid_unpaved_carplay_1" = "Χ/χωματόδρ.";
-
-"avoid_unpaved_carplay_2" = "Χ/χωματόδρομους";
-
-"avoid_ferry_carplay_1" = "Χ/πορθμεία";
-
-"avoid_ferry_carplay_2" = "Χωρίς πορθμεία";
-
-"avoid_tolls_carplay_1" = "Χωρίς διόδια";
-
-"avoid_tolls_carplay_2" = "Χωρίς διόδια";
-
-"speedcams_alert_title_carplay_1" = "Κάμερες";
-
-"speedcams_alert_title_carplay_2" = "Πληροφ. γιαόρια";
-
-"download_map_carplay" = "Κάντε λήψη χαρτών στην εφαρμογή Organic Maps στη συσκευή σας";
-
-"carplay_roundabout_exit" = "%s έξοδος";
 
 /* max. 10 symbols, both iOS and Android */
 "sort" = "Ταξινόμηση";
 
 /* Android, title, max 20-22 symbols */
 "sort_bookmarks" = "Ταξινόμηση σελιδοδ/τών";
-
-/* iOS */
-"sort_default" = "Ταξινόμηση κατά προεπιλογή";
-
-"sort_type" = "Ταξινόμηση ανά τύπο";
-
-"sort_distance" = "Ταξινόμηση κατά απόσταση";
-
-"sort_date" = "Ταξινόμηση κατά ημερομηνία";
 
 /* Android */
 "by_default" = "Προεπιλογή";
@@ -2052,63 +1214,7 @@
 /* Android */
 "by_date" = "Κατά ημερομηνία";
 
-"week_ago_sorttype" = "Μια βδομάδα πριν";
-
-"month_ago_sorttype" = "Ένας μήνας πριν";
-
-"moremonth_ago_sorttype" = "Περισσότερο από έναν μήνα πριν";
-
-"moreyear_ago_sorttype" = "Περισσότερο από ένα έτος πριν";
-
-"near_me_sorttype" = "Δίπλα μου";
-
-"others_sorttype" = "Άλλα";
-
-"food_places" = "Εστίαση";
-
-"tourist_places" = "Αξιοθέατα";
-
-"museums" = "Μουσεία";
-
-"parks" = "Πάρκα";
-
-"swim_places" = "Κολύμβηση";
-
-"mountains" = "Βουνά";
-
-"animals" = "Ζώα";
-
-"hotels" = "Διαμονή";
-
-"buildings" = "Κτήρια";
-
-"money" = "Χρήματα";
-
-"shops" = "Καταστήματα";
-
-"parkings" = "Χώροι στάθμευσης";
-
-"fuel_places" = "Πρατήρια βενζίνης";
-
-"water" = "Νερό";
-
-"medicine" = "Γιατρική βοήθεια";
-
 "search_in_the_list" = "Αναζήτηση στη λίστα";
-
-"view_on_map_bookmarks" = "Στον χάρτη";
-
-"more_bookmarks" = "Περισσότερα…";
-
-"no_items_found" = "Δεν βρέθηκε τίποτα";
-
-/* Android, max 18 symbols */
-"bookmarks_edit_list" = "Επεξεργασία";
-
-/* Android, max 18 symbols */
-"bookmarks_delete_list" = "Διαγραφή λίστας";
-
-"religious_places" = "Άγιοι τόποι";
 
 "select_list" = "Επιλογή λίστας";
 
@@ -2118,26 +1224,13 @@
 
 "dialog_pedestrian_route_is_long_message" = "Επιλέξτε το σημείο έναρξης ή τέλους διαδρομής πιο κοντά στο σταθμό του μετρό";
 
-/* Failed planning SUBWAY route message in navigation view */
-"routing_planning_error_subway_special" = "Σφάλμα κατά την δημιουργία διαδρομής του μετρό";
-
 "button_layer_isolines" = "Υψόμετρα";
-
-"tips_map_layers_title_countour" = "Τοπογραφικά στρώματα εκτός σύνδεσης στο Organic Maps!";
-
-"tips_map_layers_message_countour" = "Τα τοπογραφικά στρώματα θα σας βοηθήσουν να σχεδιάσετε το ταξίδι σας στη φύση και να μην χαθείτε στην περιοχή";
 
 "isolines_activation_error_dialog" = "Για να χρησιμοποιήσετε τοπογραφικά στρώματα, ενημερώστε ή κατεβάστε τον χάρτη της επιθυμητής περιοχής";
 
 "isolines_location_error_dialog" = "Τα τοπογραφικά στρώματα δεν είναι ακόμα διαθέσιμα σε αυτή την περιοχή";
 
 "elevation_profile_diff_level" = "Επίπεδο δυσκολίας";
-
-"elevation_profile_diff_level_easy" = "Εύκολο";
-
-"elevation_profile_diff_level_moderate" = "Μέτριο";
-
-"elevation_profile_diff_level_hard" = "Δύσκολο";
 
 "elevation_profile_ascent" = "Άνοδος";
 
@@ -2147,25 +1240,13 @@
 
 "elevation_profile_maxaltitude" = "Μέγ. υψόμετρο";
 
-"elevation_profile_m" = "μ";
-
 "elevation_profile_difficulty" = "Δυσκολία";
 
 "elevation_profile_distance" = "Απόστ.:";
 
-"elevation_profile_km" = "χλμ";
-
 "elevation_profile_time" = "Διαρκ:";
 
-"elevation_profile_hours" = "ω.";
-
-"elevation_profile_minutes" = "λ.";
-
 "isolines_toast_zooms_1_10" = "Μεγεθύνετε για να δείτε περιγράμματα";
-
-"downloader_updating_ios" = "Ενημέρωση";
-
-"downloader_loading_ios" = "Φόρτωση";
 
 "key_information_title" = "Βασικές πληροφορίες";
 

--- a/iphone/Maps/LocalizedStrings/el.lproj/Localizable.stringsdict
+++ b/iphone/Maps/LocalizedStrings/el.lproj/Localizable.stringsdict
@@ -9,21 +9,6 @@
 
 <!-- ********** Strings for downloading map from search **********/ -->
 
-  <key>bookmarks_places</key>
-  <dict>
-    <key>NSStringLocalizedFormatKey</key>
-    <string>%#@value@</string>
-    <key>value</key>
-    <dict>
-      <key>NSStringFormatSpecTypeKey</key>
-      <string>NSStringPluralRuleType</string>
-      <key>NSStringFormatValueTypeKey</key>
-      <string>d</string>
-      <key>other</key>
-      <string>%d αγαπημένα</string>
-    </dict>
-  </dict>
-
   <key>bookmarks_detect_message</key>
   <dict>
     <key>NSStringLocalizedFormatKey</key>
@@ -38,21 +23,6 @@
       <string>Βρέθηκε %d αρχείο. Θα το δείτε μετά τη μετατροπή.</string>
       <key>other</key>
       <string>έχουν βρεθεί %d αρχεία. Θα τα δείτε μετά τη μετατροπή.</string>
-    </dict>
-  </dict>
-
-  <key>bookmarks_objects</key>
-  <dict>
-    <key>NSStringLocalizedFormatKey</key>
-    <string>%#@value@</string>
-    <key>value</key>
-    <dict>
-      <key>NSStringFormatSpecTypeKey</key>
-      <string>NSStringPluralRuleType</string>
-      <key>NSStringFormatValueTypeKey</key>
-      <string>d</string>
-      <key>other</key>
-      <string>%s αντικέιμενο</string>
     </dict>
   </dict>
 

--- a/iphone/Maps/LocalizedStrings/en-GB.lproj/Localizable.strings
+++ b/iphone/Maps/LocalizedStrings/en-GB.lproj/Localizable.strings
@@ -18,9 +18,6 @@
 /* Button which deletes downloaded country */
 "delete" = "Delete";
 
-/* Button "do not interrupt download" if user touched actively downloading country */
-"do_nothing" = "Continue";
-
 "download_maps" = "Download Maps";
 
 /* Settings/Downloader - info for country when download fails */
@@ -28,9 +25,6 @@
 
 /* Settings/Downloader - info for country which started downloading */
 "downloading" = "Downloading…";
-
-/* Settings/Downloader - size string, only strings different from English should be translated */
-"kb" = "kB";
 
 /* Choose measurement on first launch alert - choose metric system button */
 "kilometres" = "Kilometres";
@@ -55,17 +49,11 @@
 /* Update maps later/Buy pro version later button text */
 "later" = "Later";
 
-/* Don't show some dialog any more */
-"never" = "Never";
-
 /* View and button titles for accessibility */
 "search" = "Search";
 
 /* Search box placeholder text */
 "search_map" = "Search Map";
-
-/* Settings/Downloader - info for not downloaded country */
-"touch_to_download" = "Touch to download";
 
 /* Settings/Downloader - 3G download warning dialog confirm button */
 "use_cellular_data" = "Yes";
@@ -73,20 +61,11 @@
 /* Location services are disabled by user alert - message */
 "location_is_disabled_long_text" = "You currently have all Location Services for this device or application disabled. Please enable them in Settings.";
 
-/* Location Services are not available on the device alert - message */
-"device_doesnot_support_location_services" = "Your device doesn't support Location Services";
-
 /* View and button titles for accessibility */
 "zoom_to_country" = "Show on the map";
 
-/* Button text for the button at the center of the screen when the country is not downloaded */
-"country_status_download" = "Download Map\n(^ ^)";
-
 /* Button text for the button at the center of the screen when the country is not downloaded and the size should not be shown */
 "country_status_download_without_size" = "Download Map";
-
-/* Button text for the button at the center of the screen when the country is not downloaded */
-"country_status_download_without_routing" = "Download map\nwithout routing (^ ^)";
 
 /* Message to display at the center of the screen when the country download has failed */
 "country_status_download_failed" = "Download has failed";
@@ -96,19 +75,13 @@
 
 "about_menu_title" = "About Organic Maps";
 
-"downloaded_touch_to_delete" = "Downloaded (%@), touch to delete";
-
 "connection_settings" = "Connection Settings";
-
-"download_mb_or_kb" = "Download %@";
 
 "close" = "Close";
 
 "unsupported_phone" = "The app requires hardware accelerated OpenGL. Unfortunately, your device is not supported.";
 
 "download" = "Download";
-
-"external_storage_is_not_available" = "SD card/USB storage with downloaded maps is not available";
 
 "disconnect_usb_cable" = "Please disconnect USB cable or insert memory card to use Organic Maps";
 
@@ -117,8 +90,6 @@
 "not_enough_memory" = "Not enough memory to launch app";
 
 "download_resources" = "Before you start using the app, allow us to download the general world map to your device.\nIt will use %@ of storage.";
-
-"getting_position" = "Getting current position";
 
 "download_resources_continue" = "Go to Map";
 
@@ -140,23 +111,14 @@
 /* Add New Bookmark Set dialog title */
 "add_new_set" = "Add New Set";
 
-/* Place Page - Add To Bookmarks button */
-"add_to_bookmarks" = "Add to Bookmarks";
-
 /* Bookmark Color dialog title */
 "bookmark_color" = "Bookmark Colour";
 
 /* Add Bookmark Set dialog - hint when set name is empty */
 "bookmark_set_name" = "Bookmark Set Name";
 
-/* Bookmark Sets dialog title */
-"bookmark_sets" = "Bookmark Sets";
-
 /* Bookmarks - dialog title */
 "bookmarks" = "Bookmarks";
-
-/* Add bookmark dialog - bookmark color */
-"color" = "Colour";
 
 /* Default bookmarks set name */
 "core_my_places" = "My Places";
@@ -167,14 +129,8 @@
 /* Editor title above street and house number */
 "address" = "Address";
 
-/* Place Page - Remove Pin button */
-"remove_pin" = "Remove Pin";
-
 /* Add bookmark dialog - bookmark set, Bookmarks dialog - Bookmark set cell */
 "set" = "Set";
-
-/* Text hint in Bookmarks dialog when no any bookmarks are added */
-"bookmarks_usage_hint" = "You have no bookmarks yet.\nTap on any place on the map to add a bookmark.\nBookmarks from other sources can also be imported and displayed in Organic Maps. Open KML/KMZ file with saved bookmarks from email, Dropbox or weblink.";
 
 /* Settings button in system menu */
 "settings" = "Settings";
@@ -191,26 +147,11 @@
 /* Ask to wait user several minutes (some long process in modal dialog). */
 "wait_several_minutes" = "This can take several minutes.\nPlease wait…";
 
-/* Show bookmarks from this category on a map or not */
-"visible" = "Visible";
-
-/* Toast which is displayed when GPS has been deactivated */
-"gps_is_disabled_long_text" = "GPS is disabled. Please enable it in Settings.";
-
 /* Measurement units title in settings activity */
 "measurement_units" = "Measurement units";
 
 /* Detailed description of Measurement Units settings button */
 "measurement_units_summary" = "Choose between miles and kilometres";
-
-/* Do search in all sources */
-"search_mode_all" = "Everywhere";
-
-/* Do search near my position only */
-"search_mode_nearme" = "Near Me";
-
-/* Do search in current viewport only */
-"search_mode_viewport" = "On the Screen";
 
 /* Search category for cafes, bars, restaurants */
 "eat" = "Where to eat";
@@ -266,14 +207,8 @@
 /* Search category */
 "police" = "Police";
 
-/* String in search result list, when nothing found */
-"no_search_results_found" = "No results found";
-
 /* Notes field in Bookmarks view */
 "description" = "Notes";
-
-/* Button text */
-"share_by_email" = "Share by email";
 
 /* Email Subject when sharing bookmarks category */
 "share_bookmarks_email_subject" = "Organic Maps bookmarks were shared with you";
@@ -295,26 +230,11 @@
 /* Warning message when doing search around current position */
 "unknown_current_position" = "Your location hasn't been determined yet";
 
-/* Warning message when location country isn't downloaded during search (see also download_location_map_proposal). */
-"download_location_country" = "Download the map of your current location (%@)";
-
-/* Warning message when viewport country isn't downloaded during search */
-"download_viewport_country_to_search" = "Download the country you are searching on (%@)";
-
 /* Alert message that we can't run Map Storage settings due to some reasons. */
 "cant_change_this_setting" = "Sorry, Map Storage settings are currently disabled.";
 
 /* Alert message that downloading is in progress. */
 "downloading_is_active" = "Map download is in progress now.";
-
-/* Message that will be shown in alert view, when we ask user to leave review on App Store */
-"appStore_message" = "Hope you enjoy using Organic Maps! If so, please rate or review the app at the App Store. It takes less than a minute but can really help us. Thanks for your support!";
-
-/* No, thanks */
-"no_thanks" = "No, thanks";
-
-/* Share one specific bookmark using SMS, %1$@ contains om:// and %2$@ https://omaps.app link. @NOTE non-ascii symbols in the link will result in max 70 characters SMS instead of 140. */
-"bookmark_share_sms" = "Hey, check out my pin at Organic Maps! %1$@ or %2$@ Don't have offline maps installed? Download here: https://omaps.app/get";
 
 /* Share my position using SMS, %1$@ contains om:// and %2$@ https://omaps.app link WITHOUT NAME. @NOTE non-ascii symbols in the link will result in max 70 characters SMS instead of 140. */
 "my_position_share_sms" = "Hey, check out my current location in Organic Maps! %1$@ or %2$@ Don't have offline maps? Download here: https://omaps.app/get";
@@ -328,23 +248,11 @@
 /* Share my position using EMail, %1$@ is om:// and %2$@ is https://omaps.app link WITHOUT NAME */
 "my_position_share_email" = "Hi,\n\nI'm here now: %1$@. Click this link %2$@ or this one %3$@ to see the place on the map.\n\nThanks.";
 
-/* Android share by Message/SMS button text (including SMS) */
-"share_by_message" = "Share by message";
-
 /* Share button text which opens menu with more buttons, like Message, EMail, Facebook etc. */
 "share" = "Share";
 
-/* iOS share by Message button text (including SMS) */
-"message" = "Message";
-
 /* Share by email button text, also used in editor. */
 "email" = "Email";
-
-/* Copy Link */
-"copy_link" = "Copy Link";
-
-/* Text for the button that returns to caller application */
-"more_info" = "Show More Info";
 
 /* Text for message when used successfully copied something */
 "copied_to_clipboard" = "Copied to clipboard: %1$@";
@@ -354,15 +262,6 @@
 
 /* Used for bookmark editing */
 "done" = "Done";
-
-/* Summary for preferences in MWM */
-"yopme_pref_summary" = "Choose Back Screen settings";
-
-/* Title for yopme preferences in MWM */
-"yopme_pref_title" = "Back Screen Settings";
-
-/* Hint for upper-right icon p2b */
-"show_on_backscreen" = "Show on Back screen";
 
 /* Prints version number in About dialog */
 "version" = "Version: %@";
@@ -381,19 +280,11 @@
 
 "share_my_location" = "Share My Location";
 
-"menu_search" = "Search";
-
 /* Settings general group in settings screen */
 "prefs_group_general" = "General settings";
 
 /* Settings information group in settings screen */
 "prefs_group_information" = "Information";
-
-/* Settings screen: "Map" category title */
-"prefs_group_map" = "Map";
-
-/* Settings screen: "Miscellaneous" category title */
-"prefs_group_misc" = "Miscellaneous";
 
 "prefs_group_route" = "Navigation";
 
@@ -419,9 +310,6 @@
 /* Settings «Map» category: «3D buildings» title */
 "pref_map_3d_buildings_title" = "3D buildings";
 
-/* Settings «Map» category: «3D buildings» summary */
-"pref_map_3d_buildings_subtitle" = "Affects battery life";
-
 /* Settings «Route» category: «Tts enabled» title */
 "pref_tts_enable_title" = "Voice Instructions";
 
@@ -433,8 +321,6 @@
 
 /* Title for "Other" section in TTS settings. */
 "pref_tts_other_section_title" = "Other";
-
-"pref_tts_how_to_set_up_voice" = "How to set up voice";
 
 /* Settings «Map» category: «Record track» title */
 "pref_track_record_title" = "Recent track";
@@ -455,56 +341,7 @@
 
 "recent_track_help_text" = "This option allows you to record traveled path for a certain period and see it on the map. Please note: activation of this function causes increased battery usage. The track will be removed automatically from the map after the time interval will expire.";
 
-"pref_track_ios_caption" = "Recent track shows your traveled path.";
-
-"pref_track_ios_subcaption" = "Please select the time range of saving the track.";
-
-"placepage_distance" = "Distance";
-
-"placepage_coordinates" = "Coordinates";
-
-"placepage_unsorted" = "Unsorted";
-
 "search_show_on_map" = "View on map";
-
-/* Used to warn user when fixing KitKat issue */
-"bookmark_move_fail" = "We need to move your bookmarks to internal memory, but there is no available space for them. Please free up the memory, otherwise bookmarks won’t be available.";
-
-/* Used in More Apps menu */
-"free" = "Free";
-
-/* Used in More Apps menu */
-"buy" = "Buy";
-
-/* 1st search button-like result */
-"search_on_map" = "Search on map";
-
-/* toast with an error */
-"no_route_found" = "No route found";
-
-/* route title */
-"route" = "Route";
-
-/* category title */
-"routes" = "Routes";
-
-/* text of notification */
-"download_map_notification" = "Download the map of the place where you are";
-
-/* text of notification */
-"pro_version_is_free_today" = "Full version of Organic Maps is free today! Download now and tell your friends.";
-
-/* Dialog for transferring maps from lite to pro. */
-"move_lite_maps_to_pro" = "We are transferring your downloaded maps from Organic Maps Lite to Organic Maps. It may take a few minutes.";
-
-/* Message to display when maps moved. */
-"move_lite_maps_to_pro_ok" = "Your downloaded maps are successfully transferred to Organic Maps.";
-
-/* Message to display when maps move failed. */
-"move_lite_maps_to_pro_failed" = "Your maps failed to transfer. Please delete Organic Maps Lite and download the maps again.";
-
-/* Text in menu */
-"settings_and_more" = "Settings & More";
 
 /* Text in menu */
 "website" = "Website";
@@ -527,14 +364,8 @@
 /* Text in menu */
 "openstreetmap" = "OpenStreetMap";
 
-/* Text in menu */
-"contact_us" = "Contact us";
-
 /* Settings: Send feedback button and dialog title */
 "feedback" = "Feedback";
-
-/* Text in menu */
-"subscribe_to_news" = "Subscribe to our newsletter";
 
 /* Text in menu */
 "rate_the_app" = "Rate the app";
@@ -548,15 +379,6 @@
 /* Text in menu */
 "report_a_bug" = "Report a bug";
 
-/* Email subject */
-"subscribe_me_subject" = "Please subscribe me to the Organic Maps newsletter";
-
-/* Email body */
-"subscribe_me_body" = "I want to be the first to learn about the latest news, app updates, and promotions. I understand that I can cancel my subscription at any time.";
-
-/* About text */
-"about_text" = "Organic Maps offers the fastest offline maps of all the cities, all countries of the world. Travel with full confidence: wherever you are, Organic Maps helps to locate yourself on the map, find the nearest restaurant, hotel, bank, petrol station etc. It doesn’t require internet connection.\n\nWe are always working on new features and would love to hear from you on how you think we could improve Organic Maps. If you have any problems with the app, don't hesitate to contact us at support@organicmaps.app. We respond to every request!\n\nDo you like Organic Maps and want to support us? There are some simple and absolutely free ways:\n\n- post a review at your App Market\n- like our Facebook page http://www.facebook.com/OrganicMaps\n- or just tell about Organic Maps to your mom, friends and colleagues :)\n\nThank you for being with us. We appreciate your support very much!\n\nP.S. We take map data from OpenStreetMap, a mapping project similar to Wikipedia, which allows users to create and edit maps. If you see something is missing or wrong on the map, you can correct the maps directly at https://www.openstreetmap.org, and your changes will appear in Organic Maps app with the next version release.";
-
 /* Alert text */
 "email_error_body" = "The email client has not been set up. Please configure it or use any other way to contact us at %@";
 
@@ -569,12 +391,6 @@
 /* Search category */
 "wifi" = "WiFi";
 
-/* Update map suggestion */
-"routing_map_outdated" = "Please update the map to create a route";
-
-/* Update maps suggestion */
-"routing_update_maps" = "The new version of Organic Maps allows creating routes from your current position to a destination point. Please update maps to use this feature.";
-
 /* Update all button text */
 "downloader_update_all_button" = "Update All";
 
@@ -583,9 +399,6 @@
 
 /* Downloaded maps category */
 "downloader_downloaded_subtitle" = "Downloaded";
-
-/* Downloaded maps category */
-"downloader_available_maps" = "Available";
 
 /* Country queued for download */
 "downloader_queued" = "Queued";
@@ -598,17 +411,6 @@
 
 "downloader_downloading" = "Downloading:";
 
-"downloader_search_results" = "Found";
-
-/* Disclaimer message */
-"routing_disclaimer" = "Creating routes in Organic Maps app, please keep in mind the following:\n\n  - Suggested routes can be considered as recommendations only.\n - Road conditions, traffic rules and signs have higher priority than navigation advice.\n - The map may be incorrect or outdated, and routes may not be created the best possible way.\n\n  Be safe on roads and take care of yourself!";
-
-/* Outdated maps category */
-"downloader_outdated_maps" = "Outdated";
-
-/* Up to date maps category */
-"downloader_uptodate_maps" = "Up-to-date";
-
 /* Status of outdated country in the list */
 "downloader_status_outdated" = "Update";
 
@@ -618,49 +420,14 @@
 /* Displayed in a dialog that appears when a user tries to delete a map while the app is in the follow route mode */
 "downloader_delete_map_while_routing_dialog" = "To delete map, please stop navigation.";
 
-/* Show when user try build route, but we don't know where he */
-"routing_failed_unknown_my_position" = "Current location is undefined. Please specify location to create route.";
-
-/* Show if use has not routing file, or InconsistentMWMandRoute */
-"routing_failed_has_no_routing_file" = "Additional data is required to create the route. Download data now?";
-
-/* StartPointNotFound */
-"routing_failed_start_point_not_found" = "Cannot calculate the route. No roads near your starting point.";
-
-/* EndPointNotFound */
-"routing_failed_dst_point_not_found" = "Cannot calculate the route. No roads near your destination.";
-
 /* PointsInDifferentMWM */
 "routing_failed_cross_mwm_building" = "Routes can only be created that are fully contained within a map of a single region.";
-
-/* RouteNotFound */
-"routing_failed_route_not_found" = "There is no route found between the selected origin and destination. Please select a different start or end point.";
-
-/* InternalError */
-"routing_failed_internal_error" = "Internal error occurred. Please try to delete and download the map again. If the problem persists, please contact us at support@organicmaps.app.";
-
-/* Context menu item for downloader. */
-"downloader_download_map_and_routing" = "Download Map + Routing";
-
-/* Context menu item for downloader. */
-"downloader_download_routing" = "Download Routing";
-
-/* Context menu item for downloader. */
-"downloader_delete_routing" = "Delete Routing";
 
 /* Context menu item for downloader. */
 "downloader_download_map" = "Download map";
 
-"downloader_download_map_no_routing" = "Download map without routing";
-
-/* Button for routing. */
-"routing_go" = "Go!";
-
 /* Item status in downloader. */
 "downloader_retry" = "Retry";
-
-/* Item in context menu. */
-"downloader_map_and_routing" = "Map + Routing";
 
 /* Item in context menu. */
 "downloader_delete_map" = "Delete Map";
@@ -668,29 +435,11 @@
 /* Item in context menu. */
 "downloader_update_map" = "Update Map";
 
-/* Item in context menu. */
-"downloader_update_map_and_routing" = "Update Map + Routing";
-
-/* Item in context menu. */
-"downloader_map_only" = "Map Only";
-
-/* Toolbar title */
-"toolbar_application_menu" = "Application menu";
-
 /* Preference text */
 "pref_use_google_play" = "Use Google Play Services to determine your current location";
 
 /* Text for rating dialog */
 "rating_just_rated" = "I’ve just rated your app";
-
-/* Text for rating dialog */
-"rating_user_since" = "I’ve been a Organic Maps user since %@";
-
-/* Text for rating dialog */
-"rating_do_like_maps" = "Do you like Organic Maps?";
-
-/* Text for rating dialog */
-"rating_tap_star" = "Tap a star to rate our app.";
 
 /* Text for rating dialog */
 "rating_thanks" = "Thank you!";
@@ -701,23 +450,8 @@
 /* Text for rating dialog */
 "rating_send_feedback" = "Send feedback";
 
-/* Text for g+ dialog */
-"rating_google_plus" = "Click g+ to tell your friends about the app.";
-
 /* Text for routing error dialog */
 "routing_download_maps_along" = "Download all of the maps along your route";
-
-/* Text for routing error dialog */
-"routing_download_map" = "Get map";
-
-/* Text for routing error dialog */
-"routing_download_map_and_routing" = "Download updated map and routing data to get all Organic Maps features.";
-
-/* Text for routing error dialog */
-"routing_get_routing_data" = "Get routing data";
-
-/* Text for routing error dialog */
-"routing_get_additional_data" = "Additional data required to create routes from your location.";
 
 /* Text for routing error dialog */
 "routing_requires_all_map" = "In order to create a route, we need to download and update all the maps from your location to your destination.";
@@ -725,50 +459,15 @@
 /* Text for routing error dialog */
 "routing_not_enough_space" = "Not enough space";
 
-/* Text for routing error dialog */
-"routing_download_more_than_avail" = "You need to download %@ MB, but only %@ MB are available.";
-
-/* Text for routing error dialog */
-"routing_download_roaming" = "You are going to download %@ MB using Mobile Data (in Roaming). This may result in additional charges, depending on your operator mobile data plan.";
-
 /* bookmark button text */
 "bookmark" = "bookmark";
-
-/* map is not downloaded */
-"not_found_map" = "The map for your location is not downloaded";
 
 /* location service disabled */
 "enable_location_services" = "Please enable Location Services";
 
-/* download map */
-"download_map" = "Download the map for your location";
-
-/* download map on iPhone */
-"download_map_iphone" = "Download a current location map on your iPhone";
-
-/* clear pin */
-"nearby" = "Nearby";
-
-/* clear pin */
-"clear_pin" = "Clear Pin";
-
-/* location is undefined */
-"undefined_location" = "Current location is undefined.";
-
-/* download country of your location */
-"download_country" = "Download the country of your current location";
-
-/* download failed */
-"download_failed" = "download has failed";
-
-/* get the map */
-"get_the_map" = "Get the map";
-
 "save" = "Save";
 
 "edit_description_hint" = "Your descriptions (text or html)";
-
-"new_group" = "new group";
 
 "create" = "create";
 
@@ -795,30 +494,6 @@
 
 /* pink color */
 "pink" = "Pink";
-
-/* deep purple color */
-"deep_purple" = "Deep Purple";
-
-/* light blue color */
-"light_blue" = "Light Blue";
-
-/* cyan color */
-"cyan" = "Cyan";
-
-/* teal color */
-"teal" = "Teal";
-
-/* lime color */
-"lime" = "Lime";
-
-/* deep orange color */
-"deep_orange" = "Deep Orange";
-
-/* gray color */
-"gray" = "Gray";
-
-/* blue gray color */
-"blue_gray" = "Blue Gray";
 
 /* Wi-Fi available */
 "WiFi_available" = "Yes";
@@ -848,13 +523,9 @@
 
 "dialog_routing_location_unknown_turn_on" = "Unable to locate current GPS coordinates. Enable location services to calculate route.";
 
-"dialog_routing_location_unknown" = "Unable to locate current GPS coordinates.";
-
 "dialog_routing_download_files" = "Download required files";
 
 "dialog_routing_download_and_update_all" = "Download and update all map and routing information along the projected path to calculate route.";
-
-"dialog_routing_routes_size" = "Routing information files";
 
 "dialog_routing_unable_locate_route" = "Unable to locate route";
 
@@ -884,21 +555,11 @@
 
 "dialog_routing_try_again" = "Please try again";
 
-"dialog_routing_send_error" = "Report the Problem";
-
-"dialog_routing_if_get_cross_route" = "Would you like to create a more direct route that spans more than one map?";
-
-"dialog_routing_cross_route_is_optimal" = "A more optimal route that crosses the edge of this map is available.";
-
 "not_now" = "Not Now";
-
-"dialog_routing_build_route" = "Create";
 
 "dialog_routing_download_and_build_cross_route" = "Would you like to download the map and create a more optimal route spanning more than one map?";
 
 "dialog_routing_download_cross_route" = "Download additional maps to create a better route that crosses the boundaries of this map.";
-
-"dialog_routing_cross_route_always" = "Always cross this boundary";
 
 
 /********** Strings for downloading map from search **********/
@@ -906,8 +567,6 @@
 "search_without_internet_advertisement" = "To start searching and creating routes, please download the map. After that you will no longer need an Internet connection.";
 
 "search_select_map" = "Select Map";
-
-"search_select_other_map" = "Select Another Map";
 
 /* «Show» context menu */
 "show" = "Show";
@@ -918,17 +577,11 @@
 /* «Rename» context menu */
 "rename" = "Rename";
 
-/* Bottom sheet: expand button (should be short) */
-"bottom_sheet_more" = "More…";
-
 /* Failed planning route message in navigation view */
 "routing_planning_error" = "Route Planning Failed";
 
 /* Arrive routing message in navigation view */
 "routing_arrive" = "Arrival at %s";
-
-/* Text for routing::RouterResultCode::FileTooOld dialog. */
-"dialog_routing_download_and_update_maps" = "Download and update all map along the projected path to calculate route.";
 
 "rate_alert_title" = "Like the app?";
 
@@ -944,19 +597,11 @@
 
 "history" = "History";
 
-"next_turn_then" = "Then";
-
 "closed" = "Closed";
-
-"back_to" = "Back to %@";
 
 "search_not_found" = "Oops, no results found.";
 
 "search_not_found_query" = "Try changing your search criteria.";
-
-"search_not_found_map" = "Please download the map you are searching in.";
-
-"search_not_found_location" = "Download the map of your current location.";
 
 "search_history_title" = "Search History";
 
@@ -964,23 +609,12 @@
 
 "clear_search" = "Clear Search History";
 
-/* Title for settings to enable/disable showcase menu button */
-"showcase_settings_title" = "Show offers";
-
 /* Place Page link to Wikipedia article (if map object has it). */
 "read_in_wikipedia" = "Wikipedia";
 
-"p2p_route_planning" = "Route Planning";
-
 "p2p_your_location" = "Your Location";
 
-"p2p_from" = "From";
-
-"p2p_to" = "To";
-
 "p2p_start" = "Start";
-
-"p2p_planning" = "Planning…";
 
 "p2p_from_here" = "Route from";
 
@@ -1018,15 +652,9 @@
 
 "editor_correct_mistake" = "Correct mistake";
 
-"editor_correct_mistake_message" = "You made an editing mistake. Please correct it or switch to simple mode.";
-
 "editor_add_select_location" = "Location";
 
 "editor_done_dialog_1" = "You’ve changed the world map. Do not keep it to yourself! Tell your friends, and edit it together.";
-
-"editor_done_dialog_2" = "This is the second time you edited the map. Now you are number %d in the map editors ranking. Tell your friends about it.";
-
-"editor_done_dialog_3" = "You’ve improved the map, tell your friends about it, and edit the map together.";
 
 "share_with_friends" = "Share with friends";
 
@@ -1044,20 +672,7 @@
 
 "editor_report_problem_duplicate_place_title" = "Duplicated place";
 
-"first_launch_congrats_title" = "Organic Maps is ready to use";
-
-"first_launch_congrats_text" = "Search and navigate everywhere in the world offline, free of charge.";
-
-"migrate_title" = "Important!";
-
-/* Android uses image instead of text. */
-"download_all" = "Download all";
-
-"delete_all" = "Delete all";
-
 "autodownload" = "Auto-download";
-
-"disable_autodownload" = "Disable autodownload";
 
 /* Place Page opening hours text */
 "closed_now" = "Closed now";
@@ -1072,10 +687,6 @@
 "day_off" = "Closed";
 
 "today" = "Today";
-
-"sunrise_to_sunset" = "From sunrise to sunset";
-
-"sunset_to_sunrise" = "From sunset to sunrise";
 
 "add_opening_hours" = "Add opening hours";
 
@@ -1095,45 +706,18 @@
 
 "forgot_password" = "Forgot your password?";
 
-/* Forgot Password dialog title */
-"restore_password" = "Restore password";
-
-"enter_email_address_to_reset_password" = "Enter the email address you used during registration and we will send you the link to reset your password.";
-
-"reset_password" = "Reset Password";
-
-"username" = "Username";
-
 "osm_account" = "OSM Account";
 
 "logout" = "Log Out";
 
-"login_and_edit_map_motivation_message" = "Log in and edit objects on the map, and we will make them available for millions of users. Let’s make the world better together.";
-
 /* Information text: "Last upload 11.01.2016" */
 "last_upload" = "Last upload";
 
-/* Motivates user to login/register, title above login buttons. */
-"you_have_edited_your_first_object" = "You’ve edited your first object!";
-
 "thank_you" = "Thank You";
-
-"login_with_google" = "Login with Google";
-
-"login_with_openstreetmap" = "Log in with www.openstreetmap.org";
 
 "edit_place" = "Edit Place";
 
 "place_name" = "Place Name";
-
-/* title above languages list cells in the editor, below editable name text field. */
-"other_languages" = "Other Languages";
-
-/* small button to open list with names in different languages */
-"show_more" = "Show More";
-
-/* small button to close list with names in different languages */
-"show_less" = "Show Less";
 
 "add_language" = "Add a language";
 
@@ -1164,8 +748,6 @@
 
 "please_note" = "Please note";
 
-"common_no_wifi_dialog" = "No WiFi connection. Do you want to continue with mobile data?";
-
 "downloader_delete_map_dialog" = "All of your map edits will be deleted together with the map.";
 
 "downloader_update_maps" = "Update Maps";
@@ -1173,10 +755,6 @@
 "downloader_mwm_migration_dialog" = "To create a route, you need to update all maps and then plan the route again.";
 
 "downloader_search_field_hint" = "Find map";
-
-"migration_update_all_button" = "Update All Maps";
-
-"migration_delete_all_download_current_button" = "Download the current map and delete all of the old ones";
 
 "migration_download_error_dialog" = "Download error";
 
@@ -1186,21 +764,9 @@
 
 "downloader_no_space_message" = "Please delete any unnecessary data";
 
-"editor_general_auth_error_dialog" = "General login error.";
-
 "editor_login_error_dialog" = "Login error.";
 
-"editor_login_failed_dialog" = "Login failed";
-
-"editor_username_error_dialog" = "Username is invalid";
-
-"editor_place_edited_dialog" = "You’ve edited an object!";
-
-"editor_login_with_osm" = "Login with OpenStreetMap";
-
 "editor_profile_changes" = "Verified Changes";
-
-"editor_profile_unsent_changes" = "Not sent:";
 
 "editor_focus_map_on_location" = "Drag the map to select the correct location of the object.";
 
@@ -1222,13 +788,9 @@
 
 "editor_report_problem_other_title" = "Different problem";
 
-"placepage_report_problem_button" = "Report a problem";
-
 "placepage_add_business_button" = "Add business";
 
 "whatsnew_editor_message_1" = "Add new places to the map, and edit existing ones directly from the app.";
-
-"whatsnew_editor_message_2" = "* Organic Maps uses OpenStreetMap community data.";
 
 "dialog_incorrect_feature_position" = "Change location";
 
@@ -1236,16 +798,10 @@
 
 "login_to_make_edits_visible" = "Log in so other users can see the changes that you have made";
 
-"no_migration_during_navigation" = "Updating is not allowed during navigation.";
-
 /* Error dialog no space */
 "migration_no_space_message" = "To download, you need more space. Please delete any unnecessary data.";
 
 "editor_sharing_title" = "I improved the Organic Maps maps";
-
-"editor_comment_will_be_sent" = "We will make sure to send your comments to the map editors.";
-
-"editor_unsupported_category_message" = "You have added an object whose category we do not support yet. It will appear on the map in the future.";
 
 /* Downloaded 10 **of** 20 <- it is that "of" */
 "downloader_of" = "%1$d of %2$d";
@@ -1278,23 +834,9 @@
 
 "editor_operator" = "Owner";
 
-"editor_tag_description" = "Enter company, organization or individual responsible for the facilities.";
-
-"editor_no_local_edits_title" = "You don't have local edits";
-
-"editor_no_local_edits_description" = "This shows the number of your suggested changes on the map that are currently accessible only on your device.";
-
-"editor_send_to_osm" = "Send to OSM";
-
-"editor_remove" = "Remove";
-
-"downloader_my_maps_title" = "My maps";
-
 "downloader_no_downloaded_maps_title" = "You haven't downloaded any maps";
 
 "downloader_no_downloaded_maps_message" = "Download maps to search for a location and use navigation offline.";
-
-"downloader_find_place_hint" = "Search city or country";
 
 /* Error title that appears after certain time without location. */
 "current_location_unknown_title" = "Continue detecting your current location?";
@@ -1321,47 +863,13 @@
 /* iOS Dialog for the case when the location permission is not granted */
 "location_services_disabled_3" = "3. Select While Using the App";
 
-"placepage_parking_surface" = "Surface";
-
-"placepage_parking_multistorey" = "Multi-storey";
-
-"placepage_parking_underground" = "Underground";
-
-"placepage_parking_rooftop" = "Rooftop";
-
-"placepage_parking_sheds" = "Sheds";
-
-"placepage_parking_carports" = "Carports";
-
-"placepage_parking_boxes" = "Garage boxes";
-
-"placepage_parking_pay" = "Pay";
-
-"placepage_parking_free" = "Free";
-
-"placepage_parking_interval" = "Interval Pay";
-
-"placepage_entrance_number" = "No.";
-
-"placepage_entrance_type" = "Entrance";
-
-"placepage_flat" = "app.";
-
-"placepage_open_24_7" = "24 / 7";
-
 "meter" = "m";
 
 "kilometer" = "km";
 
-"kilometers_per_hour" = "km/h";
-
 "mile" = "mi";
 
 "foot" = "ft";
-
-"miles_per_hour" = "mph";
-
-"day" = "d";
 
 "hour" = "h";
 
@@ -1381,10 +889,6 @@
 
 "placepage_bookmark_name_hint" = "Bookmark Name";
 
-"placepage_personal_notes_hint" = "Personal notes";
-
-"placepage_delete_bookmark_button" = "Delete Bookmark";
-
 "editor_edits_sent_message" = "Your suggested changes have been sent";
 
 "editor_comment_hint" = "Comment…";
@@ -1397,8 +901,6 @@
 
 "editor_remove_place_button" = "Delete";
 
-"editor_status_sending" = "Sending…";
-
 "editor_place_doesnt_exist" = "Place does not exist";
 
 "text_more_button" = "…more";
@@ -1410,11 +912,7 @@
 
 "error_enter_correct_email" = "Enter a valid email";
 
-"error_enter_correct" = "Enter a valid value";
-
 "refresh" = "Update";
-
-"last_update" = "Last update: %s";
 
 "placepage_add_place_button" = "Add a place to the map";
 
@@ -1426,24 +924,6 @@
 
 "editor_share_to_all_dialog_message_2" = "We will check the changes. If we have any questions we will contact you via email.";
 
-"navigation_overview_button" = "overview";
-
-"navigation_stop_button" = "stop";
-
-/* Text on an empty bookmark page */
-"bookmarks_empty_title" = "Save Bookmarks";
-
-"bookmarks_empty_message_1" = "Tap on ★ to save favorite places for quick access.";
-
-"bookmarks_empty_message_2" = "Import Bookmarks from email and web.";
-
-"bookmarks_empty_message_3" = "check out: %s";
-
-/* Name of the group for booked hotels */
-"bookmarks_group_name" = "Booked hotels";
-
-"place_page_button_read_descriprion" = "Read";
-
 /* iOS dialog for the case when recent track recording is on and the app comes back from background */
 "recent_track_background_dialog_title" = "Disable recording of your recently traveled route?";
 
@@ -1451,8 +931,6 @@
 
 /* For sharing via SMS and so on */
 "sharing_call_action_look" = "Check out";
-
-"continue_recent_track_background_button" = "Continue";
 
 "recent_track_background_dialog_message" = "Organic Maps uses your geoposition in the background for recording your recently traveled route.";
 
@@ -1468,33 +946,13 @@
 /* About short text (below logo) */
 "about_description" = "Organic Maps is an essential offline application for travelling. Organic Maps is based on OpenStreetMap data and allows editing it.";
 
-/* Text in menu */
-"blog" = "Blog";
-
 "general_settings" = "General settings";
-
-"date" = "Date %d";
-
-/* "Report a bug" -> "Generaal Feedback" -> "Something is not working" */
-"something_is_not_working" = "Something is not working";
 
 /* For the first routing */
 "accept" = "Accept";
 
-"accept_and_continue" = "Accept and continue";
-
 /* For the first routing */
 "decline" = "Decline";
-
-"install_app" = "Install";
-
-"search_no_results_title" = "No Results Found";
-
-"search_no_results_message" = "Try a more general search term, zoom out or reset the filter.";
-
-"search_no_results_expand_area_button" = "Zoom out";
-
-"search_no_results_reset_button" = "Reset Filter";
 
 /* noun */
 "search_in_table" = "List";
@@ -1517,8 +975,6 @@
 
 "traffic_update_maps_text" = "To display traffic data, maps must be updated.";
 
-"traffic_outdated" = "Traffic data is outdated.";
-
 "big_font" = "Increase font size on the map";
 
 "traffic_update_app" = "Please update Organic Maps";
@@ -1529,17 +985,7 @@
 /* "traffic" as in "road congestion" */
 "traffic_data_unavailable" = "Traffic data is not available";
 
-/* "Translation is no needed, because it's a company name" */
-"uber" = "Uber";
-
-/* Simplified colour scheme for traffic information, fewer colours are used to display traffic jams on the map. The string should be kept as short as possible */
-"pref_traffic_simplified_colors_title" = "Simplified traffic colors";
-
 "enable_logging" = "Enable logging";
-
-"offline_place_page_more_information" = "Connect to the internet to get more information about the place.";
-
-"failed_load_information" = "Failed to load information.";
 
 /* Settings: "Send general feedback" button */
 "feedback_general" = "General Feedback";
@@ -1556,8 +1002,6 @@
 
 "whatsnew_transliteration_title" = "Transliteration into Latin";
 
-"yandex_taxi_title" = "Yandex.Taxi";
-
 "learn_more" = "Learn more";
 
 "core_exit" = "Exit";
@@ -1568,75 +1012,19 @@
 
 "button_exit" = "Exit";
 
-"settings_device_memory" = "Device memory";
-
-"settings_card_memory" = "Card memory";
-
-"settings_storage_available" = "%s available";
-
-"toast_location_permission_denied" = "App location permission denied";
-
-"button_use" = "Use";
-
 "planning_route_manage_route" = "Manage Route";
 
 "button_plan" = "Plan";
-
-"button_add" = "Add";
 
 "placepage_remove_stop" = "Remove";
 
 "planning_route_remove_title" = "Drag here to remove";
 
-"dialog_change_start_point_message" = "Set the current location as the starting point?";
-
-"button_replace" = "Replace";
-
 "placepage_add_stop" = "Add Stop";
-
-/* Only ru/en are needed */
-"subtitle_rent" = "Rent";
-
-/* Only ru/en are needed */
-"rub_month" = "RUB/month";
-
-/* Only ru/en are needed */
-"room" = "%s-room apt.";
-
-/* Only ru/en are needed */
-"real_estate" = "Real estate";
-
-"add_my_position" = "Add my position";
-
-"choose_start_point" = "Choose a starting point";
-
-"choose_destination" = "Choose a destination";
 
 "preloader_viator_button" = "Learn more";
 
-"start_from_my_position" = "Start from";
-
-"profile_authorization_title" = "Sign in with";
-
-"profile_authorization_message" = "Easy sign in without login and password in a couple of seconds";
-
 "profile_authorization_error" = "Oops, there was an error. Try to sign in again.";
-
-"service" = "Service";
-
-"atmosphere" = "Atmosphere";
-
-"value_for_money" = "Value for money";
-
-"experience" = "Experience";
-
-"assortment" = "Assortment";
-
-"expertise" = "Expertise";
-
-"equipment" = "Equipment";
-
-"quality" = "Quality";
 
 "dialog_error_storage_title" = "Storage access problem";
 
@@ -1644,17 +1032,7 @@
 
 "setting_emulate_bad_storage" = "Emulate bad storage";
 
-"directions_finish" = "Destination";
-
-"directions_on_foot" = "Walk %s";
-
 "core_entrance" = "Entrance";
-
-"coffee" = "Coffee";
-
-"cleanliness" = "Cleanliness";
-
-"crowdedness" = "Crowdedness";
 
 "error_enter_correct_name" = "Please, enter a correct name";
 
@@ -1673,11 +1051,9 @@
 
 "downloader_percent" = "%s (%s of %s)";
 
-"downloader_process" = "Downloading %s...";
+"downloader_process" = "Downloading %s…";
 
-"downloader_applying" = "Applying %s...";
-
-"dialog_message_transit_not_found_connection" = "Plan a route within one transit network";
+"downloader_applying" = "Applying %s…";
 
 "bookmarks_error_message_share_general" = "Unable to share due to an application error";
 
@@ -1695,17 +1071,7 @@
 
 "bookmarks_error_message_list_name_already_taken" = "Please choose another name";
 
-"bookmarks_error_title_list_name_too_long" = "This name is too long";
-
-"bookmarks_error_message_list_name_too_long" = "Please choose another name";
-
-"please_wait" = "Please wait...";
-
-"phone_number" = "Phone number";
-
-"notification_unsent_reviews_title" = " You have several unsent reviews";
-
-"notification_unsent_reviews_message" = " Please sign in to share reviews with other travellers";
+"please_wait" = "Please wait…";
 
 "profile" = "OpenStreetMap profile";
 
@@ -1719,49 +1085,13 @@
 
 "bookmarks_convert_error_message" = "Some files were not converted.";
 
-"converting" = "Converting...";
-
-"wn_reinvented_bookmarks_title" = "We reinvented bookmarks!";
-
-"wn_reinvented_bookmarks_message" = "You can backup them, create lists...It’s amazing...";
-
-"bookmarks_restore" = " Restore bookmarks";
-
-"bookmarks_restore_process" = " Restoring...";
-
-"bookmarks_restore_title" = " Restore this version?";
-
-"bookmarks_restore_message" = " Your bookmarks will be restored from %s (%s)";
-
-"bookmarks_restore_empty_title" = " You don’t have any backups";
-
-"bookmarks_restore_empty_message" = " The server couldn't find previously made backups";
+"bookmarks_restore_title" = "Restore this version?";
 
 "common_check_internet_connection_dialog_title" = "No internet connection";
 
-"error_server_title" = " Server error";
-
-"error_server_message" = " There was an error on the server, please try again later";
-
-"error_system_message" = " An unknown error occurred";
+"error_system_message" = "An unknown error occurred";
 
 "restore" = "Restore";
-
-"bookmarks_page_downloaded" = "Downloaded";
-
-"bookmarks_page_my" = "My";
-
-"routes_and_bookmarks" = "Routes and bookmarks";
-
-"bookmarks_webview_success_toast" = "Bookmarks succesfully downloaded";
-
-"cached_bookmarks_placeholder_title" = "Download new places";
-
-"cached_bookmarks_placeholder_subtitle" = "Press the button to download thousands of interesting places and routes created by Organic Maps users. You will need the internet connection.";
-
-"downloader_download_routers" = "Download bookmarks";
-
-"bookmarks_groups_cached" = "Downloaded lists";
 
 "subtittle_opt_out" = "Tracking settings";
 
@@ -1769,29 +1099,15 @@
 
 "crash_reports_description" = "We may use your data to improve Organic Maps experience. Changes will take effect after you restart the app.";
 
-"opt_out_help_ios_1" = "Your mobile device may provide a “Limit Ad Tracking” or “Opt out of interest-based advertising” setting.";
-
-"opt_out_help_ios_2" = "iOS 9 or Higher";
-
-"opt_out_help_ios_3" = "Go to your Settings → Privacy → Advertising → Enable the “Limit Ad Tracking” setting";
-
-"opt_out_help_android" = "Your mobile device may provide a “Limit Ad Tracking” or “Opt out of interest-based advertising” setting.\n\nFor Android and Google Play Services version 4.0 and up:\nSettings → Google → Ads → Opt out of Ads Personalization\nor\nSettings → Google → Google Account → Personal info & privacy → Ads Settings → Ads Personalization";
-
 "privacy_policy" = "Privacy policy";
 
 "terms_of_use" = "Terms of use";
-
-"backup_notification_failed" = "Backing up your bookmarks has been suspended. Log in to turn it back on.";
 
 "button_layer_traffic" = "Traffic";
 
 "button_layer_subway" = "Subway";
 
 "layers_title" = "Map layers";
-
-"layers_message" = "Use map layers to display the traffic, subway map, and other useful information";
-
-"button_layer_got_it" = "Got it";
 
 "subway_data_unavailable" = "Subway map is unavailable";
 
@@ -1803,39 +1119,13 @@
 
 "title_error_downloading_bookmarks" = "An error occurred";
 
-"subtitle_error_downloading_bookmarks" = "Bookmarks were not downloaded";
-
-"error_already_downloaded" = "This list has already been downloaded";
-
 "popular_place" = "Popular";
-
-"download_routes" = "Download routes";
-
-"bookmarks_downloaded_title" = "Bookmarks have been downloaded successfully";
-
-"bookmarks_downloaded_subtitle" = "Press ‘View on map’ to explore new places from the list";
-
-"why_support" = "Why support Organic Maps?";
-
-"why_support_item1" = "We respect your privacy: there are zero trackers in the app, and we are open source";
-
-"why_support_item2" = "You help us to improve Organic Maps";
-
-"why_support_item3" = "You help us improve open maps OpenStreetMap.org";
-
-"channels_map_update" = "Map updates";
-
-"server_unavailable_title" = "Server is unavailable";
-
-"sharing_options" = "Sharing options";
 
 "export_file" = "Export file";
 
 "list_settings" = "List Settings";
 
 "delete_list" = "Delete list";
-
-"hide_from_map" = "Hide from map";
 
 "public_access" = "Public access";
 
@@ -1845,40 +1135,11 @@
 
 "bookmark_category_description_hint" = "Type a description (text or html)";
 
-/* FIXME */
-"bookmarks_public_access" = "bookmarks_public_access";
-
-/* FIXME */
-"bookmarks_link_access" = "bookmarks_link_access";
-
-/* FIXME */
-"bookmarks_private_access" = "bookmarks_private_access";
-
 "not_shared" = "Private";
-
-"direct_link_progress_text" = "Uploading your file…";
-
-"direct_link_success" = "The link has been created";
-
-"send_a_link_btn" = "Send me a link";
-
-"upload_error_toast" = "An error occurred while uploading your file";
 
 "tags_loading_error_subtitle" = "An error occurred while loading tags, please try again";
 
-"unable_upload_errorr_title" = "File upload failed";
-
-"unable_upload_error_subtitle_edited" = "This file has been edited via the web app";
-
-"unable_upload_error_subtitle_broken" = "This file is damaged and couldn't be uploaded. Please upload another file.";
-
-"contact" = "Contact";
-
-"download_button" = "Download";
-
 "speedcams_alert_title" = "Speed cameras";
-
-"speedcams_alert_subtitle" = "Warn about speed limits";
 
 "speedcam_option_auto" = "Auto";
 
@@ -1886,18 +1147,10 @@
 
 "speedcam_option_never" = "Never";
 
-"bookmark_description_title" = "Bookmark Description";
-
 "place_description_title" = "Place Description";
 
 /* this text will be shown in application notification preferences opposite checkbox which enable/disable downloader notifications. Devices on Android 8+ are affected. */
 "notification_channel_downloader" = "Map downloader";
-
-"share_bookmarks_email_body_link" = "Hello!\n\nHere is the link where you can download bookmarks: %s. Open the list in Organic Maps and enjoy your trip!\n\nGet application: https://omaps.app/get?kmz";
-
-"warning_speedcams_title" = "Navigator will warn you about cameras when you exceed the speed limit of %d km/h";
-
-"warning_speedcams_subtitle" = "Please mind driving regulations of the country you are travelling to.";
 
 "speedcams_notice_message" = "Auto - Warn about speedcams if there is a risk of exceeding the speed limit\nAlways - Always warn about speedcams\nNever - Never warn about speedcams";
 
@@ -1913,23 +1166,7 @@
 
 "enable_logging_warning_message" = "The option turns on logging for diagnostic purposes. It can be helpful for our team to troubleshoot issues with the app. Enable this option temporarily to record and send detailed logs about your issue to us.";
 
-"html_error_upload_message_try_again" = "Please check your network settings and try again";
-
-"html_error_upload_title_try_again" = "No internet connection";
-
-"notification_leave_review_v2_android_short_title" = "Review and help travellers!";
-
-"megafon" = "Say goodbye to roaming!";
-
-"notifications_illegal_alert_disable_button" = "Turn off notifications";
-
 "access_rules_author_only" = "Online editing";
-
-"privacy_settings_menu" = "Privacy settings";
-
-"unable_upadate_error_title" = "File update failed";
-
-"unable_upadate_error_message" = "Some errors occurred while updating. Please check the changes and try again";
 
 "driving_options_title" = "Routing options";
 
@@ -1951,94 +1188,19 @@
 
 "change_driving_options_btn" = "Routing options enabled";
 
-"toll_road" = "Toll road";
-
-"unpaved_road" = "Unpaved road";
-
-"ferry_crossing" = "Ferry crossing";
-
-"operated_by" = "Operated by \"%s\"";
-
 "avoid_toll_roads_placepage" = "Avoid toll roads";
 
 "avoid_unpaved_roads_placepage" = "Avoid unpaved roads";
 
 "avoid_ferry_crossing_placepage" = "Avoid ferry crossings";
 
-"type.cuisine.uzbek" = "Uzbek cuisine";
-
-"trip_start" = "Let's go";
-
-"pick_destination" = "Destination";
-
-"follow_my_position" = "Re-center";
-
-"search_results" = "Search results";
-
-"then_turn" = "Then";
-
-"redirect_route_alert" = "Do you want to rebuild the route?";
-
-"redirect_route_yes" = "Yes";
-
-"redirect_route_no" = "No";
-
-"trip_finished" = "You have arrived!";
-
-"keyboard_availability_alert" = "Keyboard is not available while driving";
-
-"dialog_routing_change_start_carplay" = "Unable to build a route from your current location";
-
-"dialog_routing_change_end_carplay" = "Unable to build a route to your destination. Please choose another point";
-
-"dialog_routing_check_gps_carplay" = "No GPS signal. Please move to an open area";
-
-"dialog_routing_unable_locate_route_carplay" = "Unable to build a route. Please specify other route points";
-
-"dialog_routing_download_files_carplay" = "To create a route, download missing maps on your device";
-
-"dialog_routing_system_error_carplay" = "An error occurred. Please restart the application";
-
-"dialog_routing_rebuild_from_current_location_carplay" = "The route will be rebuilt from your current location";
-
-"dialog_routing_rebuild_for_vehicle_carplay" = "The route will be converted into an automobile one";
-
 "ok" = "Ok";
-
-"avoid_unpaved_carplay_1" = "No dirt road";
-
-"avoid_unpaved_carplay_2" = "Avoid unpaved";
-
-"avoid_ferry_carplay_1" = "No ferries";
-
-"avoid_ferry_carplay_2" = "Avoid ferries";
-
-"avoid_tolls_carplay_1" = "No toll road";
-
-"avoid_tolls_carplay_2" = "Avoid toll road";
-
-"speedcams_alert_title_carplay_1" = "Speedсams";
-
-"speedcams_alert_title_carplay_2" = "Speed warnings";
-
-"download_map_carplay" = "Please download maps in Organic Maps app on your device";
-
-"carplay_roundabout_exit" = "%s exit";
 
 /* max. 10 symbols, both iOS and Android */
 "sort" = "Sort…";
 
 /* Android, title, max 20-22 symbols */
 "sort_bookmarks" = "Sort bookmarks";
-
-/* iOS */
-"sort_default" = "Sort by default";
-
-"sort_type" = "Sort by type";
-
-"sort_distance" = "Sort by distance";
-
-"sort_date" = "Sort by date";
 
 /* Android */
 "by_default" = "By default";
@@ -2052,63 +1214,7 @@
 /* Android */
 "by_date" = "By date";
 
-"week_ago_sorttype" = "A week ago";
-
-"month_ago_sorttype" = "A month ago";
-
-"moremonth_ago_sorttype" = "More than a month ago";
-
-"moreyear_ago_sorttype" = "More than a year ago";
-
-"near_me_sorttype" = "Near me";
-
-"others_sorttype" = "Others";
-
-"food_places" = "Food";
-
-"tourist_places" = "Sights";
-
-"museums" = "Museums";
-
-"parks" = "Parks";
-
-"swim_places" = "Swim";
-
-"mountains" = "Mountains";
-
-"animals" = "Animals";
-
-"hotels" = "Hotels";
-
-"buildings" = "Buildings";
-
-"money" = "Money";
-
-"shops" = "Shops";
-
-"parkings" = "Parkings";
-
-"fuel_places" = "Gas stations";
-
-"water" = "Water";
-
-"medicine" = "Medicine";
-
 "search_in_the_list" = "Search in the list";
-
-"view_on_map_bookmarks" = "On map";
-
-"more_bookmarks" = "More…";
-
-"no_items_found" = "No items found";
-
-/* Android, max 18 symbols */
-"bookmarks_edit_list" = "Edit list";
-
-/* Android, max 18 symbols */
-"bookmarks_delete_list" = "Delete list";
-
-"religious_places" = "Religious places";
 
 "select_list" = "Select list";
 
@@ -2118,26 +1224,13 @@
 
 "dialog_pedestrian_route_is_long_message" = "Please choose a start or end point closer to a subway station";
 
-/* Failed planning SUBWAY route message in navigation view */
-"routing_planning_error_subway_special" = "Subway route planning failed";
-
 "button_layer_isolines" = "Terrain";
-
-"tips_map_layers_title_countour" = "New in Organic Maps: offline topographic layer!";
-
-"tips_map_layers_message_countour" = "Plan and enjoy your nature trips being sure you know everything about the area";
 
 "isolines_activation_error_dialog" = "To activate and use the topographic layer please update or download the map of the area";
 
 "isolines_location_error_dialog" = "The topographic layer is not yet available in this area";
 
 "elevation_profile_diff_level" = "Difficulty level";
-
-"elevation_profile_diff_level_easy" = "Easy";
-
-"elevation_profile_diff_level_moderate" = "Moderate";
-
-"elevation_profile_diff_level_hard" = "Hard";
 
 "elevation_profile_ascent" = "Ascent";
 
@@ -2147,25 +1240,13 @@
 
 "elevation_profile_maxaltitude" = "Max. altitude";
 
-"elevation_profile_m" = "m";
-
 "elevation_profile_difficulty" = "Difficulty";
 
 "elevation_profile_distance" = "Dist.:";
 
-"elevation_profile_km" = "km";
-
 "elevation_profile_time" = "Time:";
 
-"elevation_profile_hours" = "h.";
-
-"elevation_profile_minutes" = "min";
-
 "isolines_toast_zooms_1_10" = "Zoom in to explore isolines";
-
-"downloader_updating_ios" = "Updating";
-
-"downloader_loading_ios" = "Downloading";
 
 "key_information_title" = "Key information";
 

--- a/iphone/Maps/LocalizedStrings/en-GB.lproj/Localizable.stringsdict
+++ b/iphone/Maps/LocalizedStrings/en-GB.lproj/Localizable.stringsdict
@@ -9,21 +9,6 @@
 
 <!-- ********** Strings for downloading map from search **********/ -->
 
-  <key>bookmarks_places</key>
-  <dict>
-    <key>NSStringLocalizedFormatKey</key>
-    <string>%#@value@</string>
-    <key>value</key>
-    <dict>
-      <key>NSStringFormatSpecTypeKey</key>
-      <string>NSStringPluralRuleType</string>
-      <key>NSStringFormatValueTypeKey</key>
-      <string>d</string>
-      <key>other</key>
-      <string>%d bookmarks</string>
-    </dict>
-  </dict>
-
   <key>bookmarks_detect_message</key>
   <dict>
     <key>NSStringLocalizedFormatKey</key>
@@ -36,21 +21,6 @@
       <string>d</string>
       <key>other</key>
       <string>%d files were found. You can see them after conversion.</string>
-    </dict>
-  </dict>
-
-  <key>bookmarks_objects</key>
-  <dict>
-    <key>NSStringLocalizedFormatKey</key>
-    <string>%#@value@</string>
-    <key>value</key>
-    <dict>
-      <key>NSStringFormatSpecTypeKey</key>
-      <string>NSStringPluralRuleType</string>
-      <key>NSStringFormatValueTypeKey</key>
-      <string>d</string>
-      <key>other</key>
-      <string>%s objects</string>
     </dict>
   </dict>
 

--- a/iphone/Maps/LocalizedStrings/en.lproj/Localizable.strings
+++ b/iphone/Maps/LocalizedStrings/en.lproj/Localizable.strings
@@ -18,9 +18,6 @@
 /* Button which deletes downloaded country */
 "delete" = "Delete";
 
-/* Button "do not interrupt download" if user touched actively downloading country */
-"do_nothing" = "Continue";
-
 "download_maps" = "Download Maps";
 
 /* Settings/Downloader - info for country when download fails */
@@ -28,9 +25,6 @@
 
 /* Settings/Downloader - info for country which started downloading */
 "downloading" = "Downloading…";
-
-/* Settings/Downloader - size string, only strings different from English should be translated */
-"kb" = "kB";
 
 /* Choose measurement on first launch alert - choose metric system button */
 "kilometres" = "Kilometers";
@@ -55,17 +49,11 @@
 /* Update maps later/Buy pro version later button text */
 "later" = "Later";
 
-/* Don't show some dialog any more */
-"never" = "Never";
-
 /* View and button titles for accessibility */
 "search" = "Search";
 
 /* Search box placeholder text */
 "search_map" = "Search Map";
-
-/* Settings/Downloader - info for not downloaded country */
-"touch_to_download" = "Touch to download";
 
 /* Settings/Downloader - 3G download warning dialog confirm button */
 "use_cellular_data" = "Yes";
@@ -73,20 +61,11 @@
 /* Location services are disabled by user alert - message */
 "location_is_disabled_long_text" = "You currently have all Location Services for this device or application disabled. Please enable them in Settings.";
 
-/* Location Services are not available on the device alert - message */
-"device_doesnot_support_location_services" = "Your device doesn't support Location Services";
-
 /* View and button titles for accessibility */
 "zoom_to_country" = "Show on the map";
 
-/* Button text for the button at the center of the screen when the country is not downloaded */
-"country_status_download" = "Download Map\n(^ ^)";
-
 /* Button text for the button at the center of the screen when the country is not downloaded and the size should not be shown */
 "country_status_download_without_size" = "Download Map";
-
-/* Button text for the button at the center of the screen when the country is not downloaded */
-"country_status_download_without_routing" = "Download map\nwithout routing (^ ^)";
 
 /* Message to display at the center of the screen when the country download has failed */
 "country_status_download_failed" = "Download has failed";
@@ -96,19 +75,13 @@
 
 "about_menu_title" = "About Organic Maps";
 
-"downloaded_touch_to_delete" = "Downloaded (%@), touch to delete";
-
 "connection_settings" = "Connection Settings";
-
-"download_mb_or_kb" = "Download %@";
 
 "close" = "Close";
 
 "unsupported_phone" = "The app requires hardware accelerated OpenGL. Unfortunately, your device is not supported.";
 
 "download" = "Download";
-
-"external_storage_is_not_available" = "SD card/USB storage with downloaded maps is not available";
 
 "disconnect_usb_cable" = "Please disconnect USB cable or insert memory card to use Organic Maps";
 
@@ -117,8 +90,6 @@
 "not_enough_memory" = "Not enough memory to launch app";
 
 "download_resources" = "Before you start using the app, allow us to download the general world map to your device.\nIt will use %@ of storage.";
-
-"getting_position" = "Getting current position";
 
 "download_resources_continue" = "Go to Map";
 
@@ -140,23 +111,14 @@
 /* Add New Bookmark Set dialog title */
 "add_new_set" = "Add New Set";
 
-/* Place Page - Add To Bookmarks button */
-"add_to_bookmarks" = "Add to Bookmarks";
-
 /* Bookmark Color dialog title */
 "bookmark_color" = "Bookmark Color";
 
 /* Add Bookmark Set dialog - hint when set name is empty */
 "bookmark_set_name" = "Bookmark Set Name";
 
-/* Bookmark Sets dialog title */
-"bookmark_sets" = "Bookmark Sets";
-
 /* Bookmarks - dialog title */
 "bookmarks" = "Bookmarks";
-
-/* Add bookmark dialog - bookmark color */
-"color" = "Color";
 
 /* Default bookmarks set name */
 "core_my_places" = "My Places";
@@ -167,14 +129,8 @@
 /* Editor title above street and house number */
 "address" = "Address";
 
-/* Place Page - Remove Pin button */
-"remove_pin" = "Remove Pin";
-
 /* Add bookmark dialog - bookmark set, Bookmarks dialog - Bookmark set cell */
 "set" = "Set";
-
-/* Text hint in Bookmarks dialog when no any bookmarks are added */
-"bookmarks_usage_hint" = "You have no bookmarks yet.\nTap on any place on the map to add a bookmark.\nBookmarks from other sources can also be imported and displayed in Organic Maps. Open KML/KMZ file with saved bookmarks from email, Dropbox or weblink.";
 
 /* Settings button in system menu */
 "settings" = "Settings";
@@ -191,26 +147,11 @@
 /* Ask to wait user several minutes (some long process in modal dialog). */
 "wait_several_minutes" = "This can take several minutes.\nPlease wait…";
 
-/* Show bookmarks from this category on a map or not */
-"visible" = "Visible";
-
-/* Toast which is displayed when GPS has been deactivated */
-"gps_is_disabled_long_text" = "GPS is disabled. Please enable it in Settings.";
-
 /* Measurement units title in settings activity */
 "measurement_units" = "Measurement units";
 
 /* Detailed description of Measurement Units settings button */
 "measurement_units_summary" = "Choose between miles and kilometers";
-
-/* Do search in all sources */
-"search_mode_all" = "Everywhere";
-
-/* Do search near my position only */
-"search_mode_nearme" = "Near Me";
-
-/* Do search in current viewport only */
-"search_mode_viewport" = "On the Screen";
 
 /* Search category for cafes, bars, restaurants */
 "eat" = "Where to eat";
@@ -266,14 +207,8 @@
 /* Search category */
 "police" = "Police";
 
-/* String in search result list, when nothing found */
-"no_search_results_found" = "No results found";
-
 /* Notes field in Bookmarks view */
 "description" = "Notes";
-
-/* Button text */
-"share_by_email" = "Share by email";
 
 /* Email Subject when sharing bookmarks category */
 "share_bookmarks_email_subject" = "Organic Maps bookmarks were shared with you";
@@ -295,26 +230,11 @@
 /* Warning message when doing search around current position */
 "unknown_current_position" = "Your location hasn't been determined yet";
 
-/* Warning message when location country isn't downloaded during search (see also download_location_map_proposal). */
-"download_location_country" = "Download the map of your current location (%@)";
-
-/* Warning message when viewport country isn't downloaded during search */
-"download_viewport_country_to_search" = "Download the country you are searching on (%@)";
-
 /* Alert message that we can't run Map Storage settings due to some reasons. */
 "cant_change_this_setting" = "Sorry, Map Storage settings are currently disabled.";
 
 /* Alert message that downloading is in progress. */
 "downloading_is_active" = "Map download is in progress now.";
-
-/* Message that will be shown in alert view, when we ask user to leave review on App Store */
-"appStore_message" = "Hope you enjoy using Organic Maps! If so, please rate or review the app at the App Store. It takes less than a minute but can really help us. Thanks for your support!";
-
-/* No, thanks */
-"no_thanks" = "No, thanks";
-
-/* Share one specific bookmark using SMS, %1$@ contains om:// and %2$@ https://omaps.app link. @NOTE non-ascii symbols in the link will result in max 70 characters SMS instead of 140. */
-"bookmark_share_sms" = "Hey, check out my pin at Organic Maps! %1$@ or %2$@ Don't have offline maps installed? Download here: https://omaps.app/get";
 
 /* Share my position using SMS, %1$@ contains om:// and %2$@ https://omaps.app link WITHOUT NAME. @NOTE non-ascii symbols in the link will result in max 70 characters SMS instead of 140. */
 "my_position_share_sms" = "Hey, check out my current location in Organic Maps! %1$@ or %2$@ Don't have offline maps? Download here: https://omaps.app/get";
@@ -328,23 +248,11 @@
 /* Share my position using EMail, %1$@ is om:// and %2$@ is https://omaps.app link WITHOUT NAME */
 "my_position_share_email" = "Hi,\n\nI'm here now: %1$@. Click this link %2$@ or this one %3$@ to see the place on the map.\n\nThanks.";
 
-/* Android share by Message/SMS button text (including SMS) */
-"share_by_message" = "Share by message";
-
 /* Share button text which opens menu with more buttons, like Message, EMail, Facebook etc. */
 "share" = "Share";
 
-/* iOS share by Message button text (including SMS) */
-"message" = "Message";
-
 /* Share by email button text, also used in editor. */
 "email" = "Email";
-
-/* Copy Link */
-"copy_link" = "Copy Link";
-
-/* Text for the button that returns to caller application */
-"more_info" = "Show More Info";
 
 /* Text for message when used successfully copied something */
 "copied_to_clipboard" = "Copied to clipboard: %1$@";
@@ -354,15 +262,6 @@
 
 /* Used for bookmark editing */
 "done" = "Done";
-
-/* Summary for preferences in MWM */
-"yopme_pref_summary" = "Choose Back Screen settings";
-
-/* Title for yopme preferences in MWM */
-"yopme_pref_title" = "Back Screen Settings";
-
-/* Hint for upper-right icon p2b */
-"show_on_backscreen" = "Show on Back screen";
 
 /* Prints version number in About dialog */
 "version" = "Version: %@";
@@ -381,19 +280,11 @@
 
 "share_my_location" = "Share My Location";
 
-"menu_search" = "Search";
-
 /* Settings general group in settings screen */
 "prefs_group_general" = "General settings";
 
 /* Settings information group in settings screen */
 "prefs_group_information" = "Information";
-
-/* Settings screen: "Map" category title */
-"prefs_group_map" = "Map";
-
-/* Settings screen: "Miscellaneous" category title */
-"prefs_group_misc" = "Miscellaneous";
 
 "prefs_group_route" = "Navigation";
 
@@ -419,9 +310,6 @@
 /* Settings «Map» category: «3D buildings» title */
 "pref_map_3d_buildings_title" = "3D buildings";
 
-/* Settings «Map» category: «3D buildings» summary */
-"pref_map_3d_buildings_subtitle" = "Affects battery life";
-
 /* Settings «Route» category: «Tts enabled» title */
 "pref_tts_enable_title" = "Voice Instructions";
 
@@ -433,8 +321,6 @@
 
 /* Title for "Other" section in TTS settings. */
 "pref_tts_other_section_title" = "Other";
-
-"pref_tts_how_to_set_up_voice" = "How to set up voice";
 
 /* Settings «Map» category: «Record track» title */
 "pref_track_record_title" = "Recent track";
@@ -455,56 +341,7 @@
 
 "recent_track_help_text" = "This option allows you to record traveled path for a certain period and see it on the map. Please note: activation of this function causes increased battery usage. The track will be removed automatically from the map after the time interval will expire.";
 
-"pref_track_ios_caption" = "Recent track shows your traveled path.";
-
-"pref_track_ios_subcaption" = "Please select the time range of saving the track.";
-
-"placepage_distance" = "Distance";
-
-"placepage_coordinates" = "Coordinates";
-
-"placepage_unsorted" = "Unsorted";
-
 "search_show_on_map" = "View on map";
-
-/* Used to warn user when fixing KitKat issue */
-"bookmark_move_fail" = "We need to move your bookmarks to internal memory, but there is no available space for them. Please free up the memory, otherwise bookmarks won’t be available.";
-
-/* Used in More Apps menu */
-"free" = "Free";
-
-/* Used in More Apps menu */
-"buy" = "Buy";
-
-/* 1st search button-like result */
-"search_on_map" = "Search on map";
-
-/* toast with an error */
-"no_route_found" = "No route found";
-
-/* route title */
-"route" = "Route";
-
-/* category title */
-"routes" = "Routes";
-
-/* text of notification */
-"download_map_notification" = "Download the map of the place where you are";
-
-/* text of notification */
-"pro_version_is_free_today" = "Full version of Organic Maps is free today! Download now and tell your friends.";
-
-/* Dialog for transferring maps from lite to pro. */
-"move_lite_maps_to_pro" = "We are transferring your downloaded maps from Organic Maps Lite to Organic Maps. It may take a few minutes.";
-
-/* Message to display when maps moved. */
-"move_lite_maps_to_pro_ok" = "Your downloaded maps are successfully transferred to Organic Maps.";
-
-/* Message to display when maps move failed. */
-"move_lite_maps_to_pro_failed" = "Your maps failed to transfer. Please delete Organic Maps Lite and download the maps again.";
-
-/* Text in menu */
-"settings_and_more" = "Settings & More";
 
 /* Text in menu */
 "website" = "Website";
@@ -527,14 +364,8 @@
 /* Text in menu */
 "openstreetmap" = "OpenStreetMap";
 
-/* Text in menu */
-"contact_us" = "Contact us";
-
 /* Settings: Send feedback button and dialog title */
 "feedback" = "Feedback";
-
-/* Text in menu */
-"subscribe_to_news" = "Subscribe to our newsletter";
 
 /* Text in menu */
 "rate_the_app" = "Rate the app";
@@ -548,15 +379,6 @@
 /* Text in menu */
 "report_a_bug" = "Report a bug";
 
-/* Email subject */
-"subscribe_me_subject" = "Please subscribe me to the Organic Maps newsletter";
-
-/* Email body */
-"subscribe_me_body" = "I want to be the first to learn about the latest news, app updates, and promotions. I understand that I can cancel my subscription at any time.";
-
-/* About text */
-"about_text" = "Organic Maps offers the fastest offline maps of all the cities, all countries of the world. Travel with full confidence: wherever you are, Organic Maps helps to locate yourself on the map, find the nearest restaurant, hotel, bank, gas station etc. It doesn’t require internet connection.\n\nWe are always working on new features and would love to hear from you on how you think we could improve Organic Maps. If you have any problems with the app, don't hesitate to contact us at support@organicmaps.app. We respond to every request!\n\nDo you like Organic Maps and want to support us? There are some simple and absolutely free ways:\n\n- post a review at your App Market\n- like our Facebook page http://www.facebook.com/OrganicMaps\n- or just tell about Organic Maps to your mom, friends and colleagues :)\n\nThank you for being with us. We appreciate your support very much!\n\nP.S. We take map data from OpenStreetMap, a mapping project similar to Wikipedia, which allows users to create and edit maps. If you see something is missing or wrong on the map, you can correct the maps directly at https://www.openstreetmap.org, and your changes will appear in Organic Maps app with the next version release.";
-
 /* Alert text */
 "email_error_body" = "The email client has not been set up. Please configure it or use any other way to contact us at %@";
 
@@ -569,12 +391,6 @@
 /* Search category */
 "wifi" = "WiFi";
 
-/* Update map suggestion */
-"routing_map_outdated" = "Please update the map to create a route";
-
-/* Update maps suggestion */
-"routing_update_maps" = "The new version of Organic Maps allows creating routes from your current position to a destination point. Please update maps to use this feature.";
-
 /* Update all button text */
 "downloader_update_all_button" = "Update All";
 
@@ -583,9 +399,6 @@
 
 /* Downloaded maps category */
 "downloader_downloaded_subtitle" = "Downloaded";
-
-/* Downloaded maps category */
-"downloader_available_maps" = "Available";
 
 /* Country queued for download */
 "downloader_queued" = "Queued";
@@ -598,17 +411,6 @@
 
 "downloader_downloading" = "Downloading:";
 
-"downloader_search_results" = "Found";
-
-/* Disclaimer message */
-"routing_disclaimer" = "Creating routes in Organic Maps app, please keep in mind the following:\n\n  - Suggested routes can be considered as recommendations only.\n - Road conditions, traffic rules and signs have higher priority than navigation advice.\n - The map may be incorrect or outdated, and routes may not be created the best possible way.\n\n  Be safe on roads and take care of yourself!";
-
-/* Outdated maps category */
-"downloader_outdated_maps" = "Outdated";
-
-/* Up to date maps category */
-"downloader_uptodate_maps" = "Up-to-date";
-
 /* Status of outdated country in the list */
 "downloader_status_outdated" = "Update";
 
@@ -618,49 +420,14 @@
 /* Displayed in a dialog that appears when a user tries to delete a map while the app is in the follow route mode */
 "downloader_delete_map_while_routing_dialog" = "To delete map, please stop navigation.";
 
-/* Show when user try build route, but we don't know where he */
-"routing_failed_unknown_my_position" = "Current location is undefined. Please specify location to create route.";
-
-/* Show if use has not routing file, or InconsistentMWMandRoute */
-"routing_failed_has_no_routing_file" = "Additional data is required to create the route. Download data now?";
-
-/* StartPointNotFound */
-"routing_failed_start_point_not_found" = "Cannot calculate the route. No roads near your starting point.";
-
-/* EndPointNotFound */
-"routing_failed_dst_point_not_found" = "Cannot calculate the route. No roads near your destination.";
-
 /* PointsInDifferentMWM */
 "routing_failed_cross_mwm_building" = "Routes can only be created that are fully contained within a map of a single region.";
-
-/* RouteNotFound */
-"routing_failed_route_not_found" = "There is no route found between the selected origin and destination. Please select a different start or end point.";
-
-/* InternalError */
-"routing_failed_internal_error" = "Internal error occurred. Please try to delete and download the map again. If the problem persists, please contact us at support@organicmaps.app.";
-
-/* Context menu item for downloader. */
-"downloader_download_map_and_routing" = "Download Map + Routing";
-
-/* Context menu item for downloader. */
-"downloader_download_routing" = "Download Routing";
-
-/* Context menu item for downloader. */
-"downloader_delete_routing" = "Delete Routing";
 
 /* Context menu item for downloader. */
 "downloader_download_map" = "Download map";
 
-"downloader_download_map_no_routing" = "Download map without routing";
-
-/* Button for routing. */
-"routing_go" = "Go!";
-
 /* Item status in downloader. */
 "downloader_retry" = "Retry";
-
-/* Item in context menu. */
-"downloader_map_and_routing" = "Map + Routing";
 
 /* Item in context menu. */
 "downloader_delete_map" = "Delete Map";
@@ -668,29 +435,11 @@
 /* Item in context menu. */
 "downloader_update_map" = "Update Map";
 
-/* Item in context menu. */
-"downloader_update_map_and_routing" = "Update Map + Routing";
-
-/* Item in context menu. */
-"downloader_map_only" = "Map Only";
-
-/* Toolbar title */
-"toolbar_application_menu" = "Application menu";
-
 /* Preference text */
 "pref_use_google_play" = "Use Google Play Services to determine your current location";
 
 /* Text for rating dialog */
 "rating_just_rated" = "I’ve just rated your app";
-
-/* Text for rating dialog */
-"rating_user_since" = "I’ve been a Organic Maps user since %@";
-
-/* Text for rating dialog */
-"rating_do_like_maps" = "Do you like Organic Maps?";
-
-/* Text for rating dialog */
-"rating_tap_star" = "Tap a star to rate our app.";
 
 /* Text for rating dialog */
 "rating_thanks" = "Thank you!";
@@ -701,23 +450,8 @@
 /* Text for rating dialog */
 "rating_send_feedback" = "Send feedback";
 
-/* Text for g+ dialog */
-"rating_google_plus" = "Click g+ to tell your friends about the app.";
-
 /* Text for routing error dialog */
 "routing_download_maps_along" = "Download all of the maps along your route";
-
-/* Text for routing error dialog */
-"routing_download_map" = "Get map";
-
-/* Text for routing error dialog */
-"routing_download_map_and_routing" = "Download updated map and routing data to get all Organic Maps features.";
-
-/* Text for routing error dialog */
-"routing_get_routing_data" = "Get routing data";
-
-/* Text for routing error dialog */
-"routing_get_additional_data" = "Additional data required to create routes from your location.";
 
 /* Text for routing error dialog */
 "routing_requires_all_map" = "In order to create a route, we need to download and update all the maps from your location to your destination.";
@@ -725,50 +459,15 @@
 /* Text for routing error dialog */
 "routing_not_enough_space" = "Not enough space";
 
-/* Text for routing error dialog */
-"routing_download_more_than_avail" = "You need to download %@ MB, but only %@ MB are available.";
-
-/* Text for routing error dialog */
-"routing_download_roaming" = "You are going to download %@ MB using Mobile Data (in Roaming). This may result in additional charges, depending on your operator mobile data plan.";
-
 /* bookmark button text */
 "bookmark" = "bookmark";
-
-/* map is not downloaded */
-"not_found_map" = "The map for your location is not downloaded";
 
 /* location service disabled */
 "enable_location_services" = "Please enable Location Services";
 
-/* download map */
-"download_map" = "Download the map for your location";
-
-/* download map on iPhone */
-"download_map_iphone" = "Download a current location map on your iPhone";
-
-/* clear pin */
-"nearby" = "Nearby";
-
-/* clear pin */
-"clear_pin" = "Clear Pin";
-
-/* location is undefined */
-"undefined_location" = "Current location is undefined.";
-
-/* download country of your location */
-"download_country" = "Download the country of your current location";
-
-/* download failed */
-"download_failed" = "download has failed";
-
-/* get the map */
-"get_the_map" = "Get the map";
-
 "save" = "Save";
 
 "edit_description_hint" = "Your descriptions (text or html)";
-
-"new_group" = "new group";
 
 "create" = "create";
 
@@ -795,30 +494,6 @@
 
 /* pink color */
 "pink" = "Pink";
-
-/* deep purple color */
-"deep_purple" = "Deep Purple";
-
-/* light blue color */
-"light_blue" = "Light Blue";
-
-/* cyan color */
-"cyan" = "Cyan";
-
-/* teal color */
-"teal" = "Teal";
-
-/* lime color */
-"lime" = "Lime";
-
-/* deep orange color */
-"deep_orange" = "Deep Orange";
-
-/* gray color */
-"gray" = "Gray";
-
-/* blue gray color */
-"blue_gray" = "Blue Gray";
 
 /* Wi-Fi available */
 "WiFi_available" = "Yes";
@@ -848,13 +523,9 @@
 
 "dialog_routing_location_unknown_turn_on" = "Unable to locate current GPS coordinates. Enable location services to calculate route.";
 
-"dialog_routing_location_unknown" = "Unable to locate current GPS coordinates.";
-
 "dialog_routing_download_files" = "Download required files";
 
 "dialog_routing_download_and_update_all" = "Download and update all map and routing information along the projected path to calculate route.";
-
-"dialog_routing_routes_size" = "Routing information files";
 
 "dialog_routing_unable_locate_route" = "Unable to locate route";
 
@@ -884,21 +555,11 @@
 
 "dialog_routing_try_again" = "Please try again";
 
-"dialog_routing_send_error" = "Report the Problem";
-
-"dialog_routing_if_get_cross_route" = "Would you like to create a more direct route that spans more than one map?";
-
-"dialog_routing_cross_route_is_optimal" = "A more optimal route that crosses the edge of this map is available.";
-
 "not_now" = "Not Now";
-
-"dialog_routing_build_route" = "Create";
 
 "dialog_routing_download_and_build_cross_route" = "Would you like to download the map and create a more optimal route spanning more than one map?";
 
 "dialog_routing_download_cross_route" = "Download additional maps to create a better route that crosses the boundaries of this map.";
-
-"dialog_routing_cross_route_always" = "Always cross this boundary";
 
 
 /********** Strings for downloading map from search **********/
@@ -906,8 +567,6 @@
 "search_without_internet_advertisement" = "To start searching and creating routes, please download the map. After that you will no longer need an Internet connection.";
 
 "search_select_map" = "Select Map";
-
-"search_select_other_map" = "Select Another Map";
 
 /* «Show» context menu */
 "show" = "Show";
@@ -918,17 +577,11 @@
 /* «Rename» context menu */
 "rename" = "Rename";
 
-/* Bottom sheet: expand button (should be short) */
-"bottom_sheet_more" = "More…";
-
 /* Failed planning route message in navigation view */
 "routing_planning_error" = "Route Planning Failed";
 
 /* Arrive routing message in navigation view */
 "routing_arrive" = "Arrival at %s";
-
-/* Text for routing::RouterResultCode::FileTooOld dialog. */
-"dialog_routing_download_and_update_maps" = "Download and update all map along the projected path to calculate route.";
 
 "rate_alert_title" = "Like the app?";
 
@@ -944,19 +597,11 @@
 
 "history" = "History";
 
-"next_turn_then" = "Then";
-
 "closed" = "Closed";
-
-"back_to" = "Back to %@";
 
 "search_not_found" = "Oops, no results found.";
 
 "search_not_found_query" = "Try changing your search criteria.";
-
-"search_not_found_map" = "Please download the map you are searching in.";
-
-"search_not_found_location" = "Download the map of your current location.";
 
 "search_history_title" = "Search History";
 
@@ -964,23 +609,12 @@
 
 "clear_search" = "Clear Search History";
 
-/* Title for settings to enable/disable showcase menu button */
-"showcase_settings_title" = "Show offers";
-
 /* Place Page link to Wikipedia article (if map object has it). */
 "read_in_wikipedia" = "Wikipedia";
 
-"p2p_route_planning" = "Route Planning";
-
 "p2p_your_location" = "Your Location";
 
-"p2p_from" = "From";
-
-"p2p_to" = "To";
-
 "p2p_start" = "Start";
-
-"p2p_planning" = "Planning…";
 
 "p2p_from_here" = "Route from";
 
@@ -1018,15 +652,9 @@
 
 "editor_correct_mistake" = "Correct mistake";
 
-"editor_correct_mistake_message" = "You made an editing mistake. Please correct it or switch to simple mode.";
-
 "editor_add_select_location" = "Location";
 
 "editor_done_dialog_1" = "You’ve changed the world map. Do not keep it to yourself! Tell your friends, and edit it together.";
-
-"editor_done_dialog_2" = "This is the second time you edited the map. Now you are number %d in the map editors ranking. Tell your friends about it.";
-
-"editor_done_dialog_3" = "You’ve improved the map, tell your friends about it, and edit the map together.";
 
 "share_with_friends" = "Share with friends";
 
@@ -1044,20 +672,7 @@
 
 "editor_report_problem_duplicate_place_title" = "Duplicated place";
 
-"first_launch_congrats_title" = "Organic Maps is ready to use";
-
-"first_launch_congrats_text" = "Search and navigate everywhere in the world offline, free of charge.";
-
-"migrate_title" = "Important!";
-
-/* Android uses image instead of text. */
-"download_all" = "Download all";
-
-"delete_all" = "Delete all";
-
 "autodownload" = "Auto-download";
-
-"disable_autodownload" = "Disable autodownload";
 
 /* Place Page opening hours text */
 "closed_now" = "Closed now";
@@ -1072,10 +687,6 @@
 "day_off" = "Closed";
 
 "today" = "Today";
-
-"sunrise_to_sunset" = "From sunrise to sunset";
-
-"sunset_to_sunrise" = "From sunset to sunrise";
 
 "add_opening_hours" = "Add opening hours";
 
@@ -1095,45 +706,18 @@
 
 "forgot_password" = "Forgot your password?";
 
-/* Forgot Password dialog title */
-"restore_password" = "Restore password";
-
-"enter_email_address_to_reset_password" = "Enter the email address you used during registration and we will send you the link to reset your password.";
-
-"reset_password" = "Reset Password";
-
-"username" = "Username";
-
 "osm_account" = "OSM Account";
 
 "logout" = "Log Out";
 
-"login_and_edit_map_motivation_message" = "Log in and edit objects on the map, and we will make them available for millions of users. Let’s make the world better together.";
-
 /* Information text: "Last upload 11.01.2016" */
 "last_upload" = "Last upload";
 
-/* Motivates user to login/register, title above login buttons. */
-"you_have_edited_your_first_object" = "You’ve edited your first object!";
-
 "thank_you" = "Thank You";
-
-"login_with_google" = "Login with Google";
-
-"login_with_openstreetmap" = "Log in with www.openstreetmap.org";
 
 "edit_place" = "Edit Place";
 
 "place_name" = "Place Name";
-
-/* title above languages list cells in the editor, below editable name text field. */
-"other_languages" = "Other Languages";
-
-/* small button to open list with names in different languages */
-"show_more" = "Show More";
-
-/* small button to close list with names in different languages */
-"show_less" = "Show Less";
 
 "add_language" = "Add a language";
 
@@ -1164,8 +748,6 @@
 
 "please_note" = "Please note";
 
-"common_no_wifi_dialog" = "No WiFi connection. Do you want to continue with mobile data?";
-
 "downloader_delete_map_dialog" = "All of your map edits will be deleted together with the map.";
 
 "downloader_update_maps" = "Update Maps";
@@ -1173,10 +755,6 @@
 "downloader_mwm_migration_dialog" = "To create a route, you need to update all maps and then plan the route again.";
 
 "downloader_search_field_hint" = "Find map";
-
-"migration_update_all_button" = "Update All Maps";
-
-"migration_delete_all_download_current_button" = "Download the current map and delete all of the old ones";
 
 "migration_download_error_dialog" = "Download error";
 
@@ -1186,21 +764,9 @@
 
 "downloader_no_space_message" = "Please delete any unnecessary data";
 
-"editor_general_auth_error_dialog" = "General login error.";
-
 "editor_login_error_dialog" = "Login error.";
 
-"editor_login_failed_dialog" = "Login failed";
-
-"editor_username_error_dialog" = "Username is invalid";
-
-"editor_place_edited_dialog" = "You’ve edited an object!";
-
-"editor_login_with_osm" = "Login with OpenStreetMap";
-
 "editor_profile_changes" = "Verified Changes";
-
-"editor_profile_unsent_changes" = "Not sent:";
 
 "editor_focus_map_on_location" = "Drag the map to select the correct location of the object.";
 
@@ -1222,13 +788,9 @@
 
 "editor_report_problem_other_title" = "Different problem";
 
-"placepage_report_problem_button" = "Report a problem";
-
 "placepage_add_business_button" = "Add business";
 
 "whatsnew_editor_message_1" = "Add new places to the map, and edit existing ones directly from the app.";
-
-"whatsnew_editor_message_2" = "* Organic Maps uses OpenStreetMap community data.";
 
 "dialog_incorrect_feature_position" = "Change location";
 
@@ -1236,16 +798,10 @@
 
 "login_to_make_edits_visible" = "Log in so other users can see the changes that you have made";
 
-"no_migration_during_navigation" = "Updating is not allowed during navigation.";
-
 /* Error dialog no space */
 "migration_no_space_message" = "To download, you need more space. Please delete any unnecessary data.";
 
 "editor_sharing_title" = "I improved the Organic Maps maps";
-
-"editor_comment_will_be_sent" = "We will make sure to send your comments to the map editors.";
-
-"editor_unsupported_category_message" = "You have added an object whose category we do not support yet. It will appear on the map in the future.";
 
 /* Downloaded 10 **of** 20 <- it is that "of" */
 "downloader_of" = "%1$d of %2$d";
@@ -1278,23 +834,9 @@
 
 "editor_operator" = "Owner";
 
-"editor_tag_description" = "Enter company, organization or individual responsible for the facilities.";
-
-"editor_no_local_edits_title" = "You don't have local edits";
-
-"editor_no_local_edits_description" = "This shows the number of your suggested changes on the map that are currently accessible only on your device.";
-
-"editor_send_to_osm" = "Send to OSM";
-
-"editor_remove" = "Remove";
-
-"downloader_my_maps_title" = "My maps";
-
 "downloader_no_downloaded_maps_title" = "You haven't downloaded any maps";
 
 "downloader_no_downloaded_maps_message" = "Download maps to search for a location and use navigation offline.";
-
-"downloader_find_place_hint" = "Search city or country";
 
 /* Error title that appears after certain time without location. */
 "current_location_unknown_title" = "Continue detecting your current location?";
@@ -1321,47 +863,13 @@
 /* iOS Dialog for the case when the location permission is not granted */
 "location_services_disabled_3" = "3. Select While Using the App";
 
-"placepage_parking_surface" = "Surface";
-
-"placepage_parking_multistorey" = "Multi-storey";
-
-"placepage_parking_underground" = "Underground";
-
-"placepage_parking_rooftop" = "Rooftop";
-
-"placepage_parking_sheds" = "Sheds";
-
-"placepage_parking_carports" = "Carports";
-
-"placepage_parking_boxes" = "Garage boxes";
-
-"placepage_parking_pay" = "Pay";
-
-"placepage_parking_free" = "Free";
-
-"placepage_parking_interval" = "Interval Pay";
-
-"placepage_entrance_number" = "No.";
-
-"placepage_entrance_type" = "Entrance";
-
-"placepage_flat" = "app.";
-
-"placepage_open_24_7" = "24 / 7";
-
 "meter" = "m";
 
 "kilometer" = "km";
 
-"kilometers_per_hour" = "km/h";
-
 "mile" = "mi";
 
 "foot" = "ft";
-
-"miles_per_hour" = "mph";
-
-"day" = "d";
 
 "hour" = "h";
 
@@ -1381,10 +889,6 @@
 
 "placepage_bookmark_name_hint" = "Bookmark Name";
 
-"placepage_personal_notes_hint" = "Personal notes";
-
-"placepage_delete_bookmark_button" = "Delete Bookmark";
-
 "editor_edits_sent_message" = "Your suggested changes have been sent";
 
 "editor_comment_hint" = "Comment…";
@@ -1397,8 +901,6 @@
 
 "editor_remove_place_button" = "Delete";
 
-"editor_status_sending" = "Sending…";
-
 "editor_place_doesnt_exist" = "Place does not exist";
 
 "text_more_button" = "…more";
@@ -1410,11 +912,7 @@
 
 "error_enter_correct_email" = "Enter a valid email";
 
-"error_enter_correct" = "Enter a valid value";
-
 "refresh" = "Update";
-
-"last_update" = "Last update: %s";
 
 "placepage_add_place_button" = "Add a place to the map";
 
@@ -1426,24 +924,6 @@
 
 "editor_share_to_all_dialog_message_2" = "We will check the changes. If we have any questions we will contact you via email.";
 
-"navigation_overview_button" = "overview";
-
-"navigation_stop_button" = "stop";
-
-/* Text on an empty bookmark page */
-"bookmarks_empty_title" = "Save Bookmarks";
-
-"bookmarks_empty_message_1" = "Tap on ★ to save favorite places for quick access.";
-
-"bookmarks_empty_message_2" = "Import Bookmarks from email and web.";
-
-"bookmarks_empty_message_3" = "check out: %s";
-
-/* Name of the group for booked hotels */
-"bookmarks_group_name" = "Booked hotels";
-
-"place_page_button_read_descriprion" = "Read";
-
 /* iOS dialog for the case when recent track recording is on and the app comes back from background */
 "recent_track_background_dialog_title" = "Disable recording of your recently traveled route?";
 
@@ -1451,8 +931,6 @@
 
 /* For sharing via SMS and so on */
 "sharing_call_action_look" = "Check out";
-
-"continue_recent_track_background_button" = "Continue";
 
 "recent_track_background_dialog_message" = "Organic Maps uses your geoposition in the background for recording your recently traveled route.";
 
@@ -1468,33 +946,13 @@
 /* About short text (below logo) */
 "about_description" = "Organic Maps is an essential offline application for travelling. Organic Maps is based on OpenStreetMap data and allows editing it.";
 
-/* Text in menu */
-"blog" = "Blog";
-
 "general_settings" = "General settings";
-
-"date" = "Date %d";
-
-/* "Report a bug" -> "Generaal Feedback" -> "Something is not working" */
-"something_is_not_working" = "Something is not working";
 
 /* For the first routing */
 "accept" = "Accept";
 
-"accept_and_continue" = "Accept and continue";
-
 /* For the first routing */
 "decline" = "Decline";
-
-"install_app" = "Install";
-
-"search_no_results_title" = "No Results Found";
-
-"search_no_results_message" = "Try a more general search term, zoom out or reset the filter.";
-
-"search_no_results_expand_area_button" = "Zoom out";
-
-"search_no_results_reset_button" = "Reset Filter";
 
 /* noun */
 "search_in_table" = "List";
@@ -1517,8 +975,6 @@
 
 "traffic_update_maps_text" = "To display traffic data, maps must be updated.";
 
-"traffic_outdated" = "Traffic data is outdated.";
-
 "big_font" = "Increase font size on the map";
 
 "traffic_update_app" = "Please update Organic Maps";
@@ -1529,17 +985,7 @@
 /* "traffic" as in "road congestion" */
 "traffic_data_unavailable" = "Traffic data is not available";
 
-/* "Translation is no needed, because it's a company name" */
-"uber" = "Uber";
-
-/* Simplified colour scheme for traffic information, fewer colours are used to display traffic jams on the map. The string should be kept as short as possible */
-"pref_traffic_simplified_colors_title" = "Simplified traffic colors";
-
 "enable_logging" = "Enable logging";
-
-"offline_place_page_more_information" = "Connect to the internet to get more information about the place.";
-
-"failed_load_information" = "Failed to load information.";
 
 /* Settings: "Send general feedback" button */
 "feedback_general" = "General Feedback";
@@ -1556,8 +1002,6 @@
 
 "whatsnew_transliteration_title" = "Transliteration into Latin";
 
-"yandex_taxi_title" = "Yandex.Taxi";
-
 "learn_more" = "Learn more";
 
 "core_exit" = "Exit";
@@ -1568,75 +1012,19 @@
 
 "button_exit" = "Exit";
 
-"settings_device_memory" = "Device memory";
-
-"settings_card_memory" = "Card memory";
-
-"settings_storage_available" = "%s available";
-
-"toast_location_permission_denied" = "App location permission denied";
-
-"button_use" = "Use";
-
 "planning_route_manage_route" = "Manage Route";
 
 "button_plan" = "Plan";
-
-"button_add" = "Add";
 
 "placepage_remove_stop" = "Remove";
 
 "planning_route_remove_title" = "Drag here to remove";
 
-"dialog_change_start_point_message" = "Set the current location as the starting point?";
-
-"button_replace" = "Replace";
-
 "placepage_add_stop" = "Add Stop";
-
-/* Only ru/en are needed */
-"subtitle_rent" = "Rent";
-
-/* Only ru/en are needed */
-"rub_month" = "RUB/month";
-
-/* Only ru/en are needed */
-"room" = "%s-room apt.";
-
-/* Only ru/en are needed */
-"real_estate" = "Real estate";
-
-"add_my_position" = "Add my position";
-
-"choose_start_point" = "Choose a starting point";
-
-"choose_destination" = "Choose a destination";
 
 "preloader_viator_button" = "Learn more";
 
-"start_from_my_position" = "Start from";
-
-"profile_authorization_title" = "Sign in with";
-
-"profile_authorization_message" = "Easy sign in without login and password in a couple of seconds";
-
 "profile_authorization_error" = "Oops, there was an error. Try to sign in again.";
-
-"service" = "Service";
-
-"atmosphere" = "Atmosphere";
-
-"value_for_money" = "Value for money";
-
-"experience" = "Experience";
-
-"assortment" = "Assortment";
-
-"expertise" = "Expertise";
-
-"equipment" = "Equipment";
-
-"quality" = "Quality";
 
 "dialog_error_storage_title" = "Storage access problem";
 
@@ -1644,17 +1032,7 @@
 
 "setting_emulate_bad_storage" = "Emulate bad storage";
 
-"directions_finish" = "Destination";
-
-"directions_on_foot" = "Walk %s";
-
 "core_entrance" = "Entrance";
-
-"coffee" = "Coffee";
-
-"cleanliness" = "Cleanliness";
-
-"crowdedness" = "Crowdedness";
 
 "error_enter_correct_name" = "Please, enter a correct name";
 
@@ -1673,11 +1051,9 @@
 
 "downloader_percent" = "%s (%s of %s)";
 
-"downloader_process" = "Downloading %s...";
+"downloader_process" = "Downloading %s…";
 
-"downloader_applying" = "Applying %s...";
-
-"dialog_message_transit_not_found_connection" = "Plan a route within one transit network";
+"downloader_applying" = "Applying %s…";
 
 "bookmarks_error_message_share_general" = "Unable to share due to an application error";
 
@@ -1695,17 +1071,7 @@
 
 "bookmarks_error_message_list_name_already_taken" = "Please choose another name";
 
-"bookmarks_error_title_list_name_too_long" = "This name is too long";
-
-"bookmarks_error_message_list_name_too_long" = "Please choose another name";
-
-"please_wait" = "Please wait...";
-
-"phone_number" = "Phone number";
-
-"notification_unsent_reviews_title" = " You have several unsent reviews";
-
-"notification_unsent_reviews_message" = " Please sign in to share reviews with other travellers";
+"please_wait" = "Please wait…";
 
 "profile" = "OpenStreetMap profile";
 
@@ -1719,49 +1085,13 @@
 
 "bookmarks_convert_error_message" = "Some files were not converted.";
 
-"converting" = "Converting...";
-
-"wn_reinvented_bookmarks_title" = "We reinvented bookmarks!";
-
-"wn_reinvented_bookmarks_message" = "You can backup them, create lists...It’s amazing...";
-
-"bookmarks_restore" = " Restore bookmarks";
-
-"bookmarks_restore_process" = " Restoring...";
-
-"bookmarks_restore_title" = " Restore this version?";
-
-"bookmarks_restore_message" = " Your bookmarks will be restored from %s (%s)";
-
-"bookmarks_restore_empty_title" = " You don’t have any backups";
-
-"bookmarks_restore_empty_message" = " The server couldn't find previously made backups";
+"bookmarks_restore_title" = "Restore this version?";
 
 "common_check_internet_connection_dialog_title" = "No internet connection";
 
-"error_server_title" = " Server error";
-
-"error_server_message" = " There was an error on the server, please try again later";
-
-"error_system_message" = " An unknown error occurred";
+"error_system_message" = "An unknown error occurred";
 
 "restore" = "Restore";
-
-"bookmarks_page_downloaded" = "Downloaded";
-
-"bookmarks_page_my" = "My";
-
-"routes_and_bookmarks" = "Routes and bookmarks";
-
-"bookmarks_webview_success_toast" = "Bookmarks succesfully downloaded";
-
-"cached_bookmarks_placeholder_title" = "Download new places";
-
-"cached_bookmarks_placeholder_subtitle" = "Press the button to download thousands of interesting places and routes created by Organic Maps users. You will need the internet connection.";
-
-"downloader_download_routers" = "Download bookmarks";
-
-"bookmarks_groups_cached" = "Downloaded lists";
 
 "subtittle_opt_out" = "Tracking settings";
 
@@ -1769,29 +1099,15 @@
 
 "crash_reports_description" = "We may use your data to improve Organic Maps experience. Changes will take effect after you restart the app.";
 
-"opt_out_help_ios_1" = "Your mobile device may provide a “Limit Ad Tracking” or “Opt out of interest-based advertising” setting.";
-
-"opt_out_help_ios_2" = "iOS 9 or Higher";
-
-"opt_out_help_ios_3" = "Go to your Settings → Privacy → Advertising → Enable the “Limit Ad Tracking” setting";
-
-"opt_out_help_android" = "Your mobile device may provide a “Limit Ad Tracking” or “Opt out of interest-based advertising” setting.\n\nFor Android and Google Play Services version 4.0 and up:\nSettings → Google → Ads → Opt out of Ads Personalization\nor\nSettings → Google → Google Account → Personal info & privacy → Ads Settings → Ads Personalization";
-
 "privacy_policy" = "Privacy policy";
 
 "terms_of_use" = "Terms of use";
-
-"backup_notification_failed" = "Backing up your bookmarks has been suspended. Log in to turn it back on.";
 
 "button_layer_traffic" = "Traffic";
 
 "button_layer_subway" = "Subway";
 
 "layers_title" = "Map layers";
-
-"layers_message" = "Use map layers to display the traffic, subway map, and other useful information";
-
-"button_layer_got_it" = "Got it";
 
 "subway_data_unavailable" = "Subway map is unavailable";
 
@@ -1803,39 +1119,13 @@
 
 "title_error_downloading_bookmarks" = "An error occurred";
 
-"subtitle_error_downloading_bookmarks" = "Bookmarks were not downloaded";
-
-"error_already_downloaded" = "This list has already been downloaded";
-
 "popular_place" = "Popular";
-
-"download_routes" = "Download routes";
-
-"bookmarks_downloaded_title" = "Bookmarks have been downloaded successfully";
-
-"bookmarks_downloaded_subtitle" = "Press ‘View on map’ to explore new places from the list";
-
-"why_support" = "Why support Organic Maps?";
-
-"why_support_item1" = "We respect your privacy: there are zero trackers in the app, and we are open source";
-
-"why_support_item2" = "You help us to improve Organic Maps";
-
-"why_support_item3" = "You help us improve open maps OpenStreetMap.org";
-
-"channels_map_update" = "Map updates";
-
-"server_unavailable_title" = "Server is unavailable";
-
-"sharing_options" = "Sharing options";
 
 "export_file" = "Export file";
 
 "list_settings" = "List Settings";
 
 "delete_list" = "Delete list";
-
-"hide_from_map" = "Hide from map";
 
 "public_access" = "Public access";
 
@@ -1845,40 +1135,11 @@
 
 "bookmark_category_description_hint" = "Type a description (text or html)";
 
-/* FIXME */
-"bookmarks_public_access" = "bookmarks_public_access";
-
-/* FIXME */
-"bookmarks_link_access" = "bookmarks_link_access";
-
-/* FIXME */
-"bookmarks_private_access" = "bookmarks_private_access";
-
 "not_shared" = "Private";
-
-"direct_link_progress_text" = "Uploading your file…";
-
-"direct_link_success" = "The link has been created";
-
-"send_a_link_btn" = "Send me a link";
-
-"upload_error_toast" = "An error occurred while uploading your file";
 
 "tags_loading_error_subtitle" = "An error occurred while loading tags, please try again";
 
-"unable_upload_errorr_title" = "File upload failed";
-
-"unable_upload_error_subtitle_edited" = "This file has been edited via the web app";
-
-"unable_upload_error_subtitle_broken" = "This file is damaged and couldn't be uploaded. Please upload another file.";
-
-"contact" = "Contact";
-
-"download_button" = "Download";
-
 "speedcams_alert_title" = "Speed cameras";
-
-"speedcams_alert_subtitle" = "Warn about speed limits";
 
 "speedcam_option_auto" = "Auto";
 
@@ -1886,18 +1147,10 @@
 
 "speedcam_option_never" = "Never";
 
-"bookmark_description_title" = "Bookmark Description";
-
 "place_description_title" = "Place Description";
 
 /* this text will be shown in application notification preferences opposite checkbox which enable/disable downloader notifications. Devices on Android 8+ are affected. */
 "notification_channel_downloader" = "Map downloader";
-
-"share_bookmarks_email_body_link" = "Hello!\n\nHere is the link where you can download bookmarks: %s. Open the list in Organic Maps and enjoy your trip!\n\nGet application: https://omaps.app/get?kmz";
-
-"warning_speedcams_title" = "Navigator will warn you about cameras when you exceed the speed limit of %d km/h";
-
-"warning_speedcams_subtitle" = "Please mind driving regulations of the country you are travelling to.";
 
 "speedcams_notice_message" = "Auto - Warn about speedcams if there is a risk of exceeding the speed limit\nAlways - Always warn about speedcams\nNever - Never warn about speedcams";
 
@@ -1913,23 +1166,7 @@
 
 "enable_logging_warning_message" = "The option turns on logging for diagnostic purposes. It can be helpful for our team to troubleshoot issues with the app. Enable this option temporarily to record and send detailed logs about your issue to us.";
 
-"html_error_upload_message_try_again" = "Please check your network settings and try again";
-
-"html_error_upload_title_try_again" = "No internet connection";
-
-"notification_leave_review_v2_android_short_title" = "Review and help travellers!";
-
-"megafon" = "Say goodbye to roaming!";
-
-"notifications_illegal_alert_disable_button" = "Turn off notifications";
-
 "access_rules_author_only" = "Online editing";
-
-"privacy_settings_menu" = "Privacy settings";
-
-"unable_upadate_error_title" = "File update failed";
-
-"unable_upadate_error_message" = "Some errors occurred while updating. Please check the changes and try again";
 
 "driving_options_title" = "Routing options";
 
@@ -1951,94 +1188,19 @@
 
 "change_driving_options_btn" = "Routing options enabled";
 
-"toll_road" = "Toll road";
-
-"unpaved_road" = "Unpaved road";
-
-"ferry_crossing" = "Ferry crossing";
-
-"operated_by" = "Operated by \"%s\"";
-
 "avoid_toll_roads_placepage" = "Avoid toll roads";
 
 "avoid_unpaved_roads_placepage" = "Avoid unpaved roads";
 
 "avoid_ferry_crossing_placepage" = "Avoid ferry crossings";
 
-"type.cuisine.uzbek" = "Uzbek cuisine";
-
-"trip_start" = "Let's go";
-
-"pick_destination" = "Destination";
-
-"follow_my_position" = "Re-center";
-
-"search_results" = "Search results";
-
-"then_turn" = "Then";
-
-"redirect_route_alert" = "Do you want to rebuild the route?";
-
-"redirect_route_yes" = "Yes";
-
-"redirect_route_no" = "No";
-
-"trip_finished" = "You have arrived!";
-
-"keyboard_availability_alert" = "Keyboard is not available while driving";
-
-"dialog_routing_change_start_carplay" = "Unable to build a route from your current location";
-
-"dialog_routing_change_end_carplay" = "Unable to build a route to your destination. Please choose another point";
-
-"dialog_routing_check_gps_carplay" = "No GPS signal. Please move to an open area";
-
-"dialog_routing_unable_locate_route_carplay" = "Unable to build a route. Please specify other route points";
-
-"dialog_routing_download_files_carplay" = "To create a route, download missing maps on your device";
-
-"dialog_routing_system_error_carplay" = "An error occurred. Please restart the application";
-
-"dialog_routing_rebuild_from_current_location_carplay" = "The route will be rebuilt from your current location";
-
-"dialog_routing_rebuild_for_vehicle_carplay" = "The route will be converted into an automobile one";
-
 "ok" = "Ok";
-
-"avoid_unpaved_carplay_1" = "No dirt road";
-
-"avoid_unpaved_carplay_2" = "Avoid unpaved";
-
-"avoid_ferry_carplay_1" = "No ferries";
-
-"avoid_ferry_carplay_2" = "Avoid ferries";
-
-"avoid_tolls_carplay_1" = "No toll road";
-
-"avoid_tolls_carplay_2" = "Avoid toll road";
-
-"speedcams_alert_title_carplay_1" = "Speedсams";
-
-"speedcams_alert_title_carplay_2" = "Speed warnings";
-
-"download_map_carplay" = "Please download maps in Organic Maps app on your device";
-
-"carplay_roundabout_exit" = "%s exit";
 
 /* max. 10 symbols, both iOS and Android */
 "sort" = "Sort…";
 
 /* Android, title, max 20-22 symbols */
 "sort_bookmarks" = "Sort bookmarks";
-
-/* iOS */
-"sort_default" = "Sort by default";
-
-"sort_type" = "Sort by type";
-
-"sort_distance" = "Sort by distance";
-
-"sort_date" = "Sort by date";
 
 /* Android */
 "by_default" = "By default";
@@ -2052,63 +1214,7 @@
 /* Android */
 "by_date" = "By date";
 
-"week_ago_sorttype" = "A week ago";
-
-"month_ago_sorttype" = "A month ago";
-
-"moremonth_ago_sorttype" = "More than a month ago";
-
-"moreyear_ago_sorttype" = "More than a year ago";
-
-"near_me_sorttype" = "Near me";
-
-"others_sorttype" = "Others";
-
-"food_places" = "Food";
-
-"tourist_places" = "Sights";
-
-"museums" = "Museums";
-
-"parks" = "Parks";
-
-"swim_places" = "Swim";
-
-"mountains" = "Mountains";
-
-"animals" = "Animals";
-
-"hotels" = "Hotels";
-
-"buildings" = "Buildings";
-
-"money" = "Money";
-
-"shops" = "Shops";
-
-"parkings" = "Parkings";
-
-"fuel_places" = "Gas stations";
-
-"water" = "Water";
-
-"medicine" = "Medicine";
-
 "search_in_the_list" = "Search in the list";
-
-"view_on_map_bookmarks" = "On map";
-
-"more_bookmarks" = "More…";
-
-"no_items_found" = "No items found";
-
-/* Android, max 18 symbols */
-"bookmarks_edit_list" = "Edit list";
-
-/* Android, max 18 symbols */
-"bookmarks_delete_list" = "Delete list";
-
-"religious_places" = "Religious places";
 
 "select_list" = "Select list";
 
@@ -2118,26 +1224,13 @@
 
 "dialog_pedestrian_route_is_long_message" = "Please choose a start or end point closer to a subway station";
 
-/* Failed planning SUBWAY route message in navigation view */
-"routing_planning_error_subway_special" = "Subway route planning failed";
-
 "button_layer_isolines" = "Terrain";
-
-"tips_map_layers_title_countour" = "New in Organic Maps: offline topographic layer!";
-
-"tips_map_layers_message_countour" = "Plan and enjoy your nature trips being sure you know everything about the area";
 
 "isolines_activation_error_dialog" = "To activate and use the topographic layer please update or download the map of the area";
 
 "isolines_location_error_dialog" = "The topographic layer is not yet available in this area";
 
 "elevation_profile_diff_level" = "Difficulty level";
-
-"elevation_profile_diff_level_easy" = "Easy";
-
-"elevation_profile_diff_level_moderate" = "Moderate";
-
-"elevation_profile_diff_level_hard" = "Hard";
 
 "elevation_profile_ascent" = "Ascent";
 
@@ -2147,25 +1240,13 @@
 
 "elevation_profile_maxaltitude" = "Max. altitude";
 
-"elevation_profile_m" = "m";
-
 "elevation_profile_difficulty" = "Difficulty";
 
 "elevation_profile_distance" = "Dist.:";
 
-"elevation_profile_km" = "km";
-
 "elevation_profile_time" = "Time:";
 
-"elevation_profile_hours" = "h.";
-
-"elevation_profile_minutes" = "min";
-
 "isolines_toast_zooms_1_10" = "Zoom in to explore isolines";
-
-"downloader_updating_ios" = "Updating";
-
-"downloader_loading_ios" = "Downloading";
 
 "key_information_title" = "Key information";
 

--- a/iphone/Maps/LocalizedStrings/en.lproj/Localizable.stringsdict
+++ b/iphone/Maps/LocalizedStrings/en.lproj/Localizable.stringsdict
@@ -9,23 +9,6 @@
 
 <!-- ********** Strings for downloading map from search **********/ -->
 
-  <key>bookmarks_places</key>
-  <dict>
-    <key>NSStringLocalizedFormatKey</key>
-    <string>%#@value@</string>
-    <key>value</key>
-    <dict>
-      <key>NSStringFormatSpecTypeKey</key>
-      <string>NSStringPluralRuleType</string>
-      <key>NSStringFormatValueTypeKey</key>
-      <string>d</string>
-      <key>one</key>
-      <string>%d bookmark</string>
-      <key>other</key>
-      <string>%d bookmarks</string>
-    </dict>
-  </dict>
-
   <key>bookmarks_detect_message</key>
   <dict>
     <key>NSStringLocalizedFormatKey</key>
@@ -40,23 +23,6 @@
       <string>%d file was found. You can see it after conversion.</string>
       <key>other</key>
       <string>%d files were found. You can see them after conversion.</string>
-    </dict>
-  </dict>
-
-  <key>bookmarks_objects</key>
-  <dict>
-    <key>NSStringLocalizedFormatKey</key>
-    <string>%#@value@</string>
-    <key>value</key>
-    <dict>
-      <key>NSStringFormatSpecTypeKey</key>
-      <string>NSStringPluralRuleType</string>
-      <key>NSStringFormatValueTypeKey</key>
-      <string>d</string>
-      <key>one</key>
-      <string>%s object</string>
-      <key>other</key>
-      <string>%s objects</string>
     </dict>
   </dict>
 

--- a/iphone/Maps/LocalizedStrings/es.lproj/Localizable.strings
+++ b/iphone/Maps/LocalizedStrings/es.lproj/Localizable.strings
@@ -18,9 +18,6 @@
 /* Button which deletes downloaded country */
 "delete" = "Eliminar";
 
-/* Button "do not interrupt download" if user touched actively downloading country */
-"do_nothing" = "Seguir descarga";
-
 "download_maps" = "Descargar mapas";
 
 /* Settings/Downloader - info for country when download fails */
@@ -28,9 +25,6 @@
 
 /* Settings/Downloader - info for country which started downloading */
 "downloading" = "Descargando…";
-
-/* Settings/Downloader - size string, only strings different from English should be translated */
-"kb" = "kB";
 
 /* Choose measurement on first launch alert - choose metric system button */
 "kilometres" = "Kilómetros";
@@ -55,17 +49,11 @@
 /* Update maps later/Buy pro version later button text */
 "later" = "Luego";
 
-/* Don't show some dialog any more */
-"never" = "Never";
-
 /* View and button titles for accessibility */
 "search" = "Buscar";
 
 /* Search box placeholder text */
 "search_map" = "Buscar en el mapa";
-
-/* Settings/Downloader - info for not downloaded country */
-"touch_to_download" = "Presionar para descargar";
 
 /* Settings/Downloader - 3G download warning dialog confirm button */
 "use_cellular_data" = "Sí";
@@ -73,20 +61,11 @@
 /* Location services are disabled by user alert - message */
 "location_is_disabled_long_text" = "No se puede acceder a los servicios de localización. Por favor, activelo en los ajustes.";
 
-/* Location Services are not available on the device alert - message */
-"device_doesnot_support_location_services" = "Su dispositivo no es compatible con los servicios de localización";
-
 /* View and button titles for accessibility */
 "zoom_to_country" = "Mostrar en el mapa";
 
-/* Button text for the button at the center of the screen when the country is not downloaded */
-"country_status_download" = "Descargar mapa\n(^ ^)";
-
 /* Button text for the button at the center of the screen when the country is not downloaded and the size should not be shown */
 "country_status_download_without_size" = "Descargar mapa";
-
-/* Button text for the button at the center of the screen when the country is not downloaded */
-"country_status_download_without_routing" = "Descargar mapa\nsin ruta (^ ^)";
 
 /* Message to display at the center of the screen when the country download has failed */
 "country_status_download_failed" = "Error durante la descarga";
@@ -96,19 +75,13 @@
 
 "about_menu_title" = "Sobre Organic Maps";
 
-"downloaded_touch_to_delete" = "Descargado (%@), presionar para eliminar";
-
 "connection_settings" = "Ajustes de conexión";
-
-"download_mb_or_kb" = "Descargar %@";
 
 "close" = "Cerrar";
 
 "unsupported_phone" = "Un acelerador de hardware OpenGL se requiere. Desafortunadamente, su dispositivo móvil no es compatible.";
 
 "download" = "Descargar";
-
-"external_storage_is_not_available" = "La memoria SD/almacenamiento USB con los mapas descargados no está disponible";
 
 "disconnect_usb_cable" = "Por favor desconectar el cable USB o insertar la memoria SD para usar Organic Maps";
 
@@ -117,8 +90,6 @@
 "not_enough_memory" = "No hay suficiente memoria para iniciar la aplicación";
 
 "download_resources" = "Antes de comenzar, permite que descarguemos en tu dispositivo un mapamundi general.\nSe requieren %@ de datos.";
-
-"getting_position" = "Buscando su ubicación actual";
 
 "download_resources_continue" = "Ir al mapa";
 
@@ -140,23 +111,14 @@
 /* Add New Bookmark Set dialog title */
 "add_new_set" = "Agregar un grupo nuevo";
 
-/* Place Page - Add To Bookmarks button */
-"add_to_bookmarks" = "Añadir a Favoritos";
-
 /* Bookmark Color dialog title */
 "bookmark_color" = "Color del marcador";
 
 /* Add Bookmark Set dialog - hint when set name is empty */
 "bookmark_set_name" = "Nombre del grupo de marcadores";
 
-/* Bookmark Sets dialog title */
-"bookmark_sets" = "Grupos de marcadores";
-
 /* Bookmarks - dialog title */
 "bookmarks" = "Marcadores";
-
-/* Add bookmark dialog - bookmark color */
-"color" = "Color";
 
 /* Default bookmarks set name */
 "core_my_places" = "Mis lugares";
@@ -167,14 +129,8 @@
 /* Editor title above street and house number */
 "address" = "Dirección";
 
-/* Place Page - Remove Pin button */
-"remove_pin" = "Quitar la etiqueta";
-
 /* Add bookmark dialog - bookmark set, Bookmarks dialog - Bookmark set cell */
 "set" = "Grupo";
-
-/* Text hint in Bookmarks dialog when no any bookmarks are added */
-"bookmarks_usage_hint" = "Todavía no tienes favoritos.\nToca en cualquier lugar del mapa y añade favoritos.\nTambién se pueden importar y mostrar marcadores de otras fuentes en la aplicación Organic Maps. Abre el archivo KML/KMZ con los alfileres guardados desde el correo, Dropbox o Weblink.";
 
 /* Settings button in system menu */
 "settings" = "Configuración";
@@ -191,26 +147,11 @@
 /* Ask to wait user several minutes (some long process in modal dialog). */
 "wait_several_minutes" = "Esto podría tardar varios minutos.\nPor favor, espera…";
 
-/* Show bookmarks from this category on a map or not */
-"visible" = "Visible";
-
-/* Toast which is displayed when GPS has been deactivated */
-"gps_is_disabled_long_text" = "El GPS está inhabilitado. Por favor, activelo en los ajustes.";
-
 /* Measurement units title in settings activity */
 "measurement_units" = "Unidades de medida";
 
 /* Detailed description of Measurement Units settings button */
 "measurement_units_summary" = "Elija entre millas y kilómetros";
-
-/* Do search in all sources */
-"search_mode_all" = "Todos";
-
-/* Do search near my position only */
-"search_mode_nearme" = "Cerca de mí";
-
-/* Do search in current viewport only */
-"search_mode_viewport" = "En la pantalla";
 
 /* Search category for cafes, bars, restaurants */
 "eat" = "Dónde comer";
@@ -266,14 +207,8 @@
 /* Search category */
 "police" = "Policía";
 
-/* String in search result list, when nothing found */
-"no_search_results_found" = "No se han encontrado resultados";
-
 /* Notes field in Bookmarks view */
 "description" = "Notas";
-
-/* Button text */
-"share_by_email" = "Enviar por email";
 
 /* Email Subject when sharing bookmarks category */
 "share_bookmarks_email_subject" = "Marcapáginas de Organic Maps compartidos contigo";
@@ -295,26 +230,11 @@
 /* Warning message when doing search around current position */
 "unknown_current_position" = "Tu ubicación aún no ha sido determinada";
 
-/* Warning message when location country isn't downloaded during search (see also download_location_map_proposal). */
-"download_location_country" = "Descargar país de tu ubicación actual (%@)";
-
-/* Warning message when viewport country isn't downloaded during search */
-"download_viewport_country_to_search" = "Descargar país en el que estás buscando (%@)";
-
 /* Alert message that we can't run Map Storage settings due to some reasons. */
 "cant_change_this_setting" = "Lo sentimos, la configuración de Guardar Mapa está desactivada.";
 
 /* Alert message that downloading is in progress. */
 "downloading_is_active" = "Se está descargando un país.";
-
-/* Message that will be shown in alert view, when we ask user to leave review on App Store */
-"appStore_message" = "¡Ojalá disfrute mucho con Organic Maps! Si le gusta, le agradeceremos que puntúe nuestra aplicación en el App Store. Es menos de un minuto y nos sería de gran ayuda. ¡Gracias por su apoyo!";
-
-/* No, thanks */
-"no_thanks" = "No, gracias";
-
-/* Share one specific bookmark using SMS, %1$@ contains om:// and %2$@ https://omaps.app link. @NOTE non-ascii symbols in the link will result in max 70 characters SMS instead of 140. */
-"bookmark_share_sms" = "Ve mi alfiler en mapa. Abre %1$@ o %2$@";
 
 /* Share my position using SMS, %1$@ contains om:// and %2$@ https://omaps.app link WITHOUT NAME. @NOTE non-ascii symbols in the link will result in max 70 characters SMS instead of 140. */
 "my_position_share_sms" = "Mira dónde estoy. Abre %1$@ o %2$@";
@@ -328,23 +248,11 @@
 /* Share my position using EMail, %1$@ is om:// and %2$@ is https://omaps.app link WITHOUT NAME */
 "my_position_share_email" = "Hola:\n\nAhora estoy aquí: %1$@. Haz clic en este enlace %2$@ o esta %3$@ para verlo en el mapa.\n\nGracias.";
 
-/* Android share by Message/SMS button text (including SMS) */
-"share_by_message" = "Compartir por mensaje";
-
 /* Share button text which opens menu with more buttons, like Message, EMail, Facebook etc. */
 "share" = "Compartir";
 
-/* iOS share by Message button text (including SMS) */
-"message" = "Mensaje";
-
 /* Share by email button text, also used in editor. */
 "email" = "Correo electrónico";
-
-/* Copy Link */
-"copy_link" = "Copiar enlace";
-
-/* Text for the button that returns to caller application */
-"more_info" = "Mostrar más información";
 
 /* Text for message when used successfully copied something */
 "copied_to_clipboard" = "Copiado al portapapeles: %1$@";
@@ -354,15 +262,6 @@
 
 /* Used for bookmark editing */
 "done" = "Hecho";
-
-/* Summary for preferences in MWM */
-"yopme_pref_summary" = "Seleccione la сonfiguración de la pantalla trasera";
-
-/* Title for yopme preferences in MWM */
-"yopme_pref_title" = "Configuración de la pantalla trasera";
-
-/* Hint for upper-right icon p2b */
-"show_on_backscreen" = "Mostrar en la pantalla trasera";
 
 /* Prints version number in About dialog */
 "version" = "Versión: %@";
@@ -381,19 +280,11 @@
 
 "share_my_location" = "Compartir mi ubicación";
 
-"menu_search" = "Buscar";
-
 /* Settings general group in settings screen */
 "prefs_group_general" = "General settings";
 
 /* Settings information group in settings screen */
 "prefs_group_information" = "Information";
-
-/* Settings screen: "Map" category title */
-"prefs_group_map" = "Mapa";
-
-/* Settings screen: "Miscellaneous" category title */
-"prefs_group_misc" = "Varios";
 
 "prefs_group_route" = "Navegación";
 
@@ -419,9 +310,6 @@
 /* Settings «Map» category: «3D buildings» title */
 "pref_map_3d_buildings_title" = "Edificios en 3D";
 
-/* Settings «Map» category: «3D buildings» summary */
-"pref_map_3d_buildings_subtitle" = "Afecta a la duración de la batería";
-
 /* Settings «Route» category: «Tts enabled» title */
 "pref_tts_enable_title" = "Instrucciones de voz";
 
@@ -433,8 +321,6 @@
 
 /* Title for "Other" section in TTS settings. */
 "pref_tts_other_section_title" = "Otros";
-
-"pref_tts_how_to_set_up_voice" = "Cómo configurar la voz";
 
 /* Settings «Map» category: «Record track» title */
 "pref_track_record_title" = "Trayecto reciente";
@@ -455,56 +341,7 @@
 
 "recent_track_help_text" = "Permite registrar el recorrido realizado durante un determinado periodo de tiempo y verlo en el mapa. Tenga en cuenta que la activación de esta función aumenta el consumo de la batería. El registro del recorrido se eliminará automáticamente del mapa una vez vencido dicho periodo de tiempo.";
 
-"pref_track_ios_caption" = "El trayecto reciente muestra tu recorrido de viaje.";
-
-"pref_track_ios_subcaption" = "Por favor, selecciona la periodicidad para guardar el trayecto.";
-
-"placepage_distance" = "Distancia";
-
-"placepage_coordinates" = "Coordenadas";
-
-"placepage_unsorted" = "Sin clasificar";
-
 "search_show_on_map" = "Ver en el mapa";
-
-/* Used to warn user when fixing KitKat issue */
-"bookmark_move_fail" = "Tenemos que mover tus marcadores a la memoria interna, pero no hay espacio disponible para ellos. Por favor, libera memoria, en caso contrario, los marcadores no estarán disponibles.";
-
-/* Used in More Apps menu */
-"free" = "Gratis";
-
-/* Used in More Apps menu */
-"buy" = "Comprar";
-
-/* 1st search button-like result */
-"search_on_map" = "Buscar en mapa";
-
-/* toast with an error */
-"no_route_found" = "No se ha encontrado ninguna ruta";
-
-/* route title */
-"route" = "Ruta";
-
-/* category title */
-"routes" = "Rutas";
-
-/* text of notification */
-"download_map_notification" = "Descarga el mapa del lugar en que te encuentras";
-
-/* text of notification */
-"pro_version_is_free_today" = "¡Versión completa de Organic Maps gratis hoy! Descárgalo ahora y dilo a tus amigos.";
-
-/* Dialog for transferring maps from lite to pro. */
-"move_lite_maps_to_pro" = "Estamos transfiriendo tus mapas descargados de Organic Maps Lite a Organic Maps, lo cual puede llevar unos minutos.";
-
-/* Message to display when maps moved. */
-"move_lite_maps_to_pro_ok" = "Tus mapas descargados se han transferido correctamente a Organic Maps.";
-
-/* Message to display when maps move failed. */
-"move_lite_maps_to_pro_failed" = "No se han podido transferir tus mapas. Por favor, elimina Organic Maps Lite y descarga los mapas de nuevo.";
-
-/* Text in menu */
-"settings_and_more" = "Ajustes y más";
 
 /* Text in menu */
 "website" = "Sitio web";
@@ -527,14 +364,8 @@
 /* Text in menu */
 "openstreetmap" = "OpenStreetMap";
 
-/* Text in menu */
-"contact_us" = "Contacta con nosotros";
-
 /* Settings: Send feedback button and dialog title */
 "feedback" = "Comentarios";
-
-/* Text in menu */
-"subscribe_to_news" = "Suscríbete a nuestras noticias";
 
 /* Text in menu */
 "rate_the_app" = "Valora la aplicación";
@@ -548,15 +379,6 @@
 /* Text in menu */
 "report_a_bug" = "Hay un error";
 
-/* Email subject */
-"subscribe_me_subject" = "Por favor quiero suscribirme al boletín de Organic Maps";
-
-/* Email body */
-"subscribe_me_body" = "Quiero ser el primero en conocer las últimas noticias actualizaciones y promociones. Puedo cancelar mi suscripción en cualquier momento.";
-
-/* About text */
-"about_text" = "Organic Maps ofrece los mapas sin conexión más rápidos de todas las ciudades y todos los países del mundo. Viaja con plena confianza: estés donde estés, Organic Maps te ayuda a ubicarte en el mapa, encontrar el restaurante, hotel, banco o gasolinera más próximo, etc. No requiere conexión a Internet.\n\nTrabajamos continuamente en el desarrollo de nuevas funcionalidades y nos encantaría conocer tu opinión sobre cómo podríamos mejorar Organic Maps. Si tienes cualquier problema con la aplicación, no dudes en contactar con nosotros en support@organicmaps.app. ¡Respondemos a todas las solicitudes!\n\n¿Te gusta Organic Maps y quieres apoyarnos? Estas son algunas formas simples y totalmente gratis:\n\n- Publica una opinión en tu App Market\n- Dale a me gusta a nuestra página de Facebook http://www.facebook.com/OrganicMaps\n- O simplemente habla sobre Organic Maps a tu madre, amigos y colegas :)\n\nGracias por estar a nuestro lado. ¡Agradecemos mucho tu apoyo!\n\nPD: obtenemos datos de los mapas de OpenStreetMap, un proyecto de mapeo similar a Wikipedia, que permite a los usuarios crear y editar mapas. Si crees que falta algo o hay cualquier error en el mapa, puedes corregir los mapas directamente en https://www.openstreetmap.org y los cambios aparecerán en la aplicación Organic Maps en el próximo lanzamiento de la versión.";
-
 /* Alert text */
 "email_error_body" = "No se ha configurado el cliente de correo electrónico. Por favor, configúralo o utiliza alguna otra forma de ponerte en contacto con nosotros en %@";
 
@@ -569,12 +391,6 @@
 /* Search category */
 "wifi" = "WiFi";
 
-/* Update map suggestion */
-"routing_map_outdated" = "Por favor, actualiza el mapa para crear una ruta.";
-
-/* Update maps suggestion */
-"routing_update_maps" = "La nueva versión de Organic Maps permite crear rutas desde tu ubicación actual hasta un punto de destino. Por favor, actualiza los mapas para utilizar esta característica.";
-
 /* Update all button text */
 "downloader_update_all_button" = "Actualizar todos";
 
@@ -583,9 +399,6 @@
 
 /* Downloaded maps category */
 "downloader_downloaded_subtitle" = "Descargado";
-
-/* Downloaded maps category */
-"downloader_available_maps" = "Disponible";
 
 /* Country queued for download */
 "downloader_queued" = "En cola";
@@ -598,17 +411,6 @@
 
 "downloader_downloading" = "Descargando:";
 
-"downloader_search_results" = "Encontrado";
-
-/* Disclaimer message */
-"routing_disclaimer" = "Creando rutas en la aplicación Organic Maps, por favor, tenga en cuenta lo siguiente:\n\n  - Las rutas sugeridas se pueden considerar únicamente como recomendaciones.\n - Las condiciones de la carretera, las normas y las señales de tráfico tienen mayor prioridad que el consejo de navegación.\n - El mapa podría ser incorrecto o estar obsoleto y las rutas pueden no crear el mejor camino posible.\n\n  ¡Esté seguro en las carreteras y cuídese!";
-
-/* Outdated maps category */
-"downloader_outdated_maps" = "Anticuado";
-
-/* Up to date maps category */
-"downloader_uptodate_maps" = "Actualizado";
-
 /* Status of outdated country in the list */
 "downloader_status_outdated" = "Actualizar";
 
@@ -618,49 +420,14 @@
 /* Displayed in a dialog that appears when a user tries to delete a map while the app is in the follow route mode */
 "downloader_delete_map_while_routing_dialog" = "Para eliminar el mapa, por favor, detén la navegación.";
 
-/* Show when user try build route, but we don't know where he */
-"routing_failed_unknown_my_position" = "La ubicación actual no está definida. Por favor, especifique la ubicación para crear la ruta.";
-
-/* Show if use has not routing file, or InconsistentMWMandRoute */
-"routing_failed_has_no_routing_file" = "Son necesarios datos adicionales para crear la ruta. ¿Empezar la descarga?";
-
-/* StartPointNotFound */
-"routing_failed_start_point_not_found" = "No se puede calcular la ruta. No hay carreteras cerca de su punto de partida.";
-
-/* EndPointNotFound */
-"routing_failed_dst_point_not_found" = "No se puede calcular la ruta. No hay carreteras cerca de su destino.";
-
 /* PointsInDifferentMWM */
 "routing_failed_cross_mwm_building" = "Solo se pueden crear rutas que estén totalmente incluidas en un mapa único.";
-
-/* RouteNotFound */
-"routing_failed_route_not_found" = "No se ha encontrado ninguna ruta entre el origen seleccionado y el destino. Por favor, seleccione un punto de partida o destino diferente.";
-
-/* InternalError */
-"routing_failed_internal_error" = "Se ha producido un error interno. Por favor, intente eliminar y descargar el mapa otra vez. Si el problema persiste, por favor contáctenos en support@organicmaps.app.";
-
-/* Context menu item for downloader. */
-"downloader_download_map_and_routing" = "Descargar mapa + itinerario";
-
-/* Context menu item for downloader. */
-"downloader_download_routing" = "Descargar itinerario";
-
-/* Context menu item for downloader. */
-"downloader_delete_routing" = "Eliminar itinerario";
 
 /* Context menu item for downloader. */
 "downloader_download_map" = "Descargar el mapa";
 
-"downloader_download_map_no_routing" = "Descargar mapa sin ruta";
-
-/* Button for routing. */
-"routing_go" = "¡Listo!";
-
 /* Item status in downloader. */
 "downloader_retry" = "Repetir";
-
-/* Item in context menu. */
-"downloader_map_and_routing" = "Mapa + itinerario";
 
 /* Item in context menu. */
 "downloader_delete_map" = "Eliminar mapa";
@@ -668,29 +435,11 @@
 /* Item in context menu. */
 "downloader_update_map" = "Actualizar mapa";
 
-/* Item in context menu. */
-"downloader_update_map_and_routing" = "Actualizar mapa + itinerario";
-
-/* Item in context menu. */
-"downloader_map_only" = "Solo mapa";
-
-/* Toolbar title */
-"toolbar_application_menu" = "Menú de aplicación";
-
 /* Preference text */
 "pref_use_google_play" = "Usar los servicios de Google Play para obtener tu ubicación actual";
 
 /* Text for rating dialog */
 "rating_just_rated" = "Acabo de puntuar tu aplicación";
-
-/* Text for rating dialog */
-"rating_user_since" = "Soy usuario de Organic Maps desde %@";
-
-/* Text for rating dialog */
-"rating_do_like_maps" = "¿Te gusta Organic Maps?";
-
-/* Text for rating dialog */
-"rating_tap_star" = "Pulsa una estrella para puntuar tu aplicación.";
 
 /* Text for rating dialog */
 "rating_thanks" = "¡Gracias!";
@@ -701,23 +450,8 @@
 /* Text for rating dialog */
 "rating_send_feedback" = "Enviar comentarios";
 
-/* Text for g+ dialog */
-"rating_google_plus" = "Haz clic en g+ para hablar a tus amigos acerca de la app.";
-
 /* Text for routing error dialog */
 "routing_download_maps_along" = "Descarga mapas a lo largo de la ruta";
-
-/* Text for routing error dialog */
-"routing_download_map" = "Obtén el mapa";
-
-/* Text for routing error dialog */
-"routing_download_map_and_routing" = "Descarga el mapa actualizado y los datos de enrutamiento para conseguir todas las funciones de Organic Maps.";
-
-/* Text for routing error dialog */
-"routing_get_routing_data" = "Obtén datos de enrutamiento";
-
-/* Text for routing error dialog */
-"routing_get_additional_data" = "Datos adicionales necesarios para crear rutas desde tu ubicación.";
 
 /* Text for routing error dialog */
 "routing_requires_all_map" = "Para crear una ruta es necesario descargar y actualizar todos los mapas de la ubicación de destino.";
@@ -725,50 +459,15 @@
 /* Text for routing error dialog */
 "routing_not_enough_space" = "No hay suficiente espacio";
 
-/* Text for routing error dialog */
-"routing_download_more_than_avail" = "Necesitas descargar %@ MB, pero solo hay %@ MB disponibles.";
-
-/* Text for routing error dialog */
-"routing_download_roaming" = "Vas a descargar %@ MB usando datos móviles (en itinerancia). Esto puede dar lugar a cargos adicionales, dependiendo del plan de datos móviles de tu operador.";
-
 /* bookmark button text */
 "bookmark" = "marcador";
-
-/* map is not downloaded */
-"not_found_map" = "El mapa de tu ubicación no se ha descargado";
 
 /* location service disabled */
 "enable_location_services" = "Por favor, permite los servicios de localización";
 
-/* download map */
-"download_map" = "Descarga el mapa de tu ubicación";
-
-/* download map on iPhone */
-"download_map_iphone" = "Descarga el mapa para la ubicación actual en tu iPhone";
-
-/* clear pin */
-"nearby" = "Cerca";
-
-/* clear pin */
-"clear_pin" = "Borrar alfiler";
-
-/* location is undefined */
-"undefined_location" = "La ubicación actual no está definida.";
-
-/* download country of your location */
-"download_country" = "Descargar país de tu ubicación actual";
-
-/* download failed */
-"download_failed" = "la descarga ha fallado";
-
-/* get the map */
-"get_the_map" = "Obtén el mapa";
-
 "save" = "Guardar";
 
 "edit_description_hint" = "Tus descripciones (texto o html)";
-
-"new_group" = "nuevo grupo";
 
 "create" = "crear";
 
@@ -795,30 +494,6 @@
 
 /* pink color */
 "pink" = "Rosa";
-
-/* deep purple color */
-"deep_purple" = "Morado oscuro";
-
-/* light blue color */
-"light_blue" = "Azul Claro";
-
-/* cyan color */
-"cyan" = "Cian";
-
-/* teal color */
-"teal" = "Verde azulado";
-
-/* lime color */
-"lime" = "Lima";
-
-/* deep orange color */
-"deep_orange" = "Naranja oscuro";
-
-/* gray color */
-"gray" = "Gris";
-
-/* blue gray color */
-"blue_gray" = "Gris azulado";
 
 /* Wi-Fi available */
 "WiFi_available" = "Sí";
@@ -848,13 +523,9 @@
 
 "dialog_routing_location_unknown_turn_on" = "No se pueden encontrar las coordenadas del GPS. Active los servicios de ubicación para calcular la ruta.";
 
-"dialog_routing_location_unknown" = "No se pueden encontrar las coordenadas actuales del GPS.";
-
 "dialog_routing_download_files" = "Descargar archivos requeridos";
 
 "dialog_routing_download_and_update_all" = "Descargue y actualice toda la información de mapas y rutas junto con el trayecto proyectado para calcular la ruta.";
-
-"dialog_routing_routes_size" = "Archivos de información de ruta";
 
 "dialog_routing_unable_locate_route" = "Imposible encontrar ruta";
 
@@ -884,21 +555,11 @@
 
 "dialog_routing_try_again" = "Intentar nuevamente";
 
-"dialog_routing_send_error" = "Informar el problema";
-
-"dialog_routing_if_get_cross_route" = "¿Desea crear una ruta más directa que abarca más de un mapa?";
-
-"dialog_routing_cross_route_is_optimal" = "Está disponible una ruta mejor que cruza los límites de este mapa.";
-
 "not_now" = "No ahora";
-
-"dialog_routing_build_route" = "Crear";
 
 "dialog_routing_download_and_build_cross_route" = "¿Desea descargar el mapa y crear una ruta mejor que abarca más de un mapa?";
 
 "dialog_routing_download_cross_route" = "Descargar el mapa para crear una ruta mejor que cruza los límites de este mapa.";
-
-"dialog_routing_cross_route_always" = "Cruzar siempre este límite";
 
 
 /********** Strings for downloading map from search **********/
@@ -906,8 +567,6 @@
 "search_without_internet_advertisement" = "Para empezar a buscar y crear rutas, por favor, descarga el mapa y no necesitarás conexión a Internet nunca más para usarlo.";
 
 "search_select_map" = "Seleccionar el mapa";
-
-"search_select_other_map" = "Seleccionar otro mapa";
 
 /* «Show» context menu */
 "show" = "Mostrar";
@@ -918,17 +577,11 @@
 /* «Rename» context menu */
 "rename" = "Renombrar";
 
-/* Bottom sheet: expand button (should be short) */
-"bottom_sheet_more" = "Más…";
-
 /* Failed planning route message in navigation view */
 "routing_planning_error" = "Error al planificar la ruta";
 
 /* Arrive routing message in navigation view */
 "routing_arrive" = "Llegada: %s";
-
-/* Text for routing::RouterResultCode::FileTooOld dialog. */
-"dialog_routing_download_and_update_maps" = "Para crear una ruta, por favor, descarga y actualiza todos los mapas a lo largo de la ruta.";
 
 "rate_alert_title" = "¿Te gusta la aplicación?";
 
@@ -944,19 +597,11 @@
 
 "history" = "Historial";
 
-"next_turn_then" = "Luego";
-
 "closed" = "Cerrado";
-
-"back_to" = "Volver a %@";
 
 "search_not_found" = "Lo siento, no he encontrado nada.";
 
 "search_not_found_query" = "Por favor, prueba con otra consulta.";
-
-"search_not_found_map" = "Por favor, descarga el mapa en el que estás buscando.";
-
-"search_not_found_location" = "Descarga el mapa de tu ubicación actual.";
 
 "search_history_title" = "Historial de búsquedas";
 
@@ -964,23 +609,12 @@
 
 "clear_search" = "Eliminar el historial de búsqueda";
 
-/* Title for settings to enable/disable showcase menu button */
-"showcase_settings_title" = "Mostrar ofertas";
-
 /* Place Page link to Wikipedia article (if map object has it). */
 "read_in_wikipedia" = "Wikipedia";
 
-"p2p_route_planning" = "Planificación de ruta";
-
 "p2p_your_location" = "Tu ubicación";
 
-"p2p_from" = "El punto de origen";
-
-"p2p_to" = "El punto de destino";
-
 "p2p_start" = "Empezar";
-
-"p2p_planning" = "Planeando…";
 
 "p2p_from_here" = "Desde";
 
@@ -1018,15 +652,9 @@
 
 "editor_correct_mistake" = "Corregir error";
 
-"editor_correct_mistake_message" = "Ha cometido un error de edición. Por favor, corríjalo o cambie a modo sencillo.";
-
 "editor_add_select_location" = "Ubicación";
 
 "editor_done_dialog_1" = "Has cambiado el mapa del mundo. ¡No ocultarlo! Cuéntaselo a tus amigos y editadlo juntos.";
-
-"editor_done_dialog_2" = "Esta es tu segunda mejora del mapa. Ahora estás en el puesto %dº de la lista de editores de mapa. Cuéntaselo a tus amigos.";
-
-"editor_done_dialog_3" = "Has mejorado el mapa: cuéntaselo a tus amigos y editadlo juntos.";
 
 "share_with_friends" = "Compartir con amigos";
 
@@ -1044,20 +672,7 @@
 
 "editor_report_problem_duplicate_place_title" = "Lugar duplicado";
 
-"first_launch_congrats_title" = "Organic Maps está listo para usar";
-
-"first_launch_congrats_text" = "Busca y navega sin conexión por cualquier parte del mundo, sin cargos.";
-
-"migrate_title" = "¡Importante!";
-
-/* Android uses image instead of text. */
-"download_all" = "Descargar todos";
-
-"delete_all" = "Eliminar todos";
-
 "autodownload" = "Descarga automática";
-
-"disable_autodownload" = "Desactivar descarga automática";
 
 /* Place Page opening hours text */
 "closed_now" = "Cerrado ahora";
@@ -1072,10 +687,6 @@
 "day_off" = "Día libre";
 
 "today" = "Hoy";
-
-"sunrise_to_sunset" = "Del amanecer al atardecer";
-
-"sunset_to_sunrise" = "Del amanecer al anochecer";
 
 "add_opening_hours" = "Añadir horas comerciales";
 
@@ -1095,45 +706,18 @@
 
 "forgot_password" = "¿Has olvidado tu contraseña?";
 
-/* Forgot Password dialog title */
-"restore_password" = "Restaurar contraseña";
-
-"enter_email_address_to_reset_password" = "Introduce la dirección de correo electrónico que utilizaste durante el registro y te enviaremos el enlace para restaurar tu contraseña.";
-
-"reset_password" = "Restablecer contraseña";
-
-"username" = "Usuario";
-
 "osm_account" = "Cuenta OSM";
 
 "logout" = "Cerrar sesión";
 
-"login_and_edit_map_motivation_message" = "Inicia sesión y edita la información de los objetos en el mapa y los pondremos a disposición de millones de otros usuarios. Hagamos de este mundo un lugar mejor.";
-
 /* Information text: "Last upload 11.01.2016" */
 "last_upload" = "Última carga";
 
-/* Motivates user to login/register, title above login buttons. */
-"you_have_edited_your_first_object" = "¡Has editado tu primer objeto!";
-
 "thank_you" = "Gracias";
-
-"login_with_google" = "Iniciar sesión con Google";
-
-"login_with_openstreetmap" = "Iniciar sesión con www.openstreetmap.org";
 
 "edit_place" = "Editar el lugar";
 
 "place_name" = "Nombre del lugar";
-
-/* title above languages list cells in the editor, below editable name text field. */
-"other_languages" = "Otros idiomas";
-
-/* small button to open list with names in different languages */
-"show_more" = "Mostrar más";
-
-/* small button to close list with names in different languages */
-"show_less" = "Mostrar menos";
 
 "add_language" = "Añadir un idioma";
 
@@ -1164,8 +748,6 @@
 
 "please_note" = "Aviso";
 
-"common_no_wifi_dialog" = "No hay conexión Wi-Fi. ¿Quieres continuar con los datos móviles?";
-
 "downloader_delete_map_dialog" = "Todos los cambios en los mapas se borrarán junto con el mapa.";
 
 "downloader_update_maps" = "Autodescarga de mapas";
@@ -1173,10 +755,6 @@
 "downloader_mwm_migration_dialog" = "Los mapas empiezan a descargarse automáticamente cuando te aproximas al mapa.";
 
 "downloader_search_field_hint" = "Encontrar el mapa";
-
-"migration_update_all_button" = "Actualizar todos los mapas";
-
-"migration_delete_all_download_current_button" = "Descargar el mapa actual y eliminar los mapas antiguos";
 
 "migration_download_error_dialog" = "Error de descarga";
 
@@ -1186,21 +764,9 @@
 
 "downloader_no_space_message" = "Por favor, elimina los datos innecesarios";
 
-"editor_general_auth_error_dialog" = "Error general de inicio de sesión.";
-
 "editor_login_error_dialog" = "Error de inicio de sesión.";
 
-"editor_login_failed_dialog" = "Error al iniciar sesión";
-
-"editor_username_error_dialog" = "Usuario no válido";
-
-"editor_place_edited_dialog" = "¡Has editado un objeto!";
-
-"editor_login_with_osm" = "Iniciar sesión con OpenStreetMap";
-
 "editor_profile_changes" = "Cambios verificados";
-
-"editor_profile_unsent_changes" = "No enviado:";
 
 "editor_focus_map_on_location" = "Arrastra el mapa para seleccionar la ubicación correcta del objeto.";
 
@@ -1222,13 +788,9 @@
 
 "editor_report_problem_other_title" = "Un problema diferente";
 
-"placepage_report_problem_button" = "Informar de un problema";
-
 "placepage_add_business_button" = "Añadir organización";
 
 "whatsnew_editor_message_1" = "Añadir lugares nuevos al mapa y editar los lugares actuales directamente desde la aplicación.";
-
-"whatsnew_editor_message_2" = "* Organic Maps utiliza datos de la comunidad de OpenStreetMap.";
 
 "dialog_incorrect_feature_position" = "Cambiar ubicación";
 
@@ -1236,16 +798,10 @@
 
 "login_to_make_edits_visible" = "Inicia sesión para que otros usuarios puedan ver los cambios que has efectuado.";
 
-"no_migration_during_navigation" = "No se permite la actualización durante la navegación.";
-
 /* Error dialog no space */
 "migration_no_space_message" = "Necesitas más espacio para descargar. Por favor, elimina los datos innecesarios.";
 
 "editor_sharing_title" = "He mejorado los mapas de Organic Maps";
-
-"editor_comment_will_be_sent" = "Enviaremos tus comentarios a los cartógrafos.";
-
-"editor_unsupported_category_message" = "Has añadido un lugar de una categoría que no hemos incluido aún. Aparecerá en el mapa en unos momentos.";
 
 /* Downloaded 10 **of** 20 <- it is that "of" */
 "downloader_of" = "%1$d de %2$d";
@@ -1278,23 +834,9 @@
 
 "editor_operator" = "Operador";
 
-"editor_tag_description" = "Introduzca la empresa, organización o individuo responsable de las instalaciones.";
-
-"editor_no_local_edits_title" = "No tiene ediciones locales";
-
-"editor_no_local_edits_description" = "Esto muestra el número de sus cambios sugeridos en el mapa que actualmente solo son accesibles desde su dispositivo.";
-
-"editor_send_to_osm" = "Enviar a OSM";
-
-"editor_remove" = "Eliminar";
-
-"downloader_my_maps_title" = "Mis mapas";
-
 "downloader_no_downloaded_maps_title" = "No ha descargado ningún mapa";
 
 "downloader_no_downloaded_maps_message" = "Descargue mapas para encontrar la ubicación y navegar sin conexión.";
-
-"downloader_find_place_hint" = "Buscar ciudad o país";
 
 /* Error title that appears after certain time without location. */
 "current_location_unknown_title" = "¿Continuar detectando su ubicación actual?";
@@ -1321,47 +863,13 @@
 /* iOS Dialog for the case when the location permission is not granted */
 "location_services_disabled_3" = "3. Seleccionar Al usar la aplicación";
 
-"placepage_parking_surface" = "Superficie";
-
-"placepage_parking_multistorey" = "Varias plantas";
-
-"placepage_parking_underground" = "Subterráneo";
-
-"placepage_parking_rooftop" = "Azotea";
-
-"placepage_parking_sheds" = "Cobertizos";
-
-"placepage_parking_carports" = "Cochera";
-
-"placepage_parking_boxes" = "Garaje";
-
-"placepage_parking_pay" = "De pago";
-
-"placepage_parking_free" = "Gratuito";
-
-"placepage_parking_interval" = "Pago por intervalos";
-
-"placepage_entrance_number" = "N.º";
-
-"placepage_entrance_type" = "Entrada";
-
-"placepage_flat" = "aplicación";
-
-"placepage_open_24_7" = "24 / 7";
-
 "meter" = "m";
 
 "kilometer" = "km";
 
-"kilometers_per_hour" = "km/h";
-
 "mile" = "mile";
 
 "foot" = "pie";
-
-"miles_per_hour" = "mph";
-
-"day" = "d";
 
 "hour" = "h";
 
@@ -1381,10 +889,6 @@
 
 "placepage_bookmark_name_hint" = "Nombre del marcador";
 
-"placepage_personal_notes_hint" = "Notas personales";
-
-"placepage_delete_bookmark_button" = "Eliminar marcador";
-
 "editor_edits_sent_message" = "Se han enviado sus cambios sugeridos";
 
 "editor_comment_hint" = "Comentario…";
@@ -1397,8 +901,6 @@
 
 "editor_remove_place_button" = "Eliminar";
 
-"editor_status_sending" = "Enviando…";
-
 "editor_place_doesnt_exist" = "El lugar no existe";
 
 "text_more_button" = "…más";
@@ -1410,11 +912,7 @@
 
 "error_enter_correct_email" = "Introduce un email válido";
 
-"error_enter_correct" = "Introduce un valor válido";
-
 "refresh" = "Actualizar";
-
-"last_update" = "Última actualización: %s";
 
 "placepage_add_place_button" = "Añadir un lugar al mapa";
 
@@ -1426,24 +924,6 @@
 
 "editor_share_to_all_dialog_message_2" = "Comprobaremos los cambios. Si tenemos cualquier pregunta, te contactaremos por correo electrónico.";
 
-"navigation_overview_button" = "resumen";
-
-"navigation_stop_button" = "parada";
-
-/* Text on an empty bookmark page */
-"bookmarks_empty_title" = "Guardar marcadores";
-
-"bookmarks_empty_message_1" = "Pulsa ★ para guardar los lugares favoritos a los que podrás acceder rápidamente.";
-
-"bookmarks_empty_message_2" = "Importar marcadores desde Mail y la web.";
-
-"bookmarks_empty_message_3" = "hora de salida: %s";
-
-/* Name of the group for booked hotels */
-"bookmarks_group_name" = "Hoteles reservados";
-
-"place_page_button_read_descriprion" = "Leer";
-
 /* iOS dialog for the case when recent track recording is on and the app comes back from background */
 "recent_track_background_dialog_title" = "¿Deshabilitar registro de ruta recorrida recientemente?";
 
@@ -1451,8 +931,6 @@
 
 /* For sharing via SMS and so on */
 "sharing_call_action_look" = "Comprueba";
-
-"continue_recent_track_background_button" = "Continuar";
 
 "recent_track_background_dialog_message" = "Organic Maps usa tu geolocalización en segundo plano para registrar tu ruta recorrida recientemente.";
 
@@ -1468,33 +946,13 @@
 /* About short text (below logo) */
 "about_description" = "Organic Maps es una aplicación esencial offline para viajar. Organic Maps se basa en datos de OpenStreetMap y permite editarla.";
 
-/* Text in menu */
-"blog" = "Blog";
-
 "general_settings" = "Ajustes generales";
-
-"date" = "Fecha %d";
-
-/* "Report a bug" -> "Generaal Feedback" -> "Something is not working" */
-"something_is_not_working" = "Algo no funciona";
 
 /* For the first routing */
 "accept" = "Aceptar";
 
-"accept_and_continue" = "Accept and continue";
-
 /* For the first routing */
 "decline" = "Declinar";
-
-"install_app" = "Instalar";
-
-"search_no_results_title" = "No se han encontrado resultados";
-
-"search_no_results_message" = "Pruebe un término de búsqueda general, aléjese o restablezca el filtro.";
-
-"search_no_results_expand_area_button" = "Alejarse";
-
-"search_no_results_reset_button" = "Restablecer filtro";
 
 /* noun */
 "search_in_table" = "Lista";
@@ -1517,8 +975,6 @@
 
 "traffic_update_maps_text" = "Para mostrar los datos de tráfico, deben actualizarse los mapas.";
 
-"traffic_outdated" = "Los datos de tráfico están obsoletos.";
-
 "big_font" = "Aumentar el tamaño de fuente en el mapa";
 
 "traffic_update_app" = "Por favor, actualice Organic Maps";
@@ -1529,17 +985,7 @@
 /* "traffic" as in "road congestion" */
 "traffic_data_unavailable" = "Los datos de tráfico no están disponibles";
 
-/* "Translation is no needed, because it's a company name" */
-"uber" = "Uber";
-
-/* Simplified colour scheme for traffic information, fewer colours are used to display traffic jams on the map. The string should be kept as short as possible */
-"pref_traffic_simplified_colors_title" = "Colores simples para tráfico";
-
 "enable_logging" = "Habilitar historial";
-
-"offline_place_page_more_information" = "Conéctese a internet para obtener más información sobre este lugar.";
-
-"failed_load_information" = "No se ha podido cargar la información.";
 
 /* Settings: "Send general feedback" button */
 "feedback_general" = "Opinión general";
@@ -1556,8 +1002,6 @@
 
 "whatsnew_transliteration_title" = "Transliteración al alfabeto latino";
 
-"yandex_taxi_title" = "Yandex.Taxi";
-
 "learn_more" = "Leer más";
 
 "core_exit" = "Salir";
@@ -1568,75 +1012,19 @@
 
 "button_exit" = "Salir";
 
-"settings_device_memory" = "Memoria del dispositivo";
-
-"settings_card_memory" = "Tarjeta de memoria";
-
-"settings_storage_available" = "%s disponible";
-
-"toast_location_permission_denied" = "A la aplicación se le ha denegado el permiso de acceso a la ubicación";
-
-"button_use" = "Utilizar";
-
 "planning_route_manage_route" = "Administrar ruta";
 
 "button_plan" = "Planificar";
-
-"button_add" = "Añadir";
 
 "placepage_remove_stop" = "Eliminar";
 
 "planning_route_remove_title" = "Arrastre aquí para eliminar";
 
-"dialog_change_start_point_message" = "¿Cambiar el punto de inicio por la ubicación actual?";
-
-"button_replace" = "Cambiar";
-
 "placepage_add_stop" = "Añadir parada";
-
-/* Only ru/en are needed */
-"subtitle_rent" = "Rent";
-
-/* Only ru/en are needed */
-"rub_month" = "RUB/month";
-
-/* Only ru/en are needed */
-"room" = "%s-room apt.";
-
-/* Only ru/en are needed */
-"real_estate" = "Real estate";
-
-"add_my_position" = "Añadir mi posición";
-
-"choose_start_point" = "Elegir un punto de partida";
-
-"choose_destination" = "Elegir un destino";
 
 "preloader_viator_button" = "Más información";
 
-"start_from_my_position" = "Empezar desde";
-
-"profile_authorization_title" = "Iniciar sesión con";
-
-"profile_authorization_message" = "Inicie sesión fácilmente sin nombre de usuario ni contraseña en un par de segundos";
-
 "profile_authorization_error" = "Vaya, se ha producido un error. Intente iniciar sesión de nuevo.";
-
-"service" = "Servicio";
-
-"atmosphere" = "Ambiente";
-
-"value_for_money" = "Relación calidad-precio";
-
-"experience" = "Experiencia";
-
-"assortment" = "Variedad";
-
-"expertise" = "Conocimiento";
-
-"equipment" = "Equipamiento";
-
-"quality" = "Calidad";
 
 "dialog_error_storage_title" = "Problema de acceso al almacenamiento";
 
@@ -1644,17 +1032,7 @@
 
 "setting_emulate_bad_storage" = "Emular almacenamiento dañado";
 
-"directions_finish" = "Destino";
-
-"directions_on_foot" = "%s a pie";
-
 "core_entrance" = "Entrada";
-
-"coffee" = "Café";
-
-"cleanliness" = "Limpieza";
-
-"crowdedness" = "Lugar concurrido";
 
 "error_enter_correct_name" = "Por favor, introduzca el nombre correcto";
 
@@ -1673,11 +1051,9 @@
 
 "downloader_percent" = "%s (%s de %s)";
 
-"downloader_process" = "Descargando %s...";
+"downloader_process" = "Descargando %s…";
 
-"downloader_applying" = "Aplicando %s...";
-
-"dialog_message_transit_not_found_connection" = "Planea una ruta en una red de tránsito";
+"downloader_applying" = "Aplicando %s…";
 
 "bookmarks_error_message_share_general" = "No se puede compartir debido a un error de la aplicación";
 
@@ -1695,17 +1071,7 @@
 
 "bookmarks_error_message_list_name_already_taken" = "Por favor elige otro nombre";
 
-"bookmarks_error_title_list_name_too_long" = "Este nombre es demasiado largo";
-
-"bookmarks_error_message_list_name_too_long" = "Por favor elige otro nombre";
-
-"please_wait" = "Por favor espera...";
-
-"phone_number" = "Número de teléfono";
-
-"notification_unsent_reviews_title" = "Tienes varias reseñas sin enviar";
-
-"notification_unsent_reviews_message" = "Inicia sesión para compartir comentarios con otros viajeros";
+"please_wait" = "Por favor espera…";
 
 "profile" = "Perfil de OpenStreetMap";
 
@@ -1719,49 +1085,13 @@
 
 "bookmarks_convert_error_message" = "Algunos archivos no fueron convertidos.";
 
-"converting" = "Mudado...";
-
-"wn_reinvented_bookmarks_title" = "¡Hemos reinventado marcadores!";
-
-"wn_reinvented_bookmarks_message" = "Puede hacer una copia de seguridad de los marcadores, crear listas... Es increíble...";
-
-"bookmarks_restore" = "Restaurar marcadores";
-
-"bookmarks_restore_process" = "Restaurando...";
-
 "bookmarks_restore_title" = "Restaurar esta versión?";
 
-"bookmarks_restore_message" = "Tus marcadores se restaurarán desde %s (%s)";
-
-"bookmarks_restore_empty_title" = "No tienes una copia de seguridad";
-
-"bookmarks_restore_empty_message" = "El servidor no encontró copias de seguridad previamente hechas";
-
 "common_check_internet_connection_dialog_title" = "Sin conexión a Internet";
-
-"error_server_title" = "Error del Servidor";
-
-"error_server_message" = "Hubo un error en el servidor, intente de nuevo más tarde";
 
 "error_system_message" = "Un error desconocido ocurrió";
 
 "restore" = "Restaurar";
-
-"bookmarks_page_downloaded" = "Descargado";
-
-"bookmarks_page_my" = "Mis";
-
-"routes_and_bookmarks" = "Rutas y marcadores";
-
-"bookmarks_webview_success_toast" = "Marcadores descargados exitosamente";
-
-"cached_bookmarks_placeholder_title" = "Descargar nuevos lugares";
-
-"cached_bookmarks_placeholder_subtitle" = "Presione el botón para descargar miles de lugares y rutas interesantes creadas por usuarios de Organic Maps. Necesitará una conexión a Internet.";
-
-"downloader_download_routers" = "Descargar marcadores";
-
-"bookmarks_groups_cached" = "Listas descargadas";
 
 "subtittle_opt_out" = "Configuraciones de seguimiento";
 
@@ -1769,29 +1099,15 @@
 
 "crash_reports_description" = "Puede que utilicemos vuestros datos para mejorar la experiencia de Organic Maps. Los cambios tendrán efecto después que reinicie la aplicación.";
 
-"opt_out_help_ios_1" = "Su dispositivo móvil puede tener una opción de «Limitar el seguimiento de anuncios» o «Excluir anuncios basados en intereses».";
-
-"opt_out_help_ios_2" = "iOS 9 o más reciente";
-
-"opt_out_help_ios_3" = "Diríjase a su Configuración → Privacidad → Publicidad → Habilite la opción «Limitar seguimiento»";
-
-"opt_out_help_android" = "Su dispositivo móvil puede proporcionar una configuración para «Limitar el seguimiento de anuncios» o «Excluir anuncios basados en intereses». \n\nPara la versión 4.0 o más reciente de Android y Servicios de Google Play :\nConfiguración → Google → Anuncios → Excluir Personalización de Anuncios\nor\nConfiguración → Google → Cuenta de Google → Información personal y privacidad → Configuración de Anuncios → Personalización de Anuncios";
-
 "privacy_policy" = "Política de Privacidad";
 
 "terms_of_use" = "Condiciones de uso";
-
-"backup_notification_failed" = "La copia de suguridad de sus marcadores ha sido suspendida. Inicie sesión para volverla a iniciar.";
 
 "button_layer_traffic" = "Tráfico";
 
 "button_layer_subway" = "Metro";
 
 "layers_title" = "Capas del mapa";
-
-"layers_message" = "Utilice las capas del mapa para mostrar el tráfico, el mapa del metro, y otra información útil";
-
-"button_layer_got_it" = "Listo";
 
 "subway_data_unavailable" = "El mapa del metro no está disponible";
 
@@ -1803,39 +1119,13 @@
 
 "title_error_downloading_bookmarks" = "Se ha producido un error";
 
-"subtitle_error_downloading_bookmarks" = "Los marcadores no se descargaron";
-
-"error_already_downloaded" = "Esta lista ya se ha descargado";
-
 "popular_place" = "Popular";
-
-"download_routes" = "Download routes";
-
-"bookmarks_downloaded_title" = "Bookmarks have been downloaded successfully";
-
-"bookmarks_downloaded_subtitle" = "Press ‘View on map’ to explore new places from the list";
-
-"why_support" = "¿Por qué apoyar a Organic Maps?";
-
-"why_support_item1" = "We respect your privacy: there are zero trackers in the app, and we are open source";
-
-"why_support_item2" = "Usted nos ayuda a mejorar a Organic Maps";
-
-"why_support_item3" = "Nos está ayudando a mejorar los mapas de OpenStreetMap.org";
-
-"channels_map_update" = "Actualización de los mapas";
-
-"server_unavailable_title" = "Servidor no disponible";
-
-"sharing_options" = "Configuración de acceso";
 
 "export_file" = "Exportar como archivo";
 
 "list_settings" = "Configurar lista";
 
 "delete_list" = "Eliminar lista";
-
-"hide_from_map" = "Ocultar en el mapa";
 
 "public_access" = "Acceso público";
 
@@ -1845,40 +1135,11 @@
 
 "bookmark_category_description_hint" = "Agregue una descripción (texto o html)";
 
-/* FIXME */
-"bookmarks_public_access" = "bookmarks_public_access";
-
-/* FIXME */
-"bookmarks_link_access" = "bookmarks_link_access";
-
-/* FIXME */
-"bookmarks_private_access" = "bookmarks_private_access";
-
 "not_shared" = "Personal";
-
-"direct_link_progress_text" = "Cargando su archivo…";
-
-"direct_link_success" = "Enlace creado";
-
-"send_a_link_btn" = "Enviar enlace";
-
-"upload_error_toast" = "Se produjo un error durante la carga del archivo";
 
 "tags_loading_error_subtitle" = "Durante la carga de las etiquetas, se produjo un error, por favor inténtelo de nuevo";
 
-"unable_upload_errorr_title" = "No se pudo cargar el archivo";
-
-"unable_upload_error_subtitle_edited" = "El archivo fue editado a través de la aplicación web";
-
-"unable_upload_error_subtitle_broken" = "El archivo está dañado y no se puede cargar. Por favor, suba otro archivo.";
-
-"contact" = "Escribir";
-
-"download_button" = "Descargar";
-
 "speedcams_alert_title" = "Cámaras de la velocidad";
-
-"speedcams_alert_subtitle" = "Advertencia de límites de velocidad";
 
 "speedcam_option_auto" = "Auto";
 
@@ -1886,18 +1147,10 @@
 
 "speedcam_option_never" = "Nunca";
 
-"bookmark_description_title" = "Descripción de la etiqueta";
-
 "place_description_title" = "Descripción del lugar";
 
 /* this text will be shown in application notification preferences opposite checkbox which enable/disable downloader notifications. Devices on Android 8+ are affected. */
 "notification_channel_downloader" = "Cargando mapas";
-
-"share_bookmarks_email_body_link" = "Hola!\n\nSus etiquetas se pueden descargar desde el enlace: %s. Abra la lista con la ayuda de Organic Maps y disfrute del viaje!\n\nDescargar la aplicación: https://omaps.app/get?kmz";
-
-"warning_speedcams_title" = "El navegador le notificará de las cámaras cuando se exceda el límite de velocidad en %d km/h";
-
-"warning_speedcams_subtitle" = "No de olvide de leer las reglas de carretera en el país de viaje.";
 
 "speedcams_notice_message" = "Auto - advierte sobre las cámaras de velocidad si existe el riesgo de exceder el límite de velocidad\nSiempre - siempre alerta sobre las cámaras\nNunca - nunca advierte acerca de las cámaras";
 
@@ -1913,23 +1166,7 @@
 
 "enable_logging_warning_message" = "Esta opción está habilitada para las acciones de registro con fines de diagnóstico. Esto ayuda a nuestro equipo a identificar problemas con la aplicación. Habilite la opción solo a petición del apoyo de Organic Maps.";
 
-"html_error_upload_message_try_again" = "Comprueba el acceso a la red y vuelve a intentarlo";
-
-"html_error_upload_title_try_again" = "No hay conexión a internet";
-
-"notification_leave_review_v2_android_short_title" = "¡Escribe un comentario y ayuda a los viajeros!";
-
-"megafon" = "Say goodbye to roaming!";
-
-"notifications_illegal_alert_disable_button" = "Desactivar notificaciones";
-
 "access_rules_author_only" = "Se edita en línea";
-
-"privacy_settings_menu" = "Configuración de privacidad";
-
-"unable_upadate_error_title" = "No se pudo actualizar la ruta";
-
-"unable_upadate_error_message" = "Hubo errores al actualizar. Comprueba los cambios y vuelve a intentarlo";
 
 "driving_options_title" = "Configuración de desvío";
 
@@ -1951,94 +1188,19 @@
 
 "change_driving_options_btn" = "Configuración de desvío activada";
 
-"toll_road" = "Carretera con pago de peaje";
-
-"unpaved_road" = "Camino sin pavimento";
-
-"ferry_crossing" = "Cruce de ferri";
-
-"operated_by" = "Operado por \"%s\"";
-
 "avoid_toll_roads_placepage" = "Evitar las carreteras con pago de peaje";
 
 "avoid_unpaved_roads_placepage" = "Evitar los caminos sin pavimento";
 
 "avoid_ferry_crossing_placepage" = "Evitar ferries";
 
-"type.cuisine.uzbek" = "Cocina uzbeka";
-
-"trip_start" = "Vamos";
-
-"pick_destination" = "Objetivo";
-
-"follow_my_position" = "Centrar";
-
-"search_results" = "Resultados de búsqueda";
-
-"then_turn" = "Después";
-
-"redirect_route_alert" = "¿Quieres reconstruir la ruta?";
-
-"redirect_route_yes" = "Si";
-
-"redirect_route_no" = "No";
-
-"trip_finished" = "¡Llegaste!";
-
-"keyboard_availability_alert" = "Teclado no disponible durante el movimiento";
-
-"dialog_routing_change_start_carplay" = "No se puede construir la ruta desde la ubicación actual";
-
-"dialog_routing_change_end_carplay" = "No se puede construir la ruta al punto final. Elige otra";
-
-"dialog_routing_check_gps_carplay" = "No hay señal GPS. Ve a una zona abierta";
-
-"dialog_routing_unable_locate_route_carplay" = "No se puede construir una ruta. Elige otros puntos de ruta";
-
-"dialog_routing_download_files_carplay" = "Al construir ruta, descarga los mapas ausentes en tu dispositivo";
-
-"dialog_routing_system_error_carplay" = "Ocurrió un error. Reinicia la aplicación";
-
-"dialog_routing_rebuild_from_current_location_carplay" = "La ruta se reconstruirá desde tu ubicación actual";
-
-"dialog_routing_rebuild_for_vehicle_carplay" = "La ruta se cambiará a coche";
-
 "ok" = "Ok";
-
-"avoid_unpaved_carplay_1" = "Sin de grava";
-
-"avoid_unpaved_carplay_2" = "Sin de grava";
-
-"avoid_ferry_carplay_1" = "Sin ferri";
-
-"avoid_ferry_carplay_2" = "Sin ferri";
-
-"avoid_tolls_carplay_1" = "Sin peaje";
-
-"avoid_tolls_carplay_2" = "Sin peaje";
-
-"speedcams_alert_title_carplay_1" = "Cám.velocid.";
-
-"speedcams_alert_title_carplay_2" = "Alerta velocid.";
-
-"download_map_carplay" = "Descarga mapas en la aplicación Organic Maps en tu dispositivo";
-
-"carplay_roundabout_exit" = "%s desviación";
 
 /* max. 10 symbols, both iOS and Android */
 "sort" = "Ordenar…";
 
 /* Android, title, max 20-22 symbols */
 "sort_bookmarks" = "Ordenar etiquetas";
-
-/* iOS */
-"sort_default" = "Ordenar por defecto";
-
-"sort_type" = "Ordenar por tipo";
-
-"sort_distance" = "Ordenar por distancia";
-
-"sort_date" = "Ordenar por fecha";
 
 /* Android */
 "by_default" = "Por defecto";
@@ -2052,63 +1214,7 @@
 /* Android */
 "by_date" = "Por fecha";
 
-"week_ago_sorttype" = "Hace una semana";
-
-"month_ago_sorttype" = "Hace un mes";
-
-"moremonth_ago_sorttype" = "Hace más de un mes";
-
-"moreyear_ago_sorttype" = "Hace más de un año";
-
-"near_me_sorttype" = "Cerca a mí";
-
-"others_sorttype" = "Otros";
-
-"food_places" = "Comida";
-
-"tourist_places" = "Sitios de interés";
-
-"museums" = "Museos";
-
-"parks" = "Parques";
-
-"swim_places" = "Natación";
-
-"mountains" = "Montañas";
-
-"animals" = "Animales";
-
-"hotels" = "Hoteles";
-
-"buildings" = "Edificios";
-
-"money" = "Dinero";
-
-"shops" = "Tiendas";
-
-"parkings" = "Estacionamiento";
-
-"fuel_places" = "Gasolinera";
-
-"water" = "Agua";
-
-"medicine" = "Medicina";
-
 "search_in_the_list" = "Buscar en la lista";
-
-"view_on_map_bookmarks" = "En el mapa";
-
-"more_bookmarks" = "Más…";
-
-"no_items_found" = "No encontrado";
-
-/* Android, max 18 symbols */
-"bookmarks_edit_list" = "Editar";
-
-/* Android, max 18 symbols */
-"bookmarks_delete_list" = "Eliminar lista";
-
-"religious_places" = "Lugares sagrados";
 
 "select_list" = "Seleccionar lista";
 
@@ -2118,26 +1224,13 @@
 
 "dialog_pedestrian_route_is_long_message" = "Elige el punto de inicio o fin de ruta más cercano al metro";
 
-/* Failed planning SUBWAY route message in navigation view */
-"routing_planning_error_subway_special" = "Error al construir la ruta en metro";
-
 "button_layer_isolines" = "Alturas";
-
-"tips_map_layers_title_countour" = "¡Altitud de relieve sin conexión en Organic Maps!";
-
-"tips_map_layers_message_countour" = "La altitud de relieve te ayudará a planificar un viaje a la naturaleza y no perderte en la zona";
 
 "isolines_activation_error_dialog" = "Para usar la altitud de relieve, actualiza o descarga el mapa del área deseada";
 
 "isolines_location_error_dialog" = "La altitud de relieve aún no está disponible en esta región";
 
 "elevation_profile_diff_level" = "Nivel de dificultad";
-
-"elevation_profile_diff_level_easy" = "Fácil";
-
-"elevation_profile_diff_level_moderate" = "Moderado";
-
-"elevation_profile_diff_level_hard" = "Difícil";
 
 "elevation_profile_ascent" = "Ascenso";
 
@@ -2147,25 +1240,13 @@
 
 "elevation_profile_maxaltitude" = "Altura máxima";
 
-"elevation_profile_m" = "m";
-
 "elevation_profile_difficulty" = "Dificultad";
 
 "elevation_profile_distance" = "Distancia";
 
-"elevation_profile_km" = "km";
-
 "elevation_profile_time" = "Lapso:";
 
-"elevation_profile_hours" = "h.";
-
-"elevation_profile_minutes" = "min";
-
 "isolines_toast_zooms_1_10" = "Amplía el mapa para ver las isolíneas";
-
-"downloader_updating_ios" = "Actualización";
-
-"downloader_loading_ios" = "Cargando";
 
 "key_information_title" = "Información clave";
 

--- a/iphone/Maps/LocalizedStrings/es.lproj/Localizable.stringsdict
+++ b/iphone/Maps/LocalizedStrings/es.lproj/Localizable.stringsdict
@@ -9,21 +9,6 @@
 
 <!-- ********** Strings for downloading map from search **********/ -->
 
-  <key>bookmarks_places</key>
-  <dict>
-    <key>NSStringLocalizedFormatKey</key>
-    <string>%#@value@</string>
-    <key>value</key>
-    <dict>
-      <key>NSStringFormatSpecTypeKey</key>
-      <string>NSStringPluralRuleType</string>
-      <key>NSStringFormatValueTypeKey</key>
-      <string>d</string>
-      <key>other</key>
-      <string>%d marcadores</string>
-    </dict>
-  </dict>
-
   <key>bookmarks_detect_message</key>
   <dict>
     <key>NSStringLocalizedFormatKey</key>
@@ -38,21 +23,6 @@
       <string>Se encontró %d archivo. Lo verás después de la conversión.</string>
       <key>other</key>
       <string>Se han encontrado %d archivos. Los verás después de la conversión.</string>
-    </dict>
-  </dict>
-
-  <key>bookmarks_objects</key>
-  <dict>
-    <key>NSStringLocalizedFormatKey</key>
-    <string>%#@value@</string>
-    <key>value</key>
-    <dict>
-      <key>NSStringFormatSpecTypeKey</key>
-      <string>NSStringPluralRuleType</string>
-      <key>NSStringFormatValueTypeKey</key>
-      <string>d</string>
-      <key>other</key>
-      <string>%s objeto</string>
     </dict>
   </dict>
 

--- a/iphone/Maps/LocalizedStrings/fa.lproj/Localizable.strings
+++ b/iphone/Maps/LocalizedStrings/fa.lproj/Localizable.strings
@@ -18,9 +18,6 @@
 /* Button which deletes downloaded country */
 "delete" = "حذف";
 
-/* Button "do not interrupt download" if user touched actively downloading country */
-"do_nothing" = "ادامه";
-
 "download_maps" = "دانلود نقشه ها";
 
 /* Settings/Downloader - info for country when download fails */
@@ -28,9 +25,6 @@
 
 /* Settings/Downloader - info for country which started downloading */
 "downloading" = "درحال دانلود";
-
-/* Settings/Downloader - size string, only strings different from English should be translated */
-"kb" = "کیلوبایت";
 
 /* Choose measurement on first launch alert - choose metric system button */
 "kilometres" = "کیلومتر";
@@ -55,17 +49,11 @@
 /* Update maps later/Buy pro version later button text */
 "later" = "بعداً";
 
-/* Don't show some dialog any more */
-"never" = "هرگز";
-
 /* View and button titles for accessibility */
 "search" = "جست‌وجو";
 
 /* Search box placeholder text */
 "search_map" = "جست‌وجوی نقشه";
-
-/* Settings/Downloader - info for not downloaded country */
-"touch_to_download" = "برای دانلود لمس کنید";
 
 /* Settings/Downloader - 3G download warning dialog confirm button */
 "use_cellular_data" = "بله";
@@ -73,20 +61,11 @@
 /* Location services are disabled by user alert - message */
 "location_is_disabled_long_text" = "سرویس موقعیت مکانی شما غیر فعال است .لطفا جهت کارکرد صحیح نرم افزار ان را فعال کنید.";
 
-/* Location Services are not available on the device alert - message */
-"device_doesnot_support_location_services" = "دستگاه شماازسرویس موقعیت مکانی پشتیبانی نمی کند";
-
 /* View and button titles for accessibility */
 "zoom_to_country" = "بر روی نقشه نمایش بده";
 
-/* Button text for the button at the center of the screen when the country is not downloaded */
-"country_status_download" = "دانلود نقشه\n(^ ^)";
-
 /* Button text for the button at the center of the screen when the country is not downloaded and the size should not be shown */
 "country_status_download_without_size" = "دانلود نقشه";
-
-/* Button text for the button at the center of the screen when the country is not downloaded */
-"country_status_download_without_routing" = "Download map\nwithout routing (^ ^)";
 
 /* Message to display at the center of the screen when the country download has failed */
 "country_status_download_failed" = "دانلود با شکست مواجه شد";
@@ -96,19 +75,13 @@
 
 "about_menu_title" = "Organic Maps درباره‌ی";
 
-"downloaded_touch_to_delete" = "دانلود شده (%@),  برای حذف لمس کنید";
-
 "connection_settings" = "تنظیمات اتصال";
-
-"download_mb_or_kb" = "دانلود %@";
 
 "close" = "بستن";
 
 "unsupported_phone" = "نیازمند است. متاسفانه دستگاه شما از ان پشتیبانی نمی کندOpenGLبرنامه برای اجرا به";
 
 "download" = "دانلود";
-
-"external_storage_is_not_available" = "حافظه خارجی که نقشه ها در ان دانلود شده موجود نیست";
 
 "disconnect_usb_cable" = "Please disconnect USB cable or insert memory card to use Organic Maps";
 
@@ -117,8 +90,6 @@
 "not_enough_memory" = "حافظه کافی برای اجرای برنامه وجود ندارد";
 
 "download_resources" = "قبل از استفاده از اپلیکیشن, اجازه دهید تا ما نقشه جهانی را بر روی موبایل شما دانلود کنیم.\nمقدار %@ از حافظه شما اشغال می شود.";
-
-"getting_position" = "درحال دریافت موقعیت مکانی شما";
 
 "download_resources_continue" = "برو به نقشه";
 
@@ -140,23 +111,14 @@
 /* Add New Bookmark Set dialog title */
 "add_new_set" = "اضافه کردن مجموعه جدید";
 
-/* Place Page - Add To Bookmarks button */
-"add_to_bookmarks" = "اضافه کردن به نشانه ها";
-
 /* Bookmark Color dialog title */
 "bookmark_color" = "رنگ نشانه";
 
 /* Add Bookmark Set dialog - hint when set name is empty */
 "bookmark_set_name" = "Bookmark Set Name";
 
-/* Bookmark Sets dialog title */
-"bookmark_sets" = "Bookmark Sets";
-
 /* Bookmarks - dialog title */
 "bookmarks" = "نشانه ها";
-
-/* Add bookmark dialog - bookmark color */
-"color" = "رنگ";
 
 /* Default bookmarks set name */
 "core_my_places" = "مکان من";
@@ -167,14 +129,8 @@
 /* Editor title above street and house number */
 "address" = "ادرس";
 
-/* Place Page - Remove Pin button */
-"remove_pin" = "برچیدن سنجاق";
-
 /* Add bookmark dialog - bookmark set, Bookmarks dialog - Bookmark set cell */
 "set" = "مجموعه";
-
-/* Text hint in Bookmarks dialog when no any bookmarks are added */
-"bookmarks_usage_hint" = "شما تا کنون نشانه ای نداشته اید.\nبر روی مکانی از نقشه لمس کنید تا نشانه ای افزوده شود.\nنشانه ها را می توانید از جایی دیگر وارد کرده و در Organic Maps نمایش دهید.Open KML/KMZ file with saved bookmarks from email, Dropbox or weblink.";
 
 /* Settings button in system menu */
 "settings" = "تنظیمات";
@@ -189,28 +145,13 @@
 "move_maps" = "ایا نقشه ها جابه جا شود؟";
 
 /* Ask to wait user several minutes (some long process in modal dialog). */
-"wait_several_minutes" = "ممکن است چند دقیقه طول بکشد.\nلطفا صبر کنید...";
-
-/* Show bookmarks from this category on a map or not */
-"visible" = "قابل مشاهده";
-
-/* Toast which is displayed when GPS has been deactivated */
-"gps_is_disabled_long_text" = "سرویس موقعیت مکانی شما غیر فعال است.لطفا ان را در تنظیمات فعال کنید";
+"wait_several_minutes" = "ممکن است چند دقیقه طول بکشد.\nلطفا صبر کنید…";
 
 /* Measurement units title in settings activity */
 "measurement_units" = "واحد اندازه گیری";
 
 /* Detailed description of Measurement Units settings button */
 "measurement_units_summary" = "بین مایل و کیلومتر انتخاب کنید";
-
-/* Do search in all sources */
-"search_mode_all" = "همه جا";
-
-/* Do search near my position only */
-"search_mode_nearme" = "اطراف من";
-
-/* Do search in current viewport only */
-"search_mode_viewport" = "روی صفحه نمایش بده";
 
 /* Search category for cafes, bars, restaurants */
 "eat" = "کجا غذا بخوریم";
@@ -266,14 +207,8 @@
 /* Search category */
 "police" = "پلیس";
 
-/* String in search result list, when nothing found */
-"no_search_results_found" = "نتیجه ای یافت نشد";
-
 /* Notes field in Bookmarks view */
 "description" = "یادداشت ها";
-
-/* Button text */
-"share_by_email" = "اشتراک گذاری به وسیله ایمیل";
 
 /* Email Subject when sharing bookmarks category */
 "share_bookmarks_email_subject" = "Organic Maps bookmarks were shared with you";
@@ -295,26 +230,11 @@
 /* Warning message when doing search around current position */
 "unknown_current_position" = "مکان شما هنوز مشخص نشده است";
 
-/* Warning message when location country isn't downloaded during search (see also download_location_map_proposal). */
-"download_location_country" = "دانلود نقشه مکان فعلی شما (%@)";
-
-/* Warning message when viewport country isn't downloaded during search */
-"download_viewport_country_to_search" = "Download the country you are searching on (%@)";
-
 /* Alert message that we can't run Map Storage settings due to some reasons. */
 "cant_change_this_setting" = "متاسفانه,تنظیمات ذخیره سازی نقشه در حال حاظر غیر فعال است";
 
 /* Alert message that downloading is in progress. */
 "downloading_is_active" = "دانلود نقشه اکنون در حال انجام است";
-
-/* Message that will be shown in alert view, when we ask user to leave review on App Store */
-"appStore_message" = "امیدواریم از استفاده از این اپ لذت برده باشد!اگر اینطور است به این اپ در استور ستاره بدهید و نظر خود را بنویسید.این کار کمتر از یک دقیقه زمان می برد اما حقیقتا می تواند به ما کمک کند.از حمایت صمیمانه تان متشکریم.";
-
-/* No, thanks */
-"no_thanks" = "نه ,متشکرم";
-
-/* Share one specific bookmark using SMS, %1$@ contains om:// and %2$@ https://omaps.app link. @NOTE non-ascii symbols in the link will result in max 70 characters SMS instead of 140. */
-"bookmark_share_sms" = "Hey, check out my pin at Organic Maps! %1$@ or %2$@ Don't have offline maps installed? Download here: https://omaps.app/get";
 
 /* Share my position using SMS, %1$@ contains om:// and %2$@ https://omaps.app link WITHOUT NAME. @NOTE non-ascii symbols in the link will result in max 70 characters SMS instead of 140. */
 "my_position_share_sms" = "Hey, check out my current location in Organic Maps! %1$@ or %2$@ Don't have offline maps? Download here: https://omaps.app/get";
@@ -328,23 +248,11 @@
 /* Share my position using EMail, %1$@ is om:// and %2$@ is https://omaps.app link WITHOUT NAME */
 "my_position_share_email" = "Hi,\n\nI'm here now: %1$@. Click this link %2$@ or this one %3$@ to see the place on the map.\n\nThanks.";
 
-/* Android share by Message/SMS button text (including SMS) */
-"share_by_message" = "اشتراک گذاری از طریق پیامک";
-
 /* Share button text which opens menu with more buttons, like Message, EMail, Facebook etc. */
 "share" = "اشتراک گذاری";
 
-/* iOS share by Message button text (including SMS) */
-"message" = "پیامک";
-
 /* Share by email button text, also used in editor. */
 "email" = "ایمیل";
-
-/* Copy Link */
-"copy_link" = "کپی لینک";
-
-/* Text for the button that returns to caller application */
-"more_info" = "نمایش اطلاعات بیشتر";
 
 /* Text for message when used successfully copied something */
 "copied_to_clipboard" = "کپی در کلیپ برد :%1$@";
@@ -354,15 +262,6 @@
 
 /* Used for bookmark editing */
 "done" = "انجام شد";
-
-/* Summary for preferences in MWM */
-"yopme_pref_summary" = "انتخاب تنظیمات پس ضمینه";
-
-/* Title for yopme preferences in MWM */
-"yopme_pref_title" = "تنظیمات پس ضمینه";
-
-/* Hint for upper-right icon p2b */
-"show_on_backscreen" = "نمایش در پس زمینه";
 
 /* Prints version number in About dialog */
 "version" = "ورژن: %@";
@@ -381,19 +280,11 @@
 
 "share_my_location" = "به اشتراک گذاری موقعیت مکانی من";
 
-"menu_search" = "جست‌وجو";
-
 /* Settings general group in settings screen */
 "prefs_group_general" = "تنظیمات عمومی";
 
 /* Settings information group in settings screen */
 "prefs_group_information" = "اطلاعات";
-
-/* Settings screen: "Map" category title */
-"prefs_group_map" = "نقشه";
-
-/* Settings screen: "Miscellaneous" category title */
-"prefs_group_misc" = "متفرقه";
 
 "prefs_group_route" = "مسیریابی";
 
@@ -419,9 +310,6 @@
 /* Settings «Map» category: «3D buildings» title */
 "pref_map_3d_buildings_title" = "ساختمان های سه بعدی";
 
-/* Settings «Map» category: «3D buildings» summary */
-"pref_map_3d_buildings_subtitle" = "تاثیر بر روی عمر باطری";
-
 /* Settings «Route» category: «Tts enabled» title */
 "pref_tts_enable_title" = "دستور العمل صوتی";
 
@@ -433,8 +321,6 @@
 
 /* Title for "Other" section in TTS settings. */
 "pref_tts_other_section_title" = "بیشتر";
-
-"pref_tts_how_to_set_up_voice" = "نحو راه اندازی صدا";
 
 /* Settings «Map» category: «Record track» title */
 "pref_track_record_title" = "مسیر اخیر";
@@ -455,56 +341,7 @@
 
 "recent_track_help_text" = "با این قابلیت شما می توانید مسیری که می پیمایید را در یک دوره مشخص ضبط نماید و ان را بر روی نقشه ببینید.لطفا توجه نمایید:فعال سازی این قابلیت باعث افزایش مصرف باتری موبایل شما می شود.مسیر به طور خودکار بعد از مدت مشخص شده حذف خواهد شد";
 
-"pref_track_ios_caption" = "Recent track shows your traveled path.";
-
-"pref_track_ios_subcaption" = "لطفا محدوده زمانی برای ذخیره مسیر را انتخاب کنید";
-
-"placepage_distance" = "مسافت";
-
-"placepage_coordinates" = "مختصات";
-
-"placepage_unsorted" = "نا منظم";
-
 "search_show_on_map" = "مشاهده بر روی نقشه";
-
-/* Used to warn user when fixing KitKat issue */
-"bookmark_move_fail" = "We need to move your bookmarks to internal memory, but there is no available space for them. Please free up the memory, otherwise bookmarks won’t be available.";
-
-/* Used in More Apps menu */
-"free" = "رایگان";
-
-/* Used in More Apps menu */
-"buy" = "خرید";
-
-/* 1st search button-like result */
-"search_on_map" = "جست‌وجو بر روی نقشه";
-
-/* toast with an error */
-"no_route_found" = "مسیری یافت نشد";
-
-/* route title */
-"route" = "مسیر";
-
-/* category title */
-"routes" = "مسیر ها";
-
-/* text of notification */
-"download_map_notification" = "دانلود نقشه جایی که هستید";
-
-/* text of notification */
-"pro_version_is_free_today" = "نسخه کامل Organic Maps امروز رایگان است!دانلود کنید و به دوستان خود نیز بگویید";
-
-/* Dialog for transferring maps from lite to pro. */
-"move_lite_maps_to_pro" = "ما در حال انتقال نقشه های دانلود شده شما از Organic Maps Lite به Organic Maps هستیم. ممکن است چند دقیقه طول بکشد.";
-
-/* Message to display when maps moved. */
-"move_lite_maps_to_pro_ok" = "نقشه های دانلود شده شما با موفقیت به Organic Maps منتقل شد.";
-
-/* Message to display when maps move failed. */
-"move_lite_maps_to_pro_failed" = "انتقال نقشه با شکست مواجه شد.لطفا Organic Maps Lite حذف کرده و نقشه ها را دوباره دانلود نماید";
-
-/* Text in menu */
-"settings_and_more" = "تنظیمات و بیشتر";
 
 /* Text in menu */
 "website" = "وب سایت";
@@ -527,14 +364,8 @@
 /* Text in menu */
 "openstreetmap" = "OpenStreetMap";
 
-/* Text in menu */
-"contact_us" = "تماس با ما";
-
 /* Settings: Send feedback button and dialog title */
 "feedback" = "بازخورد";
-
-/* Text in menu */
-"subscribe_to_news" = "اشتراک در خبرنامه ما";
 
 /* Text in menu */
 "rate_the_app" = "امتیاز به این اپلیکیشن";
@@ -548,15 +379,6 @@
 /* Text in menu */
 "report_a_bug" = "گزارش خطا";
 
-/* Email subject */
-"subscribe_me_subject" = "لطفا من را در خبرنامه Organic Maps مشترک کنید";
-
-/* Email body */
-"subscribe_me_body" = "من می خواهم اولین نفری باشم که در جریان اخرین اخبار واپدیت های نرم افزار قرار می گیرم.می دانم در هر زمان میتوان این اشتراک را لغو کرد.";
-
-/* About text */
-"about_text" = "Organic Maps  به شما سریع ترین نقشه های تمامی شهر ها و کشور های جهان را پیشنهاد می دهد. در هرجایی که هستید با اطمینان کامل سفر کنید. Organic Maps کمک می مند تا موقعیت خود و نزدیک ترین هتل ها,بانک ها,جایگاه های سوخت و چیز های دیگر را بر روی نقشه بیابید.وای کارهیچ نیازی به اتصال اینترنتی ندارد. \n\nما همیشه بر روی قابلیت های جدید کار می کنیم و دوست داریم که از طرف شما بشنویم که چطور می توانیم این نرم افزار مسیر یابی را بهتر از قبل نماییم. اگر هر مشکلی با برنامه داشتید تردید نکنید و در support@organicmaps.app با ما تماس بگیرید.ما به تمامی درخواست ها پاسخ می دهیم! \n\n از Organic Maps راضی هستید و می خواهید از ما حمایت کنید؟ چند راه کاملا رایگان وجود دارد\n- برای ما یک نظر در فروشگاه نرم افزاری بنویسید \n- صفحه فیسبوک ما را http://www.facebook.com/OrganicMaps لایک کنید \n- یا از Organic Maps به مادرتان دوستانتان وهم دانشگاهیانتان بگویید:))\n\n متشکروسپاس گذاریم که با ما همکاری می کنید\n\nP.S. مانقشه های خود را از OpenStreetMap دریافت می کنیم این سایت همانند ویکیپدیا برای نقشه برداری است و به تمام کاربران خود اجازه می دهد تا در تکمیل نقشه ها کمک کنند اگر در نقشه مشاهده نمودید چیزی اشتباه بود یا وجود نداشت شما می توانید ان را مستقیما در سایت https://www.openstreetmap.org تصحیح یا اضافه کنید  و تغییرات ای را که ایجاد کرده اید را در اپدیت بعدی Organic Maps ببینید";
-
 /* Alert text */
 "email_error_body" = "کلاینت ایمیل شما پیکربندی نشده است.لطفا ان را پیکربندی کنید یا از طریق دیگر با ما تماس بگیرید %@";
 
@@ -569,12 +391,6 @@
 /* Search category */
 "wifi" = "وای فای";
 
-/* Update map suggestion */
-"routing_map_outdated" = "لطفا نقشه خود را برای ایجاد مسیر اپدیت نمایید";
-
-/* Update maps suggestion */
-"routing_update_maps" = "نسخه جدید Organic Maps به شما اجازه ایجاد یک مسیر از موقعیت فعلیتان به مقصدتان را می دهد.لطفابرای استفاده از این ویژگی نقشه خود را اپدیت نمایید.";
-
 /* Update all button text */
 "downloader_update_all_button" = "اپدیت همه";
 
@@ -583,9 +399,6 @@
 
 /* Downloaded maps category */
 "downloader_downloaded_subtitle" = "دانلود شده";
-
-/* Downloaded maps category */
-"downloader_available_maps" = "موجود";
 
 /* Country queued for download */
 "downloader_queued" = "صف";
@@ -598,17 +411,6 @@
 
 "downloader_downloading" = "درحال دانلود:";
 
-"downloader_search_results" = "یافت شد";
-
-/* Disclaimer message */
-"routing_disclaimer" = "Creating routes in Organic Maps app, please keep in mind the following:\n\n  - Suggested routes can be considered as recommendations only.\n - Road conditions, traffic rules and signs have higher priority than navigation advice.\n - The map may be incorrect or outdated, and routes may not be created the best possible way.\n\n  Be safe on roads and take care of yourself!";
-
-/* Outdated maps category */
-"downloader_outdated_maps" = "منسوخ شده";
-
-/* Up to date maps category */
-"downloader_uptodate_maps" = "به روز";
-
 /* Status of outdated country in the list */
 "downloader_status_outdated" = "به روز رسانی";
 
@@ -618,49 +420,14 @@
 /* Displayed in a dialog that appears when a user tries to delete a map while the app is in the follow route mode */
 "downloader_delete_map_while_routing_dialog" = "برای حذف نقشه لطفا مسیر یابی را متوقف کنید";
 
-/* Show when user try build route, but we don't know where he */
-"routing_failed_unknown_my_position" = "مکان شما نا مشخص است,لطفا قبل از ایجاد مسیر مکان خود را مشخص کنید.";
-
-/* Show if use has not routing file, or InconsistentMWMandRoute */
-"routing_failed_has_no_routing_file" = "برای ایجاد مسیر به دیتای اضافی نیاز است.اکنون ان را دانلود می کنید؟";
-
-/* StartPointNotFound */
-"routing_failed_start_point_not_found" = "نمی توان مسیر را محاسبه کرد.در نزدیکی نقطه شروع شما جاده ای نیست.";
-
-/* EndPointNotFound */
-"routing_failed_dst_point_not_found" = "نمی توان مسیر را محاسبه کرد.در نزدیکی مقصد مورد نظر شما جاده ای نیست.";
-
 /* PointsInDifferentMWM */
 "routing_failed_cross_mwm_building" = "تنها مسیر هایی می توانند ایجاد شوند که به طور کامل در یک نقشه از یک منطقه واحد قرار داشته باشند.";
-
-/* RouteNotFound */
-"routing_failed_route_not_found" = "مسیری بین مبدا و مقصد انتخابی یافت نشد.لطفا مبدا یا مقصد دیگری را انتخاب کنید";
-
-/* InternalError */
-"routing_failed_internal_error" = "خطای داخلی اتفاق افتاد.لطفا تلاش کنید نقشه را حذف و مجددا دانلود کنید.اگر همچنان مشکل پابرجاست لطفا با ما تماس بگیرید support@organicmaps.app.";
-
-/* Context menu item for downloader. */
-"downloader_download_map_and_routing" = "دانلود نقشه + مسیریابی";
-
-/* Context menu item for downloader. */
-"downloader_download_routing" = "دانلود  مسیریابی";
-
-/* Context menu item for downloader. */
-"downloader_delete_routing" = "حذف مسیریابی";
 
 /* Context menu item for downloader. */
 "downloader_download_map" = "دانلود نقشه";
 
-"downloader_download_map_no_routing" = "دانلود نقشه بدون مسیریابی";
-
-/* Button for routing. */
-"routing_go" = "برو!";
-
 /* Item status in downloader. */
 "downloader_retry" = "تلاش مجدد";
-
-/* Item in context menu. */
-"downloader_map_and_routing" = "نقشه + مسیریابی";
 
 /* Item in context menu. */
 "downloader_delete_map" = "حذف نقشه";
@@ -668,29 +435,11 @@
 /* Item in context menu. */
 "downloader_update_map" = "به روز رسانی نقشه";
 
-/* Item in context menu. */
-"downloader_update_map_and_routing" = "به روز رسانی نقشه + مسیریابی";
-
-/* Item in context menu. */
-"downloader_map_only" = "فقط نقشه";
-
-/* Toolbar title */
-"toolbar_application_menu" = "منوی برنامه";
-
 /* Preference text */
 "pref_use_google_play" = "استفاده از Google Play Services برای تعیین موقعیت کنونی شما";
 
 /* Text for rating dialog */
 "rating_just_rated" = "I’ve just rated your app";
-
-/* Text for rating dialog */
-"rating_user_since" = "I’ve been a Organic Maps user since %@";
-
-/* Text for rating dialog */
-"rating_do_like_maps" = "Organic Maps را می پسندید؟";
-
-/* Text for rating dialog */
-"rating_tap_star" = "بر روی ستاره ها لمس کنید تا به این اپ رای بدهید";
 
 /* Text for rating dialog */
 "rating_thanks" = "متشکریم!";
@@ -701,23 +450,8 @@
 /* Text for rating dialog */
 "rating_send_feedback" = "ارسال بازخورد";
 
-/* Text for g+ dialog */
-"rating_google_plus" = "بر روی g+ کلیک کنید و از این برنامه برایشان بگویید.";
-
 /* Text for routing error dialog */
 "routing_download_maps_along" = "دانلود تمامی نقشه ها در طول مسیر تان";
-
-/* Text for routing error dialog */
-"routing_download_map" = "دریافت نقشه";
-
-/* Text for routing error dialog */
-"routing_download_map_and_routing" = "برای داشتن تمامی ویژگی های Organic Maps نقشه ها و داده های مسیریابی را اپدیت نمایید.";
-
-/* Text for routing error dialog */
-"routing_get_routing_data" = "دریافت داده های مسیریابی";
-
-/* Text for routing error dialog */
-"routing_get_additional_data" = "مقداری دیتای اضافی برای ایجاد مسیر در موقعیت شما نیاز است.";
 
 /* Text for routing error dialog */
 "routing_requires_all_map" = "به منظور ایجاد مسیر ما نیاز داریم تا تمامی نقشه های شما از مبدا تا مقصد را به روز رسانی کنیم.";
@@ -725,50 +459,15 @@
 /* Text for routing error dialog */
 "routing_not_enough_space" = "فضای کافی موجود نیست";
 
-/* Text for routing error dialog */
-"routing_download_more_than_avail" = "شما نیاز به دانلود %@ مگابایت دارید, اما تنها %@ مگابایت موجود است.";
-
-/* Text for routing error dialog */
-"routing_download_roaming" = "شما قصد دانلود %@ MB و استفاده از دیتای موبایل را دارید.این کار ممکن است بر حسب اپراتور موبایلتان هزینه های اضافی برای شما در بر داشته باشد";
-
 /* bookmark button text */
 "bookmark" = "نشانه ها";
-
-/* map is not downloaded */
-"not_found_map" = "نقشه ای برای موقعیت مکانی شما دانلود نشده است";
 
 /* location service disabled */
 "enable_location_services" = "لطفا موقعیت مکانی(GPS)خود را فعال کنید.";
 
-/* download map */
-"download_map" = "دانلود نقشه برای موقعیت مکانی شما";
-
-/* download map on iPhone */
-"download_map_iphone" = "دانلود نقشه برای موقعیت مکانی شما بر روی ایفون تان";
-
-/* clear pin */
-"nearby" = "در این نزدیکی";
-
-/* clear pin */
-"clear_pin" = "پاک کردن نشانه";
-
-/* location is undefined */
-"undefined_location" = "موقعیت مکانی شما یافت نشد.";
-
-/* download country of your location */
-"download_country" = "دانلود نقشه کشور مقعیت کنونی شما";
-
-/* download failed */
-"download_failed" = "دانلود ناموفق";
-
-/* get the map */
-"get_the_map" = "دریافت نقشه";
-
 "save" = "ذخیره";
 
 "edit_description_hint" = "توضیحات شما (متن یا  (html";
-
-"new_group" = "مجموعه جدید";
 
 "create" = "ایجاد";
 
@@ -795,30 +494,6 @@
 
 /* pink color */
 "pink" = "صورتی";
-
-/* deep purple color */
-"deep_purple" = "ارغوانی سیر";
-
-/* light blue color */
-"light_blue" = "آبی کمرنگ";
-
-/* cyan color */
-"cyan" = "فیروزه ای";
-
-/* teal color */
-"teal" = "آبی سیر";
-
-/* lime color */
-"lime" = "زرد لیویی";
-
-/* deep orange color */
-"deep_orange" = "نارنجی سیر";
-
-/* gray color */
-"gray" = "خاکستری";
-
-/* blue gray color */
-"blue_gray" = "خاکستری کبود";
 
 /* Wi-Fi available */
 "WiFi_available" = "بلی";
@@ -848,13 +523,9 @@
 
 "dialog_routing_location_unknown_turn_on" = "ناتوان از مشخص کردن موقعیت مکانی شما.لطفا سرویس موقعیت مکانی خود را فعال کنید.";
 
-"dialog_routing_location_unknown" = "ناتوان از مشخص کردن موقعیت مکانی شما.";
-
 "dialog_routing_download_files" = "دانلود فایل های مورد نیاز";
 
 "dialog_routing_download_and_update_all" = "Download and update all map and routing information along the projected path to calculate route.";
-
-"dialog_routing_routes_size" = "فایل های اطلاعات مسیر یابی";
 
 "dialog_routing_unable_locate_route" = "ناتوان در تعیین مسیر";
 
@@ -884,21 +555,11 @@
 
 "dialog_routing_try_again" = "لطفا دوباره تلاش کنید";
 
-"dialog_routing_send_error" = "گزارش مشکل";
-
-"dialog_routing_if_get_cross_route" = "ایا می خواهید یک مسیر مستقیم تر که بیش از یک نقشه را شامل می شود ایجاد کنید؟";
-
-"dialog_routing_cross_route_is_optimal" = "مسیر های بهینه بیشتری موجود است که حاشیه این نقشه را رد می کند .";
-
 "not_now" = "اکنون خیر";
-
-"dialog_routing_build_route" = "ایجاد کردن";
 
 "dialog_routing_download_and_build_cross_route" = "ایا مایل به دانلود نقشه و ایجاد مسیر های بهینه بیشتری که نقشه های بیشتری را پوشش میدهد هستید؟";
 
 "dialog_routing_download_cross_route" = "دانلود نقشه های اضافی برای ایجاد مسیری بهتر که حاشیه های این نقشه را رد می کند.";
-
-"dialog_routing_cross_route_always" = "همیشه این مرز را رد کن";
 
 
 /********** Strings for downloading map from search **********/
@@ -906,8 +567,6 @@
 "search_without_internet_advertisement" = "برای شروع جستوجو و مسیر یابی لطفا نقشه رادانلود کنید بعد از ان دیگر نیازی به اتصال به اینترنت ندارید و برنامه کاملا افلاین اجرا می شود.";
 
 "search_select_map" = "انتخاب نقشه";
-
-"search_select_other_map" = "انتخاب نقشه ی دیگر";
 
 /* «Show» context menu */
 "show" = "نمایش";
@@ -918,17 +577,11 @@
 /* «Rename» context menu */
 "rename" = "تغیر نام";
 
-/* Bottom sheet: expand button (should be short) */
-"bottom_sheet_more" = "بیشتر";
-
 /* Failed planning route message in navigation view */
 "routing_planning_error" = "برنامه ریزی مسیر ناموفق";
 
 /* Arrive routing message in navigation view */
 "routing_arrive" = "ورود به: %s";
-
-/* Text for routing::RouterResultCode::FileTooOld dialog. */
-"dialog_routing_download_and_update_maps" = "Download and update all map along the projected path to calculate route.";
 
 "rate_alert_title" = "این اپ را دوست دارید؟";
 
@@ -944,19 +597,11 @@
 
 "history" = "تاریخچه";
 
-"next_turn_then" = "سپس";
-
 "closed" = "تعطیل";
-
-"back_to" = "بازگشت به %@";
 
 "search_not_found" = "متاسفانه چیزی پیدا نشد";
 
 "search_not_found_query" = "با تغییر در معیار های جست و جو دوباره امتحان کنید";
-
-"search_not_found_map" = "لطفا نقشه ای را که در ان جست و جو می کنید را دانلود کنید";
-
-"search_not_found_location" = "نقشه موقعیت مکانی تان را دانلود کنید";
 
 "search_history_title" = "سوابق جست وجو";
 
@@ -964,23 +609,12 @@
 
 "clear_search" = "پاک کردن سابقه جست وجو ها";
 
-/* Title for settings to enable/disable showcase menu button */
-"showcase_settings_title" = "نمایش پیشنهاد ها";
-
 /* Place Page link to Wikipedia article (if map object has it). */
 "read_in_wikipedia" = "ویکی پدیا";
 
-"p2p_route_planning" = "برنامه ریزی مسیر";
-
 "p2p_your_location" = "موقعیت شما";
 
-"p2p_from" = "از";
-
-"p2p_to" = "به";
-
 "p2p_start" = "شروع";
-
-"p2p_planning" = "درحال برنامه ریزی";
 
 "p2p_from_here" = "مسیر از";
 
@@ -1018,15 +652,9 @@
 
 "editor_correct_mistake" = "تصحیح خطا";
 
-"editor_correct_mistake_message" = "شما یک ویرایش اشتباه انجام دادید.لطفا ان را اصلاح کنید یا به حالت ساده بروید";
-
 "editor_add_select_location" = "موقعیت";
 
 "editor_done_dialog_1" = "شما نقشه جهان را تغییر دادید.این افتخار را پیش خود نگه ندارید!به دوستانتان درموردش بگویید و با یکدیگر ویرایش کنید.";
-
-"editor_done_dialog_2" = "این دومین بار است که نقشه را ویرایش می کنید.اکنون شما شماره %d در رنکینگ ویرایشگران هستید.در موردش به دوستانتان بگویید.";
-
-"editor_done_dialog_3" = "شما باعث بهتر شدن نقشه شدید در موردش به دوستانتان بگویید و با یکدیگر بر روی نقشه کار کنید.";
 
 "share_with_friends" = "اشتراک گذاری با دوستان";
 
@@ -1044,20 +672,7 @@
 
 "editor_report_problem_duplicate_place_title" = "مکان تکراری";
 
-"first_launch_congrats_title" = "Organic Maps اماده استفاده است";
-
-"first_launch_congrats_text" = "در سرتاسر دنیا جست وجو و مسیریابی کنید بدون نیاز به اینترنت و کاملا رایگان.";
-
-"migrate_title" = "مهم!";
-
-/* Android uses image instead of text. */
-"download_all" = "دانلود همه";
-
-"delete_all" = "حذف همه";
-
 "autodownload" = "دانلود خودکار";
-
-"disable_autodownload" = "لغو دانلود خودکار";
 
 /* Place Page opening hours text */
 "closed_now" = "اکنون تعطیل است";
@@ -1072,10 +687,6 @@
 "day_off" = "تعطیل است";
 
 "today" = "امروز";
-
-"sunrise_to_sunset" = "از طلوع خورشید تا غروب افتاب";
-
-"sunset_to_sunrise" = "از غروب خورشید تا طلوع خورشید";
 
 "add_opening_hours" = "اضافه کردن ساعت بازگشایی";
 
@@ -1095,45 +706,18 @@
 
 "forgot_password" = "رمز عبور خود را فراموش کردید؟";
 
-/* Forgot Password dialog title */
-"restore_password" = "بازیابی رمز عبور";
-
-"enter_email_address_to_reset_password" = "ادرس ایمیلی را که در هنگام ثبت نام استفاده کردید را وارد کنید و ما برای شما لینک بازیابی رمز عبور را خواهیم فرستاد.";
-
-"reset_password" = "بازیابی رمز عبور";
-
-"username" = "نام کاربری";
-
 "osm_account" = "حساب OSM";
 
 "logout" = "خروج از حساب";
 
-"login_and_edit_map_motivation_message" = "وارد شوید و اشیا درون نقشه را ویرایش کنید و ما ان را برای میلیون ها کاربر مهیا می کنیم.بزن بریم و یه دنیای بهتر با هم بسازیم.";
-
 /* Information text: "Last upload 11.01.2016" */
 "last_upload" = "اخرین بروزرسانی";
 
-/* Motivates user to login/register, title above login buttons. */
-"you_have_edited_your_first_object" = "شما اولین ویرایشتان را انجام دادید!";
-
 "thank_you" = "متشکریم";
-
-"login_with_google" = "ورود با حساب گوگل";
-
-"login_with_openstreetmap" = "ورود با حساب www.openstreetmap.org";
 
 "edit_place" = "ویرایش مکان";
 
 "place_name" = "نام مکان";
-
-/* title above languages list cells in the editor, below editable name text field. */
-"other_languages" = "زبان های دیگر";
-
-/* small button to open list with names in different languages */
-"show_more" = "نمایش بیشتر";
-
-/* small button to close list with names in different languages */
-"show_less" = "نمایش کمتر";
 
 "add_language" = "افزودن یک زبان";
 
@@ -1164,8 +748,6 @@
 
 "please_note" = "لطفا توجه داشته باشد";
 
-"common_no_wifi_dialog" = "اتصال وایفای یافت نشد.ایا می خواهید با اینترنت دیتای موبایل ادامه دهید؟";
-
 "downloader_delete_map_dialog" = "تمام ویرایش های که بر روی نقشه انجام داده اید به همراه نقشه حذف شد.";
 
 "downloader_update_maps" = "بروزرسانی نقشه ها";
@@ -1173,10 +755,6 @@
 "downloader_mwm_migration_dialog" = "برای ایجاد مسیر شما نیازمند بروزرسانی تمامی  نقشه ها هستید سپس می توانید دوباره مسیرتان را برنامه ریزی کنید";
 
 "downloader_search_field_hint" = "یافتن نقشه";
-
-"migration_update_all_button" = "بروزرسانی تمامی نقشه ها";
-
-"migration_delete_all_download_current_button" = "دانلود نقشه کنونی و حذف قدیمی ها";
 
 "migration_download_error_dialog" = "خطا در دانلود";
 
@@ -1186,21 +764,9 @@
 
 "downloader_no_space_message" = "لطفا داده های غیر ضروری را از دستگاه خود حذف کنید";
 
-"editor_general_auth_error_dialog" = "General login error.";
-
 "editor_login_error_dialog" = "خطای ورود";
 
-"editor_login_failed_dialog" = "ورود ناموفق";
-
-"editor_username_error_dialog" = "نام کاربری نامعتبر است";
-
-"editor_place_edited_dialog" = "شما یک شئی را ویرایش کردید";
-
-"editor_login_with_osm" = "ورود با استفاده از OpenStreetMap";
-
 "editor_profile_changes" = "تغییرات تایید شد";
-
-"editor_profile_unsent_changes" = "ارسال نشد:";
 
 "editor_focus_map_on_location" = "برای انتخاب مکان صحیح شئی نقشه را بکشید.";
 
@@ -1222,13 +788,9 @@
 
 "editor_report_problem_other_title" = "مشکلی دیگر";
 
-"placepage_report_problem_button" = "گزارش یک مشکل";
-
 "placepage_add_business_button" = "اضافه کردن یک تجارت";
 
 "whatsnew_editor_message_1" = "اضافه کردن مکان به نقشه و ویرایش ان مستقیما از طریق این اپلیکیشن.";
-
-"whatsnew_editor_message_2" = "* Organic Maps از دیتای انجمن  OpenStreetMap.";
 
 "dialog_incorrect_feature_position" = "تغییر موقعیت";
 
@@ -1236,16 +798,10 @@
 
 "login_to_make_edits_visible" = "وارد شوید تا دیگر کاربران نیز بتوانند تغییرات ایجاد شده توسط شما را ببینند";
 
-"no_migration_during_navigation" = "بروزرسانی در حین مسیریابی مجاز نیست.";
-
 /* Error dialog no space */
 "migration_no_space_message" = "برای دانلود,شما نیازمند فضای ذخیره سازی بیشتری هستید.لطفا داده های غیر ضروری خود را حذف کنید.";
 
 "editor_sharing_title" = "من نقشه های Organic Maps را بهبود بخشیدم";
-
-"editor_comment_will_be_sent" = "ما مطمئن خواهیم شد که پیام خود را به ویرایشگران نقشه ارسال خواهید کرد.";
-
-"editor_unsupported_category_message" = "شما شی ای را دسته بندی کرده اید که ما تاکنون از ان پشتیبانی نمی کرده ایم.ما ان را در اینده در نقشه نشان خواهیم داد.";
 
 /* Downloaded 10 **of** 20 <- it is that "of" */
 "downloader_of" = "%1$d  از  %2$d";
@@ -1278,23 +834,9 @@
 
 "editor_operator" = "مالک";
 
-"editor_tag_description" = "نام شرکت,سازمان یا اطلاعات قابل قبول برای این ساختمان را وارد کنید.";
-
-"editor_no_local_edits_title" = "شما ویرایش محلی ندارید";
-
-"editor_no_local_edits_description" = "This shows the number of your suggested changes on the map that are currently accessible only on your device.";
-
-"editor_send_to_osm" = "ارسال به OSM";
-
-"editor_remove" = "پاک کردن";
-
-"downloader_my_maps_title" = "نقشه های من";
-
 "downloader_no_downloaded_maps_title" = "شما هیچ نقشه دانلود شده ای ندارید";
 
 "downloader_no_downloaded_maps_message" = "برای جست وجو یک مکان و استفاده از قابلیت ناوبری, نقشه ها را دانلود کنید.";
-
-"downloader_find_place_hint" = "جست وجوی شهر یا کشور";
 
 /* Error title that appears after certain time without location. */
 "current_location_unknown_title" = "ایا یافتن مکان تان را ادامه می دهید؟";
@@ -1321,47 +863,13 @@
 /* iOS Dialog for the case when the location permission is not granted */
 "location_services_disabled_3" = "3. Select While Using the App";
 
-"placepage_parking_surface" = "سطح";
-
-"placepage_parking_multistorey" = "چند طبقه";
-
-"placepage_parking_underground" = "زیرزمین";
-
-"placepage_parking_rooftop" = "پشت بام";
-
-"placepage_parking_sheds" = "سایبان";
-
-"placepage_parking_carports" = "گاراژ بدون سقف";
-
-"placepage_parking_boxes" = "گاراژ";
-
-"placepage_parking_pay" = "پرداخت";
-
-"placepage_parking_free" = "مجانی";
-
-"placepage_parking_interval" = "Interval Pay";
-
-"placepage_entrance_number" = "شماره.";
-
-"placepage_entrance_type" = "ورودی";
-
-"placepage_flat" = "app.";
-
-"placepage_open_24_7" = "شبانه روزی و هفت روز هفته (24 / 7)";
-
 "meter" = "متر";
 
 "kilometer" = "کیلومتر";
 
-"kilometers_per_hour" = "کیلومتربرساعت (km/h)";
-
 "mile" = "مایل";
 
 "foot" = "فوت";
-
-"miles_per_hour" = "مایل بر ساعت (mph)";
-
-"day" = "روز";
 
 "hour" = "ساعت";
 
@@ -1381,10 +889,6 @@
 
 "placepage_bookmark_name_hint" = "نام نشانه ها";
 
-"placepage_personal_notes_hint" = "یاداشت های شخصی";
-
-"placepage_delete_bookmark_button" = "حذف نشانه";
-
 "editor_edits_sent_message" = "تغییر پیشنهادی شما ارسال شد";
 
 "editor_comment_hint" = "اظهار نظر";
@@ -1397,11 +901,9 @@
 
 "editor_remove_place_button" = "حذف";
 
-"editor_status_sending" = "درحال ارسال";
-
 "editor_place_doesnt_exist" = "مکان وجود ندارد";
 
-"text_more_button" = "بیشتر....";
+"text_more_button" = "بیشتر….";
 
 /* Phone number error message */
 "error_enter_correct_phone" = "شماره تلفن معتبری وارد نمایید";
@@ -1410,11 +912,7 @@
 
 "error_enter_correct_email" = "ایمیل معتبری وارد نمایید";
 
-"error_enter_correct" = "مقادیر معتبری وارد نمایید";
-
 "refresh" = "بروزرسانی";
-
-"last_update" = "اخرین بروزرسانی: %s";
 
 "placepage_add_place_button" = "اضافه کردن یک مکان به نقشه";
 
@@ -1426,24 +924,6 @@
 
 "editor_share_to_all_dialog_message_2" = "ما تغییرات را بررسی می کنیم.اگر سوالی بود با ایمیل با شما تماس می گیریم.";
 
-"navigation_overview_button" = "بررسی اجمالی";
-
-"navigation_stop_button" = "توقف";
-
-/* Text on an empty bookmark page */
-"bookmarks_empty_title" = "ذخیره نشانه ها";
-
-"bookmarks_empty_message_1" = "برروی ★ کلیک کنید تا در علاقه مندی ها برای دسترسی سریع ذخیره شود.";
-
-"bookmarks_empty_message_2" = "وارد کردن نشانه ها از ایمیل یا وب.";
-
-"bookmarks_empty_message_3" = "وارسی کنید: %s";
-
-/* Name of the group for booked hotels */
-"bookmarks_group_name" = "رزرو هتل ها";
-
-"place_page_button_read_descriprion" = "خواندن";
-
 /* iOS dialog for the case when recent track recording is on and the app comes back from background */
 "recent_track_background_dialog_title" = "غیرفعال سازی ذخیره مسیر اخیرا طی شده";
 
@@ -1451,8 +931,6 @@
 
 /* For sharing via SMS and so on */
 "sharing_call_action_look" = "بررسی کنید";
-
-"continue_recent_track_background_button" = "ادامه";
 
 "recent_track_background_dialog_message" = "Organic Maps  از اطلاعات موقعیت مکانی شما در پس ضمینه برای ذخیره مسیر هایی که اخیرا سفر کرده اید استفاده می کند.";
 
@@ -1468,33 +946,13 @@
 /* About short text (below logo) */
 "about_description" = "Organic Maps یک نرم افزار افلاین مخصوص سفر است. Organic Maps بر پایه دیتای OpenStreetMap است و به شما اجازه ویرایش در ان را می دهد.";
 
-/* Text in menu */
-"blog" = "وبلاگ";
-
 "general_settings" = "تنظیمات عمومی";
-
-"date" = "تاریخ %d";
-
-/* "Report a bug" -> "Generaal Feedback" -> "Something is not working" */
-"something_is_not_working" = "یه چیزی درست کار نمی کنه";
 
 /* For the first routing */
 "accept" = "موافقم";
 
-"accept_and_continue" = "قبول و ادامه";
-
 /* For the first routing */
 "decline" = "کاهش";
-
-"install_app" = "نصب";
-
-"search_no_results_title" = "چیزی یافت نشد";
-
-"search_no_results_message" = "چیز های عمومی تری را جست وجو کنید,کوچک نمایی کنید یا این فیلتر را پاک کنید.";
-
-"search_no_results_expand_area_button" = "کوچک نمایی";
-
-"search_no_results_reset_button" = "پاک کردن فیلتر";
 
 /* noun */
 "search_in_table" = "لیست";
@@ -1517,8 +975,6 @@
 
 "traffic_update_maps_text" = "برای نمایش ترافیک,نقشه می بایستی بروزرسانی شود.";
 
-"traffic_outdated" = "دیتای ترافیک منقضی شده است.";
-
 "big_font" = "افزایش اندازه متن بر روی نقشه";
 
 "traffic_update_app" = "لطفا Organic Maps را بروزرسانی کنید";
@@ -1529,17 +985,7 @@
 /* "traffic" as in "road congestion" */
 "traffic_data_unavailable" = "اطلاعات ترافیکی موجود نیست";
 
-/* "Translation is no needed, because it's a company name" */
-"uber" = "Uber";
-
-/* Simplified colour scheme for traffic information, fewer colours are used to display traffic jams on the map. The string should be kept as short as possible */
-"pref_traffic_simplified_colors_title" = "رنگ های ترافیکی ساده شده";
-
 "enable_logging" = "ورود به سیستم را فعال کنید";
-
-"offline_place_page_more_information" = "برای کسب اطلاعات بیشتر در مورد مکان، به اینترنت متصل شوید.";
-
-"failed_load_information" = "اطلاعات بارگیری نشد.";
 
 /* Settings: "Send general feedback" button */
 "feedback_general" = "\"تنظیمات: دکمه \"ارسال بازخورد کلی";
@@ -1556,8 +1002,6 @@
 
 "whatsnew_transliteration_title" = "ترجمه به لاتین";
 
-"yandex_taxi_title" = "Yandex.Taxi";
-
 "learn_more" = "بیشتر بدانید";
 
 "core_exit" = "خروج";
@@ -1568,75 +1012,19 @@
 
 "button_exit" = "خروج";
 
-"settings_device_memory" = "حافظه دستگاه";
-
-"settings_card_memory" = "کارت حافظه";
-
-"settings_storage_available" = "%s موجود";
-
-"toast_location_permission_denied" = "مجوز مکان برنامه صادر نشد";
-
-"button_use" = "استفاده";
-
 "planning_route_manage_route" = "مدیریت مسیر";
 
 "button_plan" = "برنامه";
-
-"button_add" = "افزودن";
 
 "placepage_remove_stop" = "حذف";
 
 "planning_route_remove_title" = "برای حذف اینجا بکشید";
 
-"dialog_change_start_point_message" = "مکان فعلی را به عنوان نقطه شروع تعیین کنید؟";
-
-"button_replace" = "جایگزین کردن";
-
 "placepage_add_stop" = "اضافه کردن توقف";
-
-/* Only ru/en are needed */
-"subtitle_rent" = "Rent";
-
-/* Only ru/en are needed */
-"rub_month" = "RUB/month";
-
-/* Only ru/en are needed */
-"room" = "%s-room apt.";
-
-/* Only ru/en are needed */
-"real_estate" = "Real estate";
-
-"add_my_position" = "موقعیت من را اضافه کنید";
-
-"choose_start_point" = "نقطه شروع را انتخاب کنید";
-
-"choose_destination" = "یک مقصد را انتخاب کنید";
 
 "preloader_viator_button" = "بیشتر بدانید";
 
-"start_from_my_position" = "شروع از";
-
-"profile_authorization_title" = "پیوستن با";
-
-"profile_authorization_message" = "وارد شدن آسان بدون ورود به سیستم و رمز عبور در چند ثانیه";
-
 "profile_authorization_error" = "اوه، یک خطا وجود داشت سعی کنید دوباره وارد سیستم شوید";
-
-"service" = "سرویس";
-
-"atmosphere" = "جو";
-
-"value_for_money" = "ارزش پول";
-
-"experience" = "تجربه";
-
-"assortment" = "انتخابی";
-
-"expertise" = "تجربه و تخصص";
-
-"equipment" = "تجهیزات";
-
-"quality" = "کیفیت";
 
 "dialog_error_storage_title" = "مشکل دسترسی به ذخیره سازی";
 
@@ -1644,17 +1032,7 @@
 
 "setting_emulate_bad_storage" = "شبیه سازی ذخیره سازی بد";
 
-"directions_finish" = "مقصد";
-
-"directions_on_foot" = "پیاده روی %s";
-
 "core_entrance" = "ورودی";
-
-"coffee" = "قهوه";
-
-"cleanliness" = "پاکیزگی";
-
-"crowdedness" = "ازدحام بیش از حد";
 
 "error_enter_correct_name" = "لطفا نام صحیح را وارد کنید";
 
@@ -1673,11 +1051,9 @@
 
 "downloader_percent" = "%s (%s از %s)";
 
-"downloader_process" = "در حال دانلود %s...";
+"downloader_process" = "در حال دانلود %s…";
 
-"downloader_applying" = "اعمال %s...";
-
-"dialog_message_transit_not_found_connection" = "یک مسیر را در یک شبکه حمل و نقل برنامه ریزی کنید";
+"downloader_applying" = "اعمال %s…";
 
 "bookmarks_error_message_share_general" = "با توجه به خطای برنامه، امکان اشتراک گذاری وجود ندارد";
 
@@ -1695,17 +1071,7 @@
 
 "bookmarks_error_message_list_name_already_taken" = "لطفا نام دیگری را انتخاب کنید";
 
-"bookmarks_error_title_list_name_too_long" = "این نام خیلی طولانی است";
-
-"bookmarks_error_message_list_name_too_long" = "لطفا نام دیگری را انتخاب کنید";
-
-"please_wait" = "لطفا صبر کنید...";
-
-"phone_number" = "شماره تلفن";
-
-"notification_unsent_reviews_title" = "شما چند نظر ارسال نشده دارید";
-
-"notification_unsent_reviews_message" = "لطفا برای اشتراک‌گذاری نظرات با سایر مسافرین وارد شوید";
+"please_wait" = "لطفا صبر کنید…";
 
 "profile" = "OpenStreetMap نمایه";
 
@@ -1719,49 +1085,13 @@
 
 "bookmarks_convert_error_message" = "بعضی از فایل‌ها تبدیل نشد.";
 
-"converting" = "در حال تبدیل...";
-
-"wn_reinvented_bookmarks_title" = "نشانه‌ها را بازآفرینی کردیم!";
-
-"wn_reinvented_bookmarks_message" = "می‌توانید از آن‌ها پشتیبان بگیرید، لیست درست کنید... عالی شده...";
-
-"bookmarks_restore" = "بازگردانی نشانه‌ها";
-
-"bookmarks_restore_process" = "در حال بازگردانی...";
-
 "bookmarks_restore_title" = "این نسخه برگردد؟";
 
-"bookmarks_restore_message" = "نشانه‌های شما از %s (%s) بازگردانده می‌شود";
-
-"bookmarks_restore_empty_title" = "فایل پشتیبان ندارید";
-
-"bookmarks_restore_empty_message" = "سرور پشتیبان‌هایی را که قبلا ساخته شده بودند پیدا نکرد";
-
 "common_check_internet_connection_dialog_title" = "اتصال اینترنتی برقرار نیست";
-
-"error_server_title" = "خطای سرور";
-
-"error_server_message" = "روی سرور خطایی رخ داد. لطفا بعدا امتحان کنید";
 
 "error_system_message" = "خطای ناشناخته‌ای رخ داد";
 
 "restore" = "بازیابی";
-
-"bookmarks_page_downloaded" = "دانلود شد";
-
-"bookmarks_page_my" = "مال من";
-
-"routes_and_bookmarks" = "مسیرها و نشانه‌ها";
-
-"bookmarks_webview_success_toast" = "نشانه‌ها با موفقیت دانلود شد";
-
-"cached_bookmarks_placeholder_title" = "دانلود مکان‌های جدید";
-
-"cached_bookmarks_placeholder_subtitle" = "دکمه را بزنید تا هزاران مکان و مسیر جالبی که دیگران کاربران Organic Maps ساخته‌اند را ببینید. به اتصال اینترنتی نیاز خواهید داشت.";
-
-"downloader_download_routers" = "دانلود نشانه‌ها";
-
-"bookmarks_groups_cached" = "لیست‌های دانلودشده";
 
 "subtittle_opt_out" = "تنظیمات ردیابی";
 
@@ -1769,19 +1099,9 @@
 
 "crash_reports_description" = "ما از داده‌های شما برای بهبود Organic Maps استفاده می‌کنیم. تغییرات پس از راه‌اندازی مجدد برنامه به‌کار می‌افتد.";
 
-"opt_out_help_ios_1" = "در دستگاه همراهتان تنظیمی با نام “Limit Ad Tracking” یا “Opt out of interest-based advertising” وجود دارد.";
-
-"opt_out_help_ios_2" = "آی‌اواس ۹ یا بالاتر";
-
-"opt_out_help_ios_3" = "به تنظیمات خود بروید ← حریم خصوصی ← تبلیغات ← گزینه  «محدود کردن ردیابی آگهی» را فعال کنید";
-
-"opt_out_help_android" = "دستگاه تلفن همراه شما ممکن است یک «ردیابی محدود آگهی» یا «لغو تبلیغات مبتنی بر علاقه» ارائه کند. \n \n برای Android و Google Play Services نسخه 4.0 و بالاتر: \n تنظیمات → Google → آگهی → غیرفعال کردن تبلیغات شخصی سازی \ یا \n تنظیمات → Google → حساب Google → اطلاعات شخصی و حریم خصوصی → تنظیمات تبلیغات → شخصی سازی تبلیغات";
-
 "privacy_policy" = "سیاست حریم خصوصی";
 
 "terms_of_use" = "شرایط استفاده";
-
-"backup_notification_failed" = "پشتیبانگیری از نشانکهای شما به حالت تعلیق درآمده است وارد شوید تا آن را دوباره روشن کنید";
 
 "button_layer_traffic" = "ترافیک";
 
@@ -1789,53 +1109,23 @@
 
 "layers_title" = "لایه های نقشه";
 
-"layers_message" = "از لایه های نقشه برای نمایش ترافیک، نقشه مترو و سایر اطلاعات مفید استفاده کنید";
-
-"button_layer_got_it" = "متوجه شدم";
-
 "subway_data_unavailable" = "نقشه مترو موجود نیست";
 
 "bookmarks_empty_list_title" = "این لیست خالی است";
 
 "bookmarks_empty_list_message" = "برای افزودن یک نشانه، روی یک مکان روی نقشه ضربه بزنید و سپس روی نماد ستاره ضربه بزنید";
 
-"category_desc_more" = "بیشتر...";
+"category_desc_more" = "بیشتر…";
 
 "title_error_downloading_bookmarks" = "خطایی رخ داد";
 
-"subtitle_error_downloading_bookmarks" = "نشانه ها دانلود نشدند";
-
-"error_already_downloaded" = "این لیست قبلا دانلود شده است";
-
 "popular_place" = "مشهور";
-
-"download_routes" = "دانلود مسیر";
-
-"bookmarks_downloaded_title" = "نشانکها با موفقیت دانلود شدند";
-
-"bookmarks_downloaded_subtitle" = "'نمایش بر روی نقشه' را فشار دهید تا مکان های جدید را از لیست کاوش کنید";
-
-"why_support" = "چرا پشتیبانی از Organic Maps؟";
-
-"why_support_item1" = "We respect your privacy: there are zero trackers in the app, and we are open source";
-
-"why_support_item2" = "شما برای بهبود Organic Maps به ما کمک میکنید";
-
-"why_support_item3" = "شما به ما در بهبود نقشه OpenStreetMap.org کمک میکنید.";
-
-"channels_map_update" = "بروزرسانی های نقشه";
-
-"server_unavailable_title" = "سرویس موجود نیست";
-
-"sharing_options" = "گزینه های اشتراک گذاری";
 
 "export_file" = "ارسال فایل";
 
 "list_settings" = "تنظیمات لیست";
 
 "delete_list" = "حذف لیست";
-
-"hide_from_map" = "پنهان کردن از نقشه";
 
 "public_access" = "دسترسی عمومی";
 
@@ -1845,40 +1135,11 @@
 
 "bookmark_category_description_hint" = "یک توضیح (متن یا html) تایپ نمایید";
 
-/* FIXME */
-"bookmarks_public_access" = "bookmarks_public_access";
-
-/* FIXME */
-"bookmarks_link_access" = "bookmarks_link_access";
-
-/* FIXME */
-"bookmarks_private_access" = "bookmarks_private_access";
-
 "not_shared" = "خصوصی";
-
-"direct_link_progress_text" = "در حال بارگذاری فایل شما…";
-
-"direct_link_success" = "لینک ایجاد شده است";
-
-"send_a_link_btn" = "یک لینک برای من ارسال کن";
-
-"upload_error_toast" = "هنگام بارگذاری فایل شما خطایی روی داد";
 
 "tags_loading_error_subtitle" = "هنگام بارگذاری برچسب خطایی رخ داد، لطفا دوباره امتحان کنید";
 
-"unable_upload_errorr_title" = "بارگذاری فایل انجام نشد";
-
-"unable_upload_error_subtitle_edited" = "این فایل از طریق برنامه وب ویرایش شده است";
-
-"unable_upload_error_subtitle_broken" = "این فایل آسیب دیده است و امکان بارگذاری آن وجود ندارد. لطفا فایل دیگری را بارگذاری نمایید.";
-
-"contact" = "تماس";
-
-"download_button" = "دانلود";
-
 "speedcams_alert_title" = "دوربین های سرعت";
-
-"speedcams_alert_subtitle" = "هشدار درباره محدودیت سرعت";
 
 "speedcam_option_auto" = "خودکار";
 
@@ -1886,18 +1147,10 @@
 
 "speedcam_option_never" = "هرگز";
 
-"bookmark_description_title" = "توضیحات نشانه گذاری";
-
 "place_description_title" = "توضیحات محل";
 
 /* this text will be shown in application notification preferences opposite checkbox which enable/disable downloader notifications. Devices on Android 8+ are affected. */
 "notification_channel_downloader" = "دانلود کننده نقشه";
-
-"share_bookmarks_email_body_link" = "سلام!\n\nاین لینکی است که شما می توانید نشان شده های خود را از آن دانلود نمایید: %s. لیست را از طریق Organic Maps باز کرده و از سفر خود لذت ببرید!\n\nدریافت برنامه: https://omaps.app/get?kmz";
-
-"warning_speedcams_title" = "هدایتگر هنگامی که از محدوده سرعت %d کیلومتر بر ساعت تجاوز نمایید، در مورد دوربین هشدار می دهد";
-
-"warning_speedcams_subtitle" = "لطفا قوانین رانندگی کشوری که به آن سفر می کنید، را رعایت کنید.";
 
 "speedcams_notice_message" = "خودکار- در صورتی که خطر تجاوز از سرعت مجاز وجود داشت، نسبت به دوربین های کنترل سرعت هشدار دهد\nهمیشه-همیشه درباره دوربین های کنترل سرعت هشدار دهد\nهرگز-هرگز درباره دوربین های کنترل سرعت هشدار ندهد";
 
@@ -1913,23 +1166,7 @@
 
 "enable_logging_warning_message" = "این گزینه ثبت گزارش را برای اهداف تشخیصی فعال می‌کند. برای کارکنان بخش پشتیبانی که مشکلات برنامه را عیب یابی می‌کنند، مفید باشد. این گزینه را تنها در صورت درخواست پشتیبانی Organic Maps فعال کنید.";
 
-"html_error_upload_message_try_again" = "لطفاً تنظیمات شبکه را بررسی و مجدد تلاش کنید";
-
-"html_error_upload_title_try_again" = "ارتباط اینترنت برقرار نیست";
-
-"notification_leave_review_v2_android_short_title" = "نظر خود را بیان و به مسافران کمک کنید!";
-
-"megafon" = "Say goodbye to roaming!";
-
-"notifications_illegal_alert_disable_button" = "خاموش کردن اعلان‌ها";
-
 "access_rules_author_only" = "ویرایش آنلاین";
-
-"privacy_settings_menu" = "تنظیمات حریم خصوصی";
-
-"unable_upadate_error_title" = "به روز رسانی فایل ناموفق بود";
-
-"unable_upadate_error_message" = "هنگام به روز رسانی برخی اشتباهات رخ داده است. لطفاً تغییرات را بررسی و مجدد تلاش کنید";
 
 "driving_options_title" = "گزینه های رانندگی";
 
@@ -1951,94 +1188,19 @@
 
 "change_driving_options_btn" = "گزینه های مسیریابی فعال شد";
 
-"toll_road" = "جاده دارای عوارض";
-
-"unpaved_road" = "جاده آسفالت نشده";
-
-"ferry_crossing" = "گذرگاه جاده ای";
-
-"operated_by" = "اجرا توسط \"%s\"";
-
 "avoid_toll_roads_placepage" = "اجتناب از جاده های دارای عوارض";
 
 "avoid_unpaved_roads_placepage" = "اجتناب از جاده های آسفالت نشده";
 
 "avoid_ferry_crossing_placepage" = "اجتناب از گذرگاه های کشتی";
 
-"type.cuisine.uzbek" = "غذای ازبکستانی";
-
-"trip_start" = "برویم";
-
-"pick_destination" = "مقصد";
-
-"follow_my_position" = "نشان دادن مجدد در مرکز";
-
-"search_results" = "نتایج جستجو";
-
-"then_turn" = "سپس";
-
-"redirect_route_alert" = "آیا می خواهید مسیر را دوباره ایجاد کنید?";
-
-"redirect_route_yes" = "بله";
-
-"redirect_route_no" = "خیر";
-
-"trip_finished" = "شما به مقصد رسیدید!";
-
-"keyboard_availability_alert" = "صفحه کلید در هنگام رانندگی در دسترس نیست";
-
-"dialog_routing_change_start_carplay" = "امکان ایجاد مسیر از مکان فعلی شما نیست";
-
-"dialog_routing_change_end_carplay" = "امکان ایجاد مسیر به مقصد شما نیست. لطفاً نقطه دیگری را انتخاب کنید";
-
-"dialog_routing_check_gps_carplay" = "سیگنال GPS وجود ندارد. لطفاً به فضای باز بروید";
-
-"dialog_routing_unable_locate_route_carplay" = "امکان ایجاد مسیر نیست. لطفاً نقاط مسیر دیگری را مشخص کنید";
-
-"dialog_routing_download_files_carplay" = "برای ایجاد مسیر، نقشه های ناقص را روی دستگاه خود را دانلود کنید";
-
-"dialog_routing_system_error_carplay" = "خطایی رخ داد. لطفاً برنامه را دوباره اجرا کنید";
-
-"dialog_routing_rebuild_from_current_location_carplay" = "مسیر از مکان فعلی شما بازسازی خواهد شد";
-
-"dialog_routing_rebuild_for_vehicle_carplay" = "مسیر به مسیر خودرویی تغییر خواهد کرد";
-
 "ok" = "موافقت کردن";
-
-"avoid_unpaved_carplay_1" = "بی جاده خاکی";
-
-"avoid_unpaved_carplay_2" = "پرهیز از خاکی";
-
-"avoid_ferry_carplay_1" = "بدون بزرگراه";
-
-"avoid_ferry_carplay_2" = "پرهیز از اتوبان";
-
-"avoid_tolls_carplay_1" = "بدون عوارضی";
-
-"avoid_tolls_carplay_2" = "اجتناب از عوارض";
-
-"speedcams_alert_title_carplay_1" = "دوربین سرعت";
-
-"speedcams_alert_title_carplay_2" = "هشدارهای سرعت";
-
-"download_map_carplay" = "لطفا نقشه ها را در نرم افزار Organic Maps روی دستگاه خود دانلود کنید";
-
-"carplay_roundabout_exit" = "خروجی %s";
 
 /* max. 10 symbols, both iOS and Android */
 "sort" = "مرتب سازی…";
 
 /* Android, title, max 20-22 symbols */
 "sort_bookmarks" = "مرتب سازی نشانهها";
-
-/* iOS */
-"sort_default" = "مرتب سازی بر اساس پیش فرض";
-
-"sort_type" = "مرتب سازی بر اساس نوع";
-
-"sort_distance" = "مرتب سازی بر اساس فاصله";
-
-"sort_date" = "مرتب سازی بر اساس تاریخ";
 
 /* Android */
 "by_default" = "به صورت پیش فرض";
@@ -2052,63 +1214,7 @@
 /* Android */
 "by_date" = "بر اساس تاریخ";
 
-"week_ago_sorttype" = "یک هفته قبل";
-
-"month_ago_sorttype" = "یک ماه قبل";
-
-"moremonth_ago_sorttype" = "بیش از یک ماه قبل";
-
-"moreyear_ago_sorttype" = "بیش از یک سال قبل";
-
-"near_me_sorttype" = "نزدیک من";
-
-"others_sorttype" = "دیگران";
-
-"food_places" = "غذا";
-
-"tourist_places" = "مناظر";
-
-"museums" = "موزهها";
-
-"parks" = "پارکها";
-
-"swim_places" = "شنا";
-
-"mountains" = "کوهها";
-
-"animals" = "حیوانات";
-
-"hotels" = "هتلها";
-
-"buildings" = "ساختمانها";
-
-"money" = "پول";
-
-"shops" = "مراکز خرید";
-
-"parkings" = "پارکینگها";
-
-"fuel_places" = "پمپ بنزین";
-
-"water" = "آب";
-
-"medicine" = "پزشکی";
-
 "search_in_the_list" = "جستجو در لیست";
-
-"view_on_map_bookmarks" = "روی نقشه";
-
-"more_bookmarks" = "بیشتر…";
-
-"no_items_found" = "هیچ موردی یافت نشد";
-
-/* Android, max 18 symbols */
-"bookmarks_edit_list" = "ویرایش فهرست";
-
-/* Android, max 18 symbols */
-"bookmarks_delete_list" = "حذف همه";
-
-"religious_places" = "اماکن مقدس";
 
 "select_list" = "انتخاب فهرست";
 
@@ -2118,26 +1224,13 @@
 
 "dialog_pedestrian_route_is_long_message" = "لطفا نقطه آغاز و پایان نزدیک تری به ایستگاه مترو انتخاب کنید";
 
-/* Failed planning SUBWAY route message in navigation view */
-"routing_planning_error_subway_special" = "برنامه ریزی مسیر مترو ناموفق ماند";
-
 "button_layer_isolines" = "ایزومپ";
-
-"tips_map_layers_title_countour" = "تازه ها در Organic Maps: لایه توپوگرافی آفلاین!";
-
-"tips_map_layers_message_countour" = "با اطمینان از این که همه چیز را در مورد منطقه می دانید طبیعت گردی خود را برنامه ریزی کنید و لذت ببرید";
 
 "isolines_activation_error_dialog" = "برای فعال سازی و استفاده از لایه توپوگرافی نقشه منطقه را به روزرسانی یا دانلود کنید";
 
 "isolines_location_error_dialog" = "لایه توپوگرافی هنوز برای این منطقه در دسترس نیست";
 
 "elevation_profile_diff_level" = "سطح دشواری";
-
-"elevation_profile_diff_level_easy" = "آسان";
-
-"elevation_profile_diff_level_moderate" = "متوسط";
-
-"elevation_profile_diff_level_hard" = "دشوار";
 
 "elevation_profile_ascent" = "بالا رفتن";
 
@@ -2147,25 +1240,13 @@
 
 "elevation_profile_maxaltitude" = "بیشینه ارتفاع";
 
-"elevation_profile_m" = "متر";
-
 "elevation_profile_difficulty" = "دشواری";
 
 "elevation_profile_distance" = "مسافت";
 
-"elevation_profile_km" = "کیلومتر";
-
 "elevation_profile_time" = "زمان:";
 
-"elevation_profile_hours" = "ساعت";
-
-"elevation_profile_minutes" = "دقیقه";
-
 "isolines_toast_zooms_1_10" = "برای بررسی خطوط تراز زوم کنید";
-
-"downloader_updating_ios" = "در حال بروزرسانی";
-
-"downloader_loading_ios" = "در حال دانلود";
 
 "key_information_title" = "اطلاعات کلیدی";
 

--- a/iphone/Maps/LocalizedStrings/fa.lproj/Localizable.stringsdict
+++ b/iphone/Maps/LocalizedStrings/fa.lproj/Localizable.stringsdict
@@ -9,23 +9,6 @@
 
 <!-- ********** Strings for downloading map from search **********/ -->
 
-  <key>bookmarks_places</key>
-  <dict>
-    <key>NSStringLocalizedFormatKey</key>
-    <string>%#@value@</string>
-    <key>value</key>
-    <dict>
-      <key>NSStringFormatSpecTypeKey</key>
-      <string>NSStringPluralRuleType</string>
-      <key>NSStringFormatValueTypeKey</key>
-      <string>d</string>
-      <key>one</key>
-      <string>%d نشانه</string>
-      <key>other</key>
-      <string>%d نشانه‌ها</string>
-    </dict>
-  </dict>
-
   <key>bookmarks_detect_message</key>
   <dict>
     <key>NSStringLocalizedFormatKey</key>
@@ -40,23 +23,6 @@
       <string>%d فایل پیدا شد. بعد از تبدیل آن را می‌بینید.</string>
       <key>other</key>
       <string>%d فایل پیدا شد. بعد از تبدیل آن‌ها را می‌بینید.</string>
-    </dict>
-  </dict>
-
-  <key>bookmarks_objects</key>
-  <dict>
-    <key>NSStringLocalizedFormatKey</key>
-    <string>%#@value@</string>
-    <key>value</key>
-    <dict>
-      <key>NSStringFormatSpecTypeKey</key>
-      <string>NSStringPluralRuleType</string>
-      <key>NSStringFormatValueTypeKey</key>
-      <string>d</string>
-      <key>one</key>
-      <string>%s شیء</string>
-      <key>other</key>
-      <string>%s شیء</string>
     </dict>
   </dict>
 

--- a/iphone/Maps/LocalizedStrings/fi.lproj/Localizable.strings
+++ b/iphone/Maps/LocalizedStrings/fi.lproj/Localizable.strings
@@ -18,9 +18,6 @@
 /* Button which deletes downloaded country */
 "delete" = "Poista";
 
-/* Button "do not interrupt download" if user touched actively downloading country */
-"do_nothing" = "Jatka";
-
 "download_maps" = "Lataa karttoja";
 
 /* Settings/Downloader - info for country when download fails */
@@ -28,9 +25,6 @@
 
 /* Settings/Downloader - info for country which started downloading */
 "downloading" = "Ladataan…";
-
-/* Settings/Downloader - size string, only strings different from English should be translated */
-"kb" = "Kt";
 
 /* Choose measurement on first launch alert - choose metric system button */
 "kilometres" = "Kilometrit";
@@ -55,17 +49,11 @@
 /* Update maps later/Buy pro version later button text */
 "later" = "Myöhemmin";
 
-/* Don't show some dialog any more */
-"never" = "Ei koskaan";
-
 /* View and button titles for accessibility */
 "search" = "Haku";
 
 /* Search box placeholder text */
 "search_map" = "Hae kartalta";
-
-/* Settings/Downloader - info for not downloaded country */
-"touch_to_download" = "Lataa koskettamalla";
 
 /* Settings/Downloader - 3G download warning dialog confirm button */
 "use_cellular_data" = "Kyllä";
@@ -73,20 +61,11 @@
 /* Location services are disabled by user alert - message */
 "location_is_disabled_long_text" = "Laitteen tai sovelluksen kaikki sijaintipalvelut ovat tällä hetkellä poissa käytöstä. Ota ne käyttöön Asetukset-valikossa.";
 
-/* Location Services are not available on the device alert - message */
-"device_doesnot_support_location_services" = "Laitteesi ei tue sijaintipalveluita";
-
 /* View and button titles for accessibility */
 "zoom_to_country" = "Näytä kartalla";
 
-/* Button text for the button at the center of the screen when the country is not downloaded */
-"country_status_download" = "Lataa kartta\n(^ ^)";
-
 /* Button text for the button at the center of the screen when the country is not downloaded and the size should not be shown */
 "country_status_download_without_size" = "Lataa kartta";
-
-/* Button text for the button at the center of the screen when the country is not downloaded */
-"country_status_download_without_routing" = "Lataa kartta\nilman reititystä (^ ^)";
 
 /* Message to display at the center of the screen when the country download has failed */
 "country_status_download_failed" = "Lataus epäonnistui";
@@ -96,19 +75,13 @@
 
 "about_menu_title" = "Tietoa Organic Maps:stä";
 
-"downloaded_touch_to_delete" = "Ladattu (%@), poista koskettamalla";
-
 "connection_settings" = "Yhteysasetukset";
-
-"download_mb_or_kb" = "Lataa %@";
 
 "close" = "Sulje";
 
 "unsupported_phone" = "Laitteistokiihdytetty OpenGL vaaditaan. Valitettavasti laitteesi ei ole tuettu.";
 
 "download" = "Lataa";
-
-"external_storage_is_not_available" = "SD-kortti/USB-massamuisti, jolle kartat on ladattu, ei ole käytettävissä";
 
 "disconnect_usb_cable" = "Irrota USB-kaapeli tai syötä muistikortti käyttääksesi Organic Maps -sovellusta";
 
@@ -117,8 +90,6 @@
 "not_enough_memory" = "Ei tarpeeksi muistia sovelluksen avaamiseksi";
 
 "download_resources" = "Ennen aloitusta laitteelle tulee ladata yleinen maailmankartta.\nSe tarvitsee yhteensä %@ dataa.";
-
-"getting_position" = "Etsitään sijaintia";
 
 "download_resources_continue" = "Siirry karttaan";
 
@@ -140,23 +111,14 @@
 /* Add New Bookmark Set dialog title */
 "add_new_set" = "Lisää uusi valikoima";
 
-/* Place Page - Add To Bookmarks button */
-"add_to_bookmarks" = "Lisää Kirjanmerkkeihin";
-
 /* Bookmark Color dialog title */
 "bookmark_color" = "Kirjanmerkin väri";
 
 /* Add Bookmark Set dialog - hint when set name is empty */
 "bookmark_set_name" = "Kirjanmerkkivalikoiman nimi";
 
-/* Bookmark Sets dialog title */
-"bookmark_sets" = "Kirjanmerkkivalikoimat";
-
 /* Bookmarks - dialog title */
 "bookmarks" = "Kirjanmerkit";
-
-/* Add bookmark dialog - bookmark color */
-"color" = "Väri";
 
 /* Default bookmarks set name */
 "core_my_places" = "Paikkani";
@@ -167,14 +129,8 @@
 /* Editor title above street and house number */
 "address" = "Osoite";
 
-/* Place Page - Remove Pin button */
-"remove_pin" = "Poista nasta";
-
 /* Add bookmark dialog - bookmark set, Bookmarks dialog - Bookmark set cell */
 "set" = "Aseta";
-
-/* Text hint in Bookmarks dialog when no any bookmarks are added */
-"bookmarks_usage_hint" = "Sinulla ei vielä ole kirjanmerkkejä.\nLisää kirjanmerkki napsauttamalla mitä tahansa paikkaa kartalla.\nVoit myös tuoda kirjanmerkkejä muista lähteistä Organic Maps:ssä käytettäviksi avaamalla KML/KMZ-kirjanmerkkitiedoston sähköpostistasi, Dropbox-tililtäsi tai verkko-osoitteesta.";
 
 /* Settings button in system menu */
 "settings" = "Asetukset";
@@ -191,26 +147,11 @@
 /* Ask to wait user several minutes (some long process in modal dialog). */
 "wait_several_minutes" = "Tämä voi kestää useita minuutteja.\nOdota hetki…";
 
-/* Show bookmarks from this category on a map or not */
-"visible" = "Näkyvä";
-
-/* Toast which is displayed when GPS has been deactivated */
-"gps_is_disabled_long_text" = "GPS on pois käytöstä. Voit ottaa sen käyttöön asetusvalikosta.";
-
 /* Measurement units title in settings activity */
 "measurement_units" = "Mittayksiköt";
 
 /* Detailed description of Measurement Units settings button */
 "measurement_units_summary" = "Valitse mailit tai kilometrit";
-
-/* Do search in all sources */
-"search_mode_all" = "Everywhere";
-
-/* Do search near my position only */
-"search_mode_nearme" = "Near Me";
-
-/* Do search in current viewport only */
-"search_mode_viewport" = "On the Screen";
 
 /* Search category for cafes, bars, restaurants */
 "eat" = "Missä syödä";
@@ -266,14 +207,8 @@
 /* Search category */
 "police" = "Poliisi";
 
-/* String in search result list, when nothing found */
-"no_search_results_found" = "Tuloksia ei löytynyt";
-
 /* Notes field in Bookmarks view */
 "description" = "Muistiinpanot";
-
-/* Button text */
-"share_by_email" = "Jaa sähköpostilla";
 
 /* Email Subject when sharing bookmarks category */
 "share_bookmarks_email_subject" = "Jaetut Organic Maps-kirjanmerkit";
@@ -295,26 +230,11 @@
 /* Warning message when doing search around current position */
 "unknown_current_position" = "Sijaintiasi ei ole vielä määritetty";
 
-/* Warning message when location country isn't downloaded during search (see also download_location_map_proposal). */
-"download_location_country" = "Lataa nykyisen sijainnin (%@) maa";
-
-/* Warning message when viewport country isn't downloaded during search */
-"download_viewport_country_to_search" = "Lataa hakemasi sijainnin (%@) maa";
-
 /* Alert message that we can't run Map Storage settings due to some reasons. */
 "cant_change_this_setting" = "Valitettavasti karttatallennusasetukset ovat pois päältä.";
 
 /* Alert message that downloading is in progress. */
 "downloading_is_active" = "Maata ladataan parhaillaan.";
-
-/* Message that will be shown in alert view, when we ask user to leave review on App Store */
-"appStore_message" = "Toivottavasti nautit Organic Maps -sovelluksen käyttämisestä! Olisimme tyytyväisiä, jos voisit arvioida sovelluksen App Storessa. Se kesää alle minuutin, ja auttaa meitä todella paljon. Kiitos tuestasi!";
-
-/* No, thanks */
-"no_thanks" = "Ei kiitos";
-
-/* Share one specific bookmark using SMS, %1$@ contains om:// and %2$@ https://omaps.app link. @NOTE non-ascii symbols in the link will result in max 70 characters SMS instead of 140. */
-"bookmark_share_sms" = "Hei, katso merkintäni Organic Maps-sovelluksessa! %1$@ tai %2$@ Eikö sinulla ole offline-karttoja? Lataa ne täältä: https://omaps.app/get";
 
 /* Share my position using SMS, %1$@ contains om:// and %2$@ https://omaps.app link WITHOUT NAME. @NOTE non-ascii symbols in the link will result in max 70 characters SMS instead of 140. */
 "my_position_share_sms" = "Hei, katso sijaintini Organic Maps-sovelluksessa! %1$@ tai %2$@ Eikö sinulla ole vielä offline-karttoja? Lataa ne täältä: https://omaps.app/get";
@@ -328,23 +248,11 @@
 /* Share my position using EMail, %1$@ is om:// and %2$@ is https://omaps.app link WITHOUT NAME */
 "my_position_share_email" = "Hei,n\nOlen nyt täällä: %1$@. Klikkaa linkkiä %2$@ tai %3$@ nähdäksesi paikan kartalla. Kiitos.";
 
-/* Android share by Message/SMS button text (including SMS) */
-"share_by_message" = "Jaa viestillä";
-
 /* Share button text which opens menu with more buttons, like Message, EMail, Facebook etc. */
 "share" = "Jaa";
 
-/* iOS share by Message button text (including SMS) */
-"message" = "Viesti";
-
 /* Share by email button text, also used in editor. */
 "email" = "Sähköposti";
-
-/* Copy Link */
-"copy_link" = "Kopioi linkki";
-
-/* Text for the button that returns to caller application */
-"more_info" = "Näytä lisätietoja";
 
 /* Text for message when used successfully copied something */
 "copied_to_clipboard" = "Kopioitu leikepöydälle: %1$@";
@@ -354,15 +262,6 @@
 
 /* Used for bookmark editing */
 "done" = "Valmis";
-
-/* Summary for preferences in MWM */
-"yopme_pref_summary" = "Valitse tausta-asetukset";
-
-/* Title for yopme preferences in MWM */
-"yopme_pref_title" = "Tausta-asetukset";
-
-/* Hint for upper-right icon p2b */
-"show_on_backscreen" = "Näytä taustalla";
 
 /* Prints version number in About dialog */
 "version" = "Versio: %@";
@@ -381,19 +280,11 @@
 
 "share_my_location" = "Jaa sijaintini";
 
-"menu_search" = "Haku";
-
 /* Settings general group in settings screen */
 "prefs_group_general" = "General settings";
 
 /* Settings information group in settings screen */
 "prefs_group_information" = "Information";
-
-/* Settings screen: "Map" category title */
-"prefs_group_map" = "Kartta";
-
-/* Settings screen: "Miscellaneous" category title */
-"prefs_group_misc" = "Muut";
 
 "prefs_group_route" = "Navigaatio";
 
@@ -419,9 +310,6 @@
 /* Settings «Map» category: «3D buildings» title */
 "pref_map_3d_buildings_title" = "3D-rakennukset";
 
-/* Settings «Map» category: «3D buildings» summary */
-"pref_map_3d_buildings_subtitle" = "Vaikuttaa akun kestoon";
-
 /* Settings «Route» category: «Tts enabled» title */
 "pref_tts_enable_title" = "Ääniohjeistukset";
 
@@ -433,8 +321,6 @@
 
 /* Title for "Other" section in TTS settings. */
 "pref_tts_other_section_title" = "Muu";
-
-"pref_tts_how_to_set_up_voice" = "Kuinka asettaa ääni";
 
 /* Settings «Map» category: «Record track» title */
 "pref_track_record_title" = "Viimeisin reitti";
@@ -455,56 +341,7 @@
 
 "recent_track_help_text" = "Toiminnon avulla voit tallentaa kuljetun reitin tietyltä ajalta ja nähdä sen kartalla: Huomautus: tämän toiminnon aktivoiminen lisää akun käyttöä. Reitti poistetaan kartalta automaattisesti ajanjakson päätyttyä.";
 
-"pref_track_ios_caption" = "Viimeisin reitti näyttää kulkemasi matkan.";
-
-"pref_track_ios_subcaption" = "Valitse reitin tallennuksen aikaväli.";
-
-"placepage_distance" = "Etäisyys";
-
-"placepage_coordinates" = "Koordinaatit";
-
-"placepage_unsorted" = "Järjestelemätön";
-
 "search_show_on_map" = "Näytä kartalla";
-
-/* Used to warn user when fixing KitKat issue */
-"bookmark_move_fail" = "Vapauta muistia, sillä muuten karttoja voidaan käyttää vain lukutilassa. Kirjanmerkkisi pitää siirtää laitteen sisäiseen muistiin, mutta vapaata muistia ei ole tarpeeksi. Vapauta muistia, sillä muuten kirjanmerkkejä ei voida käyttää.";
-
-/* Used in More Apps menu */
-"free" = "Free";
-
-/* Used in More Apps menu */
-"buy" = "Buy";
-
-/* 1st search button-like result */
-"search_on_map" = "Etsi kartalta";
-
-/* toast with an error */
-"no_route_found" = "Reittiä ei löydy";
-
-/* route title */
-"route" = "Reitti";
-
-/* category title */
-"routes" = "Reitit";
-
-/* text of notification */
-"download_map_notification" = "Lataa sijaintisi kartta";
-
-/* text of notification */
-"pro_version_is_free_today" = "Full version of Organic Maps is free today! Download now and tell your friends.";
-
-/* Dialog for transferring maps from lite to pro. */
-"move_lite_maps_to_pro" = "Me siirrämme lataamasi kartat Organic Maps Lite:stä Organic Maps:hen. Siirtäminen voi viedä muutaman minuutin.";
-
-/* Message to display when maps moved. */
-"move_lite_maps_to_pro_ok" = "Lataamasi kartat on siirretty onnistuneesti Organic Maps:hen.";
-
-/* Message to display when maps move failed. */
-"move_lite_maps_to_pro_failed" = "Karttoja ei voitu siirtää. Ole hyvä ja poista Organic Maps Lite ja lataa kartat uudelleen.";
-
-/* Text in menu */
-"settings_and_more" = "Asetukset &amp; Lisää";
 
 /* Text in menu */
 "website" = "Kotisivut";
@@ -527,14 +364,8 @@
 /* Text in menu */
 "openstreetmap" = "OpenStreetMap";
 
-/* Text in menu */
-"contact_us" = "Ota yhteyttä";
-
 /* Settings: Send feedback button and dialog title */
 "feedback" = "Palaute";
-
-/* Text in menu */
-"subscribe_to_news" = "Tilaa uutiskirjeemme";
 
 /* Text in menu */
 "rate_the_app" = "Arvioi sovellus";
@@ -548,15 +379,6 @@
 /* Text in menu */
 "report_a_bug" = "Ilmoita virheestä";
 
-/* Email subject */
-"subscribe_me_subject" = "Lisätkää minut Organic Maps:n uutiskirjeen tilaajaksi";
-
-/* Email body */
-"subscribe_me_body" = "Liittäkää minut Organic Maps -uutiskirjeen tilaajaksi saadakseni ensimmäisenä tietoa uusista päivityksistä ja TARJOUKSISTA. Voin peruuttaa tilaukseni koska tahansa.";
-
-/* About text */
-"about_text" = "Organic Maps tarjoaa nopeimmat offline-kartat kaikista kaupungeista, kaikissa maissa ympäri maailman. Matkusta luottavaisin mielin - missä ikinä oletkin, Organic Maps auttaa sinua löytämään itsesi kartalta, ohjaamaan sinut lähimpään ravintolaan, hotelliin, pankkiin, huoltoasemalle jne. Internet-yhteyttä ei tarvita.\n\nTyöskentelemme jatkuvasti uusien ominaisuuksien parissa, ja haluammekin kuulla sinulta kuinka voimme parantaa MAPS.me -sovellusta entisestään. Mikäli sinulla on ongelmia sovelluksen kanssa, älä epäröi ottaa yhteyttä asiakaspalveluumme osoitteessa support@organicmaps.app. Vastaamme jokaiseen yhteydenottoon!\n\nTykkäätkö Organic Maps -sovelluksesta ja haluat tukea meitä? Siihen on muutamia helppoja ja täysin ilmaisia tapoja:\n\n- lisää sovellusarviosi käyttämääsi sovelluskauppaan\n - tykkää Facebook-sivustamme osoitteessa http://www.facebook.com/OrganicMaps\n- kerro MAPS.me:stä äidillesi, ystävillesi ja kollegoillesi :)\n\nKiitos sovelluksen käytöstä. Arvostamme tukeasi todella paljon!\n\nP.S. Kaikki tiedot noudetaan OpenStreetMap-palvelusta, joka on Wikipedian kaltainen karttaprojekti, jossa kuka tahansa voi lisätä ja muokata karttoja. Mikäli havaitset kartoissa virheitä ja puutteita, voit korjata ne osoitteessa https://www.openstreetmap.org, ja muutokset näkyvät sovelluksessa seuraavan Organic Maps -päivityksen jälkeen.";
-
 /* Alert text */
 "email_error_body" = "Sähköpostisovellusta ei ole asetettu. Ole hyvä ja määritä sähköpostiasetukset tai ota meihin yhteyttä toista kautta osoitteessa %@";
 
@@ -569,12 +391,6 @@
 /* Search category */
 "wifi" = "WiFi";
 
-/* Update map suggestion */
-"routing_map_outdated" = "Päivitä kartta luodaksesi reitin";
-
-/* Update maps suggestion */
-"routing_update_maps" = "Uusi Organic Maps -versio mahdollistaa reittien luonnin nykyisestä sijainnista määränpäähäsi.Päivitä kartat käyttääksesi tätä ominaisuutta.";
-
 /* Update all button text */
 "downloader_update_all_button" = "Päivitä kaikki";
 
@@ -583,9 +399,6 @@
 
 /* Downloaded maps category */
 "downloader_downloaded_subtitle" = "Ladatut";
-
-/* Downloaded maps category */
-"downloader_available_maps" = "Saatavilla";
 
 /* Country queued for download */
 "downloader_queued" = "Jonossa";
@@ -598,17 +411,6 @@
 
 "downloader_downloading" = "Ladataan:";
 
-"downloader_search_results" = "Löytyi";
-
-/* Disclaimer message */
-"routing_disclaimer" = "Pidä mielessä seuraavat seikat luodessasi reittejä Organic Maps -sovelluksella:\n\n- Ehdotettuja reittejä tulee pitää vain suosituksina.\n- Teiden kunto, liikennesäännöt ja -merkit on aina otettava huomioon navigointiehdotuksista huolimatta.\n - Kartassa saattaa olla virheitä, tai se saattaa olla vanhentunut, eikä reittejä sen takia voida luoda parhaalla mahdollisella tavalla.\n\nPysy valppaana liikenteessä ja pidä huolta itsestäsi!";
-
-/* Outdated maps category */
-"downloader_outdated_maps" = "Vanhentunut";
-
-/* Up to date maps category */
-"downloader_uptodate_maps" = "Ajan tasalla";
-
 /* Status of outdated country in the list */
 "downloader_status_outdated" = "Päivitä";
 
@@ -618,49 +420,14 @@
 /* Displayed in a dialog that appears when a user tries to delete a map while the app is in the follow route mode */
 "downloader_delete_map_while_routing_dialog" = "Pysäytä navigointi poistaaksesi kartan.";
 
-/* Show when user try build route, but we don't know where he */
-"routing_failed_unknown_my_position" = "Tämänhetkinen sijainti ei ole tiedossa. Määritä sijainti luodaksesi reitin.";
-
-/* Show if use has not routing file, or InconsistentMWMandRoute */
-"routing_failed_has_no_routing_file" = "Reitin luomiseksi on ladattava lisää dataa. Ladatataanko data nyt?";
-
-/* StartPointNotFound */
-"routing_failed_start_point_not_found" = "Reittiä ei voida laskea, koska lähtöpisteen lähistöllä ei ole teitä.";
-
-/* EndPointNotFound */
-"routing_failed_dst_point_not_found" = "Reittiä ei voida laskea, koska määränpään lähistöllä ei ole teitä.";
-
 /* PointsInDifferentMWM */
 "routing_failed_cross_mwm_building" = "Vain kokonaisuudessaan yhdelle kartalle mahtuvia reittejä voidaan luoda.";
-
-/* RouteNotFound */
-"routing_failed_route_not_found" = "Lähtöpisteen ja määränpään välillä ei löytynyt reittiä. Valitse toinen lähtöpiste tai määränpää.";
-
-/* InternalError */
-"routing_failed_internal_error" = "Sisäinen virhe. Kokeile asentaa kartta uudelleen. Mikäli ongelma jatkuu, ota yhteyttä asiakaspalveluun osoitteessa support@organicmaps.app.";
-
-/* Context menu item for downloader. */
-"downloader_download_map_and_routing" = "Lataa kartta + reititys";
-
-/* Context menu item for downloader. */
-"downloader_download_routing" = "Lataa reititys";
-
-/* Context menu item for downloader. */
-"downloader_delete_routing" = "Poista reititys";
 
 /* Context menu item for downloader. */
 "downloader_download_map" = "Lataa kartta";
 
-"downloader_download_map_no_routing" = "Lataa kartta ilman reititystä";
-
-/* Button for routing. */
-"routing_go" = "Lähde!";
-
 /* Item status in downloader. */
 "downloader_retry" = "Yritä uudelleen";
-
-/* Item in context menu. */
-"downloader_map_and_routing" = "Kartta + reititys";
 
 /* Item in context menu. */
 "downloader_delete_map" = "Poista kartta";
@@ -668,29 +435,11 @@
 /* Item in context menu. */
 "downloader_update_map" = "Päivitä kartta";
 
-/* Item in context menu. */
-"downloader_update_map_and_routing" = "Päivitä kartta + reititys";
-
-/* Item in context menu. */
-"downloader_map_only" = "Vain kartta";
-
-/* Toolbar title */
-"toolbar_application_menu" = "Sovellusvalikko";
-
 /* Preference text */
 "pref_use_google_play" = "Käytä Google Play -palveluita sijaintisi selvittämiseksi";
 
 /* Text for rating dialog */
 "rating_just_rated" = "Olen juuri arvostellut sovelluksesi.";
-
-/* Text for rating dialog */
-"rating_user_since" = "Olen Organic Maps käyttäjä vuodesta %@.";
-
-/* Text for rating dialog */
-"rating_do_like_maps" = "Pidätkö Organic Maps sovelluksesta?";
-
-/* Text for rating dialog */
-"rating_tap_star" = "Napauta tähteä arvostellaksesi sovelluksemme.";
 
 /* Text for rating dialog */
 "rating_thanks" = "Kiitos!";
@@ -701,23 +450,8 @@
 /* Text for rating dialog */
 "rating_send_feedback" = "Lähetä palautetta";
 
-/* Text for g+ dialog */
-"rating_google_plus" = "Napsauta g+ ja kerro ystävillesi sovelluksesta.";
-
 /* Text for routing error dialog */
 "routing_download_maps_along" = "Lataa karttoja matkalla";
-
-/* Text for routing error dialog */
-"routing_download_map" = "Hanki kartta";
-
-/* Text for routing error dialog */
-"routing_download_map_and_routing" = "Lataa päivitetty kartta ja reititysdata saadaksesi kaikki Organic Maps -ominaisuudet.";
-
-/* Text for routing error dialog */
-"routing_get_routing_data" = "Hanki reitityskartta";
-
-/* Text for routing error dialog */
-"routing_get_additional_data" = "Lisädata, jotka vaaditaan reittien luomiseen sijainnistasi.";
 
 /* Text for routing error dialog */
 "routing_requires_all_map" = "Reitin luominen vaatii karttojen lataamisen ja päivityksen oman sijaintisi ja kohteeen väliltä.";
@@ -725,50 +459,15 @@
 /* Text for routing error dialog */
 "routing_not_enough_space" = "Ei tarpeeksi tilaa";
 
-/* Text for routing error dialog */
-"routing_download_more_than_avail" = "Sinun täytyy ladata %@ MB, mutta saatavilla on vain %@ MB.";
-
-/* Text for routing error dialog */
-"routing_download_roaming" = "Olet lataamassa %@ MB Mobiilidatan (roaming-lataus) avulla. Tämä voi johtaa lisämaksuihin, riippuen matkapuhelinliittymäsi palveluntarjoajasta.";
-
 /* bookmark button text */
 "bookmark" = "kirjanmerkki";
-
-/* map is not downloaded */
-"not_found_map" = "Nykyisen sijaintisi karttaa ei ole ladattu";
 
 /* location service disabled */
 "enable_location_services" = "Ota sijaintipalvelut käyttöön";
 
-/* download map */
-"download_map" = "Lataa nykyisen sijaintisi kartta";
-
-/* download map on iPhone */
-"download_map_iphone" = "Lataa tämän hetkisen sijaintisi kartta iPhoneesi";
-
-/* clear pin */
-"nearby" = "Lähellä";
-
-/* clear pin */
-"clear_pin" = "Tyhjennä kiinnitys";
-
-/* location is undefined */
-"undefined_location" = "Tämänhetkinen sijainti ei ole tiedossa.";
-
-/* download country of your location */
-"download_country" = "Lataa nykyisen sijainnin maa";
-
-/* download failed */
-"download_failed" = "Lataus epäonnistui";
-
-/* get the map */
-"get_the_map" = "Hanki kartta";
-
 "save" = "Tallenna";
 
 "edit_description_hint" = "Kuvauksesi (teksti tai html)";
-
-"new_group" = "uusi ryhmä";
 
 "create" = "luo";
 
@@ -795,30 +494,6 @@
 
 /* pink color */
 "pink" = "Pinkki";
-
-/* deep purple color */
-"deep_purple" = "Tumman purppuranpunainen";
-
-/* light blue color */
-"light_blue" = "Vaaleansininen";
-
-/* cyan color */
-"cyan" = "Sinivihreä";
-
-/* teal color */
-"teal" = "Smaragdinvihreä";
-
-/* lime color */
-"lime" = "Limen värinen";
-
-/* deep orange color */
-"deep_orange" = "Tumman oranssi";
-
-/* gray color */
-"gray" = "Harmaa";
-
-/* blue gray color */
-"blue_gray" = "Harmaan sininen";
 
 /* Wi-Fi available */
 "WiFi_available" = "Kyllä";
@@ -848,13 +523,9 @@
 
 "dialog_routing_location_unknown_turn_on" = "Tämänhetkisiä GPS-koordinaatteja ei löydy. Ota sijaintipalvelut käyttöön reitin laskemista varten.";
 
-"dialog_routing_location_unknown" = "Tämänhetkisiä GPS-koordinaatteja ei löydy.";
-
 "dialog_routing_download_files" = "Lataa tarvittavat tiedostot";
 
 "dialog_routing_download_and_update_all" = "Lataa ja päivitä kaikki suunnitellun reitin kartta- ja reititystiedot, jotta reitin voi laskea.";
-
-"dialog_routing_routes_size" = "Reititystiedostot";
 
 "dialog_routing_unable_locate_route" = "Reitin paikannus ei onnistu";
 
@@ -884,21 +555,11 @@
 
 "dialog_routing_try_again" = "Yritä uudelleen";
 
-"dialog_routing_send_error" = "Ilmoita ongelmasta";
-
-"dialog_routing_if_get_cross_route" = "Haluatko luoda suoremman reitin, joka ylettyy usealle kartalle?";
-
-"dialog_routing_cross_route_is_optimal" = "Tarjolla on suorempi reitti, joka ylittää tämän kartan reunan.";
-
 "not_now" = "Ei nyt";
-
-"dialog_routing_build_route" = "Luo";
 
 "dialog_routing_download_and_build_cross_route" = "Haluatko ladata kartan ja luoda paremman reitin, joka ylettyy usealle kartalle?";
 
 "dialog_routing_download_cross_route" = "Lataa kartta ja luo parempi reitti, joka ylittää tämän kartan reunan.";
-
-"dialog_routing_cross_route_always" = "Ylitä aina tämä raja";
 
 
 /********** Strings for downloading map from search **********/
@@ -906,8 +567,6 @@
 "search_without_internet_advertisement" = "Lataa kartta jotta voit käyttää hakua ja luoda reittejä. Tämän jälkeen et tarvitse enää Internet-yhteyttä.";
 
 "search_select_map" = "Valitse kartta";
-
-"search_select_other_map" = "Valitse toinen kartta";
 
 /* «Show» context menu */
 "show" = "Näytä";
@@ -918,17 +577,11 @@
 /* «Rename» context menu */
 "rename" = "Nimeä uudelleen";
 
-/* Bottom sheet: expand button (should be short) */
-"bottom_sheet_more" = "Lisää…";
-
 /* Failed planning route message in navigation view */
 "routing_planning_error" = "Reitin suunnittelu epäonnistui";
 
 /* Arrive routing message in navigation view */
 "routing_arrive" = "Saavut: %s";
-
-/* Text for routing::RouterResultCode::FileTooOld dialog. */
-"dialog_routing_download_and_update_maps" = "Lataa ja päivitä kaikki kartat reitin varrella luodaksesi reitin.";
 
 "rate_alert_title" = "Pidätkö sovelluksesta?";
 
@@ -944,19 +597,11 @@
 
 "history" = "Historia";
 
-"next_turn_then" = "Sitten";
-
 "closed" = "Suljettu";
-
-"back_to" = "Takaisin sovellukseen %@";
 
 "search_not_found" = "Pahoittelut, hakutuloksia ei ole.";
 
 "search_not_found_query" = "Yritä jotain toista hakusanaa.";
-
-"search_not_found_map" = "Lataa kartat sille alueelle jolta haet.";
-
-"search_not_found_location" = "Lataa nykyisen sijaintisi kartta.";
 
 "search_history_title" = "Hakuhistoria";
 
@@ -964,23 +609,12 @@
 
 "clear_search" = "Poista hakuhistoria";
 
-/* Title for settings to enable/disable showcase menu button */
-"showcase_settings_title" = "Näytä tarjoukset";
-
 /* Place Page link to Wikipedia article (if map object has it). */
 "read_in_wikipedia" = "Wikipedia";
 
-"p2p_route_planning" = "Reittisuunnittelu";
-
 "p2p_your_location" = "Sijaintisi";
 
-"p2p_from" = "Lähtöpiste";
-
-"p2p_to" = "Päämäärä";
-
 "p2p_start" = "Aloita";
-
-"p2p_planning" = "Lasketaan…";
 
 "p2p_from_here" = "Lähtöpaikka";
 
@@ -1018,15 +652,9 @@
 
 "editor_correct_mistake" = "Korjaa virhe";
 
-"editor_correct_mistake_message" = "Teit muokkausvirheen. Korjaa se tai vaihda yksinkertaiseen tilaan.";
-
 "editor_add_select_location" = "Sijainti";
 
 "editor_done_dialog_1" = "Olet muuttanut maailmankarttaa. Älä piilota tätä! Kerro ystävillesi ja muokatkaa sitä yhdessä.";
-
-"editor_done_dialog_2" = "Tämä on toinen kerta, kun paransit karttaa. Nyt olet %d. sijalla kartan muokkaajien listalla. Kerro siitä ystävillesi.";
-
-"editor_done_dialog_3" = "Olet parantanut karttaa, kerro siitä ystävillesi ja muokatkaa karttaa yhdessä.";
 
 "share_with_friends" = "Jaa kavereille";
 
@@ -1044,20 +672,7 @@
 
 "editor_report_problem_duplicate_place_title" = "Paikan kaksoiskappale";
 
-"first_launch_congrats_title" = "Organic Maps on valmiina käyttöön";
-
-"first_launch_congrats_text" = "Etsi ja navigoi ympäri maailman ilman verkkoyhteyttä, ilmaiseksi.";
-
-"migrate_title" = "Tärkeää!";
-
-/* Android uses image instead of text. */
-"download_all" = "Lataa kaikki";
-
-"delete_all" = "Poista kaikki";
-
 "autodownload" = "Lataa automaattisesti";
-
-"disable_autodownload" = "Poista käytöstä automaattinen lataus";
 
 /* Place Page opening hours text */
 "closed_now" = "Suljettu nyt";
@@ -1072,10 +687,6 @@
 "day_off" = "Suljettu";
 
 "today" = "Tänään";
-
-"sunrise_to_sunset" = "Auringonnoususta auringonlaskuun";
-
-"sunset_to_sunrise" = "Auringonnoususta auringonlaskuun";
 
 "add_opening_hours" = "Lisää aukioloajat";
 
@@ -1095,45 +706,18 @@
 
 "forgot_password" = "Unohtuiko salasana?";
 
-/* Forgot Password dialog title */
-"restore_password" = "Palauta salasana";
-
-"enter_email_address_to_reset_password" = "Syötä rekisteröitymisessä käyttämäsi sähköpostiosoite, niin lähetämme sinulle linkin salasanasi vaihtamista varten.";
-
-"reset_password" = "Aseta salasana uudelleen";
-
-"username" = "Käyttäjänimi";
-
 "osm_account" = "OSM-tili";
 
 "logout" = "Kirjaudu ulos";
 
-"login_and_edit_map_motivation_message" = "Kirjaudu sisään ja muokkaa kartan kohteiden tietoja, ja me asetamme kohteet miljoonien muiden käyttäjien saataville. Tehdään maailmasta yhdessä parempi paikka.";
-
 /* Information text: "Last upload 11.01.2016" */
 "last_upload" = "Viimeisin lisäys";
 
-/* Motivates user to login/register, title above login buttons. */
-"you_have_edited_your_first_object" = "Olet muokannut ensimmäistä kohdettasi!";
-
 "thank_you" = "Kiitos";
-
-"login_with_google" = "Kirjaudu sisään Google-tunnuksillasi";
-
-"login_with_openstreetmap" = "Kirjaudu sisään osoitteessa www.openstreetmap.org";
 
 "edit_place" = "Muokkaa kohdetta";
 
 "place_name" = "Paikan nimi";
-
-/* title above languages list cells in the editor, below editable name text field. */
-"other_languages" = "Muut Kielet";
-
-/* small button to open list with names in different languages */
-"show_more" = "Näytä enemmän";
-
-/* small button to close list with names in different languages */
-"show_less" = "Näytä vähemmän";
 
 "add_language" = "Lisää kieli";
 
@@ -1164,8 +748,6 @@
 
 "please_note" = "Huomaathan, että";
 
-"common_no_wifi_dialog" = "Ei Wi-Fi -yhteyttä. Haluatko jatkaa mobiilidatan avulla?";
-
 "downloader_delete_map_dialog" = "Kaikki karttaan tehdyt muutokset poistetaan kartan mukana.";
 
 "downloader_update_maps" = "Päivitä kartat";
@@ -1173,10 +755,6 @@
 "downloader_mwm_migration_dialog" = "Sinun täytyy päivittää kaikki kartat ja suunnitella reitti uudelleen luodaksesi uuden reitin.";
 
 "downloader_search_field_hint" = "Etsi kartta";
-
-"migration_update_all_button" = "Päivitä kaikki kartat";
-
-"migration_delete_all_download_current_button" = "Lataa nykyinen kartta ja poista kaikki vanhat kartat";
 
 "migration_download_error_dialog" = "Latausvirhe";
 
@@ -1186,21 +764,9 @@
 
 "downloader_no_space_message" = "Poista tarpeeton data";
 
-"editor_general_auth_error_dialog" = "Yleinen kirjautumisvirhe.";
-
 "editor_login_error_dialog" = "Kirjautumisvirhe.";
 
-"editor_login_failed_dialog" = "Kirjautuminen epäonnistui";
-
-"editor_username_error_dialog" = "Käyttäjätunnus on virheellinen";
-
-"editor_place_edited_dialog" = "Olet muokannut kohdetta!";
-
-"editor_login_with_osm" = "Kirjaudu sisään OpenStreetMapissa";
-
 "editor_profile_changes" = "Vahvistetut karttamuutokset";
-
-"editor_profile_unsent_changes" = "Ei lähetetty:";
 
 "editor_focus_map_on_location" = "Vedä karttaa valitaksesi kohteelle oikean sijainnin.";
 
@@ -1222,13 +788,9 @@
 
 "editor_report_problem_other_title" = "Eri ongelma";
 
-"placepage_report_problem_button" = "Ilmoita ongelmasta";
-
 "placepage_add_business_button" = "Lisää organisaatio";
 
 "whatsnew_editor_message_1" = "Lisää karttaan uusia paikkoja ja muokkaa sovelluksessa olevia karttoja suoraan sovelluksessa.";
-
-"whatsnew_editor_message_2" = "* Organic Maps käyttää OpenStreetMap -yhteisön dataa.";
 
 "dialog_incorrect_feature_position" = "Vaihda sijaintia";
 
@@ -1236,16 +798,10 @@
 
 "login_to_make_edits_visible" = "Kirjaudu sisään jotta muut käyttäjät voivat nähdä tekemäsi muokkaukset.";
 
-"no_migration_during_navigation" = "Päivittäminen ei ole mahdollista navigoinnin aikana.";
-
 /* Error dialog no space */
 "migration_no_space_message" = "Tarvitset lisää tilaa ladataksesi. Poista tarpeeton data.";
 
 "editor_sharing_title" = "Paransin Organic Maps-karttoja";
-
-"editor_comment_will_be_sent" = "Lähetämme kommenttisi kartanpiirtäjille.";
-
-"editor_unsupported_category_message" = "Olet lisännyt sijainnin katergoriaan jota emme vielä tue. Se tulee näkyviin kartalle hieman myöhemmin.";
 
 /* Downloaded 10 **of** 20 <- it is that "of" */
 "downloader_of" = "%1$d/%2$d";
@@ -1278,23 +834,9 @@
 
 "editor_operator" = "Operaattori";
 
-"editor_tag_description" = "Syötä tiloista vastuussa oleva yhtiö, organisaatio tai henkilö";
-
-"editor_no_local_edits_title" = "Sinulla ei ole paikallisia muokkauksia";
-
-"editor_no_local_edits_description" = "Tämä näyttää ehdottamiesi muutosten lukumäärän tällä hetkellä vain sinun laitteessasi saatavissa olevassa kartassa.";
-
-"editor_send_to_osm" = "Lähetä OSM:ään";
-
-"editor_remove" = "Poista";
-
-"downloader_my_maps_title" = "Omat kartat";
-
 "downloader_no_downloaded_maps_title" = "Et ole ladannut yhtään karttaa";
 
 "downloader_no_downloaded_maps_message" = "Lataa kartattoja löytääksesi paikkoja ja navigoidaksesi offline-tilassa.";
-
-"downloader_find_place_hint" = "Etsi kaupunki tai maa";
 
 /* Error title that appears after certain time without location. */
 "current_location_unknown_title" = "Jatketaanko nykyisen sijaintisi havaitsemista?";
@@ -1321,47 +863,13 @@
 /* iOS Dialog for the case when the location permission is not granted */
 "location_services_disabled_3" = "3. Valitse sovellusta käytettäessä";
 
-"placepage_parking_surface" = "Pinta";
-
-"placepage_parking_multistorey" = "Monikerroksinen";
-
-"placepage_parking_underground" = "Maan alla";
-
-"placepage_parking_rooftop" = "Katolla";
-
-"placepage_parking_sheds" = "Suojat";
-
-"placepage_parking_carports" = "Autokatokset";
-
-"placepage_parking_boxes" = "Autotalliruudut";
-
-"placepage_parking_pay" = "Maksullinen";
-
-"placepage_parking_free" = "Ilmainen";
-
-"placepage_parking_interval" = "Aikamaksu";
-
-"placepage_entrance_number" = "Nro.";
-
-"placepage_entrance_type" = "Sisäänkäynti";
-
-"placepage_flat" = "sov.";
-
-"placepage_open_24_7" = "24 / 7";
-
 "meter" = "m";
 
 "kilometer" = "km";
 
-"kilometers_per_hour" = "km/h";
-
 "mile" = "mi";
 
 "foot" = "ft";
-
-"miles_per_hour" = "mph";
-
-"day" = "p";
 
 "hour" = "t";
 
@@ -1381,10 +889,6 @@
 
 "placepage_bookmark_name_hint" = "Kirjanmerkin nimi";
 
-"placepage_personal_notes_hint" = "Henkilökohtaiset merkinnät";
-
-"placepage_delete_bookmark_button" = "Poista kirjanmerkki";
-
 "editor_edits_sent_message" = "Ehdottamasi muutokset on lähetetty";
 
 "editor_comment_hint" = "Kommentti…";
@@ -1397,8 +901,6 @@
 
 "editor_remove_place_button" = "Poista";
 
-"editor_status_sending" = "Lähetetään…";
-
 "editor_place_doesnt_exist" = "Paikkaa ei ole olemassa";
 
 "text_more_button" = "…Näytä";
@@ -1410,11 +912,7 @@
 
 "error_enter_correct_email" = "Syötä kelvollinen sähköpostiosoite";
 
-"error_enter_correct" = "Syötä kelvollinen arvo";
-
 "refresh" = "Päivitä";
-
-"last_update" = "Viimeisin päivitys: %s";
 
 "placepage_add_place_button" = "Lisää paikka kartalle";
 
@@ -1426,24 +924,6 @@
 
 "editor_share_to_all_dialog_message_2" = "Tarkistamme muutokset. Otamme sinuun yhteyttä sähköpostitse, jos meillä on kysyttävää.";
 
-"navigation_overview_button" = "yleiskatsaus";
-
-"navigation_stop_button" = "lopeta";
-
-/* Text on an empty bookmark page */
-"bookmarks_empty_title" = "Tallenna Kirjanmerkit";
-
-"bookmarks_empty_message_1" = "Napsauta ★ tallentaaksesi suosikkipaikkoja.";
-
-"bookmarks_empty_message_2" = "Tuo kirjanmerkit sähköpostista ja webistä.";
-
-"bookmarks_empty_message_3" = "kirjaudu ulos: %s";
-
-/* Name of the group for booked hotels */
-"bookmarks_group_name" = "Varatut hotellit";
-
-"place_page_button_read_descriprion" = "Lue";
-
 /* iOS dialog for the case when recent track recording is on and the app comes back from background */
 "recent_track_background_dialog_title" = "Poistetaanko viimeisen matkareitin tallennus?";
 
@@ -1451,8 +931,6 @@
 
 /* For sharing via SMS and so on */
 "sharing_call_action_look" = "Tarkastele";
-
-"continue_recent_track_background_button" = "Jatka";
 
 "recent_track_background_dialog_message" = "MAPS.SE käyttää taustalla geosijaintia sinun viimeisen matkareitin tallentamiseksi.";
 
@@ -1468,33 +946,13 @@
 /* About short text (below logo) */
 "about_description" = "Organic Maps on ehdoton offline-sovellus matkoja varten. Organic Maps perustuu OpenStreetMap-dataan ja sallii sen muokkauksen.";
 
-/* Text in menu */
-"blog" = "Blogi";
-
 "general_settings" = "Yleiset asetukset";
-
-"date" = "Päivämäärä %d";
-
-/* "Report a bug" -> "Generaal Feedback" -> "Something is not working" */
-"something_is_not_working" = "Jokin ei toimi";
 
 /* For the first routing */
 "accept" = "Hyväksy";
 
-"accept_and_continue" = "Accept and continue";
-
 /* For the first routing */
 "decline" = "Hylkää";
-
-"install_app" = "Asenna";
-
-"search_no_results_title" = "Ei hakutuloksia";
-
-"search_no_results_message" = "Kokeile yleisempää hakusanaa, loitonna tai palauta suodatin.";
-
-"search_no_results_expand_area_button" = "Loitonna";
-
-"search_no_results_reset_button" = "Palauta suodatin";
 
 /* noun */
 "search_in_table" = "Luettelo";
@@ -1517,8 +975,6 @@
 
 "traffic_update_maps_text" = "Liikennetietojen näyttämiseksi kartat on päivitettävä.";
 
-"traffic_outdated" = "Liikennetiedot ovat vanhentuneet.";
-
 "big_font" = "Suurenna fonttikokoa kartalla";
 
 "traffic_update_app" = "Päivitä Organic Maps";
@@ -1529,17 +985,7 @@
 /* "traffic" as in "road congestion" */
 "traffic_data_unavailable" = "Liikennetietoja ei ole saatavilla";
 
-/* "Translation is no needed, because it's a company name" */
-"uber" = "Uber";
-
-/* Simplified colour scheme for traffic information, fewer colours are used to display traffic jams on the map. The string should be kept as short as possible */
-"pref_traffic_simplified_colors_title" = "Simppelit liikennevärit";
-
 "enable_logging" = "Ota loki käyttöön";
-
-"offline_place_page_more_information" = "Yhdistä internetiin saadaksesi lisätietoa paikasta.";
-
-"failed_load_information" = "Tietojen lataaminen epäonnistui.";
 
 /* Settings: "Send general feedback" button */
 "feedback_general" = "Yleinen palaute";
@@ -1556,8 +1002,6 @@
 
 "whatsnew_transliteration_title" = "Translitterointi latinaksi";
 
-"yandex_taxi_title" = "Yandex.Taxi";
-
 "learn_more" = "Lisätietoja";
 
 "core_exit" = "Poistu";
@@ -1568,75 +1012,19 @@
 
 "button_exit" = "Poistu";
 
-"settings_device_memory" = "Laitteen muisti";
-
-"settings_card_memory" = "Muistkortti";
-
-"settings_storage_available" = "%s käytettävissä";
-
-"toast_location_permission_denied" = "Sovelluksen sijainnin käyttöoikeus evättiin";
-
-"button_use" = "Käytä";
-
 "planning_route_manage_route" = "Hallitse reittiä";
 
 "button_plan" = "Suunnittele";
-
-"button_add" = "Lisää";
 
 "placepage_remove_stop" = "Poista";
 
 "planning_route_remove_title" = "Vedä tähän poistaaksesi";
 
-"dialog_change_start_point_message" = "Haluatko korvata alkupisteen nykyisellä sijainnilla?";
-
-"button_replace" = "Korvaa";
-
 "placepage_add_stop" = "Lisää pysähdys";
-
-/* Only ru/en are needed */
-"subtitle_rent" = "Rent";
-
-/* Only ru/en are needed */
-"rub_month" = "RUB/month";
-
-/* Only ru/en are needed */
-"room" = "%s-room apt.";
-
-/* Only ru/en are needed */
-"real_estate" = "Real estate";
-
-"add_my_position" = "Lisää oma sijainti";
-
-"choose_start_point" = "Valitse aloituspiste";
-
-"choose_destination" = "Valitse kohde";
 
 "preloader_viator_button" = "Lisätietoja";
 
-"start_from_my_position" = "Aloita kohdasta";
-
-"profile_authorization_title" = "Kirjaudu sisään käyttämällä palvelua";
-
-"profile_authorization_message" = "Helppo sisäänkirjautuminen ilman käyttäjätunnusta ja salasanaa parissa sekunnissa";
-
 "profile_authorization_error" = "Tapahtui virhe. Yritä kirjautua sisään uudelleen.";
-
-"service" = "Palvelu";
-
-"atmosphere" = "Ilmapiiri";
-
-"value_for_money" = "Vastinetta rahoille";
-
-"experience" = "Kokemus";
-
-"assortment" = "Valikoima";
-
-"expertise" = "Asiantuntemus";
-
-"equipment" = "Laitteet";
-
-"quality" = "Laatu";
 
 "dialog_error_storage_title" = "Ongelma tallennustilan käyttämisessä";
 
@@ -1644,17 +1032,7 @@
 
 "setting_emulate_bad_storage" = "Jäljittele virheellistä tallennustilaa";
 
-"directions_finish" = "Kohde";
-
-"directions_on_foot" = "Kävele %s";
-
 "core_entrance" = "Sisäänkäynti";
-
-"coffee" = "Kahvi";
-
-"cleanliness" = "Puhtaus";
-
-"crowdedness" = "Ahtaus";
 
 "error_enter_correct_name" = "Anna oikea nimi";
 
@@ -1673,11 +1051,9 @@
 
 "downloader_percent" = "%s (%s / %s)";
 
-"downloader_process" = "Ladataan %s...";
+"downloader_process" = "Ladataan %s…";
 
-"downloader_applying" = "%s otetaan käyttöön...";
-
-"dialog_message_transit_not_found_connection" = "Suunnittele reitti yhdellä läpikulkuverkolla";
+"downloader_applying" = "%s otetaan käyttöön…";
 
 "bookmarks_error_message_share_general" = "Ei voitu jakaa sovellusvirheen vuoksi";
 
@@ -1695,17 +1071,7 @@
 
 "bookmarks_error_message_list_name_already_taken" = "Valitse toinen nimi";
 
-"bookmarks_error_title_list_name_too_long" = "Tämä nimi on liian pitkä";
-
-"bookmarks_error_message_list_name_too_long" = "Valitse toinen nimi";
-
-"please_wait" = "Odota...";
-
-"phone_number" = "Puhelinnumero";
-
-"notification_unsent_reviews_title" = "Sinulla on useita epävirallisia arvosteluja";
-
-"notification_unsent_reviews_message" = "Kirjaudu sisään jaa arviot muiden matkustajien kanssa";
+"please_wait" = "Odota…";
 
 "profile" = "OpenStreetMap-profiili";
 
@@ -1719,49 +1085,13 @@
 
 "bookmarks_convert_error_message" = "Joitakin tiedostoja ei muutettu.";
 
-"converting" = "Muuntaa...";
-
-"wn_reinvented_bookmarks_title" = "Uusimme kirjanmerkit!";
-
-"wn_reinvented_bookmarks_message" = "Voit varmuuskopioida kirjanmerkkejä, luoda luetteloita... On hämmästyttävää...";
-
-"bookmarks_restore" = "Palauta kirjanmerkit";
-
-"bookmarks_restore_process" = "Palautetaan...";
-
 "bookmarks_restore_title" = "Palauta tämä versio?";
 
-"bookmarks_restore_message" = "Kirjanmerkit palaavat %s (%s): sta";
-
-"bookmarks_restore_empty_title" = "Sinulla ei ole varmuuskopiota";
-
-"bookmarks_restore_empty_message" = "Palvelin ei löytänyt aiemmin tehtyjä varmuuskopioita";
-
 "common_check_internet_connection_dialog_title" = "Ei Internet-yhteyttä";
-
-"error_server_title" = "Palvelinvirhe";
-
-"error_server_message" = "Palvelimessa oli virhe, yritä myöhemmin uudelleen";
 
 "error_system_message" = "Tuntematon virhe tapahtui";
 
 "restore" = "Palauttaa";
-
-"bookmarks_page_downloaded" = "Ladattu";
-
-"bookmarks_page_my" = "Minun";
-
-"routes_and_bookmarks" = "Reitit ja kirjanmerkit";
-
-"bookmarks_webview_success_toast" = "Kirjanmerkit ladattu onnistuneesti";
-
-"cached_bookmarks_placeholder_title" = "Lataa uudet paikat";
-
-"cached_bookmarks_placeholder_subtitle" = "Paina nappulaa ladataksesi tuhansia kiinnostavia paikkoja ja reittejä joita Organic Maps käyttäjät ovat luoneet. Tarvitset internet yhteyden.";
-
-"downloader_download_routers" = "Lataa kirjanmerkit";
-
-"bookmarks_groups_cached" = "Ladatut lista";
 
 "subtittle_opt_out" = "Seuranta-asetukset";
 
@@ -1769,29 +1099,15 @@
 
 "crash_reports_description" = "Me saatamme käyttää tietojasi parantaaksemme Organic Maps kokemusta. Muutokset alkavat vaikuttamaan kun käynnistät sovelluksen uudestaan.";
 
-"opt_out_help_ios_1" = "Mobiililaitteesi saattaa tarjota ”Rajoittettu Mainos Seuranta” tai ”Poistu internet-perusteisesta mainnonnasta” asetuksia.";
-
-"opt_out_help_ios_2" = "iOS 9 tai Korkeampi";
-
-"opt_out_help_ios_3" = "Mene Asetuksiisi → Yksityisyys → Mainonta → Salli ”Rajoita Mainos Seurantaa” asetus";
-
-"opt_out_help_android" = "Mobiililaitteesi saattaa tarjota ”Rajoittettu Mainos Seuranta” tai ”Poistu internet-perusteisesta mainnonnasta” asetuksia.\n\nAndroidille ja Google Play Palvelut versio 4.0 tai myöhemmin:\nAsetukset → Google → Mainokset → Poistu Mainosten Yksilöinti\ntai\nAsetukset → Google → Google Tili → Henkilökohtaiset tiedot ja yksityisyys → Mainos Asetukset → Mainosten Yksilöinti";
-
 "privacy_policy" = "Yksityisyyskäytäntö";
 
 "terms_of_use" = "Käyttöehdot";
-
-"backup_notification_failed" = "Kirjanmerkkiesi varmuuskopionti on keskeytetty. Kirjaudu sisään ja laita se takaisin päälle.";
 
 "button_layer_traffic" = "Liikenne";
 
 "button_layer_subway" = "Metro";
 
 "layers_title" = "Kartan tasot";
-
-"layers_message" = "Käytä kartan tasoja näyttääksesi liikenteen, metrokartan ja muita hyödyllisiä tietoja";
-
-"button_layer_got_it" = "Ymmärsin";
 
 "subway_data_unavailable" = "Metrokartta ei ole saatavilla";
 
@@ -1803,39 +1119,13 @@
 
 "title_error_downloading_bookmarks" = "Tapahtui virhe";
 
-"subtitle_error_downloading_bookmarks" = "Kirjanmerkkejä ei ole ladattu";
-
-"error_already_downloaded" = "Tämä lista on jo ladattu";
-
 "popular_place" = "Popular";
-
-"download_routes" = "Download routes";
-
-"bookmarks_downloaded_title" = "Bookmarks have been downloaded successfully";
-
-"bookmarks_downloaded_subtitle" = "Press ‘View on map’ to explore new places from the list";
-
-"why_support" = "Miksi tukea Organic Maps?";
-
-"why_support_item1" = "We respect your privacy: there are zero trackers in the app, and we are open source";
-
-"why_support_item2" = "Sinä autat meitä parantamaan Organic Maps:tä";
-
-"why_support_item3" = "Auta meitä parantamaan avoimia karttoja OpenStreetMap.org";
-
-"channels_map_update" = "Kartan päivitykset";
-
-"server_unavailable_title" = "Serveri ei ole saatavilla";
-
-"sharing_options" = "Käyttöasetukset";
 
 "export_file" = "Viedä tiedosto";
 
 "list_settings" = "Listan asetukset";
 
 "delete_list" = "Poista lista";
-
-"hide_from_map" = "Piilottaa kartalta";
 
 "public_access" = "Julkinen pääsy";
 
@@ -1845,40 +1135,11 @@
 
 "bookmark_category_description_hint" = "Lisää kuvaus (teksti tai html)";
 
-/* FIXME */
-"bookmarks_public_access" = "bookmarks_public_access";
-
-/* FIXME */
-"bookmarks_link_access" = "bookmarks_link_access";
-
-/* FIXME */
-"bookmarks_private_access" = "bookmarks_private_access";
-
 "not_shared" = "Henkilökohtainen";
-
-"direct_link_progress_text" = "Lataamme tiedostoanne…";
-
-"direct_link_success" = "Linkki on luotu";
-
-"send_a_link_btn" = "Lähetä linkki";
-
-"upload_error_toast" = "Tiedoston lataamisen aikana tapahtui virhe";
 
 "tags_loading_error_subtitle" = "Tunnisteiden lataamisen aikana tapahtui virhe, yritä uudelleen";
 
-"unable_upload_errorr_title" = "Tiedoston lataamisen epäonnistui";
-
-"unable_upload_error_subtitle_edited" = "Tiedosto muokattiin web-sovelluksen kautta";
-
-"unable_upload_error_subtitle_broken" = "Tiedosto on vioittunut eikä sitä voi ladata. Ole hyvä, lataa toinen tiedosto.";
-
-"contact" = "Kirjoita";
-
-"download_button" = "Ladata";
-
 "speedcams_alert_title" = "Nopeuskamerat";
-
-"speedcams_alert_subtitle" = "Varoita nopeusrajoituksista";
 
 "speedcam_option_auto" = "Auto";
 
@@ -1886,18 +1147,10 @@
 
 "speedcam_option_never" = "Ei koskaan";
 
-"bookmark_description_title" = "Merkin kuvaus";
-
 "place_description_title" = "Paikan kuvaus";
 
 /* this text will be shown in application notification preferences opposite checkbox which enable/disable downloader notifications. Devices on Android 8+ are affected. */
 "notification_channel_downloader" = "Karttojen lataaminen";
-
-"share_bookmarks_email_body_link" = "Hei!\n\nMerkkinne voi ladata linkistä: %s. Avaa luettelo Organic Maps: llä ja nauti matkasta!\n\nLataa sovellus: https://omaps.app/get?kmz";
-
-"warning_speedcams_title" = "Navigaattori ilmoittaa sinulle kameroista, kun nopeusraja ylittyy %d km/t";
-
-"warning_speedcams_subtitle" = "Muista tutustua matkustusmaan liikennesääntöihin.";
 
 "speedcams_notice_message" = "Auto - Varoita nopeuskameroista, jos tuntuu siltä, että nopeusrajan ylitys on mahdollista\nAina - Varoita kameroista aina\nEi koskaan - älä koskaan varoita kameroista";
 
@@ -1913,23 +1166,7 @@
 
 "enable_logging_warning_message" = "Valinta ottaa käyttöön lokikirjaukset diagnostiikkaa varten. Se voi auttaa tukihenkilöstöämme, kun he korjaavat sovelluksen ongelmia. Ota tämä ominaisuus käyttöön vain, jos Organic Maps:n tuki pyytää.";
 
-"html_error_upload_message_try_again" = "Tarkista verkkoasetukset ja kokeile uudelleen";
-
-"html_error_upload_title_try_again" = "Ei nettiyhteyttä";
-
-"notification_leave_review_v2_android_short_title" = "Arvostele ja auta matkailijoita!";
-
-"megafon" = "Say goodbye to roaming!";
-
-"notifications_illegal_alert_disable_button" = "Kytke ilmoitukset pois";
-
 "access_rules_author_only" = "Nettimuokkaus";
-
-"privacy_settings_menu" = "Yksityisyysasetukset";
-
-"unable_upadate_error_title" = "Tiedoston päivitys epäonnistui";
-
-"unable_upadate_error_message" = "Päivityksen aikana tapahtui jokin virhe. Tarkista muutokset ja yritä uudelleen";
 
 "driving_options_title" = "Kiertotien asetukset";
 
@@ -1951,94 +1188,19 @@
 
 "change_driving_options_btn" = "Kiertotien asetukset on päällä";
 
-"toll_road" = "Maksullinen tie";
-
-"unpaved_road" = "Päällystämätön tie";
-
-"ferry_crossing" = "Lauttaliikenne";
-
-"operated_by" = "Hallinnoitu \"%s\"";
-
 "avoid_toll_roads_placepage" = "Vältä maksullisia teitä";
 
 "avoid_unpaved_roads_placepage" = "Vältä maanteitä";
 
 "avoid_ferry_crossing_placepage" = "Vältä lautan käyttöä";
 
-"type.cuisine.uzbek" = "Uzbekistanilainen ruokaa";
-
-"trip_start" = "Mennään";
-
-"pick_destination" = "Kohde";
-
-"follow_my_position" = "Kohdista";
-
-"search_results" = "Hakutulokset";
-
-"then_turn" = "Sitten";
-
-"redirect_route_alert" = "Haluatko luoda reitin uudelleen?";
-
-"redirect_route_yes" = "Kyllä";
-
-"redirect_route_no" = "Ei";
-
-"trip_finished" = "Olet saapunut!";
-
-"keyboard_availability_alert" = "Näppäimistö ei ole käytettävissä ajon aikana";
-
-"dialog_routing_change_start_carplay" = "Reittiä ei ole mahdollista luoda nykyisestä sijainnista";
-
-"dialog_routing_change_end_carplay" = "Reittiä ei ole mahdollista luoda loppupisteeseen. Valitse toinen";
-
-"dialog_routing_check_gps_carplay" = "Ei ole GPS-signaalia. Siirry avaralle alueelle";
-
-"dialog_routing_unable_locate_route_carplay" = "Reittiä ei ole mahdollista luoda. Valitse muut reittipisteet";
-
-"dialog_routing_download_files_carplay" = "Luodaksesi reitin lataa puutt. kartat";
-
-"dialog_routing_system_error_carplay" = "On tapahtunut virhe. Käynnistä sovellus uudelleen";
-
-"dialog_routing_rebuild_from_current_location_carplay" = "Reitti luodaan nykyisestä sijainnista";
-
-"dialog_routing_rebuild_for_vehicle_carplay" = "Reitti muutetaan autoilijan reitiksi";
-
 "ok" = "Ok";
-
-"avoid_unpaved_carplay_1" = "Päällyste";
-
-"avoid_unpaved_carplay_2" = "Vain päällyste";
-
-"avoid_ferry_carplay_1" = "Ei lauttoja";
-
-"avoid_ferry_carplay_2" = "Ei lauttoja";
-
-"avoid_tolls_carplay_1" = "Ei maksua";
-
-"avoid_tolls_carplay_2" = "Ei maksua";
-
-"speedcams_alert_title_carplay_1" = "Nopeuskamera";
-
-"speedcams_alert_title_carplay_2" = "Nopeuskamerat";
-
-"download_map_carplay" = "Lataa kartat laitteesi Organic Maps-sovelluksessa";
-
-"carplay_roundabout_exit" = "Poistumisramppi %s";
 
 /* max. 10 symbols, both iOS and Android */
 "sort" = "Järjestä…";
 
 /* Android, title, max 20-22 symbols */
 "sort_bookmarks" = "Järjestä kirjanmerkit";
-
-/* iOS */
-"sort_default" = "Järjestä: oletus";
-
-"sort_type" = "Järjestä: tyyppi";
-
-"sort_distance" = "Järjestä: etäisyys";
-
-"sort_date" = "Järjestä: päivämäärä";
 
 /* Android */
 "by_default" = "Oletus";
@@ -2052,63 +1214,7 @@
 /* Android */
 "by_date" = "Päivämäärä";
 
-"week_ago_sorttype" = "Viikko sitten";
-
-"month_ago_sorttype" = "Kuukausi sitten";
-
-"moremonth_ago_sorttype" = "Yli kuukausi sitten";
-
-"moreyear_ago_sorttype" = "Yli vuosi sitten";
-
-"near_me_sorttype" = "Lähelläni";
-
-"others_sorttype" = "Muut";
-
-"food_places" = "Ruoka";
-
-"tourist_places" = "Nähtävyydet";
-
-"museums" = "Museot";
-
-"parks" = "Puistot";
-
-"swim_places" = "Uiminen";
-
-"mountains" = "Vuoret";
-
-"animals" = "Eläimet";
-
-"hotels" = "Hotellit";
-
-"buildings" = "Rakennukset";
-
-"money" = "Raha";
-
-"shops" = "Kaupat";
-
-"parkings" = "Pysäköinti";
-
-"fuel_places" = "Huoltoasemat";
-
-"water" = "Vesi";
-
-"medicine" = "Apteekki";
-
 "search_in_the_list" = "Etsi listalta";
-
-"view_on_map_bookmarks" = "Kartalla";
-
-"more_bookmarks" = "Lisää…";
-
-"no_items_found" = "Kohteita ei löytynyt";
-
-/* Android, max 18 symbols */
-"bookmarks_edit_list" = "Muokkaa listaa";
-
-/* Android, max 18 symbols */
-"bookmarks_delete_list" = "Poista lista";
-
-"religious_places" = "Pyhät paikat";
 
 "select_list" = "Valitse luettelo";
 
@@ -2118,26 +1224,13 @@
 
 "dialog_pedestrian_route_is_long_message" = "Valitse reitin aloitus- tai loppupiste lähemmäksi metroasemaa";
 
-/* Failed planning SUBWAY route message in navigation view */
-"routing_planning_error_subway_special" = "Virhe metroreitin luomisessa";
-
 "button_layer_isolines" = "Korkeudet";
-
-"tips_map_layers_title_countour" = "Korkeuslinjat offline-tilassa Organic Maps:ssä!";
-
-"tips_map_layers_message_countour" = "Korkeuslinjat auttavat suunnittelemaan luontomatkan etkä enää eksy maastolla";
 
 "isolines_activation_error_dialog" = "Päivitä tai lataa haluamasi alueen kartta, voidaksesi käyttää korkeuslinjoja";
 
 "isolines_location_error_dialog" = "Korkeus linjat eivät ole vielä saatavilla tällä alueella";
 
 "elevation_profile_diff_level" = "Vaikeustaso";
-
-"elevation_profile_diff_level_easy" = "Helppo";
-
-"elevation_profile_diff_level_moderate" = "Kohtuullinen";
-
-"elevation_profile_diff_level_hard" = "Vaikea";
 
 "elevation_profile_ascent" = "Nosto";
 
@@ -2147,25 +1240,13 @@
 
 "elevation_profile_maxaltitude" = "Maks. korkeus";
 
-"elevation_profile_m" = "m";
-
 "elevation_profile_difficulty" = "Vaikeus";
 
 "elevation_profile_distance" = "Etäisyys:";
 
-"elevation_profile_km" = "km";
-
 "elevation_profile_time" = "Aika:";
 
-"elevation_profile_hours" = "t.";
-
-"elevation_profile_minutes" = "min";
-
 "isolines_toast_zooms_1_10" = "Suurenna kartta nähdäksesi korkeuslinjat";
-
-"downloader_updating_ios" = "Päivitys";
-
-"downloader_loading_ios" = "Lataus";
 
 "key_information_title" = "Avaintietoa";
 

--- a/iphone/Maps/LocalizedStrings/fi.lproj/Localizable.stringsdict
+++ b/iphone/Maps/LocalizedStrings/fi.lproj/Localizable.stringsdict
@@ -9,21 +9,6 @@
 
 <!-- ********** Strings for downloading map from search **********/ -->
 
-  <key>bookmarks_places</key>
-  <dict>
-    <key>NSStringLocalizedFormatKey</key>
-    <string>%#@value@</string>
-    <key>value</key>
-    <dict>
-      <key>NSStringFormatSpecTypeKey</key>
-      <string>NSStringPluralRuleType</string>
-      <key>NSStringFormatValueTypeKey</key>
-      <string>d</string>
-      <key>other</key>
-      <string>%d kirjanmerkkiä</string>
-    </dict>
-  </dict>
-
   <key>bookmarks_detect_message</key>
   <dict>
     <key>NSStringLocalizedFormatKey</key>
@@ -38,21 +23,6 @@
       <string>%d tiedosto löydettiin. Näet sen muunnoksen jälkeen.</string>
       <key>other</key>
       <string>%d tiedostoa on löytynyt. Näet heidät muuntamisen jälkeen.</string>
-    </dict>
-  </dict>
-
-  <key>bookmarks_objects</key>
-  <dict>
-    <key>NSStringLocalizedFormatKey</key>
-    <string>%#@value@</string>
-    <key>value</key>
-    <dict>
-      <key>NSStringFormatSpecTypeKey</key>
-      <string>NSStringPluralRuleType</string>
-      <key>NSStringFormatValueTypeKey</key>
-      <string>d</string>
-      <key>other</key>
-      <string>%s kohde</string>
     </dict>
   </dict>
 

--- a/iphone/Maps/LocalizedStrings/fr.lproj/Localizable.strings
+++ b/iphone/Maps/LocalizedStrings/fr.lproj/Localizable.strings
@@ -18,9 +18,6 @@
 /* Button which deletes downloaded country */
 "delete" = "Supprimer";
 
-/* Button "do not interrupt download" if user touched actively downloading country */
-"do_nothing" = "Continuer";
-
 "download_maps" = "Télécharger des cartes";
 
 /* Settings/Downloader - info for country when download fails */
@@ -28,9 +25,6 @@
 
 /* Settings/Downloader - info for country which started downloading */
 "downloading" = "Téléchargement…";
-
-/* Settings/Downloader - size string, only strings different from English should be translated */
-"kb" = "ko";
 
 /* Choose measurement on first launch alert - choose metric system button */
 "kilometres" = "kilomètres";
@@ -55,17 +49,11 @@
 /* Update maps later/Buy pro version later button text */
 "later" = "Plus tard";
 
-/* Don't show some dialog any more */
-"never" = "Jamais";
-
 /* View and button titles for accessibility */
 "search" = "Recherche";
 
 /* Search box placeholder text */
 "search_map" = "Rechercher sur la carte";
-
-/* Settings/Downloader - info for not downloaded country */
-"touch_to_download" = "Toucher pour télécharger";
 
 /* Settings/Downloader - 3G download warning dialog confirm button */
 "use_cellular_data" = "Oui";
@@ -73,20 +61,11 @@
 /* Location services are disabled by user alert - message */
 "location_is_disabled_long_text" = "Tous les services de localisation de cet appareil sont désactivés, ou ils le sont pour cette application. Veuillez les activer dans les paramètres.";
 
-/* Location Services are not available on the device alert - message */
-"device_doesnot_support_location_services" = "Votre appareil ne prend pas en charge les services de localisation";
-
 /* View and button titles for accessibility */
 "zoom_to_country" = "Voir sur la carte";
 
-/* Button text for the button at the center of the screen when the country is not downloaded */
-"country_status_download" = "Téléchargez la carte\n(^ ^)";
-
 /* Button text for the button at the center of the screen when the country is not downloaded and the size should not be shown */
 "country_status_download_without_size" = "Téléchargez la carte";
-
-/* Button text for the button at the center of the screen when the country is not downloaded */
-"country_status_download_without_routing" = "Télécharger la carte\nsans itinéraire (^ ^)";
 
 /* Message to display at the center of the screen when the country download has failed */
 "country_status_download_failed" = "Échec lors du téléchargement";
@@ -96,19 +75,13 @@
 
 "about_menu_title" = "À propos de Organic Maps";
 
-"downloaded_touch_to_delete" = "Téléchargé (%@), toucher pour supprimer";
-
 "connection_settings" = "Paramètres de connexion";
-
-"download_mb_or_kb" = "Télécharger %@";
 
 "close" = "Fermer";
 
 "unsupported_phone" = "L'accélération OpenGL matérielle est exigée. Malheureusement, votre appareil n'est pas pris en charge.";
 
 "download" = "Télécharger";
-
-"external_storage_is_not_available" = "La carte SD/le stockage USB contenant les cartes téléchargées n'est pas disponible";
 
 "disconnect_usb_cable" = "Veuillez débrancher le câble USB ou insérer la carte SD pour utiliser Organic Maps";
 
@@ -117,8 +90,6 @@
 "not_enough_memory" = "Mémoire insuffisante pour lancer l'appli";
 
 "download_resources" = "Avant de commencer, permettez-nous de télécharger la carte générale du monde dans votre appareil.\n%@ de données sont nécessaires.";
-
-"getting_position" = "Obtention de la position actuelle";
 
 "download_resources_continue" = "Aller sur la carte";
 
@@ -140,23 +111,14 @@
 /* Add New Bookmark Set dialog title */
 "add_new_set" = "Ajouter un nouveau groupe";
 
-/* Place Page - Add To Bookmarks button */
-"add_to_bookmarks" = "Ajouter aux signets";
-
 /* Bookmark Color dialog title */
 "bookmark_color" = "Couleur du signet";
 
 /* Add Bookmark Set dialog - hint when set name is empty */
 "bookmark_set_name" = "Nom du groupe de signets";
 
-/* Bookmark Sets dialog title */
-"bookmark_sets" = "Groupes de signets";
-
 /* Bookmarks - dialog title */
 "bookmarks" = "Signets";
-
-/* Add bookmark dialog - bookmark color */
-"color" = "Couleur";
 
 /* Default bookmarks set name */
 "core_my_places" = "Mes endroits";
@@ -167,14 +129,8 @@
 /* Editor title above street and house number */
 "address" = "Adresse";
 
-/* Place Page - Remove Pin button */
-"remove_pin" = "Enlever l'épingle";
-
 /* Add bookmark dialog - bookmark set, Bookmarks dialog - Bookmark set cell */
 "set" = "Groupe";
-
-/* Text hint in Bookmarks dialog when no any bookmarks are added */
-"bookmarks_usage_hint" = "Vous n'avez encore aucun signet.\nTouchez n'importe où sur la carte pour en ajouter un.\nLes signets provenant d'autres sources peuvent aussi être importés et affichés dans Organic Maps. Ouvrez des fichiers KML/KMZ contenant des signets enregistrés, à partir d'un courriel, de Dropbox ou d'un lien Web.";
 
 /* Settings button in system menu */
 "settings" = "Paramètres";
@@ -191,26 +147,11 @@
 /* Ask to wait user several minutes (some long process in modal dialog). */
 "wait_several_minutes" = "Ceci peut prendre plusieurs minutes.\nVeuillez patienter…";
 
-/* Show bookmarks from this category on a map or not */
-"visible" = "Visible";
-
-/* Toast which is displayed when GPS has been deactivated */
-"gps_is_disabled_long_text" = "Le GPS est désactivé. Veuillez l'activer dans les Paramètres.";
-
 /* Measurement units title in settings activity */
 "measurement_units" = "Unités de mesure";
 
 /* Detailed description of Measurement Units settings button */
 "measurement_units_summary" = "Choisir entre miles et kilomètres";
-
-/* Do search in all sources */
-"search_mode_all" = "Partout";
-
-/* Do search near my position only */
-"search_mode_nearme" = "Près de moi";
-
-/* Do search in current viewport only */
-"search_mode_viewport" = "À l'écran";
 
 /* Search category for cafes, bars, restaurants */
 "eat" = "Un endroit pour manger";
@@ -266,14 +207,8 @@
 /* Search category */
 "police" = "Police";
 
-/* String in search result list, when nothing found */
-"no_search_results_found" = "Aucun résultat trouvé";
-
 /* Notes field in Bookmarks view */
 "description" = "Notes";
-
-/* Button text */
-"share_by_email" = "Partager par courriel";
 
 /* Email Subject when sharing bookmarks category */
 "share_bookmarks_email_subject" = "Signets Organic Maps partagés";
@@ -295,26 +230,11 @@
 /* Warning message when doing search around current position */
 "unknown_current_position" = "Votre position n'a pas encore été déterminée";
 
-/* Warning message when location country isn't downloaded during search (see also download_location_map_proposal). */
-"download_location_country" = "Télécharger le pays de votre position actuelle (%@)";
-
-/* Warning message when viewport country isn't downloaded during search */
-"download_viewport_country_to_search" = "Télécharger le pays que vous recherchez (%@)";
-
 /* Alert message that we can't run Map Storage settings due to some reasons. */
 "cant_change_this_setting" = "Désolé, les paramètres de stockage des cartes sont présentement désactivés.";
 
 /* Alert message that downloading is in progress. */
 "downloading_is_active" = "Le téléchargement du pays est en cours.";
-
-/* Message that will be shown in alert view, when we ask user to leave review on App Store */
-"appStore_message" = "Nous espérons que vous appréciez l'utilisation de Organic Maps ! Si oui, veuillez évaluer l'appli ou laisser une critique sur l'App Store. Cela prend moins d'une minute, mais peut vraiment nous aider. Merci pour votre soutien !";
-
-/* No, thanks */
-"no_thanks" = "Non, merci";
-
-/* Share one specific bookmark using SMS, %1$@ contains om:// and %2$@ https://omaps.app link. @NOTE non-ascii symbols in the link will result in max 70 characters SMS instead of 140. */
-"bookmark_share_sms" = "Hé, regarde mon épingle sur Organic Maps ! %1$@ ou %2$@. Les cartes hors ligne ne sont pas installées ? Les télécharger ici : https://omaps.app/get";
 
 /* Share my position using SMS, %1$@ contains om:// and %2$@ https://omaps.app link WITHOUT NAME. @NOTE non-ascii symbols in the link will result in max 70 characters SMS instead of 140. */
 "my_position_share_sms" = "Hé, regarde ma position actuelle sur Organic Maps ! %1$@ ou %2$@. Les cartes hors ligne ne sont pas installées ? Les télécharger ici : https://omaps.app/get";
@@ -328,23 +248,11 @@
 /* Share my position using EMail, %1$@ is om:// and %2$@ is https://omaps.app link WITHOUT NAME */
 "my_position_share_email" = "Bonjour,\n\nJe suis actuellement ici : %1$@. Clique sur ce lien %2$@ ou sur celui-ci %3$@ pour voir l'endroit sur la carte.\n\nMerci.";
 
-/* Android share by Message/SMS button text (including SMS) */
-"share_by_message" = "Partager par message";
-
 /* Share button text which opens menu with more buttons, like Message, EMail, Facebook etc. */
 "share" = "Partager";
 
-/* iOS share by Message button text (including SMS) */
-"message" = "Message";
-
 /* Share by email button text, also used in editor. */
 "email" = "Email";
-
-/* Copy Link */
-"copy_link" = "Copier le lien";
-
-/* Text for the button that returns to caller application */
-"more_info" = "Afficher plus d'informations";
 
 /* Text for message when used successfully copied something */
 "copied_to_clipboard" = "Copié dans le presse-papiers : %1$@";
@@ -354,15 +262,6 @@
 
 /* Used for bookmark editing */
 "done" = "Terminé";
-
-/* Summary for preferences in MWM */
-"yopme_pref_summary" = "Choisir les réglages de l'arrière-plan";
-
-/* Title for yopme preferences in MWM */
-"yopme_pref_title" = "Paramètres de l'arrière-plan";
-
-/* Hint for upper-right icon p2b */
-"show_on_backscreen" = "Afficher sur l'arrière-plan";
 
 /* Prints version number in About dialog */
 "version" = "Version : %@";
@@ -381,19 +280,11 @@
 
 "share_my_location" = "Partager ma position";
 
-"menu_search" = "Rechercher";
-
 /* Settings general group in settings screen */
 "prefs_group_general" = "Paramètres généraux";
 
 /* Settings information group in settings screen */
 "prefs_group_information" = "Information";
-
-/* Settings screen: "Map" category title */
-"prefs_group_map" = "Carte";
-
-/* Settings screen: "Miscellaneous" category title */
-"prefs_group_misc" = "Divers";
 
 "prefs_group_route" = "Navigation";
 
@@ -419,9 +310,6 @@
 /* Settings «Map» category: «3D buildings» title */
 "pref_map_3d_buildings_title" = "Bâtiments en 3D";
 
-/* Settings «Map» category: «3D buildings» summary */
-"pref_map_3d_buildings_subtitle" = "Affecte la vie de la batterie";
-
 /* Settings «Route» category: «Tts enabled» title */
 "pref_tts_enable_title" = "Instructions vocales";
 
@@ -433,8 +321,6 @@
 
 /* Title for "Other" section in TTS settings. */
 "pref_tts_other_section_title" = "Autre";
-
-"pref_tts_how_to_set_up_voice" = "Comment configurer la voix";
 
 /* Settings «Map» category: «Record track» title */
 "pref_track_record_title" = "Parcours récent";
@@ -453,58 +339,9 @@
 
 "duration_1_day" = "1 jour";
 
-"recent_track_help_text" = "Ceci vous permet d’enregistrer le chemin emprunté pendant un certain temps et de le voir sur la carte. Veuillez noter : l’activation de cette fonction entraîne une grande utilisation de la batterie. La route sera supprimée automatiquement de la carte lorsque l’intervalle de temps sera arrivé à expiration.";
-
-"pref_track_ios_caption" = "L'itinéraire récent indique votre chemin parcouru.";
-
-"pref_track_ios_subcaption" = "Veuillez sélectionner la période d'enregistrement du parcours.";
-
-"placepage_distance" = "Distance";
-
-"placepage_coordinates" = "Coordonnées";
-
-"placepage_unsorted" = "Non trié";
+"recent_track_help_text" = "Ceci vous permet d’enregistrer le chemin emprunté pendant un certain temps et de le voir sur la carte. Veuillez noter : l’activation de cette fonction entraîne une grande utilisation de la batterie. La route sera supprimée automatiquement de la carte lorsque l’intervalle de temps sera arrivé à expiration.";
 
 "search_show_on_map" = "Voir sur la carte";
-
-/* Used to warn user when fixing KitKat issue */
-"bookmark_move_fail" = "Nous devons déplacer vos signets vers la mémoire interne, mais il n'y a pas d'espace disponible pour eux. Veuillez libérer de la mémoire, sinon les signets ne seront pas disponibles.";
-
-/* Used in More Apps menu */
-"free" = "Gratuit";
-
-/* Used in More Apps menu */
-"buy" = "Acheter";
-
-/* 1st search button-like result */
-"search_on_map" = "Rechercher sur la carte";
-
-/* toast with an error */
-"no_route_found" = "Aucun itinéraire trouvé";
-
-/* route title */
-"route" = "Itinéraire";
-
-/* category title */
-"routes" = "Itinéraires";
-
-/* text of notification */
-"download_map_notification" = "Télécharger la carte de l'endroit où vous êtes";
-
-/* text of notification */
-"pro_version_is_free_today" = "Version complète de Organic Maps gratuite aujourd'hui ! Téléchargez-le maintenant et dites-le à vos amis.";
-
-/* Dialog for transferring maps from lite to pro. */
-"move_lite_maps_to_pro" = "Nous transférons vos cartes téléchargées de Organic Maps Lite vers Organic Maps. Cela peut prendre quelques minutes.";
-
-/* Message to display when maps moved. */
-"move_lite_maps_to_pro_ok" = "Vos cartes téléchargées ont été transférées avec succès vers Organic Maps.";
-
-/* Message to display when maps move failed. */
-"move_lite_maps_to_pro_failed" = "Le transfert de vos cartes a échoué. Veuillez supprimer Organic Maps Lite et télécharger les cartes de nouveau.";
-
-/* Text in menu */
-"settings_and_more" = "Paramètres & plus";
 
 /* Text in menu */
 "website" = "Site internet";
@@ -527,14 +364,8 @@
 /* Text in menu */
 "openstreetmap" = "OpenStreetMap";
 
-/* Text in menu */
-"contact_us" = "Contactez-nous";
-
 /* Settings: Send feedback button and dialog title */
 "feedback" = "Feedback";
-
-/* Text in menu */
-"subscribe_to_news" = "S'abonner à nos informations";
 
 /* Text in menu */
 "rate_the_app" = "Évaluer l'appli";
@@ -548,15 +379,6 @@
 /* Text in menu */
 "report_a_bug" = "Signaler un bug";
 
-/* Email subject */
-"subscribe_me_subject" = "Veuillez m'inscrire à la lettre d'information de Organic Maps";
-
-/* Email body */
-"subscribe_me_body" = "Informez-moi en priorité des dernières nouvelles, des mises à jour et des promotions. Je peux annuler mon abonnement à tout moment.";
-
-/* About text */
-"about_text" = "Organic Maps offre les cartes hors ligne les plus rapides de toutes les villes, de tous les pays du monde. Voyagez en toute confiance : où que vous soyez, Organic Maps permet de vous situer sur la carte, de trouver le restaurant, l'hôtel, la banque, la station d'essence, etc. les plus proches. Ceci sans aucune connexion Internet.\n\nNous travaillons toujours sur de nouvelles fonctionnalités et nous aimerions avoir votre avis sur la manière d'améliorer Organic Maps. Si vous avez quelque problème avec l'appli, n'hésitez pas à nous contacter à support@organicmaps.app. Nous répondons à toutes les demandes !\n\nVous aimez-vous Organic Maps et souhaitez nous soutenir ? Il existe des moyens simples et tout à fait gratuits :\n\n- Publier une critique sur votre boutique d'applis\n- aimez notre page Facebook http://www.facebook.com/OrganicMaps\n- ou parlez simplement de Organic Maps à votre maman, à vos amis et à vos collègues :)\n\nNous vous remercions de votre fidélité. Nous apprécions beaucoup votre soutien !\n\nP.S. : nous prenons les données cartographiques d'OpenStreetMap, un projet de cartographie similaire à Wikipédia, qui permet aux utilisateurs de créer et de modifier des cartes. Si vous voyez une omission ou une erreur sur la carte, vous pouvez corriger les cartes directement sur https://www.openstreetmap.org, et vos modifications apparaîtront dans l'appli Organic Maps lors la prochaine version.";
-
 /* Alert text */
 "email_error_body" = "Le client de courriel n'a pas été configuré. Veuillez le faire ou employer tout autre moyen pour nous contacter à %@";
 
@@ -569,12 +391,6 @@
 /* Search category */
 "wifi" = "WiFi";
 
-/* Update map suggestion */
-"routing_map_outdated" = "Veuillez mettre à jour la carte pour créer un itinéraire.";
-
-/* Update maps suggestion */
-"routing_update_maps" = "La nouvelle version de Organic Maps permet de créer des itinéraires à partir de votre position actuelle vers un point de destination. Veuillez mettre à jour les cartes pour utiliser cette fonctionnalité.";
-
 /* Update all button text */
 "downloader_update_all_button" = "Tout mettre à jour";
 
@@ -583,9 +399,6 @@
 
 /* Downloaded maps category */
 "downloader_downloaded_subtitle" = "Téléchargé";
-
-/* Downloaded maps category */
-"downloader_available_maps" = "Disponible";
 
 /* Country queued for download */
 "downloader_queued" = "En file d'attente";
@@ -598,17 +411,6 @@
 
 "downloader_downloading" = "Téléchargement en cours :";
 
-"downloader_search_results" = "Trouvé";
-
-/* Disclaimer message */
-"routing_disclaimer" = "Quand vous créez des itinéraires sur l'application Organic Maps, veuillez garder à l'esprit les points suivants :\n\n  - Les itinéraires suggérés ne doivent être considérés que comme des recommandations.\n\n  - Les conditions des routes, les règlementations de circulations et les panneaux sont prioritaires sur les conseils de navigation.\n\n  - Il est possible qu'une carte soit incorrecte ou obsolète, et les itinéraires ne sont pas toujours créés de la meilleure façon possible.\n\n  Soyez prudents sur les routes et prenez soin de vous.";
-
-/* Outdated maps category */
-"downloader_outdated_maps" = "Dépassé";
-
-/* Up to date maps category */
-"downloader_uptodate_maps" = "À jour";
-
 /* Status of outdated country in the list */
 "downloader_status_outdated" = "Mettre à jour";
 
@@ -618,49 +420,14 @@
 /* Displayed in a dialog that appears when a user tries to delete a map while the app is in the follow route mode */
 "downloader_delete_map_while_routing_dialog" = "Veuillez interrompre la navigation pour supprimer la carte.";
 
-/* Show when user try build route, but we don't know where he */
-"routing_failed_unknown_my_position" = "L'emplacement actuel n'est pas défini. Veuillez préciser l'emplacement pour créer l'itinéraire.";
-
-/* Show if use has not routing file, or InconsistentMWMandRoute */
-"routing_failed_has_no_routing_file" = "Des données supplémentaires sont nécessaires pour créer un itinéraire. Vous désirez lancer le téléchargement ?";
-
-/* StartPointNotFound */
-"routing_failed_start_point_not_found" = "Impossible de calculer l'itinéraire. Aucune route à proximité de votre point de départ.";
-
-/* EndPointNotFound */
-"routing_failed_dst_point_not_found" = "Impossible de calculer l'itinéraire. Aucune route à proximité de votre destination.";
-
 /* PointsInDifferentMWM */
 "routing_failed_cross_mwm_building" = "Les itinéraires entièrement contenus sur une seule carte peuvent être créés.";
-
-/* RouteNotFound */
-"routing_failed_route_not_found" = "Il n'existe aucun itinéraire entre l'origine et la destination choisie. Veuillez sélectionner un point de départ ou d'arrivée différent.";
-
-/* InternalError */
-"routing_failed_internal_error" = "Une erreur interne s'est produite. Veuillez essayer de supprimer la carte et téléchargez la à nouveau. Si le problème persiste, veuillez contacter support@organicmaps.app.";
-
-/* Context menu item for downloader. */
-"downloader_download_map_and_routing" = "Télécharger Carte + Itinéraire";
-
-/* Context menu item for downloader. */
-"downloader_download_routing" = "Télécharger Itinéraire";
-
-/* Context menu item for downloader. */
-"downloader_delete_routing" = "Supprimer Itinéraire";
 
 /* Context menu item for downloader. */
 "downloader_download_map" = "Télécharger la carte";
 
-"downloader_download_map_no_routing" = "Télécharger la carte sans itinéraire";
-
-/* Button for routing. */
-"routing_go" = "Allez-y !";
-
 /* Item status in downloader. */
 "downloader_retry" = "Répéter";
-
-/* Item in context menu. */
-"downloader_map_and_routing" = "Carte + itinéraire";
 
 /* Item in context menu. */
 "downloader_delete_map" = "Supprimer carte";
@@ -668,29 +435,11 @@
 /* Item in context menu. */
 "downloader_update_map" = "Mise à jour carte";
 
-/* Item in context menu. */
-"downloader_update_map_and_routing" = "Mise à jour carte + itinéraire";
-
-/* Item in context menu. */
-"downloader_map_only" = "Carte uniquement";
-
-/* Toolbar title */
-"toolbar_application_menu" = "Menu principal";
-
 /* Preference text */
 "pref_use_google_play" = "Utilisez l'application Google Play Services pour obtenir votre emplacement actuel";
 
 /* Text for rating dialog */
 "rating_just_rated" = "Je viens d'évaluer votre appli";
-
-/* Text for rating dialog */
-"rating_user_since" = "J'utilise Organic Maps depuis %@";
-
-/* Text for rating dialog */
-"rating_do_like_maps" = "Aimez-vous Organic Maps ?";
-
-/* Text for rating dialog */
-"rating_tap_star" = "Tapotez sur une étoile pour évaluer notre appli";
 
 /* Text for rating dialog */
 "rating_thanks" = "Merci !";
@@ -701,23 +450,8 @@
 /* Text for rating dialog */
 "rating_send_feedback" = "Envoyez vos commentaires";
 
-/* Text for g+ dialog */
-"rating_google_plus" = "Clique sur g+ pour parler de l'appli à tes amis.";
-
 /* Text for routing error dialog */
 "routing_download_maps_along" = "Téléchargez des cartes le long du trajet";
-
-/* Text for routing error dialog */
-"routing_download_map" = "Téléchargez des cartes";
-
-/* Text for routing error dialog */
-"routing_download_map_and_routing" = "Des cartes actualisées et des données de routage pour obtenir toutes les fonctionnalités de Organic Maps.";
-
-/* Text for routing error dialog */
-"routing_get_routing_data" = "Recevez des données de routage";
-
-/* Text for routing error dialog */
-"routing_get_additional_data" = "Des données supplémentaires nécessaires pour créer des itinéraires depuis votre localisation.";
 
 /* Text for routing error dialog */
 "routing_requires_all_map" = "La création d'un itinéraire nécessite que toutes les cartes de votre localisation vers votre destination soient téléchargées et actualisées.";
@@ -725,50 +459,15 @@
 /* Text for routing error dialog */
 "routing_not_enough_space" = "Pas assez d'espace";
 
-/* Text for routing error dialog */
-"routing_download_more_than_avail" = "Vous devez télécharger %@ Mo, mais seulement %@ Mo sont disponibles.";
-
-/* Text for routing error dialog */
-"routing_download_roaming" = "Vous allez télécharger %@ Mo à l'aide de données mobiles (frais d'itinérance). Cela peut entraîner des frais additionnels, en fonction du plan de données mobiles proposé par votre opérateur.";
-
 /* bookmark button text */
 "bookmark" = "signet";
-
-/* map is not downloaded */
-"not_found_map" = "La carte pour votre emplacement n'est pas téléchargée";
 
 /* location service disabled */
 "enable_location_services" = "Veuillez activer les services de localisation";
 
-/* download map */
-"download_map" = "Télécharger la carte de l'endroit où vous êtes";
-
-/* download map on iPhone */
-"download_map_iphone" = "Téléchargez la carte de l'endroit où vous vous trouvez sur votre iPhone";
-
-/* clear pin */
-"nearby" = "À proximité";
-
-/* clear pin */
-"clear_pin" = "Effacer Pin";
-
-/* location is undefined */
-"undefined_location" = "L'emplacement actuel n'est pas défini.";
-
-/* download country of your location */
-"download_country" = "Téléchargez la carte pour votre emplacement";
-
-/* download failed */
-"download_failed" = "échec lors du téléchargement";
-
-/* get the map */
-"get_the_map" = "Téléchargez des cartes";
-
 "save" = "Sauvegarder";
 
 "edit_description_hint" = "Vos descriptions (version texte ou html)";
-
-"new_group" = "nouveau groupe";
 
 "create" = "créer";
 
@@ -795,30 +494,6 @@
 
 /* pink color */
 "pink" = "Rose";
-
-/* deep purple color */
-"deep_purple" = "Pourpre foncé";
-
-/* light blue color */
-"light_blue" = "Bleu ciel";
-
-/* cyan color */
-"cyan" = "Cyan";
-
-/* teal color */
-"teal" = "Émeraude";
-
-/* lime color */
-"lime" = "Vert citron";
-
-/* deep orange color */
-"deep_orange" = "Orange foncé";
-
-/* gray color */
-"gray" = "Gris";
-
-/* blue gray color */
-"blue_gray" = "Gris-bleu";
 
 /* Wi-Fi available */
 "WiFi_available" = "Oui";
@@ -848,13 +523,9 @@
 
 "dialog_routing_location_unknown_turn_on" = "Impossible d'identifier les coordonnées GPS actuelles. Activez les services de localisation pour calculer l'itinéraire.";
 
-"dialog_routing_location_unknown" = "Impossible d'identifier les coordonnées GPS actuelles.";
-
 "dialog_routing_download_files" = "Téléchargez les fichiers requis";
 
 "dialog_routing_download_and_update_all" = "Téléchargez et mettez à jour les informations de carte et d'itinéraire de votre trajet pour calculer l'itinéraire.";
-
-"dialog_routing_routes_size" = "Fichiers d'itinéraire";
 
 "dialog_routing_unable_locate_route" = "Impossible de localiser l'itinéraire";
 
@@ -884,21 +555,11 @@
 
 "dialog_routing_try_again" = "Réessayer";
 
-"dialog_routing_send_error" = "Signaler le problème";
-
-"dialog_routing_if_get_cross_route" = "Voulez-vous créer un itinéraire plus direct s'étendant sur plus d'une carte ?";
-
-"dialog_routing_cross_route_is_optimal" = "Un itinéraire plus direct sortant du cadre de cette carte est disponible.";
-
 "not_now" = "Pas maintenant";
-
-"dialog_routing_build_route" = "Créer";
 
 "dialog_routing_download_and_build_cross_route" = "Voulez-vous télécharger la carte et créer un itinéraire plus direct s'étendant sur plus d'une carte?";
 
 "dialog_routing_download_cross_route" = "Téléchargez la carte pour créer un itinéraire plus direct sortant du cadre de cette carte.";
-
-"dialog_routing_cross_route_always" = "Toujours dépasser ce cadre";
 
 
 /********** Strings for downloading map from search **********/
@@ -906,8 +567,6 @@
 "search_without_internet_advertisement" = "Pour commencer à rechercher et à créer des itinéraires, veuillez télécharger la carte, et vous n'aurez plus besoin de connexion Internet.";
 
 "search_select_map" = "Sélectionner la carte";
-
-"search_select_other_map" = "Sélectionner une autre carte";
 
 /* «Show» context menu */
 "show" = "Afficher";
@@ -918,17 +577,11 @@
 /* «Rename» context menu */
 "rename" = "Renommer";
 
-/* Bottom sheet: expand button (should be short) */
-"bottom_sheet_more" = "Plus…";
-
 /* Failed planning route message in navigation view */
 "routing_planning_error" = "La planification de l'itinéraire a échoué";
 
 /* Arrive routing message in navigation view */
 "routing_arrive" = "Arrivée: %s";
-
-/* Text for routing::RouterResultCode::FileTooOld dialog. */
-"dialog_routing_download_and_update_maps" = "Pour créer un trajet, veuillez télécharger et mettre à jour toutes les cartes concernant ce trajet.";
 
 "rate_alert_title" = "Vous aimez l’application ?";
 
@@ -944,19 +597,11 @@
 
 "history" = "Historique";
 
-"next_turn_then" = "Ensuite";
-
 "closed" = "Fermé";
-
-"back_to" = "Revenir à %@";
 
 "search_not_found" = "Désolé, je n'ai rien trouvé.";
 
 "search_not_found_query" = "Veuillez essayer un autre mot-clé.";
-
-"search_not_found_map" = "Veuillez télécharger la carte dans laquelle vous recherchez.";
-
-"search_not_found_location" = "Téléchargez la carte de votre emplacement actuel.";
 
 "search_history_title" = "Historique de recherche";
 
@@ -964,23 +609,12 @@
 
 "clear_search" = "Effacer l'historique de recherche";
 
-/* Title for settings to enable/disable showcase menu button */
-"showcase_settings_title" = "Afficher les offres";
-
 /* Place Page link to Wikipedia article (if map object has it). */
 "read_in_wikipedia" = "Wikipédia";
 
-"p2p_route_planning" = "Planification d’itinéraire";
-
 "p2p_your_location" = "Votre emplacement";
 
-"p2p_from" = "Le lieu de départ";
-
-"p2p_to" = "Le lieu de destination";
-
 "p2p_start" = "Démarrer";
-
-"p2p_planning" = "En cours de planification…";
 
 "p2p_from_here" = "Depuis";
 
@@ -1018,15 +652,9 @@
 
 "editor_correct_mistake" = "Corriger l'erreur";
 
-"editor_correct_mistake_message" = "Vous avez fait une erreur d'édition. Veuillez la corriger ou passer en mode simple.";
-
 "editor_add_select_location" = "Emplacement";
 
 "editor_done_dialog_1" = "Vous avez modifié la carte du monde ! Ne le cachez pas ! Dites-le à vos amis, et modifiez-le ensemble.";
-
-"editor_done_dialog_2" = "Ceci est votre seconde amélioration de carte. Vous êtes maintenant à la %de place dans la liste des éditeurs de cartes. Dites-le à vos amis.";
-
-"editor_done_dialog_3" = "Vous avez amélioré la carte, dites-le à vos amis et modifiez la carte ensemble.";
 
 "share_with_friends" = "Partagez avec vos amis";
 
@@ -1044,20 +672,7 @@
 
 "editor_report_problem_duplicate_place_title" = "Lieu doublon";
 
-"first_launch_congrats_title" = "Organic Maps est prêt à l'utilisation";
-
-"first_launch_congrats_text" = "Cherchez et trouvez la bonne direction partout dans le monde, en mode hors-connexion, gratuitement.";
-
-"migrate_title" = "Important !";
-
-/* Android uses image instead of text. */
-"download_all" = "Tout télécharger";
-
-"delete_all" = "Supprimer tout";
-
 "autodownload" = "Téléchargement automatique";
-
-"disable_autodownload" = "Désactiver téléchargement automatique";
 
 /* Place Page opening hours text */
 "closed_now" = "Fermé actuellement";
@@ -1072,10 +687,6 @@
 "day_off" = "Fermé";
 
 "today" = "Aujourd'hui";
-
-"sunrise_to_sunset" = "Du lever au coucher du soleil";
-
-"sunset_to_sunrise" = "Du coucher au lever du soleil";
 
 "add_opening_hours" = "Ajouter les heures d'ouverture";
 
@@ -1095,45 +706,18 @@
 
 "forgot_password" = "Mot de passe oublié ?";
 
-/* Forgot Password dialog title */
-"restore_password" = "Réinitialiser le mot de passe";
-
-"enter_email_address_to_reset_password" = "Entrez l'adresse email que vous avez utilisé lors de l'inscription et nous vous ferons parvenir le lien pour renouveler votre mot de passe.";
-
-"reset_password" = "Réinitialiser le mot de passe";
-
-"username" = "Nom d'utilisateur";
-
 "osm_account" = "Compte OSM";
 
 "logout" = "Déconnexion";
 
-"login_and_edit_map_motivation_message" = "Connectez-vous et modifiez les informations des objets présents sur la carte et nous allons les rendre disponibles pour des millions d'autres utilisateurs. Rendons le monde meilleur ensemble.";
-
 /* Information text: "Last upload 11.01.2016" */
 "last_upload" = "Dernier téléchargement";
 
-/* Motivates user to login/register, title above login buttons. */
-"you_have_edited_your_first_object" = "Vous avez modifié votre premier objet!";
-
 "thank_you" = "Merci";
-
-"login_with_google" = "Connectez-vous avec Google";
-
-"login_with_openstreetmap" = "Connectez-vous sur www.openstreetmap.org";
 
 "edit_place" = "Modifier le lieu";
 
 "place_name" = "Nom du lieu";
-
-/* title above languages list cells in the editor, below editable name text field. */
-"other_languages" = "Autres langues";
-
-/* small button to open list with names in different languages */
-"show_more" = "Montrer plus";
-
-/* small button to close list with names in different languages */
-"show_less" = "Montrer moins";
 
 "add_language" = "Ajouter une langue";
 
@@ -1164,8 +748,6 @@
 
 "please_note" = "À noter";
 
-"common_no_wifi_dialog" = "Aucune connexion Wi-Fi. Voulez-vous continuer avec les données mobiles ?";
-
 "downloader_delete_map_dialog" = "Toutes les modifications de la carte seront supprimées avec elle.";
 
 "downloader_update_maps" = "Mettre à jour les cartes";
@@ -1173,10 +755,6 @@
 "downloader_mwm_migration_dialog" = "Pour créer un itinéraire, vous devez mettre à jour toutes les cartes puis reprogrammer l'itinéraire.";
 
 "downloader_search_field_hint" = "Trouver la carte";
-
-"migration_update_all_button" = "Mettre à jour toutes les cartes";
-
-"migration_delete_all_download_current_button" = "Téléchargez la carte actuelle et supprimez les anciennes";
 
 "migration_download_error_dialog" = "Erreur de téléchargement";
 
@@ -1186,21 +764,9 @@
 
 "downloader_no_space_message" = "Veuillez supprimer les données inutiles";
 
-"editor_general_auth_error_dialog" = "Erreur générale de connexion.";
-
 "editor_login_error_dialog" = "Erreur de connexion.";
 
-"editor_login_failed_dialog" = "La connexion a échoué";
-
-"editor_username_error_dialog" = "Le nom d'utilisateur est invalide";
-
-"editor_place_edited_dialog" = "Vous avez modifié un objet !";
-
-"editor_login_with_osm" = "Connexion avec OpenStreetMap";
-
 "editor_profile_changes" = "Modifications vérifiées";
-
-"editor_profile_unsent_changes" = "Non envoyé :";
 
 "editor_focus_map_on_location" = "Tirez la carte pour sélectionner la bonne position de l'objet.";
 
@@ -1222,13 +788,9 @@
 
 "editor_report_problem_other_title" = "Un problème différent";
 
-"placepage_report_problem_button" = "Signaler un problème";
-
 "placepage_add_business_button" = "Ajouter une organisation";
 
 "whatsnew_editor_message_1" = "Ajoutez de nouveaux lieux sur la carte et modifiez les lieux existants directement depuis l'appli.";
-
-"whatsnew_editor_message_2" = "* Organic Maps utilise les données de la communauté OpenStreetMap.";
 
 "dialog_incorrect_feature_position" = "Modifier l'emplacement";
 
@@ -1236,16 +798,10 @@
 
 "login_to_make_edits_visible" = "Se connecter pour que d'autres utilisateurs puissent voir les changements que vous avez effectués.";
 
-"no_migration_during_navigation" = "La mise à jour est interdite pendant la navigation.";
-
 /* Error dialog no space */
 "migration_no_space_message" = "Pour télécharger, vous avez besoin de plus d'espace. Veuillez supprimer les données non nécessaires.";
 
 "editor_sharing_title" = "J'ai amélioré les cartes de Organic Maps";
-
-"editor_comment_will_be_sent" = "Nous transmettrons votre commentaire aux cartographes.";
-
-"editor_unsupported_category_message" = "Vous avez ajouté un lieu appartenant à une catégorie que nous ne prenons pas encore en charge. Il apparaîtra sur la carte prochainement.";
 
 /* Downloaded 10 **of** 20 <- it is that "of" */
 "downloader_of" = "%1$d de %2$d";
@@ -1278,23 +834,9 @@
 
 "editor_operator" = "Opérateur";
 
-"editor_tag_description" = "Entrer la société, l'organisation ou l'individu responsable des installations.";
-
-"editor_no_local_edits_title" = "Vous n'avez pas de modifications locales";
-
-"editor_no_local_edits_description" = "Affiche le nombre de modifications suggérées dans la carte actuellement uniquement accessible sur votre périphérique.";
-
-"editor_send_to_osm" = "Envoyer à OSM";
-
-"editor_remove" = "Supprimer";
-
-"downloader_my_maps_title" = "Mes cartes";
-
 "downloader_no_downloaded_maps_title" = "Vous n'avez téléchargé aucune carte";
 
 "downloader_no_downloaded_maps_message" = "Téléchargez des cartes pour rechercher l'emplacement et naviguer hors ligne";
-
-"downloader_find_place_hint" = "Rechercher ville ou pays";
 
 /* Error title that appears after certain time without location. */
 "current_location_unknown_title" = "Continuer la détection de votre emplacement actuel ?";
@@ -1321,47 +863,13 @@
 /* iOS Dialog for the case when the location permission is not granted */
 "location_services_disabled_3" = "3. Sélectionner tout en utilisant l'app";
 
-"placepage_parking_surface" = "Surface";
-
-"placepage_parking_multistorey" = "Multi-niveaux";
-
-"placepage_parking_underground" = "Souterrain";
-
-"placepage_parking_rooftop" = "Toit";
-
-"placepage_parking_sheds" = "Hangars";
-
-"placepage_parking_carports" = "Abris auto";
-
-"placepage_parking_boxes" = "Box de garage";
-
-"placepage_parking_pay" = "Payer";
-
-"placepage_parking_free" = "Gratuit";
-
-"placepage_parking_interval" = "Période de paiement";
-
-"placepage_entrance_number" = "N°";
-
-"placepage_entrance_type" = "Entrée";
-
-"placepage_flat" = "app.";
-
-"placepage_open_24_7" = "24h/24 et 7j/7";
-
 "meter" = "m";
 
 "kilometer" = "km";
 
-"kilometers_per_hour" = "km/h";
-
 "mile" = "mi";
 
 "foot" = "pied";
-
-"miles_per_hour" = "mph";
-
-"day" = "j";
 
 "hour" = "h";
 
@@ -1381,10 +889,6 @@
 
 "placepage_bookmark_name_hint" = "Nom du signet";
 
-"placepage_personal_notes_hint" = "Remarques personnelles";
-
-"placepage_delete_bookmark_button" = "Supprimer signet";
-
 "editor_edits_sent_message" = "Vos modifications suggérées ont été envoyées";
 
 "editor_comment_hint" = "Commentaire…";
@@ -1397,8 +901,6 @@
 
 "editor_remove_place_button" = "Supprimer";
 
-"editor_status_sending" = "Envoyer…";
-
 "editor_place_doesnt_exist" = "La place n'existe pas";
 
 "text_more_button" = "…Afficher la suite";
@@ -1410,11 +912,7 @@
 
 "error_enter_correct_email" = "Saisir un email valide";
 
-"error_enter_correct" = "Saisir une valeur correcte";
-
 "refresh" = "Mettre à jour";
-
-"last_update" = "Dernière mise à jour à %s";
 
 "placepage_add_place_button" = "Ajouter un lieu sur la carte";
 
@@ -1426,24 +924,6 @@
 
 "editor_share_to_all_dialog_message_2" = "Nous vérifierons les changements. Si nous avons des questions quelles qu’elles soient, nous vous contacterons par courriel.";
 
-"navigation_overview_button" = "aperçu";
-
-"navigation_stop_button" = "stop";
-
-/* Text on an empty bookmark page */
-"bookmarks_empty_title" = "Enregistrez des signets";
-
-"bookmarks_empty_message_1" = "Tapez sur ★ pour enregistrer vos lieux préférés pour un accès rapide.";
-
-"bookmarks_empty_message_2" = "Importez des signets à partir d'un email et du Web.";
-
-"bookmarks_empty_message_3" = "départ : %s";
-
-/* Name of the group for booked hotels */
-"bookmarks_group_name" = "Hôtels réservés";
-
-"place_page_button_read_descriprion" = "Lire";
-
 /* iOS dialog for the case when recent track recording is on and the app comes back from background */
 "recent_track_background_dialog_title" = "Souhaitez-vous désactiver l'enregistrement de vos itinéraires récents ?";
 
@@ -1451,8 +931,6 @@
 
 /* For sharing via SMS and so on */
 "sharing_call_action_look" = "Consultez";
-
-"continue_recent_track_background_button" = "Continuer";
 
 "recent_track_background_dialog_message" = "Organic Maps utilise votre géolocalisation en arrière-plan pour enregistrer vos itinéraires récents.";
 
@@ -1468,33 +946,13 @@
 /* About short text (below logo) */
 "about_description" = "Organic Maps est une application hors ligne essentielle pour les voyages. Organic Maps se base sur les données OpenStreetMap et permet de les modifier.";
 
-/* Text in menu */
-"blog" = "Blog";
-
 "general_settings" = "Paramètres généraux";
-
-"date" = "Date %d";
-
-/* "Report a bug" -> "Generaal Feedback" -> "Something is not working" */
-"something_is_not_working" = "Quelque chose ne fonctionne pas";
 
 /* For the first routing */
 "accept" = "Accepter";
 
-"accept_and_continue" = "Accepter et continuer";
-
 /* For the first routing */
 "decline" = "Refuser";
-
-"install_app" = "Installer";
-
-"search_no_results_title" = "Aucun résultat trouvé";
-
-"search_no_results_message" = "Essayez un terme de recherche plus général , effectuez un zoom arrière ou réinitialisez le filtre.";
-
-"search_no_results_expand_area_button" = "Zoom arrière";
-
-"search_no_results_reset_button" = "Réinitialiser le filtre";
 
 /* noun */
 "search_in_table" = "Liste";
@@ -1517,8 +975,6 @@
 
 "traffic_update_maps_text" = "Pour afficher les données de circulation, les cartes doivent être actualisées.";
 
-"traffic_outdated" = "Les données de circulation ne sont pas actuelles.";
-
 "big_font" = "Augmenter la taille de police sur la carte";
 
 "traffic_update_app" = "Veuillez mettre à jour Organic Maps";
@@ -1529,17 +985,7 @@
 /* "traffic" as in "road congestion" */
 "traffic_data_unavailable" = "Les données de circulation ne sont pas disponibles";
 
-/* "Translation is no needed, because it's a company name" */
-"uber" = "Uber";
-
-/* Simplified colour scheme for traffic information, fewer colours are used to display traffic jams on the map. The string should be kept as short as possible */
-"pref_traffic_simplified_colors_title" = "Couleurs circulation simplifiées";
-
 "enable_logging" = "Activer le journal";
-
-"offline_place_page_more_information" = "Connectez-vous à Internet pour obtenir plus d’informations sur ce lieu.";
-
-"failed_load_information" = "Impossible de charger les informations.";
 
 /* Settings: "Send general feedback" button */
 "feedback_general" = "Feedback général";
@@ -1556,8 +1002,6 @@
 
 "whatsnew_transliteration_title" = "Translittération en latin";
 
-"yandex_taxi_title" = "Yandex.Taxi";
-
 "learn_more" = "En savoir plus";
 
 "core_exit" = "Quitter";
@@ -1568,75 +1012,19 @@
 
 "button_exit" = "Quitter";
 
-"settings_device_memory" = "Mémoire de l’appareil";
-
-"settings_card_memory" = "Mémoire carte";
-
-"settings_storage_available" = "%s disponible";
-
-"toast_location_permission_denied" = "Autorisation de localisation refusée à l'application";
-
-"button_use" = "Utiliser";
-
 "planning_route_manage_route" = "Gérer l’itinéraire";
 
 "button_plan" = "Planifier";
-
-"button_add" = "Ajouter";
 
 "placepage_remove_stop" = "Supprimer";
 
 "planning_route_remove_title" = "Faire glisser ici pour supprimer";
 
-"dialog_change_start_point_message" = "Remplacer le point de départ par l’emplacement actuel ?";
-
-"button_replace" = "Remplacer";
-
 "placepage_add_stop" = "Ajouter un arrêt";
-
-/* Only ru/en are needed */
-"subtitle_rent" = "Rent";
-
-/* Only ru/en are needed */
-"rub_month" = "RUB/month";
-
-/* Only ru/en are needed */
-"room" = "%s-room apt.";
-
-/* Only ru/en are needed */
-"real_estate" = "Real estate";
-
-"add_my_position" = "Ajouter ma position";
-
-"choose_start_point" = "Choisissez un point de départ";
-
-"choose_destination" = "Choisissez une destination";
 
 "preloader_viator_button" = "En savoir plus";
 
-"start_from_my_position" = "Commencer à partir de";
-
-"profile_authorization_title" = "Se connecter avec";
-
-"profile_authorization_message" = "Connexion facile sans identifiant ni mot de passe en quelques secondes";
-
 "profile_authorization_error" = "Oups, une erreur s'est produite. Essayez de vous connecter à nouveau.";
-
-"service" = "Service";
-
-"atmosphere" = "Ambiance";
-
-"value_for_money" = "Rapport qualité/prix";
-
-"experience" = "Expérience";
-
-"assortment" = "Assortiment";
-
-"expertise" = "Expertise";
-
-"equipment" = "Équipement";
-
-"quality" = "Qualité";
 
 "dialog_error_storage_title" = "Problème d'accès au stockage";
 
@@ -1644,17 +1032,7 @@
 
 "setting_emulate_bad_storage" = "Émuler le mauvais stockage";
 
-"directions_finish" = "Destination";
-
-"directions_on_foot" = "Marcher %s";
-
 "core_entrance" = "Entrée";
-
-"coffee" = "Café";
-
-"cleanliness" = "Propreté";
-
-"crowdedness" = "Affluence";
 
 "error_enter_correct_name" = "Veuillez entrer un nom correct";
 
@@ -1673,11 +1051,9 @@
 
 "downloader_percent" = "%s (%s de %s)";
 
-"downloader_process" = "Téléchargement de %s...";
+"downloader_process" = "Téléchargement de %s…";
 
-"downloader_applying" = "Application de %s...";
-
-"dialog_message_transit_not_found_connection" = "Planifier un itinéraire dans un réseau de transport en commun";
+"downloader_applying" = "Application de %s…";
 
 "bookmarks_error_message_share_general" = "Impossible de partager en raison d'une erreur d'application";
 
@@ -1695,17 +1071,7 @@
 
 "bookmarks_error_message_list_name_already_taken" = "Merci de choisir un autre nom";
 
-"bookmarks_error_title_list_name_too_long" = "Ce nom est trop long";
-
-"bookmarks_error_message_list_name_too_long" = "Merci de choisir un autre nom";
-
-"please_wait" = "S'il vous plaît, attendez...";
-
-"phone_number" = "Numéro de téléphone";
-
-"notification_unsent_reviews_title" = "Vous avez plusieurs avis non envoyés";
-
-"notification_unsent_reviews_message" = "Veuillez vous connecter pour partager des avis avec d'autres voyageurs";
+"please_wait" = "S'il vous plaît, attendez…";
 
 "profile" = "Profil OpenStreetMap";
 
@@ -1719,49 +1085,13 @@
 
 "bookmarks_convert_error_message" = "Certains fichiers n'ont pas été convertis.";
 
-"converting" = "Conversion...";
-
-"wn_reinvented_bookmarks_title" = "Nous avons réinventé les signets!";
-
-"wn_reinvented_bookmarks_message" = "Vous pouvez sauvegarder des signets, créer des listes... C'est incroyable...";
-
-"bookmarks_restore" = "Restaurer les favoris";
-
-"bookmarks_restore_process" = "Restaurer...";
-
 "bookmarks_restore_title" = "Restaurer cette version?";
 
-"bookmarks_restore_message" = "Vos marque-pages restaureront à partir de %s (%s)";
-
-"bookmarks_restore_empty_title" = "Vous n'avez pas de sauvegarde";
-
-"bookmarks_restore_empty_message" = "Le serveur n'a pas trouvé de sauvegardes effectuées précédemment";
-
 "common_check_internet_connection_dialog_title" = "Pas de connexion Internet";
-
-"error_server_title" = "Erreur du serveur";
-
-"error_server_message" = "Une erreur s'est produite sur le serveur. Veuillez réessayer plus tard.";
 
 "error_system_message" = "Une erreur inconnue est survenue";
 
 "restore" = "Restaurer";
-
-"bookmarks_page_downloaded" = "Téléchargé";
-
-"bookmarks_page_my" = "Mes";
-
-"routes_and_bookmarks" = "Itinéraires et favoris";
-
-"bookmarks_webview_success_toast" = "Favoris enregistrés avec succès";
-
-"cached_bookmarks_placeholder_title" = "Télécharger de nouveaux lieux";
-
-"cached_bookmarks_placeholder_subtitle" = "Appuyez sur le bouton pour télécharger des milliers de lieux et d'itinéraires intéressants créés par les utilisateurs de Organic Maps. Vous aurez besoin d'une connexion Internet.";
-
-"downloader_download_routers" = "Télécharger les favoris";
-
-"bookmarks_groups_cached" = "Listes téléchargées";
 
 "subtittle_opt_out" = "Paramètres de suivi";
 
@@ -1769,29 +1099,15 @@
 
 "crash_reports_description" = "Nous pouvons utiliser vos données pour améliorer l'expérience de Organic Maps. Les modifications prendront effet après le redémarrage de l'application.";
 
-"opt_out_help_ios_1" = "Votre appareil mobile peut fournir un paramètre «Limiter le suivi des annonces» ou «Désactiver la publicité ciblée par centres d'intérêt».";
-
-"opt_out_help_ios_2" = "iOS 9 ou plus récent";
-
-"opt_out_help_ios_3" = "Accédez à vos paramètres → Confidentialité → Publicité → Activer le paramètre «Limiter le suivi des annonces»";
-
-"opt_out_help_android" = "Votre appareil mobile peut proposer un paramètre «Limiter le suivi des annonces\"\" ou «Désactiver la publicité ciblée par centres d'intérêt».\n\n Pour Android et les services Google Play version 4.0 et ultérieure :\n Réglages → Google → Annonces → Désactiver la personnalisation des annonces\ni\n Paramètres → Google → Compte Google → Informations personnelles et confidentialité → Paramètres des annonces → Personnalisation des annonces";
-
 "privacy_policy" = "Politique de confidentialité";
 
 "terms_of_use" = "Conditions d'utilisation";
-
-"backup_notification_failed" = "La sauvegarde de vos favoris a été suspendue. Connectez-vous pour la réactiver.";
 
 "button_layer_traffic" = "Trafic";
 
 "button_layer_subway" = "Métro";
 
 "layers_title" = "Couches de carte";
-
-"layers_message" = "Utiliser des couches de carte pour afficher le trafic, la carte de métro et d'autres informations utiles";
-
-"button_layer_got_it" = "J'ai compris";
 
 "subway_data_unavailable" = "La carte du métro n'est pas disponible";
 
@@ -1803,39 +1119,13 @@
 
 "title_error_downloading_bookmarks" = "Une erreur est survenue";
 
-"subtitle_error_downloading_bookmarks" = "Les signets n'ont pas été téléchargés";
-
-"error_already_downloaded" = "Cette liste a déjà été téléchargée";
-
 "popular_place" = "Populaire";
-
-"download_routes" = "Télécharger itinéraires";
-
-"bookmarks_downloaded_title" = "Signets téléchargés avec succès";
-
-"bookmarks_downloaded_subtitle" = "Appuyez sur 'Rechercher sur la carte' pour explorer les endroits sur la liste";
-
-"why_support" = "Pourquoi soutenir Organic Maps ?";
-
-"why_support_item1" = "We respect your privacy: there are zero trackers in the app, and we are open source";
-
-"why_support_item2" = "Vous nous aidez à améliorer Organic Maps";
-
-"why_support_item3" = "Vous nous aidez à améliorer les cartes ouvertes OpenStreetMap.org";
-
-"channels_map_update" = "Mises à jour de la carte";
-
-"server_unavailable_title" = "Le serveur n'est pas disponible";
-
-"sharing_options" = "Options de partage";
 
 "export_file" = "Fichier d'exportation";
 
 "list_settings" = "Paramètres liste";
 
 "delete_list" = "Supprimer liste";
-
-"hide_from_map" = "Masquer de la carte";
 
 "public_access" = "Accès publique";
 
@@ -1845,40 +1135,11 @@
 
 "bookmark_category_description_hint" = "Tapez une description (texte ou html)";
 
-/* FIXME */
-"bookmarks_public_access" = "bookmarks_public_access";
-
-/* FIXME */
-"bookmarks_link_access" = "bookmarks_link_access";
-
-/* FIXME */
-"bookmarks_private_access" = "bookmarks_private_access";
-
 "not_shared" = "Personnel";
-
-"direct_link_progress_text" = "Télécharger votre fichier…";
-
-"direct_link_success" = "Le lien a été créé";
-
-"send_a_link_btn" = "Envoyez moi un lien";
-
-"upload_error_toast" = "Une erreur s'est produite lors du téléchargement de votre fichier";
 
 "tags_loading_error_subtitle" = "Une erreur s'est produite lors du chargement des tags, veuillez réessayer";
 
-"unable_upload_errorr_title" = "Échec du téléchargement du fichier";
-
-"unable_upload_error_subtitle_edited" = "Ce fichier a été édité via l'application Web";
-
-"unable_upload_error_subtitle_broken" = "Ce fichier est endommagé et n'a pas pu être téléchargé. S'il vous plaît télécharger un autre fichier.";
-
-"contact" = "Contactez";
-
-"download_button" = "Téléchargez";
-
 "speedcams_alert_title" = "Vitesse de caméras";
-
-"speedcams_alert_subtitle" = "Prévenir concernant les limites de vitesse";
 
 "speedcam_option_auto" = "Auto";
 
@@ -1886,18 +1147,10 @@
 
 "speedcam_option_never" = "Jamais";
 
-"bookmark_description_title" = "Description du signet";
-
 "place_description_title" = "Description d'endroit";
 
 /* this text will be shown in application notification preferences opposite checkbox which enable/disable downloader notifications. Devices on Android 8+ are affected. */
 "notification_channel_downloader" = "Téléchargeur carte";
-
-"share_bookmarks_email_body_link" = "Bonjour !\n\nVoici le lien où vous pouvez télécharger vos signets : %s. Ouvrez la liste via Organic Maps et profitez de votre voyage !\n\nInstaller l'application : https://omaps.app/get?kmz";
-
-"warning_speedcams_title" = "Navigator vous avertira des caméras lorsque vous dépassez la limite de vitesse de %d km/h";
-
-"warning_speedcams_subtitle" = "Veuillez respecter les réglementations de conduite du pays dans lequel vous vous rendez.";
 
 "speedcams_notice_message" = "Auto - Alerte sur les radars en cas de risque de dépassement de la limite de vitesse\nToujours - Toujours avertir des radars\nJamais - Jamais avertir à propos des radars";
 
@@ -1913,23 +1166,7 @@
 
 "enable_logging_warning_message" = "Cette option est activée pour l'identification des actions à des fins de diagnostic. Cela aide l’équipe à identifier les problèmes liés à l’application. Activez cette option uniquement à la demande du support Organic Maps.";
 
-"html_error_upload_message_try_again" = "Vérifiez l'accès au réseau et réessayez";
-
-"html_error_upload_title_try_again" = "Il n'y a pas de connexion internet";
-
-"notification_leave_review_v2_android_short_title" = "Laissez vos commentaire et aidez les voyageurs !";
-
-"megafon" = "Say goodbye to roaming!";
-
-"notifications_illegal_alert_disable_button" = "Désactiver les notifications";
-
 "access_rules_author_only" = "Édition en ligne";
-
-"privacy_settings_menu" = "Paramètres de confidentialité";
-
-"unable_upadate_error_title" = "Impossible de mettre à jour l'itinéraire";
-
-"unable_upadate_error_message" = "Il y a eu des erreurs pendant la mise à jour. Veuilelz revérifiez les modifications et réessayez";
 
 "driving_options_title" = "Réglages de détour";
 
@@ -1951,94 +1188,19 @@
 
 "change_driving_options_btn" = "Paramètres de détour activés";
 
-"toll_road" = "Route à péage";
-
-"unpaved_road" = "Routes non revêtues";
-
-"ferry_crossing" = "Passage d'un cours d'eau";
-
-"operated_by" = "Géré par \"%s\"";
-
 "avoid_toll_roads_placepage" = "Éviter les routes à péage";
 
 "avoid_unpaved_roads_placepage" = "Éviter les routes non revêtues";
 
 "avoid_ferry_crossing_placepage" = "Éviter les passages d'un cours d'eau";
 
-"type.cuisine.uzbek" = "Cuisine ouzbek";
-
-"trip_start" = "On y va";
-
-"pick_destination" = "Point d'arrivée";
-
-"follow_my_position" = "Préciser";
-
-"search_results" = "Résultats de recherche";
-
-"then_turn" = "Ensuite";
-
-"redirect_route_alert" = "Voulez-vous reconstruire l'itinéraire ?";
-
-"redirect_route_yes" = "Oui";
-
-"redirect_route_no" = "Non";
-
-"trip_finished" = "Vous êtes arrivé !";
-
-"keyboard_availability_alert" = "Clavier non disponible en conduisant";
-
-"dialog_routing_change_start_carplay" = "Impossible de créer un itinéraire à partir de lieux actuel";
-
-"dialog_routing_change_end_carplay" = "Impossible de créer un itinéraire jusqu'au point final. Choisissez un autre";
-
-"dialog_routing_check_gps_carplay" = "Pas de signal GPS. Passez sur le site ouvert";
-
-"dialog_routing_unable_locate_route_carplay" = "Impossible de calculer l'itinéraire. Sélectionnez les autres points d'itinéraire";
-
-"dialog_routing_download_files_carplay" = "Pour créer la route, téléchargez les cartes sur votre appareil";
-
-"dialog_routing_system_error_carplay" = "Une erreur est survenue. Redémarrez l'application";
-
-"dialog_routing_rebuild_from_current_location_carplay" = "L'itinéraire sera reconstruit à partir de votre position actuelle";
-
-"dialog_routing_rebuild_for_vehicle_carplay" = "L'itinéraire sera changé en mode Voiture";
-
 "ok" = "Ok";
-
-"avoid_unpaved_carplay_1" = "Route de ter";
-
-"avoid_unpaved_carplay_2" = "Route de terre";
-
-"avoid_ferry_carplay_1" = "Sans navires";
-
-"avoid_ferry_carplay_2" = "Sans navires";
-
-"avoid_tolls_carplay_1" = "Sans péage";
-
-"avoid_tolls_carplay_2" = "Sans péage";
-
-"speedcams_alert_title_carplay_1" = "Caméras";
-
-"speedcams_alert_title_carplay_2" = "Info Caméras";
-
-"download_map_carplay" = "Téléchargez des cartes dans l'application Organic Maps sur votre appareil";
-
-"carplay_roundabout_exit" = "%s sortie";
 
 /* max. 10 symbols, both iOS and Android */
 "sort" = "Trier…";
 
 /* Android, title, max 20-22 symbols */
 "sort_bookmarks" = "Trier les signets";
-
-/* iOS */
-"sort_default" = "Trier par défaut";
-
-"sort_type" = "Trier par type";
-
-"sort_distance" = "Trier par distance";
-
-"sort_date" = "Classer pa date";
 
 /* Android */
 "by_default" = "Par défaut";
@@ -2052,63 +1214,7 @@
 /* Android */
 "by_date" = "Par date";
 
-"week_ago_sorttype" = "Il y a une semaine";
-
-"month_ago_sorttype" = "Il y a un mois";
-
-"moremonth_ago_sorttype" = "Il y a plus d'un mois";
-
-"moreyear_ago_sorttype" = "Il y a plus d'un an";
-
-"near_me_sorttype" = "Près de moi";
-
-"others_sorttype" = "Autres";
-
-"food_places" = "Aliments";
-
-"tourist_places" = "Choses à voir";
-
-"museums" = "Musées";
-
-"parks" = "Parcs";
-
-"swim_places" = "Natation";
-
-"mountains" = "Montagnes";
-
-"animals" = "Animaux";
-
-"hotels" = "Hotels";
-
-"buildings" = "Batiments";
-
-"money" = "Argent";
-
-"shops" = "Magasins";
-
-"parkings" = "Parkings";
-
-"fuel_places" = "Stations d'essence";
-
-"water" = "Eau";
-
-"medicine" = "Médicament";
-
 "search_in_the_list" = "Chercher dans la liste";
-
-"view_on_map_bookmarks" = "Sur plan";
-
-"more_bookmarks" = "Plus…";
-
-"no_items_found" = "Aucun article trouvé";
-
-/* Android, max 18 symbols */
-"bookmarks_edit_list" = "Modifier la liste";
-
-/* Android, max 18 symbols */
-"bookmarks_delete_list" = "Supprimer la liste";
-
-"religious_places" = "Lieux saints";
 
 "select_list" = "Sélectionner une liste";
 
@@ -2118,26 +1224,13 @@
 
 "dialog_pedestrian_route_is_long_message" = "Choisissez le point de départ ou d'arrivée de l'itinéraire le plus proche de la station de métro";
 
-/* Failed planning SUBWAY route message in navigation view */
-"routing_planning_error_subway_special" = "Erreur dans le tracé de l'itinéraire du métro";
-
 "button_layer_isolines" = "Terrain";
-
-"tips_map_layers_title_countour" = "Lignes d'altitude hors-ligne dans Organic Maps !";
-
-"tips_map_layers_message_countour" = "Les lignes d'altitude vous aideront à planifier votre voyage à la campagne sans vous perdre dans les champs";
 
 "isolines_activation_error_dialog" = "Pour utiliser les lignes d'altitude, mettez à jour ou téléchargez la carte de l'endroit désiré";
 
 "isolines_location_error_dialog" = "Les lignes d'élévation ne sont pas encore disponibles dans cette région";
 
 "elevation_profile_diff_level" = "Niveau de difficulté";
-
-"elevation_profile_diff_level_easy" = "Faible";
-
-"elevation_profile_diff_level_moderate" = "Moyen";
-
-"elevation_profile_diff_level_hard" = "Haut";
 
 "elevation_profile_ascent" = "Montée";
 
@@ -2147,25 +1240,13 @@
 
 "elevation_profile_maxaltitude" = "Hauteur maximale";
 
-"elevation_profile_m" = "m";
-
 "elevation_profile_difficulty" = "Difficulté";
 
 "elevation_profile_distance" = "Russe :";
 
-"elevation_profile_km" = "km";
-
 "elevation_profile_time" = "Temps:";
 
-"elevation_profile_hours" = "h";
-
-"elevation_profile_minutes" = "mn";
-
 "isolines_toast_zooms_1_10" = "Zoomez pour voir les courbes de niveaux";
-
-"downloader_updating_ios" = "Misе à jour";
-
-"downloader_loading_ios" = "Téléchargement";
 
 "key_information_title" = "Informations clés";
 

--- a/iphone/Maps/LocalizedStrings/fr.lproj/Localizable.stringsdict
+++ b/iphone/Maps/LocalizedStrings/fr.lproj/Localizable.stringsdict
@@ -9,21 +9,6 @@
 
 <!-- ********** Strings for downloading map from search **********/ -->
 
-  <key>bookmarks_places</key>
-  <dict>
-    <key>NSStringLocalizedFormatKey</key>
-    <string>%#@value@</string>
-    <key>value</key>
-    <dict>
-      <key>NSStringFormatSpecTypeKey</key>
-      <string>NSStringPluralRuleType</string>
-      <key>NSStringFormatValueTypeKey</key>
-      <string>d</string>
-      <key>other</key>
-      <string>%d signets</string>
-    </dict>
-  </dict>
-
   <key>bookmarks_detect_message</key>
   <dict>
     <key>NSStringLocalizedFormatKey</key>
@@ -34,27 +19,12 @@
       <string>NSStringPluralRuleType</string>
       <key>NSStringFormatValueTypeKey</key>
       <string>d</string>
-      <key>zero</key>
-      <string>%d fichier a été trouvé. Vous le verrez après la conversion.</string>
       <key>one</key>
       <string>%d fichier a été trouvé. Vous le verrez après la conversion.</string>
       <key>other</key>
       <string>%d fichiers ont été trouvés. Vous les verrez après la conversion.</string>
-    </dict>
-  </dict>
-
-  <key>bookmarks_objects</key>
-  <dict>
-    <key>NSStringLocalizedFormatKey</key>
-    <string>%#@value@</string>
-    <key>value</key>
-    <dict>
-      <key>NSStringFormatSpecTypeKey</key>
-      <string>NSStringPluralRuleType</string>
-      <key>NSStringFormatValueTypeKey</key>
-      <string>d</string>
-      <key>other</key>
-      <string>objet %s</string>
+      <key>zero</key>
+      <string>%d fichier a été trouvé. Vous le verrez après la conversion.</string>
     </dict>
   </dict>
 

--- a/iphone/Maps/LocalizedStrings/hu.lproj/Localizable.strings
+++ b/iphone/Maps/LocalizedStrings/hu.lproj/Localizable.strings
@@ -18,9 +18,6 @@
 /* Button which deletes downloaded country */
 "delete" = "Törlés";
 
-/* Button "do not interrupt download" if user touched actively downloading country */
-"do_nothing" = "Folytatás";
-
 "download_maps" = "Térképek letöltése";
 
 /* Settings/Downloader - info for country when download fails */
@@ -28,9 +25,6 @@
 
 /* Settings/Downloader - info for country which started downloading */
 "downloading" = "Letöltés…";
-
-/* Settings/Downloader - size string, only strings different from English should be translated */
-"kb" = "kB";
 
 /* Choose measurement on first launch alert - choose metric system button */
 "kilometres" = "Kilométer";
@@ -55,17 +49,11 @@
 /* Update maps later/Buy pro version later button text */
 "later" = "Később";
 
-/* Don't show some dialog any more */
-"never" = "Soha";
-
 /* View and button titles for accessibility */
 "search" = "Keresés";
 
 /* Search box placeholder text */
 "search_map" = "Keresés a térképen";
-
-/* Settings/Downloader - info for not downloaded country */
-"touch_to_download" = "Érintse meg letöltéshez";
 
 /* Settings/Downloader - 3G download warning dialog confirm button */
 "use_cellular_data" = "Igen";
@@ -73,20 +61,11 @@
 /* Location services are disabled by user alert - message */
 "location_is_disabled_long_text" = "Ezen az eszközön jelenleg minden helyzetmeghatározó szolgáltatás ki van kapcsolva. Kérjük kapcsolja be ezeket a Beállítások között.";
 
-/* Location Services are not available on the device alert - message */
-"device_doesnot_support_location_services" = "Az eszköz nem támogatja a helyzetmeghatározó szolgáltatásokat";
-
 /* View and button titles for accessibility */
 "zoom_to_country" = "Megjelenítés a térképen";
 
-/* Button text for the button at the center of the screen when the country is not downloaded */
-"country_status_download" = "Térkép letöltése\n(^ ^)";
-
 /* Button text for the button at the center of the screen when the country is not downloaded and the size should not be shown */
 "country_status_download_without_size" = "Térkép letöltése";
-
-/* Button text for the button at the center of the screen when the country is not downloaded */
-"country_status_download_without_routing" = "Térkép letöltése\nútvonal nélkül (^ ^)";
 
 /* Message to display at the center of the screen when the country download has failed */
 "country_status_download_failed" = "Letöltése sikertelen";
@@ -96,19 +75,13 @@
 
 "about_menu_title" = "A Organic Maps programról";
 
-"downloaded_touch_to_delete" = "Letöltve (%@), érintse meg törléshez";
-
 "connection_settings" = "Kapcsolat beállítások";
-
-"download_mb_or_kb" = "Letöltés %@";
 
 "close" = "Bezár";
 
 "unsupported_phone" = "Hardware-s gyorsítású OpenGL szükséges. Sajnos az Ön eszköze nem támogatott.";
 
 "download" = "Letöltés";
-
-"external_storage_is_not_available" = "Nem található téképeket tartalmazó SD kártya / USB tároló";
 
 "disconnect_usb_cable" = "Kérjük bontsa az USB kapcsolatot vagy helyezzen be memóriakártyát a Organic Maps használatához";
 
@@ -117,8 +90,6 @@
 "not_enough_memory" = "Nincs elegendő memória az alkalmazás futtatásához";
 
 "download_resources" = "Első használat előtt letöltjük a világtérképet.\n%@ tárolóhely szükséges.";
-
-"getting_position" = "Aktuális pozíció meghatározása…";
 
 "download_resources_continue" = "Térképhez ugrás";
 
@@ -140,23 +111,14 @@
 /* Add New Bookmark Set dialog title */
 "add_new_set" = "Új csoport létrehozása";
 
-/* Place Page - Add To Bookmarks button */
-"add_to_bookmarks" = "Könyvjelzőkhöz hozzáadás";
-
 /* Bookmark Color dialog title */
 "bookmark_color" = "Könyvjelző színe";
 
 /* Add Bookmark Set dialog - hint when set name is empty */
 "bookmark_set_name" = "Könyvjelzőcsoport neve";
 
-/* Bookmark Sets dialog title */
-"bookmark_sets" = "Könyvjelzőcsoportok";
-
 /* Bookmarks - dialog title */
 "bookmarks" = "Könyvjelzők";
-
-/* Add bookmark dialog - bookmark color */
-"color" = "Szín";
 
 /* Default bookmarks set name */
 "core_my_places" = "Saját helyeim";
@@ -167,14 +129,8 @@
 /* Editor title above street and house number */
 "address" = "Cím";
 
-/* Place Page - Remove Pin button */
-"remove_pin" = "Jelző törlése";
-
 /* Add bookmark dialog - bookmark set, Bookmarks dialog - Bookmark set cell */
 "set" = "Csoport";
-
-/* Text hint in Bookmarks dialog when no any bookmarks are added */
-"bookmarks_usage_hint" = "Nincsenek megjelölt helyeid.\nHely megjelöléséhez koppints a térkép bármelyik pontjára.\nSzintén más forrásokból származó könyvjelzőket is beolvashat a Organic Maps programba. Nyisson meg KML/KMZ fájlt egy levélből, Dropbox-ból vagy internetről.";
 
 /* Settings button in system menu */
 "settings" = "Beállítások";
@@ -191,26 +147,11 @@
 /* Ask to wait user several minutes (some long process in modal dialog). */
 "wait_several_minutes" = "Ez több percig is eltarthat.\nKérjük várjon…";
 
-/* Show bookmarks from this category on a map or not */
-"visible" = "látható";
-
-/* Toast which is displayed when GPS has been deactivated */
-"gps_is_disabled_long_text" = "GPS kikapcsolva. Kérjük kapcsolja be a Beállítások között.";
-
 /* Measurement units title in settings activity */
 "measurement_units" = "Mértékegységek";
 
 /* Detailed description of Measurement Units settings button */
 "measurement_units_summary" = "Válasszon kilométer és mérföld között";
-
-/* Do search in all sources */
-"search_mode_all" = "Mindenütt";
-
-/* Do search near my position only */
-"search_mode_nearme" = "A közelben";
-
-/* Do search in current viewport only */
-"search_mode_viewport" = "A képernyőn";
 
 /* Search category for cafes, bars, restaurants */
 "eat" = "Hol lehet enni valamit";
@@ -266,14 +207,8 @@
 /* Search category */
 "police" = "Rendőrség";
 
-/* String in search result list, when nothing found */
-"no_search_results_found" = "Nincs keresési találat";
-
 /* Notes field in Bookmarks view */
 "description" = "Jegyzetek";
-
-/* Button text */
-"share_by_email" = "Megosztás email-en";
 
 /* Email Subject when sharing bookmarks category */
 "share_bookmarks_email_subject" = "Egy Organic Maps könyvjelzőt osztottak meg Önnel";
@@ -295,26 +230,11 @@
 /* Warning message when doing search around current position */
 "unknown_current_position" = "Még nem határoztuk meg az aktuális helyzetét";
 
-/* Warning message when location country isn't downloaded during search (see also download_location_map_proposal). */
-"download_location_country" = "Töltse le az aktuális helyzet országát (%@)";
-
-/* Warning message when viewport country isn't downloaded during search */
-"download_viewport_country_to_search" = "Töltse le a keresés országát (%@)";
-
 /* Alert message that we can't run Map Storage settings due to some reasons. */
 "cant_change_this_setting" = "Sajnáljuk, a térképek tárolása jelenleg ki van kapcsolva.";
 
 /* Alert message that downloading is in progress. */
 "downloading_is_active" = "Országletöltés folyamatban.";
-
-/* Message that will be shown in alert view, when we ask user to leave review on App Store */
-"appStore_message" = "Reméljük élvezi a Organic Maps használatát. Ha igen, kérjük írjon ajánlást az App Store-ban! Kevesebb mint egy perc, és valóban segít nekünk. Köszönjük!";
-
-/* No, thanks */
-"no_thanks" = "Köszönöm, nem";
-
-/* Share one specific bookmark using SMS, %1$@ contains om:// and %2$@ https://omaps.app link. @NOTE non-ascii symbols in the link will result in max 70 characters SMS instead of 140. */
-"bookmark_share_sms" = "Nézd meg a Organic Maps jelzőt! %1$@ vagy %2$@ A program letöltése: https://omaps.app/get";
 
 /* Share my position using SMS, %1$@ contains om:// and %2$@ https://omaps.app link WITHOUT NAME. @NOTE non-ascii symbols in the link will result in max 70 characters SMS instead of 140. */
 "my_position_share_sms" = "Nézd meg a Organic Maps helyzetemet! %1$@ vagy %2$@ A program letöltése: https://omaps.app/get";
@@ -328,23 +248,11 @@
 /* Share my position using EMail, %1$@ is om:// and %2$@ is https://omaps.app link WITHOUT NAME */
 "my_position_share_email" = "Üdvözlöm!\n\nJelenleg itt vagyok: %1$@ Kattintson erre a hivatkozásra %2$@ vagy erre %3$@, hogy lássa a helyet a térképen.\n\nKöszönöm.";
 
-/* Android share by Message/SMS button text (including SMS) */
-"share_by_message" = "Megosztás üzenetben";
-
 /* Share button text which opens menu with more buttons, like Message, EMail, Facebook etc. */
 "share" = "Megosztás";
 
-/* iOS share by Message button text (including SMS) */
-"message" = "Üzenet";
-
 /* Share by email button text, also used in editor. */
 "email" = "Email";
-
-/* Copy Link */
-"copy_link" = "Hivatkozás másolása";
-
-/* Text for the button that returns to caller application */
-"more_info" = "Mutasson több adatot";
 
 /* Text for message when used successfully copied something */
 "copied_to_clipboard" = "A vágólapra másolva: %1$@";
@@ -354,15 +262,6 @@
 
 /* Used for bookmark editing */
 "done" = "Kész";
-
-/* Summary for preferences in MWM */
-"yopme_pref_summary" = "Válassza ki a hátoldali képernyő-beállításokat";
-
-/* Title for yopme preferences in MWM */
-"yopme_pref_title" = "Hátoldali képernyő-beállítások";
-
-/* Hint for upper-right icon p2b */
-"show_on_backscreen" = "Mutassa a vissza képernyőn";
 
 /* Prints version number in About dialog */
 "version" = "Verzió: %@";
@@ -381,19 +280,11 @@
 
 "share_my_location" = "Helyzetem megosztása";
 
-"menu_search" = "Keresés";
-
 /* Settings general group in settings screen */
 "prefs_group_general" = "General settings";
 
 /* Settings information group in settings screen */
 "prefs_group_information" = "Information";
-
-/* Settings screen: "Map" category title */
-"prefs_group_map" = "Térkép";
-
-/* Settings screen: "Miscellaneous" category title */
-"prefs_group_misc" = "Egyéb";
 
 "prefs_group_route" = "Navigáció";
 
@@ -419,9 +310,6 @@
 /* Settings «Map» category: «3D buildings» title */
 "pref_map_3d_buildings_title" = "3D-s épületek";
 
-/* Settings «Map» category: «3D buildings» summary */
-"pref_map_3d_buildings_subtitle" = "Akkumulátor élettartamára hat";
-
 /* Settings «Route» category: «Tts enabled» title */
 "pref_tts_enable_title" = "Hangutasítások";
 
@@ -433,8 +321,6 @@
 
 /* Title for "Other" section in TTS settings. */
 "pref_tts_other_section_title" = "Egyéb";
-
-"pref_tts_how_to_set_up_voice" = "Így állítsd be a hangot";
 
 /* Settings «Map» category: «Record track» title */
 "pref_track_record_title" = "Legutolsó útvonal";
@@ -455,56 +341,7 @@
 
 "recent_track_help_text" = "Ez lehetővé teszi a bejárt útvonal rögzítését és megtekintését a térképen bizonyos időre. Kérjük, vegye figyelembe, hogy ezen funkció aktiválásával megnöveli az akkumulátor használatát. Az útvonal automatikusan törlődik a térképről az időtartam lejártával.";
 
-"pref_track_ios_caption" = "A legutolsó útvonal megmutatja, hogy milyen útvonalon haladtál.";
-
-"pref_track_ios_subcaption" = "Válaszd ki az útvonalak elmentésének időtartamát!";
-
-"placepage_distance" = "Távolság";
-
-"placepage_coordinates" = "Koordináták";
-
-"placepage_unsorted" = "Osztályozatlan";
-
 "search_show_on_map" = "Megtekintés a térképen";
-
-/* Used to warn user when fixing KitKat issue */
-"bookmark_move_fail" = "A könyvjelzőit át kell helyeznünk a belső memóriába, azonban ehhez nincs elegendő szabad tárhely. Kérjük, szabadítson fel lemezterületet, ellenkező esetben a könyvjelzői nem lesznek elérhetőek.";
-
-/* Used in More Apps menu */
-"free" = "Ingyenes";
-
-/* Used in More Apps menu */
-"buy" = "Megvásárlás";
-
-/* 1st search button-like result */
-"search_on_map" = "Keresés a térképen";
-
-/* toast with an error */
-"no_route_found" = "Nem található útvonal";
-
-/* route title */
-"route" = "Útvonal";
-
-/* category title */
-"routes" = "Útvonalak";
-
-/* text of notification */
-"download_map_notification" = "Töltsd le annak a helynek a térképét, ahol most vagy";
-
-/* text of notification */
-"pro_version_is_free_today" = "A teljes verzió Organic Maps ma ingyenes! Töltsd le most és meséld el barátaidnak.";
-
-/* Dialog for transferring maps from lite to pro. */
-"move_lite_maps_to_pro" = "Letöltött térképeidet áthelyezzük a Organic Maps Lite-ból a Organic Maps-be. Ez eltarthat pár percig.";
-
-/* Message to display when maps moved. */
-"move_lite_maps_to_pro_ok" = "Letöltött térképeidet sikeresen áthelyeztük a Organic Maps-be.";
-
-/* Message to display when maps move failed. */
-"move_lite_maps_to_pro_failed" = "Térképeid áthelyezése nem sikerült. Kérjük, töröld a Organic Maps Lite-t és töltsd le a térképet megint.";
-
-/* Text in menu */
-"settings_and_more" = "Beállítások és egyéb";
 
 /* Text in menu */
 "website" = "Honlap";
@@ -527,14 +364,8 @@
 /* Text in menu */
 "openstreetmap" = "OpenStreetMap";
 
-/* Text in menu */
-"contact_us" = "Kapcsolat";
-
 /* Settings: Send feedback button and dialog title */
 "feedback" = "Visszajelzés";
-
-/* Text in menu */
-"subscribe_to_news" = "Iratkozz fel hírlevelünkre";
 
 /* Text in menu */
 "rate_the_app" = "Értékeld az alkalmazást";
@@ -548,15 +379,6 @@
 /* Text in menu */
 "report_a_bug" = "Hibabejelentés";
 
-/* Email subject */
-"subscribe_me_subject" = "Fel szeretnék iratkozni a Organic Maps hírlevelére";
-
-/* Email body */
-"subscribe_me_body" = "Elsőként szeretnék értesülni a legújabb hírekről frissítésekről és promóciókról. A feliratkozásom bármikor törölhetem.";
-
-/* About text */
-"about_text" = "A Organic Maps kínálja a leggyorsabb offline térképeket, a világ összes városáról és országáról. Utazz magabiztosan: bárhol is vagy, a Organic Maps segít, hogy megtaláld magad a térképen, valamint segít a legközelebbi étterem, hotel, bank, benzinkút stb. felkutatásában is. Nem igényel internet kapcsolatot.\n\nMindig dolgozunk új fejlesztéseken és örömmel vennénk a te véleményedet is arról, hogyan tudnánk tovább fejleszteni a Organic Maps-t. Bármely probléma esetén írj nekünk a support@organicmaps.app email címre. Minden levélre válaszolunk!\n\nSzereted a Organic Maps-t és szeretnél támogatni minket? Van erre pár egyszerű és teljesen ingyenes lehetőséged:\n\n- írj rólunk értékelést az App Market-en\n- kedveld a Facebook oldalunkat: http://www.facebook.com/OrganicMaps\n- vagy csak mesélj a Organic Maps-ről anyukádnak, barátaidnak és munkatársaidnak :)\n\nKöszönjük, hogy velünk vagy. Nagyra értékeljük támogatásodat!\n\nU.i: Adatainkat az OpenStreetMap-ről vesszük, ami egy, a Wikipedia-hoz hasonló térképes projekt, ami megengedi felhasználóinak a térképek létrehozását és szerkesztését. Ha bármi hiányzik vagy rossz a térképpel, közvetlenül te is kijavíthatod a https://www.openstreetmap.org-on és változtatásaid a Organic Maps következő verziójában már meg fognak jelenni.";
-
 /* Alert text */
 "email_error_body" = "Az email kliens nincs beállítva. Kérjük, konfiguráld vagy próbálj meg valamilyen más módon kapcsolatba lépni velünk a %@ email címen keresztül.";
 
@@ -569,12 +391,6 @@
 /* Search category */
 "wifi" = "WiFi";
 
-/* Update map suggestion */
-"routing_map_outdated" = "Kérjük, útvonal létrehozásához frissítsd a térképet.";
-
-/* Update maps suggestion */
-"routing_update_maps" = "A Organic Maps új verziójában már útvonalakt is létrehozhatsz tartózkodási helyedtől az úticélodig. Kérjük, ennek a funkciónak a használatához frissítsd a térképeket.";
-
 /* Update all button text */
 "downloader_update_all_button" = "Mindegyik frissítése";
 
@@ -583,9 +399,6 @@
 
 /* Downloaded maps category */
 "downloader_downloaded_subtitle" = "Letöltve";
-
-/* Downloaded maps category */
-"downloader_available_maps" = "Elérhető";
 
 /* Country queued for download */
 "downloader_queued" = "Várólistás";
@@ -598,17 +411,6 @@
 
 "downloader_downloading" = "Letöltés:";
 
-"downloader_search_results" = "Megtalálva";
-
-/* Disclaimer message */
-"routing_disclaimer" = "Amikor útvonalakat készít a Organic Maps appban, kérjük, vegye figyelembe a következőket:\n\n  - Az ajánlott útvonalak csak javaslatoknak tekintendők.\n - Az utak kondíciója, a forgalmi szabályok és jelzőtáblák magasabb prioritásúak, mint a navigációs javaslatok.\n - A térkép lehet, hogy hibás vagy idejétmúlt, az útvonalak pedig lehet, hogy nem a lehető legjobb módon készülnek el.\n\n  Legyen óvatos az utakon és vigyázzon magára!";
-
-/* Outdated maps category */
-"downloader_outdated_maps" = "Elavult";
-
-/* Up to date maps category */
-"downloader_uptodate_maps" = "Friss";
-
 /* Status of outdated country in the list */
 "downloader_status_outdated" = "Frissítés";
 
@@ -618,49 +420,14 @@
 /* Displayed in a dialog that appears when a user tries to delete a map while the app is in the follow route mode */
 "downloader_delete_map_while_routing_dialog" = "Kérjük, állítsa le a navigációt a térkép törléséhez.";
 
-/* Show when user try build route, but we don't know where he */
-"routing_failed_unknown_my_position" = "Nem meghatározott a jelenlegi helyszín. Kérjük, határozza meg a helyszínt, hogy útvonal készülhessen.";
-
-/* Show if use has not routing file, or InconsistentMWMandRoute */
-"routing_failed_has_no_routing_file" = "Útvonaltervezéshez további adatok is szükségesek. Elkezded a letöltést?";
-
-/* StartPointNotFound */
-"routing_failed_start_point_not_found" = "Az útvonal nem tervezhető meg. Nincsenek utak a kiindulópontja közelében.";
-
-/* EndPointNotFound */
-"routing_failed_dst_point_not_found" = "Az útvonal nem tervezhető meg. Nincsenek utak az úti céljának közelében.";
-
 /* PointsInDifferentMWM */
 "routing_failed_cross_mwm_building" = "Útvonalakat csak akkor lehet készíteni, ha teljesen rajta vannak egy térképen.";
-
-/* RouteNotFound */
-"routing_failed_route_not_found" = "Nem találtunk útvonalat a kiválasztott kiindulópont és az úti cél között. Kérjük, válasszon másik kiinduló- vagy végpontot.";
-
-/* InternalError */
-"routing_failed_internal_error" = "Belső hiba történt. Kérjük, próbálja meg kitörölni és újra letölteni a térképet. Ha a probléma továbbra is fennáll, kérjük, vegye fel velünk a kapcsolatot a support@organicmaps.app email címen.";
-
-/* Context menu item for downloader. */
-"downloader_download_map_and_routing" = "Térkép + útvonal letöltése";
-
-/* Context menu item for downloader. */
-"downloader_download_routing" = "Útvonal letöltése";
-
-/* Context menu item for downloader. */
-"downloader_delete_routing" = "Útvonal törlése";
 
 /* Context menu item for downloader. */
 "downloader_download_map" = "Töltsd le a térképet";
 
-"downloader_download_map_no_routing" = "Térkép letöltése útvonal nélkül";
-
-/* Button for routing. */
-"routing_go" = "Indulás!";
-
 /* Item status in downloader. */
 "downloader_retry" = "Ismétlés";
-
-/* Item in context menu. */
-"downloader_map_and_routing" = "Térkép + útvonal megállapítása";
 
 /* Item in context menu. */
 "downloader_delete_map" = "Térkép törlése";
@@ -668,29 +435,11 @@
 /* Item in context menu. */
 "downloader_update_map" = "Térkép frissítése";
 
-/* Item in context menu. */
-"downloader_update_map_and_routing" = "Térkép frissítése + útvonal megállapítása";
-
-/* Item in context menu. */
-"downloader_map_only" = "Csak térkép";
-
-/* Toolbar title */
-"toolbar_application_menu" = "Menü";
-
 /* Preference text */
 "pref_use_google_play" = "Használja a Google Play szolgáltatást, hogy szert tegyen aktuális helyszínéről";
 
 /* Text for rating dialog */
 "rating_just_rated" = "Most értékeltem az alkalmazásodat";
-
-/* Text for rating dialog */
-"rating_user_since" = "Organic Maps felhasználó vagyok %@ óta";
-
-/* Text for rating dialog */
-"rating_do_like_maps" = "Szereted a Organic Maps-t?";
-
-/* Text for rating dialog */
-"rating_tap_star" = "Érints meg egy csillagot az alkalmazás értékeléséhez.";
 
 /* Text for rating dialog */
 "rating_thanks" = "Köszönjük!";
@@ -701,23 +450,8 @@
 /* Text for rating dialog */
 "rating_send_feedback" = "Visszajelzés elküldése";
 
-/* Text for g+ dialog */
-"rating_google_plus" = "Kattints a g+-ra és mesélj barátaidnak az alkalmazásról";
-
 /* Text for routing error dialog */
 "routing_download_maps_along" = "Tölts le térképeket az útvonal mellett";
-
-/* Text for routing error dialog */
-"routing_download_map" = "Térkép megszerzése";
-
-/* Text for routing error dialog */
-"routing_download_map_and_routing" = "Frissített térkép és útvonaltervezési adatok letöltése az összes Organic Maps tulajdonság megszerzése érdekében.";
-
-/* Text for routing error dialog */
-"routing_get_routing_data" = "Útvonaltervezési adatok megszerzése";
-
-/* Text for routing error dialog */
-"routing_get_additional_data" = "További adatok szükségesek a kiinduló pontról történő útvonaltervezéshez";
 
 /* Text for routing error dialog */
 "routing_requires_all_map" = "Útvonal tervezéséhez a kiindulási pont és a célútvonal összes térképét szükséges letölteni és frissíteni.";
@@ -725,50 +459,15 @@
 /* Text for routing error dialog */
 "routing_not_enough_space" = "Nincs elég hely";
 
-/* Text for routing error dialog */
-"routing_download_more_than_avail" = "%@ MB-t kell letöltened, de csak %@ MB hely szabad.";
-
-/* Text for routing error dialog */
-"routing_download_roaming" = "%@ MB-nyi adatot készül letölteni mobilján (roamingon) keresztül. Ez további költségekkel járhat, a mobilcsomagjától függően.";
-
 /* bookmark button text */
 "bookmark" = "könyvjelző";
-
-/* map is not downloaded */
-"not_found_map" = "A helyszínéhez tartozó térképet letöltöttük";
 
 /* location service disabled */
 "enable_location_services" = "Kérjük kapcsolja be a helyzetmeghatározó szolgáltatást";
 
-/* download map */
-"download_map" = "Töltse le a térképet a helyszínéhez";
-
-/* download map on iPhone */
-"download_map_iphone" = "Töltse le a térképet iPhone-jára jelenlegi helyzetének meghatározásához";
-
-/* clear pin */
-"nearby" = "A közelben";
-
-/* clear pin */
-"clear_pin" = "Pin törlése";
-
-/* location is undefined */
-"undefined_location" = "Nem meghatározott a jelenlegi helyszín.";
-
-/* download country of your location */
-"download_country" = "Töltse le az aktuális helyzet országát";
-
-/* download failed */
-"download_failed" = "letöltése sikertelen";
-
-/* get the map */
-"get_the_map" = "Térkép megszerzése";
-
 "save" = "Simpan";
 
 "edit_description_hint" = "Az ön leírásai (sima szöveg vagy html)";
-
-"new_group" = "új csoport";
 
 "create" = "létrehoz";
 
@@ -795,30 +494,6 @@
 
 /* pink color */
 "pink" = "Rózsaszín";
-
-/* deep purple color */
-"deep_purple" = "Sötét lila";
-
-/* light blue color */
-"light_blue" = "Világoskék";
-
-/* cyan color */
-"cyan" = "Cián";
-
-/* teal color */
-"teal" = "Zöldeskék";
-
-/* lime color */
-"lime" = "Lime";
-
-/* deep orange color */
-"deep_orange" = "Sötét Narancs";
-
-/* gray color */
-"gray" = "Szürke";
-
-/* blue gray color */
-"blue_gray" = "Kékes Szürke";
 
 /* Wi-Fi available */
 "WiFi_available" = "Igen";
@@ -848,13 +523,9 @@
 
 "dialog_routing_location_unknown_turn_on" = "Nem sikerült lokalizálni a jelenlegi GPS koordinátákat. Az útvonaltervezéshez engedélyezze a helyszíni szolgáltatásokat.";
 
-"dialog_routing_location_unknown" = "Nem sikerült lokalizálni a jelenlegi GPS koordinátákat.";
-
 "dialog_routing_download_files" = "Töltse le a szükséges fájlokat";
 
 "dialog_routing_download_and_update_all" = "Útvonaltervezéshez töltse le és frissítse az összes térkép- és útvonal-információt a tervezett út mentén.";
-
-"dialog_routing_routes_size" = "Útvonal-információs fájlok";
 
 "dialog_routing_unable_locate_route" = "Nem sikerült meghatározni az útvonalat";
 
@@ -884,21 +555,11 @@
 
 "dialog_routing_try_again" = "Kérjük, próbálja újra";
 
-"dialog_routing_send_error" = "Probléma bejelentése";
-
-"dialog_routing_if_get_cross_route" = "Szeretne egy közvetlenebb útvonalat létrehozni, amely több, mint egy térképen terül el?";
-
-"dialog_routing_cross_route_is_optimal" = "Elérhető egy optimálisabb útvonal, amely áthalad a jelenlegi térkép szélén.";
-
 "not_now" = "Most nem";
-
-"dialog_routing_build_route" = "Létrehozás";
 
 "dialog_routing_download_and_build_cross_route" = "Szeretné letölteni a térképet és létrehozni egy optimálisabb útvonalat, amely több, mint egy térképen terül el?";
 
 "dialog_routing_download_cross_route" = "Töltse le a térképet, hogy létrehozzon egy optimálisabb útvonalat, amely áthalad a jelenlegi térkép szélén.";
-
-"dialog_routing_cross_route_always" = "Mindig haladjon át ezen a határon";
 
 
 /********** Strings for downloading map from search **********/
@@ -906,8 +567,6 @@
 "search_without_internet_advertisement" = "Útvonalak kereséséhez és létrehozásához, kérjük, töltsd le a térképet és többé nem lesz szükséged internetkapcsolatra.";
 
 "search_select_map" = "Jelöld ki a térképet";
-
-"search_select_other_map" = "Jelölj ki másik térképet";
 
 /* «Show» context menu */
 "show" = "Mutat";
@@ -918,17 +577,11 @@
 /* «Rename» context menu */
 "rename" = "Átnevez";
 
-/* Bottom sheet: expand button (should be short) */
-"bottom_sheet_more" = "Továbbiak…";
-
 /* Failed planning route message in navigation view */
 "routing_planning_error" = "Sikertelen útvonaltervezés";
 
 /* Arrive routing message in navigation view */
 "routing_arrive" = "Megérkezik: %s";
-
-/* Text for routing::RouterResultCode::FileTooOld dialog. */
-"dialog_routing_download_and_update_maps" = "Útvonal létrehozásához kérjük, töltse le és frissítse az összes térképet az útvonal mentén.";
 
 "rate_alert_title" = "Tetszik az app?";
 
@@ -944,19 +597,11 @@
 
 "history" = "Előzmények";
 
-"next_turn_then" = "Aztán";
-
 "closed" = "Zárva";
-
-"back_to" = "Vissza ide %@";
 
 "search_not_found" = "Sajnos, semmit nem találtam.";
 
 "search_not_found_query" = "Próbáljon másik lekérdezést.";
-
-"search_not_found_map" = "Töltse le azt a térképet, amelyen keres.";
-
-"search_not_found_location" = "Töltse le a jelenlegi tartózkodási helye térképét.";
 
 "search_history_title" = "Előző keresések";
 
@@ -964,23 +609,12 @@
 
 "clear_search" = "A keresési előzmények törlése";
 
-/* Title for settings to enable/disable showcase menu button */
-"showcase_settings_title" = "Ajánlatok mutatása";
-
 /* Place Page link to Wikipedia article (if map object has it). */
 "read_in_wikipedia" = "Wikipedia";
 
-"p2p_route_planning" = "Útvonaltervezés";
-
 "p2p_your_location" = "Az Ön helyzete";
 
-"p2p_from" = "Az indulás helye";
-
-"p2p_to" = "Az érkezés helye";
-
 "p2p_start" = "Indítás";
-
-"p2p_planning" = "Tervezés…";
 
 "p2p_from_here" = "Innen";
 
@@ -1018,15 +652,9 @@
 
 "editor_correct_mistake" = "Hiba javítása";
 
-"editor_correct_mistake_message" = "Szerkesztési hibát vétett. Javítsa ki vagy váltson egyszerű módba.";
-
 "editor_add_select_location" = "Elhelyezkedés";
 
 "editor_done_dialog_1" = "Megváltoztattad a világ térképét. Ne titkold el mások elől! Mondd el a barátaidnak, és szerkesszétek közösen!";
-
-"editor_done_dialog_2" = "Ez a második térképjavításod. Most már te is rajta vagy a térképszerkesztők listáján, az %d. helyen. Mesélj erről a barátaidnak is.";
-
-"editor_done_dialog_3" = "Javítottál a térképen! Mondd el a barátaidnak is és szerkesszétek közösen!";
 
 "share_with_friends" = "Oszd meg az ismerőseiddel";
 
@@ -1044,20 +672,7 @@
 
 "editor_report_problem_duplicate_place_title" = "Duplikált hely";
 
-"first_launch_congrats_title" = "A Organic Maps használatra készen áll";
-
-"first_launch_congrats_text" = "Keress és navigálj offline a világon mindenhol, térítésmentesen.";
-
-"migrate_title" = "Fontos!";
-
-/* Android uses image instead of text. */
-"download_all" = "Összes letöltése";
-
-"delete_all" = "Összes térkép törlése";
-
 "autodownload" = "Automatikus letöltés";
-
-"disable_autodownload" = "Automatikus letöltés tiltása";
 
 /* Place Page opening hours text */
 "closed_now" = "Most zárva";
@@ -1072,10 +687,6 @@
 "day_off" = "Zárva";
 
 "today" = "Ma";
-
-"sunrise_to_sunset" = "Napkeltétől napnyugtáig";
-
-"sunset_to_sunrise" = "Napkeltétől napnyugtáig";
 
 "add_opening_hours" = "Nyitvatartás hozzáadása";
 
@@ -1095,45 +706,18 @@
 
 "forgot_password" = "Elfelejtett jelszó?";
 
-/* Forgot Password dialog title */
-"restore_password" = "Jelszó visszaállítása";
-
-"enter_email_address_to_reset_password" = "Add meg a regisztrációkor használt email-címedet és elküldjük neked a jelszavad megújításához szükséges linket.";
-
-"reset_password" = "Jelszó visszaállítása";
-
-"username" = "Felhasználónév";
-
 "osm_account" = "OSM-felhasználói fiók";
 
 "logout" = "Kijelentkezés";
 
-"login_and_edit_map_motivation_message" = "Jelentkezz be és szerkeszd az egyes objektumokhoz tartozó információkat a térképen, valamint tedd őket elérhetővé több millió felhasználó számára.";
-
 /* Information text: "Last upload 11.01.2016" */
 "last_upload" = "Utolsó frissítés";
 
-/* Motivates user to login/register, title above login buttons. */
-"you_have_edited_your_first_object" = "Szerkesztetted az első objektumod!";
-
 "thank_you" = "Köszönjük";
-
-"login_with_google" = "Bejelentkezés Google- vel";
-
-"login_with_openstreetmap" = "Jelentkezz be a www.openstreetmap.org oldalon";
 
 "edit_place" = "Hely szerkesztése";
 
 "place_name" = "Hely neve";
-
-/* title above languages list cells in the editor, below editable name text field. */
-"other_languages" = "Más nyelv";
-
-/* small button to open list with names in different languages */
-"show_more" = "Több mutatása";
-
-/* small button to close list with names in different languages */
-"show_less" = "Kevesebb mutatása";
 
 "add_language" = "Nyelv hozzáadása";
 
@@ -1164,8 +748,6 @@
 
 "please_note" = "Megjegyzés";
 
-"common_no_wifi_dialog" = "Nincs WiFi-kapcsolat. Szeretnéd folytatni mobil adatforgalom használatával?";
-
 "downloader_delete_map_dialog" = "A térképekkel együtt minden rajtuk végzett módosítás is törlésre kerül.";
 
 "downloader_update_maps" = "Térképek frissítése";
@@ -1173,10 +755,6 @@
 "downloader_mwm_migration_dialog" = "Útvonal létrehozásához frissítsd az összes térképet, majd tervezd meg újra az útvonalat.";
 
 "downloader_search_field_hint" = "Térkép keresése";
-
-"migration_update_all_button" = "Minden térkép frissítése";
-
-"migration_delete_all_download_current_button" = "Töltsd le a jelenlegi térképet és töröld a régieket";
 
 "migration_download_error_dialog" = "Letöltési hiba";
 
@@ -1186,21 +764,9 @@
 
 "downloader_no_space_message" = "Kérjük, töröld a szükségtelen adatokat";
 
-"editor_general_auth_error_dialog" = "Általános bejelentkezési hiba.";
-
 "editor_login_error_dialog" = "Bejelentkezési hiba.";
 
-"editor_login_failed_dialog" = "Sikertelen bejelentkezés";
-
-"editor_username_error_dialog" = "Érvénytelen felhasználónév";
-
-"editor_place_edited_dialog" = "Szerkesztettél egy objektumot!";
-
-"editor_login_with_osm" = "Bejelentkezés OpenStreetMappel";
-
 "editor_profile_changes" = "Jóváhagyott változtatások";
-
-"editor_profile_unsent_changes" = "Nincs elküldve:";
 
 "editor_focus_map_on_location" = "Húzd a térképet a megfelelő helyre az objektum helyes helyszínének kiválasztásához.";
 
@@ -1222,13 +788,9 @@
 
 "editor_report_problem_other_title" = "Különböző probléma";
 
-"placepage_report_problem_button" = "Hibabejelentés";
-
 "placepage_add_business_button" = "Szervezet hozzáadása";
 
 "whatsnew_editor_message_1" = "Adj hozzá új helyeket a térképhez, és szerkeszd a meglévőket közvetlenül az alkalmazásból.";
-
-"whatsnew_editor_message_2" = "* A Organic Maps az OpenStreetMap közösség adatait használja.";
 
 "dialog_incorrect_feature_position" = "Helyszín megváltoztatása";
 
@@ -1236,16 +798,10 @@
 
 "login_to_make_edits_visible" = "Jelentkezz be, hogy más felhasználók is láthassák a változtatásaidat.";
 
-"no_migration_during_navigation" = "Navigáció közbeni módosítás nem engedélyezett.";
-
 /* Error dialog no space */
 "migration_no_space_message" = "A letöltéshez több szabad tárhelyre van szükség. Kérjük, töröld a szükségtelen adatokat.";
 
 "editor_sharing_title" = "Én fejlesztettem a Organic Maps térképeket";
-
-"editor_comment_will_be_sent" = "Megjegyzését elküldjük a térképészeknek.";
-
-"editor_unsupported_category_message" = "Olyan kategóriához adott helyet, amelyet még nem támogatunk. Ez a kategória később fog megjelenni a térképen.";
 
 /* Downloaded 10 **of** 20 <- it is that "of" */
 "downloader_of" = "%1$d/%2$d";
@@ -1278,23 +834,9 @@
 
 "editor_operator" = "Üzemeltető";
 
-"editor_tag_description" = "Írja ide a működtetésért felelős cég, szervezet vagy magánszemély nevét.";
-
-"editor_no_local_edits_title" = "Nincsenek helyi módosításai";
-
-"editor_no_local_edits_description" = "Itt a pillanatnyilag csak az Ön készülékén elérhető térképek javasolt módosításainak száma látható.";
-
-"editor_send_to_osm" = "Küldés az OSM-nek";
-
-"editor_remove" = "Eltávolítás";
-
-"downloader_my_maps_title" = "Térképeim";
-
 "downloader_no_downloaded_maps_title" = "Még nem töltött le térképet";
 
 "downloader_no_downloaded_maps_message" = "Töltse le a szükséges térképeket, hogy megtalálja a helyet és internet nélkül is navigálhasson.";
-
-"downloader_find_place_hint" = "Város vagy ország keresése";
 
 /* Error title that appears after certain time without location. */
 "current_location_unknown_title" = "Folytatja tartózkodási helyének keresését?";
@@ -1321,47 +863,13 @@
 /* iOS Dialog for the case when the location permission is not granted */
 "location_services_disabled_3" = "3. Kiválaszt az alkalmazás használata alatt";
 
-"placepage_parking_surface" = "Szabadtéri parkoló";
-
-"placepage_parking_multistorey" = "Parkolóház";
-
-"placepage_parking_underground" = "Föld alatti parkoló";
-
-"placepage_parking_rooftop" = "Tetőparkoló";
-
-"placepage_parking_sheds" = "Fedett parkolóállás";
-
-"placepage_parking_carports" = "Nagyobb fedett parkoló";
-
-"placepage_parking_boxes" = "Garázsbox";
-
-"placepage_parking_pay" = "Fizetős";
-
-"placepage_parking_free" = "Díjmentes";
-
-"placepage_parking_interval" = "Idősávos fizetős";
-
-"placepage_entrance_number" = "Szám";
-
-"placepage_entrance_type" = "Bejárat";
-
-"placepage_flat" = "lakás";
-
-"placepage_open_24_7" = "24 órás";
-
 "meter" = "m";
 
 "kilometer" = "km";
 
-"kilometers_per_hour" = "km/h";
-
 "mile" = "mf";
 
 "foot" = "ft";
-
-"miles_per_hour" = "mph";
-
-"day" = "n";
 
 "hour" = "ó";
 
@@ -1381,10 +889,6 @@
 
 "placepage_bookmark_name_hint" = "Könyvjelző neve";
 
-"placepage_personal_notes_hint" = "Jegyzet";
-
-"placepage_delete_bookmark_button" = "Könyvjelző törlése";
-
 "editor_edits_sent_message" = "Javasolt változtatásainak elküldése sikerült";
 
 "editor_comment_hint" = "Megjegyzés…";
@@ -1397,8 +901,6 @@
 
 "editor_remove_place_button" = "Eltávolítás";
 
-"editor_status_sending" = "Küldés…";
-
 "editor_place_doesnt_exist" = "A hely nem létezik";
 
 "text_more_button" = "…tovább";
@@ -1410,11 +912,7 @@
 
 "error_enter_correct_email" = "Adj meg egy érvényes email-címet";
 
-"error_enter_correct" = "Adj meg egy érvényes értéket";
-
 "refresh" = "Frissítés";
-
-"last_update" = "Utolsó frissítés: %s";
 
 "placepage_add_place_button" = "Hely hozzáadása a térképhez";
 
@@ -1426,24 +924,6 @@
 
 "editor_share_to_all_dialog_message_2" = "Ellenőrizni fogjuk a változásokat. Ha bármilyen kérdésünk van, emailben keresünk.";
 
-"navigation_overview_button" = "áttekintés";
-
-"navigation_stop_button" = "megállítás";
-
-/* Text on an empty bookmark page */
-"bookmarks_empty_title" = "Könyvjelzők mentése";
-
-"bookmarks_empty_message_1" = "Koppintson a ★-ra a kedvenc helyei mentéséhez, gyors eléréséhez.";
-
-"bookmarks_empty_message_2" = "Importálja a könyvjelzőket a levelezésből és a böngészőből.";
-
-"bookmarks_empty_message_3" = "kijelentkezés: %s";
-
-/* Name of the group for booked hotels */
-"bookmarks_group_name" = "Hotelfoglalások";
-
-"place_page_button_read_descriprion" = "Olvassa el";
-
 /* iOS dialog for the case when recent track recording is on and the app comes back from background */
 "recent_track_background_dialog_title" = "Megszakítod a legutóbb megtett utad rögzítését?";
 
@@ -1451,8 +931,6 @@
 
 /* For sharing via SMS and so on */
 "sharing_call_action_look" = "Tekintse meg";
-
-"continue_recent_track_background_button" = "Folytatás";
 
 "recent_track_background_dialog_message" = "A Organic Maps a geopozíciód használatával a háttérben rögzíti a legutóbb megtett utad.";
 
@@ -1468,33 +946,13 @@
 /* About short text (below logo) */
 "about_description" = "A Organic Maps egy nélkülözhetetlen alkalmazás utazáshoz. A Organic Maps az OpenStreetMap adataira épül, és lehetővé teszi ezek szerkesztését.";
 
-/* Text in menu */
-"blog" = "Blog";
-
 "general_settings" = "Általános beállítások";
-
-"date" = "Dátum %d";
-
-/* "Report a bug" -> "Generaal Feedback" -> "Something is not working" */
-"something_is_not_working" = "Valami nem működik";
 
 /* For the first routing */
 "accept" = "Elfogadja";
 
-"accept_and_continue" = "Accept and continue";
-
 /* For the first routing */
 "decline" = "Elutasítja";
-
-"install_app" = "Telepítés";
-
-"search_no_results_title" = "Nincs találat";
-
-"search_no_results_message" = "Próbálkozzon általánosabb kereső kifejezéssel, tágítsa vagy törölje a szűrőt.";
-
-"search_no_results_expand_area_button" = "Kicsinyítés";
-
-"search_no_results_reset_button" = "Szűrő nullázása";
 
 /* noun */
 "search_in_table" = "Lista";
@@ -1517,8 +975,6 @@
 
 "traffic_update_maps_text" = "Forgalmi adatok megjelenítéséhez a térképeket frissíteni kell.";
 
-"traffic_outdated" = "A forgalmi adatok elavultak.";
-
 "big_font" = "Betűméret növelése a térképen";
 
 "traffic_update_app" = "Kérjük, frissítse a Organic Maps alkalmazást";
@@ -1529,17 +985,7 @@
 /* "traffic" as in "road congestion" */
 "traffic_data_unavailable" = "Forgalmi adatok nem állnak rendelkezésre";
 
-/* "Translation is no needed, because it's a company name" */
-"uber" = "Uber";
-
-/* Simplified colour scheme for traffic information, fewer colours are used to display traffic jams on the map. The string should be kept as short as possible */
-"pref_traffic_simplified_colors_title" = "Egyszerűsített forgalmi színek";
-
 "enable_logging" = "Naplózás engedélyezése";
-
-"offline_place_page_more_information" = "A helyszínről további tájékoztatást kaphat, ha csatlakozik az internethez.";
-
-"failed_load_information" = "Nem sikerült betölteni az adatokat.";
 
 /* Settings: "Send general feedback" button */
 "feedback_general" = "Általános visszajelzés";
@@ -1556,8 +1002,6 @@
 
 "whatsnew_transliteration_title" = "Átírás latin nyelvre";
 
-"yandex_taxi_title" = "Yandex.Taxi";
-
 "learn_more" = "Tudjon meg többet";
 
 "core_exit" = "Kilépés";
@@ -1568,75 +1012,19 @@
 
 "button_exit" = "Kilépés";
 
-"settings_device_memory" = "Készülék memóriája";
-
-"settings_card_memory" = "Memóriakártya";
-
-"settings_storage_available" = "%s rendelkezésre áll";
-
-"toast_location_permission_denied" = "Alkalmazás helymeghatározási engedélye megtagadva";
-
-"button_use" = "Használat";
-
 "planning_route_manage_route" = "Útvonal kezelése";
 
 "button_plan" = "Terv";
-
-"button_add" = "Hozzáad";
 
 "placepage_remove_stop" = "Eltávolítja";
 
 "planning_route_remove_title" = "Húzza ide az eltávolításhoz";
 
-"dialog_change_start_point_message" = "Kicseréli a kiindulási pontot az aktuális pozícióval?";
-
-"button_replace" = "Csere";
-
 "placepage_add_stop" = "Hozzáad megállót";
-
-/* Only ru/en are needed */
-"subtitle_rent" = "Rent";
-
-/* Only ru/en are needed */
-"rub_month" = "RUB/month";
-
-/* Only ru/en are needed */
-"room" = "%s-room apt.";
-
-/* Only ru/en are needed */
-"real_estate" = "Real estate";
-
-"add_my_position" = "Add hozzá saját pozíciómat";
-
-"choose_start_point" = "Válasszon egy kiindulási pontot";
-
-"choose_destination" = "Válassza ki a célt";
 
 "preloader_viator_button" = "Tudjon meg többet";
 
-"start_from_my_position" = "Elkezdi innen:";
-
-"profile_authorization_title" = "Bejelentkezés ezzel";
-
-"profile_authorization_message" = "Egyszerű bejelentkezés jelszó és bejelentkezési név nélkül, pár másodperc alatt";
-
 "profile_authorization_error" = "Hoppá, volt egy hiba. Próbáljon meg újra bejelentkezni.";
-
-"service" = "Szolgáltatások";
-
-"atmosphere" = "Légkör";
-
-"value_for_money" = "Ár-érték arány";
-
-"experience" = "Tapasztalat";
-
-"assortment" = "Választék";
-
-"expertise" = "Szakértelem";
-
-"equipment" = "Berendezések";
-
-"quality" = "Minőség";
 
 "dialog_error_storage_title" = "Tároló hozzáférési hiba";
 
@@ -1644,17 +1032,7 @@
 
 "setting_emulate_bad_storage" = "Sérült tároló emulálása";
 
-"directions_finish" = "Rendeltetési hely";
-
-"directions_on_foot" = "%s séta";
-
 "core_entrance" = "Bejárat";
-
-"coffee" = "Kávé";
-
-"cleanliness" = "Tisztaság";
-
-"crowdedness" = "Zsúfoltság";
 
 "error_enter_correct_name" = "Kérjük adja meg a helyes nevet";
 
@@ -1673,11 +1051,9 @@
 
 "downloader_percent" = "%s (%s / %s)";
 
-"downloader_process" = "%s letöltése...";
+"downloader_process" = "%s letöltése…";
 
-"downloader_applying" = "%s alkalmazása...";
-
-"dialog_message_transit_not_found_connection" = "Útvonaltervezés egy összekötő hálózaton belül";
+"downloader_applying" = "%s alkalmazása…";
 
 "bookmarks_error_message_share_general" = "Nem lehet megosztani alkalmazáshiba miatt";
 
@@ -1695,17 +1071,7 @@
 
 "bookmarks_error_message_list_name_already_taken" = "Kérjük, válasszon másik nevet";
 
-"bookmarks_error_title_list_name_too_long" = "Ez a név túl hosszú";
-
-"bookmarks_error_message_list_name_too_long" = "Kérjük, válasszon másik nevet";
-
-"please_wait" = "Kérlek várj...";
-
-"phone_number" = "Telefonszám";
-
-"notification_unsent_reviews_title" = "Több elküldött véleménye is van";
-
-"notification_unsent_reviews_message" = "Kérjük, jelentkezzen be, hogy megoszthassa véleményét más utazókkal";
+"please_wait" = "Kérlek várj…";
 
 "profile" = "OpenStreetMap profil";
 
@@ -1719,49 +1085,13 @@
 
 "bookmarks_convert_error_message" = "Egyes fájlok nem konvertáltak.";
 
-"converting" = "Átalakítás...";
-
-"wn_reinvented_bookmarks_title" = "Új könyveket készítettünk!";
-
-"wn_reinvented_bookmarks_message" = "Könyvjelzőket menthet, listákat hozhat létre... Hihetetlen...";
-
-"bookmarks_restore" = "Könyvjelzők visszaállítása";
-
-"bookmarks_restore_process" = "Visszaállítása ...";
-
 "bookmarks_restore_title" = "A verzió visszaállítása?";
 
-"bookmarks_restore_message" = "Könyvjelzői %s (%s)-ból visszaállnak";
-
-"bookmarks_restore_empty_title" = "Nincs biztonsági mentése";
-
-"bookmarks_restore_empty_message" = "A szerver nem találta a korábban készített biztonsági másolatokat";
-
 "common_check_internet_connection_dialog_title" = "Nincs internetkapcsolat";
-
-"error_server_title" = "Szerver hiba";
-
-"error_server_message" = "Hiba történt a szerveren, próbálkozzon később";
 
 "error_system_message" = "Ismeretlen hiba történt";
 
 "restore" = "Visszaállítás";
-
-"bookmarks_page_downloaded" = "Letöltött";
-
-"bookmarks_page_my" = "Az én";
-
-"routes_and_bookmarks" = "Útvonalaim és könyvjelzőim";
-
-"bookmarks_webview_success_toast" = "Könyvjelzők sikeresen letöltve";
-
-"cached_bookmarks_placeholder_title" = "Új helyek letöltése";
-
-"cached_bookmarks_placeholder_subtitle" = "Nyomja meg a gombot, hogy Organic Maps felhasználók ezrei által gyűjtött érdekes helyet és útvonalat tölthessen le. Ehhez internetkapcsolatra van szükség.";
-
-"downloader_download_routers" = "Könyvjelzők letöltése";
-
-"bookmarks_groups_cached" = "Letöltött listák";
 
 "subtittle_opt_out" = "Követési beállítások";
 
@@ -1769,29 +1099,15 @@
 
 "crash_reports_description" = "A Organic Maps fejlesztéséhez felhasználhatjuk az adatait. A változtatások az alkalmazás újraindítása után lépnek életbe.";
 
-"opt_out_help_ios_1" = "A mobileszköz „Reklámkövetés korlátozása” vagy „Érdeklődési kör alapú reklámozás” beállítással rendelkezhet.";
-
-"opt_out_help_ios_2" = "iOS 9 vagy újabb";
-
-"opt_out_help_ios_3" = "Nyissa meg a Beállítások → Adatvédelem→ Reklámok→ és engedélyezze a “Reklámkövetés korlátozása” beállítást";
-
-"opt_out_help_android" = "A mobileszköz „Reklámkövetés korlátozása” vagy „Érdeklődési kör alapú reklámozás” beállítással rendelkezhet.\n\nAndroidban és Google Play szolgáltatások 4.0 vagy újabb verzió:\nBeállítások → Google → Google fiók → Személyes és adatvédelem → Reklámok → Reklámok személyre szabása";
-
 "privacy_policy" = "Adatvédelmi irányelvek";
 
 "terms_of_use" = "Felhasználási feltételek";
-
-"backup_notification_failed" = "A könyvjelzői biztonsági mentése felfüggesztésre került. Jelentkezz be a visszakapcsoláshoz.";
 
 "button_layer_traffic" = "Forgalom";
 
 "button_layer_subway" = "Metró";
 
 "layers_title" = "Térképrétegek";
-
-"layers_message" = "Használjon térképrétegeket a forgalom, metrótérkép és más hasznos információ megjelenítéséhez";
-
-"button_layer_got_it" = "Értem";
 
 "subway_data_unavailable" = "A metrótérkép nem elérhető";
 
@@ -1803,39 +1119,13 @@
 
 "title_error_downloading_bookmarks" = "Hiba történt";
 
-"subtitle_error_downloading_bookmarks" = "Nem került letöltésre könyvjelző";
-
-"error_already_downloaded" = "Ezt a listát már letöltötték";
-
 "popular_place" = "Popular";
-
-"download_routes" = "Download routes";
-
-"bookmarks_downloaded_title" = "Bookmarks have been downloaded successfully";
-
-"bookmarks_downloaded_subtitle" = "Press ‘View on map’ to explore new places from the list";
-
-"why_support" = "Miért éri meg támogatni a Organic Maps-t?";
-
-"why_support_item1" = "We respect your privacy: there are zero trackers in the app, and we are open source";
-
-"why_support_item2" = "Ön segít a Organic Maps-t fejleszteni";
-
-"why_support_item3" = "Segítsen a térkép fejlesztésében az OpenStreetMap.org-on";
-
-"channels_map_update" = "Térképfrissítések";
-
-"server_unavailable_title" = "A szerver nem elérhető";
-
-"sharing_options" = "A hozzáférés beállításai";
 
 "export_file" = "Fájl exportálása";
 
 "list_settings" = "Lista beállításai";
 
 "delete_list" = "Törölni a listát";
-
-"hide_from_map" = "Lefedés a térképen";
 
 "public_access" = "Nyílt hozzáférés";
 
@@ -1845,40 +1135,11 @@
 
 "bookmark_category_description_hint" = "Leírás hozzáadása (szöveg vagy html)";
 
-/* FIXME */
-"bookmarks_public_access" = "bookmarks_public_access";
-
-/* FIXME */
-"bookmarks_link_access" = "bookmarks_link_access";
-
-/* FIXME */
-"bookmarks_private_access" = "bookmarks_private_access";
-
 "not_shared" = "Privát";
-
-"direct_link_progress_text" = "Betöltjük az Ön fájlát…";
-
-"direct_link_success" = "A hivatkozás létre van hozva";
-
-"send_a_link_btn" = "Hivatkozás küldése";
-
-"upload_error_toast" = "A fájl feltöltésekor hiba történt";
 
 "tags_loading_error_subtitle" = "A tag-ek feltöltésekor hiba történt, kérjük próbálja meg még egyszer";
 
-"unable_upload_errorr_title" = "Nem sikerült a fájl feltöltése";
-
-"unable_upload_error_subtitle_edited" = "A fájl a web alkalmazáson keresztül volt újraszerkesztve";
-
-"unable_upload_error_subtitle_broken" = "A fájl sérült és nem lehet feltölteni. Kérjük, más fájlt töltsön fel.";
-
-"contact" = "Írás";
-
-"download_button" = "Letöltés";
-
 "speedcams_alert_title" = "Sebességmérő kamerák";
-
-"speedcams_alert_subtitle" = "Figyelmeztetés a sebessség korlátozására";
 
 "speedcam_option_auto" = "Autó";
 
@@ -1886,18 +1147,10 @@
 
 "speedcam_option_never" = "Soha";
 
-"bookmark_description_title" = "A jel ismertetése";
-
 "place_description_title" = "A hely ismertetése";
 
 /* this text will be shown in application notification preferences opposite checkbox which enable/disable downloader notifications. Devices on Android 8+ are affected. */
 "notification_channel_downloader" = "Kártyák letöltése";
-
-"share_bookmarks_email_body_link" = "Üdvözlöm!\n\nA jeleit le lehet tölteni ezzel a linkkel: %s. Nyíssa meg a listát Organic Maps segítségével és élvezze az utazását!\n\nAlkalmazás letöltése: https://omaps.app/get?kmz";
-
-"warning_speedcams_title" = "Navigátor értesít a kamerákról sebességkorlátozás megsértésénél %d km/óra-ra";
-
-"warning_speedcams_subtitle" = "Ne felejtse el megismerkedni a cél ország közlekedési szabályaival.";
 
 "speedcams_notice_message" = "Autó - Figyelmeztetés a sebesség kamerákról, ha van kockázat a sebesség korlátozás megsértéséről\nMindig - Mindig figyelmeztet a kamerákról\nSoha - Soha ne figyelmezet a kamerákról";
 
@@ -1913,23 +1166,7 @@
 
 "enable_logging_warning_message" = "Az opció bekapcsolja a diagnosztikai célú naplózást. Hasznos lehet a support csapatunknak, akik elhárítják az alkalmazás hibáit. Csak a Organic Maps support kérésére kapcsold be ezt az opciót.";
 
-"html_error_upload_message_try_again" = "Kérjük ellenőrizd a hálózati beállításaidat és próbáld újra";
-
-"html_error_upload_title_try_again" = "Nincs internetkapcsolat";
-
-"notification_leave_review_v2_android_short_title" = "Értékelj és segítsd az utazókat!";
-
-"megafon" = "Say goodbye to roaming!";
-
-"notifications_illegal_alert_disable_button" = "Értesítések kikapcsolása";
-
 "access_rules_author_only" = "Online szerkesztés";
-
-"privacy_settings_menu" = "Adatvédelmi beállítások";
-
-"unable_upadate_error_title" = "Fájl frissítés sikertelen";
-
-"unable_upadate_error_message" = "Néhány hiba történt frissítés közben. Kérjük ellenőrizd a változtatásokat és próbáld újra";
 
 "driving_options_title" = "Vezetési lehetőségek";
 
@@ -1951,94 +1188,19 @@
 
 "change_driving_options_btn" = "Vezetési lehetőségek bekapcsolva";
 
-"toll_road" = "Fizetős utak";
-
-"unpaved_road" = "Kövezetlen utak";
-
-"ferry_crossing" = "Kompátkelők";
-
-"operated_by" = "\"%s\" működteti";
-
 "avoid_toll_roads_placepage" = "Fizetős utak elkerülése";
 
 "avoid_unpaved_roads_placepage" = "Kövezetlen utak elkerülése";
 
 "avoid_ferry_crossing_placepage" = "Kompátkelők elkerülése";
 
-"type.cuisine.uzbek" = "Üzbég konyha";
-
-"trip_start" = "Gyerünk";
-
-"pick_destination" = "Cél";
-
-"follow_my_position" = "Középre";
-
-"search_results" = "Keresési eredmények";
-
-"then_turn" = "Utána";
-
-"redirect_route_alert" = "Szeretnél újratervezni egy útvonalat?";
-
-"redirect_route_yes" = "Igen";
-
-"redirect_route_no" = "Nem";
-
-"trip_finished" = "Megérkeztél!";
-
-"keyboard_availability_alert" = "A billentyűzet nem elérhető vezetés közben";
-
-"dialog_routing_change_start_carplay" = "Nem lehet útvonalat tervezni a jelenlegi helyedről";
-
-"dialog_routing_change_end_carplay" = "Nem lehet útvonalat tervezni a célodhoz. Kérjük válassz egy másik pontot";
-
-"dialog_routing_check_gps_carplay" = "Nincs GPS-jel. Kérjük menj egy nyílt területre";
-
-"dialog_routing_unable_locate_route_carplay" = "Nem lehet útvonalat tervezni. Kérjük határozz meg más útvonal lehetőségeket";
-
-"dialog_routing_download_files_carplay" = "Útvonal létrehozásához töltsd le a hiányzó térképeket az eszközre";
-
-"dialog_routing_system_error_carplay" = "Hiba történt. Kérjük indítsd újra az alkalmazást";
-
-"dialog_routing_rebuild_from_current_location_carplay" = "Az útvonal újra lesz tervezve a jelenlegi helyzetedről";
-
-"dialog_routing_rebuild_for_vehicle_carplay" = "Az útvonal módosítva lesz egy autó számára";
-
 "ok" = "Oké";
-
-"avoid_unpaved_carplay_1" = "Nem földút";
-
-"avoid_unpaved_carplay_2" = "Földút kerülése";
-
-"avoid_ferry_carplay_1" = "Komp nélkül";
-
-"avoid_ferry_carplay_2" = "Kompok kerülése";
-
-"avoid_tolls_carplay_1" = "Nincs útdíj";
-
-"avoid_tolls_carplay_2" = "Útdíj kerülése";
-
-"speedcams_alert_title_carplay_1" = "Traffipaxok";
-
-"speedcams_alert_title_carplay_2" = "Sebességjelzés";
-
-"download_map_carplay" = "Kérjük, töltsd le a térképeket a Organic Maps alkalmazásban az eszközödre";
-
-"carplay_roundabout_exit" = "%s kijárat";
 
 /* max. 10 symbols, both iOS and Android */
 "sort" = "Rendezd…";
 
 /* Android, title, max 20-22 symbols */
 "sort_bookmarks" = "Könyvelzők rendezése";
-
-/* iOS */
-"sort_default" = "Alapértelmezés szerint";
-
-"sort_type" = "Típus szerint";
-
-"sort_distance" = "Távolság szerint";
-
-"sort_date" = "Dátum szerint";
 
 /* Android */
 "by_default" = "Alapértelmezés szerint";
@@ -2052,63 +1214,7 @@
 /* Android */
 "by_date" = "Dátum szerint";
 
-"week_ago_sorttype" = "Egy hete";
-
-"month_ago_sorttype" = "Egy hónapja";
-
-"moremonth_ago_sorttype" = "Több mint egy hónapja";
-
-"moreyear_ago_sorttype" = "Több mint egy éve";
-
-"near_me_sorttype" = "Hozzám közel";
-
-"others_sorttype" = "Más";
-
-"food_places" = "Étel";
-
-"tourist_places" = "Látnivalók";
-
-"museums" = "Múzeumok";
-
-"parks" = "Parkok";
-
-"swim_places" = "Úszás";
-
-"mountains" = "Hegyek";
-
-"animals" = "Állatok";
-
-"hotels" = "Hotelek";
-
-"buildings" = "Épületek";
-
-"money" = "Pénz";
-
-"shops" = "Üzletek";
-
-"parkings" = "Parkolók";
-
-"fuel_places" = "Benzinkutak";
-
-"water" = "Víz";
-
-"medicine" = "Gyógyszer";
-
 "search_in_the_list" = "Keresés a listában";
-
-"view_on_map_bookmarks" = "Térképen";
-
-"more_bookmarks" = "Továbbiak…";
-
-"no_items_found" = "Nincs találat";
-
-/* Android, max 18 symbols */
-"bookmarks_edit_list" = "Lista szerkesztése";
-
-/* Android, max 18 symbols */
-"bookmarks_delete_list" = "Lista törlése";
-
-"religious_places" = "Vallási helyek";
 
 "select_list" = "Lista kiválasztása";
 
@@ -2118,26 +1224,13 @@
 
 "dialog_pedestrian_route_is_long_message" = "Válasszon indulási vagy végpontot közelebb a metróállomáshoz";
 
-/* Failed planning SUBWAY route message in navigation view */
-"routing_planning_error_subway_special" = "A metró útvonaltervezése sikertelen";
-
 "button_layer_isolines" = "Terep";
-
-"tips_map_layers_title_countour" = "Újdonság a Organic Maps-n: offline topográfiai réteg!";
-
-"tips_map_layers_message_countour" = "Tervezze meg és élvezze a természetjáró kirándulásait, és tudjon meg mindent a környékről";
 
 "isolines_activation_error_dialog" = "A topográfiai réteg aktiválásához és használatához kérjük frissítse vagy töltse le az adott terület térképét";
 
 "isolines_location_error_dialog" = "Ezen a területen a topográfiai réteg még nem elérhető";
 
 "elevation_profile_diff_level" = "Nehézségi szint";
-
-"elevation_profile_diff_level_easy" = "Könnyű";
-
-"elevation_profile_diff_level_moderate" = "Mérsékelt";
-
-"elevation_profile_diff_level_hard" = "Nehéz";
 
 "elevation_profile_ascent" = "Felemelkedés";
 
@@ -2147,25 +1240,13 @@
 
 "elevation_profile_maxaltitude" = "Max. magasság";
 
-"elevation_profile_m" = "m";
-
 "elevation_profile_difficulty" = "Nehézség";
 
 "elevation_profile_distance" = "Táv.:";
 
-"elevation_profile_km" = "km";
-
 "elevation_profile_time" = "Idő";
 
-"elevation_profile_hours" = "ó.";
-
-"elevation_profile_minutes" = "p.";
-
 "isolines_toast_zooms_1_10" = "Nagyítás az isovonalak felfedezéséhez";
-
-"downloader_updating_ios" = "Feltöltés";
-
-"downloader_loading_ios" = "Letöltés";
 
 "key_information_title" = "Kulcs információ";
 

--- a/iphone/Maps/LocalizedStrings/hu.lproj/Localizable.stringsdict
+++ b/iphone/Maps/LocalizedStrings/hu.lproj/Localizable.stringsdict
@@ -9,21 +9,6 @@
 
 <!-- ********** Strings for downloading map from search **********/ -->
 
-  <key>bookmarks_places</key>
-  <dict>
-    <key>NSStringLocalizedFormatKey</key>
-    <string>%#@value@</string>
-    <key>value</key>
-    <dict>
-      <key>NSStringFormatSpecTypeKey</key>
-      <string>NSStringPluralRuleType</string>
-      <key>NSStringFormatValueTypeKey</key>
-      <string>d</string>
-      <key>other</key>
-      <string>könyvjelzők %d</string>
-    </dict>
-  </dict>
-
   <key>bookmarks_detect_message</key>
   <dict>
     <key>NSStringLocalizedFormatKey</key>
@@ -38,21 +23,6 @@
       <string>%d fájlt találtunk. Látni fogja őket a megtérés után.</string>
       <key>other</key>
       <string>%d fájl található. Látni fogja őket a megtérés után.</string>
-    </dict>
-  </dict>
-
-  <key>bookmarks_objects</key>
-  <dict>
-    <key>NSStringLocalizedFormatKey</key>
-    <string>%#@value@</string>
-    <key>value</key>
-    <dict>
-      <key>NSStringFormatSpecTypeKey</key>
-      <string>NSStringPluralRuleType</string>
-      <key>NSStringFormatValueTypeKey</key>
-      <string>d</string>
-      <key>other</key>
-      <string>%s tárgy</string>
     </dict>
   </dict>
 

--- a/iphone/Maps/LocalizedStrings/id.lproj/Localizable.strings
+++ b/iphone/Maps/LocalizedStrings/id.lproj/Localizable.strings
@@ -18,9 +18,6 @@
 /* Button which deletes downloaded country */
 "delete" = "Hapus";
 
-/* Button "do not interrupt download" if user touched actively downloading country */
-"do_nothing" = "Lanjutkan";
-
 "download_maps" = "Unduh Peta";
 
 /* Settings/Downloader - info for country when download fails */
@@ -28,9 +25,6 @@
 
 /* Settings/Downloader - info for country which started downloading */
 "downloading" = "Sedang mengunduh…";
-
-/* Settings/Downloader - size string, only strings different from English should be translated */
-"kb" = "kB";
 
 /* Choose measurement on first launch alert - choose metric system button */
 "kilometres" = "Kilometer";
@@ -55,17 +49,11 @@
 /* Update maps later/Buy pro version later button text */
 "later" = "Nanti";
 
-/* Don't show some dialog any more */
-"never" = "Tidak akan pernah";
-
 /* View and button titles for accessibility */
 "search" = "Cari";
 
 /* Search box placeholder text */
 "search_map" = "Cari Peta";
-
-/* Settings/Downloader - info for not downloaded country */
-"touch_to_download" = "Sentuh untuk mengunduh";
 
 /* Settings/Downloader - 3G download warning dialog confirm button */
 "use_cellular_data" = "Ya";
@@ -73,20 +61,11 @@
 /* Location services are disabled by user alert - message */
 "location_is_disabled_long_text" = "Saat ini semua Layanan Lokasi untuk perangkat atau aplikasi ini non-aktif. Mohon aktifkan lewat Setelan.";
 
-/* Location Services are not available on the device alert - message */
-"device_doesnot_support_location_services" = "Perangkat Anda tidak mendukung Layanan Lokasi";
-
 /* View and button titles for accessibility */
 "zoom_to_country" = "Tampilkan di peta";
 
-/* Button text for the button at the center of the screen when the country is not downloaded */
-"country_status_download" = "Unduh Peta\n(^ ^)";
-
 /* Button text for the button at the center of the screen when the country is not downloaded and the size should not be shown */
 "country_status_download_without_size" = "Unduh Peta";
-
-/* Button text for the button at the center of the screen when the country is not downloaded */
-"country_status_download_without_routing" = "Unduh peta tanpa\nperutean (^ ^)";
 
 /* Message to display at the center of the screen when the country download has failed */
 "country_status_download_failed" = "Sedang Mengunduh telah gagal";
@@ -96,19 +75,13 @@
 
 "about_menu_title" = "Tentang Organic Maps";
 
-"downloaded_touch_to_delete" = "(%@) telah diunduh, sentuh untuk menghapus";
-
 "connection_settings" = "Pengaturan Koneksi";
-
-"download_mb_or_kb" = "Unduh %@";
 
 "close" = "Tutup";
 
 "unsupported_phone" = "OpenGL yang dipercepat oleh OpenGL diperlukan. Sayangnya, perangkat Anda tidak mendukung.";
 
 "download" = "Unduh";
-
-"external_storage_is_not_available" = "Penyimpanan kartu SD/USB dengan peta terunduh tidak tersedia";
 
 "disconnect_usb_cable" = "Mohon lepas kabel USB atau masukkan kartu memori untuk menggunakan Organic Maps";
 
@@ -117,8 +90,6 @@
 "not_enough_memory" = "Memori tidak cukup untuk meluncurkan aplikasi";
 
 "download_resources" = "Sebelum Anda mulai izinkan kami mengunduh peta dunia secara umum ke perangkat Anda.\nHal ini memerlukan data %@.";
-
-"getting_position" = "Sedang mencari lokasi saat ini";
 
 "download_resources_continue" = "Pergi ke Peta";
 
@@ -140,23 +111,14 @@
 /* Add New Bookmark Set dialog title */
 "add_new_set" = "Tambahkan Set baru";
 
-/* Place Page - Add To Bookmarks button */
-"add_to_bookmarks" = "Tambahkan ke Penanda";
-
 /* Bookmark Color dialog title */
 "bookmark_color" = "Warna Penanda";
 
 /* Add Bookmark Set dialog - hint when set name is empty */
 "bookmark_set_name" = "Nama Set Penanda";
 
-/* Bookmark Sets dialog title */
-"bookmark_sets" = "Set Penanda";
-
 /* Bookmarks - dialog title */
 "bookmarks" = "Penanda";
-
-/* Add bookmark dialog - bookmark color */
-"color" = "Warna";
 
 /* Default bookmarks set name */
 "core_my_places" = "Tempat-tempat Saya";
@@ -167,14 +129,8 @@
 /* Editor title above street and house number */
 "address" = "Alamat";
 
-/* Place Page - Remove Pin button */
-"remove_pin" = "Hapus Pin";
-
 /* Add bookmark dialog - bookmark set, Bookmarks dialog - Bookmark set cell */
 "set" = "Set";
-
-/* Text hint in Bookmarks dialog when no any bookmarks are added */
-"bookmarks_usage_hint" = "Belum ada yang ditandai.\nSentuh lokasi apa pun pada peta untuk menandai.\nPenanda dari sumber lainnya juga dapat di impor dan ditampilkan pada Organic Maps. Buka berkas KML/KMZ tersebut dengan penanda yang disimpan dari surel, Dropbox atau tautan jaringan.";
 
 /* Settings button in system menu */
 "settings" = "Pengaturan";
@@ -191,26 +147,11 @@
 /* Ask to wait user several minutes (some long process in modal dialog). */
 "wait_several_minutes" = "Ini akan memakan waktu beberapa menit.\nMohon tunggu…";
 
-/* Show bookmarks from this category on a map or not */
-"visible" = "Tampak";
-
-/* Toast which is displayed when GPS has been deactivated */
-"gps_is_disabled_long_text" = "GPS dinon-aktifkan. Mohon aktifkan lewat Pengaturan.";
-
 /* Measurement units title in settings activity */
 "measurement_units" = "Unit Pengukuran";
 
 /* Detailed description of Measurement Units settings button */
 "measurement_units_summary" = "Pilihlah antara mil dan kilometer";
-
-/* Do search in all sources */
-"search_mode_all" = "Everywhere";
-
-/* Do search near my position only */
-"search_mode_nearme" = "Near Me";
-
-/* Do search in current viewport only */
-"search_mode_viewport" = "On the Screen";
 
 /* Search category for cafes, bars, restaurants */
 "eat" = "Tempat makan";
@@ -266,14 +207,8 @@
 /* Search category */
 "police" = "Polisi";
 
-/* String in search result list, when nothing found */
-"no_search_results_found" = "Tidak ada hasil yang ditemukan";
-
 /* Notes field in Bookmarks view */
 "description" = "Catatan";
-
-/* Button text */
-"share_by_email" = "Bagikan menggunakan surel";
 
 /* Email Subject when sharing bookmarks category */
 "share_bookmarks_email_subject" = "Bagikan penanda Organic Maps";
@@ -295,26 +230,11 @@
 /* Warning message when doing search around current position */
 "unknown_current_position" = "Lokasi Anda belum ditentukan";
 
-/* Warning message when location country isn't downloaded during search (see also download_location_map_proposal). */
-"download_location_country" = "Unduh negara di mana Anda berada saat ini (%@)";
-
-/* Warning message when viewport country isn't downloaded during search */
-"download_viewport_country_to_search" = "Unduh negara yang lokasinya sedang Anda cari (%@)";
-
 /* Alert message that we can't run Map Storage settings due to some reasons. */
 "cant_change_this_setting" = "Maaf, pengaturan Penyimpanan Peta saat ini sedang non-aktif.";
 
 /* Alert message that downloading is in progress. */
 "downloading_is_active" = "Pengunduhan negara sedang berjalan.";
-
-/* Message that will be shown in alert view, when we ask user to leave review on App Store */
-"appStore_message" = "Kami harap Anda senang menggunakan Organic Maps! Jika ya, mohon beri nilai atau ulasan untuk aplikasi ini di App Store. Hanya memakan waktu kurang dari satu menit tetapi hal itu dapat benar-benar membantu kami. Terima kasih atas dukungan Anda!";
-
-/* No, thanks */
-"no_thanks" = "Tidak, terima kasih";
-
-/* Share one specific bookmark using SMS, %1$@ contains om:// and %2$@ https://omaps.app link. @NOTE non-ascii symbols in the link will result in max 70 characters SMS instead of 140. */
-"bookmark_share_sms" = "Hei, lihat pinku di Organic Maps! %1$@ atau %2$@ belum memiliki peta offline? Unduh di sini: https://omaps.app/get";
 
 /* Share my position using SMS, %1$@ contains om:// and %2$@ https://omaps.app link WITHOUT NAME. @NOTE non-ascii symbols in the link will result in max 70 characters SMS instead of 140. */
 "my_position_share_sms" = "Hei, lihat lokasiku saat ini di Organic Maps! %1$@ atau %2$@ belum memiliki peta offline? Unduh di sini: https://omaps.app/get";
@@ -328,23 +248,11 @@
 /* Share my position using EMail, %1$@ is om:// and %2$@ is https://omaps.app link WITHOUT NAME */
 "my_position_share_email" = "Hai,\n\nSekarang saya ada di sini: %1$@. Klik tautan ini %2$@ atau yang ini %3$@ untuk melihat tempatnya di peta.\n\nTerima kasih.";
 
-/* Android share by Message/SMS button text (including SMS) */
-"share_by_message" = "Bagikan menggunakan pesan";
-
 /* Share button text which opens menu with more buttons, like Message, EMail, Facebook etc. */
 "share" = "Bagikan";
 
-/* iOS share by Message button text (including SMS) */
-"message" = "Pesan";
-
 /* Share by email button text, also used in editor. */
 "email" = "Surel";
-
-/* Copy Link */
-"copy_link" = "Salin Tautan";
-
-/* Text for the button that returns to caller application */
-"more_info" = "Tampilkan Lebih Banyak Info";
 
 /* Text for message when used successfully copied something */
 "copied_to_clipboard" = "Telah Disalin ke Papan Klip: %1$@";
@@ -354,15 +262,6 @@
 
 /* Used for bookmark editing */
 "done" = "Selesai";
-
-/* Summary for preferences in MWM */
-"yopme_pref_summary" = "Pilih pengaturan Layar Belakang";
-
-/* Title for yopme preferences in MWM */
-"yopme_pref_title" = "Pengaturan Layar Belakang";
-
-/* Hint for upper-right icon p2b */
-"show_on_backscreen" = "Tampilkan pada layar Belakang";
 
 /* Prints version number in About dialog */
 "version" = "Versi: %@";
@@ -381,19 +280,11 @@
 
 "share_my_location" = "Bagikan Lokasi Saya";
 
-"menu_search" = "Cari";
-
 /* Settings general group in settings screen */
 "prefs_group_general" = "General settings";
 
 /* Settings information group in settings screen */
 "prefs_group_information" = "Information";
-
-/* Settings screen: "Map" category title */
-"prefs_group_map" = "Peta";
-
-/* Settings screen: "Miscellaneous" category title */
-"prefs_group_misc" = "Lain-Lain";
 
 "prefs_group_route" = "Navigasi";
 
@@ -419,9 +310,6 @@
 /* Settings «Map» category: «3D buildings» title */
 "pref_map_3d_buildings_title" = "Bangunan 3D";
 
-/* Settings «Map» category: «3D buildings» summary */
-"pref_map_3d_buildings_subtitle" = "Memengaruhi daya baterai";
-
 /* Settings «Route» category: «Tts enabled» title */
 "pref_tts_enable_title" = "Petunjuk Suara";
 
@@ -433,8 +321,6 @@
 
 /* Title for "Other" section in TTS settings. */
 "pref_tts_other_section_title" = "Lainnya";
-
-"pref_tts_how_to_set_up_voice" = "Cara mengatur suara";
 
 /* Settings «Map» category: «Record track» title */
 "pref_track_record_title" = "Jalur terkini";
@@ -455,56 +341,7 @@
 
 "recent_track_help_text" = "Ini memungkinkan Anda untuk merekam jalur yang telah dilalui selama jangka waktu tertentu dan melihatnya pada peta. Harap ketahui: aktivasi fungsi ini menyebabkan peningkatan penggunaan baterai. Trek akan dihapus secara otomatis dari peta setelah selang waktu berakhir.";
 
-"pref_track_ios_caption" = "Jalur terakhir menunjukkan jalur yang sudah Anda lalui.";
-
-"pref_track_ios_subcaption" = "Silakan pilih jangka waktu penyimpanan jalur.";
-
-"placepage_distance" = "Jarak";
-
-"placepage_coordinates" = "Koordinat";
-
-"placepage_unsorted" = "Tidak diurutkan";
-
 "search_show_on_map" = "Tampilkan pada peta";
-
-/* Used to warn user when fixing KitKat issue */
-"bookmark_move_fail" = "Kami perlu memindahkan penanda lokasi Anda ke memori internal, tetapi tidak ada ruang yang tersedia. Mohon bebaskan memori, atau penanda lokasi tidak akan tersedia.";
-
-/* Used in More Apps menu */
-"free" = "Free";
-
-/* Used in More Apps menu */
-"buy" = "Buy";
-
-/* 1st search button-like result */
-"search_on_map" = "Cari ada peta";
-
-/* toast with an error */
-"no_route_found" = "Tidak ada rute yang ditemukan";
-
-/* route title */
-"route" = "Rute";
-
-/* category title */
-"routes" = "Rute";
-
-/* text of notification */
-"download_map_notification" = "Unduh peta tempat di mana Anda berada sekarang";
-
-/* text of notification */
-"pro_version_is_free_today" = "Full version of Organic Maps is free today! Download now and tell your friends.";
-
-/* Dialog for transferring maps from lite to pro. */
-"move_lite_maps_to_pro" = "Kami sedang mentransfer peta unduhan Anda dari Organic Maps Lite ke Organic Maps. Proses ini mungkin membutuhkan waktu beberapa menit.";
-
-/* Message to display when maps moved. */
-"move_lite_maps_to_pro_ok" = "Peta unduhan Anda berhasil ditransfer ke Organic Maps.";
-
-/* Message to display when maps move failed. */
-"move_lite_maps_to_pro_failed" = "Peta Anda gagal ditransfer. Silakan hapus Organic Maps Lite dan unduh peta lagi.";
-
-/* Text in menu */
-"settings_and_more" = "Setelan &amp; Lebih Banyak";
 
 /* Text in menu */
 "website" = "Situs Web";
@@ -527,14 +364,8 @@
 /* Text in menu */
 "openstreetmap" = "OpenStreetMap";
 
-/* Text in menu */
-"contact_us" = "Hubungi kami";
-
 /* Settings: Send feedback button and dialog title */
 "feedback" = "Umpan balik";
-
-/* Text in menu */
-"subscribe_to_news" = "Berlangganan berita kami";
 
 /* Text in menu */
 "rate_the_app" = "Beri nilai aplikasi";
@@ -548,15 +379,6 @@
 /* Text in menu */
 "report_a_bug" = "Laporkan gangguan";
 
-/* Email subject */
-"subscribe_me_subject" = "Mohon daftarkan saya untuk berlangganan berita Organic Maps";
-
-/* Email body */
-"subscribe_me_body" = "Saya ingin menjadi yang pertama untuk mengetahui kabar dan promosi terbaru. Saya dapat membatalkan langganan saya kapan saja.";
-
-/* About text */
-"about_text" = "Organic Maps menawarkan peta offline tercepat dari semua kota, semua negara di dunia. Berpergianlah dengan kepercayaan diri yang penuh: di nana pun Anda berada, Organic Maps akan membantu Anda mengetahui posisi Anda pada peta, menemukan restoran, hotel, bank, stasiun bahan bakar terdekat, dll. Tidak perlu koneksi internet.Kami selalu membuat fitur-fitur baru dan ingin mendengar pendapat Anda mengenai bagaimana kami dapat membuat Organic Maps menjadi lebih baik. Jika Anda memiliki masalah apa pun dengan aplikasinya, jangan segan untuk menghubungi kami di support@organicmaps.app. Kami akan merespons setiap permintaan!Apakah Anda menyukai Organic Maps an ingin membantu kami? Terdapat beberapa cara yang mudah dan sepenuhnya gratis:- tulis ulasan di App Market Anda";
-
 /* Alert text */
 "email_error_body" = "Surel pelanggan belum diatur. Mohon konfigurasikan atau gunakan cara lain untuk menghubungi kami di %@";
 
@@ -569,12 +391,6 @@
 /* Search category */
 "wifi" = "WiFi";
 
-/* Update map suggestion */
-"routing_map_outdated" = "Mohon perbarui peta untuk membuat rute";
-
-/* Update maps suggestion */
-"routing_update_maps" = "Versi Organic Maps yang terbaru memungkinkan pembuatan rute dari posisi Anda saat itu ke titik tujuan. Mohon perbarui peta untuk menggunakan fitur ini.";
-
 /* Update all button text */
 "downloader_update_all_button" = "Perbarui semua";
 
@@ -583,9 +399,6 @@
 
 /* Downloaded maps category */
 "downloader_downloaded_subtitle" = "Diunduh";
-
-/* Downloaded maps category */
-"downloader_available_maps" = "Tersedia";
 
 /* Country queued for download */
 "downloader_queued" = "Telah diantrekan";
@@ -598,17 +411,6 @@
 
 "downloader_downloading" = "Mengunduh:";
 
-"downloader_search_results" = "Ditemukan";
-
-/* Disclaimer message */
-"routing_disclaimer" = "Dalam membuat rute di aplikasi Organic Maps, mohon ingat:\n\n- Rute yang disarankan hanya dapat dianggap sebagai rekomendasi.\n- Kondisi jalan, peraturan dan tanda-tanda lalu lintas memiliki prioritas yang lebih tinggi daripada saran navigasi.\n- Kondisi jalan, peraturan dan tanda-tanda lalu lintas memiliki prioritas yang lebih tinggi daripada saran navigasi.\n- Peta bisa saja salah atau sudah usang, dan rute yang dibuat mungkin bukan yang terbaik.\n\nBerhati-hatilah di jalan dan jagalah diri Anda sendiri!";
-
-/* Outdated maps category */
-"downloader_outdated_maps" = "Usang";
-
-/* Up to date maps category */
-"downloader_uptodate_maps" = "Terkini";
-
 /* Status of outdated country in the list */
 "downloader_status_outdated" = "Perbarui";
 
@@ -618,49 +420,14 @@
 /* Displayed in a dialog that appears when a user tries to delete a map while the app is in the follow route mode */
 "downloader_delete_map_while_routing_dialog" = "Untuk menghapus peta, silakan hentikan navigasi.";
 
-/* Show when user try build route, but we don't know where he */
-"routing_failed_unknown_my_position" = "Lokasi saat ini tidak diketahui. Mohon masukkan lokasi untuk membuat rute.";
-
-/* Show if use has not routing file, or InconsistentMWMandRoute */
-"routing_failed_has_no_routing_file" = "Data tambahan yang diperlukan untuk membuat rute dari lokasi Anda.";
-
-/* StartPointNotFound */
-"routing_failed_start_point_not_found" = "Tidak dapat memperhitungkan rute. Tidak ada jalan di dekat titik Anda mulai.";
-
-/* EndPointNotFound */
-"routing_failed_dst_point_not_found" = "Tidak dapat memperhitungkan rute. Tidak ada jalan di dekat tujuan Anda.";
-
 /* PointsInDifferentMWM */
 "routing_failed_cross_mwm_building" = "Rute hanya dapat dibuat dengan yang seluruhnya ada di dalam peta tunggal.";
-
-/* RouteNotFound */
-"routing_failed_route_not_found" = "Tidak ada rute yang ditemukan antara tempat asal dan tujuan yang dipilih. Mohon pilih titik mulai atau tujuan yang berbeda.";
-
-/* InternalError */
-"routing_failed_internal_error" = "Terjadi gangguan internal. Mohon coba menghapus dan mengunduh petanya lagi. Jika masih terjadi masalah mohon hubungi kami di support@organicmaps.app.";
-
-/* Context menu item for downloader. */
-"downloader_download_map_and_routing" = "Untuh Peta + Rute";
-
-/* Context menu item for downloader. */
-"downloader_download_routing" = "Unduh Rute";
-
-/* Context menu item for downloader. */
-"downloader_delete_routing" = "Hapus Rute";
 
 /* Context menu item for downloader. */
 "downloader_download_map" = "Unduh peta";
 
-"downloader_download_map_no_routing" = "Unduh peta tanpa perutean";
-
-/* Button for routing. */
-"routing_go" = "Mulai!";
-
 /* Item status in downloader. */
 "downloader_retry" = "Ulangi";
-
-/* Item in context menu. */
-"downloader_map_and_routing" = "Peta + Rute";
 
 /* Item in context menu. */
 "downloader_delete_map" = "Hapus Peta";
@@ -668,29 +435,11 @@
 /* Item in context menu. */
 "downloader_update_map" = "Perbarui Peta";
 
-/* Item in context menu. */
-"downloader_update_map_and_routing" = "Perbarui Peta + Rute";
-
-/* Item in context menu. */
-"downloader_map_only" = "Hanya Peta";
-
-/* Toolbar title */
-"toolbar_application_menu" = "Menu aplikasi";
-
 /* Preference text */
 "pref_use_google_play" = "Gunakan Layanan Google Play untuk mendapatkan lokasi Anda saat ini";
 
 /* Text for rating dialog */
 "rating_just_rated" = "Saya baru saja menilai app Anda";
-
-/* Text for rating dialog */
-"rating_user_since" = "Saya pengguna Organic Maps sejak %@";
-
-/* Text for rating dialog */
-"rating_do_like_maps" = "Anda suka Organic Maps?";
-
-/* Text for rating dialog */
-"rating_tap_star" = "Ketuk bintang untuk menilai app kami.";
 
 /* Text for rating dialog */
 "rating_thanks" = "Terima kasih!";
@@ -701,23 +450,8 @@
 /* Text for rating dialog */
 "rating_send_feedback" = "Kirim umpan balik";
 
-/* Text for g+ dialog */
-"rating_google_plus" = "Klik g+ untuk memberi tahu teman-teman tentang aplikasi tersebut.";
-
 /* Text for routing error dialog */
 "routing_download_maps_along" = "Unduh peta bersama rute";
-
-/* Text for routing error dialog */
-"routing_download_map" = "Dapatkan peta";
-
-/* Text for routing error dialog */
-"routing_download_map_and_routing" = "Unduh peta yang diperbarui dan data perutean untuk mendapatkan semua fitur Organic Maps.";
-
-/* Text for routing error dialog */
-"routing_get_routing_data" = "Dapatkan data perutean";
-
-/* Text for routing error dialog */
-"routing_get_additional_data" = "Data tambahan yang diperlukan untuk membuat rute dari lokasi Anda.";
 
 /* Text for routing error dialog */
 "routing_requires_all_map" = "Membuat rute memerlukan semua peta dari lokasi Anda ke tujuan yang diunduh dan diperbarui.";
@@ -725,50 +459,15 @@
 /* Text for routing error dialog */
 "routing_not_enough_space" = "Ruang simpan tidak cukup";
 
-/* Text for routing error dialog */
-"routing_download_more_than_avail" = "Anda harus mengunduh %@ MB, tetapi hanya %@ MB yang tersedia.";
-
-/* Text for routing error dialog */
-"routing_download_roaming" = "Anda akan mengunduh %@ MB menggunakan Data Seluler (dalam Roaming). Hal ini dapat mengakibatkan biaya tambahan, tergantung pada paket data seluler operator.";
-
 /* bookmark button text */
 "bookmark" = "bookmark";
-
-/* map is not downloaded */
-"not_found_map" = "Peta untuk lokasi Anda tidak diunduh";
 
 /* location service disabled */
 "enable_location_services" = "Mohon aktifkan Layanan Lokasi";
 
-/* download map */
-"download_map" = "Unduh peta untuk lokasi Anda";
-
-/* download map on iPhone */
-"download_map_iphone" = "Unduh peta lokasi saat ini pada iPhone Anda";
-
-/* clear pin */
-"nearby" = "Terdekat";
-
-/* clear pin */
-"clear_pin" = "Kosongkan Pin";
-
-/* location is undefined */
-"undefined_location" = "Lokasi saat ini tidak diketahui.";
-
-/* download country of your location */
-"download_country" = "Unduh negara di mana Anda berada saat ini";
-
-/* download failed */
-"download_failed" = "gagal diunduh";
-
-/* get the map */
-"get_the_map" = "Dapatkan peta";
-
 "save" = "Simpan";
 
 "edit_description_hint" = "Your descriptions (text or html)";
-
-"new_group" = "grup baru";
 
 "create" = "buat";
 
@@ -795,30 +494,6 @@
 
 /* pink color */
 "pink" = "Hồng";
-
-/* deep purple color */
-"deep_purple" = "Ungu Gelap";
-
-/* light blue color */
-"light_blue" = "Biru Muda";
-
-/* cyan color */
-"cyan" = "Biru Kehijauan";
-
-/* teal color */
-"teal" = "Biru Gelap";
-
-/* lime color */
-"lime" = "Kuning Gelap";
-
-/* deep orange color */
-"deep_orange" = "Oranye Gelap";
-
-/* gray color */
-"gray" = "Abu-abu";
-
-/* blue gray color */
-"blue_gray" = "Biru Keabu-abuan";
 
 /* Wi-Fi available */
 "WiFi_available" = "Ya";
@@ -848,13 +523,9 @@
 
 "dialog_routing_location_unknown_turn_on" = "TIdak dapat menemukan koordinat GPS saat ini. Aktifkan layanan lokasi untuk mengalkulasi rute.";
 
-"dialog_routing_location_unknown" = "TIdak dapat menemukan koordinat GPS saat ini.";
-
 "dialog_routing_download_files" = "Unduh file yang diperlukan";
 
 "dialog_routing_download_and_update_all" = "Unduh dan perbarui semua informasi peta dan perutean di sepanjang proyeksi jalan untuk mengalkulasi rute.";
-
-"dialog_routing_routes_size" = "File informasi rute";
 
 "dialog_routing_unable_locate_route" = "Tidak dapat menemukan rute";
 
@@ -884,21 +555,11 @@
 
 "dialog_routing_try_again" = "Mohon coba lagi";
 
-"dialog_routing_send_error" = "Laporkan Masalah";
-
-"dialog_routing_if_get_cross_route" = "Apakah Anda ingin membuat rute yang lebih langsung yang meliputi lebih dari satu peta?";
-
-"dialog_routing_cross_route_is_optimal" = "Ada rute yang lebih optimal yang melewati ujung peta ini.";
-
 "not_now" = "Jangan Sekarang";
-
-"dialog_routing_build_route" = "Buat";
 
 "dialog_routing_download_and_build_cross_route" = "Apakah Anda ingin mengunduh peta dan membuat rute yang lebih optimal yang meliputi lebih dari satu peta?";
 
 "dialog_routing_download_cross_route" = "Unduh peta untuk membuat rute yang lebih optimal yang melewati ujung peta ini.";
-
-"dialog_routing_cross_route_always" = "Selalu lewati batas ini";
 
 
 /********** Strings for downloading map from search **********/
@@ -906,8 +567,6 @@
 "search_without_internet_advertisement" = "Untuk mulai mencari dan membuat rute, silakan unduh peta, dan Anda tidak akan membutuhkan koneksi internet lagi.";
 
 "search_select_map" = "Pilih Peta";
-
-"search_select_other_map" = "Pilih Peta Lain";
 
 /* «Show» context menu */
 "show" = "Tampilkan";
@@ -918,17 +577,11 @@
 /* «Rename» context menu */
 "rename" = "Ubah nama";
 
-/* Bottom sheet: expand button (should be short) */
-"bottom_sheet_more" = "Lainnya…";
-
 /* Failed planning route message in navigation view */
 "routing_planning_error" = "Sudah sampai di tujuan";
 
 /* Arrive routing message in navigation view */
 "routing_arrive" = "Kedatangan: %s";
-
-/* Text for routing::RouterResultCode::FileTooOld dialog. */
-"dialog_routing_download_and_update_maps" = "Untuk membuat rute, silakan unduh dan perbarui semua peta sepanjang rute.";
 
 "rate_alert_title" = "Suka aplikasi ini?";
 
@@ -944,19 +597,11 @@
 
 "history" = "Riwayat";
 
-"next_turn_then" = "Lalu";
-
 "closed" = "Tutup";
-
-"back_to" = "Kembali ke %@";
 
 "search_not_found" = "Maaf, saya tidak menemukan apa pun.";
 
 "search_not_found_query" = "Silakan coba kueri lainnya.";
-
-"search_not_found_map" = "Silakan unduh peta yang Anda gunakan dalam pencarian Anda.";
-
-"search_not_found_location" = "Unduh peta dari lokasi Anda saat ini.";
 
 "search_history_title" = "Riwayat Pencarian";
 
@@ -964,23 +609,12 @@
 
 "clear_search" = "Bersihkan riwayat pencarian";
 
-/* Title for settings to enable/disable showcase menu button */
-"showcase_settings_title" = "Tampilkan penawaran";
-
 /* Place Page link to Wikipedia article (if map object has it). */
 "read_in_wikipedia" = "Wikipedia";
 
-"p2p_route_planning" = "Perencana Rute";
-
 "p2p_your_location" = "Lokasi Anda";
 
-"p2p_from" = "Titik keberangkatan";
-
-"p2p_to" = "Titik tujuan";
-
 "p2p_start" = "Mulai";
-
-"p2p_planning" = "Merencanakan…";
 
 "p2p_from_here" = "Dari";
 
@@ -1018,15 +652,9 @@
 
 "editor_correct_mistake" = "Koreksi kesalahan";
 
-"editor_correct_mistake_message" = "Pengeditan salah. Koreksi atau ubah ke mode sederhana.";
-
 "editor_add_select_location" = "Lokasi";
 
 "editor_done_dialog_1" = "Anda telah mengubah peta dunia. Jangan menyembunyikan ini! Katakan kepada teman-teman Anda, dan edit bersama.";
-
-"editor_done_dialog_2" = "ini peningkatan peta kedua Anda. Sekarang Anda di tempat yang ke-%d di daftar editor peta. Katakan kepada teman-teman Anda tentang hal ini.";
-
-"editor_done_dialog_3" = "Anda telah meningkatkan peta, katakan kepada teman-teman Anda tentang hal ini, dan edit peta bersama.";
 
 "share_with_friends" = "Bagikan dengan teman-teman";
 
@@ -1044,20 +672,7 @@
 
 "editor_report_problem_duplicate_place_title" = "Tempat ganda";
 
-"first_launch_congrats_title" = "Organic Maps siap digunakan";
-
-"first_launch_congrats_text" = "Cari dan bernavigasilah ke mana saja di dunia secara offline, bebas biaya.";
-
-"migrate_title" = "Penting!";
-
-/* Android uses image instead of text. */
-"download_all" = "Unduh semua";
-
-"delete_all" = "Hapus semua";
-
 "autodownload" = "Unduhan otomatis";
-
-"disable_autodownload" = "Nonaktifkan unduh otomatis";
 
 /* Place Page opening hours text */
 "closed_now" = "Sekarang Tutup";
@@ -1072,10 +687,6 @@
 "day_off" = "Tutup";
 
 "today" = "Hari ini";
-
-"sunrise_to_sunset" = "Dari matahari terbit sampai matahari terbenam";
-
-"sunset_to_sunrise" = "Dari matahari terbenam sampai matahari terbit";
 
 "add_opening_hours" = "Tambah jam kerja";
 
@@ -1095,45 +706,18 @@
 
 "forgot_password" = "Lupa kata sandi?";
 
-/* Forgot Password dialog title */
-"restore_password" = "Pulihkan kata sandi";
-
-"enter_email_address_to_reset_password" = "Masukkan alamat surek yang Anda gunakan pada saat pendaftaran dan kami akan mengirim tautan untuk memperbarui kata sandi Anda.";
-
-"reset_password" = "Atur ulang kata sandi";
-
-"username" = "Nama pengguna";
-
 "osm_account" = "Akun OSM";
 
 "logout" = "Keluar";
 
-"login_and_edit_map_motivation_message" = "Masuk dan sunting informasi objek pada peta dan kami akan membuatnya tersedia bagi jutaan pengguna lain. Mari kita menjadikan dunia lebih baik bersama-sama.";
-
 /* Information text: "Last upload 11.01.2016" */
 "last_upload" = "Pengunggahan terakhir";
 
-/* Motivates user to login/register, title above login buttons. */
-"you_have_edited_your_first_object" = "Anda menyunting objek pertama Anda!";
-
 "thank_you" = "Terima kasih";
-
-"login_with_google" = "Masuk menggunakan Google";
-
-"login_with_openstreetmap" = "Masuk menggunakan www.openstreetmap.org";
 
 "edit_place" = "Sunting tempat";
 
 "place_name" = "Nama tempat";
-
-/* title above languages list cells in the editor, below editable name text field. */
-"other_languages" = "Bahasa lainnya";
-
-/* small button to open list with names in different languages */
-"show_more" = "Tampilkan lebih banyak";
-
-/* small button to close list with names in different languages */
-"show_less" = "Tampilkan lebih sedikit";
 
 "add_language" = "Tambahkan bahasa";
 
@@ -1164,8 +748,6 @@
 
 "please_note" = "Harap diperhatikan";
 
-"common_no_wifi_dialog" = "Tidak ada koneksi WiFi. Apakah Anda ingin melanjutkan dengan data seluler?";
-
 "downloader_delete_map_dialog" = "Semua perubahan peta akan dihapus bersama dengan peta.";
 
 "downloader_update_maps" = "Perbarui peta";
@@ -1173,10 +755,6 @@
 "downloader_mwm_migration_dialog" = "Untuk membuat rute, Anda perlu memperbarui semua peta dan kemudian merencanakan rute tersebut lagi.";
 
 "downloader_search_field_hint" = "Temukan peta";
-
-"migration_update_all_button" = "Perbarui semua peta";
-
-"migration_delete_all_download_current_button" = "Unduh peta sekarang dan hapus peta lama";
 
 "migration_download_error_dialog" = "Unduh kesalahan";
 
@@ -1186,21 +764,9 @@
 
 "downloader_no_space_message" = "Harap menghapus data yang tidak diperlukan";
 
-"editor_general_auth_error_dialog" = "Kesalahan masuk umum.";
-
 "editor_login_error_dialog" = "Kesalahan masuk.";
 
-"editor_login_failed_dialog" = "Masuk gagal";
-
-"editor_username_error_dialog" = "Nama pengguna tidak benar";
-
-"editor_place_edited_dialog" = "Anda telah mengedit sebuah obyek!";
-
-"editor_login_with_osm" = "Masuk dengan OpenStreetMap";
-
 "editor_profile_changes" = "Perubahan Terverifikasi";
-
-"editor_profile_unsent_changes" = "Tidak terkirim:";
 
 "editor_focus_map_on_location" = "Tarik peta untuk memilih lokasi yang benar dari obyek.";
 
@@ -1222,13 +788,9 @@
 
 "editor_report_problem_other_title" = "Masalah yang berbeda";
 
-"placepage_report_problem_button" = "Laporkan masalah";
-
 "placepage_add_business_button" = "Tambahkan organisasi";
 
 "whatsnew_editor_message_1" = "Tambahkan tempat-tempat baru di peta, dan edit peta-peta yang ada langsung dari aplikasi.";
-
-"whatsnew_editor_message_2" = "* Organic Maps menggunakan data komunitas OpenStreetMap.";
 
 "dialog_incorrect_feature_position" = "Ubah lokasi";
 
@@ -1236,16 +798,10 @@
 
 "login_to_make_edits_visible" = "Masuk agar pengguna lain dapat melihat perubahan yang Anda buat.";
 
-"no_migration_during_navigation" = "Memperbarui tidak diperbolehkan selama navigasi.";
-
 /* Error dialog no space */
 "migration_no_space_message" = "Untuk mengunduh, Anda perlu ruang lebih banyak. Harap menghapus data yang tidak diperlukan.";
 
 "editor_sharing_title" = "Saya meningkatkan peta Organic Maps";
-
-"editor_comment_will_be_sent" = "Kami akan mengirim komen Anda ke pembuat peta.";
-
-"editor_unsupported_category_message" = "Anda telah menambahkan sebuah tempat kategori yang belum kami dukung. Tempat itu akan muncul di peta beberapa saat kemudian.";
 
 /* Downloaded 10 **of** 20 <- it is that "of" */
 "downloader_of" = "%1$d dari %2$d";
@@ -1278,23 +834,9 @@
 
 "editor_operator" = "Pemilik";
 
-"editor_tag_description" = "Masukkan perusahaan, organisasi, atau individu yang bertanggung jawab atas fasilitas tersebut.";
-
-"editor_no_local_edits_title" = "Anda tidak memiliki pengeditan lokal";
-
-"editor_no_local_edits_description" = "Ini menunjukkan jumlah saran perubahan dalam peta yang saat ini hanya dapat diakses di perangkat Anda.";
-
-"editor_send_to_osm" = "Kirim ke OSM";
-
-"editor_remove" = "Hapus";
-
-"downloader_my_maps_title" = "Peta saya";
-
 "downloader_no_downloaded_maps_title" = "Tidak ada peta apa pun yang diunduh";
 
 "downloader_no_downloaded_maps_message" = "Unduh peta untuk menemukan lokasi dan bernavigasi secara offline.";
-
-"downloader_find_place_hint" = "Cari kota atau negara";
 
 /* Error title that appears after certain time without location. */
 "current_location_unknown_title" = "Terus mendeteksi lokasi Anda saat ini?";
@@ -1321,47 +863,13 @@
 /* iOS Dialog for the case when the location permission is not granted */
 "location_services_disabled_3" = "3. Pilih While Using the App";
 
-"placepage_parking_surface" = "Parkir Luar";
-
-"placepage_parking_multistorey" = "Bertingkat";
-
-"placepage_parking_underground" = "Bawah Tanah";
-
-"placepage_parking_rooftop" = "Atap";
-
-"placepage_parking_sheds" = "Gudang";
-
-"placepage_parking_carports" = "Parkir Beratap";
-
-"placepage_parking_boxes" = "Sasana tinju";
-
-"placepage_parking_pay" = "Berbayar";
-
-"placepage_parking_free" = "Gratis";
-
-"placepage_parking_interval" = "Biaya Rutin";
-
-"placepage_entrance_number" = "Nomor";
-
-"placepage_entrance_type" = "Gerbang Masuk";
-
-"placepage_flat" = "persegi";
-
-"placepage_open_24_7" = "24 jam sehari, 7 hari seminggu";
-
 "meter" = "m";
 
 "kilometer" = "km";
 
-"kilometers_per_hour" = "km/j";
-
 "mile" = "mil";
 
 "foot" = "kaki";
-
-"miles_per_hour" = "mpj";
-
-"day" = "h";
 
 "hour" = "j";
 
@@ -1381,10 +889,6 @@
 
 "placepage_bookmark_name_hint" = "Nama Bookmark";
 
-"placepage_personal_notes_hint" = "Catatan pribadi";
-
-"placepage_delete_bookmark_button" = "Hapus Bookmark";
-
 "editor_edits_sent_message" = "Saran perubahan Anda telah dikirim";
 
 "editor_comment_hint" = "Komentar…";
@@ -1397,8 +901,6 @@
 
 "editor_remove_place_button" = "Hapus";
 
-"editor_status_sending" = "Mengirim…";
-
 "editor_place_doesnt_exist" = "Tempat tidak ada";
 
 "text_more_button" = "…selebihnya";
@@ -1410,11 +912,7 @@
 
 "error_enter_correct_email" = "Masukkan surel valid";
 
-"error_enter_correct" = "Masukkan nilai valid";
-
 "refresh" = "Memperbarui";
-
-"last_update" = "Pembaruan terakhir: %s";
 
 "placepage_add_place_button" = "Tambahkan tempat ke peta";
 
@@ -1426,24 +924,6 @@
 
 "editor_share_to_all_dialog_message_2" = "Kami akan memeriksa perubahan tersebut. Jika kami memiliki pertanyaan maka kami akan menghubungi Anda melalui surel.";
 
-"navigation_overview_button" = "ikhtisar";
-
-"navigation_stop_button" = "berhenti";
-
-/* Text on an empty bookmark page */
-"bookmarks_empty_title" = "Simpan Penanda";
-
-"bookmarks_empty_message_1" = "Ketuk pada ★ untuk menyimpan tempat-tempat favorit untuk akses cepat.";
-
-"bookmarks_empty_message_2" = "Impor penanda dari email dan web.";
-
-"bookmarks_empty_message_3" = "check-out: %s";
-
-/* Name of the group for booked hotels */
-"bookmarks_group_name" = "Hotel yang dipesan";
-
-"place_page_button_read_descriprion" = "Baca";
-
 /* iOS dialog for the case when recent track recording is on and the app comes back from background */
 "recent_track_background_dialog_title" = "Nonaktifkan rekaman dari rute yang baru Anda lalui?";
 
@@ -1451,8 +931,6 @@
 
 /* For sharing via SMS and so on */
 "sharing_call_action_look" = "Lihat";
-
-"continue_recent_track_background_button" = "Teruskan";
 
 "recent_track_background_dialog_message" = "Organic Maps menggunakan geoposisi di latar belakang untuk merekam rute yang baru Anda lalui.";
 
@@ -1468,33 +946,13 @@
 /* About short text (below logo) */
 "about_description" = "Organic Maps adalah aplikasi offline yang sangat berguna untuk bepergian. Organic Maps didasarkan pada data OpenStreetMap dan memungkinkan kita untuk mengeditnya.";
 
-/* Text in menu */
-"blog" = "Blog";
-
 "general_settings" = "Setelan umum";
-
-"date" = "Tanggal %d";
-
-/* "Report a bug" -> "Generaal Feedback" -> "Something is not working" */
-"something_is_not_working" = "Ada yang tidak berfungsi";
 
 /* For the first routing */
 "accept" = "Terima";
 
-"accept_and_continue" = "Accept and continue";
-
 /* For the first routing */
 "decline" = "Tolak";
-
-"install_app" = "Pasang";
-
-"search_no_results_title" = "Tidak Ada Hasil";
-
-"search_no_results_message" = "Cobalah dengan istilah pencarian yang lebih umum, perkecil atau atur ulang filter.";
-
-"search_no_results_expand_area_button" = "Perkecil";
-
-"search_no_results_reset_button" = "Atur Ulang Filter";
 
 /* noun */
 "search_in_table" = "Daftar";
@@ -1517,8 +975,6 @@
 
 "traffic_update_maps_text" = "Untuk memperlihatkan data lalu lintas, peta harus diperbarui.";
 
-"traffic_outdated" = "Data lalu lintas belum diperbarui.";
-
 "big_font" = "Perbesar ukuran huruf pada peta";
 
 "traffic_update_app" = "Perbarui Organic Maps";
@@ -1529,17 +985,7 @@
 /* "traffic" as in "road congestion" */
 "traffic_data_unavailable" = "Data lalu lintas tidak tersedia";
 
-/* "Translation is no needed, because it's a company name" */
-"uber" = "Uber";
-
-/* Simplified colour scheme for traffic information, fewer colours are used to display traffic jams on the map. The string should be kept as short as possible */
-"pref_traffic_simplified_colors_title" = "Warna lalu lintas sederhana";
-
 "enable_logging" = "Aktifkan pencatatan";
-
-"offline_place_page_more_information" = "Sambungkan ke internet untuk mendapatkan informasi selengkapnya tentang tempat ini.";
-
-"failed_load_information" = "Gagal memuat informasi.";
 
 /* Settings: "Send general feedback" button */
 "feedback_general" = "Umpan Balik Umum";
@@ -1556,8 +1002,6 @@
 
 "whatsnew_transliteration_title" = "Transliterasi ke dalam bahasa Latin";
 
-"yandex_taxi_title" = "Yandex.Taxi";
-
 "learn_more" = "Pelajari selengkapnya";
 
 "core_exit" = "Keluar";
@@ -1568,75 +1012,19 @@
 
 "button_exit" = "Keluar";
 
-"settings_device_memory" = "Memori perangkat";
-
-"settings_card_memory" = "Memori kartu";
-
-"settings_storage_available" = "%s tersedia";
-
-"toast_location_permission_denied" = "Izin lokasi aplikasi ditolak";
-
-"button_use" = "Gunakan";
-
 "planning_route_manage_route" = "Kelola rute";
 
 "button_plan" = "Rencana";
-
-"button_add" = "Tambah";
 
 "placepage_remove_stop" = "Hapus";
 
 "planning_route_remove_title" = "Seret ke sini untuk menghapus";
 
-"dialog_change_start_point_message" = "Ganti titik awal ke lokasi saat ini?";
-
-"button_replace" = "Ganti";
-
 "placepage_add_stop" = "Tambah perhentian";
-
-/* Only ru/en are needed */
-"subtitle_rent" = "Rent";
-
-/* Only ru/en are needed */
-"rub_month" = "RUB/month";
-
-/* Only ru/en are needed */
-"room" = "%s-room apt.";
-
-/* Only ru/en are needed */
-"real_estate" = "Real estate";
-
-"add_my_position" = "Tambahkan posisi saya";
-
-"choose_start_point" = "Pilih titik awal";
-
-"choose_destination" = "Pilih destinasi";
 
 "preloader_viator_button" = "Pelajari selengkapnya";
 
-"start_from_my_position" = "Mulai dari";
-
-"profile_authorization_title" = "Masuk dengan";
-
-"profile_authorization_message" = "Masuk dengan mudah tanpa kredensial dan kata sandi dalam beberapa detik";
-
 "profile_authorization_error" = "Ah, tadi ada kesalahan. Coba masuk kembali.";
-
-"service" = "Layanan";
-
-"atmosphere" = "Suasana";
-
-"value_for_money" = "Kepantasan harga";
-
-"experience" = "Pengalaman";
-
-"assortment" = "Lain-Lain";
-
-"expertise" = "Keahlian";
-
-"equipment" = "Perlengkapan";
-
-"quality" = "Mutu";
 
 "dialog_error_storage_title" = "Masalah akses penyimpanan";
 
@@ -1644,17 +1032,7 @@
 
 "setting_emulate_bad_storage" = "Emulasi penyimpanan yang buruk";
 
-"directions_finish" = "Destinasi";
-
-"directions_on_foot" = "Berjalan %s";
-
 "core_entrance" = "Tempat masuk";
-
-"coffee" = "Kopi";
-
-"cleanliness" = "Kebersihan";
-
-"crowdedness" = "Keramaian";
 
 "error_enter_correct_name" = "Harap masukkan nama yang benar";
 
@@ -1673,11 +1051,9 @@
 
 "downloader_percent" = "%s (%s dari %s)";
 
-"downloader_process" = "Mengunduh %s...";
+"downloader_process" = "Mengunduh %s…";
 
-"downloader_applying" = "Menerapkan %s...";
-
-"dialog_message_transit_not_found_connection" = "Rencanakan rute dalam satu jaringan transit";
+"downloader_applying" = "Menerapkan %s…";
 
 "bookmarks_error_message_share_general" = "Tidak dapat berbagi karena kesalahan aplikasi";
 
@@ -1695,17 +1071,7 @@
 
 "bookmarks_error_message_list_name_already_taken" = "Silakan pilih nama lain";
 
-"bookmarks_error_title_list_name_too_long" = "Nama ini terlalu panjang";
-
-"bookmarks_error_message_list_name_too_long" = "Silakan pilih nama lain";
-
-"please_wait" = "Mohon tunggu...";
-
-"phone_number" = "Nomor telepon";
-
-"notification_unsent_reviews_title" = "Anda memiliki beberapa ulasan yang tidak terkirim";
-
-"notification_unsent_reviews_message" = "Harap masuk untuk berbagi ulasan dengan wisatawan lain";
+"please_wait" = "Mohon tunggu…";
 
 "profile" = "Profil OpenStreetMap";
 
@@ -1719,49 +1085,13 @@
 
 "bookmarks_convert_error_message" = "Beberapa file tidak dikonversi.";
 
-"converting" = "Mengkonversi...";
-
-"wn_reinvented_bookmarks_title" = "Kami menemukan kembali bookmark!";
-
-"wn_reinvented_bookmarks_message" = "Anda dapat mencadangkan bookmark, membuat daftar... Sungguh menakjubkan...";
-
-"bookmarks_restore" = "Kembalikan bookmark";
-
-"bookmarks_restore_process" = "Memulihkan...";
-
 "bookmarks_restore_title" = "Kembalikan versi ini?";
 
-"bookmarks_restore_message" = "Bookmark Anda akan memulihkan dari %s (%s)";
-
-"bookmarks_restore_empty_title" = "Anda tidak memiliki cadangan";
-
-"bookmarks_restore_empty_message" = "Server tidak menemukan cadangan yang dibuat sebelumnya";
-
 "common_check_internet_connection_dialog_title" = "Tidak ada koneksi internet";
-
-"error_server_title" = "Server error";
-
-"error_server_message" = "Terjadi kesalahan pada server, coba lagi nanti";
 
 "error_system_message" = "Terjadi kesalahan yang tidak diketahui";
 
 "restore" = "Mengembalikan";
-
-"bookmarks_page_downloaded" = "Diunduh";
-
-"bookmarks_page_my" = "Milik saya";
-
-"routes_and_bookmarks" = "Rute dan bookmark";
-
-"bookmarks_webview_success_toast" = "Bookmark berhasil diunduh";
-
-"cached_bookmarks_placeholder_title" = "Unduh tempat baru";
-
-"cached_bookmarks_placeholder_subtitle" = "Tekan tombol untuk mengunduh ribuan tempat dan rute menarik yang dibuat oleh pengguna Organic Maps. Anda akan memerlukan koneksi internet.";
-
-"downloader_download_routers" = "Unduh bookmark";
-
-"bookmarks_groups_cached" = "Daftar yang telah diunduh.";
 
 "subtittle_opt_out" = "Pengaturan treking";
 
@@ -1769,29 +1099,15 @@
 
 "crash_reports_description" = "Kami dapat menggunakan data Anda untuk meningkatkan pengalaman Organic Maps. Perubahan akan berlaku setelah Anda memulai ulang aplikasi.";
 
-"opt_out_help_ios_1" = "Perangkat seluler Anda mungkin menyediakan pengaturan \"\"Batasi Treking Iklan\"\" atau \"\"Keluar dari iklan berbasis ketertarikan\"\".";
-
-"opt_out_help_ios_2" = "iOS 9 atau Lebih Tinggi";
-
-"opt_out_help_ios_3" = "Ke Pengaturan → Privasi → Iklan → Aktifkan pengaturan \"\"Batasi Treking Iklan\"\"";
-
-"opt_out_help_android" = "Perangkat seluler Anda mungkin menyediakan pengaturan \"\"Batasi treking iklan\"\" atau \"\"Keluar dari iklan berbasis ketertarikan\"\".\n\nUntuk Android dan Google Play Services versi 4.0 dan ke atas:\nPengaturan → Google → Iklan → Keluar dari Personalisasi Iklan\nor\nPengaturan → Google → Akun Google → Informasi personal & privasi → Pengaturan Iklan → Personalisasi Iklan";
-
 "privacy_policy" = "Kebijakan privasi";
 
 "terms_of_use" = "Ketentuan penggunaan";
-
-"backup_notification_failed" = "Mencadangkan bookmark Anda telah dihentikan. Masuk untuk kembali mengaktifkannya.";
 
 "button_layer_traffic" = "Lalu lintas";
 
 "button_layer_subway" = "Kereta bawah tanah";
 
 "layers_title" = "Lapisan peta";
-
-"layers_message" = "Gunakan lapisan peta untuk menampilkan lalu lintas, peta kereta bawah tanah, dan informasi berguna lainnya";
-
-"button_layer_got_it" = "Mengerti";
 
 "subway_data_unavailable" = "Peta bawah tanah tidak tersedia";
 
@@ -1803,39 +1119,13 @@
 
 "title_error_downloading_bookmarks" = "Terjadi kesalahan";
 
-"subtitle_error_downloading_bookmarks" = "Bookmark tidak terunduh";
-
-"error_already_downloaded" = "Daftar ini sudah diunduh";
-
 "popular_place" = "Popular";
-
-"download_routes" = "Download routes";
-
-"bookmarks_downloaded_title" = "Bookmarks have been downloaded successfully";
-
-"bookmarks_downloaded_subtitle" = "Press ‘View on map’ to explore new places from the list";
-
-"why_support" = "Kenapa dukungan Organic Maps?";
-
-"why_support_item1" = "We respect your privacy: there are zero trackers in the app, and we are open source";
-
-"why_support_item2" = "Anda membantu kami meningkatkan Organic Maps";
-
-"why_support_item3" = "Anda membantu kami meningkatkan peta terbuka OpenStreetMap.org";
-
-"channels_map_update" = "Pembaruan peta";
-
-"server_unavailable_title" = "Server tidak tersedia";
-
-"sharing_options" = "Opsi berbagi";
 
 "export_file" = "File ekspor";
 
 "list_settings" = "Pengaturan Daftar";
 
 "delete_list" = "Hapus Daftar";
-
-"hide_from_map" = "Sembunyikan dari peta";
 
 "public_access" = "Akses umum";
 
@@ -1845,40 +1135,11 @@
 
 "bookmark_category_description_hint" = "Ketikkan deskripsi (teks atau html)";
 
-/* FIXME */
-"bookmarks_public_access" = "bookmarks_public_access";
-
-/* FIXME */
-"bookmarks_link_access" = "bookmarks_link_access";
-
-/* FIXME */
-"bookmarks_private_access" = "bookmarks_private_access";
-
 "not_shared" = "Pribadi";
-
-"direct_link_progress_text" = "Mengunggah file Anda…";
-
-"direct_link_success" = "Tautan telah dibuat";
-
-"send_a_link_btn" = "Kirim tautan ke saya";
-
-"upload_error_toast" = "Kesalahan terjadi saat mengunggah file Anda";
 
 "tags_loading_error_subtitle" = "Kesalahan terjadi saat memuat tag, silakan coba lagi";
 
-"unable_upload_errorr_title" = "Gagal mengunggah file";
-
-"unable_upload_error_subtitle_edited" = "File telah diedit melalui aplikasi web";
-
-"unable_upload_error_subtitle_broken" = "File rusak dan tidak dapat diunggah. Silakan unggah file lain.";
-
-"contact" = "Kontak";
-
-"download_button" = "Unduh";
-
 "speedcams_alert_title" = "Kamera cepat";
-
-"speedcams_alert_subtitle" = "Peringatan tentang batas kecepatan";
 
 "speedcam_option_auto" = "Auto";
 
@@ -1886,18 +1147,10 @@
 
 "speedcam_option_never" = "Tidak pernah";
 
-"bookmark_description_title" = "Deskripsi Bookmark";
-
 "place_description_title" = "Deskripsi Tempat";
 
 /* this text will be shown in application notification preferences opposite checkbox which enable/disable downloader notifications. Devices on Android 8+ are affected. */
 "notification_channel_downloader" = "Pengunduh peta";
-
-"share_bookmarks_email_body_link" = "Halo!\n\nBerikut tautan untuk mengunduh bookmark Anda: %s. Buka daftar melalui Organic Maps dan nikmati perjalanan Anda!\n\nDapatkan aplikasi: https://omaps.app/get?kmz";
-
-"warning_speedcams_title" = "Navigator akan memberi Anda peringatan tentang adanya kamera saat Anda melebihi batas kecepatan %d km/jam";
-
-"warning_speedcams_subtitle" = "Harap perhatikan aturan berkendara di negara tempat Anda bepergian.";
 
 "speedcams_notice_message" = "Auto - Peringatkan tentang kamera kecepatan saat terdapat risiko melebihi batas kecepatan\nSelalu - Selalu peringatkan tentang kamera kecepatan\nTidak pernah - Jangan pernah peringatkan tentang kamera kecepatan";
 
@@ -1913,23 +1166,7 @@
 
 "enable_logging_warning_message" = "Opsi ini mengaktifkan pencatatan untuk tujuan diagnostik. Bisa amat membantu bagi staf dukungan kami yang memecahkan masalah dalam aplikasi. Aktifkan opsi ini hanya saat diminta oleh dukungan Organic Maps.";
 
-"html_error_upload_message_try_again" = "Periksa pengaturan jaringan Anda dan coba lagi";
-
-"html_error_upload_title_try_again" = "Tidak ada koneksi internet";
-
-"notification_leave_review_v2_android_short_title" = "Ulas dan bantu traveler!";
-
-"megafon" = "Say goodbye to roaming!";
-
-"notifications_illegal_alert_disable_button" = "Nonaktifkan pemberitahuan";
-
 "access_rules_author_only" = "Pengeditan online";
-
-"privacy_settings_menu" = "Pengaturan privasi";
-
-"unable_upadate_error_title" = "Pembaruan file gagal";
-
-"unable_upadate_error_message" = "Beberapa kesalahan terjadi saat memperbarui. Periksa perubahan dan coba lagi";
 
 "driving_options_title" = "Pilihan berkendara";
 
@@ -1951,94 +1188,19 @@
 
 "change_driving_options_btn" = "Opsi perutean diaktifkan";
 
-"toll_road" = "Jalan tol";
-
-"unpaved_road" = "Jalan tanah";
-
-"ferry_crossing" = "Penyeberangan kapal feri";
-
-"operated_by" = "Dioperasikan oleh \"%s\"";
-
 "avoid_toll_roads_placepage" = "Hindari jalan tol";
 
 "avoid_unpaved_roads_placepage" = "Hindari jalan tanah";
 
 "avoid_ferry_crossing_placepage" = "Hindari penyeberangan kapal feri";
 
-"type.cuisine.uzbek" = "Masakan Uzbek";
-
-"trip_start" = "Ayo";
-
-"pick_destination" = "Tujuan";
-
-"follow_my_position" = "Pusatkan ulang";
-
-"search_results" = "Hasil pencarian";
-
-"then_turn" = "Lalu";
-
-"redirect_route_alert" = "Anda ingin membuat ulang rute?";
-
-"redirect_route_yes" = "Ya";
-
-"redirect_route_no" = "Tidak";
-
-"trip_finished" = "Anda telah tiba!";
-
-"keyboard_availability_alert" = "Papan ketik tidak tersedia saat berkendara";
-
-"dialog_routing_change_start_carplay" = "Tidak dapat membuat rute dari lokasi saat ini";
-
-"dialog_routing_change_end_carplay" = "Tidak dapat membuat rute ke tujuan Anda. Pilih titik lainnya";
-
-"dialog_routing_check_gps_carplay" = "Tidak ada sinyal GPS. Harap pindah ke area terbuka";
-
-"dialog_routing_unable_locate_route_carplay" = "Tidak dapat membuat rute. Harap tentukan titik rute lainnya";
-
-"dialog_routing_download_files_carplay" = "Untuk membuat rute, unduh peta baru di perangkat anda";
-
-"dialog_routing_system_error_carplay" = "Terjadi kesalahan. Harap mulai ulang aplikasi";
-
-"dialog_routing_rebuild_from_current_location_carplay" = "Rute akan dibuat ulang dari lokasi saat ini";
-
-"dialog_routing_rebuild_for_vehicle_carplay" = "Rute akan diubah untuk mobil";
-
 "ok" = "Oke";
-
-"avoid_unpaved_carplay_1" = "Jalan aspal";
-
-"avoid_unpaved_carplay_2" = "Hindari tanah";
-
-"avoid_ferry_carplay_1" = "Tanpa feri";
-
-"avoid_ferry_carplay_2" = "Hindari feri";
-
-"avoid_tolls_carplay_1" = "Tanpa tol";
-
-"avoid_tolls_carplay_2" = "Hindari tol";
-
-"speedcams_alert_title_carplay_1" = "Speedcam";
-
-"speedcams_alert_title_carplay_2" = "Info kecepatan";
-
-"download_map_carplay" = "Silakan unduh peta di apl Organic Maps pada perangkat Anda";
-
-"carplay_roundabout_exit" = "Jalan keluar ke %s";
 
 /* max. 10 symbols, both iOS and Android */
 "sort" = "Urutkan…";
 
 /* Android, title, max 20-22 symbols */
 "sort_bookmarks" = "Urutkan bookmark";
-
-/* iOS */
-"sort_default" = "Urutkan standar";
-
-"sort_type" = "Urutkan per tipe";
-
-"sort_distance" = "Urutkan per jarak";
-
-"sort_date" = "Urutkan per tanggal";
 
 /* Android */
 "by_default" = "Standar";
@@ -2052,63 +1214,7 @@
 /* Android */
 "by_date" = "Per tanggal";
 
-"week_ago_sorttype" = "Seminggu yang lalu";
-
-"month_ago_sorttype" = "Sebulan yang lalu";
-
-"moremonth_ago_sorttype" = "Lebih dari sebulan yang lalu";
-
-"moreyear_ago_sorttype" = "Lebih dari setahun yang lalu";
-
-"near_me_sorttype" = "Dekat dengan saya";
-
-"others_sorttype" = "Lainnya";
-
-"food_places" = "Makanan";
-
-"tourist_places" = "Tempat Rekreasi";
-
-"museums" = "Museum";
-
-"parks" = "Taman";
-
-"swim_places" = "Kolam renang";
-
-"mountains" = "Pegunungan";
-
-"animals" = "Kebun binatang";
-
-"hotels" = "Hotel";
-
-"buildings" = "Gedung";
-
-"money" = "Uang";
-
-"shops" = "Pusat perbelanjaan";
-
-"parkings" = "Parkir";
-
-"fuel_places" = "SPBU";
-
-"water" = "Air";
-
-"medicine" = "Obat";
-
 "search_in_the_list" = "Cari dalam daftar";
-
-"view_on_map_bookmarks" = "Di peta";
-
-"more_bookmarks" = "Lainnya…";
-
-"no_items_found" = "Item tidak ditemukan";
-
-/* Android, max 18 symbols */
-"bookmarks_edit_list" = "Ubah daftar";
-
-/* Android, max 18 symbols */
-"bookmarks_delete_list" = "Hapus daftar";
-
-"religious_places" = "Tempat ibadah";
 
 "select_list" = "Pilih daftar";
 
@@ -2118,26 +1224,13 @@
 
 "dialog_pedestrian_route_is_long_message" = "Silakan pilih titik awal atau akhir yang lebih dekat ke stasiun kereta bawah tanah";
 
-/* Failed planning SUBWAY route message in navigation view */
-"routing_planning_error_subway_special" = "Perencanaan jalur kereta bawah tanah gagal";
-
 "button_layer_isolines" = "Isometrik";
-
-"tips_map_layers_title_countour" = "Yang baru di Organic Maps: lapisan topografi offline!";
-
-"tips_map_layers_message_countour" = "Rencanakan dan nikmati perjalanan alam Anda dan pastikan Anda tahu segalanya tentang daerah tersebut";
 
 "isolines_activation_error_dialog" = "Untuk mengaktifkan dan menggunakan lapisan topografi, silakan perbarui atau unduh peta area";
 
 "isolines_location_error_dialog" = "Lapisan topografi belum tersedia untuk wilayah ini";
 
 "elevation_profile_diff_level" = "Tingkat kesulitan";
-
-"elevation_profile_diff_level_easy" = "Mudah";
-
-"elevation_profile_diff_level_moderate" = "Sedang";
-
-"elevation_profile_diff_level_hard" = "Sulit";
 
 "elevation_profile_ascent" = "Menanjak";
 
@@ -2147,25 +1240,13 @@
 
 "elevation_profile_maxaltitude" = "Ketinggian Maks.";
 
-"elevation_profile_m" = "m";
-
 "elevation_profile_difficulty" = "Kesulitan";
 
 "elevation_profile_distance" = "Jarak:";
 
-"elevation_profile_km" = "km";
-
 "elevation_profile_time" = "Waktu:";
 
-"elevation_profile_hours" = "j.";
-
-"elevation_profile_minutes" = "mnt";
-
 "isolines_toast_zooms_1_10" = "Perbesar untuk menjelajahi garis kontur";
-
-"downloader_updating_ios" = "Memperbarui";
-
-"downloader_loading_ios" = "Mengunduh";
 
 "key_information_title" = "Informasi kunci";
 

--- a/iphone/Maps/LocalizedStrings/id.lproj/Localizable.stringsdict
+++ b/iphone/Maps/LocalizedStrings/id.lproj/Localizable.stringsdict
@@ -9,21 +9,6 @@
 
 <!-- ********** Strings for downloading map from search **********/ -->
 
-  <key>bookmarks_places</key>
-  <dict>
-    <key>NSStringLocalizedFormatKey</key>
-    <string>%#@value@</string>
-    <key>value</key>
-    <dict>
-      <key>NSStringFormatSpecTypeKey</key>
-      <string>NSStringPluralRuleType</string>
-      <key>NSStringFormatValueTypeKey</key>
-      <string>d</string>
-      <key>other</key>
-      <string>%d markah</string>
-    </dict>
-  </dict>
-
   <key>bookmarks_detect_message</key>
   <dict>
     <key>NSStringLocalizedFormatKey</key>
@@ -38,21 +23,6 @@
       <string>%d file ditemukan. Anda akan melihatnya setelah mengonversi.</string>
       <key>other</key>
       <string>%d file telah ditemukan. Anda akan melihatnya setelah konversi.</string>
-    </dict>
-  </dict>
-
-  <key>bookmarks_objects</key>
-  <dict>
-    <key>NSStringLocalizedFormatKey</key>
-    <string>%#@value@</string>
-    <key>value</key>
-    <dict>
-      <key>NSStringFormatSpecTypeKey</key>
-      <string>NSStringPluralRuleType</string>
-      <key>NSStringFormatValueTypeKey</key>
-      <string>d</string>
-      <key>other</key>
-      <string>obyek %s</string>
     </dict>
   </dict>
 

--- a/iphone/Maps/LocalizedStrings/it.lproj/Localizable.strings
+++ b/iphone/Maps/LocalizedStrings/it.lproj/Localizable.strings
@@ -18,9 +18,6 @@
 /* Button which deletes downloaded country */
 "delete" = "Cancella";
 
-/* Button "do not interrupt download" if user touched actively downloading country */
-"do_nothing" = "Continua";
-
 "download_maps" = "Scarica le mappe";
 
 /* Settings/Downloader - info for country when download fails */
@@ -28,9 +25,6 @@
 
 /* Settings/Downloader - info for country which started downloading */
 "downloading" = "In fase di download…";
-
-/* Settings/Downloader - size string, only strings different from English should be translated */
-"kb" = "kB";
 
 /* Choose measurement on first launch alert - choose metric system button */
 "kilometres" = "Chilometri";
@@ -55,17 +49,11 @@
 /* Update maps later/Buy pro version later button text */
 "later" = "Più tardi";
 
-/* Don't show some dialog any more */
-"never" = "Mai";
-
 /* View and button titles for accessibility */
 "search" = "Cerca";
 
 /* Search box placeholder text */
 "search_map" = "Ricerca Mappa";
-
-/* Settings/Downloader - info for not downloaded country */
-"touch_to_download" = "Tocca per scaricare";
 
 /* Settings/Downloader - 3G download warning dialog confirm button */
 "use_cellular_data" = "Sì";
@@ -73,20 +61,11 @@
 /* Location services are disabled by user alert - message */
 "location_is_disabled_long_text" = "Attualmente hai disattivati tutti i servizi di locazione per questo dispositivo o applicazione. Cortesemente abilitali nelle Impostazioni.";
 
-/* Location Services are not available on the device alert - message */
-"device_doesnot_support_location_services" = "Il tuo dispositivo non supporta i servizi di localizzazione";
-
 /* View and button titles for accessibility */
 "zoom_to_country" = "Mostra sulla mappa";
 
-/* Button text for the button at the center of the screen when the country is not downloaded */
-"country_status_download" = "Scarica Map\n(^ ^)";
-
 /* Button text for the button at the center of the screen when the country is not downloaded and the size should not be shown */
 "country_status_download_without_size" = "Scarica Map";
-
-/* Button text for the button at the center of the screen when the country is not downloaded */
-"country_status_download_without_routing" = "Scarica mappa\nsenza percorsi (^ ^)";
 
 /* Message to display at the center of the screen when the country download has failed */
 "country_status_download_failed" = "Lo scaricamento è fallito";
@@ -96,19 +75,13 @@
 
 "about_menu_title" = "Informazioni su Organic Maps";
 
-"downloaded_touch_to_delete" = "Scaricato (%@), tocca per cancellare";
-
 "connection_settings" = "Impostazioni di connessione";
-
-"download_mb_or_kb" = "Scarica %@";
 
 "close" = "Chiudi";
 
 "unsupported_phone" = "È necessaria una accelerazione hardware OpenGL. Purtroppo, il tuo dispositivo non è supportato.";
 
 "download" = "Carica";
-
-"external_storage_is_not_available" = "La scheda/USB/di memoria SD con le mappe scaricate non è disponibile";
 
 "disconnect_usb_cable" = "Coortesemente scollega il cavo USB oppure inserisci la scheda di memoria per l'usco dell'app";
 
@@ -117,8 +90,6 @@
 "not_enough_memory" = "Memoria insufficiente per lanciare l'app";
 
 "download_resources" = "Prima di iniziare è necessario scaricare la mappa generale del mondo sul tuo dispositivo.\nLa dimensione del download è di %@.";
-
-"getting_position" = "Ottieni la posizione corrente";
 
 "download_resources_continue" = "Vai alla mappa";
 
@@ -140,23 +111,14 @@
 /* Add New Bookmark Set dialog title */
 "add_new_set" = "Aggiungi un nuovo Set";
 
-/* Place Page - Add To Bookmarks button */
-"add_to_bookmarks" = "Aggiungi al Segnalibri";
-
 /* Bookmark Color dialog title */
 "bookmark_color" = "Colore del Segnalibro";
 
 /* Add Bookmark Set dialog - hint when set name is empty */
 "bookmark_set_name" = "Seleziona un nome del segnalibro";
 
-/* Bookmark Sets dialog title */
-"bookmark_sets" = "Seleziona un segnalibro";
-
 /* Bookmarks - dialog title */
 "bookmarks" = "Segnalibri";
-
-/* Add bookmark dialog - bookmark color */
-"color" = "Colore";
 
 /* Default bookmarks set name */
 "core_my_places" = "I miei luoghi";
@@ -167,14 +129,8 @@
 /* Editor title above street and house number */
 "address" = "Indirizzo";
 
-/* Place Page - Remove Pin button */
-"remove_pin" = "Rimuovi il Pin";
-
 /* Add bookmark dialog - bookmark set, Bookmarks dialog - Bookmark set cell */
 "set" = "Seleziona";
-
-/* Text hint in Bookmarks dialog when no any bookmarks are added */
-"bookmarks_usage_hint" = "Non hai ancora nessun segnalibro.\nTocca qualsiasi luogo sulla cartina per aggiungere un segnalibro.\nPossono essere anche importati Preferiti da altre fonti e visualizzate nell'app Organic Maps. Apri il file KML/KMZ con i pin salvati da una casella di posta, Dropbox o un link web.";
 
 /* Settings button in system menu */
 "settings" = "Impostazioni";
@@ -191,26 +147,11 @@
 /* Ask to wait user several minutes (some long process in modal dialog). */
 "wait_several_minutes" = "Questo può richiedere diversi minuti.\ncortesemente attendi…";
 
-/* Show bookmarks from this category on a map or not */
-"visible" = "Visibile";
-
-/* Toast which is displayed when GPS has been deactivated */
-"gps_is_disabled_long_text" = "Il GPS è disabilitato. Cortesemente abilitalo nelle Impostazioni.";
-
 /* Measurement units title in settings activity */
 "measurement_units" = "Unità di misura";
 
 /* Detailed description of Measurement Units settings button */
 "measurement_units_summary" = "Scegli tra miglia e chilometri";
-
-/* Do search in all sources */
-"search_mode_all" = "Ovunque";
-
-/* Do search near my position only */
-"search_mode_nearme" = "Vicino a me";
-
-/* Do search in current viewport only */
-"search_mode_viewport" = "Nella schermata";
 
 /* Search category for cafes, bars, restaurants */
 "eat" = "Dove mangiare";
@@ -266,14 +207,8 @@
 /* Search category */
 "police" = "Polizia";
 
-/* String in search result list, when nothing found */
-"no_search_results_found" = "Nessun risultato trovato";
-
 /* Notes field in Bookmarks view */
 "description" = "Note";
-
-/* Button text */
-"share_by_email" = "Condividi via email";
 
 /* Email Subject when sharing bookmarks category */
 "share_bookmarks_email_subject" = "Il segnalibri Organic Maps è stato condiviso con te";
@@ -295,26 +230,11 @@
 /* Warning message when doing search around current position */
 "unknown_current_position" = "La tua posizione non è stata ancora stabilita";
 
-/* Warning message when location country isn't downloaded during search (see also download_location_map_proposal). */
-"download_location_country" = "Scarica il paese della tua posizione attuale (%@)";
-
-/* Warning message when viewport country isn't downloaded during search */
-"download_viewport_country_to_search" = "Scarica il paese che stai cercando (%@)";
-
 /* Alert message that we can't run Map Storage settings due to some reasons. */
 "cant_change_this_setting" = "Siamo spiacenti, ma le impostazioni di archiviazione delle mappe sono disabilitate.";
 
 /* Alert message that downloading is in progress. */
 "downloading_is_active" = "Il download della nazione è in corso.";
-
-/* Message that will be shown in alert view, when we ask user to leave review on App Store */
-"appStore_message" = "Confidiamo nel fatto che sia piacevole utilizzare Organic Maps! In caso positivo, ti preghiamo di valutare o recensire l'app all'interno dell'app store. Ti porterà via meno di un minuto e la cosa ci aiuterebbe tantissimo. Grazie per il tuo sostegno!";
-
-/* No, thanks */
-"no_thanks" = "No, grazie";
-
-/* Share one specific bookmark using SMS, %1$@ contains om:// and %2$@ https://omaps.app link. @NOTE non-ascii symbols in the link will result in max 70 characters SMS instead of 140. */
-"bookmark_share_sms" = "Vedi pin sulla mappa. Apri %1$@ o %2$@";
 
 /* Share my position using SMS, %1$@ contains om:// and %2$@ https://omaps.app link WITHOUT NAME. @NOTE non-ascii symbols in the link will result in max 70 characters SMS instead of 140. */
 "my_position_share_sms" = "Vedi dove sono ora. Apri %1$@ o %2$@";
@@ -328,23 +248,11 @@
 /* Share my position using EMail, %1$@ is om:// and %2$@ is https://omaps.app link WITHOUT NAME */
 "my_position_share_email" = "Ciao,\n\nSono qui adesso: %1$@. Clicca su questo link %2$@ oppure su questo %3$@ per vedere il posto sulla mappa.\n\nGrazie.";
 
-/* Android share by Message/SMS button text (including SMS) */
-"share_by_message" = "Condividi con un messaggio";
-
 /* Share button text which opens menu with more buttons, like Message, EMail, Facebook etc. */
 "share" = "Condividi";
 
-/* iOS share by Message button text (including SMS) */
-"message" = "Messaggio";
-
 /* Share by email button text, also used in editor. */
 "email" = "Email";
-
-/* Copy Link */
-"copy_link" = "Copia link";
-
-/* Text for the button that returns to caller application */
-"more_info" = "Mostra più informazioni";
 
 /* Text for message when used successfully copied something */
 "copied_to_clipboard" = "Copiato sugli Appunti: %1$@";
@@ -354,15 +262,6 @@
 
 /* Used for bookmark editing */
 "done" = "Fine";
-
-/* Summary for preferences in MWM */
-"yopme_pref_summary" = "Selezionate le impostazioni Sfondo";
-
-/* Title for yopme preferences in MWM */
-"yopme_pref_title" = "Impostazioni Sfondo";
-
-/* Hint for upper-right icon p2b */
-"show_on_backscreen" = "Mostra Sfondo";
 
 /* Prints version number in About dialog */
 "version" = "Versione: %@";
@@ -381,19 +280,11 @@
 
 "share_my_location" = "Condividi la mia location";
 
-"menu_search" = "Cerca";
-
 /* Settings general group in settings screen */
 "prefs_group_general" = "General settings";
 
 /* Settings information group in settings screen */
 "prefs_group_information" = "Information";
-
-/* Settings screen: "Map" category title */
-"prefs_group_map" = "Mappa";
-
-/* Settings screen: "Miscellaneous" category title */
-"prefs_group_misc" = "Miscellanea";
 
 "prefs_group_route" = "Navigazione";
 
@@ -419,9 +310,6 @@
 /* Settings «Map» category: «3D buildings» title */
 "pref_map_3d_buildings_title" = "Edifici in 3D";
 
-/* Settings «Map» category: «3D buildings» summary */
-"pref_map_3d_buildings_subtitle" = "Diminuisce la durata della batteria";
-
 /* Settings «Route» category: «Tts enabled» title */
 "pref_tts_enable_title" = "Istruzioni vocali";
 
@@ -433,8 +321,6 @@
 
 /* Title for "Other" section in TTS settings. */
 "pref_tts_other_section_title" = "Altro";
-
-"pref_tts_how_to_set_up_voice" = "Come impostare la voce";
 
 /* Settings «Map» category: «Record track» title */
 "pref_track_record_title" = "Percorso recente";
@@ -455,56 +341,7 @@
 
 "recent_track_help_text" = "Consente di registrare il tratto percorso in un determinato periodo di tempo e vedere lo stesso sulla mappa. Nota: l'attivazione di questa funzione incrementa l'uso della batteria. Il tratto viene rimosso automaticamente dalla mappa allo scadere dell'intervallo di tempo.";
 
-"pref_track_ios_caption" = "Il percorso recente mostra il tragitto effettuato.";
-
-"pref_track_ios_subcaption" = "Seleziona un intervallo temporale per la registrazione del percorso.";
-
-"placepage_distance" = "Distanza";
-
-"placepage_coordinates" = "Coordinate";
-
-"placepage_unsorted" = "Non classificato";
-
 "search_show_on_map" = "Visualizza sulla mappa";
-
-/* Used to warn user when fixing KitKat issue */
-"bookmark_move_fail" = "Abbiamo bisogno di trasferire i tuoi preferiti nella memoria interna, ma non c'è abbastanza spazio disponibile. Ti preghiamo di liberare la memoria, altrimenti i preferiti non saranno disponibili.";
-
-/* Used in More Apps menu */
-"free" = "Gratis";
-
-/* Used in More Apps menu */
-"buy" = "Acquista";
-
-/* 1st search button-like result */
-"search_on_map" = "Cerca sulla mappa";
-
-/* toast with an error */
-"no_route_found" = "Nessun percorso trovato";
-
-/* route title */
-"route" = "Linea";
-
-/* category title */
-"routes" = "Percorsi";
-
-/* text of notification */
-"download_map_notification" = "Scarica la mappa del luogo in cui ti trovi";
-
-/* text of notification */
-"pro_version_is_free_today" = "Versione completa di Organic Maps è oggi gratis! Scaricala ora e dillo ai tuoi amici!";
-
-/* Dialog for transferring maps from lite to pro. */
-"move_lite_maps_to_pro" = "Stiamo trasferendo le tue mappe scaricate da Organic Maps Lite a Organic Maps. Potrebbe richiedere alcuni minuti.";
-
-/* Message to display when maps moved. */
-"move_lite_maps_to_pro_ok" = "Le mappe che hai scaricato sono state trasferite con successo a Organic Maps.";
-
-/* Message to display when maps move failed. */
-"move_lite_maps_to_pro_failed" = "Non è stato possibile trasferire le tue mappe. Cancella Organic Maps Lite e scarica le mappe di nuovo.";
-
-/* Text in menu */
-"settings_and_more" = "Impostazioni e Altro";
 
 /* Text in menu */
 "website" = "Sito web";
@@ -527,14 +364,8 @@
 /* Text in menu */
 "openstreetmap" = "OpenStreetMap";
 
-/* Text in menu */
-"contact_us" = "Contattaci";
-
 /* Settings: Send feedback button and dialog title */
 "feedback" = "Feedback";
-
-/* Text in menu */
-"subscribe_to_news" = "Iscriviti alle nostre notizie";
 
 /* Text in menu */
 "rate_the_app" = "Vota l'app";
@@ -548,15 +379,6 @@
 /* Text in menu */
 "report_a_bug" = "Riporta un bug";
 
-/* Email subject */
-"subscribe_me_subject" = "Iscrivimi alla newsletter di Organic Maps";
-
-/* Email body */
-"subscribe_me_body" = "Voglio essere tra i primi a sapere delle ultime novità aggiornamenti e promozioni. Potrò annullare l'iscrizione in ogni momento.";
-
-/* About text */
-"about_text" = "Organic Maps offre le più veloci mappe offline di tutte le città, di tutti i paesi del mondo. Viaggia con piena fiducia: ovunque ti trovi, Organic Maps ti aiuta a localizzarti sulla mappa, trovare ristoranti, hotel, banche, distributori di benzina ecc.., e non richiede la connessione a internet.\n\nLavoriamo sempre su nuove funzionalità e ci piacerebbe sapere da te in cosa potremmo migliorare Organic Maps. Se avessi problemi con l'app, non esitare a contattarci a support@organicmaps.app. Rispondiamo ad ogni richiesta!\n\nTi piace Organic Maps e vuoi sostenerci? Ci sono alcuni modi semplici e assolutamente gratuiti:\n\n- Invia una recensione al tuo App Market\n- Metti mi piace sulla nostra pagina di Facebook http://www.facebook.com/OrganicMaps\n- O semplicemente fai pubblicità a Organic Maps con la tua mamma, i tuoi amici e colleghi :)\n\nGrazie per essere stato con noi. Apprezziamo molto il tuo supporto!\n\nP.S. Prendiamo i dati delle mappe da OpenStreetMap, un progetto di mappatura simile a Wikipedia, che permette agli utenti di creare e modificare le mappe. Se vedi che manca qualcosa o se c'è qualcosa di sbagliato sulla mappa, puoi correggere le mappe direttamente su https://www.openstreetmap.org, e le modifiche appariranno nella prossima versione dell'app Organic Maps.";
-
 /* Alert text */
 "email_error_body" = "Il client email non è stato configurato. Si prega di configurarlo o di usare qualsiasi altro metodo per contattarci all'indirizzo %@";
 
@@ -569,12 +391,6 @@
 /* Search category */
 "wifi" = "WiFi";
 
-/* Update map suggestion */
-"routing_map_outdated" = "Aggiorna la mappa per creare un itinerario.";
-
-/* Update maps suggestion */
-"routing_update_maps" = "La nuova versione di Organic Maps ti permette di creare itinerari dalla tua posizione attuale a un punto di destinazione. Aggiorna le mappe per utilizzare questa funzione.";
-
 /* Update all button text */
 "downloader_update_all_button" = "Aggiorna tutte";
 
@@ -583,9 +399,6 @@
 
 /* Downloaded maps category */
 "downloader_downloaded_subtitle" = "Scaricate";
-
-/* Downloaded maps category */
-"downloader_available_maps" = "Disponibile";
 
 /* Country queued for download */
 "downloader_queued" = "In coda";
@@ -598,17 +411,6 @@
 
 "downloader_downloading" = "In scaricamento:";
 
-"downloader_search_results" = "Trovate";
-
-/* Disclaimer message */
-"routing_disclaimer" = "Creando percorsi nell'app Organic Maps tieni a mente quanto segue:\n\n  - I percorsi suggeriti possono essere considerati solo come consigliati.\n - Le condizioni della strada, le regole del traffico e i segnali hanno una priorità maggiore rispetto ai consigli sulla circolazione.\n - La mappa potrebbe essere scorretta o datata e i percorsi potrebbero non aver creato la strada migliore possibile.\n\n  Stai attento sulle strade e prenditi cura di te!";
-
-/* Outdated maps category */
-"downloader_outdated_maps" = "Obsoleto";
-
-/* Up to date maps category */
-"downloader_uptodate_maps" = "Aggiornato";
-
 /* Status of outdated country in the list */
 "downloader_status_outdated" = "Aggiorna";
 
@@ -618,49 +420,14 @@
 /* Displayed in a dialog that appears when a user tries to delete a map while the app is in the follow route mode */
 "downloader_delete_map_while_routing_dialog" = "Per eliminare una mappa interrompi la navigazione.";
 
-/* Show when user try build route, but we don't know where he */
-"routing_failed_unknown_my_position" = "La posizione attuale non è definita. Specifica la posizione per creare il percorso.";
-
-/* Show if use has not routing file, or InconsistentMWMandRoute */
-"routing_failed_has_no_routing_file" = "Ulteriori dati sono necessari per creare un percorso. Inizio a scaricarli?";
-
-/* StartPointNotFound */
-"routing_failed_start_point_not_found" = "Impossibile calcolare il percorso. Nessuna strada vicina al tuo punto di partenza.";
-
-/* EndPointNotFound */
-"routing_failed_dst_point_not_found" = "Impossibile calcolare il percorso. Nessuna strada vicina al tuo punto di arrivo.";
-
 /* PointsInDifferentMWM */
 "routing_failed_cross_mwm_building" = "I percorsi possono essere creati solo se interamente presenti in una singola mappa.";
-
-/* RouteNotFound */
-"routing_failed_route_not_found" = "Non è stata trovata alcuna strada fra il punto di partenza e d'arrivo selezionati. Seleziona un punto di partenza e d'arrivo diversi.";
-
-/* InternalError */
-"routing_failed_internal_error" = "Si è verificato un errore interno. Prova ad eliminare la mappa e a scaricarla nuovamente. Se il problema dovesse persistere, contattaci all'indirizzo support@organicmaps.app.";
-
-/* Context menu item for downloader. */
-"downloader_download_map_and_routing" = "Scarica mappa e percorso";
-
-/* Context menu item for downloader. */
-"downloader_download_routing" = "Scarica percorso";
-
-/* Context menu item for downloader. */
-"downloader_delete_routing" = "Elimina il percorso";
 
 /* Context menu item for downloader. */
 "downloader_download_map" = "Scarica mappa";
 
-"downloader_download_map_no_routing" = "Scarica mappa senza percorsi";
-
-/* Button for routing. */
-"routing_go" = "Andare!";
-
 /* Item status in downloader. */
 "downloader_retry" = "Ripeti";
-
-/* Item in context menu. */
-"downloader_map_and_routing" = "Mappa + percorso";
 
 /* Item in context menu. */
 "downloader_delete_map" = "Elimina mappa";
@@ -668,29 +435,11 @@
 /* Item in context menu. */
 "downloader_update_map" = "Aggiorna mappa";
 
-/* Item in context menu. */
-"downloader_update_map_and_routing" = "Aggiorna mappa + percorso";
-
-/* Item in context menu. */
-"downloader_map_only" = "Solo mappa";
-
-/* Toolbar title */
-"toolbar_application_menu" = "Menu applicazione";
-
 /* Preference text */
 "pref_use_google_play" = "Usa i servizi Google Play per ottenere la tua posizione attuale";
 
 /* Text for rating dialog */
 "rating_just_rated" = "Ho appena valutato la tua app";
-
-/* Text for rating dialog */
-"rating_user_since" = "Sono un utente Organic Maps dal %@";
-
-/* Text for rating dialog */
-"rating_do_like_maps" = "Ti piace Organic Maps?";
-
-/* Text for rating dialog */
-"rating_tap_star" = "Fai tap sulla stella per valutare la nostra app.";
 
 /* Text for rating dialog */
 "rating_thanks" = "Grazie!";
@@ -701,23 +450,8 @@
 /* Text for rating dialog */
 "rating_send_feedback" = "Invia feedback";
 
-/* Text for g+ dialog */
-"rating_google_plus" = "Clicca su g+ per far conoscere l'app ai tuoi amici.";
-
 /* Text for routing error dialog */
 "routing_download_maps_along" = "Scarica le mappe lungo il percorso";
-
-/* Text for routing error dialog */
-"routing_download_map" = "Scarica la mappa";
-
-/* Text for routing error dialog */
-"routing_download_map_and_routing" = "Scarica la mappa aggiornata e i dati del percorso per ottenere tutte le funzionalità Organic Maps.";
-
-/* Text for routing error dialog */
-"routing_get_routing_data" = "Ottieni i dati del percorso";
-
-/* Text for routing error dialog */
-"routing_get_additional_data" = "dati aggiuntivi richiesti per creare i percorsi dalla tua posizione.";
 
 /* Text for routing error dialog */
 "routing_requires_all_map" = "Creare un percorso necessita la presenza di tutte le mappe scaricate e aggiornate dalla tua posizione alla destinazione.";
@@ -725,50 +459,15 @@
 /* Text for routing error dialog */
 "routing_not_enough_space" = "Spazio non sufficiente";
 
-/* Text for routing error dialog */
-"routing_download_more_than_avail" = "Devi scaricare %@ MB, ma lo spazio disponibile è di soli %@ MB.";
-
-/* Text for routing error dialog */
-"routing_download_roaming" = "Stai per scaricare %@ MB tramite la rete cellulare (in roaming). Questo potrebbe comportare costi aggiuntivi, in base al piano dati del tuo operatore mobile.";
-
 /* bookmark button text */
 "bookmark" = "segnalibro";
-
-/* map is not downloaded */
-"not_found_map" = "La mappa del tuo posto non è stata trovata";
 
 /* location service disabled */
 "enable_location_services" = "Cortesemente abilita i servizi di localizzazione";
 
-/* download map */
-"download_map" = "Scarica la mappa per il tuo paese";
-
-/* download map on iPhone */
-"download_map_iphone" = "Scarica la mappa per la tua posizione corrente sul tuo iPhone";
-
-/* clear pin */
-"nearby" = "Nelle vicinanze";
-
-/* clear pin */
-"clear_pin" = "Annulla pin";
-
-/* location is undefined */
-"undefined_location" = "La posizione attuale non è definita.";
-
-/* download country of your location */
-"download_country" = "Scarica il paese della tua posizione attuale";
-
-/* download failed */
-"download_failed" = "Il trasferimento di non è riuscito";
-
-/* get the map */
-"get_the_map" = "Scarica la mappa";
-
 "save" = "Salva";
 
 "edit_description_hint" = "Le tue descrizioni (formato testo o html)";
-
-"new_group" = "nuovo gruppo";
 
 "create" = "crea";
 
@@ -795,30 +494,6 @@
 
 /* pink color */
 "pink" = "Rosa";
-
-/* deep purple color */
-"deep_purple" = "Viola scuro";
-
-/* light blue color */
-"light_blue" = "Azzurro";
-
-/* cyan color */
-"cyan" = "Cyan";
-
-/* teal color */
-"teal" = "Verde smeraldo";
-
-/* lime color */
-"lime" = "Verde fluo";
-
-/* deep orange color */
-"deep_orange" = "Arancione scuro";
-
-/* gray color */
-"gray" = "Grigio";
-
-/* blue gray color */
-"blue_gray" = "Grigiazzurro";
 
 /* Wi-Fi available */
 "WiFi_available" = "Sì";
@@ -848,13 +523,9 @@
 
 "dialog_routing_location_unknown_turn_on" = "Impossibile individuare le coordinate GPS attuali. Per calcolare il percorso, abilita i servizi di localizzazione.";
 
-"dialog_routing_location_unknown" = "Impossibile individuare le coordinate GPS attuali.";
-
 "dialog_routing_download_files" = "Scarica i file necessari";
 
 "dialog_routing_download_and_update_all" = "Per calcolare il percorso, scarica e aggiorna tutte le mappe e le informazioni di itinerario lungo la strada prevista.";
-
-"dialog_routing_routes_size" = "File di informazioni di itinerario";
 
 "dialog_routing_unable_locate_route" = "Impossibile individuare il percorso";
 
@@ -884,21 +555,11 @@
 
 "dialog_routing_try_again" = "Riprova";
 
-"dialog_routing_send_error" = "Segnala il problema";
-
-"dialog_routing_if_get_cross_route" = "Vuoi creare un percorso più diretto che si estende su più mappe?";
-
-"dialog_routing_cross_route_is_optimal" = "È disponibile un percorso migliore che oltrepassa il limite di questa mappa.";
-
 "not_now" = "Non ora";
-
-"dialog_routing_build_route" = "Crea";
 
 "dialog_routing_download_and_build_cross_route" = "Vuoi scaricare la mappa e creare un percorso migliore che si estende su più mappe?";
 
 "dialog_routing_download_cross_route" = "Per creare un percorso migliore che oltrepassa il limite di questa mappa, scarica la mappa.";
-
-"dialog_routing_cross_route_always" = "Oltrepassa sempre questo limite";
 
 
 /********** Strings for downloading map from search **********/
@@ -906,8 +567,6 @@
 "search_without_internet_advertisement" = "Per iniziare a cercare e a creare i percorsi, scarica la mappa e non avrai più bisogno di una connessione a internet.";
 
 "search_select_map" = "Seleziona mappa";
-
-"search_select_other_map" = "Seleziona un'altra mappa";
 
 /* «Show» context menu */
 "show" = "Mostra";
@@ -918,17 +577,11 @@
 /* «Rename» context menu */
 "rename" = "Rinomina";
 
-/* Bottom sheet: expand button (should be short) */
-"bottom_sheet_more" = "Altro…";
-
 /* Failed planning route message in navigation view */
 "routing_planning_error" = "Pianificazione del percorso fallito";
 
 /* Arrive routing message in navigation view */
 "routing_arrive" = "Arrivo: %s";
-
-/* Text for routing::RouterResultCode::FileTooOld dialog. */
-"dialog_routing_download_and_update_maps" = "Per creare un percorso, scaricare e aggiornare tutte le mappe interessate dal percorso.";
 
 "rate_alert_title" = "Ti piace l’app?";
 
@@ -944,19 +597,11 @@
 
 "history" = "Cronologia";
 
-"next_turn_then" = "Poi";
-
 "closed" = "Chiuso";
-
-"back_to" = "Torna a %@";
 
 "search_not_found" = "Spiacente, non ho trovato nulla.";
 
 "search_not_found_query" = "Prova con un'altra ricerca.";
-
-"search_not_found_map" = "Scarica la mappa nella quale stai cercando.";
-
-"search_not_found_location" = "Scarica la mappa del luogo in cui ti trovi.";
 
 "search_history_title" = "Cerca nella cronologia";
 
@@ -964,23 +609,12 @@
 
 "clear_search" = "Cancella сronologia ricerche";
 
-/* Title for settings to enable/disable showcase menu button */
-"showcase_settings_title" = "Mostra offerte";
-
 /* Place Page link to Wikipedia article (if map object has it). */
 "read_in_wikipedia" = "Wikipedia";
 
-"p2p_route_planning" = "Pianificazione percorso";
-
 "p2p_your_location" = "La tua posizione";
 
-"p2p_from" = "Il punto di partenza";
-
-"p2p_to" = "Il punto di destinazione";
-
 "p2p_start" = "Inizia";
-
-"p2p_planning" = "Pianificazione…";
 
 "p2p_from_here" = "Da";
 
@@ -1018,15 +652,9 @@
 
 "editor_correct_mistake" = "Correggi errore";
 
-"editor_correct_mistake_message" = "Hai commesso un errore nella modifica. Correggerlo o passare alla modalità semplice.";
-
 "editor_add_select_location" = "Posizione";
 
 "editor_done_dialog_1" = "Hai modificato la mappa del mondo. Non tenerlo per te! Dillo ai tuoi amici e modificatela insieme.";
-
-"editor_done_dialog_2" = "Questa è la tua seconda modifica alla mappa. Adesso sei al %d° posto nella lista di chi ha modificato la mappa. Dillo ai tuoi amici.";
-
-"editor_done_dialog_3" = "Hai migliorato la mappa. Dillo ai tuoi amici e modificate la mappa insieme.";
 
 "share_with_friends" = "Condividi con gli amici";
 
@@ -1044,20 +672,7 @@
 
 "editor_report_problem_duplicate_place_title" = "Luogo duplicato";
 
-"first_launch_congrats_title" = "Organic Maps è pronto per essere usato";
-
-"first_launch_congrats_text" = "Cerca e naviga offline, ovunque ti trovi nel mondo, gratis.";
-
-"migrate_title" = "Importante!";
-
-/* Android uses image instead of text. */
-"download_all" = "Scarica tutto";
-
-"delete_all" = "Elimina tutti";
-
 "autodownload" = "Scaricamento automatico";
-
-"disable_autodownload" = "Disattiva download automatico";
 
 /* Place Page opening hours text */
 "closed_now" = "Ora chiuso";
@@ -1072,10 +687,6 @@
 "day_off" = "Chiuso";
 
 "today" = "Oggi";
-
-"sunrise_to_sunset" = "Dall'alba al tramonto";
-
-"sunset_to_sunrise" = "Dal tramonto all'alba";
 
 "add_opening_hours" = "Aggiungi orari di apertura";
 
@@ -1095,45 +706,18 @@
 
 "forgot_password" = "Hai dimenticato la password?";
 
-/* Forgot Password dialog title */
-"restore_password" = "Ripristina password";
-
-"enter_email_address_to_reset_password" = "Inserisci l'indirizzo email utilizzato durante la registrazione e ti invieremo un link per recuperare la password.";
-
-"reset_password" = "Reimpostare password";
-
-"username" = "Nome utente";
-
 "osm_account" = "Account OSM";
 
 "logout" = "Esci";
 
-"login_and_edit_map_motivation_message" = "Accedi e modifica le informazioni degli oggetti sulla mappa e noi provvederemo a renderli disponibili a milioni di altri utenti. Creiamo un mondo migliore assieme.";
-
 /* Information text: "Last upload 11.01.2016" */
 "last_upload" = "Ultimo caricamento";
 
-/* Motivates user to login/register, title above login buttons. */
-"you_have_edited_your_first_object" = "Hai modificato il tuo primo oggetto!";
-
 "thank_you" = "Grazie";
-
-"login_with_google" = "Accedi con Google";
-
-"login_with_openstreetmap" = "Accedi con www.openstreetmap.org";
 
 "edit_place" = "Modifica il luogo";
 
 "place_name" = "Nome del luogo";
-
-/* title above languages list cells in the editor, below editable name text field. */
-"other_languages" = "Altre lingue";
-
-/* small button to open list with names in different languages */
-"show_more" = "Mostra più";
-
-/* small button to close list with names in different languages */
-"show_less" = "Mostra meno";
 
 "add_language" = "Aggiungi una lingua";
 
@@ -1164,8 +748,6 @@
 
 "please_note" = "Si prega di notare";
 
-"common_no_wifi_dialog" = "Nessuna connessione WiFi. Vuoi continuare con la connessione dati?";
-
 "downloader_delete_map_dialog" = "Tutti i cambiamenti nella mappa saranno cancellati insieme alla mappa.";
 
 "downloader_update_maps" = "Aggiorna mappe";
@@ -1173,10 +755,6 @@
 "downloader_mwm_migration_dialog" = "Per creare un percorso, devi aggiornare tutte le mappe e pianificare nuovamente il percorso.";
 
 "downloader_search_field_hint" = "Trova la mappa";
-
-"migration_update_all_button" = "Aggiorna tutte le mappe";
-
-"migration_delete_all_download_current_button" = "Scarica la mappa attuale e cancella quelle vecchie";
 
 "migration_download_error_dialog" = "Errore nel download";
 
@@ -1186,21 +764,9 @@
 
 "downloader_no_space_message" = "Si prega di rimuovere i dati non necessari";
 
-"editor_general_auth_error_dialog" = "Errore generale di accesso.";
-
 "editor_login_error_dialog" = "Errore accesso.";
 
-"editor_login_failed_dialog" = "Accesso fallito";
-
-"editor_username_error_dialog" = "Nome utente non valido";
-
-"editor_place_edited_dialog" = "Hai modificato un oggetto!";
-
-"editor_login_with_osm" = "Accedi con OpenStreetMap";
-
 "editor_profile_changes" = "Modifiche approvate";
-
-"editor_profile_unsent_changes" = "Non inviato:";
 
 "editor_focus_map_on_location" = "Sposta la mappa per selezionare l’esatta posizione dell’oggetto.";
 
@@ -1222,13 +788,9 @@
 
 "editor_report_problem_other_title" = "Un problema diverso";
 
-"placepage_report_problem_button" = "Riporta un problema";
-
 "placepage_add_business_button" = "Aggiungi organizzazione";
 
 "whatsnew_editor_message_1" = "Aggiungi nuovi luoghi alla mappa, e modifica quelli già esistenti direttamente dall’app.";
-
-"whatsnew_editor_message_2" = "* Organic Maps usa i dati della community OpenStreetMap.";
 
 "dialog_incorrect_feature_position" = "Cambia posizione";
 
@@ -1236,16 +798,10 @@
 
 "login_to_make_edits_visible" = "Accedi per consentire ad altri utenti di vedere le modifiche apportate.";
 
-"no_migration_during_navigation" = "Non è possibile effettuare aggiornamenti durante la navigazione.";
-
 /* Error dialog no space */
 "migration_no_space_message" = "Per scaricare, hai bisogno di più spazio. Sei pregato di eliminare i dati non necessari.";
 
 "editor_sharing_title" = "Ho migliorato le mappe Organic Maps";
-
-"editor_comment_will_be_sent" = "Invieremo i tuoi commenti ai cartografi.";
-
-"editor_unsupported_category_message" = "Hai aggiunto un luogo di una categoria che non è ancora disponibile. Apparirà sulla mappa in futuro.";
 
 /* Downloaded 10 **of** 20 <- it is that "of" */
 "downloader_of" = "%1$d di %2$d";
@@ -1278,23 +834,9 @@
 
 "editor_operator" = "Titolare";
 
-"editor_tag_description" = "Inserire la società, organizzazione o soggetto responsabile per la struttura.";
-
-"editor_no_local_edits_title" = "Non vi sono modifiche locali";
-
-"editor_no_local_edits_description" = "Qui è visualizzato il numero di modifiche suggerite sulla mappa che sono attualmente solo accessibili sul tuo dispositivo.";
-
-"editor_send_to_osm" = "Invia a OSM";
-
-"editor_remove" = "Rimuovi";
-
-"downloader_my_maps_title" = "Le mie mappe";
-
 "downloader_no_downloaded_maps_title" = "Non hai scaricato mappe";
 
 "downloader_no_downloaded_maps_message" = "Scarica mappe per trovare il luogo e navigare offline.";
-
-"downloader_find_place_hint" = "Cerca città o paese";
 
 /* Error title that appears after certain time without location. */
 "current_location_unknown_title" = "Continuare a rilevare la posizione attuale?";
@@ -1321,47 +863,13 @@
 /* iOS Dialog for the case when the location permission is not granted */
 "location_services_disabled_3" = "3. Seleziona mentre usi l'app";
 
-"placepage_parking_surface" = "Superficie";
-
-"placepage_parking_multistorey" = "Su più piani";
-
-"placepage_parking_underground" = "Sotterraneo";
-
-"placepage_parking_rooftop" = "Su terrazza";
-
-"placepage_parking_sheds" = "Coperto";
-
-"placepage_parking_carports" = "Tettoia";
-
-"placepage_parking_boxes" = "Box";
-
-"placepage_parking_pay" = "A pagamento";
-
-"placepage_parking_free" = "Gratis";
-
-"placepage_parking_interval" = "Pagamento a tempo";
-
-"placepage_entrance_number" = "N.";
-
-"placepage_entrance_type" = "Ingresso";
-
-"placepage_flat" = "app.";
-
-"placepage_open_24_7" = "24 / 7";
-
 "meter" = "m";
 
 "kilometer" = "km";
 
-"kilometers_per_hour" = "chilometri orari (km/h)";
-
 "mile" = "mi";
 
 "foot" = "ft";
-
-"miles_per_hour" = "mph";
-
-"day" = "g";
 
 "hour" = "h";
 
@@ -1381,10 +889,6 @@
 
 "placepage_bookmark_name_hint" = "Nome segnalibro";
 
-"placepage_personal_notes_hint" = "Note personali";
-
-"placepage_delete_bookmark_button" = "Elimina segnalibro";
-
 "editor_edits_sent_message" = "Le modifiche suggerite sono state inviate";
 
 "editor_comment_hint" = "Commenta…";
@@ -1397,8 +901,6 @@
 
 "editor_remove_place_button" = "Rimuovi";
 
-"editor_status_sending" = "Invio…";
-
 "editor_place_doesnt_exist" = "Luogo inesistente";
 
 "text_more_button" = "…continua";
@@ -1410,11 +912,7 @@
 
 "error_enter_correct_email" = "Inserisci un'email valida";
 
-"error_enter_correct" = "Inserisci un valore valido";
-
 "refresh" = "Aggiornare";
-
-"last_update" = "Ultimo aggiornamento: %s";
 
 "placepage_add_place_button" = "Aggiungi un luogo sulla mappa";
 
@@ -1426,24 +924,6 @@
 
 "editor_share_to_all_dialog_message_2" = "Controlleremo le modifiche. Se avremo delle domande, ti contatteremo via email.";
 
-"navigation_overview_button" = "panoramica";
-
-"navigation_stop_button" = "ferma";
-
-/* Text on an empty bookmark page */
-"bookmarks_empty_title" = "Salva i Segnalibri";
-
-"bookmarks_empty_message_1" = "Tocca su ★ per salvare i luoghi preferiti e accedervi rapidamente.";
-
-"bookmarks_empty_message_2" = "Importa i segnalibri dalla posta elettronica e dal web.";
-
-"bookmarks_empty_message_3" = "check out: %s";
-
-/* Name of the group for booked hotels */
-"bookmarks_group_name" = "Hotel prenotati";
-
-"place_page_button_read_descriprion" = "Leggi";
-
 /* iOS dialog for the case when recent track recording is on and the app comes back from background */
 "recent_track_background_dialog_title" = "Disattivare la registrazione del tuo percorso effettuato di recente?";
 
@@ -1451,8 +931,6 @@
 
 /* For sharing via SMS and so on */
 "sharing_call_action_look" = "Dai uno sguardo";
-
-"continue_recent_track_background_button" = "Continua";
 
 "recent_track_background_dialog_message" = "Organic Maps usa la tua posizione geografica in background per registrare il tuo percorso effettuato più di recente.";
 
@@ -1468,33 +946,13 @@
 /* About short text (below logo) */
 "about_description" = "Organic Maps è un'applicazione offline essenziale per chi ama viaggiare. Organic Maps si basa sui dati OpenStreetMap e consente di apportare modifiche.";
 
-/* Text in menu */
-"blog" = "Blog";
-
 "general_settings" = "Impostazioni generali";
-
-"date" = "Data %d";
-
-/* "Report a bug" -> "Generaal Feedback" -> "Something is not working" */
-"something_is_not_working" = "Qualcosa non funziona";
 
 /* For the first routing */
 "accept" = "Accetta";
 
-"accept_and_continue" = "Accept and continue";
-
 /* For the first routing */
 "decline" = "Rifiuta";
-
-"install_app" = "Installa";
-
-"search_no_results_title" = "Nessun risultato trovato";
-
-"search_no_results_message" = "Prova con un termine di ricerca più generale, fai lo zoom indietro o reimposta il filtro.";
-
-"search_no_results_expand_area_button" = "Zoom indietro";
-
-"search_no_results_reset_button" = "Reimposta filtro";
 
 /* noun */
 "search_in_table" = "Elenco";
@@ -1517,8 +975,6 @@
 
 "traffic_update_maps_text" = "Per visualizzare i dati sul traffico, le mappe devono essere aggiornate.";
 
-"traffic_outdated" = "Dati sul traffico non aggiornati.";
-
 "big_font" = "Aumenta dimensione carattere sulla mappa";
 
 "traffic_update_app" = "Aggiorna Organic Maps";
@@ -1529,17 +985,7 @@
 /* "traffic" as in "road congestion" */
 "traffic_data_unavailable" = "Dati sul traffico non disponibili";
 
-/* "Translation is no needed, because it's a company name" */
-"uber" = "Uber";
-
-/* Simplified colour scheme for traffic information, fewer colours are used to display traffic jams on the map. The string should be kept as short as possible */
-"pref_traffic_simplified_colors_title" = "Colori traffico semplificati";
-
 "enable_logging" = "Abilita registrazione";
-
-"offline_place_page_more_information" = "Connettiti a Internet per ottenere maggiori informazioni sul luogo.";
-
-"failed_load_information" = "Impossibile caricare le informazioni.";
 
 /* Settings: "Send general feedback" button */
 "feedback_general" = "Feedback generale";
@@ -1556,8 +1002,6 @@
 
 "whatsnew_transliteration_title" = "Traslitterazione in latino";
 
-"yandex_taxi_title" = "Yandex.Taxi";
-
 "learn_more" = "Ulteriori informazioni";
 
 "core_exit" = "Esci";
@@ -1568,75 +1012,19 @@
 
 "button_exit" = "Esci";
 
-"settings_device_memory" = "Memoria del dispositivo";
-
-"settings_card_memory" = "Scheda di memoria";
-
-"settings_storage_available" = "%s disponibile";
-
-"toast_location_permission_denied" = "Autorizzazione a posizione app negata";
-
-"button_use" = "Usa";
-
 "planning_route_manage_route" = "Gestisci percorso";
 
 "button_plan" = "Pianifica";
-
-"button_add" = "Aggiungi";
 
 "placepage_remove_stop" = "Rimuovi";
 
 "planning_route_remove_title" = "Trascina qui per rimuovere";
 
-"dialog_change_start_point_message" = "Sostituire il punto di partenza con la posizione corrente?";
-
-"button_replace" = "Sostituisci";
-
 "placepage_add_stop" = "Aggiungi sosta";
-
-/* Only ru/en are needed */
-"subtitle_rent" = "Rent";
-
-/* Only ru/en are needed */
-"rub_month" = "RUB/month";
-
-/* Only ru/en are needed */
-"room" = "%s-room apt.";
-
-/* Only ru/en are needed */
-"real_estate" = "Real estate";
-
-"add_my_position" = "Aggiungi mia posizione";
-
-"choose_start_point" = "Scegli un punto di partenza";
-
-"choose_destination" = "Scegli una destinazione";
 
 "preloader_viator_button" = "Ulteriori informazioni";
 
-"start_from_my_position" = "Parti da";
-
-"profile_authorization_title" = "Accedi con";
-
-"profile_authorization_message" = "Semplice accesso senza login e password in un paio di secondi";
-
 "profile_authorization_error" = "Ops, si è verificato un errore. Prova a ripetere l'accesso più tardi.";
-
-"service" = "Servizio";
-
-"atmosphere" = "Atmosfera";
-
-"value_for_money" = "Rapporto qualità/prezzo";
-
-"experience" = "Esperienza";
-
-"assortment" = "Assortimento";
-
-"expertise" = "Competenza";
-
-"equipment" = "Attrezzature";
-
-"quality" = "Qualità";
 
 "dialog_error_storage_title" = "Problema di accesso all'archivio";
 
@@ -1644,17 +1032,7 @@
 
 "setting_emulate_bad_storage" = "Simula archivio danneggiato";
 
-"directions_finish" = "Destinazione";
-
-"directions_on_foot" = "Percorri %s";
-
 "core_entrance" = "Ingresso";
-
-"coffee" = "Caffè";
-
-"cleanliness" = "Pulizia";
-
-"crowdedness" = "Clientela";
 
 "error_enter_correct_name" = "Inserisci un nome corretto";
 
@@ -1673,11 +1051,9 @@
 
 "downloader_percent" = "%s (%s di %s)";
 
-"downloader_process" = "Download di %s...";
+"downloader_process" = "Download di %s…";
 
-"downloader_applying" = "Applicazione di %s...";
-
-"dialog_message_transit_not_found_connection" = "Pianifica un percorso all'interno di una rete di transito";
+"downloader_applying" = "Applicazione di %s…";
 
 "bookmarks_error_message_share_general" = "Impossibile condividere a causa di un errore dell'applicazione";
 
@@ -1695,17 +1071,7 @@
 
 "bookmarks_error_message_list_name_already_taken" = "Si prega di scegliere un altro nome";
 
-"bookmarks_error_title_list_name_too_long" = "Questo nome è troppo lungo";
-
-"bookmarks_error_message_list_name_too_long" = "Si prega di scegliere un altro nome";
-
-"please_wait" = "Attendere prego...";
-
-"phone_number" = "Numero di telefono";
-
-"notification_unsent_reviews_title" = "Hai diverse recensioni non inviate";
-
-"notification_unsent_reviews_message" = "Accedi per condividere recensioni con altri viaggiatori";
+"please_wait" = "Attendere prego…";
 
 "profile" = "Profilo OpenStreetMap";
 
@@ -1719,49 +1085,13 @@
 
 "bookmarks_convert_error_message" = "Alcuni file non sono stati convertiti.";
 
-"converting" = "Conversione...";
-
-"wn_reinvented_bookmarks_title" = "Abbiamo reinventato i segnalibri!";
-
-"wn_reinvented_bookmarks_message" = "Puoi fare il backup dei segnalibri, creare liste... È incredibile...";
-
-"bookmarks_restore" = "Ripristina segnalibri";
-
-"bookmarks_restore_process" = "Ripristino...";
-
 "bookmarks_restore_title" = "Ripristina questa versione?";
 
-"bookmarks_restore_message" = "I tuoi segnalibri verranno ripristinati da %s (%s)";
-
-"bookmarks_restore_empty_title" = "Non hai un backup";
-
-"bookmarks_restore_empty_message" = "Il server non ha trovato i backup creati in precedenza";
-
 "common_check_internet_connection_dialog_title" = "Nessuna connessione internet";
-
-"error_server_title" = "Errore del server";
-
-"error_server_message" = "Si è verificato un errore sul server, riprova più tardi";
 
 "error_system_message" = "Si è verificato un errore sconosciuto";
 
 "restore" = "Ristabilire";
-
-"bookmarks_page_downloaded" = "Scaricati";
-
-"bookmarks_page_my" = "I miei";
-
-"routes_and_bookmarks" = "Percorsi e segnalibri";
-
-"bookmarks_webview_success_toast" = "Segnalibri scaricati con successo";
-
-"cached_bookmarks_placeholder_title" = "Scarica nuovi posti";
-
-"cached_bookmarks_placeholder_subtitle" = "Premi il pulsante per scaricare migliaia di luoghi e percorsi interessanti creati dagli utenti di Organic Maps. Avrai bisogno della connessione internet.";
-
-"downloader_download_routers" = "Scarica i segnalibri";
-
-"bookmarks_groups_cached" = "Elenchi scaricati da";
 
 "subtittle_opt_out" = "Impostazioni di tracciamento";
 
@@ -1769,29 +1099,15 @@
 
 "crash_reports_description" = "Potremmo utilizzare i tuoi dati per migliorare l'esperienza Organic Maps. Le modifiche avranno effetto dopo il riavvio dell'applicazione.";
 
-"opt_out_help_ios_1" = "Il tuo dispositivo mobile potrebbe fornire un'impostazione «Limita monitoraggio annunci» o «Disattiva la pubblicità mirata».";
-
-"opt_out_help_ios_2" = "iOS 9 o versioni successive";
-
-"opt_out_help_ios_3" = "Vai a Impostazioni → Privacy → Pubblicità → Abilita l'impostazione «Limita monitoraggio degli annunci»";
-
-"opt_out_help_android" = "Il tuo dispositivo mobile potrebbe fornire un'impostazione «Limita monitoraggio annunci» o «Disattiva pubblicità mirata». \n\nPer Android e Google Play Services versione 4.0 e successive:\nImpostazioni → Google → Annunci → Disattiva personalizzazione annunci \né\nImpostazioni → Google → Account Google → Informazioni personali e privacy → Impostazioni annunci → Personalizzazione annunci";
-
 "privacy_policy" = "Politica sulla riservatezza";
 
 "terms_of_use" = "Condizioni d'uso";
-
-"backup_notification_failed" = "Il backup dei segnalibri è stato sospeso. Accedi per riaccenderlo.";
 
 "button_layer_traffic" = "Traffico";
 
 "button_layer_subway" = "Metropolitana";
 
 "layers_title" = "Livelli mappa";
-
-"layers_message" = "Usa i livelli mappa per visualizzare il traffico, la mappa della metropolitana e altre informazioni utili";
-
-"button_layer_got_it" = "Fatto";
 
 "subway_data_unavailable" = "La mappa della metropolitana non è disponibile";
 
@@ -1803,39 +1119,13 @@
 
 "title_error_downloading_bookmarks" = "Si è verificato un errore";
 
-"subtitle_error_downloading_bookmarks" = "I segnalibri non sono stati scaricati";
-
-"error_already_downloaded" = "Questa lista è già stata scaricata";
-
 "popular_place" = "Popular";
-
-"download_routes" = "Download routes";
-
-"bookmarks_downloaded_title" = "Bookmarks have been downloaded successfully";
-
-"bookmarks_downloaded_subtitle" = "Press ‘View on map’ to explore new places from the list";
-
-"why_support" = "Perché sostenere Organic Maps?";
-
-"why_support_item1" = "We respect your privacy: there are zero trackers in the app, and we are open source";
-
-"why_support_item2" = "Voi ci aiutate a migliorare Organic Maps";
-
-"why_support_item3" = "Ci aiutate a migliorare le mappe OpenStreetMap.org";
-
-"channels_map_update" = "Rinnovare la carta";
-
-"server_unavailable_title" = "Server non è disponibile";
-
-"sharing_options" = "Impostazione accesso";
 
 "export_file" = "Esportare il file";
 
 "list_settings" = "Impostazioni elenco";
 
 "delete_list" = "Cancella elenco";
-
-"hide_from_map" = "Nascondere sulla mappa";
 
 "public_access" = "Accesso pubblico";
 
@@ -1845,40 +1135,11 @@
 
 "bookmark_category_description_hint" = "Aggiungere la descrizione (testo o html)";
 
-/* FIXME */
-"bookmarks_public_access" = "bookmarks_public_access";
-
-/* FIXME */
-"bookmarks_link_access" = "bookmarks_link_access";
-
-/* FIXME */
-"bookmarks_private_access" = "bookmarks_private_access";
-
 "not_shared" = "Personale";
-
-"direct_link_progress_text" = "Il file si sta caricando…";
-
-"direct_link_success" = "Il link è stato creato";
-
-"send_a_link_btn" = "Mandare il link";
-
-"upload_error_toast" = "Errore durante il caricamento";
 
 "tags_loading_error_subtitle" = "Si è verificato un errore durante il caricamento dei tag. Si prega di riprovare";
 
-"unable_upload_errorr_title" = "Il file non è stato caricato";
-
-"unable_upload_error_subtitle_edited" = "Il file è stato modificato tramite web App";
-
-"unable_upload_error_subtitle_broken" = "Il file è danneggiato e non può essere caricato. Si prega di caricare un altro file.";
-
-"contact" = "Scrivere";
-
-"download_button" = "Scaricare";
-
 "speedcams_alert_title" = "Autovelox o Tutor";
-
-"speedcams_alert_subtitle" = "Avvisare sul limite della velocità";
 
 "speedcam_option_auto" = "Auto";
 
@@ -1886,18 +1147,10 @@
 
 "speedcam_option_never" = "Mai";
 
-"bookmark_description_title" = "Descrizione tag";
-
 "place_description_title" = "Descrizione luogo";
 
 /* this text will be shown in application notification preferences opposite checkbox which enable/disable downloader notifications. Devices on Android 8+ are affected. */
 "notification_channel_downloader" = "Caricamento mappe";
-
-"share_bookmarks_email_body_link" = "Ciao,\n\npuoi scaricare i tag dal seguente link: %s. Aprire elenco tramite Organic Maps e godersi viaggio!\n\nScaricare l'App: https://omaps.app/get?kmz";
-
-"warning_speedcams_title" = "Il navigatore avvisa della presenza della telecamere in caso di eccesso velocità di %d km/o";
-
-"warning_speedcams_subtitle" = "Ricorda di informarti sul Codice della Strada del paese che visiti.";
 
 "speedcams_notice_message" = "Auto - Avvisare di autovelox in caso di rischio eccesso velocità\nSempre - avvisare sempre di autovelox\nMai - Non avvisare mai di autovelox";
 
@@ -1913,23 +1166,7 @@
 
 "enable_logging_warning_message" = "Questa opzione si attiva per registrare tutte le azioni ai fini diagnostici. Ciò aiuta il nostro staff ad ottimizzare il funzionamento dell'applicazione. Attiva l'opzione sulla richiesta dello staff di suporto di Organic Maps.";
 
-"html_error_upload_message_try_again" = "Controllare la connessione e riprova";
-
-"html_error_upload_title_try_again" = "Nessuna connessione a internet";
-
-"notification_leave_review_v2_android_short_title" = "Scrivi il commento ed aiuta altri viaggiatori!";
-
-"megafon" = "Say goodbye to roaming!";
-
-"notifications_illegal_alert_disable_button" = "Disattiva le notifiche";
-
 "access_rules_author_only" = "Modifica online";
-
-"privacy_settings_menu" = "Impostazioni della privacy";
-
-"unable_upadate_error_title" = "Non siamo riusciti ad aggiornare l'itinerario";
-
-"unable_upadate_error_message" = "Si sono verificati errori durante l'aggiornamento. Controlla le modifiche e riprova";
 
 "driving_options_title" = "Impostazioni di deviazione";
 
@@ -1951,94 +1188,19 @@
 
 "change_driving_options_btn" = "Impostazioni di deviazione abilitate";
 
-"toll_road" = "Strada a pedaggio";
-
-"unpaved_road" = "Strada sterrata";
-
-"ferry_crossing" = "Traghetto";
-
-"operated_by" = "Gestita da \"%s\"";
-
 "avoid_toll_roads_placepage" = "Evitare strade a pedaggio";
 
 "avoid_unpaved_roads_placepage" = "Evitare strade sterrate";
 
 "avoid_ferry_crossing_placepage" = "Evitare i traghetti";
 
-"type.cuisine.uzbek" = "Cucina uzbeka";
-
-"trip_start" = "Si parte";
-
-"pick_destination" = "Meta";
-
-"follow_my_position" = "Centrare";
-
-"search_results" = "Risultati di ricerca";
-
-"then_turn" = "Avanti";
-
-"redirect_route_alert" = "Vuoi modificare il percorso?";
-
-"redirect_route_yes" = "Sì";
-
-"redirect_route_no" = "No";
-
-"trip_finished" = "Sei giunto a destinazione!";
-
-"keyboard_availability_alert" = "Tastiera non disponibile in movimento";
-
-"dialog_routing_change_start_carplay" = "Impossibile creare percorso dal punto di partenza selezionato";
-
-"dialog_routing_change_end_carplay" = "Impossibile creare percorso per raggiungere la destinazione Scegli un'altra destinazione";
-
-"dialog_routing_check_gps_carplay" = "Segnale GPS assente. Procedi su terreno aperto";
-
-"dialog_routing_unable_locate_route_carplay" = "Impossibile trovare percorso. Scegli altre tappe";
-
-"dialog_routing_download_files_carplay" = "Per creare percorso scarica mappe mancanti sul proprio dispositivo";
-
-"dialog_routing_system_error_carplay" = "Si è verificato un errore. Riavviare l'applicazione";
-
-"dialog_routing_rebuild_from_current_location_carplay" = "Il percorso verrà impostato dalla tua posizione corrente";
-
-"dialog_routing_rebuild_for_vehicle_carplay" = "Il percorso verrà modificato in modalità Auto";
-
 "ok" = "Ok";
-
-"avoid_unpaved_carplay_1" = "No sterrati";
-
-"avoid_unpaved_carplay_2" = "No sterrati";
-
-"avoid_ferry_carplay_1" = "No traghetti";
-
-"avoid_ferry_carplay_2" = "No traghetti";
-
-"avoid_tolls_carplay_1" = "No pedaggi";
-
-"avoid_tolls_carplay_2" = "Senza pedaggi";
-
-"speedcams_alert_title_carplay_1" = "Autovelox";
-
-"speedcams_alert_title_carplay_2" = "Info autovelox";
-
-"download_map_carplay" = "Scarica l'applicazione Organic Maps sul tuo smartphone";
-
-"carplay_roundabout_exit" = "%s uscita";
 
 /* max. 10 symbols, both iOS and Android */
 "sort" = "Ordina…";
 
 /* Android, title, max 20-22 symbols */
 "sort_bookmarks" = "Ordina i segnalibri";
-
-/* iOS */
-"sort_default" = "Ordina per default";
-
-"sort_type" = "Ordina per tipo";
-
-"sort_distance" = "Ordina per distanza";
-
-"sort_date" = "Ordina per data";
 
 /* Android */
 "by_default" = "Per default";
@@ -2052,63 +1214,7 @@
 /* Android */
 "by_date" = "Per data";
 
-"week_ago_sorttype" = "Una settimana fa";
-
-"month_ago_sorttype" = "Un mese fa";
-
-"moremonth_ago_sorttype" = "Più di un mese fa";
-
-"moreyear_ago_sorttype" = "Più di un anno fa";
-
-"near_me_sorttype" = "Vicino a me";
-
-"others_sorttype" = "Altri";
-
-"food_places" = "Cibo";
-
-"tourist_places" = "Luoghi d'interesse";
-
-"museums" = "Musei";
-
-"parks" = "Parchi";
-
-"swim_places" = "Nuoto";
-
-"mountains" = "Montagne";
-
-"animals" = "Animali";
-
-"hotels" = "Alberghi";
-
-"buildings" = "Edifici";
-
-"money" = "Denaro";
-
-"shops" = "Negozi";
-
-"parkings" = "Parcheggi";
-
-"fuel_places" = "Stazione di servizio";
-
-"water" = "Acqua";
-
-"medicine" = "Farmacia";
-
 "search_in_the_list" = "Cerca nella lista";
-
-"view_on_map_bookmarks" = "Sulla mappa";
-
-"more_bookmarks" = "Ecc…";
-
-"no_items_found" = "Nessun risultato trovato";
-
-/* Android, max 18 symbols */
-"bookmarks_edit_list" = "Modifica";
-
-/* Android, max 18 symbols */
-"bookmarks_delete_list" = "Cancella la lista";
-
-"religious_places" = "Luoghi di culto";
 
 "select_list" = "Scegli la lista";
 
@@ -2118,26 +1224,13 @@
 
 "dialog_pedestrian_route_is_long_message" = "Seleziona il punto iniziale o finale del percorso più vicino alla stazione della metro";
 
-/* Failed planning SUBWAY route message in navigation view */
-"routing_planning_error_subway_special" = "Errore di creazione del percorso della metro";
-
 "button_layer_isolines" = "Terreno";
-
-"tips_map_layers_title_countour" = "Novità su Organic Maps modalità topografica offline!";
-
-"tips_map_layers_message_countour" = "La modalità topografica aiuta a programmare il viaggio nella natura e a non perdersi";
 
 "isolines_activation_error_dialog" = "Per utilizzare la modalità topografica, aggiornate o scaricate la mappa dell'area interessata";
 
 "isolines_location_error_dialog" = "La modalità topografica per questa regione non è ancora disponibile";
 
 "elevation_profile_diff_level" = "Livello di difficoltà";
-
-"elevation_profile_diff_level_easy" = "Facile";
-
-"elevation_profile_diff_level_moderate" = "Moderato";
-
-"elevation_profile_diff_level_hard" = "Difficile";
 
 "elevation_profile_ascent" = "Ascesa";
 
@@ -2147,25 +1240,13 @@
 
 "elevation_profile_maxaltitude" = "Altitudine massima";
 
-"elevation_profile_m" = "m";
-
 "elevation_profile_difficulty" = "Difficoltà";
 
 "elevation_profile_distance" = "Dist.";
 
-"elevation_profile_km" = "km";
-
 "elevation_profile_time" = "Tempo:";
 
-"elevation_profile_hours" = "ore";
-
-"elevation_profile_minutes" = "min";
-
 "isolines_toast_zooms_1_10" = "Ingrandisci mappa per vedere l'isolinea";
-
-"downloader_updating_ios" = "Aggiornamento in corso";
-
-"downloader_loading_ios" = "Caricamento";
 
 "key_information_title" = "Informazioni importanti";
 

--- a/iphone/Maps/LocalizedStrings/it.lproj/Localizable.stringsdict
+++ b/iphone/Maps/LocalizedStrings/it.lproj/Localizable.stringsdict
@@ -9,21 +9,6 @@
 
 <!-- ********** Strings for downloading map from search **********/ -->
 
-  <key>bookmarks_places</key>
-  <dict>
-    <key>NSStringLocalizedFormatKey</key>
-    <string>%#@value@</string>
-    <key>value</key>
-    <dict>
-      <key>NSStringFormatSpecTypeKey</key>
-      <string>NSStringPluralRuleType</string>
-      <key>NSStringFormatValueTypeKey</key>
-      <string>d</string>
-      <key>other</key>
-      <string>%d preferiti</string>
-    </dict>
-  </dict>
-
   <key>bookmarks_detect_message</key>
   <dict>
     <key>NSStringLocalizedFormatKey</key>
@@ -38,21 +23,6 @@
       <string>%d file è stato trovato. Lo vedrai dopo la conversione.</string>
       <key>other</key>
       <string>%d file trovati Li vedrai dopo la conversione.</string>
-    </dict>
-  </dict>
-
-  <key>bookmarks_objects</key>
-  <dict>
-    <key>NSStringLocalizedFormatKey</key>
-    <string>%#@value@</string>
-    <key>value</key>
-    <dict>
-      <key>NSStringFormatSpecTypeKey</key>
-      <string>NSStringPluralRuleType</string>
-      <key>NSStringFormatValueTypeKey</key>
-      <string>d</string>
-      <key>other</key>
-      <string>%s oggetto</string>
     </dict>
   </dict>
 

--- a/iphone/Maps/LocalizedStrings/ja.lproj/Localizable.strings
+++ b/iphone/Maps/LocalizedStrings/ja.lproj/Localizable.strings
@@ -18,9 +18,6 @@
 /* Button which deletes downloaded country */
 "delete" = "削除";
 
-/* Button "do not interrupt download" if user touched actively downloading country */
-"do_nothing" = "何もしない";
-
 "download_maps" = "マップをダウンロード";
 
 /* Settings/Downloader - info for country when download fails */
@@ -28,9 +25,6 @@
 
 /* Settings/Downloader - info for country which started downloading */
 "downloading" = "ダウンロード中…";
-
-/* Settings/Downloader - size string, only strings different from English should be translated */
-"kb" = "kB";
 
 /* Choose measurement on first launch alert - choose metric system button */
 "kilometres" = "キロメートル";
@@ -55,17 +49,11 @@
 /* Update maps later/Buy pro version later button text */
 "later" = "次の機会に";
 
-/* Don't show some dialog any more */
-"never" = "今後表示しない";
-
 /* View and button titles for accessibility */
 "search" = "検索";
 
 /* Search box placeholder text */
 "search_map" = "マップを検索";
-
-/* Settings/Downloader - info for not downloaded country */
-"touch_to_download" = "タッチしてダウンロード";
 
 /* Settings/Downloader - 3G download warning dialog confirm button */
 "use_cellular_data" = "はい";
@@ -73,20 +61,11 @@
 /* Location services are disabled by user alert - message */
 "location_is_disabled_long_text" = "端末の位置情報サービスが無効になっているか、このアプリケーションからの位置情報利用が制限されています。端末の設定を有効化してください。";
 
-/* Location Services are not available on the device alert - message */
-"device_doesnot_support_location_services" = "ご使用中の端末は位置情報サービスをサポートしていません。";
-
 /* View and button titles for accessibility */
 "zoom_to_country" = "地図に表示";
 
-/* Button text for the button at the center of the screen when the country is not downloaded */
-"country_status_download" = "地図をダウンロード\n(^ ^)";
-
 /* Button text for the button at the center of the screen when the country is not downloaded and the size should not be shown */
 "country_status_download_without_size" = "地図をダウンロード";
-
-/* Button text for the button at the center of the screen when the country is not downloaded */
-"country_status_download_without_routing" = "ルートなしで地図をダウンロード\n(^ ^)";
 
 /* Message to display at the center of the screen when the country download has failed */
 "country_status_download_failed" = "のダウンロードに失敗しました";
@@ -96,19 +75,13 @@
 
 "about_menu_title" = "Organic Mapsについて";
 
-"downloaded_touch_to_delete" = "(%@)をダウンロードしました。削除するには画面をタッチしてください。";
-
 "connection_settings" = "接続設定";
-
-"download_mb_or_kb" = "%@をダウンロード";
 
 "close" = "閉じる";
 
 "unsupported_phone" = "ハードウェアアクセラレーションされたOpenGLが必要です。残念ながらご利用中のデバイスではサポートされていません。";
 
 "download" = "ダウンロード";
-
-"external_storage_is_not_available" = "マップをダウンロードしたSDカード/USBストレージへ接続できません";
 
 "disconnect_usb_cable" = "Organic Mapsを利用するにはUSBケーブルを抜くかメモリーカードを挿入してください";
 
@@ -117,8 +90,6 @@
 "not_enough_memory" = "メモリ不足のためアプリを起動できません";
 
 "download_resources" = "利用を開始する前におおまかな世界地図をダウンロードします。これには%@の空き容量が必要です。";
-
-"getting_position" = "現在地を取得中";
 
 "download_resources_continue" = "マップを表示";
 
@@ -140,23 +111,14 @@
 /* Add New Bookmark Set dialog title */
 "add_new_set" = "新しいセットを作成";
 
-/* Place Page - Add To Bookmarks button */
-"add_to_bookmarks" = "ブックマークに追加";
-
 /* Bookmark Color dialog title */
 "bookmark_color" = "ブックマーク表示色";
 
 /* Add Bookmark Set dialog - hint when set name is empty */
 "bookmark_set_name" = "ブックマークセット名称";
 
-/* Bookmark Sets dialog title */
-"bookmark_sets" = "ブックマークセット";
-
 /* Bookmarks - dialog title */
 "bookmarks" = "ブックマーク";
-
-/* Add bookmark dialog - bookmark color */
-"color" = "表示色";
 
 /* Default bookmarks set name */
 "core_my_places" = "マイロケーション";
@@ -167,14 +129,8 @@
 /* Editor title above street and house number */
 "address" = "住所";
 
-/* Place Page - Remove Pin button */
-"remove_pin" = "ピンを削除";
-
 /* Add bookmark dialog - bookmark set, Bookmarks dialog - Bookmark set cell */
 "set" = "セット";
-
-/* Text hint in Bookmarks dialog when no any bookmarks are added */
-"bookmarks_usage_hint" = "未だブックマークがありません。\nマップ上をタップすればブックマークを追加できます。\nOrganic Maps以外のアプリで作成したブックマークの表示も可能です。KML/KMZ形式のピン情報をメールやDropbox、URLから取得してください。";
 
 /* Settings button in system menu */
 "settings" = "設定";
@@ -191,26 +147,11 @@
 /* Ask to wait user several minutes (some long process in modal dialog). */
 "wait_several_minutes" = "数分かかる場合があります。\nしばらくお待ち下さい…";
 
-/* Show bookmarks from this category on a map or not */
-"visible" = "マップに表示";
-
-/* Toast which is displayed when GPS has been deactivated */
-"gps_is_disabled_long_text" = "GPS機能が無効です。端末の設定画面から有効にしてください。";
-
 /* Measurement units title in settings activity */
 "measurement_units" = "距離計測単位";
 
 /* Detailed description of Measurement Units settings button */
 "measurement_units_summary" = "マイルまたはキロメートルを選択";
-
-/* Do search in all sources */
-"search_mode_all" = "全マップから検索";
-
-/* Do search near my position only */
-"search_mode_nearme" = "現在地周辺";
-
-/* Do search in current viewport only */
-"search_mode_viewport" = "マップ表示範囲";
 
 /* Search category for cafes, bars, restaurants */
 "eat" = "食事場所";
@@ -266,14 +207,8 @@
 /* Search category */
 "police" = "警察";
 
-/* String in search result list, when nothing found */
-"no_search_results_found" = "検索結果が見つかりませんでした";
-
 /* Notes field in Bookmarks view */
 "description" = "メモ";
-
-/* Button text */
-"share_by_email" = "Eメールで共有";
 
 /* Email Subject when sharing bookmarks category */
 "share_bookmarks_email_subject" = "Organic Mapsの位置情報シェア";
@@ -295,26 +230,11 @@
 /* Warning message when doing search around current position */
 "unknown_current_position" = "現在の座標が未確定です";
 
-/* Warning message when location country isn't downloaded during search (see also download_location_map_proposal). */
-"download_location_country" = "現在の地域をダウンロード(%@)";
-
-/* Warning message when viewport country isn't downloaded during search */
-"download_viewport_country_to_search" = "現在マップで検索している国をダウンロード(%@)";
-
 /* Alert message that we can't run Map Storage settings due to some reasons. */
 "cant_change_this_setting" = "恐れ入ります、マップストレージ設定が無効になっています。";
 
 /* Alert message that downloading is in progress. */
 "downloading_is_active" = "ダウンロードを実行中です";
-
-/* Message that will be shown in alert view, when we ask user to leave review on App Store */
-"appStore_message" = "Organic Mapsの使い心地はいかがでしょうか。もしよろしければ、App Storeでレビューや評価をお知らせください。皆様からいただく一言が開発の励みになります。ご支援をよろしくお願いいたします！";
-
-/* No, thanks */
-"no_thanks" = "いいえ";
-
-/* Share one specific bookmark using SMS, %1$@ contains om:// and %2$@ https://omaps.app link. @NOTE non-ascii symbols in the link will result in max 70 characters SMS instead of 140. */
-"bookmark_share_sms" = "私のピン情報はこの位置です。リンク: %1$@, %2$@";
 
 /* Share my position using SMS, %1$@ contains om:// and %2$@ https://omaps.app link WITHOUT NAME. @NOTE non-ascii symbols in the link will result in max 70 characters SMS instead of 140. */
 "my_position_share_sms" = "私は今ここにいます。リンク: %1$@, %2$@";
@@ -328,23 +248,11 @@
 /* Share my position using EMail, %1$@ is om:// and %2$@ is https://omaps.app link WITHOUT NAME */
 "my_position_share_email" = "私は今ここにいます: %1$@\n\nリンクをクリックすると詳細がマップに表示されます。\n\n%2$@\n\n%3$@";
 
-/* Android share by Message/SMS button text (including SMS) */
-"share_by_message" = "メッセージで共有";
-
 /* Share button text which opens menu with more buttons, like Message, EMail, Facebook etc. */
 "share" = "共有";
 
-/* iOS share by Message button text (including SMS) */
-"message" = "メッセージ";
-
 /* Share by email button text, also used in editor. */
 "email" = "Eメール";
-
-/* Copy Link */
-"copy_link" = "リンクをコピー";
-
-/* Text for the button that returns to caller application */
-"more_info" = "詳細情報を表示";
 
 /* Text for message when used successfully copied something */
 "copied_to_clipboard" = "クリップボードにコピーしました: %1$@";
@@ -354,15 +262,6 @@
 
 /* Used for bookmark editing */
 "done" = "完了";
-
-/* Summary for preferences in MWM */
-"yopme_pref_summary" = "Choose Back Screen settings";
-
-/* Title for yopme preferences in MWM */
-"yopme_pref_title" = "Back Screen Settings";
-
-/* Hint for upper-right icon p2b */
-"show_on_backscreen" = "Show on Back screen";
 
 /* Prints version number in About dialog */
 "version" = "バージョン： %@";
@@ -381,19 +280,11 @@
 
 "share_my_location" = "位置情報を共有する";
 
-"menu_search" = "検索";
-
 /* Settings general group in settings screen */
 "prefs_group_general" = "General settings";
 
 /* Settings information group in settings screen */
 "prefs_group_information" = "Information";
-
-/* Settings screen: "Map" category title */
-"prefs_group_map" = "地図";
-
-/* Settings screen: "Miscellaneous" category title */
-"prefs_group_misc" = "その他";
 
 "prefs_group_route" = "ナビゲーション";
 
@@ -419,9 +310,6 @@
 /* Settings «Map» category: «3D buildings» title */
 "pref_map_3d_buildings_title" = "3Dビルディング";
 
-/* Settings «Map» category: «3D buildings» summary */
-"pref_map_3d_buildings_subtitle" = "電池の持ち時間に影響します";
-
 /* Settings «Route» category: «Tts enabled» title */
 "pref_tts_enable_title" = "音声指示";
 
@@ -433,8 +321,6 @@
 
 /* Title for "Other" section in TTS settings. */
 "pref_tts_other_section_title" = "その他";
-
-"pref_tts_how_to_set_up_voice" = "音声設定の仕方";
 
 /* Settings «Map» category: «Record track» title */
 "pref_track_record_title" = "最近の移動経路";
@@ -455,56 +341,7 @@
 
 "recent_track_help_text" = "移動経路を一定期間記録し、地図上で確認できるようにします。注意：この機能を有効にすると、バッテリーの消費量が増えます。表示期間が終了すると、走行軌跡は地図から自動的に削除されます。";
 
-"pref_track_ios_caption" = "最近ルートは、使用した道のりを表示する機能です。";
-
-"pref_track_ios_subcaption" = "ルートを保存する期間を選択してください。";
-
-"placepage_distance" = "距離";
-
-"placepage_coordinates" = "コーディネート";
-
-"placepage_unsorted" = "未分類";
-
 "search_show_on_map" = "地図に表示";
-
-/* Used to warn user when fixing KitKat issue */
-"bookmark_move_fail" = "ブックマークを内部メモリに移動させなければなりませんが、メモリの空き容量がありません。空き容量を増やさなければ、ブックマークをご利用いただくことができません。";
-
-/* Used in More Apps menu */
-"free" = "無料";
-
-/* Used in More Apps menu */
-"buy" = "購入";
-
-/* 1st search button-like result */
-"search_on_map" = "地図を検索";
-
-/* toast with an error */
-"no_route_found" = "一致する経路がありません";
-
-/* route title */
-"route" = "経路";
-
-/* category title */
-"routes" = "ルート";
-
-/* text of notification */
-"download_map_notification" = "あなたがいる場所のマップをダウンロードしよう";
-
-/* text of notification */
-"pro_version_is_free_today" = "Organic Mapsのフルバージョンが本日無料！今すぐダウンロードして友達に教えてあげましょう。";
-
-/* Dialog for transferring maps from lite to pro. */
-"move_lite_maps_to_pro" = "ダウンロード済みの地図をOrganic Maps LiteからOrganic Mapsに転送します。完了までに数分かかるかもしれません。";
-
-/* Message to display when maps moved. */
-"move_lite_maps_to_pro_ok" = "ダウンロード済みの地図は無事Organic Mapsに転送されました";
-
-/* Message to display when maps move failed. */
-"move_lite_maps_to_pro_failed" = "地図の転送に失敗しました。Organic Maps Liteを削除してから地図を再度ダウンロードしてください。";
-
-/* Text in menu */
-"settings_and_more" = "設定&その他";
 
 /* Text in menu */
 "website" = "ウェブサイト";
@@ -527,14 +364,8 @@
 /* Text in menu */
 "openstreetmap" = "OpenStreetMap";
 
-/* Text in menu */
-"contact_us" = "お問い合わせ";
-
 /* Settings: Send feedback button and dialog title */
 "feedback" = "フィードバック";
-
-/* Text in menu */
-"subscribe_to_news" = "当社のニュースに登録";
 
 /* Text in menu */
 "rate_the_app" = "アプリを評価";
@@ -548,15 +379,6 @@
 /* Text in menu */
 "report_a_bug" = "バグを報告";
 
-/* Email subject */
-"subscribe_me_subject" = "Organic Mapsニュースレターを購読します";
-
-/* Email body */
-"subscribe_me_body" = "最新ニュース、アップデートとプロモーションにすいてまず知りたいです。いつでも購読をキャンセル出来ます。";
-
-/* About text */
-"about_text" = "Organic Mapsは世界の全ての国、全ての都市が載っている最速のオフラインマップ。どこにいてもOrganic Mapsの地図上でユーザーの現在地が分かり、付近のレストラン、ホテル、銀行、ガソリンスタンドなどが見つけられるので、自信を持って旅行ができます。インターネット接続は必要ありません。\n\n弊社では常に新機能の開発に取り組んでいるので、Organic Mapsの改善についてユーザーの皆様からのご意見やご感想をお待ちしています。アプリで問題点が見つかった際は、お気軽にsupport@organicmaps.appまでご連絡ください。どのようなリクエストにでも対応いたします!\n\nOrganic Mapsが好きでサポートしていただけますか。シンプルで完全無料の方法がいくつかあります。\n\n- お使いのアプリマーケットでレビューを投稿\n- 弊社のFacebookページで「いいね!」をクリック：http://www.facebook.com/OrganicMaps\n- Organic Mapsのことをお母様、お友達、同僚の皆様に話す (^_^)\n\n弊社アプリをご利用いただきありがとうございます。皆様からのサポートに大変感謝しております!\n\n追伸：ウィキペディアのようにユーザーによる作成や編集が可能なマッピングプロジェクトOpenStreetMapの地図データを使用しています。地図上で欠けているものや誤りを見つけた場合、https://www.openstreetmap.orgでユーザーが直接修正ができます。このような変更はOrganic Mapsのその後のバージョンリリースの際に反映されます。";
-
 /* Alert text */
 "email_error_body" = "このメールクライアントはセットアップされていません。設定するか、他の方法で%@にご連絡ください。";
 
@@ -569,12 +391,6 @@
 /* Search category */
 "wifi" = "無線LAN";
 
-/* Update map suggestion */
-"routing_map_outdated" = "ルートを作成するためにマップを更新してください。";
-
-/* Update maps suggestion */
-"routing_update_maps" = "新バージョンのOrganic Mapsは現在地から目的地までのルートを作成可能です。 この機能を使うためにマップを更新してください。";
-
 /* Update all button text */
 "downloader_update_all_button" = "全てをアップデート";
 
@@ -583,9 +399,6 @@
 
 /* Downloaded maps category */
 "downloader_downloaded_subtitle" = "ダウンロード済み";
-
-/* Downloaded maps category */
-"downloader_available_maps" = "利用可能";
 
 /* Country queued for download */
 "downloader_queued" = "待ち行列型の";
@@ -598,17 +411,6 @@
 
 "downloader_downloading" = "ダウンロード中：";
 
-"downloader_search_results" = "見つかりました";
-
-/* Disclaimer message */
-"routing_disclaimer" = "Organic Mapsアプリでルートを作成する時は、以下のことに留意してください：\n\n  - 提案されたルートは推奨するだけです。\n - 道路状況、交通規則と標識はナビゲーションのアドバイスより優先度が高くなっています。\n - マップが不正確または古くなっている場合や、ルートが最適な方法で作成されていないことがあります。\n\n  安全運転でご自愛ください！";
-
-/* Outdated maps category */
-"downloader_outdated_maps" = "旧式";
-
-/* Up to date maps category */
-"downloader_uptodate_maps" = "最新";
-
 /* Status of outdated country in the list */
 "downloader_status_outdated" = "を更新";
 
@@ -618,49 +420,14 @@
 /* Displayed in a dialog that appears when a user tries to delete a map while the app is in the follow route mode */
 "downloader_delete_map_while_routing_dialog" = "地図を削除するにはナビゲーションを停止してください。";
 
-/* Show when user try build route, but we don't know where he */
-"routing_failed_unknown_my_position" = "現在地が設定されていません。ルートを作成するには現在地を設定してください。";
-
-/* Show if use has not routing file, or InconsistentMWMandRoute */
-"routing_failed_has_no_routing_file" = "ルートを作成するには追加のデータが必要です。ダウンロードを開始しますか？";
-
-/* StartPointNotFound */
-"routing_failed_start_point_not_found" = "ルートを計算できません。出発地点の近くに道路がありません。";
-
-/* EndPointNotFound */
-"routing_failed_dst_point_not_found" = "ルートを計算できません。目的地の近くに道路がありません。";
-
 /* PointsInDifferentMWM */
 "routing_failed_cross_mwm_building" = "一つの地図に完全に収まるルートのみ作成可能です。";
-
-/* RouteNotFound */
-"routing_failed_route_not_found" = "選択した出発地と目的地との間にルートが見つかりません。別の出発地点と到着地点を選択してください。";
-
-/* InternalError */
-"routing_failed_internal_error" = "内部エラーが発生しました。もう一度地図をダウンロードしてください。問題が解決しない場合は、support@organicmaps.appまでご連絡ください。";
-
-/* Context menu item for downloader. */
-"downloader_download_map_and_routing" = "地図とルートをダウンロード";
-
-/* Context menu item for downloader. */
-"downloader_download_routing" = "ルートをダウンロード";
-
-/* Context menu item for downloader. */
-"downloader_delete_routing" = "ルートを削除";
 
 /* Context menu item for downloader. */
 "downloader_download_map" = "地図をダウンロード";
 
-"downloader_download_map_no_routing" = "ルートなしで地図をダウンロード";
-
-/* Button for routing. */
-"routing_go" = "開始！";
-
 /* Item status in downloader. */
 "downloader_retry" = "リピート";
-
-/* Item in context menu. */
-"downloader_map_and_routing" = "地図とルート";
 
 /* Item in context menu. */
 "downloader_delete_map" = "地図を削除";
@@ -668,29 +435,11 @@
 /* Item in context menu. */
 "downloader_update_map" = "地図を更新";
 
-/* Item in context menu. */
-"downloader_update_map_and_routing" = "地図とルートを更新";
-
-/* Item in context menu. */
-"downloader_map_only" = "地図のみ";
-
-/* Toolbar title */
-"toolbar_application_menu" = "アプリケーションメニュー";
-
 /* Preference text */
 "pref_use_google_play" = "現在のロケーションを取得するためにGoogle Playのサービスを使う";
 
 /* Text for rating dialog */
 "rating_just_rated" = "たった今アプリを評価したところです";
-
-/* Text for rating dialog */
-"rating_user_since" = "私は%@年からOrganic Mapsのユーザーです";
-
-/* Text for rating dialog */
-"rating_do_like_maps" = "Organic Mapsをお気に入りいただいていますか？";
-
-/* Text for rating dialog */
-"rating_tap_star" = "星印をタップしてアプリを評価してください。";
 
 /* Text for rating dialog */
 "rating_thanks" = "よろしくお願いします！";
@@ -701,23 +450,8 @@
 /* Text for rating dialog */
 "rating_send_feedback" = "フィードバックを送信";
 
-/* Text for g+ dialog */
-"rating_google_plus" = "g+をクリックして友達にこのアプリを教えてあげましょう。";
-
 /* Text for routing error dialog */
 "routing_download_maps_along" = "ルート上の地図をダウンロード";
-
-/* Text for routing error dialog */
-"routing_download_map" = "地図を入手";
-
-/* Text for routing error dialog */
-"routing_download_map_and_routing" = "最新の地図とルートデータを入手して、Organic Mapsの全機能をご利用ください。";
-
-/* Text for routing error dialog */
-"routing_get_routing_data" = "ルートデータを入手";
-
-/* Text for routing error dialog */
-"routing_get_additional_data" = "現在位置からのルート作成に必要な追加データです。";
 
 /* Text for routing error dialog */
 "routing_requires_all_map" = "ルートの作成には現在位置から目的地までのすべての地図をダウンロードし、最新のものにする必要があります。";
@@ -725,50 +459,15 @@
 /* Text for routing error dialog */
 "routing_not_enough_space" = "空き容量が足りません";
 
-/* Text for routing error dialog */
-"routing_download_more_than_avail" = "%@ MBダウンロードする必要がありますが、%@ MBしか空いていません。";
-
-/* Text for routing error dialog */
-"routing_download_roaming" = "携帯のデータ通信（ローミング）を使用して%@ MBダウンロードしようとしています。これにより、ご利用の通信会社の携帯データプランによっては追加料金が発生する可能性があります。";
-
 /* bookmark button text */
 "bookmark" = "お気に入り";
-
-/* map is not downloaded */
-"not_found_map" = "現在地の地図が見つかりません";
 
 /* location service disabled */
 "enable_location_services" = "位置情報サービスを有効化してください";
 
-/* download map */
-"download_map" = "あなたがいる場所のマップをダウンロードしよう";
-
-/* download map on iPhone */
-"download_map_iphone" = "iPhoneに現在位置の地図をダウンロード";
-
-/* clear pin */
-"nearby" = "近くに";
-
-/* clear pin */
-"clear_pin" = "ピンをクリア";
-
-/* location is undefined */
-"undefined_location" = "現在地が設定されていません。";
-
-/* download country of your location */
-"download_country" = "現在の地域をダウンロード";
-
-/* download failed */
-"download_failed" = "のダウンロードが失敗しました";
-
-/* get the map */
-"get_the_map" = "地図を入手";
-
 "save" = "保存";
 
 "edit_description_hint" = "説明（テキストまたはHTML）";
-
-"new_group" = "新規グループ";
 
 "create" = "作成";
 
@@ -795,30 +494,6 @@
 
 /* pink color */
 "pink" = "ピンク";
-
-/* deep purple color */
-"deep_purple" = "ディープパープル";
-
-/* light blue color */
-"light_blue" = "ライトブルー";
-
-/* cyan color */
-"cyan" = "シアン";
-
-/* teal color */
-"teal" = "ティール";
-
-/* lime color */
-"lime" = "ライム";
-
-/* deep orange color */
-"deep_orange" = "ディープオレンジ";
-
-/* gray color */
-"gray" = "グレイ";
-
-/* blue gray color */
-"blue_gray" = "ブルーグレイ";
 
 /* Wi-Fi available */
 "WiFi_available" = "はい";
@@ -848,13 +523,9 @@
 
 "dialog_routing_location_unknown_turn_on" = "現在地のGPSコードを確認できません。案内ルートを作成するには、位置情報サービスを有効にしてください。";
 
-"dialog_routing_location_unknown" = "現在地のGPSコードを確認できません。";
-
 "dialog_routing_download_files" = "必要なファイルをダウンロードしてください";
 
 "dialog_routing_download_and_update_all" = "案内ルートを作成するには、表示されたパスに従ってすべてのマップ、ルート情報をダウンロード、アップデートしてください。";
-
-"dialog_routing_routes_size" = "ルート情報ファイル";
 
 "dialog_routing_unable_locate_route" = "ルートの位置を確認できません";
 
@@ -884,21 +555,11 @@
 
 "dialog_routing_try_again" = "もう一度お試しください";
 
-"dialog_routing_send_error" = "問題を報告する";
-
-"dialog_routing_if_get_cross_route" = "複数マップを利用してより最適なルートを作成しますか？";
-
-"dialog_routing_cross_route_is_optimal" = "このマップの境界を越えて複数マップを利用すると、より最適なルートを作成できます。";
-
 "not_now" = "あとで";
-
-"dialog_routing_build_route" = "作成する";
 
 "dialog_routing_download_and_build_cross_route" = "マップをダウンロードし、複数マップを利用してより最適なルートを作成しますか？";
 
 "dialog_routing_download_cross_route" = "このマップの境界を越えて複数マップを利用し、より最適なルートを作成するには、マップをダウンロードしてください。";
-
-"dialog_routing_cross_route_always" = "常にこの境界を越える";
 
 
 /********** Strings for downloading map from search **********/
@@ -906,8 +567,6 @@
 "search_without_internet_advertisement" = "検索とルート作成を開始するには、地図をダウンロードしてください。地図をダウンロードすると、インターネット接続は必要なくなります。";
 
 "search_select_map" = "地図を選択";
-
-"search_select_other_map" = "別の地図を選択";
 
 /* «Show» context menu */
 "show" = "表示する";
@@ -918,17 +577,11 @@
 /* «Rename» context menu */
 "rename" = "名前を変更する";
 
-/* Bottom sheet: expand button (should be short) */
-"bottom_sheet_more" = "さらに…";
-
 /* Failed planning route message in navigation view */
 "routing_planning_error" = "ルート検索に失敗";
 
 /* Arrive routing message in navigation view */
 "routing_arrive" = "到着予定: %s";
-
-/* Text for routing::RouterResultCode::FileTooOld dialog. */
-"dialog_routing_download_and_update_maps" = "ルートを作成するには、ルートの通過する地図を全てダウンロード・アップデートしてください。";
 
 "rate_alert_title" = "このアプリが好きですか?";
 
@@ -944,19 +597,11 @@
 
 "history" = "履歴";
 
-"next_turn_then" = "その後";
-
 "closed" = "閉鎖";
-
-"back_to" = "%@に戻る";
 
 "search_not_found" = "申し訳ありませんが該当するものは見つかりませんでした。";
 
 "search_not_found_query" = "別のクエリをお試しください。";
-
-"search_not_found_map" = "検索する地図をダウンロードしてください。";
-
-"search_not_found_location" = "現在地の地図をダウンロードしてください。";
 
 "search_history_title" = "検索履歴";
 
@@ -964,23 +609,12 @@
 
 "clear_search" = "検索履歴を消去";
 
-/* Title for settings to enable/disable showcase menu button */
-"showcase_settings_title" = "オファーを表示";
-
 /* Place Page link to Wikipedia article (if map object has it). */
 "read_in_wikipedia" = "Wikipedia";
 
-"p2p_route_planning" = "ルート作成";
-
 "p2p_your_location" = "現在位置";
 
-"p2p_from" = "出発地";
-
-"p2p_to" = "目的地";
-
 "p2p_start" = "開始";
-
-"p2p_planning" = "作成中…";
 
 "p2p_from_here" = "出発地";
 
@@ -1018,15 +652,9 @@
 
 "editor_correct_mistake" = "間違いの訂正";
 
-"editor_correct_mistake_message" = "編集の間違いがあります。訂正するか、シンプルモードに切り替えてください。";
-
 "editor_add_select_location" = "現在位置";
 
 "editor_done_dialog_1" = "世界地図を変更しました。この変更を秘密にしないでください! 友達に教えて一緒に編集しましょう。";
-
-"editor_done_dialog_2" = "これは2回目の地図改善。現在地図編集者リストで%d位です。";
-
-"editor_done_dialog_3" = "地図を改善したので、友達に教えて一緒に編集しましょう。";
 
 "share_with_friends" = "友達にシェア";
 
@@ -1044,20 +672,7 @@
 
 "editor_report_problem_duplicate_place_title" = "重複している場所";
 
-"first_launch_congrats_title" = "Organic Mapsを使用する準備が整いました";
-
-"first_launch_congrats_text" = "世界中どこでも無料で検索・ナビゲーションできます。";
-
-"migrate_title" = "重要！";
-
-/* Android uses image instead of text. */
-"download_all" = "全てをダウンロード";
-
-"delete_all" = "すべて削除";
-
 "autodownload" = "自動ダウンロード";
-
-"disable_autodownload" = "自動ダウンロードを無効にする";
 
 /* Place Page opening hours text */
 "closed_now" = "現在閉店";
@@ -1072,10 +687,6 @@
 "day_off" = "終業";
 
 "today" = "今日は";
-
-"sunrise_to_sunset" = "日の出から日没まで";
-
-"sunset_to_sunrise" = "日の出から日没まで";
 
 "add_opening_hours" = "営業時間を追加";
 
@@ -1095,45 +706,18 @@
 
 "forgot_password" = "パスワードをお忘れですか？";
 
-/* Forgot Password dialog title */
-"restore_password" = "パスワードを復元";
-
-"enter_email_address_to_reset_password" = "登録の際に使用したメールアドレスを入力してください。パスワードを更新するリンクをお送りします。";
-
-"reset_password" = "パスワードをリセット";
-
-"username" = "ユーザー名";
-
 "osm_account" = "OSMアカウント";
 
 "logout" = "ログアウト";
 
-"login_and_edit_map_motivation_message" = "ログインしてマップ上のオブジェクトの詳細を編集すると、何百万人もの他のユーザーがその情報を利用できるようになります。一緒により良い世界を作りましょう。";
-
 /* Information text: "Last upload 11.01.2016" */
 "last_upload" = "最終更新";
 
-/* Motivates user to login/register, title above login buttons. */
-"you_have_edited_your_first_object" = "初めてオブジェクトを編集しました！";
-
 "thank_you" = "ありがとうございます";
-
-"login_with_google" = "Googleでログイン";
-
-"login_with_openstreetmap" = "www.openstreetmap.orgでログインしてください";
 
 "edit_place" = "場所を編集";
 
 "place_name" = "場所の名前";
-
-/* title above languages list cells in the editor, below editable name text field. */
-"other_languages" = "その他の言語";
-
-/* small button to open list with names in different languages */
-"show_more" = "もっと表示";
-
-/* small button to close list with names in different languages */
-"show_less" = "少なく表示";
 
 "add_language" = "言語を追加";
 
@@ -1164,8 +748,6 @@
 
 "please_note" = "ご注意ください";
 
-"common_no_wifi_dialog" = "WiFi接続がありません。モバイルデータ通信を続行しますか?";
-
 "downloader_delete_map_dialog" = "この地図を削除すると、今まで行った変更の全ても一緒に削除されます。";
 
 "downloader_update_maps" = "地図をアップデート";
@@ -1173,10 +755,6 @@
 "downloader_mwm_migration_dialog" = "ルートを作成するには、全ての地図をアップデートした後で再びルート計画を行う必要があります。";
 
 "downloader_search_field_hint" = "地図を検索";
-
-"migration_update_all_button" = "全ての地図をアップデート";
-
-"migration_delete_all_download_current_button" = "現在の地図をダウンロードして古い地図を削除";
 
 "migration_download_error_dialog" = "ダウンロードエラー";
 
@@ -1186,21 +764,9 @@
 
 "downloader_no_space_message" = "不必要なデータを削除してください";
 
-"editor_general_auth_error_dialog" = "一般的なログインエラー。";
-
 "editor_login_error_dialog" = "ログインエラー。";
 
-"editor_login_failed_dialog" = "ログインに失敗しました";
-
-"editor_username_error_dialog" = "ユーザー名が無効です";
-
-"editor_place_edited_dialog" = "オブジェクトを編集しました!";
-
-"editor_login_with_osm" = "OpenStreetMapを使ってログイン";
-
 "editor_profile_changes" = "確認された変更";
-
-"editor_profile_unsent_changes" = "未送信：";
 
 "editor_focus_map_on_location" = "地図を操作してオブジェクトの正しい場所を選択します。";
 
@@ -1222,13 +788,9 @@
 
 "editor_report_problem_other_title" = "異なる問題";
 
-"placepage_report_problem_button" = "問題を報告";
-
 "placepage_add_business_button" = "団体を追加";
 
 "whatsnew_editor_message_1" = "アプリから直接地図に新しい場所を追加したり、既存の場所を編集できます。";
-
-"whatsnew_editor_message_2" = "* Organic MapsはOpenStreetMapコミュニティのデータを使用しています。";
 
 "dialog_incorrect_feature_position" = "位置を変更してください";
 
@@ -1236,16 +798,10 @@
 
 "login_to_make_edits_visible" = "他のユーザーにも変更が表示されるようログインしてください。";
 
-"no_migration_during_navigation" = "ナビゲーション中は更新できません。";
-
 /* Error dialog no space */
 "migration_no_space_message" = "ダウンロードするには空き容量がさらに必要です。不必要なデータを削除してください。";
 
 "editor_sharing_title" = "Organic Mapsの地図を改善しました";
-
-"editor_comment_will_be_sent" = "いただいたコメントを地図製作者に送ります。";
-
-"editor_unsupported_category_message" = "現在未対応のカテゴリーの場所を追加しました。地図には後程表示されるようになります。";
 
 /* Downloaded 10 **of** 20 <- it is that "of" */
 "downloader_of" = "%2$d中%1$d";
@@ -1278,23 +834,9 @@
 
 "editor_operator" = "オペレーター";
 
-"editor_tag_description" = "施設を管理する企業、組織または個人を入力してください。";
-
-"editor_no_local_edits_title" = "ローカル編集はできません";
-
-"editor_no_local_edits_description" = "これは、現在お使いのデバイスでのみアクセス可能な、マップ上に提案された変更の数を示しています。";
-
-"editor_send_to_osm" = "OSMに送信";
-
-"editor_remove" = "削除";
-
-"downloader_my_maps_title" = "マイマップ";
-
 "downloader_no_downloaded_maps_title" = "マップをダウンロードしていません";
 
 "downloader_no_downloaded_maps_message" = "ロケーションの検索とオフラインナビゲートのためにマップをダウンロードしてください。";
-
-"downloader_find_place_hint" = "都市や国を検索";
 
 /* Error title that appears after certain time without location. */
 "current_location_unknown_title" = "あなたの現在地を検出し続けますか？";
@@ -1321,47 +863,13 @@
 /* iOS Dialog for the case when the location permission is not granted */
 "location_services_disabled_3" = "3. アプリの使用中を選択してください";
 
-"placepage_parking_surface" = "表面";
-
-"placepage_parking_multistorey" = "複数階";
-
-"placepage_parking_underground" = "地下";
-
-"placepage_parking_rooftop" = "屋上";
-
-"placepage_parking_sheds" = "小屋";
-
-"placepage_parking_carports" = "カーポート";
-
-"placepage_parking_boxes" = "ガレージボックス";
-
-"placepage_parking_pay" = "支払い";
-
-"placepage_parking_free" = "無料";
-
-"placepage_parking_interval" = "支払間隔";
-
-"placepage_entrance_number" = "番号";
-
-"placepage_entrance_type" = "エントランス";
-
-"placepage_flat" = "アプリ";
-
-"placepage_open_24_7" = "24時間体制";
-
 "meter" = "m";
 
 "kilometer" = "km";
 
-"kilometers_per_hour" = "キロメートル毎時";
-
 "mile" = "マイル";
 
 "foot" = "フィート";
-
-"miles_per_hour" = "マイル毎時";
-
-"day" = "日";
 
 "hour" = "時間";
 
@@ -1381,10 +889,6 @@
 
 "placepage_bookmark_name_hint" = "ブックマーク名";
 
-"placepage_personal_notes_hint" = "パーソナルメモ";
-
-"placepage_delete_bookmark_button" = "ブックマークを削除";
-
 "editor_edits_sent_message" = "あなたの提案の変更が送信されました";
 
 "editor_comment_hint" = "コメント…";
@@ -1397,8 +901,6 @@
 
 "editor_remove_place_button" = "削除";
 
-"editor_status_sending" = "送信中…";
-
 "editor_place_doesnt_exist" = "存在しない場所";
 
 "text_more_button" = "…続き";
@@ -1410,11 +912,7 @@
 
 "error_enter_correct_email" = "有効なメールアドレスを入力してください";
 
-"error_enter_correct" = "有効な値を入力してください";
-
 "refresh" = "更新";
-
-"last_update" = "最終更新日: %s";
 
 "placepage_add_place_button" = "地図上に場所を追加";
 
@@ -1426,24 +924,6 @@
 
 "editor_share_to_all_dialog_message_2" = "弊社で変更を確認します。質問がある場合はメールでご連絡します。";
 
-"navigation_overview_button" = "概要";
-
-"navigation_stop_button" = "停止";
-
-/* Text on an empty bookmark page */
-"bookmarks_empty_title" = "ブックマークを保存";
-
-"bookmarks_empty_message_1" = "★をタップしてお気に入りの場所にクイックアクセス。";
-
-"bookmarks_empty_message_2" = "メールやウェブからブックマークをインポートする。";
-
-"bookmarks_empty_message_3" = "チェックアウト：%s";
-
-/* Name of the group for booked hotels */
-"bookmarks_group_name" = "予約したホテル";
-
-"place_page_button_read_descriprion" = "詳細";
-
 /* iOS dialog for the case when recent track recording is on and the app comes back from background */
 "recent_track_background_dialog_title" = "最近の走行ルートの記録を無効にしますか？";
 
@@ -1451,8 +931,6 @@
 
 /* For sharing via SMS and so on */
 "sharing_call_action_look" = "ご覧ください";
-
-"continue_recent_track_background_button" = "続行";
 
 "recent_track_background_dialog_message" = "Organic Mapsは、あなたの位置情報をバックグラウンドで使用して最近の走行ルートを記録します。";
 
@@ -1468,33 +946,13 @@
 /* About short text (below logo) */
 "about_description" = "Organic Maps は旅に必要不可欠なオフラインアプリケーションです。Organic Maps は OpenStreetMap データに基づいており、データを編集することができます。";
 
-/* Text in menu */
-"blog" = "ブログ";
-
 "general_settings" = "一般設定";
-
-"date" = "日付 %d";
-
-/* "Report a bug" -> "Generaal Feedback" -> "Something is not working" */
-"something_is_not_working" = "動作が変です";
 
 /* For the first routing */
 "accept" = "了解";
 
-"accept_and_continue" = "Accept and continue";
-
 /* For the first routing */
 "decline" = "拒否";
-
-"install_app" = "インストール";
-
-"search_no_results_title" = "結果が見つかりません";
-
-"search_no_results_message" = "一般的な検索語句や、フィルター範囲を広げたりリセットしたりしてください。";
-
-"search_no_results_expand_area_button" = "広げる";
-
-"search_no_results_reset_button" = "フィルターをリセット";
 
 /* noun */
 "search_in_table" = "一覧";
@@ -1517,8 +975,6 @@
 
 "traffic_update_maps_text" = "交通データを表示するには、地図を更新する必要があります。";
 
-"traffic_outdated" = "交通データが古くなっています。";
-
 "big_font" = "地図上のフォントサイズを大きく";
 
 "traffic_update_app" = "Organic Maps をアップデートしてください";
@@ -1529,17 +985,7 @@
 /* "traffic" as in "road congestion" */
 "traffic_data_unavailable" = "交通データは利用できません";
 
-/* "Translation is no needed, because it's a company name" */
-"uber" = "Uber";
-
-/* Simplified colour scheme for traffic information, fewer colours are used to display traffic jams on the map. The string should be kept as short as possible */
-"pref_traffic_simplified_colors_title" = "簡易的な交通状況色";
-
 "enable_logging" = "ログを有効化";
-
-"offline_place_page_more_information" = "この場所に関する詳細情報を取得するには、インターネットに接続してください。";
-
-"failed_load_information" = "情報の読み込みに失敗しました。";
 
 /* Settings: "Send general feedback" button */
 "feedback_general" = "一般的なフィードバック";
@@ -1556,8 +1002,6 @@
 
 "whatsnew_transliteration_title" = "ラテン文字への字訳";
 
-"yandex_taxi_title" = "Yandex.Taxi";
-
 "learn_more" = "詳細情報";
 
 "core_exit" = "終了";
@@ -1568,75 +1012,19 @@
 
 "button_exit" = "終了";
 
-"settings_device_memory" = "デバイスのメモリ";
-
-"settings_card_memory" = "カードのメモリ";
-
-"settings_storage_available" = "%s 使用可能";
-
-"toast_location_permission_denied" = "アプリの位置情報へのアクセスが拒否されました";
-
-"button_use" = "使う";
-
 "planning_route_manage_route" = "ルートを編集";
 
 "button_plan" = "適用する";
-
-"button_add" = "追加";
 
 "placepage_remove_stop" = "削除";
 
 "planning_route_remove_title" = "ここにドラッグして削除";
 
-"dialog_change_start_point_message" = "出発地点を現在の場所に変更しますか？";
-
-"button_replace" = "変更する";
-
 "placepage_add_stop" = "経由地点を追加";
-
-/* Only ru/en are needed */
-"subtitle_rent" = "Rent";
-
-/* Only ru/en are needed */
-"rub_month" = "RUB/month";
-
-/* Only ru/en are needed */
-"room" = "%s-room apt.";
-
-/* Only ru/en are needed */
-"real_estate" = "Real estate";
-
-"add_my_position" = "自分の場所を追加";
-
-"choose_start_point" = "出発地点を選択";
-
-"choose_destination" = "目的地を選択";
 
 "preloader_viator_button" = "詳細情報";
 
-"start_from_my_position" = "開始位置";
-
-"profile_authorization_title" = "サインイン方法";
-
-"profile_authorization_message" = "ログイン名とパスワードなしですぐに簡単にサインインできます";
-
 "profile_authorization_error" = "エラーが発生しました。もう一度サインインしてみてください。";
-
-"service" = "サービス";
-
-"atmosphere" = "雰囲気";
-
-"value_for_money" = "金額に見合う価値";
-
-"experience" = "経験";
-
-"assortment" = "品揃え";
-
-"expertise" = "専門知識";
-
-"equipment" = "設備";
-
-"quality" = "品質";
 
 "dialog_error_storage_title" = "ストレージアクセスの問題";
 
@@ -1644,17 +1032,7 @@
 
 "setting_emulate_bad_storage" = "壊れたストレージをエミュレート";
 
-"directions_finish" = "目的地";
-
-"directions_on_foot" = "徒歩 %s";
-
 "core_entrance" = "入口";
-
-"coffee" = "コーヒー";
-
-"cleanliness" = "清潔さ";
-
-"crowdedness" = "混雑度";
 
 "error_enter_correct_name" = "正しい名前を入力してください";
 
@@ -1673,11 +1051,9 @@
 
 "downloader_percent" = "%s (%s / %s)";
 
-"downloader_process" = "%s をダウンロードしています...";
+"downloader_process" = "%s をダウンロードしています…";
 
-"downloader_applying" = "%s を適用中です...";
-
-"dialog_message_transit_not_found_connection" = "1つの交通ネットワーク内でルートを作成";
+"downloader_applying" = "%s を適用中です…";
 
 "bookmarks_error_message_share_general" = "アプリケーションエラーのため共有できません";
 
@@ -1695,17 +1071,7 @@
 
 "bookmarks_error_message_list_name_already_taken" = "別の名前を選んでください";
 
-"bookmarks_error_title_list_name_too_long" = "この名前は長すぎます";
-
-"bookmarks_error_message_list_name_too_long" = "別の名前を選んでください";
-
-"please_wait" = "お待ちください...";
-
-"phone_number" = "電話番号";
-
-"notification_unsent_reviews_title" = "あなたはいくつかの未送信のレビューを持っています";
-
-"notification_unsent_reviews_message" = "他の旅行者とレビューを共有するにはログインしてください";
+"please_wait" = "お待ちください…";
 
 "profile" = "OpenStreetMap プロフィール";
 
@@ -1719,49 +1085,13 @@
 
 "bookmarks_convert_error_message" = "一部のファイルは変換されませんでした。";
 
-"converting" = "変換中...";
-
-"wn_reinvented_bookmarks_title" = "ブックマークを作り直しました！";
-
-"wn_reinvented_bookmarks_message" = "あなたはブックマークをバックアップし、リストを作成することができます...それは素晴らしいです...";
-
-"bookmarks_restore" = "ブックマークを復元する";
-
-"bookmarks_restore_process" = "復元中...";
-
 "bookmarks_restore_title" = "このバージョンを復元しますか？";
 
-"bookmarks_restore_message" = "ブックマークは%s (%s)から復元されます";
-
-"bookmarks_restore_empty_title" = "あなたはバックアップを持っていません";
-
-"bookmarks_restore_empty_message" = "サーバーは以前に作成したバックアップを見つけられませんでした";
-
 "common_check_internet_connection_dialog_title" = "インターネット接続なし";
-
-"error_server_title" = "サーバーエラー";
-
-"error_server_message" = "サーバーにエラーがありました。後でもう一度お試しください";
 
 "error_system_message" = "不明なエラーが発生しました";
 
 "restore" = "リストア";
-
-"bookmarks_page_downloaded" = "ダウンロード済み";
-
-"bookmarks_page_my" = "私の";
-
-"routes_and_bookmarks" = "ルートとブックマーク";
-
-"bookmarks_webview_success_toast" = "ブックマークが正常にダウンロードされました";
-
-"cached_bookmarks_placeholder_title" = "新しい場所をダウンロード";
-
-"cached_bookmarks_placeholder_subtitle" = "Organic Mapsユーザーが作成した数千ものおもしろい場所やルートをダウンロードするには、このボタンを押します。インターネット接続が必要です。";
-
-"downloader_download_routers" = "ブックマークをダウンロード";
-
-"bookmarks_groups_cached" = "ダウンロード済みリスト";
 
 "subtittle_opt_out" = "追跡の設定";
 
@@ -1769,29 +1099,15 @@
 
 "crash_reports_description" = "Organic Maps体験を向上させるため、お客様のデータを使用する可能性があります。変更は、アプリを再起動した後に、反映されます。";
 
-"opt_out_help_ios_1" = "お使いの携帯端末には、「追跡型広告を制限」または「関心に基づく広告を非表示」の設定があるかもしれません。";
-
-"opt_out_help_ios_2" = "iOS 9以降";
-
-"opt_out_help_ios_3" = "設定→プライバシー→広告に進み、「追跡型広告を制限」を有効にします";
-
-"opt_out_help_android" = "お使いの携帯端末には、「追跡型広告を制限」または「関心に基づく広告を非表示」の設定があるかもしれません。\n\nAndroid、Google Play Servicesバージョン4.0以降：\n設定→Google→広告→広告パーソナライゼーションの提供停止\nor\n設定→Google→Googleアカウント→個人情報とプライバシー→広告設定→広告パーソナライゼーション";
-
 "privacy_policy" = "個人情報保護方針";
 
 "terms_of_use" = "ご利用規約";
-
-"backup_notification_failed" = "ブックマークのバックアップが中断されました。ログインして、元に戻します。";
 
 "button_layer_traffic" = "交通状況";
 
 "button_layer_subway" = "地下鉄";
 
 "layers_title" = "マップレイヤー";
-
-"layers_message" = "マップレイヤーを使用して、交通状況、地下鉄路線図、その他の有益な情報を表示";
-
-"button_layer_got_it" = "了解";
 
 "subway_data_unavailable" = "地下鉄路線図はご利用いただけません";
 
@@ -1803,39 +1119,13 @@
 
 "title_error_downloading_bookmarks" = "エラーが発生しました";
 
-"subtitle_error_downloading_bookmarks" = "ブックマークはダウンロードされませんでした";
-
-"error_already_downloaded" = "このリストは既にダウンロード済みです";
-
 "popular_place" = "Popular";
-
-"download_routes" = "Download routes";
-
-"bookmarks_downloaded_title" = "Bookmarks have been downloaded successfully";
-
-"bookmarks_downloaded_subtitle" = "Press ‘View on map’ to explore new places from the list";
-
-"why_support" = "Organic Mapsをサポートする理由？";
-
-"why_support_item1" = "We respect your privacy: there are zero trackers in the app, and we are open source";
-
-"why_support_item2" = "Organic Mapsの改善にご協力いただいております";
-
-"why_support_item3" = "オープンマップOpenStreetMap.orgの改善にご協力いただいております";
-
-"channels_map_update" = "地図の更新";
-
-"server_unavailable_title" = "サーバーは利用できません";
-
-"sharing_options" = "オプションの共有";
 
 "export_file" = "ファイルのエクスポート";
 
 "list_settings" = "リスト設定";
 
 "delete_list" = "リスト削除";
-
-"hide_from_map" = "マップから隠す";
 
 "public_access" = "パブリック・アクセス";
 
@@ -1845,40 +1135,11 @@
 
 "bookmark_category_description_hint" = "説明(テキストまたはhtml)を記入してください";
 
-/* FIXME */
-"bookmarks_public_access" = "bookmarks_public_access";
-
-/* FIXME */
-"bookmarks_link_access" = "bookmarks_link_access";
-
-/* FIXME */
-"bookmarks_private_access" = "bookmarks_private_access";
-
 "not_shared" = "非公開";
-
-"direct_link_progress_text" = "あなたのファイルをアップロードしています…";
-
-"direct_link_success" = "リンクが作成されました";
-
-"send_a_link_btn" = "リンクを自分に送る";
-
-"upload_error_toast" = "ファイルのアップロード中にエラーが起きました";
 
 "tags_loading_error_subtitle" = "タグのロード中にエラーが起きました。もう一度やり直してください";
 
-"unable_upload_errorr_title" = "ファイルのアップロードができませんでした";
-
-"unable_upload_error_subtitle_edited" = "このファイルはウェブアプリで編集されました";
-
-"unable_upload_error_subtitle_broken" = "このファイルは損傷しており、アップロードできませんでした。別のファイルをアップロードしてください。";
-
-"contact" = "連絡";
-
-"download_button" = "ダウンロード";
-
 "speedcams_alert_title" = "自動速度違反取締装置";
-
-"speedcams_alert_subtitle" = "速度制限警告";
 
 "speedcam_option_auto" = "自動";
 
@@ -1886,18 +1147,10 @@
 
 "speedcam_option_never" = "無効";
 
-"bookmark_description_title" = "ブックマークの説明";
-
 "place_description_title" = "場所の説明";
 
 /* this text will be shown in application notification preferences opposite checkbox which enable/disable downloader notifications. Devices on Android 8+ are affected. */
 "notification_channel_downloader" = "マップダウンローダー";
-
-"share_bookmarks_email_body_link" = "こんにちは!\n\nこれはあなたのブックマークをダウンロードできるリンクです:%s。Organic Mapsを通じてリストを開いて旅をお楽しみください!\n\nアプリの入手: https://omaps.app/get?kmz";
-
-"warning_speedcams_title" = "%d km/hの速度制限を超えているときナビゲーターが自動速度違反取締装置について警告します";
-
-"warning_speedcams_subtitle" = "旅行先の国の道路交通法を考慮してください。";
 
 "speedcams_notice_message" = "自動－速度制限超過の危険性がある場合には、自動速度違反取締装置について警告します\n常時－自動速度違反取締装置について常に警告します\n無効－自動速度違反取締装置を警告しません";
 
@@ -1913,23 +1166,7 @@
 
 "enable_logging_warning_message" = "このオプションは診断目的でのデータ記録を有効にします。これはこのアプリケーションのトラブルシューティングを担当する当社のサポートスタッフの助けになります。このオプションはOrganic Mapsにリクエストされた場合にのみ有効にしてください。";
 
-"html_error_upload_message_try_again" = "ネットワーク設定をチェックして、もう一度お試しください";
-
-"html_error_upload_title_try_again" = "インターネットに接続していません";
-
-"notification_leave_review_v2_android_short_title" = "レビューして旅行者を助けましょう！";
-
-"megafon" = "Say goodbye to roaming!";
-
-"notifications_illegal_alert_disable_button" = "通知を無効化";
-
 "access_rules_author_only" = "オンライン編集";
-
-"privacy_settings_menu" = "プライバシー設定";
-
-"unable_upadate_error_title" = "ファイルが更新できませんでした";
-
-"unable_upadate_error_message" = "更新中に何かミスが発生しました。変更を確認して、もう一度お試しください";
 
 "driving_options_title" = "運転オプション";
 
@@ -1951,94 +1188,19 @@
 
 "change_driving_options_btn" = "運転オプションはアクティブです";
 
-"toll_road" = "有料道路";
-
-"unpaved_road" = "未舗装道路";
-
-"ferry_crossing" = "フェリー航路";
-
-"operated_by" = "\"%s\"で稼働";
-
 "avoid_toll_roads_placepage" = "有料道路を回避";
 
 "avoid_unpaved_roads_placepage" = "未舗装道路を回避";
 
 "avoid_ferry_crossing_placepage" = "フェリー航路を回避";
 
-"type.cuisine.uzbek" = "ウズベキスタン料理";
-
-"trip_start" = "レッツゴー";
-
-"pick_destination" = "目的地";
-
-"follow_my_position" = "リセンター";
-
-"search_results" = "検索結果";
-
-"then_turn" = "その後";
-
-"redirect_route_alert" = "ルートを再構築しますか?";
-
-"redirect_route_yes" = "はい";
-
-"redirect_route_no" = "いいえ";
-
-"trip_finished" = "到着しました!";
-
-"keyboard_availability_alert" = "運転中はキーボードを使用する事はできません";
-
-"dialog_routing_change_start_carplay" = "現在位置からはルートを構築できません";
-
-"dialog_routing_change_end_carplay" = "目的地へのルートは構築できません。別の地点を選択してください";
-
-"dialog_routing_check_gps_carplay" = "GPS信号がありません。開けた場所へ移動してください";
-
-"dialog_routing_unable_locate_route_carplay" = "ルートが構築できません。別のルート地点を設定して下さい";
-
-"dialog_routing_download_files_carplay" = "ルートを作成するには、地図に表示されていない部分を端末でダウンロードします";
-
-"dialog_routing_system_error_carplay" = "エラーが発生しました。アプリを再起動してください";
-
-"dialog_routing_rebuild_from_current_location_carplay" = "ルートは現在位置から再構築されます";
-
-"dialog_routing_rebuild_for_vehicle_carplay" = "ルートは自動車用として修正されます";
-
 "ok" = "OK";
-
-"avoid_unpaved_carplay_1" = "未舗装道路無し";
-
-"avoid_unpaved_carplay_2" = "未舗装道路無し";
-
-"avoid_ferry_carplay_1" = "フェリー無し";
-
-"avoid_ferry_carplay_2" = "フェリーを回避";
-
-"avoid_tolls_carplay_1" = "有料道路無し";
-
-"avoid_tolls_carplay_2" = "有料道路を回避";
-
-"speedcams_alert_title_carplay_1" = "速度警告";
-
-"speedcams_alert_title_carplay_2" = "速度警告";
-
-"download_map_carplay" = "あなたの機器のOrganic Mapsのアプリにマップをダウンロードしてください";
-
-"carplay_roundabout_exit" = "第%s出口";
 
 /* max. 10 symbols, both iOS and Android */
 "sort" = "並び替え中…";
 
 /* Android, title, max 20-22 symbols */
 "sort_bookmarks" = "ブックマークの並び替え";
-
-/* iOS */
-"sort_default" = "デフォルトで並び替え";
-
-"sort_type" = "タイプで並び替え";
-
-"sort_distance" = "距離で並び替え";
-
-"sort_date" = "日付で並び替え";
 
 /* Android */
 "by_default" = "デフォルトで";
@@ -2052,63 +1214,7 @@
 /* Android */
 "by_date" = "日付で";
 
-"week_ago_sorttype" = "1週間前";
-
-"month_ago_sorttype" = "1ケ月前";
-
-"moremonth_ago_sorttype" = "1ケ月以上前";
-
-"moreyear_ago_sorttype" = "1年以上前";
-
-"near_me_sorttype" = "近隣";
-
-"others_sorttype" = "その他";
-
-"food_places" = "食べ物";
-
-"tourist_places" = "観光地";
-
-"museums" = "博物館";
-
-"parks" = "公園";
-
-"swim_places" = "水泳";
-
-"mountains" = "山";
-
-"animals" = "動物園";
-
-"hotels" = "ホテル";
-
-"buildings" = "ビル";
-
-"money" = "金銭";
-
-"shops" = "ショップ";
-
-"parkings" = "駐車場";
-
-"fuel_places" = "ガソリンスタンド";
-
-"water" = "水";
-
-"medicine" = "医薬品";
-
 "search_in_the_list" = "リスト内で検索";
-
-"view_on_map_bookmarks" = "マップ上";
-
-"more_bookmarks" = "更に…";
-
-"no_items_found" = "何も見つかりませんでした";
-
-/* Android, max 18 symbols */
-"bookmarks_edit_list" = "リストの編集";
-
-/* Android, max 18 symbols */
-"bookmarks_delete_list" = "リストの削除";
-
-"religious_places" = "宗教に関連した場所";
 
 "select_list" = "リストを選択";
 
@@ -2118,26 +1224,13 @@
 
 "dialog_pedestrian_route_is_long_message" = "もっと地下鉄駅に近い出発地または目的地を選択してください";
 
-/* Failed planning SUBWAY route message in navigation view */
-"routing_planning_error_subway_special" = "地下鉄ルートの計画ができませんでした";
-
 "button_layer_isolines" = "地形";
-
-"tips_map_layers_title_countour" = "Organic Mapsの新要素：オフラインのトポグラフィーレイヤー！";
-
-"tips_map_layers_message_countour" = "自然の旅で訪れる地域を全てを把握しながら計画を立て楽しみましょう";
 
 "isolines_activation_error_dialog" = "トポグラフィーレイヤーを有効化して使用するには、このエリアのマップを更新もしくはダウンロードしてください";
 
 "isolines_location_error_dialog" = "トポグラフィーレイヤーはこの地域ではまだ利用できません";
 
 "elevation_profile_diff_level" = "難易度";
-
-"elevation_profile_diff_level_easy" = "イージー";
-
-"elevation_profile_diff_level_moderate" = "ノーマル";
-
-"elevation_profile_diff_level_hard" = "ハード";
 
 "elevation_profile_ascent" = "上昇";
 
@@ -2147,25 +1240,13 @@
 
 "elevation_profile_maxaltitude" = "最大高度";
 
-"elevation_profile_m" = "m";
-
 "elevation_profile_difficulty" = "難易度";
 
 "elevation_profile_distance" = "距離：";
 
-"elevation_profile_km" = "㎞";
-
 "elevation_profile_time" = "時間：";
 
-"elevation_profile_hours" = "時間";
-
-"elevation_profile_minutes" = "分";
-
 "isolines_toast_zooms_1_10" = "等高線を調べるためにズームインしましょう";
-
-"downloader_updating_ios" = "更新中";
-
-"downloader_loading_ios" = "ダウンロード中";
 
 "key_information_title" = "重要情報";
 

--- a/iphone/Maps/LocalizedStrings/ja.lproj/Localizable.stringsdict
+++ b/iphone/Maps/LocalizedStrings/ja.lproj/Localizable.stringsdict
@@ -9,21 +9,6 @@
 
 <!-- ********** Strings for downloading map from search **********/ -->
 
-  <key>bookmarks_places</key>
-  <dict>
-    <key>NSStringLocalizedFormatKey</key>
-    <string>%#@value@</string>
-    <key>value</key>
-    <dict>
-      <key>NSStringFormatSpecTypeKey</key>
-      <string>NSStringPluralRuleType</string>
-      <key>NSStringFormatValueTypeKey</key>
-      <string>d</string>
-      <key>other</key>
-      <string>%d個のブックマーク</string>
-    </dict>
-  </dict>
-
   <key>bookmarks_detect_message</key>
   <dict>
     <key>NSStringLocalizedFormatKey</key>
@@ -36,21 +21,6 @@
       <string>d</string>
       <key>other</key>
       <string>%d ファイルが見つかりました。 あなたは変換後にそれらを見るでしょう。</string>
-    </dict>
-  </dict>
-
-  <key>bookmarks_objects</key>
-  <dict>
-    <key>NSStringLocalizedFormatKey</key>
-    <string>%#@value@</string>
-    <key>value</key>
-    <dict>
-      <key>NSStringFormatSpecTypeKey</key>
-      <string>NSStringPluralRuleType</string>
-      <key>NSStringFormatValueTypeKey</key>
-      <string>d</string>
-      <key>other</key>
-      <string>%sのオブジェクト</string>
     </dict>
   </dict>
 

--- a/iphone/Maps/LocalizedStrings/ko.lproj/Localizable.strings
+++ b/iphone/Maps/LocalizedStrings/ko.lproj/Localizable.strings
@@ -18,9 +18,6 @@
 /* Button which deletes downloaded country */
 "delete" = "삭제하기";
 
-/* Button "do not interrupt download" if user touched actively downloading country */
-"do_nothing" = "아무것도 하지 마세요";
-
 "download_maps" = "지도 다운로드받기";
 
 /* Settings/Downloader - info for country when download fails */
@@ -28,9 +25,6 @@
 
 /* Settings/Downloader - info for country which started downloading */
 "downloading" = "다운로드 중…";
-
-/* Settings/Downloader - size string, only strings different from English should be translated */
-"kb" = "kB";
 
 /* Choose measurement on first launch alert - choose metric system button */
 "kilometres" = "킬로미터";
@@ -55,17 +49,11 @@
 /* Update maps later/Buy pro version later button text */
 "later" = "후";
 
-/* Don't show some dialog any more */
-"never" = "거절";
-
 /* View and button titles for accessibility */
 "search" = "검색하기";
 
 /* Search box placeholder text */
 "search_map" = "지도 검색하기";
-
-/* Settings/Downloader - info for not downloaded country */
-"touch_to_download" = "두드려 다운로드하세요";
 
 /* Settings/Downloader - 3G download warning dialog confirm button */
 "use_cellular_data" = "네";
@@ -73,20 +61,11 @@
 /* Location services are disabled by user alert - message */
 "location_is_disabled_long_text" = "현재 이 장치나 애플리케이션을 위한 전 위치 서비스를 불능시키셨습니다. 설정에서 이를 작동시켜 주시기 바랍니다.";
 
-/* Location Services are not available on the device alert - message */
-"device_doesnot_support_location_services" = "귀하의장치가 위치 서비스를 지원하지 않습니다.";
-
 /* View and button titles for accessibility */
 "zoom_to_country" = "지도에 표시";
 
-/* Button text for the button at the center of the screen when the country is not downloaded */
-"country_status_download" = "지도 다운로드\n(^ ^)";
-
 /* Button text for the button at the center of the screen when the country is not downloaded and the size should not be shown */
 "country_status_download_without_size" = "지도 다운로드";
-
-/* Button text for the button at the center of the screen when the country is not downloaded */
-"country_status_download_without_routing" = "라우팅없이 지도 다운로드\n(^ ^)";
 
 /* Message to display at the center of the screen when the country download has failed */
 "country_status_download_failed" = "다운로드에 실패하였습니다";
@@ -96,19 +75,13 @@
 
 "about_menu_title" = "소개";
 
-"downloaded_touch_to_delete" = "(%@)가 다운로드 되었습니다, 두드려 삭제하십시요.";
-
 "connection_settings" = "연결 설정";
-
-"download_mb_or_kb" = "%@ 다운로드하기";
 
 "close" = "닫기";
 
 "unsupported_phone" = "하드웨어 촉진 OpenGL이 요구됩니다. 애석하게도 귀하의 장치는 지원되지 않습니다.";
 
 "download" = "다운로드";
-
-"external_storage_is_not_available" = "다운로드된지도와 SD 카드 / USB 저장 장치를 사용할 수 없습니다";
 
 "disconnect_usb_cable" = "Organic Maps를 사용하려면 USB 케이블이나 삽입 메모리 카드를 분리하십시오";
 
@@ -117,8 +90,6 @@
 "not_enough_memory" = "응용 프로그램을 실행하기위한 메모리가 충분하지 않다";
 
 "download_resources" = "시작하시기 전에 일반 세계 지도를 귀하의 장치로 다운로드하겠습니다.\n%@ 데이터가 필요합니다.";
-
-"getting_position" = "현재 위치 얻기";
 
 "download_resources_continue" = "지도로 이동";
 
@@ -140,23 +111,14 @@
 /* Add New Bookmark Set dialog title */
 "add_new_set" = "새로운 세트 추가";
 
-/* Place Page - Add To Bookmarks button */
-"add_to_bookmarks" = "즐겨찾기에 추가";
-
 /* Bookmark Color dialog title */
 "bookmark_color" = "색상 즐겨찾기에 추가";
 
 /* Add Bookmark Set dialog - hint when set name is empty */
 "bookmark_set_name" = "집합 이름을 즐겨찾기에 추가";
 
-/* Bookmark Sets dialog title */
-"bookmark_sets" = "세트를 즐겨찾기에 추가";
-
 /* Bookmarks - dialog title */
 "bookmarks" = "북마크";
-
-/* Add bookmark dialog - bookmark color */
-"color" = "색깔";
 
 /* Default bookmarks set name */
 "core_my_places" = "내 장소";
@@ -167,14 +129,8 @@
 /* Editor title above street and house number */
 "address" = "주소";
 
-/* Place Page - Remove Pin button */
-"remove_pin" = "핀 제거";
-
 /* Add bookmark dialog - bookmark set, Bookmarks dialog - Bookmark set cell */
 "set" = "집합";
-
-/* Text hint in Bookmarks dialog when no any bookmarks are added */
-"bookmarks_usage_hint" = "즐겨찾기가 없습니다.\n즐겨찾기를 추가하도록 지도에 어떤 장소를 누릅니다.\n다른 소스에서 북마크는 Organic Maps 앱에서 가져와서 표시할 수 있습니다. 메일, 드롭박스 또는 웹링크에서 저장한 핀으로 KML/KMZ 파일을 열 수 있습니다.";
 
 /* Settings button in system menu */
 "settings" = "설정";
@@ -191,26 +147,11 @@
 /* Ask to wait user several minutes (some long process in modal dialog). */
 "wait_several_minutes" = "이 작업은 수 분 소요될 수 있습니다.\n잠시 기다리세요…";
 
-/* Show bookmarks from this category on a map or not */
-"visible" = "눈에 보이는";
-
-/* Toast which is displayed when GPS has been deactivated */
-"gps_is_disabled_long_text" = "GPS가 사용 중지되었습니다. 설정에서 이를 작동시켜 주시기 바랍니다.";
-
 /* Measurement units title in settings activity */
 "measurement_units" = "측정 단위";
 
 /* Detailed description of Measurement Units settings button */
 "measurement_units_summary" = "마일과 킬로미터 중에서 선택하십시오";
-
-/* Do search in all sources */
-"search_mode_all" = "모든 곳";
-
-/* Do search near my position only */
-"search_mode_nearme" = "근처 검색";
-
-/* Do search in current viewport only */
-"search_mode_viewport" = "화면에";
 
 /* Search category for cafes, bars, restaurants */
 "eat" = "어디서먹을까";
@@ -266,14 +207,8 @@
 /* Search category */
 "police" = "치안대";
 
-/* String in search result list, when nothing found */
-"no_search_results_found" = "결과 없음";
-
 /* Notes field in Bookmarks view */
 "description" = "메모";
-
-/* Button text */
-"share_by_email" = "이메일로 공유";
 
 /* Email Subject when sharing bookmarks category */
 "share_bookmarks_email_subject" = "귀하와 공유된 Organic Maps 즐겨찾기";
@@ -295,26 +230,11 @@
 /* Warning message when doing search around current position */
 "unknown_current_position" = "귀하의 위치를 아직 알아내지 못 했습니다";
 
-/* Warning message when location country isn't downloaded during search (see also download_location_map_proposal). */
-"download_location_country" = "귀하께서 현재 계신 국가인 을(를) 다운로드 (%@)";
-
-/* Warning message when viewport country isn't downloaded during search */
-"download_viewport_country_to_search" = "귀하께서 검색 중인 국가인 을(를) 다운로드 (%@)";
-
 /* Alert message that we can't run Map Storage settings due to some reasons. */
 "cant_change_this_setting" = "죄송합니다, 지도 스토리지 설정이 비활성화되어 있습니다.";
 
 /* Alert message that downloading is in progress. */
 "downloading_is_active" = "국가 다운로드가 지금 진행 중입니다.";
-
-/* Message that will be shown in alert view, when we ask user to leave review on App Store */
-"appStore_message" = "Organic Maps로 즐거운 시간을 보내시기 바랍니다! Organic Maps가 마음에 드신다면 앱스토어에서 평가를 남겨 주시기 바랍니다. 평가하는 데는 1분이 채 걸리지 않지만 저희에게 큰 도움이 됩니다. 성원해 주셔서 감사합니다!";
-
-/* No, thanks */
-"no_thanks" = "평가하지 않겠습니다";
-
-/* Share one specific bookmark using SMS, %1$@ contains om:// and %2$@ https://omaps.app link. @NOTE non-ascii symbols in the link will result in max 70 characters SMS instead of 140. */
-"bookmark_share_sms" = "지도에서 내 PIN을 참조하십시오. %1$@ 또는 %2$@ 열기";
 
 /* Share my position using SMS, %1$@ contains om:// and %2$@ https://omaps.app link WITHOUT NAME. @NOTE non-ascii symbols in the link will result in max 70 characters SMS instead of 140. */
 "my_position_share_sms" = "현재 위치를 알아 보십시오. %1$@ 또는 %2$@ 열기";
@@ -328,23 +248,11 @@
 /* Share my position using EMail, %1$@ is om:// and %2$@ is https://omaps.app link WITHOUT NAME */
 "my_position_share_email" = "안녕하세요.\n\n지금 다음 위치에 있습니다: %1$@. %2$@ 또는 %3$@ 링크를 클릭하여 지도상에서 해당 장소를 살펴보시기 바랍니다.\n\n감사합니다.";
 
-/* Android share by Message/SMS button text (including SMS) */
-"share_by_message" = "메시지로 공유";
-
 /* Share button text which opens menu with more buttons, like Message, EMail, Facebook etc. */
 "share" = "공유";
 
-/* iOS share by Message button text (including SMS) */
-"message" = "메시지";
-
 /* Share by email button text, also used in editor. */
 "email" = "이메일";
-
-/* Copy Link */
-"copy_link" = "링크 복사하기";
-
-/* Text for the button that returns to caller application */
-"more_info" = "추가 정보 보기";
 
 /* Text for message when used successfully copied something */
 "copied_to_clipboard" = "클립보드에 복사됨: %1$@";
@@ -354,15 +262,6 @@
 
 /* Used for bookmark editing */
 "done" = "완료";
-
-/* Summary for preferences in MWM */
-"yopme_pref_summary" = "Choose Back Screen settings";
-
-/* Title for yopme preferences in MWM */
-"yopme_pref_title" = "Back Screen Settings";
-
-/* Hint for upper-right icon p2b */
-"show_on_backscreen" = "Show on Back screen";
 
 /* Prints version number in About dialog */
 "version" = "버전: %@";
@@ -381,19 +280,11 @@
 
 "share_my_location" = "내 위치 공유";
 
-"menu_search" = "검색";
-
 /* Settings general group in settings screen */
 "prefs_group_general" = "General settings";
 
 /* Settings information group in settings screen */
 "prefs_group_information" = "Information";
-
-/* Settings screen: "Map" category title */
-"prefs_group_map" = "지도";
-
-/* Settings screen: "Miscellaneous" category title */
-"prefs_group_misc" = "기타";
 
 "prefs_group_route" = "네비게이션";
 
@@ -419,9 +310,6 @@
 /* Settings «Map» category: «3D buildings» title */
 "pref_map_3d_buildings_title" = "주변 건물 3D";
 
-/* Settings «Map» category: «3D buildings» summary */
-"pref_map_3d_buildings_subtitle" = "배터리 수명에 영향";
-
 /* Settings «Route» category: «Tts enabled» title */
 "pref_tts_enable_title" = "음성 지침";
 
@@ -433,8 +321,6 @@
 
 /* Title for "Other" section in TTS settings. */
 "pref_tts_other_section_title" = "다른 언어";
-
-"pref_tts_how_to_set_up_voice" = "음성 설정 방법";
 
 /* Settings «Map» category: «Record track» title */
 "pref_track_record_title" = "최근 추적";
@@ -455,56 +341,7 @@
 
 "recent_track_help_text" = "특정 기간 동안 이동된 경로를 기록하고 지도에서 그 경로를 볼 수 있습니다. 참고: 이 기능을 활성화하면 배터리 사용량이 증가하게 됩니다. 시간 간격이 만료된 후 지도에서 해당 트랙이 자동으로 제거됩니다.";
 
-"pref_track_ios_caption" = "최근 추적은 여행한 경로를 보여줍니다.";
-
-"pref_track_ios_subcaption" = "추적을 저장하는 시간 범위를 선택하십시오.";
-
-"placepage_distance" = "거리";
-
-"placepage_coordinates" = "좌표";
-
-"placepage_unsorted" = "분류되지 않음";
-
 "search_show_on_map" = "지도 보기";
-
-/* Used to warn user when fixing KitKat issue */
-"bookmark_move_fail" = "우리는 내부 메모리로 북마크를 이동해야 하지만, 이에 대한 사용 가능한 공간이 없습니다. 메모리를 확보하지 않으면, 북마크를 사용할 수 없습니다.";
-
-/* Used in More Apps menu */
-"free" = "무료";
-
-/* Used in More Apps menu */
-"buy" = "구입";
-
-/* 1st search button-like result */
-"search_on_map" = "지도에서 검색";
-
-/* toast with an error */
-"no_route_found" = "경로를 찾을 수 없음";
-
-/* route title */
-"route" = "경로";
-
-/* category title */
-"routes" = "경로";
-
-/* text of notification */
-"download_map_notification" = "당신이 있는 장소의지도를 다운로드 하십시오";
-
-/* text of notification */
-"pro_version_is_free_today" = "Organic Maps의 전체 버전 오늘 무료! 지금 다운로드하고 친구들에게 알리세요.";
-
-/* Dialog for transferring maps from lite to pro. */
-"move_lite_maps_to_pro" = "우리는 Organic Maps. Lite에서 Organic Maps로 다운로드된 지도를 전송하고 있습니다. 이는 몇 분 정도 걸릴 수 있습니다.";
-
-/* Message to display when maps moved. */
-"move_lite_maps_to_pro_ok" = "다운로드된 지도가 성공적으로 Organic Maps에 전송됨";
-
-/* Message to display when maps move failed. */
-"move_lite_maps_to_pro_failed" = "지도를 전송하지 못했습니다. Organic Maps Lite를 삭제하고 다시지도를 다운로드하십시오.";
-
-/* Text in menu */
-"settings_and_more" = "설정 및 기타";
 
 /* Text in menu */
 "website" = "웹사이트";
@@ -527,14 +364,8 @@
 /* Text in menu */
 "openstreetmap" = "OpenStreetMap";
 
-/* Text in menu */
-"contact_us" = "연락처";
-
 /* Settings: Send feedback button and dialog title */
 "feedback" = "피드백";
-
-/* Text in menu */
-"subscribe_to_news" = "우리 뉴스 구독";
 
 /* Text in menu */
 "rate_the_app" = "앱 평가";
@@ -548,15 +379,6 @@
 /* Text in menu */
 "report_a_bug" = "오류 신고";
 
-/* Email subject */
-"subscribe_me_subject" = "Organic Maps 뉴스 레터로 나를 구독해 주십시오.";
-
-/* Email body */
-"subscribe_me_body" = "나는 최신 뉴스 업데이트 및 프로모션에 대해 알게될 첫번째 사람이 되고 싶습니다. 나는 언제나 구독을 취소할 수 있습니다.";
-
-/* About text */
-"about_text" = "Organic Maps는 가장 빠른 전 세계 모든 국가 및 도시의 오프라인 지도를 제공하고 있습니다. 자신있게 여행하세요. 계신 곳이 어디이든 Organic Maps는 지도상에서 위치하고 계신 곳이 어디 있지 알려 주고 가장 가까운 식당, 호텔 및 주유소 등을 찾아 줍니다. 인터넷 접속이 필요없는 서비스입니다.\n\nOrganic Maps는 항상 새로운 기능들에 대해 연구하고 있습니다. Organic Maps가 더 훌륭한 서비스를 제공할 수 있도록 많은 의견 주시면 감사하겠습니다. 앱을 사용하시다 불편한 점이 있으시면, 주저 마시고 support@organicmaps.app으로 문의해 주세요. Organic Maps는 어떤 요청에도 기꺼이 응답할 것입니다.\n\nOrganic Maps가 좋은 앱이라고 생각하시나요? Organic Maps을 후원할 수 있는 간단하면서도 비용이 전혀 들지 않는 몇 가지 방법을 소개합니다.\n\n- 앱 마켓에 리뷰를 올려주세요.\n- Organic Maps의 페이스북 페이지 http://www.facebook.com/OrganicMaps 에 “좋아요”를 남겨 주세요.\n- 가족, 친구 및 동료들에게 Organic Maps를 자랑해 주세요.\n\nOrganic Maps와 함께 해 주셔서 감사합니다. 여러분의 후원에 정말 감사드립니다!\n\nP.S. Organic Maps는 OpenStreetMap으로부터 맵 데이터를 수집하고 있습니다. OpenStreetMap은 위키피디아처럼 유저들이 맵을 만들고 편집할 수 있는 맵핑 프로젝트입니다.\n\n혹 맵에서 누락된 곳이나 잘못된 점을 발견하실 경우, https://www.openstreetmap.org에서 직접 맵을 수정하실 수 있습니다. 수정한 부분은 다음 버전으로 출시되는 Organic Maps 앱에 반영될 것입니다.";
-
 /* Alert text */
 "email_error_body" = "이메일 클라이언트가 설정되지 않았습니다. 이를 구성하거나 %@로 연락할 다른 방법을 사용하십시오.";
 
@@ -569,12 +391,6 @@
 /* Search category */
 "wifi" = "WiFi 인터넷";
 
-/* Update map suggestion */
-"routing_map_outdated" = "경로를 생성하도록 지도를 업데이트하십시오.";
-
-/* Update maps suggestion */
-"routing_update_maps" = "Organic Maps의 새로운 버전으로 당신의 현재 위치에서 목적지 지점으로 경로를 생성할 수 있습니다. 이 기능을 사용하려면 지도를 업데이트하십시오.";
-
 /* Update all button text */
 "downloader_update_all_button" = "모두 업데이트";
 
@@ -583,9 +399,6 @@
 
 /* Downloaded maps category */
 "downloader_downloaded_subtitle" = "다운로드";
-
-/* Downloaded maps category */
-"downloader_available_maps" = "사용 가능";
 
 /* Country queued for download */
 "downloader_queued" = "대기";
@@ -598,17 +411,6 @@
 
 "downloader_downloading" = "다운로드 중:";
 
-"downloader_search_results" = "검색 결과";
-
-/* Disclaimer message */
-"routing_disclaimer" = "Organic Maps 앱에서 경로를 작성할 때, 다음에 유의하시기 바랍니다:\n\n  - 추천 루트는 권장 사항으로만 간주될 수 있습니다.\n - 도로 조건, 교통 규칙 및 징후는 탐색 조언보다 더 높은 우선 순위를 갖습니다.\n -지도는 잘못되었거나 만료되었을 수 있으며, 경로는 최상의 방법을 만들어지지 않을 수 있습니다.\n\n  도로에서 안전하게 몸조심하세요!";
-
-/* Outdated maps category */
-"downloader_outdated_maps" = "만료됨";
-
-/* Up to date maps category */
-"downloader_uptodate_maps" = "최신";
-
 /* Status of outdated country in the list */
 "downloader_status_outdated" = "업데이트";
 
@@ -618,49 +420,14 @@
 /* Displayed in a dialog that appears when a user tries to delete a map while the app is in the follow route mode */
 "downloader_delete_map_while_routing_dialog" = "지도를 삭제하시려면 길 찾기를 멈추세요.";
 
-/* Show when user try build route, but we don't know where he */
-"routing_failed_unknown_my_position" = "현재 위치는 정의되지 않습니다. 경로를 생성할 위치를 지정하십시오.";
-
-/* Show if use has not routing file, or InconsistentMWMandRoute */
-"routing_failed_has_no_routing_file" = "추가 데이터는 경로를 생성하기 위해 필요합니다. 다운로드를 시작하시겠습니까?";
-
-/* StartPointNotFound */
-"routing_failed_start_point_not_found" = "경로를 계산할 수 없습니다. 시작 지점 근처에 도로가 없습니다.";
-
-/* EndPointNotFound */
-"routing_failed_dst_point_not_found" = "경로를 계산할 수 없습니다. 목적지 근처에 도로가 없습니다.";
-
 /* PointsInDifferentMWM */
 "routing_failed_cross_mwm_building" = "경로는 하나의 지도에 완전히 포함되도록만 생성할 수 있습니다.";
-
-/* RouteNotFound */
-"routing_failed_route_not_found" = "선택한 출발지와 목적지 사이에서 발견있는 경로가 없습니다. 다른 출발지 또는 도착지를 선택하십시오.";
-
-/* InternalError */
-"routing_failed_internal_error" = "내부 오류가 발생했습니다. 다시지도를 삭제하고 다운로드하도록 시도하십시오. 문제가 지속되면 support@organicmaps.app로 문의하시기 바랍니다.";
-
-/* Context menu item for downloader. */
-"downloader_download_map_and_routing" = "지도 + 라우팅 다운로드";
-
-/* Context menu item for downloader. */
-"downloader_download_routing" = "라우팅 다운로드";
-
-/* Context menu item for downloader. */
-"downloader_delete_routing" = "라우팅 삭제";
 
 /* Context menu item for downloader. */
 "downloader_download_map" = "지도 다운로드";
 
-"downloader_download_map_no_routing" = "라우팅없이 지도 다운로드";
-
-/* Button for routing. */
-"routing_go" = "이동!";
-
 /* Item status in downloader. */
 "downloader_retry" = "반복";
-
-/* Item in context menu. */
-"downloader_map_and_routing" = "지도 + 라우팅";
 
 /* Item in context menu. */
 "downloader_delete_map" = "지도 삭제";
@@ -668,29 +435,11 @@
 /* Item in context menu. */
 "downloader_update_map" = "지도 업데이트";
 
-/* Item in context menu. */
-"downloader_update_map_and_routing" = "지도 + 라우팅 업데이트";
-
-/* Item in context menu. */
-"downloader_map_only" = "지도만";
-
-/* Toolbar title */
-"toolbar_application_menu" = "애플리케이션 메뉴";
-
 /* Preference text */
 "pref_use_google_play" = "Google Play 서비스를 사용하여 현재 위치 정보 얻기";
 
 /* Text for rating dialog */
 "rating_just_rated" = "앱 평가 완료";
-
-/* Text for rating dialog */
-"rating_user_since" = "%@ 이후로 Organic Maps 사용자임";
-
-/* Text for rating dialog */
-"rating_do_like_maps" = "Organic Maps를 좋아하나요?";
-
-/* Text for rating dialog */
-"rating_tap_star" = "별을 눌러 우리의 앱을 평가하세요.";
 
 /* Text for rating dialog */
 "rating_thanks" = "감사합니다!";
@@ -701,23 +450,8 @@
 /* Text for rating dialog */
 "rating_send_feedback" = "의견 보내기";
 
-/* Text for g+ dialog */
-"rating_google_plus" = "g+를 클릭하여 이 앱에 대해 친구들에게 말하세요.";
-
 /* Text for routing error dialog */
 "routing_download_maps_along" = "경로를 따라 지도 다운로드";
-
-/* Text for routing error dialog */
-"routing_download_map" = "지도 가져오기";
-
-/* Text for routing error dialog */
-"routing_download_map_and_routing" = "업데이트된 지도와 라우팅 데이터를 다운로드하여 모든 Organic Maps 기능을 가져옵니다.";
-
-/* Text for routing error dialog */
-"routing_get_routing_data" = "라우팅 데이터 가져오기";
-
-/* Text for routing error dialog */
-"routing_get_additional_data" = "추가 데이터는 사용자의 위치에서 경로를 생성하도록 필요합니다.";
 
 /* Text for routing error dialog */
 "routing_requires_all_map" = "경로를 만드는 것은 사용자의 위치에서의 모든 지도를 다운로드되고 업데이트된 대상으로 필요합니다.";
@@ -725,50 +459,15 @@
 /* Text for routing error dialog */
 "routing_not_enough_space" = "여유 공간 부족";
 
-/* Text for routing error dialog */
-"routing_download_more_than_avail" = "%@ MB를 다운로드해야 하지만 %@ MB만 사용할 수 있습니다.";
-
-/* Text for routing error dialog */
-"routing_download_roaming" = "모바일 데이터(로밍시)를 사용하여 %@ MB를 다운로드할 것입니다. 이는 운영자 모바일 데이터 계획에 따라 추가 요금이 발생할 수 있습니다.";
-
 /* bookmark button text */
 "bookmark" = "북마크";
-
-/* map is not downloaded */
-"not_found_map" = "위치에 대한 지도가 다운로드되지 않음";
 
 /* location service disabled */
 "enable_location_services" = "위치 서비스를 작동시켜 주십시요.";
 
-/* download map */
-"download_map" = "위치에 대한 지도 다운로드";
-
-/* download map on iPhone */
-"download_map_iphone" = "아이폰에서 현재 위치의 지도 다운로드";
-
-/* clear pin */
-"nearby" = "근처에";
-
-/* clear pin */
-"clear_pin" = "핀 지우기";
-
-/* location is undefined */
-"undefined_location" = "현재 위치는 정의되지 않습니다.";
-
-/* download country of your location */
-"download_country" = "귀하께서 현재 계신 국가인 을(를) 다운로드";
-
-/* download failed */
-"download_failed" = "다운로드가 실패했습니다";
-
-/* get the map */
-"get_the_map" = "지도 가져오기";
-
 "save" = "저장";
 
 "edit_description_hint" = "설명(텍스트 또는 HTML)";
-
-"new_group" = "새 그룹";
 
 "create" = "만들기기";
 
@@ -795,30 +494,6 @@
 
 /* pink color */
 "pink" = "분홍색";
-
-/* deep purple color */
-"deep_purple" = "진보라색";
-
-/* light blue color */
-"light_blue" = "하늘색";
-
-/* cyan color */
-"cyan" = "시안";
-
-/* teal color */
-"teal" = "틸";
-
-/* lime color */
-"lime" = "라임";
-
-/* deep orange color */
-"deep_orange" = "진주황색";
-
-/* gray color */
-"gray" = "회색";
-
-/* blue gray color */
-"blue_gray" = "청회색";
 
 /* Wi-Fi available */
 "WiFi_available" = "네";
@@ -848,13 +523,9 @@
 
 "dialog_routing_location_unknown_turn_on" = "현재 GPS 좌표를 찾을 수 없습니다. 경로를 계산하려면 위치 서비스를 활성화하세요.";
 
-"dialog_routing_location_unknown" = "현재 GPS 좌표를 찾을 수 없습니다.";
-
 "dialog_routing_download_files" = "필수 파일 다운로드";
 
 "dialog_routing_download_and_update_all" = "경로를 계산하려면 모든 지도와 예상 경로 정보를 다운로드하고 업데이트하세요.";
-
-"dialog_routing_routes_size" = "경로 정보 파일";
 
 "dialog_routing_unable_locate_route" = "경로를 찾을 수 없습니다";
 
@@ -884,21 +555,11 @@
 
 "dialog_routing_try_again" = "다시 시도해주세요.";
 
-"dialog_routing_send_error" = "문제 신고";
-
-"dialog_routing_if_get_cross_route" = "두 개 이상의 지도를 통과하는 더 직접적인 경로를 설정하시겠습니까?";
-
-"dialog_routing_cross_route_is_optimal" = "이 지도의 경계를 통과하는 더 최적화된 경로를 사용할 수 있습니다.";
-
 "not_now" = "나중에";
-
-"dialog_routing_build_route" = "만들기";
 
 "dialog_routing_download_and_build_cross_route" = "지도를 다운로드하여, 두 개 이상의 지도를 통과하는 더 최적화된 경로를 설정하시겠습니까?";
 
 "dialog_routing_download_cross_route" = "이 지도의 경계를 통과하는 더 최적화된 경로를 설정하려면 지도를 다운로드하세요.";
-
-"dialog_routing_cross_route_always" = "항상 이 경계 통과";
 
 
 /********** Strings for downloading map from search **********/
@@ -906,8 +567,6 @@
 "search_without_internet_advertisement" = "경로를 검색하고 만들기시작하려면, 지도를 다운로드하십시오. 그러면, 더 이상 인터넷 연결이 필요하지 않습니다.";
 
 "search_select_map" = "지도 선택";
-
-"search_select_other_map" = "다른 지도 선택";
 
 /* «Show» context menu */
 "show" = "표시";
@@ -918,17 +577,11 @@
 /* «Rename» context menu */
 "rename" = "다른 이름으로 변경";
 
-/* Bottom sheet: expand button (should be short) */
-"bottom_sheet_more" = "기타…";
-
 /* Failed planning route message in navigation view */
 "routing_planning_error" = "경로 계획 실패";
 
 /* Arrive routing message in navigation view */
 "routing_arrive" = "도착: %s";
-
-/* Text for routing::RouterResultCode::FileTooOld dialog. */
-"dialog_routing_download_and_update_maps" = "경로를 만들려면, 경로를 따라 모든 지도를 다운로드하고 업데이트하십시오.";
 
 "rate_alert_title" = "앱을 좋아하나요?";
 
@@ -944,19 +597,11 @@
 
 "history" = "내역";
 
-"next_turn_then" = "그런 다음";
-
 "closed" = "닫음";
-
-"back_to" = "%@(으)로 복귀";
 
 "search_not_found" = "죄송합니다. 아무것도 찾지 못했습니다.";
 
 "search_not_found_query" = "다른 쿼리를 시도하십시오.";
-
-"search_not_found_map" = "검색할 지도를 다운로드하십시오.";
-
-"search_not_found_location" = "현재 위치의 지도를 다운로드하십시오.";
 
 "search_history_title" = "검색 기록";
 
@@ -964,23 +609,12 @@
 
 "clear_search" = "이력 검색 지우기";
 
-/* Title for settings to enable/disable showcase menu button */
-"showcase_settings_title" = "추천 보기";
-
 /* Place Page link to Wikipedia article (if map object has it). */
 "read_in_wikipedia" = "Wikipedia";
 
-"p2p_route_planning" = "경로 계획 중";
-
 "p2p_your_location" = "위치";
 
-"p2p_from" = "출발 지점";
-
-"p2p_to" = "도착 지점";
-
 "p2p_start" = "시작";
-
-"p2p_planning" = "계획 중…";
 
 "p2p_from_here" = "출발지";
 
@@ -1018,15 +652,9 @@
 
 "editor_correct_mistake" = "입력 수정";
 
-"editor_correct_mistake_message" = "잘못 입력했습니다. 수정하거나 기본 모드로 전환하세요.";
-
 "editor_add_select_location" = "위치";
 
 "editor_done_dialog_1" = "세계 지도를 변경했습니다. 이를 숨기지 마십시오! 친구에게 말하고, 이를 함께 편집합니다.";
-
-"editor_done_dialog_2" = "이는 두 번째 지도의 개선 사항입니다. 지금 지도 편집기의 목록에서 %d번째 장소에 있습니다. 친구들에게 이에 대해 말하십시오.";
-
-"editor_done_dialog_3" = "지도를 개선했으며, 친구들에게 이에 대해 말하고, 함께 지도를 편집할 수 있습니다.";
 
 "share_with_friends" = "친구들과 공유";
 
@@ -1044,20 +672,7 @@
 
 "editor_report_problem_duplicate_place_title" = "중복된 장소";
 
-"first_launch_congrats_title" = "Organic Maps를 사용할 준비가 완료되었습니다";
-
-"first_launch_congrats_text" = "무료로 세계 어디에서나 오프라인으로 검색하고 탐색할 수 있습니다.";
-
-"migrate_title" = "중요!";
-
-/* Android uses image instead of text. */
-"download_all" = "모두 다운로드";
-
-"delete_all" = "모두 삭제";
-
 "autodownload" = "자동 다운로드";
-
-"disable_autodownload" = "자동 다운로드 해제";
 
 /* Place Page opening hours text */
 "closed_now" = "지금 닫힘";
@@ -1072,10 +687,6 @@
 "day_off" = "종료됨";
 
 "today" = "오늘";
-
-"sunrise_to_sunset" = "일출에서 일몰로";
-
-"sunset_to_sunrise" = "일출에서 일몰까지";
 
 "add_opening_hours" = "영업일 추가";
 
@@ -1095,45 +706,18 @@
 
 "forgot_password" = "암호를 잊으 셨나요?";
 
-/* Forgot Password dialog title */
-"restore_password" = "암호 복원";
-
-"enter_email_address_to_reset_password" = "등록시 사용한 이메일 주소를 입력하면 암호를 갱신하도록 링크를 전송할 것입니다.";
-
-"reset_password" = "비밀번호 재 설정";
-
-"username" = "사용자 이름";
-
 "osm_account" = "OSM 계정";
 
 "logout" = "로그 아웃";
 
-"login_and_edit_map_motivation_message" = "로그인하고 지도 상의 개체 정보를 편집하면 다른 수백만 명의 사용자가 사용할 수 있도록 하겠습니다. 함께 더 나은 세상으로 만들어 봅시다.";
-
 /* Information text: "Last upload 11.01.2016" */
 "last_upload" = "마지막 업로드";
 
-/* Motivates user to login/register, title above login buttons. */
-"you_have_edited_your_first_object" = "로그인하고 전 세계 수백만 사람들을 위해 변화를 더하십시오!";
-
 "thank_you" = "고맙습니다.";
-
-"login_with_google" = "Google로 로그인";
-
-"login_with_openstreetmap" = "www.openstreetmap.org에 로그인";
 
 "edit_place" = "장소 편집";
 
 "place_name" = "지명";
-
-/* title above languages list cells in the editor, below editable name text field. */
-"other_languages" = "다른 언어";
-
-/* small button to open list with names in different languages */
-"show_more" = "더 많이 표시";
-
-/* small button to close list with names in different languages */
-"show_less" = "더 적게 표시";
 
 "add_language" = "언어 추가";
 
@@ -1164,8 +748,6 @@
 
 "please_note" = "참고 사항";
 
-"common_no_wifi_dialog" = "WiFi 연결이 없습니다. 모바일 데이터를 계속하시겠습니까?";
-
 "downloader_delete_map_dialog" = "모든 지도의 변경 사항은 지도와 함께 삭제됩니다.";
 
 "downloader_update_maps" = "지도 업데이트";
@@ -1173,10 +755,6 @@
 "downloader_mwm_migration_dialog" = "경로를 만들려면, 모든 지도를 업데이트한 다음, 다시 경로를 계획해야 합니다.";
 
 "downloader_search_field_hint" = "지도 찾기";
-
-"migration_update_all_button" = "모든지도 업데이트";
-
-"migration_delete_all_download_current_button" = "현재 지도 다운로드 및 기존 지도 삭제";
 
 "migration_download_error_dialog" = "다운로드 오류";
 
@@ -1186,21 +764,9 @@
 
 "downloader_no_space_message" = "불필요한 데이터를 제거하십시오.";
 
-"editor_general_auth_error_dialog" = "일반 로그인 오류.";
-
 "editor_login_error_dialog" = "로그인 오류.";
 
-"editor_login_failed_dialog" = "로그인 실패";
-
-"editor_username_error_dialog" = "잘못된 사용자 이름";
-
-"editor_place_edited_dialog" = "개체를 편집했습니다!";
-
-"editor_login_with_osm" = "OpenStreetMap으로 로그인";
-
 "editor_profile_changes" = "변경사항 승인";
-
-"editor_profile_unsent_changes" = "전송되지 않음:";
 
 "editor_focus_map_on_location" = "개체의 정확한 위치를 선택하려면 지도를 당깁니다.";
 
@@ -1222,13 +788,9 @@
 
 "editor_report_problem_other_title" = "다른 문제";
 
-"placepage_report_problem_button" = "문제 신고";
-
 "placepage_add_business_button" = "조직 추가";
 
 "whatsnew_editor_message_1" = "지도에 새로운 장소를 추가하고 응용 프로그램에서 직접 기존 편집 할 수 있습니다.";
-
-"whatsnew_editor_message_2" = "* Organic Maps는 OpenStreetMap 커뮤니티 데이터를 사용합니다.";
 
 "dialog_incorrect_feature_position" = "위치 변경";
 
@@ -1236,16 +798,10 @@
 
 "login_to_make_edits_visible" = "로그인하여 다른 사용자가 변경한 내용을 볼 수 있도록 하십시오.";
 
-"no_migration_during_navigation" = "업데이트는 탐색 중 금지되어 있습니다.";
-
 /* Error dialog no space */
 "migration_no_space_message" = "다운로드하려면, 더 많은 여유 공간이 필요합니다. 불필요한 데이터를 삭제하십시오.";
 
 "editor_sharing_title" = "나는 Organic Maps 지도를 향상함";
-
-"editor_comment_will_be_sent" = "지도 제작자에게 의견을 보낼 것입니다.";
-
-"editor_unsupported_category_message" = "아직 지원하지 않는 카테고리의 장소를 추가했습니다. 시간이 좀 흐른 나중에 이 지도에 표시될 것입니다.";
 
 /* Downloaded 10 **of** 20 <- it is that "of" */
 "downloader_of" = "%2$d중의 %1$d";
@@ -1278,23 +834,9 @@
 
 "editor_operator" = "소유자";
 
-"editor_tag_description" = "회사, 조직 또는 시설 책임자를 입력하세요.";
-
-"editor_no_local_edits_title" = "편집한 지역정보가 없습니다";
-
-"editor_no_local_edits_description" = "이는 현재 귀하의 장치에서만 액세스할 수 있으며, 지도에서 만든 변경사항를 보여줍니다.";
-
-"editor_send_to_osm" = "OSM에 전송";
-
-"editor_remove" = "삭제";
-
-"downloader_my_maps_title" = "내 지도";
-
 "downloader_no_downloaded_maps_title" = "지도를 다운로드하지 않았습니다";
 
 "downloader_no_downloaded_maps_message" = "오프라인으로 위치를 검색하려면 지도를 다운로드하세요.";
-
-"downloader_find_place_hint" = "도시/국가 검색";
 
 /* Error title that appears after certain time without location. */
 "current_location_unknown_title" = "현재 위치검색을 계속하시겠습니까?";
@@ -1321,47 +863,13 @@
 /* iOS Dialog for the case when the location permission is not granted */
 "location_services_disabled_3" = "3. 앱 사용 중에 선택";
 
-"placepage_parking_surface" = "주차공간";
-
-"placepage_parking_multistorey" = "주차장 건물";
-
-"placepage_parking_underground" = "지하";
-
-"placepage_parking_rooftop" = "옥상";
-
-"placepage_parking_sheds" = "창고";
-
-"placepage_parking_carports" = "간이 차고";
-
-"placepage_parking_boxes" = "차고";
-
-"placepage_parking_pay" = "유료";
-
-"placepage_parking_free" = "무료";
-
-"placepage_parking_interval" = "주차요금 간격";
-
-"placepage_entrance_number" = "번호";
-
-"placepage_entrance_type" = "입구";
-
-"placepage_flat" = "앱";
-
-"placepage_open_24_7" = "연중무휴";
-
 "meter" = "m";
 
 "kilometer" = "km";
 
-"kilometers_per_hour" = "km/시";
-
 "mile" = "mi";
 
 "foot" = "풋";
-
-"miles_per_hour" = "mph";
-
-"day" = "d";
 
 "hour" = "t";
 
@@ -1381,10 +889,6 @@
 
 "placepage_bookmark_name_hint" = "즐겨찾기 이름";
 
-"placepage_personal_notes_hint" = "개인 메모";
-
-"placepage_delete_bookmark_button" = "즐겨찾기 삭제";
-
 "editor_edits_sent_message" = "귀하의 제안 변경사항이 전송되었습니다";
 
 "editor_comment_hint" = "설명…";
@@ -1397,8 +901,6 @@
 
 "editor_remove_place_button" = "삭제";
 
-"editor_status_sending" = "보내는 중…";
-
 "editor_place_doesnt_exist" = "존재하지 않는 장소입니다.";
 
 "text_more_button" = "…기타";
@@ -1410,11 +912,7 @@
 
 "error_enter_correct_email" = "유효한 이메일 주소 입력";
 
-"error_enter_correct" = "유효한 값 입력";
-
 "refresh" = "최신 정보";
-
-"last_update" = "마지막 업데이트: %s";
 
 "placepage_add_place_button" = "지도에 장소 추가";
 
@@ -1426,24 +924,6 @@
 
 "editor_share_to_all_dialog_message_2" = "저희가 변경 사항을 확인할 것입니다. 질문이 있으신 경우, 저희에게 이메일을 통해 연락하십시오.";
 
-"navigation_overview_button" = "개요";
-
-"navigation_stop_button" = "중지";
-
-/* Text on an empty bookmark page */
-"bookmarks_empty_title" = "북마크 저장";
-
-"bookmarks_empty_message_1" = "빠른 액세스를 위해 즐겨찾는 장소에 저장하기 위해 ★를 누릅니다.";
-
-"bookmarks_empty_message_2" = "이메일 및 웹에서 북마크를 가져옵니다.";
-
-"bookmarks_empty_message_3" = "체크아웃: %s";
-
-/* Name of the group for booked hotels */
-"bookmarks_group_name" = "호텔 예약함";
-
-"place_page_button_read_descriprion" = "읽기";
-
 /* iOS dialog for the case when recent track recording is on and the app comes back from background */
 "recent_track_background_dialog_title" = "최근 여행한 경로 녹음을 비활성화하시겠습니까?";
 
@@ -1451,8 +931,6 @@
 
 /* For sharing via SMS and so on */
 "sharing_call_action_look" = "체크아웃";
-
-"continue_recent_track_background_button" = "계속";
 
 "recent_track_background_dialog_message" = "Organic Maps는 최근 여행한 경로를 녹음하기 위해 배경 화면에서 지역 위치 서비스를 사용합니다.";
 
@@ -1468,33 +946,13 @@
 /* About short text (below logo) */
 "about_description" = "Organic Maps는 여행용 필수 오프라인 응용 프로그램입니다. Organic Maps는 OpenStreetMap 데이터를 기반으로 하며 이 데이터 편집을 허용합니다.";
 
-/* Text in menu */
-"blog" = "블로그";
-
 "general_settings" = "일반 설정";
-
-"date" = "날짜 %d";
-
-/* "Report a bug" -> "Generaal Feedback" -> "Something is not working" */
-"something_is_not_working" = "문제가 발생했습니다.";
 
 /* For the first routing */
 "accept" = "동의";
 
-"accept_and_continue" = "Accept and continue";
-
 /* For the first routing */
 "decline" = "거부";
-
-"install_app" = "설치";
-
-"search_no_results_title" = "결과 찾지 못함";
-
-"search_no_results_message" = "보다 일반적인 검색어로 시도하거나, 축소하거나, 필터를 재설정하세요.";
-
-"search_no_results_expand_area_button" = "축소";
-
-"search_no_results_reset_button" = "필터 재설정";
 
 /* noun */
 "search_in_table" = "목록";
@@ -1517,8 +975,6 @@
 
 "traffic_update_maps_text" = "교통 데이터를 표시하려면 지도를 업데이트해야 합니다.";
 
-"traffic_outdated" = "교통 데이터가 오래되었습니다.";
-
 "big_font" = "지도에서 글꼴 크기 늘리기";
 
 "traffic_update_app" = "Organic Maps를 업데이트하세요.";
@@ -1529,17 +985,7 @@
 /* "traffic" as in "road congestion" */
 "traffic_data_unavailable" = "교통 데이터를 사용할 수 없습니다";
 
-/* "Translation is no needed, because it's a company name" */
-"uber" = "Uber";
-
-/* Simplified colour scheme for traffic information, fewer colours are used to display traffic jams on the map. The string should be kept as short as possible */
-"pref_traffic_simplified_colors_title" = "단순화된 트래픽 색상";
-
 "enable_logging" = "로깅 사용";
-
-"offline_place_page_more_information" = "인터넷에 연결하여 그곳에 대한 자세한 정보를 얻으세요.";
-
-"failed_load_information" = "정보를 로드하지 못했습니다.";
 
 /* Settings: "Send general feedback" button */
 "feedback_general" = "일반 피드백";
@@ -1556,8 +1002,6 @@
 
 "whatsnew_transliteration_title" = "라틴어로 음역";
 
-"yandex_taxi_title" = "Yandex.Taxi";
-
 "learn_more" = "자세히 알아보기";
 
 "core_exit" = "끝내기";
@@ -1568,75 +1012,19 @@
 
 "button_exit" = "끝내기";
 
-"settings_device_memory" = "장치 메모리";
-
-"settings_card_memory" = "카드 메모리";
-
-"settings_storage_available" = "%s 사용 가능";
-
-"toast_location_permission_denied" = "앱 위치 권한 거부됨";
-
-"button_use" = "사용";
-
 "planning_route_manage_route" = "경로 관리";
 
 "button_plan" = "계획";
-
-"button_add" = "추가";
 
 "placepage_remove_stop" = "제거";
 
 "planning_route_remove_title" = "여기로 끌어와서 제거";
 
-"dialog_change_start_point_message" = "시작 지점을 현재 위치로 바꾸시겠습니까?";
-
-"button_replace" = "바꾸기";
-
 "placepage_add_stop" = "스톱 추가";
-
-/* Only ru/en are needed */
-"subtitle_rent" = "Rent";
-
-/* Only ru/en are needed */
-"rub_month" = "RUB/month";
-
-/* Only ru/en are needed */
-"room" = "%s-room apt.";
-
-/* Only ru/en are needed */
-"real_estate" = "Real estate";
-
-"add_my_position" = "내 위치 추가";
-
-"choose_start_point" = "시작 지점 선택";
-
-"choose_destination" = "목적지 선택";
 
 "preloader_viator_button" = "자세히 알아보기";
 
-"start_from_my_position" = "시작 위치:";
-
-"profile_authorization_title" = "로그인";
-
-"profile_authorization_message" = "로그인 및 암호 없이 몇 초 내에 간편하게 로그인";
-
 "profile_authorization_error" = "죄송합니다. 오류가 발생했습니다. 다시 로그인해 보세요.";
-
-"service" = "서비스";
-
-"atmosphere" = "분위기";
-
-"value_for_money" = "가성비";
-
-"experience" = "경험";
-
-"assortment" = "구색";
-
-"expertise" = "전문성";
-
-"equipment" = "장비";
-
-"quality" = "품질";
 
 "dialog_error_storage_title" = "저장소 액세스 문제";
 
@@ -1644,17 +1032,7 @@
 
 "setting_emulate_bad_storage" = "불량 저장소 에뮬레이션";
 
-"directions_finish" = "목적지";
-
-"directions_on_foot" = "%s 걷기";
-
 "core_entrance" = "입구";
-
-"coffee" = "커피";
-
-"cleanliness" = "청결";
-
-"crowdedness" = "혼잡";
 
 "error_enter_correct_name" = "올바른 이름을 입력하세요.";
 
@@ -1673,11 +1051,9 @@
 
 "downloader_percent" = "%s(%s / %s)";
 
-"downloader_process" = "%s 다운로드 중...";
+"downloader_process" = "%s 다운로드 중…";
 
-"downloader_applying" = "%s 적용 중...";
-
-"dialog_message_transit_not_found_connection" = "대중 교통망 내에서 하나의 경로를 계획하세요";
+"downloader_applying" = "%s 적용 중…";
 
 "bookmarks_error_message_share_general" = "애플리케이션 오류로 인해 공유할 수 없습니다";
 
@@ -1695,17 +1071,7 @@
 
 "bookmarks_error_message_list_name_already_taken" = "다른 이름을 선택하십시오.";
 
-"bookmarks_error_title_list_name_too_long" = "이 이름이 너무 깁니다.";
-
-"bookmarks_error_message_list_name_too_long" = "다른 이름을 선택하십시오.";
-
-"please_wait" = "잠시만 기다려주십시오...";
-
-"phone_number" = "전화 번호";
-
-"notification_unsent_reviews_title" = "보내지 않은 리뷰가 여러 개 있습니다.";
-
-"notification_unsent_reviews_message" = "다른 여행자와 리뷰를 공유하려면 로그인하십시오.";
+"please_wait" = "잠시만 기다려주십시오…";
 
 "profile" = "OpenStreetMap 프로필";
 
@@ -1719,49 +1085,13 @@
 
 "bookmarks_convert_error_message" = "일부 파일은 변환되지 않았습니다.";
 
-"converting" = "변환 중...";
-
-"wn_reinvented_bookmarks_title" = "우리는 북마크를 재발 명했습니다!";
-
-"wn_reinvented_bookmarks_message" = "당신은 북마크를 백업하고, 목록을 만들 수 있습니다... 그것은 놀랍습니다...";
-
-"bookmarks_restore" = "북마크 복원";
-
-"bookmarks_restore_process" = "복원 중...";
-
 "bookmarks_restore_title" = "이 버전을 복원 하시겠습니까?";
 
-"bookmarks_restore_message" = "북마크가 %s (%s)에서 복원됩니다.";
-
-"bookmarks_restore_empty_title" = "백업이 없습니다.";
-
-"bookmarks_restore_empty_message" = "서버가 이전에 만들어진 백업을 찾지 못했습니다.";
-
 "common_check_internet_connection_dialog_title" = "인터넷에 연결되지 않음";
-
-"error_server_title" = "서버 오류";
-
-"error_server_message" = "서버에 오류가 발생했습니다. 잠시 후 다시 시도하십시오";
 
 "error_system_message" = "알 수없는 오류가 발생했습니다";
 
 "restore" = "복원";
-
-"bookmarks_page_downloaded" = "다운로드 되었습니다.";
-
-"bookmarks_page_my" = "나의";
-
-"routes_and_bookmarks" = "경로 및 북마크";
-
-"bookmarks_webview_success_toast" = "성공적으로 북마크를 다운로드 하였습니다.";
-
-"cached_bookmarks_placeholder_title" = "새로운 장소를 다운로드 하세요.";
-
-"cached_bookmarks_placeholder_subtitle" = "버튼을 눌러 Organic Maps 사용자들이 작성한 수천 개의 흥미로운 장소와 경로를 다운로드 하세요. 인터넷 연결이 필요합니다.";
-
-"downloader_download_routers" = "북마크를 다운로드 하세요.";
-
-"bookmarks_groups_cached" = "목록을 다운로드 하세요.";
 
 "subtittle_opt_out" = "추적 설정";
 
@@ -1769,29 +1099,15 @@
 
 "crash_reports_description" = "당사는 Organic Maps 경험을 개선하기 위해 귀하의 데이터를 활용할 수 있습니다. 앱을 다시 시작한 후 변경사항이 적용됩니다.";
 
-"opt_out_help_ios_1" = "귀하의 모바일 장치는 \"\"광고 추적 제한\"\" 혹은 \"\"관심 기반의 광고의 옵트아웃\"\" 설정을 제공할 수 있습니다.";
-
-"opt_out_help_ios_2" = "iOS 9 혹은 이상";
-
-"opt_out_help_ios_3" = "설정 → 개인정보 → 광고 → “광고 추적 제한” 설정을 활성화합니다.";
-
-"opt_out_help_android" = "귀하의 모바일 장치는 \"\"광고 추적 제한\"\" 혹은 \"\"관심 기반의 광고의 옵트아웃\"\" 설정을 제공할 수 있습니다.\n\n안드로이드와 구글 플레이 서비스 버전 4.0 혹은 이상은\n설정 → 구글 → 광고 → 광고 개별 맞춤 설정 옵트아웃\nor\n설정 → 구글 → 구글 계정 → 개인 정보 및 보호 → 광고 설정 → 광고 개별 맞춤 설정";
-
 "privacy_policy" = "개인정보 보호 방침";
 
 "terms_of_use" = "사용 약관";
-
-"backup_notification_failed" = "북마크의 백업이 중단되었습니다. 다시 작동시키려면 로그인하세요.";
 
 "button_layer_traffic" = "트래픽";
 
 "button_layer_subway" = "지하철";
 
 "layers_title" = "맵 레이어";
-
-"layers_message" = "트래픽, 지하철 지도 그리고 기타 유용한 정보를 표시하려면 맵 레이어를 사용하세요.";
-
-"button_layer_got_it" = "알겠습니다.";
 
 "subway_data_unavailable" = "지하철 지도가 가용하지 않습니다.";
 
@@ -1803,39 +1119,13 @@
 
 "title_error_downloading_bookmarks" = "오류가 발생했습니다.";
 
-"subtitle_error_downloading_bookmarks" = "북마크가 다운로드 되지 않았습니다.";
-
-"error_already_downloaded" = "해당 목록을 이미 다운로드 하였습니다.";
-
 "popular_place" = "Popular";
-
-"download_routes" = "Download routes";
-
-"bookmarks_downloaded_title" = "Bookmarks have been downloaded successfully";
-
-"bookmarks_downloaded_subtitle" = "Press ‘View on map’ to explore new places from the list";
-
-"why_support" = "왜 Organic Maps를 지원하죠?";
-
-"why_support_item1" = "We respect your privacy: there are zero trackers in the app, and we are open source";
-
-"why_support_item2" = "당신은 Organic Maps를 개선하는데 우리를 도와주세요";
-
-"why_support_item3" = "오픈 지도들 OpenStreetMap.org를 개선하는데 도와주세요";
-
-"channels_map_update" = "지도 업데이트";
-
-"server_unavailable_title" = "서버를 사용할 수 없습니다";
-
-"sharing_options" = "옵션 공유";
 
 "export_file" = "파일 내보내기";
 
 "list_settings" = "목록 세팅";
 
 "delete_list" = "리스트 삭제";
-
-"hide_from_map" = "지도에서 숨기기";
 
 "public_access" = "일반 접근";
 
@@ -1845,40 +1135,11 @@
 
 "bookmark_category_description_hint" = "묘사를 적으세요 (글자 혹은 html)";
 
-/* FIXME */
-"bookmarks_public_access" = "bookmarks_public_access";
-
-/* FIXME */
-"bookmarks_link_access" = "bookmarks_link_access";
-
-/* FIXME */
-"bookmarks_private_access" = "bookmarks_private_access";
-
 "not_shared" = "개인";
-
-"direct_link_progress_text" = "당신의 파일을 업로드 중…";
-
-"direct_link_success" = "링크가 만들어졌습니다";
-
-"send_a_link_btn" = "나에게 링크 보내기";
-
-"upload_error_toast" = "당신의 파일을 업로드 중에 에러가 발생했습니다";
 
 "tags_loading_error_subtitle" = "태그를 불러오는 중 에러가 발생했습니다. 다시 시도해보세요";
 
-"unable_upload_errorr_title" = "파일 업로드 실패";
-
-"unable_upload_error_subtitle_edited" = "이 파일은 웹 앱을 통해 수정되었습니다";
-
-"unable_upload_error_subtitle_broken" = "파일이 망가져서 업로드를 할 수 없습니다. 다른 파일을 업로드하세요.";
-
-"contact" = "연락";
-
-"download_button" = "다운로드";
-
 "speedcams_alert_title" = "속도 감시 카메라";
-
-"speedcams_alert_subtitle" = "속도 제한에 대한 경고";
 
 "speedcam_option_auto" = "자동";
 
@@ -1886,18 +1147,10 @@
 
 "speedcam_option_never" = "안함";
 
-"bookmark_description_title" = "즐겨찾기 묘사";
-
 "place_description_title" = "장소 묘사";
 
 /* this text will be shown in application notification preferences opposite checkbox which enable/disable downloader notifications. Devices on Android 8+ are affected. */
 "notification_channel_downloader" = "맵 다운로더";
-
-"share_bookmarks_email_body_link" = "안녕하세요!\n\n여기 즐겨찾기들을 다운로드 받을 수 있는 링크입니다: %s. Organic Maps 를 통해 리스트를 열고 당신의 여행을 즐기세요!\n\n어플리케이션을 받으세요: https://omaps.app/get?kmz";
-
-"warning_speedcams_title" = "네비게이터가 %d km/h의 속도 제한을 초과시 카메라에 대해 경고 할 것입니다";
-
-"warning_speedcams_subtitle" = "여행하시는 나라의 운전 법규를 준수하시길 바랍니다.";
 
 "speedcams_notice_message" = "자동 - 속도 제한 초과 위험이 있을때 스피드캠에 대해 경고하기\n항상 - 스피드캠에 대해 항상 경고하기\n절대 아님 - 스피드캠에 대해 경고하지 않기";
 
@@ -1913,23 +1166,7 @@
 
 "enable_logging_warning_message" = "이 옵션은 진단을 목적으로 로그를 엽니다 이를 통해 앱에 대한 문제를 분석하는 우리의 스탭을 도울 수 있습니다 이 옵션은 오직 Organic Maps 지원 요청에서만 가능합니다.";
 
-"html_error_upload_message_try_again" = "네트워크 설정을 확인하신 후 다시 시도해주세요";
-
-"html_error_upload_title_try_again" = "인터넷이 연결되지 않았습니다";
-
-"notification_leave_review_v2_android_short_title" = "리뷰하고 여행객들을 도우세요!";
-
-"megafon" = "Say goodbye to roaming!";
-
-"notifications_illegal_alert_disable_button" = "알림 끄기";
-
 "access_rules_author_only" = "온라인 수정";
-
-"privacy_settings_menu" = "개인정보 설정";
-
-"unable_upadate_error_title" = "파일 업데이트 실패";
-
-"unable_upadate_error_message" = "업데이트 중 무언가 실수가 일어났습니다. 변경점들을 확인하시고 다시 시도해주세요";
 
 "driving_options_title" = "운전 옵션";
 
@@ -1951,94 +1188,19 @@
 
 "change_driving_options_btn" = "운전 옵션이 가능합니다";
 
-"toll_road" = "유료 도로";
-
-"unpaved_road" = "비포장 도로";
-
-"ferry_crossing" = "여객선 횡단길";
-
-"operated_by" = "\"%s\" 로 운용됨";
-
 "avoid_toll_roads_placepage" = "유료 도로 피하기";
 
 "avoid_unpaved_roads_placepage" = "비포장 도로 피하기";
 
 "avoid_ferry_crossing_placepage" = "여객선 횡단길 피하기";
 
-"type.cuisine.uzbek" = "우즈벡 요리";
-
-"trip_start" = "가자";
-
-"pick_destination" = "목적지";
-
-"follow_my_position" = "내 위치 조정하기";
-
-"search_results" = "검색 결과";
-
-"then_turn" = "그 다음";
-
-"redirect_route_alert" = "루트를 재구축하길 원하시나요?";
-
-"redirect_route_yes" = "네";
-
-"redirect_route_no" = "아니오";
-
-"trip_finished" = "도착했습니다!";
-
-"keyboard_availability_alert" = "운전 중에는 키보드를 사용할 수 없습니다";
-
-"dialog_routing_change_start_carplay" = "현재 위치에서 루트를 만들 수 없습니다";
-
-"dialog_routing_change_end_carplay" = "목적지 경로를 만들 수 없습니다. 다른 지점을 선택해주세요";
-
-"dialog_routing_check_gps_carplay" = "GPS 신호가 없습니다. 열린 장소로 이동해주세요";
-
-"dialog_routing_unable_locate_route_carplay" = "루트를 만들 수 없습니다. 또 다른 루트 지점을 지정해주세요";
-
-"dialog_routing_download_files_carplay" = "루트를 만들려면, 빠진 맵을 기기에 다운로드하세요";
-
-"dialog_routing_system_error_carplay" = "오류 발생. 어플리케이션을 재실행해주시길 바랍니다";
-
-"dialog_routing_rebuild_from_current_location_carplay" = "루트가 귀하의 현재 위치로부터 재생성됩니다";
-
-"dialog_routing_rebuild_for_vehicle_carplay" = "루트가 차량에 맞춰 수정됩니다";
-
 "ok" = "OK";
-
-"avoid_unpaved_carplay_1" = "비포장 도로 없음";
-
-"avoid_unpaved_carplay_2" = "비포장 도로 없음";
-
-"avoid_ferry_carplay_1" = "여객선 없음";
-
-"avoid_ferry_carplay_2" = "여객선 없음";
-
-"avoid_tolls_carplay_1" = "유료 도로 없음";
-
-"avoid_tolls_carplay_2" = "유료 도로 없음";
-
-"speedcams_alert_title_carplay_1" = "속도단속 카메라";
-
-"speedcams_alert_title_carplay_2" = "속도단속 카메라";
-
-"download_map_carplay" = "Organic Maps 앱 안의 지도들을 디바이스에 다운로드하세요";
-
-"carplay_roundabout_exit" = "%s번 출구";
 
 /* max. 10 symbols, both iOS and Android */
 "sort" = "분류…";
 
 /* Android, title, max 20-22 symbols */
 "sort_bookmarks" = "북마크 분류하기";
-
-/* iOS */
-"sort_default" = "기본 값으로 분류";
-
-"sort_type" = "유형으로 분류";
-
-"sort_distance" = "거리로 분류";
-
-"sort_date" = "날짜로 분류";
 
 /* Android */
 "by_default" = "기본 값";
@@ -2052,63 +1214,7 @@
 /* Android */
 "by_date" = "날짜 별";
 
-"week_ago_sorttype" = "일주일 전";
-
-"month_ago_sorttype" = "한달 전";
-
-"moremonth_ago_sorttype" = "한달 그 이상 전";
-
-"moreyear_ago_sorttype" = "1년 그 이상 전";
-
-"near_me_sorttype" = "나와 가까운 곳";
-
-"others_sorttype" = "기타";
-
-"food_places" = "음식";
-
-"tourist_places" = "명소";
-
-"museums" = "박물관";
-
-"parks" = "공원";
-
-"swim_places" = "수영";
-
-"mountains" = "산";
-
-"animals" = "동물원";
-
-"hotels" = "호텔";
-
-"buildings" = "빌딩";
-
-"money" = "돈";
-
-"shops" = "상점";
-
-"parkings" = "주차장";
-
-"fuel_places" = "주유소";
-
-"water" = "물";
-
-"medicine" = "의료";
-
 "search_in_the_list" = "리스트에서 검색";
-
-"view_on_map_bookmarks" = "맵에서";
-
-"more_bookmarks" = "더…";
-
-"no_items_found" = "발견 없음";
-
-/* Android, max 18 symbols */
-"bookmarks_edit_list" = "리스트 수정";
-
-/* Android, max 18 symbols */
-"bookmarks_delete_list" = "리스트 삭제";
-
-"religious_places" = "종교적 장소";
 
 "select_list" = "목록 선택";
 
@@ -2118,26 +1224,13 @@
 
 "dialog_pedestrian_route_is_long_message" = "지하철역에서 가까운 출발점 또는 종점을 선택하세요";
 
-/* Failed planning SUBWAY route message in navigation view */
-"routing_planning_error_subway_special" = "지하철 루트 계획 생성 실패";
-
 "button_layer_isolines" = "지형";
-
-"tips_map_layers_title_countour" = "Organic Maps의 새 기능: 오프라인 지형 레이어!";
-
-"tips_map_layers_message_countour" = "이 지역에 대한 모든 것을 알고 있는지 확인하면서 자연 여행을 계획하고 즐기세요";
 
 "isolines_activation_error_dialog" = "지형 레이어를 활성화하고 사용하려면 해당 지역의 지도를 업데이트하거나 다운로드하십시오";
 
 "isolines_location_error_dialog" = "이 지역의 지형 레이어는 아직 사용할 수 없습니다";
 
 "elevation_profile_diff_level" = "난이도";
-
-"elevation_profile_diff_level_easy" = "쉬움";
-
-"elevation_profile_diff_level_moderate" = "보통";
-
-"elevation_profile_diff_level_hard" = "어려움";
 
 "elevation_profile_ascent" = "올라가기";
 
@@ -2147,25 +1240,13 @@
 
 "elevation_profile_maxaltitude" = "산 최대 높이";
 
-"elevation_profile_m" = "m";
-
 "elevation_profile_difficulty" = "난이도";
 
 "elevation_profile_distance" = "거리:";
 
-"elevation_profile_km" = "km";
-
 "elevation_profile_time" = "소비 시간:";
 
-"elevation_profile_hours" = "시간";
-
-"elevation_profile_minutes" = "분";
-
 "isolines_toast_zooms_1_10" = "등치선 탐색을 위한 확대";
-
-"downloader_updating_ios" = "업데이트 중";
-
-"downloader_loading_ios" = "다운로드 중";
 
 "key_information_title" = "핵심 정보";
 

--- a/iphone/Maps/LocalizedStrings/ko.lproj/Localizable.stringsdict
+++ b/iphone/Maps/LocalizedStrings/ko.lproj/Localizable.stringsdict
@@ -9,21 +9,6 @@
 
 <!-- ********** Strings for downloading map from search **********/ -->
 
-  <key>bookmarks_places</key>
-  <dict>
-    <key>NSStringLocalizedFormatKey</key>
-    <string>%#@value@</string>
-    <key>value</key>
-    <dict>
-      <key>NSStringFormatSpecTypeKey</key>
-      <string>NSStringPluralRuleType</string>
-      <key>NSStringFormatValueTypeKey</key>
-      <string>d</string>
-      <key>other</key>
-      <string>%d 북마크</string>
-    </dict>
-  </dict>
-
   <key>bookmarks_detect_message</key>
   <dict>
     <key>NSStringLocalizedFormatKey</key>
@@ -36,21 +21,6 @@
       <string>d</string>
       <key>other</key>
       <string>%d 파일을 찾았습니다. 회심 후 그들을 볼 수 있습니다.</string>
-    </dict>
-  </dict>
-
-  <key>bookmarks_objects</key>
-  <dict>
-    <key>NSStringLocalizedFormatKey</key>
-    <string>%#@value@</string>
-    <key>value</key>
-    <dict>
-      <key>NSStringFormatSpecTypeKey</key>
-      <string>NSStringPluralRuleType</string>
-      <key>NSStringFormatValueTypeKey</key>
-      <string>d</string>
-      <key>other</key>
-      <string>%s 대상</string>
     </dict>
   </dict>
 

--- a/iphone/Maps/LocalizedStrings/nb.lproj/Localizable.strings
+++ b/iphone/Maps/LocalizedStrings/nb.lproj/Localizable.strings
@@ -18,9 +18,6 @@
 /* Button which deletes downloaded country */
 "delete" = "Slett";
 
-/* Button "do not interrupt download" if user touched actively downloading country */
-"do_nothing" = "Ikke spør meg igjen";
-
 "download_maps" = "Last ned kart";
 
 /* Settings/Downloader - info for country when download fails */
@@ -28,9 +25,6 @@
 
 /* Settings/Downloader - info for country which started downloading */
 "downloading" = "Laster ned …";
-
-/* Settings/Downloader - size string, only strings different from English should be translated */
-"kb" = "kB";
 
 /* Choose measurement on first launch alert - choose metric system button */
 "kilometres" = "Kilometer";
@@ -55,17 +49,11 @@
 /* Update maps later/Buy pro version later button text */
 "later" = "Senere";
 
-/* Don't show some dialog any more */
-"never" = "Aldri";
-
 /* View and button titles for accessibility */
 "search" = "Søk";
 
 /* Search box placeholder text */
 "search_map" = "Søk kart";
-
-/* Settings/Downloader - info for not downloaded country */
-"touch_to_download" = "Trykk for å laste ned";
 
 /* Settings/Downloader - 3G download warning dialog confirm button */
 "use_cellular_data" = "Ja";
@@ -73,20 +61,11 @@
 /* Location services are disabled by user alert - message */
 "location_is_disabled_long_text" = "Du har for øyeblikket deaktivert alle posisjonstjenester for denne enheten eller applikasjonen. Slå dem på i «Innstillinger».";
 
-/* Location Services are not available on the device alert - message */
-"device_doesnot_support_location_services" = "Enheten din støtter ikke posisjonstjenester";
-
 /* View and button titles for accessibility */
 "zoom_to_country" = "Vis på kartet";
 
-/* Button text for the button at the center of the screen when the country is not downloaded */
-"country_status_download" = "Last ned kart\n(^ ^)";
-
 /* Button text for the button at the center of the screen when the country is not downloaded and the size should not be shown */
 "country_status_download_without_size" = "Last ned kart";
-
-/* Button text for the button at the center of the screen when the country is not downloaded */
-"country_status_download_without_routing" = "Last ned kart\nuten veiviserfunksjon (^ ^)";
 
 /* Message to display at the center of the screen when the country download has failed */
 "country_status_download_failed" = "Laster ned mislyktes";
@@ -96,19 +75,13 @@
 
 "about_menu_title" = "Om Organic Maps";
 
-"downloaded_touch_to_delete" = "Lastet ned (%@) – trykk for å slette";
-
 "connection_settings" = "Tilkoblingsinnstillinger";
-
-"download_mb_or_kb" = "Last ned %@";
 
 "close" = "Lukk";
 
 "unsupported_phone" = "En maskinvareakselerert OpenGL kreves. Dessverre støttes ikke enheten din.";
 
 "download" = "Last ned";
-
-"external_storage_is_not_available" = "SD-kort/USB-enhet med nedlastede kart er ikke tilgjengelig";
 
 "disconnect_usb_cable" = "Koble fra USB-kabelen eller sett inn minnekortet for å bruke Organic Maps";
 
@@ -117,8 +90,6 @@
 "not_enough_memory" = "Ikke nok minne til å starte appen";
 
 "download_resources" = "Før du begynner, la oss laste ned det generelle verdenskartet til enheten. Det trengs %@ med data.";
-
-"getting_position" = "Henter nåværende posisjon";
 
 "download_resources_continue" = "Gå til kart";
 
@@ -140,23 +111,14 @@
 /* Add New Bookmark Set dialog title */
 "add_new_set" = "Legg til nytt sett";
 
-/* Place Page - Add To Bookmarks button */
-"add_to_bookmarks" = "Legg til i bokmerker";
-
 /* Bookmark Color dialog title */
 "bookmark_color" = "Bokmerk farge";
 
 /* Add Bookmark Set dialog - hint when set name is empty */
 "bookmark_set_name" = "Bokmerk settnavn";
 
-/* Bookmark Sets dialog title */
-"bookmark_sets" = "Bokmerk sett";
-
 /* Bookmarks - dialog title */
 "bookmarks" = "Bokmerker";
-
-/* Add bookmark dialog - bookmark color */
-"color" = "Farge";
 
 /* Default bookmarks set name */
 "core_my_places" = "Mine steder";
@@ -167,14 +129,8 @@
 /* Editor title above street and house number */
 "address" = "Adresse";
 
-/* Place Page - Remove Pin button */
-"remove_pin" = "Fjern merke";
-
 /* Add bookmark dialog - bookmark set, Bookmarks dialog - Bookmark set cell */
 "set" = "Sett";
-
-/* Text hint in Bookmarks dialog when no any bookmarks are added */
-"bookmarks_usage_hint" = "Du har ingen bokmerker enda.\nTrykk på et hvilket som helst sted på kartet for å legge til et bokmerke.\nBokmerker fra andre kilder kan også importeres og vises i Organic Maps. Åpne KML-/KMZ-filer med lagrede bokmerker fra e-post, Dropbox eller internettkobling.";
 
 /* Settings button in system menu */
 "settings" = "Innstillinger";
@@ -191,26 +147,11 @@
 /* Ask to wait user several minutes (some long process in modal dialog). */
 "wait_several_minutes" = "Dette kan ta flere minutter. Vent et øyeblikk …";
 
-/* Show bookmarks from this category on a map or not */
-"visible" = "Synlig";
-
-/* Toast which is displayed when GPS has been deactivated */
-"gps_is_disabled_long_text" = "GPS er deaktivert. Dette kan aktiveres i «Innstillinger».";
-
 /* Measurement units title in settings activity */
 "measurement_units" = "Måleenheter";
 
 /* Detailed description of Measurement Units settings button */
 "measurement_units_summary" = "Velg mellom miles og kilometer";
-
-/* Do search in all sources */
-"search_mode_all" = "Everywhere";
-
-/* Do search near my position only */
-"search_mode_nearme" = "Near Me";
-
-/* Do search in current viewport only */
-"search_mode_viewport" = "On the Screen";
 
 /* Search category for cafes, bars, restaurants */
 "eat" = "Spisesteder";
@@ -266,14 +207,8 @@
 /* Search category */
 "police" = "Politi";
 
-/* String in search result list, when nothing found */
-"no_search_results_found" = "Ingen resultater funnet";
-
 /* Notes field in Bookmarks view */
 "description" = "Merknader";
-
-/* Button text */
-"share_by_email" = "Del på e-post";
 
 /* Email Subject when sharing bookmarks category */
 "share_bookmarks_email_subject" = "Delte Organic Maps-bokmerker";
@@ -295,26 +230,11 @@
 /* Warning message when doing search around current position */
 "unknown_current_position" = "Posisjonen din har ikke blitt fastslått enda";
 
-/* Warning message when location country isn't downloaded during search (see also download_location_map_proposal). */
-"download_location_country" = "Last ned det landet du befinner deg i (%@)";
-
-/* Warning message when viewport country isn't downloaded during search */
-"download_viewport_country_to_search" = "Last ned det landet du søker på (%@)";
-
 /* Alert message that we can't run Map Storage settings due to some reasons. */
 "cant_change_this_setting" = "Beklager, innstillingene for kartlagring er for øyeblikket deaktivert.";
 
 /* Alert message that downloading is in progress. */
 "downloading_is_active" = "Nedlasting av land pågår nå.";
-
-/* Message that will be shown in alert view, when we ask user to leave review on App Store */
-"appStore_message" = "Håper du liker å bruke Organic Maps! Hvis du gjør det er det flott om du rangerer eller vurderer appen på App Store. Det tar deg mindre enn ett minutt, men kan virkelig hjelpe oss. Takk for støtten!";
-
-/* No, thanks */
-"no_thanks" = "Nei takk";
-
-/* Share one specific bookmark using SMS, %1$@ contains om:// and %2$@ https://omaps.app link. @NOTE non-ascii symbols in the link will result in max 70 characters SMS instead of 140. */
-"bookmark_share_sms" = "Hei, se merket mitt på Organic Maps! %1$@ eller %2$@ Har du ikke installert offline-kart? Last dem ned her: https://omaps.app/get";
 
 /* Share my position using SMS, %1$@ contains om:// and %2$@ https://omaps.app link WITHOUT NAME. @NOTE non-ascii symbols in the link will result in max 70 characters SMS instead of 140. */
 "my_position_share_sms" = "Hei, se posisjonen min på Organic Maps! %1$@ eller %2$@ Har du ikke offline-kart? Last dem ned her: https://omaps.app/get";
@@ -328,23 +248,11 @@
 /* Share my position using EMail, %1$@ is om:// and %2$@ is https://omaps.app link WITHOUT NAME */
 "my_position_share_email" = "Hei,Jeg er her nå: %1$@. Klikk på denne koblingen %2$@ eller denne %3$@ for å se stedet på kartet.\n\nTakk.";
 
-/* Android share by Message/SMS button text (including SMS) */
-"share_by_message" = "Del med melding";
-
 /* Share button text which opens menu with more buttons, like Message, EMail, Facebook etc. */
 "share" = "Del";
 
-/* iOS share by Message button text (including SMS) */
-"message" = "Melding";
-
 /* Share by email button text, also used in editor. */
 "email" = "E-post";
-
-/* Copy Link */
-"copy_link" = "Kopier kobling";
-
-/* Text for the button that returns to caller application */
-"more_info" = "Vis mer info";
 
 /* Text for message when used successfully copied something */
 "copied_to_clipboard" = "Kopiert til utklippstavlen: %1$@";
@@ -354,15 +262,6 @@
 
 /* Used for bookmark editing */
 "done" = "Ferdig";
-
-/* Summary for preferences in MWM */
-"yopme_pref_summary" = "Velg innstillinger for tilbakeskjerm";
-
-/* Title for yopme preferences in MWM */
-"yopme_pref_title" = "Innstillinger for tilbakeskjerm";
-
-/* Hint for upper-right icon p2b */
-"show_on_backscreen" = "Vis på tilbakeskjermen";
 
 /* Prints version number in About dialog */
 "version" = "Versjon: %@";
@@ -381,19 +280,11 @@
 
 "share_my_location" = "Del posisjonen min";
 
-"menu_search" = "Søk";
-
 /* Settings general group in settings screen */
 "prefs_group_general" = "General settings";
 
 /* Settings information group in settings screen */
 "prefs_group_information" = "Information";
-
-/* Settings screen: "Map" category title */
-"prefs_group_map" = "Kart";
-
-/* Settings screen: "Miscellaneous" category title */
-"prefs_group_misc" = "Diverse";
 
 "prefs_group_route" = "Navigasjon";
 
@@ -419,9 +310,6 @@
 /* Settings «Map» category: «3D buildings» title */
 "pref_map_3d_buildings_title" = "Bygninger i 3D";
 
-/* Settings «Map» category: «3D buildings» summary */
-"pref_map_3d_buildings_subtitle" = "Påvirker batteriets levetid";
-
 /* Settings «Route» category: «Tts enabled» title */
 "pref_tts_enable_title" = "Taleinstrukser";
 
@@ -433,8 +321,6 @@
 
 /* Title for "Other" section in TTS settings. */
 "pref_tts_other_section_title" = "Andre";
-
-"pref_tts_how_to_set_up_voice" = "Slik installerer du stemme";
 
 /* Settings «Map» category: «Record track» title */
 "pref_track_record_title" = "Siste rute";
@@ -455,56 +341,7 @@
 
 "recent_track_help_text" = "Det lar deg lagre ruten du har reist i en spesifikk periode og se den på kartet. Merk: Aktivering av funksjonen øker batteriforbruket. Ruten fjernes automatisk fra kartet når tidsintervallet utløper.";
 
-"pref_track_ios_caption" = "Nylig rute viser ruten du har fulgt.";
-
-"pref_track_ios_subcaption" = "Velg en tidsperiode for rutelagring.";
-
-"placepage_distance" = "Avstand";
-
-"placepage_coordinates" = "Koordinater";
-
-"placepage_unsorted" = "Usortert";
-
 "search_show_on_map" = "Vis på kartet";
-
-/* Used to warn user when fixing KitKat issue */
-"bookmark_move_fail" = "Vi må flytte bokmerkene til internminnet, men det er ingen ledig plass til dem. Du må frigjøre minne, ellers vil ikke bokmerkene være tilgjengelige.";
-
-/* Used in More Apps menu */
-"free" = "Free";
-
-/* Used in More Apps menu */
-"buy" = "Buy";
-
-/* 1st search button-like result */
-"search_on_map" = "Søk på kartet";
-
-/* toast with an error */
-"no_route_found" = "Finner ingen rute";
-
-/* route title */
-"route" = "Rute";
-
-/* category title */
-"routes" = "Ruter";
-
-/* text of notification */
-"download_map_notification" = "Last ned kart over stedet der du befinner deg";
-
-/* text of notification */
-"pro_version_is_free_today" = "Full version of Organic Maps is free today! Download now and tell your friends.";
-
-/* Dialog for transferring maps from lite to pro. */
-"move_lite_maps_to_pro" = "Vi overfører dine nedlastede kart fra Organic Maps Lite til Organic Maps. Det kan ta noen minutter.";
-
-/* Message to display when maps moved. */
-"move_lite_maps_to_pro_ok" = "Nedlastede kart er overført til Organic Maps.";
-
-/* Message to display when maps move failed. */
-"move_lite_maps_to_pro_failed" = "Kartene dine ble ikke overført. Slett Organic Maps Lite og last ned kartene på nytt.";
-
-/* Text in menu */
-"settings_and_more" = "Innstillinger med mer";
 
 /* Text in menu */
 "website" = "Nettside";
@@ -527,14 +364,8 @@
 /* Text in menu */
 "openstreetmap" = "OpenStreetMap";
 
-/* Text in menu */
-"contact_us" = "Kontakt oss";
-
 /* Settings: Send feedback button and dialog title */
 "feedback" = "Tilbakemelding";
-
-/* Text in menu */
-"subscribe_to_news" = "Abonner på nyheter fra oss";
 
 /* Text in menu */
 "rate_the_app" = "Ranger appen";
@@ -548,15 +379,6 @@
 /* Text in menu */
 "report_a_bug" = "Rapporter en feil";
 
-/* Email subject */
-"subscribe_me_subject" = "Jeg vil abonnere på Organic Maps-nyhetsbrevet";
-
-/* Email body */
-"subscribe_me_body" = "Jeg ønsker å være den første som får vite om siste nytt og nye kampanjer. Jeg kan avbestille abonnementet når som helst.";
-
-/* About text */
-"about_text" = "Organic Maps tilbyr de raskeste offline-kartene over alle byer i alle land i verden. Reis trygt: Uansett hvor du er, kan Organic Maps hjelpe deg med å finne ut hvor du er på kartet eller finne nærmeste restaurant, hotell, bank, bensinstasjon osv. Det kreves ingen internettforbindelse.\n\nVi jobber alltid med å legge inn nye funksjoner, og vi vil gjerne høre hvordan du synes at vi kan forbedre Organic Maps. Hvis du får problemer med appen, ikke nøl med å kontakte oss på support@organicmaps.app. Vi svarer på alle forespørsler!\n\nLiker du Organic Maps og ønsker å støtte oss? Det er noen enkle og helt gratis måter å gjøre det på:\n\n- Legg inn en vurdering på app-butikken\n- Lik Facebook-siden vår på http://www.facebook.com/OrganicMaps\n- Eller bare fortell mamma, venner og kolleger om Organic Maps :)\n\nTakk for at du er med oss. Vi setter stor pris på støtten!\n\nPS! Vi henter kartdata fra OpenStreetMap, et kartprosjekt som ligner på Wikipedia, der brukerne selv kan opprette og redigere kart. Hvis du finner mangler eller feil på kartet, kan du korrigere kartet direkte på https://www.openstreetmap.org, og endringene vil vises i Organic Maps-appen når neste versjon kommer.";
-
 /* Alert text */
 "email_error_body" = "E-postklienten har ikke blitt konfigurert. Konfigurer den eller bruk en annen måte å kontakte oss på %@";
 
@@ -569,12 +391,6 @@
 /* Search category */
 "wifi" = "WiFi";
 
-/* Update map suggestion */
-"routing_map_outdated" = "Oppdater kartet for å opprette en rute";
-
-/* Update maps suggestion */
-"routing_update_maps" = "Med den nye versjonen av Organic Maps kan du opprette ruter fra din nåværende posisjon til et ankomststed på kartet. Oppdater kartene for å bruke denne funksjonen.";
-
 /* Update all button text */
 "downloader_update_all_button" = "Oppdater alle";
 
@@ -583,9 +399,6 @@
 
 /* Downloaded maps category */
 "downloader_downloaded_subtitle" = "Lastet ned";
-
-/* Downloaded maps category */
-"downloader_available_maps" = "Tilgjengelig";
 
 /* Country queued for download */
 "downloader_queued" = "Lagt i kø";
@@ -598,17 +411,6 @@
 
 "downloader_downloading" = "Laster ned:";
 
-"downloader_search_results" = "Funnet";
-
-/* Disclaimer message */
-"routing_disclaimer" = "Når du oppretter ruter i Organic Maps-appen må du huske på følgende:\n\n- Foreslåtte ruter må bare betraktes som anbefalinger.\n- Veiforhold, trafikkregler og skilt må gis høyere prioritet enn navigasjonsråd.\n- Kartet kan være feil eller utdatert, og det er ikke sikkert at rutene opprettes på best mulig måte.\n\nVær nøye med veisikkerheten og pass på deg selv!";
-
-/* Outdated maps category */
-"downloader_outdated_maps" = "Utdatert";
-
-/* Up to date maps category */
-"downloader_uptodate_maps" = "Oppdatert";
-
 /* Status of outdated country in the list */
 "downloader_status_outdated" = "Oppdatering";
 
@@ -618,49 +420,14 @@
 /* Displayed in a dialog that appears when a user tries to delete a map while the app is in the follow route mode */
 "downloader_delete_map_while_routing_dialog" = "Stans navigeringen for å slette kartet.";
 
-/* Show when user try build route, but we don't know where he */
-"routing_failed_unknown_my_position" = "Nåværende posisjon er udefinert. Oppgi en posisjon for å opprette en rute.";
-
-/* Show if use has not routing file, or InconsistentMWMandRoute */
-"routing_failed_has_no_routing_file" = "Tilleggsinformasjon som er nødvendig for å opprette ruter fra ditt ståsted.";
-
-/* StartPointNotFound */
-"routing_failed_start_point_not_found" = "Klarer ikke å beregne ruten. Ingen veier i nærheten av startpunktet.";
-
-/* EndPointNotFound */
-"routing_failed_dst_point_not_found" = "Klarer ikke å beregne ruten. Ingen veier i nærheten av reisemålet.";
-
 /* PointsInDifferentMWM */
 "routing_failed_cross_mwm_building" = "Det kan bare opprettes ruter som passer fullstendig innenfor ett enkelt kart.";
-
-/* RouteNotFound */
-"routing_failed_route_not_found" = "Finner ingen rute mellom valgt startsted og destinasjon. Velg et annet start- eller sluttpunkt.";
-
-/* InternalError */
-"routing_failed_internal_error" = "Det oppsto en intern feil. Prøv å slette og laste ned kartet på nytt. Hvis problemet vedvarer kan du kontakte oss på support@organicmaps.app.";
-
-/* Context menu item for downloader. */
-"downloader_download_map_and_routing" = "Last ned kart + rutetilordning";
-
-/* Context menu item for downloader. */
-"downloader_download_routing" = "Last ned rutetilordning";
-
-/* Context menu item for downloader. */
-"downloader_delete_routing" = "Slett rutetilordning";
 
 /* Context menu item for downloader. */
 "downloader_download_map" = "Last ned kartet";
 
-"downloader_download_map_no_routing" = "Last ned kart uten veiviserfunksjon";
-
-/* Button for routing. */
-"routing_go" = "Kjør!";
-
 /* Item status in downloader. */
 "downloader_retry" = "Gjenta";
-
-/* Item in context menu. */
-"downloader_map_and_routing" = "Kart + rutetilordning";
 
 /* Item in context menu. */
 "downloader_delete_map" = "Slett kart";
@@ -668,29 +435,11 @@
 /* Item in context menu. */
 "downloader_update_map" = "Oppdater kart";
 
-/* Item in context menu. */
-"downloader_update_map_and_routing" = "Oppdater kart + rutetilordning";
-
-/* Item in context menu. */
-"downloader_map_only" = "Bare kart";
-
-/* Toolbar title */
-"toolbar_application_menu" = "Applikasjonsmeny";
-
 /* Preference text */
 "pref_use_google_play" = "Bruk Google Play Services for å hente din nåværende posisjon";
 
 /* Text for rating dialog */
 "rating_just_rated" = "Jeg har nettopp vurdert appen";
-
-/* Text for rating dialog */
-"rating_user_since" = "Jeg har vært Organic Maps-bruker siden %@";
-
-/* Text for rating dialog */
-"rating_do_like_maps" = "Liker du Organic Maps?";
-
-/* Text for rating dialog */
-"rating_tap_star" = "Trykk på en stjerne for å vurdere appen.";
 
 /* Text for rating dialog */
 "rating_thanks" = "Tusen takk!";
@@ -701,23 +450,8 @@
 /* Text for rating dialog */
 "rating_send_feedback" = "Send tilbakemelding";
 
-/* Text for g+ dialog */
-"rating_google_plus" = "Klikk på g+ for å fortelle vennene dine om denne appen.";
-
 /* Text for routing error dialog */
 "routing_download_maps_along" = "Last ned kart langs ruten";
-
-/* Text for routing error dialog */
-"routing_download_map" = "Skaff kart";
-
-/* Text for routing error dialog */
-"routing_download_map_and_routing" = "Last ned oppdatert kart og ruteinformasjon for å få alle Organic Maps funksjonene";
-
-/* Text for routing error dialog */
-"routing_get_routing_data" = "Skaff ruteinformasjon";
-
-/* Text for routing error dialog */
-"routing_get_additional_data" = "Tilleggsinformasjon som er nødvendig for å opprette ruter fra ditt ståsted.";
 
 /* Text for routing error dialog */
 "routing_requires_all_map" = "Når du skal opprette en rute må du ha oppdatert alle kartene fra ditt ståsted til din destinasjon.";
@@ -725,50 +459,15 @@
 /* Text for routing error dialog */
 "routing_not_enough_space" = "Ikke nok ledig minne";
 
-/* Text for routing error dialog */
-"routing_download_more_than_avail" = "Du vil laste ned %@ MB, men du har kun %@ MB tilgjengelig.";
-
-/* Text for routing error dialog */
-"routing_download_roaming" = "Du er på vei til å laste ned %@ MB via mobildata (under 'roaming'). Dette kan resultere i påløpende ekstragebyrer, avhengig av din mobiloperatørløsning.";
-
 /* bookmark button text */
 "bookmark" = "bokmerk";
-
-/* map is not downloaded */
-"not_found_map" = "Kartet for posisjonen din er ikke lastet ned";
 
 /* location service disabled */
 "enable_location_services" = "Aktiver posisjonstjenester";
 
-/* download map */
-"download_map" = "Last ned kartet for posisjonen din";
-
-/* download map on iPhone */
-"download_map_iphone" = "Last ned kartet for en aktuell posisjon til iPhone";
-
-/* clear pin */
-"nearby" = "I nærheten";
-
-/* clear pin */
-"clear_pin" = "Fjern merke";
-
-/* location is undefined */
-"undefined_location" = "Nåværende posisjon er udefinert.";
-
-/* download country of your location */
-"download_country" = "Last ned kartet for posisjonen din";
-
-/* download failed */
-"download_failed" = "Nedlasting mislyktes";
-
-/* get the map */
-"get_the_map" = "Hent kartet";
-
 "save" = "Lagre";
 
 "edit_description_hint" = "Dine beskrivelser (tekst eller html)";
-
-"new_group" = "ny gruppe";
 
 "create" = "opprett";
 
@@ -795,30 +494,6 @@
 
 /* pink color */
 "pink" = "Rosa";
-
-/* deep purple color */
-"deep_purple" = "Mørkepurpur";
-
-/* light blue color */
-"light_blue" = "Lyseblå";
-
-/* cyan color */
-"cyan" = "Blågrønn";
-
-/* teal color */
-"teal" = "Smaragdgrønn";
-
-/* lime color */
-"lime" = "Limegrønn";
-
-/* deep orange color */
-"deep_orange" = "Mørkeoransje";
-
-/* gray color */
-"gray" = "Grå";
-
-/* blue gray color */
-"blue_gray" = "Gråblå";
 
 /* Wi-Fi available */
 "WiFi_available" = "Ja";
@@ -848,13 +523,9 @@
 
 "dialog_routing_location_unknown_turn_on" = "Nåværende GPS-koordinater ble ikke funnet. Aktiver stedstjenester for å beregne en rute.";
 
-"dialog_routing_location_unknown" = "Nåværende GPS-koordinater ble ikke funnet.";
-
 "dialog_routing_download_files" = "Last ned nødvendige filer";
 
 "dialog_routing_download_and_update_all" = "Last ned og oppdater all kart- og ruteinformasjon langs den foreslåtte veien for å beregne ruten.";
-
-"dialog_routing_routes_size" = "Ruteinformasjonsfiler";
 
 "dialog_routing_unable_locate_route" = "Kunne ikke finne rute";
 
@@ -884,21 +555,11 @@
 
 "dialog_routing_try_again" = "Vennligst prøv igjen";
 
-"dialog_routing_send_error" = "Rapporter problemet";
-
-"dialog_routing_if_get_cross_route" = "Vil du opprette en mer direkte rute som går over flere kart?";
-
-"dialog_routing_cross_route_is_optimal" = "En mer optimal rute som går utenfor dette kartet er tilgjengelig.";
-
 "not_now" = "Ikke nå";
-
-"dialog_routing_build_route" = "Opprett";
 
 "dialog_routing_download_and_build_cross_route" = "Vil du laste ned kartet og lage en mer optimal rute som går over flere kart?";
 
 "dialog_routing_download_cross_route" = "Last ned kartet for å opprette en mer optimal rute som går utenfor dette kartet.";
-
-"dialog_routing_cross_route_always" = "Kryss alltid denne grensen";
 
 
 /********** Strings for downloading map from search **********/
@@ -906,8 +567,6 @@
 "search_without_internet_advertisement" = "Last vennligst ned kartet for å begynne å søke og opprette ruter - så slipper du i fremtiden å være avhengig av å ha internettforbindelse.";
 
 "search_select_map" = "Velg kartet";
-
-"search_select_other_map" = "Velg et annet kart";
 
 /* «Show» context menu */
 "show" = "Vis";
@@ -918,17 +577,11 @@
 /* «Rename» context menu */
 "rename" = "Nytt navn";
 
-/* Bottom sheet: expand button (should be short) */
-"bottom_sheet_more" = "Mer…";
-
 /* Failed planning route message in navigation view */
 "routing_planning_error" = "Mislykket ruteplanlegging";
 
 /* Arrive routing message in navigation view */
 "routing_arrive" = "Ankomme: %s";
-
-/* Text for routing::RouterResultCode::FileTooOld dialog. */
-"dialog_routing_download_and_update_maps" = "Hvis du vil oppprette en rute, last ned og oppdater alle kartene langs ruten.";
 
 "rate_alert_title" = "Liker du appen?";
 
@@ -944,19 +597,11 @@
 
 "history" = "Historikk";
 
-"next_turn_then" = "Deretter";
-
 "closed" = "Stengt";
-
-"back_to" = "Tilbake til %@";
 
 "search_not_found" = "Beklager, jeg fant ingenting.";
 
 "search_not_found_query" = "Vennligst prøv et annet søk.";
-
-"search_not_found_map" = "Vennligst last ned kartet du søker i.";
-
-"search_not_found_location" = "Last ned kartet til din nåværende beliggenhet.";
 
 "search_history_title" = "Søkehistorikk";
 
@@ -964,23 +609,12 @@
 
 "clear_search" = "Tøm søkehistorikk";
 
-/* Title for settings to enable/disable showcase menu button */
-"showcase_settings_title" = "Vis tilbud";
-
 /* Place Page link to Wikipedia article (if map object has it). */
 "read_in_wikipedia" = "Wikipedia";
 
-"p2p_route_planning" = "Ruteplanlegging";
-
 "p2p_your_location" = "Din beliggenhet";
 
-"p2p_from" = "Avreisested";
-
-"p2p_to" = "Destinasjonssted";
-
 "p2p_start" = "Start";
-
-"p2p_planning" = "Planlegger…";
 
 "p2p_from_here" = "Fra";
 
@@ -1018,15 +652,9 @@
 
 "editor_correct_mistake" = "Rett feil";
 
-"editor_correct_mistake_message" = "Du har gjort en redigeringsfeil. Rett den eller bytt til enkel modus.";
-
 "editor_add_select_location" = "Plassering";
 
 "editor_done_dialog_1" = "Du har endret verdenskartet. Ikke skjul denne! Fortell vennene dine, og rediger det sammen.";
-
-"editor_done_dialog_2" = "Dette er din andre forbedring av kartet. Nå er du på %d. plass i listen av kart-forbedrere. Fortell vennene dine om dette.";
-
-"editor_done_dialog_3" = "Du har forbedret kartet, fortell vennene dine om det, og rediger kartet sammen.";
 
 "share_with_friends" = "Del med venner";
 
@@ -1044,20 +672,7 @@
 
 "editor_report_problem_duplicate_place_title" = "Duplisert sted";
 
-"first_launch_congrats_title" = "Organic Maps er klar til bruk";
-
-"first_launch_congrats_text" = "Søk og naviger i frakoblet status, hvor som helst i verden, helt gratis.";
-
-"migrate_title" = "Viktig!";
-
-/* Android uses image instead of text. */
-"download_all" = "Last ned alle";
-
-"delete_all" = "Slett alle";
-
 "autodownload" = "Automatisk nedlasting";
-
-"disable_autodownload" = "Deaktiver automatisk nedlasting";
 
 /* Place Page opening hours text */
 "closed_now" = "Lukket nå";
@@ -1072,10 +687,6 @@
 "day_off" = "Fridag";
 
 "today" = "I dag";
-
-"sunrise_to_sunset" = "Fra morgen til kveld";
-
-"sunset_to_sunrise" = "Fra solnedgang til soloppgang";
 
 "add_opening_hours" = "Legg til åpningstider";
 
@@ -1095,45 +706,18 @@
 
 "forgot_password" = "Glemt passordet?";
 
-/* Forgot Password dialog title */
-"restore_password" = "Gjenopprett passordet";
-
-"enter_email_address_to_reset_password" = "Skriv inn e-postadressen du brukte ved registreringen, så vil vi sende deg en kobling for å fornye passordet ditt.";
-
-"reset_password" = "Tilbakestill passord";
-
-"username" = "Brukernavn";
-
 "osm_account" = "OSM-konto";
 
 "logout" = "Logg ut";
 
-"login_and_edit_map_motivation_message" = "Logg deg inn og rediger informasjonen til objektene på kartet, så vil vi gjøre den tilgjengelig for millioner av andre brukere. La oss gjøre verden bedre sammen.";
-
 /* Information text: "Last upload 11.01.2016" */
 "last_upload" = "Siste opplasting";
 
-/* Motivates user to login/register, title above login buttons. */
-"you_have_edited_your_first_object" = "Du har redigert ditt første objekt!";
-
 "thank_you" = "Takk skal du ha";
-
-"login_with_google" = "Logg inn med Google";
-
-"login_with_openstreetmap" = "Logg inn med www.openstreetmap.org";
 
 "edit_place" = "Rediger stedet";
 
 "place_name" = "Stedsnavn";
-
-/* title above languages list cells in the editor, below editable name text field. */
-"other_languages" = "Andre språk";
-
-/* small button to open list with names in different languages */
-"show_more" = "Vis mer";
-
-/* small button to close list with names in different languages */
-"show_less" = "Vis mindre";
 
 "add_language" = "Legg til et språk";
 
@@ -1164,8 +748,6 @@
 
 "please_note" = "Vær oppmerksom på at";
 
-"common_no_wifi_dialog" = "Ingen trådløs forbindelse. Vil du fortsette med mobildata?";
-
 "downloader_delete_map_dialog" = "Alle endringer i kartet vil slettes sammen med kartet.";
 
 "downloader_update_maps" = "Oppdater kart";
@@ -1173,10 +755,6 @@
 "downloader_mwm_migration_dialog" = "For å opprette en reiserute må du oppdatere alle kartene og deretter planlegge reiseruten på nytt.";
 
 "downloader_search_field_hint" = "Finn kartet";
-
-"migration_update_all_button" = "Oppdater alle kart";
-
-"migration_delete_all_download_current_button" = "Last ned det oppdaterte kartet og slett de gamle";
 
 "migration_download_error_dialog" = "Nedlastningsfeil";
 
@@ -1186,21 +764,9 @@
 
 "downloader_no_space_message" = "Fjern unødvendig data";
 
-"editor_general_auth_error_dialog" = "Generell innloggingsfeil.";
-
 "editor_login_error_dialog" = "Innloggingsfeil.";
 
-"editor_login_failed_dialog" = "Innloggingen mislyktes";
-
-"editor_username_error_dialog" = "Brukernavnet er ugyldig";
-
-"editor_place_edited_dialog" = "Du har redigert et objekt!";
-
-"editor_login_with_osm" = "Logg inn med OpenStreetMat";
-
 "editor_profile_changes" = "Bekreftede endringer";
-
-"editor_profile_unsent_changes" = "Ikke sendt:";
 
 "editor_focus_map_on_location" = "Dra kartet for å velge riktig beliggenhet for objektet.";
 
@@ -1222,13 +788,9 @@
 
 "editor_report_problem_other_title" = "Et annet problem";
 
-"placepage_report_problem_button" = "Rapporter et problem";
-
 "placepage_add_business_button" = "Legg til organisasjon";
 
 "whatsnew_editor_message_1" = "Legg til nye steder i kartet og rediger eksisterende steder direkte fra appen.";
-
-"whatsnew_editor_message_2" = "* Organic Maps bruker data fra OpenStreetMap-samfunnet.";
 
 "dialog_incorrect_feature_position" = "Endre plassering";
 
@@ -1236,16 +798,10 @@
 
 "login_to_make_edits_visible" = "Logg inn slik at andre brukere kan se endringene du har utført.";
 
-"no_migration_during_navigation" = "Det er ikke mulig å oppdatere under navigering.";
-
 /* Error dialog no space */
 "migration_no_space_message" = "Du må frigjøre mer lagringsplass for å laste ned. Slett unødvendig data.";
 
 "editor_sharing_title" = "Jeg har forbedret Organic Maps kartene";
-
-"editor_comment_will_be_sent" = "Vi vil sende kommentaren din til kartografene.";
-
-"editor_unsupported_category_message" = "Du har lagt til et sted i en kategori som enda ikke har støtte. Den vil vises på kartet senere.";
 
 /* Downloaded 10 **of** 20 <- it is that "of" */
 "downloader_of" = "%1$d av %2$d";
@@ -1278,23 +834,9 @@
 
 "editor_operator" = "Eier";
 
-"editor_tag_description" = "Angi firma, organisasjon eller enkeltperson som er ansvarlig for anlegget.";
-
-"editor_no_local_edits_title" = "Du har ikke lokale redigeringer";
-
-"editor_no_local_edits_description" = "Dette viser antallet foreslåtte endringer på kartet som i øyeblikket bare er tilgjengelige på enheten din.";
-
-"editor_send_to_osm" = "Send til OSM";
-
-"editor_remove" = "Fjern";
-
-"downloader_my_maps_title" = "Mine kart";
-
 "downloader_no_downloaded_maps_title" = "Du har ikke lastet ned noen kart";
 
 "downloader_no_downloaded_maps_message" = "Last ned kart for å finne plasseringen og navigere frakoblet.";
-
-"downloader_find_place_hint" = "Søk etter by eller land";
 
 /* Error title that appears after certain time without location. */
 "current_location_unknown_title" = "Fortsette å oppdage din gjeldende plassering?";
@@ -1321,47 +863,13 @@
 /* iOS Dialog for the case when the location permission is not granted */
 "location_services_disabled_3" = "3.Velg når appen er i bruk";
 
-"placepage_parking_surface" = "Åpen plass";
-
-"placepage_parking_multistorey" = "Fleretasjers";
-
-"placepage_parking_underground" = "Undergrunns";
-
-"placepage_parking_rooftop" = "På taket";
-
-"placepage_parking_sheds" = "Skur";
-
-"placepage_parking_carports" = "Carport";
-
-"placepage_parking_boxes" = "Garasjebokser";
-
-"placepage_parking_pay" = "Betaling";
-
-"placepage_parking_free" = "Gratis";
-
-"placepage_parking_interval" = "Intervallbetaling";
-
-"placepage_entrance_number" = "Nr.";
-
-"placepage_entrance_type" = "Vindfang";
-
-"placepage_flat" = "leil.";
-
-"placepage_open_24_7" = "Døgnåpen";
-
 "meter" = "m";
 
 "kilometer" = "km";
 
-"kilometers_per_hour" = "km/t";
-
 "mile" = "mi";
 
 "foot" = "fot";
-
-"miles_per_hour" = "mph";
-
-"day" = "d";
 
 "hour" = "t";
 
@@ -1381,10 +889,6 @@
 
 "placepage_bookmark_name_hint" = "Bokmerkenavn";
 
-"placepage_personal_notes_hint" = "Personlige notater";
-
-"placepage_delete_bookmark_button" = "Slett bokmerke";
-
 "editor_edits_sent_message" = "De foreslåtte endringene er sendt";
 
 "editor_comment_hint" = "Kommentar…";
@@ -1397,8 +901,6 @@
 
 "editor_remove_place_button" = "Fjern";
 
-"editor_status_sending" = "Sender…";
-
 "editor_place_doesnt_exist" = "Sted finnes ikke";
 
 "text_more_button" = "…mer";
@@ -1410,11 +912,7 @@
 
 "error_enter_correct_email" = "Oppgi en gyldig epostadresse";
 
-"error_enter_correct" = "Oppgi en gyldig verdi";
-
 "refresh" = "Oppdatere";
-
-"last_update" = "Sist oppdatert: %s";
 
 "placepage_add_place_button" = "Legg til en plass på kartet";
 
@@ -1426,24 +924,6 @@
 
 "editor_share_to_all_dialog_message_2" = "Vi vil sjekke endringene. Vi kontakter deg via e-post dersom vi har spørsmål.";
 
-"navigation_overview_button" = "oversikt";
-
-"navigation_stop_button" = "stopp";
-
-/* Text on an empty bookmark page */
-"bookmarks_empty_title" = "Lagre bokmerker";
-
-"bookmarks_empty_message_1" = "Trykk på ★ for å lagre favorittsteder og få rask tilgang.";
-
-"bookmarks_empty_message_2" = "Importer bokmerker fra e-post og nettet.";
-
-"bookmarks_empty_message_3" = "sjekk ut: %s";
-
-/* Name of the group for booked hotels */
-"bookmarks_group_name" = "Bestilte hoteller";
-
-"place_page_button_read_descriprion" = "Les";
-
 /* iOS dialog for the case when recent track recording is on and the app comes back from background */
 "recent_track_background_dialog_title" = "Deaktivere opptak av nylig reiste rute?";
 
@@ -1451,8 +931,6 @@
 
 /* For sharing via SMS and so on */
 "sharing_call_action_look" = "Sjekk ut";
-
-"continue_recent_track_background_button" = "Fortsett";
 
 "recent_track_background_dialog_message" = "Organic Maps bruker geografiske funksjoner i bakgrunnen for å registrere din nylig reiste rute.";
 
@@ -1468,33 +946,13 @@
 /* About short text (below logo) */
 "about_description" = "Organic Maps er en offline app for reising. Organic Maps bygger på OpenStreetMap-data og tillater redigering av den.";
 
-/* Text in menu */
-"blog" = "Blogg";
-
 "general_settings" = "Generelle innstillinger";
-
-"date" = "Dato %d";
-
-/* "Report a bug" -> "Generaal Feedback" -> "Something is not working" */
-"something_is_not_working" = "Noe fungerer ikke som det skal";
 
 /* For the first routing */
 "accept" = "Godta";
 
-"accept_and_continue" = "Accept and continue";
-
 /* For the first routing */
 "decline" = "Avvis";
-
-"install_app" = "Installer";
-
-"search_no_results_title" = "Fant ingen resultater";
-
-"search_no_results_message" = "Prøv et mer generelt søkeord, zoom ut eller tilbakestill filteret.";
-
-"search_no_results_expand_area_button" = "Zoom ut";
-
-"search_no_results_reset_button" = "Tilbakestill filter";
 
 /* noun */
 "search_in_table" = "Liste";
@@ -1517,8 +975,6 @@
 
 "traffic_update_maps_text" = "For å vise trafikkdata må kartene i appen være oppdaterte.";
 
-"traffic_outdated" = "Trafikkdata er utdatert.";
-
 "big_font" = "Forstørr skriften på kartet";
 
 "traffic_update_app" = "Vennligst oppdater Organic Maps";
@@ -1529,17 +985,7 @@
 /* "traffic" as in "road congestion" */
 "traffic_data_unavailable" = "Trafikkdata er ikke tilgjengelig";
 
-/* "Translation is no needed, because it's a company name" */
-"uber" = "Uber";
-
-/* Simplified colour scheme for traffic information, fewer colours are used to display traffic jams on the map. The string should be kept as short as possible */
-"pref_traffic_simplified_colors_title" = "Enkelt trafikkfargeoppsett";
-
 "enable_logging" = "Aktiver loggføring";
-
-"offline_place_page_more_information" = "Koble til internett for å få mer informasjon om stedet.";
-
-"failed_load_information" = "Kunne ikke laste inn informasjon.";
 
 /* Settings: "Send general feedback" button */
 "feedback_general" = "Generell tilbakemelding";
@@ -1556,8 +1002,6 @@
 
 "whatsnew_transliteration_title" = "Omskrivning til latin";
 
-"yandex_taxi_title" = "Yandex.Taxi";
-
 "learn_more" = "Finn ut mer";
 
 "core_exit" = "Avslutt";
@@ -1568,75 +1012,19 @@
 
 "button_exit" = "Avslutt";
 
-"settings_device_memory" = "Enhetsminnet";
-
-"settings_card_memory" = "Minnekort";
-
-"settings_storage_available" = "%s tilgjengelig";
-
-"toast_location_permission_denied" = "App-plasseringstillatelse avvist";
-
-"button_use" = "Bruk";
-
 "planning_route_manage_route" = "Administrere rute";
 
 "button_plan" = "Planlegge";
-
-"button_add" = "Angi";
 
 "placepage_remove_stop" = "Fjern";
 
 "planning_route_remove_title" = "Dra hit for å fjerne";
 
-"dialog_change_start_point_message" = "Plassére startpunkt til nåværende plassering?";
-
-"button_replace" = "Plassére";
-
 "placepage_add_stop" = "Angi stopp";
-
-/* Only ru/en are needed */
-"subtitle_rent" = "Rent";
-
-/* Only ru/en are needed */
-"rub_month" = "RUB/month";
-
-/* Only ru/en are needed */
-"room" = "%s-room apt.";
-
-/* Only ru/en are needed */
-"real_estate" = "Real estate";
-
-"add_my_position" = "Legg til min posisjon";
-
-"choose_start_point" = "Velg startpunkt";
-
-"choose_destination" = "Velg destinasjon";
 
 "preloader_viator_button" = "Finn ut mer";
 
-"start_from_my_position" = "Start fra";
-
-"profile_authorization_title" = "Logg inn med";
-
-"profile_authorization_message" = "Enkel innlogging uten innloggingsinfo og passord på bare noen sekunder";
-
 "profile_authorization_error" = "Oops, en feil oppstod. Prøv å logge inn på nytt.";
-
-"service" = "Service";
-
-"atmosphere" = "Atmosfære";
-
-"value_for_money" = "Valuta for pengene";
-
-"experience" = "Erfaren";
-
-"assortment" = "Utvalg";
-
-"expertise" = "Kompetanse";
-
-"equipment" = "Utstyr";
-
-"quality" = "Kvalitet";
 
 "dialog_error_storage_title" = "Problemer med tilgang til lagring";
 
@@ -1644,17 +1032,7 @@
 
 "setting_emulate_bad_storage" = "Emulere skadet lagring";
 
-"directions_finish" = "Destinasjon";
-
-"directions_on_foot" = "Gå %s";
-
 "core_entrance" = "Inngang";
-
-"coffee" = "Kaffe";
-
-"cleanliness" = "Renslighet";
-
-"crowdedness" = "Mye folk";
 
 "error_enter_correct_name" = "Skriv inn korrekt navn";
 
@@ -1673,11 +1051,9 @@
 
 "downloader_percent" = "%s (%s av %s)";
 
-"downloader_process" = "Laster ned %s ...";
+"downloader_process" = "Laster ned %s …";
 
-"downloader_applying" = "Bruker %s ...";
-
-"dialog_message_transit_not_found_connection" = "Planlegg en rute innenfor transittnettverket";
+"downloader_applying" = "Bruker %s …";
 
 "bookmarks_error_message_share_general" = "Kan ikke dele på grunn av en programfeil";
 
@@ -1695,17 +1071,7 @@
 
 "bookmarks_error_message_list_name_already_taken" = "Vennligst velg et annet navn";
 
-"bookmarks_error_title_list_name_too_long" = "Dette navnet er for langt";
-
-"bookmarks_error_message_list_name_too_long" = "Vennligst velg et annet navn";
-
-"please_wait" = "Vennligst vent...";
-
-"phone_number" = "Telefonnummer";
-
-"notification_unsent_reviews_title" = "Du har flere usendte anmeldelser";
-
-"notification_unsent_reviews_message" = "Vennligst logg inn for å dele anmeldelser med andre reisende";
+"please_wait" = "Vennligst vent…";
 
 "profile" = "OpenStreetMap profil";
 
@@ -1719,49 +1085,13 @@
 
 "bookmarks_convert_error_message" = "Noen filer ble ikke konvertert.";
 
-"converting" = "Konvertere...";
-
-"wn_reinvented_bookmarks_title" = "Vi gjenoppfunnet bokmerker!";
-
-"wn_reinvented_bookmarks_message" = "Du kan sikkerhetskopiere bokmerker, lage lister... Det er utrolig...";
-
-"bookmarks_restore" = "Gjenopprett bokmerker";
-
-"bookmarks_restore_process" = "Gjenopprette...";
-
 "bookmarks_restore_title" = "Gjenopprett denne versjonen?";
 
-"bookmarks_restore_message" = "Bokmerkene dine gjenopprettes fra %s (%s)";
-
-"bookmarks_restore_empty_title" = "Du har ikke en sikkerhetskopi";
-
-"bookmarks_restore_empty_message" = "Serveren fant ikke tidligere sikkerhetskopier";
-
 "common_check_internet_connection_dialog_title" = "Ingen internettforbindelse";
-
-"error_server_title" = "Serverfeil";
-
-"error_server_message" = "Det oppsto en feil på serveren, prøv igjen senere";
 
 "error_system_message" = "En ukjent feil oppstod";
 
 "restore" = "Restaurere";
-
-"bookmarks_page_downloaded" = "Downloaded";
-
-"bookmarks_page_my" = "My";
-
-"routes_and_bookmarks" = "Routes and bookmarks";
-
-"bookmarks_webview_success_toast" = "Bookmarks succesfully downloaded";
-
-"cached_bookmarks_placeholder_title" = "Download new places";
-
-"cached_bookmarks_placeholder_subtitle" = "Press the button to download thousands of interesting places and routes created by Organic Maps users. You will need the internet connection.";
-
-"downloader_download_routers" = "Download bookmarks";
-
-"bookmarks_groups_cached" = "Downloaded lists";
 
 "subtittle_opt_out" = "Tracking settings";
 
@@ -1769,29 +1099,15 @@
 
 "crash_reports_description" = "We may use your data to improve Organic Maps experience. Changes will take effect after you restart the app.";
 
-"opt_out_help_ios_1" = "Your mobile device may provide a “Limit Ad Tracking” or “Opt out of interest-based advertising” setting.";
-
-"opt_out_help_ios_2" = "iOS 9 or Higher";
-
-"opt_out_help_ios_3" = "Go to your Settings → Privacy → Advertising → Enable the “Limit Ad Tracking” setting";
-
-"opt_out_help_android" = "Your mobile device may provide a “Limit Ad Tracking” or “Opt out of interest-based advertising” setting.\n\nFor Android and Google Play Services version 4.0 and up:\nSettings → Google → Ads → Opt out of Ads Personalization\nor\nSettings → Google → Google Account → Personal info & privacy → Ads Settings → Ads Personalization";
-
 "privacy_policy" = "Privacy policy";
 
 "terms_of_use" = "Terms of use";
-
-"backup_notification_failed" = "Backing up your bookmarks has been suspended. Log in to turn it back on.";
 
 "button_layer_traffic" = "Traffic";
 
 "button_layer_subway" = "Subway";
 
 "layers_title" = "Map layers";
-
-"layers_message" = "Use map layers to display the traffic, subway map, and other useful information";
-
-"button_layer_got_it" = "Got it";
 
 "subway_data_unavailable" = "Subway map is unavailable";
 
@@ -1803,39 +1119,13 @@
 
 "title_error_downloading_bookmarks" = "An error occurred";
 
-"subtitle_error_downloading_bookmarks" = "Bookmarks were not downloaded";
-
-"error_already_downloaded" = "This list has already been downloaded";
-
 "popular_place" = "Popular";
-
-"download_routes" = "Download routes";
-
-"bookmarks_downloaded_title" = "Bookmarks have been downloaded successfully";
-
-"bookmarks_downloaded_subtitle" = "Press ‘View on map’ to explore new places from the list";
-
-"why_support" = "Why support Organic Maps?";
-
-"why_support_item1" = "We respect your privacy: there are zero trackers in the app, and we are open source";
-
-"why_support_item2" = "You help us to improve Organic Maps";
-
-"why_support_item3" = "You help us improve open maps OpenStreetMap.org";
-
-"channels_map_update" = "Map updates";
-
-"server_unavailable_title" = "Server is unavailable";
-
-"sharing_options" = "Delemuligheter";
 
 "export_file" = "Eksporter fil";
 
 "list_settings" = "Liste Innstillinger";
 
 "delete_list" = "Slett liste";
-
-"hide_from_map" = "Skjul fra kart";
 
 "public_access" = "Offentlig tilgang";
 
@@ -1845,40 +1135,11 @@
 
 "bookmark_category_description_hint" = "Lag en beskrivelse (text or html)";
 
-/* FIXME */
-"bookmarks_public_access" = "bookmarks_public_access";
-
-/* FIXME */
-"bookmarks_link_access" = "bookmarks_link_access";
-
-/* FIXME */
-"bookmarks_private_access" = "bookmarks_private_access";
-
 "not_shared" = "Privat";
-
-"direct_link_progress_text" = "Laster opp filen din…";
-
-"direct_link_success" = "Lenken er opprettet";
-
-"send_a_link_btn" = "Send meg en link";
-
-"upload_error_toast" = "Det oppsto en feil under opplasting av filen";
 
 "tags_loading_error_subtitle" = "Det oppsto en feil under lasting av emneknagger, prøv igjen";
 
-"unable_upload_errorr_title" = "Filopplasting mislyktes";
-
-"unable_upload_error_subtitle_edited" = "Denne filen har blitt redigert via nettappappen";
-
-"unable_upload_error_subtitle_broken" = "Denne filen er skadet og kan ikke lastes opp. Vennligst last opp en annen fil.";
-
-"contact" = "Kontakt";
-
-"download_button" = "Last ned";
-
 "speedcams_alert_title" = "Fartskamera";
-
-"speedcams_alert_subtitle" = "Advar om fartsgrenser";
 
 "speedcam_option_auto" = "Auto";
 
@@ -1886,18 +1147,10 @@
 
 "speedcam_option_never" = "Aldri";
 
-"bookmark_description_title" = "Beskrivelse av bokmerke";
-
 "place_description_title" = "Plasser beskrivelse";
 
 /* this text will be shown in application notification preferences opposite checkbox which enable/disable downloader notifications. Devices on Android 8+ are affected. */
 "notification_channel_downloader" = "Nedlast kart";
-
-"share_bookmarks_email_body_link" = "Hei!\n\nHer er lenken der du kan laste ned bokmerkene dine: %s. Åpne listen via Organic Maps og nyt reisen!\n\nFå tak i app: https://omaps.app/get?kmz";
-
-"warning_speedcams_title" = "Navigatøren vil advare deg om kameraer når du overskrider fartsgrensen på %d km/t";
-
-"warning_speedcams_subtitle" = "Vær oppmerksom på kjøreregler for landet du reiser til.";
 
 "speedcams_notice_message" = "Auto - Advarsel om fartskamera hvis det er fare for å overskride fartsgrensen\nAlltid - Advar alltid om farskameraer\nAldri - Advar aldri om fartskameraer";
 
@@ -1913,23 +1166,7 @@
 
 "enable_logging_warning_message" = "Alternativet slår på logging for diagnostiske formål. Det kan være nyttig for våre supportpersonale som feilsøker problemer med appen. Aktiver dette alternativet bare på forespørsel fra Organic Maps-brukerstøtte.";
 
-"html_error_upload_message_try_again" = "Vennligst sjekk nettverksinnstillingene og prøv igjen";
-
-"html_error_upload_title_try_again" = "Ingen internettforbindelse";
-
-"notification_leave_review_v2_android_short_title" = "Anmeld og hjelp reisende!";
-
-"megafon" = "Say goodbye to roaming!";
-
-"notifications_illegal_alert_disable_button" = "Skru av notefikasjoner";
-
 "access_rules_author_only" = "Redigering på nett";
-
-"privacy_settings_menu" = "Pesonverninstillinger";
-
-"unable_upadate_error_title" = "Feil ved fil-oppdatering";
-
-"unable_upadate_error_message" = "Feil oppstod ved oppdatering. Sjekk forandringer og prøv igjen";
 
 "driving_options_title" = "Kjørealternativer";
 
@@ -1951,94 +1188,19 @@
 
 "change_driving_options_btn" = "Kjørealternativer aktivert";
 
-"toll_road" = "Bompengevei";
-
-"unpaved_road" = "Uasfaltert vei";
-
-"ferry_crossing" = "Fergeovergang";
-
-"operated_by" = "Bemannet av \"%s\"";
-
 "avoid_toll_roads_placepage" = "Unngå bompengeveier";
 
 "avoid_unpaved_roads_placepage" = "Unngå uasfalterte veier";
 
 "avoid_ferry_crossing_placepage" = "Unngå fergeoverganger";
 
-"type.cuisine.uzbek" = "Usbekisk mat";
-
-"trip_start" = "La oss begynne";
-
-"pick_destination" = "Destinasjon";
-
-"follow_my_position" = "Sentrer";
-
-"search_results" = "Søkeresultater";
-
-"then_turn" = "Deretter";
-
-"redirect_route_alert" = "Vil du planlegge en rute på nytt?";
-
-"redirect_route_yes" = "Ja";
-
-"redirect_route_no" = "Nei";
-
-"trip_finished" = "Du har ankommet!";
-
-"keyboard_availability_alert" = "Tastatur er ikke tilgjengelig mens en kjører";
-
-"dialog_routing_change_start_carplay" = "Kan ikke planlegge rute fra din nåværende posisjon";
-
-"dialog_routing_change_end_carplay" = "Kan ikke planlegge rute til din nåværende posisjon. Vennligst velg en annen posisjon";
-
-"dialog_routing_check_gps_carplay" = "Ingen GPS-signal. Vennligst gå til et åpent område";
-
-"dialog_routing_unable_locate_route_carplay" = "Kan ikke planlegge rute. Vennligst spesifiser en annen posisjon for rute";
-
-"dialog_routing_download_files_carplay" = "For å beregne rute last ned manglende kart på enheten din";
-
-"dialog_routing_system_error_carplay" = "Feil oppstod. Vennligst restart appen";
-
-"dialog_routing_rebuild_from_current_location_carplay" = "Rute vil planlegges fra din nåværende posisjon";
-
-"dialog_routing_rebuild_for_vehicle_carplay" = "Rute vil oppdateres til kjørerute";
-
 "ok" = "Ok";
-
-"avoid_unpaved_carplay_1" = "Ikke grusvei";
-
-"avoid_unpaved_carplay_2" = "Ikke uasfaltert";
-
-"avoid_ferry_carplay_1" = "Ingen ferger";
-
-"avoid_ferry_carplay_2" = "Unngå ferger";
-
-"avoid_tolls_carplay_1" = "Ingen bomvei";
-
-"avoid_tolls_carplay_2" = "Unngå bomvei";
-
-"speedcams_alert_title_carplay_1" = "Kamera-info";
-
-"speedcams_alert_title_carplay_2" = "Kamera-advarsel";
-
-"download_map_carplay" = "Vennligst last ned kart i Organic Maps appen på enheten din";
-
-"carplay_roundabout_exit" = "%s avkjøring";
 
 /* max. 10 symbols, both iOS and Android */
 "sort" = "Sortere…";
 
 /* Android, title, max 20-22 symbols */
 "sort_bookmarks" = "Sortere merker";
-
-/* iOS */
-"sort_default" = "Sortere som standard";
-
-"sort_type" = "Sortere etter type";
-
-"sort_distance" = "Sortere etter avstand";
-
-"sort_date" = "Sortere etter dato";
 
 /* Android */
 "by_default" = "Som standard";
@@ -2052,63 +1214,7 @@
 /* Android */
 "by_date" = "Etter dato";
 
-"week_ago_sorttype" = "For en uke siden";
-
-"month_ago_sorttype" = "For en måned siden";
-
-"moremonth_ago_sorttype" = "Mer enn en måned siden";
-
-"moreyear_ago_sorttype" = "Mer enn ett år siden";
-
-"near_me_sorttype" = "Nær meg";
-
-"others_sorttype" = "Andre";
-
-"food_places" = "Mat";
-
-"tourist_places" = "Severdigheter";
-
-"museums" = "Museer";
-
-"parks" = "Parker";
-
-"swim_places" = "Svømming";
-
-"mountains" = "Fjell";
-
-"animals" = "Dyr";
-
-"hotels" = "Hoteller";
-
-"buildings" = "Bygninger";
-
-"money" = "Penger";
-
-"shops" = "Butikker";
-
-"parkings" = "Parkeringer";
-
-"fuel_places" = "Bensinstasjoner";
-
-"water" = "Vann";
-
-"medicine" = "Medisin";
-
 "search_in_the_list" = "Søk på lista";
-
-"view_on_map_bookmarks" = "På kartet";
-
-"more_bookmarks" = "Mer…";
-
-"no_items_found" = "Ingenting funnet";
-
-/* Android, max 18 symbols */
-"bookmarks_edit_list" = "Endre";
-
-/* Android, max 18 symbols */
-"bookmarks_delete_list" = "Slette lista";
-
-"religious_places" = "Hellige steder";
 
 "select_list" = "Velge liste";
 
@@ -2118,26 +1224,13 @@
 
 "dialog_pedestrian_route_is_long_message" = "Velg utgangspunkt eller destinasjon som befinner seg nærmere en T-bane stasjon";
 
-/* Failed planning SUBWAY route message in navigation view */
-"routing_planning_error_subway_special" = "Feil ved ruteplanlegging";
-
 "button_layer_isolines" = "Høyder";
-
-"tips_map_layers_title_countour" = "Høydekurver uten nett med Organic Maps!";
-
-"tips_map_layers_message_countour" = "Høydekurver hjelper deg å planlegge turen din og ikke gå seg vill";
 
 "isolines_activation_error_dialog" = "For å bruke høydekurver oppdater eller last opp kartet til nødvendig område";
 
 "isolines_location_error_dialog" = "Høydekurver er ikke tilgjengelige i dette området ennå";
 
 "elevation_profile_diff_level" = "Vanskelighetsgrad";
-
-"elevation_profile_diff_level_easy" = "Lett";
-
-"elevation_profile_diff_level_moderate" = "Middels";
-
-"elevation_profile_diff_level_hard" = "Vanskelig";
 
 "elevation_profile_ascent" = "Stigning";
 
@@ -2147,25 +1240,13 @@
 
 "elevation_profile_maxaltitude" = "Maks. høyde";
 
-"elevation_profile_m" = "m";
-
 "elevation_profile_difficulty" = "Vanskelighet";
 
 "elevation_profile_distance" = "Avstand:";
 
-"elevation_profile_km" = "km";
-
 "elevation_profile_time" = "I rute";
 
-"elevation_profile_hours" = "t.";
-
-"elevation_profile_minutes" = "min";
-
 "isolines_toast_zooms_1_10" = "Forstørr kartet for å se høydekurver";
-
-"downloader_updating_ios" = "Oppdatering";
-
-"downloader_loading_ios" = "Nedlasting";
 
 "key_information_title" = "Nøkkelinformasjon";
 

--- a/iphone/Maps/LocalizedStrings/nb.lproj/Localizable.stringsdict
+++ b/iphone/Maps/LocalizedStrings/nb.lproj/Localizable.stringsdict
@@ -9,21 +9,6 @@
 
 <!-- ********** Strings for downloading map from search **********/ -->
 
-  <key>bookmarks_places</key>
-  <dict>
-    <key>NSStringLocalizedFormatKey</key>
-    <string>%#@value@</string>
-    <key>value</key>
-    <dict>
-      <key>NSStringFormatSpecTypeKey</key>
-      <string>NSStringPluralRuleType</string>
-      <key>NSStringFormatValueTypeKey</key>
-      <string>d</string>
-      <key>other</key>
-      <string>%d bokmerker</string>
-    </dict>
-  </dict>
-
   <key>bookmarks_detect_message</key>
   <dict>
     <key>NSStringLocalizedFormatKey</key>
@@ -38,21 +23,6 @@
       <string>%d filen ble funnet. Du vil se dem etter konverteringen.</string>
       <key>other</key>
       <string>%d filer funnet. Du vil se dem etter konverteringen.</string>
-    </dict>
-  </dict>
-
-  <key>bookmarks_objects</key>
-  <dict>
-    <key>NSStringLocalizedFormatKey</key>
-    <string>%#@value@</string>
-    <key>value</key>
-    <dict>
-      <key>NSStringFormatSpecTypeKey</key>
-      <string>NSStringPluralRuleType</string>
-      <key>NSStringFormatValueTypeKey</key>
-      <string>d</string>
-      <key>other</key>
-      <string>%s objects</string>
     </dict>
   </dict>
 

--- a/iphone/Maps/LocalizedStrings/nl.lproj/Localizable.strings
+++ b/iphone/Maps/LocalizedStrings/nl.lproj/Localizable.strings
@@ -18,9 +18,6 @@
 /* Button which deletes downloaded country */
 "delete" = "Verwijder";
 
-/* Button "do not interrupt download" if user touched actively downloading country */
-"do_nothing" = "Doorgaan";
-
 "download_maps" = "Gedownloade Kaarten";
 
 /* Settings/Downloader - info for country when download fails */
@@ -28,9 +25,6 @@
 
 /* Settings/Downloader - info for country which started downloading */
 "downloading" = "Downloaden…";
-
-/* Settings/Downloader - size string, only strings different from English should be translated */
-"kb" = "KB";
 
 /* Choose measurement on first launch alert - choose metric system button */
 "kilometres" = "Kilometers";
@@ -55,17 +49,11 @@
 /* Update maps later/Buy pro version later button text */
 "later" = "Later";
 
-/* Don't show some dialog any more */
-"never" = "Nooit";
-
 /* View and button titles for accessibility */
 "search" = "Zoeken";
 
 /* Search box placeholder text */
 "search_map" = "Zoek Kaart";
-
-/* Settings/Downloader - info for not downloaded country */
-"touch_to_download" = "Klik om te downloaden";
 
 /* Settings/Downloader - 3G download warning dialog confirm button */
 "use_cellular_data" = "Ja";
@@ -73,20 +61,11 @@
 /* Location services are disabled by user alert - message */
 "location_is_disabled_long_text" = "U heeft momenteel alle Locatie Services voor dit apparaat of deze app uitgeschakeld. Schakel ze in bij Instellingen";
 
-/* Location Services are not available on the device alert - message */
-"device_doesnot_support_location_services" = "Uw apparaat ondersteunt geen Locatie Services";
-
 /* View and button titles for accessibility */
 "zoom_to_country" = "Op de kaart tonen";
 
-/* Button text for the button at the center of the screen when the country is not downloaded */
-"country_status_download" = "Kaart downloaden\n(^ ^)";
-
 /* Button text for the button at the center of the screen when the country is not downloaded and the size should not be shown */
 "country_status_download_without_size" = "Kaart downloaden";
-
-/* Button text for the button at the center of the screen when the country is not downloaded */
-"country_status_download_without_routing" = "Download kaart\nzonder routeplanning (^ ^)";
 
 /* Message to display at the center of the screen when the country download has failed */
 "country_status_download_failed" = "Downloaden is niet gelukt";
@@ -96,19 +75,13 @@
 
 "about_menu_title" = "Over Organic Maps";
 
-"downloaded_touch_to_delete" = "Downloaded (%@), klik om te verwijderen";
-
 "connection_settings" = "Verbindingsinstellingen";
-
-"download_mb_or_kb" = "Download %@";
 
 "close" = "Sluiten";
 
 "unsupported_phone" = "Een hardware geaccellereerde OpenGL is nodig. Jammer genoeg wordt uw apparaat niet ondersteund.";
 
 "download" = "Download";
-
-"external_storage_is_not_available" = "SD kaart/USB opslag met gedownloade kaarten is niet beschikbaar";
 
 "disconnect_usb_cable" = "Verwijder de USB kabel of plaats een geheugen kaart om Organic Maps te gebruiken";
 
@@ -117,8 +90,6 @@
 "not_enough_memory" = "Not genoeg geheugen om app te starten";
 
 "download_resources" = "Voor u van start gaat downloaden we een wereldkaart naar uw apparaat.\nDe kaart neemt %@ in beslag.";
-
-"getting_position" = "Huidige locatie opvragen";
 
 "download_resources_continue" = "Ga naar de Kaart";
 
@@ -140,23 +111,14 @@
 /* Add New Bookmark Set dialog title */
 "add_new_set" = "Voeg nieuwe Groep toe";
 
-/* Place Page - Add To Bookmarks button */
-"add_to_bookmarks" = "Toevoegen aan Bladwijzers";
-
 /* Bookmark Color dialog title */
 "bookmark_color" = "Bladwijzer Kleur";
 
 /* Add Bookmark Set dialog - hint when set name is empty */
 "bookmark_set_name" = "Bladwijzer Groep Naam";
 
-/* Bookmark Sets dialog title */
-"bookmark_sets" = "Bladwijzer groepen";
-
 /* Bookmarks - dialog title */
 "bookmarks" = "Bladwijzers";
-
-/* Add bookmark dialog - bookmark color */
-"color" = "Kleur";
 
 /* Default bookmarks set name */
 "core_my_places" = "Mijn Plaatsen";
@@ -167,14 +129,8 @@
 /* Editor title above street and house number */
 "address" = "Adres";
 
-/* Place Page - Remove Pin button */
-"remove_pin" = "Verwijder speld";
-
 /* Add bookmark dialog - bookmark set, Bookmarks dialog - Bookmark set cell */
 "set" = "Groep";
-
-/* Text hint in Bookmarks dialog when no any bookmarks are added */
-"bookmarks_usage_hint" = "Je hebt nog geen bladwijzers.\nTik op een plek op de kaart om een bladwijzer toe te voegen.\nBladwijzers uit andere bronnen kunnen ook worden geïmporteerd en weergegeven in de Organic Maps app. Open KML/KMZ bestand met opgeslagen speldjes uit mail, Dropbox of weblink.";
 
 /* Settings button in system menu */
 "settings" = "Instellingen";
@@ -191,26 +147,11 @@
 /* Ask to wait user several minutes (some long process in modal dialog). */
 "wait_several_minutes" = "Dit kan enkele minuten duren.\nEven geduld…";
 
-/* Show bookmarks from this category on a map or not */
-"visible" = "Zichtbaar";
-
-/* Toast which is displayed when GPS has been deactivated */
-"gps_is_disabled_long_text" = "GPS is uitgeschakeld. Schakel ze in bij Instellingen.";
-
 /* Measurement units title in settings activity */
 "measurement_units" = "Afstandseenheid";
 
 /* Detailed description of Measurement Units settings button */
 "measurement_units_summary" = "Kies tussen mijlen en kilometers";
-
-/* Do search in all sources */
-"search_mode_all" = "Overal";
-
-/* Do search near my position only */
-"search_mode_nearme" = "Dichtbij mij";
-
-/* Do search in current viewport only */
-"search_mode_viewport" = "Op het scherm";
 
 /* Search category for cafes, bars, restaurants */
 "eat" = "Waar iets gaan eten";
@@ -266,14 +207,8 @@
 /* Search category */
 "police" = "Politie";
 
-/* String in search result list, when nothing found */
-"no_search_results_found" = "Geen resultaten gevonden";
-
 /* Notes field in Bookmarks view */
 "description" = "Notities";
-
-/* Button text */
-"share_by_email" = "Delen via email";
 
 /* Email Subject when sharing bookmarks category */
 "share_bookmarks_email_subject" = "Bladwijzers van Organic Maps met u gedeeld";
@@ -295,26 +230,11 @@
 /* Warning message when doing search around current position */
 "unknown_current_position" = "Je plaats werd nog niet vastgesteld";
 
-/* Warning message when location country isn't downloaded during search (see also download_location_map_proposal). */
-"download_location_country" = "Download land waar je nu bent (%@)";
-
-/* Warning message when viewport country isn't downloaded during search */
-"download_viewport_country_to_search" = "Download land waar je op wilt zoeken (%@)";
-
 /* Alert message that we can't run Map Storage settings due to some reasons. */
 "cant_change_this_setting" = "Sorry, instellingen voor kaartopslag uitgeschakeld.";
 
 /* Alert message that downloading is in progress. */
 "downloading_is_active" = "Het downloaden van het land is nu aan de gang.";
-
-/* Message that will be shown in alert view, when we ask user to leave review on App Store */
-"appStore_message" = "Ik hoop dat u veel plezier hebt met Organic Maps! Zo ja, geef de app dan een cijfer in de App Store of schrijf een recensie. Dit duurt minder dan een minuut, maar kan ons echt helpen. Bedankt voor uw steun!";
-
-/* No, thanks */
-"no_thanks" = "Nee, bedankt";
-
-/* Share one specific bookmark using SMS, %1$@ contains om:// and %2$@ https://omaps.app link. @NOTE non-ascii symbols in the link will result in max 70 characters SMS instead of 140. */
-"bookmark_share_sms" = "Bekijk mijn pin op de kaart. Open %1$@ of %2$@";
 
 /* Share my position using SMS, %1$@ contains om:// and %2$@ https://omaps.app link WITHOUT NAME. @NOTE non-ascii symbols in the link will result in max 70 characters SMS instead of 140. */
 "my_position_share_sms" = "Kijk waar ik nu ben. Open %1$@ of %2$@";
@@ -328,23 +248,11 @@
 /* Share my position using EMail, %1$@ is om:// and %2$@ is https://omaps.app link WITHOUT NAME */
 "my_position_share_email" = "Hoi,\n\nMomenteel ben ik hier: %1$@. Klik op deze %2$@ of deze %3$@ om de plaats op de kaart te zien.\n\nBedankt.";
 
-/* Android share by Message/SMS button text (including SMS) */
-"share_by_message" = "Delen via bericht";
-
 /* Share button text which opens menu with more buttons, like Message, EMail, Facebook etc. */
 "share" = "Delen";
 
-/* iOS share by Message button text (including SMS) */
-"message" = "Bericht";
-
 /* Share by email button text, also used in editor. */
 "email" = "Email";
-
-/* Copy Link */
-"copy_link" = "Kopieer koppeling";
-
-/* Text for the button that returns to caller application */
-"more_info" = "Toon meer info";
 
 /* Text for message when used successfully copied something */
 "copied_to_clipboard" = "Op het klembord gekopieerd: %1$@";
@@ -354,15 +262,6 @@
 
 /* Used for bookmark editing */
 "done" = "Gedaan";
-
-/* Summary for preferences in MWM */
-"yopme_pref_summary" = "Kies instellingen voor achtergrondscherm";
-
-/* Title for yopme preferences in MWM */
-"yopme_pref_title" = "Instellingen voor achtergrondscherm";
-
-/* Hint for upper-right icon p2b */
-"show_on_backscreen" = "Toon op achtergrondscherm";
 
 /* Prints version number in About dialog */
 "version" = "Versie: %@";
@@ -381,19 +280,11 @@
 
 "share_my_location" = "Deel mijn locatie";
 
-"menu_search" = "Zoek";
-
 /* Settings general group in settings screen */
 "prefs_group_general" = "General settings";
 
 /* Settings information group in settings screen */
 "prefs_group_information" = "Information";
-
-/* Settings screen: "Map" category title */
-"prefs_group_map" = "Kaart";
-
-/* Settings screen: "Miscellaneous" category title */
-"prefs_group_misc" = "Diversen";
 
 "prefs_group_route" = "Navigatie";
 
@@ -419,9 +310,6 @@
 /* Settings «Map» category: «3D buildings» title */
 "pref_map_3d_buildings_title" = "3D-gebouwen";
 
-/* Settings «Map» category: «3D buildings» summary */
-"pref_map_3d_buildings_subtitle" = "Beïnvloedt batterijduur";
-
 /* Settings «Route» category: «Tts enabled» title */
 "pref_tts_enable_title" = "Gesproken instructies";
 
@@ -433,8 +321,6 @@
 
 /* Title for "Other" section in TTS settings. */
 "pref_tts_other_section_title" = "Andere";
-
-"pref_tts_how_to_set_up_voice" = "Hoe stel je de stem in";
 
 /* Settings «Map» category: «Record track» title */
 "pref_track_record_title" = "Recente route";
@@ -455,56 +341,7 @@
 
 "recent_track_help_text" = "Dit laat u toe het afgelegde traject voor een bepaalde periode te registreren en te bekijken op de kaart. Merk op: activatie van deze functie veroorzaakt een hoger batterijverbruik. Het traject wordt automatisch van de kaart verwijderd nadat het tijdsinterval verloopt.";
 
-"pref_track_ios_caption" = "Recente route geeft uw gebruikte route weer.";
-
-"pref_track_ios_subcaption" = "Selecteer de tijdperiode voor het opslaan van route.";
-
-"placepage_distance" = "Afstand";
-
-"placepage_coordinates" = "Coördinaten";
-
-"placepage_unsorted" = "Ongeclassificeerd";
-
 "search_show_on_map" = "Op kaart bekijken";
-
-/* Used to warn user when fixing KitKat issue */
-"bookmark_move_fail" = "We moeten uw bladwijzers naar het interne geheugen verplaatsen, maar er is geen ruimte beschikbaar voor ze. Maak alstublieft geheugen vrij, anders zullen de bladwijzers niet beschikbaar zijn.";
-
-/* Used in More Apps menu */
-"free" = "Gratis";
-
-/* Used in More Apps menu */
-"buy" = "Koop";
-
-/* 1st search button-like result */
-"search_on_map" = "Op kaart zoeken";
-
-/* toast with an error */
-"no_route_found" = "Geen route gevonden";
-
-/* route title */
-"route" = "Route";
-
-/* category title */
-"routes" = "Routes";
-
-/* text of notification */
-"download_map_notification" = "Download de kaart van de plaats waar u bent";
-
-/* text of notification */
-"pro_version_is_free_today" = "Volledige versie van Organic Maps is nu gratis! Download nu en vertel het je vrienden.";
-
-/* Dialog for transferring maps from lite to pro. */
-"move_lite_maps_to_pro" = "We verplaatsen uw gedownloade kaarten van Organic Maps Lite naar Organic Maps. Dit kan enkele minuten duren.";
-
-/* Message to display when maps moved. */
-"move_lite_maps_to_pro_ok" = "Uw gedownloade kaarten werden met succes verplaatst naar Organic Maps.";
-
-/* Message to display when maps move failed. */
-"move_lite_maps_to_pro_failed" = "Verplaatsing van uw kaarten mislukt. Gelieve Organic Maps Lite te verwijderen en de kaarten opnieuw te downloaden.";
-
-/* Text in menu */
-"settings_and_more" = "Instellingen & meer";
 
 /* Text in menu */
 "website" = "Website";
@@ -527,14 +364,8 @@
 /* Text in menu */
 "openstreetmap" = "OpenStreetMap";
 
-/* Text in menu */
-"contact_us" = "Contact met ons opnemen";
-
 /* Settings: Send feedback button and dialog title */
 "feedback" = "Feedback";
-
-/* Text in menu */
-"subscribe_to_news" = "Aanmelden voor onze nieuwtjes";
 
 /* Text in menu */
 "rate_the_app" = "App beoordelen";
@@ -548,15 +379,6 @@
 /* Text in menu */
 "report_a_bug" = "Meld een fout";
 
-/* Email subject */
-"subscribe_me_subject" = "Ik meld mij aan voor de nieuwsbrief Organic Maps";
-
-/* Email body */
-"subscribe_me_body" = "Ik wil graag als eerste horen over het laatste nieuws updates en acties. Ik kan mijn abonnement te allen tijde annuleren.";
-
-/* About text */
-"about_text" = "Organic Maps biedt de snelste offline kaarten van alle steden en alle landen ter wereld. Reis vol vertrouwen: waar je ook bent,\n\nOrganic Maps zal je helpen om jezelf op de kaart terug te vinden en het dichstbijzijnde restaurant, hotel, bank, benzinestation etc. te vinden. Er is geen internetverbinding voor nodig.\n\nWe werken voortdurend aan nieuwe functies en we zouden graag van je willen horen hoe we Organic Maps volgens jou zouden kunnen verbeteren. Als je eventueel problemen hebt met de app, aarzel dan niet om contact met ons op te nemen op support@organicmaps.app. We reageren op elke aanvraag!\n\nVindt je Organic Maps leuk en wil je ons steunen? Dat kan op een aantal simpele en absoluut gratis manieren:\n- plaats een beoordeling op je App Market\n- like onze Facebook-pagina http://www.facebook.com/OrganicMaps\n- of vertel gewoon je ma, vrienden en collega’s over Organic Maps :) Dank je dat je ons steunt. Wij waarderen dit heel erg!\n\nP.S. We halen onze kaartgegevens van OpenStreetMap, een kaartproject dat lijkt op Wikipedia, waarbij gebruikers kaarten kunnen maken en aanpassen. Als je ziet dat er iets ontbreekt of een fout ontdekt in een kaart, dan kun je de kaart direct verbeteren op https://www.openstreetmap.org, en dan zullen je verbeteringen bij het uitbrengen van de volgende versie in Organic Maps verschijnen.";
-
 /* Alert text */
 "email_error_body" = "De emailcliënt is niet ingesteld. Gelieve de cliënt te configureren of op een andere manier contact met ons op te nemen op %@";
 
@@ -569,12 +391,6 @@
 /* Search category */
 "wifi" = "WiFi";
 
-/* Update map suggestion */
-"routing_map_outdated" = "Werk de kaart bij om een route te maken.";
-
-/* Update maps suggestion */
-"routing_update_maps" = "Met de nieuwe versie van Organic Maps kunt u routes maken vanaf uw huidige positie naar een punt van bestemming. Werk kaarten bij om deze functie te gebruiken.";
-
 /* Update all button text */
 "downloader_update_all_button" = "Update alles";
 
@@ -583,9 +399,6 @@
 
 /* Downloaded maps category */
 "downloader_downloaded_subtitle" = "Gedownload";
-
-/* Downloaded maps category */
-"downloader_available_maps" = "Beschikbaar";
 
 /* Country queued for download */
 "downloader_queued" = "In de wachtrij";
@@ -598,17 +411,6 @@
 
 "downloader_downloading" = "Aan het downloaden:";
 
-"downloader_search_results" = "Gevonden";
-
-/* Disclaimer message */
-"routing_disclaimer" = "Bij het creëren van routes in Organic Maps-app, dient u rekening te houden met het volgende:\n\n  - Voorgestelde routes kunnen uitsluitend als aanbevelingen beschouwd worden.\n - Wegconditie, verkeersregels en borden hebben een hogere prioriteit dan het navigatie-advies.\n - De kaart kan onjuist of verouderd zijn en de routes kunnen niet op de beste mogelijke manier gecreëerd zijn.\n\n  Wees veilig op wegen en zorg goed voor uzelf!";
-
-/* Outdated maps category */
-"downloader_outdated_maps" = "Verouderd";
-
-/* Up to date maps category */
-"downloader_uptodate_maps" = "Up-to-date";
-
 /* Status of outdated country in the list */
 "downloader_status_outdated" = "Bijwerken";
 
@@ -618,49 +420,14 @@
 /* Displayed in a dialog that appears when a user tries to delete a map while the app is in the follow route mode */
 "downloader_delete_map_while_routing_dialog" = "Stop de navigatie om de kaart te verwijderen.";
 
-/* Show when user try build route, but we don't know where he */
-"routing_failed_unknown_my_position" = "Huidige locatie is niet gedefinieerd. Gelieve de locatie te specificeren om de route te creëren.";
-
-/* Show if use has not routing file, or InconsistentMWMandRoute */
-"routing_failed_has_no_routing_file" = "Er zijn extra gegevens nodig om een ​​route te creëren. Beginnen met downloaden?";
-
-/* StartPointNotFound */
-"routing_failed_start_point_not_found" = "Kan de route niet berekenen. Geen wegen in de buurt van uw beginpunt.";
-
-/* EndPointNotFound */
-"routing_failed_dst_point_not_found" = "Kan de route niet berekenen. Geen wegen in de buurt van uw bestemming.";
-
 /* PointsInDifferentMWM */
 "routing_failed_cross_mwm_building" = "Slechts de routes die volledig opgenomen zijn in één kaart kunnen gecreëerd worden.";
-
-/* RouteNotFound */
-"routing_failed_route_not_found" = "Er is geen route gevonden tussen het geselecteerde beginpunt en de bestemming. Gelieve een andere beginpunt of een eindbestemming te kiezen.";
-
-/* InternalError */
-"routing_failed_internal_error" = "Er is een interne fout opgetreden. Probeer het kaart te verwijderen en opnieuw te downloaden. Indien het probleem blijft optreden, neem dan contact met ons op support@organicmaps.app.";
-
-/* Context menu item for downloader. */
-"downloader_download_map_and_routing" = "Download kaart + routering";
-
-/* Context menu item for downloader. */
-"downloader_download_routing" = "Download routering";
-
-/* Context menu item for downloader. */
-"downloader_delete_routing" = "Verwijder routering";
 
 /* Context menu item for downloader. */
 "downloader_download_map" = "Download de kaart";
 
-"downloader_download_map_no_routing" = "Download kaart zonder routeplanning";
-
-/* Button for routing. */
-"routing_go" = "Starten!";
-
 /* Item status in downloader. */
 "downloader_retry" = "Herhalen";
-
-/* Item in context menu. */
-"downloader_map_and_routing" = "Kaart + route";
 
 /* Item in context menu. */
 "downloader_delete_map" = "Kaart verwijderen";
@@ -668,29 +435,11 @@
 /* Item in context menu. */
 "downloader_update_map" = "Kaart bijwerken";
 
-/* Item in context menu. */
-"downloader_update_map_and_routing" = "Kaart bijwerken + route";
-
-/* Item in context menu. */
-"downloader_map_only" = "Alleen de kaart";
-
-/* Toolbar title */
-"toolbar_application_menu" = "Applicatiemenu";
-
 /* Preference text */
 "pref_use_google_play" = "Gebruik de diensten van Google Play om uw huidige locatie te bepalen";
 
 /* Text for rating dialog */
 "rating_just_rated" = "Ik heb je app zojuist gewaardeerd";
-
-/* Text for rating dialog */
-"rating_user_since" = "Ik ben een Organic Maps-gebruiker vanaf %@";
-
-/* Text for rating dialog */
-"rating_do_like_maps" = "Vind je Organic Maps leuk?";
-
-/* Text for rating dialog */
-"rating_tap_star" = "Druk op een ster om onze app te waarderen.";
 
 /* Text for rating dialog */
 "rating_thanks" = "Dank je!";
@@ -701,23 +450,8 @@
 /* Text for rating dialog */
 "rating_send_feedback" = "Feedback verzenden";
 
-/* Text for g+ dialog */
-"rating_google_plus" = "Klik op g+ om je vrienden te informeren over de app.";
-
 /* Text for routing error dialog */
 "routing_download_maps_along" = "Download kaarten op de route";
-
-/* Text for routing error dialog */
-"routing_download_map" = "Krijg kaart";
-
-/* Text for routing error dialog */
-"routing_download_map_and_routing" = "Download bijgewerkte kaart en routegegevens om alle functies van Organic Maps te krijgen.";
-
-/* Text for routing error dialog */
-"routing_get_routing_data" = "Krijg routegegevens";
-
-/* Text for routing error dialog */
-"routing_get_additional_data" = "Aanvullende gegevens die nodig zijn om routes te maken vanaf uw locatie.";
 
 /* Text for routing error dialog */
 "routing_requires_all_map" = "Voor het creëren van een route is het nodig dat alle kaarten van uw locatie naar uw bestemming gedownload en bijgewerkt zijn.";
@@ -725,50 +459,15 @@
 /* Text for routing error dialog */
 "routing_not_enough_space" = "Niet genoeg ruimte";
 
-/* Text for routing error dialog */
-"routing_download_more_than_avail" = "U dient %@ MB te downloaden, maar er is slechts %@ MB beschikbaar.";
-
-/* Text for routing error dialog */
-"routing_download_roaming" = "U gaat %@ MB downloaden met behulp van mobiele data (roaming). Dit kan leiden tot extra kosten, afhankelijk van het mobiele data-abonnement van uw aanbieder.";
-
 /* bookmark button text */
 "bookmark" = "markeren";
-
-/* map is not downloaded */
-"not_found_map" = "De kaart voor uw locatie is niet gedownload";
 
 /* location service disabled */
 "enable_location_services" = "Schakel Locatie Services in";
 
-/* download map */
-"download_map" = "Download de kaart voor uw locatie";
-
-/* download map on iPhone */
-"download_map_iphone" = "Download de kaart van uw huidige lokatie op uw iPhone";
-
-/* clear pin */
-"nearby" = "In de buurt";
-
-/* clear pin */
-"clear_pin" = "Speld wissen";
-
-/* location is undefined */
-"undefined_location" = "Huidige locatie is niet gedefinieerd.";
-
-/* download country of your location */
-"download_country" = "Download land waar je nu bent";
-
-/* download failed */
-"download_failed" = "download is afgebroken";
-
-/* get the map */
-"get_the_map" = "Krijg kaart";
-
 "save" = "Opslaan";
 
 "edit_description_hint" = "Uw omschrijvingen (tekst of html)";
-
-"new_group" = "nieuwe groep";
 
 "create" = "aanmaken";
 
@@ -795,30 +494,6 @@
 
 /* pink color */
 "pink" = "Roze";
-
-/* deep purple color */
-"deep_purple" = "Donker paars";
-
-/* light blue color */
-"light_blue" = "Lichtblauw";
-
-/* cyan color */
-"cyan" = "Blauwgroen";
-
-/* teal color */
-"teal" = "Smaragdgroen";
-
-/* lime color */
-"lime" = "Lime";
-
-/* deep orange color */
-"deep_orange" = "Donkeroranje";
-
-/* gray color */
-"gray" = "Grijs";
-
-/* blue gray color */
-"blue_gray" = "Grijsblauw";
 
 /* Wi-Fi available */
 "WiFi_available" = "Ja";
@@ -848,13 +523,9 @@
 
 "dialog_routing_location_unknown_turn_on" = "De huidige gps-coördinaten kunnen niet worden gevonden. Schakel locatiediensten in om de route te berekenen.";
 
-"dialog_routing_location_unknown" = "De huidige gps-coördinaten kunnen niet worden gevonden.";
-
 "dialog_routing_download_files" = "Download vereiste bestanden";
 
 "dialog_routing_download_and_update_all" = "Download de kaart en route-informatie voor het ingestelde traject en werk deze bij om de route te berekenen.";
-
-"dialog_routing_routes_size" = "Route-informatiebestanden";
 
 "dialog_routing_unable_locate_route" = "Route vinden mislukt";
 
@@ -884,21 +555,11 @@
 
 "dialog_routing_try_again" = "Probeer het opnieuw";
 
-"dialog_routing_send_error" = "Meld het probleem";
-
-"dialog_routing_if_get_cross_route" = "Wilt u een rechtstreeksere route samenstellen die meer dan één kaart beslaat?";
-
-"dialog_routing_cross_route_is_optimal" = "Er is een betere route beschikbaar die de grenzen van deze kaart overschrijdt.";
-
 "not_now" = "Niet nu";
-
-"dialog_routing_build_route" = "Samenstellen";
 
 "dialog_routing_download_and_build_cross_route" = "Wilt u de kaart downloaden en een betere route samenstellen die meer dan één kaart beslaat?";
 
 "dialog_routing_download_cross_route" = "Download de kaart om een betere route samen te stellen die de grenzen van deze kaart overschrijdt.";
-
-"dialog_routing_cross_route_always" = "Deze grens altijd overschrijden";
 
 
 /********** Strings for downloading map from search **********/
@@ -906,8 +567,6 @@
 "search_without_internet_advertisement" = "Om te beginnen met zoeken en om routebeschrijvingen te kunnen maken, moet u de kaart downloaden. U heeft vervolgens geen internetverbinding meer nodig.";
 
 "search_select_map" = "Selecteer de kaart";
-
-"search_select_other_map" = "Selecteer een andere kaart";
 
 /* «Show» context menu */
 "show" = "Tonen";
@@ -918,17 +577,11 @@
 /* «Rename» context menu */
 "rename" = "Naam wijzigen";
 
-/* Bottom sheet: expand button (should be short) */
-"bottom_sheet_more" = "Meer…";
-
 /* Failed planning route message in navigation view */
 "routing_planning_error" = "Routeberekening mislukt";
 
 /* Arrive routing message in navigation view */
 "routing_arrive" = "Aankomst: %s";
-
-/* Text for routing::RouterResultCode::FileTooOld dialog. */
-"dialog_routing_download_and_update_maps" = "Om een route te maken, download en update alle kaarten rondom de route.";
 
 "rate_alert_title" = "Vindt u de app leuk?";
 
@@ -944,19 +597,11 @@
 
 "history" = "Geschiedenis";
 
-"next_turn_then" = "Dan";
-
 "closed" = "Gesloten";
-
-"back_to" = "Terug naar %@";
 
 "search_not_found" = "Sorry, ik heb niets gevonden.";
 
 "search_not_found_query" = "Probeer een andere zoekopdracht.";
-
-"search_not_found_map" = "Download de kaart waarin u zoekt, alstublieft.";
-
-"search_not_found_location" = "Download de kaart van uw huidige locatie.";
 
 "search_history_title" = "Zoekgeschiedenis";
 
@@ -964,23 +609,12 @@
 
 "clear_search" = "Zoekgeschiedenis wissen";
 
-/* Title for settings to enable/disable showcase menu button */
-"showcase_settings_title" = "Aanbiedingen weergeven";
-
 /* Place Page link to Wikipedia article (if map object has it). */
 "read_in_wikipedia" = "Wikipedia";
 
-"p2p_route_planning" = "Routeberekening";
-
 "p2p_your_location" = "Uw locatie";
 
-"p2p_from" = "Vertrekpunt";
-
-"p2p_to" = "Bestemmingspunt";
-
 "p2p_start" = "Beginnen";
-
-"p2p_planning" = "Aan het plannen…";
 
 "p2p_from_here" = "Van";
 
@@ -1018,15 +652,9 @@
 
 "editor_correct_mistake" = "Fout corrigeren";
 
-"editor_correct_mistake_message" = "U hebt een bewerkingsfout gemaakt. Corrigeer deze of schakel over naar de eenvoudige modus.";
-
 "editor_add_select_location" = "Locatie";
 
 "editor_done_dialog_1" = "Je hebt de wereldkaart gewijzigd. Verberg dit niet! Vertel het je vrienden en bewerk het samen.";
-
-"editor_done_dialog_2" = "Dit is je tweede kaartverbetering. Nu sta je op de %de plaats in de lijst van de kaartbewerkers. Vertel je vrienden erover.";
-
-"editor_done_dialog_3" = "Je hebt de kaart verbeterd, vertel je vrienden erover en bewerk samen de kaart.";
 
 "share_with_friends" = "Deel met je vrienden";
 
@@ -1044,20 +672,7 @@
 
 "editor_report_problem_duplicate_place_title" = "Dubbele plaats";
 
-"first_launch_congrats_title" = "Organic Maps is klaar voor gebruik";
-
-"first_launch_congrats_text" = "Zoek en navigeer overal ter wereld offline, gratis.";
-
-"migrate_title" = "Belangrijk!";
-
-/* Android uses image instead of text. */
-"download_all" = "Alles downloaden";
-
-"delete_all" = "Alles verwijderen";
-
 "autodownload" = "Automatische download";
-
-"disable_autodownload" = "Automatisch downloaden uitschakelen";
 
 /* Place Page opening hours text */
 "closed_now" = "Nu gesloten";
@@ -1072,10 +687,6 @@
 "day_off" = "Vrije dag";
 
 "today" = "Vandaag";
-
-"sunrise_to_sunset" = "Van zonsopgang tot zonsondergang";
-
-"sunset_to_sunrise" = "Van zonsondergang tot zonsopgang";
 
 "add_opening_hours" = "Openingsuren toevoegen";
 
@@ -1095,45 +706,18 @@
 
 "forgot_password" = "Wachtwoord vergeten?";
 
-/* Forgot Password dialog title */
-"restore_password" = "Wachtwoord herstellen";
-
-"enter_email_address_to_reset_password" = "Voer het emailadres in dat u heeft gebruikt tijdens de registratie, dan sturen wij u de link om uw wachtwoord te vernieuwen.";
-
-"reset_password" = "Wachtwoord resetten";
-
-"username" = "Gebruikersnaam";
-
 "osm_account" = "OSM-account";
 
 "logout" = "Uitloggen";
 
-"login_and_edit_map_motivation_message" = "Log in en bewerk gegevens van de objecten op de kaart, dan zullen wij ze beschikbaar maken voor miljoenen andere gebruikers. Laten we samen de wereld beter maken.";
-
 /* Information text: "Last upload 11.01.2016" */
 "last_upload" = "Laatste upload";
 
-/* Motivates user to login/register, title above login buttons. */
-"you_have_edited_your_first_object" = "Je hebt je eerste object aangepast!";
-
 "thank_you" = "Dank je wel";
-
-"login_with_google" = "Aanmelden met Google";
-
-"login_with_openstreetmap" = "Aanmelden met www.openstreetmap.org";
 
 "edit_place" = "De locatie bewerken";
 
 "place_name" = "Locatienaam";
-
-/* title above languages list cells in the editor, below editable name text field. */
-"other_languages" = "Overige talen";
-
-/* small button to open list with names in different languages */
-"show_more" = "Laat meer zien";
-
-/* small button to close list with names in different languages */
-"show_less" = "Laat minder zien";
 
 "add_language" = "Een taal toevoegen";
 
@@ -1164,8 +748,6 @@
 
 "please_note" = "Opgelet";
 
-"common_no_wifi_dialog" = "Geen WiFi-verbinding. Wil je doorgaan via mobiele data?";
-
 "downloader_delete_map_dialog" = "Alle wijzigingen aan de kaart zullen samen met de kaart worden verwijderd.";
 
 "downloader_update_maps" = "Kaarten updaten";
@@ -1173,10 +755,6 @@
 "downloader_mwm_migration_dialog" = "Om een route te creëren, moet je alle kaarten updaten en dan de route opnieuw plannen.";
 
 "downloader_search_field_hint" = "Vind de kaart";
-
-"migration_update_all_button" = "Update alle kaarten";
-
-"migration_delete_all_download_current_button" = "Download de huidige kaart en verwijder de oude";
 
 "migration_download_error_dialog" = "Downloadfout";
 
@@ -1186,21 +764,9 @@
 
 "downloader_no_space_message" = "Verwijder overbodige gegevens";
 
-"editor_general_auth_error_dialog" = "Algemene inlogfout.";
-
 "editor_login_error_dialog" = "Inlogfout.";
 
-"editor_login_failed_dialog" = "Inloggen mislukt";
-
-"editor_username_error_dialog" = "Gebruikersnaam is ongeldig";
-
-"editor_place_edited_dialog" = "Je hebt een object bewerkt!";
-
-"editor_login_with_osm" = "Log in met OpenStreetMap";
-
 "editor_profile_changes" = "Gecontroleerde wijzigingen";
-
-"editor_profile_unsent_changes" = "Niet verzonden:";
 
 "editor_focus_map_on_location" = "Trek aan de kaart om de juiste locatie van het object te selecteren.";
 
@@ -1222,13 +788,9 @@
 
 "editor_report_problem_other_title" = "Een ander probleem";
 
-"placepage_report_problem_button" = "Meld een probleem";
-
 "placepage_add_business_button" = "Een organisatie toevoegen";
 
 "whatsnew_editor_message_1" = "Voeg nieuwe plaatsen toe aan de kaart en bewerk de bestaande rechtstreeks vanuit de app.";
-
-"whatsnew_editor_message_2" = "* Organic Maps gebruikt OpenStreetMap-communitiedata.";
 
 "dialog_incorrect_feature_position" = "Locatie wijzigen";
 
@@ -1236,16 +798,10 @@
 
 "login_to_make_edits_visible" = "Log in zodat andere gebruikers kunnen zien wat u hebt gewijzigd.";
 
-"no_migration_during_navigation" = "Updaten tijdens navigatie is niet toegestaan.";
-
 /* Error dialog no space */
 "migration_no_space_message" = "Om te kunnen downloaden, heb je meer ruimte nodig. Verwijder overbodige gegevens.";
 
 "editor_sharing_title" = "Ik heb de Organic Maps-kaarten verbeterd";
-
-"editor_comment_will_be_sent" = "We zullen uw opmerking doorsturen naar de kaartmakers.";
-
-"editor_unsupported_category_message" = "U hebt een plaats of categorie toegevoegd die we nog niet ondersteunen. Het zal enige tijd duren voordat deze op de kaart verschijnt.";
 
 /* Downloaded 10 **of** 20 <- it is that "of" */
 "downloader_of" = "%1$d van %2$d";
@@ -1278,23 +834,9 @@
 
 "editor_operator" = "Uitvoerder";
 
-"editor_tag_description" = "Voer het bedrijf, de organisatie of het individu in dat verantwoordelijk is voor de faciliteiten.";
-
-"editor_no_local_edits_title" = "U hebt geen lokale bewerkingen";
-
-"editor_no_local_edits_description" = "Dit toont het aantal voorgestelde wijzigingen voor de kaart die momenteel alleen toegankelijk zijn op uw apparaat.";
-
-"editor_send_to_osm" = "Naar OSM sturen";
-
-"editor_remove" = "Verwijderen";
-
-"downloader_my_maps_title" = "Mijn kaarten";
-
 "downloader_no_downloaded_maps_title" = "U hebt geen kaarten gedownload";
 
 "downloader_no_downloaded_maps_message" = "Download kaarten om de locatie te zoeken en offline te navigeren.";
-
-"downloader_find_place_hint" = "Stad of land zoeken";
 
 /* Error title that appears after certain time without location. */
 "current_location_unknown_title" = "Doorgaan met het detecteren van uw huidige locatie?";
@@ -1321,47 +863,13 @@
 /* iOS Dialog for the case when the location permission is not granted */
 "location_services_disabled_3" = "3. Selecteer Terwijl Je de App Gebruikt";
 
-"placepage_parking_surface" = "Boven de grond";
-
-"placepage_parking_multistorey" = "Meerlaags";
-
-"placepage_parking_underground" = "Onder de grond";
-
-"placepage_parking_rooftop" = "Dak";
-
-"placepage_parking_sheds" = "Afdak";
-
-"placepage_parking_carports" = "Carports";
-
-"placepage_parking_boxes" = "Garageboxen";
-
-"placepage_parking_pay" = "Betalen";
-
-"placepage_parking_free" = "Gratis";
-
-"placepage_parking_interval" = "Intervalbetaling";
-
-"placepage_entrance_number" = "Nr.";
-
-"placepage_entrance_type" = "Ingang";
-
-"placepage_flat" = "app.";
-
-"placepage_open_24_7" = "Dag en nacht";
-
 "meter" = "m";
 
 "kilometer" = "km";
 
-"kilometers_per_hour" = "km/h";
-
 "mile" = "mijl";
 
 "foot" = "voet";
-
-"miles_per_hour" = "mph";
-
-"day" = "d";
 
 "hour" = "u";
 
@@ -1381,10 +889,6 @@
 
 "placepage_bookmark_name_hint" = "Bladwijzernaam";
 
-"placepage_personal_notes_hint" = "Persoonlijke aantekeningen";
-
-"placepage_delete_bookmark_button" = "Bladwijzer verwijderen";
-
 "editor_edits_sent_message" = "Uw voorgestelde wijzigingen zijn verzonden";
 
 "editor_comment_hint" = "Reactie…";
@@ -1397,8 +901,6 @@
 
 "editor_remove_place_button" = "Verwijderen";
 
-"editor_status_sending" = "Verzenden…";
-
 "editor_place_doesnt_exist" = "Locatie bestaat niet";
 
 "text_more_button" = "…meer";
@@ -1410,11 +912,7 @@
 
 "error_enter_correct_email" = "Voer een geldig emailadres in";
 
-"error_enter_correct" = "Voer een geldige waarde in";
-
 "refresh" = "Updaten";
-
-"last_update" = "Laatste update: %s";
 
 "placepage_add_place_button" = "Een plek toevoegen aan de kaart";
 
@@ -1426,24 +924,6 @@
 
 "editor_share_to_all_dialog_message_2" = "We zullen de wijzigingen controleren. Als we nog vragen hebben, zullen we contact met je opnemen via email.";
 
-"navigation_overview_button" = "overzicht";
-
-"navigation_stop_button" = "stoppen";
-
-/* Text on an empty bookmark page */
-"bookmarks_empty_title" = "Bladwijzers opslaan";
-
-"bookmarks_empty_message_1" = "Tik op ★ om favoriete plaatsen op te slaan voor snelle toegang.";
-
-"bookmarks_empty_message_2" = "Importeer bladwijzers vanuit email en het internet.";
-
-"bookmarks_empty_message_3" = "uitchecken: %s";
-
-/* Name of the group for booked hotels */
-"bookmarks_group_name" = "Geboekte hotels";
-
-"place_page_button_read_descriprion" = "Lezen";
-
 /* iOS dialog for the case when recent track recording is on and the app comes back from background */
 "recent_track_background_dialog_title" = "Vastleggen van uw onlangs afgelegde route uitschakelen?";
 
@@ -1451,8 +931,6 @@
 
 /* For sharing via SMS and so on */
 "sharing_call_action_look" = "Bekijk";
-
-"continue_recent_track_background_button" = "Verdergaan";
 
 "recent_track_background_dialog_message" = "Organic Maps gebruikt uw geografische positie op de achtergrond om uw onlangs afgelegde route vast te leggen.";
 
@@ -1468,33 +946,13 @@
 /* About short text (below logo) */
 "about_description" = "Organic Maps is een essentiële offline applicatie om te reizen. Organic Maps is gebaseerd op OpenStreetMap gegevens en laat bewerking toe.";
 
-/* Text in menu */
-"blog" = "Blog";
-
 "general_settings" = "Algemene instellingen";
-
-"date" = "Datum %d";
-
-/* "Report a bug" -> "Generaal Feedback" -> "Something is not working" */
-"something_is_not_working" = "Er werkt iets niet";
 
 /* For the first routing */
 "accept" = "Aanvaarden";
 
-"accept_and_continue" = "Accept and continue";
-
 /* For the first routing */
 "decline" = "Weigeren";
-
-"install_app" = "Installeer";
-
-"search_no_results_title" = "Geen Resultaten Gevonden";
-
-"search_no_results_message" = "Probeer een meer algemene zoekterm, zoom uit of reset de filter.";
-
-"search_no_results_expand_area_button" = "Uitzoomen";
-
-"search_no_results_reset_button" = "Filter Resetten";
 
 /* noun */
 "search_in_table" = "Lijst";
@@ -1517,8 +975,6 @@
 
 "traffic_update_maps_text" = "Om verkeersgegevens weer te geven, moeten de kaarten bijgewerkt worden.";
 
-"traffic_outdated" = "Verkeersgegevens zijn verouderd.";
-
 "big_font" = "Lettergrootte op de kaart vergroten";
 
 "traffic_update_app" = "Gelieve Organic Maps bij te werken";
@@ -1529,17 +985,7 @@
 /* "traffic" as in "road congestion" */
 "traffic_data_unavailable" = "Verkeersgegevens zijn niet beschikbaar";
 
-/* "Translation is no needed, because it's a company name" */
-"uber" = "Uber";
-
-/* Simplified colour scheme for traffic information, fewer colours are used to display traffic jams on the map. The string should be kept as short as possible */
-"pref_traffic_simplified_colors_title" = "Eenvoudige verkeerskleuren";
-
 "enable_logging" = "Logboekregistratie inschakelen";
-
-"offline_place_page_more_information" = "Maak verbinding met het internet om meer informatie over de plaats te krijgen.";
-
-"failed_load_information" = "Informatie laden mislukt.";
 
 /* Settings: "Send general feedback" button */
 "feedback_general" = "Algemene Feedback";
@@ -1556,8 +1002,6 @@
 
 "whatsnew_transliteration_title" = "Transliteratie in het Latijn";
 
-"yandex_taxi_title" = "Yandex.Taxi";
-
 "learn_more" = "Meer informatie";
 
 "core_exit" = "Verlaten";
@@ -1568,75 +1012,19 @@
 
 "button_exit" = "Verlaten";
 
-"settings_device_memory" = "Apparaatgeheugen";
-
-"settings_card_memory" = "Kaartgeheugen";
-
-"settings_storage_available" = "%s beschikbaar";
-
-"toast_location_permission_denied" = "App toelating locatie geweigerd";
-
-"button_use" = "Gebruiken";
-
 "planning_route_manage_route" = "Route beheren";
 
 "button_plan" = "Plannen";
-
-"button_add" = "Toevoegen";
 
 "placepage_remove_stop" = "Verwijderen";
 
 "planning_route_remove_title" = "Sleep hier om te verwijderen";
 
-"dialog_change_start_point_message" = "Het beginpunt vervangen met de huidige locatie?";
-
-"button_replace" = "Vervangen";
-
 "placepage_add_stop" = "Tussenstop toevoegen";
-
-/* Only ru/en are needed */
-"subtitle_rent" = "Rent";
-
-/* Only ru/en are needed */
-"rub_month" = "RUB/month";
-
-/* Only ru/en are needed */
-"room" = "%s-room apt.";
-
-/* Only ru/en are needed */
-"real_estate" = "Real estate";
-
-"add_my_position" = "Voeg mijn positie toe";
-
-"choose_start_point" = "Kies een vertrekpunt";
-
-"choose_destination" = "Kies een bestemming";
 
 "preloader_viator_button" = "Meer leren";
 
-"start_from_my_position" = "Start vanaf";
-
-"profile_authorization_title" = "Aanmelden met";
-
-"profile_authorization_message" = "Eenvoudig aanmelden zonder gebruikersnaam en wachtwoord in enkele seconden";
-
 "profile_authorization_error" = "Oeps, er is een fout opgetreden. Probeer opnieuw aan te melden.";
-
-"service" = "Dienst";
-
-"atmosphere" = "Sfeer";
-
-"value_for_money" = "Waarde voor geld";
-
-"experience" = "Ervaring";
-
-"assortment" = "Assortiment";
-
-"expertise" = "Expertise";
-
-"equipment" = "Uitrusting";
-
-"quality" = "Kwaliteit";
 
 "dialog_error_storage_title" = "Probleem met opslagtoegang";
 
@@ -1644,17 +1032,7 @@
 
 "setting_emulate_bad_storage" = "Slechte opslag emuleren";
 
-"directions_finish" = "Bestemming";
-
-"directions_on_foot" = "Wandel %s";
-
 "core_entrance" = "Ingang";
-
-"coffee" = "Koffie";
-
-"cleanliness" = "Netheid";
-
-"crowdedness" = "Drukte";
 
 "error_enter_correct_name" = "Voer een juiste naam in";
 
@@ -1673,11 +1051,9 @@
 
 "downloader_percent" = "%s (%s van %s)";
 
-"downloader_process" = "%s downloaden...";
+"downloader_process" = "%s downloaden…";
 
-"downloader_applying" = "%s toepassen...";
-
-"dialog_message_transit_not_found_connection" = "Plan een route binnen één vervoersnetwerk";
+"downloader_applying" = "%s toepassen…";
 
 "bookmarks_error_message_share_general" = "Delen is onmogelijk wegens een toepassingsfout";
 
@@ -1695,17 +1071,7 @@
 
 "bookmarks_error_message_list_name_already_taken" = "Kies alstublieft een andere naam";
 
-"bookmarks_error_title_list_name_too_long" = "Deze naam is te lang";
-
-"bookmarks_error_message_list_name_too_long" = "Kies alstublieft een andere naam";
-
-"please_wait" = "Even geduld aub...";
-
-"phone_number" = "Telefoonnummer";
-
-"notification_unsent_reviews_title" = "U heeft verschillende niet-verzonden recensies";
-
-"notification_unsent_reviews_message" = "Meld u aan om recensies te delen met andere reizigers";
+"please_wait" = "Even geduld aub…";
 
 "profile" = "OpenStreetMap-profiel";
 
@@ -1719,49 +1085,13 @@
 
 "bookmarks_convert_error_message" = "Sommige bestanden waren niet geconverteerd.";
 
-"converting" = "Het omzetten van...";
-
-"wn_reinvented_bookmarks_title" = "We hebben bladwijzers opnieuw uitgevonden!";
-
-"wn_reinvented_bookmarks_message" = "U kunt een back-up maken van bladwijzers, lijsten maken... Het is verbazingwekkend...";
-
-"bookmarks_restore" = "Bladwijzers herstellen";
-
-"bookmarks_restore_process" = "Herstel van...";
-
 "bookmarks_restore_title" = "Deze versie herstellen?";
 
-"bookmarks_restore_message" = "Je bladwijzers worden hersteld vanaf %s (%s)";
-
-"bookmarks_restore_empty_title" = "U hebt geen back-up";
-
-"bookmarks_restore_empty_message" = "De server heeft eerder gemaakte back-ups niet gevonden";
-
 "common_check_internet_connection_dialog_title" = "Geen internet verbinding";
-
-"error_server_title" = "Serverfout";
-
-"error_server_message" = "Der var en fejl på serveren, prøv igen senere";
 
 "error_system_message" = "Er is een onbekende fout opgetreden";
 
 "restore" = "Herstellen";
-
-"bookmarks_page_downloaded" = "Gedownload";
-
-"bookmarks_page_my" = "Mijn";
-
-"routes_and_bookmarks" = "Routes en Bladwijzers";
-
-"bookmarks_webview_success_toast" = "Bladwijzers succesvol gedownload";
-
-"cached_bookmarks_placeholder_title" = "Download nieuwe plaatsen";
-
-"cached_bookmarks_placeholder_subtitle" = "Druk op de knop om duizenden interessante plaatsen en routes te downloaden, gecreëerd door Organic Maps-gebruikers. U hebt een internet-verbinding nodig.";
-
-"downloader_download_routers" = "Download bladwijzers";
-
-"bookmarks_groups_cached" = "Download lijsten";
 
 "subtittle_opt_out" = "Tracking-instellingen";
 
@@ -1769,29 +1099,15 @@
 
 "crash_reports_description" = "Wij kunnen uw gegevens gebruiken om Organic Maps te verbeteren. Wijzigingen treden in werking na het opnieuw opstarten van de app.";
 
-"opt_out_help_ios_1" = "Uw mobiele apparaat kan voorzien zijn van een instelling voor „Gelimiteerde advertentie-tracking” of „afmelden voor op interesses gebaseerd adverteren”.";
-
-"opt_out_help_ios_2" = "iOS 9 of hoger";
-
-"opt_out_help_ios_3" = "Ga naar uw Instellingen → Privacy → Advertenties → Inschakelen van de „Gelimiteerde advertentie-tracking” - instelling";
-
-"opt_out_help_android" = "Uw mobiele apparaat kan voorzien zijn van een instelling voor „Gelimiteerde advertentie-tracking” of „Afmelden voor op interesses gebaseerd adverteren”. \n\nVoor Android en Google Play Services versie 4. 0 en hoger:\nInstellingen → Google → Advertenties → Afmelden voor personalisatie van advertenties \n of \nInstellingen → Google → Google-Account → Gegevens & personalisatie → Advertentiepersonalisatie";
-
 "privacy_policy" = "Privacy beleid";
 
 "terms_of_use" = "Gebruiksvoorwaarden";
-
-"backup_notification_failed" = "Een back-up van uw bladwijzers werd opgeschort. Log in om weer op te starten.";
 
 "button_layer_traffic" = "Verkeer";
 
 "button_layer_subway" = "Metro";
 
 "layers_title" = "Map layers";
-
-"layers_message" = "Gebruik „Map layers” voor het weergeven van verkeer, metro, en andere nuttige informatie";
-
-"button_layer_got_it" = "Ik begrijp het";
 
 "subway_data_unavailable" = "Metrokaart is niet beschikbaar";
 
@@ -1803,39 +1119,13 @@
 
 "title_error_downloading_bookmarks" = "Er is een fout opgetreden";
 
-"subtitle_error_downloading_bookmarks" = "Bladwijzers werden niet gedownload";
-
-"error_already_downloaded" = "Deze lijst is al gedownload";
-
 "popular_place" = "Popular";
-
-"download_routes" = "Download routes";
-
-"bookmarks_downloaded_title" = "Bookmarks have been downloaded successfully";
-
-"bookmarks_downloaded_subtitle" = "Press ‘View on map’ to explore new places from the list";
-
-"why_support" = "Waarom Organic Maps ondersteunen?";
-
-"why_support_item1" = "We respect your privacy: there are zero trackers in the app, and we are open source";
-
-"why_support_item2" = "U helpt ons Organic Maps te verbeteren";
-
-"why_support_item3" = "U helpt ons de kaarten van OpenStreetMap.org te verbeteren";
-
-"channels_map_update" = "Kaartupdates";
-
-"server_unavailable_title" = "Server niet beschikbaar";
-
-"sharing_options" = "Opties voor delen";
 
 "export_file" = "Bestand exporteren";
 
 "list_settings" = "Lijst Instellingen";
 
 "delete_list" = "Lijst verwijderen";
-
-"hide_from_map" = "Van de kaart verbergen";
 
 "public_access" = "Publiek toegang";
 
@@ -1845,40 +1135,11 @@
 
 "bookmark_category_description_hint" = "Maak een beschrijving aan (tekst of html)";
 
-/* FIXME */
-"bookmarks_public_access" = "bookmarks_public_access";
-
-/* FIXME */
-"bookmarks_link_access" = "bookmarks_link_access";
-
-/* FIXME */
-"bookmarks_private_access" = "bookmarks_private_access";
-
 "not_shared" = "Privé";
-
-"direct_link_progress_text" = "Uw bestand aan het uploaden…";
-
-"direct_link_success" = "De link is aangemaakt";
-
-"send_a_link_btn" = "Stuur mij een link";
-
-"upload_error_toast" = "Er is een fout opgetreden tijdens het uploaden van uw bestand";
 
 "tags_loading_error_subtitle" = "Er is een fout opgetreden tijdens het laden van tags, probeer het opnieuw";
 
-"unable_upload_errorr_title" = "Bestand uploaden mislukt";
-
-"unable_upload_error_subtitle_edited" = "Dit bestand is bewerkt via de web app";
-
-"unable_upload_error_subtitle_broken" = "Dit bestand is beschadigd en kon niet worden geüpload. Gelieve een ander bestand te uploaden.";
-
-"contact" = "Contact";
-
-"download_button" = "Downloaden";
-
 "speedcams_alert_title" = "Snelheidscamera's";
-
-"speedcams_alert_subtitle" = "Waarschuw voor snelheidsbeperkingen";
 
 "speedcam_option_auto" = "Auto";
 
@@ -1886,18 +1147,10 @@
 
 "speedcam_option_never" = "Nooit";
 
-"bookmark_description_title" = "Bladwijzer Beschrijving";
-
 "place_description_title" = "Plaats Beschrijving";
 
 /* this text will be shown in application notification preferences opposite checkbox which enable/disable downloader notifications. Devices on Android 8+ are affected. */
 "notification_channel_downloader" = "Kaart downloader";
-
-"share_bookmarks_email_body_link" = "Hello!\n\nHier is de link waar u uw bladwijzers kunt downloaden: %s. Open de lijst via Organic Maps en geniet van uw reis!\n\nHaal de applicatie op: https://omaps.app/get?kmz";
-
-"warning_speedcams_title" = "Navigator waarschuwt u over camera's wanneer u de maximumsnelheid van %d km/h overschrijdt";
-
-"warning_speedcams_subtitle" = "Let op de rijvoorschriften van het land waar u naartoe reist.";
 
 "speedcams_notice_message" = "Auto - Waarschuw voor speedcams als er een risico bestaat dat de snelheidslimiet wordt overschreden\nAltijd - Waarschuw altijd voor flitspalen\nNooit - Waarschuw nooit over flitspalen";
 
@@ -1913,23 +1166,7 @@
 
 "enable_logging_warning_message" = "Deze optie is ingeschakeld voor logboekregistraties voor diagnostische doeleinden. Het helpt bij het identificeren van problemen met de applicatie. Schakel de optie alleen in op verzoek van Organic Maps-ondersteuning.";
 
-"html_error_upload_message_try_again" = "Controleer de netwerktoegang en probeer het opnieuw";
-
-"html_error_upload_title_try_again" = "Geen internetverbinding";
-
-"notification_leave_review_v2_android_short_title" = "Laat een feedback achter en help reizigers!";
-
-"megafon" = "Say goodbye to roaming!";
-
-"notifications_illegal_alert_disable_button" = "Meldingen uitschakelen";
-
 "access_rules_author_only" = "Wordt online bewerkt";
-
-"privacy_settings_menu" = "Privacy instellingen";
-
-"unable_upadate_error_title" = "Kan de route niet bijwerken";
-
-"unable_upadate_error_message" = "Er zijn fouten opgetreden tijdens het updaten. Controleer de wijzigingen en probeer het opnieuw";
 
 "driving_options_title" = "Omweginstellingen";
 
@@ -1951,94 +1188,19 @@
 
 "change_driving_options_btn" = "Omweginstellingen ingeschakeld";
 
-"toll_road" = "Tolweg";
-
-"unpaved_road" = "Aardeweg";
-
-"ferry_crossing" = "Ferry";
-
-"operated_by" = "Gecontroleerd door \"%s\"";
-
 "avoid_toll_roads_placepage" = "Tolwegen vermijden";
 
 "avoid_unpaved_roads_placepage" = "Aardewegen vermijden";
 
 "avoid_ferry_crossing_placepage" = "Ferries vermijden";
 
-"type.cuisine.uzbek" = "Oezbeekse keuken";
-
-"trip_start" = "Kom op";
-
-"pick_destination" = "Doel";
-
-"follow_my_position" = "Centreren";
-
-"search_results" = "Zoekresultaten";
-
-"then_turn" = "Dan";
-
-"redirect_route_alert" = "Wilt u de route wijzigen?";
-
-"redirect_route_yes" = "Ja";
-
-"redirect_route_no" = "Nee";
-
-"trip_finished" = "U bent aangekomen!";
-
-"keyboard_availability_alert" = "Toetsenbord is niet beschikbaar tijdens het rijden";
-
-"dialog_routing_change_start_carplay" = "Kan route vanaf huidige positie niet opbouwen";
-
-"dialog_routing_change_end_carplay" = "Kan route naar het eindpunt niet opbouwen. Kies een andere punt";
-
-"dialog_routing_check_gps_carplay" = "Geen GPS-signaal. Ga naar het open veld";
-
-"dialog_routing_unable_locate_route_carplay" = "Kan route niet bouwen. Selecteer andere tussenpunten";
-
-"dialog_routing_download_files_carplay" = "Om een route te bouwen, download u ontbrekende kaarten";
-
-"dialog_routing_system_error_carplay" = "Lets fout gegaan. Start de app opnieuw";
-
-"dialog_routing_rebuild_from_current_location_carplay" = "De route wordt opnieuw opgebouwd vanaf uw huidige positie";
-
-"dialog_routing_rebuild_for_vehicle_carplay" = "De route wordt gewijzigd in de autoroute";
-
 "ok" = "Goed";
-
-"avoid_unpaved_carplay_1" = "Geen aardew.";
-
-"avoid_unpaved_carplay_2" = "Geen aardewegen";
-
-"avoid_ferry_carplay_1" = "Geen ferry's";
-
-"avoid_ferry_carplay_2" = "Geen ferry's";
-
-"avoid_tolls_carplay_1" = "Zonder tol";
-
-"avoid_tolls_carplay_2" = "Zonder tol";
-
-"speedcams_alert_title_carplay_1" = "Cameras";
-
-"speedcams_alert_title_carplay_2" = "Over cameras";
-
-"download_map_carplay" = "Download kaarten in de Organic Maps app op uw apparaat";
-
-"carplay_roundabout_exit" = "Afrit nr. %s";
 
 /* max. 10 symbols, both iOS and Android */
 "sort" = "Sorteer…";
 
 /* Android, title, max 20-22 symbols */
 "sort_bookmarks" = "Bladwijzers sorteren";
-
-/* iOS */
-"sort_default" = "Standaard sorteren";
-
-"sort_type" = "Sorteren op type";
-
-"sort_distance" = "Sorteer op afstand";
-
-"sort_date" = "Sorteer op datum";
 
 /* Android */
 "by_default" = "Standaard";
@@ -2052,63 +1214,7 @@
 /* Android */
 "by_date" = "Op datum";
 
-"week_ago_sorttype" = "Een week geleden";
-
-"month_ago_sorttype" = "Een maand geleden";
-
-"moremonth_ago_sorttype" = "Meer dan een maand geleden";
-
-"moreyear_ago_sorttype" = "Meer dan een jaar geleden";
-
-"near_me_sorttype" = "Naast mij";
-
-"others_sorttype" = "Andere";
-
-"food_places" = "Eten";
-
-"tourist_places" = "Bezienswaardigheden";
-
-"museums" = "Musea";
-
-"parks" = "Parken";
-
-"swim_places" = "Zwemmen";
-
-"mountains" = "Bergen";
-
-"animals" = "Dieren";
-
-"hotels" = "Hotels";
-
-"buildings" = "Gebouwen";
-
-"money" = "Geld";
-
-"shops" = "Winkels";
-
-"parkings" = "Parkeerplaatsen";
-
-"fuel_places" = "Benzinestations";
-
-"water" = "Water";
-
-"medicine" = "Geneeskunde";
-
 "search_in_the_list" = "In de lijst zoeken";
-
-"view_on_map_bookmarks" = "Op de kaart";
-
-"more_bookmarks" = "Meer…";
-
-"no_items_found" = "Niets gevonden";
-
-/* Android, max 18 symbols */
-"bookmarks_edit_list" = "Bewerken";
-
-/* Android, max 18 symbols */
-"bookmarks_delete_list" = "Lijst verwijderen";
-
-"religious_places" = "Religieuze plaatsen";
 
 "select_list" = "Lijst kiezen";
 
@@ -2118,26 +1224,13 @@
 
 "dialog_pedestrian_route_is_long_message" = "Kies een begin- of eindpunt dichter bij het metrostation";
 
-/* Failed planning SUBWAY route message in navigation view */
-"routing_planning_error_subway_special" = "Routeplanner per metro is mislukt";
-
 "button_layer_isolines" = "Hoogtes";
-
-"tips_map_layers_title_countour" = "Hoogtelijnen offline in Organic Maps!";
-
-"tips_map_layers_message_countour" = "Dankzij de hoogtelijnen kunt u probleemloos natuurreizen plannen en er zeker van zijn dat u niet verdwalen zult";
 
 "isolines_activation_error_dialog" = "Als u gebruik wilt maken van hoogtelijnen, moet u een kaart van het gewenste gebied bijwerken of downloaden";
 
 "isolines_location_error_dialog" = "De hoogtelijnen zijn nog niet beschikbaar in deze regio";
 
 "elevation_profile_diff_level" = "Moeilijkheidsgraad";
-
-"elevation_profile_diff_level_easy" = "Gemakkelijk";
-
-"elevation_profile_diff_level_moderate" = "Middelmatig";
-
-"elevation_profile_diff_level_hard" = "Moeilijk";
 
 "elevation_profile_ascent" = "Opstijging";
 
@@ -2147,25 +1240,13 @@
 
 "elevation_profile_maxaltitude" = "Max. hoogte";
 
-"elevation_profile_m" = "m";
-
 "elevation_profile_difficulty" = "Moeilijkheid";
 
 "elevation_profile_distance" = "Afst.:";
 
-"elevation_profile_km" = "km";
-
 "elevation_profile_time" = "Op weg";
 
-"elevation_profile_hours" = "uur";
-
-"elevation_profile_minutes" = "min";
-
 "isolines_toast_zooms_1_10" = "Zoom in om isolijnen te bekijken";
-
-"downloader_updating_ios" = "Updaten";
-
-"downloader_loading_ios" = "Downloaden";
 
 "key_information_title" = "Belangrijke informatie";
 

--- a/iphone/Maps/LocalizedStrings/nl.lproj/Localizable.stringsdict
+++ b/iphone/Maps/LocalizedStrings/nl.lproj/Localizable.stringsdict
@@ -9,21 +9,6 @@
 
 <!-- ********** Strings for downloading map from search **********/ -->
 
-  <key>bookmarks_places</key>
-  <dict>
-    <key>NSStringLocalizedFormatKey</key>
-    <string>%#@value@</string>
-    <key>value</key>
-    <dict>
-      <key>NSStringFormatSpecTypeKey</key>
-      <string>NSStringPluralRuleType</string>
-      <key>NSStringFormatValueTypeKey</key>
-      <string>d</string>
-      <key>other</key>
-      <string>%d bladwijzers</string>
-    </dict>
-  </dict>
-
   <key>bookmarks_detect_message</key>
   <dict>
     <key>NSStringLocalizedFormatKey</key>
@@ -38,21 +23,6 @@
       <string>%d bestand gevonden. Je ziet het na het converteren.</string>
       <key>other</key>
       <string>Er zijn %d bestanden gevonden. Je zult ze na de conversie zien.</string>
-    </dict>
-  </dict>
-
-  <key>bookmarks_objects</key>
-  <dict>
-    <key>NSStringLocalizedFormatKey</key>
-    <string>%#@value@</string>
-    <key>value</key>
-    <dict>
-      <key>NSStringFormatSpecTypeKey</key>
-      <string>NSStringPluralRuleType</string>
-      <key>NSStringFormatValueTypeKey</key>
-      <string>d</string>
-      <key>other</key>
-      <string>%s object</string>
     </dict>
   </dict>
 

--- a/iphone/Maps/LocalizedStrings/pl.lproj/Localizable.strings
+++ b/iphone/Maps/LocalizedStrings/pl.lproj/Localizable.strings
@@ -18,9 +18,6 @@
 /* Button which deletes downloaded country */
 "delete" = "Usuń";
 
-/* Button "do not interrupt download" if user touched actively downloading country */
-"do_nothing" = "Kontynuuj";
-
 "download_maps" = "Pobierz mapy";
 
 /* Settings/Downloader - info for country when download fails */
@@ -28,9 +25,6 @@
 
 /* Settings/Downloader - info for country which started downloading */
 "downloading" = "Pobieranie…";
-
-/* Settings/Downloader - size string, only strings different from English should be translated */
-"kb" = "KB";
 
 /* Choose measurement on first launch alert - choose metric system button */
 "kilometres" = "Kilometry";
@@ -55,17 +49,11 @@
 /* Update maps later/Buy pro version later button text */
 "later" = "Później";
 
-/* Don't show some dialog any more */
-"never" = "Nigdy";
-
 /* View and button titles for accessibility */
 "search" = "Wyszukaj";
 
 /* Search box placeholder text */
 "search_map" = "Wyszukaj mapy";
-
-/* Settings/Downloader - info for not downloaded country */
-"touch_to_download" = "Proszę nacisnąć, aby pobrać.";
 
 /* Settings/Downloader - 3G download warning dialog confirm button */
 "use_cellular_data" = "Tak";
@@ -73,20 +61,11 @@
 /* Location services are disabled by user alert - message */
 "location_is_disabled_long_text" = "Usługi lokalizacji są aktualnie wyłączone dla tego urządzenia lub aplikacji. Proszę włączyć je w ustawieniach.";
 
-/* Location Services are not available on the device alert - message */
-"device_doesnot_support_location_services" = "Urządzenie nie obsługuje usług lokalizacji";
-
 /* View and button titles for accessibility */
 "zoom_to_country" = "Wyświetl na mapie";
 
-/* Button text for the button at the center of the screen when the country is not downloaded */
-"country_status_download" = "Pobierz mapę\n(^ ^)";
-
 /* Button text for the button at the center of the screen when the country is not downloaded and the size should not be shown */
 "country_status_download_without_size" = "Pobierz mapę";
-
-/* Button text for the button at the center of the screen when the country is not downloaded */
-"country_status_download_without_routing" = "Pobierz mapę bez\noznaczania tras (^ ^)";
 
 /* Message to display at the center of the screen when the country download has failed */
 "country_status_download_failed" = "Nie udało się pobrać";
@@ -96,19 +75,13 @@
 
 "about_menu_title" = "O aplikacji Organic Maps";
 
-"downloaded_touch_to_delete" = "Pobrano (%@). Proszę nacisnąć, aby usunąć.";
-
 "connection_settings" = "Ustawienia połączenia";
-
-"download_mb_or_kb" = "Pobierz %@";
 
 "close" = "Zamknij";
 
 "unsupported_phone" = "Wymagana jest sprzętowa akceleracja OpenGL. Aktualne urządzenie nie jest obsługiwane.";
 
 "download" = "Pobierz";
-
-"external_storage_is_not_available" = "Karta SD/Pamięć USB z pobranymi mapami nie jest dostępna";
 
 "disconnect_usb_cable" = "Proszę odłączyć kabel USB albo włożyć kartę pamięci, aby korzystać z Organic Maps";
 
@@ -117,8 +90,6 @@
 "not_enough_memory" = "Za mało pamięci, aby uruchomić aplikację";
 
 "download_resources" = "Przed rozpoczęciem prosimy o pobranie ogólnej mapy świata na urządzenie.\nWymaga to %@ danych.";
-
-"getting_position" = "Określanie aktualnego położenia";
 
 "download_resources_continue" = "Przejdź do mapy";
 
@@ -140,23 +111,14 @@
 /* Add New Bookmark Set dialog title */
 "add_new_set" = "Dodaj nowy zestaw";
 
-/* Place Page - Add To Bookmarks button */
-"add_to_bookmarks" = "Dodaj zakładkę";
-
 /* Bookmark Color dialog title */
 "bookmark_color" = "Kolor zakładki";
 
 /* Add Bookmark Set dialog - hint when set name is empty */
 "bookmark_set_name" = "Nazwa zestawu zakładek";
 
-/* Bookmark Sets dialog title */
-"bookmark_sets" = "Zestawy zakładek";
-
 /* Bookmarks - dialog title */
 "bookmarks" = "Zakładki";
-
-/* Add bookmark dialog - bookmark color */
-"color" = "Kolor";
 
 /* Default bookmarks set name */
 "core_my_places" = "Moje miejsca";
@@ -167,14 +129,8 @@
 /* Editor title above street and house number */
 "address" = "Adres";
 
-/* Place Page - Remove Pin button */
-"remove_pin" = "Usuń znacznik";
-
 /* Add bookmark dialog - bookmark set, Bookmarks dialog - Bookmark set cell */
 "set" = "Zestaw";
-
-/* Text hint in Bookmarks dialog when no any bookmarks are added */
-"bookmarks_usage_hint" = "Nie oznaczono jeszcze żadnych zakładek.\nProszę dotknąć dowolnego miejsca na mapie, aby dodać zakładkę.\nMożna importować i wyświetlać zakładki z innych zasobów. Program otwiera pliki KML/KMZ z zapisanymi zakładkami, pochodzące z wiadomości email, Dropboxa lub odnośników internetowych.";
 
 /* Settings button in system menu */
 "settings" = "Ustawienia";
@@ -191,26 +147,11 @@
 /* Ask to wait user several minutes (some long process in modal dialog). */
 "wait_several_minutes" = "To może zająć kilka minut.\nProszę czekać…";
 
-/* Show bookmarks from this category on a map or not */
-"visible" = "Widoczne";
-
-/* Toast which is displayed when GPS has been deactivated */
-"gps_is_disabled_long_text" = "GPS jest wyłączony. Proszę włączyć go w ustawieniach.";
-
 /* Measurement units title in settings activity */
 "measurement_units" = "Jednostki miary";
 
 /* Detailed description of Measurement Units settings button */
 "measurement_units_summary" = "Wybiera pomiędzy milami, a kilometrami";
-
-/* Do search in all sources */
-"search_mode_all" = "Wszędzie";
-
-/* Do search near my position only */
-"search_mode_nearme" = "W pobliżu mnie";
-
-/* Do search in current viewport only */
-"search_mode_viewport" = "Na ekranie";
 
 /* Search category for cafes, bars, restaurants */
 "eat" = "Gdzie zjeść";
@@ -266,14 +207,8 @@
 /* Search category */
 "police" = "Policja";
 
-/* String in search result list, when nothing found */
-"no_search_results_found" = "Nie odnaleziono";
-
 /* Notes field in Bookmarks view */
 "description" = "Notatki";
-
-/* Button text */
-"share_by_email" = "Udostępnij przez email";
 
 /* Email Subject when sharing bookmarks category */
 "share_bookmarks_email_subject" = "Udostępnione zakładki z Organic Maps";
@@ -295,26 +230,11 @@
 /* Warning message when doing search around current position */
 "unknown_current_position" = "Nie określono jeszcze aktualnego położenia";
 
-/* Warning message when location country isn't downloaded during search (see also download_location_map_proposal). */
-"download_location_country" = "Pobierz mapę kraju, w którym aktualnie przebywasz (%@)";
-
-/* Warning message when viewport country isn't downloaded during search */
-"download_viewport_country_to_search" = "Pobierz mapę kraju, którego aktualnie poszukujesz (%@)";
-
 /* Alert message that we can't run Map Storage settings due to some reasons. */
 "cant_change_this_setting" = "Przepraszamy, ustawienia pamięci mapy są aktualnie wyłączone.";
 
 /* Alert message that downloading is in progress. */
 "downloading_is_active" = "Trwa pobieranie mapy kraju.";
-
-/* Message that will be shown in alert view, when we ask user to leave review on App Store */
-"appStore_message" = "Mamy nadzieję, że podoba ci się aplikacja Organic Maps! Jeśli tak to proszę oceń ją lub napisz recenzję w AppStore. To zajmie mniej niż minutę, a bardzo nam pomoże. Dziękujemy za wsparcie!";
-
-/* No, thanks */
-"no_thanks" = "Nie, dziękuję";
-
-/* Share one specific bookmark using SMS, %1$@ contains om:// and %2$@ https://omaps.app link. @NOTE non-ascii symbols in the link will result in max 70 characters SMS instead of 140. */
-"bookmark_share_sms" = "Mój znacznik w Organic Maps %1$@ i %2$@";
 
 /* Share my position using SMS, %1$@ contains om:// and %2$@ https://omaps.app link WITHOUT NAME. @NOTE non-ascii symbols in the link will result in max 70 characters SMS instead of 140. */
 "my_position_share_sms" = "Zobacz gdzie jestem. Link %1$@ lub %2$@";
@@ -328,23 +248,11 @@
 /* Share my position using EMail, %1$@ is om:// and %2$@ is https://omaps.app link WITHOUT NAME */
 "my_position_share_email" = "Cześć,\n\nJestem teraz tutaj: %1$@. Naciśnij na ten link %2$@ lub ten %3$@, aby zobaczyć to miejsce na mapie.\n\nDziękuję.";
 
-/* Android share by Message/SMS button text (including SMS) */
-"share_by_message" = "Udostępnij przez wiadomość";
-
 /* Share button text which opens menu with more buttons, like Message, EMail, Facebook etc. */
 "share" = "Udostępnij";
 
-/* iOS share by Message button text (including SMS) */
-"message" = "Wiadomość";
-
 /* Share by email button text, also used in editor. */
 "email" = "Email";
-
-/* Copy Link */
-"copy_link" = "Skopiuj odnośnik";
-
-/* Text for the button that returns to caller application */
-"more_info" = "Pokaż więcej informacji";
 
 /* Text for message when used successfully copied something */
 "copied_to_clipboard" = "Skopiowano do schowka: %1$@";
@@ -354,15 +262,6 @@
 
 /* Used for bookmark editing */
 "done" = "Gotowe";
-
-/* Summary for preferences in MWM */
-"yopme_pref_summary" = "Wybierz ustawienia tylnego ekranu";
-
-/* Title for yopme preferences in MWM */
-"yopme_pref_title" = "Ustawienia tylnego ekranu";
-
-/* Hint for upper-right icon p2b */
-"show_on_backscreen" = "Pokaż na tylnym ekranie";
 
 /* Prints version number in About dialog */
 "version" = "Wersja: %@";
@@ -381,19 +280,11 @@
 
 "share_my_location" = "Udostępnij aktualne położenie";
 
-"menu_search" = "Wyszukaj";
-
 /* Settings general group in settings screen */
 "prefs_group_general" = "Ustawienia ogólne";
 
 /* Settings information group in settings screen */
 "prefs_group_information" = "Informacje";
-
-/* Settings screen: "Map" category title */
-"prefs_group_map" = "Mapa";
-
-/* Settings screen: "Miscellaneous" category title */
-"prefs_group_misc" = "Różne";
 
 "prefs_group_route" = "Nawigacja";
 
@@ -419,9 +310,6 @@
 /* Settings «Map» category: «3D buildings» title */
 "pref_map_3d_buildings_title" = "Budynki w 3D";
 
-/* Settings «Map» category: «3D buildings» summary */
-"pref_map_3d_buildings_subtitle" = "Wpływa na czas pracy baterii";
-
 /* Settings «Route» category: «Tts enabled» title */
 "pref_tts_enable_title" = "Komunikaty głosowe";
 
@@ -433,8 +321,6 @@
 
 /* Title for "Other" section in TTS settings. */
 "pref_tts_other_section_title" = "Inny";
-
-"pref_tts_how_to_set_up_voice" = "Jak skonfigurować usługę głosową";
 
 /* Settings «Map» category: «Record track» title */
 "pref_track_record_title" = "Ostatnia trasa";
@@ -455,56 +341,7 @@
 
 "recent_track_help_text" = "Umożliwia na pewien okres zapisanie przebytej trasy i obejrzenie jej na mapie. Uwaga: włączenie tej funkcji spowoduje większe zużycie baterii. Trasa zostanie usunięta z mapy automatycznie po upływie określonego czasu.";
 
-"pref_track_ios_caption" = "Ostatnia trasa pokazuje pokonaną przez Ciebie ścieżkę.";
-
-"pref_track_ios_subcaption" = "Wybierz zakres czasowy dla zapisywanej trasy.";
-
-"placepage_distance" = "Dystans";
-
-"placepage_coordinates" = "Współrzędne";
-
-"placepage_unsorted" = "Niesklasyfikowane";
-
 "search_show_on_map" = "Wyświetl na mapie";
-
-/* Used to warn user when fixing KitKat issue */
-"bookmark_move_fail" = "Musimy przenieść Twoje zakładki do pamięci wewnętrznej, ale nie ma tam dla nich wolnego miejsca. Prosimy zwolnić pamięć, inaczej zakładki nie będą dostępne.";
-
-/* Used in More Apps menu */
-"free" = "Darmowy";
-
-/* Used in More Apps menu */
-"buy" = "Kup";
-
-/* 1st search button-like result */
-"search_on_map" = "Szukaj na mapie";
-
-/* toast with an error */
-"no_route_found" = "Nie znaleziono trasy";
-
-/* route title */
-"route" = "Trasa";
-
-/* category title */
-"routes" = "Marszruty";
-
-/* text of notification */
-"download_map_notification" = "Pobierz mapę miejsca, w którym się zajdujesz";
-
-/* text of notification */
-"pro_version_is_free_today" = "Pełna wersja Organic Maps jest dziś za darmo! Pobierz teraz i powiedz znajomym.";
-
-/* Dialog for transferring maps from lite to pro. */
-"move_lite_maps_to_pro" = "Przenosimy twoje pobrane mapy z Organic Maps Lite do Organic Maps. Może to zająć kilka minut.";
-
-/* Message to display when maps moved. */
-"move_lite_maps_to_pro_ok" = "Pomyślnie przeniesiono twoje pobrane mapy do Organic Maps.";
-
-/* Message to display when maps move failed. */
-"move_lite_maps_to_pro_failed" = "Nie udało się przenieść twoich map. Proszę skasować Organic Maps Lite i pobrać mapy ponownie.";
-
-/* Text in menu */
-"settings_and_more" = "Ustawienia i inne";
 
 /* Text in menu */
 "website" = "Strona internetowa";
@@ -527,14 +364,8 @@
 /* Text in menu */
 "openstreetmap" = "OpenStreetMap";
 
-/* Text in menu */
-"contact_us" = "Skontaktuj się z nami";
-
 /* Settings: Send feedback button and dialog title */
 "feedback" = "Opinia";
-
-/* Text in menu */
-"subscribe_to_news" = "Subskrybuj nasze wiadomości";
 
 /* Text in menu */
 "rate_the_app" = "Oceń aplikację";
@@ -548,15 +379,6 @@
 /* Text in menu */
 "report_a_bug" = "Zgłoś błąd";
 
-/* Email subject */
-"subscribe_me_subject" = "Chcę subskrybować biuletyn Organic Maps";
-
-/* Email body */
-"subscribe_me_body" = "Chcę w pierwszej kolejności otrzymywać powiadomienia o nowościach aktualizacjach i promocjach. Mogę w każdej chwili anulować swoją subskrypcję.";
-
-/* About text */
-"about_text" = "Organic Maps oferuje najszybsze mapy offline wszystkich miast we wszystkich krajach świata. Podróżuj bez obaw: gdziekolwiek jesteś, Organic Maps pomoże Ci odszukać się na mapie, znaleźć najbliższą restaurację, hotel, bank, stację benzynową itp. Aplikacja nie wymaga połączenia z Internetem.\n\nNieustannie pracujemy nad nowymi funkcjami i chcielibyśmy dowiedzieć się, jak Twoim zdaniem moglibyśmy poprawić Organic Maps. Jeśli masz jakieś problemy z aplikacją, skontaktuj się z nami, pisząc na adres support@organicmaps.app. Odpowiemy na każde zapytanie!\n\nLubisz aplikację Organic Maps i chcesz udzielić nam wsparcia? Istnieje kilka prostych i absolutnie darmowych sposobów, jak to zrobić:\n\n- napisz recenzję w swoim sklepie z aplikacjami\n- polub naszą stronę na Facebooku: http://www.facebook.com/OrganicMaps\n- albo po prostu opowiedz o Organic Maps swojej mamie, znajomym i kolegom :)\n\nDziękujemy, że jesteś z nami. Jesteśmy bardzo wdzięczni za Twoje wsparcie!\n\nP.S. Dane mapy pochodzą z OpenStreetMap, projektu kartograficznego podobnego do Wikipedii, który umożliwia użytkownikom tworzenie i edytowanie map. Jeśli zauważysz, że na mapie czegoś brakuje albo jest błąd, możesz nanieść poprawki bezpośrednio na stronie https://www.openstreetmap.org, a Twoje zmiany pojawią się w aplikacji Organic Maps po wydaniu kolejnej wersji.";
-
 /* Alert text */
 "email_error_body" = "Email klienta nie został założony. Proszę skonfigurować adres email, bądź skorzystać z innych opcji, aby się z nami skontaktować na %@";
 
@@ -569,12 +391,6 @@
 /* Search category */
 "wifi" = "WiFi";
 
-/* Update map suggestion */
-"routing_map_outdated" = "Proszę zaktualizować mapę, by utworzyć trasę.";
-
-/* Update maps suggestion */
-"routing_update_maps" = "Nowa wersja aplikacji Organic Maps pozwala na tworzenie tras z Twojej bieżącej lokalizacji do punktu docelowego. Proszę zaktualizować mapy, by móc korzystać z tej funkcji.";
-
 /* Update all button text */
 "downloader_update_all_button" = "Aktualizuj wszystkie";
 
@@ -583,9 +399,6 @@
 
 /* Downloaded maps category */
 "downloader_downloaded_subtitle" = "Pobrane";
-
-/* Downloaded maps category */
-"downloader_available_maps" = "Dostępne";
 
 /* Country queued for download */
 "downloader_queued" = "W kolejce";
@@ -598,17 +411,6 @@
 
 "downloader_downloading" = "Pobieranie:";
 
-"downloader_search_results" = "Znaleziono";
-
-/* Disclaimer message */
-"routing_disclaimer" = "Podczas tworzenia tras w aplikacji Organic Maps pamiętaj o poniższych zasadach:\n\n  - Sugerowane trasy mogą być traktowane jedynie jako propozycje.\n - Warunki na drodze, przepisy ruchu drogowego i znaki mają większy priorytet niż wskazówki nawigacyjne.\n - Mapa może okazać się nieprawidłowa lub nieaktualna a trasy mogą nie zostać utworzone w sposób najlepszy z możliwych.\n\n  Szerokiej drogi, uważaj na siebie!";
-
-/* Outdated maps category */
-"downloader_outdated_maps" = "Nieaktualne";
-
-/* Up to date maps category */
-"downloader_uptodate_maps" = "Najnowsze";
-
 /* Status of outdated country in the list */
 "downloader_status_outdated" = "Aktualizacja";
 
@@ -618,49 +420,14 @@
 /* Displayed in a dialog that appears when a user tries to delete a map while the app is in the follow route mode */
 "downloader_delete_map_while_routing_dialog" = "Aby usunąć mapę, zatrzymaj nawigację.";
 
-/* Show when user try build route, but we don't know where he */
-"routing_failed_unknown_my_position" = "Bieżąca lokalizacja nie została zdefiniowana. Aby utworzyć trasę, określ lokalizację.";
-
-/* Show if use has not routing file, or InconsistentMWMandRoute */
-"routing_failed_has_no_routing_file" = "Aby stworzyć trasę, potrzebne są dodatkowe dane. Rozpocząć pobieranie?";
-
-/* StartPointNotFound */
-"routing_failed_start_point_not_found" = "Nie można obliczyć trasy. Brak dróg w pobliżu punktu rozpoczęcia podróży.";
-
-/* EndPointNotFound */
-"routing_failed_dst_point_not_found" = "Nie można obliczyć trasy. Brak dróg w pobliżu celu podróży.";
-
 /* PointsInDifferentMWM */
 "routing_failed_cross_mwm_building" = "Trasy można tworzyć tylko pod warunkiem, że zawarte będą w ramach pojedynczej mapy.";
-
-/* RouteNotFound */
-"routing_failed_route_not_found" = "Nie znaleziono trasy pomiędzy wybranym punktem rozpoczęcia podróży a jej celem. Wybierz inny punkt początkowy lub końcowy.";
-
-/* InternalError */
-"routing_failed_internal_error" = "Wystąpił wewnętrzny błąd. Spróbuj usunąć mapę i pobrać ją ponownie. Jeśli problem będzie się nadal powtarzał, skontaktuj się z nami pod adresem support@organicmaps.app.";
-
-/* Context menu item for downloader. */
-"downloader_download_map_and_routing" = "Pobierz mapę + wyznaczanie tras";
-
-/* Context menu item for downloader. */
-"downloader_download_routing" = "Pobierz wyznaczanie tras";
-
-/* Context menu item for downloader. */
-"downloader_delete_routing" = "Skasuj wyznaczanie tras";
 
 /* Context menu item for downloader. */
 "downloader_download_map" = "Pobierz mapę";
 
-"downloader_download_map_no_routing" = "Pobierz mapę bez oznaczania tras";
-
-/* Button for routing. */
-"routing_go" = "Przejdź!";
-
 /* Item status in downloader. */
 "downloader_retry" = "Powtórz";
-
-/* Item in context menu. */
-"downloader_map_and_routing" = "Mapa + trasy";
 
 /* Item in context menu. */
 "downloader_delete_map" = "Usuń mapę";
@@ -668,29 +435,11 @@
 /* Item in context menu. */
 "downloader_update_map" = "Aktualizuj mapę";
 
-/* Item in context menu. */
-"downloader_update_map_and_routing" = "Aktualizuj mapę + trasy";
-
-/* Item in context menu. */
-"downloader_map_only" = "Tylko mapa";
-
-/* Toolbar title */
-"toolbar_application_menu" = "Menu aplikacji";
-
 /* Preference text */
 "pref_use_google_play" = "Używa usług Google Play do ustalenia aktualnego położenia";
 
 /* Text for rating dialog */
 "rating_just_rated" = "Właśnie oceniłem Waszą aplikację";
-
-/* Text for rating dialog */
-"rating_user_since" = "Jestem użytkownikiem Organic Maps od %@ r.";
-
-/* Text for rating dialog */
-"rating_do_like_maps" = "Lubisz Organic Maps?";
-
-/* Text for rating dialog */
-"rating_tap_star" = "Stuknij gwiazdkę, by ocenić naszą aplikację.";
 
 /* Text for rating dialog */
 "rating_thanks" = "Dziękujemy!";
@@ -701,23 +450,8 @@
 /* Text for rating dialog */
 "rating_send_feedback" = "Wyślij opinię";
 
-/* Text for g+ dialog */
-"rating_google_plus" = "Kliknij g+, aby powiedzieć swoim znajomym o tej apce.";
-
 /* Text for routing error dialog */
 "routing_download_maps_along" = "Pobierz mapy wzdłuż trasy";
-
-/* Text for routing error dialog */
-"routing_download_map" = "Pobierz mapę";
-
-/* Text for routing error dialog */
-"routing_download_map_and_routing" = "Pobierz zaktualizowaną mapę i dane ustalania tras, by mieć dostęp do wszystkich funkcji Organic Maps.";
-
-/* Text for routing error dialog */
-"routing_get_routing_data" = "Pobierz dane ustalania tras";
-
-/* Text for routing error dialog */
-"routing_get_additional_data" = "Dodatkowe dane wymagane do tworzenia tras z Twojej lokalizacji.";
 
 /* Text for routing error dialog */
 "routing_requires_all_map" = "Tworzenie tras wymaga pobrania i zaktualizowania wszystkich map od Twojej lokalizacji do celu podróży.";
@@ -725,50 +459,15 @@
 /* Text for routing error dialog */
 "routing_not_enough_space" = "Brak wolnego miejsca";
 
-/* Text for routing error dialog */
-"routing_download_more_than_avail" = "Musisz pobrać %@ MB, lecz dostępne jest tylko %@ MB.";
-
-/* Text for routing error dialog */
-"routing_download_roaming" = "%@ MB do pobrania przy wykorzystaniu danych mobilnych (w roamingu). Może to oznaczać dodatkowe opłaty w zależności od planu danych mobilnych Twojego dostawcy usług.";
-
 /* bookmark button text */
 "bookmark" = "zakładka";
-
-/* map is not downloaded */
-"not_found_map" = "Nie znaleziono mapy Twojej lokalizacji";
 
 /* location service disabled */
 "enable_location_services" = "Proszę włączyć usługi lokalizacji";
 
-/* download map */
-"download_map" = "Pobierz mapę dla swojej lokalizacji";
-
-/* download map on iPhone */
-"download_map_iphone" = "Pobierz na swojego iPhone'a mapę dla bieżącej lokalizacji";
-
-/* clear pin */
-"nearby" = "W pobliżu";
-
-/* clear pin */
-"clear_pin" = "Wyczyść pinezkę";
-
-/* location is undefined */
-"undefined_location" = "Bieżąca lokalizacja nie została zdefiniowana.";
-
-/* download country of your location */
-"download_country" = "Pobierz mapę kraju, w którym aktualnie przebywasz";
-
-/* download failed */
-"download_failed" = "pobieranie nie powiodło się";
-
-/* get the map */
-"get_the_map" = "Pobierz mapę";
-
 "save" = "Zapisz";
 
 "edit_description_hint" = "Twoje opisy (tekst lub html)";
-
-"new_group" = "nowa grupa";
 
 "create" = "utwórz";
 
@@ -795,30 +494,6 @@
 
 /* pink color */
 "pink" = "Różowy";
-
-/* deep purple color */
-"deep_purple" = "Ciemnopurpurowy";
-
-/* light blue color */
-"light_blue" = "Jasnoniebieski";
-
-/* cyan color */
-"cyan" = "Niebieskozielony";
-
-/* teal color */
-"teal" = "Szmaragdowy";
-
-/* lime color */
-"lime" = "Lima";
-
-/* deep orange color */
-"deep_orange" = "Ciemnopomarańczowy";
-
-/* gray color */
-"gray" = "Szary";
-
-/* blue gray color */
-"blue_gray" = "Szaroniebieski";
 
 /* Wi-Fi available */
 "WiFi_available" = "Tak";
@@ -848,13 +523,9 @@
 
 "dialog_routing_location_unknown_turn_on" = "Nie można ustalić współrzędnych GPS. Włącz usługi określania lokalizacji, aby wyznaczyć trasę.";
 
-"dialog_routing_location_unknown" = "Nie można ustalić współrzędnych GPS.";
-
 "dialog_routing_download_files" = "Pobierz wymagane pliki";
 
 "dialog_routing_download_and_update_all" = "Pobierz i zaktualizuj dane mapy i wyznaczania trasy wzdłuż planowanej drogi, aby wyznaczyć trasę.";
-
-"dialog_routing_routes_size" = "Pliki wyznaczania trasy";
 
 "dialog_routing_unable_locate_route" = "Nie można zlokalizować trasy";
 
@@ -884,21 +555,11 @@
 
 "dialog_routing_try_again" = "Spróbuj ponownie";
 
-"dialog_routing_send_error" = "Zgłoś problem";
-
-"dialog_routing_if_get_cross_route" = "Chcesz wyznaczyć lepszą trasę, obejmującą więcej map?";
-
-"dialog_routing_cross_route_is_optimal" = "Dostępna jest lepsza trasa, wykraczająca poza granice bieżącej mapy.";
-
 "not_now" = "Nie teraz";
-
-"dialog_routing_build_route" = "Wyznacz";
 
 "dialog_routing_download_and_build_cross_route" = "Chcesz pobrać mapę i wyznaczyć lepszą trasę, obejmującą więcej map?";
 
 "dialog_routing_download_cross_route" = "Pobierz mapę i wyznacz lepszą trasę, wykraczającą poza granice bieżącej mapy.";
-
-"dialog_routing_cross_route_always" = "Zawsze przekraczaj tę granicę";
 
 
 /********** Strings for downloading map from search **********/
@@ -906,8 +567,6 @@
 "search_without_internet_advertisement" = "Aby rozpocząć wyszukiwanie i tworzenie tras, pobierz mapę, a nie będzie ci już potrzebne połączenie z Internetem.";
 
 "search_select_map" = "Wybierz mapę";
-
-"search_select_other_map" = "Wybierz inną mapę";
 
 /* «Show» context menu */
 "show" = "Pokaż";
@@ -918,17 +577,11 @@
 /* «Rename» context menu */
 "rename" = "Zmień nazwę";
 
-/* Bottom sheet: expand button (should be short) */
-"bottom_sheet_more" = "Więcej…";
-
 /* Failed planning route message in navigation view */
 "routing_planning_error" = "Planowanie trasy nieudane";
 
 /* Arrive routing message in navigation view */
 "routing_arrive" = "Przybycie: %s";
-
-/* Text for routing::RouterResultCode::FileTooOld dialog. */
-"dialog_routing_download_and_update_maps" = "Aby utworzyć trasę, pobierz i zaktualizuj wszystkie właściwe dla niej mapy.";
 
 "rate_alert_title" = "Lubisz tę aplikację?";
 
@@ -944,19 +597,11 @@
 
 "history" = "Historia";
 
-"next_turn_then" = "Potem";
-
 "closed" = "Zamknięte";
-
-"back_to" = "Powróć do %@";
 
 "search_not_found" = "Przepraszamy, nic nie znaleziono.";
 
 "search_not_found_query" = "Wpisz inne zapytanie.";
-
-"search_not_found_map" = "Pobierz mapę interesującego cię obszaru.";
-
-"search_not_found_location" = "Pobierz mapę swojej bieżącej lokalizacji.";
 
 "search_history_title" = "Historia wyszukiwania";
 
@@ -964,23 +609,12 @@
 
 "clear_search" = "Wyczyść historię wyszukiwania";
 
-/* Title for settings to enable/disable showcase menu button */
-"showcase_settings_title" = "Oferty";
-
 /* Place Page link to Wikipedia article (if map object has it). */
 "read_in_wikipedia" = "Wikipedia";
 
-"p2p_route_planning" = "Planowanie trasy";
-
 "p2p_your_location" = "Twoja lokalizacja";
 
-"p2p_from" = "Miejsce wyjazdu";
-
-"p2p_to" = "Miejsce docelowe";
-
 "p2p_start" = "Start";
-
-"p2p_planning" = "Planowanie…";
 
 "p2p_from_here" = "Z";
 
@@ -1018,15 +652,9 @@
 
 "editor_correct_mistake" = "Popraw błąd";
 
-"editor_correct_mistake_message" = "Popełniono błąd podczas edycji. Popraw go lub przełącz się na tryb prosty.";
-
 "editor_add_select_location" = "Lokalizacja";
 
 "editor_done_dialog_1" = "Dokonałeś zmian na mapie świata. Nie kryj się z tym! Powiadom znajomych i edytujcie mapę razem.";
-
-"editor_done_dialog_2" = "Po raz drugi dokonałeś poprawek na mapie. Aktualnie znajdujesz się na %d miejscu na liście osób edytujących mapy. Opowiedz o tym znajomym.";
-
-"editor_done_dialog_3" = "Dokonałeś poprawek na mapie. Opowiedz o tym znajomym i razem ją edytujcie.";
 
 "share_with_friends" = "Udostępnij znajomym";
 
@@ -1044,20 +672,7 @@
 
 "editor_report_problem_duplicate_place_title" = "Powielone miejsce";
 
-"first_launch_congrats_title" = "Aplikacja Organic Maps jest gotowa";
-
-"first_launch_congrats_text" = "Wyszukuj i nawiguj w każdym zakątku świata — offline i bezpłatnie.";
-
-"migrate_title" = "Ważne!";
-
-/* Android uses image instead of text. */
-"download_all" = "Pobierz wszystko";
-
-"delete_all" = "Usuń wszystkie";
-
 "autodownload" = "Automatyczne pobieranie";
-
-"disable_autodownload" = "Wyłącz automatyczne pobieranie";
 
 /* Place Page opening hours text */
 "closed_now" = "Nieczynne";
@@ -1072,10 +687,6 @@
 "day_off" = "Nieczynne";
 
 "today" = "Dzisiaj";
-
-"sunrise_to_sunset" = "Od wschodu do zachodu słońca";
-
-"sunset_to_sunrise" = "Od zachodu do wschodu słońca";
 
 "add_opening_hours" = "Dodaj godziny otwarcia";
 
@@ -1095,45 +706,18 @@
 
 "forgot_password" = "Nie pamiętasz hasła?";
 
-/* Forgot Password dialog title */
-"restore_password" = "Przypomnij hasło";
-
-"enter_email_address_to_reset_password" = "Wpisz adres email, którego użyto podczas rejestracji, a prześlemy Ci link do ponownego utworzenia hasła.";
-
-"reset_password" = "Resetuj hasło";
-
-"username" = "Nazwa użytkownika";
-
 "osm_account" = "Konto OSM";
 
 "logout" = "Wyloguj";
 
-"login_and_edit_map_motivation_message" = "Zaloguj się i edytuj dane obiektów na mapie, a my udostępnimy je milionom innych użytkowników. Razem możemy poprawić świat.";
-
 /* Information text: "Last upload 11.01.2016" */
 "last_upload" = "Ostatnio przesłane";
 
-/* Motivates user to login/register, title above login buttons. */
-"you_have_edited_your_first_object" = "Edycja Twojego pierwszego obiektu zakończona!";
-
 "thank_you" = "Dziękujemy";
-
-"login_with_google" = "Zaloguj się przez Google";
-
-"login_with_openstreetmap" = "Zaloguj się przez www.openstreetmap.org";
 
 "edit_place" = "Edytuj miejsce";
 
 "place_name" = "Nazwa miejsca";
-
-/* title above languages list cells in the editor, below editable name text field. */
-"other_languages" = "Inne języki";
-
-/* small button to open list with names in different languages */
-"show_more" = "Pokaż więcej";
-
-/* small button to close list with names in different languages */
-"show_less" = "Pokaż mniej";
 
 "add_language" = "Dodaj język";
 
@@ -1164,8 +748,6 @@
 
 "please_note" = "Uwaga!";
 
-"common_no_wifi_dialog" = "Brak połączenia Wi-Fi. Czy chcesz kontynuować z użyciem danych pakietowych?";
-
 "downloader_delete_map_dialog" = "Wszystkie zmiany dotyczące mapy zostaną usunięte wraz z nią.";
 
 "downloader_update_maps" = "Aktualizuj mapy";
@@ -1173,10 +755,6 @@
 "downloader_mwm_migration_dialog" = "Aby utworzyć trasę, należy zaktualizować wszystkie mapy, a następnie ponownie zaplanować trasę.";
 
 "downloader_search_field_hint" = "Znajdź mapę";
-
-"migration_update_all_button" = "Aktualizuj wszystkie mapy";
-
-"migration_delete_all_download_current_button" = "Pobierz bieżącą mapę i usuń stare";
 
 "migration_download_error_dialog" = "Błąd pobierania";
 
@@ -1186,21 +764,9 @@
 
 "downloader_no_space_message" = "Usuń niepotrzebne dane";
 
-"editor_general_auth_error_dialog" = "Ogólny błąd logowania.";
-
 "editor_login_error_dialog" = "Błąd logowania.";
 
-"editor_login_failed_dialog" = "Nieudane logowanie";
-
-"editor_username_error_dialog" = "Nieprawidłowa nazwa użytkownika";
-
-"editor_place_edited_dialog" = "Obiekt był edytowany!";
-
-"editor_login_with_osm" = "Zaloguj się z OpenStreetMap";
-
 "editor_profile_changes" = "Zmiany zweryfikowane";
-
-"editor_profile_unsent_changes" = "Nie wysłano:";
 
 "editor_focus_map_on_location" = "Przeciągnij mapę, aby wybrać poprawną lokalizację obiektu.";
 
@@ -1222,13 +788,9 @@
 
 "editor_report_problem_other_title" = "Inny problem";
 
-"placepage_report_problem_button" = "Zgłoś problem";
-
 "placepage_add_business_button" = "Dodaj organizację";
 
 "whatsnew_editor_message_1" = "Dodawaj nowe miejsca do mapy i edytuj już istniejące bezpośrednio z poziomu aplikacji.";
-
-"whatsnew_editor_message_2" = "* Organic Maps korzysta z danych społeczności OpenStreetMap.";
 
 "dialog_incorrect_feature_position" = "Zmień lokalizację";
 
@@ -1236,16 +798,10 @@
 
 "login_to_make_edits_visible" = "Zaloguj się, by inni użytkownicy mogli zobaczyć Twoje zmiany.";
 
-"no_migration_during_navigation" = "Podczas nawigacji aktualizacja jest niemożliwa.";
-
 /* Error dialog no space */
 "migration_no_space_message" = "Aby pobrać, potrzebujesz więcej miejsca. Usuń niepotrzebne dane.";
 
 "editor_sharing_title" = "Dokonałem poprawek map na Organic Maps";
-
-"editor_comment_will_be_sent" = "Prześlemy Twoje komentarze kartografom.";
-
-"editor_unsupported_category_message" = "Dodałeś miejsce w kategorii, której jeszcze nie obsługujemy. Pojawi się ono na mapie za jakiś czas.";
 
 /* Downloaded 10 **of** 20 <- it is that "of" */
 "downloader_of" = "%1$d z %2$d";
@@ -1278,23 +834,9 @@
 
 "editor_operator" = "Operator";
 
-"editor_tag_description" = "Wprowadź nazwę firmy, organizacji lub osoby odpowiedzialnej za obiekty.";
-
-"editor_no_local_edits_title" = "Nie masz lokalnych edycji";
-
-"editor_no_local_edits_description" = "Jest to liczba sugerowanych przez ciebie zmian na mapie, które aktualnie dostępne są tylko na twoim urządzeniu.";
-
-"editor_send_to_osm" = "Wyślij do OSM";
-
-"editor_remove" = "Usuń";
-
-"downloader_my_maps_title" = "Moje mapy";
-
 "downloader_no_downloaded_maps_title" = "Nie pobrano żadnych map";
 
 "downloader_no_downloaded_maps_message" = "Aby znajdować miejsca i nawigować bez połączenia z internetem, musisz pobrać mapy.";
-
-"downloader_find_place_hint" = "Szukaj miasta lub kraju";
 
 /* Error title that appears after certain time without location. */
 "current_location_unknown_title" = "Kontynuować wykrywanie bieżącej lokalizacji?";
@@ -1321,47 +863,13 @@
 /* iOS Dialog for the case when the location permission is not granted */
 "location_services_disabled_3" = "3. Zaznacz Podczas korzystania z aplikacji";
 
-"placepage_parking_surface" = "Powierzchnia";
-
-"placepage_parking_multistorey" = "Wielopoziomowy";
-
-"placepage_parking_underground" = "Podziemny";
-
-"placepage_parking_rooftop" = "Na dachu";
-
-"placepage_parking_sheds" = "Wiaty";
-
-"placepage_parking_carports" = "Zadaszenia dla samochodów";
-
-"placepage_parking_boxes" = "Miejsca parkingowe w garażu";
-
-"placepage_parking_pay" = "Płatny";
-
-"placepage_parking_free" = "Darmowy";
-
-"placepage_parking_interval" = "Płatny na godziny";
-
-"placepage_entrance_number" = "Nr";
-
-"placepage_entrance_type" = "Wejście";
-
-"placepage_flat" = "Mieszkanie";
-
-"placepage_open_24_7" = "24 / 7";
-
 "meter" = "m";
 
 "kilometer" = "km";
 
-"kilometers_per_hour" = "km/h";
-
 "mile" = "mi";
 
 "foot" = "ft";
-
-"miles_per_hour" = "mph";
-
-"day" = "d";
 
 "hour" = "godz";
 
@@ -1381,10 +889,6 @@
 
 "placepage_bookmark_name_hint" = "Nazwa zakładki";
 
-"placepage_personal_notes_hint" = "Notatki osobiste";
-
-"placepage_delete_bookmark_button" = "Usuń zakładkę";
-
 "editor_edits_sent_message" = "Twoje sugestie zostały wysłane";
 
 "editor_comment_hint" = "Komentarz…";
@@ -1397,8 +901,6 @@
 
 "editor_remove_place_button" = "Usuń";
 
-"editor_status_sending" = "Wysyłanie…";
-
 "editor_place_doesnt_exist" = "Takie miejsce nie istnieje";
 
 "text_more_button" = "…więcej";
@@ -1410,11 +912,7 @@
 
 "error_enter_correct_email" = "Wpisz prawidłowy email";
 
-"error_enter_correct" = "Wpisz prawidłową wartość";
-
 "refresh" = "Uaktualnić";
-
-"last_update" = "Ostatnia aktualizacja: %s";
 
 "placepage_add_place_button" = "Dodaj miejsce do mapy";
 
@@ -1426,24 +924,6 @@
 
 "editor_share_to_all_dialog_message_2" = "Zapoznamy się ze zmianami. W przypadku pytań skontaktujemy się z Tobą przez email.";
 
-"navigation_overview_button" = "przegląd";
-
-"navigation_stop_button" = "stop";
-
-/* Text on an empty bookmark page */
-"bookmarks_empty_title" = "Zapisz zakładki";
-
-"bookmarks_empty_message_1" = "Stuknij ★, aby zapisać ulubione miejsca w celu szybkiego dostępu.";
-
-"bookmarks_empty_message_2" = "Importuj zakładki z aplikacji Mail i z Sieci.";
-
-"bookmarks_empty_message_3" = "wymeldowanie: %s";
-
-/* Name of the group for booked hotels */
-"bookmarks_group_name" = "Zarezerwowane hotele";
-
-"place_page_button_read_descriprion" = "Czytaj";
-
 /* iOS dialog for the case when recent track recording is on and the app comes back from background */
 "recent_track_background_dialog_title" = "Wyłączyć rejestrowanie niedawno przebytej trasy?";
 
@@ -1451,8 +931,6 @@
 
 /* For sharing via SMS and so on */
 "sharing_call_action_look" = "Sprawdź";
-
-"continue_recent_track_background_button" = "Kontynuuj";
 
 "recent_track_background_dialog_message" = "Organic Maps używa w tle geolokalizacji w celu rejestrowania niedawno przebytej trasy.";
 
@@ -1468,33 +946,13 @@
 /* About short text (below logo) */
 "about_description" = "Organic Maps to niezbędna aplikacja do podróży działająca w trybie offline. Organic Maps opiera się o dane OpenStreetMap oraz umożliwia ich edycję.";
 
-/* Text in menu */
-"blog" = "Blog";
-
 "general_settings" = "Ustawienia ogólne";
-
-"date" = "Data %d";
-
-/* "Report a bug" -> "Generaal Feedback" -> "Something is not working" */
-"something_is_not_working" = "Coś nie działa";
 
 /* For the first routing */
 "accept" = "Zaakceptuj";
 
-"accept_and_continue" = "Accept and continue";
-
 /* For the first routing */
 "decline" = "Odrzuć";
-
-"install_app" = "Zainstaluj";
-
-"search_no_results_title" = "Nie znaleziono wyników";
-
-"search_no_results_message" = "Spróbuj szerszego terminu wyszukiwania, zawęzić lub resetować filtr.";
-
-"search_no_results_expand_area_button" = "Zawęź";
-
-"search_no_results_reset_button" = "Resetuj filtr";
 
 /* noun */
 "search_in_table" = "Lista";
@@ -1517,8 +975,6 @@
 
 "traffic_update_maps_text" = "Aby wyświetlić dane o ruchu, muszą zostać zaktualizowane mapy.";
 
-"traffic_outdated" = "Dane o ruchu są przestarzałe.";
-
 "big_font" = "Powiększ rozmiar czcionki na mapie";
 
 "traffic_update_app" = "Zaktualizuj Organic Maps";
@@ -1529,17 +985,7 @@
 /* "traffic" as in "road congestion" */
 "traffic_data_unavailable" = "Dane o ruchu są niedostępne";
 
-/* "Translation is no needed, because it's a company name" */
-"uber" = "Uber";
-
-/* Simplified colour scheme for traffic information, fewer colours are used to display traffic jams on the map. The string should be kept as short as possible */
-"pref_traffic_simplified_colors_title" = "Uproszczone kolory sygnalizacji";
-
 "enable_logging" = "Włącz logowanie";
-
-"offline_place_page_more_information" = "Połącz się z Internetem, aby uzyskać więcej informacji na temat miejsca.";
-
-"failed_load_information" = "Nie można załadować informacji.";
 
 /* Settings: "Send general feedback" button */
 "feedback_general" = "Ogólne uwagi";
@@ -1556,8 +1002,6 @@
 
 "whatsnew_transliteration_title" = "Transkrypcja na alfabet łaciński";
 
-"yandex_taxi_title" = "Yandex.Taxi";
-
 "learn_more" = "Dowiedz się więcej";
 
 "core_exit" = "Wyjdź";
@@ -1568,75 +1012,19 @@
 
 "button_exit" = "Wyjdź";
 
-"settings_device_memory" = "Pamięć urządzenia";
-
-"settings_card_memory" = "Pamięć na karcie";
-
-"settings_storage_available" = "dostępne %s";
-
-"toast_location_permission_denied" = "Odmowa dla aplikacji uprawnień do lokalizacji";
-
-"button_use" = "Użyj";
-
 "planning_route_manage_route" = "Zarządzaj trasą";
 
 "button_plan" = "Zaplanuj";
-
-"button_add" = "Dodaj";
 
 "placepage_remove_stop" = "Usuń";
 
 "planning_route_remove_title" = "Przeciągnij tu, aby usunąć";
 
-"dialog_change_start_point_message" = "Zamienić punkt początkowy na bieżącą lokalizację?";
-
-"button_replace" = "Zamień";
-
 "placepage_add_stop" = "Dodaj postój";
-
-/* Only ru/en are needed */
-"subtitle_rent" = "Rent";
-
-/* Only ru/en are needed */
-"rub_month" = "RUB/month";
-
-/* Only ru/en are needed */
-"room" = "%s-room apt.";
-
-/* Only ru/en are needed */
-"real_estate" = "Real estate";
-
-"add_my_position" = "Dodaj moją pozycję";
-
-"choose_start_point" = "Wybierz punkty początkowy";
-
-"choose_destination" = "Wybierz punkt docelowy";
 
 "preloader_viator_button" = "Dowiedz się więcej";
 
-"start_from_my_position" = "Zacznij od";
-
-"profile_authorization_title" = "Zaloguj się za pomocą";
-
-"profile_authorization_message" = "Łatwe logowanie w kilka sekund bez podawania loginu i hasła";
-
 "profile_authorization_error" = "Ups, nastąpił błąd. Spróbuj zalogować się ponownie.";
-
-"service" = "Usługa";
-
-"atmosphere" = "Atmosfera";
-
-"value_for_money" = "Stosunek jakości do ceny";
-
-"experience" = "Doświadczenie";
-
-"assortment" = "Asortyment";
-
-"expertise" = "Fachowość";
-
-"equipment" = "Wyposażenie";
-
-"quality" = "Jakość";
 
 "dialog_error_storage_title" = "Problem z dostępem do pamięci masowej";
 
@@ -1644,17 +1032,7 @@
 
 "setting_emulate_bad_storage" = "Emuluj wadliwą pamięć masową";
 
-"directions_finish" = "Punkt docelowy";
-
-"directions_on_foot" = "Przejdź %s";
-
 "core_entrance" = "Wejście";
-
-"coffee" = "Kawa";
-
-"cleanliness" = "Czystość";
-
-"crowdedness" = "Zatłoczenie";
 
 "error_enter_correct_name" = "Wprowadź poprawną nazwę";
 
@@ -1673,11 +1051,9 @@
 
 "downloader_percent" = "%s (%s z %s)";
 
-"downloader_process" = "Pobieranie %s...";
+"downloader_process" = "Pobieranie %s…";
 
-"downloader_applying" = "Stosowanie zmian %s...";
-
-"dialog_message_transit_not_found_connection" = "Zaplanuj trasę w ramach jednej sieci transportowej";
+"downloader_applying" = "Stosowanie zmian %s…";
 
 "bookmarks_error_message_share_general" = "Nie można udostępnić z powodu błędu aplikacji";
 
@@ -1695,17 +1071,7 @@
 
 "bookmarks_error_message_list_name_already_taken" = "Wybierz inną nazwę";
 
-"bookmarks_error_title_list_name_too_long" = "Ta nazwa jest za długa";
-
-"bookmarks_error_message_list_name_too_long" = "Wybierz inną nazwę";
-
-"please_wait" = "Proszę czekać...";
-
-"phone_number" = "Numer telefonu";
-
-"notification_unsent_reviews_title" = "Masz kilka niewysłanych recenzji";
-
-"notification_unsent_reviews_message" = "Zaloguj się, aby udostępniać recenzje innym podróżnym";
+"please_wait" = "Proszę czekać…";
 
 "profile" = "Profil OpenStreetMap";
 
@@ -1719,49 +1085,13 @@
 
 "bookmarks_convert_error_message" = "Sommige bestanden waren niet geconverteerd.";
 
-"converting" = "Przekształcanie...";
-
-"wn_reinvented_bookmarks_title" = "Odnowiliśmy zakładki!";
-
-"wn_reinvented_bookmarks_message" = "Możesz tworzyć kopie zapasowe zakładek, tworzyć listy... To niesamowite...";
-
-"bookmarks_restore" = "Przywróć zakładki";
-
-"bookmarks_restore_process" = "Przywracanie...";
-
 "bookmarks_restore_title" = "Przywróć tę wersję?";
 
-"bookmarks_restore_message" = "Twoje zakładki zostaną przywrócone z %s (%s)";
-
-"bookmarks_restore_empty_title" = "Nie masz kopii zapasowej";
-
-"bookmarks_restore_empty_message" = "Serwer nie znalazł wcześniej utworzonych kopii zapasowych";
-
 "common_check_internet_connection_dialog_title" = "Brak połączenia z internetem";
-
-"error_server_title" = "Błąd serwera";
-
-"error_server_message" = "Der var en fejl på serveren, prøv igen senere";
 
 "error_system_message" = "Wystąpił nieznany błąd";
 
 "restore" = "Przywracać";
-
-"bookmarks_page_downloaded" = "Pobrane";
-
-"bookmarks_page_my" = "Moje";
-
-"routes_and_bookmarks" = "Trasy i zakładki";
-
-"bookmarks_webview_success_toast" = "Zakładki pobrane pomyślnie";
-
-"cached_bookmarks_placeholder_title" = "Pobierz nowe miejsca";
-
-"cached_bookmarks_placeholder_subtitle" = "Naciśnij przycisk, aby pobrać tysiące interesujących miejsc i tras utworzonych przez użytkowników Organic Maps. Wymagane jest połączenie internetowe.";
-
-"downloader_download_routers" = "Pobierz zakładki";
-
-"bookmarks_groups_cached" = "Pobrane listy";
 
 "subtittle_opt_out" = "Ustawienia śledzenia";
 
@@ -1769,29 +1099,15 @@
 
 "crash_reports_description" = "Możemy używać Twoich danych do usprawnienia działania Organic Maps. Zmiany zostaną zastosowane po ponownym uruchomieniu aplikacji.";
 
-"opt_out_help_ios_1" = "W Twoim urządzeniu mobilnym może być dostępne ustawienie „Limit Ad Tracking” lub „Opt out of interest-based advertising”.";
-
-"opt_out_help_ios_2" = "iOS 9 lub nowszy";
-
-"opt_out_help_ios_3" = "Przejdź do Ustawień → Prywatność→ Reklamy→ Włącz ustawienie „Limit Ad Tracking”";
-
-"opt_out_help_android" = "W Twoim urządzeniu mobilnym może być dostępne ustawienie „Limit Ad Tracking” lub „Opt out of interest-based advertising”.\n\nW przypadku systemu Android i Google Play Services w wersji 4.0 i nowszych:\nUstawienia → Google → Reklamy→ Rezygnacja z personalizacji reklam\nlub\nUstawienia→ Google → Konto Google→ Dane i personalizacja→ Personalizacja reklam→ Personalizacja reklam";
-
 "privacy_policy" = "Polityka prywatności";
 
 "terms_of_use" = "Warunki użytkowania";
-
-"backup_notification_failed" = "Tworzenie kopii zapasowych Twoich zakładek zostało zawieszone. Zaloguj się, aby włączyć je ponownie.";
 
 "button_layer_traffic" = "Ruch drogowy";
 
 "button_layer_subway" = "Metro";
 
 "layers_title" = "Warstwy map";
-
-"layers_message" = "Użyj warstw map, aby wyświetlić ruch drogowy, mapę metra i inne przydatne informacje";
-
-"button_layer_got_it" = "Rozumiem";
 
 "subway_data_unavailable" = "Mapa metra jest niedostępna";
 
@@ -1803,39 +1119,13 @@
 
 "title_error_downloading_bookmarks" = "Wystąpił błąd";
 
-"subtitle_error_downloading_bookmarks" = "Zakładki nie zostały pobrane";
-
-"error_already_downloaded" = "Ta lista została już pobrana";
-
 "popular_place" = "Popular";
-
-"download_routes" = "Download routes";
-
-"bookmarks_downloaded_title" = "Bookmarks have been downloaded successfully";
-
-"bookmarks_downloaded_subtitle" = "Press ‘View on map’ to explore new places from the list";
-
-"why_support" = "Po co wspierać Organic Maps?";
-
-"why_support_item1" = "We respect your privacy: there are zero trackers in the app, and we are open source";
-
-"why_support_item2" = "Pomagasz nam udoskonalać Organic Maps";
-
-"why_support_item3" = "Pomagasz nam udoskonalać mapy OpenStreetMap.org";
-
-"channels_map_update" = "Aktualizacja map";
-
-"server_unavailable_title" = "Serwer jest niedostępny";
-
-"sharing_options" = "Ustawienia dostępu";
 
 "export_file" = "Eksportuj plik";
 
 "list_settings" = "Ustawienia listy";
 
 "delete_list" = "Usuń listę";
-
-"hide_from_map" = "Ukryj mapy";
 
 "public_access" = "Dostęp publiczny";
 
@@ -1845,40 +1135,11 @@
 
 "bookmark_category_description_hint" = "Dodaj opis (tekst lub html)";
 
-/* FIXME */
-"bookmarks_public_access" = "bookmarks_public_access";
-
-/* FIXME */
-"bookmarks_link_access" = "bookmarks_link_access";
-
-/* FIXME */
-"bookmarks_private_access" = "bookmarks_private_access";
-
 "not_shared" = "Osobisty";
-
-"direct_link_progress_text" = "Trwa pobieranie Twojego pliku…";
-
-"direct_link_success" = "Link został utworzony";
-
-"send_a_link_btn" = "Wyślij link";
-
-"upload_error_toast" = "Wystąpił błąd podczas pobierania pliku";
 
 "tags_loading_error_subtitle" = "Wystąpił błąd podczas pobierania tagów, spróbuj ponownie";
 
-"unable_upload_errorr_title" = "Nie udało się przesłać pliku";
-
-"unable_upload_error_subtitle_edited" = "Plik edytowano za pomocą aplikacji internetowej";
-
-"unable_upload_error_subtitle_broken" = "Plik jest uszkodzony i nie można go załadować. Proszę przesłać inny plik.";
-
-"contact" = "Napisz";
-
-"download_button" = "Pobierz";
-
 "speedcams_alert_title" = "Fotoradary";
-
-"speedcams_alert_subtitle" = "Ostrzegać o ograniczeniach prędkości";
 
 "speedcam_option_auto" = "Auto";
 
@@ -1886,18 +1147,10 @@
 
 "speedcam_option_never" = "Nigdy";
 
-"bookmark_description_title" = "Opis znacznika";
-
 "place_description_title" = "Opis miejsca";
 
 /* this text will be shown in application notification preferences opposite checkbox which enable/disable downloader notifications. Devices on Android 8+ are affected. */
 "notification_channel_downloader" = "Pobieranie map";
-
-"share_bookmarks_email_body_link" = "Witaj!\n\nTwoje znaczniki można pobrać, używając link: %s. Otwórz listę, używając Organic Maps i ciesz się podrożą!\n\nPobierz aplikację: https://omaps.app/get?kmz";
-
-"warning_speedcams_title" = "Nawigator powiadomi Cibie o kamerach, gdy przekrocz prędkość na %d km/h";
-
-"warning_speedcams_subtitle" = "Nie zapomnij zapoznać się z zasadami ruchu drogowego w kraju podróży.";
 
 "speedcams_notice_message" = "Auto – Ostrzegać o kamerach, jeśli istnieje ryzyko przekroczenia ograniczenia prędkości\nZawsze – Zawsze ostrzegaj o kamerach\nNigdy – Nigdy nie ostrzegaj o kamerach";
 
@@ -1913,23 +1166,7 @@
 
 "enable_logging_warning_message" = "Ta opcja zostaje włączona do logowania działań w celach diagnostycznych. Pomaga to zespołowi zidentyfikować problemy z aplikacją. Włączaj opcję tylko na żądanie wsparcia technicznego Organic Maps.";
 
-"html_error_upload_message_try_again" = "Sprawdź dostęp do sieci i spróbuj ponownie";
-
-"html_error_upload_title_try_again" = "Brak połączenia z Internetem";
-
-"notification_leave_review_v2_android_short_title" = "Pozostaw komentarze i pomóż podróżującym!";
-
-"megafon" = "Say goodbye to roaming!";
-
-"notifications_illegal_alert_disable_button" = "Wyłącz powiadomienia";
-
 "access_rules_author_only" = "Edytowane online";
-
-"privacy_settings_menu" = "Ustawienia prywatności";
-
-"unable_upadate_error_title" = "Nieudana próba aktualizacji trasy";
-
-"unable_upadate_error_message" = "Podczas aktualizacji wystąpiły błędy. Sprawdź zmiany i spróbuj ponownie";
 
 "driving_options_title" = "Ustawienia objazdu";
 
@@ -1951,94 +1188,19 @@
 
 "change_driving_options_btn" = "Ustawienia objazdu są włączone";
 
-"toll_road" = "Droga płatna";
-
-"unpaved_road" = "Droga gruntowa";
-
-"ferry_crossing" = "Przeprawa promowa";
-
-"operated_by" = "Zarządzany przez \"%s\"";
-
 "avoid_toll_roads_placepage" = "Unikać dróg płatnych";
 
 "avoid_unpaved_roads_placepage" = "Unikać dróg gruntowych";
 
 "avoid_ferry_crossing_placepage" = "Unikać przepraw promowych";
 
-"type.cuisine.uzbek" = "Kuchnia uzbecka";
-
-"trip_start" = "Jedźmy";
-
-"pick_destination" = "Meta";
-
-"follow_my_position" = "Wyśrodkuj";
-
-"search_results" = "Wyniki wyszukiwania";
-
-"then_turn" = "Dalej";
-
-"redirect_route_alert" = "Czy chcesz przebudować trasę?";
-
-"redirect_route_yes" = "Tak";
-
-"redirect_route_no" = "Nie";
-
-"trip_finished" = "Jesteś na miejscu!";
-
-"keyboard_availability_alert" = "Klawiatura nie jest dostępna podczas ruchu";
-
-"dialog_routing_change_start_carplay" = "Brak możliwości zbudowania trasy od bieżącej lokalizacji";
-
-"dialog_routing_change_end_carplay" = "Brak możliwości zbudowania trasy do punktu końcowego. Wybierz inny";
-
-"dialog_routing_check_gps_carplay" = "Brak sygnału GPS. Dostań się do terenu otwartego";
-
-"dialog_routing_unable_locate_route_carplay" = "Brak możliwości zbudowania trasy. Wybierz inne punkty trasy";
-
-"dialog_routing_download_files_carplay" = "Aby wyznaczyć trasę, pobierz brakujące mapy na Twoim urządzeniu";
-
-"dialog_routing_system_error_carplay" = "Wystąpił błąd. Uruchom aplikację ponownie";
-
-"dialog_routing_rebuild_from_current_location_carplay" = "Trasa zostanie przebudowana z Twojej bieżącej lokalizacji";
-
-"dialog_routing_rebuild_for_vehicle_carplay" = "Trasa zostanie zmieniona na samochodową";
-
 "ok" = "Ok";
-
-"avoid_unpaved_carplay_1" = "Bez gruntow.";
-
-"avoid_unpaved_carplay_2" = "Bez gruntowych";
-
-"avoid_ferry_carplay_1" = "Bez promów";
-
-"avoid_ferry_carplay_2" = "Bez promów";
-
-"avoid_tolls_carplay_1" = "Wył. płatne";
-
-"avoid_tolls_carplay_2" = "Wyłącz płatne";
-
-"speedcams_alert_title_carplay_1" = "Kamery";
-
-"speedcams_alert_title_carplay_2" = "Info o kamerach";
-
-"download_map_carplay" = "Pobierz mapy do aplikacji Organic Maps na swoje urządzenie";
-
-"carplay_roundabout_exit" = "%s zjazd";
 
 /* max. 10 symbols, both iOS and Android */
 "sort" = "Sortuj…";
 
 /* Android, title, max 20-22 symbols */
 "sort_bookmarks" = "Sortuj znaczniki";
-
-/* iOS */
-"sort_default" = "Sortuj domyślnie";
-
-"sort_type" = "Sortuj wg rodzaju";
-
-"sort_distance" = "Sortuj wg odległości";
-
-"sort_date" = "Sortuj wg daty";
 
 /* Android */
 "by_default" = "Domyślnie";
@@ -2052,63 +1214,7 @@
 /* Android */
 "by_date" = "Wg daty";
 
-"week_ago_sorttype" = "Tydzień wstecz";
-
-"month_ago_sorttype" = "Miesiąc wstecz";
-
-"moremonth_ago_sorttype" = "Ponad miesiąc wstecz";
-
-"moreyear_ago_sorttype" = "Ponad rok wstecz";
-
-"near_me_sorttype" = "Obok mnie";
-
-"others_sorttype" = "Inne";
-
-"food_places" = "Jedzenie";
-
-"tourist_places" = "Zabytki";
-
-"museums" = "Muzea";
-
-"parks" = "Parki";
-
-"swim_places" = "Pływanie";
-
-"mountains" = "Góry";
-
-"animals" = "Zwierzęta";
-
-"hotels" = "Hotele";
-
-"buildings" = "Budynki";
-
-"money" = "Pieniądze";
-
-"shops" = "Sklepy";
-
-"parkings" = "Parkingi";
-
-"fuel_places" = "Stacje paliw";
-
-"water" = "Woda";
-
-"medicine" = "Lecznictwo";
-
 "search_in_the_list" = "Wyszukaj na liście";
-
-"view_on_map_bookmarks" = "Na mapie";
-
-"more_bookmarks" = "Więcej…";
-
-"no_items_found" = "Brak wyników";
-
-/* Android, max 18 symbols */
-"bookmarks_edit_list" = "Redaguj";
-
-/* Android, max 18 symbols */
-"bookmarks_delete_list" = "Usuń listę";
-
-"religious_places" = "Święte miejsca";
 
 "select_list" = "Wybierz listę";
 
@@ -2118,26 +1224,13 @@
 
 "dialog_pedestrian_route_is_long_message" = "Wybierz punkt początkowy lub końcowy trasy najbliżej do stacji metra";
 
-/* Failed planning SUBWAY route message in navigation view */
-"routing_planning_error_subway_special" = "Błąd tworzenia trasy metra";
-
 "button_layer_isolines" = "Wysokości";
-
-"tips_map_layers_title_countour" = "Linie wysokości w trybie offline w Organic Maps!";
-
-"tips_map_layers_message_countour" = "Linie wysokości pomogą zaplanować podróż i nie zgubić się w terenie";
 
 "isolines_activation_error_dialog" = "Do skorzystania z linii wysokości, zaktualizuj lub pobierz mapę obszaru, który potrzebujesz";
 
 "isolines_location_error_dialog" = "W tej chwili nie są dostępne linie wysokości w tym regionie";
 
 "elevation_profile_diff_level" = "Poziom trudności";
-
-"elevation_profile_diff_level_easy" = "Łatwy";
-
-"elevation_profile_diff_level_moderate" = "Umiarkowany";
-
-"elevation_profile_diff_level_hard" = "Skomplikowany";
 
 "elevation_profile_ascent" = "Wejście";
 
@@ -2147,25 +1240,13 @@
 
 "elevation_profile_maxaltitude" = "Maks. wysokość";
 
-"elevation_profile_m" = "m";
-
 "elevation_profile_difficulty" = "Trudność";
 
 "elevation_profile_distance" = "Odległ.:";
 
-"elevation_profile_km" = "km";
-
 "elevation_profile_time" = "Trasa:";
 
-"elevation_profile_hours" = "godz.";
-
-"elevation_profile_minutes" = "min";
-
 "isolines_toast_zooms_1_10" = "Powiększ mapę, aby zobaczyć izolinie";
-
-"downloader_updating_ios" = "Aktualizacja";
-
-"downloader_loading_ios" = "Pobieranie";
 
 "key_information_title" = "Kluczowe informacje";
 

--- a/iphone/Maps/LocalizedStrings/pl.lproj/Localizable.stringsdict
+++ b/iphone/Maps/LocalizedStrings/pl.lproj/Localizable.stringsdict
@@ -9,21 +9,6 @@
 
 <!-- ********** Strings for downloading map from search **********/ -->
 
-  <key>bookmarks_places</key>
-  <dict>
-    <key>NSStringLocalizedFormatKey</key>
-    <string>%#@value@</string>
-    <key>value</key>
-    <dict>
-      <key>NSStringFormatSpecTypeKey</key>
-      <string>NSStringPluralRuleType</string>
-      <key>NSStringFormatValueTypeKey</key>
-      <string>d</string>
-      <key>other</key>
-      <string>Zakładki: %d</string>
-    </dict>
-  </dict>
-
   <key>bookmarks_detect_message</key>
   <dict>
     <key>NSStringLocalizedFormatKey</key>
@@ -36,25 +21,10 @@
       <string>d</string>
       <key>one</key>
       <string>Znaleziono %d plik. Zobaczysz to po konwersji.</string>
-      <key>two</key>
-      <string>Znaleziono %d pliki. Zobaczysz je po konwersji.</string>
       <key>other</key>
       <string>Znaleziono %d plików. Zobaczysz je po konwersji.</string>
-    </dict>
-  </dict>
-
-  <key>bookmarks_objects</key>
-  <dict>
-    <key>NSStringLocalizedFormatKey</key>
-    <string>%#@value@</string>
-    <key>value</key>
-    <dict>
-      <key>NSStringFormatSpecTypeKey</key>
-      <string>NSStringPluralRuleType</string>
-      <key>NSStringFormatValueTypeKey</key>
-      <string>d</string>
-      <key>other</key>
-      <string>%s obiekt</string>
+      <key>two</key>
+      <string>Znaleziono %d pliki. Zobaczysz je po konwersji.</string>
     </dict>
   </dict>
 

--- a/iphone/Maps/LocalizedStrings/pt.lproj/Localizable.strings
+++ b/iphone/Maps/LocalizedStrings/pt.lproj/Localizable.strings
@@ -18,9 +18,6 @@
 /* Button which deletes downloaded country */
 "delete" = "Eliminar";
 
-/* Button "do not interrupt download" if user touched actively downloading country */
-"do_nothing" = "Continuar";
-
 "download_maps" = "Descarregar mapas";
 
 /* Settings/Downloader - info for country when download fails */
@@ -28,9 +25,6 @@
 
 /* Settings/Downloader - info for country which started downloading */
 "downloading" = "A descarregar…";
-
-/* Settings/Downloader - size string, only strings different from English should be translated */
-"kb" = "kB";
 
 /* Choose measurement on first launch alert - choose metric system button */
 "kilometres" = "Quilómetros";
@@ -55,17 +49,11 @@
 /* Update maps later/Buy pro version later button text */
 "later" = "Mais tarde";
 
-/* Don't show some dialog any more */
-"never" = "Nunca";
-
 /* View and button titles for accessibility */
 "search" = "Procura";
 
 /* Search box placeholder text */
 "search_map" = "Procurar mapa";
-
-/* Settings/Downloader - info for not downloaded country */
-"touch_to_download" = "Toque para descarregar";
 
 /* Settings/Downloader - 3G download warning dialog confirm button */
 "use_cellular_data" = "Sim";
@@ -73,20 +61,11 @@
 /* Location services are disabled by user alert - message */
 "location_is_disabled_long_text" = "Atualmente tem todos os Serviços de Localização para este dispositivo ou aplicação desativados. Por favor ative-os nas Definições.";
 
-/* Location Services are not available on the device alert - message */
-"device_doesnot_support_location_services" = "Os Serviços de Localização não estão disponíveis em seu dispositivo";
-
 /* View and button titles for accessibility */
 "zoom_to_country" = "Mostrar no mapa";
 
-/* Button text for the button at the center of the screen when the country is not downloaded */
-"country_status_download" = "Descarregar Mapa\n(^ ^)";
-
 /* Button text for the button at the center of the screen when the country is not downloaded and the size should not be shown */
 "country_status_download_without_size" = "Descarregar Mapa";
-
-/* Button text for the button at the center of the screen when the country is not downloaded */
-"country_status_download_without_routing" = "Baixar mapa\nsem roteamento (^ ^)";
 
 /* Message to display at the center of the screen when the country download has failed */
 "country_status_download_failed" = "A descarga falhou";
@@ -96,19 +75,13 @@
 
 "about_menu_title" = "Sobre o Organic Maps";
 
-"downloaded_touch_to_delete" = "(%@) descarregados, toque para eliminar";
-
 "connection_settings" = "Definições de Ligação";
-
-"download_mb_or_kb" = "Descarga %@";
 
 "close" = "Fechar";
 
 "unsupported_phone" = "É necessário OpenGL acelerado por hardware. Infelizmente o seu dispositivo não é compatível.";
 
 "download" = "Descarga";
-
-"external_storage_is_not_available" = "Não está disponível um cartão SD/armazenamento USB com os mapas descarregados";
 
 "disconnect_usb_cable" = "Por favor desligue o cabo USB ou introduza um cartão de memória para utilizar Organic Maps";
 
@@ -117,8 +90,6 @@
 "not_enough_memory" = "Não há memória suficiente para executar a app";
 
 "download_resources" = "Antes de começar, permita-nos que descarreguemos um mapa mundial geral para o seu dispositivo.\nÉ necessário %@ de dados.";
-
-"getting_position" = "A obter a posição atual";
 
 "download_resources_continue" = "Ir para o mapa";
 
@@ -140,23 +111,14 @@
 /* Add New Bookmark Set dialog title */
 "add_new_set" = "Adicionar novo conjunto";
 
-/* Place Page - Add To Bookmarks button */
-"add_to_bookmarks" = "Adicionar aos Favoritos";
-
 /* Bookmark Color dialog title */
 "bookmark_color" = "Cor de favoritos";
 
 /* Add Bookmark Set dialog - hint when set name is empty */
 "bookmark_set_name" = "Nome do conjunto dos favoritos";
 
-/* Bookmark Sets dialog title */
-"bookmark_sets" = "Conjuntos de favoritos";
-
 /* Bookmarks - dialog title */
 "bookmarks" = "Favoritos";
-
-/* Add bookmark dialog - bookmark color */
-"color" = "Cor";
 
 /* Default bookmarks set name */
 "core_my_places" = "Os meus locais";
@@ -167,14 +129,8 @@
 /* Editor title above street and house number */
 "address" = "Endereço";
 
-/* Place Page - Remove Pin button */
-"remove_pin" = "Retirar o marcador";
-
 /* Add bookmark dialog - bookmark set, Bookmarks dialog - Bookmark set cell */
 "set" = "Conjunto";
-
-/* Text hint in Bookmarks dialog when no any bookmarks are added */
-"bookmarks_usage_hint" = "Ainda não tem marcadores.\nToque em qualquer lugar no mapa para adicionar um marcador.\nOs marcadores de outras fontes também podem ser importados e exibidos na aplicação Organic Maps. Abrir ficheiro KML/KMZ com pinos guardados a partir do mail, Dropbox ou ligação web.";
 
 /* Settings button in system menu */
 "settings" = "Configurações";
@@ -191,26 +147,11 @@
 /* Ask to wait user several minutes (some long process in modal dialog). */
 "wait_several_minutes" = "Isto pode demorar alguns minutos.\nPor favor aguarde…";
 
-/* Show bookmarks from this category on a map or not */
-"visible" = "Visível";
-
-/* Toast which is displayed when GPS has been deactivated */
-"gps_is_disabled_long_text" = "O GPS está desativado. Por favor ative-o nas Definições.";
-
 /* Measurement units title in settings activity */
 "measurement_units" = "Unidades de medida";
 
 /* Detailed description of Measurement Units settings button */
 "measurement_units_summary" = "Escolha entre milhas e quilómetros";
-
-/* Do search in all sources */
-"search_mode_all" = "Em toda a parte";
-
-/* Do search near my position only */
-"search_mode_nearme" = "Perto de mim";
-
-/* Do search in current viewport only */
-"search_mode_viewport" = "No ecrã";
 
 /* Search category for cafes, bars, restaurants */
 "eat" = "Onde lanchar";
@@ -266,14 +207,8 @@
 /* Search category */
 "police" = "Polícia";
 
-/* String in search result list, when nothing found */
-"no_search_results_found" = "Não foram encontrados resultados";
-
 /* Notes field in Bookmarks view */
 "description" = "Notas";
-
-/* Button text */
-"share_by_email" = "Partilhar por email";
 
 /* Email Subject when sharing bookmarks category */
 "share_bookmarks_email_subject" = "Os favoritos do Organic Maps foram partilhados consigo";
@@ -295,26 +230,11 @@
 /* Warning message when doing search around current position */
 "unknown_current_position" = "A sua localização ainda não foi determinada";
 
-/* Warning message when location country isn't downloaded during search (see also download_location_map_proposal). */
-"download_location_country" = "Descarregue o país da sua localização atual (%@)";
-
-/* Warning message when viewport country isn't downloaded during search */
-"download_viewport_country_to_search" = "Descarregue o país em que está a fazer a procura (%@)";
-
 /* Alert message that we can't run Map Storage settings due to some reasons. */
 "cant_change_this_setting" = "Lamentamos, as definições do Map Storage estão atualmente desativadas.";
 
 /* Alert message that downloading is in progress. */
 "downloading_is_active" = "A descarga do país está atualmente em progresso.";
-
-/* Message that will be shown in alert view, when we ask user to leave review on App Store */
-"appStore_message" = "Esperamos que esteja a disfrutar da utilização do Organic Maps! Se assim for, por favor classifique ou dê a sua opinião sobre a app na App Store. Vai demorar menos de um minuto mas pode mesmo ajudar-nos. Obrigado pelo seu apoio!";
-
-/* No, thanks */
-"no_thanks" = "Não, obrigado";
-
-/* Share one specific bookmark using SMS, %1$@ contains om:// and %2$@ https://omaps.app link. @NOTE non-ascii symbols in the link will result in max 70 characters SMS instead of 140. */
-"bookmark_share_sms" = "Veja o meu marcador no mapa do Organic Maps. Abra a hiperligação: %1$@ ou %2$@";
 
 /* Share my position using SMS, %1$@ contains om:// and %2$@ https://omaps.app link WITHOUT NAME. @NOTE non-ascii symbols in the link will result in max 70 characters SMS instead of 140. */
 "my_position_share_sms" = "Veja onde estou agora. Abra a hiperligação: %1$@ ou %2$@";
@@ -328,23 +248,11 @@
 /* Share my position using EMail, %1$@ is om:// and %2$@ is https://omaps.app link WITHOUT NAME */
 "my_position_share_email" = "Olá,\n\nEstou aqui agora: %1$@. Clique nesta ligação %2$@ ou nesta %3$@ para ver o local no mapa.\n\nObrigado.";
 
-/* Android share by Message/SMS button text (including SMS) */
-"share_by_message" = "Partilhar por mensagem";
-
 /* Share button text which opens menu with more buttons, like Message, EMail, Facebook etc. */
 "share" = "Partilhar";
 
-/* iOS share by Message button text (including SMS) */
-"message" = "Mensagem";
-
 /* Share by email button text, also used in editor. */
 "email" = "Email";
-
-/* Copy Link */
-"copy_link" = "Copiar hiperligação";
-
-/* Text for the button that returns to caller application */
-"more_info" = "Mostrar informação adicional";
 
 /* Text for message when used successfully copied something */
 "copied_to_clipboard" = "Copiado para a Área de Transferência: %1$@";
@@ -354,15 +262,6 @@
 
 /* Used for bookmark editing */
 "done" = "Feito";
-
-/* Summary for preferences in MWM */
-"yopme_pref_summary" = "Escolha as definições de Ecrã Posterior";
-
-/* Title for yopme preferences in MWM */
-"yopme_pref_title" = "Configurações do Ecrã Posterior";
-
-/* Hint for upper-right icon p2b */
-"show_on_backscreen" = "Mostrar no Ecrã Posterior";
 
 /* Prints version number in About dialog */
 "version" = "Versão: %@";
@@ -381,19 +280,11 @@
 
 "share_my_location" = "Partilhar a minha localização";
 
-"menu_search" = "Pesquisar";
-
 /* Settings general group in settings screen */
 "prefs_group_general" = "General settings";
 
 /* Settings information group in settings screen */
 "prefs_group_information" = "Information";
-
-/* Settings screen: "Map" category title */
-"prefs_group_map" = "Mapa";
-
-/* Settings screen: "Miscellaneous" category title */
-"prefs_group_misc" = "Diversos";
 
 "prefs_group_route" = "Navegação";
 
@@ -419,9 +310,6 @@
 /* Settings «Map» category: «3D buildings» title */
 "pref_map_3d_buildings_title" = "Prédios em 3D";
 
-/* Settings «Map» category: «3D buildings» summary */
-"pref_map_3d_buildings_subtitle" = "Afeta a vida da bateria";
-
 /* Settings «Route» category: «Tts enabled» title */
 "pref_tts_enable_title" = "Instruções de voz";
 
@@ -433,8 +321,6 @@
 
 /* Title for "Other" section in TTS settings. */
 "pref_tts_other_section_title" = "Outro";
-
-"pref_tts_how_to_set_up_voice" = "Como configurar a voz";
 
 /* Settings «Map» category: «Record track» title */
 "pref_track_record_title" = "Trajeto recente";
@@ -455,56 +341,7 @@
 
 "recent_track_help_text" = "Permite-lhe gravar um caminho percorrido durante um determinado período e vê-lo no papa. Nota: esta funcionalidade provoca uma maior utilização da bateria. A rota será automaticamente removida do mapa após o intervalo de tempo expirar.";
 
-"pref_track_ios_caption" = "O trajeto recente mostra o seu caminho percorrido.";
-
-"pref_track_ios_subcaption" = "Por favor, selecione o intervalo de tempo para gravação do percurso.";
-
-"placepage_distance" = "Distância";
-
-"placepage_coordinates" = "Coordenadas";
-
-"placepage_unsorted" = "Não classificado";
-
 "search_show_on_map" = "Ver no mapa";
-
-/* Used to warn user when fixing KitKat issue */
-"bookmark_move_fail" = "É necessário mover os seus marcadores para a memória interna, mas não há espaço disponível para eles. Por favor, liberte a memória, caso contrário, os marcadores não estarão disponíveis.";
-
-/* Used in More Apps menu */
-"free" = "Grátis";
-
-/* Used in More Apps menu */
-"buy" = "Comprar";
-
-/* 1st search button-like result */
-"search_on_map" = "Pesquisar no mapa";
-
-/* toast with an error */
-"no_route_found" = "Não foi encontrado nenhum trajecto";
-
-/* route title */
-"route" = "Trajeto";
-
-/* category title */
-"routes" = "Trajetos";
-
-/* text of notification */
-"download_map_notification" = "Descarregue o mapa do local onde estiver";
-
-/* text of notification */
-"pro_version_is_free_today" = "A versão completa do Organic Maps é hoje grátis! Descarregue e conte aos seus amigos.";
-
-/* Dialog for transferring maps from lite to pro. */
-"move_lite_maps_to_pro" = "Estamos a transferir os seus mapas descarregados da Organic Maps Lite para a Organic Maps. Isto pode demorar alguns minutos.";
-
-/* Message to display when maps moved. */
-"move_lite_maps_to_pro_ok" = "Os seus mapas descarregados estão transferidos com sucesso para a Organic Maps.";
-
-/* Message to display when maps move failed. */
-"move_lite_maps_to_pro_failed" = "Falhou a transferência dos seus mapas. Por favor, elimine a Organic Maps Lite e descarregue os mapas novamente.";
-
-/* Text in menu */
-"settings_and_more" = "Definições e Mais";
 
 /* Text in menu */
 "website" = "Site";
@@ -527,14 +364,8 @@
 /* Text in menu */
 "openstreetmap" = "OpenStreetMap";
 
-/* Text in menu */
-"contact_us" = "Contacte-nos";
-
 /* Settings: Send feedback button and dialog title */
 "feedback" = "Comentários";
-
-/* Text in menu */
-"subscribe_to_news" = "Subscreva as nossas notícias";
 
 /* Text in menu */
 "rate_the_app" = "Classificar o aplicativo";
@@ -548,15 +379,6 @@
 /* Text in menu */
 "report_a_bug" = "Relatar um problema";
 
-/* Email subject */
-"subscribe_me_subject" = "Por favor inscrevam-me na newsletter da Organic Maps";
-
-/* Email body */
-"subscribe_me_body" = "Quero ser o(a) primeiro(a) a saber sobre as últimas notícias, actualizações e promoções. Posso cancelar a minha subscrição a qualquer altura.";
-
-/* About text */
-"about_text" = "A Organic Maps oferece os mapas offline mais rápidos de todas as cidades, de todos os países do mundo. Viaje com plena confiança: onde estiver, a Organic Maps ajuda a localizar-se no mapa, a encontrar o restaurante, hotel, banco, posto de gasolina, etc. mais próximos. Não requer ligação à Internet.\n\nEstamos sempre a trabalhar em novas funcionalidades e gostaríamos de saber a sua opinião sobre como poderíamos melhorar a Organic Maps. Se tiver algum problema com a app, não hesite em contactar-nos em support@organicmaps.app. Respondemos a cada pedido!\n\nGosta da Organic Maps e quer apoiar-nos? Há algumas maneiras simples e absolutamente gratuitas:\n\n- publique um comentário no seu App Market\n- faça \"gosto\" na nossa página do Facebook http://www.facebook.com/OrganicMaps\n- ou fale da Organic Maps à sua mãe, amigos e colegas :)\n\nObrigado por estar connosco. Agradecemos imenso o seu apoio!\n\nP. S. Tiramos os dados do OpenStreetMap, um projeto de mapeamento semelhante à Wikipedia, que permite aos utilizadores criarem e editarem mapas. Se vir que algo está em falta ou errado no mapa, pode corrigir diretamente os mapas em https://www.openstreetmap.org e as suas alterações irão aparecer na app Organic Maps com o lançamento da próxima versão.";
-
 /* Alert text */
 "email_error_body" = "O cliente de email não está configurado. Por favor, configure-o ou utilize qualquer outro modo para nos contactar através de %@";
 
@@ -569,12 +391,6 @@
 /* Search category */
 "wifi" = "WiFi";
 
-/* Update map suggestion */
-"routing_map_outdated" = "Por favor, atualize o mapa para criar uma rota.";
-
-/* Update maps suggestion */
-"routing_update_maps" = "A nova versão do Organic Maps permite criar rotas a partir da sua posição atual até um ponto de destino. Por favor, atualize o maps para utilizar esta funcionalidade.";
-
 /* Update all button text */
 "downloader_update_all_button" = "Atualizar tudo";
 
@@ -583,9 +399,6 @@
 
 /* Downloaded maps category */
 "downloader_downloaded_subtitle" = "Descarregado";
-
-/* Downloaded maps category */
-"downloader_available_maps" = "Disponível";
 
 /* Country queued for download */
 "downloader_queued" = "Na fila";
@@ -598,17 +411,6 @@
 
 "downloader_downloading" = "Descarregando:";
 
-"downloader_search_results" = "Encontrado";
-
-/* Disclaimer message */
-"routing_disclaimer" = "Ao criar rotas no app Organic Maps, por favor, lembre-se do seguinte:\n\n  - As rotas sugeridas podem apenas ser consideradas como recomendações.\n - As condições da estrada, regras de trânsito e sinais têm maior prioridade do que os conselhos de navegação.\n - O mapa poderá estar errado, ou desatualizado, e as rotas poderão não ser criadas da melhor forma possível.\n\n  Circule em segurança nas estradas e cuide do seu bem estar!";
-
-/* Outdated maps category */
-"downloader_outdated_maps" = "Desatualizado";
-
-/* Up to date maps category */
-"downloader_uptodate_maps" = "Atualizado";
-
 /* Status of outdated country in the list */
 "downloader_status_outdated" = "Atualizar";
 
@@ -618,49 +420,14 @@
 /* Displayed in a dialog that appears when a user tries to delete a map while the app is in the follow route mode */
 "downloader_delete_map_while_routing_dialog" = "Favor parar a navegação para apagar o mapa.";
 
-/* Show when user try build route, but we don't know where he */
-"routing_failed_unknown_my_position" = "A localização atual não foi definida. Por favor especifique a localização para criar o trajeto.";
-
-/* Show if use has not routing file, or InconsistentMWMandRoute */
-"routing_failed_has_no_routing_file" = "São necessários dados adicionais para criar uma rota. Descarregar os dados agora?";
-
-/* StartPointNotFound */
-"routing_failed_start_point_not_found" = "Impossível calcular o trajeto. Não há estradas próximas ao seu ponto de partida.";
-
-/* EndPointNotFound */
-"routing_failed_dst_point_not_found" = "Impossível calcular o trajeto. Não há estradas próximas ao seu destino.";
-
 /* PointsInDifferentMWM */
 "routing_failed_cross_mwm_building" = "Só podem ser criados trajetos que estejam completamente contidos num único mapa.";
-
-/* RouteNotFound */
-"routing_failed_route_not_found" = "Não foi encontrado um trajeto entre a origem e o destino selecionados. Por favor selecione um ponto de partida ou de chegada diferente.";
-
-/* InternalError */
-"routing_failed_internal_error" = "Ocorreu um erro interno. Por favor experimente apagar o mapa e depois descarregue-o novamente. Se o problema persistir, contacte-nos através de support@organicmaps.app.";
-
-/* Context menu item for downloader. */
-"downloader_download_map_and_routing" = "Descarregar Mapa + Roteamento";
-
-/* Context menu item for downloader. */
-"downloader_download_routing" = "Descarregar Roteamento";
-
-/* Context menu item for downloader. */
-"downloader_delete_routing" = "Apagar Roteamento";
 
 /* Context menu item for downloader. */
 "downloader_download_map" = "Baixar o mapa";
 
-"downloader_download_map_no_routing" = "Baixar mapa sem roteamento";
-
-/* Button for routing. */
-"routing_go" = "Avançar!";
-
 /* Item status in downloader. */
 "downloader_retry" = "Repetir";
-
-/* Item in context menu. */
-"downloader_map_and_routing" = "Mapa + Criação de Trajeto";
 
 /* Item in context menu. */
 "downloader_delete_map" = "Apagar Mapa";
@@ -668,29 +435,11 @@
 /* Item in context menu. */
 "downloader_update_map" = "Atualizar Mapa";
 
-/* Item in context menu. */
-"downloader_update_map_and_routing" = "Atualizar Mapa + Criação de Trajeto";
-
-/* Item in context menu. */
-"downloader_map_only" = "Apenas Mapa";
-
-/* Toolbar title */
-"toolbar_application_menu" = "Menu de Aplicação";
-
 /* Preference text */
 "pref_use_google_play" = "Use o Google Play Serviços para determinar a sua localização actual";
 
 /* Text for rating dialog */
 "rating_just_rated" = "Acabei de avaliar o seu app";
-
-/* Text for rating dialog */
-"rating_user_since" = "Sou usuário do Organic Maps desde %@";
-
-/* Text for rating dialog */
-"rating_do_like_maps" = "Você gosta de Organic Maps?";
-
-/* Text for rating dialog */
-"rating_tap_star" = "Toque em alguma estrela para classificar o nosso app.";
 
 /* Text for rating dialog */
 "rating_thanks" = "Obrigado!";
@@ -701,23 +450,8 @@
 /* Text for rating dialog */
 "rating_send_feedback" = "Envie seu comentário";
 
-/* Text for g+ dialog */
-"rating_google_plus" = "Clique em g+ para contar aos seus amigos sobre o app.";
-
 /* Text for routing error dialog */
 "routing_download_maps_along" = "Descarregar todos os mapas ao longo do trajeto";
-
-/* Text for routing error dialog */
-"routing_download_map" = "Obter mapa";
-
-/* Text for routing error dialog */
-"routing_download_map_and_routing" = "Descarregue o mapa e os dados de itinerário atualizados para acessar todos os recursos do Organic Maps.";
-
-/* Text for routing error dialog */
-"routing_get_routing_data" = "Obter dados de itinerário";
-
-/* Text for routing error dialog */
-"routing_get_additional_data" = "São necessários dados adicionais para criar rotas a partir da sua localização.";
 
 /* Text for routing error dialog */
 "routing_requires_all_map" = "É necessário baixar e atualizar todos os mapas entre sua localização e o destino para criar uma rota.";
@@ -725,50 +459,15 @@
 /* Text for routing error dialog */
 "routing_not_enough_space" = "Espaço insuficiente";
 
-/* Text for routing error dialog */
-"routing_download_more_than_avail" = "É necessário descarregar %@ MB, mas há apenas %@ MB disponíveis.";
-
-/* Text for routing error dialog */
-"routing_download_roaming" = "Você fará o download de %@ MB através de Dados Móveis (em Roaming). Isto poderá resultar em cobranças adicionais, dependendo do seu plano de dados móveis.";
-
 /* bookmark button text */
 "bookmark" = "favorito";
-
-/* map is not downloaded */
-"not_found_map" = "O mapa para a sua localização não foi descarregado";
 
 /* location service disabled */
 "enable_location_services" = "Por favor active os Serviços de Localização";
 
-/* download map */
-"download_map" = "Descarregue o mapa para a sua localização";
-
-/* download map on iPhone */
-"download_map_iphone" = "Descarregue o mapa da localização atual para o seu iPhone";
-
-/* clear pin */
-"nearby" = "Próximo";
-
-/* clear pin */
-"clear_pin" = "Limpar marcação";
-
-/* location is undefined */
-"undefined_location" = "A localização actual não foi definida.";
-
-/* download country of your location */
-"download_country" = "Descarregue o país da sua localização actual";
-
-/* download failed */
-"download_failed" = "descarga falhou";
-
-/* get the map */
-"get_the_map" = "Obter mapa";
-
 "save" = "Salvar";
 
 "edit_description_hint" = "Suas descrições (texto ou html)";
-
-"new_group" = "novo grupo";
 
 "create" = "criar";
 
@@ -795,30 +494,6 @@
 
 /* pink color */
 "pink" = "Rosa";
-
-/* deep purple color */
-"deep_purple" = "Purpúreo escuro";
-
-/* light blue color */
-"light_blue" = "Azul Claro";
-
-/* cyan color */
-"cyan" = "Azul-verde";
-
-/* teal color */
-"teal" = "Esmeralda";
-
-/* lime color */
-"lime" = "Lima";
-
-/* deep orange color */
-"deep_orange" = "Laranja escuro";
-
-/* gray color */
-"gray" = "Cinza";
-
-/* blue gray color */
-"blue_gray" = "Azul-cinza";
 
 /* Wi-Fi available */
 "WiFi_available" = "Sim";
@@ -848,13 +523,9 @@
 
 "dialog_routing_location_unknown_turn_on" = "Não foi possível localizar as coordenadas do GPS. Ative os serviços de localização para que a rota seja traçada.";
 
-"dialog_routing_location_unknown" = "Não foi possível obter as coordenadas GPS.";
-
 "dialog_routing_download_files" = "Descarregar os arquivos necessários";
 
 "dialog_routing_download_and_update_all" = "Descarregue e actualize todos os dados de mapa e roteamento ao longo do trajeto desejado para que a rota seja traçada.";
-
-"dialog_routing_routes_size" = "Arquivos de dados de roteamento";
 
 "dialog_routing_unable_locate_route" = "Não foi possível encontrar uma rota";
 
@@ -884,21 +555,11 @@
 
 "dialog_routing_try_again" = "Tente novamente";
 
-"dialog_routing_send_error" = "Relatar o Problema";
-
-"dialog_routing_if_get_cross_route" = "Deseja traçar uma rota mais direta, mas que se estenda por mais de um mapa?";
-
-"dialog_routing_cross_route_is_optimal" = "Há uma rota disponível que vai além dos limites deste mapa.";
-
 "not_now" = "Agora Não";
-
-"dialog_routing_build_route" = "Traçar";
 
 "dialog_routing_download_and_build_cross_route" = "Deseja descarregar o mapa e traçar uma rota melhor, mas que se estenda por mais de um mapa?";
 
 "dialog_routing_download_cross_route" = "Descarregue o mapa para traçar uma rota melhor que vai além dos limites desse mapa.";
-
-"dialog_routing_cross_route_always" = "Sempre cruzar esse limite";
 
 
 /********** Strings for downloading map from search **********/
@@ -906,8 +567,6 @@
 "search_without_internet_advertisement" = "Para começar a pesquisar e criar rotas, por favor, descarregue o mapa. Assim, não precisará mais de uma conexão com a internet.";
 
 "search_select_map" = "Selecionar Mapa";
-
-"search_select_other_map" = "Selecionar Outro Mapa";
 
 /* «Show» context menu */
 "show" = "Mostrar";
@@ -918,17 +577,11 @@
 /* «Rename» context menu */
 "rename" = "Renomear";
 
-/* Bottom sheet: expand button (should be short) */
-"bottom_sheet_more" = "Mais…";
-
 /* Failed planning route message in navigation view */
 "routing_planning_error" = "Falhou o Planeamento da Rota";
 
 /* Arrive routing message in navigation view */
 "routing_arrive" = "Chegada: %s";
-
-/* Text for routing::RouterResultCode::FileTooOld dialog. */
-"dialog_routing_download_and_update_maps" = "Para criar uma rota, por favor, baixe e atualize todos os mapas ao longo do trajeto.";
 
 "rate_alert_title" = "Gosta do aplicativo?";
 
@@ -944,19 +597,11 @@
 
 "history" = "Histórico";
 
-"next_turn_then" = "Em seguida";
-
 "closed" = "Fechado";
-
-"back_to" = "Voltar para %@";
 
 "search_not_found" = "Lamento, mas não encontrei nada.";
 
 "search_not_found_query" = "Por favor, tente outro termo de busca.";
-
-"search_not_found_map" = "Por favor, descarregue o mapa em que está pesquisando.";
-
-"search_not_found_location" = "Descarregue o mapa da sua localização atual.";
 
 "search_history_title" = "Histórico de Busca";
 
@@ -964,23 +609,12 @@
 
 "clear_search" = "Limpar histórico de pesquisa";
 
-/* Title for settings to enable/disable showcase menu button */
-"showcase_settings_title" = "Mostrar ofertas";
-
 /* Place Page link to Wikipedia article (if map object has it). */
 "read_in_wikipedia" = "Wikipédia";
 
-"p2p_route_planning" = "Planejar rota";
-
 "p2p_your_location" = "Localização atual";
 
-"p2p_from" = "Ponto de partida";
-
-"p2p_to" = "Ponto de destino";
-
 "p2p_start" = "Iniciar";
-
-"p2p_planning" = "Planejando…";
 
 "p2p_from_here" = "De";
 
@@ -1018,15 +652,9 @@
 
 "editor_correct_mistake" = "Corrigir erro";
 
-"editor_correct_mistake_message" = "Fez um erro de edição. Corrija-o ou mude para o modo simples.";
-
 "editor_add_select_location" = "Local";
 
 "editor_done_dialog_1" = "Modificou o mapa-múndi. Não esconda isto! Diga aos seus amigos e editem-no juntos.";
-
-"editor_done_dialog_2" = "Esta é a sua segunda melhoria ao mapa. Agora, está no %dº lugar na lista de editores de mapas. Fale disto aos seus amigos.";
-
-"editor_done_dialog_3" = "Melhorou o mapa, fale disto aos seus amigos e editem o mapa juntos.";
 
 "share_with_friends" = "Compartilhar com amigos";
 
@@ -1044,20 +672,7 @@
 
 "editor_report_problem_duplicate_place_title" = "Lugar em duplicado";
 
-"first_launch_congrats_title" = "Organic Maps está pronto para utilização";
-
-"first_launch_congrats_text" = "Busque qualquer lugar do mundo e navegue offline, gratuitamente.";
-
-"migrate_title" = "Importante!";
-
-/* Android uses image instead of text. */
-"download_all" = "Descarregar tudo";
-
-"delete_all" = "Excluir todos";
-
 "autodownload" = "Download automático";
-
-"disable_autodownload" = "Desativar o download automático";
 
 /* Place Page opening hours text */
 "closed_now" = "Fechado agora";
@@ -1072,10 +687,6 @@
 "day_off" = "Dia de folga";
 
 "today" = "Hoje";
-
-"sunrise_to_sunset" = "Do amanhecer ao anoitecer";
-
-"sunset_to_sunrise" = "Do pôr do sol ao amanhecer";
 
 "add_opening_hours" = "Adicionar horário de funcionamento";
 
@@ -1095,45 +706,18 @@
 
 "forgot_password" = "Esqueceu sua senha?";
 
-/* Forgot Password dialog title */
-"restore_password" = "Recuperar senha";
-
-"enter_email_address_to_reset_password" = "Digite o endereço de email que você usou ao cadastrar-se, e nós lhe enviaremos o link para redefinir a sua senha.";
-
-"reset_password" = "Redefinir senha";
-
-"username" = "Nome de usuário";
-
 "osm_account" = "Conta OSM";
 
 "logout" = "Encerrar sessão";
 
-"login_and_edit_map_motivation_message" = "Acesse e edite informações dos objetos no mapa e eles serão disponibilizados para milhões de outros usuários. Vamos melhorar o mundo juntos.";
-
 /* Information text: "Last upload 11.01.2016" */
 "last_upload" = "Último upload";
 
-/* Motivates user to login/register, title above login buttons. */
-"you_have_edited_your_first_object" = "Você editou o seu primeiro objeto!";
-
 "thank_you" = "Obrigado";
-
-"login_with_google" = "Entrar com Google";
-
-"login_with_openstreetmap" = "Entrar com www.openstreetmap.org";
 
 "edit_place" = "Editar o local";
 
 "place_name" = "Nome do local";
-
-/* title above languages list cells in the editor, below editable name text field. */
-"other_languages" = "Outros idiomas";
-
-/* small button to open list with names in different languages */
-"show_more" = "Mostrar mais";
-
-/* small button to close list with names in different languages */
-"show_less" = "Mostrar menos";
 
 "add_language" = "Adicionar um idioma";
 
@@ -1164,8 +748,6 @@
 
 "please_note" = "Aviso";
 
-"common_no_wifi_dialog" = "Nenhuma ligação Wi-Fi. Deseja continuar com os dados móveis?";
-
 "downloader_delete_map_dialog" = "Todas as alterações ao mapa serão eliminadas juntamente com o mapa.";
 
 "downloader_update_maps" = "Atualizar mapas";
@@ -1173,10 +755,6 @@
 "downloader_mwm_migration_dialog" = "Para criar um itinerário é necessário actualizar todos os mapas e, em seguida, planejá-lo novamente.";
 
 "downloader_search_field_hint" = "Encontrar o mapa";
-
-"migration_update_all_button" = "Atualizar todos os mapas";
-
-"migration_delete_all_download_current_button" = "Descarregue o mapa atual e elimine os antigos";
 
 "migration_download_error_dialog" = "Erro de download";
 
@@ -1186,21 +764,9 @@
 
 "downloader_no_space_message" = "Por favor, remova os dados desnecessários";
 
-"editor_general_auth_error_dialog" = "Erro genérico de início de sessão.";
-
 "editor_login_error_dialog" = "Erro de início de sessão.";
 
-"editor_login_failed_dialog" = "O início de sessão falhou";
-
-"editor_username_error_dialog" = "O nome de utilizador é inválido";
-
-"editor_place_edited_dialog" = "Editou um objeto!";
-
-"editor_login_with_osm" = "Iniciar sessão com a OpenStreetMap";
-
 "editor_profile_changes" = "Alterações verificadas";
-
-"editor_profile_unsent_changes" = "Não enviado:";
 
 "editor_focus_map_on_location" = "Mova o mapa para selecionar o lugar correto do objeto.";
 
@@ -1222,13 +788,9 @@
 
 "editor_report_problem_other_title" = "Um problema diferente";
 
-"placepage_report_problem_button" = "Comunicar um problema";
-
 "placepage_add_business_button" = "Adicionar uma organização";
 
 "whatsnew_editor_message_1" = "Adicione novos lugares ao mapa e edite os já existentes diretamente a partir do app.";
-
-"whatsnew_editor_message_2" = "* A Organic Maps utiliza dados da comunidade OpenStreetMap.";
 
 "dialog_incorrect_feature_position" = "Mudar local";
 
@@ -1236,16 +798,10 @@
 
 "login_to_make_edits_visible" = "Inicie sessão para que outros usuários vejam as mudanças que você fez.";
 
-"no_migration_during_navigation" = "Actualização não é permitida durante a navegação.";
-
 /* Error dialog no space */
 "migration_no_space_message" = "Para descarregar, é necessário mais espaço. Por favor, elimine os dados desnecessários.";
 
 "editor_sharing_title" = "Melhorei os mapas do Organic Maps";
-
-"editor_comment_will_be_sent" = "Encaminharemos o seu comentário aos cartógrafos.";
-
-"editor_unsupported_category_message" = "Você adicionou um local de uma categoria para a qual ainda não temos suporte. Ele aparecerá no mapa no futuro.";
 
 /* Downloaded 10 **of** 20 <- it is that "of" */
 "downloader_of" = "%1$d de %2$d";
@@ -1278,23 +834,9 @@
 
 "editor_operator" = "Operador";
 
-"editor_tag_description" = "Introduza a empresa, organização ou indivíduo responsável pelas instalações.";
-
-"editor_no_local_edits_title" = "Não tem edições locais";
-
-"editor_no_local_edits_description" = "Isto demonstra o número das suas alterações sugeridas no mapa que atualmente só são acessíveis no seu dispositivo.";
-
-"editor_send_to_osm" = "Enviar para OSM";
-
-"editor_remove" = "Remover";
-
-"downloader_my_maps_title" = "Os meus mapas";
-
 "downloader_no_downloaded_maps_title" = "Não descarregou quaisquer mapas";
 
 "downloader_no_downloaded_maps_message" = "Descarregar mapas para encontrar a localização e navegar offline.";
-
-"downloader_find_place_hint" = "Pesquisar cidade ou país";
 
 /* Error title that appears after certain time without location. */
 "current_location_unknown_title" = "Continuar a detetar a sua localização atual?";
@@ -1321,47 +863,13 @@
 /* iOS Dialog for the case when the location permission is not granted */
 "location_services_disabled_3" = "3. Selecione Durante Uso do Aplicativo";
 
-"placepage_parking_surface" = "Superfície";
-
-"placepage_parking_multistorey" = "Vários andares";
-
-"placepage_parking_underground" = "Local desconhecido";
-
-"placepage_parking_rooftop" = "Terraço";
-
-"placepage_parking_sheds" = "Abrigos";
-
-"placepage_parking_carports" = "Garagens";
-
-"placepage_parking_boxes" = "Garagens";
-
-"placepage_parking_pay" = "Pagamento";
-
-"placepage_parking_free" = "Gratuito";
-
-"placepage_parking_interval" = "Pagamento intervalado";
-
-"placepage_entrance_number" = "N.º";
-
-"placepage_entrance_type" = "Entrada";
-
-"placepage_flat" = "apto.";
-
-"placepage_open_24_7" = "24 / 7";
-
 "meter" = "m";
 
 "kilometer" = "Km";
 
-"kilometers_per_hour" = "km/h";
-
 "mile" = "M";
 
 "foot" = "ft";
-
-"miles_per_hour" = "mph";
-
-"day" = "d";
 
 "hour" = "h";
 
@@ -1381,10 +889,6 @@
 
 "placepage_bookmark_name_hint" = "Nome do marcador";
 
-"placepage_personal_notes_hint" = "Notas pessoais";
-
-"placepage_delete_bookmark_button" = "Eliminar marcador";
-
 "editor_edits_sent_message" = "As suas alterações sugeridas foram enviadas";
 
 "editor_comment_hint" = "Comentário…";
@@ -1397,8 +901,6 @@
 
 "editor_remove_place_button" = "Remover";
 
-"editor_status_sending" = "A enviar…";
-
 "editor_place_doesnt_exist" = "O local não existe";
 
 "text_more_button" = "…mais";
@@ -1410,11 +912,7 @@
 
 "error_enter_correct_email" = "Preencha com um endereço válido de email";
 
-"error_enter_correct" = "Preencha com um valor válido";
-
 "refresh" = "Atualizar";
-
-"last_update" = "Última atualização: %s";
 
 "placepage_add_place_button" = "Adicionar um local ao mapa";
 
@@ -1426,24 +924,6 @@
 
 "editor_share_to_all_dialog_message_2" = "Verificaremos as alterações. Se tivermos perguntas, entraremos em contato com você por email.";
 
-"navigation_overview_button" = "visão geral";
-
-"navigation_stop_button" = "parar";
-
-/* Text on an empty bookmark page */
-"bookmarks_empty_title" = "Salvar Favoritos";
-
-"bookmarks_empty_message_1" = "Toque em ★ para salvar locais favoritos para rápido acesso.";
-
-"bookmarks_empty_message_2" = "Importe favoritos do Mail e da web.";
-
-"bookmarks_empty_message_3" = "check out: %s";
-
-/* Name of the group for booked hotels */
-"bookmarks_group_name" = "Hotéis reservados";
-
-"place_page_button_read_descriprion" = "Leia";
-
 /* iOS dialog for the case when recent track recording is on and the app comes back from background */
 "recent_track_background_dialog_title" = "Desabilitar registro de sua rota recente?";
 
@@ -1451,8 +931,6 @@
 
 /* For sharing via SMS and so on */
 "sharing_call_action_look" = "Procure";
-
-"continue_recent_track_background_button" = "Continuar";
 
 "recent_track_background_dialog_message" = "O Organic Maps usa sua localização geográfica em segundo plano para registrar sua rota recente.";
 
@@ -1468,33 +946,13 @@
 /* About short text (below logo) */
 "about_description" = "O Organic Maps é uma aplicação offline essencial para viajar. O Organic Maps baseia-se nos dados do OpenStreetMap e permite editá-los.";
 
-/* Text in menu */
-"blog" = "Blogue";
-
 "general_settings" = "Configurações gerais";
-
-"date" = "Data %d";
-
-/* "Report a bug" -> "Generaal Feedback" -> "Something is not working" */
-"something_is_not_working" = "Algo não está a funcionar";
 
 /* For the first routing */
 "accept" = "Aceitar";
 
-"accept_and_continue" = "Accept and continue";
-
 /* For the first routing */
 "decline" = "Declinar";
-
-"install_app" = "Instalar";
-
-"search_no_results_title" = "Nenhum resultado encontrado";
-
-"search_no_results_message" = "Tente um termo de pesquisa mais geral, diminuir o zoom ou redefinir o filtro.";
-
-"search_no_results_expand_area_button" = "Diminuir o zoom";
-
-"search_no_results_reset_button" = "Redefinir o filtro";
 
 /* noun */
 "search_in_table" = "Lista";
@@ -1517,8 +975,6 @@
 
 "traffic_update_maps_text" = "Para ver os dados de tráfego, os mapas devem ser atualizados.";
 
-"traffic_outdated" = "Os dados sobre o tráfego estão desatualizados.";
-
 "big_font" = "Aumentar tamanho da fonte no mapa";
 
 "traffic_update_app" = "Atualize o MAPS. ME";
@@ -1529,17 +985,7 @@
 /* "traffic" as in "road congestion" */
 "traffic_data_unavailable" = "Não existem dados de tráfego";
 
-/* "Translation is no needed, because it's a company name" */
-"uber" = "Uber";
-
-/* Simplified colour scheme for traffic information, fewer colours are used to display traffic jams on the map. The string should be kept as short as possible */
-"pref_traffic_simplified_colors_title" = "Cores de trânsito simplificadas";
-
 "enable_logging" = "Ativar o histórico";
-
-"offline_place_page_more_information" = "Efetue ligação à internet para obter mais informações sobre o local.";
-
-"failed_load_information" = "Falha ao carregar informações.";
 
 /* Settings: "Send general feedback" button */
 "feedback_general" = "Opinão geral";
@@ -1556,8 +1002,6 @@
 
 "whatsnew_transliteration_title" = "Transliteração para o latim";
 
-"yandex_taxi_title" = "Yandex.Taxi";
-
 "learn_more" = "Saber mais";
 
 "core_exit" = "Sair";
@@ -1568,75 +1012,19 @@
 
 "button_exit" = "Sair";
 
-"settings_device_memory" = "Memória do dispositivo";
-
-"settings_card_memory" = "Memória do cartão";
-
-"settings_storage_available" = "%s disponível";
-
-"toast_location_permission_denied" = "Permissão de localização da aplicação não autorizada";
-
-"button_use" = "Utilizar";
-
 "planning_route_manage_route" = "Gerir rota";
 
 "button_plan" = "Planear";
-
-"button_add" = "Adicionar";
 
 "placepage_remove_stop" = "Remover";
 
 "planning_route_remove_title" = "Arraste aqui para remover";
 
-"dialog_change_start_point_message" = "Substituir ponto de partida pela localização atual?";
-
-"button_replace" = "Substituir";
-
 "placepage_add_stop" = "Adicionar paragem";
-
-/* Only ru/en are needed */
-"subtitle_rent" = "Rent";
-
-/* Only ru/en are needed */
-"rub_month" = "RUB/month";
-
-/* Only ru/en are needed */
-"room" = "%s-room apt.";
-
-/* Only ru/en are needed */
-"real_estate" = "Real estate";
-
-"add_my_position" = "Adicionar a minha posição";
-
-"choose_start_point" = "Escolher um ponto de partida";
-
-"choose_destination" = "Escolher um destino";
 
 "preloader_viator_button" = "Saiba Mais";
 
-"start_from_my_position" = "Iniciar a partir de";
-
-"profile_authorization_title" = "Iniciar sessao com";
-
-"profile_authorization_message" = "Início de sessão fácil e em apenas alguns segundos, sem dados de acesso e palavra-passe";
-
 "profile_authorization_error" = "Ups, ocorreu um erro. Tente iniciar sessão novamente.";
-
-"service" = "Serviço";
-
-"atmosphere" = "Atmosfera";
-
-"value_for_money" = "Relação qualidade-preço";
-
-"experience" = "Experiência";
-
-"assortment" = "Variedade";
-
-"expertise" = "Especialidade";
-
-"equipment" = "Equipamento";
-
-"quality" = "Qualidade";
 
 "dialog_error_storage_title" = "Problema de acesso ao armazenamento";
 
@@ -1644,17 +1032,7 @@
 
 "setting_emulate_bad_storage" = "Emular o mau armazenamento";
 
-"directions_finish" = "Destino";
-
-"directions_on_foot" = "Caminhar %s";
-
 "core_entrance" = "Entrada";
-
-"coffee" = "Café";
-
-"cleanliness" = "Limpeza";
-
-"crowdedness" = "Lotado";
 
 "error_enter_correct_name" = "Introduza um nome correto";
 
@@ -1673,11 +1051,9 @@
 
 "downloader_percent" = "%s (%s de %s)";
 
-"downloader_process" = "A transferir %s...";
+"downloader_process" = "A transferir %s…";
 
-"downloader_applying" = "A aplicar %s...";
-
-"dialog_message_transit_not_found_connection" = "Planeie uma rota dentro de uma rede de tráfego";
+"downloader_applying" = "A aplicar %s…";
 
 "bookmarks_error_message_share_general" = "A partilha não foi possível devido a um erro da aplicação";
 
@@ -1695,17 +1071,7 @@
 
 "bookmarks_error_message_list_name_already_taken" = "Por favor, escolha outro nome";
 
-"bookmarks_error_title_list_name_too_long" = "Este nome é muito longo";
-
-"bookmarks_error_message_list_name_too_long" = "Por favor, escolha outro nome";
-
-"please_wait" = "Por favor, espere...";
-
-"phone_number" = "Número de telefone";
-
-"notification_unsent_reviews_title" = "Você tem vários comentários não enviados";
-
-"notification_unsent_reviews_message" = "Por favor, faça o login para compartilhar opiniões com outros viajantes";
+"please_wait" = "Por favor, espere…";
 
 "profile" = "Perfil do OpenStreetMap";
 
@@ -1719,49 +1085,13 @@
 
 "bookmarks_convert_error_message" = "Alguns arquivos não foram convertidos.";
 
-"converting" = "Convertendo...";
-
-"wn_reinvented_bookmarks_title" = "Nós reinventamos os marcadores!";
-
-"wn_reinvented_bookmarks_message" = "Você pode fazer backup de favoritos, criar listas... É incrível...";
-
-"bookmarks_restore" = "Restaurar marcadores";
-
-"bookmarks_restore_process" = "Restaurando...";
-
 "bookmarks_restore_title" = "Restaurar esta versão?";
 
-"bookmarks_restore_message" = "Seus favoritos serão restaurados a partir de %s (%s)";
-
-"bookmarks_restore_empty_title" = "Você não tem um backup";
-
-"bookmarks_restore_empty_message" = "O servidor não encontrou backups feitos anteriormente";
-
 "common_check_internet_connection_dialog_title" = "Sem conexão com a internet";
-
-"error_server_title" = "Erro de servidor";
-
-"error_server_message" = "Houve um erro no servidor, tente novamente mais tarde";
 
 "error_system_message" = "Ocorreu um erro desconhecido";
 
 "restore" = "Restaurar";
-
-"bookmarks_page_downloaded" = "Baixado";
-
-"bookmarks_page_my" = "Minhas";
-
-"routes_and_bookmarks" = "Rotas e favoritos";
-
-"bookmarks_webview_success_toast" = "Favoritos baixados com sucesso";
-
-"cached_bookmarks_placeholder_title" = "Baixar novos lugares";
-
-"cached_bookmarks_placeholder_subtitle" = "Aperte o botão para baixar milhares de lugares e rotas interessantes criados pelos usuários de Organic Maps. Você precisará de conexão com a internet.";
-
-"downloader_download_routers" = "Baixar favoritos";
-
-"bookmarks_groups_cached" = "Listas baixadas";
 
 "subtittle_opt_out" = "Configurações de rastreamento";
 
@@ -1769,29 +1099,15 @@
 
 "crash_reports_description" = "Podemos utilizar seus dados para melhorar a experiência no Organic Maps. As mudanças entrarão em vigor após você reiniciar o aplicativo.";
 
-"opt_out_help_ios_1" = "O seu dispositivo móvel pode fornecer as opções de «Limitar rastreamento de anúncios» ou «Desativar publicidade baseada em interesse».";
-
-"opt_out_help_ios_2" = "iOS 9 ou Superior";
-
-"opt_out_help_ios_3" = "Vá para: Configurações → Privacidade → Anúncios → Habilitar «Limitar Rastreamento de Anúncios»";
-
-"opt_out_help_android" = "O seu dispositivo móvel pode fornecer as opções de «Limitar rastreamento de anúncios» ou «Desativar publicidade baseada em interesse».\n\nPara versões de Android e Google Play Services superiores a 4.0:\nConfigurações → Google → Anúncios → Desativar publicidade baseada em interesse\nor\n nConfigurações → Google → Anúncios → Informações pessoais & privacidade → Configurações de Anúncios → Personalização de Anúncios";
-
 "privacy_policy" = "Política de privacidade";
 
 "terms_of_use" = "Termos de uso";
-
-"backup_notification_failed" = "O back-up dos seus favoritos foi suspenso. É preciso logar para ligá-lo de volta.";
 
 "button_layer_traffic" = "Tráfego";
 
 "button_layer_subway" = "Metrô";
 
 "layers_title" = "Map Layers";
-
-"layers_message" = "Utilize o Map Layers para exibir tráfego, mapa do metrô e outras informações úteis";
-
-"button_layer_got_it" = "Entendi";
 
 "subway_data_unavailable" = "Mapa de metrô está indisponível";
 
@@ -1803,39 +1119,13 @@
 
 "title_error_downloading_bookmarks" = "Ocorreu um erro";
 
-"subtitle_error_downloading_bookmarks" = "Favoritos não foram baixados";
-
-"error_already_downloaded" = "Esta lista já foi transferida";
-
 "popular_place" = "Popular";
-
-"download_routes" = "Download routes";
-
-"bookmarks_downloaded_title" = "Bookmarks have been downloaded successfully";
-
-"bookmarks_downloaded_subtitle" = "Press ‘View on map’ to explore new places from the list";
-
-"why_support" = "Porquê apoiar o Organic Maps?";
-
-"why_support_item1" = "We respect your privacy: there are zero trackers in the app, and we are open source";
-
-"why_support_item2" = "Ajude-nos a melhorar o Organic Maps";
-
-"why_support_item3" = "Ajude-nos a melhorar mapas livres em OpenStreeMap.org";
-
-"channels_map_update" = "Atualizações de mapa";
-
-"server_unavailable_title" = "O servidor está indisponível";
-
-"sharing_options" = "Definições de acesso";
 
 "export_file" = "Exportar o arquivo";
 
 "list_settings" = "Lista de configurações";
 
 "delete_list" = "Apagar lista";
-
-"hide_from_map" = "Remover do mapa";
 
 "public_access" = "Acesso público";
 
@@ -1845,40 +1135,11 @@
 
 "bookmark_category_description_hint" = "Adicionar uma descrição (texto ou html)";
 
-/* FIXME */
-"bookmarks_public_access" = "bookmarks_public_access";
-
-/* FIXME */
-"bookmarks_link_access" = "bookmarks_link_access";
-
-/* FIXME */
-"bookmarks_private_access" = "bookmarks_private_access";
-
 "not_shared" = "Personal";
-
-"direct_link_progress_text" = "A carregar o seu arquivo…";
-
-"direct_link_success" = "Link criado";
-
-"send_a_link_btn" = "Enviar link";
-
-"upload_error_toast" = "Ocorreu um erro ao carregar o arquivo";
 
 "tags_loading_error_subtitle" = "Ocorreu um erro ao carregar tags, por favor tente de novo";
 
-"unable_upload_errorr_title" = "Não foi possível carregar arquivo";
-
-"unable_upload_error_subtitle_edited" = "O arquivo foi editado através da uma aplicação web";
-
-"unable_upload_error_subtitle_broken" = "Arquivo corrompido e não pode ser carregado. Por favor, carregue outro arquivo.";
-
-"contact" = "Escrever";
-
-"download_button" = "Baixar";
-
 "speedcams_alert_title" = "Câmeras de velocidade";
-
-"speedcams_alert_subtitle" = "Avisar sobre limites de velocidade";
 
 "speedcam_option_auto" = "Auto";
 
@@ -1886,18 +1147,10 @@
 
 "speedcam_option_never" = "Nunca";
 
-"bookmark_description_title" = "Descrição da marca";
-
 "place_description_title" = "Descrição do local";
 
 /* this text will be shown in application notification preferences opposite checkbox which enable/disable downloader notifications. Devices on Android 8+ are affected. */
 "notification_channel_downloader" = "A carregar mapas";
-
-"share_bookmarks_email_body_link" = "Olá!\n\nSeus rótulos podem ser baixado aqui: %s. Abra a lista usando Organic Maps e desfrute do passeio!\n\nBaixar aplicação: https://omaps.app/get?kmz";
-
-"warning_speedcams_title" = "O navegador irá notificá-lo sobre as câmeras quando o limite de velocidade for excedido em %d km/h";
-
-"warning_speedcams_subtitle" = "Não esqueça de ler as regras da estrada no país de viagem.";
 
 "speedcams_notice_message" = "Auto - Avisa sobre radares de velocidade se houver risco de exceder o limite de velocidade\nSempre - Sempre alerta sobre câmeras\nNunca - nunca avisar sobre câmeras";
 
@@ -1913,23 +1166,7 @@
 
 "enable_logging_warning_message" = "Esta opção é ativada para registro das ações para fins de diagnóstico. Isso permite que a equipe localiza problemas com aplicação. Ative opção apenas a pedido do suporte da Organic Maps.";
 
-"html_error_upload_message_try_again" = "Verifique o acesso à rede e volte a tentar";
-
-"html_error_upload_title_try_again" = "Sem conexão a internet";
-
-"notification_leave_review_v2_android_short_title" = "Deixe um comentário e ajude aos viajantes!";
-
-"megafon" = "Say goodbye to roaming!";
-
-"notifications_illegal_alert_disable_button" = "Ativar notificações";
-
 "access_rules_author_only" = "Editado Online";
-
-"privacy_settings_menu" = "Configurações de privacidade";
-
-"unable_upadate_error_title" = "Erro na atualização do percurso";
-
-"unable_upadate_error_message" = "Ocorreram uns erros durante a atualização. Verifique as alterações e volte a tentar";
 
 "driving_options_title" = "Configurações de desvio";
 
@@ -1951,94 +1188,19 @@
 
 "change_driving_options_btn" = "Configurações de desvio ativadas";
 
-"toll_road" = "Estrada com portagem";
-
-"unpaved_road" = "Estrada rural";
-
-"ferry_crossing" = "Ferryboat";
-
-"operated_by" = "Operado por \"%s\"";
-
 "avoid_toll_roads_placepage" = "Evitar as estradas com portagem";
 
 "avoid_unpaved_roads_placepage" = "Evitar as estradas rurais";
 
 "avoid_ferry_crossing_placepage" = "Evitar ferryboat";
 
-"type.cuisine.uzbek" = "Cozinha uzbeque";
-
-"trip_start" = "Vamos";
-
-"pick_destination" = "Objetivo";
-
-"follow_my_position" = "Centrar";
-
-"search_results" = "Resultados da pesquisa";
-
-"then_turn" = "A seguir";
-
-"redirect_route_alert" = "Deseja personalizar o percurso?";
-
-"redirect_route_yes" = "Sim";
-
-"redirect_route_no" = "Não";
-
-"trip_finished" = "Chegou!";
-
-"keyboard_availability_alert" = "Teclado indisponível durante o movimento";
-
-"dialog_routing_change_start_carplay" = "Impossível criar percurso a partir da localização atual";
-
-"dialog_routing_change_end_carplay" = "Impossível criar percurso para o ponto final. Escolher outro";
-
-"dialog_routing_check_gps_carplay" = "Sem GPS. Siga para uma área aberta";
-
-"dialog_routing_unable_locate_route_carplay" = "Impossível criar percurso. Escolher outros pontos do percurso";
-
-"dialog_routing_download_files_carplay" = "Para construir percurso falta carregar os mapas no seu dispositivo";
-
-"dialog_routing_system_error_carplay" = "Ocorreu um erro. Reiniciar aplicação";
-
-"dialog_routing_rebuild_from_current_location_carplay" = "O percurso será reconstruído a partir da sua localização atual";
-
-"dialog_routing_rebuild_for_vehicle_carplay" = "O percurso será reconstruído para o rodoviário";
-
 "ok" = "Ok";
-
-"avoid_unpaved_carplay_1" = "Sem rurais";
-
-"avoid_unpaved_carplay_2" = "Sem rurais";
-
-"avoid_ferry_carplay_1" = "Sem ferry";
-
-"avoid_ferry_carplay_2" = "Sem ferry";
-
-"avoid_tolls_carplay_1" = "Sem pedágio";
-
-"avoid_tolls_carplay_2" = "Sem pedágio";
-
-"speedcams_alert_title_carplay_1" = "Radares";
-
-"speedcams_alert_title_carplay_2" = "Avisos de radar";
-
-"download_map_carplay" = "Baixar mapas de aplicação Organic Maps para o seu dispositivo";
-
-"carplay_roundabout_exit" = "%s saída";
 
 /* max. 10 symbols, both iOS and Android */
 "sort" = "Ordenar…";
 
 /* Android, title, max 20-22 symbols */
 "sort_bookmarks" = "Ordenar tags";
-
-/* iOS */
-"sort_default" = "Ordenar por predefinição";
-
-"sort_type" = "Ordenar por tipo";
-
-"sort_distance" = "Ordenar por distância";
-
-"sort_date" = "Ordenar por data";
 
 /* Android */
 "by_default" = "Por predefinição";
@@ -2052,63 +1214,7 @@
 /* Android */
 "by_date" = "Por data";
 
-"week_ago_sorttype" = "Uma semana atrás";
-
-"month_ago_sorttype" = "Um mês atrás";
-
-"moremonth_ago_sorttype" = "Mais de um mês atrás";
-
-"moreyear_ago_sorttype" = "Mais de um ano atrás";
-
-"near_me_sorttype" = "Perto de mim";
-
-"others_sorttype" = "Outro";
-
-"food_places" = "Alimento";
-
-"tourist_places" = "Pontos turísticos";
-
-"museums" = "Museus";
-
-"parks" = "Jardins";
-
-"swim_places" = "Natação";
-
-"mountains" = "Montanhas";
-
-"animals" = "Animais";
-
-"hotels" = "Hotéis";
-
-"buildings" = "Prédios";
-
-"money" = "Dinheiro";
-
-"shops" = "Lojas";
-
-"parkings" = "Estacionamentos";
-
-"fuel_places" = "Postos de gasolina";
-
-"water" = "Água";
-
-"medicine" = "Medicina";
-
 "search_in_the_list" = "Pesquisar na lista";
-
-"view_on_map_bookmarks" = "No mapa";
-
-"more_bookmarks" = "Mais…";
-
-"no_items_found" = "Nada encontrado";
-
-/* Android, max 18 symbols */
-"bookmarks_edit_list" = "Editar";
-
-/* Android, max 18 symbols */
-"bookmarks_delete_list" = "Eliminar a lista";
-
-"religious_places" = "Lugares sagrados";
 
 "select_list" = "Escolher a lista";
 
@@ -2118,26 +1224,13 @@
 
 "dialog_pedestrian_route_is_long_message" = "Escolhe ponto inicial ou final de percurso próximo da estação de metro";
 
-/* Failed planning SUBWAY route message in navigation view */
-"routing_planning_error_subway_special" = "Erro ao construir o percurso de metro";
-
 "button_layer_isolines" = "Alturas";
-
-"tips_map_layers_title_countour" = "Linhas de alturas offline na Organic Maps!";
-
-"tips_map_layers_message_countour" = "As linhas de alturas offline ajudarão planejar sua viagem à natureza e não se perder no local";
 
 "isolines_activation_error_dialog" = "Para usar as linhas de alturas, atualize ou carregue o mapa da área desejada";
 
 "isolines_location_error_dialog" = "A linhas de alturas ainda não está disponível em sua região";
 
 "elevation_profile_diff_level" = "Nível de complexidade";
-
-"elevation_profile_diff_level_easy" = "Fácil";
-
-"elevation_profile_diff_level_moderate" = "Moderado";
-
-"elevation_profile_diff_level_hard" = "Complicado";
 
 "elevation_profile_ascent" = "Subida";
 
@@ -2147,25 +1240,13 @@
 
 "elevation_profile_maxaltitude" = "Altura max.";
 
-"elevation_profile_m" = "m";
-
 "elevation_profile_difficulty" = "Complexidade";
 
 "elevation_profile_distance" = "Distância:";
 
-"elevation_profile_km" = "km";
-
 "elevation_profile_time" = "Ida:";
 
-"elevation_profile_hours" = "h.";
-
-"elevation_profile_minutes" = "min";
-
 "isolines_toast_zooms_1_10" = "Ampliar mapa para ver as curvas de nível";
-
-"downloader_updating_ios" = "Atualização";
-
-"downloader_loading_ios" = "Carregamento";
 
 "key_information_title" = "Informações principais";
 

--- a/iphone/Maps/LocalizedStrings/pt.lproj/Localizable.stringsdict
+++ b/iphone/Maps/LocalizedStrings/pt.lproj/Localizable.stringsdict
@@ -9,21 +9,6 @@
 
 <!-- ********** Strings for downloading map from search **********/ -->
 
-  <key>bookmarks_places</key>
-  <dict>
-    <key>NSStringLocalizedFormatKey</key>
-    <string>%#@value@</string>
-    <key>value</key>
-    <dict>
-      <key>NSStringFormatSpecTypeKey</key>
-      <string>NSStringPluralRuleType</string>
-      <key>NSStringFormatValueTypeKey</key>
-      <string>d</string>
-      <key>other</key>
-      <string>%d favoritos</string>
-    </dict>
-  </dict>
-
   <key>bookmarks_detect_message</key>
   <dict>
     <key>NSStringLocalizedFormatKey</key>
@@ -38,21 +23,6 @@
       <string>%d arquivo foi encontrado. Você vai ver depois da conversão.</string>
       <key>other</key>
       <string>%d arquivos foram encontrados. Você os verá depois da conversão.</string>
-    </dict>
-  </dict>
-
-  <key>bookmarks_objects</key>
-  <dict>
-    <key>NSStringLocalizedFormatKey</key>
-    <string>%#@value@</string>
-    <key>value</key>
-    <dict>
-      <key>NSStringFormatSpecTypeKey</key>
-      <string>NSStringPluralRuleType</string>
-      <key>NSStringFormatValueTypeKey</key>
-      <string>d</string>
-      <key>other</key>
-      <string>%s objeto</string>
     </dict>
   </dict>
 

--- a/iphone/Maps/LocalizedStrings/ro.lproj/Localizable.strings
+++ b/iphone/Maps/LocalizedStrings/ro.lproj/Localizable.strings
@@ -18,9 +18,6 @@
 /* Button which deletes downloaded country */
 "delete" = "Ștergere";
 
-/* Button "do not interrupt download" if user touched actively downloading country */
-"do_nothing" = "Continuare";
-
 "download_maps" = "Descărcare hărți";
 
 /* Settings/Downloader - info for country when download fails */
@@ -28,9 +25,6 @@
 
 /* Settings/Downloader - info for country which started downloading */
 "downloading" = "Se descarcă…";
-
-/* Settings/Downloader - size string, only strings different from English should be translated */
-"kb" = "kB";
 
 /* Choose measurement on first launch alert - choose metric system button */
 "kilometres" = "Kilometri";
@@ -55,17 +49,11 @@
 /* Update maps later/Buy pro version later button text */
 "later" = "Mai târziu";
 
-/* Don't show some dialog any more */
-"never" = "Niciodată";
-
 /* View and button titles for accessibility */
 "search" = "Căutare";
 
 /* Search box placeholder text */
 "search_map" = "Căutare hartă";
-
-/* Settings/Downloader - info for not downloaded country */
-"touch_to_download" = "Atingeți pentru a descărca.";
 
 /* Settings/Downloader - 3G download warning dialog confirm button */
 "use_cellular_data" = "Da";
@@ -73,20 +61,11 @@
 /* Location services are disabled by user alert - message */
 "location_is_disabled_long_text" = "În acest moment aveți dezactivate toate serviciile de localizare pentru acest dispozitiv sau aplicație. Vă rugăm să le activați la setări.";
 
-/* Location Services are not available on the device alert - message */
-"device_doesnot_support_location_services" = "Dispozitivul dvs. nu acceptă servicii de localizare.";
-
 /* View and button titles for accessibility */
 "zoom_to_country" = "Afișare pe hartă";
 
-/* Button text for the button at the center of the screen when the country is not downloaded */
-"country_status_download" = "Descărcare hartă\n(^ ^)";
-
 /* Button text for the button at the center of the screen when the country is not downloaded and the size should not be shown */
 "country_status_download_without_size" = "Descărcare hartă";
-
-/* Button text for the button at the center of the screen when the country is not downloaded */
-"country_status_download_without_routing" = "Descărcare hartă\nfără rutare (^ ^)";
 
 /* Message to display at the center of the screen when the country download has failed */
 "country_status_download_failed" = "Se descarcă a eșuat";
@@ -96,19 +75,13 @@
 
 "about_menu_title" = "Despre Organic Maps";
 
-"downloaded_touch_to_delete" = "Descărcat (%@). Atingeți pentru a șterge.";
-
 "connection_settings" = "Setări conexiune";
-
-"download_mb_or_kb" = "Descărcare %@";
 
 "close" = "Închidere";
 
 "unsupported_phone" = "Este necesar un OpenGL accelerat din hardware. Din păcate, dispozitivul nu este acceptat.";
 
 "download" = "Descărcare";
-
-"external_storage_is_not_available" = "Cartela SD/dispozitivul de stocare USB cu hărțile descărcate nu este disponibil.";
 
 "disconnect_usb_cable" = "Vă rugăm să deconectați cablul USB sau să introduceți cartela de memorie pentru a putea utiliza Organic Maps.";
 
@@ -117,8 +90,6 @@
 "not_enough_memory" = "Nu este suficientă memorie pentru a lansa aplicația.";
 
 "download_resources" = "Înainte de a începe, permiteți-ne să descărcăm harta generală a lumii pe dispozitivul dvs.\nAre nevoie de %@ de date.";
-
-"getting_position" = "Se obține poziția actuală";
 
 "download_resources_continue" = "Mergeți la hartă.";
 
@@ -140,23 +111,14 @@
 /* Add New Bookmark Set dialog title */
 "add_new_set" = "Adăugare la „Marcaje”";
 
-/* Place Page - Add To Bookmarks button */
-"add_to_bookmarks" = "Adăugare la „Marcaje”";
-
 /* Bookmark Color dialog title */
 "bookmark_color" = "Culoare marcaj";
 
 /* Add Bookmark Set dialog - hint when set name is empty */
 "bookmark_set_name" = "Nume set marcaje";
 
-/* Bookmark Sets dialog title */
-"bookmark_sets" = "Seturi marcaje";
-
 /* Bookmarks - dialog title */
 "bookmarks" = "Marcaje";
-
-/* Add bookmark dialog - bookmark color */
-"color" = "Culoare";
 
 /* Default bookmarks set name */
 "core_my_places" = "Locurile mele";
@@ -167,14 +129,8 @@
 /* Editor title above street and house number */
 "address" = "Adresă";
 
-/* Place Page - Remove Pin button */
-"remove_pin" = "Poziție eliminată";
-
 /* Add bookmark dialog - bookmark set, Bookmarks dialog - Bookmark set cell */
 "set" = "Set";
-
-/* Text hint in Bookmarks dialog when no any bookmarks are added */
-"bookmarks_usage_hint" = "Încă nu aveți niciun marcaj.\nAtingeți orice loc de pe hartă pentru a adăuga un marcaj.\nPot fi importate și afișate pe Organic Maps și marcaje din alte surse. Deschideți fișierul KML/KMZ, cu marcajele salvate din email, Dropbox sau de la un link web.";
 
 /* Settings button in system menu */
 "settings" = "Setări";
@@ -191,26 +147,11 @@
 /* Ask to wait user several minutes (some long process in modal dialog). */
 "wait_several_minutes" = "Aceasta poate dura câteva minute.\nVă rugăm să așteptați…";
 
-/* Show bookmarks from this category on a map or not */
-"visible" = "Vizibil";
-
-/* Toast which is displayed when GPS has been deactivated */
-"gps_is_disabled_long_text" = "GPS-ul este dezactivat. Vă rugăm să îl activați din setări.";
-
 /* Measurement units title in settings activity */
 "measurement_units" = "Unități de măsură";
 
 /* Detailed description of Measurement Units settings button */
 "measurement_units_summary" = "Alegeți între mile și kilometri";
-
-/* Do search in all sources */
-"search_mode_all" = "Everywhere";
-
-/* Do search near my position only */
-"search_mode_nearme" = "Near Me";
-
-/* Do search in current viewport only */
-"search_mode_viewport" = "On the Screen";
 
 /* Search category for cafes, bars, restaurants */
 "eat" = "Unde să mănânci";
@@ -266,14 +207,8 @@
 /* Search category */
 "police" = "Poliție";
 
-/* String in search result list, when nothing found */
-"no_search_results_found" = "Nu s-a găsit niciun rezultat.";
-
 /* Notes field in Bookmarks view */
 "description" = "Note";
-
-/* Button text */
-"share_by_email" = "Partajare prin email";
 
 /* Email Subject when sharing bookmarks category */
 "share_bookmarks_email_subject" = "Marcaje Organic Maps partajate";
@@ -295,26 +230,11 @@
 /* Warning message when doing search around current position */
 "unknown_current_position" = "Poziția dvs. nu a fost stabilită încă.";
 
-/* Warning message when location country isn't downloaded during search (see also download_location_map_proposal). */
-"download_location_country" = "Descărcați hărțile pentru țara în care vă aflați (%@).";
-
-/* Warning message when viewport country isn't downloaded during search */
-"download_viewport_country_to_search" = "Descărcați hărțile pentru țara pe care o căutați pe (%@).";
-
 /* Alert message that we can't run Map Storage settings due to some reasons. */
 "cant_change_this_setting" = "Ne pare rău. Setările pentru stocarea hărților sunt dezactivate în acest moment.";
 
 /* Alert message that downloading is in progress. */
 "downloading_is_active" = "Descărcarea hărților pentru țara dorită este în curs.";
-
-/* Message that will be shown in alert view, when we ask user to leave review on App Store */
-"appStore_message" = "Sperăm că vă place Organic Maps! Dacă da, vă rugăm să o votați sau să scrieți o recenzie în App Store. Durează mai puțin de un minut, dar pe noi ne ajută foarte mult. Vă mulțumim pentru susținere!";
-
-/* No, thanks */
-"no_thanks" = "Nu, mulțumesc";
-
-/* Share one specific bookmark using SMS, %1$@ contains om:// and %2$@ https://omaps.app link. @NOTE non-ascii symbols in the link will result in max 70 characters SMS instead of 140. */
-"bookmark_share_sms" = "Hei, poți vedea care este poziția mea pe Organic Maps! %1$@ sau %2$@ Nu ai instalate hărțile offline? Descarcă de aici: https://omaps.app/get";
 
 /* Share my position using SMS, %1$@ contains om:// and %2$@ https://omaps.app link WITHOUT NAME. @NOTE non-ascii symbols in the link will result in max 70 characters SMS instead of 140. */
 "my_position_share_sms" = "Hei, îmi poți vedea poziția actuală pe Organic Maps! %1$@ sau %2$@ Nu ai hărțile offline? Descarcă de aici: https://omaps.app/get";
@@ -328,23 +248,11 @@
 /* Share my position using EMail, %1$@ is om:// and %2$@ is https://omaps.app link WITHOUT NAME */
 "my_position_share_email" = "Chào,\n\nTôi hiện đang ở đây: %1$@. Hãy nhấn vào liên kết này %2$@ hoặc liên kết này %3$@ để xem địa điểm trên bản đồ.\n\nCám ơn.";
 
-/* Android share by Message/SMS button text (including SMS) */
-"share_by_message" = "Partajare ca mesaj";
-
 /* Share button text which opens menu with more buttons, like Message, EMail, Facebook etc. */
 "share" = "Partajare";
 
-/* iOS share by Message button text (including SMS) */
-"message" = "Tin nhắn";
-
 /* Share by email button text, also used in editor. */
 "email" = "Email";
-
-/* Copy Link */
-"copy_link" = "Copiați link-ul";
-
-/* Text for the button that returns to caller application */
-"more_info" = "Afișează mai multe informații";
 
 /* Text for message when used successfully copied something */
 "copied_to_clipboard" = "Copiat în clipboard: %1$@";
@@ -354,15 +262,6 @@
 
 /* Used for bookmark editing */
 "done" = "Gata";
-
-/* Summary for preferences in MWM */
-"yopme_pref_summary" = "Alegeți setările pentru ecranul din spate";
-
-/* Title for yopme preferences in MWM */
-"yopme_pref_title" = "Setări ecran spate";
-
-/* Hint for upper-right icon p2b */
-"show_on_backscreen" = "Afișare pe ecranul din spate";
 
 /* Prints version number in About dialog */
 "version" = "Versiune: %@";
@@ -381,19 +280,11 @@
 
 "share_my_location" = "Partajează-mi poziția";
 
-"menu_search" = "Căutare";
-
 /* Settings general group in settings screen */
 "prefs_group_general" = "General settings";
 
 /* Settings information group in settings screen */
 "prefs_group_information" = "Information";
-
-/* Settings screen: "Map" category title */
-"prefs_group_map" = "Hartă";
-
-/* Settings screen: "Miscellaneous" category title */
-"prefs_group_misc" = "Diverse";
 
 "prefs_group_route" = "Navigație";
 
@@ -419,9 +310,6 @@
 /* Settings «Map» category: «3D buildings» title */
 "pref_map_3d_buildings_title" = "Clădiri 3D";
 
-/* Settings «Map» category: «3D buildings» summary */
-"pref_map_3d_buildings_subtitle" = "Afectează durata de funcționare a bateriei";
-
 /* Settings «Route» category: «Tts enabled» title */
 "pref_tts_enable_title" = "Instrucțiuni vocale";
 
@@ -433,8 +321,6 @@
 
 /* Title for "Other" section in TTS settings. */
 "pref_tts_other_section_title" = "Alta";
-
-"pref_tts_how_to_set_up_voice" = "Modalitatea de configurare a vocii";
 
 /* Settings «Map» category: «Record track» title */
 "pref_track_record_title" = "Rute recente";
@@ -455,56 +341,7 @@
 
 "recent_track_help_text" = "Vă permite să înregistrați traseul parcurs pentru o anumită perioadă și să îl vedeți pe hartă. Rețineți: activarea acestei funcții crește consumul bateriei. Traseul va fi eliminat automat de pe hartă după expirarea intervalului de timp.";
 
-"pref_track_ios_caption" = "Opțiunea Rută recentă vă afișează ruta folosită anterior.";
-
-"pref_track_ios_subcaption" = "Vă rugăm să selectați intervalul orar corespunzător salvării rutei.";
-
-"placepage_distance" = "Distanță";
-
-"placepage_coordinates" = "Coordonate";
-
-"placepage_unsorted" = "Nesortate";
-
 "search_show_on_map" = "Vizualizare pe hartă";
-
-/* Used to warn user when fixing KitKat issue */
-"bookmark_move_fail" = "Trebuie să vă mutăm marcajele în memoria internă, dar nu există spațiu suficient pentru ele. Vă rugăm să eliberați memoria, altfel marcajele nu vor fi disponibile.";
-
-/* Used in More Apps menu */
-"free" = "Free";
-
-/* Used in More Apps menu */
-"buy" = "Buy";
-
-/* 1st search button-like result */
-"search_on_map" = "Căutare pe hartă";
-
-/* toast with an error */
-"no_route_found" = "Nu a fost găsit nici un traseu";
-
-/* route title */
-"route" = "Traseu";
-
-/* category title */
-"routes" = "Trasee";
-
-/* text of notification */
-"download_map_notification" = "Descărcați harta locului în care vă aflați";
-
-/* text of notification */
-"pro_version_is_free_today" = "Full version of Organic Maps is free today! Download now and tell your friends.";
-
-/* Dialog for transferring maps from lite to pro. */
-"move_lite_maps_to_pro" = "Transferăm hărțile dvs. descărcate din Organic Maps Lite în Organic Maps. Acest lucru poate dura câteva minute.";
-
-/* Message to display when maps moved. */
-"move_lite_maps_to_pro_ok" = "Hărțile dvs. descărcate sunt transferate cu succes către Organic Maps.";
-
-/* Message to display when maps move failed. */
-"move_lite_maps_to_pro_failed" = "Your maps failed to transfer. Please delete Organic Maps Lite and download the maps again.";
-
-/* Text in menu */
-"settings_and_more" = "Setări și altele";
 
 /* Text in menu */
 "website" = "Site web";
@@ -527,14 +364,8 @@
 /* Text in menu */
 "openstreetmap" = "OpenStreetMap";
 
-/* Text in menu */
-"contact_us" = "Contactați-ne";
-
 /* Settings: Send feedback button and dialog title */
 "feedback" = "Feedback";
-
-/* Text in menu */
-"subscribe_to_news" = "Abonați-vă la știrile noastre";
 
 /* Text in menu */
 "rate_the_app" = "Votați-ne aplicația";
@@ -548,15 +379,6 @@
 /* Text in menu */
 "report_a_bug" = "Raportați o eroare";
 
-/* Email subject */
-"subscribe_me_subject" = "Abonează-mă la buletinul informativ Organic Maps.";
-
-/* Email body */
-"subscribe_me_body" = "Vreau să fiu primul care află despre cele mai recente actualizări și promoții. Îmi pot anula abonamentul în orice moment.";
-
-/* About text */
-"about_text" = "Organic Maps oferă cele mai rapide hărți offline ale tuturor orașelor, tuturor țărilor din lume. Călătoriți cu încredere deplină: oriunde v-ați afla, Organic Maps vă ajută să vă reperați poziția pe hartă, să găsiți cel mai apropiat restaurant sau hotel, cea mai apropiată bancă sau benzinărie etc. Nu necesită conexiune la internet.\n\nLucrăm încontinuu să introducem funcții noi și ne-ar face mare plăcere să ne comunicați cum credeți dvs. că am putea îmbunătăți Organic Maps. Dacă aveți probleme cu aplicația, nu ezitați să ne contactați la adresa support@organicmaps.app. Răspundem la fiecare solicitare!\n\nVă place Organic Maps și doriți să ne susțineți? Iată câteva moduri simple și complet gratuite:\n- publicați o recenzie în magazinul de aplicații\n- apreciați-ne pagina de Facebook: http://www.facebook.com/OrganicMaps\n- sau spuneți și mamei, prietenilor și colegilor despre Organic Maps. :)\n\nVă mulțumim că ne sunteți alături. Vă apreciem foarte mult susținerea!\n\nP.S. Noi preluăm datele din OpenStreetMap, un proiect de cartografiere similar Wikipediei, ce permite utilizatorilor să creeze și să editeze hărți. Dacă vedeți că ceva lipsește sau este greșit pe hartă, puteți corecta hărțile direct la adresa: https://www.openstreetmap.org, iar modificările dvs. vor apărea în aplicația Organic Maps atunci când va fi lansată versiunea următoare.";
-
 /* Alert text */
 "email_error_body" = "Nu a fost setat clientul de email. Vă rugăm să o configurați sau să utilizați un alt mod de a ne contacta la %@.";
 
@@ -569,12 +391,6 @@
 /* Search category */
 "wifi" = "WiFi";
 
-/* Update map suggestion */
-"routing_map_outdated" = "Vă rugăm să actualizați harta pentru a crea o rută.";
-
-/* Update maps suggestion */
-"routing_update_maps" = "Noua versiune a Organic Maps vă permite să creați rute din poziția dvs. actuală către un punct de destinație. Vă rugăm să actualizați harta pentru a utiliza această funcție.";
-
 /* Update all button text */
 "downloader_update_all_button" = "Actualizați toate";
 
@@ -583,9 +399,6 @@
 
 /* Downloaded maps category */
 "downloader_downloaded_subtitle" = "Descărcat";
-
-/* Downloaded maps category */
-"downloader_available_maps" = "Disponibil";
 
 /* Country queued for download */
 "downloader_queued" = "În lista de așteptare";
@@ -598,17 +411,6 @@
 
 "downloader_downloading" = "Descărcare:";
 
-"downloader_search_results" = "S-au găsit";
-
-/* Disclaimer message */
-"routing_disclaimer" = "Atunci când creați rute în aplicația Organic Maps, vă rugăm să nu uitați următoarele:\n\n- Rutele sugerate pot fi luate în considerare numai ca recomandări.\n- Harta poate fi incorectă sau neactualizată, iar rutele pot să nu fie create în cel mai bun mod posibil.\n- Condițiile de trafic, regulile și semnele de circulație au prioritate mai mare decât sugestiile de navigare.\n\nCirculați cu atenție și aveți grijă de dvs.!";
-
-/* Outdated maps category */
-"downloader_outdated_maps" = "Neactualizată";
-
-/* Up to date maps category */
-"downloader_uptodate_maps" = "Actualizată";
-
 /* Status of outdated country in the list */
 "downloader_status_outdated" = "Actualizare";
 
@@ -618,49 +420,14 @@
 /* Displayed in a dialog that appears when a user tries to delete a map while the app is in the follow route mode */
 "downloader_delete_map_while_routing_dialog" = "Pentru a șterge harta, vă rugăm să opriți navigarea.";
 
-/* Show when user try build route, but we don't know where he */
-"routing_failed_unknown_my_position" = "Poziția dvs. curentă este nedefinită. Vă rugăm să specificați poziția, pentru a crea o rută.";
-
-/* Show if use has not routing file, or InconsistentMWMandRoute */
-"routing_failed_has_no_routing_file" = "Datele suplimentare necesare pentru a crea trasee de la locația dvs.";
-
-/* StartPointNotFound */
-"routing_failed_start_point_not_found" = "Nu se poate calcula ruta. Nu există drumuri în apropierea punctului de pornire.";
-
-/* EndPointNotFound */
-"routing_failed_dst_point_not_found" = "Nu se poate calcula ruta. Nu există drumuri în apropierea punctului de destinație.";
-
 /* PointsInDifferentMWM */
 "routing_failed_cross_mwm_building" = "Pot fi create doar rutele ce se află în întregime într-o singură hartă.";
-
-/* RouteNotFound */
-"routing_failed_route_not_found" = "Nu am găsit nicio rută între punctul de pornire și destinația selectată. Vă rugăm să alegeți un alt punct de pornire sau de destinație.";
-
-/* InternalError */
-"routing_failed_internal_error" = "A survenit o eroare internă. Vă rugăm să încercați să ștergeți și să descărcați harta din nou. Dacă problema persistă, vă rugăm să ne contactați la adresa support@organicmaps.app.";
-
-/* Context menu item for downloader. */
-"downloader_download_map_and_routing" = "Descărcare hartă + traseu";
-
-/* Context menu item for downloader. */
-"downloader_download_routing" = "Descărcare traseu";
-
-/* Context menu item for downloader. */
-"downloader_delete_routing" = "Ștergere traseu";
 
 /* Context menu item for downloader. */
 "downloader_download_map" = "Descărcați harta";
 
-"downloader_download_map_no_routing" = "Descărcare hartă fără rutare";
-
-/* Button for routing. */
-"routing_go" = "Pornește!";
-
 /* Item status in downloader. */
 "downloader_retry" = "Repetare";
-
-/* Item in context menu. */
-"downloader_map_and_routing" = "Hartă + trasee";
 
 /* Item in context menu. */
 "downloader_delete_map" = "Ștergere hartă";
@@ -668,29 +435,11 @@
 /* Item in context menu. */
 "downloader_update_map" = "Actualizare hartă";
 
-/* Item in context menu. */
-"downloader_update_map_and_routing" = "Actualizare hartă + trasee";
-
-/* Item in context menu. */
-"downloader_map_only" = "Doar harta";
-
-/* Toolbar title */
-"toolbar_application_menu" = "Meniu aplicație";
-
 /* Preference text */
 "pref_use_google_play" = "Utilizați serviciile Google Play, pentru a vă obține poziția actuală.";
 
 /* Text for rating dialog */
 "rating_just_rated" = "Tocmai ți-am votat aplicația";
-
-/* Text for rating dialog */
-"rating_user_since" = "Sunt utilizator Organic Maps din %@";
-
-/* Text for rating dialog */
-"rating_do_like_maps" = "Îți place Organic Maps?";
-
-/* Text for rating dialog */
-"rating_tap_star" = "Apasă pe una dintre stele pentru a ne vota aplicația";
 
 /* Text for rating dialog */
 "rating_thanks" = "Îți mulțumim!";
@@ -701,23 +450,8 @@
 /* Text for rating dialog */
 "rating_send_feedback" = "Trimitere feedback";
 
-/* Text for g+ dialog */
-"rating_google_plus" = "Clic pe g+ pentru a le spune prietenilor tăi despre aplicație.";
-
 /* Text for routing error dialog */
 "routing_download_maps_along" = "Descarcă hărțile adiacente rutei";
-
-/* Text for routing error dialog */
-"routing_download_map" = "Descărcați harta";
-
-/* Text for routing error dialog */
-"routing_download_map_and_routing" = "Descărcați harta actualizată și informațiile pentru direcționare, pentru a beneficia de toate funcțiile Organic Maps.";
-
-/* Text for routing error dialog */
-"routing_get_routing_data" = "Descărcați informațiile pentru direcționare";
-
-/* Text for routing error dialog */
-"routing_get_additional_data" = "Datele suplimentare necesare pentru a crea trasee de la locația dvs.";
 
 /* Text for routing error dialog */
 "routing_requires_all_map" = "Crearea unui traseu necesită ca toate hărțile de la locația dvs. până la destinație să fie descărcate și actualizate.";
@@ -725,50 +459,15 @@
 /* Text for routing error dialog */
 "routing_not_enough_space" = "Nu există spațiu suficient";
 
-/* Text for routing error dialog */
-"routing_download_more_than_avail" = "Trebuie să descărcați %@ MB, dar numai un spațiu de %@ MB este disponibil.";
-
-/* Text for routing error dialog */
-"routing_download_roaming" = "Urmează să descărcați %@ MB folosind abonamentul de date pentru mobil (în roaming). Acest lucru poate genera costuri suplimentare, în funcție de abonamentul dvs. de date, activat de operatorul de telefonie mobilă.";
-
 /* bookmark button text */
 "bookmark" = "marcaj";
-
-/* map is not downloaded */
-"not_found_map" = "Harta pentru poziția dvs. nu este descărcată";
 
 /* location service disabled */
 "enable_location_services" = "Vă rugăm să activați serviciile de localizare";
 
-/* download map */
-"download_map" = "Descărcați harta pentru poziția dvs.";
-
-/* download map on iPhone */
-"download_map_iphone" = "Descărcați o hartă pentru poziția dvs. actuală pe iPhone-ul dvs.";
-
-/* clear pin */
-"nearby" = "În apropiere";
-
-/* clear pin */
-"clear_pin" = "Ștergeți semnul de poziție";
-
-/* location is undefined */
-"undefined_location" = "Poziția dvs. curentă este nedefinită.";
-
-/* download country of your location */
-"download_country" = "Descărcați hărțile pentru țara în care vă aflați";
-
-/* download failed */
-"download_failed" = "descărcarea a eșuat";
-
-/* get the map */
-"get_the_map" = "Obțineți harta";
-
 "save" = "Salvare";
 
 "edit_description_hint" = "Your descriptions (text or html)";
-
-"new_group" = "grup nou";
 
 "create" = "creează";
 
@@ -795,30 +494,6 @@
 
 /* pink color */
 "pink" = "Roz";
-
-/* deep purple color */
-"deep_purple" = "Purpuriu închis";
-
-/* light blue color */
-"light_blue" = "Albastru deschis";
-
-/* cyan color */
-"cyan" = "Albastru-verziu";
-
-/* teal color */
-"teal" = "Smarald";
-
-/* lime color */
-"lime" = "Var";
-
-/* deep orange color */
-"deep_orange" = "Portocaliu închis";
-
-/* gray color */
-"gray" = "Gri";
-
-/* blue gray color */
-"blue_gray" = "Gri albăstriu";
 
 /* Wi-Fi available */
 "WiFi_available" = "Da";
@@ -848,13 +523,9 @@
 
 "dialog_routing_location_unknown_turn_on" = "Localizarea coordonatelor GPS curente a eşuat. Pentru a calcula traseul, activaţi serviciile de localizare.";
 
-"dialog_routing_location_unknown" = "Localizarea coordonatelor GPS curente a eşuat.";
-
 "dialog_routing_download_files" = "Descărcaţi fişierele necesare";
 
 "dialog_routing_download_and_update_all" = "Pentru calcularea traseului, descărcaţi şi actualizaţi toate hărţile şi informaţiile de stabilire a traseului pentru calea estimată.";
-
-"dialog_routing_routes_size" = "Fişiere cu informaţii de stabilire a traseului";
 
 "dialog_routing_unable_locate_route" = "Localizarea traseului a eşuat";
 
@@ -884,21 +555,11 @@
 
 "dialog_routing_try_again" = "Încercaţi din nou";
 
-"dialog_routing_send_error" = "Raportaţi problema";
-
-"dialog_routing_if_get_cross_route" = "Doriţi să creaţi un traseu mai direct care include mai mult decât o hartă?";
-
-"dialog_routing_cross_route_is_optimal" = "Este disponibil un traseu mai adecvat care trece de limita acestei hărţi.";
-
 "not_now" = "Nu acum";
-
-"dialog_routing_build_route" = "Creare";
 
 "dialog_routing_download_and_build_cross_route" = "Doriţi să descărcaţi harta şi să creaţi un traseu mai direct care include mai mult decât o hartă?";
 
 "dialog_routing_download_cross_route" = "Pentru a crea un traseu mai adecvat care trece de limita acestei hărţi, descărcaţi harta.";
-
-"dialog_routing_cross_route_always" = "Întotdeauna să se treacă această limită";
 
 
 /********** Strings for downloading map from search **********/
@@ -906,8 +567,6 @@
 "search_without_internet_advertisement" = "Pentru a putea începe căutarea și crearea unor rute, vă rugăm să descărcați harta, iar apoi nu veți mai avea nevoie de conexiune la internet.";
 
 "search_select_map" = "Selectați harta";
-
-"search_select_other_map" = "Selectați altă hartă";
 
 /* «Show» context menu */
 "show" = "Afișare";
@@ -918,17 +577,11 @@
 /* «Rename» context menu */
 "rename" = "Redenumire";
 
-/* Bottom sheet: expand button (should be short) */
-"bottom_sheet_more" = "Mai multe…";
-
 /* Failed planning route message in navigation view */
 "routing_planning_error" = "Planificarea rutei a eșuat";
 
 /* Arrive routing message in navigation view */
 "routing_arrive" = "Sosire: %s";
-
-/* Text for routing::RouterResultCode::FileTooOld dialog. */
-"dialog_routing_download_and_update_maps" = "Pentru a crea o rută, vă rugăm să descărcați și să actualizați toate hărțile de pe parcursul rutei.";
 
 "rate_alert_title" = "Vă place aplicația?";
 
@@ -944,19 +597,11 @@
 
 "history" = "Istoric";
 
-"next_turn_then" = "Apoi";
-
 "closed" = "Închis";
-
-"back_to" = "Înapoi la %@";
 
 "search_not_found" = "Ne pare rău, nu s-au găsit rezultate.";
 
 "search_not_found_query" = "Vă rugăm să încercați altă căutare.";
-
-"search_not_found_map" = "Vă rugăm să descărcați harta pe care doriți să căutați.";
-
-"search_not_found_location" = "Descărcați harta locului în care vă aflați acum.";
 
 "search_history_title" = "Istoricul căutărilor";
 
@@ -964,23 +609,12 @@
 
 "clear_search" = "Ștergere istoric de căutare";
 
-/* Title for settings to enable/disable showcase menu button */
-"showcase_settings_title" = "Afișare oferte";
-
 /* Place Page link to Wikipedia article (if map object has it). */
 "read_in_wikipedia" = "Wikipedia";
 
-"p2p_route_planning" = "Planificare rută";
-
 "p2p_your_location" = "Locația dvs.";
 
-"p2p_from" = "Punctul de plecare";
-
-"p2p_to" = "Punctul de sosire";
-
 "p2p_start" = "Start";
-
-"p2p_planning" = "Se planifică…";
 
 "p2p_from_here" = "Din";
 
@@ -1018,15 +652,9 @@
 
 "editor_correct_mistake" = "Corectare greșeală";
 
-"editor_correct_mistake_message" = "Ați efectuat o eroare de editare. Corectați eroarea sau treceți în modul Simplu.";
-
 "editor_add_select_location" = "Locație";
 
 "editor_done_dialog_1" = "Ați modificat harta lumii. Nu ascundeți acest lucru! Spuneți-le prietenilor dvs. și modificați-o împreună.";
-
-"editor_done_dialog_2" = "Aceasta este a doua modificare a hărții. Acum sunteți pe locul %d în lista editorilor de hărți. Spuneți prietenilor dvs. despre aceasta.";
-
-"editor_done_dialog_3" = "Ați modificat harta, spuneți prietenilor dvs. despre aceasta și modificați-o împreună.";
 
 "share_with_friends" = "Partajează cu prietenii";
 
@@ -1044,20 +672,7 @@
 
 "editor_report_problem_duplicate_place_title" = "Locație dublată";
 
-"first_launch_congrats_title" = "Organic Maps este gata pentru utilizare";
-
-"first_launch_congrats_text" = "Căutați și navigați în regim offline oriunde în lume, în mod gratuit.";
-
-"migrate_title" = "Important!";
-
-/* Android uses image instead of text. */
-"download_all" = "Descarcă toate";
-
-"delete_all" = "Ștergere toate";
-
 "autodownload" = "Descărcare automată";
-
-"disable_autodownload" = "Dezactivare descărcare automată";
 
 /* Place Page opening hours text */
 "closed_now" = "Închis acum";
@@ -1072,10 +687,6 @@
 "day_off" = "Închis";
 
 "today" = "Azi";
-
-"sunrise_to_sunset" = "De la răsărit până la apus";
-
-"sunset_to_sunrise" = "De la apus până la răsărit";
 
 "add_opening_hours" = "Adăugare ore de funcționare";
 
@@ -1095,45 +706,18 @@
 
 "forgot_password" = "Ați uitat parola?";
 
-/* Forgot Password dialog title */
-"restore_password" = "Recuperare parolă";
-
-"enter_email_address_to_reset_password" = "Introduceți adresa de email pe care ați utilizat-o în momentul înregistrării, iar noi vă vom trimite link-ul pentru a vă reînnoi parola.";
-
-"reset_password" = "Resetare parolă";
-
-"username" = "Nume de utilizator";
-
 "osm_account" = "Cont OSM";
 
 "logout" = "Ieșire";
 
-"login_and_edit_map_motivation_message" = "Autentificați-vă și editați informația despre obiectele de pe hartă, iar noi le vom face disponibile pentru milioane de alți utilizatori. Să facem împreună lumea mai bună.";
-
 /* Information text: "Last upload 11.01.2016" */
 "last_upload" = "Ultima încărcare";
 
-/* Motivates user to login/register, title above login buttons. */
-"you_have_edited_your_first_object" = "Ați editat primul dvs. obiect!";
-
 "thank_you" = "Vă mulțumim";
-
-"login_with_google" = "Logați-vă cu contul de Google";
-
-"login_with_openstreetmap" = "Logați-vă cu contul de www.openstreetmap.org";
 
 "edit_place" = "Editați loc";
 
 "place_name" = "Denumire loc";
-
-/* title above languages list cells in the editor, below editable name text field. */
-"other_languages" = "Alte limbi";
-
-/* small button to open list with names in different languages */
-"show_more" = "Afișează mai mult";
-
-/* small button to close list with names in different languages */
-"show_less" = "Afișează mai puțin";
 
 "add_language" = "Adăugare limbă";
 
@@ -1164,8 +748,6 @@
 
 "please_note" = "Actualizați hărțile";
 
-"common_no_wifi_dialog" = "Nu există conexiune WiFi. Doriți să continuați cu conexiunea de pe mobil?";
-
 "downloader_delete_map_dialog" = "Pentru a crea un traseu, trebuie să actualizați toate hărțile, iar apoi să planificați traseul încă o dată.";
 
 "downloader_update_maps" = "Actualizați hărțile";
@@ -1173,10 +755,6 @@
 "downloader_mwm_migration_dialog" = "Pentru a crea un traseu, trebuie să actualizați toate hărțile, iar apoi să planificați traseul încă o dată.";
 
 "downloader_search_field_hint" = "Găsiți harta";
-
-"migration_update_all_button" = "Actualizați toate hărțile";
-
-"migration_delete_all_download_current_button" = "Descărcați harta actuală și ștergeți toate hărțile vechi";
 
 "migration_download_error_dialog" = "Eroare de descărcare";
 
@@ -1186,21 +764,9 @@
 
 "downloader_no_space_message" = "Vă rugăm să ștergeți datele care nu sunt necesare";
 
-"editor_general_auth_error_dialog" = "Eroare generală de conectare.";
-
 "editor_login_error_dialog" = "Eroare de conectare.";
 
-"editor_login_failed_dialog" = "Conectare eșuată";
-
-"editor_username_error_dialog" = "Nume de utilizator nevalid";
-
-"editor_place_edited_dialog" = "Ați editat un obiect!";
-
-"editor_login_with_osm" = "Conectați-vă cu OpenStreetMap";
-
 "editor_profile_changes" = "Modificări confirmate";
-
-"editor_profile_unsent_changes" = "Netrimis:";
 
 "editor_focus_map_on_location" = "Trageți de hartă pentru a selecta locația corectă a obiectului.";
 
@@ -1222,13 +788,9 @@
 
 "editor_report_problem_other_title" = "O problemă diferită";
 
-"placepage_report_problem_button" = "Raportați o problemă";
-
 "placepage_add_business_button" = "Adăugare organizație";
 
 "whatsnew_editor_message_1" = "Adăugați locuri noi pe hartă și modificați-le pe cele existente direct din aplicație.";
-
-"whatsnew_editor_message_2" = "* Organic Maps folosește datele comunității OpenStreetMap community.";
 
 "dialog_incorrect_feature_position" = "Schimbare locație";
 
@@ -1236,16 +798,10 @@
 
 "login_to_make_edits_visible" = "Autentificați-vă pentru ca modificările pe care le-ați efectuat să poată fi văzute și de alți utilizatori.";
 
-"no_migration_during_navigation" = "În timpul navigării, actualizarea este interzisă.";
-
 /* Error dialog no space */
 "migration_no_space_message" = "Aveți nevoie de mai mult spațiu ca să descărcați. Vă rugăm să ștergeți toate informațiile inutile.";
 
 "editor_sharing_title" = "Am îmbunătățit hărțile Organic Maps";
-
-"editor_comment_will_be_sent" = "Vom trimite comentariul dumneavoastră cartografilor.";
-
-"editor_unsupported_category_message" = "Ați adăugat o locație pentru care nu avem încă o categorie creată. Aceasta va apărea pe hartă în viitorul apropiat.";
 
 /* Downloaded 10 **of** 20 <- it is that "of" */
 "downloader_of" = "%1$d din %2$d";
@@ -1278,23 +834,9 @@
 
 "editor_operator" = "Operator";
 
-"editor_tag_description" = "Introduceți compania, organizația sau persoana responsabilă de facilități.";
-
-"editor_no_local_edits_title" = "Nu aveți modificări locale";
-
-"editor_no_local_edits_description" = "Acesta arată numărul de modificări sugerate pe hartă care sunt momentan accesibile doar pe dispozitivul dvs.";
-
-"editor_send_to_osm" = "Trimitere la OSM";
-
-"editor_remove" = "Eliminare";
-
-"downloader_my_maps_title" = "Hărțile mele";
-
 "downloader_no_downloaded_maps_title" = "Nu ați descărcat nicio hartă";
 
 "downloader_no_downloaded_maps_message" = "Descărcați hărți pt. a găsi locația și navigați offline.";
-
-"downloader_find_place_hint" = "Căutare oraș sau țară";
 
 /* Error title that appears after certain time without location. */
 "current_location_unknown_title" = "Continuați cu detectarea locației dvs. curente?";
@@ -1321,47 +863,13 @@
 /* iOS Dialog for the case when the location permission is not granted */
 "location_services_disabled_3" = "3. Selectați în timp ce folosiți aplicația";
 
-"placepage_parking_surface" = "Suprafață";
-
-"placepage_parking_multistorey" = "Multi-etajat";
-
-"placepage_parking_underground" = "Subteran";
-
-"placepage_parking_rooftop" = "Pe acoperiș";
-
-"placepage_parking_sheds" = "Garaj";
-
-"placepage_parking_carports" = "Garaje";
-
-"placepage_parking_boxes" = "Garage boxes";
-
-"placepage_parking_pay" = "Cu plată";
-
-"placepage_parking_free" = "Gratuit";
-
-"placepage_parking_interval" = "Interval de plată";
-
-"placepage_entrance_number" = "Nr.";
-
-"placepage_entrance_type" = "Intrare";
-
-"placepage_flat" = "ap.";
-
-"placepage_open_24_7" = "24 / 7";
-
 "meter" = "m";
 
 "kilometer" = "km";
 
-"kilometers_per_hour" = "km/h";
-
 "mile" = "mi";
 
 "foot" = "picior";
-
-"miles_per_hour" = "mph";
-
-"day" = "z";
 
 "hour" = "o";
 
@@ -1381,10 +889,6 @@
 
 "placepage_bookmark_name_hint" = "Nume marcaj";
 
-"placepage_personal_notes_hint" = "Note personale";
-
-"placepage_delete_bookmark_button" = "Ștergere marcaj";
-
 "editor_edits_sent_message" = "Modificările sugerate au fost trimise";
 
 "editor_comment_hint" = "Comentariu…";
@@ -1397,8 +901,6 @@
 
 "editor_remove_place_button" = "Eliminare";
 
-"editor_status_sending" = "Se trimite…";
-
 "editor_place_doesnt_exist" = "Locul nu există";
 
 "text_more_button" = "…mai multe";
@@ -1410,11 +912,7 @@
 
 "error_enter_correct_email" = "Introduceți o adresă de email validă";
 
-"error_enter_correct" = "Introduceți o valoare validă";
-
 "refresh" = "Actualizați";
-
-"last_update" = "Ultima actualizare: %s";
 
 "placepage_add_place_button" = "Adăugați un loc pe hartă";
 
@@ -1426,24 +924,6 @@
 
 "editor_share_to_all_dialog_message_2" = "Vom verifica modificările. Dacă vor apărea întrebări, vă vom contacta prin email.";
 
-"navigation_overview_button" = "rezumat";
-
-"navigation_stop_button" = "stop";
-
-/* Text on an empty bookmark page */
-"bookmarks_empty_title" = "Salvare marcaje";
-
-"bookmarks_empty_message_1" = "Atingeți ★ pentru a salva locurile preferate, pentru un acces rapid.";
-
-"bookmarks_empty_message_2" = "Importare marcaje din Mail și web.";
-
-"bookmarks_empty_message_3" = "check out: %s";
-
-/* Name of the group for booked hotels */
-"bookmarks_group_name" = "Hoteluri rezervate";
-
-"place_page_button_read_descriprion" = "Citiți";
-
 /* iOS dialog for the case when recent track recording is on and the app comes back from background */
 "recent_track_background_dialog_title" = "Dezactivați înregistrarea celui mai recent traseu urmat?";
 
@@ -1451,8 +931,6 @@
 
 /* For sharing via SMS and so on */
 "sharing_call_action_look" = "Aruncați o privire";
-
-"continue_recent_track_background_button" = "Continuare";
 
 "recent_track_background_dialog_message" = "Organic Maps folosește în fundal geo-locația pentru a înregistra cel mai recent traseu urmat.";
 
@@ -1468,33 +946,13 @@
 /* About short text (below logo) */
 "about_description" = "Organic Maps este o aplicație offline esențială când călătoriți. Organic Maps utilizează datele OpenStreeMap și permite editarea acestora.";
 
-/* Text in menu */
-"blog" = "Blog";
-
 "general_settings" = "Setări generale";
-
-"date" = "Data %d";
-
-/* "Report a bug" -> "Generaal Feedback" -> "Something is not working" */
-"something_is_not_working" = "Ceva nu funcționează corect";
 
 /* For the first routing */
 "accept" = "Acceptați";
 
-"accept_and_continue" = "Accept and continue";
-
 /* For the first routing */
 "decline" = "Refuzați";
-
-"install_app" = "Instalați";
-
-"search_no_results_title" = "Nu au fost găsite rezultate";
-
-"search_no_results_message" = "Încercați un termen mai general, micșorați sau resetați filtrul.";
-
-"search_no_results_expand_area_button" = "Micșorare";
-
-"search_no_results_reset_button" = "Resetare filtru";
 
 /* noun */
 "search_in_table" = "Listă";
@@ -1517,8 +975,6 @@
 
 "traffic_update_maps_text" = "Pentru a afişa datele privind traficul, hărțile trebuie actualizate.";
 
-"traffic_outdated" = "Datele privind traficul sunt învechite.";
-
 "big_font" = "Măriți dimensiunea fontului pe hartă";
 
 "traffic_update_app" = "Vă rugăm să actualizaţi Organic Maps";
@@ -1529,17 +985,7 @@
 /* "traffic" as in "road congestion" */
 "traffic_data_unavailable" = "Datele privind traficul nu sunt disponibile";
 
-/* "Translation is no needed, because it's a company name" */
-"uber" = "Uber";
-
-/* Simplified colour scheme for traffic information, fewer colours are used to display traffic jams on the map. The string should be kept as short as possible */
-"pref_traffic_simplified_colors_title" = "Culori trafic simplificate";
-
 "enable_logging" = "Activare jurnalizare";
-
-"offline_place_page_more_information" = "Conectați-vă la internet pentru a primi mai multe informații despre locație.";
-
-"failed_load_information" = "Încărcarea informațiilor a eșuat.";
 
 /* Settings: "Send general feedback" button */
 "feedback_general" = "Feedback general";
@@ -1556,8 +1002,6 @@
 
 "whatsnew_transliteration_title" = "Transcriere în alfabet latin";
 
-"yandex_taxi_title" = "Yandex.Taxi";
-
 "learn_more" = "Mai multe";
 
 "core_exit" = "Ieșire";
@@ -1568,75 +1012,19 @@
 
 "button_exit" = "Ieșire";
 
-"settings_device_memory" = "Memoria dispozitivului";
-
-"settings_card_memory" = "Card";
-
-"settings_storage_available" = "%s disponibil";
-
-"toast_location_permission_denied" = "Permisiune de accesare a locației respinsă";
-
-"button_use" = "Utilizare";
-
 "planning_route_manage_route" = "Administrare traseu";
 
 "button_plan" = "Planificare";
-
-"button_add" = "Adăugare";
 
 "placepage_remove_stop" = "Eliminare";
 
 "planning_route_remove_title" = "Trageți aici pentru a elimina";
 
-"dialog_change_start_point_message" = "Înlocuiți punctul de plecare cu locația curentă?";
-
-"button_replace" = "Înlocuire";
-
 "placepage_add_stop" = "Adăugare oprire";
-
-/* Only ru/en are needed */
-"subtitle_rent" = "Rent";
-
-/* Only ru/en are needed */
-"rub_month" = "RUB/month";
-
-/* Only ru/en are needed */
-"room" = "%s-room apt.";
-
-/* Only ru/en are needed */
-"real_estate" = "Real estate";
-
-"add_my_position" = "Adaugă poziția mea";
-
-"choose_start_point" = "Alege un punct de plecare";
-
-"choose_destination" = "Alege o destinație";
 
 "preloader_viator_button" = "Află mai multe";
 
-"start_from_my_position" = "Începând de la";
-
-"profile_authorization_title" = "Conectare cu";
-
-"profile_authorization_message" = "Conectare rapidă în câteva secunde, fără autentificare și parolă";
-
 "profile_authorization_error" = "Ups, a survenit o eroare. Încercați să vă conectați din nou.";
-
-"service" = "Servicii";
-
-"atmosphere" = "Atmosferă";
-
-"value_for_money" = "Raport calitate/preț";
-
-"experience" = "Experiență";
-
-"assortment" = "Varietate";
-
-"expertise" = "Expertiză";
-
-"equipment" = "Echipamente";
-
-"quality" = "Calitate";
 
 "dialog_error_storage_title" = "Problemă de accesare spațiu de stocare";
 
@@ -1644,17 +1032,7 @@
 
 "setting_emulate_bad_storage" = "Emulare stocare eronată";
 
-"directions_finish" = "Destinație";
-
-"directions_on_foot" = "%s de mers";
-
 "core_entrance" = "Intrare";
-
-"coffee" = "Cafea";
-
-"cleanliness" = "Curățenie";
-
-"crowdedness" = "Aglomerație";
 
 "error_enter_correct_name" = "Introdu un nume corect";
 
@@ -1673,11 +1051,9 @@
 
 "downloader_percent" = "%s (%s din %s)";
 
-"downloader_process" = "Descărcare %s...";
+"downloader_process" = "Descărcare %s…";
 
-"downloader_applying" = "Aplicare %s...";
-
-"dialog_message_transit_not_found_connection" = "Planifică o rută într-o singură rețea de tranzit";
+"downloader_applying" = "Aplicare %s…";
 
 "bookmarks_error_message_share_general" = "Imposibil de distribuit din cauza unei erori a aplicației";
 
@@ -1695,17 +1071,7 @@
 
 "bookmarks_error_message_list_name_already_taken" = "Alegeți un alt nume";
 
-"bookmarks_error_title_list_name_too_long" = "Acest nume este prea lung";
-
-"bookmarks_error_message_list_name_too_long" = "Alegeți un alt nume";
-
-"please_wait" = "Te rog asteapta...";
-
-"phone_number" = "Numar de telefon";
-
-"notification_unsent_reviews_title" = "Aveți mai multe recenzii nesoluționate";
-
-"notification_unsent_reviews_message" = "Vă rugăm să vă conectați pentru a trimite recenzii altor călătorii";
+"please_wait" = "Te rog asteapta…";
 
 "profile" = "Profil OpenStreetMap";
 
@@ -1719,49 +1085,13 @@
 
 "bookmarks_convert_error_message" = "Unele fișiere nu au fost convertite.";
 
-"converting" = "Conversia...";
-
-"wn_reinvented_bookmarks_title" = "Am reinventat marcaje!";
-
-"wn_reinvented_bookmarks_message" = "Aveți posibilitatea să copiați marcajele de rezervă, să creați liste... Este uimitor...";
-
-"bookmarks_restore" = "Restaurați marcajele";
-
-"bookmarks_restore_process" = "Restaurarea...";
-
 "bookmarks_restore_title" = "Restabiliți această versiune?";
 
-"bookmarks_restore_message" = "Marcajele dvs. vor fi restabilite de la %s (%s)";
-
-"bookmarks_restore_empty_title" = "Nu aveți o copie de rezervă";
-
-"bookmarks_restore_empty_message" = "Serverul nu a găsit copii de rezervă create anterior";
-
 "common_check_internet_connection_dialog_title" = "Fără conexiune internet";
-
-"error_server_title" = "Eroare de server";
-
-"error_server_message" = "A apărut o eroare la server, încercați din nou mai târziu";
 
 "error_system_message" = "O eroare necunoscută s-a întamplat";
 
 "restore" = "Restabili";
-
-"bookmarks_page_downloaded" = "Fișierele descărcate";
-
-"bookmarks_page_my" = "Al mele";
-
-"routes_and_bookmarks" = "Rute și tag-uri";
-
-"bookmarks_webview_success_toast" = "Locațiile au fost descărcate cu succes";
-
-"cached_bookmarks_placeholder_title" = "Încărcați locuri noi";
-
-"cached_bookmarks_placeholder_subtitle" = "Faceți clic pe butonul pentru a descărca mii de locuri interesante și rute create de utilizatori Organic Maps. Veți avea nevoie de o conexiune la Internet.";
-
-"downloader_download_routers" = "Descărcați tag-urile";
-
-"bookmarks_groups_cached" = "Listele descărcate";
 
 "subtittle_opt_out" = "Setări de servire";
 
@@ -1769,29 +1099,15 @@
 
 "crash_reports_description" = "Putem folosi datele dvs. pentru a dezvolta și de a îmbunătăți Organic Maps. Modificările vor intra în vigoare după repornirea aplicației.";
 
-"opt_out_help_ios_1" = "Puteți renunța la primirea de publicitate țintă în setările aparatului.";
-
-"opt_out_help_ios_2" = "iOS 9 sau mai sus";
-
-"opt_out_help_ios_3" = "Deschideți Setări → Confidențialitate → Publicitate → „Activați Limitarea trackking”";
-
-"opt_out_help_android" = "Puteți renunța la primirea de publicitate țintă în setările aparatului.\n Android și Google Play Servicii 4.0 și mai sus\n\n Setări de telefon → Google → Publicitate → Dezactivarea personalizării publicității \n sau \n Setări de telefon → Google → un Cont Google → Confidențialitate → Setări pentru anunțuri → Personalizarea publicității";
-
 "privacy_policy" = "Politica de confidențialitate";
 
 "terms_of_use" = "Termeni de utilizare";
-
-"backup_notification_failed" = "Copierea de rezervă a tag-uri lor a fost suspendată. Conectați-vă pentru a activa copierea de rezervă.";
 
 "button_layer_traffic" = "Dopuri";
 
 "button_layer_subway" = "Metrou";
 
 "layers_title" = "Straturile hărții";
-
-"layers_message" = "Conectați straturile pe hartă pentru a afișa rutierele medii, schema de metrou sau alte informații utile";
-
-"button_layer_got_it" = "Clar";
 
 "subway_data_unavailable" = "Harta de metrou nu este disponibilă";
 
@@ -1803,39 +1119,13 @@
 
 "title_error_downloading_bookmarks" = "A apărut o eroare";
 
-"subtitle_error_downloading_bookmarks" = "Tag-urile nu au fost încărcate";
-
-"error_already_downloaded" = "Lista aceasta a fost descărcată deja";
-
 "popular_place" = "Popular";
-
-"download_routes" = "Download routes";
-
-"bookmarks_downloaded_title" = "Bookmarks have been downloaded successfully";
-
-"bookmarks_downloaded_subtitle" = "Press ‘View on map’ to explore new places from the list";
-
-"why_support" = "Pentru ce să susțineți Organic Maps?";
-
-"why_support_item1" = "We respect your privacy: there are zero trackers in the app, and we are open source";
-
-"why_support_item2" = "Voi ne ajutați să îmbunătățim Organic Maps";
-
-"why_support_item3" = "Voi ne ajutați să îmbunătățim hărțile OpenStreetMap.org";
-
-"channels_map_update" = "Actualizarea hărților";
-
-"server_unavailable_title" = "Serverul nu este disponibil";
-
-"sharing_options" = "Setările accesului";
 
 "export_file" = "Exportați fișierul";
 
 "list_settings" = "Elaborarea listei";
 
 "delete_list" = "Ștergerea listei";
-
-"hide_from_map" = "Ascundeți de pe hartă";
 
 "public_access" = "Acces public";
 
@@ -1845,40 +1135,11 @@
 
 "bookmark_category_description_hint" = "Adăugați o descriere (text sau html)";
 
-/* FIXME */
-"bookmarks_public_access" = "bookmarks_public_access";
-
-/* FIXME */
-"bookmarks_link_access" = "bookmarks_link_access";
-
-/* FIXME */
-"bookmarks_private_access" = "bookmarks_private_access";
-
 "not_shared" = "Personal";
-
-"direct_link_progress_text" = "Încărcăm fișierul dumneavoastră…";
-
-"direct_link_success" = "Linkul a fost creat";
-
-"send_a_link_btn" = "Trimiteți linkul";
-
-"upload_error_toast" = "În timpul încărcării fișierului s-a produs o eroare";
 
 "tags_loading_error_subtitle" = "În timpul încărcării tag-urilor s-a produs o eroare, vă rugăm să încercați încă odată";
 
-"unable_upload_errorr_title" = "Încărcarea fișierului nu s-a primit";
-
-"unable_upload_error_subtitle_edited" = "Fișierul a fost editat prin intermediul aplicației web";
-
-"unable_upload_error_subtitle_broken" = "Fișierul a fost deteriorat și nu poate fi încărcat. Vă rugăm, alegeți alt fișier.";
-
-"contact" = "Scrie";
-
-"download_button" = "Descărcați";
-
 "speedcams_alert_title" = "Camere de supraveghere video a vitezei";
-
-"speedcams_alert_subtitle" = "Avertizați despre limitele de viteză";
 
 "speedcam_option_auto" = "Auto";
 
@@ -1886,18 +1147,10 @@
 
 "speedcam_option_never" = "Niciodată";
 
-"bookmark_description_title" = "Descrierea semnului";
-
 "place_description_title" = "Descrierea locului";
 
 /* this text will be shown in application notification preferences opposite checkbox which enable/disable downloader notifications. Devices on Android 8+ are affected. */
 "notification_channel_downloader" = "Încărcarea hărților";
-
-"share_bookmarks_email_body_link" = "Bună ziua!\n\nEtichetele dvs. le puteți descărca de pe linki-ul: %s. Deschideți lista cu ajutorul Organic Maps și primiți plăcere de la călătorie!\n\nDescărcați aplicația: https://omaps.app/get?kmz";
-
-"warning_speedcams_title" = "Navigatorul o să avertizeze despre camerele video în cazul depășirii limitei de viteză cu %d km/h";
-
-"warning_speedcams_subtitle" = "Nu uitați să faceți cunoștință cu regulele de circulație în țara unde călătoriți.";
 
 "speedcams_notice_message" = "Auto - De avertizat despre camerele video de înregistrare a vitezei, dacă există riscul depășirii limitei de viteză\nMereu - De avertizat întotdeauna despre camerele video\nNiciodată - De nu avertizat niciodată despre camerele video";
 
@@ -1913,23 +1166,7 @@
 
 "enable_logging_warning_message" = "Aceasta opțiune se pornește pentru logarea acțiunii în scopul diagnosticării. Aceasta va ajuta echipei să găsească problemele legate de aplicație. Conectați opțiunea numai la solicitarea serviciului de suport Organic Maps.";
 
-"html_error_upload_message_try_again" = "Verificați accesul la rețea și încercați încă o dată";
-
-"html_error_upload_title_try_again" = "Aveți o problemă cu conexiunea dvs. la internet";
-
-"notification_leave_review_v2_android_short_title" = "Lăsați un comentariu și ajutați călătorii!";
-
-"megafon" = "Say goodbye to roaming!";
-
-"notifications_illegal_alert_disable_button" = "Porniți notificarea";
-
 "access_rules_author_only" = "Se editează online";
-
-"privacy_settings_menu" = "Setarea confidențialității";
-
-"unable_upadate_error_title" = "Nu s-a actualizat traseul";
-
-"unable_upadate_error_message" = "Au intervenit erori de actualizare. Verificați modificările și încercați încă o dată";
 
 "driving_options_title" = "Setarea ocolirii";
 
@@ -1951,94 +1188,19 @@
 
 "change_driving_options_btn" = "Setarea ocolirii este activată";
 
-"toll_road" = "Drum cu plată";
-
-"unpaved_road" = "Drum de țară";
-
-"ferry_crossing" = "Trecere cu bac";
-
-"operated_by" = "Se gestionează \"%s\"";
-
 "avoid_toll_roads_placepage" = "De evitat drumurile cu plată";
 
 "avoid_unpaved_roads_placepage" = "De evitat drumurile de țară";
 
 "avoid_ferry_crossing_placepage" = "De evitat trecerile cu bac";
 
-"type.cuisine.uzbek" = "Bucătărie uzbecă";
-
-"trip_start" = "Mergem";
-
-"pick_destination" = "Scop";
-
-"follow_my_position" = "Centrați";
-
-"search_results" = "Rezultatul căutării";
-
-"then_turn" = "După";
-
-"redirect_route_alert" = "Doriți să refaceți traseul?";
-
-"redirect_route_yes" = "Da";
-
-"redirect_route_no" = "Nu";
-
-"trip_finished" = "Ați sosit!";
-
-"keyboard_availability_alert" = "Tastiera nu este accesibilă în timpul deplasării";
-
-"dialog_routing_change_start_carplay" = "Este imposibil de elabora traseul de la punctul de aflare";
-
-"dialog_routing_change_end_carplay" = "Este imposibil de elaborat traseu până la punctul de sosire. Selectați altul";
-
-"dialog_routing_check_gps_carplay" = "Nu este semnal GPS. Mergeți la loc deschis";
-
-"dialog_routing_unable_locate_route_carplay" = "Este imposibil de elaborat un traseu. Selectați alte puncte ale traseului";
-
-"dialog_routing_download_files_carplay" = "Pentru noi trasee, încărcați hărțile lipsa pe dispozitivul dvs.";
-
-"dialog_routing_system_error_carplay" = "Eroare. Restartați aplicația";
-
-"dialog_routing_rebuild_from_current_location_carplay" = "Traseul se va reface de la locul actual al aflării dvs";
-
-"dialog_routing_rebuild_for_vehicle_carplay" = "Traseul va fi modificat cu unul automobilistic";
-
 "ok" = "Ok";
-
-"avoid_unpaved_carplay_1" = "Fără neasfal";
-
-"avoid_unpaved_carplay_2" = "Fără neasfaltat";
-
-"avoid_ferry_carplay_1" = "Fără bacuri";
-
-"avoid_ferry_carplay_2" = "Fără bacuri";
-
-"avoid_tolls_carplay_1" = "Gratis";
-
-"avoid_tolls_carplay_2" = "Gratis";
-
-"speedcams_alert_title_carplay_1" = "Cameră video";
-
-"speedcams_alert_title_carplay_2" = "Info camere";
-
-"download_map_carplay" = "Vă rugăm să descărcați hărțile în aplicația Organic Maps de pe dispozitivul dvs.";
-
-"carplay_roundabout_exit" = "%s ieșire";
 
 /* max. 10 symbols, both iOS and Android */
 "sort" = "Sortați…";
 
 /* Android, title, max 20-22 symbols */
 "sort_bookmarks" = "Sortați inscripțiile";
-
-/* iOS */
-"sort_default" = "Sortați la modul implicit";
-
-"sort_type" = "Sortați după dip";
-
-"sort_distance" = "Sortați după distanță";
-
-"sort_date" = "Sortați după dată";
 
 /* Android */
 "by_default" = "Mod implicit";
@@ -2052,63 +1214,7 @@
 /* Android */
 "by_date" = "După dată";
 
-"week_ago_sorttype" = "O săptămână în urmă";
-
-"month_ago_sorttype" = "O lună în urmă";
-
-"moremonth_ago_sorttype" = "Mai mult de o lună în urmă";
-
-"moreyear_ago_sorttype" = "Mai mult de un an în urmă";
-
-"near_me_sorttype" = "Alături de mine";
-
-"others_sorttype" = "Altele";
-
-"food_places" = "Mâncare";
-
-"tourist_places" = "Locuri faimoase";
-
-"museums" = "Muzeu";
-
-"parks" = "Parcuri";
-
-"swim_places" = "Înot";
-
-"mountains" = "Munți";
-
-"animals" = "Animale";
-
-"hotels" = "Hoteluri";
-
-"buildings" = "Clădiri";
-
-"money" = "Bani";
-
-"shops" = "Magazine";
-
-"parkings" = "Parcări";
-
-"fuel_places" = "Benzinării";
-
-"water" = "Apă";
-
-"medicine" = "Medicină";
-
 "search_in_the_list" = "Căutați în listă";
-
-"view_on_map_bookmarks" = "Pe hartă";
-
-"more_bookmarks" = "Încă…";
-
-"no_items_found" = "Nu a fost găsit nimic";
-
-/* Android, max 18 symbols */
-"bookmarks_edit_list" = "Redactați";
-
-/* Android, max 18 symbols */
-"bookmarks_delete_list" = "Ștergeți lista";
-
-"religious_places" = "Locuri sfinte";
 
 "select_list" = "Alegeți lista";
 
@@ -2118,26 +1224,13 @@
 
 "dialog_pedestrian_route_is_long_message" = "Selectați punctul de început sau de sfârșit al rutei mai aproape de stația de metrou";
 
-/* Failed planning SUBWAY route message in navigation view */
-"routing_planning_error_subway_special" = "Eroare la construirea rutei metroului";
-
 "button_layer_isolines" = "Înălțimi";
-
-"tips_map_layers_title_countour" = "Linii de înălțimi offline pe Organic Maps!";
-
-"tips_map_layers_message_countour" = "Liniile de înălțimi vă vor ajuta să planificați o călătorie în natură și să nu vă pierdeți";
 
 "isolines_activation_error_dialog" = "Pentru a utiliza liniile de înălțimi, actualizați sau descărcați harta zonei dorite";
 
 "isolines_location_error_dialog" = "Liniile de înălțimi pană ce nu sunt disponibile în această regiune";
 
 "elevation_profile_diff_level" = "Nivel de dificultate";
-
-"elevation_profile_diff_level_easy" = "Ușor";
-
-"elevation_profile_diff_level_moderate" = "Mediu";
-
-"elevation_profile_diff_level_hard" = "Dificil";
 
 "elevation_profile_ascent" = "Urcare";
 
@@ -2147,25 +1240,13 @@
 
 "elevation_profile_maxaltitude" = "Înălțime max.";
 
-"elevation_profile_m" = "m";
-
 "elevation_profile_difficulty" = "Dificultate";
 
 "elevation_profile_distance" = "Dist.:";
 
-"elevation_profile_km" = "km";
-
 "elevation_profile_time" = "Timp:";
 
-"elevation_profile_hours" = "ore";
-
-"elevation_profile_minutes" = "min";
-
 "isolines_toast_zooms_1_10" = "Măriți harta pentru a vedea contururile";
-
-"downloader_updating_ios" = "Actualizare";
-
-"downloader_loading_ios" = "Încărcare";
 
 "key_information_title" = "Informații cheie";
 

--- a/iphone/Maps/LocalizedStrings/ro.lproj/Localizable.stringsdict
+++ b/iphone/Maps/LocalizedStrings/ro.lproj/Localizable.stringsdict
@@ -9,21 +9,6 @@
 
 <!-- ********** Strings for downloading map from search **********/ -->
 
-  <key>bookmarks_places</key>
-  <dict>
-    <key>NSStringLocalizedFormatKey</key>
-    <string>%#@value@</string>
-    <key>value</key>
-    <dict>
-      <key>NSStringFormatSpecTypeKey</key>
-      <string>NSStringPluralRuleType</string>
-      <key>NSStringFormatValueTypeKey</key>
-      <string>d</string>
-      <key>other</key>
-      <string>%d semne de carte</string>
-    </dict>
-  </dict>
-
   <key>bookmarks_detect_message</key>
   <dict>
     <key>NSStringLocalizedFormatKey</key>
@@ -38,21 +23,6 @@
       <string>%d fișier a fost găsit. Veți vedea după conversie.</string>
       <key>other</key>
       <string>Au fost găsite %d fișiere. Veți vedea după convertire.</string>
-    </dict>
-  </dict>
-
-  <key>bookmarks_objects</key>
-  <dict>
-    <key>NSStringLocalizedFormatKey</key>
-    <string>%#@value@</string>
-    <key>value</key>
-    <dict>
-      <key>NSStringFormatSpecTypeKey</key>
-      <string>NSStringPluralRuleType</string>
-      <key>NSStringFormatValueTypeKey</key>
-      <string>d</string>
-      <key>other</key>
-      <string>%s obiect</string>
     </dict>
   </dict>
 

--- a/iphone/Maps/LocalizedStrings/ru.lproj/Localizable.strings
+++ b/iphone/Maps/LocalizedStrings/ru.lproj/Localizable.strings
@@ -18,9 +18,6 @@
 /* Button which deletes downloaded country */
 "delete" = "Удалить";
 
-/* Button "do not interrupt download" if user touched actively downloading country */
-"do_nothing" = "Продолжить загрузку";
-
 "download_maps" = "Загрузить карты";
 
 /* Settings/Downloader - info for country when download fails */
@@ -28,9 +25,6 @@
 
 /* Settings/Downloader - info for country which started downloading */
 "downloading" = "Загружается…";
-
-/* Settings/Downloader - size string, only strings different from English should be translated */
-"kb" = "кБ";
 
 /* Choose measurement on first launch alert - choose metric system button */
 "kilometres" = "Километры";
@@ -55,17 +49,11 @@
 /* Update maps later/Buy pro version later button text */
 "later" = "Не сейчас";
 
-/* Don't show some dialog any more */
-"never" = "Не показывать";
-
 /* View and button titles for accessibility */
 "search" = "Поиск";
 
 /* Search box placeholder text */
 "search_map" = "Поиск на карте";
-
-/* Settings/Downloader - info for not downloaded country */
-"touch_to_download" = "Нажмите для загрузки";
 
 /* Settings/Downloader - 3G download warning dialog confirm button */
 "use_cellular_data" = "Да";
@@ -73,20 +61,11 @@
 /* Location services are disabled by user alert - message */
 "location_is_disabled_long_text" = "Геолокация выключена в настройках устройства. Пожалуйста, включите её для удобного использования программы.";
 
-/* Location Services are not available on the device alert - message */
-"device_doesnot_support_location_services" = "Ваше устройство не поддерживает геолокацию";
-
 /* View and button titles for accessibility */
 "zoom_to_country" = "Показать на карте";
 
-/* Button text for the button at the center of the screen when the country is not downloaded */
-"country_status_download" = "Загрузить карту\n(^ ^)";
-
 /* Button text for the button at the center of the screen when the country is not downloaded and the size should not be shown */
 "country_status_download_without_size" = "Загрузить карту";
-
-/* Button text for the button at the center of the screen when the country is not downloaded */
-"country_status_download_without_routing" = "Загрузить карту\nбез маршрутов (^ ^)";
 
 /* Message to display at the center of the screen when the country download has failed */
 "country_status_download_failed" = "Ошибка загрузки";
@@ -96,19 +75,13 @@
 
 "about_menu_title" = "О программе";
 
-"downloaded_touch_to_delete" = "Загружено (%@), нажмите для удаления";
-
 "connection_settings" = "Настройки подключения";
-
-"download_mb_or_kb" = "Загрузить %@";
 
 "close" = "Закрыть";
 
 "unsupported_phone" = "Для работы приложения необходим аппаратно ускоренный OpenGL. К сожалению, ваше устройство не поддерживается.";
 
 "download" = "Загрузить";
-
-"external_storage_is_not_available" = "Загруженные карты недоступны";
 
 "disconnect_usb_cable" = "Отключите USB кабель или вставьте SD-карту";
 
@@ -117,8 +90,6 @@
 "not_enough_memory" = "Недостаточно памяти для запуска программы";
 
 "download_resources" = "Перед началом работы разрешите нам загрузить общую карту мира на ваше устройство.\nЭто потребует %@ данных.";
-
-"getting_position" = "Получаем местоположение";
 
 "download_resources_continue" = "Перейти на карту";
 
@@ -140,23 +111,14 @@
 /* Add New Bookmark Set dialog title */
 "add_new_set" = "Добавить группу";
 
-/* Place Page - Add To Bookmarks button */
-"add_to_bookmarks" = "Сохранить метку";
-
 /* Bookmark Color dialog title */
 "bookmark_color" = "Цвет метки";
 
 /* Add Bookmark Set dialog - hint when set name is empty */
 "bookmark_set_name" = "Название группы";
 
-/* Bookmark Sets dialog title */
-"bookmark_sets" = "Группы меток";
-
 /* Bookmarks - dialog title */
 "bookmarks" = "Метки";
-
-/* Add bookmark dialog - bookmark color */
-"color" = "Цвет";
 
 /* Default bookmarks set name */
 "core_my_places" = "Мои Метки";
@@ -167,14 +129,8 @@
 /* Editor title above street and house number */
 "address" = "Адрес";
 
-/* Place Page - Remove Pin button */
-"remove_pin" = "Удалить метку";
-
 /* Add bookmark dialog - bookmark set, Bookmarks dialog - Bookmark set cell */
 "set" = "Группа";
-
-/* Text hint in Bookmarks dialog when no any bookmarks are added */
-"bookmarks_usage_hint" = "У вас пока нет меток.\nВыберите любое место на карте, чтобы добавить его.\nТакже метки можно импортировать из Organic Maps либо других приложений и сайтов. Для этого откройте KML/KMZ файл из Dropbox, почты или по веб-ссылке.";
 
 /* Settings button in system menu */
 "settings" = "Настройки";
@@ -191,26 +147,11 @@
 /* Ask to wait user several minutes (some long process in modal dialog). */
 "wait_several_minutes" = "Это может занять несколько минут.\nПожалуйста, подождите…";
 
-/* Show bookmarks from this category on a map or not */
-"visible" = "Показывать на карте";
-
-/* Toast which is displayed when GPS has been deactivated */
-"gps_is_disabled_long_text" = "GPS-позиционирование выключено. Пожалуйста, включите его в настройках для удобного использования программы.";
-
 /* Measurement units title in settings activity */
 "measurement_units" = "Единицы измерения";
 
 /* Detailed description of Measurement Units settings button */
 "measurement_units_summary" = "Использовать километры или мили";
-
-/* Do search in all sources */
-"search_mode_all" = "Везде";
-
-/* Do search near my position only */
-"search_mode_nearme" = "Возле меня";
-
-/* Do search in current viewport only */
-"search_mode_viewport" = "На экране";
 
 /* Search category for cafes, bars, restaurants */
 "eat" = "Где поесть";
@@ -266,14 +207,8 @@
 /* Search category */
 "police" = "Полиция";
 
-/* String in search result list, when nothing found */
-"no_search_results_found" = "Нет результатов поиска";
-
 /* Notes field in Bookmarks view */
 "description" = "Примечание";
-
-/* Button text */
-"share_by_email" = "Послать по email";
 
 /* Email Subject when sharing bookmarks category */
 "share_bookmarks_email_subject" = "С вами поделились метками Organic Maps";
@@ -295,26 +230,11 @@
 /* Warning message when doing search around current position */
 "unknown_current_position" = "Ваше местоположение еще не определено";
 
-/* Warning message when location country isn't downloaded during search (see also download_location_map_proposal). */
-"download_location_country" = "Скачайте страну вашего текущего местоположения (%@)";
-
-/* Warning message when viewport country isn't downloaded during search */
-"download_viewport_country_to_search" = "Скачайте страну, на которой вы ищете (%@)";
-
 /* Alert message that we can't run Map Storage settings due to some reasons. */
 "cant_change_this_setting" = "Извините, настройки места хранения карт сейчас недоступны.";
 
 /* Alert message that downloading is in progress. */
 "downloading_is_active" = "Идет процесс загрузки карт.";
-
-/* Message that will be shown in alert view, when we ask user to leave review on App Store */
-"appStore_message" = "Надеемся, вам нравится пользоваться Organic Maps! Если так, то оставьте, пожалуйста, отзыв в магазине приложений. Это занимает меньше минуты, но может нам реально помочь. Спасибо вам за поддержку!";
-
-/* No, thanks */
-"no_thanks" = "Нет, спасибо";
-
-/* Share one specific bookmark using SMS, %1$@ contains om:// and %2$@ https://omaps.app link. @NOTE non-ascii symbols in the link will result in max 70 characters SMS instead of 140. */
-"bookmark_share_sms" = "Моя метка на карте. Жми %1$@ или %2$@";
 
 /* Share my position using SMS, %1$@ contains om:// and %2$@ https://omaps.app link WITHOUT NAME. @NOTE non-ascii symbols in the link will result in max 70 characters SMS instead of 140. */
 "my_position_share_sms" = "Смотри где я сейчас. Жми %1$@ или %2$@";
@@ -328,23 +248,11 @@
 /* Share my position using EMail, %1$@ is om:// and %2$@ is https://omaps.app link WITHOUT NAME */
 "my_position_share_email" = "Привет!\n\nЯ сейчас здесь: %1$@. Чтобы увидеть это место на карте Organic Maps, открой эту ссылку %2$@ или эту %3$@\n\nСпасибо.";
 
-/* Android share by Message/SMS button text (including SMS) */
-"share_by_message" = "Отправить сообщением";
-
 /* Share button text which opens menu with more buttons, like Message, EMail, Facebook etc. */
 "share" = "Поделиться";
 
-/* iOS share by Message button text (including SMS) */
-"message" = "Сообщение";
-
 /* Share by email button text, also used in editor. */
 "email" = "Email";
-
-/* Copy Link */
-"copy_link" = "Скопировать ссылку";
-
-/* Text for the button that returns to caller application */
-"more_info" = "Подробнее";
 
 /* Text for message when used successfully copied something */
 "copied_to_clipboard" = "Скопировано в буфер обмена: %1$@";
@@ -354,15 +262,6 @@
 
 /* Used for bookmark editing */
 "done" = "Готово";
-
-/* Summary for preferences in MWM */
-"yopme_pref_summary" = "Выберите настройки второго экрана";
-
-/* Title for yopme preferences in MWM */
-"yopme_pref_title" = "Настройки второго экрана";
-
-/* Hint for upper-right icon p2b */
-"show_on_backscreen" = "Показать на втором экране";
 
 /* Prints version number in About dialog */
 "version" = "Версия: %@";
@@ -381,19 +280,11 @@
 
 "share_my_location" = "Поделиться местоположением";
 
-"menu_search" = "Поиск";
-
 /* Settings general group in settings screen */
 "prefs_group_general" = "Общие настройки";
 
 /* Settings information group in settings screen */
 "prefs_group_information" = "Информация";
-
-/* Settings screen: "Map" category title */
-"prefs_group_map" = "Карта";
-
-/* Settings screen: "Miscellaneous" category title */
-"prefs_group_misc" = "Прочее";
 
 "prefs_group_route" = "Навигация";
 
@@ -419,9 +310,6 @@
 /* Settings «Map» category: «3D buildings» title */
 "pref_map_3d_buildings_title" = "3D здания";
 
-/* Settings «Map» category: «3D buildings» summary */
-"pref_map_3d_buildings_subtitle" = "Увеличивает расход батареи";
-
 /* Settings «Route» category: «Tts enabled» title */
 "pref_tts_enable_title" = "Голосовые инструкции";
 
@@ -433,8 +321,6 @@
 
 /* Title for "Other" section in TTS settings. */
 "pref_tts_other_section_title" = "Другой";
-
-"pref_tts_how_to_set_up_voice" = "Как настроить голос";
 
 /* Settings «Map» category: «Record track» title */
 "pref_track_record_title" = "Недавний путь";
@@ -455,56 +341,7 @@
 
 "recent_track_help_text" = "Эта функция позволяет записывать пройденный путь за определенный период времени и видеть его на карте. Внимание: активация этой функции может привести к повышенному расходу батареи. Записанный трек будет удален с карты по истечении этого срока.";
 
-"pref_track_ios_caption" = "История пути покажет недавно пройденный маршрут.";
-
-"pref_track_ios_subcaption" = "Выберите длительность записи истории.";
-
-"placepage_distance" = "Расстояние";
-
-"placepage_coordinates" = "Координаты";
-
-"placepage_unsorted" = "Без категории";
-
 "search_show_on_map" = "Посмотреть на карте";
-
-/* Used to warn user when fixing KitKat issue */
-"bookmark_move_fail" = "Для оптимизации хранения данных нам нужно переместить метки во внутреннюю память, но там сейчас нет свободного места. Пожалуйста, освободите место, иначе метки вам будут недоступны.";
-
-/* Used in More Apps menu */
-"free" = "Бесплатно";
-
-/* Used in More Apps menu */
-"buy" = "Купить";
-
-/* 1st search button-like result */
-"search_on_map" = "Искать на карте";
-
-/* toast with an error */
-"no_route_found" = "Маршрут не найден";
-
-/* route title */
-"route" = "Маршрут";
-
-/* category title */
-"routes" = "Маршруты";
-
-/* text of notification */
-"download_map_notification" = "Скачайте карту места, где вы находитесь";
-
-/* text of notification */
-"pro_version_is_free_today" = "Полная версия Organic Maps сегодня бесплатна! Скачай сейчас и расскажи друзьям.";
-
-/* Dialog for transferring maps from lite to pro. */
-"move_lite_maps_to_pro" = "Мы переносим загруженные карты из Organic Maps Lite в Organic Maps. Это может занять несколько минут.";
-
-/* Message to display when maps moved. */
-"move_lite_maps_to_pro_ok" = "Ваши карты успешно перенесены в Organic Maps.";
-
-/* Message to display when maps move failed. */
-"move_lite_maps_to_pro_failed" = "При переносе карт возникла ошибка. Пожалуйста, удалите Organic Maps Lite и загрузите карты заново.";
-
-/* Text in menu */
-"settings_and_more" = "Настройки и другое";
 
 /* Text in menu */
 "website" = "Вебсайт";
@@ -527,14 +364,8 @@
 /* Text in menu */
 "openstreetmap" = "OpenStreetMap";
 
-/* Text in menu */
-"contact_us" = "Свяжитесь с нами";
-
 /* Settings: Send feedback button and dialog title */
 "feedback" = "Связаться с нами";
-
-/* Text in menu */
-"subscribe_to_news" = "Подписаться на новости";
 
 /* Text in menu */
 "rate_the_app" = "Оценить приложение";
@@ -548,15 +379,6 @@
 /* Text in menu */
 "report_a_bug" = "Сообщить о проблеме";
 
-/* Email subject */
-"subscribe_me_subject" = "Подпишите меня на email-рассылку Organic Maps";
-
-/* Email body */
-"subscribe_me_body" = "Я хочу первым узнавать обо всех новостях, обновлениях приложения и акциях. Я могу отписаться от рассылки в любой момент.";
-
-/* About text */
-"about_text" = "Organic Maps предлагает карты всех городов, всех стран мира, которые работают без подключения к интернету. Путешествуйте с уверенностью: где бы вы ни находились, Organic Maps помогут решить любую вашу проблему - помогут определить ваше местоположение, найти ресторан, отель, заправку, банк, туалет и т.д.\n\nМы постоянно работаем над добавлением новых функций, поэтому если у вас есть идеи или предложения по улучшению Organic Maps, пишите нам. Если у вас возникла проблема с приложением, сообщите нам, пожалуйста, о ней. Наш емэйл support@organicmaps.app. Мы отвечаем на все письма! Если вам нравится приложение и вы хотите поддержать нас, есть несколько простых и абсолютно бесплатных способов:\n\n- оставьте отзыв в вашем магазине приложений\n- подпишитесь на наши новости на Facebook странице http://www.facebook.com/OrganicMaps\n- или просто расскажите о Organic Maps своей маме, друзьям и коллегам :)\n\nСпасибо за вашу поддержку!\n\nP.S. В приложении мы используем картографические данные проекта OpenStreetMap, который работает по принципу Википедии, давая возможность пользователям со всего мира создавать и редактировать карты. Если вы заметили, что на карте что-то не соответствует действительности либо отсутствует, вы можете откорректировать это прямо на сайте https://www.openstreetmap.org, и эти исправления появятся во время следующего обновления Organic Maps.";
-
 /* Alert text */
 "email_error_body" = "Почтовый клиент не настроен. Настройте его или используйте другие способы для связи. Наш адрес - %@.";
 
@@ -569,12 +391,6 @@
 /* Search category */
 "wifi" = "WiFi";
 
-/* Update map suggestion */
-"routing_map_outdated" = "Пожалуйста, обновите карту для того, чтобы проложить маршрут.";
-
-/* Update maps suggestion */
-"routing_update_maps" = "В новой версии Organic Maps вы сможете строить маршруты от текущего местоположения до точки назначения. Чтобы воспользоваться этой функцией, обновите, пожалуйста, карты.";
-
 /* Update all button text */
 "downloader_update_all_button" = "Обновить все";
 
@@ -583,9 +399,6 @@
 
 /* Downloaded maps category */
 "downloader_downloaded_subtitle" = "Загруженные";
-
-/* Downloaded maps category */
-"downloader_available_maps" = "Доступные";
 
 /* Country queued for download */
 "downloader_queued" = "В очереди";
@@ -598,17 +411,6 @@
 
 "downloader_downloading" = "Загружается:";
 
-"downloader_search_results" = "Найдено";
-
-/* Disclaimer message */
-"routing_disclaimer" = "Используя маршруты в приложении Organic Maps, пожалуйста, учитывайте следующее:\n\n  - Предлагаемые маршруты могут рассматриваться только в качестве рекомендации.\n - Дорожная обстановка, правила дорожного движения, знаки являются более приоритетными по сравнению с советами навигационной программы.\n - Карта может быть неточной или неактуальной, а предложенный маршрут не самым оптимальным.\n\n  Будьте внимательны на дорогах и берегите себя!";
-
-/* Outdated maps category */
-"downloader_outdated_maps" = "Неактуальные";
-
-/* Up to date maps category */
-"downloader_uptodate_maps" = "Обновленные";
-
 /* Status of outdated country in the list */
 "downloader_status_outdated" = "Обновить";
 
@@ -618,49 +420,14 @@
 /* Displayed in a dialog that appears when a user tries to delete a map while the app is in the follow route mode */
 "downloader_delete_map_while_routing_dialog" = "Чтобы удалить карту, пожалуйста, остановите навигацию.";
 
-/* Show when user try build route, but we don't know where he */
-"routing_failed_unknown_my_position" = "Невозможно проложить маршрут. Не определено текущее местоположение.";
-
-/* Show if use has not routing file, or InconsistentMWMandRoute */
-"routing_failed_has_no_routing_file" = "Для построения маршрута необходимы дополнительные данные. Перейти к загрузке?";
-
-/* StartPointNotFound */
-"routing_failed_start_point_not_found" = "Невозможно проложить маршрут. Нет дорог рядом с пунктом отправления.";
-
-/* EndPointNotFound */
-"routing_failed_dst_point_not_found" = "Невозможно проложить маршрут. Нет дорог рядом с пунктом назначения.";
-
 /* PointsInDifferentMWM */
 "routing_failed_cross_mwm_building" = "Маршрут может быть проложен только внутри карты одного региона.";
-
-/* RouteNotFound */
-"routing_failed_route_not_found" = "Невозможно проложить маршрут между выбранными точками. Пожалуйста, измените начало или конец маршрута.";
-
-/* InternalError */
-"routing_failed_internal_error" = "Внутренняя ошибка. Пожалуйста, удалите карту и скачайте её еще раз. Если это не помогло, напишите нам на support@organicmaps.app";
-
-/* Context menu item for downloader. */
-"downloader_download_map_and_routing" = "Загрузить карту + маршруты";
-
-/* Context menu item for downloader. */
-"downloader_download_routing" = "Загрузить маршруты";
-
-/* Context menu item for downloader. */
-"downloader_delete_routing" = "Удалить маршруты";
 
 /* Context menu item for downloader. */
 "downloader_download_map" = "Загрузить карту";
 
-"downloader_download_map_no_routing" = "Загрузить карту без маршрутов";
-
-/* Button for routing. */
-"routing_go" = "Поехали!";
-
 /* Item status in downloader. */
 "downloader_retry" = "Повторить";
-
-/* Item in context menu. */
-"downloader_map_and_routing" = "Карта + Маршруты";
 
 /* Item in context menu. */
 "downloader_delete_map" = "Удалить карту";
@@ -668,29 +435,11 @@
 /* Item in context menu. */
 "downloader_update_map" = "Обновить карту";
 
-/* Item in context menu. */
-"downloader_update_map_and_routing" = "Обновить карту + Маршруты";
-
-/* Item in context menu. */
-"downloader_map_only" = "Только карта";
-
-/* Toolbar title */
-"toolbar_application_menu" = "Меню приложения";
-
 /* Preference text */
 "pref_use_google_play" = "Использовать Google Play Services для определения позиции";
 
 /* Text for rating dialog */
 "rating_just_rated" = "Я только что оценил Organic Maps";
-
-/* Text for rating dialog */
-"rating_user_since" = "Я пользуюсь Organic Maps c %@";
-
-/* Text for rating dialog */
-"rating_do_like_maps" = "Нравится приложение?";
-
-/* Text for rating dialog */
-"rating_tap_star" = "Оцените Organic Maps.";
 
 /* Text for rating dialog */
 "rating_thanks" = "Спасибо!";
@@ -701,23 +450,8 @@
 /* Text for rating dialog */
 "rating_send_feedback" = "Напишите нам";
 
-/* Text for g+ dialog */
-"rating_google_plus" = "Нажмите g+, чтобы рассказать друзьям о приложении";
-
 /* Text for routing error dialog */
 "routing_download_maps_along" = "Загрузите все карты по пути следования";
-
-/* Text for routing error dialog */
-"routing_download_map" = "Загрузите карту";
-
-/* Text for routing error dialog */
-"routing_download_map_and_routing" = "Загрузите карту и маршруты, чтобы получить доступ ко всем возможностям приложения.";
-
-/* Text for routing error dialog */
-"routing_get_routing_data" = "Загрузите маршруты";
-
-/* Text for routing error dialog */
-"routing_get_additional_data" = "Загрузите данные для построения маршрутов";
 
 /* Text for routing error dialog */
 "routing_requires_all_map" = "Для создания маршрута необходимо загрузить и обновить все карты на пути следования.";
@@ -725,50 +459,15 @@
 /* Text for routing error dialog */
 "routing_not_enough_space" = "Недостаточно места";
 
-/* Text for routing error dialog */
-"routing_download_more_than_avail" = "Необходимо загрузить %@ МБ, но есть место только для %@ МБ";
-
-/* Text for routing error dialog */
-"routing_download_roaming" = "Будет загружено %@ MB с использованием сотовой связи (мобильный интернет). В зависимости от тарифного плана оператора это может повлечь списание значительной суммы с телефонного счета";
-
 /* bookmark button text */
 "bookmark" = "метка";
-
-/* map is not downloaded */
-"not_found_map" = "Карта вашего местоположения не загружена";
 
 /* location service disabled */
 "enable_location_services" = "Пожалуйста, включите геолокацию";
 
-/* download map */
-"download_map" = "Скачайте карту места, где вы находитесь";
-
-/* download map on iPhone */
-"download_map_iphone" = "Скачайте на вашем iPhone карту места, где вы находитесь";
-
-/* clear pin */
-"nearby" = "поблизости";
-
-/* clear pin */
-"clear_pin" = "убрать метку";
-
-/* location is undefined */
-"undefined_location" = "Не определено текущее местоположение.";
-
-/* download country of your location */
-"download_country" = "Скачайте страну вашего местоположения";
-
-/* download failed */
-"download_failed" = "Не удалось загрузить";
-
-/* get the map */
-"get_the_map" = "Загрузить карту";
-
 "save" = "Сохранить";
 
 "edit_description_hint" = "Ваше описание (текст или html)";
-
-"new_group" = "новая группа";
 
 "create" = "создать";
 
@@ -795,30 +494,6 @@
 
 /* pink color */
 "pink" = "Розовый";
-
-/* deep purple color */
-"deep_purple" = "Тёмно-пурпурный";
-
-/* light blue color */
-"light_blue" = "Голубой";
-
-/* cyan color */
-"cyan" = "Сине-зелёный";
-
-/* teal color */
-"teal" = "Изумрудный";
-
-/* lime color */
-"lime" = "Лайм";
-
-/* deep orange color */
-"deep_orange" = "Тёмно-оранжевый";
-
-/* gray color */
-"gray" = "Серый";
-
-/* blue gray color */
-"blue_gray" = "Серо-голубой";
 
 /* Wi-Fi available */
 "WiFi_available" = "Есть";
@@ -848,13 +523,9 @@
 
 "dialog_routing_location_unknown_turn_on" = "Текущая геопозиция не определена. Для построения маршрута включите режим определения геопозиции.";
 
-"dialog_routing_location_unknown" = "Текущая геопозиция не определена.";
-
 "dialog_routing_download_files" = "Загрузите необходимые файлы";
 
 "dialog_routing_download_and_update_all" = "Для построения маршрута загрузите и обновите все карты и файлы маршрутов по пути следования.";
-
-"dialog_routing_routes_size" = "Файлы маршрутов";
 
 "dialog_routing_unable_locate_route" = "Маршрут не найден";
 
@@ -884,21 +555,11 @@
 
 "dialog_routing_try_again" = "Попробуйте снова";
 
-"dialog_routing_send_error" = "Сообщить об ошибке";
-
-"dialog_routing_if_get_cross_route" = "Построить более оптимальный маршрут с пересечением границы карты?";
-
-"dialog_routing_cross_route_is_optimal" = "Маршрут с пересечением границы карты более оптимальный.";
-
 "not_now" = "Не сейчас";
-
-"dialog_routing_build_route" = "Построить";
 
 "dialog_routing_download_and_build_cross_route" = "Загрузить карту и построить более оптимальный маршрут с пересечением границы карты?";
 
 "dialog_routing_download_cross_route" = "Для построения более оптимального маршрута с пересечением границы требуется загрузить карту.";
-
-"dialog_routing_cross_route_always" = "Всегда пересекать эту границу";
 
 
 /********** Strings for downloading map from search **********/
@@ -906,8 +567,6 @@
 "search_without_internet_advertisement" = "Для поиска мест и построения маршрутов скачайте карту, и интернет вам больше не понадобится.";
 
 "search_select_map" = "Выбрать карту";
-
-"search_select_other_map" = "Выбрать другую карту";
 
 /* «Show» context menu */
 "show" = "Показать";
@@ -918,17 +577,11 @@
 /* «Rename» context menu */
 "rename" = "Переименовать";
 
-/* Bottom sheet: expand button (should be short) */
-"bottom_sheet_more" = "Ещё…";
-
 /* Failed planning route message in navigation view */
 "routing_planning_error" = "Ошибка построения маршрута";
 
 /* Arrive routing message in navigation view */
 "routing_arrive" = "Прибытие в %s";
-
-/* Text for routing::RouterResultCode::FileTooOld dialog. */
-"dialog_routing_download_and_update_maps" = "Для построения маршрута загрузите и обновите все карты по пути следования.";
 
 "rate_alert_title" = "Нравится приложение?";
 
@@ -944,19 +597,11 @@
 
 "history" = "История";
 
-"next_turn_then" = "Далее";
-
 "closed" = "Закрыто";
-
-"back_to" = "Назад к %@";
 
 "search_not_found" = "К сожалению, мы ничего не нашли.";
 
 "search_not_found_query" = "Попробуйте изменить условия поиска.";
-
-"search_not_found_map" = "Убедитесь, что карта области поиска загружена.";
-
-"search_not_found_location" = "Скачайте карту текущего местоположения.";
 
 "search_history_title" = "История поиска";
 
@@ -964,23 +609,12 @@
 
 "clear_search" = "Очистить историю поиска";
 
-/* Title for settings to enable/disable showcase menu button */
-"showcase_settings_title" = "Показывать предложения";
-
 /* Place Page link to Wikipedia article (if map object has it). */
 "read_in_wikipedia" = "Wikipedia";
 
-"p2p_route_planning" = "Планирование маршрута";
-
 "p2p_your_location" = "Ваше местоположение";
 
-"p2p_from" = "Пункт отправления";
-
-"p2p_to" = "Пункт назначения";
-
 "p2p_start" = "Начать";
-
-"p2p_planning" = "Планируем…";
 
 "p2p_from_here" = "Отсюда";
 
@@ -1018,15 +652,9 @@
 
 "editor_correct_mistake" = "Исправьте ошибку";
 
-"editor_correct_mistake_message" = "При редактировании времени работы вы допустили ошибку. Исправьте её или переключитесь в простой режим.";
-
 "editor_add_select_location" = "Местоположение";
 
 "editor_done_dialog_1" = "Вы изменили карту мира. Не скрывайте это, расскажите друзьям и редактируйте вместе.";
-
-"editor_done_dialog_2" = "Вы улучшили карту уже два раза. Вы теперь %d в рейтинге редакторов карты. Расскажите друзьям.";
-
-"editor_done_dialog_3" = "Вы улучшили карту, расскажите об этом друзьям и редактируйте карту вместе.";
 
 "share_with_friends" = "Поделиться с друзьями";
 
@@ -1044,20 +672,7 @@
 
 "editor_report_problem_duplicate_place_title" = "Повторяющееся место";
 
-"first_launch_congrats_title" = "Organic Maps готов к работе";
-
-"first_launch_congrats_text" = "Пользуйтесь поиском и навигацией по всему миру без интернета и бесплатно.";
-
-"migrate_title" = "Важно!";
-
-/* Android uses image instead of text. */
-"download_all" = "Загрузить все";
-
-"delete_all" = "Удалить все";
-
 "autodownload" = "Автоматическая загрузка";
-
-"disable_autodownload" = "Запретить автозагрузку";
 
 /* Place Page opening hours text */
 "closed_now" = "Сейчас закрыто";
@@ -1072,10 +687,6 @@
 "day_off" = "Закрыто";
 
 "today" = "Сегодня";
-
-"sunrise_to_sunset" = "От рассвета до заката";
-
-"sunset_to_sunrise" = "От заката до рассвета";
 
 "add_opening_hours" = "Добавить время работы";
 
@@ -1095,45 +706,18 @@
 
 "forgot_password" = "Забыли пароль?";
 
-/* Forgot Password dialog title */
-"restore_password" = "Восстановление пароля";
-
-"enter_email_address_to_reset_password" = "Введите почтовый ящик, который вы использовали для регистрации, и мы вышлем на него ссылку для сброса пароля.";
-
-"reset_password" = "Cбросить пароль";
-
-"username" = "Имя пользователя";
-
 "osm_account" = "OSM Аккаунт";
 
 "logout" = "Выйти";
 
-"login_and_edit_map_motivation_message" = "Авторизуйтесь и редактируйте информацию об объектах на карте. А мы сделаем её доступной для миллионов пользователей. Улучшим мир вместе!";
-
 /* Information text: "Last upload 11.01.2016" */
 "last_upload" = "Последняя отправка";
 
-/* Motivates user to login/register, title above login buttons. */
-"you_have_edited_your_first_object" = "Вы отредактировали свой первый объект!";
-
 "thank_you" = "Спасибо";
-
-"login_with_google" = "Войти через Google";
-
-"login_with_openstreetmap" = "Войти через www.openstreetmap.org";
 
 "edit_place" = "Редактировать место";
 
 "place_name" = "Название";
-
-/* title above languages list cells in the editor, below editable name text field. */
-"other_languages" = "Другие языки";
-
-/* small button to open list with names in different languages */
-"show_more" = "Показать больше";
-
-/* small button to close list with names in different languages */
-"show_less" = "Показать меньше";
 
 "add_language" = "Добавить язык";
 
@@ -1164,8 +748,6 @@
 
 "please_note" = "Обратите внимание";
 
-"common_no_wifi_dialog" = "Нет WiFi соединения. Вы хотите продолжить работу через мобильный интернет?";
-
 "downloader_delete_map_dialog" = "Вместе с картой удалятся и внесенные вами правки на этой карте.";
 
 "downloader_update_maps" = "Обновите карты";
@@ -1173,10 +755,6 @@
 "downloader_mwm_migration_dialog" = "Для построения маршрутов необходимо обновить все карты и построить маршрут заново.";
 
 "downloader_search_field_hint" = "Найти карту";
-
-"migration_update_all_button" = "Обновить все карты";
-
-"migration_delete_all_download_current_button" = "Скачать текущую и удалить все старые карты";
 
 "migration_download_error_dialog" = "Ошибка загрузки";
 
@@ -1186,21 +764,9 @@
 
 "downloader_no_space_message" = "Удалите ненужные данные";
 
-"editor_general_auth_error_dialog" = "Общая ошибка авторизации.";
-
 "editor_login_error_dialog" = "Произошла ошибка при авторизации.";
 
-"editor_login_failed_dialog" = "Войти не удалось";
-
-"editor_username_error_dialog" = "Неверное имя пользователя";
-
-"editor_place_edited_dialog" = "Вы отредактировали объект!";
-
-"editor_login_with_osm" = "Войти через OpenStreetMap";
-
 "editor_profile_changes" = "Учтённые правки";
-
-"editor_profile_unsent_changes" = "Не отправлено:";
 
 "editor_focus_map_on_location" = "Потяните карту, чтобы выбрать правильное местоположение объекта.";
 
@@ -1222,13 +788,9 @@
 
 "editor_report_problem_other_title" = "Другая проблема";
 
-"placepage_report_problem_button" = "Сообщить о проблеме";
-
 "placepage_add_business_button" = "Добавить организацию";
 
 "whatsnew_editor_message_1" = "Добавляйте новые объекты и редактируйте старые прямо из приложения.";
-
-"whatsnew_editor_message_2" = "* Organic Maps использует данные открытых карт сообщества OpenStreetMap.";
 
 "dialog_incorrect_feature_position" = "Измените местоположение";
 
@@ -1236,16 +798,10 @@
 
 "login_to_make_edits_visible" = "Войдите, чтобы ваши изменения увидели другие пользователи.";
 
-"no_migration_during_navigation" = "Во время навигации обновление запрещено.";
-
 /* Error dialog no space */
 "migration_no_space_message" = "Для загрузки требуется больше свободного места. Пожалуйста, удалите ненужные данные.";
 
 "editor_sharing_title" = "Я улучшил карты Organic Maps";
-
-"editor_comment_will_be_sent" = "Мы обязательно отправим ваш комментарий картографам.";
-
-"editor_unsupported_category_message" = "Вы добавили объект, категорию которого мы пока не поддерживаем. В будущем он появится на карте.";
 
 /* Downloaded 10 **of** 20 <- it is that "of" */
 "downloader_of" = "%1$d из %2$d";
@@ -1278,23 +834,9 @@
 
 "editor_operator" = "Владелец";
 
-"editor_tag_description" = "Укажите компанию, организацию или лицо, которое отвечает за работоспособность объекта.";
-
-"editor_no_local_edits_title" = "У вас пока нет локальных правок";
-
-"editor_no_local_edits_description" = "Здесь отображается количество предложенных вами изменений на карте, которые доступны пока только на вашем устройстве.";
-
-"editor_send_to_osm" = "Отправить в OSM";
-
-"editor_remove" = "Удалить";
-
-"downloader_my_maps_title" = "Мои карты";
-
 "downloader_no_downloaded_maps_title" = "У вас нет загруженных карт";
 
 "downloader_no_downloaded_maps_message" = "Загрузите необходимые карты, чтобы находить места и пользоваться навигацией без интернета.";
-
-"downloader_find_place_hint" = "Найти город или страну";
 
 /* Error title that appears after certain time without location. */
 "current_location_unknown_title" = "Продолжить поиск местоположения?";
@@ -1321,47 +863,13 @@
 /* iOS Dialog for the case when the location permission is not granted */
 "location_services_disabled_3" = "3. Выберите «При использовании программы»";
 
-"placepage_parking_surface" = "Открытая парковка";
-
-"placepage_parking_multistorey" = "Многоэтажная наземная парковка";
-
-"placepage_parking_underground" = "Подземная парковка";
-
-"placepage_parking_rooftop" = "Парковка на крыше здания";
-
-"placepage_parking_sheds" = "Частное легкое укрытие для автомобилей";
-
-"placepage_parking_carports" = "Капитальный навес";
-
-"placepage_parking_boxes" = "Гаражный бокс";
-
-"placepage_parking_pay" = "Платная";
-
-"placepage_parking_free" = "Бесплатная";
-
-"placepage_parking_interval" = "Переменно платная";
-
-"placepage_entrance_number" = "№";
-
-"placepage_entrance_type" = "Подъезд";
-
-"placepage_flat" = "кв.";
-
-"placepage_open_24_7" = "Круглосуточно";
-
 "meter" = "м";
 
 "kilometer" = "км";
 
-"kilometers_per_hour" = "км/ч";
-
 "mile" = "ми";
 
 "foot" = "фут";
-
-"miles_per_hour" = "ми/ч";
-
-"day" = "д";
 
 "hour" = "ч";
 
@@ -1381,10 +889,6 @@
 
 "placepage_bookmark_name_hint" = "Название метки";
 
-"placepage_personal_notes_hint" = "Примечание";
-
-"placepage_delete_bookmark_button" = "Удалить метку";
-
 "editor_edits_sent_message" = "Предложенные вами изменения отправлены";
 
 "editor_comment_hint" = "Коментарий…";
@@ -1397,8 +901,6 @@
 
 "editor_remove_place_button" = "Удалить";
 
-"editor_status_sending" = "Отправка…";
-
 "editor_place_doesnt_exist" = "Места не существует";
 
 "text_more_button" = "…ещё";
@@ -1410,11 +912,7 @@
 
 "error_enter_correct_email" = "Введите корректный email";
 
-"error_enter_correct" = "Введите корректное значение";
-
 "refresh" = "Обновить";
-
-"last_update" = "Последнее обновление: %s";
 
 "placepage_add_place_button" = "Добавить место на карту";
 
@@ -1426,24 +924,6 @@
 
 "editor_share_to_all_dialog_message_2" = "Если при проверке изменений возникнут вопросы, мы напишем вам на email.";
 
-"navigation_overview_button" = "обзор";
-
-"navigation_stop_button" = "стоп";
-
-/* Text on an empty bookmark page */
-"bookmarks_empty_title" = "Сохраняйте метки";
-
-"bookmarks_empty_message_1" = "Нажмите ★, чтобы сохранить любимые места для быстрого доступа к ним.";
-
-"bookmarks_empty_message_2" = "Импортируйте метки из почты и интернета.";
-
-"bookmarks_empty_message_3" = "выезд: %s";
-
-/* Name of the group for booked hotels */
-"bookmarks_group_name" = "Забронированные отели";
-
-"place_page_button_read_descriprion" = "Прочитать";
-
 /* iOS dialog for the case when recent track recording is on and the app comes back from background */
 "recent_track_background_dialog_title" = "Выключить запись недавно пройденого пути?";
 
@@ -1451,8 +931,6 @@
 
 /* For sharing via SMS and so on */
 "sharing_call_action_look" = "Посмотри";
-
-"continue_recent_track_background_button" = "Продолжить";
 
 "recent_track_background_dialog_message" = "Organic Maps использует вашу геопозицию в фоновом режиме для записи недавно пройденного пути.";
 
@@ -1468,33 +946,13 @@
 /* About short text (below logo) */
 "about_description" = "Organic Maps — незаменимое приложение для путешествий, работающее без подключения к интернету. Organic Maps использует данные OpenStreetMap и позволяет их улучшать.";
 
-/* Text in menu */
-"blog" = "Блог";
-
 "general_settings" = "Общие настройки";
-
-"date" = "Дата %d";
-
-/* "Report a bug" -> "Generaal Feedback" -> "Something is not working" */
-"something_is_not_working" = "Что-то не работает";
 
 /* For the first routing */
 "accept" = "Принять";
 
-"accept_and_continue" = "Принять и продолжить";
-
 /* For the first routing */
 "decline" = "Отклонить";
-
-"install_app" = "Установить";
-
-"search_no_results_title" = "Поиск не дал результатов";
-
-"search_no_results_message" = "Попробуйте задать более общий запрос, уменьшить масштаб карты или сбросить фильтр.";
-
-"search_no_results_expand_area_button" = "Уменьшить масштаб карты";
-
-"search_no_results_reset_button" = "Сбросить фильтр";
 
 /* noun */
 "search_in_table" = "Список";
@@ -1517,8 +975,6 @@
 
 "traffic_update_maps_text" = "Для отображения пробок необходимо обновить карты.";
 
-"traffic_outdated" = "Данные о пробках устарели.";
-
 "big_font" = "Увеличить шрифт на карте";
 
 "traffic_update_app" = "Обновите Organic Maps";
@@ -1529,17 +985,7 @@
 /* "traffic" as in "road congestion" */
 "traffic_data_unavailable" = "Данные о пробках недоступны";
 
-/* "Translation is no needed, because it's a company name" */
-"uber" = "Uber";
-
-/* Simplified colour scheme for traffic information, fewer colours are used to display traffic jams on the map. The string should be kept as short as possible */
-"pref_traffic_simplified_colors_title" = "Простые цвета пробок";
-
 "enable_logging" = "Включить запись логов";
-
-"offline_place_page_more_information" = "Подключитесь к интернету, чтобы получить больше информации о месте.";
-
-"failed_load_information" = "Не удалось загрузить информацию.";
 
 /* Settings: "Send general feedback" button */
 "feedback_general" = "Отправить отзыв";
@@ -1556,8 +1002,6 @@
 
 "whatsnew_transliteration_title" = "Латинская транслитерация";
 
-"yandex_taxi_title" = "Яндекс.Такси";
-
 "learn_more" = "Узнать больше";
 
 "core_exit" = "Выход";
@@ -1568,75 +1012,19 @@
 
 "button_exit" = "Выход";
 
-"settings_device_memory" = "Память устроства";
-
-"settings_card_memory" = "Карта памяти";
-
-"settings_storage_available" = "%s доступно";
-
-"toast_location_permission_denied" = "Определение местоположения запрещено";
-
-"button_use" = "Использовать";
-
 "planning_route_manage_route" = "Изменить маршрут";
 
 "button_plan" = "Построить";
-
-"button_add" = "Добавить";
 
 "placepage_remove_stop" = "Удалить";
 
 "planning_route_remove_title" = "Перетяните сюда, чтобы удалить";
 
-"dialog_change_start_point_message" = "Заменить стартовую точку на текущее местоположение?";
-
-"button_replace" = "Заменить";
-
 "placepage_add_stop" = "Заехать";
-
-/* Only ru/en are needed */
-"subtitle_rent" = "Аренда";
-
-/* Only ru/en are needed */
-"rub_month" = "руб./мес.";
-
-/* Only ru/en are needed */
-"room" = "%s-комн. кв.";
-
-/* Only ru/en are needed */
-"real_estate" = "Недвижимость";
-
-"add_my_position" = "Добавить мое местоположение";
-
-"choose_start_point" = "Выберите начало маршрута";
-
-"choose_destination" = "Выберите конец маршрута";
 
 "preloader_viator_button" = "Посмотреть";
 
-"start_from_my_position" = "Начать от";
-
-"profile_authorization_title" = "Авторизуйтесь с помощью";
-
-"profile_authorization_message" = "Простая авторизация за пару секунд без логина и пароля";
-
 "profile_authorization_error" = "Упс, произошла ошибка. Попробуйте авторизоваться повторно.";
-
-"service" = "Обслуживание";
-
-"atmosphere" = "Атмосфера";
-
-"value_for_money" = "Цена / качество";
-
-"experience" = "Впечатления";
-
-"assortment" = "Ассортимент";
-
-"expertise" = "Профессионализм";
-
-"equipment" = "Оборудование";
-
-"quality" = "Качество";
 
 "dialog_error_storage_title" = "Проблема с доступом к хранилищу";
 
@@ -1644,17 +1032,7 @@
 
 "setting_emulate_bad_storage" = "Эмуляция ошибки с внешней памятью";
 
-"directions_finish" = "Место назначения";
-
-"directions_on_foot" = "Пешком %s";
-
 "core_entrance" = "Вход";
-
-"coffee" = "Кофе";
-
-"cleanliness" = "Чистота";
-
-"crowdedness" = "Многолюдность";
 
 "error_enter_correct_name" = "Пожалуйста, введите название правильно";
 
@@ -1677,8 +1055,6 @@
 
 "downloader_applying" = "Применение %s…";
 
-"dialog_message_transit_not_found_connection" = "Постройте маршрут в пределах одной транспортной сети";
-
 "bookmarks_error_message_share_general" = "Не удалось поделиться из-за ошибки приложения";
 
 "bookmarks_error_title_share_empty" = "Ошибка при попытке поделиться";
@@ -1695,17 +1071,7 @@
 
 "bookmarks_error_message_list_name_already_taken" = "Выберите, пожалуйста, другое имя";
 
-"bookmarks_error_title_list_name_too_long" = "Слишком длинное название";
-
-"bookmarks_error_message_list_name_too_long" = "Выберите, пожалуйста, другое имя";
-
-"please_wait" = "Пожалуйста, подождите...";
-
-"phone_number" = "Номер телефона";
-
-"notification_unsent_reviews_title" = "У вас есть неотправленные отзывы";
-
-"notification_unsent_reviews_message" = "Пожалуйста, авторизуйтесь, чтобы поделиться своими отзывами с другими путешественниками";
+"please_wait" = "Пожалуйста, подождите…";
 
 "profile" = "Профиль OpenStreetMap";
 
@@ -1719,49 +1085,13 @@
 
 "bookmarks_convert_error_message" = "Некоторые файлы не конвертировались.";
 
-"converting" = "Конвертация...";
-
-"wn_reinvented_bookmarks_title" = "Мы улучшили функционал меток!";
-
-"wn_reinvented_bookmarks_message" = "Теперь вы можете сделать резервное копирование меток, создать списки. А как круто они смотрятся на карте!";
-
-"bookmarks_restore" = "Восстановить метки";
-
-"bookmarks_restore_process" = "Восстановление...";
-
 "bookmarks_restore_title" = "Восстановить эту версию?";
 
-"bookmarks_restore_message" = "Ваши закладки будут восстановлены от %s (%s)";
-
-"bookmarks_restore_empty_title" = "У вас нет резервных копий";
-
-"bookmarks_restore_empty_message" = "Сервер не нашел ранее сделанные резервные копии";
-
 "common_check_internet_connection_dialog_title" = "Нет интернет соединения";
-
-"error_server_title" = "Ошибка сервера";
-
-"error_server_message" = "На сервере произошла ошибка, повторите попытку позже";
 
 "error_system_message" = "Произошла неизвестная ошибка";
 
 "restore" = "Восстановить";
-
-"bookmarks_page_downloaded" = "Загруженные";
-
-"bookmarks_page_my" = "Мои";
-
-"routes_and_bookmarks" = "Маршруты и метки";
-
-"bookmarks_webview_success_toast" = "Метки успешно загружены";
-
-"cached_bookmarks_placeholder_title" = "Загрузите новые места";
-
-"cached_bookmarks_placeholder_subtitle" = "Нажмите кнопку, чтобы загрузить тысячи интересных мест и маршрутов, созданных пользователями Organic Maps. Вам понадобится подключение к интернету.";
-
-"downloader_download_routers" = "Загрузить метки";
-
-"bookmarks_groups_cached" = "Загруженные списки";
 
 "subtittle_opt_out" = "Настройки сопровождения";
 
@@ -1769,29 +1099,15 @@
 
 "crash_reports_description" = "Мы можем использовать ваши данные, чтобы развивать и улучшать Organic Maps. Изменения вступят в силу после перезапуска приложения.";
 
-"opt_out_help_ios_1" = "Вы можете отказаться от получения целевой рекламы в настройках устройства.";
-
-"opt_out_help_ios_2" = "iOS 9 или выше";
-
-"opt_out_help_ios_3" = "Откройте Настройки → Конфиденциальность → Реклама → Включите «Ограничение трекинга»";
-
-"opt_out_help_android" = "Вы можете отказаться от получения целевой рекламы в настройках устройства.\nAndroid и Google Play Сервисы 4.0 и выше\n\nНастройки телефона → Google → Реклама → Отключить персонализацию рекламы\nили\nНастройки телефона → Google → Аккаунт Google → Конфиденциальность → Настройки рекламных предпочтений → Персонализация рекламы";
-
 "privacy_policy" = "Политика конфиденциальности";
 
 "terms_of_use" = "Условия использования";
-
-"backup_notification_failed" = "Резервное копирование меток было приостановлено. Войдите, чтобы включить резервное копирование.";
 
 "button_layer_traffic" = "Пробки";
 
 "button_layer_subway" = "Метро";
 
 "layers_title" = "Слои карты";
-
-"layers_message" = "Включайте слои на карте для отображения дорожной обстановки, схемы метро или другой полезной информации";
-
-"button_layer_got_it" = "Понятно";
 
 "subway_data_unavailable" = "Карта метро недоступна";
 
@@ -1803,39 +1119,13 @@
 
 "title_error_downloading_bookmarks" = "Произошла ошибка";
 
-"subtitle_error_downloading_bookmarks" = "Метки не были загружены";
-
-"error_already_downloaded" = "Этот список уже был загружен";
-
 "popular_place" = "Популярно";
-
-"download_routes" = "Загрузить маршруты";
-
-"bookmarks_downloaded_title" = "Метки были успешно загружены";
-
-"bookmarks_downloaded_subtitle" = "Нажмите «Посмотреть на карте» чтобы посмотреть новые места из списка";
-
-"why_support" = "Зачем поддерживать Organic Maps?";
-
-"why_support_item1" = "Мы никому не отсылаем ваши личные данные, а исходный код нашего приложения открыт";
-
-"why_support_item2" = "Вы помогаете нам улучшать Organic Maps";
-
-"why_support_item3" = "Вы помогаете нам улучшать карты OpenStreetMap.org";
-
-"channels_map_update" = "Обновления карт";
-
-"server_unavailable_title" = "Сервер недоступен";
-
-"sharing_options" = "Настройки доступа";
 
 "export_file" = "Экспортировать файл";
 
 "list_settings" = "Настройки списка";
 
 "delete_list" = "Удалить список";
-
-"hide_from_map" = "Скрыть с карты";
 
 "public_access" = "Публичный доступ";
 
@@ -1845,40 +1135,11 @@
 
 "bookmark_category_description_hint" = "Добавьте описание (текст или html)";
 
-/* FIXME */
-"bookmarks_public_access" = "bookmarks_public_access";
-
-/* FIXME */
-"bookmarks_link_access" = "bookmarks_link_access";
-
-/* FIXME */
-"bookmarks_private_access" = "bookmarks_private_access";
-
 "not_shared" = "Личный";
-
-"direct_link_progress_text" = "Загружаем ваш файл…";
-
-"direct_link_success" = "Ссылка создана";
-
-"send_a_link_btn" = "Отправить ссылку";
-
-"upload_error_toast" = "Во время загрузки файла произошла ошибка";
 
 "tags_loading_error_subtitle" = "Во время загрузки тегов произошла ошибка, пожалуйста, попробуйте еще раз";
 
-"unable_upload_errorr_title" = "Не удалось загрузить файл";
-
-"unable_upload_error_subtitle_edited" = "Файл был отредактирован через веб-приложение";
-
-"unable_upload_error_subtitle_broken" = "Файл поврежден и не может быть загружен. Пожалуйста, загрузите другой файл.";
-
-"contact" = "Написать";
-
-"download_button" = "Скачать";
-
 "speedcams_alert_title" = "Камеры скорости";
-
-"speedcams_alert_subtitle" = "Предупреждать об ограничениях скорости";
 
 "speedcam_option_auto" = "Авто";
 
@@ -1886,18 +1147,10 @@
 
 "speedcam_option_never" = "Никогда";
 
-"bookmark_description_title" = "Описание метки";
-
 "place_description_title" = "Описание места";
 
 /* this text will be shown in application notification preferences opposite checkbox which enable/disable downloader notifications. Devices on Android 8+ are affected. */
 "notification_channel_downloader" = "Загрузка карт";
-
-"share_bookmarks_email_body_link" = "Здравствуйте!\n\nМетки можно скачать по ссылке: %s. Открывайте список с помощью Organic Maps и наслаждайтесь поездкой!\n\nСкачать приложение: https://omaps.app/get?kmz";
-
-"warning_speedcams_title" = "Навигатор оповестит вас о камерах при превышении скоростного лимита на %d км/ч";
-
-"warning_speedcams_subtitle" = "Не забудьте ознакомиться с правилами дорожного движения в стране путешествия.";
 
 "speedcams_notice_message" = "Авто - Предупреждать о камерах скорости, если есть риск превышения скоростного лимита\nВсегда - Всегда предупреждать о камерах\nНикогда - Никогда не предупреждать о камерах";
 
@@ -1913,23 +1166,7 @@
 
 "enable_logging_warning_message" = "Данная настройка включается для записи действий в целях диагностики, чтобы помочь нашей команде выявить проблемы с приложением. Временно включайте эту настройку только для отправки детальной информации о найденной вами проблеме в приложении.";
 
-"html_error_upload_message_try_again" = "Проверьте доступ к сети и повторите попытку";
-
-"html_error_upload_title_try_again" = "Нет соединения с Интернетом";
-
-"notification_leave_review_v2_android_short_title" = "Оставляйте отзыв и помогайте путешественникам!";
-
-"megafon" = "Роуминг, гудбай!";
-
-"notifications_illegal_alert_disable_button" = "Выключить уведомления";
-
 "access_rules_author_only" = "Редактируется онлайн";
-
-"privacy_settings_menu" = "Настройки конфиденциальности";
-
-"unable_upadate_error_title" = "Не удалось обновить маршрут";
-
-"unable_upadate_error_message" = "Возникли ошибки при обновлении. Проверьте изменения и повторите попытку";
 
 "driving_options_title" = "Настройки объезда";
 
@@ -1951,94 +1188,19 @@
 
 "change_driving_options_btn" = "Настройки объезда включены";
 
-"toll_road" = "Платная дорога";
-
-"unpaved_road" = "Грунтовая дорога";
-
-"ferry_crossing" = "Паромная переправа";
-
-"operated_by" = "Управляется оператором \"%s\"";
-
 "avoid_toll_roads_placepage" = "Избегать платных дорог";
 
 "avoid_unpaved_roads_placepage" = "Избегать грунтовых дорог";
 
 "avoid_ferry_crossing_placepage" = "Избегать паромных переправ";
 
-"type.cuisine.uzbek" = "Узбекская кухня";
-
-"trip_start" = "Поехали";
-
-"pick_destination" = "Цель";
-
-"follow_my_position" = "Отцентровать";
-
-"search_results" = "Результаты поиска";
-
-"then_turn" = "Затем";
-
-"redirect_route_alert" = "Хотите перестроить маршрут?";
-
-"redirect_route_yes" = "Да";
-
-"redirect_route_no" = "Нет";
-
-"trip_finished" = "Вы прибыли!";
-
-"keyboard_availability_alert" = "Клавиатура недоступна во время движения";
-
-"dialog_routing_change_start_carplay" = "Невозможно построить маршрут от текущего местоположения";
-
-"dialog_routing_change_end_carplay" = "Невозможно построить маршрут до конечной точки. Выберите другую";
-
-"dialog_routing_check_gps_carplay" = "Нет сигнала GPS. Проследуйте на открытую местность";
-
-"dialog_routing_unable_locate_route_carplay" = "Невозможно построить маршрут. Выберите другие точки маршрута";
-
-"dialog_routing_download_files_carplay" = "Чтобы построить маршрут, загрузите недостающие карты на своем устройстве";
-
-"dialog_routing_system_error_carplay" = "Произошла ошибка. Перезапустите приложение";
-
-"dialog_routing_rebuild_from_current_location_carplay" = "Маршрут будет перестроен от вашего текущего местоположения";
-
-"dialog_routing_rebuild_for_vehicle_carplay" = "Маршрут будет изменен на автомобильный";
-
 "ok" = "Ок";
-
-"avoid_unpaved_carplay_1" = "Без грунт.";
-
-"avoid_unpaved_carplay_2" = "Без грунтовых";
-
-"avoid_ferry_carplay_1" = "Без паромов";
-
-"avoid_ferry_carplay_2" = "Без паромов";
-
-"avoid_tolls_carplay_1" = "Без платных";
-
-"avoid_tolls_carplay_2" = "Без платных";
-
-"speedcams_alert_title_carplay_1" = "Камеры";
-
-"speedcams_alert_title_carplay_2" = "Инфо о камерах";
-
-"download_map_carplay" = "Скачайте карты в приложении Organic Maps на своем устройстве";
-
-"carplay_roundabout_exit" = "%s съезд";
 
 /* max. 10 symbols, both iOS and Android */
 "sort" = "Сортировать…";
 
 /* Android, title, max 20-22 symbols */
 "sort_bookmarks" = "Сортировать метки";
-
-/* iOS */
-"sort_default" = "Сортировать по умолчанию";
-
-"sort_type" = "Сортировать по типу";
-
-"sort_distance" = "Сортировать по расстоянию";
-
-"sort_date" = "Сортировать по дате";
 
 /* Android */
 "by_default" = "По умолчанию";
@@ -2052,63 +1214,7 @@
 /* Android */
 "by_date" = "По дате";
 
-"week_ago_sorttype" = "Неделю назад";
-
-"month_ago_sorttype" = "Месяц назад";
-
-"moremonth_ago_sorttype" = "Больше месяца назад";
-
-"moreyear_ago_sorttype" = "Больше года назад";
-
-"near_me_sorttype" = "Рядом со мной";
-
-"others_sorttype" = "Другие";
-
-"food_places" = "Еда";
-
-"tourist_places" = "Достопримечательности";
-
-"museums" = "Музеи";
-
-"parks" = "Парки";
-
-"swim_places" = "Плавание";
-
-"mountains" = "Горы";
-
-"animals" = "Животные";
-
-"hotels" = "Отели";
-
-"buildings" = "Здания";
-
-"money" = "Деньги";
-
-"shops" = "Магазины";
-
-"parkings" = "Парковки";
-
-"fuel_places" = "Заправки";
-
-"water" = "Вода";
-
-"medicine" = "Медицина";
-
 "search_in_the_list" = "Искать в списке";
-
-"view_on_map_bookmarks" = "На карте";
-
-"more_bookmarks" = "Еще…";
-
-"no_items_found" = "Ничего не найдено";
-
-/* Android, max 18 symbols */
-"bookmarks_edit_list" = "Редактировать";
-
-/* Android, max 18 symbols */
-"bookmarks_delete_list" = "Удалить список";
-
-"religious_places" = "Святые места";
 
 "select_list" = "Выбрать список";
 
@@ -2118,26 +1224,13 @@
 
 "dialog_pedestrian_route_is_long_message" = "Выберите начальную или конечную точку маршрута ближе к станции метро";
 
-/* Failed planning SUBWAY route message in navigation view */
-"routing_planning_error_subway_special" = "Ошибка построения маршрута метро";
-
 "button_layer_isolines" = "Высоты";
-
-"tips_map_layers_title_countour" = "Линии высот офлайн в Organic Maps!";
-
-"tips_map_layers_message_countour" = "Линии высот помогут спланировать путешествие на природу и не потеряться на местности";
 
 "isolines_activation_error_dialog" = "Чтобы воспользоваться линиями высот, обновите или загрузите карту нужной местности";
 
 "isolines_location_error_dialog" = "Линии высот пока не доступны в этом регионе";
 
 "elevation_profile_diff_level" = "Уровень сложности";
-
-"elevation_profile_diff_level_easy" = "Лёгкий";
-
-"elevation_profile_diff_level_moderate" = "Умеренный";
-
-"elevation_profile_diff_level_hard" = "Сложный";
 
 "elevation_profile_ascent" = "Подъём";
 
@@ -2147,25 +1240,13 @@
 
 "elevation_profile_maxaltitude" = "Макс. высота";
 
-"elevation_profile_m" = "м";
-
 "elevation_profile_difficulty" = "Сложность";
 
 "elevation_profile_distance" = "Расст.:";
 
-"elevation_profile_km" = "км";
-
 "elevation_profile_time" = "В пути:";
 
-"elevation_profile_hours" = "ч.";
-
-"elevation_profile_minutes" = "мин";
-
 "isolines_toast_zooms_1_10" = "Увеличьте карту, чтобы увидеть изолинии";
-
-"downloader_updating_ios" = "Обновление";
-
-"downloader_loading_ios" = "Загрузка";
 
 "key_information_title" = "Ключевая информация";
 

--- a/iphone/Maps/LocalizedStrings/ru.lproj/Localizable.stringsdict
+++ b/iphone/Maps/LocalizedStrings/ru.lproj/Localizable.stringsdict
@@ -9,25 +9,6 @@
 
 <!-- ********** Strings for downloading map from search **********/ -->
 
-  <key>bookmarks_places</key>
-  <dict>
-    <key>NSStringLocalizedFormatKey</key>
-    <string>%#@value@</string>
-    <key>value</key>
-    <dict>
-      <key>NSStringFormatSpecTypeKey</key>
-      <string>NSStringPluralRuleType</string>
-      <key>NSStringFormatValueTypeKey</key>
-      <string>d</string>
-      <key>one</key>
-      <string>%d метка</string>
-      <key>few</key>
-      <string>%d метки</string>
-      <key>other</key>
-      <string>%d меток</string>
-    </dict>
-  </dict>
-
   <key>bookmarks_detect_message</key>
   <dict>
     <key>NSStringLocalizedFormatKey</key>
@@ -38,33 +19,12 @@
       <string>NSStringPluralRuleType</string>
       <key>NSStringFormatValueTypeKey</key>
       <string>d</string>
-      <key>one</key>
-      <string>%d файл был найден. Вы увидете его после конвертации.</string>
       <key>few</key>
       <string>%d файла были найдены. Вы увидете их после конвертации.</string>
+      <key>one</key>
+      <string>%d файл был найден. Вы увидете его после конвертации.</string>
       <key>other</key>
       <string>%d файлов было найдено. Вы увидете их после конвертации.</string>
-    </dict>
-  </dict>
-
-  <key>bookmarks_objects</key>
-  <dict>
-    <key>NSStringLocalizedFormatKey</key>
-    <string>%#@value@</string>
-    <key>value</key>
-    <dict>
-      <key>NSStringFormatSpecTypeKey</key>
-      <string>NSStringPluralRuleType</string>
-      <key>NSStringFormatValueTypeKey</key>
-      <string>d</string>
-      <key>one</key>
-      <string>%s объект</string>
-      <key>two</key>
-      <string>%d объекта</string>
-      <key>few</key>
-      <string>%d объекта</string>
-      <key>other</key>
-      <string>%s объектов</string>
     </dict>
   </dict>
 
@@ -78,14 +38,14 @@
       <string>NSStringPluralRuleType</string>
       <key>NSStringFormatValueTypeKey</key>
       <string>d</string>
-      <key>one</key>
-      <string>%d объект</string>
-      <key>two</key>
-      <string>%d объекта</string>
       <key>few</key>
       <string>%d объекта</string>
+      <key>one</key>
+      <string>%d объект</string>
       <key>other</key>
       <string>%d объектов</string>
+      <key>two</key>
+      <string>%d объекта</string>
     </dict>
   </dict>
 
@@ -99,14 +59,14 @@
       <string>NSStringPluralRuleType</string>
       <key>NSStringFormatValueTypeKey</key>
       <string>d</string>
-      <key>one</key>
-      <string>%d место</string>
-      <key>two</key>
-      <string>%d места</string>
       <key>few</key>
       <string>%d места</string>
+      <key>one</key>
+      <string>%d место</string>
       <key>other</key>
       <string>%d мест</string>
+      <key>two</key>
+      <string>%d места</string>
     </dict>
   </dict>
 
@@ -120,14 +80,14 @@
       <string>NSStringPluralRuleType</string>
       <key>NSStringFormatValueTypeKey</key>
       <string>d</string>
-      <key>one</key>
-      <string>%d трек</string>
-      <key>two</key>
-      <string>%d трека</string>
       <key>few</key>
       <string>%d трека</string>
+      <key>one</key>
+      <string>%d трек</string>
       <key>other</key>
       <string>%d треков</string>
+      <key>two</key>
+      <string>%d трека</string>
     </dict>
   </dict>
 </dict>

--- a/iphone/Maps/LocalizedStrings/sk.lproj/Localizable.strings
+++ b/iphone/Maps/LocalizedStrings/sk.lproj/Localizable.strings
@@ -18,9 +18,6 @@
 /* Button which deletes downloaded country */
 "delete" = "Zmazať";
 
-/* Button "do not interrupt download" if user touched actively downloading country */
-"do_nothing" = "Pokračovať";
-
 "download_maps" = "Stiahnuť mapy";
 
 /* Settings/Downloader - info for country when download fails */
@@ -28,9 +25,6 @@
 
 /* Settings/Downloader - info for country which started downloading */
 "downloading" = "Sťahovanie…";
-
-/* Settings/Downloader - size string, only strings different from English should be translated */
-"kb" = "kB";
 
 /* Choose measurement on first launch alert - choose metric system button */
 "kilometres" = "Kilometre";
@@ -55,17 +49,11 @@
 /* Update maps later/Buy pro version later button text */
 "later" = "Neskôr";
 
-/* Don't show some dialog any more */
-"never" = "Nikdy";
-
 /* View and button titles for accessibility */
 "search" = "Hľadať";
 
 /* Search box placeholder text */
 "search_map" = "Prehľadať mapu";
-
-/* Settings/Downloader - info for not downloaded country */
-"touch_to_download" = "Stlačte pre stiahnutie";
 
 /* Settings/Downloader - 3G download warning dialog confirm button */
 "use_cellular_data" = "Áno";
@@ -73,20 +61,11 @@
 /* Location services are disabled by user alert - message */
 "location_is_disabled_long_text" = "Aktuálne máte všetky možnosti pre určovanie polohy vypnuté. Prosím, povoľte ich v Nastaveniach.";
 
-/* Location Services are not available on the device alert - message */
-"device_doesnot_support_location_services" = "Vaše zariadenie nepodporuje služby pre určovanie polohy";
-
 /* View and button titles for accessibility */
 "zoom_to_country" = "Ukázať na mape";
 
-/* Button text for the button at the center of the screen when the country is not downloaded */
-"country_status_download" = "Stiahnite si Mapu\n(^ ^)";
-
 /* Button text for the button at the center of the screen when the country is not downloaded and the size should not be shown */
 "country_status_download_without_size" = "Stiahnite si Mapu";
-
-/* Button text for the button at the center of the screen when the country is not downloaded */
-"country_status_download_without_routing" = "Stiahnite si mapu\nbez smerovania (^ ^)";
 
 /* Message to display at the center of the screen when the country download has failed */
 "country_status_download_failed" = "Sťahovanie zlyhalo";
@@ -96,19 +75,13 @@
 
 "about_menu_title" = "O aplikácii Organic Maps";
 
-"downloaded_touch_to_delete" = "Stiahnuté (%@), stlačte pre zmazanie";
-
 "connection_settings" = "Nastavenie pripojenia";
-
-"download_mb_or_kb" = "Stiahnuť %@";
 
 "close" = "Zavrieť";
 
 "unsupported_phone" = "Je vyžadovaná hardwarová akcelerácia OpenGL. Bohužial, vaše zariadenie nie je podporované.";
 
 "download" = "Stiahnuť";
-
-"external_storage_is_not_available" = "SD karta/USB úložisko s uloženými mapami nie je k dispozícii";
 
 "disconnect_usb_cable" = "Prosím, odpojte USB kábel alebo vložte pamäťovú kartu pre použitie s Organic Maps";
 
@@ -117,8 +90,6 @@
 "not_enough_memory" = "Nedostatok pamäti k spusteniu aplikácie";
 
 "download_resources" = "Skôr ako začnete, bude treba stiahnuť základnú mapu sveta.\nZaberie to %@.";
-
-"getting_position" = "Získavanie aktuálnej polohy";
 
 "download_resources_continue" = "Prejsť na mapu";
 
@@ -140,23 +111,14 @@
 /* Add New Bookmark Set dialog title */
 "add_new_set" = "Pridať novú skupinu záložiek";
 
-/* Place Page - Add To Bookmarks button */
-"add_to_bookmarks" = "Pridať k záložkám";
-
 /* Bookmark Color dialog title */
 "bookmark_color" = "Farba záložky";
 
 /* Add Bookmark Set dialog - hint when set name is empty */
 "bookmark_set_name" = "Meno záložky";
 
-/* Bookmark Sets dialog title */
-"bookmark_sets" = "Skupiny záložiek";
-
 /* Bookmarks - dialog title */
 "bookmarks" = "Záložky";
-
-/* Add bookmark dialog - bookmark color */
-"color" = "Farba";
 
 /* Default bookmarks set name */
 "core_my_places" = "Moje miesta";
@@ -167,14 +129,8 @@
 /* Editor title above street and house number */
 "address" = "Adresa";
 
-/* Place Page - Remove Pin button */
-"remove_pin" = "Odstrániť špendlík";
-
 /* Add bookmark dialog - bookmark set, Bookmarks dialog - Bookmark set cell */
 "set" = "Skupina";
-
-/* Text hint in Bookmarks dialog when no any bookmarks are added */
-"bookmarks_usage_hint" = "Zatiaľ nemáte žiadne záložky.\nZáložku môžete pridať pridržaním ľubovolného miesta na mape.\nV Organic Maps môžu byť tiež zobrazené importované záložky z iných zdrojov. Súbor vo formáte KML/KMZ s uloženými záložkami môžete otvoriť napr. z emailu, Dropboxu alebo z webového odkazu.";
 
 /* Settings button in system menu */
 "settings" = "Nastavenia";
@@ -191,26 +147,11 @@
 /* Ask to wait user several minutes (some long process in modal dialog). */
 "wait_several_minutes" = "Táto akcia môže trvať niekoľko minút.\nProsím čakajte…";
 
-/* Show bookmarks from this category on a map or not */
-"visible" = "Viditeľné";
-
-/* Toast which is displayed when GPS has been deactivated */
-"gps_is_disabled_long_text" = "Navigácia GPS deaktivovaná. Prosím, povoľte ju v Nastaveniach.";
-
 /* Measurement units title in settings activity */
 "measurement_units" = "Meracie jednotky";
 
 /* Detailed description of Measurement Units settings button */
 "measurement_units_summary" = "Vyberte si míle alebo kilometre";
-
-/* Do search in all sources */
-"search_mode_all" = "Všade";
-
-/* Do search near my position only */
-"search_mode_nearme" = "V mojom okolí";
-
-/* Do search in current viewport only */
-"search_mode_viewport" = "Na obrazovke";
 
 /* Search category for cafes, bars, restaurants */
 "eat" = "Kde sa najesť";
@@ -266,14 +207,8 @@
 /* Search category */
 "police" = "Polícia";
 
-/* String in search result list, when nothing found */
-"no_search_results_found" = "Žiadne výsledky";
-
 /* Notes field in Bookmarks view */
 "description" = "Poznámky";
-
-/* Button text */
-"share_by_email" = "Share by email";
 
 /* Email Subject when sharing bookmarks category */
 "share_bookmarks_email_subject" = "Zdielané záložky Organic Maps";
@@ -295,26 +230,11 @@
 /* Warning message when doing search around current position */
 "unknown_current_position" = "Vaša poloha zatiaľ nebola určená";
 
-/* Warning message when location country isn't downloaded during search (see also download_location_map_proposal). */
-"download_location_country" = "Sťahovanie krajiny vašej aktuálnej polohy (%@)";
-
-/* Warning message when viewport country isn't downloaded during search */
-"download_viewport_country_to_search" = "Sťahovanie krajiny, v ktorej hľadáte (%@)";
-
 /* Alert message that we can't run Map Storage settings due to some reasons. */
 "cant_change_this_setting" = "Prepáčte, nastavenie uloženia máp je dočasne nedostupné.";
 
 /* Alert message that downloading is in progress. */
 "downloading_is_active" = "Práve prebieha sťahovanie krajiny.";
-
-/* Message that will be shown in alert view, when we ask user to leave review on App Store */
-"appStore_message" = "Dúfame, že sa vám používánie Organic Maps páči! Ak to je tak, ohodnoťte prosím našu aplikáciu alebo napíšte na ňu recenziu v Obchode s aplikáciami. Nezaberie vám to ani minútu času, ale nám s tým môžete veľmi pomôoť. Ďakujeme vám za vašu podporu!";
-
-/* No, thanks */
-"no_thanks" = "Nie, ďakujem";
-
-/* Share one specific bookmark using SMS, %1$@ contains om:// and %2$@ https://omaps.app link. @NOTE non-ascii symbols in the link will result in max 70 characters SMS instead of 140. */
-"bookmark_share_sms" = "Pozrite na moju značku na mape. Otvoriť odkaz: %1$@ alebo %2$@";
 
 /* Share my position using SMS, %1$@ contains om:// and %2$@ https://omaps.app link WITHOUT NAME. @NOTE non-ascii symbols in the link will result in max 70 characters SMS instead of 140. */
 "my_position_share_sms" = "Pozri kde som. Otvor odkaz: %1$@ alebo %2$@";
@@ -328,23 +248,11 @@
 /* Share my position using EMail, %1$@ is om:// and %2$@ is https://omaps.app link WITHOUT NAME */
 "my_position_share_email" = "Ahoj,\n\nPráve som tu: %1$@. Stlačte jeden z týchto odkazov %2$@, %3$@ a uvidíte toto miesto na mape.\n\nVďaka";
 
-/* Android share by Message/SMS button text (including SMS) */
-"share_by_message" = "Zdielať pomocou správy";
-
 /* Share button text which opens menu with more buttons, like Message, EMail, Facebook etc. */
 "share" = "Zdielať";
 
-/* iOS share by Message button text (including SMS) */
-"message" = "Správa";
-
 /* Share by email button text, also used in editor. */
 "email" = "Email";
-
-/* Copy Link */
-"copy_link" = "Skopírovať odkaz";
-
-/* Text for the button that returns to caller application */
-"more_info" = "Zobraziť ďaľšie informácie";
 
 /* Text for message when used successfully copied something */
 "copied_to_clipboard" = "Skopírované do schránky: %1$@";
@@ -354,15 +262,6 @@
 
 /* Used for bookmark editing */
 "done" = "Hotovo";
-
-/* Summary for preferences in MWM */
-"yopme_pref_summary" = "Zvoliť nastavenie Zadnej obrazovky";
-
-/* Title for yopme preferences in MWM */
-"yopme_pref_title" = "Nastavenie Zadnej obrazovky";
-
-/* Hint for upper-right icon p2b */
-"show_on_backscreen" = "Zobraziť na Zadnej obrazovke";
 
 /* Prints version number in About dialog */
 "version" = "Verzia: %@";
@@ -381,19 +280,11 @@
 
 "share_my_location" = "Zdielať moje umiestnenie";
 
-"menu_search" = "Vyhľadávanie";
-
 /* Settings general group in settings screen */
 "prefs_group_general" = "General settings";
 
 /* Settings information group in settings screen */
 "prefs_group_information" = "Information";
-
-/* Settings screen: "Map" category title */
-"prefs_group_map" = "Mapa";
-
-/* Settings screen: "Miscellaneous" category title */
-"prefs_group_misc" = "Iné";
 
 "prefs_group_route" = "Navigácia";
 
@@ -419,9 +310,6 @@
 /* Settings «Map» category: «3D buildings» title */
 "pref_map_3d_buildings_title" = "3D budovy";
 
-/* Settings «Map» category: «3D buildings» summary */
-"pref_map_3d_buildings_subtitle" = "Ovplyvňuje životnosť batérie";
-
 /* Settings «Route» category: «Tts enabled» title */
 "pref_tts_enable_title" = "Hlasové povely";
 
@@ -433,8 +321,6 @@
 
 /* Title for "Other" section in TTS settings. */
 "pref_tts_other_section_title" = "Iný";
-
-"pref_tts_how_to_set_up_voice" = "Ako nastaviť hlas";
 
 /* Settings «Map» category: «Record track» title */
 "pref_track_record_title" = "Posledná trasa";
@@ -455,56 +341,7 @@
 
 "recent_track_help_text" = "Umožňuje zaznamenať precestovanú trasu za určité obdobie a zobraziť ju na mape. Upozornenie: zapnutie tejto funkcie spôsobí vyššiu spotrebu batérie. Trasa sa z mapy automaticky odstráni po uplynutí časového intervalu.";
 
-"pref_track_ios_caption" = "Funkcia Čerstvá stopa zobrazuje trasu, ktorú ste prešli.";
-
-"pref_track_ios_subcaption" = "Prosím, vyberte si, po akú dobu má aplikácia zaznamenávať vašu trasu.";
-
-"placepage_distance" = "Vzdialenosť";
-
-"placepage_coordinates" = "Súradnice";
-
-"placepage_unsorted" = "Nezaradené";
-
 "search_show_on_map" = "Zobraziť na mape";
-
-/* Used to warn user when fixing KitKat issue */
-"bookmark_move_fail" = "Potrebujeme presunúť vaše záložky do internej pamäti zariadenia, ale nie je pre ne voľné miesto. Prosím, uvoľnite pamäť, inak nebudú záložky dostupné.";
-
-/* Used in More Apps menu */
-"free" = "Zadarmo";
-
-/* Used in More Apps menu */
-"buy" = "Kúpiť";
-
-/* 1st search button-like result */
-"search_on_map" = "Hľadať na mape";
-
-/* toast with an error */
-"no_route_found" = "Nebola nájdená žiadna trasa";
-
-/* route title */
-"route" = "Trasa";
-
-/* category title */
-"routes" = "Trasy";
-
-/* text of notification */
-"download_map_notification" = "Stiahnite si mapu miesta, kde sa práve nachádzate";
-
-/* text of notification */
-"pro_version_is_free_today" = "Plná verzia Organic Maps dnes zadarmo! Stiahnite si teraz a povedzte to svojim priateľom.";
-
-/* Dialog for transferring maps from lite to pro. */
-"move_lite_maps_to_pro" = "Práve prenášame Vaše stiahnuté mapy z Organic Maps lite na Organic Maps. Môže to trvať niekoľko minút.";
-
-/* Message to display when maps moved. */
-"move_lite_maps_to_pro_ok" = "Vaše stiahnuté mapy sú úspešne prenesené na Organic Maps.";
-
-/* Message to display when maps move failed. */
-"move_lite_maps_to_pro_failed" = "Vaše mapy sa nepodarilo preniesť. Vymažte prosím Organic Maps Lite a stiahnite si mapy znova.";
-
-/* Text in menu */
-"settings_and_more" = "Nastavenia a viac";
 
 /* Text in menu */
 "website" = "Webové stránky";
@@ -527,14 +364,8 @@
 /* Text in menu */
 "openstreetmap" = "OpenStreetMap";
 
-/* Text in menu */
-"contact_us" = "Kontaktovať nás";
-
 /* Settings: Send feedback button and dialog title */
 "feedback" = "Spätná väzba";
-
-/* Text in menu */
-"subscribe_to_news" = "Prihlásiť sa k našim novinkám";
 
 /* Text in menu */
 "rate_the_app" = "Ohodnotiť aplikáciu";
@@ -548,15 +379,6 @@
 /* Text in menu */
 "report_a_bug" = "Nahlásiť chybu";
 
-/* Email subject */
-"subscribe_me_subject" = "Prihláste ma prosím k odberu spravodaja Organic Maps";
-
-/* Email body */
-"subscribe_me_body" = "Chcem sa vždy ako prvý dozvedať o najnovších správach, aktualizáciách a akčných ponukách. Svoje prihlásenie k odberu môžem kedykoľvek zrušiť.";
-
-/* About text */
-"about_text" = "Organic Maps ponúka najrýchlejšie offline mapy všetkých miest a krajín po celom svete. Cestujte s úplnou dôverou: kdekoľvek ste, Organic Maps vám pomôže sa nájsť na mape, nájsť najbližšiu reštauráciu, hotel, banku, benzínovú pumpu atď. Nevyžaduje pripojenie k internetu.\n\nNeustále pracujeme na nových funkciách a radi by sme počuli váš názor, ako môžeme vylepšiť Organic Maps. Pokiaľ máte s touto aplikáciou akékoľvek problémy, tak nás neváhajte kontaktovať na support@organicmaps.app. Odpovedáme na každú požiadavku!\n\nPáči sa vám Organic Maps a chceli by ste nás podporiť? Existuje niekoľko ľahkých spôsobov celkom zadarmo:\n\n-napíšte recenziu vo svojom obchode s aplikáciami\n-označte našu stránku http://www.facebook.com/OrganicMaps pomocou Páči sa mi to\n- alebo len povedzte o Organic Maps svojej mame, priateľom a kolegom :)\n\nĎakujeme, že ste s nami. Veľmi oceňujeme vašu podporu!\n\nP.S. Mapové dáta získavame z OpenStreetMap, čo je mapový projekt podobný Wikipédii, ktorý umožňuje užívateľom vytvárať a upravovať mapy. Pokiaľ zistíte, že na mape niečo chýba alebo je nesprávné, môžete to opraviť priamo na https://www.openstreetmap.org, a vaše zmeny sa objavia v budúcej verzii Organic Maps.";
-
 /* Alert text */
 "email_error_body" = "Emailový klient nebol nastavený. Nakonfigurujte ho prosím alebo použite iný spôsob k tomu, abyste nás kontaktovali na %@";
 
@@ -569,12 +391,6 @@
 /* Search category */
 "wifi" = "WiFi";
 
-/* Update map suggestion */
-"routing_map_outdated" = "Pre vytvorenie trasy si, prosím, aktualizujte mapu.";
-
-/* Update maps suggestion */
-"routing_update_maps" = "Nová verzia aplikácie Organic Maps umožňuje vytvárať trasy z vašej aktuálnej polohy do cieľového bodu. Pre použitie tejto funkcie si, prosím, aktualizujte mapy.";
-
 /* Update all button text */
 "downloader_update_all_button" = "Aktualizovať všetko";
 
@@ -583,9 +399,6 @@
 
 /* Downloaded maps category */
 "downloader_downloaded_subtitle" = "Stiahnuté";
-
-/* Downloaded maps category */
-"downloader_available_maps" = "Dostupné";
 
 /* Country queued for download */
 "downloader_queued" = "V rade";
@@ -598,17 +411,6 @@
 
 "downloader_downloading" = "Sťahovanie:";
 
-"downloader_search_results" = "Nájdených";
-
-/* Disclaimer message */
-"routing_disclaimer" = "Tvorenie trás v aplikácii Organic Maps, prosím, majte na pamäti nasledovné:\n\n  - Navrhnuté trasy možno považovať iba za odporúčanie.\n - Stav vozovky, dopravné predpisy a značenie majú vyššiu prioritu, ako navigačné rady.\n - Mapa môže byť nesprávna alebo zastaraná a trasy nemusia byť vytvorené tým najlepším možným spôsobom.\n\n  Buďte na cestách v bezpečí a postarajte sa o seba!";
-
-/* Outdated maps category */
-"downloader_outdated_maps" = "Zastarané";
-
-/* Up to date maps category */
-"downloader_uptodate_maps" = "Aktualizované";
-
 /* Status of outdated country in the list */
 "downloader_status_outdated" = "Aktualizácia";
 
@@ -618,49 +420,14 @@
 /* Displayed in a dialog that appears when a user tries to delete a map while the app is in the follow route mode */
 "downloader_delete_map_while_routing_dialog" = "Ak chcete odstrániť mapy, prosím, zastavte navigáciu.";
 
-/* Show when user try build route, but we don't know where he */
-"routing_failed_unknown_my_position" = "Aktuálna lokácia nie je definovaná. Prosím, špecifikujte lokáciu pre vytvorenie trasy.";
-
-/* Show if use has not routing file, or InconsistentMWMandRoute */
-"routing_failed_has_no_routing_file" = "Na vytvorenie trasy sú potrebné ďalšie dáta. Začať sťahovanie?";
-
-/* StartPointNotFound */
-"routing_failed_start_point_not_found" = "Nedá sa vypočítať trasa. Žiadne cesty v blízkosti východiskového bodu.";
-
-/* EndPointNotFound */
-"routing_failed_dst_point_not_found" = "Nedá sa vypočítať trasa. Žiadne cesty v blízkosti cieľa.";
-
 /* PointsInDifferentMWM */
 "routing_failed_cross_mwm_building" = "Cesty môžu byť vytvorené len tak, že sú plne obsiahnuté v jednej mape.";
-
-/* RouteNotFound */
-"routing_failed_route_not_found" = "Nebol nájdená trasa medzi vybraným východiskom a cieľom. Prosím vyberte iný počiatočný a koncový bod.";
-
-/* InternalError */
-"routing_failed_internal_error" = "Došlo k vnútornej chybe. Prosím, skúste zmazať a znovu stiahnuť mapu. Ak problém pretrvá, prosím, kontaktujte nás na support@organicmaps.app.";
-
-/* Context menu item for downloader. */
-"downloader_download_map_and_routing" = "Na stiahnutie Mapa + Trasa";
-
-/* Context menu item for downloader. */
-"downloader_download_routing" = "Trasa na stiahnutie";
-
-/* Context menu item for downloader. */
-"downloader_delete_routing" = "Zmazať Trasu";
 
 /* Context menu item for downloader. */
 "downloader_download_map" = "Stiahnuť mapu";
 
-"downloader_download_map_no_routing" = "Stiahnite si mapu bez smerovania";
-
-/* Button for routing. */
-"routing_go" = "Štart!";
-
 /* Item status in downloader. */
 "downloader_retry" = "Zopakovať";
-
-/* Item in context menu. */
-"downloader_map_and_routing" = "Mapa + Smerovanie";
 
 /* Item in context menu. */
 "downloader_delete_map" = "Zmazať mapu";
@@ -668,29 +435,11 @@
 /* Item in context menu. */
 "downloader_update_map" = "Aktualizovať mapu";
 
-/* Item in context menu. */
-"downloader_update_map_and_routing" = "Aktualizovať mapu + Smerovanie";
-
-/* Item in context menu. */
-"downloader_map_only" = "Iba mapa";
-
-/* Toolbar title */
-"toolbar_application_menu" = "Ponuka aplikácie";
-
 /* Preference text */
 "pref_use_google_play" = "Pomocou Google Play služieb získajte svoju aktuálnu polohu";
 
 /* Text for rating dialog */
 "rating_just_rated" = "Práve som hodnotil vašu aplikáciu";
-
-/* Text for rating dialog */
-"rating_user_since" = "Som používateľ Organic Maps od roku %@";
-
-/* Text for rating dialog */
-"rating_do_like_maps" = "Páči sa vám Organic Maps?";
-
-/* Text for rating dialog */
-"rating_tap_star" = "Kliknutím na hviezdu ohodnotíte našu aplikáciu.";
 
 /* Text for rating dialog */
 "rating_thanks" = "Ďakujeme vám!";
@@ -701,23 +450,8 @@
 /* Text for rating dialog */
 "rating_send_feedback" = "Odoslať spätnú väzbu";
 
-/* Text for g+ dialog */
-"rating_google_plus" = "Kliknutím na tlačidlo g + povedzte o aplikácii svojim priateľom.";
-
 /* Text for routing error dialog */
 "routing_download_maps_along" = "Stiahnite si mapy pozdĺž trasy";
-
-/* Text for routing error dialog */
-"routing_download_map" = "Stiahnuť mapu";
-
-/* Text for routing error dialog */
-"routing_download_map_and_routing" = "Aktualizovať mapu a trasové dáta na to aby ste mohli získajte všetky funkcie Organic Maps.";
-
-/* Text for routing error dialog */
-"routing_get_routing_data" = "Získať trasové dáta";
-
-/* Text for routing error dialog */
-"routing_get_additional_data" = "Dodatočné údaje potrebné na vytvorenie trasy zo vašej polohy.";
 
 /* Text for routing error dialog */
 "routing_requires_all_map" = "In order to create a route, we need to download and update all the maps from your location to your destination.";
@@ -725,50 +459,15 @@
 /* Text for routing error dialog */
 "routing_not_enough_space" = "Nedostatok miesta";
 
-/* Text for routing error dialog */
-"routing_download_more_than_avail" = "Musíte stiahnuť %@ MB, ale k dispozícií máte len %@ MB.";
-
-/* Text for routing error dialog */
-"routing_download_roaming" = "Veľkosť súboru je %@ MB, ktoré stiahnete prostredníctvom Mobilných Dát (v Roamingu). Toto môže mať za následok dodatočné poplatky, v závislosti od dátových taríf vášho mobilného operátora.";
-
 /* bookmark button text */
 "bookmark" = "záložka";
-
-/* map is not downloaded */
-"not_found_map" = "Mapa vašej polohy nebola nájdená";
 
 /* location service disabled */
 "enable_location_services" = "Prosím, povoľte Služby určovania polohy";
 
-/* download map */
-"download_map" = "Stiahnite si mapu miesta, kde sa práve nachádzate";
-
-/* download map on iPhone */
-"download_map_iphone" = "Stiahnite si mapu pre aktuálnu polohu na vašom iPhone";
-
-/* clear pin */
-"nearby" = "V blízkosti";
-
-/* clear pin */
-"clear_pin" = "Vymazať špendlík";
-
-/* location is undefined */
-"undefined_location" = "Aktuálna lokácia nie je definovaná.";
-
-/* download country of your location */
-"download_country" = "Sťahovanie krajiny vašej aktuálnej polohy";
-
-/* download failed */
-"download_failed" = "Sťahovanie zlyhalo";
-
-/* get the map */
-"get_the_map" = "Stiahnuť mapu";
-
 "save" = "Uložiť";
 
 "edit_description_hint" = "Váš popis (text alebo html)";
-
-"new_group" = "nová skupina";
 
 "create" = "vytvoriť";
 
@@ -795,30 +494,6 @@
 
 /* pink color */
 "pink" = "Ružová";
-
-/* deep purple color */
-"deep_purple" = "Tmavofialová";
-
-/* light blue color */
-"light_blue" = "Svetlo modrá";
-
-/* cyan color */
-"cyan" = "Tyrkysová";
-
-/* teal color */
-"teal" = "Modrozelená";
-
-/* lime color */
-"lime" = "Limetková";
-
-/* deep orange color */
-"deep_orange" = "Tmavo oranžová";
-
-/* gray color */
-"gray" = "Sivá";
-
-/* blue gray color */
-"blue_gray" = "Modro sivá";
 
 /* Wi-Fi available */
 "WiFi_available" = "Áno";
@@ -848,13 +523,9 @@
 
 "dialog_routing_location_unknown_turn_on" = "Aktuálne súradnice GPS sa nedajú lokalizovať. Aktivujte lokalizačné služby na výpočet trasy.";
 
-"dialog_routing_location_unknown" = "Nedajú sa lokalizovať aktuálne súradnice GPS.";
-
 "dialog_routing_download_files" = "Prevezmite si požadované súbory";
 
 "dialog_routing_download_and_update_all" = "Prevezmite si a aktualizujte všetky mapy a informácie o trase pozdĺž naplánovanej trasy na výpočet trasy.";
-
-"dialog_routing_routes_size" = "Súbory s informáciami o trase";
 
 "dialog_routing_unable_locate_route" = "Trasa sa nedá lokalizovať";
 
@@ -884,21 +555,11 @@
 
 "dialog_routing_try_again" = "Skúste znova, prosím";
 
-"dialog_routing_send_error" = "Nahláste problém";
-
-"dialog_routing_if_get_cross_route" = "Chceli by ste vytvoriť priamejšiu trasu, ktorá zahŕňa viac ako jednu mapu?";
-
-"dialog_routing_cross_route_is_optimal" = "K dispozícii je optimálnejšia trasa, ktorá presahuje hranice tejto mapy.";
-
 "not_now" = "Nie teraz";
-
-"dialog_routing_build_route" = "Vytvoriť";
 
 "dialog_routing_download_and_build_cross_route" = "Chcete si prevziať mapu a vytvoriť optimálnejšiu trasu, ktorá si vyžaduje viac ako jednu mapu?";
 
 "dialog_routing_download_cross_route" = "Prevezmite si mapu na vytvorenie optimálnejšej trasy, ktorá prekračuje okraje tejto mapy.";
-
-"dialog_routing_cross_route_always" = "Vždy prekročiť túto hranicu";
 
 
 /********** Strings for downloading map from search **********/
@@ -906,8 +567,6 @@
 "search_without_internet_advertisement" = "Stiahnutím mapy už nebudete potrebovať pripojenie k internetu a môžete si začať vyhľadávať a vytvárať trasy.";
 
 "search_select_map" = "Vybrať mapu";
-
-"search_select_other_map" = "Vybrať inú mapu";
 
 /* «Show» context menu */
 "show" = "Ukázať";
@@ -918,17 +577,11 @@
 /* «Rename» context menu */
 "rename" = "Premenovať";
 
-/* Bottom sheet: expand button (should be short) */
-"bottom_sheet_more" = "Viac…";
-
 /* Failed planning route message in navigation view */
 "routing_planning_error" = "Plánovanie trasy zlyhalo";
 
 /* Arrive routing message in navigation view */
 "routing_arrive" = "Pricestovať: %s";
-
-/* Text for routing::RouterResultCode::FileTooOld dialog. */
-"dialog_routing_download_and_update_maps" = "Prosím, pre vytvorenie trasy si stiahnite a aktualizujte všetky mapy pozdĺž trasy.";
 
 "rate_alert_title" = "Páči sa vám aplikácia?";
 
@@ -944,19 +597,11 @@
 
 "history" = "Archív";
 
-"next_turn_then" = "Potom";
-
 "closed" = "Zatvorené";
-
-"back_to" = "Späť do %@";
 
 "search_not_found" = "Ľutujeme, ale nič sme nenašli.";
 
 "search_not_found_query" = "Vyskúšajte, prosím, iný hľadaný výraz.";
-
-"search_not_found_map" = "Prosím, stiahnite si mapu, na ktorej vyhľadávate.";
-
-"search_not_found_location" = "Stiahnite si mapu svojej súčasnej polohy.";
 
 "search_history_title" = "História vyhľadávania";
 
@@ -964,23 +609,12 @@
 
 "clear_search" = "Vymazať históriu vyhľadávania";
 
-/* Title for settings to enable/disable showcase menu button */
-"showcase_settings_title" = "Zobraziť akcie";
-
 /* Place Page link to Wikipedia article (if map object has it). */
 "read_in_wikipedia" = "Wikipedia";
 
-"p2p_route_planning" = "Plánovanie trasy";
-
 "p2p_your_location" = "Vaša poloha";
 
-"p2p_from" = "Východiskový bod";
-
-"p2p_to" = "Cieľový bod";
-
 "p2p_start" = "Štart";
-
-"p2p_planning" = "Plánovanie…";
 
 "p2p_from_here" = "Cesta z";
 
@@ -1018,15 +652,9 @@
 
 "editor_correct_mistake" = "Opraviť chybu";
 
-"editor_correct_mistake_message" = "Chyba pri úprave. Opravte chybu, alebo sa prepnite do jednoduchého režimu.";
-
 "editor_add_select_location" = "Poloha";
 
 "editor_done_dialog_1" = "Zmenili ste mapu sveta. Nemusíte to skrývať! Povedzte o tom svojim priateľom a začnite ju spolu upravovať.";
-
-"editor_done_dialog_2" = "Toto je vaša druhá vylepšená mapa. Momentálne ste na %d. mieste zoznamu editorov máp. Povedzte o tom svojim priateľom.";
-
-"editor_done_dialog_3" = "Práve ste vylepšili mapu. Povedzte o tom svojim priateľom a môžete mapu upraviť aj spolu.";
 
 "share_with_friends" = "Zdieľaj s priateľmi";
 
@@ -1044,20 +672,7 @@
 
 "editor_report_problem_duplicate_place_title" = "Duplicitné miesto";
 
-"first_launch_congrats_title" = "Aplikácia Organic Maps je pripravená na použitie";
-
-"first_launch_congrats_text" = "Vyhľadávajte a určujte trasu bez pripojenia všade na svete bez poplatkov.";
-
-"migrate_title" = "Dôležité!";
-
-/* Android uses image instead of text. */
-"download_all" = "Stiahnuť všetko";
-
-"delete_all" = "Vymazať všetky";
-
 "autodownload" = "Automaticky stiahnuť";
-
-"disable_autodownload" = "Zrušiť automatické preberanie";
 
 /* Place Page opening hours text */
 "closed_now" = "Teraz zatvorené";
@@ -1072,10 +687,6 @@
 "day_off" = "Deň voľna";
 
 "today" = "Dnes";
-
-"sunrise_to_sunset" = "Od východu do západu slnka";
-
-"sunset_to_sunrise" = "Od západu do východu slnka";
 
 "add_opening_hours" = "Pridať otváracie hodiny";
 
@@ -1095,45 +706,18 @@
 
 "forgot_password" = "Zabudli ste heslo?";
 
-/* Forgot Password dialog title */
-"restore_password" = "Obnovenie hesla";
-
-"enter_email_address_to_reset_password" = "Zadajte emailovú adresu, ktorú ste použili pri registrácii, a my Vám zašleme odkaz na obnovenie hesla.";
-
-"reset_password" = "Obnoviť heslo";
-
-"username" = "Používateľské meno";
-
 "osm_account" = "OSM účet";
 
 "logout" = "Odhlásiť sa";
 
-"login_and_edit_map_motivation_message" = "Prihláste sa a upravte informácie o objektoch na mape, a my ich sprístupníme miliónom ďalších používateľov. Urobme svet spoločne lepším.";
-
 /* Information text: "Last upload 11.01.2016" */
 "last_upload" = "Posledné nahrávanie";
 
-/* Motivates user to login/register, title above login buttons. */
-"you_have_edited_your_first_object" = "Upravili ste svoj prvý objekt!";
-
 "thank_you" = "Ďakujeme Vám";
-
-"login_with_google" = "Prihlásiť sa cez Google";
-
-"login_with_openstreetmap" = "Prihlásiť sa cez www.openstreetmap.org";
 
 "edit_place" = "Upraviť miesto";
 
 "place_name" = "Názov miesta";
-
-/* title above languages list cells in the editor, below editable name text field. */
-"other_languages" = "Iné jazyky";
-
-/* small button to open list with names in different languages */
-"show_more" = "Zobraziť viac";
-
-/* small button to close list with names in different languages */
-"show_less" = "Zobraziť menej";
 
 "add_language" = "Pridať jazyk";
 
@@ -1164,8 +748,6 @@
 
 "please_note" = "Upozorňujeme vás, že";
 
-"common_no_wifi_dialog" = "Pripojenie k WiFi nie je k dispozícii. Chcete pokračovať s využitím mobilných dát?";
-
 "downloader_delete_map_dialog" = "Všetky zmeny týkajúce sa mapy budú vymazané spolu s mapou.";
 
 "downloader_update_maps" = "Aktualizovať mapy";
@@ -1173,10 +755,6 @@
 "downloader_mwm_migration_dialog" = "Ak chcete vytvoriť cestu, musíte najskôr aktualizovať všetky mapy a potom odznova naplánovať trasu.";
 
 "downloader_search_field_hint" = "Nájsť mapu";
-
-"migration_update_all_button" = "Aktualizovať všetky mapy";
-
-"migration_delete_all_download_current_button" = "Stiahnite si aktuálnu mapu a odstráňte neaktuálne mapy";
 
 "migration_download_error_dialog" = "Chyba pri sťahovaní";
 
@@ -1186,21 +764,9 @@
 
 "downloader_no_space_message" = "Prosím, odstráňte prebytočné dáta";
 
-"editor_general_auth_error_dialog" = "Pri prihlasovaní sa vyskytla všeobecná chyba.";
-
 "editor_login_error_dialog" = "Pri prihlasovaní sa vyskytla chyba.";
 
-"editor_login_failed_dialog" = "Prihlasovanie bolo neúspešné";
-
-"editor_username_error_dialog" = "Používateľské meno je neplatné";
-
-"editor_place_edited_dialog" = "Práve ste upravili objekt!";
-
-"editor_login_with_osm" = "Prihlásiť sa prostredníctvom OpenStreetMap";
-
 "editor_profile_changes" = "Overené zmeny";
-
-"editor_profile_unsent_changes" = "Neodoslané:";
 
 "editor_focus_map_on_location" = "Ak chcete nastaviť správnu polohu objektu, posuňte mapu.";
 
@@ -1222,13 +788,9 @@
 
 "editor_report_problem_other_title" = "Iný problém";
 
-"placepage_report_problem_button" = "Nahlásiť problém";
-
 "placepage_add_business_button" = "Pridať organizáciu";
 
 "whatsnew_editor_message_1" = "Na mapu môžete pridávať nové miesta a upravovať tie, ktoré sú už pridané.";
-
-"whatsnew_editor_message_2" = "* Organic Maps využíva dáta komunity OpenStreetMap.";
 
 "dialog_incorrect_feature_position" = "Zmeniť polohu";
 
@@ -1236,16 +798,10 @@
 
 "login_to_make_edits_visible" = "Prihláste sa, aby mohli ostatní užívatelia vidieť Vami vykonané zmeny.";
 
-"no_migration_during_navigation" = "Počas hľadania trasy nie je možné vykonať aktualizáciu.";
-
 /* Error dialog no space */
 "migration_no_space_message" = "Ak chcete pokračovať v sťahovaní, musíte uvoľniť viac miesta na ukladacom priestore. Prosím, odstráňte prebytočné dáta.";
 
 "editor_sharing_title" = "Vďaka mne sú mapy na Organic Maps lepšie";
-
-"editor_comment_will_be_sent" = "Pošleme Váš príspevok kartografom.";
-
-"editor_unsupported_category_message" = "Pridali ste miesto z kategórie, ktorú zatiaľ nepodporujeme. Na mape sa zobrazí až za istú dobu.";
 
 /* Downloaded 10 **of** 20 <- it is that "of" */
 "downloader_of" = "%1$d z %2$d";
@@ -1278,23 +834,9 @@
 
 "editor_operator" = "Prevádzkovateľ";
 
-"editor_tag_description" = "Zadajte spoločnosť, organizáciu alebo osobu zodpovednú za prevádzku.";
-
-"editor_no_local_edits_title" = "Nemáte miestne poznámky";
-
-"editor_no_local_edits_description" = "Tu sa zobrazuje počet navrhovaných zmien na mape momentálne dostupných len vo vašom zariadení.";
-
-"editor_send_to_osm" = "Odoslať do OSM";
-
-"editor_remove" = "Odstrániť";
-
-"downloader_my_maps_title" = "Moje mapy";
-
 "downloader_no_downloaded_maps_title" = "Neprevzali ste žiadne mapy";
 
 "downloader_no_downloaded_maps_message" = "Prevziať mapy na nájdenie pozície a navigovanie off-line.";
-
-"downloader_find_place_hint" = "Hľadať mesto alebo krajinu";
 
 /* Error title that appears after certain time without location. */
 "current_location_unknown_title" = "Pokračovať v mazaní vašej súčasnej pozície?";
@@ -1321,47 +863,13 @@
 /* iOS Dialog for the case when the location permission is not granted */
 "location_services_disabled_3" = "3. Vyberte si počas používania aplikácie";
 
-"placepage_parking_surface" = "Typ parkoviska";
-
-"placepage_parking_multistorey" = "Viacpodlažné";
-
-"placepage_parking_underground" = "Podzemné";
-
-"placepage_parking_rooftop" = "Na streche";
-
-"placepage_parking_sheds" = "Garáž";
-
-"placepage_parking_carports" = "Otvorené garáže";
-
-"placepage_parking_boxes" = "Hromadné garáže";
-
-"placepage_parking_pay" = "Platené";
-
-"placepage_parking_free" = "Zdarma";
-
-"placepage_parking_interval" = "Platba v intervaloch";
-
-"placepage_entrance_number" = "Číslo";
-
-"placepage_entrance_type" = "Vstup";
-
-"placepage_flat" = "Byt";
-
-"placepage_open_24_7" = "24 / 7";
-
 "meter" = "m";
 
 "kilometer" = "km";
 
-"kilometers_per_hour" = "km/h";
-
 "mile" = "mi";
 
 "foot" = "stopa";
-
-"miles_per_hour" = "mph";
-
-"day" = "d";
 
 "hour" = "hod";
 
@@ -1381,10 +889,6 @@
 
 "placepage_bookmark_name_hint" = "Názov záložky";
 
-"placepage_personal_notes_hint" = "Osobné poznámky";
-
-"placepage_delete_bookmark_button" = "Zmazať záložku";
-
 "editor_edits_sent_message" = "Vykonali sa vami odporúčané zmeny";
 
 "editor_comment_hint" = "Poznámka…";
@@ -1397,8 +901,6 @@
 
 "editor_remove_place_button" = "Odstrániť";
 
-"editor_status_sending" = "Odosiela sa…";
-
 "editor_place_doesnt_exist" = "Miesto neexistuje";
 
 "text_more_button" = "…viac";
@@ -1410,11 +912,7 @@
 
 "error_enter_correct_email" = "Zadajte platný email";
 
-"error_enter_correct" = "Zadajte platnú hodnotu";
-
 "refresh" = "Aktualizovať";
-
-"last_update" = "Naposledy aktualizované: %s";
 
 "placepage_add_place_button" = "Pridať miesto na mape";
 
@@ -1426,24 +924,6 @@
 
 "editor_share_to_all_dialog_message_2" = "Skontrolujeme zmeny. V prípade otázok vás budeme kontaktovať emailom.";
 
-"navigation_overview_button" = "zhrnutie";
-
-"navigation_stop_button" = "stop";
-
-/* Text on an empty bookmark page */
-"bookmarks_empty_title" = "Uložiť záložky";
-
-"bookmarks_empty_message_1" = "Ak si chcete uložiť obľúbené miesta pre rýchly prístup, klepnite na ★.";
-
-"bookmarks_empty_message_2" = "Importujte si záložky z emailu a webu.";
-
-"bookmarks_empty_message_3" = "odchod: %s";
-
-/* Name of the group for booked hotels */
-"bookmarks_group_name" = "Rezervované hotely";
-
-"place_page_button_read_descriprion" = "Prečítajte si";
-
 /* iOS dialog for the case when recent track recording is on and the app comes back from background */
 "recent_track_background_dialog_title" = "Znemožniť nahrávanie vami nedávno precestovanej trasy?";
 
@@ -1451,8 +931,6 @@
 
 /* For sharing via SMS and so on */
 "sharing_call_action_look" = "Pozrite si";
-
-"continue_recent_track_background_button" = "Pokračovať";
 
 "recent_track_background_dialog_message" = "Organic Maps používa vašu geopozíciu na pozadí pre zaznamenávanie vami nedávno precestovanej trasy.";
 
@@ -1468,33 +946,13 @@
 /* About short text (below logo) */
 "about_description" = "Organic Maps je offine aplikácia na cestovanie. Základom aplikácie Organic Maps sú dáta OpenStreetMap, pričom aplikácia nám ich umožňuje upravovať.";
 
-/* Text in menu */
-"blog" = "Blog";
-
 "general_settings" = "Všeobecné nastavenia";
-
-"date" = "Dátum %d";
-
-/* "Report a bug" -> "Generaal Feedback" -> "Something is not working" */
-"something_is_not_working" = "Niečo nefunguje";
 
 /* For the first routing */
 "accept" = "Prijať";
 
-"accept_and_continue" = "Accept and continue";
-
 /* For the first routing */
 "decline" = "Odmietnuť";
-
-"install_app" = "Nainštalovať";
-
-"search_no_results_title" = "Nenašli sa žiadne výsledky";
-
-"search_no_results_message" = "Skúste vyhľadávať všeobecnejší výraz, vzdialiť alebo obnoviť nastavenie filtra.";
-
-"search_no_results_expand_area_button" = "Vzdialiť";
-
-"search_no_results_reset_button" = "Obnoviť filter";
 
 /* noun */
 "search_in_table" = "Zoznam";
@@ -1517,8 +975,6 @@
 
 "traffic_update_maps_text" = "Na zobrazenie dopravných informácií je potrebné aktualizovať mapy.";
 
-"traffic_outdated" = "Dopravné informácie sú neaktuálne.";
-
 "big_font" = "Zväčšiť veľkosť písma na mape";
 
 "traffic_update_app" = "Aktualizujte si aplikáciu Organic Maps";
@@ -1529,17 +985,7 @@
 /* "traffic" as in "road congestion" */
 "traffic_data_unavailable" = "Dopravné informácie nie sú k dispozícii";
 
-/* "Translation is no needed, because it's a company name" */
-"uber" = "Uber";
-
-/* Simplified colour scheme for traffic information, fewer colours are used to display traffic jams on the map. The string should be kept as short as possible */
-"pref_traffic_simplified_colors_title" = "Zjednodušené farby dopravy";
-
 "enable_logging" = "Zapnúť zaznamenávanie";
-
-"offline_place_page_more_information" = "Viac informácií o mieste získate po pripojení na internet.";
-
-"failed_load_information" = "Nepodarilo sa načítať informácie.";
 
 /* Settings: "Send general feedback" button */
 "feedback_general" = "Všeobecné pripomienky";
@@ -1556,8 +1002,6 @@
 
 "whatsnew_transliteration_title" = "Prepis do latinčiny";
 
-"yandex_taxi_title" = "Yandex.Taxi";
-
 "learn_more" = "Zistiť viac";
 
 "core_exit" = "Ukončiť";
@@ -1568,75 +1012,19 @@
 
 "button_exit" = "Ukončiť";
 
-"settings_device_memory" = "Pamäť zariadenia";
-
-"settings_card_memory" = "Pamäť na karte";
-
-"settings_storage_available" = "K dispozícii %s";
-
-"toast_location_permission_denied" = "Zamietnutý prístup aplikácie k lokalite";
-
-"button_use" = "Použiť";
-
 "planning_route_manage_route" = "Spravovať trasu";
 
 "button_plan" = "Naplánovať";
-
-"button_add" = "Pridať";
 
 "placepage_remove_stop" = "Odstrániť";
 
 "planning_route_remove_title" = "Presunutím sem odstránite";
 
-"dialog_change_start_point_message" = "Nahradiť štart na aktuálnou polohou?";
-
-"button_replace" = "Nahradiť";
-
 "placepage_add_stop" = "Pridať zastávku";
-
-/* Only ru/en are needed */
-"subtitle_rent" = "Rent";
-
-/* Only ru/en are needed */
-"rub_month" = "RUB/month";
-
-/* Only ru/en are needed */
-"room" = "%s-room apt.";
-
-/* Only ru/en are needed */
-"real_estate" = "Real estate";
-
-"add_my_position" = "Pridať moju polohu";
-
-"choose_start_point" = "Vyberte počiatočný bod";
-
-"choose_destination" = "Vyberte cieľ";
 
 "preloader_viator_button" = "Zistiť viac";
 
-"start_from_my_position" = "Začať od";
-
-"profile_authorization_title" = "Prihlásiť sa pomocou";
-
-"profile_authorization_message" = "Jednoduché prihlásenie bez zadávania mena a hesla za pár sekúnd";
-
 "profile_authorization_error" = "Ups, vyskytla sa chyba. Skúste sa prihlásiť znova.";
-
-"service" = "Služba";
-
-"atmosphere" = "Atmosféra";
-
-"value_for_money" = "Hodnota za peniaze";
-
-"experience" = "Skúsenosti";
-
-"assortment" = "Sortiment";
-
-"expertise" = "Odbornosť";
-
-"equipment" = "Vybavenie";
-
-"quality" = "Kvalita";
 
 "dialog_error_storage_title" = "Problém s prístupom k úložisku";
 
@@ -1644,17 +1032,7 @@
 
 "setting_emulate_bad_storage" = "Imitovať poškodené úložisko";
 
-"directions_finish" = "Ciel";
-
-"directions_on_foot" = "Chôdza %s";
-
 "core_entrance" = "Vchod  | vjazd";
-
-"coffee" = "Káva";
-
-"cleanliness" = "Čistota";
-
-"crowdedness" = "Preplnenosť";
 
 "error_enter_correct_name" = "Prosím, zadajte správne meno";
 
@@ -1673,11 +1051,9 @@
 
 "downloader_percent" = "%s (%s z %s)";
 
-"downloader_process" = "Sťahovanie %s...";
+"downloader_process" = "Sťahovanie %s…";
 
-"downloader_applying" = "Použitie %s...";
-
-"dialog_message_transit_not_found_connection" = "Naplánujte si trasu v jednej sieti verejnej dopravy";
+"downloader_applying" = "Použitie %s…";
 
 "bookmarks_error_message_share_general" = "Pre chybu aplikácie nie je zdieľanie možné";
 
@@ -1695,17 +1071,7 @@
 
 "bookmarks_error_message_list_name_already_taken" = "Vyberte iné meno";
 
-"bookmarks_error_title_list_name_too_long" = "Tento názov je príliš dlhý";
-
-"bookmarks_error_message_list_name_too_long" = "Vyberte iné meno";
-
-"please_wait" = "Prosím čakajte...";
-
-"phone_number" = "Telefónne číslo";
-
-"notification_unsent_reviews_title" = "Máte niekoľko neoslaných recenzií";
-
-"notification_unsent_reviews_message" = "Prihláste sa a zdieľajte recenzie s ostatnými cestujúcimi";
+"please_wait" = "Prosím čakajte…";
 
 "profile" = "Profil OpenStreetMap";
 
@@ -1719,49 +1085,13 @@
 
 "bookmarks_convert_error_message" = "Niektoré súbory neboli konvertované.";
 
-"converting" = "Konverziu...";
-
-"wn_reinvented_bookmarks_title" = "Znovu sme vytvorili záložky!";
-
-"wn_reinvented_bookmarks_message" = "Môžete zálohovať záložky, vytvárať zoznamy... Je to úžasné...";
-
-"bookmarks_restore" = "Obnoviť záložky";
-
-"bookmarks_restore_process" = "Obnovenie...";
-
 "bookmarks_restore_title" = "Obnoviť túto verziu?";
 
-"bookmarks_restore_message" = "Záložky sa obnovia z %s (%s)";
-
-"bookmarks_restore_empty_title" = "Nemáte zálohu";
-
-"bookmarks_restore_empty_message" = "Server nenašiel predtým vytvorené zálohy";
-
 "common_check_internet_connection_dialog_title" = "Žiadne internetové pripojenie";
-
-"error_server_title" = "Chyba servera";
-
-"error_server_message" = "Na serveri sa vyskytla chyba, skúste to znova neskôr";
 
 "error_system_message" = "Vyskytla sa neznáma chyba";
 
 "restore" = "Obnoviť";
-
-"bookmarks_page_downloaded" = "Prevzaté";
-
-"bookmarks_page_my" = "Moje";
-
-"routes_and_bookmarks" = "Trasy a záložky";
-
-"bookmarks_webview_success_toast" = "Záložky úspešne prevzaté";
-
-"cached_bookmarks_placeholder_title" = "Prevziať nové miesta";
-
-"cached_bookmarks_placeholder_subtitle" = "Stlačením tlačidla stiahnete tisíce zaujímavých miest a trás vytvorených používateľmi Organic Maps. Budete potrebovať internetové pripojenie.";
-
-"downloader_download_routers" = "Prevziať záložky";
-
-"bookmarks_groups_cached" = "Prevziať zoznamy";
 
 "subtittle_opt_out" = "Nastavenie sledovania";
 
@@ -1769,29 +1099,15 @@
 
 "crash_reports_description" = "Vaše údaje môžeme použiť na zlepšenie skúseností s programom Organic Maps. Zmeny sa prejavia po reštartovaní aplikácie.";
 
-"opt_out_help_ios_1" = "Vaše mobilné zariadenie môže poskytnúť nastavenie „Obmedziť reklamné sledovanie“ alebo „Zrušiť inzerciu založenú na záujmoch“.";
-
-"opt_out_help_ios_2" = "iOS 9 alebo vyšší";
-
-"opt_out_help_ios_3" = "Prejdite do nastavenia → Ochrana osobných údajov → Reklama → Povolenie nastavenia „Obmedziť reklamné sledovanie“";
-
-"opt_out_help_android" = "Vaše mobilné zariadenie môže obsahovať nastavenie „Obmedziť reklamné sledovanie“ alebo „Zrušiť inzerciu založenú na záujmoch“. \n\nPre Android a služby Google Play verzie 4.0 a vyššie: \nNastavenia → Google → Reklamy → Zrušiť inzerciu založenú na záujmoch \nalebo\nNastavenia → Google → Google Účet → Osobné informácie a ochrana osobných údajov → Nastavenia reklamy → Personalizácia reklám";
-
 "privacy_policy" = "Zásady ochrany osobných údajov";
 
 "terms_of_use" = "Podmienky používania";
-
-"backup_notification_failed" = "Zálohovanie záložiek bolo pozastavené. Pre opätovné zapnutie sa prihláste.";
 
 "button_layer_traffic" = "Vyťaženie";
 
 "button_layer_subway" = "Metro";
 
 "layers_title" = "Vrstvy mapy";
-
-"layers_message" = "Na zobrazenie návštevnosti, mapy metra a ďalších užitočných informácií použite vrstvy mapy";
-
-"button_layer_got_it" = "Mám to";
 
 "subway_data_unavailable" = "Mapa metra nie je dostupná";
 
@@ -1803,39 +1119,13 @@
 
 "title_error_downloading_bookmarks" = "Vyskytla sa chyba";
 
-"subtitle_error_downloading_bookmarks" = "Záložky neboli stiahnuté";
-
-"error_already_downloaded" = "Tento zoznam už bol stiahnutý";
-
 "popular_place" = "Popular";
-
-"download_routes" = "Download routes";
-
-"bookmarks_downloaded_title" = "Bookmarks have been downloaded successfully";
-
-"bookmarks_downloaded_subtitle" = "Press ‘View on map’ to explore new places from the list";
-
-"why_support" = "Prečo podporiť Organic Maps?";
-
-"why_support_item1" = "We respect your privacy: there are zero trackers in the app, and we are open source";
-
-"why_support_item2" = "Pomôžete nám zlepšiť Organic Maps";
-
-"why_support_item3" = "Pomôžete nám vylepšiť otvorené mapy OpenStreetMap.org";
-
-"channels_map_update" = "Aktualizácia máp";
-
-"server_unavailable_title" = "Server je nedostupný";
-
-"sharing_options" = "Možnosti zdieľania";
 
 "export_file" = "Exportovať súbor";
 
 "list_settings" = "Nastavenie zoznamu";
 
 "delete_list" = "Vymazať zoznam";
-
-"hide_from_map" = "Skryť z mapy";
 
 "public_access" = "Verejný prístup";
 
@@ -1845,40 +1135,11 @@
 
 "bookmark_category_description_hint" = "Zadajte popis (text alebo html)";
 
-/* FIXME */
-"bookmarks_public_access" = "bookmarks_public_access";
-
-/* FIXME */
-"bookmarks_link_access" = "bookmarks_link_access";
-
-/* FIXME */
-"bookmarks_private_access" = "bookmarks_private_access";
-
 "not_shared" = "Súkromné";
-
-"direct_link_progress_text" = "Nahrávanie váľho súboru…";
-
-"direct_link_success" = "Odkaz bol vytvorený";
-
-"send_a_link_btn" = "Poslať mi odkaz";
-
-"upload_error_toast" = "Počas nahrávania súboru sa vyskytla chyba";
 
 "tags_loading_error_subtitle" = "Počas načítavania značiek sa vyskytla chyba, skúste to znova";
 
-"unable_upload_errorr_title" = "Nahrávanie súboru zlyhalo";
-
-"unable_upload_error_subtitle_edited" = "Tento súbor bol upravený prostredníctvom webovej aplikácie";
-
-"unable_upload_error_subtitle_broken" = "Tento súbor je poškodený a nedá sa nahrať. Prosím nahrajte iný súbor.";
-
-"contact" = "Kontakt";
-
-"download_button" = "Stiahnuť";
-
 "speedcams_alert_title" = "Rýchlostné kamery";
-
-"speedcams_alert_subtitle" = "Upozornenie na rýchlostné obmedzenia";
 
 "speedcam_option_auto" = "Automaticky";
 
@@ -1886,18 +1147,10 @@
 
 "speedcam_option_never" = "Nikdy";
 
-"bookmark_description_title" = "Popis záložiek";
-
 "place_description_title" = "Popis miesta";
 
 /* this text will be shown in application notification preferences opposite checkbox which enable/disable downloader notifications. Devices on Android 8+ are affected. */
 "notification_channel_downloader" = "Sťahovač máp";
-
-"share_bookmarks_email_body_link" = "Dobrý deň!\n\nTu je odkaz, kde si môžete stiahnuť svoje záložky: %s. Otvorte zoznam prostredníctvom služby Organic Maps a užite si výlet!\n\nZískajte aplikáciu: https://omaps.app/get?kmz";
-
-"warning_speedcams_title" = "Navigátor vás upozorní na kamery, keď prekročíte rýchlostný limit %d km/h";
-
-"warning_speedcams_subtitle" = "Dodržujte pravidlá cestnej premávky v krajine, do ktorej cestujete.";
 
 "speedcams_notice_message" = "Automaticky - Upozornenie na rýchlostné kamery, ak existuje riziko prekročenia rýchlostného limitu\nVždy - Vždy upozorniť na rýchlostné kamery\nNikdy - Nikdy neupozorňovať na rýchlostné kamery";
 
@@ -1913,23 +1166,7 @@
 
 "enable_logging_warning_message" = "Táto možnosť zapína zaznamenávanie na diagnostické účely. Môže to byť užitočné pre našu technickú podporu, ktorá rieši problémy s aplikáciou. Povoliť túto možnosť iba na požiadanie podpory Organic Maps.";
 
-"html_error_upload_message_try_again" = "Skontrolujte svoje sieťové nastavenia a skúste to znova";
-
-"html_error_upload_title_try_again" = "Žiadne internetové pripojenie";
-
-"notification_leave_review_v2_android_short_title" = "Ohodnotiť a pomôcť cestujúcim!";
-
-"megafon" = "Say goodbye to roaming!";
-
-"notifications_illegal_alert_disable_button" = "Vypnite upozornenia";
-
 "access_rules_author_only" = "Online úprava";
-
-"privacy_settings_menu" = "Nastavenia ochrany osobných údajov";
-
-"unable_upadate_error_title" = "Aktualizácia súboru zlyhala";
-
-"unable_upadate_error_message" = "Počas aktualizácie sa vyskytli určité chyby. Skontrolujte zmeny a skúste to znova";
 
 "driving_options_title" = "Možnosti jazdy";
 
@@ -1951,94 +1188,19 @@
 
 "change_driving_options_btn" = "Možnosti trasy povolené";
 
-"toll_road" = "Spoplatnená cesta";
-
-"unpaved_road" = "Nespevnená cesta";
-
-"ferry_crossing" = "Prechod trajektom";
-
-"operated_by" = "Prevádzkuje \"%s\"";
-
 "avoid_toll_roads_placepage" = "Vyhnúť sa spoplatneným cestám";
 
 "avoid_unpaved_roads_placepage" = "Vyhnúť sa nespevneným cestám";
 
 "avoid_ferry_crossing_placepage" = "Vyhnúť sa prechodom na trajekte";
 
-"type.cuisine.uzbek" = "Uzbecká kuchyňa";
-
-"trip_start" = "Poďme";
-
-"pick_destination" = "Cieľ";
-
-"follow_my_position" = "Vycentrovať";
-
-"search_results" = "Výsledky vyhľadávania";
-
-"then_turn" = "Potom";
-
-"redirect_route_alert" = "Chcete znova vytvoriť trasu?";
-
-"redirect_route_yes" = "Áno";
-
-"redirect_route_no" = "Nie";
-
-"trip_finished" = "Prišli ste do cieľa!";
-
-"keyboard_availability_alert" = "Počas jazdy nie je klávesnica k dispozícii";
-
-"dialog_routing_change_start_carplay" = "Z vašej aktuálnej polohy nie je možné vytvoriť trasu";
-
-"dialog_routing_change_end_carplay" = "Nie je možné vytvoriť trasu do cieľa. Prosím vyberte iný bod";
-
-"dialog_routing_check_gps_carplay" = "Žiaden GPS signál. Presuňte sa na otvorené priestranstvo";
-
-"dialog_routing_unable_locate_route_carplay" = "Nie je možné vytvoriť trasu. Prosím zadajte iné body trasy";
-
-"dialog_routing_download_files_carplay" = "Pre vytvorenie trasy si stiahnite do zariadenia chýbajúce mapy";
-
-"dialog_routing_system_error_carplay" = "Vyskytla sa chyba. Prosím reštartujte aplikáciu";
-
-"dialog_routing_rebuild_from_current_location_carplay" = "Trasa bude obnovená z vašej aktuálnej polohy";
-
-"dialog_routing_rebuild_for_vehicle_carplay" = "Trasa bude upravená na jazdu autom";
-
 "ok" = "Ok";
-
-"avoid_unpaved_carplay_1" = "Nespevn. NIE";
-
-"avoid_unpaved_carplay_2" = "Nespevnené ÁNO";
-
-"avoid_ferry_carplay_1" = "Trajekty NIE";
-
-"avoid_ferry_carplay_2" = "Trajekty ÁNO";
-
-"avoid_tolls_carplay_1" = "Spoplat. NIE";
-
-"avoid_tolls_carplay_2" = "Spoplatnené ÁNO";
-
-"speedcams_alert_title_carplay_1" = "Radary";
-
-"speedcams_alert_title_carplay_2" = "Rýchl. upozorn.";
-
-"download_map_carplay" = "Prosím stiahnite si mapy v aplikácii Organic Maps vo vašom zariadení";
-
-"carplay_roundabout_exit" = "%s výjazd";
 
 /* max. 10 symbols, both iOS and Android */
 "sort" = "Zoradiť…";
 
 /* Android, title, max 20-22 symbols */
 "sort_bookmarks" = "Zoradiť záložky";
-
-/* iOS */
-"sort_default" = "Zoradiť Predvolené";
-
-"sort_type" = "Zoradiť podľa typu";
-
-"sort_distance" = "Zoradiť podľa vzdialenosti";
-
-"sort_date" = "Zoradiť podľa dátumu";
 
 /* Android */
 "by_default" = "Podľa predvoleného";
@@ -2052,63 +1214,7 @@
 /* Android */
 "by_date" = "Podľa dátumu";
 
-"week_ago_sorttype" = "Pred týždňom";
-
-"month_ago_sorttype" = "Pred mesiacom";
-
-"moremonth_ago_sorttype" = "Pred viac ako mesiacom";
-
-"moreyear_ago_sorttype" = "Pred viac ako rokom";
-
-"near_me_sorttype" = "Blízko mňa";
-
-"others_sorttype" = "Iné";
-
-"food_places" = "Jedlo";
-
-"tourist_places" = "Pamiatky";
-
-"museums" = "Múzeá";
-
-"parks" = "Parky";
-
-"swim_places" = "Plávanie";
-
-"mountains" = "Hory";
-
-"animals" = "Zvieratá";
-
-"hotels" = "Hotely";
-
-"buildings" = "Budovy";
-
-"money" = "Peniaze";
-
-"shops" = "Obchody";
-
-"parkings" = "Parkovanie";
-
-"fuel_places" = "Čerpacie stanice";
-
-"water" = "Voda";
-
-"medicine" = "Medicína";
-
 "search_in_the_list" = "Vyhľadať v zozname";
-
-"view_on_map_bookmarks" = "Na mape";
-
-"more_bookmarks" = "Viac…";
-
-"no_items_found" = "Žiadne položky nenájdené";
-
-/* Android, max 18 symbols */
-"bookmarks_edit_list" = "Upraviť zoznam";
-
-/* Android, max 18 symbols */
-"bookmarks_delete_list" = "Vymazať zoznam";
-
-"religious_places" = "Náboženské miesta";
 
 "select_list" = "Vybrať zoznam";
 
@@ -2118,26 +1224,13 @@
 
 "dialog_pedestrian_route_is_long_message" = "Vyberte počiatočný alebo konečný bod bližšie k stanici metra";
 
-/* Failed planning SUBWAY route message in navigation view */
-"routing_planning_error_subway_special" = "Plánovanie trasy metra zlyhalo";
-
 "button_layer_isolines" = "Terén";
-
-"tips_map_layers_title_countour" = "Nové v Organic Maps: offline topografická vrstva!";
-
-"tips_map_layers_message_countour" = "Naplánujte a užite si výlety do prírody s istotou, že viete o tejto oblasti všetko";
 
 "isolines_activation_error_dialog" = "Ak chcete aktivovať a používať topografickú vrstvu, aktualizujte alebo stiahnite mapu oblasti";
 
 "isolines_location_error_dialog" = "Topografická vrstva ešte nie je v tejto oblasti k dispozícii";
 
 "elevation_profile_diff_level" = "Level obtiažnosti";
-
-"elevation_profile_diff_level_easy" = "Jednoduchá";
-
-"elevation_profile_diff_level_moderate" = "Mierna";
-
-"elevation_profile_diff_level_hard" = "Náročná";
 
 "elevation_profile_ascent" = "Výstup";
 
@@ -2147,25 +1240,13 @@
 
 "elevation_profile_maxaltitude" = "Max. nadmorská výška";
 
-"elevation_profile_m" = "m";
-
 "elevation_profile_difficulty" = "Obtiažnosť";
 
 "elevation_profile_distance" = "Vzdial.:";
 
-"elevation_profile_km" = "km";
-
 "elevation_profile_time" = "Čas:";
 
-"elevation_profile_hours" = "h.";
-
-"elevation_profile_minutes" = "min";
-
 "isolines_toast_zooms_1_10" = "Priblížením preskúmajte izočiary";
-
-"downloader_updating_ios" = "Aktualizovanie";
-
-"downloader_loading_ios" = "Sťahovanie";
 
 "key_information_title" = "Kľúčová informácia";
 

--- a/iphone/Maps/LocalizedStrings/sk.lproj/Localizable.stringsdict
+++ b/iphone/Maps/LocalizedStrings/sk.lproj/Localizable.stringsdict
@@ -9,21 +9,6 @@
 
 <!-- ********** Strings for downloading map from search **********/ -->
 
-  <key>bookmarks_places</key>
-  <dict>
-    <key>NSStringLocalizedFormatKey</key>
-    <string>%#@value@</string>
-    <key>value</key>
-    <dict>
-      <key>NSStringFormatSpecTypeKey</key>
-      <string>NSStringPluralRuleType</string>
-      <key>NSStringFormatValueTypeKey</key>
-      <string>d</string>
-      <key>other</key>
-      <string>%d záložiek</string>
-    </dict>
-  </dict>
-
   <key>bookmarks_detect_message</key>
   <dict>
     <key>NSStringLocalizedFormatKey</key>
@@ -34,27 +19,12 @@
       <string>NSStringPluralRuleType</string>
       <key>NSStringFormatValueTypeKey</key>
       <string>d</string>
-      <key>one</key>
-      <string>Bol nájdený %d súbor. Uvidíte to po konverzii.</string>
       <key>few</key>
       <string>Boli nájdené %d súbory. Uvidíte ich po konverzii.</string>
+      <key>one</key>
+      <string>Bol nájdený %d súbor. Uvidíte to po konverzii.</string>
       <key>other</key>
       <string>Bolo nájdených %d súborov. Uvidíte ich po konverzii.</string>
-    </dict>
-  </dict>
-
-  <key>bookmarks_objects</key>
-  <dict>
-    <key>NSStringLocalizedFormatKey</key>
-    <string>%#@value@</string>
-    <key>value</key>
-    <dict>
-      <key>NSStringFormatSpecTypeKey</key>
-      <string>NSStringPluralRuleType</string>
-      <key>NSStringFormatValueTypeKey</key>
-      <string>d</string>
-      <key>other</key>
-      <string>%s objekt</string>
     </dict>
   </dict>
 

--- a/iphone/Maps/LocalizedStrings/sv.lproj/Localizable.strings
+++ b/iphone/Maps/LocalizedStrings/sv.lproj/Localizable.strings
@@ -18,9 +18,6 @@
 /* Button which deletes downloaded country */
 "delete" = "Ta bort";
 
-/* Button "do not interrupt download" if user touched actively downloading country */
-"do_nothing" = "Fortsätt";
-
 "download_maps" = "Ladda ner kartor";
 
 /* Settings/Downloader - info for country when download fails */
@@ -28,9 +25,6 @@
 
 /* Settings/Downloader - info for country which started downloading */
 "downloading" = "Laddar ner…";
-
-/* Settings/Downloader - size string, only strings different from English should be translated */
-"kb" = "kB";
 
 /* Choose measurement on first launch alert - choose metric system button */
 "kilometres" = "Kilometer";
@@ -55,17 +49,11 @@
 /* Update maps later/Buy pro version later button text */
 "later" = "Senare";
 
-/* Don't show some dialog any more */
-"never" = "Aldrig";
-
 /* View and button titles for accessibility */
 "search" = "Sök";
 
 /* Search box placeholder text */
 "search_map" = "Sök karta";
-
-/* Settings/Downloader - info for not downloaded country */
-"touch_to_download" = "Trycka för att ladda ner";
 
 /* Settings/Downloader - 3G download warning dialog confirm button */
 "use_cellular_data" = "Ja";
@@ -73,20 +61,11 @@
 /* Location services are disabled by user alert - message */
 "location_is_disabled_long_text" = "Du har inaktiverat alla platstjänster för denna enhet eller program. Vänligen aktivera dem i Inställningar.";
 
-/* Location Services are not available on the device alert - message */
-"device_doesnot_support_location_services" = "Din enhet stöder inte platstjänster";
-
 /* View and button titles for accessibility */
 "zoom_to_country" = "Visa på kartan";
 
-/* Button text for the button at the center of the screen when the country is not downloaded */
-"country_status_download" = "Ladda ner karta\n(^ ^)";
-
 /* Button text for the button at the center of the screen when the country is not downloaded and the size should not be shown */
 "country_status_download_without_size" = "Ladda ner karta";
-
-/* Button text for the button at the center of the screen when the country is not downloaded */
-"country_status_download_without_routing" = "Hämta karta\nutan rutter (^ ^)";
 
 /* Message to display at the center of the screen when the country download has failed */
 "country_status_download_failed" = "Downloading har misslyckats";
@@ -96,19 +75,13 @@
 
 "about_menu_title" = "Om Organic Maps";
 
-"downloaded_touch_to_delete" = "Nedladdad (%@), tryck för att ta bort";
-
 "connection_settings" = "Anslutningsinställningar";
-
-"download_mb_or_kb" = "Ladda ner %@";
 
 "close" = "Stäng";
 
 "unsupported_phone" = "Hårdvaruaccelererad OpenGL krävs. Din enhet stöds tyvärr inte.";
 
 "download" = "Ladda ner";
-
-"external_storage_is_not_available" = "SD-kort/USB-lagring med nedladdade kartor är inte tillgänglig.";
 
 "disconnect_usb_cable" = "Vänligen koppla ifrån USB-kabeln eller sätt in ett minneskort för att använda Organic Maps";
 
@@ -117,8 +90,6 @@
 "not_enough_memory" = "Inte tillräckligt med utrymme för att starta appen";
 
 "download_resources" = "Innan du startar, låt oss ladda ner den generella världskartan på din enhet.\nDen behöver %@ data.";
-
-"getting_position" = "Hämtar nuvarande position";
 
 "download_resources_continue" = "Gå till karta";
 
@@ -140,23 +111,14 @@
 /* Add New Bookmark Set dialog title */
 "add_new_set" = "Lägg till ny samling";
 
-/* Place Page - Add To Bookmarks button */
-"add_to_bookmarks" = "Lägg till till bokmärken";
-
 /* Bookmark Color dialog title */
 "bookmark_color" = "Bokmärkesfärg";
 
 /* Add Bookmark Set dialog - hint when set name is empty */
 "bookmark_set_name" = "Bokmärkessamlingens namn";
 
-/* Bookmark Sets dialog title */
-"bookmark_sets" = "Bokmärkessamlingar";
-
 /* Bookmarks - dialog title */
 "bookmarks" = "Bokmärken";
-
-/* Add bookmark dialog - bookmark color */
-"color" = "Färg";
 
 /* Default bookmarks set name */
 "core_my_places" = "Mina Platser";
@@ -167,14 +129,8 @@
 /* Editor title above street and house number */
 "address" = "Adress";
 
-/* Place Page - Remove Pin button */
-"remove_pin" = "Ta bort knappnål";
-
 /* Add bookmark dialog - bookmark set, Bookmarks dialog - Bookmark set cell */
 "set" = "Samling";
-
-/* Text hint in Bookmarks dialog when no any bookmarks are added */
-"bookmarks_usage_hint" = "Du har inga bokmärken än.\nTryck var som helst på kartan för att lägga till ett bokmärke.\nBokmärken från andra källor kan också importeras och visas i Organic Maps. Öppna KML/KMZ filer med sparade bokmärken från mail, Dropbox eller webadress.";
 
 /* Settings button in system menu */
 "settings" = "Inställningar";
@@ -191,26 +147,11 @@
 /* Ask to wait user several minutes (some long process in modal dialog). */
 "wait_several_minutes" = "Detta kan ta flera minuter.\nVänligen vänta…";
 
-/* Show bookmarks from this category on a map or not */
-"visible" = "Synliga";
-
-/* Toast which is displayed when GPS has been deactivated */
-"gps_is_disabled_long_text" = "GPS har inaktiverats. Vänligen aktivera den i Inställningar.";
-
 /* Measurement units title in settings activity */
 "measurement_units" = "Längdenheter";
 
 /* Detailed description of Measurement Units settings button */
 "measurement_units_summary" = "Välj mellan mil och kilometer";
-
-/* Do search in all sources */
-"search_mode_all" = "Överallt";
-
-/* Do search near my position only */
-"search_mode_nearme" = "I närheten";
-
-/* Do search in current viewport only */
-"search_mode_viewport" = "På skärmen";
 
 /* Search category for cafes, bars, restaurants */
 "eat" = "Var att äta";
@@ -266,14 +207,8 @@
 /* Search category */
 "police" = "Polis";
 
-/* String in search result list, when nothing found */
-"no_search_results_found" = "Inga resultat";
-
 /* Notes field in Bookmarks view */
 "description" = "Anteckningar";
-
-/* Button text */
-"share_by_email" = "Dela via email";
 
 /* Email Subject when sharing bookmarks category */
 "share_bookmarks_email_subject" = "Organic Maps bokmärken har delats med dig";
@@ -295,26 +230,11 @@
 /* Warning message when doing search around current position */
 "unknown_current_position" = "Din position har inte bestämts ännu";
 
-/* Warning message when location country isn't downloaded during search (see also download_location_map_proposal). */
-"download_location_country" = "Ladda ner landet vid din nuvarande position (%@)";
-
-/* Warning message when viewport country isn't downloaded during search */
-"download_viewport_country_to_search" = "Ladda ner landet du söker på (%@)";
-
 /* Alert message that we can't run Map Storage settings due to some reasons. */
 "cant_change_this_setting" = "Ledsen, Kartlagring är inaktiverat i inställningar";
 
 /* Alert message that downloading is in progress. */
 "downloading_is_active" = "Nedladdning av landet är startat nu.";
-
-/* Message that will be shown in alert view, when we ask user to leave review on App Store */
-"appStore_message" = "Hoppas du gillar att använda Organic Maps! I så fall, skriv en recension eller ge ett betyg på App Store. Det tar mindre än en minut men kan verkligen hjälpa oss. Tack för din hjälp!";
-
-/* No, thanks */
-"no_thanks" = "Nej, tack";
-
-/* Share one specific bookmark using SMS, %1$@ contains om:// and %2$@ https://omaps.app link. @NOTE non-ascii symbols in the link will result in max 70 characters SMS instead of 140. */
-"bookmark_share_sms" = "Hej, kolla på min pin på Organic Maps! %1$@ eller %2$@ Har du inte offline-kartor installerat? Ladda ner här: https://omaps.app/get";
 
 /* Share my position using SMS, %1$@ contains om:// and %2$@ https://omaps.app link WITHOUT NAME. @NOTE non-ascii symbols in the link will result in max 70 characters SMS instead of 140. */
 "my_position_share_sms" = "Hej, kolla på min nuvarande position på Organic Maps! %1$@ eller %2$@ Har du inte offline-kartor? Ladda ner här: https://omaps.app/get";
@@ -328,23 +248,11 @@
 /* Share my position using EMail, %1$@ is om:// and %2$@ is https://omaps.app link WITHOUT NAME */
 "my_position_share_email" = "Hej,\n\nJag är här nu: %1$@. Klicka på denna länk %2$@ eller denna %3$@ för att se platsen på kartan.\n\nTack.";
 
-/* Android share by Message/SMS button text (including SMS) */
-"share_by_message" = "Dela via meddelande";
-
 /* Share button text which opens menu with more buttons, like Message, EMail, Facebook etc. */
 "share" = "Dela";
 
-/* iOS share by Message button text (including SMS) */
-"message" = "Meddelande";
-
 /* Share by email button text, also used in editor. */
 "email" = "E-post";
-
-/* Copy Link */
-"copy_link" = "Kopiera Länk";
-
-/* Text for the button that returns to caller application */
-"more_info" = "Visa Mer Info";
 
 /* Text for message when used successfully copied something */
 "copied_to_clipboard" = "Kopierat till urklippsbordet: %1$@";
@@ -354,15 +262,6 @@
 
 /* Used for bookmark editing */
 "done" = "Klar";
-
-/* Summary for preferences in MWM */
-"yopme_pref_summary" = "Välj bakskärmsinställningar";
-
-/* Title for yopme preferences in MWM */
-"yopme_pref_title" = "Bakskärmsinställningar";
-
-/* Hint for upper-right icon p2b */
-"show_on_backscreen" = "Visa på bakskärm";
 
 /* Prints version number in About dialog */
 "version" = "Version: %@";
@@ -381,19 +280,11 @@
 
 "share_my_location" = "Dela Min Plats";
 
-"menu_search" = "Sök";
-
 /* Settings general group in settings screen */
 "prefs_group_general" = "General settings";
 
 /* Settings information group in settings screen */
 "prefs_group_information" = "Information";
-
-/* Settings screen: "Map" category title */
-"prefs_group_map" = "Karta";
-
-/* Settings screen: "Miscellaneous" category title */
-"prefs_group_misc" = "Diverse";
 
 "prefs_group_route" = "Navigering";
 
@@ -419,9 +310,6 @@
 /* Settings «Map» category: «3D buildings» title */
 "pref_map_3d_buildings_title" = "3D-byggnader";
 
-/* Settings «Map» category: «3D buildings» summary */
-"pref_map_3d_buildings_subtitle" = "Påverkar batteriets livslängd";
-
 /* Settings «Route» category: «Tts enabled» title */
 "pref_tts_enable_title" = "Röstinstruktioner";
 
@@ -433,8 +321,6 @@
 
 /* Title for "Other" section in TTS settings. */
 "pref_tts_other_section_title" = "Övrigt";
-
-"pref_tts_how_to_set_up_voice" = "Hur man ställer in ljud";
 
 /* Settings «Map» category: «Record track» title */
 "pref_track_record_title" = "Senaste resväg";
@@ -455,56 +341,7 @@
 
 "recent_track_help_text" = "Detta gör att du kan spara en resväg för en viss tidsperiod och visa den på kartan. Obs: aktivering av den här funktionen ökar batterianvändningen. Spåret tas bort automatiskt från kartan när tidsintervallet slutar gälla.";
 
-"pref_track_ios_caption" = "Senaste resväg visar den väg du rest.";
-
-"pref_track_ios_subcaption" = "Välj tidsintervall för att spara resvägen.";
-
-"placepage_distance" = "Avstånd";
-
-"placepage_coordinates" = "Koordinater";
-
-"placepage_unsorted" = "Osorterade";
-
 "search_show_on_map" = "Visa på kartan";
-
-/* Used to warn user when fixing KitKat issue */
-"bookmark_move_fail" = "Vi behöver flytta dina bokmärken till internminnet, men det finns inte tillräckligt med utrymme för dem. Vänligen frigör mer minne, annars kommer bokmärkena inte finnas tillgängliga.";
-
-/* Used in More Apps menu */
-"free" = "Gratis";
-
-/* Used in More Apps menu */
-"buy" = "Köp";
-
-/* 1st search button-like result */
-"search_on_map" = "Sök på kartan";
-
-/* toast with an error */
-"no_route_found" = "Ingen rutt hittades";
-
-/* route title */
-"route" = "Rutt";
-
-/* category title */
-"routes" = "Rutter";
-
-/* text of notification */
-"download_map_notification" = "Ladda ner kartan över din nuvarande plats";
-
-/* text of notification */
-"pro_version_is_free_today" = "Fullständig version av Organic Maps är gratis idag! Ladda ner den nu och berätta för dina vänner.";
-
-/* Dialog for transferring maps from lite to pro. */
-"move_lite_maps_to_pro" = "Vi flyttar dina nedladdade kartor från Organic Maps Lite till Organic Maps. Det kan ta några minuter.";
-
-/* Message to display when maps moved. */
-"move_lite_maps_to_pro_ok" = "Dina nedladdade kartor flyttades till Organic Maps.";
-
-/* Message to display when maps move failed. */
-"move_lite_maps_to_pro_failed" = "Flytten av dina kartor misslyckades. Vänligen ta bort Organic Maps Lite och ladda ner kartorna igen.";
-
-/* Text in menu */
-"settings_and_more" = "Inställningar & Mer";
 
 /* Text in menu */
 "website" = "Webbplats";
@@ -527,14 +364,8 @@
 /* Text in menu */
 "openstreetmap" = "OpenStreetMap";
 
-/* Text in menu */
-"contact_us" = "Kontakta oss";
-
 /* Settings: Send feedback button and dialog title */
 "feedback" = "Feedback";
-
-/* Text in menu */
-"subscribe_to_news" = "Prenumerera på våra nyheter";
 
 /* Text in menu */
 "rate_the_app" = "Ge appen ett betyg";
@@ -548,15 +379,6 @@
 /* Text in menu */
 "report_a_bug" = "Rapportera en bugg";
 
-/* Email subject */
-"subscribe_me_subject" = "Anmäl mig till Organic Maps nyhetsbrev";
-
-/* Email body */
-"subscribe_me_body" = "Jag vill bli först att veta om de senaste uppdateringarna och erbjudandena. Jag kan avbryta min prenumeration när som helst.";
-
-/* About text */
-"about_text" = "Organic Maps erbjuder de snabbaste offline-kartorna över alla städer och länder i hela världen. Res med förtroende: oavsett var du är hjälper Organic Maps dig att placera dig på kartan, hitta den närmaste restaurangen, hotellet, banken, bensinstationen m.m. Den kräver inte internetanslutning.\n\nVi arbetar ständigt med nya funktioner och vill gärna veta hur du tycker att vi kan förbättra Organic Maps. Ifall du har problem med appen, tveka inte att kontakta oss på support@organicmaps.app. Vi svarar på alla mail!\n\nGillar du Organic Maps och vill hjälpa oss? Det finns några enkla och kostnadsfria sätt:\n\n- posta en recension på din Appmarknad\n- gilla vår Facebooksida http://www.facebook.com/OrganicMaps\n- eller berätta bara om Organic Maps för din mamma, vänner eller kollegor :)\n\nTack för att du är med oss. Vi uppskattar ditt stöd väldigt mycket!\n\nP.S. Vi använder oss av kartdata från OpenStreetMap, ett kartprojket som liknar Wikipedia och som tillåter användare att skapa och redigera kartor. Ifall du ser något som saknas eller är fel på kartan så kan du korrigera kartan direkt på https://www.openstreetmap.org och dina ändringar kommer att finns i Organic Maps appen när nästa version släpps.";
-
 /* Alert text */
 "email_error_body" = "Emailklienten har inte konfigurerats. Konfigurera den eller använd ett annat sätt att kontakta oss på %@";
 
@@ -569,12 +391,6 @@
 /* Search category */
 "wifi" = "WiFi";
 
-/* Update map suggestion */
-"routing_map_outdated" = "Uppdatera kartan för att skapa en rutt.";
-
-/* Update maps suggestion */
-"routing_update_maps" = "Den nya versionen av Organic Maps låter dig skapa rutter från din nuvarande position till en destinationspunkt. Uppdatera kartan för att använda den här funktionen.";
-
 /* Update all button text */
 "downloader_update_all_button" = "Uppdatera alla";
 
@@ -583,9 +399,6 @@
 
 /* Downloaded maps category */
 "downloader_downloaded_subtitle" = "Nedladdade";
-
-/* Downloaded maps category */
-"downloader_available_maps" = "Tillgänglig";
 
 /* Country queued for download */
 "downloader_queued" = "Köade";
@@ -598,17 +411,6 @@
 
 "downloader_downloading" = "Ladda ner:";
 
-"downloader_search_results" = "Hittat";
-
-/* Disclaimer message */
-"routing_disclaimer" = "När du skapar rutter i appen Organic Maps, vänligen tänk på följande:\n\n  - Föreslagna rutter kan endast ses som rekommendationer.\n - Vägskick, trafikregler och skyltar har högre prioritet än navigeringsråd.\n - Kartan kan vara felaktig eller förlegad, och rutter skapas inte alltid på bästa tänkbara sätt.\n\n  Kör säkert på vägarna och ta hand om dig själv!";
-
-/* Outdated maps category */
-"downloader_outdated_maps" = "Gammal";
-
-/* Up to date maps category */
-"downloader_uptodate_maps" = "Aktuell";
-
 /* Status of outdated country in the list */
 "downloader_status_outdated" = "Uppdatera";
 
@@ -618,49 +420,14 @@
 /* Displayed in a dialog that appears when a user tries to delete a map while the app is in the follow route mode */
 "downloader_delete_map_while_routing_dialog" = "Avsluta navigering för att radera kartan.";
 
-/* Show when user try build route, but we don't know where he */
-"routing_failed_unknown_my_position" = "Nuvarande plats är inte definierad. Ange din plats för att skapa rutt.";
-
-/* Show if use has not routing file, or InconsistentMWMandRoute */
-"routing_failed_has_no_routing_file" = "Ytterligare data behövs för att skapa en rutt. Påbörja nedladdning?";
-
-/* StartPointNotFound */
-"routing_failed_start_point_not_found" = "Rutten kan inte beräknas. Det finns inga vägar vid startpunkten.";
-
-/* EndPointNotFound */
-"routing_failed_dst_point_not_found" = "Rutten kan inte beräknas. Det finns inga vägar vid målet.";
-
 /* PointsInDifferentMWM */
 "routing_failed_cross_mwm_building" = "Rutter kan endast skapas om de finns inom en enda karta.";
-
-/* RouteNotFound */
-"routing_failed_route_not_found" = "Ingen rutt hittades mellan vald startpunkt och målet. Välj en annan start- eller slutpunkt.";
-
-/* InternalError */
-"routing_failed_internal_error" = "Ett internt fel inträffade. Försök att radera och ladda ner kartan igen. Kontakta oss på support@organicmaps.app om problemet kvarstår.";
-
-/* Context menu item for downloader. */
-"downloader_download_map_and_routing" = "Ladda ner karta + anvisningar";
-
-/* Context menu item for downloader. */
-"downloader_download_routing" = "Ladda ner anvisningar";
-
-/* Context menu item for downloader. */
-"downloader_delete_routing" = "Radera anvisningar";
 
 /* Context menu item for downloader. */
 "downloader_download_map" = "Ladda ner kartan";
 
-"downloader_download_map_no_routing" = "Hämta karta utan rutter";
-
-/* Button for routing. */
-"routing_go" = "Kör!";
-
 /* Item status in downloader. */
 "downloader_retry" = "Repetera";
-
-/* Item in context menu. */
-"downloader_map_and_routing" = "Karta + Navigering";
 
 /* Item in context menu. */
 "downloader_delete_map" = "Radera karta";
@@ -668,29 +435,11 @@
 /* Item in context menu. */
 "downloader_update_map" = "Uppdatera karta";
 
-/* Item in context menu. */
-"downloader_update_map_and_routing" = "Uppdatera karta + Navigering";
-
-/* Item in context menu. */
-"downloader_map_only" = "Endast karta";
-
-/* Toolbar title */
-"toolbar_application_menu" = "Programmeny";
-
 /* Preference text */
 "pref_use_google_play" = "Använd Google Play Services för att bestämma din aktuella position";
 
 /* Text for rating dialog */
 "rating_just_rated" = "Jag har precis betygsatt er app";
-
-/* Text for rating dialog */
-"rating_user_since" = "Jag har använt Organic Maps sedan %@";
-
-/* Text for rating dialog */
-"rating_do_like_maps" = "Gillar du Organic Maps?";
-
-/* Text for rating dialog */
-"rating_tap_star" = "Tryck på en stjärna för att betygsätta vår app.";
 
 /* Text for rating dialog */
 "rating_thanks" = "Tack!";
@@ -701,23 +450,8 @@
 /* Text for rating dialog */
 "rating_send_feedback" = "Skicka återkoppling";
 
-/* Text for g+ dialog */
-"rating_google_plus" = "Klicka på g+ för att berätta om appen för dina vänner.";
-
 /* Text for routing error dialog */
 "routing_download_maps_along" = "Ladda ned kartor längs vägen";
-
-/* Text for routing error dialog */
-"routing_download_map" = "Hämta karta";
-
-/* Text for routing error dialog */
-"routing_download_map_and_routing" = "Ladda ner uppdaterad karta och navigeringsdata för att få tillgång till alla Organic Maps funktioner.";
-
-/* Text for routing error dialog */
-"routing_get_routing_data" = "Hämta navigeringsdata";
-
-/* Text for routing error dialog */
-"routing_get_additional_data" = "Ytterligare data krävs för att skapa navigeringsvägar från din plats";
 
 /* Text for routing error dialog */
 "routing_requires_all_map" = "Att kunna skapa en navigeringsväg kräver att alla kartorna från din plats till din destination är nerladdade och uppdaterade.";
@@ -725,50 +459,15 @@
 /* Text for routing error dialog */
 "routing_not_enough_space" = "För lite utrymme kvar";
 
-/* Text for routing error dialog */
-"routing_download_more_than_avail" = "Du behöver ladda ner %@ MB men du har bara %@ MB tillgänglig";
-
-/* Text for routing error dialog */
-"routing_download_roaming" = "Du kommer ladda ner %@ MB med mobildata (i roamingläge). Detta kan resultera i extra kostnader beroende på din operatörs mobildataplan.";
-
 /* bookmark button text */
 "bookmark" = "bokmärke";
-
-/* map is not downloaded */
-"not_found_map" = "Kartan för din plats hittas inte";
 
 /* location service disabled */
 "enable_location_services" = "Vänligen aktivera platstjänster";
 
-/* download map */
-"download_map" = "Ladda ner kartan över din nuvarande plats";
-
-/* download map on iPhone */
-"download_map_iphone" = "Ladda ner kartan för aktuell plats på din iPhone";
-
-/* clear pin */
-"nearby" = "I närheten";
-
-/* clear pin */
-"clear_pin" = "Rensa Pin";
-
-/* location is undefined */
-"undefined_location" = "Nuvarande plats är inte definierad.";
-
-/* download country of your location */
-"download_country" = "Ladda ner landet vid din nuvarande position";
-
-/* download failed */
-"download_failed" = "nedladdning misslyckades";
-
-/* get the map */
-"get_the_map" = "Hämta karta";
-
 "save" = "Spara";
 
 "edit_description_hint" = "Dina beskrivningar (text eller html)";
-
-"new_group" = "ny grupp";
 
 "create" = "skapa";
 
@@ -795,30 +494,6 @@
 
 /* pink color */
 "pink" = "Rosa";
-
-/* deep purple color */
-"deep_purple" = "Mörk purpur";
-
-/* light blue color */
-"light_blue" = "Ljusblå";
-
-/* cyan color */
-"cyan" = "Blågrön";
-
-/* teal color */
-"teal" = "Smaragdgrön";
-
-/* lime color */
-"lime" = "Limefärg";
-
-/* deep orange color */
-"deep_orange" = "Mörkorange";
-
-/* gray color */
-"gray" = "Grå";
-
-/* blue gray color */
-"blue_gray" = "Ljusblå grå";
 
 /* Wi-Fi available */
 "WiFi_available" = "Ja";
@@ -848,13 +523,9 @@
 
 "dialog_routing_location_unknown_turn_on" = "Kan inte lokalisera nuvarande GPS-koordinater. Aktivera platstjänster för att beräkna väg.";
 
-"dialog_routing_location_unknown" = "Kan inte lokalisera nuvarande GPS-koordinater.";
-
 "dialog_routing_download_files" = "Ladda ned nödvändiga filer";
 
 "dialog_routing_download_and_update_all" = "Ladda ned och uppdatera all kart- och väginformation längs den beräknade vägbanan för att beräkna vägen.";
-
-"dialog_routing_routes_size" = "Väginformationsfiler";
 
 "dialog_routing_unable_locate_route" = "Kan inte lokalisera väg";
 
@@ -884,21 +555,11 @@
 
 "dialog_routing_try_again" = "Försök igen";
 
-"dialog_routing_send_error" = "Rapportera problem";
-
-"dialog_routing_if_get_cross_route" = "Vill du skapa en mer direkt väg som sträcker sig över fler än en karta?";
-
-"dialog_routing_cross_route_is_optimal" = "En optimalare väg som sträcker sig utanför den här kartan är tillgänglig.";
-
 "not_now" = "Inte nu";
-
-"dialog_routing_build_route" = "Skapa";
 
 "dialog_routing_download_and_build_cross_route" = "Vill du ladda ned kartan och skapa en optimalare väg som sträcker sig över fler än en karta?";
 
 "dialog_routing_download_cross_route" = "Ladda ned kartan för att skapa en optimalare väg som sträcker sig utanför den här kartan.";
-
-"dialog_routing_cross_route_always" = "Korsa alltid den här gränsen";
 
 
 /********** Strings for downloading map from search **********/
@@ -906,8 +567,6 @@
 "search_without_internet_advertisement" = "För att börja söka och skapa rutter, ladda ner kartan, och du behöver inte Internet-anslutning längre.";
 
 "search_select_map" = "Välj kartan";
-
-"search_select_other_map" = "Välj en annan karta";
 
 /* «Show» context menu */
 "show" = "Visa";
@@ -918,17 +577,11 @@
 /* «Rename» context menu */
 "rename" = "Byt namn";
 
-/* Bottom sheet: expand button (should be short) */
-"bottom_sheet_more" = "Mer…";
-
 /* Failed planning route message in navigation view */
 "routing_planning_error" = "Ruttplanering misslyckades";
 
 /* Arrive routing message in navigation view */
 "routing_arrive" = "Ankomst: %s";
-
-/* Text for routing::RouterResultCode::FileTooOld dialog. */
-"dialog_routing_download_and_update_maps" = "För att skapa en rutt, ladda ner och uppdatera alla kartor längs rutten.";
 
 "rate_alert_title" = "Gillar du appen?";
 
@@ -944,19 +597,11 @@
 
 "history" = "Historik";
 
-"next_turn_then" = "Sedan";
-
 "closed" = "Stängt";
-
-"back_to" = "Tillbaka till %@";
 
 "search_not_found" = "Ledsen, jag hittade ingenting.";
 
 "search_not_found_query" = "Försök med en annan sökförfrågan.";
-
-"search_not_found_map" = "Ladda ner kartan du söker på.";
-
-"search_not_found_location" = "Ladda ner kartan över din nuvarande position.";
 
 "search_history_title" = "Sökhistorik";
 
@@ -964,23 +609,12 @@
 
 "clear_search" = "Rensa sökhistorik";
 
-/* Title for settings to enable/disable showcase menu button */
-"showcase_settings_title" = "Visa erbjudanden";
-
 /* Place Page link to Wikipedia article (if map object has it). */
 "read_in_wikipedia" = "Wikipedia";
 
-"p2p_route_planning" = "Ruttplanering";
-
 "p2p_your_location" = "Din plats";
 
-"p2p_from" = "Startplats";
-
-"p2p_to" = "Målplats";
-
 "p2p_start" = "Start";
-
-"p2p_planning" = "Planerar…";
 
 "p2p_from_here" = "Från";
 
@@ -1018,15 +652,9 @@
 
 "editor_correct_mistake" = "Korrigera fel";
 
-"editor_correct_mistake_message" = "Du har gjort ett fel i redigeringen. Var vänlig korrigera det eller byt till enkelt läge.";
-
 "editor_add_select_location" = "Plats";
 
 "editor_done_dialog_1" = "Du har ändrat världskartan. Dölj inte detta! Berätta för dina vänner och redigera den tillsammans.";
-
-"editor_done_dialog_2" = "Detta är din andra kartförbättring. Du är nu på plats %d i listan över kartredigerare. Berätta för dina vänner om det.";
-
-"editor_done_dialog_3" = "Du har förbättrat kartan, berätta för dina vänner om det och redigera kartan tillsammans.";
 
 "share_with_friends" = "Dela med vänner";
 
@@ -1044,20 +672,7 @@
 
 "editor_report_problem_duplicate_place_title" = "Duplicerad plats";
 
-"first_launch_congrats_title" = "Du kan nu använda Organic Maps";
-
-"first_launch_congrats_text" = "Sök och navigera offline var som helst i världen, helt gratis.";
-
-"migrate_title" = "Viktigt!";
-
-/* Android uses image instead of text. */
-"download_all" = "Ladda ner alla";
-
-"delete_all" = "Radera alla";
-
 "autodownload" = "Automatisk nedladdning";
-
-"disable_autodownload" = "Avaktivera automatisk nedladdning";
 
 /* Place Page opening hours text */
 "closed_now" = "Stängt just nu";
@@ -1072,10 +687,6 @@
 "day_off" = "Stängt";
 
 "today" = "Idag";
-
-"sunrise_to_sunset" = "Från gryning till skymning";
-
-"sunset_to_sunrise" = "Från soluppgång till solnedgång";
 
 "add_opening_hours" = "Lägg till öppettider";
 
@@ -1095,45 +706,18 @@
 
 "forgot_password" = "Glömt lösenord?";
 
-/* Forgot Password dialog title */
-"restore_password" = "Återställ lösenord?";
-
-"enter_email_address_to_reset_password" = "Mata in e-postadressen som du använde vid registrering så skickar vi en återställningslänk till dig.";
-
-"reset_password" = "återställ lösenord";
-
-"username" = "Användarnamn";
-
 "osm_account" = "OSM-konto";
 
 "logout" = "Logga ut";
 
-"login_and_edit_map_motivation_message" = "Logga in och redigera informationen om objekten på kartan så kommer vi att göra ändringarna tillgängliga för miljontals andra användare. Låt oss göra världen bättre tillsammans.";
-
 /* Information text: "Last upload 11.01.2016" */
 "last_upload" = "Senast uppladdad";
 
-/* Motivates user to login/register, title above login buttons. */
-"you_have_edited_your_first_object" = "Du har redigerat ditt första objekt!";
-
 "thank_you" = "Tack";
-
-"login_with_google" = "Logga in med Google";
-
-"login_with_openstreetmap" = "Logga in med www.openstreetmap.org";
 
 "edit_place" = "Ändra platsen";
 
 "place_name" = "Platsens namn";
-
-/* title above languages list cells in the editor, below editable name text field. */
-"other_languages" = "Övriga språk";
-
-/* small button to open list with names in different languages */
-"show_more" = "Visa mer";
-
-/* small button to close list with names in different languages */
-"show_less" = "Visa mindre";
 
 "add_language" = "Lägg till ett språk";
 
@@ -1164,8 +748,6 @@
 
 "please_note" = "Observera";
 
-"common_no_wifi_dialog" = "Ingen wifi-anslutning. Vill du fortsätta med mobildata?";
-
 "downloader_delete_map_dialog" = "Alla kartändringar kommer att raderas tillsammans med kartan.";
 
 "downloader_update_maps" = "Uppdatera kartor";
@@ -1173,10 +755,6 @@
 "downloader_mwm_migration_dialog" = "För att skapa en rutt måste du uppdatera alla kartor och sedan planera rutten igen.";
 
 "downloader_search_field_hint" = "Hitta kartan";
-
-"migration_update_all_button" = "Uppdatera alla kartor";
-
-"migration_delete_all_download_current_button" = "Ladda ned senaste kartan och radera de gamla";
 
 "migration_download_error_dialog" = "Nedladdningsfel";
 
@@ -1186,21 +764,9 @@
 
 "downloader_no_space_message" = "Ta bort onödig data";
 
-"editor_general_auth_error_dialog" = "Allmänt fel vid inloggning.";
-
 "editor_login_error_dialog" = "Inloggningsfel.";
 
-"editor_login_failed_dialog" = "Inloggningen misslyckades";
-
-"editor_username_error_dialog" = "Användarnamnet är ogiltigt";
-
-"editor_place_edited_dialog" = "Du har redigerat ett objekt!";
-
-"editor_login_with_osm" = "Logga in med OpenStreetMap";
-
 "editor_profile_changes" = "Verifierade ändringar";
-
-"editor_profile_unsent_changes" = "Inte skickade:";
 
 "editor_focus_map_on_location" = "Dra på kartan för att välja objektets rätta plats.";
 
@@ -1222,13 +788,9 @@
 
 "editor_report_problem_other_title" = "Ett annat problem";
 
-"placepage_report_problem_button" = "Rapportera ett problem";
-
 "placepage_add_business_button" = "Lägg till organisation";
 
 "whatsnew_editor_message_1" = "Lägg till nya platser till kartan och redigera de befintliga direkt från appen.";
-
-"whatsnew_editor_message_2" = "* Organic Maps använder data från OpenStreetMaps community.";
 
 "dialog_incorrect_feature_position" = "Ändra placering";
 
@@ -1236,16 +798,10 @@
 
 "login_to_make_edits_visible" = "Logga in så att andra användare kan se de ändringar du gjort.";
 
-"no_migration_during_navigation" = "Att uppdatera är förbjudet under navigering.";
-
 /* Error dialog no space */
 "migration_no_space_message" = "Du behöver mer utrymme för att ladda ned. Radera onödig data.";
 
 "editor_sharing_title" = "Jag förbättrade kartorna hos Organic Maps";
-
-"editor_comment_will_be_sent" = "Vi vidarebefordrar din kommentar till kartritarna.";
-
-"editor_unsupported_category_message" = "Du har lagt till en plats i en kategori vi ännu inte stödjer. Den kommer att finnas på kartan vid ett senare tillfälle.";
 
 /* Downloaded 10 **of** 20 <- it is that "of" */
 "downloader_of" = "%1$d av %2$d";
@@ -1278,23 +834,9 @@
 
 "editor_operator" = "Användare";
 
-"editor_tag_description" = "Ange företag, organisation eller person som är ansvarig för lokalerna.";
-
-"editor_no_local_edits_title" = "Du har inga lokala redigeraingar";
-
-"editor_no_local_edits_description" = "Detta visar antalet föreslagna förändringar på kartan som som endast är tillgängliga på din enhet.";
-
-"editor_send_to_osm" = "Skicka till OSM";
-
-"editor_remove" = "Ta bord";
-
-"downloader_my_maps_title" = "Mina kartor";
-
 "downloader_no_downloaded_maps_title" = "Du har inte laddat ner några kartor";
 
 "downloader_no_downloaded_maps_message" = "Ladda ner kartor för att hitta platsen och navigera offline.";
-
-"downloader_find_place_hint" = "Sök stad eller land";
 
 /* Error title that appears after certain time without location. */
 "current_location_unknown_title" = "Fortsätt detektera din nuvarande plats?";
@@ -1321,47 +863,13 @@
 /* iOS Dialog for the case when the location permission is not granted */
 "location_services_disabled_3" = "3. Välj Medan appen används";
 
-"placepage_parking_surface" = "Yta";
-
-"placepage_parking_multistorey" = "Flera våningar";
-
-"placepage_parking_underground" = "Under mark";
-
-"placepage_parking_rooftop" = "Hustak";
-
-"placepage_parking_sheds" = "Skjul";
-
-"placepage_parking_carports" = "Garage";
-
-"placepage_parking_boxes" = "Garageboxar";
-
-"placepage_parking_pay" = "Kostnadsbelagd";
-
-"placepage_parking_free" = "Gratis";
-
-"placepage_parking_interval" = "Delvis kostnadsbelagd";
-
-"placepage_entrance_number" = "Nr";
-
-"placepage_entrance_type" = "Entré";
-
-"placepage_flat" = "lgh";
-
-"placepage_open_24_7" = "Døgnet rundt";
-
 "meter" = "m";
 
 "kilometer" = "km";
 
-"kilometers_per_hour" = "km/h";
-
 "mile" = "mile";
 
 "foot" = "fot";
-
-"miles_per_hour" = "mph";
-
-"day" = "d";
 
 "hour" = "h";
 
@@ -1381,10 +889,6 @@
 
 "placepage_bookmark_name_hint" = "Namn bokmärke";
 
-"placepage_personal_notes_hint" = "Personlig anteckning";
-
-"placepage_delete_bookmark_button" = "Radera bokmärke";
-
 "editor_edits_sent_message" = "Dina föreslagna ändringar har skickats";
 
 "editor_comment_hint" = "kommentar…";
@@ -1397,8 +901,6 @@
 
 "editor_remove_place_button" = "Ta bort";
 
-"editor_status_sending" = "Skickar…";
-
 "editor_place_doesnt_exist" = "Platsen finns inte";
 
 "text_more_button" = "…mer";
@@ -1410,11 +912,7 @@
 
 "error_enter_correct_email" = "Ange en giltig e-postadress";
 
-"error_enter_correct" = "Ange ett giltigt värde";
-
 "refresh" = "Uppdatera";
-
-"last_update" = "Senast uppdaterad: %s";
 
 "placepage_add_place_button" = "Lägg till en plats på kartan";
 
@@ -1426,24 +924,6 @@
 
 "editor_share_to_all_dialog_message_2" = "Vi kommer att kontrollera ändringar. Om vi har några frågor kontaktar vi dig via e-post.";
 
-"navigation_overview_button" = "översikt";
-
-"navigation_stop_button" = "stopp";
-
-/* Text on an empty bookmark page */
-"bookmarks_empty_title" = "Spara bokmärken";
-
-"bookmarks_empty_message_1" = "Knacka på ★ för att spara favoritplatser för snabb åtkomst.";
-
-"bookmarks_empty_message_2" = "Importera bokmärken från Mail och webben.";
-
-"bookmarks_empty_message_3" = "utcheckning: %s";
-
-/* Name of the group for booked hotels */
-"bookmarks_group_name" = "Bokade hotell";
-
-"place_page_button_read_descriprion" = "Läs";
-
 /* iOS dialog for the case when recent track recording is on and the app comes back from background */
 "recent_track_background_dialog_title" = "Avaktivera inspelning av din senaste resta rutt?";
 
@@ -1451,8 +931,6 @@
 
 /* For sharing via SMS and so on */
 "sharing_call_action_look" = "Kolla in";
-
-"continue_recent_track_background_button" = "Fortsätt";
 
 "recent_track_background_dialog_message" = "Organic Maps använder din geografiska position i bakgrunden för att spela in din senaste resta rutt.";
 
@@ -1468,33 +946,13 @@
 /* About short text (below logo) */
 "about_description" = "Organic Maps är en offline-applikation som du behöver när du reser. Organic Maps baseras på OpenStreetMap-data och tillåter redigering i den.";
 
-/* Text in menu */
-"blog" = "Blogg";
-
 "general_settings" = "Allmänna inställningar";
-
-"date" = "Datum %d";
-
-/* "Report a bug" -> "Generaal Feedback" -> "Something is not working" */
-"something_is_not_working" = "Något fungerar inte";
 
 /* For the first routing */
 "accept" = "Acceptera";
 
-"accept_and_continue" = "Accept and continue";
-
 /* For the first routing */
 "decline" = "Neka";
-
-"install_app" = "Installera";
-
-"search_no_results_title" = "Inga resultat hittades";
-
-"search_no_results_message" = "Försök med en mer allmän sökterm, zooma ut eller återställ filtret.";
-
-"search_no_results_expand_area_button" = "Zooma ut";
-
-"search_no_results_reset_button" = "Återställ filtret";
 
 /* noun */
 "search_in_table" = "Lista";
@@ -1517,8 +975,6 @@
 
 "traffic_update_maps_text" = "Kartor måste uppdateras för att visa trafikdata.";
 
-"traffic_outdated" = "Trafikdata är inaktuellt.";
-
 "big_font" = "Öka teckenstorlek på kartan";
 
 "traffic_update_app" = "Uppdatera Organic Maps";
@@ -1529,17 +985,7 @@
 /* "traffic" as in "road congestion" */
 "traffic_data_unavailable" = "Trafikdata är inte tillgänglig";
 
-/* "Translation is no needed, because it's a company name" */
-"uber" = "Uber";
-
-/* Simplified colour scheme for traffic information, fewer colours are used to display traffic jams on the map. The string should be kept as short as possible */
-"pref_traffic_simplified_colors_title" = "Enkla trafikfärger";
-
 "enable_logging" = "Aktivera loggning";
-
-"offline_place_page_more_information" = "Anslut till internet för att hämta mer information om platsen.";
-
-"failed_load_information" = "Det gick inte att ladda informationen.";
 
 /* Settings: "Send general feedback" button */
 "feedback_general" = "Allmän feedback";
@@ -1556,8 +1002,6 @@
 
 "whatsnew_transliteration_title" = "Transkribering till latin";
 
-"yandex_taxi_title" = "Yandex.Taxi";
-
 "learn_more" = "Läs mer";
 
 "core_exit" = "Avsluta";
@@ -1568,75 +1012,19 @@
 
 "button_exit" = "Avsluta";
 
-"settings_device_memory" = "Enhetens minne";
-
-"settings_card_memory" = "Kortets minne";
-
-"settings_storage_available" = "%s tillgängligt";
-
-"toast_location_permission_denied" = "Behörighet till appens plats nekades";
-
-"button_use" = "Använd";
-
 "planning_route_manage_route" = "Hantera rutt";
 
 "button_plan" = "Planera";
-
-"button_add" = "Lägg till";
 
 "placepage_remove_stop" = "Ta bort";
 
 "planning_route_remove_title" = "Dra här för att ta bort";
 
-"dialog_change_start_point_message" = "Ersätt startpunkt för den aktuella platsen?";
-
-"button_replace" = "Ersätt";
-
 "placepage_add_stop" = "Lägg till stopp";
-
-/* Only ru/en are needed */
-"subtitle_rent" = "Rent";
-
-/* Only ru/en are needed */
-"rub_month" = "RUB/month";
-
-/* Only ru/en are needed */
-"room" = "%s-room apt.";
-
-/* Only ru/en are needed */
-"real_estate" = "Real estate";
-
-"add_my_position" = "Lägg till min position";
-
-"choose_start_point" = "Välj en startpunkt";
-
-"choose_destination" = "Välj en destination";
 
 "preloader_viator_button" = "Läs mer";
 
-"start_from_my_position" = "Starta från";
-
-"profile_authorization_title" = "Logga in med";
-
-"profile_authorization_message" = "Enkelt att logga in utan inloggning och lösenord inom ett par sekunder";
-
 "profile_authorization_error" = "Hoppsan, ett fel har inträffat. Försök att logga in igen.";
-
-"service" = "Service";
-
-"atmosphere" = "Atmosfär";
-
-"value_for_money" = "Valuta för pengarna";
-
-"experience" = "Erfarenhet";
-
-"assortment" = "Urval";
-
-"expertise" = "Expertis";
-
-"equipment" = "Utrustning";
-
-"quality" = "Kvalitet";
 
 "dialog_error_storage_title" = "Lagringsåtkomstproblem";
 
@@ -1644,17 +1032,7 @@
 
 "setting_emulate_bad_storage" = "Emulera dålig lagring";
 
-"directions_finish" = "Destination";
-
-"directions_on_foot" = "Gå %s";
-
 "core_entrance" = "Ingång";
-
-"coffee" = "Kaffe";
-
-"cleanliness" = "Rent";
-
-"crowdedness" = "Fullt";
 
 "error_enter_correct_name" = "Ange ett korrekt namn";
 
@@ -1673,11 +1051,9 @@
 
 "downloader_percent" = "%s (%s av %s)";
 
-"downloader_process" = "Ladda ned %s...";
+"downloader_process" = "Ladda ned %s…";
 
-"downloader_applying" = "Tillämpar %s...";
-
-"dialog_message_transit_not_found_connection" = "Planera en rutt inom ett transportnätverk";
+"downloader_applying" = "Tillämpar %s…";
 
 "bookmarks_error_message_share_general" = "Kunde inte delas på grund av ett applikationsfel";
 
@@ -1695,17 +1071,7 @@
 
 "bookmarks_error_message_list_name_already_taken" = "Vänligen välj ett annat namn";
 
-"bookmarks_error_title_list_name_too_long" = "Det här namnet är för långt";
-
-"bookmarks_error_message_list_name_too_long" = "Vänligen välj ett annat namn";
-
-"please_wait" = "Vänligen vänta...";
-
-"phone_number" = "Telefonnummer";
-
-"notification_unsent_reviews_title" = "Du har flera unsent recensioner";
-
-"notification_unsent_reviews_message" = "Vänligen logga in för att dela omdömen med andra resenärer";
+"please_wait" = "Vänligen vänta…";
 
 "profile" = "OpenStreetMap profil";
 
@@ -1719,49 +1085,13 @@
 
 "bookmarks_convert_error_message" = "Vissa filer konverterades inte.";
 
-"converting" = "Konvertera...";
-
-"wn_reinvented_bookmarks_title" = "Vi återuppfinde bokmärken!";
-
-"wn_reinvented_bookmarks_message" = "Du kan säkerhetskopiera bokmärken, skapa listor... Det är fantastiskt...";
-
-"bookmarks_restore" = "Återställ bokmärken";
-
-"bookmarks_restore_process" = "Återställer...";
-
 "bookmarks_restore_title" = "Återställ den här versionen?";
 
-"bookmarks_restore_message" = "Dina bokmärken återställs från %s (%s)";
-
-"bookmarks_restore_empty_title" = "Du har ingen säkerhetskopia";
-
-"bookmarks_restore_empty_message" = "Servern hittade inte tidigare säkerhetskopior";
-
 "common_check_internet_connection_dialog_title" = "Ingen internetanslutning";
-
-"error_server_title" = "Serverfel";
-
-"error_server_message" = "Det uppstod ett fel på servern, försök igen senare";
 
 "error_system_message" = "Ett okänt fel uppstod";
 
 "restore" = "Återställa";
-
-"bookmarks_page_downloaded" = "Ladda ner";
-
-"bookmarks_page_my" = "Min";
-
-"routes_and_bookmarks" = "Rutt och bokmärken";
-
-"bookmarks_webview_success_toast" = "Bokmärkena har laddats ner";
-
-"cached_bookmarks_placeholder_title" = "Ladda ner nya platser";
-
-"cached_bookmarks_placeholder_subtitle" = "Tryck på knappen för att ladda ner tusentals intressanta platser och rutter skapade av Organic Maps användare. Du behöver internetanslutning.";
-
-"downloader_download_routers" = "Ladda ner bokmärken";
-
-"bookmarks_groups_cached" = "Nedladdade listor";
 
 "subtittle_opt_out" = "Spårningsinställningar";
 
@@ -1769,29 +1099,15 @@
 
 "crash_reports_description" = "Vi kan komma att använda din data för att förbättra Organic Maps upplevelsen. Ändringarna kommer träda i kraft när du startar om appen.";
 
-"opt_out_help_ios_1" = "Din mobila enhet kan tillhandahålla en ”Begränsad annonsspårning” eller ”Välj bort intressebaserad annonsering” inställning.";
-
-"opt_out_help_ios_2" = "iOS 9 eller nyare";
-
-"opt_out_help_ios_3" = "Gå till Inställningar → Integritet → Annonsering → Tillåt inställningen ”Begränsad annonsspårning”";
-
-"opt_out_help_android" = "Din mobila enhet kan tillhandahålla en ”Begränsad annonsspårning” eller ”Välj bort intressebaserad annonsering” -inställning.\n\nFör Android och Google Play tjänster version 4.0 och nyare:\nInställningar → Google → Annonsering → Välj bort personlig annonsering\eller\nInställningar→ Google → Google konto → Personlig information och integritet → Annonseringsinställningar → Personlig annonsering";
-
 "privacy_policy" = "Integritetspolicy";
 
 "terms_of_use" = "Allmänna villkor";
-
-"backup_notification_failed" = "Säkerhetskopiering av dina bokmärken har avbrutits. Logga in för att starta det igen.";
 
 "button_layer_traffic" = "Trafik";
 
 "button_layer_subway" = "Tunnelbana";
 
 "layers_title" = "Kartlager";
-
-"layers_message" = "Använd kartlager för att visa trafik, karta över tunnelbanan och annan användbar information";
-
-"button_layer_got_it" = "Förstått";
 
 "subway_data_unavailable" = "Kartor över tunnelbana är otillgänglig";
 
@@ -1803,39 +1119,13 @@
 
 "title_error_downloading_bookmarks" = "Ett fel har uppstått";
 
-"subtitle_error_downloading_bookmarks" = "Bokmärkena laddades inte ner";
-
-"error_already_downloaded" = "Den här listan har redan laddats ned";
-
 "popular_place" = "Popular";
-
-"download_routes" = "Download routes";
-
-"bookmarks_downloaded_title" = "Bookmarks have been downloaded successfully";
-
-"bookmarks_downloaded_subtitle" = "Press ‘View on map’ to explore new places from the list";
-
-"why_support" = "Varför stödja Organic Maps?";
-
-"why_support_item1" = "We respect your privacy: there are zero trackers in the app, and we are open source";
-
-"why_support_item2" = "Du hjälper oss att förbättra Organic Maps";
-
-"why_support_item3" = "Du hjälper oss att förbättra de offentliga kartorna OpenStreetMap.org";
-
-"channels_map_update" = "Uppdatering av kartor";
-
-"server_unavailable_title" = "Servern är inte tillgänglig";
-
-"sharing_options" = "Åtkomstinställningar";
 
 "export_file" = "Exportera fil";
 
 "list_settings" = "Listinställningar";
 
 "delete_list" = "Radera listan";
-
-"hide_from_map" = "Dölj från kort";
 
 "public_access" = "Allmänhetens åtkomst";
 
@@ -1845,40 +1135,11 @@
 
 "bookmark_category_description_hint" = "Lägg till en beskrivning (text eller html)";
 
-/* FIXME */
-"bookmarks_public_access" = "bookmarks_public_access";
-
-/* FIXME */
-"bookmarks_link_access" = "bookmarks_link_access";
-
-/* FIXME */
-"bookmarks_private_access" = "bookmarks_private_access";
-
 "not_shared" = "Personlig";
-
-"direct_link_progress_text" = "Laddar upp din fil…";
-
-"direct_link_success" = "Länk skapad";
-
-"send_a_link_btn" = "Skicka länk";
-
-"upload_error_toast" = "Ett fel uppstod när du laddar filen";
 
 "tags_loading_error_subtitle" = "Ett fel uppstod när du laddar taggarna, försök igen";
 
-"unable_upload_errorr_title" = "Det gick inte att ladda upp filen";
-
-"unable_upload_error_subtitle_edited" = "Filen har redigerats via webbapplikation";
-
-"unable_upload_error_subtitle_broken" = "Filen är skadad och kan inte laddas upp. Var vänlig ladda upp en annan fil.";
-
-"contact" = "Kontakta";
-
-"download_button" = "Nedladdning";
-
 "speedcams_alert_title" = "Hastighetskameror";
-
-"speedcams_alert_subtitle" = "Varna om hastighetsbegränsningar";
 
 "speedcam_option_auto" = "Auto";
 
@@ -1886,18 +1147,10 @@
 
 "speedcam_option_never" = "Aldrig";
 
-"bookmark_description_title" = "Etikettbeskrivning";
-
 "place_description_title" = "Beskrivning av platsen";
 
 /* this text will be shown in application notification preferences opposite checkbox which enable/disable downloader notifications. Devices on Android 8+ are affected. */
 "notification_channel_downloader" = "Kartladdning";
-
-"share_bookmarks_email_body_link" = "Hej!\n\nDina etiketter kan laddas ner från länken: %s. Öppna listan med hjälp av Organic Maps och njut av resan!\n\nLadda ner appen: https://omaps.app/get?kmz";
-
-"warning_speedcams_title" = "Navigatören ska meddela dig om kameror när hastighetsgränsen överskrids med %d km/h";
-
-"warning_speedcams_subtitle" = "Glöm inte att bekanta sig med trafikregler i landet av resan.";
 
 "speedcams_notice_message" = "Auto - Varna om fartkameror om det finns risk att överskrida hastighetsgränsen\nAlltid - Varna alltid om kameror\nAldrig - Varna aldrig om kameror";
 
@@ -1913,23 +1166,7 @@
 
 "enable_logging_warning_message" = "Denna funktion aktiveras för loggning av åtgärder för diagnostiska ändamål. Detta hjälper laget att identifiera problem med applikationen. Slå på funktionen endast på begäran av Organic Maps supporttjänst.";
 
-"html_error_upload_message_try_again" = "Kontrollera nätverksåtkomst och försök igen";
-
-"html_error_upload_title_try_again" = "Ingen internetanslutning";
-
-"notification_leave_review_v2_android_short_title" = "Lämna en recension och hjälp resenärer!";
-
-"megafon" = "Say goodbye to roaming!";
-
-"notifications_illegal_alert_disable_button" = "Stäng av meddelanden";
-
 "access_rules_author_only" = "Redigeras online";
-
-"privacy_settings_menu" = "Sekretessinställningar";
-
-"unable_upadate_error_title" = "Det gick inte att uppdatera resrutten";
-
-"unable_upadate_error_message" = "Det uppstod några fel vid uppdatering. Kontrollera ändringarna och försök igen";
 
 "driving_options_title" = "Omvägsinställningar";
 
@@ -1951,94 +1188,19 @@
 
 "change_driving_options_btn" = "Omvägsinställningar aktiverade";
 
-"toll_road" = "Betalvägen";
-
-"unpaved_road" = "Kärrvägen";
-
-"ferry_crossing" = "Färjetrafik";
-
-"operated_by" = "Kontrolleras \"%s\"";
-
 "avoid_toll_roads_placepage" = "Undvik betalvägar";
 
 "avoid_unpaved_roads_placepage" = "Undvik kärrvägar";
 
 "avoid_ferry_crossing_placepage" = "Undvik färjetrafik";
 
-"type.cuisine.uzbek" = "Uzbekiska mat";
-
-"trip_start" = "Kom igen";
-
-"pick_destination" = "Målet";
-
-"follow_my_position" = "Placera i mitten";
-
-"search_results" = "Sökresultat";
-
-"then_turn" = "Vidare";
-
-"redirect_route_alert" = "Räknar om rutten?";
-
-"redirect_route_yes" = "Ja";
-
-"redirect_route_no" = "Nej";
-
-"trip_finished" = "Du är framme!";
-
-"keyboard_availability_alert" = "Tangentbordet är inte tillgängligt vid rörelsen";
-
-"dialog_routing_change_start_carplay" = "Det gick inte att bygga rutten från nuvarande plats";
-
-"dialog_routing_change_end_carplay" = "Det går inte att bygga rutten till slutpunkten. Välj en annan";
-
-"dialog_routing_check_gps_carplay" = "Ingen GPS-signal. Följ till öppna området";
-
-"dialog_routing_unable_locate_route_carplay" = "Det går inte att bygga ruten. Välj andra rutenspunkter";
-
-"dialog_routing_download_files_carplay" = "För att skapa en rutt, ladda ner saknade kartor på din enhet";
-
-"dialog_routing_system_error_carplay" = "Ett fel uppstod. Starta om appen";
-
-"dialog_routing_rebuild_from_current_location_carplay" = "Ruten kommer att byggas om från din nuvarande plats";
-
-"dialog_routing_rebuild_for_vehicle_carplay" = "Ruten kommer att ändras till bil";
-
 "ok" = "Ok";
-
-"avoid_unpaved_carplay_1" = "Utan kärrväg";
-
-"avoid_unpaved_carplay_2" = "Utan kärrvägar";
-
-"avoid_ferry_carplay_1" = "Utan färjor";
-
-"avoid_ferry_carplay_2" = "Utan färjor";
-
-"avoid_tolls_carplay_1" = "Utan betalda";
-
-"avoid_tolls_carplay_2" = "Utan betalda";
-
-"speedcams_alert_title_carplay_1" = "Kameror";
-
-"speedcams_alert_title_carplay_2" = "Info om kameror";
-
-"download_map_carplay" = "Ladda ner kartor i applikation Organic Maps på din enhet";
-
-"carplay_roundabout_exit" = "%s utgången";
 
 /* max. 10 symbols, both iOS and Android */
 "sort" = "Sortera…";
 
 /* Android, title, max 20-22 symbols */
 "sort_bookmarks" = "Sortera bokmärken";
-
-/* iOS */
-"sort_default" = "Sortera som standard";
-
-"sort_type" = "Sortera efter typ";
-
-"sort_distance" = "Sortera efter avstånd";
-
-"sort_date" = "Sortera efter datum";
 
 /* Android */
 "by_default" = "Som standard";
@@ -2052,63 +1214,7 @@
 /* Android */
 "by_date" = "Efter datum";
 
-"week_ago_sorttype" = "För en vecka sedan";
-
-"month_ago_sorttype" = "För en månad sedan";
-
-"moremonth_ago_sorttype" = "För över en månad sedan";
-
-"moreyear_ago_sorttype" = "För över ett år sedan";
-
-"near_me_sorttype" = "Bredvid mig";
-
-"others_sorttype" = "Andra";
-
-"food_places" = "Mat";
-
-"tourist_places" = "Sevärdheter";
-
-"museums" = "Museer";
-
-"parks" = "Parker";
-
-"swim_places" = "Simning";
-
-"mountains" = "Berg";
-
-"animals" = "Djur";
-
-"hotels" = "Hotell";
-
-"buildings" = "Byggnader";
-
-"money" = "Pengar";
-
-"shops" = "Butiker";
-
-"parkings" = "Parkeringsplatser";
-
-"fuel_places" = "Bensinstationer";
-
-"water" = "Vatten";
-
-"medicine" = "Medicin";
-
 "search_in_the_list" = "Söka i listan";
-
-"view_on_map_bookmarks" = "På kartan";
-
-"more_bookmarks" = "Mer…";
-
-"no_items_found" = "Ingenting hittades";
-
-/* Android, max 18 symbols */
-"bookmarks_edit_list" = "Redigera";
-
-/* Android, max 18 symbols */
-"bookmarks_delete_list" = "Ta bort listan";
-
-"religious_places" = "Heliga platser";
 
 "select_list" = "Välja lista";
 
@@ -2118,26 +1224,13 @@
 
 "dialog_pedestrian_route_is_long_message" = "Välj ruttens start- eller slutpunkt närmare till tunnelbanestation";
 
-/* Failed planning SUBWAY route message in navigation view */
-"routing_planning_error_subway_special" = "Fel vid byggande av metro rutt";
-
 "button_layer_isolines" = "Terräng";
-
-"tips_map_layers_title_countour" = "Höjningslinjer offline i Organic Maps!";
-
-"tips_map_layers_message_countour" = "Höjdlinjer hjälper dig att planera din resa till naturen och inte gå vilse på marken";
 
 "isolines_activation_error_dialog" = "Om du vill använda höjdlinjer, uppdatera eller ladda ner en karta över önskat område";
 
 "isolines_location_error_dialog" = "Höjningslinjer är ännu inte tillgängligt i den här regionen";
 
 "elevation_profile_diff_level" = "Svårighetsgrad";
-
-"elevation_profile_diff_level_easy" = "Lätt";
-
-"elevation_profile_diff_level_moderate" = "Måttlig";
-
-"elevation_profile_diff_level_hard" = "Svår";
 
 "elevation_profile_ascent" = "Stigning";
 
@@ -2147,25 +1240,13 @@
 
 "elevation_profile_maxaltitude" = "Max. höjd";
 
-"elevation_profile_m" = "m";
-
 "elevation_profile_difficulty" = "Komplexitet";
 
 "elevation_profile_distance" = "Avst.:";
 
-"elevation_profile_km" = "km";
-
 "elevation_profile_time" = "Tid:";
 
-"elevation_profile_hours" = "h.";
-
-"elevation_profile_minutes" = "min";
-
 "isolines_toast_zooms_1_10" = "Förstora kartan för att se isolinjer";
-
-"downloader_updating_ios" = "Uppdatering";
-
-"downloader_loading_ios" = "Nedladdning";
 
 "key_information_title" = "Nyckelinformation";
 

--- a/iphone/Maps/LocalizedStrings/sv.lproj/Localizable.stringsdict
+++ b/iphone/Maps/LocalizedStrings/sv.lproj/Localizable.stringsdict
@@ -9,21 +9,6 @@
 
 <!-- ********** Strings for downloading map from search **********/ -->
 
-  <key>bookmarks_places</key>
-  <dict>
-    <key>NSStringLocalizedFormatKey</key>
-    <string>%#@value@</string>
-    <key>value</key>
-    <dict>
-      <key>NSStringFormatSpecTypeKey</key>
-      <string>NSStringPluralRuleType</string>
-      <key>NSStringFormatValueTypeKey</key>
-      <string>d</string>
-      <key>other</key>
-      <string>%d bokmärken</string>
-    </dict>
-  </dict>
-
   <key>bookmarks_detect_message</key>
   <dict>
     <key>NSStringLocalizedFormatKey</key>
@@ -38,21 +23,6 @@
       <string>%d fil hittades. Du kommer att se den efter omvandlingen.</string>
       <key>other</key>
       <string>%d filer har hittats. Du kommer att se dem efter omvandlingen.</string>
-    </dict>
-  </dict>
-
-  <key>bookmarks_objects</key>
-  <dict>
-    <key>NSStringLocalizedFormatKey</key>
-    <string>%#@value@</string>
-    <key>value</key>
-    <dict>
-      <key>NSStringFormatSpecTypeKey</key>
-      <string>NSStringPluralRuleType</string>
-      <key>NSStringFormatValueTypeKey</key>
-      <string>d</string>
-      <key>other</key>
-      <string>%s objekt</string>
     </dict>
   </dict>
 

--- a/iphone/Maps/LocalizedStrings/th.lproj/Localizable.strings
+++ b/iphone/Maps/LocalizedStrings/th.lproj/Localizable.strings
@@ -18,9 +18,6 @@
 /* Button which deletes downloaded country */
 "delete" = "ลบ";
 
-/* Button "do not interrupt download" if user touched actively downloading country */
-"do_nothing" = "ดำเนินการต่อ";
-
 "download_maps" = "ดาวน์โหลดแผนที่";
 
 /* Settings/Downloader - info for country when download fails */
@@ -28,9 +25,6 @@
 
 /* Settings/Downloader - info for country which started downloading */
 "downloading" = "กำลังดาวน์โหลด…";
-
-/* Settings/Downloader - size string, only strings different from English should be translated */
-"kb" = "กิโลไบต์";
 
 /* Choose measurement on first launch alert - choose metric system button */
 "kilometres" = "กิโลเมตร";
@@ -55,17 +49,11 @@
 /* Update maps later/Buy pro version later button text */
 "later" = "ภายหลัง";
 
-/* Don't show some dialog any more */
-"never" = "ไม่ต้องเตือนอีก";
-
 /* View and button titles for accessibility */
 "search" = "ค้นหา";
 
 /* Search box placeholder text */
 "search_map" = "ค้นหาแผนที่";
-
-/* Settings/Downloader - info for not downloaded country */
-"touch_to_download" = "แตะเพื่อดาวน์โหลด";
 
 /* Settings/Downloader - 3G download warning dialog confirm button */
 "use_cellular_data" = "ใช่";
@@ -73,20 +61,11 @@
 /* Location services are disabled by user alert - message */
 "location_is_disabled_long_text" = "ในปัจจุบันนี้มีการปิดการใช้งานการบริการตำแหน่งที่ตั้งสำหรับอุปกรณ์หรือแอปพลิเคชันนี้ โปรดเปิดใช้งานในการตั้งค่า";
 
-/* Location Services are not available on the device alert - message */
-"device_doesnot_support_location_services" = "อุปกรณ์ของคุณไม่รองรับการบริการตำแหน่งที่ตั้ง";
-
 /* View and button titles for accessibility */
 "zoom_to_country" = "แสดงบนแผนที่";
 
-/* Button text for the button at the center of the screen when the country is not downloaded */
-"country_status_download" = "ดาวน์โหลดแผนที่\n(^ ^)";
-
 /* Button text for the button at the center of the screen when the country is not downloaded and the size should not be shown */
 "country_status_download_without_size" = "ดาวน์โหลดแผนที่";
-
-/* Button text for the button at the center of the screen when the country is not downloaded */
-"country_status_download_without_routing" = "ดาวน์โหลดแผนที่โดยไม่กำหนดเส้นทาง\n(^ ^)";
 
 /* Message to display at the center of the screen when the country download has failed */
 "country_status_download_failed" = "การดาวน์โหลดล้มเหลว";
@@ -96,19 +75,13 @@
 
 "about_menu_title" = "เกี่ยวกับ Organic Maps";
 
-"downloaded_touch_to_delete" = "ดาวน์โหลดแล้ว (%@), แตะเพื่อลบ";
-
 "connection_settings" = "การตั้งค่าการเชื่อมต่อ";
-
-"download_mb_or_kb" = "ดาวน์โหลด %@";
 
 "close" = "ปิด";
 
 "unsupported_phone" = "จำเป็นต้องใช้ฮาร์ดแวร์ที่เพิ่มความเร็ว OpenGL โชคไม่ดีที่อุปกรณ์ของคุณไม่รองรับ";
 
 "download" = "ดาวน์โหลด";
-
-"external_storage_is_not_available" = "ไม่สามารถใช้การ์ด SD /พื้นที่จัดเก็บ USB ที่มีดาวน์โหลดแผนที่ได้";
 
 "disconnect_usb_cable" = "โปรดยกเลิกการเชื่อมต่อสาย USB หรือใส่การ์ดหน่วยความจำเพื่อใช้ Organic Maps";
 
@@ -117,8 +90,6 @@
 "not_enough_memory" = "มีหน่วยความจำไม่เพียงพอสำหรับการเปิดแอป";
 
 "download_resources" = "ก่อนที่คุณจะเริ่มต้น โปรดให้เราดาวน์โหลดแผนที่โลกลงในอุปกรณ์ของคุณ\nจำเป็นต้องใช้ %@ ของข้อมูล";
-
-"getting_position" = "กำลังรับตำแหน่งปัจจุบัน";
 
 "download_resources_continue" = "ไปยังแผนที่";
 
@@ -140,23 +111,14 @@
 /* Add New Bookmark Set dialog title */
 "add_new_set" = "เพิ่มชุดใหม่";
 
-/* Place Page - Add To Bookmarks button */
-"add_to_bookmarks" = "เพิ่มไปยังบุ๊กมาร์ก";
-
 /* Bookmark Color dialog title */
 "bookmark_color" = "สีของบุ๊กมาร์ก";
 
 /* Add Bookmark Set dialog - hint when set name is empty */
 "bookmark_set_name" = "ชื่อของชุดบุ๊กมาร์ก";
 
-/* Bookmark Sets dialog title */
-"bookmark_sets" = "ชุดของบุ๊กมาร์ก";
-
 /* Bookmarks - dialog title */
 "bookmarks" = "บุ๊กมาร์ก";
-
-/* Add bookmark dialog - bookmark color */
-"color" = "สี";
 
 /* Default bookmarks set name */
 "core_my_places" = "สถานที่ของฉัน";
@@ -167,14 +129,8 @@
 /* Editor title above street and house number */
 "address" = "ที่อยู่";
 
-/* Place Page - Remove Pin button */
-"remove_pin" = "ลบหมุด";
-
 /* Add bookmark dialog - bookmark set, Bookmarks dialog - Bookmark set cell */
 "set" = "ชุด";
-
-/* Text hint in Bookmarks dialog when no any bookmarks are added */
-"bookmarks_usage_hint" = "คุณยังไม่มีบุ๊กมาร์ก\nแตะที่ใด ๆ บนแผนที่เพื่อเพิ่มบุ๊กมาร์ก\nสามารถนำเข้าบุ๊กมาร์กจากแหล่งอื่น ๆ และแสดงบน Organic Maps เปิดไฟล์ KML/KMZ ด้วยหมุดที่บันทึกไว้จากอีเมล ดรอปบ็อกซ์ หรือเว็บลิงก์";
 
 /* Settings button in system menu */
 "settings" = "การตั้งค่า";
@@ -191,26 +147,11 @@
 /* Ask to wait user several minutes (some long process in modal dialog). */
 "wait_several_minutes" = "นี่อาจจะใช้เวลาสองสามนาที\nโปรดรอ…";
 
-/* Show bookmarks from this category on a map or not */
-"visible" = "มองเห็นได้";
-
-/* Toast which is displayed when GPS has been deactivated */
-"gps_is_disabled_long_text" = "มีการปิดใช้งาน GPS โปรดเปิดใช้งานในการตั้งค่า";
-
 /* Measurement units title in settings activity */
 "measurement_units" = "หน่วยการวัด";
 
 /* Detailed description of Measurement Units settings button */
 "measurement_units_summary" = "เลือกระหว่างไมล์และกิโลเมตร";
-
-/* Do search in all sources */
-"search_mode_all" = "ทุกที่";
-
-/* Do search near my position only */
-"search_mode_nearme" = "ใกล้ฉัน";
-
-/* Do search in current viewport only */
-"search_mode_viewport" = "บนหน้าจอ";
 
 /* Search category for cafes, bars, restaurants */
 "eat" = "กินร้านไหนดี";
@@ -266,14 +207,8 @@
 /* Search category */
 "police" = "ตำรวจ";
 
-/* String in search result list, when nothing found */
-"no_search_results_found" = "ไม่พบผลลัพธ์";
-
 /* Notes field in Bookmarks view */
 "description" = "บันทึก";
-
-/* Button text */
-"share_by_email" = "แชร์จากอีเมล";
 
 /* Email Subject when sharing bookmarks category */
 "share_bookmarks_email_subject" = "แชร์บุ๊กมาร์กของ Organic Maps แล้ว";
@@ -295,26 +230,11 @@
 /* Warning message when doing search around current position */
 "unknown_current_position" = "ตำแหน่งที่ตั้งของคุณยังไม่ได้รับการกำหนด";
 
-/* Warning message when location country isn't downloaded during search (see also download_location_map_proposal). */
-"download_location_country" = "ดาวน์โหลด (%@) ประเทศของตำแหน่งที่ตั้งปัจจุบันของคุณ";
-
-/* Warning message when viewport country isn't downloaded during search */
-"download_viewport_country_to_search" = "ดาวน์โหลดประเทศ (%@) ที่คุณกำลังค้นหา";
-
 /* Alert message that we can't run Map Storage settings due to some reasons. */
 "cant_change_this_setting" = "ขออภัย ไม่มีการเปิดใช้งานการตั้งค่าพื้นที่จัดเก็บแผนที่ในปัจจุบัน";
 
 /* Alert message that downloading is in progress. */
 "downloading_is_active" = "กำลังดำเนินการดาวน์โหลดประเทศในตอนนี้";
-
-/* Message that will be shown in alert view, when we ask user to leave review on App Store */
-"appStore_message" = "หวังว่าคุณจะสนุกกับการใช้ Organic Maps! หากเป็นเช่นนั้น โปรดให้คะแนนหรือวิจารณ์แอปได้ที่แอปสโตร์ (App Store) มันจะใช้เวลาไม่เกินหนึ่งนาทีแต่สามารถช่วยเหลือเราได้ ขอบคุณสำหรับการสนับสนุนของคุณ!";
-
-/* No, thanks */
-"no_thanks" = "ไม่ ขอบคุณ";
-
-/* Share one specific bookmark using SMS, %1$@ contains om:// and %2$@ https://omaps.app link. @NOTE non-ascii symbols in the link will result in max 70 characters SMS instead of 140. */
-"bookmark_share_sms" = "เฮ้ ตรวจสอบหมุดของฉันที่ Organic Maps! %1$@ หรือ %2$@";
 
 /* Share my position using SMS, %1$@ contains om:// and %2$@ https://omaps.app link WITHOUT NAME. @NOTE non-ascii symbols in the link will result in max 70 characters SMS instead of 140. */
 "my_position_share_sms" = "เฮ้อ ตรวจสอบตำแหน่งที่ตั้งปัจจุบันของฉันที่ Organic Maps! %1$@ หรือ %2$@ ไม่มีการติดตั้งแผนที่แบบออฟไลน์? ดาวน์โหลดที่นี่: https://omaps.app/get";
@@ -328,23 +248,11 @@
 /* Share my position using EMail, %1$@ is om:// and %2$@ is https://omaps.app link WITHOUT NAME */
 "my_position_share_email" = "หวัดดี\n\nฉันอยู่ที่นี่ตอนนี้: %1$@. คลิกลิงก์นี้ %2$@ หรือลิงก์นี้ %3$@ เพื่อดูสถานที่บนแผนที่\n\nขอบคุณ";
 
-/* Android share by Message/SMS button text (including SMS) */
-"share_by_message" = "แชร์จากข้อความ";
-
 /* Share button text which opens menu with more buttons, like Message, EMail, Facebook etc. */
 "share" = "แชร์";
 
-/* iOS share by Message button text (including SMS) */
-"message" = "ข้อความ";
-
 /* Share by email button text, also used in editor. */
 "email" = "อีเมล";
-
-/* Copy Link */
-"copy_link" = "คัดลอกลิงก์";
-
-/* Text for the button that returns to caller application */
-"more_info" = "แสดงข้อมูลเพิ่มเติม";
 
 /* Text for message when used successfully copied something */
 "copied_to_clipboard" = "คัดลอกไปยังคลิปบอร์ด: %1$@";
@@ -354,15 +262,6 @@
 
 /* Used for bookmark editing */
 "done" = "เสร็จแล้ว";
-
-/* Summary for preferences in MWM */
-"yopme_pref_summary" = "เลือกการตั้งค่าหน้าจอส่วนหลัง";
-
-/* Title for yopme preferences in MWM */
-"yopme_pref_title" = "การตั้งค่าหน้าจอส่วนหลัง";
-
-/* Hint for upper-right icon p2b */
-"show_on_backscreen" = "แสดงหน้าจอส่วนหลัง";
 
 /* Prints version number in About dialog */
 "version" = "เวอร์ชัน: %@";
@@ -381,19 +280,11 @@
 
 "share_my_location" = "แชร์ตำแหน่งที่ตั้งของฉัน";
 
-"menu_search" = "ค้นหา";
-
 /* Settings general group in settings screen */
 "prefs_group_general" = "General settings";
 
 /* Settings information group in settings screen */
 "prefs_group_information" = "Information";
-
-/* Settings screen: "Map" category title */
-"prefs_group_map" = "แผนที่";
-
-/* Settings screen: "Miscellaneous" category title */
-"prefs_group_misc" = "เบ็ดเตล็ด";
 
 "prefs_group_route" = "การนำทาง";
 
@@ -419,9 +310,6 @@
 /* Settings «Map» category: «3D buildings» title */
 "pref_map_3d_buildings_title" = "ตึก 3D";
 
-/* Settings «Map» category: «3D buildings» summary */
-"pref_map_3d_buildings_subtitle" = "มีผลกระทบต่ออายุการใช้งานแบตเตอรี่";
-
 /* Settings «Route» category: «Tts enabled» title */
 "pref_tts_enable_title" = "คำแนะนำด้วยเสียง";
 
@@ -433,8 +321,6 @@
 
 /* Title for "Other" section in TTS settings. */
 "pref_tts_other_section_title" = "อื่น ๆ";
-
-"pref_tts_how_to_set_up_voice" = "วิธีตั้งค่าเสียง";
 
 /* Settings «Map» category: «Record track» title */
 "pref_track_record_title" = "เส้นทางล่าสุด";
@@ -455,56 +341,7 @@
 
 "recent_track_help_text" = "ช่วยให้คุณบันทึกเส้นทางที่คุณเดินทางในช่วงระยะเวลาหนึ่งแล้วดูบนแผนที่ได้ โปรดทราบว่า: การเปิดใช้งานฟังก์ชั่นนี้จะทำให้การใช้งานแบตเตอรี่เพิ่มมากขึ้น การติดตามจะถูกเอาออกไปโดยอัตโนมัติจากแผนที่หลังจากผ่านช่วงเวลาที่กำหนด";
 
-"pref_track_ios_caption" = "เส้นทางล่าสุดแสดงให้เห็นถึงเส้นทางที่เดินทางแล้วของคุณ";
-
-"pref_track_ios_subcaption" = "โปรดเลือกช่วงเวลาในการบันทึกการติดตาม";
-
-"placepage_distance" = "ระยะห่าง";
-
-"placepage_coordinates" = "พิกัด";
-
-"placepage_unsorted" = "ไม่เรียงลำดับ";
-
 "search_show_on_map" = "ดูบนแผนที่";
-
-/* Used to warn user when fixing KitKat issue */
-"bookmark_move_fail" = "เราจำเป็นต้องลบบุ๊กมาร์กของคุณไปยังหน่วยความจำภายใน แต่ไม่มีพื้นที่ที่สามารถใช้ได้ โปรดเพิ่มหน่วยความจำ มิฉะนั้นจะไม่สามารถใช้บุ๊กมาร์กได้";
-
-/* Used in More Apps menu */
-"free" = "ฟรี";
-
-/* Used in More Apps menu */
-"buy" = "ซื้อ";
-
-/* 1st search button-like result */
-"search_on_map" = "ค้นหาแผนที่";
-
-/* toast with an error */
-"no_route_found" = "ไม่พบเส้นทาง";
-
-/* route title */
-"route" = "เส้นทาง";
-
-/* category title */
-"routes" = "เส้นทาง";
-
-/* text of notification */
-"download_map_notification" = "ดาวน์โหลดแผนที่เกี่ยวกับสถานที่ที่คุณอยู่";
-
-/* text of notification */
-"pro_version_is_free_today" = "เวอร์ชันเต็มของ Organic Maps วันนี้ฟรี! ดาวน์โหลดตอนนี้แล้วบอกเพื่อน ๆ ของคุณ";
-
-/* Dialog for transferring maps from lite to pro. */
-"move_lite_maps_to_pro" = "เรากำลังโอนแผนที่ที่ดาวน์โหลดของคุณจาก Organic Maps Lite ไปยัง Organic Maps อาจใช้เวลาสองสามวินาที";
-
-/* Message to display when maps moved. */
-"move_lite_maps_to_pro_ok" = "แผนที่ที่ดาวน์โหลดของคุณโอนไปยัง Organic Maps สำเร็จ";
-
-/* Message to display when maps move failed. */
-"move_lite_maps_to_pro_failed" = "ล้มเหลวในการโอนแผนที่ของคุณ โปรดลบ Organic Maps Lite และดาวน์โหลดแผนที่อีกครั้ง";
-
-/* Text in menu */
-"settings_and_more" = "การตั้งค่า & อื่น ๆ";
 
 /* Text in menu */
 "website" = "เว็บไซต์";
@@ -527,14 +364,8 @@
 /* Text in menu */
 "openstreetmap" = "OpenStreetMap";
 
-/* Text in menu */
-"contact_us" = "ติดต่อเรา";
-
 /* Settings: Send feedback button and dialog title */
 "feedback" = "ข้อเสนอแนะ";
-
-/* Text in menu */
-"subscribe_to_news" = "สมัครรับข่าวของเรา";
 
 /* Text in menu */
 "rate_the_app" = "ให้คะแนนแอป";
@@ -548,15 +379,6 @@
 /* Text in menu */
 "report_a_bug" = "แจ้งข้อผิดพลาด";
 
-/* Email subject */
-"subscribe_me_subject" = "โปรดลงชื่อฉันเพื่อรับจดหมายข่าว Organic Maps";
-
-/* Email body */
-"subscribe_me_body" = "ฉันอยากเป็นคนแรกที่รู้เกี่ยวกับข่าว อัปเดตและโปรโมชั่นล่าสุด ฉันสามารถยกเลิกการเป็นสมาชิกของฉันได้ตลอดเวลา";
-
-/* About text */
-"about_text" = "Organic Maps ขอเสนอแผนที่ออฟไลน์ของทุกเมือง ทุกประเทศในโลกที่รวดเร็วที่สุด เดินทางด้วยความมั่นใจ: ไม่ว่าคุณจะอยู่ที่ไหน Organic Maps จะช่วยระบุตำแหน่งที่ตั้งของตัวคุณบนแผนที่ ค้นหาร้านอาหาร โรงแรม ธนาคาร ปั๊มน้ำมัน และอื่น ๆ ที่ใกล้ที่สุด โดยไม่จำเป็นต้องใช้การเชื่อมต่ออินเทอร์เน็ต\n\nเราทำงานเพื่อพัฒนาฟีเจอร์ใหม่ ๆ อยู่เสมอและยินดีรับฟังว่าคุณมีความคิดเห็นว่าเราจะพัฒนา Organic Maps ได้อย่างไร หากคุณมีปัญหาใด ๆ กับแอป อย่าลังเลที่จะติดต่อเราที่ support@organicmaps.app โดยเราจะตอบรับทุกคำขอ!\n\nคุณชอบ Organic Maps และต้องการสนับสนุนเราหรือไม่? มีวิธีง่าย ๆ และฟรีอยู่บ้าง:\n\n- โพสต์คำวิจารณ์ของคุณที่ ตลาดแอป (App Market)\n- ถูกใจเพจ Facebook ของเรา http://www.facebook.com/OrganicMaps\n- หรือเพียงแค่บอกแม่ เพื่อน ๆ และเพื่อนร่วมงานของคุณเกี่ยวกับ Organic Maps :)\n\nขอบคุณที่ใช้บริการของเรา เราซาบซึ้งในการสนับสนุนของคุณมาก!\n\nป.ล. เรานำข้อมูลแผนที่มาจาก OpenStreetMap ซึ่งเป็นโครงการจัดทำแผนที่ที่เหมือนกับ Wikipedia ที่ช่วยให้ผู้ใช้สามารถสร้างและแก้ไขแผนที่ได้ หากคุณเห็นว่ามีสิ่งใดที่ขาดหายหรือไม่ถูกต้องบนแผนที่ คุณสามารถแก้ไขแผนที่ได้โดยตรงที่ https://www.openstreetmap.org และการเปลี่ยนแปลงของคุณจะปรากฏในแอป Organic Maps ในการปล่อยเวอร์ชันถัดไป";
-
 /* Alert text */
 "email_error_body" = "อีเมลลูกค้ายังไม่ได้รับการจัดตั้งขึ้น กรุณาตั้งค่าหรือใช้วิธีอื่นที่จะติดต่อเราที่ %@";
 
@@ -569,12 +391,6 @@
 /* Search category */
 "wifi" = "WiFi";
 
-/* Update map suggestion */
-"routing_map_outdated" = "โปรดอัปเดตแผนที่เพื่อสร้างเส้นทาง";
-
-/* Update maps suggestion */
-"routing_update_maps" = "เวอร์ชันใหม่ของ Organic Maps อนุญาติให้สร้างเส้นทางจากตำแหน่งปัจจุบันของคุณไปยังจุดปลายทาง โปรดอัปเดตแผนเพื่อใช้ฟีเจอร์นี้";
-
 /* Update all button text */
 "downloader_update_all_button" = "อัปเดตทั้งหมด";
 
@@ -583,9 +399,6 @@
 
 /* Downloaded maps category */
 "downloader_downloaded_subtitle" = "ดาวน์โหลดแล้ว";
-
-/* Downloaded maps category */
-"downloader_available_maps" = "มีให้ใช้";
 
 /* Country queued for download */
 "downloader_queued" = "ต่อแถว";
@@ -598,17 +411,6 @@
 
 "downloader_downloading" = "กำลังดาวน์โหลด:";
 
-"downloader_search_results" = "พบ";
-
-/* Disclaimer message */
-"routing_disclaimer" = "การสร้างเส้นทางในแอป Organic Maps มีสิ่งที่ควรทราบดังต่อไปนี้:\n\n  - พึงพิจารณาเส้นทางที่แนะนำไว้ในฐานะที่เป็นการแนะนำเท่านั้น\n - สภาพถนน กฎจราจรและป้ายมีความสำคัญมากกว่าคำแนะนำในการนำทาง\n - แผนที่อาจไม่ถูกต้องหรือล้าสมัย และอาจไม่ได้มีการสร้างเส้นทางในรูปแบบพอจะเป็นไปได้ที่ดีที่สุด\n\n  ขอให้ปลอดภัยบนท้องถนนและดูแลตัวคุณเองด้วย!";
-
-/* Outdated maps category */
-"downloader_outdated_maps" = "ล้าสมัย";
-
-/* Up to date maps category */
-"downloader_uptodate_maps" = "ทันสมัย";
-
 /* Status of outdated country in the list */
 "downloader_status_outdated" = "ปรับปรุง";
 
@@ -618,49 +420,14 @@
 /* Displayed in a dialog that appears when a user tries to delete a map while the app is in the follow route mode */
 "downloader_delete_map_while_routing_dialog" = "เพื่อลบแผนที่ โปรดหยุดใช้การนำทาง";
 
-/* Show when user try build route, but we don't know where he */
-"routing_failed_unknown_my_position" = "ไม่มีการกำหนดสถานที่ปัจจุบัน โปรดระบุสถานที่ตั้งเพื่อสร้างเส้นทาง";
-
-/* Show if use has not routing file, or InconsistentMWMandRoute */
-"routing_failed_has_no_routing_file" = "ข้อมูลเพิ่มเติมเป็นต้องมีเพื่อสร้างเส้นทาง เริ่มต้นการดาวน์โหลด?";
-
-/* StartPointNotFound */
-"routing_failed_start_point_not_found" = "ไม่สามารถคำนวณเส้นทางได้ ไม่มีถนนที่อยู่ใกล้เคียงกับจุดเริ่มต้นของคุณ";
-
-/* EndPointNotFound */
-"routing_failed_dst_point_not_found" = "ไม่สามารถคำนวณเส้นทางได้ ไม่มีถนนที่อยู่ใกล้กับปลายทางของคุณ";
-
 /* PointsInDifferentMWM */
 "routing_failed_cross_mwm_building" = "สามารถสร้างเส้นทางแบบสมบูรณ์ได้เฉพาะที่มีอยู่ในแผนที่เดียวเท่านั้น";
-
-/* RouteNotFound */
-"routing_failed_route_not_found" = "ไม่พบเส้นทางที่อยู่ระหว่างต้นทางและปลายทางที่เลือก โปรดเลือกจุดเริ่มต้นและจุดสิ้นสุดอื่น";
-
-/* InternalError */
-"routing_failed_internal_error" = "เกิดข้อผิดพลาดขึ้นภายใน โปรดลองลบและดาวน์โหลดแผนที่อีกครั้ง โปรดติดต่อเราได้ที่ support@organicmaps.app.";
-
-/* Context menu item for downloader. */
-"downloader_download_map_and_routing" = "ดาวน์โหลดแผนที่ + การเลือกเส้นทาง";
-
-/* Context menu item for downloader. */
-"downloader_download_routing" = "ดาวน์โหลดการเลือกเส้นทาง";
-
-/* Context menu item for downloader. */
-"downloader_delete_routing" = "ลบการเลือกเส้นทาง";
 
 /* Context menu item for downloader. */
 "downloader_download_map" = "ดาวน์โหลดแผนที่";
 
-"downloader_download_map_no_routing" = "ดาวน์โหลดแผนที่โดยไม่กำหนดเส้นทาง";
-
-/* Button for routing. */
-"routing_go" = "ไป!";
-
 /* Item status in downloader. */
 "downloader_retry" = "ทำซ้ำ";
-
-/* Item in context menu. */
-"downloader_map_and_routing" = "แผนที่ + เส้นทาง";
 
 /* Item in context menu. */
 "downloader_delete_map" = "ลบแผนที่";
@@ -668,29 +435,11 @@
 /* Item in context menu. */
 "downloader_update_map" = "อัปเดตแผนที่";
 
-/* Item in context menu. */
-"downloader_update_map_and_routing" = "อัปเดตแผนที่ + เส้นทาง";
-
-/* Item in context menu. */
-"downloader_map_only" = "แผนที่เท่านั้น";
-
-/* Toolbar title */
-"toolbar_application_menu" = "เมนูของแอปพลิเคชัน";
-
 /* Preference text */
 "pref_use_google_play" = "ใช้บริการ Google Play เพื่อรับตำแหน่งปัจจุบันของคุณ";
 
 /* Text for rating dialog */
 "rating_just_rated" = "ฉันเพิ่งให้คะแนนแอปของคุณ";
-
-/* Text for rating dialog */
-"rating_user_since" = "ฉันคือผู้ใช้ MAPS. ME ตั้งแต่ปี %@";
-
-/* Text for rating dialog */
-"rating_do_like_maps" = "คุณชอบ MAPS. ME หรือไม่?";
-
-/* Text for rating dialog */
-"rating_tap_star" = "แตะดาวเพื่อให้คะแนนแอปของเรา";
 
 /* Text for rating dialog */
 "rating_thanks" = "ขอบคุณ!";
@@ -701,23 +450,8 @@
 /* Text for rating dialog */
 "rating_send_feedback" = "ส่งข้อเสนอแนะ";
 
-/* Text for g+ dialog */
-"rating_google_plus" = "คลิก g+ เพื่อบอกเพื่อน ๆ ของคุณเกี่ยวกับแอป";
-
 /* Text for routing error dialog */
 "routing_download_maps_along" = "ดาวน์โหลดแผนที่ตามเส้นทาง";
-
-/* Text for routing error dialog */
-"routing_download_map" = "รับแผนที่";
-
-/* Text for routing error dialog */
-"routing_download_map_and_routing" = "ดาวน์โหลดแผนที่มีการอัปเดตและการกำหนดเส้นทางข้อมูลเพื่อรับฟีเจอร์ Organic Maps ทั้งหมด";
-
-/* Text for routing error dialog */
-"routing_get_routing_data" = "รับข้อมูลการกำหนดเส้นทาง";
-
-/* Text for routing error dialog */
-"routing_get_additional_data" = "ข้อมูลเพิ่มเติมที่จำเป็นสำหรับการสร้างเส้นทางจากสถานที่ตั้งของคุณ";
 
 /* Text for routing error dialog */
 "routing_requires_all_map" = "การสร้างเส้นทางจำเป็นต้องใช้แผนที่จากสถานที่ตั้งของคุณไปยังปลายทางที่มีการดาวน์โหลดและอัปเดต";
@@ -725,50 +459,15 @@
 /* Text for routing error dialog */
 "routing_not_enough_space" = "มีพื้นที่ไม่เพียงพอ";
 
-/* Text for routing error dialog */
-"routing_download_more_than_avail" = "คุณจำเป็นต้องดาวน์โหลด %@ MB แต่สามารถใช้ได้เพียง %@ MB เท่านั้น";
-
-/* Text for routing error dialog */
-"routing_download_roaming" = "คุณกำลังจะดาวน์โหลด %@ MB โดยการใช้ข้อมูลโทรศัพท์มือถือ (ในการใช้งานข้ามเขต) นี่อาจส่งผลในการคิดค่าบริการเพิ่มเติมโดยขึ้นอยู่กับแผนการใช้ข้อมูลโทรศัพท์มือถือของผู้ให้บริการของคุณ";
-
 /* bookmark button text */
 "bookmark" = "บุ๊กมาร์ก";
-
-/* map is not downloaded */
-"not_found_map" = "ไม่พบแผนที่ของตำแหน่งของคุณ";
 
 /* location service disabled */
 "enable_location_services" = "โปรดเปิดการใช้งานการบริการตำแหน่งที่ตั้ง";
 
-/* download map */
-"download_map" = "ดาวน์โหลดแผนที่เกี่ยวกับสถานที่ที่คุณอยู่";
-
-/* download map on iPhone */
-"download_map_iphone" = "ดาวน์โหลดแผนที่สำหรับตำแหน่งปัจจุบันบน iPhone ของคุณ";
-
-/* clear pin */
-"nearby" = "ใกล้เคียง";
-
-/* clear pin */
-"clear_pin" = "ล้างปักหมุด";
-
-/* location is undefined */
-"undefined_location" = "ไม่มีการกำหนดสถานที่ปัจจุบัน";
-
-/* download country of your location */
-"download_country" = "ดาวน์โหลด ประเทศของตำแหน่งที่ตั้งปัจจุบันของคุณ";
-
-/* download failed */
-"download_failed" = "การดาวน์โหลด  ล้มเหลว";
-
-/* get the map */
-"get_the_map" = "รับแผนที่";
-
 "save" = "บันทึก";
 
 "edit_description_hint" = "คำอธิบายของคุณ (ข้อความหรือ html)";
-
-"new_group" = "กลุ่มใหม่";
 
 "create" = "สร้าง";
 
@@ -795,30 +494,6 @@
 
 /* pink color */
 "pink" = "สีชมพู";
-
-/* deep purple color */
-"deep_purple" = "สีม่วงเข้ม";
-
-/* light blue color */
-"light_blue" = "สีฟ้าอ่อน";
-
-/* cyan color */
-"cyan" = "สีฟ้าอมเขียว";
-
-/* teal color */
-"teal" = "สีเขียวนกเป็ดน้ำ";
-
-/* lime color */
-"lime" = "สีเขียวอมเหลือง";
-
-/* deep orange color */
-"deep_orange" = "สีส้มเข้ม";
-
-/* gray color */
-"gray" = "สีเทา";
-
-/* blue gray color */
-"blue_gray" = "สีฟ้าอมเทา";
 
 /* Wi-Fi available */
 "WiFi_available" = "ใช่";
@@ -848,13 +523,9 @@
 
 "dialog_routing_location_unknown_turn_on" = "ไม่สามารถหาตำแหน่งพิกัด GPS ปัจจุบันได้ เปิดใช้บริการหาตำแหน่งเพื่อคำนวณเส้นทาง";
 
-"dialog_routing_location_unknown" = "ไม่สามารถหาตำแหน่งพิกัด GPS ปัจจุบันได้";
-
 "dialog_routing_download_files" = "ดาวน์โหลดไฟล์ที่จำเป็น";
 
 "dialog_routing_download_and_update_all" = "ดาวน์โหลดและอัปเดตแผนที่กับข้อมูลเส้นทางทั้งหมดตามเส้นทางที่คาดหมายเพื่อคำนวณเส้นทาง";
-
-"dialog_routing_routes_size" = "ไฟล์ข้อมูลเส้นทาง";
 
 "dialog_routing_unable_locate_route" = "ไม่สามารถหาเส้นทางได้";
 
@@ -884,21 +555,11 @@
 
 "dialog_routing_try_again" = "กรุณาลองอีกครั้ง";
 
-"dialog_routing_send_error" = "รายงานปัญหา";
-
-"dialog_routing_if_get_cross_route" = "คุณต้องการสร้างเส้นทางที่อ้อมน้อยลงซึ่งข้ามเกินหนึ่งแผนที่หรือไม่?";
-
-"dialog_routing_cross_route_is_optimal" = "มีเส้นทางที่เหมาะสมกว่าซึ่งข้ามเลยขอบของแผนที่นี้";
-
 "not_now" = "ไว้คราวหลัง";
-
-"dialog_routing_build_route" = "สร้าง";
 
 "dialog_routing_download_and_build_cross_route" = "คุณต้องการดาวน์โหลดแผนที่และสร้างเส้นทางที่เหมาะสมกว่าซึ่งข้ามเกินหนึ่งแผนที่หรือไม่?";
 
 "dialog_routing_download_cross_route" = "ดาวน์โหลดแผนที่เพื่อสร้างเส้นทางที่เหมาะสมกว่าซึ่งข้ามเลยขอบของแผนที่นี้";
-
-"dialog_routing_cross_route_always" = "ข้ามขอบเขตนี้เสมอ";
 
 
 /********** Strings for downloading map from search **********/
@@ -906,8 +567,6 @@
 "search_without_internet_advertisement" = "เพื่อเริ่มต้นการค้นหาและสร้างเส้นทาง โปรดดาวน์โหลดแผนที่ และคุณจะไม่จำเป็นต้องทำการเชื่อมต่ออินเทอร์เน็ตอีกต่อไป";
 
 "search_select_map" = "เลือกแผนที่";
-
-"search_select_other_map" = "เลือกแผนที่อื่น";
 
 /* «Show» context menu */
 "show" = "แสดง";
@@ -918,17 +577,11 @@
 /* «Rename» context menu */
 "rename" = "เปลี่ยนชื่อ";
 
-/* Bottom sheet: expand button (should be short) */
-"bottom_sheet_more" = "เพิ่มเติม…";
-
 /* Failed planning route message in navigation view */
 "routing_planning_error" = "การวางแผนเส้นทางล้มเหลว";
 
 /* Arrive routing message in navigation view */
 "routing_arrive" = "มาถึง: %s";
-
-/* Text for routing::RouterResultCode::FileTooOld dialog. */
-"dialog_routing_download_and_update_maps" = "เพื่อสร้างเส้นทาง โปรดดาวน์โหลดและอัปเดตแผนที่ทั้งหมดตลอดเส้นทาง";
 
 "rate_alert_title" = "ชอบแอปหรือไม่?";
 
@@ -944,19 +597,11 @@
 
 "history" = "ประวัติ";
 
-"next_turn_then" = "จากนั้น";
-
 "closed" = "ปิด";
-
-"back_to" = "กลับไป %@";
 
 "search_not_found" = "ขออภัย ฉันไม่พบสิ่งใด";
 
 "search_not_found_query" = "โปรดลองใช้คำถามอื่น";
-
-"search_not_found_map" = "กรุณาดาวน์โหลดแผนที่ที่คุณกำลังค้นหา";
-
-"search_not_found_location" = "ดาวน์โหลดแผนที่ของตำแหน่งปัจจุบันของคุณ";
 
 "search_history_title" = "ประวัติการค้นหา";
 
@@ -964,23 +609,12 @@
 
 "clear_search" = "ล้างการค้นหาประวัติ";
 
-/* Title for settings to enable/disable showcase menu button */
-"showcase_settings_title" = "แสดงข้อเสนอ";
-
 /* Place Page link to Wikipedia article (if map object has it). */
 "read_in_wikipedia" = "Wikipedia";
 
-"p2p_route_planning" = "การวางแผนเส้นทาง";
-
 "p2p_your_location" = "ตำแหน่งที่ตั้งของคุณ";
 
-"p2p_from" = "จุดที่ออกเดินทาง";
-
-"p2p_to" = "จุดที่เป็นปลายทาง";
-
 "p2p_start" = "เริ่มต้น";
-
-"p2p_planning" = "กำลังวางแผน…";
 
 "p2p_from_here" = "จาก";
 
@@ -1018,15 +652,9 @@
 
 "editor_correct_mistake" = "แก้ไขข้อผิดพลาด";
 
-"editor_correct_mistake_message" = "มีข้อผิดพลาดเกิดขึ้นจากการแก้ไขของคุณ โปรดแก้ไขให้ถูกต้อง หรือ สลับไปใช้ในโหมดแบบง่าย";
-
 "editor_add_select_location" = "ตำแหน่ง";
 
 "editor_done_dialog_1" = "คุณได้เปลี่ยนแผนที่โลก อย่าซ่อนมันไว้! บอกเพื่อนคุณ แล้วมาแก้ไขมันไปด้วยกัน";
-
-"editor_done_dialog_2" = "มันเป็นการปรับปรุงแผนที่ครั้งที่สองของคุณ ตอนนี้คุณอยู่ในอันดับที่ %d ของรายการผู้แก้ไขแผนที่ บอกให้เพื่อนคุณรู้";
-
-"editor_done_dialog_3" = "คุณได้ปรับปรุงแผนที่ บอกให้เพื่อนคุณรู้ แล้วมาแก้ไขแผนที่ไปด้วยกัน";
 
 "share_with_friends" = "แชร์กับเพื่อน";
 
@@ -1044,20 +672,7 @@
 
 "editor_report_problem_duplicate_place_title" = "สถานที่ซ้ำ";
 
-"first_launch_congrats_title" = "Organic Maps พร้อมใช้งานแล้ว";
-
-"first_launch_congrats_text" = "ค้นหาและนำทางไปทุกที่ในโลกแบบออฟไลน์ ไม่มีค่าใช้จ่าย";
-
-"migrate_title" = "สำคัญ!";
-
-/* Android uses image instead of text. */
-"download_all" = "ดาวน์โหลดทั้งหมด";
-
-"delete_all" = "ลบทั้งหมด";
-
 "autodownload" = "ดาวน์โหลดอัตโนมัติ";
-
-"disable_autodownload" = "หยุดการดาวน์โหลดแบบอัตโนมัติ";
 
 /* Place Page opening hours text */
 "closed_now" = "ปิดตอนนี้";
@@ -1072,10 +687,6 @@
 "day_off" = "ปิด";
 
 "today" = "วันนี้";
-
-"sunrise_to_sunset" = "ตั้งแต่พระอาทิตย์ขึ้นจนพระอาทิตย์ตก";
-
-"sunset_to_sunrise" = "ตั้งแต่พระอาทิตย์ตกจนพระอาทิตย์ขึ้น";
 
 "add_opening_hours" = "เพิ่มชั่วโมงทำการ";
 
@@ -1095,45 +706,18 @@
 
 "forgot_password" = "ลืมรหัสผ่าน?";
 
-/* Forgot Password dialog title */
-"restore_password" = "เรียกคืนรหัสผ่าน";
-
-"enter_email_address_to_reset_password" = "ใส่ที่อยู่อีเมลที่คุณใช้ระหว่างการลงทะเบียนแล้วเราจะส่งลิงก์ไปยังคุณเพื่อต่ออายุรหัสผ่านของคุณ";
-
-"reset_password" = "ตั้งรหัสผ่านใหม่";
-
-"username" = "ชื่อผู้ใช้";
-
 "osm_account" = "บัญชี OSM";
 
 "logout" = "ออกจากระบบ";
 
-"login_and_edit_map_motivation_message" = "ล็อกอินและแก้ไขข้อมูลวัตถุบนแผนที่ และเราจะทำให้มันสามารถใช้งานได้สำหรับผู้ใช้ท่านอื่น ๆ อีกนับล้าน มาช่วยกันทำให้โลกดียิ่งขึ้นร่วมกัน";
-
 /* Information text: "Last upload 11.01.2016" */
 "last_upload" = "อัปโหลดครั้งสุดท้าย";
 
-/* Motivates user to login/register, title above login buttons. */
-"you_have_edited_your_first_object" = "คุณได้แก้ไขวัตถุแรกของคุณ!";
-
 "thank_you" = "ขอบพระคุณ";
-
-"login_with_google" = "ล็อกอินด้วย Google";
-
-"login_with_openstreetmap" = "ล็อกอินที่ www.openstreetmap.org";
 
 "edit_place" = "แก้ไขสถานที่";
 
 "place_name" = "ชื่อสถานที่";
-
-/* title above languages list cells in the editor, below editable name text field. */
-"other_languages" = "ภาษาอื่น ๆ";
-
-/* small button to open list with names in different languages */
-"show_more" = "แสดงมากขึ้น";
-
-/* small button to close list with names in different languages */
-"show_less" = "แสดงน้อยลง";
 
 "add_language" = "เพิ่มภาษา";
 
@@ -1164,8 +748,6 @@
 
 "please_note" = "โปรดทราบ";
 
-"common_no_wifi_dialog" = "ไม่มีการเชื่อมต่อ WiFi คุณต้องการดำเนินการต่อโดยใช้ข้อมูลมือถือหรือไม่?";
-
 "downloader_delete_map_dialog" = "การเปลี่ยนแปลงแผนที่ทั้งหมดจะถูกลบไปพร้อมกับแผนที่";
 
 "downloader_update_maps" = "อัปเดตแผนที่";
@@ -1173,10 +755,6 @@
 "downloader_mwm_migration_dialog" = "ในการสร้างเส้นทาง คุณต้องอัปเดตแผนที่ทั้งหมดแล้ววางแผนเส้นทางอีกครั้ง";
 
 "downloader_search_field_hint" = "ค้นหาแผนที่";
-
-"migration_update_all_button" = "อัปเดตแผนที่ทั้งหมด";
-
-"migration_delete_all_download_current_button" = "ดาวน์โหลดแผนที่ปัจจุบันและลบแผนที่เก่า";
 
 "migration_download_error_dialog" = "ข้อผิดพลาดในการดาวน์โหลด";
 
@@ -1186,21 +764,9 @@
 
 "downloader_no_space_message" = "กรุณาลบข้อมูลที่ไม่จำเป็น";
 
-"editor_general_auth_error_dialog" = "ข้อผิดพลาดในการล็อกอินทั่วไป";
-
 "editor_login_error_dialog" = "ข้อผิดพลาดในการล็อกอิน";
 
-"editor_login_failed_dialog" = "การล็อกอินล้มเหลว";
-
-"editor_username_error_dialog" = "ชื่อผู้ใช้ไม่ถูกต้อง";
-
-"editor_place_edited_dialog" = "คุณได้แก้ไขวัตถุ!";
-
-"editor_login_with_osm" = "ล็อกอินด้วย OpenStreetMap";
-
 "editor_profile_changes" = "การเปลี่ยนแปลงที่อนุมัติแล้ว";
-
-"editor_profile_unsent_changes" = "ไม่ได้ส่ง:";
 
 "editor_focus_map_on_location" = "ดึงแผนที่เพื่อเลือกตำแหน่งวัตถุที่ถูกต้อง";
 
@@ -1222,13 +788,9 @@
 
 "editor_report_problem_other_title" = "ปัญหาอีกอย่างหนึ่ง";
 
-"placepage_report_problem_button" = "แจ้งปัญหา";
-
 "placepage_add_business_button" = "เพิ่มองค์กร";
 
 "whatsnew_editor_message_1" = "เพิ่มสถานที่ใหม่ ๆ ไปยังแผนที่ และแก้ไขสถานที่ที่มีอยู่เดิมจากแอปโดยตรง";
-
-"whatsnew_editor_message_2" = "* Organic Maps ใช้ข้อมูลจากชุมชน OpenStreetMap";
 
 "dialog_incorrect_feature_position" = "เปลี่ยนสถานที่ตั้ง";
 
@@ -1236,16 +798,10 @@
 
 "login_to_make_edits_visible" = "ล็อกอินเพื่อให้ผู้ใช้คนอื่นสามารถเห็นการเปลี่ยนแปลงของคุณได้";
 
-"no_migration_during_navigation" = "ห้ามอัปเดตระหว่างการนำทาง";
-
 /* Error dialog no space */
 "migration_no_space_message" = "ในการดาวน์โหลด คุณต้องมีพื้นที่มากขึ้น กรุณาลบเนื้อหาที่ไม่จำเป็นออกไป";
 
 "editor_sharing_title" = "ฉันได้ปรับปรุงแผนที่ Organic Maps";
-
-"editor_comment_will_be_sent" = "เราจะส่งความคิดเห็นของคุณไปให้กับนักเขียนแผนที่";
-
-"editor_unsupported_category_message" = "คุณได้เพิ่มสถานที่ในหมวดหมู่ที่เรายังไม่รองรับ มันจะปรากฏบนแผนที่หลังจากนี้สักพักหนึ่ง";
 
 /* Downloaded 10 **of** 20 <- it is that "of" */
 "downloader_of" = "%1$d จาก %2$d";
@@ -1278,23 +834,9 @@
 
 "editor_operator" = "เจ้าของ";
 
-"editor_tag_description" = "ใส่ชื่อบริษัท, องค์กร หรือ บุคคลที่เป็นผู้รับผิดชอบสถานที่นี้";
-
-"editor_no_local_edits_title" = "คุณไม่มีการแก้ไขท้องถิ่น";
-
-"editor_no_local_edits_description" = "หมายเลขที่แสดงอยู่ คือ หมายเลขที่คุณได้ทำการแนะนำการเปลี่ยนแปลงบนแผนที่ที่สามารถเข้าถึงได้โดยอุปกรณ์ของคุณท่านั้น";
-
-"editor_send_to_osm" = "ส่งไปที่ OSM";
-
-"editor_remove" = "ลบออก";
-
-"downloader_my_maps_title" = "แผนที่ของฉัน";
-
 "downloader_no_downloaded_maps_title" = "คุณยังไม่ได้ดาวน์โหลดแผนที่";
 
 "downloader_no_downloaded_maps_message" = "ดาวน์โหลดแผนที่เพื่อค้นหาสถานที่ และนำทางแบบออฟไลน์";
-
-"downloader_find_place_hint" = "ค้นหาชื่อเมือง หรือ ประเทศ";
 
 /* Error title that appears after certain time without location. */
 "current_location_unknown_title" = "ค้นหาที่ตั้งปัจจุบันต่อไปหรือไม่?";
@@ -1321,47 +863,13 @@
 /* iOS Dialog for the case when the location permission is not granted */
 "location_services_disabled_3" = "3. เลือกในขณะใช้แอป";
 
-"placepage_parking_surface" = "กลางแจ้ง";
-
-"placepage_parking_multistorey" = "หลายชั้น";
-
-"placepage_parking_underground" = "ชั้นใต้ดิน";
-
-"placepage_parking_rooftop" = "ดาดฟ้า";
-
-"placepage_parking_sheds" = "ในร่ม";
-
-"placepage_parking_carports" = "โรงรถ";
-
-"placepage_parking_boxes" = "โรงรถแบบกล่อง";
-
-"placepage_parking_pay" = "เสียเงิน";
-
-"placepage_parking_free" = "ฟรี";
-
-"placepage_parking_interval" = "จ่ายตามช่วงเวลา";
-
-"placepage_entrance_number" = "หมายเลข";
-
-"placepage_entrance_type" = "ทางเข้า";
-
-"placepage_flat" = "ห้อง";
-
-"placepage_open_24_7" = "24 ชั่วโมง";
-
 "meter" = "ม.";
 
 "kilometer" = "กม.";
 
-"kilometers_per_hour" = "กม./ชม.";
-
 "mile" = "ไมล์";
 
 "foot" = "ฟุต";
-
-"miles_per_hour" = "ไมล์/ชม.";
-
-"day" = "ว.";
 
 "hour" = "ชม.";
 
@@ -1381,10 +889,6 @@
 
 "placepage_bookmark_name_hint" = "ชื่อของ Bookmark";
 
-"placepage_personal_notes_hint" = "ข้อความส่วนตัว";
-
-"placepage_delete_bookmark_button" = "ลบ Bookmark";
-
 "editor_edits_sent_message" = "คำแนะนำการเปลี่ยนแปลงของคุณถูกส่งไปแล้ว";
 
 "editor_comment_hint" = "ข้อคิดเห็น";
@@ -1397,8 +901,6 @@
 
 "editor_remove_place_button" = "ลบออก";
 
-"editor_status_sending" = "กำลังส่ง…";
-
 "editor_place_doesnt_exist" = "ไม่พบสถานที่นี้";
 
 "text_more_button" = "…เพิ่มเติม";
@@ -1410,11 +912,7 @@
 
 "error_enter_correct_email" = "กรอกอีเมลที่ถูกต้อง";
 
-"error_enter_correct" = "กรอกค่าที่ถูกต้อง";
-
 "refresh" = "อัปเดต";
-
-"last_update" = "การอัปเดตล่าสุด: %s";
 
 "placepage_add_place_button" = "เพิ่มสถานที่ไปยังแผนที่";
 
@@ -1426,24 +924,6 @@
 
 "editor_share_to_all_dialog_message_2" = "เราจะตรวจสอบการเปลี่ยนแปลง หากเรามีคำถามใด ๆ เราจะติดต่อคุณผ่านทางอีเมล";
 
-"navigation_overview_button" = "ภาพรวม";
-
-"navigation_stop_button" = "หยุด";
-
-/* Text on an empty bookmark page */
-"bookmarks_empty_title" = "บันทึกบุ๊กมาร์ก";
-
-"bookmarks_empty_message_1" = "แตะ ★ เพื่อบันทึกสถานที่โปรดเพื่อให้เข้าถึงได้อย่างรวดเร็ว";
-
-"bookmarks_empty_message_2" = "นำเข้าบุ๊กมาร์กจาก Mail และเว็บ";
-
-"bookmarks_empty_message_3" = "เช็คเอาท์: %s";
-
-/* Name of the group for booked hotels */
-"bookmarks_group_name" = "โรงแรมที่จอง";
-
-"place_page_button_read_descriprion" = "อ่าน";
-
 /* iOS dialog for the case when recent track recording is on and the app comes back from background */
 "recent_track_background_dialog_title" = "ปิดการใช้งานการบันทึกเส้นทางที่คุณเดินทางเมื่อเร็ว ๆ นี้?";
 
@@ -1451,8 +931,6 @@
 
 /* For sharing via SMS and so on */
 "sharing_call_action_look" = "ตรวจชม";
-
-"continue_recent_track_background_button" = "ดำเนินการต่อ";
 
 "recent_track_background_dialog_message" = "Organic Maps ใช้ตำแหน่งทางภูมิศาสตร์ของคุณในพื้นหลังเพื่อบันทึกเส้นทางที่คุณเดินทางเมื่อเร็ว ๆ นี้";
 
@@ -1468,33 +946,13 @@
 /* About short text (below logo) */
 "about_description" = "Organic Maps เป็นแอปพลิเคชั่นออฟไลน์ที่จำเป็นสำหรับการท่องเที่ยว Organic Maps นั้นใช้งานบนพื้นฐานของข้อมูล OpenStreetMap และใช้แก้ไขได้ด้วย";
 
-/* Text in menu */
-"blog" = "บล็อก";
-
 "general_settings" = "การตั้งค่าทั่วไป";
-
-"date" = "วันที่ %d";
-
-/* "Report a bug" -> "Generaal Feedback" -> "Something is not working" */
-"something_is_not_working" = "มีบางอย่างไม่ทำงาน";
 
 /* For the first routing */
 "accept" = "ยอมรับ";
 
-"accept_and_continue" = "Accept and continue";
-
 /* For the first routing */
 "decline" = "ปฏิเสธ";
-
-"install_app" = "ติดตั้ง";
-
-"search_no_results_title" = "ไม่พบผลลัพธ์";
-
-"search_no_results_message" = "ลองค้นหาด้วยคำทั่ว ๆ ไปดู ซูมออกหรือรีเซ็ตตัวกรอง";
-
-"search_no_results_expand_area_button" = "ซูมออก";
-
-"search_no_results_reset_button" = "รีเซ็ตตัวกรอง";
 
 /* noun */
 "search_in_table" = "รายการ";
@@ -1517,8 +975,6 @@
 
 "traffic_update_maps_text" = "ต้องอัปเดตแผนที่เพื่อแสดงข้อมูลการจราจร";
 
-"traffic_outdated" = "ข้อมูลการจราจรเก่าเกินไปแล้ว";
-
 "big_font" = "เพิ่มขนาดฟอนต์บนแผนที่";
 
 "traffic_update_app" = "กรุณาอัปเดต Organic Maps";
@@ -1529,17 +985,7 @@
 /* "traffic" as in "road congestion" */
 "traffic_data_unavailable" = "ไม่มีข้อมูลการจราจร";
 
-/* "Translation is no needed, because it's a company name" */
-"uber" = "Uber";
-
-/* Simplified colour scheme for traffic information, fewer colours are used to display traffic jams on the map. The string should be kept as short as possible */
-"pref_traffic_simplified_colors_title" = "ไฟจราจรแบบง่าย";
-
 "enable_logging" = "เปิดใช้งานการเก็บล็อก";
-
-"offline_place_page_more_information" = "เชื่อมต่ออินเทอร์เน็ตเพื่อรับข้อมูลเพิ่มเติมเกี่ยวกับสถานที่";
-
-"failed_load_information" = "ไม่สามารถโหลดข้อมูลได้";
 
 /* Settings: "Send general feedback" button */
 "feedback_general" = "ข้อเสนอแนะทั่วไป";
@@ -1556,8 +1002,6 @@
 
 "whatsnew_transliteration_title" = "การทับศัพท์เป็นภาษาละติน";
 
-"yandex_taxi_title" = "Yandex.Taxi";
-
 "learn_more" = "ศึกษาเพิ่มเติม";
 
 "core_exit" = "ออก";
@@ -1568,75 +1012,19 @@
 
 "button_exit" = "ออก";
 
-"settings_device_memory" = "หน่วยความจำเครื่อง";
-
-"settings_card_memory" = "หน่วยความจำการ์ด";
-
-"settings_storage_available" = "เหลือให้ใช้ได้ %s";
-
-"toast_location_permission_denied" = "สิทธิ์ตำแหน่งที่ตั้งของแอปถูกปฏิเสธ";
-
-"button_use" = "ใช้";
-
 "planning_route_manage_route" = "จัดการเส้นทาง";
 
 "button_plan" = "วางแผน";
-
-"button_add" = "เพิ่ม";
 
 "placepage_remove_stop" = "เอาออก";
 
 "planning_route_remove_title" = "ลากมาที่นี่เพื่อเอาออก";
 
-"dialog_change_start_point_message" = "แทนที่จุดเริ่มต้นไปยังตำแหน่งปัจจุบันหรือไม่?";
-
-"button_replace" = "แทนที่";
-
 "placepage_add_stop" = "เพิ่มจุดแวะพัก";
-
-/* Only ru/en are needed */
-"subtitle_rent" = "Rent";
-
-/* Only ru/en are needed */
-"rub_month" = "RUB/month";
-
-/* Only ru/en are needed */
-"room" = "%s-room apt.";
-
-/* Only ru/en are needed */
-"real_estate" = "Real estate";
-
-"add_my_position" = "เพิ่มตำแหน่งของฉัน";
-
-"choose_start_point" = "เลือกจุดเริ่มต้น";
-
-"choose_destination" = "เลือกปลายทาง";
 
 "preloader_viator_button" = "เรียนรู้เพิ่มเติม";
 
-"start_from_my_position" = "เริ่มจาก";
-
-"profile_authorization_title" = "ลงชื่อเข้าใช้ด้วย";
-
-"profile_authorization_message" = "ลงชื่อเข้าใช้อย่างง่ายโดยไม่ต้องใช้ชื่อเข้าสู่ระบบและรหัสผ่านเพียงไม่กี่วินาที";
-
 "profile_authorization_error" = "โอ๊ะ มีข้อผิดพลาดเกิดขึ้น ลองลงชื่อเข้าใช้อีกครั้ง";
-
-"service" = "บริการ";
-
-"atmosphere" = "บรรยากาศ";
-
-"value_for_money" = "คุ้มค่าเงิน";
-
-"experience" = "ประสบการณ์";
-
-"assortment" = "การแบ่งประเภท";
-
-"expertise" = "ความเชี่ยวชาญ";
-
-"equipment" = "อุปกรณ์";
-
-"quality" = "คุณภาพ";
 
 "dialog_error_storage_title" = "ปัญหาการเข้าถึงที่เก็บข้อมูล";
 
@@ -1644,17 +1032,7 @@
 
 "setting_emulate_bad_storage" = "จำลองแบบที่เก็บข้อมูลที่ไม่ดี";
 
-"directions_finish" = "จุดหมายปลายทาง";
-
-"directions_on_foot" = "เดินเท้า %s";
-
 "core_entrance" = "ทางเข้า";
-
-"coffee" = "กาแฟ";
-
-"cleanliness" = "ความสะอาด";
-
-"crowdedness" = "ความแออัด";
 
 "error_enter_correct_name" = "กรุณาใส่ชื่อที่ถูกต้อง";
 
@@ -1673,11 +1051,9 @@
 
 "downloader_percent" = "%s (%s จาก %s)";
 
-"downloader_process" = "กำลังดาวน์โหลด %s...";
+"downloader_process" = "กำลังดาวน์โหลด %s…";
 
-"downloader_applying" = "กำลังนำ %s ไปใช้งาน...";
-
-"dialog_message_transit_not_found_connection" = "วางแผนเส้นทางภายในเครือข่ายการเดินทางเดียว";
+"downloader_applying" = "กำลังนำ %s ไปใช้งาน…";
 
 "bookmarks_error_message_share_general" = "ไม่สามารถแชร์ได้เนื่องจากเกิดข้อผิดพลาดในแอปพลิเคชัน";
 
@@ -1695,17 +1071,7 @@
 
 "bookmarks_error_message_list_name_already_taken" = "โปรดเลือกชื่ออื่น";
 
-"bookmarks_error_title_list_name_too_long" = "ชื่อนี้ยาวเกินไป";
-
-"bookmarks_error_message_list_name_too_long" = "โปรดเลือกชื่ออื่น";
-
-"please_wait" = "โปรดรอสักครู่ ...";
-
-"phone_number" = "หมายเลขโทรศัพท์";
-
-"notification_unsent_reviews_title" = "คุณมีรีวิวที่ยังไม่ได้อ่านหลายฉบับ";
-
-"notification_unsent_reviews_message" = "โปรดลงชื่อเข้าใช้เพื่อแบ่งปันความเห็นกับผู้อื่น";
+"please_wait" = "โปรดรอสักครู่ …";
 
 "profile" = "โปรไฟล์ OpenStreetMap";
 
@@ -1719,49 +1085,13 @@
 
 "bookmarks_convert_error_message" = "ไฟล์บางไฟล์ไม่ได้รับการแปลง";
 
-"converting" = "กำลังแปลง...";
-
-"wn_reinvented_bookmarks_title" = "เราสร้างสรรค์บุ๊กมาร์กใหม่!";
-
-"wn_reinvented_bookmarks_message" = "คุณสามารถสำรองบุ๊คมาร์คสร้างรายการ... มันน่าทึ่ง...";
-
-"bookmarks_restore" = "เรียกคืนบุ๊กมาร์ก";
-
-"bookmarks_restore_process" = "กำลังกู้คืน...";
-
 "bookmarks_restore_title" = "เรียกคืนเวอร์ชันนี้หรือไม่?";
 
-"bookmarks_restore_message" = "บุ๊กมาร์กของคุณจะคืนค่าจาก %s (%s)";
-
-"bookmarks_restore_empty_title" = "คุณไม่มีข้อมูลสำรอง";
-
-"bookmarks_restore_empty_message" = "เซิร์ฟเวอร์ไม่พบการสำรองข้อมูลก่อนหน้านี้";
-
 "common_check_internet_connection_dialog_title" = "ไม่มีการเชื่อมต่ออินเทอร์เน็ต";
-
-"error_server_title" = "ข้อผิดพลาดของเซิร์ฟเวอร์";
-
-"error_server_message" = "เกิดข้อผิดพลาดบนเซิร์ฟเวอร์โปรดลองอีกครั้งในภายหลัง";
 
 "error_system_message" = "เกิดข้อผิดพลาดที่ไม่ทราบสาเหตุ";
 
 "restore" = "ฟื้นฟู";
-
-"bookmarks_page_downloaded" = "ดาวน์โหลด";
-
-"bookmarks_page_my" = "ของฉัน";
-
-"routes_and_bookmarks" = "เส้นทาง และบุ๊กมาร์ก";
-
-"bookmarks_webview_success_toast" = "ดาวน์โหลดบุ๊กมาร์กสำเร็จแล้ว";
-
-"cached_bookmarks_placeholder_title" = "ดาวน์โหลดสถานที่ใหม่";
-
-"cached_bookmarks_placeholder_subtitle" = "กดปุ่มเพื่อดาวน์โหลดหลายพันสถานที่ และเส้นทางที่น่าสนใจต่าง ๆ ซึ่งสร้างขึ้นโดยผู้ใช้งานของ Organic Maps คุณจำเป็นต้องเชื่อมต่อกับอินเตอร์เน็ต";
-
-"downloader_download_routers" = "ดาวน์โหลดบุ๊กมาร์ก";
-
-"bookmarks_groups_cached" = "ดาวน์โหลดรายการต่าง ๆ แล้ว";
 
 "subtittle_opt_out" = "การตั้งค่าการติดตาม";
 
@@ -1769,29 +1099,15 @@
 
 "crash_reports_description" = "เราอาจใช้ข้อมูลของคุณเพื่อพัฒนาประสบการณ์ของ Organic Maps การเปลี่ยนแปลงจะมีผลหลังจากที่คุณเปิดแอพฯ ขึ้นใหม่";
 
-"opt_out_help_ios_1" = "อุปกรณ์มือถือของคุณอาจมีการตั้งค่า \"\"จำกัดการติดตามโฆษณา\"\" หรือ \"\"เลือกไม่ใช้การโฆษณาตามความสนใจ\"\"";
-
-"opt_out_help_ios_2" = "iOS 9 หรือสูงกว่า";
-
-"opt_out_help_ios_3" = "ไปที่การตั้งค่าของคุณ → ความเป็นส่วนตัว → การโฆษณา → เปิดใช้งานการตั้งค่า “จำกัดการติดตามโฆษณา”";
-
-"opt_out_help_android" = "อุปกรณ์มือถือของคุณอาจมีการตั้งค่า \"\"จำกัดการติดตามโฆษณา\"\" หรือ \"\"เลือกไม่ใช้การโฆษณาตามความสนใจ\"\"\n\nสำหรับ Android และบริการ Google Play เวอร์ชั่น 4.0 และสูงกว่า:\nการตั้งค่า → Google → โฆษณา → เลือกไม่ใช้การโฆษณา ในแบบของคุณ\หรือ\nการตั้งค่า → Google → Google Account → ข้อมูลส่วนตัว และส่วนบุคคล → การตั้งค่าโฆษณา → โฆษณาในแบบของคุณ";
-
 "privacy_policy" = "นโยบายความเป็นส่วนตัว";
 
 "terms_of_use" = "ข้อกำหนดในการใช้งาน";
-
-"backup_notification_failed" = "การเก็บสำรองบุ๊กมาร์กของคุณได้ถูกระงับ เข้าสู่ระบบเพื่อเปิดใช้งานอีกครั้ง";
 
 "button_layer_traffic" = "การจราจร";
 
 "button_layer_subway" = "รถไฟใต้ดิน";
 
 "layers_title" = "ชั้นแผนที่";
-
-"layers_message" = "ใช้ชั้นแผนที่เพื่อแสดงแผนที่ข้อมูลด้านการจราจร รถไฟใต้ดิน และข้อมูลอื่น ๆ ที่เป็นประโยชน์";
-
-"button_layer_got_it" = "เข้าใจแล้ว";
 
 "subway_data_unavailable" = "แผนที่รถไฟใต้ดินไม่พร้อมใช้งาน";
 
@@ -1803,39 +1119,13 @@
 
 "title_error_downloading_bookmarks" = "มีข้อผิดพลาดเกิดขึ้น";
 
-"subtitle_error_downloading_bookmarks" = "ไม่ได้ดาวน์โหลดบุ๊กมาร์ก";
-
-"error_already_downloaded" = "มีการดาวน์โหลดรายการนี้แล้ว";
-
 "popular_place" = "Popular";
-
-"download_routes" = "Download routes";
-
-"bookmarks_downloaded_title" = "Bookmarks have been downloaded successfully";
-
-"bookmarks_downloaded_subtitle" = "Press ‘View on map’ to explore new places from the list";
-
-"why_support" = "ทำไมถึงควรใช้บริการ Organic Maps?";
-
-"why_support_item1" = "We respect your privacy: there are zero trackers in the app, and we are open source";
-
-"why_support_item2" = "คุณช่วยเราพัฒนา Organic Maps";
-
-"why_support_item3" = "คุณช่วยเราพัฒนาแผนที่ที่เปิดให้คนทั่วไปเข้าใช้งานของ OpenStreetMap.org";
-
-"channels_map_update" = "อัพเดตโรงแรม";
-
-"server_unavailable_title" = "ไม่สามารถเข้าถึงเซิร์ฟเวอร์";
-
-"sharing_options" = "ตัวเลือกการแชร์";
 
 "export_file" = "ส่งออกไฟล์";
 
 "list_settings" = "การตั้งค่ารายการ";
 
 "delete_list" = "ลบรายการ";
-
-"hide_from_map" = "ซ่อนจากแผนที่";
 
 "public_access" = "เข้าถึงได้โดยสาธารณะ";
 
@@ -1845,40 +1135,11 @@
 
 "bookmark_category_description_hint" = "พิมพ์รายละเอียด (ข้อความหรือ html)";
 
-/* FIXME */
-"bookmarks_public_access" = "bookmarks_public_access";
-
-/* FIXME */
-"bookmarks_link_access" = "bookmarks_link_access";
-
-/* FIXME */
-"bookmarks_private_access" = "bookmarks_private_access";
-
 "not_shared" = "ส่วนตัว";
-
-"direct_link_progress_text" = "กำลังอัพโหลดไฟล์ของคุณ…";
-
-"direct_link_success" = "ลิงค์ถูกสร้างแล้ว";
-
-"send_a_link_btn" = "ส่งลิงค์ให้ฉัน";
-
-"upload_error_toast" = "เกิดข้อผิดพลาดขณะอัพโหลดไฟล์ของคุณ";
 
 "tags_loading_error_subtitle" = "เกิดข้อผิดพลาดขณะโหลดแท็ก โปรดลองใหม่อีกครั้ง";
 
-"unable_upload_errorr_title" = "การอัพโหลดไฟล์ล้มเหลว";
-
-"unable_upload_error_subtitle_edited" = "ไฟล์นั้นถูกแก้ไขผ่านทางเว็บแอพ";
-
-"unable_upload_error_subtitle_broken" = "ไฟล์นั้นเสียหายและไม่สามารถอัพโหลดได้ โปรอัพโหลดไฟล์อื่นแทน";
-
-"contact" = "ติดต่อ";
-
-"download_button" = "ดาวน์โหลด";
-
 "speedcams_alert_title" = "กล้องตรวจจับความเร็ว";
-
-"speedcams_alert_subtitle" = "เตือนเรื่องการจำกัดความเร็ว";
 
 "speedcam_option_auto" = "อัตโนมัติ";
 
@@ -1886,18 +1147,10 @@
 
 "speedcam_option_never" = "ไม่ต้องเตือน";
 
-"bookmark_description_title" = "รายละเอียดของบุ๊คมาร์ค";
-
 "place_description_title" = "รายละเอียดของสถานที่";
 
 /* this text will be shown in application notification preferences opposite checkbox which enable/disable downloader notifications. Devices on Android 8+ are affected. */
 "notification_channel_downloader" = "ตัวดาวน์โหลดแผนที่";
-
-"share_bookmarks_email_body_link" = "สวัสดี!\n\nนี่คือลิงค์ที่คุณสามารถดาวน์โหลดบุ๊คมาร์คของคุณ: %s เปิดรายการผ่าน Organic Maps และเพลิดเพลินไปกับการเดินทางของคุณ!\n\nรับแอพพลิเคชัน: https://omaps.app/get?kmz";
-
-"warning_speedcams_title" = "เนวิเกเตอร์จะเตือนคุณเกี่ยวกับกล้องถ่ายรูปเมื่อคุณขับเร็วเกินกำหนดโดยอยู่ที่ %d กม./ชม";
-
-"warning_speedcams_subtitle" = "โปรดปฏิบัติตามกฎหมายการขับขี่รถยนต์ของประเทศที่คุณกำลังเดินทางไป";
 
 "speedcams_notice_message" = "อัตโนมัติ - เตือนเกี่ยวกับกล้องตรวจจับความเร็วหากมีความเป็นได้ว่าจะขับเร็วเกิดกำหนด\nทุกครั้ง - เตือนเกี่ยวกับกล้องตรวจจับความเร็วเสมอ\nไม่ต้องเตือน - ไม่เคยเตือนเกี่ยวกับกล้องตรวจจับความเร็ว";
 
@@ -1913,23 +1166,7 @@
 
 "enable_logging_warning_message" = "ออปชันเพื่อเปิดการบันทึกประวัติการทำงานเพื่อการวินิจฉัย ประวัติดังกล่าวอาจเป็นประโยชน์กับทีมงานช่วยเหลือของเราที่คอยจัดการกับปัญหาที่เจอระหว่างแอปทำงาน โปรดเปิดออปชันดังกล่าวจากการร้องข้อการสนับสนุนจาก Organic Maps เท่านั้น";
 
-"html_error_upload_message_try_again" = "โปรดเช็คการตั้งค่าเครือข่ายและลองใหม่อีกครั้ง";
-
-"html_error_upload_title_try_again" = "ไม่มีการเชื่อมต่ออินเทอร์เน็ต";
-
-"notification_leave_review_v2_android_short_title" = "รีวิวและช่วยนักท่องเที่ยวคนอื่น!";
-
-"megafon" = "Say goodbye to roaming!";
-
-"notifications_illegal_alert_disable_button" = "ปิดการแจ้งเตือน";
-
 "access_rules_author_only" = "การแก้ไขทางออนไลน์";
-
-"privacy_settings_menu" = "การตั้งค่าความเป็นส่วนตัว";
-
-"unable_upadate_error_title" = "อัพเดตไฟล์ล้มเหลว";
-
-"unable_upadate_error_message" = "มีข้อผิดพลาดบางอย่างเกิดขึ้นขณะอัพเดต โปรดตรวจทานการแก้ไขและลองใหม่อีกครั้ง";
 
 "driving_options_title" = "ทางเลือกเส้นทางขับขี่";
 
@@ -1951,94 +1188,19 @@
 
 "change_driving_options_btn" = "เปิดใช้การค้นหาเส้นทางขับขี่แล้ว";
 
-"toll_road" = "ถนนแบบเสียค่าผ่านทาง";
-
-"unpaved_road" = "ถนนดิน";
-
-"ferry_crossing" = "เรือข้ามฟาก";
-
-"operated_by" = "กำลังทำงานอยู่ที่ \"%s\"";
-
 "avoid_toll_roads_placepage" = "เลี่ยงทางที่ต้องเสียเงินทั้งหมด";
 
 "avoid_unpaved_roads_placepage" = "เลี่ยงถนนดินทั้งหมด";
 
 "avoid_ferry_crossing_placepage" = "เลี่ยงการข้ามฟากด้วยเรือ";
 
-"type.cuisine.uzbek" = "อาหารแนวอุซเบค";
-
-"trip_start" = "ไปกันเลย";
-
-"pick_destination" = "จุดหมาย";
-
-"follow_my_position" = "รีเซ็นเตอร์";
-
-"search_results" = "ผลการค้นหา";
-
-"then_turn" = "จากนั้น";
-
-"redirect_route_alert" = "ต้องการสร้างเส้นทางใหม่หรือไม่";
-
-"redirect_route_yes" = "ใช่";
-
-"redirect_route_no" = "ไม่ใช่";
-
-"trip_finished" = "คุณมาถึงแล้ว!";
-
-"keyboard_availability_alert" = "คีย์บอร์ดไม่สามารถใช้งานได้ขณะขับขี่";
-
-"dialog_routing_change_start_carplay" = "ไม่สามารถสร้างเส้นทางจากตำแหน่งปัจจุบันของคุณ";
-
-"dialog_routing_change_end_carplay" = "ไม่สามารถสร้างเส้นทางไปยังจุดหมายของคุณ โปรดเลือกจุดหมายใหม่";
-
-"dialog_routing_check_gps_carplay" = "ไม่มีสัญญาณจีพีเอส โปรดไปในที่โล่งเพื่อหาสัญญาณ";
-
-"dialog_routing_unable_locate_route_carplay" = "ไม่สามารถคำนวณเส้นทาง โปรดระบุตำแหน่งของเส้นทางอื่น";
-
-"dialog_routing_download_files_carplay" = "เพื่อสร้างเส้นทาง โปรดดาวน์โหลดแผนที่บนอุปกรณ์ของคุณ";
-
-"dialog_routing_system_error_carplay" = "พบข้อผิดพลาด โปรดปิดและเปิดแอปพลิเคชันใหม่อีกครั้ง";
-
-"dialog_routing_rebuild_from_current_location_carplay" = "เส้นทางจะถูกสร้างอีกครั้งจากตำแหน่งปัจจุบันของคุณ";
-
-"dialog_routing_rebuild_for_vehicle_carplay" = "เส้นทางของรถยนต์อาจถูกปรับเปลี่ยน";
-
 "ok" = "โอเค";
-
-"avoid_unpaved_carplay_1" = "ไม่มีลูกรัง";
-
-"avoid_unpaved_carplay_2" = "หลีกเลี่ยงทาง";
-
-"avoid_ferry_carplay_1" = "ไม่มีเรือ";
-
-"avoid_ferry_carplay_2" = "หลีกเลี่ยงเรือ";
-
-"avoid_tolls_carplay_1" = "ไม่มีค่าผ่าน";
-
-"avoid_tolls_carplay_2" = "เลี่ยงทางด่วน";
-
-"speedcams_alert_title_carplay_1" = "จับความเร็ว";
-
-"speedcams_alert_title_carplay_2" = "เตือนความเร็ว";
-
-"download_map_carplay" = "โปรดดาวน์โหลดแผนที่ในแอพฯ Organic Maps บนอุปกรณ์ของคุณ";
-
-"carplay_roundabout_exit" = "ทางออกที่ %s";
 
 /* max. 10 symbols, both iOS and Android */
 "sort" = "เรียง…";
 
 /* Android, title, max 20-22 symbols */
 "sort_bookmarks" = "เรียงบุ๊กมาร์ก";
-
-/* iOS */
-"sort_default" = "เรียงตามค่าเริ่มต้น";
-
-"sort_type" = "เรียงตามประเภท";
-
-"sort_distance" = "เรียงตามระยะทาง";
-
-"sort_date" = "เรียงตามวันที่";
 
 /* Android */
 "by_default" = "ตามค่าเริ่มต้น";
@@ -2052,63 +1214,7 @@
 /* Android */
 "by_date" = "ตามวันที่";
 
-"week_ago_sorttype" = "สัปดาห์ที่ผ่านมา";
-
-"month_ago_sorttype" = "เดือนที่ผ่านมา";
-
-"moremonth_ago_sorttype" = "มากกว่าหนึ่งเดือนที่ผ่านมา";
-
-"moreyear_ago_sorttype" = "มากกว่าหนึ่งปีที่ผ่านมา";
-
-"near_me_sorttype" = "ใกล้ฉัน";
-
-"others_sorttype" = "อื่นๆ";
-
-"food_places" = "อาหาร";
-
-"tourist_places" = "ที่ท่องเที่ยว";
-
-"museums" = "พิพิธภัณฑ์";
-
-"parks" = "ที่จอดรถ";
-
-"swim_places" = "ว่ายน้ำ";
-
-"mountains" = "ภูเขา";
-
-"animals" = "สวนสัตว์";
-
-"hotels" = "โรงแรม";
-
-"buildings" = "สิ่งปลูกสร้าง";
-
-"money" = "เงิน";
-
-"shops" = "ร้านค้า";
-
-"parkings" = "ที่จอดรถ";
-
-"fuel_places" = "ปั๊มน้ำมัน/แก๊ส";
-
-"water" = "น้ำ";
-
-"medicine" = "ยา";
-
 "search_in_the_list" = "ค้นหาในรายการ";
-
-"view_on_map_bookmarks" = "บนแผนที่";
-
-"more_bookmarks" = "เพิ่มเติม…";
-
-"no_items_found" = "ไม่พบรายการ";
-
-/* Android, max 18 symbols */
-"bookmarks_edit_list" = "แก้ไขรายการ";
-
-/* Android, max 18 symbols */
-"bookmarks_delete_list" = "ลบรายการ";
-
-"religious_places" = "สถานที่ทางศาสนา";
 
 "select_list" = "เลือกรายการ";
 
@@ -2118,26 +1224,13 @@
 
 "dialog_pedestrian_route_is_long_message" = "โปรดเลือกจุดเริ่มต้นและสิ้นสุดที่อยู่ใกล้สถานีรถไฟใต้ดิน";
 
-/* Failed planning SUBWAY route message in navigation view */
-"routing_planning_error_subway_special" = "การวางแผนเส้นทางของทางรถไฟใต้ดินล้มเหลว";
-
 "button_layer_isolines" = "ความสูง";
-
-"tips_map_layers_title_countour" = "เลเยอร์แผนที่ภูมิประเทศแบบออฟไลน์ ใหม่ในแอป Organic Maps!";
-
-"tips_map_layers_message_countour" = "วางแผนและสนุกไปกับทริปท่องธรรมชาติโดยมั่นใจว่าคุณรู้ทุกอย่างเกี่ยวกับพื้นที่นั้น";
 
 "isolines_activation_error_dialog" = "ในการเปิดใช้งานเลเยอร์แผนที่ภูมิประเทศโปรดอัปเดตหรือดาวน์โหลดแผนที่ของบริเวณนั้น";
 
 "isolines_location_error_dialog" = "เลเยอร์แผนที่ภูมิประเทศยังใช้งานไม่ได้ในพื้นที่นี้";
 
 "elevation_profile_diff_level" = "ระดับความยาก";
-
-"elevation_profile_diff_level_easy" = "ง่าย";
-
-"elevation_profile_diff_level_moderate" = "ปานกลาง";
-
-"elevation_profile_diff_level_hard" = "ยาก";
 
 "elevation_profile_ascent" = "การขึ้น";
 
@@ -2147,25 +1240,13 @@
 
 "elevation_profile_maxaltitude" = "ระดับความสูงสูงสุด";
 
-"elevation_profile_m" = "ม";
-
 "elevation_profile_difficulty" = "ลำบาก";
 
 "elevation_profile_distance" = "ระยะทาง";
 
-"elevation_profile_km" = "กม";
-
 "elevation_profile_time" = "เวลา:";
 
-"elevation_profile_hours" = "ชม";
-
-"elevation_profile_minutes" = "นาที";
-
 "isolines_toast_zooms_1_10" = "ขยายเข้าเพื่อสำรวจเส้นชั้นความสูง";
-
-"downloader_updating_ios" = "การอัปเดต";
-
-"downloader_loading_ios" = "การดาวน์โหลด";
 
 "key_information_title" = "ข้อมูลหลัก";
 

--- a/iphone/Maps/LocalizedStrings/th.lproj/Localizable.stringsdict
+++ b/iphone/Maps/LocalizedStrings/th.lproj/Localizable.stringsdict
@@ -9,21 +9,6 @@
 
 <!-- ********** Strings for downloading map from search **********/ -->
 
-  <key>bookmarks_places</key>
-  <dict>
-    <key>NSStringLocalizedFormatKey</key>
-    <string>%#@value@</string>
-    <key>value</key>
-    <dict>
-      <key>NSStringFormatSpecTypeKey</key>
-      <string>NSStringPluralRuleType</string>
-      <key>NSStringFormatValueTypeKey</key>
-      <string>d</string>
-      <key>other</key>
-      <string>%d บุ๊กมาร์ก</string>
-    </dict>
-  </dict>
-
   <key>bookmarks_detect_message</key>
   <dict>
     <key>NSStringLocalizedFormatKey</key>
@@ -36,21 +21,6 @@
       <string>d</string>
       <key>other</key>
       <string>%d ไฟล์ที่ค้นพบ คุณจะเห็นพวกเขาหลังจากการแปลง</string>
-    </dict>
-  </dict>
-
-  <key>bookmarks_objects</key>
-  <dict>
-    <key>NSStringLocalizedFormatKey</key>
-    <string>%#@value@</string>
-    <key>value</key>
-    <dict>
-      <key>NSStringFormatSpecTypeKey</key>
-      <string>NSStringPluralRuleType</string>
-      <key>NSStringFormatValueTypeKey</key>
-      <string>d</string>
-      <key>other</key>
-      <string>%s วัตถุประสงค์</string>
     </dict>
   </dict>
 

--- a/iphone/Maps/LocalizedStrings/tr.lproj/Localizable.strings
+++ b/iphone/Maps/LocalizedStrings/tr.lproj/Localizable.strings
@@ -18,9 +18,6 @@
 /* Button which deletes downloaded country */
 "delete" = "Sil";
 
-/* Button "do not interrupt download" if user touched actively downloading country */
-"do_nothing" = "Devam";
-
 "download_maps" = "Haritaları İndir";
 
 /* Settings/Downloader - info for country when download fails */
@@ -28,9 +25,6 @@
 
 /* Settings/Downloader - info for country which started downloading */
 "downloading" = "İndiriliyor…";
-
-/* Settings/Downloader - size string, only strings different from English should be translated */
-"kb" = "kB";
 
 /* Choose measurement on first launch alert - choose metric system button */
 "kilometres" = "Kilometre";
@@ -55,17 +49,11 @@
 /* Update maps later/Buy pro version later button text */
 "later" = "Daha sonra";
 
-/* Don't show some dialog any more */
-"never" = "Asla";
-
 /* View and button titles for accessibility */
 "search" = "Ara";
 
 /* Search box placeholder text */
 "search_map" = "Haritada Ara";
-
-/* Settings/Downloader - info for not downloaded country */
-"touch_to_download" = "İndirmek için dokunun";
 
 /* Settings/Downloader - 3G download warning dialog confirm button */
 "use_cellular_data" = "Evet";
@@ -73,20 +61,11 @@
 /* Location services are disabled by user alert - message */
 "location_is_disabled_long_text" = "Şu anda bu cihaz için tüm Yer Hizmetleri veya uygulama devre dışı bırakılmış. Lütfen Ayarlar bölümünden etkinleştirin.";
 
-/* Location Services are not available on the device alert - message */
-"device_doesnot_support_location_services" = "Cihazınız Yer Hizmetlerini desteklemiyor";
-
 /* View and button titles for accessibility */
 "zoom_to_country" = "Haritada göster";
 
-/* Button text for the button at the center of the screen when the country is not downloaded */
-"country_status_download" = "Haritayı İndir\n(^ ^)";
-
 /* Button text for the button at the center of the screen when the country is not downloaded and the size should not be shown */
 "country_status_download_without_size" = "Haritayı İndir";
-
-/* Button text for the button at the center of the screen when the country is not downloaded */
-"country_status_download_without_routing" = "Haritayı rota\nolmadan indirin (^ ^)";
 
 /* Message to display at the center of the screen when the country download has failed */
 "country_status_download_failed" = "Indirme işlemi başarısız oldu";
@@ -96,19 +75,13 @@
 
 "about_menu_title" = "Organic Maps Hakkında";
 
-"downloaded_touch_to_delete" = "(%@) indirildi, silmek için dokunun";
-
 "connection_settings" = "Bağlantı Ayarları";
-
-"download_mb_or_kb" = "%@ indir";
 
 "close" = "Kapat";
 
 "unsupported_phone" = "Hızlı donanıma sahip bir OpenGL gerekli. Ne yazık ki cihazınız desteklenmiyor.";
 
 "download" = "İndir";
-
-"external_storage_is_not_available" = "İndirilen haritalarla SD kart/USB depolama aygıtı kullanılamıyor";
 
 "disconnect_usb_cable" = "Organic Maps’yi kullanabilmeniz için lütfen USB kablosunun bağlantısını kesin veya hafıza kartı takın";
 
@@ -117,8 +90,6 @@
 "not_enough_memory" = "Uygulamayı başlatmak için yeterli hafıza yok";
 
 "download_resources" = "Başlamadan önce cihazınıza genel dünya haritasını indirelim.\nVerilerin %@’si gerekli.";
-
-"getting_position" = "Geçerli konum alınıyor";
 
 "download_resources_continue" = "Haritaya Git";
 
@@ -140,23 +111,14 @@
 /* Add New Bookmark Set dialog title */
 "add_new_set" = "Yeni Ayar ekle";
 
-/* Place Page - Add To Bookmarks button */
-"add_to_bookmarks" = "Yer İmlerine Ekle";
-
 /* Bookmark Color dialog title */
 "bookmark_color" = "Yer İmi Rengi";
 
 /* Add Bookmark Set dialog - hint when set name is empty */
 "bookmark_set_name" = "Yer İmi Adını Ayarla";
 
-/* Bookmark Sets dialog title */
-"bookmark_sets" = "Yer İmi Ayarları";
-
 /* Bookmarks - dialog title */
 "bookmarks" = "Yer İmleri";
-
-/* Add bookmark dialog - bookmark color */
-"color" = "Renk";
 
 /* Default bookmarks set name */
 "core_my_places" = "Yerlerim";
@@ -167,14 +129,8 @@
 /* Editor title above street and house number */
 "address" = "Adres";
 
-/* Place Page - Remove Pin button */
-"remove_pin" = "Pini Kaldır";
-
 /* Add bookmark dialog - bookmark set, Bookmarks dialog - Bookmark set cell */
 "set" = "Ayarla";
-
-/* Text hint in Bookmarks dialog when no any bookmarks are added */
-"bookmarks_usage_hint" = "Henüz hiç yer iminiz yok.\nYer imi eklemek için haritada bir yere dokunun.\nBaşka kaynaklardan da yer imleri alınıp Organic Maps’de gösterilebilir KML/KMZ dosyasını posta, Dropbox veya web bağlantısından kaydedilen pinlerle aç.";
 
 /* Settings button in system menu */
 "settings" = "Ayarlar";
@@ -191,26 +147,11 @@
 /* Ask to wait user several minutes (some long process in modal dialog). */
 "wait_several_minutes" = "Bu işlem birkaç dakika sürebilir.\nLütfen bekleyin…";
 
-/* Show bookmarks from this category on a map or not */
-"visible" = "Görünür";
-
-/* Toast which is displayed when GPS has been deactivated */
-"gps_is_disabled_long_text" = "GPS devre dışı bırakıldı. Lütfen Ayarlar bölümünden etkinleştirin.";
-
 /* Measurement units title in settings activity */
 "measurement_units" = "Ölçü Birimleri";
 
 /* Detailed description of Measurement Units settings button */
 "measurement_units_summary" = "Mil veya kilometre seçimini yap";
-
-/* Do search in all sources */
-"search_mode_all" = "Her Yerde";
-
-/* Do search near my position only */
-"search_mode_nearme" = "Yakınlarımda";
-
-/* Do search in current viewport only */
-"search_mode_viewport" = "Ekranda";
 
 /* Search category for cafes, bars, restaurants */
 "eat" = "Nerede yenir";
@@ -266,14 +207,8 @@
 /* Search category */
 "police" = "Polis";
 
-/* String in search result list, when nothing found */
-"no_search_results_found" = "Sonuç bulunamadı";
-
 /* Notes field in Bookmarks view */
 "description" = "Notlar";
-
-/* Button text */
-"share_by_email" = "E-postayla paylaş";
 
 /* Email Subject when sharing bookmarks category */
 "share_bookmarks_email_subject" = "Paylaşılan Organic Maps yer imleri";
@@ -295,26 +230,11 @@
 /* Warning message when doing search around current position */
 "unknown_current_position" = "Yeriniz henüz belirlenmedi";
 
-/* Warning message when location country isn't downloaded during search (see also download_location_map_proposal). */
-"download_location_country" = "Geçerli konumuzun (%@) ülkesini indirin";
-
-/* Warning message when viewport country isn't downloaded during search */
-"download_viewport_country_to_search" = "Aradığınız (%@) ülkesini indirin";
-
 /* Alert message that we can't run Map Storage settings due to some reasons. */
 "cant_change_this_setting" = "Üzgünüz, Harita Depolama ayarları şu anda devre dışı.";
 
 /* Alert message that downloading is in progress. */
 "downloading_is_active" = "Ülke indirme işlemi şu anda sürüyor.";
-
-/* Message that will be shown in alert view, when we ask user to leave review on App Store */
-"appStore_message" = "Organic Maps kullanmaktan keyif aldığınızı umuyoruz! Öyleyse, lütfen App Store’da uygulamaya puan verin veya uygulama hakkında yorum yapın. Bir dakikadan daha kısa sürer ama bize gerçekten yardımcı olabilir. Desteğiniz için teşekkürler!";
-
-/* No, thanks */
-"no_thanks" = "Hayır, teşekkürler";
-
-/* Share one specific bookmark using SMS, %1$@ contains om:// and %2$@ https://omaps.app link. @NOTE non-ascii symbols in the link will result in max 70 characters SMS instead of 140. */
-"bookmark_share_sms" = "Hey, Organic Maps’de pinimi incele! %1$@ veya %2$@ Çevrimiçi haritalar sende yüklü değil mi? Buradan indir: https://omaps.app/get";
 
 /* Share my position using SMS, %1$@ contains om:// and %2$@ https://omaps.app link WITHOUT NAME. @NOTE non-ascii symbols in the link will result in max 70 characters SMS instead of 140. */
 "my_position_share_sms" = "Hey, Organic Maps’de geçerli konumumu incele! %1$@ veya %2$@ Çevrimiçi haritalar sende yok mu? Buradan indir: https://omaps.app/get";
@@ -328,23 +248,11 @@
 /* Share my position using EMail, %1$@ is om:// and %2$@ is https://omaps.app link WITHOUT NAME */
 "my_position_share_email" = "Merhaba,\n\nŞu anda bulunduğum yer: %1$@. Yeri haritada görmek için bu bağlantıya %2$@ veya şuna %3$@ tıkla.\n\nTeşekkürler.";
 
-/* Android share by Message/SMS button text (including SMS) */
-"share_by_message" = "Mesajla paylaş";
-
 /* Share button text which opens menu with more buttons, like Message, EMail, Facebook etc. */
 "share" = "Paylaş";
 
-/* iOS share by Message button text (including SMS) */
-"message" = "Mesaj";
-
 /* Share by email button text, also used in editor. */
 "email" = "E-posta";
-
-/* Copy Link */
-"copy_link" = "Bağlantıyı Kopyala";
-
-/* Text for the button that returns to caller application */
-"more_info" = "Daha Fazla Bilgi Göster";
 
 /* Text for message when used successfully copied something */
 "copied_to_clipboard" = "Panoya Kopyalandı: %1$@";
@@ -354,15 +262,6 @@
 
 /* Used for bookmark editing */
 "done" = "Bitti";
-
-/* Summary for preferences in MWM */
-"yopme_pref_summary" = "Arka Ekran ayarlarını seç";
-
-/* Title for yopme preferences in MWM */
-"yopme_pref_title" = "Arka Ekran Ayarları";
-
-/* Hint for upper-right icon p2b */
-"show_on_backscreen" = "Arka ekranda göster";
 
 /* Prints version number in About dialog */
 "version" = "Sürüm: %@";
@@ -381,19 +280,11 @@
 
 "share_my_location" = "Yerimi paylaş";
 
-"menu_search" = "Ara";
-
 /* Settings general group in settings screen */
 "prefs_group_general" = "General settings";
 
 /* Settings information group in settings screen */
 "prefs_group_information" = "Information";
-
-/* Settings screen: "Map" category title */
-"prefs_group_map" = "Harita";
-
-/* Settings screen: "Miscellaneous" category title */
-"prefs_group_misc" = "Çeşitli";
 
 "prefs_group_route" = "Navigasyon";
 
@@ -419,9 +310,6 @@
 /* Settings «Map» category: «3D buildings» title */
 "pref_map_3d_buildings_title" = "3 Boyutlu Binalar";
 
-/* Settings «Map» category: «3D buildings» summary */
-"pref_map_3d_buildings_subtitle" = "Pil ömrünü etkiler";
-
 /* Settings «Route» category: «Tts enabled» title */
 "pref_tts_enable_title" = "Sesli Talimatlar";
 
@@ -433,8 +321,6 @@
 
 /* Title for "Other" section in TTS settings. */
 "pref_tts_other_section_title" = "Diğer";
-
-"pref_tts_how_to_set_up_voice" = "Ses nasıl ayarlanır";
 
 /* Settings «Map» category: «Record track» title */
 "pref_track_record_title" = "En son yol";
@@ -455,56 +341,7 @@
 
 "recent_track_help_text" = "Bu özellik, belirli bir süre içinde katedilen yolu kaydetmenizi ve harita üzerinde izlemenizi sağlar. Lütfen unutmayın: bu işlevin etkinleştirilmesi pil tüketiminin artmasına neden olur. Takip, zaman aralığının sona ermesinin ardından otomatik olarak haritadan kaldırılacaktır.";
 
-"pref_track_ios_caption" = "En son yol seyahat ettiğiniz yolları gösterir.";
-
-"pref_track_ios_subcaption" = "Lütfen kaydedilecek yol süresini seçin.";
-
-"placepage_distance" = "Mesafe";
-
-"placepage_coordinates" = "Koordinatlar";
-
-"placepage_unsorted" = "Sıralanmamış";
-
 "search_show_on_map" = "Haritada görüntüle";
-
-/* Used to warn user when fixing KitKat issue */
-"bookmark_move_fail" = "Yer imlerinizi dâhili hafızaya taşımamız gerekiyor ancak bunlar için kullanılabilir alan yok. Lütfen hafızayı boşaltın, aksi takdirde yer imleri kullanılamaz olacaktır.";
-
-/* Used in More Apps menu */
-"free" = "Ücretsiz";
-
-/* Used in More Apps menu */
-"buy" = "Satın Al";
-
-/* 1st search button-like result */
-"search_on_map" = "Haritada Ara";
-
-/* toast with an error */
-"no_route_found" = "Rota bulunamadı";
-
-/* route title */
-"route" = "Rota";
-
-/* category title */
-"routes" = "Güzergahlar";
-
-/* text of notification */
-"download_map_notification" = "Bulunduğun yerin haritasını indir";
-
-/* text of notification */
-"pro_version_is_free_today" = "Organic Maps tam sürümü bugün ücretsiz! İndir ve arkadaşlarına haber ver.";
-
-/* Dialog for transferring maps from lite to pro. */
-"move_lite_maps_to_pro" = "Organic Maps Lite'den indirmiş olduğunuz haritaları Organic Maps'ye aktarıyoruz. Bu bir kaç dakika sürebilir.";
-
-/* Message to display when maps moved. */
-"move_lite_maps_to_pro_ok" = "İndirmiş olduğunuz haritalar başarılı bir şekilde Organic Maps'ye aktarıldı.";
-
-/* Message to display when maps move failed. */
-"move_lite_maps_to_pro_failed" = "Haritanızın aktarımı başarısız oldu. Lütfen Organic Maps Lite'yi silin ve haritaları tekrar indirin.";
-
-/* Text in menu */
-"settings_and_more" = "Ayarlar & Fazlası";
 
 /* Text in menu */
 "website" = "Web Sitesi";
@@ -527,14 +364,8 @@
 /* Text in menu */
 "openstreetmap" = "OpenStreetMap";
 
-/* Text in menu */
-"contact_us" = "İletişim";
-
 /* Settings: Send feedback button and dialog title */
 "feedback" = "Geri Bildirim";
-
-/* Text in menu */
-"subscribe_to_news" = "Haberlerimize abone ol";
 
 /* Text in menu */
 "rate_the_app" = "Uygulamayı değerlendir";
@@ -548,15 +379,6 @@
 /* Text in menu */
 "report_a_bug" = "Hata bildir";
 
-/* Email subject */
-"subscribe_me_subject" = "Lütfen Organic Maps haber bültenine beni abone yap";
-
-/* Email body */
-"subscribe_me_body" = "En son haberlerden güncellemelerden ve tanıtımlardan ilk önce haberdar olmak istiyorum. Aboneliğimi herhangi bir zaman iptal edebilirim.";
-
-/* About text */
-"about_text" = "Organic Maps dünyadaki tüm ülkelerdeki şehirlerin en hızlı çevrimdışı haritalarını sunuyor. Tam güven ile seyahat edin: nerede olursanız olun, Organic Maps harita üzerinde nerede olduğunuzu belirlemeye, en yakın restoranı, oteli, bankayı, benzin istasyonunu v.b. bulmaya yardımcı olur. İnternet bağlantısı gerektirmez.\n\nHer zaman yeni özellikler üzerinde çalışıyoruz ve sizlerin Organic Maps'yi nasıl geliştirebileceğimize dair görüşlerinizi almaktan mutluluk duyuyoruz. Eğer uygulama ile ilgili herhangi bir probleminiz varsa, bizimle support@organicmaps.app adresinden temasa geçmekten çekinmeyin. Her talebe cevap veriyoruz!\n\nOrganic Maps'yi beğendiniz ve bize destek olmak ister misiniz? Bunun bazı basit ve tamamıyla ücretsiz yolları var:\n\n- Uygulama Marketinizde bir yorum yazın\n- Facebook sayfamızı beğenin http://www.facebook.com/OrganicMaps\n- veya sadece annenize, arkadaşlarınıza ve iş arkadaşlarınıza Organic Maps'den bahsedin :)\n\nBizi tercih ettiğiniz için teşekkür ederiz. Desteğinizden dolayı çok memnuniyet duyarız!\n\nNot: Verileri haritaları kullanıcıların yaratmasına ve düzenlemesine olanak veren Wikipedia benzeri bir proje olan OpenStreetMap'dan almaktayız. Eğer haritada eksik ya da hatalı bir şeyler görürseniz doğrudan haritaları\n\nhttps://www.openstreetmap.org, adresinden düzeltebilirsiniz ve yaptığınız değişiklikler Organic Maps'de bir sonraki sürüm yayınlandığında görülebilir olacaktır.";
-
 /* Alert text */
 "email_error_body" = "E-posta istemcisi henüz kurulmamış. Lütfen e-posta istemcisini yapılandırın ya da bize %@ adresinden ulaşmak için başka bir yöntem deneyin";
 
@@ -569,12 +391,6 @@
 /* Search category */
 "wifi" = "WiFi";
 
-/* Update map suggestion */
-"routing_map_outdated" = "Yeni bir rota oluşturmak için lütfen haritayı güncelleyin.";
-
-/* Update maps suggestion */
-"routing_update_maps" = "Organic Maps'nin yeni sürümü mevcut pozisyonunuzdan varış noktasına rotalar oluşturmanıza imkan verir. Lütfen bu özelliği kullanmak için haritaları güncelleyin.";
-
 /* Update all button text */
 "downloader_update_all_button" = "Hepsini güncelle";
 
@@ -583,9 +399,6 @@
 
 /* Downloaded maps category */
 "downloader_downloaded_subtitle" = "İndirildi";
-
-/* Downloaded maps category */
-"downloader_available_maps" = "Mevcut";
 
 /* Country queued for download */
 "downloader_queued" = "Sıraya alındı";
@@ -598,17 +411,6 @@
 
 "downloader_downloading" = "İndiriliyor:";
 
-"downloader_search_results" = "Bulundu";
-
-/* Disclaimer message */
-"routing_disclaimer" = "Organic Maps uygulamasında rota yaratırken lütfen aşağıdakileri dikkate alın:\n\n  - Önerilen rotalar sadece tavsiyeler olarak düşünülmelidir.\n - Yol koşulları, trafik kuralları ve işaretleri navigasyon tavsiyelerden daha önceliklidir.\n - Harita doğru olmayabilir ya da eskimiş olabilir ve rotalar en iyi mümkün yola göre oluşturulmamış olabilir.\n\n  Yollarda güvende olun ve kendinize dikkat edin!";
-
-/* Outdated maps category */
-"downloader_outdated_maps" = "Güncel değil";
-
-/* Up to date maps category */
-"downloader_uptodate_maps" = "Güncel";
-
 /* Status of outdated country in the list */
 "downloader_status_outdated" = "Güncelle";
 
@@ -618,49 +420,14 @@
 /* Displayed in a dialog that appears when a user tries to delete a map while the app is in the follow route mode */
 "downloader_delete_map_while_routing_dialog" = "Haritayı silmek için lütfen navigasyonu durdurun.";
 
-/* Show when user try build route, but we don't know where he */
-"routing_failed_unknown_my_position" = "Geçerli konum tanımlı değil. Rota oluşturmak için lütfen konum belirtin.";
-
-/* Show if use has not routing file, or InconsistentMWMandRoute */
-"routing_failed_has_no_routing_file" = "Bir rota oluşturmak için ek bilgiler gereklidir. İndirme işlemini başlat?";
-
-/* StartPointNotFound */
-"routing_failed_start_point_not_found" = "Rota hesaplanamıyor. Başlangıç noktanızın yakınında hiçbir yol yok.";
-
-/* EndPointNotFound */
-"routing_failed_dst_point_not_found" = "Rota hesaplanamıyor. Varış yerinizin yakınında hiçbir yol yok.";
-
 /* PointsInDifferentMWM */
 "routing_failed_cross_mwm_building" = "Rotalar sadece tamamen tek bir harita dâhilinde oluşturulabilir.";
-
-/* RouteNotFound */
-"routing_failed_route_not_found" = "Seçilen kalkış yeriyle varış yeri arasında hiçbir rota bulunamadı. Lütfen farklı bir başlangıç veya bitiş noktası seçin.";
-
-/* InternalError */
-"routing_failed_internal_error" = "Sistem içi hata oluştu. Lütfen haritayı silin ve tekrar yüklemeyi deneyin. Sorun devam ettiği takdirde lütfen support@organicmaps.app adresinden bize ulaşın.";
-
-/* Context menu item for downloader. */
-"downloader_download_map_and_routing" = "Harita + Rota İndir";
-
-/* Context menu item for downloader. */
-"downloader_download_routing" = "Rota İndir";
-
-/* Context menu item for downloader. */
-"downloader_delete_routing" = "Rotayı Sil";
 
 /* Context menu item for downloader. */
 "downloader_download_map" = "Haritayı indir";
 
-"downloader_download_map_no_routing" = "Haritayı rota olmadan indirin";
-
-/* Button for routing. */
-"routing_go" = "Git!";
-
 /* Item status in downloader. */
 "downloader_retry" = "Tekrarla";
-
-/* Item in context menu. */
-"downloader_map_and_routing" = "Harita + Rota";
 
 /* Item in context menu. */
 "downloader_delete_map" = "Haritayı Sil";
@@ -668,29 +435,11 @@
 /* Item in context menu. */
 "downloader_update_map" = "Haritayı Güncelle";
 
-/* Item in context menu. */
-"downloader_update_map_and_routing" = "Harita + Rota Güncelle";
-
-/* Item in context menu. */
-"downloader_map_only" = "Sadece harita";
-
-/* Toolbar title */
-"toolbar_application_menu" = "Uygulama menüsü";
-
 /* Preference text */
 "pref_use_google_play" = "Şu anki konumunuzu almak için Google Play hizmetlerini kullanın";
 
 /* Text for rating dialog */
 "rating_just_rated" = "Uygulamanıza az önce puan verdim";
-
-/* Text for rating dialog */
-"rating_user_since" = "%@ yılından beri Organic Maps kullanıcısıyım";
-
-/* Text for rating dialog */
-"rating_do_like_maps" = "Organic Maps'yi beğeniyor musunuz?";
-
-/* Text for rating dialog */
-"rating_tap_star" = "Uygulamamıza puan vermek için bir yıldıza dokunun.";
 
 /* Text for rating dialog */
 "rating_thanks" = "Teşekkürler!";
@@ -701,23 +450,8 @@
 /* Text for rating dialog */
 "rating_send_feedback" = "Geribildirim gönder";
 
-/* Text for g+ dialog */
-"rating_google_plus" = "Arkadaşlarına uygulamayı duyurmak için g+'ya tıkla.";
-
 /* Text for routing error dialog */
 "routing_download_maps_along" = "Rota üzerindeki haritaları indir";
-
-/* Text for routing error dialog */
-"routing_download_map" = "Harita alın";
-
-/* Text for routing error dialog */
-"routing_download_map_and_routing" = "Tüm Organic Maps özelliklerini edinmek için güncellenmiş harita ve rota verilerini indirin.";
-
-/* Text for routing error dialog */
-"routing_get_routing_data" = "Rota verileri edin";
-
-/* Text for routing error dialog */
-"routing_get_additional_data" = "Konumunuzdan rota oluşturmak için ilave verileri edinin.";
 
 /* Text for routing error dialog */
 "routing_requires_all_map" = "Konumunuzdan bir rota oluşturmak bölgenizdeki tüm haritaların indirilmesini ve güncellenmesini gerektirir.";
@@ -725,50 +459,15 @@
 /* Text for routing error dialog */
 "routing_not_enough_space" = "Yeterli alan yok";
 
-/* Text for routing error dialog */
-"routing_download_more_than_avail" = "%@ MB indirmeniz gerekiyor fakat sadece %@ MB boş alan mevcut.";
-
-/* Text for routing error dialog */
-"routing_download_roaming" = "%@ MB boyutunda veriyi Mobil Veri (Roaming) kullanarak indireceksiniz. Bu mobil operatör veri planınıza göre ilave ödeme gerektirebilir.";
-
 /* bookmark button text */
 "bookmark" = "yer i̇mi";
-
-/* map is not downloaded */
-"not_found_map" = "Konum haritası bulunamadı";
 
 /* location service disabled */
 "enable_location_services" = "Lütfen Yer Hizmetlerini etkinleştirin";
 
-/* download map */
-"download_map" = "Konumunuz için haritayı indirin";
-
-/* download map on iPhone */
-"download_map_iphone" = "Mevcut konum için iPhone'nunuza haritayı indirin";
-
-/* clear pin */
-"nearby" = "Yakında";
-
-/* clear pin */
-"clear_pin" = "İğneyi Temizle";
-
-/* location is undefined */
-"undefined_location" = "Geçerli konum tanımlı değil.";
-
-/* download country of your location */
-"download_country" = "Geçerli konumuzun ülkesini indirin";
-
-/* download failed */
-"download_failed" = "indirme işlemi başarısız oldu";
-
-/* get the map */
-"get_the_map" = "Harita alın";
-
 "save" = "Kaydet";
 
 "edit_description_hint" = "Açıklamalarınız (metin veya html)";
-
-"new_group" = "yeni grup";
 
 "create" = "oluştur";
 
@@ -795,30 +494,6 @@
 
 /* pink color */
 "pink" = "Pembe";
-
-/* deep purple color */
-"deep_purple" = "Koyu Mor";
-
-/* light blue color */
-"light_blue" = "Açık Mavi";
-
-/* cyan color */
-"cyan" = "Cam Göbeği";
-
-/* teal color */
-"teal" = "Deniz Mavisi";
-
-/* lime color */
-"lime" = "Çim Rengi";
-
-/* deep orange color */
-"deep_orange" = "Koyu Turuncu";
-
-/* gray color */
-"gray" = "Gri";
-
-/* blue gray color */
-"blue_gray" = "Mavi Gri";
 
 /* Wi-Fi available */
 "WiFi_available" = "Evet";
@@ -848,13 +523,9 @@
 
 "dialog_routing_location_unknown_turn_on" = "Mevcut GPS koordinatları belirlenemiyor. Güzergah hesaplamak için konum hizmetlerini etkinleştirin.";
 
-"dialog_routing_location_unknown" = "Mevcut GPS koordinatları belirlenemiyor.";
-
 "dialog_routing_download_files" = "Gerekli dosyaları indirin";
 
 "dialog_routing_download_and_update_all" = "Planlanan yoldaki tüm harita ve güzergah bilgilerini indirip güncelleyerek güzergahı hesaplayın.";
-
-"dialog_routing_routes_size" = "Güzergah bilgi dosyaları";
 
 "dialog_routing_unable_locate_route" = "Güzergah belirlenemiyor";
 
@@ -884,21 +555,11 @@
 
 "dialog_routing_try_again" = "Lütfen daha sonra tekrar deneyin";
 
-"dialog_routing_send_error" = "Hatayı Bildirin";
-
-"dialog_routing_if_get_cross_route" = "Bir haritadan daha fazlasına uzanan doğrudan bir güzergah oluşturmak ister misiniz?";
-
-"dialog_routing_cross_route_is_optimal" = "Bu haritanın bir kısmından geçen daha uygun bir güzergah mevcut.";
-
 "not_now" = "Şimdi Değil";
-
-"dialog_routing_build_route" = "Oluşturun";
 
 "dialog_routing_download_and_build_cross_route" = "Haritayı indirerek birden fazla haritaya uzanan daha uygun bir güzergah oluşturmak ister misiniz?";
 
 "dialog_routing_download_cross_route" = "Bu haritanın bir kısmından geçen daha uygun bir güzergah oluşturmak için haritayı indirin.";
-
-"dialog_routing_cross_route_always" = "Bu sınırı her zaman geçin";
 
 
 /********** Strings for downloading map from search **********/
@@ -906,8 +567,6 @@
 "search_without_internet_advertisement" = "Rotaları aramak ve oluşturmaya başlamak için lütfen haritayı indirin ve artık internet bağlantısına ihtiyacınız yok.";
 
 "search_select_map" = "Haritayi Seçin";
-
-"search_select_other_map" = "Başka Bir Harita Seçin";
 
 /* «Show» context menu */
 "show" = "Göster";
@@ -918,17 +577,11 @@
 /* «Rename» context menu */
 "rename" = "Yeniden Adlandır";
 
-/* Bottom sheet: expand button (should be short) */
-"bottom_sheet_more" = "Daha Fazla…";
-
 /* Failed planning route message in navigation view */
 "routing_planning_error" = "Rota Planlaması Başarısız";
 
 /* Arrive routing message in navigation view */
 "routing_arrive" = "Varış: %s";
-
-/* Text for routing::RouterResultCode::FileTooOld dialog. */
-"dialog_routing_download_and_update_maps" = "Bir rota oluşturmak için lütfen rota üzerindeki tüm haritaları indirin ve güncelleyin.";
 
 "rate_alert_title" = "Uygulamayı beğendiniz mi?";
 
@@ -944,19 +597,11 @@
 
 "history" = "Geçmiş";
 
-"next_turn_then" = "Sonra";
-
 "closed" = "Kapatıldı";
-
-"back_to" = "Geri Dön %@";
 
 "search_not_found" = "Üzgünüz, hiç bir şey bulamadık.";
 
 "search_not_found_query" = "Lütfen başka bir sorgu girin.";
-
-"search_not_found_map" = "Lütfen arama yaptığınız haritayı indirin.";
-
-"search_not_found_location" = "Mevcut konumunuzun haritasını indirin.";
 
 "search_history_title" = "Arama Geçmişi";
 
@@ -964,23 +609,12 @@
 
 "clear_search" = "Arama geçmişini temizle";
 
-/* Title for settings to enable/disable showcase menu button */
-"showcase_settings_title" = "Teklifleri göster";
-
 /* Place Page link to Wikipedia article (if map object has it). */
 "read_in_wikipedia" = "Wikipedia";
 
-"p2p_route_planning" = "Rota planlama";
-
 "p2p_your_location" = "Konumunuz";
 
-"p2p_from" = "Kalkış noktası";
-
-"p2p_to" = "Varış noktası";
-
 "p2p_start" = "Başla";
-
-"p2p_planning" = "Planlanıyor…";
 
 "p2p_from_here" = "Başlangıç";
 
@@ -1018,15 +652,9 @@
 
 "editor_correct_mistake" = "Hatayı düzelt";
 
-"editor_correct_mistake_message" = "Bir düzenleme hatası yaptınız. Lütfen düzeltin veya basit moda geçin.";
-
 "editor_add_select_location" = "Konum";
 
 "editor_done_dialog_1" = "Dünya haritasını değiştirdiniz. Bunu gizlemeyin! Arkadaşlarınıza anlatın ve birlikte düzenleyin.";
-
-"editor_done_dialog_2" = "Bu sizin ikinci harita iyileştirmeniz. Artık siz harita editörleri arasında %d. sıradasınız. Arkadaşlarınıza bunu anlatın.";
-
-"editor_done_dialog_3" = "Haritayı geliştirdiniz, arkadaşlarınıza bunu anlatın ve birlikte haritayı düzenleyin.";
 
 "share_with_friends" = "Arkadaşlarınla paylaş";
 
@@ -1044,20 +672,7 @@
 
 "editor_report_problem_duplicate_place_title" = "Kopyalanmış yer";
 
-"first_launch_congrats_title" = "Organic Maps kullanıma hazır";
-
-"first_launch_congrats_text" = "Dünyanın her yerinde çevrimdışı olarak ücretsiz arama yapın ve gezinin.";
-
-"migrate_title" = "Önemli!";
-
-/* Android uses image instead of text. */
-"download_all" = "Tümünü indir";
-
-"delete_all" = "Tümünü sil";
-
 "autodownload" = "Otomatik indir";
-
-"disable_autodownload" = "Otomatik indirmeyi devre dışı bırak";
 
 /* Place Page opening hours text */
 "closed_now" = "Şu anda kapalı";
@@ -1072,10 +687,6 @@
 "day_off" = "Kapalı";
 
 "today" = "Bugün";
-
-"sunrise_to_sunset" = "Güneşin doğuşundan batışına kadar";
-
-"sunset_to_sunrise" = "Gün doğumundan gün batımına";
 
 "add_opening_hours" = "İş saatlerini ekle";
 
@@ -1095,45 +706,18 @@
 
 "forgot_password" = "Şifreni mi unuttun?";
 
-/* Forgot Password dialog title */
-"restore_password" = "Şifreyi yenile";
-
-"enter_email_address_to_reset_password" = "Kayıt sırasında kullandığınız e-posta adresini girin ve şifrenizi yenileyeceğiniz bağlantıyı gönderelim.";
-
-"reset_password" = "Parolayı sıfırla";
-
-"username" = "Kullanıcı Adı";
-
 "osm_account" = "OSM Hesabı";
 
 "logout" = "Oturumu kapat";
 
-"login_and_edit_map_motivation_message" = "Oturum aç ve haritada nesne bilgilerini düzenleyip diğer milyonlarca kullanıcıya aç. Birlikte dünyayı daha iyi bir yer haline getirelim.";
-
 /* Information text: "Last upload 11.01.2016" */
 "last_upload" = "Son yükleme";
 
-/* Motivates user to login/register, title above login buttons. */
-"you_have_edited_your_first_object" = "İlk nesneni düzenledin!";
-
 "thank_you" = "Teşekkür ederiz";
-
-"login_with_google" = "Google ile giriş";
-
-"login_with_openstreetmap" = "www.openstreetmap.org adresinden oturum aç";
 
 "edit_place" = "Yeri düzenle";
 
 "place_name" = "Yer ismi";
-
-/* title above languages list cells in the editor, below editable name text field. */
-"other_languages" = "Diğer Diller";
-
-/* small button to open list with names in different languages */
-"show_more" = "Daha fazlasını göster";
-
-/* small button to close list with names in different languages */
-"show_less" = "Daha azını göster";
 
 "add_language" = "Bir dil ekle";
 
@@ -1164,8 +748,6 @@
 
 "please_note" = "Lütfen dikkat";
 
-"common_no_wifi_dialog" = "WiFi bağlantısı yok. Mobil veri ile devam etmek istiyor musunuz?";
-
 "downloader_delete_map_dialog" = "Harita ile birlikte tüm harita değişiklikleri de silinecektir.";
 
 "downloader_update_maps" = "Haritaları güncelle";
@@ -1173,10 +755,6 @@
 "downloader_mwm_migration_dialog" = "Bir rota oluşturmak için tüm haritaları güncellemeli ve ardından rotayı tekrar planlamalısınız.";
 
 "downloader_search_field_hint" = "Harita bul";
-
-"migration_update_all_button" = "Haritaları güncelle";
-
-"migration_delete_all_download_current_button" = "Mevcut haritayı indir ve tüm eski haritaları sil";
 
 "migration_download_error_dialog" = "İndirme hatası";
 
@@ -1186,21 +764,9 @@
 
 "downloader_no_space_message" = "Lütfen gereksiz verileri silin";
 
-"editor_general_auth_error_dialog" = "Genel giriş hatası.";
-
 "editor_login_error_dialog" = "Giriş hatası";
 
-"editor_login_failed_dialog" = "Giriş başarısız";
-
-"editor_username_error_dialog" = "Kullanıcı adı geçersiz";
-
-"editor_place_edited_dialog" = "Bir objeyi düzenlediniz'!";
-
-"editor_login_with_osm" = "OpenStreetMap ile giriş yapın";
-
 "editor_profile_changes" = "Doğrulanan Değişiklikler";
-
-"editor_profile_unsent_changes" = "Gönderilmedi:";
 
 "editor_focus_map_on_location" = "Objenin doğru konumunu seçmek için haritayı çekin.";
 
@@ -1222,13 +788,9 @@
 
 "editor_report_problem_other_title" = "Farklı bir problem";
 
-"placepage_report_problem_button" = "Bir problem bildirin";
-
 "placepage_add_business_button" = "Kuruluş ekle";
 
 "whatsnew_editor_message_1" = "Doğrudan uygulamadan haritaya yeni yerler ekle ve mevcut yerleri düzenleyin.";
-
-"whatsnew_editor_message_2" = "* Organic Maps, OpenStreetMap topluluğu verilerini kullanmaktadır.";
 
 "dialog_incorrect_feature_position" = "Konumu değiştir";
 
@@ -1236,16 +798,10 @@
 
 "login_to_make_edits_visible" = "Giriş yapın böylelikle diğer kullanıcılar yaptığınız değişiklikleri görebilirler.";
 
-"no_migration_during_navigation" = "Navigasyon sırasında güncelleme yasaktır.";
-
 /* Error dialog no space */
 "migration_no_space_message" = "İndirmek için daha fazla alana ihtiyacınız var. Lütfen gereksiz verileri silin.";
 
 "editor_sharing_title" = "Organic Maps haritalarını iyileştirdim";
-
-"editor_comment_will_be_sent" = "Yorumunuzu haritacılara göndereceğiz.";
-
-"editor_unsupported_category_message" = "Henüz desteklemediğimiz bir kategori yeri eklediniz. Bir süre sonra haritada yer alacaktır.";
 
 /* Downloaded 10 **of** 20 <- it is that "of" */
 "downloader_of" = "%1$d/%2$d";
@@ -1278,23 +834,9 @@
 
 "editor_operator" = "İşletmeci";
 
-"editor_tag_description" = "Tesislerden sorumlu şirketi, kurumu veya bireyi girin.";
-
-"editor_no_local_edits_title" = "Yerel düzenlemeniz yok";
-
-"editor_no_local_edits_description" = "Bu, harita üzerinde önerdiğiniz değişikliklerden sadece şu anda cihazınızda erişilebilenlerin sayısını gösterir.";
-
-"editor_send_to_osm" = "OSM’ye gönder";
-
-"editor_remove" = "Kaldır";
-
-"downloader_my_maps_title" = "Haritalarım";
-
 "downloader_no_downloaded_maps_title" = "Hiç harita indirmediniz";
 
 "downloader_no_downloaded_maps_message" = "Çevrimdışı olarak adres bulmak ve gezinmek için haritaları indirin.";
-
-"downloader_find_place_hint" = "Şehirde veya ülkede arama yapın";
 
 /* Error title that appears after certain time without location. */
 "current_location_unknown_title" = "Geçerli konumunuzuz izlenmeye devam edilsin mi";
@@ -1321,47 +863,13 @@
 /* iOS Dialog for the case when the location permission is not granted */
 "location_services_disabled_3" = "3. Uygulamayı Kullanırken Seç";
 
-"placepage_parking_surface" = "Yüzey";
-
-"placepage_parking_multistorey" = "Çok Katlı";
-
-"placepage_parking_underground" = "Metro";
-
-"placepage_parking_rooftop" = "Çatı üstü";
-
-"placepage_parking_sheds" = "Kulübe";
-
-"placepage_parking_carports" = "Açık Park Alanları";
-
-"placepage_parking_boxes" = "Garaj kutuları";
-
-"placepage_parking_pay" = "Ücretli";
-
-"placepage_parking_free" = "Ücretsiz";
-
-"placepage_parking_interval" = "Süre Ücretli";
-
-"placepage_entrance_number" = "No.";
-
-"placepage_entrance_type" = "Giriş";
-
-"placepage_flat" = "uygulama";
-
-"placepage_open_24_7" = "24 / 7";
-
 "meter" = "m";
 
 "kilometer" = "km";
 
-"kilometers_per_hour" = "km/s";
-
 "mile" = "mil";
 
 "foot" = "fit";
-
-"miles_per_hour" = "mph";
-
-"day" = "g";
 
 "hour" = "sa";
 
@@ -1381,10 +889,6 @@
 
 "placepage_bookmark_name_hint" = "Yer İmi Adı";
 
-"placepage_personal_notes_hint" = "Kişisel notlar";
-
-"placepage_delete_bookmark_button" = "Yer İmini Sil";
-
 "editor_edits_sent_message" = "Önerdiğiniz değişiklikler gönderildi";
 
 "editor_comment_hint" = "Yorum…";
@@ -1397,8 +901,6 @@
 
 "editor_remove_place_button" = "Kaldır";
 
-"editor_status_sending" = "Gönderiliyor…";
-
 "editor_place_doesnt_exist" = "Bu yer mevcut değil";
 
 "text_more_button" = "…daha fazla";
@@ -1410,11 +912,7 @@
 
 "error_enter_correct_email" = "Geçerli bir e-posta girin";
 
-"error_enter_correct" = "Geçerli bir değer girin";
-
 "refresh" = "Güncelleştirme";
-
-"last_update" = "Son güncelleme: %s";
 
 "placepage_add_place_button" = "Haritaya bir yer ekleyin";
 
@@ -1426,24 +924,6 @@
 
 "editor_share_to_all_dialog_message_2" = "Değişikliği kontrol edeceğiz. Eğer herhangi bir sorumuz olursa sizinle e-posta aracılığıyla temasa geçeceğiz.";
 
-"navigation_overview_button" = "genel bakış";
-
-"navigation_stop_button" = "dur";
-
-/* Text on an empty bookmark page */
-"bookmarks_empty_title" = "Yer İşaretlerini Kaydet";
-
-"bookmarks_empty_message_1" = "Hızlı erişim için favori yerlere kaydetmek için ★ dokunun.";
-
-"bookmarks_empty_message_2" = "E-postadan ve weben yer işaretlerini içe aktarın.";
-
-"bookmarks_empty_message_3" = "çıkış: %s";
-
-/* Name of the group for booked hotels */
-"bookmarks_group_name" = "Ayırtılan oteller";
-
-"place_page_button_read_descriprion" = "Oku";
-
 /* iOS dialog for the case when recent track recording is on and the app comes back from background */
 "recent_track_background_dialog_title" = "En son seyahat edilen rotanızı kaydetmeyi devre dışı bırakmak istiyor musunuz?";
 
@@ -1451,8 +931,6 @@
 
 /* For sharing via SMS and so on */
 "sharing_call_action_look" = "İncele";
-
-"continue_recent_track_background_button" = "Devam Et";
 
 "recent_track_background_dialog_message" = "Organic Maps, en son seyahat ettiğiniz rotayı kaydetmek için arka planda coğrafi konumunuzu kullanır.";
 
@@ -1468,33 +946,13 @@
 /* About short text (below logo) */
 "about_description" = "Organic Maps, seyahatler için vazgeçilmez bir çevrimdışı uygulamadır. Organic Maps, OpenStreetMap verilerine dayanmakta ve bu verilerin düzenlenmesini sağlamaktadır.";
 
-/* Text in menu */
-"blog" = "Blog";
-
 "general_settings" = "Genel ayarlar";
-
-"date" = "Tarih %d";
-
-/* "Report a bug" -> "Generaal Feedback" -> "Something is not working" */
-"something_is_not_working" = "Bir şey çalışmıyor";
 
 /* For the first routing */
 "accept" = "Kabul";
 
-"accept_and_continue" = "Accept and continue";
-
 /* For the first routing */
 "decline" = "Ret";
-
-"install_app" = "Kur";
-
-"search_no_results_title" = "Hiçbir Sonuç Bulunamadı";
-
-"search_no_results_message" = "Daha genel bir terimi aramayı deneyin, uzaklaşın veya filtreyi Sıfırlayın.";
-
-"search_no_results_expand_area_button" = "Uzaklaş";
-
-"search_no_results_reset_button" = "Filtreyi Sıfırla";
 
 /* noun */
 "search_in_table" = "Liste";
@@ -1517,8 +975,6 @@
 
 "traffic_update_maps_text" = "Trafik verilerini görüntülemek için haritaların güncellenmesi gerekiyor.";
 
-"traffic_outdated" = "Trafik verileri güncel değil.";
-
 "big_font" = "Harita üzerindeki yazı tipi boyutunu artır";
 
 "traffic_update_app" = "Lütfen Organic Maps uygulamasını güncelleyin";
@@ -1529,17 +985,7 @@
 /* "traffic" as in "road congestion" */
 "traffic_data_unavailable" = "Trafik verileri kullanılamıyor";
 
-/* "Translation is no needed, because it's a company name" */
-"uber" = "Uber";
-
-/* Simplified colour scheme for traffic information, fewer colours are used to display traffic jams on the map. The string should be kept as short as possible */
-"pref_traffic_simplified_colors_title" = "Sadeleştirilmiş trafik renkleri";
-
 "enable_logging" = "Günlüğü etkinleştir";
-
-"offline_place_page_more_information" = "Yerle ilgili daha fazla bilgi almak için internete bağlanın.";
-
-"failed_load_information" = "Bilgiler yüklenemedi.";
 
 /* Settings: "Send general feedback" button */
 "feedback_general" = "Genel Geribildirim";
@@ -1556,8 +1002,6 @@
 
 "whatsnew_transliteration_title" = "Latince alfabesine çevirme";
 
-"yandex_taxi_title" = "Yandex.Taxi";
-
 "learn_more" = "Daha fazla bilgi edinin";
 
 "core_exit" = "Çık";
@@ -1568,75 +1012,19 @@
 
 "button_exit" = "Çık";
 
-"settings_device_memory" = "Cihaz belleği";
-
-"settings_card_memory" = "Kart belleği";
-
-"settings_storage_available" = "%s kullanılabilir";
-
-"toast_location_permission_denied" = "Uygulamanın konum bilgilerine erişim isteği reddedildi";
-
-"button_use" = "Kullan";
-
 "planning_route_manage_route" = "Güzergâhı yönet";
 
 "button_plan" = "Plan";
-
-"button_add" = "Ekle";
 
 "placepage_remove_stop" = "Kaldır";
 
 "planning_route_remove_title" = "Kaldırmak için buraya sürükleyin";
 
-"dialog_change_start_point_message" = "Başlangıç noktası mevcut konumla değiştirilsin mi?";
-
-"button_replace" = "Değiştir";
-
 "placepage_add_stop" = "Ara nokta ekle";
-
-/* Only ru/en are needed */
-"subtitle_rent" = "Rent";
-
-/* Only ru/en are needed */
-"rub_month" = "RUB/month";
-
-/* Only ru/en are needed */
-"room" = "%s-room apt.";
-
-/* Only ru/en are needed */
-"real_estate" = "Real estate";
-
-"add_my_position" = "Konumumu ekle";
-
-"choose_start_point" = "Bir başlangıç noktası seçin";
-
-"choose_destination" = "Bir hedef seçin";
 
 "preloader_viator_button" = "Daha fazla bilgi edinin";
 
-"start_from_my_position" = "Buradan başla";
-
-"profile_authorization_title" = "Oturum aç";
-
-"profile_authorization_message" = "Kullanıcı adı ve şifreye gerek kalmadan saniyeler içinde kolayca oturum açın";
-
 "profile_authorization_error" = "Üzgünüz, bir hata oluştu. Tekrar oturum açmayı deneyin.";
-
-"service" = "Hizmet";
-
-"atmosphere" = "Ortam";
-
-"value_for_money" = "Fiyat/Fayda";
-
-"experience" = "Tecrübe";
-
-"assortment" = "Ürün çeşitliliği";
-
-"expertise" = "Uzmanlık";
-
-"equipment" = "Ekipman";
-
-"quality" = "Kalite";
 
 "dialog_error_storage_title" = "Depolama alanı erişim sorunu";
 
@@ -1644,17 +1032,7 @@
 
 "setting_emulate_bad_storage" = "Bozuk depolama alanını taklit et";
 
-"directions_finish" = "Varış konumu";
-
-"directions_on_foot" = "%s doğru yürüyün";
-
 "core_entrance" = "Giriş";
-
-"coffee" = "Kahve";
-
-"cleanliness" = "Temizlik";
-
-"crowdedness" = "Doluluk";
 
 "error_enter_correct_name" = "Lütfen, doğru bir isim girin";
 
@@ -1673,11 +1051,9 @@
 
 "downloader_percent" = "%s (%s / %s)";
 
-"downloader_process" = "%s indiriliyor...";
+"downloader_process" = "%s indiriliyor…";
 
-"downloader_applying" = "%s uygulanıyor...";
-
-"dialog_message_transit_not_found_connection" = "Tek transit bir ağda bir rota planla";
+"downloader_applying" = "%s uygulanıyor…";
 
 "bookmarks_error_message_share_general" = "Bir uygulama hatasından dolayı paylaşılamıyor";
 
@@ -1695,17 +1071,7 @@
 
 "bookmarks_error_message_list_name_already_taken" = "Lütfen başka bir isim seçiniz";
 
-"bookmarks_error_title_list_name_too_long" = "Bu isim çok uzun";
-
-"bookmarks_error_message_list_name_too_long" = "Lütfen başka bir isim seçiniz";
-
-"please_wait" = "Lütfen bekle...";
-
-"phone_number" = "Telefon numarası";
-
-"notification_unsent_reviews_title" = "Birkaç onaylanmamış yorumunuz var";
-
-"notification_unsent_reviews_message" = "Diğer gezginlerle yorum paylaşmak için lütfen giriş yapın";
+"please_wait" = "Lütfen bekle…";
 
 "profile" = "OpenStreetMap profil";
 
@@ -1719,49 +1085,13 @@
 
 "bookmarks_convert_error_message" = "Bazı dosyalar dönüştürülmedi.";
 
-"converting" = "Dönüştürme...";
-
-"wn_reinvented_bookmarks_title" = "Yer imlerini yeniden keşfettik!";
-
-"wn_reinvented_bookmarks_message" = "Yer imlerini yedekleyebilir, listeler oluşturabilirsin... Harika...";
-
-"bookmarks_restore" = "Yer işaretlerini geri yükle";
-
-"bookmarks_restore_process" = "Geri yükleniyor...";
-
 "bookmarks_restore_title" = "Bu sürümü geri yükle?";
 
-"bookmarks_restore_message" = "Yer işaretleriniz %s (%s)'dan geri yüklenecek";
-
-"bookmarks_restore_empty_title" = "Yedekleme yok";
-
-"bookmarks_restore_empty_message" = "Sunucu daha önce yapılmış yedeklemeyi bulamadı";
-
 "common_check_internet_connection_dialog_title" = "İnternet bağlantısı yok";
-
-"error_server_title" = "Server hatası";
-
-"error_server_message" = "Sunucuda bir hata oluştu, lütfen daha sonra tekrar deneyin";
 
 "error_system_message" = "Bilinmeyen bir hata oluştu";
 
 "restore" = "Restore";
-
-"bookmarks_page_downloaded" = "İndirildi";
-
-"bookmarks_page_my" = "Bana ait";
-
-"routes_and_bookmarks" = "Rotalar ve yer imleri";
-
-"bookmarks_webview_success_toast" = "Yer imleri başarıyla indirildi";
-
-"cached_bookmarks_placeholder_title" = "Yeni yerler indirin";
-
-"cached_bookmarks_placeholder_subtitle" = "Organic Maps kullanıcılarının oluşturduğu binlerce ilgi çekici yeri ve rotayı indirmek için düğmeye basın. İnternet bağlantınızın olması gerekir.";
-
-"downloader_download_routers" = "İndirilen yer imleri";
-
-"bookmarks_groups_cached" = "İndirilen listeler";
 
 "subtittle_opt_out" = "İzleme ayarları";
 
@@ -1769,29 +1099,15 @@
 
 "crash_reports_description" = "Organic Maps deneyimini geliştirmek için verilerinizi kullanabiliriz. Değişiklikler, uygulama yeniden başlatıldıktan sonra geçerli olur.";
 
-"opt_out_help_ios_1" = "Mobil cihazınız, “Reklam İzlemeyi Sınırla” veya “İlgiye dayalı reklamcılığı devre dışı bırak” ayarı sunar.";
-
-"opt_out_help_ios_2" = "iOS 9 veya Üstü";
-
-"opt_out_help_ios_3" = "Ayarlar → Gizlilik → Reklamcılık'a gidin ve “Reklam İzlemeyi Sınırla” ayarını etkinleştirin";
-
-"opt_out_help_android" = "Mobil cihazınız, “Reklam İzlemeyi Sınırla” veya “İlgiye dayalı reklamcılığı devre dışı bırak” ayarı sunar.\n\nAndroid ve Google Play Services 4.0 ve üzeri sürümü için:\nAyarlar → Google → Reklamlar → Reklamları Kişiselleştirme'yi devre dışı bırak\nAyarlar → Google → Google Hesabı → Kişisel bilgiler ve gizlilik → Reklam Ayarları → Reklamları Kişiselleştirme";
-
 "privacy_policy" = "Gizlilik politikası";
 
 "terms_of_use" = "Kullanım koşulları";
-
-"backup_notification_failed" = "Yer imlerinizin yedeklenmesi işlemi askıya alındı. İşlemi devam ettirmek için oturum açın.";
 
 "button_layer_traffic" = "Trafik";
 
 "button_layer_subway" = "Metro";
 
 "layers_title" = "Harita katmanları";
-
-"layers_message" = "Trafik, metro haritası ve diğer kullanışlı bilgileri görüntülemek için harita katmanlarını kullanın";
-
-"button_layer_got_it" = "Anladım";
 
 "subway_data_unavailable" = "Metro haritası mevcut değil";
 
@@ -1803,39 +1119,13 @@
 
 "title_error_downloading_bookmarks" = "Bir hata oluştu";
 
-"subtitle_error_downloading_bookmarks" = "Yer imleri indirilmedi";
-
-"error_already_downloaded" = "Bu liste zaten indirildi";
-
 "popular_place" = "Popular";
-
-"download_routes" = "Download routes";
-
-"bookmarks_downloaded_title" = "Bookmarks have been downloaded successfully";
-
-"bookmarks_downloaded_subtitle" = "Press ‘View on map’ to explore new places from the list";
-
-"why_support" = "Organic Maps'yi neden desteklemeliyim?";
-
-"why_support_item1" = "We respect your privacy: there are zero trackers in the app, and we are open source";
-
-"why_support_item2" = "Organic Maps'yi geliştirmemize yardımcı oldunuz";
-
-"why_support_item3" = "OpenStreetMap.org'daki açık haritaları geliştirmemize yardımcı oldunuz";
-
-"channels_map_update" = "Harita güncellemeleri";
-
-"server_unavailable_title" = "Hizmet kullanılamıyor";
-
-"sharing_options" = "Paylaşma seçenekleri";
 
 "export_file" = "Dosyayı dışa aktar";
 
 "list_settings" = "Liste Ayarları";
 
 "delete_list" = "Listeyi sil";
-
-"hide_from_map" = "Haritadan gizle";
 
 "public_access" = "Genel erişim";
 
@@ -1845,40 +1135,11 @@
 
 "bookmark_category_description_hint" = "Bir açıklama yazın (metin veya html)";
 
-/* FIXME */
-"bookmarks_public_access" = "bookmarks_public_access";
-
-/* FIXME */
-"bookmarks_link_access" = "bookmarks_link_access";
-
-/* FIXME */
-"bookmarks_private_access" = "bookmarks_private_access";
-
 "not_shared" = "Şahsi";
-
-"direct_link_progress_text" = "Dosyanız yükleniyor…";
-
-"direct_link_success" = "Bağlantı oluşturuldu";
-
-"send_a_link_btn" = "Bana bir bağlantı gönder";
-
-"upload_error_toast" = "Dosyanızı yüklerken bir hata oluştu";
 
 "tags_loading_error_subtitle" = "Etiketler yüklenirken bir hata oluştu, lütfen tekrar deneyin";
 
-"unable_upload_errorr_title" = "Dosya yükleme başarısız";
-
-"unable_upload_error_subtitle_edited" = "Bu dosya web uygulamasıyla düzenlendi";
-
-"unable_upload_error_subtitle_broken" = "Bu dosya bozuk olduğundan yüklenemedi. Lütfen başka bir dosya yükleyin.";
-
-"contact" = "İletişim";
-
-"download_button" = "İndir";
-
 "speedcams_alert_title" = "Hız kameraları";
-
-"speedcams_alert_subtitle" = "Hız limitleri hakkında uyar";
 
 "speedcam_option_auto" = "Otomatik";
 
@@ -1886,18 +1147,10 @@
 
 "speedcam_option_never" = "Asla";
 
-"bookmark_description_title" = "Yer İmi Açıklaması";
-
 "place_description_title" = "Yer Açıklaması";
 
 /* this text will be shown in application notification preferences opposite checkbox which enable/disable downloader notifications. Devices on Android 8+ are affected. */
 "notification_channel_downloader" = "Harita indiricisi";
-
-"share_bookmarks_email_body_link" = "Merhaba!\n\nİşte yer işaretlerinizi indirebileceğiniz bağlantı: %s. Organic Maps ile listeyi açın ve yolculuğunuzun tadını çıkarın!\n\nUygulamayı indir: https://omaps.app/get?kmz";
-
-"warning_speedcams_title" = "%d km/sa hız limitini aştığınızda navigasyon, kameralar hakkında sizi uyaracak";
-
-"warning_speedcams_subtitle" = "Lütfen bulunduğunuz ülkenin trafik kurallarına dikkat edin.";
 
 "speedcams_notice_message" = "Otomatik - Hız sınırını aşma riski varsa hız kameraları hakkında uyar\nHer zaman - Hız kameraları hakkında her zaman uyar\nAsla - Hız kameraları hakkında hiçbir zaman uyarma";
 
@@ -1913,23 +1166,7 @@
 
 "enable_logging_warning_message" = "Seçenek tanı amaçlı, günlüğe kaydetmeyi açar. Uygulamayla ilgili sorunları gideren destek ekibimiz için yardımcı olabilir. Bu seçeneği yalnızca Organic Maps desteğinin isteği üzerine etkinleştirin.";
 
-"html_error_upload_message_try_again" = "Lütfen ağ ayarlarınızı kontrol edip tekrar deneyin";
-
-"html_error_upload_title_try_again" = "İnternet bağlantısı yok";
-
-"notification_leave_review_v2_android_short_title" = "İnceleyin ve gezginlere yardım edin!";
-
-"megafon" = "Say goodbye to roaming!";
-
-"notifications_illegal_alert_disable_button" = "Bildirimleri kapat";
-
 "access_rules_author_only" = "Çevrimiçi düzenleme";
-
-"privacy_settings_menu" = "Gizlilik ayarları";
-
-"unable_upadate_error_title" = "Dosya güncellemesi başarısız oldu";
-
-"unable_upadate_error_message" = "Güncelleme sırasında bazı hatalar oluştu. Lütfen değişiklikleri kontrol edip tekrar deneyin";
 
 "driving_options_title" = "Sürüş seçenekleri";
 
@@ -1951,94 +1188,19 @@
 
 "change_driving_options_btn" = "Sürüş seçenekleri etkinleştirildi";
 
-"toll_road" = "Paralı yol";
-
-"unpaved_road" = "Asfaltsız yol";
-
-"ferry_crossing" = "Feribot geçişi";
-
-"operated_by" = "\"%s\" tarafından işletiliyor";
-
 "avoid_toll_roads_placepage" = "Paralı yollardan kaçın";
 
 "avoid_unpaved_roads_placepage" = "Asfaltsız yollardan kaçın";
 
 "avoid_ferry_crossing_placepage" = "Feribot geçişlerinden kaçın";
 
-"type.cuisine.uzbek" = "Özbek mutfağı";
-
-"trip_start" = "Hadi gidelim";
-
-"pick_destination" = "Hedef";
-
-"follow_my_position" = "Tekrar ortala";
-
-"search_results" = "Arama sonuçları";
-
-"then_turn" = "Sonra";
-
-"redirect_route_alert" = "Yeniden bir rota oluşturmak ister misiniz?";
-
-"redirect_route_yes" = "Evet";
-
-"redirect_route_no" = "Hayır";
-
-"trip_finished" = "Vardınız!";
-
-"keyboard_availability_alert" = "Klavye, sürüş sırasında kullanılamaz";
-
-"dialog_routing_change_start_carplay" = "Mevcut konumunuzdan rota oluşturulamıyor";
-
-"dialog_routing_change_end_carplay" = "Hedefinize rota oluşturulamıyor. Lütfen başka bir nokta seçin";
-
-"dialog_routing_check_gps_carplay" = "GPS sinyali yok. Lütfen açık bir alana geçin";
-
-"dialog_routing_unable_locate_route_carplay" = "Rota oluşturulamıyor. Lütfen başka bir rota noktası belirtin";
-
-"dialog_routing_download_files_carplay" = "Rota oluşturmak için cihazınızdaki eksik haritaları indirin";
-
-"dialog_routing_system_error_carplay" = "Hata oluştu. Lütfen uygulamayı yeniden başlatın";
-
-"dialog_routing_rebuild_from_current_location_carplay" = "Rota, mevcut konumunuzdan yeniden oluşturulacak";
-
-"dialog_routing_rebuild_for_vehicle_carplay" = "Rota, bir arabalı seyahat rotasına dönüştürülecek";
-
 "ok" = "Tamam";
-
-"avoid_unpaved_carplay_1" = "Stabilizesiz";
-
-"avoid_unpaved_carplay_2" = "Asfaltsız hariç";
-
-"avoid_ferry_carplay_1" = "Feribotsuz";
-
-"avoid_ferry_carplay_2" = "Feribot hariç";
-
-"avoid_tolls_carplay_1" = "Paralı yok";
-
-"avoid_tolls_carplay_2" = "Paralı hariç";
-
-"speedcams_alert_title_carplay_1" = "Hız kamerası";
-
-"speedcams_alert_title_carplay_2" = "Hız uyarıları";
-
-"download_map_carplay" = "Lütfen haritaları cihazınıza Organic Maps uygulamasından indirin";
-
-"carplay_roundabout_exit" = "%s çıkış";
 
 /* max. 10 symbols, both iOS and Android */
 "sort" = "Sırala…";
 
 /* Android, title, max 20-22 symbols */
 "sort_bookmarks" = "Yer imlerini sırala";
-
-/* iOS */
-"sort_default" = "Varsayılana göre sırala";
-
-"sort_type" = "Türe göre sırala";
-
-"sort_distance" = "Mesafeye göre sırala";
-
-"sort_date" = "Tarihe göre sırala";
 
 /* Android */
 "by_default" = "Varsayılana göre";
@@ -2052,63 +1214,7 @@
 /* Android */
 "by_date" = "Tarihe göre";
 
-"week_ago_sorttype" = "Bir hafta önce";
-
-"month_ago_sorttype" = "Bir ay önce";
-
-"moremonth_ago_sorttype" = "Bir aydan daha önce";
-
-"moreyear_ago_sorttype" = "Bir yıldan daha önce";
-
-"near_me_sorttype" = "Bana yakın";
-
-"others_sorttype" = "Diğerleri";
-
-"food_places" = "Yiyecek";
-
-"tourist_places" = "Görülecek yerler";
-
-"museums" = "Müzeler";
-
-"parks" = "Parklar";
-
-"swim_places" = "Yüzme";
-
-"mountains" = "Dağlar";
-
-"animals" = "Hayvanlar";
-
-"hotels" = "Oteller";
-
-"buildings" = "Binalar";
-
-"money" = "Para";
-
-"shops" = "Mağazalar";
-
-"parkings" = "Otoparklar";
-
-"fuel_places" = "Benzin istasyonları";
-
-"water" = "Su";
-
-"medicine" = "İlaç";
-
 "search_in_the_list" = "Listede ara";
-
-"view_on_map_bookmarks" = "Haritada";
-
-"more_bookmarks" = "Daha fazla…";
-
-"no_items_found" = "Hiç bir öğe bulunamadı";
-
-/* Android, max 18 symbols */
-"bookmarks_edit_list" = "Listeyi düzenle";
-
-/* Android, max 18 symbols */
-"bookmarks_delete_list" = "Listeyi sil";
-
-"religious_places" = "Dini yerler";
 
 "select_list" = "Liste seç";
 
@@ -2118,26 +1224,13 @@
 
 "dialog_pedestrian_route_is_long_message" = "Metro istasyonuna en yakın rotanın başlangıç veya bitiş noktasını seçin";
 
-/* Failed planning SUBWAY route message in navigation view */
-"routing_planning_error_subway_special" = "Metro güzergahı oluşturma hatası";
-
 "button_layer_isolines" = "Yükseklikler";
-
-"tips_map_layers_title_countour" = "Organic Maps'de yükseklik çizgileri çevrimdışı!";
-
-"tips_map_layers_message_countour" = "Yükseklik çizgileri, doğaya bir gezi planlamanıza ve arazide kaybolmamanıza yardımcı olacaktır";
 
 "isolines_activation_error_dialog" = "Yükseklik çizgilerini kullanmak için, istediğiniz arazinin haritasını güncelleyin veya indirin";
 
 "isolines_location_error_dialog" = "Bu bölgede henüz yükseklik çizgileri mevcut değil";
 
 "elevation_profile_diff_level" = "Zorluk seviyesi";
-
-"elevation_profile_diff_level_easy" = "Kolay";
-
-"elevation_profile_diff_level_moderate" = "Orta";
-
-"elevation_profile_diff_level_hard" = "Karmaşık";
 
 "elevation_profile_ascent" = "Tırmanış";
 
@@ -2147,25 +1240,13 @@
 
 "elevation_profile_maxaltitude" = "Maks. rakım";
 
-"elevation_profile_m" = "m";
-
 "elevation_profile_difficulty" = "Zorluk";
 
 "elevation_profile_distance" = "Mesafe:";
 
-"elevation_profile_km" = "km";
-
 "elevation_profile_time" = "Süre:";
 
-"elevation_profile_hours" = "sa.";
-
-"elevation_profile_minutes" = "dk.";
-
 "isolines_toast_zooms_1_10" = "Konturları görmek için haritayı büyütün";
-
-"downloader_updating_ios" = "Güncelleme";
-
-"downloader_loading_ios" = "İndir";
 
 "key_information_title" = "Anahtar bilgisi";
 

--- a/iphone/Maps/LocalizedStrings/tr.lproj/Localizable.stringsdict
+++ b/iphone/Maps/LocalizedStrings/tr.lproj/Localizable.stringsdict
@@ -9,21 +9,6 @@
 
 <!-- ********** Strings for downloading map from search **********/ -->
 
-  <key>bookmarks_places</key>
-  <dict>
-    <key>NSStringLocalizedFormatKey</key>
-    <string>%#@value@</string>
-    <key>value</key>
-    <dict>
-      <key>NSStringFormatSpecTypeKey</key>
-      <string>NSStringPluralRuleType</string>
-      <key>NSStringFormatValueTypeKey</key>
-      <string>d</string>
-      <key>other</key>
-      <string>%d yer imi</string>
-    </dict>
-  </dict>
-
   <key>bookmarks_detect_message</key>
   <dict>
     <key>NSStringLocalizedFormatKey</key>
@@ -36,21 +21,6 @@
       <string>d</string>
       <key>other</key>
       <string>%d dosya bulundu. Dönüşümden sonra onları göreceksiniz.</string>
-    </dict>
-  </dict>
-
-  <key>bookmarks_objects</key>
-  <dict>
-    <key>NSStringLocalizedFormatKey</key>
-    <string>%#@value@</string>
-    <key>value</key>
-    <dict>
-      <key>NSStringFormatSpecTypeKey</key>
-      <string>NSStringPluralRuleType</string>
-      <key>NSStringFormatValueTypeKey</key>
-      <string>d</string>
-      <key>other</key>
-      <string>%s nesne</string>
     </dict>
   </dict>
 

--- a/iphone/Maps/LocalizedStrings/uk.lproj/Localizable.strings
+++ b/iphone/Maps/LocalizedStrings/uk.lproj/Localizable.strings
@@ -18,9 +18,6 @@
 /* Button which deletes downloaded country */
 "delete" = "Видалити";
 
-/* Button "do not interrupt download" if user touched actively downloading country */
-"do_nothing" = "Продовжити завантаження";
-
 "download_maps" = "Завантажити карти";
 
 /* Settings/Downloader - info for country when download fails */
@@ -28,9 +25,6 @@
 
 /* Settings/Downloader - info for country which started downloading */
 "downloading" = "Завантажується…";
-
-/* Settings/Downloader - size string, only strings different from English should be translated */
-"kb" = "кБ";
 
 /* Choose measurement on first launch alert - choose metric system button */
 "kilometres" = "Кілометри";
@@ -55,17 +49,11 @@
 /* Update maps later/Buy pro version later button text */
 "later" = "Не зараз";
 
-/* Don't show some dialog any more */
-"never" = "Не показувати";
-
 /* View and button titles for accessibility */
 "search" = "Пошук";
 
 /* Search box placeholder text */
 "search_map" = "Пошук на картi";
-
-/* Settings/Downloader - info for not downloaded country */
-"touch_to_download" = "Натисніть для завантаження";
 
 /* Settings/Downloader - 3G download warning dialog confirm button */
 "use_cellular_data" = "Так";
@@ -73,20 +61,11 @@
 /* Location services are disabled by user alert - message */
 "location_is_disabled_long_text" = "Геолокація вимкнена в налаштуваннях пристрою. Будь ласка, увімкніть її для зручного використання програми.";
 
-/* Location Services are not available on the device alert - message */
-"device_doesnot_support_location_services" = "Ваш пристрій не підтримує геолокацію";
-
 /* View and button titles for accessibility */
 "zoom_to_country" = "Показати на мапі";
 
-/* Button text for the button at the center of the screen when the country is not downloaded */
-"country_status_download" = "Завантажити мапу\n(^ ^)";
-
 /* Button text for the button at the center of the screen when the country is not downloaded and the size should not be shown */
 "country_status_download_without_size" = "Завантажити мапу";
-
-/* Button text for the button at the center of the screen when the country is not downloaded */
-"country_status_download_without_routing" = "Завантажити карту\nбез маршрутів (^ ^)";
 
 /* Message to display at the center of the screen when the country download has failed */
 "country_status_download_failed" = "Помилка завантаження";
@@ -96,19 +75,13 @@
 
 "about_menu_title" = "Про програму";
 
-"downloaded_touch_to_delete" = "Завантажено (%@), натисніть для видалення";
-
 "connection_settings" = "Налаштування підключення";
-
-"download_mb_or_kb" = "Завантажити %@";
 
 "close" = "Закрити";
 
 "unsupported_phone" = "Для роботи програми необхідний апаратно прискорений OpenGL. На жаль, ваш пристрій не підтримується.";
 
 "download" = "Завантажити";
-
-"external_storage_is_not_available" = "Завантажені карти недоступні";
 
 "disconnect_usb_cable" = "Вимкніть USB кабель або вставте SD-карту";
 
@@ -117,8 +90,6 @@
 "not_enough_memory" = "Недостатньо пам'яті для запуску програми";
 
 "download_resources" = "Перш ніж розпочати дозвольте нам завантажити карту світу на ваш пристрій.\nВона потребує %@ даних.";
-
-"getting_position" = "Oтримуємо розташування";
 
 "download_resources_continue" = "Перейти на карту";
 
@@ -140,23 +111,14 @@
 /* Add New Bookmark Set dialog title */
 "add_new_set" = "Додати групу";
 
-/* Place Page - Add To Bookmarks button */
-"add_to_bookmarks" = "Зберегти мiтку";
-
 /* Bookmark Color dialog title */
 "bookmark_color" = "Колір мiтки";
 
 /* Add Bookmark Set dialog - hint when set name is empty */
 "bookmark_set_name" = "Назва групи";
 
-/* Bookmark Sets dialog title */
-"bookmark_sets" = "Групи мiток";
-
 /* Bookmarks - dialog title */
 "bookmarks" = "Мітки";
-
-/* Add bookmark dialog - bookmark color */
-"color" = "Колір";
 
 /* Default bookmarks set name */
 "core_my_places" = "Мої Мітки";
@@ -167,14 +129,8 @@
 /* Editor title above street and house number */
 "address" = "Адреса";
 
-/* Place Page - Remove Pin button */
-"remove_pin" = "Видалити мітку";
-
 /* Add bookmark dialog - bookmark set, Bookmarks dialog - Bookmark set cell */
 "set" = "Група";
-
-/* Text hint in Bookmarks dialog when no any bookmarks are added */
-"bookmarks_usage_hint" = "У вас ще немає мiток.\nНатисніть на будь-яке місце на карті, щоб зберегти мiтку.\nМiтки з інших ресурсів також можна імпортувати для застосунка Organic Maps. Відкрийте файл KML/KMZ із збереженими пінами з почти, Dropbox або інтернет посилання.";
 
 /* Settings button in system menu */
 "settings" = "Налаштування";
@@ -191,26 +147,11 @@
 /* Ask to wait user several minutes (some long process in modal dialog). */
 "wait_several_minutes" = "Це може зайняти кілька хвилин.\nБудь ласка, зачекайте…";
 
-/* Show bookmarks from this category on a map or not */
-"visible" = "Показувати на карті";
-
-/* Toast which is displayed when GPS has been deactivated */
-"gps_is_disabled_long_text" = "GPS вимкнено в налаштуваннях пристрою. Будь ласка, увімкніть його для зручного використання програми.";
-
 /* Measurement units title in settings activity */
 "measurement_units" = "Одиниці виміру";
 
 /* Detailed description of Measurement Units settings button */
 "measurement_units_summary" = "Використовувати милі чи кілометри";
-
-/* Do search in all sources */
-"search_mode_all" = "Всюди";
-
-/* Do search near my position only */
-"search_mode_nearme" = "Поруч";
-
-/* Do search in current viewport only */
-"search_mode_viewport" = "На екрані";
 
 /* Search category for cafes, bars, restaurants */
 "eat" = "Де поїсти";
@@ -266,14 +207,8 @@
 /* Search category */
 "police" = "Міліція";
 
-/* String in search result list, when nothing found */
-"no_search_results_found" = "Результатів не знайдено";
-
 /* Notes field in Bookmarks view */
 "description" = "Примітка";
-
-/* Button text */
-"share_by_email" = "Подiлитися по електронній пошті";
 
 /* Email Subject when sharing bookmarks category */
 "share_bookmarks_email_subject" = "З вами поділилися мiтками Organic Maps";
@@ -295,26 +230,11 @@
 /* Warning message when doing search around current position */
 "unknown_current_position" = "Ваше місце розташування не визначено";
 
-/* Warning message when location country isn't downloaded during search (see also download_location_map_proposal). */
-"download_location_country" = "Завантажити країну вашого поточного місця розташування (%@)";
-
-/* Warning message when viewport country isn't downloaded during search */
-"download_viewport_country_to_search" = "Завантажити країну, в якій ви шукаєте (%@)";
-
 /* Alert message that we can't run Map Storage settings due to some reasons. */
 "cant_change_this_setting" = "Вибачте, налаштування папки з картами зараз недоступні.";
 
 /* Alert message that downloading is in progress. */
 "downloading_is_active" = "Зараз відбувається завантаження країни.";
-
-/* Message that will be shown in alert view, when we ask user to leave review on App Store */
-"appStore_message" = "Сподіваємося, що вам сподобалося користуватися Organic Maps! Якщо так, будь ласка, надайте оцінку програмі або залиште свій відгук на app store. Витративши менше хвилини, ви дійсно нам допоможете. Дякуємо за вашу підтримку!";
-
-/* No, thanks */
-"no_thanks" = "Ні, дякую";
-
-/* Share one specific bookmark using SMS, %1$@ contains om:// and %2$@ https://omaps.app link. @NOTE non-ascii symbols in the link will result in max 70 characters SMS instead of 140. */
-"bookmark_share_sms" = "Моя мітка на карті. Іди %1$@ або %2$@";
 
 /* Share my position using SMS, %1$@ contains om:// and %2$@ https://omaps.app link WITHOUT NAME. @NOTE non-ascii symbols in the link will result in max 70 characters SMS instead of 140. */
 "my_position_share_sms" = "Глянь де я зараз. Іди %1$@ або %2$@";
@@ -328,23 +248,11 @@
 /* Share my position using EMail, %1$@ is om:// and %2$@ is https://omaps.app link WITHOUT NAME */
 "my_position_share_email" = "Привіт,\n\nЯ зараз тут: %1$@. Натисни на це посилання %2$@ або на це посилання %3$@ щоб побачити місце на карті.\n\nДякую.";
 
-/* Android share by Message/SMS button text (including SMS) */
-"share_by_message" = "Подiлитися за допомогою повідомлення";
-
 /* Share button text which opens menu with more buttons, like Message, EMail, Facebook etc. */
 "share" = "Подiлитись";
 
-/* iOS share by Message button text (including SMS) */
-"message" = "Повідомлення";
-
 /* Share by email button text, also used in editor. */
 "email" = "Ел. пошта";
-
-/* Copy Link */
-"copy_link" = "Копіювати посилання";
-
-/* Text for the button that returns to caller application */
-"more_info" = "Докладніше";
 
 /* Text for message when used successfully copied something */
 "copied_to_clipboard" = "Скопіювати в буфер обміну: %1$@";
@@ -354,15 +262,6 @@
 
 /* Used for bookmark editing */
 "done" = "Готово";
-
-/* Summary for preferences in MWM */
-"yopme_pref_summary" = "Оберіть налаштування заднього екрану";
-
-/* Title for yopme preferences in MWM */
-"yopme_pref_title" = "Налаштування заднього екрану";
-
-/* Hint for upper-right icon p2b */
-"show_on_backscreen" = "Показати на задньому екрані";
 
 /* Prints version number in About dialog */
 "version" = "Версія: %@";
@@ -381,19 +280,11 @@
 
 "share_my_location" = "Поділитися моїм місцезнаходженням";
 
-"menu_search" = "Пошук";
-
 /* Settings general group in settings screen */
 "prefs_group_general" = "General settings";
 
 /* Settings information group in settings screen */
 "prefs_group_information" = "Information";
-
-/* Settings screen: "Map" category title */
-"prefs_group_map" = "Карта";
-
-/* Settings screen: "Miscellaneous" category title */
-"prefs_group_misc" = "Інше";
 
 "prefs_group_route" = "Навігація";
 
@@ -419,9 +310,6 @@
 /* Settings «Map» category: «3D buildings» title */
 "pref_map_3d_buildings_title" = "Будівлі у 3D";
 
-/* Settings «Map» category: «3D buildings» summary */
-"pref_map_3d_buildings_subtitle" = "Негативно впливає на ресурс акумулятора";
-
 /* Settings «Route» category: «Tts enabled» title */
 "pref_tts_enable_title" = "Голосові інструкції";
 
@@ -433,8 +321,6 @@
 
 /* Title for "Other" section in TTS settings. */
 "pref_tts_other_section_title" = "Інша";
-
-"pref_tts_how_to_set_up_voice" = "Як налаштувати голосовий контроль";
 
 /* Settings «Map» category: «Record track» title */
 "pref_track_record_title" = "Недавній маршрут";
@@ -455,56 +341,7 @@
 
 "recent_track_help_text" = "Ця функція дозволяє прокласти подоланий маршрут протягом певного проміжку часу та переглянути його на карті. Звертаємо вашу увагу, що вмикання цієї функції пришвидшить розрядження акумулятора. Щойно сплине заданий проміжок часу, прокладений маршрут буде видалено з карти.";
 
-"pref_track_ios_caption" = "Останній маршрут показує пройдену відстань.";
-
-"pref_track_ios_subcaption" = "Будь ласка, виберіть проміжок часу для збереження маршруту.";
-
-"placepage_distance" = "Відстань";
-
-"placepage_coordinates" = "Координати";
-
-"placepage_unsorted" = "Без категорії";
-
 "search_show_on_map" = "Подивитись на карті";
-
-/* Used to warn user when fixing KitKat issue */
-"bookmark_move_fail" = "Для оптимiзацiї збереження данних нам потрiбно перенести мітки до внутрiшньої пам'ятi, але там немає вiльного мiсця. Будь ласка, звiльнiть мiсце, бо мітки вам не будуть доступнi.";
-
-/* Used in More Apps menu */
-"free" = "Безкоштовно";
-
-/* Used in More Apps menu */
-"buy" = "Придбати";
-
-/* 1st search button-like result */
-"search_on_map" = "Шукати на карті";
-
-/* toast with an error */
-"no_route_found" = "Маршрути не знайдено";
-
-/* route title */
-"route" = "Маршрут";
-
-/* category title */
-"routes" = "Маршрути";
-
-/* text of notification */
-"download_map_notification" = "Завантажуйте карту тієї місцевості, де ви знаходитесь";
-
-/* text of notification */
-"pro_version_is_free_today" = "Повна версія Organic Maps сьогодні безкоштовна! Завантажуй та розкажи друзям.";
-
-/* Dialog for transferring maps from lite to pro. */
-"move_lite_maps_to_pro" = "Ми переносимо завантажені карти з Organic Maps Lite в Organic Maps. Це може зайняти декілька хвилин.";
-
-/* Message to display when maps moved. */
-"move_lite_maps_to_pro_ok" = "Ваші карти успішно перенесено в Organic Maps.";
-
-/* Message to display when maps move failed. */
-"move_lite_maps_to_pro_failed" = "При переносі карт виникла помилка. Будь ласка, видаліть Organic Maps Lite і завантажте карти знову.";
-
-/* Text in menu */
-"settings_and_more" = "Налаштування";
 
 /* Text in menu */
 "website" = "Вебсайт";
@@ -527,14 +364,8 @@
 /* Text in menu */
 "openstreetmap" = "OpenStreetMap";
 
-/* Text in menu */
-"contact_us" = "Контакти";
-
 /* Settings: Send feedback button and dialog title */
 "feedback" = "Відгук";
-
-/* Text in menu */
-"subscribe_to_news" = "Email-бюлетень";
 
 /* Text in menu */
 "rate_the_app" = "Оцінити застосунок";
@@ -548,15 +379,6 @@
 /* Text in menu */
 "report_a_bug" = "Сповістити про помилку";
 
-/* Email subject */
-"subscribe_me_subject" = "Підпишіть мене на email-розсилку Organic Maps";
-
-/* Email body */
-"subscribe_me_body" = "Я хочу першим дізнаватися про всі новини оновлення програм і акції. Я можу відписатися від розсилки в будь-який момент.";
-
-/* About text */
-"about_text" = "Organic Maps пропонує карти всіх міст, всіх країн світу, які працюють без підключення до інтернету. Подорожуйте з впевненістю: де б ви не були, Organic Maps допоможуть вирішити будь-яку вашу проблему - допоможуть визначити ваше місцезнаходження, знайти ресторан, готель, заправку, банк, туалет і т.д.\n\nМи постійно працюємо над додаванням нових функцій, тому, якщо у вас є ідеї або пропозиції з покращення Organic Maps, пишіть нам. Якщо у вам виникла проблема з програмою, сповістіть нас, будь ласка, про неї. Наш емейл support@organicmaps.app. Ми відповідаємо на всі листи!\n\nЯкщо вам подобається програма і ви хочете підтримати нас, є декілька простих і абсолютно безкоштовних способів:\n\n- залиште відгук у вашому магазині програм\n- підпишіться на наші новини на сторінці у Facebook http://www.facebook.com/OrganicMaps\n- або просто розкажіть про Organic Maps своїй мамі, друзям і колегам :)\n\nДякуємо за вашу підтримку!\n\nP.S. У програмі ми використовуємо картографічні дані проекту OpenStreetMap, який працює за принципом Вікіпедії, надаючи можливість користувачам зі всього світу створювати і редагувати карти. Якщо ви помітили, що на карті щось не відповідає дійсності або відсутнє, ви можете виправити це прямо на сайті https://www.openstreetmap.org, і ці виправлення з'являться під час наступного оновлення Organic Maps.";
-
 /* Alert text */
 "email_error_body" = "Поштовий клієнт не налаштований. Налаштуйте його або скористайтеся іншими способами зв'язку. Наша адреса – %@.";
 
@@ -569,12 +391,6 @@
 /* Search category */
 "wifi" = "WiFi";
 
-/* Update map suggestion */
-"routing_map_outdated" = "Будь ласка, оновіть карту, щоб прокласти маршрут.";
-
-/* Update maps suggestion */
-"routing_update_maps" = "В новій версії Organic Maps ви зможете прокладати маршрут від поточного місця перебування до точки призначення. Щоб скористатися цією функцією, будь ласка, оновіть карти.";
-
 /* Update all button text */
 "downloader_update_all_button" = "Оновити всі";
 
@@ -583,9 +399,6 @@
 
 /* Downloaded maps category */
 "downloader_downloaded_subtitle" = "Завантажено";
-
-/* Downloaded maps category */
-"downloader_available_maps" = "Доступні";
 
 /* Country queued for download */
 "downloader_queued" = "В черзі";
@@ -598,17 +411,6 @@
 
 "downloader_downloading" = "Завантажується:";
 
-"downloader_search_results" = "Знайдено";
-
-/* Disclaimer message */
-"routing_disclaimer" = "Використовуючи маршрути в програмі Organic Maps, будь ласка, враховуйте наступне:\n\n  - Пропоновані маршрути можуть розглядатися тільки в якості рекомендації.\n - Дорожні умови, правила дорожнього руху, знаки являються більш пріоритетними в порівнянні з порадами навігаційної програми.\n - Карта може бути неточною або неактуальною, а запропонований маршрут не найоптимальнішим.\n\n  Будьте уважні на дорозі та бережіть себе!";
-
-/* Outdated maps category */
-"downloader_outdated_maps" = "Неактуальні";
-
-/* Up to date maps category */
-"downloader_uptodate_maps" = "Оновлені";
-
 /* Status of outdated country in the list */
 "downloader_status_outdated" = "Oновити";
 
@@ -618,49 +420,14 @@
 /* Displayed in a dialog that appears when a user tries to delete a map while the app is in the follow route mode */
 "downloader_delete_map_while_routing_dialog" = "Щоб видалити карту, будь ласка, зупините навiгацiю.";
 
-/* Show when user try build route, but we don't know where he */
-"routing_failed_unknown_my_position" = "Неможливо прокласти маршрут. Не визначено поточне місцезнаходження.";
-
-/* Show if use has not routing file, or InconsistentMWMandRoute */
-"routing_failed_has_no_routing_file" = "Для прокладання маршруту необхідна додаткова інформація. Перейти до завантаження?";
-
-/* StartPointNotFound */
-"routing_failed_start_point_not_found" = "Неможливо прокласти маршрут. Немає доріг поруч з відправною точкою.";
-
-/* EndPointNotFound */
-"routing_failed_dst_point_not_found" = "Неможливо прокласти маршрут. Немає доріг поруч з пунктом призначення.";
-
 /* PointsInDifferentMWM */
 "routing_failed_cross_mwm_building" = "Маршрут бути прокладений всередині мапи тільки одного регіону.";
-
-/* RouteNotFound */
-"routing_failed_route_not_found" = "Неможливо прокласти маршрут між вибраними точками. Будь ласка, змініть початок і кінець маршруту.";
-
-/* InternalError */
-"routing_failed_internal_error" = "Внутрішня помилка. Будь ласка, видаліть мапу і завантажте її ще раз. Якщо це не допомогло, напишіть нам на support@organicmaps.app";
-
-/* Context menu item for downloader. */
-"downloader_download_map_and_routing" = "Завантажити карту + маршрути";
-
-/* Context menu item for downloader. */
-"downloader_download_routing" = "Завантажити маршрути";
-
-/* Context menu item for downloader. */
-"downloader_delete_routing" = "Видалити маршрути";
 
 /* Context menu item for downloader. */
 "downloader_download_map" = "Завантажити карту";
 
-"downloader_download_map_no_routing" = "Завантажити карту без маршрутів";
-
-/* Button for routing. */
-"routing_go" = "Поїхали!";
-
 /* Item status in downloader. */
 "downloader_retry" = "Повторити";
-
-/* Item in context menu. */
-"downloader_map_and_routing" = "Мапа + Маршрути";
 
 /* Item in context menu. */
 "downloader_delete_map" = "Видалити мапу";
@@ -668,29 +435,11 @@
 /* Item in context menu. */
 "downloader_update_map" = "Оновити мапу";
 
-/* Item in context menu. */
-"downloader_update_map_and_routing" = "Оновити мапу + Маршрути";
-
-/* Item in context menu. */
-"downloader_map_only" = "Тільки карта";
-
-/* Toolbar title */
-"toolbar_application_menu" = "Меню програми";
-
 /* Preference text */
 "pref_use_google_play" = "Щоб визначити ваше поточне місцезнаходження, використовуйте сервіси Google Play";
 
 /* Text for rating dialog */
 "rating_just_rated" = "Я щойно оцінив вашу програму";
-
-/* Text for rating dialog */
-"rating_user_since" = "Я користувач Organic Maps з %@ року";
-
-/* Text for rating dialog */
-"rating_do_like_maps" = "Вам подобається Organic Maps?";
-
-/* Text for rating dialog */
-"rating_tap_star" = "Торкніться зірочки, щоб оцінити нашу програму.";
 
 /* Text for rating dialog */
 "rating_thanks" = "Дякуємо!";
@@ -701,23 +450,8 @@
 /* Text for rating dialog */
 "rating_send_feedback" = "Надіслати відгук";
 
-/* Text for g+ dialog */
-"rating_google_plus" = "Щоб розповісти своїм друзям про програму, клацніть g+.";
-
 /* Text for routing error dialog */
 "routing_download_maps_along" = "Завантажити карти з дороги";
-
-/* Text for routing error dialog */
-"routing_download_map" = "Отримати карту";
-
-/* Text for routing error dialog */
-"routing_download_map_and_routing" = "Завантажте оновлену карту та дані про маршрут, щоб отримати всі можливості Organic Maps.";
-
-/* Text for routing error dialog */
-"routing_get_routing_data" = "Отримати дані про маршрут";
-
-/* Text for routing error dialog */
-"routing_get_additional_data" = "Щоб створювати маршрути від вашого місцезнаходження, потрібно додаткові дані";
 
 /* Text for routing error dialog */
 "routing_requires_all_map" = "Для створення маршруту необхідно щоб всі карти, починаючи від вашого місцезнаходження і до пункту призначення, були завантажені та оновлені.";
@@ -725,50 +459,15 @@
 /* Text for routing error dialog */
 "routing_not_enough_space" = "Недостатньо місця";
 
-/* Text for routing error dialog */
-"routing_download_more_than_avail" = "Вам треба завантажити %@ Мб, а доступно лише %@ Мб.";
-
-/* Text for routing error dialog */
-"routing_download_roaming" = "Ви збираєтесь завантажити %@ MB з використанням послуги передачі даних (у роумінгу). Це може потребувати додаткової оплати, в залежності від вашого мобільного оператора та умов використання вашого тарифного плану.";
-
 /* bookmark button text */
 "bookmark" = "мітка";
-
-/* map is not downloaded */
-"not_found_map" = "Карту місця, де ви знаходитеся, не завантажено";
 
 /* location service disabled */
 "enable_location_services" = "Будь ласка, увімкніть геолокацію";
 
-/* download map */
-"download_map" = "Завантажуйте карту тієї місцевості, де ви знаходитесь";
-
-/* download map on iPhone */
-"download_map_iphone" = "Завантажити карту вашого місця розташування на iPhone";
-
-/* clear pin */
-"nearby" = "Поруч";
-
-/* clear pin */
-"clear_pin" = "Очисти мітку";
-
-/* location is undefined */
-"undefined_location" = "Не визначено поточне місцезнаходження.";
-
-/* download country of your location */
-"download_country" = "Завантажити країну вашого місця розташування";
-
-/* download failed */
-"download_failed" = "Не вдалося завантажити";
-
-/* get the map */
-"get_the_map" = "Отримати карту";
-
 "save" = "Зберегти";
 
 "edit_description_hint" = "Ваше описання (текст або html)";
-
-"new_group" = "нова група";
 
 "create" = "створити";
 
@@ -795,30 +494,6 @@
 
 /* pink color */
 "pink" = "Рожевий";
-
-/* deep purple color */
-"deep_purple" = "Темно-пурпуровий";
-
-/* light blue color */
-"light_blue" = "Блакитний";
-
-/* cyan color */
-"cyan" = "Синьо-зелений";
-
-/* teal color */
-"teal" = "Смарагдовий";
-
-/* lime color */
-"lime" = "Лайм";
-
-/* deep orange color */
-"deep_orange" = "Темно-помаранчевий";
-
-/* gray color */
-"gray" = "Сірий";
-
-/* blue gray color */
-"blue_gray" = "Сіро-блакитний";
 
 /* Wi-Fi available */
 "WiFi_available" = "Так";
@@ -848,13 +523,9 @@
 
 "dialog_routing_location_unknown_turn_on" = "Поточну геопозицію не визначено. Для побудови маршруту увімкніть режим визначення геопозиції.";
 
-"dialog_routing_location_unknown" = "Поточну геопозицію не визначено.";
-
 "dialog_routing_download_files" = "Завантажте необхідні файли";
 
 "dialog_routing_download_and_update_all" = "Для побудови маршруту завантажте і обновіть всі карти і файли маршрутів на шляху руху.";
-
-"dialog_routing_routes_size" = "Файли маршрутів";
 
 "dialog_routing_unable_locate_route" = "Маршрут не знайдено";
 
@@ -884,21 +555,11 @@
 
 "dialog_routing_try_again" = "Спробуйте знову";
 
-"dialog_routing_send_error" = "Повідомити про помилку";
-
-"dialog_routing_if_get_cross_route" = "Побудувати більш оптимальний маршрут з перетином межі карти?";
-
-"dialog_routing_cross_route_is_optimal" = "Маршрут з перетином межі карти більш оптимальний.";
-
 "not_now" = "Не зараз";
-
-"dialog_routing_build_route" = "Побудувати";
 
 "dialog_routing_download_and_build_cross_route" = "Завантажити карту і побудувати більш оптимальний маршрут з перетином межі карти?";
 
 "dialog_routing_download_cross_route" = "Для побудови більш оптимального маршруту з перетином межі потрібно завантажити карту.";
-
-"dialog_routing_cross_route_always" = "Завжди перетинати цю межу";
 
 
 /********** Strings for downloading map from search **********/
@@ -906,8 +567,6 @@
 "search_without_internet_advertisement" = "Щоб розпочати пошук та створення маршрутів, будь ласка, завантажте карту і вам більше ніколи не знадобиться інтернет-з’єднання.";
 
 "search_select_map" = "Вибрати карту";
-
-"search_select_other_map" = "Вибрати іншу карту";
 
 /* «Show» context menu */
 "show" = "Показати";
@@ -918,17 +577,11 @@
 /* «Rename» context menu */
 "rename" = "Перейменувати";
 
-/* Bottom sheet: expand button (should be short) */
-"bottom_sheet_more" = "Більше…";
-
 /* Failed planning route message in navigation view */
 "routing_planning_error" = "Збій планування маршруту";
 
 /* Arrive routing message in navigation view */
 "routing_arrive" = "Прибуття в %s";
-
-/* Text for routing::RouterResultCode::FileTooOld dialog. */
-"dialog_routing_download_and_update_maps" = "Для створення маршруту, будь ласка, скачайте та обновіть всі карти за ним.";
 
 "rate_alert_title" = "Подобається програма?";
 
@@ -944,19 +597,11 @@
 
 "history" = "Історія";
 
-"next_turn_then" = "Потім";
-
 "closed" = "Зачинено";
-
-"back_to" = "Назад до %@";
 
 "search_not_found" = "На жаль, нічого не знайдено.";
 
 "search_not_found_query" = "Спробуйте змінити запит.";
-
-"search_not_found_map" = "Завантажте карту місцевості на якій шукаєте.";
-
-"search_not_found_location" = "Завантажте карту вашого місцезнаходження.";
 
 "search_history_title" = "Історія пошуку";
 
@@ -964,23 +609,12 @@
 
 "clear_search" = "Очистити історію пошуку";
 
-/* Title for settings to enable/disable showcase menu button */
-"showcase_settings_title" = "Показати пропозиції";
-
 /* Place Page link to Wikipedia article (if map object has it). */
 "read_in_wikipedia" = "Wikipedia";
 
-"p2p_route_planning" = "Планування маршруту";
-
 "p2p_your_location" = "Ваше місцезнаходження";
 
-"p2p_from" = "Пункт відправлення";
-
-"p2p_to" = "Пункт призначення";
-
 "p2p_start" = "Почати рух";
-
-"p2p_planning" = "Плануємо…";
 
 "p2p_from_here" = "Звідси";
 
@@ -1018,15 +652,9 @@
 
 "editor_correct_mistake" = "Виправте помилку";
 
-"editor_correct_mistake_message" = "Під час редагування часу роботи ви зробили помилку. Виправте її або перейдіть у простий режим.";
-
 "editor_add_select_location" = "Місцезнаходження";
 
 "editor_done_dialog_1" = "Ви змінили карту світу. Не приховуйте це! Розкажіть своїм друзям і редагуйте разом.";
-
-"editor_done_dialog_2" = "Це ваше друге поліпшення карти. Тепер ви на %d місці в списку редакторів карт. Розкажіть своїм друзям про це.";
-
-"editor_done_dialog_3" = "Ви покращили карту, розкажіть своїм друзям про це і редагуйте її разом.";
 
 "share_with_friends" = "Поділитися з друзями";
 
@@ -1044,20 +672,7 @@
 
 "editor_report_problem_duplicate_place_title" = "Дубльовані місця";
 
-"first_launch_congrats_title" = "Organic Maps готовий до роботи";
-
-"first_launch_congrats_text" = "Користуйтесь пошуком і навігацією по всьому світу без інтернету і безкоштовно.";
-
-"migrate_title" = "Важливо!";
-
-/* Android uses image instead of text. */
-"download_all" = "Завантажити всі";
-
-"delete_all" = "Видалити всі";
-
 "autodownload" = "Автоматичне завантаження";
-
-"disable_autodownload" = "Заборонити автозавантаження";
 
 /* Place Page opening hours text */
 "closed_now" = "Зараз закрито";
@@ -1072,10 +687,6 @@
 "day_off" = "Зачинено";
 
 "today" = "Сьогодні";
-
-"sunrise_to_sunset" = "Від світанку до заходу";
-
-"sunset_to_sunrise" = "Від заходу до світанку";
 
 "add_opening_hours" = "Додати години роботи";
 
@@ -1095,45 +706,18 @@
 
 "forgot_password" = "Забули пароль?";
 
-/* Forgot Password dialog title */
-"restore_password" = "Відновити пароль";
-
-"enter_email_address_to_reset_password" = "Введіть адресу ел. пошти, яку ви використали під час реєстрації і ми надішлемо вам посилання для відновлення паролю.";
-
-"reset_password" = "Змінити пароль";
-
-"username" = "Ім'я користувача";
-
 "osm_account" = "Обліковий запис OSM";
 
 "logout" = "Вийти";
 
-"login_and_edit_map_motivation_message" = "Увійдіть та редагуйте інформацію про об'єкти на карті, і ми зробимо їх доступними для мільйонів інших користувачів. Давайте зробимо світ кращим разом.";
-
 /* Information text: "Last upload 11.01.2016" */
 "last_upload" = "Остання вiдправка";
 
-/* Motivates user to login/register, title above login buttons. */
-"you_have_edited_your_first_object" = "Ви редагували свій перший об'єкт!";
-
 "thank_you" = "Дякуємо";
-
-"login_with_google" = "Увійти за допомогою Google";
-
-"login_with_openstreetmap" = "Увійти за допомогою www.openstreetmap.org";
 
 "edit_place" = "Редагувати місце";
 
 "place_name" = "Назва";
-
-/* title above languages list cells in the editor, below editable name text field. */
-"other_languages" = "Інші мови";
-
-/* small button to open list with names in different languages */
-"show_more" = "Показати більше";
-
-/* small button to close list with names in different languages */
-"show_less" = "Показати менше";
 
 "add_language" = "Додати мову";
 
@@ -1164,8 +748,6 @@
 
 "please_note" = "Будь ласка, зверніть увагу";
 
-"common_no_wifi_dialog" = "Немає WiFi з’єднання. Ви бажаєте продовжити роботу через мобільний інтернет?";
-
 "downloader_delete_map_dialog" = "Разом з мапою будуть видалені й внесені Вами правки на цій мапі.";
 
 "downloader_update_maps" = "Оновити мапи";
@@ -1173,10 +755,6 @@
 "downloader_mwm_migration_dialog" = "Для побудови маршруту необхідно оновити усі мапи та побудувати маршрут заново.";
 
 "downloader_search_field_hint" = "Знайти карту";
-
-"migration_update_all_button" = "Оновити всі карти";
-
-"migration_delete_all_download_current_button" = "Завантажте поточну карту і видаліть старі";
 
 "migration_download_error_dialog" = "Помилка завантаження";
 
@@ -1186,21 +764,9 @@
 
 "downloader_no_space_message" = "Видаліть непотрібні дані";
 
-"editor_general_auth_error_dialog" = "Загальна помилка входу.";
-
 "editor_login_error_dialog" = "Виникла помилка при авторизації.";
 
-"editor_login_failed_dialog" = "Помилка входу";
-
-"editor_username_error_dialog" = "Ім'я користувача є недійсним";
-
-"editor_place_edited_dialog" = "Ви відредагували об’єкт!";
-
-"editor_login_with_osm" = "Увійти через OpenStreetMap";
-
 "editor_profile_changes" = "Виправлення, що ураховані";
-
-"editor_profile_unsent_changes" = "Не відправлено:";
 
 "editor_focus_map_on_location" = "Потягніть мапу, щоб вибрати правильне місцезнаходження об’єкту.";
 
@@ -1222,13 +788,9 @@
 
 "editor_report_problem_other_title" = "Інші проблема";
 
-"placepage_report_problem_button" = "Повідомити про проблему";
-
 "placepage_add_business_button" = "Додати організацію";
 
 "whatsnew_editor_message_1" = "Додати нові місця до карти і редагувати існуючі місця прямо з програми.";
-
-"whatsnew_editor_message_2" = "* Organic Maps використовує дані спільноти OpenStreetMap.";
 
 "dialog_incorrect_feature_position" = "Змініть розташування";
 
@@ -1236,16 +798,10 @@
 
 "login_to_make_edits_visible" = "Увійдіть, щоб ваші зміни побачили інші користувачі.";
 
-"no_migration_during_navigation" = "Під час навігації оновлення заборонено.";
-
 /* Error dialog no space */
 "migration_no_space_message" = "Для завантаження потрібно більше вільного місця. Будь ласка, видаліть непотрібні дані.";
 
 "editor_sharing_title" = "Я покращив мапи Organic Maps";
-
-"editor_comment_will_be_sent" = "Ми обов'язково відправимо ваш коментар картографам.";
-
-"editor_unsupported_category_message" = "Ви додали об'єкт, категорію якого ми поки що не підтримуємо. У майбутньому він з'явиться на мапі.";
 
 /* Downloaded 10 **of** 20 <- it is that "of" */
 "downloader_of" = "%1$d з %2$d";
@@ -1278,23 +834,9 @@
 
 "editor_operator" = "Володар";
 
-"editor_tag_description" = "Вкажіть компанію, організацію або особу, що відповідає за працездатність об'єкта";
-
-"editor_no_local_edits_title" = "Поки що ви не маєте локальних виправлень";
-
-"editor_no_local_edits_description" = "Тут відображається кількість запропонованих вами змін на карті, які доступні тільки на вашому пристрою";
-
-"editor_send_to_osm" = "Відправити до OSM";
-
-"editor_remove" = "Видалити";
-
-"downloader_my_maps_title" = "Мої мапи";
-
 "downloader_no_downloaded_maps_title" = "Ви не маєте завантажених мап";
 
 "downloader_no_downloaded_maps_message" = "Завантажте необхідні мапи, щоб знаходити місця та користуватися навігацією без iнтернету.";
-
-"downloader_find_place_hint" = "Знайти місто або країну";
 
 /* Error title that appears after certain time without location. */
 "current_location_unknown_title" = "Продовжити пошук місцезнаходження?";
@@ -1321,47 +863,13 @@
 /* iOS Dialog for the case when the location permission is not granted */
 "location_services_disabled_3" = "3. Оберіть \"Під час роботи програми\"";
 
-"placepage_parking_surface" = "Відкрите паркування";
-
-"placepage_parking_multistorey" = "Багатоповерхове наземне паркування";
-
-"placepage_parking_underground" = "Підземне паркування";
-
-"placepage_parking_rooftop" = "Паркування на даху будівлі";
-
-"placepage_parking_sheds" = "Приватне легке укриття для автомобілів";
-
-"placepage_parking_carports" = "Капітальний навіс";
-
-"placepage_parking_boxes" = "Гаражний бокс";
-
-"placepage_parking_pay" = "Платне";
-
-"placepage_parking_free" = "Безкоштовне";
-
-"placepage_parking_interval" = "Змінно платне";
-
-"placepage_entrance_number" = "№";
-
-"placepage_entrance_type" = "Під'їзд";
-
-"placepage_flat" = "кв.";
-
-"placepage_open_24_7" = "Цілодобово";
-
 "meter" = "м";
 
 "kilometer" = "км";
 
-"kilometers_per_hour" = "км/год";
-
 "mile" = "ми";
 
 "foot" = "фут";
-
-"miles_per_hour" = "ми/год";
-
-"day" = "д";
 
 "hour" = "год";
 
@@ -1381,10 +889,6 @@
 
 "placepage_bookmark_name_hint" = "Назва мiтки";
 
-"placepage_personal_notes_hint" = "Примітка";
-
-"placepage_delete_bookmark_button" = "Видалити мiтку";
-
 "editor_edits_sent_message" = "Зміни, що ви запропонували, відправлено";
 
 "editor_comment_hint" = "Коментар…";
@@ -1397,8 +901,6 @@
 
 "editor_remove_place_button" = "Видалити";
 
-"editor_status_sending" = "Відправка…";
-
 "editor_place_doesnt_exist" = "Місце не існує";
 
 "text_more_button" = "…більше";
@@ -1410,11 +912,7 @@
 
 "error_enter_correct_email" = "Введіть вірниу адресу електронної пошти";
 
-"error_enter_correct" = "Введіть вірне значення";
-
 "refresh" = "Обновити";
-
-"last_update" = "Останнє оновлення: %s";
 
 "placepage_add_place_button" = "Додати на карту";
 
@@ -1426,24 +924,6 @@
 
 "editor_share_to_all_dialog_message_2" = "Якщо при перевірці змін виникнуть питання, ми напишемо вам на email.";
 
-"navigation_overview_button" = "огляд";
-
-"navigation_stop_button" = "стоп";
-
-/* Text on an empty bookmark page */
-"bookmarks_empty_title" = "Зберегти закладки";
-
-"bookmarks_empty_message_1" = "Клацніть по ★, щоб зберегти улюблені місця для швидкого доступу.";
-
-"bookmarks_empty_message_2" = "Імпортувати закладки з Mail та web.";
-
-"bookmarks_empty_message_3" = "виїзд: %s";
-
-/* Name of the group for booked hotels */
-"bookmarks_group_name" = "Заброньовані готелі";
-
-"place_page_button_read_descriprion" = "Прочитати";
-
 /* iOS dialog for the case when recent track recording is on and the app comes back from background */
 "recent_track_background_dialog_title" = "Вимкнути запис нещодавно пройденого шляху?";
 
@@ -1451,8 +931,6 @@
 
 /* For sharing via SMS and so on */
 "sharing_call_action_look" = "Подивись,";
-
-"continue_recent_track_background_button" = "Продовжити";
 
 "recent_track_background_dialog_message" = "Organic Maps використовує вашу геопозицію у фоновому режимі для запису нещодавно пройденого шляху.";
 
@@ -1468,33 +946,13 @@
 /* About short text (below logo) */
 "about_description" = "Organic Maps — це додаток must-have для мандрівників. У Organic Maps використовуються офлайн-дані OpenStreetMap, які можна редагувати.";
 
-/* Text in menu */
-"blog" = "Блог";
-
 "general_settings" = "Загальні налаштування";
-
-"date" = "Дата %d";
-
-/* "Report a bug" -> "Generaal Feedback" -> "Something is not working" */
-"something_is_not_working" = "Щось пішло не так";
 
 /* For the first routing */
 "accept" = "Прийняти";
 
-"accept_and_continue" = "Accept and continue";
-
 /* For the first routing */
 "decline" = "Відхилити";
-
-"install_app" = "Встановити";
-
-"search_no_results_title" = "Не знайдено жодного результату";
-
-"search_no_results_message" = "Спробуйте пошук за більш узагальненим пошуковим виразом, зменшіть масштаб або скиньте фільтри.";
-
-"search_no_results_expand_area_button" = "Зменшити масштаб";
-
-"search_no_results_reset_button" = "Скинути фільтри";
 
 /* noun */
 "search_in_table" = "Список";
@@ -1517,8 +975,6 @@
 
 "traffic_update_maps_text" = "Для відображення інформації про трафік необхідно оновити карти.";
 
-"traffic_outdated" = "Дані про трафік застаріли.";
-
 "big_font" = "Збільшити розмір шрифту на карті";
 
 "traffic_update_app" = "Будь ласка, встановіть оновлення Organic Maps";
@@ -1529,17 +985,7 @@
 /* "traffic" as in "road congestion" */
 "traffic_data_unavailable" = "Дані про трафік недоступні";
 
-/* "Translation is no needed, because it's a company name" */
-"uber" = "Uber";
-
-/* Simplified colour scheme for traffic information, fewer colours are used to display traffic jams on the map. The string should be kept as short as possible */
-"pref_traffic_simplified_colors_title" = "Спрощені кольори світлофору";
-
 "enable_logging" = "Підтримка журналювання";
-
-"offline_place_page_more_information" = "Підключіться до мережі Інтернет, щоб отримати більше інформації про місце.";
-
-"failed_load_information" = "Не вдалося завантажити інформацію.";
 
 /* Settings: "Send general feedback" button */
 "feedback_general" = "Загальний відгук";
@@ -1556,8 +1002,6 @@
 
 "whatsnew_transliteration_title" = "Транслітерація латинськими літерами";
 
-"yandex_taxi_title" = "Yandex.Taxi";
-
 "learn_more" = "Докладніше";
 
 "core_exit" = "Вихід";
@@ -1568,75 +1012,19 @@
 
 "button_exit" = "Вихід";
 
-"settings_device_memory" = "Вбудована пам'ять";
-
-"settings_card_memory" = "Карта пам'яті";
-
-"settings_storage_available" = "Доступно: %s";
-
-"toast_location_permission_denied" = "Відмовлено у доступі до функції визначення геолокації";
-
-"button_use" = "Використовувати";
-
 "planning_route_manage_route" = "Редагування маршруту";
 
 "button_plan" = "Прокласти маршрут";
-
-"button_add" = "Додати";
 
 "placepage_remove_stop" = "Видалити";
 
 "planning_route_remove_title" = "Перетягніть сюди, щоб видалити";
 
-"dialog_change_start_point_message" = "Змінити початкову точку на поточне місцезнаходження?";
-
-"button_replace" = "Змінити";
-
 "placepage_add_stop" = "Додати зупинку";
-
-/* Only ru/en are needed */
-"subtitle_rent" = "Rent";
-
-/* Only ru/en are needed */
-"rub_month" = "RUB/month";
-
-/* Only ru/en are needed */
-"room" = "%s-room apt.";
-
-/* Only ru/en are needed */
-"real_estate" = "Real estate";
-
-"add_my_position" = "Додати моє розташування";
-
-"choose_start_point" = "Вибрати відправну точку";
-
-"choose_destination" = "Вибрати пункт призначення";
 
 "preloader_viator_button" = "Докладніше";
 
-"start_from_my_position" = "Почати з";
-
-"profile_authorization_title" = "Увійти за допомогою";
-
-"profile_authorization_message" = "Швидкий вхід без логіна та пароля за кілька секунд";
-
 "profile_authorization_error" = "Ой, трапилася помилка. Спробуйте ввійти знову.";
-
-"service" = "Обслуговування";
-
-"atmosphere" = "Атмосфера";
-
-"value_for_money" = "Співвідношення ціна/якість";
-
-"experience" = "Загальне враження";
-
-"assortment" = "Асортимент";
-
-"expertise" = "Досвід співробітників";
-
-"equipment" = "Обладнання";
-
-"quality" = "Якість";
 
 "dialog_error_storage_title" = "Не вдалося отримати доступ до сховища";
 
@@ -1644,17 +1032,7 @@
 
 "setting_emulate_bad_storage" = "Емулювати проблемне сховище";
 
-"directions_finish" = "Напрямок";
-
-"directions_on_foot" = "Піша прогулянка %s";
-
 "core_entrance" = "Вхід";
-
-"coffee" = "Кава";
-
-"cleanliness" = "Чистота";
-
-"crowdedness" = "Завантаженість";
 
 "error_enter_correct_name" = "Будь ласка, введіть коректне ім'я";
 
@@ -1673,11 +1051,9 @@
 
 "downloader_percent" = "%s (%s з %s)";
 
-"downloader_process" = "Завантаження %s...";
+"downloader_process" = "Завантаження %s…";
 
-"downloader_applying" = "Застосування %s...";
-
-"dialog_message_transit_not_found_connection" = "Плануйте маршрут в межах однієї транзитної мережі";
+"downloader_applying" = "Застосування %s…";
 
 "bookmarks_error_message_share_general" = "Неможливо поділитися через помилку програми";
 
@@ -1695,17 +1071,7 @@
 
 "bookmarks_error_message_list_name_already_taken" = "Виберіть інше ім'я";
 
-"bookmarks_error_title_list_name_too_long" = "Це ім'я задовге";
-
-"bookmarks_error_message_list_name_too_long" = "Виберіть інше ім'я";
-
-"please_wait" = "Будь ласка, зачекайте...";
-
-"phone_number" = "Номер телефону";
-
-"notification_unsent_reviews_title" = "У вас є невідправлені відгуки";
-
-"notification_unsent_reviews_message" = "Будь ласка, увійдіть, щоб поділитися своїми відгуками з іншими мандрівниками";
+"please_wait" = "Будь ласка, зачекайте…";
 
 "profile" = "Профіль OpenStreetMap";
 
@@ -1719,49 +1085,13 @@
 
 "bookmarks_convert_error_message" = "Деякі файли не конвертувалися.";
 
-"converting" = "Конвертація...";
-
-"wn_reinvented_bookmarks_title" = "Ми переізобрел мітки!";
-
-"wn_reinvented_bookmarks_message" = "Ви можете зробити резервне копіювання міток, створити списки. А як круто вони виглядають на карті!";
-
-"bookmarks_restore" = "Відновити закладки";
-
-"bookmarks_restore_process" = "Відновлення...";
-
 "bookmarks_restore_title" = "Відновити цю версію?";
 
-"bookmarks_restore_message" = "Ваші закладки відновлюватимуться з %s (%s)";
-
-"bookmarks_restore_empty_title" = "У вас немає резервної копії";
-
-"bookmarks_restore_empty_message" = "Сервер не знайшов раніше створені резервні копії";
-
 "common_check_internet_connection_dialog_title" = "Нема інтернет з'єднання";
-
-"error_server_title" = "Помилка серверу";
-
-"error_server_message" = "На сервері сталася помилка. Повторіть спробу пізніше";
 
 "error_system_message" = "Виникла невідома помилка";
 
 "restore" = "Відновити";
-
-"bookmarks_page_downloaded" = "Завантажені";
-
-"bookmarks_page_my" = "Мої";
-
-"routes_and_bookmarks" = "Маршрути та позначки";
-
-"bookmarks_webview_success_toast" = "Мітки успішно завантажені";
-
-"cached_bookmarks_placeholder_title" = "Завантажте нові місця";
-
-"cached_bookmarks_placeholder_subtitle" = "Натисніть кнопку, щоб завантажити тисячі цікавих місць і маршрутів, створених користувачами Organic Maps. Вам знадобиться підключення до Інтернету.";
-
-"downloader_download_routers" = "Завантажити позначки";
-
-"bookmarks_groups_cached" = "Завантажені списки";
 
 "subtittle_opt_out" = "Налаштування супроводу";
 
@@ -1769,29 +1099,15 @@
 
 "crash_reports_description" = "Ми можемо використовувати ваші дані, щоб розвивати та покращувати Organic Maps. Зміни вступлять у силу після перезапуску програми";
 
-"opt_out_help_ios_1" = "Ви можете відмовитися від отримання цільової реклами в налаштуваннях пристрою.";
-
-"opt_out_help_ios_2" = "iOS 9 або вище";
-
-"opt_out_help_ios_3" = "Відкрийте Налаштування → Конфіденційність → Реклама → Увімкніть «Обмеження трекінгу»";
-
-"opt_out_help_android" = "Ви можете відмовитися від отримання цільової реклами в налаштуваннях пристрою.\ nAndroid і Google Play Сервіси 4.0 і вище\n\nНалаштування телефону → Google → Реклама → Відключити персоналізацію реклами\ nабо\ nНалаштування телефону → Google → Акаунт Google → Конфіденційність → Налаштування рекламних переваг → персоналізація реклами";
-
 "privacy_policy" = "Політика конфіденційності";
 
 "terms_of_use" = "Умови використання";
-
-"backup_notification_failed" = "Резервне копіювання позначок було призупинено. Увійдіть, щоб увімкнути резервне копіювання.";
 
 "button_layer_traffic" = "Затор";
 
 "button_layer_subway" = "Метрополітен";
 
 "layers_title" = "Зображення карти";
-
-"layers_message" = "Включайте зображення на карті для відображення дорожнього стану, схеми метрополітену або іншої корисної інформації";
-
-"button_layer_got_it" = "Зрозуміло";
 
 "subway_data_unavailable" = "Карта метрополітену недоступна";
 
@@ -1803,39 +1119,13 @@
 
 "title_error_downloading_bookmarks" = "Виникла помилка";
 
-"subtitle_error_downloading_bookmarks" = "Позначки не були завантажені";
-
-"error_already_downloaded" = "Цей список вже завантажений";
-
 "popular_place" = "Popular";
-
-"download_routes" = "Download routes";
-
-"bookmarks_downloaded_title" = "Bookmarks have been downloaded successfully";
-
-"bookmarks_downloaded_subtitle" = "Press ‘View on map’ to explore new places from the list";
-
-"why_support" = "Навіщо підтримувати Organic Maps?";
-
-"why_support_item1" = "We respect your privacy: there are zero trackers in the app, and we are open source";
-
-"why_support_item2" = "Ви допомагаєте нам покращувати Organic Maps";
-
-"why_support_item3" = "Ви допомагаєте нам покращувати карти OpenStreetMap.org";
-
-"channels_map_update" = "Оновлення карт";
-
-"server_unavailable_title" = "Сервер недоступний";
-
-"sharing_options" = "Налаштування доступу";
 
 "export_file" = "Експортувати файл";
 
 "list_settings" = "Налаштування списку";
 
 "delete_list" = "Видалити список";
-
-"hide_from_map" = "Приховати з карти";
 
 "public_access" = "Публічний доступ";
 
@@ -1845,40 +1135,11 @@
 
 "bookmark_category_description_hint" = "Додайте опис (текст чи html)";
 
-/* FIXME */
-"bookmarks_public_access" = "bookmarks_public_access";
-
-/* FIXME */
-"bookmarks_link_access" = "bookmarks_link_access";
-
-/* FIXME */
-"bookmarks_private_access" = "bookmarks_private_access";
-
 "not_shared" = "Особистий";
-
-"direct_link_progress_text" = "Завантажуємо ваш файл…";
-
-"direct_link_success" = "Посилання створено";
-
-"send_a_link_btn" = "Надіслати посилання";
-
-"upload_error_toast" = "Під час завантаження файлу сталася помилка";
 
 "tags_loading_error_subtitle" = "Під час завантаження тегів сталася помилка, будь ласка, спробуйте ще раз";
 
-"unable_upload_errorr_title" = "Не вдалося завантажити файл";
-
-"unable_upload_error_subtitle_edited" = "Файл було відредаговано через веб-застосунок";
-
-"unable_upload_error_subtitle_broken" = "Файл пошкоджено та не може бути завантажений. Прохання завантажити інший файл.";
-
-"contact" = "Написати";
-
-"download_button" = "Завантажити";
-
 "speedcams_alert_title" = "Камери швидкості";
-
-"speedcams_alert_subtitle" = "Попереджати про обмеження швидкості";
 
 "speedcam_option_auto" = "Авто";
 
@@ -1886,18 +1147,10 @@
 
 "speedcam_option_never" = "Ніколи";
 
-"bookmark_description_title" = "Опис мітки";
-
 "place_description_title" = "Опис місця";
 
 /* this text will be shown in application notification preferences opposite checkbox which enable/disable downloader notifications. Devices on Android 8+ are affected. */
 "notification_channel_downloader" = "Завантаження мап";
-
-"share_bookmarks_email_body_link" = "Вітаємо!\n\nВаші мітки можна завантажити за посиланням: %s. Відкривайте список за допомогою Organic Maps та насолоджуйтесь подорожжю!\n\nЗавантажити додаток: https://omaps.app/get?kmz";
-
-"warning_speedcams_title" = "Навігатор вас попередить про камери при перевищенні швидкісного режиму на %d км/г";
-
-"warning_speedcams_subtitle" = "Не забудьте ознайомитися з правилами дорожнього руху у країні подорожі.";
 
 "speedcams_notice_message" = "Авто - Попереджати про камери швидкості, якщо є ризик перевищення швидкісного ліміту\nЗавжди - Завжди попереджати про камери\nНіколи - Ніколи не попереджати про камери";
 
@@ -1913,23 +1166,7 @@
 
 "enable_logging_warning_message" = "Дана опція вмикається для логування дій з метою діагностики. Це допомагає команді виявити проблеми з додатком. Тимчасово включайте цю настройку тільки для відправки детальної інформації про знайдену вами проблему в додатку.";
 
-"html_error_upload_message_try_again" = "Перевірте доступ до мережі та спробуйте ще раз";
-
-"html_error_upload_title_try_again" = "Немає з’єднання з Інтернетом";
-
-"notification_leave_review_v2_android_short_title" = "Залишайте відгук і допомагайте мандрівникам!";
-
-"megafon" = "Say goodbye to roaming!";
-
-"notifications_illegal_alert_disable_button" = "Вимкнути сповіщення";
-
 "access_rules_author_only" = "Редагується онлайн";
-
-"privacy_settings_menu" = "Налаштування конфіденційності";
-
-"unable_upadate_error_title" = "Не вдалося оновити маршрут";
-
-"unable_upadate_error_message" = "Виникли помилки під час оновлення. Перевірте зміни та спробуйте ще раз";
 
 "driving_options_title" = "Налаштування об’їзду";
 
@@ -1951,94 +1188,19 @@
 
 "change_driving_options_btn" = "Увімкнено налаштування об’їзду";
 
-"toll_road" = "Платна дорога";
-
-"unpaved_road" = "Ґрунтова дорога";
-
-"ferry_crossing" = "Поромна переправа";
-
-"operated_by" = "Керується \"%s\"";
-
 "avoid_toll_roads_placepage" = "Уникати платних доріг";
 
 "avoid_unpaved_roads_placepage" = "Уникати ґрунтових доріг";
 
 "avoid_ferry_crossing_placepage" = "Уникати поромних переправ";
 
-"type.cuisine.uzbek" = "Узбецька кухня";
-
-"trip_start" = "Поїхали";
-
-"pick_destination" = "Ціль";
-
-"follow_my_position" = "Відцентрувати";
-
-"search_results" = "Результати пошуку";
-
-"then_turn" = "Далі";
-
-"redirect_route_alert" = "Бажаєте перебудувати маршрут?";
-
-"redirect_route_yes" = "Так";
-
-"redirect_route_no" = "Ні";
-
-"trip_finished" = "Ви прибули!";
-
-"keyboard_availability_alert" = "Клавіатура недоступна під час руху";
-
-"dialog_routing_change_start_carplay" = "Неможливо побудувати маршрут від поточного місця розташування";
-
-"dialog_routing_change_end_carplay" = "Неможливо побудувати маршрут до кінцевої точки. Оберіть іншу";
-
-"dialog_routing_check_gps_carplay" = "Немає сигналу GPS. Перейдіть на відкриту місцевість";
-
-"dialog_routing_unable_locate_route_carplay" = "Неможливо побудувати маршрут. Оберіть інші точки маршруту";
-
-"dialog_routing_download_files_carplay" = "Щоб побудувати маршрут, завантажте відсутні карти на своєму пристрої";
-
-"dialog_routing_system_error_carplay" = "Виникла помилка. Перезапустіть додаток";
-
-"dialog_routing_rebuild_from_current_location_carplay" = "Маршрут буде перебудовано від вашого поточного місця розташування";
-
-"dialog_routing_rebuild_for_vehicle_carplay" = "Маршрут буде змінено на автомобільний";
-
 "ok" = "Ок";
-
-"avoid_unpaved_carplay_1" = "Без ґрунт.";
-
-"avoid_unpaved_carplay_2" = "Без ґрунтових";
-
-"avoid_ferry_carplay_1" = "Без поромів";
-
-"avoid_ferry_carplay_2" = "Без поромів";
-
-"avoid_tolls_carplay_1" = "Без платних";
-
-"avoid_tolls_carplay_2" = "Без платних";
-
-"speedcams_alert_title_carplay_1" = "Камери";
-
-"speedcams_alert_title_carplay_2" = "Інфо о камерах";
-
-"download_map_carplay" = "Завантажте карти в додатку Organic Maps на своєму пристрої";
-
-"carplay_roundabout_exit" = "%s з’їзд";
 
 /* max. 10 symbols, both iOS and Android */
 "sort" = "Сортувати";
 
 /* Android, title, max 20-22 symbols */
 "sort_bookmarks" = "Сортувати мітки";
-
-/* iOS */
-"sort_default" = "Сортувати за промовчанням";
-
-"sort_type" = "Сортувати за типом";
-
-"sort_distance" = "Сортувати за відстанню";
-
-"sort_date" = "Сортувати за датою";
 
 /* Android */
 "by_default" = "За промовчанням";
@@ -2052,63 +1214,7 @@
 /* Android */
 "by_date" = "За датою";
 
-"week_ago_sorttype" = "Тиждень тому";
-
-"month_ago_sorttype" = "Місяць тому";
-
-"moremonth_ago_sorttype" = "Понад місяць тому";
-
-"moreyear_ago_sorttype" = "Понад рік тому";
-
-"near_me_sorttype" = "Поруч зі мною";
-
-"others_sorttype" = "Інші";
-
-"food_places" = "Їжа";
-
-"tourist_places" = "Пам’ятки";
-
-"museums" = "Музеї";
-
-"parks" = "Парки";
-
-"swim_places" = "Плавання";
-
-"mountains" = "Гори";
-
-"animals" = "Тварини";
-
-"hotels" = "Готелі";
-
-"buildings" = "Будівлі";
-
-"money" = "Гроші";
-
-"shops" = "Магазини";
-
-"parkings" = "Парковки";
-
-"fuel_places" = "Заправки";
-
-"water" = "Вода";
-
-"medicine" = "Медицина";
-
 "search_in_the_list" = "Шукати в списку";
-
-"view_on_map_bookmarks" = "На карті";
-
-"more_bookmarks" = "Ще…";
-
-"no_items_found" = "Нічого не знайдено";
-
-/* Android, max 18 symbols */
-"bookmarks_edit_list" = "Редагувати";
-
-/* Android, max 18 symbols */
-"bookmarks_delete_list" = "Видалити список";
-
-"religious_places" = "Святі місця";
 
 "select_list" = "Обрати список";
 
@@ -2118,26 +1224,13 @@
 
 "dialog_pedestrian_route_is_long_message" = "Виберіть початкову чи кінцеву точку маршруту ближче до станції метро";
 
-/* Failed planning SUBWAY route message in navigation view */
-"routing_planning_error_subway_special" = "Не вдалося прокласти маршрут метро";
-
 "button_layer_isolines" = "Висоти";
-
-"tips_map_layers_title_countour" = "Лінії висот офлайн у Organic Maps!";
-
-"tips_map_layers_message_countour" = "Лінії висот допоможуть спланувати подорож на природу та не загубитися на місцевості";
 
 "isolines_activation_error_dialog" = "Щоб скористатися лініями висот, оновіть чи завантажте карту потрібної місцевості";
 
 "isolines_location_error_dialog" = "Лінії висот ще недоступні в цьому регіоні";
 
 "elevation_profile_diff_level" = "Рівень складності";
-
-"elevation_profile_diff_level_easy" = "Простий";
-
-"elevation_profile_diff_level_moderate" = "Помірний";
-
-"elevation_profile_diff_level_hard" = "Складний";
 
 "elevation_profile_ascent" = "Підйом";
 
@@ -2147,25 +1240,13 @@
 
 "elevation_profile_maxaltitude" = "Макс. висота";
 
-"elevation_profile_m" = "м";
-
 "elevation_profile_difficulty" = "Складність";
 
 "elevation_profile_distance" = "Відст.:";
 
-"elevation_profile_km" = "км";
-
 "elevation_profile_time" = "Шлях:";
 
-"elevation_profile_hours" = "год.";
-
-"elevation_profile_minutes" = "хв";
-
 "isolines_toast_zooms_1_10" = "Збільште карту, щоб побачити ізолінії";
-
-"downloader_updating_ios" = "Оновлення";
-
-"downloader_loading_ios" = "Завантаження";
 
 "key_information_title" = "Ключова інформація";
 

--- a/iphone/Maps/LocalizedStrings/uk.lproj/Localizable.stringsdict
+++ b/iphone/Maps/LocalizedStrings/uk.lproj/Localizable.stringsdict
@@ -9,21 +9,6 @@
 
 <!-- ********** Strings for downloading map from search **********/ -->
 
-  <key>bookmarks_places</key>
-  <dict>
-    <key>NSStringLocalizedFormatKey</key>
-    <string>%#@value@</string>
-    <key>value</key>
-    <dict>
-      <key>NSStringFormatSpecTypeKey</key>
-      <string>NSStringPluralRuleType</string>
-      <key>NSStringFormatValueTypeKey</key>
-      <string>d</string>
-      <key>other</key>
-      <string>%d закладок</string>
-    </dict>
-  </dict>
-
   <key>bookmarks_detect_message</key>
   <dict>
     <key>NSStringLocalizedFormatKey</key>
@@ -36,25 +21,10 @@
       <string>d</string>
       <key>one</key>
       <string>%d файл був знайдений. Ви побачите його після перетворення.</string>
-      <key>two</key>
-      <string>%d файлу були знайдені. Ви побачите їх після конвертації.</string>
       <key>other</key>
       <string>%d файлів було знайдено. Ви побачите їх після конвертації.</string>
-    </dict>
-  </dict>
-
-  <key>bookmarks_objects</key>
-  <dict>
-    <key>NSStringLocalizedFormatKey</key>
-    <string>%#@value@</string>
-    <key>value</key>
-    <dict>
-      <key>NSStringFormatSpecTypeKey</key>
-      <string>NSStringPluralRuleType</string>
-      <key>NSStringFormatValueTypeKey</key>
-      <string>d</string>
-      <key>other</key>
-      <string>%s об’єкт</string>
+      <key>two</key>
+      <string>%d файлу були знайдені. Ви побачите їх після конвертації.</string>
     </dict>
   </dict>
 

--- a/iphone/Maps/LocalizedStrings/vi.lproj/Localizable.strings
+++ b/iphone/Maps/LocalizedStrings/vi.lproj/Localizable.strings
@@ -18,9 +18,6 @@
 /* Button which deletes downloaded country */
 "delete" = "Xóa";
 
-/* Button "do not interrupt download" if user touched actively downloading country */
-"do_nothing" = "Tiếp tục";
-
 "download_maps" = "Tải xuống Bản đồ";
 
 /* Settings/Downloader - info for country when download fails */
@@ -28,9 +25,6 @@
 
 /* Settings/Downloader - info for country which started downloading */
 "downloading" = "Đang tải xuống…";
-
-/* Settings/Downloader - size string, only strings different from English should be translated */
-"kb" = "kB";
 
 /* Choose measurement on first launch alert - choose metric system button */
 "kilometres" = "Kilômét";
@@ -55,17 +49,11 @@
 /* Update maps later/Buy pro version later button text */
 "later" = "Để sau";
 
-/* Don't show some dialog any more */
-"never" = "Không bao giờ";
-
 /* View and button titles for accessibility */
 "search" = "Tìm kiếm";
 
 /* Search box placeholder text */
 "search_map" = "Tìm kiếm Bản đồ";
-
-/* Settings/Downloader - info for not downloaded country */
-"touch_to_download" = "Chạm để tải xuống";
 
 /* Settings/Downloader - 3G download warning dialog confirm button */
 "use_cellular_data" = "Có";
@@ -73,20 +61,11 @@
 /* Location services are disabled by user alert - message */
 "location_is_disabled_long_text" = "Bạn hiện đang tắt tất cả Dịch vụ Định vị cho thiết bị hoặc ứng dụng này. Bạn vui lòng bật lại chúng trong Thiết lập.";
 
-/* Location Services are not available on the device alert - message */
-"device_doesnot_support_location_services" = "Thiết bị của bạn không hỗ trợ Dịch vụ Định vị";
-
 /* View and button titles for accessibility */
 "zoom_to_country" = "Hiển thị trên bản đồ";
 
-/* Button text for the button at the center of the screen when the country is not downloaded */
-"country_status_download" = "Tải xuống Bản đồ\n(^ ^)";
-
 /* Button text for the button at the center of the screen when the country is not downloaded and the size should not be shown */
 "country_status_download_without_size" = "Tải xuống Bản đồ";
-
-/* Button text for the button at the center of the screen when the country is not downloaded */
-"country_status_download_without_routing" = "Tải về bản đồ không\ncó chỉ đường (^ ^)";
 
 /* Message to display at the center of the screen when the country download has failed */
 "country_status_download_failed" = "Tải xuống đã thất bại";
@@ -96,19 +75,13 @@
 
 "about_menu_title" = "Giới thiệu về Organic Maps";
 
-"downloaded_touch_to_delete" = "Đã tải xuống (%@), chạm để xóa";
-
 "connection_settings" = "Thiết lập Kết nối";
-
-"download_mb_or_kb" = "Tải xuống %@";
 
 "close" = "Đóng";
 
 "unsupported_phone" = "Cần có OpenGL được tăng tốc phần cứng. Thật không may, thiết bị của bạn không được hỗ trợ.";
 
 "download" = "Tải xuống";
-
-"external_storage_is_not_available" = "Không hỗ trợ lưu trữ trên thẻ SD/USB với các bản đồ được tải xuống";
 
 "disconnect_usb_cable" = "Bạn vui lòng tháo cáp USB hoặc lắp thẻ nhớ vào để sử dụng Organic Maps";
 
@@ -117,8 +90,6 @@
 "not_enough_memory" = "Không đủ bộ nhớ để chạy ứng dụng";
 
 "download_resources" = "Trước khi bạn bắt đầu, hãy để chúng tôi tải bản đồ thế giới vào thiết bị của bạn.\nBản đồ này cần %@ dữ liệu.";
-
-"getting_position" = "Đang tìm vị trí hiện tại";
 
 "download_resources_continue" = "Đến Bản đồ";
 
@@ -140,23 +111,14 @@
 /* Add New Bookmark Set dialog title */
 "add_new_set" = "Thêm Bộ Mới";
 
-/* Place Page - Add To Bookmarks button */
-"add_to_bookmarks" = "Thêm vào Điểm đánh dấu";
-
 /* Bookmark Color dialog title */
 "bookmark_color" = "Đánh dấu Màu sắc";
 
 /* Add Bookmark Set dialog - hint when set name is empty */
 "bookmark_set_name" = "Đánh dấu Tên Bộ";
 
-/* Bookmark Sets dialog title */
-"bookmark_sets" = "Đánh dấu Bộ";
-
 /* Bookmarks - dialog title */
 "bookmarks" = "Đánh dấu";
-
-/* Add bookmark dialog - bookmark color */
-"color" = "Màu sắc";
 
 /* Default bookmarks set name */
 "core_my_places" = "Các Địa chỉ của Tôi";
@@ -167,14 +129,8 @@
 /* Editor title above street and house number */
 "address" = "Địa chỉ";
 
-/* Place Page - Remove Pin button */
-"remove_pin" = "Xóa Con Dấu";
-
 /* Add bookmark dialog - bookmark set, Bookmarks dialog - Bookmark set cell */
 "set" = "Đặt";
-
-/* Text hint in Bookmarks dialog when no any bookmarks are added */
-"bookmarks_usage_hint" = "Bạn chưa có điểm đánh dấu.\nChạm vào bất kỳ địa điểm nào trên bản đồ để thêm một điểm đánh dấu.\nĐiểm đánh dấu từ các nguồn khác cũng có thể được nhập và hiển thị trong Organic Maps. Mở tập tin KML/KMZ với các điểm đánh dấu được lưu từ email, Dropbox hoặc liên kết web.";
 
 /* Settings button in system menu */
 "settings" = "Thiết lập";
@@ -191,26 +147,11 @@
 /* Ask to wait user several minutes (some long process in modal dialog). */
 "wait_several_minutes" = "Việc này có thể mất vài phút.\nVui lòng đợi…";
 
-/* Show bookmarks from this category on a map or not */
-"visible" = "Hiện";
-
-/* Toast which is displayed when GPS has been deactivated */
-"gps_is_disabled_long_text" = "GPS đã bị tắt. Vui lòng bật nó trong Cài đặt.";
-
 /* Measurement units title in settings activity */
 "measurement_units" = "Đơn vị đo";
 
 /* Detailed description of Measurement Units settings button */
 "measurement_units_summary" = "Chọn giữa dặm và kilômét";
-
-/* Do search in all sources */
-"search_mode_all" = "Everywhere";
-
-/* Do search near my position only */
-"search_mode_nearme" = "Near Me";
-
-/* Do search in current viewport only */
-"search_mode_viewport" = "On the Screen";
 
 /* Search category for cafes, bars, restaurants */
 "eat" = "Ăn ở đâu";
@@ -266,14 +207,8 @@
 /* Search category */
 "police" = "Cảnh sát";
 
-/* String in search result list, when nothing found */
-"no_search_results_found" = "Không tìm thấy kết quả nào";
-
 /* Notes field in Bookmarks view */
 "description" = "Ghi chú";
-
-/* Button text */
-"share_by_email" = "Chia sẻ bằng email";
 
 /* Email Subject when sharing bookmarks category */
 "share_bookmarks_email_subject" = "Điểm đánh dấu Organic Maps được chia sẻ";
@@ -295,26 +230,11 @@
 /* Warning message when doing search around current position */
 "unknown_current_position" = "Chưa xác định được vị trí của bạn";
 
-/* Warning message when location country isn't downloaded during search (see also download_location_map_proposal). */
-"download_location_country" = "Tải xuống quốc gia của vị trí hiện tại của bạn (%@)";
-
-/* Warning message when viewport country isn't downloaded during search */
-"download_viewport_country_to_search" = "Tải xuống quốc gia bạn đang tìm kiếm trên (%@)";
-
 /* Alert message that we can't run Map Storage settings due to some reasons. */
 "cant_change_this_setting" = "Rất tiếc, cài đặt Lưu trữ Bản đồ hiện đã bị tắt.";
 
 /* Alert message that downloading is in progress. */
 "downloading_is_active" = "Hiện đang tải xuống quốc gia.";
-
-/* Message that will be shown in alert view, when we ask user to leave review on App Store */
-"appStore_message" = "Hi vọng bạn thích sử dụng Organic Maps! Nếu vậy, bạn vui lòng cho điểm hoặc đánh giá ứng dụng trên App Store. Việc này chỉ tốn dưới một phút và sẽ giúp chúng tôi rất nhiều. Cảm ơn bạn đã ủng hộ!";
-
-/* No, thanks */
-"no_thanks" = "Không, cảm ơn";
-
-/* Share one specific bookmark using SMS, %1$@ contains om:// and %2$@ https://omaps.app link. @NOTE non-ascii symbols in the link will result in max 70 characters SMS instead of 140. */
-"bookmark_share_sms" = "Này, hãy xem ghim của tôi tại Organic Maps! %1$@ hoặc %2$@ Bạn chưa cài đặt bản đồ ngoại tuyến? Tải xuống tại đây: https://omaps.app/get";
 
 /* Share my position using SMS, %1$@ contains om:// and %2$@ https://omaps.app link WITHOUT NAME. @NOTE non-ascii symbols in the link will result in max 70 characters SMS instead of 140. */
 "my_position_share_sms" = "Này, hãy xem vị trí hiện tại của tôi tại Organic Maps! %1$@ hoặc %2$@ Bạn không có bản đồ ngoại tuyến? Tải xuống tại đây: https://omaps.app/get";
@@ -328,23 +248,11 @@
 /* Share my position using EMail, %1$@ is om:// and %2$@ is https://omaps.app link WITHOUT NAME */
 "my_position_share_email" = "Chào,\n\nTôi hiện đang ở đây: %1$@. Hãy nhấn vào liên kết này %2$@ hoặc liên kết này %3$@ để xem địa điểm trên bản đồ.\n\nCám ơn.";
 
-/* Android share by Message/SMS button text (including SMS) */
-"share_by_message" = "Chia sẻ bằng tin nhắn";
-
 /* Share button text which opens menu with more buttons, like Message, EMail, Facebook etc. */
 "share" = "Chia sẻ";
 
-/* iOS share by Message button text (including SMS) */
-"message" = "Tin nhắn";
-
 /* Share by email button text, also used in editor. */
 "email" = "Email";
-
-/* Copy Link */
-"copy_link" = "Sao chép Liên kết";
-
-/* Text for the button that returns to caller application */
-"more_info" = "Hiển thị thêm thông tin";
 
 /* Text for message when used successfully copied something */
 "copied_to_clipboard" = "Đã sao chép vào Bảng tạm: %1$@";
@@ -354,15 +262,6 @@
 
 /* Used for bookmark editing */
 "done" = "Xong";
-
-/* Summary for preferences in MWM */
-"yopme_pref_summary" = "Chọn cài đặt Màn hình Sau";
-
-/* Title for yopme preferences in MWM */
-"yopme_pref_title" = "Cài đặt Màn hình Sau";
-
-/* Hint for upper-right icon p2b */
-"show_on_backscreen" = "Hiển thị trên màn hình Sau";
 
 /* Prints version number in About dialog */
 "version" = "Phiên bản: %@";
@@ -381,19 +280,11 @@
 
 "share_my_location" = "Chia sẻ Vị trí của tôi";
 
-"menu_search" = "Tìm kiếm";
-
 /* Settings general group in settings screen */
 "prefs_group_general" = "General settings";
 
 /* Settings information group in settings screen */
 "prefs_group_information" = "Information";
-
-/* Settings screen: "Map" category title */
-"prefs_group_map" = "Bản đồ";
-
-/* Settings screen: "Miscellaneous" category title */
-"prefs_group_misc" = "Khác";
 
 "prefs_group_route" = "Điều hướng";
 
@@ -419,9 +310,6 @@
 /* Settings «Map» category: «3D buildings» title */
 "pref_map_3d_buildings_title" = "Nhà cửa 3D";
 
-/* Settings «Map» category: «3D buildings» summary */
-"pref_map_3d_buildings_subtitle" = "Ảnh hưởng tới tuổi thọ của pin";
-
 /* Settings «Route» category: «Tts enabled» title */
 "pref_tts_enable_title" = "Hướng dẫn bằng Giọng nói";
 
@@ -433,8 +321,6 @@
 
 /* Title for "Other" section in TTS settings. */
 "pref_tts_other_section_title" = "Khác";
-
-"pref_tts_how_to_set_up_voice" = "Làm thế nào để thiết lập tiếng nói";
 
 /* Settings «Map» category: «Record track» title */
 "pref_track_record_title" = "Tìm kiếm gần đây";
@@ -455,56 +341,7 @@
 
 "recent_track_help_text" = "Chức năng này cho phép bạn ghi lại đường đi trong một khoảng thời gian nhất định và xem nó trên bản đồ. Xin lưu ý: việc kích hoạt chức năng này sẽ tăng mức sử dụng pin. Đường đi sẽ tự động bị xóa khỏi bản đồ sau khi kết thúc khoảng thời gian nói trên.";
 
-"pref_track_ios_caption" = "Chức năng theo dấu gần đây hiển thị các đường bạn đã đi.";
-
-"pref_track_ios_subcaption" = "Vui lòng chọn khoảng thời gian lưu dấu.";
-
-"placepage_distance" = "Khoảng cách";
-
-"placepage_coordinates" = "Tọa độ";
-
-"placepage_unsorted" = "Chưa phân loại";
-
 "search_show_on_map" = "Xem trên bản đồ";
-
-/* Used to warn user when fixing KitKat issue */
-"bookmark_move_fail" = "Chúng tôi cần di chuyển các điểm đánh dấu của bạn vào bộ nhớ trong nhưng không còn dung lượng cho chúng. Vui lòng giải phóng bộ nhớ, nếu không các điểm đánh dấu sẽ không khả dụng.";
-
-/* Used in More Apps menu */
-"free" = "Free";
-
-/* Used in More Apps menu */
-"buy" = "Buy";
-
-/* 1st search button-like result */
-"search_on_map" = "Tìm trên bản đồ";
-
-/* toast with an error */
-"no_route_found" = "Không tìm thấy tuyến đường";
-
-/* route title */
-"route" = "Tuyến đường";
-
-/* category title */
-"routes" = "Tuyến đường";
-
-/* text of notification */
-"download_map_notification" = "Tải xuống bản đồ của vị trí của bạn";
-
-/* text of notification */
-"pro_version_is_free_today" = "Full version of Organic Maps is free today! Download now and tell your friends.";
-
-/* Dialog for transferring maps from lite to pro. */
-"move_lite_maps_to_pro" = "Chúng tôi đang chuyển bản đồ đã tải xuống của bạn từ Organic Maps Lite sang Organic Maps. Việc này có thể mất vài phút.";
-
-/* Message to display when maps moved. */
-"move_lite_maps_to_pro_ok" = "Bản đồ đã tải xuống của bạn đã được chuyển thành công sang Organic Maps.";
-
-/* Message to display when maps move failed. */
-"move_lite_maps_to_pro_failed" = "Bản đồ của bạn không chuyển được. Vui lòng xóa Organic Maps Lite và tải xuống lại bản đồ.";
-
-/* Text in menu */
-"settings_and_more" = "Thiết lập &amp; Khác";
 
 /* Text in menu */
 "website" = "Trang web";
@@ -527,14 +364,8 @@
 /* Text in menu */
 "openstreetmap" = "OpenStreetMap";
 
-/* Text in menu */
-"contact_us" = "Liên hệ với chúng tôi";
-
 /* Settings: Send feedback button and dialog title */
 "feedback" = "Phản hồi";
-
-/* Text in menu */
-"subscribe_to_news" = "Đăng ký nhận tin tức của chúng tôi";
 
 /* Text in menu */
 "rate_the_app" = "Cho điểm ứng dụng";
@@ -548,15 +379,6 @@
 /* Text in menu */
 "report_a_bug" = "Báo cáo lỗi";
 
-/* Email subject */
-"subscribe_me_subject" = "Vui lòng đăng ký tôi vào danh sách nhận thư định kỳ Organic Maps";
-
-/* Email body */
-"subscribe_me_body" = "Tôi muốn là người đầu tiên được biết về các thông tin cập nhật và quảng bá mới nhất. Tôi có thể hủy bỏ đăng ký nhận tin của mình bất cứ lúc nào.";
-
-/* About text */
-"about_text" = "Organic Maps cung cấp bản đồ ngoại tuyến của tất cả các thành phố và quốc gia trên thế giới một cách nhanh nhất. Hoàn toàn tự tin đi du lịch: dù bạn ở đâu, Organic Maps vẫn sẽ giúp bạn định vị bản thân trên bản đồ, tìm các nhà hàng, khách sạn, ngân hàng, trạm xăng, v.v… gần nhất. Ứng dụng này không yêu cầu kết nối Internet.\n\nChúng tôi luôn phát triển các tính năng mới và rất chào đón ý kiến của bạn về cách mà chúng tôi có thể cải thiện Organic Maps. Nếu bạn có bất cứ vấn đề nào với ứng dụng, hãy liên hệ với chúng tôi qua địa chỉ support@organicmaps.app. Chúng tôi sẽ trả lời mọi yêu cầu!\n\nBạn có thích Organic Maps và muốn hỗ trợ chúng tôi hay không? Sau đây là một số cách đơn giản và hoàn toàn miễn phí:\n\n- viết đánh giá trên Chợ Ứng dụng mà bạn sử dụng\n- thích trang Facebook của chúng tôi http://www.facebook.com/OrganicMaps\n- hoặc chỉ đơn giản là kể về Organic Maps với mẹ, bạn bè và đồng nghiệp của bạn :)\n\nCảm ơn bạn đã ủng hộ chúng tôi. Chúng tôi rất cảm ơn sự giúp đỡ của bạn!\n\nT.B. Chúng tôi lấy dữ liệu bản đồ từ OpenStreetMap, một dự án bản đồ tương đương với Wikipedia, cho phép người dùng có thể tạo và sửa bản đồ. Nếu bạn thấy có thông tin bị thiếu hoặc sai trên bản đồ, bạn có thể sửa trực tiếp tại https://www.openstreetmap.org, và các thay đổi của bạn sẽ xuất hiện trong ứng dụng Organic Maps ở phiên bản kế tiếp.";
-
 /* Alert text */
 "email_error_body" = "Trình khách email này chưa được thiết lập. Bạn vui lòng cấu hình nó hoặc sử dụng một cách khác để liên hệ với chúng tôi tại %@";
 
@@ -569,12 +391,6 @@
 /* Search category */
 "wifi" = "WiFi";
 
-/* Update map suggestion */
-"routing_map_outdated" = "Vui lòng cập nhật bản đồ để tạo tuyến đường";
-
-/* Update maps suggestion */
-"routing_update_maps" = "Phiên bản Organic Maps mới cho phép tạo các tuyến đường từ vị trí hiện tại của bạn đến điểm đến. Vui lòng cập nhật bản đồ để sử dụng tính năng này.";
-
 /* Update all button text */
 "downloader_update_all_button" = "Cập nhật tất cả";
 
@@ -583,9 +399,6 @@
 
 /* Downloaded maps category */
 "downloader_downloaded_subtitle" = "Đã tải xuống";
-
-/* Downloaded maps category */
-"downloader_available_maps" = "Đã có";
 
 /* Country queued for download */
 "downloader_queued" = "Đã xếp hàng chờ";
@@ -598,17 +411,6 @@
 
 "downloader_downloading" = "Đang tải về:";
 
-"downloader_search_results" = "Đã tìm thấy";
-
-/* Disclaimer message */
-"routing_disclaimer" = "Tạo các tuyến đường trong ứng dụng Organic Maps, xin lưu ý điều sau:\n\n – Các tuyến đường được gợi ý chỉ có thể được xem là đề xuất.\n – Điều kiện con đường, luật giao thông và biển báo có mức ưu tiên cao hơn lời khuyên dẫn hướng.\n – Bản đồ có thể không chính xác hoặc lỗi thời, tuyến đường có thể không được tạo theo cách tốt nhất có thể.\n\n Hãy lái xe an toàn trên đường và bảo trọng!";
-
-/* Outdated maps category */
-"downloader_outdated_maps" = "Lỗi thời";
-
-/* Up to date maps category */
-"downloader_uptodate_maps" = "Cập nhật";
-
 /* Status of outdated country in the list */
 "downloader_status_outdated" = "Cập nhật";
 
@@ -618,49 +420,14 @@
 /* Displayed in a dialog that appears when a user tries to delete a map while the app is in the follow route mode */
 "downloader_delete_map_while_routing_dialog" = "Để xóa bản đồ, vui lòng dừng điều hướng.";
 
-/* Show when user try build route, but we don't know where he */
-"routing_failed_unknown_my_position" = "Không xác định được vị trí hiện tại. Vui lòng xác định vị trí để tạo tuyến đường.";
-
-/* Show if use has not routing file, or InconsistentMWMandRoute */
-"routing_failed_has_no_routing_file" = "số liệu bổ sung cần thiết để tạo ra các tuyến đường đi từ vị trí của bạn.";
-
-/* StartPointNotFound */
-"routing_failed_start_point_not_found" = "Không thể tính toán tuyến đường. Không có con đường nào gần điểm bắt đầu của bạn.";
-
-/* EndPointNotFound */
-"routing_failed_dst_point_not_found" = "Không thể tính toán tuyến đường. Không có con đường nào gần điểm đến của bạn.";
-
 /* PointsInDifferentMWM */
 "routing_failed_cross_mwm_building" = "Tuyến đường chỉ có thể được tạo hoàn toàn được chứa trong một bản đồ.";
-
-/* RouteNotFound */
-"routing_failed_route_not_found" = "Không tìm thấy tuyến đường nào giữa điểm gốc và điểm đến được chọn. Vui lòng chọn điểm bắt đầu hoặc điểm cuối khác.";
-
-/* InternalError */
-"routing_failed_internal_error" = "Đã xảy ra lỗi nội bộ. Vui lòng thử xóa và tải lại xuống bản đồ. Nếu vấn đề vẫn còn tồn tại, vui lòng liên hệ với chúng tôi tại support@organicmaps.app.";
-
-/* Context menu item for downloader. */
-"downloader_download_map_and_routing" = "Tải xuống Bản đồ + Định tuyến";
-
-/* Context menu item for downloader. */
-"downloader_download_routing" = "Tải xuống Định tuyến";
-
-/* Context menu item for downloader. */
-"downloader_delete_routing" = "Xóa Định tuyến";
 
 /* Context menu item for downloader. */
 "downloader_download_map" = "Tải về bản đồ";
 
-"downloader_download_map_no_routing" = "Tải về bản đồ không có chỉ đường";
-
-/* Button for routing. */
-"routing_go" = "Tiến hành!";
-
 /* Item status in downloader. */
 "downloader_retry" = "Lặp lại";
-
-/* Item in context menu. */
-"downloader_map_and_routing" = "Bản đồ + Định tuyến";
 
 /* Item in context menu. */
 "downloader_delete_map" = "Xóa Bản đồ";
@@ -668,29 +435,11 @@
 /* Item in context menu. */
 "downloader_update_map" = "Cập nhật Bản đồ";
 
-/* Item in context menu. */
-"downloader_update_map_and_routing" = "Cập nhật bản đồ + Định tuyến";
-
-/* Item in context menu. */
-"downloader_map_only" = "Chỉ bản đồ";
-
-/* Toolbar title */
-"toolbar_application_menu" = "Menu ứng dụng";
-
 /* Preference text */
 "pref_use_google_play" = "Sử dụng Dịch vụ Google Play để có được vị trí hiện tại của bạn";
 
 /* Text for rating dialog */
 "rating_just_rated" = "Tôi vừa đánh giá ứng dụng của bạn";
-
-/* Text for rating dialog */
-"rating_user_since" = "Tôi là người dùng Organic Maps từ năm %@";
-
-/* Text for rating dialog */
-"rating_do_like_maps" = "Bạn có thích Organic Maps?";
-
-/* Text for rating dialog */
-"rating_tap_star" = "Chạm vào một ngôi sao để đánh giá ứng dụng của chúng tôi.";
 
 /* Text for rating dialog */
 "rating_thanks" = "Xin cám ơn!";
@@ -701,23 +450,8 @@
 /* Text for rating dialog */
 "rating_send_feedback" = "Gửi phản hồi";
 
-/* Text for g+ dialog */
-"rating_google_plus" = "Nhấp vào g+ để nói với bạn bè của bạn về ứng dụng.";
-
 /* Text for routing error dialog */
 "routing_download_maps_along" = "Tải xuống bản đồ theo tuyến đường";
-
-/* Text for routing error dialog */
-"routing_download_map" = "Nhận bản đồ";
-
-/* Text for routing error dialog */
-"routing_download_map_and_routing" = "Tải bản đồ và dữ liệu đường đi cập nhật để nhận được tất cả các tính năng của Organic Maps.";
-
-/* Text for routing error dialog */
-"routing_get_routing_data" = "Nhận dữ liệu đường đi";
-
-/* Text for routing error dialog */
-"routing_get_additional_data" = "số liệu bổ sung cần thiết để tạo ra các tuyến đường đi từ vị trí của bạn.";
 
 /* Text for routing error dialog */
 "routing_requires_all_map" = "Tạo một tuyến đường đòi hỏi tất cả các bản đồ từ vị trí của bạn đến điểm đến phải được tải xuống và cập nhật.";
@@ -725,50 +459,15 @@
 /* Text for routing error dialog */
 "routing_not_enough_space" = "Không đủ không gian";
 
-/* Text for routing error dialog */
-"routing_download_more_than_avail" = "Bạn cần phải tải về %@ MB, nhưng chỉ có %@ MB sẵn có.";
-
-/* Text for routing error dialog */
-"routing_download_roaming" = "Bạn sắp tải xuống %@ MB sử dụng Dữ liệu Di động (trong dịch vụ Chuyển vùng). Điều này có thể dẫn đến cước phí bổ sung, tùy thuộc vào gói dữ liệu di động của nhà mạng của bạn.";
-
 /* bookmark button text */
 "bookmark" = "yer i̇mi";
-
-/* map is not downloaded */
-"not_found_map" = "Bản đồ cho vị trí của bạn chưa được tải xuống";
 
 /* location service disabled */
 "enable_location_services" = "Bạn vui lòng bật Dịch vụ Định vị";
 
-/* download map */
-"download_map" = "Tải xuống bản đồ cho vị trí của bạn";
-
-/* download map on iPhone */
-"download_map_iphone" = "Tải bản đồ vị trí hiện tại xuống iPhone của bạn";
-
-/* clear pin */
-"nearby" = "Gần kề";
-
-/* clear pin */
-"clear_pin" = "Xóa Pin";
-
-/* location is undefined */
-"undefined_location" = "Không xác định được vị trí hiện tại.";
-
-/* download country of your location */
-"download_country" = "Tải xuống quốc gia bạn đang tìm kiếm trên";
-
-/* download failed */
-"download_failed" = "tải xuống thất bại";
-
-/* get the map */
-"get_the_map" = "Tải bản đồ";
-
 "save" = "Lưu";
 
 "edit_description_hint" = "Mô tả của bạn (chữ hoặc html)";
-
-"new_group" = "nhóm mới";
 
 "create" = "tạo";
 
@@ -795,30 +494,6 @@
 
 /* pink color */
 "pink" = "Hồng";
-
-/* deep purple color */
-"deep_purple" = "Tía thẫm";
-
-/* light blue color */
-"light_blue" = "Xanh da trời";
-
-/* cyan color */
-"cyan" = "Xanh lơ";
-
-/* teal color */
-"teal" = "Lục bảo";
-
-/* lime color */
-"lime" = "Màu xanh chanh";
-
-/* deep orange color */
-"deep_orange" = "Cam đậm";
-
-/* gray color */
-"gray" = "Xám";
-
-/* blue gray color */
-"blue_gray" = "Xám xanh da trời";
 
 /* Wi-Fi available */
 "WiFi_available" = "Có";
@@ -848,13 +523,9 @@
 
 "dialog_routing_location_unknown_turn_on" = "Không thể xác định vị trí tọa độ GPS hiện tại. Bật các dịch vụ định vị để tính toán tuyến đường.";
 
-"dialog_routing_location_unknown" = "Không thể xác định vị trí tọa độ GPS hiện tại.";
-
 "dialog_routing_download_files" = "Tải xuống các tệp yêu cầu";
 
 "dialog_routing_download_and_update_all" = "Tải về và cập nhật tất cả các bản đồ và các thông tin tuyến đường dọc theo lộ trình dự kiến để tính toán tuyến đường.";
-
-"dialog_routing_routes_size" = "Tệp thông tin tuyến đường";
 
 "dialog_routing_unable_locate_route" = "Không thể xác định tuyến đường";
 
@@ -884,21 +555,11 @@
 
 "dialog_routing_try_again" = "Vui lòng thử lại";
 
-"dialog_routing_send_error" = "Báo cáo vấn đề";
-
-"dialog_routing_if_get_cross_route" = "Bạn có muốn tạo một tuyến đường thẳng hơn mà kéo dài trên nhiều bản đồ không?";
-
-"dialog_routing_cross_route_is_optimal" = "Có một tuyến đường tối ưu hơn đi qua cạnh của bản đồ này.";
-
 "not_now" = "Lúc khác";
-
-"dialog_routing_build_route" = "Tạo";
 
 "dialog_routing_download_and_build_cross_route" = "Bạn có muốn tải về bản đồ và tạo một tuyến đường tối ưu hơn kéo dài trên nhiều hơn một bản đồ?";
 
 "dialog_routing_download_cross_route" = "Tải về bản đồ để tạo tuyến đường tối ưu hơn mà đi qua cạnh của bản đồ này.";
-
-"dialog_routing_cross_route_always" = "Luôn đi qua ranh giới này";
 
 
 /********** Strings for downloading map from search **********/
@@ -906,8 +567,6 @@
 "search_without_internet_advertisement" = "Để bắt đầu tìm kiếm và tạo đường đi, vui lòng tải về bản đồ, và bạn sẽ không cần đến kết nối Internet nữa.";
 
 "search_select_map" = "Chọn bản đồ";
-
-"search_select_other_map" = "Chọn bản đồ khác";
 
 /* «Show» context menu */
 "show" = "Hiện";
@@ -918,17 +577,11 @@
 /* «Rename» context menu */
 "rename" = "Đổi tên";
 
-/* Bottom sheet: expand button (should be short) */
-"bottom_sheet_more" = "Thêm…";
-
 /* Failed planning route message in navigation view */
 "routing_planning_error" = "Không thể Lập Lộ trình";
 
 /* Arrive routing message in navigation view */
 "routing_arrive" = "Đến: %s";
-
-/* Text for routing::RouterResultCode::FileTooOld dialog. */
-"dialog_routing_download_and_update_maps" = "Để tạo đường đi, vui lòng tải về và cập nhật tất cả bản đồ dọc theo tuyến đường.";
 
 "rate_alert_title" = "Bạn thích ứng dụng chứ?";
 
@@ -944,19 +597,11 @@
 
 "history" = "Lịch sử";
 
-"next_turn_then" = "Sau đó";
-
 "closed" = "Đã đóng";
-
-"back_to" = "Quay lại %@";
 
 "search_not_found" = "Xin lỗi, tôi không tìm thấy kết quả nào.";
 
 "search_not_found_query" = "Vui lòng thử câu hỏi khác.";
-
-"search_not_found_map" = "Vui lòng tải về bản đồ mà bạn đang tìm kiếm trong đó.";
-
-"search_not_found_location" = "Tải về bản đồ vị trí hiện tại của bạn.";
 
 "search_history_title" = "Lịch sử tìm kiếm";
 
@@ -964,23 +609,12 @@
 
 "clear_search" = "Xóa Lịch sử Tìm kiếm";
 
-/* Title for settings to enable/disable showcase menu button */
-"showcase_settings_title" = "Hiển thị lời mời";
-
 /* Place Page link to Wikipedia article (if map object has it). */
 "read_in_wikipedia" = "Wikipedia";
 
-"p2p_route_planning" = "Hoạch định đường đi";
-
 "p2p_your_location" = "Vị trí của bạn";
 
-"p2p_from" = "Điểm khởi hành";
-
-"p2p_to" = "Điểm đích";
-
 "p2p_start" = "Bắt đầu";
-
-"p2p_planning" = "Đang hoạch định…";
 
 "p2p_from_here" = "Từ";
 
@@ -1018,15 +652,9 @@
 
 "editor_correct_mistake" = "Sửa lỗi";
 
-"editor_correct_mistake_message" = "Bạn đã mắc lỗi chỉnh sửa. Vui lòng sửa lỗi hoặc chuyển qua chế độ đơn giản.";
-
 "editor_add_select_location" = "Vị trí";
 
 "editor_done_dialog_1" = "Bạn đã thay đổi bản đồ thế giới. Đừng giấu điều đó! Hãy cho các bạn khác biết và cùng nhau chỉnh sửa.";
-
-"editor_done_dialog_2" = "Đây là lần nâng cấp bản đồ thứ hai của bạn. Giờ bạn xếp hạng %d trong các nhà hiệu chỉnh bản đồ. Hãy nói với các bạn khác về điều đó.";
-
-"editor_done_dialog_3" = "Bạn đã nâng cấp bản đồ này, hãy cho các bạn khác biết và cùng nhau chỉnh sửa bản đồ.";
 
 "share_with_friends" = "Chia sẻ với bạn bè";
 
@@ -1044,20 +672,7 @@
 
 "editor_report_problem_duplicate_place_title" = "Địa điểm trùng lặp";
 
-"first_launch_congrats_title" = "Organic Maps đã sẵn sàng để sử dụng";
-
-"first_launch_congrats_text" = "Tìm kiếm và điều hướng ngoại tuyến, miễn phí khắp mọi nơi trên thế giới.";
-
-"migrate_title" = "Quan trọng!";
-
-/* Android uses image instead of text. */
-"download_all" = "Tải về tất cả";
-
-"delete_all" = "Xóa tất cả";
-
 "autodownload" = "Tự động tải về";
-
-"disable_autodownload" = "Tắt chế độ tự động tải xuống";
 
 /* Place Page opening hours text */
 "closed_now" = "Hiện đã đóng";
@@ -1072,10 +687,6 @@
 "day_off" = "Ngày nghỉ";
 
 "today" = "Hôm nay";
-
-"sunrise_to_sunset" = "Từ bình minh đến hoàng hôn";
-
-"sunset_to_sunrise" = "Từ hoàng hôn đến bình minh";
 
 "add_opening_hours" = "Thêm giờ làm việc";
 
@@ -1095,45 +706,18 @@
 
 "forgot_password" = "Quên mật khẩu?";
 
-/* Forgot Password dialog title */
-"restore_password" = "Khôi phục mật khẩu";
-
-"enter_email_address_to_reset_password" = "Nhập địa chỉ email bạn đã sử dụng trong quá trình đăng ký và chúng tôi sẽ gửi cho bạn liên kết để tạo mới mật khẩu của bạn.";
-
-"reset_password" = "đặt lại mật khẩu";
-
-"username" = "Tên đăng nhập";
-
 "osm_account" = "Tài khoản OSM";
 
 "logout" = "Đăng xuất";
 
-"login_and_edit_map_motivation_message" = "Đăng nhập và chỉnh sửa thông tin của các đối tượng trên bản đồ và chúng tôi sẽ hiển thị chúng cho hàng triệu người dùng khác. Hãy cùng nhau làm cho thế giới tốt đẹp hơn.";
-
 /* Information text: "Last upload 11.01.2016" */
 "last_upload" = "Tải lên mới nhất";
 
-/* Motivates user to login/register, title above login buttons. */
-"you_have_edited_your_first_object" = "Bạn đã chỉnh sửa đối tượng đầu tiên của mình!";
-
 "thank_you" = "Cảm ơn bạn";
-
-"login_with_google" = "Đăng nhập với Google";
-
-"login_with_openstreetmap" = "Đăng nhập với www.openstreetmap.org";
 
 "edit_place" = "Chỉnh sửa địa điểm";
 
 "place_name" = "Tên địa điểm";
-
-/* title above languages list cells in the editor, below editable name text field. */
-"other_languages" = "Ngôn ngữ khác";
-
-/* small button to open list with names in different languages */
-"show_more" = "Hiển thị nhiều hơn";
-
-/* small button to close list with names in different languages */
-"show_less" = "Hiển thị ít hơn";
 
 "add_language" = "Thêm ngôn ngữ";
 
@@ -1164,8 +748,6 @@
 
 "please_note" = "Xin lưu ý";
 
-"common_no_wifi_dialog" = "Không có Wifi. Bạn có muốn tiếp tục dùng dữ liệu di động?";
-
 "downloader_delete_map_dialog" = "Tất cả những thay đổi của bản đồ sẽ bị xóa cùng với bản đồ đó.";
 
 "downloader_update_maps" = "Cập nhật các bản đồ";
@@ -1173,10 +755,6 @@
 "downloader_mwm_migration_dialog" = "Để tạo một tuyến đường, bạn cần cập nhật tất cả các bản đồ và sau đó lập lại tuyến đường.";
 
 "downloader_search_field_hint" = "Tìm bản đồ";
-
-"migration_update_all_button" = "Cập nhật tất cả các bản đồ";
-
-"migration_delete_all_download_current_button" = "Tải xuống bản đồ hiện tại và xóa những bản đồ cũ";
 
 "migration_download_error_dialog" = "Lỗi tải xuống";
 
@@ -1186,21 +764,9 @@
 
 "downloader_no_space_message" = "Xin xóa dữ liệu không cần thiết";
 
-"editor_general_auth_error_dialog" = "Lỗi đăng nhập chung.";
-
 "editor_login_error_dialog" = "Lỗi đăng nhập.";
 
-"editor_login_failed_dialog" = "Đăng nhập thất bại";
-
-"editor_username_error_dialog" = "Tên đăng nhập không hợp lệ";
-
-"editor_place_edited_dialog" = "Bạn đã chỉnh sửa một đối tượng!";
-
-"editor_login_with_osm" = "Đăng nhập với OpenStreetMap";
-
 "editor_profile_changes" = "Các thay đổi đã được xác thực";
-
-"editor_profile_unsent_changes" = "Không gửi được:";
 
 "editor_focus_map_on_location" = "Kéo bản đồ để chọn vị trí chính xác của đối tượng";
 
@@ -1222,13 +788,9 @@
 
 "editor_report_problem_other_title" = "Một vấn đề khác";
 
-"placepage_report_problem_button" = "Báo cáo vấn đề";
-
 "placepage_add_business_button" = "Thêm tổ chức";
 
 "whatsnew_editor_message_1" = "Nhập các địa điểm mới vào bản đồ, và trực tiếp chỉnh sửa những địa điểm hiện có trên ứng dụng.";
-
-"whatsnew_editor_message_2" = "* Organic Maps sử dụng dữ liệu của cộng đồng OpenStreetMap.";
 
 "dialog_incorrect_feature_position" = "Thay đổi địa điểm";
 
@@ -1236,16 +798,10 @@
 
 "login_to_make_edits_visible" = "Đăng nhập để người dùng khác có thể nhìn thấy những thay đổi bạn đã thực hiện.";
 
-"no_migration_during_navigation" = "Không cho phép cập nhật trong khi điều hướng.";
-
 /* Error dialog no space */
 "migration_no_space_message" = "Để tải xuống, bạn cần thêm dung lượng. Xin xóa mọi dữ liệu không cần thiết.";
 
 "editor_sharing_title" = "Tôi đã cải thiện các bản đồ Organic Maps";
-
-"editor_comment_will_be_sent" = "Chúng tôi sẽ gửi bình luận của bạn đến những người lập bản đồ.";
-
-"editor_unsupported_category_message" = "Bạn đã thêm một địa điểm của một hạng mục mà chúng tôi chưa hỗ trợ. Nó sẽ xuất hiện trên bản đồ một thời gian sau đó.";
 
 /* Downloaded 10 **of** 20 <- it is that "of" */
 "downloader_of" = "%1$d trên %2$d";
@@ -1278,23 +834,9 @@
 
 "editor_operator" = "Đơn vị điều hành";
 
-"editor_tag_description" = "Nhập công ty, tổ chức hoặc cá nhân phụ trách cơ sở.";
-
-"editor_no_local_edits_title" = "Bạn không có những chỗ sửa cục bộ";
-
-"editor_no_local_edits_description" = "Thông tin này cho biết số thay đổi đề nghị của bạn trên bản đồ hiện chỉ có thể truy cập trên thiết bị của bạn.";
-
-"editor_send_to_osm" = "Gửi đến OSM";
-
-"editor_remove" = "Xóa";
-
-"downloader_my_maps_title" = "Bản đồ của tôi";
-
 "downloader_no_downloaded_maps_title" = "Bạn chưa tải về bất kỳ bản đồ nào";
 
 "downloader_no_downloaded_maps_message" = "Tải về bản đồ để tìm địa điểm và định hướng ngoại tuyến.";
-
-"downloader_find_place_hint" = "Tìm kiếm thành phố hoặc quốc gia";
 
 /* Error title that appears after certain time without location. */
 "current_location_unknown_title" = "Tiếp tục phát hiện địa điểm hiện tại của bạn?";
@@ -1321,47 +863,13 @@
 /* iOS Dialog for the case when the location permission is not granted */
 "location_services_disabled_3" = "3. Chọn Khi Đang Dùng Ứng dụng";
 
-"placepage_parking_surface" = "Trên mặt đất";
-
-"placepage_parking_multistorey" = "Nhiều tầng";
-
-"placepage_parking_underground" = "Dưới mặt đất";
-
-"placepage_parking_rooftop" = "Trên mái";
-
-"placepage_parking_sheds" = "Chỗ để xe";
-
-"placepage_parking_carports" = "Nhà để xe";
-
-"placepage_parking_boxes" = "Thùng gara";
-
-"placepage_parking_pay" = "Trả phí";
-
-"placepage_parking_free" = "Miễn phí";
-
-"placepage_parking_interval" = "Trả Phí Cách Quãng";
-
-"placepage_entrance_number" = "Số";
-
-"placepage_entrance_type" = "Lối vào";
-
-"placepage_flat" = "áp dụng";
-
-"placepage_open_24_7" = "24 / 7";
-
 "meter" = "m";
 
 "kilometer" = "km";
 
-"kilometers_per_hour" = "km/giờ";
-
 "mile" = "dặm";
 
 "foot" = "ft";
-
-"miles_per_hour" = "mph";
-
-"day" = "ngày";
 
 "hour" = "giờ";
 
@@ -1381,10 +889,6 @@
 
 "placepage_bookmark_name_hint" = "Tên Dấu Trang";
 
-"placepage_personal_notes_hint" = "Ghi chú cá nhân";
-
-"placepage_delete_bookmark_button" = "Xóa Dấu Trang";
-
 "editor_edits_sent_message" = "Những thay đổi đề nghị của bạn đã được gửi";
 
 "editor_comment_hint" = "Nhận xét…";
@@ -1397,8 +901,6 @@
 
 "editor_remove_place_button" = "Xóa";
 
-"editor_status_sending" = "Đang gửi …";
-
 "editor_place_doesnt_exist" = "Địa điểm không tồn tại";
 
 "text_more_button" = "…thêm";
@@ -1410,11 +912,7 @@
 
 "error_enter_correct_email" = "Nhập email hợp lệ";
 
-"error_enter_correct" = "Nhập giá trị hợp lệ";
-
 "refresh" = "Cập nhật";
-
-"last_update" = "Cập nhật cuối cùng: %s";
 
 "placepage_add_place_button" = "Thêm địa điểm vào bản đồ";
 
@@ -1426,24 +924,6 @@
 
 "editor_share_to_all_dialog_message_2" = "Chúng tôi sẽ kiểm tra những thay đổi. Nếu chúng tôi có câu hỏi nào, chúng tôi sẽ liên lạc với bạn qua email.";
 
-"navigation_overview_button" = "tổng quan";
-
-"navigation_stop_button" = "dừng";
-
-/* Text on an empty bookmark page */
-"bookmarks_empty_title" = "Lưu Đánh dấu trang";
-
-"bookmarks_empty_message_1" = "Chạm vào ★ để lưu địa điểm yêu thích giúp truy cập nhanh.";
-
-"bookmarks_empty_message_2" = "Nhập đánh dấu trang từ Hộp thư và trang web.";
-
-"bookmarks_empty_message_3" = "đăng ký ra: %s";
-
-/* Name of the group for booked hotels */
-"bookmarks_group_name" = "Đã đặt trước khách sạn";
-
-"place_page_button_read_descriprion" = "Đọc";
-
 /* iOS dialog for the case when recent track recording is on and the app comes back from background */
 "recent_track_background_dialog_title" = "Tắt ghi lại tuyến đường đã đi gần đây của bạn?";
 
@@ -1451,8 +931,6 @@
 
 /* For sharing via SMS and so on */
 "sharing_call_action_look" = "Xem";
-
-"continue_recent_track_background_button" = "Tiếp tục";
 
 "recent_track_background_dialog_message" = "Organic Maps sử dụng định vị của bạn trong ứng dụng chạy nền để ghi lại tuyến đường đã đi gần đây của bạn.";
 
@@ -1468,33 +946,13 @@
 /* About short text (below logo) */
 "about_description" = "Organic Maps là một ứng dụng ngoại tuyến thiết yếu khi đi du lịch. Organic Maps được dựa trên dữ liệu của OpenStreetMap và cho phép bạn hiệu chỉnh nó.";
 
-/* Text in menu */
-"blog" = "Blog";
-
 "general_settings" = "Thiết lập chung";
-
-"date" = "Ngày %d";
-
-/* "Report a bug" -> "Generaal Feedback" -> "Something is not working" */
-"something_is_not_working" = "Có một vấn đề nào đó";
 
 /* For the first routing */
 "accept" = "Chấp nhận";
 
-"accept_and_continue" = "Accept and continue";
-
 /* For the first routing */
 "decline" = "Từ chối";
-
-"install_app" = "Cài đặt";
-
-"search_no_results_title" = "Không tìm thấy kết quả nào";
-
-"search_no_results_message" = "Hãy thử một từ khóa tìm kiếm chung hơn, thu nhỏ hoặc đặt lại bộ lọc.";
-
-"search_no_results_expand_area_button" = "Thu nhỏ";
-
-"search_no_results_reset_button" = "Đặt lại Bộ lọc";
 
 /* noun */
 "search_in_table" = "Danh sách";
@@ -1517,8 +975,6 @@
 
 "traffic_update_maps_text" = "Để hiển thị dữ liệu giao thông, cần cập nhật bản đồ.";
 
-"traffic_outdated" = "Dữ liệu giao thông đã lỗi thời.";
-
 "big_font" = "Tăng kích cỡ phông chữ trên bản đồ";
 
 "traffic_update_app" = "Vui lòng cập nhật Organic Maps";
@@ -1529,17 +985,7 @@
 /* "traffic" as in "road congestion" */
 "traffic_data_unavailable" = "Dữ liệu giao thông không khả dụng";
 
-/* "Translation is no needed, because it's a company name" */
-"uber" = "Uber";
-
-/* Simplified colour scheme for traffic information, fewer colours are used to display traffic jams on the map. The string should be kept as short as possible */
-"pref_traffic_simplified_colors_title" = "Màu sắc giao thông đơn giản";
-
 "enable_logging" = "Bật nhật ký";
-
-"offline_place_page_more_information" = "Kết nối đến Internet để xem thêm thông tin về địa điểm này.";
-
-"failed_load_information" = "Không thể tải thông tin.";
 
 /* Settings: "Send general feedback" button */
 "feedback_general" = "Phản hồi chung";
@@ -1556,8 +1002,6 @@
 
 "whatsnew_transliteration_title" = "Chuyển ngữ sang chữ Latinh";
 
-"yandex_taxi_title" = "Yandex.Taxi";
-
 "learn_more" = "Tìm hiểu thêm";
 
 "core_exit" = "Lối ra";
@@ -1568,75 +1012,19 @@
 
 "button_exit" = "Thoát";
 
-"settings_device_memory" = "Bộ nhớ thiết bị";
-
-"settings_card_memory" = "Bộ nhớ thẻ";
-
-"settings_storage_available" = "%s trống";
-
-"toast_location_permission_denied" = "Quyền định vị của ứng dụng bị từ chối";
-
-"button_use" = "Sử dụng";
-
 "planning_route_manage_route" = "Quản lý lộ trình";
 
 "button_plan" = "Kế hoạch";
-
-"button_add" = "Thêm";
 
 "placepage_remove_stop" = "Xóa";
 
 "planning_route_remove_title" = "Kéo vào đây để xóa";
 
-"dialog_change_start_point_message" = "Thay điểm bắt đầu cho vị trí hiện tại?";
-
-"button_replace" = "Thay thế";
-
 "placepage_add_stop" = "Thêm điểm dừng";
-
-/* Only ru/en are needed */
-"subtitle_rent" = "Rent";
-
-/* Only ru/en are needed */
-"rub_month" = "RUB/month";
-
-/* Only ru/en are needed */
-"room" = "%s-room apt.";
-
-/* Only ru/en are needed */
-"real_estate" = "Real estate";
-
-"add_my_position" = "Thêm vị trí của tôi";
-
-"choose_start_point" = "Chọn một điểm bắt đầu";
-
-"choose_destination" = "Chọn một điểm đến";
 
 "preloader_viator_button" = "Tìm hiểu thêm";
 
-"start_from_my_position" = "Bắt đầu từ";
-
-"profile_authorization_title" = "Đăng nhập với";
-
-"profile_authorization_message" = "Dễ dàng đăng nhập chỉ trong một vài giây mà không cần tên người dùng và mật khẩu";
-
 "profile_authorization_error" = "Rất tiếc, đã có lỗi xảy ra. Hãy thử đăng nhập lại.";
-
-"service" = "Dịch vụ";
-
-"atmosphere" = "Không khí";
-
-"value_for_money" = "Đáng đồng tiền";
-
-"experience" = "Trải nghiệm";
-
-"assortment" = "Phân loại";
-
-"expertise" = "Chuyên môn";
-
-"equipment" = "Thiết bị";
-
-"quality" = "Chất lượng";
 
 "dialog_error_storage_title" = "Vấn đề truy cập ổ lưu trữ";
 
@@ -1644,17 +1032,7 @@
 
 "setting_emulate_bad_storage" = "Giả lập ổ lưu trữ hỏng";
 
-"directions_finish" = "Điểm đến";
-
-"directions_on_foot" = "Đi bộ %s";
-
 "core_entrance" = "Lối vào";
-
-"coffee" = "Cà phê";
-
-"cleanliness" = "Sạch sẽ";
-
-"crowdedness" = "Đông đúc";
 
 "error_enter_correct_name" = "Vui lòng nhập một tên chính xác";
 
@@ -1673,11 +1051,9 @@
 
 "downloader_percent" = "%s (%s / %s)";
 
-"downloader_process" = "Tải về %s...";
+"downloader_process" = "Tải về %s…";
 
-"downloader_applying" = "Áp dụng %s...";
-
-"dialog_message_transit_not_found_connection" = "Xây dựng lộ trình trong một mạng chuyển tiếp";
+"downloader_applying" = "Áp dụng %s…";
 
 "bookmarks_error_message_share_general" = "Không thể chia sẻ do lỗi ứng dụng";
 
@@ -1695,17 +1071,7 @@
 
 "bookmarks_error_message_list_name_already_taken" = "Vui lòng chọn một tên khác";
 
-"bookmarks_error_title_list_name_too_long" = "Tên này quá dài";
-
-"bookmarks_error_message_list_name_too_long" = "Vui lòng chọn một tên khác";
-
-"please_wait" = "Vui lòng chờ...";
-
-"phone_number" = "Số điện thoại";
-
-"notification_unsent_reviews_title" = "Bạn có một số bài đánh giá chưa được đánh giá";
-
-"notification_unsent_reviews_message" = "Vui lòng đăng nhập để chia sẻ bài đánh giá với các khách du lịch khác";
+"please_wait" = "Vui lòng chờ…";
 
 "profile" = "Hồ sơ OpenStreetMap";
 
@@ -1719,49 +1085,13 @@
 
 "bookmarks_convert_error_message" = "Một số tệp không được chuyển đổi.";
 
-"converting" = "Đang chuyển đổi...";
-
-"wn_reinvented_bookmarks_title" = "Chúng tôi đã tạo lại dấu trang!";
-
-"wn_reinvented_bookmarks_message" = "Bạn có thể sao lưu dấu trang, tạo danh sách... Thật tuyệt vời...";
-
-"bookmarks_restore" = "Khôi phục dấu trang";
-
-"bookmarks_restore_process" = "Đang khôi phục...";
-
 "bookmarks_restore_title" = "Khôi phục phiên bản này?";
 
-"bookmarks_restore_message" = "Dấu trang của bạn sẽ khôi phục từ %s (%s)";
-
-"bookmarks_restore_empty_title" = "Bạn không có bản sao lưu";
-
-"bookmarks_restore_empty_message" = "Máy chủ không tìm thấy các bản sao lưu được tạo trước đó";
-
 "common_check_internet_connection_dialog_title" = "Không có kết nối internet";
-
-"error_server_title" = "Lỗi máy chủ";
-
-"error_server_message" = "Đã xảy ra lỗi trên máy chủ, vui lòng thử lại sau";
 
 "error_system_message" = "Đã xảy ra lỗi không xác định";
 
 "restore" = "Khôi phục";
-
-"bookmarks_page_downloaded" = "Đã tải về";
-
-"bookmarks_page_my" = "của tôi";
-
-"routes_and_bookmarks" = "Tuyến đường và dấu trang";
-
-"bookmarks_webview_success_toast" = "Đã tải xuống thành công dấu trang";
-
-"cached_bookmarks_placeholder_title" = "Tải xuống các địa điểm mới";
-
-"cached_bookmarks_placeholder_subtitle" = "Nhấn nút để tải xuống hàng ngàn địa điểm và tuyến đường thú vị được tạo bởi người dùng Organic Maps. Bạn sẽ cần kết nối internet.";
-
-"downloader_download_routers" = "Tải dấu trang xuống";
-
-"bookmarks_groups_cached" = "Danh sách đã tải xuống";
 
 "subtittle_opt_out" = "Thiết lập theo dõi";
 
@@ -1769,29 +1099,15 @@
 
 "crash_reports_description" = "Chúng tôi có thể sử dụng dữ liệu của bạn để cải thiện trải nghiệm trên Organic Maps. Thay đổi sẽ có hiệu lực sau khi bạn khởi động lại ứng dụng.";
 
-"opt_out_help_ios_1" = "Thiết bị di động của bạn có thể cung cấp cài đặt \"\"Giới hạn theo dõi quảng cáo\"\" hoặc \"\"Chọn không tham gia quảng cáo dựa trên sở thích\"\".";
-
-"opt_out_help_ios_2" = "iOS 9 hoặc lớn hơn";
-
-"opt_out_help_ios_3" = "Đến Cài đặt → Bảo mật → Quảng cáo → Bật cài đặt \"\"Giới hạn theo dõi quảng cáo\"\"";
-
-"opt_out_help_android" = "Thiết bị di động của bạn có thể cung cấp cài đặt \"\"Giới hạn theo dõi quảng cáo\"\" hoặc \"\"Chọn không tham gia quảng cáo dựa trên sở thích\"\".\n\nĐối với Android và Google Play Services phiên bản 4.0 trở lên:\nCài đặt → Google → Quảng cáo → Chọn không tham gia Quảng cáo dựa trên sở thích\ n\nCài đặt → Google → Tài khoản Google → Thông tin cá nhân và bảo mật → Cài đặt quảng cáo → Cá nhân hóa quảng cáo";
-
 "privacy_policy" = "Chính sách bảo mật";
 
 "terms_of_use" = "Điều khoảng sử dụng";
-
-"backup_notification_failed" = "Sao lưu dấu trang của bạn đã bị tạm ngưng. Đăng nhập để bật lại.";
 
 "button_layer_traffic" = "Giao thông";
 
 "button_layer_subway" = "Xe điện ngầm";
 
 "layers_title" = "Các lớp bản đồ";
-
-"layers_message" = "Sử dụng các lớp bản đồ để hiển thị tình trạng giao thông, bản đồ tàu điện ngầm và các thông tin hữu ích khác";
-
-"button_layer_got_it" = "Đã hiểu";
 
 "subway_data_unavailable" = "Bản đồ tàu điện ngầm không khả dụng";
 
@@ -1803,39 +1119,13 @@
 
 "title_error_downloading_bookmarks" = "Đã xảy ra lỗi";
 
-"subtitle_error_downloading_bookmarks" = "Dấu trang chưa được tải xuống";
-
-"error_already_downloaded" = "Danh sách này đã được tải về";
-
 "popular_place" = "Popular";
-
-"download_routes" = "Download routes";
-
-"bookmarks_downloaded_title" = "Bookmarks have been downloaded successfully";
-
-"bookmarks_downloaded_subtitle" = "Press ‘View on map’ to explore new places from the list";
-
-"why_support" = "Tại sao hỗ trợ Organic Maps?";
-
-"why_support_item1" = "We respect your privacy: there are zero trackers in the app, and we are open source";
-
-"why_support_item2" = "You help us to improve Organic Maps";
-
-"why_support_item3" = "Bạn giúp chúng tôi cải thiện bản đồ mở OpenStreetMap.org";
-
-"channels_map_update" = "Cập nhật bản đồ";
-
-"server_unavailable_title" = "Máy chủ không khả dụng";
-
-"sharing_options" = "Chia sẻ lựa chọn";
 
 "export_file" = "Xuất tập tin";
 
 "list_settings" = "Cài đặt danh sách";
 
 "delete_list" = "Xóa danh sách";
-
-"hide_from_map" = "Ẩn từ bản đồ";
 
 "public_access" = "Truy cập công khai";
 
@@ -1845,40 +1135,11 @@
 
 "bookmark_category_description_hint" = "Đánh vào một mô tả (văn bản hoặc html)";
 
-/* FIXME */
-"bookmarks_public_access" = "bookmarks_public_access";
-
-/* FIXME */
-"bookmarks_link_access" = "bookmarks_link_access";
-
-/* FIXME */
-"bookmarks_private_access" = "bookmarks_private_access";
-
 "not_shared" = "Riêng tư";
-
-"direct_link_progress_text" = "Đang tải tập tin của bạn…";
-
-"direct_link_success" = "Liên kết đã được tạo";
-
-"send_a_link_btn" = "Gửi cho tôi liên kết";
-
-"upload_error_toast" = "Đã xảy ra lỗi trong khi tải lên tập tin của bạn";
 
 "tags_loading_error_subtitle" = "Đã xảy ra lỗi khi tải thẻ, vui lòng thử lại";
 
-"unable_upload_errorr_title" = "Tải tập tin lên không thành công";
-
-"unable_upload_error_subtitle_edited" = "Tập tin này đã được chỉnh sửa qua ứng dụng web";
-
-"unable_upload_error_subtitle_broken" = "Tập tin này bị hỏng và không thể tải lên được. Vui lòng tải lên một tập tin khác.";
-
-"contact" = "Liên hệ";
-
-"download_button" = "Tải";
-
 "speedcams_alert_title" = "Tăn tốc độ máy ảnh";
-
-"speedcams_alert_subtitle" = "Cảnh báo về giới hạn tốc độ";
 
 "speedcam_option_auto" = "Tự động";
 
@@ -1886,18 +1147,10 @@
 
 "speedcam_option_never" = "Không bao giờ";
 
-"bookmark_description_title" = "Mô tả dấu trang";
-
 "place_description_title" = "Mô tả Địa điểm";
 
 /* this text will be shown in application notification preferences opposite checkbox which enable/disable downloader notifications. Devices on Android 8+ are affected. */
 "notification_channel_downloader" = "Trình tải xuống bản đồ";
-
-"share_bookmarks_email_body_link" = "Xin chào!\n\nĐây là liên kết nơi bạn có thể tải xuống dấu trang của mình: %s. Mở danh sách qua Organic Maps và tận hưởng chuyến đi của bạn!\n\nNhận đơn đăng ký: https://omaps.app/get?kmz";
-
-"warning_speedcams_title" = "Thanh điều hướng sẽ cảnh báo bạn về máy ảnh khi bạn vượt quá giới hạn tốc độ %d km/h";
-
-"warning_speedcams_subtitle" = "Hãy nhớ lái xe quy định của đất nước bạn đang đi du lịch đến.";
 
 "speedcams_notice_message" = "Tự động - Cảnh báo về speedcam nếu có nguy cơ vượt quá giới hạn tốc độ\nLuôn luôn - Luôn cảnh báo về speedcams\nKhông bao giờ - Không bao giờ cảnh báo về speedcams";
 
@@ -1913,23 +1166,7 @@
 
 "enable_logging_warning_message" = "Tùy chọn này được kích hoạt để ghi nhật ký đăng nhập cho mục đích chẩn đoán. Điều này sẽ giúp nhóm chúng tôi làm rõ các vấn đề liên quan đến ứng dụng. Hãy bật tùy chọn này chỉ khi nào có yêu cầu hỗ trợ từ Organic Maps.";
 
-"html_error_upload_message_try_again" = "Vui lòng kiểm tra kết nối internet và thử lại";
-
-"html_error_upload_title_try_again" = "Không có kết nối internet";
-
-"notification_leave_review_v2_android_short_title" = "Hãy để lại nhận xét và giúp khách du lịch!";
-
-"megafon" = "Say goodbye to roaming!";
-
-"notifications_illegal_alert_disable_button" = "Tắt thông báo";
-
 "access_rules_author_only" = "Chỉnh sửa trực tuyến";
-
-"privacy_settings_menu" = "Cài đặt bảo mật";
-
-"unable_upadate_error_title" = "Cập nhận hướng dẫn không thành công";
-
-"unable_upadate_error_message" = "Xuất hiện lỗi khi cập nhật. Hãy kiểm tra lại những thay đổi và thử lại lần nữa";
 
 "driving_options_title" = "Thiết lập đi vòng";
 
@@ -1951,94 +1188,19 @@
 
 "change_driving_options_btn" = "Thiết lập đường đi tránh đã được bật";
 
-"toll_road" = "Đường trả phí";
-
-"unpaved_road" = "Đường đất";
-
-"ferry_crossing" = "Bến phà";
-
-"operated_by" = "Tạo được \"%s\"";
-
 "avoid_toll_roads_placepage" = "Tránh đường trả phí";
 
 "avoid_unpaved_roads_placepage" = "Tránh đường đất";
 
 "avoid_ferry_crossing_placepage" = "Tránh bến phà";
 
-"type.cuisine.uzbek" = "Ẩm thực của Uzbekistan";
-
-"trip_start" = "Đi nào";
-
-"pick_destination" = "Mục đích";
-
-"follow_my_position" = "Định tâm";
-
-"search_results" = "Kết quả tìm kiếm";
-
-"then_turn" = "Sau đó";
-
-"redirect_route_alert" = "Bạn có muốn tạo lại tuyến không?";
-
-"redirect_route_yes" = "Có";
-
-"redirect_route_no" = "Không";
-
-"trip_finished" = "Bạn đã tới nơi!";
-
-"keyboard_availability_alert" = "Bàn phím không khả dụng trong thời gian di chuyển";
-
-"dialog_routing_change_start_carplay" = "Không thể tạo tuyến đường từ địa điểm hiển tại";
-
-"dialog_routing_change_end_carplay" = "Không thể tạo tuyến đường tới điểm kết cuối. Hãy chọn điểm khác";
-
-"dialog_routing_check_gps_carplay" = "Không có tín hiệu GPS. Hãy đến vị trí có không gian mở";
-
-"dialog_routing_unable_locate_route_carplay" = "Không thể tạo tuyến đường. Hãy chọn những điểm khác cho tuyến đường";
-
-"dialog_routing_download_files_carplay" = "Để tạo tuyến đường, hãy tải xuống các bản đồ còn thiếu về thiết bị";
-
-"dialog_routing_system_error_carplay" = "Đã xảy ra lỗi. Khởi động lại ứng dụng";
-
-"dialog_routing_rebuild_from_current_location_carplay" = "Tuyến đường sẽ được tạo lại từ vị trí hiện tại của bạn";
-
-"dialog_routing_rebuild_for_vehicle_carplay" = "Tuyến đường sẽ được thay đổi thành tuyến dành cho xe ô tô";
-
 "ok" = "Ok";
-
-"avoid_unpaved_carplay_1" = "Trừ đườg đất";
-
-"avoid_unpaved_carplay_2" = "Trừ khôg trnhựa";
-
-"avoid_ferry_carplay_1" = "Không có phà";
-
-"avoid_ferry_carplay_2" = "Trừ phà";
-
-"avoid_tolls_carplay_1" = "Khôg đgcóphí";
-
-"avoid_tolls_carplay_2" = "Trừ đg có phí";
-
-"speedcams_alert_title_carplay_1" = "Сam tốc độ";
-
-"speedcams_alert_title_carplay_2" = "Cảnh báo tốc độ";
-
-"download_map_carplay" = "Vui lòng tải xuống bản đồ trong ứng dụng Organic Maps trên thiết bị của bạn";
-
-"carplay_roundabout_exit" = "Lối ra %s của vòng xuyến";
 
 /* max. 10 symbols, both iOS and Android */
 "sort" = "Sắp xếp…";
 
 /* Android, title, max 20-22 symbols */
 "sort_bookmarks" = "Sắp xếp dấu trang";
-
-/* iOS */
-"sort_default" = "Sắp xếp theo mặc định";
-
-"sort_type" = "Sắp xếp theo kiểu";
-
-"sort_distance" = "Sắp xếp theo khoảng cách";
-
-"sort_date" = "Sắp xếp theo ngày";
 
 /* Android */
 "by_default" = "Theo mặc định";
@@ -2052,63 +1214,7 @@
 /* Android */
 "by_date" = "Theo ngày";
 
-"week_ago_sorttype" = "Tuần trước";
-
-"month_ago_sorttype" = "Tháng trước";
-
-"moremonth_ago_sorttype" = "Hơn một tháng trước";
-
-"moreyear_ago_sorttype" = "Hơn một năm trước";
-
-"near_me_sorttype" = "Ở gần tôi";
-
-"others_sorttype" = "Khác";
-
-"food_places" = "Đồ ăn";
-
-"tourist_places" = "Danh lam thắng cảnh";
-
-"museums" = "Bảo tàng";
-
-"parks" = "Công viên";
-
-"swim_places" = "Bơi lội";
-
-"mountains" = "Núi non";
-
-"animals" = "Động vật";
-
-"hotels" = "Khách sạn";
-
-"buildings" = "Tòa nhà";
-
-"money" = "Tiền";
-
-"shops" = "Cửa hàng";
-
-"parkings" = "Bãi đậu xe";
-
-"fuel_places" = "Trạm xăng dầu";
-
-"water" = "Nước";
-
-"medicine" = "Y tế";
-
 "search_in_the_list" = "Tìm trong danh sách";
-
-"view_on_map_bookmarks" = "Trên bản đồ";
-
-"more_bookmarks" = "Thêm…";
-
-"no_items_found" = "Không tìm thấy gì cả";
-
-/* Android, max 18 symbols */
-"bookmarks_edit_list" = "Chỉnh sửa";
-
-/* Android, max 18 symbols */
-"bookmarks_delete_list" = "Xóa dánh sách";
-
-"religious_places" = "Những nơi tôn nghiêm";
 
 "select_list" = "Chọn danh sách";
 
@@ -2118,26 +1224,13 @@
 
 "dialog_pedestrian_route_is_long_message" = "Hãy chọn điểm đầu hoặc điểm cuối của tuyến gần với bến Metro";
 
-/* Failed planning SUBWAY route message in navigation view */
-"routing_planning_error_subway_special" = "Lỗi xây dựng tuyến Metro";
-
 "button_layer_isolines" = "Độ cao";
-
-"tips_map_layers_title_countour" = "Đường độ cao ngoại tuyến trong Organic Maps!";
-
-"tips_map_layers_message_countour" = "Đường độ cao giúp lên kế hoạch du lịch hòa mình với thiên nhiên và không bị lạc khi di chuyển";
 
 "isolines_activation_error_dialog" = "Để sử dụng các đường chỉ độ cao, hãy cập nhật hoặc tải xuống bản đồ của khu vực bạn mong muốn";
 
 "isolines_location_error_dialog" = "Đường hiển thị độ cao hiện chưa khả dụng tại khu vực này";
 
 "elevation_profile_diff_level" = "Mức độ phức tạp";
-
-"elevation_profile_diff_level_easy" = "Dễ";
-
-"elevation_profile_diff_level_moderate" = "Trung bình";
-
-"elevation_profile_diff_level_hard" = "Khó";
 
 "elevation_profile_ascent" = "Đi lên";
 
@@ -2147,25 +1240,13 @@
 
 "elevation_profile_maxaltitude" = "Độ cao tối đa";
 
-"elevation_profile_m" = "m";
-
 "elevation_profile_difficulty" = "Độ khó";
 
 "elevation_profile_distance" = "Khoảng cách";
 
-"elevation_profile_km" = "km";
-
 "elevation_profile_time" = "Giờ:";
 
-"elevation_profile_hours" = "h.";
-
-"elevation_profile_minutes" = "ph";
-
 "isolines_toast_zooms_1_10" = "Phóng bản đồ để nhìn rõ đường đồng mức";
-
-"downloader_updating_ios" = "Cập nhật";
-
-"downloader_loading_ios" = "Tải xuống";
 
 "key_information_title" = "Thông tin chìa khóa";
 

--- a/iphone/Maps/LocalizedStrings/vi.lproj/Localizable.stringsdict
+++ b/iphone/Maps/LocalizedStrings/vi.lproj/Localizable.stringsdict
@@ -9,21 +9,6 @@
 
 <!-- ********** Strings for downloading map from search **********/ -->
 
-  <key>bookmarks_places</key>
-  <dict>
-    <key>NSStringLocalizedFormatKey</key>
-    <string>%#@value@</string>
-    <key>value</key>
-    <dict>
-      <key>NSStringFormatSpecTypeKey</key>
-      <string>NSStringPluralRuleType</string>
-      <key>NSStringFormatValueTypeKey</key>
-      <string>d</string>
-      <key>other</key>
-      <string>%d dấu trang</string>
-    </dict>
-  </dict>
-
   <key>bookmarks_detect_message</key>
   <dict>
     <key>NSStringLocalizedFormatKey</key>
@@ -38,21 +23,6 @@
       <string>%d dã tìm thấy một tệp. Bạn sẽ thấy nó sau khi chuyển đổi.</string>
       <key>other</key>
       <string>%d files were found. You can see them after conversion.</string>
-    </dict>
-  </dict>
-
-  <key>bookmarks_objects</key>
-  <dict>
-    <key>NSStringLocalizedFormatKey</key>
-    <string>%#@value@</string>
-    <key>value</key>
-    <dict>
-      <key>NSStringFormatSpecTypeKey</key>
-      <string>NSStringPluralRuleType</string>
-      <key>NSStringFormatValueTypeKey</key>
-      <string>d</string>
-      <key>other</key>
-      <string>%s mục tiêu</string>
     </dict>
   </dict>
 

--- a/iphone/Maps/LocalizedStrings/zh-Hans.lproj/Localizable.strings
+++ b/iphone/Maps/LocalizedStrings/zh-Hans.lproj/Localizable.strings
@@ -18,9 +18,6 @@
 /* Button which deletes downloaded country */
 "delete" = "删除";
 
-/* Button "do not interrupt download" if user touched actively downloading country */
-"do_nothing" = "继续";
-
 "download_maps" = "下载地图";
 
 /* Settings/Downloader - info for country when download fails */
@@ -28,9 +25,6 @@
 
 /* Settings/Downloader - info for country which started downloading */
 "downloading" = "下载…";
-
-/* Settings/Downloader - size string, only strings different from English should be translated */
-"kb" = "kB";
 
 /* Choose measurement on first launch alert - choose metric system button */
 "kilometres" = "千米";
@@ -55,17 +49,11 @@
 /* Update maps later/Buy pro version later button text */
 "later" = "稍后";
 
-/* Don't show some dialog any more */
-"never" = "从来不";
-
 /* View and button titles for accessibility */
 "search" = "搜索";
 
 /* Search box placeholder text */
 "search_map" = "搜索地图";
-
-/* Settings/Downloader - info for not downloaded country */
-"touch_to_download" = "轻触下载";
 
 /* Settings/Downloader - 3G download warning dialog confirm button */
 "use_cellular_data" = "是";
@@ -73,20 +61,11 @@
 /* Location services are disabled by user alert - message */
 "location_is_disabled_long_text" = "您目前有此设备的所有位置服务或应用已禁用。请在设置中启用它们。";
 
-/* Location Services are not available on the device alert - message */
-"device_doesnot_support_location_services" = "您的设备不支持位置服务。";
-
 /* View and button titles for accessibility */
 "zoom_to_country" = "在地图上显示";
 
-/* Button text for the button at the center of the screen when the country is not downloaded */
-"country_status_download" = "下载地图\n(^ ^)";
-
 /* Button text for the button at the center of the screen when the country is not downloaded and the size should not be shown */
 "country_status_download_without_size" = "下载地图";
-
-/* Button text for the button at the center of the screen when the country is not downloaded */
-"country_status_download_without_routing" = "下载不带路线的地图\n(^ ^)";
 
 /* Message to display at the center of the screen when the country download has failed */
 "country_status_download_failed" = "下载失败了";
@@ -96,19 +75,13 @@
 
 "about_menu_title" = "关于 Organic Maps";
 
-"downloaded_touch_to_delete" = "下载了(%@),轻触删除";
-
 "connection_settings" = "连接设置";
-
-"download_mb_or_kb" = "下载%@";
 
 "close" = "关闭";
 
 "unsupported_phone" = "硬件加速的 OpenGL 是必需的。遗憾的是您 的设备不支持。";
 
 "download" = "下载";
-
-"external_storage_is_not_available" = "缺少包含已下载地图的 SD 卡/ USB 储存设备";
 
 "disconnect_usb_cable" = "请断开 USB 线或插入存储卡以使用 Organic Maps";
 
@@ -117,8 +90,6 @@
 "not_enough_memory" = "没有足够的内存来启动应用程序";
 
 "download_resources" = "在您开始前请让我们下载通用世界地 图至您的设备中。\n它需要%@的 数据。";
-
-"getting_position" = "获取当前位置";
 
 "download_resources_continue" = "前往地图";
 
@@ -140,23 +111,14 @@
 /* Add New Bookmark Set dialog title */
 "add_new_set" = "添加新的集合";
 
-/* Place Page - Add To Bookmarks button */
-"add_to_bookmarks" = "添加至书签";
-
 /* Bookmark Color dialog title */
 "bookmark_color" = "书签颜色";
 
 /* Add Bookmark Set dialog - hint when set name is empty */
 "bookmark_set_name" = "书签集名称";
 
-/* Bookmark Sets dialog title */
-"bookmark_sets" = "书签集";
-
 /* Bookmarks - dialog title */
 "bookmarks" = "书签";
-
-/* Add bookmark dialog - bookmark color */
-"color" = "色彩";
 
 /* Default bookmarks set name */
 "core_my_places" = "我的位置";
@@ -167,14 +129,8 @@
 /* Editor title above street and house number */
 "address" = "地址";
 
-/* Place Page - Remove Pin button */
-"remove_pin" = "移除图钉";
-
 /* Add bookmark dialog - bookmark set, Bookmarks dialog - Bookmark set cell */
 "set" = "集合";
-
-/* Text hint in Bookmarks dialog when no any bookmarks are added */
-"bookmarks_usage_hint" = "您还没有书签。\n在地图任何位置轻触以添 加一个书签。\n其他来源的书签也可载入并 显示在 Organic Maps 中。从邮件、 Dropbox 或 weblink 中打开存储有图钉的 KML/KMZ 文 件。";
 
 /* Settings button in system menu */
 "settings" = "设置";
@@ -191,26 +147,11 @@
 /* Ask to wait user several minutes (some long process in modal dialog). */
 "wait_several_minutes" = "这可能需要几分钟的时间。\n请稍候…";
 
-/* Show bookmarks from this category on a map or not */
-"visible" = "可见";
-
-/* Toast which is displayed when GPS has been deactivated */
-"gps_is_disabled_long_text" = "GPS 已禁用。请在设置中启用它。";
-
 /* Measurement units title in settings activity */
 "measurement_units" = "测量单位";
 
 /* Detailed description of Measurement Units settings button */
 "measurement_units_summary" = "选择英里或公里";
-
-/* Do search in all sources */
-"search_mode_all" = "到处";
-
-/* Do search near my position only */
-"search_mode_nearme" = "靠近我的";
-
-/* Do search in current viewport only */
-"search_mode_viewport" = "在屏幕上";
 
 /* Search category for cafes, bars, restaurants */
 "eat" = "在哪儿吃";
@@ -266,14 +207,8 @@
 /* Search category */
 "police" = "警察";
 
-/* String in search result list, when nothing found */
-"no_search_results_found" = "没有找到结果";
-
 /* Notes field in Bookmarks view */
 "description" = "注释";
-
-/* Button text */
-"share_by_email" = "邮件分享";
 
 /* Email Subject when sharing bookmarks category */
 "share_bookmarks_email_subject" = "Organic Maps 书签已与您共享";
@@ -295,26 +230,11 @@
 /* Warning message when doing search around current position */
 "unknown_current_position" = "您的位置尚未确定";
 
-/* Warning message when location country isn't downloaded during search (see also download_location_map_proposal). */
-"download_location_country" = "下载您所在位置的国家 (%@)";
-
-/* Warning message when viewport country isn't downloaded during search */
-"download_viewport_country_to_search" = "下载您所搜索的国家 (%@)";
-
 /* Alert message that we can't run Map Storage settings due to some reasons. */
 "cant_change_this_setting" = "抱歉,地图存储设置目前被禁用";
 
 /* Alert message that downloading is in progress. */
 "downloading_is_active" = "国家下载进行中。";
-
-/* Message that will be shown in alert view, when we ask user to leave review on App Store */
-"appStore_message" = "希望您喜欢使用 Organic Maps! 若确实喜欢, 请在应用商店对此应用进行打分和点评。这 花不了一分钟但却可以实在地帮助我们。感 谢您的支持!";
-
-/* No, thanks */
-"no_thanks" = "不,谢谢";
-
-/* Share one specific bookmark using SMS, %1$@ contains om:// and %2$@ https://omaps.app link. @NOTE non-ascii symbols in the link will result in max 70 characters SMS instead of 140. */
-"bookmark_share_sms" = "嘿,在 Organic Maps 上查看我标注的图钉吧! %1$@ 或%2$@ 未安装离线地图?在此下 载: https://omaps.app/get";
 
 /* Share my position using SMS, %1$@ contains om:// and %2$@ https://omaps.app link WITHOUT NAME. @NOTE non-ascii symbols in the link will result in max 70 characters SMS instead of 140. */
 "my_position_share_sms" = "嘿,在 Organic Maps 上查看我目前的位置 吧!%1$@ 或%2$@ 未安装离线地图?在此 下载: https://omaps.app/get";
@@ -328,23 +248,11 @@
 /* Share my position using EMail, %1$@ is om:// and %2$@ is https://omaps.app link WITHOUT NAME */
 "my_position_share_email" = "嗨,\n\n我现在在这:%1$@。点击此链 接%2$@或此链接 %3$@来查看在地图上的 位置。\n\n谢谢。";
 
-/* Android share by Message/SMS button text (including SMS) */
-"share_by_message" = "通过消息分享";
-
 /* Share button text which opens menu with more buttons, like Message, EMail, Facebook etc. */
 "share" = "分享";
 
-/* iOS share by Message button text (including SMS) */
-"message" = "消息";
-
 /* Share by email button text, also used in editor. */
 "email" = "邮件";
-
-/* Copy Link */
-"copy_link" = "复制链接";
-
-/* Text for the button that returns to caller application */
-"more_info" = "显示更多资讯";
 
 /* Text for message when used successfully copied something */
 "copied_to_clipboard" = "复制到剪贴板:%1$@";
@@ -354,15 +262,6 @@
 
 /* Used for bookmark editing */
 "done" = "完成";
-
-/* Summary for preferences in MWM */
-"yopme_pref_summary" = "选择背屏设置";
-
-/* Title for yopme preferences in MWM */
-"yopme_pref_title" = "背屏设置";
-
-/* Hint for upper-right icon p2b */
-"show_on_backscreen" = "显示在背屏上";
 
 /* Prints version number in About dialog */
 "version" = "版本:%@";
@@ -381,19 +280,11 @@
 
 "share_my_location" = "共享我的位置";
 
-"menu_search" = "搜索";
-
 /* Settings general group in settings screen */
 "prefs_group_general" = "General settings";
 
 /* Settings information group in settings screen */
 "prefs_group_information" = "Information";
-
-/* Settings screen: "Map" category title */
-"prefs_group_map" = "地图";
-
-/* Settings screen: "Miscellaneous" category title */
-"prefs_group_misc" = "其他";
 
 "prefs_group_route" = "导航";
 
@@ -419,9 +310,6 @@
 /* Settings «Map» category: «3D buildings» title */
 "pref_map_3d_buildings_title" = "3D 建筑";
 
-/* Settings «Map» category: «3D buildings» summary */
-"pref_map_3d_buildings_subtitle" = "增加电池消耗";
-
 /* Settings «Route» category: «Tts enabled» title */
 "pref_tts_enable_title" = "语音指导";
 
@@ -433,8 +321,6 @@
 
 /* Title for "Other" section in TTS settings. */
 "pref_tts_other_section_title" = "其他";
-
-"pref_tts_how_to_set_up_voice" = "如何设置语音";
 
 /* Settings «Map» category: «Record track» title */
 "pref_track_record_title" = "最近的路径";
@@ -455,56 +341,7 @@
 
 "recent_track_help_text" = "它允许您记录一定时间段内的旅行路径，并在地图上查看。请注意：激活此功能会导致电量消耗加快。过期后，轨迹将从地图中自动移除。";
 
-"pref_track_ios_caption" = "近期轨迹显示您的行进道路。";
-
-"pref_track_ios_subcaption" = "请选择保存轨迹的时间范围。";
-
-"placepage_distance" = "距离";
-
-"placepage_coordinates" = "坐标";
-
-"placepage_unsorted" = "未分类";
-
 "search_show_on_map" = "在地图上查看";
-
-/* Used to warn user when fixing KitKat issue */
-"bookmark_move_fail" = "我们需要移动您的书签到内部存储器,但没 有可用的空间。请释放存储,否则书签将不 可用。";
-
-/* Used in More Apps menu */
-"free" = "免费";
-
-/* Used in More Apps menu */
-"buy" = "购买";
-
-/* 1st search button-like result */
-"search_on_map" = "在地图上搜索";
-
-/* toast with an error */
-"no_route_found" = "未找到路线";
-
-/* route title */
-"route" = "路线";
-
-/* category title */
-"routes" = "路线";
-
-/* text of notification */
-"download_map_notification" = "下载您所在地方的地图";
-
-/* text of notification */
-"pro_version_is_free_today" = "完整版Organic Maps是免费的今天! 立刻下载并告诉您的好友。";
-
-/* Dialog for transferring maps from lite to pro. */
-"move_lite_maps_to_pro" = "我们正在将您从Organic Maps Lite 下载的地图传输至 Organic Maps。这可能需要几分钟的时间。";
-
-/* Message to display when maps moved. */
-"move_lite_maps_to_pro_ok" = "您下载的地图已成功传输至 Organic Maps。";
-
-/* Message to display when maps move failed. */
-"move_lite_maps_to_pro_failed" = "您的地图传输失败。请删除 Organic Maps Lite，然后再次下载地图。";
-
-/* Text in menu */
-"settings_and_more" = "设置及更多";
 
 /* Text in menu */
 "website" = "网站";
@@ -527,14 +364,8 @@
 /* Text in menu */
 "openstreetmap" = "OpenStreetMap";
 
-/* Text in menu */
-"contact_us" = "联系我们";
-
 /* Settings: Send feedback button and dialog title */
 "feedback" = "反馈";
-
-/* Text in menu */
-"subscribe_to_news" = "订阅我们的新闻";
 
 /* Text in menu */
 "rate_the_app" = "为该应用打分";
@@ -548,15 +379,6 @@
 /* Text in menu */
 "report_a_bug" = "报告漏洞";
 
-/* Email subject */
-"subscribe_me_subject" = "请帮我订阅Organic Maps简报";
-
-/* Email body */
-"subscribe_me_body" = "我想率先了解最新新闻、更新及促销活动。订阅可随时取消。";
-
-/* About text */
-"about_text" = "Organic Maps 提供全球所有国家和所有城市的最快速的离线地图。充满自信地出行：无论您在哪，Organic Maps都能够帮助您在地图上找到您自己的位置，找到最近的餐馆、酒店、银行、加油站，等等。无需网络连接。\n\n我们始终在为添加新功能而努力，并希望能够听到您对我们应如何改进Organic Maps的想法。若您在使用本应用时遇到任何问题，请随时联系我们：support@organicmaps.app。我们会回复每一条请求！\n\n您喜欢Organic Maps并希望支持我们吗？以下为一些简单且完全免费的方法：\n\n- 在您的App Market发表评论\n- 在我们的Facebook页面http://www.facebook.com/OrganicMaps赞我们\n- 或者向您的母亲、朋友，以及同事介绍Organic Maps :)\n\n感谢您与我们在一起。非常感谢您的支持。\n\n附言：我们从OpenStreetMap获取地图信息，这是一个类似于Wikipedia的地图绘制项目，能够让用户创建并编辑地图。若您看到地图上缺少了什么或者有什么错误，可以直接在https://www.openstreetmap.org上进行纠正。在下一个版本发布时，您做出的更改便会出现在Organic Maps应用中。";
-
 /* Alert text */
 "email_error_body" = "电子邮件客户端尚未建立。请配置或使用任何其他方式与我们联系%@";
 
@@ -569,12 +391,6 @@
 /* Search category */
 "wifi" = "无线网络";
 
-/* Update map suggestion */
-"routing_map_outdated" = "请更新地图以创建一条路线。";
-
-/* Update maps suggestion */
-"routing_update_maps" = "使用新版本的Organic Maps可以创建从您的当前位置至一个目的地的路线。请更新地图以使用该功能。";
-
 /* Update all button text */
 "downloader_update_all_button" = "更新全部";
 
@@ -583,9 +399,6 @@
 
 /* Downloaded maps category */
 "downloader_downloaded_subtitle" = "已下载";
-
-/* Downloaded maps category */
-"downloader_available_maps" = "可用";
 
 /* Country queued for download */
 "downloader_queued" = "已排队";
@@ -598,17 +411,6 @@
 
 "downloader_downloading" = "正在下载：";
 
-"downloader_search_results" = "找到";
-
-/* Disclaimer message */
-"routing_disclaimer" = "在Organic Maps应用中制定路线时请谨记以下 几点：\n\n  - 建议路线仅可当作推荐路线。\n - 路况、交通规则以及标志应优先于导航建议。\n - 地图可能会不正确或者过时，路线也可能不是以最佳可能方式制定的。\n\n  行车安全，请照顾好您自己！";
-
-/* Outdated maps category */
-"downloader_outdated_maps" = "过时的";
-
-/* Up to date maps category */
-"downloader_uptodate_maps" = "最新的";
-
 /* Status of outdated country in the list */
 "downloader_status_outdated" = "下载";
 
@@ -618,49 +420,14 @@
 /* Displayed in a dialog that appears when a user tries to delete a map while the app is in the follow route mode */
 "downloader_delete_map_while_routing_dialog" = "要删除地图，请停止导航。";
 
-/* Show when user try build route, but we don't know where he */
-"routing_failed_unknown_my_position" = "当前地点未定。请明确地点以创建路线。";
-
-/* Show if use has not routing file, or InconsistentMWMandRoute */
-"routing_failed_has_no_routing_file" = "需要额外的数据才能创建路线。开始下载吗？";
-
-/* StartPointNotFound */
-"routing_failed_start_point_not_found" = "无法计算路线。没有在您起点附近的路。";
-
-/* EndPointNotFound */
-"routing_failed_dst_point_not_found" = "无法计算路线。没有在您终点附近的路。";
-
 /* PointsInDifferentMWM */
 "routing_failed_cross_mwm_building" = "路程只能完全处在同一地图里时才能被创建。";
-
-/* RouteNotFound */
-"routing_failed_route_not_found" = "找不到所选起点和终点间的路程。请选择不同的起点或终点。";
-
-/* InternalError */
-"routing_failed_internal_error" = "出现内部错误。请尝试删除并再次下载地图。如果还有问题请联系我们：support@organicmaps.app。";
-
-/* Context menu item for downloader. */
-"downloader_download_map_and_routing" = "下载地图 + 路线";
-
-/* Context menu item for downloader. */
-"downloader_download_routing" = "下载路线";
-
-/* Context menu item for downloader. */
-"downloader_delete_routing" = "删除路线";
 
 /* Context menu item for downloader. */
 "downloader_download_map" = "下载地图";
 
-"downloader_download_map_no_routing" = "下载不带路线的地图";
-
-/* Button for routing. */
-"routing_go" = "出发！";
-
 /* Item status in downloader. */
 "downloader_retry" = "重复";
-
-/* Item in context menu. */
-"downloader_map_and_routing" = "地图 + 布置路线";
 
 /* Item in context menu. */
 "downloader_delete_map" = "删除地图";
@@ -668,29 +435,11 @@
 /* Item in context menu. */
 "downloader_update_map" = "更新地图";
 
-/* Item in context menu. */
-"downloader_update_map_and_routing" = "更新地图 + 布置路线";
-
-/* Item in context menu. */
-"downloader_map_only" = "只有地图";
-
-/* Toolbar title */
-"toolbar_application_menu" = "Application menu";
-
 /* Preference text */
 "pref_use_google_play" = "使用Google Play服务以获取您的当前位置。";
 
 /* Text for rating dialog */
 "rating_just_rated" = "我刚刚评价了您的应用";
-
-/* Text for rating dialog */
-"rating_user_since" = "我是从%@年起的Organic Maps用户";
-
-/* Text for rating dialog */
-"rating_do_like_maps" = "您喜欢Organic Maps吗？";
-
-/* Text for rating dialog */
-"rating_tap_star" = "点击星星给我们应用评分。";
 
 /* Text for rating dialog */
 "rating_thanks" = "谢谢您！";
@@ -701,23 +450,8 @@
 /* Text for rating dialog */
 "rating_send_feedback" = "发送反馈";
 
-/* Text for g+ dialog */
-"rating_google_plus" = "点击g+向您的朋友们告知这款应用。";
-
 /* Text for routing error dialog */
 "routing_download_maps_along" = "下载沿线地图";
-
-/* Text for routing error dialog */
-"routing_download_map" = "获取地图";
-
-/* Text for routing error dialog */
-"routing_download_map_and_routing" = "下载更新的地图和路线数据，获取所有 Organic Maps 的特色功能。";
-
-/* Text for routing error dialog */
-"routing_get_routing_data" = "获取所需的路线数据";
-
-/* Text for routing error dialog */
-"routing_get_additional_data" = "更多数据，从您的位置创建路线。";
 
 /* Text for routing error dialog */
 "routing_requires_all_map" = "创建路线需要下载并更新好所有从您的位置到目的地的地图。";
@@ -725,50 +459,15 @@
 /* Text for routing error dialog */
 "routing_not_enough_space" = "空间不够";
 
-/* Text for routing error dialog */
-"routing_download_more_than_avail" = "您需要下载%@ MB，但只有%@ MB空间。";
-
-/* Text for routing error dialog */
-"routing_download_roaming" = "您将使用移动数据下载%@ MB（漫游）。这取决于您的移动数据方案运营商，可能会产生额外的费用。";
-
 /* bookmark button text */
 "bookmark" = "书签";
-
-/* map is not downloaded */
-"not_found_map" = "您地点的地图没有被下载";
 
 /* location service disabled */
 "enable_location_services" = "请启用位置服务";
 
-/* download map */
-"download_map" = "为您的地点下载地图";
-
-/* download map on iPhone */
-"download_map_iphone" = "在您的iPhone上下载当前位置的地图";
-
-/* clear pin */
-"nearby" = "附近的";
-
-/* clear pin */
-"clear_pin" = "清除针";
-
-/* location is undefined */
-"undefined_location" = "当前地点未定。";
-
-/* download country of your location */
-"download_country" = "下载您所在位置的国家";
-
-/* download failed */
-"download_failed" = "下载失败";
-
-/* get the map */
-"get_the_map" = "获取地图";
-
 "save" = "保存";
 
 "edit_description_hint" = "您的描述（文本或html）";
-
-"new_group" = "新群組";
 
 "create" = "创建";
 
@@ -795,30 +494,6 @@
 
 /* pink color */
 "pink" = "粉色";
-
-/* deep purple color */
-"deep_purple" = "暗紫色";
-
-/* light blue color */
-"light_blue" = "天蓝色";
-
-/* cyan color */
-"cyan" = "蓝绿色";
-
-/* teal color */
-"teal" = "碧绿色";
-
-/* lime color */
-"lime" = "青柠";
-
-/* deep orange color */
-"deep_orange" = "深橘色";
-
-/* gray color */
-"gray" = "灰色";
-
-/* blue gray color */
-"blue_gray" = "蓝灰色";
 
 /* Wi-Fi available */
 "WiFi_available" = "是";
@@ -848,13 +523,9 @@
 
 "dialog_routing_location_unknown_turn_on" = "无法定位当前 GPS 坐标。请启用定位服务以计算路线。";
 
-"dialog_routing_location_unknown" = "无法定位当前 GPS 坐标。";
-
 "dialog_routing_download_files" = "下载所需文件";
 
 "dialog_routing_download_and_update_all" = "下载和更新所有地图和预定路径沿途的路线信息，以计算路线。";
-
-"dialog_routing_routes_size" = "路线信息文件";
 
 "dialog_routing_unable_locate_route" = "无法定位路线";
 
@@ -884,21 +555,11 @@
 
 "dialog_routing_try_again" = "请重试";
 
-"dialog_routing_send_error" = "报告问题";
-
-"dialog_routing_if_get_cross_route" = "您是否要创建一条跨越多张地图的更直接路线？";
-
-"dialog_routing_cross_route_is_optimal" = "有一条跨越本地图边缘的更佳路线可用。";
-
 "not_now" = "现在不用";
-
-"dialog_routing_build_route" = "创建";
 
 "dialog_routing_download_and_build_cross_route" = "您是否要下载地图并创建一条跨越多张地图的更佳路线？";
 
 "dialog_routing_download_cross_route" = "下载地图，创建一条跨越此地图边缘的更佳路线。";
-
-"dialog_routing_cross_route_always" = "始终跨越此边界线";
 
 
 /********** Strings for downloading map from search **********/
@@ -906,8 +567,6 @@
 "search_without_internet_advertisement" = "要开始搜索和创建路线，请下载地图，那您就不再需要网络连接了。";
 
 "search_select_map" = "选择地图";
-
-"search_select_other_map" = "选择另一个地图";
 
 /* «Show» context menu */
 "show" = "显示";
@@ -918,17 +577,11 @@
 /* «Rename» context menu */
 "rename" = "重命名";
 
-/* Bottom sheet: expand button (should be short) */
-"bottom_sheet_more" = "更多…";
-
 /* Failed planning route message in navigation view */
 "routing_planning_error" = "路线计划失败";
 
 /* Arrive routing message in navigation view */
 "routing_arrive" = "抵達:%s";
-
-/* Text for routing::RouterResultCode::FileTooOld dialog. */
-"dialog_routing_download_and_update_maps" = "要创建路线，请下载并更新所有沿路线的地图。";
 
 "rate_alert_title" = "喜欢这个应用吗？";
 
@@ -944,19 +597,11 @@
 
 "history" = "历史";
 
-"next_turn_then" = "然后";
-
 "closed" = "已关闭";
-
-"back_to" = "回到 %@";
 
 "search_not_found" = "抱歉，没有找到任何东西。";
 
 "search_not_found_query" = "请尝试其它查询。";
-
-"search_not_found_map" = "请下载您搜索的地图。";
-
-"search_not_found_location" = "下载您当前位置的地图。";
 
 "search_history_title" = "搜索历史";
 
@@ -964,23 +609,12 @@
 
 "clear_search" = "清除历史搜索";
 
-/* Title for settings to enable/disable showcase menu button */
-"showcase_settings_title" = "显示优惠";
-
 /* Place Page link to Wikipedia article (if map object has it). */
 "read_in_wikipedia" = "Wikipedia";
 
-"p2p_route_planning" = "路线计划";
-
 "p2p_your_location" = "您的位置";
 
-"p2p_from" = "出发地点";
-
-"p2p_to" = "目的地点";
-
 "p2p_start" = "开始";
-
-"p2p_planning" = "计划中…";
 
 "p2p_from_here" = "从";
 
@@ -1018,15 +652,9 @@
 
 "editor_correct_mistake" = "纠正错误";
 
-"editor_correct_mistake_message" = "出现编辑错误，请纠正或切换至简单模式。";
-
 "editor_add_select_location" = "位置";
 
 "editor_done_dialog_1" = "您已经改变了世界地图。请不要隐藏这一点！告诉您的朋友们并一起编辑它。";
-
-"editor_done_dialog_2" = "这是您的第二个地图改进。现在您在地图编辑者排行榜中排在第%d名。把它告诉您的朋友们。";
-
-"editor_done_dialog_3" = "您已改进此地图，请把它告诉您的朋友们，并一起编辑此地图。";
 
 "share_with_friends" = "与朋友分享";
 
@@ -1044,20 +672,7 @@
 
 "editor_report_problem_duplicate_place_title" = "重复的地点";
 
-"first_launch_congrats_title" = "Organic Maps已经可用";
-
-"first_launch_congrats_text" = "在世界各地离线搜索和导航，免费。";
-
-"migrate_title" = "重要！";
-
-/* Android uses image instead of text. */
-"download_all" = "下载所有";
-
-"delete_all" = "删除全部";
-
 "autodownload" = "自动下载";
-
-"disable_autodownload" = "禁用自动下载";
 
 /* Place Page opening hours text */
 "closed_now" = "现在关门";
@@ -1072,10 +687,6 @@
 "day_off" = "没有营业";
 
 "today" = "今天";
-
-"sunrise_to_sunset" = "从日出到日落";
-
-"sunset_to_sunrise" = "从日落到日出";
 
 "add_opening_hours" = "添加工作时间";
 
@@ -1095,45 +706,18 @@
 
 "forgot_password" = "忘记密码";
 
-/* Forgot Password dialog title */
-"restore_password" = "恢复密码";
-
-"enter_email_address_to_reset_password" = "输入您在注册时所用的邮箱地址，我们会给您发送链接更新密码";
-
-"reset_password" = "重置密码";
-
-"username" = "用户名";
-
 "osm_account" = "OSM账户";
 
 "logout" = "登出";
 
-"login_and_edit_map_motivation_message" = "登录并编辑地图上的物品信息，我们就会让数百万其他用户看到。";
-
 /* Information text: "Last upload 11.01.2016" */
 "last_upload" = "上次上传";
 
-/* Motivates user to login/register, title above login buttons. */
-"you_have_edited_your_first_object" = "您已编辑您的第一件物品！";
-
 "thank_you" = "谢谢您";
-
-"login_with_google" = "用谷歌登陆";
-
-"login_with_openstreetmap" = "登录到www.openstreetmap.org";
 
 "edit_place" = "编辑地点";
 
 "place_name" = "地点名";
-
-/* title above languages list cells in the editor, below editable name text field. */
-"other_languages" = "其他语言";
-
-/* small button to open list with names in different languages */
-"show_more" = "显示更多";
-
-/* small button to close list with names in different languages */
-"show_less" = "显示更少";
 
 "add_language" = "添加语言";
 
@@ -1164,8 +748,6 @@
 
 "please_note" = "请注意";
 
-"common_no_wifi_dialog" = "无 WiFi 连接。您想继续使用移动数据进行连接吗？";
-
 "downloader_delete_map_dialog" = "所有对地图的修改都将与地图一起被删除。";
 
 "downloader_update_maps" = "更新地图";
@@ -1173,10 +755,6 @@
 "downloader_mwm_migration_dialog" = "为了创建路线，您需要更新全部地图并重新规划路线。";
 
 "downloader_search_field_hint" = "找到地图";
-
-"migration_update_all_button" = "更新全部地图";
-
-"migration_delete_all_download_current_button" = "下载当前地图并删除旧地图";
 
 "migration_download_error_dialog" = "下载错误";
 
@@ -1186,21 +764,9 @@
 
 "downloader_no_space_message" = "请删除不必要的数据";
 
-"editor_general_auth_error_dialog" = "一般登录错误。";
-
 "editor_login_error_dialog" = "登录错误。";
 
-"editor_login_failed_dialog" = "登录失败";
-
-"editor_username_error_dialog" = "用户名不存在";
-
-"editor_place_edited_dialog" = "您已编辑了一个对象！";
-
-"editor_login_with_osm" = "使用OpenStreetMap进行登录";
-
 "editor_profile_changes" = "已验证的更改";
-
-"editor_profile_unsent_changes" = "未发送：";
 
 "editor_focus_map_on_location" = "拖动地图以选择此对象的正确位置。";
 
@@ -1222,13 +788,9 @@
 
 "editor_report_problem_other_title" = "一个不同的问题";
 
-"placepage_report_problem_button" = "报告一个问题";
-
 "placepage_add_business_button" = "添加组织";
 
 "whatsnew_editor_message_1" = "添加新地点到该地图，并直接通过此应用编辑已存在的地点。";
-
-"whatsnew_editor_message_2" = "* Organic Maps使用OpenStreetMap社区的数据。";
 
 "dialog_incorrect_feature_position" = "改变位置";
 
@@ -1236,16 +798,10 @@
 
 "login_to_make_edits_visible" = "登陆，让其他用户能看到您所作出的修改。";
 
-"no_migration_during_navigation" = "导航中禁止更新。";
-
 /* Error dialog no space */
 "migration_no_space_message" = "为了下载，您需要更多的空间。请删除不必要的数据。";
 
 "editor_sharing_title" = "我改进了Organic Maps地图";
-
-"editor_comment_will_be_sent" = "我们将把您的评论发送给地图制作者。";
-
-"editor_unsupported_category_message" = "您已添加了一个我们尚未支持类别的地点。它将在一段时间之后显示在地图上。";
 
 /* Downloaded 10 **of** 20 <- it is that "of" */
 "downloader_of" = "%1$d个/共%2$d个";
@@ -1278,23 +834,9 @@
 
 "editor_operator" = "运营者";
 
-"editor_tag_description" = "输入公司、组织或设施负责人。";
-
-"editor_no_local_edits_title" = "您没有本地编辑";
-
-"editor_no_local_edits_description" = "这显示了当前仅在您设备上能够访问的对地图建议修改的数量。";
-
-"editor_send_to_osm" = "发送至 OSM";
-
-"editor_remove" = "删除";
-
-"downloader_my_maps_title" = "我的地图";
-
 "downloader_no_downloaded_maps_title" = "您尚未下载任何地图";
 
 "downloader_no_downloaded_maps_message" = "下载地图来查找位置和离线浏览";
-
-"downloader_find_place_hint" = "搜索城市或国家";
 
 /* Error title that appears after certain time without location. */
 "current_location_unknown_title" = "继续检测您的当前位置？";
@@ -1321,47 +863,13 @@
 /* iOS Dialog for the case when the location permission is not granted */
 "location_services_disabled_3" = "3. 使用应用时选择";
 
-"placepage_parking_surface" = "表面";
-
-"placepage_parking_multistorey" = "多层";
-
-"placepage_parking_underground" = "地下";
-
-"placepage_parking_rooftop" = "楼顶";
-
-"placepage_parking_sheds" = "小屋";
-
-"placepage_parking_carports" = "屋侧车库";
-
-"placepage_parking_boxes" = "停车房";
-
-"placepage_parking_pay" = "付款";
-
-"placepage_parking_free" = "免费";
-
-"placepage_parking_interval" = "间隔付款";
-
-"placepage_entrance_number" = "编号";
-
-"placepage_entrance_type" = "入口";
-
-"placepage_flat" = "公寓";
-
-"placepage_open_24_7" = "24 / 7";
-
 "meter" = "米";
 
 "kilometer" = "公里";
 
-"kilometers_per_hour" = "公里每小时";
-
 "mile" = "英里";
 
 "foot" = "英尺";
-
-"miles_per_hour" = "英里每小时";
-
-"day" = "天";
 
 "hour" = "小時";
 
@@ -1381,10 +889,6 @@
 
 "placepage_bookmark_name_hint" = "书签名称";
 
-"placepage_personal_notes_hint" = "个人备注";
-
-"placepage_delete_bookmark_button" = "删除书签";
-
 "editor_edits_sent_message" = "您的建议已发送";
 
 "editor_comment_hint" = "备注…";
@@ -1397,8 +901,6 @@
 
 "editor_remove_place_button" = "删除";
 
-"editor_status_sending" = "正在发送…";
-
 "editor_place_doesnt_exist" = "位置不存在";
 
 "text_more_button" = "…更多";
@@ -1410,11 +912,7 @@
 
 "error_enter_correct_email" = "输入有效电子邮箱";
 
-"error_enter_correct" = "输入有效值";
-
 "refresh" = "更新";
-
-"last_update" = "上次更新于：%s";
 
 "placepage_add_place_button" = "添加地点到地图上";
 
@@ -1426,24 +924,6 @@
 
 "editor_share_to_all_dialog_message_2" = "我们会检查更改。如果我们有任何问题，我们会邮件与您联系。";
 
-"navigation_overview_button" = "概览";
-
-"navigation_stop_button" = "停止";
-
-/* Text on an empty bookmark page */
-"bookmarks_empty_title" = "保存书签";
-
-"bookmarks_empty_message_1" = "点击★保存收藏地点以便快速访问。";
-
-"bookmarks_empty_message_2" = "从邮箱和网页导入书签。";
-
-"bookmarks_empty_message_3" = "退房： %s";
-
-/* Name of the group for booked hotels */
-"bookmarks_group_name" = "预订的酒店";
-
-"place_page_button_read_descriprion" = "阅读";
-
 /* iOS dialog for the case when recent track recording is on and the app comes back from background */
 "recent_track_background_dialog_title" = "禁止记录您最近去过的路径？";
 
@@ -1451,8 +931,6 @@
 
 /* For sharing via SMS and so on */
 "sharing_call_action_look" = "来看看";
-
-"continue_recent_track_background_button" = "继续";
 
 "recent_track_background_dialog_message" = "Organic Maps使用背景中的地理位置记录您最近去过的路径。";
 
@@ -1468,33 +946,13 @@
 /* About short text (below logo) */
 "about_description" = "Organic Maps 是一款基本的离线旅行应用。Organic Maps 基于 OpenStreetMap 数据并且允许对其进行编辑。";
 
-/* Text in menu */
-"blog" = "博客";
-
 "general_settings" = "常规设置";
-
-"date" = "日期 %d";
-
-/* "Report a bug" -> "Generaal Feedback" -> "Something is not working" */
-"something_is_not_working" = "某些地方出错了";
 
 /* For the first routing */
 "accept" = "接受";
 
-"accept_and_continue" = "Accept and continue";
-
 /* For the first routing */
 "decline" = "拒绝";
-
-"install_app" = "安装";
-
-"search_no_results_title" = "未找到任何结果";
-
-"search_no_results_message" = "尝试一个更普通的搜索词、缩小显示或重置筛选器。";
-
-"search_no_results_expand_area_button" = "缩小";
-
-"search_no_results_reset_button" = "重置筛选器";
 
 /* noun */
 "search_in_table" = "列表";
@@ -1517,8 +975,6 @@
 
 "traffic_update_maps_text" = "要显示交通数据，必须更新地图。";
 
-"traffic_outdated" = "交通数据已过时。";
-
 "big_font" = "增大地图上的字体大小";
 
 "traffic_update_app" = "请更新 Organic Maps";
@@ -1529,17 +985,7 @@
 /* "traffic" as in "road congestion" */
 "traffic_data_unavailable" = "交通数据不可用";
 
-/* "Translation is no needed, because it's a company name" */
-"uber" = "Uber";
-
-/* Simplified colour scheme for traffic information, fewer colours are used to display traffic jams on the map. The string should be kept as short as possible */
-"pref_traffic_simplified_colors_title" = "简化的交通状况颜色";
-
 "enable_logging" = "启用记录";
-
-"offline_place_page_more_information" = "连接到互联网来获取关于地点的更多信息。";
-
-"failed_load_information" = "无法加载信息。";
 
 /* Settings: "Send general feedback" button */
 "feedback_general" = "一般反馈";
@@ -1556,8 +1002,6 @@
 
 "whatsnew_transliteration_title" = "直译成拉丁文";
 
-"yandex_taxi_title" = "Yandex.Taxi";
-
 "learn_more" = "了解更多";
 
 "core_exit" = "退出";
@@ -1568,75 +1012,19 @@
 
 "button_exit" = "退出";
 
-"settings_device_memory" = "设备内存";
-
-"settings_card_memory" = "存储卡";
-
-"settings_storage_available" = "%s 可用";
-
-"toast_location_permission_denied" = "应用已拒绝地点获取权限";
-
-"button_use" = "使用";
-
 "planning_route_manage_route" = "管理路线";
 
 "button_plan" = "规划";
-
-"button_add" = "添加";
 
 "placepage_remove_stop" = "移除";
 
 "planning_route_remove_title" = "拖动到此处以移除";
 
-"dialog_change_start_point_message" = "将起点替换为当前地点？";
-
-"button_replace" = "替换";
-
 "placepage_add_stop" = "添加经停点";
-
-/* Only ru/en are needed */
-"subtitle_rent" = "Rent";
-
-/* Only ru/en are needed */
-"rub_month" = "RUB/month";
-
-/* Only ru/en are needed */
-"room" = "%s-room apt.";
-
-/* Only ru/en are needed */
-"real_estate" = "Real estate";
-
-"add_my_position" = "添加我的位置";
-
-"choose_start_point" = "选择起点";
-
-"choose_destination" = "选择终点";
 
 "preloader_viator_button" = "了解更多";
 
-"start_from_my_position" = "起点";
-
-"profile_authorization_title" = "登录方式";
-
-"profile_authorization_message" = "在几秒内轻松登录，无需登录名和密码";
-
 "profile_authorization_error" = "糟糕，出错了。请尝试重新登录。";
-
-"service" = "服务";
-
-"atmosphere" = "氛围";
-
-"value_for_money" = "物有所值";
-
-"experience" = "经验";
-
-"assortment" = "分类";
-
-"expertise" = "专业";
-
-"equipment" = "设备";
-
-"quality" = "质量";
 
 "dialog_error_storage_title" = "存储空间访问问题";
 
@@ -1644,17 +1032,7 @@
 
 "setting_emulate_bad_storage" = "模拟不良存储空间";
 
-"directions_finish" = "目的地";
-
-"directions_on_foot" = "步行 %s";
-
 "core_entrance" = "入口";
-
-"coffee" = "咖啡";
-
-"cleanliness" = "卫生程度";
-
-"crowdedness" = "拥挤程度";
 
 "error_enter_correct_name" = "请输入正确的名称";
 
@@ -1673,11 +1051,9 @@
 
 "downloader_percent" = "%s (%s / %s)";
 
-"downloader_process" = "正在下載 %s...";
+"downloader_process" = "正在下載 %s…";
 
-"downloader_applying" = "正在套用 %s...";
-
-"dialog_message_transit_not_found_connection" = "规划一个交通网络内的路线";
+"downloader_applying" = "正在套用 %s…";
 
 "bookmarks_error_message_share_general" = "由于应用程序出错而无法分享";
 
@@ -1695,17 +1071,7 @@
 
 "bookmarks_error_message_list_name_already_taken" = "请选择其他名称";
 
-"bookmarks_error_title_list_name_too_long" = "这个名字太长了";
-
-"bookmarks_error_message_list_name_too_long" = "请选择其他名称";
-
-"please_wait" = "请稍候...";
-
-"phone_number" = "电话号码";
-
-"notification_unsent_reviews_title" = "你有几个未发表的评论";
-
-"notification_unsent_reviews_message" = "请登录与其他旅客分享评论";
+"please_wait" = "请稍候…";
 
 "profile" = "OpenStreetMap 资料";
 
@@ -1719,49 +1085,13 @@
 
 "bookmarks_convert_error_message" = "有些文件未被转换。";
 
-"converting" = "转换...";
-
-"wn_reinvented_bookmarks_title" = "我们改造了书签！";
-
-"wn_reinvented_bookmarks_message" = "你可以备份书签，创建列表...这太神奇了...";
-
-"bookmarks_restore" = "恢复书签";
-
-"bookmarks_restore_process" = "恢复...";
-
 "bookmarks_restore_title" = "还原这个版本？";
 
-"bookmarks_restore_message" = "您的书签将从%s (%s)个恢复";
-
-"bookmarks_restore_empty_title" = "你没有备份";
-
-"bookmarks_restore_empty_message" = "服务器没有找到以前做的备份";
-
 "common_check_internet_connection_dialog_title" = "没有互联网连接";
-
-"error_server_title" = "服务器错误";
-
-"error_server_message" = "服务器发生错误，请稍后重试";
 
 "error_system_message" = "出现未知错误";
 
 "restore" = "恢复";
-
-"bookmarks_page_downloaded" = "加载";
-
-"bookmarks_page_my" = "我的";
-
-"routes_and_bookmarks" = "路线和标签";
-
-"bookmarks_webview_success_toast" = "标签已成功下载";
-
-"cached_bookmarks_placeholder_title" = "上传新地点";
-
-"cached_bookmarks_placeholder_subtitle" = "单击按钮下载Organic Maps用户创建的数千个有趣的地点和路线。您需要连接网络。";
-
-"downloader_download_routers" = "下载标签";
-
-"bookmarks_groups_cached" = "上传的列表";
 
 "subtittle_opt_out" = "支持设置";
 
@@ -1769,29 +1099,15 @@
 
 "crash_reports_description" = "我们可以使用您的数据来开发和改进Organic Maps.更改将在重新启动应用程序后生效。";
 
-"opt_out_help_ios_1" = "您可以选择停止在设备设置中接收定位广告。";
-
-"opt_out_help_ios_2" = "iOS 9或更高版本";
-
-"opt_out_help_ios_3" = "打开设置→隐私→广告→启用“跟踪限制”";
-
-"opt_out_help_android" = "您可以选择不在设备设置中接收定向广告。\ NAndroid和Google Play Services 4.0或更高版本\ n \ n电话设置→Google→广告→停用广告个性化\ n或\ n手机设置→Google→Google帐户→隐私→首选项设置→ 广告的个性化";
-
 "privacy_policy" = "隐私政策";
 
 "terms_of_use" = "使用条款";
-
-"backup_notification_failed" = "标签备份已暂停。登录以启用备份。";
 
 "button_layer_traffic" = "堵塞";
 
 "button_layer_subway" = "地铁";
 
 "layers_title" = "地图图层";
-
-"layers_message" = "打开在地图上的图层以显示交通状况、地铁图或其他有用信息";
-
-"button_layer_got_it" = "明白";
 
 "subway_data_unavailable" = "地铁地图不可用";
 
@@ -1803,39 +1119,13 @@
 
 "title_error_downloading_bookmarks" = "发生错误";
 
-"subtitle_error_downloading_bookmarks" = "标签尚未上传";
-
-"error_already_downloaded" = "这个列表已被下载";
-
 "popular_place" = "Popular";
-
-"download_routes" = "Download routes";
-
-"bookmarks_downloaded_title" = "Bookmarks have been downloaded successfully";
-
-"bookmarks_downloaded_subtitle" = "Press ‘View on map’ to explore new places from the list";
-
-"why_support" = "为什么支持Organic Maps?";
-
-"why_support_item1" = "We respect your privacy: there are zero trackers in the app, and we are open source";
-
-"why_support_item2" = "您帮助我们改进Organic Maps";
-
-"why_support_item3" = "您帮助我们改进OpenStreetMap.org地图";
-
-"channels_map_update" = "更新地图";
-
-"server_unavailable_title" = "服务不可用";
-
-"sharing_options" = "登录设置";
 
 "export_file" = "导出文件";
 
 "list_settings" = "列表设置";
 
 "delete_list" = "删除列表";
-
-"hide_from_map" = "从卡中隐藏";
 
 "public_access" = "公共访问";
 
@@ -1845,40 +1135,11 @@
 
 "bookmark_category_description_hint" = "请添加说明(文字或html)";
 
-/* FIXME */
-"bookmarks_public_access" = "bookmarks_public_access";
-
-/* FIXME */
-"bookmarks_link_access" = "bookmarks_link_access";
-
-/* FIXME */
-"bookmarks_private_access" = "bookmarks_private_access";
-
 "not_shared" = "个人";
-
-"direct_link_progress_text" = "正在上传您的文件......";
-
-"direct_link_success" = "链接已创建";
-
-"send_a_link_btn" = "发送链接";
-
-"upload_error_toast" = "加载文件时出错";
 
 "tags_loading_error_subtitle" = "加载标签时出错，请重试";
 
-"unable_upload_errorr_title" = "无法上传文件";
-
-"unable_upload_error_subtitle_edited" = "文件是通过Web应用程序编辑的";
-
-"unable_upload_error_subtitle_broken" = "该文件已损坏，无法上传。请上传其他文件。";
-
-"contact" = "写";
-
-"download_button" = "下载";
-
 "speedcams_alert_title" = "高速摄像机";
-
-"speedcams_alert_subtitle" = "速度限制警告";
 
 "speedcam_option_auto" = "自动";
 
@@ -1886,18 +1147,10 @@
 
 "speedcam_option_never" = "从不";
 
-"bookmark_description_title" = "标签说明";
-
 "place_description_title" = "地点说明";
 
 /* this text will be shown in application notification preferences opposite checkbox which enable/disable downloader notifications. Devices on Android 8+ are affected. */
 "notification_channel_downloader" = "加载地图";
-
-"share_bookmarks_email_body_link" = "您好！\n\n您的标签可以从链接下载：%s.使用Organic Maps打开列表并享受旅行!\n\n下载程序：https://omaps.app/get?kmz";
-
-"warning_speedcams_title" = "当速度限制超过%d km / h时，导航会通知您的摄像机";
-
-"warning_speedcams_subtitle" = "请不要忘记阅读旅行国的道路规则。";
 
 "speedcams_notice_message" = "自动 - 如果存在超出速度限制的风险，则对速度摄像头发出警告\n总是 - 始终提醒摄像头\n从不 - 永远不会对摄像头发出警告";
 
@@ -1913,23 +1166,7 @@
 
 "enable_logging_warning_message" = "此选项启用以记录操作来进行诊断。这有助于团队识别应用程序的问题。请仅在Organic Maps支持请求时开启该选项。";
 
-"html_error_upload_message_try_again" = "请检查网络访问，然后再重试";
-
-"html_error_upload_title_try_again" = "未连接到网络";
-
-"notification_leave_review_v2_android_short_title" = "请发表评论来帮助旅行者们！";
-
-"megafon" = "Say goodbye to roaming!";
-
-"notifications_illegal_alert_disable_button" = "关闭通知";
-
 "access_rules_author_only" = "在线编辑";
-
-"privacy_settings_menu" = "隐私设置";
-
-"unable_upadate_error_title" = "无法更新路线";
-
-"unable_upadate_error_message" = "更新时出错。请检查更改，然后再重试";
 
 "driving_options_title" = "绕行设置";
 
@@ -1951,94 +1188,19 @@
 
 "change_driving_options_btn" = "繞行設置已開啟";
 
-"toll_road" = "收费公路";
-
-"unpaved_road" = "土路";
-
-"ferry_crossing" = "轮渡";
-
-"operated_by" = "由\"%s\"管理";
-
 "avoid_toll_roads_placepage" = "规避收费公路";
 
 "avoid_unpaved_roads_placepage" = "规避土路";
 
 "avoid_ferry_crossing_placepage" = "规避轮渡";
 
-"type.cuisine.uzbek" = "乌兹别克美食";
-
-"trip_start" = "前往";
-
-"pick_destination" = "目标";
-
-"follow_my_position" = "定好中心";
-
-"search_results" = "搜索结果";
-
-"then_turn" = "接下来";
-
-"redirect_route_alert" = "想重建路线?";
-
-"redirect_route_yes" = "是";
-
-"redirect_route_no" = "否";
-
-"trip_finished" = "您已到达!";
-
-"keyboard_availability_alert" = "移动时键盘不可用";
-
-"dialog_routing_change_start_carplay" = "无法从当前位置构建路线";
-
-"dialog_routing_change_end_carplay" = "无法建立到终点的路线。请选择其他（路线）";
-
-"dialog_routing_check_gps_carplay" = "无GPS信号。请沿着空旷区域行驶";
-
-"dialog_routing_unable_locate_route_carplay" = "无法建立路线。请选择其他路线点";
-
-"dialog_routing_download_files_carplay" = "为了创建线路，请在您的设备中下载所缺少的地图";
-
-"dialog_routing_system_error_carplay" = "发生了错误。请重新启动程序";
-
-"dialog_routing_rebuild_from_current_location_carplay" = "该路线将从您的当前位置重建";
-
-"dialog_routing_rebuild_for_vehicle_carplay" = "该路线将改为汽车（路线）";
-
 "ok" = "好的";
-
-"avoid_unpaved_carplay_1" = "无土路路段";
-
-"avoid_unpaved_carplay_2" = "无土路路段";
-
-"avoid_ferry_carplay_1" = "无渡船";
-
-"avoid_ferry_carplay_2" = "无渡船";
-
-"avoid_tolls_carplay_1" = "无付费路段";
-
-"avoid_tolls_carplay_2" = "无付费路段";
-
-"speedcams_alert_title_carplay_1" = "摄像头";
-
-"speedcams_alert_title_carplay_2" = "摄像头信息";
-
-"download_map_carplay" = "将Organic Maps软件中的地图下载至个人设备中";
-
-"carplay_roundabout_exit" = "%s号坡道";
 
 /* max. 10 symbols, both iOS and Android */
 "sort" = "分类……";
 
 /* Android, title, max 20-22 symbols */
 "sort_bookmarks" = "分类标签";
-
-/* iOS */
-"sort_default" = "默认排序";
-
-"sort_type" = "按类型排序";
-
-"sort_distance" = "按距离排序";
-
-"sort_date" = "按日期排序";
 
 /* Android */
 "by_default" = "默认情况下";
@@ -2052,63 +1214,7 @@
 /* Android */
 "by_date" = "按时间";
 
-"week_ago_sorttype" = "一周前";
-
-"month_ago_sorttype" = "一月前";
-
-"moremonth_ago_sorttype" = "一个多月前";
-
-"moreyear_ago_sorttype" = "一年多以前";
-
-"near_me_sorttype" = "在我旁边";
-
-"others_sorttype" = "其他";
-
-"food_places" = "美食";
-
-"tourist_places" = "名胜";
-
-"museums" = "博物馆";
-
-"parks" = "公园";
-
-"swim_places" = "游泳";
-
-"mountains" = "山";
-
-"animals" = "动物";
-
-"hotels" = "酒店";
-
-"buildings" = "建筑物";
-
-"money" = "货币";
-
-"shops" = "商店";
-
-"parkings" = "停车场";
-
-"fuel_places" = "加油站";
-
-"water" = "水";
-
-"medicine" = "医疗";
-
 "search_in_the_list" = "在列表中搜索";
-
-"view_on_map_bookmarks" = "在地图上";
-
-"more_bookmarks" = "更多……";
-
-"no_items_found" = "未搜索到内容";
-
-/* Android, max 18 symbols */
-"bookmarks_edit_list" = "编辑";
-
-/* Android, max 18 symbols */
-"bookmarks_delete_list" = "删除列表";
-
-"religious_places" = "圣地";
 
 "select_list" = "选择列表";
 
@@ -2118,26 +1224,13 @@
 
 "dialog_pedestrian_route_is_long_message" = "选择地铁站附近的起点和终点";
 
-/* Failed planning SUBWAY route message in navigation view */
-"routing_planning_error_subway_special" = "地铁路线图设计出错";
-
 "button_layer_isolines" = "高度";
-
-"tips_map_layers_title_countour" = "离线高度线在Organic Maps中！";
-
-"tips_map_layers_message_countour" = "高度线可以帮您规划通往大自然地区的路线，不会迷路";
 
 "isolines_activation_error_dialog" = "如需使用高度線，請更新或下載所需區域的地圖";
 
 "isolines_location_error_dialog" = "暂时无法获取该地区的高低线";
 
 "elevation_profile_diff_level" = "难度等级";
-
-"elevation_profile_diff_level_easy" = "容易";
-
-"elevation_profile_diff_level_moderate" = "中等";
-
-"elevation_profile_diff_level_hard" = "困难";
 
 "elevation_profile_ascent" = "上坡";
 
@@ -2147,25 +1240,13 @@
 
 "elevation_profile_maxaltitude" = "最大高度";
 
-"elevation_profile_m" = "米";
-
 "elevation_profile_difficulty" = "难度";
 
 "elevation_profile_distance" = "距离：";
 
-"elevation_profile_km" = "千米";
-
 "elevation_profile_time" = "在路上：";
 
-"elevation_profile_hours" = "小时";
-
-"elevation_profile_minutes" = "分钟";
-
 "isolines_toast_zooms_1_10" = "放大地图以查看等高线";
-
-"downloader_updating_ios" = "更新";
-
-"downloader_loading_ios" = "加载";
 
 "key_information_title" = "关键信息";
 

--- a/iphone/Maps/LocalizedStrings/zh-Hans.lproj/Localizable.stringsdict
+++ b/iphone/Maps/LocalizedStrings/zh-Hans.lproj/Localizable.stringsdict
@@ -9,21 +9,6 @@
 
 <!-- ********** Strings for downloading map from search **********/ -->
 
-  <key>bookmarks_places</key>
-  <dict>
-    <key>NSStringLocalizedFormatKey</key>
-    <string>%#@value@</string>
-    <key>value</key>
-    <dict>
-      <key>NSStringFormatSpecTypeKey</key>
-      <string>NSStringPluralRuleType</string>
-      <key>NSStringFormatValueTypeKey</key>
-      <string>d</string>
-      <key>other</key>
-      <string>%d 個書籤</string>
-    </dict>
-  </dict>
-
   <key>bookmarks_detect_message</key>
   <dict>
     <key>NSStringLocalizedFormatKey</key>
@@ -36,21 +21,6 @@
       <string>d</string>
       <key>other</key>
       <string>找到%d个文件。 转换后你会看到它。</string>
-    </dict>
-  </dict>
-
-  <key>bookmarks_objects</key>
-  <dict>
-    <key>NSStringLocalizedFormatKey</key>
-    <string>%#@value@</string>
-    <key>value</key>
-    <dict>
-      <key>NSStringFormatSpecTypeKey</key>
-      <string>NSStringPluralRuleType</string>
-      <key>NSStringFormatValueTypeKey</key>
-      <string>d</string>
-      <key>other</key>
-      <string>%s 对象</string>
     </dict>
   </dict>
 

--- a/iphone/Maps/LocalizedStrings/zh-Hant.lproj/Localizable.strings
+++ b/iphone/Maps/LocalizedStrings/zh-Hant.lproj/Localizable.strings
@@ -18,9 +18,6 @@
 /* Button which deletes downloaded country */
 "delete" = "刪除";
 
-/* Button "do not interrupt download" if user touched actively downloading country */
-"do_nothing" = "繼續";
-
 "download_maps" = "下載地圖";
 
 /* Settings/Downloader - info for country when download fails */
@@ -28,9 +25,6 @@
 
 /* Settings/Downloader - info for country which started downloading */
 "downloading" = "下載中…";
-
-/* Settings/Downloader - size string, only strings different from English should be translated */
-"kb" = "kB";
 
 /* Choose measurement on first launch alert - choose metric system button */
 "kilometres" = "公里";
@@ -55,17 +49,11 @@
 /* Update maps later/Buy pro version later button text */
 "later" = "稍後";
 
-/* Don't show some dialog any more */
-"never" = "不再提醒";
-
 /* View and button titles for accessibility */
 "search" = "搜尋";
 
 /* Search box placeholder text */
 "search_map" = "搜尋地圖";
-
-/* Settings/Downloader - info for not downloaded country */
-"touch_to_download" = "輕觸以下載";
 
 /* Settings/Downloader - 3G download warning dialog confirm button */
 "use_cellular_data" = "是";
@@ -73,20 +61,11 @@
 /* Location services are disabled by user alert - message */
 "location_is_disabled_long_text" = "您目前裝置所有的定位服務或相關應用程式是處於停用的狀態，請從系統設定中選擇啟用。";
 
-/* Location Services are not available on the device alert - message */
-"device_doesnot_support_location_services" = "您的裝置不支援定位服務";
-
 /* View and button titles for accessibility */
 "zoom_to_country" = "在地圖上顯示";
 
-/* Button text for the button at the center of the screen when the country is not downloaded */
-"country_status_download" = "下載地圖\n(^ ^)";
-
 /* Button text for the button at the center of the screen when the country is not downloaded and the size should not be shown */
 "country_status_download_without_size" = "下載地圖";
-
-/* Button text for the button at the center of the screen when the country is not downloaded */
-"country_status_download_without_routing" = "下載不帶路線的地圖\n(^ ^)";
 
 /* Message to display at the center of the screen when the country download has failed */
 "country_status_download_failed" = "下載失敗";
@@ -96,19 +75,13 @@
 
 "about_menu_title" = "關於 Organic Maps";
 
-"downloaded_touch_to_delete" = "已下載的 (%@)，輕觸以刪除";
-
 "connection_settings" = "連線設定";
-
-"download_mb_or_kb" = "下載 %@";
 
 "close" = "關閉";
 
 "unsupported_phone" = "需要 OpenGL 硬體加速功能的支援。但很不幸的，您的裝置並不支援此功能！";
 
 "download" = "下載";
-
-"external_storage_is_not_available" = "SD 卡/USB 無法有效儲存下載的地圖";
 
 "disconnect_usb_cable" = "請拔除 USB 線或插入 SD 卡以使用 Organic Maps";
 
@@ -117,8 +90,6 @@
 "not_enough_memory" = "沒有足夠的記憶體以啟動應用程式";
 
 "download_resources" = "在您開始之前，先讓我們下載世界地圖到您的裝置中以便瀏覽。\n這需要資料的 %@。";
-
-"getting_position" = "取得目前所在位置";
 
 "download_resources_continue" = "跳到地圖";
 
@@ -140,23 +111,14 @@
 /* Add New Bookmark Set dialog title */
 "add_new_set" = "新增收藏夾";
 
-/* Place Page - Add To Bookmarks button */
-"add_to_bookmarks" = "新增到書籤";
-
 /* Bookmark Color dialog title */
 "bookmark_color" = "書籤顏色";
 
 /* Add Bookmark Set dialog - hint when set name is empty */
 "bookmark_set_name" = "收藏夾名稱";
 
-/* Bookmark Sets dialog title */
-"bookmark_sets" = "收藏夾";
-
 /* Bookmarks - dialog title */
 "bookmarks" = "書籤";
-
-/* Add bookmark dialog - bookmark color */
-"color" = "顏色";
 
 /* Default bookmarks set name */
 "core_my_places" = "我的地點";
@@ -167,14 +129,8 @@
 /* Editor title above street and house number */
 "address" = "位址";
 
-/* Place Page - Remove Pin button */
-"remove_pin" = "移除圖釘";
-
 /* Add bookmark dialog - bookmark set, Bookmarks dialog - Bookmark set cell */
 "set" = "收藏夾";
-
-/* Text hint in Bookmarks dialog when no any bookmarks are added */
-"bookmarks_usage_hint" = "您還沒有任何書籤。\n點擊地圖上的任何地方以新增書籤。\n其他來源的書籤也可導入在 Organic Maps 中顯示。從電子郵件、Dropbox 或網站連結開啟有著已儲存書籤的 KML/KMZ 檔案。";
 
 /* Settings button in system menu */
 "settings" = "設定";
@@ -191,26 +147,11 @@
 /* Ask to wait user several minutes (some long process in modal dialog). */
 "wait_several_minutes" = "這可能需要幾分鐘\n請稍候…";
 
-/* Show bookmarks from this category on a map or not */
-"visible" = "可見";
-
-/* Toast which is displayed when GPS has been deactivated */
-"gps_is_disabled_long_text" = "GPS 目前是關閉的，請在系統中設定為啟用";
-
 /* Measurement units title in settings activity */
 "measurement_units" = "測量單位";
 
 /* Detailed description of Measurement Units settings button */
 "measurement_units_summary" = "請選擇公里或英哩";
-
-/* Do search in all sources */
-"search_mode_all" = "任何地方";
-
-/* Do search near my position only */
-"search_mode_nearme" = "我的附近";
-
-/* Do search in current viewport only */
-"search_mode_viewport" = "畫面中";
 
 /* Search category for cafes, bars, restaurants */
 "eat" = "在哪兒吃";
@@ -266,14 +207,8 @@
 /* Search category */
 "police" = "警察局";
 
-/* String in search result list, when nothing found */
-"no_search_results_found" = "找不到搜尋結果";
-
 /* Notes field in Bookmarks view */
 "description" = "描述說明";
-
-/* Button text */
-"share_by_email" = "以電子郵件分享";
 
 /* Email Subject when sharing bookmarks category */
 "share_bookmarks_email_subject" = "已分享 Organic Maps 書籤";
@@ -295,26 +230,11 @@
 /* Warning message when doing search around current position */
 "unknown_current_position" = "您的位置尚未定位完成";
 
-/* Warning message when location country isn't downloaded during search (see also download_location_map_proposal). */
-"download_location_country" = "下載您目前所在位置的國家 地圖 (%@)";
-
-/* Warning message when viewport country isn't downloaded during search */
-"download_viewport_country_to_search" = "下載您正在搜尋的國家 地圖 (%@)";
-
 /* Alert message that we can't run Map Storage settings due to some reasons. */
 "cant_change_this_setting" = "很抱歉，地圖儲存設定目前已停用。";
 
 /* Alert message that downloading is in progress. */
 "downloading_is_active" = "國家地圖正在進行下載";
-
-/* Message that will be shown in alert view, when we ask user to leave review on App Store */
-"appStore_message" = "祝您使用 Organic Maps 愉快！ 方便的話，請到 App Store 幫我們評分或寫寫評論。在這短短的時間當中卻能夠真正的協助我們改善，再次感謝您的支持！";
-
-/* No, thanks */
-"no_thanks" = "不，謝了";
-
-/* Share one specific bookmark using SMS, %1$@ contains om:// and %2$@ https://omaps.app link. @NOTE non-ascii symbols in the link will result in max 70 characters SMS instead of 140. */
-"bookmark_share_sms" = "嘿，看看我在 Organic Maps 標記的圖釘吧！ %1$@ 或%2$@ 沒安裝離線地圖？在此下載: https://omaps.app/get";
 
 /* Share my position using SMS, %1$@ contains om:// and %2$@ https://omaps.app link WITHOUT NAME. @NOTE non-ascii symbols in the link will result in max 70 characters SMS instead of 140. */
 "my_position_share_sms" = "嘿，在 Organic Maps 查看我的目前位置吧！ %1$@ 或%2$@ 沒安裝離線地圖？在此下載: https://omaps.app/get";
@@ -328,23 +248,11 @@
 /* Share my position using EMail, %1$@ is om:// and %2$@ is https://omaps.app link WITHOUT NAME */
 "my_position_share_email" = "嗨，\n\n我現在在這：%1$@。點擊此連結 %2$@ 或此連結 %3$@ 來查看在地圖上的位置。\n\n謝謝。";
 
-/* Android share by Message/SMS button text (including SMS) */
-"share_by_message" = "透過訊息分享";
-
 /* Share button text which opens menu with more buttons, like Message, EMail, Facebook etc. */
 "share" = "分享";
 
-/* iOS share by Message button text (including SMS) */
-"message" = "訊息";
-
 /* Share by email button text, also used in editor. */
 "email" = "電子郵件";
-
-/* Copy Link */
-"copy_link" = "複製連結";
-
-/* Text for the button that returns to caller application */
-"more_info" = "顯示更多資訊";
 
 /* Text for message when used successfully copied something */
 "copied_to_clipboard" = "已複製到剪貼簿：%1$@";
@@ -354,15 +262,6 @@
 
 /* Used for bookmark editing */
 "done" = "完成";
-
-/* Summary for preferences in MWM */
-"yopme_pref_summary" = "選擇第二螢幕設定";
-
-/* Title for yopme preferences in MWM */
-"yopme_pref_title" = "第二螢幕設定";
-
-/* Hint for upper-right icon p2b */
-"show_on_backscreen" = "在第二螢幕上顯示";
 
 /* Prints version number in About dialog */
 "version" = "版本： %@";
@@ -381,19 +280,11 @@
 
 "share_my_location" = "分享我的位置";
 
-"menu_search" = "搜尋";
-
 /* Settings general group in settings screen */
 "prefs_group_general" = "General settings";
 
 /* Settings information group in settings screen */
 "prefs_group_information" = "Information";
-
-/* Settings screen: "Map" category title */
-"prefs_group_map" = "地圖";
-
-/* Settings screen: "Miscellaneous" category title */
-"prefs_group_misc" = "其他";
 
 "prefs_group_route" = "導航";
 
@@ -419,9 +310,6 @@
 /* Settings «Map» category: «3D buildings» title */
 "pref_map_3d_buildings_title" = "3D 建築";
 
-/* Settings «Map» category: «3D buildings» summary */
-"pref_map_3d_buildings_subtitle" = "增加電池消耗";
-
 /* Settings «Route» category: «Tts enabled» title */
 "pref_tts_enable_title" = "語音指示";
 
@@ -433,8 +321,6 @@
 
 /* Title for "Other" section in TTS settings. */
 "pref_tts_other_section_title" = "其他";
-
-"pref_tts_how_to_set_up_voice" = "如何設定語音";
 
 /* Settings «Map» category: «Record track» title */
 "pref_track_record_title" = "最近的軌跡";
@@ -455,56 +341,7 @@
 
 "recent_track_help_text" = "它可讓您記錄特定期間所行經的路徑，並在地圖上看到該路徑。請注意：啟用此項功能會增加電池使用量。在時間間隔過期後，會從地圖中自動移除行進路線。";
 
-"pref_track_ios_caption" = "近期軌跡顯示您的行進道路。";
-
-"pref_track_ios_subcaption" = "請選擇儲存軌跡的時間範圍。";
-
-"placepage_distance" = "距离";
-
-"placepage_coordinates" = "座標";
-
-"placepage_unsorted" = "未分類";
-
 "search_show_on_map" = "在地圖上查看";
-
-/* Used to warn user when fixing KitKat issue */
-"bookmark_move_fail" = "我們需要將您的書籤移至內部記憶體中，但沒有足夠的存儲空間。請釋放一些記憶體，否則，書籤將不可用。";
-
-/* Used in More Apps menu */
-"free" = "免費";
-
-/* Used in More Apps menu */
-"buy" = "購買";
-
-/* 1st search button-like result */
-"search_on_map" = "在地圖上搜尋";
-
-/* toast with an error */
-"no_route_found" = "找不到路線";
-
-/* route title */
-"route" = "路線";
-
-/* category title */
-"routes" = "路線";
-
-/* text of notification */
-"download_map_notification" = "下載您所在地方的地圖";
-
-/* text of notification */
-"pro_version_is_free_today" = "現在完整版 Organic Maps 是免費的！馬上下載並告訴您的朋友。";
-
-/* Dialog for transferring maps from lite to pro. */
-"move_lite_maps_to_pro" = "我們正在將您從 Organic Maps Lite 下載的地圖傳輸至 Organic Maps。這可能需要幾分鐘的時間。";
-
-/* Message to display when maps moved. */
-"move_lite_maps_to_pro_ok" = "您下載的地圖已成功傳輸至 Organic Maps。";
-
-/* Message to display when maps move failed. */
-"move_lite_maps_to_pro_failed" = "您的地圖傳輸失敗。請刪除 Organic Maps Lite，然後再次下載地圖。";
-
-/* Text in menu */
-"settings_and_more" = "設定及更多";
 
 /* Text in menu */
 "website" = "網站";
@@ -527,14 +364,8 @@
 /* Text in menu */
 "openstreetmap" = "OpenStreetMap";
 
-/* Text in menu */
-"contact_us" = "聯絡我們";
-
 /* Settings: Send feedback button and dialog title */
 "feedback" = "意見反應";
-
-/* Text in menu */
-"subscribe_to_news" = "訂閱我們的新聞";
 
 /* Text in menu */
 "rate_the_app" = "為該應用程式評分";
@@ -548,15 +379,6 @@
 /* Text in menu */
 "report_a_bug" = "報告錯誤";
 
-/* Email subject */
-"subscribe_me_subject" = "請幫我訂閱 Organic Maps 新聞郵件、";
-
-/* Email body */
-"subscribe_me_body" = "我想搶先了解最新新聞、更新和促銷活動。我可以隨時取消我的訂閱。";
-
-/* About text */
-"about_text" = "Organic Maps 提供全球所有國家和所有城市的最快速的離線地圖。充滿自信地出行：無論您在哪，Organic Maps都能夠幫助您在地圖上找到您自己的位置，找到最近的餐館、酒店、銀行、加油站，等等。無需網路連接。 我們始終在為增加新功能而努力，並希望能夠聽到您對我們應如何改進 Organic Maps 的想法。若您在使用本應用程式時遇到任何問題，請隨時聯繫我們：support@organicmaps.app。我們會回覆每一條請求！\n\n您喜歡 Organic Maps 並想支持我們嗎？以下為一些簡單且完全免費的方法：\n- 在您的應用程式商店上發表評論\n- 在我們的 Facebook 頁面 http://www.facebook.com/OrganicMaps 上按讚\n- 或者向您的母親、朋友，以及同事介紹 Organic Maps :)\n\n感謝您與我們在一起。非常感謝您的支持。\n\nP.S.：我們從 OpenStreetMap 獲得地圖資訊，這是一個類似維基百科的地圖繪製專案，能夠讓使用者建立並編輯編輯地圖。若您看到地圖上缺少了什麽或者有什麽錯誤，可以直接在 https://www.openstreetmap.org 上進行糾正。在下一個版本發佈時，您做出的更改便會出現在 Organic Maps 應用程式中。";
-
 /* Alert text */
 "email_error_body" = "電子郵件客戶端尚未建立。請設定或使用任何其他方式與我們聯絡%@";
 
@@ -569,12 +391,6 @@
 /* Search category */
 "wifi" = "無線網路";
 
-/* Update map suggestion */
-"routing_map_outdated" = "請更新地圖以建立一條路線。";
-
-/* Update maps suggestion */
-"routing_update_maps" = "使用新版本的 Organic Maps 可以建立從您的目前位置至一個目的地的路線。請更新地圖以使用該功能。";
-
 /* Update all button text */
 "downloader_update_all_button" = "更新全部";
 
@@ -583,9 +399,6 @@
 
 /* Downloaded maps category */
 "downloader_downloaded_subtitle" = "已下載";
-
-/* Downloaded maps category */
-"downloader_available_maps" = "可用";
 
 /* Country queued for download */
 "downloader_queued" = "已佇列";
@@ -598,17 +411,6 @@
 
 "downloader_downloading" = "正在下載：";
 
-"downloader_search_results" = "已找到";
-
-/* Disclaimer message */
-"routing_disclaimer" = "在 Organic Maps 應用程式中建立路線時請謹記以下幾點：\n\n  - 建議路線僅可當作推薦路線。\n - 路況、交通規則以及標誌應優先於導航建議。\n - 地圖可能會不正確或者過時，路線也可能不是以最佳可能方式建立的。\n\n  行車安全，請照顧好您自己！";
-
-/* Outdated maps category */
-"downloader_outdated_maps" = "過時的";
-
-/* Up to date maps category */
-"downloader_uptodate_maps" = "最新的";
-
 /* Status of outdated country in the list */
 "downloader_status_outdated" = "更新";
 
@@ -618,49 +420,14 @@
 /* Displayed in a dialog that appears when a user tries to delete a map while the app is in the follow route mode */
 "downloader_delete_map_while_routing_dialog" = "如欲刪除地圖，請停止導航。";
 
-/* Show when user try build route, but we don't know where he */
-"routing_failed_unknown_my_position" = "目前地點未定。請等待明確地點以建立路線。";
-
-/* Show if use has not routing file, or InconsistentMWMandRoute */
-"routing_failed_has_no_routing_file" = "需要額外的數據才能建立路線。開始下載嗎？";
-
-/* StartPointNotFound */
-"routing_failed_start_point_not_found" = "無法計算路線。沒有路在您的起點附近。";
-
-/* EndPointNotFound */
-"routing_failed_dst_point_not_found" = "無法計算路線。沒有路在您的終點附近。";
-
 /* PointsInDifferentMWM */
 "routing_failed_cross_mwm_building" = "路程只能完全處在同一地圖裡時才能被建立。";
-
-/* RouteNotFound */
-"routing_failed_route_not_found" = "找不到所選起點和終點間的路程。請選擇不同的起點或終點。";
-
-/* InternalError */
-"routing_failed_internal_error" = "出現內部錯誤。請嘗試刪除並再次下載地圖。如果還有問題請聯絡我們：support@organicmaps.app。";
-
-/* Context menu item for downloader. */
-"downloader_download_map_and_routing" = "下載地圖 + 路線";
-
-/* Context menu item for downloader. */
-"downloader_download_routing" = "下載路線";
-
-/* Context menu item for downloader. */
-"downloader_delete_routing" = "刪除路線";
 
 /* Context menu item for downloader. */
 "downloader_download_map" = "下載地圖";
 
-"downloader_download_map_no_routing" = "下載不帶路線的地圖";
-
-/* Button for routing. */
-"routing_go" = "開始！";
-
 /* Item status in downloader. */
 "downloader_retry" = "重試";
-
-/* Item in context menu. */
-"downloader_map_and_routing" = "地圖 + 路線";
 
 /* Item in context menu. */
 "downloader_delete_map" = "刪除地圖";
@@ -668,29 +435,11 @@
 /* Item in context menu. */
 "downloader_update_map" = "更新地圖";
 
-/* Item in context menu. */
-"downloader_update_map_and_routing" = "更新地圖 + 路線";
-
-/* Item in context menu. */
-"downloader_map_only" = "只有地圖";
-
-/* Toolbar title */
-"toolbar_application_menu" = "Application menu";
-
 /* Preference text */
 "pref_use_google_play" = "使用 Google Play 服務來獲得您的目前位置";
 
 /* Text for rating dialog */
 "rating_just_rated" = "我剛剛評價了您的應用";
-
-/* Text for rating dialog */
-"rating_user_since" = "我是從 %@ 年起的 Organic Maps 使用者";
-
-/* Text for rating dialog */
-"rating_do_like_maps" = "您喜歡 Organic Maps 嗎？";
-
-/* Text for rating dialog */
-"rating_tap_star" = "點擊星星給我們應用程式評分。";
 
 /* Text for rating dialog */
 "rating_thanks" = "謝謝您！";
@@ -701,23 +450,8 @@
 /* Text for rating dialog */
 "rating_send_feedback" = "發送回饋";
 
-/* Text for g+ dialog */
-"rating_google_plus" = "點擊g+向您的朋友們告知這款應用程式。";
-
 /* Text for routing error dialog */
 "routing_download_maps_along" = "下載沿線地圖";
-
-/* Text for routing error dialog */
-"routing_download_map" = "獲取地圖";
-
-/* Text for routing error dialog */
-"routing_download_map_and_routing" = "下載更新的地圖和路線數據，獲取所有 Organic Maps 的特色功能。";
-
-/* Text for routing error dialog */
-"routing_get_routing_data" = "獲取所需的路線數據";
-
-/* Text for routing error dialog */
-"routing_get_additional_data" = "需要更多數據以從您的位置建立路線。";
 
 /* Text for routing error dialog */
 "routing_requires_all_map" = "建立路線需要下載並更新好所有從您的位置到目的地的地圖。";
@@ -725,50 +459,15 @@
 /* Text for routing error dialog */
 "routing_not_enough_space" = "空間不足";
 
-/* Text for routing error dialog */
-"routing_download_more_than_avail" = "您需要下載%@ MB，但只有%@ MB空間。";
-
-/* Text for routing error dialog */
-"routing_download_roaming" = "您將使用行動數據下載%@ MB（漫遊）。這取決於您的行動數據方案服務業者，可能會產生額外的費用。";
-
 /* bookmark button text */
 "bookmark" = "書籤";
-
-/* map is not downloaded */
-"not_found_map" = "您地點的地圖尚未下載";
 
 /* location service disabled */
 "enable_location_services" = "請啟用定位服務";
 
-/* download map */
-"download_map" = "為您的地點下載地圖";
-
-/* download map on iPhone */
-"download_map_iphone" = "在您的 iPhone 上下載目前位置的地圖";
-
-/* clear pin */
-"nearby" = "附近的";
-
-/* clear pin */
-"clear_pin" = "清除圖釘";
-
-/* location is undefined */
-"undefined_location" = "目前地點未定。";
-
-/* download country of your location */
-"download_country" = "下載您目前所在位置的國家 地圖";
-
-/* download failed */
-"download_failed" = "下載失敗";
-
-/* get the map */
-"get_the_map" = "獲取地圖";
-
 "save" = "儲存";
 
 "edit_description_hint" = "您的描述（文字或 html）";
-
-"new_group" = "新組";
 
 "create" = "建立";
 
@@ -795,30 +494,6 @@
 
 /* pink color */
 "pink" = "粉色";
-
-/* deep purple color */
-"deep_purple" = "暗紫色";
-
-/* light blue color */
-"light_blue" = "天藍色";
-
-/* cyan color */
-"cyan" = "藍綠色";
-
-/* teal color */
-"teal" = "碧綠色";
-
-/* lime color */
-"lime" = "青檸";
-
-/* deep orange color */
-"deep_orange" = "深橘色";
-
-/* gray color */
-"gray" = "灰色";
-
-/* blue gray color */
-"blue_gray" = "藍灰色";
 
 /* Wi-Fi available */
 "WiFi_available" = "是";
@@ -848,13 +523,9 @@
 
 "dialog_routing_location_unknown_turn_on" = "無法定位目前 GPS 座標。請啟用定位服務以產生路線。";
 
-"dialog_routing_location_unknown" = "無法定位目前 GPS 座標。";
-
 "dialog_routing_download_files" = "下載所需檔案";
 
 "dialog_routing_download_and_update_all" = "若要產生路線，請下載並更新所有地圖及沿路線的路線檔案。";
-
-"dialog_routing_routes_size" = "路線資訊檔案";
 
 "dialog_routing_unable_locate_route" = "路線未找到";
 
@@ -884,21 +555,11 @@
 
 "dialog_routing_try_again" = "請再試一次";
 
-"dialog_routing_send_error" = "回報問題";
-
-"dialog_routing_if_get_cross_route" = "您想產生跨越邊界的更好路線嗎？";
-
-"dialog_routing_cross_route_is_optimal" = "有更理想的跨越邊界的路線可用。";
-
 "not_now" = "現在不要";
-
-"dialog_routing_build_route" = "產生";
 
 "dialog_routing_download_and_build_cross_route" = "您是否要下載地圖，產生跨越邊界的更好路線？";
 
 "dialog_routing_download_cross_route" = "若要產生跨越邊界的更理想路線，您需要下載地圖。";
-
-"dialog_routing_cross_route_always" = "一律跨越此邊界";
 
 
 /********** Strings for downloading map from search **********/
@@ -906,8 +567,6 @@
 "search_without_internet_advertisement" = "要開始搜索和建立路線，請下載地圖，那您就不再需要網絡連接了。";
 
 "search_select_map" = "選擇地圖";
-
-"search_select_other_map" = "選擇另一個地圖";
 
 /* «Show» context menu */
 "show" = "顯示";
@@ -918,17 +577,11 @@
 /* «Rename» context menu */
 "rename" = "重新命名";
 
-/* Bottom sheet: expand button (should be short) */
-"bottom_sheet_more" = "更多…";
-
 /* Failed planning route message in navigation view */
 "routing_planning_error" = "路線計劃失敗";
 
 /* Arrive routing message in navigation view */
 "routing_arrive" = "抵達:%s";
-
-/* Text for routing::RouterResultCode::FileTooOld dialog. */
-"dialog_routing_download_and_update_maps" = "要建立路線，請下載並更新所有沿線的地圖。";
 
 "rate_alert_title" = "喜歡這個應用程式嗎？";
 
@@ -944,19 +597,11 @@
 
 "history" = "記錄";
 
-"next_turn_then" = "然後";
-
 "closed" = "已關閉";
-
-"back_to" = "返回 %@";
 
 "search_not_found" = "很抱歉，找不到任何東西。";
 
 "search_not_found_query" = "請嘗試其他搜尋字詞。";
-
-"search_not_found_map" = "請下載你搜尋的地圖。";
-
-"search_not_found_location" = "下載您目前位置的地圖。";
 
 "search_history_title" = "搜尋歷史紀錄";
 
@@ -964,23 +609,12 @@
 
 "clear_search" = "清除搜尋記錄";
 
-/* Title for settings to enable/disable showcase menu button */
-"showcase_settings_title" = "顯示優惠";
-
 /* Place Page link to Wikipedia article (if map object has it). */
 "read_in_wikipedia" = "維基百科";
 
-"p2p_route_planning" = "路線計劃";
-
 "p2p_your_location" = "您的位置";
 
-"p2p_from" = "出發地點";
-
-"p2p_to" = "目的地點";
-
 "p2p_start" = "開始";
-
-"p2p_planning" = "計劃中…";
 
 "p2p_from_here" = "從";
 
@@ -1018,15 +652,9 @@
 
 "editor_correct_mistake" = "修正錯誤";
 
-"editor_correct_mistake_message" = "編輯時出錯。請修正或切換到簡易模式。";
-
 "editor_add_select_location" = "位置";
 
 "editor_done_dialog_1" = "您已經改變了世界地圖。別藏私！告訴您的朋友們一起來編輯。";
-
-"editor_done_dialog_2" = "這是您的第二次地圖改進。現在您在地圖編輯者排行榜中排在第%d名。把它告訴您的朋友們。";
-
-"editor_done_dialog_3" = "您已改進此地圖，請把它告訴您的朋友們，並一起編輯此地圖。";
 
 "share_with_friends" = "和朋友分享";
 
@@ -1044,20 +672,7 @@
 
 "editor_report_problem_duplicate_place_title" = "重複的地點";
 
-"first_launch_congrats_title" = "Organic Maps 已做好使用準備";
-
-"first_launch_congrats_text" = "在世界各地離線搜尋和導航，免費。";
-
-"migrate_title" = "重要！";
-
-/* Android uses image instead of text. */
-"download_all" = "全部下載";
-
-"delete_all" = "刪除全部";
-
 "autodownload" = "自動下載";
-
-"disable_autodownload" = "停用自動下載";
 
 /* Place Page opening hours text */
 "closed_now" = "現在關門";
@@ -1072,10 +687,6 @@
 "day_off" = "沒有營業";
 
 "today" = "今天";
-
-"sunrise_to_sunset" = "從日出到日落";
-
-"sunset_to_sunrise" = "從日落到日出";
 
 "add_opening_hours" = "新增營業時間";
 
@@ -1095,45 +706,18 @@
 
 "forgot_password" = "忘記密碼";
 
-/* Forgot Password dialog title */
-"restore_password" = "恢復密碼";
-
-"enter_email_address_to_reset_password" = "輸入您在註冊時所用的電子郵件地址，我們會發送連結給您更新密碼";
-
-"reset_password" = "重置密碼";
-
-"username" = "使用者名稱";
-
 "osm_account" = "OSM 帳號";
 
 "logout" = "登出";
 
-"login_and_edit_map_motivation_message" = "登錄並編輯地圖上的物件資訊，我們就會讓其他數百萬用戶看到。";
-
 /* Information text: "Last upload 11.01.2016" */
 "last_upload" = "上次上傳";
 
-/* Motivates user to login/register, title above login buttons. */
-"you_have_edited_your_first_object" = "您已編輯您的第一個物件！";
-
 "thank_you" = "謝謝您";
-
-"login_with_google" = "用 Google 登入";
-
-"login_with_openstreetmap" = "登入到 www.openstreetmap.org";
 
 "edit_place" = "編輯地點";
 
 "place_name" = "地點名稱";
-
-/* title above languages list cells in the editor, below editable name text field. */
-"other_languages" = "其他語言";
-
-/* small button to open list with names in different languages */
-"show_more" = "顯示更多";
-
-/* small button to close list with names in different languages */
-"show_less" = "顯示較少";
 
 "add_language" = "新增語言";
 
@@ -1164,8 +748,6 @@
 
 "please_note" = "請註意";
 
-"common_no_wifi_dialog" = "無 WiFi 連接。您想繼續使用行動數據進行連接嗎？";
-
 "downloader_delete_map_dialog" = "所有對地圖的修改都將與地圖一起被刪除。";
 
 "downloader_update_maps" = "更新地圖";
@@ -1173,10 +755,6 @@
 "downloader_mwm_migration_dialog" = "為了建立路線，您需要更新全部地圖並重新規劃路線。";
 
 "downloader_search_field_hint" = "找到地圖";
-
-"migration_update_all_button" = "更新全部地圖";
-
-"migration_delete_all_download_current_button" = "下載目前地圖並刪除舊地圖";
 
 "migration_download_error_dialog" = "下載錯誤";
 
@@ -1186,21 +764,9 @@
 
 "downloader_no_space_message" = "請刪除不必要的資料";
 
-"editor_general_auth_error_dialog" = "一般登入錯誤。";
-
 "editor_login_error_dialog" = "登入錯誤。";
 
-"editor_login_failed_dialog" = "登入失敗";
-
-"editor_username_error_dialog" = "使用者名稱不存在";
-
-"editor_place_edited_dialog" = "您已編輯了一個物件！";
-
-"editor_login_with_osm" = "使用 OpenStreetMap 進行登入";
-
 "editor_profile_changes" = "已驗證的變更";
-
-"editor_profile_unsent_changes" = "未發送：";
 
 "editor_focus_map_on_location" = "拖動地圖以選擇此物件的正確位置。";
 
@@ -1222,13 +788,9 @@
 
 "editor_report_problem_other_title" = "一個不同的問題";
 
-"placepage_report_problem_button" = "回報問題";
-
 "placepage_add_business_button" = "添加組織";
 
 "whatsnew_editor_message_1" = "新增新地點到該地圖，並直接通過此應用程式編輯已存在的地點。";
-
-"whatsnew_editor_message_2" = "* Organic Maps 使用 OpenStreetMap 社群的數據。";
 
 "dialog_incorrect_feature_position" = "改變位置";
 
@@ -1236,16 +798,10 @@
 
 "login_to_make_edits_visible" = "登入來讓其他使用者能看到您所作出的修改。";
 
-"no_migration_during_navigation" = "導航中禁止更新。";
-
 /* Error dialog no space */
 "migration_no_space_message" = "為了下載，您需要更多的空間。請刪除不必要的數據。";
 
 "editor_sharing_title" = "我改進了 Organic Maps 地圖";
-
-"editor_comment_will_be_sent" = "我們將把您的評論發送給地圖編輯者。";
-
-"editor_unsupported_category_message" = "您已新增了一個我們尚未支援的類別的地點。它未來會顯示在地圖上。";
 
 /* Downloaded 10 **of** 20 <- it is that "of" */
 "downloader_of" = "%1$d個/共%2$d個";
@@ -1278,23 +834,9 @@
 
 "editor_operator" = "營運者";
 
-"editor_tag_description" = "輸入公司、組織或設施負責人。";
-
-"editor_no_local_edits_title" = "您沒有本機編輯";
-
-"editor_no_local_edits_description" = "這顯示了對目前僅可在您的裝置上存取的地圖的建議修改數量。";
-
-"editor_send_to_osm" = "傳送至 OSM";
-
-"editor_remove" = "移除";
-
-"downloader_my_maps_title" = "我的地圖";
-
 "downloader_no_downloaded_maps_title" = "您尚未下載任何地圖";
 
 "downloader_no_downloaded_maps_message" = "下載地圖來尋找位置和離線瀏覽。";
-
-"downloader_find_place_hint" = "搜尋城市或國家";
 
 /* Error title that appears after certain time without location. */
 "current_location_unknown_title" = "繼續偵測您的目前位置？";
@@ -1321,47 +863,13 @@
 /* iOS Dialog for the case when the location permission is not granted */
 "location_services_disabled_3" = "3. 使用應用時選擇";
 
-"placepage_parking_surface" = "表面";
-
-"placepage_parking_multistorey" = "多樓層";
-
-"placepage_parking_underground" = "未知的位置";
-
-"placepage_parking_rooftop" = "樓頂";
-
-"placepage_parking_sheds" = "小屋";
-
-"placepage_parking_carports" = "屋側車庫";
-
-"placepage_parking_boxes" = "停車房";
-
-"placepage_parking_pay" = "付款";
-
-"placepage_parking_free" = "免費";
-
-"placepage_parking_interval" = "間隔付款";
-
-"placepage_entrance_number" = "編號";
-
-"placepage_entrance_type" = "入口";
-
-"placepage_flat" = "公寓";
-
-"placepage_open_24_7" = "全天候";
-
 "meter" = "米";
 
 "kilometer" = "公里";
 
-"kilometers_per_hour" = "公里每小時";
-
 "mile" = "英里";
 
 "foot" = "英尺";
-
-"miles_per_hour" = "英里每小時";
-
-"day" = "天";
 
 "hour" = "小時";
 
@@ -1381,10 +889,6 @@
 
 "placepage_bookmark_name_hint" = "書籤名稱";
 
-"placepage_personal_notes_hint" = "個人備註";
-
-"placepage_delete_bookmark_button" = "刪除書籤";
-
 "editor_edits_sent_message" = "您的建議已傳送";
 
 "editor_comment_hint" = "註解…";
@@ -1397,8 +901,6 @@
 
 "editor_remove_place_button" = "移除";
 
-"editor_status_sending" = "正在傳送…";
-
 "editor_place_doesnt_exist" = "位置不存在";
 
 "text_more_button" = "…更多";
@@ -1410,11 +912,7 @@
 
 "error_enter_correct_email" = "輸入有效電子郵箱";
 
-"error_enter_correct" = "輸入有效值";
-
 "refresh" = "更新";
-
-"last_update" = "上次更新於：%s";
 
 "placepage_add_place_button" = "添加地點到地圖上";
 
@@ -1426,24 +924,6 @@
 
 "editor_share_to_all_dialog_message_2" = "我們會檢查更改。如果我們有任何問題，我們會郵件與您聯系。";
 
-"navigation_overview_button" = "概覽";
-
-"navigation_stop_button" = "停止";
-
-/* Text on an empty bookmark page */
-"bookmarks_empty_title" = "儲存書籤";
-
-"bookmarks_empty_message_1" = "按★ 儲存至愛地點以方便存取。";
-
-"bookmarks_empty_message_2" = "從 Mail及網上匯入書籤。";
-
-"bookmarks_empty_message_3" = "退房： %s";
-
-/* Name of the group for booked hotels */
-"bookmarks_group_name" = "預訂的酒店";
-
-"place_page_button_read_descriprion" = "閱讀";
-
 /* iOS dialog for the case when recent track recording is on and the app comes back from background */
 "recent_track_background_dialog_title" = "禁止記錄您最近去過的路徑？";
 
@@ -1451,8 +931,6 @@
 
 /* For sharing via SMS and so on */
 "sharing_call_action_look" = "看一看";
-
-"continue_recent_track_background_button" = "繼續";
 
 "recent_track_background_dialog_message" = "Organic Maps使用背景中的地理位置記錄您最近去過的路徑。";
 
@@ -1468,33 +946,13 @@
 /* About short text (below logo) */
 "about_description" = "Organic Maps 是一款基本離線旅遊應用程式。Organic Maps 以 OpenStreetMap 數據為基礎，並允許對其進行編輯。";
 
-/* Text in menu */
-"blog" = "部落格";
-
 "general_settings" = "一般設定";
-
-"date" = "日期 %d";
-
-/* "Report a bug" -> "Generaal Feedback" -> "Something is not working" */
-"something_is_not_working" = "某些地方出錯了";
 
 /* For the first routing */
 "accept" = "接受";
 
-"accept_and_continue" = "Accept and continue";
-
 /* For the first routing */
 "decline" = "拒絕";
-
-"install_app" = "安裝";
-
-"search_no_results_title" = "找不到任何結果";
-
-"search_no_results_message" = "嘗試一個更普通的搜尋字詞、縮小顯示或重設篩選條件。";
-
-"search_no_results_expand_area_button" = "縮小";
-
-"search_no_results_reset_button" = "重設篩選條件";
 
 /* noun */
 "search_in_table" = "清單";
@@ -1517,8 +975,6 @@
 
 "traffic_update_maps_text" = "若要顯示交通資料，必須更新地圖。";
 
-"traffic_outdated" = "交通資料已過時。";
-
 "big_font" = "增加地圖上的字體大小";
 
 "traffic_update_app" = "請更新 Organic Maps";
@@ -1529,17 +985,7 @@
 /* "traffic" as in "road congestion" */
 "traffic_data_unavailable" = "無法使用交通資訊";
 
-/* "Translation is no needed, because it's a company name" */
-"uber" = "Uber";
-
-/* Simplified colour scheme for traffic information, fewer colours are used to display traffic jams on the map. The string should be kept as short as possible */
-"pref_traffic_simplified_colors_title" = "簡化的交通狀況顏色";
-
 "enable_logging" = "啟用記錄";
-
-"offline_place_page_more_information" = "連上網路以取得關於地點的更多資訊。";
-
-"failed_load_information" = "無法載入資訊。";
 
 /* Settings: "Send general feedback" button */
 "feedback_general" = "一般反應";
@@ -1556,8 +1002,6 @@
 
 "whatsnew_transliteration_title" = "音譯為拉丁文";
 
-"yandex_taxi_title" = "Yandex.Taxi";
-
 "learn_more" = "瞭解更多資訊";
 
 "core_exit" = "退出";
@@ -1568,75 +1012,19 @@
 
 "button_exit" = "退出";
 
-"settings_device_memory" = "裝置記憶體";
-
-"settings_card_memory" = "卡記憶體";
-
-"settings_storage_available" = "%s 可用";
-
-"toast_location_permission_denied" = "應用程式地點存取權限被拒絕";
-
-"button_use" = "使用";
-
 "planning_route_manage_route" = "管理路線";
 
 "button_plan" = "計畫";
-
-"button_add" = "新增";
 
 "placepage_remove_stop" = "移除";
 
 "planning_route_remove_title" = "在此拖曳以移除";
 
-"dialog_change_start_point_message" = "取代目前位置的起點嗎？";
-
-"button_replace" = "取代";
-
 "placepage_add_stop" = "新增應用程式";
-
-/* Only ru/en are needed */
-"subtitle_rent" = "Rent";
-
-/* Only ru/en are needed */
-"rub_month" = "RUB/month";
-
-/* Only ru/en are needed */
-"room" = "%s-room apt.";
-
-/* Only ru/en are needed */
-"real_estate" = "Real estate";
-
-"add_my_position" = "新增我的位置";
-
-"choose_start_point" = "選擇起點";
-
-"choose_destination" = "選擇目的地";
 
 "preloader_viator_button" = "進一步了解";
 
-"start_from_my_position" = "起點";
-
-"profile_authorization_title" = "登入方式";
-
-"profile_authorization_message" = "無須帳號密碼，在幾秒內輕鬆登入。";
-
 "profile_authorization_error" = "噢，發生錯誤。請嘗試再次登入。";
-
-"service" = "服務";
-
-"atmosphere" = "氣氛";
-
-"value_for_money" = "物有所值";
-
-"experience" = "體驗";
-
-"assortment" = "分類";
-
-"expertise" = "專業";
-
-"equipment" = "設備";
-
-"quality" = "品質";
 
 "dialog_error_storage_title" = "儲存空間存取問題";
 
@@ -1644,17 +1032,7 @@
 
 "setting_emulate_bad_storage" = "模擬不良儲存空間";
 
-"directions_finish" = "目的地";
-
-"directions_on_foot" = "步行 %s";
-
 "core_entrance" = "入口";
-
-"coffee" = "咖啡";
-
-"cleanliness" = "清潔程度";
-
-"crowdedness" = "擁擠程度";
 
 "error_enter_correct_name" = "請輸入正確的名稱";
 
@@ -1677,8 +1055,6 @@
 
 "downloader_applying" = "應用 %s 中……";
 
-"dialog_message_transit_not_found_connection" = "規劃一個交通網絡內的路線";
-
 "bookmarks_error_message_share_general" = "由於應用程序出錯而無法分享";
 
 "bookmarks_error_title_share_empty" = "分享錯誤";
@@ -1695,17 +1071,7 @@
 
 "bookmarks_error_message_list_name_already_taken" = "請選擇其他名稱";
 
-"bookmarks_error_title_list_name_too_long" = "這個名字太長了";
-
-"bookmarks_error_message_list_name_too_long" = "請選擇其他名稱";
-
-"please_wait" = "請稍候...";
-
-"phone_number" = "電話號碼";
-
-"notification_unsent_reviews_title" = "你有幾個未發表的評論";
-
-"notification_unsent_reviews_message" = "請登錄與其他旅客分享評論";
+"please_wait" = "請稍候…";
 
 "profile" = "OpenStreetMap 資料";
 
@@ -1719,49 +1085,13 @@
 
 "bookmarks_convert_error_message" = "有些文件未被轉換。";
 
-"converting" = "轉換...";
-
-"wn_reinvented_bookmarks_title" = "我們改造了書籤！";
-
-"wn_reinvented_bookmarks_message" = "你可以備份書籤，創建列表...這太神奇了...";
-
-"bookmarks_restore" = "恢復書籤";
-
-"bookmarks_restore_process" = "恢復...";
-
 "bookmarks_restore_title" = "還原這個版本？";
 
-"bookmarks_restore_message" = "您的書籤將從%s (%s)個恢復";
-
-"bookmarks_restore_empty_title" = "你沒有備份";
-
-"bookmarks_restore_empty_message" = "服務器沒有找到以前做的備份";
-
 "common_check_internet_connection_dialog_title" = "沒有互聯網連接";
-
-"error_server_title" = "服務器錯誤";
-
-"error_server_message" = "服務器發生錯誤，請稍後重試";
 
 "error_system_message" = "出現未知錯誤";
 
 "restore" = "恢復";
-
-"bookmarks_page_downloaded" = "加載";
-
-"bookmarks_page_my" = "我的";
-
-"routes_and_bookmarks" = "路線和標籤";
-
-"bookmarks_webview_success_toast" = "標籤已成功加載";
-
-"cached_bookmarks_placeholder_title" = "上傳新地點";
-
-"cached_bookmarks_placeholder_subtitle" = "單擊按鈕下載Organic Maps用戶創建的數千個有趣的地點和路線。您需要網絡連接。";
-
-"downloader_download_routers" = "加載標籤";
-
-"bookmarks_groups_cached" = "加載的列表";
 
 "subtittle_opt_out" = "跟蹤設置";
 
@@ -1769,29 +1099,15 @@
 
 "crash_reports_description" = "我們可以使用您的數據來開發和改進Organic Maps。更改將再重新啟動應用程序后生效。";
 
-"opt_out_help_ios_1" = "您可以選擇停止在設備設置中接受定向廣告。";
-
-"opt_out_help_ios_2" = "iOS 9或更高版本";
-
-"opt_out_help_ios_3" = "請打開設置 → 隱私 → 廣告 → 啟用“跟蹤限制”";
-
-"opt_out_help_android" = "您可以選擇停止在設備設置中接受定向廣告。Android и Google Play Services 4.0或更高版本\n\n電話設置 → Google → 廣告 → 停用廣告個性化\n或\n電話設置 → Google → Google賬戶 → 隱私 → 首選項設置 → 廣告個性化";
-
 "privacy_policy" = "隱私政策";
 
 "terms_of_use" = "使用條款";
-
-"backup_notification_failed" = "標籤的備份已暫停。請登錄以啟用設備。";
 
 "button_layer_traffic" = "堵塞";
 
 "button_layer_subway" = "地鐵";
 
 "layers_title" = "地圖圖層";
-
-"layers_message" = "請打開地圖圖層、地鐵圖及其他有用信息來顯示交通狀況。";
-
-"button_layer_got_it" = "明白";
 
 "subway_data_unavailable" = "地鐵圖不可用";
 
@@ -1803,39 +1119,13 @@
 
 "title_error_downloading_bookmarks" = "發生錯誤";
 
-"subtitle_error_downloading_bookmarks" = "標籤未加載";
-
-"error_already_downloaded" = "這個列表已被下載";
-
 "popular_place" = "Popular";
-
-"download_routes" = "Download routes";
-
-"bookmarks_downloaded_title" = "Bookmarks have been downloaded successfully";
-
-"bookmarks_downloaded_subtitle" = "Press ‘View on map’ to explore new places from the list";
-
-"why_support" = "為什麼支持Organic Maps?";
-
-"why_support_item1" = "We respect your privacy: there are zero trackers in the app, and we are open source";
-
-"why_support_item2" = "您幫助我們改進Organic Maps";
-
-"why_support_item3" = "您幫助我們改進OpenStreetMap.org地圖";
-
-"channels_map_update" = "更新地圖";
-
-"server_unavailable_title" = "服務不可用";
-
-"sharing_options" = "登錄設置";
 
 "export_file" = "導出文件";
 
 "list_settings" = "列表設置";
 
 "delete_list" = "刪除列表";
-
-"hide_from_map" = "從卡中隱藏";
 
 "public_access" = "公共訪問";
 
@@ -1845,40 +1135,11 @@
 
 "bookmark_category_description_hint" = "添加說明(文字或html)";
 
-/* FIXME */
-"bookmarks_public_access" = "bookmarks_public_access";
-
-/* FIXME */
-"bookmarks_link_access" = "bookmarks_link_access";
-
-/* FIXME */
-"bookmarks_private_access" = "bookmarks_private_access";
-
 "not_shared" = "個人";
-
-"direct_link_progress_text" = "正在上傳您的文件......";
-
-"direct_link_success" = "鏈接已創建";
-
-"send_a_link_btn" = "發送鏈接";
-
-"upload_error_toast" = "加載文件時出錯";
 
 "tags_loading_error_subtitle" = "加載代碼時出錯，請重試";
 
-"unable_upload_errorr_title" = "無法上傳文件";
-
-"unable_upload_error_subtitle_edited" = "文件是通過Web應用程序編輯的";
-
-"unable_upload_error_subtitle_broken" = "該文件已損壞，無法上傳。請上傳其他文件。";
-
-"contact" = "寫";
-
-"download_button" = "下載";
-
 "speedcams_alert_title" = "高速相機";
-
-"speedcams_alert_subtitle" = "警告速度限制";
 
 "speedcam_option_auto" = "自動";
 
@@ -1886,18 +1147,10 @@
 
 "speedcam_option_never" = "從不";
 
-"bookmark_description_title" = "標籤說明";
-
 "place_description_title" = "地點說明";
 
 /* this text will be shown in application notification preferences opposite checkbox which enable/disable downloader notifications. Devices on Android 8+ are affected. */
 "notification_channel_downloader" = "加載地圖";
-
-"share_bookmarks_email_body_link" = "您好！\n\n您的標籤可以從鏈接下載：%s.使用Organic Maps打開列表並享受旅行!\n\n下載應用程序：https://omaps.app/get?kmz";
-
-"warning_speedcams_title" = "當速度限制超過%d km / h時，導航會通知您的攝像機";
-
-"warning_speedcams_subtitle" = "請不要忘記閱讀旅行國的道路規則。";
 
 "speedcams_notice_message" = "自動 - 如果存在超出速度限制的風險，則對速度攝像頭髮出警告\n總是 - 始終提醒攝像頭\n從不 - 永遠不會對攝像頭發出警告";
 
@@ -1913,23 +1166,7 @@
 
 "enable_logging_warning_message" = "此選項啟用以記錄操作來進行診斷。這有助於團隊識別應用程序的問題。請僅在Organic Maps支持請求時開啟該選項。";
 
-"html_error_upload_message_try_again" = "請檢查網絡訪問，然後再重試";
-
-"html_error_upload_title_try_again" = "未連接到網絡";
-
-"notification_leave_review_v2_android_short_title" = "請發表評論來幫助旅行者們！";
-
-"megafon" = "Say goodbye to roaming!";
-
-"notifications_illegal_alert_disable_button" = "關閉通知";
-
 "access_rules_author_only" = "在線編輯";
-
-"privacy_settings_menu" = "隱私設置";
-
-"unable_upadate_error_title" = "無法更新路線";
-
-"unable_upadate_error_message" = "更新時出錯。請檢查更改，然後再重試";
 
 "driving_options_title" = "繞行設置";
 
@@ -1951,94 +1188,19 @@
 
 "change_driving_options_btn" = "绕行设置已开启";
 
-"toll_road" = "收費公路";
-
-"unpaved_road" = "土路";
-
-"ferry_crossing" = "輪渡";
-
-"operated_by" = "由\"%s\"管理";
-
 "avoid_toll_roads_placepage" = "規避收費公路";
 
 "avoid_unpaved_roads_placepage" = "規避土路";
 
 "avoid_ferry_crossing_placepage" = "規避輪渡";
 
-"type.cuisine.uzbek" = "烏茲別克美食";
-
-"trip_start" = "前往";
-
-"pick_destination" = "目標";
-
-"follow_my_position" = "定好中心";
-
-"search_results" = "搜索結果";
-
-"then_turn" = "接下來";
-
-"redirect_route_alert" = "想重建路線?";
-
-"redirect_route_yes" = "是";
-
-"redirect_route_no" = "否";
-
-"trip_finished" = "您已到達!";
-
-"keyboard_availability_alert" = "移動時鍵盤不可用";
-
-"dialog_routing_change_start_carplay" = "無法從當前位置構建路線";
-
-"dialog_routing_change_end_carplay" = "無法建立到終點的路線。請選擇其他（路線）";
-
-"dialog_routing_check_gps_carplay" = "無GPS信號。請沿著空曠區域行駛";
-
-"dialog_routing_unable_locate_route_carplay" = "無法建立路線。請選擇其他路線點";
-
-"dialog_routing_download_files_carplay" = "爲了創建線路，請在您的設備中下載所缺少的地圖";
-
-"dialog_routing_system_error_carplay" = "發生了錯誤。請重新啟動程序";
-
-"dialog_routing_rebuild_from_current_location_carplay" = "該路線將從您的當前位置重建";
-
-"dialog_routing_rebuild_for_vehicle_carplay" = "該路線將改為汽車（路線）";
-
 "ok" = "好的";
-
-"avoid_unpaved_carplay_1" = "無土路路段";
-
-"avoid_unpaved_carplay_2" = "無土路路段";
-
-"avoid_ferry_carplay_1" = "無渡船";
-
-"avoid_ferry_carplay_2" = "無渡船";
-
-"avoid_tolls_carplay_1" = "無付費路段";
-
-"avoid_tolls_carplay_2" = "無付費路段";
-
-"speedcams_alert_title_carplay_1" = "攝像頭";
-
-"speedcams_alert_title_carplay_2" = "攝像頭信息";
-
-"download_map_carplay" = "將Organic Maps軟件中的地圖下載至個人設備中";
-
-"carplay_roundabout_exit" = "%s號坡道";
 
 /* max. 10 symbols, both iOS and Android */
 "sort" = "分類……";
 
 /* Android, title, max 20-22 symbols */
 "sort_bookmarks" = "分類標籤";
-
-/* iOS */
-"sort_default" = "默認排序";
-
-"sort_type" = "按類型排序";
-
-"sort_distance" = "按距離排序";
-
-"sort_date" = "按日期排序";
 
 /* Android */
 "by_default" = "默認情況下";
@@ -2052,63 +1214,7 @@
 /* Android */
 "by_date" = "按時間";
 
-"week_ago_sorttype" = "一周前";
-
-"month_ago_sorttype" = "一月前";
-
-"moremonth_ago_sorttype" = "一個多月前";
-
-"moreyear_ago_sorttype" = "一年多以前";
-
-"near_me_sorttype" = "在我旁邊";
-
-"others_sorttype" = "其他";
-
-"food_places" = "美食";
-
-"tourist_places" = "名勝";
-
-"museums" = "博物館";
-
-"parks" = "公園";
-
-"swim_places" = "游泳";
-
-"mountains" = "山";
-
-"animals" = "動物";
-
-"hotels" = "酒店";
-
-"buildings" = "建築物";
-
-"money" = "貨幣";
-
-"shops" = "商店";
-
-"parkings" = "停車場";
-
-"fuel_places" = "加油站";
-
-"water" = "水";
-
-"medicine" = "醫療";
-
 "search_in_the_list" = "在列表中搜索";
-
-"view_on_map_bookmarks" = "在地圖上";
-
-"more_bookmarks" = "更多……";
-
-"no_items_found" = "未搜索到內容";
-
-/* Android, max 18 symbols */
-"bookmarks_edit_list" = "編輯";
-
-/* Android, max 18 symbols */
-"bookmarks_delete_list" = "刪除列表";
-
-"religious_places" = "聖地";
 
 "select_list" = "選擇列表";
 
@@ -2118,26 +1224,13 @@
 
 "dialog_pedestrian_route_is_long_message" = "選擇地鐵站附近的起點和終點";
 
-/* Failed planning SUBWAY route message in navigation view */
-"routing_planning_error_subway_special" = "地鐵路線圖設計出錯";
-
 "button_layer_isolines" = "高度";
-
-"tips_map_layers_title_countour" = "離線高度線在Organic Maps中！";
-
-"tips_map_layers_message_countour" = "高度線可以幫您規劃通往大自然地區的路線，不會迷路";
 
 "isolines_activation_error_dialog" = "如需使用高度线，请更新或下载所需区域的地图";
 
 "isolines_location_error_dialog" = "暫時無法獲取該地區的高低線";
 
 "elevation_profile_diff_level" = "難度等級";
-
-"elevation_profile_diff_level_easy" = "容易";
-
-"elevation_profile_diff_level_moderate" = "中等";
-
-"elevation_profile_diff_level_hard" = "困難";
 
 "elevation_profile_ascent" = "上坡";
 
@@ -2147,25 +1240,13 @@
 
 "elevation_profile_maxaltitude" = "最大高度";
 
-"elevation_profile_m" = "米";
-
 "elevation_profile_difficulty" = "難度";
 
 "elevation_profile_distance" = "距離：";
 
-"elevation_profile_km" = "千米";
-
 "elevation_profile_time" = "在路上：";
 
-"elevation_profile_hours" = "小時";
-
-"elevation_profile_minutes" = "分鐘";
-
 "isolines_toast_zooms_1_10" = "放大地圖以查看等高線";
-
-"downloader_updating_ios" = "更新";
-
-"downloader_loading_ios" = "加載";
 
 "key_information_title" = "關鍵信息";
 

--- a/iphone/Maps/LocalizedStrings/zh-Hant.lproj/Localizable.stringsdict
+++ b/iphone/Maps/LocalizedStrings/zh-Hant.lproj/Localizable.stringsdict
@@ -9,21 +9,6 @@
 
 <!-- ********** Strings for downloading map from search **********/ -->
 
-  <key>bookmarks_places</key>
-  <dict>
-    <key>NSStringLocalizedFormatKey</key>
-    <string>%#@value@</string>
-    <key>value</key>
-    <dict>
-      <key>NSStringFormatSpecTypeKey</key>
-      <string>NSStringPluralRuleType</string>
-      <key>NSStringFormatValueTypeKey</key>
-      <string>d</string>
-      <key>other</key>
-      <string>%d個書籤</string>
-    </dict>
-  </dict>
-
   <key>bookmarks_detect_message</key>
   <dict>
     <key>NSStringLocalizedFormatKey</key>
@@ -36,21 +21,6 @@
       <string>d</string>
       <key>other</key>
       <string>找到%d個文件。 轉換後你會看到它。</string>
-    </dict>
-  </dict>
-
-  <key>bookmarks_objects</key>
-  <dict>
-    <key>NSStringLocalizedFormatKey</key>
-    <string>%#@value@</string>
-    <key>value</key>
-    <dict>
-      <key>NSStringFormatSpecTypeKey</key>
-      <string>NSStringPluralRuleType</string>
-      <key>NSStringFormatValueTypeKey</key>
-      <string>d</string>
-      <key>other</key>
-      <string>%s 對象</string>
     </dict>
   </dict>
 


### PR DESCRIPTION
There is a special tool `/tools/python/clean_strings_txt.py` for cleaning and formatting `strings.txt` file. 
The script is pretty old, but looks like it still works!
I've made a few changes, and now it supports `python3` and plural strings.