### PR TITLE
download_gtfs.py: feed["spec"] is not "GTFS"

### DIFF
--- a/tools/python/transit/gtfs/download_gtfs.py
+++ b/tools/python/transit/gtfs/download_gtfs.py
@@ -60,7 +60,7 @@ def get_feeds_links(data):
     gtfs_feeds_urls = []
 
     for feed in data:
-        if feed["spec"] != "gtfs":
+        if feed["spec"].lower() != "gtfs":
             continue
 
         if "urls" in feed and feed["urls"] is not None and feed["urls"]:


### PR DESCRIPTION
While using the `download_gtfs.py` script seems that `feed["spec"]` values is `GTFS` not `gtfs`.

Thanks