### PR TITLE
[Android] Changed Snack bar anchor view

### DIFF
--- a/android/src/com/mapswithme/maps/widget/placepage/PlacePageView.java
+++ b/android/src/com/mapswithme/maps/widget/placepage/PlacePageView.java
@@ -1526,7 +1526,7 @@ public class PlacePageView extends NestedScrollViewClickFixed
     {
       Utils.copyTextToClipboard(ctx, items.get(0));
       Utils.showSnackbarAbove(mDetails,
-                              getRootView().findViewById(R.id.menu_frame),
+                              getRootView().findViewById(R.id.pp_buttons_layout),
                               ctx.getString(R.string.copied_to_clipboard, items.get(0)));
     }
     else
@@ -1542,7 +1542,7 @@ public class PlacePageView extends NestedScrollViewClickFixed
         final int id = item.getItemId();
         Utils.copyTextToClipboard(ctx, items.get(id));
         Utils.showSnackbarAbove(mDetails,
-                                getRootView().findViewById(R.id.menu_frame),
+                                getRootView().findViewById(R.id.pp_buttons_layout),
                                 ctx.getString(R.string.copied_to_clipboard, items.get(id)));
         return true;
       });

--- a/android/src/com/mapswithme/maps/widget/placepage/PlacePhoneAdapter.java
+++ b/android/src/com/mapswithme/maps/widget/placepage/PlacePhoneAdapter.java
@@ -99,7 +99,7 @@ public class PlacePhoneAdapter extends RecyclerView.Adapter<PlacePhoneAdapter.Vi
       final String phoneNumber = mPhone.getText().toString();
       final Context ctx = view.getContext();
       Utils.copyTextToClipboard(ctx, phoneNumber);
-      Utils.showSnackbarAbove(view, view.getRootView().findViewById(R.id.menu_frame),
+      Utils.showSnackbarAbove(view, view.getRootView().findViewById(R.id.pp_buttons_layout),
                               ctx.getString(R.string.copied_to_clipboard, phoneNumber));
       return true;
     }


### PR DESCRIPTION
Steps to reproduce:
1. Select POI
2. Open POI details
3. Long click on website, email, phone, address

**Actual result:** Text is copied to clipboard with no UI notification

**Expected result:** Black snack bar should appear saying "Copied to clipboard: bla-bla-bla".

The problem probably is caused by #2258. Earlier `menu_frame` item contained bottom buttons bar:
![organic-maps-old-layout](https://user-images.githubusercontent.com/720808/196230927-1adc628d-154c-4029-bb2f-05b16133399f.jpg)
I had to change it to `pp_buttons_layout`.


Fixes #3638