### PR TITLE
[navigation] Increase finish intermediate stop distance from 20 to 30m for car

### DIFF
--- a/routing/routing_settings.cpp
+++ b/routing/routing_settings.cpp
@@ -84,7 +84,7 @@ RoutingSettings GetRoutingSettings(VehicleType vehicleType)
             50.0 /* m_matchingThresholdM */,
             true /* m_showTurnAfterNext */,
             measurement_utils::KmphToMps(3.0) /* m_minSpeedForRouteRebuildMpS */,
-            20.0 /* m_finishToleranceM */,
+            30.0 /* m_finishToleranceM */,
             9 /* m_maxOutgoingPointsCount */,
             120.0 /* m_minOutgoingDistMeters */,
             2 /* m_maxIngoingPointsCount */,


### PR DESCRIPTION
Many users complained that intermediate stops are staying when they drive nearby. This change may improve this behavior.