### PR TITLE
[android] Hide duplicate back button in cuisine editor

### DIFF
--- a/android/src/com/mapswithme/maps/editor/EditorHostFragment.java
+++ b/android/src/com/mapswithme/maps/editor/EditorHostFragment.java
@@ -161,6 +161,12 @@ public class EditorHostFragment extends BaseMwmToolbarFragment
         if (fragment != null)
           ((CuisineFragment) fragment).setFilter(query);
       }
+
+      @Override
+      protected boolean showBackButton()
+      {
+        return false;
+      }
     };
   }
 

--- a/android/src/com/mapswithme/maps/widget/SearchToolbarController.java
+++ b/android/src/com/mapswithme/maps/widget/SearchToolbarController.java
@@ -28,6 +28,8 @@ public class SearchToolbarController extends ToolbarController
   @NonNull
   private final View mSearchContainer;
   @NonNull
+  private final View mBack;
+  @NonNull
   private final EditText mQuery;
   @NonNull
   private final View mProgress;
@@ -58,6 +60,7 @@ public class SearchToolbarController extends ToolbarController
     super(root, activity);
     mToolbarContainer = getToolbar().findViewById(R.id.toolbar_container);
     mSearchContainer = getToolbar().findViewById(R.id.search_container);
+    mBack = mSearchContainer.findViewById(R.id.back);
     mQuery = mSearchContainer.findViewById(R.id.query);
     mQuery.setOnClickListener(this);
     mQuery.addTextChangedListener(mTextWatcher);
@@ -84,8 +87,14 @@ public class SearchToolbarController extends ToolbarController
 
   private void updateViewsVisibility(boolean queryEmpty)
   {
+    UiUtils.showIf(showBackButton(), mBack);
     UiUtils.showIf(supportsVoiceSearch() && queryEmpty && mVoiceInputSupported, mVoiceInput);
     UiUtils.showIf(alwaysShowClearButton() || !queryEmpty, mClear);
+  }
+
+  protected boolean showBackButton()
+  {
+    return true;
   }
 
   protected void onQueryClick(String query) {}


### PR DESCRIPTION
Adds a new function in SearchToolbarController to control the button visibility, overridden in EditorHostFragment to return false.

Fixes #1285

Signed-off-by: Arnaud Vergnet <arnaud.vergnet@mailo.com>