### PR TITLE
Explicitly set ~FileWriter() as noexcept(false).

### DIFF
--- a/coding/buffered_file_writer.cpp
+++ b/coding/buffered_file_writer.cpp
@@ -13,7 +13,7 @@ BufferedFileWriter::BufferedFileWriter(std::string const & fileName,
   m_buf.reserve(bufferSize);
 }
 
-BufferedFileWriter::~BufferedFileWriter()
+BufferedFileWriter::~BufferedFileWriter() noexcept(false)
 {
   DropBuffer();
 }

--- a/coding/buffered_file_writer.hpp
+++ b/coding/buffered_file_writer.hpp
@@ -12,8 +12,9 @@ public:
   explicit BufferedFileWriter(std::string const & fileName, Op operation = OP_WRITE_TRUNCATE,
                               size_t bufferSize = 4096);
 
+  ~BufferedFileWriter() noexcept(false) override;
+
   // Writer overrides:
-  ~BufferedFileWriter() override;
   void Seek(uint64_t pos) override;
   uint64_t Pos() const override;
   void Write(void const * p, size_t size) override;

--- a/coding/coding_tests/reader_test.cpp
+++ b/coding/coding_tests/reader_test.cpp
@@ -96,7 +96,8 @@ UNIT_TEST(ReaderStreamBuf)
   string const name = "test.txt";
 
   {
-    WriterStreamBuf buffer(new FileWriter(name));
+    FileWriter writer(name);
+    WriterStreamBuf buffer(writer);
     ostream s(&buffer);
     s << "hey!" << '\n' << 1 << '\n' << 3.14 << '\n' << 0x0102030405060708ull << endl;
   }

--- a/coding/file_writer.cpp
+++ b/coding/file_writer.cpp
@@ -10,7 +10,7 @@ FileWriter::FileWriter(string const & fileName, FileWriter::Op op)
 {
 }
 
-FileWriter::~FileWriter()
+FileWriter::~FileWriter() noexcept(false)
 {
   // Note: FileWriter::Flush will be called (like non virtual method).
   Flush();
@@ -41,19 +41,9 @@ uint64_t FileWriter::Size() const
   return m_pFileData->Size();
 }
 
-void FileWriter::Flush()
+void FileWriter::Flush() noexcept(false)
 {
   m_pFileData->Flush();
-}
-
-base::FileData & FileWriter::GetFileData()
-{
-  return *m_pFileData;
-}
-
-base::FileData const & FileWriter::GetFileData() const
-{
-  return *m_pFileData;
 }
 
 void FileWriter::DeleteFileX(string const & fName)

--- a/coding/file_writer.hpp
+++ b/coding/file_writer.hpp
@@ -38,7 +38,7 @@ public:
                       Op operation = OP_WRITE_TRUNCATE);
   FileWriter(FileWriter && rhs) = default;
 
-  ~FileWriter() override;
+  virtual ~FileWriter() noexcept(false);
 
   // Writer overrides:
   void Seek(uint64_t pos) override;
@@ -46,17 +46,13 @@ public:
   void Write(void const * p, size_t size) override;
 
   virtual uint64_t Size() const;
-  virtual void Flush();
+  virtual void Flush() noexcept(false);
 
   std::string const & GetName() const;
 
   static void DeleteFileX(std::string const & fName);
 
 protected:
-  base::FileData & GetFileData();
-  base::FileData const & GetFileData() const;
-
-private:
   std::unique_ptr<base::FileData> m_pFileData;
 };
 
@@ -92,10 +88,9 @@ public:
 
   TruncatingFileWriter(TruncatingFileWriter && rhs) = default;
 
-  // Writer overrides:
-  ~TruncatingFileWriter() override
+  ~TruncatingFileWriter() noexcept(false) override
   {
-    GetFileData().Flush();
-    GetFileData().Truncate(Pos());
+    m_pFileData->Flush();
+    m_pFileData->Truncate(Pos());
   }
 };

--- a/coding/reader_streambuf.cpp
+++ b/coding/reader_streambuf.cpp
@@ -40,14 +40,9 @@ ReaderStreamBuf::int_type ReaderStreamBuf::underflow()
 }
 
 
-WriterStreamBuf::~WriterStreamBuf()
-{
-  delete m_writer;
-}
-
 streamsize WriterStreamBuf::xsputn(char_type const * s, streamsize n)
 {
-  m_writer->Write(s, n);
+  m_writer.Write(s, n);
   return n;
 }
 
@@ -63,7 +58,7 @@ WriterStreamBuf::int_type WriterStreamBuf::overflow(int_type c)
 
 int WriterStreamBuf::sync()
 {
-  FileWriter * p = dynamic_cast<FileWriter *>(m_writer);
+  FileWriter * p = dynamic_cast<FileWriter *>(&m_writer);
   if (p)
     p->Flush();
   return 0;

--- a/coding/reader_streambuf.hpp
+++ b/coding/reader_streambuf.hpp
@@ -34,12 +34,11 @@ private:
 
 class WriterStreamBuf : public BaseStreamBuf
 {
-  Writer * m_writer;
+  Writer & m_writer;
 
 public:
   /// Takes the ownership of p. Writer should be allocated in dynamic memory.
-  WriterStreamBuf(Writer * p) : m_writer(p) {}
-  virtual ~WriterStreamBuf();
+  explicit WriterStreamBuf(Writer & writer) : m_writer(writer) {}
 
 private:
   virtual std::streamsize xsputn(char_type const * s, std::streamsize n);

--- a/coding/writer.hpp
+++ b/coding/writer.hpp
@@ -22,10 +22,13 @@ public:
   DECLARE_EXCEPTION(SeekException, Exception);
   DECLARE_EXCEPTION(CreateDirException, Exception);
 
-  virtual ~Writer() {}
   virtual void Seek(uint64_t pos) = 0;
   virtual uint64_t Pos() const = 0;
   virtual void Write(void const * p, size_t size) = 0;
+
+  // Disable deletion via this interface, because some dtors in derived classes are noexcept(false).
+protected:
+  ~Writer() = default;
 };
 
 template <typename ContainerT>
@@ -82,7 +85,7 @@ public:
   {
   }
 
-  ~SubWriter() override
+  ~SubWriter()
   {
     ASSERT_EQUAL(m_offset, GetOffset(), ());
     if (m_pos != m_maxPos)

--- a/generator/feature_emitter_iface.hpp
+++ b/generator/feature_emitter_iface.hpp
@@ -7,7 +7,10 @@ class FeatureBuilder;
 
 class FeatureEmitterIFace
 {
+  // Disable deletion via this interface, because some dtors in derived classes are noexcept(false).
+protected:
+  ~FeatureEmitterIFace() = default;
+
 public:
-  virtual ~FeatureEmitterIFace() {}
   virtual void operator() (feature::FeatureBuilder const &) = 0;
 };

--- a/generator/intermediate_data.cpp
+++ b/generator/intermediate_data.cpp
@@ -157,7 +157,7 @@ public:
   {
   }
 
-  ~RawMemPointStorageWriter() override
+  ~RawMemPointStorageWriter() noexcept(false) override
   {
     m_fileWriter.Write(m_data.data(), m_data.size() * sizeof(LatLon));
   }

--- a/generator/intermediate_data.hpp
+++ b/generator/intermediate_data.hpp
@@ -58,7 +58,7 @@ static_assert(std::is_trivially_copyable<LatLonPos>::value, "");
 class PointStorageWriterInterface
 {
 public:
-  virtual ~PointStorageWriterInterface() {}
+  virtual ~PointStorageWriterInterface() noexcept(false) = default;
   virtual void AddPoint(uint64_t id, double lat, double lon) = 0;
   virtual uint64_t GetNumProcessedPoints() const = 0;
 };

--- a/generator/world_map_generator.hpp
+++ b/generator/world_map_generator.hpp
@@ -210,10 +210,10 @@ class WorldMapGenerator
       LOG_SHORT(LINFO, ("Output World file:", worldFilename));
     }
 
-    ~EmitterImpl() override
+    ~EmitterImpl()
     {
       Classificator const & c = classif();
-      
+
       std::stringstream ss;
       ss << std::endl;
       for (auto const & p : m_mapTypes)


### PR DESCRIPTION
- C++11 Destructor has implicit non-throwing exception specification
- Throw from a function marked noexcept, std::terminate is called immediately

Now we have Flush() noexcept(false) call in ~FileWriter() and I don't know how to avoid it and don't break the code.
So mark ~FileWriter() as noexcept(false) too.

Closes https://github.com/organicmaps/organicmaps/issues/672