### PR TITLE
Github issues templates

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -1,16 +1,16 @@
 ---
-name: Bug report
-about: Create a report to help us improve OrganicMaps
+name: Bug Report
+about: Describe your issue in details to help us improve Organic Maps
 title: ''
 labels: ''
 assignees: ''
 
 ---
 
-**Describe the bug**
-A clear and concise description of what the bug is.
+**Describe the issue**
+Please write here a clear and concise description of what the bug/issue is about.
 
-**Steps To Reproduce**
+**Steps to reproduce**
 1. Go to '...'
 2. Click on '....'
 3. Scroll down to '....'
@@ -22,10 +22,10 @@ A clear and concise description of what you expected to happen.
 **Screenshots**
 If applicable, add screenshots or screen recordings to help explain your problem.
 
-**Application:**
- - OS: [iOS, Android, Linux, MacOS, etc]
- - OrganicMaps version: [you can find it clicking "?" button]
+**System information:**
+ - Operating system and its version: [iOS 12, Android 10, Ubuntu 22, MacOS Big Sur, etc.]
+ - Organic Maps version: [you can find it by clicking the "?" button]
  - Device Model: [e.g. iPhone6, Samsung S22]
 
 **Additional context**
-Add any other context about the problem here.
+Please add any other context and important details/notes/comments about the problem here.

--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -1,0 +1,31 @@
+---
+name: Bug report
+about: Create a report to help us improve OrganicMaps
+title: ''
+labels: ''
+assignees: ''
+
+---
+
+**Describe the bug**
+A clear and concise description of what the bug is.
+
+**Steps To Reproduce**
+1. Go to '...'
+2. Click on '....'
+3. Scroll down to '....'
+4. See error
+
+**Expected behavior**
+A clear and concise description of what you expected to happen.
+
+**Screenshots**
+If applicable, add screenshots or screen recordings to help explain your problem.
+
+**Application:**
+ - OS: [iOS, Android, Linux, MacOS, etc]
+ - OrganicMaps version: [you can find it clicking "?" button]
+ - Device Model: [e.g. iPhone6, Samsung S22]
+
+**Additional context**
+Add any other context about the problem here.

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,8 @@
+blank_issues_enabled: true
+contact_links:
+  - name: Discussions
+    url: https://github.com/organicmaps/organicmaps/discussions
+    about: For discussions about the usage of OrganicMaps, asking questions or talking about ideas which are not yet actionable.
+  - name: Translations
+    url: https://github.com/organicmaps/organicmaps/blob/master/docs/TRANSLATIONS.md
+    about: For contributing translations of OrganicMaps

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -2,7 +2,10 @@ blank_issues_enabled: true
 contact_links:
   - name: Discussions
     url: https://github.com/organicmaps/organicmaps/discussions
-    about: For discussions about the usage of OrganicMaps, asking questions or talking about ideas which are not yet actionable.
+    about: Discuss the usage of OrganicMaps, ask questions, or talk about ideas that are not yet actionable.
   - name: Translations
     url: https://github.com/organicmaps/organicmaps/blob/master/docs/TRANSLATIONS.md
-    about: For contributing translations of OrganicMaps
+    about: Translate Organic Maps into your language
+  - name: News
+    url: https://organicmaps.app/news/
+    about: Check the latest project news

--- a/.github/ISSUE_TEMPLATE/feature_request.md
+++ b/.github/ISSUE_TEMPLATE/feature_request.md
@@ -1,0 +1,20 @@
+---
+name: Feature request
+about: Suggest an idea for OrganicMaps
+title: ''
+labels: ''
+assignees: ''
+
+---
+
+**Is your feature request related to a problem? Please describe.**
+A clear and concise description of what the problem is. Ex. I'm always frustrated when [...]
+
+**Describe the solution you'd like**
+A clear and concise description of what you want to happen.
+
+**Describe alternatives you've considered**
+A clear and concise description of any alternative solutions or features you've considered.
+
+**Additional context**
+Add any other context or screenshots about the feature request here.

--- a/.github/ISSUE_TEMPLATE/feature_request.md
+++ b/.github/ISSUE_TEMPLATE/feature_request.md
@@ -2,19 +2,21 @@
 name: Feature request
 about: Suggest an idea for OrganicMaps
 title: ''
-labels: ''
+labels: [Enhancement]
 assignees: ''
 
 ---
 
 **Is your feature request related to a problem? Please describe.**
-A clear and concise description of what the problem is. Ex. I'm always frustrated when [...]
+A clear and concise description of what the problem is. For example:
+I'm always frustrated when [...]
 
-**Describe the solution you'd like**
-A clear and concise description of what you want to happen.
+**Describe the solution you would like**
+A clear and concise description of what you want to see in Organic Maps.
 
-**Describe alternatives you've considered**
-A clear and concise description of any alternative solutions or features you've considered.
+**Describe alternatives you have considered**
+- How do you solve this issue now with Organic Maps or other apps?
+- Attach any examples, screenshots, or screen recordings from other apps that help us to better understand the idea.
 
 **Additional context**
 Add any other context or screenshots about the feature request here.


### PR DESCRIPTION
Look like PR #2484 has stuck.
I created simple issues templates: "Bug report" and "Feature request".
Got to my fork https://github.com/strump/organicmaps/ and try to create an issue:

<img width="300" alt="Screenshot 2023-02-02 at 10 09 21" src="https://user-images.githubusercontent.com/720808/216267586-502f22df-2d02-4548-8a04-14e127e037bb.png">


<img width="300" alt="Screenshot 2023-02-01 at 18 13 15" src="https://user-images.githubusercontent.com/720808/216100005-c37f4358-38c7-4d4e-b41e-8235a31bd80f.png"> <img width="300" alt="Screenshot 2023-02-01 at 18 13 29" src="https://user-images.githubusercontent.com/720808/216100046-b7e93b10-3d51-422c-95cc-cca0aea6eb1a.png">

Closes #2484
