### PR TITLE
[android] Make navigation bar semi-transparent 

### DIFF
--- a/android/res/layout-land/layout_nav.xml
+++ b/android/res/layout-land/layout_nav.xml
@@ -36,4 +36,10 @@
 
   </androidx.coordinatorlayout.widget.CoordinatorLayout>
 
+  <View
+    android:id="@+id/nav_bottom_sheet_nav_bar"
+    android:layout_width="0dp"
+    android:layout_height="0dp"
+    android:layout_gravity="bottom"
+    android:background="@color/bg_cards"/>
 </FrameLayout>

--- a/android/res/layout/activity_map.xml
+++ b/android/res/layout/activity_map.xml
@@ -9,26 +9,33 @@
 <RelativeLayout
   android:layout_width="match_parent"
   android:layout_height="match_parent">
+
   <FrameLayout
     android:id="@+id/map_fragment_container"
     android:layout_width="match_parent"
     android:layout_height="match_parent"/>
 
-  <include
-    android:id="@+id/onmap_downloader"
-    android:layout_width="wrap_content"
-    android:layout_height="wrap_content"
-    android:layout_centerInParent="true"
-    layout="@layout/onmap_downloader"/>
 
-  <include
-    android:id="@+id/position_chooser"
-    layout="@layout/position_chooser"/>
-
-  <androidx.fragment.app.FragmentContainerView
-    android:id="@+id/map_buttons"
+  <RelativeLayout
     android:layout_width="match_parent"
-    android:layout_height="match_parent" />
+    android:layout_height="match_parent"
+    android:id="@+id/map_ui_container">
+    <include
+      android:id="@+id/onmap_downloader"
+      android:layout_width="wrap_content"
+      android:layout_height="wrap_content"
+      android:layout_centerInParent="true"
+      layout="@layout/onmap_downloader"/>
+
+    <include
+      android:id="@+id/position_chooser"
+      layout="@layout/position_chooser"/>
+
+    <androidx.fragment.app.FragmentContainerView
+      android:id="@+id/map_buttons"
+      android:layout_width="match_parent"
+      android:layout_height="match_parent" />
+  </RelativeLayout>
 
   <include
     android:id="@+id/toolbar"
@@ -39,14 +46,6 @@
     android:visibility="gone"
     tools:visibility="visible" />
 
-   <include
-    layout="@layout/layout_nav"
-    android:layout_width="match_parent"
-    android:layout_height="match_parent"
-    android:layout_below="@id/toolbar"
-    android:paddingBottom="@dimen/margin_base"
-    android:visibility="invisible"/>
-
   <include
     layout="@layout/routing_plan"
     android:visibility="invisible"/>
@@ -56,6 +55,14 @@
     android:layout_width="match_parent"
     android:layout_height="wrap_content"
     android:layout_alignParentBottom="true"/>
+
+  <include
+    layout="@layout/layout_nav"
+    android:layout_width="match_parent"
+    android:layout_height="match_parent"
+    android:layout_below="@id/toolbar"
+    android:paddingBottom="@dimen/margin_base"
+    android:visibility="invisible"/>
 
 </RelativeLayout>
   <com.mapswithme.maps.widget.placepage.PlacePageView
@@ -70,13 +77,13 @@
     android:layout_width="match_parent"
     android:layout_height="wrap_content"
     android:layout_gravity="bottom"
+    android:background="?ppButtonsBackground"
     android:visibility="invisible">
     <LinearLayout
       android:id="@+id/container"
       android:layout_width="match_parent"
       android:layout_height="@dimen/place_page_buttons_height"
-      android:orientation="horizontal"
-      android:background="?ppButtonsBackground"/>
+      android:orientation="horizontal"/>
     <include layout="@layout/divider_horizontal"/>
   </FrameLayout>
   <include layout="@layout/elevation_profile_bottom_sheet" />

--- a/android/res/layout/layout_nav.xml
+++ b/android/res/layout/layout_nav.xml
@@ -35,4 +35,10 @@
 
   </androidx.coordinatorlayout.widget.CoordinatorLayout>
 
+  <View
+    android:id="@+id/nav_bottom_sheet_nav_bar"
+    android:layout_width="0dp"
+    android:layout_height="0dp"
+    android:layout_gravity="bottom"
+    android:background="@color/bg_cards"/>
 </FrameLayout>

--- a/android/res/layout/layout_nav_top.xml
+++ b/android/res/layout/layout_nav_top.xml
@@ -32,66 +32,72 @@
     android:layout_height="wrap_content"
     android:layout_below="@id/street_frame"/>
 
-  <LinearLayout
-    android:id="@+id/nav_next_turn_frame"
-    android:layout_width="@dimen/nav_next_turn_frame"
+  <RelativeLayout
+    android:id="@+id/nav_next_turn_container"
+    android:layout_width="wrap_content"
     android:layout_height="wrap_content"
-    android:layout_margin="@dimen/margin_half"
-    android:orientation="vertical"
-    android:background="?navNextTurnFrame"
     android:elevation="@dimen/nav_elevation">
-    <FrameLayout
-      android:layout_width="wrap_content"
+    <LinearLayout
+      android:id="@+id/nav_next_turn_frame"
+      android:layout_width="@dimen/nav_next_turn_frame"
       android:layout_height="wrap_content"
-      android:layout_marginTop="@dimen/nav_next_turn_top"
-      android:layout_marginBottom="@dimen/nav_next_turn_space"
-      android:layout_gravity="center_horizontal">
-      <com.mapswithme.maps.widget.ArrowView
-        android:id="@+id/turn"
-        android:theme="?navigationTheme"
-        android:layout_width="@dimen/nav_next_turn_sign"
-        android:layout_height="@dimen/nav_next_turn_sign"
-        android:tint="?iconTint"
-        tools:background="#400000FF"/>
+      android:layout_margin="@dimen/margin_half"
+      android:orientation="vertical"
+      android:background="?navNextTurnFrame"
+      android:elevation="@dimen/nav_elevation">
+      <FrameLayout
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:layout_marginTop="@dimen/nav_next_turn_top"
+        android:layout_marginBottom="@dimen/nav_next_turn_space"
+        android:layout_gravity="center_horizontal">
+        <com.mapswithme.maps.widget.ArrowView
+          android:id="@+id/turn"
+          android:theme="?navigationTheme"
+          android:layout_width="@dimen/nav_next_turn_sign"
+          android:layout_height="@dimen/nav_next_turn_sign"
+          android:tint="?iconTint"
+          tools:background="#400000FF"/>
+
+        <TextView
+          android:id="@+id/circle_exit"
+          style="@style/MwmWidget.TextView.NavNextTurn.Exit"
+          android:layout_width="wrap_content"
+          android:layout_height="wrap_content"
+          android:layout_gravity="center"
+          tools:text="9"/>
+      </FrameLayout>
 
       <TextView
-        android:id="@+id/circle_exit"
-        style="@style/MwmWidget.TextView.NavNextTurn.Exit"
+        android:id="@+id/distance"
+        style="@style/MwmWidget.TextView.NavNextTurn"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:layout_marginBottom="@dimen/nav_next_turn_bottom"
+        android:layout_gravity="center_horizontal"
+        android:gravity="center_horizontal"
+        tools:text="9999 ft"/>
+    </LinearLayout>
+
+    <FrameLayout
+      android:id="@+id/nav_next_next_turn_frame"
+      android:layout_width="wrap_content"
+      android:layout_height="@dimen/nav_next_next_turn_frame"
+      android:layout_marginBottom="@dimen/margin_base"
+      android:layout_below="@id/nav_next_turn_frame"
+      android:layout_alignStart="@id/nav_next_turn_frame"
+      android:layout_alignEnd="@id/nav_next_turn_frame"
+      android:background="?navNextNextTurnFrame"
+      android:elevation="@dimen/nav_elevation"
+      android:visibility="gone"
+      tools:visibility="visible">
+      <ImageView
+        android:id="@id/turn"
         android:layout_width="wrap_content"
         android:layout_height="wrap_content"
         android:layout_gravity="center"
-        tools:text="9"/>
+        android:tint="?iconTint"
+        tools:src="@drawable/ic_then_left_sharp"/>
     </FrameLayout>
-
-    <TextView
-      android:id="@+id/distance"
-      style="@style/MwmWidget.TextView.NavNextTurn"
-      android:layout_width="wrap_content"
-      android:layout_height="wrap_content"
-      android:layout_marginBottom="@dimen/nav_next_turn_bottom"
-      android:layout_gravity="center_horizontal"
-      android:gravity="center_horizontal"
-      tools:text="9999 ft"/>
-  </LinearLayout>
-
-  <FrameLayout
-    android:id="@+id/nav_next_next_turn_frame"
-    android:layout_width="wrap_content"
-    android:layout_height="@dimen/nav_next_next_turn_frame"
-    android:layout_marginBottom="@dimen/margin_base"
-    android:layout_below="@id/nav_next_turn_frame"
-    android:layout_alignStart="@id/nav_next_turn_frame"
-    android:layout_alignEnd="@id/nav_next_turn_frame"
-    android:background="?navNextNextTurnFrame"
-    android:elevation="@dimen/nav_elevation"
-    android:visibility="gone"
-    tools:visibility="visible">
-    <ImageView
-      android:id="@id/turn"
-      android:layout_width="wrap_content"
-      android:layout_height="wrap_content"
-      android:layout_gravity="center"
-      android:tint="?iconTint"
-      tools:src="@drawable/ic_then_left_sharp"/>
-  </FrameLayout>
+  </RelativeLayout>
 </RelativeLayout>

--- a/android/res/layout/menu.xml
+++ b/android/res/layout/menu.xml
@@ -4,7 +4,7 @@
   android:id="@+id/menu_frame"
   android:layout_width="match_parent"
   android:layout_height="wrap_content"
-  android:background="?menuBackground"
+  android:background="?cardBackground"
   android:visibility="gone"
   tools:visibility="visible">
 

--- a/android/res/values/themes.xml
+++ b/android/res/values/themes.xml
@@ -6,11 +6,13 @@
   <style name="MwmTheme.Splash">
     <item name="android:windowBackground">@color/bg_primary</item>
     <item name="android:textColorPrimary">@color/white_primary</item>
+    <item name="android:navigationBarColor">@color/bg_primary</item>
   </style>
 
   <style name="MwmTheme.Night.Splash">
     <item name="android:windowBackground">@color/bg_primary_night</item>
     <item name="android:textColorPrimary">@color/white_primary</item>
+    <item name="android:navigationBarColor">@color/bg_primary_night</item>
   </style>
 
   <style name="MwmTheme.MainActivity">

--- a/android/res/values/themes.xml
+++ b/android/res/values/themes.xml
@@ -18,11 +18,13 @@
   <style name="MwmTheme.MainActivity">
     <item name="android:colorPrimaryDark">@android:color/black</item>
     <item name="android:windowBackground">@null</item>
+    <item name="android:windowTranslucentNavigation">true</item>
   </style>
 
   <style name="MwmTheme.Night.MainActivity">
     <item name="android:colorPrimaryDark">@android:color/black</item>
     <item name="android:windowBackground">@null</item>
+    <item name="android:windowTranslucentNavigation">true</item>
   </style>
 
   <style name="MwmTheme.Settings">

--- a/android/src/com/mapswithme/maps/MapFragment.java
+++ b/android/src/com/mapswithme/maps/MapFragment.java
@@ -57,6 +57,9 @@ public class MapFragment extends BaseMwmFragment
   private static final int INVALID_POINTER_MASK = 0xFF;
   private static final int INVALID_TOUCH_ID = -1;
 
+  private int mCurrentCompassOffsetX;
+  private int mCurrentCompassOffsetY;
+
   private int mHeight;
   private int mWidth;
   private int mBottomWidgetOffset;
@@ -86,21 +89,34 @@ public class MapFragment extends BaseMwmFragment
                       UiUtils.dimen(context, R.dimen.margin_base),
                       ANCHOR_LEFT_TOP);
 
-    setupCompass(UiUtils.getCompassYOffset(requireContext()), false);
+    mCurrentCompassOffsetX = 0;
+    mCurrentCompassOffsetY = UiUtils.getCompassYOffset(requireContext());
+    setupCompass(mCurrentCompassOffsetY, mCurrentCompassOffsetX, false);
   }
 
-  void setupCompass(int offsetY, boolean forceRedraw)
+  /**
+   * Moves the map compass using the given offsets.
+   *
+   * @param offsetY Pixel offset from the top. -1 to keep the previous value.
+   * @param offsetX Pixel offset from the right.  -1 to keep the previous value.
+   * @param forceRedraw True to force the compass to redraw
+   */
+  void setupCompass(int offsetY, int offsetX, boolean forceRedraw)
   {
     Context context = requireContext();
+    int x = offsetX < 0 ? mCurrentCompassOffsetX : offsetX;
+    int y = offsetY < 0 ? mCurrentCompassOffsetY : offsetY;
     int navPadding = UiUtils.dimen(context, R.dimen.nav_frame_padding);
     int marginX = UiUtils.dimen(context, R.dimen.margin_compass) + navPadding;
     int marginY = UiUtils.dimen(context, R.dimen.margin_compass_top) + navPadding;
     nativeSetupWidget(WIDGET_COMPASS,
-                      mWidth - marginX,
-                      offsetY + marginY,
+                      mWidth - x - marginX,
+                      y + marginY,
                       ANCHOR_CENTER);
     if (forceRedraw && mSurfaceCreated)
       nativeApplyWidgets();
+    mCurrentCompassOffsetX = x;
+    mCurrentCompassOffsetY = y;
   }
 
   void setupBottomWidgetsOffset(int offset)

--- a/android/src/com/mapswithme/maps/MapFragment.java
+++ b/android/src/com/mapswithme/maps/MapFragment.java
@@ -59,10 +59,11 @@ public class MapFragment extends BaseMwmFragment
 
   private int mCurrentCompassOffsetX;
   private int mCurrentCompassOffsetY;
+  private int mBottomWidgetOffsetX;
+  private int mBottomWidgetOffsetY;
 
   private int mHeight;
   private int mWidth;
-  private int mBottomWidgetOffset;
   private boolean mRequireResize;
   private boolean mSurfaceCreated;
   private boolean mSurfaceAttached;
@@ -82,7 +83,7 @@ public class MapFragment extends BaseMwmFragment
     Context context = requireContext();
 
     nativeCleanWidgets();
-    setupBottomWidgetsOffset(mBottomWidgetOffset);
+    setupBottomWidgetsOffset(mBottomWidgetOffsetY, mBottomWidgetOffsetX);
 
     nativeSetupWidget(WIDGET_SCALE_FPS_LABEL,
                       UiUtils.dimen(context, R.dimen.margin_base),
@@ -119,29 +120,38 @@ public class MapFragment extends BaseMwmFragment
     mCurrentCompassOffsetY = y;
   }
 
-  void setupBottomWidgetsOffset(int offset)
+  /**
+   * Moves the ruler and copyright using the given offsets.
+   *
+   * @param offsetY Pixel offset from the bottom. -1 to keep the previous value.
+   * @param offsetX Pixel offset from the left.  -1 to keep the previous value.
+   */
+  void setupBottomWidgetsOffset(int offsetY, int offsetX)
   {
-    mBottomWidgetOffset = offset;
-    setupRuler(offset, true);
-    setupAttribution(offset, true);
+    int x = offsetX < 0 ? mBottomWidgetOffsetX : offsetX;
+    int y = offsetY < 0 ? mBottomWidgetOffsetY : offsetY;
+    setupRuler(y, x,true);
+    setupAttribution(y, x, true);
+    mBottomWidgetOffsetX = x;
+    mBottomWidgetOffsetY = y;
   }
 
-  void setupRuler(int offsetY, boolean forceRedraw)
+  private void setupRuler(int offsetY, int offsetX, boolean forceRedraw)
   {
     Context context = requireContext();
     nativeSetupWidget(WIDGET_RULER,
-                      UiUtils.dimen(context, R.dimen.margin_ruler),
+                      UiUtils.dimen(context, R.dimen.margin_ruler) + offsetX,
                       mHeight - UiUtils.dimen(context, R.dimen.margin_ruler) - offsetY,
                       ANCHOR_LEFT_BOTTOM);
     if (forceRedraw && mSurfaceCreated)
       nativeApplyWidgets();
   }
 
-  void setupAttribution(int offsetY, boolean forceRedraw)
+  private void setupAttribution(int offsetY, int offsetX, boolean forceRedraw)
   {
     Context context = requireContext();
     nativeSetupWidget(WIDGET_COPYRIGHT,
-                      UiUtils.dimen(context, R.dimen.margin_ruler),
+                      UiUtils.dimen(context, R.dimen.margin_ruler) + offsetX,
                       mHeight - UiUtils.dimen(context, R.dimen.margin_ruler) - offsetY,
                       ANCHOR_LEFT_BOTTOM);
     if (forceRedraw && mSurfaceCreated)

--- a/android/src/com/mapswithme/maps/MwmActivity.java
+++ b/android/src/com/mapswithme/maps/MwmActivity.java
@@ -195,6 +195,8 @@ public class MwmActivity extends BaseMwmFragmentActivity
 
   private String mDonatesUrl;
 
+  private int navBarHeight;
+
   public interface LeftAnimationTrackListener
   {
     void onTrackStarted(boolean collapsed);
@@ -434,7 +436,9 @@ public class MwmActivity extends BaseMwmFragmentActivity
                                          .setOnApplyWindowInsetsListener(this::setViewInsetsSides);
 
     findViewById(R.id.map_fragment_container).setOnApplyWindowInsetsListener((view, windowInsets) -> {
+      navBarHeight = windowInsets.getSystemWindowInsetBottom();
       adjustCompass(-1, windowInsets.getSystemWindowInsetRight());
+      adjustBottomWidgets(windowInsets.getSystemWindowInsetLeft());
       return windowInsets;
     });
   }
@@ -1296,19 +1300,24 @@ public class MwmActivity extends BaseMwmFragmentActivity
 
   public void adjustBottomWidgets()
   {
+    adjustBottomWidgets(-1);
+  }
+
+  public void adjustBottomWidgets(int offsetX)
+  {
     if (mMapFragment == null || !mMapFragment.isAdded())
       return;
 
     int mapButtonsHeight = 0;
     int mainMenuHeight = 0;
     if (mMapButtonsController != null)
-      mapButtonsHeight = (int) mMapButtonsController.getBottomButtonsHeight();
+      mapButtonsHeight = (int) mMapButtonsController.getBottomButtonsHeight() + navBarHeight;
     if (mMainMenu != null)
       mainMenuHeight = mMainMenu.getMenuHeight();
 
-    int offsetY = Math.max(mapButtonsHeight, mainMenuHeight);
+    int y = Math.max(Math.max(mapButtonsHeight, mainMenuHeight), navBarHeight);
 
-    mMapFragment.setupBottomWidgetsOffset(offsetY);
+    mMapFragment.setupBottomWidgetsOffset(y, offsetX);
   }
 
   @Override

--- a/android/src/com/mapswithme/maps/MwmActivity.java
+++ b/android/src/com/mapswithme/maps/MwmActivity.java
@@ -9,13 +9,13 @@ import android.content.Intent;
 import android.location.Location;
 import android.net.Uri;
 import android.os.Bundle;
-import android.os.Handler;
 import android.text.TextUtils;
 import android.view.KeyEvent;
 import android.view.MotionEvent;
 import android.view.View;
 import android.view.View.OnClickListener;
 import android.view.ViewTreeObserver;
+import android.view.WindowInsets;
 import android.view.WindowManager;
 import android.widget.TextView;
 
@@ -25,6 +25,7 @@ import androidx.annotation.Nullable;
 import androidx.annotation.StyleRes;
 import androidx.appcompat.app.AlertDialog;
 import androidx.appcompat.widget.Toolbar;
+import androidx.core.content.ContextCompat;
 import androidx.fragment.app.Fragment;
 import androidx.fragment.app.FragmentActivity;
 import androidx.fragment.app.FragmentManager;
@@ -419,6 +420,34 @@ public class MwmActivity extends BaseMwmFragmentActivity
 
     if (savedInstanceState == null && RoutingController.get().hasSavedRoute())
       addTask(new Factory.RestoreRouteTask());
+
+    updateViewsInsets();
+  }
+
+  private void updateViewsInsets()
+  {
+    findViewById(R.id.map_ui_container).setOnApplyWindowInsetsListener(this::setViewInsets);
+    findViewById(R.id.pp_buttons_layout).setOnApplyWindowInsetsListener(this::setViewInsets);
+    findViewById(R.id.toolbar).setOnApplyWindowInsetsListener(this::setViewInsets);
+    findViewById(R.id.menu_frame).setOnApplyWindowInsetsListener(this::setViewInsets);
+    findViewById(R.id.routing_plan_frame).findViewById(R.id.toolbar)
+                                         .setOnApplyWindowInsetsListener(this::setViewInsetsSides);
+
+
+  }
+
+  private WindowInsets setViewInsets(View view, WindowInsets windowInsets)
+  {
+    view.setPadding(windowInsets.getSystemWindowInsetLeft(), view.getPaddingTop(),
+                    windowInsets.getSystemWindowInsetRight(), windowInsets.getSystemWindowInsetBottom());
+    return windowInsets;
+  }
+
+  private WindowInsets setViewInsetsSides(View view, WindowInsets windowInsets)
+  {
+    view.setPadding(windowInsets.getSystemWindowInsetLeft(), view.getPaddingTop(),
+                    windowInsets.getSystemWindowInsetRight(), view.getPaddingBottom());
+    return windowInsets;
   }
 
   private void initBottomSheets()

--- a/android/src/com/mapswithme/maps/MwmActivity.java
+++ b/android/src/com/mapswithme/maps/MwmActivity.java
@@ -433,7 +433,10 @@ public class MwmActivity extends BaseMwmFragmentActivity
     findViewById(R.id.routing_plan_frame).findViewById(R.id.toolbar)
                                          .setOnApplyWindowInsetsListener(this::setViewInsetsSides);
 
-
+    findViewById(R.id.map_fragment_container).setOnApplyWindowInsetsListener((view, windowInsets) -> {
+      adjustCompass(-1, windowInsets.getSystemWindowInsetRight());
+      return windowInsets;
+    });
   }
 
   private WindowInsets setViewInsets(View view, WindowInsets windowInsets)
@@ -1276,10 +1279,15 @@ public class MwmActivity extends BaseMwmFragmentActivity
 
   void adjustCompass(int offsetY)
   {
+    adjustCompass(offsetY, -1);
+  }
+
+  void adjustCompass(int offsetY, int offsetX)
+  {
     if (mMapFragment == null || !mMapFragment.isAdded())
       return;
 
-    mMapFragment.setupCompass(offsetY, true);
+    mMapFragment.setupCompass(offsetY, offsetX, true);
 
     CompassData compass = LocationHelper.INSTANCE.getCompassData();
     if (compass != null)

--- a/android/src/com/mapswithme/maps/routing/NavigationController.java
+++ b/android/src/com/mapswithme/maps/routing/NavigationController.java
@@ -12,6 +12,7 @@ import android.os.IBinder;
 import android.text.SpannableStringBuilder;
 import android.text.TextUtils;
 import android.view.View;
+import android.view.ViewGroup;
 import android.widget.ImageView;
 import android.widget.TextView;
 
@@ -86,12 +87,25 @@ public class NavigationController implements Application.ActivityLifecycleCallba
     mOnSettingsClickListener = onSettingsClickListener;
     mMapButtonsController = mapButtonsController;
 
+    // Show a blank view below the navbar to hide the menu content
+    mFrame.findViewById(R.id.nav_bottom_sheet_nav_bar).setOnApplyWindowInsetsListener((view, windowInsets) -> {
+      view.getLayoutParams().height = windowInsets.getSystemWindowInsetBottom();
+      view.getLayoutParams().width = mFrame.findViewById(R.id.nav_bottom_sheet).getWidth();
+      return windowInsets;
+    });
+
     // Top frame
     View topFrame = mFrame.findViewById(R.id.nav_top_frame);
     View turnFrame = topFrame.findViewById(R.id.nav_next_turn_frame);
     mNextTurnImage = turnFrame.findViewById(R.id.turn);
     mNextTurnDistance = turnFrame.findViewById(R.id.distance);
     mCircleExit = turnFrame.findViewById(R.id.circle_exit);
+
+    topFrame.findViewById(R.id.nav_next_turn_container).setOnApplyWindowInsetsListener((view, windowInsets) -> {
+      view.setPadding(windowInsets.getSystemWindowInsetLeft(), view.getPaddingTop(),
+                      view.getPaddingRight(), view.getPaddingBottom());
+      return windowInsets;
+    });
 
     mNextNextTurnFrame = topFrame.findViewById(R.id.nav_next_next_turn_frame);
     mNextNextTurnImage = mNextNextTurnFrame.findViewById(R.id.turn);

--- a/android/src/com/mapswithme/maps/widget/placepage/RichPlacePageController.java
+++ b/android/src/com/mapswithme/maps/widget/placepage/RichPlacePageController.java
@@ -249,7 +249,10 @@ public class RichPlacePageController implements PlacePageController, LocationLis
 
   private int calculatePeekHeight()
   {
-    final int organicPeekHeight = mPlacePage.getPreviewHeight() + mButtonsLayout.getHeight();
+    // Buttons layout padding is the navigation bar height.
+    // Bottom sheets are displayed above it so we need to remove it from the computed size
+    final int organicPeekHeight = mPlacePage.getPreviewHeight() +
+                                  mButtonsLayout.getHeight() - mButtonsLayout.getPaddingBottom();
     final MapObject object = mPlacePage.getMapObject();
     if (object != null)
     {


### PR DESCRIPTION
Makes the navigation bar semi transparent to make the map more visible. This is only true for the map activity, other activities/screens are untouched.

This was not a trivial change as the navigation bar is now drawn on top of the app and we need to make UI elements manually avoid it. On the splash screen, the navigation bar is now the same color as the background.

I handled map UI elements such as the buttons, navigation UI, ... and also the ruler/copyright and the compass. Please help me test this PR to make sure it does not introduce new issues.

Helps towards https://github.com/organicmaps/organicmaps/issues/3029.

Closes https://github.com/organicmaps/organicmaps/issues/2943.

## Pixel 5

### 3-buttons navigation


https://user-images.githubusercontent.com/80701113/188902190-d3936d1d-9576-46cd-acca-2f0f59dac1aa.mp4

### Gesture navigation

https://user-images.githubusercontent.com/80701113/188902213-7953b1ca-b3ec-408d-b215-0c42b9917b8e.mp4

### Splash screen

![Screenshot_1662560925](https://user-images.githubusercontent.com/80701113/188904052-c8c6ab67-b20e-4bf8-aab9-195af1d5ba22.png)
