### PR TITLE
[android] make bottom sheet menu title 3 lines max

### DIFF
--- a/android/res/layout/bottom_sheet.xml
+++ b/android/res/layout/bottom_sheet.xml
@@ -20,6 +20,8 @@
     android:layout_marginTop="@dimen/margin_base"
     android:layout_marginBottom="@dimen/margin_base"
     android:layout_marginStart="@dimen/margin_base"
+    android:maxLines="3"
+    android:ellipsize="end"
     android:textAppearance="?fontHeadline6"
     tools:text="Title" />
 


### PR DESCRIPTION
This will work on any bottom sheet menu, not only the bookmark list.

| Portrait | Landscape |
|-|-|
|![Screenshot_1656754738](https://user-images.githubusercontent.com/80701113/176995269-cde9a449-3972-48a4-8c2a-4ed6df93fd2d.png) | ![Screenshot_1656754745](https://user-images.githubusercontent.com/80701113/176995273-1580b9a4-5083-49ac-b8f5-fda03ad6b033.png) |


Closes #2635