### PR TITLE
[android] fix wiki description not always shown

### DIFF
--- a/android/src/app/organicmaps/widget/placepage/sections/PlacePageWikipediaFragment.java
+++ b/android/src/app/organicmaps/widget/placepage/sections/PlacePageWikipediaFragment.java
@@ -95,6 +95,7 @@ public class PlacePageWikipediaFragment extends Fragment implements Observer<Map
       UiUtils.hide(mPlaceDescriptionViewContainer);
     else
     {
+      UiUtils.show(mPlaceDescriptionViewContainer);
       mPlaceDescriptionView.setText(getShortDescription());
       final String descriptionString = mPlaceDescriptionView.getText().toString();
       mPlaceDescriptionView.setOnLongClickListener((v) -> {


### PR DESCRIPTION
Description was not reappearing when switching back from a map object with only a link.

Here are the steps to reproduce the issue fixed in this PR:
- Open the place page for an object **without** a wiki description
- Without closing the place page, click on an object **with** a wiki description: the description will not show
- Close the place page and open the object with the wiki description: the description will now show

The code only took care of hiding the description but there was nowhere to show it back. The description was shown by default when the fragment was created, so if you switched map object the fragment was kept and thus the description stayed hidden.