### PR TITLE
[android] fix blink on exit fullscreen

### DIFF
--- a/android/src/app/organicmaps/util/UiUtils.java
+++ b/android/src/app/organicmaps/util/UiUtils.java
@@ -387,9 +387,10 @@ public final class UiUtils
     final View decorView = window.getDecorView();
     if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.M)
     {
-      WindowInsetsControllerCompat wic = WindowCompat.getInsetsController(window, decorView);
       // It should not be possible for Window insets controller to be null
-      Objects.requireNonNull(wic).setAppearanceLightStatusBars(isLight);
+      WindowInsetsControllerCompat wic = Objects.requireNonNull(WindowCompat.getInsetsController(window, decorView));
+      if (wic.isAppearanceLightStatusBars() != isLight)
+        wic.setAppearanceLightStatusBars(isLight);
     }
     else
     {


### PR DESCRIPTION
For some reason, setting the status bar to light when also showing them makes the screen blink on some Android configurations. No idea why so this patch simply checks if it is needed to set the status bar to light before actually doing it. So now this is not called when exiting fullscreen anymore as the status is already light (black text = light status bar).

Please tell me if this properly fixes the issue on your devices. @Jean-BaptisteC if you want to help testing it would be much appreciated!

Fixes https://github.com/organicmaps/organicmaps/issues/3727