### PR TITLE
#457 Better support for OLC

### DIFF
--- a/3party/open-location-code/README.md
+++ b/3party/open-location-code/README.md
@@ -1,4 +1,36 @@
 # Open Location Code C++ API
 This is the C++ implementation of the Open Location Code API.
 
-Copied from [Google's Repository](https://github.com/google/open-location-code).
+# Usage
+
+See openlocationcode_example.cc for how to use the library. To run the example, use:
+
+```
+bazel run openlocationcode_example
+```
+
+# Development
+
+The library is built/tested using [Bazel](https://bazel.build). To build the library, use:
+
+```
+bazel build openlocationcode
+```
+
+To run the tests, use:
+
+```
+bazel test --test_output=all openlocationcode_test
+```
+
+The tests use the CSV files in the test_data folder. Make sure you copy this folder to the
+root of your local workspace.
+
+# Formatting
+
+Code must be formatted using `clang-format`, and this will be checked in the
+tests. You can format your code using the script:
+
+```
+sh clang_check.sh
+```

--- a/3party/open-location-code/codearea.cc
+++ b/3party/open-location-code/codearea.cc
@@ -16,29 +16,24 @@ CodeArea::CodeArea(double latitude_lo, double longitude_lo, double latitude_hi,
   code_length_ = code_length;
 }
 
-double CodeArea::GetLatitudeLo() const{
-  return latitude_lo_;
-}
+double CodeArea::GetLatitudeLo() const { return latitude_lo_; }
 
-double CodeArea::GetLongitudeLo() const {
-  return longitude_lo_;
-}
+double CodeArea::GetLongitudeLo() const { return longitude_lo_; }
 
-double CodeArea::GetLatitudeHi() const {
-  return latitude_hi_;
-}
+double CodeArea::GetLatitudeHi() const { return latitude_hi_; }
 
-double CodeArea::GetLongitudeHi() const {
-  return longitude_hi_;
-}
+double CodeArea::GetLongitudeHi() const { return longitude_hi_; }
 
 size_t CodeArea::GetCodeLength() const { return code_length_; }
 
 LatLng CodeArea::GetCenter() const {
-  double latitude_center = std::min(latitude_lo_ + (latitude_hi_ - latitude_lo_) / 2, kLatitudeMaxDegrees);
-  double longitude_center = std::min(longitude_lo_ + (longitude_hi_ - longitude_lo_) / 2, kLongitudeMaxDegrees);
-  LatLng center{latitude_center, longitude_center};
+  const double latitude_center = std::min(
+      latitude_lo_ + (latitude_hi_ - latitude_lo_) / 2, kLatitudeMaxDegrees);
+  const double longitude_center =
+      std::min(longitude_lo_ + (longitude_hi_ - longitude_lo_) / 2,
+               kLongitudeMaxDegrees);
+  const LatLng center = {latitude_center, longitude_center};
   return center;
 }
 
-} // namespace openlocationcode
+}  // namespace openlocationcode

--- a/3party/open-location-code/codearea.h
+++ b/3party/open-location-code/codearea.h
@@ -29,6 +29,6 @@ class CodeArea {
   size_t code_length_;
 };
 
-} // namespace openlocationcode
+}  // namespace openlocationcode
 
 #endif  // LOCATION_OPENLOCATIONCODE_CODEAREA_H_

--- a/3party/open-location-code/openlocationcode.h
+++ b/3party/open-location-code/openlocationcode.h
@@ -90,6 +90,9 @@ extern const size_t kMaximumDigitCount;
 extern const char kPaddingCharacter;
 // The alphabet of the codes.
 extern const char kAlphabet[];
+// Lookup table of the alphabet positions of characters 'C' through 'X',
+// inclusive. A value of -1 means the character isn't part of the alphabet.
+extern const int kPositionLUT['X' - 'C' + 1];
 // The number base used for the encoding.
 extern const size_t kEncodingBase;
 // How many characters use the pair algorithm.
@@ -98,9 +101,6 @@ extern const size_t kPairCodeLength;
 extern const size_t kGridColumns;
 // Number of rows in the grid refinement method.
 extern const size_t kGridRows;
-// Defines the minimum pair resolution (in degrees) to remove when shortening a
-// code.
-extern const double kMinShortenDegrees;
 // Gives the exponent used for the first pair.
 extern const size_t kInitialExponent;
 // Size of the initial grid in degrees. This is the size of the area represented

--- a/android/jni/com/mapswithme/maps/Framework.cpp
+++ b/android/jni/com/mapswithme/maps/Framework.cpp
@@ -922,16 +922,16 @@ Java_com_mapswithme_maps_Framework_nativeGetDistanceAndAzimuthFromLatLon(
 JNIEXPORT jobject JNICALL
 Java_com_mapswithme_maps_Framework_nativeFormatLatLon(JNIEnv * env, jclass, jdouble lat, jdouble lon, int coordsFormat)
 {
-  switch (coordsFormat) // See CoordinatesFormat enum for all possible values.
+  switch (static_cast<android::CoordinatesFormat>(coordsFormat))
   {
     default:
-    case 0: // DMS, comma separated
+    case android::CoordinatesFormat::LatLonDMS: // DMS, comma separated
       return jni::ToJavaString(env, measurement_utils::FormatLatLonAsDMS(lat, lon, true /*withComma*/, 2));
-    case 1: // Decimal, comma separated
+    case android::CoordinatesFormat::LatLonDecimal: // Decimal, comma separated
       return jni::ToJavaString(env, measurement_utils::FormatLatLon(lat, lon, true /* withComma */, 6));
-    case 2: // Open location code, long format
+    case android::CoordinatesFormat::OLCFull: // Open location code, long format
       return jni::ToJavaString(env, openlocationcode::Encode({lat, lon}));
-    case 3: // Link to osm.org
+    case android::CoordinatesFormat::OSMLink: // Link to osm.org
       return jni::ToJavaString(env, measurement_utils::FormatOsmLink(lat, lon, 14));
   }
 }

--- a/android/jni/com/mapswithme/maps/Framework.cpp
+++ b/android/jni/com/mapswithme/maps/Framework.cpp
@@ -51,6 +51,8 @@
 #include "base/math.hpp"
 #include "base/sunrise_sunset.hpp"
 
+#include "3party/open-location-code/openlocationcode.h"
+
 #include <cstdint>
 #include <memory>
 #include <string>
@@ -918,29 +920,20 @@ Java_com_mapswithme_maps_Framework_nativeGetDistanceAndAzimuthFromLatLon(
 }
 
 JNIEXPORT jobject JNICALL
-Java_com_mapswithme_maps_Framework_nativeFormatLatLon(JNIEnv * env, jclass, jdouble lat, jdouble lon, jboolean useDMSFormat)
+Java_com_mapswithme_maps_Framework_nativeFormatLatLon(JNIEnv * env, jclass, jdouble lat, jdouble lon, int coordsFormat)
 {
-  return jni::ToJavaString(
-      env, (useDMSFormat ? measurement_utils::FormatLatLonAsDMS(lat, lon, 2)
-                         : measurement_utils::FormatLatLon(lat, lon, true /* withSemicolon */, 6)));
-}
-
-JNIEXPORT jobjectArray JNICALL
-Java_com_mapswithme_maps_Framework_nativeFormatLatLonToArr(JNIEnv * env, jclass, jdouble lat, jdouble lon, jboolean useDMSFormat)
-{
-  string slat, slon;
-  if (useDMSFormat)
-    measurement_utils::FormatLatLonAsDMS(lat, lon, slat, slon, 2);
-  else
-    measurement_utils::FormatLatLon(lat, lon, slat, slon, 6);
-
-  static jclass const klass = jni::GetGlobalClassRef(env, "java/lang/String");
-  jobjectArray arr = env->NewObjectArray(2, klass, 0);
-
-  env->SetObjectArrayElement(arr, 0, jni::ToJavaString(env, slat));
-  env->SetObjectArrayElement(arr, 1, jni::ToJavaString(env, slon));
-
-  return arr;
+  switch (coordsFormat) // See CoordinatesFormat enum for all possible values.
+  {
+    default:
+    case 0: // DMS, comma separated
+      return jni::ToJavaString(env, measurement_utils::FormatLatLonAsDMS(lat, lon, true /*withComma*/, 2));
+    case 1: // Decimal, comma separated
+      return jni::ToJavaString(env, measurement_utils::FormatLatLon(lat, lon, true /* withComma */, 6));
+    case 2: // Open location code, long format
+      return jni::ToJavaString(env, openlocationcode::Encode({lat, lon}));
+    case 3: // Link to osm.org
+      return jni::ToJavaString(env, measurement_utils::FormatOsmLink(lat, lon, 14));
+  }
 }
 
 JNIEXPORT jobject JNICALL

--- a/android/jni/com/mapswithme/maps/Framework.hpp
+++ b/android/jni/com/mapswithme/maps/Framework.hpp
@@ -39,6 +39,14 @@ struct EverywhereSearchParams;
 
 namespace android
 {
+  enum CoordinatesFormat // See Java enum com.mapswithme.maps.widget.placepage.CoordinatesFormat for all possible values.
+  {
+    LatLonDMS = 0,     // Latitude, Longitude in degrees minutes seconds format, comma separated
+    LatLonDecimal = 1, // Latitude, Longitude in decimal format, comma separated
+    OLCFull = 2,       // Open location code, full format
+    OSMLink = 3        // Link to the OSM. E.g. https://osm.org/go/xcXjyqQlq-?m=
+  };
+
   class Framework : private power_management::PowerManager::Subscriber
   {
   private:

--- a/android/src/com/mapswithme/maps/Framework.java
+++ b/android/src/com/mapswithme/maps/Framework.java
@@ -207,10 +207,7 @@ public class Framework
 
   public static native DistanceAndAzimut nativeGetDistanceAndAzimuthFromLatLon(double dstLat, double dstLon, double srcLat, double srcLon, double north);
 
-  public static native String nativeFormatLatLon(double lat, double lon, boolean useDmsFormat);
-
-  @Size(2)
-  public static native String[] nativeFormatLatLonToArr(double lat, double lon, boolean useDmsFormat);
+  public static native String nativeFormatLatLon(double lat, double lon, int coordFormat);
 
   public static native String nativeFormatAltitude(double alt);
 

--- a/android/src/com/mapswithme/maps/routing/RoutingController.java
+++ b/android/src/com/mapswithme/maps/routing/RoutingController.java
@@ -23,6 +23,7 @@ import com.mapswithme.maps.base.Initializable;
 import com.mapswithme.maps.bookmarks.data.FeatureId;
 import com.mapswithme.maps.bookmarks.data.MapObject;
 import com.mapswithme.maps.location.LocationHelper;
+import com.mapswithme.maps.widget.placepage.CoordinatesFormat;
 import com.mapswithme.util.Config;
 import com.mapswithme.util.StringUtils;
 import com.mapswithme.util.Utils;
@@ -933,7 +934,7 @@ public class RoutingController implements Initializable<Void>
       }
       else
       {
-        title = Framework.nativeFormatLatLon(point.getLat(), point.getLon(), false /* useDmsFormat */);
+        title = Framework.nativeFormatLatLon(point.getLat(), point.getLon(), CoordinatesFormat.LatLonDecimal.getId());
       }
     }
     return new Pair<>(title, subtitle);

--- a/android/src/com/mapswithme/maps/widget/placepage/CoordinatesFormat.java
+++ b/android/src/com/mapswithme/maps/widget/placepage/CoordinatesFormat.java
@@ -27,6 +27,6 @@ public enum CoordinatesFormat
         return cursor;
     }
 
-    throw new IllegalArgumentException();
+    return LatLonDMS; // Default format is DMS
   }
 }

--- a/android/src/com/mapswithme/maps/widget/placepage/CoordinatesFormat.java
+++ b/android/src/com/mapswithme/maps/widget/placepage/CoordinatesFormat.java
@@ -1,0 +1,32 @@
+package com.mapswithme.maps.widget.placepage;
+
+public enum CoordinatesFormat
+{
+  LatLonDMS(0),     // Latitude, Longitude in degrees minutes seconds format, comma separated
+  LatLonDecimal(1), // Latitude, Longitude in decimal format, comma separated
+  OLCFull(2),       // Open location code, full format
+  OSMLink(3);       // Link to the OSM. E.g. https://osm.org/go/xcXjyqQlq-?m=
+
+  private final int id;
+
+  CoordinatesFormat(int id)
+  {
+    this.id = id;
+  }
+
+  public int getId()
+  {
+    return id;
+  }
+
+  public static CoordinatesFormat fromId(int id)
+  {
+    for (CoordinatesFormat cursor: CoordinatesFormat.values())
+    {
+      if (cursor.id == id)
+        return cursor;
+    }
+
+    throw new IllegalArgumentException();
+  }
+}

--- a/map/place_page_info.cpp
+++ b/map/place_page_info.cpp
@@ -214,7 +214,7 @@ void Info::SetCustomNameWithCoordinates(m2::PointD const & mercator, std::string
     m_uiTitle = name;
     m_uiSubtitle = measurement_utils::FormatLatLon(
         mercator::YToLat(mercator.y), mercator::XToLon(mercator.x),
-                                                   true /* withSemicolon */);
+                                                   true /* withComma */);
   }
   m_customName = name;
 }
@@ -279,7 +279,7 @@ std::string Info::GetFormattedCoordinate(bool isDMS) const
 {
   auto const & ll = GetLatLon();
   return isDMS ? measurement_utils::FormatLatLon(ll.m_lat, ll.m_lon, true)
-               : measurement_utils::FormatLatLonAsDMS(ll.m_lat, ll.m_lon, 2);
+               : measurement_utils::FormatLatLonAsDMS(ll.m_lat, ll.m_lon, false, 2);
 }
 
 void Info::SetRoadType(RoadWarningMarkType type, std::string const & localizedType, std::string const & distance)

--- a/platform/measurement_utils.cpp
+++ b/platform/measurement_utils.cpp
@@ -249,19 +249,19 @@ string FormatSpeedUnits(Units units)
 string FormatOsmLink(double lat, double lon, int zoom)
 {
   static char char_array[] = "ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789_~";
-  uint32_t x = round((lon + 180.0) / 360.0 * (1L<<32));
-  uint32_t y = round((lat + 90.0) / 180.0 * (1L<<32));
-  uint64_t code = bits::BitwiseMerge(y, x);
+  uint32_t const x = round((lon + 180.0) / 360.0 * (1L<<32));
+  uint32_t const y = round((lat + 90.0) / 180.0 * (1L<<32));
+  uint64_t const code = bits::BitwiseMerge(y, x);
   string osmUrl = "https://osm.org/go/";
 
-  for (int i = 0; i < ((zoom+10)/3) ; ++i)
+  for (int i = 0; i < (zoom + 10) / 3; ++i)
   {
-    int digit = (code >> (58 - (6 * i))) & 0x3f;
+    int digit = (code >> (58 - 6 * i)) & 0x3f;
     osmUrl += char_array[digit];
   }
 
-  for (int i = 0; i < ((zoom + 8) % 3); ++i)
-    osmUrl +=  "-";
+  for (int i = 0; i < (zoom + 8) % 3; ++i)
+    osmUrl += "-";
 
   return osmUrl + "?m=";
 }

--- a/platform/measurement_utils.hpp
+++ b/platform/measurement_utils.hpp
@@ -50,7 +50,7 @@ std::string FormatSpeedUnits(Units units);
 
 /// @param[in] dac  Digits after comma in seconds.
 /// Use dac == 3 for our common conversions to DMS.
-std::string FormatLatLonAsDMS(double lat, double lon, int dac = 3);
+std::string FormatLatLonAsDMS(double lat, double lon, bool withComma, int dac = 3);
 void FormatLatLonAsDMS(double lat, double lon, std::string & latText, std::string & lonText,
                        int dac = 3);
 std::string FormatMercatorAsDMS(m2::PointD const & mercator, int dac = 3);
@@ -59,11 +59,13 @@ void FormatMercatorAsDMS(m2::PointD const & mercator, std::string & lat, std::st
 
 /// Default dac == 6 for the simple decimal formatting.
 std::string FormatLatLon(double lat, double lon, int dac = 6);
-std::string FormatLatLon(double lat, double lon, bool withSemicolon, int dac = 6);
+std::string FormatLatLon(double lat, double lon, bool withComma, int dac = 6);
 void FormatLatLon(double lat, double lon, std::string & latText, std::string & lonText,
                   int dac = 6);
 std::string FormatMercator(m2::PointD const & mercator, int dac = 6);
 void FormatMercator(m2::PointD const & mercator, std::string & lat, std::string & lon, int dac = 6);
+
+std::string FormatOsmLink(double lat, double lon, int zoom);
 
 /// Converts OSM distance (height, ele etc.) to meters.
 /// @returns false if fails.

--- a/platform/platform_tests/measurement_tests.cpp
+++ b/platform/platform_tests/measurement_tests.cpp
@@ -65,29 +65,39 @@ UNIT_TEST(Measurement_Smoke)
 
 UNIT_TEST(LatLonToDMS_Origin)
 {
-  TEST_EQUAL(FormatLatLonAsDMS(0, 0), "00°00′00″ 00°00′00″", ());
-  TEST_EQUAL(FormatLatLonAsDMS(0, 0, 3), "00°00′00″ 00°00′00″", ());
+  TEST_EQUAL(FormatLatLonAsDMS(0, 0, false), "00°00′00″ 00°00′00″", ());
+  TEST_EQUAL(FormatLatLonAsDMS(0, 0, false, 3), "00°00′00″ 00°00′00″", ());
 }
 
 UNIT_TEST(LatLonToDMS_Rounding)
 {
   // Here and after data is from Wiki: http://bit.ly/datafotformatingtest
   // Boston
-  TEST_EQUAL(FormatLatLonAsDMS(42.358056, -71.063611, 0), "42°21′29″N 71°03′49″W", ());
+  TEST_EQUAL(FormatLatLonAsDMS(42.358056, -71.063611, false, 0), "42°21′29″N 71°03′49″W", ());
   // Minsk
-  TEST_EQUAL(FormatLatLonAsDMS(53.916667, 27.55, 0), "53°55′00″N 27°33′00″E", ());
+  TEST_EQUAL(FormatLatLonAsDMS(53.916667, 27.55, false, 0), "53°55′00″N 27°33′00″E", ());
   // Rio
-  TEST_EQUAL(FormatLatLonAsDMS(-22.908333, -43.196389, 0), "22°54′30″S 43°11′47″W", ());
+  TEST_EQUAL(FormatLatLonAsDMS(-22.908333, -43.196389, false, 0), "22°54′30″S 43°11′47″W", ());
 }
 
 UNIT_TEST(LatLonToDMS_NoRounding)
 {
   // Paris
-  TEST_EQUAL(FormatLatLonAsDMS(48.8567, 2.3508, 2), "48°51′24.12″N 02°21′02.88″E", ());
+  TEST_EQUAL(FormatLatLonAsDMS(48.8567, 2.3508, false, 2), "48°51′24.12″N 02°21′02.88″E", ());
   // Vatican
-  TEST_EQUAL(FormatLatLonAsDMS(41.904, 12.453, 2), "41°54′14.4″N 12°27′10.8″E", ());
+  TEST_EQUAL(FormatLatLonAsDMS(41.904, 12.453, false, 2), "41°54′14.4″N 12°27′10.8″E", ());
 
-  TEST_EQUAL(FormatLatLonAsDMS(21.981112, -159.371112, 2), "21°58′52″N 159°22′16″W", ());
+  TEST_EQUAL(FormatLatLonAsDMS(21.981112, -159.371112, false, 2), "21°58′52″N 159°22′16″W", ());
+}
+
+UNIT_TEST(FormatOsmLink)
+{
+  //Zero point
+  TEST_EQUAL(FormatOsmLink(0, 0, 5), "https://osm.org/go/wAAAA-?m=", ());
+  //Eifel tower
+  TEST_EQUAL(FormatOsmLink(48.85825, 2.29450, 15), "https://osm.org/go/0BOdUs9e--?m=", ());
+  //Buenos Aires
+  TEST_EQUAL(FormatOsmLink(-34.6061, -58.4360, 10), "https://osm.org/go/Mnx6SB?m=", ());
 }
 
 UNIT_TEST(FormatAltitude)

--- a/qt/bookmark_dialog.cpp
+++ b/qt/bookmark_dialog.cpp
@@ -286,7 +286,7 @@ void BookmarkDialog::FillTree()
         {
           name = measurement_utils::FormatLatLon(mercator::YToLat(bookmark->GetPivot().y),
                                                  mercator::XToLon(bookmark->GetPivot().x),
-                                                 true /* withSemicolon */);
+                                                 true /* withComma */);
         }
         auto bookmarkItem = CreateTreeItem(name + " (Bookmark)", categoryItem);
         bookmarkItem->setTextColor(0, Qt::blue);


### PR DESCRIPTION
Fix for issue [#457](https://github.com/organicmaps/organicmaps/issues/457) "Better support for OLC (Open Location Code)".

* Updated `3party/open-location-code` to latest version 1.0.4.
* Added full OLC code and OSM.org link to point coordinates formats.

Short OLC format is not supported because it requires reference coordinates (nearest city usually). It's hard to implement curently.

![new-coordinates](https://user-images.githubusercontent.com/720808/135045823-f0261134-c6b2-43e5-acd8-90498faf294e.png)

TODO: There's is a bug in search. If you enter short OLC code `WF8Q+WF` in search field then decoded coordinates depend on current position. So if user moves and GPS coordinates change then decoded coordinates change too. This is not how OLC should work.