### PR TITLE
WIP: Use ctest to run all tests

### DIFF
--- a/.github/workflows/linux-check.yaml
+++ b/.github/workflows/linux-check.yaml
@@ -70,6 +70,11 @@ jobs:
         working-directory: build
         run: ninja
 
+      - name: CTest
+        shell: bash
+        working-directory: build
+        run: ctest -j$(nproc) --output-on-failure
+
   linux-matrix:
     name: Linux builds and tests
     runs-on: ubuntu-22.04

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -204,6 +204,7 @@ endif()
 
 if (NOT SKIP_TESTS)
   set(SKIP_TESTS FALSE)
+  enable_testing()
 endif()
 
 if (NOT PYTHON_VERSION)

--- a/cmake/OmimHelpers.cmake
+++ b/cmake/OmimHelpers.cmake
@@ -99,6 +99,7 @@ function(omim_add_test_impl disable_platform_init executable)
     endif()
     # testingmain.cpp uses base::HighResTimer::ElapsedNano
     target_link_libraries(${executable} base)
+    add_test(NAME ${executable} COMMAND ${executable} WORKING_DIRECTORY ${CMAKE_BINARY_DIR})
   endif()
 endfunction()
 


### PR DESCRIPTION
`ctest --test-dir ../omim-build-debug -j$(sysctl -n hw.ncpu) --output-on-failure`

TODO:
1. Add 3party tests (e.g. opening hours).
2. Handle environment preparation for some tests (e.g. pre-download necessary maps).
3. Workaround or set up a real HTTP server for downloader tests.