### PR TITLE
[android] fix crash on exit splitscreen

### DIFF
--- a/android/src/com/mapswithme/maps/MwmActivity.java
+++ b/android/src/com/mapswithme/maps/MwmActivity.java
@@ -1004,7 +1004,6 @@ public class MwmActivity extends BaseMwmFragmentActivity
       mOnmapDownloader.onResume();
 
     mNavigationController.onActivityResumed(this);
-    mMapButtonsController.onResume();
     mPlacePageController.onActivityResumed(this);
     refreshLightStatusBar();
   }

--- a/android/src/com/mapswithme/maps/maplayer/MapButtonsController.java
+++ b/android/src/com/mapswithme/maps/maplayer/MapButtonsController.java
@@ -187,7 +187,8 @@ public class MapButtonsController extends Fragment
   public void updateMenuBadge()
   {
     final View menuButton = mButtonsMap.get(MapButtons.menu);
-    final Context context = requireContext();
+    final Context context = getContext();
+    // Sometimes the global layout listener fires when the fragment is not attached to a context
     if (menuButton == null || context == null)
       return;
     final UpdateInfo info = MapManager.nativeGetUpdateInfo(null);


### PR DESCRIPTION
Sometimes the global layout listener is called when the fragment is not attached to a context so the `requireContext` call would crash the app. Also as the map buttons controller is a fragment itself, there is no need to call its `onResume` method from the main activity.

Fixes https://github.com/organicmaps/organicmaps/issues/3640