### PR TITLE
[android] Don't mirror next turn sign in LTR layout

### DIFF
--- a/android/res/layout/layout_nav_top.xml
+++ b/android/res/layout/layout_nav_top.xml
@@ -5,6 +5,7 @@
   android:id="@+id/nav_top_frame"
   android:layout_width="match_parent"
   android:layout_height="wrap_content"
+  android:layoutDirection="ltr"
   tools:background="#20FF0000"
   tools:showIn="@layout/layout_nav">
   <FrameLayout


### PR DESCRIPTION
To finish off #2307.

So only the bottom bar is mirrored in RTL layouts.
![Screenshot_1648648667](https://user-images.githubusercontent.com/18434508/160853389-d694a062-19c5-4c94-b5cf-b5a738993bea.png)
![Screenshot_1648648676](https://user-images.githubusercontent.com/18434508/160853415-a3ab4a4b-7bd6-47be-aaa4-25c73c39f662.png)

