### PR TITLE
Update release notes

### DIFF
--- a/android/src/fdroid/play/release-notes/de-DE/default.txt
+++ b/android/src/fdroid/play/release-notes/de-DE/default.txt
@@ -1,9 +1,10 @@
-• neue Kartendaten vom 16. August
-• längere Routen werden nun deutlich schneller berechnet
-• die Suchfunktion ist nun zuverlässiger und schneller
-• reduzierter Speicherplatzverbrauch der Offlinekarten
-• Fehler, dass manche Suchergebnisse nicht auf der Karte angezeigt wurden, wurde behoben
-• verbesserte Darstellung von Militärgebieten und Grenzen
-• barrierefreie Parkplätze werden nun auf der Karte angezeigt
-• verschiedene Icons für Sportarten hinzugefügt
-meht unter omaps.app/news
+• Neue OSM-Kartendaten ab dem 12. September
+• Entfernte untere Symbolleiste für bessere UX und Sichtbarkeit der Karte
+• Verbesserte OSM-Anmeldeseite und OSM-Profil
+• Schnellere, bessere Suche
+• Absturz beim Starten nach der Bearbeitung behoben
+• Lesezeichenlisten sind nun nach der letzten Änderungszeit sortiert
+• Fixierte Übersetzungen
+• Fahr-, Musik- und Sprachschulen, archäologische Stätten und Schlösser hinzugefügt
+• Andere Stile und Icons wurden verbessert
+…mehr: omaps.app/news

--- a/android/src/fdroid/play/release-notes/de-DE/default.txt
+++ b/android/src/fdroid/play/release-notes/de-DE/default.txt
@@ -4,7 +4,7 @@
 • Schnellere, bessere Suche
 • Absturz beim Starten nach der Bearbeitung behoben
 • Lesezeichenlisten sind nun nach der letzten Änderungszeit sortiert
-• Fixierte Übersetzungen
+• Verbesserte Übersetzungen
 • Fahr-, Musik- und Sprachschulen, archäologische Stätten und Schlösser hinzugefügt
 • Andere Stile und Icons wurden verbessert
 …mehr: omaps.app/news

--- a/android/src/fdroid/play/release-notes/en-US/default.txt
+++ b/android/src/fdroid/play/release-notes/en-US/default.txt
@@ -1,12 +1,11 @@
-• New data as of August 16
-• Longer routes are calculated way faster than before
-• Search should work way better and faster now, many improvements!
-• Reduced size of mwm files
-• Fixed issue when some found objects were not highlighted on the map
-• Improved visibility of military areas and boundaries
-• Show disabled parking spaces
-• Added different sports icons
-• Render farm yard
-• Updated Arabic translations and TTS texts
-• Belarusian translations of countries
-…more: organicmaps.app/news
+• New OSM maps data as of September 12
+• Removed bottom toolbar for better UX & map visibility
+• Improved OSM login page & OSM profile
+• Faster, better search
+• Fixed crash on startup after editing
+• Bookmark lists are now sorted by recently modified time
+• Fixed nl, pt-BR, it, ca, tr, be translations
+• Enabled Catalan TTS (Text-To-Speech)
+• Added driving-, music- and language schools, archaeological_site, castles
+• Improved other styles and icons
+…more: omaps.app/news

--- a/android/src/fdroid/play/release-notes/tr-TR/default.txt
+++ b/android/src/fdroid/play/release-notes/tr-TR/default.txt
@@ -1,11 +1,10 @@
-• Yeni harita verileri (16 Ağustos)
-• Uzun rotalar artık eskisinden çok daha hızlı hesaplanıyor
-• Arama iyileştirildi, artık çok daha iyi ve daha hızlı!
-• mwm (harita) dosya boyutları azaltıldı
-• Aranan bazı nesnelerin haritada gösterilmemesi sorunu düzeltildi
-• Askeri alan ve sınırların görünürlüğü iyileştirildi
-• Engelli park yerleri eklendi
-• Farklı spor simgeleri eklendi
-• Çiftlik avlusu eklendi
-• Eksik çeviriler eklendi
-…dahası: organicmaps.app/news
+• Yeni OSM haritaları verileri 12 Eylül itibariyle
+• Daha iyi UX ve harita görünürlüğü için alt araç çubuğu kaldırıldı
+• Geliştirilmiş OSM giriş sayfası ve OSM profili
+• Daha hızlı, daha iyi arama
+• Düzenlemeden sonra başlangıçta oluşan çökme düzeltildi
+• Yer imi listeleri artık son değiştirilme zamanına göre sıralanıyor
+• Bazı çeviriler iyileştirildi
+• Sürüş, müzik ve dil okulları, arkeolojik_site, kaleler eklendi
+• Diğer stiller ve simgeler geliştirildi
+…daha fazlası: omaps.app/news

--- a/iphone/metadata/de-DE/release_notes.txt
+++ b/iphone/metadata/de-DE/release_notes.txt
@@ -1,46 +1,32 @@
-Highlights:
-• Neue Daten vom 16. August
-• Längere Routen werden schneller berechnet
-• Die Suche sollte jetzt viel besser und schneller funktionieren
-• Reduzierte Größe der mwm-Dateien
-• Wiederhergestellte WunderLINQ-Unterstützung (ja, wir haben eine API! Siehe omaps.app/api)
+• Neue OSM-Kartendaten ab dem 12. September
+• Absturz beim Starten nach dem Bearbeiten einiger OSM-Objekte behoben
+• Lesezeichenlisten werden nun nach der letzten Änderungszeit sortiert
+• Verbesserte Anzeige des nächsten Straßennamens in der Wegbeschreibung
+• Überall wird die gleiche Systemschrift verwendet
+• Verwenden Sie die Standard-Mail-App unter iOS 14, um einen Fehler zu melden
+• Aktivierte katalanische Übersetzungen
 
-Benutzeroberfläche:
-• Vereinheitlichtes Layout von Orts-Seite und Editor UI
-• Ersetzte Höhendifferenz zu Aufstieg und Abstieg
-• Anzeige der POI-Ebene auf der Orts-Seite
-• Social Media Kanäle werden auf der Ortsseite und im Editor angezeigt
-• Anzeige von "Öffnet in"/"Schließt in" auf der Ort-Seite
-• Animation für seitliche Schaltflächen korrigiert
+Suche:
+• Anzeige von Funktionen im Ansichtsfenster oben in den Suchergebnissen
+• Erhebliche Beschleunigung einiger Suchszenarien
+• Verbessertes Kategorie-Ranking und Adressensuche.
+• Das Symbol für hervorgehobene Hotelsuchergebnisse auf der Karte wurde korrigiert
+• Verbesserte deutsche Kategoriesuche
 
-Navigation:
-• Verbesserte Anzeige der Geschwindigkeitsbegrenzung für CarPlay (rot bei Geschwindigkeitsüberschreitung)
-• Feste Kreisverkehrsnummer
-• Verbesserte Sichtbarkeit der nächsten Straße
+Stile und Icons:
+• Fahrschule, Musikschule, Sprachschule, archäologische Stätte hinzugefügt,
+• Die Hintergründe von historischen Friedhofssymbolen wurden entfernt
+• Verschiedene Schlosstypen hinzugefügt: castrum, fortified_church, fortress, hillfort, kremlin, manor, palace & shiro
+• Erhöhte Sichtbarkeit von Bildung und einigen Sportarten
+• Getrennte Möbel- und Küchentypen
+• Besser aussehende Freizeit=Bahn
+• Verkaufs=Brennstoff-Symbol repariert
 
-Verbesserungen bei der Suche:
-• Problem behoben, bei dem einige gefundene Objekte nicht auf der Karte hervorgehoben wurden
-• Gängige Synonyme für die Straßensuche wie Parkway, Path, Line, Walk, Trail, etc. wurden entfernt.
-• Die Koordinatensuche wurde korrigiert, wenn die Anfrage einen Zeilenumbruch enthält
-• Ignorieren nicht relevanter Suchergebnisse für Koordinaten
-• Bessere Suche nach Hauptstädten
-• 'Notfall' als letzte Wahl des Merkmalstyps behandeln
-• Synonyme für die Straßensuche in Cathalan hinzugefügt
-• Richtiges Filtern gleicher Straßen in den Suchergebnissen
+Lokalisierungen:
+• Fehlende Übersetzungen für craft=* hinzugefügt
+• Übersetzungen für Niederländisch, Portugiesisch (Brasilien), Italienisch, Katalanisch, Türkisch und Weißrussisch hinzugefügt/korrigiert
+• Katalanisch TTS (Text-To-Speech) aktiviert
+• Einige Telegram- und Instagram-Links wurden lokalisiert
 
-Kartenstile:
-• Verbesserte Sichtbarkeit von militärischen Gebieten und Grenzen
-• Behindertenparkplätze anzeigen
-• Symbol für Hausgärten nicht einzeichnen
-• Bauernhof gerendert
-• Parkplateinfahrt (parking_entrance) hinzufügen
-• Spielplatz- und Internetcafé-Symbol hinzufügen
-• Second Hand Laden (second_hand) und Sozialkaufhaus (charity) hinzufügen
-• Hinzufügen von Tischtennis, Volleyball, Beachvolleyball, Skateboard, Schach, Padel, Handball, Futsal, Hockey, Badminton, Pelota
-• Hintergrundkreise aus den Icons entfernt
 
-Übersetzungen:
-• Arabische Übersetzungen und TTS-Texte aktualisiert
-• Fehlende Übersetzungen für place=* hinzugefügt
-• Weißrussische Übersetzungen von Ländern
-• Fehlende türkische Übersetzungen hinzugefügt
+Übersetzt mit www.DeepL.com/Translator (kostenlose Version)

--- a/iphone/metadata/de-DE/release_notes.txt
+++ b/iphone/metadata/de-DE/release_notes.txt
@@ -27,6 +27,3 @@ Lokalisierungen:
 • Übersetzungen für Niederländisch, Portugiesisch (Brasilien), Italienisch, Katalanisch, Türkisch und Weißrussisch hinzugefügt/korrigiert
 • Katalanisch TTS (Text-To-Speech) aktiviert
 • Einige Telegram- und Instagram-Links wurden lokalisiert
-
-
-Übersetzt mit www.DeepL.com/Translator (kostenlose Version)

--- a/iphone/metadata/en-US/release_notes.txt
+++ b/iphone/metadata/en-US/release_notes.txt
@@ -1,46 +1,29 @@
-Highlights:
-• New data as of August 16
-• Longer routes are calculated faster
-• Search should work way better and faster now
-• Reduced size of mwm files
-• Restored WunderLINQ support (yes, we have an API! Check omaps.app/api)
+• New OSM maps data as of September 12
+• Fixed crash on startup after editing some OSM objects
+• Bookmark lists are now sorted by recently modified time
+• Improved displaying of the next street name directions
+• Use the same system font everywhere
+• Use the default mail app on iOS 14 to report a bug
+• Enabled Catalan translations
 
-User Interface:
-• Unified Place Page and Editor UI layout
-• Replaced altitude difference to ascent and descent
-• Show POI level in Place Page
-• Social media contacts are displayed in Place Page and Editor
-• Show "Opens in"/"Closes in" in Place Page
-• Fixed animation for side buttons
+Search:
+• Show features in the viewport at the top of search results
+• Significantly speedup some search scenarios
+• Improved category ranking & address search.
+• Fixed highlighted hotel search results icon on the map
+• Improved German category search
 
-Navigation:
-• Improved speed limit displaying for CarPlay (red for overspeed)
-• Fixed roundabout number
-• Increased visibility of next street
+Styles and icons:
+• Added driving_school, music_school, language_school, archaeological_site,
+• Removed backgrounds from historic cemetery icons
+• Added different castle types: castrum, fortified_church, fortress, hillfort, kremlin, manor, palace & shiro
+• Increased visibility of education & some sports
+• Separated furniture & kitchen types
+• Better looking leisure=track
+• Fixed vending=fuel icon
 
-Search improvements:
-• Fixed issue when some found objects were not highlighted on the map
-• Removed common street search synonyms like parkway, path, line, walk, trail, etc.
-• Fixed coordinates search if query contains newline
-• Ignore non-relevant search results for coordinates
-• Better search for capitails
-• Treat 'emergency' as last-choice feature type
-• Added Cathalan street search synonyms
-• Properly filter equal streets in search results
-
-Map styles:
-• Improved visibility of military areas and boundaries
-• Show disabled parking spaces
-• Do not draw icon for residential gardens
-• Render farm yard
-• Add parking_entrance
-• Add playground and internet cafe icon
-• Add second_hand and charity
-• Add table_tennis, volleyball, beachvolleyball, skateboard, chess, padel, handball, futsal, hockey, badminton, pelota
-• Removed background circles from icons
-
-Translations:
-• Updated Arabic translations and TTS texts
-• Added missing translations for place=*
-• Belarusian translations of countries
-• Added missing Turkish translations
+Localizations:
+• Added missing translations for craft=*
+• Added/fixed Dutch, Portuguese (Brazil), Italian, Catalan, Turkish, Belarusian translations
+• Enabled Catalan TTS (Text-To-Speech)
+• Localized some Telegram and Instagram links

--- a/iphone/metadata/en-US/release_notes.txt
+++ b/iphone/metadata/en-US/release_notes.txt
@@ -15,7 +15,7 @@ Search:
 • Improved German category search
 
 Styles and icons:
-• Added driving_school, music_school, language_school, archaeological_site,
+• Added driving_school, music_school, language_school, archaeological_site, craft-painter
 • Removed backgrounds from historic cemetery icons
 • Added different castle types: castrum, fortified_church, fortress, hillfort, kremlin, manor, palace & shiro
 • Increased visibility of education & some sports

--- a/iphone/metadata/en-US/release_notes.txt
+++ b/iphone/metadata/en-US/release_notes.txt
@@ -1,6 +1,7 @@
 • New OSM maps data as of September 12
 • Fixed crash on startup after editing some OSM objects
 • Bookmark lists are now sorted by recently modified time
+• Fixed annoying "Continue detecting location" dialog when returning to OM
 • Improved displaying of the next street name directions
 • Use the same system font everywhere
 • Use the default mail app on iOS 14 to report a bug

--- a/iphone/metadata/en-US/release_notes.txt
+++ b/iphone/metadata/en-US/release_notes.txt
@@ -24,7 +24,7 @@ Styles and icons:
 • Fixed vending=fuel icon
 
 Localizations:
-• Added missing translations for craft=*
+• Added missing translations for craft=* and residential gardens
 • Added/fixed Dutch, Portuguese (Brazil), Italian, Catalan, Turkish, Belarusian translations
 • Enabled Catalan TTS (Text-To-Speech)
 • Localized some Telegram and Instagram links

--- a/iphone/metadata/tr/release_notes.txt
+++ b/iphone/metadata/tr/release_notes.txt
@@ -1,43 +1,32 @@
-Öne Çıkanlar:
-• Yeni harita verileri (16 Ağustos)
-• Uzun rotalar artık daha hızlı hesaplanıyor
-• Arama artık daha iyi ve daha hızlı
-• mwm (harita) dosya boyutları azaltıldı
-• WunderLINQ desteği geri geldi (evet, API hizmetimiz mevcut! omaps.app/api adresini ziyaret edin)
+• Yeni OSM haritaları verileri 12 Eylül itibariyle
+• Bazı OSM nesnelerini düzenledikten sonra başlangıçta oluşan çökme düzeltildi
+• Yer imi listeleri artık son değiştirilme zamanına göre sıralanıyor
+• Bir sonraki sokak adı talimatlarının daha iyi görüntülenmesi
+• Her yerde aynı sistem yazı tipini kullanın
+• Bir hatayı bildirmek için iOS 14'te varsayılan posta uygulamasını kullanın
+• Katalanca çevirileri etkinleştirildi
 
-Kullanıcı Arayüzü:
-• Birleşik Mekan Sayfası ve Düzenleyici Arayüzü düzeni
-• Yükseklik farkı, iniş ve çıkış olarak değiştirildi
-• Mekan Sayfasında POI (İÇN) seviyesi gösteriliyor
-• Sosyal medya bağlantıları Mekan Sayfası ve Düzenleyicide gösteriliyor
-• Mekan Sayfasında "süre sonra açılıyor/kapanıyor" gösteriliyor
-• Kenardaki butonlar için animasyonlar düzeltildi
+Arama yapın:
+• Arama sonuçlarının üst kısmındaki görünüm alanında özellikleri gösterin
+• Bazı arama senaryolarını önemli ölçüde hızlandırır
+• Kategori sıralaması ve adres araması iyileştirildi.
+• Harita üzerinde vurgulanan otel arama sonuçları simgesi düzeltildi
+• Geliştirilmiş Almanca kategori araması
 
-Navigasyon:
-• CarPlay için geliştirilmiş hız sınırı görüntüleme (aşırı hızlı için kırmızı)
-• Kavşak numaraları düzeltildi
-• Bir sonraki sokağın görünürlüğü arttırıldı
+Stiller ve simgeler:
+• Sürücü_okulu, müzik_okulu, dil_okulu, arkeolojik_site eklendi,
+• Tarihi mezarlık simgelerinden arka planlar kaldırıldı
+• Farklı kale türleri eklendi: castrum, fortified_church, fortress, hillfort, kremlin, manor, palace & shiro
+• Eğitim ve bazı spor dallarının görünürlüğünün artması
+• Ayrılmış mobilya ve mutfak tipleri
+• Daha iyi görünümlü eğlence=track
+• Otomat=yakıt simgesi düzeltildi
 
-Arama İyileştirmeleri:
-• Aranan bazı nesnelerin haritada vurgulanmaması sorunu düzeltildi
-• Park yolu, yol, hat, yürüyüş yolu, patika vb. gibi yaygın sokak arama eş anlamlıları kaldırıldı.
-• Arama sorgusunda yeni satır içeren koordinat aramaları düzeltildi
-• Koordinatlar için alakasız arama sonuçları kaldırıldı
-• Başkentler için daha iyi arama
-• 'Acil' kategorisi son seçenek özellik türü olarak hesaplanıyor
-• Artık arama sonuçlarında aynı seviyedeki caddeleri uygun şekilde filtreleniyor
+Yerelleştirmeler:
+• craft=* için eksik çeviriler eklendi
+• Hollandaca, Portekizce (Brezilya), İtalyanca, Katalanca, Türkçe, Belarusça çeviriler eklendi/düzeltildi
+• Etkin Katalanca TTS (Metin Okuma)
+• Bazı Telegram ve Instagram bağlantıları yerelleştirildi
 
-Harita Stili:
-• Askeri alan ve sınırların görünürlüğü iyileştirildi
-• Engelli park yerleri eklendi
-• Artık konut bahçeleri için simge gösterilmiyor
-• Çiftlik avlusu eklendi
-• parking_entrance eklendi
-• Oyun alanı ve internet kafe simgesi eklendi
-• second_hand ve hayır kurumları eklendi
-• table_tennis, volleyball, beachvolleyball, skateboard, chess, padel, handball, futsal, hockey, badminton, pelota eklendi
-• Simgelerden arka plan daireleri kaldırıldı
 
-Çeviriler:
-• place=* için eksik çeviriler eklendi
-• Eksik Türkçe çeviriler eklendi
+Translated with www.DeepL.com/Translator (free version)

--- a/iphone/metadata/tr/release_notes.txt
+++ b/iphone/metadata/tr/release_notes.txt
@@ -27,6 +27,3 @@ Yerelleştirmeler:
 • Hollandaca, Portekizce (Brezilya), İtalyanca, Katalanca, Türkçe, Belarusça çeviriler eklendi/düzeltildi
 • Etkin Katalanca TTS (Metin Okuma)
 • Bazı Telegram ve Instagram bağlantıları yerelleştirildi
-
-
-Translated with www.DeepL.com/Translator (free version)


### PR DESCRIPTION
Signed-off-by: Roman Tsisyk <roman@tsisyk.com>

##

[strings] add missing translations for craft=*
[styles] Add driving_school, music_school and language_school
[editor] Fixed exception type.
[search] Better street's FeaturesLayer filtering logic.
[search] Decrease score for numeric streets like "2-й ...".
[search] Increased penalty for error; increased city rank factor.
[search] Added Shop POI type for ranking.
[search] Fixed category results ranking.
[search] Cleanup debug features fetching.
[search][tests] Correct affiliations initialization.
[desktop] Added "ru" locale and category checkbox.
[search] Fixed categories.
[strings] Add @501Ghost's NL translations
[android] set bottom map buttons max width to 300dp
[android] Adjust ruler and copyright to transparent nav bar
[android] Adjust compass to transparent nav bar
[android] Make navigation bar transparent on map
[android] Make splash screen navigation bar follow background color
[android] Add themed icon for Android 13
[symbols] Added norating-bg-l.png mask.
[android] Fix displaying hotel rating in search results
[styles] Add icon for archaeological_site
[android] remove custom search activity fade
[symbols] Removed background circles from icons used for tag historic and cemetery-m.svg
[generator] Fixed castle_type.
[styles] Added castle_type castrum, fortified_church, fortress, hillfort, kremlin, manor, palace & shiro
[android] Minor search wheel clean up
[drape] Fixed dropped metalines.
[styles] Increased visibility of education and some sports
[android] try to match previous map buttons layout
[android] make buttons layout react to screen height
[android] use separate buttons layout for each map mode
[android] make all map buttons independent
[android] remove main menu bar
[android] replace custom map buttons by FloatingActionButton
[android] remove layers selection from main menu
[android] improve map buttons moving behavior
[android] unify handling of map buttons
[android] simplify layers button
[strings] Add nl-Dutch translations
[ios] Use default mail app on iOS 14 to report a bug
[search] Always process viewport MWM first (after World).
[android] Note to OSM editors
[styles] Tweaks for leisure=track
[strings] Beach volleyball in English is 2 words
[strings] Fixed not working pt-BR bowling transloation for iOS
[categories] Improve german category word coverage
[bookmarks] Fixed last modified time categories order.
[altitudes] Simplify loading checks.
[string] Fix Italian generic "Stop": set "Bus stop" + "Bus tram"
[styles] Change icon of vending=fuel
[android] Increased the font size of exit number
[android] improve osm login page
[strings] update osm strings
[android] refactor profile and add changes loading indicator
[android] rework OSM login UX
[direction] Fixed some bugs for next street name
Enabled Catalan translations for iOS
Enabled Catalan TTS
[strings] Add Catalan translation
Add cross-platform system fonts in CSS for copyright.html
Add cross-platform system fonts in CSS for faq.html
[ios] Change UI font from Helvetica to system
[strings] Added missing Turkish translations
[strings] Added Telegram and Instagram links
[strings] Added additional Belarusian names of countries
Separate furniture & kitchen types
[android] Fixed possible crash.