### PR TITLE
[iPhone] Increased visibility of next street

### DIFF
--- a/iphone/Maps/Classes/CustomViews/NavigationDashboard/Views/MWMNavigationInfoView.mm
+++ b/iphone/Maps/Classes/CustomViews/NavigationDashboard/Views/MWMNavigationInfoView.mm
@@ -339,6 +339,11 @@ BOOL defaultOrientation(CGSize const &size) {
 
 - (void)refreshLayout {
   dispatch_async(dispatch_get_main_queue(), ^{
+    if (UIDeviceOrientationIsLandscape([UIDevice currentDevice].orientation))
+      self.streetNameLabel.numberOfLines = 1;
+    else
+      self.streetNameLabel.numberOfLines = 2;
+
     auto const availableArea = self.availableArea;
     [self animateConstraintsWithAnimations:^{
       self.topConstraint.constant = availableArea.origin.y;

--- a/iphone/Maps/Classes/CustomViews/NavigationDashboard/Views/MWMNavigationInfoView.xib
+++ b/iphone/Maps/Classes/CustomViews/NavigationDashboard/Views/MWMNavigationInfoView.xib
@@ -104,12 +104,12 @@
                                 <userDefinedRuntimeAttribute type="string" keyPath="styleName" value="StreetNameBackgroundView"/>
                             </userDefinedRuntimeAttributes>
                         </view>
-                        <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" horizontalCompressionResistancePriority="600" verticalCompressionResistancePriority="600" text="Ленинградский проспект" textAlignment="center" lineBreakMode="wordWrap" numberOfLines="0" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="ShI-bz-5g8">
+                        <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" horizontalCompressionResistancePriority="600" verticalCompressionResistancePriority="600" text="Ленинградский проспект" textAlignment="center" lineBreakMode="truncatingTail" numberOfLines="0" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="YES" translatesAutoresizingMaskIntoConstraints="NO" minimumScaleFactor="0.5" id="ShI-bz-5g8">
                             <rect key="frame" x="204" y="24" width="900" height="21.5"/>
                             <accessibility key="accessibilityConfiguration">
                                 <accessibilityTraits key="traits" staticText="YES" notEnabled="YES"/>
                             </accessibility>
-                            <fontDescription key="fontDescription" type="boldSystem" pointSize="18"/>
+                            <fontDescription key="fontDescription" type="boldSystem" pointSize="24"/>
                             <color key="textColor" red="0.0" green="0.0" blue="0.0" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
                             <nil key="highlightedColor"/>
                             <userDefinedRuntimeAttributes>


### PR DESCRIPTION
Now label max lines are 2 for portrait and 1 for landscape (was unlimited).
Font increased from 18 to 24 (like many other fonts on this screen). Scaled till 0.5.

Horizontal. Unscaled.
![image](https://user-images.githubusercontent.com/85622715/185391431-7aa331f6-4717-4645-8d9f-24aae5f423de.png)

Horizontal. Scaled font:
![image](https://user-images.githubusercontent.com/85622715/185390518-25e22ce9-1251-45ed-97ed-2bc18cdda866.png)

Vertical. Scaled and Unscaled.
![image](https://user-images.githubusercontent.com/85622715/185391986-a3bdecc5-5484-422b-88fd-1ea94f01a8b7.png)