### PR TITLE
fix reported TTS language for Slovenčina

### DIFF
--- a/android/res/values/strings-tts.xml
+++ b/android/res/values/strings-tts.xml
@@ -35,7 +35,7 @@
     <item>pl</item>
     <item>pt</item>
     <item>ro</item>
-    <item>sv</item>
+    <item>sk</item>
     <item>fi</item>
     <item>sv</item>
     <item>vi</item>


### PR DESCRIPTION
fixes

        @endim8 sv is Swedish, but below it was Slovenčina

_Originally posted by @biodranik in https://github.com/organicmaps/organicmaps/pull/4201#discussion_r1083258237_