### PR TITLE
[ios] Settings and routing options table headers are visible now in the Dark Mode

### DIFF
--- a/iphone/Maps/Classes/Components/MWMTableViewController.m
+++ b/iphone/Maps/Classes/Components/MWMTableViewController.m
@@ -33,6 +33,9 @@
   if ([headerView isKindOfClass: [UITableViewHeaderFooterView class]]) {
     UITableViewHeaderFooterView* header = (UITableViewHeaderFooterView *)headerView;
     header.textLabel.textColor = [UIColor blackSecondaryText];
+    if (self.tableView.style == UITableViewStyleGrouped) {
+      header.detailTextLabel.textColor = [UIColor blackSecondaryText];
+    }
   }
 }
 

--- a/iphone/Maps/Classes/Components/MWMTableViewController.m
+++ b/iphone/Maps/Classes/Components/MWMTableViewController.m
@@ -19,6 +19,23 @@
   return NO;
 }
 
+- (void)viewWillAppear:(BOOL)animated
+{
+  [super viewWillAppear:animated];
+  
+  for (NSInteger i = 0; i < [self numberOfSectionsInTableView:self.tableView]; i++) {
+    [self updateHeaderView:[self.tableView headerViewForSection:i]];
+  }
+}
+
+// Fix table section header font color for all tables, including Setting and Route Options.
+- (void)updateHeaderView:(UIView*)headerView {
+  if ([headerView isKindOfClass: [UITableViewHeaderFooterView class]]) {
+    UITableViewHeaderFooterView* header = (UITableViewHeaderFooterView *)headerView;
+    header.textLabel.textColor = [UIColor blackSecondaryText];
+  }
+}
+
 - (void)viewDidLoad
 {
   [super viewDidLoad];
@@ -29,6 +46,10 @@
          forCellReuseIdentifier:[UITableViewCell className]];
   [self.tableView registerClass:[MWMTableViewSubtitleCell class]
          forCellReuseIdentifier:[MWMTableViewSubtitleCell className]];
+}
+
+- (void)tableView:(UITableView *)tableView willDisplayHeaderView:(UIView *)view forSection:(NSInteger)section {
+  [self updateHeaderView:view];
 }
 
 #pragma mark - Properties


### PR DESCRIPTION
Fixes #4009 
Closes #4011 

<img width="1533" alt="Screenshot 2022-12-05 at 17 51 48" src="https://user-images.githubusercontent.com/266271/205869746-f2ebdda4-ab9e-477c-a559-7df3acfde188.png">
