### PR TITLE
Update short-description.txt

### DIFF
--- a/android/src/fdroid/play/listings/de-DE/short-description.txt
+++ b/android/src/fdroid/play/listings/de-DE/short-description.txt
@@ -1,1 +1,1 @@
-Open-Source, gemeinschaftlich erstellte Karten für Reisende, Radler und Wanderer
+Open-Source, gemeinschaftlich erstellte Karten für den Alltag, Radeln und Wandern


### PR DESCRIPTION
Changed general word "Reisender" (Traveler) to "Alltag" (Every day use). I prefer "Alltag" over "Reisender" as this app is not only for holidays and recreational purposes but an everyday tool to be used in all kinds of contexts.  Furthermore I replaced person-description "Radler und Wanderer" (Cyclist and Hiker) to the verb-form (Cycling and Hiking) which seems more appropriate. You do not need to be a pro-hiker to use this app, but anyone can use it for hiking. Similar reasoning for cycling.