### PR TITLE
[android] Fix permissions error on some devices when exporting bookmarks

### DIFF
--- a/android/AndroidManifest.xml
+++ b/android/AndroidManifest.xml
@@ -348,7 +348,7 @@
     <provider
       android:name="androidx.core.content.FileProvider"
       android:authorities="${FILE_PROVIDER_PLACEHOLDER}"
-      android:exported="false"
+      android:exported="true"
       android:grantUriPermissions="true">
       <meta-data
         android:name="android.support.FILE_PROVIDER_PATHS"


### PR DESCRIPTION
In theory, this error on some devices should be fixed:
```
08-16 20:29:12.343 E/DatabaseUtils( 6385): Writing exception to parcel
08-16 20:29:12.343 E/DatabaseUtils( 6385): java.lang.SecurityException: Permission Denial: reading androidx.core.content.FileProvider uri content://app.organicmaps.provider/cache/Cabo.kmz from pid=4023, uid=1000 requires the provider be exported, or grantUriPermission()
08-16 20:29:12.343 E/DatabaseUtils( 6385): 	at android.content.ContentProvider.enforceReadPermissionInner(ContentProvider.java:848)
08-16 20:29:12.343 E/DatabaseUtils( 6385): 	at android.content.ContentProvider$Transport.enforceReadPermission(ContentProvider.java:689)
08-16 20:29:12.343 E/DatabaseUtils( 6385): 	at android.content.ContentProvider$Transport.query(ContentProvider.java:244)
08-16 20:29:12.343 E/DatabaseUtils( 6385): 	at android.content.ContentProviderNative.onTransact(ContentProviderNative.java:106)
08-16 20:29:12.343 E/DatabaseUtils( 6385): 	at android.os.Binder.execTransactInternal(Binder.java:1157)
08-16 20:29:12.343 E/DatabaseUtils( 6385): 	at android.os.Binder.execTransact(Binder.java:1126)
08-16 20:29:23.850 D/OpenGLRenderer( 6385): endAllActiveAnimators on 0xb4000079d252aa00 (PinnedSecti
```

true: The provider is available to other applications. Any application can use the provider's content URI to access it, subject to the permissions specified for the provider.

false: The provider is not available to other applications. Set android:exported="false" to limit access to the provider to your applications. Only applications that have the same user ID (UID) as the provider, or applications that have been temporarily granted access to the provider through the android:grantUriPermissions element, have access to it.

See https://developer.android.com/guide/topics/manifest/provider-element#exported
