### PR TITLE
[linux] Check connection to hostname

### DIFF
--- a/platform/platform_linux.cpp
+++ b/platform/platform_linux.cpp
@@ -1,3 +1,4 @@
+#include "private.h"
 #include "platform/platform.hpp"
 
 #include "platform/socket.hpp"
@@ -33,9 +34,6 @@
 
 namespace
 {
-// Web service ip to check internet connection. Now it's a GitHub.com IP.
-char constexpr kSomeWorkingWebServer[] = "140.82.121.4";
-
 // Returns directory where binary resides, including slash at the end.
 std::optional<std::string> GetExecutableDir()
 {
@@ -171,7 +169,7 @@ std::string Platform::DeviceModel() const
 
 Platform::EConnectionType Platform::ConnectionStatus()
 {
-  int socketFd = socket(AF_INET, SOCK_STREAM, 0);
+  int socketFd = socket(AF_INET, SOCK_STREAM, IPPROTO_TCP);
   SCOPE_GUARD(closeSocket, std::bind(&close, socketFd));
   if (socketFd < 0)
     return EConnectionType::CONNECTION_NONE;
@@ -180,7 +178,7 @@ Platform::EConnectionType Platform::ConnectionStatus()
   memset(&addr, 0, sizeof(addr));
   addr.sin_family = AF_INET;
   addr.sin_port = htons(80);
-  inet_pton(AF_INET, kSomeWorkingWebServer, &addr.sin_addr);
+  inet_pton(AF_INET, DEFAULT_CONNECTION_CHECK_IP, &addr.sin_addr);
 
   if (connect(socketFd, reinterpret_cast<struct sockaddr *>(&addr), sizeof(addr)) < 0)
     return EConnectionType::CONNECTION_NONE;

--- a/private_default.h
+++ b/private_default.h
@@ -6,6 +6,7 @@
 #define METASERVER_URL "https://meta.omaps.app/maps"
 #define DIFF_LIST_URL ""
 #define DEFAULT_URLS_JSON "[ \"https://cdn.organicmaps.app/\" ]"
+#define DEFAULT_CONNECTION_CHECK_IP "140.82.121.4"  // For now the IP of cdn.organicmaps.app
 #define TRAFFIC_DATA_BASE_URL ""
 #define USER_BINDING_PKCS12 ""
 #define USER_BINDING_PKCS12_PASSWORD ""


### PR DESCRIPTION
* Considering, that organicmaps is advertised as:

  "We protect your privacy from Big Tech's prying eyes"

  It is perhaps a benefit if the user's IP address is not sent to Microsoft every time a status check is needed. Currently Microsoft is among the top five [Big Tech](https://en.wikipedia.org/wiki/Big_Tech) companies.

* With this change the code checks whether the host name resolution also works because by default the map downloading relies on host names instead of IP addresses and therefore does not work if name resolution doesn't work.

* Uses a meaningful target for checking the connectivity towards. For downloading maps, the connectivity has to work either towards the metaserver. (Or as a fallback towards a default server.)

* Specifies the protocol of the SOCK_STREAM more than before. Previously the requested socket protocol was "any" indicated by 0. Which theoretically includes more than just IPPROTO_TCP. For example IPPROTO_STCP as well, although non-TCP scenarios are rare.

Signed-off-by: Ferenc Géczi <ferenc.gm@gmail.com>