### PR TITLE
[navigation] populate incoming speed camera place page

### DIFF
--- a/android/jni/com/mapswithme/maps/Framework.cpp
+++ b/android/jni/com/mapswithme/maps/Framework.cpp
@@ -947,7 +947,9 @@ Java_com_mapswithme_maps_Framework_nativeFormatAltitude(JNIEnv * env, jclass, jd
 JNIEXPORT jstring JNICALL
 Java_com_mapswithme_maps_Framework_nativeFormatSpeed(JNIEnv * env, jclass, jdouble speed)
 {
-  return jni::ToJavaString(env, measurement_utils::FormatSpeed(speed));
+  auto const units = measurement_utils::GetMeasurementUnits();
+  return jni::ToJavaString(env, measurement_utils::FormatSpeedNumeric(speed, units) + " " +
+                                platform::GetLocalizedSpeedUnits(units));
 }
 
 /*

--- a/android/jni/com/mapswithme/util/StringUtils.cpp
+++ b/android/jni/com/mapswithme/util/StringUtils.cpp
@@ -54,10 +54,9 @@ Java_com_mapswithme_util_StringUtils_nativeFilterContainsNormalized(JNIEnv * env
 JNIEXPORT jobject JNICALL Java_com_mapswithme_util_StringUtils_nativeFormatSpeedAndUnits(
     JNIEnv * env, jclass thiz, jdouble metersPerSecond)
 {
-  auto units = measurement_utils::Units::Metric;
-  settings::Get(settings::kMeasurementUnits, units);
+  auto const units = measurement_utils::GetMeasurementUnits();
   return MakeJavaPair(env, measurement_utils::FormatSpeedNumeric(metersPerSecond, units),
-                      measurement_utils::FormatSpeedUnits(units));
+                      platform::GetLocalizedSpeedUnits(units));
 }
 
 JNIEXPORT jstring JNICALL

--- a/drape_frontend/gui/ruler_helper.cpp
+++ b/drape_frontend/gui/ruler_helper.cpp
@@ -224,14 +224,12 @@ double RulerHelper::CalcMetersDiff(double value)
 
   auto conversionFn = &Identity;
 
-  auto units = measurement_utils::Units::Metric;
-  settings::TryGet(settings::kMeasurementUnits, units);
-
-  if (units == measurement_utils::Units::Imperial)
+  using namespace measurement_utils;
+  if (GetMeasurementUnits() == Units::Imperial)
   {
     arrU = g_arrFeets;
     count = ARRAY_SIZE(g_arrFeets);
-    conversionFn = &measurement_utils::MetersToFeet;
+    conversionFn = &MetersToFeet;
   }
 
   int prevUnitRange = m_rangeIndex;

--- a/map/framework.cpp
+++ b/map/framework.cpp
@@ -732,6 +732,19 @@ void Framework::FillRouteMarkInfo(RouteMarkPoint const & rmp, place_page::Info &
   info.SetIntermediateIndex(rmp.GetIntermediateIndex());
 }
 
+void Framework::FillSpeedCameraMarkInfo(SpeedCameraMark const & speedCameraMark, place_page::Info & info) const
+{
+  info.SetCanEditOrAdd(false);
+  info.SetMercator(speedCameraMark.GetPivot());
+
+  // Title is a speed limit, if any.
+  auto title = speedCameraMark.GetTitle();
+  if (!title.empty())
+    title = title + " " + platform::GetLocalizedSpeedUnits(measurement_utils::GetMeasurementUnits());
+
+  info.SetCustomNames(title, platform::GetLocalizedTypeName("highway-speed_camera"));
+}
+
 void Framework::FillTransitMarkInfo(TransitMark const & transitMark, place_page::Info & info) const
 {
   FillFeatureInfo(transitMark.GetFeatureID(), info);
@@ -2145,6 +2158,11 @@ std::optional<place_page::Info> Framework::BuildPlacePageInfo(
       case UserMark::Type::TRANSIT:
       {
         FillTransitMarkInfo(*static_cast<TransitMark const *>(mark), outInfo);
+        break;
+      }
+      case UserMark::Type::SPEED_CAM:
+      {
+        FillSpeedCameraMarkInfo(*static_cast<SpeedCameraMark const *>(mark), outInfo);
         break;
       }
       default:

--- a/map/framework.cpp
+++ b/map/framework.cpp
@@ -1699,10 +1699,7 @@ void Framework::SetupMeasurementSystem()
 {
   GetPlatform().SetupMeasurementSystem();
 
-  auto units = measurement_utils::Units::Metric;
-  settings::TryGet(settings::kMeasurementUnits, units);
-
-  m_routingManager.SetTurnNotificationsUnits(units);
+  m_routingManager.SetTurnNotificationsUnits(measurement_utils::GetMeasurementUnits());
 }
 
 void Framework::SetWidgetLayout(gui::TWidgetsLayoutInfo && layout)

--- a/map/framework.hpp
+++ b/map/framework.hpp
@@ -588,6 +588,7 @@ private:
   void FillSearchResultInfo(SearchMarkPoint const & smp, place_page::Info & info) const;
   void FillMyPositionInfo(place_page::Info & info, place_page::BuildInfo const & buildInfo) const;
   void FillRouteMarkInfo(RouteMarkPoint const & rmp, place_page::Info & info) const;
+  void FillSpeedCameraMarkInfo(SpeedCameraMark const & speedCameraMark, place_page::Info & info) const;
   void FillTransitMarkInfo(TransitMark const & transitMark, place_page::Info & info) const;
   void FillRoadTypeMarkInfo(RoadWarningMark const & roadTypeMark, place_page::Info & info) const;
   void FillPointInfoForBookmark(Bookmark const & bmk, place_page::Info & info) const;

--- a/map/routing_manager.cpp
+++ b/map/routing_manager.cpp
@@ -362,10 +362,7 @@ RoutingManager::RoutingManager(Callbacks && callbacks, Delegate & delegate)
         return;
 
       double speed = cameraSpeedKmPH;
-      measurement_utils::Units units = measurement_utils::Units::Metric;
-      settings::TryGet(settings::kMeasurementUnits, units);
-
-      if (units == measurement_utils::Units::Imperial)
+      if (measurement_utils::GetMeasurementUnits() == measurement_utils::Units::Imperial)
         speed = measurement_utils::KmphToMiph(cameraSpeedKmPH);
 
       mark->SetTitle(strings::to_string(static_cast<int>(speed + 0.5)));

--- a/map/routing_mark.cpp
+++ b/map/routing_mark.cpp
@@ -573,6 +573,11 @@ void SpeedCameraMark::SetTitle(std::string const & title)
   m_titleDecl.m_primaryText = title;
 }
 
+std::string const & SpeedCameraMark::GetTitle() const
+{
+  return m_titleDecl.m_primaryText;
+}
+
 void SpeedCameraMark::SetIndex(uint32_t index)
 {
   SetDirty();

--- a/map/routing_mark.hpp
+++ b/map/routing_mark.hpp
@@ -169,7 +169,9 @@ class SpeedCameraMark : public UserMark
 {
 public:
   explicit SpeedCameraMark(m2::PointD const & ptOrg);
+
   void SetTitle(std::string const & title);
+  std::string const & GetTitle() const;
 
   void SetIndex(uint32_t index);
   uint32_t GetIndex() const override { return m_index; }
@@ -192,7 +194,6 @@ private:
   uint32_t m_index = 0;
   SymbolNameZoomInfo m_symbolNames;
   ColoredSymbolZoomInfo m_textBg;
-  std::string m_title;
   dp::TitleDecl m_titleDecl;
 };
 

--- a/platform/localization.cpp
+++ b/platform/localization.cpp
@@ -20,7 +20,7 @@ const LocalizedUnits & GetLocalizedUnits(measurement_utils::Units units, Measure
 {
   static LocalizedUnits UnitsLenghImperial = {GetLocalizedString("foot"), GetLocalizedString("mile")};
   static LocalizedUnits UnitsLenghMetric = {GetLocalizedString("meter"), GetLocalizedString("kilometer")};
-  
+
   static LocalizedUnits UnitsSpeedImperial = {GetLocalizedString("foot"), GetLocalizedString("miles_per_hour")};
   static LocalizedUnits UnitsSpeedMetric = {GetLocalizedString("meter"), GetLocalizedString("kilometers_per_hour")};
 
@@ -47,18 +47,12 @@ const LocalizedUnits & GetLocalizedUnits(measurement_utils::Units units, Measure
 
 LocalizedUnits GetLocalizedDistanceUnits()
 {
-  auto units = measurement_utils::Units::Metric;
-  settings::TryGet(settings::kMeasurementUnits, units);
-
-  return GetLocalizedUnits(units, MeasurementType::Distance);
+  return GetLocalizedUnits(measurement_utils::GetMeasurementUnits(), MeasurementType::Distance);
 }
 
 LocalizedUnits GetLocalizedAltitudeUnits()
 {
-  auto units = measurement_utils::Units::Metric;
-  settings::TryGet(settings::kMeasurementUnits, units);
-
-  return GetLocalizedUnits(units, MeasurementType::Altitude);
+  return GetLocalizedUnits(measurement_utils::GetMeasurementUnits(), MeasurementType::Altitude);
 }
 
 const std::string & GetLocalizedSpeedUnits(measurement_utils::Units units)
@@ -68,9 +62,6 @@ const std::string & GetLocalizedSpeedUnits(measurement_utils::Units units)
 
 std::string GetLocalizedSpeedUnits()
 {
-  auto units = measurement_utils::Units::Metric;
-  settings::TryGet(settings::kMeasurementUnits, units);
-
-  return GetLocalizedSpeedUnits(units);
+  return GetLocalizedSpeedUnits(measurement_utils::GetMeasurementUnits());
 }
 }  // namespace platform

--- a/platform/measurement_utils.cpp
+++ b/platform/measurement_utils.cpp
@@ -15,12 +15,12 @@
 #include <iomanip>
 #include <sstream>
 
+namespace measurement_utils
+{
 using namespace settings;
 using namespace std;
 using namespace strings;
 
-namespace measurement_utils
-{
 namespace
 {
 string ToStringPrecision(double d, int pr)
@@ -73,6 +73,13 @@ std::string DebugPrint(Units units)
   UNREACHABLE();
 }
 
+Units GetMeasurementUnits()
+{
+  Units units = measurement_utils::Units::Metric;
+  settings::TryGet(settings::kMeasurementUnits, units);
+  return units;
+}
+
 double ToSpeedKmPH(double speed, Units units)
 {
   switch (units)
@@ -85,9 +92,7 @@ double ToSpeedKmPH(double speed, Units units)
 
 std::string FormatDistanceWithLocalization(double m, OptionalStringRef high, OptionalStringRef low)
 {
-  auto units = Units::Metric;
-  TryGet(kMeasurementUnits, units);
-
+  Units const units = GetMeasurementUnits();
   switch (units)
   {
   case Units::Imperial: return FormatDistanceImpl(units, m, low ? *low : "ft", high ? *high : "mi");
@@ -203,9 +208,7 @@ string FormatAltitude(double altitudeInMeters)
 
 string FormatAltitudeWithLocalization(double altitudeInMeters, OptionalStringRef localizedUnits)
 {
-  Units units = Units::Metric;
-  TryGet(kMeasurementUnits, units);
-
+  Units const units = GetMeasurementUnits();
   switch (units)
   {
   case Units::Imperial:
@@ -214,14 +217,6 @@ string FormatAltitudeWithLocalization(double altitudeInMeters, OptionalStringRef
     return FormatAltitudeImpl(units, altitudeInMeters, localizedUnits ? *localizedUnits : "m");
   }
   UNREACHABLE();
-}
-
-string FormatSpeed(double metersPerSecond)
-{
-  auto units = Units::Metric;
-  TryGet(kMeasurementUnits, units);
-
-  return FormatSpeedNumeric(metersPerSecond, units) + " " + FormatSpeedUnits(units);
 }
 
 double MpsToUnits(double metersPerSecond, Units units)
@@ -238,16 +233,6 @@ string FormatSpeedNumeric(double metersPerSecond, Units units)
 {
   double const unitsPerHour = MpsToUnits(metersPerSecond, units);
   return ToStringPrecision(unitsPerHour, unitsPerHour >= 10.0 ? 0 : 1);
-}
-
-string FormatSpeedUnits(Units units)
-{
-  switch (units)
-  {
-  case Units::Imperial: return "mph";
-  case Units::Metric: return "km/h";
-  }
-  UNREACHABLE();
 }
 
 string FormatOsmLink(double lat, double lon, int zoom)

--- a/platform/measurement_utils.hpp
+++ b/platform/measurement_utils.hpp
@@ -2,8 +2,6 @@
 
 #include "geometry/point2d.hpp"
 
-#include "base/assert.hpp"
-
 #include <optional>
 #include <string>
 
@@ -18,6 +16,8 @@ enum class Units
 };
 
 std::string DebugPrint(Units units);
+
+Units GetMeasurementUnits();
 
 inline double MetersToMiles(double m) { return m * 0.000621371192; }
 inline double MilesToMeters(double mi) { return mi * 1609.344; }
@@ -41,13 +41,11 @@ double MpsToUnits(double mps, Units units);
 std::string FormatDistance(double distanceInMeters);
 std::string FormatDistanceWithLocalization(double m, OptionalStringRef high, OptionalStringRef low);
 
-/// We always use meters and feet/yards for altitude
+/// @return Localized meters or feets string for altitude, depending on current measurement units.
 std::string FormatAltitude(double altitudeInMeters);
 std::string FormatAltitudeWithLocalization(double altitudeInMeters, OptionalStringRef localizedUnits);
-// Return value is measured in km/h for Metric and in mph for Imperial.
-std::string FormatSpeed(double metersPerSecond);
+/// @return Speed value string (without suffix) in km/h for Metric and in mph for Imperial.
 std::string FormatSpeedNumeric(double metersPerSecond, Units units);
-std::string FormatSpeedUnits(Units units);
 
 /// @param[in] dac  Digits after comma in seconds.
 /// Use dac == 3 for our common conversions to DMS.

--- a/platform/platform_tests/measurement_tests.cpp
+++ b/platform/platform_tests/measurement_tests.cpp
@@ -161,21 +161,6 @@ UNIT_TEST(FormatAltitude)
   TEST_EQUAL(FormatAltitude(5), "5 m", ());
 }
 
-UNIT_TEST(FormatSpeed)
-{
-  {
-    ScopedSettings guard(Units::Metric);
-    TEST_EQUAL(FormatSpeed(10), "36 km/h", ());
-    TEST_EQUAL(FormatSpeed(1), "3.6 km/h", ());
-  }
-
-  {
-    ScopedSettings guard(Units::Imperial);
-    TEST_EQUAL(FormatSpeed(10), "22 mph", ());
-    TEST_EQUAL(FormatSpeed(1), "2.2 mph", ());
-  }
-}
-
 UNIT_TEST(FormatSpeedNumeric)
 {
   TEST_EQUAL(FormatSpeedNumeric(10, Units::Metric), "36", ());
@@ -183,12 +168,6 @@ UNIT_TEST(FormatSpeedNumeric)
 
   TEST_EQUAL(FormatSpeedNumeric(10, Units::Imperial), "22", ());
   TEST_EQUAL(FormatSpeedNumeric(1, Units::Imperial), "2.2", ());
-}
-
-UNIT_TEST(FormatSpeedUnits)
-{
-  TEST_EQUAL(FormatSpeedUnits(Units::Metric), "km/h", ());
-  TEST_EQUAL(FormatSpeedUnits(Units::Imperial), "mph", ());
 }
 
 UNIT_TEST(OSMDistanceToMetersString)

--- a/platform/settings.hpp
+++ b/platform/settings.hpp
@@ -8,7 +8,7 @@
 
 namespace settings
 {
-/// Metric or Feet.
+/// Metric or Imperial.
 extern char const * kMeasurementUnits;
 
 template <class T>

--- a/qt/draw_widget.cpp
+++ b/qt/draw_widget.cpp
@@ -495,8 +495,11 @@ void DrawWidget::SubmitFakeLocationPoint(m2::PointD const & pt)
     }
     else
     {
-      LOG(LDEBUG, ("Distance:", loc.m_distToTarget + loc.m_targetUnitsSuffix, "Time:", loc.m_time,
-                   loc.m_speedLimitMps < 0 ? "" : "SpeedLimit: " + measurement_utils::FormatSpeed(loc.m_speedLimitMps),
+      std::string speed;
+      if (loc.m_speedLimitMps > 0)
+        speed = "SpeedLimit: " + measurement_utils::FormatSpeedNumeric(loc.m_speedLimitMps, measurement_utils::Units::Metric);
+
+      LOG(LDEBUG, ("Distance:", loc.m_distToTarget + loc.m_targetUnitsSuffix, "Time:", loc.m_time, speed,
                    GetTurnString(loc.m_turn), (loc.m_exitNum != 0 ? ":" + std::to_string(loc.m_exitNum) : ""),
                    "in", loc.m_distToTurn + loc.m_turnUnitsSuffix,
                    loc.m_targetName.empty() ? "" : "to " + loc.m_targetName ));


### PR DESCRIPTION
Adds information in the place page for incoming speed cameras (the ones shown in red).

For the moment, the place page shows the camera position and the title is the max speed if any.

I need help for this one as I have trouble retrieving the speed camera information. The `SpeedCameraMark` object does not contain a lot of information, and I was not able to retrieve the POI/Feature associated.

Here is what it looks like for the moment:
![Screenshot_1656782339](https://user-images.githubusercontent.com/80701113/177010218-dcd915ef-9328-43cc-837f-593ad05faf89.png)

But here is how regular speed cameras look like:
![Screenshot_1656782706](https://user-images.githubusercontent.com/80701113/177010344-8d5d6546-d034-4607-b04c-01082c1bfdc2.png)

I would like to retrieve the information from the regular speed camera and integrate it in the `SpeedCameraMark` but I am lost on how to proceed. Could please help me understand where to look?

Closes #1657