### PR TITLE
[android] fix toolbars insets

### DIFF
--- a/android/res/layout/fragment_edit_bookmark.xml
+++ b/android/res/layout/fragment_edit_bookmark.xml
@@ -8,19 +8,23 @@
     android:id="@+id/toolbar"
     style="@style/MwmWidget.ToolbarStyle"
     android:layout_width="match_parent"
-    android:layout_height="?attr/actionBarSize"
+    android:layout_height="wrap_content"
     android:theme="@style/MwmWidget.ToolbarTheme">
-    <TextView
-      android:id="@+id/tv__save"
-      android:layout_width="wrap_content"
-      android:layout_height="match_parent"
-      android:layout_gravity="end"
-      android:background="?attr/selectableItemBackgroundBorderless"
-      android:clickable="true"
-      android:gravity="center_vertical"
-      android:padding="@dimen/margin_half"
-      android:text="@string/save"
-      android:textAppearance="@style/MwmTextAppearance.Toolbar.Title.Button"/>
+    <RelativeLayout
+      android:layout_width="match_parent"
+      android:layout_height="?attr/actionBarSize">
+      <TextView
+        android:id="@+id/tv__save"
+        android:layout_width="wrap_content"
+        android:layout_height="match_parent"
+        android:layout_alignParentEnd="true"
+        android:background="?attr/selectableItemBackgroundBorderless"
+        android:clickable="true"
+        android:gravity="center_vertical"
+        android:padding="@dimen/margin_half"
+        android:text="@string/save"
+        android:textAppearance="@style/MwmTextAppearance.Toolbar.Title.Button" />
+    </RelativeLayout>
   </androidx.appcompat.widget.Toolbar>
   <FrameLayout
     style="@style/MwmWidget.FrameLayout.Elevation"

--- a/android/res/layout/layout_nav_top.xml
+++ b/android/res/layout/layout_nav_top.xml
@@ -12,20 +12,25 @@
   <FrameLayout
     android:id="@+id/street_frame"
     android:layout_width="match_parent"
-    android:layout_height="@dimen/nav_street_height"
+    android:layout_height="wrap_content"
     android:elevation="@dimen/nav_elevation"
     app:layout_constraintTop_toTopOf="parent"
     android:background="?cardBackground">
-    <TextView
-      android:id="@+id/street"
-      style="@style/MwmWidget.TextView.NavStreet"
+    <RelativeLayout
       android:layout_width="match_parent"
-      android:layout_height="match_parent"
-      android:layout_marginStart="@dimen/nav_street_left"
-      android:maxLines="2"
-      android:layout_gravity="center_vertical"
-      android:gravity="center"
-      tools:text="Sample street name.\nLong looooooooong!!!!"/>
+      android:layout_height="@dimen/nav_street_height"
+      tools:ignore="UselessParent">
+      <TextView
+        android:id="@+id/street"
+        style="@style/MwmWidget.TextView.NavStreet"
+        android:layout_width="match_parent"
+        android:layout_height="match_parent"
+        android:layout_marginStart="@dimen/nav_street_left"
+        android:maxLines="2"
+        android:layout_gravity="center_vertical"
+        android:gravity="center"
+        tools:text="Sample street name.\nLong looooooooong!!!!"/>
+    </RelativeLayout>
   </FrameLayout>
 
   <RelativeLayout

--- a/android/res/layout/position_chooser.xml
+++ b/android/res/layout/position_chooser.xml
@@ -8,13 +8,13 @@
     android:id="@+id/toolbar_point_chooser"
     style="@style/MwmWidget.ToolbarStyle"
     android:layout_width="match_parent"
-    android:layout_height="?attr/actionBarSize"
+    android:layout_height="wrap_content"
     android:gravity="end|center_vertical"
     android:theme="@style/MwmWidget.ToolbarTheme">
 
     <LinearLayout
       android:layout_width="match_parent"
-      android:layout_height="wrap_content"
+      android:layout_height="?attr/actionBarSize"
       android:orientation="horizontal"
       android:padding="@dimen/margin_half">
 

--- a/android/res/layout/routing_plan.xml
+++ b/android/res/layout/routing_plan.xml
@@ -17,12 +17,12 @@
       android:theme="@style/MwmWidget.ToolbarTheme"
       android:layout_width="match_parent"
       app:contentInsetStart="0dp"
-      android:layout_height="?attr/actionBarSize"
+      android:layout_height="wrap_content"
       android:elevation="0dp">
 
       <RelativeLayout
           android:layout_width="match_parent"
-          android:layout_height="wrap_content">
+          android:layout_height="?attr/actionBarSize">
 
         <ImageView
             android:id="@+id/back"

--- a/android/src/app/organicmaps/MwmActivity.java
+++ b/android/src/app/organicmaps/MwmActivity.java
@@ -422,7 +422,7 @@ public class MwmActivity extends BaseMwmFragmentActivity
   {
     ViewCompat.setOnApplyWindowInsetsListener(mPointChooser, (view, windowInsets) -> {
       UiUtils.setViewInsetsPaddingBottom(mPointChooser, windowInsets);
-      UiUtils.extendViewWithStatusBar(mPointChooserToolbar, windowInsets);
+      UiUtils.setViewInsetsPaddingNoBottom(mPointChooserToolbar, windowInsets);
 
       mNavBarHeight = mIsFullscreen ? 0 : windowInsets.getInsets(WindowInsetsCompat.Type.systemBars()).bottom;
       // For the first loading, set compass top margin to status bar size

--- a/android/src/app/organicmaps/routing/NavigationController.java
+++ b/android/src/app/organicmaps/routing/NavigationController.java
@@ -116,7 +116,7 @@ public class NavigationController implements Application.ActivityLifecycleCallba
     final View navigationBarBackground = mFrame.findViewById(R.id.nav_bottom_sheet_nav_bar);
     final View nextTurnContainer = mFrame.findViewById(R.id.nav_next_turn_container);
     ViewCompat.setOnApplyWindowInsetsListener(mStreetFrame, (v, windowInsets) -> {
-      UiUtils.extendViewWithStatusBar(v, windowInsets);
+      UiUtils.setViewInsetsPaddingNoBottom(v, windowInsets);
       nextTurnContainer.setPadding(windowInsets.getInsets(WindowInsetsCompat.Type.systemBars()).left, nextTurnContainer.getPaddingTop(),
                                    nextTurnContainer.getPaddingRight(), nextTurnContainer.getPaddingBottom());
       navigationBarBackground.getLayoutParams().height = windowInsets.getInsets(WindowInsetsCompat.Type.systemBars()).bottom;

--- a/android/src/app/organicmaps/util/UiUtils.java
+++ b/android/src/app/organicmaps/util/UiUtils.java
@@ -411,19 +411,6 @@ public final class UiUtils
     }
   }
 
-  public static void extendViewWithStatusBar(@NonNull View view, WindowInsetsCompat windowInsets)
-  {
-    final int height = windowInsets.getInsets(WindowInsetsCompat.Type.systemBars()).top;
-    final ViewGroup.LayoutParams lp = view.getLayoutParams();
-    // Extend the height only when necessary
-    if (lp.height != ViewGroup.LayoutParams.WRAP_CONTENT && view.getPaddingTop() < height)
-    {
-      lp.height += height;
-      view.setLayoutParams(lp);
-    }
-    setViewInsetsPaddingNoBottom(view, windowInsets);
-  }
-
   public static void setViewInsetsPadding(View view, WindowInsetsCompat windowInsets)
   {
     final Insets systemInsets = windowInsets.getInsets(WindowInsetsCompat.Type.systemBars());

--- a/android/src/app/organicmaps/widget/ToolbarController.java
+++ b/android/src/app/organicmaps/widget/ToolbarController.java
@@ -34,7 +34,7 @@ public class ToolbarController implements Detachable<Activity>
     if (useExtendedToolbar())
     {
       ViewCompat.setOnApplyWindowInsetsListener(getToolbar(), (view, windowInsets) -> {
-        UiUtils.extendViewWithStatusBar(getToolbar(), windowInsets);
+        UiUtils.setViewInsetsPaddingNoBottom(getToolbar(), windowInsets);
         return windowInsets;
       });
     }

--- a/android/src/app/organicmaps/widget/placepage/EditBookmarkFragment.java
+++ b/android/src/app/organicmaps/widget/placepage/EditBookmarkFragment.java
@@ -108,7 +108,7 @@ public class EditBookmarkFragment extends BaseMwmDialogFragment implements View.
   {
     Toolbar toolbar = view.findViewById(R.id.toolbar);
     ViewCompat.setOnApplyWindowInsetsListener(toolbar, (v, windowInsets) -> {
-      UiUtils.extendViewWithStatusBar(v, windowInsets);
+      UiUtils.setViewInsetsPaddingNoBottom(v, windowInsets);
       return windowInsets;
     });
     final TextView textView = toolbar.findViewById(R.id.tv__save);


### PR DESCRIPTION
Fixes #4636.

Toolbars and other elements showing under the status bar had a fixed height, so we relied on a hack to update the view height to include the inset.

Instead of this buggy hack, I reworked the layouts so the fixed height is set to a child view instead of the parent. This way we can apply inset padding to the parent, and the content under the status bar (the child with fixed height) will still be sized correctly.

@Jean-BaptisteC @rtsisyk can you confirm this fixes your issue? I could reproduce it when the device had display cutouts enabled in the developers settings.