### PR TITLE
[android] Refactor logging and logs folder fallback to internal storage location

### DIFF
--- a/android/src/com/mapswithme/maps/MwmApplication.java
+++ b/android/src/com/mapswithme/maps/MwmApplication.java
@@ -44,7 +44,7 @@ public class MwmApplication extends Application implements AppBackgroundTracker.
 {
   @SuppressWarnings("NotNullFieldNotInitialized")
   @NonNull
-  private Logger mLogger;
+  private final Logger mLogger = LoggerFactory.INSTANCE.getLogger(LoggerFactory.Type.MISC);
   public final static String TAG = "MwmApplication";
 
   private AppBackgroundTracker mBackgroundTracker;
@@ -100,8 +100,7 @@ public class MwmApplication extends Application implements AppBackgroundTracker.
   @NonNull
   public static SharedPreferences prefs(@NonNull Context context)
   {
-    String prefFile = context.getString(R.string.pref_file_name);
-    return context.getSharedPreferences(prefFile, MODE_PRIVATE);
+    return context.getSharedPreferences(context.getString(R.string.pref_file_name), MODE_PRIVATE);
   }
 
   @Override
@@ -116,13 +115,13 @@ public class MwmApplication extends Application implements AppBackgroundTracker.
   public void onCreate()
   {
     super.onCreate();
-    LoggerFactory.INSTANCE.initialize(this);
-    mLogger = LoggerFactory.INSTANCE.getLogger(LoggerFactory.Type.MISC);
-    getLogger().d(TAG, "Application is created");
+    mLogger.i(TAG, "Initializing application");
+    LoggerFactory.INSTANCE.initFileLogging(this);
+
     // Set configuration directory as early as possible.
     // Other methods may explicitly use Config, which requires settingsDir to be set.
     final String settingsPath = StorageUtils.getSettingsPath(this);
-    getLogger().d(TAG, "Settings path = " + settingsPath);
+    mLogger.d(TAG, "Settings path = " + settingsPath);
     try
     {
       StorageUtils.createDirectory(settingsPath);
@@ -168,16 +167,15 @@ public class MwmApplication extends Application implements AppBackgroundTracker.
     if (mPlatformInitialized)
       return;
 
-    final Logger log = getLogger();
     final String apkPath = StorageUtils.getApkPath(this);
-    log.d(TAG, "Apk path = " + apkPath);
+    mLogger.d(TAG, "Apk path = " + apkPath);
     // Note: StoragePathManager uses Config, which requires initConfig() to be called.
     final String writablePath = StoragePathManager.findMapsStorage(this);
-    log.d(TAG, "Writable path = " + writablePath);
+    mLogger.d(TAG, "Writable path = " + writablePath);
     final String privatePath = StorageUtils.getPrivatePath(this);
-    log.d(TAG, "Private path = " + privatePath);
+    mLogger.d(TAG, "Private path = " + privatePath);
     final String tempPath = StorageUtils.getTempPath(this);
-    log.d(TAG, "Temp path = " + tempPath);
+    mLogger.d(TAG, "Temp path = " + tempPath);
 
     // If platform directories are not created it means that native part of app will not be able
     // to work at all. So, we just ignore native part initialization in this case, e.g. when the
@@ -195,7 +193,7 @@ public class MwmApplication extends Application implements AppBackgroundTracker.
 
     Editor.init(this);
     mPlatformInitialized = true;
-    log.i(TAG, "Platform initialized");
+    mLogger.i(TAG, "Platform initialized");
   }
 
   private void createPlatformDirectories(@NonNull String writablePath,
@@ -231,7 +229,7 @@ public class MwmApplication extends Application implements AppBackgroundTracker.
     IsolinesManager.from(this).initialize(null);
     mBackgroundTracker.addListener(this);
 
-    getLogger().i(TAG, "Framework initialized");
+    mLogger.i(TAG, "Framework initialized");
     mFrameworkInitialized = true;
   }
 
@@ -296,12 +294,6 @@ public class MwmApplication extends Application implements AppBackgroundTracker.
   private static native void nativeProcessTask(long taskPointer);
   private static native void nativeAddLocalization(String name, String value);
   private static native void nativeOnTransit(boolean foreground);
-
-  @NonNull
-  public Logger getLogger()
-  {
-    return mLogger;
-  }
 
   public boolean isFirstLaunch()
   {

--- a/android/src/com/mapswithme/maps/MwmApplication.java
+++ b/android/src/com/mapswithme/maps/MwmApplication.java
@@ -121,16 +121,11 @@ public class MwmApplication extends Application implements AppBackgroundTracker.
     // Set configuration directory as early as possible.
     // Other methods may explicitly use Config, which requires settingsDir to be set.
     final String settingsPath = StorageUtils.getSettingsPath(this);
-    mLogger.d(TAG, "Settings path = " + settingsPath);
-    try
-    {
-      StorageUtils.createDirectory(settingsPath);
-      nativeSetSettingsDir(settingsPath);
-    } catch (IOException e)
-    {
-      // We have nothing to do here.
+    if (!StorageUtils.createDirectory(settingsPath))
       throw new AssertionError("Can't create settingsDir " + settingsPath);
-    }
+    mLogger.d(TAG, "Settings path = " + settingsPath);
+    nativeSetSettingsDir(settingsPath);
+
     mMainLoopHandler = new Handler(getMainLooper());
     ConnectionState.INSTANCE.initialize(this);
     CrashlyticsUtils.INSTANCE.initialize(this);
@@ -202,9 +197,9 @@ public class MwmApplication extends Application implements AppBackgroundTracker.
   {
     SharedPropertiesUtils.emulateBadExternalStorage(this);
 
-    StorageUtils.createDirectory(writablePath);
-    StorageUtils.createDirectory(privatePath);
-    StorageUtils.createDirectory(tempPath);
+    StorageUtils.requireDirectory(writablePath);
+    StorageUtils.requireDirectory(privatePath);
+    StorageUtils.requireDirectory(tempPath);
   }
 
   private void initNativeFramework()

--- a/android/src/com/mapswithme/maps/help/FaqFragment.java
+++ b/android/src/com/mapswithme/maps/help/FaqFragment.java
@@ -30,7 +30,7 @@ public class FaqFragment extends BaseMwmFragment
 
     private void reportBug()
     {
-      Utils.sendBugReport(requireActivity(), "Organic Maps Bugreport");
+      Utils.sendBugReport(requireActivity(), "");
     }
 
     @Override

--- a/android/src/com/mapswithme/maps/help/HelpFragment.java
+++ b/android/src/com/mapswithme/maps/help/HelpFragment.java
@@ -128,7 +128,7 @@ public class HelpFragment extends BaseMwmFragment implements View.OnClickListene
     else if (id == R.id.faq)
       ((HelpActivity) getActivity()).stackFragment(FaqFragment.class, getString(R.string.faq), null);
     else if (id == R.id.report)
-      Utils.sendFeedback(getActivity());
+      Utils.sendBugReport(getActivity(), "");
     else if (id == R.id.support_us)
       openLink(Constants.Url.SUPPORT_US);
     else if (id == R.id.rate)

--- a/android/src/com/mapswithme/maps/settings/SettingsPrefsFragment.java
+++ b/android/src/com/mapswithme/maps/settings/SettingsPrefsFragment.java
@@ -21,7 +21,6 @@ import androidx.preference.Preference;
 import androidx.preference.PreferenceCategory;
 import androidx.preference.PreferenceScreen;
 import androidx.preference.TwoStatePreference;
-
 import com.mapswithme.maps.Framework;
 import com.mapswithme.maps.R;
 import com.mapswithme.maps.downloader.MapManager;
@@ -481,16 +480,11 @@ public class SettingsPrefsFragment extends BaseXmlSettingsFragment
     if (pref == null)
       return;
 
-    final boolean isLoggingEnabled = LoggerFactory.INSTANCE.isFileLoggingEnabled();
-    ((TwoStatePreference) pref).setChecked(isLoggingEnabled);
-    pref.setOnPreferenceChangeListener(
-        (preference, newValue) ->
-        {
-          boolean newVal = (Boolean) newValue;
-          if (isLoggingEnabled != newVal)
-            LoggerFactory.INSTANCE.setFileLoggingEnabled(newVal);
-          return true;
-        });
+    ((TwoStatePreference) pref).setChecked(LoggerFactory.INSTANCE.isFileLoggingEnabled);
+    pref.setOnPreferenceChangeListener((preference, newValue) -> {
+      LoggerFactory.INSTANCE.setFileLoggingEnabled((Boolean) newValue);
+      return true;
+    });
   }
 
   private void initEmulationBadStorage()

--- a/android/src/com/mapswithme/maps/settings/SettingsPrefsFragment.java
+++ b/android/src/com/mapswithme/maps/settings/SettingsPrefsFragment.java
@@ -482,7 +482,12 @@ public class SettingsPrefsFragment extends BaseXmlSettingsFragment
 
     ((TwoStatePreference) pref).setChecked(LoggerFactory.INSTANCE.isFileLoggingEnabled);
     pref.setOnPreferenceChangeListener((preference, newValue) -> {
-      LoggerFactory.INSTANCE.setFileLoggingEnabled((Boolean) newValue);
+      if (!LoggerFactory.INSTANCE.setFileLoggingEnabled((Boolean) newValue))
+      {
+        // It's a very rare condition when debugging, so we can do without translation.
+        Utils.showSnackbar(getView(), "Can't create a logs folder!");
+        return false;
+      }
       return true;
     });
   }

--- a/android/src/com/mapswithme/maps/settings/SettingsPrefsFragment.java
+++ b/android/src/com/mapswithme/maps/settings/SettingsPrefsFragment.java
@@ -485,7 +485,7 @@ public class SettingsPrefsFragment extends BaseXmlSettingsFragment
       if (!LoggerFactory.INSTANCE.setFileLoggingEnabled((Boolean) newValue))
       {
         // It's a very rare condition when debugging, so we can do without translation.
-        Utils.showSnackbar(getView(), "Can't create a logs folder!");
+        Utils.showSnackbar(getView(), "ERROR: Can't create a logs folder!");
         return false;
       }
       return true;

--- a/android/src/com/mapswithme/util/Constants.java
+++ b/android/src/com/mapswithme/util/Constants.java
@@ -46,7 +46,6 @@ public final class Constants
 
   public static class Email
   {
-    public static final String FEEDBACK = "android@organicmaps.app";
     public static final String SUPPORT = BuildConfig.SUPPORT_MAIL;
     public static final String RATING = "rating@organicmaps.app";
 

--- a/android/src/com/mapswithme/util/StorageUtils.java
+++ b/android/src/com/mapswithme/util/StorageUtils.java
@@ -7,7 +7,6 @@ import android.content.pm.PackageManager;
 import android.database.Cursor;
 import android.net.Uri;
 import android.provider.DocumentsContract;
-import android.text.TextUtils;
 
 import androidx.annotation.NonNull;
 import androidx.annotation.Nullable;
@@ -80,7 +79,9 @@ public class StorageUtils
     final File directory = new File(path);
     if (!directory.exists() && !directory.mkdirs())
     {
-      LOGGER.e(TAG, "Can't create directory " + path);
+      final String errMsg = "Can't create directory " + path;
+      LOGGER.e(TAG, errMsg);
+      CrashlyticsUtils.INSTANCE.logException(new IOException(errMsg));
       return false;
     }
     return true;

--- a/android/src/com/mapswithme/util/StorageUtils.java
+++ b/android/src/com/mapswithme/util/StorageUtils.java
@@ -98,14 +98,6 @@ public class StorageUtils
     return externalDir + File.separator + LOGS_FOLDER;
   }
 
-  @Nullable
-  static String getLogsZipPath(@NonNull Application application)
-  {
-    String zipFile = getExternalFilesDir(application) + File.separator + LOGS_FOLDER + ".zip";
-    File file = new File(zipFile);
-    return file.isFile() && file.exists() ? zipFile : null;
-  }
-
   @NonNull
   public static String getApkPath(@NonNull Application application)
   {

--- a/android/src/com/mapswithme/util/StorageUtils.java
+++ b/android/src/com/mapswithme/util/StorageUtils.java
@@ -66,8 +66,7 @@ public class StorageUtils
     if (dir != null)
       return dir.getAbsolutePath();
 
-    Log.e(StorageUtils.class.getSimpleName(),
-          "Cannot get the external files directory for some reasons", new Throwable());
+    Log.e(TAG, "Cannot get the external files directory for some reasons", new Throwable());
     return null;
   }
 

--- a/android/src/com/mapswithme/util/Utils.java
+++ b/android/src/com/mapswithme/util/Utils.java
@@ -818,7 +818,7 @@ public class Utils
         intent.setFlags(Intent.FLAG_ACTIVITY_NEW_TASK);
         intent.putExtra(Intent.EXTRA_EMAIL, new String[] { mEmail });
         intent.putExtra(Intent.EXTRA_SUBJECT, "[" + BuildConfig.VERSION_NAME + "] " + mSubject);
-        //TODO: if zipping logs failed send a short text attachment with system info and logs zipping error/stacktrace.
+        // TODO: Send a short text attachment with system info and logs if zipping logs failed 
         if (success)
         {
           final Uri uri = StorageUtils.getUriForFilePath(activity, zipPath);
@@ -841,7 +841,7 @@ public class Utils
         }
         catch (ActivityNotFoundException e)
         {
-          LOGGER.w("No activities found which can handle sending a support message.", e);
+          LOGGER.w(TAG, "No activities found which can handle sending a support message.", e);
         }
       });
     }

--- a/android/src/com/mapswithme/util/Utils.java
+++ b/android/src/com/mapswithme/util/Utils.java
@@ -343,16 +343,23 @@ public class Utils
     }
   }
 
+  // subject is optional (could be an empty string).
+
+  /**
+   * @param subject could be an empty string
+   */
   public static void sendBugReport(@NonNull Activity activity, @NonNull String subject)
   {
+    subject = "Organic Maps Bugreport" + (TextUtils.isEmpty(subject) ? "" : ": " + subject);
     LoggerFactory.INSTANCE.zipLogs(new SupportInfoWithLogsCallback(activity, subject,
                                                                    Constants.Email.SUPPORT));
   }
 
+  // TODO: Don't send logs with general feedback, send system information only (version, device name, connectivity, etc.)
   public static void sendFeedback(@NonNull Activity activity)
   {
     LoggerFactory.INSTANCE.zipLogs(new SupportInfoWithLogsCallback(activity, "Organic Maps Feedback",
-                                                                   Constants.Email.FEEDBACK));
+                                                                   Constants.Email.SUPPORT));
   }
 
   public static void navigateToParent(@Nullable Activity activity)
@@ -799,10 +806,11 @@ public class Utils
     }
 
     @Override
-    public void onCompleted(final boolean success)
+    public void onCompleted(final boolean success, @Nullable final String zipPath)
     {
+      //TODO: delete zip file after its sent.
       UiThread.run(() -> {
-        Activity activity = mActivityRef.get();
+        final Activity activity = mActivityRef.get();
         if (activity == null)
           return;
 
@@ -810,21 +818,18 @@ public class Utils
         intent.setFlags(Intent.FLAG_ACTIVITY_NEW_TASK);
         intent.putExtra(Intent.EXTRA_EMAIL, new String[] { mEmail });
         intent.putExtra(Intent.EXTRA_SUBJECT, "[" + BuildConfig.VERSION_NAME + "] " + mSubject);
+        //TODO: if zipping logs failed send a short text attachment with system info and logs zipping error/stacktrace.
         if (success)
         {
-          String logsZipFile = StorageUtils.getLogsZipPath(activity.getApplication());
-          if (!TextUtils.isEmpty(logsZipFile))
-          {
-            Uri uri = StorageUtils.getUriForFilePath(activity, logsZipFile);
-            intent.putExtra(Intent.EXTRA_STREAM, uri);
-            // Properly set permissions for intent, see
-            // https://developer.android.com/reference/androidx/core/content/FileProvider#include-the-permission-in-an-intent
-            intent.setData(uri);
-            intent.setFlags(Intent.FLAG_GRANT_READ_URI_PERMISSION);
-            if (android.os.Build.VERSION.SDK_INT <= android.os.Build.VERSION_CODES.LOLLIPOP_MR1) {
-              intent.setClipData(ClipData.newRawUri("", uri));
-              intent.addFlags(Intent.FLAG_GRANT_READ_URI_PERMISSION | Intent.FLAG_GRANT_WRITE_URI_PERMISSION);
-            }
+          final Uri uri = StorageUtils.getUriForFilePath(activity, zipPath);
+          intent.putExtra(Intent.EXTRA_STREAM, uri);
+          // Properly set permissions for intent, see
+          // https://developer.android.com/reference/androidx/core/content/FileProvider#include-the-permission-in-an-intent
+          intent.setData(uri);
+          intent.setFlags(Intent.FLAG_GRANT_READ_URI_PERMISSION);
+          if (android.os.Build.VERSION.SDK_INT <= android.os.Build.VERSION_CODES.LOLLIPOP_MR1) {
+            intent.setClipData(ClipData.newRawUri("", uri));
+            intent.addFlags(Intent.FLAG_GRANT_READ_URI_PERMISSION | Intent.FLAG_GRANT_WRITE_URI_PERMISSION);
           }
         }
         // Do this so some email clients don't complain about empty body.
@@ -836,7 +841,7 @@ public class Utils
         }
         catch (ActivityNotFoundException e)
         {
-          CrashlyticsUtils.INSTANCE.logException(e);
+          LOGGER.w("No activities found which can handle sending a support message.", e);
         }
       });
     }

--- a/android/src/com/mapswithme/util/log/FileLoggerStrategy.java
+++ b/android/src/com/mapswithme/util/log/FileLoggerStrategy.java
@@ -9,11 +9,9 @@ import android.os.Build;
 import android.util.Log;
 
 import androidx.annotation.NonNull;
-
 import com.mapswithme.maps.BuildConfig;
 import com.mapswithme.util.StorageUtils;
 import com.mapswithme.util.Utils;
-
 import net.jcip.annotations.Immutable;
 
 import java.io.File;
@@ -36,8 +34,8 @@ class FileLoggerStrategy implements LoggerStrategy
   @NonNull
   private final Application mApplication;
 
-  FileLoggerStrategy(@NonNull Application application, @NonNull String filePath,
-                     @NonNull Executor executor)
+  public FileLoggerStrategy(@NonNull Application application, @NonNull String filePath,
+                            @NonNull Executor executor)
   {
     mApplication = application;
     mFilePath = filePath;

--- a/android/src/com/mapswithme/util/log/FileLoggerStrategy.java
+++ b/android/src/com/mapswithme/util/log/FileLoggerStrategy.java
@@ -1,17 +1,9 @@
 package com.mapswithme.util.log;
 
-import android.app.Application;
-import android.content.Context;
-import android.location.LocationManager;
-import android.net.ConnectivityManager;
-import android.net.NetworkInfo;
-import android.os.Build;
+import android.text.TextUtils;
 import android.util.Log;
 
 import androidx.annotation.NonNull;
-import com.mapswithme.maps.BuildConfig;
-import com.mapswithme.util.StorageUtils;
-import com.mapswithme.util.Utils;
 import net.jcip.annotations.Immutable;
 
 import java.io.File;
@@ -28,17 +20,13 @@ class FileLoggerStrategy implements LoggerStrategy
 {
   private static final String TAG = FileLoggerStrategy.class.getSimpleName();
   @NonNull
-  private final String mFilePath;
+  private final String mFileName;
   @NonNull
   private final Executor mExecutor;
-  @NonNull
-  private final Application mApplication;
 
-  public FileLoggerStrategy(@NonNull Application application, @NonNull String filePath,
-                            @NonNull Executor executor)
+  public FileLoggerStrategy(@NonNull String fileName, @NonNull Executor executor)
   {
-    mApplication = application;
-    mFilePath = filePath;
+    mFileName = fileName;
     mExecutor = executor;
   }
 
@@ -111,10 +99,15 @@ class FileLoggerStrategy implements LoggerStrategy
 
   private void write(@NonNull final String data)
   {
-    mExecutor.execute(new WriteTask(mApplication, mFilePath, data, Thread.currentThread().getName()));
+    final String logsPath = LoggerFactory.INSTANCE.ensureLogsFolder();
+    if (logsPath == null)
+      Log.e(TAG, "Couldn't log to " + mFileName + ": " + data);
+    else
+      mExecutor.execute(new WriteTask(logsPath + File.separator + mFileName,
+                                      data, Thread.currentThread().getName()));
   }
 
-  static class WriteTask implements Runnable
+  private static class WriteTask implements Runnable
   {
     private static final int MAX_SIZE = 3000000;
     @NonNull
@@ -123,13 +116,9 @@ class FileLoggerStrategy implements LoggerStrategy
     private final String mData;
     @NonNull
     private final String mCallingThread;
-    @NonNull
-    private final Application mApplication;
 
-    private WriteTask(@NonNull Application application, @NonNull String filePath,
-                      @NonNull String data, @NonNull String callingThread)
+    private WriteTask(@NonNull String filePath, @NonNull String data, @NonNull String callingThread)
     {
-      mApplication = application;
       mFilePath = filePath;
       mData = data;
       mCallingThread = callingThread;
@@ -145,7 +134,7 @@ class FileLoggerStrategy implements LoggerStrategy
         if (!file.exists() || file.length() > MAX_SIZE)
         {
           fw = new FileWriter(file, false);
-          writeSystemInformation(mApplication, fw);
+          LoggerFactory.INSTANCE.writeSystemInformation(fw);
         }
         else
         {
@@ -156,8 +145,7 @@ class FileLoggerStrategy implements LoggerStrategy
       }
       catch (IOException e)
       {
-        Log.e(TAG, "Failed to write the string: " + mData, e);
-        Log.i(TAG, "Logs folder exists: " + StorageUtils.ensureLogsFolderExistence(mApplication));
+        Log.e(TAG, "Failed to log: " + mData, e);
       }
       finally
       {
@@ -168,27 +156,9 @@ class FileLoggerStrategy implements LoggerStrategy
           }
           catch (IOException e)
           {
-            Log.e(TAG, "Failed to close file: " + mData, e);
+            Log.e(TAG, "Failed to close file " + mFilePath, e);
           }
       }
-    }
-
-    static void writeSystemInformation(@NonNull Application application, @NonNull FileWriter fw)
-        throws IOException
-    {
-      fw.write("Android version: " + Build.VERSION.SDK_INT + "\n");
-      fw.write("Device: " + Utils.getFullDeviceModel() + "\n");
-      fw.write("App version: " + BuildConfig.APPLICATION_ID + " " + BuildConfig.VERSION_NAME + "\n");
-      fw.write("Locale : " + Locale.getDefault());
-      fw.write("\nNetworks : ");
-      final ConnectivityManager manager = (ConnectivityManager) application.getSystemService(Context.CONNECTIVITY_SERVICE);
-      for (NetworkInfo info : manager.getAllNetworkInfo())
-        fw.write(info.toString());
-      fw.write("\nLocation providers: ");
-      final LocationManager locMngr = (android.location.LocationManager) application.getSystemService(Context.LOCATION_SERVICE);
-      for (String provider: locMngr.getProviders(true))
-        fw.write(provider + " ");
-      fw.write("\n\n");
     }
   }
 }

--- a/android/src/com/mapswithme/util/log/LogCatStrategy.java
+++ b/android/src/com/mapswithme/util/log/LogCatStrategy.java
@@ -1,39 +1,43 @@
 package com.mapswithme.util.log;
 
 import android.util.Log;
-
-import com.mapswithme.maps.BuildConfig;
-
 import net.jcip.annotations.Immutable;
 
 @Immutable
 class LogCatStrategy implements LoggerStrategy
 {
+  private final boolean mIsDebug;
+
+  public LogCatStrategy(final boolean isDebug)
+  {
+    mIsDebug = isDebug;
+  }
+
   @Override
   public void v(String tag, String msg)
   {
-    if (canLog())
+    if (mIsDebug)
       Log.v(tag, msg);
   }
 
   @Override
   public void v(String tag, String msg, Throwable tr)
   {
-    if (canLog())
+    if (mIsDebug)
       Log.v(tag, msg, tr);
   }
 
   @Override
   public void d(String tag, String msg)
   {
-    if (canLog())
+    if (mIsDebug)
       Log.d(tag, msg);
   }
 
   @Override
   public void d(String tag, String msg, Throwable tr)
   {
-    if (canLog())
+    if (mIsDebug)
       Log.d(tag, msg, tr);
   }
 
@@ -77,10 +81,5 @@ class LogCatStrategy implements LoggerStrategy
   public void e(String tag, String msg, Throwable tr)
   {
     Log.e(tag, msg, tr);
-  }
-
-  private static boolean canLog()
-  {
-    return BuildConfig.DEBUG;
   }
 }

--- a/android/src/com/mapswithme/util/log/LoggerFactory.java
+++ b/android/src/com/mapswithme/util/log/LoggerFactory.java
@@ -35,14 +35,8 @@ public class LoggerFactory
 
   public interface OnZipCompletedListener
   {
-    /**
-     * Indicates about completion of zipping operation.
-     * <p>
-     * <b>NOTE:</b> called from the logger thread
-     * </p>
-     * @param success indicates about a status of zipping operation
-     */
-    void onCompleted(boolean success);
+    // Called from the logger thread.
+    public void onCompleted(final boolean success, @Nullable final String zipPath);
   }
 
   public final static LoggerFactory INSTANCE = new LoggerFactory();
@@ -92,7 +86,7 @@ public class LoggerFactory
                   .putBoolean(mApplication.getString(R.string.pref_enable_logging), enabled)
                   .apply();
     updateLoggers();
-    getLogger(Type.MISC).i(TAG, "File logging " + (enabled ? " started to " + mLogsFolder : "stopped"));
+    getLogger(Type.MISC).i(TAG, "File logging " + (enabled ? "started to " + mLogsFolder : "stopped"));
   }
 
   /**
@@ -137,7 +131,7 @@ public class LoggerFactory
     if (TextUtils.isEmpty(mLogsFolder))
     {
       if (listener != null)
-        listener.onCompleted(false);
+        listener.onCompleted(false, null);
       return;
     }
 

--- a/android/src/com/mapswithme/util/log/LoggerFactory.java
+++ b/android/src/com/mapswithme/util/log/LoggerFactory.java
@@ -93,12 +93,12 @@ public class LoggerFactory
    *
    * @return logs folder path, null if it can't be created
    *
-   * NOTE: throws a NullPointerException if initFileLogging() was not called before.
+   * NOTE: initFileLogging() must be called before.
    */
   @Nullable
   public synchronized String ensureLogsFolder()
   {
-    Objects.requireNonNull(mApplication);
+    assert mApplication != null : "mApplication must be initialized first by calling initFileLogging()";
 
     if (mLogsFolder != null && createWritableDir(mLogsFolder))
       return mLogsFolder;
@@ -106,9 +106,7 @@ public class LoggerFactory
     mLogsFolder = null;
     mLogsFolder = createLogsFolder(mApplication.getExternalFilesDir(null));
     if (mLogsFolder == null)
-    {
       mLogsFolder = createLogsFolder(mApplication.getFilesDir());
-    }
 
     if (mLogsFolder == null)
     {
@@ -167,13 +165,15 @@ public class LoggerFactory
 
   /**
    * Returns false if file logging can't be enabled.
-   * NOTE: Throws a NullPointerException if initFileLogging() was not called before.
+   *
+   * NOTE: initFileLogging() must be called before.
    */
   public boolean setFileLoggingEnabled(boolean enabled)
   {
-    Objects.requireNonNull(mApplication);
+    assert mApplication != null : "mApplication must be initialized first by calling initFileLogging()";
 
     if (isFileLoggingEnabled != enabled)
+    {
       if (enabled && ensureLogsFolder() == null)
       {
         Log.e(TAG, "Can't enable file logging: there is no logs folder.");
@@ -181,6 +181,7 @@ public class LoggerFactory
       }
       else
         switchFileLoggingEnabled(enabled);
+    }
 
     return true;
   }
@@ -204,11 +205,11 @@ public class LoggerFactory
   }
 
   /**
-   * Throws a NullPointerException if initFileLogging() was not called before.
+   * NOTE: initFileLogging() must be called before.
    */
   public synchronized void zipLogs(@NonNull OnZipCompletedListener listener)
   {
-    Objects.requireNonNull(mApplication);
+    assert mApplication != null : "mApplication must be initialized first by calling initFileLogging()";
 
     if (ensureLogsFolder() == null)
     {
@@ -269,17 +270,17 @@ public class LoggerFactory
   }
 
   /**
-   * Throws a NullPointerException if initFileLogging() was not called before.
+   * NOTE: initFileLogging() must be called before.
    */
   public void writeSystemInformation(@NonNull final FileWriter fw) throws IOException
   {
-    Objects.requireNonNull(mApplication);
+    assert mApplication != null : "mApplication must be initialized first by calling initFileLogging()";
 
-    fw.write("Android version: " + Build.VERSION.SDK_INT + "\n");
-    fw.write("Device: " + Utils.getFullDeviceModel() + "\n");
-    fw.write("App version: " + BuildConfig.APPLICATION_ID + " " + BuildConfig.VERSION_NAME + "\n");
-    fw.write("Locale : " + Locale.getDefault());
-    fw.write("\nNetworks : ");
+    fw.write("Android version: " + Build.VERSION.SDK_INT);
+    fw.write("\nDevice: " + Utils.getFullDeviceModel());
+    fw.write("\nApp version: " + BuildConfig.APPLICATION_ID + " " + BuildConfig.VERSION_NAME);
+    fw.write("\nLocale: " + Locale.getDefault());
+    fw.write("\nNetworks: ");
     final ConnectivityManager manager = (ConnectivityManager) mApplication.getSystemService(Context.CONNECTIVITY_SERVICE);
     if (manager != null)
       // TODO: getAllNetworkInfo() is deprecated, for alternatives check

--- a/android/src/com/mapswithme/util/log/LoggerFactory.java
+++ b/android/src/com/mapswithme/util/log/LoggerFactory.java
@@ -100,7 +100,7 @@ public class LoggerFactory
   {
     Objects.requireNonNull(mApplication);
 
-    if (mLogsFolder != null && createDir(mLogsFolder))
+    if (mLogsFolder != null && createWritableDir(mLogsFolder))
       return mLogsFolder;
 
     mLogsFolder = null;
@@ -121,12 +121,17 @@ public class LoggerFactory
   }
 
   // Only system logging allowed, see ensureLogsFolder().
-  private synchronized boolean createDir(@NonNull final String path)
+  private synchronized boolean createWritableDir(@NonNull final String path)
   {
     final File dir = new File(path);
     if (!dir.exists() && !dir.mkdirs())
     {
       Log.e(TAG, "Can't create a logs folder " + path);
+      return false;
+    }
+    if (!dir.canWrite())
+    {
+      Log.e(TAG, "Can't write to a logs folder " + path);
       return false;
     }
     return true;
@@ -139,7 +144,7 @@ public class LoggerFactory
     if (dir != null)
     {
       final String path = dir.getPath() + File.separator + "logs";
-      if (createDir(path))
+      if (createWritableDir(path))
         return path;
     }
     return null;

--- a/android/src/com/mapswithme/util/log/ZipLogsTask.java
+++ b/android/src/com/mapswithme/util/log/ZipLogsTask.java
@@ -30,14 +30,10 @@ class ZipLogsTask implements Runnable
   private final String mZipPath;
   @Nullable
   private final LoggerFactory.OnZipCompletedListener mOnCompletedListener;
-  @NonNull
-  private final Application mApplication;
 
-  ZipLogsTask(@NonNull Application application, @NonNull String logsPath,
-              @NonNull String zipPath,
-              @Nullable LoggerFactory.OnZipCompletedListener onCompletedListener)
+  ZipLogsTask(@NonNull String logsPath, @NonNull String zipPath,
+              @NonNull LoggerFactory.OnZipCompletedListener onCompletedListener)
   {
-    mApplication = application;
     mLogsPath = logsPath;
     mZipPath = zipPath;
     mOnCompletedListener = onCompletedListener;
@@ -133,7 +129,7 @@ class ZipLogsTask implements Runnable
         InputStreamReader reader = new InputStreamReader(process.getInputStream());
         FileWriter writer = new FileWriter(file))
     {
-      FileLoggerStrategy.WriteTask.writeSystemInformation(mApplication, writer);
+      LoggerFactory.INSTANCE.writeSystemInformation(writer);
       char[] buffer = new char[10000];
       do
       {

--- a/android/src/com/mapswithme/util/log/ZipLogsTask.java
+++ b/android/src/com/mapswithme/util/log/ZipLogsTask.java
@@ -1,13 +1,11 @@
 package com.mapswithme.util.log;
 
 import android.app.Application;
+import android.text.TextUtils;
 import android.util.Log;
 
 import androidx.annotation.NonNull;
 import androidx.annotation.Nullable;
-
-import com.mapswithme.util.StorageUtils;
-import com.mapswithme.util.Utils;
 
 import java.io.BufferedInputStream;
 import java.io.BufferedOutputStream;
@@ -24,68 +22,50 @@ import java.util.zip.ZipOutputStream;
 class ZipLogsTask implements Runnable
 {
   private final static String TAG = ZipLogsTask.class.getSimpleName();
+  private final static Logger LOGGER = LoggerFactory.INSTANCE.getLogger(LoggerFactory.Type.MISC);
   private final static int BUFFER_SIZE = 2048;
   @NonNull
-  private final String mSourcePath;
+  private final String mLogsPath;
   @NonNull
-  private final String mDestPath;
+  private final String mZipPath;
   @Nullable
   private final LoggerFactory.OnZipCompletedListener mOnCompletedListener;
   @NonNull
   private final Application mApplication;
 
-  ZipLogsTask(@NonNull Application application, @NonNull String sourcePath,
-              @NonNull String destPath,
+  ZipLogsTask(@NonNull Application application, @NonNull String logsPath,
+              @NonNull String zipPath,
               @Nullable LoggerFactory.OnZipCompletedListener onCompletedListener)
   {
     mApplication = application;
-    mSourcePath = sourcePath;
-    mDestPath = destPath;
+    mLogsPath = logsPath;
+    mZipPath = zipPath;
     mOnCompletedListener = onCompletedListener;
   }
 
   @Override
   public void run()
   {
-    saveSystemLogcat();
-    boolean success = zipFileAtPath(mSourcePath, mDestPath);
+    saveSystemLogcat(mLogsPath);
+    final boolean success = zipFileAtPath(mLogsPath, mZipPath);
     if (mOnCompletedListener != null)
-      mOnCompletedListener.onCompleted(success);
+      mOnCompletedListener.onCompleted(success, mZipPath);
   }
 
   private boolean zipFileAtPath(@NonNull String sourcePath, @NonNull String toLocation)
   {
     File sourceFile = new File(sourcePath);
-    try(FileOutputStream dest = new FileOutputStream(toLocation, false);
+    if (!sourceFile.isDirectory())
+      return false;
+    try (
+        FileOutputStream dest = new FileOutputStream(toLocation, false);
         ZipOutputStream out = new ZipOutputStream(new BufferedOutputStream(dest)))
     {
-      if (sourceFile.isDirectory())
-      {
-        zipSubFolder(out, sourceFile, sourceFile.getParent().length());
-      }
-      else
-      {
-        try(FileInputStream fi = new FileInputStream(sourcePath);
-            BufferedInputStream origin = new BufferedInputStream(fi, BUFFER_SIZE))
-        {
-          ZipEntry entry = new ZipEntry(getLastPathComponent(sourcePath));
-          out.putNextEntry(entry);
-          byte[] data = new byte[BUFFER_SIZE];
-          int count;
-          while ((count = origin.read(data, 0, BUFFER_SIZE)) != -1) {
-            out.write(data, 0, count);
-          }
-        } catch (Exception e)
-        {
-          Log.e(TAG, "Failed to read zip file entry '" + sourcePath +"' to location '"
-                  + toLocation + "'", e);
-          return false;
-        }
-      }
+      zipSubFolder(out, sourceFile, sourceFile.getParent().length());
     }
     catch (Exception e)
     {
-      Log.e(TAG, "Failed to zip file '" + sourcePath +"' to location '" + toLocation + "'", e);
+      Log.e(TAG, "Failed to zip file '" + sourcePath + "' to location '" + toLocation + "'", e);
       return false;
     }
     return true;
@@ -95,7 +75,9 @@ class ZipLogsTask implements Runnable
                             int basePathLength) throws IOException
   {
     File[] fileList = folder.listFiles();
-    BufferedInputStream origin;
+    if (fileList == null)
+      throw new IOException("Can't get files list of " + folder.getPath());
+
     for (File file : fileList)
     {
       if (file.isDirectory())
@@ -106,18 +88,19 @@ class ZipLogsTask implements Runnable
       {
         byte[] data = new byte[BUFFER_SIZE];
         String unmodifiedFilePath = file.getPath();
-        String relativePath = unmodifiedFilePath
-            .substring(basePathLength);
-        FileInputStream fi = new FileInputStream(unmodifiedFilePath);
-        origin = new BufferedInputStream(fi, BUFFER_SIZE);
-        ZipEntry entry = new ZipEntry(relativePath);
-        out.putNextEntry(entry);
-        int count;
-        while ((count = origin.read(data, 0, BUFFER_SIZE)) != -1)
+        String relativePath = unmodifiedFilePath.substring(basePathLength);
+        try (
+            FileInputStream fi = new FileInputStream(unmodifiedFilePath);
+            BufferedInputStream origin = new BufferedInputStream(fi, BUFFER_SIZE))
         {
-          out.write(data, 0, count);
+          ZipEntry entry = new ZipEntry(relativePath);
+          out.putNextEntry(entry);
+          int count;
+          while ((count = origin.read(data, 0, BUFFER_SIZE)) != -1)
+          {
+            out.write(data, 0, count);
+          }
         }
-        origin.close();
       }
     }
   }
@@ -130,19 +113,27 @@ class ZipLogsTask implements Runnable
     return segments[segments.length - 1];
   }
 
-  private void saveSystemLogcat()
+  private void saveSystemLogcat(String path)
   {
-    String fullName = StorageUtils.getLogsFolder(mApplication) + File.separator + "logcat.log";
-    final File file = new File(fullName);
-    InputStreamReader reader = null;
-    FileWriter writer = null;
+    final String cmd = "logcat -d -v time";
+    Process process;
     try
     {
-      writer = new FileWriter(file);
+      process = Runtime.getRuntime().exec(cmd);
+    }
+    catch (IOException e)
+    {
+      LOGGER.e(TAG, "Failed to get system logcat", e);
+      return;
+    }
+
+    path += File.separator + "logcat.log";
+    final File file = new File(path);
+    try (
+        InputStreamReader reader = new InputStreamReader(process.getInputStream());
+        FileWriter writer = new FileWriter(file))
+    {
       FileLoggerStrategy.WriteTask.writeSystemInformation(mApplication, writer);
-      String cmd = "logcat -d -v time";
-      Process process = Runtime.getRuntime().exec(cmd);
-      reader = new InputStreamReader(process.getInputStream());
       char[] buffer = new char[10000];
       do
       {
@@ -154,12 +145,8 @@ class ZipLogsTask implements Runnable
     }
     catch (Throwable e)
     {
-      Log.e(TAG, "Failed to save system logcat to file: " + file, e);
-    }
-    finally
-    {
-      Utils.closeSafely(writer);
-      Utils.closeSafely(reader);
+      LoggerFactory.INSTANCE.getLogger(LoggerFactory.Type.MISC);
+      LOGGER.e(TAG, "Failed to save system logcat to " + path, e);
     }
   }
 }


### PR DESCRIPTION
- use internal storage as a logs folder fallback location (fixes https://github.com/organicmaps/organicmaps/issues/2567#issuecomment-1145751561)
- try to re-create / re-get a changed folder from the system if its gone
- the current logs location stays active until app restart or another "folder is gone" issue
- switch file logging off if nothing had helped
- show message to a user if he tries to enable the logging setting but a logs folder can't be created
- fix DEBUG core messages not logged after file logging is switched on and off
- better logging and error handling
- simplify and delete unused code

- make bugreport and general feedback features send to flavor-specific support email

upd:
- check logs folder for writability
(for cases it becomes readonly after it was initially created)


    
