### PR TITLE
[android] Check if new fused location is better than old one, except Google provider.

### DIFF
--- a/android/flavors/gms-enabled/com/mapswithme/maps/location/GoogleFusedLocationProvider.java
+++ b/android/flavors/gms-enabled/com/mapswithme/maps/location/GoogleFusedLocationProvider.java
@@ -111,4 +111,7 @@ class GoogleFusedLocationProvider extends BaseLocationProvider
     mFusedLocationClient.removeLocationUpdates(mCallback);
     mActive = false;
   }
+
+  @Override
+  protected boolean trustFusedLocations() { return true; }
 }

--- a/android/src/com/mapswithme/maps/location/BaseLocationProvider.java
+++ b/android/src/com/mapswithme/maps/location/BaseLocationProvider.java
@@ -27,4 +27,5 @@ abstract class BaseLocationProvider
 
   protected abstract void start(long interval);
   protected abstract void stop();
+  protected boolean trustFusedLocations() { return false; }
 }

--- a/android/src/com/mapswithme/maps/location/LocationHelper.java
+++ b/android/src/com/mapswithme/maps/location/LocationHelper.java
@@ -304,12 +304,19 @@ public enum LocationHelper implements Initializable<Context>, AppBackgroundTrack
     mLogger.d(TAG, "onLocationChanged, location = " + location);
 
     if (!LocationUtils.isAccuracySatisfied(location))
-      return;
-
-    if (mSavedLocation != null && !LocationUtils.isLocationBetterThanLast(location, mSavedLocation))
     {
-      mLogger.d(TAG, "The new " + location + " is worse than the last " +  mSavedLocation);
+      mLogger.w(TAG, "Unsatisfied accuracy for location = " + location);
       return;
+    }
+
+    if (mSavedLocation != null)
+    {
+      final boolean isTrustedFused = mLocationProvider.trustFusedLocations() && LocationUtils.isFromFusedProvider(location);
+      if (!isTrustedFused && !LocationUtils.isLocationBetterThanLast(location, mSavedLocation))
+      {
+        mLogger.d(TAG, "The new " + location + " is worse than the last " + mSavedLocation);
+        return;
+      }
     }
 
     mSavedLocation = location;

--- a/android/src/com/mapswithme/util/LocationUtils.java
+++ b/android/src/com/mapswithme/util/LocationUtils.java
@@ -89,9 +89,7 @@ public class LocationUtils
 
   public static boolean isLocationBetterThanLast(@NonNull Location newLocation, @NonNull Location lastLocation)
   {
-    if (isFromFusedProvider(newLocation))
-      return true;
-
+    // As described in isAccuracySatisfied, GPS may have zero accuracy "for some reasons".
     if (isFromGpsProvider(lastLocation) && lastLocation.getAccuracy() == 0.0f)
       return true;
 


### PR DESCRIPTION
This device (stock system):
```
Android version: 31
Device: samsung SM-A525F
App version: app.organicmaps 2022.04.27-2-Google
Locale : ru_RU
Location providers: passive network fused gps 
```
prints in location logs:
"fused" locations from AndroidNative provider with network accuracy=500.

User confirmed that the build with these PR works better.