### PR TITLE
Fixed non-working API on iOS and Android

### DIFF
--- a/iphone/Maps/Core/DeepLink/DeepLinkHandler.swift
+++ b/iphone/Maps/Core/DeepLink/DeepLinkHandler.swift
@@ -51,9 +51,9 @@
     LOG(.info, "handleDeepLink: \(url)")
 
     switch url.scheme {
-      // Process url scheme.
-      case "geo", "ge0", "om":
-        if (DeepLinkParser.showMap(for: url)) {
+      // Process old Maps.Me url schemes.
+      case "geo", "ge0":
+        if DeepLinkParser.showMap(for: url) {
           MapsAppDelegate.theApp().showMap()
           return true
         }
@@ -61,6 +61,14 @@
       case "file":
         DeepLinkParser.addBookmarksFile(url)
         return true  // We don't really know if async parsing was successful.
+      case  "om":
+        // It could be either a renamed ge0 link...
+        if DeepLinkParser.showMap(for: url) {
+          MapsAppDelegate.theApp().showMap()
+          return true
+        }
+        // ...or an API scheme.
+        fallthrough
       // API scheme.
       case "mapswithme", "mapsme", "mwm":
         let dlData = DeepLinkParser.parseAndSetApiURL(url)
@@ -76,7 +84,7 @@
             }
 
           case .map:
-            if (DeepLinkParser.showMap(for: url)) {
+            if DeepLinkParser.showMap(for: url) {
               MapsAppDelegate.theApp().showMap()
               return true
             }

--- a/map/framework.cpp
+++ b/map/framework.cpp
@@ -1760,8 +1760,21 @@ bool Framework::ShowMapForURL(string const & url)
   enum ResultT { FAILED, NEED_CLICK, NO_NEED_CLICK };
   ResultT result = FAILED;
 
-  if (strings::StartsWith(url, "om") || strings::StartsWith(url, "ge0"))
+  // It's an API request, parsed in parseAndSetApiURL and nativeParseAndSetApiUrl.
+  if (m_parsedMapApi.IsValid())
   {
+    if (!m_parsedMapApi.GetViewportParams(point, scale))
+    {
+      point = {0, 0};
+      scale = 0;
+    }
+
+    apiMark = m_parsedMapApi.GetSinglePoint();
+    result = apiMark ? NEED_CLICK : NO_NEED_CLICK;
+  }
+  else if (strings::StartsWith(url, "om") || strings::StartsWith(url, "ge0"))
+  {
+    // Note that om scheme is used to encode both API and ge0 links.
     ge0::Ge0Parser parser;
     ge0::Ge0Parser::Result parseResult;
 
@@ -1772,17 +1785,6 @@ bool Framework::ShowMapForURL(string const & url)
       name = move(parseResult.m_name);
       result = NEED_CLICK;
     }
-  }
-  else if (m_parsedMapApi.IsValid())
-  {
-    if (!m_parsedMapApi.GetViewportParams(point, scale))
-    {
-      point = {0, 0};
-      scale = 0;
-    }
-
-    apiMark = m_parsedMapApi.GetSinglePoint();
-    result = apiMark ? NEED_CLICK : NO_NEED_CLICK;
   }
   else  // Actually, we can parse any geo url scheme with correct coordinates.
   {


### PR DESCRIPTION
The problem was that before were separate URL schemes for ge0 and for API, now our om:// scheme supports both.

Use https://omaps.app/test for testing.