### PR TITLE
[android] do not try to hide navigation bottom sheet

### DIFF
--- a/android/src/com/mapswithme/maps/routing/NavigationController.java
+++ b/android/src/com/mapswithme/maps/routing/NavigationController.java
@@ -233,8 +233,6 @@ public class NavigationController implements Application.ActivityLifecycleCallba
   {
     if (show && !UiUtils.isVisible(mFrame))
       collapseNavMenu();
-    else if (!show && UiUtils.isVisible(mFrame))
-      mNavMenu.hideNavBottomSheet();
     UiUtils.showIf(show, mFrame);
   }
 
@@ -368,7 +366,6 @@ public class NavigationController implements Application.ActivityLifecycleCallba
   @Override
   public void onStopClicked()
   {
-    mNavMenu.hideNavBottomSheet();
     RoutingController.get().cancel();
   }
 

--- a/android/src/com/mapswithme/maps/widget/menu/NavMenu.java
+++ b/android/src/com/mapswithme/maps/widget/menu/NavMenu.java
@@ -106,8 +106,6 @@ public class NavMenu
     Button stop = mBottomFrame.findViewById(R.id.stop);
     stop.setOnClickListener(v -> onStopClicked());
     UiUtils.updateRedButton(stop);
-
-    hideNavBottomSheet();
   }
 
   private void onStopClicked()
@@ -152,11 +150,6 @@ public class NavMenu
   public void expandNavBottomSheet()
   {
     mNavBottomSheetBehavior.setState(BottomSheetBehavior.STATE_EXPANDED);
-  }
-
-  public void hideNavBottomSheet()
-  {
-    mNavBottomSheetBehavior.setState(BottomSheetBehavior.STATE_HIDDEN);
   }
 
   public int getBottomSheetState()


### PR DESCRIPTION
Fixes issue mentioned in https://github.com/organicmaps/organicmaps/pull/3377#issuecomment-1272388581. The navigation bottom sheet cannot be hidden so the user cannot dismiss it and the whole navigation frame is hidden when the navigation stops. So it is pointless to try and set the bottom sheet to the "hidden" state.