### PR TITLE
[android] Draw ruler in the corner

### DIFF
--- a/android/src/app/organicmaps/Map.java
+++ b/android/src/app/organicmaps/Map.java
@@ -1,6 +1,7 @@
 package app.organicmaps;
 
 import android.content.Context;
+import android.content.res.Configuration;
 import android.graphics.Rect;
 import android.view.MotionEvent;
 import android.view.Surface;
@@ -317,9 +318,10 @@ public final class Map
 
   private void updateRulerOffset(final Context context, int offsetX, int offsetY)
   {
+    int orientation = context.getResources().getConfiguration().orientation;
     nativeSetupWidget(WIDGET_RULER,
         UiUtils.dimen(context, R.dimen.margin_ruler) + offsetX,
-        mHeight - UiUtils.dimen(context, R.dimen.margin_ruler) - offsetY,
+        mHeight - UiUtils.dimen(context, R.dimen.margin_ruler) - (orientation == Configuration.ORIENTATION_LANDSCAPE? 0 : offsetY),
         ANCHOR_LEFT_BOTTOM);
     if (mSurfaceCreated)
       nativeApplyWidgets();


### PR DESCRIPTION
Updated updateRulerOffset() function in Map.java to show ruler in lower left corner in landscape mode.

Fixes #4169

Based on orientation of the page I changed the bottom offsetY of the ruler.
For the landscape I changed offsetY to 0 and got following results:

If it works this way. Please @biodranik assign me this issue I will make a pull request.

portrait preview:
![portrait](https://user-images.githubusercontent.com/61724808/234454965-d352ac92-2c77-4206-ae05-c72c38e6185c.jpeg)

landscape preview:
![landscape](https://user-images.githubusercontent.com/61724808/234454920-a3433298-9ee0-48da-9b0d-57594129404b.jpeg)
