### PR TITLE
[android] Disable non-working links verification

### DIFF
--- a/android/AndroidManifest.xml
+++ b/android/AndroidManifest.xml
@@ -95,7 +95,7 @@
         <data android:scheme="https"/>
       </intent-filter>
 
-      <intent-filter android:autoVerify="true">
+      <intent-filter>
         <action android:name="android.intent.action.VIEW"/>
 
         <category android:name="android.intent.category.DEFAULT"/>


### PR DESCRIPTION
In our case it does not work anyway because of foreign domains.

Without this flag the app will be more private and do not issue requests to foreign sites

Only if the system finds a matching Digital Asset Links file for ALL hosts in the manifest does it then establish your app as the default handler for the specified URL patterns.

Fixes #1276

@rtsisyk please double-check that new behavior is the same as it is now after a fresh app install for omaps.app, ge0.me and map.google.com
