### PR TITLE
[android] Remove BATTERY_STATS system permission

### DIFF
--- a/android/AndroidManifest.xml
+++ b/android/AndroidManifest.xml
@@ -37,7 +37,6 @@
     the application must request the Manifest.permission.WAKE_LOCK permission.
   //-->
   <uses-permission android:name="android.permission.WAKE_LOCK"/>
-  <uses-permission android:name="android.permission.BATTERY_STATS"/>
   <uses-permission android:name="android.permission.FOREGROUND_SERVICE"/>
 
   <queries>


### PR DESCRIPTION
This system permission must not be used by regular apps. The only one potential user of battery level information is util/BatteryState class. This class uses `Intent.ACTION_BATTERY_CHANGED` intent which doesn't require any additional permissions [1]. The updated version without BATTERY_STATS permission works well up to API 21. There is no difference at all. It is not clear why this permission was needed at all. Please note that this code is only called in "Automatic" power-save mode enabled in settings.

[1]: https://developer.android.com/training/monitoring-device-state/battery-monitoring.html

Signed-off-by: Roman Tsisyk <roman@tsisyk.com>