### PR TITLE
Revert "[drape] SetCenterEvent animation fix"

### DIFF
--- a/drape_frontend/drape_engine.cpp
+++ b/drape_frontend/drape_engine.cpp
@@ -204,6 +204,14 @@ void DrapeEngine::Rotate(double azimuth, bool isAnim)
   AddUserEvent(make_unique_dp<RotateEvent>(azimuth, isAnim, nullptr /* parallelAnimCreator */));
 }
 
+void DrapeEngine::ScaleAndSetCenter(m2::PointD const & centerPt, double scaleFactor, bool isAnim,
+                                    bool trackVisibleViewport)
+{
+  PostUserEvent(make_unique_dp<SetCenterEvent>(scaleFactor, centerPt, isAnim,
+                                               trackVisibleViewport,
+                                               nullptr /* parallelAnimCreator */));
+}
+
 void DrapeEngine::SetModelViewCenter(m2::PointD const & centerPt, int zoom, bool isAnim,
                                      bool trackVisibleViewport)
 {

--- a/drape_frontend/drape_engine.hpp
+++ b/drape_frontend/drape_engine.hpp
@@ -131,6 +131,9 @@ public:
   void Move(double factorX, double factorY, bool isAnim);
   void Rotate(double azimuth, bool isAnim);
 
+  void ScaleAndSetCenter(m2::PointD const & centerPt, double scaleFactor, bool isAnim,
+                         bool trackVisibleViewport);
+
   // If zoom == -1 then current zoom will not be changed.
   void SetModelViewCenter(m2::PointD const & centerPt, int zoom, bool isAnim,
                           bool trackVisibleViewport);

--- a/drape_frontend/screen_animations.cpp
+++ b/drape_frontend/screen_animations.cpp
@@ -92,7 +92,7 @@ drape_ptr<SequenceAnimation> GetPrettyFollowAnimation(ScreenBase const & startSc
 
     auto moveAnim = make_unique_dp<MapLinearAnimation>();
     moveAnim->SetMove(startScreen.GetOrg(), tmp.GetOrg(), viewportRect, tmp.GetScale());
-    moveAnim->SetMaxDuration(kMaxAnimationTimeSec * 0.5);
+    moveAnim->SetMaxDuration(kMaxAnimationTimeSec);
     sequenceAnim->AddAnimation(move(moveAnim));
   }
 
@@ -138,7 +138,7 @@ drape_ptr<MapFollowAnimation> GetFollowAnimation(ScreenBase const & startScreen,
                                                  bool isAutoZoom)
 {
   auto anim = make_unique_dp<MapFollowAnimation>(startScreen, userPos, endPixelPos, targetScale, targetAngle, isAutoZoom);
-  anim->SetMaxDuration(kMaxAnimationTimeSec * 0.5);
+  anim->SetMaxDuration(kMaxAnimationTimeSec);
 
   return anim;
 }

--- a/drape_frontend/user_event_stream.hpp
+++ b/drape_frontend/user_event_stream.hpp
@@ -164,15 +164,28 @@ public:
                  TAnimationCreator const & parallelAnimCreator)
     : m_center(center)
     , m_zoom(zoom)
+    , m_scaleFactor(0.0)
     , m_isAnim(isAnim)
     , m_trackVisibleViewport(trackVisibleViewport)
     , m_parallelAnimCreator(parallelAnimCreator)
+  {}
+
+  SetCenterEvent(double scaleFactor, m2::PointD const & center,
+                 bool isAnim, bool trackVisibleViewport,
+                 TAnimationCreator const & parallelAnimCreator)
+      : m_center(center)
+      , m_zoom(-1)
+      , m_scaleFactor(scaleFactor)
+      , m_isAnim(isAnim)
+      , m_trackVisibleViewport(trackVisibleViewport)
+      , m_parallelAnimCreator(parallelAnimCreator)
   {}
 
   EventType GetType() const override { return UserEvent::EventType::SetCenter; }
 
   m2::PointD const & GetCenter() const { return m_center; }
   int GetZoom() const { return m_zoom; }
+  double GetScaleFactor() const { return m_scaleFactor; }
   bool IsAnim() const { return m_isAnim; }
   bool TrackVisibleViewport() const { return m_trackVisibleViewport; }
   TAnimationCreator const & GetParallelAnimCreator() const { return m_parallelAnimCreator; }
@@ -180,6 +193,8 @@ public:
 private:
   m2::PointD m_center; // center point in mercator
   int m_zoom; // if zoom == -1, then zoom level will not change
+  double m_scaleFactor; // this parameter is used when zoom == -1,
+                        // if scaleFactor <= 0.0, then scale will not change
   bool m_isAnim;
   bool m_trackVisibleViewport;
   TAnimationCreator m_parallelAnimCreator;


### PR DESCRIPTION
There is a bug with animation when a search result is selected. A better fix is needed.

Also one beta-tester has reported this:

I'm experiencing some weird behaviour where it zooms to the poi I was looking for but then zooms away from it unendlessly. Here are the steps to reproduce:
- start at poi x,
- click location button,
- search for same poi x again,
- click on said poi x from search results.

This reverts commit 19dc496a3571ca424cfc5c7057a92018914be6d3.