### PR TITLE
[docs] Add Java style guide

### DIFF
--- a/docs/CONTRIBUTING.md
+++ b/docs/CONTRIBUTING.md
@@ -83,6 +83,7 @@ The OM community abides by the [CNCF code of conduct](CODE_OF_CONDUCT.md).
 
 - [Directories structure](STRUCTURE.md)
 - [C++ Style Guide](CPP_STYLE.md).
+- [Java Style Guide](JAVA_STYLE.md).
 - [Objective-C Style Guide](OBJC_STYLE.md).
 - [Pull Request Guide](PR_GUIDE.md).
 - [How to write a commit message](COMMIT_MESSAGES.md).

--- a/docs/JAVA_STYLE.md
+++ b/docs/JAVA_STYLE.md
@@ -1,0 +1,11 @@
+# Java Style Guide
+
+The Android app follows the style defined in `android/code_style_scheme.xml`. Code not respecting this style will not be accepted and you will be asked by reviewers to edit your PR.
+
+## Importing the style in Android Studio
+
+You can import this configuration file in Android Studio to allow automatically formatting Java files. When Android Studio is open, go to `File -> Settings` then open the section `Editor -> Code Style -> Java`. Here click on the gear icon next to the dropdown at the top of the page and select `Import Scheme...`. Select `android/code_style_scheme.xml` and press `OK` in the next dialog.
+
+## Formatting a file
+
+Before making a commit, please reformat your files using `Code -> Reformat File`. In the opening dialog, select the scope `Only VCS changed text` and tick all the optional checkbox (optimize imports, rearrange code and code cleanup).

--- a/docs/PR_GUIDE.md
+++ b/docs/PR_GUIDE.md
@@ -25,7 +25,7 @@
 - Comments in PR should be not only about things which are worth redeveloping but about good designs as well
 - It's better to ask the developer to make code simpler or add comments to the code base than to understand the code through the developer's explanation
 - It's worth writing comments in PR which help the PR author to learn something new
-- All code base should conform to ./docs/CPP_STYLE.md, ./docs/OBJC_STYLE.md or other style in ./docs/ depending on the language
+- All code base should conform to ./docs/CPP_STYLE.md, ./docs/OBJC_STYLE.md, ./docs/JAVA_STYLE.md or other style in ./docs/ depending on the language
 - Code review should be started as quick as possible after a PR is published. A reviewer should answer developer comments as quick as possible
 - If a PR looks good to a reviewer they should approve this PR. It means the review is finished
 - If a developer changes the PR significantly, the reviewers who have already approved the PR should be informed about these changes


### PR DESCRIPTION
This PR adds information about the Java style used in the Android app. This will make it easier for new contributors to use the right code style.