### PR TITLE
fix linking error on Arch Linux

### DIFF
--- a/cmake/OmimHelpers.cmake
+++ b/cmake/OmimHelpers.cmake
@@ -154,7 +154,7 @@ function(link_opengl target)
     if (PLATFORM_LINUX)
       omim_link_libraries(
         ${target}
-        ${OPENGL_gl_LIBRARY}
+        OpenGL::GL
       )
     endif()
 endfunction()


### PR DESCRIPTION
On recent Arch Linux I can not link project, millions of errors about missed references to `gl*`.
Looks like `cmake` has problem with old syntax for accessing `opengl`,
but because of
```
cmake_minimum_required(VERSION 3.18)
```
I suppose usage of new syntax don't break anything.