### PR TITLE
[android-auto] Layout change fix

### DIFF
--- a/android/src/app/organicmaps/car/SurfaceRenderer.java
+++ b/android/src/app/organicmaps/car/SurfaceRenderer.java
@@ -3,7 +3,6 @@ package app.organicmaps.car;
 import android.graphics.Rect;
 
 import androidx.annotation.NonNull;
-import androidx.annotation.Nullable;
 import androidx.car.app.AppManager;
 import androidx.car.app.CarContext;
 import androidx.car.app.CarToast;
@@ -26,10 +25,10 @@ public class SurfaceRenderer implements DefaultLifecycleObserver, SurfaceCallbac
   private final CarContext mCarContext;
   private final Map mMap = new Map(MapType.AndroidAuto);
 
-  @Nullable
-  private Rect mVisibleArea;
-  @Nullable
-  private Rect mStableArea;
+  @NonNull
+  private Rect mVisibleArea = new Rect();
+  @NonNull
+  private Rect mStableArea = new Rect();
 
   public SurfaceRenderer(@NonNull CarContext carContext, @NonNull Lifecycle lifecycle)
   {
@@ -62,7 +61,11 @@ public class SurfaceRenderer implements DefaultLifecycleObserver, SurfaceCallbac
   {
     Logger.d(TAG, "Stable area changed. stableArea: " + stableArea);
     mStableArea = stableArea;
-    Framework.nativeSetVisibleRect(mStableArea.left, mStableArea.top, mStableArea.right, mStableArea.bottom);
+
+    if (!mStableArea.isEmpty())
+      Framework.nativeSetVisibleRect(mStableArea.left, mStableArea.top, mStableArea.right, mStableArea.bottom);
+    else if (!mVisibleArea.isEmpty())
+      Framework.nativeSetVisibleRect(mVisibleArea.left, mVisibleArea.top, mVisibleArea.right, mVisibleArea.bottom);
   }
 
   @Override
@@ -143,14 +146,13 @@ public class SurfaceRenderer implements DefaultLifecycleObserver, SurfaceCallbac
     float x = focusX;
     float y = focusY;
 
-    Rect visibleArea = mVisibleArea;
-    if (visibleArea != null)
+    if (!mVisibleArea.isEmpty())
     {
       // If a focal point value is negative, use the center point of the visible area.
       if (x < 0)
-        x = visibleArea.centerX();
+        x = mVisibleArea.centerX();
       if (y < 0)
-        y = visibleArea.centerY();
+        y = mVisibleArea.centerY();
     }
 
     final boolean animated = Float.compare(scaleFactor, 2f) == 0;


### PR DESCRIPTION
Android Auto was updated and added a new layout for split-screen. This is a small fix to handle layout change properly.
There is no updated documentation yet. Perhaps, I didn't find it. So, I don't know what was added more.

Case: Entering split-screen mode
Before: crash
Now:

https://user-images.githubusercontent.com/10351358/218823589-2eb63dc9-c6cc-46e4-9540-6badd728a8b6.mp4

Google Maps for comparison:


https://user-images.githubusercontent.com/10351358/218823873-46bbfa61-ea2e-4a3e-a2df-ac9ec33efadc.mp4


As you can see from GMaps example, there is a possibility to select the route point from split-screen. No other apps like Yandex, OsmAnd, or 2GIS support this feature yet.