### PR TITLE
Add missing returns in non-void functions

### DIFF
--- a/3party/opening_hours/CMakeLists.txt
+++ b/3party/opening_hours/CMakeLists.txt
@@ -19,8 +19,6 @@ set(SRC
 
 omim_add_library(${PROJECT_NAME} ${SRC})
 
-target_link_libraries(${PROJECT_NAME} base)
-
 target_include_directories(${PROJECT_NAME} INTERFACE .)
 
 target_compile_options(${PROJECT_NAME} PRIVATE -Wno-deprecated-copy)

--- a/3party/opening_hours/CMakeLists.txt
+++ b/3party/opening_hours/CMakeLists.txt
@@ -19,6 +19,8 @@ set(SRC
 
 omim_add_library(${PROJECT_NAME} ${SRC})
 
+target_link_libraries(${PROJECT_NAME} base)
+
 target_include_directories(${PROJECT_NAME} INTERFACE .)
 
 target_compile_options(${PROJECT_NAME} PRIVATE -Wno-deprecated-copy)

--- a/3party/opening_hours/rules_evaluation.cpp
+++ b/3party/opening_hours/rules_evaluation.cpp
@@ -108,9 +108,9 @@ osmoh::RuleState ModifierToRuleState(osmoh::RuleSequence::Modifier const modifie
 
     case Modifier::Unknown:
     case Modifier::Comment:
-    default:
       return osmoh::RuleState::Unknown;
   }
+  return osmoh::RuleState::Unknown;
 }
 
 // Transform timspan with extended end of the form of

--- a/3party/opening_hours/rules_evaluation.cpp
+++ b/3party/opening_hours/rules_evaluation.cpp
@@ -1,11 +1,11 @@
 #include "rules_evaluation.hpp"
 #include "rules_evaluation_private.hpp"
 
-#include "base/assert.hpp"
-
 #include <algorithm>
+#include <cstdlib>
 #include <ctime>
 #include <iomanip>
+#include <iostream>
 #include <sstream>
 #include <tuple>
 
@@ -112,7 +112,8 @@ osmoh::RuleState ModifierToRuleState(osmoh::RuleSequence::Modifier const modifie
     case Modifier::Comment:
       return osmoh::RuleState::Unknown;
   }
-  CHECK(false, ("Unreachable"));
+  std::cerr << "Unreachable\n";
+  std::abort();
   return osmoh::RuleState::Unknown;
 }
 

--- a/3party/opening_hours/rules_evaluation.cpp
+++ b/3party/opening_hours/rules_evaluation.cpp
@@ -108,6 +108,7 @@ osmoh::RuleState ModifierToRuleState(osmoh::RuleSequence::Modifier const modifie
 
     case Modifier::Unknown:
     case Modifier::Comment:
+    default:
       return osmoh::RuleState::Unknown;
   }
 }

--- a/3party/opening_hours/rules_evaluation.cpp
+++ b/3party/opening_hours/rules_evaluation.cpp
@@ -1,6 +1,8 @@
 #include "rules_evaluation.hpp"
 #include "rules_evaluation_private.hpp"
 
+#include "base/assert.hpp"
+
 #include <algorithm>
 #include <ctime>
 #include <iomanip>
@@ -110,6 +112,7 @@ osmoh::RuleState ModifierToRuleState(osmoh::RuleSequence::Modifier const modifie
     case Modifier::Comment:
       return osmoh::RuleState::Unknown;
   }
+  CHECK(false, ("Unreachable"));
   return osmoh::RuleState::Unknown;
 }
 

--- a/generator/generator_tests/collector_building_parts_tests.cpp
+++ b/generator/generator_tests/collector_building_parts_tests.cpp
@@ -32,6 +32,7 @@ public:
   // OSMElementCacheReaderInterface overrides:
   bool Read(generator::cache::Key /* id */, WayElement & /* value */) override {
     CHECK(false, ("Should not be called"));
+    return false;
   }
 
   bool Read(generator::cache::Key id, RelationElement & value) override

--- a/generator/generator_tests/collector_building_parts_tests.cpp
+++ b/generator/generator_tests/collector_building_parts_tests.cpp
@@ -30,9 +30,8 @@ public:
   }
 
   // OSMElementCacheReaderInterface overrides:
-  bool Read(generator::cache::Key /* id */, WayElement & /* value */) override {
+  [[noreturn]] bool Read(generator::cache::Key /* id */, WayElement & /* value */) override {
     CHECK(false, ("Should not be called"));
-    return false;
   }
 
   bool Read(generator::cache::Key id, RelationElement & value) override

--- a/generator/generator_tests/relation_tags_tests.cpp
+++ b/generator/generator_tests/relation_tags_tests.cpp
@@ -22,9 +22,8 @@ public:
   }
 
   // OSMElementCacheReaderInterface overrides:
-  bool Read(Key /* id */, WayElement & /* value */) override {
+  [[noreturn]] bool Read(Key /* id */, WayElement & /* value */) override {
     CHECK(false, ("Should not be called"));
-    return false;
   }
 
   bool Read(Key id, RelationElement & value) override

--- a/generator/generator_tests/relation_tags_tests.cpp
+++ b/generator/generator_tests/relation_tags_tests.cpp
@@ -24,6 +24,7 @@ public:
   // OSMElementCacheReaderInterface overrides:
   bool Read(Key /* id */, WayElement & /* value */) override {
     CHECK(false, ("Should not be called"));
+    return false;
   }
 
   bool Read(Key id, RelationElement & value) override

--- a/geometry/clipping.cpp
+++ b/geometry/clipping.cpp
@@ -207,6 +207,7 @@ vector<m2::SharedSpline> ClipSplineByRect(m2::RectD const & rect, m2::SharedSpli
   case RectCase::Outside: return {};
   case RectCase::Intersect: return ClipPathByRectImpl(rect, spline->GetPath());
   }
+  CHECK(false, ("Unreachable"));
   return {};
 }
 
@@ -219,6 +220,7 @@ std::vector<m2::SharedSpline> ClipPathByRect(m2::RectD const & rect,
   case RectCase::Outside: return {};
   case RectCase::Intersect: return ClipPathByRectImpl(rect, path);
   }
+  CHECK(false, ("Unreachable"));
   return {};
 }
 

--- a/geometry/clipping.cpp
+++ b/geometry/clipping.cpp
@@ -206,6 +206,7 @@ vector<m2::SharedSpline> ClipSplineByRect(m2::RectD const & rect, m2::SharedSpli
   case RectCase::Inside: return {spline};
   case RectCase::Outside: return {};
   case RectCase::Intersect: return ClipPathByRectImpl(rect, spline->GetPath());
+  default: return {};
   }
 }
 
@@ -217,6 +218,7 @@ std::vector<m2::SharedSpline> ClipPathByRect(m2::RectD const & rect,
   case RectCase::Inside: return {m2::SharedSpline(path)};
   case RectCase::Outside: return {};
   case RectCase::Intersect: return ClipPathByRectImpl(rect, path);
+  default: return {};
   }
 }
 

--- a/geometry/clipping.cpp
+++ b/geometry/clipping.cpp
@@ -206,8 +206,8 @@ vector<m2::SharedSpline> ClipSplineByRect(m2::RectD const & rect, m2::SharedSpli
   case RectCase::Inside: return {spline};
   case RectCase::Outside: return {};
   case RectCase::Intersect: return ClipPathByRectImpl(rect, spline->GetPath());
-  default: return {};
   }
+  return {};
 }
 
 std::vector<m2::SharedSpline> ClipPathByRect(m2::RectD const & rect,
@@ -218,8 +218,8 @@ std::vector<m2::SharedSpline> ClipPathByRect(m2::RectD const & rect,
   case RectCase::Inside: return {m2::SharedSpline(path)};
   case RectCase::Outside: return {};
   case RectCase::Intersect: return ClipPathByRectImpl(rect, path);
-  default: return {};
   }
+  return {};
 }
 
 void ClipPathByRectBeforeSmooth(m2::RectD const & rect, std::vector<m2::PointD> const & path,

--- a/routing/cross_mwm_graph.cpp
+++ b/routing/cross_mwm_graph.cpp
@@ -209,6 +209,7 @@ CrossMwmGraph::MwmStatus CrossMwmGraph::GetMwmStatus(NumMwmId numMwmId, string c
   case MwmDataSource::MwmNotLoaded: return MwmStatus::NotLoaded;
   case MwmDataSource::SectionExists: return MwmStatus::SectionExists;
   case MwmDataSource::NoSection: return MwmStatus::NoSection;
+  default: return MwmStatus::NoSection;
   }
 }
 

--- a/routing/cross_mwm_graph.cpp
+++ b/routing/cross_mwm_graph.cpp
@@ -210,6 +210,7 @@ CrossMwmGraph::MwmStatus CrossMwmGraph::GetMwmStatus(NumMwmId numMwmId, string c
   case MwmDataSource::SectionExists: return MwmStatus::SectionExists;
   case MwmDataSource::NoSection: return MwmStatus::NoSection;
   }
+  CHECK(false, ("Unreachable"));
   return MwmStatus::NoSection;
 }
 

--- a/routing/cross_mwm_graph.cpp
+++ b/routing/cross_mwm_graph.cpp
@@ -209,8 +209,8 @@ CrossMwmGraph::MwmStatus CrossMwmGraph::GetMwmStatus(NumMwmId numMwmId, string c
   case MwmDataSource::MwmNotLoaded: return MwmStatus::NotLoaded;
   case MwmDataSource::SectionExists: return MwmStatus::SectionExists;
   case MwmDataSource::NoSection: return MwmStatus::NoSection;
-  default: return MwmStatus::NoSection;
   }
+  return MwmStatus::NoSection;
 }
 
 CrossMwmGraph::MwmStatus CrossMwmGraph::GetCrossMwmStatus(NumMwmId numMwmId) const

--- a/routing/fake_vertex.hpp
+++ b/routing/fake_vertex.hpp
@@ -70,6 +70,7 @@ inline std::string DebugPrint(FakeVertex::Type type)
   {
   case FakeVertex::Type::PureFake: return "PureFake";
   case FakeVertex::Type::PartOfReal: return "PartOfReal";
+  default: return "UnkonwFakeVertexType";
   }
 }
 }  // namespace routing

--- a/routing/fake_vertex.hpp
+++ b/routing/fake_vertex.hpp
@@ -71,6 +71,7 @@ inline std::string DebugPrint(FakeVertex::Type type)
   case FakeVertex::Type::PureFake: return "PureFake";
   case FakeVertex::Type::PartOfReal: return "PartOfReal";
   }
+  CHECK(false, ("Unreachable"));
   return "UnknownFakeVertexType";
 }
 }  // namespace routing

--- a/routing/fake_vertex.hpp
+++ b/routing/fake_vertex.hpp
@@ -71,6 +71,6 @@ inline std::string DebugPrint(FakeVertex::Type type)
   case FakeVertex::Type::PureFake: return "PureFake";
   case FakeVertex::Type::PartOfReal: return "PartOfReal";
   }
-  return "UnkonwFakeVertexType";
+  return "UnknownFakeVertexType";
 }
 }  // namespace routing

--- a/routing/fake_vertex.hpp
+++ b/routing/fake_vertex.hpp
@@ -70,7 +70,7 @@ inline std::string DebugPrint(FakeVertex::Type type)
   {
   case FakeVertex::Type::PureFake: return "PureFake";
   case FakeVertex::Type::PartOfReal: return "PartOfReal";
-  default: return "UnkonwFakeVertexType";
   }
+  return "UnkonwFakeVertexType";
 }
 }  // namespace routing


### PR DESCRIPTION
Distributions like openSUSE compile packages with the "-Werror=return-type".

Signed-off-by: Jaime Marquínez Ferrándiz <jaime.marquinez.ferrandiz@fastmail.net>