### PR TITLE
Directions refactoring + Show speed limit

### DIFF
--- a/qt/draw_widget.cpp
+++ b/qt/draw_widget.cpp
@@ -467,21 +467,25 @@ void DrawWidget::SubmitFakeLocationPoint(m2::PointD const & pt)
 
   if (m_framework.GetRoutingManager().IsRoutingActive())
   {
+    // Immidiate update of of position in Route. m_framework.OnLocationUpdate is too late.
+    m_framework.GetRoutingManager().RoutingSession().OnLocationPositionChanged(qt::common::MakeGpsInfo(point));
+
     routing::FollowingInfo loc;
     m_framework.GetRoutingManager().GetRouteFollowingInfo(loc);
     if (m_framework.GetRoutingManager().GetCurrentRouterType() == routing::RouterType::Pedestrian)
     {
-      LOG(LDEBUG, ("Distance:", loc.m_distToTarget, loc.m_targetUnitsSuffix, "Time:", loc.m_time,
+      LOG(LDEBUG, ("Distance:", loc.m_distToTarget + loc.m_targetUnitsSuffix, "Time:", loc.m_time,
                    DebugPrint(loc.m_pedestrianTurn),
-                   "in", loc.m_distToTurn, loc.m_turnUnitsSuffix,
-                   "to", loc.m_targetName));
+                   "in", loc.m_distToTurn + loc.m_turnUnitsSuffix,
+                   loc.m_targetName.empty() ? "" : "to " + loc.m_targetName ));
     }
     else
     {
-      LOG(LDEBUG, ("Distance:", loc.m_distToTarget, loc.m_targetUnitsSuffix, "Time:", loc.m_time,
+      LOG(LDEBUG, ("Distance:", loc.m_distToTarget + loc.m_targetUnitsSuffix, "Time:", loc.m_time,
+                   loc.m_speedLimitUnitsSuffix.empty() ? "" : "SpeedLimit: " + loc.m_speedLimit + loc.m_speedLimitUnitsSuffix,
                    GetTurnString(loc.m_turn), (loc.m_exitNum != 0 ? ":" + std::to_string(loc.m_exitNum) : ""),
-                   "in", loc.m_distToTurn, loc.m_turnUnitsSuffix,
-                   "to", loc.m_targetName));
+                   "in", loc.m_distToTurn + loc.m_turnUnitsSuffix,
+                   loc.m_targetName.empty() ? "" : "to " + loc.m_targetName ));
     }
   }
 }

--- a/routing/car_directions.cpp
+++ b/routing/car_directions.cpp
@@ -30,7 +30,8 @@ void FixupCarTurns(vector<RouteSegment> & routeSegments)
   // (1) the route enters to the roundabout;
   // (2) the route leaves the roundabout;
   uint32_t exitNum = 0;
-  size_t currentEnterRoundAbout = routeSegments.size();
+  size_t const kInvalidEnter = routeSegments.size();
+  size_t currentEnterRoundAbout = kInvalidEnter;
 
   for (size_t idx = 0; idx < routeSegments.size(); ++idx)
   {
@@ -38,16 +39,16 @@ void FixupCarTurns(vector<RouteSegment> & routeSegments)
     if (t.IsTurnNone())
       continue;
 
-    if (currentEnterRoundAbout < routeSegments.size() && t.m_turn != CarDirection::StayOnRoundAbout
+    if (currentEnterRoundAbout != kInvalidEnter && t.m_turn != CarDirection::StayOnRoundAbout
         && t.m_turn != CarDirection::LeaveRoundAbout && t.m_turn != CarDirection::ReachedYourDestination)
     {
       ASSERT(false, ("Only StayOnRoundAbout, LeaveRoundAbout or ReachedYourDestination are expected after EnterRoundAbout."));
       exitNum = 0;
-      currentEnterRoundAbout = routeSegments.size();
+      currentEnterRoundAbout = kInvalidEnter;
     }
     else if (t.m_turn == CarDirection::EnterRoundAbout)
     {
-      ASSERT(currentEnterRoundAbout == routeSegments.size(), ("It's not expected to find new EnterRoundAbout until previous EnterRoundAbout was leaved."));
+      ASSERT(currentEnterRoundAbout == kInvalidEnter, ("It's not expected to find new EnterRoundAbout until previous EnterRoundAbout was leaved."));
       currentEnterRoundAbout = idx;
       ASSERT(exitNum == 0, ("exitNum is reset at start and after LeaveRoundAbout."));
       exitNum = 0;
@@ -62,10 +63,10 @@ void FixupCarTurns(vector<RouteSegment> & routeSegments)
     {
       // It's possible for car to be on roundabout without entering it
       // if route calculation started at roundabout (e.g. if user made full turn on roundabout).
-      if (currentEnterRoundAbout < routeSegments.size())
+      if (currentEnterRoundAbout != kInvalidEnter)
         routeSegments[currentEnterRoundAbout].SetTurnExits(exitNum + 1);
       routeSegments[idx].SetTurnExits(exitNum + 1); // For LeaveRoundAbout turn.
-      currentEnterRoundAbout = routeSegments.size();
+      currentEnterRoundAbout = kInvalidEnter;
       exitNum = 0;
     }
 

--- a/routing/car_directions.cpp
+++ b/routing/car_directions.cpp
@@ -17,61 +17,55 @@ CarDirectionsEngine::CarDirectionsEngine(MwmDataSource & dataSource, shared_ptr<
 {
 }
 
-void CarDirectionsEngine::FixupTurns(std::vector<geometry::PointWithAltitude> const & junctions, Route::TTurns & turnsDir)
+void CarDirectionsEngine::FixupTurns(vector<RouteSegment> & routeSegments)
 {
-  FixupCarTurns(junctions, turnsDir);
-
-#ifdef DEBUG
-  for (auto const & t : turnsDir)
-    LOG(LDEBUG, (GetTurnString(t.m_turn), ":", t.m_index, t.m_sourceName, "-",
-                 t.m_targetName, "exit:", t.m_exitNum));
-#endif
+  FixupCarTurns(routeSegments);
 }
 
-void FixupCarTurns(std::vector<geometry::PointWithAltitude> const & junctions, Route::TTurns & turnsDir)
+void FixupCarTurns(vector<RouteSegment> & routeSegments)
 {
-  uint32_t turn_index = base::asserted_cast<uint32_t>(junctions.size() - 1);
-  turnsDir.emplace_back(TurnItem(turn_index, CarDirection::ReachedYourDestination));
-
   double constexpr kMergeDistMeters = 15.0;
   // For turns that are not EnterRoundAbout/ExitRoundAbout exitNum is always equal to zero.
   // If a turn is EnterRoundAbout exitNum is a number of turns between two junctions:
   // (1) the route enters to the roundabout;
   // (2) the route leaves the roundabout;
   uint32_t exitNum = 0;
-  TurnItem * currentEnterRoundAbout = nullptr;
+  size_t currentEnterRoundAbout = routeSegments.size();
 
-  for (size_t idx = 0; idx < turnsDir.size(); )
+  for (size_t idx = 0; idx < routeSegments.size(); ++idx)
   {
-    TurnItem & t = turnsDir[idx];
-    if (currentEnterRoundAbout && t.m_turn != CarDirection::StayOnRoundAbout
+    auto & t = routeSegments[idx].GetTurn();
+    if (t.IsTurnNone())
+      continue;
+
+    if (currentEnterRoundAbout < routeSegments.size() && t.m_turn != CarDirection::StayOnRoundAbout
         && t.m_turn != CarDirection::LeaveRoundAbout && t.m_turn != CarDirection::ReachedYourDestination)
     {
       ASSERT(false, ("Only StayOnRoundAbout, LeaveRoundAbout or ReachedYourDestination are expected after EnterRoundAbout."));
       exitNum = 0;
-      currentEnterRoundAbout = nullptr;
+      currentEnterRoundAbout = routeSegments.size();
     }
     else if (t.m_turn == CarDirection::EnterRoundAbout)
     {
-      ASSERT(!currentEnterRoundAbout, ("It's not expected to find new EnterRoundAbout until previous EnterRoundAbout was leaved."));
-      currentEnterRoundAbout = &t;
+      ASSERT(currentEnterRoundAbout == routeSegments.size(), ("It's not expected to find new EnterRoundAbout until previous EnterRoundAbout was leaved."));
+      currentEnterRoundAbout = idx;
       ASSERT(exitNum == 0, ("exitNum is reset at start and after LeaveRoundAbout."));
       exitNum = 0;
     }
     else if (t.m_turn == CarDirection::StayOnRoundAbout)
     {
       ++exitNum;
-      turnsDir.erase(turnsDir.begin() + idx);
+      routeSegments[idx].ClearTurn();
       continue;
     }
     else if (t.m_turn == CarDirection::LeaveRoundAbout)
     {
       // It's possible for car to be on roundabout without entering it
       // if route calculation started at roundabout (e.g. if user made full turn on roundabout).
-      if (currentEnterRoundAbout)
-        currentEnterRoundAbout->m_exitNum = exitNum + 1;
-      t.m_exitNum = exitNum + 1; // For LeaveRoundAbout turn.
-      currentEnterRoundAbout = nullptr;
+      if (currentEnterRoundAbout < routeSegments.size())
+        routeSegments[currentEnterRoundAbout].SetTurnExits(exitNum + 1);
+      routeSegments[idx].SetTurnExits(exitNum + 1); // For LeaveRoundAbout turn.
+      currentEnterRoundAbout = routeSegments.size();
       exitNum = 0;
     }
 
@@ -79,18 +73,16 @@ void FixupCarTurns(std::vector<geometry::PointWithAltitude> const & junctions, R
     // distance(turnsDir[idx - 1].m_index, turnsDir[idx].m_index) < kMergeDistMeters
     // means the distance in meters between the former turn (idx - 1)
     // and the current turn (idx).
-    if (idx > 0 && IsStayOnRoad(turnsDir[idx - 1].m_turn) &&
-        IsLeftOrRightTurn(turnsDir[idx].m_turn) &&
-        CalcRouteDistanceM(junctions, turnsDir[idx - 1].m_index, turnsDir[idx].m_index) <
-            kMergeDistMeters)
+    if (idx > 0 && IsStayOnRoad(routeSegments[idx - 1].GetTurn().m_turn) &&
+        IsLeftOrRightTurn(t.m_turn))
     {
-      turnsDir.erase(turnsDir.begin() + idx - 1);
-      continue;
+      auto const & junction = routeSegments[idx].GetJunction();
+      auto const & prevJunction = routeSegments[idx - 1].GetJunction();
+      if (mercator::DistanceOnEarth(junction.GetPoint(), prevJunction.GetPoint()) < kMergeDistMeters)
+        routeSegments[idx - 1].ClearTurn();
     }
-
-    ++idx;
   }
-  SelectRecommendedLanes(turnsDir);
+  SelectRecommendedLanes(routeSegments);
 }
 
 void GetTurnDirectionBasic(IRoutingResult const & result, size_t const outgoingSegmentIndex,
@@ -101,11 +93,17 @@ size_t CarDirectionsEngine::GetTurnDirection(IRoutingResult const & result, size
                                              NumMwmIds const & numMwmIds,
                                              RoutingSettings const & vehicleSettings, TurnItem & turnItem)
 {
+  if (outgoingSegmentIndex == result.GetSegments().size())
+  {
+    turnItem.m_turn = CarDirection::ReachedYourDestination;
+    return 0;
+  }
+
   // This is for jump from initial point to start of the route. No direction is given.
   /// @todo Sometimes results of GetPossibleTurns are empty, sometimes are invalid.
   /// The best will be to fix GetPossibleTurns(). It will allow us to use following approach.
   /// E.g. Google Maps until you reach the destination will guide you to go to the left or to the right of the first road.
-  if (turnItem.m_index == 2)
+  if (outgoingSegmentIndex == 1) // The same as turnItem.m_index == 2.
     return 0;
 
   size_t skipTurnSegments = CheckUTurnOnRoute(result, outgoingSegmentIndex, numMwmIds, vehicleSettings, turnItem);
@@ -265,7 +263,7 @@ double constexpr kMinAbsAngleDiffForSameOrSmallerRoad = 35.0;
 /// \param turnInfo is information about ingoing and outgoing segments of the route.
 bool CanDiscardTurnByHighwayClassOrAngles(CarDirection const routeDirection,
                                           double const routeAngle,
-                                          std::vector<TurnCandidate> const & turnCandidates,
+                                          vector<TurnCandidate> const & turnCandidates,
                                           TurnInfo const & turnInfo,
                                           NumMwmIds const & numMwmIds)
 {
@@ -363,7 +361,7 @@ void CorrectGoStraight(TurnCandidate const & notRouteCandidate, double const rou
 // and there's another not sharp enough turn
 // GoStraight is corrected to TurnSlightRight/TurnSlightLeft
 // to avoid ambiguity for GoStraight direction: 2 or more almost straight turns.
-void CorrectRightmostAndLeftmost(std::vector<TurnCandidate> const & turnCandidates,
+void CorrectRightmostAndLeftmost(vector<TurnCandidate> const & turnCandidates,
                                  Segment const & firstOutgoingSeg, double const turnAngle,
                                  TurnItem & turn)
 {
@@ -425,8 +423,6 @@ void GetTurnDirectionBasic(IRoutingResult const & result, size_t const outgoingS
   if (!GetTurnInfo(result, outgoingSegmentIndex, vehicleSettings, turnInfo))
     return;
 
-  turn.m_sourceName = turnInfo.m_ingoing->m_roadNameInfo.m_name;
-  turn.m_targetName = turnInfo.m_outgoing->m_roadNameInfo.m_name;
   turn.m_turn = CarDirection::None;
 
   ASSERT_GREATER(turnInfo.m_ingoing->m_path.size(), 1, ());
@@ -598,7 +594,7 @@ size_t CheckUTurnOnRoute(IRoutingResult const & result, size_t const outgoingSeg
   return 0;
 }
 
-bool FixupLaneSet(CarDirection turn, std::vector<SingleLaneInfo> & lanes,
+bool FixupLaneSet(CarDirection turn, vector<SingleLaneInfo> & lanes,
                   function<bool(LaneWay l, CarDirection t)> checker)
 {
   bool isLaneConformed = false;
@@ -620,21 +616,21 @@ bool FixupLaneSet(CarDirection turn, std::vector<SingleLaneInfo> & lanes,
   return isLaneConformed;
 }
 
-void SelectRecommendedLanes(Route::TTurns & turnsDir)
+void SelectRecommendedLanes(vector<RouteSegment> & routeSegments)
 {
-  for (auto & t : turnsDir)
+  for (size_t idx = 0; idx < routeSegments.size(); ++idx)
   {
-    std::vector<SingleLaneInfo> & lanes = t.m_lanes;
-    if (lanes.empty())
+    auto & t = routeSegments[idx].GetTurn();
+    if (t.IsTurnNone() || t.m_lanes.empty())
       continue;
-    CarDirection const turn = t.m_turn;
-    // Checking if threre are elements in lanes which correspond with the turn exactly.
+    auto & lanes = routeSegments[idx].GetTurnLanes();
+    // Checking if there are elements in lanes which correspond with the turn exactly.
     // If so fixing up all the elements in lanes which correspond with the turn.
-    if (FixupLaneSet(turn, lanes, &IsLaneWayConformedTurnDirection))
+    if (FixupLaneSet(t.m_turn, lanes, &IsLaneWayConformedTurnDirection))
       continue;
     // If not checking if there are elements in lanes which corresponds with the turn
     // approximately. If so fixing up all these elements.
-    FixupLaneSet(turn, lanes, &IsLaneWayConformedTurnDirectionApproximately);
+    FixupLaneSet(t.m_turn, lanes, &IsLaneWayConformedTurnDirectionApproximately);
   }
 }
 

--- a/routing/car_directions.hpp
+++ b/routing/car_directions.hpp
@@ -3,6 +3,7 @@
 #include "routing/directions_engine.hpp"
 
 #include "routing_common/num_mwm_id.hpp"
+#include "routing/route.hpp"
 
 #include <map>
 #include <memory>
@@ -20,16 +21,15 @@ protected:
   virtual size_t GetTurnDirection(turns::IRoutingResult const & result, size_t const outgoingSegmentIndex,
                                   NumMwmIds const & numMwmIds,
                                   RoutingSettings const & vehicleSettings, turns::TurnItem & turn);
-  virtual void FixupTurns(std::vector<geometry::PointWithAltitude> const & junctions,
-                          Route::TTurns & turnsDir);
+  virtual void FixupTurns(std::vector<RouteSegment> & routeSegments);
 };
 
 /*!
  * \brief Selects lanes which are recommended for an end user.
  */
-void SelectRecommendedLanes(Route::TTurns & turnsDir);
+void SelectRecommendedLanes(std::vector<RouteSegment> & routeSegments);
 
-void FixupCarTurns(std::vector<geometry::PointWithAltitude> const & junctions, Route::TTurns & turnsDir);
+void FixupCarTurns(std::vector<RouteSegment> & routeSegments);
 
 /*!
  * \brief Finds an U-turn that starts from master segment and returns how many segments it lasts.

--- a/routing/directions_engine.cpp
+++ b/routing/directions_engine.cpp
@@ -74,7 +74,8 @@ void DirectionsEngine::LoadPathAttributes(FeatureID const & featureId,
   pathSegment.m_roadNameInfo.m_ref = ft->GetRoadNumber();
   pathSegment.m_roadNameInfo.m_name = ft->GetName(StringUtf8Multilang::kDefaultCode);
 
-  if (m_vehicleType == VehicleType::Car)
+  /// @todo Find a way to optimize it, e.g. by using speeds cache in GeometryLoader (GeometryLoaderImpl).
+  if (false && m_vehicleType == VehicleType::Car)
   {
     auto const & handle = m_dataSource.GetHandle(featureId.m_mwmId);
     auto const speeds = routing::LoadMaxspeeds(handle);

--- a/routing/directions_engine.cpp
+++ b/routing/directions_engine.cpp
@@ -2,6 +2,7 @@
 
 #include "routing/data_source.hpp"
 #include "routing/fake_feature_ids.hpp"
+#include "routing/maxspeeds.hpp"
 #include "routing/routing_helpers.hpp"
 #include "routing/routing_callbacks.hpp"
 
@@ -40,7 +41,7 @@ void DirectionsEngine::Clear()
   m_pathSegments.clear();
 }
 
-std::unique_ptr<FeatureType> DirectionsEngine::GetFeature(FeatureID const & featureId)
+unique_ptr<FeatureType> DirectionsEngine::GetFeature(FeatureID const & featureId)
 {
   if (IsFakeFeature(featureId.m_index))
     return nullptr;
@@ -72,6 +73,18 @@ void DirectionsEngine::LoadPathAttributes(FeatureID const & featureId,
   pathSegment.m_roadNameInfo.m_destination = ft->GetMetadata(feature::Metadata::FMD_DESTINATION);
   pathSegment.m_roadNameInfo.m_ref = ft->GetRoadNumber();
   pathSegment.m_roadNameInfo.m_name = ft->GetName(StringUtf8Multilang::kDefaultCode);
+
+  if (m_vehicleType == VehicleType::Car)
+  {
+    auto const & handle = m_dataSource.GetHandle(featureId.m_mwmId);
+    auto const speeds = routing::LoadMaxspeeds(handle);
+    if (speeds)
+    {
+      auto s = speeds->GetMaxspeed(featureId.m_index);
+      if (s.IsValid() && !pathSegment.m_segments.empty())
+        pathSegment.m_maxSpeed = routing::SpeedInUnits(s.GetSpeedInUnits(pathSegment.m_segments[0].IsForward()), s.GetUnits());
+    }
+  }
 }
 
 void DirectionsEngine::GetSegmentRangeAndAdjacentEdges(IRoadGraph::EdgeListT const & outgoingEdges,
@@ -202,7 +215,6 @@ void DirectionsEngine::FillPathSegmentsAndAdjacentEdgesMap(
 
     size_t const prevJunctionSize = prevJunctions.size();
     LoadedPathSegment pathSegment;
-    LoadPathAttributes(segmentRange.GetFeature(), pathSegment);
     pathSegment.m_segmentRange = segmentRange;
     pathSegment.m_path = move(prevJunctions);
     // @TODO(bykoianko) |pathSegment.m_weight| should be filled here.
@@ -211,6 +223,7 @@ void DirectionsEngine::FillPathSegmentsAndAdjacentEdgesMap(
     // fake edge a fake segment is created.
     CHECK_EQUAL(prevSegments.size() + 1, prevJunctionSize, ());
     pathSegment.m_segments = move(prevSegments);
+    LoadPathAttributes(segmentRange.GetFeature(), pathSegment); // inEdge.IsForward()
 
     if (!segmentRange.IsEmpty())
     {
@@ -228,38 +241,36 @@ void DirectionsEngine::FillPathSegmentsAndAdjacentEdgesMap(
 
 bool DirectionsEngine::Generate(IndexRoadGraph const & graph,
                                 vector<geometry::PointWithAltitude> const & path,
-                                base::Cancellable const & cancellable, Route::TTurns & turns,
-                                Route::TStreets & streetNames,
-                                vector<geometry::PointWithAltitude> & routeGeometry,
-                                vector<Segment> & segments)
+                                base::Cancellable const & cancellable,
+                                vector<RouteSegment> & routeSegments)
 {
   CHECK(m_numMwmIds, ());
 
   m_adjacentEdges.clear();
   m_pathSegments.clear();
-  turns.clear();
-  streetNames.clear();
-  segments.clear();
 
   IndexRoadGraph::EdgeVector routeEdges;
+  graph.GetRouteEdges(routeEdges);
 
   CHECK_NOT_EQUAL(m_vehicleType, VehicleType::Count, (m_vehicleType));
 
   if (m_vehicleType == VehicleType::Transit)
   {
-    routeGeometry = path;
-    graph.GetRouteSegments(segments);
-    graph.GetRouteEdges(routeEdges);
-    turns.emplace_back(routeEdges.size(), turns::PedestrianDirection::ReachedYourDestination);
+    for (size_t i = 0; i < routeEdges.size(); ++i)
+    {
+      auto const & pos = path[i+1];
+      TurnItem turn;
+      if (i == routeEdges.size() - 2)
+        turn.m_pedestrianTurn = turns::PedestrianDirection::ReachedYourDestination;
+      routeSegments.emplace_back(
+        RouteSegment(ConvertEdgeToSegment(*m_numMwmIds, routeEdges[i]), turn, pos, RouteSegment::RoadNameInfo(),
+                                  SpeedInUnits(), traffic::SpeedGroup::Unknown));
+    }
     return true;
   }
 
-  routeGeometry.clear();
-
   if (path.size() <= 1)
     return false;
-
-  graph.GetRouteEdges(routeEdges);
 
   if (routeEdges.empty())
     return false;
@@ -272,23 +283,9 @@ bool DirectionsEngine::Generate(IndexRoadGraph const & graph,
   if (cancellable.IsCancelled())
     return false;
 
-  auto const res = MakeTurnAnnotation(routeEdges, cancellable,
-                                      routeGeometry, turns, streetNames, segments);
+  MakeTurnAnnotation(routeEdges, routeSegments);
 
-  if (res != RouterResultCode::NoError)
-    return false;
-
-  // In case of bicycle routing |m_pathSegments| may have an empty
-  // |LoadedPathSegment::m_segments| fields. In that case |segments| is empty
-  // so size of |segments| is not equal to size of |routeEdges|.
-  if (!segments.empty())
-    CHECK_EQUAL(segments.size(), routeEdges.size(), ());
-
-
-  CHECK_EQUAL(
-      routeGeometry.size(), path.size(),
-      ("routeGeometry and path have different sizes. routeGeometry size:", routeGeometry.size(),
-       "path size:", path.size(), "segments size:", segments.size(), "routeEdges size:", routeEdges.size()));
+  CHECK_EQUAL(routeSegments.size(), routeEdges.size(), ());
 
   return true;
 }
@@ -324,81 +321,65 @@ bool DirectionsEngine::Generate(IndexRoadGraph const & graph,
 // So minimum m_index of ReachedYourDestination is 5 (real route with single segment),
 // and minimal |turnsDir| is - single ReachedYourDestination with m_index == 5.
 
-RouterResultCode DirectionsEngine::MakeTurnAnnotation(IndexRoadGraph::EdgeVector const & routeEdges,
-                                                      base::Cancellable const & cancellable,
-                                                      std::vector<geometry::PointWithAltitude> & junctions,
-                                                      Route::TTurns & turnsDir, Route::TStreets & streets,
-                                                      std::vector<Segment> & segments)
+void DirectionsEngine::MakeTurnAnnotation(IndexRoadGraph::EdgeVector const & routeEdges,
+                                          vector<RouteSegment> & routeSegments)
 {
+  CHECK_GREATER_OR_EQUAL(routeEdges.size(), 2, ());
+
   RoutingEngineResult result(routeEdges, m_adjacentEdges, m_pathSegments);
 
   LOG(LDEBUG, ("Shortest path length:", result.GetPathLength()));
 
-  if (cancellable.IsCancelled())
-    return RouterResultCode::Cancelled;
-
-  size_t skipTurnSegments = 0;
-  auto const & loadedSegments = result.GetSegments();
-  segments.reserve(loadedSegments.size());
+  routeSegments.reserve(routeEdges.size());
 
   RoutingSettings const vehicleSettings = GetRoutingSettings(m_vehicleType);
 
-  for (auto loadedSegmentIt = loadedSegments.cbegin(); loadedSegmentIt != loadedSegments.cend(); ++loadedSegmentIt)
+  auto const & loadedSegments = result.GetSegments();
+
+  // First point of first loadedSegment is ignored. This is the reason for:
+  auto lastSegment = loadedSegments.front();
+  ASSERT(lastSegment.m_path.back() == lastSegment.m_path.front(), ());
+
+  size_t skipTurnSegments = 0;
+  for (size_t idxLoadedSegment = 0; idxLoadedSegment < loadedSegments.size(); ++idxLoadedSegment)
   {
-    CHECK(loadedSegmentIt->IsValid(), ());
+    auto & loadedSegment = loadedSegments[idxLoadedSegment];
 
-    // Street names contain empty names too for avoiding of freezing of old street name while
-    // moving along unnamed street.
-    streets.emplace_back(max(junctions.size(), static_cast<size_t>(1)) - 1, loadedSegmentIt->m_roadNameInfo);
+    CHECK(loadedSegment.IsValid(), ());
+    CHECK_GREATER_OR_EQUAL(loadedSegment.m_segments.size(), 1, ());
+    CHECK_EQUAL(loadedSegment.m_segments.size() + 1, loadedSegment.m_path.size(), ());
 
-    // Turns information.
-    if (!junctions.empty() && skipTurnSegments == 0)
+    for (size_t i = 0; i < loadedSegment.m_segments.size() - 1; ++i)
     {
-      size_t const outgoingSegmentIndex = base::asserted_cast<size_t>(distance(loadedSegments.begin(), loadedSegmentIt));
-
-      TurnItem turnItem;
-      turnItem.m_index = static_cast<uint32_t>(junctions.size() - 1);
-
-      skipTurnSegments = GetTurnDirection(result, outgoingSegmentIndex, *m_numMwmIds, vehicleSettings, turnItem);
-
-      if (!turnItem.IsTurnNone())
-        turnsDir.push_back(move(turnItem));
+      auto const & junction = loadedSegment.m_path[i + 1];
+      routeSegments.emplace_back(
+        RouteSegment(loadedSegment.m_segments[i], TurnItem(), junction, RouteSegment::RoadNameInfo(),
+                                  loadedSegment.m_maxSpeed, traffic::SpeedGroup::Unknown)
+      );
     }
 
-    if (skipTurnSegments > 0)
+    // For the last segment of current loadedSegment put info about turn
+    // from current loadedSegment to the next one.
+    TurnItem turnItem;
+    if (skipTurnSegments == 0)
+    {
+      turnItem.m_index = routeSegments.size() + 1;
+      skipTurnSegments = GetTurnDirection(result, idxLoadedSegment + 1, *m_numMwmIds, vehicleSettings, turnItem);
+    }
+    else
       --skipTurnSegments;
 
-    // Path geometry.
-    CHECK_GREATER_OR_EQUAL(loadedSegmentIt->m_path.size(), 2, ());
-    // Note. Every LoadedPathSegment in TUnpackedPathSegments contains LoadedPathSegment::m_path
-    // of several Junctions. Last PointWithAltitude in a LoadedPathSegment::m_path is equal to first
-    // junction in next LoadedPathSegment::m_path in vector TUnpackedPathSegments:
-    // *---*---*---*---*       *---*           *---*---*---*
-    //                 *---*---*   *---*---*---*
-    // To prevent having repetitions in |junctions| list it's necessary to take the first point only
-    // from the first item of |loadedSegments|. The beginning should be ignored for the rest
-    // |m_path|.
-    junctions.insert(junctions.end(), loadedSegmentIt == loadedSegments.cbegin()
-                                          ? loadedSegmentIt->m_path.cbegin()
-                                          : loadedSegmentIt->m_path.cbegin() + 1,
-                     loadedSegmentIt->m_path.cend());
-    segments.insert(segments.end(), loadedSegmentIt->m_segments.cbegin(),
-                    loadedSegmentIt->m_segments.cend());
+    auto const & junction = loadedSegment.m_path.back();
+    routeSegments.emplace_back(
+      RouteSegment(loadedSegment.m_segments.back(), turnItem, junction, move(loadedSegment.m_roadNameInfo),
+                                loadedSegment.m_maxSpeed, traffic::SpeedGroup::Unknown)
+    );
   }
 
-  // Path found. Points will be replaced by start and end edges junctions.
-  if (junctions.size() == 1)
-    junctions.push_back(junctions.front());
+  ASSERT(routeSegments.front().GetJunction() == result.GetStartPoint(), ());
+  ASSERT(routeSegments.back().GetJunction() == result.GetEndPoint(), ());
 
-  if (junctions.size() < 2)
-    return RouterResultCode::RouteNotFound;
-
-  junctions.front() = result.GetStartPoint();
-  junctions.back() = result.GetEndPoint();
-
-  FixupTurns(junctions, turnsDir);
-
-  return RouterResultCode::NoError;
+  FixupTurns(routeSegments);
 }
 
 }  // namespace routing

--- a/routing/directions_engine.cpp
+++ b/routing/directions_engine.cpp
@@ -263,9 +263,8 @@ bool DirectionsEngine::Generate(IndexRoadGraph const & graph,
       TurnItem turn;
       if (i == routeEdges.size() - 2)
         turn.m_pedestrianTurn = turns::PedestrianDirection::ReachedYourDestination;
-      routeSegments.emplace_back(
-        RouteSegment(ConvertEdgeToSegment(*m_numMwmIds, routeEdges[i]), turn, pos, RouteSegment::RoadNameInfo(),
-                                  SpeedInUnits(), traffic::SpeedGroup::Unknown));
+      routeSegments.emplace_back(ConvertEdgeToSegment(*m_numMwmIds, routeEdges[i]), turn, pos, RouteSegment::RoadNameInfo(),
+                                 SpeedInUnits(), traffic::SpeedGroup::Unknown);
     }
     return true;
   }
@@ -353,10 +352,8 @@ void DirectionsEngine::MakeTurnAnnotation(IndexRoadGraph::EdgeVector const & rou
     for (size_t i = 0; i < loadedSegment.m_segments.size() - 1; ++i)
     {
       auto const & junction = loadedSegment.m_path[i + 1];
-      routeSegments.emplace_back(
-        RouteSegment(loadedSegment.m_segments[i], TurnItem(), junction, RouteSegment::RoadNameInfo(),
-                                  loadedSegment.m_maxSpeed, traffic::SpeedGroup::Unknown)
-      );
+      routeSegments.emplace_back(loadedSegment.m_segments[i], TurnItem(), junction, RouteSegment::RoadNameInfo(),
+                                 loadedSegment.m_maxSpeed, traffic::SpeedGroup::Unknown);
     }
 
     // For the last segment of current loadedSegment put info about turn
@@ -371,10 +368,8 @@ void DirectionsEngine::MakeTurnAnnotation(IndexRoadGraph::EdgeVector const & rou
       --skipTurnSegments;
 
     auto const & junction = loadedSegment.m_path.back();
-    routeSegments.emplace_back(
-      RouteSegment(loadedSegment.m_segments.back(), turnItem, junction, move(loadedSegment.m_roadNameInfo),
-                                loadedSegment.m_maxSpeed, traffic::SpeedGroup::Unknown)
-    );
+    routeSegments.emplace_back(loadedSegment.m_segments.back(), turnItem, junction, move(loadedSegment.m_roadNameInfo),
+                               loadedSegment.m_maxSpeed, traffic::SpeedGroup::Unknown);
   }
 
   ASSERT(routeSegments.front().GetJunction() == result.GetStartPoint(), ());

--- a/routing/directions_engine.hpp
+++ b/routing/directions_engine.hpp
@@ -45,10 +45,8 @@ public:
   /// \returns true if fields passed by reference are filled correctly and false otherwise.
   bool Generate(IndexRoadGraph const & graph,
                 std::vector<geometry::PointWithAltitude> const & path,
-                base::Cancellable const & cancellable, Route::TTurns & turns,
-                Route::TStreets & streetNames,
-                std::vector<geometry::PointWithAltitude> & routeGeometry,
-                std::vector<Segment> & segments);
+                base::Cancellable const & cancellable,
+                std::vector<RouteSegment> & routeSegments);
   void Clear();
 
   void SetVehicleType(VehicleType const & vehicleType) { m_vehicleType = vehicleType; }
@@ -62,8 +60,7 @@ protected:
   virtual size_t GetTurnDirection(turns::IRoutingResult const & result, size_t const outgoingSegmentIndex,
                                   NumMwmIds const & numMwmIds,
                                   RoutingSettings const & vehicleSettings, turns::TurnItem & turn) = 0;
-  virtual void FixupTurns(std::vector<geometry::PointWithAltitude> const & junctions,
-                          Route::TTurns & turnsDir) = 0;
+  virtual void FixupTurns(std::vector<RouteSegment> & routeSegments) = 0;
   std::unique_ptr<FeatureType> GetFeature(FeatureID const & featureId);
   void LoadPathAttributes(FeatureID const & featureId, LoadedPathSegment & pathSegment);
   void GetSegmentRangeAndAdjacentEdges(IRoadGraph::EdgeListT const & outgoingEdges,
@@ -89,10 +86,7 @@ protected:
   VehicleType m_vehicleType = VehicleType::Count;
 
 private:
-  RouterResultCode MakeTurnAnnotation(IndexRoadGraph::EdgeVector const & routeEdges,
-                                      base::Cancellable const & cancellable,
-                                      std::vector<geometry::PointWithAltitude> & junctions,
-                                      Route::TTurns & turnsDir, Route::TStreets & streets,
-                                      std::vector<Segment> & segments);
+  void MakeTurnAnnotation(IndexRoadGraph::EdgeVector const & routeEdges,
+                          std::vector<RouteSegment> & routeSegments);
 };
 }  // namespace routing

--- a/routing/following_info.hpp
+++ b/routing/following_info.hpp
@@ -83,5 +83,9 @@ public:
   //@{
   turns::PedestrianDirection m_pedestrianTurn;
   //@}
+
+  // Current speed limit. If no info about speed limit then m_speedLimit == 0.
+  std::string m_speedLimit;
+  std::string m_speedLimitUnitsSuffix;
 };
 }  // namespace routing

--- a/routing/index_router.cpp
+++ b/routing/index_router.cpp
@@ -1561,20 +1561,17 @@ RouterResultCode IndexRouter::RedressRoute(vector<Segment> const & segments,
   IndexRoadGraph roadGraph(starter, segments, junctions, m_dataSource);
   starter.GetGraph().SetMode(WorldGraphMode::NoLeaps);
 
-  Route::TTimes times;
+  vector<double> times;
   times.reserve(segments.size());
-
-  // Time at zero route point.
-  times.emplace_back(static_cast<uint32_t>(0), 0.0);
 
   // Time at first route point - weight of first segment.
   double time = starter.CalculateETAWithoutPenalty(segments.front());
-  times.emplace_back(static_cast<uint32_t>(1), time);
+  times.emplace_back(time);
 
   for (size_t i = 1; i < segments.size(); ++i)
   {
     time += starter.CalculateETA(segments[i - 1], segments[i]);
-    times.emplace_back(static_cast<uint32_t>(i + 1), time);
+    times.emplace_back(time);
   }
 
   m_directionsEngine->SetVehicleType(m_vehicleType);

--- a/routing/loaded_path_segment.hpp
+++ b/routing/loaded_path_segment.hpp
@@ -4,6 +4,7 @@
 #include "routing/turns.hpp"
 #include "routing/segment.hpp"
 #include "routing/route.hpp"
+#include "routing/maxspeeds.hpp"
 
 #include "indexer/ftypes_matcher.hpp"
 
@@ -24,13 +25,14 @@ struct LoadedPathSegment
   std::vector<geometry::PointWithAltitude> m_path;
   std::vector<turns::SingleLaneInfo> m_lanes;
   RouteSegment::RoadNameInfo m_roadNameInfo;
-  double m_weight = 0.0; /*!< Time in seconds to pass the segment. */
+  //double m_weight = 0.0; /*!< Time in seconds to pass the segment. */
   SegmentRange m_segmentRange;
   std::vector<Segment> m_segments; /*!< Traffic segments for |m_path|. */
   ftypes::HighwayClass m_highwayClass = ftypes::HighwayClass::Undefined;
   bool m_onRoundabout = false;
   bool m_isLink = false;
   bool m_isOneWay = false;
+  routing::SpeedInUnits m_maxSpeed;
 
   bool IsValid() const { return m_path.size() > 1; }
 };

--- a/routing/pedestrian_directions.hpp
+++ b/routing/pedestrian_directions.hpp
@@ -18,7 +18,6 @@ protected:
   virtual size_t GetTurnDirection(turns::IRoutingResult const & result, size_t const outgoingSegmentIndex,
                                   NumMwmIds const & numMwmIds,
                                   RoutingSettings const & vehicleSettings, turns::TurnItem & turn);
-  virtual void FixupTurns(std::vector<geometry::PointWithAltitude> const & junctions,
-                          Route::TTurns & turnsDir);
+  virtual void FixupTurns(std::vector<RouteSegment> & routeSegments);
 };
 }  // namespace routing

--- a/routing/route.cpp
+++ b/routing/route.cpp
@@ -113,13 +113,24 @@ double Route::GetCurrentTimeToEndSec() const
 
   double const curSegSpeedMPerS = curSegLenMeters / curSegTimeS;
   CHECK_GREATER(curSegSpeedMPerS, 0, ("Route can't contain segments with zero speed."));
+  /// @todo GetDistFromCurPointTo!Next!RoutePointMeters should be used for calculalation of remaining segment length.
   return totalTimeS - (etaToLastPassedPointS +
                        m_poly.GetDistFromCurPointToRoutePointMeters() / curSegSpeedMPerS);
 }
 
+void Route::GetCurrentSpeedLimit(SpeedInUnits & speedLimit) const
+{
+  if (!IsValid())
+    return;
+
+  auto const idx = m_poly.GetCurrentIter().m_ind;
+  if (idx < m_routeSegments.size())
+    speedLimit = m_routeSegments[idx].GetSpeedLimit();
+}
+
 void Route::GetCurrentStreetName(RouteSegment::RoadNameInfo & roadNameInfo) const
 {
-  GetStreetNameAfterIdx(static_cast<uint32_t>(m_poly.GetCurrentIter().m_ind), roadNameInfo);
+  GetClosestStreetNameAfterIdx(m_poly.GetCurrentIter().m_ind, roadNameInfo);
 }
 
 void Route::GetNextTurnStreetName(RouteSegment::RoadNameInfo & roadNameInfo) const
@@ -127,7 +138,7 @@ void Route::GetNextTurnStreetName(RouteSegment::RoadNameInfo & roadNameInfo) con
   double distance;
   TurnItem turn;
   GetCurrentTurn(distance, turn);
-  GetStreetNameAfterIdx(turn.m_index, roadNameInfo);
+  GetClosestStreetNameAfterIdx(turn.m_index, roadNameInfo);
 }
 
 // If exit is false, returns ref and name.
@@ -144,23 +155,19 @@ void Route::GetNextTurnStreetName(RouteSegment::RoadNameInfo & roadNameInfo) con
 // - Sometimes exit is not tagged as link (e.g. if new road starts here).
 // At the same time they can have all useful tags just like link.
 // Usually |destination:ref| = |ref| in such cases, or only 1st part of |destination:ref| can match.
-void Route::GetStreetNameAfterIdx(uint32_t idx, RouteSegment::RoadNameInfo & roadNameInfo) const
+void Route::GetClosestStreetNameAfterIdx(size_t segIdx, RouteSegment::RoadNameInfo & roadNameInfo) const
 {
-  auto const iterIdx = m_poly.GetIterToIndex(idx);
-  if (!IsValid() || !iterIdx.IsValid())
+  if (!IsValid())
     return;
 
   // Info about 1st segment with existing basic (non-link) info after link.
   RouteSegment::RoadNameInfo roadNameInfoNext;
 
-  for (size_t i = idx; i < m_poly.GetPolyline().GetSize(); ++i)
+  // Note. curIter.m_ind == 0 means route iter at zero point.
+  // No corresponding route segments at |m_routeSegments| in this case.
+  for (size_t i = segIdx; i < m_routeSegments.size(); ++i)
   {
-    // Note. curIter.m_ind == 0 means route iter at zero point. No corresponding route segments at
-    // |m_routeSegments| in this case. |name| should be cleared.
-    if (i == 0)
-      continue;
-
-    auto const & r = m_routeSegments[ConvertPointIdxToSegmentIdx(i)].GetRoadNameInfo();
+    auto const & r = m_routeSegments[i].GetRoadNameInfo();
 
     if (r.HasBasicTextInfo())
     {
@@ -175,10 +182,14 @@ void Route::GetStreetNameAfterIdx(uint32_t idx, RouteSegment::RoadNameInfo & roa
     // For exit wait for non-exit.
     else if (roadNameInfo.HasExitInfo() && !r.m_isLink)
       continue;
+
     // For non-exits check only during first |kSteetNameLinkMeters|.
+    // Note. |m_poly.GetCurrentIter().m_ind| is a point index of last passed point at |m_poly|.
+    auto const startIter = m_poly.GetIterToIndex(segIdx);
+    CHECK(startIter.IsValid(), ());
     auto const furtherIter = m_poly.GetIterToIndex(i);
     CHECK(furtherIter.IsValid(), ());
-    if (m_poly.GetDistanceM(iterIdx, furtherIter) > kSteetNameLinkMeters)
+    if (m_poly.GetDistanceM(startIter, furtherIter) > kSteetNameLinkMeters)
       break;
   }
 
@@ -187,20 +198,12 @@ void Route::GetStreetNameAfterIdx(uint32_t idx, RouteSegment::RoadNameInfo & roa
     // Use basic info from |roadNameInfoNext| to update |roadNameInfo|.
     if (roadNameInfo.m_destination_ref.empty())
       roadNameInfo.m_destination_ref = roadNameInfoNext.m_ref;
-    roadNameInfo.m_name = roadNameInfoNext.m_name;
+    if (!roadNameInfoNext.m_name.empty())
+      roadNameInfo.m_name = roadNameInfoNext.m_name;
   }
 }
 
-size_t Route::ConvertPointIdxToSegmentIdx(size_t pointIdx) const
-{
-  CHECK_GREATER(pointIdx, 0, ());
-  // Note. |pointIdx| is an index at |m_poly|. Properties of the point gets a segment at |m_routeSegments|
-  // which precedes the point. So to get segment index it's needed to subtract one.
-  CHECK_LESS(pointIdx, m_routeSegments.size() + 1, ());
-  return pointIdx - 1;
-}
-
-void Route::GetClosestTurn(size_t segIdx, TurnItem & turn) const
+void Route::GetClosestTurnAfterIdx(size_t segIdx, TurnItem & turn) const
 {
   CHECK_LESS(segIdx, m_routeSegments.size(), ());
 
@@ -218,7 +221,9 @@ void Route::GetClosestTurn(size_t segIdx, TurnItem & turn) const
 void Route::GetCurrentTurn(double & distanceToTurnMeters, TurnItem & turn) const
 {
   // Note. |m_poly.GetCurrentIter().m_ind| is a point index of last passed point at |m_poly|.
-  GetClosestTurn(m_poly.GetCurrentIter().m_ind, turn);
+  GetClosestTurnAfterIdx(m_poly.GetCurrentIter().m_ind, turn);
+  CHECK_LESS(m_poly.GetCurrentIter().m_ind, turn.m_index, ());
+
   distanceToTurnMeters = m_poly.GetDistanceM(m_poly.GetCurrentIter(),
                                              m_poly.GetIterToIndex(turn.m_index));
 }
@@ -238,11 +243,11 @@ bool Route::GetNextTurn(double & distanceToTurnMeters, TurnItem & nextTurn) cons
   TurnItem curTurn;
   // Note. |m_poly.GetCurrentIter().m_ind| is a zero based index of last passed point at |m_poly|.
   size_t const curIdx = m_poly.GetCurrentIter().m_ind;
-  // Note. First param of GetClosestTurn() is a segment index at |m_routeSegments|.
+  // Note. First param of GetClosestTurnAfterIdx() is a segment index at |m_routeSegments|.
   // |curIdx| is an index of last passed point at |m_poly|.
   // |curIdx| + 1 is an index of next point.
   // |curIdx| + 1 - 1 is an index of segment to start look for the closest turn.
-  GetClosestTurn(curIdx, curTurn);
+  GetClosestTurnAfterIdx(curIdx, curTurn);
   CHECK_LESS(curIdx, curTurn.m_index, ());
   if (curTurn.IsTurnReachedYourDestination())
   {
@@ -254,7 +259,7 @@ bool Route::GetNextTurn(double & distanceToTurnMeters, TurnItem & nextTurn) cons
   // |curTurn.m_index| + 1 is an index of the next point after |curTurn|.
   // |curTurn.m_index| + 1 - 1 is an index of the segment next to the |curTurn| segment.
   CHECK_LESS(curTurn.m_index, m_routeSegments.size(), ());
-  GetClosestTurn(curTurn.m_index, nextTurn);
+  GetClosestTurnAfterIdx(curTurn.m_index, nextTurn);
   CHECK_LESS(curTurn.m_index, nextTurn.m_index, ());
   distanceToTurnMeters = m_poly.GetDistanceM(m_poly.GetCurrentIter(),
                                              m_poly.GetIterToIndex(nextTurn.m_index));

--- a/routing/routing_helpers.cpp
+++ b/routing/routing_helpers.cpp
@@ -21,90 +21,39 @@ namespace routing
 using namespace std;
 using namespace traffic;
 
-void FillSegmentInfo(vector<Segment> const & segments,
-                     vector<geometry::PointWithAltitude> const & junctions,
-                     Route::TTurns const & turns, Route::TStreets const & streets,
-                     Route::TTimes const & times, shared_ptr<TrafficStash> const & trafficStash,
-                     vector<RouteSegment> & routeSegment)
+void FillSegmentInfo(vector<double> const & times,
+                     shared_ptr<TrafficStash> const & trafficStash,
+                     vector<RouteSegment> & routeSegments)
 {
-  CHECK_EQUAL(segments.size() + 1, junctions.size(), ());
-  CHECK(!turns.empty(), ());
   CHECK(!times.empty(), ());
+  CHECK(is_sorted(times.cbegin(), times.cend()), ());
 
-  CHECK(is_sorted(turns.cbegin(), turns.cend(), base::LessBy(&turns::TurnItem::m_index)), ());
-  CHECK(is_sorted(streets.cbegin(), streets.cend(), base::LessBy(&Route::TStreetItem::first)), ());
-  CHECK(is_sorted(times.cbegin(), times.cend(), base::LessBy(&Route::TTimeItem::first)), ());
-
-  CHECK_LESS(turns.back().m_index, junctions.size(), ());
-  if (!streets.empty())
-    CHECK_LESS(streets.back().first, junctions.size(), ());
-  CHECK_LESS(times.back().first, junctions.size(), ());
-
-  routeSegment.clear();
-  if (segments.empty())
+  if (routeSegments.empty())
     return;
 
-  routeSegment.reserve(segments.size());
-  // Note. |turns|, |streets| and |times| have point based index.
-  // On the other hand turns, street names and times are considered for further end of |segments| after conversion
-  // to |segmentInfo|. It means that street, turn and time information of zero point will be lost after
-  // conversion to |segmentInfo|.
-  size_t turnIdx = turns[0].m_index != 0 ? 0 : 1;
-  size_t streetIdx = (!streets.empty() && streets[0].first != 0) ? 0 : 1;
-  size_t timeIdx = times[0].first != 0 ? 0 : 1;
   double routeLengthMeters = 0.0;
   double routeLengthMerc = 0.0;
   double timeFromBeginningS = 0.0;
-
-  for (size_t i = 0; i < segments.size(); ++i)
+  for (size_t i = 0; i < routeSegments.size(); ++i)
   {
-    size_t const segmentEndPointIdx = i + 1;
-
-    turns::TurnItem curTurn;
-    CHECK_LESS_OR_EQUAL(turnIdx, turns.size(), ());
-    if (turnIdx != turns.size() && turns[turnIdx].m_index == segmentEndPointIdx)
+    if (i > 0)
     {
-      curTurn = turns[turnIdx];
-      if (turnIdx + 1 < turns.size())
-        ++turnIdx;
+      auto const & junction = routeSegments[i].GetJunction();
+      auto const & prevJunction = routeSegments[i - 1].GetJunction();
+      routeLengthMeters += mercator::DistanceOnEarth(junction.GetPoint(), prevJunction.GetPoint());
+      routeLengthMerc += junction.GetPoint().Length(prevJunction.GetPoint());
     }
 
-    RouteSegment::RoadNameInfo curStreet;
-    if (!streets.empty())
-    {
-      CHECK_LESS_OR_EQUAL(streetIdx, streets.size(), ());
-      if (streetIdx != streets.size() && streets[streetIdx].first == segmentEndPointIdx)
-      {
-        curStreet = streets[streetIdx].second;
-        if (streetIdx + 1 < streets.size())
-          ++streetIdx;
-      }
-    }
+    timeFromBeginningS = times[i];
 
-    CHECK_LESS_OR_EQUAL(timeIdx, times.size(), ());
-    if (timeIdx != times.size() && times[timeIdx].first == segmentEndPointIdx)
-    {
-      timeFromBeginningS = times[timeIdx].second;
-      if (timeIdx + 1 < times.size())
-        ++timeIdx;
-    }
-
-    routeLengthMeters +=
-      mercator::DistanceOnEarth(junctions[i].GetPoint(), junctions[i + 1].GetPoint());
-    routeLengthMerc += junctions[i].GetPoint().Length(junctions[i + 1].GetPoint());
-
-    routeSegment.emplace_back(
-        segments[i], curTurn, junctions[i + 1], curStreet, routeLengthMeters, routeLengthMerc,
-        timeFromBeginningS,
-        trafficStash ? trafficStash->GetSpeedGroup(segments[i]) : traffic::SpeedGroup::Unknown,
-        nullptr /* transitInfo */);
+    routeSegments[i].SetDistancesAndTime(routeLengthMeters, routeLengthMerc, timeFromBeginningS);
   }
 }
 
 void ReconstructRoute(DirectionsEngine & engine, IndexRoadGraph const & graph,
                       shared_ptr<TrafficStash> const & trafficStash,
                       base::Cancellable const & cancellable,
-                      vector<geometry::PointWithAltitude> const & path, Route::TTimes && times,
+                      vector<geometry::PointWithAltitude> const & path, vector<double> const && times,
                       Route & route)
 {
   if (path.empty())
@@ -113,40 +62,20 @@ void ReconstructRoute(DirectionsEngine & engine, IndexRoadGraph const & graph,
     return;
   }
 
-  CHECK_EQUAL(path.size(), times.size(), ());
+  CHECK_EQUAL(path.size(), times.size() + 1, ());
 
-  Route::TTurns turnsDir;
-  vector<geometry::PointWithAltitude> junctions;
-  Route::TStreets streetNames;
-  vector<Segment> segments;
-
-  if (!engine.Generate(graph, path, cancellable, turnsDir, streetNames, junctions, segments))
+  vector<RouteSegment> routeSegments;
+  if (!engine.Generate(graph, path, cancellable, routeSegments))
     return;
 
   if (cancellable.IsCancelled())
     return;
 
-  // In case of any errors in DirectionsEngine::Generate() |junctions| is empty.
-  if (junctions.empty())
-  {
-    LOG(LERROR, ("Internal error happened while turn generation."));
-    return;
-  }
-
-  CHECK_EQUAL(path.size(), junctions.size(),
-              ("Size of path:", path.size(), "size of junctions:", junctions.size()));
-
-  vector<RouteSegment> segmentInfo;
-  FillSegmentInfo(segments, junctions, turnsDir, streetNames, times, trafficStash, segmentInfo);
-  CHECK_EQUAL(segmentInfo.size(), segments.size(), ());
-  route.SetRouteSegments(move(segmentInfo));
-
-  // @TODO(bykoianko) If the start and the finish of a route lies on the same road segment
-  // engine->Generate() fills with empty vectors |times|, |turnsDir|, |junctions| and |segments|.
-  // It's not correct and should be fixed. It's necessary to work correctly with such routes.
+  FillSegmentInfo(times, trafficStash, routeSegments);
+  route.SetRouteSegments(move(routeSegments));
 
   vector<m2::PointD> routeGeometry;
-  JunctionsToPoints(junctions, routeGeometry);
+  JunctionsToPoints(path, routeGeometry);
 
   route.SetGeometry(routeGeometry.begin(), routeGeometry.end());
 }
@@ -213,9 +142,9 @@ bool RectCoversPolyline(IRoadGraph::PointWithAltitudeVec const & junctions, m2::
 }
 
 bool CheckGraphConnectivity(Segment const & start, bool isOutgoing, bool useRoutingOptions,
-                            size_t limit, WorldGraph & graph, std::set<Segment> & marked)
+                            size_t limit, WorldGraph & graph, set<Segment> & marked)
 {
-  std::queue<Segment> q;
+  queue<Segment> q;
   q.push(start);
 
   marked.insert(start);

--- a/routing/routing_helpers.hpp
+++ b/routing/routing_helpers.hpp
@@ -49,17 +49,14 @@ bool IsRoad(Types const & types)
          IsBicycleRoad(types);
 }
 
-void FillSegmentInfo(std::vector<Segment> const & segments,
-                     std::vector<geometry::PointWithAltitude> const & junctions,
-                     Route::TTurns const & turns, Route::TStreets const & streets,
-                     Route::TTimes const & times,
+void FillSegmentInfo(std::vector<double> const & times,
                      std::shared_ptr<TrafficStash> const & trafficStash,
-                     std::vector<RouteSegment> & routeSegment);
+                     std::vector<RouteSegment> & routeSegments);
 
 void ReconstructRoute(DirectionsEngine & engine, IndexRoadGraph const & graph,
                       std::shared_ptr<TrafficStash> const & trafficStash,
                       base::Cancellable const & cancellable,
-                      std::vector<geometry::PointWithAltitude> const & path, Route::TTimes && times,
+                      std::vector<geometry::PointWithAltitude> const & path, std::vector<double> const && times,
                       Route & route);
 
 /// \brief Converts |edge| to |segment|.

--- a/routing/routing_session.cpp
+++ b/routing/routing_session.cpp
@@ -49,6 +49,16 @@ void FormatDistance(double dist, string & value, string & suffix)
   value.erase(delim);
 };
 
+void FormatSpeed(double speedKmPH, string & value, string & suffix)
+{
+  value = measurement_utils::FormatSpeed(measurement_utils::KmphToMps(speedKmPH));
+
+  size_t const delim = value.find(' ');
+  ASSERT(delim != string::npos, ());
+  suffix = value.substr(delim + 1);
+  value.erase(delim);
+};
+
 RoutingSession::RoutingSession()
   : m_router(nullptr)
   , m_route(make_shared<Route>(string() /* router */, 0 /* route id */))
@@ -404,6 +414,11 @@ void RoutingSession::GetRouteFollowingInfo(FollowingInfo & info) const
   m_route->GetCurrentTurn(distanceToTurnMeters, turn);
   FormatDistance(distanceToTurnMeters, info.m_distToTurn, info.m_turnUnitsSuffix);
   info.m_turn = turn.m_turn;
+
+  SpeedInUnits speedLimit;
+  m_route->GetCurrentSpeedLimit(speedLimit);
+  if (speedLimit.IsValid())
+    FormatSpeed(speedLimit.GetSpeedKmPH(), info.m_speedLimit, info.m_speedLimitUnitsSuffix);
 
   // The turn after the next one.
   if (m_routingSettings.m_showTurnAfterNext)

--- a/routing/routing_tests/CMakeLists.txt
+++ b/routing/routing_tests/CMakeLists.txt
@@ -36,6 +36,7 @@ set(SRC
   routing_options_tests.cpp
   routing_session_test.cpp
   speed_cameras_tests.cpp
+  tools.cpp
   tools.hpp
   turns_generator_test.cpp
   turns_sound_test.cpp

--- a/routing/routing_tests/route_tests.cpp
+++ b/routing/routing_tests/route_tests.cpp
@@ -6,6 +6,8 @@
 
 #include "routing/base/followed_polyline.hpp"
 
+#include "routing/routing_tests/tools.hpp"
+
 #include "platform/location.hpp"
 
 #include "geometry/mercator.hpp"

--- a/routing/routing_tests/route_tests.cpp
+++ b/routing/routing_tests/route_tests.cpp
@@ -22,55 +22,50 @@ using namespace routing;
 using namespace routing::turns;
 using namespace std;
 
-static vector<m2::PointD> const kTestGeometry({{0, 0}, {0,1}, {1,1}, {1,2}, {1,3}});
-static vector<Segment> const kTestSegments(
-    {{0, 0, 0, true}, {0, 0, 1, true}, {0, 0, 2, true}, {0, 0, 3, true}});
-static Route::TTurns const kTestTurns(
-    {turns::TurnItem(1, turns::CarDirection::TurnLeft),
-     turns::TurnItem(2, turns::CarDirection::TurnRight),
-     turns::TurnItem(4, turns::CarDirection::ReachedYourDestination)});
-static Route::TStreets const kTestNames({{0, {"Street1", "", "", "", "", false}},
-                                         {1, {"Street2", "", "", "", "", false}},
-                                         {4, {"Street3", "", "", "", "", false}}});
-static Route::TTimes const kTestTimes({Route::TTimeItem(1, 5), Route::TTimeItem(3, 10),
-                                      Route::TTimeItem(4, 15)});
+// For all test geometry: geometry[0] == geometry[1], since info about 1st point will be lost.
+static vector<m2::PointD> const kTestGeometry =
+    {{0,0}, {0,0}, {1,1}, {1,2}, {1,3}, {1,4}};
+static vector<Segment> const kTestSegments =
+    {{0, 0, 0, true},
+     {0, 0, 1, true},
+     {0, 0, 2, true},
+     {0, 0, 3, true},
+     {0, 0, 4, true}};
+static vector<turns::TurnItem> const kTestTurns(
+    {turns::TurnItem(1, turns::CarDirection::None),
+     turns::TurnItem(2, turns::CarDirection::TurnLeft),
+     turns::TurnItem(3, turns::CarDirection::TurnRight),
+     turns::TurnItem(4, turns::CarDirection::None),
+     turns::TurnItem(5, turns::CarDirection::ReachedYourDestination)});
+static vector<RouteSegment::RoadNameInfo> const kTestNames =
+    {{"Street1", "", "", "", "", false},
+     {"Street2", "", "", "", "", false},
+     {"", "", "", "", "", false},
+     {"", "", "", "", "", false},
+     {"Street3", "", "", "", "", false}};
+static vector<double> const kTestTimes =
+    {0.0, 5.0, 7.0, 10.0, 15.0, 20.0};
+static vector<turns::TurnItem> const kTestTurns2(
+    {turns::TurnItem(1, turns::CarDirection::None),
+     turns::TurnItem(2, turns::CarDirection::TurnLeft),
+     turns::TurnItem(3, turns::CarDirection::TurnRight),
+     turns::TurnItem(4, turns::CarDirection::None),
+     turns::TurnItem(5, turns::CarDirection::ReachedYourDestination)});
+static vector<RouteSegment::RoadNameInfo> const kTestNames2 =
+    {{"Street0", "", "", "", "", false},
+     {"Street1", "", "", "", "", false},
+     {"Street2", "", "", "", "", false},
+     {"", "", "", "", "", false},
+     {"Street3", "", "", "", "", false}};
+static vector<double> const kTestTimes2 =
+    {0.0, 5.0, 6.0, 10.0, 15.0, 20.0};
 
-static Route::TTurns const kTestTurns2(
-    {turns::TurnItem(0, turns::CarDirection::None),
-     turns::TurnItem(1, turns::CarDirection::TurnLeft),
-     turns::TurnItem(2, turns::CarDirection::TurnRight),
-     turns::TurnItem(3, turns::CarDirection::None),
-     turns::TurnItem(4, turns::CarDirection::ReachedYourDestination)});
-static vector<RouteSegment::RoadNameInfo> const kTestNames2 = {{"Street0", "", "", "", "", false},
-                                                               {"Street1", "", "", "", "", false},
-                                                               {"Street2", "", "", "", "", false},
-                                                               {"", "", "", "", "", false},
-                                                               {"Street3", "", "", "", "", false}};
-static vector<double> const kTestTimes2 = {0.0, 5.0, 6.0, 10.0, 15.0};
-
-void GetTestRouteSegments(vector<m2::PointD> const & routePoints, Route::TTurns const & turns,
+void GetTestRouteSegments(vector<m2::PointD> const & routePoints, vector<turns::TurnItem> const & turns,
                           vector<RouteSegment::RoadNameInfo> const & streets, vector<double> const & times,
                           vector<RouteSegment> & routeSegments)
 {
-  CHECK_EQUAL(routePoints.size(), turns.size(), ());
-  CHECK_EQUAL(turns.size(), streets.size(), ());
-  CHECK_EQUAL(turns.size(), times.size(), ());
-
-  FollowedPolyline poly(routePoints.cbegin(), routePoints.cend());
-
-  double routeLengthMeters = 0.0;
-  double routeLengthMertc = 0.0;
-  for (size_t i = 1; i < routePoints.size(); ++i)
-  {
-    routeLengthMeters += mercator::DistanceOnEarth(routePoints[i - 1], routePoints[i]);
-    routeLengthMertc += routePoints[i - 1].Length(routePoints[i]);
-    routeSegments.emplace_back(
-        Segment(0 /* mwm id */, static_cast<uint32_t>(i) /* feature id */, 0 /* seg id */,
-                true /* forward */),
-        turns[i], geometry::PointWithAltitude(routePoints[i], geometry::kInvalidAltitude),
-        streets[i], routeLengthMeters, routeLengthMertc, times[i], traffic::SpeedGroup::Unknown,
-        nullptr /* transitInfo */);
-  }
+  RouteSegmentsFrom(vector<Segment>(), routePoints, turns, streets, routeSegments);
+  FillSegmentInfo(kTestTimes, nullptr /* trafficStash */, routeSegments);
 }
 
 location::GpsInfo GetGps(double x, double y)
@@ -82,15 +77,21 @@ location::GpsInfo GetGps(double x, double y)
   return info;
 }
 
-std::vector<vector<Segment>> GetSegments()
+vector<vector<Segment>> GetSegments()
 {
   auto const segmentsAllReal = kTestSegments;
-  vector<Segment> segmentsAllFake = {{kFakeNumMwmId, 0, 0, true},
-                                     {kFakeNumMwmId, 0, 1, true},
-                                     {kFakeNumMwmId, 0, 2, true},
-                                     {kFakeNumMwmId, 0, 3, true}};
-  vector<Segment> segmentsFakeHeadAndTail = {
-      {kFakeNumMwmId, 0, 0, true}, {0, 0, 1, true}, {0, 0, 2, true}, {kFakeNumMwmId, 0, 3, true}};
+  vector<Segment> segmentsAllFake =
+      {{kFakeNumMwmId, 0, 0, true},
+       {kFakeNumMwmId, 0, 1, true},
+       {kFakeNumMwmId, 0, 2, true},
+       {kFakeNumMwmId, 0, 3, true},
+       {kFakeNumMwmId, 0, 4, true}};
+  vector<Segment> segmentsFakeHeadAndTail =
+      {{kFakeNumMwmId, 0, 0, true},
+       {0, 0, 1, true},
+       {0, 0, 2, true},
+       {0, 0, 3, true},
+       {kFakeNumMwmId, 0, 4, true}};
   return {segmentsAllReal, segmentsFakeHeadAndTail, segmentsAllFake};
 }
 
@@ -119,36 +120,34 @@ UNIT_TEST(FinshRouteOnSomeDistanceToTheFinishPointTest)
       Route route("TestRouter", 0 /* route id */);
       route.SetRoutingSettings(settings);
 
-      vector<geometry::PointWithAltitude> junctions;
-      for (auto const & point : kTestGeometry)
-        junctions.emplace_back(point, geometry::kDefaultAltitudeMeters);
-
-      vector<RouteSegment> segmentInfo;
-      FillSegmentInfo(segments, junctions, kTestTurns, kTestNames, kTestTimes,
-                      nullptr /* trafficStash */, segmentInfo);
-      route.SetRouteSegments(move(segmentInfo));
+      vector<RouteSegment> routeSegments;
+      RouteSegmentsFrom(segments, kTestGeometry, kTestTurns, kTestNames, routeSegments);
+      FillSegmentInfo(kTestTimes, nullptr /* trafficStash */, routeSegments);
+      route.SetRouteSegments(move(routeSegments));
 
       route.SetGeometry(kTestGeometry.begin(), kTestGeometry.end());
       route.SetSubroteAttrs(vector<Route::SubrouteAttrs>(
-          {Route::SubrouteAttrs(junctions.front(), junctions.back(), 0, kTestSegments.size())}));
+          {Route::SubrouteAttrs(geometry::PointWithAltitude(kTestGeometry.front(), geometry::kDefaultAltitudeMeters),
+                                geometry::PointWithAltitude(kTestGeometry.back(), geometry::kDefaultAltitudeMeters),
+                                0, kTestSegments.size())}));
 
       // The route should be finished at some distance to the finish point.
       double const distToFinish = settings.m_finishToleranceM;
 
-      route.MoveIterator(GetGps(1.0, 2.9));
+      route.MoveIterator(GetGps(kTestGeometry.back().x, kTestGeometry.back().y - 0.1));
       TEST(!route.IsSubroutePassed(0), ());
       TEST_GREATER(route.GetCurrentDistanceToEndMeters(), distToFinish, ());
 
-      route.MoveIterator(GetGps(1.0, 2.98));
+      route.MoveIterator(GetGps(kTestGeometry.back().x, kTestGeometry.back().y - 0.02));
       TEST(!route.IsSubroutePassed(0), ());
       TEST_GREATER(route.GetCurrentDistanceToEndMeters(), distToFinish, ());
 
       // Finish tolerance value for cars is greater then for other vehicle types.
       // The iterator for other types should be moved closer to the finish point.
       if (vehicleType == VehicleType::Car)
-        route.MoveIterator(GetGps(1.0, 2.99986));
+        route.MoveIterator(GetGps(kTestGeometry.back().x, kTestGeometry.back().y - 0.00014));
       else
-        route.MoveIterator(GetGps(1.0, 2.99989));
+        route.MoveIterator(GetGps(kTestGeometry.back().x, kTestGeometry.back().y - 0.00011));
 
       TEST(route.IsSubroutePassed(0), ());
       TEST_LESS(route.GetCurrentDistanceToEndMeters(), distToFinish, ());
@@ -158,6 +157,8 @@ UNIT_TEST(FinshRouteOnSomeDistanceToTheFinishPointTest)
 
 UNIT_TEST(DistanceToCurrentTurnTest)
 {
+  // |curTurn.m_index| is an index of the point of |curTurn| at polyline |route.m_poly|.
+
   Route route("TestRouter", 0 /* route id */);
   vector<RouteSegment> routeSegments;
   GetTestRouteSegments(kTestGeometry, kTestTurns2, kTestNames2, kTestTimes2, routeSegments);
@@ -169,29 +170,49 @@ UNIT_TEST(DistanceToCurrentTurnTest)
   double distance;
   turns::TurnItem turn;
 
-  route.GetCurrentTurn(distance, turn);
-  TEST(base::AlmostEqualAbs(distance,
-                            mercator::DistanceOnEarth(kTestGeometry[0], kTestGeometry[1]), 0.1),
-                            ());
-  TEST_EQUAL(turn, kTestTurns[0], ());
+  {
+    // Initial point.
+    auto pos = kTestGeometry[0];
 
-  route.MoveIterator(GetGps(0, 0.5));
-  route.GetCurrentTurn(distance, turn);
-  TEST(base::AlmostEqualAbs(distance,
-                            mercator::DistanceOnEarth({0, 0.5}, kTestGeometry[1]), 0.1), ());
-  TEST_EQUAL(turn, kTestTurns[0], ());
+    route.GetCurrentTurn(distance, turn);
+    size_t currentTurnIndex = 2; // Turn with m_index == 1 is None.
+    TEST(base::AlmostEqualAbs(distance,
+                              mercator::DistanceOnEarth(pos, kTestGeometry[currentTurnIndex]), 0.1), ());
+    TEST_EQUAL(turn, kTestTurns[currentTurnIndex - 1], ());
+  }
+  {
+    // Move between points 1 and 2.
+    auto pos = (kTestGeometry[1] + kTestGeometry[2]) / 2;
+    route.MoveIterator(GetGps(pos.x, pos.y));
 
-  route.MoveIterator(GetGps(1, 1.5));
-  route.GetCurrentTurn(distance, turn);
-  TEST(base::AlmostEqualAbs(distance,
-                            mercator::DistanceOnEarth({1, 1.5}, kTestGeometry[4]), 0.1), ());
-  TEST_EQUAL(turn, kTestTurns[2], ());
+    route.GetCurrentTurn(distance, turn);
+    size_t currentTurnIndex = 2;
+    TEST(base::AlmostEqualAbs(distance,
+                              mercator::DistanceOnEarth(pos, kTestGeometry[currentTurnIndex]), 0.1), ());
+    TEST_EQUAL(turn, kTestTurns[currentTurnIndex - 1], ());
+  }
+  {
+    // Move between points 2 and 3.
+    auto pos = (kTestGeometry[2] + kTestGeometry[3]) / 2;
+    route.MoveIterator(GetGps(pos.x, pos.y));
 
-  route.MoveIterator(GetGps(1, 2.5));
-  route.GetCurrentTurn(distance, turn);
-  TEST(base::AlmostEqualAbs(distance,
-                            mercator::DistanceOnEarth({1, 2.5}, kTestGeometry[4]), 0.1), ());
-  TEST_EQUAL(turn, kTestTurns[2], ());
+    route.GetCurrentTurn(distance, turn);
+    size_t currentTurnIndex = 3;
+    TEST(base::AlmostEqualAbs(distance,
+                              mercator::DistanceOnEarth(pos, kTestGeometry[currentTurnIndex]), 0.1), ());
+    TEST_EQUAL(turn, kTestTurns[currentTurnIndex - 1], ());
+  }
+  {
+    // Move between points 3 and 4.
+    auto pos = (kTestGeometry[3] + kTestGeometry[4]) / 2;
+    route.MoveIterator(GetGps(pos.x, pos.y));
+
+    route.GetCurrentTurn(distance, turn);
+    size_t currentTurnIndex = 5; // Turn with m_index == 4 is None.
+    TEST(base::AlmostEqualAbs(distance,
+                              mercator::DistanceOnEarth(pos, kTestGeometry[currentTurnIndex]), 0.1), ());
+    TEST_EQUAL(turn, kTestTurns[currentTurnIndex - 1], ());
+  }
 }
 
 UNIT_TEST(NextTurnTest)
@@ -203,25 +224,44 @@ UNIT_TEST(NextTurnTest)
   route.SetGeometry(kTestGeometry.begin(), kTestGeometry.end());
 
   double distance, nextDistance;
-  turns::TurnItem turn;
-  turns::TurnItem nextTurn;
+  turns::TurnItem turn, nextTurn;
 
-  route.GetCurrentTurn(distance, turn);
-  route.GetNextTurn(nextDistance, nextTurn);
-  TEST_EQUAL(turn, kTestTurns[0], ());
-  TEST_EQUAL(nextTurn, kTestTurns[1], ());
+  {
+    // Initial point.
+    size_t currentTurnIndex = 2; // Turn with m_index == 1 is None.
+    route.GetCurrentTurn(distance, turn);
+    TEST_EQUAL(turn, kTestTurns[currentTurnIndex - 1], ());
 
-  route.MoveIterator(GetGps(0.5, 1));
-  route.GetCurrentTurn(distance, turn);
-  route.GetNextTurn(nextDistance, nextTurn);
-  TEST_EQUAL(turn, kTestTurns[1], ());
-  TEST_EQUAL(nextTurn, kTestTurns[2], ());
+    size_t nextTurnIndex = 3;
+    route.GetNextTurn(nextDistance, nextTurn);
+    TEST_EQUAL(nextTurn, kTestTurns[nextTurnIndex - 1], ());
+  }
+  {
+    // Move between points 1 and 2.
+    auto pos = (kTestGeometry[1] + kTestGeometry[2]) / 2;
+    route.MoveIterator(GetGps(pos.x, pos.y));
 
-  route.MoveIterator(GetGps(1, 1.5));
-  route.GetCurrentTurn(distance, turn);
-  route.GetNextTurn(nextDistance, nextTurn);
-  TEST_EQUAL(turn, kTestTurns[2], ());
-  TEST_EQUAL(nextTurn, turns::TurnItem(), ());
+    size_t currentTurnIndex = 2;
+    route.GetCurrentTurn(distance, turn);
+    TEST_EQUAL(turn, kTestTurns[currentTurnIndex - 1], ());
+
+    size_t nextTurnIndex = 3;
+    route.GetNextTurn(nextDistance, nextTurn);
+    TEST_EQUAL(nextTurn, kTestTurns[nextTurnIndex - 1], ());
+  }
+  {
+    // Move between points 3 and 4.
+    auto pos = (kTestGeometry[3] + kTestGeometry[4]) / 2;
+    route.MoveIterator(GetGps(pos.x, pos.y));
+
+    size_t currentTurnIndex = 5; // Turn with m_index == 4 is None.
+    route.GetCurrentTurn(distance, turn);
+    TEST_EQUAL(turn, kTestTurns[currentTurnIndex - 1], ());
+
+    // nextTurn is absent.
+    route.GetNextTurn(nextDistance, nextTurn);
+    TEST_EQUAL(nextTurn, turns::TurnItem(), ());
+  }
 }
 
 UNIT_TEST(NextTurnsTest)
@@ -236,69 +276,94 @@ UNIT_TEST(NextTurnsTest)
   vector<turns::TurnItemDist> turnsDist;
 
   {
+    // Initial point.
+    auto pos = kTestGeometry[0];
+
+    size_t currentTurnIndex = 2; // Turn with m_index == 1 is None.
+    size_t nextTurnIndex = 3;
     TEST(route.GetNextTurns(turnsDist), ());
     TEST_EQUAL(turnsDist.size(), 2, ());
-    double const firstSegLenM = mercator::DistanceOnEarth(kTestGeometry[0], kTestGeometry[1]);
-    double const secondSegLenM = mercator::DistanceOnEarth(kTestGeometry[1], kTestGeometry[2]);
+    double const firstSegLenM = mercator::DistanceOnEarth(pos, kTestGeometry[currentTurnIndex]);
+    double const secondSegLenM = mercator::DistanceOnEarth(kTestGeometry[currentTurnIndex], kTestGeometry[nextTurnIndex]);
+    TEST_EQUAL(turnsDist[0].m_turnItem, kTestTurns[currentTurnIndex - 1], ());
+    TEST_EQUAL(turnsDist[1].m_turnItem, kTestTurns[nextTurnIndex - 1], ());
     TEST(base::AlmostEqualAbs(turnsDist[0].m_distMeters, firstSegLenM, 0.1), ());
     TEST(base::AlmostEqualAbs(turnsDist[1].m_distMeters, firstSegLenM + secondSegLenM, 0.1), ());
-    TEST_EQUAL(turnsDist[0].m_turnItem, kTestTurns[0], ());
-    TEST_EQUAL(turnsDist[1].m_turnItem, kTestTurns[1], ());
+
   }
   {
-    double const x = 0.;
-    double const y = 0.5;
-    route.MoveIterator(GetGps(x, y));
+    // Move between points 1 and 2.
+    auto pos = (kTestGeometry[1] + kTestGeometry[2]) / 2;
+    route.MoveIterator(GetGps(pos.x, pos.y));
+
+    size_t currentTurnIndex = 2;
+    size_t nextTurnIndex = 3;
     TEST(route.GetNextTurns(turnsDist), ());
     TEST_EQUAL(turnsDist.size(), 2, ());
-    double const firstSegLenM = mercator::DistanceOnEarth({x, y}, kTestGeometry[1]);
-    double const secondSegLenM = mercator::DistanceOnEarth(kTestGeometry[1], kTestGeometry[2]);
+    double const firstSegLenM = mercator::DistanceOnEarth(pos, kTestGeometry[currentTurnIndex]);
+    double const secondSegLenM = mercator::DistanceOnEarth(kTestGeometry[currentTurnIndex], kTestGeometry[nextTurnIndex]);
+    TEST_EQUAL(turnsDist[0].m_turnItem, kTestTurns[currentTurnIndex - 1], ());
+    TEST_EQUAL(turnsDist[1].m_turnItem, kTestTurns[nextTurnIndex - 1], ());
     TEST(base::AlmostEqualAbs(turnsDist[0].m_distMeters, firstSegLenM, 0.1), ());
     TEST(base::AlmostEqualAbs(turnsDist[1].m_distMeters, firstSegLenM + secondSegLenM, 0.1), ());
-    TEST_EQUAL(turnsDist[0].m_turnItem, kTestTurns[0], ());
-    TEST_EQUAL(turnsDist[1].m_turnItem, kTestTurns[1], ());
   }
   {
-    double const x = 1.;
-    double const y = 2.5;
-    route.MoveIterator(GetGps(x, y));
+    // Move between points 2 and 3.
+    auto pos = (kTestGeometry[2] + kTestGeometry[3]) / 2;
+    route.MoveIterator(GetGps(pos.x, pos.y));
+
+    size_t currentTurnIndex = 3;
+    size_t nextTurnIndex = 5; // Turn with m_index == 4 is None.
     TEST(route.GetNextTurns(turnsDist), ());
-    TEST_EQUAL(turnsDist.size(), 1, ());
-    double const firstSegLenM = mercator::DistanceOnEarth({x, y}, kTestGeometry[4]);
+    TEST_EQUAL(turnsDist.size(), 2, ());
+    double const firstSegLenM = mercator::DistanceOnEarth(pos, kTestGeometry[currentTurnIndex]);
+    double const secondSegLenM = mercator::DistanceOnEarth(kTestGeometry[currentTurnIndex], kTestGeometry[nextTurnIndex]);
+    TEST_EQUAL(turnsDist[0].m_turnItem, kTestTurns[currentTurnIndex - 1], ());
+    TEST_EQUAL(turnsDist[1].m_turnItem, kTestTurns[nextTurnIndex - 1], ());
     TEST(base::AlmostEqualAbs(turnsDist[0].m_distMeters, firstSegLenM, 0.1), ());
-    TEST_EQUAL(turnsDist[0].m_turnItem, kTestTurns[2], ());
+    TEST(base::AlmostEqualAbs(turnsDist[1].m_distMeters, firstSegLenM + secondSegLenM, 0.1), ());
   }
   {
-    double const x = 1.;
-    double const y = 3.5;
-    route.MoveIterator(GetGps(x, y));
+    // Move between points 3 and 4.
+    auto pos = (kTestGeometry[3] + kTestGeometry[4]) / 2;
+    route.MoveIterator(GetGps(pos.x, pos.y));
+
+    size_t currentTurnIndex = 5; // Turn with m_index == 4 is None.
+    // nextTurn is absent.
     TEST(route.GetNextTurns(turnsDist), ());
-    TEST_EQUAL(turnsDist.size(), 1, ());
+    double const firstSegLenM = mercator::DistanceOnEarth(pos, kTestGeometry[currentTurnIndex]);
+    TEST_EQUAL(turnsDist[0].m_turnItem, kTestTurns[currentTurnIndex - 1], ());
+    TEST(base::AlmostEqualAbs(turnsDist[0].m_distMeters, firstSegLenM, 0.1), ());
   }
 }
 
-//   0.0002        *--------*
-//                 |        |
-//                 |        |
-//        Finish   |        |
-//   0.0001  *--------------*
-//                 |
-//                 |
-//                 |
-//        0        * Start
+//   0.0002          *--------*
+//                   |        |
+//                   |        |
+//        Finish     |        |
+//   0.0001  *----------------*
+//                   |
+//                   |
+//                   |
+//        0          * Start
 //           0  0.0001    0.0002
 //
 UNIT_TEST(SelfIntersectedRouteMatchingTest)
 {
-  vector<m2::PointD> const kRouteGeometry(
-      {{0.0001, 0.0}, {0.0001, 0.0002}, {0.0002, 0.0002}, {0.0002, 0.0001}, {0.0, 0.0001}});
+  vector<m2::PointD> const kRouteGeometry =
+      {{0.0001, 0.0},
+       {0.0001, 0.0},
+       {0.0001, 0.0002},
+       {0.0002, 0.0002},
+       {0.0002, 0.0001},
+       {0.0, 0.0001}};
   double constexpr kRoundingErrorMeters = 0.001;
 
   Route route("TestRouter", 0 /* route id */);
   route.SetGeometry(kRouteGeometry.begin(), kRouteGeometry.end());
 
   vector<RouteSegment> routeSegments;
-  GetTestRouteSegments(kRouteGeometry, kTestTurns2, kTestNames2, kTestTimes2, routeSegments);
+  GetTestRouteSegments(kRouteGeometry, vector<turns::TurnItem>(), vector<RouteSegment::RoadNameInfo>(), vector<double>(), routeSegments);
   route.SetRouteSegments(move(routeSegments));
 
   auto const testMachedPos = [&](location::GpsInfo const & pos,
@@ -312,35 +377,35 @@ UNIT_TEST(SelfIntersectedRouteMatchingTest)
                   m2::PointD(matchedPos.m_latitude, matchedPos.m_longitude),
                   m2::PointD(expectedMatchingPos.m_latitude, expectedMatchingPos.m_longitude)),
               kRoundingErrorMeters, ());
-    TEST_EQUAL(routeMatchingInfo.GetIndexInRoute(), expectedIndexInRoute, ());
+    TEST_EQUAL(max(size_t(1), routeMatchingInfo.GetIndexInRoute()), expectedIndexInRoute, ());
   };
 
   // Moving along the route from start point.
   location::GpsInfo const pos1(GetGps(0.0001, 0.0));
-  testMachedPos(pos1, pos1, 0 /* expectedIndexInRoute */);
+  testMachedPos(pos1, pos1, 1 /* expectedIndexInRoute */);
   location::GpsInfo const pos2(GetGps(0.0001, 0.00005));
-  testMachedPos(pos2, pos2, 0 /* expectedIndexInRoute */);
+  testMachedPos(pos2, pos2, 1 /* expectedIndexInRoute */);
 
   // Moving around the self intersection and checking that position is matched to the first segment of the route.
   location::GpsInfo const selfIntersectionPos(GetGps(0.0001, 0.0001));
   location::GpsInfo const pos3(GetGps(0.00005, 0.0001));
-  testMachedPos(pos3, selfIntersectionPos, 0 /* expectedIndexInRoute */);
+  testMachedPos(pos3, selfIntersectionPos, 1 /* expectedIndexInRoute */);
   location::GpsInfo const pos4(GetGps(0.00015, 0.0001));
-  testMachedPos(pos4, selfIntersectionPos, 0 /* expectedIndexInRoute */);
+  testMachedPos(pos4, selfIntersectionPos, 1 /* expectedIndexInRoute */);
 
   // Continue moving along the route.
   location::GpsInfo const pos5(GetGps(0.00011, 0.0002));
-  testMachedPos(pos5, pos5, 1 /* expectedIndexInRoute */);
+  testMachedPos(pos5, pos5, 2 /* expectedIndexInRoute */);
   location::GpsInfo const pos6(GetGps(0.0002, 0.00019));
-  testMachedPos(pos6, pos6, 2 /* expectedIndexInRoute */);
+  testMachedPos(pos6, pos6, 3 /* expectedIndexInRoute */);
   location::GpsInfo const pos7(GetGps(0.00019, 0.0001));
-  testMachedPos(pos7, pos7, 3 /* expectedIndexInRoute */);
+  testMachedPos(pos7, pos7, 4 /* expectedIndexInRoute */);
 
   // Moving around the self intersection and checking that position is matched to the last segment of the route.
   location::GpsInfo const pos8(GetGps(0.0001, 0.00005));
-  testMachedPos(pos8, selfIntersectionPos, 3 /* expectedIndexInRoute */);
+  testMachedPos(pos8, selfIntersectionPos, 4 /* expectedIndexInRoute */);
   location::GpsInfo const pos9(GetGps(0.0001, 0.00015));
-  testMachedPos(pos9, selfIntersectionPos, 3 /* expectedIndexInRoute */);
+  testMachedPos(pos9, selfIntersectionPos, 4 /* expectedIndexInRoute */);
 }
 
 UNIT_TEST(RouteNameTest)
@@ -354,21 +419,18 @@ UNIT_TEST(RouteNameTest)
 
   RouteSegment::RoadNameInfo roadNameInfo;
   route.GetCurrentStreetName(roadNameInfo);
+  TEST_EQUAL(roadNameInfo.m_name, "Street0", (roadNameInfo.m_name));
+
+  route.GetClosestStreetNameAfterIdx(1, roadNameInfo);
   TEST_EQUAL(roadNameInfo.m_name, "Street1", (roadNameInfo.m_name));
 
-  route.GetStreetNameAfterIdx(0, roadNameInfo);
-  TEST_EQUAL(roadNameInfo.m_name, "Street1", (roadNameInfo.m_name));
-
-  route.GetStreetNameAfterIdx(1, roadNameInfo);
-  TEST_EQUAL(roadNameInfo.m_name, "Street1", (roadNameInfo.m_name));
-
-  route.GetStreetNameAfterIdx(2, roadNameInfo);
+  route.GetClosestStreetNameAfterIdx(2, roadNameInfo);
   TEST_EQUAL(roadNameInfo.m_name, "Street2", (roadNameInfo.m_name));
 
-  route.GetStreetNameAfterIdx(3, roadNameInfo);
+  route.GetClosestStreetNameAfterIdx(3, roadNameInfo);
   TEST_EQUAL(roadNameInfo.m_name, "Street3", (roadNameInfo.m_name));
 
-  route.GetStreetNameAfterIdx(4, roadNameInfo);
+  route.GetClosestStreetNameAfterIdx(4, roadNameInfo);
   TEST_EQUAL(roadNameInfo.m_name, "Street3", (roadNameInfo.m_name));
 
   location::GpsInfo info;

--- a/routing/routing_tests/routing_helpers_tests.cpp
+++ b/routing/routing_tests/routing_helpers_tests.cpp
@@ -7,6 +7,8 @@
 #include "routing/segment.hpp"
 #include "routing/turns.hpp"
 
+#include "routing/routing_tests/tools.hpp"
+
 #include "indexer/feature_altitude.hpp"
 
 #include "geometry/point2d.hpp"

--- a/routing/routing_tests/routing_helpers_tests.cpp
+++ b/routing/routing_tests/routing_helpers_tests.cpp
@@ -25,47 +25,53 @@ UNIT_TEST(FillSegmentInfoSmokeTest)
 {
   vector<Segment> const segments = {
       {0 /* mwmId */, 1 /* featureId */, 0 /* segmentIdx */, true /* forward */}};
-  vector<geometry::PointWithAltitude> const junctions = {
-      {m2::PointD(0.0 /* x */, 0.0 /* y */), geometry::kInvalidAltitude},
-      {m2::PointD(0.1 /* x */, 0.0 /* y */), geometry::kInvalidAltitude}};
-  Route::TTurns const & turnDirs = {{1 /* point index */, CarDirection::ReachedYourDestination}};
-  Route::TStreets const streets = {};
-  Route::TTimes const times = {{0 /* point index */, 0.0 /* time in seconds */}, {1, 1.0}};
+  vector<m2::PointD> const junctions = {
+      m2::PointD(0.0 /* x */, 0.0 /* y */),
+      m2::PointD(0.0 /* x */, 0.0 /* y */)};
+  vector<turns::TurnItem> const & turnDirs = {{1 /* point index */, CarDirection::ReachedYourDestination}};
+  vector<double> const times = {0.0, 1.0};
 
-  vector<RouteSegment> segmentInfo;
-  FillSegmentInfo(segments, junctions, turnDirs, streets, times, nullptr, segmentInfo);
+  vector<RouteSegment> routeSegments;
+  RouteSegmentsFrom(segments, junctions, turnDirs, vector<RouteSegment::RoadNameInfo>(), routeSegments);
+  FillSegmentInfo(times, nullptr, routeSegments);
 
-  TEST_EQUAL(segmentInfo.size(), 1, ());
-  TEST_EQUAL(segmentInfo[0].GetTurn().m_turn, CarDirection::ReachedYourDestination, ());
-  TEST(segmentInfo[0].GetRoadNameInfo().m_name.empty(), ());
+  TEST_EQUAL(routeSegments.size(), 1, ());
+  TEST_EQUAL(routeSegments[0].GetTurn().m_turn, CarDirection::ReachedYourDestination, ());
+  TEST(routeSegments[0].GetRoadNameInfo().m_name.empty(), ());
 }
 
 UNIT_TEST(FillSegmentInfoTest)
 {
-  vector<Segment> const segments = {
-      {0 /* mwmId */, 1 /* featureId */, 0 /* segmentIdx */, true /* forward */}, {0, 2, 0, true}};
-  vector<geometry::PointWithAltitude> const junctions = {
-      {m2::PointD(0.0 /* x */, 0.0 /* y */), geometry::kInvalidAltitude},
-      {m2::PointD(0.1 /* x */, 0.0 /* y */), geometry::kInvalidAltitude},
-      {m2::PointD(0.2 /* x */, 0.0 /* y */), geometry::kInvalidAltitude}};
-  Route::TTurns const & turnDirs = {{1 /* point index */, CarDirection::TurnRight},
-                                    {2 /* point index */, CarDirection::ReachedYourDestination}};
-  Route::TStreets const streets = {{0 /* point index */, {"zero", "", "", "", "", false}},
-                                   {1 /* point index */, {"first", "", "", "", "", false}},
-                                   {2 /* point index */, {"second", "", "", "", "", false}}};
-  Route::TTimes const times = {
-      {0 /* point index */, 0.0 /* time in seconds */}, {1, 1.0}, {2, 2.0}};
+  vector<Segment> const segments =
+      {{0 /* mwmId */, 1 /* featureId */, 0 /* segmentIdx */, true /* forward */},
+       {0, 2, 0, true},
+       {0, 3, 0, true}};
+  vector<m2::PointD> const junctions =
+      {m2::PointD(0.0 /* x */, 0.0 /* y */),
+       m2::PointD(0.0 /* x */, 0.0 /* y */),
+       m2::PointD(0.1 /* x */, 0.0 /* y */),
+       m2::PointD(0.2 /* x */, 0.0 /* y */)};
+  vector<turns::TurnItem> const & turnDirs =
+      {{1 /* point index */, CarDirection::None},
+       {2 /* point index */, CarDirection::TurnRight},
+       {3 /* point index */, CarDirection::ReachedYourDestination}};
+  vector<RouteSegment::RoadNameInfo> const streets =
+      {{"zero", "", "", "", "", false},
+       {"first", "", "", "", "", false},
+       {"second", "", "", "", "", false}};
+  vector<double> const times = {0.0, 1.0, 2.0, 3.0};
 
   vector<RouteSegment> segmentInfo;
-  FillSegmentInfo(segments, junctions, turnDirs, streets, times, nullptr, segmentInfo);
+  RouteSegmentsFrom(segments, junctions, turnDirs, streets, segmentInfo);
+  FillSegmentInfo(times, nullptr /* trafficStash */, segmentInfo);
 
-  TEST_EQUAL(segmentInfo.size(), 2, ());
-  TEST_EQUAL(segmentInfo[0].GetTurn().m_turn, CarDirection::TurnRight, ());
-  TEST_EQUAL(segmentInfo[0].GetRoadNameInfo().m_name, string("first"), ());
+  TEST_EQUAL(segmentInfo.size(), 3, ());
+  TEST_EQUAL(segmentInfo[1].GetTurn().m_turn, CarDirection::TurnRight, ());
+  TEST_EQUAL(segmentInfo[1].GetRoadNameInfo().m_name, string("first"), ());
   TEST_EQUAL(segmentInfo[0].GetSegment(), segments[0], ());
 
-  TEST_EQUAL(segmentInfo[1].GetTurn().m_turn, CarDirection::ReachedYourDestination, ());
-  TEST_EQUAL(segmentInfo[1].GetRoadNameInfo().m_name, string("second"), ());
+  TEST_EQUAL(segmentInfo[2].GetTurn().m_turn, CarDirection::ReachedYourDestination, ());
+  TEST_EQUAL(segmentInfo[2].GetRoadNameInfo().m_name, string("second"), ());
   TEST_EQUAL(segmentInfo[1].GetSegment(), segments[1], ());
 }
 

--- a/routing/routing_tests/routing_session_test.cpp
+++ b/routing/routing_tests/routing_session_test.cpp
@@ -28,17 +28,20 @@ using namespace std;
 using chrono::seconds;
 using chrono::steady_clock;
 
-vector<m2::PointD> kTestRoute = {{0., 1.}, {0., 2.}, {0., 3.}, {0., 4.}};
-vector<Segment> const kTestSegments({{0, 0, 0, true}, {0, 0, 1, true}, {0, 0, 2, true}});
-Route::TTurns const kTestTurnsReachOnly = {
-    turns::TurnItem(3, turns::CarDirection::ReachedYourDestination)};
-Route::TTurns const kTestTurns = {turns::TurnItem(1, turns::CarDirection::TurnLeft),
+vector<m2::PointD> kTestRoute = {{0., 1.}, {0., 1.}, {0., 3.}, {0., 4.}};
+vector<Segment> const kTestSegments = {{0, 0, 0, true}, {0, 0, 1, true}, {0, 0, 2, true}};
+vector<turns::TurnItem> const kTestTurnsReachOnly =
+                                 {turns::TurnItem(1, turns::CarDirection::None),
+                                  turns::TurnItem(2, turns::CarDirection::None),
                                   turns::TurnItem(3, turns::CarDirection::ReachedYourDestination)};
-Route::TTimes const kTestTimes({Route::TTimeItem(1, 5), Route::TTimeItem(2, 10),
-                                Route::TTimeItem(3, 15)});
+vector<turns::TurnItem> const kTestTurns =
+                                 {turns::TurnItem(1, turns::CarDirection::None),
+                                  turns::TurnItem(2, turns::CarDirection::TurnLeft),
+                                  turns::TurnItem(3, turns::CarDirection::ReachedYourDestination)};
+vector<double> const kTestTimes = {0.0, 5.0, 10.0, 15.0};
 auto const kRouteBuildingMaxDuration = seconds(30);
 
-void FillSubroutesInfo(Route & route, Route::TTurns const & turns = kTestTurnsReachOnly);
+void FillSubroutesInfo(Route & route, vector<turns::TurnItem> const & turns = kTestTurnsReachOnly);
 
 // Simple router. It returns route given to him on creation.
 class DummyRouter : public IRouter
@@ -192,14 +195,15 @@ private:
   RoutingSession & m_session;
 };
 
-void FillSubroutesInfo(Route & route, Route::TTurns const & turns /* = kTestTurnsReachOnly */)
+void FillSubroutesInfo(Route & route, vector<turns::TurnItem> const & turns /* = kTestTurnsReachOnly */)
 {
   vector<geometry::PointWithAltitude> junctions;
   for (auto const & point : kTestRoute)
     junctions.emplace_back(point, geometry::kDefaultAltitudeMeters);
 
   vector<RouteSegment> segmentInfo;
-  FillSegmentInfo(kTestSegments, junctions, turns, {}, kTestTimes, nullptr /* trafficStash */,
+  RouteSegmentsFrom(kTestSegments, kTestRoute, turns, vector<RouteSegment::RoadNameInfo>(), segmentInfo);
+  FillSegmentInfo(kTestTimes, nullptr /* trafficStash */,
                   segmentInfo);
   route.SetRouteSegments(move(segmentInfo));
   route.SetSubroteAttrs(vector<Route::SubrouteAttrs>(

--- a/routing/routing_tests/tools.cpp
+++ b/routing/routing_tests/tools.cpp
@@ -4,10 +4,10 @@ namespace routing
 {
 void AsyncGuiThreadTestWithRoutingSession::InitRoutingSession()
 {
-    m_session = std::make_unique<routing::RoutingSession>();
-    m_session->Init(nullptr /* pointCheckCallback */);
-    m_session->SetRoutingSettings(routing::GetRoutingSettings(routing::VehicleType::Car));
-    m_session->SetOnNewTurnCallback([this]() { ++m_onNewTurnCallbackCounter; });
+  m_session = std::make_unique<routing::RoutingSession>();
+  m_session->Init(nullptr /* pointCheckCallback */);
+  m_session->SetRoutingSettings(routing::GetRoutingSettings(routing::VehicleType::Car));
+  m_session->SetOnNewTurnCallback([this]() { ++m_onNewTurnCallbackCounter; });
 }
 
 void RouteSegmentsFrom(std::vector<Segment> const & segments, std::vector<m2::PointD> const & path,
@@ -44,10 +44,7 @@ void RouteSegmentsFrom(std::vector<Segment> const & segments, std::vector<m2::Po
     RouteSegment::RoadNameInfo name;
     if (names.size() > 0)
       name = names[i];
-    routeSegments.emplace_back(RouteSegment(
-      segment, turn,
-      point, name, SpeedInUnits(), traffic::SpeedGroup::Unknown)
-      );
+    routeSegments.emplace_back(segment, turn, point, name, SpeedInUnits(), traffic::SpeedGroup::Unknown);
   }
-};
+}
 }  // namespace routing

--- a/routing/routing_tests/tools.cpp
+++ b/routing/routing_tests/tools.cpp
@@ -1,0 +1,53 @@
+#include "routing/routing_tests/tools.hpp"
+
+namespace routing
+{
+void AsyncGuiThreadTestWithRoutingSession::InitRoutingSession()
+{
+    m_session = std::make_unique<routing::RoutingSession>();
+    m_session->Init(nullptr /* pointCheckCallback */);
+    m_session->SetRoutingSettings(routing::GetRoutingSettings(routing::VehicleType::Car));
+    m_session->SetOnNewTurnCallback([this]() { ++m_onNewTurnCallbackCounter; });
+}
+
+void RouteSegmentsFrom(std::vector<Segment> const & segments, std::vector<m2::PointD> const & path,
+                       std::vector<turns::TurnItem> const & turns, std::vector<RouteSegment::RoadNameInfo> const & names,
+                       std::vector<RouteSegment> & routeSegments)
+{
+  size_t size = segments.size();
+  if (size == 0)
+    size = turns.size();
+  if (size == 0)
+    size = names.size();
+  if (size == 0)
+    size = path.size() - 1;
+
+  ASSERT(segments.empty() || segments.size() == size, ());
+  ASSERT(turns.empty() || turns.size() == size, ());
+  ASSERT(names.empty() || names.size() == size, ());
+  ASSERT(path.empty() || path.size() - 1 == size, ());
+
+  for (size_t i = 0; i < size; ++i)
+  {
+    geometry::PointWithAltitude point;
+    if (path.size() > 0)
+      point = geometry::PointWithAltitude(path[i+1], geometry::kDefaultAltitudeMeters);
+    Segment segment({0, 0, 0, true});
+    if (segments.size() > 0)
+      segment = segments[i];
+    turns::TurnItem turn;
+    if (turns.size() > 0)
+    {
+      turn = turns[i];
+      ASSERT(turn.m_index == i + 1, ());
+    }
+    RouteSegment::RoadNameInfo name;
+    if (names.size() > 0)
+      name = names[i];
+    routeSegments.emplace_back(RouteSegment(
+      segment, turn,
+      point, name, SpeedInUnits(), traffic::SpeedGroup::Unknown)
+      );
+  }
+};
+}  // namespace routing

--- a/routing/routing_tests/tools.hpp
+++ b/routing/routing_tests/tools.hpp
@@ -30,9 +30,9 @@ public:
 
 namespace routing
 {
-void RouteSegmentsFrom(std::vector<Segment> const & segments, std::vector<m2::PointD> const & path,
-                       std::vector<turns::TurnItem> const & turns, std::vector<RouteSegment::RoadNameInfo> const & names,
-                       std::vector<RouteSegment> & routeSegments)
+inline void RouteSegmentsFrom(std::vector<Segment> const & segments, std::vector<m2::PointD> const & path,
+                              std::vector<turns::TurnItem> const & turns, std::vector<RouteSegment::RoadNameInfo> const & names,
+                              std::vector<RouteSegment> & routeSegments)
 {
   size_t size = segments.size();
   if (size == 0)

--- a/routing/routing_tests/tools.hpp
+++ b/routing/routing_tests/tools.hpp
@@ -3,11 +3,11 @@
 #include "platform/platform_tests_support/async_gui_thread.hpp"
 
 #include "routing/routing_session.hpp"
-#include "routing/routing_settings.hpp"
-#include "routing/vehicle_mask.hpp"
 
 #include <memory>
 
+namespace routing
+{
 class AsyncGuiThreadTest
 {
   platform::tests_support::AsyncGuiThread m_asyncGuiThread;
@@ -16,58 +16,13 @@ class AsyncGuiThreadTest
 class AsyncGuiThreadTestWithRoutingSession : public AsyncGuiThreadTest
 {
 public:
-  void InitRoutingSession()
-  {
-    m_session = std::make_unique<routing::RoutingSession>();
-    m_session->Init(nullptr /* pointCheckCallback */);
-    m_session->SetRoutingSettings(routing::GetRoutingSettings(routing::VehicleType::Car));
-    m_session->SetOnNewTurnCallback([this]() { ++m_onNewTurnCallbackCounter; });
-  }
+  void InitRoutingSession();
 
-  std::unique_ptr<routing::RoutingSession> m_session;
+  std::unique_ptr<RoutingSession> m_session;
   size_t m_onNewTurnCallbackCounter = 0;
 };
 
-namespace routing
-{
-inline void RouteSegmentsFrom(std::vector<Segment> const & segments, std::vector<m2::PointD> const & path,
-                              std::vector<turns::TurnItem> const & turns, std::vector<RouteSegment::RoadNameInfo> const & names,
-                              std::vector<RouteSegment> & routeSegments)
-{
-  size_t size = segments.size();
-  if (size == 0)
-    size = turns.size();
-  if (size == 0)
-    size = names.size();
-  if (size == 0)
-    size = path.size() - 1;
-
-  ASSERT(segments.empty() || segments.size() == size, ());
-  ASSERT(turns.empty() || turns.size() == size, ());
-  ASSERT(names.empty() || names.size() == size, ());
-  ASSERT(path.empty() || path.size() - 1 == size, ());
-
-  for (size_t i = 0; i < size; ++i)
-  {
-    geometry::PointWithAltitude point;
-    if (path.size() > 0)
-      point = geometry::PointWithAltitude(path[i+1], geometry::kDefaultAltitudeMeters);
-    Segment segment({0, 0, 0, true});
-    if (segments.size() > 0)
-      segment = segments[i];
-    turns::TurnItem turn;
-    if (turns.size() > 0)
-    {
-      turn = turns[i];
-      ASSERT(turn.m_index == i + 1, ());
-    }
-    RouteSegment::RoadNameInfo name;
-    if (names.size() > 0)
-      name = names[i];
-    routeSegments.emplace_back(RouteSegment(
-      segment, turn,
-      point, name, SpeedInUnits(), traffic::SpeedGroup::Unknown)
-      );
-  }
-};
+void RouteSegmentsFrom(std::vector<Segment> const & segments, std::vector<m2::PointD> const & path,
+                       std::vector<turns::TurnItem> const & turns, std::vector<RouteSegment::RoadNameInfo> const & names,
+                       std::vector<RouteSegment> & routeSegments);
 }  // namespace routing

--- a/routing/routing_tests/tools.hpp
+++ b/routing/routing_tests/tools.hpp
@@ -28,9 +28,11 @@ public:
   size_t m_onNewTurnCallbackCounter = 0;
 };
 
+namespace routing
+{
 void RouteSegmentsFrom(std::vector<Segment> const & segments, std::vector<m2::PointD> const & path,
                        std::vector<turns::TurnItem> const & turns, std::vector<RouteSegment::RoadNameInfo> const & names,
-                       vector<RouteSegment> & routeSegments)
+                       std::vector<RouteSegment> & routeSegments)
 {
   size_t size = segments.size();
   if (size == 0)
@@ -68,3 +70,4 @@ void RouteSegmentsFrom(std::vector<Segment> const & segments, std::vector<m2::Po
       );
   }
 };
+}  // namespace routing

--- a/routing/routing_tests/tools.hpp
+++ b/routing/routing_tests/tools.hpp
@@ -27,3 +27,44 @@ public:
   std::unique_ptr<routing::RoutingSession> m_session;
   size_t m_onNewTurnCallbackCounter = 0;
 };
+
+void RouteSegmentsFrom(std::vector<Segment> const & segments, std::vector<m2::PointD> const & path,
+                       std::vector<turns::TurnItem> const & turns, std::vector<RouteSegment::RoadNameInfo> const & names,
+                       vector<RouteSegment> & routeSegments)
+{
+  size_t size = segments.size();
+  if (size == 0)
+    size = turns.size();
+  if (size == 0)
+    size = names.size();
+  if (size == 0)
+    size = path.size() - 1;
+
+  ASSERT(segments.empty() || segments.size() == size, ());
+  ASSERT(turns.empty() || turns.size() == size, ());
+  ASSERT(names.empty() || names.size() == size, ());
+  ASSERT(path.empty() || path.size() - 1 == size, ());
+
+  for (size_t i = 0; i < size; ++i)
+  {
+    geometry::PointWithAltitude point;
+    if (path.size() > 0)
+      point = geometry::PointWithAltitude(path[i+1], geometry::kDefaultAltitudeMeters);
+    Segment segment({0, 0, 0, true});
+    if (segments.size() > 0)
+      segment = segments[i];
+    turns::TurnItem turn;
+    if (turns.size() > 0)
+    {
+      turn = turns[i];
+      ASSERT(turn.m_index == i + 1, ());
+    }
+    RouteSegment::RoadNameInfo name;
+    if (names.size() > 0)
+      name = names[i];
+    routeSegments.emplace_back(RouteSegment(
+      segment, turn,
+      point, name, SpeedInUnits(), traffic::SpeedGroup::Unknown)
+      );
+  }
+};

--- a/routing/turns.cpp
+++ b/routing/turns.cpp
@@ -171,8 +171,6 @@ string DebugPrint(TurnItem const & turnItem)
   out << "TurnItem [ m_index = " << turnItem.m_index
       << ", m_turn = " << DebugPrint(turnItem.m_turn)
       << ", m_lanes = " << ::DebugPrint(turnItem.m_lanes) << ", m_exitNum = " << turnItem.m_exitNum
-      << ", m_sourceName = " << turnItem.m_sourceName
-      << ", m_targetName = " << turnItem.m_targetName
       << ", m_pedestrianDir = " << DebugPrint(turnItem.m_pedestrianTurn)
       << " ]" << endl;
   return out.str();

--- a/routing/turns.hpp
+++ b/routing/turns.hpp
@@ -63,9 +63,6 @@ private:
 
 namespace turns
 {
-/// @todo(vbykoianko) It's a good idea to gather all the turns information into one entity.
-/// For the time being several separate entities reflect the turn information. Like Route::TTurns
-
 double constexpr kFeaturesNearTurnMeters = 3.0;
 
 /*!
@@ -181,9 +178,7 @@ struct TurnItem
   bool operator==(TurnItem const & rhs) const
   {
     return m_index == rhs.m_index && m_turn == rhs.m_turn && m_lanes == rhs.m_lanes &&
-           m_exitNum == rhs.m_exitNum && m_sourceName == rhs.m_sourceName &&
-           m_targetName == rhs.m_targetName &&
-           m_pedestrianTurn == rhs.m_pedestrianTurn;
+           m_exitNum == rhs.m_exitNum && m_pedestrianTurn == rhs.m_pedestrianTurn;
   }
 
   bool IsTurnReachedYourDestination() const
@@ -197,12 +192,10 @@ struct TurnItem
     return m_turn == CarDirection::None && m_pedestrianTurn == PedestrianDirection::None;
   }
 
-  uint32_t m_index;                    /*!< Index of point on route polyline (number of segment + 1). */
+  uint32_t m_index;                    /*!< Index of point on route polyline (Index of segment + 1). */
   CarDirection m_turn = CarDirection::None; /*!< The turn instruction of the TurnItem */
   std::vector<SingleLaneInfo> m_lanes; /*!< Lane information on the edge before the turn. */
   uint32_t m_exitNum;                  /*!< Number of exit on roundabout. */
-  std::string m_sourceName;            /*!< Name of the street which the ingoing edge belongs to */
-  std::string m_targetName;            /*!< Name of the street which the outgoing edge belongs to */
   /*!
    * \brief m_pedestrianTurn is type of corresponding direction for a pedestrian, or None
    * if there is no pedestrian specific direction


### PR DESCRIPTION
Now RouteSegments generation starts at DirectionsEngine::Generate().
But this is just preparation, when segments are not created,
but turns, street names, any new staff like speed limits are created
with indexes when it should be applied later.
Later in FillSegmentInfo all this info is unpacked to RouteSegments
and populated by segments and junctions.
This approach is overcomplicated and makes difficult adding new info,
like speed limits, by creating more and more data to pack and unpack.
Also extra memory allocations are done for intermediate steps.
Several todo were found mentioning desirability of changes.
For this reason it was decided to create RouteSegments
at DirectionsEngine::Generate() with all available info
with minimal post-processing at later stages.