### PR TITLE
[fdroid] Fix release notes symlink

### DIFF
--- a/android/src/fdroid/play/release-notes/en-US/default.txt
+++ b/android/src/fdroid/play/release-notes/en-US/default.txt
@@ -1,1 +1,1 @@
-android/src/google/play/release-notes/en-US/default.txt
+../../../../google/play/release-notes/en-US/default.txt


### PR DESCRIPTION
At the moment there are no release notes displayed in F-Droid app.
The symlink to Google Play relnotes was broken.