### PR TITLE
[android] Rework Save Maps To settings 

### DIFF
--- a/CONTRIBUTORS
+++ b/CONTRIBUTORS
@@ -37,6 +37,7 @@ Code contributions:
   Max Grigorev <forwidur@gmail.com>
   Roman Tsisyk <roman@tsisyk.com>
   Caspar Nuël <casparnuel@yandex.com>
+  Konstantin Pastbin
 
 Porting to Tizen platform:
   Sergey Pisarchik

--- a/android/res/layout/item_storage.xml
+++ b/android/res/layout/item_storage.xml
@@ -6,4 +6,5 @@
     android:layout_height="wrap_content"
     android:minHeight="@dimen/height_item_oneline"
     android:checkMark="?android:attr/listChoiceIndicatorSingle"
+    android:minLines="3"
     tools:text="/storage/mnt/"/>

--- a/android/res/values-ar/strings.xml
+++ b/android/res/values-ar/strings.xml
@@ -17,8 +17,6 @@
 	<string name="downloading">جاري التنزيل…</string>
 	<!-- Choose measurement on first launch alert - choose metric system button -->
 	<string name="kilometres">كيلومتر</string>
-	<!-- View and button titles for accessibility -->
-	<string name="maps">الخرائط</string>
 	<!-- Settings/Downloader - size string, only strings different from English should be translated -->
 	<string name="mb">م.ب.</string>
 	<!-- Choose measurement on first launch alert - choose imperial system button -->
@@ -80,6 +78,8 @@
 	<string name="maps_storage">تخزين الخرائط</string>
 	<!-- Detailed description of Maps Storage settings button -->
 	<string name="maps_storage_summary">اختر المكان الذي ينبغي تنزيل الخرائط  فيه.</string>
+	<!-- E.g. "Downloaded maps: 500Mb" in Maps Storage settings -->
+	<string name="maps_storage_downloaded">الخرائط</string>
 	<!-- Question dialog for transferring maps from one storage to another -->
 	<string name="move_maps">هل تريد نقل الخرائط؟</string>
 	<!-- Ask to wait user several minutes (some long process in modal dialog). -->
@@ -228,11 +228,12 @@
 	<string name="downloader_update_all_button">تحديث الكل</string>
 	<!-- Cancel all button text -->
 	<string name="downloader_cancel_all">إلغاء الكل</string>
-	<!-- Downloaded maps category -->
+	<!-- Downloaded maps list header -->
 	<string name="downloader_downloaded_subtitle">تم تنزيلها</string>
 	<!-- Country queued for download -->
 	<string name="downloader_queued">مَصْفوف</string>
 	<string name="downloader_near_me_subtitle">بالقرب مني</string>
+	<!-- In maps downloader and country place page shows how many maps are downloaded / to download, e.g. "Maps: 3 of 10" -->
 	<string name="downloader_status_maps">الخرائط</string>
 	<string name="downloader_download_all_button">تنزيل الكل</string>
 	<string name="downloader_downloading">يتم تنزيل:</string>

--- a/android/res/values-be/strings.xml
+++ b/android/res/values-be/strings.xml
@@ -17,8 +17,6 @@
 	<string name="downloading">Спампоўваецца…</string>
 	<!-- Choose measurement on first launch alert - choose metric system button -->
 	<string name="kilometres">Кіламетры</string>
-	<!-- View and button titles for accessibility -->
-	<string name="maps">Мапы</string>
 	<!-- Settings/Downloader - size string, only strings different from English should be translated -->
 	<string name="mb">МБ</string>
 	<string name="gb">ГБ</string>
@@ -81,6 +79,12 @@
 	<string name="maps_storage">Захаваць мапы ў</string>
 	<!-- Detailed description of Maps Storage settings button -->
 	<string name="maps_storage_summary">Выберыце месца, дзе захоўваць запампаваныя мапы</string>
+	<!-- E.g. "Downloaded maps: 500Mb" in Maps Storage settings -->
+	<string name="maps_storage_downloaded">Мапы</string>
+	<!-- Shared storage type in Maps Storage settings (a primary storage usually) -->
+	<string name="maps_storage_shared">Унутранае абагуленае сховішча</string>
+	<!-- Removable external storage type in Maps Storage settings, e.g. an SD card -->
+	<string name="maps_storage_removable">SD-карта</string>
 	<!-- Question dialog for transferring maps from one storage to another -->
 	<string name="move_maps">Перамясціць мапы?</string>
 	<!-- Ask to wait user several minutes (some long process in modal dialog). -->
@@ -236,11 +240,12 @@
 	<string name="downloader_update_all_button">Абнавіць усё</string>
 	<!-- Cancel all button text -->
 	<string name="downloader_cancel_all">Адмяніць усё</string>
-	<!-- Downloaded maps category -->
+	<!-- Downloaded maps list header -->
 	<string name="downloader_downloaded_subtitle">Спампаваныя</string>
 	<!-- Country queued for download -->
 	<string name="downloader_queued">У чарзе</string>
 	<string name="downloader_near_me_subtitle">Каля мяне</string>
+	<!-- In maps downloader and country place page shows how many maps are downloaded / to download, e.g. "Maps: 3 of 10" -->
 	<string name="downloader_status_maps">Мапы</string>
 	<string name="downloader_download_all_button">Спампаваць усё</string>
 	<string name="downloader_downloading">Спампоўваецца:</string>

--- a/android/res/values-bg/strings.xml
+++ b/android/res/values-bg/strings.xml
@@ -17,8 +17,6 @@
 	<string name="downloading">Теглене…</string>
 	<!-- Choose measurement on first launch alert - choose metric system button -->
 	<string name="kilometres">Километри</string>
-	<!-- View and button titles for accessibility -->
-	<string name="maps">Карти</string>
 	<!-- Settings/Downloader - size string, only strings different from English should be translated -->
 	<string name="mb">МБ</string>
 	<string name="gb">ГБ</string>
@@ -81,6 +79,8 @@
 	<string name="maps_storage">Запаметяване на карти в</string>
 	<!-- Detailed description of Maps Storage settings button -->
 	<string name="maps_storage_summary">Изберете мястото, където картите трябва да се изтеглят</string>
+	<!-- E.g. "Downloaded maps: 500Mb" in Maps Storage settings -->
+	<string name="maps_storage_downloaded">Карти</string>
 	<!-- Question dialog for transferring maps from one storage to another -->
 	<string name="move_maps">Преместване на карти?</string>
 	<!-- Ask to wait user several minutes (some long process in modal dialog). -->
@@ -233,11 +233,12 @@
 	<string name="downloader_update_all_button">Обновяване на всичко</string>
 	<!-- Cancel all button text -->
 	<string name="downloader_cancel_all">Отмяна на всичко</string>
-	<!-- Downloaded maps category -->
+	<!-- Downloaded maps list header -->
 	<string name="downloader_downloaded_subtitle">Изтеглено</string>
 	<!-- Country queued for download -->
 	<string name="downloader_queued">На опашка</string>
 	<string name="downloader_near_me_subtitle">Близо до мен</string>
+	<!-- In maps downloader and country place page shows how many maps are downloaded / to download, e.g. "Maps: 3 of 10" -->
 	<string name="downloader_status_maps">Карти</string>
 	<string name="downloader_download_all_button">Изтегляне на всичко</string>
 	<string name="downloader_downloading">Теглене:</string>

--- a/android/res/values-cs/strings.xml
+++ b/android/res/values-cs/strings.xml
@@ -17,8 +17,6 @@
 	<string name="downloading">Stahování…</string>
 	<!-- Choose measurement on first launch alert - choose metric system button -->
 	<string name="kilometres">Kilometry</string>
-	<!-- View and button titles for accessibility -->
-	<string name="maps">Mapy</string>
 	<!-- Choose measurement on first launch alert - choose imperial system button -->
 	<string name="miles">Míle</string>
 	<!-- A text for current gps location point/arrow selected on the map -->
@@ -78,6 +76,8 @@
 	<string name="maps_storage">Uložit mapy na</string>
 	<!-- Detailed description of Maps Storage settings button -->
 	<string name="maps_storage_summary">Vyberte místo, kam by měly být mapy stahovány</string>
+	<!-- E.g. "Downloaded maps: 500Mb" in Maps Storage settings -->
+	<string name="maps_storage_downloaded">Mapy</string>
 	<!-- Question dialog for transferring maps from one storage to another -->
 	<string name="move_maps">Přesunout mapy?</string>
 	<!-- Ask to wait user several minutes (some long process in modal dialog). -->
@@ -226,11 +226,12 @@
 	<string name="downloader_update_all_button">Aktualizovat vše</string>
 	<!-- Cancel all button text -->
 	<string name="downloader_cancel_all">Zrušit vše</string>
-	<!-- Downloaded maps category -->
+	<!-- Downloaded maps list header -->
 	<string name="downloader_downloaded_subtitle">Staženo</string>
 	<!-- Country queued for download -->
 	<string name="downloader_queued">Ve frontě</string>
 	<string name="downloader_near_me_subtitle">Poblíž mě</string>
+	<!-- In maps downloader and country place page shows how many maps are downloaded / to download, e.g. "Maps: 3 of 10" -->
 	<string name="downloader_status_maps">Mapy</string>
 	<string name="downloader_download_all_button">Stáhnout vše</string>
 	<string name="downloader_downloading">Probíhá stahování:</string>

--- a/android/res/values-da/strings.xml
+++ b/android/res/values-da/strings.xml
@@ -17,8 +17,6 @@
 	<string name="downloading">Downloader…</string>
 	<!-- Choose measurement on first launch alert - choose metric system button -->
 	<string name="kilometres">Kilometre</string>
-	<!-- View and button titles for accessibility -->
-	<string name="maps">Kort</string>
 	<!-- Choose measurement on first launch alert - choose imperial system button -->
 	<string name="miles">Mil</string>
 	<!-- A text for current gps location point/arrow selected on the map -->
@@ -78,6 +76,8 @@
 	<string name="maps_storage">Gem kort på</string>
 	<!-- Detailed description of Maps Storage settings button -->
 	<string name="maps_storage_summary">Vælg destination hvor dine kort skal downloades til</string>
+	<!-- E.g. "Downloaded maps: 500Mb" in Maps Storage settings -->
+	<string name="maps_storage_downloaded">Kort</string>
 	<!-- Question dialog for transferring maps from one storage to another -->
 	<string name="move_maps">Flyt kort?</string>
 	<!-- Ask to wait user several minutes (some long process in modal dialog). -->
@@ -226,11 +226,12 @@
 	<string name="downloader_update_all_button">Opdatér alle</string>
 	<!-- Cancel all button text -->
 	<string name="downloader_cancel_all">Aflys Alt</string>
-	<!-- Downloaded maps category -->
+	<!-- Downloaded maps list header -->
 	<string name="downloader_downloaded_subtitle">Downloadet</string>
 	<!-- Country queued for download -->
 	<string name="downloader_queued">I kø</string>
 	<string name="downloader_near_me_subtitle">I nærheden</string>
+	<!-- In maps downloader and country place page shows how many maps are downloaded / to download, e.g. "Maps: 3 of 10" -->
 	<string name="downloader_status_maps">Kort</string>
 	<string name="downloader_download_all_button">Download alle</string>
 	<string name="downloader_downloading">Downloader:</string>

--- a/android/res/values-de/strings.xml
+++ b/android/res/values-de/strings.xml
@@ -17,8 +17,6 @@
 	<string name="downloading">Wird heruntergeladen…</string>
 	<!-- Choose measurement on first launch alert - choose metric system button -->
 	<string name="kilometres">Kilometer</string>
-	<!-- View and button titles for accessibility -->
-	<string name="maps">Karten</string>
 	<!-- Settings/Downloader - size string, only strings different from English should be translated -->
 	<string name="mb">MB</string>
 	<!-- Choose measurement on first launch alert - choose imperial system button -->
@@ -80,6 +78,8 @@
 	<string name="maps_storage">Karten speichern auf</string>
 	<!-- Detailed description of Maps Storage settings button -->
 	<string name="maps_storage_summary">Wählen Sie den Speicherort, an den die Karten heruntergeladen werden sollen</string>
+	<!-- E.g. "Downloaded maps: 500Mb" in Maps Storage settings -->
+	<string name="maps_storage_downloaded">Karten</string>
 	<!-- Question dialog for transferring maps from one storage to another -->
 	<string name="move_maps">Karten verschieben?</string>
 	<!-- Ask to wait user several minutes (some long process in modal dialog). -->
@@ -232,11 +232,12 @@
 	<string name="downloader_update_all_button">Alle aktualisieren</string>
 	<!-- Cancel all button text -->
 	<string name="downloader_cancel_all">Alle abbrechen</string>
-	<!-- Downloaded maps category -->
+	<!-- Downloaded maps list header -->
 	<string name="downloader_downloaded_subtitle">Heruntergeladen</string>
 	<!-- Country queued for download -->
 	<string name="downloader_queued">In der Warteschlange</string>
 	<string name="downloader_near_me_subtitle">In meiner Nähe</string>
+	<!-- In maps downloader and country place page shows how many maps are downloaded / to download, e.g. "Maps: 3 of 10" -->
 	<string name="downloader_status_maps">Karten</string>
 	<string name="downloader_download_all_button">Alle herunterladen</string>
 	<string name="downloader_downloading">Gerade wird heruntergeladen:</string>

--- a/android/res/values-el/strings.xml
+++ b/android/res/values-el/strings.xml
@@ -17,8 +17,6 @@
 	<string name="downloading">Λήψη…</string>
 	<!-- Choose measurement on first launch alert - choose metric system button -->
 	<string name="kilometres">Χιλιόμετρα</string>
-	<!-- View and button titles for accessibility -->
-	<string name="maps">Χάρτες</string>
 	<string name="gb">GB</string>
 	<!-- Choose measurement on first launch alert - choose imperial system button -->
 	<string name="miles">Μίλια</string>
@@ -79,6 +77,8 @@
 	<string name="maps_storage">Αποθήκευση χαρτών στο</string>
 	<!-- Detailed description of Maps Storage settings button -->
 	<string name="maps_storage_summary">Επιλέξτε από που θα γίνει λήψη χαρτών</string>
+	<!-- E.g. "Downloaded maps: 500Mb" in Maps Storage settings -->
+	<string name="maps_storage_downloaded">Χάρτες</string>
 	<!-- Question dialog for transferring maps from one storage to another -->
 	<string name="move_maps">Να γίνει μετακίνηση χαρτών;</string>
 	<!-- Ask to wait user several minutes (some long process in modal dialog). -->
@@ -227,11 +227,12 @@
 	<string name="downloader_update_all_button">Ενημέρωση όλων</string>
 	<!-- Cancel all button text -->
 	<string name="downloader_cancel_all">Ακύρωση όλων</string>
-	<!-- Downloaded maps category -->
+	<!-- Downloaded maps list header -->
 	<string name="downloader_downloaded_subtitle">Έγινε λήψη</string>
 	<!-- Country queued for download -->
 	<string name="downloader_queued">στην ουρά</string>
 	<string name="downloader_near_me_subtitle">Κοντά μου</string>
+	<!-- In maps downloader and country place page shows how many maps are downloaded / to download, e.g. "Maps: 3 of 10" -->
 	<string name="downloader_status_maps">Χάρτες</string>
 	<string name="downloader_download_all_button">Λήψη όλων</string>
 	<string name="downloader_downloading">Λήψη:</string>

--- a/android/res/values-es/strings.xml
+++ b/android/res/values-es/strings.xml
@@ -17,8 +17,6 @@
 	<string name="downloading">Descargando…</string>
 	<!-- Choose measurement on first launch alert - choose metric system button -->
 	<string name="kilometres">Kilómetros</string>
-	<!-- View and button titles for accessibility -->
-	<string name="maps">Mapas</string>
 	<!-- Choose measurement on first launch alert - choose imperial system button -->
 	<string name="miles">Milla</string>
 	<!-- A text for current gps location point/arrow selected on the map -->
@@ -78,6 +76,8 @@
 	<string name="maps_storage">Guardar mapas en</string>
 	<!-- Detailed description of Maps Storage settings button -->
 	<string name="maps_storage_summary">Seleccione el lugar donde deben descargarse los mapas</string>
+	<!-- E.g. "Downloaded maps: 500Mb" in Maps Storage settings -->
+	<string name="maps_storage_downloaded">Mapas</string>
 	<!-- Question dialog for transferring maps from one storage to another -->
 	<string name="move_maps">¿Mover mapas?</string>
 	<!-- Ask to wait user several minutes (some long process in modal dialog). -->
@@ -231,11 +231,12 @@
 	<string name="downloader_update_all_button">Actualizar todos</string>
 	<!-- Cancel all button text -->
 	<string name="downloader_cancel_all">Cancelar todo</string>
-	<!-- Downloaded maps category -->
+	<!-- Downloaded maps list header -->
 	<string name="downloader_downloaded_subtitle">Descargado</string>
 	<!-- Country queued for download -->
 	<string name="downloader_queued">En cola</string>
 	<string name="downloader_near_me_subtitle">Cerca de mí</string>
+	<!-- In maps downloader and country place page shows how many maps are downloaded / to download, e.g. "Maps: 3 of 10" -->
 	<string name="downloader_status_maps">Mapas</string>
 	<string name="downloader_download_all_button">Descargar todos</string>
 	<string name="downloader_downloading">Descargando:</string>

--- a/android/res/values-eu/strings.xml
+++ b/android/res/values-eu/strings.xml
@@ -17,8 +17,6 @@
 	<string name="downloading">Deskargatzen…</string>
 	<!-- Choose measurement on first launch alert - choose metric system button -->
 	<string name="kilometres">Kilometroak</string>
-	<!-- View and button titles for accessibility -->
-	<string name="maps">Mapak</string>
 	<!-- Choose measurement on first launch alert - choose imperial system button -->
 	<string name="miles">Milia</string>
 	<!-- A text for current gps location point/arrow selected on the map -->
@@ -78,6 +76,8 @@
 	<string name="maps_storage">Mapak gordetzeko</string>
 	<!-- Detailed description of Maps Storage settings button -->
 	<string name="maps_storage_summary">Hautatu mapak non deskargatu behar diren</string>
+	<!-- E.g. "Downloaded maps: 500Mb" in Maps Storage settings -->
+	<string name="maps_storage_downloaded">Mapak</string>
 	<!-- Question dialog for transferring maps from one storage to another -->
 	<string name="move_maps">Mapak mugitu?</string>
 	<!-- Ask to wait user several minutes (some long process in modal dialog). -->
@@ -231,11 +231,12 @@
 	<string name="downloader_update_all_button">Eguneratu guztiak</string>
 	<!-- Cancel all button text -->
 	<string name="downloader_cancel_all">Guztiak bertan behera utzi</string>
-	<!-- Downloaded maps category -->
+	<!-- Downloaded maps list header -->
 	<string name="downloader_downloaded_subtitle">Alta</string>
 	<!-- Country queued for download -->
 	<string name="downloader_queued">Ilaran</string>
 	<string name="downloader_near_me_subtitle">Nigandik gertu</string>
+	<!-- In maps downloader and country place page shows how many maps are downloaded / to download, e.g. "Maps: 3 of 10" -->
 	<string name="downloader_status_maps">Mapak</string>
 	<string name="downloader_download_all_button">Deskargatu guztiak</string>
 	<string name="downloader_downloading">Deskargatzen:</string>

--- a/android/res/values-fa/strings.xml
+++ b/android/res/values-fa/strings.xml
@@ -17,8 +17,6 @@
 	<string name="downloading">درحال دانلود</string>
 	<!-- Choose measurement on first launch alert - choose metric system button -->
 	<string name="kilometres">کیلومتر</string>
-	<!-- View and button titles for accessibility -->
-	<string name="maps">نقشه ها</string>
 	<!-- Settings/Downloader - size string, only strings different from English should be translated -->
 	<string name="mb">مگابایت</string>
 	<string name="gb">گیگابایت</string>
@@ -77,6 +75,8 @@
 	<string name="maps_storage">ذخیره نقشه ها در</string>
 	<!-- Detailed description of Maps Storage settings button -->
 	<string name="maps_storage_summary">مسیری را که نقشه ها باید در ان دانلود شود را انتخاب کنید</string>
+	<!-- E.g. "Downloaded maps: 500Mb" in Maps Storage settings -->
+	<string name="maps_storage_downloaded">نقشه ها</string>
 	<!-- Question dialog for transferring maps from one storage to another -->
 	<string name="move_maps">ایا نقشه ها جابه جا شود؟</string>
 	<!-- Ask to wait user several minutes (some long process in modal dialog). -->
@@ -219,11 +219,12 @@
 	<string name="downloader_update_all_button">اپدیت همه</string>
 	<!-- Cancel all button text -->
 	<string name="downloader_cancel_all">لغو همه</string>
-	<!-- Downloaded maps category -->
+	<!-- Downloaded maps list header -->
 	<string name="downloader_downloaded_subtitle">دانلود شده</string>
 	<!-- Country queued for download -->
 	<string name="downloader_queued">صف</string>
 	<string name="downloader_near_me_subtitle">نزدیک من</string>
+	<!-- In maps downloader and country place page shows how many maps are downloaded / to download, e.g. "Maps: 3 of 10" -->
 	<string name="downloader_status_maps">نقشه ها</string>
 	<string name="downloader_download_all_button">دانلود همه</string>
 	<string name="downloader_downloading">درحال دانلود:</string>

--- a/android/res/values-fi/strings.xml
+++ b/android/res/values-fi/strings.xml
@@ -17,8 +17,6 @@
 	<string name="downloading">Ladataan…</string>
 	<!-- Choose measurement on first launch alert - choose metric system button -->
 	<string name="kilometres">Kilometrit</string>
-	<!-- View and button titles for accessibility -->
-	<string name="maps">Kartat</string>
 	<!-- Settings/Downloader - size string, only strings different from English should be translated -->
 	<string name="mb">Mt</string>
 	<!-- Choose measurement on first launch alert - choose imperial system button -->
@@ -80,6 +78,8 @@
 	<string name="maps_storage">Tallenna kartat kohteeseen</string>
 	<!-- Detailed description of Maps Storage settings button -->
 	<string name="maps_storage_summary">Valitse karttojen latauskohde</string>
+	<!-- E.g. "Downloaded maps: 500Mb" in Maps Storage settings -->
+	<string name="maps_storage_downloaded">Kartat</string>
 	<!-- Question dialog for transferring maps from one storage to another -->
 	<string name="move_maps">Siirrä karttoja?</string>
 	<!-- Ask to wait user several minutes (some long process in modal dialog). -->
@@ -232,11 +232,12 @@
 	<string name="downloader_update_all_button">Päivitä kaikki</string>
 	<!-- Cancel all button text -->
 	<string name="downloader_cancel_all">Peruuta kaikki</string>
-	<!-- Downloaded maps category -->
+	<!-- Downloaded maps list header -->
 	<string name="downloader_downloaded_subtitle">Ladatut</string>
 	<!-- Country queued for download -->
 	<string name="downloader_queued">Jonossa</string>
 	<string name="downloader_near_me_subtitle">Lähelläni</string>
+	<!-- In maps downloader and country place page shows how many maps are downloaded / to download, e.g. "Maps: 3 of 10" -->
 	<string name="downloader_status_maps">Kartat</string>
 	<string name="downloader_download_all_button">Lataa kaikki</string>
 	<string name="downloader_downloading">Ladataan:</string>

--- a/android/res/values-fr/strings.xml
+++ b/android/res/values-fr/strings.xml
@@ -17,8 +17,6 @@
 	<string name="downloading">Téléchargement…</string>
 	<!-- Choose measurement on first launch alert - choose metric system button -->
 	<string name="kilometres">kilomètres</string>
-	<!-- View and button titles for accessibility -->
-	<string name="maps">Cartes</string>
 	<!-- Settings/Downloader - size string, only strings different from English should be translated -->
 	<string name="mb">Mo</string>
 	<!-- Choose measurement on first launch alert - choose imperial system button -->
@@ -80,6 +78,8 @@
 	<string name="maps_storage">Enregistrer les cartes dans</string>
 	<!-- Detailed description of Maps Storage settings button -->
 	<string name="maps_storage_summary">Sélectionner l\'emplacement où les cartes devraient être téléchargées</string>
+	<!-- E.g. "Downloaded maps: 500Mb" in Maps Storage settings -->
+	<string name="maps_storage_downloaded">Cartes</string>
 	<!-- Question dialog for transferring maps from one storage to another -->
 	<string name="move_maps">Déplacer les cartes ?</string>
 	<!-- Ask to wait user several minutes (some long process in modal dialog). -->
@@ -233,11 +233,12 @@
 	<string name="downloader_update_all_button">Tout mettre à jour</string>
 	<!-- Cancel all button text -->
 	<string name="downloader_cancel_all">Tout annuler</string>
-	<!-- Downloaded maps category -->
+	<!-- Downloaded maps list header -->
 	<string name="downloader_downloaded_subtitle">Téléchargé</string>
 	<!-- Country queued for download -->
 	<string name="downloader_queued">En file d\'attente</string>
 	<string name="downloader_near_me_subtitle">Près de moi</string>
+	<!-- In maps downloader and country place page shows how many maps are downloaded / to download, e.g. "Maps: 3 of 10" -->
 	<string name="downloader_status_maps">Cartes</string>
 	<string name="downloader_download_all_button">Télécharger tout</string>
 	<string name="downloader_downloading">Téléchargement en cours :</string>

--- a/android/res/values-hu/strings.xml
+++ b/android/res/values-hu/strings.xml
@@ -17,8 +17,6 @@
 	<string name="downloading">Letöltés…</string>
 	<!-- Choose measurement on first launch alert - choose metric system button -->
 	<string name="kilometres">Kilométer</string>
-	<!-- View and button titles for accessibility -->
-	<string name="maps">Térképek</string>
 	<!-- Choose measurement on first launch alert - choose imperial system button -->
 	<string name="miles">Mérföld</string>
 	<!-- A text for current gps location point/arrow selected on the map -->
@@ -78,6 +76,8 @@
 	<string name="maps_storage">Térképek mentése ide:</string>
 	<!-- Detailed description of Maps Storage settings button -->
 	<string name="maps_storage_summary">Válassza ki, hogy hova töltsük le a térképeket</string>
+	<!-- E.g. "Downloaded maps: 500Mb" in Maps Storage settings -->
+	<string name="maps_storage_downloaded">Térképek</string>
 	<!-- Question dialog for transferring maps from one storage to another -->
 	<string name="move_maps">Áthelyezzük a térképeket?</string>
 	<!-- Ask to wait user several minutes (some long process in modal dialog). -->
@@ -226,11 +226,12 @@
 	<string name="downloader_update_all_button">Mindegyik frissítése</string>
 	<!-- Cancel all button text -->
 	<string name="downloader_cancel_all">Mindent visszavon</string>
-	<!-- Downloaded maps category -->
+	<!-- Downloaded maps list header -->
 	<string name="downloader_downloaded_subtitle">Letöltve</string>
 	<!-- Country queued for download -->
 	<string name="downloader_queued">Várólistás</string>
 	<string name="downloader_near_me_subtitle">A közelemben</string>
+	<!-- In maps downloader and country place page shows how many maps are downloaded / to download, e.g. "Maps: 3 of 10" -->
 	<string name="downloader_status_maps">Térképek</string>
 	<string name="downloader_download_all_button">Mindegyik letöltése</string>
 	<string name="downloader_downloading">Letöltés:</string>

--- a/android/res/values-in/strings.xml
+++ b/android/res/values-in/strings.xml
@@ -17,8 +17,6 @@
 	<string name="downloading">Sedang mengunduh…</string>
 	<!-- Choose measurement on first launch alert - choose metric system button -->
 	<string name="kilometres">Kilometer</string>
-	<!-- View and button titles for accessibility -->
-	<string name="maps">Peta</string>
 	<!-- Settings/Downloader - size string, only strings different from English should be translated -->
 	<string name="mb">MB</string>
 	<!-- Choose measurement on first launch alert - choose imperial system button -->
@@ -80,6 +78,8 @@
 	<string name="maps_storage">Simpan peta di</string>
 	<!-- Detailed description of Maps Storage settings button -->
 	<string name="maps_storage_summary">Pilih tempat untuk menyimpan unduhan peta</string>
+	<!-- E.g. "Downloaded maps: 500Mb" in Maps Storage settings -->
+	<string name="maps_storage_downloaded">Peta</string>
 	<!-- Question dialog for transferring maps from one storage to another -->
 	<string name="move_maps">Pindahkan peta?</string>
 	<!-- Ask to wait user several minutes (some long process in modal dialog). -->
@@ -228,11 +228,12 @@
 	<string name="downloader_update_all_button">Perbarui semua</string>
 	<!-- Cancel all button text -->
 	<string name="downloader_cancel_all">Batalkan Semuanya</string>
-	<!-- Downloaded maps category -->
+	<!-- Downloaded maps list header -->
 	<string name="downloader_downloaded_subtitle">Diunduh</string>
 	<!-- Country queued for download -->
 	<string name="downloader_queued">Telah diantrekan</string>
 	<string name="downloader_near_me_subtitle">Dekat saya</string>
+	<!-- In maps downloader and country place page shows how many maps are downloaded / to download, e.g. "Maps: 3 of 10" -->
 	<string name="downloader_status_maps">Peta</string>
 	<string name="downloader_download_all_button">Unduh semua</string>
 	<string name="downloader_downloading">Mengunduh:</string>

--- a/android/res/values-it/strings.xml
+++ b/android/res/values-it/strings.xml
@@ -17,8 +17,6 @@
 	<string name="downloading">Download in corso…</string>
 	<!-- Choose measurement on first launch alert - choose metric system button -->
 	<string name="kilometres">Chilometri</string>
-	<!-- View and button titles for accessibility -->
-	<string name="maps">Mappe</string>
 	<!-- Choose measurement on first launch alert - choose imperial system button -->
 	<string name="miles">Miglia</string>
 	<!-- A text for current gps location point/arrow selected on the map -->
@@ -78,6 +76,8 @@
 	<string name="maps_storage">Salva mappe in</string>
 	<!-- Detailed description of Maps Storage settings button -->
 	<string name="maps_storage_summary">Seleziona il luogo in cui le mappe devono essere scaricate</string>
+	<!-- E.g. "Downloaded maps: 500Mb" in Maps Storage settings -->
+	<string name="maps_storage_downloaded">Mappe</string>
 	<!-- Question dialog for transferring maps from one storage to another -->
 	<string name="move_maps">Vuoi spostare le mappe?</string>
 	<!-- Ask to wait user several minutes (some long process in modal dialog). -->
@@ -231,11 +231,12 @@
 	<string name="downloader_update_all_button">Aggiorna tutte</string>
 	<!-- Cancel all button text -->
 	<string name="downloader_cancel_all">Annulla tutto</string>
-	<!-- Downloaded maps category -->
+	<!-- Downloaded maps list header -->
 	<string name="downloader_downloaded_subtitle">Scaricate</string>
 	<!-- Country queued for download -->
 	<string name="downloader_queued">In coda</string>
 	<string name="downloader_near_me_subtitle">Vicino a me</string>
+	<!-- In maps downloader and country place page shows how many maps are downloaded / to download, e.g. "Maps: 3 of 10" -->
 	<string name="downloader_status_maps">Mappe</string>
 	<string name="downloader_download_all_button">Scarica tutte</string>
 	<string name="downloader_downloading">In scaricamento:</string>

--- a/android/res/values-iw/strings.xml
+++ b/android/res/values-iw/strings.xml
@@ -17,8 +17,6 @@
 	<string name="downloading">מוריד….</string>
 	<!-- Choose measurement on first launch alert - choose metric system button -->
 	<string name="kilometres">ק\"מ</string>
-	<!-- View and button titles for accessibility -->
-	<string name="maps">מפות</string>
 	<!-- Choose measurement on first launch alert - choose imperial system button -->
 	<string name="miles">מ\"ב</string>
 	<!-- A text for current gps location point/arrow selected on the map -->
@@ -72,6 +70,8 @@
 	<string name="settings">הגדרות</string>
 	<!-- Detailed description of Maps Storage settings button -->
 	<string name="maps_storage_summary">בחר הכתובת במחשבך לשמירת המפות שתוריד</string>
+	<!-- E.g. "Downloaded maps: 500Mb" in Maps Storage settings -->
+	<string name="maps_storage_downloaded">מפות</string>
 	<!-- Question dialog for transferring maps from one storage to another -->
 	<string name="move_maps">להעביר המפות?</string>
 	<!-- Ask to wait user several minutes (some long process in modal dialog). -->

--- a/android/res/values-ja/strings.xml
+++ b/android/res/values-ja/strings.xml
@@ -17,8 +17,6 @@
 	<string name="downloading">ダウンロード中…</string>
 	<!-- Choose measurement on first launch alert - choose metric system button -->
 	<string name="kilometres">キロメートル</string>
-	<!-- View and button titles for accessibility -->
-	<string name="maps">マップ</string>
 	<!-- Choose measurement on first launch alert - choose imperial system button -->
 	<string name="miles">マイル</string>
 	<!-- A text for current gps location point/arrow selected on the map -->
@@ -78,6 +76,8 @@
 	<string name="maps_storage">地図の保存先</string>
 	<!-- Detailed description of Maps Storage settings button -->
 	<string name="maps_storage_summary">マップのダウンロード先を選択してください</string>
+	<!-- E.g. "Downloaded maps: 500Mb" in Maps Storage settings -->
+	<string name="maps_storage_downloaded">マップ</string>
 	<!-- Question dialog for transferring maps from one storage to another -->
 	<string name="move_maps">マップを移動させますか？</string>
 	<!-- Ask to wait user several minutes (some long process in modal dialog). -->
@@ -224,11 +224,12 @@
 	<string name="downloader_update_all_button">全てをアップデート</string>
 	<!-- Cancel all button text -->
 	<string name="downloader_cancel_all">すべてキャンセル</string>
-	<!-- Downloaded maps category -->
+	<!-- Downloaded maps list header -->
 	<string name="downloader_downloaded_subtitle">ダウンロード済み</string>
 	<!-- Country queued for download -->
 	<string name="downloader_queued">待ち行列型の</string>
 	<string name="downloader_near_me_subtitle">付近</string>
+	<!-- In maps downloader and country place page shows how many maps are downloaded / to download, e.g. "Maps: 3 of 10" -->
 	<string name="downloader_status_maps">地図</string>
 	<string name="downloader_download_all_button">全てをダウンロード</string>
 	<string name="downloader_downloading">ダウンロード中：</string>

--- a/android/res/values-ko/strings.xml
+++ b/android/res/values-ko/strings.xml
@@ -17,8 +17,6 @@
 	<string name="downloading">다운로드 중…</string>
 	<!-- Choose measurement on first launch alert - choose metric system button -->
 	<string name="kilometres">킬로미터</string>
-	<!-- View and button titles for accessibility -->
-	<string name="maps">지도</string>
 	<!-- Choose measurement on first launch alert - choose imperial system button -->
 	<string name="miles">마일</string>
 	<!-- A text for current gps location point/arrow selected on the map -->
@@ -78,6 +76,8 @@
 	<string name="maps_storage">지도 저장 위치:</string>
 	<!-- Detailed description of Maps Storage settings button -->
 	<string name="maps_storage_summary">지도가 다운로드될 곳을 선택합니다</string>
+	<!-- E.g. "Downloaded maps: 500Mb" in Maps Storage settings -->
+	<string name="maps_storage_downloaded">지도</string>
 	<!-- Question dialog for transferring maps from one storage to another -->
 	<string name="move_maps">지도를 이동합니까?</string>
 	<!-- Ask to wait user several minutes (some long process in modal dialog). -->
@@ -226,11 +226,12 @@
 	<string name="downloader_update_all_button">모두 업데이트</string>
 	<!-- Cancel all button text -->
 	<string name="downloader_cancel_all">모두 취소</string>
-	<!-- Downloaded maps category -->
+	<!-- Downloaded maps list header -->
 	<string name="downloader_downloaded_subtitle">다운로드</string>
 	<!-- Country queued for download -->
 	<string name="downloader_queued">대기</string>
 	<string name="downloader_near_me_subtitle">내 근처</string>
+	<!-- In maps downloader and country place page shows how many maps are downloaded / to download, e.g. "Maps: 3 of 10" -->
 	<string name="downloader_status_maps">지도</string>
 	<string name="downloader_download_all_button">모두 다운로드</string>
 	<string name="downloader_downloading">다운로드 중:</string>

--- a/android/res/values-nb/strings.xml
+++ b/android/res/values-nb/strings.xml
@@ -17,8 +17,6 @@
 	<string name="downloading">Laster ned …</string>
 	<!-- Choose measurement on first launch alert - choose metric system button -->
 	<string name="kilometres">Kilometer</string>
-	<!-- View and button titles for accessibility -->
-	<string name="maps">Kart</string>
 	<!-- Settings/Downloader - size string, only strings different from English should be translated -->
 	<string name="mb">MB</string>
 	<!-- Choose measurement on first launch alert - choose imperial system button -->
@@ -80,6 +78,8 @@
 	<string name="maps_storage">Lagre kart på</string>
 	<!-- Detailed description of Maps Storage settings button -->
 	<string name="maps_storage_summary">Velg hvor du vil at kartene skal lastes ned til</string>
+	<!-- E.g. "Downloaded maps: 500Mb" in Maps Storage settings -->
+	<string name="maps_storage_downloaded">Kart</string>
 	<!-- Question dialog for transferring maps from one storage to another -->
 	<string name="move_maps">Flytt kart?</string>
 	<!-- Ask to wait user several minutes (some long process in modal dialog). -->
@@ -228,11 +228,12 @@
 	<string name="downloader_update_all_button">Oppdater alle</string>
 	<!-- Cancel all button text -->
 	<string name="downloader_cancel_all">Avbryt alle</string>
-	<!-- Downloaded maps category -->
+	<!-- Downloaded maps list header -->
 	<string name="downloader_downloaded_subtitle">Lastet ned</string>
 	<!-- Country queued for download -->
 	<string name="downloader_queued">Lagt i kø</string>
 	<string name="downloader_near_me_subtitle">I nærheten</string>
+	<!-- In maps downloader and country place page shows how many maps are downloaded / to download, e.g. "Maps: 3 of 10" -->
 	<string name="downloader_status_maps">Kart</string>
 	<string name="downloader_download_all_button">Last ned alle</string>
 	<string name="downloader_downloading">Laster ned:</string>

--- a/android/res/values-nl/strings.xml
+++ b/android/res/values-nl/strings.xml
@@ -17,8 +17,6 @@
 	<string name="downloading">Downloaden…</string>
 	<!-- Choose measurement on first launch alert - choose metric system button -->
 	<string name="kilometres">Kilometers</string>
-	<!-- View and button titles for accessibility -->
-	<string name="maps">Kaarten</string>
 	<!-- Choose measurement on first launch alert - choose imperial system button -->
 	<string name="miles">Mijlen</string>
 	<!-- A text for current gps location point/arrow selected on the map -->
@@ -75,6 +73,8 @@
 	<string name="maps_storage">Kaarten opslaan in</string>
 	<!-- Detailed description of Maps Storage settings button -->
 	<string name="maps_storage_summary">Selecteer de plaats waar kaarten naar gedownload zouden moeten worden</string>
+	<!-- E.g. "Downloaded maps: 500Mb" in Maps Storage settings -->
+	<string name="maps_storage_downloaded">Kaarten</string>
 	<!-- Question dialog for transferring maps from one storage to another -->
 	<string name="move_maps">Kaarten verplaatsen?</string>
 	<!-- Ask to wait user several minutes (some long process in modal dialog). -->
@@ -228,11 +228,12 @@
 	<string name="downloader_update_all_button">Update alles</string>
 	<!-- Cancel all button text -->
 	<string name="downloader_cancel_all">Alles annuleren</string>
-	<!-- Downloaded maps category -->
+	<!-- Downloaded maps list header -->
 	<string name="downloader_downloaded_subtitle">Gedownload</string>
 	<!-- Country queued for download -->
 	<string name="downloader_queued">In de wachtrij</string>
 	<string name="downloader_near_me_subtitle">Bij mij in de buurt</string>
+	<!-- In maps downloader and country place page shows how many maps are downloaded / to download, e.g. "Maps: 3 of 10" -->
 	<string name="downloader_status_maps">Kaarten</string>
 	<string name="downloader_download_all_button">Alles downloaden</string>
 	<string name="downloader_downloading">Aan het downloaden:</string>
@@ -518,11 +519,13 @@
 	<string name="setting_emulate_bad_storage">Slechte opslag emuleren</string>
 	<string name="core_entrance">Ingang</string>
 	<string name="error_enter_correct_name">Voer een juiste naam in</string>
-	<string name="bookmark_lists">lijsten</string>
+	<string name="bookmark_lists">Lijsten</string>
 	<!-- Do not display all bookmark lists on the map -->
 	<string name="bookmark_lists_hide_all">Alles verbergen</string>
 	<string name="bookmark_lists_show_all">Alles weergeven</string>
 	<string name="bookmarks_create_new_group">Nieuwe lijst maken</string>
+	<!-- Bookmark categories screen -->
+	<string name="bookmarks_import">Bladwijzers importeren</string>
 	<string name="bookmarks_error_message_share_general">Delen is onmogelijk wegens een toepassingsfout</string>
 	<string name="bookmarks_error_title_share_empty">Deelfout</string>
 	<string name="bookmarks_error_message_share_empty">Een lege lijst kan niet gedeeld worden</string>
@@ -556,7 +559,7 @@
 	<string name="terms_of_use">Gebruiksvoorwaarden</string>
 	<string name="button_layer_traffic">Verkeer</string>
 	<string name="button_layer_subway">Metro</string>
-	<string name="layers_title">Map layers</string>
+	<string name="layers_title">Kaartweergave</string>
 	<string name="subway_data_unavailable">Metrokaart is niet beschikbaar</string>
 	<string name="bookmarks_empty_list_title">Deze lijst is leeg</string>
 	<string name="bookmarks_empty_list_message">Om een bladwijzer toe te voegen, tikt u op een plaats op de kaart en vervolgens op het sterpictogram</string>
@@ -582,12 +585,12 @@
 	<string name="power_managment_setting_manual_max">Maximale energiebesparing</string>
 	<string name="enable_logging_warning_message">Deze optie is ingeschakeld voor logboekregistraties voor diagnostische doeleinden. Het helpt bij het identificeren van problemen met de applicatie. Schakel de optie alleen in op verzoek van Organic Maps-ondersteuning.</string>
 	<string name="access_rules_author_only">Wordt online bewerkt</string>
-	<string name="driving_options_title">Omweginstellingen</string>
+	<string name="driving_options_title">Route instellingen</string>
 	<string name="driving_options_subheader">Vermijden op elke route</string>
 	<string name="avoid_tolls">Tolwegen</string>
-	<string name="avoid_unpaved">Aardewegen</string>
-	<string name="avoid_ferry">Ferries</string>
-	<string name="avoid_motorways">Hoofdverkeerswegen</string>
+	<string name="avoid_unpaved">Onverharde wegen</string>
+	<string name="avoid_ferry">Veerdiensten</string>
+	<string name="avoid_motorways">Autosnelwegen</string>
 	<string name="unable_to_calc_alert_title">Kan route niet opbouwen</string>
 	<string name="unable_to_calc_alert_subtitle">Helaas konden we geen route opbouwen met de gekozen opties. Wijzig de instellingen en probeer het opnieuw</string>
 	<string name="define_to_avoid_btn">Omwegen configureren</string>
@@ -661,6 +664,10 @@
 	<string name="enable_screen_sleep">Laat het scherm slapen</string>
 	<!-- Description in preferences -->
 	<string name="enable_screen_sleep_description">Indien ingeschakeld, mag het scherm slapen na een periode van inactiviteit.</string>
+	<!-- A preference title; keep short! -->
+	<string name="enable_show_on_lock_screen">Toon op vergrendelscherm</string>
+	<!-- Description in preferences -->
+	<string name="enable_show_on_lock_screen_description">Indien ingeschakeld, hoeft het scherm niet te worden ontgrendeld wanneer de app actief is.</string>
 
 	<!-- SECTION: Types -->
 	<string name="type.aerialway.station">Kabelwagenstation</string>

--- a/android/res/values-pl/strings.xml
+++ b/android/res/values-pl/strings.xml
@@ -17,8 +17,6 @@
 	<string name="downloading">Pobieranie…</string>
 	<!-- Choose measurement on first launch alert - choose metric system button -->
 	<string name="kilometres">Kilometry</string>
-	<!-- View and button titles for accessibility -->
-	<string name="maps">Mapy</string>
 	<!-- Choose measurement on first launch alert - choose imperial system button -->
 	<string name="miles">Mile</string>
 	<!-- A text for current gps location point/arrow selected on the map -->
@@ -78,6 +76,8 @@
 	<string name="maps_storage">Zapisz mapy do</string>
 	<!-- Detailed description of Maps Storage settings button -->
 	<string name="maps_storage_summary">Określa położenie przechowywania pobranych map</string>
+	<!-- E.g. "Downloaded maps: 500Mb" in Maps Storage settings -->
+	<string name="maps_storage_downloaded">Mapy</string>
 	<!-- Question dialog for transferring maps from one storage to another -->
 	<string name="move_maps">Przenieść mapy?</string>
 	<!-- Ask to wait user several minutes (some long process in modal dialog). -->
@@ -231,11 +231,12 @@
 	<string name="downloader_update_all_button">Aktualizuj wszystkie</string>
 	<!-- Cancel all button text -->
 	<string name="downloader_cancel_all">Anuluj wszystko</string>
-	<!-- Downloaded maps category -->
+	<!-- Downloaded maps list header -->
 	<string name="downloader_downloaded_subtitle">Pobrane</string>
 	<!-- Country queued for download -->
 	<string name="downloader_queued">W kolejce</string>
 	<string name="downloader_near_me_subtitle">Blisko mnie</string>
+	<!-- In maps downloader and country place page shows how many maps are downloaded / to download, e.g. "Maps: 3 of 10" -->
 	<string name="downloader_status_maps">Mapy</string>
 	<string name="downloader_download_all_button">Pobierz wszystkie</string>
 	<string name="downloader_downloading">Pobieranie:</string>

--- a/android/res/values-pt-rBR/strings.xml
+++ b/android/res/values-pt-rBR/strings.xml
@@ -17,8 +17,6 @@
 	<string name="downloading">Baixando…</string>
 	<!-- Choose measurement on first launch alert - choose metric system button -->
 	<string name="kilometres">Quilômetros</string>
-	<!-- View and button titles for accessibility -->
-	<string name="maps">Mapas</string>
 	<!-- Choose measurement on first launch alert - choose imperial system button -->
 	<string name="miles">Milhas</string>
 	<!-- A text for current gps location point/arrow selected on the map -->
@@ -78,6 +76,8 @@
 	<string name="maps_storage">Salvar mapas para</string>
 	<!-- Detailed description of Maps Storage settings button -->
 	<string name="maps_storage_summary">Selecione o local para onde os mapas devem ser baixados</string>
+	<!-- E.g. "Downloaded maps: 500Mb" in Maps Storage settings -->
+	<string name="maps_storage_downloaded">Mapas</string>
 	<!-- Question dialog for transferring maps from one storage to another -->
 	<string name="move_maps">Mover mapas?</string>
 	<!-- Ask to wait user several minutes (some long process in modal dialog). -->
@@ -227,11 +227,12 @@
 	<string name="downloader_update_all_button">Atualizar tudo</string>
 	<!-- Cancel all button text -->
 	<string name="downloader_cancel_all">Cancelar tudo</string>
-	<!-- Downloaded maps category -->
+	<!-- Downloaded maps list header -->
 	<string name="downloader_downloaded_subtitle">Baixado</string>
 	<!-- Country queued for download -->
 	<string name="downloader_queued">Na fila</string>
 	<string name="downloader_near_me_subtitle">Perto de mim</string>
+	<!-- In maps downloader and country place page shows how many maps are downloaded / to download, e.g. "Maps: 3 of 10" -->
 	<string name="downloader_status_maps">Mapas</string>
 	<string name="downloader_download_all_button">Baixar tudo</string>
 	<string name="downloader_downloading">Baixando:</string>

--- a/android/res/values-pt/strings.xml
+++ b/android/res/values-pt/strings.xml
@@ -17,8 +17,6 @@
 	<string name="downloading">A descarregar…</string>
 	<!-- Choose measurement on first launch alert - choose metric system button -->
 	<string name="kilometres">Quilómetros</string>
-	<!-- View and button titles for accessibility -->
-	<string name="maps">Mapas</string>
 	<!-- Choose measurement on first launch alert - choose imperial system button -->
 	<string name="miles">Milhas</string>
 	<!-- A text for current gps location point/arrow selected on the map -->
@@ -78,6 +76,8 @@
 	<string name="maps_storage">Guardar mapas em</string>
 	<!-- Detailed description of Maps Storage settings button -->
 	<string name="maps_storage_summary">Selecione o local onde os mapas devem ser descarregados</string>
+	<!-- E.g. "Downloaded maps: 500Mb" in Maps Storage settings -->
+	<string name="maps_storage_downloaded">Mapas</string>
 	<!-- Question dialog for transferring maps from one storage to another -->
 	<string name="move_maps">Mover mapas?</string>
 	<!-- Ask to wait user several minutes (some long process in modal dialog). -->
@@ -231,11 +231,12 @@
 	<string name="downloader_update_all_button">Atualizar tudo</string>
 	<!-- Cancel all button text -->
 	<string name="downloader_cancel_all">Cancelar tudo</string>
-	<!-- Downloaded maps category -->
+	<!-- Downloaded maps list header -->
 	<string name="downloader_downloaded_subtitle">Descarregado</string>
 	<!-- Country queued for download -->
 	<string name="downloader_queued">Na fila</string>
 	<string name="downloader_near_me_subtitle">Perto de mim</string>
+	<!-- In maps downloader and country place page shows how many maps are downloaded / to download, e.g. "Maps: 3 of 10" -->
 	<string name="downloader_status_maps">Mapas</string>
 	<string name="downloader_download_all_button">Descarregar tudo</string>
 	<string name="downloader_downloading">A descarregar:</string>

--- a/android/res/values-ro/strings.xml
+++ b/android/res/values-ro/strings.xml
@@ -17,8 +17,6 @@
 	<string name="downloading">Se descarcă…</string>
 	<!-- Choose measurement on first launch alert - choose metric system button -->
 	<string name="kilometres">Kilometri</string>
-	<!-- View and button titles for accessibility -->
-	<string name="maps">Hărţi</string>
 	<!-- Choose measurement on first launch alert - choose imperial system button -->
 	<string name="miles">Mile</string>
 	<!-- A text for current gps location point/arrow selected on the map -->
@@ -78,6 +76,8 @@
 	<string name="maps_storage">Salvează hărțile în</string>
 	<!-- Detailed description of Maps Storage settings button -->
 	<string name="maps_storage_summary">Alege locul în care vrei să fie descărcate hărțile</string>
+	<!-- E.g. "Downloaded maps: 500Mb" in Maps Storage settings -->
+	<string name="maps_storage_downloaded">Hărţi</string>
 	<!-- Question dialog for transferring maps from one storage to another -->
 	<string name="move_maps">Muți hărțile?</string>
 	<!-- Ask to wait user several minutes (some long process in modal dialog). -->
@@ -233,11 +233,12 @@
 	<string name="downloader_update_all_button">Actualizează tot</string>
 	<!-- Cancel all button text -->
 	<string name="downloader_cancel_all">Anulează tot</string>
-	<!-- Downloaded maps category -->
+	<!-- Downloaded maps list header -->
 	<string name="downloader_downloaded_subtitle">Descărcate</string>
 	<!-- Country queued for download -->
 	<string name="downloader_queued">În așteptare</string>
 	<string name="downloader_near_me_subtitle">Lângă mine</string>
+	<!-- In maps downloader and country place page shows how many maps are downloaded / to download, e.g. "Maps: 3 of 10" -->
 	<string name="downloader_status_maps">Hărți</string>
 	<string name="downloader_download_all_button">Descarcă tot</string>
 	<string name="downloader_downloading">Se descarcă:</string>

--- a/android/res/values-ru/strings.xml
+++ b/android/res/values-ru/strings.xml
@@ -17,8 +17,6 @@
 	<string name="downloading">Загружается…</string>
 	<!-- Choose measurement on first launch alert - choose metric system button -->
 	<string name="kilometres">Километры</string>
-	<!-- View and button titles for accessibility -->
-	<string name="maps">Карты</string>
 	<!-- Settings/Downloader - size string, only strings different from English should be translated -->
 	<string name="mb">МБ</string>
 	<string name="gb">ГБ</string>
@@ -81,8 +79,22 @@
 	<string name="maps_storage">Сохранять карты в</string>
 	<!-- Detailed description of Maps Storage settings button -->
 	<string name="maps_storage_summary">Выберите место, где будут храниться загруженные карты</string>
+	<!-- E.g. "Downloaded maps: 500Mb" in Maps Storage settings -->
+	<string name="maps_storage_downloaded">Загруженные карты</string>
+	<!-- Internal storage type in Maps Storage settings (not accessible by the user) -->
+	<string name="maps_storage_internal">Внутренний скрытый накопитель</string>
+	<!-- Shared storage type in Maps Storage settings (a primary storage usually) -->
+	<string name="maps_storage_shared">Внутренний общий накопитель</string>
+	<!-- Removable external storage type in Maps Storage settings, e.g. an SD card -->
+	<string name="maps_storage_removable">SD-карта</string>
+	<!-- Generic external storage type in Maps Storage settings -->
+	<string name="maps_storage_external">Внешний общий накопитель</string>
+	<!-- Free space out of total storage size in Maps Storage settings, e.g. "300 MB free (of 2 GB)" -->
+	<string name="maps_storage_free_size">%1$s свободно (из %2$s)</string>
 	<!-- Question dialog for transferring maps from one storage to another -->
 	<string name="move_maps">Переместить карты?</string>
+	<!-- Error moving map files from one storage to another -->
+	<string name="move_maps_error">Ошибка перемещения файлов карт</string>
 	<!-- Ask to wait user several minutes (some long process in modal dialog). -->
 	<string name="wait_several_minutes">Это может занять несколько минут.\nПожалуйста, подождите…</string>
 	<!-- Measurement units title in settings activity -->
@@ -236,11 +248,12 @@
 	<string name="downloader_update_all_button">Обновить все</string>
 	<!-- Cancel all button text -->
 	<string name="downloader_cancel_all">Отменить все</string>
-	<!-- Downloaded maps category -->
+	<!-- Downloaded maps list header -->
 	<string name="downloader_downloaded_subtitle">Загруженные</string>
 	<!-- Country queued for download -->
 	<string name="downloader_queued">В очереди</string>
 	<string name="downloader_near_me_subtitle">Возле меня</string>
+	<!-- In maps downloader and country place page shows how many maps are downloaded / to download, e.g. "Maps: 3 of 10" -->
 	<string name="downloader_status_maps">Карт</string>
 	<string name="downloader_download_all_button">Загрузить все</string>
 	<string name="downloader_downloading">Загружается:</string>

--- a/android/res/values-sk/strings.xml
+++ b/android/res/values-sk/strings.xml
@@ -17,8 +17,6 @@
 	<string name="downloading">Sťahovanie…</string>
 	<!-- Choose measurement on first launch alert - choose metric system button -->
 	<string name="kilometres">Kilometre</string>
-	<!-- View and button titles for accessibility -->
-	<string name="maps">Mapy</string>
 	<!-- Choose measurement on first launch alert - choose imperial system button -->
 	<string name="miles">Míle</string>
 	<!-- A text for current gps location point/arrow selected on the map -->
@@ -78,6 +76,8 @@
 	<string name="maps_storage">Uložiť mapy do</string>
 	<!-- Detailed description of Maps Storage settings button -->
 	<string name="maps_storage_summary">Vyberte miesto, kam by mali byť mapy sťahované</string>
+	<!-- E.g. "Downloaded maps: 500Mb" in Maps Storage settings -->
+	<string name="maps_storage_downloaded">Mapy</string>
 	<!-- Question dialog for transferring maps from one storage to another -->
 	<string name="move_maps">Presunúť mapy?</string>
 	<!-- Ask to wait user several minutes (some long process in modal dialog). -->
@@ -226,11 +226,12 @@
 	<string name="downloader_update_all_button">Aktualizovať všetko</string>
 	<!-- Cancel all button text -->
 	<string name="downloader_cancel_all">Zrušiť všetko</string>
-	<!-- Downloaded maps category -->
+	<!-- Downloaded maps list header -->
 	<string name="downloader_downloaded_subtitle">Stiahnuté</string>
 	<!-- Country queued for download -->
 	<string name="downloader_queued">V rade</string>
 	<string name="downloader_near_me_subtitle">Neďaleko mňa</string>
+	<!-- In maps downloader and country place page shows how many maps are downloaded / to download, e.g. "Maps: 3 of 10" -->
 	<string name="downloader_status_maps">Mapy</string>
 	<string name="downloader_download_all_button">Stiahnuť všetko</string>
 	<string name="downloader_downloading">Sťahovanie:</string>

--- a/android/res/values-sv/strings.xml
+++ b/android/res/values-sv/strings.xml
@@ -17,8 +17,6 @@
 	<string name="downloading">Laddar ner…</string>
 	<!-- Choose measurement on first launch alert - choose metric system button -->
 	<string name="kilometres">Kilometer</string>
-	<!-- View and button titles for accessibility -->
-	<string name="maps">Kartor</string>
 	<!-- Choose measurement on first launch alert - choose imperial system button -->
 	<string name="miles">Mil</string>
 	<!-- A text for current gps location point/arrow selected on the map -->
@@ -78,6 +76,8 @@
 	<string name="maps_storage">Spara kartor i</string>
 	<!-- Detailed description of Maps Storage settings button -->
 	<string name="maps_storage_summary">Välj en plats dit kartor ska laddas ner</string>
+	<!-- E.g. "Downloaded maps: 500Mb" in Maps Storage settings -->
+	<string name="maps_storage_downloaded">Kartor</string>
 	<!-- Question dialog for transferring maps from one storage to another -->
 	<string name="move_maps">Flytta kartor?</string>
 	<!-- Ask to wait user several minutes (some long process in modal dialog). -->
@@ -224,11 +224,12 @@
 	<string name="downloader_update_all_button">Uppdatera alla</string>
 	<!-- Cancel all button text -->
 	<string name="downloader_cancel_all">Avbryt alla</string>
-	<!-- Downloaded maps category -->
+	<!-- Downloaded maps list header -->
 	<string name="downloader_downloaded_subtitle">Nedladdade</string>
 	<!-- Country queued for download -->
 	<string name="downloader_queued">Köade</string>
 	<string name="downloader_near_me_subtitle">Nära mig</string>
+	<!-- In maps downloader and country place page shows how many maps are downloaded / to download, e.g. "Maps: 3 of 10" -->
 	<string name="downloader_status_maps">Kartor</string>
 	<string name="downloader_download_all_button">Ladda ned alla</string>
 	<string name="downloader_downloading">Ladda ner:</string>

--- a/android/res/values-th/strings.xml
+++ b/android/res/values-th/strings.xml
@@ -17,8 +17,6 @@
 	<string name="downloading">กำลังดาวน์โหลด…</string>
 	<!-- Choose measurement on first launch alert - choose metric system button -->
 	<string name="kilometres">กิโลเมตร</string>
-	<!-- View and button titles for accessibility -->
-	<string name="maps">แผนที่</string>
 	<!-- Settings/Downloader - size string, only strings different from English should be translated -->
 	<string name="mb">MB</string>
 	<!-- Choose measurement on first launch alert - choose imperial system button -->
@@ -80,6 +78,8 @@
 	<string name="maps_storage">บันทึกแผนที่ไปยัง</string>
 	<!-- Detailed description of Maps Storage settings button -->
 	<string name="maps_storage_summary">เลือกสถานที่ที่ต้องการดาวน์โหลดใช้แผนที่</string>
+	<!-- E.g. "Downloaded maps: 500Mb" in Maps Storage settings -->
+	<string name="maps_storage_downloaded">แผนที่</string>
 	<!-- Question dialog for transferring maps from one storage to another -->
 	<string name="move_maps">ลบแผนที่?</string>
 	<!-- Ask to wait user several minutes (some long process in modal dialog). -->
@@ -228,11 +228,12 @@
 	<string name="downloader_update_all_button">อัปเดตทั้งหมด</string>
 	<!-- Cancel all button text -->
 	<string name="downloader_cancel_all">ยกเลิกทั้งหมด</string>
-	<!-- Downloaded maps category -->
+	<!-- Downloaded maps list header -->
 	<string name="downloader_downloaded_subtitle">ดาวน์โหลดแล้ว</string>
 	<!-- Country queued for download -->
 	<string name="downloader_queued">ต่อแถว</string>
 	<string name="downloader_near_me_subtitle">ใกล้ฉัน</string>
+	<!-- In maps downloader and country place page shows how many maps are downloaded / to download, e.g. "Maps: 3 of 10" -->
 	<string name="downloader_status_maps">แผนที่</string>
 	<string name="downloader_download_all_button">ดาวน์โหลดทั้งหมด</string>
 	<string name="downloader_downloading">กำลังดาวน์โหลด:</string>

--- a/android/res/values-tr/strings.xml
+++ b/android/res/values-tr/strings.xml
@@ -17,8 +17,6 @@
 	<string name="downloading">İndiriliyor…</string>
 	<!-- Choose measurement on first launch alert - choose metric system button -->
 	<string name="kilometres">Kilometre</string>
-	<!-- View and button titles for accessibility -->
-	<string name="maps">Haritalar</string>
 	<!-- Settings/Downloader - size string, only strings different from English should be translated -->
 	<string name="mb">MB</string>
 	<!-- Choose measurement on first launch alert - choose imperial system button -->
@@ -80,6 +78,8 @@
 	<string name="maps_storage">Haritaları şuraya kaydet:</string>
 	<!-- Detailed description of Maps Storage settings button -->
 	<string name="maps_storage_summary">Haritaların indirileceği yeri seçin</string>
+	<!-- E.g. "Downloaded maps: 500Mb" in Maps Storage settings -->
+	<string name="maps_storage_downloaded">Haritalar</string>
 	<!-- Question dialog for transferring maps from one storage to another -->
 	<string name="move_maps">Haritalar taşınsın mı?</string>
 	<!-- Ask to wait user several minutes (some long process in modal dialog). -->
@@ -235,11 +235,12 @@
 	<string name="downloader_update_all_button">Tümünü güncelle</string>
 	<!-- Cancel all button text -->
 	<string name="downloader_cancel_all">Tümünü İptal Et</string>
-	<!-- Downloaded maps category -->
+	<!-- Downloaded maps list header -->
 	<string name="downloader_downloaded_subtitle">İndirilenler</string>
 	<!-- Country queued for download -->
 	<string name="downloader_queued">Sıraya alındı</string>
 	<string name="downloader_near_me_subtitle">Yakınlarımda</string>
+	<!-- In maps downloader and country place page shows how many maps are downloaded / to download, e.g. "Maps: 3 of 10" -->
 	<string name="downloader_status_maps">Haritalar</string>
 	<string name="downloader_download_all_button">Hepsini İndir</string>
 	<string name="downloader_downloading">İndiriliyor:</string>

--- a/android/res/values-uk/strings.xml
+++ b/android/res/values-uk/strings.xml
@@ -17,8 +17,6 @@
 	<string name="downloading">Завантажується…</string>
 	<!-- Choose measurement on first launch alert - choose metric system button -->
 	<string name="kilometres">Кілометри</string>
-	<!-- View and button titles for accessibility -->
-	<string name="maps">Мапи</string>
 	<!-- Settings/Downloader - size string, only strings different from English should be translated -->
 	<string name="mb">МБ</string>
 	<string name="gb">ГБ</string>
@@ -81,6 +79,16 @@
 	<string name="maps_storage">Зберігати мапи до</string>
 	<!-- Detailed description of Maps Storage settings button -->
 	<string name="maps_storage_summary">Виберіть місце, куди повинні бути завантажені мапи</string>
+	<!-- E.g. "Downloaded maps: 500Mb" in Maps Storage settings -->
+	<string name="maps_storage_downloaded">Завантаженнi мапи</string>
+	<!-- Internal storage type in Maps Storage settings (not accessible by the user) -->
+	<string name="maps_storage_internal">Внутрішнє зховане сховище</string>
+	<!-- Shared storage type in Maps Storage settings (a primary storage usually) -->
+	<string name="maps_storage_shared">Внутрішнє спільне сховище</string>
+	<!-- Removable external storage type in Maps Storage settings, e.g. an SD card -->
+	<string name="maps_storage_removable">SD-карта</string>
+	<!-- Generic external storage type in Maps Storage settings -->
+	<string name="maps_storage_external">Зовнiшне спільне сховище</string>
 	<!-- Question dialog for transferring maps from one storage to another -->
 	<string name="move_maps">Перемістити мапи?</string>
 	<!-- Ask to wait user several minutes (some long process in modal dialog). -->
@@ -231,11 +239,12 @@
 	<string name="downloader_update_all_button">Оновити всі</string>
 	<!-- Cancel all button text -->
 	<string name="downloader_cancel_all">Скасувати всі</string>
-	<!-- Downloaded maps category -->
+	<!-- Downloaded maps list header -->
 	<string name="downloader_downloaded_subtitle">Завантажено</string>
 	<!-- Country queued for download -->
 	<string name="downloader_queued">В черзі</string>
 	<string name="downloader_near_me_subtitle">Поблизу</string>
+	<!-- In maps downloader and country place page shows how many maps are downloaded / to download, e.g. "Maps: 3 of 10" -->
 	<string name="downloader_status_maps">Мапи</string>
 	<string name="downloader_download_all_button">Завантажити всі</string>
 	<string name="downloader_downloading">Завантажується:</string>

--- a/android/res/values-vi/strings.xml
+++ b/android/res/values-vi/strings.xml
@@ -17,8 +17,6 @@
 	<string name="downloading">Đang tải xuống…</string>
 	<!-- Choose measurement on first launch alert - choose metric system button -->
 	<string name="kilometres">Kilômét</string>
-	<!-- View and button titles for accessibility -->
-	<string name="maps">Bản đồ</string>
 	<!-- Choose measurement on first launch alert - choose imperial system button -->
 	<string name="miles">Dặm</string>
 	<!-- A text for current gps location point/arrow selected on the map -->
@@ -78,6 +76,8 @@
 	<string name="maps_storage">Lưu bản đồ vào</string>
 	<!-- Detailed description of Maps Storage settings button -->
 	<string name="maps_storage_summary">Chọn vị trí nơi bản đồ sẽ được tải về</string>
+	<!-- E.g. "Downloaded maps: 500Mb" in Maps Storage settings -->
+	<string name="maps_storage_downloaded">Bản đồ</string>
 	<!-- Question dialog for transferring maps from one storage to another -->
 	<string name="move_maps">Di chuyển bản đồ?</string>
 	<!-- Ask to wait user several minutes (some long process in modal dialog). -->
@@ -226,11 +226,12 @@
 	<string name="downloader_update_all_button">Cập nhật tất cả</string>
 	<!-- Cancel all button text -->
 	<string name="downloader_cancel_all">Hủy tất cả</string>
-	<!-- Downloaded maps category -->
+	<!-- Downloaded maps list header -->
 	<string name="downloader_downloaded_subtitle">Đã tải xuống</string>
 	<!-- Country queued for download -->
 	<string name="downloader_queued">Đã xếp hàng chờ</string>
 	<string name="downloader_near_me_subtitle">Gần tôi</string>
+	<!-- In maps downloader and country place page shows how many maps are downloaded / to download, e.g. "Maps: 3 of 10" -->
 	<string name="downloader_status_maps">Bản đồ</string>
 	<string name="downloader_download_all_button">Tải xuống tất cả</string>
 	<string name="downloader_downloading">Đang tải về:</string>

--- a/android/res/values-zh-rTW/strings.xml
+++ b/android/res/values-zh-rTW/strings.xml
@@ -17,8 +17,6 @@
 	<string name="downloading">下載中…</string>
 	<!-- Choose measurement on first launch alert - choose metric system button -->
 	<string name="kilometres">公里</string>
-	<!-- View and button titles for accessibility -->
-	<string name="maps">地圖</string>
 	<!-- Choose measurement on first launch alert - choose imperial system button -->
 	<string name="miles">英哩</string>
 	<!-- A text for current gps location point/arrow selected on the map -->
@@ -78,6 +76,8 @@
 	<string name="maps_storage">將地圖儲存至</string>
 	<!-- Detailed description of Maps Storage settings button -->
 	<string name="maps_storage_summary">請選擇下載地圖後要放的位置</string>
+	<!-- E.g. "Downloaded maps: 500Mb" in Maps Storage settings -->
+	<string name="maps_storage_downloaded">地圖</string>
 	<!-- Question dialog for transferring maps from one storage to another -->
 	<string name="move_maps">移動地圖？</string>
 	<!-- Ask to wait user several minutes (some long process in modal dialog). -->
@@ -237,11 +237,12 @@
 	<string name="downloader_update_all_button">更新全部</string>
 	<!-- Cancel all button text -->
 	<string name="downloader_cancel_all">全部取消</string>
-	<!-- Downloaded maps category -->
+	<!-- Downloaded maps list header -->
 	<string name="downloader_downloaded_subtitle">已下載</string>
 	<!-- Country queued for download -->
 	<string name="downloader_queued">已佇列</string>
 	<string name="downloader_near_me_subtitle">在我附近</string>
+	<!-- In maps downloader and country place page shows how many maps are downloaded / to download, e.g. "Maps: 3 of 10" -->
 	<string name="downloader_status_maps">地圖</string>
 	<string name="downloader_download_all_button">下載全部</string>
 	<string name="downloader_downloading">正在下載：</string>

--- a/android/res/values-zh/strings.xml
+++ b/android/res/values-zh/strings.xml
@@ -17,8 +17,6 @@
 	<string name="downloading">下载…</string>
 	<!-- Choose measurement on first launch alert - choose metric system button -->
 	<string name="kilometres">千米</string>
-	<!-- View and button titles for accessibility -->
-	<string name="maps">地图</string>
 	<!-- Choose measurement on first launch alert - choose imperial system button -->
 	<string name="miles">英里</string>
 	<!-- A text for current gps location point/arrow selected on the map -->
@@ -78,6 +76,8 @@
 	<string name="maps_storage">将地图保存到</string>
 	<!-- Detailed description of Maps Storage settings button -->
 	<string name="maps_storage_summary">选取地图应该下载的位置</string>
+	<!-- E.g. "Downloaded maps: 500Mb" in Maps Storage settings -->
+	<string name="maps_storage_downloaded">地图</string>
 	<!-- Question dialog for transferring maps from one storage to another -->
 	<string name="move_maps">移动地图？</string>
 	<!-- Ask to wait user several minutes (some long process in modal dialog). -->
@@ -234,11 +234,12 @@
 	<string name="downloader_update_all_button">更新全部</string>
 	<!-- Cancel all button text -->
 	<string name="downloader_cancel_all">全部取消</string>
-	<!-- Downloaded maps category -->
+	<!-- Downloaded maps list header -->
 	<string name="downloader_downloaded_subtitle">已下载</string>
 	<!-- Country queued for download -->
 	<string name="downloader_queued">已排队</string>
 	<string name="downloader_near_me_subtitle">在我附近</string>
+	<!-- In maps downloader and country place page shows how many maps are downloaded / to download, e.g. "Maps: 3 of 10" -->
 	<string name="downloader_status_maps">地图</string>
 	<string name="downloader_download_all_button">下载全部</string>
 	<string name="downloader_downloading">正在下载：</string>

--- a/android/res/values/strings.xml
+++ b/android/res/values/strings.xml
@@ -17,8 +17,6 @@
 	<string name="downloading">Downloading…</string>
 	<!-- Choose measurement on first launch alert - choose metric system button -->
 	<string name="kilometres">Kilometers</string>
-	<!-- View and button titles for accessibility -->
-	<string name="maps">Maps</string>
 	<!-- Settings/Downloader - size string, only strings different from English should be translated -->
 	<string name="mb">MB</string>
 	<string name="gb">GB</string>
@@ -81,8 +79,22 @@
 	<string name="maps_storage">Save maps to</string>
 	<!-- Detailed description of Maps Storage settings button -->
 	<string name="maps_storage_summary">Select the place where maps should be downloaded to</string>
+	<!-- E.g. "Downloaded maps: 500Mb" in Maps Storage settings -->
+	<string name="maps_storage_downloaded">Downloaded maps</string>
+	<!-- Internal storage type in Maps Storage settings (not accessible by the user) -->
+	<string name="maps_storage_internal">Internal hidden storage</string>
+	<!-- Shared storage type in Maps Storage settings (a primary storage usually) -->
+	<string name="maps_storage_shared">Internal shared storage</string>
+	<!-- Removable external storage type in Maps Storage settings, e.g. an SD card -->
+	<string name="maps_storage_removable">SD card</string>
+	<!-- Generic external storage type in Maps Storage settings -->
+	<string name="maps_storage_external">External shared storage</string>
+	<!-- Free space out of total storage size in Maps Storage settings, e.g. "300 MB free (of 2 GB)" -->
+	<string name="maps_storage_free_size">%1$s free (of %2$s)</string>
 	<!-- Question dialog for transferring maps from one storage to another -->
 	<string name="move_maps">Move maps?</string>
+	<!-- Error moving map files from one storage to another -->
+	<string name="move_maps_error">Error moving map files</string>
 	<!-- Ask to wait user several minutes (some long process in modal dialog). -->
 	<string name="wait_several_minutes">This can take several minutes.\nPlease wait…</string>
 	<!-- Measurement units title in settings activity -->
@@ -254,11 +266,12 @@
 	<string name="downloader_update_all_button">Update All</string>
 	<!-- Cancel all button text -->
 	<string name="downloader_cancel_all">Cancel All</string>
-	<!-- Downloaded maps category -->
+	<!-- Downloaded maps list header -->
 	<string name="downloader_downloaded_subtitle">Downloaded</string>
 	<!-- Country queued for download -->
 	<string name="downloader_queued">Queued</string>
 	<string name="downloader_near_me_subtitle">Near me</string>
+	<!-- In maps downloader and country place page shows how many maps are downloaded / to download, e.g. "Maps: 3 of 10" -->
 	<string name="downloader_status_maps">Maps</string>
 	<string name="downloader_download_all_button">Download All</string>
 	<string name="downloader_downloading">Downloading:</string>

--- a/android/src/com/mapswithme/maps/MwmActivity.java
+++ b/android/src/com/mapswithme/maps/MwmActivity.java
@@ -151,7 +151,6 @@ public class MwmActivity extends BaseMwmFragmentActivity
 
   // Map tasks that we run AFTER rendering initialized
   private final Stack<MapTask> mTasks = new Stack<>();
-  private final StoragePathManager mPathManager = new StoragePathManager();
 
   @Nullable
   private MapFragment mMapFragment;

--- a/android/src/com/mapswithme/maps/routing/BaseRoutingErrorDialogFragment.java
+++ b/android/src/com/mapswithme/maps/routing/BaseRoutingErrorDialogFragment.java
@@ -166,7 +166,7 @@ abstract class BaseRoutingErrorDialogFragment extends BaseMwmDialogFragment
     }
 
     Map<String, String> group = new HashMap<>();
-    group.put(GROUP_NAME, getString(R.string.maps) + " (" + mMissingMaps.size() + ") ");
+    group.put(GROUP_NAME, getString(R.string.downloader_status_maps) + " (" + mMissingMaps.size() + ") ");
     group.put(GROUP_SIZE, StringUtils.getFileSizeString(requireContext(), size));
 
     List<Map<String, String>> groups = new ArrayList<>();

--- a/android/src/com/mapswithme/maps/settings/StorageItem.java
+++ b/android/src/com/mapswithme/maps/settings/StorageItem.java
@@ -9,11 +9,20 @@ public class StorageItem
   private final String mPath;
   // Free size.
   private final long mFreeSize;
+  // Total size.
+  private final long mTotalSize;
+  // User-visible description.
+  private final String mLabel;
+  // Is it read-only storage?
+  private final boolean mReadonly;
 
-  public StorageItem(String path, long size)
+  public StorageItem(String path, long freeSize, long totalSize, final String label, boolean isReadonly)
   {
     mPath = path;
-    mFreeSize = size;
+    mFreeSize = freeSize;
+    mTotalSize = totalSize;
+    mLabel = label;
+    mReadonly = isReadonly;
   }
 
   @Override
@@ -37,12 +46,6 @@ public class StorageItem
     return 0;
   }
 
-  @Override
-  public String toString()
-  {
-    return mPath + ", " + mFreeSize;
-  }
-
   public String getFullPath()
   {
     return mPath;
@@ -51,5 +54,20 @@ public class StorageItem
   public long getFreeSize()
   {
     return mFreeSize;
+  }
+
+  public long getTotalSize()
+  {
+    return mTotalSize;
+  }
+
+  public String getLabel()
+  {
+    return mLabel;
+  }
+
+  public boolean isReadonly()
+  {
+    return mReadonly;
   }
 }

--- a/android/src/com/mapswithme/maps/settings/StorageItem.java
+++ b/android/src/com/mapswithme/maps/settings/StorageItem.java
@@ -6,11 +6,11 @@ package com.mapswithme.maps.settings;
 public class StorageItem
 {
   // Path to the root of writable directory.
-  public final String mPath;
+  private final String mPath;
   // Free size.
-  public final long mFreeSize;
+  private final long mFreeSize;
 
-  StorageItem(String path, long size)
+  public StorageItem(String path, long size)
   {
     mPath = path;
     mFreeSize = size;
@@ -26,7 +26,7 @@ public class StorageItem
     StorageItem other = (StorageItem) o;
     // Storage equal is considered equal, either its path OR size equals to another one's.
     // Size of storage free space can change dynamically, so that hack provides us with better results identifying the same storages.
-    return mFreeSize == other.mFreeSize || mPath.equals(other.mPath);
+    return mFreeSize == other.getFreeSize() || mPath.equals(other.getFullPath());
   }
 
   @Override

--- a/android/src/com/mapswithme/maps/settings/StoragePathAdapter.java
+++ b/android/src/com/mapswithme/maps/settings/StoragePathAdapter.java
@@ -1,17 +1,19 @@
 package com.mapswithme.maps.settings;
 
 import android.app.Activity;
-import android.view.LayoutInflater;
+import android.text.SpannableStringBuilder;
+import android.text.Spanned;
+import android.text.format.Formatter;
+import android.text.style.AbsoluteSizeSpan;
+import android.text.style.ForegroundColorSpan;
 import android.view.View;
 import android.view.ViewGroup;
 import android.widget.BaseAdapter;
 import android.widget.CheckedTextView;
 
-import androidx.annotation.NonNull;
 import com.mapswithme.maps.R;
-
-import java.util.ArrayList;
-import java.util.List;
+import com.mapswithme.util.ThemeUtils;
+import com.mapswithme.util.UiUtils;
 
 class StoragePathAdapter extends BaseAdapter
 {
@@ -50,10 +52,29 @@ class StoragePathAdapter extends BaseAdapter
       convertView = mActivity.getLayoutInflater().inflate(R.layout.item_storage, parent, false);
 
     StorageItem item = mPathManager.getStorageItems().get(position);
+    final boolean isCurrent = position == mPathManager.getCurrentStorageIndex();
     CheckedTextView checkedView = (CheckedTextView) convertView;
-    checkedView.setText(item.getFullPath() + ": " + StoragePathFragment.getSizeString(item.getFreeSize()));
-    checkedView.setChecked(position == mPathManager.getCurrentStorageIndex());
-    checkedView.setEnabled(position == mPathManager.getCurrentStorageIndex() || isStorageBigEnough(position));
+    checkedView.setChecked(isCurrent);
+    checkedView.setEnabled(!item.isReadonly() && (isStorageBigEnough(position) || isCurrent));
+
+    final String size = mActivity.getString(R.string.maps_storage_free_size,
+                                            Formatter.formatShortFileSize(mActivity, item.getFreeSize()),
+                                            Formatter.formatShortFileSize(mActivity, item.getTotalSize()));
+
+    SpannableStringBuilder sb = new SpannableStringBuilder(item.getLabel() + "\n" + size);
+    sb.setSpan(new ForegroundColorSpan(ThemeUtils.getColor(mActivity, android.R.attr.textColorSecondary)),
+               sb.length() - size.length(), sb.length(), Spanned.SPAN_EXCLUSIVE_EXCLUSIVE);
+    sb.setSpan(new AbsoluteSizeSpan(UiUtils.dimen(mActivity, R.dimen.text_size_body_3)),
+               sb.length() - size.length(), sb.length(), Spanned.SPAN_EXCLUSIVE_EXCLUSIVE);
+
+    final String path = item.getFullPath() + (item.isReadonly() ? " (read-only)" : "");
+    sb.append("\n" + path);
+    sb.setSpan(new ForegroundColorSpan(ThemeUtils.getColor(mActivity, android.R.attr.textColorSecondary)),
+               sb.length() - path.length(), sb.length(), Spanned.SPAN_EXCLUSIVE_EXCLUSIVE);
+    sb.setSpan(new AbsoluteSizeSpan(UiUtils.dimen(mActivity, R.dimen.text_size_body_4)),
+               sb.length() - path.length(), sb.length(), Spanned.SPAN_EXCLUSIVE_EXCLUSIVE);
+
+    checkedView.setText(sb);
 
     return convertView;
   }

--- a/android/src/com/mapswithme/maps/settings/StoragePathAdapter.java
+++ b/android/src/com/mapswithme/maps/settings/StoragePathAdapter.java
@@ -7,6 +7,7 @@ import android.view.ViewGroup;
 import android.widget.BaseAdapter;
 import android.widget.CheckedTextView;
 
+import androidx.annotation.NonNull;
 import com.mapswithme.maps.R;
 
 import java.util.ArrayList;
@@ -14,16 +15,14 @@ import java.util.List;
 
 class StoragePathAdapter extends BaseAdapter
 {
-  private final StoragePathManager mStoragePathManager;
   private final LayoutInflater mInflater;
 
   private final List<StorageItem> mItems = new ArrayList<>();
   private int mCurrentStorageIndex = -1;
   private long mSizeNeeded;
 
-  StoragePathAdapter(StoragePathManager storagePathManager, Activity context)
+  public StoragePathAdapter(@NonNull Activity context)
   {
-    mStoragePathManager = storagePathManager;
     mInflater = context.getLayoutInflater();
   }
 
@@ -60,12 +59,6 @@ class StoragePathAdapter extends BaseAdapter
     return convertView;
   }
 
-  public void onItemClick(int position)
-  {
-    if (isStorageBigEnough(position) && position != mCurrentStorageIndex)
-      mStoragePathManager.changeStorage(position);
-  }
-
   public void update(List<StorageItem> items, int currentItemIndex, long dirSize)
   {
     mSizeNeeded = dirSize;
@@ -76,7 +69,7 @@ class StoragePathAdapter extends BaseAdapter
     notifyDataSetChanged();
   }
 
-  private boolean isStorageBigEnough(int index)
+  public boolean isStorageBigEnough(int index)
   {
     return mItems.get(index).mFreeSize >= mSizeNeeded;
   }

--- a/android/src/com/mapswithme/maps/settings/StoragePathAdapter.java
+++ b/android/src/com/mapswithme/maps/settings/StoragePathAdapter.java
@@ -15,27 +15,26 @@ import java.util.List;
 
 class StoragePathAdapter extends BaseAdapter
 {
-  private final LayoutInflater mInflater;
-
-  private final List<StorageItem> mItems = new ArrayList<>();
-  private int mCurrentStorageIndex = -1;
+  private final StoragePathManager mPathManager;
+  private final Activity mActivity;
   private long mSizeNeeded;
 
-  public StoragePathAdapter(@NonNull Activity context)
+  public StoragePathAdapter(StoragePathManager pathManager, Activity activity)
   {
-    mInflater = context.getLayoutInflater();
+    mPathManager = pathManager;
+    mActivity = activity;
   }
 
   @Override
   public int getCount()
   {
-    return (mItems == null ? 0 : mItems.size());
+    return (mPathManager.getStorageItems() == null ? 0 : mPathManager.getStorageItems().size());
   }
 
   @Override
   public StorageItem getItem(int position)
   {
-    return mItems.get(position);
+    return mPathManager.getStorageItems().get(position);
   }
 
   @Override
@@ -48,29 +47,25 @@ class StoragePathAdapter extends BaseAdapter
   public View getView(int position, View convertView, ViewGroup parent)
   {
     if (convertView == null)
-      convertView = mInflater.inflate(R.layout.item_storage, parent, false);
+      convertView = mActivity.getLayoutInflater().inflate(R.layout.item_storage, parent, false);
 
-    StorageItem item = mItems.get(position);
+    StorageItem item = mPathManager.getStorageItems().get(position);
     CheckedTextView checkedView = (CheckedTextView) convertView;
-    checkedView.setText(item.mPath + ": " + StoragePathFragment.getSizeString(item.mFreeSize));
-    checkedView.setChecked(position == mCurrentStorageIndex);
-    checkedView.setEnabled(position == mCurrentStorageIndex || isStorageBigEnough(position));
+    checkedView.setText(item.getFullPath() + ": " + StoragePathFragment.getSizeString(item.getFreeSize()));
+    checkedView.setChecked(position == mPathManager.getCurrentStorageIndex());
+    checkedView.setEnabled(position == mPathManager.getCurrentStorageIndex() || isStorageBigEnough(position));
 
     return convertView;
   }
 
-  public void update(List<StorageItem> items, int currentItemIndex, long dirSize)
+  public void update(long dirSize)
   {
     mSizeNeeded = dirSize;
-    mItems.clear();
-    mItems.addAll(items);
-    mCurrentStorageIndex = currentItemIndex;
-
     notifyDataSetChanged();
   }
 
   public boolean isStorageBigEnough(int index)
   {
-    return mItems.get(index).mFreeSize >= mSizeNeeded;
+    return mPathManager.getStorageItems().get(index).getFreeSize() >= mSizeNeeded;
   }
 }

--- a/android/src/com/mapswithme/maps/settings/StoragePathFragment.java
+++ b/android/src/com/mapswithme/maps/settings/StoragePathFragment.java
@@ -45,7 +45,7 @@ public class StoragePathFragment extends BaseSettingsFragment
   {
     View root = super.onCreateView(inflater, container, savedInstanceState);
     mPathManager = new StoragePathManager(requireActivity());
-    mAdapter = new StoragePathAdapter(requireActivity());
+    mAdapter = new StoragePathAdapter(mPathManager, requireActivity());
 
     mHeader = root.findViewById(R.id.header);
     mList = root.findViewById(R.id.list);
@@ -89,7 +89,7 @@ public class StoragePathFragment extends BaseSettingsFragment
   {
     long dirSize = getWritableDirSize();
     mHeader.setText(getString(R.string.maps) + ": " + getSizeString(dirSize));
-    mAdapter.update(mPathManager.getStorageItems(), mPathManager.getCurrentStorageIndex(), dirSize);
+    mAdapter.update(dirSize);
   }
 
   /**

--- a/android/src/com/mapswithme/maps/settings/StoragePathManager.java
+++ b/android/src/com/mapswithme/maps/settings/StoragePathManager.java
@@ -7,11 +7,14 @@ import android.content.Context;
 import android.content.Intent;
 import android.content.IntentFilter;
 import android.os.Environment;
+import android.os.storage.StorageManager;
+import android.os.storage.StorageVolume;
 import android.text.TextUtils;
 
 import androidx.annotation.NonNull;
 import androidx.annotation.Nullable;
 import com.mapswithme.maps.Framework;
+import com.mapswithme.maps.R;
 import com.mapswithme.maps.downloader.MapManager;
 import com.mapswithme.util.Config;
 import com.mapswithme.util.StorageUtils;
@@ -20,13 +23,10 @@ import com.mapswithme.util.log.Logger;
 import com.mapswithme.util.log.LoggerFactory;
 
 import java.io.File;
-import java.io.FileFilter;
 import java.io.FilenameFilter;
 import java.io.IOException;
 import java.util.ArrayList;
-import java.util.HashSet;
 import java.util.List;
-import java.util.Set;
 
 public class StoragePathManager
 {
@@ -78,7 +78,7 @@ public class StoragePathManager
       @Override
       public void onReceive(Context context, Intent intent)
       {
-        updateExternalStorages();
+        scanAvailableStorages();
 
         if (mStoragesChangedListener != null)
           mStoragesChangedListener.onStorageListChanged(mItems, mCurrentStorageIndex);
@@ -126,118 +126,165 @@ public class StoragePathManager
   }
 
   /**
-   * Updates the list of available external storages.
-   *
-   * The scan order is following:
-   *
-   *  1. Current directory from Config.
-   *  2. Application-specific directories on shared/external storage devices.
-   *  3. Application-specific directory on the internal memory.
-   *
-   * Directories are checked for the free space and the write access.
+   * Adds a storage into the list if it passes sanity checks.
    */
-  public void updateExternalStorages() throws AssertionError
+  private void addStorageOption(File dir, boolean isInternal, String configPath)
   {
-    List<File> candidates = new ArrayList<>();
-
-    // Current directory.
-    // Config.getStoragePath() can be empty on the first run.
-    String configDir = Config.getStoragePath();
-    if (!TextUtils.isEmpty(configDir))
-      candidates.add(new File(configDir));
-
-    // External storages (SD cards and other).
-    for (File dir : mContext.getExternalFilesDirs(null))
+    // Internal storage must always exists, but Android is unpredictable.
+    // External storages can be null in some cases.
+    // https://github.com/organicmaps/organicmaps/issues/632
+    if (dir == null)
     {
-      // There was an evidence that `dir` can be null on some Samsungs.
-      // https://github.com/organicmaps/organicmaps/issues/632
-      if (dir == null)
-        continue;
-
-      //
-      // If the contents of emulated storage devices are backed by a private user data partition,
-      // then there is little benefit to apps storing data here instead of the private directories
-      // returned by Context#getFilesDir(), etc.
-      //
-      boolean isStorageEmulated;
-      try
-      {
-        isStorageEmulated = Environment.isExternalStorageEmulated(dir);
-      }
-      catch (IllegalArgumentException e)
-      {
-        // isExternalStorageEmulated may throw IllegalArgumentException
-        // https://github.com/organicmaps/organicmaps/issues/538
-        isStorageEmulated = false;
-      }
-      if (!isStorageEmulated)
-        candidates.add(dir);
+      LOGGER.w(TAG, "The system returned 'null' " + (isInternal ? "internal" : "external") + " storage");
+      return;
     }
 
-    // Internal storage must always exists, but Android is unpredictable.
-    // https://github.com/organicmaps/organicmaps/issues/632
-    File internalDir = mContext.getFilesDir();
-    if (internalDir != null)
-      candidates.add(internalDir);
+    String commentedPath = null;
+    try
+    {
+      // Add the trailing separator because the native code assumes that all paths have it.
+      final String path = StorageUtils.addTrailingSeparator(dir.getCanonicalPath());
+      final boolean isCurrent = path.equals(configPath);
+      final long totalSize = dir.getTotalSpace();
+      final long freeSize = dir.getUsableSpace();
 
-    if (candidates.isEmpty())
-      throw new AssertionError("Can't find available storage");
+      commentedPath = path + (StorageUtils.addTrailingSeparator(dir.getPath()).equals(path)
+                              ? "" : " (" + dir.getPath() + ")") + " - " +
+                      (isCurrent ? "currently configured, " : "") +
+                      (isInternal ? "internal" : "external") + ", " +
+                      freeSize + " available out of " + totalSize + " bytes";
 
-    //
-    // Update internal state.
-    //
+      boolean isEmulated = false;
+      boolean isRemovable = false;
+      boolean isReadonly = false;
+      String state = null;
+      String label = null;
+      if (!isInternal)
+      {
+        try
+        {
+          isEmulated = Environment.isExternalStorageEmulated(dir);
+          isRemovable = Environment.isExternalStorageRemovable(dir);
+          state = Environment.getExternalStorageState(dir);
+          commentedPath += (isEmulated ? ", emulated" : "") +
+                           (isRemovable ? ", removable" : "") +
+                           (state != null ? ", state=" + state : "");
+        }
+        catch (IllegalArgumentException e)
+        {
+          // Thrown if the dir is not a valid storage device.
+          // https://github.com/organicmaps/organicmaps/issues/538
+          LOGGER.w(TAG, "isExternalStorage checks failed for " + commentedPath);
+        }
+
+        // Get additional storage information for Android 7+.
+        if (android.os.Build.VERSION.SDK_INT >= android.os.Build.VERSION_CODES.N)
+        {
+          final StorageManager sm = (StorageManager) mContext.getSystemService(mContext.STORAGE_SERVICE);
+          if (sm != null)
+          {
+            final StorageVolume sv = sm.getStorageVolume(dir);
+            if (sv != null)
+            {
+              label = sv.getDescription(mContext);
+              commentedPath += (sv.isPrimary() ? ", primary" : "") +
+                               (!TextUtils.isEmpty(sv.getUuid()) ? ", uuid=" + sv.getUuid() : "") +
+                               (!TextUtils.isEmpty(label) ? ", label='" + label + "'": "");
+            }
+            else
+              LOGGER.w(TAG, "Can't get StorageVolume for " + commentedPath);
+          }
+          else
+            LOGGER.w(TAG, "Can't get StorageManager for " + commentedPath);
+        }
+      }
+
+      if (state != null && !Environment.MEDIA_MOUNTED.equals(state)
+          && !Environment.MEDIA_MOUNTED_READ_ONLY.equals(state))
+      {
+        LOGGER.w(TAG, "Not mounted: " + commentedPath);
+        return;
+      }
+      if (!dir.exists())
+      {
+        LOGGER.w(TAG, "Not exists: " + commentedPath);
+        return;
+      }
+      if (!dir.isDirectory())
+      {
+        LOGGER.w(TAG, "Not a directory: " + commentedPath);
+        return;
+      }
+      if (!dir.canWrite() || Environment.MEDIA_MOUNTED_READ_ONLY.equals(state))
+      {
+        isReadonly = true;
+        LOGGER.w(TAG, "Not writable: " + commentedPath);
+        // Keep using currently configured storage even if its read-only.
+        if (isCurrent)
+          commentedPath += ", read-only";
+        else
+          return;
+      }
+      if (isEmulated)
+      {
+        // TODO: External emulated storage can be backed either by internal or adopted external storage.
+        // https://github.com/organicmaps/organicmaps/issues/2451
+        LOGGER.i(TAG, "Emulated storage: " + commentedPath);
+        return;
+      }
+
+      if (TextUtils.isEmpty(label))
+        label = isInternal ? mContext.getString(R.string.maps_storage_internal)
+                           : (isRemovable ? mContext.getString(R.string.maps_storage_removable)
+                                          : (isEmulated ? mContext.getString(R.string.maps_storage_shared)
+                                                        : mContext.getString(R.string.maps_storage_external)));
+
+      StorageItem item = new StorageItem(path, freeSize, totalSize, label, isReadonly);
+      mItems.add(item);
+      if (isCurrent)
+        mCurrentStorageIndex = mItems.size() - 1;
+      LOGGER.i(TAG, "Accepted " + commentedPath);
+    }
+    catch (SecurityException | IOException ex)
+    {
+      LOGGER.e(TAG, "Error: " + (commentedPath != null ? commentedPath : "(" + dir.getPath() + ")"), ex);
+    }
+  }
+
+  /**
+   * Updates the list of available storages.
+   * The scan order is following:
+   *  1. App-specific directories on shared/external storage devices.
+   *  2. App-specific directory in the internal memory.
+   */
+  public void scanAvailableStorages() throws AssertionError
+  {
+    // Current configured storage directory, can be empty on the first run.
+    final String configPath = Config.getStoragePath();
+    LOGGER.i(TAG, "Currently configured storage: " + (TextUtils.isEmpty(configPath) ? "N/A" : configPath));
+
     LOGGER.i(TAG, "Begin scanning storages");
     mItems.clear();
     mCurrentStorageIndex = -1;
-    Set<String> unique = new HashSet<>();
-    for (File dir : candidates)
+
+    // External storages (SD cards and other).
+    for (File externalDir : mContext.getExternalFilesDirs(null))
     {
-      try
-      {
-        String path = dir.getCanonicalPath();
-        // Add the trailing separator because the native code assumes that all paths have it.
-        if (!path.endsWith(File.separator))
-          path = path + File.separator;
-
-        if (!dir.exists() || !dir.isDirectory())
-        {
-          LOGGER.i(TAG, "Rejected " + path + ": not a directory");
-          continue;
-        }
-        if (!dir.canWrite())
-        {
-          LOGGER.i(TAG, "Rejected " + path + ": not writable");
-          continue;
-        }
-
-        if (!unique.add(path))
-        {
-          LOGGER.i(TAG, "Rejected " + path + ": a duplicate");
-          continue;
-        }
-
-        final long freeSize = StorageUtils.getFreeBytesAtPath(path);
-        StorageItem item = new StorageItem(path, freeSize);
-        if (!TextUtils.isEmpty(configDir) && configDir.equals(path))
-        {
-          mCurrentStorageIndex = mItems.size();
-        }
-        LOGGER.i(TAG, "Accepted " + path + ": " + freeSize + " bytes available");
-        mItems.add(item);
-      }
-      catch (IllegalArgumentException | IOException ex)
-      {
-        LOGGER.e(TAG, "Rejected " + dir.getPath() + ": error", ex);
-        continue;
-      }
+      addStorageOption(externalDir, false, configPath);
     }
+
+    File internalDir = mContext.getFilesDir();
+    addStorageOption(internalDir, true, configPath);
+
     LOGGER.i(TAG, "End scanning storages");
 
-    if (!TextUtils.isEmpty(configDir) && mCurrentStorageIndex == -1)
+    if (mItems.isEmpty())
+      // Shut down the app.
+      throw new AssertionError("Can't find available storages");
+
+    if (!TextUtils.isEmpty(configPath) && mCurrentStorageIndex == -1)
     {
-      LOGGER.w(TAG, configDir + ": can't find configured directory in the list above!");
-      for (StorageItem item : mItems)
-        LOGGER.w(TAG, item.toString());
+      LOGGER.w(TAG, "Currently configured storage is not available!");
     }
   }
 
@@ -254,62 +301,79 @@ public class StoragePathManager
   private static boolean containsMapData(String storagePath)
   {
     File path = new File(storagePath);
-    File[] candidates = path.listFiles(new FileFilter()
-    {
-      @Override
-      public boolean accept(File pathname)
+    File[] candidates = path.listFiles((pathname) ->
       {
-        if (!pathname.isDirectory())
-          return false;
+       if (!pathname.isDirectory())
+         return false;
 
-        try
-        {
-          String name = pathname.getName();
-          if (name.length() != 6)
-            return false;
+       try
+       {
+         String name = pathname.getName();
+         if (name.length() != 6)
+           return false;
 
-          int version = Integer.valueOf(name);
-          return (version > 120000 && version <= 999999);
-        } catch (NumberFormatException ignored) {}
+         int version = Integer.valueOf(name);
+         return (version > 120000 && version <= 999999);
+       }
+       catch (NumberFormatException ignored)
+       {
+       }
 
-        return false;
-      }
-    });
+       return false;
+      });
 
     return (candidates != null && candidates.length > 0 &&
             candidates[0].list().length > 0);
   }
 
   /**
-   * Finds a first available storage with existing maps files.
-   * Returns the best available option if no maps files found.
-   * See updateExternalStorages() for the scan order details.
+   * Returns an available storage with existing maps files.
+   * Checks the currently configured storage first,
+   * then scans other storages. Defaults to the first available option if no maps files found
+   * (see scanAvailableStorages() for the scan order details).
    */
   public static String findMapsStorage(@NonNull Application application)
   {
-    StoragePathManager instance = new StoragePathManager(application);
-    instance.updateExternalStorages();
+    StoragePathManager mgr = new StoragePathManager(application);
+    mgr.scanAvailableStorages();
+    String path = null;
+    final int currentIdx = mgr.getCurrentStorageIndex();
 
-    List<StorageItem> items = instance.getStorageItems();
-
-    for (StorageItem item : items)
+    if (currentIdx != -1)
     {
-      String path = item.getFullPath();
+      path = mgr.getStorageItems().get(currentIdx).getFullPath();
       if (containsMapData(path))
       {
-        LOGGER.i(TAG, "Found maps files at " + path);
+        LOGGER.i(TAG, "Found map files at the currently configured " + path);
         return path;
       }
       else
       {
-        LOGGER.i(TAG, "No maps files found at " + path);
+        LOGGER.w(TAG, "No map files found at the currenly configured " + path);
       }
     }
 
-    // Use the first item by default.
-    final String defaultDir = items.get(0).getFullPath();
-    LOGGER.i(TAG, "Using default directory: " + defaultDir);
-    return defaultDir;
+    LOGGER.i(TAG, "Looking for map files in available storages...");
+    for (int idx = 0; idx < mgr.getStorageItems().size(); ++idx)
+    {
+      if (idx == currentIdx)
+        continue;
+      path = mgr.getStorageItems().get(idx).getFullPath();
+      if (containsMapData(path))
+      {
+        LOGGER.i(TAG, "Found map files at " + path);
+        return path;
+      }
+      else
+      {
+        LOGGER.i(TAG, "No map files found at " + path);
+      }
+    }
+
+    // Use the first storage by default.
+    path = mgr.getStorageItems().get(0).getFullPath();
+    LOGGER.i(TAG, "Using default storage: " + path);
+    return path;
   }
 
   /**

--- a/android/src/com/mapswithme/maps/settings/StoragePathManager.java
+++ b/android/src/com/mapswithme/maps/settings/StoragePathManager.java
@@ -294,19 +294,20 @@ public class StoragePathManager
 
     for (StorageItem item : items)
     {
-      if (containsMapData(item.mPath))
+      String path = item.getFullPath();
+      if (containsMapData(path))
       {
-        LOGGER.i(TAG, "Found maps files at " + item.mPath);
-        return item.mPath;
+        LOGGER.i(TAG, "Found maps files at " + path);
+        return path;
       }
       else
       {
-        LOGGER.i(TAG, "No maps files found at " + item.mPath);
+        LOGGER.i(TAG, "No maps files found at " + path);
       }
     }
 
     // Use the first item by default.
-    final String defaultDir = items.get(0).mPath;
+    final String defaultDir = items.get(0).getFullPath();
     LOGGER.i(TAG, "Using default directory: " + defaultDir);
     return defaultDir;
   }

--- a/android/src/com/mapswithme/util/StorageUtils.java
+++ b/android/src/com/mapswithme/util/StorageUtils.java
@@ -123,9 +123,9 @@ public class StorageUtils
   }
 
   @NonNull
-  private static String addTrailingSeparator(@NonNull String dir)
+  public static String addTrailingSeparator(@NonNull String dir)
   {
-    if (!dir.endsWith("/"))
+    if (!dir.endsWith(File.separator))
       return dir + File.separator;
     return dir;
   }
@@ -248,20 +248,6 @@ public class StorageUtils
       if (filter.accept(dir, name))
         relPaths.add(prefix + name);
     }
-  }
-
-  public static long getFreeBytesAtPath(String path)
-  {
-    long size = 0;
-    try
-    {
-      size = new File(path).getFreeSpace();
-    } catch (RuntimeException e)
-    {
-      e.printStackTrace();
-    }
-
-    return size;
   }
 
   public static long getDirSizeRecursively(File file, FilenameFilter fileFilter)

--- a/data/strings/strings.txt
+++ b/data/strings/strings.txt
@@ -342,44 +342,6 @@
     zh-Hans = 发表评论
     zh-Hant = 撰寫評論
 
-  [maps]
-    comment = View and button titles for accessibility
-    tags = android,ios
-    en = Maps
-    ar = الخرائط
-    be = Мапы
-    bg = Карти
-    cs = Mapy
-    da = Kort
-    de = Karten
-    el = Χάρτες
-    es = Mapas
-    eu = Mapak
-    fa = نقشه ها
-    fi = Kartat
-    fr = Cartes
-    he = מפות
-    hu = Térképek
-    id = Peta
-    it = Mappe
-    ja = マップ
-    ko = 지도
-    nb = Kart
-    nl = Kaarten
-    pl = Mapy
-    pt = Mapas
-    pt-BR = Mapas
-    ro = Hărţi
-    ru = Карты
-    sk = Mapy
-    sv = Kartor
-    th = แผนที่
-    tr = Haritalar
-    uk = Мапи
-    vi = Bản đồ
-    zh-Hans = 地图
-    zh-Hant = 地圖
-
   [mb]
     comment = Settings/Downloader - size string, only strings different from English should be translated
     tags = android
@@ -1835,6 +1797,80 @@
     zh-Hans = 选取地图应该下载的位置
     zh-Hant = 請選擇下載地圖後要放的位置
 
+  [maps_storage_downloaded]
+    comment = E.g. "Downloaded maps: 500Mb" in Maps Storage settings
+    tags = android
+    en = Downloaded maps
+    ar = الخرائط
+    be = Мапы
+    bg = Карти
+    cs = Mapy
+    da = Kort
+    de = Karten
+    el = Χάρτες
+    es = Mapas
+    eu = Mapak
+    fa = نقشه ها
+    fi = Kartat
+    fr = Cartes
+    he = מפות
+    hu = Térképek
+    id = Peta
+    it = Mappe
+    ja = マップ
+    ko = 지도
+    nb = Kart
+    nl = Kaarten
+    pl = Mapy
+    pt = Mapas
+    pt-BR = Mapas
+    ro = Hărţi
+    ru = Загруженные карты
+    sk = Mapy
+    sv = Kartor
+    th = แผนที่
+    tr = Haritalar
+    uk = Завантаженнi мапи
+    vi = Bản đồ
+    zh-Hans = 地图
+    zh-Hant = 地圖
+
+  [maps_storage_internal]
+    comment = Internal storage type in Maps Storage settings (not accessible by the user)
+    tags = android
+    en = Internal hidden storage
+    ru = Внутренний скрытый накопитель
+    uk = Внутрішнє зховане сховище
+
+  [maps_storage_shared]
+    comment = Shared storage type in Maps Storage settings (a primary storage usually)
+    tags = android
+    en = Internal shared storage
+    be = Унутранае абагуленае сховішча
+    ru = Внутренний общий накопитель
+    uk = Внутрішнє спільне сховище
+
+  [maps_storage_removable]
+    comment = Removable external storage type in Maps Storage settings, e.g. an SD card
+    tags = android
+    en = SD card
+    be = SD-карта
+    ru = SD-карта
+    uk = SD-карта
+
+  [maps_storage_external]
+    comment = Generic external storage type in Maps Storage settings
+    tags = android
+    en = External shared storage
+    ru = Внешний общий накопитель
+    uk = Зовнiшне спільне сховище
+
+  [maps_storage_free_size]
+    comment = Free space out of total storage size in Maps Storage settings, e.g. "300 MB free (of 2 GB)"
+    tags = android
+    en = %1$@ free (of %2$@)
+    ru = %1$@ свободно (из %2$@)
+
   [move_maps]
     comment = Question dialog for transferring maps from one storage to another
     tags = android
@@ -1872,6 +1908,12 @@
     vi = Di chuyển bản đồ?
     zh-Hans = 移动地图？
     zh-Hant = 移動地圖？
+
+  [move_maps_error]
+    comment = Error moving map files from one storage to another
+    tags = android
+    en = Error moving map files
+    ru = Ошибка перемещения файлов карт
 
   [wait_several_minutes]
     comment = Ask to wait user several minutes (some long process in modal dialog).
@@ -5228,7 +5270,7 @@
     zh-Hant = 全部取消
 
   [downloader_downloaded_subtitle]
-    comment = Downloaded maps category
+    comment = Downloaded maps list header
     tags = android,ios
     en = Downloaded
     ar = تم تنزيلها
@@ -5375,6 +5417,7 @@
     zh-Hant = 在我附近
 
   [downloader_status_maps]
+    comment = In maps downloader and country place page shows how many maps are downloaded / to download, e.g. "Maps: 3 of 10"
     tags = android,ios
     en = Maps
     ar = الخرائط

--- a/iphone/Maps/Classes/CustomAlert/DownloadTransitMapsAlert/MWMDownloadTransitMapAlert.mm
+++ b/iphone/Maps/Classes/CustomAlert/DownloadTransitMapsAlert/MWMDownloadTransitMapAlert.mm
@@ -334,7 +334,7 @@ CGFloat const kAnimationDuration = .05;
   if (!_listHeader)
     _listHeader = [MWMDownloaderDialogHeader headerForOwnerAlert:self];
 
-  [_listHeader setTitle:[NSString stringWithFormat:@"%@ (%@)", L(@"maps"), @(m_countries.size())]
+  [_listHeader setTitle:[NSString stringWithFormat:@"%@ (%@)", L(@"downloader_status_maps"), @(m_countries.size())]
                    size:self.countriesSize];
   return _listHeader;
 }

--- a/iphone/Maps/LocalizedStrings/ar.lproj/Localizable.strings
+++ b/iphone/Maps/LocalizedStrings/ar.lproj/Localizable.strings
@@ -26,9 +26,6 @@
 /* Leave Review dialog - Review button */
 "leave_a_review" = "اترك تعليق";
 
-/* View and button titles for accessibility */
-"maps" = "الخرائط";
-
 /* Choose measurement on first launch alert - choose imperial system button */
 "miles" = "ميل";
 
@@ -321,7 +318,7 @@
 /* Update all button text */
 "downloader_update_all_button" = "تحديث الكل";
 
-/* Downloaded maps category */
+/* Downloaded maps list header */
 "downloader_downloaded_subtitle" = "تم تنزيلها";
 
 /* Downloaded maps category */
@@ -332,6 +329,7 @@
 
 "downloader_near_me_subtitle" = "بالقرب مني";
 
+/* In maps downloader and country place page shows how many maps are downloaded / to download, e.g. "Maps: 3 of 10" */
 "downloader_status_maps" = "الخرائط";
 
 "downloader_download_all_button" = "تنزيل الكل";

--- a/iphone/Maps/LocalizedStrings/be.lproj/Localizable.strings
+++ b/iphone/Maps/LocalizedStrings/be.lproj/Localizable.strings
@@ -26,9 +26,6 @@
 /* Leave Review dialog - Review button */
 "leave_a_review" = "Напісаць водгук";
 
-/* View and button titles for accessibility */
-"maps" = "Мапы";
-
 /* Choose measurement on first launch alert - choose imperial system button */
 "miles" = "Мілі";
 
@@ -321,7 +318,7 @@
 /* Update all button text */
 "downloader_update_all_button" = "Абнавіць усё";
 
-/* Downloaded maps category */
+/* Downloaded maps list header */
 "downloader_downloaded_subtitle" = "Спампаваныя";
 
 /* Downloaded maps category */
@@ -332,6 +329,7 @@
 
 "downloader_near_me_subtitle" = "Каля мяне";
 
+/* In maps downloader and country place page shows how many maps are downloaded / to download, e.g. "Maps: 3 of 10" */
 "downloader_status_maps" = "Мапы";
 
 "downloader_download_all_button" = "Спампаваць усё";

--- a/iphone/Maps/LocalizedStrings/bg.lproj/Localizable.strings
+++ b/iphone/Maps/LocalizedStrings/bg.lproj/Localizable.strings
@@ -26,9 +26,6 @@
 /* Leave Review dialog - Review button */
 "leave_a_review" = "Напишете отзив";
 
-/* View and button titles for accessibility */
-"maps" = "Карти";
-
 /* Choose measurement on first launch alert - choose imperial system button */
 "miles" = "Мили";
 
@@ -321,7 +318,7 @@
 /* Update all button text */
 "downloader_update_all_button" = "Обновяване на всичко";
 
-/* Downloaded maps category */
+/* Downloaded maps list header */
 "downloader_downloaded_subtitle" = "Изтеглено";
 
 /* Downloaded maps category */
@@ -332,6 +329,7 @@
 
 "downloader_near_me_subtitle" = "Близо до мен";
 
+/* In maps downloader and country place page shows how many maps are downloaded / to download, e.g. "Maps: 3 of 10" */
 "downloader_status_maps" = "Карти";
 
 "downloader_download_all_button" = "Изтегляне на всичко";

--- a/iphone/Maps/LocalizedStrings/cs.lproj/Localizable.strings
+++ b/iphone/Maps/LocalizedStrings/cs.lproj/Localizable.strings
@@ -26,9 +26,6 @@
 /* Leave Review dialog - Review button */
 "leave_a_review" = "Zpětná vazba";
 
-/* View and button titles for accessibility */
-"maps" = "Mapy";
-
 /* Choose measurement on first launch alert - choose imperial system button */
 "miles" = "Míle";
 
@@ -321,7 +318,7 @@
 /* Update all button text */
 "downloader_update_all_button" = "Aktualizovat vše";
 
-/* Downloaded maps category */
+/* Downloaded maps list header */
 "downloader_downloaded_subtitle" = "Staženo";
 
 /* Downloaded maps category */
@@ -332,6 +329,7 @@
 
 "downloader_near_me_subtitle" = "Poblíž mě";
 
+/* In maps downloader and country place page shows how many maps are downloaded / to download, e.g. "Maps: 3 of 10" */
 "downloader_status_maps" = "Mapy";
 
 "downloader_download_all_button" = "Stáhnout vše";

--- a/iphone/Maps/LocalizedStrings/da.lproj/Localizable.strings
+++ b/iphone/Maps/LocalizedStrings/da.lproj/Localizable.strings
@@ -26,9 +26,6 @@
 /* Leave Review dialog - Review button */
 "leave_a_review" = "Lav en bedømmelse";
 
-/* View and button titles for accessibility */
-"maps" = "Kort";
-
 /* Choose measurement on first launch alert - choose imperial system button */
 "miles" = "Mil";
 
@@ -321,7 +318,7 @@
 /* Update all button text */
 "downloader_update_all_button" = "Opdatér alle";
 
-/* Downloaded maps category */
+/* Downloaded maps list header */
 "downloader_downloaded_subtitle" = "Downloadet";
 
 /* Downloaded maps category */
@@ -332,6 +329,7 @@
 
 "downloader_near_me_subtitle" = "I nærheden";
 
+/* In maps downloader and country place page shows how many maps are downloaded / to download, e.g. "Maps: 3 of 10" */
 "downloader_status_maps" = "Kort";
 
 "downloader_download_all_button" = "Download alle";

--- a/iphone/Maps/LocalizedStrings/de.lproj/Localizable.strings
+++ b/iphone/Maps/LocalizedStrings/de.lproj/Localizable.strings
@@ -26,9 +26,6 @@
 /* Leave Review dialog - Review button */
 "leave_a_review" = "Bericht abgeben";
 
-/* View and button titles for accessibility */
-"maps" = "Karten";
-
 /* Choose measurement on first launch alert - choose imperial system button */
 "miles" = "Meilen";
 
@@ -321,7 +318,7 @@
 /* Update all button text */
 "downloader_update_all_button" = "Alle aktualisieren";
 
-/* Downloaded maps category */
+/* Downloaded maps list header */
 "downloader_downloaded_subtitle" = "Heruntergeladen";
 
 /* Downloaded maps category */
@@ -332,6 +329,7 @@
 
 "downloader_near_me_subtitle" = "In meiner Nähe";
 
+/* In maps downloader and country place page shows how many maps are downloaded / to download, e.g. "Maps: 3 of 10" */
 "downloader_status_maps" = "Karten";
 
 "downloader_download_all_button" = "Alle herunterladen";

--- a/iphone/Maps/LocalizedStrings/el.lproj/Localizable.strings
+++ b/iphone/Maps/LocalizedStrings/el.lproj/Localizable.strings
@@ -26,9 +26,6 @@
 /* Leave Review dialog - Review button */
 "leave_a_review" = "Αφήστε μια κριτική";
 
-/* View and button titles for accessibility */
-"maps" = "Χάρτες";
-
 /* Choose measurement on first launch alert - choose imperial system button */
 "miles" = "Μίλια";
 
@@ -321,7 +318,7 @@
 /* Update all button text */
 "downloader_update_all_button" = "Ενημέρωση όλων";
 
-/* Downloaded maps category */
+/* Downloaded maps list header */
 "downloader_downloaded_subtitle" = "Έγινε λήψη";
 
 /* Downloaded maps category */
@@ -332,6 +329,7 @@
 
 "downloader_near_me_subtitle" = "Κοντά μου";
 
+/* In maps downloader and country place page shows how many maps are downloaded / to download, e.g. "Maps: 3 of 10" */
 "downloader_status_maps" = "Χάρτες";
 
 "downloader_download_all_button" = "Λήψη όλων";

--- a/iphone/Maps/LocalizedStrings/en-GB.lproj/Localizable.strings
+++ b/iphone/Maps/LocalizedStrings/en-GB.lproj/Localizable.strings
@@ -26,9 +26,6 @@
 /* Leave Review dialog - Review button */
 "leave_a_review" = "Leave a Review";
 
-/* View and button titles for accessibility */
-"maps" = "Maps";
-
 /* Choose measurement on first launch alert - choose imperial system button */
 "miles" = "Miles";
 
@@ -321,7 +318,7 @@
 /* Update all button text */
 "downloader_update_all_button" = "Update All";
 
-/* Downloaded maps category */
+/* Downloaded maps list header */
 "downloader_downloaded_subtitle" = "Downloaded";
 
 /* Downloaded maps category */
@@ -332,6 +329,7 @@
 
 "downloader_near_me_subtitle" = "Near me";
 
+/* In maps downloader and country place page shows how many maps are downloaded / to download, e.g. "Maps: 3 of 10" */
 "downloader_status_maps" = "Maps";
 
 "downloader_download_all_button" = "Download All";

--- a/iphone/Maps/LocalizedStrings/en.lproj/Localizable.strings
+++ b/iphone/Maps/LocalizedStrings/en.lproj/Localizable.strings
@@ -26,9 +26,6 @@
 /* Leave Review dialog - Review button */
 "leave_a_review" = "Leave a Review";
 
-/* View and button titles for accessibility */
-"maps" = "Maps";
-
 /* Choose measurement on first launch alert - choose imperial system button */
 "miles" = "Miles";
 
@@ -321,7 +318,7 @@
 /* Update all button text */
 "downloader_update_all_button" = "Update All";
 
-/* Downloaded maps category */
+/* Downloaded maps list header */
 "downloader_downloaded_subtitle" = "Downloaded";
 
 /* Downloaded maps category */
@@ -332,6 +329,7 @@
 
 "downloader_near_me_subtitle" = "Near me";
 
+/* In maps downloader and country place page shows how many maps are downloaded / to download, e.g. "Maps: 3 of 10" */
 "downloader_status_maps" = "Maps";
 
 "downloader_download_all_button" = "Download All";

--- a/iphone/Maps/LocalizedStrings/es-MX.lproj/Localizable.strings
+++ b/iphone/Maps/LocalizedStrings/es-MX.lproj/Localizable.strings
@@ -26,9 +26,6 @@
 /* Leave Review dialog - Review button */
 "leave_a_review" = "Escribir una opinión";
 
-/* View and button titles for accessibility */
-"maps" = "Mapas";
-
 /* Choose measurement on first launch alert - choose imperial system button */
 "miles" = "Milla";
 
@@ -321,7 +318,7 @@
 /* Update all button text */
 "downloader_update_all_button" = "Actualizar todos";
 
-/* Downloaded maps category */
+/* Downloaded maps list header */
 "downloader_downloaded_subtitle" = "Descargado";
 
 /* Downloaded maps category */
@@ -332,6 +329,7 @@
 
 "downloader_near_me_subtitle" = "Cerca de mí";
 
+/* In maps downloader and country place page shows how many maps are downloaded / to download, e.g. "Maps: 3 of 10" */
 "downloader_status_maps" = "Mapas";
 
 "downloader_download_all_button" = "Descargar todos";

--- a/iphone/Maps/LocalizedStrings/es.lproj/Localizable.strings
+++ b/iphone/Maps/LocalizedStrings/es.lproj/Localizable.strings
@@ -26,9 +26,6 @@
 /* Leave Review dialog - Review button */
 "leave_a_review" = "Escribir una opinión";
 
-/* View and button titles for accessibility */
-"maps" = "Mapas";
-
 /* Choose measurement on first launch alert - choose imperial system button */
 "miles" = "Milla";
 
@@ -321,7 +318,7 @@
 /* Update all button text */
 "downloader_update_all_button" = "Actualizar todos";
 
-/* Downloaded maps category */
+/* Downloaded maps list header */
 "downloader_downloaded_subtitle" = "Descargado";
 
 /* Downloaded maps category */
@@ -332,6 +329,7 @@
 
 "downloader_near_me_subtitle" = "Cerca de mí";
 
+/* In maps downloader and country place page shows how many maps are downloaded / to download, e.g. "Maps: 3 of 10" */
 "downloader_status_maps" = "Mapas";
 
 "downloader_download_all_button" = "Descargar todos";

--- a/iphone/Maps/LocalizedStrings/eu.lproj/Localizable.strings
+++ b/iphone/Maps/LocalizedStrings/eu.lproj/Localizable.strings
@@ -26,9 +26,6 @@
 /* Leave Review dialog - Review button */
 "leave_a_review" = "Idatzi iritzia";
 
-/* View and button titles for accessibility */
-"maps" = "Mapak";
-
 /* Choose measurement on first launch alert - choose imperial system button */
 "miles" = "Milia";
 
@@ -321,7 +318,7 @@
 /* Update all button text */
 "downloader_update_all_button" = "Eguneratu guztiak";
 
-/* Downloaded maps category */
+/* Downloaded maps list header */
 "downloader_downloaded_subtitle" = "Alta";
 
 /* Downloaded maps category */
@@ -332,6 +329,7 @@
 
 "downloader_near_me_subtitle" = "Nigandik gertu";
 
+/* In maps downloader and country place page shows how many maps are downloaded / to download, e.g. "Maps: 3 of 10" */
 "downloader_status_maps" = "Mapak";
 
 "downloader_download_all_button" = "Deskargatu guztiak";

--- a/iphone/Maps/LocalizedStrings/fa.lproj/Localizable.strings
+++ b/iphone/Maps/LocalizedStrings/fa.lproj/Localizable.strings
@@ -26,9 +26,6 @@
 /* Leave Review dialog - Review button */
 "leave_a_review" = "نظر خود را بیان کنید";
 
-/* View and button titles for accessibility */
-"maps" = "نقشه ها";
-
 /* Choose measurement on first launch alert - choose imperial system button */
 "miles" = "مایل";
 
@@ -321,7 +318,7 @@
 /* Update all button text */
 "downloader_update_all_button" = "اپدیت همه";
 
-/* Downloaded maps category */
+/* Downloaded maps list header */
 "downloader_downloaded_subtitle" = "دانلود شده";
 
 /* Downloaded maps category */
@@ -332,6 +329,7 @@
 
 "downloader_near_me_subtitle" = "نزدیک من";
 
+/* In maps downloader and country place page shows how many maps are downloaded / to download, e.g. "Maps: 3 of 10" */
 "downloader_status_maps" = "نقشه ها";
 
 "downloader_download_all_button" = "دانلود همه";

--- a/iphone/Maps/LocalizedStrings/fi.lproj/Localizable.strings
+++ b/iphone/Maps/LocalizedStrings/fi.lproj/Localizable.strings
@@ -26,9 +26,6 @@
 /* Leave Review dialog - Review button */
 "leave_a_review" = "Jätä arviointi";
 
-/* View and button titles for accessibility */
-"maps" = "Kartat";
-
 /* Choose measurement on first launch alert - choose imperial system button */
 "miles" = "Mailit";
 
@@ -321,7 +318,7 @@
 /* Update all button text */
 "downloader_update_all_button" = "Päivitä kaikki";
 
-/* Downloaded maps category */
+/* Downloaded maps list header */
 "downloader_downloaded_subtitle" = "Ladatut";
 
 /* Downloaded maps category */
@@ -332,6 +329,7 @@
 
 "downloader_near_me_subtitle" = "Lähelläni";
 
+/* In maps downloader and country place page shows how many maps are downloaded / to download, e.g. "Maps: 3 of 10" */
 "downloader_status_maps" = "Kartat";
 
 "downloader_download_all_button" = "Lataa kaikki";

--- a/iphone/Maps/LocalizedStrings/fr.lproj/Localizable.strings
+++ b/iphone/Maps/LocalizedStrings/fr.lproj/Localizable.strings
@@ -26,9 +26,6 @@
 /* Leave Review dialog - Review button */
 "leave_a_review" = "Laisser une critique";
 
-/* View and button titles for accessibility */
-"maps" = "Cartes";
-
 /* Choose measurement on first launch alert - choose imperial system button */
 "miles" = "Miles";
 
@@ -321,7 +318,7 @@
 /* Update all button text */
 "downloader_update_all_button" = "Tout mettre à jour";
 
-/* Downloaded maps category */
+/* Downloaded maps list header */
 "downloader_downloaded_subtitle" = "Téléchargé";
 
 /* Downloaded maps category */
@@ -332,6 +329,7 @@
 
 "downloader_near_me_subtitle" = "Près de moi";
 
+/* In maps downloader and country place page shows how many maps are downloaded / to download, e.g. "Maps: 3 of 10" */
 "downloader_status_maps" = "Cartes";
 
 "downloader_download_all_button" = "Télécharger tout";

--- a/iphone/Maps/LocalizedStrings/he.lproj/Localizable.strings
+++ b/iphone/Maps/LocalizedStrings/he.lproj/Localizable.strings
@@ -26,9 +26,6 @@
 /* Leave Review dialog - Review button */
 "leave_a_review" = "הבע דעתך";
 
-/* View and button titles for accessibility */
-"maps" = "מפות";
-
 /* Choose measurement on first launch alert - choose imperial system button */
 "miles" = "מ\"ב";
 
@@ -321,7 +318,7 @@
 /* Update all button text */
 "downloader_update_all_button" = "Update All";
 
-/* Downloaded maps category */
+/* Downloaded maps list header */
 "downloader_downloaded_subtitle" = "Downloaded";
 
 /* Downloaded maps category */
@@ -332,6 +329,7 @@
 
 "downloader_near_me_subtitle" = "Near me";
 
+/* In maps downloader and country place page shows how many maps are downloaded / to download, e.g. "Maps: 3 of 10" */
 "downloader_status_maps" = "Maps";
 
 "downloader_download_all_button" = "Download All";

--- a/iphone/Maps/LocalizedStrings/hu.lproj/Localizable.strings
+++ b/iphone/Maps/LocalizedStrings/hu.lproj/Localizable.strings
@@ -26,9 +26,6 @@
 /* Leave Review dialog - Review button */
 "leave_a_review" = "Ajánlás írása";
 
-/* View and button titles for accessibility */
-"maps" = "Térképek";
-
 /* Choose measurement on first launch alert - choose imperial system button */
 "miles" = "Mérföld";
 
@@ -321,7 +318,7 @@
 /* Update all button text */
 "downloader_update_all_button" = "Mindegyik frissítése";
 
-/* Downloaded maps category */
+/* Downloaded maps list header */
 "downloader_downloaded_subtitle" = "Letöltve";
 
 /* Downloaded maps category */
@@ -332,6 +329,7 @@
 
 "downloader_near_me_subtitle" = "A közelemben";
 
+/* In maps downloader and country place page shows how many maps are downloaded / to download, e.g. "Maps: 3 of 10" */
 "downloader_status_maps" = "Térképek";
 
 "downloader_download_all_button" = "Mindegyik letöltése";

--- a/iphone/Maps/LocalizedStrings/id.lproj/Localizable.strings
+++ b/iphone/Maps/LocalizedStrings/id.lproj/Localizable.strings
@@ -26,9 +26,6 @@
 /* Leave Review dialog - Review button */
 "leave_a_review" = "Tulis Ulasan";
 
-/* View and button titles for accessibility */
-"maps" = "Peta";
-
 /* Choose measurement on first launch alert - choose imperial system button */
 "miles" = "Mil";
 
@@ -321,7 +318,7 @@
 /* Update all button text */
 "downloader_update_all_button" = "Perbarui semua";
 
-/* Downloaded maps category */
+/* Downloaded maps list header */
 "downloader_downloaded_subtitle" = "Diunduh";
 
 /* Downloaded maps category */
@@ -332,6 +329,7 @@
 
 "downloader_near_me_subtitle" = "Dekat saya";
 
+/* In maps downloader and country place page shows how many maps are downloaded / to download, e.g. "Maps: 3 of 10" */
 "downloader_status_maps" = "Peta";
 
 "downloader_download_all_button" = "Unduh semua";

--- a/iphone/Maps/LocalizedStrings/it.lproj/Localizable.strings
+++ b/iphone/Maps/LocalizedStrings/it.lproj/Localizable.strings
@@ -26,9 +26,6 @@
 /* Leave Review dialog - Review button */
 "leave_a_review" = "Lascia una recensione";
 
-/* View and button titles for accessibility */
-"maps" = "Mappe";
-
 /* Choose measurement on first launch alert - choose imperial system button */
 "miles" = "Miglia";
 
@@ -321,7 +318,7 @@
 /* Update all button text */
 "downloader_update_all_button" = "Aggiorna tutte";
 
-/* Downloaded maps category */
+/* Downloaded maps list header */
 "downloader_downloaded_subtitle" = "Scaricate";
 
 /* Downloaded maps category */
@@ -332,6 +329,7 @@
 
 "downloader_near_me_subtitle" = "Vicino a me";
 
+/* In maps downloader and country place page shows how many maps are downloaded / to download, e.g. "Maps: 3 of 10" */
 "downloader_status_maps" = "Mappe";
 
 "downloader_download_all_button" = "Scarica tutte";

--- a/iphone/Maps/LocalizedStrings/ja.lproj/Localizable.strings
+++ b/iphone/Maps/LocalizedStrings/ja.lproj/Localizable.strings
@@ -26,9 +26,6 @@
 /* Leave Review dialog - Review button */
 "leave_a_review" = "評価する";
 
-/* View and button titles for accessibility */
-"maps" = "マップ";
-
 /* Choose measurement on first launch alert - choose imperial system button */
 "miles" = "マイル";
 
@@ -321,7 +318,7 @@
 /* Update all button text */
 "downloader_update_all_button" = "全てをアップデート";
 
-/* Downloaded maps category */
+/* Downloaded maps list header */
 "downloader_downloaded_subtitle" = "ダウンロード済み";
 
 /* Downloaded maps category */
@@ -332,6 +329,7 @@
 
 "downloader_near_me_subtitle" = "付近";
 
+/* In maps downloader and country place page shows how many maps are downloaded / to download, e.g. "Maps: 3 of 10" */
 "downloader_status_maps" = "地図";
 
 "downloader_download_all_button" = "全てをダウンロード";

--- a/iphone/Maps/LocalizedStrings/ko.lproj/Localizable.strings
+++ b/iphone/Maps/LocalizedStrings/ko.lproj/Localizable.strings
@@ -26,9 +26,6 @@
 /* Leave Review dialog - Review button */
 "leave_a_review" = "평 남기기";
 
-/* View and button titles for accessibility */
-"maps" = "지도";
-
 /* Choose measurement on first launch alert - choose imperial system button */
 "miles" = "마일";
 
@@ -321,7 +318,7 @@
 /* Update all button text */
 "downloader_update_all_button" = "모두 업데이트";
 
-/* Downloaded maps category */
+/* Downloaded maps list header */
 "downloader_downloaded_subtitle" = "다운로드";
 
 /* Downloaded maps category */
@@ -332,6 +329,7 @@
 
 "downloader_near_me_subtitle" = "내 근처";
 
+/* In maps downloader and country place page shows how many maps are downloaded / to download, e.g. "Maps: 3 of 10" */
 "downloader_status_maps" = "지도";
 
 "downloader_download_all_button" = "모두 다운로드";

--- a/iphone/Maps/LocalizedStrings/nb.lproj/Localizable.strings
+++ b/iphone/Maps/LocalizedStrings/nb.lproj/Localizable.strings
@@ -26,9 +26,6 @@
 /* Leave Review dialog - Review button */
 "leave_a_review" = "Legg inn en vurdering";
 
-/* View and button titles for accessibility */
-"maps" = "Kart";
-
 /* Choose measurement on first launch alert - choose imperial system button */
 "miles" = "Miles";
 
@@ -321,7 +318,7 @@
 /* Update all button text */
 "downloader_update_all_button" = "Oppdater alle";
 
-/* Downloaded maps category */
+/* Downloaded maps list header */
 "downloader_downloaded_subtitle" = "Lastet ned";
 
 /* Downloaded maps category */
@@ -332,6 +329,7 @@
 
 "downloader_near_me_subtitle" = "I nærheten";
 
+/* In maps downloader and country place page shows how many maps are downloaded / to download, e.g. "Maps: 3 of 10" */
 "downloader_status_maps" = "Kart";
 
 "downloader_download_all_button" = "Last ned alle";

--- a/iphone/Maps/LocalizedStrings/nl.lproj/Localizable.strings
+++ b/iphone/Maps/LocalizedStrings/nl.lproj/Localizable.strings
@@ -26,9 +26,6 @@
 /* Leave Review dialog - Review button */
 "leave_a_review" = "Laat een review achter";
 
-/* View and button titles for accessibility */
-"maps" = "Kaarten";
-
 /* Choose measurement on first launch alert - choose imperial system button */
 "miles" = "Mijlen";
 
@@ -321,7 +318,7 @@
 /* Update all button text */
 "downloader_update_all_button" = "Update alles";
 
-/* Downloaded maps category */
+/* Downloaded maps list header */
 "downloader_downloaded_subtitle" = "Gedownload";
 
 /* Downloaded maps category */
@@ -332,6 +329,7 @@
 
 "downloader_near_me_subtitle" = "Bij mij in de buurt";
 
+/* In maps downloader and country place page shows how many maps are downloaded / to download, e.g. "Maps: 3 of 10" */
 "downloader_status_maps" = "Kaarten";
 
 "downloader_download_all_button" = "Alles downloaden";
@@ -885,7 +883,7 @@
 
 "error_enter_correct_name" = "Voer een juiste naam in";
 
-"bookmark_lists" = "lijsten";
+"bookmark_lists" = "Lijsten";
 
 /* Do not display all bookmark lists on the map */
 "bookmark_lists_hide_all" = "Alles verbergen";
@@ -938,7 +936,7 @@
 
 "button_layer_subway" = "Metro";
 
-"layers_title" = "Map layers";
+"layers_title" = "Kaartweergave";
 
 "subway_data_unavailable" = "Metrokaart is niet beschikbaar";
 
@@ -982,17 +980,17 @@
 
 "power_managment_setting_manual_max" = "Maximale energiebesparing";
 
-"driving_options_title" = "Omweginstellingen";
+"driving_options_title" = "Route instellingen";
 
 "driving_options_subheader" = "Vermijden op elke route";
 
 "avoid_tolls" = "Tolwegen";
 
-"avoid_unpaved" = "Aardewegen";
+"avoid_unpaved" = "Onverharde wegen";
 
-"avoid_ferry" = "Ferries";
+"avoid_ferry" = "Veerdiensten";
 
-"avoid_motorways" = "Hoofdverkeerswegen";
+"avoid_motorways" = "Autosnelwegen";
 
 "unable_to_calc_alert_title" = "Kan route niet opbouwen";
 

--- a/iphone/Maps/LocalizedStrings/pl.lproj/Localizable.strings
+++ b/iphone/Maps/LocalizedStrings/pl.lproj/Localizable.strings
@@ -26,9 +26,6 @@
 /* Leave Review dialog - Review button */
 "leave_a_review" = "Napisz recenzję";
 
-/* View and button titles for accessibility */
-"maps" = "Mapy";
-
 /* Choose measurement on first launch alert - choose imperial system button */
 "miles" = "Mile";
 
@@ -321,7 +318,7 @@
 /* Update all button text */
 "downloader_update_all_button" = "Aktualizuj wszystkie";
 
-/* Downloaded maps category */
+/* Downloaded maps list header */
 "downloader_downloaded_subtitle" = "Pobrane";
 
 /* Downloaded maps category */
@@ -332,6 +329,7 @@
 
 "downloader_near_me_subtitle" = "Blisko mnie";
 
+/* In maps downloader and country place page shows how many maps are downloaded / to download, e.g. "Maps: 3 of 10" */
 "downloader_status_maps" = "Mapy";
 
 "downloader_download_all_button" = "Pobierz wszystkie";

--- a/iphone/Maps/LocalizedStrings/pt-BR.lproj/Localizable.strings
+++ b/iphone/Maps/LocalizedStrings/pt-BR.lproj/Localizable.strings
@@ -26,9 +26,6 @@
 /* Leave Review dialog - Review button */
 "leave_a_review" = "Deixe uma avaliação";
 
-/* View and button titles for accessibility */
-"maps" = "Mapas";
-
 /* Choose measurement on first launch alert - choose imperial system button */
 "miles" = "Milhas";
 
@@ -321,7 +318,7 @@
 /* Update all button text */
 "downloader_update_all_button" = "Atualizar tudo";
 
-/* Downloaded maps category */
+/* Downloaded maps list header */
 "downloader_downloaded_subtitle" = "Baixado";
 
 /* Downloaded maps category */
@@ -332,6 +329,7 @@
 
 "downloader_near_me_subtitle" = "Perto de mim";
 
+/* In maps downloader and country place page shows how many maps are downloaded / to download, e.g. "Maps: 3 of 10" */
 "downloader_status_maps" = "Mapas";
 
 "downloader_download_all_button" = "Baixar tudo";

--- a/iphone/Maps/LocalizedStrings/pt.lproj/Localizable.strings
+++ b/iphone/Maps/LocalizedStrings/pt.lproj/Localizable.strings
@@ -26,9 +26,6 @@
 /* Leave Review dialog - Review button */
 "leave_a_review" = "Faça uma avaliação";
 
-/* View and button titles for accessibility */
-"maps" = "Mapas";
-
 /* Choose measurement on first launch alert - choose imperial system button */
 "miles" = "Milhas";
 
@@ -321,7 +318,7 @@
 /* Update all button text */
 "downloader_update_all_button" = "Atualizar tudo";
 
-/* Downloaded maps category */
+/* Downloaded maps list header */
 "downloader_downloaded_subtitle" = "Descarregado";
 
 /* Downloaded maps category */
@@ -332,6 +329,7 @@
 
 "downloader_near_me_subtitle" = "Perto de mim";
 
+/* In maps downloader and country place page shows how many maps are downloaded / to download, e.g. "Maps: 3 of 10" */
 "downloader_status_maps" = "Mapas";
 
 "downloader_download_all_button" = "Descarregar tudo";

--- a/iphone/Maps/LocalizedStrings/ro.lproj/Localizable.strings
+++ b/iphone/Maps/LocalizedStrings/ro.lproj/Localizable.strings
@@ -26,9 +26,6 @@
 /* Leave Review dialog - Review button */
 "leave_a_review" = "Lasă un comentariu";
 
-/* View and button titles for accessibility */
-"maps" = "Hărţi";
-
 /* Choose measurement on first launch alert - choose imperial system button */
 "miles" = "Mile";
 
@@ -321,7 +318,7 @@
 /* Update all button text */
 "downloader_update_all_button" = "Actualizează tot";
 
-/* Downloaded maps category */
+/* Downloaded maps list header */
 "downloader_downloaded_subtitle" = "Descărcate";
 
 /* Downloaded maps category */
@@ -332,6 +329,7 @@
 
 "downloader_near_me_subtitle" = "Lângă mine";
 
+/* In maps downloader and country place page shows how many maps are downloaded / to download, e.g. "Maps: 3 of 10" */
 "downloader_status_maps" = "Hărți";
 
 "downloader_download_all_button" = "Descarcă tot";

--- a/iphone/Maps/LocalizedStrings/ru.lproj/Localizable.strings
+++ b/iphone/Maps/LocalizedStrings/ru.lproj/Localizable.strings
@@ -26,9 +26,6 @@
 /* Leave Review dialog - Review button */
 "leave_a_review" = "Написать отзыв";
 
-/* View and button titles for accessibility */
-"maps" = "Карты";
-
 /* Choose measurement on first launch alert - choose imperial system button */
 "miles" = "Мили";
 
@@ -321,7 +318,7 @@
 /* Update all button text */
 "downloader_update_all_button" = "Обновить все";
 
-/* Downloaded maps category */
+/* Downloaded maps list header */
 "downloader_downloaded_subtitle" = "Загруженные";
 
 /* Downloaded maps category */
@@ -332,6 +329,7 @@
 
 "downloader_near_me_subtitle" = "Возле меня";
 
+/* In maps downloader and country place page shows how many maps are downloaded / to download, e.g. "Maps: 3 of 10" */
 "downloader_status_maps" = "Карт";
 
 "downloader_download_all_button" = "Загрузить все";

--- a/iphone/Maps/LocalizedStrings/sk.lproj/Localizable.strings
+++ b/iphone/Maps/LocalizedStrings/sk.lproj/Localizable.strings
@@ -26,9 +26,6 @@
 /* Leave Review dialog - Review button */
 "leave_a_review" = "Spätná väzba";
 
-/* View and button titles for accessibility */
-"maps" = "Mapy";
-
 /* Choose measurement on first launch alert - choose imperial system button */
 "miles" = "Míle";
 
@@ -321,7 +318,7 @@
 /* Update all button text */
 "downloader_update_all_button" = "Aktualizovať všetko";
 
-/* Downloaded maps category */
+/* Downloaded maps list header */
 "downloader_downloaded_subtitle" = "Stiahnuté";
 
 /* Downloaded maps category */
@@ -332,6 +329,7 @@
 
 "downloader_near_me_subtitle" = "Neďaleko mňa";
 
+/* In maps downloader and country place page shows how many maps are downloaded / to download, e.g. "Maps: 3 of 10" */
 "downloader_status_maps" = "Mapy";
 
 "downloader_download_all_button" = "Stiahnuť všetko";

--- a/iphone/Maps/LocalizedStrings/sv.lproj/Localizable.strings
+++ b/iphone/Maps/LocalizedStrings/sv.lproj/Localizable.strings
@@ -26,9 +26,6 @@
 /* Leave Review dialog - Review button */
 "leave_a_review" = "Skriv en recension";
 
-/* View and button titles for accessibility */
-"maps" = "Kartor";
-
 /* Choose measurement on first launch alert - choose imperial system button */
 "miles" = "Mil";
 
@@ -321,7 +318,7 @@
 /* Update all button text */
 "downloader_update_all_button" = "Uppdatera alla";
 
-/* Downloaded maps category */
+/* Downloaded maps list header */
 "downloader_downloaded_subtitle" = "Nedladdade";
 
 /* Downloaded maps category */
@@ -332,6 +329,7 @@
 
 "downloader_near_me_subtitle" = "Nära mig";
 
+/* In maps downloader and country place page shows how many maps are downloaded / to download, e.g. "Maps: 3 of 10" */
 "downloader_status_maps" = "Kartor";
 
 "downloader_download_all_button" = "Ladda ned alla";

--- a/iphone/Maps/LocalizedStrings/sw.lproj/Localizable.strings
+++ b/iphone/Maps/LocalizedStrings/sw.lproj/Localizable.strings
@@ -26,9 +26,6 @@
 /* Leave Review dialog - Review button */
 "leave_a_review" = "Leave a Review";
 
-/* View and button titles for accessibility */
-"maps" = "Maps";
-
 /* Choose measurement on first launch alert - choose imperial system button */
 "miles" = "Miles";
 
@@ -321,7 +318,7 @@
 /* Update all button text */
 "downloader_update_all_button" = "Update All";
 
-/* Downloaded maps category */
+/* Downloaded maps list header */
 "downloader_downloaded_subtitle" = "Downloaded";
 
 /* Downloaded maps category */
@@ -332,6 +329,7 @@
 
 "downloader_near_me_subtitle" = "Near me";
 
+/* In maps downloader and country place page shows how many maps are downloaded / to download, e.g. "Maps: 3 of 10" */
 "downloader_status_maps" = "Maps";
 
 "downloader_download_all_button" = "Download All";

--- a/iphone/Maps/LocalizedStrings/th.lproj/Localizable.strings
+++ b/iphone/Maps/LocalizedStrings/th.lproj/Localizable.strings
@@ -26,9 +26,6 @@
 /* Leave Review dialog - Review button */
 "leave_a_review" = "ให้คำวิจารณ์";
 
-/* View and button titles for accessibility */
-"maps" = "แผนที่";
-
 /* Choose measurement on first launch alert - choose imperial system button */
 "miles" = "ไมล์";
 
@@ -321,7 +318,7 @@
 /* Update all button text */
 "downloader_update_all_button" = "อัปเดตทั้งหมด";
 
-/* Downloaded maps category */
+/* Downloaded maps list header */
 "downloader_downloaded_subtitle" = "ดาวน์โหลดแล้ว";
 
 /* Downloaded maps category */
@@ -332,6 +329,7 @@
 
 "downloader_near_me_subtitle" = "ใกล้ฉัน";
 
+/* In maps downloader and country place page shows how many maps are downloaded / to download, e.g. "Maps: 3 of 10" */
 "downloader_status_maps" = "แผนที่";
 
 "downloader_download_all_button" = "ดาวน์โหลดทั้งหมด";

--- a/iphone/Maps/LocalizedStrings/tr.lproj/Localizable.strings
+++ b/iphone/Maps/LocalizedStrings/tr.lproj/Localizable.strings
@@ -26,9 +26,6 @@
 /* Leave Review dialog - Review button */
 "leave_a_review" = "Bir Yorum Bırak";
 
-/* View and button titles for accessibility */
-"maps" = "Haritalar";
-
 /* Choose measurement on first launch alert - choose imperial system button */
 "miles" = "Mil";
 
@@ -321,7 +318,7 @@
 /* Update all button text */
 "downloader_update_all_button" = "Tümünü güncelle";
 
-/* Downloaded maps category */
+/* Downloaded maps list header */
 "downloader_downloaded_subtitle" = "İndirilenler";
 
 /* Downloaded maps category */
@@ -332,6 +329,7 @@
 
 "downloader_near_me_subtitle" = "Yakınlarımda";
 
+/* In maps downloader and country place page shows how many maps are downloaded / to download, e.g. "Maps: 3 of 10" */
 "downloader_status_maps" = "Haritalar";
 
 "downloader_download_all_button" = "Hepsini İndir";

--- a/iphone/Maps/LocalizedStrings/uk.lproj/Localizable.strings
+++ b/iphone/Maps/LocalizedStrings/uk.lproj/Localizable.strings
@@ -26,9 +26,6 @@
 /* Leave Review dialog - Review button */
 "leave_a_review" = "Написати відгук";
 
-/* View and button titles for accessibility */
-"maps" = "Мапи";
-
 /* Choose measurement on first launch alert - choose imperial system button */
 "miles" = "Милі";
 
@@ -321,7 +318,7 @@
 /* Update all button text */
 "downloader_update_all_button" = "Оновити всі";
 
-/* Downloaded maps category */
+/* Downloaded maps list header */
 "downloader_downloaded_subtitle" = "Завантажено";
 
 /* Downloaded maps category */
@@ -332,6 +329,7 @@
 
 "downloader_near_me_subtitle" = "Поблизу";
 
+/* In maps downloader and country place page shows how many maps are downloaded / to download, e.g. "Maps: 3 of 10" */
 "downloader_status_maps" = "Мапи";
 
 "downloader_download_all_button" = "Завантажити всі";

--- a/iphone/Maps/LocalizedStrings/vi.lproj/Localizable.strings
+++ b/iphone/Maps/LocalizedStrings/vi.lproj/Localizable.strings
@@ -26,9 +26,6 @@
 /* Leave Review dialog - Review button */
 "leave_a_review" = "Để lại Đánh giá";
 
-/* View and button titles for accessibility */
-"maps" = "Bản đồ";
-
 /* Choose measurement on first launch alert - choose imperial system button */
 "miles" = "Dặm";
 
@@ -321,7 +318,7 @@
 /* Update all button text */
 "downloader_update_all_button" = "Cập nhật tất cả";
 
-/* Downloaded maps category */
+/* Downloaded maps list header */
 "downloader_downloaded_subtitle" = "Đã tải xuống";
 
 /* Downloaded maps category */
@@ -332,6 +329,7 @@
 
 "downloader_near_me_subtitle" = "Gần tôi";
 
+/* In maps downloader and country place page shows how many maps are downloaded / to download, e.g. "Maps: 3 of 10" */
 "downloader_status_maps" = "Bản đồ";
 
 "downloader_download_all_button" = "Tải xuống tất cả";

--- a/iphone/Maps/LocalizedStrings/zh-Hans.lproj/Localizable.strings
+++ b/iphone/Maps/LocalizedStrings/zh-Hans.lproj/Localizable.strings
@@ -26,9 +26,6 @@
 /* Leave Review dialog - Review button */
 "leave_a_review" = "发表评论";
 
-/* View and button titles for accessibility */
-"maps" = "地图";
-
 /* Choose measurement on first launch alert - choose imperial system button */
 "miles" = "英里";
 
@@ -321,7 +318,7 @@
 /* Update all button text */
 "downloader_update_all_button" = "更新全部";
 
-/* Downloaded maps category */
+/* Downloaded maps list header */
 "downloader_downloaded_subtitle" = "已下载";
 
 /* Downloaded maps category */
@@ -332,6 +329,7 @@
 
 "downloader_near_me_subtitle" = "在我附近";
 
+/* In maps downloader and country place page shows how many maps are downloaded / to download, e.g. "Maps: 3 of 10" */
 "downloader_status_maps" = "地图";
 
 "downloader_download_all_button" = "下载全部";

--- a/iphone/Maps/LocalizedStrings/zh-Hant.lproj/Localizable.strings
+++ b/iphone/Maps/LocalizedStrings/zh-Hant.lproj/Localizable.strings
@@ -26,9 +26,6 @@
 /* Leave Review dialog - Review button */
 "leave_a_review" = "撰寫評論";
 
-/* View and button titles for accessibility */
-"maps" = "地圖";
-
 /* Choose measurement on first launch alert - choose imperial system button */
 "miles" = "英哩";
 
@@ -321,7 +318,7 @@
 /* Update all button text */
 "downloader_update_all_button" = "更新全部";
 
-/* Downloaded maps category */
+/* Downloaded maps list header */
 "downloader_downloaded_subtitle" = "已下載";
 
 /* Downloaded maps category */
@@ -332,6 +329,7 @@
 
 "downloader_near_me_subtitle" = "在我附近";
 
+/* In maps downloader and country place page shows how many maps are downloaded / to download, e.g. "Maps: 3 of 10" */
 "downloader_status_maps" = "地圖";
 
 "downloader_download_all_button" = "下載全部";


### PR DESCRIPTION
- refactor & simplify messy code
- update Save Maps To UI
- add storage labels (get them from the system on Android 7+)
- add storage total sizes
- improve storage sanity checks
- more logging details
- keep using currently configured storage even if its read-only

upd: storage selection priorities are left intact (external (SD) first, then internal, "emulated" is omitted still - I plan to address #2451 it in a separate PR).