### PR TITLE
[core] Prioritize line features selection over area ones

### DIFF
--- a/map/framework.cpp
+++ b/map/framework.cpp
@@ -1916,7 +1916,7 @@ FeatureID Framework::GetFeatureAtPoint(m2::PointD const & mercator,
     }
   }, mercator);
 
-  return fullMatch.IsValid() ? fullMatch : (poi.IsValid() ? poi : (area.IsValid() ? area : line));
+  return fullMatch.IsValid() ? fullMatch : (poi.IsValid() ? poi : (line.IsValid() ? line : area));
 }
 
 osm::MapObject Framework::GetMapObjectByID(FeatureID const & fid) const


### PR DESCRIPTION
Needed-for: #1847

Works well so far.
Buildings still have a priority, so its not possible to select indoor-mapped foot paths etc. inside a building. Which is fine to my mind.
Need to add translation for some types that were previously not likely to be selected like aeroway-runway (inside of airport area).