### PR TITLE
[Experimental] Avoid unneeded initialization in buffer_vector::resize.

### DIFF
--- a/base/base_tests/buffer_vector_test.cpp
+++ b/base/base_tests/buffer_vector_test.cpp
@@ -145,16 +145,6 @@ UNIT_TEST(BufferVectorSwap)
   }
 }
 
-UNIT_TEST(BufferVectorZeroInitialized)
-{
-  for (size_t size = 0; size < 20; ++size)
-  {
-    buffer_vector<int, 5> v(size);
-    for (size_t i = 0; i < size; ++i)
-      TEST_EQUAL(v[i], 0, ());
-  }
-}
-
 UNIT_TEST(BufferVectorResize)
 {
   for (size_t size = 0; size < 20; ++size)
@@ -347,7 +337,7 @@ void TestVector(VectorT const & v, size_t sz)
     TEST_EQUAL(v[i].m_s, strings::to_string(i), ());
 }
 
-}
+} // namespace
 
 UNIT_TEST(BufferVectorMove)
 {

--- a/base/string_utils.hpp
+++ b/base/string_utils.hpp
@@ -34,7 +34,8 @@ public:
   using value_type = UniChar;
 
   UniString() {}
-  explicit UniString(size_t n, UniChar c = UniChar()) : BaseT(n, c) {}
+  explicit UniString(size_t n) : BaseT(n) {}
+  UniString(size_t n, UniChar c) { resize(n, c); }
 
   template <typename Iter>
   UniString(Iter b, Iter e) : BaseT(b, e)

--- a/coding/var_record_reader.hpp
+++ b/coding/var_record_reader.hpp
@@ -1,13 +1,8 @@
 #pragma once
 
-#include "coding/byte_stream.hpp"
 #include "coding/reader.hpp"
 #include "coding/varint.hpp"
 
-#include "base/base.hpp"
-
-#include <algorithm>
-#include <cstdint>
 #include <string>
 #include <vector>
 
@@ -16,7 +11,7 @@ template <class ReaderT>
 class VarRecordReader
 {
 public:
-  VarRecordReader(ReaderT const & reader) : m_reader(reader) {}
+  explicit VarRecordReader(ReaderT const & reader) : m_reader(reader) {}
 
   std::vector<uint8_t> ReadRecord(uint64_t const pos) const
   {
@@ -29,7 +24,7 @@ public:
     return buffer;
   }
 
-  void ForEachRecord(std::function<void(uint32_t, std::vector<uint8_t> &&)> const & f) const
+  template <class FnT> void ForEachRecord(FnT && fn) const
   {
     ReaderSource source(m_reader);
     while (source.Size() > 0)
@@ -38,10 +33,10 @@ public:
       uint32_t const recordSize = ReadVarUint<uint32_t>(source);
       std::vector<uint8_t> buffer(recordSize);
       source.Read(buffer.data(), recordSize);
-      f(static_cast<uint32_t>(pos), std::move(buffer));
+      fn(static_cast<uint32_t>(pos), std::move(buffer));
     }
   }
 
-protected:
+private:
   ReaderT m_reader;
 };

--- a/generator/feature_builder.cpp
+++ b/generator/feature_builder.cpp
@@ -3,7 +3,6 @@
 #include "routing/routing_helpers.hpp"
 
 #include "indexer/feature_algo.hpp"
-#include "indexer/feature_impl.hpp"
 #include "indexer/feature_visibility.hpp"
 #include "indexer/ftypes_matcher.hpp"
 #include "indexer/search_string_utils.hpp"
@@ -348,12 +347,11 @@ bool FeatureBuilder::operator==(FeatureBuilder const & fb) const
 
 bool FeatureBuilder::IsExactEq(FeatureBuilder const & fb) const
 {
-  return m_center == fb.m_center &&
-      m_polygons == fb.m_polygons &&
-      m_limitRect == fb.m_limitRect &&
-      m_osmIds == fb.m_osmIds &&
-      m_params == fb.m_params &&
-      m_coastCell == fb.m_coastCell;
+  if (m_params.GetGeomType() == GeomType::Point && m_center != fb.m_center)
+    return false;
+
+  return (m_polygons == fb.m_polygons && m_limitRect == fb.m_limitRect &&
+          m_osmIds == fb.m_osmIds && m_params == fb.m_params && m_coastCell == fb.m_coastCell);
 }
 
 void FeatureBuilder::SerializeForIntermediate(Buffer & data) const

--- a/generator/generator_tests/feature_builder_test.cpp
+++ b/generator/generator_tests/feature_builder_test.cpp
@@ -5,10 +5,8 @@
 #include "generator/feature_builder.hpp"
 #include "generator/generator_tests_support/test_with_classificator.hpp"
 #include "generator/geometry_holder.hpp"
-#include "generator/osm2type.hpp"
 
 #include "indexer/data_header.hpp"
-#include "indexer/classificator_loader.hpp"
 #include "indexer/feature_visibility.hpp"
 
 #include "base/geo_object_id.hpp"
@@ -250,7 +248,7 @@ UNIT_CLASS_TEST(TestWithClassificator, FeatureBuilder_SerializeLocalityObjectFor
   fb.SerializeLocalityObject(serial::GeometryCodingParams(), buffer);
 }
 
-UNIT_TEST(FeatureBuilder_SerializeAccuratelyForIntermediate)
+UNIT_CLASS_TEST(TestWithClassificator, FeatureBuilder_SerializeAccuratelyForIntermediate)
 {
   FeatureBuilder fb1;
   FeatureBuilderParams params;

--- a/generator/generator_tests_support/test_feature.cpp
+++ b/generator/generator_tests_support/test_feature.cpp
@@ -70,9 +70,8 @@ TestFeature::TestFeature(m2::PointD const & center, StringUtf8Multilang const & 
   Init();
 }
 
-TestFeature::TestFeature(vector<m2::PointD> const & boundary, string const & name,
-                         string const & lang)
-  : m_id(GenUniqueId()), m_boundary(boundary), m_type(Type::Area)
+TestFeature::TestFeature(vector<m2::PointD> const & boundary, string const & name, string const & lang)
+  : m_id(GenUniqueId()), m_center(0, 0), m_boundary(boundary), m_type(Type::Area)
 {
   m_names.AddString(lang, name);
   m_names.AddString("default", name);

--- a/geometry/point2d.hpp
+++ b/geometry/point2d.hpp
@@ -1,13 +1,11 @@
 #pragma once
 
 #include "base/assert.hpp"
-#include "base/base.hpp"
 #include "base/math.hpp"
 #include "base/matrix.hpp"
 
 #include <array>
 #include <cmath>
-#include <functional>
 #include <limits>
 #include <sstream>
 #include <typeinfo>
@@ -22,8 +20,7 @@ public:
 
   T x, y;
 
-  constexpr Point() : x(T()), y(T()) {}
-
+  Point() = default;
   constexpr Point(T x_, T y_) : x(x_), y(y_) {}
 
   template <typename U>

--- a/geometry/point3d.hpp
+++ b/geometry/point3d.hpp
@@ -12,8 +12,8 @@ template <typename T>
 class Point
 {
 public:
-  constexpr Point() : x(T()), y(T()), z(T()) {}
-  constexpr Point(T const & x, T const & y, T const & z) : x(x), y(y), z(z) {}
+  Point() = default;
+  constexpr Point(T x_, T y_, T z_) : x(x_), y(y_), z(z_) {}
 
   T Length() const { return std::sqrt(x * x + y * y + z * z); }
 

--- a/indexer/interval_index.hpp
+++ b/indexer/interval_index.hpp
@@ -78,7 +78,7 @@ private:
       uint64_t keyBase /* discarded part of object key value in the parent nodes*/) const
   {
     buffer_vector<uint8_t, 1024> data;
-    data.resize_no_init(size);
+    data.resize(size);
 
     m_Reader.Read(offset, &data[0], size);
     ArrayByteSource src(&data[0]);
@@ -103,6 +103,7 @@ private:
       uint32_t offset, uint32_t size,
       uint64_t keyBase /* discarded part of object key value in the parent nodes */) const
   {
+    ASSERT(size > 0, ());
     offset += m_LevelOffsets[level];
 
     if (level == 0)
@@ -120,7 +121,7 @@ private:
     ASSERT_LESS(end0, (1U << m_Header.m_BitsPerLevel), (beg, end, skipBits));
 
     buffer_vector<uint8_t, 576> data;
-    data.resize_no_init(size);
+    data.resize(size);
 
     m_Reader.Read(offset, &data[0], size);
     ArrayByteSource src(&data[0]);

--- a/indexer/interval_index_builder.hpp
+++ b/indexer/interval_index_builder.hpp
@@ -8,11 +8,9 @@
 #include "coding/write_to_sink.hpp"
 
 #include "base/assert.hpp"
-#include "base/base.hpp"
 #include "base/bits.hpp"
 #include "base/logging.hpp"
 
-#include <cstdint>
 #include <limits>
 #include <vector>
 
@@ -244,11 +242,14 @@ public:
   {
     ASSERT_GREATER_OR_EQUAL(m_BitsPerLevel, 3, ());
     WriteVarUint(sink, (offset << 1) + 1);
-    buffer_vector<uint8_t, 32> bitMask(1 << (m_BitsPerLevel - 3));
+
+    buffer_vector<uint8_t, 32> bitMask;
+    bitMask.resize(1 << (m_BitsPerLevel - 3), 0);
     for (uint32_t i = 0; i < static_cast<uint32_t>(1 << m_BitsPerLevel); ++i)
       if (childSizes[i])
         bits::SetBitTo1(&bitMask[0], i);
     sink.Write(&bitMask[0], bitMask.size());
+
     for (uint32_t i = 0; i < static_cast<uint32_t>(1 << m_BitsPerLevel); ++i)
       if (childSizes[i])
         WriteVarUint(sink, childSizes[i]);

--- a/indexer/mwm_set.hpp
+++ b/indexer/mwm_set.hpp
@@ -47,8 +47,12 @@ public:
   MwmInfo();
   virtual ~MwmInfo() = default;
 
-  m2::RectD m_bordersRect;        ///< Rect around region border. Features which cross region border may
-                                  ///< cross this rect.
+  /// @obsolete Rect around region border. Features which cross region border may cross this rect.
+  /// @todo VNG: Not true. This rect accumulates all features in MWM. Since we don't crop features by border,
+  /// the rect defines _bigger_ area (in general) that MWM is responsible for.
+  /// Take into account this fact, or you can get fair rect with CountryInfoGetter.
+  m2::RectD m_bordersRect;
+
   uint8_t m_minScale;             ///< Min zoom level of mwm.
   uint8_t m_maxScale;             ///< Max zoom level of mwm.
   version::MwmVersion m_version;  ///< Mwm file version.

--- a/map/features_fetcher.cpp
+++ b/map/features_fetcher.cpp
@@ -3,7 +3,6 @@
 #include "platform/platform.hpp"
 
 #include "indexer/classificator_loader.hpp"
-#include "indexer/scales.hpp"
 
 #include "base/assert.hpp"
 #include "base/logging.hpp"
@@ -71,8 +70,7 @@ m2::RectD FeaturesFetcher::GetWorldRect() const
 {
   if (m_rect == m2::RectD())
   {
-    // rect is empty when now countries are loaded
-    // return max global rect
+    // Rect is empty when no countries are loaded, return max global rect.
     return mercator::Bounds::FullRect();
   }
   return m_rect;

--- a/map/search_mark.cpp
+++ b/map/search_mark.cpp
@@ -202,7 +202,7 @@ m2::PointD SearchMarkPoint::GetPixelOffset() const
 {
   if (!IsHotel())
     return {0.0, 4.0};
-  return {};
+  return {0.0, 0.0};
 }
 
 drape_ptr<df::UserPointMark::SymbolNameZoomInfo> SearchMarkPoint::GetSymbolNames() const
@@ -218,9 +218,9 @@ drape_ptr<df::UserPointMark::SymbolNameZoomInfo> SearchMarkPoint::GetSymbolNames
 
 drape_ptr<df::UserPointMark::SymbolOffsets> SearchMarkPoint::GetSymbolOffsets() const
 {
-  m2::PointF offset;
+  m2::PointF offset(0, 0);
   if (!IsHotel())
-    offset = m2::PointF{0.0, 1.0};
+    offset.y = 1;
   return make_unique_dp<SymbolOffsets>(static_cast<size_t>(scales::UPPER_STYLE_SCALE), offset);
 }
 

--- a/map/user_mark.hpp
+++ b/map/user_mark.hpp
@@ -68,7 +68,7 @@ public:
   void ResetChanges() const override { m_isDirty = false; }
   bool IsVisible() const override { return true; }
   m2::PointD const & GetPivot() const override;
-  m2::PointD GetPixelOffset() const override { return {}; }
+  m2::PointD GetPixelOffset() const override { return {0.0, 0.0}; }
   dp::Anchor GetAnchor() const override { return dp::Center; }
   bool GetDepthTestEnabled() const override { return true; }
   float GetDepth() const override { return kInvalidDepth; }

--- a/routing/features_road_graph.cpp
+++ b/routing/features_road_graph.cpp
@@ -263,7 +263,7 @@ void FeaturesRoadGraphBase::ExtractRoadInfo(FeatureID const & featureId, Feature
 
   CHECK_EQUAL(altitudes.size(), pointsCount, ("GetAltitudes for", featureId, "returns wrong altitudes:", altitudes));
 
-  ri.m_junctions.resize_no_init(pointsCount);
+  ri.m_junctions.resize(pointsCount);
   for (size_t i = 0; i < pointsCount; ++i)
     ri.m_junctions[i] = { ft.GetPoint(i), altitudes[i] };
 }

--- a/search/locality_finder.cpp
+++ b/search/locality_finder.cpp
@@ -6,7 +6,6 @@
 #include "search/mwm_context.hpp"
 
 #include "indexer/data_source.hpp"
-#include "indexer/feature_algo.hpp"
 #include "indexer/feature_visibility.hpp"
 #include "indexer/ftypes_matcher.hpp"
 
@@ -15,10 +14,10 @@
 
 #include <vector>
 
-using namespace std;
-
 namespace search
 {
+using namespace std;
+
 namespace
 {
 double const kMaxCityRadiusMeters = 30000.0;
@@ -309,6 +308,8 @@ void LocalityFinder::UpdateMaps()
     switch (info->GetType())
     {
     case MwmInfo::WORLD: m_worldId = id; break;
+    /// @todo Use fair MWM rect from CountryInfoGetter here and everywhere in search?
+    /// @see MwmInfo.m_bordersRect for details.
     case MwmInfo::COUNTRY: m_maps.Add(id, info->m_bordersRect); break;
     case MwmInfo::COASTS: break;
     }


### PR DESCRIPTION
Needs good manual testing in case if someone relied on implicit buffer zero initialization.