### PR TITLE
[android] Bookmark button now shows "Save" and "Delete" instead of just "Bookmark"

### DIFF
--- a/android/src/com/mapswithme/maps/widget/placepage/PlacePageButtons.java
+++ b/android/src/com/mapswithme/maps/widget/placepage/PlacePageButtons.java
@@ -171,8 +171,13 @@ public final class PlacePageButtons
         },
         ButtonType.BACK),
 
-    BOOKMARK(
-        R.string.bookmark,
+    BOOKMARK_SAVE(
+        R.string.save,
+        new ImageResources(R.drawable.ic_bookmarks_on),
+        ButtonType.BOOKMARK),
+
+    BOOKMARK_DELETE(
+        R.string.delete,
         new ImageResources(R.drawable.ic_bookmarks_off),
         ButtonType.BOOKMARK),
 

--- a/android/src/com/mapswithme/maps/widget/placepage/PlacePageView.java
+++ b/android/src/com/mapswithme/maps/widget/placepage/PlacePageView.java
@@ -1000,7 +1000,8 @@ public class PlacePageView extends NestedScrollViewClickFixed
     if (needToShowRoutingButtons && !hasNumber)
       buttons.add(PlacePageButtons.Item.ROUTE_FROM);
 
-    buttons.add(PlacePageButtons.Item.BOOKMARK);
+    buttons.add(mapObject.getMapObjectType() == MapObject.BOOKMARK ? PlacePageButtons.Item.BOOKMARK_DELETE
+        : PlacePageButtons.Item.BOOKMARK_SAVE);
 
     if (needToShowRoutingButtons)
     {


### PR DESCRIPTION
The behavior was fixed to represent the current iOS implementation and to avoid
accidental delete (now it's very clear for the user).

Signed-off-by: Alexander Borsuk <me@alex.bio>