### PR TITLE
[Linux] Allow to change source directory name

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -156,6 +156,9 @@ designer_version.h
 # Build version
 build_version.hpp
 
+# Source code directory
+source_dir.hpp
+
 #python modules building
 tools/python/*/build
 tools/python/*/dist

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -297,6 +297,7 @@ execute_process(COMMAND tools/unix/version.sh git_hash
 # TODO: Does it run on every build or only on configure step?
 # TODO: Run only when dependent targets are built.
 configure_file(build_version.hpp.in ${CMAKE_SOURCE_DIR}/build_version.hpp @ONLY)
+configure_file(source_dir.hpp.in ${CMAKE_SOURCE_DIR}/source_dir.hpp @ONLY)
 
 # Include 3party dependencies.
 

--- a/platform/platform_linux.cpp
+++ b/platform/platform_linux.cpp
@@ -4,6 +4,8 @@
 
 #include "coding/file_reader.hpp"
 
+#include "source_dir.hpp"
+
 #include "base/exception.hpp"
 #include "base/file_name_utils.hpp"
 #include "base/logging.hpp"
@@ -104,7 +106,7 @@ Platform::Platform()
     std::string const dirsToScan[] = {
         "./data",  // symlink in the current folder
         "../data",  // 'build' folder inside the repo
-        JoinPath(*execDir, "..", "organicmaps", "data"),  // build-omim-{debug,release}
+        JoinPath(*execDir, "..", project_info::SourceDirName(), "data"),  // build-omim-{debug,release}
         JoinPath(*execDir, "..", "share"),  // installed version with packages
         JoinPath(*execDir, "..", "OMaps"),  // installed version without packages
         JoinPath(*execDir, "..", "share", "organicmaps", "data"),  // flatpak-build

--- a/source_dir.hpp.in
+++ b/source_dir.hpp.in
@@ -1,0 +1,13 @@
+#pragma once
+
+#include <string>
+#include <QDir>
+
+namespace project_info {
+inline std::string AbsSourcePath() {
+  return "@CMAKE_SOURCE_DIR@";
+}
+inline std::string SourceDirName() {
+  return QDir(AbsSourcePath().c_str()).dirName().toStdString();
+}
+}


### PR DESCRIPTION
CMake provides info about source directory at the configuration stage, information is stored in the corresponding header file.
these commits fix #3058 