### PR TITLE
[android] Fix lint warnings for intent-filters

### DIFF
--- a/android/AndroidManifest.xml
+++ b/android/AndroidManifest.xml
@@ -94,8 +94,9 @@
         <category android:name="android.intent.category.DEFAULT"/>
         <category android:name="android.intent.category.BROWSABLE"/>
 
-        <data android:scheme="http" android:host="ge0.me"/>
+        <data android:scheme="http"/>
         <data android:scheme="https"/>
+        <data android:host="ge0.me"/>
       </intent-filter>
 
       <intent-filter android:autoVerify="@bool/autoVerify">
@@ -104,8 +105,9 @@
         <category android:name="android.intent.category.DEFAULT"/>
         <category android:name="android.intent.category.BROWSABLE"/>
 
-        <data android:scheme="http" android:host="omaps.app"/>
+        <data android:scheme="http"/>
         <data android:scheme="https"/>
+        <data android:host="omaps.app"/>
       </intent-filter>
 
       <intent-filter>
@@ -558,24 +560,10 @@
         <data android:scheme="https"/>
 
         <!-- #map=$zoom/$lat/$lon -->
-        <data android:host="www.openstreetmap.org" android:path="/"/>
-        <data android:host="www.openstreetmap.org" android:pathPrefix="/search"/>
-        <data android:host="openstreetmap.org" android:path="/"/>
-        <data android:host="openstreetmap.org" android:pathPrefix="/search"/>
-      </intent-filter>
-
-      <intent-filter>
-        <action android:name="android.intent.action.VIEW"/>
-
-        <category android:name="android.intent.category.DEFAULT"/>
-        <category android:name="android.intent.category.BROWSABLE"/>
-
-        <data
-          android:host="lead"
-          android:scheme="mapsme"/>
-        <data
-          android:host="lead"
-          android:scheme="mapswithme"/>
+        <data android:host="openstreetmap.org"/>
+        <data android:host="www.openstreetmap.org"/>
+        <data android:path="/"/>
+        <data android:path="/search"/>
       </intent-filter>
 
       <intent-filter>

--- a/android/AndroidManifest.xml
+++ b/android/AndroidManifest.xml
@@ -68,7 +68,6 @@
       android:name="com.mapswithme.maps.SplashActivity"
       android:exported="true">
 
-      <!-- standard "geo" scheme -->
       <intent-filter>
         <action android:name="android.intent.action.VIEW"/>
 
@@ -76,14 +75,6 @@
         <category android:name="android.intent.category.BROWSABLE"/>
 
         <data android:scheme="geo"/>
-      </intent-filter>
-
-      <intent-filter>
-        <action android:name="android.intent.action.VIEW"/>
-
-        <category android:name="android.intent.category.DEFAULT"/>
-        <category android:name="android.intent.category.BROWSABLE"/>
-
         <data android:scheme="ge0"/>
         <data android:scheme="om"/>
       </intent-filter>
@@ -593,13 +584,8 @@
       <intent-filter>
         <action android:name="android.intent.action.SEND"/>
         <category android:name="android.intent.category.DEFAULT"/>
-        <data android:mimeType="application/vnd.google-earth.kmz"/>
-      </intent-filter>
-
-      <intent-filter>
-        <action android:name="android.intent.action.SEND"/>
-        <category android:name="android.intent.category.DEFAULT"/>
         <data android:mimeType="application/vnd.google-earth.kml+xml"/>
+        <data android:mimeType="application/vnd.google-earth.kmz"/>
       </intent-filter>
 
       <intent-filter>
@@ -618,35 +604,13 @@
         <data android:pathPattern=".*\\..*\\..*\\.kmz" />
         <data android:pathPattern=".*\\..*\\..*\\..*\\.kmz" />
         <data android:pathPattern=".*\\..*\\..*\\..*\\..*\\.kmz" />
-      </intent-filter>
-
-      <intent-filter>
-        <action android:name="android.intent.action.VIEW" />
-        <category android:name="android.intent.category.DEFAULT" />
-        <category android:name="android.intent.category.BROWSABLE" />
-        <data android:scheme="content"/>
-        <data android:scheme="file"/>
-        <data android:scheme="data"/>
-        <data android:host="*"/>
-        <data android:mimeType="*/*"/>
         <data android:pathPattern="*.kml"/>
         <data android:pathPattern=".*\\.kml" />
         <data android:pathPattern=".*\\..*\\.kml" />
         <data android:pathPattern=".*\\..*\\..*\\.kml" />
         <data android:pathPattern=".*\\..*\\..*\\..*\\.kml" />
         <data android:pathPattern=".*\\..*\\..*\\..*\\..*\\.kml" />
-      </intent-filter>
-
-      <!-- Old MAPS.ME binary format //-->
-      <intent-filter>
-        <action android:name="android.intent.action.VIEW"/>
-        <category android:name="android.intent.category.DEFAULT"/>
-        <category android:name="android.intent.category.BROWSABLE"/>
-        <data android:scheme="content"/>
-        <data android:scheme="file"/>
-        <data android:scheme="data"/>
-        <data android:host="*"/>
-        <data android:mimeType="*/*"/>
+        <!-- Old MAPS.ME binary format //-->
         <data android:pathPattern="*.kmb"/>
         <data android:pathPattern=".*\\.kmb" />
         <data android:pathPattern=".*\\..*\\.kmb" />


### PR DESCRIPTION
> Data tags should only declare unique attributes
> Consider splitting data tag into multiple tags
> with individual attributes to avoid confusion

All the `<data>` elements contained within the same `<intent-filter>` element contribute to the same filter. So, for example, the following filter specification,

```
<intent-filter . . . >
    <data android:scheme="something" android:host="project.example.com" />
    . . .
</intent-filter>
```

is equivalent to this one:

```
<intent-filter . . . >
    <data android:scheme="something" />
    <data android:host="project.example.com" />
    . . .
</intent-filter>
```

https://developer.android.com/guide/topics/manifest/data-element

Signed-off-by: Roman Tsisyk <roman@tsisyk.com>