### PR TITLE
Show text info about next turn street/road longer

### DIFF
--- a/routing/car_directions.cpp
+++ b/routing/car_directions.cpp
@@ -106,7 +106,7 @@ size_t CarDirectionsEngine::GetTurnDirection(IRoutingResult const & result, size
   /// @todo Sometimes results of GetPossibleTurns are empty, sometimes are invalid.
   /// The best will be to fix GetPossibleTurns(). It will allow us to use following approach.
   /// E.g. Google Maps until you reach the destination will guide you to go to the left or to the right of the first road.
-  if (outgoingSegmentIndex == 1) // The same as turnItem.m_index == 2.
+  if (outgoingSegmentIndex == 2) // The same as turnItem.m_index == 2.
     return 0;
 
   size_t skipTurnSegments = CheckUTurnOnRoute(result, outgoingSegmentIndex, numMwmIds, vehicleSettings, turnItem);

--- a/routing/pedestrian_directions.cpp
+++ b/routing/pedestrian_directions.cpp
@@ -30,6 +30,10 @@ size_t PedestrianDirectionsEngine::GetTurnDirection(IRoutingResult const & resul
     return 0;
   }
 
+  // See comment for the same in CarDirectionsEngine::GetTurnDirection().
+  if (outgoingSegmentIndex == 2) // The same as turnItem.m_index == 2.
+    return 0;
+
   TurnInfo turnInfo;
   if (!GetTurnInfo(result, outgoingSegmentIndex, vehicleSettings, turnInfo))
     return 0;

--- a/routing/route.cpp
+++ b/routing/route.cpp
@@ -97,7 +97,7 @@ double Route::GetCurrentTimeToNearestTurnSec() const
   TurnItem turn;
   GetNearestTurn(distance, turn);
 
-  // |curTurn.m_index| - 1 is the index of |curTurn| segment.
+  // |turn.m_index| - 1 is the index of |turn| segment.
   CHECK_LESS_OR_EQUAL(turn.m_index, m_routeSegments.size(), ());
   CHECK_GREATER(turn.m_index, 0, ());
 

--- a/routing/route.cpp
+++ b/routing/route.cpp
@@ -88,33 +88,65 @@ double Route::GetTotalTimeSec() const
 
 double Route::GetCurrentTimeToEndSec() const
 {
+  return GetCurrentTimeToSegmentSec(m_routeSegments.size() - 1);
+}
+
+double Route::GetCurrentTimeToNearestTurnSec() const
+{
+  double distance;
+  TurnItem turn;
+  GetNearestTurn(distance, turn);
+
+  // |curTurn.m_index| - 1 is the index of |curTurn| segment.
+  CHECK_LESS_OR_EQUAL(turn.m_index, m_routeSegments.size(), ());
+  CHECK_GREATER(turn.m_index, 0, ());
+
+  return GetCurrentTimeToSegmentSec(turn.m_index - 1);
+}
+
+//           |     curSegLenMeters          |
+//           |                              |
+//           | passedSegMeters |            |
+// ----------*-----------------*------------*----> x
+//           |                 |            |
+//           LastPoint     CurrentPoint     NextPoint
+//
+//           | fromLastPassedPointToEndSec
+// ----------*-----------------*------------*----> t
+//           |                 |            |
+//           toLastPointSec    currentTime  toNextPointSec
+//
+// CurrentTime is calculated using equal proportions for distance and time at any segment.
+double Route::GetCurrentTimeFromBeginSec() const
+{
   if (!IsValid())
     return 0.0;
 
   auto const & curIter = m_poly.GetCurrentIter();
   CHECK_LESS(curIter.m_ind, m_routeSegments.size(), ());
-  double const etaToLastPassedPointS = GetETAToLastPassedPointSec();
+
+  double const toLastPointSec = (curIter.m_ind == 0) ? 0.0 : m_routeSegments[curIter.m_ind - 1].GetTimeFromBeginningSec();
+  double const toNextPointSec = m_routeSegments[curIter.m_ind].GetTimeFromBeginningSec();
+
   double const curSegLenMeters = GetSegLenMeters(curIter.m_ind);
-  double const totalTimeS = GetTotalTimeSec();
-  double const fromLastPassedPointToEndSec = totalTimeS - etaToLastPassedPointS;
-  // Note. If a segment is short it does not make any sense to take into account time needed
-  // to path its part.
-  if (base::AlmostEqualAbs(curSegLenMeters, 0.0, 1.0 /* meters */))
-    return fromLastPassedPointToEndSec;
 
-  CHECK_LESS(curIter.m_ind, m_routeSegments.size(), ());
-  // Pure fake edges should not be taken into account while ETA calculation.
-  if (!m_routeSegments[curIter.m_ind].GetSegment().IsRealSegment())
-    return fromLastPassedPointToEndSec;
+  if (curSegLenMeters < 1.0)
+    return toLastPointSec;
 
-  double const curSegTimeS = GetTimeToPassSegSec(curIter.m_ind);
-  CHECK_GREATER(curSegTimeS, 0, ("Route can't contain segments with infinite speed."));
+  double const passedSegMeters = m_poly.GetDistFromCurPointToRoutePointMeters();
 
-  double const curSegSpeedMPerS = curSegLenMeters / curSegTimeS;
-  CHECK_GREATER(curSegSpeedMPerS, 0, ("Route can't contain segments with zero speed."));
-  /// @todo GetDistFromCurPointTo!Next!RoutePointMeters should be used for calculalation of remaining segment length.
-  return totalTimeS - (etaToLastPassedPointS +
-                       m_poly.GetDistFromCurPointToRoutePointMeters() / curSegSpeedMPerS);
+  return toLastPointSec + passedSegMeters / curSegLenMeters * (toNextPointSec - toLastPointSec);
+}
+
+double Route::GetCurrentTimeToSegmentSec(size_t segIdx) const
+{
+  if (!IsValid())
+    return 0.0;
+
+  double const endTimeSec = m_routeSegments[segIdx].GetTimeFromBeginningSec();
+  double const passedTimeSec = GetCurrentTimeFromBeginSec();
+
+  return endTimeSec - passedTimeSec;
 }
 
 void Route::GetCurrentSpeedLimit(SpeedInUnits & speedLimit) const
@@ -139,7 +171,7 @@ void Route::GetNextTurnStreetName(RouteSegment::RoadNameInfo & roadNameInfo) con
 {
   double distance;
   TurnItem turn;
-  GetCurrentTurn(distance, turn);
+  GetNearestTurn(distance, turn);
   GetClosestStreetNameAfterIdx(turn.m_index, roadNameInfo);
 }
 
@@ -227,7 +259,7 @@ void Route::GetClosestTurnAfterIdx(size_t segIdx, TurnItem & turn) const
   CHECK(false, ("The last turn should be ReachedYourDestination."));
 }
 
-void Route::GetCurrentTurn(double & distanceToTurnMeters, TurnItem & turn) const
+void Route::GetNearestTurn(double & distanceToTurnMeters, TurnItem & turn) const
 {
   // Note. |m_poly.GetCurrentIter().m_ind| is a point index of last passed point at |m_poly|.
   GetClosestTurnAfterIdx(m_poly.GetCurrentIter().m_ind, turn);
@@ -279,7 +311,7 @@ bool Route::GetNextTurn(double & distanceToTurnMeters, TurnItem & nextTurn) cons
 bool Route::GetNextTurns(vector<TurnItemDist> & turns) const
 {
   TurnItemDist currentTurn;
-  GetCurrentTurn(currentTurn.m_distMeters, currentTurn.m_turnItem);
+  GetNearestTurn(currentTurn.m_distMeters, currentTurn.m_turnItem);
 
   turns.clear();
   turns.emplace_back(move(currentTurn));
@@ -447,13 +479,6 @@ void Route::GetTurnsForTesting(vector<TurnItem> & turns) const
   }
 }
 
-double Route::GetTimeToPassSegSec(size_t segIdx) const
-{
-  CHECK_LESS(segIdx, m_routeSegments.size(), ());
-  return m_routeSegments[segIdx].GetTimeFromBeginningSec() -
-         (segIdx == 0 ? 0.0 : m_routeSegments[segIdx - 1].GetTimeFromBeginningSec());
-}
-
 double Route::GetSegLenMeters(size_t segIdx) const
 {
   CHECK_LESS(segIdx, m_routeSegments.size(), ());
@@ -474,15 +499,6 @@ bool Route::CrossMwmsPartlyProhibitedForSpeedCams() const
 vector<platform::CountryFile> const & Route::GetMwmsPartlyProhibitedForSpeedCams() const
 {
   return m_speedCamPartlyProhibitedMwms;
-}
-
-double Route::GetETAToLastPassedPointSec() const
-{
-  CHECK(IsValid(), ());
-  auto const & curIter = m_poly.GetCurrentIter();
-  CHECK_LESS(curIter.m_ind, m_routeSegments.size(), ());
-
-  return curIter.m_ind == 0 ? 0.0 : m_routeSegments[curIter.m_ind - 1].GetTimeFromBeginningSec();
 }
 
 bool IsNormalTurn(TurnItem const & turn)

--- a/routing/route.hpp
+++ b/routing/route.hpp
@@ -303,6 +303,12 @@ public:
   /// \returns estimated time to reach the route end.
   double GetCurrentTimeToEndSec() const;
 
+  /// \brief estimated time to reach segment.
+  double GetCurrentTimeToSegmentSec(size_t segIdx) const;
+
+  /// \brief estimated time to the nearest turn.
+  double GetCurrentTimeToNearestTurnSec() const;
+
   FollowedPolyline const & GetFollowedPolyline() const { return m_poly; }
 
   std::string const & GetRouterId() const { return m_router; }
@@ -322,7 +328,7 @@ public:
   /// \brief Extracts information about the nearest turn according to the route.
   /// \param distanceToTurnMeters is a distance from current position to the nearest turn.
   /// \param turn is information about the nearest turn.
-  void GetCurrentTurn(double & distanceToTurnMeters, turns::TurnItem & turn) const;
+  void GetNearestTurn(double & distanceToTurnMeters, turns::TurnItem & turn) const;
 
   /// \returns information about turn from RouteSegment according to current iterator
   /// set with MoveIterator() method. If it's not possible returns nullopt.
@@ -424,11 +430,8 @@ private:
   double GetPolySegAngle(size_t ind) const;
   void GetClosestTurnAfterIdx(size_t segIdx, turns::TurnItem & turn) const;
 
-  /// \returns Estimated time to pass the route segment with |segIdx|.
-  double GetTimeToPassSegSec(size_t segIdx) const;
-
-  /// \returns ETA to the last passed route point in seconds.
-  double GetETAToLastPassedPointSec() const;
+  /// \returns Estimated time from the beginning.
+  double GetCurrentTimeFromBeginSec() const;
 
   std::string m_router;
   RoutingSettings m_routingSettings;

--- a/routing/route.hpp
+++ b/routing/route.hpp
@@ -325,7 +325,7 @@ public:
   double GetCurrentDistanceToEndMeters() const;
   double GetMercatorDistanceFromBegin() const;
 
-  /// \brief Extracts information about the nearest turn according to the route.
+  /// \brief Extracts information about the nearest turn from the remaining part of the route.
   /// \param distanceToTurnMeters is a distance from current position to the nearest turn.
   /// \param turn is information about the nearest turn.
   void GetNearestTurn(double & distanceToTurnMeters, turns::TurnItem & turn) const;
@@ -343,7 +343,7 @@ public:
   /// \brief Returns current speed limit
   void GetCurrentSpeedLimit(SpeedInUnits & speedLimit) const;
 
-  /// \brief Return name info of a street according to next turn.
+  /// \brief Return name info of a street according to the next turn.
   void GetNextTurnStreetName(RouteSegment::RoadNameInfo & roadNameInfo) const;
 
   /// \brief Gets turn information after the turn next to the nearest one.
@@ -358,15 +358,15 @@ public:
 
   bool MoveIterator(location::GpsInfo const & info);
 
-  /// \brief Finds projection of |location| to the nearest route and sets |routeMatchingInfo|
+  /// \brief Finds projection of |location| to the nearest route and sets |routeMatchingInfo|.
   /// fields accordingly.
   bool MatchLocationToRoute(location::GpsInfo & location,
                             location::RouteMatchingInfo & routeMatchingInfo) const;
 
-  /// Add country name if we have no country filename to make route
+  /// Add country name if we have no country filename to make route.
   void AddAbsentCountry(std::string const & name);
 
-  /// Get absent file list of a routing files for shortest path finding
+  /// Get absent file list of a routing files for shortest path finding.
   std::set<std::string> const & GetAbsentCountries() const { return m_absentCountries; }
 
   inline void SetRoutingSettings(RoutingSettings const & routingSettings)

--- a/routing/routing_session.cpp
+++ b/routing/routing_session.cpp
@@ -435,7 +435,7 @@ void RoutingSession::GetRouteFollowingInfo(FollowingInfo & info) const
 
   info.m_completionPercent = GetCompletionPercent();
 
-  double timeToNearestTurnSec = m_route->GetCurrentTimeToNearestTurnSec();
+  double const timeToNearestTurnSec = m_route->GetCurrentTimeToNearestTurnSec();
 
   // Lane information and next street name.
   if (distanceToTurnMeters < kShowLanesMinDistInMeters || timeToNearestTurnSec < 60.0)

--- a/routing/routing_session.cpp
+++ b/routing/routing_session.cpp
@@ -23,8 +23,7 @@ namespace
 
 int constexpr kOnRouteMissedCount = 10;
 
-// @TODO(vbykoianko) The distance should depend on the current speed.
-double constexpr kShowLanesDistInMeters = 500.;
+double constexpr kShowLanesMinDistInMeters = 500.0;
 
 // @TODO The distance may depend on the current speed.
 double constexpr kShowPedestrianTurnInMeters = 20.0;
@@ -411,7 +410,7 @@ void RoutingSession::GetRouteFollowingInfo(FollowingInfo & info) const
 
   double distanceToTurnMeters = 0.;
   turns::TurnItem turn;
-  m_route->GetCurrentTurn(distanceToTurnMeters, turn);
+  m_route->GetNearestTurn(distanceToTurnMeters, turn);
   FormatDistance(distanceToTurnMeters, info.m_distToTurn, info.m_turnUnitsSuffix);
   info.m_turn = turn.m_turn;
 
@@ -436,8 +435,10 @@ void RoutingSession::GetRouteFollowingInfo(FollowingInfo & info) const
 
   info.m_completionPercent = GetCompletionPercent();
 
+  double timeToNearestTurnSec = m_route->GetCurrentTimeToNearestTurnSec();
+
   // Lane information and next street name.
-  if (distanceToTurnMeters < kShowLanesDistInMeters)
+  if (distanceToTurnMeters < kShowLanesMinDistInMeters || timeToNearestTurnSec < 60.0)
   {
     info.m_displayedStreetName = info.m_targetName;
     // There are two nested loops below. Outer one is for lanes and inner one (ctor of

--- a/routing/routing_tests/route_tests.cpp
+++ b/routing/routing_tests/route_tests.cpp
@@ -65,16 +65,16 @@ location::GpsInfo GetGps(double x, double y)
   return info;
 }
 
-vector<vector<Segment>> GetSegments()
+vector<vector<Segment>> const GetSegments()
 {
   auto const segmentsAllReal = kTestSegments;
-  vector<Segment> segmentsAllFake =
+  vector<Segment> const segmentsAllFake =
       {{kFakeNumMwmId, 0, 0, true},
        {kFakeNumMwmId, 0, 1, true},
        {kFakeNumMwmId, 0, 2, true},
        {kFakeNumMwmId, 0, 3, true},
        {kFakeNumMwmId, 0, 4, true}};
-  vector<Segment> segmentsFakeHeadAndTail =
+  vector<Segment> const segmentsFakeHeadAndTail =
       {{kFakeNumMwmId, 0, 0, true},
        {0, 0, 1, true},
        {0, 0, 2, true},
@@ -164,74 +164,70 @@ UNIT_TEST(DistanceAndTimeToCurrentTurnTest)
 
     route.GetNearestTurn(distance, turn);
     size_t currentTurnIndex = 2; // Turn with m_index == 1 is None.
-    TEST(base::AlmostEqualAbs(distance,
-                              mercator::DistanceOnEarth(pos, kTestGeometry[currentTurnIndex]), 0.1), ());
+    TEST_ALMOST_EQUAL_ABS(distance, mercator::DistanceOnEarth(pos, kTestGeometry[currentTurnIndex]), 0.1, ());
     TEST_EQUAL(turn, kTestTurns[currentTurnIndex - 1], ());
 
     double timePassed = 0;
 
     double time = route.GetCurrentTimeToEndSec();
-    TEST(base::AlmostEqualAbs(time, kTestTimes[4] - timePassed, 0.1), ());
+    TEST_ALMOST_EQUAL_ABS(time, kTestTimes[4] - timePassed, 0.1, ());
 
     time = route.GetCurrentTimeToNearestTurnSec();
-    TEST(base::AlmostEqualAbs(time, kTestTimes[currentTurnIndex - 1] - timePassed, 0.1), ());
+    TEST_ALMOST_EQUAL_ABS(time, kTestTimes[currentTurnIndex - 1] - timePassed, 0.1, ());
   }
   {
     // Move between points 1 and 2.
-    auto pos = (kTestGeometry[1] + kTestGeometry[2]) / 2;
+    auto const pos = (kTestGeometry[1] + kTestGeometry[2]) / 2;
     route.MoveIterator(GetGps(pos.x, pos.y));
 
     route.GetNearestTurn(distance, turn);
-    size_t currentTurnIndex = 2;
-    TEST(base::AlmostEqualAbs(distance,
-                              mercator::DistanceOnEarth(pos, kTestGeometry[currentTurnIndex]), 0.1), ());
+    size_t const currentTurnIndex = 2;
+    TEST_ALMOST_EQUAL_ABS(distance, mercator::DistanceOnEarth(pos, kTestGeometry[currentTurnIndex]), 0.1, ());
     TEST_EQUAL(turn, kTestTurns[currentTurnIndex - 1], ());
 
-    double timePassed = (kTestTimes[1 - 1] + kTestTimes[2 - 1]) / 2;
+    double const timePassed = (kTestTimes[1 - 1] + kTestTimes[2 - 1]) / 2;
 
     double time = route.GetCurrentTimeToEndSec();
-    TEST(base::AlmostEqualAbs(time, kTestTimes[4] - timePassed, 0.1), ());
+    TEST_ALMOST_EQUAL_ABS(time, kTestTimes[4] - timePassed, 0.1, ());
 
     time = route.GetCurrentTimeToNearestTurnSec();
-    TEST(base::AlmostEqualAbs(time, kTestTimes[currentTurnIndex - 1] - timePassed, 0.1), ());
+    TEST_ALMOST_EQUAL_ABS(time, kTestTimes[currentTurnIndex - 1] - timePassed, 0.1, ());
   }
   {
     // Move between points 2 and 3.
-    auto pos = kTestGeometry[2] * 0.8 + kTestGeometry[3] * 0.2;
+    auto const pos = kTestGeometry[2] * 0.8 + kTestGeometry[3] * 0.2;
     route.MoveIterator(GetGps(pos.x, pos.y));
 
     route.GetNearestTurn(distance, turn);
-    size_t currentTurnIndex = 3;
-    TEST(base::AlmostEqualAbs(distance,
-                              mercator::DistanceOnEarth(pos, kTestGeometry[currentTurnIndex]), 0.1), ());
+    size_t const currentTurnIndex = 3;
+    TEST_ALMOST_EQUAL_ABS(distance, mercator::DistanceOnEarth(pos, kTestGeometry[currentTurnIndex]), 0.1, ());
     TEST_EQUAL(turn, kTestTurns[currentTurnIndex - 1], ());
 
-    double timePassed = 0.8 * kTestTimes[2 - 1] + 0.2 * kTestTimes[3 - 1];
+    double const timePassed = 0.8 * kTestTimes[2 - 1] + 0.2 * kTestTimes[3 - 1];
 
     double time = route.GetCurrentTimeToEndSec();
-    TEST(base::AlmostEqualAbs(time, kTestTimes[4] - timePassed, 0.1), ());
+    TEST_ALMOST_EQUAL_ABS(time, kTestTimes[4] - timePassed, 0.1, ());
 
     time = route.GetCurrentTimeToNearestTurnSec();
-    TEST(base::AlmostEqualAbs(time, kTestTimes[currentTurnIndex - 1] - timePassed, 0.1), ());
+    TEST_ALMOST_EQUAL_ABS(time, kTestTimes[currentTurnIndex - 1] - timePassed, 0.1, ());
   }
   {
     // Move between points 3 and 4.
-    auto pos = kTestGeometry[3] * 0.3 + kTestGeometry[4] * 0.7;
+    auto const pos = kTestGeometry[3] * 0.3 + kTestGeometry[4] * 0.7;
     route.MoveIterator(GetGps(pos.x, pos.y));
 
     route.GetNearestTurn(distance, turn);
-    size_t currentTurnIndex = 5; // Turn with m_index == 4 is None.
-    TEST(base::AlmostEqualAbs(distance,
-                              mercator::DistanceOnEarth(pos, kTestGeometry[currentTurnIndex]), 0.1), ());
+    size_t const currentTurnIndex = 5; // Turn with m_index == 4 is None.
+    TEST_ALMOST_EQUAL_ABS(distance, mercator::DistanceOnEarth(pos, kTestGeometry[currentTurnIndex]), 0.1, ());
     TEST_EQUAL(turn, kTestTurns[currentTurnIndex - 1], ());
 
-    double timePassed = 0.3 * kTestTimes[3 - 1] + 0.7 * kTestTimes[4 - 1];
+    double const timePassed = 0.3 * kTestTimes[3 - 1] + 0.7 * kTestTimes[4 - 1];
 
     double time = route.GetCurrentTimeToEndSec();
-    TEST(base::AlmostEqualAbs(time, kTestTimes[4] - timePassed, 0.1), ());
+    TEST_ALMOST_EQUAL_ABS(time, kTestTimes[4] - timePassed, 0.1, ());
 
     time = route.GetCurrentTimeToNearestTurnSec();
-    TEST(base::AlmostEqualAbs(time, kTestTimes[currentTurnIndex - 1] - timePassed, 0.1), ());
+    TEST_ALMOST_EQUAL_ABS(time, kTestTimes[currentTurnIndex - 1] - timePassed, 0.1, ());
   }
 }
 
@@ -248,33 +244,33 @@ UNIT_TEST(NextTurnTest)
 
   {
     // Initial point.
-    size_t currentTurnIndex = 2; // Turn with m_index == 1 is None.
+    size_t const currentTurnIndex = 2; // Turn with m_index == 1 is None.
     route.GetNearestTurn(distance, turn);
     TEST_EQUAL(turn, kTestTurns[currentTurnIndex - 1], ());
 
-    size_t nextTurnIndex = 3;
+    size_t const nextTurnIndex = 3;
     route.GetNextTurn(nextDistance, nextTurn);
     TEST_EQUAL(nextTurn, kTestTurns[nextTurnIndex - 1], ());
   }
   {
     // Move between points 1 and 2.
-    auto pos = (kTestGeometry[1] + kTestGeometry[2]) / 2;
+    auto const pos = (kTestGeometry[1] + kTestGeometry[2]) / 2;
     route.MoveIterator(GetGps(pos.x, pos.y));
 
-    size_t currentTurnIndex = 2;
+    size_t const currentTurnIndex = 2;
     route.GetNearestTurn(distance, turn);
     TEST_EQUAL(turn, kTestTurns[currentTurnIndex - 1], ());
 
-    size_t nextTurnIndex = 3;
+    size_t const nextTurnIndex = 3;
     route.GetNextTurn(nextDistance, nextTurn);
     TEST_EQUAL(nextTurn, kTestTurns[nextTurnIndex - 1], ());
   }
   {
     // Move between points 3 and 4.
-    auto pos = (kTestGeometry[3] + kTestGeometry[4]) / 2;
+    auto const pos = (kTestGeometry[3] + kTestGeometry[4]) / 2;
     route.MoveIterator(GetGps(pos.x, pos.y));
 
-    size_t currentTurnIndex = 5; // Turn with m_index == 4 is None.
+    size_t const currentTurnIndex = 5; // Turn with m_index == 4 is None.
     route.GetNearestTurn(distance, turn);
     TEST_EQUAL(turn, kTestTurns[currentTurnIndex - 1], ());
 
@@ -297,63 +293,63 @@ UNIT_TEST(NextTurnsTest)
 
   {
     // Initial point.
-    auto pos = kTestGeometry[0];
+    auto const pos = kTestGeometry[0];
 
-    size_t currentTurnIndex = 2; // Turn with m_index == 1 is None.
-    size_t nextTurnIndex = 3;
+    size_t const currentTurnIndex = 2; // Turn with m_index == 1 is None.
+    size_t const nextTurnIndex = 3;
     TEST(route.GetNextTurns(turnsDist), ());
     TEST_EQUAL(turnsDist.size(), 2, ());
     double const firstSegLenM = mercator::DistanceOnEarth(pos, kTestGeometry[currentTurnIndex]);
     double const secondSegLenM = mercator::DistanceOnEarth(kTestGeometry[currentTurnIndex], kTestGeometry[nextTurnIndex]);
     TEST_EQUAL(turnsDist[0].m_turnItem, kTestTurns[currentTurnIndex - 1], ());
     TEST_EQUAL(turnsDist[1].m_turnItem, kTestTurns[nextTurnIndex - 1], ());
-    TEST(base::AlmostEqualAbs(turnsDist[0].m_distMeters, firstSegLenM, 0.1), ());
-    TEST(base::AlmostEqualAbs(turnsDist[1].m_distMeters, firstSegLenM + secondSegLenM, 0.1), ());
+    TEST_ALMOST_EQUAL_ABS(turnsDist[0].m_distMeters, firstSegLenM, 0.1, ());
+    TEST_ALMOST_EQUAL_ABS(turnsDist[1].m_distMeters, firstSegLenM + secondSegLenM, 0.1, ());
 
   }
   {
     // Move between points 1 and 2.
-    auto pos = (kTestGeometry[1] + kTestGeometry[2]) / 2;
+    auto const pos = (kTestGeometry[1] + kTestGeometry[2]) / 2;
     route.MoveIterator(GetGps(pos.x, pos.y));
 
-    size_t currentTurnIndex = 2;
-    size_t nextTurnIndex = 3;
+    size_t const currentTurnIndex = 2;
+    size_t const nextTurnIndex = 3;
     TEST(route.GetNextTurns(turnsDist), ());
     TEST_EQUAL(turnsDist.size(), 2, ());
     double const firstSegLenM = mercator::DistanceOnEarth(pos, kTestGeometry[currentTurnIndex]);
     double const secondSegLenM = mercator::DistanceOnEarth(kTestGeometry[currentTurnIndex], kTestGeometry[nextTurnIndex]);
     TEST_EQUAL(turnsDist[0].m_turnItem, kTestTurns[currentTurnIndex - 1], ());
     TEST_EQUAL(turnsDist[1].m_turnItem, kTestTurns[nextTurnIndex - 1], ());
-    TEST(base::AlmostEqualAbs(turnsDist[0].m_distMeters, firstSegLenM, 0.1), ());
-    TEST(base::AlmostEqualAbs(turnsDist[1].m_distMeters, firstSegLenM + secondSegLenM, 0.1), ());
+    TEST_ALMOST_EQUAL_ABS(turnsDist[0].m_distMeters, firstSegLenM, 0.1, ());
+    TEST_ALMOST_EQUAL_ABS(turnsDist[1].m_distMeters, firstSegLenM + secondSegLenM, 0.1, ());
   }
   {
     // Move between points 2 and 3.
-    auto pos = (kTestGeometry[2] + kTestGeometry[3]) / 2;
+    auto const pos = (kTestGeometry[2] + kTestGeometry[3]) / 2;
     route.MoveIterator(GetGps(pos.x, pos.y));
 
-    size_t currentTurnIndex = 3;
-    size_t nextTurnIndex = 5; // Turn with m_index == 4 is None.
+    size_t const currentTurnIndex = 3;
+    size_t const nextTurnIndex = 5; // Turn with m_index == 4 is None.
     TEST(route.GetNextTurns(turnsDist), ());
     TEST_EQUAL(turnsDist.size(), 2, ());
     double const firstSegLenM = mercator::DistanceOnEarth(pos, kTestGeometry[currentTurnIndex]);
     double const secondSegLenM = mercator::DistanceOnEarth(kTestGeometry[currentTurnIndex], kTestGeometry[nextTurnIndex]);
     TEST_EQUAL(turnsDist[0].m_turnItem, kTestTurns[currentTurnIndex - 1], ());
     TEST_EQUAL(turnsDist[1].m_turnItem, kTestTurns[nextTurnIndex - 1], ());
-    TEST(base::AlmostEqualAbs(turnsDist[0].m_distMeters, firstSegLenM, 0.1), ());
-    TEST(base::AlmostEqualAbs(turnsDist[1].m_distMeters, firstSegLenM + secondSegLenM, 0.1), ());
+    TEST_ALMOST_EQUAL_ABS(turnsDist[0].m_distMeters, firstSegLenM, 0.1, ());
+    TEST_ALMOST_EQUAL_ABS(turnsDist[1].m_distMeters, firstSegLenM + secondSegLenM, 0.1, ());
   }
   {
     // Move between points 3 and 4.
-    auto pos = (kTestGeometry[3] + kTestGeometry[4]) / 2;
+    auto const pos = (kTestGeometry[3] + kTestGeometry[4]) / 2;
     route.MoveIterator(GetGps(pos.x, pos.y));
 
-    size_t currentTurnIndex = 5; // Turn with m_index == 4 is None.
+    size_t const currentTurnIndex = 5; // Turn with m_index == 4 is None.
     // nextTurn is absent.
     TEST(route.GetNextTurns(turnsDist), ());
     double const firstSegLenM = mercator::DistanceOnEarth(pos, kTestGeometry[currentTurnIndex]);
     TEST_EQUAL(turnsDist[0].m_turnItem, kTestTurns[currentTurnIndex - 1], ());
-    TEST(base::AlmostEqualAbs(turnsDist[0].m_distMeters, firstSegLenM, 0.1), ());
+    TEST_ALMOST_EQUAL_ABS(turnsDist[0].m_distMeters, firstSegLenM, 0.1, ());
   }
 }
 
@@ -453,10 +449,8 @@ UNIT_TEST(RouteNameTest)
   route.GetClosestStreetNameAfterIdx(4, roadNameInfo);
   TEST_EQUAL(roadNameInfo.m_name, "Street3", (roadNameInfo.m_name));
 
-  location::GpsInfo info;
-  info.m_longitude = 1.0;
-  info.m_latitude = 2.0;
-  route.MoveIterator(info);
+  location::GpsInfo const pos(GetGps(1.0, 2.0));
+  route.MoveIterator(pos);
   route.GetCurrentStreetName(roadNameInfo);
   TEST_EQUAL(roadNameInfo.m_name, "Street2", (roadNameInfo.m_name));
 }


### PR DESCRIPTION
Text info about next turn street/road will be displayed
at least during 60 seconds before turn.

Fix for #2640