### PR TITLE
[base] Treat fast_double_parser as a system header

### DIFF
--- a/base/CMakeLists.txt
+++ b/base/CMakeLists.txt
@@ -2,7 +2,6 @@ project(base)
 
 set(SRC
   # Our code will be recompiled on modification of these headers.
-  ../3party/fast_double_parser/include/fast_double_parser.h
   ../std/boost_container_hash.hpp
   ../std/target_os.hpp
   ../std/windows.hpp
@@ -109,5 +108,7 @@ omim_add_library(${PROJECT_NAME} ${SRC})
 set(THREADS_PREFER_PTHREAD_FLAG ON)
 find_package(Threads REQUIRED)
 target_link_libraries(${PROJECT_NAME} INTERFACE Threads::Threads)
+
+target_include_directories(${PROJECT_NAME} PRIVATE "${OMIM_ROOT}/3party/fast_double_parser/include")
 
 omim_add_test_subdirectory(base_tests)

--- a/base/string_utils.cpp
+++ b/base/string_utils.cpp
@@ -2,8 +2,6 @@
 
 #include "base/assert.hpp"
 
-#include "3party/fast_double_parser/include/fast_double_parser.h"
-
 #include <algorithm>
 #include <cmath>
 #include <iomanip>
@@ -11,6 +9,7 @@
 
 #include <boost/algorithm/string/trim.hpp>
 #include <boost/math/special_functions/fpclassify.hpp>
+#include <fast_double_parser.h>
 
 namespace strings
 {

--- a/xcode/base/base.xcodeproj/project.pbxproj
+++ b/xcode/base/base.xcodeproj/project.pbxproj
@@ -815,6 +815,10 @@
 		675341831A3F57BF00A0A8C3 /* Debug */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
+				HEADER_SEARCH_PATHS = (
+					"$(inherited)",
+					"$(OMIM_ROOT)/3party/fast_double_parser/include",
+				);
 				EXECUTABLE_PREFIX = lib;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 			};
@@ -823,6 +827,10 @@
 		675341841A3F57BF00A0A8C3 /* Release */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
+				HEADER_SEARCH_PATHS = (
+					"$(inherited)",
+					"$(OMIM_ROOT)/3party/fast_double_parser/include",
+				);
 				EXECUTABLE_PREFIX = lib;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 			};


### PR DESCRIPTION
* For compiler diagnostics
* For dependency management

Signed-off-by: Ferenc Géczi <ferenc.gm@gmail.com>