### PR TITLE
[android] Show confirm dialog on back press while navigating

### DIFF
--- a/android/res/values/strings.xml
+++ b/android/res/values/strings.xml
@@ -463,6 +463,10 @@
 	<string name="current_location_unknown_message">Current location is unknown. Maybe you are in a building or in a tunnel.</string>
 	<string name="current_location_unknown_continue_button">Continue</string>
 	<string name="current_location_unknown_stop_button">Stop</string>
+	<string name="stop_navigation_title">Stop navigation?</string>
+	<string name="stop_navigation_message">Current route will be lost.</string>
+	<string name="stop_navigation_stop_button">Stop</string>
+	<string name="stop_navigation_cancel_button">Cancel</string>
 	<string name="meter">m</string>
 	<string name="kilometer">km</string>
 	<string name="kilometers_per_hour">km/h</string>

--- a/android/src/com/mapswithme/maps/MwmActivity.java
+++ b/android/src/com/mapswithme/maps/MwmActivity.java
@@ -1053,6 +1053,13 @@ public class MwmActivity extends BaseMwmFragmentActivity
       hideBookmarkCategoryToolbar();
       return;
     }
+
+    if (RoutingController.get().isNavigating())
+    {
+      showCancelNavigationDialog();
+      return;
+    }
+
     boolean isRoutingCancelled = RoutingController.get().cancel();
     if (!closePlacePage() && !closeSidePanel() && !isRoutingCancelled
         && !closePositionChooser())
@@ -1860,6 +1867,15 @@ public class MwmActivity extends BaseMwmFragmentActivity
         .setPositiveButton(R.string.current_location_unknown_continue_button, continueClickListener)
         .setCancelable(false)
         .show();
+  }
+
+  private void showCancelNavigationDialog()
+  {
+    new AlertDialog.Builder(this)
+            .setTitle(R.string.stop_navigation_title)
+            .setMessage(R.string.stop_navigation_message)
+            .setNegativeButton(R.string.stop_navigation_cancel_button, null)
+            .setPositiveButton(R.string.stop_navigation_stop_button, (dialog, which) -> RoutingController.get().cancel()).show();
   }
 
   @Override


### PR DESCRIPTION
Adds a confirm dialog when the user presses the Android back button while navigating. Pressing back again or the cancel button dismisses the dialog. Pressing stop cancels the navigation.

This PR adds 4 new untranslated strings. Was not really inspired so they might need some improvements.

![Screenshot_1643196589](https://user-images.githubusercontent.com/80701113/151155704-f09bf3d4-2c5f-455a-a431-e3fa2352e727.png)

Fixes #836 