### PR TITLE
[string] Fix text for [load_kmz_failed]

### DIFF
--- a/data/strings/strings.txt
+++ b/data/strings/strings.txt
@@ -3109,13 +3109,13 @@
   [load_kmz_failed]
     comment = Kml file loading failed
     tags = android,ios
-    en = Bookmarks upload failed. The file may be corrupted or defective.
+    en = Failed to load bookmarks. The file may be corrupted or defective.
     ar = فشلت عملية تحميل الإشارات المرجعية. قد يكون الملف تالف.
     be = Не атрамалася запампаваць закладкі. Файл можа быць пашкоджаны альбо дэфектыўны.
     bg = Качването на отметките се провали. Файлът може да бъде повреден или дефектен.
     cs = Nahrávání záložek se nezdařilo. Soubor může být poškozený nebo vadný.
     da = Bogmærkerne kunne ikke indlæses. Fil kan være skadet eller defekte.
-    de = Hochladen der Lesezeichen fehlgeschlagen. Die Datei könnte beschädigt oder defekt sein.
+    de = Laden der Lesezeichen fehlgeschlagen. Die Datei könnte beschädigt oder defekt sein.
     el = Η μεταφόρτωση των αγαπημένων απέτυχε. Το αρχείο μπορεί να είναι κατεστραμμένο ή ελαττωματικό.
     es = La carga de favoritos ha fallado. El archivo puede estar corrupto o ser defectuoso.
     eu = Ezin izan da gogokoak kargatu. Fitxategia hondatuta edo akastuna izan daiteke.


### PR DESCRIPTION
This is the opposite to [load_kmz_successful] and is used at loading bookmarks from the file system into the app:
https://github.com/organicmaps/organicmaps/blob/2b1e4d54f9ae334cec73a851e56375a978ebe251/android/src/com/mapswithme/maps/MwmActivity.java#L1849-L1853
 So it's about _loading_, not *up*loading.

Fixed the English text and the German translation. Russian and Ukrainian translations are correct, but some of the other translations probably need to be fixed.
