### PR TITLE
[qt] Fix deprecated functions

### DIFF
--- a/qt/qt_common/map_widget.cpp
+++ b/qt/qt_common/map_widget.cpp
@@ -449,7 +449,7 @@ void MapWidget::wheelEvent(QWheelEvent * e)
     return;
 
   QOpenGLWidget::wheelEvent(e);
-  m_framework.Scale(exp(e->delta() / 360.0), m2::PointD(L2D(e->x()), L2D(e->y())), false);
+  m_framework.Scale(exp(e->angleDelta().y() / 3.0 / 360.0), m2::PointD(L2D(e->position().x()), L2D(e->position().y())), false);
 }
 
 search::ReverseGeocoder::Address GetFeatureAddressInfo(Framework const & framework,


### PR DESCRIPTION
Fixes the following:
 * warning: ‘int QWheelEvent::delta() const’ is deprecated
 * warning: ‘int QWheelEvent::x() const’ is deprecated
 * warning: ‘int QWheelEvent::y() const’ is deprecated

Signed-off-by: Ferenc Géczi <ferenc.gm@gmail.com>