### PR TITLE
[docs] update STYLES.md about installing protobuf

### DIFF
--- a/docs/STYLES.md
+++ b/docs/STYLES.md
@@ -17,9 +17,13 @@ and ["icons wanted" issues](https://github.com/organicmaps/organicmaps/issues?q=
 
 To work with styles first [clone the OM repository](INSTALL.md#getting-sources).
 
-Install a `protobuf` python package, e.g.
+Install a `protobuf` python package with `pip`
 ```
 pip install protobuf
+```
+or with your OS package manager, e.g for Ubuntu 
+```
+sudo apt install python3-protobuf 
 ```
 
 To run the `generate_symbols.sh` script install `optipng` also, e.g. for Ubuntu


### PR DESCRIPTION
This is small a docs update to ease contributing to the project.

I added another option of installing required `protobuf` dependency. 
This is actually what allowed me to build the styles after following INSTALL.md on clean Linux (Windows WSL) installation. I guess I didn't have `pip` installed because INSTALL.md only tell to install `python3`, not `python3-pip`.