### PR TITLE
Improved german translation for unpaved roads

### DIFF
--- a/android/res/values-de/strings.xml
+++ b/android/res/values-de/strings.xml
@@ -648,10 +648,10 @@
 	<string name="define_to_avoid_btn">Umwege einstellen</string>
 	<string name="change_driving_options_btn">Routenbeschränkungen aktiv</string>
 	<string name="toll_road">Mautstraße</string>
-	<string name="unpaved_road">Erdweg</string>
+	<string name="unpaved_road">Unbefestigte Straße</string>
 	<string name="ferry_crossing">Fährstelle</string>
 	<string name="avoid_toll_roads_placepage">Mautstraßen vermeiden</string>
-	<string name="avoid_unpaved_roads_placepage">Erdwege vermeiden</string>
+	<string name="avoid_unpaved_roads_placepage">Unbefestigte Straßen vermeiden</string>
 	<string name="avoid_ferry_crossing_placepage">Fährstellen vermeiden</string>
 	<!-- A generic "Yes" button in dialogs -->
 	<string name="yes">Ja</string>

--- a/data/strings/strings.txt
+++ b/data/strings/strings.txt
@@ -21983,7 +21983,7 @@
     ca = Via sense pavimentar
     cs = Nezpevněná silnice
     da = Grusvej
-    de = Erdweg
+    de = Unbefestigte Straße
     el = Χωματόδρομος
     es = Camino sin pavimento
     es-MX = Camino de tierra
@@ -22108,7 +22108,7 @@
     ca = Evita vies sense pavimentar
     cs = Vyhnout se nezpevněným silnicím
     da = Undgå grusveje
-    de = Erdwege vermeiden
+    de = Unbefestigte Straßen vermeiden
     el = Αποφυγή των χωματόδρομων
     es = Evitar los caminos sin pavimento
     es-MX = Evitar los caminos de tierra

--- a/iphone/Maps/LocalizedStrings/de.lproj/Localizable.strings
+++ b/iphone/Maps/LocalizedStrings/de.lproj/Localizable.strings
@@ -1033,13 +1033,13 @@
 
 "toll_road" = "Mautstraße";
 
-"unpaved_road" = "Erdweg";
+"unpaved_road" = "Unbefestigte Straße";
 
 "ferry_crossing" = "Fährstelle";
 
 "avoid_toll_roads_placepage" = "Mautstraßen vermeiden";
 
-"avoid_unpaved_roads_placepage" = "Erdwege vermeiden";
+"avoid_unpaved_roads_placepage" = "Unbefestigte Straßen vermeiden";
 
 "avoid_ferry_crossing_placepage" = "Fährstellen vermeiden";
 

--- a/iphone/Maps/LocalizedStrings/pt-BR.lproj/Localizable.strings
+++ b/iphone/Maps/LocalizedStrings/pt-BR.lproj/Localizable.strings
@@ -1564,7 +1564,7 @@
 
 "type.barrier.chain" = "Chain";
 
-"type.barrier.city_wall" = "City Wall";
+"type.barrier.city_wall" = "Muralha";
 
 "type.barrier.cycle_barrier" = "Barreira de bicicletas";
 


### PR DESCRIPTION
Follow up change of #5057. Also changed "Erdweg" to "Unbefestigte Straße" in other strings to make the UX consistent.