### PR TITLE
[android] Fixed layout bugs with text cut in editor.

### DIFF
--- a/android/res/layout/fragment_editor.xml
+++ b/android/res/layout/fragment_editor.xml
@@ -19,7 +19,7 @@
         android:id="@+id/category"
         style="@style/MwmWidget.Editor.MetadataBlock.Clickable"
         android:layout_width="match_parent"
-        android:layout_height="@dimen/editor_height_field"
+        android:layout_height="wrap_content"
         android:layout_marginBottom="0dp"
         android:padding="@dimen/margin_half_plus">
         <ImageView
@@ -31,16 +31,12 @@
           android:layout_marginStart="@dimen/margin_quarter"
           android:tint="?iconTint"
           tools:src="@drawable/ic_operator"/>
-        <Space
-          android:id="@+id/anchor_center"
-          android:layout_width="0dp"
-          android:layout_height="0dp"
-          android:layout_centerVertical="true"/>
+
         <TextView
           android:id="@+id/title"
           android:layout_width="match_parent"
           android:layout_height="wrap_content"
-          android:layout_above="@id/anchor_center"
+          android:layout_alignParentTop="true"
           android:layout_marginStart="@dimen/margin_quarter"
           android:layout_toEndOf="@id/icon"
           android:text="@string/editor_edit_place_category_title"
@@ -51,7 +47,7 @@
           android:layout_width="match_parent"
           android:layout_height="wrap_content"
           android:layout_alignStart="@id/title"
-          android:layout_below="@id/anchor_center"
+          android:layout_below="@id/title"
           android:textAppearance="@style/MwmTextAppearance.Body1"
           tools:text="Ololo"/>
       </RelativeLayout>

--- a/android/res/layout/fragment_timetable.xml
+++ b/android/res/layout/fragment_timetable.xml
@@ -16,22 +16,23 @@
 
   <View
     android:layout_width="match_parent"
-    android:layout_height="@dimen/height_block_base"
+    android:layout_height="wrap_content"
+    android:layout_alignTop="@+id/tv__mode_switch"
     android:layout_alignParentBottom="true"
     android:background="?cardBackground"/>
 
   <TextView
-    android:id="@+id/tv__mode_switch"
-    android:layout_width="match_parent"
-    android:layout_height="@dimen/height_block_base"
-    android:layout_alignParentBottom="true"
-    android:background="?clickableBackground"
-    android:gravity="center_vertical"
-    android:padding="@dimen/margin_base"
-    android:text="@string/editor_time_advanced"
-    android:textAllCaps="true"
-    android:textAppearance="@style/MwmTextAppearance.Body3"
-    android:textColor="?colorAccent"/>
+      android:id="@+id/tv__mode_switch"
+      android:layout_width="match_parent"
+      android:layout_height="wrap_content"
+      android:layout_alignParentBottom="true"
+      android:background="?clickableBackground"
+      android:gravity="center_vertical"
+      android:padding="@dimen/margin_base"
+      android:text="@string/editor_time_advanced"
+      android:textAllCaps="true"
+      android:textAppearance="@style/MwmTextAppearance.Body3"
+      android:textColor="?colorAccent" />
 
   <include
     layout="@layout/shadow_bottom"

--- a/android/res/layout/fragment_timetable.xml
+++ b/android/res/layout/fragment_timetable.xml
@@ -22,17 +22,17 @@
     android:background="?cardBackground"/>
 
   <TextView
-      android:id="@+id/tv__mode_switch"
-      android:layout_width="match_parent"
-      android:layout_height="wrap_content"
-      android:layout_alignParentBottom="true"
-      android:background="?clickableBackground"
-      android:gravity="center_vertical"
-      android:padding="@dimen/margin_base"
-      android:text="@string/editor_time_advanced"
-      android:textAllCaps="true"
-      android:textAppearance="@style/MwmTextAppearance.Body3"
-      android:textColor="?colorAccent" />
+    android:id="@+id/tv__mode_switch"
+    android:layout_width="match_parent"
+    android:layout_height="wrap_content"
+    android:layout_alignParentBottom="true"
+    android:background="?clickableBackground"
+    android:gravity="center_vertical"
+    android:padding="@dimen/margin_base"
+    android:text="@string/editor_time_advanced"
+    android:textAllCaps="true"
+    android:textAppearance="@style/MwmTextAppearance.Body3"
+    android:textColor="?colorAccent" />
 
   <include
     layout="@layout/shadow_bottom"

--- a/android/res/layout/item_timetable.xml
+++ b/android/res/layout/item_timetable.xml
@@ -192,7 +192,7 @@
       <LinearLayout
         android:id="@+id/time_open_close"
         android:layout_width="match_parent"
-        android:layout_height="@dimen/editor_height_hours"
+        android:layout_height="wrap_content"
         android:baselineAligned="false"
         android:gravity="center_vertical"
         android:orientation="horizontal">


### PR DESCRIPTION
With switched on big font size in the system layout was a bit broken in editor.

Before:

![Screenshot_20210801_102416](https://user-images.githubusercontent.com/86627724/127847024-4f0a3240-0646-49d9-8e43-6a7207a8c914.jpg)
![Screenshot_20210801_113501](https://user-images.githubusercontent.com/86627724/127847061-25cd66c8-907a-4041-b4cf-8dc947351672.jpg)

After:

![Screenshot_20210801_113409](https://user-images.githubusercontent.com/86627724/127847090-06328be2-f617-4386-9c38-f148ef4dd2d5.jpg)
![Screenshot_20210801_114902](https://user-images.githubusercontent.com/86627724/127847114-bb74e9d9-ca52-4689-bb0a-e00f5c456bab.jpg)


Signed-off-by: Dzmitry Yarmolenka <dzmitry.yarmolenka.1986@gmail.com>