### PR TITLE
[desktop] enable Anti-Aliasing by default

### DIFF
--- a/drape/support_manager.cpp
+++ b/drape/support_manager.cpp
@@ -93,6 +93,10 @@ void SupportManager::Init(ref_ptr<GraphicsContext> context)
 //    settings::Set(kSupportedAntialiasing, m_isAntialiasingEnabledByDefault);
 //  }
 
+#ifdef OMIM_OS_DESKTOP
+     m_isAntialiasingEnabledByDefault = true;
+#endif
+
   m_isInitialized = true;
 }
 


### PR DESCRIPTION
fixes #4817
desktop screens are usually lower DPI than mobile, so AA should be enabled by default