### PR TITLE
[android] show only one back arrow in bookmark search

### DIFF
--- a/android/src/com/mapswithme/maps/bookmarks/BookmarksToolbarController.java
+++ b/android/src/com/mapswithme/maps/bookmarks/BookmarksToolbarController.java
@@ -43,4 +43,10 @@ public class BookmarksToolbarController extends SearchToolbarController
     else
       mFragment.cancelSearch();
   }
+
+  @Override
+  protected boolean showBackButton()
+  {
+    return false;
+  }
 }


### PR DESCRIPTION
By using the same fix as in https://github.com/organicmaps/organicmaps/pull/1671, this PR removes the second back button in the header for the bookmark search.

| Portrait | Landscape |
|-|-|
| ![Screenshot_1656718849](https://user-images.githubusercontent.com/80701113/176978055-298b5628-9d95-4748-bf4b-60c5d5d4d4e4.png) | ![Screenshot_1656718853](https://user-images.githubusercontent.com/80701113/176978060-769e593e-3aa9-495f-a233-84e716b492c7.png) |

Closes #2173