### PR TITLE
[android][routing] Decrease TTS speed from 1.2 to 1.0

### DIFF
--- a/android/src/app/organicmaps/sound/TtsPlayer.java
+++ b/android/src/app/organicmaps/sound/TtsPlayer.java
@@ -43,7 +43,7 @@ public enum TtsPlayer implements Initializable<Context>
 
   private static final String TAG = TtsPlayer.class.getSimpleName();
   private static final Locale DEFAULT_LOCALE = Locale.US;
-  private static final float SPEECH_RATE = 1.2f;
+  private static final float SPEECH_RATE = 1.0f;
   private static final int TTS_SPEAK_DELAY_MILLIS = 50;
 
   private TextToSpeech mTts;


### PR DESCRIPTION
This is something that I noticed while testing OM on a family trip in parallel to driver's GMaps. 1.2 speed is quite fast.
Not sure why [this was done](https://github.com/organicmaps/organicmaps/commit/29553bd25c81dfbc0bae29e1e735151e31a315db). Maybe back then built-in TTS was different (Pico TTS?). Now, for Google Speech Services a speed of 1.0 feels better to me. For Samsung TTS as well.

Fixes #1080