### PR TITLE
Faster and locale-independent parser for double/float

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -41,3 +41,6 @@
 [submodule "3party/googletest"]
 	path = 3party/googletest
 	url = https://github.com/google/googletest.git
+[submodule "3party/fast_double_parser"]
+	path = 3party/fast_double_parser
+	url = https://github.com/lemire/fast_double_parser.git

--- a/base/CMakeLists.txt
+++ b/base/CMakeLists.txt
@@ -1,6 +1,8 @@
 project(base)
 
 set(SRC
+  # Added to automatically recompile our sources if the submodule is updated.
+  ../3party/fast_double_parser/include/fast_double_parser.h
   array_adapters.hpp
   assert.hpp
   atomic_shared_ptr.hpp


### PR DESCRIPTION
Faster double parsing with a fallback to our existing one, also closes #1659