### PR TITLE
[android] Prevent sharing bookmarks to self

### DIFF
--- a/android/src/com/mapswithme/util/SharingUtils.java
+++ b/android/src/com/mapswithme/util/SharingUtils.java
@@ -3,6 +3,7 @@ package com.mapswithme.util;
 import android.content.ClipData;
 import android.content.Context;
 import android.content.Intent;
+import android.content.ComponentName;
 import android.location.Location;
 import android.net.Uri;
 import android.text.TextUtils;
@@ -112,6 +113,15 @@ public class SharingUtils
       intent.addFlags(Intent.FLAG_GRANT_READ_URI_PERMISSION | Intent.FLAG_GRANT_WRITE_URI_PERMISSION);
     }
 
-    context.startActivity(Intent.createChooser(intent, context.getString(R.string.share)));
+    Intent chooser = Intent.createChooser(intent, context.getString(R.string.share));
+
+    // Prevent sharing to ourselves (supported from API Level 24).
+    if (android.os.Build.VERSION.SDK_INT >= android.os.Build.VERSION_CODES.N)
+    {
+      ComponentName[] excludeSelf = { new ComponentName(context, com.mapswithme.maps.SplashActivity.class) };
+      chooser.putExtra(Intent.EXTRA_EXCLUDE_COMPONENTS, excludeSelf);
+    }
+
+    context.startActivity(chooser);
   }
 }


### PR DESCRIPTION
When sharing a bookmarks list a system chooser appears and amongst other targets there is Organic Maps app, i.e. its possible to share back to the app.

1. It doesn't make sense.
2. It leads to "Bookmarks upload failed. The file may be corrupted or defective." error.

This patch excludes self from sharing targets list. Tested on Android 9.0.
Unfortunately this solution will work for Android 7.0+ only.
I didn't find a good solution for earlier Android versions.