### PR TITLE
[android] Fix wrong string used

### DIFF
--- a/android/src/app/organicmaps/editor/OsmLoginFragment.java
+++ b/android/src/app/organicmaps/editor/OsmLoginFragment.java
@@ -45,7 +45,7 @@ public class OsmLoginFragment extends BaseMwmToolbarFragment
     getToolbarController().setTitle(R.string.login);
     mLoginInput = view.findViewById(R.id.osm_username);
     mPasswordInput = view.findViewById(R.id.osm_password);
-    mLoginButton = view.findViewById(R.id.login);
+    mLoginButton = view.findViewById(R.id.login_osm);
     mLoginButton.setOnClickListener((v) -> login());
     mLostPasswordButton = view.findViewById(R.id.lost_password);
     mLostPasswordButton.setOnClickListener((v) -> recoverPassword());
@@ -90,7 +90,7 @@ public class OsmLoginFragment extends BaseMwmToolbarFragment
 
     enableInput(true);
     UiUtils.hide(mProgress);
-    mLoginButton.setText(R.string.login);
+    mLoginButton.setText(R.string.login_osm);
     if (auth == null)
       onAuthFail();
     else


### PR DESCRIPTION
During my tests, i have detect a bug
In OsmLoginFragment ->LoginButton use [string login_osm](https://github.com/organicmaps/organicmaps/blob/143086b451405c0824829c151ba6393a8363e0a2/android/res/layout/fragment_osm_login.xml#L93), like asked here https://github.com/organicmaps/organicmaps/pull/2909#issuecomment-1179559429
If i try to log in without fill connection informations, after skip pop-up, `Login to OpenStreetMap` is replaced by `Log In` in LoginButton
Signed-off-by: Jean-Baptiste CHARRON <jeanbaptiste.charron@outlook.fr>