### PR TITLE
[android] Don't show PP copy pop-up menu if there is one copy option only

### DIFF
--- a/android/src/com/mapswithme/maps/widget/placepage/PlacePageView.java
+++ b/android/src/com/mapswithme/maps/widget/placepage/PlacePageView.java
@@ -1402,10 +1402,7 @@ public class PlacePageView extends NestedScrollViewClickFixed
   public boolean onLongClick(View v)
   {
     final Object tag = v.getTag();
-    final String tagStr = tag == null ? "" : tag.toString();
 
-    final PopupMenu popup = new PopupMenu(getContext(), v);
-    final Menu menu = popup.getMenu();
     final List<String> items = new ArrayList<>();
     switch (v.getId())
     {
@@ -1488,21 +1485,34 @@ public class PlacePageView extends NestedScrollViewClickFixed
         break;
     }
 
-    final String copyText = getResources().getString(android.R.string.copy);
-    for (int i = 0; i < items.size(); i++)
-      menu.add(Menu.NONE, i, i, String.format("%s %s", copyText, items.get(i)));
-
-    popup.setOnMenuItemClickListener(item -> {
-      final int id = item.getItemId();
-      final Context ctx = getContext();
-      Utils.copyTextToClipboard(ctx, items.get(id));
+    final Context ctx = getContext();
+    if (items.size() == 1)
+    {
+      Utils.copyTextToClipboard(ctx, items.get(0));
       Utils.showSnackbarAbove(mDetails,
                               getRootView().findViewById(R.id.menu_frame),
-                              ctx.getString(R.string.copied_to_clipboard, items.get(id)));
-      return true;
-    });
+                              ctx.getString(R.string.copied_to_clipboard, items.get(0)));
+    }
+    else
+    {
+      final PopupMenu popup = new PopupMenu(getContext(), v);
+      final Menu menu = popup.getMenu();
+      final String copyText = getResources().getString(android.R.string.copy);
 
-    popup.show();
+      for (int i = 0; i < items.size(); i++)
+        menu.add(Menu.NONE, i, i, String.format("%s %s", copyText, items.get(i)));
+
+      popup.setOnMenuItemClickListener(item -> {
+        final int id = item.getItemId();
+        Utils.copyTextToClipboard(ctx, items.get(id));
+        Utils.showSnackbarAbove(mDetails,
+                                getRootView().findViewById(R.id.menu_frame),
+                                ctx.getString(R.string.copied_to_clipboard, items.get(id)));
+        return true;
+      });
+      popup.show();
+    }
+
     return true;
   }
 

--- a/android/src/com/mapswithme/maps/widget/placepage/PlacePhoneAdapter.java
+++ b/android/src/com/mapswithme/maps/widget/placepage/PlacePhoneAdapter.java
@@ -96,21 +96,11 @@ public class PlacePhoneAdapter extends RecyclerView.Adapter<PlacePhoneAdapter.Vi
     @Override
     public boolean onLongClick(View view)
     {
-      final PopupMenu popup = new PopupMenu(view.getContext(), view);
-      final Menu menu = popup.getMenu();
-      final String copyText = view.getResources().getString(android.R.string.copy);
       final String phoneNumber = mPhone.getText().toString();
-      menu.add(Menu.NONE, 0, 0, String.format("%s %s", copyText, phoneNumber));
-
-      popup.setOnMenuItemClickListener(item -> {
-        final Context ctx = view.getContext();
-        Utils.copyTextToClipboard(ctx, phoneNumber);
-        Utils.showSnackbarAbove(view, view.getRootView().findViewById(R.id.menu_frame),
-                                ctx.getString(R.string.copied_to_clipboard, phoneNumber));
-        return true;
-      });
-
-      popup.show();
+      final Context ctx = view.getContext();
+      Utils.copyTextToClipboard(ctx, phoneNumber);
+      Utils.showSnackbarAbove(view, view.getRootView().findViewById(R.id.menu_frame),
+                              ctx.getString(R.string.copied_to_clipboard, phoneNumber));
       return true;
     }
   }

--- a/android/src/com/mapswithme/util/Utils.java
+++ b/android/src/com/mapswithme/util/Utils.java
@@ -155,7 +155,7 @@ public class Utils
   {
     final android.content.ClipboardManager clipboard =
         (android.content.ClipboardManager) context.getSystemService(Context.CLIPBOARD_SERVICE);
-    final ClipData clip = ClipData.newPlainText("maps.me: " + text, text);
+    final ClipData clip = ClipData.newPlainText("Organic Maps: " + text, text);
     clipboard.setPrimaryClip(clip);
   }
 


### PR DESCRIPTION
If a PP info line like POI name or e-mail contain only one copy option then
don't show the copy pop-up menu - copy it to clipboard immediately.
PP info lines like coordinates and most social media links display a pop-up
menu still (e.g. to copy a full social media url or a username only).

Needed-for: #1616