### PR TITLE
[generator] Social pages normalization changes

### DIFF
--- a/android/src/com/mapswithme/maps/widget/placepage/PlacePageView.java
+++ b/android/src/com/mapswithme/maps/widget/placepage/PlacePageView.java
@@ -1009,36 +1009,18 @@ public class PlacePageView extends NestedScrollViewClickFixed
   private void refreshSocialLinks(@NonNull MapObject mapObject)
   {
     final String facebookPageLink = mapObject.getMetadata(Metadata.MetadataType.FMD_CONTACT_FACEBOOK);
-    refreshSocialPageLink(mFacebookPage, mTvFacebookPage, facebookPageLink, "facebook.com");
+    refreshSocialPageLink(mFacebookPage, mTvFacebookPage, facebookPageLink);
     final String instagramPageLink = mapObject.getMetadata(Metadata.MetadataType.FMD_CONTACT_INSTAGRAM);
-    refreshSocialPageLink(mInstagramPage, mTvInstagramPage, instagramPageLink, "instagram.com");
+    refreshSocialPageLink(mInstagramPage, mTvInstagramPage, instagramPageLink);
     final String twitterPageLink = mapObject.getMetadata(Metadata.MetadataType.FMD_CONTACT_TWITTER);
-    refreshSocialPageLink(mTwitterPage, mTvTwitterPage, twitterPageLink, "twitter.com");
+    refreshSocialPageLink(mTwitterPage, mTvTwitterPage, twitterPageLink);
     final String vkPageLink = mapObject.getMetadata(Metadata.MetadataType.FMD_CONTACT_VK);
-    refreshSocialPageLink(mVkPage, mTvVkPage, vkPageLink, "vk.com");
+    refreshSocialPageLink(mVkPage, mTvVkPage, vkPageLink);
     final String linePageLink = mapObject.getMetadata(Metadata.MetadataType.FMD_CONTACT_LINE);
-    refreshLinePageLink(mLinePage, mTvLinePage, linePageLink);
+    refreshSocialPageLink(mLinePage, mTvLinePage, linePageLink);
   }
 
-  private void refreshSocialPageLink(View view, TextView tvSocialPage, String socialPage, String webDomain)
-  {
-    if (TextUtils.isEmpty(socialPage))
-    {
-      view.setVisibility(GONE);
-    }
-    else
-    {
-      view.setVisibility(VISIBLE);
-      if (socialPage.indexOf('/') >= 0)
-        tvSocialPage.setText("https://" + webDomain + "/" + socialPage);
-      else
-        tvSocialPage.setText("@" + socialPage);
-    }
-  }
-
-  // Tag `contact:line` could contain urls from domains: line.me, liff.line.me, page.line.me, etc.
-  // And `socialPage` should not be prepended with domain, but only with "https://" protocol.
-  private void refreshLinePageLink(View view, TextView tvSocialPage, String socialPage)
+  private void refreshSocialPageLink(View view, TextView tvSocialPage, String socialPage)
   {
     if (TextUtils.isEmpty(socialPage))
     {
@@ -1356,26 +1338,23 @@ public class PlacePageView extends NestedScrollViewClickFixed
         break;
       case R.id.ll__place_facebook:
         final String facebookPage = mMapObject.getMetadata(Metadata.MetadataType.FMD_CONTACT_FACEBOOK);
-        Utils.openUrl(getContext(), "https://m.facebook.com/"+facebookPage);
+        Utils.openUrl(getContext(), facebookPage.contains("/") ? "https://"+facebookPage : "https://m.facebook.com/"+facebookPage);
         break;
       case R.id.ll__place_instagram:
         final String instagramPage = mMapObject.getMetadata(Metadata.MetadataType.FMD_CONTACT_INSTAGRAM);
-        Utils.openUrl(getContext(), "https://instagram.com/"+instagramPage);
+        Utils.openUrl(getContext(), instagramPage.contains("/") ? "https://"+instagramPage : "https://instagram.com/"+instagramPage);
         break;
       case R.id.ll__place_twitter:
         final String twitterPage = mMapObject.getMetadata(Metadata.MetadataType.FMD_CONTACT_TWITTER);
-        Utils.openUrl(getContext(), "https://mobile.twitter.com/"+twitterPage);
+        Utils.openUrl(getContext(), twitterPage.contains("/") ? "https://"+twitterPage : "https://mobile.twitter.com/"+twitterPage);
         break;
       case R.id.ll__place_vk:
         final String vkPage = mMapObject.getMetadata(Metadata.MetadataType.FMD_CONTACT_VK);
-        Utils.openUrl(getContext(), "https://vk.com/" + vkPage);
+        Utils.openUrl(getContext(), vkPage.contains("/") ? "https://" + vkPage : "https://vk.com/" + vkPage);
         break;
       case R.id.ll__place_line:
         final String linePage = mMapObject.getMetadata(Metadata.MetadataType.FMD_CONTACT_LINE);
-        if (linePage.indexOf('/') >= 0)
-          Utils.openUrl(getContext(), "https://" + linePage);
-        else
-          Utils.openUrl(getContext(), "https://line.me/R/ti/p/@" + linePage);
+        Utils.openUrl(getContext(), linePage.contains("/") ? "https://" + linePage : "https://line.me/R/ti/p/@" + linePage);
         break;
       case R.id.ll__place_wiki:
         Utils.openUrl(getContext(), mMapObject.getMetadata(Metadata.MetadataType.FMD_WIKIPEDIA));
@@ -1449,36 +1428,52 @@ public class PlacePageView extends NestedScrollViewClickFixed
       case R.id.ll__place_facebook:
         final String facebookPage = mMapObject.getMetadata(Metadata.MetadataType.FMD_CONTACT_FACEBOOK);
         if (facebookPage.indexOf('/') == -1)
+        {
           items.add(facebookPage); // Show username along with URL.
-        items.add("https://m.facebook.com/" + facebookPage);
+          items.add("https://m.facebook.com/" + facebookPage);
+        }
+        else
+          items.add("https://" + facebookPage);
         break;
       case R.id.ll__place_instagram:
         final String instagramPage = mMapObject.getMetadata(Metadata.MetadataType.FMD_CONTACT_INSTAGRAM);
         if (instagramPage.indexOf('/') == -1)
+        {
           items.add(instagramPage); // Show username along with URL.
-        items.add("https://instagram.com/" + instagramPage);
+          items.add("https://instagram.com/" + instagramPage);
+        }
+        else
+          items.add("https://" + instagramPage);
         break;
       case R.id.ll__place_twitter:
         final String twitterPage = mMapObject.getMetadata(Metadata.MetadataType.FMD_CONTACT_TWITTER);
         if (twitterPage.indexOf('/') == -1)
+        {
           items.add(twitterPage); // Show username along with URL.
-        items.add("https://mobile.twitter.com/" + twitterPage);
+          items.add("https://mobile.twitter.com/" + twitterPage);
+        }
+        else
+          items.add("https://" + twitterPage);
         break;
       case R.id.ll__place_vk:
         final String vkPage = mMapObject.getMetadata(Metadata.MetadataType.FMD_CONTACT_VK);
         if (vkPage.indexOf('/') == -1)
+        {
           items.add(vkPage); // Show username along with URL.
-        items.add("https://vk.com/" + vkPage);
+          items.add("https://vk.com/" + vkPage);
+        }
+        else
+          items.add("https://" + vkPage);
         break;
       case R.id.ll__place_line:
         final String linePage = mMapObject.getMetadata(Metadata.MetadataType.FMD_CONTACT_LINE);
-        if (linePage.indexOf('/') >= 0)
-          items.add("https://" + linePage);
-        else
+        if (linePage.indexOf('/') == -1)
         {
           items.add(linePage); // Show username along with URL.
           items.add("https://line.me/R/ti/p/@" + linePage);
         }
+        else
+          items.add("https://" + linePage);
         break;
       case R.id.ll__place_email:
         items.add(mTvEmail.getText().toString());

--- a/generator/generator_tests/metadata_parser_test.cpp
+++ b/generator/generator_tests/metadata_parser_test.cpp
@@ -319,15 +319,15 @@ UNIT_CLASS_TEST(TestWithClassificator, ValidateAndFormat_facebook)
   md.Drop(Metadata::FMD_CONTACT_FACEBOOK);
 
   p("contact:facebook", "https://facebook.com/238702340219158/posts/284664265622965");
-  TEST_EQUAL(md.Get(Metadata::FMD_CONTACT_FACEBOOK), "238702340219158/posts/284664265622965", ());
+  TEST_EQUAL(md.Get(Metadata::FMD_CONTACT_FACEBOOK), "facebook.com/238702340219158/posts/284664265622965", ());
   md.Drop(Metadata::FMD_CONTACT_FACEBOOK);
 
   p("contact:facebook", "https://facebook.com/238702340219158/posts/284664265622965");
-  TEST_EQUAL(md.Get(Metadata::FMD_CONTACT_FACEBOOK), "238702340219158/posts/284664265622965", ());
+  TEST_EQUAL(md.Get(Metadata::FMD_CONTACT_FACEBOOK), "facebook.com/238702340219158/posts/284664265622965", ());
   md.Drop(Metadata::FMD_CONTACT_FACEBOOK);
 
   p("contact:facebook", "https://fr-fr.facebook.com/people/Paillote-Lgm/100012630853826/");
-  TEST_EQUAL(md.Get(Metadata::FMD_CONTACT_FACEBOOK), "people/Paillote-Lgm/100012630853826", ());
+  TEST_EQUAL(md.Get(Metadata::FMD_CONTACT_FACEBOOK), "facebook.com/people/Paillote-Lgm/100012630853826", ());
   md.Drop(Metadata::FMD_CONTACT_FACEBOOK);
 
   p("contact:facebook", "https://www.sandwichparlour.com.au/");
@@ -368,15 +368,15 @@ UNIT_CLASS_TEST(TestWithClassificator, ValidateAndFormat_instagram)
   md.Drop(Metadata::FMD_CONTACT_INSTAGRAM);
 
   p("contact:instagram", "https://www.instagram.com/explore/locations/358536820/trivium-sport-en-dance/");
-  TEST_EQUAL(md.Get(Metadata::FMD_CONTACT_INSTAGRAM), "explore/locations/358536820/trivium-sport-en-dance", ());
+  TEST_EQUAL(md.Get(Metadata::FMD_CONTACT_INSTAGRAM), "instagram.com/explore/locations/358536820/trivium-sport-en-dance", ());
   md.Drop(Metadata::FMD_CONTACT_INSTAGRAM);
 
   p("contact:instagram", "https://www.instagram.com/explore/tags/boojum/");
-  TEST_EQUAL(md.Get(Metadata::FMD_CONTACT_INSTAGRAM), "explore/tags/boojum", ());
+  TEST_EQUAL(md.Get(Metadata::FMD_CONTACT_INSTAGRAM), "instagram.com/explore/tags/boojum", ());
   md.Drop(Metadata::FMD_CONTACT_INSTAGRAM);
 
   p("contact:instagram", "https://www.instagram.com/p/BvkgKZNDbqN");
-  TEST_EQUAL(md.Get(Metadata::FMD_CONTACT_INSTAGRAM), "p/BvkgKZNDbqN", ());
+  TEST_EQUAL(md.Get(Metadata::FMD_CONTACT_INSTAGRAM), "instagram.com/p/BvkgKZNDbqN", ());
   md.Drop(Metadata::FMD_CONTACT_INSTAGRAM);
 
   p("contact:instagram", "dharampura road");
@@ -399,7 +399,7 @@ UNIT_CLASS_TEST(TestWithClassificator, ValidateAndFormat_twitter)
   TEST(md.Empty(), ());
 
   p("contact:twitter", "https://twitter.com/hashtag/sotanosiete");
-  TEST_EQUAL(md.Get(Metadata::FMD_CONTACT_TWITTER), "hashtag/sotanosiete", ());
+  TEST_EQUAL(md.Get(Metadata::FMD_CONTACT_TWITTER), "twitter.com/hashtag/sotanosiete", ());
   md.Drop(Metadata::FMD_CONTACT_TWITTER);
 
   p("contact:twitter", "twitter.com/osm_tech");

--- a/indexer/indexer_tests/validate_and_format_contacts_test.cpp
+++ b/indexer/indexer_tests/validate_and_format_contacts_test.cpp
@@ -14,6 +14,8 @@ UNIT_TEST(EditableMapObject_ValidateAndFormat_facebook)
   TEST_EQUAL(osm::ValidateAndFormat_facebook("http://www.facebook.com/OpenStreetMap"), "OpenStreetMap", ());
   TEST_EQUAL(osm::ValidateAndFormat_facebook("https://www.facebook.com/OpenStreetMap"), "OpenStreetMap", ());
   TEST_EQUAL(osm::ValidateAndFormat_facebook("https://en-us.facebook.com/OpenStreetMap"), "OpenStreetMap", ());
+  TEST_EQUAL(osm::ValidateAndFormat_facebook("https://fr.facebook.com/pages/Daikichi-Japans-Restaurant/118163444928138"), "facebook.com/pages/Daikichi-Japans-Restaurant/118163444928138", ());
+  TEST_EQUAL(osm::ValidateAndFormat_facebook("fr-fr.facebook.com/people/Paillote-Lgm/100012630853826/"), "facebook.com/people/Paillote-Lgm/100012630853826", ());
   TEST_EQUAL(osm::ValidateAndFormat_facebook("some.good.page"), "some.good.page", ());
   TEST_EQUAL(osm::ValidateAndFormat_facebook("@tree-house-interiors"), "tree-house-interiors", ());
 
@@ -35,8 +37,8 @@ UNIT_TEST(EditableMapObject_ValidateAndFormat_instagram)
   TEST_EQUAL(osm::ValidateAndFormat_instagram("https://www.instagram.com/openstreetmapus"), "openstreetmapus", ());
   TEST_EQUAL(osm::ValidateAndFormat_instagram("https://en-us.instagram.com/openstreetmapus"), "openstreetmapus", ());
   TEST_EQUAL(osm::ValidateAndFormat_instagram("@open_street_map_us"), "open_street_map_us", ());
-  TEST_EQUAL(osm::ValidateAndFormat_instagram("https://www.instagram.com/explore/locations/358536820/trivium-sport-en-dance/"), "explore/locations/358536820/trivium-sport-en-dance", ());
-  TEST_EQUAL(osm::ValidateAndFormat_instagram("https://www.instagram.com/p/BvkgKZNDbqN/?ghid=UwPchX7B"), "p/BvkgKZNDbqN", ());
+  TEST_EQUAL(osm::ValidateAndFormat_instagram("https://www.instagram.com/explore/locations/358536820/trivium-sport-en-dance/"), "instagram.com/explore/locations/358536820/trivium-sport-en-dance", ());
+  TEST_EQUAL(osm::ValidateAndFormat_instagram("https://www.instagram.com/p/BvkgKZNDbqN/?ghid=UwPchX7B"), "instagram.com/p/BvkgKZNDbqN", ());
 
   TEST_EQUAL(osm::ValidateAndFormat_instagram("facebook.com/osm_us"), "", ());
   TEST_EQUAL(osm::ValidateAndFormat_instagram(".dots_not_allowed."), "", ());
@@ -51,6 +53,7 @@ UNIT_TEST(EditableMapObject_ValidateAndFormat_twitter)
   TEST_EQUAL(osm::ValidateAndFormat_twitter("https://twitter.com/osm_tech"), "osm_tech", ());
   TEST_EQUAL(osm::ValidateAndFormat_twitter("http://www.twitter.com/osm_tech"), "osm_tech", ());
   TEST_EQUAL(osm::ValidateAndFormat_twitter("https://www.twitter.com/osm_tech"), "osm_tech", ());
+  TEST_EQUAL(osm::ValidateAndFormat_twitter("https://twitter.com/hashtag/sotanosiete"), "twitter.com/hashtag/sotanosiete", ());
   TEST_EQUAL(osm::ValidateAndFormat_twitter("@_osm_tech_"), "_osm_tech_", ());
 
   TEST_EQUAL(osm::ValidateAndFormat_twitter("instagram.com/osm_tech"), "", ());

--- a/indexer/validate_and_format_contacts.cpp
+++ b/indexer/validate_and_format_contacts.cpp
@@ -94,7 +94,7 @@ string ValidateAndFormat_facebook(string const & facebookPage)
     auto webPath = url.GetPath();
     // Strip last '/' symbol
     webPath.erase(webPath.find_last_not_of('/') + 1);
-    return webPath;
+    return (webPath.find('/') == string::npos) ? webPath : ("facebook.com/" + webPath);
   }
 
   return {};
@@ -123,7 +123,7 @@ string ValidateAndFormat_instagram(string const & instagramPage)
     auto webPath = url.GetPath();
     // Strip last '/' symbol.
     webPath.erase(webPath.find_last_not_of('/') + 1);
-    return webPath;
+    return (webPath.find('/') == string::npos) ? webPath : ("instagram.com/" + webPath);
   }
 
   return {};
@@ -155,7 +155,7 @@ string ValidateAndFormat_twitter(string const & twitterPage)
     webPath.erase(webPath.find_last_not_of('/') + 1);
     webPath.erase(0, webPath.find_first_not_of('@'));
 
-    return webPath;
+    return (webPath.find('/') == string::npos) ? webPath : ("twitter.com/" + webPath);
   }
 
   return {};
@@ -194,7 +194,7 @@ string ValidateAndFormat_vk(string const & vkPage)
     auto webPath = url.GetPath();
     // Strip last '/' symbol.
     webPath.erase(webPath.find_last_not_of('/') + 1);
-    return webPath;
+    return (webPath.find('/') == string::npos) ? webPath : ("vk.com/" + webPath);
   }
 
   return {};


### PR DESCRIPTION
Closes issue #2787 #3089

| OSM data<br/> User input | After normalization |
| --------------- | --------------- |
| `https://facebook.com/pages/Daikichi-Japans-Restaurant/118163444928138` | Old: `pages/Daikichi-Japans-Restaurant/118163444928138` <br/> New: `facebook.com/pages/Daikichi-Japans-Restaurant/118163444928138` |
| `https://www.instagram.com/p/BvkgKZNDbqN/?ghid=UwPchX7B` | Old: `p/BvkgKZNDbqN` <br/> New: `instagram.com/p/BvkgKZNDbqN` |
| `www.facebook.com/OpenStreetMap` | `OpenStreetMap` |

The problem is some URLs after normalization are not valid because domain name is removed. I fixed the issue by keeping domain name when we import OSM data or consume user input.

As far as I can tell this change could break backward compatibility. New PlacePage code expects that domain name is present and with old map data this could cause bad experience.

Updated unittests.

N.B.: Other solution would be to automatically prepend domain name at `EditorFragment.java` depending on `Metadata.MetadataType`.