### PR TITLE
[android] Update map buttons alpha

### DIFF
--- a/android/res/values/themes-base.xml
+++ b/android/res/values/themes-base.xml
@@ -71,7 +71,7 @@
     <item name="circleAccent">@drawable/circle_accent</item>
 
     <item name="menuBackground">@color/bg_menu</item>
-    <item name="mapButtonBackground">@color/bg_map_button</item>
+    <item name="mapButtonBackground">@color/bg_menu</item>
 
     <item name="myPositionButtonAnimation">@drawable/anim_myposition_pending</item>
     <item name="wheelPendingAnimation">@drawable/anim_spinner_pending</item>
@@ -249,7 +249,7 @@
     <item name="circleAccent">@drawable/circle_accent_night</item>
 
     <item name="menuBackground">@color/bg_menu_night</item>
-    <item name="mapButtonBackground">@color/bg_map_button_night</item>
+    <item name="mapButtonBackground">@color/bg_menu_night</item>
 
     <item name="myPositionButtonAnimation">@drawable/anim_myposition_pending_night</item>
     <item name="wheelPendingAnimation">@drawable/anim_spinner_pending</item>


### PR DESCRIPTION
Makes all map buttons 80% alpha as requested in https://github.com/organicmaps/organicmaps/pull/2905#issuecomment-1243056354

![Screenshot_1663009210](https://user-images.githubusercontent.com/80701113/189734643-e2faaa90-28a5-4a48-8e4d-819125c6712f.png)
