### PR TITLE
[android] Increased the font size of exit number

### DIFF
--- a/android/res/values-sw720dp/font_sizes.xml
+++ b/android/res/values-sw720dp/font_sizes.xml
@@ -2,7 +2,7 @@
 <resources>
   <dimen name="text_size_nav_street">26sp</dimen>
   <dimen name="text_size_nav_next_turn">32sp</dimen>
-  <dimen name="text_size_nav_circle_exit">16sp</dimen>
+  <dimen name="text_size_nav_circle_exit">30sp</dimen>
   <dimen name="text_size_nav_number">36sp</dimen>
   <dimen name="text_size_nav_dimension">30sp</dimen>
 </resources>

--- a/android/res/values/font_sizes.xml
+++ b/android/res/values/font_sizes.xml
@@ -55,7 +55,7 @@
 
   <dimen name="text_size_nav_street">17sp</dimen>
   <dimen name="text_size_nav_next_turn">24sp</dimen>
-  <dimen name="text_size_nav_circle_exit">12sp</dimen>
+  <dimen name="text_size_nav_circle_exit">20sp</dimen>
   <dimen name="text_size_nav_number">24sp</dimen>
   <dimen name="text_size_nav_dimension">20sp</dimen>
   <dimen name="text_size_nav_menu_number">28sp</dimen>


### PR DESCRIPTION
fixes #2198
Increased the font size for the roundabout exit number in navigation mode.

# Screenshots

## Phone (Portrait Mode)
![phone_p1](https://user-images.githubusercontent.com/76740999/187069726-d3bfc340-5765-41f6-b362-e25dbb947328.png)

## Phone (Landscape Mode)
![phone_l1](https://user-images.githubusercontent.com/76740999/187069727-7917fc0f-aebe-4eb9-b38f-bdc61e1cedab.png)

## Tablet (Portrait Mode)
![tablet_p1](https://user-images.githubusercontent.com/76740999/187069730-e84bd8ad-1e67-4d8f-9856-a8a51f789fcb.png)

## Tablet (Landscape Mode)
![tablet_l1](https://user-images.githubusercontent.com/76740999/187069734-6457b3b9-7873-4715-9273-0f7c34b381ee.png)

Signed-off-by: pratyaksh1610 <pratyakshkhuranaofficial@gmail.com>