### PR TITLE
[Android] Changed padding of bookmark category item

### DIFF
--- a/android/res/layout/item_bookmark_category.xml
+++ b/android/res/layout/item_bookmark_category.xml
@@ -11,9 +11,9 @@
     android:layout_width="wrap_content"
     android:layout_height="wrap_content"
     android:layout_centerVertical="true"
-    android:minWidth="@dimen/bookmark_category_checkbox_width"
     android:layout_marginStart="@dimen/margin_half_plus"
-    android:layout_marginEnd="@dimen/margin_base_plus" />
+    android:layout_marginEnd="0dp"
+    android:minWidth="@dimen/bookmark_category_checkbox_width" />
   <TextView
     android:id="@+id/name"
     android:layout_width="match_parent"
@@ -51,8 +51,8 @@
     android:layout_alignParentEnd="true"
     android:background="?selectableItemBackgroundBorderless"
     android:minHeight="@dimen/height_item_edit_bookmark"
-    android:paddingStart="@dimen/margin_double"
-    android:paddingEnd="@dimen/margin_base_plus_quarter"
+    android:paddingStart="@dimen/margin_quarter"
+    android:paddingEnd="@dimen/margin_half"
     android:src="@drawable/ic_more"
     android:tint="?secondary" />
 </RelativeLayout>


### PR DESCRIPTION
Closes issue #2964 

| Before | Checkbox padding | Checkbox and `⋮` button padding |
| --------------- | --------------- | --------------- |
| ![2022-07-19 19 49 18](https://user-images.githubusercontent.com/720808/179913680-4e55deba-d102-4b47-956e-4fa1d4bba722.png) | ![2022-07-19 18 41 13](https://user-images.githubusercontent.com/720808/179913866-2d0ec94c-3592-47f4-a69b-99b1d5ec1266.png) | ![2022-07-19 18 54 55](https://user-images.githubusercontent.com/720808/179913903-a7a1c9db-8eec-4938-8add-bad200575352.png) |

Reduced padding for checkbox and `⋮` button.