### PR TITLE
[iOS] ability to edit/move/delete tracks

### DIFF
--- a/android/res/values-ar/strings.xml
+++ b/android/res/values-ar/strings.xml
@@ -818,6 +818,8 @@
 	<string name="whats_new_auto_update_button_size">تحديث (%s)</string>
 	<!-- Autoupdate dialog on start -->
 	<string name="whats_new_auto_update_button_later">تحديث يدوياً في وقت لاحق</string>
+	<!-- edit track screen title -->
+	<string name="track_title">مسار</string>
 
 	<!-- SECTION: Types -->
 	<string name="type.aerialway.station">محطة تلفريك</string>

--- a/android/res/values-cs/strings.xml
+++ b/android/res/values-cs/strings.xml
@@ -818,6 +818,8 @@
 	<string name="whats_new_auto_update_button_size">Aktualizace (%s)</string>
 	<!-- Autoupdate dialog on start -->
 	<string name="whats_new_auto_update_button_later">Aktualizovat ručně později</string>
+	<!-- edit track screen title -->
+	<string name="track_title">Dráha</string>
 
 	<!-- SECTION: Types -->
 	<string name="type.aerialway.station">Stanice lanové dráhy</string>

--- a/android/res/values-da/strings.xml
+++ b/android/res/values-da/strings.xml
@@ -819,6 +819,8 @@
 	<string name="whats_new_auto_update_button_size">Opdater (%s)</string>
 	<!-- Autoupdate dialog on start -->
 	<string name="whats_new_auto_update_button_later">Opdater manuelt senere</string>
+	<!-- edit track screen title -->
+	<string name="track_title">Rute</string>
 
 	<!-- SECTION: Types -->
 	<string name="type.aerialway.station">Kabelbanestation</string>

--- a/android/res/values-de/strings.xml
+++ b/android/res/values-de/strings.xml
@@ -821,6 +821,8 @@
 	<string name="whats_new_auto_update_button_size">Aktualisieren (%s)</string>
 	<!-- Autoupdate dialog on start -->
 	<string name="whats_new_auto_update_button_later">Später manuell aktualisieren</string>
+	<!-- edit track screen title -->
+	<string name="track_title">Strecken</string>
 
 	<!-- SECTION: Types -->
 	<string name="type.aerialway.station">Seilbahn</string>

--- a/android/res/values-el/strings.xml
+++ b/android/res/values-el/strings.xml
@@ -809,6 +809,8 @@
 	<string name="whats_new_auto_update_button_size">Ενημέρωση (%s)</string>
 	<!-- Autoupdate dialog on start -->
 	<string name="whats_new_auto_update_button_later">Χειροκίνητη ενημέρωση αργότερα</string>
+	<!-- edit track screen title -->
+	<string name="track_title">Τροχιά</string>
 
 	<!-- SECTION: Types -->
 	<string name="type.aerialway.station">Σταθμός αερομεταφοράς</string>

--- a/android/res/values-es/strings.xml
+++ b/android/res/values-es/strings.xml
@@ -815,6 +815,8 @@
 	<string name="whats_new_auto_update_button_size">Actualizar (%s)</string>
 	<!-- Autoupdate dialog on start -->
 	<string name="whats_new_auto_update_button_later">Actualizar más tarde de forma manual</string>
+	<!-- edit track screen title -->
+	<string name="track_title">Ruta</string>
 
 	<!-- SECTION: Types -->
 	<string name="type.aerialway.station">Estación de teleférico</string>

--- a/android/res/values-fa/strings.xml
+++ b/android/res/values-fa/strings.xml
@@ -810,6 +810,8 @@
 	<string name="whats_new_auto_update_button_size">بروزرسانی (%s)</string>
 	<!-- Autoupdate dialog on start -->
 	<string name="whats_new_auto_update_button_later">بعدا به صورت دستی به روزرسانی کنید</string>
+	<!-- edit track screen title -->
+	<string name="track_title">مسیر</string>
 
 	<!-- SECTION: Types -->
 	<string name="type.aeroway.aerodrome">فرودگاه</string>

--- a/android/res/values-fi/strings.xml
+++ b/android/res/values-fi/strings.xml
@@ -819,6 +819,8 @@
 	<string name="whats_new_auto_update_button_size">Päivitä (%s)</string>
 	<!-- Autoupdate dialog on start -->
 	<string name="whats_new_auto_update_button_later">Päivitä manuaalisesti myöhemmin</string>
+	<!-- edit track screen title -->
+	<string name="track_title">Reitti</string>
 
 	<!-- SECTION: Types -->
 	<string name="type.aerialway.station">Köysirata-asema</string>

--- a/android/res/values-fr/strings.xml
+++ b/android/res/values-fr/strings.xml
@@ -827,6 +827,8 @@
 	<string name="whats_new_auto_update_button_size">Mettre à jour (%s)</string>
 	<!-- Autoupdate dialog on start -->
 	<string name="whats_new_auto_update_button_later">Mettre à jour manuellement plus tard</string>
+	<!-- edit track screen title -->
+	<string name="track_title">Route</string>
 
 	<!-- SECTION: Types -->
 	<string name="type.aerialway.station">Remontées mécaniques</string>

--- a/android/res/values-hu/strings.xml
+++ b/android/res/values-hu/strings.xml
@@ -816,6 +816,8 @@
 	<string name="whats_new_auto_update_button_size">Frissítés (%s)</string>
 	<!-- Autoupdate dialog on start -->
 	<string name="whats_new_auto_update_button_later">Kézi frissítés később</string>
+	<!-- edit track screen title -->
+	<string name="track_title">Útvonal</string>
 
 	<!-- SECTION: Types -->
 	<string name="type.aerialway.station">Felvonóállomás</string>

--- a/android/res/values-in/strings.xml
+++ b/android/res/values-in/strings.xml
@@ -819,6 +819,8 @@
 	<string name="whats_new_auto_update_button_size">Pembaruan (%s)</string>
 	<!-- Autoupdate dialog on start -->
 	<string name="whats_new_auto_update_button_later">Perbarui secara manual nanti</string>
+	<!-- edit track screen title -->
+	<string name="track_title">Trek</string>
 
 	<!-- SECTION: Types -->
 	<string name="type.aerialway.station">Stasiun kereta gantung</string>

--- a/android/res/values-it/strings.xml
+++ b/android/res/values-it/strings.xml
@@ -815,6 +815,8 @@
 	<string name="whats_new_auto_update_button_size">Aggiorna (%s)</string>
 	<!-- Autoupdate dialog on start -->
 	<string name="whats_new_auto_update_button_later">Aggiorna manualmente più tardi</string>
+	<!-- edit track screen title -->
+	<string name="track_title">Traccia</string>
 
 	<!-- SECTION: Types -->
 	<string name="type.aerialway.station">Funivia</string>

--- a/android/res/values-ja/strings.xml
+++ b/android/res/values-ja/strings.xml
@@ -814,6 +814,8 @@
 	<string name="whats_new_auto_update_button_size">更新 (%s)</string>
 	<!-- Autoupdate dialog on start -->
 	<string name="whats_new_auto_update_button_later">あとで手動で更新</string>
+	<!-- edit track screen title -->
+	<string name="track_title">トラック</string>
 
 	<!-- SECTION: Types -->
 	<string name="type.aerialway">索道</string>

--- a/android/res/values-ko/strings.xml
+++ b/android/res/values-ko/strings.xml
@@ -816,6 +816,8 @@
 	<string name="whats_new_auto_update_button_size">업데이트(%s)</string>
 	<!-- Autoupdate dialog on start -->
 	<string name="whats_new_auto_update_button_later">나중에 수동으로 업데이트</string>
+	<!-- edit track screen title -->
+	<string name="track_title">길</string>
 
 	<!-- SECTION: Types -->
 	<string name="type.aerialway.station">케이블카 역</string>

--- a/android/res/values-nb/strings.xml
+++ b/android/res/values-nb/strings.xml
@@ -795,6 +795,8 @@
 	<string name="whats_new_auto_update_button_size">Oppdater (%s)</string>
 	<!-- Autoupdate dialog on start -->
 	<string name="whats_new_auto_update_button_later">Oppdater manuelt senere</string>
+	<!-- edit track screen title -->
+	<string name="track_title">Rute</string>
 
 	<!-- SECTION: Types -->
 	<string name="type.aerialway.station">Kabelbanestasjon</string>

--- a/android/res/values-nl/strings.xml
+++ b/android/res/values-nl/strings.xml
@@ -814,6 +814,8 @@
 	<string name="whats_new_auto_update_button_size">Bijwerken (%s)</string>
 	<!-- Autoupdate dialog on start -->
 	<string name="whats_new_auto_update_button_later">Later handmatig bijwerken</string>
+	<!-- edit track screen title -->
+	<string name="track_title">Track</string>
 
 	<!-- SECTION: Types -->
 	<string name="type.aerialway.station">Kabelwagenstation</string>

--- a/android/res/values-pl/strings.xml
+++ b/android/res/values-pl/strings.xml
@@ -824,6 +824,8 @@
 	<string name="whats_new_auto_update_button_size">Zaktualizuj (%s)</string>
 	<!-- Autoupdate dialog on start -->
 	<string name="whats_new_auto_update_button_later">Zaktualizuj ręcznie później</string>
+	<!-- edit track screen title -->
+	<string name="track_title">Trasa</string>
 
 	<!-- SECTION: Types -->
 	<string name="type.aerialway">Transport linowy</string>

--- a/android/res/values-pt-rBR/strings.xml
+++ b/android/res/values-pt-rBR/strings.xml
@@ -833,6 +833,8 @@
 	<string name="whats_new_auto_update_button_size">Atualizar (%s)</string>
 	<!-- Autoupdate dialog on start -->
 	<string name="whats_new_auto_update_button_later">Atualizar manualmente mais tarde</string>
+	<!-- edit track screen title -->
+	<string name="track_title">Percurso</string>
 
 	<!-- SECTION: Types -->
 	<string name="type.aerialway.station">Estação de teleférico</string>

--- a/android/res/values-pt/strings.xml
+++ b/android/res/values-pt/strings.xml
@@ -835,6 +835,8 @@
 	<string name="whats_new_auto_update_button_size">Atualizar (%s)</string>
 	<!-- Autoupdate dialog on start -->
 	<string name="whats_new_auto_update_button_later">Atualizar manualmente mais tarde</string>
+	<!-- edit track screen title -->
+	<string name="track_title">Percurso</string>
 
 	<!-- SECTION: Types -->
 	<string name="type.aerialway.station">Estação de teleférico</string>

--- a/android/res/values-ro/strings.xml
+++ b/android/res/values-ro/strings.xml
@@ -818,6 +818,8 @@
 	<string name="whats_new_auto_update_button_size">Actualizare (%s)</string>
 	<!-- Autoupdate dialog on start -->
 	<string name="whats_new_auto_update_button_later">Actualizare manuală mai târziu</string>
+	<!-- edit track screen title -->
+	<string name="track_title">Rută</string>
 
 	<!-- SECTION: Types -->
 	<string name="type.aerialway.station">Stație de teleferic</string>

--- a/android/res/values-ru/strings.xml
+++ b/android/res/values-ru/strings.xml
@@ -846,6 +846,14 @@
 	<string name="whats_new_auto_update_button_size">Обновить (%s)</string>
 	<!-- Autoupdate dialog on start -->
 	<string name="whats_new_auto_update_button_later">Обновить вручную позже</string>
+	<!-- Delete track button on track edit screen -->
+	<string name="placepage_delete_track_button">Удалить трек</string>
+	<!-- Placeholder for track name input on track edit screen -->
+	<string name="placepage_track_name_hint">Название трека</string>
+	<!-- move track or bookmark from the list button text -->
+	<string name="move">Переместить</string>
+	<!-- edit track screen title -->
+	<string name="track_title">Трек</string>
 
 	<!-- SECTION: Types -->
 	<string name="type.aerialway.station">Канатная дорога</string>

--- a/android/res/values-sk/strings.xml
+++ b/android/res/values-sk/strings.xml
@@ -816,6 +816,8 @@
 	<string name="whats_new_auto_update_button_size">Aktualizovať (%s)</string>
 	<!-- Autoupdate dialog on start -->
 	<string name="whats_new_auto_update_button_later">Manuálne aktualizovať neskôr</string>
+	<!-- edit track screen title -->
+	<string name="track_title">Šľapaj Stopy</string>
 
 	<!-- SECTION: Types -->
 	<string name="type.aerialway.station">Lanovka</string>

--- a/android/res/values-sv/strings.xml
+++ b/android/res/values-sv/strings.xml
@@ -815,6 +815,8 @@
 	<string name="whats_new_auto_update_button_size">Uppdatera (%s)</string>
 	<!-- Autoupdate dialog on start -->
 	<string name="whats_new_auto_update_button_later">Uppdatera senare manuellt</string>
+	<!-- edit track screen title -->
+	<string name="track_title">Rutt</string>
 
 	<!-- SECTION: Types -->
 	<string name="type.aerialway.station">Linbanestation</string>

--- a/android/res/values-th/strings.xml
+++ b/android/res/values-th/strings.xml
@@ -818,6 +818,8 @@
 	<string name="whats_new_auto_update_button_size">อัปเดต (%s)</string>
 	<!-- Autoupdate dialog on start -->
 	<string name="whats_new_auto_update_button_later">อัปเดตด้วยตนเองภายหลัง</string>
+	<!-- edit track screen title -->
+	<string name="track_title">ติดตาม</string>
 
 	<!-- SECTION: Types -->
 	<string name="type.aerialway.station">สถานีกระเช้าลอยฟ้า</string>

--- a/android/res/values-tr/strings.xml
+++ b/android/res/values-tr/strings.xml
@@ -818,6 +818,8 @@
 	<string name="whats_new_auto_update_button_size">Güncelle (%s)</string>
 	<!-- Autoupdate dialog on start -->
 	<string name="whats_new_auto_update_button_later">Daha sonra manüel olarak güncelle</string>
+	<!-- edit track screen title -->
+	<string name="track_title">Rota</string>
 
 	<!-- SECTION: Types -->
 	<string name="type.aerialway.station">Remontées mécaniques</string>

--- a/android/res/values-uk/strings.xml
+++ b/android/res/values-uk/strings.xml
@@ -821,6 +821,8 @@
 	<string name="whats_new_auto_update_button_size">Оновити (%s)</string>
 	<!-- Autoupdate dialog on start -->
 	<string name="whats_new_auto_update_button_later">Оновити вручну пізніше</string>
+	<!-- edit track screen title -->
+	<string name="track_title">Маршрут</string>
 
 	<!-- SECTION: Types -->
 	<string name="type.aerialway.station">Канатна дорога</string>

--- a/android/res/values-vi/strings.xml
+++ b/android/res/values-vi/strings.xml
@@ -819,6 +819,8 @@
 	<string name="whats_new_auto_update_button_size">Cập nhật (%s)</string>
 	<!-- Autoupdate dialog on start -->
 	<string name="whats_new_auto_update_button_later">Cập nhật thủ công sau</string>
+	<!-- edit track screen title -->
+	<string name="track_title">Dấu chân</string>
 
 	<!-- SECTION: Types -->
 	<string name="type.aerialway.station">Trạm Cáp Treo</string>

--- a/android/res/values-zh-rTW/strings.xml
+++ b/android/res/values-zh-rTW/strings.xml
@@ -828,6 +828,8 @@
 	<string name="whats_new_auto_update_button_size">更新 (%s)</string>
 	<!-- Autoupdate dialog on start -->
 	<string name="whats_new_auto_update_button_later">稍後手動更新</string>
+	<!-- edit track screen title -->
+	<string name="track_title">追踪</string>
 
 	<!-- SECTION: Types -->
 	<string name="type.aerialway.cable_car">纜車</string>

--- a/android/res/values-zh/strings.xml
+++ b/android/res/values-zh/strings.xml
@@ -828,6 +828,8 @@
 	<string name="whats_new_auto_update_button_size">更新 (%s)</string>
 	<!-- Autoupdate dialog on start -->
 	<string name="whats_new_auto_update_button_later">稍后手动更新</string>
+	<!-- edit track screen title -->
+	<string name="track_title">追踪</string>
 
 	<!-- SECTION: Types -->
 	<string name="type.aerialway">缆车要素</string>

--- a/android/res/values/strings.xml
+++ b/android/res/values/strings.xml
@@ -852,6 +852,14 @@
 	<string name="whats_new_auto_update_button_size">Update (%s)</string>
 	<!-- Autoupdate dialog on start -->
 	<string name="whats_new_auto_update_button_later">Manually update later</string>
+	<!-- Delete track button on track edit screen -->
+	<string name="placepage_delete_track_button">Delete Track</string>
+	<!-- Placeholder for track name input on track edit screen -->
+	<string name="placepage_track_name_hint">Track Name</string>
+	<!-- move track or bookmark from the list button text -->
+	<string name="move">Move</string>
+	<!-- edit track screen title -->
+	<string name="track_title">Track</string>
 
 	<!-- SECTION: Types -->
 	<string name="type.aerialway">aerialway</string>

--- a/data/strings/strings.txt
+++ b/data/strings/strings.txt
@@ -2756,7 +2756,7 @@
 
   [edit]
     comment = resource for context menu
-    tags = android
+    tags = android, ios
     en = Edit
     ru = Редактировать
     bg = Редакция
@@ -21593,3 +21593,57 @@
     hi = बाद में मैनुअल रूप से अपडेट करें
     sk = Manuálne aktualizovať neskôr
     sw = Sasisha mwenyewe baadaye
+
+  [placepage_delete_track_button]
+    comment = Delete track button on track edit screen
+    tags = ios
+    en = Delete Track
+    ru = Удалить трек
+
+  [placepage_track_name_hint]
+    comment = Placeholder for track name input on track edit screen
+    tags = ios
+    en = Track Name
+    ru = Название трека
+
+  [move]
+    comment = move track or bookmark from the list button text
+    tags = ios
+    en = Move
+    ru = Переместить
+
+  [track_title]
+    comment = edit track screen title
+    tags = ios
+    en = Track
+    ru = Трек
+    bg = Пътека
+    ar = مسار
+    cs = Dráha
+    da = Rute
+    nl = Track
+    fi = Reitti
+    fr = Route
+    de = Strecken
+    hu = Útvonal
+    id = Trek
+    it = Traccia
+    ja = トラック
+    ko = 길
+    nb = Rute
+    pl = Trasa
+    pt = Percurso
+    pt-BR = Percurso
+    ro = Rută
+    es = Ruta
+    sv = Rutt
+    th = ติดตาม
+    tr = Rota
+    uk = Маршрут
+    vi = Dấu chân
+    zh-Hans = 追踪
+    zh-Hant = 追踪
+    el = Τροχιά
+    fa = مسیر
+    he = מַסלוּל
+    sk = Šľapaj Stopy

--- a/iphone/CoreApi/CoreApi/Bookmarks/MWMBookmarksManager.h
+++ b/iphone/CoreApi/CoreApi/Bookmarks/MWMBookmarksManager.h
@@ -69,6 +69,9 @@ NS_SWIFT_NAME(BookmarksManager)
 - (NSArray<MWMCarPlayBookmarkObject *> *)bookmarksForCategory:(MWMMarkGroupID)categoryId;
 - (MWMMarkIDCollection)bookmarkIdsForCategory:(MWMMarkGroupID)categoryId;
 - (void)deleteBookmark:(MWMMarkID)bookmarkId;
+- (void)deleteTrack:(MWMTrackID)trackId;
+- (MWMBookmark *)bookmarkWithId:(MWMMarkID)bookmarkId;
+- (MWMTrack *)trackWithId:(MWMTrackID)trackId;
 - (NSArray<MWMBookmark *> *)bookmarksForGroup:(MWMMarkGroupID)groupId;
 - (NSArray<MWMTrack *> *)tracksForGroup:(MWMMarkGroupID)groupId;
 - (NSArray<MWMBookmarkGroup *> *)collectionsForGroup:(MWMMarkGroupID)groupId;
@@ -88,11 +91,24 @@ NS_SWIFT_NAME(BookmarksManager)
 
 - (NSArray<MWMBookmarkGroup *> *)userCategories;
 - (MWMBookmarkGroup *)categoryWithId:(MWMMarkGroupID)groupId;
+- (MWMBookmarkGroup *)categoryForBookmarkId:(MWMMarkID)bookmarkId;
+- (MWMBookmarkGroup *)categoryForTrackId:(MWMTrackID)trackId;
+- (NSString *)descriptionForBookmarkId:(MWMMarkID)bookmarkId;
 - (void)updateBookmark:(MWMMarkID)bookmarkId
             setGroupId:(MWMMarkGroupID)groupId
                  title:(NSString *)title
                  color:(MWMBookmarkColor)color
            description:(NSString *)description;
+
+- (void)moveBookmark:(MWMMarkID)bookmarkId
+           toGroupId:(MWMMarkGroupID)groupId;
+
+- (void)updateTrack:(MWMTrackID)trackId
+         setGroupId:(MWMMarkGroupID)groupId
+              title:(NSString *)title;
+
+- (void)moveTrack:(MWMTrackID)trackId
+        toGroupId:(MWMMarkGroupID)groupId;
 
 - (instancetype)init __attribute__((unavailable("call +manager instead")));
 - (instancetype)copy __attribute__((unavailable("call +manager instead")));

--- a/iphone/Maps/Bookmarks/BookmarksList/BookmarksListInteractor.swift
+++ b/iphone/Maps/Bookmarks/BookmarksList/BookmarksListInteractor.swift
@@ -140,6 +140,26 @@ extension BookmarksListInteractor: IBookmarksListInteractor {
     bookmarksManager.deleteBookmark(bookmarkId)
   }
 
+  func deleteTrack(_ trackId: MWMTrackID) {
+    bookmarksManager.deleteTrack(trackId)
+  }
+
+  func moveBookmark(_ bookmarkId: MWMMarkID, toGroupId groupId: MWMMarkGroupID) {
+    bookmarksManager.moveBookmark(bookmarkId, toGroupId: groupId)
+  }
+  
+  func moveTrack(_ trackId: MWMTrackID, toGroupId groupId: MWMMarkGroupID) {
+    bookmarksManager.moveTrack(trackId, toGroupId: groupId)
+  }
+
+  func updateBookmark(_ bookmarkId: MWMMarkID, setGroupId groupId: MWMMarkGroupID, title: String, color: BookmarkColor, description: String) {
+    bookmarksManager.updateBookmark(bookmarkId, setGroupId: groupId, title: title, color: color, description: description)
+  }
+
+  func updateTrack(_ trackId: MWMTrackID, setGroupId groupId: MWMMarkGroupID) {
+    bookmarksManager.moveTrack(trackId, toGroupId: groupId)
+  }
+
   func deleteBookmarksGroup() {
     bookmarksManager.deleteCategory(markGroupId)
   }

--- a/iphone/Maps/Bookmarks/BookmarksList/BookmarksListInterfaces.swift
+++ b/iphone/Maps/Bookmarks/BookmarksList/BookmarksListInterfaces.swift
@@ -64,13 +64,16 @@ protocol IBookmarksListView: AnyObject {
 
 protocol IBookmarksListPresenter {
   func viewDidLoad()
+  func viewDidAppear()
   func activateSearch()
   func deactivateSearch()
   func cancelSearch()
   func search(_ text: String)
   func sort()
   func more()
-  func deleteBookmark(in section: IBookmarksListSectionViewModel, at index: Int)
+  func deleteItem(in section: IBookmarksListSectionViewModel, at index: Int)
+  func moveItem(in section: IBookmarksListSectionViewModel, at index: Int)
+  func editItem(in section: IBookmarksListSectionViewModel, at index: Int)
   func selectItem(in section: IBookmarksListSectionViewModel, at index: Int)
   func checkItem(in section: IBookmarksListSectionViewModel, at index: Int, checked: Bool)
   func toggleVisibility(in section: IBookmarksListSectionViewModel)
@@ -99,6 +102,11 @@ protocol IBookmarksListInteractor {
   func resetSort()
   func lastSortingType() -> BookmarksListSortingType?
   func deleteBookmark(_ bookmarkId: MWMMarkID)
+  func deleteTrack(_ trackId: MWMTrackID)
+  func moveBookmark(_ bookmarkId: MWMMarkID, toGroupId: MWMMarkGroupID)
+  func moveTrack(_ trackId: MWMTrackID, toGroupId: MWMMarkGroupID)
+  func updateBookmark(_ bookmarkId: MWMMarkID, setGroupId groupId: MWMMarkGroupID, title: String, color: BookmarkColor, description: String)
+  func updateTrack(_ trackId: MWMTrackID, setGroupId groupId: MWMMarkGroupID)
   func deleteBookmarksGroup()
   func canDeleteGroup() -> Bool
   func exportFile(_ completion: @escaping (URL?, ExportFileStatus) -> Void)
@@ -110,6 +118,11 @@ protocol IBookmarksListRouter {
   func viewOnMap(_ bookmarkGroup: BookmarkGroup)
   func showDescription(_ bookmarkGroup: BookmarkGroup)
   func showSubgroup(_ subgroupId: MWMMarkGroupID)
+  func selectGroup(currentGroupName groupName: String,
+                   currentGroupId groupId: MWMMarkGroupID,
+                   delegate: SelectBookmarkGroupViewControllerDelegate?)
+  func editBookmark(bookmarkId: MWMMarkID, completion: @escaping (Bool) -> Void)
+  func editTrack(trackId: MWMTrackID, completion: @escaping (Bool) -> Void)
 }
 
 protocol IBookmakrsListInfoViewModel {

--- a/iphone/Maps/Bookmarks/BookmarksList/BookmarksListRouter.swift
+++ b/iphone/Maps/Bookmarks/BookmarksList/BookmarksListRouter.swift
@@ -29,4 +29,23 @@ extension BookmarksListRouter: IBookmarksListRouter {
                                                                  bookmarksCoordinator: coordinator)
     mapViewController.navigationController?.pushViewController(bookmarksListViewController, animated: true)
   }
+  
+  func selectGroup(currentGroupName groupName: String,
+                   currentGroupId groupId: MWMMarkGroupID,
+                   delegate: SelectBookmarkGroupViewControllerDelegate?) {
+    let groupViewController = SelectBookmarkGroupViewController(groupName: groupName, groupId: groupId)
+    groupViewController.delegate = delegate
+    mapViewController.navigationController?.pushViewController(groupViewController, animated: true)
+  }
+  
+  func editBookmark(bookmarkId: MWMMarkID, completion: @escaping (Bool) -> Void) {
+    let editBookmarkController = UIStoryboard.instance(.main).instantiateViewController(withIdentifier: "MWMEditBookmarkController") as! EditBookmarkViewController
+    editBookmarkController.configure(with: bookmarkId, editCompletion: completion)
+    mapViewController.navigationController?.pushViewController(editBookmarkController, animated: true)
+  }
+  
+  func editTrack(trackId: MWMTrackID, completion: @escaping (Bool) -> Void) {
+    let editTrackController = EditTrackViewController(trackId: trackId, editCompletion: completion)
+    mapViewController.navigationController?.pushViewController(editTrackController, animated: true)
+  }
 }

--- a/iphone/Maps/Bookmarks/BookmarksList/BookmarksListViewController.swift
+++ b/iphone/Maps/Bookmarks/BookmarksList/BookmarksListViewController.swift
@@ -41,6 +41,11 @@ final class BookmarksListViewController: MWMViewController {
     presenter.viewDidLoad()
     MWMKeyboard.add(self);
   }
+  
+  override func viewDidAppear(_ animated: Bool) {
+    super.viewDidAppear(animated)
+    presenter.viewDidAppear()
+  }
 
   deinit {
     MWMKeyboard.remove(self);
@@ -122,12 +127,30 @@ extension BookmarksListViewController: UITableViewDelegate {
   func tableView(_ tableView: UITableView, didEndEditingRowAt indexPath: IndexPath?) {
     isEditing = false
   }
+  
+  func tableView(_ tableView: UITableView,
+                 leadingSwipeActionsConfigurationForRowAt indexPath: IndexPath) -> UISwipeActionsConfiguration? {
+    let moveAction = UIContextualAction(style: .normal, title: L("move")) { [weak self] (_, _, completion) in
+      guard let section = self?.sections?[indexPath.section] else { fatalError() }
+      self?.presenter.moveItem(in: section, at: indexPath.row)
+      completion(true)
+    }
+    return UISwipeActionsConfiguration(actions: [moveAction])
+  }
 
   func tableView(_ tableView: UITableView,
-                 commit editingStyle: UITableViewCell.EditingStyle,
-                 forRowAt indexPath: IndexPath) {
-    guard let section = sections?[indexPath.section] else { fatalError() }
-    presenter.deleteBookmark(in: section, at: indexPath.row)
+                 trailingSwipeActionsConfigurationForRowAt indexPath: IndexPath) -> UISwipeActionsConfiguration? {
+    let deleteAction = UIContextualAction(style: .destructive, title: L("delete")) { [weak self] (_, _, completion) in
+      guard let section = self?.sections?[indexPath.section] else { fatalError() }
+      self?.presenter.deleteItem(in: section, at: indexPath.row)
+      completion(true)
+    }
+    let editAction = UIContextualAction(style: .normal, title: L("edit")) { [weak self] (_, _, completion) in
+      guard let section = self?.sections?[indexPath.section] else { fatalError() }
+      self?.presenter.editItem(in: section, at: indexPath.row)
+      completion(true)
+    }
+    return UISwipeActionsConfiguration(actions: [deleteAction, editAction])
   }
 }
 

--- a/iphone/Maps/LocalizedStrings/ar.lproj/Localizable.strings
+++ b/iphone/Maps/LocalizedStrings/ar.lproj/Localizable.strings
@@ -1412,6 +1412,9 @@
 /* Autoupdate dialog on start */
 "whats_new_auto_update_button_later" = "تحديث يدوياً في وقت لاحق";
 
+/* edit track screen title */
+"track_title" = "مسار";
+
 
 /********** Types **********/
 

--- a/iphone/Maps/LocalizedStrings/bg.lproj/Localizable.strings
+++ b/iphone/Maps/LocalizedStrings/bg.lproj/Localizable.strings
@@ -1249,3 +1249,6 @@
 
 /* Autoupdate dialog on start */
 "whats_new_auto_update_button_later" = "Ръчно актуализиране по-късно";
+
+/* edit track screen title */
+"track_title" = "Пътека";

--- a/iphone/Maps/LocalizedStrings/cs.lproj/Localizable.strings
+++ b/iphone/Maps/LocalizedStrings/cs.lproj/Localizable.strings
@@ -1409,6 +1409,9 @@
 /* Autoupdate dialog on start */
 "whats_new_auto_update_button_later" = "Aktualizovat ručně později";
 
+/* edit track screen title */
+"track_title" = "Dráha";
+
 
 /********** Types **********/
 

--- a/iphone/Maps/LocalizedStrings/da.lproj/Localizable.strings
+++ b/iphone/Maps/LocalizedStrings/da.lproj/Localizable.strings
@@ -1412,6 +1412,9 @@
 /* Autoupdate dialog on start */
 "whats_new_auto_update_button_later" = "Opdater manuelt senere";
 
+/* edit track screen title */
+"track_title" = "Rute";
+
 
 /********** Types **********/
 

--- a/iphone/Maps/LocalizedStrings/de.lproj/Localizable.strings
+++ b/iphone/Maps/LocalizedStrings/de.lproj/Localizable.strings
@@ -1415,6 +1415,9 @@
 /* Autoupdate dialog on start */
 "whats_new_auto_update_button_later" = "Später manuell aktualisieren";
 
+/* edit track screen title */
+"track_title" = "Strecken";
+
 
 /********** Types **********/
 

--- a/iphone/Maps/LocalizedStrings/el.lproj/Localizable.strings
+++ b/iphone/Maps/LocalizedStrings/el.lproj/Localizable.strings
@@ -1391,6 +1391,9 @@
 /* Autoupdate dialog on start */
 "whats_new_auto_update_button_later" = "Χειροκίνητη ενημέρωση αργότερα";
 
+/* edit track screen title */
+"track_title" = "Τροχιά";
+
 
 /********** Types **********/
 

--- a/iphone/Maps/LocalizedStrings/en.lproj/Localizable.strings
+++ b/iphone/Maps/LocalizedStrings/en.lproj/Localizable.strings
@@ -1459,6 +1459,18 @@
 /* Autoupdate dialog on start */
 "whats_new_auto_update_button_later" = "Manually update later";
 
+/* Delete track button on track edit screen */
+"placepage_delete_track_button" = "Delete Track";
+
+/* Placeholder for track name input on track edit screen */
+"placepage_track_name_hint" = "Track Name";
+
+/* move track or bookmark from the list button text */
+"move" = "Move";
+
+/* edit track screen title */
+"track_title" = "Track";
+
 
 /********** Types **********/
 

--- a/iphone/Maps/LocalizedStrings/es.lproj/Localizable.strings
+++ b/iphone/Maps/LocalizedStrings/es.lproj/Localizable.strings
@@ -1406,6 +1406,9 @@
 /* Autoupdate dialog on start */
 "whats_new_auto_update_button_later" = "Actualizar más tarde de forma manual";
 
+/* edit track screen title */
+"track_title" = "Ruta";
+
 
 /********** Types **********/
 

--- a/iphone/Maps/LocalizedStrings/fa.lproj/Localizable.strings
+++ b/iphone/Maps/LocalizedStrings/fa.lproj/Localizable.strings
@@ -1392,6 +1392,9 @@
 /* Autoupdate dialog on start */
 "whats_new_auto_update_button_later" = "بعدا به صورت دستی به روزرسانی کنید";
 
+/* edit track screen title */
+"track_title" = "مسیر";
+
 
 /********** Types **********/
 

--- a/iphone/Maps/LocalizedStrings/fi.lproj/Localizable.strings
+++ b/iphone/Maps/LocalizedStrings/fi.lproj/Localizable.strings
@@ -1412,6 +1412,9 @@
 /* Autoupdate dialog on start */
 "whats_new_auto_update_button_later" = "Päivitä manuaalisesti myöhemmin";
 
+/* edit track screen title */
+"track_title" = "Reitti";
+
 
 /********** Types **********/
 

--- a/iphone/Maps/LocalizedStrings/fr.lproj/Localizable.strings
+++ b/iphone/Maps/LocalizedStrings/fr.lproj/Localizable.strings
@@ -1423,6 +1423,9 @@
 /* Autoupdate dialog on start */
 "whats_new_auto_update_button_later" = "Mettre à jour manuellement plus tard";
 
+/* edit track screen title */
+"track_title" = "Route";
+
 
 /********** Types **********/
 

--- a/iphone/Maps/LocalizedStrings/hu.lproj/Localizable.strings
+++ b/iphone/Maps/LocalizedStrings/hu.lproj/Localizable.strings
@@ -1407,6 +1407,9 @@
 /* Autoupdate dialog on start */
 "whats_new_auto_update_button_later" = "Kézi frissítés később";
 
+/* edit track screen title */
+"track_title" = "Útvonal";
+
 
 /********** Types **********/
 

--- a/iphone/Maps/LocalizedStrings/id.lproj/Localizable.strings
+++ b/iphone/Maps/LocalizedStrings/id.lproj/Localizable.strings
@@ -1412,6 +1412,9 @@
 /* Autoupdate dialog on start */
 "whats_new_auto_update_button_later" = "Perbarui secara manual nanti";
 
+/* edit track screen title */
+"track_title" = "Trek";
+
 
 /********** Types **********/
 

--- a/iphone/Maps/LocalizedStrings/it.lproj/Localizable.strings
+++ b/iphone/Maps/LocalizedStrings/it.lproj/Localizable.strings
@@ -1406,6 +1406,9 @@
 /* Autoupdate dialog on start */
 "whats_new_auto_update_button_later" = "Aggiorna manualmente più tardi";
 
+/* edit track screen title */
+"track_title" = "Traccia";
+
 
 /********** Types **********/
 

--- a/iphone/Maps/LocalizedStrings/ja.lproj/Localizable.strings
+++ b/iphone/Maps/LocalizedStrings/ja.lproj/Localizable.strings
@@ -1406,6 +1406,9 @@
 /* Autoupdate dialog on start */
 "whats_new_auto_update_button_later" = "あとで手動で更新";
 
+/* edit track screen title */
+"track_title" = "トラック";
+
 
 /********** Types **********/
 

--- a/iphone/Maps/LocalizedStrings/ko.lproj/Localizable.strings
+++ b/iphone/Maps/LocalizedStrings/ko.lproj/Localizable.strings
@@ -1409,6 +1409,9 @@
 /* Autoupdate dialog on start */
 "whats_new_auto_update_button_later" = "나중에 수동으로 업데이트";
 
+/* edit track screen title */
+"track_title" = "길";
+
 
 /********** Types **********/
 

--- a/iphone/Maps/LocalizedStrings/nb.lproj/Localizable.strings
+++ b/iphone/Maps/LocalizedStrings/nb.lproj/Localizable.strings
@@ -1382,6 +1382,9 @@
 /* Autoupdate dialog on start */
 "whats_new_auto_update_button_later" = "Oppdater manuelt senere";
 
+/* edit track screen title */
+"track_title" = "Rute";
+
 
 /********** Types **********/
 

--- a/iphone/Maps/LocalizedStrings/nl.lproj/Localizable.strings
+++ b/iphone/Maps/LocalizedStrings/nl.lproj/Localizable.strings
@@ -1404,6 +1404,9 @@
 /* Autoupdate dialog on start */
 "whats_new_auto_update_button_later" = "Later handmatig bijwerken";
 
+/* edit track screen title */
+"track_title" = "Track";
+
 
 /********** Types **********/
 

--- a/iphone/Maps/LocalizedStrings/pl.lproj/Localizable.strings
+++ b/iphone/Maps/LocalizedStrings/pl.lproj/Localizable.strings
@@ -1418,6 +1418,9 @@
 /* Autoupdate dialog on start */
 "whats_new_auto_update_button_later" = "Zaktualizuj ręcznie później";
 
+/* edit track screen title */
+"track_title" = "Trasa";
+
 
 /********** Types **********/
 

--- a/iphone/Maps/LocalizedStrings/pt-BR.lproj/Localizable.strings
+++ b/iphone/Maps/LocalizedStrings/pt-BR.lproj/Localizable.strings
@@ -1428,6 +1428,9 @@
 /* Autoupdate dialog on start */
 "whats_new_auto_update_button_later" = "Atualizar manualmente mais tarde";
 
+/* edit track screen title */
+"track_title" = "Percurso";
+
 
 /********** Types **********/
 

--- a/iphone/Maps/LocalizedStrings/pt.lproj/Localizable.strings
+++ b/iphone/Maps/LocalizedStrings/pt.lproj/Localizable.strings
@@ -1432,6 +1432,9 @@
 /* Autoupdate dialog on start */
 "whats_new_auto_update_button_later" = "Atualizar manualmente mais tarde";
 
+/* edit track screen title */
+"track_title" = "Percurso";
+
 
 /********** Types **********/
 

--- a/iphone/Maps/LocalizedStrings/ro.lproj/Localizable.strings
+++ b/iphone/Maps/LocalizedStrings/ro.lproj/Localizable.strings
@@ -1410,6 +1410,9 @@
 /* Autoupdate dialog on start */
 "whats_new_auto_update_button_later" = "Actualizare manuală mai târziu";
 
+/* edit track screen title */
+"track_title" = "Rută";
+
 
 /********** Types **********/
 

--- a/iphone/Maps/LocalizedStrings/ru.lproj/Localizable.strings
+++ b/iphone/Maps/LocalizedStrings/ru.lproj/Localizable.strings
@@ -1438,6 +1438,18 @@
 /* Autoupdate dialog on start */
 "whats_new_auto_update_button_later" = "Обновить вручную позже";
 
+/* Delete track button on track edit screen */
+"placepage_delete_track_button" = "Удалить трек";
+
+/* Placeholder for track name input on track edit screen */
+"placepage_track_name_hint" = "Название трека";
+
+/* move track or bookmark from the list button text */
+"move" = "Переместить";
+
+/* edit track screen title */
+"track_title" = "Трек";
+
 
 /********** Types **********/
 

--- a/iphone/Maps/LocalizedStrings/sk.lproj/Localizable.strings
+++ b/iphone/Maps/LocalizedStrings/sk.lproj/Localizable.strings
@@ -1406,6 +1406,9 @@
 /* Autoupdate dialog on start */
 "whats_new_auto_update_button_later" = "Manuálne aktualizovať neskôr";
 
+/* edit track screen title */
+"track_title" = "Šľapaj Stopy";
+
 
 /********** Types **********/
 

--- a/iphone/Maps/LocalizedStrings/sv.lproj/Localizable.strings
+++ b/iphone/Maps/LocalizedStrings/sv.lproj/Localizable.strings
@@ -1406,6 +1406,9 @@
 /* Autoupdate dialog on start */
 "whats_new_auto_update_button_later" = "Uppdatera senare manuellt";
 
+/* edit track screen title */
+"track_title" = "Rutt";
+
 
 /********** Types **********/
 

--- a/iphone/Maps/LocalizedStrings/th.lproj/Localizable.strings
+++ b/iphone/Maps/LocalizedStrings/th.lproj/Localizable.strings
@@ -1412,6 +1412,9 @@
 /* Autoupdate dialog on start */
 "whats_new_auto_update_button_later" = "อัปเดตด้วยตนเองภายหลัง";
 
+/* edit track screen title */
+"track_title" = "ติดตาม";
+
 
 /********** Types **********/
 

--- a/iphone/Maps/LocalizedStrings/tr.lproj/Localizable.strings
+++ b/iphone/Maps/LocalizedStrings/tr.lproj/Localizable.strings
@@ -1412,6 +1412,9 @@
 /* Autoupdate dialog on start */
 "whats_new_auto_update_button_later" = "Daha sonra manüel olarak güncelle";
 
+/* edit track screen title */
+"track_title" = "Rota";
+
 
 /********** Types **********/
 

--- a/iphone/Maps/LocalizedStrings/uk.lproj/Localizable.strings
+++ b/iphone/Maps/LocalizedStrings/uk.lproj/Localizable.strings
@@ -1414,6 +1414,9 @@
 /* Autoupdate dialog on start */
 "whats_new_auto_update_button_later" = "Оновити вручну пізніше";
 
+/* edit track screen title */
+"track_title" = "Маршрут";
+
 
 /********** Types **********/
 

--- a/iphone/Maps/LocalizedStrings/vi.lproj/Localizable.strings
+++ b/iphone/Maps/LocalizedStrings/vi.lproj/Localizable.strings
@@ -1412,6 +1412,9 @@
 /* Autoupdate dialog on start */
 "whats_new_auto_update_button_later" = "Cập nhật thủ công sau";
 
+/* edit track screen title */
+"track_title" = "Dấu chân";
+
 
 /********** Types **********/
 

--- a/iphone/Maps/LocalizedStrings/zh-Hans.lproj/Localizable.strings
+++ b/iphone/Maps/LocalizedStrings/zh-Hans.lproj/Localizable.strings
@@ -1427,6 +1427,9 @@
 /* Autoupdate dialog on start */
 "whats_new_auto_update_button_later" = "稍后手动更新";
 
+/* edit track screen title */
+"track_title" = "追踪";
+
 
 /********** Types **********/
 

--- a/iphone/Maps/LocalizedStrings/zh-Hant.lproj/Localizable.strings
+++ b/iphone/Maps/LocalizedStrings/zh-Hant.lproj/Localizable.strings
@@ -1427,6 +1427,9 @@
 /* Autoupdate dialog on start */
 "whats_new_auto_update_button_later" = "稍後手動更新";
 
+/* edit track screen title */
+"track_title" = "追踪";
+
 
 /********** Types **********/
 

--- a/iphone/Maps/Maps.xcodeproj/project.pbxproj
+++ b/iphone/Maps/Maps.xcodeproj/project.pbxproj
@@ -498,6 +498,7 @@
 		99F9A0E52462CA0E00AE21E0 /* DownloadAllView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 99F9A0E42462CA0E00AE21E0 /* DownloadAllView.swift */; };
 		99F9A0E72462CA1700AE21E0 /* DownloadAllView.xib in Resources */ = {isa = PBXBuildFile; fileRef = 99F9A0E62462CA1700AE21E0 /* DownloadAllView.xib */; };
 		A630D1EA207CA95900976DEA /* Localizable.stringsdict in Resources */ = {isa = PBXBuildFile; fileRef = A630D1E8207CA95900976DEA /* Localizable.stringsdict */; };
+		AA1C7E3E269A2DD600BAADF2 /* EditTrackViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = AA1C7E3D269A2DD600BAADF2 /* EditTrackViewController.swift */; };
 		B33D21AF20DAF9F000BAD749 /* Toast.swift in Sources */ = {isa = PBXBuildFile; fileRef = B33D21AE20DAF9F000BAD749 /* Toast.swift */; };
 		B33D21B820E130D000BAD749 /* BookmarksTabViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = B33D21B720E130D000BAD749 /* BookmarksTabViewController.swift */; };
 		B3E3B4FD20D463B700DA8C13 /* BMCCategoriesHeader.xib in Resources */ = {isa = PBXBuildFile; fileRef = B3E3B4FC20D463B700DA8C13 /* BMCCategoriesHeader.xib */; };
@@ -1332,6 +1333,7 @@
 		A630D204207CAA3400976DEA /* vi */ = {isa = PBXFileReference; lastKnownFileType = text.plist.stringsdict; name = vi; path = vi.lproj/Localizable.stringsdict; sourceTree = "<group>"; };
 		A630D205207CAA3A00976DEA /* zh-Hant */ = {isa = PBXFileReference; lastKnownFileType = text.plist.stringsdict; name = "zh-Hant"; path = "zh-Hant.lproj/Localizable.stringsdict"; sourceTree = "<group>"; };
 		A630D206207CAA5800976DEA /* zh-Hans */ = {isa = PBXFileReference; lastKnownFileType = text.plist.stringsdict; name = "zh-Hans"; path = "zh-Hans.lproj/Localizable.stringsdict"; sourceTree = "<group>"; };
+		AA1C7E3D269A2DD600BAADF2 /* EditTrackViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EditTrackViewController.swift; sourceTree = "<group>"; };
 		AC79F11E1E534D0B00B7D954 /* AVFoundation.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = AVFoundation.framework; path = System/Library/Frameworks/AVFoundation.framework; sourceTree = SDKROOT; };
 		AC79F1201E534D4000B7D954 /* CoreTelephony.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = CoreTelephony.framework; path = System/Library/Frameworks/CoreTelephony.framework; sourceTree = SDKROOT; };
 		AC79F1221E534DFA00B7D954 /* SystemConfiguration.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = SystemConfiguration.framework; path = System/Library/Frameworks/SystemConfiguration.framework; sourceTree = SDKROOT; };
@@ -3230,6 +3232,7 @@
 				471A7BBF2481C82500A0D4C1 /* BookmarkTitleCell.swift */,
 				471A7BC12481C9B700A0D4C1 /* BookmarkTitleCell.xib */,
 				471A7BBD2481A3D000A0D4C1 /* EditBookmarkViewController.swift */,
+				AA1C7E3D269A2DD600BAADF2 /* EditTrackViewController.swift */,
 				471A7BC3248471BE00A0D4C1 /* BookmarkUIUtils.swift */,
 				4715273424907F8200E91BBA /* BookmarkColorViewController.swift */,
 				471527362491C20500E91BBA /* SelectBookmarkGroupViewController.swift */,
@@ -3951,6 +3954,7 @@
 				34F742321E0834F400AC1FD6 /* UIViewController+Navigation.m in Sources */,
 				340475811E081B3300C92850 /* iosOGLContextFactory.mm in Sources */,
 				99F3EB0623F418A200C713F8 /* PlacePagePresenter.swift in Sources */,
+				AA1C7E3E269A2DD600BAADF2 /* EditTrackViewController.swift in Sources */,
 				34AB66561FC5AA330078E451 /* TransportTransitPedestrian.swift in Sources */,
 				993DF0C823F6BD0600AC231A /* ElevationDetailsViewController.swift in Sources */,
 				BB8123D62130427E00ADE512 /* MetalContextFactory.mm in Sources */,

--- a/iphone/Maps/UI/EditBookmark/EditTrackViewController.swift
+++ b/iphone/Maps/UI/EditBookmark/EditTrackViewController.swift
@@ -1,0 +1,171 @@
+import UIKit
+
+final class EditTrackViewController: MWMTableViewController {
+  private enum Sections: Int {
+    case info
+    case delete
+    case count
+  }
+  
+  private enum InfoSectionRows: Int {
+    case title
+    //case color // TODO: need to know which layer color should be changed in track
+    //case lineWidth // TODO: possible new section & ability - edit track line width
+    case bookmarkGroup
+    case count
+  }
+  
+  private var editingCompleted: (Bool) -> Void
+
+  private let trackId: MWMTrackID
+  private var trackTitle: String?
+  private var trackGroupTitle: String?
+  private var trackGroupId = FrameworkHelper.invalidCategoryId()
+  //private var trackColor: BookmarkColor // or add TrackColor type
+
+  private let bookmarksManager = BookmarksManager.shared()
+  
+  init(trackId: MWMTrackID, editCompletion completion: @escaping (Bool) -> Void) {
+    self.trackId = trackId
+    
+    let bm = BookmarksManager.shared()
+    let track = bm.track(withId: trackId)
+    
+    trackTitle = track.trackName
+    //trackColor = ....
+
+    let category = bm.category(forTrackId: trackId)
+    trackGroupId = category.categoryId
+    trackGroupTitle = category.title
+    
+
+    editingCompleted = completion
+
+    super.init(style: .grouped)
+  }
+  
+  required init?(coder: NSCoder) {
+    fatalError("init(coder:) has not been implemented")
+  }
+  
+  override func viewDidLoad() {
+    super.viewDidLoad()
+    
+    title = L("track_title")
+    navigationItem.rightBarButtonItem = UIBarButtonItem(barButtonSystemItem: .save,
+                                                        target: self,
+                                                        action: #selector(onSave))
+    
+    tableView.registerNib(cell: BookmarkTitleCell.self)
+    tableView.registerNib(cell: MWMButtonCell.self)
+  }
+    
+  // MARK: - Table view data source
+  
+  override func numberOfSections(in tableView: UITableView) -> Int {
+    Sections.count.rawValue
+  }
+  
+  override func tableView(_ tableView: UITableView, numberOfRowsInSection section: Int) -> Int {
+    switch Sections(rawValue: section) {
+    case .info:
+      return InfoSectionRows.count.rawValue
+    case .delete:
+      return 1
+    default:
+      fatalError()
+    }
+  }
+  
+  override func tableView(_ tableView: UITableView, cellForRowAt indexPath: IndexPath) -> UITableViewCell {
+    switch Sections(rawValue: indexPath.section) {
+    case .info:
+      switch InfoSectionRows(rawValue: indexPath.row) {
+      case .title:
+        let cell = tableView.dequeueReusableCell(cell: BookmarkTitleCell.self, indexPath: indexPath)
+        cell.configure(name: trackTitle ?? "", delegate: self, hint: L("placepage_track_name_hint"))
+        return cell
+//      case .color:
+//        let cell = tableView.dequeueDefaultCell(for: indexPath)
+//        cell.accessoryType = .disclosureIndicator
+//        cell.textLabel?.text = trackColor.title
+//        cell.imageView?.image = circleImageForColor(trackColor.color, frameSize: 28, diameter: 22, iconName: "ic_bm_none")
+//        return cell
+      case .bookmarkGroup:
+        let cell = tableView.dequeueDefaultCell(for: indexPath)
+        cell.textLabel?.text = trackGroupTitle
+        cell.imageView?.image = UIImage(named: "ic_folder")
+        cell.imageView?.styleName = "MWMBlack";
+        cell.accessoryType = .disclosureIndicator;
+        return cell;
+      default:
+        fatalError()
+      }
+    case .delete:
+      let cell = tableView.dequeueReusableCell(cell: MWMButtonCell.self, indexPath: indexPath)
+      cell.configure(with: self, title: L("placepage_delete_track_button"), enabled: true)
+      return cell
+    default:
+      fatalError()
+    }
+  }
+  
+  override func tableView(_ tableView: UITableView, didSelectRowAt indexPath: IndexPath) {
+    switch InfoSectionRows(rawValue: indexPath.row) {
+//    case .color:
+//      let colorViewController = BookmarkColorViewController(bookmarkColor: trackColor)
+//      colorViewController.delegate = self
+//      navigationController?.pushViewController(colorViewController, animated: true)
+    case .bookmarkGroup:
+      let groupViewController = SelectBookmarkGroupViewController(groupName: trackGroupTitle ?? "", groupId: trackGroupId)
+      groupViewController.delegate = self
+      navigationController?.pushViewController(groupViewController, animated: true)
+    default:
+      break
+    }
+  }
+  
+  // MARK: - Private
+  
+  @objc private func onSave() {
+    view.endEditing(true)
+    
+    BookmarksManager.shared().updateTrack(trackId, setGroupId: trackGroupId, title: trackTitle ?? "")
+    editingCompleted(true)
+    goBack()
+  }
+}
+
+extension EditTrackViewController: BookmarkTitleCellDelegate {
+  func didFinishEditingTitle(_ title: String) {
+    trackTitle = title
+  }
+}
+
+extension EditTrackViewController: MWMButtonCellDelegate {
+  func cellDidPressButton(_ cell: UITableViewCell) {
+    bookmarksManager.deleteTrack(trackId)
+    goBack()
+  }
+}
+
+//extension EditTrackViewController: BookmarkColorViewControllerDelegate {
+//  func bookmarkColorViewController(_ viewController: BookmarkColorViewController, didSelect color: BookmarkColor) {
+//    goBack()
+//    trackColor = color
+//    tableView.reloadRows(at: [IndexPath(row: InfoSectionRows.color.rawValue, section: Sections.info.rawValue)],
+//                         with: .none)
+//  }
+//}
+
+extension EditTrackViewController: SelectBookmarkGroupViewControllerDelegate {
+  func bookmarkGroupViewController(_ viewController: SelectBookmarkGroupViewController,
+                                   didSelect groupTitle: String,
+                                   groupId: MWMMarkGroupID) {
+    goBack()
+    trackGroupTitle = groupTitle
+    trackGroupId = groupId
+    tableView.reloadRows(at: [IndexPath(row: InfoSectionRows.bookmarkGroup.rawValue, section: Sections.info.rawValue)],
+                         with: .none)
+  }
+}

--- a/iphone/Maps/UI/PlacePage/Components/PlacePageHeader/PlacePageHeaderViewController.swift
+++ b/iphone/Maps/UI/PlacePage/Components/PlacePageHeader/PlacePageHeaderViewController.swift
@@ -9,7 +9,7 @@ protocol PlacePageHeaderViewProtocol: AnyObject {
 class PlacePageHeaderViewController: UIViewController {
   var presenter: PlacePageHeaderPresenterProtocol?
 
-  @IBOutlet private var titleLabel: UILabel!
+  @IBOutlet private var titleLabel: UILabel?
   @IBOutlet private var expandView: UIView!
   @IBOutlet private var shadowView: UIView!
 
@@ -49,6 +49,6 @@ extension PlacePageHeaderViewController: PlacePageHeaderViewProtocol {
   }
 
   func setTitle(_ title: String) {
-    titleLabel.text = title
+    titleLabel?.text = title
   }
 }

--- a/iphone/Maps/UI/PlacePage/PlacePageLayout/Layouts/PlacePageCommonLayout.swift
+++ b/iphone/Maps/UI/PlacePage/PlacePageLayout/Layouts/PlacePageCommonLayout.swift
@@ -205,6 +205,10 @@ extension PlacePageCommonLayout {
       bookmarkViewController.bookmarkData = bookmarkData
       isBookmark = true
     }
+    if let title = placePageData.previewData.title {
+      header?.setTitle(title)
+      placePageNavigationViewController.setTitle(title)
+    }
     self.presenter?.layoutIfNeeded()
     UIView.animate(withDuration: kDefaultAnimationDuration) { [unowned self] in
       self.bookmarkViewController.view.isHidden = !isBookmark

--- a/iphone/Maps/UI/PlacePage/PlacePageManager/MWMPlacePageManager.mm
+++ b/iphone/Maps/UI/PlacePage/PlacePageManager/MWMPlacePageManager.mm
@@ -204,7 +204,7 @@ using namespace storage;
 - (void)editBookmark:(PlacePageData *)data {
   MWMEditBookmarkController *editBookmarkController = [[UIStoryboard instance:MWMStoryboardMain]
                                                        instantiateViewControllerWithIdentifier:@"MWMEditBookmarkController"];
-  editBookmarkController.placePageData = data;
+  [editBookmarkController configureWithPlacePageData:data];
   [[MapViewController sharedController].navigationController pushViewController:editBookmarkController animated:YES];
 }
 

--- a/map/bookmark_manager.cpp
+++ b/map/bookmark_manager.cpp
@@ -359,6 +359,23 @@ Track const * BookmarkManager::GetTrack(kml::TrackId trackId) const
   return (it != m_tracks.end()) ? it->second.get() : nullptr;
 }
 
+Track * BookmarkManager::GetTrackForEdit(kml::TrackId trackId)
+{
+  CHECK_THREAD_CHECKER(m_threadChecker, ());
+  auto it = m_tracks.find(trackId);
+  if (it == m_tracks.end())
+    return nullptr;
+
+  return it->second.get();
+}
+
+void BookmarkManager::MoveTrack(kml::TrackId trackID, kml::MarkGroupId curGroupID, kml::MarkGroupId newGroupID)
+{
+  CHECK_THREAD_CHECKER(m_threadChecker, ());
+  DetachTrack(trackID, curGroupID);
+  AttachTrack(trackID, newGroupID);
+}
+
 void BookmarkManager::AttachTrack(kml::TrackId trackId, kml::MarkGroupId groupId)
 {
   CHECK_THREAD_CHECKER(m_threadChecker, ());
@@ -370,6 +387,8 @@ void BookmarkManager::AttachTrack(kml::TrackId trackId, kml::MarkGroupId groupId
 void BookmarkManager::DetachTrack(kml::TrackId trackId, kml::MarkGroupId groupId)
 {
   CHECK_THREAD_CHECKER(m_threadChecker, ());
+  auto it = m_tracks.find(trackId);
+  it->second->Detach();
   GetBmCategory(groupId)->DetachTrack(trackId);
 }
 
@@ -3375,6 +3394,11 @@ void BookmarkManager::EditSession::DeleteBookmark(kml::MarkId bmId)
   m_bmManager.DeleteBookmark(bmId);
 }
 
+Track * BookmarkManager::EditSession::GetTrackForEdit(kml::TrackId trackId)
+{
+  return m_bmManager.GetTrackForEdit(trackId);
+}
+
 void BookmarkManager::EditSession::DeleteTrack(kml::TrackId trackId)
 {
   m_bmManager.DeleteTrack(trackId);
@@ -3409,6 +3433,11 @@ void BookmarkManager::EditSession::AttachBookmark(kml::MarkId bmId, kml::MarkGro
 void BookmarkManager::EditSession::DetachBookmark(kml::MarkId bmId, kml::MarkGroupId groupId)
 {
   m_bmManager.DetachBookmark(bmId, groupId);
+}
+
+void BookmarkManager::EditSession::MoveTrack(kml::TrackId trackID, kml::MarkGroupId curGroupID, kml::MarkGroupId newGroupID)
+{
+  m_bmManager.MoveTrack(trackID, curGroupID, newGroupID);
 }
 
 void BookmarkManager::EditSession::AttachTrack(kml::TrackId trackId, kml::MarkGroupId groupId)

--- a/map/bookmark_manager.hpp
+++ b/map/bookmark_manager.hpp
@@ -152,7 +152,10 @@ public:
 
     void AttachBookmark(kml::MarkId bmId, kml::MarkGroupId groupId);
     void DetachBookmark(kml::MarkId bmId, kml::MarkGroupId groupId);
+      
+    Track * GetTrackForEdit(kml::TrackId trackId);
 
+    void MoveTrack(kml::TrackId trackID, kml::MarkGroupId curGroupID, kml::MarkGroupId newGroupID);
     void AttachTrack(kml::TrackId trackId, kml::MarkGroupId groupId);
     void DetachTrack(kml::TrackId trackId, kml::MarkGroupId groupId);
 
@@ -566,9 +569,11 @@ private:
 
   Track * CreateTrack(kml::TrackData && trackData);
 
+  Track * GetTrackForEdit(kml::TrackId trackId);
   void AttachTrack(kml::TrackId trackId, kml::MarkGroupId groupId);
   void DetachTrack(kml::TrackId trackId, kml::MarkGroupId groupId);
   void DeleteTrack(kml::TrackId trackId);
+  void MoveTrack(kml::TrackId trackID, kml::MarkGroupId curGroupID, kml::MarkGroupId newGroupID);
 
   void ClearGroup(kml::MarkGroupId groupId);
   void SetIsVisible(kml::MarkGroupId groupId, bool visible);

--- a/map/track.cpp
+++ b/map/track.cpp
@@ -118,6 +118,11 @@ std::string Track::GetName() const
   return GetPreferredBookmarkStr(m_data.m_name);
 }
 
+void Track::SetName(std::string const & name)
+{
+    kml::SetDefaultStr(m_data.m_name, name);
+}
+
 m2::RectD Track::GetLimitRect() const
 {
   if (m_interactionData)

--- a/map/track.hpp
+++ b/map/track.hpp
@@ -20,6 +20,8 @@ public:
   kml::TrackData const & GetData() const { return m_data; }
 
   std::string GetName() const;
+  void SetName(std::string const & name);
+
   m2::RectD GetLimitRect() const;
   double GetLengthMeters() const;
   double GetLengthMeters(size_t pointIndex) const;


### PR DESCRIPTION
Resolves #760

# New functionality
- bookmark can be moved to other group with right swipe directly from the bookmarks list (no need to open "Edit bookmark" screen)
- bookmark can be edited right from the list: swipe left and select "Edit"
- new ability: edit track. Swipe track left in the list and select "Edit". Track name and track group can be changed (but not the color yet)
- new ability: tracks can be deleted. Swipe track left and select "Delete"
- track can be moved to other group with right swipe directly from the bookmark list

# UI examples

![Simulator Screen Shot - iPod touch (7th generation) - 2021-07-24 at 21 58 06](https://user-images.githubusercontent.com/483899/126879897-cd6ec5c2-e47d-49eb-94cd-c3d204a6f4db.png)
![Simulator Screen Shot - iPod touch (7th generation) - 2021-07-24 at 21 57 53](https://user-images.githubusercontent.com/483899/126879898-2a113050-5ec1-4699-8a24-a89952bcd94e.png)
![Simulator Screen Shot - iPod touch (7th generation) - 2021-07-24 at 21 57 50](https://user-images.githubusercontent.com/483899/126879900-bdf4d116-a62c-4b1d-b374-6824cce32584.png)
![Simulator Screen Shot - iPod touch (7th generation) - 2021-07-24 at 21 57 44](https://user-images.githubusercontent.com/483899/126879903-70050d1e-d14e-41f7-846d-d8475b083e56.png)
![Simulator Screen Shot - iPod touch (7th generation) - 2021-07-24 at 21 57 40](https://user-images.githubusercontent.com/483899/126879905-d1f63618-7310-4fec-9725-8f4ded14f943.png)
