### PR TITLE
[android] fix crash on login to osm after edits

### DIFF
--- a/android/src/com/mapswithme/maps/editor/OsmLoginFragment.java
+++ b/android/src/com/mapswithme/maps/editor/OsmLoginFragment.java
@@ -107,12 +107,9 @@ public class OsmLoginFragment extends BaseMwmToolbarFragment
   {
     OsmOAuth.setAuthorization(requireContext(), auth[0], auth[1], username);
     final Bundle extras = requireActivity().getIntent().getExtras();
-    final boolean redirectToProfile = extras.getBoolean("redirectToProfile", false);
-    if (redirectToProfile)
-    {
+    if (extras != null && extras.getBoolean("redirectToProfile", false))
       startActivity(new Intent(requireContext(), ProfileActivity.class));
-      requireActivity().finish();
-    }
+    requireActivity().finish();
   }
 
   private void register()


### PR DESCRIPTION
The app was querying the intent's extras without checking if these were null and would only leave the login activity if the calling activity wanted to redirect to the profile.

So essentially login worked only when accessing the OSM profile from the settings.

Fixes https://github.com/organicmaps/organicmaps/issues/3597

Fixes https://github.com/organicmaps/organicmaps/issues/3498