### PR TITLE
[android] Tweak Huawei and Google Play publishing

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -44,7 +44,7 @@ buildscript {
     }
 
     classpath("com.github.triplet.gradle:play-publisher:3.6.0")
-    classpath("ru.cian:huawei-publish-gradle-plugin:1.2.4")
+    classpath("ru.cian:huawei-publish-gradle-plugin:1.3.0")
   }
 }
 
@@ -436,9 +436,10 @@ import com.github.triplet.gradle.androidpublisher.ReleaseStatus
 
 play {
   enabled.set(false)
-  track.set("alpha") // = Closed Testing
+  track.set("production")
+  userFraction.set(Double.valueOf(0.05)) // 5%
   defaultToAppBundles.set(true)
-  releaseStatus.set(ReleaseStatus.DRAFT)
+  releaseStatus.set(ReleaseStatus.COMPLETED)
   serviceAccountCredentials.set(file("google-play.json"))
 }
 
@@ -447,7 +448,7 @@ huaweiPublish {
     huaweiRelease {
       credentialsPath = "$rootDir/huawei-appgallery.json"
       buildFormat = "aab"
-      deployType = 'draft'
+      deployType = 'publish'
     }
   }
 }


### PR DESCRIPTION
- [google] Publish to production without manual approval.
- [huawei] Update Gradle plugin to support Gradle 7.x.
- [huawei] Publish to production without manual approval.

Signed-off-by: Roman Tsisyk <roman@tsisyk.com>