### PR TITLE
[android] Show "turn on Google's location service" dialog

### DIFF
--- a/android/flavors/gms-enabled/com/mapswithme/maps/location/GoogleFusedLocationProvider.java
+++ b/android/flavors/gms-enabled/com/mapswithme/maps/location/GoogleFusedLocationProvider.java
@@ -6,6 +6,7 @@ import android.os.Looper;
 
 import androidx.annotation.NonNull;
 import androidx.annotation.Nullable;
+
 import com.google.android.gms.location.FusedLocationProviderClient;
 import com.google.android.gms.location.LocationAvailability;
 import com.google.android.gms.location.LocationCallback;
@@ -15,8 +16,6 @@ import com.google.android.gms.location.LocationServices;
 import com.google.android.gms.location.LocationSettingsRequest;
 import com.google.android.gms.location.SettingsClient;
 import com.mapswithme.util.log.Logger;
-
-import static com.mapswithme.maps.location.LocationHelper.ERROR_NOT_SUPPORTED;
 
 class GoogleFusedLocationProvider extends BaseLocationProvider
 {
@@ -44,7 +43,6 @@ class GoogleFusedLocationProvider extends BaseLocationProvider
     {
       if (!availability.isLocationAvailable()) {
         Logger.w(TAG, "isLocationAvailable returned false");
-        //mListener.onLocationError(ERROR_GPS_OFF);
       }
     }
   }
@@ -90,7 +88,7 @@ class GoogleFusedLocationProvider extends BaseLocationProvider
       mFusedLocationClient.requestLocationUpdates(locationRequest, mCallback, Looper.myLooper());
     }).addOnFailureListener(e -> {
       Logger.e(TAG, "Service is not available: " + e);
-      mListener.onLocationError(ERROR_NOT_SUPPORTED);
+      mListener.onLocationDisabled();
     });
 
     // onLocationResult() may not always be called regularly, however the device location is known.

--- a/android/src/com/mapswithme/maps/MwmActivity.java
+++ b/android/src/com/mapswithme/maps/MwmActivity.java
@@ -219,6 +219,10 @@ public class MwmActivity extends BaseMwmFragmentActivity
     checkMeasurementSystem();
 
     LocationHelper.INSTANCE.attach(this);
+
+    if (!Config.isScreenSleepEnabled()) {
+      Utils.keepScreenOn(true, getWindow());
+    }
   }
 
   @Override
@@ -1096,6 +1100,7 @@ public class MwmActivity extends BaseMwmFragmentActivity
     MwmApplication.backgroundTracker(getActivity()).removeListener(this);
     IsolinesManager.from(getApplicationContext()).detach();
     mSearchController.detach();
+    Utils.keepScreenOn(false, getWindow());
   }
 
   @CallSuper

--- a/android/src/com/mapswithme/maps/MwmActivity.java
+++ b/android/src/com/mapswithme/maps/MwmActivity.java
@@ -61,6 +61,7 @@ import com.mapswithme.maps.intent.Factory;
 import com.mapswithme.maps.intent.MapTask;
 import com.mapswithme.maps.location.CompassData;
 import com.mapswithme.maps.location.LocationHelper;
+import com.mapswithme.maps.location.LocationState;
 import com.mapswithme.maps.maplayer.MapButtonsController;
 import com.mapswithme.maps.maplayer.Mode;
 import com.mapswithme.maps.maplayer.ToggleMapLayerFragment;
@@ -99,6 +100,7 @@ import com.mapswithme.util.UiUtils;
 import com.mapswithme.util.Utils;
 import com.mapswithme.util.bottomsheet.MenuBottomSheetFragment;
 import com.mapswithme.util.bottomsheet.MenuBottomSheetItem;
+import com.mapswithme.util.log.Logger;
 
 import java.util.ArrayList;
 import java.util.Objects;
@@ -111,6 +113,7 @@ public class MwmActivity extends BaseMwmFragmentActivity
                CustomNavigateUpListener,
                RoutingController.Container,
                LocationHelper.UiCallback,
+               LocationState.ModeChangeListener,
                RoutingPlanInplaceController.RoutingPlanListener,
                RoutingBottomMenuListener,
                BookmarkManager.BookmarksLoadingListener,
@@ -122,6 +125,8 @@ public class MwmActivity extends BaseMwmFragmentActivity
                MenuBottomSheetFragment.MenuBottomSheetInterfaceWithHeader,
                ToggleMapLayerFragment.LayerItemClickListener
 {
+  private static final String TAG = MwmActivity.class.getSimpleName();
+
   public static final String EXTRA_TASK = "map_task";
   public static final String EXTRA_LAUNCH_BY_DEEP_LINK = "launch_by_deep_link";
   public static final String EXTRA_BACK_URL = "backurl";
@@ -219,7 +224,8 @@ public class MwmActivity extends BaseMwmFragmentActivity
     checkMeasurementSystem();
 
     LocationHelper.INSTANCE.attach(this);
-
+    onMyPositionModeChanged(LocationHelper.INSTANCE.getMyPositionMode());
+    LocationState.nativeSetListener(this);
     if (!Config.isScreenSleepEnabled()) {
       Utils.keepScreenOn(true, getWindow());
     }
@@ -1645,6 +1651,8 @@ public class MwmActivity extends BaseMwmFragmentActivity
   @Override
   public void onMyPositionModeChanged(int newMode)
   {
+    Logger.d(TAG, "onMyPositionModeChanged mode = " + LocationState.nameOf(newMode));
+
     mMapButtonsController.updateNavMyPositionButton(newMode);
     RoutingController controller = RoutingController.get();
     if (controller.isPlanning())

--- a/android/src/com/mapswithme/maps/MwmActivity.java
+++ b/android/src/com/mapswithme/maps/MwmActivity.java
@@ -1681,14 +1681,14 @@ public class MwmActivity extends BaseMwmFragmentActivity
   }
 
   @Override
-  public void onLocationError(int errorCode)
+  public void onLocationDenied()
   {
-    if (errorCode == LocationHelper.ERROR_DENIED)
-    {
-      PermissionsUtils.requestLocationPermission(MwmActivity.this, REQ_CODE_LOCATION_PERMISSION);
-      return;
-    }
+    PermissionsUtils.requestLocationPermission(this, REQ_CODE_LOCATION_PERMISSION);
+  }
 
+  @Override
+  public void onLocationDisabled()
+  {
     if (mLocationErrorDialogAnnoying || (mLocationErrorDialog != null && mLocationErrorDialog.isShowing()))
       return;
 

--- a/android/src/com/mapswithme/maps/location/AndroidNativeProvider.java
+++ b/android/src/com/mapswithme/maps/location/AndroidNativeProvider.java
@@ -29,7 +29,7 @@ class AndroidNativeProvider extends BaseLocationProvider
       Logger.d(TAG, "Disabled location provider: " + provider);
       mProviderCount--;
       if (mProviderCount < MIN_PROVIDER_COUNT)
-        mListener.onLocationError(LocationHelper.ERROR_GPS_OFF);
+        mListener.onLocationDisabled();
     }
 
     @Override
@@ -78,7 +78,7 @@ class AndroidNativeProvider extends BaseLocationProvider
     mProviderCount = providers.size();
     if (mProviderCount < MIN_PROVIDER_COUNT)
     {
-      mListener.onLocationError(LocationHelper.ERROR_GPS_OFF);
+      mListener.onLocationDisabled();
     }
 
     for (String provider : providers)

--- a/android/src/com/mapswithme/maps/location/BaseLocationProvider.java
+++ b/android/src/com/mapswithme/maps/location/BaseLocationProvider.java
@@ -11,7 +11,7 @@ abstract class BaseLocationProvider
   interface Listener
   {
     void onLocationChanged(@NonNull Location location);
-    void onLocationDenied();
+    void onLocationDenied(@Nullable PendingIntent pendingIntent);
     void onLocationDisabled();
   }
 

--- a/android/src/com/mapswithme/maps/location/BaseLocationProvider.java
+++ b/android/src/com/mapswithme/maps/location/BaseLocationProvider.java
@@ -1,15 +1,18 @@
 package com.mapswithme.maps.location;
 
+import android.app.PendingIntent;
 import android.location.Location;
 
 import androidx.annotation.NonNull;
+import androidx.annotation.Nullable;
 
 abstract class BaseLocationProvider
 {
   interface Listener
   {
     void onLocationChanged(@NonNull Location location);
-    void onLocationError(int errorCode);
+    void onLocationDenied();
+    void onLocationDisabled();
   }
 
   @NonNull

--- a/android/src/com/mapswithme/maps/location/LocationHelper.java
+++ b/android/src/com/mapswithme/maps/location/LocationHelper.java
@@ -1,5 +1,6 @@
 package com.mapswithme.maps.location;
 
+import android.app.PendingIntent;
 import android.content.Context;
 import android.content.Intent;
 import android.content.IntentFilter;
@@ -268,12 +269,12 @@ public enum LocationHelper implements Initializable<Context>, AppBackgroundTrack
   }
 
   @Override
-  public void onLocationDenied()
+  public void onLocationDenied(@Nullable PendingIntent pendingIntent)
   {
     mSavedLocation = null;
     nativeOnLocationError(ERROR_DENIED);
     if (mUiCallback != null)
-      mUiCallback.onLocationDenied();
+      mUiCallback.onLocationDenied(pendingIntent);
   }
 
   @Override
@@ -427,7 +428,7 @@ public enum LocationHelper implements Initializable<Context>, AppBackgroundTrack
     if (!PermissionsUtils.isLocationGranted(mContext))
     {
       Logger.w(TAG, "Dynamic permissions ACCESS_COARSE_LOCATION and/or ACCESS_FINE_LOCATION are granted");
-      onLocationDenied();
+      onLocationDenied(null);
       return;
     }
     Logger.i(TAG, "start(): interval = " + mInterval + " provider = '" + mLocationProvider + "' mInFirstRun = " + mInFirstRun);
@@ -578,7 +579,7 @@ public enum LocationHelper implements Initializable<Context>, AppBackgroundTrack
   {
     void onLocationUpdated(@NonNull Location location);
     void onCompassUpdated(@NonNull CompassData compass);
-    void onLocationDenied();
+    void onLocationDenied(@Nullable PendingIntent pendingIntent);
     void onLocationDisabled();
     void onLocationNotFound();
     void onRoutingFinish();

--- a/android/src/com/mapswithme/maps/location/LocationHelper.java
+++ b/android/src/com/mapswithme/maps/location/LocationHelper.java
@@ -306,10 +306,6 @@ public enum LocationHelper implements Initializable<Context>, AppBackgroundTrack
     nativeOnLocationError(errCode);
     if (mUiCallback != null)
       mUiCallback.onLocationError(errCode);
-
-    for (LocationListener listener : mListeners)
-      listener.onLocationError(errCode);
-    mListeners.finishIterate();
   }
 
   private void notifyMyPositionModeChanged(int newMode)

--- a/android/src/com/mapswithme/maps/location/LocationHelper.java
+++ b/android/src/com/mapswithme/maps/location/LocationHelper.java
@@ -514,10 +514,6 @@ public enum LocationHelper implements Initializable<Context>, AppBackgroundTrack
 
     mUiCallback = callback;
 
-    if (!Config.isScreenSleepEnabled()) {
-      Utils.keepScreenOn(true, mUiCallback.getActivity().getWindow());
-    }
-
     mUiCallback.onMyPositionModeChanged(getMyPositionMode());
     if (mCompassData != null)
       mUiCallback.onCompassUpdated(mCompassData);
@@ -548,7 +544,6 @@ public enum LocationHelper implements Initializable<Context>, AppBackgroundTrack
       return;
     }
 
-    Utils.keepScreenOn(false, mUiCallback.getActivity().getWindow());
     mUiCallback = null;
   }
 
@@ -606,7 +601,6 @@ public enum LocationHelper implements Initializable<Context>, AppBackgroundTrack
 
   public interface UiCallback
   {
-    Activity getActivity();
     void onMyPositionModeChanged(int newMode);
     void onLocationUpdated(@NonNull Location location);
     void onCompassUpdated(@NonNull CompassData compass);

--- a/android/src/com/mapswithme/maps/location/LocationHelper.java
+++ b/android/src/com/mapswithme/maps/location/LocationHelper.java
@@ -75,21 +75,6 @@ public enum LocationHelper implements Initializable<Context>, AppBackgroundTrack
   private boolean mLocationUpdateStoppedByUser;
 
   @SuppressWarnings("FieldCanBeLocal")
-  private final LocationState.ModeChangeListener mMyPositionModeListener =
-      new LocationState.ModeChangeListener()
-  {
-    @Override
-    public void onMyPositionModeChanged(int newMode)
-    {
-      notifyMyPositionModeChanged(newMode);
-      Logger.d(TAG, "onMyPositionModeChanged mode = " + LocationState.nameOf(newMode));
-
-      if (mUiCallback == null)
-        Logger.d(TAG, "UI is not ready to listen my position changes, i.e. it's not attached yet.");
-    }
-  };
-
-  @SuppressWarnings("FieldCanBeLocal")
   private final LocationState.LocationPendingTimeoutListener mLocationPendingTimeoutListener = () -> {
     if (mActive)
     {
@@ -104,7 +89,6 @@ public enum LocationHelper implements Initializable<Context>, AppBackgroundTrack
     mContext = context;
     mSensorHelper = new SensorHelper(context);
     mLocationProvider = LocationProviderFactory.getProvider(mContext, this);
-    LocationState.nativeSetListener(mMyPositionModeListener);
     LocationState.nativeSetLocationPendingTimeoutListener(mLocationPendingTimeoutListener);
     MwmApplication.backgroundTracker(context).addListener(this);
   }
@@ -308,14 +292,6 @@ public enum LocationHelper implements Initializable<Context>, AppBackgroundTrack
       mUiCallback.onLocationError(errCode);
   }
 
-  private void notifyMyPositionModeChanged(int newMode)
-  {
-    Logger.d(TAG, "notifyMyPositionModeChanged(): " + LocationState.nameOf(newMode));
-
-    if (mUiCallback != null)
-      mUiCallback.onMyPositionModeChanged(newMode);
-  }
-
   private void notifyLocationNotFound()
   {
     Logger.d(TAG, "notifyLocationNotFound()");
@@ -510,7 +486,6 @@ public enum LocationHelper implements Initializable<Context>, AppBackgroundTrack
 
     mUiCallback = callback;
 
-    mUiCallback.onMyPositionModeChanged(getMyPositionMode());
     if (mCompassData != null)
       mUiCallback.onCompassUpdated(mCompassData);
 
@@ -597,7 +572,6 @@ public enum LocationHelper implements Initializable<Context>, AppBackgroundTrack
 
   public interface UiCallback
   {
-    void onMyPositionModeChanged(int newMode);
     void onLocationUpdated(@NonNull Location location);
     void onCompassUpdated(@NonNull CompassData compass);
     void onLocationError(int errorCode);

--- a/android/src/com/mapswithme/maps/location/LocationListener.java
+++ b/android/src/com/mapswithme/maps/location/LocationListener.java
@@ -11,12 +11,8 @@ public interface LocationListener
 
     @Override
     public void onCompassUpdated(long time, double north) {}
-
-    @Override
-    public void onLocationError(int errorCode) {}
   }
 
   void onLocationUpdated(Location location);
   void onCompassUpdated(long time, double north);
-  void onLocationError(int errorCode);
 }

--- a/android/src/com/mapswithme/maps/location/LocationState.java
+++ b/android/src/com/mapswithme/maps/location/LocationState.java
@@ -8,7 +8,7 @@ import java.lang.annotation.RetentionPolicy;
 
 public final class LocationState
 {
-  interface ModeChangeListener
+  public interface ModeChangeListener
   {
     @SuppressWarnings("unused")
     void onMyPositionModeChanged(int newMode);
@@ -35,7 +35,7 @@ public final class LocationState
   @Value
   static native int nativeGetMode();
 
-  static native void nativeSetListener(ModeChangeListener listener);
+  public static native void nativeSetListener(ModeChangeListener listener);
   static native void nativeRemoveListener();
 
   static native void nativeSetLocationPendingTimeoutListener(
@@ -57,7 +57,7 @@ public final class LocationState
     return (mode > NOT_FOLLOW_NO_POSITION);
   }
 
-  static String nameOf(@Value int mode)
+  public static String nameOf(@Value int mode)
   {
     switch (mode)
     {

--- a/android/src/com/mapswithme/maps/routing/NavigationService.java
+++ b/android/src/com/mapswithme/maps/routing/NavigationService.java
@@ -69,12 +69,6 @@ public class NavigationService extends Service
         updateNotification(routingInfo);
       }
     }
-
-    @Override
-    public void onLocationError(int errorCode)
-    {
-      Logger.e(TAG, "onLocationError() errorCode: " + errorCode);
-    }
   };
 
   public class LocalBinder extends Binder

--- a/android/src/com/mapswithme/maps/widget/placepage/DirectionFragment.java
+++ b/android/src/com/mapswithme/maps/widget/placepage/DirectionFragment.java
@@ -135,7 +135,4 @@ public class DirectionFragment extends BaseMwmDialogFragment
     if (da.getAzimuth() >= 0)
       mAvDirection.setAzimuth(da.getAzimuth());
   }
-
-  @Override
-  public void onLocationError(int errorCode) {}
 }

--- a/android/src/com/mapswithme/maps/widget/placepage/RichPlacePageController.java
+++ b/android/src/com/mapswithme/maps/widget/placepage/RichPlacePageController.java
@@ -311,12 +311,6 @@ public class RichPlacePageController implements PlacePageController, LocationLis
   }
 
   @Override
-  public void onLocationError(int errorCode)
-  {
-    // Do nothing by default.
-  }
-
-  @Override
   public void onLayoutChange(View v, int left, int top, int right, int bottom, int oldLeft, int
       oldTop, int oldRight, int oldBottom)
   {


### PR DESCRIPTION
In very rare case Google Location Provider asks user to enable
Wi-Fi for "for a better (?surveillance) experience":

1. Airplane is OFF;
2. Mobile data is ON;
3. Wi-Fi is OFF;
4. No actual Internet connection from mobile network.

Before this patch the app just downgraded to use the system location
provider, which waited until HW GPS is found.

With this patch the app dispalys "For a better experience, turn on
device location, which uses Google's location settings". Pressing
"Yes" just enables Wi-Fi without any other changes in the system.
There are no other practical outcomes to users other than reminding
about disabled Wi-Fi.

Signed-off-by: Roman Tsisyk <roman@tsisyk.com>