### PR TITLE
[android] Don't stop location until Stop button is pressed

### DIFF
--- a/android/src/com/mapswithme/maps/MwmActivity.java
+++ b/android/src/com/mapswithme/maps/MwmActivity.java
@@ -1725,6 +1725,7 @@ public class MwmActivity extends BaseMwmFragmentActivity
           if (!LocationHelper.INSTANCE.isActive())
             LocationHelper.INSTANCE.start();
           LocationHelper.INSTANCE.switchToNextMode();
+          // TODO(AB): Leads to inconsistent UX: dialog won't appear later if user cancels and starts location search again.
           mLocationErrorDialogAnnoying = true;
         })
         .show();

--- a/android/src/com/mapswithme/maps/MwmActivity.java
+++ b/android/src/com/mapswithme/maps/MwmActivity.java
@@ -25,11 +25,11 @@ import androidx.annotation.Nullable;
 import androidx.annotation.StyleRes;
 import androidx.appcompat.app.AlertDialog;
 import androidx.appcompat.widget.Toolbar;
-import androidx.core.content.ContextCompat;
 import androidx.fragment.app.Fragment;
 import androidx.fragment.app.FragmentActivity;
 import androidx.fragment.app.FragmentManager;
 import androidx.fragment.app.FragmentTransaction;
+
 import com.mapswithme.maps.Framework.PlacePageActivationListener;
 import com.mapswithme.maps.api.Const;
 import com.mapswithme.maps.background.AppBackgroundTracker;
@@ -1657,6 +1657,9 @@ public class MwmActivity extends BaseMwmFragmentActivity
   @Override
   public void onLocationUpdated(@NonNull Location location)
   {
+    if (mLocationErrorDialog != null && mLocationErrorDialog.isShowing())
+      mLocationErrorDialog.dismiss();
+
     if (!RoutingController.get().isNavigating())
       return;
 
@@ -1687,6 +1690,7 @@ public class MwmActivity extends BaseMwmFragmentActivity
     AlertDialog.Builder builder = new AlertDialog.Builder(this)
         .setTitle(R.string.enable_location_services)
         .setMessage(R.string.location_is_disabled_long_text)
+        .setOnDismissListener(dialog -> mLocationErrorDialog = null)
         .setOnCancelListener(dialog -> mLocationErrorDialogAnnoying = true)
         .setNegativeButton(R.string.close, (dialog, which) -> mLocationErrorDialogAnnoying = true);
     final Intent intent = Utils.makeSystemLocationSettingIntent(this);
@@ -1703,38 +1707,32 @@ public class MwmActivity extends BaseMwmFragmentActivity
   @Override
   public void onLocationNotFound()
   {
-    showLocationNotFoundDialog();
+    if (mLocationErrorDialogAnnoying || (mLocationErrorDialog != null && mLocationErrorDialog.isShowing()))
+      return;
+
+    final String message = String.format("%s\n\n%s", getString(R.string.current_location_unknown_message),
+        getString(R.string.current_location_unknown_title));
+    mLocationErrorDialog = new AlertDialog.Builder(this)
+        .setMessage(message)
+        .setOnDismissListener(dialog -> mLocationErrorDialog = null)
+        .setNegativeButton(R.string.current_location_unknown_stop_button, (dialog, which) ->
+        {
+          LocationHelper.INSTANCE.setStopLocationUpdateByUser(true);
+          LocationHelper.INSTANCE.stop();
+        })
+        .setPositiveButton(R.string.current_location_unknown_continue_button, (dialog, which) ->
+        {
+          if (!LocationHelper.INSTANCE.isActive())
+            LocationHelper.INSTANCE.start();
+          LocationHelper.INSTANCE.switchToNextMode();
+          mLocationErrorDialogAnnoying = true;
+        })
+        .show();
   }
 
   @Override
   public void onRoutingFinish()
   {
-  }
-
-  private void showLocationNotFoundDialog()
-  {
-    String message = String.format("%s\n\n%s", getString(R.string.current_location_unknown_message),
-                                   getString(R.string.current_location_unknown_title));
-
-    DialogInterface.OnClickListener stopClickListener = (dialog, which) ->
-    {
-      LocationHelper.INSTANCE.setStopLocationUpdateByUser(true);
-      LocationHelper.INSTANCE.stop();
-    };
-
-    DialogInterface.OnClickListener continueClickListener = (dialog, which) ->
-    {
-      if (!LocationHelper.INSTANCE.isActive())
-        LocationHelper.INSTANCE.start();
-      LocationHelper.INSTANCE.switchToNextMode();
-    };
-
-    new AlertDialog.Builder(this)
-        .setMessage(message)
-        .setNegativeButton(R.string.current_location_unknown_stop_button, stopClickListener)
-        .setPositiveButton(R.string.current_location_unknown_continue_button, continueClickListener)
-        .setCancelable(false)
-        .show();
   }
 
   @Override

--- a/android/src/com/mapswithme/maps/location/LocationHelper.java
+++ b/android/src/com/mapswithme/maps/location/LocationHelper.java
@@ -151,7 +151,6 @@ public enum LocationHelper implements Initializable<Context>, AppBackgroundTrack
   private final LocationState.LocationPendingTimeoutListener mLocationPendingTimeoutListener = () -> {
     if (mActive)
     {
-      stop();
       if (PermissionsUtils.isLocationGranted(mContext) && LocationUtils.areLocationServicesTurnedOn(mContext))
         notifyLocationNotFound();
     }


### PR DESCRIPTION
The app displays "Current location is unknown. Do you want to continue detection your location?" dialog after if location wasn't found after 30 seconds. Before this patch, we disabled GPS even before the user pressed "Stop". With this patch, the app continue to search for location while the dialog is displayed, until "Stop" button is clicked explicitly.

Signed-off-by: Roman Tsisyk <roman@tsisyk.com>