### PR TITLE
[android] Use registerForActivityResult() in SplashActivity

### DIFF
--- a/android/src/app/organicmaps/SplashActivity.java
+++ b/android/src/app/organicmaps/SplashActivity.java
@@ -6,8 +6,11 @@ import static android.Manifest.permission.ACCESS_FINE_LOCATION;
 import android.app.Activity;
 import android.content.Context;
 import android.content.Intent;
+import android.content.pm.PackageManager;
 import android.os.Bundle;
 
+import androidx.activity.result.ActivityResultLauncher;
+import androidx.activity.result.contract.ActivityResultContracts;
 import androidx.annotation.NonNull;
 import androidx.annotation.Nullable;
 import androidx.annotation.StringRes;
@@ -20,22 +23,26 @@ import app.organicmaps.base.BaseActivityDelegate;
 import app.organicmaps.location.LocationHelper;
 import app.organicmaps.util.Config;
 import app.organicmaps.util.Counters;
-import app.organicmaps.util.LocationUtils;
 import app.organicmaps.util.ThemeUtils;
 import app.organicmaps.util.concurrency.UiThread;
+import app.organicmaps.util.log.Logger;
 
 import java.io.IOException;
 
 public class SplashActivity extends AppCompatActivity implements BaseActivity
 {
+  private static final String TAG = SplashActivity.class.getSimpleName();
   private static final String EXTRA_ACTIVITY_TO_START = "extra_activity_to_start";
   public static final String EXTRA_INITIAL_INTENT = "extra_initial_intent";
-  private static final int REQUEST_PERMISSIONS = 1;
   private static final int REQ_CODE_API_RESULT = 10;
 
   private static final long DELAY = 100;
 
   private boolean mCanceled = false;
+
+  @SuppressWarnings("NotNullFieldNotInitialized")
+  @NonNull
+  private ActivityResultLauncher<String[]> mPermissionRequest;
 
   @NonNull
   private final Runnable mInitCoreDelayedTask = new Runnable()
@@ -70,6 +77,8 @@ public class SplashActivity extends AppCompatActivity implements BaseActivity
     UiThread.cancelDelayedTasks(mInitCoreDelayedTask);
     Counters.initCounters(this);
     setContentView(R.layout.activity_splash);
+    mPermissionRequest = registerForActivityResult(new ActivityResultContracts.RequestMultiplePermissions(),
+        result -> Config.setLocationRequested());
   }
 
   @Override
@@ -93,12 +102,14 @@ public class SplashActivity extends AppCompatActivity implements BaseActivity
     mBaseDelegate.onResume();
     if (mCanceled)
       return;
-    if (!Config.isLocationRequested() && !LocationUtils.isLocationGranted(this))
+    if (!Config.isLocationRequested() && ActivityCompat.checkSelfPermission(this, ACCESS_COARSE_LOCATION)
+        != PackageManager.PERMISSION_GRANTED)
     {
-      ActivityCompat.requestPermissions(this, new String[]{
+      Logger.d(TAG, "Requesting location permissions");
+      mPermissionRequest.launch(new String[]{
           ACCESS_COARSE_LOCATION,
           ACCESS_FINE_LOCATION
-      }, REQUEST_PERMISSIONS);
+      });
       return;
     }
 
@@ -125,6 +136,8 @@ public class SplashActivity extends AppCompatActivity implements BaseActivity
   {
     super.onDestroy();
     mBaseDelegate.onDestroy();
+    mPermissionRequest.unregister();
+    mPermissionRequest = null;
   }
 
   private void showFatalErrorDialog(@StringRes int titleId, @StringRes int messageId)
@@ -136,17 +149,6 @@ public class SplashActivity extends AppCompatActivity implements BaseActivity
         .setNegativeButton(R.string.ok, (dialog, which) -> SplashActivity.this.finish())
         .setCancelable(false)
         .show();
-  }
-
-  @Override
-  public void onRequestPermissionsResult(int requestCode, @NonNull String[] permissions,
-                                         @NonNull int[] grantResults)
-  {
-    if (requestCode != REQUEST_PERMISSIONS)
-      throw new AssertionError("Unexpected requestCode");
-    super.onRequestPermissionsResult(requestCode, permissions, grantResults);
-    Config.setLocationRequested();
-    // No-op here - onResume() calls init();
   }
 
   private void init()
@@ -161,7 +163,9 @@ public class SplashActivity extends AppCompatActivity implements BaseActivity
       return;
     }
 
-    if (Counters.isFirstLaunch(this) && LocationUtils.isLocationGranted(this))
+    if (Counters.isFirstLaunch(this) &&
+        (ActivityCompat.checkSelfPermission(this, ACCESS_COARSE_LOCATION) == PackageManager.PERMISSION_GRANTED ||
+         ActivityCompat.checkSelfPermission(this, ACCESS_FINE_LOCATION) == PackageManager.PERMISSION_GRANTED))
     {
       LocationHelper.INSTANCE.onEnteredIntoFirstRun();
       if (!LocationHelper.INSTANCE.isActive())


### PR DESCRIPTION
Use registerForActivityResult() instead of deprecated requestPermissions(). No semantic changes intended.