### PR TITLE
[android] Enabled displaying of bookmark list description

### DIFF
--- a/android/src/app/organicmaps/bookmarks/BookmarkListAdapter.java
+++ b/android/src/app/organicmaps/bookmarks/BookmarkListAdapter.java
@@ -100,8 +100,8 @@ public class BookmarkListAdapter extends RecyclerView.Adapter<Holders.BaseBookma
 
       mSectionsCount = 0;
       // Hide the category description
-      //if (hasDescription())
-      //  mDescriptionSectionIndex = mSectionsCount++;
+      if (hasDescription())
+       mDescriptionSectionIndex = mSectionsCount++;
       if (getCategory().getTracksCount() > 0)
         mTracksSectionIndex = mSectionsCount++;
       if (getCategory().getBookmarksCount() > 0)


### PR DESCRIPTION
...more button is not clickable there yet.

Description was accidentally disabled when we cleaned up the project 2 years ago.