### PR TITLE
Revert "Temporarily disable OSM auth tests"

### DIFF
--- a/.github/workflows/linux-check.yaml
+++ b/.github/workflows/linux-check.yaml
@@ -154,7 +154,6 @@ jobs:
             -e routing_consistency_tests \
             -e opening_hours_supported_features_tests \
             -e storage_integration_tests \
-            -e osm_auth_tests \  # Disable temporarily while OSM dev server is down.
 
   linux-appstream:
     name: Linux validate appstream data


### PR DESCRIPTION
https://master.apis.dev.openstreetmap.org is working again

This reverts commit b3def7daf49b9034c2e13950910b8606d50a71d9.