### PR TITLE
Fix performance-no-automatic-move clang-tidy warnings

### DIFF
--- a/base/mem_trie.hpp
+++ b/base/mem_trie.hpp
@@ -382,7 +382,7 @@ private:
     {
       ASSERT_LESS_OR_EQUAL(n, Size(), ());
 
-      Edge const prefix(m_label.rbegin(), m_label.rbegin() + n);
+      Edge prefix(m_label.rbegin(), m_label.rbegin() + n);
       m_label.erase(m_label.begin() + Size() - n, m_label.end());
       return prefix;
     }

--- a/generator/final_processor_utils.hpp
+++ b/generator/final_processor_utils.hpp
@@ -81,7 +81,7 @@ std::vector<std::vector<std::string>> AppendToMwmTmp(std::vector<feature::Featur
                        feature::AffiliationInterface const & affiliation,
                        std::string const & temporaryMwmPath, size_t threadsCount = 1)
 {
-  auto const affiliations = GetAffiliations(fbs, affiliation, threadsCount);
+  auto affiliations = GetAffiliations(fbs, affiliation, threadsCount);
   std::unordered_map<std::string, std::vector<size_t>> countryToFbsIndexes;
   for (size_t i = 0; i < fbs.size(); ++i)
   {

--- a/generator/generator_tests_support/test_with_custom_mwms.hpp
+++ b/generator/generator_tests_support/test_with_custom_mwms.hpp
@@ -48,7 +48,7 @@ public:
     auto result = m_dataSource.RegisterMap(file);
     CHECK_EQUAL(result.second, MwmSet::RegResult::Success, ());
 
-    auto const id = result.first;
+    auto id = result.first;
     auto const info = id.GetInfo();
     CHECK(info.get(), ());
     OnMwmBuilt(*info);

--- a/kml/serdes.cpp
+++ b/kml/serdes.cpp
@@ -217,7 +217,7 @@ void SaveColorToABGR(KmlWriter::WriterWrapper & writer, uint32_t rgba)
 std::string TimestampToString(Timestamp const & timestamp)
 {
   auto const ts = TimestampClock::to_time_t(timestamp);
-  std::string const strTimeStamp = base::TimestampToString(ts);
+  std::string strTimeStamp = base::TimestampToString(ts);
   if (strTimeStamp.size() != 20)
     MYTHROW(KmlWriter::WriteKmlException, ("We always generate fixed length UTC-format timestamp."));
   return strTimeStamp;

--- a/map/framework.cpp
+++ b/map/framework.cpp
@@ -139,7 +139,7 @@ bool ParseSetGpsTrackMinAccuracyCommand(string const & query)
 
 pair<MwmSet::MwmId, MwmSet::RegResult> Framework::RegisterMap(LocalCountryFile const & file)
 {
-  auto const res = m_featuresFetcher.RegisterMap(file);
+  auto res = m_featuresFetcher.RegisterMap(file);
   if (res.second == MwmSet::RegResult::Success)
   {
     auto const & id = res.first;

--- a/routing/routing_callbacks.hpp
+++ b/routing/routing_callbacks.hpp
@@ -108,7 +108,7 @@ inline std::string ToString(RouterResultCode code)
   case RouterResultCode::HasWarnings: return "HasWarnings";
   }
 
-  std::string const result = "Unknown RouterResultCode: " + std::to_string(static_cast<int>(code));
+  std::string result = "Unknown RouterResultCode: " + std::to_string(static_cast<int>(code));
   ASSERT(false, (result));
   return result;
 }

--- a/search/region_info_getter.cpp
+++ b/search/region_info_getter.cpp
@@ -100,11 +100,11 @@ string RegionInfoGetter::GetLocalizedCountryName(storage::CountryId const & id) 
   if (!m_nameGetter)
     return {};
 
-  auto const shortName = (*m_nameGetter)(id + " Short");
+  auto shortName = (*m_nameGetter)(id + " Short");
   if (!shortName.empty())
     return shortName;
 
-  auto const officialName = (*m_nameGetter)(id);
+  auto officialName = (*m_nameGetter)(id);
   if (!officialName.empty())
     return officialName;
 

--- a/search/reverse_geocoder.cpp
+++ b/search/reverse_geocoder.cpp
@@ -70,7 +70,7 @@ string Join(string const & s)
 template <typename... Args>
 string Join(string const & s, Args &&... args)
 {
-  auto const tail = Join(forward<Args>(args)...);
+  auto tail = Join(forward<Args>(args)...);
   if (s.empty())
     return tail;
   if (tail.empty())

--- a/storage/country_name_getter.cpp
+++ b/storage/country_name_getter.cpp
@@ -26,7 +26,7 @@ std::string CountryNameGetter::Get(std::string const & key) const
 
 std::string CountryNameGetter::operator()(CountryId const & countryId) const
 {
-  std::string const name = Get(countryId);
+  std::string name = Get(countryId);
   if (name.empty())
     return countryId;
 


### PR DESCRIPTION
See https://releases.llvm.org/12.0.0/tools/clang/tools/extra/docs/clang-tidy/checks/performance-no-automatic-move.html