### PR TITLE
[android] Clear search input on enter

### DIFF
--- a/android/src/com/mapswithme/maps/search/SearchFragment.java
+++ b/android/src/com/mapswithme/maps/search/SearchFragment.java
@@ -108,8 +108,7 @@ public class SearchFragment extends BaseMwmFragment
     @Override
     protected boolean onStartSearchClick()
     {
-      if (!RoutingController.get().isWaitingPoiPick())
-        showAllResultsOnMap();
+      deactivate();
       return true;
     }
 


### PR DESCRIPTION
Instead of opening the map view, pressing enter in the search view closes the keyboard and removes focus from the input field.

Fixes #1573