### PR TITLE
Fix disappearing map files after allowing emulated storage

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -26,7 +26,7 @@ buildscript {
   ext.googleFirebaseServicesEnabled = project.hasProperty('firebase') ?: googleFirebaseServicesDefault
 
   dependencies {
-    classpath 'com.android.tools.build:gradle:7.2.0'
+    classpath 'com.android.tools.build:gradle:7.2.1'
 
     if (googleMobileServicesEnabled) {
       println("Building with Google Mobile Services")
@@ -86,7 +86,7 @@ dependencies {
   implementation 'androidx.recyclerview:recyclerview:1.2.1'
   implementation 'androidx.work:work-runtime:2.7.1'
   implementation 'com.github.bumptech.glide:glide:4.13.2'
-  implementation 'com.google.android.material:material:1.7.0-alpha01'
+  implementation 'com.google.android.material:material:1.7.0-alpha02'
   implementation 'com.google.code.gson:gson:2.9.0'
   implementation 'com.timehop.stickyheadersrecyclerview:library:0.4.3@aar'
   implementation 'com.trafi:anchor-bottom-sheet-behavior:0.14-alpha'
@@ -95,8 +95,8 @@ dependencies {
 
   // Test Dependencies
   testImplementation 'junit:junit:4.13.2'
-  testImplementation 'org.mockito:mockito-core:4.5.1'
-  testImplementation 'org.mockito:mockito-inline:4.5.1'
+  testImplementation 'org.mockito:mockito-core:4.6.0'
+  testImplementation 'org.mockito:mockito-inline:4.6.0'
 }
 
 def run(cmd) {

--- a/android/build.gradle
+++ b/android/build.gradle
@@ -67,9 +67,6 @@ apply plugin: 'com.github.triplet.play'
 apply plugin: 'ru.cian.huawei-publish-gradle-plugin'
 
 dependencies {
-
-  implementation 'androidx.multidex:multidex:' + propMultiDexVersion
-
   // Google Mobile Services
   if (googleMobileServicesEnabled) {
     implementation 'com.google.android.gms:play-services-location:19.0.1'
@@ -81,29 +78,25 @@ dependencies {
     implementation 'com.google.firebase:firebase-crashlytics-ndk:18.2.6'
   }
 
-  // 3-party
-  implementation 'com.google.code.gson:gson:2.9.0'
-  // Sticky recycler view headers
-  implementation 'com.timehop.stickyheadersrecyclerview:library:0.4.3@aar'
-  // Glide
-  implementation 'com.github.bumptech.glide:glide:4.13.2'
-  // Java concurrency annotations
-  implementation 'net.jcip:jcip-annotations:1.0'
-
+  implementation 'androidx.appcompat:appcompat:1.4.1'
   implementation 'androidx.constraintlayout:constraintlayout:2.1.4'
+  implementation 'androidx.fragment:fragment:1.4.1'
+  implementation 'androidx.multidex:multidex:2.0.1'
+  implementation 'androidx.preference:preference:1.2.0'
+  implementation 'androidx.recyclerview:recyclerview:1.2.1'
   implementation 'androidx.work:work-runtime:2.7.1'
+  implementation 'com.github.bumptech.glide:glide:4.13.2'
+  implementation 'com.google.android.material:material:1.7.0-alpha01'
+  implementation 'com.google.code.gson:gson:2.9.0'
+  implementation 'com.timehop.stickyheadersrecyclerview:library:0.4.3@aar'
   implementation 'com.trafi:anchor-bottom-sheet-behavior:0.14-alpha'
   implementation 'com.github.devnullorthrow:MPAndroidChart:3.2.0-alpha'
-  implementation 'com.google.android.material:material:1.7.0-alpha01'
-  implementation 'androidx.appcompat:appcompat:1.4.1'
-  implementation 'androidx.preference:preference:1.2.0'
-  implementation 'androidx.fragment:fragment:1.4.1'
-  implementation 'androidx.recyclerview:recyclerview:1.2.1'
+  implementation 'net.jcip:jcip-annotations:1.0'
 
   // Test Dependencies
-  testImplementation "junit:junit:$jUnitVersion"
-  testImplementation "org.mockito:mockito-core:$mockitoVersion"
-  testImplementation "org.mockito:mockito-inline:$mockitoVersion"
+  testImplementation 'junit:junit:4.13.2'
+  testImplementation 'org.mockito:mockito-core:4.5.1'
+  testImplementation 'org.mockito:mockito-inline:4.5.1'
 }
 
 def run(cmd) {

--- a/android/gradle.properties
+++ b/android/gradle.properties
@@ -2,9 +2,6 @@ propMinSdkVersion=21
 propTargetSdkVersion=31
 propCompileSdkVersion=31
 propBuildToolsVersion=32.0.0
-propMultiDexVersion=2.0.1
-jUnitVersion=4.13.2
-mockitoVersion=4.5.1
 
 org.gradle.caching=true
 org.gradle.jvmargs=-Xmx1024m -Xms256m

--- a/android/jni/com/mapswithme/maps/Framework.cpp
+++ b/android/jni/com/mapswithme/maps/Framework.cpp
@@ -1036,6 +1036,12 @@ Java_com_mapswithme_maps_Framework_nativeGetSettingsDir(JNIEnv * env, jclass)
   return jni::ToJavaString(env, GetPlatform().SettingsDir().c_str());
 }
 
+JNIEXPORT jstring JNICALL
+Java_com_mapswithme_maps_Framework_nativeGetDataFileExt(JNIEnv * env, jclass)
+{
+  return jni::ToJavaString(env, DATA_FILE_EXTENSION);
+}
+
 JNIEXPORT jobjectArray JNICALL
 Java_com_mapswithme_maps_Framework_nativeGetMovableFilesExts(JNIEnv * env, jclass)
 {

--- a/android/src/com/mapswithme/maps/Framework.java
+++ b/android/src/com/mapswithme/maps/Framework.java
@@ -212,6 +212,8 @@ public class Framework
 
   public static native void nativeDeactivatePopup();
 
+  public static native String nativeGetDataFileExt();
+
   public static native String[] nativeGetMovableFilesExts();
 
   public static native String[] nativeGetBookmarksFilesExts();

--- a/android/src/com/mapswithme/maps/settings/StoragePathFragment.java
+++ b/android/src/com/mapswithme/maps/settings/StoragePathFragment.java
@@ -28,7 +28,6 @@ public class StoragePathFragment extends BaseSettingsFragment
     implements OnBackPressListener
 {
   private TextView mHeader;
-  private ListView mList;
 
   private StoragePathAdapter mAdapter;
   private StoragePathManager mPathManager;
@@ -47,7 +46,7 @@ public class StoragePathFragment extends BaseSettingsFragment
     mAdapter = new StoragePathAdapter(mPathManager, requireActivity());
 
     mHeader = root.findViewById(R.id.header);
-    mList = root.findViewById(R.id.list);
+    ListView mList = root.findViewById(R.id.list);
     mList.setOnItemClickListener((parent, view, position, id) -> changeStorage(position));
     mList.setAdapter(mAdapter);
 
@@ -125,7 +124,7 @@ public class StoragePathFragment extends BaseSettingsFragment
     dialog.show();
 
     ThreadPool.getStorage().execute(() -> {
-      final boolean result = mPathManager.moveStorage(newPath, oldPath);
+      final boolean result = StoragePathManager.moveStorage(newPath, oldPath);
 
       UiThread.run(() -> {
         if (dialog.isShowing())

--- a/android/src/com/mapswithme/maps/settings/StoragePathManager.java
+++ b/android/src/com/mapswithme/maps/settings/StoragePathManager.java
@@ -32,6 +32,7 @@ public class StoragePathManager
 {
   static final String TAG = StoragePathManager.class.getName();
   private static final Logger LOGGER = LoggerFactory.INSTANCE.getLogger(LoggerFactory.Type.STORAGE);
+  private static final String DATA_FILE_EXT = Framework.nativeGetDataFileExt();
   private static final String[] MOVABLE_EXTS = Framework.nativeGetMovableFilesExts();
   static final FilenameFilter MOVABLE_FILES_FILTER = (dir, filename) -> {
     for (String ext : MOVABLE_EXTS)
@@ -291,34 +292,11 @@ public class StoragePathManager
   }
 
   /**
-   * Determine whether the storage contains map files
-   * by checking for non-empty directories with version-like names (e.g. "220415").
+   * Determine whether the storage contains map files.
    */
   private static boolean containsMapData(String storagePath)
   {
-    File path = new File(storagePath);
-    File[] candidates = path.listFiles((pathname) -> {
-      if (!pathname.isDirectory())
-        return false;
-
-      try
-      {
-        String name = pathname.getName();
-        if (name.length() != 6)
-          return false;
-
-        int version = Integer.valueOf(name);
-        return (version > 120000 && version <= 999999);
-      }
-      catch (NumberFormatException ignored)
-      {
-      }
-
-      return false;
-    });
-
-    return (candidates != null && candidates.length > 0 &&
-            candidates[0].list().length > 0);
+    return StorageUtils.getDirSizeRecursively(new File(storagePath), (dir, filename) -> filename.endsWith(DATA_FILE_EXT)) > 0;
   }
 
   /**

--- a/android/src/com/mapswithme/maps/settings/StoragePathManager.java
+++ b/android/src/com/mapswithme/maps/settings/StoragePathManager.java
@@ -53,7 +53,7 @@ public class StoragePathManager
 
   public final List<StorageItem> mStorages = new ArrayList<>();
   public int mCurrentStorageIndex = -1;
-  private StorageItem mEmulatedStorage = null;
+  private StorageItem mInternalStorage = null;
 
   public StoragePathManager(@NonNull Context context)
   {
@@ -119,8 +119,6 @@ public class StoragePathManager
 
   /**
    * Adds a storage into the list if it passes sanity checks.
-   * Internal storage is omitted if it backs an emulated one (unless internal is the current one),
-   * hence internal should be fed to this method last.
    */
   private void addStorageOption(File dir, boolean isInternal, String configPath)
   {
@@ -147,22 +145,6 @@ public class StoragePathManager
                       (isCurrent ? "currently configured, " : "") +
                       (isInternal ? "internal" : "external") + ", " +
                       freeSize + " available out of " + totalSize + " bytes";
-
-      // Check if internal and emulated are the same physical device.
-      // Allow for some divergence in freeSize because there could have been file operations inbetween free space checks.
-      if (isInternal && mEmulatedStorage != null && mEmulatedStorage.mTotalSize == totalSize
-          && mEmulatedStorage.mFreeSize > freeSize - 1024 * 1024
-          && mEmulatedStorage.mFreeSize < freeSize + 1024 * 1024)
-      {
-        final String emulated = ", backs emulated (" + mEmulatedStorage.mPath + ")";
-        // Allow duplicating internal storage if its the current one (for migration purposes).
-        if (!isCurrent)
-        {
-          LOGGER.i(TAG, "Duplicate" + emulated + ": " + commentedPath);
-          return;
-        }
-        commentedPath += emulated;
-      }
 
       boolean isEmulated = false;
       boolean isRemovable = false;
@@ -246,8 +228,8 @@ public class StoragePathManager
       mStorages.add(storage);
       if (isCurrent)
         mCurrentStorageIndex = mStorages.size() - 1;
-      if (isEmulated)
-        mEmulatedStorage = storage;
+      if (isInternal)
+        mInternalStorage = storage;
       LOGGER.i(TAG, "Accepted " + commentedPath);
     }
     catch (SecurityException | IOException ex)
@@ -268,7 +250,7 @@ public class StoragePathManager
     LOGGER.i(TAG, "Begin scanning storages");
     mStorages.clear();
     mCurrentStorageIndex = -1;
-    mEmulatedStorage = null;
+    mInternalStorage = null;
 
     // External storages (SD cards and other).
     for (File externalDir : mContext.getExternalFilesDirs(null))
@@ -300,26 +282,26 @@ public class StoragePathManager
   }
 
   /**
-   * Get storage with the most free space.
+   * Get a writable non-internal storage with the most free space.
+   * Returns an internal storage if no other options are suitable.
    */
-  public StorageItem getBiggestStorage()
+  public StorageItem getDefaultStorage()
   {
     StorageItem res = null;
     for (StorageItem storage : mStorages)
     {
-      if (res == null || res.mFreeSize < storage.mFreeSize)
-      {
+      if ((res == null || res.mFreeSize < storage.mFreeSize)
+          && storage.mIsReadonly == false && !storage.equals(mInternalStorage))
         res = storage;
-      }
     }
-    return res;
+
+    return res != null ? res : mInternalStorage;
   }
 
   /**
    * Returns an available storage with existing maps files.
-   * Checks the currently configured storage first,
-   * then scans other storages. If no maps files found
-   * defaults to the storage with the most free space.
+   * Checks the currently configured storage first, then scans other storages.
+   * If no map files found uses getDefaultStorage().
    */
   public static String findMapsStorage(@NonNull Application application)
   {
@@ -360,8 +342,8 @@ public class StoragePathManager
       }
     }
 
-    path = mgr.getBiggestStorage().mPath;
-    LOGGER.i(TAG, "Defaulting to a storage with the most free space: " + path);
+    path = mgr.getDefaultStorage().mPath;
+    LOGGER.i(TAG, "Using default storage " + path);
     return path;
   }
 

--- a/android/src/com/mapswithme/maps/settings/StoragePathManager.java
+++ b/android/src/com/mapswithme/maps/settings/StoragePathManager.java
@@ -49,7 +49,7 @@ public class StoragePathManager
 
   private OnStorageListChangedListener mStoragesChangedListener;
   private BroadcastReceiver mInternalReceiver;
-  private Context mContext;
+  private final Context mContext;
 
   public final List<StorageItem> mStorages = new ArrayList<>();
   public int mCurrentStorageIndex = -1;
@@ -131,21 +131,20 @@ public class StoragePathManager
       return;
     }
 
-    String path = null;
+    String path;
     try {
       path = dir.getCanonicalPath();
     } catch (IOException e) {
       LOGGER.e(TAG, "IOException at getCanonicalPath " + e);
       return;
     }
-    String commentedPath = null;
     // Add the trailing separator because the native code assumes that all paths have it.
     path = StorageUtils.addTrailingSeparator(path);
     final boolean isCurrent = path.equals(configPath);
     final long totalSize = dir.getTotalSpace();
     final long freeSize = dir.getUsableSpace();
 
-    commentedPath = path + (StorageUtils.addTrailingSeparator(dir.getPath()).equals(path)
+    String commentedPath = path + (StorageUtils.addTrailingSeparator(dir.getPath()).equals(path)
                             ? "" : " (" + dir.getPath() + ")") + " - " +
                     (isCurrent ? "currently configured, " : "") +
                     (isInternal ? "internal" : "external") + ", " +
@@ -177,7 +176,7 @@ public class StoragePathManager
       // Get additional storage information for Android 7+.
       if (android.os.Build.VERSION.SDK_INT >= android.os.Build.VERSION_CODES.N)
       {
-        final StorageManager sm = (StorageManager) mContext.getSystemService(mContext.STORAGE_SERVICE);
+        final StorageManager sm = (StorageManager) mContext.getSystemService(Context.STORAGE_SERVICE);
         if (sm != null)
         {
           final StorageVolume sv = sm.getStorageVolume(dir);
@@ -291,7 +290,7 @@ public class StoragePathManager
     for (StorageItem storage : mStorages)
     {
       if ((res == null || res.mFreeSize < storage.mFreeSize)
-          && storage.mIsReadonly == false && !storage.equals(mInternalStorage))
+          && !storage.mIsReadonly && !storage.equals(mInternalStorage))
         res = storage;
     }
 
@@ -307,7 +306,7 @@ public class StoragePathManager
   {
     StoragePathManager mgr = new StoragePathManager(application);
     mgr.scanAvailableStorages();
-    String path = null;
+    String path;
     final List<StorageItem> storages = mgr.mStorages;
     final int currentIdx = mgr.mCurrentStorageIndex;
 

--- a/android/src/com/mapswithme/util/StorageUtils.java
+++ b/android/src/com/mapswithme/util/StorageUtils.java
@@ -250,12 +250,21 @@ public class StorageUtils
     }
   }
 
+  /**
+   * Returns 0 in case of the error or if no files have passed the filter.
+   */
   public static long getDirSizeRecursively(File file, FilenameFilter fileFilter)
   {
     if (file.isDirectory())
     {
+      final File[] list = file.listFiles();
+      if (list == null)
+      {
+        LOGGER.w(TAG, "getDirSizeRecursively dirFiles returned null");
+        return 0;
+      }
       long dirSize = 0;
-      for (File child : file.listFiles())
+      for (File child : list)
         dirSize += getDirSizeRecursively(child, fileFilter);
 
       return dirSize;
@@ -270,7 +279,10 @@ public class StorageUtils
   @SuppressWarnings("ResultOfMethodCallIgnored")
   public static void removeEmptyDirectories(File dir)
   {
-    for (File file : dir.listFiles())
+    final File[] list = dir.listFiles();
+    if (list == null)
+      return;
+    for (File file : list)
     {
       if (!file.isDirectory())
         continue;

--- a/android/src/com/mapswithme/util/StorageUtils.java
+++ b/android/src/com/mapswithme/util/StorageUtils.java
@@ -253,27 +253,33 @@ public class StorageUtils
   /**
    * Returns 0 in case of the error or if no files have passed the filter.
    */
-  public static long getDirSizeRecursively(File file, FilenameFilter fileFilter)
+  public static long getDirSizeRecursively(File dir, FilenameFilter fileFilter)
   {
-    if (file.isDirectory())
+    long dirSize = 0;
+
+    try
     {
-      final File[] list = file.listFiles();
+      final File[] list = dir.listFiles();
       if (list == null)
       {
         LOGGER.w(TAG, "getDirSizeRecursively dirFiles returned null");
         return 0;
       }
-      long dirSize = 0;
-      for (File child : list)
-        dirSize += getDirSizeRecursively(child, fileFilter);
 
-      return dirSize;
+      for (File child : list)
+      {
+        if (child.isDirectory())
+          dirSize += getDirSizeRecursively(child, fileFilter);
+        else if (fileFilter.accept(dir, child.getName()))
+          dirSize += child.length();
+      }
+    }
+    catch (SecurityException e)
+    {
+      LOGGER.e(TAG, "Can't calculate size of directory " + dir.getPath(), e);
     }
 
-    if (fileFilter.accept(file.getParentFile(), file.getName()))
-      return file.length();
-
-    return 0;
+    return dirSize;
   }
 
   @SuppressWarnings("ResultOfMethodCallIgnored")

--- a/android/src/com/mapswithme/util/StorageUtils.java
+++ b/android/src/com/mapswithme/util/StorageUtils.java
@@ -323,8 +323,6 @@ public class StorageUtils
    */
   public static void listContentProviderFilesRecursively(ContentResolver contentResolver, Uri rootUri, UriVisitor filter)
   {
-    ArrayList<Uri> result = new ArrayList<>();
-
     Uri rootDir = DocumentsContract.buildChildDocumentsUriUsingTree(rootUri, DocumentsContract.getTreeDocumentId(rootUri));
     Queue<Uri> directories = new LinkedBlockingQueue<>();
     directories.add(rootDir);


### PR DESCRIPTION
Map files were "disappearing" because the app couldn't find them in internal storage (due to unreliable detection algo - if there were empty maps directories in certain order) and hence switched to emulated storage (and internal storage became hidden for the user as duplicating the same physical device).

- Improve reliability of map files detection (calc sizes of *.mwm files)
- Make internal storage always visible (so affected users can manually switch back to it and have their maps back)
- Catch possible exceptions in getDirSizeRecursively()

Users that lost their maps before and didn't download any new maps (incl. world maps) will be switched to internal storage automatically (and have their maps back).
Other users will have an internal storage option added (if it was hidden before), but there will be no automatic switchover. If they lost the maps before and downloaded new ones then they'll have to switch the storage to internal manually (new maps will overwrite same old maps, hence they will be "merged").

Fixes #2589