### PR TITLE
[Android] fix whitespace in wikipedia description (regression fix)

### DIFF
--- a/android/res/layout/place_page_description_layout.xml
+++ b/android/res/layout/place_page_description_layout.xml
@@ -15,7 +15,6 @@
     android:layout_height="wrap_content"
     android:layout_marginEnd="@dimen/margin_base"
     android:layout_marginStart="@dimen/margin_base"
-    android:layout_marginTop="@dimen/margin_base"
     android:maxLength="@integer/place_page_description_max_length"
     android:fontFamily="@string/robotoRegular"
     android:textStyle="normal"


### PR DESCRIPTION
(regression, doesn't need to be included in changelog)
Before/after
![Screenshot_20230221-112206_Organic Maps (Debug)](https://user-images.githubusercontent.com/26939824/220332294-83a42048-d2bf-4ab2-a3c6-2db3ad9176c6.png)

fixes #4563 