### PR TITLE
[string] Fix Italian generic "Stop": set "Bus stop" + "Bus tram"

### DIFF
--- a/data/categories.txt
+++ b/data/categories.txt
@@ -2126,7 +2126,7 @@ fr:Arrêt de bus|2bus|arrêt|2autobus
 de:Bushaltestelle|Haltestelle|2Bus|Autobus|ÖPNV
 hu:2Buszmegálló|2busz|megálló
 id:3Halte bus
-it:3Fermata|autobus
+it:3Fermata|3autobus|3pullman
 ja:1バス停|停留所|トランスポート|バス|乗合|交通|ばす
 ko:버스 정류장|버스
 mr:बस स्टॉप|बस थांबा
@@ -2162,7 +2162,7 @@ fr:Arrêt de tramway|3tramway|tram|arrêt
 de:4Straßenbahnhaltestelle|Tramhaltestelle|Haltestelle|Tram|ÖPNV
 hu:4Villamosmegálló|3villamos|megálló
 id:3Perhentian trem
-it:Fermata|tram
+it:3Fermata|3tram
 ja:1トラム|トラム停留所|市電|トランスポート|交通|路面電車
 ko:시가 전차 정류장|시가 전차
 nb:3Trikkestopp

--- a/data/strings/types_strings.txt
+++ b/data/strings/types_strings.txt
@@ -8453,7 +8453,7 @@
     fr = Arrêt de bus
     hu = Buszmegálló
     id = Halte bus
-    it = Fermata
+    it = Fermata dell'autobus
     ja = バス停
     ko = 버스 정류장
     mr = बस थांबा
@@ -16739,7 +16739,7 @@
     fr = Arrêt de tramway
     hu = Villamosmegálló
     id = Perhentian trem
-    it = Fermata
+    it = Fermata del tram
     ja = トラム
     ko = 트램 정류장
     mr = ट्राम थांबा


### PR DESCRIPTION
This small change allows many people in Italy not to confuse search results related to tram and bus stops (and train stations): now all of them have a different description.

This bug was originally reported by @amreo during an OpenStreetMap mapping party in the lovely La Pigna, Sanremo (Italy):

https://scambi.org/2022/lab/18/

Added the `Signed-off-by` as expected but I've not executed the `ruby` stuff, sorry.

Please note (since in some projects it's a problem in compilation): There is an apostrophe character in my translation: `'`

This change also adds the ability to search "pullman" (widely used in Torino) plus a couple of autocomplete limitation (3 characters).

Thank you for this amazing Free/Libre and Open Source Project.