### PR TITLE
[styles] Render natural=shrubbery

### DIFF
--- a/data/replaced_tags.txt
+++ b/data/replaced_tags.txt
@@ -72,6 +72,7 @@ man_made=quay : man_made=pier
 natural=marsh     : natural=wetland, wetland=marsh
 natural=waterfall : waterway=waterfall
 natural=forest    : natural=wood
+natural=shrubbery : natural=scrub
 cliff=yes         : natural=cliff
 
 office=notary : office=lawyer


### PR DESCRIPTION
Fixes https://github.com/organicmaps/organicmaps/issues/3517

This is my first time contributing to OM - sorry if something was done wrong. I hope overtaking assigned issues isn't bad. I did it because it was a simple fix.
The tag is used for managed, urban _natural=scrub_ s. The way OM renders natural=scrub currently fits this tag well enough, it's the same as grass, and the way scrub is used is close to natural=shrubbery, so I added it as a line to replaced_tags.txt as @biodranik said in https://github.com/organicmaps/organicmaps/issues/3517#issuecomment-1264608619. It will make the map easier to understand and look nicer, especially in certain European cities in which this tag is heavily used.

Signed-off-by Luna Rose luna@anarchy.center