### PR TITLE
[android] Remove space for icons in Settings

### DIFF
--- a/android/res/values-sw360dp-v13/values-preference.xml
+++ b/android/res/values-sw360dp-v13/values-preference.xml
@@ -1,4 +1,20 @@
 <?xml version="1.0" encoding="utf-8"?>
+<!--
+Items in the Preferences can have space reserved for an icon. As none of the
+settings currently have associated icons, this leads to items that seem indented
+without purpose. This wastes space and can lead to truncation of the item names
+and descriptions. See https://github.com/organicmaps/organicmaps/issues/1872
+
+To rectify this, the iconSpaceReserved property needs to be set to false.
+According to https://developer.android.com/reference/android/preference/Preference#attr_android:iconSpaceReserved
+false should be the default. However, according to
+https://material.io/design/platform-guidance/android-settings.html this goes
+against the material design guidelines and the default was overridden to true in
+https://cs.android.com/android/platform/superproject/+/android-9.0.0_r1:prebuilts/sdk/current/support/v7/preference/res/values-sw360dp-v13/values-sw360dp-v13.xml
+This file sets the default value back to false (i.e. no space reserved for icons).
+
+See also the discussion at https://github.com/organicmaps/organicmaps/pull/1924
+-->
 <resources>
   <bool name="config_materialPreferenceIconSpaceReserved">false</bool>
 </resources>

--- a/android/res/values-sw360dp-v13/values-preference.xml
+++ b/android/res/values-sw360dp-v13/values-preference.xml
@@ -1,0 +1,4 @@
+<?xml version="1.0" encoding="utf-8"?>
+<resources>
+  <bool name="config_materialPreferenceIconSpaceReserved">false</bool>
+</resources>


### PR DESCRIPTION
Override the the iconSpaceReserved property specified in [the Android sources](https://cs.android.com/android/platform/superproject/+/android-12.0.0_r4:prebuilts/sdk/current/support/v7/preference/res/values-sw360dp-v13/values-sw360dp-v13.xml) as none of the Settings items has an icon; hence the space is wasted and leads to the truncation of item names and descriptions. Inspired by https://stackoverflow.com/a/52960668.

Closes #1872 