### PR TITLE
[drape][gl_functions]: Handle ES2 scenario on Linux 

### DIFF
--- a/drape/gl_extensions_list.cpp
+++ b/drape/gl_extensions_list.cpp
@@ -37,6 +37,20 @@ void GLExtensionsList::Init(dp::ApiVersion apiVersion)
     SetExtension(VertexArrayObject, true);
     SetExtension(UintIndices, true);
   }
+#elif defined(OMIM_OS_LINUX)
+  SetExtension(MapBuffer, true);
+  SetExtension(UintIndices, true);
+  if (apiVersion == dp::ApiVersion::OpenGLES2)
+  {
+    SetExtension(VertexArrayObject, true);
+    SetExtension(MapBuffer, true);
+    SetExtension(MapBufferRange, true);
+  }
+  else // OpenGLES3 branch
+  {
+    SetExtension(VertexArrayObject, true);
+    SetExtension(MapBufferRange, true);
+  }
 #elif defined(OMIM_OS_WINDOWS)
   SetExtension(MapBuffer, true);
   SetExtension(UintIndices, true);

--- a/drape/gl_extensions_list.cpp
+++ b/drape/gl_extensions_list.cpp
@@ -46,7 +46,7 @@ void GLExtensionsList::Init(dp::ApiVersion apiVersion)
     SetExtension(MapBuffer, true);
     SetExtension(MapBufferRange, true);
   }
-  else // OpenGLES3 branch
+  else // OpenGLES3 or any desktop OpenGL >=3
   {
     SetExtension(VertexArrayObject, true);
     SetExtension(MapBufferRange, true);

--- a/drape/gl_extensions_list.cpp
+++ b/drape/gl_extensions_list.cpp
@@ -40,17 +40,8 @@ void GLExtensionsList::Init(dp::ApiVersion apiVersion)
 #elif defined(OMIM_OS_LINUX)
   SetExtension(MapBuffer, true);
   SetExtension(UintIndices, true);
-  if (apiVersion == dp::ApiVersion::OpenGLES2)
-  {
-    SetExtension(VertexArrayObject, true);
-    SetExtension(MapBuffer, true);
-    SetExtension(MapBufferRange, true);
-  }
-  else // OpenGLES3 or any desktop OpenGL >=3
-  {
-    SetExtension(VertexArrayObject, true);
-    SetExtension(MapBufferRange, true);
-  }
+  SetExtension(VertexArrayObject, true);
+  SetExtension(MapBufferRange, true);
 #elif defined(OMIM_OS_WINDOWS)
   SetExtension(MapBuffer, true);
   SetExtension(UintIndices, true);

--- a/drape/gl_functions.cpp
+++ b/drape/gl_functions.cpp
@@ -255,7 +255,7 @@ void GLFunctions::Init(dp::ApiVersion apiVersion)
     glUnmapBufferFn = &::glUnmapBuffer;
 
 #elif defined(OMIM_OS_LINUX)
-    void *libhandle = dlopen("libGL.so.1", RTLD_NOW);
+    void *libhandle = dlopen("libGL.so.1", RTLD_LAZY);
     if (!libhandle)
       LOG(LCRITICAL, ("Failed to open libGL.so.1:", dlerror()));
     glGenVertexArraysFn = (TglGenVertexArraysFn)dlsym(libhandle,"glGenVertexArraysOES");
@@ -302,7 +302,7 @@ void GLFunctions::Init(dp::ApiVersion apiVersion)
   }
   else
   {
-    ASSERT(false, ("Unknown Graphics API"));
+    CHECK(false, ("Unknown Graphics API"));
   }
 
 #else  // OMIM_OS_WINDOWS

--- a/drape/gl_functions.cpp
+++ b/drape/gl_functions.cpp
@@ -256,7 +256,8 @@ void GLFunctions::Init(dp::ApiVersion apiVersion)
 
 #elif defined(OMIM_OS_LINUX)
     void *libhandle = dlopen("libGL.so.1", RTLD_NOW);
-    ASSERT(libhandle, ("Failed to open libGL.so.1:", dlerror()));
+    if (!libhandle)
+      LOG(LCRITICAL, ("Failed to open libGL.so.1:", dlerror()));
     glGenVertexArraysFn = (TglGenVertexArraysFn)dlsym(libhandle,"glGenVertexArraysOES");
     glBindVertexArrayFn = (TglBindVertexArrayFn)dlsym(libhandle, "glBindVertexArrayOES");
     glDeleteVertexArrayFn = (TglDeleteVertexArrayFn)dlsym(libhandle,"glDeleteVertexArraysOES");

--- a/drape/gl_functions.cpp
+++ b/drape/gl_functions.cpp
@@ -255,8 +255,16 @@ void GLFunctions::Init(dp::ApiVersion apiVersion)
     glUnmapBufferFn = &::glUnmapBuffer;
 
 #elif defined(OMIM_OS_LINUX)
-
-    CHECK(false, ("OpenGLES2 is not yet supported"));
+    void *libhandle = dlopen("libGL.so.1", RTLD_NOW);
+    ASSERT(libhandle, ("Failed to open libGL.so.1:", dlerror()));
+    glGenVertexArraysFn = (TglGenVertexArraysFn)dlsym(libhandle,"glGenVertexArraysOES");
+    glBindVertexArrayFn = (TglBindVertexArrayFn)dlsym(libhandle, "glBindVertexArrayOES");
+    glDeleteVertexArrayFn = (TglDeleteVertexArrayFn)dlsym(libhandle,"glDeleteVertexArraysOES");
+    glMapBufferFn = (TglMapBufferFn)dlsym(libhandle, "glMapBufferOES");
+    glUnmapBufferFn = (TglUnmapBufferFn)dlsym(libhandle, "glUnmapBufferOES");
+    glMapBufferRangeFn = (TglMapBufferRangeFn)dlsym(libhandle, "glMapBufferRangeEXT");
+    glFlushMappedBufferRangeFn =
+        (TglFlushMappedBufferRangeFn)dlsym(libhandle, "glFlushMappedBufferRangeEXT");
 
 #elif defined(OMIM_OS_ANDROID)
 

--- a/drape/gl_includes.hpp
+++ b/drape/gl_includes.hpp
@@ -21,6 +21,11 @@
   #include <GLES2/gl2ext.h>
   #include "android/jni/app/organicmaps/opengl/gl3stub.h"
   #include <EGL/egl.h>
+#elif defined(OMIM_OS_LINUX)
+  #define GL_GLEXT_PROTOTYPES
+  #include <dlfcn.h>
+  #include <GL/gl.h>
+  #include <GL/glext.h>
 #else
   #define GL_GLEXT_PROTOTYPES
   #include <GL/gl.h>

--- a/openlr/openlr_match_quality/openlr_assessment_tool/mainwindow.cpp
+++ b/openlr/openlr_match_quality/openlr_assessment_tool/mainwindow.cpp
@@ -243,7 +243,7 @@ private:
 MainWindow::MainWindow(Framework & framework)
   : m_framework(framework)
 {
-  m_mapWidget = new MapWidget(m_framework, false /* apiOpenGLES3 */, this /* parent */);
+  m_mapWidget = new MapWidget(m_framework, this /* parent */);
 
   m_layout = new QHBoxLayout();
   m_layout->addWidget(m_mapWidget);

--- a/openlr/openlr_match_quality/openlr_assessment_tool/map_widget.cpp
+++ b/openlr/openlr_match_quality/openlr_assessment_tool/map_widget.cpp
@@ -8,8 +8,8 @@
 
 namespace openlr
 {
-MapWidget::MapWidget(Framework & framework, bool apiOpenGLES3, QWidget * parent)
-  : Base(framework, apiOpenGLES3, false /* screenshotMode */, parent)
+MapWidget::MapWidget(Framework & framework, QWidget * parent)
+  : Base(framework, false /* screenshotMode */, parent)
 {
 }
 

--- a/openlr/openlr_match_quality/openlr_assessment_tool/map_widget.hpp
+++ b/openlr/openlr_match_quality/openlr_assessment_tool/map_widget.hpp
@@ -24,7 +24,7 @@ public:
     TrafficMarkup
   };
 
-  MapWidget(Framework & framework, bool apiOpenGLES3, QWidget * parent);
+  MapWidget(Framework & framework, QWidget * parent);
   ~MapWidget() override = default;
 
   void SetMode(Mode const mode) { m_mode = mode; }

--- a/qt/draw_widget.cpp
+++ b/qt/draw_widget.cpp
@@ -79,9 +79,9 @@ void DrawMwmBorder(df::DrapeApi & drapeApi, std::string const & mwmName,
 }
 }  // namespace
 
-DrawWidget::DrawWidget(Framework & framework, bool apiOpenGLES3, std::unique_ptr<ScreenshotParams> && screenshotParams,
+DrawWidget::DrawWidget(Framework & framework, std::unique_ptr<ScreenshotParams> && screenshotParams,
                        QWidget * parent)
-  : TBase(framework, apiOpenGLES3, screenshotParams != nullptr, parent)
+  : TBase(framework, screenshotParams != nullptr, parent)
   , m_rubberBand(nullptr)
   , m_emulatingLocation(false)
 {
@@ -680,35 +680,6 @@ void DrawWidget::SetRuler(bool enabled)
 }
 
 // static
-void DrawWidget::SetDefaultSurfaceFormat(bool apiOpenGLES3)
-{
-  QSurfaceFormat fmt;
-  fmt.setAlphaBufferSize(8);
-  fmt.setBlueBufferSize(8);
-  fmt.setGreenBufferSize(8);
-  fmt.setRedBufferSize(8);
-  fmt.setStencilBufferSize(0);
-  fmt.setSamples(0);
-  fmt.setSwapBehavior(QSurfaceFormat::DoubleBuffer);
-  fmt.setSwapInterval(1);
-  fmt.setDepthBufferSize(16);
-#ifdef ENABLE_OPENGL_DIAGNOSTICS
-  fmt.setOption(QSurfaceFormat::DebugContext);
-#endif
-  if (apiOpenGLES3)
-  {
-    fmt.setProfile(QSurfaceFormat::CoreProfile);
-    fmt.setVersion(3, 2);
-  }
-  else
-  {
-    fmt.setProfile(QSurfaceFormat::CompatibilityProfile);
-    fmt.setVersion(2, 0);
-  }
-  //fmt.setOption(QSurfaceFormat::DebugContext);
-  QSurfaceFormat::setDefaultFormat(fmt);
-}
-
 void DrawWidget::RefreshDrawingRules()
 {
   SetMapStyle(MapStyleClear);

--- a/qt/draw_widget.cpp
+++ b/qt/draw_widget.cpp
@@ -703,7 +703,7 @@ void DrawWidget::SetDefaultSurfaceFormat(bool apiOpenGLES3)
   else
   {
     fmt.setProfile(QSurfaceFormat::CompatibilityProfile);
-    fmt.setVersion(2, 1);
+    fmt.setVersion(2, 0);
   }
   //fmt.setOption(QSurfaceFormat::DebugContext);
   QSurfaceFormat::setDefaultFormat(fmt);

--- a/qt/draw_widget.hpp
+++ b/qt/draw_widget.hpp
@@ -42,7 +42,7 @@ public Q_SLOTS:
   void ChoosePositionModeDisable();
 
 public:
-  DrawWidget(Framework & framework, bool apiOpenGLES3, std::unique_ptr<ScreenshotParams> && screenshotParams,
+  DrawWidget(Framework & framework, std::unique_ptr<ScreenshotParams> && screenshotParams,
              QWidget * parent);
   ~DrawWidget() override;
 
@@ -71,8 +71,6 @@ public:
   void OnRouteRecommendation(RoutingManager::Recommendation recommendation);
 
   void RefreshDrawingRules();
-
-  static void SetDefaultSurfaceFormat(bool apiOpenGLES3);
 
 protected:
   /// @name Overriden from MapWidget.

--- a/qt/main.cpp
+++ b/qt/main.cpp
@@ -47,7 +47,6 @@ DEFINE_int32(height, 0, "Screenshot height.");
 DEFINE_double(dpi_scale, 0.0, "Screenshot dpi scale (mdpi = 1.0, hdpi = 1.5, "
               "xhdpiScale = 2.0, 6plus = 2.4, xxhdpi = 3.0, xxxhdpi = 3.5).");
 
-
 using namespace std;
 
 namespace

--- a/qt/main.cpp
+++ b/qt/main.cpp
@@ -145,7 +145,7 @@ int main(int argc, char * argv[])
   // Pretty icons on HDPI displays.
   QApplication::setAttribute(Qt::AA_UseHighDpiPixmaps);
   platform.SetupMeasurementSystem();
-  
+
 
 #ifdef BUILD_DESIGNER
     QApplication::setApplicationName("Organic Maps Designer");
@@ -215,6 +215,17 @@ int main(int argc, char * argv[])
     fmt.setSwapBehavior(QSurfaceFormat::DoubleBuffer);
     fmt.setSwapInterval(1);
     fmt.setDepthBufferSize(16);
+#if defined(OMIM_OS_LINUX)
+    // This is a workaround for older distros, which rely on X.org and Mesa,
+    // where somehow the Mesa driver itself doesn't
+    // make all the otherwise supported GLSL versions available by default
+    // and such requests are somehow disregarded at later stages of execution.
+    // This setting here will be potentially overwritten and overruled anyway,
+    // and only needed to ensure that we have the needed GLSL compiler available
+    // later when we need it.
+    if (app.platformName() == QString("xcb"))
+      fmt.setVersion(3, 2);
+#endif
 #ifdef ENABLE_OPENGL_DIAGNOSTICS
     fmt.setOption(QSurfaceFormat::DebugContext);
 #endif

--- a/qt/mainwindow.cpp
+++ b/qt/mainwindow.cpp
@@ -87,7 +87,7 @@ void FormatMapSize(uint64_t sizeInBytes, std::string & units, size_t & sizeToDow
 extern char const * kTokenKeySetting;
 extern char const * kTokenSecretSetting;
 
-MainWindow::MainWindow(Framework & framework, bool apiOpenGLES3,
+MainWindow::MainWindow(Framework & framework,
                        std::unique_ptr<ScreenshotParams> && screenshotParams,
                        QRect const & screenGeometry
 #ifdef BUILD_DESIGNER
@@ -115,7 +115,7 @@ MainWindow::MainWindow(Framework & framework, bool apiOpenGLES3,
 
   int const width = m_screenshotMode ? static_cast<int>(screenshotParams->m_width) : 0;
   int const height = m_screenshotMode ? static_cast<int>(screenshotParams->m_height) : 0;
-  m_pDrawWidget = new DrawWidget(framework, apiOpenGLES3, std::move(screenshotParams), this);
+  m_pDrawWidget = new DrawWidget(framework, std::move(screenshotParams), this);
 
   setCentralWidget(m_pDrawWidget);
 
@@ -928,9 +928,4 @@ void MainWindow::OnBookmarksAction()
   m_pDrawWidget->update();
 }
 
-// static
-void MainWindow::SetDefaultSurfaceFormat(bool apiOpenGLES3)
-{
-  DrawWidget::SetDefaultSurfaceFormat(apiOpenGLES3);
-}
 }  // namespace qt

--- a/qt/mainwindow.hpp
+++ b/qt/mainwindow.hpp
@@ -74,14 +74,12 @@ class MainWindow : public QMainWindow, location::LocationObserver
   Q_OBJECT
 
 public:
-  MainWindow(Framework & framework, bool apiOpenGLES3, std::unique_ptr<ScreenshotParams> && screenshotParams,
+  MainWindow(Framework & framework, std::unique_ptr<ScreenshotParams> && screenshotParams,
              QRect const & screenGeometry
 #ifdef BUILD_DESIGNER
              , QString const & mapcssFilePath = QString()
 #endif
             );
-
-  static void SetDefaultSurfaceFormat(bool apiOpenGLES3);
 
 protected:
   Framework & GetFramework() const;

--- a/qt/qt_common/map_widget.cpp
+++ b/qt/qt_common/map_widget.cpp
@@ -245,6 +245,13 @@ void MapWidget::Build()
 
     fragmentSrc =
         "\
+      #ifdef GL_ES\n\
+        #ifdef GL_FRAGMENT_PRECISION_HIGH\n\
+          precision highp float;\n\
+        #else\n\
+          precision mediump float;\n\
+        #endif\n\
+      #endif\n\
       uniform sampler2D u_sampler; \
       varying vec2 v_texCoord; \
       \

--- a/qt/qt_common/map_widget.cpp
+++ b/qt/qt_common/map_widget.cpp
@@ -345,25 +345,16 @@ void MapWidget::initializeGL()
   if (!m_screenshotMode)
     m_ratio = devicePixelRatio();
 
-#if defined(OMIM_OS_MAC)
-  m_apiOpenGLES3 = false;
-#elif defined(OMIM_OS_LINUX)
+  m_apiOpenGLES3 = true;
+
+#if defined(OMIM_OS_LINUX)
   {
     QOpenGLFunctions * funcs = context()->functions();
-    const std::string vendor = QString::fromLatin1(
-      (const char*)funcs->glGetString(GL_VENDOR)).toStdString();
-    const std::string renderer = QString::fromLatin1(
-      (const char*)funcs->glGetString(GL_RENDERER)).toStdString();
-    const std::string version = QString::fromLatin1(
-      (const char*)funcs->glGetString(GL_VERSION)).toStdString();
-    const std::string glslVersion = QString::fromLatin1(
-      (const char*)funcs->glGetString(GL_SHADING_LANGUAGE_VERSION)).toStdString();
-    const std::string extensions = QString::fromLatin1(
-      (const char*)funcs->glGetString(GL_EXTENSIONS)).toStdString();
-
-    LOG(LINFO, ("Vendor:", vendor, "\nRenderer:", renderer,
-                "\nVersion:", version, "\nShading language version:\n", glslVersion,
-                "\nExtensions:", extensions));
+    LOG(LINFO, ("Vendor:", funcs->glGetString(GL_VENDOR),
+                "\nRenderer:", funcs->glGetString(GL_RENDERER),
+                "\nVersion:", funcs->glGetString(GL_VERSION),
+                "\nShading language version:\n",funcs->glGetString(GL_SHADING_LANGUAGE_VERSION),
+                "\nExtensions:", funcs->glGetString(GL_EXTENSIONS)));
 
     if (context()->isOpenGLES())
     {
@@ -372,12 +363,12 @@ void MapWidget::initializeGL()
       m_apiOpenGLES3 = false;
       constexpr const char* requiredExtensions[3] =
         { "GL_EXT_map_buffer_range", "GL_OES_mapbuffer", "GL_OES_vertex_array_object" };
-      for (auto &requiredExtension: requiredExtensions)
+      for (auto & requiredExtension : requiredExtensions)
       {
-        if(context()->hasExtension(QByteArray::fromStdString(requiredExtension)))
+        if (context()->hasExtension(QByteArray::fromStdString(requiredExtension)))
           LOG(LDEBUG, ("Found OpenGL ES 2.0 extension: ", requiredExtension));
         else
-          LOG(LCRITICAL, ("A required OpenGL ES 2.0 extension is missing: ", requiredExtension));
+          LOG(LCRITICAL, ("A required OpenGL ES 2.0 extension is missing:", requiredExtension));
       }
     }
     else
@@ -400,7 +391,6 @@ void MapWidget::initializeGL()
     fmt.setVersion(2, 1);
   }
   QSurfaceFormat::setDefaultFormat(fmt);
-
 
   m_contextFactory.reset(new QtOGLContextFactory(context()));
 

--- a/qt/qt_common/map_widget.hpp
+++ b/qt/qt_common/map_widget.hpp
@@ -34,7 +34,7 @@ class MapWidget : public QOpenGLWidget
   Q_OBJECT
 
 public:
-  MapWidget(Framework & framework, bool apiOpenGLES3, bool isScreenshotMode, QWidget * parent);
+  MapWidget(Framework & framework, bool isScreenshotMode, QWidget * parent);
   ~MapWidget() override;
 
   void BindHotkeys(QWidget & parent);

--- a/search/search_quality/assessment_tool/main_view.cpp
+++ b/search/search_quality/assessment_tool/main_view.cpp
@@ -325,7 +325,7 @@ void MainView::InitMapWidget()
   widget->setLayout(layout);
 
   {
-    auto * mapWidget = new qt::common::MapWidget(m_framework, false /* apiOpenGLES3 */,
+    auto * mapWidget = new qt::common::MapWidget(m_framework,
                                                  false /* screenshotMode */, widget /* parent */);
     connect(mapWidget, &qt::common::MapWidget::OnContextMenuRequested,
             [this](QPoint const & p) { AddSelectedFeature(p); });


### PR DESCRIPTION
Fixes flathub/app.organicmaps.desktop#1 for devices that are only capable of ES2.

Signed-off-by: Ferenc Géczi <ferenc.gm@gmail.com>