### PR TITLE
Better wording in support emails

### DIFF
--- a/android/src/com/mapswithme/maps/settings/HelpFragment.java
+++ b/android/src/com/mapswithme/maps/settings/HelpFragment.java
@@ -29,7 +29,7 @@ public class HelpFragment extends BaseSettingsFragment
 
     private void reportBug()
     {
-      Utils.sendBugReport(requireActivity(), "Bugreport from user");
+      Utils.sendBugReport(requireActivity(), "Organic Maps Bugreport");
     }
 
     @Override

--- a/android/src/com/mapswithme/util/Utils.java
+++ b/android/src/com/mapswithme/util/Utils.java
@@ -333,7 +333,7 @@ public class Utils
 
   public static void sendFeedback(@NonNull Activity activity)
   {
-    LoggerFactory.INSTANCE.zipLogs(new SupportInfoWithLogsCallback(activity, "Feedback",
+    LoggerFactory.INSTANCE.zipLogs(new SupportInfoWithLogsCallback(activity, "Organic Maps Feedback",
                                                                    Constants.Email.FEEDBACK));
   }
 

--- a/iphone/Maps/UI/Settings/MWMHelpController.m
+++ b/iphone/Maps/UI/Settings/MWMHelpController.m
@@ -106,13 +106,13 @@ static NSString * const kiOSEmail = @"ios@organicmaps.app";
 - (void)commonReportAction
 {
   // Do not localize subject. Support team uses it to filter emails.
-  [self sendEmailWithSubject:@"Feedback from user" toRecipient:kiOSEmail];
+  [self sendEmailWithSubject:@"Organic Maps Feedback" toRecipient:kiOSEmail];
 }
 
 - (void)bugReportAction
 {
   // Do not localize subject. Support team uses it to filter emails.
-  [self sendEmailWithSubject:@"Bugreport from user" toRecipient:kiOSEmail];
+  [self sendEmailWithSubject:@"Organic Maps Bugreport" toRecipient:kiOSEmail];
 }
 
 #pragma mark - Email


### PR DESCRIPTION
It helps to restore the context of email conversation by just looking at the topic.