### PR TITLE
[generator] Update checks for wikimedia_commons tag

### DIFF
--- a/generator/osm2meta.cpp
+++ b/generator/osm2meta.cpp
@@ -289,6 +289,13 @@ string MetadataTagProcessorImpl::ValidateAndFormat_wikipedia(string v) const
 
 string MetadataTagProcessorImpl::ValidateAndFormat_wikimedia_commons(string v) const
 {
+
+    // Putting the full wikimedia url to this tag is incorrect according to:
+    // https://wiki.openstreetmap.org/wiki/Key:wikimedia_commons
+    // But it happens often enough that we should guard against it.
+    strings::ReplaceFirst(v, "https://commons.wikimedia.org/wiki/", "");
+    strings::ReplaceFirst(v, "https://commons.m.wikimedia.org/wiki/", "");
+
     if(strings::StartsWith(v, "File:") || strings::StartsWith(v, "Category:"))
     {
         return v;


### PR DESCRIPTION
This tag is frequenty misused and a full url is provided.
It's incorrect but happens so often that we should protect against it.