### PR TITLE
WIP [indexer] Allow feature visibility override

### DIFF
--- a/generator/geometry_holder.hpp
+++ b/generator/geometry_holder.hpp
@@ -58,14 +58,20 @@ public:
 
   Points const & GetSourcePoints()
   {
+    // For short lines keep simplifying the previous version to ensure points visibility is consistent.
     return !m_current.empty() ? m_current : m_fb.GetOuterGeometry();
   }
 
+  // Its important AddPoints is called sequentially from upper scales to lower.
   void AddPoints(Points const & points, int scaleIndex)
   {
     if (m_ptsInner && points.size() <= m_maxNumTriangles)
     {
+      // Store small features inline and keep a mask for individual points scale visibility.
       if (m_buffer.m_innerPts.empty())
+        // FIXME: if geometry is added for the most detailed scale 3 only
+        // then the mask is never updated and left == 0,
+        // which means the geometry could be used on any scale.
         m_buffer.m_innerPts = points;
       else
         FillInnerPointsMask(points, scaleIndex);

--- a/indexer/data_source.cpp
+++ b/indexer/data_source.cpp
@@ -49,6 +49,10 @@ public:
 
       // In case of WorldCoasts we should pass correct scale in ForEachInIntervalAndScale.
       auto const lastScale = header.GetLastScale();
+      // Read 3 additional scale indices to allow visibility changes
+      // for style designers and for custom style users.
+      // TODO: add enable/disable flag and always keep disabled for the world map.
+      scale += 3;
       if (scale > lastScale)
         scale = lastScale;
 


### PR DESCRIPTION
This is a WIP experimental change to allow for easy feature visibility changes without scale index or whole map regeneration.
Its meant to be generally disabled and enabled for the following use cases only:
- style designers
- power users whishing to use a custom map style

There are two changes:
- read extra 3 scale indices - its necessary for a visibility-changed feature to be discoverable at a new lower zoom level, because its not present in the scale index at this new level
- fallback to a nearest (worst) geometry if optimized geometry doesn't exist for the feature's new zoom level

This comes with some performance degradation:
- in my testing on a mid-range android device a slowdown was noticeable but it was comfotable to use the app still;
- on a mid-range laptop a slowdown was barely noticeable;
- the most of the speed impact comes from the extra scale indices read;
- the impact of the geometry fallback was insignificant (but can raise if a lot more complex features will have their visibility raises compared to my test case),
this impact could be further reduced if needed by a run-time excess line points remover (we do have this code used for lines at zl [10,12] already).

So I think performance-wise its perfectly fine for a style design scenario and user testing is needed to see if power users will be happy too.

It basically replaces existing "designer tool's" functionality to regenerate a scale index (atm it does it with each feature's visibility extended by +-3 zoom levels) and additionally solves a missing geometry case (atm a full map regeneration is needed).


TODO:
Make the feature enabled for design and custom styles use cases only (and always disabled for the world map?):
- on android and ios switch it on if a custom style file is loaded;
- on desktop enable by a command line option?
- enable by default in a "designer tool".
