### PR TITLE
[android] Remove unused com.github.bumptech.glide dependency

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -86,7 +86,6 @@ dependencies {
   implementation 'androidx.preference:preference:1.2.0'
   implementation 'androidx.recyclerview:recyclerview:1.2.1'
   implementation 'androidx.work:work-runtime:2.7.1'
-  implementation 'com.github.bumptech.glide:glide:4.13.2'
   implementation 'com.google.android.material:material:1.7.0-alpha02'
   implementation 'com.google.code.gson:gson:2.9.0'
   implementation 'com.timehop.stickyheadersrecyclerview:library:0.4.3@aar'

--- a/data/copyright.html
+++ b/data/copyright.html
@@ -164,10 +164,6 @@
     <li><a href="http://www.freetype.org">FreeType</a><br>
       &copy; 2013 The FreeType Project; <a href="#freetype-license" class="license">FTL</a></li>
 
-    <Li><a href="https://github.com/bumptech/glide">Glide</a><br>
-      &copy; 2014 Google Inc.; <a href="#bsd3-license" class="license">BSD License;</a> <a href="#mit-license" class="license">MIT License;</a>
-      <a href="#apache2-license" class="license">Apache License</a></li>
-
     <li><a href="http://www.g-truc.net/project-0016.html">GLM</a><br>
       &copy; 2005&ndash;2014 G-Truc Creation; <a href="#mit-license" class="license">MIT License</a></li>
 


### PR DESCRIPTION
[Glide](https://github.com/bumptech/glide) is used for loading images and videos but I did not see any usage of this lib. I was able to sync gradle and build on an emulator without issues. Maybe this was a leftover from the mapsme fork?
