### PR TITLE
[android] modified PlacePageView to fix hotel subtitles color

### DIFF
--- a/android/src/com/mapswithme/maps/widget/placepage/PlacePageView.java
+++ b/android/src/com/mapswithme/maps/widget/placepage/PlacePageView.java
@@ -830,7 +830,7 @@ public class PlacePageView extends NestedScrollViewClickFixed
       if (start > -1)
       {
         sb.setSpan(new ForegroundColorSpan(getResources().getColor(R.color.base_yellow)),
-                   start, end), Spanned.SPAN_INCLUSIVE_EXCLUSIVE);
+                   start, end, Spanned.SPAN_INCLUSIVE_EXCLUSIVE);
 
       }
       mTvSubtitle.setText(sb);

--- a/android/src/com/mapswithme/maps/widget/placepage/PlacePageView.java
+++ b/android/src/com/mapswithme/maps/widget/placepage/PlacePageView.java
@@ -826,7 +826,7 @@ public class PlacePageView extends NestedScrollViewClickFixed
     {
       SpannableStringBuilder sb = new SpannableStringBuilder(text);
       int start = text.indexOf("★");
-      int end = text.lastIndexOf("★") + 1
+      int end = text.lastIndexOf("★") + 1;
       if (start > -1)
       {
         sb.setSpan(new ForegroundColorSpan(getResources().getColor(R.color.base_yellow)),

--- a/android/src/com/mapswithme/maps/widget/placepage/PlacePageView.java
+++ b/android/src/com/mapswithme/maps/widget/placepage/PlacePageView.java
@@ -829,7 +829,7 @@ public class PlacePageView extends NestedScrollViewClickFixed
       if (start > -1)
       {
         sb.setSpan(new ForegroundColorSpan(getResources().getColor(R.color.base_yellow)),
-                   start, sb.length(), Spanned.SPAN_INCLUSIVE_EXCLUSIVE);
+                   start, text.lastIndexOf("★"), Spanned.SPAN_INCLUSIVE_EXCLUSIVE);
 
       }
       mTvSubtitle.setText(sb);

--- a/android/src/com/mapswithme/maps/widget/placepage/PlacePageView.java
+++ b/android/src/com/mapswithme/maps/widget/placepage/PlacePageView.java
@@ -826,10 +826,11 @@ public class PlacePageView extends NestedScrollViewClickFixed
     {
       SpannableStringBuilder sb = new SpannableStringBuilder(text);
       int start = text.indexOf("★");
+      int end = text.lastIndexOf("★") + 1
       if (start > -1)
       {
         sb.setSpan(new ForegroundColorSpan(getResources().getColor(R.color.base_yellow)),
-                   start, text.lastIndexOf("★"), Spanned.SPAN_INCLUSIVE_EXCLUSIVE);
+                   start, end), Spanned.SPAN_INCLUSIVE_EXCLUSIVE);
 
       }
       mTvSubtitle.setText(sb);


### PR DESCRIPTION
## Problem
When an hotel POI has stars : all the end of hotel subtitles is colored yellow, only the stars should be colored yellow, the remaining characters shall be grey as the rest of the string.
![Screenshot_20211112-220031](https://user-images.githubusercontent.com/41507326/141541198-11196d6f-346f-48f8-b828-3857233091d6.png)
(here `· Wifi `shall be grey color)

The coloration was set to be applied until the end of the text with `sb.length()` 

This PR propose a fix, unfortunatly I was not able to build the application to test my modification.

## System
* OS: Android 12
* Organic Maps version: 2021.11.04-2-FDroid
* Data Version: 211022
