### PR TITLE
Allow less width dialogs.

### DIFF
--- a/qt/about.cpp
+++ b/qt/about.cpp
@@ -21,6 +21,7 @@ AboutDialog::AboutDialog(QWidget * parent)
 {
   QIcon icon(":/ui/logo.png");
   setWindowIcon(icon);
+  setGeometry(0, 0, 250, 250);
   setWindowTitle(QMenuBar::tr("About"));
 
   QLabel * labelIcon = new QLabel();

--- a/qt/main.cpp
+++ b/qt/main.cpp
@@ -153,6 +153,10 @@ int main(int argc, char * argv[])
       reader.ReadAsString(buffer);
     }
     qt::InfoDialog eulaDialog(qAppName(), buffer.c_str(), nullptr, {"Accept", "Decline"});
+
+    //This intro screen should be visible not going off the edge on phones or other less wide devices:
+    eulaDialog.setMinimumWidth(250);
+    
     eulaAccepted = (eulaDialog.exec() == 1);
     settings::Set(settingsEULA, eulaAccepted);
   }

--- a/qt/mainwindow.cpp
+++ b/qt/mainwindow.cpp
@@ -113,7 +113,7 @@ MainWindow::MainWindow(Framework & framework, bool apiOpenGLES3,
     };
   }
 
-  int const width = m_screenshotMode ? static_cast<int>(screenshotParams->m_width) : 0;
+  int const width = 100; //m_screenshotMode ? static_cast<int>(screenshotParams->m_width) : 0;
   int const height = m_screenshotMode ? static_cast<int>(screenshotParams->m_height) : 0;
   m_pDrawWidget = new DrawWidget(framework, apiOpenGLES3, std::move(screenshotParams), this);
 
@@ -196,6 +196,10 @@ MainWindow::MainWindow(Framework & framework, bool apiOpenGLES3,
     {
       InfoDialog welcomeDlg(QString("Welcome to ") + qAppName(), text.c_str(),
                             this, QStringList(tr("Download Maps")));
+                            
+      //This intro screen should be visible not going off the edge on phones or other less wide devices:
+      welcomeDlg.setMinimumWidth(250);
+
       if (welcomeDlg.exec() == QDialog::Rejected)
         bShowUpdateDialog = false;
     }


### PR DESCRIPTION
On phones and devices with smaller screens, the dialogs should be allowed to be smaller.
Without this it oddly goes all the way off the screen.
I tested this on desktop resizing the windows smaller.