### PR TITLE
[iOS][UI] Show local language secondary title in Place Page.

### DIFF
--- a/iphone/CoreApi/CoreApi/PlacePageData/Common/PlacePagePreviewData.h
+++ b/iphone/CoreApi/CoreApi/PlacePageData/Common/PlacePagePreviewData.h
@@ -32,6 +32,7 @@ NS_ASSUME_NONNULL_BEGIN
 @interface PlacePagePreviewData : NSObject
 
 @property(nonatomic, readonly, nullable) NSString *title;
+@property(nonatomic, readonly, nullable) NSString *secondaryTitle;
 @property(nonatomic, readonly, nullable) NSString *subtitle;
 @property(nonatomic, readonly, nullable) NSString *coordinates;
 @property(nonatomic, readonly, nullable) NSString *address;

--- a/iphone/CoreApi/CoreApi/PlacePageData/Common/PlacePagePreviewData.mm
+++ b/iphone/CoreApi/CoreApi/PlacePageData/Common/PlacePagePreviewData.mm
@@ -89,6 +89,7 @@ static PlacePageDataHotelType convertHotelType(std::optional<ftypes::IsHotelChec
   self = [super init];
   if (self) {
     _title = rawData.GetTitle().empty() ? nil : @(rawData.GetTitle().c_str());
+    _secondaryTitle = rawData.GetSecondaryTitle().empty() ? nil : @(rawData.GetSecondaryTitle().c_str());
     _subtitle = rawData.GetSubtitle().empty() ? nil : @(rawData.GetSubtitle().c_str());
     _coordinates = rawData.GetFormattedCoordinate(true).empty() ? nil : @(rawData.GetFormattedCoordinate(true).c_str());
     _address = rawData.GetAddress().empty() ? nil : @(rawData.GetAddress().c_str());

--- a/iphone/Maps/UI/PlacePage/Components/PlacePageHeader/PlacePageHeaderPresenter.swift
+++ b/iphone/Maps/UI/PlacePage/Components/PlacePageHeader/PlacePageHeaderPresenter.swift
@@ -33,7 +33,7 @@ class PlacePageHeaderPresenter {
 
 extension PlacePageHeaderPresenter: PlacePageHeaderPresenterProtocol {
   func configure() {
-    view?.setTitle(placePagePreviewData.title ?? "")
+    view?.setTitle(placePagePreviewData.title, secondaryTitle: placePagePreviewData.secondaryTitle)
     switch headerType {
     case .flexible:
       view?.isExpandViewHidden = false

--- a/iphone/Maps/UI/PlacePage/Components/PlacePageHeader/PlacePageHeaderViewController.swift
+++ b/iphone/Maps/UI/PlacePage/Components/PlacePageHeader/PlacePageHeaderViewController.swift
@@ -3,7 +3,7 @@ protocol PlacePageHeaderViewProtocol: AnyObject {
   var isExpandViewHidden: Bool { get set }
   var isShadowViewHidden: Bool { get set }
 
-  func setTitle(_ title: String)
+  func setTitle(_ title: String?, secondaryTitle: String?)
 }
 
 class PlacePageHeaderViewController: UIViewController {
@@ -50,7 +50,33 @@ extension PlacePageHeaderViewController: PlacePageHeaderViewProtocol {
     }
   }
 
-  func setTitle(_ title: String) {
-    titleLabel?.text = title
+  func setTitle(_ title: String?, secondaryTitle: String?) {
+    guard let title else {
+      titleLabel?.attributedText = nil
+      return
+    }
+
+    let titleAttributes: [NSAttributedString.Key: Any] = [
+      .font: StyleManager.shared.theme!.fonts.medium20,
+      .foregroundColor: UIColor.blackPrimaryText()
+    ]
+
+    let attributedText = NSMutableAttributedString(string: title, attributes: titleAttributes)
+
+    guard let secondaryTitle else {
+      titleLabel?.attributedText = attributedText
+      return
+    }
+
+    let paragraphStyle = NSMutableParagraphStyle()
+    paragraphStyle.paragraphSpacingBefore = 2
+    let secondaryTitleAttributes: [NSAttributedString.Key: Any] = [
+      .font: StyleManager.shared.theme!.fonts.medium16,
+      .foregroundColor: UIColor.blackPrimaryText(),
+      .paragraphStyle: paragraphStyle
+    ]
+
+    attributedText.append(NSAttributedString(string: "\n" + secondaryTitle, attributes: secondaryTitleAttributes))
+    titleLabel?.attributedText = attributedText
   }
 }

--- a/iphone/Maps/UI/PlacePage/PlacePage.storyboard
+++ b/iphone/Maps/UI/PlacePage/PlacePage.storyboard
@@ -1,9 +1,9 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="20037" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES" initialViewController="bX8-ZQ-XDA">
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="21225" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES" initialViewController="bX8-ZQ-XDA">
     <device id="retina4_7" orientation="portrait" appearance="light"/>
     <dependencies>
         <deployment identifier="iOS"/>
-        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="20020"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="21207"/>
         <capability name="Safe area layout guides" minToolsVersion="9.0"/>
         <capability name="Stack View standard spacing" minToolsVersion="9.0"/>
         <capability name="System colors in document resources" minToolsVersion="11.0"/>
@@ -1726,9 +1726,6 @@
                                         <fontDescription key="fontDescription" type="system" weight="medium" pointSize="20"/>
                                         <nil key="textColor"/>
                                         <nil key="highlightedColor"/>
-                                        <userDefinedRuntimeAttributes>
-                                            <userDefinedRuntimeAttribute type="string" keyPath="styleName" value="medium20:blackPrimaryText"/>
-                                        </userDefinedRuntimeAttributes>
                                     </label>
                                     <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="yZT-ea-Kac">
                                         <rect key="frame" x="333" y="12" width="30" height="30"/>

--- a/iphone/Maps/UI/PlacePage/PlacePageLayout/Layouts/PlacePageCommonLayout.swift
+++ b/iphone/Maps/UI/PlacePage/PlacePageLayout/Layouts/PlacePageCommonLayout.swift
@@ -184,8 +184,9 @@ extension PlacePageCommonLayout {
       isBookmark = true
     }
     if let title = placePageData.previewData.title {
-      header?.setTitle(title)
-      placePageNavigationViewController.setTitle(title)
+      let secondaryTitle = placePageData.previewData.secondaryTitle
+      header?.setTitle(title, secondaryTitle: secondaryTitle)
+      placePageNavigationViewController.setTitle(title, secondaryTitle: secondaryTitle)
     }
     self.presenter?.layoutIfNeeded()
     UIView.animate(withDuration: kDefaultAnimationDuration) { [unowned self] in

--- a/map/place_page_info.cpp
+++ b/map/place_page_info.cpp
@@ -56,9 +56,17 @@ void Info::SetFromFeatureType(FeatureType & ft)
   {
     m_uiTitle = GetBookmarkName();
 
-    auto const secondaryTitle = m_customName.empty() ? m_primaryFeatureName : m_customName;
+    std::string secondaryTitle;
+
+    if (!m_customName.empty())
+      secondaryTitle = m_customName;
+    else if (!out.secondary.empty())
+      secondaryTitle = out.secondary;
+    else
+      secondaryTitle = m_primaryFeatureName;
+
     if (m_uiTitle != secondaryTitle)
-      m_uiSecondaryTitle = secondaryTitle;
+      m_uiSecondaryTitle = std::move(secondaryTitle);
 
     m_uiSubtitle = FormatSubtitle(true /* withType */);
     m_uiAddress = m_address;


### PR DESCRIPTION
Fixes #3756.

Before:
![Untitled1](https://user-images.githubusercontent.com/11923691/199301755-0a5e2a9f-bf9c-4372-88f0-08b986e0368c.jpg)
After:
![Untitled](https://user-images.githubusercontent.com/11923691/199301753-61352f84-53f2-459f-a2cb-8b6c0c796454.jpg)


Secondary title was missing in bookmark mode, that's why some `place_page_info.cpp` logic was changed.