### PR TITLE
[android] Unify accent color across the app

### DIFF
--- a/android/res/values/colors.xml
+++ b/android/res/values/colors.xml
@@ -8,7 +8,7 @@
   <color name="text_light_subtitle">@color/white_secondary</color>
   <color name="text_light_hint">@color/white_lightest</color>
 
-  <color name="base_accent">#FF249CF2</color>
+  <color name="base_accent">#FF006C35</color>
   <color name="base_accent_night">#FF4BB9E6</color>
   <color name="base_accent_pressed">#FF1C85D6</color>
   <color name="base_accent_pressed_night">#FF3C9BBE</color>

--- a/android/res/values/styles.xml
+++ b/android/res/values/styles.xml
@@ -53,6 +53,7 @@
 
   <style name="MwmWidget.Button.Accent">
     <item name="android:background">?accentButtonBackground</item>
+    <item name="android:textColor">?accentButtonTextColor</item>
   </style>
 
   <style name="MwmWidget.Button.StackedButtonsDialog">


### PR DESCRIPTION
This is a follow-up for bfe401a602f. Original MAPS.ME blue (#249CF2) color left untouched just by a mistake. One accent color (#006c35) as for the logo is more than enough for this design system. The app looks less old-fashioned and more consistent, solid and "organic". The night theme is not affected and a variation of blue is used as green counterpart.

<table>
<tr>
<th>After</th>
<th>Before</th>
</tr>
<tr>
<td><img src="https://user-images.githubusercontent.com/1799054/218269235-0c58b4bf-2860-4810-913b-61e778630056.png" width="300px"></td>
<td><img src="https://user-images.githubusercontent.com/1799054/218269364-391b9a3b-c215-4cef-b302-41012cd7a431.png" width="300px"></td>
</tr>
<tr>
<td><img src="https://user-images.githubusercontent.com/1799054/218269243-4e0bd513-4695-4bd1-be87-4c2e1bc92f7f.png" width="300px"></td>
<td><img src="https://user-images.githubusercontent.com/1799054/218269241-1ea639f6-6011-4b4d-a297-624a9b15e6c0.png" width="300px"></td>
</tr>
<tr>
<td><img src="https://user-images.githubusercontent.com/1799054/218269244-b3784f88-5a1e-4cff-9d32-ab5d63230cba.png" width="300px"></td>
<td><img src="https://user-images.githubusercontent.com/1799054/218269245-b92e4ef8-f682-496b-b91e-317c14e039ba.png" width="300px"></td>
</tr>
<table>