### PR TITLE
Issues #1297 - Added non-business hours time to editor UI and copy text

### DIFF
--- a/android/src/com/mapswithme/maps/editor/EditorFragment.java
+++ b/android/src/com/mapswithme/maps/editor/EditorFragment.java
@@ -439,7 +439,8 @@ public class EditorFragment extends BaseMwmFragment implements View.OnClickListe
     {
       final Timetable[] timetables = OpeningHours.nativeTimetablesFromString(openingHours);
       String content = timetables == null ? openingHours
-                                          : TimeFormatUtils.formatTimetables(requireContext(),
+                                          : TimeFormatUtils.formatTimetables(getResources(),
+                                                                             openingHours,
                                                                              timetables);
       UiUtils.hide(mEmptyOpeningHours);
       UiUtils.setTextAndShow(mOpeningHours, content);

--- a/android/src/com/mapswithme/maps/widget/placepage/PlacePageView.java
+++ b/android/src/com/mapswithme/maps/widget/placepage/PlacePageView.java
@@ -1475,7 +1475,7 @@ public class PlacePageView extends NestedScrollViewClickFixed
       case R.id.ll__place_schedule:
         final String ohStr = mMapObject.getMetadata(Metadata.MetadataType.FMD_OPEN_HOURS);
         final Timetable[] timetables = OpeningHours.nativeTimetablesFromString(ohStr);
-        items.add(TimeFormatUtils.generateCopyText(getResources(), ohStr, timetables));
+        items.add(TimeFormatUtils.formatTimetables(getResources(), ohStr, timetables));
         break;
       case R.id.ll__place_operator:
         items.add(mTvOperator.getText().toString());


### PR DESCRIPTION
Changed string representation of opening hours in long-click copy menu and in editor UI.

It how includes non-business hours:

| Before | After |
| --- | --- |
| ![opening_hours_editor-daily-before](https://user-images.githubusercontent.com/720808/147562263-c5a4519a-ee61-4161-838c-e64769d11aed.png) | ![opening_hours_editor-daily-after](https://user-images.githubusercontent.com/720808/147562290-3ecf85a6-d30b-49d2-b1a3-025e915d90a4.png) |
| ![opening_hours_editor-week-before](https://user-images.githubusercontent.com/720808/147562317-25ef455d-3a21-4803-8728-8bfdfd39cc96.png) | ![opening_hours_editor-week-after](https://user-images.githubusercontent.com/720808/147562555-58882f2d-09f8-416f-9eb3-9e9b908abe1f.png) |

Also long-click menu with copy opening hours now also includes non-business hours.

<img src="https://user-images.githubusercontent.com/720808/147562782-01840088-a866-458a-9d94-c4b846fda26c.png" width="500px"/>
