### PR TITLE
[Styles] Render parking spaces

### DIFF
--- a/data/styles/clear/include/Basemap.mapcss
+++ b/data/styles/clear/include/Basemap.mapcss
@@ -109,6 +109,7 @@ area[amenity=grave_yard]
 {z-index: 44;}
 
 area[highway=pedestrian][area?],
+area[amenity=parking_space],
 area[area:highway=pedestrian],
 area[highway=footway][area?][!sac_scale],
 area[area:highway=footway],
@@ -593,10 +594,15 @@ area|z10-[landuse=farmland],
 area|z10-[landuse=farmyard],
 {fill-position: background; fill-color: @farmland; fill-opacity: 1;}
 
+
 /* Parking */
 
 area|z15-[amenity=parking]
 {fill-color: @parking;}
+
+area|z16-[amenity=parking_space]
+{fill-color: @parking_space; fill-opacity: 0.3;}
+
 
 /* 8.BUILDINGS */
 

--- a/data/styles/clear/style-clear/colors.mapcss
+++ b/data/styles/clear/style-clear/colors.mapcss
@@ -10,6 +10,7 @@
 	4.2 Aerodrome
   4.3 Barriers
   4.4 Buildings
+  4.5 Parking
 5.ROADS
   5.1 All roads
 	5.2 Bridges
@@ -65,7 +66,6 @@
 @hospital: #F8D9D9;
 @industrial: #E4E2EB;
 @sport: #D1CDA7;
-@parking: #F2F2BC;
 @military: #E53935;
 @farmland: #EBE4A5;
 
@@ -89,6 +89,10 @@
 @building_dark: #C2C0B3;
 @building_border: #A1A096;
 @building_dark_border: #9B9A8F;
+
+/* 4.5 Parking */
+@parking: #F2F2BC;
+@parking_space: #FFFFFF;
 
 /* 5.ROADS */
 /* 5.1 All roads */

--- a/data/styles/clear/style-night/colors.mapcss
+++ b/data/styles/clear/style-night/colors.mapcss
@@ -10,6 +10,7 @@
 	4.2 Aerodrome
   4.3 Barriers
   4.4 Buildings
+  4.5 Parking
 5.ROADS
   5.1 All roads
 	5.2 Bridges
@@ -65,7 +66,6 @@
 @hospital: #261916;
 @industrial: #191419;
 @sport: #21211B;
-@parking: #1F1B1B;
 @military: #B71C1C;
 @farmland: #151500;
 
@@ -89,6 +89,10 @@
 @building_dark: #3B3B3B;
 @building_border: #303030;
 @building_dark_border: #474747;
+
+/* 4.5 Parking */
+@parking: #1F1B1B;
+@parking_space: #444444;
 
 /* 5.ROADS */
 /* 5.1 All roads */

--- a/data/styles/vehicle/include/Basemap.mapcss
+++ b/data/styles/vehicle/include/Basemap.mapcss
@@ -165,7 +165,6 @@ line[barrier=hedge],
 line[barrier=city_wall],
 line[historic=citywalls],
 area[amenity=parking],
-area[amenity=parking_space],
 {z-index: 950;}
 
 /* 2.LAND */
@@ -425,7 +424,6 @@ area|z15-[landuse=railway],
 area|z15-[landuse=quarry],
 area|z15-[leisure=stadium],
 area|z15-[amenity=parking],
-area|z15-[amenity=parking_space],
 area|z16-[public_transport=platform],
 area|z16-[amenity=place_of_worship],
 area|z16-[railway=platform],
@@ -503,10 +501,8 @@ area|z14-[landuse=farmland],
 /* Parking */
 
 area|z15-[amenity=parking],
-area|z15-[amenity=parking_space]
 {fill-color: @parking;fill-opacity: 1;}
 area|z17-[amenity=parking],
-area|z17-[amenity=parking_space]
 {fill-color: @parking_l;fill-opacity: 1;}
 
 /* 8.BUILDINGS */


### PR DESCRIPTION
(needs map regeneration)
finally figured out how to generate maps 🥳

renders parking spaces. I tried to keep it unobtrusive which is why it's hard to see, but i think this is ok as rendering them strongly would make the map look cluttered and overly complex.

link to MWM with parking_spaces generated: https://drive.google.com/file/d/1kkbFmjlqddTLOvJx2xGCF_wi6xaV5KOf
location: 51.4986905, 0.0039843

z18
<img width="1032" alt="Screenshot 2022-05-14 at 15 17 58" src="https://user-images.githubusercontent.com/26939824/168429870-938aa5b4-9e57-43f4-a9e0-157fbd5f1dec.png">
>

z19 onwards
<img width="1032" alt="Screenshot 2022-05-14 at 15 18 13" src="https://user-images.githubusercontent.com/26939824/168429894-29d7676e-7205-43cc-8f00-fed976f463e5.png">

Signed-off-by: Harry Bond <endim8@pm.me>