### PR TITLE
[android] fix centring for follow icon

### DIFF
--- a/android/res/drawable/ic_follow.xml
+++ b/android/res/drawable/ic_follow.xml
@@ -1,5 +1,5 @@
 <vector android:height="24dp" android:tint="#FFFFFF"
     android:viewportHeight="24" android:viewportWidth="24"
     android:width="24dp" xmlns:android="http://schemas.android.com/apk/res/android">
-    <path android:fillColor="@android:color/white" android:pathData="M21 3L3 10.53V11.5L9.84 14.16L12.5 21H13.46L21 3Z"/>
+    <path android:fillColor="@android:color/white" android:pathData="m20.214641 3.7904477-18 7.5300003v0.97l6.84 2.66 2.6599999 6.84h0.96z"/>
 </vector>

--- a/data/resources-svg/ic_follow.svg
+++ b/data/resources-svg/ic_follow.svg
@@ -1,0 +1,4 @@
+<svg width="24pt" height="24pt" version="1.1" viewBox="0 0 24 24" xmlns="http://www.w3.org/2000/svg">
+    <path d="m20.214641 3.7904477-18 7.5300003v.97l6.84 2.66 2.6599999 6.84h.96z" fill="fff" style="stroke-width:1.22562"/>
+    <circle cx="11.999999" cy="12.000001" r="1" fill="#ff0000"/>
+</svg>


### PR DESCRIPTION
Now centred on shape centroid instead of bbox

before / after:
![after](https://user-images.githubusercontent.com/26939824/203082960-7460cfd5-1307-4b06-80d4-757a0e0654cd.png)

fixes https://github.com/organicmaps/organicmaps/issues/3926