### PR TITLE
Version script should use UTC dates instead of local ones

### DIFF
--- a/tools/unix/version.sh
+++ b/tools/unix/version.sh
@@ -7,7 +7,8 @@ set -euo pipefail
 # This approach counts a number of commits each day based on committer's commit date
 # instead of author's commit date, to avoid conflicts when old PRs are merged, but the
 # number of today's commits stays the same.
-COUNT_AND_DATE=( $(git log --date=short --pretty=format:%cd --date=format:'%Y.%m.%d' --since="30 days ago" | sort | uniq -c | tail -1) )
+# Force git with TZ variable and local dates to print the UTC date.
+COUNT_AND_DATE=( $(TZ=UTC0 git log --pretty=format:%cd --date=iso-local --since="30 days ago" | cut -d' ' -f 1 | sed 's/-/./g' | sort | uniq -c | tail -1) )
 if [ -z "$COUNT_AND_DATE" ]; then
   # Fallback: use today's date if there were no commits since last month.
   COUNT_AND_DATE=( 0 $(date +%Y.%m.%d) )


### PR DESCRIPTION
Git was using local dates instead of UTC ones, and that lead to wrong and inconsistent version numbers.