### PR TITLE
[routing] Bicycle model enhancements.

### DIFF
--- a/generator/routing_index_generator.cpp
+++ b/generator/routing_index_generator.cpp
@@ -542,6 +542,7 @@ void FillWeights(string const & path, string const & mwmFile, string const & cou
                                                            nullptr /* trafficStash */,
                                                            nullptr /* dataSource */,
                                                            nullptr /* numMvmIds */));
+  graph.SetCurrentTimeGetter([time = routing::GetCurrentTimestamp()] { return time; });
   DeserializeIndexGraph(mwmValue, routing::VehicleType::Car, graph);
 
   map<routing::Segment, map<routing::Segment, routing::RouteWeight>> weights;
@@ -561,8 +562,8 @@ void FillWeights(string const & path, string const & mwmFile, string const & cou
     Algorithm astar;
     IndexGraphWrapper indexGraphWrapper(graph, enter);
     DijkstraWrapperJoints wrapper(indexGraphWrapper, enter);
-    routing::AStarAlgorithm<routing::JointSegment, routing::JointEdge,
-                            routing::RouteWeight>::Context context(wrapper);
+    Algorithm::Context context(wrapper);
+
     unordered_map<uint32_t, vector<routing::JointSegment>> visitedVertexes;
     astar.PropagateWave(
         wrapper, wrapper.GetStartJoint(),
@@ -622,7 +623,6 @@ void FillWeights(string const & path, string const & mwmFile, string const & cou
           routing::Segment const & firstChild = jointSegment.GetSegment(true /* start */);
           uint32_t const lastPoint = exit.GetPointId(true /* front */);
 
-          static map<routing::JointSegment, routing::JointSegment> kEmptyParents;
           auto optionalEdge =  graph.GetJointEdgeByLastPoint(parentSegment, firstChild,
                                                              true /* isOutgoing */, lastPoint);
 

--- a/indexer/indexer_tests/categories_test.cpp
+++ b/indexer/indexer_tests/categories_test.cpp
@@ -315,7 +315,7 @@ UNIT_TEST(CategoriesIndex_AllCategories)
   index.AddAllCategoriesInAllLangs();
   // Consider deprecating this method if this bound rises as high as a million.
   LOG(LINFO, ("Number of nodes in the CategoriesIndex trie:", index.GetNumTrieNodes()));
-  TEST_LESS(index.GetNumTrieNodes(), 400000, ());
+  TEST_LESS(index.GetNumTrieNodes(), 450000, ());
 }
 #endif
 

--- a/routing/index_graph_loader.cpp
+++ b/routing/index_graph_loader.cpp
@@ -64,7 +64,7 @@ private:
   unordered_map<NumMwmId, map<SegmentCoord, vector<RouteSegment::SpeedCamera>>> m_cachedCameras;
   decltype(m_cachedCameras)::iterator ReceiveSpeedCamsFromMwm(NumMwmId numMwmId);
 
-  RoutingOptions m_avoidRoutingOptions = RoutingOptions();
+  RoutingOptions m_avoidRoutingOptions;
   std::function<time_t()> m_currentTimeGetter = [time = GetCurrentTimestamp()]() {
     return time;
   };

--- a/routing/index_router.cpp
+++ b/routing/index_router.cpp
@@ -954,12 +954,9 @@ RouterResultCode IndexRouter::AdjustRoute(Checkpoints const & checkpoints,
 
 unique_ptr<WorldGraph> IndexRouter::MakeWorldGraph()
 {
-  RoutingOptions routingOptions;
-  if (m_vehicleType == VehicleType::Car)
-  {
-    routingOptions = RoutingOptions::LoadCarOptionsFromSettings();
-    LOG(LINFO, ("Avoid next roads:", routingOptions));
-  }
+  // Use saved routing options for all types (car, bicycle, pedestrian).
+  RoutingOptions const routingOptions = RoutingOptions::LoadCarOptionsFromSettings();
+  LOG(LINFO, ("Avoid next roads:", routingOptions));
 
   auto crossMwmGraph = make_unique<CrossMwmGraph>(
       m_numMwmIds, m_numMwmTree, m_vehicleModelFactory,

--- a/routing/road_access.hpp
+++ b/routing/road_access.hpp
@@ -153,8 +153,8 @@ private:
   static std::optional<Confidence> GetConfidenceForAccessConditional(
       time_t momentInTime, osmoh::OpeningHours const & openingHours);
 
-  std::pair<Type, Confidence> GetAccess(uint32_t featureId, time_t momentInTime) const;
-  std::pair<Type, Confidence> GetAccess(RoadPoint const & point, time_t momentInTime) const;
+  std::pair<Type, Confidence> GetAccess(uint32_t featureId, double weight) const;
+  std::pair<Type, Confidence> GetAccess(RoadPoint const & point, double weight) const;
 
   std::function<time_t()> m_currentTimeGetter;
 

--- a/routing/single_vehicle_world_graph.hpp
+++ b/routing/single_vehicle_world_graph.hpp
@@ -129,7 +129,7 @@ private:
   std::unique_ptr<CrossMwmGraph> m_crossMwmGraph;
   std::unique_ptr<IndexGraphLoader> m_loader;
   std::shared_ptr<EdgeEstimator> m_estimator;
-  RoutingOptions m_avoidRoutingOptions = RoutingOptions();
+  RoutingOptions m_avoidRoutingOptions;
   WorldGraphMode m_mode = WorldGraphMode::NoLeaps;
 
   template <typename Vertex>

--- a/routing_common/bicycle_model.cpp
+++ b/routing_common/bicycle_model.cpp
@@ -49,7 +49,8 @@ HighwayBasedSpeeds const kDefaultSpeeds = {
     {HighwayType::HighwayCycleway, InOutCitySpeedKMpH(SpeedKMpH(30.0, 20.0))},
     {HighwayType::HighwayResidential, InOutCitySpeedKMpH(SpeedKMpH(8.0, 10.0))},
     {HighwayType::HighwayLivingStreet, InOutCitySpeedKMpH(SpeedKMpH(7.0, 8.0))},
-    {HighwayType::HighwaySteps, InOutCitySpeedKMpH(SpeedKMpH(1.0, 5.0))},
+    // Steps have obvious inconvenience of a bike in hands.
+    {HighwayType::HighwaySteps, InOutCitySpeedKMpH(SpeedKMpH(1.0, 1.0))},
     {HighwayType::HighwayPedestrian, InOutCitySpeedKMpH(SpeedKMpH(5.0))},
     {HighwayType::HighwayFootway, InOutCitySpeedKMpH(SpeedKMpH(7.0, 5.0))},
     {HighwayType::ManMadePier, InOutCitySpeedKMpH(SpeedKMpH(7.0))},
@@ -400,16 +401,33 @@ void BicycleModel::Init()
 {
   initializer_list<char const *> hwtagYesBicycle = {"hwtag", "yesbicycle"};
 
-  m_noBicycleType = classif().GetTypeByPath({"hwtag", "nobicycle"});
-  m_yesBicycleType = classif().GetTypeByPath(hwtagYesBicycle);
-  m_bidirBicycleType = classif().GetTypeByPath({"hwtag", "bidir_bicycle"});
-  m_onedirBicycleType = classif().GetTypeByPath({"hwtag", "onedir_bicycle"});
-  vector<AdditionalRoadTags> const additionalTags = {
-      {hwtagYesBicycle, m_maxModelSpeed},
-      {{"route", "ferry"}, bicycle_model::kDefaultSpeeds.at(HighwayType::RouteFerry)},
-      {{"man_made", "pier"}, bicycle_model::kDefaultSpeeds.at(HighwayType::ManMadePier)}};
+  auto const & cl = classif();
+  m_noBicycleType = cl.GetTypeByPath({"hwtag", "nobicycle"});
+  m_yesBicycleType = cl.GetTypeByPath(hwtagYesBicycle);
+  m_bidirBicycleType = cl.GetTypeByPath({"hwtag", "bidir_bicycle"});
+  m_onedirBicycleType = cl.GetTypeByPath({"hwtag", "onedir_bicycle"});
 
-  SetAdditionalRoadTypes(classif(), additionalTags);
+  {
+    vector<AdditionalRoadTags> const tags = {
+        {hwtagYesBicycle, m_maxModelSpeed},
+        {{"route", "ferry"}, bicycle_model::kDefaultSpeeds.at(HighwayType::RouteFerry)},
+        {{"man_made", "pier"}, bicycle_model::kDefaultSpeeds.at(HighwayType::ManMadePier)}};
+
+    AddAdditionalRoadTypes(cl, tags);
+  }
+
+  {
+    // Small dismount speed with obvious inconvenience of a bike in hands.
+    InOutCitySpeedKMpH const dismountSpeed(SpeedKMpH(2.0, 2.0));
+
+    vector<AdditionalRoadTags> const tags = {
+        {hwtagYesBicycle, m_maxModelSpeed},
+        {{"highway", "footway"}, dismountSpeed},
+        {{"highway", "pedestrian"}, dismountSpeed},
+        {{"highway", "steps"}, dismountSpeed}};
+
+    AddAdditionalRoadTypes(cl, tags);
+  }
 }
 
 VehicleModelInterface::RoadAvailability BicycleModel::GetRoadAvailability(feature::TypesHolder const & types) const

--- a/routing_common/car_model.cpp
+++ b/routing_common/car_model.cpp
@@ -178,7 +178,7 @@ void CarModel::Init()
   m_noCarType = classif().GetTypeByPath({"hwtag", "nocar"});
   m_yesCarType = classif().GetTypeByPath({"hwtag", "yescar"});
 
-  SetAdditionalRoadTypes(classif(), car_model::kAdditionalTags);
+  AddAdditionalRoadTypes(classif(), car_model::kAdditionalTags);
 }
 
 VehicleModelInterface::RoadAvailability CarModel::GetRoadAvailability(feature::TypesHolder const & types) const

--- a/routing_common/pedestrian_model.cpp
+++ b/routing_common/pedestrian_model.cpp
@@ -52,8 +52,9 @@ HighwayBasedSpeeds const kDefaultSpeeds = {
     {HighwayType::HighwaySteps, InOutCitySpeedKMpH(SpeedKMpH(3.0))},
     {HighwayType::HighwayPedestrian, InOutCitySpeedKMpH(SpeedKMpH(5.0))},
     {HighwayType::HighwayFootway, InOutCitySpeedKMpH(SpeedKMpH(5.0))},
-    {HighwayType::ManMadePier, InOutCitySpeedKMpH(SpeedKMpH(7.0))},
-    {HighwayType::RouteFerry, InOutCitySpeedKMpH(SpeedKMpH(1.0, 20.0))},
+    {HighwayType::ManMadePier, InOutCitySpeedKMpH(SpeedKMpH(5.0))},
+    /// @todo Set the same speed as a ferry for bicycle. At the same time, a car ferry has {10, 10}.
+    {HighwayType::RouteFerry, InOutCitySpeedKMpH(SpeedKMpH(3.0, 20.0))},
 };
 
 SpeedKMpH constexpr kSpeedOffroadKMpH = {3.0 /* weight */, 3.0 /* eta */};
@@ -300,7 +301,7 @@ void PedestrianModel::Init()
       {{"route", "ferry"}, pedestrian_model::kDefaultSpeeds.at(HighwayType::RouteFerry)},
       {{"man_made", "pier"}, pedestrian_model::kDefaultSpeeds.at(HighwayType::ManMadePier)}};
 
-  SetAdditionalRoadTypes(classif(), additionalTags);
+  AddAdditionalRoadTypes(classif(), additionalTags);
 }
 
 VehicleModelInterface::RoadAvailability PedestrianModel::GetRoadAvailability(feature::TypesHolder const & types) const

--- a/routing_common/vehicle_model.hpp
+++ b/routing_common/vehicle_model.hpp
@@ -284,13 +284,15 @@ public:
   VehicleModel(Classificator const & c, LimitsInitList const & featureTypeLimits,
                SurfaceInitList const & featureTypeSurface, HighwayBasedInfo const & info);
 
-  /// VehicleModelInterface overrides:
+  /// @name VehicleModelInterface overrides.
+  /// @{
   SpeedKMpH GetSpeed(FeatureType & f, SpeedParams const & speedParams) const override;
   HighwayType GetHighwayType(FeatureType & f) const override;
   double GetMaxWeightSpeed() const override;
   bool IsOneWay(FeatureType & f) const override;
   bool IsRoad(FeatureType & f) const override;
   bool IsPassThroughAllowed(FeatureType & f) const override;
+  /// @}
 
 public:
   /// @returns true if |m_highwayTypes| or |m_addRoadTypes| contains |type| and false otherwise.
@@ -318,8 +320,8 @@ protected:
   virtual RoadAvailability GetRoadAvailability(feature::TypesHolder const & types) const;
 
   /// Used in derived class constructors only. Not for public use.
-  void SetAdditionalRoadTypes(Classificator const & c,
-                              std::vector<AdditionalRoadTags> const & additionalTags);
+  using AdditionalTagsT = std::vector<AdditionalRoadTags>;
+  void AddAdditionalRoadTypes(Classificator const & c, AdditionalTagsT const & tags);
 
   static uint32_t PrepareToMatchType(uint32_t type);
 
@@ -343,12 +345,10 @@ protected:
 private:
   struct AdditionalRoadType final
   {
-    AdditionalRoadType(Classificator const & c, AdditionalRoadTags const & tag);
-
     bool operator==(AdditionalRoadType const & rhs) const { return m_type == rhs.m_type; }
 
-    uint32_t const m_type;
-    InOutCitySpeedKMpH const m_speed;
+    uint32_t m_type;
+    InOutCitySpeedKMpH m_speed;
   };
 
   class RoadType final
@@ -359,7 +359,7 @@ private:
     {
     }
 
-    bool IsPassThroughAllowed() const { return m_isPassThroughAllowed; };
+    bool IsPassThroughAllowed() const { return m_isPassThroughAllowed; }
     HighwayType GetHighwayType() const { return m_highwayType; }
     bool operator==(RoadType const & rhs) const
     {
@@ -396,6 +396,7 @@ private:
   // Note. It's an array (not map or unordered_map) because of perfomance reasons.
   std::array<TypeFactor, 4> m_surfaceFactors;
 
+  /// @todo Do we really need a separate vector of road types or can merge with the m_roadTypes map?
   std::vector<AdditionalRoadType> m_addRoadTypes;
   uint32_t m_onewayType;
 


### PR DESCRIPTION
Closes #1088
Closes #1739

Some issues from #1201 

Can make full test only after new data generation.

Sometimes current bicycle routing makes really strange routes, e.g. bicycle in Istanbul or Zurich via ferries is not working because of banned footways when entering/exit ferries. The idea behind that is to allow footways but with the small speed 2 km/h. So this approach will work for fast bicycle routes, but probably not good for cycling-only-based routes (who doesn't want to dismount).