### PR TITLE
Issue 2787 - Facebook validation fix

### DIFF
--- a/indexer/indexer_tests/validate_and_format_contacts_test.cpp
+++ b/indexer/indexer_tests/validate_and_format_contacts_test.cpp
@@ -18,6 +18,7 @@ UNIT_TEST(EditableMapObject_ValidateFacebookPage)
   TEST(osm::ValidateFacebookPage("some.good.page"), ());
   TEST(osm::ValidateFacebookPage("Quaama-Volunteer-Bushfire-Brigade-526790054021506"), ());
   TEST(osm::ValidateFacebookPage("P\xE1ter-Bonif\xE1""c-Restaurant-Budapest-111001693867133"), ());
+  TEST(osm::ValidateFacebookPage("P\xc3\xa1ter-Bonif\xc3\xa1""c-Restaurant-Budapest-111001693867133"), ());
   TEST(osm::ValidateFacebookPage("@tree-house-interiors"), ());
   TEST(osm::ValidateFacebookPage("allow_underscore-1234567890"), ());
   TEST(osm::ValidateFacebookPage("alexander.net"), ());

--- a/indexer/indexer_tests/validate_and_format_contacts_test.cpp
+++ b/indexer/indexer_tests/validate_and_format_contacts_test.cpp
@@ -17,13 +17,14 @@ UNIT_TEST(EditableMapObject_ValidateFacebookPage)
   TEST(osm::ValidateFacebookPage("OpenStreetMap"), ());
   TEST(osm::ValidateFacebookPage("some.good.page"), ());
   TEST(osm::ValidateFacebookPage("Quaama-Volunteer-Bushfire-Brigade-526790054021506"), ());
+  TEST(osm::ValidateFacebookPage("P\xE1ter-Bonif\xE1""c-Restaurant-Budapest-111001693867133"), ());
   TEST(osm::ValidateFacebookPage("@tree-house-interiors"), ());
+  TEST(osm::ValidateFacebookPage("allow_underscore-1234567890"), ());
   TEST(osm::ValidateFacebookPage("alexander.net"), ());
 
   TEST(!osm::ValidateFacebookPage("instagram.com/openstreetmapus"), ());
   TEST(!osm::ValidateFacebookPage("https://instagram.com/openstreetmapus"), ());
   TEST(!osm::ValidateFacebookPage("osm"), ());
-  TEST(!osm::ValidateFacebookPage("invalid_username"), ());
 }
 
 UNIT_TEST(EditableMapObject_ValidateInstagramPage)

--- a/indexer/validate_and_format_contacts.cpp
+++ b/indexer/validate_and_format_contacts.cpp
@@ -10,7 +10,7 @@ using namespace std;
 
 namespace osm {
 
-static auto const s_fbRegex = regex(R"(^@?[a-zA-Z\d.\-]{5,}$)");
+static auto const s_fbRegex = regex(R"(^@?[a-zA-Z\xE1\d.\-_]{5,}$)");
 static auto const s_instaRegex = regex(R"(^@?[A-Za-z0-9_][A-Za-z0-9_.]{0,28}[A-Za-z0-9_]$)");
 static auto const s_twitterRegex = regex(R"(^@?[A-Za-z0-9_]{1,15}$)");
 static auto const s_badVkRegex = regex(R"(^\d\d\d.+$)");


### PR DESCRIPTION
Working on #2787 issue.

Looks like FB validation fails because of extra character `á` (Latin Small Letter A with acute). It's part of (Latin-1 Supplement)[https://en.wikipedia.org/wiki/Latin-1_Supplement] part of codepage.

This extra char code is `\xE1`. But when we get string from Java to C++ the char is converted to unicode bytes `\xC3\xA1`. How to write correct regex to cover 2 bytes chars?

And another question: should we also validate other Latin-1 Supplement characters such as `Ç`, `Ó`, `ß`, `ñ` ?