### PR TITLE
[android] Fix bugs in external storage scanning code 

### DIFF
--- a/android/jni/com/mapswithme/platform/Platform.cpp
+++ b/android/jni/com/mapswithme/platform/Platform.cpp
@@ -141,9 +141,8 @@ void Platform::Initialize(JNIEnv * env, jobject functorProcessObject, jstring ap
   m_resourcesDir = jni::ToNativeString(env, apkPath);
   m_privateDir = jni::ToNativeString(env, privatePath);
   m_tmpDir = jni::ToNativeString(env, tmpPath);
-  m_writableDir = jni::ToNativeString(env, writablePath);
+  SetWritableDir(jni::ToNativeString(env, writablePath));
   LOG(LINFO, ("Apk path = ", m_resourcesDir));
-  LOG(LINFO, ("Writable path = ", m_writableDir));
   LOG(LINFO, ("Temporary path = ", m_tmpDir));
 
   // IMPORTANT: This method SHOULD be called from UI thread to cache static jni ID-s inside.

--- a/android/src/com/mapswithme/maps/MwmApplication.java
+++ b/android/src/com/mapswithme/maps/MwmApplication.java
@@ -181,7 +181,7 @@ public class MwmApplication extends Application implements AppBackgroundTracker.
     final String apkPath = StorageUtils.getApkPath(this);
     log.d(TAG, "Apk path = " + apkPath);
     // Note: StoragePathManager uses Config, which requires initConfig() to be called.
-    final String writablePath = new StoragePathManager().findMapsStorage(this);
+    final String writablePath = StoragePathManager.findMapsStorage(this);
     log.d(TAG, "Writable path = " + writablePath);
     final String privatePath = StorageUtils.getPrivatePath(this);
     log.d(TAG, "Private path = " + privatePath);

--- a/android/src/com/mapswithme/util/Config.java
+++ b/android/src/com/mapswithme/util/Config.java
@@ -131,11 +131,6 @@ public final class Config
     return getString(KEY_APP_STORAGE);
   }
 
-  public static void setStoragePath(String path)
-  {
-    setString(KEY_APP_STORAGE, path);
-  }
-
   public static boolean isTtsEnabled()
   {
     return getBool(KEY_TTS_ENABLED, true);


### PR DESCRIPTION
[android] Fix bugs in external storage scanning code

The app scans all available storages for the maps files on every start.
Initially, we prepare a list of available directories and scan them
for the write access and the free space. After that, we pick a first
directory which contains existing maps files. A first directory from
the list is used if no maps files were found.

The problem was that directory from settings.ini wasn't first in
the scan list. It could lead to weird behaviour if you add/remove
SD cards between app runs. App could switch to a newly added SD
card if this card had some old maps files. After switching the new
patch wasn't saved to settings.ini.

This patch sets the highest priority to a directory from settings.ini.
The configuration file is now updated in all cases.

Added verbose logging for troubleshooting.