### PR TITLE
[android] Fixes non-working "Bookmark import succeeded/failed" snackbar

### DIFF
--- a/android/src/app/organicmaps/MwmActivity.java
+++ b/android/src/app/organicmaps/MwmActivity.java
@@ -1686,7 +1686,7 @@ public class MwmActivity extends BaseMwmFragmentActivity
   @Override
   public void onBookmarksFileLoaded(boolean success)
   {
-    Utils.showSnackbar(this, findViewById(R.id.coordinator), findViewById(R.id.menu_frame),
+    Utils.showSnackbar(this, findViewById(R.id.coordinator), null,
                         success ? R.string.load_kmz_successful : R.string.load_kmz_failed);
   }
 

--- a/android/src/app/organicmaps/MwmActivity.java
+++ b/android/src/app/organicmaps/MwmActivity.java
@@ -1686,7 +1686,7 @@ public class MwmActivity extends BaseMwmFragmentActivity
   @Override
   public void onBookmarksFileLoaded(boolean success)
   {
-    Utils.showSnackbar(this, findViewById(R.id.coordinator), null,
+    Utils.showSnackbar(this, findViewById(R.id.coordinator),
                         success ? R.string.load_kmz_successful : R.string.load_kmz_failed);
   }
 

--- a/android/src/app/organicmaps/MwmActivity.java
+++ b/android/src/app/organicmaps/MwmActivity.java
@@ -26,7 +26,6 @@ import androidx.fragment.app.Fragment;
 import androidx.fragment.app.FragmentFactory;
 import androidx.fragment.app.FragmentManager;
 import androidx.fragment.app.FragmentTransaction;
-import androidx.lifecycle.LiveData;
 import androidx.lifecycle.ViewModelProvider;
 import app.organicmaps.Framework.PlacePageActivationListener;
 import app.organicmaps.api.Const;

--- a/android/src/app/organicmaps/bookmarks/BookmarkCategoriesFragment.java
+++ b/android/src/app/organicmaps/bookmarks/BookmarkCategoriesFragment.java
@@ -26,6 +26,7 @@ import app.organicmaps.bookmarks.data.BookmarkCategory;
 import app.organicmaps.bookmarks.data.BookmarkManager;
 import app.organicmaps.bookmarks.data.BookmarkSharingResult;
 import app.organicmaps.dialog.EditTextDialogFragment;
+import app.organicmaps.util.Utils;
 import app.organicmaps.widget.PlaceholderView;
 import app.organicmaps.widget.recycler.DividerItemDecorationWithPadding;
 import app.organicmaps.util.StorageUtils;
@@ -208,7 +209,15 @@ public class BookmarkCategoriesFragment extends BaseMwmRecyclerFragment<Bookmark
   @Override
   public void onBookmarksFileLoaded(boolean success)
   {
-    // Do nothing here.
+    // TODO: Is there a way to display several failure notifications?
+    // TODO: It would be helpful to see the file name that failed to import.
+    if (!success)
+    {
+      final View view = getView();
+      // TODO: how to get import button view to show snackbar above it?
+      if (view != null)
+        Utils.showSnackbar(requireActivity(), view, R.string.load_kmz_failed);
+    }
   }
 
   @Override

--- a/android/src/app/organicmaps/util/Utils.java
+++ b/android/src/app/organicmaps/util/Utils.java
@@ -74,11 +74,6 @@ public class Utils
   {
   }
 
-  public static boolean isMarshmallowOrLater()
-  {
-    return isTargetOrLater(Build.VERSION_CODES.M);
-  }
-
   public static boolean isNougatOrLater()
   {
     return isTargetOrLater(Build.VERSION_CODES.N);
@@ -106,7 +101,6 @@ public class Utils
       w.clearFlags(android.view.WindowManager.LayoutParams.FLAG_KEEP_SCREEN_ON);
   }
 
-  @SuppressWarnings("deprecation")
   private static void showOnLockScreenOld(boolean enable, Activity activity)
   {
     if (enable)

--- a/android/src/app/organicmaps/widget/placepage/PlacePageUtils.java
+++ b/android/src/app/organicmaps/widget/placepage/PlacePageUtils.java
@@ -79,12 +79,11 @@ public class PlacePageUtils
   public static void copyToClipboard(Context context, View frame, String text)
   {
     Utils.copyTextToClipboard(context, text);
-    Utils.showSnackbarAbove(frame,
-                            frame.getRootView().findViewById(R.id.pp_buttons_layout),
+    Utils.showSnackbarAbove(frame.getRootView().findViewById(R.id.pp_buttons_layout), frame,
                             context.getString(R.string.copied_to_clipboard, text));
   }
 
-  public static void showCopyPopup(Context context, View popupAnchor, View frame, List<String> items)
+  public static void showCopyPopup(Context context, View popupAnchor, List<String> items)
   {
     final PopupMenu popup = new PopupMenu(context, popupAnchor);
     final Menu menu = popup.getMenu();
@@ -95,7 +94,7 @@ public class PlacePageUtils
 
     popup.setOnMenuItemClickListener(item -> {
       final String text = items.get(item.getItemId());
-      copyToClipboard(context, frame, text);
+      copyToClipboard(context, popupAnchor, text);
       return true;
     });
     popup.show();

--- a/android/src/app/organicmaps/widget/placepage/PlacePageUtils.java
+++ b/android/src/app/organicmaps/widget/placepage/PlacePageUtils.java
@@ -39,11 +39,6 @@ public class PlacePageUtils
     return state == BottomSheetBehavior.STATE_COLLAPSED;
   }
 
-  static boolean isHalfExpandedState(@BottomSheetBehavior.State int state)
-  {
-    return state == BottomSheetBehavior.STATE_HALF_EXPANDED;
-  }
-
   static boolean isExpandedState(@BottomSheetBehavior.State int state)
   {
     return state == BottomSheetBehavior.STATE_EXPANDED;

--- a/android/src/app/organicmaps/widget/placepage/PlacePageView.java
+++ b/android/src/app/organicmaps/widget/placepage/PlacePageView.java
@@ -531,7 +531,7 @@ public class PlacePageView extends Fragment implements View.OnClickListener,
     if (items.size() == 1)
       PlacePageUtils.copyToClipboard(context, mFrame, items.get(0));
     else
-      PlacePageUtils.showCopyPopup(context, v, mFrame, items);
+      PlacePageUtils.showCopyPopup(context, v, items);
 
     return true;
   }

--- a/android/src/app/organicmaps/widget/placepage/sections/PlacePageBookmarkFragment.java
+++ b/android/src/app/organicmaps/widget/placepage/sections/PlacePageBookmarkFragment.java
@@ -136,8 +136,7 @@ public class PlacePageBookmarkFragment extends Fragment implements View.OnClickL
 
     final Context ctx = requireContext();
     Utils.copyTextToClipboard(ctx, notes);
-    Utils.showSnackbarAbove(mFrame,
-                            mFrame.getRootView().findViewById(R.id.pp_buttons_layout),
+    Utils.showSnackbarAbove(mFrame.getRootView().findViewById(R.id.pp_buttons_layout), mFrame,
                             ctx.getString(R.string.copied_to_clipboard, notes));
     return true;
   }

--- a/android/src/app/organicmaps/widget/placepage/sections/PlacePageLinksFragment.java
+++ b/android/src/app/organicmaps/widget/placepage/sections/PlacePageLinksFragment.java
@@ -185,7 +185,7 @@ public class PlacePageLinksFragment extends Fragment implements Observer<MapObje
     if (items.size() == 1)
       PlacePageUtils.copyToClipboard(requireContext(), mFrame, items.get(0));
     else
-      PlacePageUtils.showCopyPopup(requireContext(), view, mFrame, items);
+      PlacePageUtils.showCopyPopup(requireContext(), view, items);
     return true;
   }
 

--- a/android/src/app/organicmaps/widget/placepage/sections/PlacePhoneAdapter.java
+++ b/android/src/app/organicmaps/widget/placepage/sections/PlacePhoneAdapter.java
@@ -97,7 +97,7 @@ public class PlacePhoneAdapter extends RecyclerView.Adapter<PlacePhoneAdapter.Vi
       final String phoneNumber = mPhone.getText().toString();
       final Context ctx = view.getContext();
       Utils.copyTextToClipboard(ctx, phoneNumber);
-      Utils.showSnackbarAbove(view, view.getRootView().findViewById(R.id.pp_buttons_layout),
+      Utils.showSnackbarAbove(view.getRootView().findViewById(R.id.pp_buttons_layout), view,
                               ctx.getString(R.string.copied_to_clipboard, phoneNumber));
       return true;
     }

--- a/android/src/app/organicmaps/widget/placepage/sections/PlacePhoneAdapter.java
+++ b/android/src/app/organicmaps/widget/placepage/sections/PlacePhoneAdapter.java
@@ -19,23 +19,20 @@ import java.util.List;
 public class PlacePhoneAdapter extends RecyclerView.Adapter<PlacePhoneAdapter.ViewHolder>
 {
 
-  private List<String> mPhoneData = Collections.emptyList();
+  private ArrayList<String> mPhoneData = new ArrayList<>();
 
   public PlacePhoneAdapter() {}
-
-  public PlacePhoneAdapter(String phones) {
-    refreshPhones(phones);
-  }
 
   public void refreshPhones(String phones) {
     if (TextUtils.isEmpty(phones))
       return;
 
-    mPhoneData = new ArrayList<>();
+    mPhoneData.clear();
     for (String p : phones.split(";"))
     {
       p = p.trim();
-      if (TextUtils.isEmpty(p)) continue;
+      if (TextUtils.isEmpty(p))
+        continue;
       mPhoneData.add(p);
     }
 
@@ -47,7 +44,7 @@ public class PlacePhoneAdapter extends RecyclerView.Adapter<PlacePhoneAdapter.Vi
   public ViewHolder onCreateViewHolder(@NonNull ViewGroup parent, int viewType)
   {
     return new ViewHolder(LayoutInflater.from(parent.getContext())
-                                        .inflate(R.layout.place_page_phone_item, parent, false));
+        .inflate(R.layout.place_page_phone_item, parent, false));
   }
 
   @Override
@@ -62,12 +59,7 @@ public class PlacePhoneAdapter extends RecyclerView.Adapter<PlacePhoneAdapter.Vi
     return mPhoneData.size();
   }
 
-  public List<String> getPhonesList()
-  {
-    return new ArrayList<>(mPhoneData);
-  }
-
-  public class ViewHolder extends RecyclerView.ViewHolder implements View.OnClickListener, View.OnLongClickListener
+  public static class ViewHolder extends RecyclerView.ViewHolder implements View.OnClickListener, View.OnLongClickListener
   {
     private final TextView mPhone;
 


### PR DESCRIPTION
Fixes #4815 
Closes #5105

@arnaudvergnet showSnackbar's viewAbove was broken after refactorings. I've fixed other wrong viewAbove uses too.

This fix can be done better if the snack message is displayed above the map buttons. Would you happen to have any ideas on how to do it?
But there can also be a visible place page that may hide the toast, right?