### PR TITLE
Issue 2052 wikipedia link from street relation

### DIFF
--- a/generator/generator_tests/CMakeLists.txt
+++ b/generator/generator_tests/CMakeLists.txt
@@ -38,6 +38,7 @@ set(SRC
   osm_o5m_source_test.cpp
   osm_type_test.cpp
   place_processor_tests.cpp
+  relation_tags_tests.cpp
   restriction_collector_test.cpp
   restriction_test.cpp
   road_access_test.cpp

--- a/generator/generator_tests/collector_building_parts_tests.cpp
+++ b/generator/generator_tests/collector_building_parts_tests.cpp
@@ -30,7 +30,9 @@ public:
   }
 
   // OSMElementCacheReaderInterface overrides:
-  bool Read(generator::cache::Key /* id */, WayElement & /* value */) override { UNREACHABLE(); }
+  bool Read(generator::cache::Key /* id */, WayElement & /* value */) override {
+    CHECK(false, ("Should not be called"));
+  }
 
   bool Read(generator::cache::Key id, RelationElement & value) override
   {

--- a/generator/generator_tests/relation_tags_tests.cpp
+++ b/generator/generator_tests/relation_tags_tests.cpp
@@ -6,9 +6,9 @@
 
 namespace relation_tags_tests
 {
-using namespace generator_tests;
-using namespace generator;
 using namespace feature;
+using namespace generator;
+using namespace generator_tests;
 using namespace std;
 
 // In memory relations storage (copy-n-paste from collector_building_parts_tests.cpp).
@@ -21,7 +21,9 @@ public:
   }
 
   // OSMElementCacheReaderInterface overrides:
-  bool Read(generator::cache::Key /* id */, WayElement & /* value */) override { UNREACHABLE(); }
+  bool Read(generator::cache::Key /* id */, WayElement & /* value */) override {
+    CHECK(false, ("Should not be called"));
+  }
 
   bool Read(generator::cache::Key id, RelationElement & value) override
   {
@@ -53,8 +55,7 @@ UNIT_TEST(Process_route_with_ref) {
    */
 
   // Create relation.
-  std::vector<RelationElement::Member> testMembers = {{10, ""},
-                                                      {11, ""}};
+  std::vector<RelationElement::Member> testMembers = {{10, ""}, {11, ""}};
 
   RelationElement e1;
   e1.m_ways = testMembers;
@@ -65,15 +66,12 @@ UNIT_TEST(Process_route_with_ref) {
   std::unordered_map<generator::cache::Key, RelationElement> m_IdToRelation = {{1, e1}};
   TestOSMElementCacheReader reader(m_IdToRelation);
 
-  // Create buildings polygons.
-  auto road10 = MakeOsmElement(10, {{"highway", "motorway"}},
-  OsmElement::EntityType::Way);
+  // Create roads.
+  auto road10 = MakeOsmElement(10, {{"highway", "motorway"}}, OsmElement::EntityType::Way);
 
-  auto road11 = MakeOsmElement(11, {{"highway", "motorway"},
-    {"ref", "F-16"}},
-  OsmElement::EntityType::Way);
+  auto road11 = MakeOsmElement(11, {{"highway", "motorway"}, {"ref", "F-16"}}, OsmElement::EntityType::Way);
 
-  // Process road tags using relation tags.
+  // Process roads tags using relation tags.
   RelationTagsWay rtw;
 
   rtw.Reset(10, &road10);
@@ -82,7 +80,7 @@ UNIT_TEST(Process_route_with_ref) {
   rtw.Reset(11, &road11);
   rtw(1, reader);
 
-  // Verify ways tags.
+  // Verify roads tags.
   TEST_EQUAL(road10.GetTag("ref"), "E-99", ());
   TEST_EQUAL(road11.GetTag("ref"), "F-16", ());
 }
@@ -105,8 +103,7 @@ UNIT_TEST(Process_route_with_ref_network) {
    */
 
   // Create relation.
-  std::vector<RelationElement::Member> testMembers = {{10, ""},
-                                                      {11, ""}};
+  std::vector<RelationElement::Member> testMembers = {{10, ""}, {11, ""}};
 
   RelationElement e1;
   e1.m_ways = testMembers;
@@ -118,16 +115,12 @@ UNIT_TEST(Process_route_with_ref_network) {
   std::unordered_map<generator::cache::Key, RelationElement> m_IdToRelation = {{1, e1}};
   TestOSMElementCacheReader reader(m_IdToRelation);
 
-  // Create buildings polygons.
-  auto road10 = MakeOsmElement(10, {{"highway", "motorway"},
-    {"name", "Via Corleto"}},
-  OsmElement::EntityType::Way);
+  // Create roads.
+  auto road10 = MakeOsmElement(10, {{"highway", "motorway"}, {"name", "Via Corleto"}}, OsmElement::EntityType::Way);
 
-  auto road11 = MakeOsmElement(11, {{"highway", "motorway"},
-    {"ref", "SP62"}},
-  OsmElement::EntityType::Way);
+  auto road11 = MakeOsmElement(11, {{"highway", "motorway"}, {"ref", "SP62"}}, OsmElement::EntityType::Way);
 
-  // Process road tags using relation tags.
+  // Process roads tags using relation tags.
   RelationTagsWay rtw;
 
   rtw.Reset(10, &road10);
@@ -136,7 +129,7 @@ UNIT_TEST(Process_route_with_ref_network) {
   rtw.Reset(11, &road11);
   rtw(1, reader);
 
-  // Verify ways tags.
+  // Verify roads tags.
   TEST_EQUAL(road10.GetTag("ref"), "IT:RA/SP60", ());
   TEST_EQUAL(road11.GetTag("ref"), "SP62", ());
 }
@@ -160,8 +153,7 @@ UNIT_TEST(Process_associatedStreet) {
    */
 
   // Create relation.
-  std::vector<RelationElement::Member> testMembers = {{2, "house"},
-                                                      {3, "house"}};
+  std::vector<RelationElement::Member> testMembers = {{2, "house"}, {3, "house"}};
 
   RelationElement e1;
   e1.m_ways = testMembers;
@@ -173,17 +165,11 @@ UNIT_TEST(Process_associatedStreet) {
   TestOSMElementCacheReader reader(m_IdToRelation);
 
   // Create buildings polygons.
-  auto buildingWay2 = MakeOsmElement(2, {{"building", "yes"},
-    {"addr:housenumber", "121"}},
-  OsmElement::EntityType::Way);
+  auto buildingWay2 = MakeOsmElement(2, {{"building", "yes"}, {"addr:housenumber", "121"}}, OsmElement::EntityType::Way);
 
-  auto buildingWay3 = MakeOsmElement(3, {{"auto const", "yes"},
-    {"addr:housenumber", "123"},
-    {"addr:street", "The Main Street"},
-    {"wikipedia", "en:Mega Theater"}},
-  OsmElement::EntityType::Way);
+  auto buildingWay3 = MakeOsmElement(3, {{"auto const", "yes"}, {"addr:housenumber", "123"}, {"addr:street", "The Main Street"}, {"wikipedia", "en:Mega Theater"}}, OsmElement::EntityType::Way);
 
-  // Process way tags using relation tags.
+  // Process buildings tags using relation tags.
   RelationTagsWay rtw;
 
   rtw.Reset(2, &buildingWay2);
@@ -216,8 +202,7 @@ UNIT_TEST(Process_boundary) {
    */
 
   // Create relation.
-  std::vector<RelationElement::Member> testMembers = {{5, "outer"},
-                                                      {6, "outer"}};
+  std::vector<RelationElement::Member> testMembers = {{5, "outer"}, {6, "outer"}};
 
   RelationElement e1;
   e1.m_ways = testMembers;
@@ -230,15 +215,12 @@ UNIT_TEST(Process_boundary) {
   std::unordered_map<generator::cache::Key, RelationElement> m_IdToRelation = {{1, e1}};
   TestOSMElementCacheReader reader(m_IdToRelation);
 
-  // Create buildings polygons.
-  auto outerWay5 = MakeOsmElement(5, {{"natural", "coastline"}},
-  OsmElement::EntityType::Way);
+  // Create ways.
+  auto outerWay5 = MakeOsmElement(5, {{"natural", "coastline"}}, OsmElement::EntityType::Way);
 
-  auto outerWay6 = MakeOsmElement(6, {{"natural", "coastline"},
-    {"name", "Cala Rossa"}},
-  OsmElement::EntityType::Way);
+  auto outerWay6 = MakeOsmElement(6, {{"natural", "coastline"}, {"name", "Cala Rossa"}}, OsmElement::EntityType::Way);
 
-  // Process way tags using relation tags.
+  // Process ways tags using relation tags.
   RelationTagsWay rtw;
 
   rtw.Reset(5, &outerWay5);

--- a/generator/generator_tests/relation_tags_tests.cpp
+++ b/generator/generator_tests/relation_tags_tests.cpp
@@ -4,6 +4,7 @@
 #include "generator/relation_tags.hpp"
 #include "generator/intermediate_data.hpp"
 
+// TODO: Rewrite this tests using RelationTagsEnricher with some test mock of IntermediateDataReaderInterface.
 namespace relation_tags_tests
 {
 using namespace feature;
@@ -69,7 +70,6 @@ UNIT_TEST(Process_route_with_ref)
 
   // Create roads.
   auto road10 = MakeOsmElement(10, {{"highway", "motorway"}}, OsmElement::EntityType::Way);
-
   auto road11 = MakeOsmElement(11, {{"highway", "motorway"}, {"ref", "F-16"}}, OsmElement::EntityType::Way);
 
   // Process roads tags using relation tags.
@@ -100,7 +100,7 @@ UNIT_TEST(Process_route_with_ref_network)
    *         - name = Via Corleto
    *       Way 11:
    *         - highway = motorway
-   *         - ref = SP60
+   *         - ref = SP62
    *     ]
    */
 
@@ -119,7 +119,6 @@ UNIT_TEST(Process_route_with_ref_network)
 
   // Create roads.
   auto road10 = MakeOsmElement(10, {{"highway", "motorway"}, {"name", "Via Corleto"}}, OsmElement::EntityType::Way);
-
   auto road11 = MakeOsmElement(11, {{"highway", "motorway"}, {"ref", "SP62"}}, OsmElement::EntityType::Way);
 
   // Process roads tags using relation tags.
@@ -133,7 +132,7 @@ UNIT_TEST(Process_route_with_ref_network)
 
   // Verify roads tags.
   TEST_EQUAL(road10.GetTag("ref"), "IT:RA/SP60", ());
-  TEST_EQUAL(road11.GetTag("ref"), "SP62", ());
+  TEST_EQUAL(road11.GetTag("ref"), "SP62", ()); // TODO: Check refs inheritance (expected "IT:RA/SP60;SP62")
 }
 
 UNIT_TEST(Process_associatedStreet)
@@ -169,7 +168,6 @@ UNIT_TEST(Process_associatedStreet)
 
   // Create buildings polygons.
   auto buildingWay2 = MakeOsmElement(2, {{"building", "yes"}, {"addr:housenumber", "121"}}, OsmElement::EntityType::Way);
-
   auto buildingWay3 = MakeOsmElement(3, {{"auto const", "yes"}, {"addr:housenumber", "123"}, {"addr:street", "The Main Street"}, {"wikipedia", "en:Mega Theater"}}, OsmElement::EntityType::Way);
 
   // Process buildings tags using relation tags.
@@ -221,7 +219,6 @@ UNIT_TEST(Process_boundary)
 
   // Create ways.
   auto outerWay5 = MakeOsmElement(5, {{"natural", "coastline"}}, OsmElement::EntityType::Way);
-
   auto outerWay6 = MakeOsmElement(6, {{"natural", "coastline"}, {"name", "Cala Rossa"}}, OsmElement::EntityType::Way);
 
   // Process ways tags using relation tags.

--- a/generator/generator_tests/relation_tags_tests.cpp
+++ b/generator/generator_tests/relation_tags_tests.cpp
@@ -9,23 +9,24 @@ namespace relation_tags_tests
 {
 using namespace feature;
 using namespace generator;
+using namespace generator::cache;
 using namespace generator_tests;
 
 // In memory relations storage (copy-n-paste from collector_building_parts_tests.cpp).
-class TestOSMElementCacheReader : public cache::OSMElementCacheReaderInterface
+class TestOSMElementCacheReader : public OSMElementCacheReaderInterface
 {
 public:
-  TestOSMElementCacheReader(std::unordered_map<cache::Key, RelationElement> & m)
+  TestOSMElementCacheReader(std::unordered_map<Key, RelationElement> & m)
     : m_mapping(m)
   {
   }
 
   // OSMElementCacheReaderInterface overrides:
-  bool Read(cache::Key /* id */, WayElement & /* value */) override {
+  bool Read(Key /* id */, WayElement & /* value */) override {
     CHECK(false, ("Should not be called"));
   }
 
-  bool Read(cache::Key id, RelationElement & value) override
+  bool Read(Key id, RelationElement & value) override
   {
     auto const it = m_mapping.find(id);
     if (it == std::cend(m_mapping))
@@ -36,7 +37,7 @@ public:
   }
 
 private:
-  std::unordered_map<cache::Key, RelationElement> & m_mapping;
+  std::unordered_map<Key, RelationElement> & m_mapping;
 };
 
 UNIT_TEST(Process_route_with_ref)
@@ -64,7 +65,7 @@ UNIT_TEST(Process_route_with_ref)
   e1.m_tags.emplace("route", "road");
   e1.m_tags.emplace("ref", "E-99");
 
-  std::unordered_map<cache::Key, RelationElement> m_IdToRelation = {{1, e1}};
+  std::unordered_map<Key, RelationElement> m_IdToRelation = {{1, e1}};
   TestOSMElementCacheReader reader(m_IdToRelation);
 
   // Create roads.
@@ -113,7 +114,7 @@ UNIT_TEST(Process_route_with_ref_network)
   e1.m_tags.emplace("ref", "SP60");
   e1.m_tags.emplace("network", "IT:RA");
 
-  std::unordered_map<cache::Key, RelationElement> m_IdToRelation = {{1, e1}};
+  std::unordered_map<Key, RelationElement> m_IdToRelation = {{1, e1}};
   TestOSMElementCacheReader reader(m_IdToRelation);
 
   // Create roads.
@@ -162,7 +163,7 @@ UNIT_TEST(Process_associatedStreet)
   e1.m_tags.emplace("name", "Main Street");
   e1.m_tags.emplace("wikipedia", "en:Main Street");
 
-  std::unordered_map<cache::Key, RelationElement> m_IdToRelation = {{1, e1}};
+  std::unordered_map<Key, RelationElement> m_IdToRelation = {{1, e1}};
   TestOSMElementCacheReader reader(m_IdToRelation);
 
   // Create buildings polygons.
@@ -213,7 +214,7 @@ UNIT_TEST(Process_boundary)
   e1.m_tags.emplace("name:en", "Italian Peninsula");
   e1.m_tags.emplace("wikidata", "Q145694");
 
-  std::unordered_map<cache::Key, RelationElement> m_IdToRelation = {{1, e1}};
+  std::unordered_map<Key, RelationElement> m_IdToRelation = {{1, e1}};
   TestOSMElementCacheReader reader(m_IdToRelation);
 
   // Create ways.

--- a/generator/generator_tests/relation_tags_tests.cpp
+++ b/generator/generator_tests/relation_tags_tests.cpp
@@ -39,7 +39,8 @@ private:
   std::unordered_map<generator::cache::Key, RelationElement> & m_mapping;
 };
 
-UNIT_TEST(Process_route_with_ref) {
+UNIT_TEST(Process_route_with_ref)
+{
   /* Prepare relations data:
    * Relation 1:
    *   - type = route
@@ -85,7 +86,8 @@ UNIT_TEST(Process_route_with_ref) {
   TEST_EQUAL(road11.GetTag("ref"), "F-16", ());
 }
 
-UNIT_TEST(Process_route_with_ref_network) {
+UNIT_TEST(Process_route_with_ref_network)
+{
   /* Prepare relations data:
    * Relation 1:
    *   - type = route
@@ -134,7 +136,8 @@ UNIT_TEST(Process_route_with_ref_network) {
   TEST_EQUAL(road11.GetTag("ref"), "SP62", ());
 }
 
-UNIT_TEST(Process_associatedStreet) {
+UNIT_TEST(Process_associatedStreet)
+{
   /* Prepare relations data:
    * Relation 1:
    *   - type = associatedStreet
@@ -186,7 +189,8 @@ UNIT_TEST(Process_associatedStreet) {
   TEST_EQUAL(buildingWay3.HasTag("wikipedia"), true, ());
 }
 
-UNIT_TEST(Process_boundary) {
+UNIT_TEST(Process_boundary)
+{
   /* Prepare relations data:
    * Relation 1:
    *   - type = boundary
@@ -240,6 +244,5 @@ UNIT_TEST(Process_boundary) {
   TEST_EQUAL(outerWay6.HasTag("name:en"), false, ());
   TEST_EQUAL(outerWay6.GetTag("wikidata"), "Q145694", ());
 }
-
 
 }

--- a/generator/generator_tests/relation_tags_tests.cpp
+++ b/generator/generator_tests/relation_tags_tests.cpp
@@ -4,29 +4,28 @@
 #include "generator/relation_tags.hpp"
 #include "generator/intermediate_data.hpp"
 
-// TODO: Rewrite this tests using RelationTagsEnricher with some test mock of IntermediateDataReaderInterface.
+// TODO: Rewrite these tests using RelationTagsEnricher with some test mock of IntermediateDataReaderInterface.
 namespace relation_tags_tests
 {
 using namespace feature;
 using namespace generator;
 using namespace generator_tests;
-using namespace std;
 
 // In memory relations storage (copy-n-paste from collector_building_parts_tests.cpp).
-class TestOSMElementCacheReader : public generator::cache::OSMElementCacheReaderInterface
+class TestOSMElementCacheReader : public cache::OSMElementCacheReaderInterface
 {
 public:
-  TestOSMElementCacheReader(std::unordered_map<generator::cache::Key, RelationElement> & m)
+  TestOSMElementCacheReader(std::unordered_map<cache::Key, RelationElement> & m)
     : m_mapping(m)
   {
   }
 
   // OSMElementCacheReaderInterface overrides:
-  bool Read(generator::cache::Key /* id */, WayElement & /* value */) override {
+  bool Read(cache::Key /* id */, WayElement & /* value */) override {
     CHECK(false, ("Should not be called"));
   }
 
-  bool Read(generator::cache::Key id, RelationElement & value) override
+  bool Read(cache::Key id, RelationElement & value) override
   {
     auto const it = m_mapping.find(id);
     if (it == std::cend(m_mapping))
@@ -37,7 +36,7 @@ public:
   }
 
 private:
-  std::unordered_map<generator::cache::Key, RelationElement> & m_mapping;
+  std::unordered_map<cache::Key, RelationElement> & m_mapping;
 };
 
 UNIT_TEST(Process_route_with_ref)
@@ -65,7 +64,7 @@ UNIT_TEST(Process_route_with_ref)
   e1.m_tags.emplace("route", "road");
   e1.m_tags.emplace("ref", "E-99");
 
-  std::unordered_map<generator::cache::Key, RelationElement> m_IdToRelation = {{1, e1}};
+  std::unordered_map<cache::Key, RelationElement> m_IdToRelation = {{1, e1}};
   TestOSMElementCacheReader reader(m_IdToRelation);
 
   // Create roads.
@@ -114,7 +113,7 @@ UNIT_TEST(Process_route_with_ref_network)
   e1.m_tags.emplace("ref", "SP60");
   e1.m_tags.emplace("network", "IT:RA");
 
-  std::unordered_map<generator::cache::Key, RelationElement> m_IdToRelation = {{1, e1}};
+  std::unordered_map<cache::Key, RelationElement> m_IdToRelation = {{1, e1}};
   TestOSMElementCacheReader reader(m_IdToRelation);
 
   // Create roads.
@@ -163,7 +162,7 @@ UNIT_TEST(Process_associatedStreet)
   e1.m_tags.emplace("name", "Main Street");
   e1.m_tags.emplace("wikipedia", "en:Main Street");
 
-  std::unordered_map<generator::cache::Key, RelationElement> m_IdToRelation = {{1, e1}};
+  std::unordered_map<cache::Key, RelationElement> m_IdToRelation = {{1, e1}};
   TestOSMElementCacheReader reader(m_IdToRelation);
 
   // Create buildings polygons.
@@ -214,7 +213,7 @@ UNIT_TEST(Process_boundary)
   e1.m_tags.emplace("name:en", "Italian Peninsula");
   e1.m_tags.emplace("wikidata", "Q145694");
 
-  std::unordered_map<generator::cache::Key, RelationElement> m_IdToRelation = {{1, e1}};
+  std::unordered_map<cache::Key, RelationElement> m_IdToRelation = {{1, e1}};
   TestOSMElementCacheReader reader(m_IdToRelation);
 
   // Create ways.

--- a/generator/generator_tests/relation_tags_tests.cpp
+++ b/generator/generator_tests/relation_tags_tests.cpp
@@ -2,7 +2,7 @@
 
 #include "generator/generator_tests/common.hpp"
 #include "generator/relation_tags.hpp"
-
+#include "generator/intermediate_data.hpp"
 
 namespace relation_tags_tests
 {

--- a/generator/generator_tests/relation_tags_tests.cpp
+++ b/generator/generator_tests/relation_tags_tests.cpp
@@ -1,0 +1,99 @@
+#include "testing/testing.hpp"
+
+#include "generator/generator_tests/common.hpp"
+#include "generator/relation_tags.hpp"
+
+
+namespace relation_tags_tests
+{
+using namespace generator_tests;
+using namespace generator;
+using namespace feature;
+using namespace std;
+
+// In memory relations storage (copy-n-paste from collector_building_parts_tests.cpp).
+class TestOSMElementCacheReader : public generator::cache::OSMElementCacheReaderInterface
+{
+public:
+  TestOSMElementCacheReader(std::unordered_map<generator::cache::Key, RelationElement> & m)
+    : m_mapping(m)
+  {
+  }
+
+  // OSMElementCacheReaderInterface overrides:
+  bool Read(generator::cache::Key /* id */, WayElement & /* value */) override { UNREACHABLE(); }
+
+  bool Read(generator::cache::Key id, RelationElement & value) override
+  {
+    auto const it = m_mapping.find(id);
+    if (it == std::cend(m_mapping))
+      return false;
+
+    value = it->second;
+    return true;
+  }
+
+private:
+  std::unordered_map<generator::cache::Key, RelationElement> & m_mapping;
+};
+
+
+UNIT_TEST() {
+  /* Prepare relations data:
+   * Relation 1:
+   *   - type = associatedStreet
+   *   - name = Main street
+   *   - wikipedia = en:Main Street
+   *   - members: [
+   *       Way 2:
+   *         - building = yes
+   *         - addr:housenumber = 121
+   *       Way 3:
+   *         - building = house
+   *         - addr:housenumber = 123
+   *         - addr:street = The Main Street
+   *     ]
+   */
+
+  // Create relation.
+  std::vector<RelationElement::Member> testMembers = {{2, "house"},
+                                                      {3, "house"}};
+
+  RelationElement e1;
+  e1.m_ways = testMembers;
+  e1.m_tags.emplace("type", "associatedStreet");
+  e1.m_tags.emplace("name", "Main Street");
+  e1.m_tags.emplace("wikipedia", "en:Main Street");
+
+  std::unordered_map<generator::cache::Key, RelationElement> m_IdToRelation = {{1, e1}};
+  TestOSMElementCacheReader reader(m_IdToRelation);
+
+  // Create buildings polygons.
+  auto buildingWay2 = MakeOsmElement(2, {{"building", "yes"},
+    {"addr:housenumber", "121"}},
+  OsmElement::EntityType::Way);
+
+  auto buildingWay3 = MakeOsmElement(3, {{"auto const", "yes"},
+    {"addr:housenumber", "123"},
+    {"addr:street", "The Main Street"},
+    {"wikipedia", "en:Mega Theater"}},
+  OsmElement::EntityType::Way);
+
+  // Process way tags using relation tags.
+  RelationTagsWay rtw;
+
+  rtw.Reset(2, &buildingWay2);
+  rtw(1, reader);
+
+  rtw.Reset(3, &buildingWay3);
+  rtw(1, reader);
+
+  // Verify ways tags.
+  TEST_EQUAL(buildingWay2.GetTag("addr:street"), "Main Street", ());
+  TEST_EQUAL(buildingWay2.HasTag("wikipedia"), false, ());
+
+  TEST_EQUAL(buildingWay3.GetTag("addr:street"), "The Main Street", ());
+  TEST_EQUAL(buildingWay3.HasTag("wikipedia"), true, ());
+}
+
+}

--- a/generator/relation_tags.cpp
+++ b/generator/relation_tags.cpp
@@ -100,10 +100,10 @@ void RelationTagsWay::Process(RelationElement const & e)
     return;
 
   bool const isBoundary = (type == "boundary") && IsAcceptBoundary(e);
-  bool const processAssociatedStreet = type == "associatedStreet" &&
+  bool const isAssociatedStreet = type == "associatedStreet";
+  bool const processAssociatedStreet = isAssociatedStreet &&
                                        Base::IsKeyTagExists("addr:housenumber") &&
                                        !Base::IsKeyTagExists("addr:street");
-  bool const isAssociatedStreet = type == "associatedStreet";
   bool const isHighway = Base::IsKeyTagExists("highway");
 
   for (auto const & p : e.m_tags)

--- a/generator/relation_tags.cpp
+++ b/generator/relation_tags.cpp
@@ -103,6 +103,7 @@ void RelationTagsWay::Process(RelationElement const & e)
   bool const processAssociatedStreet = type == "associatedStreet" &&
                                        Base::IsKeyTagExists("addr:housenumber") &&
                                        !Base::IsKeyTagExists("addr:street");
+  bool const isAssociatedStreet = type == "associatedStreet";
   bool const isHighway = Base::IsKeyTagExists("highway");
 
   for (auto const & p : e.m_tags)
@@ -121,6 +122,9 @@ void RelationTagsWay::Process(RelationElement const & e)
     {
       continue;
     }
+
+    if (isAssociatedStreet && p.first == "wikipedia")
+      continue;
 
     if (!isBoundary && p.first == "boundary")
       continue;


### PR DESCRIPTION
Closes #2052 

Added special case when `associatedStreet` relation has `wikipedia` tag then this tag should not be copied to relation members.