### PR TITLE
Fixed cut text in Views

### DIFF
--- a/android/res/layout/edit_bookmark_common.xml
+++ b/android/res/layout/edit_bookmark_common.xml
@@ -1,8 +1,8 @@
 <?xml version="1.0" encoding="utf-8"?>
 <RelativeLayout
   xmlns:android="http://schemas.android.com/apk/res/android"
-    xmlns:app="http://schemas.android.com/apk/res-auto"
-    xmlns:tools="http://schemas.android.com/tools"
+  xmlns:app="http://schemas.android.com/apk/res-auto"
+  xmlns:tools="http://schemas.android.com/tools"
   android:id="@+id/rl__bookmark_details"
   android:layout_width="match_parent"
   android:layout_height="match_parent"
@@ -11,7 +11,7 @@
   <LinearLayout
     android:id="@+id/ll__bookmark_name"
     android:layout_width="match_parent"
-    android:layout_height="@dimen/height_item_edit_bookmark"
+    android:layout_height="wrap_content"
     android:layout_marginStart="@dimen/margin_half"
     android:layout_marginEnd="@dimen/margin_half"
     android:orientation="vertical">
@@ -33,10 +33,9 @@
   <RelativeLayout
     android:id="@+id/rl__bookmark_set"
     android:layout_width="match_parent"
-    android:layout_height="@dimen/height_item_edit_bookmark"
+    android:layout_height="wrap_content"
     android:layout_below="@id/ll__bookmark_name"
-    android:layout_marginStart="@dimen/margin_half_plus"
-    android:layout_marginTop="@dimen/margin_half">
+    android:layout_marginStart="@dimen/margin_half_plus">
     <TextView
       android:id="@+id/tv__bookmark_set_title"
       android:layout_width="match_parent"
@@ -55,22 +54,23 @@
       android:background="?attr/selectableItemBackground"
       android:clickable="true"
       android:paddingTop="@dimen/margin_quarter_plus"
-      android:paddingBottom="@dimen/margin_half"
+      android:paddingBottom="@dimen/margin_half_plus"
       android:textAppearance="@style/MwmTextAppearance.Body1"
       app:drawableEndCompat="@drawable/ic_arrow_down" />
     <View
+      android:id="@+id/divideerrr"
       android:layout_width="match_parent"
       android:layout_height="1dp"
-      android:layout_alignParentBottom="true"
+      android:layout_alignBottom="@id/tv__bookmark_set"
       android:layout_marginEnd="@dimen/margin_quadruple"
-      android:layout_marginBottom="@dimen/margin_half"
       android:background="@color/divider" />
     <ImageView
       android:id="@+id/iv__bookmark_color"
       android:layout_width="wrap_content"
       android:layout_height="wrap_content"
-      android:layout_alignParentEnd="true"
-      android:layout_alignParentBottom="true"
+      android:layout_marginTop="20dp"
+      android:layout_alignParentRight="true"
+      android:layout_alignEnd="@id/divideerrr"
       android:background="?clickableBackground"
       android:padding="@dimen/margin_half"
       tools:src="@drawable/ic_bookmark_none" />
@@ -81,7 +81,6 @@
     android:layout_height="wrap_content"
     android:layout_below="@id/rl__bookmark_set"
     android:layout_margin="@dimen/margin_half"
-    android:paddingTop="@dimen/margin_half"
     android:textColorHint="?android:textColorSecondary">
     <EditText
       android:id="@+id/et__description"

--- a/android/res/layout/fragment_phone.xml
+++ b/android/res/layout/fragment_phone.xml
@@ -25,7 +25,7 @@
     <TextView
         android:id="@+id/tv__append_phone"
         android:layout_width="match_parent"
-        android:layout_height="@dimen/height_block_base"
+        android:layout_height="wrap_content"
         android:layout_alignParentBottom="true"
         android:background="?clickableBackground"
         android:gravity="center_vertical"

--- a/android/res/layout/fragment_timetable_advanced.xml
+++ b/android/res/layout/fragment_timetable_advanced.xml
@@ -52,7 +52,7 @@
         <TextView
           android:id="@+id/tv__examples_title"
           android:layout_width="match_parent"
-          android:layout_height="@dimen/height_block_base"
+          android:layout_height="wrap_content"
           android:background="?clickableBackground"
           android:drawablePadding="@dimen/margin_base"
           android:gravity="center_vertical"

--- a/android/res/layout/item_add_street.xml
+++ b/android/res/layout/item_add_street.xml
@@ -3,7 +3,7 @@
   xmlns:android="http://schemas.android.com/apk/res/android"
   xmlns:app="http://schemas.android.com/apk/res-auto"
   android:layout_width="match_parent"
-  android:layout_height="@dimen/height_item_oneline"
+  android:layout_height="wrap_content"
   android:background="?clickableBackground"
   android:gravity="center_vertical"
   android:orientation="horizontal"

--- a/android/res/layout/position_chooser.xml
+++ b/android/res/layout/position_chooser.xml
@@ -14,7 +14,7 @@
 
     <LinearLayout
       android:layout_width="match_parent"
-      android:layout_height="?attr/actionBarSize"
+      android:layout_height="match_parent"
       android:orientation="horizontal"
       android:padding="@dimen/margin_half">
 
@@ -32,7 +32,7 @@
         android:layout_height="wrap_content"
         android:background="?selectableItemBackgroundBorderless"
         android:clickable="true"
-        android:padding="@dimen/margin_half"
+        android:layout_margin="@dimen/margin_half"
         android:text="@string/done"
         android:textAppearance="@style/MwmTextAppearance.Body1"/>
 


### PR DESCRIPTION
### Issue: 
The text cuts out when the text size increased.

### Expected behaviour:
View scales with respect to the text size.

### Views progress:
- [x] Fragment phone
- [x] Fragment Advanced timetable
- [x] Edit bookmark
- [x] Add place done button (English is ok but there seems to be an issue with German)
- [x] item_add_street

### Issues:
https://github.com/organicmaps/organicmaps/issues/4774
https://github.com/organicmaps/organicmaps/issues/4417
