### PR TITLE
[desktop] Allow importing of upper-case .KML and .KMZ files on case-sensitive Linux

### DIFF
--- a/qt/bookmark_dialog.cpp
+++ b/qt/bookmark_dialog.cpp
@@ -132,7 +132,7 @@ void BookmarkDialog::OnCloseClick()
 void BookmarkDialog::OnImportClick()
 {
   auto const files = QFileDialog::getOpenFileNames(this /* parent */, tr("Open KML/KMZ..."),
-                                                   QString() /* dir */, "KML/KMZ files (*.kml *.kmz)");
+                                                   QString() /* dir */, "KML/KMZ files (*.kml *.KML *.kmz *.KMZ)");
 
   for (auto const & name : files)
   {


### PR DESCRIPTION
Fixes #3878