### PR TITLE
Removed bad workaround with several start/end MWMs in optimal route.

### DIFF
--- a/3party/opening_hours/opening_hours.cpp
+++ b/3party/opening_hours/opening_hours.cpp
@@ -186,6 +186,7 @@ std::ostream & operator<<(std::ostream & ost, TimeEvent::Event const event)
   {
     case TimeEvent::Event::None:
       ost << "None";
+      break;
     case TimeEvent::Event::Sunrise:
       ost << "sunrise";
       break;

--- a/routing/index_router.cpp
+++ b/routing/index_router.cpp
@@ -722,14 +722,14 @@ RouterResultCode IndexRouter::CalculateSubroute(Checkpoints const & checkpoints,
                                                 vector<Segment> & subroute,
                                                 bool guidesActive /* = false */)
 {
-  CHECK(progress, (checkpoints));
   subroute.clear();
 
   SetupAlgorithmMode(starter, guidesActive);
-  LOG(LINFO, ("Routing in mode:", starter.GetGraph().GetMode()));
+
+  WorldGraphMode const mode = starter.GetGraph().GetMode();
+  LOG(LINFO, ("Routing in mode:", mode));
 
   base::ScopedTimerWithLog timer("Route build");
-  WorldGraphMode const mode = starter.GetGraph().GetMode();
   switch (mode)
   {
   case WorldGraphMode::Joints:
@@ -770,6 +770,7 @@ RouterResultCode IndexRouter::CalculateSubrouteJointsMode(
   if (result != RouterResultCode::NoError)
     return result;
 
+  LOG(LDEBUG, ("Result route weight:", routingResult.m_distance));
   subroute = ProcessJoints(routingResult.m_path, jointStarter);
   return result;
 }
@@ -1210,7 +1211,8 @@ RouterResultCode IndexRouter::ProcessLeapsJoints(vector<Segment> const & input,
                                                  shared_ptr<AStarProgress> const & progress,
                                                  vector<Segment> & output)
 {
-  CHECK(progress, ());
+  LOG(LDEBUG, ("Leaps path:", input));
+
   SCOPE_GUARD(progressGuard, [&progress]() {
     progress->PushAndDropLastSubProgress();
   });

--- a/routing/index_router.cpp
+++ b/routing/index_router.cpp
@@ -1238,6 +1238,10 @@ RouterResultCode IndexRouter::ProcessLeapsJoints(vector<Segment> const & input,
   // To avoid this behavior we collapse all leaps from start to  last occurrence of startId to one leap and
   // use WorldGraph with NoLeaps mode to proccess these leap. Unlike SingleMwm mode used to process ordinary leaps
   // NoLeaps allows to use all mwms so if we really need to visit other mwm we will.
+  /// @todo By VNG: This workaround doesn't work on issues below. Comment it and check unneeded loops again.
+  /// https://github.com/organicmaps/organicmaps/issues/821
+
+  /*
   auto const firstMwmId = input[1].GetMwmId();
   auto const startLeapEndReverseIt = find_if(input.rbegin() + 2, input.rend(),
                                              [firstMwmId](Segment const & s) { return s.GetMwmId() == firstMwmId; });
@@ -1249,6 +1253,10 @@ RouterResultCode IndexRouter::ProcessLeapsJoints(vector<Segment> const & input,
   auto const finishLeapStartIt = find_if(startLeapEndIt, input.end(),
                                          [lastMwmId](Segment const & s) { return s.GetMwmId() == lastMwmId; });
   auto const finishLeapStart = static_cast<size_t>(distance(input.begin(), finishLeapStartIt));
+  */
+
+  auto const startLeapEnd = 1;
+  auto const finishLeapStart = input.size() - 2;
 
   auto fillMwmIds = [&](size_t start, size_t end, set<NumMwmId> & mwmIds)
   {

--- a/routing/junction_visitor.cpp
+++ b/routing/junction_visitor.cpp
@@ -9,6 +9,21 @@ namespace routing
 {
 
 #ifdef DEBUG
+// Leaps algorithm.
+void DebugRoutingState(Segment const & vertex, std::optional<Segment> const & parent,
+                       RouteWeight const & heuristic, RouteWeight const & distance)
+{
+  // 1. Dump current processing vertex.
+//  std::cout << DebugPrint(vertex);
+//  std::cout << std::setprecision(8) << "; H = " << heuristic << "; D = " << distance;
+
+  // 2. Dump parent vertex.
+//  std::cout << "; P = " << (parent ? DebugPrint(*parent) : std::string("NO"));
+
+//  std::cout << std::endl;
+}
+
+// Joints algorithm.
 void DebugRoutingState(JointSegment const & vertex, std::optional<JointSegment> const & parent,
                        RouteWeight const & heuristic, RouteWeight const & distance)
 {

--- a/routing/junction_visitor.hpp
+++ b/routing/junction_visitor.hpp
@@ -18,6 +18,9 @@ inline void DebugRoutingState(...) {}
 
 class JointSegment;
 class RouteWeight;
+class Segment;
+void DebugRoutingState(Segment const & vertex, std::optional<Segment> const & parent,
+                       RouteWeight const & heuristic, RouteWeight const & distance);
 void DebugRoutingState(JointSegment const & vertex, std::optional<JointSegment> const & parent,
                        RouteWeight const & heuristic, RouteWeight const & distance);
 #endif

--- a/routing/routing_integration_tests/pedestrian_route_test.cpp
+++ b/routing/routing_integration_tests/pedestrian_route_test.cpp
@@ -580,9 +580,12 @@ UNIT_TEST(NoTurnOnForkingRoad2)
   RouterResultCode const result = routeResult.second;
   TEST_EQUAL(result, RouterResultCode::NoError, ());
 
+  // Unfortunatelly, we don't have SlightRight for pedestrians, but current turns are OK.
+  // https://www.openstreetmap.org/directions?engine=graphhopper_foot&route=55.68336%2C37.49492%3B55.68488%2C37.49789
   std::vector<turns::TurnItem> t;
   route.GetTurnsForTesting(t);
-  TEST_EQUAL(t.size(), 2, ());
+  TEST_EQUAL(t.size(), 3, (t));
 
   TEST_EQUAL(t[0].m_pedestrianTurn, PedestrianDirection::TurnRight, ());
+  TEST_EQUAL(t[1].m_pedestrianTurn, PedestrianDirection::TurnRight, ());
 }

--- a/routing/routing_integration_tests/route_test.cpp
+++ b/routing/routing_integration_tests/route_test.cpp
@@ -582,4 +582,13 @@ namespace
         mercator::FromLatLon(49.512076, 8.284476), {0., 0.},
         mercator::FromLatLon(49.523783, 8.288701), 2014.);
   }
+
+  // https://github.com/organicmaps/organicmaps/issues/821
+  UNIT_TEST(Ukraine_UmanOdessa)
+  {
+    integration::CalculateRouteAndTestRouteLength(
+        integration::GetVehicleComponents(VehicleType::Car),
+        mercator::FromLatLon(48.7498, 30.2203), {0., 0.},
+        mercator::FromLatLon(46.4859, 30.6837), 265163.);
+  }
 }  // namespace

--- a/routing/routing_integration_tests/turn_test.cpp
+++ b/routing/routing_integration_tests/turn_test.cpp
@@ -370,9 +370,7 @@ UNIT_TEST(BelarusMKADShosseinai)
   integration::TestTurnCount(route, 0 /* expectedTurnCount */);
 }
 
-// Test case: a route goes straight along a big road when joined small road.
-// An end user shall not be informed about such manoeuvres.
-// But at the end of the route an end user shall be informed about junction of two big roads.
+// A route goes straight along a big road ignoring joined small roads.
 UNIT_TEST(ThailandPhuketNearPrabarameeRoad)
 {
   TRouteResult const routeResult =
@@ -383,9 +381,9 @@ UNIT_TEST(ThailandPhuketNearPrabarameeRoad)
   Route const & route = *routeResult.first;
   RouterResultCode const result = routeResult.second;
 
+  // https://www.openstreetmap.org/directions?engine=fossgis_osrm_car&route=7.91797%2C98.36937%3B7.90724%2C98.36790
   TEST_EQUAL(result, RouterResultCode::NoError, ());
-  integration::TestTurnCount(route, 1 /* expectedTurnCount */);
-  integration::GetNthTurn(route, 0).TestValid().TestDirection(CarDirection::TurnSlightLeft);
+  integration::TestTurnCount(route, 0 /* expectedTurnCount */);
 }
 
 // Test case: a route goes in Moscow from Varshavskoe shosse (from the city center direction)


### PR DESCRIPTION
Closes https://github.com/organicmaps/organicmaps/issues/821

According to the comments, some unneeded loops may occur, but will debug them separately if any.
It should work fine because we have honest **Leaps Graph** that is generated 4 days now ..