### PR TITLE
[android] Remove Nexus 6 and Nexus 7 from Android Monkey

### DIFF
--- a/.github/workflows/android-monkey.yaml
+++ b/.github/workflows/android-monkey.yaml
@@ -73,7 +73,7 @@ jobs:
         run: |
           cmake --version
           ninja --version
-          gradle -Pfirebase assembleGoogleDebug uploadCrashlyticsSymbolFileGoogleDebug
+          gradle -Pfirebase -Parm64-v8a -Parmeabi-v7a -Px86_64 assembleGoogleDebug uploadCrashlyticsSymbolFileGoogleDebug
 
       - name: Run monkey
         run: |
@@ -93,6 +93,4 @@ jobs:
             --device model=Nexus6,version=25 \
             --device model=NexusLowRes,version=24 \
             --device model=NexusLowRes,version=23,orientation=landscape \
-            --device model=Nexus6,version=22 \
-            --device model=Nexus7,version=21 \
             --timeout 15m


### PR DESCRIPTION
These virtual devices are x86 VMs with broken OpenGL:

```
*** *** *** *** *** *** *** *** *** *** *** *** *** *** *** ***
Build fingerprint: 'generic/gce_x86_phone/gce_x86:5.0.2/LGR1.200331.001/6350401:userdebug/test-keys'
Revision: '0'
ABI: 'x86'
pid: 8947, tid: 9244, name: Thread-431  >>> app.organicmaps.debug <<<
signal 11 (SIGSEGV), code 1 (SEGV_MAPERR), fault addr 0x0
    eax 00000000  ebx aaa2b8c8  ecx 00000019  edx 00000640
    esi 00000640  edi 00000640
    xcs 00000073  xds 0000007b  xes 0000007b  xfs 0000013f  xss 0000007b
    eip aa2ee380  ebp 8d90d4a8  esp 8d90d470  flags 00210202
backtrace:
    #00 pc 00110380  /system/lib/egl/libGLESv2_swiftshader.so
    #01 pc 00110c7d  /system/lib/egl/libGLESv2_swiftshader.so
    #02 pc 000496fb  /system/lib/egl/libGLESv2_swiftshader.so
    #03 pc 00041166  /system/lib/egl/libGLESv2_swiftshader.so
    #04 pc 0004f8c7  /system/lib/egl/libGLESv2_swiftshader.so
    #05 pc 0005fd83  /system/lib/egl/libGLESv2_swiftshader.so (glClear+35)
    #06 pc 02caaef6  /data/app/app.organicmaps.debug-1/lib/x86/liborganicmaps.so (GLFunctions::glClear(unsigned int)+902)
    #07 pc 02cce44e  /data/app/app.organicmaps.debug-1/lib/x86/liborganicmaps.so (dp::OGLContext::Clear(unsigned int, unsigned int)+142)
    #08 pc 02991a4f  /data/app/app.organicmaps.debug-1/lib/x86/liborganicmaps.so (df::FrontendRenderer::RenderScene(ScreenBase const&, bool)+1087)
    #09 pc 0299a59b  /data/app/app.organicmaps.debug-1/lib/x86/liborganicmaps.so (df::FrontendRenderer::RenderFrame()+1899)
    #10 pc 02947f3b  /data/app/app.organicmaps.debug-1/lib/x86/liborganicmaps.so (df::BaseRenderer::IterateRenderLoopImpl()+43)
    #11 pc 02945ec3  /data/app/app.organicmaps.debug-1/lib/x86/liborganicmaps.so (df::BaseRenderer::IterateRenderLoop()+35)
    #12 pc 029a12cc  /data/app/app.organicmaps.debug-1/lib/x86/liborganicmaps.so (df::FrontendRenderer::Routine::Do()+1196)
    #13 pc 039dccb3  /data/app/app.organicmaps.debug-1/lib/x86/liborganicmaps.so
    #14 pc 03a0ca47  /data/app/app.organicmaps.debug-1/lib/x86/liborganicmaps.so
    #15 pc 03a0c976  /data/app/app.organicmaps.debug-1/lib/x86/liborganicmaps.so
    #16 pc 03a0c47b  /data/app/app.organicmaps.debug-1/lib/x86/liborganicmaps.so
    #17 pc 000301e9  /system/lib/libc.so (__pthread_start(void*)+57)
    #18 pc 0002b3ca  /system/lib/libc.so (__start_thread+26)
    #19 pc 00012c46  /system/lib/libc.so (__bionic_clone+70)
```

Unfortunally, Firebase TestLab doesn't provide any non-broken alternatives for API=21,22.