### PR TITLE
[drape] Remove hardcoded minVisibleScale = 10 from road shields

### DIFF
--- a/drape_frontend/apply_feature_functors.cpp
+++ b/drape_frontend/apply_feature_functors.cpp
@@ -63,7 +63,6 @@ df::ColorConstant const kRoadShieldOrangeBackgroundColor = "RoadShieldOrangeBack
 
 uint32_t const kPathTextBaseTextIndex = 128;
 uint32_t const kShieldBaseTextIndex = 0;
-int const kShieldMinVisibleZoomLevel = 10;
 
 #ifdef LINES_GENERATION_CALC_FILTERED_POINTS
 class LinesStat
@@ -960,7 +959,7 @@ void ApplyLineFeatureAdditional::GetRoadShieldsViewParams(ref_ptr<dp::TextureMan
   textParams.m_depthTestEnabled = false;
   textParams.m_depth = m_depth;
   textParams.m_depthLayer = DepthLayer::OverlayLayer;
-  textParams.m_minVisibleScale = kShieldMinVisibleZoomLevel;
+  textParams.m_minVisibleScale = m_minVisibleScale;
   textParams.m_rank = m_rank;
   textParams.m_featureId = m_id;
   textParams.m_titleDecl.m_anchor = anchor;
@@ -991,7 +990,7 @@ void ApplyLineFeatureAdditional::GetRoadShieldsViewParams(ref_ptr<dp::TextureMan
     symbolParams.m_depthTestEnabled = true;
     symbolParams.m_depth = m_depth;
     symbolParams.m_depthLayer = DepthLayer::OverlayLayer;
-    symbolParams.m_minVisibleScale = kShieldMinVisibleZoomLevel;
+    symbolParams.m_minVisibleScale = m_minVisibleScale;
     symbolParams.m_rank = m_rank;
     symbolParams.m_anchor = anchor;
     symbolParams.m_offset = shieldOffset;
@@ -1019,7 +1018,7 @@ void ApplyLineFeatureAdditional::GetRoadShieldsViewParams(ref_ptr<dp::TextureMan
     poiParams.m_depth = m_depth;
     poiParams.m_depthTestEnabled = false;
     poiParams.m_depthLayer = DepthLayer::OverlayLayer;
-    poiParams.m_minVisibleScale = kShieldMinVisibleZoomLevel;
+    poiParams.m_minVisibleScale = m_minVisibleScale;
     poiParams.m_rank = m_rank;
     poiParams.m_symbolName = symbolName;
     poiParams.m_extendingSize = 0;

--- a/drape_frontend/rule_drawer.cpp
+++ b/drape_frontend/rule_drawer.cpp
@@ -363,6 +363,7 @@ void RuleDrawer::ProcessLineStyle(FeatureType & f, Stylist const & s,
 
   if (needAdditional && !clippedSplines.empty())
   {
+    minVisibleScale = feature::GetMinDrawableScale(f);
     ApplyLineFeatureAdditional applyAdditional(m_context->GetTileKey(), insertShape, f.GetID(),
                                                m_currentScaleGtoP, minVisibleScale, f.GetRank(),
                                                s.GetCaptionDescription(), clippedSplines);


### PR DESCRIPTION
This PR removes the hardcoded `minVisibleScale = 10` for all road shields.
I didn't see any change for higher zooms (z13-) - probably because shields' priorities are very high there anyway (they use minVisibleScale from the road which is lower than that of shields).
However on z10-z12 this change makes motorway, trunk & primary shields' priority somewhat higher (before the PR they were fixed to z10 bucket, now they're in z7 & z8 buckets).
Summary of priority change (shows drawing elements which became lower priority, than shields):

```
OVRL/z10/16476	 symbol	 landuse-military-danger_area	 	 z[16-19]
OVRL/z10/16590	 symbol	 natural-volcano	 	 z[10-19]
OVRL/z10/16666	 symbol	 boundary-national_park	 	 z[11-19]
OVRL/z10/16666	 symbol	 leisure-nature_reserve	 	 z[11-19]
OVRL/z9/15000	 caption	 place-island	 	 z[9-19]
OVRL/z8/15523	 caption	 place-town	 if[population<20000]	 z[12-19]
OVRL/z8/15523	 caption	 place-town	 if[population>=0]	 z[10-11]
OVRL/z8/15523	 caption	 place-town	 if[population>=20000]	 z[9]
OVRL/z8/15523	 caption	 place-town	 if[population>=40000]	 z[8]
OVRL/z8/16428	 shield	 highway-primary	 	 z[10-19]
OVRL/z8/16428	 shield	 highway-primary-bridge	 	 z[10-19]
OVRL/z8/16428	 shield	 highway-primary-tunnel	 	 z[10-19]
OVRL/z7/3100	 symbol	 aeroway-aerodrome-international	 	 z[11-13]
OVRL/z7/10000	 symbol	 aeroway-aerodrome-international	 	 z[7-9]
OVRL/z7/15009	 caption	 aeroway-aerodrome-international	 	 z[10-19]
OVRL/z7/16009	 symbol	 aeroway-aerodrome-international	 	 z[10, 14-19]
OVRL/z7/16447	 shield	 highway-motorway	 	 z[10-19]
OVRL/z7/16447	 shield	 highway-motorway-bridge	 	 z[10-19]
OVRL/z7/16447	 shield	 highway-motorway-tunnel	 	 z[10-19]
OVRL/z7/16447	 shield	 highway-trunk	 	 z[10-19]
OVRL/z7/16447	 shield	 highway-trunk-bridge	 	 z[10-19]
OVRL/z7/16447	 shield	 highway-trunk-tunnel	 	 z[10-19]
```
E.g. motorway/trunk shields will displace international airport and place-town captions now.
(should be easy to make airports prioritized over motorway shields as they're in the same z7).

![road-shields_z10-11](https://user-images.githubusercontent.com/18434508/218124624-af237a15-dcc3-4cea-affa-08f6c685df73.png)
