### PR TITLE
[strings] Install Twine in user's home, not system-wide

### DIFF
--- a/tools/unix/generate_localizations.sh
+++ b/tools/unix/generate_localizations.sh
@@ -38,7 +38,7 @@ if [ ! -f "$TWINE_PATH/$TWINE_GEM" ] || ! gem list -i twine; then
     cd $TWINE_PATH \
     && rm -f *.gem \
     && gem build --output $TWINE_GEM \
-    && gem install $TWINE_GEM
+    && gem install --user-install $TWINE_GEM
   )
 fi
 


### PR DESCRIPTION
Now no need to run the script with `sudo` to allow to install system-wide.