### PR TITLE
[android] Install window insets handlers in onSafeCreate()

### DIFF
--- a/android/src/com/mapswithme/maps/MwmActivity.java
+++ b/android/src/com/mapswithme/maps/MwmActivity.java
@@ -410,6 +410,7 @@ public class MwmActivity extends BaseMwmFragmentActivity
 
     boolean isLaunchByDeepLink = getIntent().getBooleanExtra(EXTRA_LAUNCH_BY_DEEP_LINK, false);
     initViews(isLaunchByDeepLink);
+    updateViewsInsets();
 
     boolean isConsumed = savedInstanceState == null && processIntent(getIntent());
     boolean isFirstLaunch = Counters.isFirstLaunch(this);
@@ -1042,8 +1043,6 @@ public class MwmActivity extends BaseMwmFragmentActivity
     mNavigationController.onActivityResumed(this);
     mMapButtonsController.onResume();
     mPlacePageController.onActivityResumed(this);
-
-    updateViewsInsets();
   }
 
   @Override


### PR DESCRIPTION
This patch moves updateViewsInsets() from `onResume()` back to `onSafeCreate()`. The #3389 issue happened because of premature return from onSafeCreate() when app was lanunched with an intent:

```
    boolean isConsumed = savedInstanceState == null && processIntent(getIntent());
    boolean isFirstLaunch = Counters.isFirstLaunch(this);
    // If the map activity is launched by any incoming intent (deeplink, update maps event, etc)
    // or it's the first launch (onboarding) we haven't to try restoring the route,
    // showing the tips, etc.
    if (isConsumed || isFirstLaunch)
      return; <!-- Exited here.

    if (savedInstanceState == null && RoutingController.get().hasSavedRoute())
      addTask(new Factory.RestoreRouteTask());

    updateViewsInsets(); <!-- never reached if launched with an intent.
```

Follow up #3389

Signed-off-by: Roman Tsisyk <roman@tsisyk.com>