### PR TITLE
[android] fix "download world" systematic pause after phone rotation 

### DIFF
--- a/android/AndroidManifest.xml
+++ b/android/AndroidManifest.xml
@@ -624,7 +624,7 @@
 
     <activity
         android:name="app.organicmaps.DownloadResourcesLegacyActivity"
-        android:configChanges="screenLayout|screenSize"/>
+        android:configChanges="orientation|screenLayout|screenSize"/>
 
     <activity-alias
       android:name="app.organicmaps.DownloadResourcesActivity"


### PR DESCRIPTION
As explained in [18023cd](https://github.com/organicmaps/organicmaps/commit/18023cdb5f4c8869d4593ba1d44013e72b60e2a3), this fixes a bug that occured on the "download map" screen, typically on a first launch/after a cache reset.

The solution I found is to track a status variable between the activity destruction and its creation after the rotation.

This PR shoud fix #4496.

I look forward to your feedback regarding this matter :)