### PR TITLE
[android] Migrate AlertDialog to MaterialAlertDialog

### DIFF
--- a/android/src/app/organicmaps/DownloadResourcesLegacyActivity.java
+++ b/android/src/app/organicmaps/DownloadResourcesLegacyActivity.java
@@ -17,7 +17,6 @@ import androidx.annotation.NonNull;
 import androidx.annotation.Nullable;
 import androidx.annotation.StringRes;
 import androidx.annotation.StyleRes;
-import androidx.appcompat.app.AlertDialog;
 
 import app.organicmaps.api.ParsedMwmRequest;
 import app.organicmaps.base.BaseMwmFragmentActivity;
@@ -34,6 +33,7 @@ import app.organicmaps.util.StringUtils;
 import app.organicmaps.util.UiUtils;
 import app.organicmaps.util.Utils;
 import app.organicmaps.util.log.Logger;
+import com.google.android.material.dialog.MaterialAlertDialogBuilder;
 
 import java.util.List;
 
@@ -459,7 +459,7 @@ public class DownloadResourcesLegacyActivity extends BaseMwmFragmentActivity
       throw new AssertionError("Unexpected result code = " + result);
     }
 
-    new AlertDialog.Builder(this, R.style.MwmTheme_AlertDialog)
+    new MaterialAlertDialogBuilder(this, R.style.MwmTheme_AlertDialog)
         .setTitle(titleId)
         .setMessage(messageId)
         .setCancelable(true)

--- a/android/src/app/organicmaps/MapFragment.java
+++ b/android/src/app/organicmaps/MapFragment.java
@@ -12,11 +12,11 @@ import android.view.View;
 import android.view.ViewGroup;
 
 import androidx.annotation.Nullable;
-import androidx.appcompat.app.AlertDialog;
 import androidx.core.content.res.ConfigurationHelper;
 
 import app.organicmaps.base.BaseMwmFragment;
 import app.organicmaps.util.log.Logger;
+import com.google.android.material.dialog.MaterialAlertDialogBuilder;
 
 public class MapFragment extends BaseMwmFragment implements View.OnTouchListener, SurfaceHolder.Callback
 {
@@ -170,7 +170,7 @@ public class MapFragment extends BaseMwmFragment implements View.OnTouchListener
 
   private void reportUnsupported()
   {
-    new AlertDialog.Builder(requireContext(), R.style.MwmTheme_AlertDialog)
+    new MaterialAlertDialogBuilder(requireContext(), R.style.MwmTheme_AlertDialog)
         .setMessage(R.string.unsupported_phone)
         .setCancelable(false)
         .setPositiveButton(R.string.close, (dlg, which) -> requireActivity().moveTaskToBack(true))

--- a/android/src/app/organicmaps/MwmActivity.java
+++ b/android/src/app/organicmaps/MwmActivity.java
@@ -93,6 +93,7 @@ import app.organicmaps.widget.placepage.PlacePageButtons;
 import app.organicmaps.widget.placepage.PlacePageController;
 import app.organicmaps.widget.placepage.PlacePageData;
 import app.organicmaps.widget.placepage.PlacePageView;
+import com.google.android.material.dialog.MaterialAlertDialogBuilder;
 
 import java.util.ArrayList;
 import java.util.Objects;
@@ -325,7 +326,7 @@ public class MwmActivity extends BaseMwmFragmentActivity
       return;
     }
 
-    new AlertDialog.Builder(MwmActivity.this, R.style.MwmTheme_AlertDialog)
+    new MaterialAlertDialogBuilder(MwmActivity.this, R.style.MwmTheme_AlertDialog)
         .setMessage(R.string.unknown_current_position)
         .setCancelable(true)
         .setPositiveButton(R.string.ok, null)
@@ -447,7 +448,7 @@ public class MwmActivity extends BaseMwmFragmentActivity
   @Override
   public void onNoConnectionError()
   {
-    new AlertDialog.Builder(this, R.style.MwmTheme_AlertDialog)
+    new MaterialAlertDialogBuilder(this, R.style.MwmTheme_AlertDialog)
         .setTitle(R.string.common_check_internet_connection_dialog_title)
         .setMessage(R.string.common_check_internet_connection_dialog)
         .setPositiveButton(R.string.ok, null)
@@ -920,7 +921,7 @@ public class MwmActivity extends BaseMwmFragmentActivity
       return;
     }
 
-    new AlertDialog.Builder(this, R.style.MwmTheme_AlertDialog)
+    new MaterialAlertDialogBuilder(this, R.style.MwmTheme_AlertDialog)
         .setTitle(R.string.downloader_update_maps)
         .setMessage(R.string.isolines_activation_error_dialog)
         .setPositiveButton(R.string.ok, (dialog, which) -> startActivity(new Intent(this, DownloaderActivity.class)))
@@ -1592,7 +1593,7 @@ public class MwmActivity extends BaseMwmFragmentActivity
   @Override
   public void onDrivingOptionsBuildError()
   {
-    new AlertDialog.Builder(this, R.style.MwmTheme_AlertDialog)
+    new MaterialAlertDialogBuilder(this, R.style.MwmTheme_AlertDialog)
         .setTitle(R.string.unable_to_calc_alert_title)
         .setMessage(R.string.unable_to_calc_alert_subtitle)
         .setPositiveButton(R.string.settings, (dialog, which) -> DrivingOptionsActivity.start(this))

--- a/android/src/app/organicmaps/SplashActivity.java
+++ b/android/src/app/organicmaps/SplashActivity.java
@@ -14,7 +14,6 @@ import androidx.activity.result.contract.ActivityResultContracts;
 import androidx.annotation.NonNull;
 import androidx.annotation.Nullable;
 import androidx.annotation.StringRes;
-import androidx.appcompat.app.AlertDialog;
 import androidx.appcompat.app.AppCompatActivity;
 import androidx.core.app.ActivityCompat;
 
@@ -26,6 +25,7 @@ import app.organicmaps.util.Counters;
 import app.organicmaps.util.ThemeUtils;
 import app.organicmaps.util.concurrency.UiThread;
 import app.organicmaps.util.log.Logger;
+import com.google.android.material.dialog.MaterialAlertDialogBuilder;
 
 import java.io.IOException;
 
@@ -143,7 +143,7 @@ public class SplashActivity extends AppCompatActivity implements BaseActivity
   private void showFatalErrorDialog(@StringRes int titleId, @StringRes int messageId)
   {
     mCanceled = true;
-    new AlertDialog.Builder(this, R.style.MwmTheme_AlertDialog)
+    new MaterialAlertDialogBuilder(this, R.style.MwmTheme_AlertDialog)
         .setTitle(titleId)
         .setMessage(messageId)
         .setNegativeButton(R.string.ok, (dialog, which) -> SplashActivity.this.finish())

--- a/android/src/app/organicmaps/bookmarks/BookmarkCategorySettingsFragment.java
+++ b/android/src/app/organicmaps/bookmarks/BookmarkCategorySettingsFragment.java
@@ -13,13 +13,13 @@ import android.widget.EditText;
 
 import androidx.annotation.NonNull;
 import androidx.annotation.Nullable;
-import androidx.appcompat.app.AlertDialog;
 
 import app.organicmaps.R;
 import app.organicmaps.base.BaseMwmToolbarFragment;
 import app.organicmaps.bookmarks.data.BookmarkCategory;
 import app.organicmaps.bookmarks.data.BookmarkManager;
 import app.organicmaps.util.Utils;
+import com.google.android.material.dialog.MaterialAlertDialogBuilder;
 
 import java.util.Objects;
 
@@ -115,7 +115,7 @@ public class BookmarkCategorySettingsFragment extends BaseMwmToolbarFragment
   {
     if (TextUtils.isEmpty(name))
     {
-      new AlertDialog.Builder(requireActivity(), R.style.MwmTheme_AlertDialog)
+      new MaterialAlertDialogBuilder(requireActivity(), R.style.MwmTheme_AlertDialog)
           .setTitle(R.string.bookmarks_error_title_empty_list_name)
           .setMessage(R.string.bookmarks_error_message_empty_list_name)
           .setPositiveButton(R.string.ok, null)
@@ -125,7 +125,7 @@ public class BookmarkCategorySettingsFragment extends BaseMwmToolbarFragment
 
     if (BookmarkManager.INSTANCE.isUsedCategoryName(name) && !TextUtils.equals(name, mCategory.getName()))
     {
-      new AlertDialog.Builder(requireActivity(), R.style.MwmTheme_AlertDialog)
+      new MaterialAlertDialogBuilder(requireActivity(), R.style.MwmTheme_AlertDialog)
           .setTitle(R.string.bookmarks_error_title_list_name_already_taken)
           .setMessage(R.string.bookmarks_error_message_list_name_already_taken)
           .setPositiveButton(R.string.ok, null)

--- a/android/src/app/organicmaps/bookmarks/BookmarksSharingHelper.java
+++ b/android/src/app/organicmaps/bookmarks/BookmarksSharingHelper.java
@@ -5,7 +5,6 @@ import android.app.ProgressDialog;
 
 import androidx.annotation.NonNull;
 import androidx.annotation.Nullable;
-import androidx.appcompat.app.AlertDialog;
 import androidx.fragment.app.FragmentActivity;
 
 import app.organicmaps.R;
@@ -13,6 +12,7 @@ import app.organicmaps.bookmarks.data.BookmarkManager;
 import app.organicmaps.bookmarks.data.BookmarkSharingResult;
 import app.organicmaps.util.SharingUtils;
 import app.organicmaps.util.log.Logger;
+import com.google.android.material.dialog.MaterialAlertDialogBuilder;
 
 public enum BookmarksSharingHelper
 {
@@ -46,7 +46,7 @@ public enum BookmarksSharingHelper
         SharingUtils.shareBookmarkFile(context, result.getSharingPath());
         break;
       case BookmarkSharingResult.EMPTY_CATEGORY:
-        new AlertDialog.Builder(context, R.style.MwmTheme_AlertDialog)
+        new MaterialAlertDialogBuilder(context, R.style.MwmTheme_AlertDialog)
             .setTitle(R.string.bookmarks_error_title_share_empty)
             .setMessage(R.string.bookmarks_error_message_share_empty)
             .setPositiveButton(R.string.ok, null)
@@ -54,7 +54,7 @@ public enum BookmarksSharingHelper
         break;
       case BookmarkSharingResult.ARCHIVE_ERROR:
       case BookmarkSharingResult.FILE_ERROR:
-        new AlertDialog.Builder(context, R.style.MwmTheme_AlertDialog)
+        new MaterialAlertDialogBuilder(context, R.style.MwmTheme_AlertDialog)
             .setTitle(R.string.dialog_routing_system_error)
             .setMessage(R.string.bookmarks_error_message_share_general)
             .setPositiveButton(R.string.ok, null)

--- a/android/src/app/organicmaps/dialog/EditTextDialogFragment.java
+++ b/android/src/app/organicmaps/dialog/EditTextDialogFragment.java
@@ -19,6 +19,7 @@ import androidx.fragment.app.Fragment;
 
 import androidx.fragment.app.FragmentActivity;
 import androidx.fragment.app.FragmentManager;
+import com.google.android.material.dialog.MaterialAlertDialogBuilder;
 import com.google.android.material.textfield.TextInputLayout;
 import app.organicmaps.R;
 import app.organicmaps.base.BaseMwmDialogFragment;
@@ -122,7 +123,7 @@ public class EditTextDialogFragment extends BaseMwmDialogFragment
       negativeButtonText = args.getString(ARG_NEGATIVE_BUTTON);
     }
 
-    AlertDialog editTextDialog = new AlertDialog.Builder(requireActivity(), R.style.MwmTheme_AlertDialog)
+    AlertDialog editTextDialog = new MaterialAlertDialogBuilder(requireActivity(), R.style.MwmTheme_AlertDialog)
         .setView(buildView())
         .setNegativeButton(negativeButtonText, null)
         .setPositiveButton(positiveButtonText, (dialog, which) -> {

--- a/android/src/app/organicmaps/downloader/DownloaderAdapter.java
+++ b/android/src/app/organicmaps/downloader/DownloaderAdapter.java
@@ -17,7 +17,6 @@ import android.widget.TextView;
 import androidx.annotation.LayoutRes;
 import androidx.annotation.NonNull;
 import androidx.annotation.Nullable;
-import androidx.appcompat.app.AlertDialog;
 import androidx.recyclerview.widget.LinearLayoutManager;
 import androidx.recyclerview.widget.RecyclerView;
 
@@ -30,6 +29,7 @@ import app.organicmaps.util.StringUtils;
 import app.organicmaps.util.UiUtils;
 import app.organicmaps.util.bottomsheet.MenuBottomSheetFragment;
 import app.organicmaps.util.bottomsheet.MenuBottomSheetItem;
+import com.google.android.material.dialog.MaterialAlertDialogBuilder;
 import com.timehop.stickyheadersrecyclerview.StickyRecyclerHeadersAdapter;
 import com.timehop.stickyheadersrecyclerview.StickyRecyclerHeadersDecoration;
 
@@ -100,7 +100,7 @@ class DownloaderAdapter extends RecyclerView.Adapter<DownloaderAdapter.ViewHolde
   {
     if (RoutingController.get().isNavigating())
     {
-      new AlertDialog.Builder(adapter.mActivity, R.style.MwmTheme_AlertDialog)
+      new MaterialAlertDialogBuilder(adapter.mActivity, R.style.MwmTheme_AlertDialog)
           .setTitle(R.string.downloader_delete_map)
           .setMessage(R.string.downloader_delete_map_while_routing_dialog)
           .setPositiveButton(R.string.ok, null)
@@ -114,7 +114,7 @@ class DownloaderAdapter extends RecyclerView.Adapter<DownloaderAdapter.ViewHolde
       return;
     }
 
-    new AlertDialog.Builder(adapter.mActivity, R.style.MwmTheme_AlertDialog)
+    new MaterialAlertDialogBuilder(adapter.mActivity, R.style.MwmTheme_AlertDialog)
         .setTitle(R.string.downloader_delete_map)
         .setMessage(R.string.downloader_delete_map_dialog)
         .setNegativeButton(R.string.cancel, null)

--- a/android/src/app/organicmaps/downloader/MapManager.java
+++ b/android/src/app/organicmaps/downloader/MapManager.java
@@ -13,6 +13,7 @@ import androidx.appcompat.app.AlertDialog;
 import app.organicmaps.R;
 import app.organicmaps.util.ConnectionState;
 import app.organicmaps.util.Utils;
+import com.google.android.material.dialog.MaterialAlertDialogBuilder;
 
 import java.lang.ref.WeakReference;
 import java.util.List;
@@ -88,7 +89,7 @@ public final class MapManager
       throw new IllegalArgumentException("Given error can not be displayed: " + errorData.errorCode);
     }
 
-    final AlertDialog dlg = new AlertDialog.Builder(activity, R.style.MwmTheme_AlertDialog)
+    final AlertDialog dlg = new MaterialAlertDialogBuilder(activity, R.style.MwmTheme_AlertDialog)
         .setTitle(R.string.country_status_download_failed)
         .setMessage(text)
         .setNegativeButton(R.string.cancel, (dialog, which) -> {
@@ -109,7 +110,7 @@ public final class MapManager
 
   private static void notifyNoSpaceInternal(Activity activity)
   {
-    new AlertDialog.Builder(activity, R.style.MwmTheme_AlertDialog)
+    new MaterialAlertDialogBuilder(activity, R.style.MwmTheme_AlertDialog)
         .setTitle(R.string.downloader_no_space_title)
         .setMessage(R.string.downloader_no_space_message)
         .setPositiveButton(android.R.string.ok, null)
@@ -160,7 +161,7 @@ public final class MapManager
       return false;
     }
 
-    new AlertDialog.Builder(activity, R.style.MwmTheme_AlertDialog)
+    new MaterialAlertDialogBuilder(activity, R.style.MwmTheme_AlertDialog)
         .setTitle(R.string.download_over_mobile_header)
         .setMessage(R.string.download_over_mobile_message)
         .setNegativeButton(R.string.cancel, null)

--- a/android/src/app/organicmaps/editor/EditorFragment.java
+++ b/android/src/app/organicmaps/editor/EditorFragment.java
@@ -20,12 +20,12 @@ import androidx.annotation.IdRes;
 import androidx.annotation.NonNull;
 import androidx.annotation.Nullable;
 import androidx.annotation.StringRes;
-import androidx.appcompat.app.AlertDialog;
 import androidx.appcompat.widget.SwitchCompat;
 import androidx.core.content.ContextCompat;
 import androidx.recyclerview.widget.LinearLayoutManager;
 import androidx.recyclerview.widget.RecyclerView;
 
+import com.google.android.material.dialog.MaterialAlertDialogBuilder;
 import com.google.android.material.textfield.TextInputLayout;
 import app.organicmaps.Framework;
 import app.organicmaps.R;
@@ -638,7 +638,7 @@ public class EditorFragment extends BaseMwmFragment implements View.OnClickListe
       message = R.string.editor_reset_edits_message;
     }
 
-    new AlertDialog.Builder(requireActivity(), R.style.MwmTheme_AlertDialog)
+    new MaterialAlertDialogBuilder(requireActivity(), R.style.MwmTheme_AlertDialog)
         .setTitle(message)
         .setPositiveButton(title, (dialog, which) -> {
           Editor.nativeRollbackMapObject();

--- a/android/src/app/organicmaps/editor/EditorHostFragment.java
+++ b/android/src/app/organicmaps/editor/EditorHostFragment.java
@@ -13,7 +13,6 @@ import androidx.annotation.CallSuper;
 import androidx.annotation.NonNull;
 import androidx.annotation.Nullable;
 import androidx.annotation.StringRes;
-import androidx.appcompat.app.AlertDialog;
 import androidx.fragment.app.Fragment;
 
 import androidx.fragment.app.FragmentManager;
@@ -31,6 +30,7 @@ import app.organicmaps.widget.ToolbarController;
 import app.organicmaps.util.ConnectionState;
 import app.organicmaps.util.UiUtils;
 import app.organicmaps.util.Utils;
+import com.google.android.material.dialog.MaterialAlertDialogBuilder;
 
 import java.util.ArrayList;
 import java.util.List;
@@ -360,7 +360,7 @@ public class EditorHostFragment extends BaseMwmToolbarFragment
 
   private void processNoFeatures()
   {
-    new AlertDialog.Builder(requireActivity(), R.style.MwmTheme_AlertDialog)
+    new MaterialAlertDialogBuilder(requireActivity(), R.style.MwmTheme_AlertDialog)
         .setTitle(R.string.downloader_no_space_title)
         .setPositiveButton(R.string.ok, null)
         .show();
@@ -395,7 +395,7 @@ public class EditorHostFragment extends BaseMwmToolbarFragment
 
   private void showMistakeDialog(@StringRes int resId)
   {
-    new AlertDialog.Builder(requireActivity(), R.style.MwmTheme_AlertDialog)
+    new MaterialAlertDialogBuilder(requireActivity(), R.style.MwmTheme_AlertDialog)
         .setMessage(resId)
         .setPositiveButton(R.string.ok, null)
         .show();
@@ -403,7 +403,7 @@ public class EditorHostFragment extends BaseMwmToolbarFragment
 
   private void showNoobDialog()
   {
-    new AlertDialog.Builder(requireActivity(), R.style.MwmTheme_AlertDialog)
+    new MaterialAlertDialogBuilder(requireActivity(), R.style.MwmTheme_AlertDialog)
         .setTitle(R.string.editor_share_to_all_dialog_title)
         .setMessage(getString(R.string.editor_share_to_all_dialog_message_1)
             + " " + getString(R.string.editor_share_to_all_dialog_message_2))

--- a/android/src/app/organicmaps/editor/HoursMinutesPickerFragment.java
+++ b/android/src/app/organicmaps/editor/HoursMinutesPickerFragment.java
@@ -19,6 +19,7 @@ import androidx.appcompat.app.AlertDialog;
 import androidx.appcompat.content.res.AppCompatResources;
 import androidx.fragment.app.FragmentManager;
 
+import com.google.android.material.dialog.MaterialAlertDialogBuilder;
 import com.google.android.material.tabs.TabLayout;
 import app.organicmaps.R;
 import app.organicmaps.base.BaseMwmDialogFragment;
@@ -81,7 +82,7 @@ public class HoursMinutesPickerFragment extends BaseMwmDialogFragment
     @StyleRes final int theme = ThemeUtils.isNightTheme(requireContext()) ?
         R.style.MwmMain_DialogFragment_TimePicker_Night :
         R.style.MwmMain_DialogFragment_TimePicker;
-    final AlertDialog dialog = new AlertDialog.Builder(requireActivity(), theme)
+    final AlertDialog dialog = new MaterialAlertDialogBuilder(requireActivity(), theme)
         .setView(root)
         .setNegativeButton(R.string.cancel, null)
         .setPositiveButton(R.string.ok, null)

--- a/android/src/app/organicmaps/editor/OsmLoginFragment.java
+++ b/android/src/app/organicmaps/editor/OsmLoginFragment.java
@@ -14,7 +14,6 @@ import android.widget.TextView;
 import androidx.annotation.NonNull;
 import androidx.annotation.Nullable;
 import androidx.annotation.Size;
-import androidx.appcompat.app.AlertDialog;
 
 import app.organicmaps.Framework;
 import app.organicmaps.R;
@@ -25,6 +24,7 @@ import app.organicmaps.util.InputUtils;
 import app.organicmaps.util.UiUtils;
 import app.organicmaps.util.concurrency.ThreadPool;
 import app.organicmaps.util.concurrency.UiThread;
+import com.google.android.material.dialog.MaterialAlertDialogBuilder;
 
 public class OsmLoginFragment extends BaseMwmToolbarFragment
 {
@@ -105,7 +105,7 @@ public class OsmLoginFragment extends BaseMwmToolbarFragment
 
   private void onAuthFail()
   {
-    new AlertDialog.Builder(requireActivity(), R.style.MwmTheme_AlertDialog)
+    new MaterialAlertDialogBuilder(requireActivity(), R.style.MwmTheme_AlertDialog)
         .setTitle(R.string.editor_login_error_dialog)
         .setPositiveButton(R.string.ok, null)
         .show();

--- a/android/src/app/organicmaps/editor/ProfileFragment.java
+++ b/android/src/app/organicmaps/editor/ProfileFragment.java
@@ -11,7 +11,6 @@ import android.widget.TextView;
 
 import androidx.annotation.NonNull;
 import androidx.annotation.Nullable;
-import androidx.appcompat.app.AlertDialog;
 
 import app.organicmaps.R;
 import app.organicmaps.base.BaseMwmToolbarFragment;
@@ -19,6 +18,7 @@ import app.organicmaps.util.Constants;
 import app.organicmaps.util.UiUtils;
 import app.organicmaps.util.concurrency.ThreadPool;
 import app.organicmaps.util.concurrency.UiThread;
+import com.google.android.material.dialog.MaterialAlertDialogBuilder;
 
 public class ProfileFragment extends BaseMwmToolbarFragment
 {
@@ -84,7 +84,7 @@ public class ProfileFragment extends BaseMwmToolbarFragment
 
   private void logout()
   {
-    new AlertDialog.Builder(requireContext(), R.style.MwmTheme_AlertDialog)
+    new MaterialAlertDialogBuilder(requireContext(), R.style.MwmTheme_AlertDialog)
         .setMessage(R.string.are_you_sure)
         .setPositiveButton(R.string.ok, (dialog, which) ->
         {

--- a/android/src/app/organicmaps/editor/TimetableContainerFragment.java
+++ b/android/src/app/organicmaps/editor/TimetableContainerFragment.java
@@ -12,7 +12,6 @@ import android.widget.TextView;
 import androidx.annotation.NonNull;
 import androidx.annotation.Nullable;
 import androidx.annotation.StringRes;
-import androidx.appcompat.app.AlertDialog;
 import androidx.fragment.app.Fragment;
 import androidx.fragment.app.FragmentActivity;
 
@@ -20,6 +19,7 @@ import app.organicmaps.R;
 import app.organicmaps.base.BaseMwmFragment;
 import app.organicmaps.base.OnBackPressListener;
 import app.organicmaps.util.UiUtils;
+import com.google.android.material.dialog.MaterialAlertDialogBuilder;
 
 public class TimetableContainerFragment extends BaseMwmFragment implements OnBackPressListener,
                                                                            TimetableChangedListener
@@ -151,7 +151,7 @@ public class TimetableContainerFragment extends BaseMwmFragment implements OnBac
       if (activity == null)
         return;
 
-      new AlertDialog.Builder(activity)
+      new MaterialAlertDialogBuilder(activity)
         .setMessage(R.string.editor_correct_mistake)
         .setPositiveButton(android.R.string.ok, null)
         .show();

--- a/android/src/app/organicmaps/location/LocationHelper.java
+++ b/android/src/app/organicmaps/location/LocationHelper.java
@@ -17,7 +17,6 @@ import androidx.activity.result.contract.ActivityResultContracts;
 import androidx.annotation.NonNull;
 import androidx.annotation.Nullable;
 import androidx.annotation.UiThread;
-import androidx.appcompat.app.AlertDialog;
 import androidx.appcompat.app.AppCompatActivity;
 
 import app.organicmaps.Framework;
@@ -34,6 +33,7 @@ import app.organicmaps.util.LocationUtils;
 import app.organicmaps.util.NetworkPolicy;
 import app.organicmaps.util.Utils;
 import app.organicmaps.util.log.Logger;
+import com.google.android.material.dialog.MaterialAlertDialogBuilder;
 
 public enum LocationHelper implements Initializable<Context>, AppBackgroundTracker.OnTransitionListener, BaseLocationProvider.Listener
 {
@@ -298,7 +298,7 @@ public enum LocationHelper implements Initializable<Context>, AppBackgroundTrack
       return;
     }
 
-    AlertDialog.Builder builder = new AlertDialog.Builder(mActivity, R.style.MwmTheme_AlertDialog)
+    MaterialAlertDialogBuilder builder = new MaterialAlertDialogBuilder(mActivity, R.style.MwmTheme_AlertDialog)
         .setTitle(R.string.enable_location_services)
         .setMessage(R.string.location_is_disabled_long_text)
         .setOnDismissListener(dialog -> mErrorDialog = null)
@@ -336,7 +336,7 @@ public enum LocationHelper implements Initializable<Context>, AppBackgroundTrack
       return;
     }
 
-    mErrorDialog = new AlertDialog.Builder(mActivity, R.style.MwmTheme_AlertDialog)
+    mErrorDialog = new MaterialAlertDialogBuilder(mActivity, R.style.MwmTheme_AlertDialog)
         .setTitle(R.string.enable_location_services)
         .setMessage(R.string.location_is_disabled_long_text)
         .setOnDismissListener(dialog -> mErrorDialog = null)
@@ -373,7 +373,7 @@ public enum LocationHelper implements Initializable<Context>, AppBackgroundTrack
     }
 
     final AppCompatActivity activity = mActivity;
-    mErrorDialog = new AlertDialog.Builder(activity, R.style.MwmTheme_AlertDialog)
+    mErrorDialog = new MaterialAlertDialogBuilder(activity, R.style.MwmTheme_AlertDialog)
         .setTitle(R.string.current_location_unknown_title)
         .setMessage(R.string.current_location_unknown_message)
         .setOnDismissListener(dialog -> mErrorDialog = null)

--- a/android/src/app/organicmaps/maplayer/traffic/widget/TrafficButtonController.java
+++ b/android/src/app/organicmaps/maplayer/traffic/widget/TrafficButtonController.java
@@ -5,11 +5,11 @@ import android.app.Dialog;
 
 import androidx.annotation.NonNull;
 import androidx.annotation.Nullable;
-import androidx.appcompat.app.AlertDialog;
 
 import app.organicmaps.R;
 import app.organicmaps.maplayer.traffic.TrafficManager;
 import app.organicmaps.util.Utils;
+import com.google.android.material.dialog.MaterialAlertDialogBuilder;
 
 public class TrafficButtonController implements TrafficManager.TrafficCallback
 {
@@ -110,7 +110,7 @@ public class TrafficButtonController implements TrafficManager.TrafficCallback
     if (mDialog != null && mDialog.isShowing())
       return;
 
-    mDialog = new AlertDialog.Builder(mActivity, R.style.MwmTheme_AlertDialog)
+    mDialog = new MaterialAlertDialogBuilder(mActivity, R.style.MwmTheme_AlertDialog)
         .setMessage(R.string.common_check_internet_connection_dialog)
         .setPositiveButton(R.string.ok, (dialog, which) -> TrafficManager.INSTANCE.setEnabled(false))
         .setCancelable(true)

--- a/android/src/app/organicmaps/routing/BaseRoutingErrorDialogFragment.java
+++ b/android/src/app/organicmaps/routing/BaseRoutingErrorDialogFragment.java
@@ -21,6 +21,7 @@ import app.organicmaps.base.BaseMwmDialogFragment;
 import app.organicmaps.downloader.CountryItem;
 import app.organicmaps.util.StringUtils;
 import app.organicmaps.util.UiUtils;
+import com.google.android.material.dialog.MaterialAlertDialogBuilder;
 
 import java.util.ArrayList;
 import java.util.HashMap;
@@ -57,7 +58,7 @@ abstract class BaseRoutingErrorDialogFragment extends BaseMwmDialogFragment
   public Dialog onCreateDialog(Bundle savedInstanceState)
   {
     parseArguments();
-    AlertDialog.Builder builder = new AlertDialog.Builder(requireActivity(), R.style.MwmTheme_AlertDialog)
+    MaterialAlertDialogBuilder builder = new MaterialAlertDialogBuilder(requireActivity(), R.style.MwmTheme_AlertDialog)
         .setCancelable(true)
         .setNegativeButton(android.R.string.cancel, null);
     beforeDialogCreated(builder);

--- a/android/src/app/organicmaps/routing/RoutingController.java
+++ b/android/src/app/organicmaps/routing/RoutingController.java
@@ -29,6 +29,7 @@ import app.organicmaps.util.StringUtils;
 import app.organicmaps.util.Utils;
 import app.organicmaps.util.concurrency.UiThread;
 import app.organicmaps.util.log.Logger;
+import com.google.android.material.dialog.MaterialAlertDialogBuilder;
 
 import java.util.Calendar;
 import java.util.concurrent.TimeUnit;
@@ -343,7 +344,7 @@ public class RoutingController implements Initializable<Void>
                                  R.string.dialog_routing_disclaimer_beware })
       builder.append(MwmApplication.from(activity.getApplicationContext()).getString(resId)).append("\n\n");
 
-    new AlertDialog.Builder(activity, R.style.MwmTheme_AlertDialog)
+    new MaterialAlertDialogBuilder(activity, R.style.MwmTheme_AlertDialog)
         .setTitle(R.string.dialog_routing_disclaimer_title)
         .setMessage(builder.toString())
         .setCancelable(false)
@@ -538,7 +539,7 @@ public class RoutingController implements Initializable<Void>
     if (mContainer == null)
       return;
 
-    final AlertDialog.Builder builder = new AlertDialog.Builder(mContainer.requireActivity())
+    final MaterialAlertDialogBuilder builder = new MaterialAlertDialogBuilder(mContainer.requireActivity())
         .setMessage(R.string.p2p_reroute_from_current)
         .setCancelable(false)
         .setNegativeButton(R.string.cancel, null);

--- a/android/src/app/organicmaps/settings/SettingsPrefsFragment.java
+++ b/android/src/app/organicmaps/settings/SettingsPrefsFragment.java
@@ -14,7 +14,6 @@ import android.view.View;
 import androidx.annotation.NonNull;
 import androidx.annotation.Nullable;
 import androidx.annotation.StringRes;
-import androidx.appcompat.app.AlertDialog;
 import androidx.core.content.ContextCompat;
 import androidx.preference.ListPreference;
 import androidx.preference.Preference;
@@ -40,6 +39,7 @@ import app.organicmaps.util.ThemeSwitcher;
 import app.organicmaps.util.UiUtils;
 import app.organicmaps.util.Utils;
 import app.organicmaps.util.log.LogsManager;
+import com.google.android.material.dialog.MaterialAlertDialogBuilder;
 
 import java.util.HashMap;
 import java.util.List;
@@ -698,7 +698,7 @@ public class SettingsPrefsFragment extends BaseXmlSettingsFragment
       {
         if (MapManager.nativeIsDownloading())
         {
-          new AlertDialog.Builder(requireActivity(), R.style.MwmTheme_AlertDialog)
+          new MaterialAlertDialogBuilder(requireActivity(), R.style.MwmTheme_AlertDialog)
               .setTitle(R.string.downloading_is_active)
               .setMessage(R.string.cant_change_this_setting)
               .setPositiveButton(R.string.ok, null)

--- a/android/src/app/organicmaps/settings/StoragePathFragment.java
+++ b/android/src/app/organicmaps/settings/StoragePathFragment.java
@@ -11,7 +11,6 @@ import android.widget.ListView;
 import android.widget.TextView;
 
 import androidx.annotation.NonNull;
-import androidx.appcompat.app.AlertDialog;
 
 import app.organicmaps.Framework;
 import app.organicmaps.R;
@@ -21,6 +20,7 @@ import app.organicmaps.util.StorageUtils;
 import app.organicmaps.util.Utils;
 import app.organicmaps.util.concurrency.ThreadPool;
 import app.organicmaps.util.concurrency.UiThread;
+import com.google.android.material.dialog.MaterialAlertDialogBuilder;
 
 import java.io.File;
 import java.util.List;
@@ -94,7 +94,7 @@ public class StoragePathFragment extends BaseSettingsFragment
     final String oldPath = storages.get(currentIndex).mPath;
     final String newPath = storages.get(newIndex).mPath;
 
-    new AlertDialog.Builder(requireActivity(), R.style.MwmTheme_AlertDialog)
+    new MaterialAlertDialogBuilder(requireActivity(), R.style.MwmTheme_AlertDialog)
         .setCancelable(false)
         .setTitle(R.string.move_maps)
         .setPositiveButton(R.string.ok, (dlg, which) -> moveStorage(newPath, oldPath))
@@ -130,7 +130,7 @@ public class StoragePathFragment extends BaseSettingsFragment
 
         if (!result)
         {
-          new AlertDialog.Builder(requireActivity(), R.style.MwmTheme_AlertDialog)
+          new MaterialAlertDialogBuilder(requireActivity(), R.style.MwmTheme_AlertDialog)
               .setTitle(R.string.move_maps_error)
               .setPositiveButton(R.string.report_a_bug,
                   (dlg, which) -> Utils.sendBugReport(requireActivity(), "Error moving map files"))

--- a/android/src/app/organicmaps/util/Utils.java
+++ b/android/src/app/organicmaps/util/Utils.java
@@ -32,11 +32,11 @@ import androidx.annotation.DimenRes;
 import androidx.annotation.NonNull;
 import androidx.annotation.Nullable;
 import androidx.annotation.StringRes;
-import androidx.appcompat.app.AlertDialog;
 import androidx.core.app.NavUtils;
 import androidx.fragment.app.Fragment;
 import androidx.fragment.app.FragmentManager;
 
+import com.google.android.material.dialog.MaterialAlertDialogBuilder;
 import com.google.android.material.snackbar.Snackbar;
 
 import app.organicmaps.BuildConfig;
@@ -385,7 +385,7 @@ public class Utils
     }
 
     final Holder holder = new Holder();
-    new AlertDialog.Builder(context, R.style.MwmTheme_AlertDialog)
+    new MaterialAlertDialogBuilder(context, R.style.MwmTheme_AlertDialog)
         .setMessage(message)
         .setNegativeButton(R.string.cancel, null)
         .setPositiveButton(R.string.downloader_retry, (dialog, which) -> {

--- a/android/src/app/organicmaps/widget/placepage/BookmarkColorDialogFragment.java
+++ b/android/src/app/organicmaps/widget/placepage/BookmarkColorDialogFragment.java
@@ -9,13 +9,13 @@ import android.widget.AdapterView;
 import android.widget.GridView;
 
 import androidx.annotation.NonNull;
-import androidx.appcompat.app.AlertDialog;
 
 import app.organicmaps.R;
 import app.organicmaps.base.BaseMwmDialogFragment;
 import app.organicmaps.bookmarks.IconsAdapter;
 import app.organicmaps.bookmarks.data.BookmarkManager;
 import app.organicmaps.bookmarks.data.Icon;
+import com.google.android.material.dialog.MaterialAlertDialogBuilder;
 
 import java.util.List;
 
@@ -41,7 +41,7 @@ public class BookmarkColorDialogFragment extends BaseMwmDialogFragment
     if (getArguments() != null)
       mIconColor = getArguments().getInt(ICON_TYPE);
 
-    return new AlertDialog.Builder(requireActivity(), R.style.MwmTheme_AlertDialog)
+    return new MaterialAlertDialogBuilder(requireActivity(), R.style.MwmTheme_AlertDialog)
         .setView(buildView())
         .setTitle(R.string.bookmark_color)
         .setNegativeButton(R.string.cancel, null)


### PR DESCRIPTION
I have migrate all AlertDialog to MaterialAlertDialog
https://developer.android.com/reference/com/google/android/material/dialog/MaterialAlertDialogBuilder
Migrate to new AlertDialog have no impact because it's the same dialog with just support to used Material Theming

Tested on Pixel 6 - Android 13 and Honor 8 - Android 8
I have tested custom alert dialog (EditTextDialogFragment, missmapsdialog)

Screenshot are available here https://github.com/organicmaps/organicmaps/pull/4575