### PR TITLE
[android] Improve theming in alertDialog on most recent devices

### DIFF
--- a/android/res/values/themes-attrs.xml
+++ b/android/res/values/themes-attrs.xml
@@ -2,6 +2,8 @@
 <resources>
   <declare-styleable name="ThemeAttrs">
     <attr name="fullscreenDialogTheme" format="reference" />
+    <attr name="titleDialogTheme" format="reference" />
+    <attr name="textDialogTheme" format="reference" />
     <attr name="windowBackgroundForced" format="reference|color" />
     <attr name="cardBackground" format="reference" />
     <attr name="clickableBackground" format="reference" />

--- a/android/res/values/themes-base.xml
+++ b/android/res/values/themes-base.xml
@@ -23,6 +23,8 @@
     <item name="alertDialogTheme">@style/MwmTheme.AlertDialog</item>
     <item name="windowBackgroundForced">@color/bg_window</item>
     <item name="cardBackground">@color/bg_cards</item>
+    <item name="titleDialogTheme">@color/black_primary</item>
+    <item name="textDialogTheme">@color/black_secondary</item>
     <item name="fullscreenDialogTheme">@style/MwmTheme.DialogFragment.Fullscreen</item>
     <item name="colorPrimary">@color/bg_primary</item>
     <item name="colorControlNormal">?secondary</item>
@@ -154,6 +156,8 @@
     <item name="alertDialogTheme">@style/MwmTheme.Night.AlertDialog</item>
     <item name="windowBackgroundForced">@color/bg_window_night</item>
     <item name="cardBackground">@color/bg_cards_night</item>
+    <item name="titleDialogTheme">@color/white_primary</item>
+    <item name="textDialogTheme">@color/white_secondary</item>
     <item name="fullscreenDialogTheme">@style/MwmTheme.DialogFragment.Fullscreen.Night</item>
     <item name="colorPrimary">@color/bg_primary_night</item>
     <item name="colorControlNormal">?secondary</item>

--- a/android/res/values/themes.xml
+++ b/android/res/values/themes.xml
@@ -53,7 +53,8 @@
 
   <style name="MwmTheme.AlertDialog" parent="Theme.AppCompat.Light.Dialog.Alert">
     <item name="colorAccent">@color/base_accent</item>
-    <item name="android:textColorPrimary">@color/black_secondary</item>
+    <item name="android:background">?cardBackground</item>
+    <item name="android:textColorPrimary">?textDialogTheme</item>
     <item name="android:textSize">@dimen/text_size_body_1</item>
     <item name="android:windowTitleStyle">@style/MwmTheme.DialogTitleStyle.Light</item>
   </style>
@@ -64,20 +65,21 @@
   </style>
 
   <style name="MwmTheme.DialogTitleStyle.Light" parent="MwmTheme.DialogTitleBase">
-    <item name="android:textColor">@color/black_primary</item>
+    <item name="android:textColor">?titleDialogTheme</item>
   </style>
 
   <style name="MwmTheme.Night.AlertDialog" parent="Theme.AppCompat.Dialog.Alert">
     <item name="colorAccent">@color/base_accent_night</item>
+    <item name="android:background">?cardBackground</item>
     <!-- Used for the message in the dialog -->
-    <item name="android:textColorPrimary">@color/white_secondary</item>
+    <item name="android:textColorPrimary">?textDialogTheme</item>
     <item name="android:textSize">@dimen/text_size_body_1</item>
     <!-- Used for the title in the dialog -->
     <item name="android:windowTitleStyle">@style/MwmTheme.DialogTitleStyle.Night</item>
   </style>
 
   <style name="MwmTheme.DialogTitleStyle.Night" parent="MwmTheme.DialogTitleBase">
-    <item name="android:textColor">@color/white_primary</item>
+    <item name="android:textColor">?titleDialogTheme</item>
   </style>
 
   <style name="MwmTheme.DialogFragment.TitleStyle" parent="Base.DialogWindowTitle.AppCompat">


### PR DESCRIPTION
Tested on Pixel 6 - Android 13, Honor 8 - Android 8
| Before | After |
|---|---|
|<img src="https://user-images.githubusercontent.com/87148630/220699737-a01305b0-920b-4ad7-bddf-b94c638003e2.png" height=400 />|<img src="https://user-images.githubusercontent.com/87148630/222568679-f45f6cc6-567c-4c2c-b002-cb218a3fb5ff.png" height=400 />|
|<img src="https://user-images.githubusercontent.com/87148630/220700312-a9ee50c9-7bfb-4a68-964b-32e267f19b14.png" height=400 />|<img src="https://user-images.githubusercontent.com/87148630/222568952-bc067cae-d2d1-44a1-89fc-114ece104ef0.png" height=400 />|
|<img src="https://user-images.githubusercontent.com/87148630/220701015-8d00eef3-93b7-4b74-b8a3-3dbad9338ec6.png" height=400 />|<img src="https://user-images.githubusercontent.com/87148630/222569082-df3f725f-56cd-43ca-86cd-88a586ea86c6.png" height=400 />|

I have re-used properties used in dialog layout https://github.com/organicmaps/organicmaps/blob/352ac9bda12b4f2bd57c0bba1065bf28a7a2c2d0/android/res/layout/dialog_sorting_types.xml#L7

I have check on Yoga Tab 2 - Android 5, background color is good without corrections

I have just need help to fix color on Title and text :)
