### PR TITLE
[android] Make editor toolbar title visible if search is hidden

### DIFF
--- a/android/res/layout/fragment_editor_host.xml
+++ b/android/res/layout/fragment_editor_host.xml
@@ -14,6 +14,8 @@
     android:theme="@style/MwmWidget.ToolbarTheme">
 
     <RelativeLayout
+      android:id="@+id/toolbar_inner_layout"
+      android:layout_gravity="end|center_vertical"
       android:layout_width="match_parent"
       android:layout_height="match_parent">
 

--- a/android/src/com/mapswithme/maps/editor/EditorHostFragment.java
+++ b/android/src/com/mapswithme/maps/editor/EditorHostFragment.java
@@ -135,8 +135,9 @@ public class EditorHostFragment extends BaseMwmToolbarFragment
   {
     super.onViewCreated(view, savedInstanceState);
 
-    mToolbarInnerLayout = getToolbarController().getToolbar().findViewById(R.id.toolbar_inner_layout);
-    mSave = getToolbarController().getToolbar().findViewById(R.id.save);
+    final View toolbar = getToolbarController().getToolbar();
+    mToolbarInnerLayout = toolbar.findViewById(R.id.toolbar_inner_layout);
+    mSave = toolbar.findViewById(R.id.save);
     mSave.setOnClickListener(this);
     UiUtils.setupHomeUpButtonAsNavigationIcon(getToolbarController().getToolbar(),
                                               v -> onBackPressed());
@@ -266,10 +267,12 @@ public class EditorHostFragment extends BaseMwmToolbarFragment
     startActivity(new Intent(host, FeatureCategoryActivity.class));
   }
 
-  private void showSearchControls(boolean showSearch) {
+  private void showSearchControls(boolean showSearch)
+  {
     ((SearchToolbarController) getToolbarController()).showSearchControls(showSearch);
-    if (mToolbarInnerLayout != null && mSave != null) {
-      // Make room for the toolbar title if the search controls are hidden
+    if (mToolbarInnerLayout != null && mSave != null)
+    {
+      // Make room for the toolbar title if the search controls are hidden.
       mToolbarInnerLayout.getLayoutParams().width = showSearch
               ? ViewGroup.LayoutParams.MATCH_PARENT
               : mSave.getLayoutParams().width;

--- a/android/src/com/mapswithme/maps/editor/EditorHostFragment.java
+++ b/android/src/com/mapswithme/maps/editor/EditorHostFragment.java
@@ -42,6 +42,10 @@ public class EditorHostFragment extends BaseMwmToolbarFragment
                              implements OnBackPressListener, View.OnClickListener, LanguagesFragment.Listener
 {
   private boolean mIsNewObject;
+  @Nullable
+  private View mToolbarInnerLayout;
+  @Nullable
+  private View mSave;
 
   enum Mode
   {
@@ -131,7 +135,9 @@ public class EditorHostFragment extends BaseMwmToolbarFragment
   {
     super.onViewCreated(view, savedInstanceState);
 
-    getToolbarController().getToolbar().findViewById(R.id.save).setOnClickListener(this);
+    mToolbarInnerLayout = getToolbarController().getToolbar().findViewById(R.id.toolbar_inner_layout);
+    mSave = getToolbarController().getToolbar().findViewById(R.id.save);
+    mSave.setOnClickListener(this);
     UiUtils.setupHomeUpButtonAsNavigationIcon(getToolbarController().getToolbar(),
                                               v -> onBackPressed());
 
@@ -190,7 +196,7 @@ public class EditorHostFragment extends BaseMwmToolbarFragment
   protected void editMapObject(boolean focusToLastName)
   {
     mMode = Mode.MAP_OBJECT;
-    ((SearchToolbarController) getToolbarController()).showSearchControls(false);
+    showSearchControls(false);
     getToolbarController().setTitle(getTitle());
     UiUtils.show(getToolbarController().getToolbar().findViewById(R.id.save));
     Bundle args = new Bundle();
@@ -243,7 +249,7 @@ public class EditorHostFragment extends BaseMwmToolbarFragment
 
     mMode = newMode;
     getToolbarController().setTitle(toolbarTitle);
-    ((SearchToolbarController) getToolbarController()).showSearchControls(showSearch);
+    showSearchControls(showSearch);
     final Fragment fragment = Fragment.instantiate(getActivity(), fragmentClass.getName(), args);
     getChildFragmentManager().beginTransaction()
                              .replace(R.id.fragment_container, fragment, fragmentClass.getName())
@@ -258,6 +264,16 @@ public class EditorHostFragment extends BaseMwmToolbarFragment
     final Activity host = getActivity();
     host.finish();
     startActivity(new Intent(host, FeatureCategoryActivity.class));
+  }
+
+  private void showSearchControls(boolean showSearch) {
+    ((SearchToolbarController) getToolbarController()).showSearchControls(showSearch);
+    if (mToolbarInnerLayout != null && mSave != null) {
+      // Make room for the toolbar title if the search controls are hidden
+      mToolbarInnerLayout.getLayoutParams().width = showSearch
+              ? ViewGroup.LayoutParams.MATCH_PARENT
+              : mSave.getLayoutParams().width;
+    }
   }
 
   private boolean setEdits()


### PR DESCRIPTION
Resizes the toolbar layout to contain only the save button when the search controls are hidden, to leave room for the toolbar title.


### Before
| Main editor | Opening hours editor | Cuisine editor |
| - | - | - |
| ![Screenshot_20211208-092706](https://user-images.githubusercontent.com/80701113/145185421-17fed80f-328e-4381-9c3e-aae33b53563d.png) | ![Screenshot_20211208-092719](https://user-images.githubusercontent.com/80701113/145185427-34da0267-610f-4f4c-8110-2a3ec3dea477.png) | ![Screenshot_20211208-092732](https://user-images.githubusercontent.com/80701113/145185431-c14fea26-59b6-48f2-abbd-261bedabfab5.png) |

### After
| Main editor | Opening hours editor | Cuisine editor |
| - | - | - |
| ![Screenshot_20211208-093404](https://user-images.githubusercontent.com/80701113/145185838-328cbc9e-f0f1-4a5e-acdd-a122692d3842.png)| ![Screenshot_20211208-093424](https://user-images.githubusercontent.com/80701113/145185577-18278438-5433-4dd6-bbba-9ee37d204797.png) | ![Screenshot_20211208-093435](https://user-images.githubusercontent.com/80701113/145185585-8700c85c-b3b7-4a16-b0bf-92c5ba1658d9.png) |


### After (landscape)
| Main editor | Opening hours editor | Cuisine editor |
| - | - | - |
| ![Screenshot_20211208-093448](https://user-images.githubusercontent.com/80701113/145185599-f9de5078-c20b-4131-a1d3-cf0a5fd9cc04.png) | ![Screenshot_20211208-093452](https://user-images.githubusercontent.com/80701113/145185607-7396784b-af7f-4809-a3b7-c3817dd04a39.png) | ![Screenshot_20211208-093506](https://user-images.githubusercontent.com/80701113/145185612-a71d9753-986a-4876-82e6-bb9120b77266.png) |

### After (tablet)
| Main editor | Opening hours editor | Cuisine editor |
| - | - | - |
| ![Screenshot_1638956081](https://user-images.githubusercontent.com/80701113/145185708-42018402-5063-47bb-a0f3-2c27bd7317c0.png) | ![Screenshot_1638956085](https://user-images.githubusercontent.com/80701113/145185712-24223ad1-b0da-43f0-ac79-26e63cb39113.png) | ![Screenshot_1638956092](https://user-images.githubusercontent.com/80701113/145185725-4929ed8b-6a8a-4aee-a6e5-9d1675e79483.png) |
