### PR TITLE
[android] Fixes security exception when bookmarks are imported

### DIFF
--- a/android/src/app/organicmaps/bookmarks/data/BookmarkManager.java
+++ b/android/src/app/organicmaps/bookmarks/data/BookmarkManager.java
@@ -427,6 +427,11 @@ public enum BookmarkManager
             filename = cursor.getString(columnIndex);
         }
       }
+      catch (Exception ex)
+      {
+        Logger.e(TAG, ex + " while querying " + uri);
+        ex.printStackTrace();
+      }
     }
 
     if (filename == null)
@@ -434,9 +439,7 @@ public enum BookmarkManager
       filename = uri.getPath();
       int cut = filename.lastIndexOf('/');
       if (cut != -1)
-      {
         filename = filename.substring(cut + 1);
-      }
     }
     // See IsBadCharForPath()
     filename = filename.replaceAll("[:/\\\\<>\"|?*]", "");
@@ -469,15 +472,12 @@ public enum BookmarkManager
   @WorkerThread
   public boolean importBookmarksFile(@NonNull ContentResolver resolver, @NonNull Uri uri, @NonNull File tempDir)
   {
-    String filename = getBookmarksFilenameFromUri(resolver, uri);
+    final String filename = getBookmarksFilenameFromUri(resolver, uri);
     if (filename == null)
-    {
-      Logger.w(TAG, "Missing path in bookmarks URI: " + uri);
       return false;
-    }
 
-    Logger.w(TAG, "Downloading bookmarks file " + uri);
-    File tempFile = new File(tempDir, filename);
+    Logger.w(TAG, "Downloading bookmarks file " + uri + " with file name " + filename);
+    final File tempFile = new File(tempDir, filename);
     try
     {
       StorageUtils.copyFile(resolver, uri, tempFile);


### PR DESCRIPTION
An example of the exception after selecting Downloads folder:

java.lang.SecurityException: Document 4450 is not a descendant of downloads

Also fixes #3594
