### PR TITLE
Fail cmake when execute_process fails

### DIFF
--- a/platform/CMakeLists.txt
+++ b/platform/CMakeLists.txt
@@ -89,11 +89,13 @@ else() # neither iPhone nor Android
     WORKING_DIRECTORY ${CMAKE_SOURCE_DIR}
     OUTPUT_VARIABLE OM_VERSION
     OUTPUT_STRIP_TRAILING_WHITESPACE
+    COMMAND_ERROR_IS_FATAL ANY
   )
   execute_process(COMMAND tools/unix/version.sh qt_int_version
     WORKING_DIRECTORY ${CMAKE_SOURCE_DIR}
     OUTPUT_VARIABLE OM_INT_VERSION
     OUTPUT_STRIP_TRAILING_WHITESPACE
+    COMMAND_ERROR_IS_FATAL ANY
   )
   configure_file("${CMAKE_CURRENT_SOURCE_DIR}/platform_qt_version.cpp.in"
                  "${CMAKE_CURRENT_BINARY_DIR}/platform_qt_version.cpp"


### PR DESCRIPTION
We have `set -euo pipefail` set in `version.sh`, but the `set -e` that would normally report errors up the chain doesn't end up having any effect, since `cmake` just ignores the errors and proceeds.

I specifically ran into this error because I cloned the repo on my dev machine, but attempted to run the build in a container to fix some dependency bugs, and neglected to install Git. (In theory, why should I need it? I've already cloned the project! 😃)

This led to a reasonably annoying-to-debug error (for me, since I'm a bit rusty at C++ projects and debugging!)---the cmake does provide a non-fatal hint, but it's easy to miss:

```text
root@559a03f5281e:/organicmaps# tools/unix/build_omim.sh -r desktop
-- The C compiler identification is GNU 11.3.0
-- The CXX compiler identification is GNU 11.3.0
[...]
-- Found python to use in qt/, shaders/ and 3party/: /usr/bin/python3.10
-- Found OpenGL: /usr/lib/x86_64-linux-gnu/libGL.so   
-- Found Python: /usr/bin/python3.10 (found version "3.10.6") found components: Interpreter 
tools/unix/version.sh: line 11: git: command not found
tools/unix/version.sh: line 11: git: command not found
-- Configuring done
-- Generating done
-- Build files have been written to: /omim-build-release
[...]
```

And eventually fails with errors like this:

```text
In file included from /omim-build-release/platform/CMakeFiles/platform.dir/Unity/unity_0_cxx.cxx:51:
/omim-build-release/platform/platform_qt_version.cpp: In member function 'int32_t Platform::IntVersion() const':
/omim-build-release/platform/platform_qt_version.cpp:10:3: error: return-statement with no value, in function returning 'int32_t' {aka 'int'} [-fpermissive]
   10 |   return ;
      |   ^~~~~~
```

stemming from an `omim-build-release/platform/platform_qt_version.cpp` file like:
```cpp
#include "platform/platform.hpp"

std::string Platform::Version() const
{
  return ;
}

int32_t Platform::IntVersion() const
{
  return ;
}
```

Now, we fail fast with a much more sensible error:

```text
root@559a03f5281e:/organicmaps# tools/unix/build_omim.sh -r desktop
-- Using compiler GNU 11.3.0
-- Using Unity Build with batch 50, export UNITY_DISABLE=1 or use -DUNITY_DISABLE=ON to disable it.
-- export COLORS_DISABLE=1 or use -DCOLORS_DISABLE=ON to disable colored compiler output.
Setting PLATFORM_LINUX to true
-- Build type: Release
-- Using ld.gold
-- ===========================================================================
-- 
-- Configuration
--   Prefix ..................... /usr/local
--   Build type ................. Release
--   Shared libraries ........... OFF
--   Character type ............. char (UTF-8)
-- 
--   Build documentation ........ OFF
--   Build examples ............. OFF
--   Build fuzzers .............. OFF
--   Build tests ................ OFF
--   Build tools (xmlwf) ........ OFF
--   Build pkg-config file ...... OFF
--   Install files .............. OFF
-- 
--   Features
--     // Advanced options, changes not advised
--     Attributes info .......... OFF
--     Context bytes ............ 1024
--     DTD support .............. ON
--     Large size ............... OFF
--     Minimum size ............. OFF
--     Namespace support ........ ON
-- 
--   Entropy sources
--     getrandom ................ 1
--     syscall SYS_getrandom .... 1
--     libbsd ................... OFF
--     /dev/random .............. ON
-- 
-- ===========================================================================
-- Found the following ICU libraries:
--   uc (required)
--   i18n (required)
--   data (required)
-- Found python to use in qt/, shaders/ and 3party/: /usr/bin/python3.10
tools/unix/version.sh: line 11: git: command not found
CMake Error at platform/CMakeLists.txt:88 (execute_process):
  execute_process failed command indexes:

    1: "Child return code: 127"



-- Configuring incomplete, errors occurred!
See also "/omim-build-release/CMakeFiles/CMakeOutput.log".
See also "/omim-build-release/CMakeFiles/CMakeError.log".
root@559a03f5281e:/organicmaps# 
```

`COMMAND_ERROR_IS_FATAL` was introduced in `cmake` 3.19. We already require 3.22.x, so we'll always have `COMMAND_ERROR_IS_FATAL` available. (https://cmake.org/cmake/help/latest/command/execute_process.html)