### PR TITLE
[android] update nav icons to match previous design

### DIFF
--- a/android/res/drawable/ic_follow.xml
+++ b/android/res/drawable/ic_follow.xml
@@ -1,5 +1,5 @@
 <vector android:height="24dp" android:tint="#FFFFFF"
     android:viewportHeight="24" android:viewportWidth="24"
     android:width="24dp" xmlns:android="http://schemas.android.com/apk/res/android">
-    <path android:fillColor="@android:color/white" android:pathData="M12,7.27l4.28,10.43 -3.47,-1.53 -0.81,-0.36 -0.81,0.36 -3.47,1.53L12,7.27M12,2L4.5,20.29l0.71,0.71L12,18l6.79,3 0.71,-0.71L12,2z"/>
+    <path android:fillColor="@android:color/white" android:pathData="M21 3L3 10.53V11.5L9.84 14.16L12.5 21H13.46L21 3Z"/>
 </vector>

--- a/android/res/drawable/ic_follow_and_rotate.xml
+++ b/android/res/drawable/ic_follow_and_rotate.xml
@@ -1,5 +1,22 @@
-<vector android:height="24dp" android:tint="#FFFFFF"
-    android:viewportHeight="24" android:viewportWidth="24"
-    android:width="24dp" xmlns:android="http://schemas.android.com/apk/res/android">
-    <path android:fillColor="@android:color/white" android:pathData="M12,2L4.5,20.29l0.71,0.71L12,18l6.79,3 0.71,-0.71z"/>
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:width="24dp"
+    android:height="24dp"
+    android:viewportWidth="24"
+    android:viewportHeight="24">
+  <path
+      android:fillColor="@android:color/white"
+      android:pathData="M12,5.484 L6.291,19.406 6.831,19.947 12,17.663l5.169,2.284 0.54,-0.54z"
+      android:strokeWidth="0.761229"/>
+  <path
+      android:pathData="m12,19.359v2.887"
+      android:strokeLineJoin="miter"
+      android:strokeWidth="1.5"
+      android:strokeColor="@android:color/white"
+      android:strokeLineCap="butt"/>
+  <path
+      android:pathData="m12,1.509v2.887"
+      android:strokeLineJoin="miter"
+      android:strokeWidth="1.5"
+      android:strokeColor="@android:color/white"
+      android:strokeLineCap="butt"/>
 </vector>

--- a/android/res/values/dimens.xml
+++ b/android/res/values/dimens.xml
@@ -89,6 +89,9 @@
   <dimen name="elevation_profile_height">108dp</dimen>
   <dimen name="elevation_profile_half_height">54dp</dimen>
   <dimen name="elevation_profile_dot_levels_margin">3dp</dimen>
+  <dimen name="map_button_size">48dp</dimen>
+  <dimen name="map_button_icon_size">28dp</dimen>
+  <dimen name="map_button_arrow_icon_size">34dp</dimen>
 
   <!-- routing layout -->
   <dimen name="routing_info_height">48dp</dimen>

--- a/android/res/values/styles.xml
+++ b/android/res/values/styles.xml
@@ -17,8 +17,8 @@
     <item name="hoveredFocusedTranslationZ">0dp</item>
     <item name="pressedTranslationZ">0dp</item>
     <item name="android:tint">?iconTint</item>
-    <item name="fabCustomSize">48dp</item>
-    <item name="maxImageSize">28dp</item>
+    <item name="fabCustomSize">@dimen/map_button_size</item>
+    <item name="maxImageSize">@dimen/map_button_icon_size</item>
     <item name="borderWidth">0dp</item>
   </style>
 

--- a/android/src/com/mapswithme/maps/widget/menu/MyPositionButton.java
+++ b/android/src/com/mapswithme/maps/widget/menu/MyPositionButton.java
@@ -9,6 +9,7 @@ import android.util.SparseArray;
 import android.view.View;
 
 import androidx.annotation.AttrRes;
+import androidx.annotation.DimenRes;
 import androidx.annotation.DrawableRes;
 import androidx.annotation.NonNull;
 import androidx.core.content.res.ResourcesCompat;
@@ -47,9 +48,16 @@ public class MyPositionButton
   {
     mMode = mode;
     Drawable image = mIcons.get(mode);
-    @AttrRes int colorAttr =
-        mode == LocationState.FOLLOW || mode == LocationState.FOLLOW_AND_ROTATE || mode == LocationState.PENDING_POSITION
-        ? R.attr.colorAccent : R.attr.iconTint;
+    @AttrRes int colorAttr = R.attr.iconTint;
+    @DimenRes int sizeDimen = R.dimen.map_button_icon_size;
+    if (mode == LocationState.FOLLOW || mode == LocationState.FOLLOW_AND_ROTATE || mode == LocationState.PENDING_POSITION)
+    {
+      colorAttr = R.attr.colorAccent;
+      if (mode == LocationState.PENDING_POSITION)
+        sizeDimen = R.dimen.map_button_size;
+      else
+        sizeDimen = R.dimen.map_button_arrow_icon_size;
+    }
     Resources resources = mButton.getResources();
     Context context = mButton.getContext();
     if (image == null)
@@ -78,6 +86,7 @@ public class MyPositionButton
     }
 
     mButton.setImageDrawable(image);
+    mButton.setMaxImageSize((int) resources.getDimension(sizeDimen));
     ImageViewCompat.setImageTintList(mButton, ColorStateList.valueOf(ThemeUtils.getColor(context, colorAttr)));
     updatePadding(mode);
 


### PR DESCRIPTION
First step of https://github.com/organicmaps/organicmaps/issues/3406.

Took the icons from [Material Design Icons](https://materialdesignicons.com/) and manually edited the _follow and rotate_ to add the line.

| not follow | pending | follow | follow and rotate |
|-|-|-|-|
| ![Screenshot_1663161694](https://user-images.githubusercontent.com/80701113/190165652-aef6304c-62ef-447b-a02a-1b4972603404.png) | ![Screenshot_1663161698](https://user-images.githubusercontent.com/80701113/190165667-41453d41-3bd0-4356-a856-be558e991ad9.png) | ![Screenshot_1663161711](https://user-images.githubusercontent.com/80701113/190165749-30db6b60-a0ab-457d-866a-ea0e27ea47c1.png) | ![Screenshot_1663161713](https://user-images.githubusercontent.com/80701113/190165827-f24146c7-2ba7-4abf-bcef-1e81796d5ad4.png) |
| | | ![navigation-variant](https://user-images.githubusercontent.com/80701113/190131952-5e1b7a11-8f1e-4be0-a6ac-c650c4821d78.svg) | ![navigation](https://user-images.githubusercontent.com/80701113/190088010-ec828d49-c78b-47f0-b997-08f2c19b5581.svg) |
