### PR TITLE
[android] Bottom nav layout fix

### DIFF
--- a/android/res/layout/layout_nav_bottom_numbers.xml
+++ b/android/res/layout/layout_nav_bottom_numbers.xml
@@ -8,23 +8,25 @@
   tools:background="#3000FF00"
   tools:ignore="RtlSymmetry">
 
-  <!-- Speed -->
-  <RelativeLayout
-    android:id="@+id/speed_view_container"
+  <Space
     android:layout_width="0dp"
     android:layout_height="match_parent"
-    android:layout_weight="1"
+    android:layout_weight="0.5"/>
+
+  <!-- Speed -->
+  <LinearLayout
+    android:id="@+id/speed_view_container"
+    android:layout_width="wrap_content"
+    android:layout_height="match_parent"
+    android:orientation="vertical"
     android:background="@drawable/speed_cams_bg"
     android:gravity="center"
-    android:minWidth="@dimen/nav_numbers_side_min_width"
-    android:paddingStart="@dimen/nav_numbers_margin"
-    android:paddingEnd="@dimen/nav_numbers_margin">
+    android:minWidth="@dimen/nav_numbers_side_min_width">
 
     <TextView
       android:id="@+id/speed_value"
       android:layout_width="wrap_content"
       android:layout_height="wrap_content"
-      android:layout_centerHorizontal="true"
       android:includeFontPadding="false"
       android:lines="1"
       android:textAppearance="@style/MwmTextAppearance.NavMenu.Number"
@@ -35,30 +37,30 @@
       android:id="@+id/speed_dimen"
       android:layout_width="wrap_content"
       android:layout_height="wrap_content"
-      android:layout_below="@id/speed_value"
-      android:layout_centerHorizontal="true"
       android:includeFontPadding="false"
       android:lines="1"
       android:textAppearance="@style/MwmTextAppearance.NavMenu.Number.Dimension"
       tools:background="#20FF0000"
       tools:text="km/h" />
-  </RelativeLayout>
+  </LinearLayout>
 
-  <!-- Time -->
-  <RelativeLayout
+  <Space
     android:layout_width="0dp"
     android:layout_height="match_parent"
-    android:layout_weight="1.5"
+    android:layout_weight="1.25"/>
+
+  <!-- Time -->
+  <LinearLayout
+    android:layout_width="wrap_content"
+    android:layout_height="match_parent"
+    android:orientation="vertical"
     android:gravity="center"
-    android:minWidth="@dimen/nav_numbers_side_min_width"
-    android:paddingStart="@dimen/nav_numbers_margin"
-    android:paddingEnd="@dimen/nav_numbers_margin">
+    android:minWidth="@dimen/nav_numbers_side_min_width">
 
     <LinearLayout
       android:id="@+id/time_values_container"
       android:layout_width="wrap_content"
       android:layout_height="wrap_content"
-      android:layout_centerHorizontal="true"
       tools:background="#20FF0000">
 
       <TextView
@@ -104,31 +106,30 @@
       android:id="@+id/time_estimate"
       android:layout_width="wrap_content"
       android:layout_height="wrap_content"
-      android:layout_below="@+id/time_values_container"
-      android:layout_centerHorizontal="true"
       android:includeFontPadding="false"
       android:lines="1"
       android:textAlignment="center"
       android:textAppearance="@style/MwmTextAppearance.NavMenu.Number.Dimension"
       tools:text="99:99 AM" />
-  </RelativeLayout>
+  </LinearLayout>
 
-
-  <!-- Distance -->
-  <RelativeLayout
+  <Space
     android:layout_width="0dp"
     android:layout_height="match_parent"
-    android:layout_weight="1"
+    android:layout_weight="1.25"/>
+
+  <!-- Distance -->
+  <LinearLayout
+    android:layout_width="wrap_content"
+    android:layout_height="match_parent"
+    android:orientation="vertical"
     android:gravity="center"
-    android:minWidth="@dimen/nav_numbers_side_min_width"
-    android:paddingStart="@dimen/nav_numbers_margin"
-    android:paddingEnd="@dimen/nav_numbers_margin">
+    android:minWidth="@dimen/nav_numbers_side_min_width">
 
     <TextView
       android:id="@+id/distance_value"
       android:layout_width="wrap_content"
       android:layout_height="wrap_content"
-      android:layout_centerHorizontal="true"
       android:includeFontPadding="false"
       android:lines="1"
       android:textAppearance="@style/MwmTextAppearance.NavMenu.Number"
@@ -138,12 +139,15 @@
       android:id="@+id/distance_dimen"
       android:layout_width="wrap_content"
       android:layout_height="wrap_content"
-      android:layout_below="@id/distance_value"
-      android:layout_centerHorizontal="true"
       android:includeFontPadding="false"
       android:lines="1"
       android:textAppearance="@style/MwmTextAppearance.NavMenu.Number.Dimension"
       tools:background="#20FF0000"
       tools:text="km" />
-  </RelativeLayout>
+  </LinearLayout>
+
+  <Space
+    android:layout_width="0dp"
+    android:layout_height="match_parent"
+    android:layout_weight="0.5"/>
 </LinearLayout>

--- a/android/res/values-land/dimens.xml
+++ b/android/res/values-land/dimens.xml
@@ -6,7 +6,6 @@
 
   <!-- Nav menu -->
   <dimen name="nav_menu_content_height">48dp</dimen>
-  <dimen name="nav_numbers_margin">16dp</dimen>
   <dimen name="nav_bottom_gap">24dp</dimen>
 
   <!-- Altitude chart -->

--- a/android/res/values-sw720dp-land/dimens.xml
+++ b/android/res/values-sw720dp-land/dimens.xml
@@ -3,7 +3,6 @@
   <!-- Nav menu -->
   <dimen name="nav_menu_content_height">64dp</dimen>
   <dimen name="nav_progress">8dp</dimen>
-  <dimen name="nav_numbers_margin">32dp</dimen>
 
   <!-- Altitude chart -->
   <dimen name="altitude_chart_image_width">328dp</dimen>

--- a/android/res/values/dimens.xml
+++ b/android/res/values/dimens.xml
@@ -105,7 +105,6 @@
   <dimen name="nav_next_turn_space">6dp</dimen>
   <dimen name="nav_next_turn_sign">64dp</dimen>
   <dimen name="nav_next_next_turn_frame">32dp</dimen>
-  <dimen name="nav_numbers_margin">8dp</dimen>
   <dimen name="nav_numbers_side_min_width">90dp</dimen>
   <dimen name="nav_progress">4sp</dimen>
   <dimen name="nav_progress_head">2dp</dimen>


### PR DESCRIPTION
Closes: #4189

The bug was related to the big padding value (32dp). I decided to fully replace paddings with spaces for not to have such problems in the future.

Current configuration:
`|space(weight 0.5)|SPEED|space(weight 1.25)|TIME|space(weight 1.25)|DISTANCE|space(weight 0.5)|`

+ I replaced `RelativeLayout` with `LinearLayout` - it should work faster.

<img width="400" src="https://user-images.githubusercontent.com/10351358/224559739-f68dc2f9-ae5e-4c27-97ab-0e7ec2265425.png"/>
<img width="200" src="https://user-images.githubusercontent.com/10351358/224559813-55324c68-8135-4344-856e-c1c59749e8a8.png"/>
