### PR TITLE
[android] reset place page scroll on open

### DIFF
--- a/android/src/app/organicmaps/widget/placepage/PlacePageController.java
+++ b/android/src/app/organicmaps/widget/placepage/PlacePageController.java
@@ -189,14 +189,6 @@ public class PlacePageController extends Fragment implements
     return items;
   }
 
-  private void open()
-  {
-    // Only collapse the place page if the data is different from the one already available
-    mShouldCollapse = PlacePageUtils.isHiddenState(mPlacePageBehavior.getState()) || !MapObject.same(mPreviousMapObject, mMapObject);
-    mPreviousMapObject = mMapObject;
-    // Place page will automatically open when the bottom sheet content is loaded so we can compute the peek height
-  }
-
   private void close()
   {
     mPlacePageBehavior.setState(BottomSheetBehavior.STATE_HIDDEN);
@@ -563,7 +555,10 @@ public class PlacePageController extends Fragment implements
     mMapObject = mapObject;
     if (mapObject != null)
     {
-      open();
+      // Only collapse the place page if the data is different from the one already available
+      mShouldCollapse = PlacePageUtils.isHiddenState(mPlacePageBehavior.getState()) || !MapObject.same(mPreviousMapObject, mMapObject);
+      mPreviousMapObject = mMapObject;
+      // Place page will automatically open when the bottom sheet content is loaded so we can compute the peek height
       createPlacePageFragments();
       updateButtons(
           mapObject,

--- a/android/src/app/organicmaps/widget/placepage/PlacePageController.java
+++ b/android/src/app/organicmaps/widget/placepage/PlacePageController.java
@@ -306,7 +306,12 @@ public class PlacePageController extends Fragment implements
     mPlacePage.post(() -> {
       setPeekHeight();
       if (mShouldCollapse && !PlacePageUtils.isCollapsedState(mPlacePageBehavior.getState()))
+      {
         mPlacePageBehavior.setState(BottomSheetBehavior.STATE_COLLAPSED);
+        // Make sure to reset the scroll position when opening the place page
+        if (mPlacePage.getScrollY() != 0)
+          mPlacePage.setScrollY(0);
+      }
       mShouldCollapse = false;
     });
   }


### PR DESCRIPTION
Fixes issue raised in https://github.com/organicmaps/organicmaps/pull/4613#issuecomment-1545050797 where the last scroll position would be wrongly remembered.

To reproduce open the place page and scroll so content goes out of screen (you can add to bookmark and add a long description to create a large place page), then rotate the device.

When the place page opens (set to "collapsed" state), we check the scroll position and reset it to 0 if necessary.
