### PR TITLE
[android] Fix search floating toolbar focus on Android 8 and lower

### DIFF
--- a/android/src/com/mapswithme/maps/search/FloatingSearchToolbarController.java
+++ b/android/src/com/mapswithme/maps/search/FloatingSearchToolbarController.java
@@ -27,6 +27,8 @@ public class FloatingSearchToolbarController extends SearchToolbarController
   {
     super(activity.getWindow().getDecorView(), activity);
     mListener = listener;
+    // We only want to detect a click on the input and not allow editing.
+    disableQueryEditing();
   }
 
   @Override

--- a/android/src/com/mapswithme/maps/widget/SearchToolbarController.java
+++ b/android/src/com/mapswithme/maps/widget/SearchToolbarController.java
@@ -3,6 +3,7 @@ package com.mapswithme.maps.widget;
 import android.app.Activity;
 import android.content.ActivityNotFoundException;
 import android.content.Intent;
+import android.text.InputType;
 import android.text.TextUtils;
 import android.text.TextWatcher;
 import android.view.KeyEvent;
@@ -19,8 +20,7 @@ import com.mapswithme.util.InputUtils;
 import com.mapswithme.util.StringUtils;
 import com.mapswithme.util.UiUtils;
 
-public class SearchToolbarController extends ToolbarController
-                                  implements View.OnClickListener, View.OnFocusChangeListener
+public class SearchToolbarController extends ToolbarController implements View.OnClickListener
 {
   private static final int REQUEST_VOICE_RECOGNITION = 0xCA11;
   @Nullable
@@ -62,7 +62,7 @@ public class SearchToolbarController extends ToolbarController
     mSearchContainer = getToolbar().findViewById(R.id.search_container);
     mBack = mSearchContainer.findViewById(R.id.back);
     mQuery = mSearchContainer.findViewById(R.id.query);
-    mQuery.setOnFocusChangeListener(this);
+    mQuery.setOnClickListener(this);
     mQuery.addTextChangedListener(mTextWatcher);
     mQuery.setOnEditorActionListener(
         (v, actionId, event) ->
@@ -146,6 +146,13 @@ public class SearchToolbarController extends ToolbarController
     return R.string.search;
   }
 
+  protected void disableQueryEditing()
+  {
+    mQuery.setFocusable(false);
+    mQuery.setLongClickable(false);
+    mQuery.setInputType(InputType.TYPE_NULL);
+  }
+
   public String getQuery()
   {
     return (UiUtils.isVisible(mSearchContainer) ? mQuery.getText().toString() : "");
@@ -186,19 +193,16 @@ public class SearchToolbarController extends ToolbarController
   }
 
   @Override
-  public void onFocusChange(View view, boolean b)
-  {
-    if (view.getId()== R.id.query && b)
-        onQueryClick(getQuery());
-  }
-
-  @Override
   public void onClick(View v)
   {
     switch (v.getId())
     {
     case R.id.clear:
       onClearClick();
+      break;
+
+    case R.id.query:
+      onQueryClick(getQuery());
       break;
 
     case R.id.voice_input:


### PR DESCRIPTION
Do not rely on the focus event to detect a tap on the search query when looking at results on the map. Instead this PR makes use of the onClick event as before patch #2081 but also disables focusing and long pressing the input.

Compared to the previous implementation of onClick event handling, only a single click is needed to detect a tap. Compared to the current implementation using onFocus event (introduced with #2081), it works the same across Android versions.

Tested on physical device with Android 7 and an Android 11 emulator.

I do not have the internet bandwidth or the disk space to test on all Android versions. So please test this on your device to make sure it correctly fixes the issue and does not introduce any new.

Fixes #2347