### PR TITLE
Adding version specifier for brew Qt in the docs

### DIFF
--- a/docs/INSTALL.md
+++ b/docs/INSTALL.md
@@ -47,10 +47,10 @@ sudo dnf install -y \
     sqlite-devel
 ```
 
-**macOS**:
+**macOS**: 
 
 ```bash
-brew install qt cmake
+brew install cmake qt@5
 ```
 
 ### Getting sources


### PR DESCRIPTION
Latest Qt version is 6.1.3 which doesn't work with building, adding @5 ensures that Qt 5 is installed instead of the latest version.

(This is my first ever pull-request! 🥳)