### PR TITLE
Enable Show on lock screen by default and improve prefs titles display

### DIFF
--- a/android/res/values-be/strings.xml
+++ b/android/res/values-be/strings.xml
@@ -670,7 +670,8 @@
 	<string name="enable_screen_sleep">Дазволіць экрану засынаць</string>
 	<!-- Description in preferences -->
 	<string name="enable_screen_sleep_description">Дазваляе экрану засынаць пасля перыяда бездзеяння.</string>
-	<string name="enable_show_on_lock_screen">Паказваць Organic Maps на экране блакіроўкі</string>
+	<!-- A preference title; keep short! -->
+	<string name="enable_show_on_lock_screen">Паказваць на экране блакіроўкі</string>
 	<!-- Description in preferences -->
 	<string name="enable_show_on_lock_screen_description">Калі ўключана, вам не трэба разблакіраваць прыладу кожны раз падчас працы дадатку.</string>
 

--- a/android/res/values-pl/strings.xml
+++ b/android/res/values-pl/strings.xml
@@ -662,7 +662,8 @@
 	<string name="enable_screen_sleep">Pozwól ekranowi spać</string>
 	<!-- Description in preferences -->
 	<string name="enable_screen_sleep_description">Po włączeniu ekran będzie mógł spać po okresie bezczynności.</string>
-	<string name="enable_show_on_lock_screen">Pokazuj Organic Maps na ekranie blokady</string>
+	<!-- A preference title; keep short! -->
+	<string name="enable_show_on_lock_screen">Pokazuj na ekranie blokady</string>
 	<!-- Description in preferences -->
 	<string name="enable_show_on_lock_screen_description">Po włączeniu nie musisz odblokowywać urządzenia za każdym razem, gdy aplikacja jest uruchomiona.</string>
 

--- a/android/res/values-ru/strings.xml
+++ b/android/res/values-ru/strings.xml
@@ -680,7 +680,8 @@
 	<string name="enable_screen_sleep">Разрешить экрану спать</string>
 	<!-- Description in preferences -->
 	<string name="enable_screen_sleep_description">При включении экран может переходить в спящий режим после периода бездействия.</string>
-	<string name="enable_show_on_lock_screen">Показывать Organic Maps на экране блокировки</string>
+	<!-- A preference title; keep short! -->
+	<string name="enable_show_on_lock_screen">Показывать на экране блокировки</string>
 	<!-- Description in preferences -->
 	<string name="enable_show_on_lock_screen_description">Если эта функция включена, вам не нужно каждый раз разблокировать устройство во время работы приложения.</string>
 

--- a/android/res/values-uk/strings.xml
+++ b/android/res/values-uk/strings.xml
@@ -663,7 +663,8 @@
 	<string name="enable_screen_sleep">Дозволити екрану вимкнутись</string>
 	<!-- Description in preferences -->
 	<string name="enable_screen_sleep_description">При включенні екран може переходити в сплячий режим після певного періоду бездіяльності</string>
-	<string name="enable_show_on_lock_screen">Показувати Organic Maps на заблокованому екрані</string>
+	<!-- A preference title; keep short! -->
+	<string name="enable_show_on_lock_screen">Показувати на заблокованому екрані</string>
 	<!-- Description in preferences -->
 	<string name="enable_show_on_lock_screen_description">Якщо ввімкнено, вам не потрібно щоразу розблоковувати пристрій під час роботи програми.</string>
 

--- a/android/res/values/strings.xml
+++ b/android/res/values/strings.xml
@@ -694,7 +694,8 @@
 	<string name="enable_screen_sleep">Allow screen to sleep</string>
 	<!-- Description in preferences -->
 	<string name="enable_screen_sleep_description">When enabled the screen will be allowed to sleep after a period of inactivity.</string>
-	<string name="enable_show_on_lock_screen">Show Organic Maps on the lock screen</string>
+	<!-- A preference title; keep short! -->
+	<string name="enable_show_on_lock_screen">Show on the lock screen</string>
 	<!-- Description in preferences -->
 	<string name="enable_show_on_lock_screen_description">When enabled, you don\'t need to unlock your device every time while the app is running.</string>
 

--- a/android/res/xml/prefs_main.xml
+++ b/android/res/xml/prefs_main.xml
@@ -1,10 +1,12 @@
 <?xml version="1.0" encoding="utf-8"?>
 <androidx.preference.PreferenceScreen
-  xmlns:android="http://schemas.android.com/apk/res/android">
+  xmlns:android="http://schemas.android.com/apk/res/android"
+  xmlns:app="http://schemas.android.com/apk/res-auto">
 
   <Preference
     android:key="@string/pref_osm_profile"
     android:title="@string/profile"
+    app:singleLineTitle="false"
     android:order="1"/>
   <androidx.preference.PreferenceCategory
     android:key="@string/pref_settings_general"
@@ -13,6 +15,7 @@
     <ListPreference
       android:key="@string/pref_munits"
       android:title="@string/measurement_units"
+      app:singleLineTitle="false"
       android:summary="@string/measurement_units_summary"
       android:entries="@array/measument_units"
       android:entryValues="@array/measument_units_values"
@@ -20,45 +23,54 @@
     <SwitchPreferenceCompat
       android:key="@string/pref_show_zoom_buttons"
       android:title="@string/pref_zoom_title"
+      app:singleLineTitle="false"
       android:summary="@string/pref_zoom_summary"
       android:order="2"/>
     <SwitchPreferenceCompat
       android:key="@string/pref_3d_buildings"
       android:title="@string/pref_map_3d_buildings_title"
+      app:singleLineTitle="false"
       android:order="3"/>
     <SwitchPreferenceCompat
       android:key="@string/pref_autodownload"
       android:title="@string/autodownload"
+      app:singleLineTitle="false"
       android:order="4"/>
     <SwitchPreferenceCompat
       android:key="@string/pref_large_fonts_size"
       android:title="@string/big_font"
+      app:singleLineTitle="false"
       android:defaultValue="false"
       android:order="6"/>
     <SwitchPreferenceCompat
       android:key="@string/pref_transliteration"
       android:title="@string/transliteration_title"
+      app:singleLineTitle="false"
       android:defaultValue="false"
       android:order="7"/>
     <Preference
       android:key="@string/pref_storage"
       android:title="@string/maps_storage"
+      app:singleLineTitle="false"
       android:summary="@string/maps_storage_summary"
       android:order="8"/>
     <SwitchPreferenceCompat
       android:key="@string/pref_enable_logging"
       android:title="@string/enable_logging"
+      app:singleLineTitle="false"
       android:summary="@string/enable_logging_warning_message"
       android:defaultValue="false"
       android:order="12"/>
     <SwitchPreferenceCompat
       android:key="@string/pref_emulate_bad_external_storage"
       android:title="@string/setting_emulate_bad_storage"
+      app:singleLineTitle="false"
       android:defaultValue="false"
       android:order="13"/>
     <ListPreference
       android:key="@string/pref_use_mobile_data"
       android:title="@string/mobile_data"
+      app:singleLineTitle="false"
       android:summary="@string/mobile_data_description"
       android:entries="@array/mobile_data_options"
       android:entryValues="@array/mobile_data_options_values"
@@ -66,6 +78,7 @@
     <ListPreference
       android:key="@string/pref_power_management"
       android:title="@string/power_managment_title"
+      app:singleLineTitle="false"
       android:summary="@string/power_managment_description"
       android:entries="@array/power_management_scheme"
       android:entryValues="@array/power_management_scheme_values"
@@ -73,16 +86,17 @@
     <SwitchPreferenceCompat
       android:key="@string/pref_screen_sleep"
       android:title="@string/enable_screen_sleep"
+      app:singleLineTitle="false"
       android:summary="@string/enable_screen_sleep_description"
       android:defaultValue="false"
       android:order="16"/>
-
     <SwitchPreferenceCompat
-        android:key="@string/pref_show_on_lock_screen"
-        android:title="@string/enable_show_on_lock_screen"
-        android:summary="@string/enable_show_on_lock_screen_description"
-        android:defaultValue="true"
-        android:order="17"/>
+      android:key="@string/pref_show_on_lock_screen"
+      android:title="@string/enable_show_on_lock_screen"
+      app:singleLineTitle="false"
+      android:summary="@string/enable_show_on_lock_screen_description"
+      android:defaultValue="true"
+      android:order="17"/>
   </androidx.preference.PreferenceCategory>
 
   <androidx.preference.PreferenceCategory
@@ -92,29 +106,35 @@
     <ListPreference
       android:key="@string/pref_map_style"
       android:title="@string/pref_map_style_title"
+      app:singleLineTitle="false"
       android:entries="@array/map_style"
       android:entryValues="@array/map_style_values"
       android:order="1"/>
     <SwitchPreferenceCompat
       android:key="@string/pref_3d"
       android:title="@string/pref_map_3d_title"
+      app:singleLineTitle="false"
       android:order="2"/>
     <SwitchPreferenceCompat
       android:key="@string/pref_auto_zoom"
       android:title="@string/pref_map_auto_zoom"
+      app:singleLineTitle="false"
       android:order="3"/>
     <androidx.preference.PreferenceScreen
       android:key="@string/pref_tts_screen"
       android:title="@string/pref_tts_enable_title"
+      app:singleLineTitle="false"
       android:persistent="false"
       android:order="4">
       <SwitchPreferenceCompat
         android:key="@string/pref_tts_enabled"
         android:title="@string/pref_tts_enable_title"
+        app:singleLineTitle="false"
         android:order="1"/>
       <ListPreference
         android:key="@string/pref_tts_language"
         android:title="@string/pref_tts_language_title"
+        app:singleLineTitle="false"
         android:order="2"/>
       <Preference
         android:key="@string/pref_tts_info"
@@ -134,6 +154,7 @@
     <ListPreference
       android:key="@string/pref_speed_cameras"
       android:title="@string/speedcams_alert_title"
+      app:singleLineTitle="false"
       android:entries="@array/speed_cameras"
       android:entryValues="@array/speed_cameras_values"
       android:defaultValue="@string/auto_enum_value"
@@ -155,6 +176,7 @@
     <SwitchPreferenceCompat
       android:key="@string/pref_play_services"
       android:title="Google Play Services"
+      app:singleLineTitle="false"
       android:summary="@string/pref_use_google_play"
       android:defaultValue="true"
       android:order="1"/>
@@ -162,6 +184,7 @@
       android:key="@string/pref_crash_reports"
       android:defaultValue="true"
       android:title="@string/crash_reports"
+      app:singleLineTitle="false"
       android:summary="@string/crash_reports_description"
       android:order="2"/>
   </androidx.preference.PreferenceCategory>
@@ -172,6 +195,7 @@
     <Preference
       android:key="@string/pref_help"
       android:title="@string/help"
+      app:singleLineTitle="false"
       android:order="1">
     </Preference>
   </androidx.preference.PreferenceCategory>

--- a/android/res/xml/prefs_main.xml
+++ b/android/res/xml/prefs_main.xml
@@ -81,7 +81,7 @@
         android:key="@string/pref_show_on_lock_screen"
         android:title="@string/enable_show_on_lock_screen"
         android:summary="@string/enable_show_on_lock_screen_description"
-        android:defaultValue="false"
+        android:defaultValue="true"
         android:order="17"/>
   </androidx.preference.PreferenceCategory>
 

--- a/android/src/com/mapswithme/util/Config.java
+++ b/android/src/com/mapswithme/util/Config.java
@@ -189,7 +189,7 @@ public final class Config
 
   public static boolean isShowOnLockScreenEnabled()
   {
-    return getBool(KEY_MISC_SHOW_ON_LOCK_SCREEN, false);
+    return getBool(KEY_MISC_SHOW_ON_LOCK_SCREEN, true);
   }
 
   public static void setShowOnLockScreenEnabled(boolean enabled)

--- a/data/strings/strings.txt
+++ b/data/strings/strings.txt
@@ -21761,11 +21761,12 @@
 
   [enable_show_on_lock_screen]
     tags = android
-    en = Show Organic Maps on the lock screen
-    be = Паказваць Organic Maps на экране блакіроўкі
-    pl = Pokazuj Organic Maps na ekranie blokady
-    ru = Показывать Organic Maps на экране блокировки
-    uk = Показувати Organic Maps на заблокованому екрані
+    comment = A preference title; keep short!
+    en = Show on the lock screen
+    be = Паказваць на экране блакіроўкі
+    pl = Pokazuj na ekranie blokady
+    ru = Показывать на экране блокировки
+    uk = Показувати на заблокованому екрані
 
   [enable_show_on_lock_screen_description]
     tags = android


### PR DESCRIPTION
Needed-for: #1928

Multiple lines for prefs titles tested on Android 5 & 9.

Before:
![Screenshot_1644509478](https://user-images.githubusercontent.com/18434508/153488345-6befbe0a-7a17-43b3-907a-928441ca4d75.png)
After:
![Screenshot_1644518610](https://user-images.githubusercontent.com/18434508/153488386-d254c3db-ff8c-41c4-a332-43f6e77a79ed.png)


Before:
![Screenshot_1644509309](https://user-images.githubusercontent.com/18434508/153488251-3c625d79-4638-4f8e-8e75-28dd255420c2.png)
After:
![Screenshot_1644518637](https://user-images.githubusercontent.com/18434508/153488307-891ecc89-22f2-4dff-92a7-49a7b9e1012a.png)



