### PR TITLE
[android] update listeners subscription lifecycle

### DIFF
--- a/android/src/app/organicmaps/widget/placepage/PlacePageBookmarkFragment.java
+++ b/android/src/app/organicmaps/widget/placepage/PlacePageBookmarkFragment.java
@@ -59,8 +59,6 @@ public class PlacePageBookmarkFragment extends Fragment implements View.OnClickL
     mTvBookmarkNote.setOnLongClickListener(this);
     final View editBookmarkBtn = mFrame.findViewById(R.id.tv__bookmark_edit);
     editBookmarkBtn.setOnClickListener(this);
-
-    mViewModel.getMapObject().observe(requireActivity(), this);
   }
 
   private void initWebView()
@@ -75,9 +73,16 @@ public class PlacePageBookmarkFragment extends Fragment implements View.OnClickL
   }
 
   @Override
-  public void onDestroyView()
+  public void onResume()
   {
-    super.onDestroyView();
+    super.onResume();
+    mViewModel.getMapObject().observe(requireActivity(), this);
+  }
+
+  @Override
+  public void onPause()
+  {
+    super.onPause();
     mViewModel.getMapObject().removeObserver(this);
   }
 

--- a/android/src/app/organicmaps/widget/placepage/PlacePageLinksFragment.java
+++ b/android/src/app/organicmaps/widget/placepage/PlacePageLinksFragment.java
@@ -134,8 +134,6 @@ public class PlacePageLinksFragment extends Fragment implements Observer<MapObje
     mTvLinePage = mFrame.findViewById(R.id.tv__place_line_page);
     mLinePage.setOnClickListener((v) -> openUrl(Metadata.MetadataType.FMD_CONTACT_LINE));
     mLinePage.setOnLongClickListener((v) -> copyUrl(mLinePage, Metadata.MetadataType.FMD_CONTACT_LINE));
-
-    mViewModel.getMapObject().observe(requireActivity(), this);
   }
 
   private boolean isSocialUsername(Metadata.MetadataType type)
@@ -218,9 +216,16 @@ public class PlacePageLinksFragment extends Fragment implements Observer<MapObje
   }
 
   @Override
-  public void onDestroyView()
+  public void onResume()
   {
-    super.onDestroyView();
+    super.onResume();
+    mViewModel.getMapObject().observe(requireActivity(), this);
+  }
+
+  @Override
+  public void onPause()
+  {
+    super.onPause();
     mViewModel.getMapObject().removeObserver(this);
   }
 

--- a/android/src/app/organicmaps/widget/placepage/PlacePageOpeningHoursFragment.java
+++ b/android/src/app/organicmaps/widget/placepage/PlacePageOpeningHoursFragment.java
@@ -59,8 +59,6 @@ public class PlacePageOpeningHoursFragment extends Fragment implements Observer<
     mFullWeekOpeningHours = view.findViewById(R.id.rw__full_opening_hours);
     mOpeningHoursAdapter = new PlaceOpeningHoursAdapter();
     mFullWeekOpeningHours.setAdapter(mOpeningHoursAdapter);
-
-    mViewModel.getMapObject().observe(requireActivity(), this);
   }
 
   private void refreshTodayNonBusinessTime(Timespan[] closedTimespans)
@@ -180,9 +178,16 @@ public class PlacePageOpeningHoursFragment extends Fragment implements Observer<
   }
 
   @Override
-  public void onDestroyView()
+  public void onResume()
   {
-    super.onDestroyView();
+    super.onResume();
+    mViewModel.getMapObject().observe(requireActivity(), this);
+  }
+
+  @Override
+  public void onPause()
+  {
+    super.onPause();
     mViewModel.getMapObject().removeObserver(this);
   }
 

--- a/android/src/app/organicmaps/widget/placepage/PlacePagePhoneFragment.java
+++ b/android/src/app/organicmaps/widget/placepage/PlacePagePhoneFragment.java
@@ -36,14 +36,19 @@ public class PlacePagePhoneFragment extends Fragment implements Observer<MapObje
     RecyclerView phoneRecycler = view.findViewById(R.id.rw__phone);
     mPhoneAdapter = new PlacePhoneAdapter();
     phoneRecycler.setAdapter(mPhoneAdapter);
+  }
 
+  @Override
+  public void onResume()
+  {
+    super.onResume();
     mViewModel.getMapObject().observe(requireActivity(), this);
   }
 
   @Override
-  public void onDestroyView()
+  public void onPause()
   {
-    super.onDestroyView();
+    super.onPause();
     mViewModel.getMapObject().removeObserver(this);
   }
 

--- a/android/src/app/organicmaps/widget/placepage/PlacePageView.java
+++ b/android/src/app/organicmaps/widget/placepage/PlacePageView.java
@@ -239,10 +239,7 @@ public class PlacePageView extends Fragment implements View.OnClickListener,
 
     mDownloaderInfo = mPreview.findViewById(R.id.tv__downloader_details);
 
-    mViewModel.getMapObject().observe(requireActivity(), this);
     mMapObject = mViewModel.getMapObject().getValue();
-
-    LocationHelper.INSTANCE.addListener(this);
   }
 
   @Override
@@ -253,12 +250,32 @@ public class PlacePageView extends Fragment implements View.OnClickListener,
   }
 
   @Override
-  public void onDestroyView()
+  public void onResume()
   {
-    super.onDestroyView();
-    detachCountry();
+    super.onResume();
+    mViewModel.getMapObject().observe(requireActivity(), this);
+    LocationHelper.INSTANCE.addListener(this);
+  }
+
+  @Override
+  public void onPause()
+  {
+    super.onPause();
+    // Unsubscribe from events as soon as the fragment becomes inactive
+    // to prevent unwanted side effects
     mViewModel.getMapObject().removeObserver(this);
     LocationHelper.INSTANCE.removeListener(this);
+  }
+
+  @Override
+  public void onStop()
+  {
+    super.onStop();
+    // Safely detach the country once the fragment is hidden from the user
+    // It is safer to call this here than in onPause as the app could go from onPause to
+    // onResume without killing the fragment.
+    // In this case we would not want to detach the country.
+    detachCountry();
   }
 
   @Override

--- a/android/src/app/organicmaps/widget/placepage/PlacePageWikipediaFragment.java
+++ b/android/src/app/organicmaps/widget/placepage/PlacePageWikipediaFragment.java
@@ -52,8 +52,6 @@ public class PlacePageWikipediaFragment extends Fragment implements Observer<Map
     placeDescriptionMoreBtn.setOnClickListener(v -> showDescriptionScreen());
     mPlaceDescriptionView.setOnClickListener(v -> showDescriptionScreen());
     mWiki = view.findViewById(R.id.ll__place_wiki);
-
-    mViewModel.getMapObject().observe(requireActivity(), this);
   }
 
   private void showDescriptionScreen()
@@ -97,9 +95,16 @@ public class PlacePageWikipediaFragment extends Fragment implements Observer<Map
   }
 
   @Override
-  public void onDestroyView()
+  public void onResume()
   {
-    super.onDestroyView();
+    super.onResume();
+    mViewModel.getMapObject().observe(requireActivity(), this);
+  }
+
+  @Override
+  public void onPause()
+  {
+    super.onPause();
     mViewModel.getMapObject().removeObserver(this);
   }
 


### PR DESCRIPTION
Subscribe to listeners in onResume and unsubscribe in onPause.

Should hopefully fix #4729, but I was not able to reproduce it.


According to the [doc](https://developer.android.com/guide/fragments/lifecycle), these are the first/last events from the create/destroy lifecycle. So the callbacks should never get called when the views are not ready.