### PR TITLE
Allow use of system-provided pugixml

### DIFF
--- a/3party/pugixml/CMakeLists.txt
+++ b/3party/pugixml/CMakeLists.txt
@@ -8,3 +8,5 @@ set(SRC
 )
 
 add_library(${PROJECT_NAME} ${SRC})
+
+target_include_directories(${PROJECT_NAME} PUBLIC pugixml/src)

--- a/3party/pugixml/utils.hpp
+++ b/3party/pugixml/utils.hpp
@@ -1,6 +1,6 @@
 #pragma once
 
-#include "pugixml/src/pugixml.hpp"
+#include <pugixml.hpp>
 
 #include <sstream>
 #include <string>

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -314,6 +314,9 @@ if (NOT WITH_SYSTEM_PROVIDED_3PARTY)
   set(JANSSON_WITHOUT_TESTS ON)
   add_subdirectory(3party/jansson/jansson/)
   target_include_directories(jansson INTERFACE "${PROJECT_BINARY_DIR}/3party/jansson/jansson/include")
+
+  # Configure pugixml library
+  add_subdirectory(3party/pugixml)
 endif()
 
 add_subdirectory(3party/agg)
@@ -338,7 +341,6 @@ endif()
 add_subdirectory(3party/liboauthcpp)
 add_subdirectory(3party/minizip)
 add_subdirectory(3party/opening_hours)
-add_subdirectory(3party/pugixml)
 add_subdirectory(3party/sdf_image)
 add_subdirectory(3party/stb_image)
 add_subdirectory(3party/succinct)

--- a/editor/config_loader.cpp
+++ b/editor/config_loader.cpp
@@ -11,7 +11,7 @@
 #include <iterator>
 #include <stdexcept>
 
-#include "3party/pugixml/pugixml/src/pugixml.hpp"
+#include <pugixml.hpp>
 
 namespace editor
 {

--- a/editor/editor_config.hpp
+++ b/editor/editor_config.hpp
@@ -5,7 +5,7 @@
 #include <string>
 #include <vector>
 
-#include "3party/pugixml/pugixml/src/pugixml.hpp"
+#include <pugixml.hpp>
 
 class Reader;
 

--- a/editor/editor_notes.cpp
+++ b/editor/editor_notes.cpp
@@ -14,7 +14,7 @@
 #include <chrono>
 #include <future>
 
-#include "3party/pugixml/pugixml/src/pugixml.hpp"
+#include <pugixml.hpp>
 
 namespace
 {

--- a/editor/editor_storage.hpp
+++ b/editor/editor_storage.hpp
@@ -2,7 +2,7 @@
 
 #include <mutex>
 
-#include "3party/pugixml/pugixml/src/pugixml.hpp"
+#include <pugixml.hpp>
 
 namespace editor
 {

--- a/editor/editor_tests/config_loader_test.cpp
+++ b/editor/editor_tests/config_loader_test.cpp
@@ -7,7 +7,7 @@
 
 #include "base/atomic_shared_ptr.hpp"
 
-#include "3party/pugixml/pugixml/src/pugixml.hpp"
+#include <pugixml.hpp>
 
 namespace
 {

--- a/editor/editor_tests/feature_matcher_test.cpp
+++ b/editor/editor_tests/feature_matcher_test.cpp
@@ -6,7 +6,7 @@
 #include <string>
 #include <vector>
 
-#include "3party/pugixml/pugixml/src/pugixml.hpp"
+#include <pugixml.hpp>
 
 namespace
 {

--- a/editor/editor_tests/match_by_geometry_test.cpp
+++ b/editor/editor_tests/match_by_geometry_test.cpp
@@ -6,7 +6,7 @@
 #include <string>
 #include <vector>
 
-#include "3party/pugixml/pugixml/src/pugixml.hpp"
+#include <pugixml.hpp>
 
 namespace
 {

--- a/editor/editor_tests/xml_feature_test.cpp
+++ b/editor/editor_tests/xml_feature_test.cpp
@@ -14,7 +14,7 @@
 #include <string>
 #include <vector>
 
-#include "3party/pugixml/pugixml/src/pugixml.hpp"
+#include <pugixml.hpp>
 
 using namespace editor;
 

--- a/editor/osm_auth_tests/server_api_test.cpp
+++ b/editor/osm_auth_tests/server_api_test.cpp
@@ -11,7 +11,7 @@
 #include <string>
 #include <random>
 
-#include "3party/pugixml/pugixml/src/pugixml.hpp"
+#include <pugixml.hpp>
 
 using osm::ServerApi06;
 using osm::OsmOAuth;

--- a/editor/osm_editor.cpp
+++ b/editor/osm_editor.cpp
@@ -27,7 +27,7 @@
 #include <sstream>
 
 #include "3party/opening_hours/opening_hours.hpp"
-#include "3party/pugixml/pugixml/src/pugixml.hpp"
+#include <pugixml.hpp>
 
 namespace osm
 {

--- a/editor/server_api.cpp
+++ b/editor/server_api.cpp
@@ -12,7 +12,7 @@
 #include <algorithm>
 #include <sstream>
 
-#include "3party/pugixml/pugixml/src/pugixml.hpp"
+#include <pugixml.hpp>
 
 namespace
 {

--- a/editor/xml_feature.hpp
+++ b/editor/xml_feature.hpp
@@ -12,7 +12,7 @@
 #include <iostream>
 #include <vector>
 
-#include "3party/pugixml/pugixml/src/pugixml.hpp"
+#include <pugixml.hpp>
 
 namespace osm
 {

--- a/openlr/decoded_path.hpp
+++ b/openlr/decoded_path.hpp
@@ -10,7 +10,7 @@
 #include <string>
 #include <vector>
 
-#include "3party/pugixml/pugixml/src/pugixml.hpp"
+#include <pugixml.hpp>
 
 class DataSource;
 

--- a/openlr/openlr_match_quality/openlr_assessment_tool/segment_correspondence.hpp
+++ b/openlr/openlr_match_quality/openlr_assessment_tool/segment_correspondence.hpp
@@ -3,7 +3,7 @@
 #include "openlr/decoded_path.hpp"
 #include "openlr/openlr_model.hpp"
 
-#include "3party/pugixml/pugixml/src/pugixml.hpp"
+#include <pugixml.hpp>
 
 namespace openlr
 {

--- a/openlr/openlr_match_quality/openlr_assessment_tool/traffic_mode.hpp
+++ b/openlr/openlr_match_quality/openlr_assessment_tool/traffic_mode.hpp
@@ -10,7 +10,7 @@
 
 #include "base/exception.hpp"
 
-#include "3party/pugixml/pugixml/src/pugixml.hpp"
+#include <pugixml.hpp>
 
 #include <memory>
 #include <string>

--- a/openlr/openlr_model_xml.cpp
+++ b/openlr/openlr_model_xml.cpp
@@ -9,7 +9,7 @@
 #include <optional>
 #include <type_traits>
 
-#include "3party/pugixml/pugixml/src/pugixml.hpp"
+#include <pugixml.hpp>
 
 using namespace std;
 

--- a/openlr/openlr_stat/openlr_stat.cpp
+++ b/openlr/openlr_stat/openlr_stat.cpp
@@ -29,7 +29,7 @@
 #include <vector>
 
 #include "gflags/gflags.h"
-#include "3party/pugixml/pugixml/src/pugixml.hpp"
+#include <pugixml.hpp>
 
 DEFINE_string(input, "", "Path to OpenLR file.");
 DEFINE_string(spark_output, "", "Path to output file in spark-oriented format");

--- a/openlr/openlr_tests/decoded_path_test.cpp
+++ b/openlr/openlr_tests/decoded_path_test.cpp
@@ -22,7 +22,7 @@
 #include <sstream>
 #include <vector>
 
-#include "3party/pugixml/pugixml/src/pugixml.hpp"
+#include <pugixml.hpp>
 #include "3party/pugixml/utils.hpp"
 
 using namespace generator::tests_support;


### PR DESCRIPTION
Linux distributions don't like vendoring of libraries by applications and prefer to ship their own version.
This makes the build look for a system-provided pugixml first and if not found, fallback to the vendored one like before.