### PR TITLE
[android] fix color accent on alert dialog

### DIFF
--- a/android/res/values/themes.xml
+++ b/android/res/values/themes.xml
@@ -52,7 +52,7 @@
   </style>
 
   <style name="MwmTheme.AlertDialog" parent="Theme.AppCompat.Light.Dialog.Alert">
-    <item name="colorAccent">@color/base_accent</item>
+    <item name="colorAccent">?buttonDialogTextColor</item>
     <item name="android:background">?cardBackground</item>
     <item name="android:textColorPrimary">?textDialogTheme</item>
     <item name="android:textSize">@dimen/text_size_body_1</item>
@@ -69,7 +69,7 @@
   </style>
 
   <style name="MwmTheme.Night.AlertDialog" parent="Theme.AppCompat.Dialog.Alert">
-    <item name="colorAccent">@color/base_accent_night</item>
+    <item name="colorAccent">?buttonDialogTextColor</item>
     <item name="android:background">?cardBackground</item>
     <!-- Used for the message in the dialog -->
     <item name="android:textColorPrimary">?textDialogTheme</item>


### PR DESCRIPTION
Tested on Honor 8 - Android 8 (alert dialog with layout and without)

| Before | After |
|---|---|
|<img src="https://user-images.githubusercontent.com/87148630/223785972-8edd002d-6abf-4715-9b68-febd8ff6cf12.jpg" height=400 />|<img src="https://user-images.githubusercontent.com/87148630/223786135-a4256690-7daf-41d8-a468-29c1ba3bf77a.jpg" height=400 />|

Actually colorAccent used in dark mode is same like in light mode
I have used other property to be sure color is good following app theme like in #4575
(Size of alert dialog box is a little different because on before screenshot i used older app compat alert dialog and on after screenshots, i used new material alert dialog)

