### PR TITLE
[android] Fix bg color of layers and main menus

### DIFF
--- a/android/res/values/styles.xml
+++ b/android/res/values/styles.xml
@@ -395,10 +395,12 @@
 
   <style name="MwmWidget.BottomSheetDialog" parent="Theme.Material3.Light.BottomSheetDialog">
     <item name="colorSurface">?cardBackground</item>
+    <item name="elevationOverlayEnabled">false</item>
   </style>
 
   <style name="MwmWidget.Night.BottomSheetDialog" parent="Theme.Material3.Dark.BottomSheetDialog" >
     <item name="colorSurface">?cardBackground</item>
+    <item name="elevationOverlayEnabled">false</item>
   </style>
 
 </resources>


### PR DESCRIPTION
Enabled ElevationOverlays make components mix colors to produce a "3d elevated look" - that's how the grey color not defined in the palette came into existence.

Tested on a5.0 and a9.0.
No regressions found in different dialogs of the app, the dark mode also looks consistent.
![menu-bg](https://user-images.githubusercontent.com/18434508/164541937-dbfd43d9-5478-43e9-b4d2-6f27ca9e010a.png)

Closes #2297 