### PR TITLE
Change german translations for wilderness_hut and alpine_hut

### DIFF
--- a/data/strings/types_strings.txt
+++ b/data/strings/types_strings.txt
@@ -20843,7 +20843,7 @@
     ar = مساكن جبلية
     cs = Ubytování v horách
     da = Bjerg logi
-    de = bewirtschaftete Schutzhütte
+    de = Berghütte
     el = Ορεινό καταφύγιο
     es = Cabaña
     eu = Kabina
@@ -21698,7 +21698,7 @@
     ar = كوخ برية
     cs = Chata v divočině
     da = Vildmarkshytte
-    de = unbewirtschaftete Schutzhütte
+    de = Waldhütte
     el = Καλύβα
     es = Cabaña
     eu = Kabina


### PR DESCRIPTION
In my opinion the german translations for wilderness_hut (line ~21696) and alpine_hut (line ~20841) have a wrong translations with different meaning:
- 'unbewirtschaftete schutzhütte' means 'unmanaged shelter'
- 'bewirtschaftete schutzhütte' means 'managed shelter'

While wilderness and alpine indicate more the locationtype. Wilderness a hut in the forest and alpine in the mountains. Looking at the other translations it seams that there is the same consens. 'Cabană în pădure' means 'Cabin in the forest' ([deepl](https://www.deepl.com/translator#ro/en/Caban%C4%83%20%C3%AEn%20p%C4%83dure)) 

Signed-off-by: Christos Sidiropoulos csidirop@runbox.com