### PR TITLE
Use new faster MacOS runners for workflows

### DIFF
--- a/.github/workflows/ios-beta.yaml
+++ b/.github/workflows/ios-beta.yaml
@@ -28,7 +28,7 @@ on:
 jobs:
   ios-beta:
     name: Apple TestFlight
-    runs-on: macos-12
+    runs-on: macos-12-xl
     env:
       LANG: en_US.UTF-8  # Fastlane complains that the terminal is using ASCII.
       LANGUAGE: en_US.UTF-8

--- a/.github/workflows/ios-check.yaml
+++ b/.github/workflows/ios-check.yaml
@@ -27,7 +27,7 @@ on:
 jobs:
   ios-check:
     name: Build iOS
-    runs-on: macos-12
+    runs-on: macos-12-xl
     env:
       LANG: en_US.UTF-8  # Fastlane complains that the terminal is using ASCII.
       LANGUAGE: en_US.UTF-8

--- a/.github/workflows/ios-release.yaml
+++ b/.github/workflows/ios-release.yaml
@@ -5,7 +5,7 @@ on:
 jobs:
   ios-release:
     name: iOS Release
-    runs-on: macos-12
+    runs-on: macos-12-xl
     env:
       LANG: en_US.UTF-8  # Fastlane complains that the terminal is using ASCII.
       LANGUAGE: en_US.UTF-8

--- a/.github/workflows/macos-check.yaml
+++ b/.github/workflows/macos-check.yaml
@@ -25,7 +25,7 @@ on:
 jobs:
   macos-matrix:
     name: macOS builds and tests
-    runs-on: macos-12
+    runs-on: macos-12-xl
     env:
       HOMEBREW_NO_ANALYTICS: 1
       HOMEBREW_NO_INSTALL_CLEANUP: 1


### PR DESCRIPTION
uses 12 cores instead of 3
see https://github.blog/changelog/2023-04-24-github-actions-faster-macos-runners-are-now-available-in-open-public-beta/

worth noting that [it's more expensive per-minute](https://docs.github.com/en/billing/managing-billing-for-github-actions/about-billing-for-github-actions#per-minute-rates), but this might even out with the increased build speed as macOS builds currently take ~40 mins
