### PR TITLE
[styles] rendering for waterway=fish_pass

### DIFF
--- a/data/mapcss-mapping.csv
+++ b/data/mapcss-mapping.csv
@@ -493,8 +493,8 @@ deprecated|deprecated;492;x
 highway|tertiary_link|bridge;[highway=tertiary_link][bridge?];;name;int_name;493;
 deprecated|deprecated;494;x
 amenity|parking|park_and_ride;[amenity=parking][parking=park_and_ride];;name;int_name;495;
-deprecated|deprecated;496;x
-deprecated|deprecated;497;x
+waterway|fish_pass;496;
+waterway|fish_pass|tunnel;[waterway=fish_pass][tunnel?];;name;int_name;497;
 natural|water|lock;[natural=water][water=lock];;name;int_name;498;
 waterway|lock;499;waterway|canal
 deprecated|deprecated;500;x

--- a/data/strings/types_strings.txt
+++ b/data/strings/types_strings.txt
@@ -26310,6 +26310,10 @@
     zh-Hans = 运河
     zh-Hant = 運河
 
+  [type.waterway.fish_pass]
+    en = Fish Pass
+    de = Fischtreppe
+
   [type.waterway.dam]
     en = Dam
     de = Staudamm

--- a/data/styles/clear/include/Basemap.mapcss
+++ b/data/styles/clear/include/Basemap.mapcss
@@ -37,6 +37,7 @@ line[waterway=river],
 line[waterway=riverbank],
 line[waterway=stream],
 line[waterway=canal],
+line[waterway=fish_pass],
 line[waterway=ditch],
 line[waterway=drain],
 line[natural=strait],
@@ -401,6 +402,7 @@ line|z10-[waterway=river],
 line|z10-[waterway=riverbank],
 line|z13-[waterway=stream],
 line|z13-[waterway=canal],
+line|z13-[waterway=fish_pass],
 line|z17-[waterway=ditch],
 line|z17-[waterway=drain],
 line|z13-[natural=strait],
@@ -436,6 +438,7 @@ line|z13[waterway=riverbank],
 {width: 1.6;}
 line|z13[waterway=stream],
 line|z13[waterway=canal],
+line|z13[waterway=fish_pass],
 line|z13[natural=strait],
 {width: 0.7;}
 line|z13[waterway=stream][intermittent=yes]
@@ -446,6 +449,7 @@ line|z14[waterway=riverbank],
 {width: 1.8;}
 line|z14[waterway=stream],
 line|z14[waterway=canal],
+line|z14[waterway=fish_pass],
 line|z14[natural=strait],
 {width: 1;}
 line|z14[waterway=stream][intermittent=yes]
@@ -456,6 +460,7 @@ line|z15-[waterway=riverbank],
 {width: 2.2;}
 line|z15-[waterway=stream],
 line|z15-[waterway=canal],
+line|z15-[waterway=fish_pass],
 line|z15-[natural=strait],
 {width: 1.6;}
 line|z15-[waterway=stream][intermittent=yes]

--- a/data/styles/clear/include/Basemap_label.mapcss
+++ b/data/styles/clear/include/Basemap_label.mapcss
@@ -521,6 +521,7 @@ node|z15-[natural=beach],
 [waterway=riverbank],
 [waterway=stream],
 [waterway=canal],
+[waterway=fish_pass],
 [natural=strait],
 [waterway=dam],
 {-x-me-text-priority: 16950;}
@@ -533,6 +534,7 @@ line|z11-[waterway=river],
 line|z11-[waterway=riverbank],
 line|z13-[waterway=stream],
 line|z13-[waterway=canal],
+line|z13-[waterway=fish_pass],
 line|z13-[natural=strait],
 node|z14-[natural=strait],
 node|z14-[natural=water],
@@ -581,17 +583,20 @@ area|z10-[natural=water][bbox_area<4000000],
 line|z11-14[waterway=river],
 line|z11-14[waterway=riverbank],
 line|z13-14[waterway=stream],
-line|z13-14[waterway=canal]
-line|z13-14[natural=strait]
+line|z13-14[waterway=canal],
+line|z13-14[waterway=fish_pass],
+line|z13-14[natural=strait],
 {font-size: 10;text:name;text-color: @water_label;}
 line|z15-17[waterway=stream],
 line|z15-17[waterway=canal],
+line|z15-17[waterway=fish_pass],
 line|z15-17[natural=strait],
 {font-size: 11;text:name;text-color: @water_label;}
 line|z15-[waterway=river],
 line|z15-[waterway=riverbank],
 line|z18-[waterway=stream],
 line|z18-[waterway=canal],
+line|z18-[waterway=fish_pass],
 line|z18-[natural=strait],
 {font-size: 12;text:name;text-color: @water_label;}
 


### PR DESCRIPTION
Added support for waterway=fish_pass. Rendering is the same as for ditch and drain.

#### Open Questions:
- should name be used as well?
- should rendering be like ditch and drain or rather like stream?
- (vehicle style not implemented yet)

Thanks for the review!

#### Example rendering:
(before and after, https://www.openstreetmap.org/way/102490507)
![Screenshot_20230514_160736](https://github.com/organicmaps/organicmaps/assets/79519062/87bf9d22-5039-45b9-8e8a-46dc92f2beab)
![Screenshot_20230514_191842](https://github.com/organicmaps/organicmaps/assets/79519062/16278a69-4d5b-44f6-b684-ddf6719b78c8)
