### PR TITLE
[drape] Remove obsolete apply_for_type icon drule attribute

### DIFF
--- a/drape_frontend/apply_feature_functors.cpp
+++ b/drape_frontend/apply_feature_functors.cpp
@@ -464,9 +464,8 @@ void ApplyPointFeature::ProcessPointRule(Stylist::TRuleWrapper const & rule)
     m_symbolRule = symRule;
   }
 
-  bool const isNode = (rule.m_rule->GetType() & drule::node) != 0;
   CaptionDefProto const * capRule = rule.m_rule->GetCaption(0);
-  if (capRule && isNode)
+  if (capRule)
   {
     TextViewParams params;
     params.m_tileCenter = m_tileRect.Center();
@@ -923,10 +922,6 @@ void ApplyLineFeatureAdditional::ProcessLineRule(Stylist::TRuleWrapper const & r
   ShieldRuleProto const * pShieldRule = rule.m_rule->GetShield();
   if (pShieldRule != nullptr)
     m_shieldRule = pShieldRule;
-
-  bool const isWay = (rule.m_rule->GetType() & drule::way) != 0;
-  if (!isWay)
-    return;
 
   CaptionDefProto const * pCaptionRule = rule.m_rule->GetCaption(0);
   if (pCaptionRule != nullptr && pCaptionRule->height() > 2 && !m_captions.GetMainText().empty())

--- a/indexer/drawing_rule_def.hpp
+++ b/indexer/drawing_rule_def.hpp
@@ -28,9 +28,6 @@ namespace drule
   /// drawing type of rule - can be one of ...
   enum rule_type_t { line, area, symbol, caption, circle, pathtext, waymarker, shield, count_of_rules };
 
-  /// geo type of rule - can be one combined of ...
-  enum rule_geo_t { node = 1, way = 2 };
-
   /// text field type - can be one of ...
   enum text_type_t { text_type_name = 0, text_type_housename, text_type_housenumber };
 

--- a/indexer/drawing_rules.cpp
+++ b/indexer/drawing_rules.cpp
@@ -35,9 +35,6 @@ namespace
   }
 } // namespace
 
-BaseRule::BaseRule() : m_type(node | way)
-{}
-
 void BaseRule::CheckCacheSize(size_t s)
 {
   m_id1.resize(s);
@@ -241,10 +238,7 @@ namespace
     {
       SymbolRuleProto m_symbol;
     public:
-      explicit Symbol(SymbolRuleProto const & r) : m_symbol(r)
-      {
-        SetType(r.apply_for_type());
-      }
+      explicit Symbol(SymbolRuleProto const & r) : m_symbol(r) {}
 
       virtual SymbolRuleProto const * GetSymbol() const { return &m_symbol; }
     };

--- a/indexer/drawing_rules.hpp
+++ b/indexer/drawing_rules.hpp
@@ -31,14 +31,13 @@ namespace drule
   class BaseRule
   {
     mutable buffer_vector<uint32_t, 4> m_id1;
-    char m_type;      // obsolete for new styles, can be removed
 
     std::unique_ptr<ISelector> m_selector;
 
   public:
     static uint32_t const empty_id = 0xFFFFFFFF;
 
-    BaseRule();
+    BaseRule() = default;
     virtual ~BaseRule() = default;
 
     void CheckCacheSize(size_t s);
@@ -48,9 +47,6 @@ namespace drule
 
     void MakeEmptyID(size_t threadSlot);
     void MakeEmptyID();
-
-    void SetType(char type) { m_type = type; }
-    inline char GetType() const { return m_type; }
 
     virtual LineDefProto const * GetLine() const;
     virtual AreaRuleProto const * GetArea() const;


### PR DESCRIPTION
This code doesn't change anything.

It was commented as `obsolete for new styles, can be removed` in https://github.com/mapsme/omim/commit/6d4e795f01a7235be2df68babcf968f72dd95694, so probably haven't been working since then.

As far as I understand the point of this "apply_for_type: 1" rule was to disable drawing an icon for an area POI, while drawing it for point POIs of this type only.
E.g. a point `amenity-hospital` with an icon, but a filled area `amenity-hospital` without an icon.

So looks like its not needed really.

If we can remove it here then we'll be able to drop it in kothic and in protobuf format also. It looks like its the only thing in our style files that requires prepending node/area/line to style definitions still, see https://github.com/organicmaps/organicmaps/issues/4137#issuecomment-1403638671