### PR TITLE
[android] handle place page direction arrow more reliably

### DIFF
--- a/android/res/layout/place_page_preview.xml
+++ b/android/res/layout/place_page_preview.xml
@@ -87,20 +87,22 @@
     android:layout_width="wrap_content"
     android:layout_height="wrap_content"
     android:layout_marginEnd="@dimen/margin_base"
+    android:paddingEnd="@dimen/margin_quarter"
+    android:paddingStart="@dimen/margin_quarter"
     android:layout_alignParentEnd="true"
     android:layout_alignWithParentIfMissing="true"
     android:layout_alignBottom="@id/title_container"
     android:background="?selectableItemBackground"
     android:layout_below="@id/pull_icon_container"
-    android:gravity="bottom"
-    android:orientation="horizontal"
+    android:gravity="center"
+    android:orientation="vertical"
     tools:background="#111111F0">
 
     <app.organicmaps.widget.ArrowView
       android:id="@+id/av__direction"
       android:layout_width="wrap_content"
       android:layout_height="wrap_content"
-      android:layout_marginEnd="@dimen/margin_half"
+      android:layout_gravity="center"
       app:tint="?colorAccent"
       android:scaleType="center"
       android:src="@drawable/ic_direction_pagepreview"/>
@@ -109,6 +111,7 @@
       android:id="@+id/tv__straight_distance"
       android:layout_width="wrap_content"
       android:layout_height="wrap_content"
+      android:layout_gravity="center"
       android:textAppearance="@style/MwmTextAppearance.PlacePage.Accent"
       android:textSize="@dimen/text_size_body_3"
       tools:text="2000 km"/>

--- a/android/src/app/organicmaps/widget/placepage/RichPlacePageController.java
+++ b/android/src/app/organicmaps/widget/placepage/RichPlacePageController.java
@@ -251,8 +251,7 @@ public class RichPlacePageController implements PlacePageController, LocationLis
   {
     @BottomSheetBehavior.State
     int currentState = mPlacePageBehavior.getState();
-    if (PlacePageUtils.isHiddenState(currentState) || PlacePageUtils.isDraggingState(currentState)
-        || PlacePageUtils.isSettlingState(currentState))
+    if (PlacePageUtils.isHiddenState(currentState))
       return;
 
     mPlacePage.refreshAzimuth(north);


### PR DESCRIPTION
Following https://github.com/organicmaps/organicmaps/pull/3544, I found the place page peek height was wrong in case the title was short enough to fit in one line without the direction arrow (position not known), but too long to fit when the direction is shown. As this arrow would blink when the sheet was opened, the logic would calculate a peek height without taking into account this arrow, and thus was not enough.

This PR aims to fix this issue by more reliably displaying the direction arrow. I also slightly modified the UI to place the arrow on top of the distance and centered, felt it was prettier. 

Going from no position to position known while the pp is open. The peek height is now correctly updated.

https://user-images.githubusercontent.com/80701113/202572365-fbecd838-3f24-4410-8817-fa74abb08c13.mp4

Changing POIs when the location is known. The direction arrow is always shown, no more ugly blinking in.

https://user-images.githubusercontent.com/80701113/202572374-ddd36de8-19a3-4cb6-9e7c-797011541eb1.mp4

