### PR TITLE
Give priority to tag sport over leisure=pitch

### DIFF
--- a/indexer/feature_data.cpp
+++ b/indexer/feature_data.cpp
@@ -134,6 +134,7 @@ private:
         {"amenity", "shelter"},
         {"amenity", "toilets"},
         {"amenity", "drinking_water"},
+        {"leisure", "pitch"}, // Give priority to tag "sport"=*.
         {"public_transport", "platform"},
         {"building", "address"},
         {"building", "has_parts"},


### PR DESCRIPTION
Easy (but not perfect) fix for of #2511.