### PR TITLE
Compatiblity interface for deprecated APIs.

### DIFF
--- a/android/src/app/organicmaps/MwmActivity.java
+++ b/android/src/app/organicmaps/MwmActivity.java
@@ -39,6 +39,7 @@ import app.organicmaps.bookmarks.data.BookmarkInfo;
 import app.organicmaps.bookmarks.data.BookmarkManager;
 import app.organicmaps.bookmarks.data.MapObject;
 import app.organicmaps.bookmarks.data.Track;
+import app.organicmaps.compat.CompatHelper;
 import app.organicmaps.downloader.DownloaderActivity;
 import app.organicmaps.downloader.DownloaderFragment;
 import app.organicmaps.downloader.MapManager;
@@ -960,7 +961,7 @@ public class MwmActivity extends BaseMwmFragmentActivity
         intent.hasExtra(EXTRA_TASK) &&
         ((intent.getFlags() & Intent.FLAG_ACTIVITY_LAUNCHED_FROM_HISTORY) == 0))
     {
-      final MapTask mapTask = (MapTask) intent.getSerializableExtra(EXTRA_TASK);
+      final MapTask mapTask = CompatHelper.getCompat().getSerializableExtra(intent, EXTRA_TASK, MapTask.class);
       mTasks.add(mapTask);
       intent.removeExtra(EXTRA_TASK);
 

--- a/android/src/app/organicmaps/SplashActivity.java
+++ b/android/src/app/organicmaps/SplashActivity.java
@@ -19,6 +19,7 @@ import androidx.core.app.ActivityCompat;
 
 import app.organicmaps.base.BaseActivity;
 import app.organicmaps.base.BaseActivityDelegate;
+import app.organicmaps.compat.CompatHelper;
 import app.organicmaps.location.LocationHelper;
 import app.organicmaps.util.Config;
 import app.organicmaps.util.Counters;
@@ -185,7 +186,7 @@ public class SplashActivity extends AppCompatActivity implements BaseActivity
       if (input.hasExtra(EXTRA_ACTIVITY_TO_START))
       {
         result = new Intent(this,
-                            (Class<? extends Activity>) input.getSerializableExtra(EXTRA_ACTIVITY_TO_START));
+                            CompatHelper.getCompat().getSerializableExtra(input, EXTRA_ACTIVITY_TO_START, Activity.class.getClass()));
       }
 
       Intent initialIntent = input.hasExtra(EXTRA_INITIAL_INTENT) ?

--- a/android/src/app/organicmaps/compat/Compat.java
+++ b/android/src/app/organicmaps/compat/Compat.java
@@ -1,0 +1,11 @@
+package app.organicmaps.compat;
+
+import android.widget.TimePicker;
+
+public interface Compat
+{
+  void setTime(TimePicker picker, int hour, int minute);
+  int getHour(TimePicker picker);
+  int getMinute(TimePicker picker);
+
+}

--- a/android/src/app/organicmaps/compat/Compat.java
+++ b/android/src/app/organicmaps/compat/Compat.java
@@ -3,7 +3,10 @@ package app.organicmaps.compat;
 import android.content.Intent;
 import android.content.pm.PackageManager;
 import android.content.pm.ResolveInfo;
+import android.os.Bundle;
 import android.widget.TimePicker;
+
+import java.io.Serializable;
 
 public interface Compat
 {
@@ -12,6 +15,8 @@ public interface Compat
   int getMinute(TimePicker picker);
 
   ResolveInfo resolveActivity(PackageManager packageManager, Intent intent, ResolveInfoFlags flags);
+
+  <T extends Serializable> T getSerializableExtra(Intent intent, String name, Class<T> className);
 
   class ResolveInfoFlags
   {

--- a/android/src/app/organicmaps/compat/Compat.java
+++ b/android/src/app/organicmaps/compat/Compat.java
@@ -1,5 +1,8 @@
 package app.organicmaps.compat;
 
+import android.content.Intent;
+import android.content.pm.PackageManager;
+import android.content.pm.ResolveInfo;
 import android.widget.TimePicker;
 
 public interface Compat
@@ -7,5 +10,24 @@ public interface Compat
   void setTime(TimePicker picker, int hour, int minute);
   int getHour(TimePicker picker);
   int getMinute(TimePicker picker);
+
+  ResolveInfo resolveActivity(PackageManager packageManager, Intent intent, ResolveInfoFlags flags);
+
+  class ResolveInfoFlags
+  {
+    private long value;
+
+    public ResolveInfoFlags(long value) {
+      this.value = value;
+    }
+
+    public long getValue() {
+      return value;
+    }
+
+    public static ResolveInfoFlags of(long value) {
+      return new ResolveInfoFlags(value);
+    }
+  }
 
 }

--- a/android/src/app/organicmaps/compat/CompatHelper.java
+++ b/android/src/app/organicmaps/compat/CompatHelper.java
@@ -13,7 +13,9 @@ public class CompatHelper
   private final Compat mCompat;
 
   private CompatHelper() {
-    if (sdkVersion() >= Build.VERSION_CODES.M) {
+    if (sdkVersion() >= Build.VERSION_CODES.TIRAMISU) {
+      mCompat = new CompatV33();
+    } else if (sdkVersion() >= Build.VERSION_CODES.M) {
       mCompat = new CompatV23();
     } else {
       mCompat = new CompatV21();

--- a/android/src/app/organicmaps/compat/CompatHelper.java
+++ b/android/src/app/organicmaps/compat/CompatHelper.java
@@ -1,0 +1,41 @@
+package app.organicmaps.compat;
+
+import android.os.Build;
+import androidx.annotation.NonNull;
+
+
+public class CompatHelper
+{
+
+  private static CompatHelper sInstance;
+
+  @NonNull
+  private final Compat mCompat;
+
+  private CompatHelper() {
+    if (sdkVersion() >= Build.VERSION_CODES.M) {
+      mCompat = new CompatV23();
+    } else {
+      mCompat = new CompatV21();
+    }
+  }
+
+  @NonNull
+  public static Compat getCompat() {
+    return getInstance().mCompat;
+  }
+
+  @NonNull
+  public static synchronized CompatHelper getInstance() {
+    if (sInstance == null) {
+      sInstance = new CompatHelper();
+    }
+    return sInstance;
+  }
+
+  /** Get the current Android API level.  */
+  public static int sdkVersion() {
+    return Build.VERSION.SDK_INT;
+  }
+
+}

--- a/android/src/app/organicmaps/compat/CompatV21.java
+++ b/android/src/app/organicmaps/compat/CompatV21.java
@@ -1,0 +1,23 @@
+package app.organicmaps.compat;
+
+import android.widget.TimePicker;
+
+@SuppressWarnings("deprecation")
+public class CompatV21 implements Compat {
+
+  @Override
+  public int getHour(TimePicker picker) {
+    return picker.getCurrentHour();
+  }
+
+  @Override
+  public int getMinute(TimePicker picker) {
+    return picker.getCurrentMinute();
+  }
+
+  @Override
+  public void setTime(TimePicker picker, int hour, int minute) {
+    picker.setCurrentHour(hour);
+    picker.setCurrentMinute(minute);
+  }
+}

--- a/android/src/app/organicmaps/compat/CompatV21.java
+++ b/android/src/app/organicmaps/compat/CompatV21.java
@@ -5,8 +5,11 @@ import android.content.pm.PackageManager;
 import android.content.pm.ResolveInfo;
 import android.widget.TimePicker;
 
+import java.io.Serializable;
+
 @SuppressWarnings("deprecation")
-public class CompatV21 implements Compat {
+public class CompatV21 implements Compat
+{
 
   @Override
   public int getHour(TimePicker picker) {
@@ -28,4 +31,14 @@ public class CompatV21 implements Compat {
   public ResolveInfo resolveActivity(PackageManager packageManager, Intent intent, Compat.ResolveInfoFlags flags) {
     return packageManager.resolveActivity(intent, (int) flags.getValue());
   }
+
+  @Override
+  public <T extends Serializable> T getSerializableExtra(Intent intent, String name, Class<T> className) {
+    try {
+      return className.cast(intent.getSerializableExtra(name));
+    } catch (Exception e) {
+      return null;
+    }
+  }
+
 }

--- a/android/src/app/organicmaps/compat/CompatV21.java
+++ b/android/src/app/organicmaps/compat/CompatV21.java
@@ -1,5 +1,8 @@
 package app.organicmaps.compat;
 
+import android.content.Intent;
+import android.content.pm.PackageManager;
+import android.content.pm.ResolveInfo;
 import android.widget.TimePicker;
 
 @SuppressWarnings("deprecation")
@@ -19,5 +22,10 @@ public class CompatV21 implements Compat {
   public void setTime(TimePicker picker, int hour, int minute) {
     picker.setCurrentHour(hour);
     picker.setCurrentMinute(minute);
+  }
+
+  @Override
+  public ResolveInfo resolveActivity(PackageManager packageManager, Intent intent, Compat.ResolveInfoFlags flags) {
+    return packageManager.resolveActivity(intent, (int) flags.getValue());
   }
 }

--- a/android/src/app/organicmaps/compat/CompatV23.java
+++ b/android/src/app/organicmaps/compat/CompatV23.java
@@ -1,0 +1,25 @@
+package app.organicmaps.compat;
+
+import android.annotation.TargetApi;
+import android.util.Log;
+import android.widget.TimePicker;
+
+@TargetApi(23)
+public class CompatV23 extends CompatV21 implements Compat {
+
+  @Override
+  public void setTime(TimePicker picker, int hour, int minute) {
+    picker.setHour(hour);
+    picker.setMinute(minute);
+  }
+
+  @Override
+  public int getHour(TimePicker picker) {
+    return picker.getHour();
+  }
+
+  @Override
+  public int getMinute(TimePicker picker) {
+    return picker.getMinute();
+  }
+}

--- a/android/src/app/organicmaps/compat/CompatV33.java
+++ b/android/src/app/organicmaps/compat/CompatV33.java
@@ -6,6 +6,8 @@ import android.content.Intent;
 import android.content.pm.PackageManager;
 import android.content.pm.ResolveInfo;
 
+import java.io.Serializable;
+
 @TargetApi(33)
 public class CompatV33 extends CompatV23 implements Compat
 {
@@ -16,5 +18,10 @@ public class CompatV33 extends CompatV23 implements Compat
     return packageManager.resolveActivity(
         intent,
         PackageManager.ResolveInfoFlags.of(flags.getValue()));
+  }
+
+  @Override
+  public <T extends Serializable> T getSerializableExtra(Intent intent, String name, Class<T> className) {
+    return intent.getSerializableExtra(name, className);
   }
 }

--- a/android/src/app/organicmaps/compat/CompatV33.java
+++ b/android/src/app/organicmaps/compat/CompatV33.java
@@ -1,0 +1,20 @@
+package app.organicmaps.compat;
+
+import android.annotation.SuppressLint;
+import android.annotation.TargetApi;
+import android.content.Intent;
+import android.content.pm.PackageManager;
+import android.content.pm.ResolveInfo;
+
+@TargetApi(33)
+public class CompatV33 extends CompatV23 implements Compat
+{
+
+  @SuppressLint("WrongConstant")
+  @Override
+  public ResolveInfo resolveActivity(PackageManager packageManager, Intent intent, Compat.ResolveInfoFlags flags) {
+    return packageManager.resolveActivity(
+        intent,
+        PackageManager.ResolveInfoFlags.of(flags.getValue()));
+  }
+}

--- a/android/src/app/organicmaps/editor/HoursMinutesPickerFragment.java
+++ b/android/src/app/organicmaps/editor/HoursMinutesPickerFragment.java
@@ -19,6 +19,8 @@ import androidx.appcompat.app.AlertDialog;
 import androidx.appcompat.content.res.AppCompatResources;
 import androidx.fragment.app.FragmentManager;
 
+import app.organicmaps.compat.Compat;
+import app.organicmaps.compat.CompatHelper;
 import com.google.android.material.dialog.MaterialAlertDialogBuilder;
 import com.google.android.material.tabs.TabLayout;
 import app.organicmaps.R;
@@ -49,6 +51,8 @@ public class HoursMinutesPickerFragment extends BaseMwmDialogFragment
 
   private int mId;
   private Button mOkButton;
+
+  private final Compat compat = CompatHelper.getCompat();
 
   public interface OnPickListener
   {
@@ -179,8 +183,9 @@ public class HoursMinutesPickerFragment extends BaseMwmDialogFragment
   private void saveHoursMinutes()
   {
     boolean is24HourFormat = DateUtils.is24HourFormat(requireContext());
-    final HoursMinutes hoursMinutes = new HoursMinutes(mPicker.getCurrentHour(),
-                                                       mPicker.getCurrentMinute(), is24HourFormat);
+    final HoursMinutes hoursMinutes = new HoursMinutes(compat.getHour(mPicker),
+                                                       compat.getMinute(mPicker),
+                                                       is24HourFormat);
     if (mSelectedTab == TAB_FROM)
       mFrom = hoursMinutes;
     else
@@ -209,8 +214,7 @@ public class HoursMinutesPickerFragment extends BaseMwmDialogFragment
       hoursMinutes = mTo;
       okBtnRes = R.string.ok;
     }
-    mPicker.setCurrentMinute((int) hoursMinutes.minutes);
-    mPicker.setCurrentHour((int) hoursMinutes.hours);
+    compat.setTime(mPicker, (int) hoursMinutes.hours, (int) hoursMinutes.minutes);
     mOkButton.setText(okBtnRes);
   }
 }

--- a/android/src/app/organicmaps/util/Utils.java
+++ b/android/src/app/organicmaps/util/Utils.java
@@ -164,7 +164,7 @@ public class Utils
   public static boolean isIntentSupported(@NonNull Context context, @NonNull Intent intent)
   {
     final PackageManager pm = context.getPackageManager();
-    return CompatHelper.getInstance().resolveActivity(pm, intent, Compat.ResolveInfoFlags.of(0)) != null;
+    return CompatHelper.getCompat().resolveActivity(pm, intent, Compat.ResolveInfoFlags.of(0)) != null;
   }
 
   public static @Nullable Intent makeSystemLocationSettingIntent(@NonNull Context context)

--- a/android/src/app/organicmaps/util/Utils.java
+++ b/android/src/app/organicmaps/util/Utils.java
@@ -36,6 +36,8 @@ import androidx.core.app.NavUtils;
 import androidx.fragment.app.Fragment;
 import androidx.fragment.app.FragmentManager;
 
+import app.organicmaps.compat.Compat;
+import app.organicmaps.compat.CompatHelper;
 import com.google.android.material.dialog.MaterialAlertDialogBuilder;
 import com.google.android.material.snackbar.Snackbar;
 
@@ -159,18 +161,10 @@ public class Utils
       showSnackbarAbove(view, viewAbove, message);
   }
 
-  @SuppressWarnings("deprecated")
-  private static @Nullable ResolveInfo resolveActivity(@NonNull PackageManager pm, @NonNull Intent intent, int flags)
-  {
-    return pm.resolveActivity(intent, flags);
-  }
-
   public static boolean isIntentSupported(@NonNull Context context, @NonNull Intent intent)
   {
     final PackageManager pm = context.getPackageManager();
-    if (Build.VERSION.SDK_INT < Build.VERSION_CODES.TIRAMISU)
-      return resolveActivity(pm, intent, 0) != null;
-    return pm.resolveActivity(intent, PackageManager.ResolveInfoFlags.of(0)) != null;
+    return CompatHelper.getInstance().resolveActivity(pm, intent, Compat.ResolveInfoFlags.of(0)) != null;
   }
 
   public static @Nullable Intent makeSystemLocationSettingIntent(@NonNull Context context)


### PR DESCRIPTION
### What is this?

This is a common interface that would help abstract away the differences between the deprecated and non-deprecated APIs.
(Inspired by the AnkiDroid implementation.)

### What each file does:

- The Compat interface and its implementations are needed in the above code to provide a unified API that can be used across different versions of the Android platform.
- The CompatHelper class is a singleton that has a private constructor and exposes a compat property that returns an instance of the Compat interface. It uses a when expression to decide which implementation of the Compat interface to use based on the Android SDK version of the device.
- The CompatV21 class is an implementation of the Compat interface that supports Android API level 21 and above. This is the base implementation of Compat.
- The CompatV23 class is an implementation of the Compat interface that supports Android API level 23 and above. It uses the non-deprecated hour and minute properties to get and set the hour and minute values of a TimePicker widget.

### Why we need this:

- If we had to implement the same without this compact system we would need to check the `Build.VERSION_CODES` every time we used any of the deprecated APIs which would lead to more maintenance & a lot of repeated code.
- Encapsulation: The implementation details of each Compat version are encapsulated within their respective classes, which means that other parts of the codebase don't need to know or care about the differences in the TimePicker API between different Android versions.

### Other:
I had originally implemented it in Kotlin https://github.com/organicmaps/organicmaps/pull/4801
There is still some work to be done here (mostly comments & documentation for the developer)
Any feedback on this would be really appreciated.