### PR TITLE
Explicitly include cstdint when using uint8_t

### DIFF
--- a/coding/sha1.hpp
+++ b/coding/sha1.hpp
@@ -1,6 +1,7 @@
 #pragma once
 
 #include <array>
+#include <cstdint>
 #include <string>
 
 namespace coding

--- a/map/power_management/power_management_schemas.hpp
+++ b/map/power_management/power_management_schemas.hpp
@@ -1,6 +1,7 @@
 #pragma once
 
 #include <array>
+#include <cstdint>
 #include <string>
 
 namespace power_management


### PR DESCRIPTION
With the current openSUSE Tumbleweed version it had started to fail.