### PR TITLE
Increased long tap radius to 30 pixels

### DIFF
--- a/drape_frontend/visual_params.cpp
+++ b/drape_frontend/visual_params.cpp
@@ -162,7 +162,7 @@ uint32_t VisualParams::GetTileSize() const
 uint32_t VisualParams::GetTouchRectRadius() const
 {
   ASSERT_INITED;
-  float const kRadiusInPixels = 20.0f;
+  float const kRadiusInPixels = 30.0f;
   return static_cast<uint32_t>(kRadiusInPixels * GetVisualScale());
 }
 


### PR DESCRIPTION
Fixes #5256

This should be carefully tested:
1. Select POIs and linear features anywhere.
2. Select POIs and linear features near the current position.

Maybe for current position the touch radius should be smaller than to select any linear feature nearby.