### PR TITLE
[android] make email icon blue

### DIFF
--- a/android/res/layout/place_page_email.xml
+++ b/android/res/layout/place_page_email.xml
@@ -1,6 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <LinearLayout
   xmlns:android="http://schemas.android.com/apk/res/android"
+  xmlns:app="http://schemas.android.com/apk/res-auto"
   xmlns:tools="http://schemas.android.com/tools"
   android:id="@+id/ll__place_email"
   style="@style/PlacePageItemFrame"
@@ -11,7 +12,8 @@
   <ImageView
     android:id="@+id/iv__place_email"
     style="@style/PlacePageMetadataIcon"
-    android:src="@drawable/ic_email" />
+    android:src="@drawable/ic_email"
+    app:tint="?colorAccent" />
 
   <TextView
     android:id="@+id/tv__place_email"


### PR DESCRIPTION
Makes email icon blue to match other interactive options:
before/after
![Screenshot_20230410-224036_Organic Maps](https://user-images.githubusercontent.com/26939824/231005369-4672f9f9-b5f8-4d5e-91cb-b5d5378abe29.png)
