### PR TITLE
[ios] Display 1 hour to open/close properly

### DIFF
--- a/iphone/Maps/UI/PlacePage/Components/PlacePagePreviewViewController.swift
+++ b/iphone/Maps/UI/PlacePage/Components/PlacePagePreviewViewController.swift
@@ -216,7 +216,7 @@ final class PlacePagePreviewViewController: UIViewController {
   
   private func getTimeIntervalString(minutes: Int) -> String {
     var str = "";
-    if (minutes > 60)
+    if (minutes >= 60)
     {
       str = String(minutes / 60) + " " + L("hour") + " ";
     }


### PR DESCRIPTION
Some time ago, I noticed that Organic Maps on iPhone doesn't show one specific case of relative time to opening/closing hours correctly. Specifically – when this time is exactly 1 hour.

---

**Example:**
<sup>(Distance from me is removed for privacy reasons)</sup>
<p>
<img width="33%" src="https://user-images.githubusercontent.com/66956532/201475222-b0a70eaa-531b-439a-a3d5-7aa2d2d37eb9.PNG">
<img width="33%" src="https://user-images.githubusercontent.com/66956532/201475420-95a989df-ee83-43a2-8e40-21a783c9631d.PNG">
<img width="33%" src="https://user-images.githubusercontent.com/66956532/201475225-3ae602f5-d694-4d99-952e-2c91c218f97e.PNG">
</p>

---

So, this PR fixes that ;)