### PR TITLE
[api] Workaround for invalid API coordinates passed via om://search requests without lat lon

### DIFF
--- a/map/mwm_url.cpp
+++ b/map/mwm_url.cpp
@@ -352,14 +352,11 @@ void ParsedMapApi::ParseCommonParam(std::string const & key, std::string const &
   }
   else if (key == kCenterLatLon)
   {
-    double lat = 0.0;
-    double lon = 0.0;
-    if (!ParseLatLon(key, value, lat, lon))
-    {
+    double lat, lon;
+    if (ParseLatLon(key, value, lat, lon))
+      m_centerLatLon = {lat, lon};
+    else
       LOG(LWARNING, ("Incorrect 'cll':", value));
-      return;
-    }
-    m_centerLatLon = ms::LatLon(lat, lon);
   }
 }
 
@@ -369,7 +366,7 @@ void ParsedMapApi::Reset()
   m_searchRequest = {};
   m_globalBackUrl ={};
   m_appName = {};
-  m_centerLatLon = {};
+  m_centerLatLon = ms::LatLon::Zero();
   m_routingType = {};
   m_version = 0;
   m_zoomLevel = 0.0;

--- a/map/mwm_url.hpp
+++ b/map/mwm_url.hpp
@@ -102,7 +102,9 @@ private:
   SearchRequest m_searchRequest;
   std::string m_globalBackUrl;
   std::string m_appName;
-  ms::LatLon m_centerLatLon;
+  // TODO: om://search? api needs to distinguish if a (search center) point was passed or not.
+  // Now Android and iOS clients check if either lat or lon is equal to zero in the "not initialized" case.
+  ms::LatLon m_centerLatLon = ms::LatLon::Zero();
   std::string m_routingType;
   int m_version = 0;
   /// Zoom level in OSM format (e.g. from 1.0 to 20.0)


### PR DESCRIPTION
Fixes #4761