### PR TITLE
[android] fix distance not shown on search results

### DIFF
--- a/android/src/app/organicmaps/MwmActivity.java
+++ b/android/src/app/organicmaps/MwmActivity.java
@@ -288,10 +288,9 @@ public class MwmActivity extends BaseMwmFragmentActivity
 
   public void showSearch(String query)
   {
+    closeSearchToolbar(false, true);
     if (mIsTabletLayout)
     {
-      closeSearchToolbar(false, false);
-
       final Bundle args = new Bundle();
       args.putString(SearchActivity.EXTRA_QUERY, query);
       replaceFragment(SearchFragment.class, args, null);

--- a/android/src/app/organicmaps/search/SearchFragment.java
+++ b/android/src/app/organicmaps/search/SearchFragment.java
@@ -285,9 +285,6 @@ public class SearchFragment extends BaseMwmFragment
     updateFrames();
     updateResultsPlaceholder();
 
-    if (mInitialQuery != null)
-      setQuery(mInitialQuery, false);
-
     mToolbarController.activate();
 
     SearchEngine.INSTANCE.addListener(this);
@@ -312,6 +309,10 @@ public class SearchFragment extends BaseMwmFragment
   {
     super.onResume();
     LocationHelper.INSTANCE.addListener(mLocationListener);
+    if (mInitialQuery != null) {
+      setQuery(mInitialQuery, false);
+      mInitialQuery = null;
+    }
   }
 
   @Override


### PR DESCRIPTION
When going back to the search activity from the map view, the search was started before the activity retrieved the current location. This PR moves the query initialization from onCreateView to onResume. It also makes sure search is properly stopped when going from the map to the search activity.

Fixes https://github.com/organicmaps/organicmaps/issues/3763

@Jean-BaptisteC can you please confirm it fixes your issue?