### PR TITLE
Fix place page corner rounding

### DIFF
--- a/iphone/Maps/UI/PlacePage/Components/PlacePageHeader/PlacePageHeaderViewController.swift
+++ b/iphone/Maps/UI/PlacePage/Components/PlacePageHeader/PlacePageHeaderViewController.swift
@@ -9,6 +9,7 @@ protocol PlacePageHeaderViewProtocol: AnyObject {
 class PlacePageHeaderViewController: UIViewController {
   var presenter: PlacePageHeaderPresenterProtocol?
 
+  @IBOutlet private var headerView: PlacePageHeaderView!
   @IBOutlet private var titleLabel: UILabel?
   @IBOutlet private var expandView: UIView!
   @IBOutlet private var shadowView: UIView!
@@ -18,6 +19,7 @@ class PlacePageHeaderViewController: UIViewController {
     presenter?.configure()
     let tap = UITapGestureRecognizer(target: self, action: #selector(onExpandPressed(sender:)))
     expandView.addGestureRecognizer(tap)
+    headerView.layer.maskedCorners = [.layerMinXMinYCorner, .layerMaxXMinYCorner]
   }
 
   @objc func onExpandPressed(sender: UITapGestureRecognizer) {

--- a/iphone/Maps/UI/PlacePage/PlacePage.storyboard
+++ b/iphone/Maps/UI/PlacePage/PlacePage.storyboard
@@ -19,7 +19,7 @@
                         <rect key="frame" x="0.0" y="0.0" width="375" height="667"/>
                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                         <subviews>
-                            <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="TtY-w3-kOi">
+                            <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="TtY-w3-kOi" userLabel="Background View">
                                 <rect key="frame" x="0.0" y="0.0" width="375" height="667"/>
                                 <color key="backgroundColor" systemColor="systemBackgroundColor"/>
                                 <userDefinedRuntimeAttributes>
@@ -52,7 +52,7 @@
                                     <outlet property="delegate" destination="bX8-ZQ-XDA" id="ASo-bI-N1l"/>
                                 </connections>
                             </scrollView>
-                            <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="RZh-69-00e">
+                            <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="RZh-69-00e" userLabel="Divider View">
                                 <rect key="frame" x="0.0" y="617" width="375" height="1"/>
                                 <color key="backgroundColor" systemColor="separatorColor"/>
                                 <constraints>

--- a/iphone/Maps/UI/PlacePage/PlacePage.storyboard
+++ b/iphone/Maps/UI/PlacePage/PlacePage.storyboard
@@ -1796,6 +1796,7 @@
                     <size key="freeformSize" width="375" height="59"/>
                     <connections>
                         <outlet property="expandView" destination="Gdy-g5-gbM" id="rzi-mb-hUi"/>
+                        <outlet property="headerView" destination="fqh-H3-eji" id="Z2K-Wd-hRO"/>
                         <outlet property="shadowView" destination="spW-XI-KSY" id="kLc-R7-Rij"/>
                         <outlet property="titleLabel" destination="lR4-to-4wX" id="l4F-JL-aNb"/>
                         <outlet property="view" destination="xTs-NP-HcT" id="jQF-X9-Xlv"/>

--- a/iphone/Maps/UI/PlacePage/PlacePageViewController.swift
+++ b/iphone/Maps/UI/PlacePage/PlacePageViewController.swift
@@ -58,7 +58,13 @@ final class PlacePageScrollView: UIScrollView {
     bgView.styleName = "PPBackgroundView"
     stackView.insertSubview(bgView, at: 0)
     bgView.alignToSuperview()
+
     scrollView.decelerationRate = .fast
+    scrollView.layer.cornerRadius = 10
+    scrollView.layer.maskedCorners = [.layerMinXMinYCorner, .layerMaxXMinYCorner]
+
+    stackView.layer.cornerRadius = 10
+    stackView.layer.maskedCorners = [.layerMinXMinYCorner, .layerMaxXMinYCorner]
 
     actionBarContainerView.layer.cornerRadius = 10
     actionBarContainerView.layer.masksToBounds = true

--- a/iphone/Maps/UI/PlacePage/PlacePageViewController.swift
+++ b/iphone/Maps/UI/PlacePage/PlacePageViewController.swift
@@ -59,6 +59,10 @@ final class PlacePageScrollView: UIScrollView {
     stackView.insertSubview(bgView, at: 0)
     bgView.alignToSuperview()
     scrollView.decelerationRate = .fast
+
+    actionBarContainerView.layer.cornerRadius = 10
+    actionBarContainerView.layer.masksToBounds = true
+    actionBarContainerView.layer.maskedCorners = [.layerMinXMaxYCorner, .layerMaxXMaxYCorner]
   }
 
   override func viewDidLayoutSubviews() {


### PR DESCRIPTION
Hi, here's my second attempt at fixing place page corners. :)

Apart from the action bar (bottom) corners mentioned in #1675, this also fixes top corners on iPhone-size devices. It also fixes visual glitches within the place page that were caused by corners that actually should not be rounded.

One thing I couldn't conclude so far: I have added code sections that set `view.layer.maskedCorners` to configure which corners don't need rounding. I feel like this *may* be part of the theme (`PlacePageStyleSheet.swift`) to keep all styling configuration in one place. May also lead to even more, very specific styles though. Also that would need extension of the theming code of course.

What do you think?