### PR TITLE
[android] Simplify float toolbars and panels lifecycles

### DIFF
--- a/android/src/com/mapswithme/maps/MwmActivity.java
+++ b/android/src/com/mapswithme/maps/MwmActivity.java
@@ -1135,20 +1135,10 @@ public class MwmActivity extends BaseMwmFragmentActivity
       return;
     }
 
-    if (closeMenu() || closePlacePage() || closeSearchToolbar(true, true) ||
-            closeBookmarkCategoryToolbar() || closeSidePanel() || closePositionChooser())
-    {
-      return;
-    }
-
     RoutingController routingController = RoutingController.get();
-    if (routingController.isNavigating())
-    {
-      routingController.resetToPlanningState();
-      return;
-    }
-
-    if (!routingController.cancel())
+    if (!closeMenu() && !closePlacePage() && !closeSearchToolbar(true, true) &&
+            !closeBookmarkCategoryToolbar() && !closeSidePanel() && !closePositionChooser() &&
+            !routingController.resetToPlanningStateIfNavigating() && !routingController.cancel())
     {
       try
       {

--- a/android/src/com/mapswithme/maps/MwmActivity.java
+++ b/android/src/com/mapswithme/maps/MwmActivity.java
@@ -549,7 +549,7 @@ public class MwmActivity extends BaseMwmFragmentActivity
     if (!TextUtils.isEmpty(mSearchController.getQuery()))
     {
       // Close all panels and tool bars (including search) but do not stop search backend
-      closeFloatingToolbarsAndPanels(false, false);
+      closeFloatingToolbars(false, false);
       // Do not show the search tool bar if we are planning or navigating
       if (!RoutingController.get().isNavigating() && !RoutingController.get().isPlanning())
       {
@@ -564,7 +564,7 @@ public class MwmActivity extends BaseMwmFragmentActivity
 
   public void showPositionChooser(boolean isBusiness, boolean applyPosition)
   {
-    closeFloatingToolbarsAndPanels(false);
+    closeFloatingToolbarsAndPanels(false, true);
     UiUtils.show(mPositionChooser);
     setFullscreen(true);
     Framework.nativeTurnOnChoosePositionMode(isBusiness, applyPosition);
@@ -739,15 +739,20 @@ public class MwmActivity extends BaseMwmFragmentActivity
     return false;
   }
 
-  private void closeFloatingToolbarsAndPanels(boolean clearSearchText)
+  private void closeFloatingToolbarsAndPanels(boolean clearSearchText, boolean stopSearch)
   {
-    closeFloatingToolbarsAndPanels(clearSearchText, true);
+    closeFloatingPanels();
+    closeFloatingToolbars(clearSearchText, stopSearch);
   }
 
-  private void closeFloatingToolbarsAndPanels(boolean clearSearchText, boolean stopSearch)
+  private void closeFloatingPanels()
   {
     closeMenu();
     closePlacePage();
+  }
+
+  private void closeFloatingToolbars(boolean clearSearchText, boolean stopSearch)
+  {
     closeBookmarkCategoryToolbar();
     closePositionChooser();
     closeSearchToolbar(clearSearchText, stopSearch);
@@ -1586,7 +1591,6 @@ public class MwmActivity extends BaseMwmFragmentActivity
     Context context = getApplicationContext();
     if (show)
     {
-      closeFloatingToolbarsAndPanels(false, false);
       if (mIsTabletLayout)
       {
         replaceFragment(RoutingPlanFragment.class, null, completionListener);
@@ -1610,7 +1614,6 @@ public class MwmActivity extends BaseMwmFragmentActivity
     }
     else
     {
-      closeFloatingToolbarsAndPanels(true, true);
       if (mIsTabletLayout)
       {
         adjustCompassAndTraffic(UiUtils.getStatusBarHeight(getApplicationContext()));
@@ -1690,7 +1693,6 @@ public class MwmActivity extends BaseMwmFragmentActivity
       mOnmapDownloader.updateState(false);
     if (show)
     {
-      closeFloatingToolbarsAndPanels(false, false);
       if (mFilterController != null)
         mFilterController.show(false);
     }
@@ -1735,8 +1737,21 @@ public class MwmActivity extends BaseMwmFragmentActivity
   @Override
   public void onNavigationStarted()
   {
+    closeFloatingToolbarsAndPanels(true, true);
     ThemeSwitcher.INSTANCE.restart(isMapRendererActive());
     mNavigationController.start(this);
+  }
+
+  @Override
+  public void onPlanningCancelled()
+  {
+    closeFloatingToolbarsAndPanels(true, true);
+  }
+
+  @Override
+  public void onPlanningStarted()
+  {
+    closeFloatingToolbarsAndPanels(true, true);
   }
 
   @Override

--- a/android/src/com/mapswithme/maps/MwmActivity.java
+++ b/android/src/com/mapswithme/maps/MwmActivity.java
@@ -564,7 +564,7 @@ public class MwmActivity extends BaseMwmFragmentActivity
 
   public void showPositionChooser(boolean isBusiness, boolean applyPosition)
   {
-    closeFloatingToolbarsAndPanels(false, true);
+    closeFloatingToolbarsAndPanels(false);
     UiUtils.show(mPositionChooser);
     setFullscreen(true);
     Framework.nativeTurnOnChoosePositionMode(isBusiness, applyPosition);
@@ -641,6 +641,9 @@ public class MwmActivity extends BaseMwmFragmentActivity
     mToggleMapLayerController.attachCore();
   }
 
+  /**
+   * @return False if the place page was already closed, true otherwise
+   */
   public boolean closePlacePage()
   {
     if (mPlacePageController.isClosed())
@@ -650,6 +653,9 @@ public class MwmActivity extends BaseMwmFragmentActivity
     return true;
   }
 
+  /**
+   * @return False if the side panel was already closed, true otherwise
+   */
   public boolean closeSidePanel()
   {
     if (interceptBackPress())
@@ -678,6 +684,9 @@ public class MwmActivity extends BaseMwmFragmentActivity
     }
   }
 
+  /**
+   * @return False if the menu was already closed, true otherwise
+   */
   public boolean closeMenu()
   {
     if (!getMainMenuController().isClosed())
@@ -689,14 +698,21 @@ public class MwmActivity extends BaseMwmFragmentActivity
     return false;
   }
 
-  public boolean closeMenu(@Nullable Runnable procAfterClose)
+  /**
+   * Tries to close the main menu then runs the given runnable
+   *
+   * @param procAfterClose The runnable to run after closing the menu
+   */
+  public void closeMenu(@Nullable Runnable procAfterClose)
   {
-    boolean closed = closeMenu();
+    closeMenu();
     if (procAfterClose != null)
       procAfterClose.run();
-    return closed;
   }
 
+  /**
+   * @return False if the position chooser was already closed, true otherwise
+   */
   private boolean closePositionChooser()
   {
     if (UiUtils.isVisible(mPositionChooser))
@@ -707,6 +723,11 @@ public class MwmActivity extends BaseMwmFragmentActivity
     return false;
   }
 
+  /**
+   * @param clearText True to clear the search query
+   * @param stopSearch True to stop the search engine
+   * @return False if the search toolbar was already closed and the search query was empty, true otherwise
+   */
   private boolean closeSearchToolbar(boolean clearText, boolean stopSearch)
   {
     if (UiUtils.isVisible(mSearchController.getToolbar()) || !TextUtils.isEmpty(SearchEngine.INSTANCE.getQuery()))
@@ -729,20 +750,18 @@ public class MwmActivity extends BaseMwmFragmentActivity
     return false;
   }
 
-  private boolean closeBookmarkCategoryToolbar()
+  private void closeBookmarkCategoryToolbar()
   {
     if (UiUtils.isVisible(mBookmarkCategoryToolbar))
     {
       hideBookmarkCategoryToolbar();
-      return true;
     }
-    return false;
   }
 
-  private void closeFloatingToolbarsAndPanels(boolean clearSearchText, boolean stopSearch)
+  private void closeFloatingToolbarsAndPanels(boolean clearSearchText)
   {
     closeFloatingPanels();
-    closeFloatingToolbars(clearSearchText, stopSearch);
+    closeFloatingToolbars(clearSearchText, true);
   }
 
   private void closeFloatingPanels()
@@ -1725,7 +1744,7 @@ public class MwmActivity extends BaseMwmFragmentActivity
   @Override
   public void onNavigationCancelled()
   {
-    closeFloatingToolbarsAndPanels(true, true);
+    closeFloatingToolbarsAndPanels(true);
     ThemeSwitcher.INSTANCE.restart(isMapRendererActive());
     if (mRoutingPlanInplaceController == null)
       return;
@@ -1737,7 +1756,7 @@ public class MwmActivity extends BaseMwmFragmentActivity
   @Override
   public void onNavigationStarted()
   {
-    closeFloatingToolbarsAndPanels(true, true);
+    closeFloatingToolbarsAndPanels(true);
     ThemeSwitcher.INSTANCE.restart(isMapRendererActive());
     mNavigationController.start(this);
   }
@@ -1745,13 +1764,13 @@ public class MwmActivity extends BaseMwmFragmentActivity
   @Override
   public void onPlanningCancelled()
   {
-    closeFloatingToolbarsAndPanels(true, true);
+    closeFloatingToolbarsAndPanels(true);
   }
 
   @Override
   public void onPlanningStarted()
   {
-    closeFloatingToolbarsAndPanels(true, true);
+    closeFloatingToolbarsAndPanels(true);
   }
 
   @Override
@@ -2028,7 +2047,7 @@ public class MwmActivity extends BaseMwmFragmentActivity
   @Override
   public void onSearchUpClick(@Nullable String query)
   {
-    closeFloatingToolbarsAndPanels(true, true);
+    closeFloatingToolbarsAndPanels(true);
     showSearch(query);
   }
 

--- a/android/src/com/mapswithme/maps/MwmActivity.java
+++ b/android/src/com/mapswithme/maps/MwmActivity.java
@@ -1695,7 +1695,7 @@ public class MwmActivity extends BaseMwmFragmentActivity
       mOnmapDownloader.updateState(false);
     if (show)
     {
-      closeFloatingToolbarsAndPanels(true, true);
+      closeFloatingToolbarsAndPanels(true, false);
       if (mFilterController != null)
         mFilterController.show(false);
     }

--- a/android/src/com/mapswithme/maps/MwmActivity.java
+++ b/android/src/com/mapswithme/maps/MwmActivity.java
@@ -383,7 +383,7 @@ public class MwmActivity extends BaseMwmFragmentActivity
     args.putBoolean(DownloaderActivity.EXTRA_OPEN_DOWNLOADED, openDownloaded);
     if (mIsTabletLayout)
     {
-      closeSearchToolbar(false);
+      closeSearchToolbar(false, true);
       replaceFragment(DownloaderFragment.class, args, null);
     }
     else
@@ -558,7 +558,7 @@ public class MwmActivity extends BaseMwmFragmentActivity
     }
     else
     {
-      closeSearchToolbar(true);
+      closeSearchToolbar(true, true);
     }
   }
 
@@ -707,18 +707,14 @@ public class MwmActivity extends BaseMwmFragmentActivity
     return false;
   }
 
-  private boolean closeSearchToolbar(boolean clearText)
-  {
-    return closeSearchToolbar(clearText, true);
-  }
-
   private boolean closeSearchToolbar(boolean clearText, boolean stopSearch)
   {
-    if (UiUtils.isVisible(mSearchController.getToolbar()) || mSearchController.hasQuery())
+    if (UiUtils.isVisible(mSearchController.getToolbar()) || !TextUtils.isEmpty(SearchEngine.INSTANCE.getQuery()))
     {
       if (stopSearch)
       {
         mSearchController.cancelSearchApiAndHide(clearText);
+        mNavigationController.resetSearchWheel();
       }
       else
       {
@@ -1115,7 +1111,7 @@ public class MwmActivity extends BaseMwmFragmentActivity
       return;
     }
 
-    if (closeSearchToolbar(true))
+    if (closeSearchToolbar(true, true))
     {
       return;
     }
@@ -1627,7 +1623,6 @@ public class MwmActivity extends BaseMwmFragmentActivity
       }
 
       closeAllFloatingPanelsTablet();
-      mNavigationController.resetSearchWheel();
 
       if (completionListener != null)
         completionListener.run();
@@ -1695,7 +1690,7 @@ public class MwmActivity extends BaseMwmFragmentActivity
       mOnmapDownloader.updateState(false);
     if (show)
     {
-      closeFloatingToolbarsAndPanels(true, false);
+      closeFloatingToolbarsAndPanels(false, false);
       if (mFilterController != null)
         mFilterController.show(false);
     }
@@ -1768,7 +1763,7 @@ public class MwmActivity extends BaseMwmFragmentActivity
     if (!RoutingController.get().isPlanning())
       return;
 
-    mNavigationController.resetSearchWheel();
+    closeSearchToolbar(true, true);
   }
 
   @Override
@@ -1959,7 +1954,7 @@ public class MwmActivity extends BaseMwmFragmentActivity
   public void onSearchRoutePoint(@RoutePointInfo.RouteMarkType int pointType)
   {
     RoutingController.get().waitForPoiPick(pointType);
-    mNavigationController.resetSearchWheel();
+    closeSearchToolbar(true, true);
     showSearch("");
   }
 

--- a/android/src/com/mapswithme/maps/MwmActivity.java
+++ b/android/src/com/mapswithme/maps/MwmActivity.java
@@ -338,7 +338,7 @@ public class MwmActivity extends BaseMwmFragmentActivity
   {
     if (mIsTabletLayout)
     {
-      mSearchController.hide();
+      closeSearchToolbar(false, false);
 
       final Bundle args = new Bundle();
       args.putString(SearchActivity.EXTRA_QUERY, query);
@@ -467,10 +467,9 @@ public class MwmActivity extends BaseMwmFragmentActivity
   {
     if (item.getItemId() == R.id.close)
     {
-      hideBookmarkCategoryToolbar();
+      closeBookmarkCategoryToolbar();
       return true;
     }
-
     return false;
   }
 
@@ -530,11 +529,11 @@ public class MwmActivity extends BaseMwmFragmentActivity
     final Toolbar toolbar = mPositionChooser.findViewById(R.id.toolbar_position_chooser);
     UiUtils.extendViewWithStatusBar(toolbar);
     UiUtils.showHomeUpButton(toolbar);
-    toolbar.setNavigationOnClickListener(v -> hidePositionChooser());
+    toolbar.setNavigationOnClickListener(v -> closePositionChooser());
     mPositionChooser.findViewById(R.id.done).setOnClickListener(
         v ->
         {
-          hidePositionChooser();
+          closePositionChooser();
           if (Framework.nativeIsDownloadedMapAtScreenCenter())
             startActivity(new Intent(MwmActivity.this, FeatureCategoryActivity.class));
           else
@@ -808,7 +807,6 @@ public class MwmActivity extends BaseMwmFragmentActivity
     if (mIsTabletLayout)
     {
       mPanelAnimator = new PanelAnimator(this);
-      return;
     }
   }
 
@@ -915,7 +913,7 @@ public class MwmActivity extends BaseMwmFragmentActivity
   @Override
   public void toggleRouteSettings(@NonNull RoadType roadType)
   {
-    mPlacePageController.close(true);
+    closePlacePage();
     RoutingOptions.addOption(roadType);
     rebuildLastRouteInternal();
   }
@@ -1249,7 +1247,7 @@ public class MwmActivity extends BaseMwmFragmentActivity
     }
     else
     {
-      mPlacePageController.close(true);
+      closePlacePage();
     }
   }
 
@@ -1431,7 +1429,7 @@ public class MwmActivity extends BaseMwmFragmentActivity
     if (RoutingController.get().isNavigating())
     {
       mNavigationController.show(true);
-      mSearchController.hide();
+      closeSearchToolbar(false, false);
       mMainMenu.setState(MainMenu.State.NAVIGATION, mIsFullscreen);
       return;
     }
@@ -2107,7 +2105,7 @@ public class MwmActivity extends BaseMwmFragmentActivity
     UiUtils.setupNavigationIcon(mBookmarkCategoryToolbar, v -> {
       BookmarkCategoriesActivity.start(MwmActivity.this, category);
       closePlacePage();
-      hideBookmarkCategoryToolbar();
+      closeBookmarkCategoryToolbar();
     });
 
     showBookmarkCategoryToolbar();
@@ -2276,7 +2274,6 @@ public class MwmActivity extends BaseMwmFragmentActivity
     @Override
     public void onAddPlaceOptionSelected()
     {
-      closePlacePage();
       closeMenu(() -> showPositionChooser(false, false));
     }
 

--- a/android/src/com/mapswithme/maps/MwmActivity.java
+++ b/android/src/com/mapswithme/maps/MwmActivity.java
@@ -2022,13 +2022,13 @@ public class MwmActivity extends BaseMwmFragmentActivity
   @Override
   public void onSearchClearClick()
   {
-    closePlacePage();
+    closeSearchToolbar(true, true);
   }
 
   @Override
   public void onSearchUpClick(@Nullable String query)
   {
-    closePlacePage();
+    closeFloatingToolbarsAndPanels(true, true);
     showSearch(query);
   }
 

--- a/android/src/com/mapswithme/maps/MwmActivity.java
+++ b/android/src/com/mapswithme/maps/MwmActivity.java
@@ -750,12 +750,17 @@ public class MwmActivity extends BaseMwmFragmentActivity
     return false;
   }
 
-  private void closeBookmarkCategoryToolbar()
+  /**
+   * @return False if the bookmark category toolbar was already closed, true otherwise
+   */
+  private boolean closeBookmarkCategoryToolbar()
   {
     if (UiUtils.isVisible(mBookmarkCategoryToolbar))
     {
       hideBookmarkCategoryToolbar();
+      return true;
     }
+    return false;
   }
 
   private void closeFloatingToolbarsAndPanels(boolean clearSearchText)
@@ -1130,23 +1135,8 @@ public class MwmActivity extends BaseMwmFragmentActivity
       return;
     }
 
-    if (closeMenu())
-    {
-      return;
-    }
-
-    if (closeSearchToolbar(true, true))
-    {
-      return;
-    }
-
-    if (UiUtils.isVisible(mBookmarkCategoryToolbar) && mPlacePageController.isClosed())
-    {
-      hideBookmarkCategoryToolbar();
-      return;
-    }
-
-    if (closePlacePage() || closeSidePanel() || closePositionChooser())
+    if (closeMenu() || closePlacePage() || closeSearchToolbar(true, true) ||
+            closeBookmarkCategoryToolbar() || closeSidePanel() || closePositionChooser())
     {
       return;
     }

--- a/android/src/com/mapswithme/maps/routing/RoutingController.java
+++ b/android/src/com/mapswithme/maps/routing/RoutingController.java
@@ -514,12 +514,20 @@ public class RoutingController implements Initializable<Void>
     backToPlaningStateIfNavigating();
   }
 
-  public void resetToPlanningState()
+  /**
+   * @return False if not navigating, true otherwise
+   */
+  public boolean resetToPlanningStateIfNavigating()
   {
-    build();
-    if (mContainer != null)
-      mContainer.onResetToPlanningState();
-    backToPlaningStateIfNavigating();
+    if (isNavigating())
+    {
+      build();
+      if (mContainer != null)
+        mContainer.onResetToPlanningState();
+      backToPlaningStateIfNavigating();
+      return true;
+    }
+    return false;
   }
 
   private void backToPlaningStateIfNavigating()

--- a/android/src/com/mapswithme/maps/routing/RoutingController.java
+++ b/android/src/com/mapswithme/maps/routing/RoutingController.java
@@ -65,6 +65,8 @@ public class RoutingController implements Initializable<Void>
     void updateMenu();
     void onNavigationCancelled();
     void onNavigationStarted();
+    void onPlanningCancelled();
+    void onPlanningStarted();
     void onAddedStop();
     void onRemovedStop();
     void onResetToPlanningState();
@@ -249,15 +251,20 @@ public class RoutingController implements Initializable<Void>
 
   private void showRoutePlan()
   {
+    showRoutePlan(null, null);
+  }
+
+  private void showRoutePlan(final @Nullable MapObject startPoint, final @Nullable MapObject endPoint)
+  {
     if (mContainer != null)
-      mContainer.showRoutePlan(true, new Runnable()
-      {
-        @Override
-        public void run()
-        {
+    {
+      mContainer.showRoutePlan(true, () -> {
+        if (startPoint == null || endPoint == null)
           updatePlan();
-        }
+        else
+          build();
       });
+    }
   }
 
   public void attach(@NonNull Container container)
@@ -456,18 +463,7 @@ public class RoutingController implements Initializable<Void>
     if (startPoint != null || endPoint != null)
       setPointsInternal(startPoint, endPoint);
 
-    if (mContainer != null)
-      mContainer.showRoutePlan(true, new Runnable()
-      {
-        @Override
-        public void run()
-        {
-          if (startPoint == null || endPoint == null)
-            updatePlan();
-          else
-            build();
-        }
-      });
+    startPlanning(startPoint, endPoint);
   }
 
   public void start()
@@ -488,12 +484,8 @@ public class RoutingController implements Initializable<Void>
 
     setState(State.NAVIGATION);
 
-    if (mContainer != null)
-    {
-      mContainer.showRoutePlan(false, null);
-      mContainer.showNavigation(true);
-      mContainer.onNavigationStarted();
-    }
+    cancelPlanning();
+    startNavigation();
 
     Framework.nativeFollowRoute();
     LocationHelper.INSTANCE.restart();
@@ -536,12 +528,11 @@ public class RoutingController implements Initializable<Void>
       return;
 
     setState(State.PREPARE);
+    cancelNavigation();
+    startPlanning();
     if (mContainer != null)
     {
-      mContainer.showNavigation(false);
-      mContainer.showRoutePlan(true, null);
       mContainer.updateMenu();
-      mContainer.onNavigationCancelled();
     }
   }
 
@@ -638,8 +629,7 @@ public class RoutingController implements Initializable<Void>
       mLogger.d(TAG, "cancel: planning");
 
       cancelInternal();
-      if (mContainer != null)
-        mContainer.showRoutePlan(false, null);
+      cancelPlanning();
       return true;
     }
 
@@ -648,18 +638,61 @@ public class RoutingController implements Initializable<Void>
       mLogger.d(TAG, "cancel: navigating");
 
       cancelInternal();
+      cancelNavigation();
       if (mContainer != null)
       {
-        mContainer.showNavigation(false);
         mContainer.updateMenu();
       }
-      if (mContainer != null)
-        mContainer.onNavigationCancelled();
       return true;
     }
 
     mLogger.d(TAG, "cancel: none");
     return false;
+  }
+
+  public void startPlanning()
+  {
+    if (mContainer != null)
+    {
+      showRoutePlan();
+      mContainer.onPlanningStarted();
+    }
+  }
+
+  public void startPlanning(final @Nullable MapObject startPoint, final @Nullable MapObject endPoint)
+  {
+    if (mContainer != null)
+    {
+      showRoutePlan(startPoint, endPoint);
+      mContainer.onPlanningStarted();
+    }
+  }
+
+  public void cancelPlanning()
+  {
+    if (mContainer != null)
+    {
+      mContainer.showRoutePlan(false, null);
+      mContainer.onPlanningCancelled();
+    }
+  }
+
+  public void startNavigation()
+  {
+    if (mContainer != null)
+    {
+      mContainer.showNavigation(true);
+      mContainer.onNavigationStarted();
+    }
+  }
+
+  public void cancelNavigation()
+  {
+    if (mContainer != null)
+    {
+      mContainer.showNavigation(false);
+      mContainer.onNavigationCancelled();
+    }
   }
 
   public boolean isPlanning()

--- a/android/src/com/mapswithme/maps/routing/SearchWheel.java
+++ b/android/src/com/mapswithme/maps/routing/SearchWheel.java
@@ -236,10 +236,7 @@ class SearchWheel implements View.OnClickListener
 
       if (mCurrentOption != null || !TextUtils.isEmpty(SearchEngine.INSTANCE.getQuery()))
       {
-        SearchEngine.INSTANCE.cancelInteractiveSearch();
-        mCurrentOption = null;
-        mIsExpanded = false;
-        resetSearchButtonImage();
+        reset();
         refreshSearchVisibility();
         return;
       }
@@ -284,8 +281,8 @@ class SearchWheel implements View.OnClickListener
     mCurrentOption = searchOption;
     final String query = mFrame.getContext().getString(searchOption.mQueryId);
     SearchEngine.INSTANCE.searchInteractive(mFrame.getContext(), query, System.nanoTime(), false /* isMapAndTable */);
+    SearchEngine.INSTANCE.setQuery(query);
     refreshSearchButtonImage();
-
     toggleSearchLayout();
   }
 }

--- a/android/src/com/mapswithme/maps/search/FloatingSearchToolbarController.java
+++ b/android/src/com/mapswithme/maps/search/FloatingSearchToolbarController.java
@@ -55,32 +55,16 @@ public class FloatingSearchToolbarController extends SearchToolbarController
     cancelSearchApiAndHide(false);
   }
 
-  public void refreshToolbar()
+  public void refreshQuery()
   {
     showProgress(false);
+    CharSequence query = ParsedMwmRequest.hasRequest() ?
+            ParsedMwmRequest.getCurrentRequest().getTitle()
+            : SearchEngine.INSTANCE.getQuery();
 
-    if (ParsedMwmRequest.hasRequest())
+    if (!TextUtils.isEmpty(query))
     {
-      UiUtils.show(getToolbar());
-
-      if (mVisibilityListener != null)
-        mVisibilityListener.onSearchVisibilityChanged(true);
-
-      setQuery(ParsedMwmRequest.getCurrentRequest().getTitle());
-    }
-    else if (!TextUtils.isEmpty(SearchEngine.INSTANCE.getQuery()))
-    {
-      UiUtils.show(getToolbar());
-
-      if (mVisibilityListener != null)
-        mVisibilityListener.onSearchVisibilityChanged(true);
-
-      setQuery(SearchEngine.INSTANCE.getQuery());
-    }
-    else
-    {
-      hide();
-      clear();
+      setQuery(query);
     }
   }
 
@@ -92,6 +76,13 @@ public class FloatingSearchToolbarController extends SearchToolbarController
       clear();
 
     hide();
+  }
+
+  public void show()
+  {
+    UiUtils.show(getToolbar());
+    if (mVisibilityListener != null)
+      mVisibilityListener.onSearchVisibilityChanged(true);
   }
 
   public boolean hide()

--- a/android/src/com/mapswithme/maps/search/FloatingSearchToolbarController.java
+++ b/android/src/com/mapswithme/maps/search/FloatingSearchToolbarController.java
@@ -34,7 +34,6 @@ public class FloatingSearchToolbarController extends SearchToolbarController
   {
     if (mListener != null)
       mListener.onSearchUpClick(getQuery());
-    cancelSearchApiAndHide(true);
   }
 
   @Override
@@ -52,7 +51,6 @@ public class FloatingSearchToolbarController extends SearchToolbarController
     super.onClearClick();
     if (mListener != null)
       mListener.onSearchClearClick();
-    cancelSearchApiAndHide(false);
   }
 
   public void refreshQuery()


### PR DESCRIPTION
This PR tries to make showing and closing floating panels/toolbars easier. It encapsulates show and close functions in `MwmActivity` for easier management. It essentially adds functions to close all floating panels, called before showing a new one to ensure only one is shown at the same time.

I did not find any bugs from the simple testing I did, but it might require some more with different scenarios (especially on tablet).

Fixes #2005