### PR TITLE
[strings] Fix translation of "Västra Götaland" in fr and pl

### DIFF
--- a/data/countries-strings/fr.json/localize.json
+++ b/data/countries-strings/fr.json/localize.json
@@ -967,7 +967,7 @@
 "Sweden_Norra Sverige":"Norra Sverige",
 "Sweden_Ostra Gotaland":"Östra Götaland",
 "Sweden_Sodra Gotaland":"Södra Götaland",
-"Sweden_Vastra Gotaland":"Östra Götaland",
+"Sweden_Vastra Gotaland":"Västra Götaland",
 "Switzerland":"Suisse",
 "Switzerland_Central":"Suisse centrale",
 "Switzerland_Eastern":"Suisse orientale",

--- a/data/countries-strings/pl.json/localize.json
+++ b/data/countries-strings/pl.json/localize.json
@@ -967,7 +967,7 @@
 "Sweden_Norra Sverige":"Norra Sverige",
 "Sweden_Ostra Gotaland":"Ostra Götaland",
 "Sweden_Sodra Gotaland":"Södra Götaland",
-"Sweden_Vastra Gotaland":"Ostra Götaland",
+"Sweden_Vastra Gotaland":"Västra Götaland",
 "Switzerland":"Szwajcaria",
 "Switzerland_Central":"Szwajcaria Środkowa",
 "Switzerland_Eastern":"Szwajcaria Wschodnia",

--- a/data/countries_names.txt
+++ b/data/countries_names.txt
@@ -30279,7 +30279,7 @@
   da = Västra Götaland
   nl = West Gotland
   fi = Länsi-Götanmaa
-  fr = Östra Götaland
+  fr = Västra Götaland
   de = Västra Götaland
   hu = Västra Götaland
   id = Västra Götaland
@@ -30287,7 +30287,7 @@
   ja = スイス中部
   ko = 바스트라 가타랜드
   nb = Västra Götaland
-  pl = Ostra Götaland
+  pl = Västra Götaland
   pt = Västra Götaland
   ro = Västra Götaland
   es = Västra Götaland


### PR DESCRIPTION
Both "Östra Götaland" and "Västra Götaland" where translated as "Östra Götaland" in french and polish which made the swedish map download confusing.