### PR TITLE
[routing] CrossMwmConnector refactoring.

### DIFF
--- a/drape_frontend/visual_params.cpp
+++ b/drape_frontend/visual_params.cpp
@@ -1,12 +1,13 @@
 #include "drape_frontend/visual_params.hpp"
 
-#include "base/macros.hpp"
-#include "base/math.hpp"
-#include "base/assert.hpp"
+#include "indexer/scales.hpp"
 
 #include "geometry/mercator.hpp"
 
-#include "indexer/scales.hpp"
+#include "base/assert.hpp"
+#include "base/logging.hpp"
+#include "base/macros.hpp"
+#include "base/math.hpp"
 
 #include "std/target_os.hpp"
 
@@ -54,6 +55,8 @@ void VisualParams::Init(double vs, uint32_t tileSize)
   vizParams.m_tileSize = tileSize;
   vizParams.m_visualScale = vs;
 
+  LOG(LINFO, ("Visual scale =", vs, "; Tile size =", tileSize));
+
   // Here we set up glyphs rendering parameters separately for high-res and low-res screens.
   if (vs <= 1.0)
     vizParams.m_glyphVisualParams = { 0.48f, 0.08f, 0.2f, 0.01f, 0.49f, 0.04f };
@@ -97,6 +100,8 @@ void VisualParams::SetVisualScale(double visualScale)
 {
   ASSERT_INITED;
   m_visualScale = visualScale;
+
+  LOG(LINFO, ("Visual scale =", visualScale));
 }
 
 std::string const & VisualParams::GetResourcePostfix(double visualScale)

--- a/indexer/feature_decl.cpp
+++ b/indexer/feature_decl.cpp
@@ -21,9 +21,7 @@ string DebugPrint(GeomType type)
 
 string DebugPrint(FeatureID const & id)
 {
-  ostringstream ss;
-  ss << "{ " << DebugPrint(id.m_mwmId) << ", " << id.m_index << " }";
-  return ss.str();
+  return "{ " + DebugPrint(id.m_mwmId) + ", " + std::to_string(id.m_index) + " }";
 }
 
 // static

--- a/map/CMakeLists.txt
+++ b/map/CMakeLists.txt
@@ -77,6 +77,12 @@ set(SRC
   viewport_search_callback.hpp
 )
 
+if (PLATFORM_DESKTOP)
+  append(SRC
+    framework_visualize.cpp
+  )
+endif()
+
 omim_add_library(${PROJECT_NAME} ${SRC})
 
 target_link_libraries(${PROJECT_NAME}
@@ -96,7 +102,7 @@ omim_add_test_subdirectory(map_tests)
 omim_add_test_subdirectory(mwm_tests)
 omim_add_test_subdirectory(style_tests)
 
-if(PLATFORM_DESKTOP)
+if (PLATFORM_DESKTOP)
   add_subdirectory(benchmark_tool)
   add_subdirectory(extrapolation_benchmark)
 endif()

--- a/map/framework.hpp
+++ b/map/framework.hpp
@@ -304,10 +304,13 @@ public:
   BookmarkManager & GetBookmarkManager();
   BookmarkManager const & GetBookmarkManager() const;
 
-  // Utilities
+  /// @name Visualize utilities, used in desktop only. Implemented in framework_visualize.cpp
+  /// @{
   void VisualizeRoadsInRect(m2::RectD const & rect);
   void VisualizeCityBoundariesInRect(m2::RectD const & rect);
   void VisualizeCityRoadsInRect(m2::RectD const & rect);
+  void VisualizeCrossMwmTransitionsInRect(m2::RectD const & rect);
+  /// @}
 
 public:
   // SearchAPI::Delegate overrides:
@@ -362,7 +365,6 @@ public:
 
   std::vector<std::string> GetRegionsCountryIdByRect(m2::RectD const & rect, bool rough) const;
   std::vector<MwmSet::MwmId> GetMwmsByRect(m2::RectD const & rect, bool rough) const;
-  MwmSet::MwmId GetMwmIdByName(std::string const & name) const;
 
   void ReadFeatures(std::function<void(FeatureType &)> const & reader,
                     std::vector<FeatureID> const & features);

--- a/map/framework_visualize.cpp
+++ b/map/framework_visualize.cpp
@@ -1,0 +1,182 @@
+#include "framework.hpp"
+
+#include "routing/city_roads.hpp"
+#include "routing/cross_mwm_index_graph.hpp"
+
+namespace
+{
+dp::Color const colorList[] = {
+    {255, 0, 0, 255},   {0, 255, 0, 255},   {0, 0, 255, 255},
+    {255, 255, 0, 255}, {0, 255, 255, 255}, {255, 0, 255, 255},
+    {100, 0, 0, 255},   {0, 100, 0, 255},   {0, 0, 100, 255},
+    {100, 100, 0, 255}, {0, 100, 100, 255}, {100, 0, 100, 255}};
+
+dp::Color const cityBoundaryBBColor{255, 0, 0, 255};
+dp::Color const cityBoundaryCBColor{0, 255, 0, 255};
+dp::Color const cityBoundaryDBColor{0, 0, 255, 255};
+
+template <class Box>
+void DrawLine(Box const & box, dp::Color const & color, df::DrapeApi & drapeApi, std::string const & id)
+{
+  auto points = box.Points();
+  CHECK(!points.empty(), ());
+  points.push_back(points.front());
+
+  points.erase(unique(points.begin(), points.end(), [](m2::PointD const & p1, m2::PointD const & p2)
+  {
+    m2::PointD const delta = p2 - p1;
+    return delta.IsAlmostZero();
+  }), points.end());
+
+  if (points.size() <= 1)
+    return;
+
+  drapeApi.AddLine(id, df::DrapeApiLineData(points, color).Width(3.0f).ShowPoints(true).ShowId());
+}
+
+void VisualizeFeatureInRect(m2::RectD const & rect, FeatureType & ft, df::DrapeApi & drapeApi)
+{
+  bool allPointsOutside = true;
+  std::vector<m2::PointD> points;
+  ft.ForEachPoint([&](m2::PointD const & pt)
+  {
+    if (rect.IsPointInside(pt))
+      allPointsOutside = false;
+    points.push_back(pt);
+  }, scales::GetUpperScale());
+
+  if (!allPointsOutside)
+  {
+    static uint64_t counter = 0;
+    auto const color = colorList[counter++ % std::size(colorList)];
+
+    // Note. The first param at DrapeApi::AddLine() should be unique, so pass unique ft.GetID().
+    // Other way last added line replaces the previous added line with the same name.
+    drapeApi.AddLine(DebugPrint(ft.GetID()), df::DrapeApiLineData(points, color).Width(3.0f).ShowPoints(true).ShowId());
+  }
+}
+}  // namespace
+
+void Framework::VisualizeRoadsInRect(m2::RectD const & rect)
+{
+  m_featuresFetcher.ForEachFeature(rect, [this, &rect](FeatureType & ft)
+  {
+    if (routing::IsRoad(feature::TypesHolder(ft)))
+      VisualizeFeatureInRect(rect, ft, m_drapeApi);
+  }, scales::GetUpperScale());
+}
+
+void Framework::VisualizeCityBoundariesInRect(m2::RectD const & rect)
+{
+  DataSource const & dataSource = GetDataSource();
+  search::CitiesBoundariesTable table(dataSource);
+  table.Load();
+
+  std::vector<uint32_t> featureIds;
+  GetCityBoundariesInRectForTesting(table, rect, featureIds);
+
+  FeaturesLoaderGuard loader(dataSource, dataSource.GetMwmIdByCountryFile(platform::CountryFile("World")));
+  for (auto const fid : featureIds)
+  {
+    search::CitiesBoundariesTable::Boundaries boundaries;
+    if (!table.Get(fid, boundaries))
+      continue;
+
+    std::string id = "fid:" + strings::to_string(fid);
+    auto ft = loader.GetFeatureByIndex(fid);
+    if (ft)
+      id.append(", name:").append(ft->GetName(StringUtf8Multilang::kDefaultCode));
+
+    boundaries.ForEachBoundary([&id, this](indexer::CityBoundary const & cityBoundary, size_t i)
+    {
+      std::string idWithIndex = id;
+      if (i > 0)
+        idWithIndex = id + ", i:" + strings::to_string(i);
+
+      DrawLine(cityBoundary.m_bbox, cityBoundaryBBColor, m_drapeApi, idWithIndex + ", bb");
+      DrawLine(cityBoundary.m_cbox, cityBoundaryCBColor, m_drapeApi, idWithIndex + ", cb");
+      DrawLine(cityBoundary.m_dbox, cityBoundaryDBColor, m_drapeApi, idWithIndex + ", db");
+    });
+  }
+}
+
+void Framework::VisualizeCityRoadsInRect(m2::RectD const & rect)
+{
+  std::map<MwmSet::MwmId, std::unique_ptr<routing::CityRoads>> cityRoads;
+  GetDataSource().ForEachInRect([&](FeatureType & ft)
+  {
+    if (ft.GetGeomType() != feature::GeomType::Line)
+      return;
+
+    auto const & mwmId = ft.GetID().m_mwmId;
+    auto const it = cityRoads.find(mwmId);
+    if (it == cityRoads.cend())
+    {
+      MwmSet::MwmHandle handle = m_featuresFetcher.GetDataSource().GetMwmHandleById(mwmId);
+      CHECK(handle.IsAlive(), ());
+
+      cityRoads[mwmId] = routing::LoadCityRoads(handle);
+    }
+
+    if (cityRoads[mwmId]->IsCityRoad(ft.GetID().m_index))
+      VisualizeFeatureInRect(rect, ft, m_drapeApi);
+
+  }, rect, scales::GetUpperScale());
+}
+
+void Framework::VisualizeCrossMwmTransitionsInRect(m2::RectD const & rect)
+{
+  using CrossMwmID = base::GeoObjectId;
+  using ConnectorT = routing::CrossMwmConnector<CrossMwmID>;
+  std::map<MwmSet::MwmId, ConnectorT> connectors;
+  std::map<MwmSet::MwmId, dp::Color> colors;
+
+  GetDataSource().ForEachInRect([&](FeatureType & ft)
+  {
+    if (ft.GetGeomType() != feature::GeomType::Line)
+      return;
+
+    auto const & mwmId = ft.GetID().m_mwmId;
+    auto res = connectors.try_emplace(mwmId, ConnectorT());
+    ConnectorT & connector = res.first->second;
+    if (res.second)
+    {
+      MwmSet::MwmHandle handle = m_featuresFetcher.GetDataSource().GetMwmHandleById(mwmId);
+      CHECK(handle.IsAlive(), ());
+
+      FilesContainerR::TReader reader(routing::connector::GetReader<CrossMwmID>(handle.GetValue()->m_cont));
+      ReaderSource src(reader);
+      routing::CrossMwmConnectorSerializer::DeserializeTransitions(routing::VehicleType::Car, connector, src);
+
+      static uint32_t counter = 0;
+      colors.emplace(mwmId, colorList[counter++ % std::size(colorList)]);
+    }
+
+    std::vector<uint32_t> transitSegments;
+    connector.ForEachTransitSegmentId(ft.GetID().m_index, [&transitSegments](uint32_t seg)
+    {
+      transitSegments.push_back(seg);
+      return false;
+    });
+
+    if (!transitSegments.empty())
+    {
+      auto const color = colors.find(mwmId)->second;
+
+      int segIdx = -1;
+      m2::PointD prevPt;
+      ft.ForEachPoint([&](m2::PointD const & pt)
+      {
+        if (base::IsExist(transitSegments, segIdx))
+        {
+          GetDrapeApi().AddLine(DebugPrint(ft.GetID()) + ", " + std::to_string(segIdx),
+                                df::DrapeApiLineData({prevPt, pt}, color).Width(10.0f));
+        }
+
+        prevPt = pt;
+        ++segIdx;
+      }, scales::GetUpperScale());
+    }
+
+  }, rect, scales::GetUpperScale());
+}

--- a/qt/CMakeLists.txt
+++ b/qt/CMakeLists.txt
@@ -40,6 +40,8 @@ set(SRC
   place_page_dialog.hpp
   preferences_dialog.cpp
   preferences_dialog.hpp
+  popup_menu_holder.cpp
+  popup_menu_holder.hpp
   routing_settings_dialog.cpp
   routing_settings_dialog.hpp
   routing_turns_visualizer.cpp
@@ -50,6 +52,7 @@ set(SRC
   screenshoter.hpp
   search_panel.cpp
   search_panel.hpp
+  selection.hpp
   update_dialog.cpp
   update_dialog.hpp
 )

--- a/qt/draw_widget.cpp
+++ b/qt/draw_widget.cpp
@@ -204,7 +204,7 @@ void DrawWidget::mousePressEvent(QMouseEvent * e)
     {
       SubmitBookmark(pt);
     }
-    else if (!m_currentSelectionMode || IsCommandModifier(e))
+    else if (!m_selectionMode || IsCommandModifier(e))
     {
       ShowInfoPopup(e, pt);
     }
@@ -228,7 +228,7 @@ void DrawWidget::mouseMoveEvent(QMouseEvent * e)
   if (IsLeftButton(e) && !IsAltModifier(e))
     m_framework.TouchEvent(GetTouchEvent(e, df::TouchEvent::TOUCH_MOVE));
 
-  if (m_currentSelectionMode && m_rubberBand != nullptr && m_rubberBand->isVisible())
+  if (m_selectionMode && m_rubberBand != nullptr && m_rubberBand->isVisible())
   {
     m_rubberBand->setGeometry(QRect(m_rubberBandOrigin, e->pos()).normalized());
   }
@@ -303,7 +303,7 @@ void DrawWidget::mouseReleaseEvent(QMouseEvent * e)
   {
     m_framework.TouchEvent(GetTouchEvent(e, df::TouchEvent::TOUCH_UP));
   }
-  else if (m_currentSelectionMode && IsRightButton(e) &&
+  else if (m_selectionMode && IsRightButton(e) &&
            m_rubberBand != nullptr && m_rubberBand->isVisible())
   {
     ProcessSelectionMode();
@@ -318,7 +318,7 @@ void DrawWidget::ProcessSelectionMode()
   rect.Add(m_framework.PtoG(m2::PointD(L2D(lt.x()), L2D(lt.y()))));
   rect.Add(m_framework.PtoG(m2::PointD(L2D(rb.x()), L2D(rb.y()))));
 
-  switch (*m_currentSelectionMode)
+  switch (*m_selectionMode)
   {
   case SelectionMode::Features:
   {
@@ -645,7 +645,7 @@ void DrawWidget::SetRouter(routing::RouterType routerType)
 
 void DrawWidget::SetRuler(bool enabled)
 {
-  if(!enabled)
+  if (!enabled)
     m_ruler.EraseLine(m_framework.GetDrapeApi());
   m_ruler.SetActive(enabled);
 }

--- a/qt/draw_widget.cpp
+++ b/qt/draw_widget.cpp
@@ -225,13 +225,12 @@ void DrawWidget::mouseMoveEvent(QMouseEvent * e)
     return;
 
   QOpenGLWidget::mouseMoveEvent(e);
+
   if (IsLeftButton(e) && !IsAltModifier(e))
     m_framework.TouchEvent(GetTouchEvent(e, df::TouchEvent::TOUCH_MOVE));
 
   if (m_selectionMode && m_rubberBand != nullptr && m_rubberBand->isVisible())
-  {
     m_rubberBand->setGeometry(QRect(m_rubberBandOrigin, e->pos()).normalized());
-  }
 }
 
 void DrawWidget::VisualizeMwmsBordersInRect(m2::RectD const & rect, bool withVertices,
@@ -259,13 +258,11 @@ void DrawWidget::VisualizeMwmsBordersInRect(m2::RectD const & rect, bool withVer
     }
     else
     {
-      std::string const bordersDir =
-          base::JoinPath(GetPlatform().ResourcesDir(), BORDERS_DIR);
-
+      std::string const bordersDir = base::JoinPath(GetPlatform().WritableDir(), BORDERS_DIR);
       std::string const path = base::JoinPath(bordersDir, mwmName + BORDERS_EXTENSION);
+
       std::vector<m2::RegionD> polygons;
       borders::LoadBorders(path, polygons);
-
       return polygons;
     }
   };
@@ -321,56 +318,51 @@ void DrawWidget::ProcessSelectionMode()
   switch (*m_selectionMode)
   {
   case SelectionMode::Features:
-  {
     m_framework.VisualizeRoadsInRect(rect);
     break;
-  }
+
   case SelectionMode::CityBoundaries:
-  {
     m_framework.VisualizeCityBoundariesInRect(rect);
     break;
-  }
+
   case SelectionMode::CityRoads:
-  {
     m_framework.VisualizeCityRoadsInRect(rect);
     break;
-  }
+
+  case SelectionMode::CrossMwmSegments:
+    m_framework.VisualizeCrossMwmTransitionsInRect(rect);
+    break;
+
   case SelectionMode::MwmsBordersByPolyFiles:
-  {
     VisualizeMwmsBordersInRect(rect, false /* withVertices */, false /* fromPackedPolygon */,
                                false /* boundingBox */);
     break;
-  }
+
   case SelectionMode::MwmsBordersWithVerticesByPolyFiles:
-  {
     VisualizeMwmsBordersInRect(rect, true /* withVertices */, false /* fromPackedPolygon */,
                                false /* boundingBox */);
     break;
-  }
+
   case SelectionMode::MwmsBordersByPackedPolygon:
-  {
     VisualizeMwmsBordersInRect(rect, false /* withVertices */, true /* fromPackedPolygon */,
                                false /* boundingBox */);
     break;
-  }
+
   case SelectionMode::MwmsBordersWithVerticesByPackedPolygon:
-  {
     VisualizeMwmsBordersInRect(rect, true /* withVertices */, true /* fromPackedPolygon */,
                                false /* boundingBox */);
     break;
-  }
+
   case SelectionMode::BoundingBoxByPolyFiles:
-  {
     VisualizeMwmsBordersInRect(rect, true /* withVertices */, false /* fromPackedPolygon */,
                                true /* boundingBox */);
     break;
-  }
+
   case SelectionMode::BoundingBoxByPackedPolygon:
-  {
     VisualizeMwmsBordersInRect(rect, true /* withVertices */, true /* fromPackedPolygon */,
                                true /* boundingBox */);
     break;
-  }
+
   default:
     UNREACHABLE();
   }

--- a/qt/draw_widget.hpp
+++ b/qt/draw_widget.hpp
@@ -3,6 +3,7 @@
 #include "qt/qt_common/map_widget.hpp"
 #include "qt/routing_turns_visualizer.hpp"
 #include "qt/ruler.hpp"
+#include "qt/selection.hpp"
 
 #include "map/everywhere_search_params.hpp"
 #include "map/place_page_info.hpp"
@@ -112,27 +113,19 @@ private:
   bool m_emulatingLocation;
 
 public:
-  enum class SelectionMode
-  {
-    Features,
-    CityBoundaries,
-    CityRoads,
-    MwmsBordersByPolyFiles,
-    MwmsBordersWithVerticesByPolyFiles,
-    MwmsBordersByPackedPolygon,
-    MwmsBordersWithVerticesByPackedPolygon,
-    BoundingBoxByPolyFiles,
-    BoundingBoxByPackedPolygon,
-  };
+  /// Pass empty \a mode to drop selection.
+  void SetSelectionMode(std::optional<SelectionMode> mode) { m_selectionMode = mode; }
 
-  void SetSelectionMode(SelectionMode mode) { m_currentSelectionMode = {mode}; }
-  void DropSelectionMode() { m_currentSelectionMode = {}; }
-  bool SelectionModeIsSet() { return static_cast<bool>(m_currentSelectionMode); }
-  SelectionMode GetSelectionMode() const { return *m_currentSelectionMode; }
+  void DropSelectionIfMWMBordersMode()
+  {
+    static_assert(SelectionMode::MWMBorders < SelectionMode::Cancelled, "");
+    if (m_selectionMode && *m_selectionMode > SelectionMode::MWMBorders && *m_selectionMode < SelectionMode::Cancelled)
+      m_selectionMode = {};
+  }
 
 private:
   void ProcessSelectionMode();
-  std::optional<SelectionMode> m_currentSelectionMode;
+  std::optional<SelectionMode> m_selectionMode;
   RouteMarkType m_routePointAddMode = RouteMarkType::Finish;
 
   std::unique_ptr<Screenshoter> m_screenshoter;

--- a/qt/main.cpp
+++ b/qt/main.cpp
@@ -158,7 +158,6 @@ int main(int argc, char * argv[])
   }
 
   int returnCode = -1;
-  QString mapcssFilePath;
   if (eulaAccepted)   // User has accepted EULA
   {
     bool apiOpenGLES3 = false;
@@ -204,6 +203,7 @@ int main(int argc, char * argv[])
     FrameworkParams frameworkParams;
 
 #ifdef BUILD_DESIGNER
+    QString mapcssFilePath;
     if (argc >= 2 && platform.IsFileExistsByFullPath(argv[1]))
         mapcssFilePath = argv[1];
     if (0 == mapcssFilePath.length())
@@ -233,7 +233,11 @@ int main(int argc, char * argv[])
 
     Framework framework(frameworkParams);
     qt::MainWindow w(framework, apiOpenGLES3, std::move(screenshotParams),
-                     app.primaryScreen()->geometry(), mapcssFilePath);
+                     app.primaryScreen()->geometry()
+#ifdef BUILD_DESIGNER
+                     , mapcssFilePath
+#endif // BUILD_DESIGNER
+                     );
     w.show();
     returnCode = app.exec();
   }

--- a/qt/mainwindow.cpp
+++ b/qt/mainwindow.cpp
@@ -339,6 +339,8 @@ void MainWindow::CreateNavigationBar()
                            std::bind(&MainWindow::OnSwitchSelectionMode, this, SelectionMode::CityBoundaries), true);
     m_selection->addAction(QIcon(":/navig64/city_roads.png"), tr("City roads selection mode"),
                            std::bind(&MainWindow::OnSwitchSelectionMode, this, SelectionMode::CityRoads), true);
+    m_selection->addAction(QIcon(":/navig64/test.png"), tr("Cross MWM segments selection mode"),
+                           std::bind(&MainWindow::OnSwitchSelectionMode, this, SelectionMode::CrossMwmSegments), true);
     m_selection->addAction(QIcon(":/navig64/borders_selection.png"), tr("MWMs borders selection mode"),
                            this, SLOT(OnSwitchMwmsBordersSelectionMode()), true);
 

--- a/qt/mainwindow.cpp
+++ b/qt/mainwindow.cpp
@@ -4,6 +4,7 @@
 #include "qt/mainwindow.hpp"
 #include "qt/mwms_borders_selection.hpp"
 #include "qt/osm_auth_dialog.hpp"
+#include "qt/popup_menu_holder.hpp"
 #include "qt/preferences_dialog.hpp"
 #include "qt/qt_common/helpers.hpp"
 #include "qt/qt_common/scale_slider.hpp"
@@ -18,6 +19,7 @@
 
 #include "defines.hpp"
 
+#include <functional>
 #include <sstream>
 
 #include "std/target_os.hpp"
@@ -33,55 +35,31 @@
 #endif // BUILD_DESIGNER
 
 #include <QtGui/QCloseEvent>
-#include <QtWidgets/QAction>
 #include <QtWidgets/QDesktopWidget>
 #include <QtWidgets/QDockWidget>
 #include <QtWidgets/QFileDialog>
 #include <QtWidgets/QHBoxLayout>
 #include <QtWidgets/QLabel>
-#include <QtWidgets/QMenu>
 #include <QtWidgets/QMenuBar>
 #include <QtWidgets/QMessageBox>
 #include <QtWidgets/QPushButton>
 #include <QtWidgets/QStatusBar>
 #include <QtWidgets/QToolBar>
-#include <QtWidgets/QToolButton>
 
+#ifdef OMIM_OS_WINDOWS
 #define IDM_ABOUT_DIALOG        1001
 #define IDM_PREFERENCES_DIALOG  1002
+#endif
 
 #ifndef NO_DOWNLOADER
 #include "qt/update_dialog.hpp"
 #include "qt/info_dialog.hpp"
-
-#include "indexer/classificator.hpp"
-
-#include <QtCore/QFile>
-
 #endif // NO_DOWNLOADER
 
+namespace qt
+{
 namespace
 {
-using namespace qt;
-
-struct button_t
-{
-  QString name;
-  char const * icon;
-  char const * slot;
-};
-
-void add_buttons(QToolBar * pBar, button_t buttons[], size_t count, QObject * pReceiver)
-{
-  for (size_t i = 0; i < count; ++i)
-  {
-    if (buttons[i].icon)
-      pBar->addAction(QIcon(buttons[i].icon), buttons[i].name, pReceiver, buttons[i].slot);
-    else
-      pBar->addSeparator();
-  }
-}
-
 void FormatMapSize(uint64_t sizeInBytes, std::string & units, size_t & sizeToDownload)
 {
   int const mbInBytes = 1024 * 1024;
@@ -103,60 +81,17 @@ void FormatMapSize(uint64_t sizeInBytes, std::string & units, size_t & sizeToDow
   }
 }
 
-DrawWidget::SelectionMode ConvertFromMwmsBordersSelection(qt::MwmsBordersSelection::Response mode)
-{
-  switch (mode)
-  {
-  case MwmsBordersSelection::Response::MwmsBordersByPolyFiles:
-  {
-    return DrawWidget::SelectionMode::MwmsBordersByPolyFiles;
-  }
-  case MwmsBordersSelection::Response::MwmsBordersWithVerticesByPolyFiles:
-  {
-    return DrawWidget::SelectionMode::MwmsBordersWithVerticesByPolyFiles;
-  }
-  case MwmsBordersSelection::Response::MwmsBordersByPackedPolygon:
-  {
-    return DrawWidget::SelectionMode::MwmsBordersByPackedPolygon;
-  }
-  case MwmsBordersSelection::Response::MwmsBordersWithVerticesByPackedPolygon:
-  {
-    return DrawWidget::SelectionMode::MwmsBordersWithVerticesByPackedPolygon;
-  }
-  case MwmsBordersSelection::Response::BoundingBoxByPolyFiles:
-  {
-    return DrawWidget::SelectionMode::BoundingBoxByPolyFiles;
-  }
-  case MwmsBordersSelection::Response::BoundingBoxByPackedPolygon:
-  {
-    return DrawWidget::SelectionMode::BoundingBoxByPackedPolygon;
-  }
-  default:
-    UNREACHABLE();
-  }
-}
-
-bool IsMwmsBordersSelectionMode(DrawWidget::SelectionMode mode)
-{
-  return mode == DrawWidget::SelectionMode::MwmsBordersByPolyFiles ||
-         mode == DrawWidget::SelectionMode::MwmsBordersWithVerticesByPolyFiles ||
-         mode == DrawWidget::SelectionMode::MwmsBordersByPackedPolygon ||
-         mode == DrawWidget::SelectionMode::MwmsBordersWithVerticesByPackedPolygon;
-}
 }  // namespace
 
-namespace qt
-{
 // Defined in osm_auth_dialog.cpp.
 extern char const * kTokenKeySetting;
 extern char const * kTokenSecretSetting;
 
 MainWindow::MainWindow(Framework & framework, bool apiOpenGLES3,
                        std::unique_ptr<ScreenshotParams> && screenshotParams,
-                       QRect const & screenGeometry,
-                       QString const &
+                       QRect const & screenGeometry
 #ifdef BUILD_DESIGNER
-                       mapcssFilePath
+                       , QString const & mapcssFilePath
 #endif
                        )
   : m_Docks{}
@@ -190,8 +125,7 @@ MainWindow::MainWindow(Framework & framework, bool apiOpenGLES3,
     setFixedSize(width, height + statusBar()->height());
   }
 
-  QObject::connect(m_pDrawWidget, &common::MapWidget::BeforeEngineCreation, this,
-                   &MainWindow::OnBeforeEngineCreation);
+  connect(m_pDrawWidget, SIGNAL(BeforeEngineCreation()), this, SLOT(OnBeforeEngineCreation()));
 
   CreateCountryStatusControls();
   CreateNavigationBar();
@@ -340,148 +274,102 @@ void MainWindow::CreateNavigationBar()
   }
 
   {
-    m_selectLayerTrafficAction = new QAction(QIcon(":/navig64/traffic.png"), tr("Traffic"), this);
-    m_selectLayerTrafficAction->setCheckable(true);
-    m_selectLayerTrafficAction->setChecked(m_pDrawWidget->GetFramework().LoadTrafficEnabled());
-    connect(m_selectLayerTrafficAction, &QAction::triggered, this, &MainWindow::OnTrafficEnabled);
+    using namespace std::placeholders;
 
-    m_selectLayerTransitAction =
-        new QAction(QIcon(":/navig64/subway.png"), tr("Public transport"), this);
-    m_selectLayerTransitAction->setCheckable(true);
-    m_selectLayerTransitAction->setChecked(
-        m_pDrawWidget->GetFramework().LoadTransitSchemeEnabled());
-    connect(m_selectLayerTransitAction, &QAction::triggered, this, &MainWindow::OnTransitEnabled);
+    m_layers = new PopupMenuHolder(this);
 
-    m_selectLayerIsolinesAction =
-        new QAction(QIcon(":/navig64/isolines.png"), tr("Isolines"), this);
-    m_selectLayerIsolinesAction->setCheckable(true);
-    m_selectLayerIsolinesAction->setChecked(m_pDrawWidget->GetFramework().LoadIsolinesEnabled());
-    connect(m_selectLayerIsolinesAction, &QAction::triggered, this, &MainWindow::OnIsolinesEnabled);
+    m_layers->addAction(QIcon(":/navig64/traffic.png"), tr("Traffic"),
+                        std::bind(&MainWindow::OnLayerEnabled, this, LayerType::TRAFFIC), true);
+    m_layers->setChecked(LayerType::TRAFFIC, m_pDrawWidget->GetFramework().LoadTrafficEnabled());
 
-    auto layersMenu = new QMenu();
-    layersMenu->addAction(m_selectLayerTrafficAction);
-    layersMenu->addAction(m_selectLayerTransitAction);
-    layersMenu->addAction(m_selectLayerIsolinesAction);
+    m_layers->addAction(QIcon(":/navig64/subway.png"), tr("Public transport"),
+                        std::bind(&MainWindow::OnLayerEnabled, this, LayerType::TRANSIT), true);
+    m_layers->setChecked(LayerType::TRANSIT, m_pDrawWidget->GetFramework().LoadTransitSchemeEnabled());
 
-    m_selectLayerButton = new QToolButton();
-    m_selectLayerButton->setPopupMode(QToolButton::MenuButtonPopup);
-    m_selectLayerButton->setMenu(layersMenu);
-    m_selectLayerButton->setIcon(QIcon(":/navig64/layers.png"));
-    pToolBar->addWidget(m_selectLayerButton);
+    m_layers->addAction(QIcon(":/navig64/isolines.png"), tr("Isolines"),
+                        std::bind(&MainWindow::OnLayerEnabled, this, LayerType::ISOLINES), true);
+    m_layers->setChecked(LayerType::ISOLINES, m_pDrawWidget->GetFramework().LoadIsolinesEnabled());
+
+    pToolBar->addWidget(m_layers->create());
+    m_layers->setMainIcon(QIcon(":/navig64/layers.png"));
+
     pToolBar->addSeparator();
 
-    m_bookmarksAction = pToolBar->addAction(QIcon(":/navig64/bookmark.png"), tr("Show bookmarks and tracks"),
-                                            this, SLOT(OnBookmarksAction()));
+    pToolBar->addAction(QIcon(":/navig64/bookmark.png"), tr("Show bookmarks and tracks"),
+                        this, SLOT(OnBookmarksAction()));
     pToolBar->addSeparator();
 
 #ifndef BUILD_DESIGNER
-    m_selectStartRoutePoint = new QAction(QIcon(":/navig64/point-start.png"),
-                                          tr("Start point"), this);
-    connect(m_selectStartRoutePoint, &QAction::triggered, this, &MainWindow::OnStartPointSelected);
+    m_routing = new PopupMenuHolder(this);
 
-    m_selectFinishRoutePoint = new QAction(QIcon(":/navig64/point-finish.png"),
-                                           tr("Finish point"), this);
-    connect(m_selectFinishRoutePoint, &QAction::triggered, this, &MainWindow::OnFinishPointSelected);
+    // The order should be the same as in "enum class RouteMarkType".
+    m_routing->addAction(QIcon(":/navig64/point-start.png"), tr("Start point"),
+                         std::bind(&MainWindow::OnRoutePointSelected, this, RouteMarkType::Start), false);
+    m_routing->addAction(QIcon(":/navig64/point-intermediate.png"), tr("Intermediate point"),
+                         std::bind(&MainWindow::OnRoutePointSelected, this, RouteMarkType::Intermediate), false);
+    m_routing->addAction(QIcon(":/navig64/point-finish.png"), tr("Finish point"),
+                         std::bind(&MainWindow::OnRoutePointSelected, this, RouteMarkType::Finish), false);
 
-    m_selectIntermediateRoutePoint = new QAction(QIcon(":/navig64/point-intermediate.png"),
-                                                 tr("Intermediate point"), this);
-    connect(m_selectIntermediateRoutePoint, &QAction::triggered, this, &MainWindow::OnIntermediatePointSelected);
+    QToolButton * toolBtn = m_routing->create();
+    toolBtn->setToolTip(tr("Select mode and use SHIFT + LMB to set point"));
+    pToolBar->addWidget(toolBtn);
+    m_routing->setCurrent(m_pDrawWidget->GetRoutePointAddMode());
 
-    auto routePointsMenu = new QMenu();
-    routePointsMenu->addAction(m_selectStartRoutePoint);
-    routePointsMenu->addAction(m_selectFinishRoutePoint);
-    routePointsMenu->addAction(m_selectIntermediateRoutePoint);
-    m_routePointsToolButton = new QToolButton();
-    m_routePointsToolButton->setPopupMode(QToolButton::MenuButtonPopup);
-    m_routePointsToolButton->setMenu(routePointsMenu);
-    switch (m_pDrawWidget->GetRoutePointAddMode())
-    {
-    case RouteMarkType::Start:
-      m_routePointsToolButton->setIcon(m_selectStartRoutePoint->icon());
-      break;
-    case RouteMarkType::Finish:
-      m_routePointsToolButton->setIcon(m_selectFinishRoutePoint->icon());
-      break;
-    case RouteMarkType::Intermediate:
-      m_routePointsToolButton->setIcon(m_selectIntermediateRoutePoint->icon());
-      break;
-    }
-    pToolBar->addWidget(m_routePointsToolButton);
-    auto routingAction = pToolBar->addAction(QIcon(":/navig64/routing.png"), tr("Follow route"),
-                                             this, SLOT(OnFollowRoute()));
-    routingAction->setToolTip(tr("Follow route"));
-    auto clearAction = pToolBar->addAction(QIcon(":/navig64/clear-route.png"), tr("Clear route"),
-                                           this, SLOT(OnClearRoute()));
-    clearAction->setToolTip(tr("Clear route"));
-
-    auto settingsRoutingAction = pToolBar->addAction(QIcon(":/navig64/settings-routing.png"),
-                                                     tr("Routing settings"), this,
-                                                     SLOT(OnRoutingSettings()));
-    settingsRoutingAction->setToolTip(tr("Routing settings"));
+    QAction * act = pToolBar->addAction(QIcon(":/navig64/routing.png"), tr("Follow route"), this, SLOT(OnFollowRoute()));
+    act->setToolTip(tr("Build route and use ALT + LMB to emulate current position"));
+    pToolBar->addAction(QIcon(":/navig64/clear-route.png"), tr("Clear route"), this, SLOT(OnClearRoute()));
+    pToolBar->addAction(QIcon(":/navig64/settings-routing.png"), tr("Routing settings"), this, SLOT(OnRoutingSettings()));
 
     pToolBar->addSeparator();
 
     m_pCreateFeatureAction = pToolBar->addAction(QIcon(":/navig64/select.png"), tr("Create Feature"),
                                                  this, SLOT(OnCreateFeatureClicked()));
     m_pCreateFeatureAction->setCheckable(true);
-    m_pCreateFeatureAction->setToolTip(tr("Please select position on a map."));
+    m_pCreateFeatureAction->setToolTip(tr("Push to select position, next push to create Feature"));
     m_pCreateFeatureAction->setShortcut(QKeySequence::New);
 
     pToolBar->addSeparator();
 
-    m_selectionMode = pToolBar->addAction(QIcon(":/navig64/selectmode.png"), tr("Selection mode"),
-                                          this, SLOT(OnSwitchSelectionMode()));
-    m_selectionMode->setCheckable(true);
-    m_selectionMode->setToolTip(tr("Turn on/off selection mode"));
+    m_selection = new PopupMenuHolder(this);
 
-    m_selectionCityBoundariesMode =
-        pToolBar->addAction(QIcon(":/navig64/city_boundaries.png"), tr("City boundaries selection mode"),
-                            this, SLOT(OnSwitchCityBoundariesSelectionMode()));
-    m_selectionCityBoundariesMode->setCheckable(true);
+    // The order should be the same as in "enum class SelectionMode".
+    m_selection->addAction(QIcon(":/navig64/selectmode.png"), tr("Roads selection mode"),
+                           std::bind(&MainWindow::OnSwitchSelectionMode, this, SelectionMode::Features), true);
+    m_selection->addAction(QIcon(":/navig64/city_boundaries.png"), tr("City boundaries selection mode"),
+                           std::bind(&MainWindow::OnSwitchSelectionMode, this, SelectionMode::CityBoundaries), true);
+    m_selection->addAction(QIcon(":/navig64/city_roads.png"), tr("City roads selection mode"),
+                           std::bind(&MainWindow::OnSwitchSelectionMode, this, SelectionMode::CityRoads), true);
+    m_selection->addAction(QIcon(":/navig64/borders_selection.png"), tr("MWMs borders selection mode"),
+                           this, SLOT(OnSwitchMwmsBordersSelectionMode()), true);
 
-    m_selectionCityRoadsMode =
-        pToolBar->addAction(QIcon(":/navig64/city_roads.png"), tr("City roads selection mode"),
-                            this, SLOT(OnSwitchCityRoadsSelectionMode()));
-    m_selectionCityRoadsMode->setCheckable(true);
+    toolBtn = m_selection->create();
+    toolBtn->setToolTip(tr("Select mode and use RMB to define selection box"));
+    pToolBar->addWidget(toolBtn);
 
-    m_selectionMwmsBordersMode =
-      pToolBar->addAction(QIcon(":/navig64/borders_selection.png"), tr("MWMs borders selection mode"),
-                          this, SLOT(OnSwitchMwmsBordersSelectionMode()));
-    m_selectionMwmsBordersMode->setCheckable(true);
+    pToolBar->addAction(QIcon(":/navig64/clear.png"), tr("Clear selection"), this, SLOT(OnClearSelection()));
 
     pToolBar->addSeparator();
 
 #endif // NOT BUILD_DESIGNER
 
     // Add search button with "checked" behavior.
-    m_pSearchAction = pToolBar->addAction(QIcon(":/navig64/search.png"), tr("Search"),
+    m_pSearchAction = pToolBar->addAction(QIcon(":/navig64/search.png"), tr("Offline Search"),
                                           this, SLOT(OnSearchButtonClicked()));
     m_pSearchAction->setCheckable(true);
-    m_pSearchAction->setToolTip(tr("Offline Search"));
     m_pSearchAction->setShortcut(QKeySequence::Find);
 
-    m_rulerAction = pToolBar->addAction(QIcon(":/navig64/ruler.png"), tr("Ruler"),
-                                        this, SLOT(OnRulerEnabled()));
+    m_rulerAction = pToolBar->addAction(QIcon(":/navig64/ruler.png"), tr("Ruler"), this, SLOT(OnRulerEnabled()));
+    m_rulerAction->setToolTip(tr("Check this button and use ALT + LMB to set points"));
     m_rulerAction->setCheckable(true);
     m_rulerAction->setChecked(false);
-
-    pToolBar->addSeparator();
-
-    m_clearSelection = pToolBar->addAction(QIcon(":/navig64/clear.png"), tr("Clear selection"),
-                                           this, SLOT(OnClearSelection()));
-    m_clearSelection->setToolTip(tr("Clear selection"));
 
     pToolBar->addSeparator();
 
 // #ifndef OMIM_OS_LINUX
     // add my position button with "checked" behavior
 
-    m_pMyPositionAction = pToolBar->addAction(QIcon(":/navig64/location.png"),
-                                           tr("My Position"),
-                                           this,
-                                           SLOT(OnMyPosition()));
+    m_pMyPositionAction = pToolBar->addAction(QIcon(":/navig64/location.png"), tr("My Position"), this, SLOT(OnMyPosition()));
     m_pMyPositionAction->setCheckable(true);
-    m_pMyPositionAction->setToolTip(tr("My Position"));
 // #endif
 
 #ifdef BUILD_DESIGNER
@@ -539,16 +427,12 @@ void MainWindow::CreateNavigationBar()
 #endif // BUILD_DESIGNER
   }
 
+  pToolBar->addSeparator();
   qt::common::ScaleSlider::Embed(Qt::Vertical, *pToolBar, *m_pDrawWidget);
+
 #ifndef NO_DOWNLOADER
-  {
-    // add mainframe actions
-    button_t arr[] = {
-      { QString(), 0, 0 },
-      { tr("Download Maps"), ":/navig64/download.png", SLOT(ShowUpdateDialog()) }
-    };
-    add_buttons(pToolBar, arr, ARRAY_SIZE(arr), this);
-  }
+  pToolBar->addSeparator();
+  pToolBar->addAction(QIcon(":/navig64/download.png"), tr("Download Maps"), this, SLOT(ShowUpdateDialog()));
 #endif // NO_DOWNLOADER
 
   if (m_screenshotMode)
@@ -692,61 +576,37 @@ void MainWindow::OnCreateFeatureClicked()
   }
 }
 
-void MainWindow::OnSwitchSelectionMode()
+void MainWindow::OnSwitchSelectionMode(SelectionMode mode)
 {
-  m_selectionCityBoundariesMode->setChecked(false);
-  m_selectionCityRoadsMode->setChecked(false);
-  m_selectionMwmsBordersMode->setChecked(false);
-
-  m_pDrawWidget->SetSelectionMode(DrawWidget::SelectionMode::Features);
-}
-
-void MainWindow::OnSwitchCityBoundariesSelectionMode()
-{
-  m_selectionMode->setChecked(false);
-  m_selectionCityRoadsMode->setChecked(false);
-  m_selectionMwmsBordersMode->setChecked(false);
-
-  m_pDrawWidget->SetSelectionMode(DrawWidget::SelectionMode::CityBoundaries);
-}
-
-void MainWindow::OnSwitchCityRoadsSelectionMode()
-{
-  m_selectionMode->setChecked(false);
-  m_selectionCityBoundariesMode->setChecked(false);
-  m_selectionMwmsBordersMode->setChecked(false);
-
-  m_pDrawWidget->SetSelectionMode(DrawWidget::SelectionMode::CityRoads);
+  if (m_selection->isChecked(mode))
+  {
+    m_selection->setCurrent(mode);
+    m_pDrawWidget->SetSelectionMode(mode);
+  }
+  else
+    OnClearSelection();
 }
 
 void MainWindow::OnSwitchMwmsBordersSelectionMode()
 {
   MwmsBordersSelection dlg(this);
   auto const response = dlg.ShowModal();
-  if (response == MwmsBordersSelection::Response::Cancelled)
+  if (response == SelectionMode::Cancelled)
   {
-    if (m_pDrawWidget->SelectionModeIsSet() &&
-        IsMwmsBordersSelectionMode(m_pDrawWidget->GetSelectionMode()))
-    {
-      m_pDrawWidget->DropSelectionMode();
-    }
-
-    m_selectionMwmsBordersMode->setChecked(false);
+    m_pDrawWidget->DropSelectionIfMWMBordersMode();
     return;
   }
 
-  m_selectionMode->setChecked(false);
-  m_selectionCityBoundariesMode->setChecked(false);
-  m_selectionCityRoadsMode->setChecked(false);
-
-  m_selectionMwmsBordersMode->setChecked(true);
-
-  m_pDrawWidget->SetSelectionMode(ConvertFromMwmsBordersSelection(response));
+  m_selection->setCurrent(SelectionMode::MWMBorders);
+  m_pDrawWidget->SetSelectionMode(response);
 }
 
 void MainWindow::OnClearSelection()
 {
   m_pDrawWidget->GetFramework().GetDrapeApi().Clear();
+  m_pDrawWidget->SetSelectionMode({});
+
+  m_selection->setMainIcon({});
 }
 
 void MainWindow::OnSearchButtonClicked()
@@ -997,60 +857,40 @@ void MainWindow::OnRetryDownloadClicked()
   GetFramework().GetStorage().RetryDownloadNode(m_lastCountry);
 }
 
-void MainWindow::SetEnabledTraffic(bool enable)
+void MainWindow::SetLayerEnabled(LayerType type, bool enable)
 {
-  m_selectLayerTrafficAction->setChecked(enable);
-  m_pDrawWidget->GetFramework().GetTrafficManager().SetEnabled(enable);
-  m_pDrawWidget->GetFramework().SaveTrafficEnabled(enable);
-}
-
-void MainWindow::SetEnabledTransit(bool enable)
-{
-  m_selectLayerTransitAction->setChecked(enable);
-  m_pDrawWidget->GetFramework().GetTransitManager().EnableTransitSchemeMode(enable);
-  m_pDrawWidget->GetFramework().SaveTransitSchemeEnabled(enable);
-}
-
-void MainWindow::SetEnabledIsolines(bool enable)
-{
-  m_selectLayerIsolinesAction->setChecked(enable);
-  m_pDrawWidget->GetFramework().GetIsolinesManager().SetEnabled(enable);
-  m_pDrawWidget->GetFramework().SaveIsolinesEnabled(enable);
-}
-
-void MainWindow::OnTrafficEnabled()
-{
-  bool const enabled = m_selectLayerTrafficAction->isChecked();
-  SetEnabledTraffic(enabled);
-
-  if (enabled)
+  auto & frm = m_pDrawWidget->GetFramework();
+  switch (type)
   {
-    SetEnabledTransit(false);
-    SetEnabledIsolines(false);
+  case LayerType::TRAFFIC:
+    frm.GetTrafficManager().SetEnabled(enable);
+    frm.SaveTrafficEnabled(enable);
+    break;
+  case LayerType::TRANSIT:
+    frm.GetTransitManager().EnableTransitSchemeMode(enable);
+    frm.SaveTransitSchemeEnabled(enable);
+    break;
+  case LayerType::ISOLINES:
+    frm.GetIsolinesManager().SetEnabled(enable);
+    frm.SaveIsolinesEnabled(enable);
+    break;
+  default:
+    UNREACHABLE();
+    break;
   }
 }
 
-void MainWindow::OnTransitEnabled()
+void MainWindow::OnLayerEnabled(LayerType layer)
 {
-  bool const enabled = m_selectLayerTransitAction->isChecked();
-  SetEnabledTransit(enabled);
-
-  if (enabled)
+  for (size_t i = 0; i < LayerType::COUNT; ++i)
   {
-    SetEnabledIsolines(false);
-    SetEnabledTraffic(false);
-  }
-}
-
-void MainWindow::OnIsolinesEnabled()
-{
-  bool const enabled = m_selectLayerIsolinesAction->isChecked();
-  SetEnabledIsolines(enabled);
-
-  if (enabled)
-  {
-    SetEnabledTraffic(false);
-    SetEnabledTransit(false);
+    if (i == layer)
+      SetLayerEnabled(static_cast<LayerType>(i), m_layers->isChecked(i));
+    else
+    {
+      m_layers->setChecked(i, false);
+      SetLayerEnabled(static_cast<LayerType>(i), false);
+    }
   }
 }
 
@@ -1059,22 +899,10 @@ void MainWindow::OnRulerEnabled()
   m_pDrawWidget->SetRuler(m_rulerAction->isChecked());
 }
 
-void MainWindow::OnStartPointSelected()
+void MainWindow::OnRoutePointSelected(RouteMarkType type)
 {
-  m_routePointsToolButton->setIcon(m_selectStartRoutePoint->icon());
-  m_pDrawWidget->SetRoutePointAddMode(RouteMarkType::Start);
-}
-
-void MainWindow::OnFinishPointSelected()
-{
-  m_routePointsToolButton->setIcon(m_selectFinishRoutePoint->icon());
-  m_pDrawWidget->SetRoutePointAddMode(RouteMarkType::Finish);
-}
-
-void MainWindow::OnIntermediatePointSelected()
-{
-  m_routePointsToolButton->setIcon(m_selectIntermediateRoutePoint->icon());
-  m_pDrawWidget->SetRoutePointAddMode(RouteMarkType::Intermediate);
+  m_routing->setCurrent(type);
+  m_pDrawWidget->SetRoutePointAddMode(type);
 }
 
 void MainWindow::OnFollowRoute()

--- a/qt/mainwindow.hpp
+++ b/qt/mainwindow.hpp
@@ -1,4 +1,7 @@
 #pragma once
+#include "qt/selection.hpp"
+
+#include "map/routing_mark.hpp"
 
 #include "storage/storage_defines.hpp"
 
@@ -16,13 +19,13 @@ class Framework;
 class QDockWidget;
 class QLabel;
 class QPushButton;
-class QToolButton;
 
 namespace search { class Result; }
 
 namespace qt
 {
 class DrawWidget;
+class PopupMenuHolder;
 struct ScreenshotParams;
 
 class MainWindow : public QMainWindow, location::LocationObserver
@@ -42,25 +45,22 @@ class MainWindow : public QMainWindow, location::LocationObserver
 
   QAction * m_pMyPositionAction = nullptr;
   QAction * m_pCreateFeatureAction = nullptr;
-  QAction * m_selectionMode = nullptr;
-  QAction * m_clearSelection = nullptr;
   QAction * m_pSearchAction = nullptr;
-
-  QAction * m_bookmarksAction = nullptr;
   QAction * m_rulerAction = nullptr;
 
-  QToolButton * m_selectLayerButton = nullptr;
-  QAction * m_selectLayerTrafficAction = nullptr;
-  QAction * m_selectLayerTransitAction = nullptr;
-  QAction * m_selectLayerIsolinesAction = nullptr;
+  enum LayerType : uint8_t
+  {
+    TRAFFIC = 0,
+    TRANSIT,      // Metro scheme
+    ISOLINES,
 
-  QAction * m_selectionCityBoundariesMode = nullptr;
-  QAction * m_selectionCityRoadsMode = nullptr;
-  QAction * m_selectionMwmsBordersMode = nullptr;
-  QToolButton * m_routePointsToolButton = nullptr;
-  QAction * m_selectStartRoutePoint = nullptr;
-  QAction * m_selectFinishRoutePoint = nullptr;
-  QAction * m_selectIntermediateRoutePoint = nullptr;
+    // Should be the last
+    COUNT
+  };
+  PopupMenuHolder * m_layers = nullptr;
+  PopupMenuHolder * m_routing = nullptr;
+  PopupMenuHolder * m_selection = nullptr;
+
 #ifdef BUILD_DESIGNER
   QString const m_mapcssFilePath = nullptr;
   QAction * m_pBuildStyleAction = nullptr;
@@ -75,7 +75,11 @@ class MainWindow : public QMainWindow, location::LocationObserver
 
 public:
   MainWindow(Framework & framework, bool apiOpenGLES3, std::unique_ptr<ScreenshotParams> && screenshotParams,
-             QRect const & screenGeometry, QString const & mapcssFilePath = QString());
+             QRect const & screenGeometry
+#ifdef BUILD_DESIGNER
+             , QString const & mapcssFilePath = QString()
+#endif
+            );
 
   static void SetDefaultSurfaceFormat(bool apiOpenGLES3);
 
@@ -91,6 +95,8 @@ protected:
   void CreateNavigationBar();
   void CreateSearchBarAndPanel();
   void CreateCountryStatusControls();
+
+  void SetLayerEnabled(LayerType type, bool enable);
 
 #if defined(Q_WS_WIN)
   /// to handle menu messages
@@ -117,24 +123,15 @@ protected Q_SLOTS:
   void OnDownloadClicked();
   void OnRetryDownloadClicked();
 
-  void OnSwitchSelectionMode();
-  void OnSwitchCityBoundariesSelectionMode();
-  void OnSwitchCityRoadsSelectionMode();
+  void OnSwitchSelectionMode(SelectionMode mode);
   void OnSwitchMwmsBordersSelectionMode();
   void OnClearSelection();
 
-  void OnTrafficEnabled();
-  void OnTransitEnabled();
-  void OnIsolinesEnabled();
-
-  void SetEnabledTraffic(bool enable);
-  void SetEnabledTransit(bool enable);
-  void SetEnabledIsolines(bool enable);
+  void OnLayerEnabled(LayerType layer);
 
   void OnRulerEnabled();
-  void OnStartPointSelected();
-  void OnFinishPointSelected();
-  void OnIntermediatePointSelected();
+
+  void OnRoutePointSelected(RouteMarkType type);
   void OnFollowRoute();
   void OnClearRoute();
   void OnRoutingSettings();

--- a/qt/mwms_borders_selection.cpp
+++ b/qt/mwms_borders_selection.cpp
@@ -41,21 +41,21 @@ QGroupBox * MwmsBordersSelection::CreateButtonBoxGroup()
   return groupBox;
 }
 
-MwmsBordersSelection::Response MwmsBordersSelection::ShowModal()
+SelectionMode MwmsBordersSelection::ShowModal()
 {
   if (exec() != QDialog::Accepted)
-    return Response::Cancelled;
+    return SelectionMode::Cancelled;
 
   if (m_radioBordersFromData->isChecked())
   {
     if (m_radioJustBorders->isChecked())
-      return Response::MwmsBordersByPolyFiles;
+      return SelectionMode::MwmsBordersByPolyFiles;
 
     if (m_radioWithPoints->isChecked())
-      return Response::MwmsBordersWithVerticesByPolyFiles;
+      return SelectionMode::MwmsBordersWithVerticesByPolyFiles;
 
     if (m_radioBoundingBox->isChecked())
-      return Response::BoundingBoxByPolyFiles;
+      return SelectionMode::BoundingBoxByPolyFiles;
 
     UNREACHABLE();
   }
@@ -63,13 +63,13 @@ MwmsBordersSelection::Response MwmsBordersSelection::ShowModal()
   if (m_radioBordersFromPackedPolygon->isChecked())
   {
     if (m_radioJustBorders->isChecked())
-      return Response::MwmsBordersByPackedPolygon;
+      return SelectionMode::MwmsBordersByPackedPolygon;
 
     if (m_radioWithPoints->isChecked())
-      return Response::MwmsBordersWithVerticesByPackedPolygon;
+      return SelectionMode::MwmsBordersWithVerticesByPackedPolygon;
 
     if (m_radioBoundingBox->isChecked())
-      return Response::BoundingBoxByPackedPolygon;
+      return SelectionMode::BoundingBoxByPackedPolygon;
 
     UNREACHABLE();
   }

--- a/qt/mwms_borders_selection.hpp
+++ b/qt/mwms_borders_selection.hpp
@@ -1,5 +1,7 @@
 #pragma once
 
+#include "qt/selection.hpp"
+
 #include <string>
 
 #include <QtWidgets/QApplication>
@@ -17,21 +19,7 @@ class MwmsBordersSelection : public QDialog
 public:
   MwmsBordersSelection(QWidget * parent);
 
-  enum class Response
-  {
-    MwmsBordersByPolyFiles,
-    MwmsBordersWithVerticesByPolyFiles,
-
-    MwmsBordersByPackedPolygon,
-    MwmsBordersWithVerticesByPackedPolygon,
-
-    BoundingBoxByPolyFiles,
-    BoundingBoxByPackedPolygon,
-
-    Cancelled
-  };
-
-  Response ShowModal();
+  SelectionMode ShowModal();
 
 private:
   QGroupBox * CreateSourceChoosingGroup();

--- a/qt/popup_menu_holder.cpp
+++ b/qt/popup_menu_holder.cpp
@@ -1,0 +1,60 @@
+#include "popup_menu_holder.hpp"
+
+#include "base/assert.hpp"
+
+#include <QtWidgets/QMenu>
+
+namespace qt
+{
+
+PopupMenuHolder::PopupMenuHolder(QObject * parent)
+: QObject(parent)
+{
+}
+
+QAction * PopupMenuHolder::addActionImpl(QIcon const & icon, QString const & text, bool checkable)
+{
+  QAction * p = new QAction(icon, text, this);
+  p->setCheckable(checkable);
+  m_actions.push_back(p);
+  return p;
+}
+
+QToolButton * PopupMenuHolder::create()
+{
+  QMenu * menu = new QMenu();
+  for (auto * p : m_actions)
+    menu->addAction(p);
+
+  m_toolButton = new QToolButton();
+  m_toolButton->setPopupMode(QToolButton::MenuButtonPopup);
+  m_toolButton->setMenu(menu);
+  return m_toolButton;
+}
+
+void PopupMenuHolder::setMainIcon(QIcon const & icon)
+{
+  m_toolButton->setIcon(icon);
+}
+
+void PopupMenuHolder::setCurrent(size_t idx)
+{
+  CHECK_LESS(idx, m_actions.size(), ());
+  m_toolButton->setIcon(m_actions[idx]->icon());
+}
+
+void PopupMenuHolder::setChecked(size_t idx, bool checked)
+{
+  CHECK_LESS(idx, m_actions.size(), ());
+  ASSERT(m_actions[idx]->isCheckable(), ());
+  m_actions[idx]->setChecked(checked);
+}
+
+bool PopupMenuHolder::isChecked(size_t idx)
+{
+  CHECK_LESS(idx, m_actions.size(), ());
+  ASSERT(m_actions[idx]->isCheckable(), ());
+  return m_actions[idx]->isChecked();
+}
+
+} // namespace qt

--- a/qt/popup_menu_holder.hpp
+++ b/qt/popup_menu_holder.hpp
@@ -1,0 +1,54 @@
+#pragma once
+
+#include <QtWidgets/QAction>
+#include <QtWidgets/QToolButton>
+
+#include <vector>
+#include <type_traits>
+
+namespace qt
+{
+/// Inherit from QObject to assign parents and don't worry about deleting.
+class PopupMenuHolder : public QObject
+{
+  Q_OBJECT
+
+  QToolButton * m_toolButton;
+
+  std::vector<QAction*> m_actions;
+
+  QAction * addActionImpl(QIcon const & icon, QString const & text, bool checkable);
+
+public:
+  explicit PopupMenuHolder(QObject * parent = nullptr);
+
+  QAction * addAction(QIcon const & icon, QString const & text,
+                      QObject const * receiver, char const * member, bool checkable)
+  {
+    QAction * p = addActionImpl(icon, text, checkable);
+    connect(p, SIGNAL(triggered()), receiver, member);
+    return p;
+  }
+
+  template <class SlotT>
+  QAction * addAction(QIcon const & icon, QString const & text, SlotT slot, bool checkable)
+  {
+    QAction * p = addActionImpl(icon, text, checkable);
+    connect(p, &QAction::triggered, std::move(slot));
+    return p;
+  }
+
+  QToolButton * create();
+  void setMainIcon(QIcon const & icon);
+
+  void setCurrent(size_t idx);
+  template <class T> typename std::enable_if<std::is_enum<T>::value, void>::type
+  setCurrent(T idx) { setCurrent(static_cast<size_t>(idx)); }
+
+  void setChecked(size_t idx, bool checked);
+
+  bool isChecked(size_t idx);
+  template <class T> typename std::enable_if<std::is_enum<T>::value, bool>::type
+  isChecked(T idx) { return isChecked(static_cast<size_t>(idx)); }
+};
+} // namespace qt

--- a/qt/qt_common/map_widget.cpp
+++ b/qt/qt_common/map_widget.cpp
@@ -63,7 +63,6 @@ void MapWidget::BindHotkeys(QWidget & parent)
       {Qt::Key_Minus, SLOT(ScaleMinus())},
       {Qt::ALT + Qt::Key_Equal, SLOT(ScalePlusLight())},
       {Qt::ALT + Qt::Key_Minus, SLOT(ScaleMinusLight())},
-      {Qt::ALT + Qt::Key_Minus, SLOT(ScaleMinusLight())},
 #ifdef ENABLE_AA_SWITCH
       {Qt::ALT + Qt::Key_A, SLOT(AntialiasingOn())},
       {Qt::ALT + Qt::Key_S, SLOT(AntialiasingOff())},

--- a/qt/selection.hpp
+++ b/qt/selection.hpp
@@ -1,0 +1,25 @@
+#pragma once
+
+namespace qt
+{
+enum class SelectionMode
+{
+  // Do not change order of first 4 entries.
+  Features = 0,
+  CityBoundaries,
+  CityRoads,
+  MWMBorders,
+
+  MwmsBordersByPolyFiles,
+  MwmsBordersWithVerticesByPolyFiles,
+
+  MwmsBordersByPackedPolygon,
+  MwmsBordersWithVerticesByPackedPolygon,
+
+  BoundingBoxByPolyFiles,
+  BoundingBoxByPackedPolygon,
+
+  // Should be the last
+  Cancelled,
+};
+} // namespace qt

--- a/qt/selection.hpp
+++ b/qt/selection.hpp
@@ -8,6 +8,7 @@ enum class SelectionMode
   Features = 0,
   CityBoundaries,
   CityRoads,
+  CrossMwmSegments,
   MWMBorders,
 
   MwmsBordersByPolyFiles,

--- a/routing/cross_mwm_connector.hpp
+++ b/routing/cross_mwm_connector.hpp
@@ -11,10 +11,6 @@
 #include "base/assert.hpp"
 #include "base/buffer_vector.hpp"
 
-#include <cmath>
-#include <cstdint>
-#include <limits>
-#include <map>
 #include <string>
 #include <unordered_map>
 #include <vector>
@@ -23,7 +19,6 @@ namespace routing
 {
 namespace connector
 {
-uint32_t constexpr kFakeIndex = std::numeric_limits<uint32_t>::max();
 double constexpr kNoRoute = 0.0;
 
 using Weight = uint32_t;
@@ -54,61 +49,63 @@ public:
   {
   }
 
-  void AddTransition(CrossMwmId const & crossMwmId, uint32_t featureId, uint32_t segmentIdx, bool oneWay,
-                     bool forwardIsEnter)
+  /// Builder component, which makes inner containers optimization after adding transitions.
+  class Builder
   {
-    featureId += m_featureNumerationOffset;
+    CrossMwmConnector & m_c;
 
-    Transition<CrossMwmId> transition(connector::kFakeIndex, connector::kFakeIndex, crossMwmId,
-                                      oneWay, forwardIsEnter);
-
-    if (forwardIsEnter)
+  public:
+    Builder(CrossMwmConnector & c, size_t count) : m_c(c)
     {
-      transition.m_enterIdx = base::asserted_cast<uint32_t>(m_enters.size());
-      m_enters.emplace_back(m_mwmId, featureId, segmentIdx, true /* forward */);
+      m_c.m_transitions.reserve(count);
     }
-    else
+    ~Builder()
     {
-      transition.m_exitIdx = base::asserted_cast<uint32_t>(m_exits.size());
-      m_exits.emplace_back(m_mwmId, featureId, segmentIdx, true /* forward */);
+      // Sort by FeatureID to make lower_bound queries.
+      std::sort(m_c.m_transitions.begin(), m_c.m_transitions.end(), LessKT());
     }
 
-    if (!oneWay)
+    void AddTransition(CrossMwmId const & crossMwmId, uint32_t featureId, uint32_t segmentIdx,
+                       bool oneWay, bool forwardIsEnter)
     {
+      featureId += m_c.m_featureNumerationOffset;
+
+      Transition transition(m_c.m_entersCount, m_c.m_exitsCount, crossMwmId, oneWay, forwardIsEnter);
+
       if (forwardIsEnter)
-      {
-        transition.m_exitIdx = base::asserted_cast<uint32_t>(m_exits.size());
-        m_exits.emplace_back(m_mwmId, featureId, segmentIdx, false /* forward */);
-      }
+        ++m_c.m_entersCount;
       else
-      {
-        transition.m_enterIdx = base::asserted_cast<uint32_t>(m_enters.size());
-        m_enters.emplace_back(m_mwmId, featureId, segmentIdx, false /* forward */);
-      }
-    }
+        ++m_c.m_exitsCount;
 
-    m_transitions[Key(featureId, segmentIdx)] = transition;
-    m_crossMwmIdToFeatureId.emplace(crossMwmId, featureId);
-    m_transitFeatureIdToSegmentId[featureId].emplace_back(segmentIdx);
-  }
+      if (!oneWay)
+      {
+        if (forwardIsEnter)
+          ++m_c.m_exitsCount;
+        else
+          ++m_c.m_entersCount;
+      }
+
+      m_c.m_transitions.emplace_back(Key(featureId, segmentIdx), transition);
+      m_c.m_crossMwmIdToFeatureId.emplace(crossMwmId, featureId);
+    }
+  };
 
   template <class FnT> void ForEachTransitSegmentId(uint32_t featureId, FnT && fn) const
   {
-    auto it = m_transitFeatureIdToSegmentId.find(featureId);
-    if (it != m_transitFeatureIdToSegmentId.cend())
+    auto it = std::lower_bound(m_transitions.begin(), m_transitions.end(), Key{featureId, 0}, LessKT());
+    while (it != m_transitions.end() && it->first.m_featureId == featureId)
     {
-      for (uint32_t segId : it->second)
-      {
-        if (fn(segId))
-          break;
-      }
+      if (fn(it->first.m_segmentIdx))
+        break;
+      ++it;
     }
   }
 
   bool IsTransition(Segment const & segment, bool isOutgoing) const
   {
-    auto const it = m_transitions.find(Key(segment.GetFeatureId(), segment.GetSegmentIdx()));
-    if (it == m_transitions.cend())
+    Key const key(segment.GetFeatureId(), segment.GetSegmentIdx());
+    auto const it = std::lower_bound(m_transitions.begin(), m_transitions.end(), key, LessKT());
+    if (it == m_transitions.end() || !(it->first == key))
       return false;
 
     auto const & transition = it->second;
@@ -129,93 +126,88 @@ public:
     return GetTransition(segment).m_crossMwmId;
   }
 
-  // returns nullptr if there is no transition for such cross mwm id.
-  Segment const * GetTransition(CrossMwmId const & crossMwmId, uint32_t segmentIdx, bool isEnter) const
+  /// @return {} if there is no transition for such cross mwm id.
+  std::optional<Segment> GetTransition(CrossMwmId const & crossMwmId, uint32_t segmentIdx, bool isEnter) const
   {
     auto const fIt = m_crossMwmIdToFeatureId.find(crossMwmId);
     if (fIt == m_crossMwmIdToFeatureId.cend())
-      return nullptr;
+      return {};
 
     uint32_t const featureId = fIt->second;
 
-    auto tIt = m_transitions.find(Key(featureId, segmentIdx));
-    if (tIt == m_transitions.cend())
+    Transition const * transition = GetTransition(featureId, segmentIdx);
+    if (transition == nullptr)
     {
       /// @todo By VNG: Workaround until cross-mwm transitions generator investigation.
       /// https://github.com/organicmaps/organicmaps/issues/1736
       /// Actually, the fix is valid, because transition features can have segment = 1 when leaving MWM
       /// and segment = 2 when entering MWM due to *not precise* packed MWM borders.
       if (isEnter)
-        tIt = m_transitions.find(Key(featureId, ++segmentIdx));
+        transition = GetTransition(featureId, ++segmentIdx);
       else if (segmentIdx > 0)
-        tIt = m_transitions.find(Key(featureId, --segmentIdx));
+        transition = GetTransition(featureId, --segmentIdx);
 
-      if (tIt == m_transitions.cend())
-        return nullptr;
+      if (transition == nullptr)
+        return {};
     }
 
-    auto const & transition = tIt->second;
-    ASSERT_EQUAL(transition.m_crossMwmId, crossMwmId, ("fId:", featureId, ", segId:", segmentIdx));
-    bool const isForward = transition.m_forwardIsEnter == isEnter;
-    if (transition.m_oneWay && !isForward)
-      return nullptr;
+    ASSERT_EQUAL(transition->m_crossMwmId, crossMwmId, ("fId:", featureId, ", segId:", segmentIdx));
+    bool const isForward = transition->m_forwardIsEnter == isEnter;
+    if (transition->m_oneWay && !isForward)
+      return {};
 
-    Segment const & segment =
-        isEnter ? GetEnter(transition.m_enterIdx) : GetExit(transition.m_exitIdx);
-
-    /// @todo Actually, we can avoid storing m_enters, m_exits, because we already have all Segment components:
-    /// Also can emulate segments iteration in Get{Ingoing/Outgoing}EdgeList.
-    ASSERT_EQUAL(segment.GetMwmId(), m_mwmId, ("fId:", featureId, ", segId:", segmentIdx));
-    ASSERT_EQUAL(segment.GetFeatureId(), featureId, ("fId:", featureId, ", segId:", segmentIdx));
-    ASSERT_EQUAL(segment.GetSegmentIdx(), segmentIdx, ("fId:", featureId, ", segId:", segmentIdx));
-    ASSERT_EQUAL(segment.IsForward(), isForward, ("fId:", featureId, ", segId:", segmentIdx));
-
-    return &segment;
+    return Segment(m_mwmId, featureId, segmentIdx, isForward);
   }
 
   using EdgeListT = SmallList<SegmentEdge>;
 
+  template <class FnT> void ForEachEnter(FnT && fn) const
+  {
+    for (auto const & [key, transit] : m_transitions)
+    {
+      if (transit.m_forwardIsEnter)
+        fn(transit.m_enterIdx, Segment(m_mwmId, key.m_featureId, key.m_segmentIdx, true));
+
+      if (!transit.m_oneWay && !transit.m_forwardIsEnter)
+        fn(transit.m_enterIdx, Segment(m_mwmId, key.m_featureId, key.m_segmentIdx, false));
+    }
+  }
+
+  template <class FnT> void ForEachExit(FnT && fn) const
+  {
+    for (auto const & [key, transit] : m_transitions)
+    {
+      if (!transit.m_forwardIsEnter)
+        fn(transit.m_exitIdx, Segment(m_mwmId, key.m_featureId, key.m_segmentIdx, true));
+
+      if (!transit.m_oneWay && transit.m_forwardIsEnter)
+        fn(transit.m_exitIdx, Segment(m_mwmId, key.m_featureId, key.m_segmentIdx, false));
+    }
+  }
+
   void GetOutgoingEdgeList(Segment const & segment, EdgeListT & edges) const
   {
-    auto const & transition = GetTransition(segment);
-    CHECK_NOT_EQUAL(transition.m_enterIdx, connector::kFakeIndex, ());
-    auto const enterIdx = transition.m_enterIdx;
-    for (size_t exitIdx = 0; exitIdx < m_exits.size(); ++exitIdx)
+    auto const enterIdx = GetTransition(segment).m_enterIdx;
+    ForEachExit([enterIdx, this, &edges](uint32_t exitIdx, Segment const & s)
     {
-      auto const weight = GetWeight(enterIdx, exitIdx);
-      AddEdge(m_exits[exitIdx], weight, edges);
-    }
+      AddEdge(s, enterIdx, exitIdx, edges);
+    });
   }
 
   void GetIngoingEdgeList(Segment const & segment, EdgeListT & edges) const
   {
-    auto const & transition = GetTransition(segment);
-    CHECK_NOT_EQUAL(transition.m_exitIdx, connector::kFakeIndex, ());
-    auto const exitIdx = transition.m_exitIdx;
-    for (size_t enterIdx = 0; enterIdx < m_enters.size(); ++enterIdx)
+    auto const exitIdx = GetTransition(segment).m_exitIdx;
+    ForEachEnter([exitIdx, this, &edges](uint32_t enterIdx, Segment const & s)
     {
-      auto const weight = GetWeight(enterIdx, exitIdx);
-      AddEdge(m_enters[enterIdx], weight, edges);
-    }
+      AddEdge(s, enterIdx, exitIdx, edges);
+    });
   }
 
-  std::vector<Segment> const & GetEnters() const { return m_enters; }
-  std::vector<Segment> const & GetExits() const { return m_exits; }
-
-  Segment const & GetEnter(size_t i) const
-  {
-    ASSERT_LESS(i, m_enters.size(), ());
-    return m_enters[i];
-  }
-
-  Segment const & GetExit(size_t i) const
-  {
-    ASSERT_LESS(i, m_exits.size(), ());
-    return m_exits[i];
-  }
+  uint32_t GetNumEnters() const { return m_entersCount; }
+  uint32_t GetNumExits() const { return m_exitsCount; }
 
   bool HasWeights() const { return !m_weights.empty(); }
-  bool IsEmpty() const { return m_enters.empty() && m_exits.empty(); }
+  bool IsEmpty() const { return m_entersCount == 0 && m_exitsCount == 0; }
 
   bool WeightsWereLoaded() const
   {
@@ -235,52 +227,44 @@ public:
     CHECK_EQUAL(m_weightsLoadState, connector::WeightsLoadState::Unknown, ());
     CHECK(m_weights.empty(), ());
 
-    m_weights.reserve(m_enters.size() * m_exits.size());
-    for (Segment const & enter : m_enters)
+    m_weights.resize(m_entersCount * m_exitsCount);
+    ForEachEnter([&](uint32_t enterIdx, Segment const & enter)
     {
-      for (Segment const & exit : m_exits)
+      ForEachExit([&](uint32_t exitIdx, Segment const & exit)
       {
         auto const weight = calcWeight(enter, exit);
         // Edges weights should be >= astar heuristic, so use std::ceil.
-        m_weights.push_back(static_cast<connector::Weight>(std::ceil(weight)));
-      }
-    }
+        m_weights[GetWeightIndex(enterIdx, exitIdx)] = static_cast<connector::Weight>(std::ceil(weight));
+      });
+    });
   }
 
 private:
   struct Key
   {
-    Key() = default;
-
     Key(uint32_t featureId, uint32_t segmentIdx) : m_featureId(featureId), m_segmentIdx(segmentIdx)
     {
     }
 
     bool operator==(Key const & key) const
     {
-      return m_featureId == key.m_featureId && m_segmentIdx == key.m_segmentIdx;
+      return (m_featureId == key.m_featureId && m_segmentIdx == key.m_segmentIdx);
+    }
+
+    bool operator<(Key const & key) const
+    {
+      if (m_featureId == key.m_featureId)
+        return m_segmentIdx < key.m_segmentIdx;
+      return m_featureId < key.m_featureId;
     }
 
     uint32_t m_featureId = 0;
     uint32_t m_segmentIdx = 0;
   };
 
-  struct HashKey
-  {
-    size_t operator()(Key const & key) const
-    {
-      return std::hash<uint64_t>()((static_cast<uint64_t>(key.m_featureId) << 32) +
-                                   static_cast<uint64_t>(key.m_segmentIdx));
-    }
-  };
-
-  template <typename CrossMwmIdInner>
   struct Transition
   {
-    Transition() = default;
-
-    Transition(uint32_t enterIdx, uint32_t exitIdx, CrossMwmIdInner const & crossMwmId, bool oneWay,
-               bool forwardIsEnter)
+    Transition(uint32_t enterIdx, uint32_t exitIdx, CrossMwmId crossMwmId, bool oneWay, bool forwardIsEnter)
       : m_enterIdx(enterIdx)
       , m_exitIdx(exitIdx)
       , m_crossMwmId(crossMwmId)
@@ -289,50 +273,80 @@ private:
     {
     }
 
-    uint32_t m_enterIdx = 0;
-    uint32_t m_exitIdx = 0;
-    CrossMwmIdInner m_crossMwmId = CrossMwmIdInner();
-    bool m_oneWay = false;
-    // Transition represents both forward and backward segments with same featureId, segmentIdx.
-    // m_forwardIsEnter == true means: forward segment is enter to mwm:
-    // Enter means: m_backPoint is outside mwm borders, m_frontPoint is inside.
-    bool m_forwardIsEnter = false;
+    uint32_t m_enterIdx;
+    uint32_t m_exitIdx;
+    CrossMwmId m_crossMwmId;
+
+    // false - Transition represents both forward and backward segments with same featureId, segmentIdx.
+    bool m_oneWay : 1;
+    // true - forward segment is enter to mwm, enter means: m_backPoint is outside mwm borders, m_frontPoint is inside.
+    bool m_forwardIsEnter : 1;
   };
 
   friend class CrossMwmConnectorSerializer;
 
-  void AddEdge(Segment const & segment, connector::Weight weight,
-               EdgeListT & edges) const
+  void AddEdge(Segment const & segment, uint32_t enterIdx, uint32_t exitIdx, EdgeListT & edges) const
   {
-    // @TODO Double and uint32_t are compared below. This comparison should be fixed.
+    auto const weight = GetWeight(enterIdx, exitIdx);
     if (weight != connector::kNoRoute)
       edges.emplace_back(segment, RouteWeight::FromCrossMwmWeight(weight));
   }
 
-  CrossMwmConnector<CrossMwmId>::Transition<CrossMwmId> const & GetTransition(
-      Segment const & segment) const
+  Transition const * GetTransition(uint32_t featureId, uint32_t segmentIdx) const
   {
-    auto const it = m_transitions.find(Key(segment.GetFeatureId(), segment.GetSegmentIdx()));
-    CHECK(it != m_transitions.cend(), ("Not a transition segment:", segment));
-    return it->second;
+    Key key(featureId, segmentIdx);
+    auto const it = std::lower_bound(m_transitions.begin(), m_transitions.end(), key, LessKT());
+    if (it == m_transitions.end() || !(it->first == key))
+      return nullptr;
+    return &(it->second);
+  }
+
+  Transition const & GetTransition(Segment const & segment) const
+  {
+    Transition const * tr = GetTransition(segment.GetFeatureId(), segment.GetSegmentIdx());
+    CHECK(tr, (segment));
+    return *tr;
+  }
+
+  size_t GetWeightIndex(size_t enterIdx, size_t exitIdx) const
+  {
+    ASSERT_LESS(enterIdx, m_entersCount, ());
+    ASSERT_LESS(exitIdx, m_exitsCount, ());
+
+    size_t const i = enterIdx * m_exitsCount + exitIdx;
+    ASSERT_LESS(i, m_weights.size(), ());
+    return i;
   }
 
   connector::Weight GetWeight(size_t enterIdx, size_t exitIdx) const
   {
-    ASSERT_LESS(enterIdx, m_enters.size(), ());
-    ASSERT_LESS(exitIdx, m_exits.size(), ());
-
-    size_t const i = enterIdx * m_exits.size() + exitIdx;
-    ASSERT_LESS(i, m_weights.size(), ());
-    return m_weights[i];
+    return m_weights[GetWeightIndex(enterIdx, exitIdx)];
   }
 
   NumMwmId const m_mwmId;
-  std::vector<Segment> m_enters;
-  std::vector<Segment> m_exits;
-  std::map<uint32_t, std::vector<uint32_t>> m_transitFeatureIdToSegmentId;
-  std::unordered_map<Key, Transition<CrossMwmId>, HashKey> m_transitions;
+  uint32_t m_entersCount = 0;
+  uint32_t m_exitsCount = 0;
+
+  using KeyTransitionT = std::pair<Key, Transition>;
+  struct LessKT
+  {
+    bool operator()(KeyTransitionT const & l, KeyTransitionT const & r) const
+    {
+      return l.first < r.first;
+    }
+    bool operator()(KeyTransitionT const & l, Key const & r) const
+    {
+      return l.first < r;
+    }
+    bool operator()(Key const & l, KeyTransitionT const & r) const
+    {
+      return l < r.first;
+    }
+  };
+  std::vector<KeyTransitionT> m_transitions;
+
   std::unordered_map<CrossMwmId, uint32_t, connector::HashKey> m_crossMwmIdToFeatureId;
+
   connector::WeightsLoadState m_weightsLoadState = connector::WeightsLoadState::Unknown;
   // For some connectors we may need to shift features with some offset.
   // For example for versions and transit section compatibility we number transit features
@@ -340,9 +354,9 @@ private:
   uint32_t const m_featureNumerationOffset = 0;
   uint64_t m_weightsOffset = 0;
   connector::Weight m_granularity = 0;
-  // |m_weights| stores edge weights.
-  // Weight is the time required for the route to pass edges.
-  // Weight is measured in seconds rounded upwards.
+
+  // Weight is the time required for the route to pass edge, measured in seconds rounded upwards.
+  /// @todo Store some fast! succinct vector instead of raw matrix m_entersCount * m_exitsCount.
   std::vector<connector::Weight> m_weights;
 };
 }  // namespace routing

--- a/routing/cross_mwm_graph.hpp
+++ b/routing/cross_mwm_graph.hpp
@@ -102,7 +102,6 @@ public:
     return m_crossMwmIndexGraph.GetTransitions(numMwmId, isEnter);
   }
 
-  bool IsFeatureTransit(NumMwmId numMwmId, uint32_t featureId);
   /// \brief Checks whether feature where |segment| is placed is a cross mwm connector.
   ///        If yes twin-segments are saved to |twins|.
   void GetTwinFeature(Segment const & segment, bool isOutgoing, std::vector<Segment> & twins);

--- a/routing/cross_mwm_graph.hpp
+++ b/routing/cross_mwm_graph.hpp
@@ -95,11 +95,10 @@ public:
 
   void Clear();
 
-  // \returns transitions for mwm with id |numMwmId| for CrossMwmIndexGraph.
-  std::vector<Segment> const & GetTransitions(NumMwmId numMwmId, bool isEnter)
+  template <class FnT> void ForEachTransition(NumMwmId numMwmId, bool isEnter, FnT && fn)
   {
-    CHECK(CrossMwmSectionExists(numMwmId), ("Should be used in LeapsOnly mode only. LeapsOnly mode requires CrossMwmIndexGraph."));
-    return m_crossMwmIndexGraph.GetTransitions(numMwmId, isEnter);
+    CHECK(CrossMwmSectionExists(numMwmId), ("Should be used in LeapsOnly mode only"));
+    return m_crossMwmIndexGraph.ForEachTransition(numMwmId, isEnter, fn);
   }
 
   /// \brief Checks whether feature where |segment| is placed is a cross mwm connector.

--- a/routing/cross_mwm_index_graph.hpp
+++ b/routing/cross_mwm_index_graph.hpp
@@ -116,8 +116,8 @@ public:
       // and the last parameter (|isEnter|) should be set to true.
       // If |isOutgoing| == false |s| should be an enter transition segment and the method below searches exits
       // and the last parameter (|isEnter|) should be set to false.
-      Segment const * twinSeg = connector.GetTransition(crossMwmId, s.GetSegmentIdx(), isOutgoing);
-      if (twinSeg == nullptr)
+      auto const twinSeg = connector.GetTransition(crossMwmId, s.GetSegmentIdx(), isOutgoing);
+      if (!twinSeg)
         continue;
 
       // Twins should have the same direction, because we assume that twins are the same segments
@@ -185,10 +185,12 @@ public:
     GetCrossMwmConnectorWithTransitions(numMwmId);
   }
 
-  std::vector<Segment> const & GetTransitions(NumMwmId numMwmId, bool isEnter)
+  template <class FnT> void ForEachTransition(NumMwmId numMwmId, bool isEnter, FnT && fn)
   {
     auto const & connector = GetCrossMwmConnectorWithTransitions(numMwmId);
-    return isEnter ? connector.GetEnters() : connector.GetExits();
+
+    auto const wrapper = [&fn](uint32_t, Segment const & s) { fn(s); };
+    return isEnter ? connector.ForEachEnter(wrapper) : connector.ForEachExit(wrapper);
   }
 
 private:

--- a/routing/leaps_graph.cpp
+++ b/routing/leaps_graph.cpp
@@ -85,14 +85,13 @@ void LeapsGraph::GetEdgesListFromStart(EdgeListT & edges) const
   for (auto const mwmId : m_starter.GetStartMwms())
   {
     // Connect start to all exits (|isEnter| == false).
-    auto const & exits = m_starter.GetGraph().GetTransitions(mwmId, false /* isEnter */);
-    for (auto const & exit : exits)
+    m_starter.GetGraph().ForEachTransition(mwmId, false /* isEnter */, [&](Segment const & exit)
     {
       auto const & exitFrontPoint = m_starter.GetPoint(exit, true /* front */);
       auto const weight = m_starter.GetGraph().CalcLeapWeight(m_startPoint, exitFrontPoint, mwmId);
 
       edges.emplace_back(exit, weight);
-    }
+    });
   }
 }
 
@@ -101,14 +100,13 @@ void LeapsGraph::GetEdgesListToFinish(EdgeListT & edges) const
   for (auto const mwmId : m_starter.GetFinishMwms())
   {
     // Connect finish to all enters (|isEnter| == true).
-    auto const & enters = m_starter.GetGraph().GetTransitions(mwmId, true /* isEnter */);
-    for (auto const & enter : enters)
+    m_starter.GetGraph().ForEachTransition(mwmId, true /* isEnter */, [&](Segment const & enter)
     {
       auto const & enterFrontPoint = m_starter.GetPoint(enter, true /* front */);
       auto const weight = m_starter.GetGraph().CalcLeapWeight(enterFrontPoint, m_finishPoint, mwmId);
 
       edges.emplace_back(enter, weight);
-    }
+    });
   }
 }
 

--- a/routing/routing_tests/cross_mwm_connector_test.cpp
+++ b/routing/routing_tests/cross_mwm_connector_test.cpp
@@ -7,6 +7,8 @@
 
 #include "base/geo_object_id.hpp"
 
+namespace cross_mwm_connector_test
+{
 using namespace routing;
 using namespace routing::connector;
 using namespace std;
@@ -24,17 +26,17 @@ CrossMwmConnector<CrossMwmId> CreateConnector()
 template <typename CrossMwmId>
 void TestConnectorConsistency(CrossMwmConnector<CrossMwmId> const & connector)
 {
-  for (Segment const & enter : connector.GetEnters())
+  connector.ForEachEnter([&connector](uint32_t, Segment const & enter)
   {
     TEST(connector.IsTransition(enter, false /* isOutgoing */), ("enter:", enter));
     TEST(!connector.IsTransition(enter, true /* isOutgoing */), ("enter:", enter));
-  }
+  });
 
-  for (Segment const & exit : connector.GetExits())
+  connector.ForEachExit([&connector](uint32_t, Segment const & exit)
   {
     TEST(!connector.IsTransition(exit, false /* isOutgoing */), ("exit:", exit));
     TEST(connector.IsTransition(exit, true /* isOutgoing */), ("exit:", exit));
-  }
+  });
 }
 
 template <typename CrossMwmId>
@@ -55,12 +57,14 @@ void TestOneWayEnter(CrossMwmId const & crossMwmId)
   uint32_t constexpr featureId = 1;
   uint32_t constexpr segmentIdx = 1;
   auto connector = CreateConnector<CrossMwmId>();
-  connector.AddTransition(crossMwmId, featureId, segmentIdx, true /* oneWay */,
-                          true /* forwardIsEnter */);
+  {
+    typename CrossMwmConnector<CrossMwmId>::Builder builder(connector, 1);
+    builder.AddTransition(crossMwmId, featureId, segmentIdx, true /* oneWay */, true /* forwardIsEnter */);
+  }
 
   TestConnectorConsistency(connector);
-  TEST_EQUAL(connector.GetEnters().size(), 1, ());
-  TEST_EQUAL(connector.GetExits().size(), 0, ());
+  TEST_EQUAL(connector.GetNumEnters(), 1, ());
+  TEST_EQUAL(connector.GetNumExits(), 0, ());
   TEST(!connector.IsTransition(Segment(mwmId, featureId, segmentIdx, true /* forward */),
                                true /* isOutgoing */),
        ());
@@ -81,12 +85,14 @@ void TestOneWayExit(CrossMwmId const & crossMwmId)
   uint32_t constexpr featureId = 1;
   uint32_t constexpr segmentIdx = 1;
   auto connector = CreateConnector<CrossMwmId>();
-  connector.AddTransition(crossMwmId, featureId, segmentIdx, true /* oneWay */,
-                          false /* forwardIsEnter */);
+  {
+    typename CrossMwmConnector<CrossMwmId>::Builder builder(connector, 1);
+    builder.AddTransition(crossMwmId, featureId, segmentIdx, true /* oneWay */, false /* forwardIsEnter */);
+  }
 
   TestConnectorConsistency(connector);
-  TEST_EQUAL(connector.GetEnters().size(), 0, ());
-  TEST_EQUAL(connector.GetExits().size(), 1, ());
+  TEST_EQUAL(connector.GetNumEnters(), 0, ());
+  TEST_EQUAL(connector.GetNumExits(), 1, ());
   TEST(connector.IsTransition(Segment(mwmId, featureId, segmentIdx, true /* forward */),
                               true /* isOutgoing */),
        ());
@@ -107,12 +113,14 @@ void TestTwoWayEnter(CrossMwmId const & crossMwmId)
   uint32_t constexpr featureId = 1;
   uint32_t constexpr segmentIdx = 1;
   auto connector = CreateConnector<CrossMwmId>();
-  connector.AddTransition(crossMwmId, featureId, segmentIdx, false /* oneWay */,
-                          true /* forwardIsEnter */);
+  {
+    typename CrossMwmConnector<CrossMwmId>::Builder builder(connector, 1);
+    builder.AddTransition(crossMwmId, featureId, segmentIdx, false /* oneWay */, true /* forwardIsEnter */);
+  }
 
   TestConnectorConsistency(connector);
-  TEST_EQUAL(connector.GetEnters().size(), 1, ());
-  TEST_EQUAL(connector.GetExits().size(), 1, ());
+  TEST_EQUAL(connector.GetNumEnters(), 1, ());
+  TEST_EQUAL(connector.GetNumExits(), 1, ());
   TEST(!connector.IsTransition(Segment(mwmId, featureId, segmentIdx, true /* forward */),
                                true /* isOutgoing */),
        ());
@@ -132,12 +140,14 @@ void TestTwoWayExit(CrossMwmId const & crossMwmId)
   uint32_t constexpr featureId = 1;
   uint32_t constexpr segmentIdx = 1;
   auto connector = CreateConnector<CrossMwmId>();
-  connector.AddTransition(crossMwmId, featureId, segmentIdx, false /* oneWay */,
-                          false /* forwardIsEnter */);
+  {
+    typename CrossMwmConnector<CrossMwmId>::Builder builder(connector, 1);
+    builder.AddTransition(crossMwmId, featureId, segmentIdx, false /* oneWay */, false /* forwardIsEnter */);
+  }
 
   TestConnectorConsistency(connector);
-  TEST_EQUAL(connector.GetEnters().size(), 1, ());
-  TEST_EQUAL(connector.GetExits().size(), 1, ());
+  TEST_EQUAL(connector.GetNumEnters(), 1, ());
+  TEST_EQUAL(connector.GetNumExits(), 1, ());
   TEST(connector.IsTransition(Segment(mwmId, featureId, segmentIdx, true /* forward */),
                               true /* isOutgoing */),
        ());
@@ -161,11 +171,13 @@ void TestSerialization(vector<CrossMwmConnectorSerializer::Transition<CrossMwmId
   {
     CrossMwmConnectorPerVehicleType<CrossMwmId> connectors;
     CrossMwmConnector<CrossMwmId> & carConnector = connectors[static_cast<size_t>(VehicleType::Car)];
-    for (auto const & transition : transitions)
-      CrossMwmConnectorSerializer::AddTransition(transition, kCarMask, carConnector);
+    {
+      typename CrossMwmConnector<CrossMwmId>::Builder builder(carConnector, transitions.size());
+      for (auto const & transition : transitions)
+        CrossMwmConnectorSerializer::AddTransition(transition, kCarMask, builder);
+    }
 
-    carConnector.FillWeights(
-        [&](Segment const & enter, Segment const & exit) { return kEdgesWeight; });
+    carConnector.FillWeights([&](Segment const &, Segment const &) { return kEdgesWeight; });
 
     serial::GeometryCodingParams const codingParams;
     MemWriter<vector<uint8_t>> writer(buffer);
@@ -181,8 +193,8 @@ void TestSerialization(vector<CrossMwmConnectorSerializer::Transition<CrossMwmId
 
   TestConnectorConsistency(connector);
 
-  TEST_EQUAL(connector.GetEnters().size(), 2, ());
-  TEST_EQUAL(connector.GetExits().size(), 1, ());
+  TEST_EQUAL(connector.GetNumEnters(), 2, ());
+  TEST_EQUAL(connector.GetNumExits(), 1, ());
 
   TEST(!connector.IsTransition(Segment(mwmId, 0, 0, true), true /* isOutgoing */), ());
 
@@ -241,29 +253,43 @@ template <typename CrossMwmId>
 void TestWeightsSerialization()
 {
   size_t constexpr kNumTransitions = 3;
-  vector<double> const weights = {
-      4.0, 20.0, connector::kNoRoute, 12.0, connector::kNoRoute, 40.0, 48.0, 24.0, 12.0};
-  TEST_EQUAL(weights.size(), kNumTransitions * kNumTransitions, ());
+  uint32_t constexpr segmentIdx = 1;
+  double const weights[] = { 4.0, 20.0, connector::kNoRoute, 12.0, connector::kNoRoute, 40.0, 48.0, 24.0, 12.0 };
+  TEST_EQUAL(std::size(weights), kNumTransitions * kNumTransitions, ());
+
+  std::map<std::pair<Segment, Segment>, double> expectedWeights;
 
   vector<uint8_t> buffer;
   {
     vector<CrossMwmConnectorSerializer::Transition<CrossMwmId>> transitions;
-    for (uint32_t featureId = 0; featureId < kNumTransitions; ++featureId)
+    for (uint32_t featureId : { 2, 0, 1 })  // reshuffled
     {
       CrossMwmId id;
       GetCrossMwmId(featureId, id);
-      transitions.emplace_back(id, featureId, 1 /* segmentIdx */, kCarMask, 0 /* oneWayMask */,
-                               true /* forwardIsEnter */);
+      transitions.emplace_back(id, featureId, segmentIdx, kCarMask, 0 /* oneWayMask */, true /* forwardIsEnter */);
     }
 
-    CrossMwmConnectorPerVehicleType<CrossMwmId> connectors;
-    CrossMwmConnector<CrossMwmId> & carConnector = connectors[static_cast<size_t>(VehicleType::Car)];
-    for (auto const & transition : transitions)
-      CrossMwmConnectorSerializer::AddTransition(transition, kCarMask, carConnector);
+    // Initialization of Car connector with valid mwmId.
+    static_assert(static_cast<int>(VehicleType::Car) == 2, "");
+    using ConnectorT = CrossMwmConnector<CrossMwmId>;
+    CrossMwmConnectorPerVehicleType<CrossMwmId> connectors = {
+      ConnectorT{}, ConnectorT{}, ConnectorT{mwmId, 0}, ConnectorT{}
+    };
+    ConnectorT & carConnector = connectors[static_cast<size_t>(VehicleType::Car)];
 
-    int weightIdx = 0;
-    carConnector.FillWeights(
-        [&](Segment const & enter, Segment const & exit) { return weights[weightIdx++]; });
+    {
+      typename ConnectorT::Builder builder(carConnector, transitions.size());
+      for (auto const & transition : transitions)
+        CrossMwmConnectorSerializer::AddTransition(transition, kCarMask, builder);
+    }
+
+    size_t weightIdx = 0;
+    carConnector.FillWeights([&](Segment const & enter, Segment const & exit)
+    {
+      double const w = weights[weightIdx++];
+      TEST(expectedWeights.insert({{enter, exit}, w}).second, ());
+      return w;
+    });
 
     serial::GeometryCodingParams const codingParams;
     MemWriter<vector<uint8_t>> writer(buffer);
@@ -279,8 +305,8 @@ void TestWeightsSerialization()
 
   TestConnectorConsistency(connector);
 
-  TEST_EQUAL(connector.GetEnters().size(), kNumTransitions, ());
-  TEST_EQUAL(connector.GetExits().size(), kNumTransitions, ());
+  TEST_EQUAL(connector.GetNumEnters(), kNumTransitions, ());
+  TEST_EQUAL(connector.GetNumExits(), kNumTransitions, ());
 
   TEST(!connector.WeightsWereLoaded(), ());
   TEST(!connector.HasWeights(), ());
@@ -293,21 +319,19 @@ void TestWeightsSerialization()
   TEST(connector.WeightsWereLoaded(), ());
   TEST(connector.HasWeights(), ());
 
-  int weightIdx = 0;
-
   for (uint32_t enterId = 0; enterId < kNumTransitions; ++enterId)
   {
-    Segment const enter(mwmId, enterId, 1, true /* forward */);
     vector<SegmentEdge> expectedEdges;
+
+    Segment const enter(mwmId, enterId, segmentIdx, true /* forward */);
     for (uint32_t exitId = 0; exitId < kNumTransitions; ++exitId)
     {
-      auto const weight = weights[weightIdx];
-      if (weight != connector::kNoRoute)
-      {
-        expectedEdges.emplace_back(Segment(mwmId, exitId, 1 /* segmentIdx */, false /* forward */),
-                                   RouteWeight::FromCrossMwmWeight(weight));
-      }
-      ++weightIdx;
+      Segment const exit(mwmId, exitId, segmentIdx, false /* forward */);
+
+      auto const it = expectedWeights.find({enter, exit});
+      TEST(it != expectedWeights.end(), ());
+      if (it->second != connector::kNoRoute)
+        expectedEdges.emplace_back(exit, RouteWeight::FromCrossMwmWeight(it->second));
     }
 
     TestOutgoingEdges(connector, enter, expectedEdges);
@@ -315,33 +339,31 @@ void TestWeightsSerialization()
 }
 }  // namespace
 
-namespace routing_test
-{
-UNIT_TEST(OneWayEnter)
+UNIT_TEST(CMWMC_OneWayEnter)
 {
   TestOneWayEnter(base::MakeOsmWay(1ULL));
   TestOneWayEnter(TransitId(1 /* stop 1 id */, 2 /* stop 2 id */, 1 /* line id */));
 }
 
-UNIT_TEST(OneWayExit)
+UNIT_TEST(CMWMC_OneWayExit)
 {
   TestOneWayExit(base::MakeOsmWay(1ULL));
   TestOneWayExit(TransitId(1 /* stop 1 id */, 2 /* stop 2 id */, 1 /* line id */));
 }
 
-UNIT_TEST(TwoWayEnter)
+UNIT_TEST(CMWMC_TwoWayEnter)
 {
   TestTwoWayEnter(base::MakeOsmWay(1ULL));
   TestTwoWayEnter(TransitId(1 /* stop 1 id */, 2 /* stop 2 id */, 1 /* line id */));
 }
 
-UNIT_TEST(TwoWayExit)
+UNIT_TEST(CMWMC_TwoWayExit)
 {
   TestTwoWayExit(base::MakeOsmWay(1ULL));
   TestTwoWayExit(TransitId(1 /* stop 1 id */, 2 /* stop 2 id */, 1 /* line id */));
 }
 
-UNIT_TEST(Serialization)
+UNIT_TEST(CMWMC_Serialization)
 {
   {
     vector<CrossMwmConnectorSerializer::Transition<base::GeoObjectId>> const transitions = {
@@ -363,9 +385,9 @@ UNIT_TEST(Serialization)
   }
 }
 
-UNIT_TEST(WeightsSerialization)
+UNIT_TEST(CMWMC_WeightsSerialization)
 {
   TestWeightsSerialization<base::GeoObjectId>();
   TestWeightsSerialization<TransitId>();
 }
-}  // namespace routing_test
+} // namespace cross_mwm_connector_test

--- a/routing/single_vehicle_world_graph.cpp
+++ b/routing/single_vehicle_world_graph.cpp
@@ -46,18 +46,15 @@ void SingleVehicleWorldGraph::CheckAndProcessTransitFeatures(Segment const & par
   {
     JointSegment const & target = jointEdges[i].GetTarget();
 
-    NumMwmId const edgeMwmId = target.GetMwmId();
-
-    if (!m_crossMwmGraph->IsFeatureTransit(edgeMwmId, target.GetFeatureId()))
+    vector<Segment> twins;
+    m_crossMwmGraph->GetTwinFeature(target.GetSegment(true /* start */), isOutgoing, twins);
+    if (twins.empty())
     {
-      ASSERT_EQUAL(mwmId, edgeMwmId, ());
+      ASSERT_EQUAL(mwmId, target.GetMwmId(), ());
       continue;
     }
 
     auto & currentIndexGraph = GetIndexGraph(mwmId);
-
-    vector<Segment> twins;
-    m_crossMwmGraph->GetTwinFeature(target.GetSegment(true /* start */), isOutgoing, twins);
     for (auto const & twin : twins)
     {
       NumMwmId const twinMwmId = twin.GetMwmId();

--- a/routing/single_vehicle_world_graph.cpp
+++ b/routing/single_vehicle_world_graph.cpp
@@ -188,9 +188,9 @@ double SingleVehicleWorldGraph::CalculateETAWithoutPenalty(Segment const & segme
                                         EdgeEstimator::Purpose::ETA);
 }
 
-vector<Segment> const & SingleVehicleWorldGraph::GetTransitions(NumMwmId numMwmId, bool isEnter)
+void SingleVehicleWorldGraph::ForEachTransition(NumMwmId numMwmId, bool isEnter, TransitionFnT const & fn)
 {
-  return m_crossMwmGraph->GetTransitions(numMwmId, isEnter);
+  return m_crossMwmGraph->ForEachTransition(numMwmId, isEnter, fn);
 }
 
 unique_ptr<TransitInfo> SingleVehicleWorldGraph::GetTransitInfo(Segment const &) { return {}; }

--- a/routing/single_vehicle_world_graph.hpp
+++ b/routing/single_vehicle_world_graph.hpp
@@ -68,7 +68,7 @@ public:
   double CalculateETA(Segment const & from, Segment const & to) override;
   double CalculateETAWithoutPenalty(Segment const & segment) override;
 
-  std::vector<Segment> const & GetTransitions(NumMwmId numMwmId, bool isEnter) override;
+  void ForEachTransition(NumMwmId numMwmId, bool isEnter, TransitionFnT const & fn) override;
 
   void SetRoutingOptions(RoutingOptions routingOptions) override { m_avoidRoutingOptions = routingOptions; }
   /// \returns true if feature, associated with segment satisfies users conditions.

--- a/routing/world_graph.cpp
+++ b/routing/world_graph.cpp
@@ -62,10 +62,8 @@ bool WorldGraph::AreWavesConnectible(Parents<JointSegment> & forwardParents, Joi
 
 void WorldGraph::SetRoutingOptions(RoutingOptions /* routingOption */) {}
 
-std::vector<Segment> const & WorldGraph::GetTransitions(NumMwmId numMwmId, bool isEnter)
+void WorldGraph::ForEachTransition(NumMwmId numMwmId, bool isEnter, TransitionFnT const & fn)
 {
-  static std::vector<Segment> const kEmpty;
-  return kEmpty;
 }
 
 CrossMwmGraph & WorldGraph::GetCrossMwmGraph()

--- a/routing/world_graph.hpp
+++ b/routing/world_graph.hpp
@@ -96,8 +96,8 @@ public:
   virtual double CalculateETA(Segment const & from, Segment const & to) = 0;
   virtual double CalculateETAWithoutPenalty(Segment const & segment) = 0;
 
-  /// \returns transitions for mwm with id |numMwmId|.
-  virtual std::vector<Segment> const & GetTransitions(NumMwmId numMwmId, bool isEnter);
+  using TransitionFnT = std::function<void(Segment const &)>;
+  virtual void ForEachTransition(NumMwmId numMwmId, bool isEnter, TransitionFnT const & fn);
 
   virtual bool IsRoutingOptionsGood(Segment const & /* segment */);
   virtual RoutingOptions GetRoutingOptions(Segment const & /* segment */);


### PR DESCRIPTION
Removed dummy:
```
std::vector<Segment> m_enters;
std::vector<Segment> m_exits;
std::map<uint32_t, std::vector<uint32_t>> m_transitFeatureIdToSegmentId;
```
Replaced:
```
std::unordered_map<Key, Transition<CrossMwmId>, HashKey> with std::vector<std::pair<Key, Transition>>
```