### PR TITLE
[docs] disable cpp folder indexing on android

### DIFF
--- a/docs/INSTALL.md
+++ b/docs/INSTALL.md
@@ -458,6 +458,7 @@ Android Studio. Please make sure that SDK for API Level 33,
 NDK version **25.2.9519653** and CMake version **3.22.1** are installed.
 
 If you are low on RAM, disk space or traffic there are ways to reduce system requirements:
+- exclude the `cpp` folder from indexing. If you do not make any work on the C++ code, this will greatly improve the startup performance and the ram usage of Android Studio. Click on the `Project` tab on the left, find the `cpp` folder (should be next to the `java` folder), right click on it and select `Mark Directory as` -> `Excluded` (red folder icon). Then restart Android Studio.
 - in Android Studio enable "File > Power Save Mode";
 - don't install Android Studio, run builds and emulator from command line;
 - build only for target arches you actually need, e.g. `arm64`;


### PR DESCRIPTION
This is a neat little trick I found out which greatly improves performance. I don't need to wait 5min for android studio to start and it doesn't take 5GB of ram anymore. It now starts in a few seconds and "only" uses 2GB of ram.