### PR TITLE
[android] increase size of zoom icons

### DIFF
--- a/android/res/layout/map_buttons_zoom.xml
+++ b/android/res/layout/map_buttons_zoom.xml
@@ -7,11 +7,11 @@
   android:orientation="vertical">
   <com.google.android.material.floatingactionbutton.FloatingActionButton
     android:id="@+id/nav_zoom_in"
-    style="@style/MwmWidget.MapButton"
+    style="@style/MwmWidget.MapButton.Zoom"
     android:src="@drawable/ic_plus"
     android:layout_marginBottom="@dimen/margin_half"/>
   <com.google.android.material.floatingactionbutton.FloatingActionButton
     android:id="@+id/nav_zoom_out"
-    style="@style/MwmWidget.MapButton"
+    style="@style/MwmWidget.MapButton.Zoom"
     android:src="@drawable/ic_minus" />
 </LinearLayout>

--- a/android/res/values/styles.xml
+++ b/android/res/values/styles.xml
@@ -22,6 +22,10 @@
     <item name="borderWidth">0dp</item>
   </style>
 
+  <style name="MwmWidget.MapButton.Zoom">
+    <item name="maxImageSize">34dp</item>
+  </style>
+
   <style name="MwmWidget.MapButton.Search">
     <item name="fabCustomSize">38dp</item>
   </style>


### PR DESCRIPTION
Another step for https://github.com/organicmaps/organicmaps/issues/3406.

Zoom icons are now a bit bigger.


![Screenshot_1663140516](https://user-images.githubusercontent.com/80701113/190090629-dbe07391-cbcb-4df7-961f-6f0213f133dd.png)
