### PR TITLE
[android] Window insets improvements

### DIFF
--- a/android/res/layout-land/layout_nav.xml
+++ b/android/res/layout-land/layout_nav.xml
@@ -41,5 +41,5 @@
     android:layout_width="0dp"
     android:layout_height="0dp"
     android:layout_gravity="bottom"
-    android:background="@color/bg_cards"/>
+    android:background="?cardBackground"/>
 </FrameLayout>

--- a/android/res/layout/layout_nav.xml
+++ b/android/res/layout/layout_nav.xml
@@ -40,5 +40,5 @@
     android:layout_width="0dp"
     android:layout_height="0dp"
     android:layout_gravity="bottom"
-    android:background="@color/bg_cards"/>
+    android:background="?cardBackground"/>
 </FrameLayout>

--- a/android/src/com/mapswithme/maps/MwmActivity.java
+++ b/android/src/com/mapswithme/maps/MwmActivity.java
@@ -426,14 +426,12 @@ public class MwmActivity extends BaseMwmFragmentActivity
 
   private void updateViewsInsets()
   {
-    findViewById(R.id.map_ui_container).setOnApplyWindowInsetsListener(this::setViewInsets);
-    findViewById(R.id.pp_buttons_layout).setOnApplyWindowInsetsListener(this::setViewInsets);
-    findViewById(R.id.toolbar).setOnApplyWindowInsetsListener(this::setViewInsets);
-    findViewById(R.id.menu_frame).setOnApplyWindowInsetsListener(this::setViewInsets);
-    findViewById(R.id.routing_plan_frame).findViewById(R.id.toolbar)
-                                         .setOnApplyWindowInsetsListener(this::setViewInsetsSides);
-
-    findViewById(R.id.map_fragment_container).setOnApplyWindowInsetsListener((view, windowInsets) -> {
+    findViewById(R.id.map_ui_container).setOnApplyWindowInsetsListener((view, windowInsets) -> {
+      setViewInsets(findViewById(R.id.map_ui_container), windowInsets);
+      setViewInsets(findViewById(R.id.pp_buttons_layout), windowInsets);
+      setViewInsets(findViewById(R.id.toolbar), windowInsets);
+      setViewInsets(findViewById(R.id.menu_frame), windowInsets);
+      setViewInsetsSides(findViewById(R.id.routing_plan_frame).findViewById(R.id.toolbar), windowInsets);
       navBarHeight = windowInsets.getSystemWindowInsetBottom();
       adjustCompass(-1, windowInsets.getSystemWindowInsetRight());
       adjustBottomWidgets(windowInsets.getSystemWindowInsetLeft());
@@ -441,18 +439,16 @@ public class MwmActivity extends BaseMwmFragmentActivity
     });
   }
 
-  private WindowInsets setViewInsets(View view, WindowInsets windowInsets)
+  private void setViewInsets(View view, WindowInsets windowInsets)
   {
     view.setPadding(windowInsets.getSystemWindowInsetLeft(), view.getPaddingTop(),
                     windowInsets.getSystemWindowInsetRight(), windowInsets.getSystemWindowInsetBottom());
-    return windowInsets;
   }
 
-  private WindowInsets setViewInsetsSides(View view, WindowInsets windowInsets)
+  private void setViewInsetsSides(View view, WindowInsets windowInsets)
   {
     view.setPadding(windowInsets.getSystemWindowInsetLeft(), view.getPaddingTop(),
                     windowInsets.getSystemWindowInsetRight(), view.getPaddingBottom());
-    return windowInsets;
   }
 
   private int getDownloadMapsCounter()


### PR DESCRIPTION
Improves on https://github.com/organicmaps/organicmaps/pull/3449

Window insets event registration is now done in `onStart`. Only one callback is used instead of one per view. Also fixes a UI issue with dark mode.

@vng what do you think? We can take the time to do a clean fix here.