### PR TITLE
Allow emulated storage

### DIFF
--- a/android/res/values-be/strings.xml
+++ b/android/res/values-be/strings.xml
@@ -81,10 +81,16 @@
 	<string name="maps_storage_summary">Выберыце месца, дзе захоўваць запампаваныя мапы</string>
 	<!-- E.g. "Downloaded maps: 500Mb" in Maps Storage settings -->
 	<string name="maps_storage_downloaded">Мапы</string>
+	<!-- Internal storage type in Maps Storage settings (not accessible by the user) -->
+	<string name="maps_storage_internal">Унутранае прыватнае сховішча</string>
 	<!-- Shared storage type in Maps Storage settings (a primary storage usually) -->
 	<string name="maps_storage_shared">Унутранае абагуленае сховішча</string>
 	<!-- Removable external storage type in Maps Storage settings, e.g. an SD card -->
 	<string name="maps_storage_removable">SD-карта</string>
+	<!-- Generic external storage type in Maps Storage settings -->
+	<string name="maps_storage_external">Знешняе абагульнае сховішча</string>
+	<!-- Free space out of total storage size in Maps Storage settings, e.g. "300 MB free of 2 GB" -->
+	<string name="maps_storage_free_size">%1$s вольна з %2$s</string>
 	<!-- Question dialog for transferring maps from one storage to another -->
 	<string name="move_maps">Перамясціць мапы?</string>
 	<!-- Ask to wait user several minutes (some long process in modal dialog). -->

--- a/android/res/values-ru/strings.xml
+++ b/android/res/values-ru/strings.xml
@@ -89,8 +89,8 @@
 	<string name="maps_storage_removable">SD-карта</string>
 	<!-- Generic external storage type in Maps Storage settings -->
 	<string name="maps_storage_external">Внешний общий накопитель</string>
-	<!-- Free space out of total storage size in Maps Storage settings, e.g. "300 MB free (of 2 GB)" -->
-	<string name="maps_storage_free_size">%1$s свободно (из %2$s)</string>
+	<!-- Free space out of total storage size in Maps Storage settings, e.g. "300 MB free of 2 GB" -->
+	<string name="maps_storage_free_size">%1$s свободно из %2$s</string>
 	<!-- Question dialog for transferring maps from one storage to another -->
 	<string name="move_maps">Переместить карты?</string>
 	<!-- Error moving map files from one storage to another -->

--- a/android/res/values-uk/strings.xml
+++ b/android/res/values-uk/strings.xml
@@ -82,13 +82,15 @@
 	<!-- E.g. "Downloaded maps: 500Mb" in Maps Storage settings -->
 	<string name="maps_storage_downloaded">Завантаженнi мапи</string>
 	<!-- Internal storage type in Maps Storage settings (not accessible by the user) -->
-	<string name="maps_storage_internal">Внутрішнє зховане сховище</string>
+	<string name="maps_storage_internal">Внутрішнє приватне сховище</string>
 	<!-- Shared storage type in Maps Storage settings (a primary storage usually) -->
 	<string name="maps_storage_shared">Внутрішнє спільне сховище</string>
 	<!-- Removable external storage type in Maps Storage settings, e.g. an SD card -->
 	<string name="maps_storage_removable">SD-карта</string>
 	<!-- Generic external storage type in Maps Storage settings -->
 	<string name="maps_storage_external">Зовнiшне спільне сховище</string>
+	<!-- Free space out of total storage size in Maps Storage settings, e.g. "300 MB free of 2 GB" -->
+	<string name="maps_storage_free_size">%1$s вільно з %2$s</string>
 	<!-- Question dialog for transferring maps from one storage to another -->
 	<string name="move_maps">Перемістити мапи?</string>
 	<!-- Ask to wait user several minutes (some long process in modal dialog). -->

--- a/android/res/values/strings.xml
+++ b/android/res/values/strings.xml
@@ -82,15 +82,15 @@
 	<!-- E.g. "Downloaded maps: 500Mb" in Maps Storage settings -->
 	<string name="maps_storage_downloaded">Downloaded maps</string>
 	<!-- Internal storage type in Maps Storage settings (not accessible by the user) -->
-	<string name="maps_storage_internal">Internal hidden storage</string>
+	<string name="maps_storage_internal">Internal private storage</string>
 	<!-- Shared storage type in Maps Storage settings (a primary storage usually) -->
 	<string name="maps_storage_shared">Internal shared storage</string>
 	<!-- Removable external storage type in Maps Storage settings, e.g. an SD card -->
 	<string name="maps_storage_removable">SD card</string>
 	<!-- Generic external storage type in Maps Storage settings -->
 	<string name="maps_storage_external">External shared storage</string>
-	<!-- Free space out of total storage size in Maps Storage settings, e.g. "300 MB free (of 2 GB)" -->
-	<string name="maps_storage_free_size">%1$s free (of %2$s)</string>
+	<!-- Free space out of total storage size in Maps Storage settings, e.g. "300 MB free of 2 GB" -->
+	<string name="maps_storage_free_size">%1$s free of %2$s</string>
 	<!-- Question dialog for transferring maps from one storage to another -->
 	<string name="move_maps">Move maps?</string>
 	<!-- Error moving map files from one storage to another -->

--- a/android/src/com/mapswithme/maps/settings/StorageItem.java
+++ b/android/src/com/mapswithme/maps/settings/StorageItem.java
@@ -5,16 +5,11 @@ package com.mapswithme.maps.settings;
  */
 public class StorageItem
 {
-  // Path to the root of writable directory.
-  private final String mPath;
-  // Free size.
-  private final long mFreeSize;
-  // Total size.
-  private final long mTotalSize;
-  // User-visible description.
-  private final String mLabel;
-  // Is it read-only storage?
-  private final boolean mReadonly;
+  public final String mPath;
+  public final long mFreeSize;
+  public final long mTotalSize;
+  public final String mLabel;
+  public final boolean mIsReadonly;
 
   public StorageItem(String path, long freeSize, long totalSize, final String label, boolean isReadonly)
   {
@@ -22,7 +17,7 @@ public class StorageItem
     mFreeSize = freeSize;
     mTotalSize = totalSize;
     mLabel = label;
-    mReadonly = isReadonly;
+    mIsReadonly = isReadonly;
   }
 
   @Override
@@ -33,9 +28,7 @@ public class StorageItem
     if (o == null || !(o instanceof StorageItem))
       return false;
     StorageItem other = (StorageItem) o;
-    // Storage equal is considered equal, either its path OR size equals to another one's.
-    // Size of storage free space can change dynamically, so that hack provides us with better results identifying the same storages.
-    return mFreeSize == other.getFreeSize() || mPath.equals(other.getFullPath());
+    return mPath.equals(other.mPath);
   }
 
   @Override
@@ -44,30 +37,5 @@ public class StorageItem
     // Yes, do not put StorageItem to Hash containers, performance will be awful.
     // At least such hash is compatible with hacky equals.
     return 0;
-  }
-
-  public String getFullPath()
-  {
-    return mPath;
-  }
-
-  public long getFreeSize()
-  {
-    return mFreeSize;
-  }
-
-  public long getTotalSize()
-  {
-    return mTotalSize;
-  }
-
-  public String getLabel()
-  {
-    return mLabel;
-  }
-
-  public boolean isReadonly()
-  {
-    return mReadonly;
   }
 }

--- a/android/src/com/mapswithme/maps/settings/StoragePathAdapter.java
+++ b/android/src/com/mapswithme/maps/settings/StoragePathAdapter.java
@@ -30,13 +30,13 @@ class StoragePathAdapter extends BaseAdapter
   @Override
   public int getCount()
   {
-    return (mPathManager.getStorageItems() == null ? 0 : mPathManager.getStorageItems().size());
+    return (mPathManager.mStorages == null ? 0 : mPathManager.mStorages.size());
   }
 
   @Override
   public StorageItem getItem(int position)
   {
-    return mPathManager.getStorageItems().get(position);
+    return mPathManager.mStorages.get(position);
   }
 
   @Override
@@ -51,23 +51,23 @@ class StoragePathAdapter extends BaseAdapter
     if (convertView == null)
       convertView = mActivity.getLayoutInflater().inflate(R.layout.item_storage, parent, false);
 
-    StorageItem item = mPathManager.getStorageItems().get(position);
-    final boolean isCurrent = position == mPathManager.getCurrentStorageIndex();
+    StorageItem item = mPathManager.mStorages.get(position);
+    final boolean isCurrent = position == mPathManager.mCurrentStorageIndex;
     CheckedTextView checkedView = (CheckedTextView) convertView;
     checkedView.setChecked(isCurrent);
-    checkedView.setEnabled(!item.isReadonly() && (isStorageBigEnough(position) || isCurrent));
+    checkedView.setEnabled(!item.mIsReadonly && (isStorageBigEnough(position) || isCurrent));
 
     final String size = mActivity.getString(R.string.maps_storage_free_size,
-                                            Formatter.formatShortFileSize(mActivity, item.getFreeSize()),
-                                            Formatter.formatShortFileSize(mActivity, item.getTotalSize()));
+                                            Formatter.formatShortFileSize(mActivity, item.mFreeSize),
+                                            Formatter.formatShortFileSize(mActivity, item.mTotalSize));
 
-    SpannableStringBuilder sb = new SpannableStringBuilder(item.getLabel() + "\n" + size);
+    SpannableStringBuilder sb = new SpannableStringBuilder(item.mLabel + "\n" + size);
     sb.setSpan(new ForegroundColorSpan(ThemeUtils.getColor(mActivity, android.R.attr.textColorSecondary)),
                sb.length() - size.length(), sb.length(), Spanned.SPAN_EXCLUSIVE_EXCLUSIVE);
     sb.setSpan(new AbsoluteSizeSpan(UiUtils.dimen(mActivity, R.dimen.text_size_body_3)),
                sb.length() - size.length(), sb.length(), Spanned.SPAN_EXCLUSIVE_EXCLUSIVE);
 
-    final String path = item.getFullPath() + (item.isReadonly() ? " (read-only)" : "");
+    final String path = item.mPath + (item.mIsReadonly ? " (read-only)" : "");
     sb.append("\n" + path);
     sb.setSpan(new ForegroundColorSpan(ThemeUtils.getColor(mActivity, android.R.attr.textColorSecondary)),
                sb.length() - path.length(), sb.length(), Spanned.SPAN_EXCLUSIVE_EXCLUSIVE);
@@ -87,6 +87,6 @@ class StoragePathAdapter extends BaseAdapter
 
   public boolean isStorageBigEnough(int index)
   {
-    return mPathManager.getStorageItems().get(index).getFreeSize() >= mSizeNeeded;
+    return mPathManager.mStorages.get(index).mFreeSize >= mSizeNeeded;
   }
 }

--- a/android/src/com/mapswithme/maps/settings/StoragePathFragment.java
+++ b/android/src/com/mapswithme/maps/settings/StoragePathFragment.java
@@ -2,13 +2,12 @@ package com.mapswithme.maps.settings;
 
 import android.app.ProgressDialog;
 import android.os.Bundle;
+import android.text.format.Formatter;
 import android.view.LayoutInflater;
 import android.view.View;
 import android.view.ViewGroup;
-import android.widget.CheckedTextView;
 import android.widget.ListView;
 import android.widget.TextView;
-import android.text.format.Formatter;
 
 import androidx.annotation.NonNull;
 import androidx.appcompat.app.AlertDialog;
@@ -99,14 +98,14 @@ public class StoragePathFragment extends BaseSettingsFragment
    */
   public void changeStorage(int newIndex)
   {
-    final int currentIndex = mPathManager.getCurrentStorageIndex();
-    final List<StorageItem> items = mPathManager.getStorageItems();
-    if (newIndex == currentIndex || currentIndex == -1 || items.get(newIndex).isReadonly()
+    final int currentIndex = mPathManager.mCurrentStorageIndex;
+    final List<StorageItem> storages = mPathManager.mStorages;
+    if (newIndex == currentIndex || currentIndex == -1 || storages.get(newIndex).mIsReadonly
         || !mAdapter.isStorageBigEnough(newIndex))
       return;
 
-    final String oldPath = items.get(currentIndex).getFullPath();
-    final String newPath = items.get(newIndex).getFullPath();
+    final String oldPath = storages.get(currentIndex).mPath;
+    final String newPath = storages.get(newIndex).mPath;
 
     new AlertDialog.Builder(requireActivity())
         .setCancelable(false)
@@ -125,27 +124,25 @@ public class StoragePathFragment extends BaseSettingsFragment
     final ProgressDialog dialog = DialogUtils.createModalProgressDialog(requireActivity(), R.string.wait_several_minutes);
     dialog.show();
 
-    ThreadPool.getStorage().execute(() ->
-      {
-        final boolean result = mPathManager.moveStorage(newPath, oldPath);
+    ThreadPool.getStorage().execute(() -> {
+      final boolean result = mPathManager.moveStorage(newPath, oldPath);
 
-        UiThread.run(() ->
-          {
-           if (dialog.isShowing())
-             dialog.dismiss();
+      UiThread.run(() -> {
+        if (dialog.isShowing())
+          dialog.dismiss();
 
-           if (!result)
-           {
-             new AlertDialog.Builder(requireActivity())
-                 .setTitle(R.string.move_maps_error)
-                 .setPositiveButton(R.string.report_a_bug,
-                                    (dlg, which) -> Utils.sendBugReport(requireActivity(), "Error moving map files"))
-                 .show();
-           }
-           mPathManager.scanAvailableStorages();
-           updateList();
-          });
+        if (!result)
+        {
+          new AlertDialog.Builder(requireActivity())
+              .setTitle(R.string.move_maps_error)
+              .setPositiveButton(R.string.report_a_bug,
+                                 (dlg, which) -> Utils.sendBugReport(requireActivity(), "Error moving map files"))
+              .show();
+        }
+        mPathManager.scanAvailableStorages();
+        updateList();
       });
+    });
   }
 
   @Override

--- a/data/strings/strings.txt
+++ b/data/strings/strings.txt
@@ -1838,9 +1838,10 @@
   [maps_storage_internal]
     comment = Internal storage type in Maps Storage settings (not accessible by the user)
     tags = android
-    en = Internal hidden storage
+    en = Internal private storage
+    be = Унутранае прыватнае сховішча
     ru = Внутренний скрытый накопитель
-    uk = Внутрішнє зховане сховище
+    uk = Внутрішнє приватне сховище
 
   [maps_storage_shared]
     comment = Shared storage type in Maps Storage settings (a primary storage usually)
@@ -1862,14 +1863,17 @@
     comment = Generic external storage type in Maps Storage settings
     tags = android
     en = External shared storage
+    be = Знешняе абагульнае сховішча
     ru = Внешний общий накопитель
     uk = Зовнiшне спільне сховище
 
   [maps_storage_free_size]
-    comment = Free space out of total storage size in Maps Storage settings, e.g. "300 MB free (of 2 GB)"
+    comment = Free space out of total storage size in Maps Storage settings, e.g. "300 MB free of 2 GB"
     tags = android
-    en = %1$@ free (of %2$@)
-    ru = %1$@ свободно (из %2$@)
+    en = %1$@ free of %2$@
+    be = %1$@ вольна з %2$@
+    ru = %1$@ свободно из %2$@
+    uk = %1$@ вільно з %2$@
 
   [move_maps]
     comment = Question dialog for transferring maps from one storage to another


### PR DESCRIPTION
Allow "emulated" in available storages list.
For new installs (and if the storage with maps was removed) default to storage with the most free space.
Omit internal storage if it backs emulated one (same physical device) unless a user had "internal" as the currently configured storage.
If the user changes to any other storage (e.g. emulated) then "internal" will disappear from a list of available storages.

And minor changes as per review comments in #2566.



Sample logs:

"Internal" is omitted because its the same physical device as "emulated". Also a storage with the most free space is selected as no map files found:
```
2022-05-18 15:37:45.034 I/com.mapswithme.maps.settings.StoragePathManager: Currently configured storage: N/A
2022-05-18 15:37:45.034 I/com.mapswithme.maps.settings.StoragePathManager: Begin scanning storages
2022-05-18 15:37:45.043 I/com.mapswithme.maps.settings.StoragePathManager: Accepted /storage/emulated/0/Android/data/app.organicmaps.debug/files/ - external, 2191511552 available out of 53689729024 bytes, emulated, state=mounted, primary, label='Internal shared storage'
2022-05-18 15:37:45.047 I/com.mapswithme.maps.settings.StoragePathManager: Accepted /storage/0B1E-18F9/Android/data/app.organicmaps.debug/files/ - external, 1383104512 available out of 7817265152 bytes, removable, state=mounted, uuid=0B1E-18F9, label='SD card'
2022-05-18 15:37:45.047 I/com.mapswithme.maps.settings.StoragePathManager: Duplicate, backs emulated (/storage/emulated/0/Android/data/app.organicmaps.debug/files/): /data/data/app.organicmaps.debug/files/ (/data/user/0/app.organicmaps.debug/files) - internal, 2191511552 available out of 53689729024 bytes
2022-05-18 15:37:45.048 I/com.mapswithme.maps.settings.StoragePathManager: End scanning storages
2022-05-18 15:37:45.048 I/com.mapswithme.maps.settings.StoragePathManager: Looking for map files in available storages...
2022-05-18 15:37:45.049 I/com.mapswithme.maps.settings.StoragePathManager: No map files found at /storage/emulated/0/Android/data/app.organicmaps.debug/files/
2022-05-18 15:37:45.049 I/com.mapswithme.maps.settings.StoragePathManager: No map files found at /storage/0B1E-18F9/Android/data/app.organicmaps.debug/files/
2022-05-18 15:37:45.049 I/com.mapswithme.maps.settings.StoragePathManager: Defaulting to a storage with the most free space: /storage/emulated/0/Android/data/app.organicmaps.debug/files/
```

"Internal" allowed because its the currently configured one (so the user can migrate):
```
I/com.mapswithme.maps.settings.StoragePathManager: Currently configured storage: /data/data/app.organicmaps.debug/files/
I/com.mapswithme.maps.settings.StoragePathManager: Begin scanning storages
I/com.mapswithme.maps.settings.StoragePathManager: Accepted /storage/emulated/0/Android/data/app.organicmaps.debug/files/ - external, 2068582400 available out of 53689729024 bytes, emulated, state=mounted, primary, label='Internal shared storage'
I/com.mapswithme.maps.settings.StoragePathManager: Accepted /storage/0B1E-18F9/Android/data/app.organicmaps.debug/files/ - external, 974716928 available out of 7817265152 bytes, removable, state=mounted, uuid=0B1E-18F9, label='SD card'
I/com.mapswithme.maps.settings.StoragePathManager: Accepted /data/data/app.organicmaps.debug/files/ (/data/user/0/app.organicmaps.debug/files) - currently configured, internal, 2068582400 available out of 53689729024 bytes, backs emulated (/storage/emulated/0/Android/data/app.organicmaps.debug/files/)
I/com.mapswithme.maps.settings.StoragePathManager: End scanning storages
```
