### PR TITLE
[android] added toast message on failed or successful bookmark imports

### DIFF
--- a/android/src/app/organicmaps/bookmarks/BookmarkCategoriesFragment.java
+++ b/android/src/app/organicmaps/bookmarks/BookmarkCategoriesFragment.java
@@ -34,6 +34,7 @@ import app.organicmaps.util.bottomsheet.MenuBottomSheetItem;
 import app.organicmaps.util.concurrency.ThreadPool;
 import app.organicmaps.util.concurrency.UiThread;
 import app.organicmaps.util.log.Logger;
+import app.organicmaps.util.Utils;
 
 import java.io.File;
 import java.util.ArrayList;
@@ -208,7 +209,9 @@ public class BookmarkCategoriesFragment extends BaseMwmRecyclerFragment<Bookmark
   @Override
   public void onBookmarksFileLoaded(boolean success)
   {
-    // Do nothing here.
+    View view = getActivity().findViewById(R.id.fragment_container);
+    if (view != null)
+      Utils.showSnackbar(requireActivity(), view, null, success ? R.string.load_kmz_successful : R.string.load_kmz_failed);
   }
 
   @Override


### PR DESCRIPTION
Users will get a feedback on corrupted bookmark files during import.
Fixes [this](https://github.com/organicmaps/organicmaps/issues/4815)

## Gif
![bm](https://user-images.githubusercontent.com/39624400/236916005-45ff6689-3a75-4eb5-b8eb-7b19c95f1727.gif)
