### PR TITLE
[ios] Add "Open"/"Opens in"/"Closes in" marker in search results

### DIFF
--- a/data/strings/strings.txt
+++ b/data/strings/strings.txt
@@ -13486,7 +13486,7 @@
     zh-Hant = 小時
 
   [minute]
-    tags = android
+    tags = android,ios
     en = min
     ar = د
     be = хв

--- a/iphone/Maps/Core/Theme/Components/IFonts.swift
+++ b/iphone/Maps/Core/Theme/Components/IFonts.swift
@@ -47,6 +47,7 @@
   var heavy20: UIFont { get }
   var heavy32: UIFont { get }
   var heavy38: UIFont { get }
+  var italic12: UIFont { get }
   var italic16: UIFont { get }
   var semibold12: UIFont { get }
   var semibold14: UIFont { get }

--- a/iphone/Maps/Core/Theme/FontStyleSheet.swift
+++ b/iphone/Maps/Core/Theme/FontStyleSheet.swift
@@ -141,6 +141,9 @@ class FontStyleSheet: IStyleSheet {
     theme.add(styleName: "heavy38") { (s) -> (Void) in
       s.font = fonts.heavy38
     }
+    theme.add(styleName: "italic12") { (s) -> (Void) in
+      s.font = fonts.italic12
+    }
     theme.add(styleName: "italic16") { (s) -> (Void) in
       s.font = fonts.italic16
     }

--- a/iphone/Maps/Core/Theme/Fonts.swift
+++ b/iphone/Maps/Core/Theme/Fonts.swift
@@ -46,6 +46,7 @@ class Fonts: IFonts {
   var heavy20 = UIFont.systemFont(ofSize: 20, weight:UIFont.Weight.heavy)
   var heavy32 = UIFont.systemFont(ofSize: 32, weight:UIFont.Weight.heavy)
   var heavy38 = UIFont.systemFont(ofSize: 38, weight:UIFont.Weight.heavy)
+  var italic12 = UIFont.italicSystemFont(ofSize: 12)
   var italic16 = UIFont.italicSystemFont(ofSize: 16)
   var semibold12 = UIFont.systemFont(ofSize: 12, weight:UIFont.Weight.semibold)
   var semibold14 = UIFont.systemFont(ofSize: 14, weight:UIFont.Weight.semibold)

--- a/iphone/Maps/LocalizedStrings/ar.lproj/Localizable.strings
+++ b/iphone/Maps/LocalizedStrings/ar.lproj/Localizable.strings
@@ -750,6 +750,8 @@
 
 "miles_per_hour" = "ميل/ساعة";
 
+"minute" = "د";
+
 "placepage_place_description" = "الوصف";
 
 "placepage_more_button" = "المزيد";

--- a/iphone/Maps/LocalizedStrings/be.lproj/Localizable.strings
+++ b/iphone/Maps/LocalizedStrings/be.lproj/Localizable.strings
@@ -750,6 +750,8 @@
 
 "miles_per_hour" = "міль/г";
 
+"minute" = "хв";
+
 "placepage_place_description" = "Апісанне";
 
 "placepage_more_button" = "Яшчэ";

--- a/iphone/Maps/LocalizedStrings/bg.lproj/Localizable.strings
+++ b/iphone/Maps/LocalizedStrings/bg.lproj/Localizable.strings
@@ -750,6 +750,8 @@
 
 "miles_per_hour" = "mph";
 
+"minute" = "мин";
+
 "placepage_place_description" = "Описание";
 
 "placepage_more_button" = "Още";

--- a/iphone/Maps/LocalizedStrings/cs.lproj/Localizable.strings
+++ b/iphone/Maps/LocalizedStrings/cs.lproj/Localizable.strings
@@ -750,6 +750,8 @@
 
 "miles_per_hour" = "mil/h";
 
+"minute" = "min";
+
 "placepage_place_description" = "Popis";
 
 "placepage_more_button" = "Více";

--- a/iphone/Maps/LocalizedStrings/da.lproj/Localizable.strings
+++ b/iphone/Maps/LocalizedStrings/da.lproj/Localizable.strings
@@ -750,6 +750,8 @@
 
 "miles_per_hour" = "mph";
 
+"minute" = "min";
+
 "placepage_place_description" = "Beskrivelse";
 
 "placepage_more_button" = "Mere";

--- a/iphone/Maps/LocalizedStrings/de.lproj/Localizable.strings
+++ b/iphone/Maps/LocalizedStrings/de.lproj/Localizable.strings
@@ -750,6 +750,8 @@
 
 "miles_per_hour" = "mph";
 
+"minute" = "min";
+
 "placepage_place_description" = "Beschreibung";
 
 "placepage_more_button" = "Mehr";

--- a/iphone/Maps/LocalizedStrings/el.lproj/Localizable.strings
+++ b/iphone/Maps/LocalizedStrings/el.lproj/Localizable.strings
@@ -750,6 +750,8 @@
 
 "miles_per_hour" = "mph";
 
+"minute" = "min";
+
 "placepage_place_description" = "Description";
 
 "placepage_more_button" = "Περισσότερα";

--- a/iphone/Maps/LocalizedStrings/en-GB.lproj/Localizable.strings
+++ b/iphone/Maps/LocalizedStrings/en-GB.lproj/Localizable.strings
@@ -750,6 +750,8 @@
 
 "miles_per_hour" = "mph";
 
+"minute" = "min";
+
 "placepage_place_description" = "Description";
 
 "placepage_more_button" = "More";

--- a/iphone/Maps/LocalizedStrings/en.lproj/Localizable.strings
+++ b/iphone/Maps/LocalizedStrings/en.lproj/Localizable.strings
@@ -750,6 +750,8 @@
 
 "miles_per_hour" = "mph";
 
+"minute" = "min";
+
 "placepage_place_description" = "Description";
 
 "placepage_more_button" = "More";

--- a/iphone/Maps/LocalizedStrings/es-MX.lproj/Localizable.strings
+++ b/iphone/Maps/LocalizedStrings/es-MX.lproj/Localizable.strings
@@ -750,6 +750,8 @@
 
 "miles_per_hour" = "mph";
 
+"minute" = "min";
+
 "placepage_place_description" = "Descripción";
 
 "placepage_more_button" = "Más";

--- a/iphone/Maps/LocalizedStrings/es.lproj/Localizable.strings
+++ b/iphone/Maps/LocalizedStrings/es.lproj/Localizable.strings
@@ -750,6 +750,8 @@
 
 "miles_per_hour" = "mph";
 
+"minute" = "min";
+
 "placepage_place_description" = "Descripción";
 
 "placepage_more_button" = "Más";

--- a/iphone/Maps/LocalizedStrings/eu.lproj/Localizable.strings
+++ b/iphone/Maps/LocalizedStrings/eu.lproj/Localizable.strings
@@ -750,6 +750,8 @@
 
 "miles_per_hour" = "mph";
 
+"minute" = "min";
+
 "placepage_place_description" = "Deskribapena";
 
 "placepage_more_button" = "Gainera";

--- a/iphone/Maps/LocalizedStrings/fa.lproj/Localizable.strings
+++ b/iphone/Maps/LocalizedStrings/fa.lproj/Localizable.strings
@@ -750,6 +750,8 @@
 
 "miles_per_hour" = "مایل بر ساعت (mph)";
 
+"minute" = "دقیقه";
+
 "placepage_place_description" = "توضیحات";
 
 "placepage_more_button" = "بیشتر";

--- a/iphone/Maps/LocalizedStrings/fi.lproj/Localizable.strings
+++ b/iphone/Maps/LocalizedStrings/fi.lproj/Localizable.strings
@@ -750,6 +750,8 @@
 
 "miles_per_hour" = "mph";
 
+"minute" = "min";
+
 "placepage_place_description" = "Kuvaus";
 
 "placepage_more_button" = "Lisää";

--- a/iphone/Maps/LocalizedStrings/fr.lproj/Localizable.strings
+++ b/iphone/Maps/LocalizedStrings/fr.lproj/Localizable.strings
@@ -750,6 +750,8 @@
 
 "miles_per_hour" = "mph";
 
+"minute" = "min";
+
 "placepage_place_description" = "Description";
 
 "placepage_more_button" = "Plus";

--- a/iphone/Maps/LocalizedStrings/he.lproj/Localizable.strings
+++ b/iphone/Maps/LocalizedStrings/he.lproj/Localizable.strings
@@ -750,6 +750,8 @@
 
 "miles_per_hour" = "mph";
 
+"minute" = "min";
+
 "placepage_place_description" = "Description";
 
 "placepage_more_button" = "More";

--- a/iphone/Maps/LocalizedStrings/hu.lproj/Localizable.strings
+++ b/iphone/Maps/LocalizedStrings/hu.lproj/Localizable.strings
@@ -750,6 +750,8 @@
 
 "miles_per_hour" = "mph";
 
+"minute" = "p";
+
 "placepage_place_description" = "Leírás";
 
 "placepage_more_button" = "Még";

--- a/iphone/Maps/LocalizedStrings/id.lproj/Localizable.strings
+++ b/iphone/Maps/LocalizedStrings/id.lproj/Localizable.strings
@@ -750,6 +750,8 @@
 
 "miles_per_hour" = "mpj";
 
+"minute" = "mnt";
+
 "placepage_place_description" = "Deskripsi";
 
 "placepage_more_button" = "Lainnya";

--- a/iphone/Maps/LocalizedStrings/it.lproj/Localizable.strings
+++ b/iphone/Maps/LocalizedStrings/it.lproj/Localizable.strings
@@ -750,6 +750,8 @@
 
 "miles_per_hour" = "mph";
 
+"minute" = "min";
+
 "placepage_place_description" = "Descrizione";
 
 "placepage_more_button" = "Di più";

--- a/iphone/Maps/LocalizedStrings/ja.lproj/Localizable.strings
+++ b/iphone/Maps/LocalizedStrings/ja.lproj/Localizable.strings
@@ -750,6 +750,8 @@
 
 "miles_per_hour" = "マイル毎時";
 
+"minute" = "分";
+
 "placepage_place_description" = "説明";
 
 "placepage_more_button" = "さらに詳しく";

--- a/iphone/Maps/LocalizedStrings/ko.lproj/Localizable.strings
+++ b/iphone/Maps/LocalizedStrings/ko.lproj/Localizable.strings
@@ -750,6 +750,8 @@
 
 "miles_per_hour" = "mph";
 
+"minute" = "min";
+
 "placepage_place_description" = "설명";
 
 "placepage_more_button" = "자세히";

--- a/iphone/Maps/LocalizedStrings/mr.lproj/Localizable.strings
+++ b/iphone/Maps/LocalizedStrings/mr.lproj/Localizable.strings
@@ -750,6 +750,8 @@
 
 "miles_per_hour" = "mph";
 
+"minute" = "मिनिट";
+
 "placepage_place_description" = "वर्णन";
 
 "placepage_more_button" = "अधिक";

--- a/iphone/Maps/LocalizedStrings/nb.lproj/Localizable.strings
+++ b/iphone/Maps/LocalizedStrings/nb.lproj/Localizable.strings
@@ -750,6 +750,8 @@
 
 "miles_per_hour" = "mph";
 
+"minute" = "min";
+
 "placepage_place_description" = "Beskrivelse";
 
 "placepage_more_button" = "Mer";

--- a/iphone/Maps/LocalizedStrings/nl.lproj/Localizable.strings
+++ b/iphone/Maps/LocalizedStrings/nl.lproj/Localizable.strings
@@ -750,6 +750,8 @@
 
 "miles_per_hour" = "mph";
 
+"minute" = "min";
+
 "placepage_place_description" = "Beschrijving";
 
 "placepage_more_button" = "Meer";

--- a/iphone/Maps/LocalizedStrings/pl.lproj/Localizable.strings
+++ b/iphone/Maps/LocalizedStrings/pl.lproj/Localizable.strings
@@ -750,6 +750,8 @@
 
 "miles_per_hour" = "mph";
 
+"minute" = "min";
+
 "placepage_place_description" = "Opis";
 
 "placepage_more_button" = "Więcej";

--- a/iphone/Maps/LocalizedStrings/pt-BR.lproj/Localizable.strings
+++ b/iphone/Maps/LocalizedStrings/pt-BR.lproj/Localizable.strings
@@ -750,6 +750,8 @@
 
 "miles_per_hour" = "mph";
 
+"minute" = "min";
+
 "placepage_place_description" = "Descrição";
 
 "placepage_more_button" = "Mais";

--- a/iphone/Maps/LocalizedStrings/pt.lproj/Localizable.strings
+++ b/iphone/Maps/LocalizedStrings/pt.lproj/Localizable.strings
@@ -750,6 +750,8 @@
 
 "miles_per_hour" = "mph";
 
+"minute" = "min";
+
 "placepage_place_description" = "Descrição";
 
 "placepage_more_button" = "Mais";

--- a/iphone/Maps/LocalizedStrings/ro.lproj/Localizable.strings
+++ b/iphone/Maps/LocalizedStrings/ro.lproj/Localizable.strings
@@ -750,6 +750,8 @@
 
 "miles_per_hour" = "mph";
 
+"minute" = "min";
+
 "placepage_place_description" = "Descriere";
 
 "placepage_more_button" = "Mai mult";

--- a/iphone/Maps/LocalizedStrings/ru.lproj/Localizable.strings
+++ b/iphone/Maps/LocalizedStrings/ru.lproj/Localizable.strings
@@ -750,6 +750,8 @@
 
 "miles_per_hour" = "ми/ч";
 
+"minute" = "мин";
+
 "placepage_place_description" = "Описание";
 
 "placepage_more_button" = "Ещё";

--- a/iphone/Maps/LocalizedStrings/sk.lproj/Localizable.strings
+++ b/iphone/Maps/LocalizedStrings/sk.lproj/Localizable.strings
@@ -750,6 +750,8 @@
 
 "miles_per_hour" = "mph";
 
+"minute" = "min";
+
 "placepage_place_description" = "Popis";
 
 "placepage_more_button" = "Viac";

--- a/iphone/Maps/LocalizedStrings/sv.lproj/Localizable.strings
+++ b/iphone/Maps/LocalizedStrings/sv.lproj/Localizable.strings
@@ -750,6 +750,8 @@
 
 "miles_per_hour" = "mph";
 
+"minute" = "min";
+
 "placepage_place_description" = "Beskrivning";
 
 "placepage_more_button" = "Mer";

--- a/iphone/Maps/LocalizedStrings/sw.lproj/Localizable.strings
+++ b/iphone/Maps/LocalizedStrings/sw.lproj/Localizable.strings
@@ -750,6 +750,8 @@
 
 "miles_per_hour" = "mph";
 
+"minute" = "min";
+
 "placepage_place_description" = "Description";
 
 "placepage_more_button" = "More";

--- a/iphone/Maps/LocalizedStrings/th.lproj/Localizable.strings
+++ b/iphone/Maps/LocalizedStrings/th.lproj/Localizable.strings
@@ -750,6 +750,8 @@
 
 "miles_per_hour" = "ไมล์/ชม.";
 
+"minute" = "น.";
+
 "placepage_place_description" = "คำอธิบาย";
 
 "placepage_more_button" = "เพิ่มเติม";

--- a/iphone/Maps/LocalizedStrings/tr.lproj/Localizable.strings
+++ b/iphone/Maps/LocalizedStrings/tr.lproj/Localizable.strings
@@ -750,6 +750,8 @@
 
 "miles_per_hour" = "saatte mil";
 
+"minute" = "dk";
+
 "placepage_place_description" = "Açıklama";
 
 "placepage_more_button" = "Diğer";

--- a/iphone/Maps/LocalizedStrings/uk.lproj/Localizable.strings
+++ b/iphone/Maps/LocalizedStrings/uk.lproj/Localizable.strings
@@ -750,6 +750,8 @@
 
 "miles_per_hour" = "ми/год";
 
+"minute" = "хв";
+
 "placepage_place_description" = "Опис";
 
 "placepage_more_button" = "Ще";

--- a/iphone/Maps/LocalizedStrings/vi.lproj/Localizable.strings
+++ b/iphone/Maps/LocalizedStrings/vi.lproj/Localizable.strings
@@ -750,6 +750,8 @@
 
 "miles_per_hour" = "mph";
 
+"minute" = "phút";
+
 "placepage_place_description" = "Mô tả";
 
 "placepage_more_button" = "Bổ sung";

--- a/iphone/Maps/LocalizedStrings/zh-Hans.lproj/Localizable.strings
+++ b/iphone/Maps/LocalizedStrings/zh-Hans.lproj/Localizable.strings
@@ -750,6 +750,8 @@
 
 "miles_per_hour" = "英里每小时";
 
+"minute" = "分鐘";
+
 "placepage_place_description" = "说明";
 
 "placepage_more_button" = "更多";

--- a/iphone/Maps/LocalizedStrings/zh-Hant.lproj/Localizable.strings
+++ b/iphone/Maps/LocalizedStrings/zh-Hant.lproj/Localizable.strings
@@ -750,6 +750,8 @@
 
 "miles_per_hour" = "英哩每小時";
 
+"minute" = "分鐘";
+
 "placepage_place_description" = "說明";
 
 "placepage_more_button" = "更多";

--- a/iphone/Maps/UI/Search/TableView/MWMSearchCommonCell.mm
+++ b/iphone/Maps/UI/Search/TableView/MWMSearchCommonCell.mm
@@ -21,7 +21,7 @@ bool PopularityHasHigherPriority(bool hasPosition, double distanceInMeters)
 @property(weak, nonatomic) IBOutlet UILabel * infoLabel;
 @property(weak, nonatomic) IBOutlet UILabel * locationLabel;
 @property(weak, nonatomic) IBOutlet UILabel * typeLabel;
-@property(weak, nonatomic) IBOutlet UIView * closedView;
+@property(weak, nonatomic) IBOutlet UILabel * openLabel;
 @property(weak, nonatomic) IBOutlet UIView * infoView;
 @property(weak, nonatomic) IBOutlet UIView * popularView;
 
@@ -80,19 +80,40 @@ bool PopularityHasHigherPriority(bool hasPosition, double distanceInMeters)
     }
   }
 
-  bool popularityHasHigherPriority = PopularityHasHigherPriority(lastLocation, distanceInMeters);
-  bool showClosed = result.IsOpenNow() == osm::No;
   bool showPopular = result.GetRankingInfo().m_popularity > 0;
-
-  if (showClosed && showPopular)
+  self.popularView.hidden = !showPopular;
+  self.openLabel.hidden = true;
+  
+  if (result.IsOpenNow() == osm::Yes)
   {
-    self.closedView.hidden = popularityHasHigherPriority;
-    self.popularView.hidden = !popularityHasHigherPriority;
+    int minutes = result.GetMinutesUntilClosed();
+    if (minutes < 60) // less than 1 hour
+    {
+      self.openLabel.textColor = UIColor.systemYellowColor;
+      NSString *time = [NSString stringWithFormat: @"%d %@", minutes, L(@"minute")];
+      self.openLabel.text = [NSString stringWithFormat: L(@"closes_in"), time];
+    }
+    else
+    {
+      self.openLabel.textColor = UIColor.systemGreenColor;
+      self.openLabel.text = L(@"editor_time_open");
+    }
+    self.openLabel.hidden = false;
   }
-  else
+  else if (result.IsOpenNow() == osm::No)
   {
-    self.closedView.hidden = !showClosed;
-    self.popularView.hidden = !showPopular;
+    self.openLabel.textColor = UIColor.systemRedColor;
+    int minutes = result.GetMinutesUntilOpen();
+    if (minutes < 60) // less than 1 hour
+    {
+      NSString *time = [NSString stringWithFormat: @"%d %@", minutes, L(@"minute")];
+      self.openLabel.text = [NSString stringWithFormat: L(@"opens_in"), time];
+    }
+    else
+    {
+      self.openLabel.text = L(@"closed");
+    }
+    self.openLabel.hidden = false;
   }
 
   [self setStyleAndApply: @"Background"];

--- a/iphone/Maps/UI/Search/TableView/MWMSearchCommonCell.mm
+++ b/iphone/Maps/UI/Search/TableView/MWMSearchCommonCell.mm
@@ -20,9 +20,7 @@ bool PopularityHasHigherPriority(bool hasPosition, double distanceInMeters)
 @property(weak, nonatomic) IBOutlet UILabel * distanceLabel;
 @property(weak, nonatomic) IBOutlet UILabel * infoLabel;
 @property(weak, nonatomic) IBOutlet UILabel * locationLabel;
-@property(weak, nonatomic) IBOutlet UILabel * typeLabel;
 @property(weak, nonatomic) IBOutlet UILabel * openLabel;
-@property(weak, nonatomic) IBOutlet UIView * infoView;
 @property(weak, nonatomic) IBOutlet UIView * popularView;
 
 @end
@@ -35,8 +33,6 @@ bool PopularityHasHigherPriority(bool hasPosition, double distanceInMeters)
 {
   [super config:result localizedTypeName:localizedTypeName];
 
-  self.typeLabel.text = localizedTypeName;
-
   self.locationLabel.text = @(result.GetAddress().c_str());
   [self.locationLabel sizeToFit];
 
@@ -47,22 +43,27 @@ bool PopularityHasHigherPriority(bool hasPosition, double distanceInMeters)
   NSString * brand  = @"";
   if (!result.GetBrand().empty())
     brand = @(platform::GetLocalizedBrandName(result.GetBrand()).c_str());
+  
+  NSString * description = @"";
 
   static NSString * fiveStars = [NSString stringWithUTF8String:"★★★★★"];
   if (starsCount > 0)
-    [self setInfoText:[fiveStars substringToIndex:starsCount]];
+    description = [fiveStars substringToIndex:starsCount];
   else if (airportIata.length > 0)
-    [self setInfoText:airportIata];
+    description = airportIata;
   else if (roadShields.length > 0)
-    [self setInfoText:roadShields];
+    description = roadShields;
   else if (brand.length > 0 && cuisine.length > 0)
-    [self setInfoText:[NSString stringWithFormat:@"%@ • %@", brand, cuisine]];
+    description = [NSString stringWithFormat:@"%@ • %@", brand, cuisine];
   else if (brand.length > 0)
-    [self setInfoText:brand];
+    description = brand;
   else if (cuisine.length > 0)
-    [self setInfoText:cuisine];
+    description = cuisine;
+  
+  if ([description length] == 0)
+    self.infoLabel.text = localizedTypeName;
   else
-    [self clearInfo];
+    self.infoLabel.text = [NSString stringWithFormat:@"%@ • %@", localizedTypeName, description];
 
   CLLocation * lastLocation = [MWMLocationManager lastLocation];
   double distanceInMeters = 0.0;
@@ -129,14 +130,6 @@ bool PopularityHasHigherPriority(bool hasPosition, double distanceInMeters)
 
   [self setStyleAndApply: @"Background"];
 }
-
-- (void)setInfoText:(NSString *)infoText
-{
-  self.infoView.hidden = NO;
-  self.infoLabel.text = infoText;
-}
-
-- (void)clearInfo { self.infoView.hidden = YES; }
 
 - (NSDictionary *)selectedTitleAttributes
 {

--- a/iphone/Maps/UI/Search/TableView/MWMSearchCommonCell.mm
+++ b/iphone/Maps/UI/Search/TableView/MWMSearchCommonCell.mm
@@ -82,38 +82,49 @@ bool PopularityHasHigherPriority(bool hasPosition, double distanceInMeters)
 
   bool showPopular = result.GetRankingInfo().m_popularity > 0;
   self.popularView.hidden = !showPopular;
-  self.openLabel.hidden = true;
   
-  if (result.IsOpenNow() == osm::Yes)
+  switch (result.IsOpenNow())
   {
-    int minutes = result.GetMinutesUntilClosed();
-    if (minutes < 60) // less than 1 hour
+    case osm::Yes:
     {
-      self.openLabel.textColor = UIColor.systemYellowColor;
-      NSString *time = [NSString stringWithFormat: @"%d %@", minutes, L(@"minute")];
-      self.openLabel.text = [NSString stringWithFormat: L(@"closes_in"), time];
+      int const minutes = result.GetMinutesUntilClosed();
+      if (minutes < 60) // less than 1 hour
+      {
+        self.openLabel.textColor = UIColor.systemYellowColor;
+        NSString *time = [NSString stringWithFormat: @"%d %@", minutes, L(@"minute")];
+        self.openLabel.text = [NSString stringWithFormat: L(@"closes_in"), time];
+      }
+      else
+      {
+        self.openLabel.textColor = UIColor.systemGreenColor;
+        self.openLabel.text = L(@"editor_time_open");
+      }
+      self.openLabel.hidden = false;
+      break;
     }
-    else
+      
+    case osm::No:
     {
-      self.openLabel.textColor = UIColor.systemGreenColor;
-      self.openLabel.text = L(@"editor_time_open");
+      self.openLabel.textColor = UIColor.systemRedColor;
+      int const minutes = result.GetMinutesUntilOpen();
+      if (minutes < 60) // less than 1 hour
+      {
+        NSString *time = [NSString stringWithFormat: @"%d %@", minutes, L(@"minute")];
+        self.openLabel.text = [NSString stringWithFormat: L(@"opens_in"), time];
+      }
+      else
+      {
+        self.openLabel.text = L(@"closed");
+      }
+      self.openLabel.hidden = false;
+      break;
     }
-    self.openLabel.hidden = false;
-  }
-  else if (result.IsOpenNow() == osm::No)
-  {
-    self.openLabel.textColor = UIColor.systemRedColor;
-    int minutes = result.GetMinutesUntilOpen();
-    if (minutes < 60) // less than 1 hour
+      
+    case osm::Unknown:
     {
-      NSString *time = [NSString stringWithFormat: @"%d %@", minutes, L(@"minute")];
-      self.openLabel.text = [NSString stringWithFormat: L(@"opens_in"), time];
+      self.openLabel.hidden = true;
+      break;
     }
-    else
-    {
-      self.openLabel.text = L(@"closed");
-    }
-    self.openLabel.hidden = false;
   }
 
   [self setStyleAndApply: @"Background"];

--- a/iphone/Maps/UI/Search/TableView/MWMSearchCommonCell.xib
+++ b/iphone/Maps/UI/Search/TableView/MWMSearchCommonCell.xib
@@ -71,7 +71,7 @@
                             <userDefinedRuntimeAttribute type="string" keyPath="styleName" value="SearchPopularView"/>
                         </userDefinedRuntimeAttributes>
                     </view>
-                    <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" ambiguous="YES" text="Сafe" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="5UO-MD-Hgx">
+                    <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" ambiguous="YES" text="Сafe" textAlignment="natural" lineBreakMode="tailTruncation" numberOfLines="0" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="5UO-MD-Hgx">
                         <rect key="frame" x="16" y="36" width="26" height="14"/>
                         <accessibility key="accessibilityConfiguration" identifier="searchType"/>
                         <constraints>
@@ -84,7 +84,7 @@
                             <userDefinedRuntimeAttribute type="string" keyPath="styleName" value="regular12:blackSecondaryText"/>
                         </userDefinedRuntimeAttributes>
                     </label>
-                    <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" ambiguous="YES" text="Open" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="SDd-3c-YeL">
+                    <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalCompressionResistancePriority="751" verticalCompressionResistancePriority="751" text="Open" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="SDd-3c-YeL">
                         <rect key="frame" x="274.5" y="36" width="29.5" height="14"/>
                         <accessibility key="accessibilityConfiguration" identifier="searchType"/>
                         <constraints>
@@ -97,32 +97,6 @@
                             <userDefinedRuntimeAttribute type="string" keyPath="styleName" value="regular12:blackSecondaryText"/>
                         </userDefinedRuntimeAttributes>
                     </label>
-                    <view hidden="YES" userInteractionEnabled="NO" contentMode="scaleToFill" ambiguous="YES" translatesAutoresizingMaskIntoConstraints="NO" id="AXe-5n-maZ" userLabel="Info">
-                        <rect key="frame" x="46" y="36" width="224.5" height="14"/>
-                        <subviews>
-                            <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" ambiguous="YES" text="Label" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="vjT-oU-iIA">
-                                <rect key="frame" x="8" y="0.0" width="71" height="14"/>
-                                <fontDescription key="fontDescription" name="HelveticaNeue" family="Helvetica Neue" pointSize="12"/>
-                                <color key="textColor" red="0.0" green="0.0" blue="0.0" alpha="0.54000000000000004" colorSpace="custom" customColorSpace="sRGB"/>
-                                <nil key="highlightedColor"/>
-                                <userDefinedRuntimeAttributes>
-                                    <userDefinedRuntimeAttribute type="string" keyPath="styleName" value="regular12:blackSecondaryText"/>
-                                </userDefinedRuntimeAttributes>
-                            </label>
-                            <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" ambiguous="YES" text="•" textAlignment="center" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="tUT-ew-nNT" userLabel="Dot">
-                                <rect key="frame" x="2" y="0.0" width="4" height="14"/>
-                                <fontDescription key="fontDescription" name="HelveticaNeue" family="Helvetica Neue" pointSize="12"/>
-                                <color key="textColor" red="0.0" green="0.0" blue="0.0" alpha="0.54000000000000004" colorSpace="custom" customColorSpace="sRGB"/>
-                                <nil key="highlightedColor"/>
-                                <userDefinedRuntimeAttributes>
-                                    <userDefinedRuntimeAttribute type="string" keyPath="styleName" value="regular12:blackSecondaryText"/>
-                                </userDefinedRuntimeAttributes>
-                            </label>
-                        </subviews>
-                        <constraints>
-                            <constraint firstItem="vjT-oU-iIA" firstAttribute="leading" secondItem="tUT-ew-nNT" secondAttribute="trailing" constant="2" id="UAm-zh-FNA"/>
-                        </constraints>
-                    </view>
                     <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" verticalCompressionResistancePriority="751" ambiguous="YES" text="Russia, Moscow &amp; Central, Moscow" textAlignment="natural" lineBreakMode="tailTruncation" numberOfLines="0" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="6pc-4s-GyP">
                         <rect key="frame" x="16" y="59" width="220" height="14"/>
                         <accessibility key="accessibilityConfiguration" identifier="searchSubTitle"/>
@@ -139,11 +113,8 @@
                     <constraint firstItem="P8X-Xp-AaE" firstAttribute="leading" secondItem="6pc-4s-GyP" secondAttribute="trailing" id="0hr-QT-t0D"/>
                     <constraint firstItem="5UO-MD-Hgx" firstAttribute="top" secondItem="4FD-RE-ffF" secondAttribute="bottom" constant="4" id="5dn-ca-dCn"/>
                     <constraint firstItem="6pc-4s-GyP" firstAttribute="top" secondItem="5UO-MD-Hgx" secondAttribute="bottom" constant="8" id="7pm-XZ-vLK"/>
-                    <constraint firstItem="AXe-5n-maZ" firstAttribute="leading" secondItem="5UO-MD-Hgx" secondAttribute="trailing" constant="4" id="A63-OI-W5K"/>
-                    <constraint firstItem="AXe-5n-maZ" firstAttribute="trailing" secondItem="SDd-3c-YeL" secondAttribute="leading" constant="-4" id="Jcf-PD-ZFs"/>
-                    <constraint firstItem="AXe-5n-maZ" firstAttribute="top" secondItem="5UO-MD-Hgx" secondAttribute="top" id="PNu-ZN-b8a"/>
                     <constraint firstItem="4FD-RE-ffF" firstAttribute="leading" secondItem="H2p-sc-9uM" secondAttribute="leading" constant="16" id="Qld-dY-CQN"/>
-                    <constraint firstItem="AXe-5n-maZ" firstAttribute="bottom" secondItem="5UO-MD-Hgx" secondAttribute="bottom" id="SgY-ef-ISG"/>
+                    <constraint firstItem="5UO-MD-Hgx" firstAttribute="trailing" relation="lessThanOrEqual" secondItem="SDd-3c-YeL" secondAttribute="leading" id="SJj-b5-T2k"/>
                     <constraint firstAttribute="trailing" secondItem="4FD-RE-ffF" secondAttribute="trailing" constant="84" id="Ugu-lP-b9G"/>
                     <constraint firstAttribute="trailing" secondItem="P8X-Xp-AaE" secondAttribute="trailing" constant="16" id="VJE-wo-TBb"/>
                     <constraint firstItem="4FD-RE-ffF" firstAttribute="top" secondItem="H2p-sc-9uM" secondAttribute="top" constant="12" id="hM6-br-iKE"/>
@@ -152,10 +123,10 @@
                     <constraint firstItem="5UO-MD-Hgx" firstAttribute="leading" secondItem="H2p-sc-9uM" secondAttribute="leading" constant="16" id="nGL-Ta-pBZ"/>
                     <constraint firstAttribute="trailing" secondItem="6pc-4s-GyP" secondAttribute="trailing" constant="84" id="nfE-NI-LX9"/>
                     <constraint firstItem="6pc-4s-GyP" firstAttribute="bottom" secondItem="P8X-Xp-AaE" secondAttribute="bottom" id="q7E-Jg-MYT"/>
-                    <constraint firstItem="SDd-3c-YeL" firstAttribute="bottom" secondItem="AXe-5n-maZ" secondAttribute="bottom" id="qba-9O-tbL"/>
                     <constraint firstItem="HGm-lZ-JNr" firstAttribute="leading" secondItem="H2p-sc-9uM" secondAttribute="leading" constant="16" id="sq9-C3-M3R"/>
                     <constraint firstAttribute="bottom" secondItem="HGm-lZ-JNr" secondAttribute="bottom" id="vJc-aE-MsA"/>
                     <constraint firstAttribute="trailing" secondItem="SDd-3c-YeL" secondAttribute="trailing" constant="16" id="vay-ux-6dA"/>
+                    <constraint firstItem="SDd-3c-YeL" firstAttribute="top" secondItem="5UO-MD-Hgx" secondAttribute="top" id="wXg-ce-SnG"/>
                     <constraint firstAttribute="trailing" secondItem="HGm-lZ-JNr" secondAttribute="trailing" id="xt0-86-Efu"/>
                 </constraints>
             </tableViewCellContentView>
@@ -164,13 +135,11 @@
             </userDefinedRuntimeAttributes>
             <connections>
                 <outlet property="distanceLabel" destination="P8X-Xp-AaE" id="Kaw-aR-8uJ"/>
-                <outlet property="infoLabel" destination="vjT-oU-iIA" id="K5N-O7-B0x"/>
-                <outlet property="infoView" destination="AXe-5n-maZ" id="obW-dd-NLt"/>
                 <outlet property="locationLabel" destination="6pc-4s-GyP" id="Te0-y3-sVQ"/>
                 <outlet property="openLabel" destination="SDd-3c-YeL" id="5Rv-fO-g4x"/>
                 <outlet property="popularView" destination="uWz-7m-GUu" id="LAK-NA-Fea"/>
                 <outlet property="titleLabel" destination="4FD-RE-ffF" id="OQm-o8-LUd"/>
-                <outlet property="typeLabel" destination="5UO-MD-Hgx" id="lgJ-zE-omX"/>
+                <outlet property="infoLabel" destination="5UO-MD-Hgx" id="lgJ-zE-omX"/>
             </connections>
             <point key="canvasLocation" x="314.49275362318843" y="297.99107142857139"/>
         </tableViewCell>

--- a/iphone/Maps/UI/Search/TableView/MWMSearchCommonCell.xib
+++ b/iphone/Maps/UI/Search/TableView/MWMSearchCommonCell.xib
@@ -126,11 +126,11 @@
                     <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" verticalCompressionResistancePriority="751" ambiguous="YES" text="Russia, Moscow &amp; Central, Moscow" textAlignment="natural" lineBreakMode="tailTruncation" numberOfLines="0" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="6pc-4s-GyP">
                         <rect key="frame" x="16" y="59" width="220" height="14"/>
                         <accessibility key="accessibilityConfiguration" identifier="searchSubTitle"/>
-                        <fontDescription key="fontDescription" name="HelveticaNeue" family="Helvetica Neue" pointSize="12"/>
+                        <fontDescription key="fontDescription" name="HelveticaNeue-Italic" family="Helvetica Neue" pointSize="12"/>
                         <color key="textColor" red="0.0" green="0.0" blue="0.0" alpha="0.54000000000000004" colorSpace="custom" customColorSpace="sRGB"/>
                         <nil key="highlightedColor"/>
                         <userDefinedRuntimeAttributes>
-                            <userDefinedRuntimeAttribute type="string" keyPath="styleName" value="regular12:blackSecondaryText"/>
+                            <userDefinedRuntimeAttribute type="string" keyPath="styleName" value="italic12:blackSecondaryText"/>
                         </userDefinedRuntimeAttributes>
                     </label>
                 </subviews>

--- a/iphone/Maps/UI/Search/TableView/MWMSearchCommonCell.xib
+++ b/iphone/Maps/UI/Search/TableView/MWMSearchCommonCell.xib
@@ -1,9 +1,9 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<document type="com.apple.InterfaceBuilder3.CocoaTouch.XIB" version="3.0" toolsVersion="17701" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" colorMatched="YES">
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.XIB" version="3.0" toolsVersion="20037" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" colorMatched="YES">
     <device id="retina6_1" orientation="portrait" appearance="light"/>
     <dependencies>
         <deployment identifier="iOS"/>
-        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="17703"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="20020"/>
         <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
     </dependencies>
     <objects>
@@ -45,33 +45,7 @@
                             <userDefinedRuntimeAttribute type="string" keyPath="styleName" value="Divider"/>
                         </userDefinedRuntimeAttributes>
                     </view>
-                    <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="V8w-dT-7B1" userLabel="ClosedBackground">
-                        <rect key="frame" x="248" y="16" width="56" height="16"/>
-                        <subviews>
-                            <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Closed" textAlignment="center" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="wcB-Lv-cex">
-                                <rect key="frame" x="0.0" y="1" width="56" height="14"/>
-                                <fontDescription key="fontDescription" name="HelveticaNeue" family="Helvetica Neue" pointSize="12"/>
-                                <color key="textColor" red="1" green="1" blue="1" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
-                                <nil key="highlightedColor"/>
-                                <userDefinedRuntimeAttributes>
-                                    <userDefinedRuntimeAttribute type="string" keyPath="styleName" value="regular12:whiteText"/>
-                                    <userDefinedRuntimeAttribute type="string" keyPath="localizedText" value="closed"/>
-                                </userDefinedRuntimeAttributes>
-                            </label>
-                        </subviews>
-                        <color key="backgroundColor" red="0.0" green="0.0" blue="0.0" alpha="0.26000000000000001" colorSpace="custom" customColorSpace="sRGB"/>
-                        <constraints>
-                            <constraint firstAttribute="height" constant="16" id="Ahy-Bj-hS9"/>
-                            <constraint firstAttribute="centerY" secondItem="wcB-Lv-cex" secondAttribute="centerY" id="HKD-vK-tIf"/>
-                            <constraint firstAttribute="trailing" secondItem="wcB-Lv-cex" secondAttribute="trailing" id="NQK-Dn-xg9"/>
-                            <constraint firstItem="wcB-Lv-cex" firstAttribute="leading" secondItem="V8w-dT-7B1" secondAttribute="leading" id="gLv-OB-7Bi"/>
-                            <constraint firstAttribute="width" constant="56" id="xkl-3E-FRu"/>
-                        </constraints>
-                        <userDefinedRuntimeAttributes>
-                            <userDefinedRuntimeAttribute type="string" keyPath="styleName" value="SearchClosedBackground"/>
-                        </userDefinedRuntimeAttributes>
-                    </view>
-                    <view hidden="YES" contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="uWz-7m-GUu">
+                    <view hidden="YES" contentMode="scaleToFill" ambiguous="YES" translatesAutoresizingMaskIntoConstraints="NO" id="uWz-7m-GUu">
                         <rect key="frame" x="262.5" y="16" width="41.5" height="20"/>
                         <subviews>
                             <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="TOP" textAlignment="center" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="yjT-ah-SWQ">
@@ -110,8 +84,21 @@
                             <userDefinedRuntimeAttribute type="string" keyPath="styleName" value="regular12:blackSecondaryText"/>
                         </userDefinedRuntimeAttributes>
                     </label>
+                    <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" ambiguous="YES" text="Open" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="SDd-3c-YeL">
+                        <rect key="frame" x="274.5" y="36" width="29.5" height="14"/>
+                        <accessibility key="accessibilityConfiguration" identifier="searchType"/>
+                        <constraints>
+                            <constraint firstAttribute="width" relation="greaterThanOrEqual" constant="26" id="tqr-8N-JwN"/>
+                        </constraints>
+                        <fontDescription key="fontDescription" name="HelveticaNeue" family="Helvetica Neue" pointSize="12"/>
+                        <color key="textColor" red="0.0" green="0.0" blue="0.0" alpha="0.54000000000000004" colorSpace="custom" customColorSpace="sRGB"/>
+                        <nil key="highlightedColor"/>
+                        <userDefinedRuntimeAttributes>
+                            <userDefinedRuntimeAttribute type="string" keyPath="styleName" value="regular12:blackSecondaryText"/>
+                        </userDefinedRuntimeAttributes>
+                    </label>
                     <view hidden="YES" userInteractionEnabled="NO" contentMode="scaleToFill" ambiguous="YES" translatesAutoresizingMaskIntoConstraints="NO" id="AXe-5n-maZ" userLabel="Info">
-                        <rect key="frame" x="46" y="36" width="258" height="14"/>
+                        <rect key="frame" x="46" y="36" width="224.5" height="14"/>
                         <subviews>
                             <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" ambiguous="YES" text="Label" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="vjT-oU-iIA">
                                 <rect key="frame" x="8" y="0.0" width="71" height="14"/>
@@ -153,24 +140,22 @@
                     <constraint firstItem="5UO-MD-Hgx" firstAttribute="top" secondItem="4FD-RE-ffF" secondAttribute="bottom" constant="4" id="5dn-ca-dCn"/>
                     <constraint firstItem="6pc-4s-GyP" firstAttribute="top" secondItem="5UO-MD-Hgx" secondAttribute="bottom" constant="8" id="7pm-XZ-vLK"/>
                     <constraint firstItem="AXe-5n-maZ" firstAttribute="leading" secondItem="5UO-MD-Hgx" secondAttribute="trailing" constant="4" id="A63-OI-W5K"/>
-                    <constraint firstItem="uWz-7m-GUu" firstAttribute="trailing" secondItem="V8w-dT-7B1" secondAttribute="trailing" id="OB1-ad-dby"/>
+                    <constraint firstItem="AXe-5n-maZ" firstAttribute="trailing" secondItem="SDd-3c-YeL" secondAttribute="leading" constant="-4" id="Jcf-PD-ZFs"/>
                     <constraint firstItem="AXe-5n-maZ" firstAttribute="top" secondItem="5UO-MD-Hgx" secondAttribute="top" id="PNu-ZN-b8a"/>
                     <constraint firstItem="4FD-RE-ffF" firstAttribute="leading" secondItem="H2p-sc-9uM" secondAttribute="leading" constant="16" id="Qld-dY-CQN"/>
                     <constraint firstItem="AXe-5n-maZ" firstAttribute="bottom" secondItem="5UO-MD-Hgx" secondAttribute="bottom" id="SgY-ef-ISG"/>
                     <constraint firstAttribute="trailing" secondItem="4FD-RE-ffF" secondAttribute="trailing" constant="84" id="Ugu-lP-b9G"/>
                     <constraint firstAttribute="trailing" secondItem="P8X-Xp-AaE" secondAttribute="trailing" constant="16" id="VJE-wo-TBb"/>
-                    <constraint firstItem="uWz-7m-GUu" firstAttribute="top" secondItem="V8w-dT-7B1" secondAttribute="top" id="ZbQ-Z5-4k9"/>
-                    <constraint firstAttribute="trailing" secondItem="AXe-5n-maZ" secondAttribute="trailing" constant="16" id="dJN-0Z-98x"/>
                     <constraint firstItem="4FD-RE-ffF" firstAttribute="top" secondItem="H2p-sc-9uM" secondAttribute="top" constant="12" id="hM6-br-iKE"/>
                     <constraint firstItem="6pc-4s-GyP" firstAttribute="leading" secondItem="5UO-MD-Hgx" secondAttribute="leading" id="jvQ-jd-XUJ"/>
-                    <constraint firstAttribute="trailing" secondItem="V8w-dT-7B1" secondAttribute="trailing" constant="16" id="lr7-cG-wNo"/>
                     <constraint firstItem="HGm-lZ-JNr" firstAttribute="top" secondItem="6pc-4s-GyP" secondAttribute="bottom" constant="12" id="m1K-R2-0LQ"/>
                     <constraint firstItem="5UO-MD-Hgx" firstAttribute="leading" secondItem="H2p-sc-9uM" secondAttribute="leading" constant="16" id="nGL-Ta-pBZ"/>
                     <constraint firstAttribute="trailing" secondItem="6pc-4s-GyP" secondAttribute="trailing" constant="84" id="nfE-NI-LX9"/>
                     <constraint firstItem="6pc-4s-GyP" firstAttribute="bottom" secondItem="P8X-Xp-AaE" secondAttribute="bottom" id="q7E-Jg-MYT"/>
+                    <constraint firstItem="SDd-3c-YeL" firstAttribute="bottom" secondItem="AXe-5n-maZ" secondAttribute="bottom" id="qba-9O-tbL"/>
                     <constraint firstItem="HGm-lZ-JNr" firstAttribute="leading" secondItem="H2p-sc-9uM" secondAttribute="leading" constant="16" id="sq9-C3-M3R"/>
                     <constraint firstAttribute="bottom" secondItem="HGm-lZ-JNr" secondAttribute="bottom" id="vJc-aE-MsA"/>
-                    <constraint firstItem="V8w-dT-7B1" firstAttribute="top" secondItem="H2p-sc-9uM" secondAttribute="top" constant="16" id="x1p-sf-n4c"/>
+                    <constraint firstAttribute="trailing" secondItem="SDd-3c-YeL" secondAttribute="trailing" constant="16" id="vay-ux-6dA"/>
                     <constraint firstAttribute="trailing" secondItem="HGm-lZ-JNr" secondAttribute="trailing" id="xt0-86-Efu"/>
                 </constraints>
             </tableViewCellContentView>
@@ -178,11 +163,11 @@
                 <userDefinedRuntimeAttribute type="string" keyPath="styleName" value="Background"/>
             </userDefinedRuntimeAttributes>
             <connections>
-                <outlet property="closedView" destination="V8w-dT-7B1" id="5by-Nb-6Ch"/>
                 <outlet property="distanceLabel" destination="P8X-Xp-AaE" id="Kaw-aR-8uJ"/>
                 <outlet property="infoLabel" destination="vjT-oU-iIA" id="K5N-O7-B0x"/>
                 <outlet property="infoView" destination="AXe-5n-maZ" id="obW-dd-NLt"/>
                 <outlet property="locationLabel" destination="6pc-4s-GyP" id="Te0-y3-sVQ"/>
+                <outlet property="openLabel" destination="SDd-3c-YeL" id="5Rv-fO-g4x"/>
                 <outlet property="popularView" destination="uWz-7m-GUu" id="LAK-NA-Fea"/>
                 <outlet property="titleLabel" destination="4FD-RE-ffF" id="OQm-o8-LUd"/>
                 <outlet property="typeLabel" destination="5UO-MD-Hgx" id="lgJ-zE-omX"/>


### PR DESCRIPTION
Continuing from https://github.com/organicmaps/organicmaps/pull/2403, this PR will add the "Open"/"Opens in"/"Closes in" marker to the search results in the iOS app

By the way, I noticed that the "minute" string in https://github.com/organicmaps/organicmaps/blob/master/data/strings/strings.txt#L13488 is tagged as android only, so I cannot get it from the iOS project. Is there a specific reason why this string is Android only? 

This is how it will look:

![](https://user-images.githubusercontent.com/47610359/180076284-378091b5-6a12-4e55-a443-827a314aace8.png)

