### PR TITLE
Fix italian translation of "then"

### DIFF
--- a/data/strings/sound.txt
+++ b/data/strings/sound.txt
@@ -1036,7 +1036,7 @@
     hr = Zatim
     hu = Majd
     id = Lalu.
-    it = Quindi
+    it = Poi
     ja = その先
     ko = 그 다음
     nl = Daarna


### PR DESCRIPTION
Me and my friends noticed this while routing, in italian we use "poi" and not "quindi" in this case. If you say "Gira a destra, quindi gira a sinistra" it's like saying "turn right, so turn left", it doesn't make any sense XD 

Signed-off-by: Luca Finizio <luca.finizio@protonmail.com>