### PR TITLE
Show application on lock screen

### DIFF
--- a/android/res/values-be/strings.xml
+++ b/android/res/values-be/strings.xml
@@ -661,6 +661,9 @@
 	<string name="enable_screen_sleep">Дазволіць экрану засынаць</string>
 	<!-- Description in preferences -->
 	<string name="enable_screen_sleep_description">Дазваляе экрану засынаць пасля перыяда бездзеяння.</string>
+	<string name="enable_show_on_lock_screen">Паказваць Organic Maps на экране блакіроўкі</string>
+	<!-- Description in preferences -->
+	<string name="enable_show_on_lock_screen_description">Калі ўключана, вам не трэба разблакіраваць прыладу кожны раз падчас працы дадатку.</string>
 
 	<!-- SECTION: Types -->
 	<!-- In most (European) countries, сemeteries are usually independent of places of worship (e.g. military cemeteries), while grave yards are usually the yard of a place of worship. -->

--- a/android/res/values-pl/strings.xml
+++ b/android/res/values-pl/strings.xml
@@ -655,6 +655,9 @@
 	<string name="enable_screen_sleep">Pozwól ekranowi spać</string>
 	<!-- Description in preferences -->
 	<string name="enable_screen_sleep_description">Po włączeniu ekran będzie mógł spać po okresie bezczynności.</string>
+	<string name="enable_show_on_lock_screen">Pokazuj aplikację na ekranie blokady</string>
+	<!-- Description in preferences -->
+	<string name="enable_show_on_lock_screen_description">Po włączeniu aplikacja będzie pokazana bez odblokowania telefonu.</string>
 
 	<!-- SECTION: Types -->
 	<string name="type.aerialway">Transport linowy</string>

--- a/android/res/values-pl/strings.xml
+++ b/android/res/values-pl/strings.xml
@@ -655,9 +655,9 @@
 	<string name="enable_screen_sleep">Pozwól ekranowi spać</string>
 	<!-- Description in preferences -->
 	<string name="enable_screen_sleep_description">Po włączeniu ekran będzie mógł spać po okresie bezczynności.</string>
-	<string name="enable_show_on_lock_screen">Pokazuj aplikację na ekranie blokady</string>
+	<string name="enable_show_on_lock_screen">Pokazuj Organic Maps na ekranie blokady</string>
 	<!-- Description in preferences -->
-	<string name="enable_show_on_lock_screen_description">Po włączeniu aplikacja będzie pokazana bez odblokowania telefonu.</string>
+	<string name="enable_show_on_lock_screen_description">Po włączeniu nie musisz odblokowywać urządzenia za każdym razem, gdy aplikacja jest uruchomiona.</string>
 
 	<!-- SECTION: Types -->
 	<string name="type.aerialway">Transport linowy</string>

--- a/android/res/values-ru/strings.xml
+++ b/android/res/values-ru/strings.xml
@@ -671,6 +671,9 @@
 	<string name="enable_screen_sleep">Разрешить экрану спать</string>
 	<!-- Description in preferences -->
 	<string name="enable_screen_sleep_description">При включении экран может переходить в спящий режим после периода бездействия.</string>
+	<string name="enable_show_on_lock_screen">Показывать Organic Maps на экране блокировки</string>
+	<!-- Description in preferences -->
+	<string name="enable_show_on_lock_screen_description">Если эта функция включена, вам не нужно каждый раз разблокировать устройство во время работы приложения.</string>
 
 	<!-- SECTION: Types -->
 	<string name="type.aerialway">Канатная дорога</string>

--- a/android/res/values-uk/strings.xml
+++ b/android/res/values-uk/strings.xml
@@ -652,6 +652,9 @@
 	<string name="enable_screen_sleep">Дозволити екрану вимкнутись</string>
 	<!-- Description in preferences -->
 	<string name="enable_screen_sleep_description">При включенні екран може переходити в сплячий режим після певного періоду бездіяльності</string>
+	<string name="enable_show_on_lock_screen">Показувати Organic Maps на заблокованому екрані</string>
+	<!-- Description in preferences -->
+	<string name="enable_show_on_lock_screen_description">Якщо ввімкнено, вам не потрібно щоразу розблоковувати пристрій під час роботи програми.</string>
 
 	<!-- SECTION: Types -->
 	<string name="type.aerialway">Канатна дорога</string>

--- a/android/res/values/donottranslate.xml
+++ b/android/res/values/donottranslate.xml
@@ -38,6 +38,7 @@
   <string name="pref_transliteration" translatable="false">Transliteration</string>
   <string name="pref_power_management" translatable="false">PowerManagment</string>
   <string name="pref_screen_sleep" translatable="false">ScreenSleep</string>
+  <string name="pref_show_on_lock_screen" translatable="false">ShowOnLockScreen</string>
 
   <string name="notification_ticker_ltr" translatable="false">%1$s: %2$s</string>
   <string name="notification_ticker_rtl" translatable="false">%2$s :%1$s</string>

--- a/android/res/values/strings.xml
+++ b/android/res/values/strings.xml
@@ -683,6 +683,9 @@
 	<string name="enable_screen_sleep">Allow screen to sleep</string>
 	<!-- Description in preferences -->
 	<string name="enable_screen_sleep_description">When enabled the screen will be allowed to sleep after a period of inactivity.</string>
+	<string name="enable_show_on_lock_screen">Show application on lock screen</string>
+	<!-- Description in preferences -->
+	<string name="enable_show_on_lock_screen_description">When enabled the application will be shown without phone unlocking.</string>
 
 	<!-- SECTION: Types -->
 	<string name="type.aerialway">Aerialway</string>

--- a/android/res/values/strings.xml
+++ b/android/res/values/strings.xml
@@ -683,9 +683,9 @@
 	<string name="enable_screen_sleep">Allow screen to sleep</string>
 	<!-- Description in preferences -->
 	<string name="enable_screen_sleep_description">When enabled the screen will be allowed to sleep after a period of inactivity.</string>
-	<string name="enable_show_on_lock_screen">Show application on lock screen</string>
+	<string name="enable_show_on_lock_screen">Show Organic Maps on the lock screen</string>
 	<!-- Description in preferences -->
-	<string name="enable_show_on_lock_screen_description">When enabled the application will be shown without phone unlocking.</string>
+	<string name="enable_show_on_lock_screen_description">When enabled, you don\'t need to unlock your device every time while the app is running.</string>
 
 	<!-- SECTION: Types -->
 	<string name="type.aerialway">Aerialway</string>

--- a/android/res/xml/prefs_main.xml
+++ b/android/res/xml/prefs_main.xml
@@ -76,6 +76,13 @@
       android:summary="@string/enable_screen_sleep_description"
       android:defaultValue="false"
       android:order="16"/>
+
+    <SwitchPreferenceCompat
+        android:key="@string/pref_show_on_lock_screen"
+        android:title="@string/enable_show_on_lock_screen"
+        android:summary="@string/enable_show_on_lock_screen_description"
+        android:defaultValue="false"
+        android:order="17"/>
   </androidx.preference.PreferenceCategory>
 
   <androidx.preference.PreferenceCategory

--- a/android/src/com/mapswithme/maps/base/BaseActivityDelegate.java
+++ b/android/src/com/mapswithme/maps/base/BaseActivityDelegate.java
@@ -9,6 +9,7 @@ import androidx.annotation.Nullable;
 
 import com.mapswithme.util.Config;
 import com.mapswithme.util.CrashlyticsUtils;
+import com.mapswithme.util.Utils;
 import com.mapswithme.util.ViewServer;
 import com.mapswithme.util.concurrency.UiThread;
 import com.mapswithme.util.log.Logger;
@@ -77,6 +78,7 @@ public class BaseActivityDelegate
   {
     logLifecycleMethod("onResume()");
     ViewServer.get(mActivity.get()).setFocusedWindow(mActivity.get());
+    Utils.showOnLockScreen(Config.isShowOnLockScreenEnabled(), mActivity.get());
   }
 
   public void onPause()

--- a/android/src/com/mapswithme/maps/settings/SettingsPrefsFragment.java
+++ b/android/src/com/mapswithme/maps/settings/SettingsPrefsFragment.java
@@ -319,6 +319,7 @@ public class SettingsPrefsFragment extends BaseXmlSettingsFragment
   {
     String key = getString(R.string.pref_speed_cameras);
     final ListPreference pref = findPreference(key);
+    // TODO: check whether it's needed #2049
     if (pref == null)
       return;
     pref.setSummary(pref.getEntry());
@@ -413,6 +414,7 @@ public class SettingsPrefsFragment extends BaseXmlSettingsFragment
   private void initLargeFontSizePrefsCallbacks()
   {
     Preference pref = findPreference(getString(R.string.pref_large_fonts_size));
+    // TODO: check whether it's needed #2049
     if (pref == null)
       return;
 
@@ -435,6 +437,7 @@ public class SettingsPrefsFragment extends BaseXmlSettingsFragment
   private void initTransliterationPrefsCallbacks()
   {
     Preference pref = findPreference(getString(R.string.pref_transliteration));
+    // TODO: check whether it's needed #2049
     if (pref == null)
       return;
 
@@ -503,6 +506,7 @@ public class SettingsPrefsFragment extends BaseXmlSettingsFragment
   private void initLoggingEnabledPrefsCallbacks()
   {
     Preference pref = findPreference(getString(R.string.pref_enable_logging));
+    // TODO: check whether it's needed #2049
     if (pref == null)
       return;
 
@@ -521,6 +525,7 @@ public class SettingsPrefsFragment extends BaseXmlSettingsFragment
   private void initEmulationBadStorage()
   {
     Preference pref = findPreference(getString(R.string.pref_emulate_bad_external_storage));
+    // TODO: check whether it's needed #2049
     if (pref == null)
       return;
 
@@ -531,6 +536,7 @@ public class SettingsPrefsFragment extends BaseXmlSettingsFragment
   private void initAutoZoomPrefsCallbacks()
   {
     final TwoStatePreference pref = findPreference(getString(R.string.pref_auto_zoom));
+    // TODO: check whether it's needed #2049
     if (pref == null)
       return;
 
@@ -550,6 +556,7 @@ public class SettingsPrefsFragment extends BaseXmlSettingsFragment
   private boolean initPlayServicesPrefsCallbacks()
   {
     Preference pref = findPreference(getString(R.string.pref_play_services));
+    // TODO: check whether it's needed #2049
     if (pref == null)
       return false;
 
@@ -583,6 +590,7 @@ public class SettingsPrefsFragment extends BaseXmlSettingsFragment
   private void init3dModePrefsCallbacks()
   {
     final TwoStatePreference pref = findPreference(getString(R.string.pref_3d_buildings));
+    // TODO: check whether it's needed #2049
     if (pref == null)
       return;
 
@@ -605,6 +613,7 @@ public class SettingsPrefsFragment extends BaseXmlSettingsFragment
   private void initPerspectivePrefsCallbacks()
   {
     final TwoStatePreference pref = findPreference(getString(R.string.pref_3d));
+    // TODO: check whether it's needed #2049
     if (pref == null)
       return;
 
@@ -627,6 +636,7 @@ public class SettingsPrefsFragment extends BaseXmlSettingsFragment
   private void initAutoDownloadPrefsCallbacks()
   {
     TwoStatePreference pref = findPreference(getString(R.string.pref_autodownload));
+    // TODO: check whether it's needed #2049
     if (pref == null)
       return;
 
@@ -650,6 +660,7 @@ public class SettingsPrefsFragment extends BaseXmlSettingsFragment
   private void initMapStylePrefsCallbacks()
   {
     final ListPreference pref = findPreference(getString(R.string.pref_map_style));
+    // TODO: check whether it's needed #2049
     if (pref == null)
       return;
 
@@ -677,6 +688,7 @@ public class SettingsPrefsFragment extends BaseXmlSettingsFragment
   private void initZoomPrefsCallbacks()
   {
     Preference pref = findPreference(getString(R.string.pref_show_zoom_buttons));
+    // TODO: check whether it's needed #2049
     if (pref == null)
       return;
 
@@ -695,6 +707,7 @@ public class SettingsPrefsFragment extends BaseXmlSettingsFragment
   private void initMeasureUnitsPrefsCallbacks()
   {
     Preference pref = findPreference(getString(R.string.pref_munits));
+    // TODO: check whether it's needed #2049
     if (pref == null)
       return;
 
@@ -740,6 +753,7 @@ public class SettingsPrefsFragment extends BaseXmlSettingsFragment
   {
     String key = getString(R.string.pref_crash_reports);
     Preference pref = findPreference(key);
+    // TODO: check whether it's needed #2049
     if (pref == null)
       return false;
 
@@ -757,6 +771,7 @@ public class SettingsPrefsFragment extends BaseXmlSettingsFragment
   private void initScreenSleepEnabledPrefsCallbacks()
   {
     Preference pref = findPreference(getString(R.string.pref_screen_sleep));
+    // TODO: check whether it's needed #2049
     if (pref == null)
       return;
 
@@ -776,6 +791,7 @@ public class SettingsPrefsFragment extends BaseXmlSettingsFragment
   private void initShowOnLockScreenPrefsCallbacks()
   {
     Preference pref = findPreference(getString(R.string.pref_show_on_lock_screen));
+    // TODO: check whether it's needed #2049
     if (pref == null)
       return;
 
@@ -797,6 +813,7 @@ public class SettingsPrefsFragment extends BaseXmlSettingsFragment
   private void removePreference(@NonNull String categoryKey, @NonNull Preference preference)
   {
     PreferenceCategory category = findPreference(categoryKey);
+    // TODO: check whether it's needed #2049
     if (category == null)
       return;
 

--- a/android/src/com/mapswithme/maps/settings/SettingsPrefsFragment.java
+++ b/android/src/com/mapswithme/maps/settings/SettingsPrefsFragment.java
@@ -311,6 +311,7 @@ public class SettingsPrefsFragment extends BaseXmlSettingsFragment
         mPreferenceScreen.removePreference(tracking);
     }
     initScreenSleepEnabledPrefsCallbacks();
+    initShowOnLockScreenPrefsCallbacks();
     updateTts();
   }
 
@@ -770,6 +771,27 @@ public class SettingsPrefsFragment extends BaseXmlSettingsFragment
             Utils.keepScreenOn(!newVal, getActivity().getWindow());
           return true;
         });
+  }
+
+  private void initShowOnLockScreenPrefsCallbacks()
+  {
+    Preference pref = findPreference(getString(R.string.pref_show_on_lock_screen));
+    if (pref == null)
+      return;
+
+    final boolean isShowOnLockScreenEnabled = Config.isShowOnLockScreenEnabled();
+    ((TwoStatePreference) pref).setChecked(isShowOnLockScreenEnabled);
+    pref.setOnPreferenceChangeListener(
+            (preference, newValue) ->
+            {
+              boolean newVal = (Boolean) newValue;
+              if (isShowOnLockScreenEnabled != newVal)
+              {
+                Config.setShowOnLockScreenEnabled(newVal);
+                Utils.showOnLockScreen(newVal, getActivity());
+              }
+              return true;
+            });
   }
 
   private void removePreference(@NonNull String categoryKey, @NonNull Preference preference)

--- a/android/src/com/mapswithme/util/Config.java
+++ b/android/src/com/mapswithme/util/Config.java
@@ -39,6 +39,7 @@ public final class Config
   private static final String KEY_MISC_USE_MOBILE_DATA_ROAMING = "UseMobileDataRoaming";
   private static final String KEY_MISC_AD_FORBIDDEN = "AdForbidden";
   private static final String KEY_MISC_ENABLE_SCREEN_SLEEP = "EnableScreenSleep";
+  private static final String KEY_MISC_SHOW_ON_LOCK_SCREEN = "ShowOnLockScreen";
 
   private Config() {}
 
@@ -184,6 +185,16 @@ public final class Config
   public static void setScreenSleepEnabled(boolean enabled)
   {
     setBool(KEY_MISC_ENABLE_SCREEN_SLEEP, enabled);
+  }
+
+  public static boolean isShowOnLockScreenEnabled()
+  {
+    return getBool(KEY_MISC_SHOW_ON_LOCK_SCREEN, false);
+  }
+
+  public static void setShowOnLockScreenEnabled(boolean enabled)
+  {
+    setBool(KEY_MISC_SHOW_ON_LOCK_SCREEN, enabled);
   }
 
   public static boolean useGoogleServices()

--- a/android/src/com/mapswithme/util/Utils.java
+++ b/android/src/com/mapswithme/util/Utils.java
@@ -18,6 +18,7 @@ import android.text.style.AbsoluteSizeSpan;
 import android.util.AndroidRuntimeException;
 import android.view.View;
 import android.view.Window;
+import android.view.WindowManager;
 import android.widget.TextView;
 import android.widget.Toast;
 
@@ -103,6 +104,16 @@ public class Utils
       w.addFlags(android.view.WindowManager.LayoutParams.FLAG_KEEP_SCREEN_ON);
     else
       w.clearFlags(android.view.WindowManager.LayoutParams.FLAG_KEEP_SCREEN_ON);
+  }
+
+  public static void showOnLockScreen(boolean enable, Activity activity)
+  {
+    if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.O_MR1)
+      activity.setShowWhenLocked(enable);
+    else if (enable)
+      activity.getWindow().addFlags(WindowManager.LayoutParams.FLAG_SHOW_WHEN_LOCKED);
+    else
+      activity.getWindow().clearFlags(WindowManager.LayoutParams.FLAG_SHOW_WHEN_LOCKED);
   }
 
   public static void showSnackbar(@NonNull View view, @NonNull String message)

--- a/data/strings/strings.txt
+++ b/data/strings/strings.txt
@@ -22003,14 +22003,20 @@
 
   [enable_show_on_lock_screen]
     tags = android
-    en = Show application on lock screen
-    pl = Pokazuj aplikację na ekranie blokady
+    en = Show Organic Maps on the lock screen
+    be = Паказваць Organic Maps на экране блакіроўкі
+    pl = Pokazuj Organic Maps na ekranie blokady
+    ru = Показывать Organic Maps на экране блокировки
+    uk = Показувати Organic Maps на заблокованому екрані
 
   [enable_show_on_lock_screen_description]
     tags = android
     comment = Description in preferences
-    en = When enabled the application will be shown without phone unlocking.
-    pl = Po włączeniu aplikacja będzie pokazana bez odblokowania telefonu.
+    en = When enabled, you don't need to unlock your device every time while the app is running.
+    be = Калі ўключана, вам не трэба разблакіраваць прыладу кожны раз падчас працы дадатку.
+    pl = Po włączeniu nie musisz odblokowywać urządzenia za każdym razem, gdy aplikacja jest uruchomiona.
+    ru = Если эта функция включена, вам не нужно каждый раз разблокировать устройство во время работы приложения.
+    uk = Якщо ввімкнено, вам не потрібно щоразу розблоковувати пристрій під час роботи програми.
 
   [whats_new_auto_update_title]
     comment = Autoupdate dialog on start

--- a/data/strings/strings.txt
+++ b/data/strings/strings.txt
@@ -22001,6 +22001,17 @@
     zh-Hans = 启用后，屏幕将在一段时间不活动后进入休眠状态。
     zh-Hant = 啟用後，螢幕將在一段時間不活動後進入休眠狀態。
 
+  [enable_show_on_lock_screen]
+    tags = android
+    en = Show application on lock screen
+    pl = Pokazuj aplikację na ekranie blokady
+
+  [enable_show_on_lock_screen_description]
+    tags = android
+    comment = Description in preferences
+    en = When enabled the application will be shown without phone unlocking.
+    pl = Po włączeniu aplikacja będzie pokazana bez odblokowania telefonu.
+
   [whats_new_auto_update_title]
     comment = Autoupdate dialog on start
     tags = ios


### PR DESCRIPTION
Allows to show app on lock screen, enabled in the settings.
Closes #558

For me it's useful while using a phone in navigation mode on a bicycle inside phone case/enclosure.

Description of steps in the video:
1. Settings shown -> `Show application on lock screen` disabled.
2. I click power button twice -> screen is turned off and then lock screen is shown.
3. I unlock the phone.
4. `Show application on lock screen` enabled.
5. I click power button twice -> screen blinks and instead of lock screen Organic Maps is shown.
6. I move the map a bit to show that it is possible to use the app.
7. I make a gesture to show home (equivalent to clicking middle onscreen button).
8. Lock screen now is shown (because I tried to switch to a different app than Organic Maps).

https://user-images.githubusercontent.com/2798728/152066003-0085a98f-45a1-4377-9abd-f77627e60b3f.mp4

