### PR TITLE
[platform] Make distance rounding more consistent

### DIFF
--- a/platform/measurement_utils.cpp
+++ b/platform/measurement_utils.cpp
@@ -39,19 +39,20 @@ string FormatDistanceImpl(Units units, double m, string const & low, string cons
   case Units::Metric: highF = 1000.0; lowF = 1.0; break;
   }
 
-  double const lowV = m / lowF;
-  if (lowV < 1.0)
-    return string("0 ") + low;
+  double lowV = round(m / lowF);
+  // Round distances over 100 units to 10 units, e.g. 112 -> 110, 998 -> 1000
+  lowV = lowV <= 100.0 ? lowV : round(lowV / 10) * 10;
 
-  // To display any lower units only if < 1000
-  if (m >= 1000.0 * lowF)
+  // Use high units for distances of 1000 units and over,
+  // e.g. 1000m -> 1.0km, 1290m -> 1.3km, 1000ft -> 0.2mi
+  if (lowV >= 1000.0)
   {
-    double const v = m / highF;
-    return ToStringPrecision(v, v >= 10.0 ? 0 : 1) + " " + high;
+    double const highV = m / highF;
+    // For distances of 10.0 high units and over round to a whole number, e.g. 9.98 -> 10, 10.9 -> 11
+    return ToStringPrecision(highV, round(highV * 10) / 10 >= 10.0 ? 0 : 1) + " " + high;
   }
 
-  // To display unit number only if <= 100.
-  return ToStringPrecision(lowV <= 100.0 ? lowV : round(lowV / 10) * 10, 0) + " " + low;
+  return ToStringPrecision(lowV, 0) + " " + low;
 }
 
 string FormatAltitudeImpl(Units units, double altitude, string const & localizedUnits)

--- a/platform/platform_tests/measurement_tests.cpp
+++ b/platform/platform_tests/measurement_tests.cpp
@@ -35,31 +35,77 @@ struct ScopedSettings
 
 UNIT_TEST(Measurement_Smoke)
 {
-  ScopedSettings guard(Units::Metric);
-
-  using Pair = std::pair<double, char const *>;
-
-  Pair arr[] = {
-    Pair(10.0, "10 m"),
-    Pair(10.4, "10 m"),
-    Pair(10.51, "11 m"),
-    Pair(1000.0, "1.0 km"),
-    Pair(1100.0, "1.1 km"),
-    Pair(1140.0, "1.1 km"),
-    Pair(1151.0, "1.2 km"),
-    Pair(1500.0, "1.5 km"),
-    Pair(1549.9, "1.5 km"),
-    Pair(1551.0, "1.6 km"),
-    Pair(10000.0, "10 km"),
-    Pair(10400.0, "10 km"),
-    Pair(10499.9, "10 km"),
-    Pair(10501.0, "11 km")
-  };
-
-  for (size_t i = 0; i < ARRAY_SIZE(arr); ++i)
   {
-    std::string s;
-    TEST_EQUAL(FormatDistance(arr[i].first), arr[i].second, (arr[i]));
+    ScopedSettings guard(Units::Metric);
+
+    using Pair = std::pair<double, char const *>;
+
+    Pair arr[] = {
+      {0.3, "0 m"},
+      {0.9, "1 m"},
+      {10.0, "10 m"},
+      {10.4, "10 m"},
+      {10.5, "11 m"},
+      {10.51, "11 m"},
+      {99.0, "99 m"},
+      {100.0, "100 m"},
+      {101.0, "100 m"},
+      {109.0, "110 m"},
+      {991.0, "990 m"},
+      {999.0, "1.0 km"},
+      {1000.0, "1.0 km"},
+      {1001.0, "1.0 km"},
+      {1100.0, "1.1 km"},
+      {1140.0, "1.1 km"},
+      {1151.0, "1.2 km"},
+      {1500.0, "1.5 km"},
+      {1549.9, "1.5 km"},
+      {1550.0, "1.6 km"},
+      {1551.0, "1.6 km"},
+      {9949.0, "9.9 km"},
+      {9992.0, "10 km"},
+      {10000.0, "10 km"},
+      {10499.9, "10 km"},
+      {10501.0, "11 km"}
+    };
+
+    for (size_t i = 0; i < ARRAY_SIZE(arr); ++i)
+      TEST_EQUAL(FormatDistance(arr[i].first), arr[i].second, (arr[i]));
+  }
+
+  {
+    ScopedSettings guard(Units::Imperial);
+
+    using Pair = std::pair<double, char const *>;
+
+    Pair arr[] = {
+      {0.1, "0 ft"},
+      {0.3, "1 ft"},
+      {0.3048, "1 ft"},
+      {0.4573, "2 ft"},
+      {0.9, "3 ft"},
+      {3.0, "10 ft"},
+      {30.17, "99 ft"},
+      {30.33, "100 ft"},
+      {30.49, "100 ft"},
+      {33.5, "110 ft"},
+      {302.0, "990 ft"},
+      {304.7, "0.2 mi"},
+      {304.8, "0.2 mi"},
+      {402.3, "0.2 mi"},
+      {402.4, "0.3 mi"},
+      {482.8, "0.3 mi"},
+      {1609.3, "1.0 mi"},
+      {1610.0, "1.0 mi"},
+      {1770.0, "1.1 mi"},
+      {15933, "9.9 mi"},
+      {16093.0, "10 mi"},
+      {16093.5, "10 mi"},
+      {16898.113, "11 mi"}
+    };
+
+    for (size_t i = 0; i < ARRAY_SIZE(arr); ++i)
+      TEST_EQUAL(FormatDistance(arr[i].first), arr[i].second, (arr[i]));
   }
 }
 


### PR DESCRIPTION
E.g. both 998m and 1004m are rounded to 1.0km now
(before the change 998m was rounded to 1000m).

```
True
dist	Before	After
-----	------	-----
0.3m	0m	0m
0.9m	0m	1m
998m	1000m	1.0km
1000m	1000m	1.0km
1004m	1.0km	1.0km
9992m	10.0km	10km
10000m	10.0km	10km
10005m	10km	10km

```