### PR TITLE
[Android] Fixed advanced timetable editor layout

### DIFF
--- a/android/res/layout/fragment_timetable.xml
+++ b/android/res/layout/fragment_timetable.xml
@@ -15,6 +15,7 @@
     android:layout_below="@id/toolbar"/>
 
   <View
+    android:id="@+id/v__bottom_bar"
     android:layout_width="match_parent"
     android:layout_height="wrap_content"
     android:layout_alignTop="@+id/tv__mode_switch"

--- a/android/src/com/mapswithme/maps/editor/TimetableContainerFragment.java
+++ b/android/src/com/mapswithme/maps/editor/TimetableContainerFragment.java
@@ -75,6 +75,10 @@ public class TimetableContainerFragment extends BaseMwmFragment implements OnBac
   @NonNull
   private TextView mSwitchMode;
 
+  @SuppressWarnings("NullableProblems")
+  @NonNull
+  private View mBottomBar;
+
   @Nullable
   @Override
   public View onCreateView(@NonNull LayoutInflater inflater, ViewGroup container, Bundle savedInstanceState)
@@ -117,9 +121,10 @@ public class TimetableContainerFragment extends BaseMwmFragment implements OnBac
   @Override
   public void onTimetableChanged(@Nullable String timetable)
   {
-    UiUtils.showIf(TextUtils.isEmpty(timetable)
-                           || OpeningHours.nativeTimetablesFromString(timetable) != null,
-                   mSwitchMode);
+    boolean isValidTimetable = TextUtils.isEmpty(timetable)
+                               || OpeningHours.nativeTimetablesFromString(timetable) != null;
+    UiUtils.showIf(isValidTimetable, mSwitchMode);
+    UiUtils.showIf(isValidTimetable, mBottomBar);
   }
 
   @Override
@@ -132,6 +137,7 @@ public class TimetableContainerFragment extends BaseMwmFragment implements OnBac
   {
     mSwitchMode = root.findViewById(R.id.tv__mode_switch);
     mSwitchMode.setOnClickListener(v -> switchMode());
+    mBottomBar = root.findViewById(R.id.v__bottom_bar);
   }
 
   private void switchMode()


### PR DESCRIPTION
Fixing issue #3077 

The problem is caused by white bar at the bottom. It's bound to "Simple mode" button. And when the button is hidden the bar height becomes too big.

Fix: If opening_hours format is invalid, then hide both button and it's background.

| Normal layout | Wrong OH format |
| -------------- | --------- |
| <img width="437" alt="Normal layout" src="https://user-images.githubusercontent.com/720808/184106845-7e319427-6d50-4775-8062-2f9775ecb082.png"> | <img width="436" alt="Wrong OH format" src="https://user-images.githubusercontent.com/720808/184106901-5db42360-c2c8-4d9e-bf85-a469e54b276f.png"> |


