### PR TITLE
[framework] Fill transit mark place page with feature info

### DIFF
--- a/map/framework.cpp
+++ b/map/framework.cpp
@@ -755,6 +755,12 @@ void Framework::FillRouteMarkInfo(RouteMarkPoint const & rmp, place_page::Info &
   info.SetIntermediateIndex(rmp.GetIntermediateIndex());
 }
 
+void Framework::FillTransitMarkInfo(TransitMark const & transitMark, place_page::Info & info) const
+{
+  FillFeatureInfo(transitMark.GetFeatureID(), info);
+  /// @todo Add useful info in PP for TransitMark (public transport).
+}
+
 void Framework::FillRoadTypeMarkInfo(RoadWarningMark const & roadTypeMark, place_page::Info & info) const
 {
   if (roadTypeMark.GetFeatureID().IsValid())
@@ -2176,7 +2182,7 @@ std::optional<place_page::Info> Framework::BuildPlacePageInfo(
       }
       case UserMark::Type::TRANSIT:
       {
-        /// @todo Add useful info in PP for TransitMark (public transport).
+        FillTransitMarkInfo(*static_cast<TransitMark const *>(mark), outInfo);
         break;
       }
       default:

--- a/map/framework.hpp
+++ b/map/framework.hpp
@@ -606,6 +606,7 @@ private:
   void FillSearchResultInfo(SearchMarkPoint const & smp, place_page::Info & info) const;
   void FillMyPositionInfo(place_page::Info & info, place_page::BuildInfo const & buildInfo) const;
   void FillRouteMarkInfo(RouteMarkPoint const & rmp, place_page::Info & info) const;
+  void FillTransitMarkInfo(TransitMark const & transitMark, place_page::Info & info) const;
   void FillRoadTypeMarkInfo(RoadWarningMark const & roadTypeMark, place_page::Info & info) const;
   void FillPointInfoForBookmark(Bookmark const & bmk, place_page::Info & info) const;
   void FillBookmarkInfo(Bookmark const & bmk, place_page::Info & info) const;


### PR DESCRIPTION
When in transit navigation mode, instead of showing an empty place page on selecting a subway station, the subway POI place page is now shown.

More information such as transit lines could be shown while in this mode so I left the todo.

![Screenshot_1656776303](https://user-images.githubusercontent.com/80701113/177007131-cc058c9f-6c17-457d-a6ad-6be9fe2ac591.png)


Closes #2214