### PR TITLE
[docs] Sort historical list of [subsystems] by most used

### DIFF
--- a/docs/COMMIT_MESSAGES.md
+++ b/docs/COMMIT_MESSAGES.md
@@ -9,14 +9,18 @@ Any commit needs a helpful message. Mind the following guidelines when committin
    - [android]
    - [ios]
    - [qt]
+   - [search]
    - [generator]
+   - [strings]
    - [platform]
    - [storage]
    - [transit]
    - [routing]
    - [bookmarks]
+   - [3party]
+   - [docs]
    - ...
-   - See `git log --oneline|egrep -o '\[[a-z]*\]'|sort|uniq|less` for ideas.
+   - See `git log --oneline|egrep -o '\[[0-9a-z]*\]'|sort|uniq -c|sort -nr|less` for ideas.
 
 4. Start a sentence with a capital letter.
 5. Do not end the subject line with a period.
@@ -28,7 +32,7 @@ Any commit needs a helpful message. Mind the following guidelines when committin
 
 8. Wrap the body to **72 characters** or so.
 9. Use the body to explain **what and why** vs. how.
-10. Link GitHub issues on the lasts lines:
+10. Link GitHub issues on the last lines:
 
     - [See tutorial](https://help.github.com/articles/closing-issues-via-commit-messages).
 


### PR DESCRIPTION
Much more useful now as it doesn't list all the misspellings and obscure one-off entries in front.