### PR TITLE
[cmake] Group targets into folders

### DIFF
--- a/3party/CMakeLists.txt
+++ b/3party/CMakeLists.txt
@@ -1,0 +1,59 @@
+if (NOT WITH_SYSTEM_PROVIDED_3PARTY)
+  # Configure expat library.
+  # Suppress "Policy CMP0077 is not set: option() honors normal variables"
+  # for the expat options below.
+  set(CMAKE_POLICY_DEFAULT_CMP0077 NEW)
+  set(EXPAT_BUILD_TOOLS OFF)
+  set(EXPAT_BUILD_EXAMPLES OFF)
+  set(EXPAT_BUILD_TESTS OFF)
+  set(EXPAT_BUILD_DOCS OFF)
+  set(EXPAT_BUILD_PKGCONFIG OFF)
+  set(EXPAT_ENABLE_INSTALL OFF)
+  set(EXPAT_SHARED_LIBS OFF)
+  add_subdirectory(expat/expat)
+
+  # Configure Jansson library.
+  set(JANSSON_BUILD_DOCS OFF)
+  set(JANSSON_BUILD_MAN OFF)
+  set(JANSSON_EXAMPLES OFF)
+  set(JANSSON_INSTALL OFF)
+  set(JANSSON_WITHOUT_TESTS ON)
+  add_subdirectory(jansson/jansson/)
+  target_include_directories(jansson INTERFACE "${PROJECT_BINARY_DIR}/3party/jansson/jansson/include")
+
+  # Add gflags library.
+  add_subdirectory(gflags)
+  target_compile_options(gflags_nothreads_static PRIVATE $<$<CXX_COMPILER_ID:GNU>:-Wno-subobject-linkage>)
+  # Not needed for the usual build process, but it fixes QtCreator editor,
+  # that doesn't see gflags/gflags.h in binary dir (gflags has tricky cmake configuration).
+  if (PLATFORM_DESKTOP)
+    include_directories("${PROJECT_BINARY_DIR}/3party/gflags/include")
+  endif()
+
+  # Add pugixml library.
+  add_subdirectory(pugixml)
+
+  # Add protobuf library.
+  add_subdirectory(protobuf)
+endif()
+
+add_subdirectory(agg)
+add_subdirectory(bsdiff-courgette)
+
+if (NOT LINUX_DETECTED)
+  add_subdirectory(freetype)
+  add_subdirectory(icu)
+endif()
+
+add_subdirectory(liboauthcpp)
+add_subdirectory(minizip)
+add_subdirectory(opening_hours)
+add_subdirectory(sdf_image)
+add_subdirectory(stb_image)
+add_subdirectory(succinct)
+add_subdirectory(open-location-code)
+add_subdirectory(vulkan_wrapper)
+
+if (PLATFORM_DESKTOP)
+  add_subdirectory(libtess2)
+endif()

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -290,69 +290,13 @@ if (USE_PCH)
     ${OMIM_PCH_TARGET_NAME}
   )
 endif()
+
 # Include 3party dependencies.
-
-if (NOT WITH_SYSTEM_PROVIDED_3PARTY)
-  # Configure expat library.
-  # Suppress "Policy CMP0077 is not set: option() honors normal variables"
-  # for the expat options below.
-  set(CMAKE_POLICY_DEFAULT_CMP0077 NEW)
-  set(EXPAT_BUILD_TOOLS OFF)
-  set(EXPAT_BUILD_EXAMPLES OFF)
-  set(EXPAT_BUILD_TESTS OFF)
-  set(EXPAT_BUILD_DOCS OFF)
-  set(EXPAT_BUILD_PKGCONFIG OFF)
-  set(EXPAT_ENABLE_INSTALL OFF)
-  set(EXPAT_SHARED_LIBS OFF)
-  add_subdirectory(3party/expat/expat)
-
-  # Configure Jansson library.
-  set(JANSSON_BUILD_DOCS OFF)
-  set(JANSSON_BUILD_MAN OFF)
-  set(JANSSON_EXAMPLES OFF)
-  set(JANSSON_INSTALL OFF)
-  set(JANSSON_WITHOUT_TESTS ON)
-  add_subdirectory(3party/jansson/jansson/)
-  target_include_directories(jansson INTERFACE "${PROJECT_BINARY_DIR}/3party/jansson/jansson/include")
-
-  # Add gflags library.
-  add_subdirectory(3party/gflags)
-  target_compile_options(gflags_nothreads_static PRIVATE $<$<CXX_COMPILER_ID:GNU>:-Wno-subobject-linkage>)
-  # Not needed for the usual build process, but it fixes QtCreator editor,
-  # that doesn't see gflags/gflags.h in binary dir (gflags has tricky cmake configuration).
-  if (PLATFORM_DESKTOP)
-    include_directories("${PROJECT_BINARY_DIR}/3party/gflags/include")
-  endif()
-
-  # Add pugixml library.
-  add_subdirectory(3party/pugixml)
-
-  # Add protobuf library.
-  add_subdirectory(${OMIM_ROOT}/3party/protobuf)
-endif()
-
-add_subdirectory(3party/agg)
-add_subdirectory(3party/bsdiff-courgette)
+add_subdirectory(3party)
 
 if (LINUX_DETECTED)
   find_package(ICU COMPONENTS uc i18n data REQUIRED)
   find_package(Freetype REQUIRED)
-else()
-  add_subdirectory(3party/freetype)
-  add_subdirectory(3party/icu)
-endif()
-
-add_subdirectory(3party/liboauthcpp)
-add_subdirectory(3party/minizip)
-add_subdirectory(3party/opening_hours)
-add_subdirectory(3party/sdf_image)
-add_subdirectory(3party/stb_image)
-add_subdirectory(3party/succinct)
-add_subdirectory(3party/open-location-code)
-add_subdirectory(3party/vulkan_wrapper)
-
-if (PLATFORM_DESKTOP)
-  add_subdirectory(3party/libtess2)
 endif()
 
 find_package(Python3 COMPONENTS Interpreter)


### PR DESCRIPTION
Small enhancement for cmake

* Moved 3party includes from `CMakeLists.txt` to `3party/CMakeLists.txt`.
* Created function `omim_add_subdirectory` that groups all targets under the subdirectory into one folder (for IDEs that support this feature). 

It won't break anything as it only affects the visual representation in the IDE

<details><summary>Before:</summary>
<p>

<img width="273" alt="Screenshot 2023-05-18 at 21 40 25" src="https://github.com/organicmaps/organicmaps/assets/10351358/eaf8f9a4-511f-45f1-b5a1-3b8ec94af7e9">

</p>
</details> 

<details><summary>After:</summary>
<p>

<img width="255" alt="Screenshot 2023-05-18 at 22 42 24" src="https://github.com/organicmaps/organicmaps/assets/10351358/e707b214-a4fe-4fe3-9085-24de1c6dc789">
<img width="256" alt="Screenshot 2023-05-18 at 22 42 41" src="https://github.com/organicmaps/organicmaps/assets/10351358/70f160e3-7c0d-4d7d-b29a-0d8d31c59fa8">
<img width="263" alt="Screenshot 2023-05-18 at 22 42 50" src="https://github.com/organicmaps/organicmaps/assets/10351358/e99d13cb-80ae-42c3-9c28-bff3b324c9ef">
<img width="244" alt="Screenshot 2023-05-18 at 22 43 07" src="https://github.com/organicmaps/organicmaps/assets/10351358/13e7aae3-23a4-4067-8735-34d45d72859a">
<img width="254" alt="Screenshot 2023-05-18 at 22 43 00" src="https://github.com/organicmaps/organicmaps/assets/10351358/0de65835-8a32-404e-b6a8-fa112ae00aba">

</p>
</details> 



