### PR TITLE
[Kotlin] Compatiblity interface for deprecated APIs.

### DIFF
--- a/android/src/app/organicmaps/compat/Compat.kt
+++ b/android/src/app/organicmaps/compat/Compat.kt
@@ -1,0 +1,9 @@
+package app.organicmaps.compat
+
+import android.widget.TimePicker
+
+interface Compat {
+  fun setTime(picker: TimePicker, hour: Int, minute: Int)
+  fun getHour(picker: TimePicker): Int
+  fun getMinute(picker: TimePicker): Int
+}

--- a/android/src/app/organicmaps/compat/CompatHelper.kt
+++ b/android/src/app/organicmaps/compat/CompatHelper.kt
@@ -1,0 +1,23 @@
+package app.organicmaps.compat
+
+import android.os.Build
+
+class CompatHelper private constructor() {
+
+  private val compatValue: Compat = when {
+    sdkVersion >= Build.VERSION_CODES.M -> CompatV23()
+    else -> CompatV21()
+  }
+
+  companion object {
+
+    private val instance by lazy { CompatHelper() }
+
+    /** Get the current Android API level.  */
+    val sdkVersion: Int
+      get() = Build.VERSION.SDK_INT
+
+    val compat get() = instance.compatValue
+  }
+
+}

--- a/android/src/app/organicmaps/compat/CompatV21.kt
+++ b/android/src/app/organicmaps/compat/CompatV21.kt
@@ -1,0 +1,21 @@
+package app.organicmaps.compat
+
+import android.widget.TimePicker
+
+@Suppress("Deprecation")
+open class CompatV21: Compat {
+
+  override fun getHour(picker: TimePicker): Int {
+    return picker.currentHour
+  }
+
+  override fun getMinute(picker: TimePicker): Int {
+    return picker.currentMinute
+
+  }
+
+  override fun setTime(picker: TimePicker, hour: Int, minute: Int) {
+    picker.currentHour = hour
+    picker.currentMinute = minute
+  }
+}

--- a/android/src/app/organicmaps/compat/CompatV23.kt
+++ b/android/src/app/organicmaps/compat/CompatV23.kt
@@ -1,0 +1,21 @@
+package app.organicmaps.compat
+
+import android.annotation.TargetApi
+import android.widget.TimePicker
+
+@TargetApi(23)
+open class CompatV23: CompatV21(), Compat {
+
+  override fun setTime(picker: TimePicker, hour: Int, minute: Int) {
+    picker.hour = hour
+    picker.minute = minute
+  }
+
+  override fun getHour(picker: TimePicker): Int {
+    return picker.hour
+  }
+
+  override fun getMinute(picker: TimePicker): Int {
+    return picker.minute
+  }
+}

--- a/android/src/app/organicmaps/editor/HoursMinutesPickerFragment.java
+++ b/android/src/app/organicmaps/editor/HoursMinutesPickerFragment.java
@@ -19,6 +19,7 @@ import androidx.appcompat.app.AlertDialog;
 import androidx.appcompat.content.res.AppCompatResources;
 import androidx.fragment.app.FragmentManager;
 
+import app.organicmaps.compat.CompatHelper;
 import com.google.android.material.dialog.MaterialAlertDialogBuilder;
 import com.google.android.material.tabs.TabLayout;
 import app.organicmaps.R;
@@ -179,8 +180,10 @@ public class HoursMinutesPickerFragment extends BaseMwmDialogFragment
   private void saveHoursMinutes()
   {
     boolean is24HourFormat = DateUtils.is24HourFormat(requireContext());
-    final HoursMinutes hoursMinutes = new HoursMinutes(mPicker.getCurrentHour(),
-                                                       mPicker.getCurrentMinute(), is24HourFormat);
+    final HoursMinutes hoursMinutes = new HoursMinutes(
+        CompatHelper.Companion.getCompat().getHour(mPicker),
+        CompatHelper.Companion.getCompat().getMinute(mPicker),
+        is24HourFormat);
     if (mSelectedTab == TAB_FROM)
       mFrom = hoursMinutes;
     else
@@ -209,8 +212,7 @@ public class HoursMinutesPickerFragment extends BaseMwmDialogFragment
       hoursMinutes = mTo;
       okBtnRes = R.string.ok;
     }
-    mPicker.setCurrentMinute((int) hoursMinutes.minutes);
-    mPicker.setCurrentHour((int) hoursMinutes.hours);
+    CompatHelper.Companion.getCompat().setTime(mPicker, (int) hoursMinutes.hours, (int) hoursMinutes.minutes);
     mOkButton.setText(okBtnRes);
   }
 }


### PR DESCRIPTION
### What is this?

This is a common interface that would help abstract away the differences between the deprecated and non-deprecated APIs.
(Inspired by the AnkiDroid implementation.)

### What each file does:

- The Compat interface and its implementations are needed in the above code to provide a unified API that can be used across different versions of the Android platform.
- The CompatHelper class is a singleton that has a private constructor and exposes a compat property that returns an instance of the Compat interface. It uses a when expression to decide which implementation of the Compat interface to use based on the Android SDK version of the device.
- The CompatV21 class is an implementation of the Compat interface that supports Android API level 21 and above. This is the base implementation of Compat.
- The CompatV23 class is an implementation of the Compat interface that supports Android API level 23 and above. It uses the non-deprecated hour and minute properties to get and set the hour and minute values of a TimePicker widget.

### Why we need this:

- If we had to implement the same without this compact system we would need to check the `Build.VERSION_CODES` every time we used any of the deprecated APIs which would lead to more maintenance & a lot of repeated code.
- Encapsulation: The implementation details of each Compat version are encapsulated within their respective classes, which means that other parts of the codebase don't need to know or care about the differences in the TimePicker API between different Android versions.

### Why this was implemented in kotlin:
<strike>
Even though this project is not being migrated to kotlin I personally think that any new code (if possible) should be written in kotlin as it has a lot of benefits over Java such as Conciseness (Readability), Null Safety (Most important if I had to say) & Interoperability with Java code which makes it plug & play.
</strike>
Read the discussion. (Turns out Java is faster)

### Other:
There is still some work to be done here (mostly comments & documentation for the developer)
Any feedback on this would be really appreciated.
