### PR TITLE
[android] unify styling for all bottom sheets

### DIFF
--- a/android/res/layout/bottom_sheet.xml
+++ b/android/res/layout/bottom_sheet.xml
@@ -5,6 +5,9 @@
   android:layout_height="match_parent"
   android:orientation="vertical">
 
+  <include
+    layout="@layout/bottom_sheet_handle" />
+
   <androidx.fragment.app.FragmentContainerView
     android:id="@+id/bottom_sheet_menu_header"
     android:layout_width="match_parent"

--- a/android/res/values/styles.xml
+++ b/android/res/values/styles.xml
@@ -386,21 +386,21 @@
     <item name="android:textSize">@dimen/text_size_toolbar</item>
   </style>
 
-  <style name="MwmWidget.BottomSheet" parent="Widget.Material3.BottomSheet.Modal">
-    <item name="android:background">?cardBackground</item>
+  <style
+    name="MwmTheme.BottomSheetDialog"
+    parent="@style/ThemeOverlay.Material3.BottomSheetDialog">
+    <item name="bottomSheetStyle">@style/MwmWidget.BottomSheetDialog</item>
+  </style>
+
+  <style name="MwmWidget.BottomSheetDialog" parent="Widget.Material3.BottomSheet.Modal">
     <item name="backgroundTint">?cardBackground</item>
-    <item name="behavior_hideable">false</item>
+    <item name="elevationOverlayEnabled">false</item>
     <item name="shapeAppearance">@style/ShapeAppearance.Material3.LargeComponent</item>
   </style>
 
-  <style name="MwmWidget.BottomSheetDialog" parent="Theme.Material3.Light.BottomSheetDialog">
-    <item name="colorSurface">?cardBackground</item>
-    <item name="elevationOverlayEnabled">false</item>
-  </style>
-
-  <style name="MwmWidget.Night.BottomSheetDialog" parent="Theme.Material3.Dark.BottomSheetDialog" >
-    <item name="colorSurface">?cardBackground</item>
-    <item name="elevationOverlayEnabled">false</item>
+  <style name="MwmWidget.BottomSheet" parent="MwmWidget.BottomSheetDialog">
+    <item name="android:background">?cardBackground</item>
+    <item name="behavior_hideable">false</item>
   </style>
 
 </resources>

--- a/android/res/values/themes-base.xml
+++ b/android/res/values/themes-base.xml
@@ -172,7 +172,10 @@
     <item name="chipTextColor">@color/bg_primary</item>
     <item name="android:popupMenuStyle">@style/PopupMenu</item>
 
+    <!-- Style used for bottom sheet behavior components -->
     <item name="bottomSheetStyle">@style/MwmWidget.BottomSheet</item>
+    <!-- Theme used for bottom sheet dialog components -->
+    <item name="bottomSheetDialogTheme">@style/MwmTheme.BottomSheetDialog</item>
   </style>
 
   <!-- Night theme -->
@@ -341,5 +344,6 @@
     <item name="android:popupMenuStyle">@style/PopupMenu.Dark</item>
 
     <item name="bottomSheetStyle">@style/MwmWidget.BottomSheet</item>
+    <item name="bottomSheetDialogTheme">@style/MwmTheme.BottomSheetDialog</item>
   </style>
 </resources>

--- a/android/src/com/mapswithme/util/bottomsheet/MenuBottomSheetFragment.java
+++ b/android/src/com/mapswithme/util/bottomsheet/MenuBottomSheetFragment.java
@@ -56,14 +56,6 @@ public class MenuBottomSheetFragment extends BottomSheetDialogFragment
   }
 
   @Override
-  public int getTheme()
-  {
-    return ThemeUtils.isNightTheme(requireContext())
-        ? R.style.MwmWidget_Night_BottomSheetDialog
-        : R.style.MwmWidget_BottomSheetDialog;
-  }
-
-  @Override
   public void onCreate(@Nullable Bundle savedInstanceState)
   {
     super.onCreate(savedInstanceState);


### PR DESCRIPTION
This PR comes to finish the work on refactoring the various bottom sheets. Here I focused making sure all bottom sheets follow the same styling.

Apart from internal code changes, there are also some visual changes:
- Bottom sheet dialogs (when the background is dimmed) have the same handle and same corner radius as the place page and navigation menu.

| Menu swiping | Menu opened | Place page collapsed | Navigation menu |
|-|-|-|-|
| ![Screenshot_20220628_084851](https://user-images.githubusercontent.com/80701113/176112259-9a6d9ad4-e2a6-49d2-8296-68df4cef1af3.png) | ![Screenshot_20220628_084924](https://user-images.githubusercontent.com/80701113/176112316-75f71f12-4070-4b14-a549-790086c81cec.png) | ![Screenshot_20220628_084942](https://user-images.githubusercontent.com/80701113/176112371-85990619-9631-4eb5-828e-b7b18d9a4193.png) | ![Screenshot_20220628_084959](https://user-images.githubusercontent.com/80701113/176112423-b0c6cf0f-c443-4ca2-a25a-fe85c05f1b3a.png) | 

| Menu night mode | Place page night mode | Layers menu |
|-|-|-|
| ![Screenshot_20220628_085748](https://user-images.githubusercontent.com/80701113/176113959-3bfa45f5-c4fa-41a1-89d9-26f248950bda.png) | ![Screenshot_20220628_085803](https://user-images.githubusercontent.com/80701113/176113970-d0af6587-23be-4a00-9f0a-b64b7837d414.png) | ![Screenshot_20220628_085022](https://user-images.githubusercontent.com/80701113/176112500-636736f0-8a7a-4321-85a5-57867beff6fe.png) |

Closes #1745
