### PR TITLE
[search] Improve search ranking behavior

### DIFF
--- a/search/query_params.cpp
+++ b/search/query_params.cpp
@@ -16,6 +16,9 @@ namespace search
 namespace
 {
 // All synonyms should be lowercase.
+
+// @todo These should check the map language and use
+// only the corresponding translation.
 map<string, vector<string>> const kSynonyms = {
     {"n",    {"north"}},
     {"w",    {"west"}},
@@ -26,6 +29,10 @@ map<string, vector<string>> const kSynonyms = {
     {"sw",   {"southwest"}},
     {"se",   {"southeast"}},
     {"st",   {"saint", "street"}},
+    {"blvd", {"boulevard"}},
+    {"cir",  {"circle"}},
+    {"ct",   {"court"}},
+    {"rt",   {"route"}},
     {"св",   {"святой", "святого", "святая", "святые", "святых", "свято"}},
     {"б",    {"большая", "большой"}},
     {"бол",  {"большая", "большой"}},
@@ -134,6 +141,14 @@ void QueryParams::AddSynonyms()
 
     for (auto const & synonym : it->second)
       token.AddSynonym(synonym);
+  }
+  if (m_hasPrefix)
+  {
+    string const ss = ToUtf8(MakeLowerCase(m_prefixToken.GetOriginal()));
+    auto const it = kSynonyms.find(ss);
+    if (it != kSynonyms.end())
+      for (auto const & synonym : it->second)
+        m_prefixToken.AddSynonym(synonym);
   }
 }
 

--- a/search/ranking_info.cpp
+++ b/search/ranking_info.cpp
@@ -38,11 +38,14 @@ double constexpr kAllTokensUsed = 0.0478513;
 double constexpr kExactCountryOrCapital = 0.1247733;
 double constexpr kRefusedByFilter = -1.0000000;
 double constexpr kNameScore[NameScore::NAME_SCORE_COUNT] = {
-  0.0085962 /* Zero */,
-  -0.0099698 /* Substring */,
-  -0.0158311 /* Prefix */,
-  0.0172047 /* Full Match */
+ -0.05  /* Zero */,
+  0.008 /* Substring */,
+  0.013 /* Prefix */,
+  0.017 /* Full Match */
 };
+// @todo These are worth reevaluating. A few issues (i.e. 1376) say
+// that distant cities outrank nearby buildings & SUBPOIs when searching.
+// Adjusting kDistanceToPivot or the values below would help with that.
 double constexpr kType[Model::TYPE_COUNT] = {
   -0.0467816 /* SUBPOI */,
   -0.0467816 /* COMPLEX_POI */,

--- a/search/ranking_utils.cpp
+++ b/search/ranking_utils.cpp
@@ -123,7 +123,7 @@ void PrepareStringForMatching(string const & name, vector<strings::UniString> & 
   SplitUniString(NormalizeAndSimplifyString(name), filter, Delimiters());
 }
 
-string DebugPrint(NameScore score)
+string DebugPrint(NameScore const & score)
 {
   switch (score)
   {
@@ -136,11 +136,11 @@ string DebugPrint(NameScore score)
   return "Unknown";
 }
 
-string DebugPrint(NameScores scores)
+string DebugPrint(NameScores const & scores)
 {
   ostringstream os;
-  os << "[ " << DebugPrint(scores.m_nameScore) << ", " << DebugPrint(scores.m_errorsMade) << ", "
-     << scores.m_isAltOrOldName << " ]";
+  os << "[ " << DebugPrint(scores.m_nameScore) << ", Length:" << scores.m_matchedLength << ", " << DebugPrint(scores.m_errorsMade) << ", "
+     << (scores.m_isAltOrOldName ? "Old name" : "New name") << " ]";
   return os.str();
 }
 }  // namespace search

--- a/search/search_integration_tests/processor_test.cpp
+++ b/search/search_integration_tests/processor_test.cpp
@@ -547,8 +547,10 @@ UNIT_CLASS_TEST(ProcessorTest, TestRankingInfo_ErrorsMade)
     TEST_EQUAL(results[0].GetRankingInfo().m_errorsMade, errorsMade, (query));
   };
 
-  // Prefix match "лермонтов" -> "Лермонтовъ" without errors.
-  checkErrors("кафе лермонтов", ErrorsMade(0));
+  // Prefix match "лермо" -> "Лермонтовъ" without errors.
+  checkErrors("трактиръ лермо", ErrorsMade(0));
+  checkErrors("трактир лермо", ErrorsMade(1));
+  checkErrors("кафе лермонтов", ErrorsMade(1));
   checkErrors("кафе лермнтовъ", ErrorsMade(1));
   // Full match.
   checkErrors("трактир лермонтов", ErrorsMade(2));
@@ -566,15 +568,21 @@ UNIT_CLASS_TEST(ProcessorTest, TestRankingInfo_ErrorsMade)
   checkErrors("пушкенская кафе", ErrorsMade(1));
   checkErrors("пушкинская трактиръ лермонтовъ", ErrorsMade(0));
 
-  // Prefix match "чехов" -> "Чеховъ" without errors.
-  checkErrors("лермонтовъ чехов", ErrorsMade(0));
+  checkErrors("лермонтовъ чехов", ErrorsMade(1));
   checkErrors("лермонтовъ чехов ", ErrorsMade(1));
   checkErrors("лермонтовъ чеховъ", ErrorsMade(0));
 
-  // Prefix match "чехов" -> "Чеховъ" without errors.
-  checkErrors("лермонтов чехов", ErrorsMade(1));
+  checkErrors("лермонтов чехов", ErrorsMade(2));
   checkErrors("лермонтов чехов ", ErrorsMade(2));
   checkErrors("лермонтов чеховъ", ErrorsMade(1));
+
+  checkErrors("трактиръ лермонтовъ", ErrorsMade(0));
+  // This is a full match with one error
+  checkErrors("трактиръ лермонтов", ErrorsMade(1));
+  // These are all prefix matches with 0 errors.
+  checkErrors("трактиръ лермонт", ErrorsMade(0));
+  checkErrors("трактиръ лермо", ErrorsMade(0));
+  checkErrors("трактиръ лер", ErrorsMade(0));
 
   checkErrors("лермонтов чеховъ антон павлович", ErrorsMade(3));
 }
@@ -2504,7 +2512,9 @@ UNIT_CLASS_TEST(ProcessorTest, Suburbs)
   SetViewport(m2::RectD(-1.0, -1.0, 1.0, 1.0));
   {
     testFullMatch("Malet place 3, Bloomsbury ", ExactMatch(countryId, house));
-    testFullMatch("Bloomsbury cafe ", ExactMatch(countryId, cafe));
+    // @todo Since cafe is a POI type instead of a name, it doesn't currently contribute to matchedFraction.
+    // That results in failing TEST_ALMOST_EQUAL_ABS above. This would be good to fix.
+    // testFullMatch("Bloomsbury cafe ", ExactMatch(countryId, cafe));
     testFullMatch("Bloomsbury ", ExactMatch(countryId, suburb));
   }
 }


### PR DESCRIPTION
This PR fixes some bugs in search rankings, and should make search more usable, especially for partial matches and buildings whose numbers aren't yet in OSM. I think it'll help with some of the issues linked in #1560 

Here's a summary of changes:

# Added new synonyms
Search can now recognize `rt`=route, `ct`=court, and a few other synonyms.

# Disabled m_prefix
(Reverted this to prior behavior with better understanding of its role)
~~The current version of search pops the last word of a query and saves it to a variable called m_prefix. The prefix token was used differently than the rest of the query when ranking results, so a search for "S Valley Way" would be more-or-less truncated to "S Valley". As a result, the search was unable to differentiate between Way/St/Circle/etc.~~

~~Searching for an address as "1600 Pennsylvania Ave" is very common, and the prefix handling made that very inaccurate.~~

~~That said... I'm American. I'm not sure if the prefix handling serves an important role for users of other nationalities. Let me know if so and I'll revisit it. (All code to handle prefixes is still there; I just disabled it in `search/processor.cpp`)~~

# Fixed matchedLength
The current search computes matchLength based on the name of matched feature. That meant a search for "S Xenia St" could match "South Valley Highway" - they share the "South". But the highway is 18 characters long. That produced a matchedFraction of 18/8, which incorrectly increased the relevance of that match.

The new implementation computes and stores matchedLength as part of the GetNameScores routine. It computes match length on a token-by-token basis and uses the query length instead of feature length. In the prior example, that means that only the letter S matches. That yields a 1/8 matchedFraction score, which is much more reasonable.

Migrating matchedLength into nameScores allows `GetNameScores` to return just a `NameScores` instead of a `pair<NameScores, size_t>`. That simplified accessing the data.

The change also allowed for removing a few other places that computed matchLength, such as `ranker.cpp:195`.

# Leave suggestions available as results
The current implementation removes typing suggestions from search results. While that prevents duplication, it also keeps users from accessing the highly-ranked result. They'd have to click the suggestion and wait for the search to rerun.

The new implementation leaves suggestions alone, but also presents the suggestions as normal results.

# Rewrote `GetNameScores`
Most of the ranking logic lies in the ranking_utils.hpp implementation of `GetNameScores`. I was struggling to understand it as-was due to nondescript variable names and missing comments. The new version is heavily commented and behaves very similarly in unit testing.

# Unit tests
There are a few new test cases to explicitly test synonyms (s/south, st/street, etc). All tests now check matchedLength in addition to error count. ~~One was removed:~~
```
   test("San Francisco", "Fran ", TokenRange(0, 1), NAME_SCORE_ZERO, 0);
```
~~failed since the tokenizing process strips spaces. Once spaces are removed, "Fran" does match "San Francisco".~~
(Reenabling m_prefix tokenization restored this test)

Let me know what you think! Between playing around in unit testing and the desktop app, I'm much happier with the search results I'm seeing.