### PR TITLE
[android] Refactoring of JNI class/method getters.

### DIFF
--- a/android/jni/CMakeLists.txt
+++ b/android/jni/CMakeLists.txt
@@ -6,6 +6,7 @@ set(SRC
   # JNI headers
   ../../private.h
   app/organicmaps/core/jni_helper.hpp
+  app/organicmaps/core/jni_java_methods.hpp
   app/organicmaps/core/logging.hpp
   app/organicmaps/core/ScopedEnv.hpp
   app/organicmaps/core/ScopedLocalRef.hpp
@@ -22,6 +23,7 @@ set(SRC
 
   # JNI sources
   app/organicmaps/core/jni_helper.cpp
+  app/organicmaps/core/jni_java_methods.cpp
   app/organicmaps/core/logging.cpp
   app/organicmaps/bookmarks/data/BookmarkManager.cpp
   app/organicmaps/DisplayedCategories.cpp

--- a/android/jni/app/organicmaps/core/jni_java_methods.cpp
+++ b/android/jni/app/organicmaps/core/jni_java_methods.cpp
@@ -1,0 +1,32 @@
+#include "jni_java_methods.hpp"
+#include "jni_helper.hpp"
+
+namespace jni
+{
+
+PairBuilder::PairBuilder(JNIEnv * env)
+{
+  m_class = jni::GetGlobalClassRef(env, "android/util/Pair");
+  m_ctor = jni::GetConstructorID(env, m_class, "(Ljava/lang/Object;Ljava/lang/Object;)V");
+  ASSERT(m_ctor, ());
+}
+
+jobject PairBuilder::Create(JNIEnv * env, jobject o1, jobject o2) const
+{
+  return env->NewObject(m_class, m_ctor, o1, o2);
+}
+
+ListBuilder::ListBuilder(JNIEnv * env)
+{
+  m_arrayClass = jni::GetGlobalClassRef(env, "java/util/ArrayList");
+  m_arrayCtor = jni::GetConstructorID(env, m_arrayClass, "(I)V");
+
+  jclass clazz = env->FindClass("java/util/List");
+  m_add = env->GetMethodID(clazz, "add", "(Ljava/lang/Object;)Z");
+}
+
+jobject ListBuilder::CreateArray(JNIEnv * env, size_t sz) const
+{
+  return env->NewObject(m_arrayClass, m_arrayCtor, sz);
+}
+} // namespace jni

--- a/android/jni/app/organicmaps/core/jni_java_methods.hpp
+++ b/android/jni/app/organicmaps/core/jni_java_methods.hpp
@@ -1,0 +1,37 @@
+#pragma once
+
+#include <jni.h>
+
+#define DECLARE_BUILDER_INSTANCE(BuilderType) static BuilderType const & Instance(JNIEnv * env) { \
+                                              static BuilderType const inst(env); return inst; }
+
+namespace jni
+{
+
+class PairBuilder
+{
+  jclass m_class;
+  jmethodID m_ctor;
+
+  explicit PairBuilder(JNIEnv * env);
+
+public:
+  DECLARE_BUILDER_INSTANCE(PairBuilder);
+  jobject Create(JNIEnv * env, jobject o1, jobject o2) const;
+};
+
+class ListBuilder
+{
+  jclass m_arrayClass;
+  jmethodID m_arrayCtor;
+
+public:
+  jmethodID m_add;
+
+  explicit ListBuilder(JNIEnv * env);
+  DECLARE_BUILDER_INSTANCE(ListBuilder);
+
+  jobject CreateArray(JNIEnv * env, size_t sz) const;
+};
+
+} // namespace jni

--- a/android/jni/app/organicmaps/util/FeatureIdBuilder.hpp
+++ b/android/jni/app/organicmaps/util/FeatureIdBuilder.hpp
@@ -7,12 +7,13 @@
 class FeatureIdBuilder
 {
 public:
-  FeatureIdBuilder(JNIEnv * env)
+  explicit FeatureIdBuilder(JNIEnv * env)
   {
-    m_class = jni::GetGlobalClassRef(env, "app/organicmaps/bookmarks/data/FeatureId");
-    m_countryName = env->GetFieldID(m_class, "mMwmName", "Ljava/lang/String;");
-    m_version = env->GetFieldID(m_class, "mMwmVersion", "J");
-    m_index = env->GetFieldID(m_class, "mFeatureIndex", "I");
+    jclass clazz = env->FindClass("app/organicmaps/bookmarks/data/FeatureId");
+    m_countryName = env->GetFieldID(clazz, "mMwmName", "Ljava/lang/String;");
+    ASSERT(m_countryName, ());
+    m_index = env->GetFieldID(clazz, "mFeatureIndex", "I");
+    ASSERT(m_index, ());
   }
 
   FeatureID Build(JNIEnv * env, jobject obj) const
@@ -20,17 +21,12 @@ public:
     jstring jcountryName = static_cast<jstring>(env->GetObjectField(obj, m_countryName));
     jint jindex = env->GetIntField(obj, m_index);
 
-    auto const countryName = jni::ToNativeString(env, jcountryName);
-    auto const index = static_cast<uint32_t>(jindex);
-
     auto const & ds = g_framework->GetDataSource();
-    auto const id = ds.GetMwmIdByCountryFile(platform::CountryFile(countryName));
-    return FeatureID(id, index);
+    auto const id = ds.GetMwmIdByCountryFile(platform::CountryFile(jni::ToNativeString(env, jcountryName)));
+    return FeatureID(id, static_cast<uint32_t>(jindex));
   }
 
 private:
-  jclass m_class;
   jfieldID m_countryName;
-  jfieldID m_version;
   jfieldID m_index;
 };

--- a/android/jni/app/organicmaps/util/StringUtils.cpp
+++ b/android/jni/app/organicmaps/util/StringUtils.cpp
@@ -1,5 +1,4 @@
 #include "app/organicmaps/core/jni_helper.hpp"
-#include "app/organicmaps/util/Distance.hpp"
 
 #include "indexer/search_string_utils.hpp"
 
@@ -13,11 +12,7 @@ namespace
 {
 jobject MakeJavaPair(JNIEnv * env, std::string const & first, std::string const & second)
 {
-  static jclass const pairClass = jni::GetGlobalClassRef(env, "android/util/Pair");
-  static jmethodID const pairCtor =
-      jni::GetConstructorID(env, pairClass, "(Ljava/lang/Object;Ljava/lang/Object;)V");
-  return env->NewObject(pairClass, pairCtor, jni::ToJavaString(env, first),
-                        jni::ToJavaString(env, second));
+  return jni::PairBuilder::Instance(env).Create(env, jni::ToJavaString(env, first), jni::ToJavaString(env, second));
 }
 }  // namespace
 

--- a/platform/country_file.cpp
+++ b/platform/country_file.cpp
@@ -1,7 +1,5 @@
 #include "platform/country_file.hpp"
 
-#include "platform/mwm_version.hpp"
-
 #include "base/assert.hpp"
 
 #include <sstream>
@@ -34,7 +32,7 @@ CountryFile::CountryFile(std::string name)
 }
 
 CountryFile::CountryFile(std::string name, MwmSize size, std::string sha1)
-: m_name(std::move(name)), m_mapSize(size), m_sha1(sha1)
+  : m_name(std::move(name)), m_mapSize(size), m_sha1(std::move(sha1))
 {
 }
 


### PR DESCRIPTION
Pros:
- clear code, avoid copy-paste in getting classes/methods
- function call has 1 static call/var initialization, instead of 3 or even 10+
- minimaze NewGlobalRef and global/static vars where possible

Want feedback here ..