### PR TITLE
Fix misleading translations (hu)

### DIFF
--- a/data/strings/types_strings.txt
+++ b/data/strings/types_strings.txt
@@ -24713,7 +24713,7 @@
     fa = گردشگری
     fi = Taideteos
     fr = Œuvre
-    hu = Szobor
+    hu = Műalkotás
     id = Pariwisata
     it = Opera d'arte
     ja = 建築
@@ -24748,7 +24748,7 @@
     fa = گردشگری
     fi = Taideteos
     fr = Œuvre
-    hu = Szobor
+    hu = Műalkotás
     id = Pariwisata
     it = Dipinto
     ja = 絵画


### PR DESCRIPTION
I've put in use a more common designation for artworks where it was intended, instead of "szobor" which we use more often for statues and sculptures.

Signed-off-by: @d4f5409d 