### PR TITLE
[android] set bottom map buttons max width to 450dp

### DIFF
--- a/android/res/layout-h400dp/map_buttons_layout_regular.xml
+++ b/android/res/layout-h400dp/map_buttons_layout_regular.xml
@@ -52,46 +52,10 @@
       app:layout_constraintBottom_toBottomOf="parent"
       app:layout_constraintEnd_toEndOf="parent" />
   </androidx.constraintlayout.widget.ConstraintLayout>
-  <androidx.constraintlayout.widget.ConstraintLayout
-    android:id="@+id/map_buttons_bottom"
+  <include
+    layout="@layout/map_buttons_bottom"
     android:layout_width="match_parent"
     android:layout_height="wrap_content"
     android:layout_alignParentBottom="true"
-    android:clipChildren="false"
-    android:clipToPadding="false"
-    android:layoutDirection="ltr"
-    android:padding="@dimen/nav_frame_padding">
-    <include
-      layout="@layout/map_buttons_help"
-      android:layout_width="wrap_content"
-      android:layout_height="wrap_content"
-      android:layout_alignParentBottom="true"
-      android:layout_marginStart="@dimen/margin_half"
-      app:layout_constraintBottom_toBottomOf="parent"
-      app:layout_constraintStart_toStartOf="parent" />
-    <include
-      layout="@layout/map_buttons_search_square"
-      android:layout_width="wrap_content"
-      android:layout_height="wrap_content"
-      android:layout_alignParentBottom="true"
-      app:layout_constraintBottom_toBottomOf="parent"
-      app:layout_constraintStart_toEndOf="@+id/help_button"
-      app:layout_constraintEnd_toStartOf="@+id/btn_bookmarks" />
-    <include
-      layout="@layout/map_buttons_bookmarks_square"
-      android:layout_width="wrap_content"
-      android:layout_height="wrap_content"
-      android:layout_alignParentBottom="true"
-      app:layout_constraintBottom_toBottomOf="parent"
-      app:layout_constraintStart_toEndOf="@+id/btn_search"
-      app:layout_constraintEnd_toStartOf="@+id/menu_button" />
-    <include
-      layout="@layout/map_buttons_menu"
-      android:layout_width="wrap_content"
-      android:layout_height="wrap_content"
-      android:layout_alignParentBottom="true"
-      android:layout_marginEnd="@dimen/margin_half"
-      app:layout_constraintBottom_toBottomOf="parent"
-      app:layout_constraintEnd_toEndOf="parent" />
-  </androidx.constraintlayout.widget.ConstraintLayout>
+    android:layout_alignParentEnd="true" />
 </RelativeLayout>

--- a/android/res/layout-land/map_buttons_bottom.xml
+++ b/android/res/layout-land/map_buttons_bottom.xml
@@ -1,0 +1,40 @@
+<?xml version="1.0" encoding="utf-8"?>
+<androidx.constraintlayout.widget.ConstraintLayout
+  xmlns:android="http://schemas.android.com/apk/res/android"
+  xmlns:app="http://schemas.android.com/apk/res-auto"
+  android:id="@+id/map_buttons_bottom"
+  style="@style/MwmWidget.MapButton.Bottom"
+  android:layout_width="match_parent"
+  android:layout_height="wrap_content"
+  android:clipChildren="false"
+  android:clipToPadding="false"
+  android:layoutDirection="ltr">
+  <include
+    layout="@layout/map_buttons_help"
+    android:layout_width="wrap_content"
+    android:layout_height="wrap_content"
+    android:layout_marginStart="@dimen/margin_half"
+    app:layout_constraintBottom_toBottomOf="parent"
+    app:layout_constraintStart_toStartOf="parent" />
+  <include
+    layout="@layout/map_buttons_search_square"
+    android:layout_width="wrap_content"
+    android:layout_height="wrap_content"
+    app:layout_constraintBottom_toBottomOf="parent"
+    app:layout_constraintEnd_toStartOf="@+id/btn_bookmarks"
+    app:layout_constraintStart_toEndOf="@+id/help_button" />
+  <include
+    layout="@layout/map_buttons_bookmarks_square"
+    android:layout_width="wrap_content"
+    android:layout_height="wrap_content"
+    app:layout_constraintBottom_toBottomOf="parent"
+    app:layout_constraintEnd_toStartOf="@+id/menu_button"
+    app:layout_constraintStart_toEndOf="@+id/btn_search" />
+  <include
+    layout="@layout/map_buttons_menu"
+    android:layout_width="wrap_content"
+    android:layout_height="wrap_content"
+    android:layout_marginEnd="@dimen/margin_half"
+    app:layout_constraintBottom_toBottomOf="parent"
+    app:layout_constraintEnd_toEndOf="parent" />
+</androidx.constraintlayout.widget.ConstraintLayout>

--- a/android/res/layout/map_buttons_bottom.xml
+++ b/android/res/layout/map_buttons_bottom.xml
@@ -1,0 +1,45 @@
+<?xml version="1.0" encoding="utf-8"?>
+<RelativeLayout
+  xmlns:android="http://schemas.android.com/apk/res/android"
+  xmlns:app="http://schemas.android.com/apk/res-auto"
+  android:id="@+id/map_buttons_bottom"
+  android:layout_width="match_parent"
+  android:layout_height="wrap_content">
+  <androidx.constraintlayout.widget.ConstraintLayout
+    style="@style/MwmWidget.MapButton.Bottom"
+    android:layout_width="match_parent"
+    android:layout_height="wrap_content"
+    android:layout_centerInParent="true"
+    android:clipChildren="false"
+    android:clipToPadding="false"
+    android:layoutDirection="ltr">
+    <include
+      layout="@layout/map_buttons_help"
+      android:layout_width="wrap_content"
+      android:layout_height="wrap_content"
+      android:layout_marginStart="@dimen/margin_half"
+      app:layout_constraintBottom_toBottomOf="parent"
+      app:layout_constraintStart_toStartOf="parent" />
+    <include
+      layout="@layout/map_buttons_search_square"
+      android:layout_width="wrap_content"
+      android:layout_height="wrap_content"
+      app:layout_constraintBottom_toBottomOf="parent"
+      app:layout_constraintEnd_toStartOf="@+id/btn_bookmarks"
+      app:layout_constraintStart_toEndOf="@+id/help_button" />
+    <include
+      layout="@layout/map_buttons_bookmarks_square"
+      android:layout_width="wrap_content"
+      android:layout_height="wrap_content"
+      app:layout_constraintBottom_toBottomOf="parent"
+      app:layout_constraintEnd_toStartOf="@+id/menu_button"
+      app:layout_constraintStart_toEndOf="@+id/btn_search" />
+    <include
+      layout="@layout/map_buttons_menu"
+      android:layout_width="wrap_content"
+      android:layout_height="wrap_content"
+      android:layout_marginEnd="@dimen/margin_half"
+      app:layout_constraintBottom_toBottomOf="parent"
+      app:layout_constraintEnd_toEndOf="parent" />
+  </androidx.constraintlayout.widget.ConstraintLayout>
+</RelativeLayout>

--- a/android/res/layout/map_buttons_layout_regular.xml
+++ b/android/res/layout/map_buttons_layout_regular.xml
@@ -51,46 +51,10 @@
       app:layout_constraintBottom_toBottomOf="parent"
       app:layout_constraintEnd_toEndOf="parent" />
   </androidx.constraintlayout.widget.ConstraintLayout>
-  <androidx.constraintlayout.widget.ConstraintLayout
-    android:id="@+id/map_buttons_bottom"
+  <include
+    layout="@layout/map_buttons_bottom"
     android:layout_width="match_parent"
     android:layout_height="wrap_content"
     android:layout_alignParentBottom="true"
-    android:clipChildren="false"
-    android:clipToPadding="false"
-    android:layoutDirection="ltr"
-    android:padding="@dimen/nav_frame_padding">
-    <include
-      layout="@layout/map_buttons_help"
-      android:layout_width="wrap_content"
-      android:layout_height="wrap_content"
-      android:layout_alignParentBottom="true"
-      android:layout_marginStart="@dimen/margin_half"
-      app:layout_constraintBottom_toBottomOf="parent"
-      app:layout_constraintStart_toStartOf="parent" />
-    <include
-      layout="@layout/map_buttons_search_square"
-      android:layout_width="wrap_content"
-      android:layout_height="wrap_content"
-      android:layout_alignParentBottom="true"
-      app:layout_constraintBottom_toBottomOf="parent"
-      app:layout_constraintStart_toEndOf="@+id/help_button"
-      app:layout_constraintEnd_toStartOf="@+id/btn_bookmarks" />
-    <include
-      layout="@layout/map_buttons_bookmarks_square"
-      android:layout_width="wrap_content"
-      android:layout_height="wrap_content"
-      android:layout_alignParentBottom="true"
-      app:layout_constraintBottom_toBottomOf="parent"
-      app:layout_constraintStart_toEndOf="@+id/btn_search"
-      app:layout_constraintEnd_toStartOf="@+id/menu_button" />
-    <include
-      layout="@layout/map_buttons_menu"
-      android:layout_width="wrap_content"
-      android:layout_height="wrap_content"
-      android:layout_alignParentBottom="true"
-      android:layout_marginEnd="@dimen/margin_half"
-      app:layout_constraintBottom_toBottomOf="parent"
-      app:layout_constraintEnd_toEndOf="parent" />
-  </androidx.constraintlayout.widget.ConstraintLayout>
+    android:layout_alignParentEnd="true" />
 </RelativeLayout>

--- a/android/res/values/dimens.xml
+++ b/android/res/values/dimens.xml
@@ -141,6 +141,7 @@
   <dimen name="nav_frame_padding">@dimen/margin_half</dimen>
   <dimen name="zoom_buttons_margin">64dp</dimen>
   <dimen name="map_buttons_bottom_margin">136dp</dimen>
+  <dimen name="map_buttons_bottom_max_width">300dp</dimen>
 
   <dimen name="panel_elevation">12dp</dimen>
   <dimen name="appbar_elevation">4dp</dimen>

--- a/android/res/values/styles.xml
+++ b/android/res/values/styles.xml
@@ -9,7 +9,7 @@
 
   <style name="MwmWidget.Downloader"/>
 
-  <style name="MwmWidget.MapButton">
+  <style name="MwmWidget.MapButton" parent="Theme.Material3.Dark">
     <item name="android:layout_width">wrap_content</item>
     <item name="android:layout_height">wrap_content</item>
     <item name="android:backgroundTint">?mapButtonBackground</item>
@@ -24,6 +24,11 @@
 
   <style name="MwmWidget.MapButton.Search">
     <item name="fabCustomSize">38dp</item>
+  </style>
+
+  <style name="MwmWidget.MapButton.Bottom">
+    <item name="android:maxWidth">@dimen/map_buttons_bottom_max_width</item>
+    <item name="android:padding">@dimen/nav_frame_padding</item>
   </style>
 
   <style name="MwmWidget.MapButton.Square">


### PR DESCRIPTION
When the screen is larger than 450dp, bottom map buttons will align to the left as requested in https://github.com/organicmaps/organicmaps/pull/2905#issuecomment-1236192812. This threshold can be edited in the `map_buttons_bottom_max_width` value.

To make code easier to maintain, bottom menu buttons have been extracted into their own layout file.

## Pixel 5

| Portrait | Landscape |
|-|-|
| ![Screenshot_1662397632](https://user-images.githubusercontent.com/80701113/188494950-76f89560-267e-42e8-9e46-45994298906a.png) | ![Screenshot_1662397637](https://user-images.githubusercontent.com/80701113/188494958-d486d2e5-f110-4b3b-a0ae-a9c21dac81ec.png) |

## Nexus One
| Portrait | Landscape |
|-|-|
| ![Screenshot_1662397763](https://user-images.githubusercontent.com/80701113/188494967-56a0301a-3926-4682-b126-d553798650c4.png) | ![Screenshot_1662397768](https://user-images.githubusercontent.com/80701113/188494972-830e7406-b6a0-4131-b2db-6806a359a467.png) |


## Pixel C

| Portrait | Landscape |
|-|-|
| ![Screenshot_1662398474](https://user-images.githubusercontent.com/80701113/188494981-761eb91d-d656-4225-8d76-c5e90d1e9ba7.png) | ![Screenshot_1662398486](https://user-images.githubusercontent.com/80701113/188494986-a9329434-ff32-4051-88fd-f072e90a5e97.png) |