### PR TITLE
[android] Fixed compilation error due to renamed dependency

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -94,7 +94,7 @@ dependencies {
   implementation 'androidx.constraintlayout:constraintlayout:2.1.0'
   implementation 'androidx.work:work-runtime:2.5.0'
   implementation 'com.trafi:anchor-bottom-sheet-behavior:0.13-alpha'
-  implementation 'com.github.yoksnod:MPAndroidChart:3.2.0-alpha'
+  implementation 'com.github.devnullorthrow:MPAndroidChart:3.2.0-alpha'
   implementation 'com.google.android.material:material:1.5.0-alpha02'
   implementation 'androidx.appcompat:appcompat:1.3.1'
   implementation 'androidx.preference:preference:1.1.1'


### PR DESCRIPTION
Looks like the GitHub user account for the dependency was renamed, and it caused a build failure.