### PR TITLE
[android] Map fragments improvements

### DIFF
--- a/android/res/layout/activity_map.xml
+++ b/android/res/layout/activity_map.xml
@@ -1,7 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <androidx.coordinatorlayout.widget.CoordinatorLayout
   xmlns:android="http://schemas.android.com/apk/res/android"
-  xmlns:app="http://schemas.android.com/apk/res-auto"
   xmlns:tools="http://schemas.android.com/tools"
   android:id="@+id/coordinator"
   android:layout_width="match_parent"
@@ -51,26 +50,9 @@
       android:paddingBottom="@dimen/margin_base"
       android:visibility="invisible" />
   </RelativeLayout>
-  <androidx.core.widget.NestedScrollViewClickFixed
-    android:id="@+id/placepage"
-    android:layout_width="match_parent"
-    android:layout_height="wrap_content"
-    style="?attr/bottomSheetStyle"
-    android:fillViewport="true"
-    app:layout_behavior="@string/placepage_behavior" >
-    <RelativeLayout
-      android:id="@+id/placepage_container"
-      android:layout_width="match_parent"
-      android:layout_height="wrap_content"
-      android:background="?panel" >
-      <androidx.fragment.app.FragmentContainerView
-        android:id="@+id/placepage_fragment"
-        android:layout_width="match_parent"
-        android:layout_height="wrap_content" />
-    </RelativeLayout>
-  </androidx.core.widget.NestedScrollViewClickFixed>
   <androidx.fragment.app.FragmentContainerView
-    android:id="@+id/pp_buttons_fragment"
+    android:id="@+id/place_page_container_fragment"
     android:layout_width="match_parent"
-    android:layout_height="match_parent" />
+    android:layout_height="match_parent"
+    android:name="app.organicmaps.widget.placepage.PlacePageController" />
 </androidx.coordinatorlayout.widget.CoordinatorLayout>

--- a/android/res/layout/place_page_container_fragment.xml
+++ b/android/res/layout/place_page_container_fragment.xml
@@ -1,0 +1,29 @@
+<?xml version="1.0" encoding="utf-8"?>
+<androidx.coordinatorlayout.widget.CoordinatorLayout
+  xmlns:android="http://schemas.android.com/apk/res/android"
+  xmlns:app="http://schemas.android.com/apk/res-auto"
+  android:layout_width="match_parent"
+  android:layout_height="match_parent">
+  <androidx.core.widget.NestedScrollViewClickFixed
+    android:id="@+id/placepage"
+    style="?attr/bottomSheetStyle"
+    android:layout_width="match_parent"
+    android:layout_height="wrap_content"
+    android:fillViewport="true"
+    app:layout_behavior="@string/placepage_behavior">
+    <RelativeLayout
+      android:id="@+id/placepage_container"
+      android:layout_width="match_parent"
+      android:layout_height="wrap_content"
+      android:background="?panel">
+      <androidx.fragment.app.FragmentContainerView
+        android:id="@+id/placepage_fragment"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content" />
+    </RelativeLayout>
+  </androidx.core.widget.NestedScrollViewClickFixed>
+  <androidx.fragment.app.FragmentContainerView
+    android:id="@+id/pp_buttons_fragment"
+    android:layout_width="match_parent"
+    android:layout_height="match_parent" />
+</androidx.coordinatorlayout.widget.CoordinatorLayout>

--- a/android/src/app/organicmaps/MwmActivity.java
+++ b/android/src/app/organicmaps/MwmActivity.java
@@ -27,6 +27,7 @@ import androidx.fragment.app.Fragment;
 import androidx.fragment.app.FragmentFactory;
 import androidx.fragment.app.FragmentManager;
 import androidx.fragment.app.FragmentTransaction;
+import androidx.lifecycle.LiveData;
 import androidx.lifecycle.ViewModelProvider;
 import app.organicmaps.Framework.PlacePageActivationListener;
 import app.organicmaps.api.Const;
@@ -57,6 +58,7 @@ import app.organicmaps.location.LocationHelper;
 import app.organicmaps.location.LocationListener;
 import app.organicmaps.location.LocationState;
 import app.organicmaps.maplayer.MapButtonsController;
+import app.organicmaps.maplayer.MapButtonsViewModel;
 import app.organicmaps.maplayer.Mode;
 import app.organicmaps.maplayer.ToggleMapLayerFragment;
 import app.organicmaps.maplayer.isolines.IsolinesManager;
@@ -114,8 +116,7 @@ public class MwmActivity extends BaseMwmFragmentActivity
                NoConnectionListener,
                MenuBottomSheetFragment.MenuBottomSheetInterfaceWithHeader,
                PlacePageController.PlacePageRouteSettingsListener,
-               MapButtonsController.MapButtonClickListener,
-               ToggleMapLayerFragment.LayerItemClickListener,
+               MapButtonsController.MapButtonClickListener
 {
   private static final String TAG = MwmActivity.class.getSimpleName();
 
@@ -130,8 +131,6 @@ public class MwmActivity extends BaseMwmFragmentActivity
                                                      EditorHostFragment.class.getName(),
                                                      ReportFragment.class.getName() };
 
-  private static final String EXTRA_CURRENT_LAYOUT_MODE = "CURRENT_LAYOUT_MODE";
-  private static final String EXTRA_IS_FULLSCREEN = "IS_FULLSCREEN";
   public static final int REQ_CODE_ERROR_DRIVING_OPTIONS_DIALOG = 5;
   public static final int REQ_CODE_DRIVING_OPTIONS = 6;
   private static final int REQ_CODE_ISOLINES_ERROR = 8;
@@ -169,12 +168,7 @@ public class MwmActivity extends BaseMwmFragmentActivity
   private PanelAnimator mPanelAnimator;
   @Nullable
   private OnmapDownloader mOnmapDownloader;
-
-  @Nullable
-  private MapButtonsController mMapButtonsController;
-
   private boolean mIsTabletLayout;
-  private boolean mIsFullscreen;
   @SuppressWarnings("NotNullFieldNotInitialized")
   @NonNull
   private FloatingSearchToolbarController mSearchController;
@@ -182,13 +176,14 @@ public class MwmActivity extends BaseMwmFragmentActivity
   private boolean mRestoreRoutingPlanFragmentNeeded;
   @Nullable
   private Bundle mSavedForTabletState;
-  private MapButtonsController.LayoutMode mCurrentLayoutMode;
-
   private String mDonatesUrl;
 
   private int mNavBarHeight;
 
   private PlacePageViewModel mPlacePageViewModel;
+  private MapButtonsViewModel mMapButtonsViewModel;
+  private MapButtonsController.LayoutMode mPreviousMapLayoutMode;
+  private Mode mPreviousLayerMode;
 
   @Nullable
   private WindowInsetsCompat mCurrentWindowInsets;
@@ -365,15 +360,6 @@ public class MwmActivity extends BaseMwmFragmentActivity
   protected void onSafeCreate(@Nullable Bundle savedInstanceState)
   {
     super.onSafeCreate(savedInstanceState);
-    if (savedInstanceState != null)
-    {
-      mCurrentLayoutMode = MapButtonsController.LayoutMode.values()[savedInstanceState.getInt(EXTRA_CURRENT_LAYOUT_MODE)];
-      mIsFullscreen = savedInstanceState.getBoolean(EXTRA_IS_FULLSCREEN);
-    }
-    else
-    {
-      mCurrentLayoutMode = MapButtonsController.LayoutMode.regular;
-    }
     mIsTabletLayout = getResources().getBoolean(R.bool.tabletLayout);
 
     if (!mIsTabletLayout)
@@ -383,6 +369,12 @@ public class MwmActivity extends BaseMwmFragmentActivity
     UiUtils.setupTransparentStatusBar(this);
 
     mPlacePageViewModel = new ViewModelProvider(this).get(PlacePageViewModel.class);
+    mMapButtonsViewModel = new ViewModelProvider(this).get(MapButtonsViewModel.class);
+    // We don't need to manually handle removing the observers it follows the activity lifecycle
+    mMapButtonsViewModel.getBottomButtonsHeight().observe(this, this::onMapBottomButtonsHeightChange);
+    mMapButtonsViewModel.getLayoutMode().observe(this, this::initNavigationButtons);
+    mPreviousLayerMode = mMapButtonsViewModel.getMapLayerMode().getValue();
+    mMapButtonsViewModel.getMapLayerMode().observe(this, this::onLayerChange);
 
     mSearchController = new FloatingSearchToolbarController(this, this);
     mSearchController.getToolbar()
@@ -419,7 +411,7 @@ public class MwmActivity extends BaseMwmFragmentActivity
       UiUtils.setViewInsetsPaddingBottom(mPointChooser, windowInsets);
       UiUtils.setViewInsetsPaddingNoBottom(mPointChooserToolbar, windowInsets);
 
-      mNavBarHeight = mIsFullscreen ? 0 : windowInsets.getInsets(WindowInsetsCompat.Type.systemBars()).bottom;
+      mNavBarHeight = isFullscreen() ? 0 : windowInsets.getInsets(WindowInsetsCompat.Type.systemBars()).bottom;
       // For the first loading, set compass top margin to status bar size
       // The top inset will be then be updated by the routing controller
       if (mCurrentWindowInsets == null)
@@ -460,7 +452,7 @@ public class MwmActivity extends BaseMwmFragmentActivity
       removeCurrentFragment(false);
     }
 
-    mNavigationController = new NavigationController(this, mMapButtonsController, v -> onSettingsOptionSelected(), this::updateBottomWidgetsOffset);
+    mNavigationController = new NavigationController(this, v -> onSettingsOptionSelected(), this::updateBottomWidgetsOffset);
     //TrafficManager.INSTANCE.attach(mNavigationController);
 
     initMainMenu();
@@ -560,7 +552,7 @@ public class MwmActivity extends BaseMwmFragmentActivity
     mPointChooserMode = mode;
     closeFloatingToolbarsAndPanels(false);
     UiUtils.show(mPointChooser);
-    mMapButtonsController.showMapButtons(false);
+    mMapButtonsViewModel.setButtonsHidden(true);
     Framework.nativeTurnOnChoosePositionMode(isBusiness, applyPosition);
     refreshLightStatusBar();
   }
@@ -569,7 +561,7 @@ public class MwmActivity extends BaseMwmFragmentActivity
   {
     UiUtils.hide(mPointChooser);
     Framework.nativeTurnOffChoosePositionMode();
-    mMapButtonsController.showMapButtons(true);
+    mMapButtonsViewModel.setButtonsHidden(false);
     if (mPointChooserMode == PointChooserMode.API)
       finish();
     mPointChooserMode = PointChooserMode.NONE;
@@ -608,31 +600,29 @@ public class MwmActivity extends BaseMwmFragmentActivity
 
   private void initNavigationButtons()
   {
-    initNavigationButtons(mCurrentLayoutMode);
+    initNavigationButtons(mMapButtonsViewModel.getLayoutMode().getValue());
   }
 
   private void initNavigationButtons(MapButtonsController.LayoutMode layoutMode)
   {
-    if (mMapButtonsController == null || mMapButtonsController.getLayoutMode() != layoutMode)
+    // Recreate the navigation buttons with the correct layout when it changes
+    if (mPreviousMapLayoutMode != layoutMode)
     {
-      mCurrentLayoutMode = layoutMode;
-
-      mMapButtonsController = new MapButtonsController();
-      mMapButtonsController.init(
-          layoutMode,
-          LocationState.nativeGetMode(),
-          this::onMapButtonClick,
-          (v) -> closeSearchToolbar(true, true),
-          this::updateBottomWidgetsOffset);
-
-
       FragmentTransaction transaction = getSupportFragmentManager()
-          .beginTransaction().replace(R.id.map_buttons, mMapButtonsController);
+          .beginTransaction().replace(R.id.map_buttons, new MapButtonsController());
       transaction.commit();
+      mPreviousMapLayoutMode = layoutMode;
     }
   }
 
-  void onMapButtonClick(MapButtonsController.MapButtons button)
+  @Override
+  public void onSearchCanceled()
+  {
+    closeSearchToolbar(true, true);
+  }
+
+  @Override
+  public void onMapButtonClick(MapButtonsController.MapButtons button)
   {
     switch (button)
     {
@@ -756,7 +746,7 @@ public class MwmActivity extends BaseMwmFragmentActivity
       if (stopSearch)
       {
         mSearchController.cancelSearchApiAndHide(clearText);
-        mMapButtonsController.resetSearch();
+        mMapButtonsViewModel.setSearchOption(null);
       }
       else
       {
@@ -836,8 +826,6 @@ public class MwmActivity extends BaseMwmFragmentActivity
     mNavigationController.onActivitySaveInstanceState(this, outState);
 
     RoutingController.get().onSaveState();
-    outState.putInt(EXTRA_CURRENT_LAYOUT_MODE, mCurrentLayoutMode.ordinal());
-    outState.putBoolean(EXTRA_IS_FULLSCREEN, mIsFullscreen);
 
     if (!isChangingConfigurations())
       RoutingController.get().saveRoute();
@@ -983,11 +971,11 @@ public class MwmActivity extends BaseMwmFragmentActivity
   {
     super.onResume();
     refreshSearchToolbar();
-    setFullscreen(mIsFullscreen);
+    setFullscreen(isFullscreen());
     if (Framework.nativeIsInChoosePositionMode())
     {
       UiUtils.show(mPointChooser);
-      mMapButtonsController.showMapButtons(false);
+      mMapButtonsViewModel.setButtonsHidden(true);
     }
     if (mOnmapDownloader != null)
       mOnmapDownloader.onResume();
@@ -1154,7 +1142,7 @@ public class MwmActivity extends BaseMwmFragmentActivity
           UiUtils.isVisible(mSearchController.getToolbar()))
         return;
 
-      setFullscreen(!mIsFullscreen);
+      setFullscreen(!isFullscreen());
     }
     else
     {
@@ -1169,9 +1157,14 @@ public class MwmActivity extends BaseMwmFragmentActivity
         || RoutingController.get().isPlanning())
       return;
 
-    mIsFullscreen = isFullscreen;
-    mMapButtonsController.showMapButtons(!isFullscreen);
+    mMapButtonsViewModel.setButtonsHidden(isFullscreen);
     UiUtils.setFullscreen(this, isFullscreen);
+  }
+
+  private boolean isFullscreen()
+  {
+    // Buttons are hidden in position chooser mode but we are not in fullscreen
+    return Boolean.TRUE.equals(mMapButtonsViewModel.getButtonsHidden().getValue()) && !Framework.nativeIsInChoosePositionMode();
   }
 
   @Override
@@ -1206,6 +1199,10 @@ public class MwmActivity extends BaseMwmFragmentActivity
       Map.onCompassUpdated(north, true);
   }
 
+  public void onMapBottomButtonsHeightChange(float height) {
+    updateBottomWidgetsOffset();
+  }
+
   public void updateBottomWidgetsOffset()
   {
     updateBottomWidgetsOffset(-1);
@@ -1217,8 +1214,9 @@ public class MwmActivity extends BaseMwmFragmentActivity
       return;
 
     int offsetY = mNavBarHeight;
-    if (mMapButtonsController != null)
-      offsetY = Math.max(offsetY, (int) mMapButtonsController.getBottomButtonsHeight() + mNavBarHeight);
+    final Float bottomButtonHeight = mMapButtonsViewModel.getBottomButtonsHeight().getValue();
+    if (bottomButtonHeight != null)
+      offsetY = Math.max(offsetY, bottomButtonHeight.intValue() + mNavBarHeight);
     if (mMainMenu != null)
       offsetY = Math.max(offsetY, mMainMenu.getMenuHeight());
 
@@ -1255,17 +1253,17 @@ public class MwmActivity extends BaseMwmFragmentActivity
     {
       mNavigationController.show(true);
       closeSearchToolbar(false, false);
-      mMainMenu.setState(MainMenu.State.NAVIGATION, mIsFullscreen);
+      mMainMenu.setState(MainMenu.State.NAVIGATION, isFullscreen());
       return;
     }
 
     if (RoutingController.get().isPlanning())
     {
-      mMainMenu.setState(MainMenu.State.ROUTE_PREPARE, mIsFullscreen);
+      mMainMenu.setState(MainMenu.State.ROUTE_PREPARE, isFullscreen());
       return;
     }
 
-    mMainMenu.setState(MainMenu.State.MENU, mIsFullscreen);
+    mMainMenu.setState(MainMenu.State.MENU, isFullscreen());
   }
 
   private boolean adjustMenuLineFrameVisibility()
@@ -1492,7 +1490,8 @@ public class MwmActivity extends BaseMwmFragmentActivity
 
     mRoutingPlanInplaceController.hideDrivingOptionsView();
     mNavigationController.stop(this);
-    initNavigationButtons(MapButtonsController.LayoutMode.regular);
+    mMapButtonsViewModel.setSearchOption(null);
+    mMapButtonsViewModel.setLayoutMode(MapButtonsController.LayoutMode.regular);
     refreshLightStatusBar();
   }
 
@@ -1502,7 +1501,7 @@ public class MwmActivity extends BaseMwmFragmentActivity
     closeFloatingToolbarsAndPanels(true);
     ThemeSwitcher.INSTANCE.restart(isMapRendererActive());
     mNavigationController.start(this);
-    initNavigationButtons(MapButtonsController.LayoutMode.navigation);
+    mMapButtonsViewModel.setLayoutMode(MapButtonsController.LayoutMode.navigation);
     refreshLightStatusBar();
   }
 
@@ -1510,7 +1509,7 @@ public class MwmActivity extends BaseMwmFragmentActivity
   public void onPlanningCancelled()
   {
     closeFloatingToolbarsAndPanels(true);
-    initNavigationButtons(MapButtonsController.LayoutMode.regular);
+    mMapButtonsViewModel.setLayoutMode(MapButtonsController.LayoutMode.regular);
     refreshLightStatusBar();
   }
 
@@ -1518,7 +1517,7 @@ public class MwmActivity extends BaseMwmFragmentActivity
   public void onPlanningStarted()
   {
     closeFloatingToolbarsAndPanels(true);
-    initNavigationButtons(MapButtonsController.LayoutMode.planning);
+    mMapButtonsViewModel.setLayoutMode(MapButtonsController.LayoutMode.planning);
     refreshLightStatusBar();
   }
 
@@ -1528,7 +1527,8 @@ public class MwmActivity extends BaseMwmFragmentActivity
     closeFloatingToolbarsAndPanels(true);
     ThemeSwitcher.INSTANCE.restart(isMapRendererActive());
     mNavigationController.stop(this);
-    initNavigationButtons(MapButtonsController.LayoutMode.planning);
+    mMapButtonsViewModel.setSearchOption(null);
+    mMapButtonsViewModel.setLayoutMode(MapButtonsController.LayoutMode.planning);
     refreshLightStatusBar();
   }
 
@@ -1591,7 +1591,7 @@ public class MwmActivity extends BaseMwmFragmentActivity
   public void onMyPositionModeChanged(int newMode)
   {
     Logger.d(TAG, "location newMode = " + newMode);
-    mMapButtonsController.updateNavMyPositionButton(newMode);
+    mMapButtonsViewModel.setMyPositionMode(newMode);
     RoutingController controller = RoutingController.get();
     if (controller.isPlanning())
       showAddStartOrFinishFrame(controller, true);
@@ -1767,12 +1767,11 @@ public class MwmActivity extends BaseMwmFragmentActivity
     shareMyLocation();
   }
 
-  @Override
-  public void onLayerItemClick(@NonNull Mode mode)
+  public void onLayerChange(Mode mode)
   {
-    closeFloatingPanels();
-    if (mMapButtonsController != null)
-      mMapButtonsController.toggleMapLayer(mode);
+    if (mPreviousLayerMode != mode)
+      closeFloatingPanels();
+    mPreviousLayerMode = mode;
   }
 
   @Override

--- a/android/src/app/organicmaps/maplayer/MapButtonsViewModel.java
+++ b/android/src/app/organicmaps/maplayer/MapButtonsViewModel.java
@@ -1,0 +1,75 @@
+package app.organicmaps.maplayer;
+
+import androidx.annotation.Nullable;
+import androidx.lifecycle.MutableLiveData;
+import androidx.lifecycle.ViewModel;
+
+public class MapButtonsViewModel extends ViewModel
+{
+  private final MutableLiveData<Boolean> mButtonsHidden = new MutableLiveData<>(false);
+  private final MutableLiveData<Float> mBottomButtonsHeight = new MutableLiveData<>(0f);
+  private final MutableLiveData<MapButtonsController.LayoutMode> mLayoutMode = new MutableLiveData<>(MapButtonsController.LayoutMode.regular);
+  private final MutableLiveData<Integer> mMyPositionMode = new MutableLiveData<>();
+  private final MutableLiveData<Mode> mMapLayerMode = new MutableLiveData<>();
+  private final MutableLiveData<SearchWheel.SearchOption> mSearchOption = new MutableLiveData<>();
+
+  public MutableLiveData<Boolean> getButtonsHidden()
+  {
+    return mButtonsHidden;
+  }
+
+  public void setButtonsHidden(boolean buttonsHidden)
+  {
+    mButtonsHidden.setValue(buttonsHidden);
+  }
+
+  public MutableLiveData<Float> getBottomButtonsHeight()
+  {
+    return mBottomButtonsHeight;
+  }
+
+  public void setBottomButtonsHeight(float height)
+  {
+    mBottomButtonsHeight.setValue(height);
+  }
+
+  public MutableLiveData<MapButtonsController.LayoutMode> getLayoutMode()
+  {
+    return mLayoutMode;
+  }
+
+  public void setLayoutMode(MapButtonsController.LayoutMode layoutMode)
+  {
+    mLayoutMode.setValue(layoutMode);
+  }
+
+  public MutableLiveData<Integer> getMyPositionMode()
+  {
+    return mMyPositionMode;
+  }
+
+  public void setMyPositionMode(int mode)
+  {
+    mMyPositionMode.setValue(mode);
+  }
+
+  public MutableLiveData<Mode> getMapLayerMode()
+  {
+    return mMapLayerMode;
+  }
+
+  public void setMapLayerMode(Mode mode)
+  {
+    mMapLayerMode.setValue(mode);
+  }
+
+  public MutableLiveData<SearchWheel.SearchOption> getSearchOption()
+  {
+    return mSearchOption;
+  }
+
+  public void setSearchOption(@Nullable SearchWheel.SearchOption searchOption)
+  {
+    mSearchOption.setValue(searchOption);
+  }
+}

--- a/android/src/app/organicmaps/maplayer/MapLayersController.java
+++ b/android/src/app/organicmaps/maplayer/MapLayersController.java
@@ -23,21 +23,19 @@ public class MapLayersController
   OnShowMenuListener mOnShowMenuListener;
   @NonNull
   private Mode mCurrentLayer;
+  private final MapButtonsViewModel mMapButtonsViewModel;
 
-  public MapLayersController(@NonNull ImageButton layersButton, @NonNull OnShowMenuListener onShowMenuListener, @NonNull Activity activity)
+  public MapLayersController(@NonNull ImageButton layersButton, @NonNull OnShowMenuListener onShowMenuListener, @NonNull Activity activity, MapButtonsViewModel mapButtonsViewModel)
   {
     mActivity = activity;
+    mMapButtonsViewModel = mapButtonsViewModel;
     mLayersButton = layersButton;
     mLayersButton.setOnClickListener(view -> onLayersButtonClick());
     mOnShowMenuListener = onShowMenuListener;
     mLayers = LayersUtils.getAvailableLayers();
     mCurrentLayer = getCurrentLayer();
-    initMode();
-  }
-
-  private void initMode()
-  {
-    setEnabled(mCurrentLayer.isEnabled(mActivity));
+    // View model only expects a layer if it is active
+    mMapButtonsViewModel.setMapLayerMode(mCurrentLayer.isEnabled(activity) ? mCurrentLayer : null);
     showButton(true);
   }
 
@@ -76,16 +74,21 @@ public class MapLayersController
   private void onLayersButtonClick()
   {
     if (mCurrentLayer.isEnabled(mActivity))
-      setEnabled(false);
+      mMapButtonsViewModel.setMapLayerMode(null);
     else
       mOnShowMenuListener.onShow();
   }
 
-  public void toggleMode(@NonNull Mode mode)
+  public void disableModes()
+  {
+    setEnabled(false);
+  }
+
+  public void enableMode(@NonNull Mode mode)
   {
     setCurrentLayer(mode);
     showButton(true);
-    setEnabled(!mode.isEnabled(mActivity));
+    setEnabled(true);
   }
 
   public void showButton(boolean show)

--- a/android/src/app/organicmaps/maplayer/ToggleMapLayerFragment.java
+++ b/android/src/app/organicmaps/maplayer/ToggleMapLayerFragment.java
@@ -9,14 +9,14 @@ import android.view.ViewGroup;
 import androidx.annotation.NonNull;
 import androidx.annotation.Nullable;
 import androidx.fragment.app.Fragment;
+import androidx.lifecycle.ViewModelProvider;
 import androidx.recyclerview.widget.LinearLayoutManager;
 import androidx.recyclerview.widget.RecyclerView;
-
 import app.organicmaps.R;
 import app.organicmaps.maplayer.isolines.IsolinesManager;
-import app.organicmaps.widget.recycler.SpanningLinearLayoutManager;
 import app.organicmaps.util.SharedPropertiesUtils;
 import app.organicmaps.util.Utils;
+import app.organicmaps.widget.recycler.SpanningLinearLayoutManager;
 
 import java.util.ArrayList;
 import java.util.List;
@@ -24,9 +24,8 @@ import java.util.List;
 public class ToggleMapLayerFragment extends Fragment
 {
   @Nullable
-  private LayerItemClickListener mLayerItemClickListener;
-  @Nullable
   private LayersAdapter mAdapter;
+  private MapButtonsViewModel mMapButtonsViewModel;
 
   @Nullable
   @Override
@@ -34,8 +33,7 @@ public class ToggleMapLayerFragment extends Fragment
   {
     View mRoot = inflater.inflate(R.layout.fragment_toggle_map_layer, container, false);
 
-    if (requireActivity() instanceof LayerItemClickListener)
-      mLayerItemClickListener = ((LayerItemClickListener) requireActivity());
+    mMapButtonsViewModel = new ViewModelProvider(requireActivity()).get(MapButtonsViewModel.class);
 
     initRecycler(mRoot);
     return mRoot;
@@ -72,12 +70,6 @@ public class ToggleMapLayerFragment extends Fragment
     mAdapter.notifyDataSetChanged();
     if (IsolinesManager.from(context).shouldShowNotification())
       Utils.showSnackbar(context, v.getRootView(), R.string.isolines_toast_zooms_1_10);
-    if (mLayerItemClickListener != null)
-      mLayerItemClickListener.onLayerItemClick(mode);
-  }
-
-  public interface LayerItemClickListener
-  {
-    void onLayerItemClick(@NonNull Mode mode);
+    mMapButtonsViewModel.setMapLayerMode(mode);
   }
 }

--- a/android/src/app/organicmaps/routing/NavigationController.java
+++ b/android/src/app/organicmaps/routing/NavigationController.java
@@ -21,17 +21,16 @@ import androidx.appcompat.app.AppCompatActivity;
 import androidx.core.view.ViewCompat;
 import androidx.core.view.WindowInsetsCompat;
 import androidx.recyclerview.widget.RecyclerView;
-import com.google.android.material.bottomsheet.BottomSheetBehavior;
 import app.organicmaps.Framework;
 import app.organicmaps.MwmActivity;
 import app.organicmaps.R;
 import app.organicmaps.base.MediaPlayerWrapper;
-import app.organicmaps.maplayer.MapButtonsController;
 import app.organicmaps.maplayer.traffic.TrafficManager;
 import app.organicmaps.sound.TtsPlayer;
-import app.organicmaps.widget.menu.NavMenu;
 import app.organicmaps.util.UiUtils;
 import app.organicmaps.util.Utils;
+import app.organicmaps.widget.menu.NavMenu;
+import com.google.android.material.bottomsheet.BottomSheetBehavior;
 
 import java.util.Arrays;
 
@@ -59,10 +58,7 @@ public class NavigationController implements Application.ActivityLifecycleCallba
   private final RecyclerView mLanes;
   @NonNull
   private final LanesAdapter mLanesAdapter;
-
-  @NonNull
-  private final MapButtonsController mMapButtonsController;
-
+  
   @NonNull
   private final MediaPlayer.OnCompletionListener mSpeedCamSignalCompletionListener;
 
@@ -106,13 +102,12 @@ public class NavigationController implements Application.ActivityLifecycleCallba
     mLanes.setNestedScrollingEnabled(false);
   }
 
-  public NavigationController(AppCompatActivity activity, @NonNull MapButtonsController mapButtonsController,
-                              View.OnClickListener onSettingsClickListener, NavMenu.OnMenuSizeChangedListener onMenuSizeChangedListener)
+  public NavigationController(AppCompatActivity activity, View.OnClickListener onSettingsClickListener,
+                              NavMenu.OnMenuSizeChangedListener onMenuSizeChangedListener)
   {
     mFrame = activity.findViewById(R.id.navigation_frame);
     mNavMenu = new NavMenu(activity, this, onMenuSizeChangedListener);
     mOnSettingsClickListener = onSettingsClickListener;
-    mMapButtonsController = mapButtonsController;
 
     // Top frame
     View topFrame = mFrame.findViewById(R.id.nav_top_frame);
@@ -154,8 +149,6 @@ public class NavigationController implements Application.ActivityLifecycleCallba
 
   public void stop(MwmActivity parent)
   {
-    mMapButtonsController.resetSearch();
-
     if (mBound)
     {
       parent.unbindService(mServiceConnection);
@@ -330,7 +323,6 @@ public class NavigationController implements Application.ActivityLifecycleCallba
   public void onActivitySaveInstanceState(@NonNull Activity activity, @NonNull Bundle outState)
   {
     outState.putBoolean(STATE_BOUND, mBound);
-    mMapButtonsController.saveNavSearchState(outState);
   }
 
   public void onRestoreState(@NonNull Bundle savedInstanceState, @NonNull MwmActivity parent)
@@ -338,7 +330,6 @@ public class NavigationController implements Application.ActivityLifecycleCallba
     mBound = savedInstanceState.getBoolean(STATE_BOUND);
     if (mBound)
       start(parent);
-    mMapButtonsController.restoreNavSearchState(savedInstanceState);
   }
 
   @Override

--- a/android/src/app/organicmaps/widget/menu/MyPositionButton.java
+++ b/android/src/app/organicmaps/widget/menu/MyPositionButton.java
@@ -30,13 +30,13 @@ public class MyPositionButton
 
   private final int mFollowPaddingShift;
 
-  public MyPositionButton(@NonNull View button, int myPositionMode, @NonNull View.OnClickListener listener)
+  public MyPositionButton(@NonNull View button, @NonNull View.OnClickListener listener)
   {
     mButton = (FloatingActionButton) button;
     mButton.setOnClickListener(listener);
     mIcons.clear();
     mFollowPaddingShift = (int) (FOLLOW_SHIFT * button.getResources().getDisplayMetrics().density);
-    update(myPositionMode);
+    update(LocationState.nativeGetMode());
   }
 
   public void update(int mode)

--- a/android/src/app/organicmaps/widget/placepage/PlacePageButtons.java
+++ b/android/src/app/organicmaps/widget/placepage/PlacePageButtons.java
@@ -1,6 +1,5 @@
 package app.organicmaps.widget.placepage;
 
-import android.content.Context;
 import android.os.Bundle;
 import android.view.LayoutInflater;
 import android.view.View;
@@ -50,28 +49,24 @@ public final class PlacePageButtons extends Fragment implements Observer<List<Pl
       return windowInsets;
     });
     mMaxButtons = getResources().getInteger(R.integer.pp_buttons_max);
-    mViewModel.getCurrentButtons().observe(requireActivity(), this);
+
+    Fragment parentFragment = getParentFragment();
+    mItemListener = (PlacePageButtonClickListener) parentFragment;
+
     createButtons(mViewModel.getCurrentButtons().getValue());
   }
 
   @Override
-  public void onAttach(@NonNull Context context)
+  public void onStart()
   {
-    super.onAttach(context);
-    try
-    {
-      mItemListener = (PlacePageButtonClickListener) context;
-    }
-    catch (ClassCastException e)
-    {
-      throw new ClassCastException(context + " must implement PlacePageButtonClickListener");
-    }
+    super.onStart();
+    mViewModel.getCurrentButtons().observe(requireActivity(), this);
   }
 
   @Override
-  public void onDestroyView()
+  public void onStop()
   {
-    super.onDestroyView();
+    super.onStop();
     mViewModel.getCurrentButtons().removeObserver(this);
   }
 
@@ -94,7 +89,7 @@ public final class PlacePageButtons extends Fragment implements Observer<List<Pl
   private void showMoreBottomSheet()
   {
     MenuBottomSheetFragment.newInstance(PLACEPAGE_MORE_MENU_ID)
-                           .show(requireActivity().getSupportFragmentManager(), PLACEPAGE_MORE_MENU_ID);
+                           .show(getParentFragmentManager(), PLACEPAGE_MORE_MENU_ID);
   }
 
   private void createButtons(@Nullable List<ButtonType> buttons)

--- a/android/src/app/organicmaps/widget/placepage/PlacePageController.java
+++ b/android/src/app/organicmaps/widget/placepage/PlacePageController.java
@@ -81,7 +81,7 @@ public class PlacePageController extends Fragment implements
       if (PlacePageUtils.isSettlingState(newState) || PlacePageUtils.isDraggingState(newState))
         return;
 
-      PlacePageUtils.moveViewportUp(mPlacePage, mViewportMinHeight);
+      PlacePageUtils.updateMapViewport(mCoordinator, mDistanceToTop, mViewportMinHeight);
 
       if (PlacePageUtils.isHiddenState(newState))
         onHiddenInternal();
@@ -165,7 +165,7 @@ public class PlacePageController extends Fragment implements
   private void onHiddenInternal()
   {
     Framework.nativeDeactivatePopup();
-    PlacePageUtils.moveViewportUp(mPlacePage, mViewportMinHeight);
+    PlacePageUtils.updateMapViewport(mCoordinator, mDistanceToTop, mViewportMinHeight);
     resetPlacePageHeightBounds();
     removePlacePageFragments();
   }
@@ -281,7 +281,7 @@ public class PlacePageController extends Fragment implements
       mViewModel.setPlacePageDistanceToTop(mDistanceToTop);
       if (value == peekHeight)
       {
-        PlacePageUtils.moveViewportUp(mPlacePage, mViewportMinHeight);
+        PlacePageUtils.updateMapViewport(mCoordinator, mDistanceToTop, mViewportMinHeight);
         setPlacePageHeightBounds();
       }
     });

--- a/android/src/app/organicmaps/widget/placepage/PlacePageUtils.java
+++ b/android/src/app/organicmaps/widget/placepage/PlacePageUtils.java
@@ -15,7 +15,7 @@ import com.google.android.material.bottomsheet.BottomSheetBehavior;
 
 import java.util.List;
 
-class PlacePageUtils
+public class PlacePageUtils
 {
   static void moveViewportUp(@NonNull View placePageView, int viewportMinHeight)
   {
@@ -84,7 +84,7 @@ class PlacePageUtils
     }
   }
 
-  static void copyToClipboard(Context context, View frame, String text)
+  public static void copyToClipboard(Context context, View frame, String text)
   {
     Utils.copyTextToClipboard(context, text);
     Utils.showSnackbarAbove(frame,
@@ -92,7 +92,7 @@ class PlacePageUtils
                             context.getString(R.string.copied_to_clipboard, text));
   }
 
-  static void showCopyPopup(Context context, View popupAnchor, View frame, List<String> items)
+  public static void showCopyPopup(Context context, View popupAnchor, View frame, List<String> items)
   {
     final PopupMenu popup = new PopupMenu(context, popupAnchor);
     final Menu menu = popup.getMenu();

--- a/android/src/app/organicmaps/widget/placepage/PlacePageUtils.java
+++ b/android/src/app/organicmaps/widget/placepage/PlacePageUtils.java
@@ -1,10 +1,8 @@
 package app.organicmaps.widget.placepage;
 
 import android.content.Context;
-import android.graphics.Rect;
 import android.view.Menu;
 import android.view.View;
-import android.view.ViewGroup;
 import android.widget.PopupMenu;
 
 import androidx.annotation.NonNull;
@@ -17,18 +15,12 @@ import java.util.List;
 
 public class PlacePageUtils
 {
-  static void moveViewportUp(@NonNull View placePageView, int viewportMinHeight)
+  static void updateMapViewport(@NonNull View parent, int placePageDistanceToTop, int viewportMinHeight)
   {
-    placePageView.post(() -> {
-      final View coordinatorLayout = (ViewGroup) placePageView.getParent();
-      final int viewPortWidth = coordinatorLayout.getWidth();
-      int viewPortHeight = coordinatorLayout.getHeight();
-      Rect sheetRect = new Rect();
-      placePageView.getGlobalVisibleRect(sheetRect);
-
-      viewPortHeight -= sheetRect.height();
-      if (viewPortHeight >= viewportMinHeight)
-        Framework.nativeSetVisibleRect(0, 0, viewPortWidth, viewPortHeight);
+    parent.post(() -> {
+      final int screenWidth = parent.getWidth();
+      if (placePageDistanceToTop >= viewportMinHeight)
+        Framework.nativeSetVisibleRect(0, 0, screenWidth, placePageDistanceToTop);
     });
   }
 

--- a/android/src/app/organicmaps/widget/placepage/PlacePageView.java
+++ b/android/src/app/organicmaps/widget/placepage/PlacePageView.java
@@ -48,6 +48,11 @@ import app.organicmaps.util.StringUtils;
 import app.organicmaps.util.UiUtils;
 import app.organicmaps.util.concurrency.UiThread;
 import app.organicmaps.widget.ArrowView;
+import app.organicmaps.widget.placepage.sections.PlacePageBookmarkFragment;
+import app.organicmaps.widget.placepage.sections.PlacePageLinksFragment;
+import app.organicmaps.widget.placepage.sections.PlacePageOpeningHoursFragment;
+import app.organicmaps.widget.placepage.sections.PlacePagePhoneFragment;
+import app.organicmaps.widget.placepage.sections.PlacePageWikipediaFragment;
 
 import java.util.ArrayList;
 import java.util.Arrays;

--- a/android/src/app/organicmaps/widget/placepage/PlacePageViewModel.java
+++ b/android/src/app/organicmaps/widget/placepage/PlacePageViewModel.java
@@ -11,6 +11,8 @@ public class PlacePageViewModel extends ViewModel
 {
   private final MutableLiveData<List<PlacePageButtons.ButtonType>> mCurrentButtons = new MutableLiveData<>();
   private final MutableLiveData<MapObject> mMapObject = new MutableLiveData<>();
+  private final MutableLiveData<Integer> mPlacePageWidth = new MutableLiveData<>();
+  private final MutableLiveData<Integer> mPlacePageDistanceToTop = new MutableLiveData<>();
 
   public LiveData<List<PlacePageButtons.ButtonType>> getCurrentButtons()
   {
@@ -30,5 +32,25 @@ public class PlacePageViewModel extends ViewModel
   public void setMapObject(MapObject mapObject)
   {
     mMapObject.setValue(mapObject);
+  }
+
+  public MutableLiveData<Integer> getPlacePageWidth()
+  {
+    return mPlacePageWidth;
+  }
+
+  public void setPlacePageWidth(int width)
+  {
+    mPlacePageWidth.setValue(width);
+  }
+
+  public MutableLiveData<Integer> getPlacePageDistanceToTop()
+  {
+    return mPlacePageDistanceToTop;
+  }
+
+  public void setPlacePageDistanceToTop(int top)
+  {
+    mPlacePageDistanceToTop.setValue(top);
   }
 }

--- a/android/src/app/organicmaps/widget/placepage/sections/PlaceOpeningHoursAdapter.java
+++ b/android/src/app/organicmaps/widget/placepage/sections/PlaceOpeningHoursAdapter.java
@@ -1,4 +1,4 @@
-package app.organicmaps.widget.placepage;
+package app.organicmaps.widget.placepage.sections;
 
 import android.view.LayoutInflater;
 import android.view.View;

--- a/android/src/app/organicmaps/widget/placepage/sections/PlacePageBookmarkFragment.java
+++ b/android/src/app/organicmaps/widget/placepage/sections/PlacePageBookmarkFragment.java
@@ -1,4 +1,4 @@
-package app.organicmaps.widget.placepage;
+package app.organicmaps.widget.placepage.sections;
 
 import android.content.Context;
 import android.os.Bundle;
@@ -26,6 +26,8 @@ import app.organicmaps.bookmarks.data.MapObject;
 import app.organicmaps.util.StringUtils;
 import app.organicmaps.util.UiUtils;
 import app.organicmaps.util.Utils;
+import app.organicmaps.widget.placepage.EditBookmarkFragment;
+import app.organicmaps.widget.placepage.PlacePageViewModel;
 
 public class PlacePageBookmarkFragment extends Fragment implements View.OnClickListener,
                                                                    View.OnLongClickListener,

--- a/android/src/app/organicmaps/widget/placepage/sections/PlacePageBookmarkFragment.java
+++ b/android/src/app/organicmaps/widget/placepage/sections/PlacePageBookmarkFragment.java
@@ -75,16 +75,16 @@ public class PlacePageBookmarkFragment extends Fragment implements View.OnClickL
   }
 
   @Override
-  public void onResume()
+  public void onStart()
   {
-    super.onResume();
+    super.onStart();
     mViewModel.getMapObject().observe(requireActivity(), this);
   }
 
   @Override
-  public void onPause()
+  public void onStop()
   {
-    super.onPause();
+    super.onStop();
     mViewModel.getMapObject().removeObserver(this);
   }
 
@@ -143,12 +143,12 @@ public class PlacePageBookmarkFragment extends Fragment implements View.OnClickL
   }
 
   @Override
-  public void onChanged(MapObject mapObject)
+  public void onChanged(@Nullable MapObject mapObject)
   {
     // MapObject could be something else than a bookmark if the user already has the place page
     // opened and clicks on a non-bookmarked POI.
     // This callback would be called before the fragment had time to be destroyed
-    if (mapObject.getMapObjectType() == MapObject.BOOKMARK)
+    if (mapObject != null && mapObject.getMapObjectType() == MapObject.BOOKMARK)
     {
       currentBookmark = (Bookmark) mapObject;
       updateBookmarkDetails();

--- a/android/src/app/organicmaps/widget/placepage/sections/PlacePageLinksFragment.java
+++ b/android/src/app/organicmaps/widget/placepage/sections/PlacePageLinksFragment.java
@@ -218,23 +218,26 @@ public class PlacePageLinksFragment extends Fragment implements Observer<MapObje
   }
 
   @Override
-  public void onResume()
+  public void onStart()
   {
-    super.onResume();
+    super.onStart();
     mViewModel.getMapObject().observe(requireActivity(), this);
   }
 
   @Override
-  public void onPause()
+  public void onStop()
   {
-    super.onPause();
+    super.onStop();
     mViewModel.getMapObject().removeObserver(this);
   }
 
   @Override
-  public void onChanged(MapObject mapObject)
+  public void onChanged(@Nullable  MapObject mapObject)
   {
-    mMapObject = mapObject;
-    refreshLinks();
+    if (mapObject != null)
+    {
+      mMapObject = mapObject;
+      refreshLinks();
+    }
   }
 }

--- a/android/src/app/organicmaps/widget/placepage/sections/PlacePageLinksFragment.java
+++ b/android/src/app/organicmaps/widget/placepage/sections/PlacePageLinksFragment.java
@@ -1,4 +1,4 @@
-package app.organicmaps.widget.placepage;
+package app.organicmaps.widget.placepage.sections;
 
 import android.os.Bundle;
 import android.text.TextUtils;
@@ -17,6 +17,8 @@ import app.organicmaps.R;
 import app.organicmaps.bookmarks.data.MapObject;
 import app.organicmaps.bookmarks.data.Metadata;
 import app.organicmaps.util.Utils;
+import app.organicmaps.widget.placepage.PlacePageUtils;
+import app.organicmaps.widget.placepage.PlacePageViewModel;
 
 import java.util.ArrayList;
 import java.util.Arrays;

--- a/android/src/app/organicmaps/widget/placepage/sections/PlacePageOpeningHoursFragment.java
+++ b/android/src/app/organicmaps/widget/placepage/sections/PlacePageOpeningHoursFragment.java
@@ -27,7 +27,6 @@ import app.organicmaps.util.UiUtils;
 import app.organicmaps.util.Utils;
 import app.organicmaps.widget.placepage.PlacePageUtils;
 import app.organicmaps.widget.placepage.PlacePageViewModel;
-import app.organicmaps.widget.placepage.sections.PlaceOpeningHoursAdapter;
 
 import java.util.Calendar;
 import java.util.Locale;
@@ -91,11 +90,9 @@ public class PlacePageOpeningHoursFragment extends Fragment implements Observer<
     mTodayOpenTime.setTextColor(color);
   }
 
-  private void refreshOpeningHours()
+  private void refreshOpeningHours(MapObject mapObject)
   {
-    final String ohStr = mViewModel.getMapObject()
-                                  .getValue()
-                                  .getMetadata(Metadata.MetadataType.FMD_OPEN_HOURS);
+    final String ohStr = mapObject.getMetadata(Metadata.MetadataType.FMD_OPEN_HOURS);
     final Timetable[] timetables = OpeningHours.nativeTimetablesFromString(ohStr);
     mFrame.setOnLongClickListener((v) -> {
       PlacePageUtils.copyToClipboard(requireContext(), mFrame, TimeFormatUtils.formatTimetables(getResources(), ohStr, timetables));
@@ -173,7 +170,7 @@ public class PlacePageOpeningHoursFragment extends Fragment implements Observer<
         // Show that place is closed today.
         if (!containsCurrentWeekday)
         {
-          refreshTodayOpeningHours(resources.getString(R.string.day_off_today), ContextCompat.getColor(getContext(), R.color.base_red));
+          refreshTodayOpeningHours(resources.getString(R.string.day_off_today), ContextCompat.getColor(requireContext(), R.color.base_red));
           UiUtils.hide(mTodayNonBusinessTime);
         }
       }
@@ -181,22 +178,23 @@ public class PlacePageOpeningHoursFragment extends Fragment implements Observer<
   }
 
   @Override
-  public void onResume()
+  public void onStart()
   {
-    super.onResume();
+    super.onStart();
     mViewModel.getMapObject().observe(requireActivity(), this);
   }
 
   @Override
-  public void onPause()
+  public void onStop()
   {
-    super.onPause();
+    super.onStop();
     mViewModel.getMapObject().removeObserver(this);
   }
 
   @Override
-  public void onChanged(MapObject mapObject)
+  public void onChanged(@Nullable MapObject mapObject)
   {
-    refreshOpeningHours();
+    if (mapObject != null)
+      refreshOpeningHours(mapObject);
   }
 }

--- a/android/src/app/organicmaps/widget/placepage/sections/PlacePageOpeningHoursFragment.java
+++ b/android/src/app/organicmaps/widget/placepage/sections/PlacePageOpeningHoursFragment.java
@@ -1,4 +1,4 @@
-package app.organicmaps.widget.placepage;
+package app.organicmaps.widget.placepage.sections;
 
 import android.content.res.Resources;
 import android.os.Bundle;
@@ -25,6 +25,9 @@ import app.organicmaps.editor.data.Timetable;
 import app.organicmaps.util.ThemeUtils;
 import app.organicmaps.util.UiUtils;
 import app.organicmaps.util.Utils;
+import app.organicmaps.widget.placepage.PlacePageUtils;
+import app.organicmaps.widget.placepage.PlacePageViewModel;
+import app.organicmaps.widget.placepage.sections.PlaceOpeningHoursAdapter;
 
 import java.util.Calendar;
 import java.util.Locale;

--- a/android/src/app/organicmaps/widget/placepage/sections/PlacePagePhoneFragment.java
+++ b/android/src/app/organicmaps/widget/placepage/sections/PlacePagePhoneFragment.java
@@ -40,22 +40,23 @@ public class PlacePagePhoneFragment extends Fragment implements Observer<MapObje
   }
 
   @Override
-  public void onResume()
+  public void onStart()
   {
-    super.onResume();
+    super.onStart();
     mViewModel.getMapObject().observe(requireActivity(), this);
   }
 
   @Override
-  public void onPause()
+  public void onStop()
   {
-    super.onPause();
+    super.onStop();
     mViewModel.getMapObject().removeObserver(this);
   }
 
   @Override
-  public void onChanged(MapObject mapObject)
+  public void onChanged(@Nullable MapObject mapObject)
   {
-    mPhoneAdapter.refreshPhones(mapObject.getMetadata(Metadata.MetadataType.FMD_PHONE_NUMBER));
+    if (mapObject != null)
+      mPhoneAdapter.refreshPhones(mapObject.getMetadata(Metadata.MetadataType.FMD_PHONE_NUMBER));
   }
 }

--- a/android/src/app/organicmaps/widget/placepage/sections/PlacePagePhoneFragment.java
+++ b/android/src/app/organicmaps/widget/placepage/sections/PlacePagePhoneFragment.java
@@ -1,4 +1,4 @@
-package app.organicmaps.widget.placepage;
+package app.organicmaps.widget.placepage.sections;
 
 import android.os.Bundle;
 import android.view.LayoutInflater;
@@ -14,6 +14,7 @@ import androidx.recyclerview.widget.RecyclerView;
 import app.organicmaps.R;
 import app.organicmaps.bookmarks.data.MapObject;
 import app.organicmaps.bookmarks.data.Metadata;
+import app.organicmaps.widget.placepage.PlacePageViewModel;
 
 public class PlacePagePhoneFragment extends Fragment implements Observer<MapObject>
 {

--- a/android/src/app/organicmaps/widget/placepage/sections/PlacePageWikipediaFragment.java
+++ b/android/src/app/organicmaps/widget/placepage/sections/PlacePageWikipediaFragment.java
@@ -112,23 +112,26 @@ public class PlacePageWikipediaFragment extends Fragment implements Observer<Map
   }
 
   @Override
-  public void onResume()
+  public void onStart()
   {
-    super.onResume();
+    super.onStart();
     mViewModel.getMapObject().observe(requireActivity(), this);
   }
 
   @Override
-  public void onPause()
+  public void onStop()
   {
-    super.onPause();
+    super.onStop();
     mViewModel.getMapObject().removeObserver(this);
   }
 
   @Override
-  public void onChanged(MapObject mapObject)
+  public void onChanged(@Nullable MapObject mapObject)
   {
-    mMapObject = mapObject;
-    updateViews();
+    if (mapObject != null)
+    {
+      mMapObject = mapObject;
+      updateViews();
+    }
   }
 }

--- a/android/src/app/organicmaps/widget/placepage/sections/PlacePageWikipediaFragment.java
+++ b/android/src/app/organicmaps/widget/placepage/sections/PlacePageWikipediaFragment.java
@@ -1,4 +1,4 @@
-package app.organicmaps.widget.placepage;
+package app.organicmaps.widget.placepage.sections;
 
 import android.os.Bundle;
 import android.text.SpannableStringBuilder;
@@ -19,6 +19,9 @@ import app.organicmaps.bookmarks.data.MapObject;
 import app.organicmaps.bookmarks.data.Metadata;
 import app.organicmaps.util.Utils;
 import app.organicmaps.util.UiUtils;
+import app.organicmaps.widget.placepage.PlaceDescriptionActivity;
+import app.organicmaps.widget.placepage.PlacePageUtils;
+import app.organicmaps.widget.placepage.PlacePageViewModel;
 
 public class PlacePageWikipediaFragment extends Fragment implements Observer<MapObject>
 {

--- a/android/src/app/organicmaps/widget/placepage/sections/PlacePhoneAdapter.java
+++ b/android/src/app/organicmaps/widget/placepage/sections/PlacePhoneAdapter.java
@@ -1,4 +1,4 @@
-package app.organicmaps.widget.placepage;
+package app.organicmaps.widget.placepage.sections;
 
 import android.content.Context;
 import android.text.TextUtils;

--- a/android/tests/java/app/organicmaps/widget/placepage/sections/PlaceOpeningHoursAdapterTest.java
+++ b/android/tests/java/app/organicmaps/widget/placepage/sections/PlaceOpeningHoursAdapterTest.java
@@ -1,9 +1,10 @@
-package app.organicmaps.widget.placepage;
+package app.organicmaps.widget.placepage.sections;
 
 import app.organicmaps.editor.data.HoursMinutes;
 import app.organicmaps.editor.data.Timespan;
 import app.organicmaps.editor.data.Timetable;
-import app.organicmaps.widget.placepage.PlaceOpeningHoursAdapter.WeekScheduleData;
+import app.organicmaps.widget.placepage.sections.PlaceOpeningHoursAdapter;
+import app.organicmaps.widget.placepage.sections.PlaceOpeningHoursAdapter.WeekScheduleData;
 import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;


### PR DESCRIPTION
Further improve place page and map buttons fragment abstraction by trying to follow [Android's best practices](https://developer.android.com/topic/architecture/ui-layer?continue=https%3A%2F%2Fdeveloper.android.com%2Fcourses%2Fpathways%2Fandroid-architecture%23article-https%3A%2F%2Fdeveloper.android.com%2Ftopic%2Farchitecture%2Fui-layer#udf).

With these changes, the main activity does not call fragment functions directly, but instead updates their state using view models. Fragments send data back to the activity using event callbacks.

Saving the UI state between configuration changes is a lot easier as view models handle this natively, it is easier to sync multiple UI components to a single state and we better understand when the data is modified.

The menu bottom sheets would also benefit from this change, but I will keep that for another PR.

This is not ready yet, I still need to find and fix possible regressions, but this will make the code easier to maintain and will also help with implementing https://github.com/organicmaps/organicmaps/pull/4613.

@Jean-BaptisteC you don't need to test yet, I already know of some bugs, but I would greatly appreciate your help when I feel the PR is close enough to being finished :). The PR is only published to let people know I'm working on this.

Fixes #4729 
Fixes #4903 
Fixes #4680