### PR TITLE
[build] Add cli options to limit number of parallel processes

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -95,6 +95,15 @@ option(SKIP_DESKTOP "Skip building of desktop application" OFF)
 # TODO: Fix mapshot, it doesn't work without our old FreeType hack.
 option(BUILD_MAPSHOT "Build mapshot tool" OFF)
 option(USE_PCH "Use precompiled headers" OFF)
+option(NJOBS "Number of parallel processes" OFF)
+
+if (NJOBS)
+  message("Number of parallel processes: ${NJOBS}")
+  set(CMAKE_JOB_POOLS custom=${NJOBS})
+  set(CMAKE_JOB_POOL_COMPILE custom)
+  set(CMAKE_JOB_POOL_LINK custom)
+  set(CMAKE_JOB_POOL_PRECOMPILE_HEADER custom)
+endif()
 
 if (CMAKE_CXX_COMPILER_ID MATCHES "GNU" AND CMAKE_CXX_COMPILER_VERSION VERSION_LESS 7.0)
   message(FATAL_ERROR "Minimum supported g++ version is 7.0 yours is ${CMAKE_CXX_COMPILER_VERSION}")

--- a/android/build.gradle
+++ b/android/build.gradle
@@ -180,13 +180,17 @@ android {
       def pchFlag = 'OFF'
       if (project.hasProperty('pch')) pchFlag = 'ON'
 
+      def njobs = ''
+      if (project.hasProperty('njobs')) njobs = project.getProperty('njobs')
+
       cmake {
         cppFlags '-fexceptions', '-frtti'
         // There is no sense to enable sections without gcc's --gc-sections flag.
         cFlags '-fno-function-sections', '-fno-data-sections',
                '-Wno-extern-c-compat'
         arguments '-DANDROID_TOOLCHAIN=clang', '-DANDROID_STL=c++_static',
-                  "-DOS=$osName", '-DSKIP_TESTS=ON', "-DUSE_PCH=$pchFlag"
+                  "-DOS=$osName", '-DSKIP_TESTS=ON', "-DUSE_PCH=$pchFlag",
+                  "-DNJOBS=$njobs"
         targets 'organicmaps'
       }
     }

--- a/docs/INSTALL.md
+++ b/docs/INSTALL.md
@@ -111,14 +111,14 @@ brew install cmake qt@5
 
 ### Building
 
-To build a debug version of the desktop app:
+To build a desktop app:
 ```bash
-tools/unix/build_omim.sh -d desktop
+tools/unix/build_omim.sh -r desktop
 ```
 
-The output binary will go into `../omim-build-debug`.
+The output binary will go into `../omim-build-release`.
 
-Check `tools/unix/build_omim.sh -h` for more build options, e.g. to build a release.
+Check `tools/unix/build_omim.sh -h` for more build options, e.g. to build a debug version.
 
 Besides _desktop_ there are other targets like _generator_tool_, to see a full list execute:
 
@@ -351,9 +351,11 @@ To create separate apks for all target arches add a `-PsplitApk` option (by defa
 
 Adding a `-Ppch` (use precompiled headers) option makes builds ~15% faster.
 
-If a running build makes your computer slow and laggish then try lowering the priority of the build process by adding a `--priority=low` option.
+If a running build makes your computer slow and laggish then try lowering the priority of the build process by adding a `--priority=low` option and/or add a `-Pnjobs=<N>` option to limit number of parallel processes.
 
 See also https://developer.android.com/studio/build/building-cmdline.
+
+To add any of those options to in-studio builds list them in "Command-line Options" in "File > Settings... > Build, Execution, Deployment > Compiler"
 
 #### Reduce resource usage
 

--- a/tools/unix/build_omim.sh
+++ b/tools/unix/build_omim.sh
@@ -13,7 +13,8 @@ OPT_PATH=
 OPT_STANDALONE=
 OPT_COMPILE_DATABASE=
 OPT_LAUNCH_BINARY=
-while getopts ":cdrstagjlp:" opt; do
+OPT_NJOBS=
+while getopts ":cdrstagjlpn:" opt; do
   case $opt in
     a) OPT_STANDALONE=1 ;;
     c) OPT_CLEAN=1 ;;
@@ -23,6 +24,9 @@ while getopts ":cdrstagjlp:" opt; do
        CMAKE_CONFIG="${CMAKE_CONFIG:-} -DCMAKE_EXPORT_COMPILE_COMMANDS=YES"
       ;;
     l) OPT_LAUNCH_BINARY=1 ;;
+    n) OPT_NJOBS="$OPTARG"
+       CMAKE_CONFIG="${CMAKE_CONFIG:-} -DNJOBS=${OPT_NJOBS}"
+      ;;
     p) OPT_PATH="$OPTARG" ;;
     r) OPT_RELEASE=1 ;;
     s) OPT_SKIP_DESKTOP=1
@@ -31,9 +35,9 @@ while getopts ":cdrstagjlp:" opt; do
     t) OPT_DESIGNER=1 ;;
     *)
       echo "This tool builds Organic Maps"
-      echo "Usage: $0 [-d] [-r] [-c] [-s] [-t] [-a] [-g] [-j] [-l] [-p PATH] [target1 target2 ...]"
+      echo "Usage: $0 [-d] [-r] [-c] [-s] [-t] [-a] [-g] [-j] [-l] [-p PATH] [-n NUM] [target1 target2 ...]"
       echo
-      echo "By default both debug and release versions are built"
+      echo "By default all targets for both debug and release versions are built"
       echo "and binaries are put into ../omim-build-<buildtype> dir."
       echo
       echo -e "-d\tBuild debug version"
@@ -44,6 +48,7 @@ while getopts ":cdrstagjlp:" opt; do
       echo -e "-a\tBuild standalone desktop app (only for MacOS X platform)"
       echo -e "-g\tForce use GCC (only for MacOS X platform)"
       echo -e "-p\tDirectory for built binaries"
+      echo -e "-n\tNumber of parallel processes"
       echo -e "-j\tGenerate compile_commands.json"
       echo -e "-l\tLaunches built binary(ies), useful for tests"
       exit 1
@@ -103,6 +108,10 @@ else
   [ -n "$OPT_STANDALONE" ] \
   && echo "Standalone desktop app supported only on MacOS X platform" && exit 2
   PROCESSES=$(nproc)
+fi
+
+if [ -n "$OPT_NJOBS" ]; then
+  PROCESSES="$OPT_NJOBS"
 fi
 
 build()


### PR DESCRIPTION
"-Pnjobs=<N>" option for gradle builds.
"-n <NUM>" option for build_omim.sh.

E.g. on my computer ninja defaults to launching 6 compile processes and the computer becomes unresponsive for some time. I have no lags when I set it to e.g. 3 processes.