### PR TITLE
[android] Upload to drafts in Huawei AppGallery

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -448,7 +448,8 @@ huaweiPublish {
     huaweiRelease {
       credentialsPath = "$rootDir/huawei-appgallery.json"
       buildFormat = "aab"
-      deployType = 'publish'
+      // https://github.com/cianru/huawei-publish-gradle-plugin/issues/32
+      deployType = 'draft'
     }
   }
 }


### PR DESCRIPTION
`publish` mode is just broken. Use `draft` and approve manually.

See https://github.com/cianru/huawei-publish-gradle-plugin/issues/32

Signed-off-by: Roman Tsisyk <roman@tsisyk.com>