### PR TITLE
Cuisine editor filter fix

### DIFF
--- a/android/jni/com/mapswithme/util/StringUtils.cpp
+++ b/android/jni/com/mapswithme/util/StringUtils.cpp
@@ -39,12 +39,13 @@ Java_com_mapswithme_util_StringUtils_nativeFilterContainsNormalized(JNIEnv * env
 {
   std::string substr = jni::ToNativeString(env, jSubstr);
   int const length = env->GetArrayLength(src);
+  auto const & cuisines = osm::Cuisines::Instance();
   std::vector<std::string> filtered;
   filtered.reserve(length);
   for (int i = 0; i < length; i++)
   {
     std::string str = jni::ToNativeString(env, (jstring) env->GetObjectArrayElement(src, i));
-    if (search::ContainsNormalized(str, substr) || search::ContainsNormalized(osm::Cuisines::Instance().Translate(str), substr))
+    if (search::ContainsNormalized(str, substr) || search::ContainsNormalized(cuisines.Translate(str), substr))
       filtered.push_back(str);
   }
 

--- a/android/jni/com/mapswithme/util/StringUtils.cpp
+++ b/android/jni/com/mapswithme/util/StringUtils.cpp
@@ -44,7 +44,7 @@ Java_com_mapswithme_util_StringUtils_nativeFilterContainsNormalized(JNIEnv * env
   for (int i = 0; i < length; i++)
   {
     std::string str = jni::ToNativeString(env, (jstring) env->GetObjectArrayElement(src, i));
-    if (search::ContainsNormalized(str, substr))
+    if (search::ContainsNormalized(str, substr) || search::ContainsNormalized(osm::Cuisines::Instance().Translate(str), substr))
       filtered.push_back(str);
   }
 


### PR DESCRIPTION
Added filtering not only by english but in translated label too.

Closes #285 and #2841.

| Rus | Ukr | Hebr |
| --- | --- | ---- |
| ![cuisine-filter](https://user-images.githubusercontent.com/720808/177290290-80139adc-f3f2-4261-bd7a-fcf819e970be.png) | ![cuisine-filter-ukr](https://user-images.githubusercontent.com/720808/177290706-3355c733-643d-4eee-87ee-1e436abc6429.png) | ![cuisine-filter-hebr](https://user-images.githubusercontent.com/720808/177290754-8ddfd689-c0c6-4f70-a806-a4d65e85bc28.png) |
