### PR TITLE
Add repology badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,6 +17,9 @@
   <a href="https://f-droid.org/en/packages/app.organicmaps/">
     <img src="docs/badges/fdroid.png" width="180">
   </a>
+  <a href="https://repology.org/project/organicmaps/versions">
+    <img src="https://repology.org/badge/vertical-allrepos/organicmaps.svg" width="180" alt="Packaging status">
+  </a>
 </p>
 
 <p float="left">


### PR DESCRIPTION
This patch adds a [repology](https://repology.org) badge to the README, next to the mobile stores, showing which distributions package Organic Maps. Right now it's empty, but it will soon be populated with NixOS, since the package i made for it just went in. Flathub will also be shown once there's a flatpak package