### PR TITLE
  [iOS] long press to copy wiki description

### DIFF
--- a/iphone/Maps/UI/PlacePage/Components/WikiDescriptionViewController.swift
+++ b/iphone/Maps/UI/PlacePage/Components/WikiDescriptionViewController.swift
@@ -18,6 +18,16 @@ class WikiDescriptionViewController: UIViewController {
 
     descriptionTextView.textContainerInset = .zero
     updateDescription()
+    
+    let longPressGesture = UILongPressGestureRecognizer(target: self, action: #selector(handleLongPress))
+      descriptionTextView.addGestureRecognizer(longPressGesture)
+  }
+  
+  @objc func handleLongPress(sender: UILongPressGestureRecognizer) {
+    if sender.state == .began {
+      UIPasteboard.general.string = descriptionTextView.text
+      Toast.toast(withText: "Copied!").show()
+    }
   }
 
   private func updateDescription() {


### PR DESCRIPTION
 Added a long press gesture to the WikiDescriptionViewController that allows the user to copy the content of a Wikipedia page. When the user performs a long press gesture on the page, the content is copied to the clipboard. Additionally, I added a Toast message to indicate that the content has been successfully copied. The Toast message is displayed for a short period of time.  Signed-off-by: Praval Gautam  <pravalgautam79@gmail.com> Closes #4553 