### PR TITLE
[ios] Fixed crash with invalid menu state

### DIFF
--- a/iphone/Maps/Classes/CustomViews/MapViewControls/MWMMapViewControlsManager.mm
+++ b/iphone/Maps/Classes/CustomViews/MapViewControls/MWMMapViewControlsManager.mm
@@ -59,6 +59,7 @@ NSString *const kMapToCategorySelectorSegue = @"MapToCategorySelectorSegue";
   self.sideButtonsHidden = NO;
   self.trafficButtonHidden = NO;
   self.isDirectionViewHidden = YES;
+  self.menuState = MWMBottomMenuStateInactive;
   self.menuRestoreState = MWMBottomMenuStateInactive;
   return self;
 }
@@ -287,7 +288,7 @@ NSString *const kMapToCategorySelectorSegue = @"MapToCategorySelectorSegue";
   _hidden = hidden;
   self.sideButtonsHidden = _sideButtonsHidden;
   self.trafficButtonHidden = _trafficButtonHidden;
-  self.menuState = _menuState = hidden ? MWMBottomMenuStateHidden : MWMBottomMenuStateInactive;
+  self.menuState = hidden ? MWMBottomMenuStateHidden : MWMBottomMenuStateInactive;
 }
 
 - (void)setZoomHidden:(BOOL)zoomHidden {


### PR DESCRIPTION
The crash log (Top 1 now in AppStoreConnect):
```
_assertionFailure(_:_:file:line:flags:) + 656 (AssertCommon.swift:132) BottomTabBarInteractor.openMenu() + 252 
(BottomTabBarInteractor.swift:0) protocol witness for BottomTabBarInteractorProtocol.openMenu() in conformance 
BottomTabBarInteractor + 4 (BottomTabBarPresenter.swift:39) BottomTabBarPresenter.onMenuButtonPressed() + 4 
(<compiler-generated>:38) protocol witness for BottomTabBarPresenterProtocol.onMenuButtonPressed() in 
conformance BottomTabBarPresenter + 4 (<compiler-generated>:0) 
BottomTabBarViewController.onMenuButtonPressed(_:) + 40 (<compiler-generated>:65) @objc 
BottomTabBarViewController.onMenuButtonPressed(_:) + 88
```