### PR TITLE
[indexer] Fix copyshop type priority

### DIFF
--- a/indexer/feature_data.cpp
+++ b/indexer/feature_data.cpp
@@ -149,6 +149,7 @@ private:
         {"amenity", "shelter"},
         {"amenity", "toilets"},
         {"amenity", "drinking_water"},
+        {"shop", "copyshop"}, // often used as secondary tag for amenity=post_office
         {"leisure", "pitch"}, // Give priority to tag "sport"=*.
         {"public_transport", "platform"},
     };


### PR DESCRIPTION
fixes cases where `shop=copyshop` is effectively a secondary tag, eg. `shop=copyshop` + `amenity=post_office`

<img width="400" src="https://user-images.githubusercontent.com/26939824/208131074-e4fdbe0e-4e68-4379-acb8-1897428577e7.png">
(previously was `shop=copyshop` type)

partial fix for https://github.com/organicmaps/organicmaps/issues/4025