### PR TITLE
[tools][twine] Build twine gem before usage

### DIFF
--- a/tools/unix/generate_localizations.sh
+++ b/tools/unix/generate_localizations.sh
@@ -2,19 +2,47 @@
 set -e -u -x
 
 # Use ruby from brew on Mac OS X, because system ruby is outdated/broken/will be removed in future releases.
-case $OSTYPE in darwin*)
-  if [ -x /usr/local/opt/ruby/bin/ruby ]; then
-    PATH="/usr/local/opt/ruby/bin:$PATH"
-  elif [ -x /opt/homebrew/opt/ruby/bin/ruby ]; then
-    PATH="/opt/homebrew/opt/ruby/bin:$PATH"
-  else
-    echo 'Please install Homebrew ruby by running "brew install ruby"'
-    exit -1
-  fi
+case $OSTYPE in 
+  darwin*)
+    if [ -x /usr/local/opt/ruby/bin/ruby ]; then
+      PATH="/usr/local/opt/ruby/bin:$PATH"
+    elif [ -x /opt/homebrew/opt/ruby/bin/ruby ]; then
+      PATH="/opt/homebrew/opt/ruby/bin:$PATH"
+    else
+      echo 'Please install Homebrew ruby by running "brew install ruby"'
+      exit -1 
+    fi ;;
+  *)
+    if [ ! -x "$(which ruby)" ]; then
+      echo "Please, install ruby (https://www.ruby-lang.org/en/documentation/installation/)"
+      exit 1
+    fi ;;
 esac
 
 OMIM_PATH="$(dirname "$0")/../.."
-TWINE="$OMIM_PATH/tools/twine/twine"
+TWINE_SUBMODULE=tools/twine
+TWINE_PATH="$OMIM_PATH/$TWINE_SUBMODULE"
+
+if [ ! -e "$TWINE_PATH/twine" ]; then
+  echo "You need to have twine submodule present to run this script"
+  echo "Try 'git submodule update --init --recursive'"
+  exit 1
+fi
+
+TWINE_COMMIT="$(git rev-parse HEAD:$TWINE_SUBMODULE)"
+TWINE_GEM="twine-$TWINE_COMMIT.gem"
+
+if [ ! -f "$TWINE_PATH/$TWINE_GEM" ] || ! gem list -i twine; then
+  echo "Building & installing twine gem..."
+  (
+    cd $TWINE_PATH \
+    && rm -f *.gem \
+    && gem build --output $TWINE_GEM \
+    && gem install $TWINE_GEM
+  )
+fi
+
+TWINE="$(gem contents twine | grep -m 1 bin/twine)"
 STRINGS_PATH="$OMIM_PATH/data/strings"
 
 MERGED_FILE="$(mktemp)"


### PR DESCRIPTION
We use tool called `twine` to generate strings. `twine` is basically just a ruby gem integrated as a git submodule.
This gem has two runtime dependencies `safe_yaml` and `rubyzip` (described in `twine.gemspec` file).
Unfortunately, this fact is not documented anywhere. Script `generate_localizations.sh` advises installing ruby only, which is not enough to run `twine` properly (#889).

This PR proposes the following changes to `generate_localizations.sh` file:

- `twine` is now built, packed and installed using built-in tool called `gem`.
- `twine` package will be rebuilt and reinstalled automatically if `tools/twine` HEAD commit changes.
- added check that `twine` submodule is fetched correctly.
