### PR TITLE
Revert "[android] ability for debugging webview"

### DIFF
--- a/android/src/com/mapswithme/maps/MwmApplication.java
+++ b/android/src/com/mapswithme/maps/MwmApplication.java
@@ -5,7 +5,6 @@ import android.content.Context;
 import android.content.SharedPreferences;
 import android.os.Handler;
 import android.os.Message;
-import android.webkit.WebView;
 
 import androidx.annotation.NonNull;
 import androidx.multidex.MultiDex;
@@ -35,7 +34,6 @@ import com.mapswithme.util.SharedPropertiesUtils;
 import com.mapswithme.util.StorageUtils;
 import com.mapswithme.util.ThemeSwitcher;
 import com.mapswithme.util.UiUtils;
-import com.mapswithme.util.Utils;
 import com.mapswithme.util.log.Logger;
 import com.mapswithme.util.log.LoggerFactory;
 
@@ -145,7 +143,6 @@ public class MwmApplication extends Application implements AppBackgroundTracker.
     mIsolinesManager = new IsolinesManager(this);
 
     mPlayer = new MediaPlayerWrapper(this);
-    WebView.setWebContentsDebuggingEnabled(Utils.isDebugOrBeta());
   }
 
   private void initNotificationChannels()

--- a/android/src/com/mapswithme/util/Utils.java
+++ b/android/src/com/mapswithme/util/Utils.java
@@ -601,17 +601,12 @@ public class Utils
     catch (RuntimeException e)
     {
       LOGGER.e(TAG, "Failed to get string with id '" + key + "'", e);
-      if (isDebugOrBeta())
+      if (BuildConfig.BUILD_TYPE.equals("debug") || BuildConfig.BUILD_TYPE.equals("beta"))
       {
         Toast.makeText(context, "Add string id for '" + key + "'!", Toast.LENGTH_LONG).show();
       }
     }
     return INVALID_ID;
-  }
-
-  public static boolean isDebugOrBeta()
-  {
-    return BuildConfig.BUILD_TYPE.equals("debug") || BuildConfig.BUILD_TYPE.equals("beta");
   }
 
   /**


### PR DESCRIPTION
This reverts commit 44eb20bd6fc5d76aea1fc07fdf561cc926d126a1.

It crashes the app on some watches because of missing
WebView.setWebContentsDebuggingEnabled implementation.

Also, we don't use and don't need this feature in our debug/beta builds.

See https://github.com/mapsme/omim/pull/14064 for more details.