### PR TITLE
Add datetime to My Position

### DIFF
--- a/android/jni/com/mapswithme/platform/Localization.cpp
+++ b/android/jni/com/mapswithme/platform/Localization.cpp
@@ -60,4 +60,15 @@ std::string GetCurrencySymbol(std::string const & currencyCode)
       env, env->CallStaticObjectMethod(g_utilsClazz, methodId, currencyCodeRef.get()));
   return jni::ToNativeString(env, static_cast<jstring>(localizedStrRef.get()));
 }
+
+std::string GetLocalizedMyPositionBookmarkName()
+{
+  JNIEnv * env = jni::GetEnv();
+  static auto const methodId = jni::GetStaticMethodID(env, g_utilsClazz, "getMyPositionBookmarkName",
+                                                      "(Landroid/content/Context;)Ljava/lang/String;");
+
+  jobject context = android::Platform::Instance().GetContext();
+  jni::TScopedLocalRef localizedStrRef(env, env->CallStaticObjectMethod(g_utilsClazz, methodId, context));
+  return jni::ToNativeString(env, static_cast<jstring>(localizedStrRef.get()));
+}
 }  // namespace platform

--- a/android/src/com/mapswithme/util/Utils.java
+++ b/android/src/com/mapswithme/util/Utils.java
@@ -11,6 +11,7 @@ import android.content.res.Resources;
 import android.net.Uri;
 import android.os.Build;
 import android.provider.Settings;
+import android.text.format.DateUtils;
 import android.text.SpannableStringBuilder;
 import android.text.Spanned;
 import android.text.TextUtils;
@@ -619,6 +620,19 @@ public class Utils
       LOGGER.e(TAG, "Failed to get value for string '" + key + "'", e);
     }
     return key;
+  }
+
+  /**
+   * Returns a name for a new bookmark created off the current GPS location.
+   * The name includes current time and date in locale-specific format.
+   *
+   * @return bookmark name with time and date.
+   */
+  @NonNull
+  public static String getMyPositionBookmarkName(@NonNull Context context)
+  {
+    return DateUtils.formatDateTime(context, System.currentTimeMillis(),
+                                    DateUtils.FORMAT_SHOW_TIME | DateUtils.FORMAT_SHOW_DATE | DateUtils.FORMAT_SHOW_YEAR);
   }
 
   @NonNull

--- a/data/strings/strings.txt
+++ b/data/strings/strings.txt
@@ -436,7 +436,7 @@
     zh-Hant = 英哩
 
   [core_my_position]
-    comment = View and button titles for accessibility
+    comment = A text for current gps location point/arrow selected on the map
     tags = android,ios
     en = My Position
     ar = موقعي

--- a/map/place_page_info.cpp
+++ b/map/place_page_info.cpp
@@ -14,6 +14,7 @@
 #include "platform/measurement_utils.hpp"
 #include "platform/preferred_languages.hpp"
 #include "platform/settings.hpp"
+#include "platform/localization.hpp"
 
 #include "base/assert.hpp"
 
@@ -261,7 +262,10 @@ kml::LocalizableString Info::FormatNewBookmarkName() const
   }
   else if (!m_uiTitle.empty())
   {
-    kml::SetDefaultStr(bookmarkName, m_uiTitle);
+    if (IsMyPosition())
+      kml::SetDefaultStr(bookmarkName, platform::GetLocalizedMyPositionBookmarkName());
+    else
+      kml::SetDefaultStr(bookmarkName, m_uiTitle);
   }
 
   return bookmarkName;

--- a/platform/localization.hpp
+++ b/platform/localization.hpp
@@ -14,6 +14,7 @@ extern std::string GetLocalizedTypeName(std::string const & type);
 extern std::string GetLocalizedBrandName(std::string const & brand);
 extern std::string GetLocalizedString(std::string const & key);
 extern std::string GetCurrencySymbol(std::string const & currencyCode);
+extern std::string GetLocalizedMyPositionBookmarkName();
 
 extern LocalizedUnits GetLocalizedDistanceUnits();
 extern LocalizedUnits GetLocalizedAltitudeUnits();

--- a/platform/localization.mm
+++ b/platform/localization.mm
@@ -36,4 +36,13 @@ std::string GetCurrencySymbol(std::string const & currencyCode)
 
   return [symbol UTF8String];
 }
+
+std::string GetLocalizedMyPositionBookmarkName()
+{
+  NSDateFormatter * dateFormatter = [[NSDateFormatter alloc] init];
+  dateFormatter.dateStyle = NSDateFormatterLongStyle;
+  dateFormatter.timeStyle = NSDateFormatterShortStyle;
+  NSDate * now = [NSDate date];
+  return [dateFormatter stringFromDate:now].UTF8String;
+}
 }  // namespace platform

--- a/platform/localization_dummy.cpp
+++ b/platform/localization_dummy.cpp
@@ -1,4 +1,5 @@
 #include "platform/localization.hpp"
+#include <ctime>
 
 namespace platform
 {
@@ -9,4 +10,12 @@ std::string GetLocalizedBrandName(std::string const & brand) { return brand; }
 std::string GetLocalizedString(std::string const & key) { return key; }
 
 std::string GetCurrencySymbol(std::string const & currencyCode) { return currencyCode; }
+
+std::string GetLocalizedMyPositionBookmarkName()
+{
+  std::time_t t = std::time(nullptr);
+  char buf[100] = {0};
+  (void)std::strftime(buf, sizeof(buf), "%Ec", std::localtime(&t));
+  return buf;
+}
 }  // namespace platform


### PR DESCRIPTION
See #1643

Current state:
![my_poisition](https://user-images.githubusercontent.com/18434508/149906845-e1dc874e-aa31-4f2e-a4fc-7967ce55bcb2.png)

However I realized it'll be confusing to the user to see a static time on the dynamic current location PP.
I think a better behavior will be to keep displaying "My Position" when the current location is selected and replace to "Me at ..." upon bookmark creation.

I need help in RD and codebase navigation though, otherwise it takes me tremendous time to find where things are...
Where bookmarks are created? So that I can inject datetime into bookmark's name if it was created from the current location.