### PR TITLE
[Routing] Fixes: #2422 + GetTurnDirection() refactoring

### DIFF
--- a/routing/routing_tests/turns_generator_test.cpp
+++ b/routing/routing_tests/turns_generator_test.cpp
@@ -335,10 +335,10 @@ UNIT_TEST(TestRightmostDirection)
 
 UNIT_TEST(TestLeftmostDirection)
 {
-  TEST_EQUAL(LeftmostDirection(180.), CarDirection::TurnSharpRight, ());
-  TEST_EQUAL(LeftmostDirection(170.), CarDirection::TurnSharpRight, ());
-  TEST_EQUAL(LeftmostDirection(90.), CarDirection::TurnRight, ());
-  TEST_EQUAL(LeftmostDirection(45.), CarDirection::TurnSlightRight, ());
+  TEST_EQUAL(LeftmostDirection(180.), CarDirection::GoStraight, ());
+  TEST_EQUAL(LeftmostDirection(170.), CarDirection::GoStraight, ());
+  TEST_EQUAL(LeftmostDirection(90.), CarDirection::GoStraight, ());
+  TEST_EQUAL(LeftmostDirection(45.), CarDirection::GoStraight, ());
   TEST_EQUAL(LeftmostDirection(0.), CarDirection::GoStraight, ());
   TEST_EQUAL(LeftmostDirection(-20.), CarDirection::TurnSlightLeft, ());
   TEST_EQUAL(LeftmostDirection(-90.), CarDirection::TurnLeft, ());

--- a/routing/routing_tests/turns_generator_test.cpp
+++ b/routing/routing_tests/turns_generator_test.cpp
@@ -328,9 +328,9 @@ UNIT_TEST(TestRightmostDirection)
   TEST_EQUAL(RightmostDirection(90.), CarDirection::TurnRight, ());
   TEST_EQUAL(RightmostDirection(45.), CarDirection::TurnSlightRight, ());
   TEST_EQUAL(RightmostDirection(0.), CarDirection::GoStraight, ());
-  TEST_EQUAL(RightmostDirection(-20.), CarDirection::TurnSlightLeft, ());
-  TEST_EQUAL(RightmostDirection(-90.), CarDirection::TurnLeft, ());
-  TEST_EQUAL(RightmostDirection(-170.), CarDirection::TurnSharpLeft, ());
+  TEST_EQUAL(RightmostDirection(-20.), CarDirection::GoStraight, ());
+  TEST_EQUAL(RightmostDirection(-90.), CarDirection::GoStraight, ());
+  TEST_EQUAL(RightmostDirection(-170.), CarDirection::GoStraight, ());
 }
 
 UNIT_TEST(TestLeftmostDirection)

--- a/routing/turns_generator.cpp
+++ b/routing/turns_generator.cpp
@@ -281,13 +281,6 @@ bool DiscardTurnByIngoingAndOutgoingEdges(CarDirection intermediateDirection, bo
                                           TurnInfo const & turnInfo, TurnItem const & turn,
                                           TurnCandidates const & turnCandidates)
 {
-  if (turn.m_keepAnyway || turnInfo.m_ingoing.m_onRoundabout ||
-      turnInfo.m_outgoing.m_onRoundabout ||
-      turnInfo.m_ingoing.m_highwayClass != turnInfo.m_outgoing.m_highwayClass)
-  {
-    return false;
-  }
-
   // @TODO(bykoianko) If all turn candidates go almost straight and there are several ways
   // from the junction (|hasMultiTurns| == true) the turn will be discarded.
   // If all turn candidates go almost straight and there is only one way
@@ -1167,8 +1160,9 @@ void GetTurnDirection(IRoutingResult const & result, size_t outgoingSegmentIndex
     return;
   }
 
-  if (DiscardTurnByIngoingAndOutgoingEdges(intermediateDirection, hasMultiTurns, turnInfo, turn, nodes))
-    return;
+  if (!turn.m_keepAnyway)
+    if (DiscardTurnByIngoingAndOutgoingEdges(intermediateDirection, hasMultiTurns, turnInfo, turn, nodes))
+      return;
 
   // Collect in candidatesWithoutUturn all turn candidates except uturn (if any).
   auto candidatesWithoutUturn = nodes.candidates;
@@ -1186,11 +1180,9 @@ void GetTurnDirection(IRoutingResult const & result, size_t outgoingSegmentIndex
   turn.m_turn = intermediateDirection;
 
   // Note 1. If the road significantly changes its direction this turn shall be kept here.
-  // Note 2. If there's only one exit from this junction (nodes.candidates.size() == 1)
-  // this turn should be kept (because it was kept by DiscardTurnByIngoingAndOutgoingEdges as an exception).
-  // Note 3. Keeping a turn at this point means that the decision to keep this turn or not
+  // Note 2. Keeping a turn at this point means that the decision to keep this turn or not
   // will be made after.
-  if (!turn.m_keepAnyway && IsGoStraightOrSlightTurn(turn.m_turn) && nodes.candidates.size() != 1)
+  if (!turn.m_keepAnyway && IsGoStraightOrSlightTurn(turn.m_turn)))
   {
     if (DiscardTurnByHighwayClass(nodes, turnInfo, numMwmIds, turn.m_turn) ||
         DiscardTurnByNoAlignedAlternatives(candidatesWithoutUturn, turnInfo, numMwmIds))

--- a/routing/turns_generator.cpp
+++ b/routing/turns_generator.cpp
@@ -1208,6 +1208,7 @@ void GetTurnDirection(IRoutingResult const & result, size_t outgoingSegmentIndex
     // GoStraight is corrected to TurnSlightRight/TurnSlightLeft
     // to avoid ambiguity: 2 or more almost straight turns and GoStraight direction.
 
+    // turnCandidates are sorted by angle from leftmost to rightmost.
     if (turnCandidates.front().m_segment == firstOutgoingSeg)
     {
       // The route goes along the leftmost candidate. 


### PR DESCRIPTION
Currently GetTurnDirection() is overcomplicated.
This is an attempt to make it more straightforward.
Also some bugs were found and fixed.
Full list nodes.candidates was used in many cases
but uturn had to be excluded.
The issue #2422 was expected to be handled even twice:
- Removing a slight turn if ingoing and outgoing edges
are not links and all other possible ways out are links.
- Usage of RightmostDirection() if
the route goes along the rightmost candidate.

But both failed because of mentioned nodes.candidates problem.