### PR TITLE
RTL fixes for Android

### DIFF
--- a/android/res/drawable/ic_question_mark.xml
+++ b/android/res/drawable/ic_question_mark.xml
@@ -1,4 +1,5 @@
 <vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:autoMirrored="true"
     android:width="24dp"
     android:height="24dp"
     android:viewportWidth="24"

--- a/android/res/layout/map_navigation_buttons.xml
+++ b/android/res/layout/map_navigation_buttons.xml
@@ -5,6 +5,7 @@
   android:layout_width="match_parent"
   android:layout_height="match_parent"
   android:padding="@dimen/nav_frame_padding"
+  android:layoutDirection="ltr"
   android:theme="?navButtonsTheme">
 
   <ImageButton

--- a/android/res/values-ar/strings.xml
+++ b/android/res/values-ar/strings.xml
@@ -166,7 +166,7 @@
 	<!-- Prints version number in About dialog -->
 	<string name="version">الاصدار: %s</string>
 	<!-- Data version in «About» screen, %@ is replaced by a local, human readable date. -->
-	<string name="data_version">OpenStreetMap: %s ﺕﺎﻧﺎﻴﺑ</string>
+	<string name="data_version">OpenStreetMap بيانات %s</string>
 	<!-- Confirmation in downloading countries dialog -->
 	<string name="are_you_sure">هل أنت واثق أنك تريد الاستمرار؟</string>
 	<!-- Title for tracks category in bookmarks manager -->
@@ -212,7 +212,7 @@
 	<!-- Text in menu -->
 	<string name="help">مساعدة</string>
 	<!-- Button in the main Help dialog -->
-	<string name="faq">ﺔﺑﻮﺟﺃﻭ ﺔﻠﺌﺳﺃ</string>
+	<string name="faq">اسئلة واجوبة</string>
 	<!-- Button in the main Help dialog -->
 	<string name="how_to_support_us">كيف تدعم لنا؟</string>
 	<!-- Button in the main Help dialog -->

--- a/data/strings/strings.txt
+++ b/data/strings/strings.txt
@@ -3442,7 +3442,7 @@
     comment = Data version in «About» screen, %@ is replaced by a local, human readable date.
     tags = android,ios
     en = OpenStreetMap data: %@
-    ar = OpenStreetMap: %@ ﺕﺎﻧﺎﻴﺑ
+    ar = OpenStreetMap بيانات %@
     be = Дадзеныя OpenStreetMap: %@
     bg = Данни на OpenStreetMap: %@
     cs = Data OpenStreetMap: %@
@@ -4721,7 +4721,7 @@
     comment = Button in the main Help dialog
     tags = android,ios
     en = Frequently Asked Questions
-    ar = ﺔﺑﻮﺟﺃﻭ ﺔﻠﺌﺳﺃ
+    ar = اسئلة واجوبة
     be = Пытанні і адказы
     bg = Въпроси и отговори
     cs = Otázky a odpovědi

--- a/iphone/Maps/LocalizedStrings/ar.lproj/Localizable.strings
+++ b/iphone/Maps/LocalizedStrings/ar.lproj/Localizable.strings
@@ -194,7 +194,7 @@
 "version" = "الاصدار: %@";
 
 /* Data version in «About» screen, %@ is replaced by a local, human readable date. */
-"data_version" = "OpenStreetMap: %@ ﺕﺎﻧﺎﻴﺑ";
+"data_version" = "OpenStreetMap بيانات %@";
 
 /* Title for tracks category in bookmarks manager */
 "tracks_title" = "المسارات";
@@ -292,7 +292,7 @@
 "help" = "مساعدة";
 
 /* Button in the main Help dialog */
-"faq" = "ﺔﺑﻮﺟﺃﻭ ﺔﻠﺌﺳﺃ";
+"faq" = "اسئلة واجوبة";
 
 /* Button in the main Help dialog */
 "how_to_support_us" = "كيف تدعم لنا؟";


### PR DESCRIPTION
Fixes #1252 by forcing LTR layout for Layers, zoom in/out and position buttons.

Also updates translations after the user's feedback, and mirrors the question mark icon.