### PR TITLE
Initialize ObjC to skip m/mm files in Unity builds

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,6 +1,12 @@
 cmake_minimum_required(VERSION 3.18)
 
-project(omim C CXX)
+set(LANGUAGES C CXX)
+if (APPLE)
+  # OBJC/OBJCXX are needed to skip m/mm files in Unity builds.
+  # https://gitlab.kitware.com/cmake/cmake/-/issues/21963
+  list(APPEND LANGUAGES OBJC OBJCXX)
+endif()
+project(omim ${LANGUAGES})
 
 set(CMAKE_CXX_STANDARD 17)
 set(CMAKE_C_STANDARD 11)

--- a/platform/CMakeLists.txt
+++ b/platform/CMakeLists.txt
@@ -159,16 +159,7 @@ omim_add_test_subdirectory(platform_tests)
 set_property(
   SOURCE
     preferred_languages.cpp
-    apple_location_service.mm
-    gui_thread_apple.mm
-    http_client_apple.mm
-    http_thread_apple.mm
-    http_uploader_apple.mm
     http_uploader_background_dummy.cpp
-    locale.mm
-    platform_mac.mm
-    socket_apple.mm
-    http_session_manager.mm
   PROPERTY
     SKIP_UNITY_BUILD_INCLUSION ON
 )


### PR DESCRIPTION
It should also initialize proper parameters used to compile ObjC(++) files