### PR TITLE
[android] improve pp attach country behavior

### DIFF
--- a/android/src/app/organicmaps/widget/placepage/PlacePageView.java
+++ b/android/src/app/organicmaps/widget/placepage/PlacePageView.java
@@ -246,7 +246,6 @@ public class PlacePageView extends Fragment implements View.OnClickListener,
     super.onStart();
     mViewModel.getMapObject().observe(requireActivity(), this);
     LocationHelper.INSTANCE.addListener(this);
-    setCurrentCountry();
   }
 
   @Override
@@ -260,7 +259,7 @@ public class PlacePageView extends Fragment implements View.OnClickListener,
 
   private void setCurrentCountry()
   {
-    if (mCurrentCountry != null || mMapObject == null)
+    if (mCurrentCountry != null)
       return;
     String country = MapManager.nativeGetSelectedCountry();
     if (country != null && !RoutingController.get().isNavigating())
@@ -601,11 +600,11 @@ public class PlacePageView extends Fragment implements View.OnClickListener,
   {
     if (mapObject == null)
       return;
+    // Starting the download will fire this callback but the object will be the same
+    // Detaching the country in that case will crash the app
     if (!mapObject.sameAs(mMapObject))
-    {
       detachCountry();
-      setCurrentCountry();
-    }
+    setCurrentCountry();
 
     mMapObject = mapObject;
 


### PR DESCRIPTION
Fixes #5140

Instead of attaching the country in onStart, we only do it when the map object observer gets called (which is done in onStart as we start observing there).

Also removed an unnecessary null check for the map object in `setCurrentCountry` which prevented the downloader icon to show when rotating the device. The map object gets assigned after the country is set so it was always null on the first call after rotating the screen.