### PR TITLE
[android] do not close bottom sheet when opening bookmarks

### DIFF
--- a/android/src/app/organicmaps/MwmActivity.java
+++ b/android/src/app/organicmaps/MwmActivity.java
@@ -279,7 +279,6 @@ public class MwmActivity extends BaseMwmFragmentActivity
 
   private void showBookmarks()
   {
-    closeFloatingPanels();
     BookmarkCategoriesActivity.start(this);
   }
 


### PR DESCRIPTION
From a UX point of view, I don't see why we should close it. Opening the search does not close the bottom sheet so this makes the behavior more consistent.

Could fix https://github.com/organicmaps/organicmaps/issues/4549. I can't reproduce it but from the video it seems to be the cause of the crash.