### PR TITLE
[indexer] allow names to contain `/`,`\`, `[`, `]` & `°`

### DIFF
--- a/indexer/editable_map_object.cpp
+++ b/indexer/editable_map_object.cpp
@@ -745,7 +745,7 @@ bool EditableMapObject::ValidateName(string const & name)
 
   if (strings::IsASCIIString(name))
   {
-    static auto const s_nameRegex = regex(R"(^[ A-Za-z0-9.,?!@#$%&()\-\+:;"'`]+$)");
+    static auto const s_nameRegex = regex(R"(^[ A-Za-z0-9.,?!@°#$%&()\-\+\/\\\[\]:;"'`]+$)");
     return regex_match(name, s_nameRegex);
   }
 
@@ -762,7 +762,7 @@ bool EditableMapObject::ValidateName(string const & name)
     return false;
   }
 
-  std::u32string const excludedSymbols = U"^~§><{}[]*=_±\n\t\r\v\f|√•÷×¶°";
+  std::u32string const excludedSymbols = U"^~§><{}*=_±\n\t\r\v\f|√•÷×¶";
 
   for (auto const ch : u32name)
   {

--- a/indexer/indexer_tests/editable_map_object_test.cpp
+++ b/indexer/indexer_tests/editable_map_object_test.cpp
@@ -199,8 +199,8 @@ UNIT_TEST(EditableMapObject_ValidateEmail)
 UNIT_TEST(EditableMapObject_ValidateName)
 {
   vector<string> correctNames = {"abc", "абв", "ᆺᆯㅕ", "꫞ꪺꫀꪸ", "a b?c", "a!b.c", "a(b)c", "a,b.c",
-                                 "a$bc", "a%bc", "a#bc", "a№bc", "c&a"};
-  vector<string> incorrectNames = {"a^bc", "a~bc", "a§bc", "a>bc", "a<bc", "a{bc", "a[bc", "*",
+                                 "a$bc", "a%bc", "a#bc", "a№bc", "c&a", "a[bc"};
+  vector<string> incorrectNames = {"a^bc", "a~bc", "a§bc", "a>bc", "a<bc", "a{bc", "*",
                                    "a*bc", "a=bc", "a_bc", "a±bc", "a\nbc", "a\tbc", "a\rbc",
                                    "a\vbc", "a\fbc", "a|bc", "N√", "Hello World!\U0001F600",
                                    "Exit →", "∫0dx = C", "\U0001210A"};


### PR DESCRIPTION
fix for:
> I am trying to edit a place that is named "Lotto / Toto", but cannot. If I click anywhere to edit something it automatically jumps back to the naming field. I guess there is a problem with the "/", however, I did not put it in the name, it was already there. Any ideas? -Vinz (Matrix)

Although not a full fix, as pre-existing banned characters will still block name editing. Maybe that's how it should be though as users will have to remove incorrect characters


usage info for the characters in names in OSM:
 `/` has `60 272` uses in the UK alone
`°` has `32 030` uses worldwide
`[ ]` has `17 190` uses worldwide
