### PR TITLE
[Android][iOS][strings] Better 3D buildings settings

### DIFF
--- a/android/res/values-ar/strings.xml
+++ b/android/res/values-ar/strings.xml
@@ -221,6 +221,8 @@
 	<string name="pref_map_3d_title">العرض المنظوري</string>
 	<!-- Settings «Map» category: «3D buildings» title -->
 	<string name="pref_map_3d_buildings_title">مباني ثلاثية الأبعاد</string>
+	<!-- A message in Settings/Preferences explaining why is it not possible to enable 3D buildings when max power saving mode is enabled -->
+	<string name="pref_map_3d_buildings_disabled_summary">يتم إيقاف تشغيل المباني ثلاثية الأبعاد في وضع توفير الطاقة</string>
 	<!-- Settings «Route» category: «Tts enabled» title -->
 	<string name="pref_tts_enable_title">تعليمات صوتية</string>
 	<!-- Settings «Route» category: «Tts language» title -->

--- a/android/res/values-be/strings.xml
+++ b/android/res/values-be/strings.xml
@@ -219,6 +219,8 @@
 	<string name="pref_map_3d_title">Перспектыўны выгляд</string>
 	<!-- Settings «Map» category: «3D buildings» title -->
 	<string name="pref_map_3d_buildings_title">3D будынкі</string>
+	<!-- A message in Settings/Preferences explaining why is it not possible to enable 3D buildings when max power saving mode is enabled -->
+	<string name="pref_map_3d_buildings_disabled_summary">У рэжыме энергазберажэння 3D-будынкі выключаны</string>
 	<!-- Settings «Route» category: «Tts enabled» title -->
 	<string name="pref_tts_enable_title">Галасавыя інструкцыі</string>
 	<!-- Settings «Route» category: «Tts language» title -->

--- a/android/res/values-bg/strings.xml
+++ b/android/res/values-bg/strings.xml
@@ -208,6 +208,8 @@
 	<string name="pref_map_3d_title">Перспективен изглед</string>
 	<!-- Settings «Map» category: «3D buildings» title -->
 	<string name="pref_map_3d_buildings_title">3D сгради</string>
+	<!-- A message in Settings/Preferences explaining why is it not possible to enable 3D buildings when max power saving mode is enabled -->
+	<string name="pref_map_3d_buildings_disabled_summary">3D сградите са изключени в режим на пестене на енергия</string>
 	<!-- Settings «Route» category: «Tts enabled» title -->
 	<string name="pref_tts_enable_title">Гласови инструкции</string>
 	<!-- Settings «Route» category: «Tts language» title -->

--- a/android/res/values-ca/strings.xml
+++ b/android/res/values-ca/strings.xml
@@ -210,6 +210,8 @@
 	<string name="pref_map_3d_title">Vista en perspectiva</string>
 	<!-- Settings «Map» category: «3D buildings» title -->
 	<string name="pref_map_3d_buildings_title">Edificis en 3D</string>
+	<!-- A message in Settings/Preferences explaining why is it not possible to enable 3D buildings when max power saving mode is enabled -->
+	<string name="pref_map_3d_buildings_disabled_summary">Els edificis en 3D es desactiven en mode d\'estalvi d\'energia</string>
 	<!-- Settings «Route» category: «Tts enabled» title -->
 	<string name="pref_tts_enable_title">Instruccions de veu</string>
 	<!-- Settings «Route» category: «Tts language» title -->

--- a/android/res/values-cs/strings.xml
+++ b/android/res/values-cs/strings.xml
@@ -205,6 +205,8 @@
 	<string name="pref_map_3d_title">Zobrazení perspektivy</string>
 	<!-- Settings «Map» category: «3D buildings» title -->
 	<string name="pref_map_3d_buildings_title">3D budovy</string>
+	<!-- A message in Settings/Preferences explaining why is it not possible to enable 3D buildings when max power saving mode is enabled -->
+	<string name="pref_map_3d_buildings_disabled_summary">3D budovy jsou vypnuty v úsporném režimu</string>
 	<!-- Settings «Route» category: «Tts enabled» title -->
 	<string name="pref_tts_enable_title">Hlasové instrukce</string>
 	<!-- Settings «Route» category: «Tts language» title -->

--- a/android/res/values-da/strings.xml
+++ b/android/res/values-da/strings.xml
@@ -201,6 +201,8 @@
 	<string name="pref_map_3d_title">Perspektivvisning</string>
 	<!-- Settings «Map» category: «3D buildings» title -->
 	<string name="pref_map_3d_buildings_title">3D-bygninger</string>
+	<!-- A message in Settings/Preferences explaining why is it not possible to enable 3D buildings when max power saving mode is enabled -->
+	<string name="pref_map_3d_buildings_disabled_summary">3D-bygninger er slukket i strømbesparende tilstand</string>
 	<!-- Settings «Route» category: «Tts enabled» title -->
 	<string name="pref_tts_enable_title">Stemmeinstruktioner</string>
 	<!-- Settings «Route» category: «Tts language» title -->

--- a/android/res/values-de/strings.xml
+++ b/android/res/values-de/strings.xml
@@ -218,6 +218,8 @@
 	<string name="pref_map_3d_title">Perspektivische Ansicht</string>
 	<!-- Settings «Map» category: «3D buildings» title -->
 	<string name="pref_map_3d_buildings_title">3D-Gebäude</string>
+	<!-- A message in Settings/Preferences explaining why is it not possible to enable 3D buildings when max power saving mode is enabled -->
+	<string name="pref_map_3d_buildings_disabled_summary">3D-Gebäude werden im Energiesparmodus ausgeschaltet</string>
 	<!-- Settings «Route» category: «Tts enabled» title -->
 	<string name="pref_tts_enable_title">Sprachführung</string>
 	<!-- Settings «Route» category: «Tts language» title -->

--- a/android/res/values-el/strings.xml
+++ b/android/res/values-el/strings.xml
@@ -202,6 +202,8 @@
 	<string name="pref_map_3d_title">Προβολή προοπτικής</string>
 	<!-- Settings «Map» category: «3D buildings» title -->
 	<string name="pref_map_3d_buildings_title">Τρισδιάστατα κτίρια</string>
+	<!-- A message in Settings/Preferences explaining why is it not possible to enable 3D buildings when max power saving mode is enabled -->
+	<string name="pref_map_3d_buildings_disabled_summary">Τα τρισδιάστατα κτίρια απενεργοποιούνται σε λειτουργία εξοικονόμησης ενέργειας</string>
 	<!-- Settings «Route» category: «Tts enabled» title -->
 	<string name="pref_tts_enable_title">Φωνητικές οδηγίες</string>
 	<!-- Settings «Route» category: «Tts language» title -->

--- a/android/res/values-es/strings.xml
+++ b/android/res/values-es/strings.xml
@@ -218,6 +218,8 @@
 	<string name="pref_map_3d_title">Vista en perspectiva</string>
 	<!-- Settings «Map» category: «3D buildings» title -->
 	<string name="pref_map_3d_buildings_title">Edificios en 3D</string>
+	<!-- A message in Settings/Preferences explaining why is it not possible to enable 3D buildings when max power saving mode is enabled -->
+	<string name="pref_map_3d_buildings_disabled_summary">Los edificios 3D se apagan en el modo de ahorro de energía</string>
 	<!-- Settings «Route» category: «Tts enabled» title -->
 	<string name="pref_tts_enable_title">Instrucciones de voz</string>
 	<!-- Settings «Route» category: «Tts language» title -->

--- a/android/res/values-et/strings.xml
+++ b/android/res/values-et/strings.xml
@@ -210,6 +210,8 @@
 	<string name="pref_map_3d_title">Perspektiivi vaade</string>
 	<!-- Settings «Map» category: «3D buildings» title -->
 	<string name="pref_map_3d_buildings_title">3D hooned</string>
+	<!-- A message in Settings/Preferences explaining why is it not possible to enable 3D buildings when max power saving mode is enabled -->
+	<string name="pref_map_3d_buildings_disabled_summary">3D-hooned lülitatakse energiasäästurežiimis välja</string>
 	<!-- Settings «Route» category: «Tts enabled» title -->
 	<string name="pref_tts_enable_title">Hääljuhised</string>
 	<!-- Settings «Route» category: «Tts language» title -->

--- a/android/res/values-eu/strings.xml
+++ b/android/res/values-eu/strings.xml
@@ -198,6 +198,8 @@
 	<string name="pref_map_3d_title">Perspektiba ikuspegia</string>
 	<!-- Settings «Map» category: «3D buildings» title -->
 	<string name="pref_map_3d_buildings_title">3D eraikinak</string>
+	<!-- A message in Settings/Preferences explaining why is it not possible to enable 3D buildings when max power saving mode is enabled -->
+	<string name="pref_map_3d_buildings_disabled_summary">3D eraikinak itzalita daude energia aurrezteko moduan</string>
 	<!-- Settings «Route» category: «Tts enabled» title -->
 	<string name="pref_tts_enable_title">Ahots argibideak</string>
 	<!-- Settings «Route» category: «Tts language» title -->

--- a/android/res/values-fa/strings.xml
+++ b/android/res/values-fa/strings.xml
@@ -194,6 +194,8 @@
 	<string name="pref_map_3d_title">نمای چشم انداز</string>
 	<!-- Settings «Map» category: «3D buildings» title -->
 	<string name="pref_map_3d_buildings_title">ساختمان‌های سه بعدی</string>
+	<!-- A message in Settings/Preferences explaining why is it not possible to enable 3D buildings when max power saving mode is enabled -->
+	<string name="pref_map_3d_buildings_disabled_summary">ساختمان های سه بعدی در حالت صرفه جویی در مصرف برق خاموش می شوند</string>
 	<!-- Settings «Route» category: «Tts enabled» title -->
 	<string name="pref_tts_enable_title">دستور العمل صوتی</string>
 	<!-- Settings «Route» category: «Tts language» title -->

--- a/android/res/values-fi/strings.xml
+++ b/android/res/values-fi/strings.xml
@@ -207,6 +207,8 @@
 	<string name="pref_map_3d_title">Perspektiivinäkymä</string>
 	<!-- Settings «Map» category: «3D buildings» title -->
 	<string name="pref_map_3d_buildings_title">3D-rakennukset</string>
+	<!-- A message in Settings/Preferences explaining why is it not possible to enable 3D buildings when max power saving mode is enabled -->
+	<string name="pref_map_3d_buildings_disabled_summary">3D-rakennukset sammutetaan virransäästötilassa</string>
 	<!-- Settings «Route» category: «Tts enabled» title -->
 	<string name="pref_tts_enable_title">Ääniohjeistukset</string>
 	<!-- Settings «Route» category: «Tts language» title -->

--- a/android/res/values-fr/strings.xml
+++ b/android/res/values-fr/strings.xml
@@ -220,6 +220,8 @@
 	<string name="pref_map_3d_title">Vue en perspective</string>
 	<!-- Settings «Map» category: «3D buildings» title -->
 	<string name="pref_map_3d_buildings_title">Bâtiments en 3D</string>
+	<!-- A message in Settings/Preferences explaining why is it not possible to enable 3D buildings when max power saving mode is enabled -->
+	<string name="pref_map_3d_buildings_disabled_summary">Les bâtiments 3D sont désactivés en mode d\'économie d\'énergie</string>
 	<!-- Settings «Route» category: «Tts enabled» title -->
 	<string name="pref_tts_enable_title">Instructions vocales</string>
 	<!-- Settings «Route» category: «Tts language» title -->

--- a/android/res/values-hu/strings.xml
+++ b/android/res/values-hu/strings.xml
@@ -201,6 +201,8 @@
 	<string name="pref_map_3d_title">Perspektivikus nézet</string>
 	<!-- Settings «Map» category: «3D buildings» title -->
 	<string name="pref_map_3d_buildings_title">3D-s épületek</string>
+	<!-- A message in Settings/Preferences explaining why is it not possible to enable 3D buildings when max power saving mode is enabled -->
+	<string name="pref_map_3d_buildings_disabled_summary">A 3D épületek energiatakarékos módban ki vannak kapcsolva</string>
 	<!-- Settings «Route» category: «Tts enabled» title -->
 	<string name="pref_tts_enable_title">Hangutasítások</string>
 	<!-- Settings «Route» category: «Tts language» title -->

--- a/android/res/values-in/strings.xml
+++ b/android/res/values-in/strings.xml
@@ -203,6 +203,8 @@
 	<string name="pref_map_3d_title">Pandangan perspektif</string>
 	<!-- Settings «Map» category: «3D buildings» title -->
 	<string name="pref_map_3d_buildings_title">Bangunan 3D</string>
+	<!-- A message in Settings/Preferences explaining why is it not possible to enable 3D buildings when max power saving mode is enabled -->
+	<string name="pref_map_3d_buildings_disabled_summary">Bangunan 3D dimatikan dalam mode hemat daya</string>
 	<!-- Settings «Route» category: «Tts enabled» title -->
 	<string name="pref_tts_enable_title">Petunjuk Suara</string>
 	<!-- Settings «Route» category: «Tts language» title -->

--- a/android/res/values-it/strings.xml
+++ b/android/res/values-it/strings.xml
@@ -206,6 +206,8 @@
 	<string name="pref_map_3d_title">Vista in prospettiva</string>
 	<!-- Settings «Map» category: «3D buildings» title -->
 	<string name="pref_map_3d_buildings_title">Edifici 3D</string>
+	<!-- A message in Settings/Preferences explaining why is it not possible to enable 3D buildings when max power saving mode is enabled -->
+	<string name="pref_map_3d_buildings_disabled_summary">Gli edifici 3D sono disattivati in modalità di risparmio energetico</string>
 	<!-- Settings «Route» category: «Tts enabled» title -->
 	<string name="pref_tts_enable_title">Istruzioni vocali</string>
 	<!-- Settings «Route» category: «Tts language» title -->

--- a/android/res/values-iw/strings.xml
+++ b/android/res/values-iw/strings.xml
@@ -166,6 +166,8 @@
 	<string name="share_my_location">שתף את מקומי</string>
 	<string name="pref_zoom_title">כפתורי זום</string>
 	<string name="pref_zoom_summary">הצג על המסך</string>
+	<!-- A message in Settings/Preferences explaining why is it not possible to enable 3D buildings when max power saving mode is enabled -->
+	<string name="pref_map_3d_buildings_disabled_summary">מבנים תלת מימדיים כבויים במצב חיסכון בחשמל</string>
 	<string name="search_show_on_map">ראה במפה</string>
 	<!-- Text in About menu, opens Organic Maps news website -->
 	<string name="news">תוֹשׁדָחֲ</string>

--- a/android/res/values-ja/strings.xml
+++ b/android/res/values-ja/strings.xml
@@ -199,6 +199,8 @@
 	<string name="pref_map_3d_title">パースペクティブ表示</string>
 	<!-- Settings «Map» category: «3D buildings» title -->
 	<string name="pref_map_3d_buildings_title">3Dビルディング</string>
+	<!-- A message in Settings/Preferences explaining why is it not possible to enable 3D buildings when max power saving mode is enabled -->
+	<string name="pref_map_3d_buildings_disabled_summary">省電力モードで建物の 3D 表示がオフになっている</string>
 	<!-- Settings «Route» category: «Tts enabled» title -->
 	<string name="pref_tts_enable_title">音声指示</string>
 	<!-- Settings «Route» category: «Tts language» title -->

--- a/android/res/values-ko/strings.xml
+++ b/android/res/values-ko/strings.xml
@@ -201,6 +201,8 @@
 	<string name="pref_map_3d_title">원근 보기</string>
 	<!-- Settings «Map» category: «3D buildings» title -->
 	<string name="pref_map_3d_buildings_title">주변 건물 3D</string>
+	<!-- A message in Settings/Preferences explaining why is it not possible to enable 3D buildings when max power saving mode is enabled -->
+	<string name="pref_map_3d_buildings_disabled_summary">3D 빌딩은 절전 모드에서 꺼집니다.</string>
 	<!-- Settings «Route» category: «Tts enabled» title -->
 	<string name="pref_tts_enable_title">음성 지침</string>
 	<!-- Settings «Route» category: «Tts language» title -->

--- a/android/res/values-mr/strings.xml
+++ b/android/res/values-mr/strings.xml
@@ -194,6 +194,8 @@
 	<string name="pref_map_3d_title">यथार्थ दृश्य</string>
 	<!-- Settings «Map» category: «3D buildings» title -->
 	<string name="pref_map_3d_buildings_title">त्रिमिती (3D) इमारती</string>
+	<!-- A message in Settings/Preferences explaining why is it not possible to enable 3D buildings when max power saving mode is enabled -->
+	<string name="pref_map_3d_buildings_disabled_summary">3D इमारती वीज बचत मोडमध्ये बंद केल्या आहेत</string>
 	<!-- Settings «Route» category: «Tts enabled» title -->
 	<string name="pref_tts_enable_title">ध्वनी सूचना</string>
 	<!-- Settings «Route» category: «Tts language» title -->

--- a/android/res/values-nb/strings.xml
+++ b/android/res/values-nb/strings.xml
@@ -220,6 +220,8 @@
 	<string name="pref_map_3d_title">Perspektivvisning</string>
 	<!-- Settings «Map» category: «3D buildings» title -->
 	<string name="pref_map_3d_buildings_title">Bygninger i 3D</string>
+	<!-- A message in Settings/Preferences explaining why is it not possible to enable 3D buildings when max power saving mode is enabled -->
+	<string name="pref_map_3d_buildings_disabled_summary">3D-bygninger er slått av i strømsparingsmodus</string>
 	<!-- Settings «Route» category: «Tts enabled» title -->
 	<string name="pref_tts_enable_title">Taleinstrukser</string>
 	<!-- Settings «Route» category: «Tts language» title -->

--- a/android/res/values-nl/strings.xml
+++ b/android/res/values-nl/strings.xml
@@ -218,6 +218,8 @@
 	<string name="pref_map_3d_title">Perspectiefbeeld</string>
 	<!-- Settings «Map» category: «3D buildings» title -->
 	<string name="pref_map_3d_buildings_title">3D-gebouwen</string>
+	<!-- A message in Settings/Preferences explaining why is it not possible to enable 3D buildings when max power saving mode is enabled -->
+	<string name="pref_map_3d_buildings_disabled_summary">3D-gebouwen worden uitgeschakeld in de energiebesparende modus</string>
 	<!-- Settings «Route» category: «Tts enabled» title -->
 	<string name="pref_tts_enable_title">Gesproken instructies</string>
 	<!-- Settings «Route» category: «Tts language» title -->

--- a/android/res/values-pl/strings.xml
+++ b/android/res/values-pl/strings.xml
@@ -218,6 +218,8 @@
 	<string name="pref_map_3d_title">Widok z perspektywy</string>
 	<!-- Settings «Map» category: «3D buildings» title -->
 	<string name="pref_map_3d_buildings_title">Budynki w 3D</string>
+	<!-- A message in Settings/Preferences explaining why is it not possible to enable 3D buildings when max power saving mode is enabled -->
+	<string name="pref_map_3d_buildings_disabled_summary">Budynki 3D są wyłączone w trybie oszczędzania energii</string>
 	<!-- Settings «Route» category: «Tts enabled» title -->
 	<string name="pref_tts_enable_title">Komunikaty głosowe</string>
 	<!-- Settings «Route» category: «Tts language» title -->

--- a/android/res/values-pt-rBR/strings.xml
+++ b/android/res/values-pt-rBR/strings.xml
@@ -216,6 +216,8 @@
 	<string name="pref_map_3d_title">Visão em perspectiva</string>
 	<!-- Settings «Map» category: «3D buildings» title -->
 	<string name="pref_map_3d_buildings_title">Prédios em 3D</string>
+	<!-- A message in Settings/Preferences explaining why is it not possible to enable 3D buildings when max power saving mode is enabled -->
+	<string name="pref_map_3d_buildings_disabled_summary">Os edifícios 3D são desativados no modo de economia de energia</string>
 	<!-- Settings «Route» category: «Tts enabled» title -->
 	<string name="pref_tts_enable_title">Instruções de voz</string>
 	<!-- Settings «Route» category: «Tts language» title -->

--- a/android/res/values-pt/strings.xml
+++ b/android/res/values-pt/strings.xml
@@ -206,6 +206,8 @@
 	<string name="pref_map_3d_title">Visão em perspetiva</string>
 	<!-- Settings «Map» category: «3D buildings» title -->
 	<string name="pref_map_3d_buildings_title">Edifícios em 3D</string>
+	<!-- A message in Settings/Preferences explaining why is it not possible to enable 3D buildings when max power saving mode is enabled -->
+	<string name="pref_map_3d_buildings_disabled_summary">Os edifícios 3D são desativados no modo de poupança de energia</string>
 	<!-- Settings «Route» category: «Tts enabled» title -->
 	<string name="pref_tts_enable_title">Instruções de voz</string>
 	<!-- Settings «Route» category: «Tts language» title -->

--- a/android/res/values-ro/strings.xml
+++ b/android/res/values-ro/strings.xml
@@ -206,6 +206,8 @@
 	<string name="pref_map_3d_title">Vedere în perspectivă</string>
 	<!-- Settings «Map» category: «3D buildings» title -->
 	<string name="pref_map_3d_buildings_title">Clădiri 3D</string>
+	<!-- A message in Settings/Preferences explaining why is it not possible to enable 3D buildings when max power saving mode is enabled -->
+	<string name="pref_map_3d_buildings_disabled_summary">Clădirile 3D sunt oprite în modul de economisire a energiei</string>
 	<!-- Settings «Route» category: «Tts enabled» title -->
 	<string name="pref_tts_enable_title">Instrucțiuni vocale</string>
 	<!-- Settings «Route» category: «Tts language» title -->

--- a/android/res/values-ru/strings.xml
+++ b/android/res/values-ru/strings.xml
@@ -221,6 +221,8 @@
 	<string name="pref_map_3d_title">Перспективный вид</string>
 	<!-- Settings «Map» category: «3D buildings» title -->
 	<string name="pref_map_3d_buildings_title">3D здания</string>
+	<!-- A message in Settings/Preferences explaining why is it not possible to enable 3D buildings when max power saving mode is enabled -->
+	<string name="pref_map_3d_buildings_disabled_summary">3D-здания отключаются в режиме энергосбережения</string>
 	<!-- Settings «Route» category: «Tts enabled» title -->
 	<string name="pref_tts_enable_title">Голосовые инструкции</string>
 	<!-- Settings «Route» category: «Tts language» title -->

--- a/android/res/values-sk/strings.xml
+++ b/android/res/values-sk/strings.xml
@@ -201,6 +201,8 @@
 	<string name="pref_map_3d_title">Perspektívne zobrazenie</string>
 	<!-- Settings «Map» category: «3D buildings» title -->
 	<string name="pref_map_3d_buildings_title">3D budovy</string>
+	<!-- A message in Settings/Preferences explaining why is it not possible to enable 3D buildings when max power saving mode is enabled -->
+	<string name="pref_map_3d_buildings_disabled_summary">3D budovy sú vypnuté v režime úspory energie</string>
 	<!-- Settings «Route» category: «Tts enabled» title -->
 	<string name="pref_tts_enable_title">Hlasové povely</string>
 	<!-- Settings «Route» category: «Tts language» title -->

--- a/android/res/values-sv/strings.xml
+++ b/android/res/values-sv/strings.xml
@@ -199,6 +199,8 @@
 	<string name="pref_map_3d_title">Perspektivvy</string>
 	<!-- Settings «Map» category: «3D buildings» title -->
 	<string name="pref_map_3d_buildings_title">3D-byggnader</string>
+	<!-- A message in Settings/Preferences explaining why is it not possible to enable 3D buildings when max power saving mode is enabled -->
+	<string name="pref_map_3d_buildings_disabled_summary">3D-byggnader är avstängda i energisparläge</string>
 	<!-- Settings «Route» category: «Tts enabled» title -->
 	<string name="pref_tts_enable_title">Röstinstruktioner</string>
 	<!-- Settings «Route» category: «Tts language» title -->

--- a/android/res/values-sw/strings.xml
+++ b/android/res/values-sw/strings.xml
@@ -36,6 +36,8 @@
 	<string name="rv">Kwa RV</string>
 	<!-- Data version in «About» screen, %@ is replaced by a local, human readable date. -->
 	<string name="data_version">Data ya OpenStreetMap: %s</string>
+	<!-- A message in Settings/Preferences explaining why is it not possible to enable 3D buildings when max power saving mode is enabled -->
+	<string name="pref_map_3d_buildings_disabled_summary">Majengo ya 3D yamezimwa katika hali ya kuokoa nishati</string>
 	<!-- Text in About menu, opens Organic Maps news website -->
 	<string name="news">Habari</string>
 	<!-- Button in the main Help dialog -->

--- a/android/res/values-th/strings.xml
+++ b/android/res/values-th/strings.xml
@@ -203,6 +203,8 @@
 	<string name="pref_map_3d_title">มุมมองเพอร์สเปกทีฟ</string>
 	<!-- Settings «Map» category: «3D buildings» title -->
 	<string name="pref_map_3d_buildings_title">ตึก 3D</string>
+	<!-- A message in Settings/Preferences explaining why is it not possible to enable 3D buildings when max power saving mode is enabled -->
+	<string name="pref_map_3d_buildings_disabled_summary">สิ่งปลูกสร้าง 3 มิติจะปิดในโหมดประหยัดพลังงาน</string>
 	<!-- Settings «Route» category: «Tts enabled» title -->
 	<string name="pref_tts_enable_title">คำแนะนำด้วยเสียง</string>
 	<!-- Settings «Route» category: «Tts language» title -->

--- a/android/res/values-tr/strings.xml
+++ b/android/res/values-tr/strings.xml
@@ -220,6 +220,8 @@
 	<string name="pref_map_3d_title">Perspektif görünüm</string>
 	<!-- Settings «Map» category: «3D buildings» title -->
 	<string name="pref_map_3d_buildings_title">3D yapılar</string>
+	<!-- A message in Settings/Preferences explaining why is it not possible to enable 3D buildings when max power saving mode is enabled -->
+	<string name="pref_map_3d_buildings_disabled_summary">3D binalar güç tasarrufu modunda kapatılır</string>
 	<!-- Settings «Route» category: «Tts enabled» title -->
 	<string name="pref_tts_enable_title">Sesli Yönlendirme</string>
 	<!-- Settings «Route» category: «Tts language» title -->

--- a/android/res/values-uk/strings.xml
+++ b/android/res/values-uk/strings.xml
@@ -214,6 +214,8 @@
 	<string name="pref_map_3d_title">Перспективний вид</string>
 	<!-- Settings «Map» category: «3D buildings» title -->
 	<string name="pref_map_3d_buildings_title">Будівлі у 3D</string>
+	<!-- A message in Settings/Preferences explaining why is it not possible to enable 3D buildings when max power saving mode is enabled -->
+	<string name="pref_map_3d_buildings_disabled_summary">3D будівлі вимкнені в режимі енергозбереження</string>
 	<!-- Settings «Route» category: «Tts enabled» title -->
 	<string name="pref_tts_enable_title">Голосові інструкції</string>
 	<!-- Settings «Route» category: «Tts language» title -->

--- a/android/res/values-vi/strings.xml
+++ b/android/res/values-vi/strings.xml
@@ -201,6 +201,8 @@
 	<string name="pref_map_3d_title">Góc nhìn phối cảnh</string>
 	<!-- Settings «Map» category: «3D buildings» title -->
 	<string name="pref_map_3d_buildings_title">Nhà cửa 3D</string>
+	<!-- A message in Settings/Preferences explaining why is it not possible to enable 3D buildings when max power saving mode is enabled -->
+	<string name="pref_map_3d_buildings_disabled_summary">Tòa nhà 3D bị tắt ở chế độ tiết kiệm năng lượng</string>
 	<!-- Settings «Route» category: «Tts enabled» title -->
 	<string name="pref_tts_enable_title">Hướng dẫn bằng Giọng nói</string>
 	<!-- Settings «Route» category: «Tts language» title -->

--- a/android/res/values-zh-rTW/strings.xml
+++ b/android/res/values-zh-rTW/strings.xml
@@ -206,6 +206,8 @@
 	<string name="pref_map_3d_title">透視圖</string>
 	<!-- Settings «Map» category: «3D buildings» title -->
 	<string name="pref_map_3d_buildings_title">3D 建築</string>
+	<!-- A message in Settings/Preferences explaining why is it not possible to enable 3D buildings when max power saving mode is enabled -->
+	<string name="pref_map_3d_buildings_disabled_summary">3D 建築在省電模式下關閉</string>
 	<!-- Settings «Route» category: «Tts enabled» title -->
 	<string name="pref_tts_enable_title">語音指示</string>
 	<!-- Settings «Route» category: «Tts language» title -->

--- a/android/res/values-zh/strings.xml
+++ b/android/res/values-zh/strings.xml
@@ -205,6 +205,8 @@
 	<string name="pref_map_3d_title">透视图</string>
 	<!-- Settings «Map» category: «3D buildings» title -->
 	<string name="pref_map_3d_buildings_title">3D 建筑</string>
+	<!-- A message in Settings/Preferences explaining why is it not possible to enable 3D buildings when max power saving mode is enabled -->
+	<string name="pref_map_3d_buildings_disabled_summary">3D 建筑在省电模式下关闭</string>
 	<!-- Settings «Route» category: «Tts enabled» title -->
 	<string name="pref_tts_enable_title">语音指导</string>
 	<!-- Settings «Route» category: «Tts language» title -->

--- a/android/res/values/strings.xml
+++ b/android/res/values/strings.xml
@@ -221,6 +221,8 @@
 	<string name="pref_map_3d_title">Perspective view</string>
 	<!-- Settings «Map» category: «3D buildings» title -->
 	<string name="pref_map_3d_buildings_title">3D buildings</string>
+	<!-- A message in Settings/Preferences explaining why is it not possible to enable 3D buildings when max power saving mode is enabled -->
+	<string name="pref_map_3d_buildings_disabled_summary">3D buildings are turned off in power saving mode</string>
 	<!-- Settings «Route» category: «Tts enabled» title -->
 	<string name="pref_tts_enable_title">Voice Instructions</string>
 	<!-- Settings «Route» category: «Tts language» title -->

--- a/android/src/app/organicmaps/settings/BaseXmlSettingsFragment.java
+++ b/android/src/app/organicmaps/settings/BaseXmlSettingsFragment.java
@@ -4,9 +4,11 @@ import android.content.Context;
 import android.os.Bundle;
 import android.view.View;
 
+import androidx.annotation.NonNull;
 import androidx.annotation.Nullable;
 import androidx.annotation.XmlRes;
 import androidx.core.content.ContextCompat;
+import androidx.preference.Preference;
 import androidx.preference.PreferenceFragmentCompat;
 
 import app.organicmaps.R;
@@ -17,6 +19,14 @@ abstract class BaseXmlSettingsFragment extends PreferenceFragmentCompat
 {
   protected abstract @XmlRes int getXmlResources();
 
+  @NonNull
+  public <T extends Preference> T getPreference(@NonNull CharSequence key)
+  {
+    final T pref = findPreference(key);
+    if (pref == null)
+      throw new RuntimeException("Can't get preference by key: "+key);
+    return pref;
+  }
   @Override
   public void onCreatePreferences(Bundle bundle, String root)
   {

--- a/android/src/app/organicmaps/settings/SettingsPrefsFragment.java
+++ b/android/src/app/organicmaps/settings/SettingsPrefsFragment.java
@@ -1,6 +1,5 @@
 package app.organicmaps.settings;
 
-import android.annotation.SuppressLint;
 import android.content.Context;
 import android.content.Intent;
 import android.net.Uri;
@@ -72,7 +71,7 @@ public class SettingsPrefsFragment extends BaseXmlSettingsFragment
     @Override
     public boolean onPreferenceChange(Preference preference, Object newValue)
     {
-      Preference root = findPreference(getString(R.string.pref_tts_screen));
+      final Preference root = getPreference(getString(R.string.pref_tts_screen));
       boolean set = (Boolean)newValue;
       if (!set)
       {
@@ -84,8 +83,7 @@ public class SettingsPrefsFragment extends BaseXmlSettingsFragment
         if (mLangInfoLink != null && isOnTtsScreen())
           getPreferenceScreen().addPreference(mLangInfoLink);
 
-        if (root != null)
-          root.setSummary(R.string.off);
+        root.setSummary(R.string.off);
 
         if (mPrefEnabled != null)
           mPrefEnabled.setTitle(R.string.off);
@@ -94,8 +92,7 @@ public class SettingsPrefsFragment extends BaseXmlSettingsFragment
 
       if (mLangInfo != null)
         mLangInfo.setSummary(R.string.prefs_languages_information);
-      if (root != null)
-        root.setSummary(R.string.on);
+      root.setSummary(R.string.on);
       if (mPrefEnabled != null)
         mPrefEnabled.setTitle(R.string.on);
       if (mLangInfoLink != null)
@@ -127,10 +124,8 @@ public class SettingsPrefsFragment extends BaseXmlSettingsFragment
       if (lang.downloaded)
         setLanguage(lang);
       else
-      {
         UiUtils.startActivityForResult(SettingsPrefsFragment.this,
             new Intent(TextToSpeech.Engine.ACTION_INSTALL_TTS_DATA), REQUEST_INSTALL_DATA);
-      }
 
       return false;
     }
@@ -165,7 +160,7 @@ public class SettingsPrefsFragment extends BaseXmlSettingsFragment
     mLanguages.clear();
     mCurrentLanguage = null;
 
-    Preference root = findPreference(getString(R.string.pref_tts_screen));
+    final Preference root = getPreference(getString(R.string.pref_tts_screen));
 
     if (languages.isEmpty())
     {
@@ -178,8 +173,7 @@ public class SettingsPrefsFragment extends BaseXmlSettingsFragment
       mLangInfo.setSummary(R.string.prefs_languages_information_off);
       if (isOnTtsScreen())
         getPreferenceScreen().addPreference(mLangInfoLink);
-      if (root != null)
-        root.setSummary(R.string.off);
+      root.setSummary(R.string.off);
 
       enableListeners(true);
       return;
@@ -247,11 +241,11 @@ public class SettingsPrefsFragment extends BaseXmlSettingsFragment
   {
     super.onViewCreated(view, savedInstanceState);
     mPreferenceScreen = getPreferenceScreen();
-    mStoragePref = findPreference(getString(R.string.pref_storage));
-    mPrefEnabled = findPreference(getString(R.string.pref_tts_enabled));
-    mPrefLanguages = findPreference(getString(R.string.pref_tts_language));
-    mLangInfo = findPreference(getString(R.string.pref_tts_info));
-    mLangInfoLink = findPreference(getString(R.string.pref_tts_info_link));
+    mStoragePref = getPreference(getString(R.string.pref_storage));
+    mPrefEnabled = getPreference(getString(R.string.pref_tts_enabled));
+    mPrefLanguages = getPreference(getString(R.string.pref_tts_language));
+    mLangInfo = getPreference(getString(R.string.pref_tts_info));
+    mLangInfoLink = getPreference(getString(R.string.pref_tts_info_link));
     initLangInfoLink();
     initStoragePrefCallbacks();
     initMeasureUnitsPrefsCallbacks();
@@ -273,9 +267,8 @@ public class SettingsPrefsFragment extends BaseXmlSettingsFragment
     if (!playServices && !crashReports)
     {
       // Remove "Tracking" section completely.
-      PreferenceCategory tracking = findPreference(getString(R.string.pref_subtittle_opt_out));
-      if (tracking != null)
-        mPreferenceScreen.removePreference(tracking);
+      final PreferenceCategory tracking = getPreference(getString(R.string.pref_subtittle_opt_out));
+      mPreferenceScreen.removePreference(tracking);
     }
     initScreenSleepEnabledPrefsCallbacks();
     initShowOnLockScreenPrefsCallbacks();
@@ -285,10 +278,7 @@ public class SettingsPrefsFragment extends BaseXmlSettingsFragment
   private void initSpeedCamerasPrefs()
   {
     String key = getString(R.string.pref_speed_cameras);
-    final ListPreference pref = findPreference(key);
-    // TODO: check whether it's needed #2049
-    if (pref == null)
-      return;
+    final ListPreference pref = getPreference(key);
     pref.setSummary(pref.getEntry());
     pref.setOnPreferenceChangeListener(this::onSpeedCamerasPrefSelected);
   }
@@ -376,10 +366,7 @@ public class SettingsPrefsFragment extends BaseXmlSettingsFragment
 
   private void initLargeFontSizePrefsCallbacks()
   {
-    Preference pref = findPreference(getString(R.string.pref_large_fonts_size));
-    // TODO: check whether it's needed #2049
-    if (pref == null)
-      return;
+    final Preference pref = getPreference(getString(R.string.pref_large_fonts_size));
 
     ((TwoStatePreference)pref).setChecked(Config.isLargeFontsSize());
     pref.setOnPreferenceChangeListener(new Preference.OnPreferenceChangeListener()
@@ -399,10 +386,7 @@ public class SettingsPrefsFragment extends BaseXmlSettingsFragment
 
   private void initTransliterationPrefsCallbacks()
   {
-    Preference pref = findPreference(getString(R.string.pref_transliteration));
-    // TODO: check whether it's needed #2049
-    if (pref == null)
-      return;
+    final Preference pref = getPreference(getString(R.string.pref_transliteration));
 
     ((TwoStatePreference)pref).setChecked(Config.isTransliteration());
     pref.setOnPreferenceChangeListener(new Preference.OnPreferenceChangeListener()
@@ -422,10 +406,7 @@ public class SettingsPrefsFragment extends BaseXmlSettingsFragment
 
   private void initUseMobileDataPrefsCallbacks()
   {
-    final ListPreference mobilePref = findPreference(
-        getString(R.string.pref_use_mobile_data));
-    if (mobilePref == null)
-      return;
+    final ListPreference mobilePref = getPreference(getString(R.string.pref_use_mobile_data));
 
     NetworkPolicy.Type curValue = Config.getUseMobileDataSettings();
     if (curValue == NetworkPolicy.Type.NOT_TODAY || curValue == NetworkPolicy.Type.TODAY)
@@ -446,10 +427,7 @@ public class SettingsPrefsFragment extends BaseXmlSettingsFragment
 
   private void initPowerManagementPrefsCallbacks()
   {
-    final ListPreference powerManagementPref = findPreference(
-      getString(R.string.pref_power_management));
-    if (powerManagementPref == null)
-      return;
+    final ListPreference powerManagementPref = getPreference(getString(R.string.pref_power_management));
 
     @PowerManagment.SchemeType
     int curValue = PowerManagment.getScheme();
@@ -462,16 +440,15 @@ public class SettingsPrefsFragment extends BaseXmlSettingsFragment
 
       PowerManagment.setScheme(scheme);
 
+      disableOrEnable3DBuildingsForPowerMode(scheme);
+
       return true;
     });
   }
 
   private void initLoggingEnabledPrefsCallbacks()
   {
-    Preference pref = findPreference(getString(R.string.pref_enable_logging));
-    // TODO: check whether it's needed #2049
-    if (pref == null)
-      return;
+    final Preference pref = getPreference(getString(R.string.pref_enable_logging));
 
     ((TwoStatePreference) pref).setChecked(LogsManager.INSTANCE.isFileLoggingEnabled());
     pref.setOnPreferenceChangeListener((preference, newValue) -> {
@@ -487,10 +464,7 @@ public class SettingsPrefsFragment extends BaseXmlSettingsFragment
 
   private void initEmulationBadStorage()
   {
-    Preference pref = findPreference(getString(R.string.pref_emulate_bad_external_storage));
-    // TODO: check whether it's needed #2049
-    if (pref == null)
-      return;
+    final Preference pref = getPreference(getString(R.string.pref_emulate_bad_external_storage));
 
     if (!SharedPropertiesUtils.shouldShowEmulateBadStorageSetting(requireContext()))
       removePreference(getString(R.string.pref_settings_general), pref);
@@ -498,10 +472,7 @@ public class SettingsPrefsFragment extends BaseXmlSettingsFragment
 
   private void initAutoZoomPrefsCallbacks()
   {
-    final TwoStatePreference pref = findPreference(getString(R.string.pref_auto_zoom));
-    // TODO: check whether it's needed #2049
-    if (pref == null)
-      return;
+    final TwoStatePreference pref = getPreference(getString(R.string.pref_auto_zoom));
 
     boolean autozoomEnabled = Framework.nativeGetAutoZoomEnabled();
     pref.setChecked(autozoomEnabled);
@@ -518,10 +489,7 @@ public class SettingsPrefsFragment extends BaseXmlSettingsFragment
 
   private boolean initPlayServicesPrefsCallbacks()
   {
-    Preference pref = findPreference(getString(R.string.pref_play_services));
-    // TODO: check whether it's needed #2049
-    if (pref == null)
-      return false;
+    final Preference pref = getPreference(getString(R.string.pref_play_services));
 
     if (!LocationProviderFactory.isGoogleLocationAvailable(requireActivity().getApplicationContext()))
     {
@@ -552,15 +520,16 @@ public class SettingsPrefsFragment extends BaseXmlSettingsFragment
 
   private void init3dModePrefsCallbacks()
   {
-    final TwoStatePreference pref = findPreference(getString(R.string.pref_3d_buildings));
-    // TODO: check whether it's needed #2049
-    if (pref == null)
-      return;
+    final TwoStatePreference pref = getPreference(getString(R.string.pref_3d_buildings));
 
     final Framework.Params3dMode _3d = new Framework.Params3dMode();
     Framework.nativeGet3dMode(_3d);
 
-    pref.setChecked(_3d.buildings);
+    // Read power managements preference.
+    final ListPreference powerManagementPref = getPreference(getString(R.string.pref_power_management));
+    final String powerManagementValueStr = powerManagementPref.getValue();
+    final Integer powerManagementValue = (powerManagementValueStr!=null) ? Integer.parseInt(powerManagementValueStr) : null;
+    disableOrEnable3DBuildingsForPowerMode(powerManagementValue);
 
     pref.setOnPreferenceChangeListener(new Preference.OnPreferenceChangeListener()
     {
@@ -573,12 +542,33 @@ public class SettingsPrefsFragment extends BaseXmlSettingsFragment
     });
   }
 
+  // Argument `powerManagementValue` could be null on the first app run.
+  private void disableOrEnable3DBuildingsForPowerMode(@Nullable Integer powerManagementValue)
+  {
+    final TwoStatePreference pref = getPreference(getString(R.string.pref_3d_buildings));
+
+    if (powerManagementValue != null && powerManagementValue == PowerManagment.HIGH)
+    {
+      pref.setShouldDisableView(true);
+      pref.setEnabled(false);
+      pref.setSummary(getString(R.string.pref_map_3d_buildings_disabled_summary));
+      pref.setChecked(false);
+    }
+    else
+    {
+      final Framework.Params3dMode _3d = new Framework.Params3dMode();
+      Framework.nativeGet3dMode(_3d);
+
+      pref.setShouldDisableView(false);
+      pref.setEnabled(true);
+      pref.setSummary("");
+      pref.setChecked(_3d.buildings);
+    }
+  }
+
   private void initPerspectivePrefsCallbacks()
   {
-    final TwoStatePreference pref = findPreference(getString(R.string.pref_3d));
-    // TODO: check whether it's needed #2049
-    if (pref == null)
-      return;
+    final TwoStatePreference pref = getPreference(getString(R.string.pref_3d));
 
     final Framework.Params3dMode _3d = new Framework.Params3dMode();
     Framework.nativeGet3dMode(_3d);
@@ -598,10 +588,7 @@ public class SettingsPrefsFragment extends BaseXmlSettingsFragment
 
   private void initAutoDownloadPrefsCallbacks()
   {
-    TwoStatePreference pref = findPreference(getString(R.string.pref_autodownload));
-    // TODO: check whether it's needed #2049
-    if (pref == null)
-      return;
+    final TwoStatePreference pref = getPreference(getString(R.string.pref_autodownload));
 
     pref.setChecked(Config.isAutodownloadEnabled());
     pref.setOnPreferenceChangeListener(new Preference.OnPreferenceChangeListener()
@@ -622,10 +609,7 @@ public class SettingsPrefsFragment extends BaseXmlSettingsFragment
 
   private void initMapStylePrefsCallbacks()
   {
-    final ListPreference pref = findPreference(getString(R.string.pref_map_style));
-    // TODO: check whether it's needed #2049
-    if (pref == null)
-      return;
+    final ListPreference pref = getPreference(getString(R.string.pref_map_style));
 
     String curTheme = Config.getUiThemeSettings(requireContext());
     pref.setValue(curTheme);
@@ -650,10 +634,7 @@ public class SettingsPrefsFragment extends BaseXmlSettingsFragment
 
   private void initZoomPrefsCallbacks()
   {
-    Preference pref = findPreference(getString(R.string.pref_show_zoom_buttons));
-    // TODO: check whether it's needed #2049
-    if (pref == null)
-      return;
+    final Preference pref = getPreference(getString(R.string.pref_show_zoom_buttons));
 
     ((TwoStatePreference)pref).setChecked(Config.showZoomButtons());
     pref.setOnPreferenceChangeListener(new Preference.OnPreferenceChangeListener()
@@ -669,10 +650,7 @@ public class SettingsPrefsFragment extends BaseXmlSettingsFragment
 
   private void initMeasureUnitsPrefsCallbacks()
   {
-    Preference pref = findPreference(getString(R.string.pref_munits));
-    // TODO: check whether it's needed #2049
-    if (pref == null)
-      return;
+    final Preference pref = getPreference(getString(R.string.pref_munits));
 
     ((ListPreference)pref).setValue(String.valueOf(UnitLocale.getUnits()));
     pref.setOnPreferenceChangeListener(new Preference.OnPreferenceChangeListener()
@@ -716,11 +694,7 @@ public class SettingsPrefsFragment extends BaseXmlSettingsFragment
 
   private boolean initCrashReports()
   {
-    String key = getString(R.string.pref_crash_reports);
-    Preference pref = findPreference(key);
-    // TODO: check whether it's needed #2049
-    if (pref == null)
-      return false;
+    final Preference pref = getPreference(getString(R.string.pref_crash_reports));
 
     if (!CrashlyticsUtils.INSTANCE.isAvailable())
     {
@@ -735,10 +709,7 @@ public class SettingsPrefsFragment extends BaseXmlSettingsFragment
 
   private void initScreenSleepEnabledPrefsCallbacks()
   {
-    Preference pref = findPreference(getString(R.string.pref_screen_sleep));
-    // TODO: check whether it's needed #2049
-    if (pref == null)
-      return;
+    final Preference pref = getPreference(getString(R.string.pref_screen_sleep));
 
     final boolean isScreenSleepEnabled = Config.isScreenSleepEnabled();
     ((TwoStatePreference) pref).setChecked(isScreenSleepEnabled);
@@ -757,10 +728,7 @@ public class SettingsPrefsFragment extends BaseXmlSettingsFragment
 
   private void initShowOnLockScreenPrefsCallbacks()
   {
-    Preference pref = findPreference(getString(R.string.pref_show_on_lock_screen));
-    // TODO: check whether it's needed #2049
-    if (pref == null)
-      return;
+    final Preference pref = getPreference(getString(R.string.pref_show_on_lock_screen));
 
     final boolean isShowOnLockScreenEnabled = Config.isShowOnLockScreenEnabled();
     ((TwoStatePreference) pref).setChecked(isShowOnLockScreenEnabled);
@@ -779,10 +747,7 @@ public class SettingsPrefsFragment extends BaseXmlSettingsFragment
 
   private void removePreference(@NonNull String categoryKey, @NonNull Preference preference)
   {
-    PreferenceCategory category = findPreference(categoryKey);
-    // TODO: check whether it's needed #2049
-    if (category == null)
-      return;
+    final PreferenceCategory category = getPreference(categoryKey);
 
     category.removePreference(preference);
   }

--- a/data/strings/strings.txt
+++ b/data/strings/strings.txt
@@ -4774,6 +4774,48 @@
     zh-Hans = 3D 建筑
     zh-Hant = 3D 建築
 
+  [pref_map_3d_buildings_disabled_summary]
+    comment = A message in Settings/Preferences explaining why is it not possible to enable 3D buildings when max power saving mode is enabled
+    tags = android,ios
+    en = 3D buildings are turned off in power saving mode
+    ar = يتم إيقاف تشغيل المباني ثلاثية الأبعاد في وضع توفير الطاقة
+    be = У рэжыме энергазберажэння 3D-будынкі выключаны
+    bg = 3D сградите са изключени в режим на пестене на енергия
+    ca = Els edificis en 3D es desactiven en mode d'estalvi d'energia
+    cs = 3D budovy jsou vypnuty v úsporném režimu
+    da = 3D-bygninger er slukket i strømbesparende tilstand
+    de = 3D-Gebäude werden im Energiesparmodus ausgeschaltet
+    el = Τα τρισδιάστατα κτίρια απενεργοποιούνται σε λειτουργία εξοικονόμησης ενέργειας
+    es = Los edificios 3D se apagan en el modo de ahorro de energía
+    et = 3D-hooned lülitatakse energiasäästurežiimis välja
+    eu = 3D eraikinak itzalita daude energia aurrezteko moduan
+    fa = ساختمان های سه بعدی در حالت صرفه جویی در مصرف برق خاموش می شوند
+    fi = 3D-rakennukset sammutetaan virransäästötilassa
+    fr = Les bâtiments 3D sont désactivés en mode d'économie d'énergie
+    he = מבנים תלת מימדיים כבויים במצב חיסכון בחשמל
+    hu = A 3D épületek energiatakarékos módban ki vannak kapcsolva
+    id = Bangunan 3D dimatikan dalam mode hemat daya
+    it = Gli edifici 3D sono disattivati in modalità di risparmio energetico
+    ja = 省電力モードで建物の 3D 表示がオフになっている
+    ko = 3D 빌딩은 절전 모드에서 꺼집니다.
+    mr = 3D इमारती वीज बचत मोडमध्ये बंद केल्या आहेत
+    nb = 3D-bygninger er slått av i strømsparingsmodus
+    nl = 3D-gebouwen worden uitgeschakeld in de energiebesparende modus
+    pl = Budynki 3D są wyłączone w trybie oszczędzania energii
+    pt = Os edifícios 3D são desativados no modo de poupança de energia
+    pt-BR = Os edifícios 3D são desativados no modo de economia de energia
+    ro = Clădirile 3D sunt oprite în modul de economisire a energiei
+    ru = 3D-здания отключаются в режиме энергосбережения
+    sk = 3D budovy sú vypnuté v režime úspory energie
+    sv = 3D-byggnader är avstängda i energisparläge
+    sw = Majengo ya 3D yamezimwa katika hali ya kuokoa nishati
+    th = สิ่งปลูกสร้าง 3 มิติจะปิดในโหมดประหยัดพลังงาน
+    tr = 3D binalar güç tasarrufu modunda kapatılır
+    uk = 3D будівлі вимкнені в режимі енергозбереження
+    vi = Tòa nhà 3D bị tắt ở chế độ tiết kiệm năng lượng
+    zh-Hans = 3D 建筑在省电模式下关闭
+    zh-Hant = 3D 建築在省電模式下關閉
+
   [pref_tts_enable_title]
     comment = Settings «Route» category: «Tts enabled» title
     tags = android,ios

--- a/iphone/Maps/LocalizedStrings/ar.lproj/Localizable.strings
+++ b/iphone/Maps/LocalizedStrings/ar.lproj/Localizable.strings
@@ -226,6 +226,9 @@
 /* Settings «Map» category: «3D buildings» title */
 "pref_map_3d_buildings_title" = "مباني ثلاثية الأبعاد";
 
+/* A message in Settings/Preferences explaining why is it not possible to enable 3D buildings when max power saving mode is enabled */
+"pref_map_3d_buildings_disabled_summary" = "يتم إيقاف تشغيل المباني ثلاثية الأبعاد في وضع توفير الطاقة";
+
 /* Settings «Route» category: «Tts enabled» title */
 "pref_tts_enable_title" = "تعليمات صوتية";
 

--- a/iphone/Maps/LocalizedStrings/be.lproj/Localizable.strings
+++ b/iphone/Maps/LocalizedStrings/be.lproj/Localizable.strings
@@ -226,6 +226,9 @@
 /* Settings «Map» category: «3D buildings» title */
 "pref_map_3d_buildings_title" = "3D будынкі";
 
+/* A message in Settings/Preferences explaining why is it not possible to enable 3D buildings when max power saving mode is enabled */
+"pref_map_3d_buildings_disabled_summary" = "У рэжыме энергазберажэння 3D-будынкі выключаны";
+
 /* Settings «Route» category: «Tts enabled» title */
 "pref_tts_enable_title" = "Галасавыя інструкцыі";
 

--- a/iphone/Maps/LocalizedStrings/bg.lproj/Localizable.strings
+++ b/iphone/Maps/LocalizedStrings/bg.lproj/Localizable.strings
@@ -226,6 +226,9 @@
 /* Settings «Map» category: «3D buildings» title */
 "pref_map_3d_buildings_title" = "3D сгради";
 
+/* A message in Settings/Preferences explaining why is it not possible to enable 3D buildings when max power saving mode is enabled */
+"pref_map_3d_buildings_disabled_summary" = "3D сградите са изключени в режим на пестене на енергия";
+
 /* Settings «Route» category: «Tts enabled» title */
 "pref_tts_enable_title" = "Гласови инструкции";
 

--- a/iphone/Maps/LocalizedStrings/ca.lproj/Localizable.strings
+++ b/iphone/Maps/LocalizedStrings/ca.lproj/Localizable.strings
@@ -226,6 +226,9 @@
 /* Settings «Map» category: «3D buildings» title */
 "pref_map_3d_buildings_title" = "Edificis en 3D";
 
+/* A message in Settings/Preferences explaining why is it not possible to enable 3D buildings when max power saving mode is enabled */
+"pref_map_3d_buildings_disabled_summary" = "Els edificis en 3D es desactiven en mode d'estalvi d'energia";
+
 /* Settings «Route» category: «Tts enabled» title */
 "pref_tts_enable_title" = "Instruccions de veu";
 

--- a/iphone/Maps/LocalizedStrings/cs.lproj/Localizable.strings
+++ b/iphone/Maps/LocalizedStrings/cs.lproj/Localizable.strings
@@ -226,6 +226,9 @@
 /* Settings «Map» category: «3D buildings» title */
 "pref_map_3d_buildings_title" = "3D budovy";
 
+/* A message in Settings/Preferences explaining why is it not possible to enable 3D buildings when max power saving mode is enabled */
+"pref_map_3d_buildings_disabled_summary" = "3D budovy jsou vypnuty v úsporném režimu";
+
 /* Settings «Route» category: «Tts enabled» title */
 "pref_tts_enable_title" = "Hlasové instrukce";
 

--- a/iphone/Maps/LocalizedStrings/da.lproj/Localizable.strings
+++ b/iphone/Maps/LocalizedStrings/da.lproj/Localizable.strings
@@ -226,6 +226,9 @@
 /* Settings «Map» category: «3D buildings» title */
 "pref_map_3d_buildings_title" = "3D-bygninger";
 
+/* A message in Settings/Preferences explaining why is it not possible to enable 3D buildings when max power saving mode is enabled */
+"pref_map_3d_buildings_disabled_summary" = "3D-bygninger er slukket i strømbesparende tilstand";
+
 /* Settings «Route» category: «Tts enabled» title */
 "pref_tts_enable_title" = "Stemmeinstruktioner";
 

--- a/iphone/Maps/LocalizedStrings/de.lproj/Localizable.strings
+++ b/iphone/Maps/LocalizedStrings/de.lproj/Localizable.strings
@@ -226,6 +226,9 @@
 /* Settings «Map» category: «3D buildings» title */
 "pref_map_3d_buildings_title" = "3D-Gebäude";
 
+/* A message in Settings/Preferences explaining why is it not possible to enable 3D buildings when max power saving mode is enabled */
+"pref_map_3d_buildings_disabled_summary" = "3D-Gebäude werden im Energiesparmodus ausgeschaltet";
+
 /* Settings «Route» category: «Tts enabled» title */
 "pref_tts_enable_title" = "Sprachführung";
 

--- a/iphone/Maps/LocalizedStrings/el.lproj/Localizable.strings
+++ b/iphone/Maps/LocalizedStrings/el.lproj/Localizable.strings
@@ -226,6 +226,9 @@
 /* Settings «Map» category: «3D buildings» title */
 "pref_map_3d_buildings_title" = "Τρισδιάστατα κτίρια";
 
+/* A message in Settings/Preferences explaining why is it not possible to enable 3D buildings when max power saving mode is enabled */
+"pref_map_3d_buildings_disabled_summary" = "Τα τρισδιάστατα κτίρια απενεργοποιούνται σε λειτουργία εξοικονόμησης ενέργειας";
+
 /* Settings «Route» category: «Tts enabled» title */
 "pref_tts_enable_title" = "Φωνητικές οδηγίες";
 

--- a/iphone/Maps/LocalizedStrings/en-GB.lproj/Localizable.strings
+++ b/iphone/Maps/LocalizedStrings/en-GB.lproj/Localizable.strings
@@ -226,6 +226,9 @@
 /* Settings «Map» category: «3D buildings» title */
 "pref_map_3d_buildings_title" = "3D buildings";
 
+/* A message in Settings/Preferences explaining why is it not possible to enable 3D buildings when max power saving mode is enabled */
+"pref_map_3d_buildings_disabled_summary" = "3D buildings are turned off in power saving mode";
+
 /* Settings «Route» category: «Tts enabled» title */
 "pref_tts_enable_title" = "Voice Instructions";
 

--- a/iphone/Maps/LocalizedStrings/en.lproj/Localizable.strings
+++ b/iphone/Maps/LocalizedStrings/en.lproj/Localizable.strings
@@ -226,6 +226,9 @@
 /* Settings «Map» category: «3D buildings» title */
 "pref_map_3d_buildings_title" = "3D buildings";
 
+/* A message in Settings/Preferences explaining why is it not possible to enable 3D buildings when max power saving mode is enabled */
+"pref_map_3d_buildings_disabled_summary" = "3D buildings are turned off in power saving mode";
+
 /* Settings «Route» category: «Tts enabled» title */
 "pref_tts_enable_title" = "Voice Instructions";
 

--- a/iphone/Maps/LocalizedStrings/es-MX.lproj/Localizable.strings
+++ b/iphone/Maps/LocalizedStrings/es-MX.lproj/Localizable.strings
@@ -226,6 +226,9 @@
 /* Settings «Map» category: «3D buildings» title */
 "pref_map_3d_buildings_title" = "Edificios en 3D";
 
+/* A message in Settings/Preferences explaining why is it not possible to enable 3D buildings when max power saving mode is enabled */
+"pref_map_3d_buildings_disabled_summary" = "Los edificios 3D se apagan en el modo de ahorro de energía";
+
 /* Settings «Route» category: «Tts enabled» title */
 "pref_tts_enable_title" = "Instrucciones de voz";
 

--- a/iphone/Maps/LocalizedStrings/es.lproj/Localizable.strings
+++ b/iphone/Maps/LocalizedStrings/es.lproj/Localizable.strings
@@ -226,6 +226,9 @@
 /* Settings «Map» category: «3D buildings» title */
 "pref_map_3d_buildings_title" = "Edificios en 3D";
 
+/* A message in Settings/Preferences explaining why is it not possible to enable 3D buildings when max power saving mode is enabled */
+"pref_map_3d_buildings_disabled_summary" = "Los edificios 3D se apagan en el modo de ahorro de energía";
+
 /* Settings «Route» category: «Tts enabled» title */
 "pref_tts_enable_title" = "Instrucciones de voz";
 

--- a/iphone/Maps/LocalizedStrings/et.lproj/Localizable.strings
+++ b/iphone/Maps/LocalizedStrings/et.lproj/Localizable.strings
@@ -226,6 +226,9 @@
 /* Settings «Map» category: «3D buildings» title */
 "pref_map_3d_buildings_title" = "3D hooned";
 
+/* A message in Settings/Preferences explaining why is it not possible to enable 3D buildings when max power saving mode is enabled */
+"pref_map_3d_buildings_disabled_summary" = "3D-hooned lülitatakse energiasäästurežiimis välja";
+
 /* Settings «Route» category: «Tts enabled» title */
 "pref_tts_enable_title" = "Hääljuhised";
 

--- a/iphone/Maps/LocalizedStrings/eu.lproj/Localizable.strings
+++ b/iphone/Maps/LocalizedStrings/eu.lproj/Localizable.strings
@@ -226,6 +226,9 @@
 /* Settings «Map» category: «3D buildings» title */
 "pref_map_3d_buildings_title" = "3D eraikinak";
 
+/* A message in Settings/Preferences explaining why is it not possible to enable 3D buildings when max power saving mode is enabled */
+"pref_map_3d_buildings_disabled_summary" = "3D eraikinak itzalita daude energia aurrezteko moduan";
+
 /* Settings «Route» category: «Tts enabled» title */
 "pref_tts_enable_title" = "Ahots argibideak";
 

--- a/iphone/Maps/LocalizedStrings/fa.lproj/Localizable.strings
+++ b/iphone/Maps/LocalizedStrings/fa.lproj/Localizable.strings
@@ -226,6 +226,9 @@
 /* Settings «Map» category: «3D buildings» title */
 "pref_map_3d_buildings_title" = "ساختمان‌های سه بعدی";
 
+/* A message in Settings/Preferences explaining why is it not possible to enable 3D buildings when max power saving mode is enabled */
+"pref_map_3d_buildings_disabled_summary" = "ساختمان های سه بعدی در حالت صرفه جویی در مصرف برق خاموش می شوند";
+
 /* Settings «Route» category: «Tts enabled» title */
 "pref_tts_enable_title" = "دستور العمل صوتی";
 

--- a/iphone/Maps/LocalizedStrings/fi.lproj/Localizable.strings
+++ b/iphone/Maps/LocalizedStrings/fi.lproj/Localizable.strings
@@ -226,6 +226,9 @@
 /* Settings «Map» category: «3D buildings» title */
 "pref_map_3d_buildings_title" = "3D-rakennukset";
 
+/* A message in Settings/Preferences explaining why is it not possible to enable 3D buildings when max power saving mode is enabled */
+"pref_map_3d_buildings_disabled_summary" = "3D-rakennukset sammutetaan virransäästötilassa";
+
 /* Settings «Route» category: «Tts enabled» title */
 "pref_tts_enable_title" = "Ääniohjeistukset";
 

--- a/iphone/Maps/LocalizedStrings/fr.lproj/Localizable.strings
+++ b/iphone/Maps/LocalizedStrings/fr.lproj/Localizable.strings
@@ -226,6 +226,9 @@
 /* Settings «Map» category: «3D buildings» title */
 "pref_map_3d_buildings_title" = "Bâtiments en 3D";
 
+/* A message in Settings/Preferences explaining why is it not possible to enable 3D buildings when max power saving mode is enabled */
+"pref_map_3d_buildings_disabled_summary" = "Les bâtiments 3D sont désactivés en mode d'économie d'énergie";
+
 /* Settings «Route» category: «Tts enabled» title */
 "pref_tts_enable_title" = "Instructions vocales";
 

--- a/iphone/Maps/LocalizedStrings/he.lproj/Localizable.strings
+++ b/iphone/Maps/LocalizedStrings/he.lproj/Localizable.strings
@@ -226,6 +226,9 @@
 /* Settings «Map» category: «3D buildings» title */
 "pref_map_3d_buildings_title" = "3D buildings";
 
+/* A message in Settings/Preferences explaining why is it not possible to enable 3D buildings when max power saving mode is enabled */
+"pref_map_3d_buildings_disabled_summary" = "מבנים תלת מימדיים כבויים במצב חיסכון בחשמל";
+
 /* Settings «Route» category: «Tts enabled» title */
 "pref_tts_enable_title" = "Voice Instructions";
 

--- a/iphone/Maps/LocalizedStrings/hu.lproj/Localizable.strings
+++ b/iphone/Maps/LocalizedStrings/hu.lproj/Localizable.strings
@@ -226,6 +226,9 @@
 /* Settings «Map» category: «3D buildings» title */
 "pref_map_3d_buildings_title" = "3D-s épületek";
 
+/* A message in Settings/Preferences explaining why is it not possible to enable 3D buildings when max power saving mode is enabled */
+"pref_map_3d_buildings_disabled_summary" = "A 3D épületek energiatakarékos módban ki vannak kapcsolva";
+
 /* Settings «Route» category: «Tts enabled» title */
 "pref_tts_enable_title" = "Hangutasítások";
 

--- a/iphone/Maps/LocalizedStrings/id.lproj/Localizable.strings
+++ b/iphone/Maps/LocalizedStrings/id.lproj/Localizable.strings
@@ -226,6 +226,9 @@
 /* Settings «Map» category: «3D buildings» title */
 "pref_map_3d_buildings_title" = "Bangunan 3D";
 
+/* A message in Settings/Preferences explaining why is it not possible to enable 3D buildings when max power saving mode is enabled */
+"pref_map_3d_buildings_disabled_summary" = "Bangunan 3D dimatikan dalam mode hemat daya";
+
 /* Settings «Route» category: «Tts enabled» title */
 "pref_tts_enable_title" = "Petunjuk Suara";
 

--- a/iphone/Maps/LocalizedStrings/it.lproj/Localizable.strings
+++ b/iphone/Maps/LocalizedStrings/it.lproj/Localizable.strings
@@ -226,6 +226,9 @@
 /* Settings «Map» category: «3D buildings» title */
 "pref_map_3d_buildings_title" = "Edifici 3D";
 
+/* A message in Settings/Preferences explaining why is it not possible to enable 3D buildings when max power saving mode is enabled */
+"pref_map_3d_buildings_disabled_summary" = "Gli edifici 3D sono disattivati in modalità di risparmio energetico";
+
 /* Settings «Route» category: «Tts enabled» title */
 "pref_tts_enable_title" = "Istruzioni vocali";
 

--- a/iphone/Maps/LocalizedStrings/ja.lproj/Localizable.strings
+++ b/iphone/Maps/LocalizedStrings/ja.lproj/Localizable.strings
@@ -226,6 +226,9 @@
 /* Settings «Map» category: «3D buildings» title */
 "pref_map_3d_buildings_title" = "3Dビルディング";
 
+/* A message in Settings/Preferences explaining why is it not possible to enable 3D buildings when max power saving mode is enabled */
+"pref_map_3d_buildings_disabled_summary" = "省電力モードで建物の 3D 表示がオフになっている";
+
 /* Settings «Route» category: «Tts enabled» title */
 "pref_tts_enable_title" = "音声指示";
 

--- a/iphone/Maps/LocalizedStrings/ko.lproj/Localizable.strings
+++ b/iphone/Maps/LocalizedStrings/ko.lproj/Localizable.strings
@@ -226,6 +226,9 @@
 /* Settings «Map» category: «3D buildings» title */
 "pref_map_3d_buildings_title" = "주변 건물 3D";
 
+/* A message in Settings/Preferences explaining why is it not possible to enable 3D buildings when max power saving mode is enabled */
+"pref_map_3d_buildings_disabled_summary" = "3D 빌딩은 절전 모드에서 꺼집니다.";
+
 /* Settings «Route» category: «Tts enabled» title */
 "pref_tts_enable_title" = "음성 지침";
 

--- a/iphone/Maps/LocalizedStrings/mr.lproj/Localizable.strings
+++ b/iphone/Maps/LocalizedStrings/mr.lproj/Localizable.strings
@@ -226,6 +226,9 @@
 /* Settings «Map» category: «3D buildings» title */
 "pref_map_3d_buildings_title" = "त्रिमिती (3D) इमारती";
 
+/* A message in Settings/Preferences explaining why is it not possible to enable 3D buildings when max power saving mode is enabled */
+"pref_map_3d_buildings_disabled_summary" = "3D इमारती वीज बचत मोडमध्ये बंद केल्या आहेत";
+
 /* Settings «Route» category: «Tts enabled» title */
 "pref_tts_enable_title" = "ध्वनी सूचना";
 

--- a/iphone/Maps/LocalizedStrings/nb.lproj/Localizable.strings
+++ b/iphone/Maps/LocalizedStrings/nb.lproj/Localizable.strings
@@ -226,6 +226,9 @@
 /* Settings «Map» category: «3D buildings» title */
 "pref_map_3d_buildings_title" = "Bygninger i 3D";
 
+/* A message in Settings/Preferences explaining why is it not possible to enable 3D buildings when max power saving mode is enabled */
+"pref_map_3d_buildings_disabled_summary" = "3D-bygninger er slått av i strømsparingsmodus";
+
 /* Settings «Route» category: «Tts enabled» title */
 "pref_tts_enable_title" = "Taleinstrukser";
 

--- a/iphone/Maps/LocalizedStrings/nl.lproj/Localizable.strings
+++ b/iphone/Maps/LocalizedStrings/nl.lproj/Localizable.strings
@@ -226,6 +226,9 @@
 /* Settings «Map» category: «3D buildings» title */
 "pref_map_3d_buildings_title" = "3D-gebouwen";
 
+/* A message in Settings/Preferences explaining why is it not possible to enable 3D buildings when max power saving mode is enabled */
+"pref_map_3d_buildings_disabled_summary" = "3D-gebouwen worden uitgeschakeld in de energiebesparende modus";
+
 /* Settings «Route» category: «Tts enabled» title */
 "pref_tts_enable_title" = "Gesproken instructies";
 

--- a/iphone/Maps/LocalizedStrings/pl.lproj/Localizable.strings
+++ b/iphone/Maps/LocalizedStrings/pl.lproj/Localizable.strings
@@ -226,6 +226,9 @@
 /* Settings «Map» category: «3D buildings» title */
 "pref_map_3d_buildings_title" = "Budynki w 3D";
 
+/* A message in Settings/Preferences explaining why is it not possible to enable 3D buildings when max power saving mode is enabled */
+"pref_map_3d_buildings_disabled_summary" = "Budynki 3D są wyłączone w trybie oszczędzania energii";
+
 /* Settings «Route» category: «Tts enabled» title */
 "pref_tts_enable_title" = "Komunikaty głosowe";
 

--- a/iphone/Maps/LocalizedStrings/pt-BR.lproj/Localizable.strings
+++ b/iphone/Maps/LocalizedStrings/pt-BR.lproj/Localizable.strings
@@ -226,6 +226,9 @@
 /* Settings «Map» category: «3D buildings» title */
 "pref_map_3d_buildings_title" = "Prédios em 3D";
 
+/* A message in Settings/Preferences explaining why is it not possible to enable 3D buildings when max power saving mode is enabled */
+"pref_map_3d_buildings_disabled_summary" = "Os edifícios 3D são desativados no modo de economia de energia";
+
 /* Settings «Route» category: «Tts enabled» title */
 "pref_tts_enable_title" = "Instruções de voz";
 
@@ -1548,7 +1551,7 @@
 
 "type.barrier.chain" = "Chain";
 
-"type.barrier.city_wall" = "Muralha";
+"type.barrier.city_wall" = "City Wall";
 
 "type.barrier.cycle_barrier" = "Barreira de bicicletas";
 

--- a/iphone/Maps/LocalizedStrings/pt.lproj/Localizable.strings
+++ b/iphone/Maps/LocalizedStrings/pt.lproj/Localizable.strings
@@ -226,6 +226,9 @@
 /* Settings «Map» category: «3D buildings» title */
 "pref_map_3d_buildings_title" = "Edifícios em 3D";
 
+/* A message in Settings/Preferences explaining why is it not possible to enable 3D buildings when max power saving mode is enabled */
+"pref_map_3d_buildings_disabled_summary" = "Os edifícios 3D são desativados no modo de poupança de energia";
+
 /* Settings «Route» category: «Tts enabled» title */
 "pref_tts_enable_title" = "Instruções de voz";
 

--- a/iphone/Maps/LocalizedStrings/ro.lproj/Localizable.strings
+++ b/iphone/Maps/LocalizedStrings/ro.lproj/Localizable.strings
@@ -226,6 +226,9 @@
 /* Settings «Map» category: «3D buildings» title */
 "pref_map_3d_buildings_title" = "Clădiri 3D";
 
+/* A message in Settings/Preferences explaining why is it not possible to enable 3D buildings when max power saving mode is enabled */
+"pref_map_3d_buildings_disabled_summary" = "Clădirile 3D sunt oprite în modul de economisire a energiei";
+
 /* Settings «Route» category: «Tts enabled» title */
 "pref_tts_enable_title" = "Instrucțiuni vocale";
 

--- a/iphone/Maps/LocalizedStrings/ru.lproj/Localizable.strings
+++ b/iphone/Maps/LocalizedStrings/ru.lproj/Localizable.strings
@@ -226,6 +226,9 @@
 /* Settings «Map» category: «3D buildings» title */
 "pref_map_3d_buildings_title" = "3D здания";
 
+/* A message in Settings/Preferences explaining why is it not possible to enable 3D buildings when max power saving mode is enabled */
+"pref_map_3d_buildings_disabled_summary" = "3D-здания отключаются в режиме энергосбережения";
+
 /* Settings «Route» category: «Tts enabled» title */
 "pref_tts_enable_title" = "Голосовые инструкции";
 

--- a/iphone/Maps/LocalizedStrings/sk.lproj/Localizable.strings
+++ b/iphone/Maps/LocalizedStrings/sk.lproj/Localizable.strings
@@ -226,6 +226,9 @@
 /* Settings «Map» category: «3D buildings» title */
 "pref_map_3d_buildings_title" = "3D budovy";
 
+/* A message in Settings/Preferences explaining why is it not possible to enable 3D buildings when max power saving mode is enabled */
+"pref_map_3d_buildings_disabled_summary" = "3D budovy sú vypnuté v režime úspory energie";
+
 /* Settings «Route» category: «Tts enabled» title */
 "pref_tts_enable_title" = "Hlasové povely";
 

--- a/iphone/Maps/LocalizedStrings/sv.lproj/Localizable.strings
+++ b/iphone/Maps/LocalizedStrings/sv.lproj/Localizable.strings
@@ -226,6 +226,9 @@
 /* Settings «Map» category: «3D buildings» title */
 "pref_map_3d_buildings_title" = "3D-byggnader";
 
+/* A message in Settings/Preferences explaining why is it not possible to enable 3D buildings when max power saving mode is enabled */
+"pref_map_3d_buildings_disabled_summary" = "3D-byggnader är avstängda i energisparläge";
+
 /* Settings «Route» category: «Tts enabled» title */
 "pref_tts_enable_title" = "Röstinstruktioner";
 

--- a/iphone/Maps/LocalizedStrings/sw.lproj/Localizable.strings
+++ b/iphone/Maps/LocalizedStrings/sw.lproj/Localizable.strings
@@ -226,6 +226,9 @@
 /* Settings «Map» category: «3D buildings» title */
 "pref_map_3d_buildings_title" = "3D buildings";
 
+/* A message in Settings/Preferences explaining why is it not possible to enable 3D buildings when max power saving mode is enabled */
+"pref_map_3d_buildings_disabled_summary" = "Majengo ya 3D yamezimwa katika hali ya kuokoa nishati";
+
 /* Settings «Route» category: «Tts enabled» title */
 "pref_tts_enable_title" = "Voice Instructions";
 

--- a/iphone/Maps/LocalizedStrings/th.lproj/Localizable.strings
+++ b/iphone/Maps/LocalizedStrings/th.lproj/Localizable.strings
@@ -226,6 +226,9 @@
 /* Settings «Map» category: «3D buildings» title */
 "pref_map_3d_buildings_title" = "ตึก 3D";
 
+/* A message in Settings/Preferences explaining why is it not possible to enable 3D buildings when max power saving mode is enabled */
+"pref_map_3d_buildings_disabled_summary" = "สิ่งปลูกสร้าง 3 มิติจะปิดในโหมดประหยัดพลังงาน";
+
 /* Settings «Route» category: «Tts enabled» title */
 "pref_tts_enable_title" = "คำแนะนำด้วยเสียง";
 

--- a/iphone/Maps/LocalizedStrings/tr.lproj/Localizable.strings
+++ b/iphone/Maps/LocalizedStrings/tr.lproj/Localizable.strings
@@ -226,6 +226,9 @@
 /* Settings «Map» category: «3D buildings» title */
 "pref_map_3d_buildings_title" = "3D yapılar";
 
+/* A message in Settings/Preferences explaining why is it not possible to enable 3D buildings when max power saving mode is enabled */
+"pref_map_3d_buildings_disabled_summary" = "3D binalar güç tasarrufu modunda kapatılır";
+
 /* Settings «Route» category: «Tts enabled» title */
 "pref_tts_enable_title" = "Sesli Yönlendirme";
 

--- a/iphone/Maps/LocalizedStrings/uk.lproj/Localizable.strings
+++ b/iphone/Maps/LocalizedStrings/uk.lproj/Localizable.strings
@@ -226,6 +226,9 @@
 /* Settings «Map» category: «3D buildings» title */
 "pref_map_3d_buildings_title" = "Будівлі у 3D";
 
+/* A message in Settings/Preferences explaining why is it not possible to enable 3D buildings when max power saving mode is enabled */
+"pref_map_3d_buildings_disabled_summary" = "3D будівлі вимкнені в режимі енергозбереження";
+
 /* Settings «Route» category: «Tts enabled» title */
 "pref_tts_enable_title" = "Голосові інструкції";
 

--- a/iphone/Maps/LocalizedStrings/vi.lproj/Localizable.strings
+++ b/iphone/Maps/LocalizedStrings/vi.lproj/Localizable.strings
@@ -226,6 +226,9 @@
 /* Settings «Map» category: «3D buildings» title */
 "pref_map_3d_buildings_title" = "Nhà cửa 3D";
 
+/* A message in Settings/Preferences explaining why is it not possible to enable 3D buildings when max power saving mode is enabled */
+"pref_map_3d_buildings_disabled_summary" = "Tòa nhà 3D bị tắt ở chế độ tiết kiệm năng lượng";
+
 /* Settings «Route» category: «Tts enabled» title */
 "pref_tts_enable_title" = "Hướng dẫn bằng Giọng nói";
 

--- a/iphone/Maps/LocalizedStrings/zh-Hans.lproj/Localizable.strings
+++ b/iphone/Maps/LocalizedStrings/zh-Hans.lproj/Localizable.strings
@@ -226,6 +226,9 @@
 /* Settings «Map» category: «3D buildings» title */
 "pref_map_3d_buildings_title" = "3D 建筑";
 
+/* A message in Settings/Preferences explaining why is it not possible to enable 3D buildings when max power saving mode is enabled */
+"pref_map_3d_buildings_disabled_summary" = "3D 建筑在省电模式下关闭";
+
 /* Settings «Route» category: «Tts enabled» title */
 "pref_tts_enable_title" = "语音指导";
 

--- a/iphone/Maps/LocalizedStrings/zh-Hant.lproj/Localizable.strings
+++ b/iphone/Maps/LocalizedStrings/zh-Hant.lproj/Localizable.strings
@@ -226,6 +226,9 @@
 /* Settings «Map» category: «3D buildings» title */
 "pref_map_3d_buildings_title" = "3D 建築";
 
+/* A message in Settings/Preferences explaining why is it not possible to enable 3D buildings when max power saving mode is enabled */
+"pref_map_3d_buildings_disabled_summary" = "3D 建築在省電模式下關閉";
+
 /* Settings «Route» category: «Tts enabled» title */
 "pref_tts_enable_title" = "語音指示";
 

--- a/iphone/Maps/UI/Settings/MWMSettingsViewController.mm
+++ b/iphone/Maps/UI/Settings/MWMSettingsViewController.mm
@@ -72,7 +72,21 @@ using namespace power_management;
 
   bool on = true, _ = true;
   GetFramework().Load3dMode(_, on);
-  [self.is3dCell configWithDelegate:self title:L(@"pref_map_3d_buildings_title") isOn:on];
+  if (GetFramework().GetPowerManager().GetScheme() == Scheme::EconomyMaximum)
+  {
+    self.is3dCell.isEnabled = false;
+    [self.is3dCell configWithDelegate:self title:L(@"pref_map_3d_buildings_title") isOn:false];
+    UITapGestureRecognizer* tapRecogniser = [[UITapGestureRecognizer alloc] initWithTarget:self
+                                                            action:@selector(show3dBuildingsAlert:)];
+
+    self.is3dCell.gestureRecognizers = @[tapRecogniser];
+  }
+  else
+  {
+    self.is3dCell.isEnabled = true;
+    [self.is3dCell configWithDelegate:self title:L(@"pref_map_3d_buildings_title") isOn:on];
+    self.is3dCell.gestureRecognizers = nil;
+  }
 
   [self.autoDownloadCell configWithDelegate:self
                                       title:L(@"autodownload")
@@ -148,6 +162,20 @@ using namespace power_management;
   [self.compassCalibrationCell configWithDelegate:self
                                             title:L(@"pref_calibration_title")
                                              isOn:[MWMSettings compassCalibrationEnabled]];
+}
+
+- (void)show3dBuildingsAlert:(UITapGestureRecognizer *)recognizer {
+  UIAlertController *alert =
+  [UIAlertController alertControllerWithTitle:L(@"pref_map_3d_buildings_title")
+                                      message:L(@"pref_map_3d_buildings_disabled_summary")
+                               preferredStyle:UIAlertControllerStyleAlert];
+
+  UIAlertAction *okButton = [UIAlertAction actionWithTitle:@"OK"
+                                                      style:UIAlertActionStyleDefault
+                                                    handler:nil];
+  [alert addAction:okButton];
+
+  [self presentViewController:alert animated:YES completion:nil];
 }
 
 - (void)configNavigationSection {


### PR DESCRIPTION
Closes #3446.

"3D Buildings" settings is disabled when power saving mode is enabled.

https://user-images.githubusercontent.com/720808/222982765-c99c9a5a-e83b-4f47-8676-384ed57c0194.mov

https://user-images.githubusercontent.com/720808/222982776-c870834a-8074-46e3-a7b5-e26c99b86154.mov


### Questiones:

1. iOS has no summary in settings to tell why 3D buildings option is disabled. Don't know how to add it.
2. Android setting label is not greyed out for disabled settings. I searched for solution and most of advises propose to create custom layout and apply styles to it.
3. New string `"pref_map_3d_buildings_disabled_summary"` needs translations.

## Update 2023-03-07

Instead of nullable method `findReference(key)` introduced NonNull method `getReference(key)`. Method `findReference(key)` could return `null` if key is not found in `prefs_main.xml`. Invalid key means error and should fail as soon as possible.

This closes #2049.


## Update 2023-03-07 number 2

Added alert on iOS setting tap:

https://user-images.githubusercontent.com/720808/223463253-2616932c-a7f0-4c24-a5c6-06ce90866a8f.mov