### PR TITLE
[storage] Don't perform http request if meta server is undefined

### DIFF
--- a/storage/map_files_downloader.cpp
+++ b/storage/map_files_downloader.cpp
@@ -149,10 +149,16 @@ MapFilesDownloader::ServersList MapFilesDownloader::LoadServersList()
 {
   auto constexpr kTimeoutInSeconds = 10.0;
 
-  platform::HttpClient request(GetPlatform().MetaServerUrl());
+  std::string const metaServerUrl = GetPlatform().MetaServerUrl();
   std::string httpResult;
-  request.SetTimeout(kTimeoutInSeconds);
-  request.RunHttpRequest(httpResult);
+
+  if (!metaServerUrl.empty())
+  {
+    platform::HttpClient request(metaServerUrl);
+    request.SetTimeout(kTimeoutInSeconds);
+    request.RunHttpRequest(httpResult);
+  }
+
   std::vector<std::string> urls;
   downloader::GetServersList(httpResult, urls);
   CHECK(!urls.empty(), ());


### PR DESCRIPTION
Desktop application (DEBUG version) fails with the following error when trying to download maps.

```
LOG TID(1) INFO      7.20201 storage/storage.cpp:1178 DownloadNode() Downloading Russia_Pskov Oblast
LOG TID(6) DEBUG     7.24453 platform/http_client_curl.cpp:228 RunHttpRequest() Executing curl -s -w '%{http_code}' -X GET -D '/home/s/tmp/95fa83d1-6b89-4a17-bef9-085499e78a99' -m '10' -o /home/s/tmp/ff61f21c-0a31-4d23-91e2-a44a798395ec ''
LOG TID(6) ERROR       7.418 platform/http_client_curl.cpp:236 RunHttpRequest() Error 768 while calling curl -s -w '%{http_code}' -X GET -D '/home/s/tmp/95fa83d1-6b89-4a17-bef9-085499e78a99' -m '10' -o /home/s/tmp/ff61f21c-0a31-4d23-91e2-a44a798395ec ''
TID(6) ASSERT FAILED
base/logging.cpp:98
CHECK(level < g_LogAbortLevel) 3 3 Abort. Log level is too serious 3
OMaps: /home/s/c++/organicmaps/base/logging.cpp:98: void base::LogMessageDefault(base::LogLevel, const base::SrcPoint&, const string&): Assertion `false' failed.
fish: Job 1, '../omim-build-debug/OMaps -data…' terminated by signal SIGABRT (Abort)
```

After some investigation, I found out that it happens because `METASERVER_URL` is empty by default.
https://github.com/organicmaps/organicmaps/blob/2a640218cdcc129d51256dd8afbc56ac85436595/private_default.h#L7

Map downloader doesn't check whether `METASERVER_URL` is empty and tries to download from empty url, which leads us to `error` log message and debug build crash.

However, `downloader::GetServersList` is totally OK with empty result, so the solution is pretty straightforward.
https://github.com/organicmaps/organicmaps/blob/2a640218cdcc129d51256dd8afbc56ac85436595/platform/servers_list.cpp#L34-L41

