### PR TITLE
[android] Fixed map fragment flow.

### DIFF
--- a/android/src/app/organicmaps/Map.java
+++ b/android/src/app/organicmaps/Map.java
@@ -119,9 +119,6 @@ public final class Map
 
   public void onSurfaceCreated(final Context context, final Surface surface, Rect surfaceFrame, int surfaceDpi)
   {
-    if (nativeIsEngineCreated())
-      nativeDetachSurface(true);
-
     if (isThemeChangingProcess(context))
     {
       Logger.d(TAG, "Theme changing process, skip 'onSurfaceCreated' callback");

--- a/android/src/app/organicmaps/MapFragment.java
+++ b/android/src/app/organicmaps/MapFragment.java
@@ -115,8 +115,8 @@ public class MapFragment extends BaseMwmFragment implements View.OnTouchListener
   @Override
   public void onPause()
   {
-    super.onPause();
     mMap.onPause(requireContext());
+    super.onPause();
   }
 
   @Override

--- a/geometry/area_on_earth.cpp
+++ b/geometry/area_on_earth.cpp
@@ -8,14 +8,16 @@
 #include <algorithm>
 #include <cmath>
 
+namespace ms
+{
 namespace
 {
-double const kEarthRadiusMetersSquared = ms::kEarthRadiusMeters * ms::kEarthRadiusMeters;
+double constexpr kEarthRadiusMetersSquared = kEarthRadiusMeters * kEarthRadiusMeters;
 
-m3::PointD GetPointOnSphere(ms::LatLon const & ll, double sphereRadius)
+m3::PointD GetPointOnSphere(LatLon const & ll, double sphereRadius)
 {
-  ASSERT(ms::LatLon::kMinLat <= ll.m_lat && ll.m_lat <= ms::LatLon::kMaxLat, (ll));
-  ASSERT(ms::LatLon::kMinLon <= ll.m_lon && ll.m_lon <= ms::LatLon::kMaxLon, (ll));
+  ASSERT(LatLon::kMinLat <= ll.m_lat && ll.m_lat <= LatLon::kMaxLat, (ll));
+  ASSERT(LatLon::kMinLon <= ll.m_lon && ll.m_lon <= LatLon::kMaxLon, (ll));
 
   double const latRad = base::DegToRad(ll.m_lat);
   double const lonRad = base::DegToRad(ll.m_lon);
@@ -28,8 +30,6 @@ m3::PointD GetPointOnSphere(ms::LatLon const & ll, double sphereRadius)
 }
 }  // namespace
 
-namespace ms
-{
 // Look to https://en.wikipedia.org/wiki/Solid_angle for more details.
 // Shortly:
 // It's possible to calculate area of triangle on sphere with it's solid angle.
@@ -68,8 +68,8 @@ double AreaOnEarth(LatLon const & ll1, LatLon const & ll2, LatLon const & ll3)
 // For circle: Ω = 2π(1 - cos(θ / 2)), where θ - is the cone apex angle.
 double CircleAreaOnEarth(double distanceOnSphereRadius)
 {
-  double const theta = 2.0 * distanceOnSphereRadius / ms::kEarthRadiusMeters;
-  static double const kConst = 2 * math::pi * kEarthRadiusMetersSquared;
+  double const theta = 2.0 * distanceOnSphereRadius / kEarthRadiusMeters;
+  double constexpr kConst = 2 * math::pi * kEarthRadiusMetersSquared;
   double const sinValue = sin(theta / 4);
   // 1 - cos(θ / 2) = 2sin^2(θ / 4)
   return kConst * 2 * sinValue * sinValue;

--- a/geometry/area_on_earth.hpp
+++ b/geometry/area_on_earth.hpp
@@ -1,7 +1,6 @@
 #pragma once
 
 #include "geometry/latlon.hpp"
-#include "geometry/point2d.hpp"
 
 namespace ms
 {

--- a/geometry/distance_on_sphere.hpp
+++ b/geometry/distance_on_sphere.hpp
@@ -1,14 +1,11 @@
 #pragma once
 
 #include "geometry/latlon.hpp"
-#include "geometry/point3d.hpp"
-
-#include "base/base.hpp"
 
 // namespace ms - "math on sphere", similar to namespace m2.
 namespace ms
 {
-double const kEarthRadiusMeters = 6378000.0;
+double constexpr kEarthRadiusMeters = 6378000.0;
 // Distance on unit sphere between (lat1, lon1) and (lat2, lon2).
 // lat1, lat2, lon1, lon2 - in degrees.
 double DistanceOnSphere(double lat1Deg, double lon1Deg, double lat2Deg, double lon2Deg);

--- a/map/framework.cpp
+++ b/map/framework.cpp
@@ -1128,6 +1128,8 @@ void Framework::MemoryWarning()
 
 void Framework::EnterBackground()
 {
+  m_usageStats.EnterBackground();
+
   if (m_drapeEngine)
     m_drapeEngine->OnEnterBackground();
 
@@ -1145,6 +1147,8 @@ void Framework::EnterBackground()
 
 void Framework::EnterForeground()
 {
+  m_usageStats.EnterForeground();
+
   if (m_drapeEngine)
     m_drapeEngine->OnEnterForeground();
 

--- a/map/framework.hpp
+++ b/map/framework.hpp
@@ -715,6 +715,7 @@ public:
 
 private:
   CachingAddressGetter m_addressGetter;
+  settings::UsageStats m_usageStats;
 
 public:
   power_management::PowerManager & GetPowerManager() { return m_powerManager; }

--- a/platform/platform.hpp
+++ b/platform/platform.hpp
@@ -235,6 +235,9 @@ public:
   static bool GetFileSizeByFullPath(std::string const & filePath, uint64_t & size);
   //@}
 
+  /// @return 0 in case of failure.
+  static time_t GetFileCreationTime(std::string const & path);
+
   /// Used to check available free storage space for downloading.
   enum TStorageStatus
   {

--- a/platform/platform_android.cpp
+++ b/platform/platform_android.cpp
@@ -232,3 +232,12 @@ void Platform::GetSystemFontNames(FilesList & res) const
     }
   }
 }
+
+// static
+time_t Platform::GetFileCreationTime(std::string const & path)
+{
+  struct stat st;
+  if (0 == stat(path.c_str(), &st))
+    return st.st_atim.tv_sec;
+  return 0;
+}

--- a/platform/platform_ios.mm
+++ b/platform/platform_ios.mm
@@ -249,6 +249,15 @@ void Platform::GetSystemFontNames(FilesList & res) const
 {
 }
 
+// static
+time_t Platform::GetFileCreationTime(std::string const & path)
+{
+  struct stat st;
+  if (0 == stat(path.c_str(), &st))
+    return st.st_birthtimespec.tv_sec;
+  return 0;
+}
+
 ////////////////////////////////////////////////////////////////////////
 extern Platform & GetPlatform()
 {

--- a/platform/platform_linux.cpp
+++ b/platform/platform_linux.cpp
@@ -16,6 +16,7 @@
 #include <optional>
 #include <string>
 
+#include <fcntl.h>
 #include <stdlib.h>
 #include <string.h>  // strrchr
 #include <unistd.h>  // access, readlink
@@ -128,7 +129,7 @@ Platform::Platform()
     // first it checks ${XDG_DATA_HOME}, if empty then it falls back to ${HOME}/.local/share
     m_writableDir = JoinPath(QStandardPaths::writableLocation(
         QStandardPaths::AppDataLocation).toStdString(), "OMaps");
-  
+
     if (!MkDirRecursively(m_writableDir))
       MYTHROW(FileSystemException, ("Can't create writable directory:", m_writableDir));
   }
@@ -262,4 +263,13 @@ void Platform::GetSystemFontNames(FilesList & res) const
       }
     }
   }
+}
+
+// static
+time_t Platform::GetFileCreationTime(std::string const & path)
+{
+  struct statx st;
+  if (0 == statx(AT_FDCWD, path.c_str(), 0, STATX_BTIME, &st))
+    return st.stx_btime.tv_sec;
+  return 0;
 }

--- a/platform/platform_mac.mm
+++ b/platform/platform_mac.mm
@@ -192,3 +192,12 @@ uint8_t Platform::GetBatteryLevel()
 void Platform::GetSystemFontNames(FilesList & res) const
 {
 }
+
+// static
+time_t Platform::GetFileCreationTime(std::string const & path)
+{
+  struct stat st;
+  if (0 == stat(path.c_str(), &st))
+    return st.st_birthtimespec.tv_sec;
+  return 0;
+}

--- a/platform/settings.hpp
+++ b/platform/settings.hpp
@@ -58,9 +58,24 @@ inline void Update(std::map<std::string, std::string> const & settings)
 inline void Delete(std::string const & key) { StringStorage::Instance().DeleteKeyAndValue(key); }
 inline void Clear() { StringStorage::Instance().Clear(); }
 
-/// Use this function for running some stuff once according to date.
-/// @param[in]  date  Current date in format yymmdd.
-bool IsFirstLaunchForDate(int date);
+class UsageStats
+{
+  static uint64_t TimeSinceEpoch();
+  uint64_t m_enterForegroundTime = 0;
+  uint64_t m_totalForegroundTime = 0;
+  uint64_t m_sessionsCount = 0;
+
+  std::string m_firstLaunch, m_lastBackground, m_totalForeground, m_sessions;
+
+  StringStorage & m_ss;
+
+public:
+  UsageStats();
+
+  void EnterForeground();
+  void EnterBackground();
+};
+
 } // namespace settings
 
 /*


### PR DESCRIPTION
Can't reproduce initial bug. Should test this change on Android 5-8.1 :

Crash log:
```
backtrace:
  #00  pc 0x000000000006ba20  /system/lib64/libc.so (tgkill+8)
  #01  pc 0x0000000000068ea4  /system/lib64/libc.so (pthread_kill+64)
  #02  pc 0x0000000000024350  /system/lib64/libc.so (raise+24)
  #03  pc 0x000000000001cd6c  /system/lib64/libc.so (abort+52)
  #04  pc 0x0000000000ba8298  /data/app/app.organicmaps-1/lib/arm64/liborganicmaps.so (dp::TextureManager::Init(ref_ptr<dp::GraphicsContext>, dp::TextureManager::Params const&)+5064)
  #05  pc 0x0000000000aa10c8  /data/app/app.organicmaps-1/lib/arm64/liborganicmaps.so (df::BackendRenderer::InitContextDependentResources()+532)
  #06  pc 0x0000000000aa0e5c  /data/app/app.organicmaps-1/lib/arm64/liborganicmaps.so (df::BackendRenderer::OnContextCreate()+276)
  #07  pc 0x0000000000aa2474  /data/app/app.organicmaps-1/lib/arm64/liborganicmaps.so (df::BaseRenderer::CheckRenderingEnabled()+596)
  #08  pc 0x0000000000aa1628  /data/app/app.organicmaps-1/lib/arm64/liborganicmaps.so (df::BackendRenderer::Routine::Do()+264)
  #09  pc 0x0000000000fc1f88  /data/app/app.organicmaps-1/lib/arm64/liborganicmaps.so (threads::(anonymous namespace)::RunRoutine(std::__ndk1::shared_ptr<threads::IRoutine>))
  #10  pc 0x0000000000fcaa84  /data/app/app.organicmaps-1/lib/arm64/liborganicmaps.so (void* std::__ndk1::__thread_proxy<std::__ndk1::tuple<std::__ndk1::unique_ptr<std::__ndk1::__thread_struct, std::__ndk1::default_delete<std::__ndk1::__thread_struct>>, void (*)(std::__ndk1::shared_ptr<threads::IRoutine>), std::__ndk1::shared_ptr<threads::IRoutine>>>(void*))
  #11  pc 0x00000000000686ac  /system/lib64/libc.so (__pthread_start(void*)+196)
  #12  pc 0x000000000001dfb0  /system/lib64/libc.so (__start_thread+16)
```

Appeared in this period: https://github.com/organicmaps/organicmaps/compare/2022.11.02-2-android...2022.11.24-3-android
Most likely here: https://github.com/organicmaps/organicmaps/pull/3820