### PR TITLE
[android] Place page performance improvements

### DIFF
--- a/android/src/com/mapswithme/maps/widget/placepage/PlacePageView.java
+++ b/android/src/com/mapswithme/maps/widget/placepage/PlacePageView.java
@@ -193,6 +193,8 @@ public class PlacePageView extends NestedScrollViewClickFixed
   private CountryItem mCurrentCountry;
   private boolean mScrollable = true;
 
+  private OnPlacePageContentChangeListener mOnPlacePageContentChangeListener;
+
   private final MapManager.StorageCallback mStorageCallback = new MapManager.StorageCallback()
   {
     @Override
@@ -1650,6 +1652,7 @@ public class PlacePageView extends NestedScrollViewClickFixed
 
     setMapObject(updatedBookmark, null);
     refreshViews();
+    mOnPlacePageContentChangeListener.OnPlacePageContentChange();
   }
 
   int getPreviewHeight()
@@ -1680,5 +1683,15 @@ public class PlacePageView extends NestedScrollViewClickFixed
                                         getActivity().getSupportFragmentManager(),
                                         PlacePageView.this);
     }
+  }
+
+  public void setOnPlacePageContentChangeListener(OnPlacePageContentChangeListener onPlacePageContentChangeListener)
+  {
+    mOnPlacePageContentChangeListener = onPlacePageContentChangeListener;
+  }
+
+  interface OnPlacePageContentChangeListener
+  {
+    void OnPlacePageContentChange();
   }
 }

--- a/android/src/com/mapswithme/maps/widget/placepage/RichPlacePageController.java
+++ b/android/src/com/mapswithme/maps/widget/placepage/RichPlacePageController.java
@@ -125,6 +125,7 @@ public class RichPlacePageController implements PlacePageController, LocationLis
     mPlacePage.setOnTouchListener((v, event) -> gestureDetector.onTouchEvent(event));
     mPlacePage.addClosable(this);
     mPlacePage.setRoutingModeListener(mRoutingModeListener);
+    mPlacePage.setOnPlacePageContentChangeListener(this::setPeekHeight);
 
     mButtonsLayout = activity.findViewById(R.id.pp_buttons_layout);
     ViewGroup buttons = mButtonsLayout.findViewById(R.id.container);

--- a/android/src/com/mapswithme/maps/widget/placepage/RichPlacePageController.java
+++ b/android/src/com/mapswithme/maps/widget/placepage/RichPlacePageController.java
@@ -30,7 +30,6 @@ public class RichPlacePageController implements PlacePageController, LocationLis
 {
   private static final String TAG = RichPlacePageController.class.getSimpleName();
 
-  private static final float ANCHOR_RATIO = 0.3f;
   private static final float PREVIEW_PLUS_RATIO = 0.45f;
   private static final int ANIM_CHANGE_PEEK_HEIGHT_MS = 100;
   @SuppressWarnings("NullableProblems")
@@ -269,7 +268,7 @@ public class RichPlacePageController implements PlacePageController, LocationLis
       {
         View parent = (View) mPlacePage.getParent();
         int promoPeekHeight = (int) (parent.getHeight() * PREVIEW_PLUS_RATIO);
-        return promoPeekHeight <= organicPeekHeight ? organicPeekHeight : promoPeekHeight;
+        return Math.max(promoPeekHeight, organicPeekHeight);
       }
     }
 
@@ -338,12 +337,10 @@ public class RichPlacePageController implements PlacePageController, LocationLis
 
     @BottomSheetBehavior.State
     int state = mPlacePageBehavior.getState();
-    mPlacePage.setMapObject(object, (isSameObject) -> {
-      restorePlacePageState(object, state);
-    });
+    mPlacePage.setMapObject(object, (isSameObject) -> restorePlacePageState(state));
   }
 
-  private void restorePlacePageState(@NonNull MapObject object, @BottomSheetBehavior.State int state)
+  private void restorePlacePageState(@BottomSheetBehavior.State int state)
   {
     mPlacePage.post(() -> {
       mPlacePageBehavior.setState(state);

--- a/android/src/com/mapswithme/maps/widget/placepage/RichPlacePageController.java
+++ b/android/src/com/mapswithme/maps/widget/placepage/RichPlacePageController.java
@@ -26,9 +26,7 @@ import com.mapswithme.util.log.Logger;
 import java.util.ArrayList;
 import java.util.Objects;
 
-public class RichPlacePageController implements PlacePageController, LocationListener,
-                                                View.OnLayoutChangeListener,
-                                                Closable
+public class RichPlacePageController implements PlacePageController, LocationListener, Closable
 {
   private static final String TAG = RichPlacePageController.class.getSimpleName();
 
@@ -130,7 +128,6 @@ public class RichPlacePageController implements PlacePageController, LocationLis
     GestureDetectorCompat gestureDetector = new GestureDetectorCompat(activity, ppGestureListener);
     mPlacePage.addPlacePageGestureListener(ppGestureListener);
     mPlacePage.setOnTouchListener((v, event) -> gestureDetector.onTouchEvent(event));
-    mPlacePage.addOnLayoutChangeListener(this);
     mPlacePage.addClosable(this);
     mPlacePage.setRoutingModeListener(mRoutingModeListener);
 
@@ -244,6 +241,7 @@ public class RichPlacePageController implements PlacePageController, LocationLis
         mPlacePage.setScrollable(true);
         mPlacePageBehavior.setDraggable(true);
         mPlacePageBehavior.setPeekHeight(peekHeight);
+        PlacePageUtils.moveViewportUp(mPlacePage, mViewportMinHeight);
       }
     });
     animator.addUpdateListener(animation -> onUpdateTranslation());
@@ -314,24 +312,6 @@ public class RichPlacePageController implements PlacePageController, LocationLis
   public void onLocationError(int errorCode)
   {
     // Do nothing by default.
-  }
-
-  @Override
-  public void onLayoutChange(View v, int left, int top, int right, int bottom, int oldLeft, int
-      oldTop, int oldRight, int oldBottom)
-  {
-    if (mPlacePageBehavior.getPeekHeight() == 0)
-    {
-      Logger.d(TAG, "Layout change ignored, peek height not calculated yet");
-      return;
-    }
-
-    mPlacePage.post(this::setPeekHeight);
-
-    if (PlacePageUtils.isHiddenState(mPlacePageBehavior.getState()))
-      return;
-
-    PlacePageUtils.moveViewportUp(mPlacePage, mViewportMinHeight);
   }
 
   @Override


### PR DESCRIPTION
This PR adds various improvements to the handling of the place page.

- Removes the `onLayoutChange` listener. All its logic has been moved outside to improve performance. For some reason this callback was called several times per seconds even when the place page was not shown, calling some unnecessary logic.
- Cleans up the code to remove warnings.
- Removes the custom peek height animation in favor of the native one.

As you can see in the following video, not much changed. The animation is slightly different but more consistent with the opening/closing ones. There is a visual artifact when you expand the bottom sheet then select a new map object, but it was already present before.

https://user-images.githubusercontent.com/80701113/194037067-dbafd45e-279a-4607-a782-0eafde48d2bb.mp4