### PR TITLE
Fixed writable/resource dir candidates for desktop.

### DIFF
--- a/android/jni/com/mapswithme/platform/Platform.cpp
+++ b/android/jni/com/mapswithme/platform/Platform.cpp
@@ -132,7 +132,6 @@ void Platform::Initialize(JNIEnv * env, jobject functorProcessObject, jstring ap
 
   m_isTablet = isTablet;
   m_resourcesDir = jni::ToNativeString(env, apkPath);
-  m_privateDir = jni::ToNativeString(env, privatePath);
   m_tmpDir = jni::ToNativeString(env, tmpPath);
   SetWritableDir(jni::ToNativeString(env, writablePath));
   LOG(LINFO, ("Apk path = ", m_resourcesDir));

--- a/generator/world_roads_builder/world_roads_builder_tool/world_roads_builder_tool.cpp
+++ b/generator/world_roads_builder/world_roads_builder_tool/world_roads_builder_tool.cpp
@@ -55,7 +55,6 @@ int main(int argc, char ** argv)
   RoadsFromOsm const & roadsFromOsm = GetRoadsFromOsm(reader, mwmMatcher, highwayTypes);
 
   storage::Storage storage;
-  storage.RegisterAllLocalMaps(false /* enableDiffs */);
   std::shared_ptr<NumMwmIds> numMwmIds = CreateNumMwmIds(storage);
 
   std::unordered_map<std::string, NumMwmId> regionsToIds;

--- a/platform/platform.cpp
+++ b/platform/platform.cpp
@@ -343,6 +343,21 @@ void Platform::ShutdownThreads()
   m_backgroundThread->ShutdownAndJoin();
 }
 
+void Platform::ValidateWritableAndResourceDirs()
+{
+  // Resources and Writable dirs maybe empty after Platform initialization and will be manually assigned
+  // later in tests, tools, etc. Set some unexisting path by default to grep logs and detect possible errors.
+  if (!m_resourcesDir.empty())
+    m_resourcesDir += '/';
+  else
+    m_resourcesDir = "OM_Unexisting_ResourceDir_path";
+
+  if (!m_writableDir.empty())
+    m_writableDir += '/';
+  else
+    m_writableDir = "OM_Unexisting_WritableDir_path";
+}
+
 void Platform::RunThreads()
 {
   ASSERT(!m_networkThread || (m_networkThread && m_networkThread->IsShutDown()), ());

--- a/platform/platform.hpp
+++ b/platform/platform.hpp
@@ -96,8 +96,6 @@ protected:
   /// Writable directory to store downloaded map data
   /// @note on some systems it can point to external ejectable storage
   std::string m_writableDir;
-  /// Application private directory.
-  std::string m_privateDir;
   /// Temporary directory, can be cleaned up by the system
   std::string m_tmpDir;
   /// Writable directory to store persistent application data
@@ -188,9 +186,6 @@ public:
   void SetSettingsDir(std::string const & path);
   /// @return full path to file in the settings directory
   std::string SettingsPathForFile(std::string const & file) const { return SettingsDir() + file; }
-
-  /// Returns application private directory.
-  std::string const & PrivateDir() const { return m_privateDir; }
 
   /// @return reader for file decriptor.
   /// @throws FileAbsentException
@@ -326,6 +321,9 @@ public:
   void SetGuiThread(std::unique_ptr<base::TaskLoop> guiThread);
 
   platform::BatteryLevelTracker & GetBatteryTracker() { return m_batteryTracker; }
+
+protected:
+  void ValidateWritableAndResourceDirs();
 
 private:
   void RunThreads();

--- a/platform/platform_ios.mm
+++ b/platform/platform_ios.mm
@@ -49,11 +49,6 @@ Platform::Platform()
   m_writableDir += "/";
   m_settingsDir = m_writableDir;
 
-  auto privatePaths = NSSearchPathForDirectoriesInDomains(NSApplicationSupportDirectory,
-                                                          NSUserDomainMask, YES);
-  m_privateDir = privatePaths.firstObject.UTF8String;
-  m_privateDir +=  "/";
-
   NSString * tmpDir = NSTemporaryDirectory();
   if (tmpDir)
     m_tmpDir = tmpDir.UTF8String;

--- a/platform/platform_linux.cpp
+++ b/platform/platform_linux.cpp
@@ -84,6 +84,8 @@ Platform::Platform()
       MYTHROW(FileSystemException, ("Can't create directory", m_settingsDir));
   }
 
+  m_settingsDir += '/';
+
   char const * resDir = ::getenv("MWM_RESOURCES_DIR");
   char const * writableDir = ::getenv("MWM_WRITABLE_DIR");
   if (resDir && writableDir)
@@ -100,7 +102,7 @@ Platform::Platform()
   }
   else
   {
-    initializer_list<string> dirs = {
+    string dirs[] = {
       "./data",                                     // check symlink in the current folder
       "../data",                                    // check if we are in the 'build' folder inside repo
       base::JoinPath(execPath, "..", "..", "data"), // check symlink from bundle?
@@ -119,12 +121,7 @@ Platform::Platform()
     }
   }
 
-  // Actually, m_resourcesDir and m_writableDir maybe empty here and
-  // will be set later by tests infrustructure.
-
-  m_resourcesDir += '/';
-  m_settingsDir += '/';
-  m_writableDir += '/';
+  ValidateWritableAndResourceDirs();
 
   char const * tmpDir = ::getenv("TMPDIR");
   if (tmpDir)
@@ -139,8 +136,6 @@ Platform::Platform()
       MYTHROW(FileSystemException, ("Can't create tmp directory:", m_tmpDir));
   }
   m_tmpDir += '/';
-
-  m_privateDir = m_settingsDir;
 
   m_guiThread = make_unique<platform::GuiThread>();
 

--- a/routing/routing_tests/cross_border_graph_tests.cpp
+++ b/routing/routing_tests/cross_border_graph_tests.cpp
@@ -116,7 +116,6 @@ UNIT_TEST(CrossBorderGraph_SerDes)
   std::string const fileName = "CrossBorderGraph_SerDes.test";
 
   storage::Storage storage;
-  storage.RegisterAllLocalMaps(false /* enableDiffs */);
   std::shared_ptr<NumMwmIds> numMwmIds = CreateNumMwmIds(storage);
 
   CrossBorderGraph graph1;

--- a/track_analyzing/track_analyzer/cmd_gpx.cpp
+++ b/track_analyzing/track_analyzer/cmd_gpx.cpp
@@ -28,7 +28,6 @@ void CmdGPX(string const & logFile, string const & outputDirName, string const &
   }
 
   storage::Storage storage;
-  storage.RegisterAllLocalMaps(false /* enableDiffs */);
   shared_ptr<NumMwmIds> numMwmIds = CreateNumMwmIds(storage);
   MwmToTracks mwmToTracks;
   ParseTracks(logFile, numMwmIds, mwmToTracks);

--- a/track_analyzing/track_analyzer/cmd_unmatched_tracks.cpp
+++ b/track_analyzing/track_analyzer/cmd_unmatched_tracks.cpp
@@ -21,7 +21,6 @@ void CmdUnmatchedTracks(string const & logFile, string const & trackFileCsv)
 {
   LOG(LINFO, ("Saving unmatched tracks", logFile));
   storage::Storage storage;
-  storage.RegisterAllLocalMaps(false /* enableDiffs */);
   shared_ptr<NumMwmIds> numMwmIds = CreateNumMwmIds(storage);
   MwmToTracks mwmToTracks;
   ParseTracks(logFile, numMwmIds, mwmToTracks);


### PR DESCRIPTION
Do not set default writable/resource path as root "/" for Linux. If any test or toolchain doesn't set it properly, then strange things may happen in root "/".

If platform can't find any valid path now, make it equal with unique string like "OM_Unexisting_ResourceDir_path". It helps better grep logs and find bugs.