### PR TITLE
[iOS] Show all supported coordinates at PlacePage

### DIFF
--- a/iphone/CoreApi/CoreApi/PlacePageData/Common/PlacePageInfoData.h
+++ b/iphone/CoreApi/CoreApi/PlacePageData/Common/PlacePageInfoData.h
@@ -23,8 +23,7 @@ NS_ASSUME_NONNULL_BEGIN
 @property(nonatomic, readonly, nullable) NSString *cuisine;
 @property(nonatomic, readonly, nullable) NSString *ppOperator;
 @property(nonatomic, readonly, nullable) NSString *address;
-@property(nonatomic, readonly, nullable) NSString *rawCoordinates;
-@property(nonatomic, readonly, nullable) NSString *formattedCoordinates;
+@property(nonatomic, readonly, nullable) NSArray *coordFormats;
 @property(nonatomic, readonly, nullable) NSString *wifiAvailable;
 @property(nonatomic, readonly, nullable) NSString *level;
 

--- a/iphone/CoreApi/CoreApi/PlacePageData/Common/PlacePageInfoData.mm
+++ b/iphone/CoreApi/CoreApi/PlacePageData/Common/PlacePageInfoData.mm
@@ -71,8 +71,12 @@ using namespace osm;
     });
 
     _address = rawData.GetAddress().empty() ? nil : @(rawData.GetAddress().c_str());
-    _rawCoordinates = @(rawData.GetFormattedCoordinate(true).c_str());
-    _formattedCoordinates = @(rawData.GetFormattedCoordinate(false).c_str());
+    _coordFormats = @[@(rawData.GetFormattedCoordinate(place_page::CoordinatesFormat::LatLonDMS).c_str()),
+                      @(rawData.GetFormattedCoordinate(place_page::CoordinatesFormat::LatLonDecimal).c_str()),
+                      @(rawData.GetFormattedCoordinate(place_page::CoordinatesFormat::OLCFull).c_str()),
+                      @(rawData.GetFormattedCoordinate(place_page::CoordinatesFormat::OSMLink).c_str()),
+                      @(rawData.GetFormattedCoordinate(place_page::CoordinatesFormat::UTM).c_str()),
+                      @(rawData.GetFormattedCoordinate(place_page::CoordinatesFormat::MGRS).c_str())];
   }
   return self;
 }

--- a/iphone/CoreApi/CoreApi/PlacePageData/Common/PlacePagePreviewData.mm
+++ b/iphone/CoreApi/CoreApi/PlacePageData/Common/PlacePagePreviewData.mm
@@ -91,7 +91,7 @@ static PlacePageDataHotelType convertHotelType(std::optional<ftypes::IsHotelChec
     _title = rawData.GetTitle().empty() ? nil : @(rawData.GetTitle().c_str());
     _secondaryTitle = rawData.GetSecondaryTitle().empty() ? nil : @(rawData.GetSecondaryTitle().c_str());
     _subtitle = rawData.GetSubtitle().empty() ? nil : @(rawData.GetSubtitle().c_str());
-    _coordinates = @(rawData.GetFormattedCoordinate(true).c_str());
+    _coordinates = @(rawData.GetFormattedCoordinate(place_page::CoordinatesFormat::LatLonDMS).c_str());
     _address = rawData.GetAddress().empty() ? nil : @(rawData.GetAddress().c_str());
     _isMyPosition = rawData.IsMyPosition();
     _isPopular = rawData.GetPopularity() > 0;

--- a/iphone/Maps/UI/PlacePage/Components/PlacePageInfoViewController.swift
+++ b/iphone/Maps/UI/PlacePage/Components/PlacePageInfoViewController.swift
@@ -64,7 +64,7 @@ protocol PlacePageInfoViewControllerDelegate: AnyObject {
 
 class PlacePageInfoViewController: UIViewController {
   private struct Const {
-    static let coordinatesKey = "PlacePageInfoViewController_coordinatesKey"
+    static let coordFormatIdKey = "PlacePageInfoViewController_coordFormatIdKey"
   }
   private typealias TapHandler = InfoItemViewController.TapHandler
   private typealias Style = InfoItemViewController.Style
@@ -95,15 +95,15 @@ class PlacePageInfoViewController: UIViewController {
 
   var placePageInfoData: PlacePageInfoData!
   weak var delegate: PlacePageInfoViewControllerDelegate?
-  var showFormattedCoordinates: Bool {
+  var coordinatesFormatId: Int {
     get {
-      UserDefaults.standard.bool(forKey: Const.coordinatesKey)
+      UserDefaults.standard.integer(forKey: Const.coordFormatIdKey)
     }
     set {
-      UserDefaults.standard.set(newValue, forKey: Const.coordinatesKey)
+      UserDefaults.standard.set(newValue, forKey: Const.coordFormatIdKey)
     }
   }
-  
+
   override func viewDidLoad() {
     super.viewDidLoad()
 
@@ -202,24 +202,24 @@ class PlacePageInfoViewController: UIViewController {
       addressView?.canShowMenu = true
     }
 
-    if let formattedCoordinates = placePageInfoData.formattedCoordinates,
-      let rawCoordinates = placePageInfoData.rawCoordinates {
-      let coordinates = showFormattedCoordinates ? formattedCoordinates : rawCoordinates
-      coordinatesView = createInfoItem(coordinates, icon: UIImage(named: "ic_placepage_coordinate")) {
+    var formatId = self.coordinatesFormatId
+    if let coordFormats = self.placePageInfoData.coordFormats as? Array<String> {
+      if formatId >= coordFormats.count {
+        formatId = 0
+      }
+      
+      coordinatesView = createInfoItem(coordFormats[formatId], icon: UIImage(named: "ic_placepage_coordinate")) {
         [unowned self] in
-        self.showFormattedCoordinates = !self.showFormattedCoordinates
-        let coordinates = self.showFormattedCoordinates ? formattedCoordinates : rawCoordinates
+        let formatId = (self.coordinatesFormatId + 1) % coordFormats.count
+        self.coordinatesFormatId = formatId
+        let coordinates:String = coordFormats[formatId]
         self.coordinatesView?.infoLabel.text = coordinates
       }
-    } else if let formattedCoordinates = placePageInfoData.formattedCoordinates {
-      coordinatesView = createInfoItem(formattedCoordinates, icon: UIImage(named: "ic_placepage_coordinate"))
-    } else if let rawCoordinates = placePageInfoData.rawCoordinates {
-      coordinatesView = createInfoItem(rawCoordinates, icon: UIImage(named: "ic_placepage_coordinate"))
-    }
 
-    coordinatesView?.accessoryImage.image = UIImage(named: "ic_placepage_change")
-    coordinatesView?.accessoryImage.isHidden = false
-    coordinatesView?.canShowMenu = true
+      coordinatesView?.accessoryImage.image = UIImage(named: "ic_placepage_change")
+      coordinatesView?.accessoryImage.isHidden = false
+      coordinatesView?.canShowMenu = true
+    }
   }
 
   // MARK: private

--- a/map/place_page_info.hpp
+++ b/map/place_page_info.hpp
@@ -16,6 +16,8 @@
 
 #include "geometry/point2d.hpp"
 
+#include "platform/utm_mgrs_utils.hpp"
+
 #include <memory>
 #include <optional>
 #include <string>
@@ -30,6 +32,16 @@ enum class OpeningMode
   PreviewPlus,
   Details,
   Full
+};
+
+enum class CoordinatesFormat
+{
+  LatLonDMS = 0, // DMS, comma separated
+  LatLonDecimal, // Decimal, comma separated
+  OLCFull, // Open location code, long format
+  OSMLink, // Link to osm.org
+  UTM, // Universal Transverse Mercator
+  MGRS // Military Grid Reference System
 };
 
 struct BuildInfo
@@ -129,7 +141,7 @@ public:
   std::string const & GetAddress() const { return m_uiAddress; }
   std::string const & GetDescription() const { return m_description; }
   /// @returns coordinate in DMS format if isDMS is true
-  std::string GetFormattedCoordinate(bool isDMS) const;
+  std::string GetFormattedCoordinate(CoordinatesFormat format) const;
 
   /// UI setters
   void SetCustomName(std::string const & name);


### PR DESCRIPTION
Added all supported coordinates to PlacePage. Tap to switch. Long tap to copy.

<img width="395" src="https://github.com/organicmaps/organicmaps/assets/720808/d5592e09-3ccf-48e2-a17b-b81a8a3e8ca9"/>

<img width="395" alt="ios-pp-copy" src="https://github.com/organicmaps/organicmaps/assets/720808/f2fe5cca-3bd4-4d1b-a395-227209141d80"/>

Closing issue #5204 and #1572
