### PR TITLE
[android] Fix deprecated getAdapterPosition()

### DIFF
--- a/android/src/app/organicmaps/bookmarks/BookmarkCategoriesAdapter.java
+++ b/android/src/app/organicmaps/bookmarks/BookmarkCategoriesAdapter.java
@@ -291,7 +291,7 @@ public class BookmarkCategoriesAdapter extends BaseBookmarkCategoryAdapter<Recyc
     {
       BookmarkCategory category = mHolder.getEntity();
       BookmarkManager.INSTANCE.toggleCategoryVisibility(category);
-      notifyItemChanged(mHolder.getAdapterPosition());
+      notifyItemChanged(mHolder.getBindingAdapterPosition());
       notifyItemChanged(HEADER_POSITION);
     }
   }

--- a/android/src/app/organicmaps/bookmarks/Holders.java
+++ b/android/src/app/organicmaps/bookmarks/Holders.java
@@ -306,7 +306,7 @@ public class Holders
     {
       mView.setOnClickListener(v -> {
         if (listener != null)
-          listener.onItemClick(v, getAdapterPosition());
+          listener.onItemClick(v, getBindingAdapterPosition());
       });
     }
 
@@ -314,7 +314,7 @@ public class Holders
     {
       mView.setOnLongClickListener(v -> {
         if (listener != null)
-          listener.onLongItemClick(v, getAdapterPosition());
+          listener.onLongItemClick(v, getBindingAdapterPosition());
         return true;
       });
     }

--- a/android/src/app/organicmaps/editor/CuisineAdapter.java
+++ b/android/src/app/organicmaps/editor/CuisineAdapter.java
@@ -131,7 +131,7 @@ public class CuisineAdapter extends RecyclerView.Adapter<CuisineAdapter.ViewHold
     @Override
     public void onCheckedChanged(CompoundButton buttonView, boolean isChecked)
     {
-      final String key = mItems.get(getAdapterPosition()).cuisineKey;
+      final String key = mItems.get(getBindingAdapterPosition()).cuisineKey;
       if (isChecked)
         mSelectedKeys.add(key);
       else

--- a/android/src/app/organicmaps/editor/FeatureCategoryAdapter.java
+++ b/android/src/app/organicmaps/editor/FeatureCategoryAdapter.java
@@ -63,7 +63,7 @@ public class FeatureCategoryAdapter extends RecyclerView.Adapter<FeatureCategory
       mName = itemView.findViewById(R.id.name);
       mSelected = itemView.findViewById(R.id.selected);
       UiUtils.hide(mSelected);
-      itemView.setOnClickListener(v -> onCategorySelected(getAdapterPosition()));
+      itemView.setOnClickListener(v -> onCategorySelected(getBindingAdapterPosition()));
     }
 
     public void bind(int position)

--- a/android/src/app/organicmaps/editor/LanguagesAdapter.java
+++ b/android/src/app/organicmaps/editor/LanguagesAdapter.java
@@ -53,7 +53,7 @@ public class LanguagesAdapter extends RecyclerView.Adapter<LanguagesAdapter.Hold
         @Override
         public void onClick(View v)
         {
-          mFragment.onLanguageSelected(mLanguages[getAdapterPosition()]);
+          mFragment.onLanguageSelected(mLanguages[getBindingAdapterPosition()]);
         }
       });
     }

--- a/android/src/app/organicmaps/editor/MultilanguageAdapter.java
+++ b/android/src/app/organicmaps/editor/MultilanguageAdapter.java
@@ -108,7 +108,7 @@ public class MultilanguageAdapter extends RecyclerView.Adapter<MultilanguageAdap
           UiUtils.setInputError(inputLayout, Editor.nativeIsNameValid(s.toString()) ?
                                                                       Utils.INVALID_ID :
                                                                       R.string.error_enter_correct_name);
-          mNames.get(getAdapterPosition()).name = s.toString();
+          mNames.get(getBindingAdapterPosition()).name = s.toString();
         }
       });
 

--- a/android/src/app/organicmaps/editor/SimpleTimetableAdapter.java
+++ b/android/src/app/organicmaps/editor/SimpleTimetableAdapter.java
@@ -231,7 +231,7 @@ class SimpleTimetableAdapter extends RecyclerView.Adapter<SimpleTimetableAdapter
         closedHours[i] = span;
         final int finalI = i;
         span.findViewById(R.id.iv__remove_closed)
-            .setOnClickListener(v -> removeClosedHours(getAdapterPosition(), finalI));
+            .setOnClickListener(v -> removeClosedHours(getBindingAdapterPosition(), finalI));
       }
     }
 
@@ -249,7 +249,7 @@ class SimpleTimetableAdapter extends RecyclerView.Adapter<SimpleTimetableAdapter
     @Override
     void onBind()
     {
-      final int position = getAdapterPosition();
+      final int position = getBindingAdapterPosition();
       final Timetable data = mItems.get(position);
       UiUtils.showIf(position > 0, deleteTimetable);
       tvOpen.setText(data.workingTimespan.start.toString());
@@ -264,13 +264,13 @@ class SimpleTimetableAdapter extends RecyclerView.Adapter<SimpleTimetableAdapter
     {
       final int id = v.getId();
       if (id == R.id.time_open)
-        pickTime(getAdapterPosition(), HoursMinutesPickerFragment.TAB_FROM, ID_OPENING);
+        pickTime(getBindingAdapterPosition(), HoursMinutesPickerFragment.TAB_FROM, ID_OPENING);
       else if (id == R.id.time_close)
-        pickTime(getAdapterPosition(), HoursMinutesPickerFragment.TAB_TO, ID_OPENING);
+        pickTime(getBindingAdapterPosition(), HoursMinutesPickerFragment.TAB_TO, ID_OPENING);
       else if (id == R.id.tv__remove_timetable)
-        removeTimetable(getAdapterPosition());
+        removeTimetable(getBindingAdapterPosition());
       else if (id == R.id.tv__add_closed)
-        pickTime(getAdapterPosition(), HoursMinutesPickerFragment.TAB_FROM, ID_CLOSING);
+        pickTime(getBindingAdapterPosition(), HoursMinutesPickerFragment.TAB_FROM, ID_CLOSING);
       else if (id == R.id.allday)
         swAllday.toggle();
     }
@@ -280,7 +280,7 @@ class SimpleTimetableAdapter extends RecyclerView.Adapter<SimpleTimetableAdapter
     {
       final int id = buttonView.getId();
       if (id == R.id.sw__allday)
-        setFullday(getAdapterPosition(), isChecked);
+        setFullday(getBindingAdapterPosition(), isChecked);
       else if (id == R.id.chb__day)
       {
         final int dayIndex = (Integer) buttonView.getTag();
@@ -353,9 +353,9 @@ class SimpleTimetableAdapter extends RecyclerView.Adapter<SimpleTimetableAdapter
     {
       final CheckBox checkBox = days.get(dayIndex);
       if (checkBox.isChecked())
-        addWorkingDay(dayIndex, getAdapterPosition());
+        addWorkingDay(dayIndex, getBindingAdapterPosition());
       else
-        removeWorkingDay(dayIndex, getAdapterPosition());
+        removeWorkingDay(dayIndex, getBindingAdapterPosition());
     }
 
     private void checkWithoutCallback(CompoundButton button, boolean check)

--- a/android/src/app/organicmaps/editor/StreetAdapter.java
+++ b/android/src/app/organicmaps/editor/StreetAdapter.java
@@ -119,7 +119,7 @@ public class StreetAdapter extends RecyclerView.Adapter<StreetAdapter.BaseViewHo
     @Override
     public void onClick(View v)
     {
-      mSelectedStreet = mStreets[getAdapterPosition()];
+      mSelectedStreet = mStreets[getBindingAdapterPosition()];
       notifyDataSetChanged();
       mFragment.saveStreet(mSelectedStreet);
     }

--- a/android/src/app/organicmaps/search/CategoriesAdapter.java
+++ b/android/src/app/organicmaps/search/CategoriesAdapter.java
@@ -177,7 +177,7 @@ class CategoriesAdapter extends RecyclerView.Adapter<CategoriesAdapter.ViewHolde
     @Override
     public final void onClick(View v)
     {
-      final int position = getAdapterPosition();
+      final int position = getBindingAdapterPosition();
       onItemClicked(position);
     }
 


### PR DESCRIPTION
**Issue:**
getAdapterPosition() is deprecated

**Solution:**
Replaced it with getBindingAdapterPosition() which returns the position in the specific adapter.

**Source:** https://stackoverflow.com/questions/63068519/getadapterposition-is-deprecated