### PR TITLE
[ios][ci] Add --depth to git clone

### DIFF
--- a/.github/workflows/ios-beta.yaml
+++ b/.github/workflows/ios-beta.yaml
@@ -32,6 +32,7 @@ jobs:
     steps:
       - name: Checkout sources
         uses: actions/checkout@v2
+          fetch-depth: 100 # enough to get all commits for the current day
 
       - name: Parallel submodules checkout
         run: git submodule update --init --recursive --jobs=4


### PR DESCRIPTION
iOS uses the number of commits in the current day as a build number.

Signed-off-by: Roman Tsisyk <roman@tsisyk.com>