### PR TITLE
[android] Fix links verification on Android 12

### DIFF
--- a/android/AndroidManifest.xml
+++ b/android/AndroidManifest.xml
@@ -97,7 +97,7 @@
         <data android:scheme="https"/>
       </intent-filter>
 
-      <intent-filter>
+      <intent-filter android:autoVerify="@bool/autoVerify">
         <action android:name="android.intent.action.VIEW"/>
 
         <category android:name="android.intent.category.DEFAULT"/>

--- a/android/res/values-v31/autoverify.xml
+++ b/android/res/values-v31/autoverify.xml
@@ -1,0 +1,4 @@
+<?xml version="1.0" encoding="utf-8"?>
+<resources>
+  <bool name="autoVerify">true</bool>
+</resources>

--- a/android/res/values/autoverify.xml
+++ b/android/res/values/autoverify.xml
@@ -1,0 +1,4 @@
+<?xml version="1.0" encoding="utf-8"?>
+<resources>
+  <bool name="autoVerify">false</bool>
+</resources>


### PR DESCRIPTION
See also 6b3313e "Disable non-working links verification"

Use the following command to check:

```
adb shell pm get-app-links app.organicmaps.debug
```

Expected output:
```
  app.organicmaps.debug:
    ID: 42334759-b298-4b82-a9ce-4cae78320426
    Signatures: [96:D6:28:81:78:B0:1B:86:9B:D3:FF:BF:95:B3:3B:EE:DE:23:01:68:DF:88:2A:1D:7A:4B:B2:8B:85:34:59:F4]
    Domain verification state:
      omaps.app: verified <!-- HERE
```

Signed-off-by: Roman Tsisyk <roman@tsisyk.com>