### PR TITLE
[strings] add residential garden strings, add craft-painter type

### DIFF
--- a/android/res/values-ar/strings.xml
+++ b/android/res/values-ar/strings.xml
@@ -1198,6 +1198,7 @@
 	<string name="type.leisure.fitness_centre">مركز للياقة البدنية، نادي رياضي</string>
 	<string name="type.leisure.fitness_station">مركز لياقة</string>
 	<string name="type.leisure.garden">حديقة</string>
+	<string name="type.leisure.garden.residential">حديقة</string>
 	<string name="type.leisure.golf_course">ملعب جولف</string>
 	<string name="type.leisure.nature_reserve">محمية طبيعية</string>
 	<string name="type.leisure.park">موقف سيارات</string>

--- a/android/res/values-be/strings.xml
+++ b/android/res/values-be/strings.xml
@@ -906,6 +906,7 @@
 	<!-- In most (European) countries, сemeteries are usually independent of places of worship (e.g. military cemeteries), while grave yards are usually the yard of a place of worship. -->
 	<string name="type.landuse.cemetery.christian">Хрысціянскія могілкі</string>
 	<string name="type.landuse.education">Адукацыйныя ўстановы</string>
+	<string name="type.leisure.garden.residential">Частный сад</string>
 	<string name="type.leisure.marina">Прычал</string>
 	<string name="type.leisure.picnic_table">Стол для пікніка</string>
 	<string name="type.sport.climbing">Скаладром</string>

--- a/android/res/values-cs/strings.xml
+++ b/android/res/values-cs/strings.xml
@@ -1117,6 +1117,7 @@
 	<string name="type.leisure.fitness_centre">Fitness</string>
 	<string name="type.leisure.fitness_station">Posilovna</string>
 	<string name="type.leisure.garden">Zahrada</string>
+	<string name="type.leisure.garden.residential">Zahrada</string>
 	<string name="type.leisure.golf_course">Golf</string>
 	<string name="type.leisure.nature_reserve">Rezervace</string>
 	<string name="type.leisure.park">Park</string>

--- a/android/res/values-da/strings.xml
+++ b/android/res/values-da/strings.xml
@@ -1110,6 +1110,7 @@
 	<string name="type.leisure.fitness_centre">Trænings- og motionscenter</string>
 	<string name="type.leisure.fitness_station">Fitness-station</string>
 	<string name="type.leisure.garden">Have</string>
+	<string name="type.leisure.garden.residential">Have</string>
 	<string name="type.leisure.golf_course">Golf</string>
 	<string name="type.leisure.nature_reserve">Reservat</string>
 	<string name="type.leisure.park">Park</string>

--- a/android/res/values-de/strings.xml
+++ b/android/res/values-de/strings.xml
@@ -1251,6 +1251,7 @@
 	<string name="type.leisure.fitness_centre">Fitnessstudio</string>
 	<string name="type.leisure.fitness_station">Fitnessstation</string>
 	<string name="type.leisure.garden">Garten</string>
+	<string name="type.leisure.garden.residential">Garten</string>
 	<string name="type.leisure.golf_course">Golfplatz</string>
 	<string name="type.leisure.ice_rink">Eislaufplatz</string>
 	<string name="type.leisure.marina">Jachthafen</string>

--- a/android/res/values-el/strings.xml
+++ b/android/res/values-el/strings.xml
@@ -1118,6 +1118,7 @@
 	<string name="type.leisure.fitness_centre">Κέντρο γυμναστικής</string>
 	<string name="type.leisure.fitness_station">Γυμναστήριο</string>
 	<string name="type.leisure.garden">Κήπος αναψυχής</string>
+	<string name="type.leisure.garden.residential">Κήπος αναψυχής</string>
 	<string name="type.leisure.golf_course">Γήπεδο γκολφ</string>
 	<string name="type.leisure.nature_reserve">Φυσικό απόθεμα</string>
 	<string name="type.leisure.park">Πάρκο</string>

--- a/android/res/values-es/strings.xml
+++ b/android/res/values-es/strings.xml
@@ -1209,6 +1209,7 @@
 	<string name="type.leisure.fitness_centre">Centro de fitness</string>
 	<string name="type.leisure.fitness_station">Gimnasio</string>
 	<string name="type.leisure.garden">Jardín</string>
+	<string name="type.leisure.garden.residential">Jardín</string>
 	<string name="type.leisure.golf_course">Campo de golf</string>
 	<string name="type.leisure.nature_reserve">Territorio reservado</string>
 	<string name="type.leisure.park">Parque</string>

--- a/android/res/values-eu/strings.xml
+++ b/android/res/values-eu/strings.xml
@@ -1185,6 +1185,7 @@
 	<string name="type.leisure.fitness_centre">Fitness zentroa</string>
 	<string name="type.leisure.fitness_station">Gimnasioa</string>
 	<string name="type.leisure.garden">Lorategi</string>
+	<string name="type.leisure.garden.residential">Lorategi</string>
 	<string name="type.leisure.golf_course">Golf kurtsoa</string>
 	<string name="type.leisure.nature_reserve">Erreserbatutako lurraldea</string>
 	<string name="type.leisure.park">Parkea</string>

--- a/android/res/values-fa/strings.xml
+++ b/android/res/values-fa/strings.xml
@@ -1033,6 +1033,7 @@
 	<string name="type.leisure.fitness_centre">باشگاه بدنسازی</string>
 	<string name="type.leisure.fitness_station">پارک سلامت</string>
 	<string name="type.leisure.garden">گردشگری</string>
+	<string name="type.leisure.garden.residential">گردشگری</string>
 	<string name="type.leisure.golf_course">زمین گلف</string>
 	<string name="type.leisure.park">پارک</string>
 	<string name="type.leisure.park.no.access">پارک</string>

--- a/android/res/values-fi/strings.xml
+++ b/android/res/values-fi/strings.xml
@@ -1130,6 +1130,7 @@
 	<string name="type.leisure.fitness_centre">Kuntosali</string>
 	<string name="type.leisure.fitness_station">Kuntokeskus</string>
 	<string name="type.leisure.garden">Puutarha</string>
+	<string name="type.leisure.garden.residential">Puutarha</string>
 	<string name="type.leisure.golf_course">Golf-rata</string>
 	<string name="type.leisure.nature_reserve">Luonnonsuojelualue</string>
 	<string name="type.leisure.park">Puisto</string>

--- a/android/res/values-fr/strings.xml
+++ b/android/res/values-fr/strings.xml
@@ -1239,6 +1239,7 @@
 	<string name="type.leisure.fitness_centre">Centre fitness</string>
 	<string name="type.leisure.fitness_station">Station de fitness</string>
 	<string name="type.leisure.garden">Jardin</string>
+	<string name="type.leisure.garden.residential">Jardin</string>
 	<string name="type.leisure.golf_course">Terrain de golf</string>
 	<string name="type.leisure.ice_rink">Patinoire</string>
 	<string name="type.leisure.nature_reserve">Réserve naturelle</string>

--- a/android/res/values-hu/strings.xml
+++ b/android/res/values-hu/strings.xml
@@ -1116,6 +1116,7 @@
 	<string name="type.leisure.fitness_centre">Fitnesz-terem</string>
 	<string name="type.leisure.fitness_station">Fitness állomás</string>
 	<string name="type.leisure.garden">Kert</string>
+	<string name="type.leisure.garden.residential">Kert</string>
 	<string name="type.leisure.golf_course">Golfpálya</string>
 	<string name="type.leisure.nature_reserve">Védett terület</string>
 	<string name="type.leisure.park">Park</string>

--- a/android/res/values-in/strings.xml
+++ b/android/res/values-in/strings.xml
@@ -1111,6 +1111,7 @@
 	<string name="type.leisure.fitness_centre">Pusat kebugaran</string>
 	<string name="type.leisure.fitness_station">Stasiun Kebugaran</string>
 	<string name="type.leisure.garden">Situs arkeologi</string>
+	<string name="type.leisure.garden.residential">Situs arkeologi</string>
 	<string name="type.leisure.golf_course">Lapangan golf</string>
 	<string name="type.leisure.nature_reserve">Cagar Alam</string>
 	<string name="type.leisure.park">Taman</string>

--- a/android/res/values-it/strings.xml
+++ b/android/res/values-it/strings.xml
@@ -1148,6 +1148,7 @@
 	<string name="type.leisure.fitness_centre">Centro benessere</string>
 	<string name="type.leisure.fitness_station">Centro fitness</string>
 	<string name="type.leisure.garden">Giardino</string>
+	<string name="type.leisure.garden.residential">Giardino</string>
 	<string name="type.leisure.golf_course">Campo da golf</string>
 	<string name="type.leisure.nature_reserve">Riserva</string>
 	<string name="type.leisure.park">Parco</string>

--- a/android/res/values-ja/strings.xml
+++ b/android/res/values-ja/strings.xml
@@ -1188,6 +1188,7 @@
 	<string name="type.leisure.fitness_centre">フィットネスセンター、ジム</string>
 	<string name="type.leisure.fitness_station">フィットネスステーション</string>
 	<string name="type.leisure.garden">庭園</string>
+	<string name="type.leisure.garden.residential">庭園</string>
 	<string name="type.leisure.golf_course">ゴルフコース</string>
 	<string name="type.leisure.ice_rink">アイスリンク</string>
 	<string name="type.leisure.landscape_reserve">自然保護区</string>

--- a/android/res/values-ko/strings.xml
+++ b/android/res/values-ko/strings.xml
@@ -1117,6 +1117,7 @@
 	<string name="type.leisure.fitness_centre">피트니스센터</string>
 	<string name="type.leisure.fitness_station">피트니스 스테이션</string>
 	<string name="type.leisure.garden">정원</string>
+	<string name="type.leisure.garden.residential">정원</string>
 	<string name="type.leisure.golf_course">골프장</string>
 	<string name="type.leisure.nature_reserve">천연보호구역</string>
 	<string name="type.leisure.park">공원</string>

--- a/android/res/values-mr/strings.xml
+++ b/android/res/values-mr/strings.xml
@@ -1154,6 +1154,7 @@
 	<string name="type.leisure.dog_park">कुत्र्याचे क्षेत्र</string>
 	<string name="type.leisure.fitness_centre">व्यायामशाळा</string>
 	<string name="type.leisure.garden">बाग</string>
+	<string name="type.leisure.garden.residential">बाग</string>
 	<string name="type.leisure.golf_course">गोल्फचे मैदान</string>
 	<string name="type.leisure.ice_rink">हिम क्रीडा क्षेत्र</string>
 	<string name="type.leisure.nature_reserve">संरक्षित निसर्गक्षेत्र</string>

--- a/android/res/values-nb/strings.xml
+++ b/android/res/values-nb/strings.xml
@@ -1112,6 +1112,7 @@
 	<string name="type.leisure.fitness_centre">Treningssenter</string>
 	<string name="type.leisure.fitness_station">Treningssenter</string>
 	<string name="type.leisure.garden">Hage</string>
+	<string name="type.leisure.garden.residential">Hage</string>
 	<string name="type.leisure.golf_course">Golfbane</string>
 	<string name="type.leisure.nature_reserve">Reservat</string>
 	<string name="type.leisure.park">Park</string>

--- a/android/res/values-nl/strings.xml
+++ b/android/res/values-nl/strings.xml
@@ -1266,6 +1266,7 @@
 	<string name="type.leisure.fitness_centre">Fitnesscentrum</string>
 	<string name="type.leisure.fitness_station">Fitness-Station</string>
 	<string name="type.leisure.garden">Tuin</string>
+	<string name="type.leisure.garden.residential">Tuin</string>
 	<string name="type.leisure.golf_course">Golfbaan</string>
 	<string name="type.leisure.ice_rink">Schaatsbaan</string>
 	<string name="type.leisure.landscape_reserve">Landschapsreservaat</string>

--- a/android/res/values-pl/strings.xml
+++ b/android/res/values-pl/strings.xml
@@ -1214,6 +1214,7 @@
 	<string name="type.leisure.fitness_centre">Centrum fitness</string>
 	<string name="type.leisure.fitness_station">Stacja fitness</string>
 	<string name="type.leisure.garden">Ogród</string>
+	<string name="type.leisure.garden.residential">Ogród przydomowy</string>
 	<string name="type.leisure.golf_course">Kurs golfowy</string>
 	<string name="type.leisure.ice_rink">Lodowisko</string>
 	<string name="type.leisure.landscape_reserve">Rezerwat krajobrazu</string>

--- a/android/res/values-pt-rBR/strings.xml
+++ b/android/res/values-pt-rBR/strings.xml
@@ -1210,6 +1210,7 @@
 	<string name="type.leisure.fitness_centre">Academia de ginástica</string>
 	<string name="type.leisure.fitness_station">Estação de fitness</string>
 	<string name="type.leisure.garden">Jardim</string>
+	<string name="type.leisure.garden.residential">Jardim residencial</string>
 	<string name="type.leisure.golf_course">Campo de golfe</string>
 	<string name="type.leisure.ice_rink">Rinque de patinação</string>
 	<string name="type.leisure.landscape_reserve">Reserva natural</string>

--- a/android/res/values-pt/strings.xml
+++ b/android/res/values-pt/strings.xml
@@ -1223,6 +1223,7 @@
 	<string name="type.leisure.fitness_centre">Academia de fitness</string>
 	<string name="type.leisure.fitness_station">Dispositivo público de exercícios</string>
 	<string name="type.leisure.garden">Jardim</string>
+	<string name="type.leisure.garden.residential">Jardim residencial</string>
 	<string name="type.leisure.golf_course">Campo de golfe</string>
 	<string name="type.leisure.ice_rink">Rinque de patinagem</string>
 	<string name="type.leisure.landscape_reserve">Reserva natural</string>

--- a/android/res/values-ro/strings.xml
+++ b/android/res/values-ro/strings.xml
@@ -1137,6 +1137,7 @@
 	<string name="type.leisure.fitness_centre">Centru fitness</string>
 	<string name="type.leisure.fitness_station">Sală de fitness</string>
 	<string name="type.leisure.garden">Sit arheologic</string>
+	<string name="type.leisure.garden.residential">Sit arheologic</string>
 	<string name="type.leisure.golf_course">Teren de golf</string>
 	<string name="type.leisure.nature_reserve">Rezervație naturală</string>
 	<string name="type.leisure.park">Parc</string>

--- a/android/res/values-ru/strings.xml
+++ b/android/res/values-ru/strings.xml
@@ -1287,6 +1287,7 @@
 	<string name="type.leisure.fitness_centre">Фитнес-клуб</string>
 	<string name="type.leisure.fitness_station">Спортивные снаряды</string>
 	<string name="type.leisure.garden">Сад</string>
+	<string name="type.leisure.garden.residential">Частный сад</string>
 	<string name="type.leisure.golf_course">Площадка для гольфа</string>
 	<string name="type.leisure.ice_rink">Каток</string>
 	<string name="type.leisure.landscape_reserve">Ландшафтный заповедник</string>

--- a/android/res/values-sk/strings.xml
+++ b/android/res/values-sk/strings.xml
@@ -1114,6 +1114,7 @@
 	<string name="type.leisure.fitness_centre">Fitnescentrum</string>
 	<string name="type.leisure.fitness_station">Fitness</string>
 	<string name="type.leisure.garden">Záhrada</string>
+	<string name="type.leisure.garden.residential">Záhrada</string>
 	<string name="type.leisure.golf_course">Golf</string>
 	<string name="type.leisure.nature_reserve">Rezervácia</string>
 	<string name="type.leisure.park">Park</string>

--- a/android/res/values-sv/strings.xml
+++ b/android/res/values-sv/strings.xml
@@ -1109,6 +1109,7 @@
 	<string name="type.leisure.fitness_centre">Gym</string>
 	<string name="type.leisure.fitness_station">Fitnesstation</string>
 	<string name="type.leisure.garden">Trädgård</string>
+	<string name="type.leisure.garden.residential">Trädgård</string>
 	<string name="type.leisure.golf_course">Golfbana</string>
 	<string name="type.leisure.nature_reserve">Naturreservat</string>
 	<string name="type.leisure.park">Parken</string>

--- a/android/res/values-th/strings.xml
+++ b/android/res/values-th/strings.xml
@@ -1121,6 +1121,7 @@
 	<string name="type.leisure.fitness_centre">ฟิตเนสเซ็นเตอร์</string>
 	<string name="type.leisure.fitness_station">ศูนย์ฟิตเนส</string>
 	<string name="type.leisure.garden">สวน</string>
+	<string name="type.leisure.garden.residential">สวน</string>
 	<string name="type.leisure.golf_course">สนามกอล์ฟ</string>
 	<string name="type.leisure.nature_reserve">เขตอนุรักษ์ธรรมชาติ</string>
 	<string name="type.leisure.park">สวนสาธารณะ</string>

--- a/android/res/values-tr/strings.xml
+++ b/android/res/values-tr/strings.xml
@@ -1273,6 +1273,7 @@
 	<string name="type.leisure.fitness_centre">Fitness Merkezi</string>
 	<string name="type.leisure.fitness_station">Fitness Salonu</string>
 	<string name="type.leisure.garden">Bahçe</string>
+	<string name="type.leisure.garden.residential">Konut Bahçesi</string>
 	<string name="type.leisure.golf_course">Golf Sahası</string>
 	<string name="type.leisure.ice_rink">Buz Pateni Pisti</string>
 	<string name="type.leisure.landscape_reserve">Peyzaj Rezervi</string>

--- a/android/res/values-uk/strings.xml
+++ b/android/res/values-uk/strings.xml
@@ -1255,6 +1255,7 @@
 	<string name="type.leisure.fitness_centre">Фітнес-зал</string>
 	<string name="type.leisure.fitness_station">Спортивні знаряддя</string>
 	<string name="type.leisure.garden">Садок</string>
+	<string name="type.leisure.garden.residential">Частный сад</string>
 	<string name="type.leisure.golf_course">Майданчик для гольфу</string>
 	<string name="type.leisure.ice_rink">Каток</string>
 	<string name="type.leisure.landscape_reserve">Ландшафтний заповідник</string>

--- a/android/res/values-vi/strings.xml
+++ b/android/res/values-vi/strings.xml
@@ -1116,6 +1116,7 @@
 	<string name="type.leisure.fitness_centre">Phòng Tập</string>
 	<string name="type.leisure.fitness_station">Trạm tập thể hình</string>
 	<string name="type.leisure.garden">Điểm khảo cổ</string>
+	<string name="type.leisure.garden.residential">Điểm khảo cổ</string>
 	<string name="type.leisure.golf_course">Sân gôn</string>
 	<string name="type.leisure.nature_reserve">Giữ chỗ</string>
 	<string name="type.leisure.park">Công viên</string>

--- a/android/res/values-zh-rTW/strings.xml
+++ b/android/res/values-zh-rTW/strings.xml
@@ -1161,6 +1161,7 @@
 	<string name="type.leisure.fitness_centre">健身中心</string>
 	<string name="type.leisure.fitness_station">健身房</string>
 	<string name="type.leisure.garden">花園</string>
+	<string name="type.leisure.garden.residential">花園</string>
 	<string name="type.leisure.golf_course">高爾夫球場</string>
 	<string name="type.leisure.nature_reserve">自然保護區</string>
 	<string name="type.leisure.park">公園</string>

--- a/android/res/values-zh/strings.xml
+++ b/android/res/values-zh/strings.xml
@@ -1209,6 +1209,7 @@
 	<string name="type.leisure.fitness_centre">健身中心</string>
 	<string name="type.leisure.fitness_station">健身驿站</string>
 	<string name="type.leisure.garden">花园</string>
+	<string name="type.leisure.garden.residential">居民区花园</string>
 	<string name="type.leisure.golf_course">高尔夫球场</string>
 	<string name="type.leisure.ice_rink">滑冰场</string>
 	<string name="type.leisure.marina">游艇码头</string>

--- a/android/res/values/strings.xml
+++ b/android/res/values/strings.xml
@@ -1318,6 +1318,7 @@
 	<string name="type.leisure.fitness_centre">Fitness Centre</string>
 	<string name="type.leisure.fitness_station">Fitness Station</string>
 	<string name="type.leisure.garden">Garden</string>
+	<string name="type.leisure.garden.residential">Residential Garden</string>
 	<string name="type.leisure.golf_course">Golf Course</string>
 	<string name="type.leisure.ice_rink">Ice Rink</string>
 	<string name="type.leisure.landscape_reserve">Landscape Reserve</string>

--- a/data/categories.txt
+++ b/data/categories.txt
@@ -3046,20 +3046,21 @@ zh-Hans:城门
 zh-Hant:城門
 
 historic-fort|@tourism
-en = Fort
-ar = قلعة
-de = Festung
-fr = Fort militaire
-ja = 歴史的な要塞
-mr = दुर्ग
-pl = Historyczny fort
-pt = Forte histórico
-pt-BR = Forte histórico
-ru = Форт
-tr = Hisar
-uk = Форт
-zh-Hans = 历史要塞
-zh-Hant = 歷史要塞
+en:Fort
+ar:قلعة
+de:Festung
+fr:Fort militaire
+it:Fortezza
+ja:歴史的な要塞
+mr:दुर्ग
+pl:Historyczny fort
+pt:Forte histórico
+pt-BR:Forte histórico
+ru:Форт
+tr:Hisar
+uk:Форт
+zh-Hans:历史要塞
+zh-Hant:歷史要塞
 
 historic-memorial|@tourism
 en:4Memorial|monument|U+1F5FC|U+1F5FD|U+1F5FF
@@ -8481,6 +8482,7 @@ vi:Nhà kim khí
 zh-Hans:金属制造工
 zh-Hant:鐵工
 
+craft-painter
 en:Painter
 ar:رسام
 be:Мастак

--- a/data/strings/types_strings.txt
+++ b/data/strings/types_strings.txt
@@ -12118,6 +12118,18 @@
     zh-Hans = 花园
     zh-Hant = 花園
 
+  [type.leisure.garden.residential]
+    ref = type.leisure.garden
+    en = Residential Garden
+    be = Частный сад
+    pl = Ogród przydomowy
+    pt = Jardim residencial
+    pt-BR = Jardim residencial
+    ru = Частный сад
+    tr = Konut Bahçesi
+    uk = Частный сад
+    zh-Hans = 居民区花园
+
   [type.leisure.golf_course]
     en = Golf Course
     ar = ملعب جولف

--- a/iphone/Maps/LocalizedStrings/ar.lproj/Localizable.strings
+++ b/iphone/Maps/LocalizedStrings/ar.lproj/Localizable.strings
@@ -2312,6 +2312,8 @@
 
 "type.leisure.garden" = "حديقة";
 
+"type.leisure.garden.residential" = "حديقة";
+
 "type.leisure.golf_course" = "ملعب جولف";
 
 "type.leisure.ice_rink" = "Ice Rink";

--- a/iphone/Maps/LocalizedStrings/be.lproj/Localizable.strings
+++ b/iphone/Maps/LocalizedStrings/be.lproj/Localizable.strings
@@ -2312,6 +2312,8 @@
 
 "type.leisure.garden" = "Garden";
 
+"type.leisure.garden.residential" = "Частный сад";
+
 "type.leisure.golf_course" = "Golf Course";
 
 "type.leisure.ice_rink" = "Ice Rink";

--- a/iphone/Maps/LocalizedStrings/bg.lproj/Localizable.strings
+++ b/iphone/Maps/LocalizedStrings/bg.lproj/Localizable.strings
@@ -2312,6 +2312,8 @@
 
 "type.leisure.garden" = "Garden";
 
+"type.leisure.garden.residential" = "Garden";
+
 "type.leisure.golf_course" = "Golf Course";
 
 "type.leisure.ice_rink" = "Ice Rink";

--- a/iphone/Maps/LocalizedStrings/ca.lproj/Localizable.strings
+++ b/iphone/Maps/LocalizedStrings/ca.lproj/Localizable.strings
@@ -2312,6 +2312,8 @@
 
 "type.leisure.garden" = "Garden";
 
+"type.leisure.garden.residential" = "Garden";
+
 "type.leisure.golf_course" = "Golf Course";
 
 "type.leisure.ice_rink" = "Ice Rink";

--- a/iphone/Maps/LocalizedStrings/cs.lproj/Localizable.strings
+++ b/iphone/Maps/LocalizedStrings/cs.lproj/Localizable.strings
@@ -2312,6 +2312,8 @@
 
 "type.leisure.garden" = "Zahrada";
 
+"type.leisure.garden.residential" = "Zahrada";
+
 "type.leisure.golf_course" = "Golf";
 
 "type.leisure.ice_rink" = "Ice Rink";

--- a/iphone/Maps/LocalizedStrings/da.lproj/Localizable.strings
+++ b/iphone/Maps/LocalizedStrings/da.lproj/Localizable.strings
@@ -2312,6 +2312,8 @@
 
 "type.leisure.garden" = "Have";
 
+"type.leisure.garden.residential" = "Have";
+
 "type.leisure.golf_course" = "Golf";
 
 "type.leisure.ice_rink" = "Ice Rink";

--- a/iphone/Maps/LocalizedStrings/de.lproj/Localizable.strings
+++ b/iphone/Maps/LocalizedStrings/de.lproj/Localizable.strings
@@ -2312,6 +2312,8 @@
 
 "type.leisure.garden" = "Garten";
 
+"type.leisure.garden.residential" = "Garten";
+
 "type.leisure.golf_course" = "Golfplatz";
 
 "type.leisure.ice_rink" = "Eislaufplatz";

--- a/iphone/Maps/LocalizedStrings/el.lproj/Localizable.strings
+++ b/iphone/Maps/LocalizedStrings/el.lproj/Localizable.strings
@@ -2312,6 +2312,8 @@
 
 "type.leisure.garden" = "Κήπος αναψυχής";
 
+"type.leisure.garden.residential" = "Κήπος αναψυχής";
+
 "type.leisure.golf_course" = "Γήπεδο γκολφ";
 
 "type.leisure.ice_rink" = "Ice Rink";

--- a/iphone/Maps/LocalizedStrings/en-GB.lproj/Localizable.strings
+++ b/iphone/Maps/LocalizedStrings/en-GB.lproj/Localizable.strings
@@ -2312,6 +2312,8 @@
 
 "type.leisure.garden" = "Garden";
 
+"type.leisure.garden.residential" = "Garden";
+
 "type.leisure.golf_course" = "Golf Course";
 
 "type.leisure.ice_rink" = "Ice Rink";

--- a/iphone/Maps/LocalizedStrings/en.lproj/Localizable.strings
+++ b/iphone/Maps/LocalizedStrings/en.lproj/Localizable.strings
@@ -2312,6 +2312,8 @@
 
 "type.leisure.garden" = "Garden";
 
+"type.leisure.garden.residential" = "Residential Garden";
+
 "type.leisure.golf_course" = "Golf Course";
 
 "type.leisure.ice_rink" = "Ice Rink";

--- a/iphone/Maps/LocalizedStrings/es-MX.lproj/Localizable.strings
+++ b/iphone/Maps/LocalizedStrings/es-MX.lproj/Localizable.strings
@@ -1378,9 +1378,9 @@
 
 "type.amenity.parking.underground" = "Aparcamiento";
 
-"type.amenity.parking_entrance.private" = "Parking entrance";
+"type.amenity.parking_entrance.private" = "Entrada al aparcamiento";
 
-"type.amenity.parking_entrance.permissive" = "Parking entrance";
+"type.amenity.parking_entrance.permissive" = "Entrada al aparcamiento";
 
 "type.amenity.parking_entrance" = "Entrada al aparcamiento";
 
@@ -1561,7 +1561,7 @@
 
 "type.boundary.administrative.11" = "Frontera administrativa";
 
-"type.boundary.administrative.2" = "National Border";
+"type.boundary.administrative.2" = "Frontera de país";
 
 "type.boundary.administrative.3" = "Frontera administrativa";
 
@@ -1865,22 +1865,22 @@
 
 "type.highway.footway" = "Camino";
 
-"type.highway.footway.alpine_hiking" = "Path";
+"type.highway.footway.alpine_hiking" = "Camino";
 
 "type.highway.footway.area" = "Camino";
 
 /* These translations are used for all type.highway.*.bridge. */
 "type.highway.footway.bridge" = "Puente";
 
-"type.highway.footway.demanding_alpine_hiking" = "Path";
+"type.highway.footway.demanding_alpine_hiking" = "Camino";
 
-"type.highway.footway.demanding_mountain_hiking" = "Path";
+"type.highway.footway.demanding_mountain_hiking" = "Camino";
 
-"type.highway.footway.difficult_alpine_hiking" = "Path";
+"type.highway.footway.difficult_alpine_hiking" = "Camino";
 
-"type.highway.footway.hiking" = "Path";
+"type.highway.footway.hiking" = "Camino";
 
-"type.highway.footway.mountain_hiking" = "Path";
+"type.highway.footway.mountain_hiking" = "Camino";
 
 "type.highway.footway.permissive" = "Camino";
 
@@ -2312,6 +2312,8 @@
 
 "type.leisure.garden" = "Jardín";
 
+"type.leisure.garden.residential" = "Jardín";
+
 "type.leisure.golf_course" = "Campo de golf";
 
 "type.leisure.ice_rink" = "Ice Rink";
@@ -2630,7 +2632,7 @@
 
 "type.railway.funicular.tunnel" = "Funicular";
 
-"type.railway.halt" = "Train Station";
+"type.railway.halt" = "Estación de tren";
 
 "type.railway.level_crossing" = "Cruce de ferrocarril";
 

--- a/iphone/Maps/LocalizedStrings/es.lproj/Localizable.strings
+++ b/iphone/Maps/LocalizedStrings/es.lproj/Localizable.strings
@@ -2312,6 +2312,8 @@
 
 "type.leisure.garden" = "Jardín";
 
+"type.leisure.garden.residential" = "Jardín";
+
 "type.leisure.golf_course" = "Campo de golf";
 
 "type.leisure.ice_rink" = "Ice Rink";

--- a/iphone/Maps/LocalizedStrings/eu.lproj/Localizable.strings
+++ b/iphone/Maps/LocalizedStrings/eu.lproj/Localizable.strings
@@ -2312,6 +2312,8 @@
 
 "type.leisure.garden" = "Lorategi";
 
+"type.leisure.garden.residential" = "Lorategi";
+
 "type.leisure.golf_course" = "Golf kurtsoa";
 
 "type.leisure.ice_rink" = "Ice Rink";

--- a/iphone/Maps/LocalizedStrings/fa.lproj/Localizable.strings
+++ b/iphone/Maps/LocalizedStrings/fa.lproj/Localizable.strings
@@ -2312,6 +2312,8 @@
 
 "type.leisure.garden" = "گردشگری";
 
+"type.leisure.garden.residential" = "گردشگری";
+
 "type.leisure.golf_course" = "زمین گلف";
 
 "type.leisure.ice_rink" = "Ice Rink";

--- a/iphone/Maps/LocalizedStrings/fi.lproj/Localizable.strings
+++ b/iphone/Maps/LocalizedStrings/fi.lproj/Localizable.strings
@@ -2312,6 +2312,8 @@
 
 "type.leisure.garden" = "Puutarha";
 
+"type.leisure.garden.residential" = "Puutarha";
+
 "type.leisure.golf_course" = "Golf-rata";
 
 "type.leisure.ice_rink" = "Ice Rink";

--- a/iphone/Maps/LocalizedStrings/fr.lproj/Localizable.strings
+++ b/iphone/Maps/LocalizedStrings/fr.lproj/Localizable.strings
@@ -2312,6 +2312,8 @@
 
 "type.leisure.garden" = "Jardin";
 
+"type.leisure.garden.residential" = "Jardin";
+
 "type.leisure.golf_course" = "Terrain de golf";
 
 "type.leisure.ice_rink" = "Patinoire";

--- a/iphone/Maps/LocalizedStrings/he.lproj/Localizable.strings
+++ b/iphone/Maps/LocalizedStrings/he.lproj/Localizable.strings
@@ -2312,6 +2312,8 @@
 
 "type.leisure.garden" = "Garden";
 
+"type.leisure.garden.residential" = "Garden";
+
 "type.leisure.golf_course" = "Golf Course";
 
 "type.leisure.ice_rink" = "Ice Rink";

--- a/iphone/Maps/LocalizedStrings/hu.lproj/Localizable.strings
+++ b/iphone/Maps/LocalizedStrings/hu.lproj/Localizable.strings
@@ -2312,6 +2312,8 @@
 
 "type.leisure.garden" = "Kert";
 
+"type.leisure.garden.residential" = "Kert";
+
 "type.leisure.golf_course" = "Golfpálya";
 
 "type.leisure.ice_rink" = "Ice Rink";

--- a/iphone/Maps/LocalizedStrings/id.lproj/Localizable.strings
+++ b/iphone/Maps/LocalizedStrings/id.lproj/Localizable.strings
@@ -2312,6 +2312,8 @@
 
 "type.leisure.garden" = "Situs arkeologi";
 
+"type.leisure.garden.residential" = "Situs arkeologi";
+
 "type.leisure.golf_course" = "Lapangan golf";
 
 "type.leisure.ice_rink" = "Ice Rink";

--- a/iphone/Maps/LocalizedStrings/it.lproj/Localizable.strings
+++ b/iphone/Maps/LocalizedStrings/it.lproj/Localizable.strings
@@ -2312,6 +2312,8 @@
 
 "type.leisure.garden" = "Giardino";
 
+"type.leisure.garden.residential" = "Giardino";
+
 "type.leisure.golf_course" = "Campo da golf";
 
 "type.leisure.ice_rink" = "Ice Rink";

--- a/iphone/Maps/LocalizedStrings/ja.lproj/Localizable.strings
+++ b/iphone/Maps/LocalizedStrings/ja.lproj/Localizable.strings
@@ -2312,6 +2312,8 @@
 
 "type.leisure.garden" = "庭園";
 
+"type.leisure.garden.residential" = "庭園";
+
 "type.leisure.golf_course" = "ゴルフコース";
 
 "type.leisure.ice_rink" = "アイスリンク";

--- a/iphone/Maps/LocalizedStrings/ko.lproj/Localizable.strings
+++ b/iphone/Maps/LocalizedStrings/ko.lproj/Localizable.strings
@@ -2312,6 +2312,8 @@
 
 "type.leisure.garden" = "정원";
 
+"type.leisure.garden.residential" = "정원";
+
 "type.leisure.golf_course" = "골프장";
 
 "type.leisure.ice_rink" = "Ice Rink";

--- a/iphone/Maps/LocalizedStrings/mr.lproj/Localizable.strings
+++ b/iphone/Maps/LocalizedStrings/mr.lproj/Localizable.strings
@@ -2312,6 +2312,8 @@
 
 "type.leisure.garden" = "बाग";
 
+"type.leisure.garden.residential" = "बाग";
+
 "type.leisure.golf_course" = "गोल्फचे मैदान";
 
 "type.leisure.ice_rink" = "हिम क्रीडा क्षेत्र";

--- a/iphone/Maps/LocalizedStrings/nb.lproj/Localizable.strings
+++ b/iphone/Maps/LocalizedStrings/nb.lproj/Localizable.strings
@@ -2312,6 +2312,8 @@
 
 "type.leisure.garden" = "Hage";
 
+"type.leisure.garden.residential" = "Hage";
+
 "type.leisure.golf_course" = "Golfbane";
 
 "type.leisure.ice_rink" = "Ice Rink";

--- a/iphone/Maps/LocalizedStrings/nl.lproj/Localizable.strings
+++ b/iphone/Maps/LocalizedStrings/nl.lproj/Localizable.strings
@@ -2312,6 +2312,8 @@
 
 "type.leisure.garden" = "Tuin";
 
+"type.leisure.garden.residential" = "Tuin";
+
 "type.leisure.golf_course" = "Golfbaan";
 
 "type.leisure.ice_rink" = "Schaatsbaan";

--- a/iphone/Maps/LocalizedStrings/pl.lproj/Localizable.strings
+++ b/iphone/Maps/LocalizedStrings/pl.lproj/Localizable.strings
@@ -2312,6 +2312,8 @@
 
 "type.leisure.garden" = "Ogród";
 
+"type.leisure.garden.residential" = "Ogród przydomowy";
+
 "type.leisure.golf_course" = "Kurs golfowy";
 
 "type.leisure.ice_rink" = "Lodowisko";

--- a/iphone/Maps/LocalizedStrings/pt-BR.lproj/Localizable.strings
+++ b/iphone/Maps/LocalizedStrings/pt-BR.lproj/Localizable.strings
@@ -2312,6 +2312,8 @@
 
 "type.leisure.garden" = "Jardim";
 
+"type.leisure.garden.residential" = "Jardim residencial";
+
 "type.leisure.golf_course" = "Campo de golfe";
 
 "type.leisure.ice_rink" = "Rinque de patinação";

--- a/iphone/Maps/LocalizedStrings/pt.lproj/Localizable.strings
+++ b/iphone/Maps/LocalizedStrings/pt.lproj/Localizable.strings
@@ -2312,6 +2312,8 @@
 
 "type.leisure.garden" = "Jardim";
 
+"type.leisure.garden.residential" = "Jardim residencial";
+
 "type.leisure.golf_course" = "Campo de golfe";
 
 "type.leisure.ice_rink" = "Rinque de patinagem";

--- a/iphone/Maps/LocalizedStrings/ro.lproj/Localizable.strings
+++ b/iphone/Maps/LocalizedStrings/ro.lproj/Localizable.strings
@@ -2312,6 +2312,8 @@
 
 "type.leisure.garden" = "Sit arheologic";
 
+"type.leisure.garden.residential" = "Sit arheologic";
+
 "type.leisure.golf_course" = "Teren de golf";
 
 "type.leisure.ice_rink" = "Ice Rink";

--- a/iphone/Maps/LocalizedStrings/ru.lproj/Localizable.strings
+++ b/iphone/Maps/LocalizedStrings/ru.lproj/Localizable.strings
@@ -2312,6 +2312,8 @@
 
 "type.leisure.garden" = "Сад";
 
+"type.leisure.garden.residential" = "Частный сад";
+
 "type.leisure.golf_course" = "Площадка для гольфа";
 
 "type.leisure.ice_rink" = "Каток";

--- a/iphone/Maps/LocalizedStrings/sk.lproj/Localizable.strings
+++ b/iphone/Maps/LocalizedStrings/sk.lproj/Localizable.strings
@@ -2312,6 +2312,8 @@
 
 "type.leisure.garden" = "Záhrada";
 
+"type.leisure.garden.residential" = "Záhrada";
+
 "type.leisure.golf_course" = "Golf";
 
 "type.leisure.ice_rink" = "Ice Rink";

--- a/iphone/Maps/LocalizedStrings/sv.lproj/Localizable.strings
+++ b/iphone/Maps/LocalizedStrings/sv.lproj/Localizable.strings
@@ -2312,6 +2312,8 @@
 
 "type.leisure.garden" = "Trädgård";
 
+"type.leisure.garden.residential" = "Trädgård";
+
 "type.leisure.golf_course" = "Golfbana";
 
 "type.leisure.ice_rink" = "Ice Rink";

--- a/iphone/Maps/LocalizedStrings/sw.lproj/Localizable.strings
+++ b/iphone/Maps/LocalizedStrings/sw.lproj/Localizable.strings
@@ -2312,6 +2312,8 @@
 
 "type.leisure.garden" = "Garden";
 
+"type.leisure.garden.residential" = "Garden";
+
 "type.leisure.golf_course" = "Golf Course";
 
 "type.leisure.ice_rink" = "Ice Rink";

--- a/iphone/Maps/LocalizedStrings/th.lproj/Localizable.strings
+++ b/iphone/Maps/LocalizedStrings/th.lproj/Localizable.strings
@@ -2312,6 +2312,8 @@
 
 "type.leisure.garden" = "สวน";
 
+"type.leisure.garden.residential" = "สวน";
+
 "type.leisure.golf_course" = "สนามกอล์ฟ";
 
 "type.leisure.ice_rink" = "Ice Rink";

--- a/iphone/Maps/LocalizedStrings/tr.lproj/Localizable.strings
+++ b/iphone/Maps/LocalizedStrings/tr.lproj/Localizable.strings
@@ -2312,6 +2312,8 @@
 
 "type.leisure.garden" = "Bahçe";
 
+"type.leisure.garden.residential" = "Konut Bahçesi";
+
 "type.leisure.golf_course" = "Golf Sahası";
 
 "type.leisure.ice_rink" = "Buz Pateni Pisti";

--- a/iphone/Maps/LocalizedStrings/uk.lproj/Localizable.strings
+++ b/iphone/Maps/LocalizedStrings/uk.lproj/Localizable.strings
@@ -2312,6 +2312,8 @@
 
 "type.leisure.garden" = "Садок";
 
+"type.leisure.garden.residential" = "Частный сад";
+
 "type.leisure.golf_course" = "Майданчик для гольфу";
 
 "type.leisure.ice_rink" = "Каток";

--- a/iphone/Maps/LocalizedStrings/vi.lproj/Localizable.strings
+++ b/iphone/Maps/LocalizedStrings/vi.lproj/Localizable.strings
@@ -2312,6 +2312,8 @@
 
 "type.leisure.garden" = "Điểm khảo cổ";
 
+"type.leisure.garden.residential" = "Điểm khảo cổ";
+
 "type.leisure.golf_course" = "Sân gôn";
 
 "type.leisure.ice_rink" = "Ice Rink";

--- a/iphone/Maps/LocalizedStrings/zh-Hans.lproj/Localizable.strings
+++ b/iphone/Maps/LocalizedStrings/zh-Hans.lproj/Localizable.strings
@@ -2312,6 +2312,8 @@
 
 "type.leisure.garden" = "花园";
 
+"type.leisure.garden.residential" = "居民区花园";
+
 "type.leisure.golf_course" = "高尔夫球场";
 
 "type.leisure.ice_rink" = "滑冰场";

--- a/iphone/Maps/LocalizedStrings/zh-Hant.lproj/Localizable.strings
+++ b/iphone/Maps/LocalizedStrings/zh-Hant.lproj/Localizable.strings
@@ -2312,6 +2312,8 @@
 
 "type.leisure.garden" = "花園";
 
+"type.leisure.garden.residential" = "花園";
+
 "type.leisure.golf_course" = "高爾夫球場";
 
 "type.leisure.ice_rink" = "Ice Rink";


### PR DESCRIPTION
Added residential garden translation (fixes #3396), 
changed historic-fort to ' = ' for consistency, 
add type to craft-painter category to remove logspam

Signed-off-by: Harry Bond <endim8@pm.me>