### PR TITLE
Fixed version script and made generated version unique

### DIFF
--- a/tools/unix/version.sh
+++ b/tools/unix/version.sh
@@ -4,8 +4,10 @@
 set -euo pipefail
 
 # Note: other ways to get date use the "when commit was rebased" date.
-# This approach counts a number of commits each day based on author's commit date.
-COUNT_AND_DATE=( $(git log --date=short --pretty=format:%ad --date=format:'%Y.%m.%d' --since="30 days ago" | sort | uniq -c | tail -1) )
+# This approach counts a number of commits each day based on committer's commit date
+# instead of author's commit date, to avoid conflicts when old PRs are merged, but the
+# number of today's commits stays the same.
+COUNT_AND_DATE=( $(git log --date=short --pretty=format:%cd --date=format:'%Y.%m.%d' --since="30 days ago" | sort | uniq -c | tail -1) )
 if [ -z "$COUNT_AND_DATE" ]; then
   # Fallback: use today's date if there were no commits since last month.
   COUNT_AND_DATE=( 0 $(date +%Y.%m.%d) )


### PR DESCRIPTION
Это пофиксит баги с несобирающимися бетами для iOS после их мержа в мастер. Там генерируемая версия [не менялась](https://github.com/organicmaps/organicmaps/runs/7063575993?check_suite_focus=true).

У каждого коммита есть дата автора, и дата коммиттера, когда коммит автора был вмержен в ветку.