### PR TITLE
[iOS] 24 vs 12 hour time fix #3272

### DIFF
--- a/iphone/Maps/UI/PlacePage/Components/PlacePagePreviewViewController.swift
+++ b/iphone/Maps/UI/PlacePage/Components/PlacePagePreviewViewController.swift
@@ -136,7 +136,8 @@ final class PlacePagePreviewViewController: UIViewController {
     let now = time_t(Date().timeIntervalSince1970);
     
     let hourFormatter = DateFormatter();
-    hourFormatter.dateFormat = "HH:mm";
+    hourFormatter.locale = Locale.current
+    hourFormatter.timeStyle = .short
     
     switch placePagePreviewData.schedule.state {
     case .allDay:


### PR DESCRIPTION
Changed hourFormatter in PlacePagePreviewView Controller from hard-coded 24 hour format to locale dependent formatting. This resolves issue #3272 .