### PR TITLE
[android] Fix a crash in "Location is disabled" dialog

### DIFF
--- a/android/src/com/mapswithme/maps/location/LocationHelper.java
+++ b/android/src/com/mapswithme/maps/location/LocationHelper.java
@@ -323,22 +323,23 @@ public enum LocationHelper implements Initializable<Context>, AppBackgroundTrack
     mSavedLocation = null;
     nativeOnLocationError(ERROR_GPS_OFF);
 
-    if (mErrorDialogAnnoying || (mErrorDialog != null && mErrorDialog.isShowing()))
+    if (mUiCallback == null || mErrorDialogAnnoying || (mErrorDialog != null && mErrorDialog.isShowing()))
       return;
 
-    AlertDialog.Builder builder = new AlertDialog.Builder(mContext)
+    final AppCompatActivity activity = mUiCallback.requireActivity();
+    AlertDialog.Builder builder = new AlertDialog.Builder(activity)
         .setTitle(R.string.enable_location_services)
         .setMessage(R.string.location_is_disabled_long_text)
         .setOnDismissListener(dialog -> mErrorDialog = null)
         .setOnCancelListener(dialog -> setLocationErrorDialogAnnoying(true))
         .setNegativeButton(R.string.close, (dialog, which) -> setLocationErrorDialogAnnoying(true));
-    final Intent intent = Utils.makeSystemLocationSettingIntent(mContext);
+    final Intent intent = Utils.makeSystemLocationSettingIntent(activity);
     if (intent != null)
     {
       intent.addFlags(Intent.FLAG_ACTIVITY_NEW_TASK);
       intent.addFlags(Intent.FLAG_ACTIVITY_NO_HISTORY);
       intent.addFlags(Intent.FLAG_ACTIVITY_EXCLUDE_FROM_RECENTS);
-      builder.setPositiveButton(R.string.connection_settings, (dialog, which) -> mContext.startActivity(intent));
+      builder.setPositiveButton(R.string.connection_settings, (dialog, which) -> activity.startActivity(intent));
     }
     mErrorDialog = builder.show();
   }
@@ -352,10 +353,11 @@ public enum LocationHelper implements Initializable<Context>, AppBackgroundTrack
     if (!mActive || !LocationUtils.isLocationGranted(mContext) || !LocationUtils.areLocationServicesTurnedOn(mContext))
       return;
 
-    if (mErrorDialogAnnoying || (mErrorDialog != null && mErrorDialog.isShowing()))
+    if (mUiCallback == null || mErrorDialogAnnoying || (mErrorDialog != null && mErrorDialog.isShowing()))
       return;
 
-    mErrorDialog = new AlertDialog.Builder(mContext)
+    final AppCompatActivity activity = mUiCallback.requireActivity();
+    mErrorDialog = new AlertDialog.Builder(activity)
         .setTitle(R.string.current_location_unknown_title)
         .setMessage(R.string.current_location_unknown_message)
         .setOnDismissListener(dialog -> mErrorDialog = null)


### PR DESCRIPTION
Pass AppCompatActivity to AlertDialog instead of global Context.

```
 FATAL EXCEPTION: main
 Process: app.organicmaps.debug, PID: 17897
 java.lang.IllegalStateException: You need to use a Theme.AppCompat theme (or descendant) with this activity.
        at androidx.appcompat.app.AppCompatDelegateImpl.createSubDecor(AppCompatDelegateImpl.java:926)
        at androidx.appcompat.app.AppCompatDelegateImpl.ensureSubDecor(AppCompatDelegateImpl.java:889)
        at androidx.appcompat.app.AppCompatDelegateImpl.setContentView(AppCompatDelegateImpl.java:772)
        at androidx.appcompat.app.AppCompatDialog.setContentView(AppCompatDialog.java:95)
        at androidx.appcompat.app.AlertController.installContent(AlertController.java:232)
        at androidx.appcompat.app.AlertDialog.onCreate(AlertDialog.java:279)
        at android.app.Dialog.dispatchOnCreate(Dialog.java:436)
        at android.app.Dialog.show(Dialog.java:325)
        at androidx.appcompat.app.AlertDialog$Builder.show(AlertDialog.java:1009)
        at com.mapswithme.maps.location.LocationHelper.onLocationDisabled(LocationHelper.java:343)
        at com.mapswithme.maps.location.LocationHelper.onLocationResolutionRequired(LocationHelper.java:296)
        at com.mapswithme.maps.location.GoogleFusedLocationProvider.lambda$start$1$com-mapswithme-maps-location-GoogleFusedLocationProvider(GoogleFusedLocationProvider.java:98)
        at com.mapswithme.maps.location.GoogleFusedLocationProvider$$ExternalSyntheticLambda1.onFailure(Unknown Source:2)
        at com.google.android.gms.tasks.zzk.run(com.google.android.gms:play-services-tasks@@18.0.1:1)
        at android.os.Handler.handleCallback(Handler.java:942)
        at android.os.Handler.dispatchMessage(Handler.java:99)
        at android.os.Looper.loopOnce(Looper.java:201)
        at android.os.Looper.loop(Looper.java:288)
        at android.app.ActivityThread.main(ActivityThread.java:7898)
        at java.lang.reflect.Method.invoke(Native Method)
        at com.android.internal.os.RuntimeInit$MethodAndArgsCaller.run(RuntimeInit.java:548)
        at com.android.internal.os.ZygoteInit.main(ZygoteInit.java:936)
```

Closes #3585

Signed-off-by: Roman Tsisyk <roman@tsisyk.com>