### PR TITLE
[tools] Fix map file stats and add outer geometry stats

### DIFF
--- a/feature_list/feature_list.cpp
+++ b/feature_list/feature_list.cpp
@@ -201,7 +201,7 @@ public:
 
   void Process(FeatureType & f, map<uint32_t, base::GeoObjectId> const & ft2osm)
   {
-    f.ParseBeforeStatistic();
+    f.ParseHeader2();
     string const & category = GetReadableType(f);
     auto const & meta = f.GetMetadata();
 

--- a/generator/feature_segments_checker/feature_segments_checker.cpp
+++ b/generator/feature_segments_checker/feature_segments_checker.cpp
@@ -167,7 +167,7 @@ public:
 
   void operator()(FeatureType & f, uint32_t const & id)
   {
-    f.ParseBeforeStatistic();
+    f.ParseHeader2();
     if (!GetBicycleModel().IsRoad(f))
     {
       ++m_notRoadCount;

--- a/generator/generator_tool/generator_tool.cpp
+++ b/generator/generator_tool/generator_tool.cpp
@@ -180,9 +180,11 @@ DEFINE_string(uk_postcodes_dataset, "", "Path to dataset with UK postcodes.");
 DEFINE_string(us_postcodes_dataset, "", "Path to dataset with US postcodes.");
 
 // Printing stuff.
-DEFINE_bool(calc_stats, false, "Print file and feature stats.");
-DEFINE_bool(calc_geom_stats, false, "Print outer geometry stats.");
-DEFINE_bool(calc_type_stats, false, "Print feature stats by type.");
+DEFINE_bool(stats_general, false, "Print file and feature stats.");
+DEFINE_bool(stats_geometry, false, "Print outer geometry stats.");
+DEFINE_double(stats_geometry_dup_factor, 1.5, "Consider feature's geometry scale "
+              "duplicating a more detailed one if it has <dup_factor less elements.");
+DEFINE_bool(stats_types, false, "Print feature stats by type.");
 DEFINE_bool(dump_types, false, "Prints all types combinations and their total count.");
 DEFINE_bool(dump_prefixes, false, "Prints statistics on feature's' name prefixes.");
 DEFINE_bool(dump_search_tokens, false, "Print statistics on search tokens.");
@@ -599,28 +601,28 @@ MAIN_WITH_ERROR_HANDLING([](int argc, char ** argv)
 
   string const dataFile = base::JoinPath(path, FLAGS_output + DATA_FILE_EXTENSION);
 
-  if (FLAGS_calc_stats || FLAGS_calc_geom_stats || FLAGS_calc_type_stats)
+  if (FLAGS_stats_general || FLAGS_stats_geometry || FLAGS_stats_types)
   {
     LOG(LINFO, ("Calculating statistics for", dataFile));
     auto file = OfstreamWithExceptions(genInfo.GetIntermediateFileName(FLAGS_output, STATS_EXTENSION));
-    stats::MapInfo info;
-    stats::CalcStatistics(dataFile, info);
+    stats::MapInfo info(FLAGS_stats_geometry_dup_factor);
+    stats::CalcStats(dataFile, info);
     
-    if (FLAGS_calc_stats)
+    if (FLAGS_stats_general)
     {
       LOG(LINFO, ("Writing general statistics"));
-      stats::FileContainerStatistics(file, dataFile);
-      stats::PrintStatistics(file, info);
+      stats::PrintFileContainerStats(file, dataFile);
+      stats::PrintStats(file, info);
     }
-    if (FLAGS_calc_geom_stats)
+    if (FLAGS_stats_geometry)
     {
       LOG(LINFO, ("Writing geometry statistics"));
-      stats::PrintOuterGeometryStatistics(file, info);
+      stats::PrintOuterGeometryStats(file, info);
     }
-    if (FLAGS_calc_type_stats)
+    if (FLAGS_stats_types)
     {
       LOG(LINFO, ("Writing types statistics"));
-      stats::PrintTypeStatistics(file, info);
+      stats::PrintTypeStats(file, info);
     }
     LOG(LINFO, ("Stats written to file", FLAGS_output + STATS_EXTENSION));
   }

--- a/generator/generator_tool/generator_tool.cpp
+++ b/generator/generator_tool/generator_tool.cpp
@@ -598,26 +598,23 @@ MAIN_WITH_ERROR_HANDLING([](int argc, char ** argv)
 
   string const dataFile = base::JoinPath(path, FLAGS_output + DATA_FILE_EXTENSION);
 
-  if (FLAGS_calc_statistics)
+  if (FLAGS_calc_statistics || FLAGS_type_statistics)
   {
-    LOG(LINFO, ("Calculating statistics for", dataFile));
-
     auto file = OfstreamWithExceptions(genInfo.GetIntermediateFileName(FLAGS_output, STATS_EXTENSION));
-    stats::FileContainerStatistic(file, dataFile);
-
     stats::MapInfo info;
-    stats::CalcStatistic(dataFile, info);
-    stats::PrintStatistic(file, info);
-  }
-
-  if (FLAGS_type_statistics)
-  {
-    LOG(LINFO, ("Calculating type statistics for", dataFile));
-
-    stats::MapInfo info;
-    stats::CalcStatistic(dataFile, info);
-    auto file = OfstreamWithExceptions(genInfo.GetIntermediateFileName(FLAGS_output, STATS_EXTENSION));
-    stats::PrintTypeStatistic(file, info);
+    stats::CalcStatistics(dataFile, info);
+    
+    if (FLAGS_calc_statistics)
+    {
+      LOG(LINFO, ("Calculating statistics for", dataFile));
+      stats::FileContainerStatistics(file, dataFile);
+      stats::PrintStatistics(file, info);
+    }
+    else
+    {
+      LOG(LINFO, ("Calculating type statistics for", dataFile));
+      stats::PrintTypeStatistics(file, info);
+    }
   }
 
   if (FLAGS_dump_types)

--- a/generator/generator_tool/generator_tool.cpp
+++ b/generator/generator_tool/generator_tool.cpp
@@ -180,8 +180,9 @@ DEFINE_string(uk_postcodes_dataset, "", "Path to dataset with UK postcodes.");
 DEFINE_string(us_postcodes_dataset, "", "Path to dataset with US postcodes.");
 
 // Printing stuff.
-DEFINE_bool(calc_statistics, false, "Calculate feature statistics for specified mwm bucket files.");
-DEFINE_bool(type_statistics, false, "Calculate statistics by type for specified mwm bucket files.");
+DEFINE_bool(calc_stats, false, "Print file and feature stats.");
+DEFINE_bool(calc_geom_stats, false, "Print outer geometry stats.");
+DEFINE_bool(calc_type_stats, false, "Print feature stats by type.");
 DEFINE_bool(dump_types, false, "Prints all types combinations and their total count.");
 DEFINE_bool(dump_prefixes, false, "Prints statistics on feature's' name prefixes.");
 DEFINE_bool(dump_search_tokens, false, "Print statistics on search tokens.");
@@ -598,23 +599,30 @@ MAIN_WITH_ERROR_HANDLING([](int argc, char ** argv)
 
   string const dataFile = base::JoinPath(path, FLAGS_output + DATA_FILE_EXTENSION);
 
-  if (FLAGS_calc_statistics || FLAGS_type_statistics)
+  if (FLAGS_calc_stats || FLAGS_calc_geom_stats || FLAGS_calc_type_stats)
   {
+    LOG(LINFO, ("Calculating statistics for", dataFile));
     auto file = OfstreamWithExceptions(genInfo.GetIntermediateFileName(FLAGS_output, STATS_EXTENSION));
     stats::MapInfo info;
     stats::CalcStatistics(dataFile, info);
     
-    if (FLAGS_calc_statistics)
+    if (FLAGS_calc_stats)
     {
-      LOG(LINFO, ("Calculating statistics for", dataFile));
+      LOG(LINFO, ("Writing general statistics"));
       stats::FileContainerStatistics(file, dataFile);
       stats::PrintStatistics(file, info);
     }
-    else
+    if (FLAGS_calc_geom_stats)
     {
-      LOG(LINFO, ("Calculating type statistics for", dataFile));
+      LOG(LINFO, ("Writing geometry statistics"));
+      stats::PrintOuterGeometryStatistics(file, info);
+    }
+    if (FLAGS_calc_type_stats)
+    {
+      LOG(LINFO, ("Writing types statistics"));
       stats::PrintTypeStatistics(file, info);
     }
+    LOG(LINFO, ("Stats written to file", FLAGS_output + STATS_EXTENSION));
   }
 
   if (FLAGS_dump_types)

--- a/generator/statistics.hpp
+++ b/generator/statistics.hpp
@@ -33,6 +33,25 @@ namespace stats
     double m_area;
   };
 
+  struct GeomInfo
+  {
+    GeomInfo() : m_count(0), m_size(0), m_elements(0) {}
+
+    void Add(uint64_t szBytes, uint32_t elements)
+    {
+      if (szBytes > 0)
+      {
+        ++m_count;
+        m_size += szBytes;
+        m_elements += elements;
+      }
+    }
+
+    uint64_t m_count, m_size, m_elements;
+  };
+
+  using GeomStats = GeomInfo[feature::DataHeader::kMaxScalesCount];
+
   template <class T, int Tag>
   struct IntegralType
   {
@@ -52,6 +71,10 @@ namespace stats
     std::map<CountType, GeneralInfo> m_byPointsCount, m_byTrgCount;
     std::map<AreaType, GeneralInfo> m_byAreaSize;
 
+    GeomStats m_byLineGeom, m_byAreaGeom,
+              m_byLineGeomCompared, m_byAreaGeomCompared,
+              m_byLineGeomDup, m_byAreaGeomDup;
+
     GeneralInfo m_inner[3];
   };
 
@@ -60,4 +83,5 @@ namespace stats
   void CalcStatistics(std::string const & fPath, MapInfo & info);
   void PrintStatistics(std::ostream & os, MapInfo & info);
   void PrintTypeStatistics(std::ostream & os, MapInfo & info);
+  void PrintOuterGeometryStatistics(std::ostream & os, MapInfo & info);
 }

--- a/generator/statistics.hpp
+++ b/generator/statistics.hpp
@@ -35,8 +35,6 @@ namespace stats
 
   struct GeomInfo
   {
-    GeomInfo() : m_count(0), m_size(0), m_elements(0) {}
-
     void Add(uint64_t szBytes, uint32_t elements)
     {
       if (szBytes > 0)
@@ -47,7 +45,7 @@ namespace stats
       }
     }
 
-    uint64_t m_count, m_size, m_elements;
+    uint64_t m_count = 0, m_size = 0, m_elements = 0;
   };
 
   using GeomStats = GeomInfo[feature::DataHeader::kMaxScalesCount];
@@ -66,6 +64,10 @@ namespace stats
 
   struct MapInfo
   {
+    explicit MapInfo(double geometryDupFactor) : m_geometryDupFactor(geometryDupFactor) {}
+
+    double m_geometryDupFactor;
+
     std::map<feature::GeomType, GeneralInfo> m_byGeomType;
     std::map<ClassifType, GeneralInfo> m_byClassifType;
     std::map<CountType, GeneralInfo> m_byPointsCount, m_byTrgCount;
@@ -78,10 +80,10 @@ namespace stats
     GeneralInfo m_inner[3];
   };
 
-  void FileContainerStatistics(std::ostream & os, std::string const & fPath);
+  void PrintFileContainerStats(std::ostream & os, std::string const & fPath);
 
-  void CalcStatistics(std::string const & fPath, MapInfo & info);
-  void PrintStatistics(std::ostream & os, MapInfo & info);
-  void PrintTypeStatistics(std::ostream & os, MapInfo & info);
-  void PrintOuterGeometryStatistics(std::ostream & os, MapInfo & info);
+  void CalcStats(std::string const & fPath, MapInfo & info);
+  void PrintStats(std::ostream & os, MapInfo & info);
+  void PrintTypeStats(std::ostream & os, MapInfo & info);
+  void PrintOuterGeometryStats(std::ostream & os, MapInfo & info);
 }

--- a/generator/statistics.hpp
+++ b/generator/statistics.hpp
@@ -55,9 +55,9 @@ namespace stats
     GeneralInfo m_inner[3];
   };
 
-  void FileContainerStatistic(std::ostream & os, std::string const & fPath);
+  void FileContainerStatistics(std::ostream & os, std::string const & fPath);
 
-  void CalcStatistic(std::string const & fPath, MapInfo & info);
-  void PrintStatistic(std::ostream & os, MapInfo & info);
-  void PrintTypeStatistic(std::ostream & os, MapInfo & info);
+  void CalcStatistics(std::string const & fPath, MapInfo & info);
+  void PrintStatistics(std::ostream & os, MapInfo & info);
+  void PrintTypeStatistics(std::ostream & os, MapInfo & info);
 }

--- a/indexer/data_header.hpp
+++ b/indexer/data_header.hpp
@@ -30,8 +30,8 @@ namespace feature
       Country
     };
 
-    /// Max possible scales. @see arrays in feature_impl.hpp
-    static const size_t kMaxScalesCount = 4;
+    /// Max possible geometry scales. @see arrays in feature_impl.hpp
+    static constexpr size_t kMaxScalesCount = 4;
 
     DataHeader() = default;
     explicit DataHeader(std::string const & fileName);

--- a/indexer/feature.cpp
+++ b/indexer/feature.cpp
@@ -421,9 +421,8 @@ void FeatureType::ResetGeometry()
   m_ptsSimpMask = 0;
 }
 
-uint32_t FeatureType::ParseGeometry(int scale)
+void FeatureType::ParseGeometry(int scale)
 {
-  uint32_t sz = 0;
   if (!m_parsed.m_points)
   {
     CHECK(m_loadInfo, ());
@@ -447,8 +446,6 @@ uint32_t FeatureType::ParseGeometry(int scale)
           serial::GeometryCodingParams cp = m_loadInfo->GetGeometryCodingParams(ind);
           cp.SetBasePoint(m_points[0]);
           serial::LoadOuterPath(src, cp, m_points);
-
-          sz = static_cast<uint32_t>(src.Pos() - m_offsets.m_pts[ind]);
         }
       }
       else
@@ -477,8 +474,6 @@ uint32_t FeatureType::ParseGeometry(int scale)
     }
     m_parsed.m_points = true;
   }
-  // TODO: return value is needed for stats calculation in generator_tool only
-  return sz;
 }
 
 FeatureType::GeomStat FeatureType::GetOuterGeometrySize()
@@ -524,9 +519,8 @@ FeatureType::GeomStat FeatureType::GetOuterGeometrySize()
   return GeomStat(sz, m_points.size());
 }
 
-uint32_t FeatureType::ParseTriangles(int scale)
+void FeatureType::ParseTriangles(int scale)
 {
-  uint32_t sz = 0;
   if (!m_parsed.m_triangles)
   {
     CHECK(m_loadInfo, ());
@@ -543,8 +537,6 @@ uint32_t FeatureType::ParseTriangles(int scale)
           ReaderSource<FilesContainerR::TReader> src(m_loadInfo->GetTrianglesReader(ind));
           src.Skip(m_offsets.m_trg[ind]);
           serial::LoadOuterTriangles(src, m_loadInfo->GetGeometryCodingParams(ind), m_triangles);
-
-          sz = static_cast<uint32_t>(src.Pos() - m_offsets.m_trg[ind]);
         }
       }
 
@@ -552,8 +544,6 @@ uint32_t FeatureType::ParseTriangles(int scale)
     }
     m_parsed.m_triangles = true;
   }
-  // TODO: return value is needed for stats calculation in generator_tool only
-  return sz;
 }
 
 FeatureType::GeomStat FeatureType::GetOuterTrianglesSize()

--- a/indexer/feature.hpp
+++ b/indexer/feature.hpp
@@ -170,17 +170,15 @@ public:
 
   InnerGeomStat GetInnerStats() const { return m_innerStats; }
 
+  using GeomArr = uint32_t[feature::DataHeader::kMaxScalesCount];
   struct GeomStat
   {
-    uint32_t m_size = 0, m_count = 0;
-
-    GeomStat(uint32_t sz, size_t count) : m_size(sz), m_count(static_cast<uint32_t>(count)) {}
+    GeomArr m_sizes = {}, m_elements = {};
   };
 
-  // Returns total outer geometry/triangles size for all geo levels and
-  // number of points/triangles in the best one. Loads the best geometry.
-  GeomStat GetOuterGeometrySize();
-  GeomStat GetOuterTrianglesSize();
+  // Returns outer points/triangles stats for all geo levels and loads the best geometry.
+  GeomStat GetOuterGeometryStats();
+  GeomStat GetOuterTrianglesStats();
   //@}
 
 private:

--- a/indexer/feature.hpp
+++ b/indexer/feature.hpp
@@ -166,14 +166,9 @@ public:
   struct InnerGeomStat
   {
     uint32_t m_points = 0, m_strips = 0, m_size = 0;
-
-    void MakeZero()
-    {
-      m_points = m_strips = m_size = 0;
-    }
   };
 
-  InnerGeomStat GetInnerStatistic() const { return m_innerStats; }
+  InnerGeomStat GetInnerStats() const { return m_innerStats; }
 
   struct GeomStat
   {
@@ -182,8 +177,10 @@ public:
     GeomStat(uint32_t sz, size_t count) : m_size(sz), m_count(static_cast<uint32_t>(count)) {}
   };
 
-  GeomStat GetGeometrySize(int scale);
-  GeomStat GetTrianglesSize(int scale);
+  // Returns total outer geometry/triangles size for all geo levels and
+  // number of points/triangles in the best one. Loads the best geometry.
+  GeomStat GetOuterGeometrySize();
+  GeomStat GetOuterTrianglesSize();
   //@}
 
 private:

--- a/indexer/feature.hpp
+++ b/indexer/feature.hpp
@@ -75,6 +75,7 @@ public:
   void SetID(FeatureID id) { m_id = std::move(id); }
   FeatureID const & GetID() const { return m_id; }
 
+  void ParseHeader2();
   void ResetGeometry();
   void ParseGeometry(int scale);
   void ParseTriangles(int scale);
@@ -159,10 +160,8 @@ public:
   std::string_view GetMetadata(feature::Metadata::EType type);
   bool HasMetadata(feature::Metadata::EType type);
 
-  /// @name Statistic functions.
+  /// @name Stats functions.
   //@{
-  void ParseBeforeStatistic() { ParseHeader2(); }
-
   struct InnerGeomStat
   {
     uint32_t m_points = 0, m_strips = 0, m_size = 0;
@@ -216,7 +215,6 @@ private:
 
   void ParseTypes();
   void ParseCommon();
-  void ParseHeader2();
   void ParseMetadata();
   void ParseMetaIds();
   void ParseGeometryAndTriangles(int scale);

--- a/indexer/feature.hpp
+++ b/indexer/feature.hpp
@@ -76,8 +76,8 @@ public:
   FeatureID const & GetID() const { return m_id; }
 
   void ResetGeometry();
-  uint32_t ParseGeometry(int scale);
-  uint32_t ParseTriangles(int scale);
+  void ParseGeometry(int scale);
+  void ParseTriangles(int scale);
   //@}
 
   /// @name Geometry.


### PR DESCRIPTION
1. Fixed some wrong stats, e.g. inner geometry sizes were double-calculated and only the best outer geometry was taken into account. Improved labelling and output formatting.
2. Added detailed outer geometry stats.

Sample run cmd:
```
../omim-build-release/generator_tool --stats_general=true --stats_geometry=true --stats_geometry_dup_factor=2.0 --stats_types=true --output="Russia_Mari El"
```

Sample stats:
```
File section sizes
              addr :     101929
         altitudes :     341744
           centers :    1150880
        city_roads :      20416
         cross_mwm :     641444
      descriptions :    1429959
          features :    7129219
             geom0 :      14355
             geom1 :      78810
             geom2 :    1068665
             geom3 :    5885068
            header :         32
               idx :    1077635
     isolines_info :          7
         maxspeeds :       4257
              meta :     215981
         metalines :       9796
              offs :     306440
             ranks :      62456
      restrictions :       2914
           rgninfo :          4
        roadaccess :       3300
           routing :     183510
               sdx :     570511
         speedcams :         47
 transit_cross_mwm :         29
              trg0 :     203673
              trg1 :     859230
              trg2 :    2075253
              trg3 :    4299267
           version :         10

               Feature headers: size =   6813593; features =  315361
            incl. inner points: size =   1661890; features =   75621
incl. inner triangles (strips): size =   2507856; features =  169044

Top SIZE by Geometry Type
 0.  Area: size =  10865588; features =  193563; w/names =     2296
 1.  Line: size =  10137284; features =  103928; w/names =    54853
 3. Point: size =    295042; features =   17870; w/names =     5217

Top SIZE by Classificator Type
(a single feature's size may be included in several types)
 0.                isoline-step_10: size =   4649323; features =   33970; w/names =    33970
 1.                 landuse-forest: size =   4461004; features =   14977; w/names =      121
 3.                       building: size =   2984414; features =  158290; w/names =     1160
 4.               isoline-step_100: size =   1980735; features =   12448; w/names =    12448
 5.                  highway-track: size =    803415; features =   11179; w/names =       57
 6.               landuse-farmland: size =    623214; features =    1464; w/names =        1
 7.            natural-water-river: size =    475228; features =     133; w/names =       12
 8.            highway-residential: size =    459388; features =    7581; w/names =     4786
 9.                natural-wetland: size =    443629; features =    2522; w/names =       44
 10.                  natural-water: size =    431182; features =    3470; w/names =      143

Top SIZE by Points Count
 0.   500: size =   2914034; features =    1983
 1.     7: size =    338663; features =   14444
 2.     9: size =    190114; features =    6756
 4.    10: size =    132103; features =    4244
 5.    11: size =    130486; features =    3864
 6.     5: size =    122763; features =    6963
 7.    15: size =    113772; features =    2154
 8.     2: size =    108608; features =   11812
 9.    12: size =    106238; features =    2904
 10.    13: size =    102135; features =    2617

Top SIZE by Triangles Count
 0.     2: size =   1563876; features =  126426
 1.     4: size =    456436; features =   25399
 2.     6: size =    251911; features =    9389
 3.     8: size =    120370; features =    3453
 4.    10: size =    111020; features =    2433
 5.    16: size =     89001; features =     855
 6. 19675: size =     88770; features =       1
 7.  9893: size =     85142; features =       1
 8.    15: size =     84904; features =     840
 9.    12: size =     83249; features =    1461

Top SIZE by Area
 0.    10: size =  19264017; features =  315123; w/names =    62338
 1.   100: size =    488214; features =      40; w/names =        9
 2.   500: size =    430128; features =      17; w/names =        3
 3.    50: size =    428084; features =      65; w/names =        6
 4.   200: size =    363125; features =      25; w/names =        4
 5.    20: size =    292968; features =      90; w/names =        6
 6.  5000: size =     31378; features =       1; w/names =        0

Feature stats by Classificator Type
(a single feature can contain several types and thus its size can be included in several type lines)
                       amenity: size =      2698; features =      46; length =          0 m; area =      22360 m²; w/names =       39
                      building: size =   2984414; features =  158290; length =          0 m; area =   35293862 m²; w/names =     1160
                 building:part: size =     18365; features =     722; length =          0 m; area =     241150 m²; w/names =       17
                      entrance: size =      6207; features =     623; length =          0 m; area =          0 m²; w/names =      177
               internet_access: size =        38; features =       1; length =          0 m; area =          0 m²; w/names =        1
                        office: size =       716; features =      22; length =          0 m; area =       1599 m²; w/names =       21
                          shop: size =      4973; features =     206; length =          0 m; area =       4372 m²; w/names =      185
             aeroway-aerodrome: size =      1377; features =       3; length =          0 m; area =    5421347 m²; w/names =        2
           amenity-arts_centre: size =       645; features =       8; length =          0 m; area =       6422 m²; w/names =        7
                 barrier-block: size =       226; features =      21; length =          0 m; area =          0 m²; w/names =        1
              building-address: size =      3713; features =     354; length =          0 m; area =          0 m²; w/names =        0
               craft-beekeeper: size =       227; features =      20; length =          0 m; area =       3409 m²; w/names =        0
         healthcare-laboratory: size =       158; features =       3; length =          0 m; area =          0 m²; w/names =        3
             highway-bridleway: size =       490; features =       6; length =      22916 m; area =          0 m²; w/names =        0
  historic-archaeological_site: size =        90; features =       2; length =          0 m; area =          0 m²; w/names =        2
          internet_access-wlan: size =      1876; features =      40; length =          0 m; area =       3223 m²; w/names =       27
               isoline-step_10: size =   4649323; features =   33970; length =   39097426 m; area =          0 m²; w/names =    33970

...
```

Sample outer geometry stats:
```
Outer LINE geometry
   geom0: size =     14355: elements =      4751; features =     650; elems/feats =   7.3; bytes/elems =  3.0
geom1w/0: size =     48764: elements =     16096; feats w/geom0 =     650; elems/feats =  24.8; size factor =  3.4x; elems factor =  3.4x
   geom1: size =     78810: elements =     26988; features =    3262; elems/feats =   8.3; bytes/elems =  2.9
geom2w/1: size =    174512: elements =     59613; feats w/geom1 =    3262; elems/feats =  18.3; size factor =  2.2x; elems factor =  2.2x
   geom2: size =   1068665: elements =    374913; features =   15426; elems/feats =  24.3; bytes/elems =  2.9
geom3w/2: size =   2249686: elements =    843519; feats w/geom2 =   15426; elems/feats =  54.7; size factor =  2.1x; elems factor =  2.2x
   geom3: size =   5885068: elements =   2209425; features =   28307; elems/feats =  78.1; bytes/elems =  2.7
Geometry almost duplicating (<1.5x less elements) a more detailed one
geom0~=1: size =      2065: elements =       689; features =     135; elems/feats =   5.1; dups size % = 14%
geom1~=2: size =     11554: elements =      4008; features =     777; elems/feats =   5.2; dups size % = 14%
geom2~=3: size =    214457: elements =     73798; features =    2534; elems/feats =  29.1; dups size % = 20%

Outer AREA geometry
   trg0: size =    203673: elements =     40681; features =    3355; elems/feats =  12.1; bytes/elems =  5.0
trg1w/0: size =    604080: elements =    155702; feats w/trg0 =    3355; elems/feats =  46.4; size factor =  3.0x; elems factor =  3.8x
   trg1: size =    859230: elements =    204763; features =   10289; elems/feats =  19.9; bytes/elems =  4.2
trg2w/1: size =   1861674: elements =    504368; feats w/trg1 =   10289; elems/feats =  49.0; size factor =  2.2x; elems factor =  2.5x
   trg2: size =   2075253: elements =    545051; features =   18169; elems/feats =  30.0; bytes/elems =  3.8
trg3w/2: size =   4096561: elements =   1174955; feats w/trg2 =   18169; elems/feats =  64.7; size factor =  2.0x; elems factor =  2.2x
   trg3: size =   4299267: elements =   1227069; features =   24519; elems/feats =  50.0; bytes/elems =  3.5
Geometry almost duplicating (<1.5x less elements) a more detailed one
trg0~=1: size =      1304: elements =       200; features =      44; elems/feats =   4.5; dups size % =  0%
trg1~=2: size =    137969: elements =     35611; features =     753; elems/feats =  47.3; dups size % = 16%
trg2~=3: size =   1066718: elements =    281620; features =    5185; elems/feats =  54.3; dups size % = 51%
```

E.g. `geom3w/2` contains `geom3` stats for features that have `geom2` also, hence we can compare actual effect of geometry simplification (in terms of data size and points/triangles counts).

Almost duplicating geometry stats give an idea how often geometry simplification doesn't result in much size/complexity difference. E.g. its useful for #2927 analysis. I think a 1.5x threshold is quite conservative (as seen in this sample an avg complexity simplification factor is >= 2.2x).