### PR TITLE
[categories] add german trash bin synonym

### DIFF
--- a/data/categories.txt
+++ b/data/categories.txt
@@ -7094,7 +7094,7 @@ da:Skraldespand
 nl:Vuilnisbak
 fi:Roska-astia
 fr:Poubelle
-de:Abfalleimer
+de:Abfalleimer|Mülleimer
 hu:Szemétkosár
 id:Kotak sampah
 it:Contenitore per rifiuti


### PR DESCRIPTION
"Abfalleimer" and "Mülleimer " are both widely used to search for wastebins.

See: https://de.wikipedia.org/wiki/Abfalleimer