### PR TITLE
[Android] Fix word wrapping & padding in download card

### DIFF
--- a/android/res/layout-land/onmap_downloader.xml
+++ b/android/res/layout-land/onmap_downloader.xml
@@ -20,7 +20,7 @@
     android:gravity="center"
     tools:ignore="UselessParent">
     <LinearLayout
-      android:layout_width="@dimen/square_block_size"
+      android:layout_width="wrap_content"
       android:layout_height="wrap_content"
       android:orientation="vertical"
       android:clipToPadding="false"
@@ -31,10 +31,10 @@
         android:id="@+id/downloader_parent"
         android:layout_width="wrap_content"
         android:layout_height="wrap_content"
-        android:layout_margin="@dimen/margin_eighth"
+        android:layout_marginBottom="@dimen/margin_eighth"
         android:textAppearance="@style/MwmTextAppearance.Body2"
         android:gravity="center_horizontal"
-        tools:text="Honduras"/>
+        tools:text="Some country very loooooooooong country"/>
       <TextView
         android:id="@+id/downloader_title"
         android:layout_width="wrap_content"
@@ -43,7 +43,7 @@
         android:fontFamily="@string/robotoMedium"
         android:textStyle="normal"
         android:gravity="center_horizontal"
-        tools:text="Some title very loooooooooong title"
+        tools:text="Some name very loooooooooong name"
         tools:ignore="UnusedAttribute"/>
       <TextView
         android:id="@+id/downloader_size"
@@ -56,12 +56,13 @@
       <FrameLayout
         android:id="@+id/downloader_controls_frame"
         android:layout_width="180dp"
-        android:layout_height="@dimen/height_block_base"
+        android:layout_height="@dimen/downloader_status_size"
         android:clipChildren="false">
         <Button
           android:id="@+id/downloader_button"
           style="@style/MwmWidget.Button.Primary"
           android:layout_width="180dp"
+          android:layout_gravity="center"
           android:visibility="gone"
           tools:visibility="visible"/>
         <app.organicmaps.widget.WheelProgressView

--- a/android/res/layout/onmap_downloader.xml
+++ b/android/res/layout/onmap_downloader.xml
@@ -8,7 +8,7 @@
   android:visibility="gone"
   tools:visibility="visible">
   <LinearLayout
-    android:layout_width="wrap_content"
+    android:layout_width="212dp"
     android:layout_height="wrap_content"
     android:orientation="vertical"
     android:padding="@dimen/margin_base"
@@ -22,12 +22,12 @@
 
     <TextView
       android:id="@+id/downloader_parent"
-      android:layout_width="wrap_content"
+      android:layout_width="@dimen/square_block_size"
       android:layout_height="wrap_content"
-      android:layout_margin="@dimen/margin_eighth"
+      android:layout_marginBottom="@dimen/margin_eighth"
       android:textAppearance="@style/MwmTextAppearance.Body2"
       android:gravity="center_horizontal"
-      tools:text="Honduras"/>
+      tools:text="Some country very loooooooooong country"/>
     <TextView
       android:id="@+id/downloader_title"
       android:layout_width="wrap_content"
@@ -36,7 +36,7 @@
       android:fontFamily="@string/robotoMedium"
       android:textStyle="normal"
       android:gravity="center_horizontal"
-      tools:text="Some title"
+      tools:text="Some name very loooooooooong name"
       tools:ignore="UnusedAttribute"/>
     <TextView
       android:id="@+id/downloader_size"
@@ -49,13 +49,15 @@
     <FrameLayout
       android:id="@+id/downloader_controls_frame"
       android:layout_width="180dp"
-      android:layout_height="@dimen/height_block_base"
+      android:layout_height="@dimen/downloader_status_size"
       android:clipChildren="false">
       <Button
         android:id="@+id/downloader_button"
         style="@style/MwmWidget.Button.Primary"
         android:layout_width="180dp"
-        android:visibility="gone"/>
+        android:layout_gravity="center"
+        android:visibility="gone"
+        tools:visibility="visible"/>
       <app.organicmaps.widget.WheelProgressView
         android:id="@+id/wheel_downloader_progress"
         android:layout_width="@dimen/downloader_status_size"


### PR DESCRIPTION
fixes https://github.com/organicmaps/organicmaps/pull/3733#issuecomment-1299086369

landscape expands, portrait is fixed size
also some small padding tweaks to reduce wasted space at the bottom

![signal-2022-11-01-232239_002](https://user-images.githubusercontent.com/26939824/199360511-55219595-70fd-44d5-8806-00bf27a4d1f3.png)

https://user-images.githubusercontent.com/26939824/199348045-1d77388e-839d-4ca6-ae8f-c90bb14433ea.mp4

![signal-2022-11-01-232233_002](https://user-images.githubusercontent.com/26939824/199360506-3dc85efb-7ec0-412f-9e56-5cffcf1b4620.png)
