### PR TITLE
[android] Made the Wikipedia article of any place page clickable

### DIFF
--- a/android/src/app/organicmaps/widget/placepage/PlacePageWikipediaFragment.java
+++ b/android/src/app/organicmaps/widget/placepage/PlacePageWikipediaFragment.java
@@ -49,6 +49,7 @@ public class PlacePageWikipediaFragment extends Fragment implements Observer<Map
     mPlaceDescriptionView = view.findViewById(R.id.poi_description);
     View placeDescriptionMoreBtn = view.findViewById(R.id.more_btn);
     placeDescriptionMoreBtn.setOnClickListener(v -> showDescriptionScreen());
+    mPlaceDescriptionView.setOnClickListener(v -> showDescriptionScreen());
     mWiki = view.findViewById(R.id.ll__place_wiki);
 
     viewModel = new ViewModelProvider(requireActivity()).get(PlacePageViewModel.class);


### PR DESCRIPTION
Fixes #4529 
Previously: 

![before](https://user-images.githubusercontent.com/79016311/220185687-01f39347-151d-4db3-ba41-946e87e2ad32.gif)

Now:

![after](https://user-images.githubusercontent.com/79016311/220185746-809d7233-ca88-47eb-a828-05501a5b02d2.gif)


And I guess it is draggable too:

![Draggable](https://user-images.githubusercontent.com/79016311/220185807-704e01d3-4575-47f3-b4d3-b90bc537b440.gif)
