### PR TITLE
Fix coordinates processing if query contains '\n'

### DIFF
--- a/search/latlon_match.cpp
+++ b/search/latlon_match.cpp
@@ -16,7 +16,7 @@ using namespace std;
 namespace
 {
 string const kSpaces = " \t";
-string const kCharsToSkip = " \t,;:.()";
+string const kCharsToSkip = " \n\t,;:.()";
 string const kDecimalMarks = ".,";
 
 bool IsDecimalMark(char c)


### PR DESCRIPTION
fixes  #2682