### PR TITLE
[strings] fix de translation for 'camera ahead'

### DIFF
--- a/data/sound-strings/de.json/localize.json
+++ b/data/sound-strings/de.json/localize.json
@@ -63,5 +63,5 @@
 "in_1_mile":"In einer Meile",
 "in_1_5_miles":"In anderthalb Meilen",
 "in_2_miles":"In zwei Meilen",
-"unknown_camera":"Kamera vorne"
+"unknown_camera":"Blitzer voraus"
 }

--- a/data/strings/sound.txt
+++ b/data/strings/sound.txt
@@ -2310,7 +2310,7 @@
     be = Наперадзе камера
     cs = Radar vpředu
     da = Kamera foran dig
-    de = Kamera vorne
+    de = Blitzer voraus
     el = Κάμερα παρακάτω
     es = Cámara adelante
     eu = Kamera aurrera


### PR DESCRIPTION
fixes #2694 