### PR TITLE
[android] Remove dead location code

### DIFF
--- a/android/src/com/mapswithme/maps/location/LocationHelper.java
+++ b/android/src/com/mapswithme/maps/location/LocationHelper.java
@@ -124,7 +124,6 @@ public enum LocationHelper implements Initializable<Context>, AppBackgroundTrack
   @Nullable
   private Location mSavedLocation;
   private MapObject mMyPosition;
-  private long mSavedLocationTime;
   @SuppressWarnings("NotNullFieldNotInitialized")
   @NonNull
   private SensorHelper mSensorHelper;
@@ -203,14 +202,11 @@ public enum LocationHelper implements Initializable<Context>, AppBackgroundTrack
   }
 
   /**
-   * <p>Obtains last known saved location. It depends on "My position" button mode and is erased on "No follow, no position" one.
-   * <p>If you need the location regardless of the button's state, use {@link #getLastKnownLocation()}.
-   * @return {@code null} if no location is saved or "My position" button is in "No follow, no position" mode.
+   * Obtains last known location.
+   * @return {@code null} if no location is saved.
    */
   @Nullable
   public Location getSavedLocation() { return mSavedLocation; }
-
-  public long getSavedLocationTime() { return mSavedLocationTime; }
 
   public void switchToNextMode()
   {
@@ -316,7 +312,6 @@ public enum LocationHelper implements Initializable<Context>, AppBackgroundTrack
 
     mSavedLocation = location;
     mMyPosition = null;
-    mSavedLocationTime = System.currentTimeMillis();
     notifyLocationUpdated();
   }
 
@@ -617,16 +612,6 @@ public enum LocationHelper implements Initializable<Context>, AppBackgroundTrack
       switchToNextMode();
     else
       restart();
-  }
-
-  /**
-   * Obtains last known location regardless of "My position" button state.
-   * @return {@code null} on failure.
-   */
-  @Nullable
-  public Location getLastKnownLocation()
-  {
-    return mSavedLocation;
   }
 
   @Nullable

--- a/android/src/com/mapswithme/maps/routing/NavigationController.java
+++ b/android/src/com/mapswithme/maps/routing/NavigationController.java
@@ -300,7 +300,7 @@ public class NavigationController implements Application.ActivityLifecycleCallba
 
   private void updateSpeedView(@NonNull RoutingInfo info)
   {
-    final Location last = LocationHelper.INSTANCE.getLastKnownLocation();
+    final Location last = LocationHelper.INSTANCE.getSavedLocation();
     if (last == null)
       return;
 

--- a/android/src/com/mapswithme/util/LocationUtils.java
+++ b/android/src/com/mapswithme/util/LocationUtils.java
@@ -5,14 +5,11 @@ import android.content.ContentResolver;
 import android.content.Context;
 import android.location.Location;
 import android.location.LocationManager;
-import android.os.Build;
-import android.os.SystemClock;
 import android.provider.Settings;
 import android.view.Surface;
 
 import androidx.annotation.NonNull;
 
-import com.mapswithme.maps.location.LocationHelper;
 import com.mapswithme.util.log.Logger;
 import com.mapswithme.util.log.LoggerFactory;
 
@@ -62,39 +59,9 @@ public class LocationUtils
     return res;
   }
 
-  public static boolean isExpired(Location l, long millis, long expirationMillis)
+  public static double getTimeDiff(@NonNull Location lastLocation, @NonNull Location newLocation)
   {
-    long timeDiff;
-    if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.JELLY_BEAN_MR1)
-      timeDiff = (SystemClock.elapsedRealtimeNanos() - l.getElapsedRealtimeNanos()) / 1000000;
-    else
-      timeDiff = System.currentTimeMillis() - millis;
-    return (timeDiff > expirationMillis);
-  }
-
-  public static double getTimeDiff(Location lastLocation, Location newLocation)
-  {
-    if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.JELLY_BEAN_MR1)
-      return (newLocation.getElapsedRealtimeNanos() - lastLocation.getElapsedRealtimeNanos()) * 1.0E-9;
-    else
-    {
-      long time = newLocation.getTime();
-      long lastTime = lastLocation.getTime();
-      if (!isSameLocationProvider(newLocation.getProvider(), lastLocation.getProvider()))
-      {
-        // Do compare current and previous system times in case when
-        // we have incorrect time settings on a device.
-        time = System.currentTimeMillis();
-        lastTime = LocationHelper.INSTANCE.getSavedLocationTime();
-      }
-
-      return (time - lastTime) * 1.0E-3;
-    }
-  }
-
-  private static boolean isSameLocationProvider(String p1, String p2)
-  {
-    return (p1 != null && p1.equals(p2));
+    return (newLocation.getElapsedRealtimeNanos() - lastLocation.getElapsedRealtimeNanos()) * 1.0E-9;
   }
 
   public static boolean isFromGpsProvider(@NonNull Location location)


### PR DESCRIPTION
`Build.VERSION.SDK_INT >= Build.VERSION_CODES.JELLY_BEAN_MR1` is always true,
because JELLY_BEAN_MR1 is API=17, but our minimal level is API=21.

No semantic changes intended.

Signed-off-by: Roman Tsisyk <roman@tsisyk.com>