### PR TITLE
[android] Allow multiple lines in map name field of search list

### DIFF
--- a/android/res/layout/downloader_item.xml
+++ b/android/res/layout/downloader_item.xml
@@ -59,7 +59,6 @@
       android:layout_width="match_parent"
       android:layout_height="wrap_content"
       android:textAppearance="@style/MwmTextAppearance.Body4"
-      android:maxLines="1"
       tools:text="Украина"
       tools:background="#60FFFF00"/>
   </LinearLayout>

--- a/android/src/app/organicmaps/downloader/DownloaderAdapter.java
+++ b/android/src/app/organicmaps/downloader/DownloaderAdapter.java
@@ -481,7 +481,6 @@ class DownloaderAdapter extends RecyclerView.Adapter<DownloaderAdapter.ViewHolde
       String found = null;
       if (mSearchResultsMode)
       {
-        mName.setMaxLines(1);
         mName.setText(mItem.name);
 
         String searchResultName = mItem.searchResultName;
@@ -502,7 +501,6 @@ class DownloaderAdapter extends RecyclerView.Adapter<DownloaderAdapter.ViewHolde
       }
       else
       {
-        mName.setMaxLines(2);
         mName.setText(mItem.name);
         if (!mItem.isExpandable())
           UiUtils.setTextAndHideIfEmpty(mSubtitle, mItem.description);


### PR DESCRIPTION
Signed-off-by: Gonzalo Pesquero <gpesquero@yahoo.es>

Fixes the cut of long map names in the map download search list, as reported in [issue 4449](https://github.com/organicmaps/organicmaps/issues/4449).

This commit also removes the limitation to 1 line of the _subtile_ (city list) of the maps in the list.