### PR TITLE
[android] hide system bars on fullscreen mode

### DIFF
--- a/android/res/values-v27/themes.xml
+++ b/android/res/values-v27/themes.xml
@@ -1,0 +1,18 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!-- Cutouts API is available for API >= 27 -->
+<resources>
+  <style name="MwmTheme.MainActivity">
+    <item name="android:colorPrimaryDark">@android:color/black</item>
+    <item name="android:windowBackground">@null</item>
+    <item name="android:windowTranslucentNavigation">true</item>
+    <!-- Allows to show the app behind the camera notch in landscape and when hiding the status bar -->
+    <item name="android:windowLayoutInDisplayCutoutMode">shortEdges</item>
+  </style>
+  <style name="MwmTheme.Night.MainActivity">
+    <item name="android:colorPrimaryDark">@android:color/black</item>
+    <item name="android:windowBackground">@null</item>
+    <item name="android:windowTranslucentNavigation">true</item>
+    <!-- Allows to show the app behind the camera notch in landscape and when hiding the status bar -->
+    <item name="android:windowLayoutInDisplayCutoutMode">shortEdges</item>
+  </style>
+</resources>

--- a/android/res/values/themes.xml
+++ b/android/res/values/themes.xml
@@ -17,12 +17,14 @@
     <item name="android:statusBarColor">@color/bg_primary_night</item>
   </style>
 
+  <!-- Theme is overridden in v27 folder to handle cutouts -->
   <style name="MwmTheme.MainActivity">
     <item name="android:colorPrimaryDark">@android:color/black</item>
     <item name="android:windowBackground">@null</item>
     <item name="android:windowTranslucentNavigation">true</item>
   </style>
 
+  <!-- Theme is overridden in v27 folder to handle cutouts -->
   <style name="MwmTheme.Night.MainActivity">
     <item name="android:colorPrimaryDark">@android:color/black</item>
     <item name="android:windowBackground">@null</item>

--- a/android/src/com/mapswithme/util/UiUtils.java
+++ b/android/src/com/mapswithme/util/UiUtils.java
@@ -38,6 +38,7 @@ import androidx.annotation.StringRes;
 import androidx.appcompat.widget.Toolbar;
 import androidx.core.content.res.ResourcesCompat;
 import androidx.core.view.WindowCompat;
+import androidx.core.view.WindowInsetsCompat;
 import androidx.core.view.WindowInsetsControllerCompat;
 import androidx.recyclerview.widget.RecyclerView;
 import com.google.android.material.textfield.TextInputLayout;
@@ -358,6 +359,20 @@ public final class UiUtils
     Rect viewRect = new Rect(viewX, viewY, viewX + width, viewY + height);
 
     return viewRect.contains(x, y);
+  }
+
+  public static void setFullscreen(@NonNull Activity activity, boolean fullscreen)
+  {
+    final Window window = activity.getWindow();
+    final View decorView = window.getDecorView();
+    WindowInsetsControllerCompat wic = Objects.requireNonNull(WindowCompat.getInsetsController(window, decorView));
+    if (fullscreen)
+    {
+      wic.hide(WindowInsetsCompat.Type.systemBars());
+      wic.setSystemBarsBehavior(WindowInsetsControllerCompat.BEHAVIOR_SHOW_TRANSIENT_BARS_BY_SWIPE);
+    }
+    else
+      wic.show(WindowInsetsCompat.Type.systemBars());
   }
 
   public static void setupTransparentStatusBar(@NonNull Activity activity)


### PR DESCRIPTION
Hide status and navigation bar when tapping on an empty map space. When in fullscreen mode, the user can still swipe up/down where the system bars where to show them again (only temporary).

The fullscreen state is remembered when switching app or rotating the screen. This PR does NOT change when and how to enable the fullscreen mode.


https://user-images.githubusercontent.com/80701113/196030151-895aa654-4be4-45cb-9dfb-ce5fbd31ff4a.mp4



Fixes https://github.com/organicmaps/organicmaps/issues/3636
Fixes https://github.com/organicmaps/organicmaps/issues/950