### PR TITLE
iOS 15 navbar fix + other fixes

### DIFF
--- a/data/strings/strings.txt
+++ b/data/strings/strings.txt
@@ -12166,40 +12166,6 @@
     zh-Hans = 运营者
     zh-Hant = 營運者
 
-  [downloader_my_maps_title]
-    tags = ios
-    en = My maps
-    ar = خرائطي
-    be = Мае мапы
-    cs = Mé mapy
-    da = Mine kort
-    de = Meine Karten
-    el = Οι χάρτες μου
-    es = Mis mapas
-    fa = نقشه های من
-    fi = Omat kartat
-    fr = Mes cartes
-    hu = Térképeim
-    id = Peta saya
-    it = Le mie mappe
-    ja = マイマップ
-    ko = 내 지도
-    nb = Mine kart
-    nl = Mijn kaarten
-    pl = Moje mapy
-    pt = Os meus mapas
-    pt-BR = Meus mapas
-    ro = Hărțile mele
-    ru = Мои карты
-    sk = Moje mapy
-    sv = Mina kartor
-    th = แผนที่ของฉัน
-    tr = Haritalarım
-    uk = Мої мапи
-    vi = Bản đồ của tôi
-    zh-Hans = 我的地图
-    zh-Hant = 我的地圖
-
   [downloader_no_downloaded_maps_title]
     tags = android,ios
     en = You haven't downloaded any maps

--- a/iphone/Maps/Core/Theme/Renderers/UINavigationBarRenderer.swift
+++ b/iphone/Maps/Core/Theme/Renderers/UINavigationBarRenderer.swift
@@ -15,10 +15,23 @@ class UINavigationBarRenderer: UIViewRenderer {
   class func render(_ control: UINavigationBar, style: Style) {
     super.render(control, style: style)
     if let barTintColor = style.barTintColor {
-      control.barTintColor = barTintColor
+      if #available(iOS 13.0, *) {
+        let appearance = UINavigationBarAppearance()
+        appearance.configureWithOpaqueBackground()
+        appearance.backgroundColor = barTintColor
+        control.standardAppearance = appearance
+        control.scrollEdgeAppearance = appearance
+      } else {
+        control.barTintColor = barTintColor
+      }
     }
     if let shadowImage = style.shadowImage {
-      control.shadowImage = shadowImage
+      if #available(iOS 13.0, *) {
+        control.standardAppearance.shadowImage = shadowImage
+        control.scrollEdgeAppearance!.shadowImage = shadowImage
+      } else {
+        control.shadowImage = shadowImage
+      }
     }
 
     var attributes = [NSAttributedString.Key: Any]()
@@ -28,6 +41,11 @@ class UINavigationBarRenderer: UIViewRenderer {
     if let fontColor = style.fontColor {
       attributes[NSAttributedString.Key.foregroundColor] = fontColor
     }
-    control.titleTextAttributes = attributes
+    if #available(iOS 13.0, *) {
+      control.standardAppearance.titleTextAttributes = attributes
+      control.scrollEdgeAppearance!.titleTextAttributes = attributes
+    } else {
+      control.titleTextAttributes = attributes
+    }
   }
 }

--- a/iphone/Maps/LocalizedStrings/af.lproj/Localizable.strings
+++ b/iphone/Maps/LocalizedStrings/af.lproj/Localizable.strings
@@ -707,8 +707,6 @@
 
 "editor_operator" = "Owner";
 
-"downloader_my_maps_title" = "My maps";
-
 "downloader_no_downloaded_maps_title" = "You haven't downloaded any maps";
 
 "downloader_no_downloaded_maps_message" = "Download maps to search for a location and use navigation offline.";

--- a/iphone/Maps/LocalizedStrings/ar.lproj/Localizable.strings
+++ b/iphone/Maps/LocalizedStrings/ar.lproj/Localizable.strings
@@ -707,8 +707,6 @@
 
 "editor_operator" = "معامل";
 
-"downloader_my_maps_title" = "خرائطي";
-
 "downloader_no_downloaded_maps_title" = "لم تقم بتنزيل أية خرائط";
 
 "downloader_no_downloaded_maps_message" = "قم بتنزيل خرائط للبحث عن مكان والتنقل بدون اتصال بالإنترنت.";

--- a/iphone/Maps/LocalizedStrings/be.lproj/Localizable.strings
+++ b/iphone/Maps/LocalizedStrings/be.lproj/Localizable.strings
@@ -707,8 +707,6 @@
 
 "editor_operator" = "Уладальнік";
 
-"downloader_my_maps_title" = "Мае мапы";
-
 "downloader_no_downloaded_maps_title" = "Вы не спампавалі ніводнай мапы";
 
 "downloader_no_downloaded_maps_message" = "Спампуйце мапы, каб шукаць месцы і карыстацца навігацыяй без інтэрнэту.";

--- a/iphone/Maps/LocalizedStrings/bg.lproj/Localizable.strings
+++ b/iphone/Maps/LocalizedStrings/bg.lproj/Localizable.strings
@@ -707,8 +707,6 @@
 
 "editor_operator" = "Собственик";
 
-"downloader_my_maps_title" = "My maps";
-
 "downloader_no_downloaded_maps_title" = "Не сте изтеглили никакви карти";
 
 "downloader_no_downloaded_maps_message" = "Изтеглете картите, от които се нуждаете, за да намирате места и да навигирате без интернет.";

--- a/iphone/Maps/LocalizedStrings/cs.lproj/Localizable.strings
+++ b/iphone/Maps/LocalizedStrings/cs.lproj/Localizable.strings
@@ -707,8 +707,6 @@
 
 "editor_operator" = "Operátor";
 
-"downloader_my_maps_title" = "Mé mapy";
-
 "downloader_no_downloaded_maps_title" = "Nemáte stažené žádné mapy";
 
 "downloader_no_downloaded_maps_message" = "Stáhněte si mapy a hledejte cestu a její cíl, i když jste offline.";

--- a/iphone/Maps/LocalizedStrings/da.lproj/Localizable.strings
+++ b/iphone/Maps/LocalizedStrings/da.lproj/Localizable.strings
@@ -707,8 +707,6 @@
 
 "editor_operator" = "Bruger";
 
-"downloader_my_maps_title" = "Mine kort";
-
 "downloader_no_downloaded_maps_title" = "Du har ikke hentet alle kort";
 
 "downloader_no_downloaded_maps_message" = "Download kort for at finde position og navigere offline.";

--- a/iphone/Maps/LocalizedStrings/de.lproj/Localizable.strings
+++ b/iphone/Maps/LocalizedStrings/de.lproj/Localizable.strings
@@ -707,8 +707,6 @@
 
 "editor_operator" = "Betreiber oder Eigentümer";
 
-"downloader_my_maps_title" = "Meine Karten";
-
 "downloader_no_downloaded_maps_title" = "Keine Karten geladen";
 
 "downloader_no_downloaded_maps_message" = "Laden Sie die für die Suche nach Orten erforderlichen Karten und verwenden Sie die Navigation offline.";

--- a/iphone/Maps/LocalizedStrings/el.lproj/Localizable.strings
+++ b/iphone/Maps/LocalizedStrings/el.lproj/Localizable.strings
@@ -707,8 +707,6 @@
 
 "editor_operator" = "Ιδιοκτήτης";
 
-"downloader_my_maps_title" = "Οι χάρτες μου";
-
 "downloader_no_downloaded_maps_title" = "Δεν έχετε κατεβάσει χάρτες";
 
 "downloader_no_downloaded_maps_message" = "Κατεβάστε χάρτες για να αναζητήσετε μια τοποθεσία και να χρησιμοποιήσετε την πλοήγησης χωρίς σύνδεση.";

--- a/iphone/Maps/LocalizedStrings/en-GB.lproj/Localizable.strings
+++ b/iphone/Maps/LocalizedStrings/en-GB.lproj/Localizable.strings
@@ -707,8 +707,6 @@
 
 "editor_operator" = "Owner";
 
-"downloader_my_maps_title" = "My maps";
-
 "downloader_no_downloaded_maps_title" = "You haven't downloaded any maps";
 
 "downloader_no_downloaded_maps_message" = "Download maps to search for a location and use navigation offline.";

--- a/iphone/Maps/LocalizedStrings/en.lproj/Localizable.strings
+++ b/iphone/Maps/LocalizedStrings/en.lproj/Localizable.strings
@@ -707,8 +707,6 @@
 
 "editor_operator" = "Owner";
 
-"downloader_my_maps_title" = "My maps";
-
 "downloader_no_downloaded_maps_title" = "You haven't downloaded any maps";
 
 "downloader_no_downloaded_maps_message" = "Download maps to search for a location and use navigation offline.";

--- a/iphone/Maps/LocalizedStrings/es-MX.lproj/Localizable.strings
+++ b/iphone/Maps/LocalizedStrings/es-MX.lproj/Localizable.strings
@@ -707,8 +707,6 @@
 
 "editor_operator" = "Owner";
 
-"downloader_my_maps_title" = "My maps";
-
 "downloader_no_downloaded_maps_title" = "You haven't downloaded any maps";
 
 "downloader_no_downloaded_maps_message" = "Download maps to search for a location and use navigation offline.";

--- a/iphone/Maps/LocalizedStrings/es.lproj/Localizable.strings
+++ b/iphone/Maps/LocalizedStrings/es.lproj/Localizable.strings
@@ -707,8 +707,6 @@
 
 "editor_operator" = "Operador";
 
-"downloader_my_maps_title" = "Mis mapas";
-
 "downloader_no_downloaded_maps_title" = "No ha descargado ningún mapa";
 
 "downloader_no_downloaded_maps_message" = "Descargue mapas para encontrar la ubicación y navegar sin conexión.";

--- a/iphone/Maps/LocalizedStrings/fa.lproj/Localizable.strings
+++ b/iphone/Maps/LocalizedStrings/fa.lproj/Localizable.strings
@@ -707,8 +707,6 @@
 
 "editor_operator" = "مالک";
 
-"downloader_my_maps_title" = "نقشه های من";
-
 "downloader_no_downloaded_maps_title" = "شما هیچ نقشه دانلود شده ای ندارید";
 
 "downloader_no_downloaded_maps_message" = "برای جست وجو یک مکان و استفاده از قابلیت ناوبری, نقشه ها را دانلود کنید.";

--- a/iphone/Maps/LocalizedStrings/fi.lproj/Localizable.strings
+++ b/iphone/Maps/LocalizedStrings/fi.lproj/Localizable.strings
@@ -707,8 +707,6 @@
 
 "editor_operator" = "Operaattori";
 
-"downloader_my_maps_title" = "Omat kartat";
-
 "downloader_no_downloaded_maps_title" = "Et ole ladannut yhtään karttaa";
 
 "downloader_no_downloaded_maps_message" = "Lataa kartattoja löytääksesi paikkoja ja navigoidaksesi offline-tilassa.";

--- a/iphone/Maps/LocalizedStrings/fr.lproj/Localizable.strings
+++ b/iphone/Maps/LocalizedStrings/fr.lproj/Localizable.strings
@@ -707,8 +707,6 @@
 
 "editor_operator" = "Opérateur";
 
-"downloader_my_maps_title" = "Mes cartes";
-
 "downloader_no_downloaded_maps_title" = "Vous n'avez téléchargé aucune carte";
 
 "downloader_no_downloaded_maps_message" = "Téléchargez des cartes pour rechercher un lieu et utiliser la navigation hors ligne";

--- a/iphone/Maps/LocalizedStrings/he.lproj/Localizable.strings
+++ b/iphone/Maps/LocalizedStrings/he.lproj/Localizable.strings
@@ -707,8 +707,6 @@
 
 "editor_operator" = "Owner";
 
-"downloader_my_maps_title" = "My maps";
-
 "downloader_no_downloaded_maps_title" = "You haven't downloaded any maps";
 
 "downloader_no_downloaded_maps_message" = "Download maps to search for a location and use navigation offline.";

--- a/iphone/Maps/LocalizedStrings/hi.lproj/Localizable.strings
+++ b/iphone/Maps/LocalizedStrings/hi.lproj/Localizable.strings
@@ -707,8 +707,6 @@
 
 "editor_operator" = "Owner";
 
-"downloader_my_maps_title" = "My maps";
-
 "downloader_no_downloaded_maps_title" = "You haven't downloaded any maps";
 
 "downloader_no_downloaded_maps_message" = "Download maps to search for a location and use navigation offline.";

--- a/iphone/Maps/LocalizedStrings/hu.lproj/Localizable.strings
+++ b/iphone/Maps/LocalizedStrings/hu.lproj/Localizable.strings
@@ -707,8 +707,6 @@
 
 "editor_operator" = "Üzemeltető";
 
-"downloader_my_maps_title" = "Térképeim";
-
 "downloader_no_downloaded_maps_title" = "Még nem töltött le térképet";
 
 "downloader_no_downloaded_maps_message" = "Töltse le a szükséges térképeket, hogy megtalálja a helyet és internet nélkül is navigálhasson.";

--- a/iphone/Maps/LocalizedStrings/id.lproj/Localizable.strings
+++ b/iphone/Maps/LocalizedStrings/id.lproj/Localizable.strings
@@ -707,8 +707,6 @@
 
 "editor_operator" = "Pemilik";
 
-"downloader_my_maps_title" = "Peta saya";
-
 "downloader_no_downloaded_maps_title" = "Tidak ada peta apa pun yang diunduh";
 
 "downloader_no_downloaded_maps_message" = "Unduh peta untuk menemukan lokasi dan bernavigasi secara offline.";

--- a/iphone/Maps/LocalizedStrings/it.lproj/Localizable.strings
+++ b/iphone/Maps/LocalizedStrings/it.lproj/Localizable.strings
@@ -707,8 +707,6 @@
 
 "editor_operator" = "Proprietario";
 
-"downloader_my_maps_title" = "Le mie mappe";
-
 "downloader_no_downloaded_maps_title" = "Non hai scaricato mappe";
 
 "downloader_no_downloaded_maps_message" = "Scarica mappe per trovare un luogo e navigare offline.";

--- a/iphone/Maps/LocalizedStrings/ja.lproj/Localizable.strings
+++ b/iphone/Maps/LocalizedStrings/ja.lproj/Localizable.strings
@@ -707,8 +707,6 @@
 
 "editor_operator" = "オペレーター";
 
-"downloader_my_maps_title" = "マイマップ";
-
 "downloader_no_downloaded_maps_title" = "マップをダウンロードしていません";
 
 "downloader_no_downloaded_maps_message" = "ロケーションの検索とオフラインナビゲートのためにマップをダウンロードしてください。";

--- a/iphone/Maps/LocalizedStrings/ko.lproj/Localizable.strings
+++ b/iphone/Maps/LocalizedStrings/ko.lproj/Localizable.strings
@@ -707,8 +707,6 @@
 
 "editor_operator" = "소유자";
 
-"downloader_my_maps_title" = "내 지도";
-
 "downloader_no_downloaded_maps_title" = "지도를 다운로드하지 않았습니다";
 
 "downloader_no_downloaded_maps_message" = "오프라인으로 위치를 검색하려면 지도를 다운로드하세요.";

--- a/iphone/Maps/LocalizedStrings/nb.lproj/Localizable.strings
+++ b/iphone/Maps/LocalizedStrings/nb.lproj/Localizable.strings
@@ -707,8 +707,6 @@
 
 "editor_operator" = "Eier";
 
-"downloader_my_maps_title" = "Mine kart";
-
 "downloader_no_downloaded_maps_title" = "Du har ikke lastet ned noen kart";
 
 "downloader_no_downloaded_maps_message" = "Last ned kart for å finne plasseringen og navigere frakoblet.";

--- a/iphone/Maps/LocalizedStrings/nl.lproj/Localizable.strings
+++ b/iphone/Maps/LocalizedStrings/nl.lproj/Localizable.strings
@@ -707,8 +707,6 @@
 
 "editor_operator" = "Uitvoerder";
 
-"downloader_my_maps_title" = "Mijn kaarten";
-
 "downloader_no_downloaded_maps_title" = "U hebt geen kaarten gedownload";
 
 "downloader_no_downloaded_maps_message" = "Download kaarten om de locatie te zoeken en offline te navigeren.";

--- a/iphone/Maps/LocalizedStrings/pl.lproj/Localizable.strings
+++ b/iphone/Maps/LocalizedStrings/pl.lproj/Localizable.strings
@@ -707,8 +707,6 @@
 
 "editor_operator" = "Operator";
 
-"downloader_my_maps_title" = "Moje mapy";
-
 "downloader_no_downloaded_maps_title" = "Nie pobrano żadnych map";
 
 "downloader_no_downloaded_maps_message" = "Aby znajdować miejsca i nawigować bez połączenia z internetem, musisz pobrać mapy.";

--- a/iphone/Maps/LocalizedStrings/pt-BR.lproj/Localizable.strings
+++ b/iphone/Maps/LocalizedStrings/pt-BR.lproj/Localizable.strings
@@ -707,8 +707,6 @@
 
 "editor_operator" = "Operador";
 
-"downloader_my_maps_title" = "Meus mapas";
-
 "downloader_no_downloaded_maps_title" = "Você não fez o download de nenhum mapa";
 
 "downloader_no_downloaded_maps_message" = "Baixe mapas para pesquisar locais e usar navegação offline.";

--- a/iphone/Maps/LocalizedStrings/pt.lproj/Localizable.strings
+++ b/iphone/Maps/LocalizedStrings/pt.lproj/Localizable.strings
@@ -707,8 +707,6 @@
 
 "editor_operator" = "Operador";
 
-"downloader_my_maps_title" = "Os meus mapas";
-
 "downloader_no_downloaded_maps_title" = "Não descarregou quaisquer mapas";
 
 "downloader_no_downloaded_maps_message" = "Descarregar mapas para encontrar a localização e navegar offline.";

--- a/iphone/Maps/LocalizedStrings/ro.lproj/Localizable.strings
+++ b/iphone/Maps/LocalizedStrings/ro.lproj/Localizable.strings
@@ -707,8 +707,6 @@
 
 "editor_operator" = "Proprietar";
 
-"downloader_my_maps_title" = "Hărțile mele";
-
 "downloader_no_downloaded_maps_title" = "Nu ai descărcat nicio hartă";
 
 "downloader_no_downloaded_maps_message" = "Descarcă hărți pentru a căuta un loc și a naviga fără conectare la internet.";

--- a/iphone/Maps/LocalizedStrings/ru.lproj/Localizable.strings
+++ b/iphone/Maps/LocalizedStrings/ru.lproj/Localizable.strings
@@ -707,8 +707,6 @@
 
 "editor_operator" = "Владелец";
 
-"downloader_my_maps_title" = "Мои карты";
-
 "downloader_no_downloaded_maps_title" = "У вас нет загруженных карт";
 
 "downloader_no_downloaded_maps_message" = "Загрузите необходимые карты, чтобы находить места и пользоваться навигацией без интернета.";

--- a/iphone/Maps/LocalizedStrings/sk.lproj/Localizable.strings
+++ b/iphone/Maps/LocalizedStrings/sk.lproj/Localizable.strings
@@ -707,8 +707,6 @@
 
 "editor_operator" = "Prevádzkovateľ";
 
-"downloader_my_maps_title" = "Moje mapy";
-
 "downloader_no_downloaded_maps_title" = "Neprevzali ste žiadne mapy";
 
 "downloader_no_downloaded_maps_message" = "Prevziať mapy na nájdenie pozície a navigovanie off-line.";

--- a/iphone/Maps/LocalizedStrings/sv.lproj/Localizable.strings
+++ b/iphone/Maps/LocalizedStrings/sv.lproj/Localizable.strings
@@ -707,8 +707,6 @@
 
 "editor_operator" = "Användare";
 
-"downloader_my_maps_title" = "Mina kartor";
-
 "downloader_no_downloaded_maps_title" = "Du har inte laddat ner några kartor";
 
 "downloader_no_downloaded_maps_message" = "Ladda ner kartor för att hitta platsen och navigera offline.";

--- a/iphone/Maps/LocalizedStrings/sw.lproj/Localizable.strings
+++ b/iphone/Maps/LocalizedStrings/sw.lproj/Localizable.strings
@@ -707,8 +707,6 @@
 
 "editor_operator" = "Owner";
 
-"downloader_my_maps_title" = "My maps";
-
 "downloader_no_downloaded_maps_title" = "You haven't downloaded any maps";
 
 "downloader_no_downloaded_maps_message" = "Download maps to search for a location and use navigation offline.";

--- a/iphone/Maps/LocalizedStrings/th.lproj/Localizable.strings
+++ b/iphone/Maps/LocalizedStrings/th.lproj/Localizable.strings
@@ -707,8 +707,6 @@
 
 "editor_operator" = "เจ้าของ";
 
-"downloader_my_maps_title" = "แผนที่ของฉัน";
-
 "downloader_no_downloaded_maps_title" = "คุณยังไม่ได้ดาวน์โหลดแผนที่";
 
 "downloader_no_downloaded_maps_message" = "ดาวน์โหลดแผนที่เพื่อค้นหาสถานที่ และนำทางแบบออฟไลน์";

--- a/iphone/Maps/LocalizedStrings/tr.lproj/Localizable.strings
+++ b/iphone/Maps/LocalizedStrings/tr.lproj/Localizable.strings
@@ -707,8 +707,6 @@
 
 "editor_operator" = "İşletmeci";
 
-"downloader_my_maps_title" = "Haritalarım";
-
 "downloader_no_downloaded_maps_title" = "Hiç harita indirmediniz";
 
 "downloader_no_downloaded_maps_message" = "Çevrimdışı olarak adres bulmak ve gezinmek için haritaları indirin.";

--- a/iphone/Maps/LocalizedStrings/uk.lproj/Localizable.strings
+++ b/iphone/Maps/LocalizedStrings/uk.lproj/Localizable.strings
@@ -707,8 +707,6 @@
 
 "editor_operator" = "Власник";
 
-"downloader_my_maps_title" = "Мої мапи";
-
 "downloader_no_downloaded_maps_title" = "Ви не маєте завантажених мап";
 
 "downloader_no_downloaded_maps_message" = "Завантажте необхідні мапи, щоб знаходити місця та користуватися навігацією без iнтернету.";

--- a/iphone/Maps/LocalizedStrings/vi.lproj/Localizable.strings
+++ b/iphone/Maps/LocalizedStrings/vi.lproj/Localizable.strings
@@ -707,8 +707,6 @@
 
 "editor_operator" = "Đơn vị điều hành";
 
-"downloader_my_maps_title" = "Bản đồ của tôi";
-
 "downloader_no_downloaded_maps_title" = "Bạn chưa tải về bất kỳ bản đồ nào";
 
 "downloader_no_downloaded_maps_message" = "Tải về bản đồ để tìm địa điểm và định hướng ngoại tuyến.";

--- a/iphone/Maps/LocalizedStrings/zh-Hans.lproj/Localizable.strings
+++ b/iphone/Maps/LocalizedStrings/zh-Hans.lproj/Localizable.strings
@@ -707,8 +707,6 @@
 
 "editor_operator" = "运营者";
 
-"downloader_my_maps_title" = "我的地图";
-
 "downloader_no_downloaded_maps_title" = "您尚未下载任何地图";
 
 "downloader_no_downloaded_maps_message" = "下载地图来查找位置和离线浏览";

--- a/iphone/Maps/LocalizedStrings/zh-Hant.lproj/Localizable.strings
+++ b/iphone/Maps/LocalizedStrings/zh-Hant.lproj/Localizable.strings
@@ -707,8 +707,6 @@
 
 "editor_operator" = "營運者";
 
-"downloader_my_maps_title" = "我的地圖";
-
 "downloader_no_downloaded_maps_title" = "您尚未下載任何地圖";
 
 "downloader_no_downloaded_maps_message" = "下載地圖來尋找位置和離線瀏覽。";

--- a/iphone/Maps/UI/Downloader/Cells/MWMMapDownloaderButtonTableViewCell.xib
+++ b/iphone/Maps/UI/Downloader/Cells/MWMMapDownloaderButtonTableViewCell.xib
@@ -1,9 +1,10 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<document type="com.apple.InterfaceBuilder3.CocoaTouch.XIB" version="3.0" toolsVersion="15702" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" colorMatched="YES">
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.XIB" version="3.0" toolsVersion="19529" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" colorMatched="YES">
     <device id="retina4_7" orientation="portrait" appearance="light"/>
     <dependencies>
         <deployment identifier="iOS"/>
-        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="15704"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="19519"/>
+        <capability name="System colors in document resources" minToolsVersion="11.0"/>
         <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
     </dependencies>
     <objects>
@@ -16,13 +17,11 @@
                 <rect key="frame" x="0.0" y="0.0" width="320" height="44"/>
                 <autoresizingMask key="autoresizingMask"/>
                 <subviews>
-                    <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Add Maps Button" textAlignment="center" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="dOW-mN-UY7">
+                    <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Add Maps Button" textAlignment="center" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" id="dOW-mN-UY7">
                         <rect key="frame" x="0.0" y="0.0" width="320" height="44"/>
-                        <constraints>
-                            <constraint firstAttribute="height" constant="44" id="6Wr-jd-ikR"/>
-                        </constraints>
+                        <autoresizingMask key="autoresizingMask" widthSizable="YES"/>
                         <fontDescription key="fontDescription" type="system" pointSize="15"/>
-                        <color key="textColor" systemColor="linkColor" red="0.0" green="0.47843137250000001" blue="1" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
+                        <color key="textColor" systemColor="linkColor"/>
                         <nil key="highlightedColor"/>
                         <userDefinedRuntimeAttributes>
                             <userDefinedRuntimeAttribute type="string" keyPath="styleName" value="regular17:linkBlueText"/>
@@ -30,12 +29,6 @@
                         </userDefinedRuntimeAttributes>
                     </label>
                 </subviews>
-                <constraints>
-                    <constraint firstItem="dOW-mN-UY7" firstAttribute="leading" secondItem="H2p-sc-9uM" secondAttribute="leading" id="EyM-Ka-jj7"/>
-                    <constraint firstAttribute="trailing" secondItem="dOW-mN-UY7" secondAttribute="trailing" id="K0a-sK-wOb"/>
-                    <constraint firstAttribute="bottom" secondItem="dOW-mN-UY7" secondAttribute="bottom" id="h4g-hj-rht"/>
-                    <constraint firstItem="dOW-mN-UY7" firstAttribute="top" secondItem="H2p-sc-9uM" secondAttribute="top" id="tcn-Sg-XSP"/>
-                </constraints>
             </tableViewCellContentView>
             <inset key="separatorInset" minX="0.0" minY="0.0" maxX="0.0" maxY="0.0"/>
             <userDefinedRuntimeAttributes>
@@ -44,4 +37,9 @@
             <point key="canvasLocation" x="139" y="155"/>
         </tableViewCell>
     </objects>
+    <resources>
+        <systemColor name="linkColor">
+            <color red="0.0" green="0.47843137254901963" blue="1" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
+        </systemColor>
+    </resources>
 </document>

--- a/iphone/Maps/UI/Downloader/DownloadMapsViewController.swift
+++ b/iphone/Maps/UI/Downloader/DownloadMapsViewController.swift
@@ -1,3 +1,5 @@
+import UIKit
+
 @objc(MWMDownloadMapsViewController)
 class DownloadMapsViewController: MWMViewController {
   // MARK: - Types
@@ -20,14 +22,12 @@ class DownloadMapsViewController: MWMViewController {
   // MARK: - Outlets
 
   @IBOutlet var tableView: UITableView!
-  @IBOutlet var searchBar: UISearchBar!
-  @IBOutlet var statusBarBackground: UIView!
   @IBOutlet var noMapsContainer: UIView!
-  @IBOutlet var searchBarTopOffset: NSLayoutConstraint!
   @IBOutlet var downloadAllViewContainer: UIView!
 
   // MARK: - Properties
 
+  private var searchBar: UISearchBar = UISearchBar()
   var dataSource: IDownloaderDataSource!
   @objc var mode: MWMMapDownloaderMode = .downloaded
   private var skipCountryEvent = false
@@ -36,7 +36,7 @@ class DownloadMapsViewController: MWMViewController {
 
   lazy var noSerchResultViewController: SearchNoResultsViewController = {
     let vc = storyboard!.instantiateViewController(ofType: SearchNoResultsViewController.self)
-    view.insertSubview(vc.view, belowSubview: statusBarBackground)
+    view.insertSubview(vc.view, aboveSubview: tableView)
     vc.view.alignToSuperview()
     vc.view.isHidden = true
     addChild(vc)
@@ -77,10 +77,12 @@ class DownloadMapsViewController: MWMViewController {
       navigationItem.rightBarButtonItem = addMapsButton
     }
     noMapsContainer.isHidden = !dataSource.isEmpty || Storage.shared().downloadInProgress()
-    if !dataSource.isRoot {
-      searchBarTopOffset.constant = -searchBar.frame.height
-    } else {
+
+    if dataSource.isRoot {
       searchBar.placeholder = L("downloader_search_field_hint")
+      searchBar.delegate = self
+      // TODO: Fix the height and centering of the searchBar, it's very tricky.
+      navigationItem.titleView = searchBar
     }
     configButtons()
   }
@@ -434,22 +436,6 @@ extension DownloadMapsViewController: StorageObserver {
 // MARK: - UISearchBarDelegate
 
 extension DownloadMapsViewController: UISearchBarDelegate {
-  func searchBarShouldBeginEditing(_ searchBar: UISearchBar) -> Bool {
-    searchBar.setShowsCancelButton(true, animated: true)
-    navigationController?.setNavigationBarHidden(true, animated: true)
-    tableView.contentInset = .zero
-    tableView.scrollIndicatorInsets = .zero
-    return true
-  }
-
-  func searchBarShouldEndEditing(_ searchBar: UISearchBar) -> Bool {
-    searchBar.setShowsCancelButton(false, animated: true)
-    navigationController?.setNavigationBarHidden(false, animated: true)
-    tableView.contentInset = .zero
-    tableView.scrollIndicatorInsets = .zero
-    return true
-  }
-
   func searchBarCancelButtonClicked(_ searchBar: UISearchBar) {
     searchBar.text = nil
     searchBar.resignFirstResponder()

--- a/iphone/Maps/UI/Downloader/DownloadedMapsDataSource.swift
+++ b/iphone/Maps/UI/Downloader/DownloadedMapsDataSource.swift
@@ -38,10 +38,10 @@ extension DownloadedMapsDataSource: IDownloaderDataSource {
   var isEmpty: Bool {
     return searching ? searchDataSource.isEmpty : countryIds.isEmpty
   }
-  
+
   var title: String {
     guard let parentCountryId = parentCountryId else {
-      return L("downloader_my_maps_title")
+      return ""  // Root Downloader dialog displays UISearchBar instead of title.
     }
     return Storage.shared().name(forCountry: parentCountryId)
   }

--- a/iphone/Maps/UI/Storyboard/Main.storyboard
+++ b/iphone/Maps/UI/Storyboard/Main.storyboard
@@ -1,9 +1,9 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="18122" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES" initialViewController="Wns-nH-AQU">
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="19529" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES" initialViewController="Wns-nH-AQU">
     <device id="retina6_1" orientation="landscape" appearance="light"/>
     <dependencies>
         <deployment identifier="iOS"/>
-        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="18093"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="19519"/>
         <capability name="Safe area layout guides" minToolsVersion="9.0"/>
         <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
     </dependencies>
@@ -670,7 +670,7 @@
                         <color key="backgroundColor" red="1" green="1" blue="1" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
                         <prototypes>
                             <tableViewCell clipsSubviews="YES" contentMode="scaleToFill" selectionStyle="default" indentationWidth="10" reuseIdentifier="ListCellIdentifier" textLabel="JcK-nR-UGw" detailTextLabel="Cmi-x5-6Vt" style="IBUITableViewCellStyleSubtitle" id="RXe-xp-xlR" customClass="MWMTableViewCell">
-                                <rect key="frame" x="0.0" y="24.5" width="896" height="44"/>
+                                <rect key="frame" x="0.0" y="44.5" width="896" height="44"/>
                                 <autoresizingMask key="autoresizingMask"/>
                                 <tableViewCellContentView key="contentView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" tableViewCell="RXe-xp-xlR" id="g0x-Vt-1FI">
                                     <rect key="frame" x="44" y="0.0" width="808" height="44"/>
@@ -873,7 +873,7 @@
                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                         <subviews>
                             <tableView clipsSubviews="YES" contentMode="scaleToFill" alwaysBounceVertical="YES" dataMode="prototypes" style="grouped" separatorStyle="default" rowHeight="-1" estimatedRowHeight="-1" sectionHeaderHeight="-1" estimatedSectionHeaderHeight="-1" sectionFooterHeight="1" translatesAutoresizingMaskIntoConstraints="NO" id="CwW-x8-G3j">
-                                <rect key="frame" x="0.0" y="51" width="896" height="342"/>
+                                <rect key="frame" x="0.0" y="0.0" width="896" height="393"/>
                                 <color key="backgroundColor" red="0.93725490199999995" green="0.93725490199999995" blue="0.95686274510000002" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
                                 <gestureRecognizers/>
                                 <userDefinedRuntimeAttributes>
@@ -884,29 +884,8 @@
                                     <outlet property="delegate" destination="h4a-ne-bSJ" id="3jT-yg-FQv"/>
                                 </connections>
                             </tableView>
-                            <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="Xxz-fq-71r" userLabel="Status Bar Background">
-                                <rect key="frame" x="0.0" y="-57" width="896" height="108"/>
-                                <color key="backgroundColor" red="0.1215686275" green="0.59999999999999998" blue="0.32156862749999998" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
-                                <color key="tintColor" red="0.0" green="0.0" blue="0.0" alpha="0.0" colorSpace="custom" customColorSpace="sRGB"/>
-                                <constraints>
-                                    <constraint firstAttribute="height" constant="108" id="9ZH-dO-Jna"/>
-                                </constraints>
-                                <userDefinedRuntimeAttributes>
-                                    <userDefinedRuntimeAttribute type="string" keyPath="styleName" value="SearchStatusBarView"/>
-                                </userDefinedRuntimeAttributes>
-                            </view>
-                            <searchBar contentMode="redraw" text="" translatesAutoresizingMaskIntoConstraints="NO" id="DPt-gs-efn">
-                                <rect key="frame" x="44" y="0.0" width="808" height="51"/>
-                                <constraints>
-                                    <constraint firstAttribute="height" relation="greaterThanOrEqual" constant="44" id="9M7-y1-RSU"/>
-                                </constraints>
-                                <textInputTraits key="textInputTraits"/>
-                                <connections>
-                                    <outlet property="delegate" destination="h4a-ne-bSJ" id="k3P-rj-vcL"/>
-                                </connections>
-                            </searchBar>
                             <containerView hidden="YES" opaque="NO" contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="kXO-Oh-2vO" userLabel="No Maps Container View">
-                                <rect key="frame" x="44" y="51" width="808" height="342"/>
+                                <rect key="frame" x="44" y="0.0" width="808" height="393"/>
                                 <connections>
                                     <segue destination="b8o-rZ-x0k" kind="embed" identifier="MapDownloaderNoResultsEmbedViewControllerSegue" id="ish-dC-mkH"/>
                                 </connections>
@@ -926,21 +905,15 @@
                         <color key="backgroundColor" red="1" green="1" blue="1" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
                         <gestureRecognizers/>
                         <constraints>
-                            <constraint firstAttribute="trailing" secondItem="Xxz-fq-71r" secondAttribute="trailing" id="5qb-GL-Rgv"/>
+                            <constraint firstItem="CwW-x8-G3j" firstAttribute="top" secondItem="dlW-OQ-WMO" secondAttribute="top" id="5wV-Dv-sjS"/>
                             <constraint firstAttribute="trailing" secondItem="CwW-x8-G3j" secondAttribute="trailing" id="6QL-v4-rNy"/>
                             <constraint firstItem="dlW-OQ-WMO" firstAttribute="bottom" secondItem="kXO-Oh-2vO" secondAttribute="bottom" id="8Tl-19-ReF"/>
-                            <constraint firstItem="DPt-gs-efn" firstAttribute="top" secondItem="dlW-OQ-WMO" secondAttribute="top" id="DaT-3k-Xu4"/>
                             <constraint firstItem="dlW-OQ-WMO" firstAttribute="trailing" secondItem="CDj-ol-HRP" secondAttribute="trailing" id="FLZ-Kr-4dV"/>
                             <constraint firstItem="kXO-Oh-2vO" firstAttribute="leading" secondItem="dlW-OQ-WMO" secondAttribute="leading" id="M0m-98-7Ev"/>
                             <constraint firstItem="dlW-OQ-WMO" firstAttribute="bottom" secondItem="CwW-x8-G3j" secondAttribute="bottom" id="QPk-e4-hZs"/>
-                            <constraint firstItem="DPt-gs-efn" firstAttribute="leading" secondItem="dlW-OQ-WMO" secondAttribute="leading" id="VJj-Tp-SDf"/>
                             <constraint firstItem="CwW-x8-G3j" firstAttribute="leading" secondItem="XQZ-0V-SyR" secondAttribute="leading" id="Wvb-0M-kQl"/>
-                            <constraint firstItem="Xxz-fq-71r" firstAttribute="bottom" secondItem="DPt-gs-efn" secondAttribute="bottom" id="ZX5-1D-Odx"/>
-                            <constraint firstItem="Xxz-fq-71r" firstAttribute="leading" secondItem="XQZ-0V-SyR" secondAttribute="leading" id="d6U-js-Akg"/>
-                            <constraint firstItem="dlW-OQ-WMO" firstAttribute="trailing" secondItem="DPt-gs-efn" secondAttribute="trailing" id="dqa-6i-25A"/>
+                            <constraint firstItem="CwW-x8-G3j" firstAttribute="top" secondItem="kXO-Oh-2vO" secondAttribute="top" id="eFX-ON-3aD"/>
                             <constraint firstItem="CDj-ol-HRP" firstAttribute="leading" secondItem="dlW-OQ-WMO" secondAttribute="leading" id="mwH-aX-jCV"/>
-                            <constraint firstItem="kXO-Oh-2vO" firstAttribute="top" secondItem="DPt-gs-efn" secondAttribute="bottom" id="nAx-dp-QrX"/>
-                            <constraint firstItem="CwW-x8-G3j" firstAttribute="top" secondItem="Xxz-fq-71r" secondAttribute="bottom" id="nLg-Zb-DT9"/>
                             <constraint firstItem="dlW-OQ-WMO" firstAttribute="bottom" secondItem="CDj-ol-HRP" secondAttribute="bottom" id="tp7-f9-Sw5"/>
                             <constraint firstItem="dlW-OQ-WMO" firstAttribute="trailing" secondItem="kXO-Oh-2vO" secondAttribute="trailing" id="yMA-25-2pq"/>
                         </constraints>
@@ -951,9 +924,6 @@
                     <connections>
                         <outlet property="downloadAllViewContainer" destination="CDj-ol-HRP" id="GL3-3D-JAQ"/>
                         <outlet property="noMapsContainer" destination="kXO-Oh-2vO" id="fpe-Gj-ZmD"/>
-                        <outlet property="searchBar" destination="DPt-gs-efn" id="HS1-0c-JX8"/>
-                        <outlet property="searchBarTopOffset" destination="DaT-3k-Xu4" id="8gw-DU-okf"/>
-                        <outlet property="statusBarBackground" destination="Xxz-fq-71r" id="W1o-7P-C8n"/>
                         <outlet property="tableView" destination="CwW-x8-G3j" id="uIf-Yj-DiC"/>
                     </connections>
                 </viewController>
@@ -966,17 +936,17 @@
             <objects>
                 <viewController storyboardIdentifier="MWMNoMapsViewController" id="3el-Zi-2E4" customClass="MWMNoMapsViewController" sceneMemberID="viewController">
                     <view key="view" contentMode="scaleToFill" id="4WP-vj-Alg">
-                        <rect key="frame" x="0.0" y="0.0" width="808" height="342"/>
+                        <rect key="frame" x="0.0" y="0.0" width="808" height="393"/>
                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                         <subviews>
                             <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="Gmw-e3-n53" userLabel="Container" customClass="MWMNoMapsView">
-                                <rect key="frame" x="222.5" y="0.0" width="407" height="342"/>
+                                <rect key="frame" x="222.5" y="0.0" width="407" height="393"/>
                                 <subviews>
                                     <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="dCZ-PN-2Ob" userLabel="BoundsView">
-                                        <rect key="frame" x="16" y="0.0" width="375" height="238"/>
+                                        <rect key="frame" x="16" y="0.0" width="375" height="289"/>
                                         <subviews>
                                             <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="87G-jh-N8H" userLabel="CenteredView">
-                                                <rect key="frame" x="0.0" y="64.5" width="375" height="109"/>
+                                                <rect key="frame" x="0.0" y="90" width="375" height="109"/>
                                                 <subviews>
                                                     <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="У вас нет загруженных карт" textAlignment="center" lineBreakMode="tailTruncation" numberOfLines="0" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="abh-G0-Alr" userLabel="Title">
                                                         <rect key="frame" x="0.0" y="40" width="375" height="24"/>
@@ -1026,7 +996,7 @@
                                         </constraints>
                                     </view>
                                     <button opaque="NO" clipsSubviews="YES" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" adjustsImageWhenHighlighted="NO" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="Moj-UK-oyl" userLabel="DownloadMaps" customClass="MWMButton">
-                                        <rect key="frame" x="83.5" y="258" width="240" height="44"/>
+                                        <rect key="frame" x="83.5" y="309" width="240" height="44"/>
                                         <color key="backgroundColor" red="0.0" green="0.0" blue="0.0" alpha="0.0" colorSpace="custom" customColorSpace="sRGB"/>
                                         <constraints>
                                             <constraint firstAttribute="width" constant="240" id="49x-bx-JJj"/>
@@ -1118,6 +1088,9 @@
                             <constraint firstItem="EbW-Mp-c6s" firstAttribute="centerX" secondItem="yK4-pW-Ads" secondAttribute="centerX" id="xbz-FB-nZl"/>
                             <constraint firstItem="EbW-Mp-c6s" firstAttribute="width" secondItem="9jm-RW-DZK" secondAttribute="width" priority="750" id="zcx-oD-0Uk"/>
                         </constraints>
+                        <userDefinedRuntimeAttributes>
+                            <userDefinedRuntimeAttribute type="string" keyPath="styleName" value="Background"/>
+                        </userDefinedRuntimeAttributes>
                     </view>
                     <connections>
                         <outlet property="container" destination="EbW-Mp-c6s" id="T6K-0M-IAe"/>


### PR DESCRIPTION
- Fixed white background in the night theme when no search results are available in Downloader
- Fixed bad status bars and nav bars on iOS 15 (when compiling with Xcode 13)
- Simplified search field in Downloader (moved it onto the navbar)
- Fixed invalid constraints for download table cell

Протестить и можно релизить. Я бы конечно ещё таки доделал вопросик.