### PR TITLE
[qt] Use OGL v3.2 by default.

### DIFF
--- a/qt/main.cpp
+++ b/qt/main.cpp
@@ -203,7 +203,6 @@ int main(int argc, char * argv[])
         screenshotParams->m_dpiScale = FLAGS_dpi_scale;
     }
 
-
     QSurfaceFormat fmt;
     fmt.setAlphaBufferSize(8);
     fmt.setBlueBufferSize(8);
@@ -214,17 +213,8 @@ int main(int argc, char * argv[])
     fmt.setSwapBehavior(QSurfaceFormat::DoubleBuffer);
     fmt.setSwapInterval(1);
     fmt.setDepthBufferSize(16);
-#if defined(OMIM_OS_LINUX)
-    // This is a workaround for older distros, which rely on X.org and Mesa,
-    // where somehow the Mesa driver itself doesn't
-    // make all the otherwise supported GLSL versions available by default
-    // and such requests are somehow disregarded at later stages of execution.
-    // This setting here will be potentially overwritten and overruled anyway,
-    // and only needed to ensure that we have the needed GLSL compiler available
-    // later when we need it.
-    if (app.platformName() == QString("xcb"))
-      fmt.setVersion(3, 2);
-#endif
+    fmt.setProfile(QSurfaceFormat::CoreProfile);
+    fmt.setVersion(3, 2);
 #ifdef ENABLE_OPENGL_DIAGNOSTICS
     fmt.setOption(QSurfaceFormat::DebugContext);
 #endif

--- a/qt/qt_common/map_widget.cpp
+++ b/qt/qt_common/map_widget.cpp
@@ -379,18 +379,14 @@ void MapWidget::initializeGL()
     }
   }
 #endif
-  auto fmt = context()->format();
-  if (m_apiOpenGLES3)
+
+  if (!m_apiOpenGLES3)
   {
-    fmt.setProfile(QSurfaceFormat::CoreProfile);
-    fmt.setVersion(3, 2);
-  }
-  else
-  {
+    auto fmt = context()->format();
     fmt.setProfile(QSurfaceFormat::CompatibilityProfile);
     fmt.setVersion(2, 1);
+    QSurfaceFormat::setDefaultFormat(fmt);
   }
-  QSurfaceFormat::setDefaultFormat(fmt);
 
   m_contextFactory.reset(new QtOGLContextFactory(context()));
 


### PR DESCRIPTION
Follow up https://github.com/organicmaps/organicmaps/pull/2947
I tested this PR on MacOS and approved it, but looks like this change was made after my review.

My Apple M1 Pro doesn't work with OGL3.

```
QOpenGLShader::compile(Vertex): ERROR: 0:1: '' :  version '150' is not supported
ERROR: 0:1: '' : syntax error: #version

*** Problematic Vertex shader source code ***
      #version 150 core
...

TID(4) ASSERT FAILED
drape/shader.cpp:28
CHECK(result) GLES3_DEBUG_RECT_VSH > Shader compile error :  ERROR: 0:1: '' :  version '150' is not supported
ERROR: 0:1: '' : syntax error: #version
```