### PR TITLE
[Android] Opening hours UI rework

### DIFF
--- a/android/res/layout/place_page_opening_hours.xml
+++ b/android/res/layout/place_page_opening_hours.xml
@@ -1,6 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <RelativeLayout
   xmlns:android="http://schemas.android.com/apk/res/android"
+  xmlns:app="http://schemas.android.com/apk/res-auto"
   xmlns:tools="http://schemas.android.com/tools"
   android:id="@+id/ll__place_schedule"
   style="@style/PlacePageItemFrame"
@@ -16,27 +17,49 @@
     android:tint="?iconTint"/>
 
   <TextView
-    android:id="@+id/today_opening_hours"
-    android:layout_width="match_parent"
+    android:id="@+id/oh_today_label"
+    android:layout_width="wrap_content"
     android:layout_height="wrap_content"
     android:layout_marginTop="6dp"
+    android:layout_marginBottom="0dp"
     android:layout_toEndOf="@id/icon"
     android:textAppearance="@style/MwmTextAppearance.PlacePage"
-    tools:text="@string/day_off_today"
-    tools:textColor="@color/base_red"
+    tools:text="@string/today"
+    android:text="@string/today"
     tools:visibility="visible"/>
 
   <TextView
-    android:id="@+id/opening_hours"
-    android:layout_width="match_parent"
+    android:id="@+id/oh_today_open_time"
+    android:layout_width="wrap_content"
     android:layout_height="wrap_content"
-    android:layout_below="@id/today_opening_hours"
-    android:layout_marginTop="@dimen/margin_base"
-    android:layout_toEndOf="@id/icon"
-    android:gravity="top|start"
-    android:lineSpacingExtra="@dimen/margin_base"
-    android:textAppearance="@style/MwmTextAppearance.Body3"
-    android:visibility="gone"
-    tools:text="Mo-Fr 16:00-18.00"/>
+    android:layout_marginTop="6dp"
+    android:layout_toEndOf="@id/oh_today_label"
+    android:layout_alignParentEnd="true"
+    android:textAppearance="@style/MwmTextAppearance.PlacePage"
+    tools:text="@string/twentyfour_seven"
+    android:text="@string/twentyfour_seven"
+    android:textAlignment="viewEnd"
+    tools:visibility="visible"/>
+
+  <TextView
+    android:id="@+id/oh_nonbusiness_time"
+    android:layout_height="wrap_content"
+    android:layout_width="wrap_content"
+    android:layout_alignParentEnd="true"
+    android:layout_alignStart="@id/oh_today_label"
+    android:layout_below="@id/oh_today_label"
+    android:textAppearance="@style/MwmTextAppearance.Body4"
+    android:textAlignment="viewEnd"
+    android:visibility="gone"/>
+
+  <androidx.recyclerview.widget.RecyclerView
+    android:id="@+id/rw__full_opening_hours"
+    android:layout_width="wrap_content"
+    android:layout_height="wrap_content"
+    android:layout_alignParentEnd="true"
+    android:layout_alignStart="@id/oh_nonbusiness_time"
+    android:layout_below="@id/oh_nonbusiness_time"
+    app:layoutManager="androidx.recyclerview.widget.LinearLayoutManager"
+    android:layout_marginTop="8dp"/>
 
 </RelativeLayout>

--- a/android/res/layout/place_page_opening_hours_item.xml
+++ b/android/res/layout/place_page_opening_hours_item.xml
@@ -1,0 +1,36 @@
+<?xml version="1.0" encoding="utf-8"?>
+<RelativeLayout
+  xmlns:android="http://schemas.android.com/apk/res/android"
+  xmlns:tools="http://schemas.android.com/tools"
+  android:id="@+id/ll__place_opening_hours_item"
+  style="@style/PlacePageOpeningHoursItem"
+  android:visibility="visible">
+
+  <TextView
+    android:id="@+id/tv__opening_hours_weekdays"
+    android:layout_height="wrap_content"
+    android:layout_width="wrap_content"
+    android:layout_alignParentStart="true"
+    android:textAppearance="@style/MwmTextAppearance.Body3"
+    tools:text="Mo-Fr"/>
+
+  <TextView
+    android:id="@+id/tv__opening_hours_time"
+    android:layout_height="wrap_content"
+    android:layout_width="wrap_content"
+    android:layout_alignParentEnd="true"
+    android:layout_toEndOf="@id/tv__opening_hours_weekdays"
+    android:textAppearance="@style/MwmTextAppearance.Body3"
+    android:textAlignment="viewEnd"
+    tools:text="08:00 - 19:00"/>
+
+  <TextView
+    android:id="@+id/tv__opening_hours_nonbusiness_time"
+    android:layout_height="wrap_content"
+    android:layout_width="wrap_content"
+    android:layout_alignParentEnd="true"
+    android:layout_below="@id/tv__opening_hours_weekdays"
+    android:textAppearance="@style/MwmTextAppearance.Body4"
+    android:textAlignment="viewEnd"
+    android:visibility="gone"/>
+</RelativeLayout>

--- a/android/res/values/styles-place_page.xml
+++ b/android/res/values/styles-place_page.xml
@@ -82,4 +82,18 @@
     <item name="android:tint">?iconTint</item>
     <item name="android:layout_marginEnd">@dimen/margin_base</item>
   </style>
+
+  <style name="PlacePageOpeningHoursItem">
+    <item name="android:layout_width">match_parent</item>
+    <item name="android:layout_height">wrap_content</item>
+    <item name="android:minHeight">24dp</item>
+    <item name="android:adjustViewBounds">true</item>
+    <item name="android:gravity">center_vertical</item>
+    <item name="android:clickable">false</item>
+    <item name="android:paddingStart">0dp</item>
+    <item name="android:paddingEnd">0dp</item>
+    <item name="android:paddingTop">@dimen/margin_half</item>
+    <item name="android:paddingBottom">@dimen/margin_half</item>
+    <item name="android:orientation">horizontal</item>
+  </style>
 </resources>

--- a/android/src/com/mapswithme/maps/editor/data/TimeFormatUtils.java
+++ b/android/src/com/mapswithme/maps/editor/data/TimeFormatUtils.java
@@ -109,22 +109,21 @@ public class TimeFormatUtils
 
   public static String generateCopyText(Resources resources, String ohStr, Timetable[] timetables)
   {
-    if(timetables == null || timetables.length == 0)
+    if (timetables == null || timetables.length == 0)
       return ohStr;
 
-    // Generate string "24/7" or "Daily HH:MM - HH:MM"
+    // Generate string "24/7" or "Daily HH:MM - HH:MM".
     if (timetables[0].isFullWeek())
     {
       Timetable tt = timetables[0];
       if (tt.isFullday)
         return resources.getString(R.string.twentyfour_seven);
-      else
-        return resources.getString(R.string.daily) + " " + tt.workingTimespan.toWideString();
+      return resources.getString(R.string.daily) + " " + tt.workingTimespan.toWideString();
     }
 
     // Generate full week multiline string. E.g.
     // "Mon-Fri HH:MM - HH:MM
-    //  Sa HH:MM - HH:MM"
+    // Sat HH:MM - HH:MM"
     StringBuilder weekSchedule = new StringBuilder();
     boolean firstRow = true;
     for (Timetable tt : timetables)

--- a/android/src/com/mapswithme/maps/editor/data/TimeFormatUtils.java
+++ b/android/src/com/mapswithme/maps/editor/data/TimeFormatUtils.java
@@ -91,4 +91,56 @@ public class TimeFormatUtils
 
     return builder.toString();
   }
+
+  public static String formatNonBusinessTime(Timespan[] closedTimespans, String hoursClosedLabel)
+  {
+    StringBuilder closedTextBuilder = new StringBuilder();
+    boolean firstLine = true;
+
+    for (Timespan cts: closedTimespans) {
+      if (!firstLine)
+        closedTextBuilder.append('\n');
+
+      closedTextBuilder.append(hoursClosedLabel).append(' ').append(cts.toWideString());
+      firstLine = false;
+    }
+    return closedTextBuilder.toString();
+  }
+
+  public static String generateCopyText(Resources resources, String ohStr, Timetable[] timetables)
+  {
+    if(timetables == null || timetables.length == 0)
+      return ohStr;
+
+    // Generate string "24/7" or "Daily HH:MM - HH:MM"
+    if (timetables[0].isFullWeek())
+    {
+      Timetable tt = timetables[0];
+      if (tt.isFullday)
+        return resources.getString(R.string.twentyfour_seven);
+      else
+        return resources.getString(R.string.daily) + " " + tt.workingTimespan.toWideString();
+    }
+
+    // Generate full week multiline string. E.g.
+    // "Mon-Fri HH:MM - HH:MM
+    //  Sa HH:MM - HH:MM"
+    StringBuilder weekSchedule = new StringBuilder();
+    boolean firstRow = true;
+    for (Timetable tt : timetables)
+    {
+      if (!firstRow)
+        weekSchedule.append('\n');
+
+      final String weekdays = formatWeekdays(tt);
+      final String openTime = tt.isFullday ?
+                              Utils.unCapitalize(resources.getString(R.string.editor_time_allday)) :
+                              tt.workingTimespan.toWideString();
+
+      weekSchedule.append(weekdays).append(' ').append(openTime);
+      firstRow = false;
+    }
+
+    return weekSchedule.toString();
+  }
 }

--- a/android/src/com/mapswithme/maps/editor/data/TimeFormatUtils.java
+++ b/android/src/com/mapswithme/maps/editor/data/TimeFormatUtils.java
@@ -42,7 +42,11 @@ public class TimeFormatUtils
   public static String formatWeekdays(@NonNull Timetable timetable)
   {
     refreshWithCurrentLocale();
-    final int[] weekdays = timetable.weekdays;
+    return formatWeekdays(timetable.weekdays);
+  }
+
+  public static String formatWeekdays(@NonNull int[] weekdays)
+  {
     if (weekdays.length == 0)
       return "";
 

--- a/android/src/com/mapswithme/maps/editor/data/Timespan.java
+++ b/android/src/com/mapswithme/maps/editor/data/Timespan.java
@@ -16,4 +16,9 @@ public class Timespan
   {
     return start + "-" + end;
   }
+
+  public String toWideString()
+  {
+    return start + " - " + end;
+  }
 }

--- a/android/src/com/mapswithme/maps/editor/data/Timespan.java
+++ b/android/src/com/mapswithme/maps/editor/data/Timespan.java
@@ -19,6 +19,6 @@ public class Timespan
 
   public String toWideString()
   {
-    return start + " - " + end;
+    return start + "\u2014" + end;
   }
 }

--- a/android/src/com/mapswithme/maps/widget/placepage/PlaceOpeningHoursAdapter.java
+++ b/android/src/com/mapswithme/maps/widget/placepage/PlaceOpeningHoursAdapter.java
@@ -42,8 +42,8 @@ public class PlaceOpeningHoursAdapter extends RecyclerView.Adapter<PlaceOpeningH
   {
     List<Integer> unhandledDays = new ArrayList<>(Arrays.asList(1, 2, 3, 4, 5, 6, 7));
 
-    for(Timetable tt : timetables) {
-      for(int weekDay: tt.weekdays) {
+    for (Timetable tt : timetables) {
+      for (int weekDay : tt.weekdays) {
         unhandledDays.remove(Integer.valueOf(weekDay));
       }
     }
@@ -53,7 +53,7 @@ public class PlaceOpeningHoursAdapter extends RecyclerView.Adapter<PlaceOpeningH
 
     // Convert List<Integer> to int[].
     int[] days = new int[unhandledDays.size()];
-    for(int i = 0; i<days.length; i++)
+    for (int i = 0; i < days.length; i++)
       days[i] = unhandledDays.get(i);
 
     return days;
@@ -78,8 +78,8 @@ public class PlaceOpeningHoursAdapter extends RecyclerView.Adapter<PlaceOpeningH
       if (closedDays == null)
         return;
       holder.setWeekdays(formatWeekdays(closedDays));
-      holder.hideNonBusinessTime();
       holder.setOpenTime(holder.itemView.getResources().getString(R.string.day_off));
+      holder.hideNonBusinessTime();
       return;
     }
 

--- a/android/src/com/mapswithme/maps/widget/placepage/PlaceOpeningHoursAdapter.java
+++ b/android/src/com/mapswithme/maps/widget/placepage/PlaceOpeningHoursAdapter.java
@@ -23,7 +23,8 @@ public class PlaceOpeningHoursAdapter extends RecyclerView.Adapter<PlaceOpeningH
 
   public PlaceOpeningHoursAdapter() {}
 
-  public PlaceOpeningHoursAdapter(Timetable[] timetables) {
+  public PlaceOpeningHoursAdapter(Timetable[] timetables)
+  {
     setTimetables(timetables);
   }
 
@@ -56,7 +57,7 @@ public class PlaceOpeningHoursAdapter extends RecyclerView.Adapter<PlaceOpeningH
     holder.setOpenTime(workingTime);
 
     final Timespan[] closedTime = tt.closedTimespans;
-    if (closedTime == null || closedTime.length==0)
+    if (closedTime == null || closedTime.length == 0)
     {
       holder.hideNonBusinessTime();
     }
@@ -70,7 +71,7 @@ public class PlaceOpeningHoursAdapter extends RecyclerView.Adapter<PlaceOpeningH
   @Override
   public int getItemCount()
   {
-    return mTimetables!=null ? mTimetables.length : 0;
+    return mTimetables != null ? mTimetables.length : 0;
   }
 
   public static class ViewHolder extends RecyclerView.ViewHolder

--- a/android/src/com/mapswithme/maps/widget/placepage/PlaceOpeningHoursAdapter.java
+++ b/android/src/com/mapswithme/maps/widget/placepage/PlaceOpeningHoursAdapter.java
@@ -1,0 +1,111 @@
+package com.mapswithme.maps.widget.placepage;
+
+import android.view.LayoutInflater;
+import android.view.View;
+import android.view.ViewGroup;
+import android.widget.TextView;
+
+import androidx.annotation.NonNull;
+import androidx.recyclerview.widget.RecyclerView;
+import com.mapswithme.maps.R;
+import static com.mapswithme.maps.editor.data.TimeFormatUtils.formatWeekdays;
+import static com.mapswithme.maps.editor.data.TimeFormatUtils.formatNonBusinessTime;
+
+import com.mapswithme.maps.editor.data.Timespan;
+import com.mapswithme.maps.editor.data.Timetable;
+import com.mapswithme.util.UiUtils;
+
+import java.util.Locale;
+
+public class PlaceOpeningHoursAdapter extends RecyclerView.Adapter<PlaceOpeningHoursAdapter.ViewHolder>
+{
+  private Timetable[] mTimetables = {};
+
+  public PlaceOpeningHoursAdapter() {}
+
+  public PlaceOpeningHoursAdapter(Timetable[] timetables) {
+    setTimetables(timetables);
+  }
+
+  public void setTimetables(Timetable[] timetables)
+  {
+    mTimetables = timetables;
+    notifyDataSetChanged();
+  }
+
+  @NonNull
+  @Override
+  public ViewHolder onCreateViewHolder(@NonNull ViewGroup parent, int viewType)
+  {
+    return new ViewHolder(LayoutInflater.from(parent.getContext())
+                                        .inflate(R.layout.place_page_opening_hours_item, parent, false));
+  }
+
+  @Override
+  public void onBindViewHolder(@NonNull ViewHolder holder, int position)
+  {
+    if (mTimetables == null || position >= mTimetables.length || position < 0)
+      return;
+    final Timetable tt = mTimetables[position];
+
+    final String weekdays = formatWeekdays(tt);
+    String workingTime = tt.isFullday ? holder.itemView.getResources().getString(R.string.editor_time_allday)
+                                      : tt.workingTimespan.toWideString();
+
+    holder.setWeekdays(weekdays);
+    holder.setOpenTime(workingTime);
+
+    final Timespan[] closedTime = tt.closedTimespans;
+    if (closedTime == null || closedTime.length==0)
+    {
+      holder.hideNonBusinessTime();
+    }
+    else
+    {
+      final String hoursNonBusinessLabel = holder.itemView.getResources().getString(R.string.editor_hours_closed);
+      holder.setNonBusinessTime(formatNonBusinessTime(closedTime, hoursNonBusinessLabel));
+    }
+  }
+
+  @Override
+  public int getItemCount()
+  {
+    return mTimetables!=null ? mTimetables.length : 0;
+  }
+
+  public static class ViewHolder extends RecyclerView.ViewHolder
+  {
+    private final TextView mWeekdays;
+    private final TextView mOpenTime;
+    private final TextView mNonBusinessTime;
+
+    public ViewHolder(@NonNull View itemView)
+    {
+      super(itemView);
+      mWeekdays = itemView.findViewById(R.id.tv__opening_hours_weekdays);
+      mOpenTime = itemView.findViewById(R.id.tv__opening_hours_time);
+      mNonBusinessTime = itemView.findViewById(R.id.tv__opening_hours_nonbusiness_time);
+      itemView.setVisibility(View.VISIBLE);
+    }
+
+    public void setWeekdays(String weekdays)
+    {
+      mWeekdays.setText(weekdays);
+    }
+
+    public void setOpenTime(String openTime)
+    {
+      mOpenTime.setText(openTime);
+    }
+
+    public void setNonBusinessTime(String nonBusinessTime)
+    {
+      UiUtils.setTextAndShow(mNonBusinessTime, nonBusinessTime);
+    }
+
+    public void hideNonBusinessTime()
+    {
+      UiUtils.clearTextAndHide(mNonBusinessTime);
+    }
+  }
+}


### PR DESCRIPTION
Another week, another PR!

Closes Issue #970. Made Android Opening hours UI simmilar to iOS. `opening_hours` value matches different cases:

## Case 1: Label only
E.g.
* `opening_hours = 24/7`
* `opening_hours` unparsable

🌍 https://osm.org/node/3882420485 → 🕗 `24/7`
🌍 https://osm.org/node/6070463188 → 🕗 Unparsed `Mo-Fr 09:00-19:00; Sa,Su,PH 09:00-20:00`

Show just label:

![case1_24-7](https://user-images.githubusercontent.com/720808/142868144-f8366182-cd2d-42a0-92ad-5674208643be.png)

Unparsable sample:

![case1_unparsable](https://user-images.githubusercontent.com/720808/142868176-afd20e44-fb5e-4427-8691-c0d3021945a6.png)

## Case 2: Label + time
E.g.
* `opening_hours = 10:00-22:00`
* `opening_hours = Mo-Su 17:00-00:00`

🌍 https://osm.org/node/4601505099 → 🕗`Mo-Su 17:00-00:00`

Open hours are right aligned:

![case2](https://user-images.githubusercontent.com/720808/142868232-b3d3c620-753e-4761-b47b-54b7b61b4b88.png)

## Case 3: Label + time + non-business time(s)
E.g.
* `opening_hours = 10:00-16:00, 16:30-22:00`
* `opening_hours = Mo-Su 10:00-16:00, 16:30-22:00`

🌍 https://osm.org/node/6293418985 → 🕗`Mo-Su 9:30-14:00, 15:00-18:30`

Open hours are right aligned. Non-business hours text below hours.

![case3](https://user-images.githubusercontent.com/720808/142868314-9f56382c-3df9-4dd7-afea-600d8e348989.png)

## Case 4: Label + time + week schedule
E.g.
* `opening_hours = Mo-Fr 09:00-20:00; Sa 10:00-17:00; Su 11:00-14:00`

🌍 https://osm.org/way/684433599 → 🕗`Mo-Fr 06:00-22:00; Sa-Su 07:00-22:00`

Open hours are right aligned for today and for the whole week.

![case4](https://user-images.githubusercontent.com/720808/142868382-52f95611-30f3-44c9-bcc2-cdac8e6c7f7f.png)

## Case 5: Label + time + week schedule + non-business time(s)
E.g.
* `opening_hours = Mo-Fr 09:00-15:00,15:30-22:00; Sa 10:00-15:00,15:30-22:00; Su 10:00-18:00`

🌍 https://osm.org/node/2665722353 → 🕗`Mo-Th 13:30-16:00,20:30-23:30;Tu off;Fr,Sa 13:30-16:00,20:30-24:00;Su 13:30-16:00`

Open hours are right aligned for today and for the whole week. Non-business hours text below hours for today and for each week day.

![case5](https://user-images.githubusercontent.com/720808/142868620-648e36f5-697c-44b8-b75d-4447ba4f1275.png)

## Case 6: Closed today label + week schedule + non-business time(s)
E.g.
* `opening_hours = Mo off; Tu-Fr 09:00-15:00,15:30-22:00; Sa 10:00-15:00,15:30-22:00; Su 10:00-18:00`

🌍 https://osm.org/node/2199786968 → 🕗`Th,Fr 21:30-00:30,Sa 14:00-17:00,21:30-00:30; Mo-We off`

Label tells that POI is closed today in red. Open hours are right aligned for the whole week. Non-business hours text below hours for each week day.

![case6](https://user-images.githubusercontent.com/720808/142868691-d7e7d439-7c83-41fb-968f-28f82ee06f13.png)

## Layout changes:

**Before:**
![layout_old](https://user-images.githubusercontent.com/720808/142869473-aabbcc99-c8d8-40d3-9e41-33aea072884f.png)

**After:**
![layout_new](https://user-images.githubusercontent.com/720808/142869507-a4572cfc-a757-4152-8799-4c9886f79dcf.png)

## Questions:

* ☑️ Do we need horizontal separators as iOS version does? - No
* ☑️ Does Opening hours widget should be collapsible like iOS version? - No
* ☑️ iOS version shows if place is closed at some date. See "Sun-Wed closed" at the Case 6 screenshot. Do we need the same feature for Android? - Added

## Update 23 Nov 2021

Added em-dash as open time and non-business time separator. (I will not update all screenshots in this PR. Just belive me 😄)

Added closed weekdays as last item of week schedule:

![android_new_case5_case6_plus](https://user-images.githubusercontent.com/720808/143013035-b71baf1b-d8e6-4b12-b6ab-53d45b7ff658.png)
