### PR TITLE
[ios] Hide the wikipedia summary till it has properly loaded

### DIFF
--- a/iphone/Maps/UI/PlacePage/Components/WikiDescriptionViewController.swift
+++ b/iphone/Maps/UI/PlacePage/Components/WikiDescriptionViewController.swift
@@ -43,9 +43,12 @@ class WikiDescriptionViewController: UIViewController {
       }
 
       DispatchQueue.main.async {
+	// descriptionTextView and moreButton are hidden by default
+        self.descriptionTextView.isHidden = false
         if attributedString.length > 500 {
           self.descriptionTextView.attributedText = attributedString.attributedSubstring(from: NSRange(location: 0,
                                                                                                        length: 500))
+          self.moreButton.isHidden = false
         } else {
           self.descriptionTextView.attributedText = attributedString
         }

--- a/iphone/Maps/UI/PlacePage/PlacePage.storyboard
+++ b/iphone/Maps/UI/PlacePage/PlacePage.storyboard
@@ -1,9 +1,9 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="20037" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES" initialViewController="bX8-ZQ-XDA">
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="21225" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES" initialViewController="bX8-ZQ-XDA">
     <device id="retina4_7" orientation="portrait" appearance="light"/>
     <dependencies>
         <deployment identifier="iOS"/>
-        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="20020"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="21207"/>
         <capability name="Safe area layout guides" minToolsVersion="9.0"/>
         <capability name="Stack View standard spacing" minToolsVersion="9.0"/>
         <capability name="System colors in document resources" minToolsVersion="11.0"/>
@@ -346,13 +346,12 @@
                         <rect key="frame" x="0.0" y="0.0" width="375" height="180"/>
                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                         <subviews>
-                            <textView clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="scaleToFill" scrollEnabled="NO" showsHorizontalScrollIndicator="NO" showsVerticalScrollIndicator="NO" editable="NO" textAlignment="natural" translatesAutoresizingMaskIntoConstraints="NO" id="4pU-ex-66e">
+                            <textView hidden="YES" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="scaleToFill" scrollEnabled="NO" showsHorizontalScrollIndicator="NO" showsVerticalScrollIndicator="NO" editable="NO" text="Wikipedia textual description" textAlignment="natural" translatesAutoresizingMaskIntoConstraints="NO" id="4pU-ex-66e">
                                 <rect key="frame" x="16" y="16" width="343" height="131"/>
                                 <color key="backgroundColor" white="0.0" alpha="0.0" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
                                 <constraints>
                                     <constraint firstAttribute="height" relation="lessThanOrEqual" constant="150" id="E6c-1w-LKj"/>
                                 </constraints>
-                                <string key="text">Lorem ipsum dolor sit er elit lamet, consectetaur cillium adipisicing pecu, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum. Nam liber te conscient to factor tum poen legum odioque civiuda.</string>
                                 <fontDescription key="fontDescription" type="system" pointSize="16"/>
                                 <textInputTraits key="textInputTraits" autocapitalizationType="sentences"/>
                                 <dataDetectorType key="dataDetectorTypes" phoneNumber="YES" link="YES"/>
@@ -363,7 +362,7 @@
                                     </userDefinedRuntimeAttribute>
                                 </userDefinedRuntimeAttributes>
                             </textView>
-                            <button opaque="NO" clipsSubviews="YES" contentMode="scaleToFill" contentHorizontalAlignment="left" contentVerticalAlignment="top" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="soI-1J-JL6">
+                            <button hidden="YES" opaque="NO" clipsSubviews="YES" contentMode="scaleToFill" contentHorizontalAlignment="left" contentVerticalAlignment="top" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="soI-1J-JL6">
                                 <rect key="frame" x="16" y="147" width="343" height="33"/>
                                 <constraints>
                                     <constraint firstAttribute="height" constant="33" id="A1M-UD-HgW"/>


### PR DESCRIPTION
As of now the wikipedia summary has a placeholder, that is visible by the enduser. That was fixed by changing the following things:

- The UITextView "descriptionTextView" (displaying the wikipedia data) and the UIButton "moreButton" (showing the complete wikipedia data) are hidden by default
- The UITextView, showing the wiki text, is made visible only after the WikiDescriptionViewController has got its data
- The UIButton is only visible if the wiki data has more than 500 chars

Fixes: #3080 

Signed-off-by: Krassy Boykinov <kozboko@gmail.com>

Preview:

https://user-images.githubusercontent.com/87526889/195630189-cad02d15-1396-41b3-ae82-8de51c7d6ccf.mp4

P.S. Now in separate branch of master, like requested