### PR TITLE
[android] call onSlideFinish only when bottomsheet is settled

### DIFF
--- a/android/src/com/mapswithme/maps/widget/placepage/BottomSheetChangedListener.java
+++ b/android/src/com/mapswithme/maps/widget/placepage/BottomSheetChangedListener.java
@@ -3,7 +3,6 @@ package com.mapswithme.maps.widget.placepage;
 public interface BottomSheetChangedListener
 {
   void onSheetHidden();
-  void onSheetDirectionIconChange();
   void onSheetDetailsOpened();
   void onSheetCollapsed();
   void onSheetSliding(int top);

--- a/android/src/com/mapswithme/maps/widget/placepage/DefaultBottomSheetCallback.java
+++ b/android/src/com/mapswithme/maps/widget/placepage/DefaultBottomSheetCallback.java
@@ -24,17 +24,15 @@ public class DefaultBottomSheetCallback extends BottomSheetBehavior.BottomSheetC
   {
     Logger.d(TAG, "State change, new = " + PlacePageUtils.toString(newState));
     if (PlacePageUtils.isSettlingState(newState) || PlacePageUtils.isDraggingState(newState))
-    {
       return;
-    }
+
+    mSheetChangedListener.onSheetSlideFinish();
 
     if (PlacePageUtils.isHiddenState(newState))
     {
       mSheetChangedListener.onSheetHidden();
       return;
     }
-
-    mSheetChangedListener.onSheetDirectionIconChange();
 
     if (isExpandedState(newState))
     {
@@ -49,10 +47,5 @@ public class DefaultBottomSheetCallback extends BottomSheetBehavior.BottomSheetC
   public void onSlide(@NonNull View bottomSheet, float slideOffset)
   {
     mSheetChangedListener.onSheetSliding(bottomSheet.getTop());
-
-    if (slideOffset < 0)
-      return;
-
-    mSheetChangedListener.onSheetSlideFinish();
   }
 }

--- a/android/src/com/mapswithme/maps/widget/placepage/RichPlacePageController.java
+++ b/android/src/com/mapswithme/maps/widget/placepage/RichPlacePageController.java
@@ -7,7 +7,6 @@ import android.location.Location;
 import android.os.Bundle;
 import android.view.View;
 import android.view.ViewGroup;
-import android.view.WindowInsets;
 
 import androidx.annotation.NonNull;
 import androidx.annotation.Nullable;
@@ -51,12 +50,6 @@ public class RichPlacePageController implements PlacePageController, LocationLis
     public void onSheetHidden()
     {
       onHiddenInternal();
-    }
-
-    @Override
-    public void onSheetDirectionIconChange()
-    {
-      // No op.
     }
 
     @Override

--- a/android/src/com/mapswithme/maps/widget/placepage/SimplePlacePageController.java
+++ b/android/src/com/mapswithme/maps/widget/placepage/SimplePlacePageController.java
@@ -53,12 +53,6 @@ public class SimplePlacePageController implements PlacePageController
         }
 
         @Override
-        public void onSheetDirectionIconChange()
-        {
-          // No op.
-        }
-
-        @Override
         public void onSheetDetailsOpened()
         {
           if (UiUtils.isLandscape(mApplication))


### PR DESCRIPTION
Only calls the onSlideFinish callback when the bottom sheet is settled. Before this patch the callback would get called on each frame when sliding the place page above its peek height.

The viewport animation is now sharper and fully opening the place page is less laggy.

https://user-images.githubusercontent.com/80701113/197361084-f6a6c1e8-c29a-475a-a311-d0817641ab45.mp4

