### PR TITLE
fix inconsistency

### DIFF
--- a/tools/python/stylesheet/cat_stat.py
+++ b/tools/python/stylesheet/cat_stat.py
@@ -161,7 +161,7 @@ if __name__ == '__main__':
 
     # Iterate over know classificator types
     w = csv.writer(sys.stdout)
-    w.writerow(('type', 'is editable', 'can add', 'drawn', 'icon', 'area', 'name drawn', 'usages in osm'))
+    w.writerow(('type', 'is editable', 'can add', 'drawn', 'icon', 'area', 'name drawn', 'usage count in osm', 'source'))
     no_editor = EditStat()
     no_drawn = DruleStat()
     seen = set()


### PR DESCRIPTION
there was unlabelled extra column, better name for usage count

Now output goes like

```
type,is editable,can add,drawn,icon,area,name drawn,usage count in osm,source
aerialway-cable_car,,,v,,,n,1277,aerialway=cable_car
aerialway-chair_lift,,,v,,,n,8855,aerialway=chair_lift
aerialway-drag_lift,,,v,,,n,4342,aerialway=drag_lift
aerialway-gondola,,,v,,,n,1704,aerialway=gondola
aerialway-j-bar,,,v,,,n,221,aerialway=j-bar
aerialway-magic_carpet,,,v,,,n,2363,aerialway=magic_carpet
aerialway-mixed_lift,,,v,,,n,97,aerialway=mixed_lift
aerialway-platter,,,v,,,n,4169,aerialway=platter
aerialway-rope_tow,,,v,,,n,1539,aerialway=rope_tow
```