### PR TITLE
[android-auto] Add gradle support

### DIFF
--- a/.github/workflows/android-check.yaml
+++ b/.github/workflows/android-check.yaml
@@ -54,7 +54,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        flavor: [WebDebug, FdroidBeta]
+        flavor: [WebNoCarDebug, WebCarDebug, FdroidNoCarBeta, FdroidCarBeta]
 
     steps:
       - name: Install build tools and dependencies

--- a/.github/workflows/android-monkey.yaml
+++ b/.github/workflows/android-monkey.yaml
@@ -73,7 +73,7 @@ jobs:
         run: |
           cmake --version
           ninja --version
-          gradle -Parm64 -Parm32 -Pfirebase assembleGoogleDebug
+          gradle -Parm64 -Parm32 -Pfirebase assembleGoogleNoCarDebug
 
       - name: Run monkey
         run: |

--- a/.github/workflows/android-release-metadata.yaml
+++ b/.github/workflows/android-release-metadata.yaml
@@ -48,6 +48,6 @@ jobs:
 
       - name: Upload
         shell: bash
-        run: ./gradlew publishGoogleReleaseListing
+        run: ./gradlew publishGoogleNoCarReleaseListing
         working-directory: android
         timeout-minutes: 5

--- a/.github/workflows/android-release.yaml
+++ b/.github/workflows/android-release.yaml
@@ -121,22 +121,22 @@ jobs:
         shell: bash
         working-directory: android
         run: |
-          gradle bundleGoogleRelease publishGoogleReleaseBundle
+          gradle bundleGoogleNoCarRelease publishGoogleNoCarReleaseBundle
         if: ${{ matrix.flavor == 'google' }}
 
       - name: Compile and upload to Huawei AppGallery
         shell: bash
         working-directory: android
         run: |
-          gradle bundleHuaweiRelease
-          gradle publishHuaweiAppGalleryHuaweiRelease
+          gradle bundleHuaweiNoCarRelease
+          gradle publishHuaweiAppGalleryHuaweiNoCarRelease
         if: ${{ matrix.flavor == 'huawei' }}
 
       - name: Compile universal APK
         shell: bash
         working-directory: android
         run: |
-          gradle assembleWebRelease
+          gradle assembleWebNoCarRelease
         if: ${{ matrix.flavor == 'web' }}
 
       - name: Prepare release notes

--- a/android/build.gradle
+++ b/android/build.gradle
@@ -232,7 +232,7 @@ android {
     res.srcDirs = ['tests/resources']
   }
 
-  flavorDimensions 'default'
+  flavorDimensions 'default', 'car'
 
   productFlavors {
     // 01 is a historical artefact, sorry.
@@ -268,10 +268,31 @@ android {
       buildConfigField 'String', 'REVIEW_URL', '"appmarket://details?id=app.organicmaps"'
       android.sourceSets.huawei.assets.srcDirs = ['flavors/world-enabled']
     }
+
+    car {
+      dimension 'car'
+      minSdkVersion propAndroidAutoMinSdkVersion.toInteger()
+
+      android.sourceSets.car {
+        manifest.srcFile 'flavors/car/AndroidManifest.xml'
+        java.srcDirs = ['flavors/car/src']
+        res.srcDirs = ['flavors/car/res']
+      }
+
+      dependencies {
+        implementation 'androidx.car.app:app:1.3.0-beta01'
+        // Fix for app/organicmaps/util/FileUploadWorker.java:14: error: cannot access ListenableFuture
+        implementation 'com.google.guava:guava:29.0-android'
+      }
+    }
+
+    noCar {
+      dimension 'car'
+    }
   }
 
   playConfigs {
-    googleRelease {
+    googleNoCarRelease {
       enabled.set(true)
     }
   }

--- a/android/flavors/car/AndroidManifest.xml
+++ b/android/flavors/car/AndroidManifest.xml
@@ -1,0 +1,30 @@
+<?xml version="1.0" encoding="utf-8"?>
+<manifest xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:tools="http://schemas.android.com/tools">
+
+  <uses-permission android:name="androidx.car.app.ACCESS_SURFACE" />
+  <uses-permission android:name="androidx.car.app.NAVIGATION_TEMPLATES" />
+
+  <application
+      android:name=".MwmApplication"
+      android:icon="@mipmap/ic_launcher"
+      tools:node="merge">
+
+    <meta-data
+        android:name="androidx.car.app.minCarApiLevel"
+        android:value="1" />
+
+    <meta-data
+        android:name="com.google.android.gms.car.application"
+        android:resource="@xml/automotive_app_desc" />
+
+    <service
+        android:name=".car.OMCarService"
+        android:exported="true">
+      <intent-filter>
+        <action android:name="androidx.car.app.CarAppService" />
+        <category android:name="androidx.car.app.category.NAVIGATION" />
+      </intent-filter>
+    </service>
+  </application>
+</manifest>

--- a/android/flavors/car/res/xml/automotive_app_desc.xml
+++ b/android/flavors/car/res/xml/automotive_app_desc.xml
@@ -1,0 +1,4 @@
+<?xml version="1.0" encoding="utf-8"?>
+<automotiveApp>
+  <uses name="template" />
+</automotiveApp>

--- a/android/flavors/car/src/app/organicmaps/car/OMCarService.java
+++ b/android/flavors/car/src/app/organicmaps/car/OMCarService.java
@@ -1,0 +1,15 @@
+package app.organicmaps.car;
+
+import androidx.annotation.NonNull;
+import androidx.car.app.CarAppService;
+import androidx.car.app.validation.HostValidator;
+
+public final class OMCarService extends CarAppService
+{
+  @NonNull
+  @Override
+  public HostValidator createHostValidator()
+  {
+    throw new UnsupportedOperationException("Not implemented, yet");
+  }
+}

--- a/android/gradle.properties
+++ b/android/gradle.properties
@@ -1,4 +1,5 @@
 propMinSdkVersion=21
+propAndroidAutoMinSdkVersion=23
 propTargetSdkVersion=33
 propCompileSdkVersion=33
 propBuildToolsVersion=33.0.0


### PR DESCRIPTION
The second part of #3806.

I know about issue #3886. From my pov, there is a lot of time to find a solution because it can wait until the end of Android Auto development.


My proposition:
* Separate product flavor `car` for Android Auto development and maybe AAOS in future
* Product flavor `noCar`. It will be used for release builds during the AA development
  * I don't like `noCar` name. Do you have a better variant?
  * I also tried to find a way to set an empty name for this flavor but didn't find a solution. Having an empty flavor name will be better in our case - no need to update almost all android workflows and `playConfigs` section in `build.gradle` . Maybe you know how to implement it?

Probably there is no way to set an empty flavor name.
So, AA support can be implemented by setting a flag f.e. in `gradle.properties` file. What do you think about this solution?