### PR TITLE
[github/workflows] Distinguish 'iOS Check' and 'iOS Check metadata'

### DIFF
--- a/.github/workflows/ios-check-metadata.yaml
+++ b/.github/workflows/ios-check-metadata.yaml
@@ -1,4 +1,4 @@
-name: iOS Check
+name: iOS Check metadata
 on:
   workflow_dispatch: # Manual trigger
   pull_request:


### PR DESCRIPTION
* Previously the two workflows have had the same name and it was impossible to distinguish them by name when having to manually trigger the right one.

Signed-off-by: Ferenc Géczi <ferenc.gm@gmail.com>