### PR TITLE
[android] Go back to planning state from navigation on system back button press

### DIFF
--- a/android/src/com/mapswithme/maps/MwmActivity.java
+++ b/android/src/com/mapswithme/maps/MwmActivity.java
@@ -1053,6 +1053,13 @@ public class MwmActivity extends BaseMwmFragmentActivity
       hideBookmarkCategoryToolbar();
       return;
     }
+
+    if (RoutingController.get().isNavigating())
+    {
+      RoutingController.get().resetToPlanningState();
+      return;
+    }
+
     boolean isRoutingCancelled = RoutingController.get().cancel();
     if (!closePlacePage() && !closeSidePanel() && !isRoutingCancelled
         && !closePositionChooser())
@@ -1672,6 +1679,12 @@ public class MwmActivity extends BaseMwmFragmentActivity
 
   @Override
   public void onRemovedStop()
+  {
+    closePlacePage();
+  }
+
+  @Override
+  public void onResetToPlanningState()
   {
     closePlacePage();
   }

--- a/android/src/com/mapswithme/maps/MwmActivity.java
+++ b/android/src/com/mapswithme/maps/MwmActivity.java
@@ -1054,15 +1054,19 @@ public class MwmActivity extends BaseMwmFragmentActivity
       return;
     }
 
-    if (RoutingController.get().isNavigating())
+    if (closePlacePage() || closeSidePanel() || closePositionChooser())
     {
-      RoutingController.get().resetToPlanningState();
       return;
     }
 
-    boolean isRoutingCancelled = RoutingController.get().cancel();
-    if (!closePlacePage() && !closeSidePanel() && !isRoutingCancelled
-        && !closePositionChooser())
+    RoutingController routingController = RoutingController.get();
+    if (routingController.isNavigating())
+    {
+      routingController.resetToPlanningState();
+      return;
+    }
+
+    if (!routingController.cancel())
     {
       try
       {

--- a/android/src/com/mapswithme/maps/routing/RoutingController.java
+++ b/android/src/com/mapswithme/maps/routing/RoutingController.java
@@ -67,6 +67,7 @@ public class RoutingController implements Initializable<Void>
     void onNavigationStarted();
     void onAddedStop();
     void onRemovedStop();
+    void onResetToPlanningState();
     void onBuiltRoute();
     void onDrivingOptionsWarning();
     boolean isSubwayEnabled();
@@ -518,6 +519,14 @@ public class RoutingController implements Initializable<Void>
     build();
     if (mContainer != null)
       mContainer.onRemovedStop();
+    backToPlaningStateIfNavigating();
+  }
+
+  public void resetToPlanningState()
+  {
+    build();
+    if (mContainer != null)
+      mContainer.onResetToPlanningState();
     backToPlaningStateIfNavigating();
   }
 


### PR DESCRIPTION
This PR changes the behavior of the Android back button while in navigation mode. Instead of stopping navigation without confirmation, it now brings the user back to the planning state and rebuilds the route with its new position. If any place detail bottom sheets are open, it first closes them. 

Here is a small demo showing this behavior (sorry for the black screen flashes):

https://user-images.githubusercontent.com/80701113/151960057-60d4e49c-c154-4083-a5bd-fabb9fce46cf.mp4



Fixes #836
Fixes #1946