### PR TITLE
[3party] Updated expat to the latest released version R_2_5_0

### DIFF
--- a/xcode/expat/expat.xcodeproj/project.pbxproj
+++ b/xcode/expat/expat.xcodeproj/project.pbxproj
@@ -26,6 +26,7 @@
 		56D1866B24FF80E5009747D2 /* xmltok.h in Headers */ = {isa = PBXBuildFile; fileRef = 56D1865824FF80E4009747D2 /* xmltok.h */; };
 		56D1866C24FF80E5009747D2 /* winconfig.h in Headers */ = {isa = PBXBuildFile; fileRef = 56D1865924FF80E4009747D2 /* winconfig.h */; };
 		56D1866D24FF80E5009747D2 /* xmltok.c in Sources */ = {isa = PBXBuildFile; fileRef = 56D1865A24FF80E5009747D2 /* xmltok.c */; };
+		FAEB4C5C29195DC00044B82E /* expat_config.h in Headers */ = {isa = PBXBuildFile; fileRef = FAEB4C5B29195DC00044B82E /* expat_config.h */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXFileReference section */
@@ -51,6 +52,7 @@
 		56D1865924FF80E4009747D2 /* winconfig.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = winconfig.h; path = expat/lib/winconfig.h; sourceTree = "<group>"; };
 		56D1865A24FF80E5009747D2 /* xmltok.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; name = xmltok.c; path = expat/lib/xmltok.c; sourceTree = "<group>"; };
 		670D04F81B0BAEE50013A7AC /* libexpat.a */ = {isa = PBXFileReference; explicitFileType = archive.ar; includeInIndex = 0; path = libexpat.a; sourceTree = BUILT_PRODUCTS_DIR; };
+		FAEB4C5B29195DC00044B82E /* expat_config.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = expat_config.h; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -67,6 +69,7 @@
 		670D04EF1B0BAEE50013A7AC = {
 			isa = PBXGroup;
 			children = (
+				FAEB4C5B29195DC00044B82E /* expat_config.h */,
 				34EBB47A1DBF51D4005BE9B8 /* common-debug.xcconfig */,
 				34EBB47B1DBF51D4005BE9B8 /* common-release.xcconfig */,
 				670D04FA1B0BAEE50013A7AC /* expat */,
@@ -130,6 +133,7 @@
 				56D1865B24FF80E5009747D2 /* siphash.h in Headers */,
 				56D1866524FF80E5009747D2 /* latin1tab.h in Headers */,
 				56D1866124FF80E5009747D2 /* internal.h in Headers */,
+				FAEB4C5C29195DC00044B82E /* expat_config.h in Headers */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};

--- a/xcode/expat/expat_config.h
+++ b/xcode/expat/expat_config.h
@@ -1,0 +1,120 @@
+/* expat_config.h.cmake.  Based upon generated expat_config.h.in.  */
+
+#ifndef EXPAT_CONFIG_H
+#define EXPAT_CONFIG_H 1
+
+/* 1234 = LIL_ENDIAN, 4321 = BIGENDIAN */
+#define BYTEORDER 1234
+
+/* Define to 1 if you have the `arc4random' function. */
+/* #undef HAVE_ARC4RANDOM */
+
+/* Define to 1 if you have the `arc4random_buf' function. */
+#define HAVE_ARC4RANDOM_BUF
+
+/* Define to 1 if you have the <dlfcn.h> header file. */
+#define HAVE_DLFCN_H
+
+/* Define to 1 if you have the <fcntl.h> header file. */
+#define HAVE_FCNTL_H
+
+/* Define to 1 if you have the `getpagesize' function. */
+#define HAVE_GETPAGESIZE
+
+/* Define to 1 if you have the `getrandom' function. */
+/* #undef HAVE_GETRANDOM */
+
+/* Define to 1 if you have the <inttypes.h> header file. */
+#define HAVE_INTTYPES_H
+
+/* Define to 1 if you have the `bsd' library (-lbsd). */
+/* #undef HAVE_LIBBSD */
+
+/* Define to 1 if you have the <memory.h> header file. */
+#define HAVE_MEMORY_H
+
+/* Define to 1 if you have a working `mmap' system call. */
+#define HAVE_MMAP
+
+/* Define to 1 if you have the <stdint.h> header file. */
+#define HAVE_STDINT_H
+
+/* Define to 1 if you have the <stdlib.h> header file. */
+#define HAVE_STDLIB_H
+
+/* Define to 1 if you have the <strings.h> header file. */
+#define HAVE_STRINGS_H
+
+/* Define to 1 if you have the <string.h> header file. */
+#define HAVE_STRING_H
+
+/* Define to 1 if you have `syscall' and `SYS_getrandom'. */
+/* #undef HAVE_SYSCALL_GETRANDOM */
+
+/* Define to 1 if you have the <sys/stat.h> header file. */
+#define HAVE_SYS_STAT_H
+
+/* Define to 1 if you have the <sys/types.h> header file. */
+#define HAVE_SYS_TYPES_H
+
+/* Define to 1 if you have the <unistd.h> header file. */
+#define HAVE_UNISTD_H
+
+/* Name of package */
+#define PACKAGE "expat"
+
+/* Define to the address where bug reports for this package should be sent. */
+#define PACKAGE_BUGREPORT "expat-bugs@libexpat.org"
+
+/* Define to the full name of this package. */
+#define PACKAGE_NAME "expat"
+
+/* Define to the full name and version of this package. */
+#define PACKAGE_STRING "expat 2.5.0"
+
+/* Define to the one symbol short name of this package. */
+#define PACKAGE_TARNAME "expat"
+
+/* Define to the home page for this package. */
+#define PACKAGE_URL ""
+
+/* Define to the version of this package. */
+#define PACKAGE_VERSION "2.5.0"
+
+/* Define to 1 if you have the ANSI C header files. */
+#define STDC_HEADERS
+
+/* whether byteorder is bigendian */
+/* #undef WORDS_BIGENDIAN */
+
+/* Define to allow retrieving the byte offsets for attribute names and values.
+ */
+/* #undef XML_ATTR_INFO */
+
+/* Define to specify how much context to retain around the current parse
+   point. */
+#define XML_CONTEXT_BYTES 1024
+
+#if ! defined(_WIN32)
+/* Define to include code reading entropy from `/dev/urandom'. */
+#define XML_DEV_URANDOM
+#endif
+
+/* Define to make parameter entity parsing functionality available. */
+#define XML_DTD
+
+/* Define to make XML Namespaces functionality available. */
+#define XML_NS
+
+/* Define to __FUNCTION__ or "" if `__func__' does not conform to ANSI C. */
+#ifdef _MSC_VER
+#  define __func__ __FUNCTION__
+#endif
+
+/* Define to `long' if <sys/types.h> does not define. */
+/* #undef off_t */
+
+/* Define to `unsigned' if <sys/types.h> does not define. */
+/* #undef size_t */
+
+#endif // ndef EXPAT_CONFIG_H


### PR DESCRIPTION
expat_config.h is generated by CMake, but for XCode project we don't use CMake at the moment. So the file, generated for Mac, is used there.