### PR TITLE
Fix corner rounding on the bottom of PlacePage

### DIFF
--- a/iphone/Maps/UI/PlacePage/PlacePage.storyboard
+++ b/iphone/Maps/UI/PlacePage/PlacePage.storyboard
@@ -66,7 +66,7 @@
                                 <rect key="frame" x="0.0" y="618" width="375" height="49"/>
                                 <color key="backgroundColor" systemColor="systemBackgroundColor"/>
                                 <userDefinedRuntimeAttributes>
-                                    <userDefinedRuntimeAttribute type="string" keyPath="styleName" value="Background"/>
+                                    <userDefinedRuntimeAttribute type="string" keyPath="styleName" value="PPView"/>
                                 </userDefinedRuntimeAttributes>
                             </view>
                         </subviews>


### PR DESCRIPTION
This appears to be fixing the problem on first sight by mimicking what has been done for `PlacePageHeaderView`. Looking very closely at the HeaderView and the Action Bar it becomes apparent that this isn't correct.

As it is now, the HeaderView has rounded corners applied independently of the main PlacePage view. That means the *bottom* corners of the HeaderView are rounded as well. That isn't a big visual issue since there's white on light gray background, however it shows that the rounding is done in a non-ideal way.
The same applies to the action bar: The top corners are rounded as well.

<img width="273" alt="place_page_corners" src="https://user-images.githubusercontent.com/772963/157338767-ac56bd33-0686-4f47-b742-0584cac29285.png">

Instead, both views should be clipped by the main PlacePage view so that corner rounding only happens on the actual outer corners. Making the PlacePage clip its subviews however also breaks (rather: clips) its shadow.

I think creating the shadow from a parent view and then putting all internal views inside one more view that does the rounding and clipping may work out.

Originating from OM issue #1675.