### PR TITLE
Fixed GitHub Action error

### DIFF
--- a/.github/workflows/android-monkey.yaml
+++ b/.github/workflows/android-monkey.yaml
@@ -54,7 +54,7 @@ jobs:
           java-version: 11
 
       - name: Install Google SDK
-        uses: google-github-actions/setup-gcloud@master
+        uses: google-github-actions/setup-gcloud@v0
 
       - name: Checkout sources
         uses: actions/checkout@v2


### PR DESCRIPTION
```
Error: On [20](https://github.com/organicmaps/organicmaps/runs/5765697202?check_suite_focus=true#step:4:20)[22](https://github.com/organicmaps/organicmaps/runs/5765697202?check_suite_focus=true#step:4:22)-04-05, the default branch will be renamed from "master" to "main". Your action is currently pinned to "@master". Even though GitHub creates redirects for renamed branches, testing found that this rename breaks existing GitHub Actions workflows that are pinned to the old branch name.

We strongly advise updating your GitHub Action YAML from:

    uses: 'google-github-actions/setup-gcloud@master'

to:

    uses: 'google-github-actions/setup-gcloud@v0'
```