### PR TITLE
Wrong styling for 'copy coordinates' popup in night mode

### DIFF
--- a/android/res/values/themes-base.xml
+++ b/android/res/values/themes-base.xml
@@ -174,6 +174,7 @@
     <item name="chipBackgroundColor">@color/white_secondary</item>
     <item name="chipIconTintColor">@color/extended_green</item>
     <item name="chipTextColor">@color/bg_primary</item>
+    <item name="android:popupMenuStyle">@style/PopupMenu</item>
   </style>
 
   <!-- Night theme -->
@@ -343,5 +344,6 @@
     <item name="chipBackgroundColor">@android:color/black</item>
     <item name="chipIconTintColor">@color/white_lightest</item>
     <item name="chipTextColor">@color/white_secondary</item>
+    <item name="android:popupMenuStyle">@style/PopupMenu.Dark</item>
   </style>
 </resources>

--- a/android/res/values/themes.xml
+++ b/android/res/values/themes.xml
@@ -203,4 +203,11 @@
     <item name="android:windowBackground">@null</item>
   </style>
 
+  <style name="PopupMenu" parent="ThemeOverlay.AppCompat">
+    <item name="android:popupBackground">?windowBackgroundForced</item>
+  </style>
+
+  <style name="PopupMenu.Dark" parent="ThemeOverlay.AppCompat.Dark">
+    <item name="android:popupBackground">?windowBackgroundForced</item>
+  </style>
 </resources>


### PR DESCRIPTION
See issue [#769](https://github.com/organicmaps/organicmaps/issues/769) "Wrong styling for 'copy coordinates' popup in night mode"

Added explicit popup menu style for light and dark themes:

![night-popup-menu](https://user-images.githubusercontent.com/720808/135098801-5329fe17-74f8-40e5-b7b9-c3bfe7516f47.png)