### PR TITLE
[strings] Translate type.organic.yes/only

### DIFF
--- a/android/res/values-be/strings.xml
+++ b/android/res/values-be/strings.xml
@@ -843,6 +843,8 @@
 	<string name="type.natural.saddle">Седлавіна</string>
 	<string name="type.natural.water">Вадаём</string>
 	<string name="type.office.telecommunication">Тэлекамунікацыйная кампанія</string>
+	<string name="type.organic.only">Эка</string>
+	<string name="type.organic.yes">Эка</string>
 	<string name="type.railway.platform">Чыгуначная платформа</string>
 	<string name="type.shop.beverages">Напоі</string>
 	<string name="type.shop.caravan">Продаж аўтадамоў</string>

--- a/android/res/values-de/strings.xml
+++ b/android/res/values-de/strings.xml
@@ -1257,6 +1257,8 @@
 	<string name="type.office.lawyer">Anwaltsbüro</string>
 	<string name="type.office.ngo">Büro einer Nichtregierungsorganisation</string>
 	<string name="type.office.telecommunication">Mobilfunkbetreiber</string>
+	<string name="type.organic.only">Bio</string>
+	<string name="type.organic.yes">Bio</string>
 	<string name="type.place">Ort</string>
 	<string name="type.place.city">Großstadt</string>
 	<string name="type.place.city.capital">Hauptstadt</string>

--- a/android/res/values-es/strings.xml
+++ b/android/res/values-es/strings.xml
@@ -1203,6 +1203,8 @@
 	<string name="type.office.lawyer">Despacho de abogados</string>
 	<string name="type.office.ngo">Sede de ONG</string>
 	<string name="type.office.telecommunication">Operadora de telefonía móvil</string>
+	<string name="type.organic.only">Orgánico</string>
+	<string name="type.organic.yes">Orgánico</string>
 	<string name="type.place.city">Ciudad</string>
 	<string name="type.place.city.capital.10">Ciudad</string>
 	<string name="type.place.city.capital.11">Ciudad</string>

--- a/android/res/values-fr/strings.xml
+++ b/android/res/values-fr/strings.xml
@@ -1209,6 +1209,8 @@
 	<string name="type.office.lawyer">Cabinet d\'avocat</string>
 	<string name="type.office.ngo">Bureau ONG</string>
 	<string name="type.office.telecommunication">Opérateur mobile</string>
+	<string name="type.organic.only">Biologique</string>
+	<string name="type.organic.yes">Biologique</string>
 	<string name="type.place.city">Ville</string>
 	<string name="type.place.city.capital">Capitale</string>
 	<string name="type.place.city.capital.10">Ville</string>

--- a/android/res/values-it/strings.xml
+++ b/android/res/values-it/strings.xml
@@ -1148,6 +1148,8 @@
 	<string name="type.office.lawyer">Studio legale</string>
 	<string name="type.office.ngo">Sede ONG</string>
 	<string name="type.office.telecommunication">Operatore di telefonia mobile</string>
+	<string name="type.organic.only">Biologico</string>
+	<string name="type.organic.yes">Biologico</string>
 	<string name="type.place.city">Città</string>
 	<string name="type.place.city.capital">Capitale</string>
 	<string name="type.place.city.capital.10">Città</string>

--- a/android/res/values-nl/strings.xml
+++ b/android/res/values-nl/strings.xml
@@ -1136,6 +1136,8 @@
 	<string name="type.office.lawyer">Advocatenkantoor</string>
 	<string name="type.office.ngo">NGO-kantoor</string>
 	<string name="type.office.telecommunication">Mobiele provider</string>
+	<string name="type.organic.only">Biologisch</string>
+	<string name="type.organic.yes">Biologisch</string>
 	<string name="type.place.city">Stad</string>
 	<string name="type.place.city.capital">Hoofdstad</string>
 	<string name="type.place.city.capital.10">Stad</string>

--- a/android/res/values-pt-rBR/strings.xml
+++ b/android/res/values-pt-rBR/strings.xml
@@ -1256,6 +1256,8 @@
 	<string name="type.office.lawyer">Escritório de advogado</string>
 	<string name="type.office.ngo">Escritório de ONG</string>
 	<string name="type.office.telecommunication">Operadora de telecomunicações</string>
+	<string name="type.organic.only">Orgânico</string>
+	<string name="type.organic.yes">Orgânico</string>
 	<string name="type.place">Local</string>
 	<string name="type.place.city">Cidade</string>
 	<string name="type.place.city.capital">Capital</string>

--- a/android/res/values-pt/strings.xml
+++ b/android/res/values-pt/strings.xml
@@ -1263,6 +1263,8 @@
 	<string name="type.office.lawyer">Advogado</string>
 	<string name="type.office.ngo">Escritório de ONG</string>
 	<string name="type.office.telecommunication">Operadora de telecomunicações</string>
+	<string name="type.organic.only">Orgânico</string>
+	<string name="type.organic.yes">Orgânico</string>
 	<string name="type.place">Local</string>
 	<string name="type.place.city">Cidade</string>
 	<string name="type.place.city.capital">Capital</string>

--- a/android/res/values-ru/strings.xml
+++ b/android/res/values-ru/strings.xml
@@ -1310,6 +1310,8 @@
 	<string name="type.office.lawyer">Адвокат</string>
 	<string name="type.office.ngo">Общественная организация</string>
 	<string name="type.office.telecommunication">Телекоммуникационная компания</string>
+	<string name="type.organic.only">Эко</string>
+	<string name="type.organic.yes">Эко</string>
 	<string name="type.place">Место</string>
 	<string name="type.place.city">Город</string>
 	<string name="type.place.city.capital">Столица</string>

--- a/android/res/values-uk/strings.xml
+++ b/android/res/values-uk/strings.xml
@@ -1286,6 +1286,8 @@
 	<string name="type.office.lawyer">Адвокат</string>
 	<string name="type.office.ngo">Недержавна організація</string>
 	<string name="type.office.telecommunication">Телекомунікаційна компанія</string>
+	<string name="type.organic.only">Еко</string>
+	<string name="type.organic.yes">Еко</string>
 	<string name="type.place">Мicце</string>
 	<string name="type.place.city">Місто</string>
 	<string name="type.place.city.capital">Столиця</string>

--- a/android/res/values/strings.xml
+++ b/android/res/values/strings.xml
@@ -1341,6 +1341,8 @@
 	<string name="type.office.lawyer">Lawyer</string>
 	<string name="type.office.ngo">Non-Governmental Organization</string>
 	<string name="type.office.telecommunication">Telecom Company</string>
+	<string name="type.organic.only">Organic</string>
+	<string name="type.organic.yes">Organic</string>
 	<string name="type.place">place</string>
 	<string name="type.place.city">City</string>
 	<string name="type.place.city.capital">Capital</string>

--- a/data/strings/types_strings.txt
+++ b/data/strings/types_strings.txt
@@ -12620,6 +12620,22 @@
     zh-Hans = 电信办公室
     zh-Hant = 行動電話業者
 
+  [type.organic.only]
+    en = Organic
+    be = Эка
+    de = Bio
+    es = Orgánico
+    fr = Biologique
+    it = Biologico
+    nl = Biologisch
+    pt = Orgânico
+    pt-BR = Orgânico
+    ru = Эко
+    uk = Еко
+
+  [type.organic.yes]
+    ref = type.organic.only
+
   [type.place]
     en = place
     de = Ort

--- a/iphone/Maps/LocalizedStrings/ar.lproj/Localizable.strings
+++ b/iphone/Maps/LocalizedStrings/ar.lproj/Localizable.strings
@@ -2419,6 +2419,10 @@
 
 "type.office.telecommunication" = "شركة اتصالات";
 
+"type.organic.only" = "Organic";
+
+"type.organic.yes" = "Organic";
+
 "type.place" = "place";
 
 "type.place.city" = "مدينة";

--- a/iphone/Maps/LocalizedStrings/be.lproj/Localizable.strings
+++ b/iphone/Maps/LocalizedStrings/be.lproj/Localizable.strings
@@ -2419,6 +2419,10 @@
 
 "type.office.telecommunication" = "Тэлекамунікацыйная кампанія";
 
+"type.organic.only" = "Эка";
+
+"type.organic.yes" = "Эка";
+
 "type.place" = "place";
 
 "type.place.city" = "City";

--- a/iphone/Maps/LocalizedStrings/bg.lproj/Localizable.strings
+++ b/iphone/Maps/LocalizedStrings/bg.lproj/Localizable.strings
@@ -2419,6 +2419,10 @@
 
 "type.office.telecommunication" = "Телекомуникационна компания";
 
+"type.organic.only" = "Organic";
+
+"type.organic.yes" = "Organic";
+
 "type.place" = "place";
 
 "type.place.city" = "City";

--- a/iphone/Maps/LocalizedStrings/cs.lproj/Localizable.strings
+++ b/iphone/Maps/LocalizedStrings/cs.lproj/Localizable.strings
@@ -2419,6 +2419,10 @@
 
 "type.office.telecommunication" = "Mobilní operátor";
 
+"type.organic.only" = "Organic";
+
+"type.organic.yes" = "Organic";
+
 "type.place" = "place";
 
 "type.place.city" = "Velkoměsto";

--- a/iphone/Maps/LocalizedStrings/da.lproj/Localizable.strings
+++ b/iphone/Maps/LocalizedStrings/da.lproj/Localizable.strings
@@ -2419,6 +2419,10 @@
 
 "type.office.telecommunication" = "Mobiloperatør";
 
+"type.organic.only" = "Organic";
+
+"type.organic.yes" = "Organic";
+
 "type.place" = "place";
 
 "type.place.city" = "By";

--- a/iphone/Maps/LocalizedStrings/de.lproj/Localizable.strings
+++ b/iphone/Maps/LocalizedStrings/de.lproj/Localizable.strings
@@ -2419,6 +2419,10 @@
 
 "type.office.telecommunication" = "Mobilfunkbetreiber";
 
+"type.organic.only" = "Bio";
+
+"type.organic.yes" = "Bio";
+
 "type.place" = "Ort";
 
 "type.place.city" = "Großstadt";

--- a/iphone/Maps/LocalizedStrings/el.lproj/Localizable.strings
+++ b/iphone/Maps/LocalizedStrings/el.lproj/Localizable.strings
@@ -2419,6 +2419,10 @@
 
 "type.office.telecommunication" = "Εταιρεία κινητής τηλεφωνίας";
 
+"type.organic.only" = "Organic";
+
+"type.organic.yes" = "Organic";
+
 "type.place" = "place";
 
 "type.place.city" = "Πόλη";

--- a/iphone/Maps/LocalizedStrings/en-GB.lproj/Localizable.strings
+++ b/iphone/Maps/LocalizedStrings/en-GB.lproj/Localizable.strings
@@ -2419,6 +2419,10 @@
 
 "type.office.telecommunication" = "Telecom Company";
 
+"type.organic.only" = "Organic";
+
+"type.organic.yes" = "Organic";
+
 "type.place" = "place";
 
 "type.place.city" = "City";

--- a/iphone/Maps/LocalizedStrings/en.lproj/Localizable.strings
+++ b/iphone/Maps/LocalizedStrings/en.lproj/Localizable.strings
@@ -2419,6 +2419,10 @@
 
 "type.office.telecommunication" = "Telecom Company";
 
+"type.organic.only" = "Organic";
+
+"type.organic.yes" = "Organic";
+
 "type.place" = "place";
 
 "type.place.city" = "City";

--- a/iphone/Maps/LocalizedStrings/es-MX.lproj/Localizable.strings
+++ b/iphone/Maps/LocalizedStrings/es-MX.lproj/Localizable.strings
@@ -2419,6 +2419,10 @@
 
 "type.office.telecommunication" = "Telecom Company";
 
+"type.organic.only" = "Organic";
+
+"type.organic.yes" = "Organic";
+
 "type.place" = "place";
 
 "type.place.city" = "City";

--- a/iphone/Maps/LocalizedStrings/es.lproj/Localizable.strings
+++ b/iphone/Maps/LocalizedStrings/es.lproj/Localizable.strings
@@ -2419,6 +2419,10 @@
 
 "type.office.telecommunication" = "Operadora de telefonía móvil";
 
+"type.organic.only" = "Orgánico";
+
+"type.organic.yes" = "Orgánico";
+
 "type.place" = "place";
 
 "type.place.city" = "Ciudad";

--- a/iphone/Maps/LocalizedStrings/fa.lproj/Localizable.strings
+++ b/iphone/Maps/LocalizedStrings/fa.lproj/Localizable.strings
@@ -2419,6 +2419,10 @@
 
 "type.office.telecommunication" = "اپراتور تلفن همراه";
 
+"type.organic.only" = "Organic";
+
+"type.organic.yes" = "Organic";
+
 "type.place" = "place";
 
 "type.place.city" = "شهر";

--- a/iphone/Maps/LocalizedStrings/fi.lproj/Localizable.strings
+++ b/iphone/Maps/LocalizedStrings/fi.lproj/Localizable.strings
@@ -2419,6 +2419,10 @@
 
 "type.office.telecommunication" = "Matkapuhelinoperaattori";
 
+"type.organic.only" = "Organic";
+
+"type.organic.yes" = "Organic";
+
 "type.place" = "place";
 
 "type.place.city" = "Kaupunki";

--- a/iphone/Maps/LocalizedStrings/fr.lproj/Localizable.strings
+++ b/iphone/Maps/LocalizedStrings/fr.lproj/Localizable.strings
@@ -2419,6 +2419,10 @@
 
 "type.office.telecommunication" = "Opérateur mobile";
 
+"type.organic.only" = "Biologique";
+
+"type.organic.yes" = "Biologique";
+
 "type.place" = "place";
 
 "type.place.city" = "Ville";

--- a/iphone/Maps/LocalizedStrings/he.lproj/Localizable.strings
+++ b/iphone/Maps/LocalizedStrings/he.lproj/Localizable.strings
@@ -2419,6 +2419,10 @@
 
 "type.office.telecommunication" = "Telecom Company";
 
+"type.organic.only" = "Organic";
+
+"type.organic.yes" = "Organic";
+
 "type.place" = "place";
 
 "type.place.city" = "City";

--- a/iphone/Maps/LocalizedStrings/hu.lproj/Localizable.strings
+++ b/iphone/Maps/LocalizedStrings/hu.lproj/Localizable.strings
@@ -2419,6 +2419,10 @@
 
 "type.office.telecommunication" = "Mobilüzemeltető";
 
+"type.organic.only" = "Organic";
+
+"type.organic.yes" = "Organic";
+
 "type.place" = "place";
 
 "type.place.city" = "Város";

--- a/iphone/Maps/LocalizedStrings/id.lproj/Localizable.strings
+++ b/iphone/Maps/LocalizedStrings/id.lproj/Localizable.strings
@@ -2419,6 +2419,10 @@
 
 "type.office.telecommunication" = "Operator seluler";
 
+"type.organic.only" = "Organic";
+
+"type.organic.yes" = "Organic";
+
 "type.place" = "place";
 
 "type.place.city" = "Kota";

--- a/iphone/Maps/LocalizedStrings/it.lproj/Localizable.strings
+++ b/iphone/Maps/LocalizedStrings/it.lproj/Localizable.strings
@@ -2419,6 +2419,10 @@
 
 "type.office.telecommunication" = "Operatore di telefonia mobile";
 
+"type.organic.only" = "Biologico";
+
+"type.organic.yes" = "Biologico";
+
 "type.place" = "place";
 
 "type.place.city" = "Città";

--- a/iphone/Maps/LocalizedStrings/ja.lproj/Localizable.strings
+++ b/iphone/Maps/LocalizedStrings/ja.lproj/Localizable.strings
@@ -2419,6 +2419,10 @@
 
 "type.office.telecommunication" = "携帯電話事業者";
 
+"type.organic.only" = "Organic";
+
+"type.organic.yes" = "Organic";
+
 "type.place" = "地名";
 
 "type.place.city" = "市";

--- a/iphone/Maps/LocalizedStrings/ko.lproj/Localizable.strings
+++ b/iphone/Maps/LocalizedStrings/ko.lproj/Localizable.strings
@@ -2419,6 +2419,10 @@
 
 "type.office.telecommunication" = "이동통신 사업자";
 
+"type.organic.only" = "Organic";
+
+"type.organic.yes" = "Organic";
+
 "type.place" = "place";
 
 "type.place.city" = "도시";

--- a/iphone/Maps/LocalizedStrings/nb.lproj/Localizable.strings
+++ b/iphone/Maps/LocalizedStrings/nb.lproj/Localizable.strings
@@ -2419,6 +2419,10 @@
 
 "type.office.telecommunication" = "Mobiloperatør";
 
+"type.organic.only" = "Organic";
+
+"type.organic.yes" = "Organic";
+
 "type.place" = "place";
 
 "type.place.city" = "By";

--- a/iphone/Maps/LocalizedStrings/nl.lproj/Localizable.strings
+++ b/iphone/Maps/LocalizedStrings/nl.lproj/Localizable.strings
@@ -2419,6 +2419,10 @@
 
 "type.office.telecommunication" = "Mobiele provider";
 
+"type.organic.only" = "Biologisch";
+
+"type.organic.yes" = "Biologisch";
+
 "type.place" = "place";
 
 "type.place.city" = "Stad";

--- a/iphone/Maps/LocalizedStrings/pl.lproj/Localizable.strings
+++ b/iphone/Maps/LocalizedStrings/pl.lproj/Localizable.strings
@@ -2419,6 +2419,10 @@
 
 "type.office.telecommunication" = "Biuro operatora telefonii komórkowej";
 
+"type.organic.only" = "Organic";
+
+"type.organic.yes" = "Organic";
+
 "type.place" = "Miejsce";
 
 "type.place.city" = "Miasto";

--- a/iphone/Maps/LocalizedStrings/pt-BR.lproj/Localizable.strings
+++ b/iphone/Maps/LocalizedStrings/pt-BR.lproj/Localizable.strings
@@ -2419,6 +2419,10 @@
 
 "type.office.telecommunication" = "Operadora de telecomunicações";
 
+"type.organic.only" = "Orgânico";
+
+"type.organic.yes" = "Orgânico";
+
 "type.place" = "Local";
 
 "type.place.city" = "Cidade";

--- a/iphone/Maps/LocalizedStrings/pt.lproj/Localizable.strings
+++ b/iphone/Maps/LocalizedStrings/pt.lproj/Localizable.strings
@@ -2419,6 +2419,10 @@
 
 "type.office.telecommunication" = "Operadora de telecomunicações";
 
+"type.organic.only" = "Orgânico";
+
+"type.organic.yes" = "Orgânico";
+
 "type.place" = "Local";
 
 "type.place.city" = "Cidade";

--- a/iphone/Maps/LocalizedStrings/ro.lproj/Localizable.strings
+++ b/iphone/Maps/LocalizedStrings/ro.lproj/Localizable.strings
@@ -2419,6 +2419,10 @@
 
 "type.office.telecommunication" = "Operator de telefonie mobilă";
 
+"type.organic.only" = "Organic";
+
+"type.organic.yes" = "Organic";
+
 "type.place" = "place";
 
 "type.place.city" = "Municipiu";

--- a/iphone/Maps/LocalizedStrings/ru.lproj/Localizable.strings
+++ b/iphone/Maps/LocalizedStrings/ru.lproj/Localizable.strings
@@ -2419,6 +2419,10 @@
 
 "type.office.telecommunication" = "Телекоммуникационная компания";
 
+"type.organic.only" = "Эко";
+
+"type.organic.yes" = "Эко";
+
 "type.place" = "Место";
 
 "type.place.city" = "Город";

--- a/iphone/Maps/LocalizedStrings/sk.lproj/Localizable.strings
+++ b/iphone/Maps/LocalizedStrings/sk.lproj/Localizable.strings
@@ -2419,6 +2419,10 @@
 
 "type.office.telecommunication" = "Mobilný operátor";
 
+"type.organic.only" = "Organic";
+
+"type.organic.yes" = "Organic";
+
 "type.place" = "place";
 
 "type.place.city" = "Mesto";

--- a/iphone/Maps/LocalizedStrings/sv.lproj/Localizable.strings
+++ b/iphone/Maps/LocalizedStrings/sv.lproj/Localizable.strings
@@ -2419,6 +2419,10 @@
 
 "type.office.telecommunication" = "Mobiloperatör";
 
+"type.organic.only" = "Organic";
+
+"type.organic.yes" = "Organic";
+
 "type.place" = "place";
 
 "type.place.city" = "Stad";

--- a/iphone/Maps/LocalizedStrings/sw.lproj/Localizable.strings
+++ b/iphone/Maps/LocalizedStrings/sw.lproj/Localizable.strings
@@ -2419,6 +2419,10 @@
 
 "type.office.telecommunication" = "Telecom Company";
 
+"type.organic.only" = "Organic";
+
+"type.organic.yes" = "Organic";
+
 "type.place" = "place";
 
 "type.place.city" = "City";

--- a/iphone/Maps/LocalizedStrings/th.lproj/Localizable.strings
+++ b/iphone/Maps/LocalizedStrings/th.lproj/Localizable.strings
@@ -2419,6 +2419,10 @@
 
 "type.office.telecommunication" = "ผู้ให้บริการโทรศัพท์มือถือ";
 
+"type.organic.only" = "Organic";
+
+"type.organic.yes" = "Organic";
+
 "type.place" = "place";
 
 "type.place.city" = "เมือง";

--- a/iphone/Maps/LocalizedStrings/tr.lproj/Localizable.strings
+++ b/iphone/Maps/LocalizedStrings/tr.lproj/Localizable.strings
@@ -2419,6 +2419,10 @@
 
 "type.office.telecommunication" = "Cep telefonu operatörü";
 
+"type.organic.only" = "Organic";
+
+"type.organic.yes" = "Organic";
+
 "type.place" = "Yer";
 
 "type.place.city" = "Şehir";

--- a/iphone/Maps/LocalizedStrings/uk.lproj/Localizable.strings
+++ b/iphone/Maps/LocalizedStrings/uk.lproj/Localizable.strings
@@ -2419,6 +2419,10 @@
 
 "type.office.telecommunication" = "Телекомунікаційна компанія";
 
+"type.organic.only" = "Еко";
+
+"type.organic.yes" = "Еко";
+
 "type.place" = "Мicце";
 
 "type.place.city" = "Місто";

--- a/iphone/Maps/LocalizedStrings/vi.lproj/Localizable.strings
+++ b/iphone/Maps/LocalizedStrings/vi.lproj/Localizable.strings
@@ -2419,6 +2419,10 @@
 
 "type.office.telecommunication" = "Điều hành di động";
 
+"type.organic.only" = "Organic";
+
+"type.organic.yes" = "Organic";
+
 "type.place" = "place";
 
 "type.place.city" = "Đất nước";

--- a/iphone/Maps/LocalizedStrings/zh-Hans.lproj/Localizable.strings
+++ b/iphone/Maps/LocalizedStrings/zh-Hans.lproj/Localizable.strings
@@ -2419,6 +2419,10 @@
 
 "type.office.telecommunication" = "电信办公室";
 
+"type.organic.only" = "Organic";
+
+"type.organic.yes" = "Organic";
+
 "type.place" = "地点";
 
 "type.place.city" = "城市";

--- a/iphone/Maps/LocalizedStrings/zh-Hant.lproj/Localizable.strings
+++ b/iphone/Maps/LocalizedStrings/zh-Hant.lproj/Localizable.strings
@@ -2419,6 +2419,10 @@
 
 "type.office.telecommunication" = "行動電話業者";
 
+"type.organic.only" = "Organic";
+
+"type.organic.yes" = "Organic";
+
 "type.place" = "place";
 
 "type.place.city" = "城市";


### PR DESCRIPTION
I took the translations from https://github.com/organicmaps/organicmaps/pull/2140#discussion_r810125673

There are two points:
- these translations are suitable for food only
- it would be good to make a distinction between `organic.yes` and `.only`