### PR TITLE
[desktop] Mark mouse move event as accepted

### DIFF
--- a/qt/draw_widget.cpp
+++ b/qt/draw_widget.cpp
@@ -236,7 +236,10 @@ void DrawWidget::mouseMoveEvent(QMouseEvent * e)
   QOpenGLWidget::mouseMoveEvent(e);
 
   if (IsLeftButton(e) && !IsAltModifier(e))
+  {
     m_framework.TouchEvent(GetTouchEvent(e, df::TouchEvent::TOUCH_MOVE));
+    e->accept();
+  }
 
   if (m_selectionMode && m_rubberBand != nullptr && m_rubberBand->isVisible())
     m_rubberBand->setGeometry(QRect(m_rubberBandOrigin, e->pos()).normalized());


### PR DESCRIPTION
At least on KDE trying to drag the map around would drag the whole application window.

Signed-off-by: Jaime Marquínez Ferrándiz <jaime.marquinez.ferrandiz@fastmail.net>

This is how it behaved on KDE:

https://user-images.githubusercontent.com/1239727/203256128-3ba6110d-ebcb-4d92-b00c-da3cac75eb92.mp4

With this change I can correctly drag the map around:

https://user-images.githubusercontent.com/1239727/203256241-50bc3eed-b4bb-42cd-b77d-f2b035522622.mp4

