### PR TITLE
[kml] Correctly import bookmarks with track data

### DIFF
--- a/kml/kml_tests/serdes_tests.cpp
+++ b/kml/kml_tests/serdes_tests.cpp
@@ -874,3 +874,46 @@ UNIT_TEST(Kml_Ver_2_3)
   TEST_EQUAL(lines[0].size(), 7, ());
   TEST_EQUAL(lines[1].size(), 6, ());
 }
+
+UNIT_TEST(Kml_Placemark_contains_both_Bookmark_and_Track_data)
+{
+  char const * input = R"(<?xml version="1.0" encoding="UTF-8"?>
+<kml xmlns="http://www.opengis.net/kml/2.2">
+  <Placemark>
+    <MultiGeometry>
+      <Point>
+        <coordinates>28.968447783842,41.009030507129,0</coordinates>
+      </Point>
+      <LineString>
+        <coordinates>28.968447783842,41.009030507129,0 28.965858,41.018449,0</coordinates>
+      </LineString>
+    </MultiGeometry>
+  </Placemark>
+  <Placemark>
+  <MultiGeometry>
+    <LineString>
+      <coordinates>28.968447783842,41.009030507129,0 28.965858,41.018449,0</coordinates>
+    </LineString>
+    <Point>
+      <coordinates>28.968447783842,41.009030507129,0</coordinates>
+    </Point>
+  </MultiGeometry>
+</Placemark>
+</kml>
+  )";
+
+  kml::FileData fData;
+  try
+  {
+    MemReader reader(input, strlen(input));
+    kml::DeserializerKml des(fData);
+    des.Deserialize(reader);
+  }
+  catch (kml::DeserializerKml::DeserializeException const & ex)
+  {
+    TEST(false, ("Exception raised", ex.Msg()));
+  }
+
+  TEST_EQUAL(fData.m_bookmarksData.size(), 2, ());
+  TEST_EQUAL(fData.m_tracksData.size(), 2, ());
+}


### PR DESCRIPTION
Closes: #3467

What do you think? Is it a valid solution?

TODO:
- [x] Cover this case with UTs

<img width="300" src="https://user-images.githubusercontent.com/10351358/224570458-c412823c-dffa-4287-9430-fb406a2a4501.jpg"/>


Here is how it looks inside a kml:
```xml
	<Placemark id="placemark20">
		<name><![CDATA[Кальянная Erenler Nargile ve Çay Bahçesi]]></name>
		<styleUrl>#icon20</styleUrl>
		<description><![CDATA[<table width="400"><tr><td></td></tr></table>]]></description>
		<MultiGeometry>
			<Point>
				<coordinates>28.968447783842,41.009030507129,0</coordinates>
			</Point>
			<LineString id="line20">
				<extrude>1</extrude>
				<tessellate>1</tessellate>
				<coordinates>28.968447783842,41.009030507129,0 28.965858,41.018449,0</coordinates>
			</LineString>
		</MultiGeometry>
	</Placemark>
```