### PR TITLE
[navigation]eta time switches with eta minutes on tap.

### DIFF
--- a/android/src/app/organicmaps/widget/menu/NavMenu.java
+++ b/android/src/app/organicmaps/widget/menu/NavMenu.java
@@ -49,6 +49,8 @@ public class NavMenu
 
   private int currentPeekHeight = 0;
 
+  private int check = 0;
+
   public NavMenu(AppCompatActivity activity, NavMenuListener navMenuListener)
   {
     mActivity = activity;
@@ -189,6 +191,12 @@ public class NavMenu
 
   private void updateTimeEstimate(int seconds)
   {
+    if(check == 1){
+      mTimeEstimate.setAlpha(0f);
+    } else if (check == 2) {
+      mTimeEstimate.setAlpha(1f);
+    }
+
     final Calendar currentTime = Calendar.getInstance();
     currentTime.add(Calendar.SECOND, seconds);
     DateFormat timeFormat;
@@ -197,6 +205,12 @@ public class NavMenu
     else
       timeFormat = new SimpleDateFormat("h:mm aa", Locale.getDefault());
     mTimeEstimate.setText(timeFormat.format(currentTime.getTime()));
+    mTimeEstimate.setOnClickListener(new View.OnClickListener() {
+      @Override
+      public void onClick(View v) {
+        check = (check==1)?2:1;
+      }
+    });
   }
 
 


### PR DESCRIPTION
Issue #4000 
I also tried to add both the times together but it looked kind of messy being the same size, so it was better to switch them on tap.
![Screenshot_20230304-091010_Organic Maps (Debug)](https://user-images.githubusercontent.com/109228835/222874115-c19ff2b9-6688-403b-ac8e-b5b82549d244.jpg)
![Screenshot_20230304-091004_Organic Maps (Debug)](https://user-images.githubusercontent.com/109228835/222874124-87a8dd9f-34b7-4d3b-9d8b-48b184bc5c3c.jpg)