### PR TITLE
Fix testserver behaviour after migration to Python 3

### DIFF
--- a/.github/workflows/linux-check.yaml
+++ b/.github/workflows/linux-check.yaml
@@ -15,6 +15,7 @@ on:
       - docs/**
       - packaging/**
       - pyhelpers/**
+      - tools/**
       - xcode/**
 
 jobs:

--- a/.github/workflows/linux-check.yaml
+++ b/.github/workflows/linux-check.yaml
@@ -15,7 +15,6 @@ on:
       - docs/**
       - packaging/**
       - pyhelpers/**
-      - tools/**
       - xcode/**
 
 jobs:

--- a/tools/python/ResponseProvider.py
+++ b/tools/python/ResponseProvider.py
@@ -209,17 +209,17 @@ class ResponseProvider:
         self.check_byterange(BIG_FILE_SIZE)
         headers = self.chunked_response_header(BIG_FILE_SIZE)
         message = self.trim_message(self.message_for_47kb_file())
-            
+
         return Payload(message, self.response_code, headers)
 
     
     def message_for_47kb_file(self):
         message = []
         for i in range(0, BIG_FILE_SIZE + 1):
-            message.append(chr(i // 256))
-            message.append(chr(i % 256))
+            message.append(i // 256)
+            message.append(i % 256)
 
-        return "".join(message)
+        return bytes(message)
 
 
     # Partners_api_tests

--- a/tools/python/ResponseProvider.py
+++ b/tools/python/ResponseProvider.py
@@ -11,7 +11,7 @@ BIG_FILE_SIZE = 47684
 class Payload:
     def __init__(self, message, response_code=200, headers={}):
         self.__response_code = response_code
-        self.__message = message
+        self.__message = message if type(message) is bytes else message.encode('utf8')
         self.__headers = headers
         
     
@@ -155,8 +155,9 @@ class ResponseProvider:
                 "/gallery/v2/map": self.guides_on_map_gallery,
                 "/partners/get_supported_tariffs": self.citymobil_supported_tariffs,
                 "/partners/calculate_price": self.citymobil_calculate_price,
-            }[url]()
-        except:
+            }.get(url, self.test_404)()
+        except Exception as e:
+            logging.error("test_server: Can't build server response", exc_info=e)
             return self.test_404()
 
 
@@ -215,7 +216,7 @@ class ResponseProvider:
     def message_for_47kb_file(self):
         message = []
         for i in range(0, BIG_FILE_SIZE + 1):
-            message.append(chr(i / 256))
+            message.append(chr(i // 256))
             message.append(chr(i % 256))
 
         return "".join(message)

--- a/tools/python/testserver.py
+++ b/tools/python/testserver.py
@@ -171,7 +171,7 @@ class PostHandler(BaseHTTPRequestHandler, ResponseProviderMixin):
             self.send_header(h, payload.headers()[h])
         self.send_header("Content-Length", payload.length())
         self.end_headers()
-        self.wfile.write(payload.message().encode('utf8'))
+        self.wfile.write(payload.message())
     
     
     def init_vars(self):
@@ -184,7 +184,7 @@ class PostHandler(BaseHTTPRequestHandler, ResponseProviderMixin):
         headers = self.prepare_headers()
         payload = self.response_provider.response_for_url_and_headers(self.path, headers)
         if payload.response_code() >= 300:
-            length = int(self.headers.getheader('content-length'))
+            length = int(self.headers.get('content-length'))
             self.dispatch_response(Payload(self.rfile.read(length)))
         else:
             self.dispatch_response(payload)
@@ -199,7 +199,7 @@ class PostHandler(BaseHTTPRequestHandler, ResponseProviderMixin):
     def prepare_headers(self):
         ret = dict()
         for h in self.headers:
-            ret[h] = self.headers.get(h)
+            ret[h.lower()] = self.headers.get(h)
         return ret
         
 


### PR DESCRIPTION
Errors were ignored in `ResponseProvider.py`. Added more logging.

Replaced float division with int division.

Fixed some API mismatch in `http.server` implementation between Python 2 and Python 3.

Is there any way we can run all unit tests with this branch version of scripts?