### PR TITLE
[android] fix navigation menu visible under navbar

### DIFF
--- a/android/res/layout-land/layout_nav.xml
+++ b/android/res/layout-land/layout_nav.xml
@@ -40,6 +40,6 @@
     android:id="@+id/nav_bottom_sheet_nav_bar"
     android:layout_width="0dp"
     android:layout_height="0dp"
-    android:layout_gravity="bottom"
+    android:layout_gravity="bottom|start"
     android:background="?cardBackground"/>
 </FrameLayout>

--- a/android/res/layout/layout_nav.xml
+++ b/android/res/layout/layout_nav.xml
@@ -37,8 +37,8 @@
 
   <View
     android:id="@+id/nav_bottom_sheet_nav_bar"
-    android:layout_width="match_parent"
+    android:layout_width="0dp"
     android:layout_height="0dp"
-    android:layout_gravity="bottom"
+    android:layout_gravity="bottom|center"
     android:background="?cardBackground"/>
 </FrameLayout>


### PR DESCRIPTION
Makes the navigation menu properly hidden behind the navigation bar on tablet.

| portrait | landscape |
|-|-|
| ![Screenshot_1667929718](https://user-images.githubusercontent.com/80701113/200639189-5fbd6514-64ff-4317-a2cb-41bb3c9052e4.png) | ![Screenshot_1667929724](https://user-images.githubusercontent.com/80701113/200639188-41fbc0ef-2137-424c-91f8-c1ab94946cf1.png) |


Fixes https://github.com/organicmaps/organicmaps/issues/3740