### PR TITLE
More intermediate stops

### DIFF
--- a/CONTRIBUTORS
+++ b/CONTRIBUTORS
@@ -36,6 +36,7 @@ Code contributions:
   Dima Korolev <dmitry.korolev@gmail.com>
   Max Grigorev <forwidur@gmail.com>
   Roman Tsisyk <roman@tsisyk.com>
+  Caspar Nuël <casparnuel@yandex.com>
 
 Porting to Tizen platform:
   Sergey Pisarchik

--- a/map/routing_mark.cpp
+++ b/map/routing_mark.cpp
@@ -192,7 +192,8 @@ drape_ptr<df::UserPointMark::SymbolNameZoomInfo> RouteMarkPoint::GetSymbolNames(
       case 0: name = "route-point-a"; break;
       case 1: name = "route-point-b"; break;
       case 2: name = "route-point-c"; break;
-      default: name = ""; break;
+      default: name = "route-point-c"; break; // This should be replaced with the "+" icon
+                                              // TODO: Properly add icons for other letters/numbers after C.
       }
       break;
     }
@@ -202,7 +203,7 @@ drape_ptr<df::UserPointMark::SymbolNameZoomInfo> RouteMarkPoint::GetSymbolNames(
   return symbol;
 }
 
-size_t const RoutePointsLayout::kMaxIntermediatePointsCount = 3;
+size_t const RoutePointsLayout::kMaxIntermediatePointsCount = 100;  // This should be tested if the routing algorithm can handle this
 
 RoutePointsLayout::RoutePointsLayout(BookmarkManager & manager)
   : m_manager(manager)

--- a/map/routing_mark.cpp
+++ b/map/routing_mark.cpp
@@ -192,8 +192,8 @@ drape_ptr<df::UserPointMark::SymbolNameZoomInfo> RouteMarkPoint::GetSymbolNames(
       case 0: name = "route-point-a"; break;
       case 1: name = "route-point-b"; break;
       case 2: name = "route-point-c"; break;
-      default: name = "route-point-c"; break; // This should be replaced with the "+" icon
-                                              // TODO: Properly add icons for other letters/numbers after C.
+      // TODO: Properly add icons for other letters/numbers after C.
+      default: name = "route-point-c"; break;
       }
       break;
     }
@@ -203,7 +203,8 @@ drape_ptr<df::UserPointMark::SymbolNameZoomInfo> RouteMarkPoint::GetSymbolNames(
   return symbol;
 }
 
-size_t const RoutePointsLayout::kMaxIntermediatePointsCount = 100;  // This should be tested if the routing algorithm can handle this
+// This should be tested if the routing algorithm can handle this
+size_t const RoutePointsLayout::kMaxIntermediatePointsCount = 100;
 
 RoutePointsLayout::RoutePointsLayout(BookmarkManager & manager)
   : m_manager(manager)


### PR DESCRIPTION
### Allow more intermediate stops
Currently, the application only allows for 3 intermediate stops: A, B, C.

The minimal changes to code allow for up to 100 intermediate stops (or more?).

Currently, the **C stop icon** is used for testing purposes. This is supposed to be **replaced with a "+" icon later** in development for a more streamlined user experience.

![Screenshot_20210821-014006](https://user-images.githubusercontent.com/73889285/130303153-f09bfa2b-d5bb-4b1d-ae67-34a93fea4bee.png)


### Remarks
While looking for a way to allow for more stops, I came across the following code:

`android/src/com/mapswithme/maps/routing/TransitStepView.java:112`

```

  @DrawableRes
  private static int getIntermediatePointDrawableId(int index)
  {
    switch (index)
    {
      case 0:
        return R.drawable.ic_24px_route_point_a;
      case 1:
        return R.drawable.ic_24px_route_point_b;
      case 2:
        return R.drawable.ic_24px_route_point_c;
    }
    throw new AssertionError("Unknown intermediate point index: " + index);
  }

```
This piece of code clearly interacts with the route points in some way. I have not yet encountered an error with my new implementation, but I was also unable to find out what this code is used for. **My implementation might break something, as this `getIntermediatePointDrawable()` does not take into account my 4th case once it is replaced with a "+" icon**.
