### PR TITLE
[core] Introduce Distance class to store distance and units separately

### DIFF
--- a/android/jni/CMakeLists.txt
+++ b/android/jni/CMakeLists.txt
@@ -16,6 +16,7 @@ set(SRC
   app/organicmaps/opengl/gl3stub.h
   app/organicmaps/platform/GuiThread.hpp
   app/organicmaps/platform/AndroidPlatform.hpp
+  app/organicmaps/util/Distance.hpp
   app/organicmaps/util/FeatureIdBuilder.hpp
   app/organicmaps/vulkan/android_vulkan_context_factory.hpp
 

--- a/android/jni/app/organicmaps/Framework.cpp
+++ b/android/jni/app/organicmaps/Framework.cpp
@@ -4,6 +4,7 @@
 #include "app/organicmaps/UserMarkHelper.hpp"
 #include "app/organicmaps/opengl/androidoglcontextfactory.hpp"
 #include "app/organicmaps/platform/AndroidPlatform.hpp"
+#include "app/organicmaps/util/Distance.hpp"
 #include "app/organicmaps/util/FeatureIdBuilder.hpp"
 #include "app/organicmaps/util/NetworkPolicy.hpp"
 #include "app/organicmaps/vulkan/android_vulkan_context_factory.hpp"
@@ -748,36 +749,6 @@ FeatureID Framework::BuildFeatureId(JNIEnv * env, jobject featureId)
  *            \\//
  *             \/
  */
-
-namespace
-{
-jobject ToJavaDistance(JNIEnv * env, platform::Distance const & distance)
-{
-  static jclass const distanceClass = jni::GetGlobalClassRef(env, "app/organicmaps/util/Distance");
-  static jclass const unitsEnumClass = jni::GetGlobalClassRef(env, "app/organicmaps/util/Distance$Units");
-
-  static jmethodID const distanceConstructor = jni::GetConstructorID(env, distanceClass, "(DLjava/lang/String;Lapp/organicmaps/util/Distance$Units;)V");
-
-  std::string desiredUnits;
-  switch(distance.GetUnits())
-  {
-  case platform::Distance::Units::Meters: desiredUnits = "Meters"; break;
-  case platform::Distance::Units::Kilometers: desiredUnits = "Kilometers"; break;
-  case platform::Distance::Units::Feet: desiredUnits = "Feet"; break;
-  case platform::Distance::Units::Miles: desiredUnits = "Miles"; break;
-  default: UNREACHABLE();
-  }
-
-  jfieldID desiredUnitsField = env->GetStaticFieldID(unitsEnumClass, desiredUnits.c_str(), "Lapp/organicmaps/util/Distance$Units;");
-  jobject desiredUnitsObject = env->GetStaticObjectField(unitsEnumClass, desiredUnitsField);
-
-  jobject distanceObject = env->NewObject(
-      distanceClass, distanceConstructor,
-      distance.GetDistance(), jni::ToJavaString(env, distance.GetDistanceString()), desiredUnitsObject);
-
-  return distanceObject;
-}
-}
 
 extern "C"
 {

--- a/android/jni/app/organicmaps/Framework.cpp
+++ b/android/jni/app/organicmaps/Framework.cpp
@@ -1204,8 +1204,6 @@ Java_app_organicmaps_Framework_nativeGetRouteFollowingInfo(JNIEnv * env, jclass)
 
   routing::FollowingInfo info;
   fr->GetRoutingManager().GetRouteFollowingInfo(info);
-  if (!info.IsValid())
-    return nullptr;
 
   static jclass const klass = jni::GetGlobalClassRef(env, "app/organicmaps/routing/RoutingInfo");
   // Java signature : RoutingInfo(Distance distToTarget, Distance distToTurn,

--- a/android/jni/app/organicmaps/Framework.cpp
+++ b/android/jni/app/organicmaps/Framework.cpp
@@ -926,16 +926,16 @@ JNIEXPORT jobject JNICALL
 Java_app_organicmaps_Framework_nativeGetDistanceAndAzimuth(
     JNIEnv * env, jclass, jdouble merX, jdouble merY, jdouble cLat, jdouble cLon, jdouble north)
 {
-  string distance;
+  platform::Distance distance;
   double azimut = -1.0;
   frm()->GetDistanceAndAzimut(m2::PointD(merX, merY), cLat, cLon, north, distance, azimut);
 
   static jclass const daClazz = jni::GetGlobalClassRef(env, "app/organicmaps/bookmarks/data/DistanceAndAzimut");
-  // Java signature : DistanceAndAzimut(String distance, double azimuth)
-  static jmethodID const methodID = jni::GetConstructorID(env, daClazz, "(Ljava/lang/String;D)V");
+  // Java signature : DistanceAndAzimut(Distance distance, double azimuth)
+  static jmethodID const methodID = jni::GetConstructorID(env, daClazz, "(Lapp/organicmaps/util/Distance;D)V");
 
   return env->NewObject(daClazz, methodID,
-                        jni::ToJavaString(env, distance.c_str()),
+                        ToJavaDistance(env, distance),
                         static_cast<jdouble>(azimut));
 }
 
@@ -981,11 +981,10 @@ Java_app_organicmaps_Framework_nativeFormatLatLon(JNIEnv * env, jclass, jdouble 
   }
 }
 
-JNIEXPORT jstring JNICALL
+JNIEXPORT jobject JNICALL
 Java_app_organicmaps_Framework_nativeFormatAltitude(JNIEnv * env, jclass, jdouble alt)
 {
-  auto const localizedUnits = platform::GetLocalizedAltitudeUnits();
-  return jni::ToJavaString(env, measurement_utils::FormatAltitudeWithLocalization(alt, localizedUnits.m_low));
+  return ToJavaDistance(env, platform::Distance::CreateAltitudeFormatted(alt));
 }
 
 JNIEXPORT jstring JNICALL

--- a/android/jni/app/organicmaps/SearchEngine.cpp
+++ b/android/jni/app/organicmaps/SearchEngine.cpp
@@ -1,6 +1,7 @@
 #include "app/organicmaps/Framework.hpp"
 #include "app/organicmaps/UserMarkHelper.hpp"
 #include "app/organicmaps/platform/AndroidPlatform.hpp"
+#include "app/organicmaps/util/Distance.hpp"
 
 #include "map/bookmarks_search_params.hpp"
 #include "map/everywhere_search_params.hpp"
@@ -92,12 +93,12 @@ jobject ToJavaResult(Result const & result, search::ProductInfo const & productI
     return env->NewObject(g_resultClass, g_suggestConstructor, name.get(), suggest.get(), ll.m_lat, ll.m_lon, ranges.get());
   }
 
-  string distance;
+  platform::Distance distance;
   double distanceInMeters = 0.0;
   if (result.HasPoint() && hasPosition)
   {
     distanceInMeters = ms::DistanceOnEarth(lat, lon, ll.m_lat, ll.m_lon);
-    distance = measurement_utils::FormatDistance(distanceInMeters);
+    distance = platform::Distance::CreateFormatted(distanceInMeters);
   }
 
   bool const popularityHasHigherPriority = PopularityHasHigherPriority(hasPosition, distanceInMeters);
@@ -109,7 +110,7 @@ jobject ToJavaResult(Result const & result, search::ProductInfo const & productI
 
   jni::TScopedLocalRef featureType(env, jni::ToJavaString(env, readableType));
   jni::TScopedLocalRef address(env, jni::ToJavaString(env, result.GetAddress()));
-  jni::TScopedLocalRef dist(env, jni::ToJavaString(env, distance));
+  jni::TScopedLocalRef dist(env, ToJavaDistance(env, distance));
   jni::TScopedLocalRef cuisine(env, jni::ToJavaString(env, result.GetCuisine()));
   jni::TScopedLocalRef brand(env, jni::ToJavaString(env, result.GetBrand()));
   jni::TScopedLocalRef airportIata(env, jni::ToJavaString(env, result.GetAirportIata()));
@@ -243,14 +244,14 @@ extern "C"
     g_suggestConstructor = jni::GetConstructorID(env, g_resultClass, "(Ljava/lang/String;Ljava/lang/String;DD[I)V");
     g_descriptionClass = jni::GetGlobalClassRef(env, "app/organicmaps/search/SearchResult$Description");
     /*
-        Description(FeatureId featureId, String featureType, String region, String distance,
+        Description(FeatureId featureId, String featureType, String region, Distance distance,
                     String cuisine, String brand, String airportIata, String roadShields,
                     int openNow, int minutesUntilOpen, int minutesUntilClosed, 
                     boolean hasPopularityHigherPriority)
     */
     g_descriptionConstructor = jni::GetConstructorID(env, g_descriptionClass,
                                                      "(Lapp/organicmaps/bookmarks/data/FeatureId;"
-                                                     "Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;"
+                                                     "Ljava/lang/String;Ljava/lang/String;Lapp/organicmaps/util/Distance;"
                                                      "Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;"
                                                      "Ljava/lang/String;IIIZ)V");
 

--- a/android/jni/app/organicmaps/util/Distance.hpp
+++ b/android/jni/app/organicmaps/util/Distance.hpp
@@ -1,0 +1,19 @@
+#pragma once
+
+#include "app/organicmaps/core/jni_helper.hpp"
+
+#include "platform/distance.hpp"
+
+inline jobject ToJavaDistance(JNIEnv * env, platform::Distance const & distance)
+{
+  static jclass const distanceClass = jni::GetGlobalClassRef(env, "app/organicmaps/util/Distance");
+  static jclass const unitsEnumClass = jni::GetGlobalClassRef(env, "app/organicmaps/util/Distance$Units");
+
+  static jmethodID const distanceConstructor = jni::GetConstructorID(env, distanceClass, "(DLjava/lang/String;B)V");
+
+  jobject distanceObject = env->NewObject(
+      distanceClass, distanceConstructor,
+      distance.GetDistance(), jni::ToJavaString(env, distance.GetDistanceString()), static_cast<uint8_t>(distance.GetUnits()));
+
+  return distanceObject;
+}

--- a/android/jni/app/organicmaps/util/Distance.hpp
+++ b/android/jni/app/organicmaps/util/Distance.hpp
@@ -7,7 +7,6 @@
 inline jobject ToJavaDistance(JNIEnv * env, platform::Distance const & distance)
 {
   static jclass const distanceClass = jni::GetGlobalClassRef(env, "app/organicmaps/util/Distance");
-  static jclass const unitsEnumClass = jni::GetGlobalClassRef(env, "app/organicmaps/util/Distance$Units");
 
   static jmethodID const distanceConstructor = jni::GetConstructorID(env, distanceClass, "(DLjava/lang/String;B)V");
 

--- a/android/jni/app/organicmaps/util/StringUtils.cpp
+++ b/android/jni/app/organicmaps/util/StringUtils.cpp
@@ -1,4 +1,5 @@
 #include "app/organicmaps/core/jni_helper.hpp"
+#include "app/organicmaps/util/Distance.hpp"
 
 #include "indexer/search_string_utils.hpp"
 
@@ -59,14 +60,11 @@ JNIEXPORT jobject JNICALL Java_app_organicmaps_util_StringUtils_nativeFormatSpee
                       platform::GetLocalizedSpeedUnits(units));
 }
 
-JNIEXPORT jstring JNICALL
-Java_app_organicmaps_util_StringUtils_nativeFormatDistance(JNIEnv * env, jclass thiz,
-                                                          jdouble distanceInMeters)
+JNIEXPORT jobject JNICALL
+Java_app_organicmaps_util_StringUtils_nativeFormatDistance(JNIEnv * env, jclass,
+                                                           jdouble distanceInMeters)
 {
-  auto const localizedUnits = platform::GetLocalizedDistanceUnits();
-  return jni::ToJavaString(env, measurement_utils::FormatDistanceWithLocalization(distanceInMeters,
-                                                                                  localizedUnits.m_high,
-                                                                                  localizedUnits.m_low));
+  return ToJavaDistance(env, platform::Distance::CreateFormatted(distanceInMeters));
 }
 
 JNIEXPORT jobject JNICALL

--- a/android/jni/app/organicmaps/util/StringUtils.cpp
+++ b/android/jni/app/organicmaps/util/StringUtils.cpp
@@ -61,8 +61,7 @@ JNIEXPORT jobject JNICALL Java_app_organicmaps_util_StringUtils_nativeFormatSpee
 }
 
 JNIEXPORT jobject JNICALL
-Java_app_organicmaps_util_StringUtils_nativeFormatDistance(JNIEnv * env, jclass,
-                                                           jdouble distanceInMeters)
+Java_app_organicmaps_util_StringUtils_nativeFormatDistance(JNIEnv * env, jclass, jdouble distanceInMeters)
 {
   return ToJavaDistance(env, platform::Distance::CreateFormatted(distanceInMeters));
 }

--- a/android/jni/app/organicmaps/util/StringUtils.cpp
+++ b/android/jni/app/organicmaps/util/StringUtils.cpp
@@ -69,17 +69,6 @@ Java_app_organicmaps_util_StringUtils_nativeFormatDistance(JNIEnv * env, jclass 
                                                                                   localizedUnits.m_low));
 }
 
-JNIEXPORT jstring JNICALL
-Java_app_organicmaps_util_StringUtils_nativeFormatDistanceWithLocalization(JNIEnv * env, jclass,
-                                                                          jdouble distanceInMeters,
-                                                                          jstring high,
-                                                                          jstring low)
-{
-  auto const distance = measurement_utils::FormatDistanceWithLocalization(
-      distanceInMeters, jni::ToNativeString(env, high), jni::ToNativeString(env, low));
-  return jni::ToJavaString(env, distance);
-}
-
 JNIEXPORT jobject JNICALL
 Java_app_organicmaps_util_StringUtils_nativeGetLocalizedDistanceUnits(JNIEnv * env, jclass)
 {

--- a/android/res/values-ar/strings.xml
+++ b/android/res/values-ar/strings.xml
@@ -501,12 +501,12 @@
 	<string name="current_location_unknown_message">الموقع الحالي غير معروف. ربما تتواجد داخل مبنى أو نفق.</string>
 	<string name="current_location_unknown_continue_button">الاستمرار</string>
 	<string name="current_location_unknown_stop_button">إيقاف</string>
-	<string name="meter">متر</string>
-	<string name="kilometer">كم</string>
+	<string name="m">متر</string>
+	<string name="km">كم</string>
 	<string name="kilometers_per_hour">كم/ساعة</string>
-	<string name="mile">ميل</string>
+	<string name="mi">ميل</string>
 	<!-- A unit of measure -->
-	<string name="foot">قدم</string>
+	<string name="ft">قدم</string>
 	<string name="miles_per_hour">ميل/ساعة</string>
 	<string name="hour">س</string>
 	<string name="minute">د</string>

--- a/android/res/values-be/strings.xml
+++ b/android/res/values-be/strings.xml
@@ -496,12 +496,12 @@
 	<string name="current_location_unknown_message">Месцазнаходжанне невядома. Магчыма вы ў будынку або ў танэлі.</string>
 	<string name="current_location_unknown_continue_button">Працягнуць</string>
 	<string name="current_location_unknown_stop_button">Спыніць</string>
-	<string name="meter">м</string>
-	<string name="kilometer">км</string>
+	<string name="m">м</string>
+	<string name="km">км</string>
 	<string name="kilometers_per_hour">км/г</string>
-	<string name="mile">міля</string>
+	<string name="mi">міля</string>
 	<!-- A unit of measure -->
-	<string name="foot">фут</string>
+	<string name="ft">фут</string>
 	<string name="miles_per_hour">міль/г</string>
 	<string name="hour">г</string>
 	<string name="minute">хв</string>

--- a/android/res/values-bg/strings.xml
+++ b/android/res/values-bg/strings.xml
@@ -465,11 +465,11 @@
 	<string name="current_location_unknown_message">Настоящото местоположение е неизвестно. Може би се намирате в сграда или тунел.</string>
 	<string name="current_location_unknown_continue_button">Продължаване</string>
 	<string name="current_location_unknown_stop_button">Стоп</string>
-	<string name="meter">м</string>
-	<string name="kilometer">км</string>
-	<string name="mile">ми</string>
+	<string name="m">м</string>
+	<string name="km">км</string>
+	<string name="mi">ми</string>
 	<!-- A unit of measure -->
-	<string name="foot">фут</string>
+	<string name="ft">фут</string>
 	<string name="hour">ч</string>
 	<string name="minute">мин</string>
 	<string name="placepage_more_button">Още</string>

--- a/android/res/values-ca/strings.xml
+++ b/android/res/values-ca/strings.xml
@@ -487,12 +487,12 @@
 	<string name="current_location_unknown_message">Es desconeix la ubicació actual. Potser sou en un edifici o en un túnel.</string>
 	<string name="current_location_unknown_continue_button">Continua</string>
 	<string name="current_location_unknown_stop_button">Atura\'t</string>
-	<string name="meter">m</string>
-	<string name="kilometer">km</string>
+	<string name="m">m</string>
+	<string name="km">km</string>
 	<string name="kilometers_per_hour">km/h</string>
-	<string name="mile">mi</string>
+	<string name="mi">mi</string>
 	<!-- A unit of measure -->
-	<string name="foot">ft</string>
+	<string name="ft">ft</string>
 	<string name="miles_per_hour">mph</string>
 	<string name="hour">h</string>
 	<string name="minute">min</string>

--- a/android/res/values-cs/strings.xml
+++ b/android/res/values-cs/strings.xml
@@ -478,12 +478,12 @@
 	<string name="current_location_unknown_message">Nezjistili jsme vaši současnou polohu. Možná jste v budově nebo tunelu.</string>
 	<string name="current_location_unknown_continue_button">Pokračovat</string>
 	<string name="current_location_unknown_stop_button">Zastavit</string>
-	<string name="meter">m</string>
-	<string name="kilometer">km</string>
+	<string name="m">m</string>
+	<string name="km">km</string>
 	<string name="kilometers_per_hour">km/h</string>
-	<string name="mile">mil</string>
+	<string name="mi">mil</string>
 	<!-- A unit of measure -->
-	<string name="foot">stopa</string>
+	<string name="ft">stopa</string>
 	<string name="miles_per_hour">mil/h</string>
 	<string name="hour">hod</string>
 	<string name="minute">min</string>

--- a/android/res/values-da/strings.xml
+++ b/android/res/values-da/strings.xml
@@ -474,12 +474,12 @@
 	<string name="current_location_unknown_message">Aktuel placering er ukendt. Måske er du i en bygning eller i en tunnel.</string>
 	<string name="current_location_unknown_continue_button">Fortsæt</string>
 	<string name="current_location_unknown_stop_button">Stop</string>
-	<string name="meter">m</string>
-	<string name="kilometer">km</string>
+	<string name="m">m</string>
+	<string name="km">km</string>
 	<string name="kilometers_per_hour">km/t</string>
-	<string name="mile">mil</string>
+	<string name="mi">mil</string>
 	<!-- A unit of measure -->
-	<string name="foot">fod</string>
+	<string name="ft">fod</string>
 	<string name="miles_per_hour">mph</string>
 	<string name="hour">time</string>
 	<string name="minute">min</string>

--- a/android/res/values-de/strings.xml
+++ b/android/res/values-de/strings.xml
@@ -494,12 +494,12 @@
 	<string name="current_location_unknown_message">Standort nicht gefunden. Möglicherweise befinden Sie sich in einem Gebäude oder einem Tunnel.</string>
 	<string name="current_location_unknown_continue_button">Fortsetzen</string>
 	<string name="current_location_unknown_stop_button">Anhalten</string>
-	<string name="meter">m</string>
-	<string name="kilometer">km</string>
+	<string name="m">m</string>
+	<string name="km">km</string>
 	<string name="kilometers_per_hour">km/h</string>
-	<string name="mile">mi</string>
+	<string name="mi">mi</string>
 	<!-- A unit of measure -->
-	<string name="foot">ft</string>
+	<string name="ft">ft</string>
 	<string name="miles_per_hour">mph</string>
 	<string name="hour">h</string>
 	<string name="minute">min</string>

--- a/android/res/values-es/strings.xml
+++ b/android/res/values-es/strings.xml
@@ -498,12 +498,12 @@
 	<string name="current_location_unknown_message">La ubicación actual es desconocida. Quizá esté en un edificio o en un túnel.</string>
 	<string name="current_location_unknown_continue_button">Continuar</string>
 	<string name="current_location_unknown_stop_button">Detener</string>
-	<string name="meter">m</string>
-	<string name="kilometer">km</string>
+	<string name="m">m</string>
+	<string name="km">km</string>
 	<string name="kilometers_per_hour">km/h</string>
-	<string name="mile">mi</string>
+	<string name="mi">mi</string>
 	<!-- A unit of measure -->
-	<string name="foot">pie</string>
+	<string name="ft">pie</string>
 	<string name="miles_per_hour">mph</string>
 	<string name="hour">h</string>
 	<string name="minute">min</string>

--- a/android/res/values-et/strings.xml
+++ b/android/res/values-et/strings.xml
@@ -486,12 +486,12 @@
 	<string name="current_location_unknown_message">Hetkeasukoht on teadmata. Võib-olla oled hoones sees või tunnelis.</string>
 	<string name="current_location_unknown_continue_button">Jätka</string>
 	<string name="current_location_unknown_stop_button">Lõpeta</string>
-	<string name="meter">m</string>
-	<string name="kilometer">km</string>
+	<string name="m">m</string>
+	<string name="km">km</string>
 	<string name="kilometers_per_hour">km/h</string>
-	<string name="mile">mi</string>
+	<string name="mi">mi</string>
 	<!-- A unit of measure -->
-	<string name="foot">jalga</string>
+	<string name="ft">jalga</string>
 	<string name="miles_per_hour">mph</string>
 	<string name="hour">h</string>
 	<string name="minute">min</string>

--- a/android/res/values-eu/strings.xml
+++ b/android/res/values-eu/strings.xml
@@ -496,12 +496,12 @@
 	<string name="current_location_unknown_message">Uneko kokapena ezezaguna da. Agian eraikin batean edo tunel batean zaudelako.</string>
 	<string name="current_location_unknown_continue_button">Jarraitu</string>
 	<string name="current_location_unknown_stop_button">Gelditu</string>
-	<string name="meter">m</string>
-	<string name="kilometer">km</string>
+	<string name="m">m</string>
+	<string name="km">km</string>
 	<string name="kilometers_per_hour">km/h</string>
-	<string name="mile">mi</string>
+	<string name="mi">mi</string>
 	<!-- A unit of measure -->
-	<string name="foot">oin</string>
+	<string name="ft">oin</string>
 	<string name="miles_per_hour">mph</string>
 	<string name="hour">h</string>
 	<string name="minute">min</string>

--- a/android/res/values-fa/strings.xml
+++ b/android/res/values-fa/strings.xml
@@ -469,12 +469,12 @@
 	<string name="current_location_unknown_message">مکان شما ناشناس مانده است.ممکن است شما داخل یک ساختمان یا تونل باشید.</string>
 	<string name="current_location_unknown_continue_button">ادامه</string>
 	<string name="current_location_unknown_stop_button">توقف</string>
-	<string name="meter">متر</string>
-	<string name="kilometer">کیلومتر</string>
+	<string name="m">متر</string>
+	<string name="km">کیلومتر</string>
 	<string name="kilometers_per_hour">کیلومتربرساعت (km/h)</string>
-	<string name="mile">مایل</string>
+	<string name="mi">مایل</string>
 	<!-- A unit of measure -->
-	<string name="foot">فوت</string>
+	<string name="ft">فوت</string>
 	<string name="miles_per_hour">مایل بر ساعت (mph)</string>
 	<string name="hour">ساعت</string>
 	<string name="minute">دقیقه</string>

--- a/android/res/values-fi/strings.xml
+++ b/android/res/values-fi/strings.xml
@@ -478,12 +478,12 @@
 	<string name="current_location_unknown_message">Nykyistä sijaintiasi ei voitu määrittää. Kenties olet rakennuksessa tai tunnelissa.</string>
 	<string name="current_location_unknown_continue_button">Jatka</string>
 	<string name="current_location_unknown_stop_button">Seis</string>
-	<string name="meter">m</string>
-	<string name="kilometer">km</string>
+	<string name="m">m</string>
+	<string name="km">km</string>
 	<string name="kilometers_per_hour">km/h</string>
-	<string name="mile">mi</string>
+	<string name="mi">mi</string>
 	<!-- A unit of measure -->
-	<string name="foot">ft</string>
+	<string name="ft">ft</string>
 	<string name="miles_per_hour">mph</string>
 	<string name="hour">t</string>
 	<string name="minute">min</string>

--- a/android/res/values-fr/strings.xml
+++ b/android/res/values-fr/strings.xml
@@ -500,12 +500,12 @@
 	<string name="current_location_unknown_message">L\'emplacement actuel est inconnu. Vous êtes peut-être dans un bâtiment ou sous un tunnel.</string>
 	<string name="current_location_unknown_continue_button">Continuer</string>
 	<string name="current_location_unknown_stop_button">Arrêter</string>
-	<string name="meter">m</string>
-	<string name="kilometer">km</string>
+	<string name="m">m</string>
+	<string name="km">km</string>
 	<string name="kilometers_per_hour">km/h</string>
-	<string name="mile">mi</string>
+	<string name="mi">mi</string>
 	<!-- A unit of measure -->
-	<string name="foot">ft</string>
+	<string name="ft">ft</string>
 	<string name="miles_per_hour">mph</string>
 	<string name="hour">h</string>
 	<string name="minute">min</string>

--- a/android/res/values-hu/strings.xml
+++ b/android/res/values-hu/strings.xml
@@ -486,12 +486,12 @@
 	<string name="current_location_unknown_message">Tartózkodási helye ismeretlen. Lehet, hogy épületben vagy alagútban tartózkodik.</string>
 	<string name="current_location_unknown_continue_button">Folytatás</string>
 	<string name="current_location_unknown_stop_button">Leállítás</string>
-	<string name="meter">m</string>
-	<string name="kilometer">km</string>
+	<string name="m">m</string>
+	<string name="km">km</string>
 	<string name="kilometers_per_hour">km/h</string>
-	<string name="mile">mf</string>
+	<string name="mi">mf</string>
 	<!-- A unit of measure -->
-	<string name="foot">ft</string>
+	<string name="ft">ft</string>
 	<string name="miles_per_hour">mph</string>
 	<string name="hour">ó</string>
 	<string name="minute">p</string>

--- a/android/res/values-in/strings.xml
+++ b/android/res/values-in/strings.xml
@@ -474,12 +474,12 @@
 	<string name="current_location_unknown_message">Lokasi saat ini tidak diketahui. Anda mungkin berada dalam bangunan atau terowongan.</string>
 	<string name="current_location_unknown_continue_button">Lanjutkan</string>
 	<string name="current_location_unknown_stop_button">Berhenti</string>
-	<string name="meter">m</string>
-	<string name="kilometer">km</string>
+	<string name="m">m</string>
+	<string name="km">km</string>
 	<string name="kilometers_per_hour">km/j</string>
-	<string name="mile">mil</string>
+	<string name="mi">mil</string>
 	<!-- A unit of measure -->
-	<string name="foot">kaki</string>
+	<string name="ft">kaki</string>
 	<string name="miles_per_hour">mpj</string>
 	<string name="hour">j</string>
 	<string name="minute">mnt</string>

--- a/android/res/values-it/strings.xml
+++ b/android/res/values-it/strings.xml
@@ -482,10 +482,10 @@
 	<string name="current_location_unknown_message">La posizione attuale è sconosciuta. È possibile che ci si trovi all\'interno di un edificio o un tunnel.</string>
 	<string name="current_location_unknown_continue_button">Continua</string>
 	<string name="current_location_unknown_stop_button">Ferma</string>
-	<string name="meter">m</string>
-	<string name="kilometer">km</string>
+	<string name="m">m</string>
+	<string name="km">km</string>
 	<string name="kilometers_per_hour">km/h</string>
-	<string name="mile">mi</string>
+	<string name="mi">mi</string>
 	<string name="miles_per_hour">mph</string>
 	<string name="minute">min</string>
 	<string name="placepage_more_button">Di più</string>

--- a/android/res/values-ja/strings.xml
+++ b/android/res/values-ja/strings.xml
@@ -470,12 +470,12 @@
 	<string name="current_location_unknown_message">現在地が不明です。建物の中やトンネル内の可能性があります。</string>
 	<string name="current_location_unknown_continue_button">続ける</string>
 	<string name="current_location_unknown_stop_button">止める</string>
-	<string name="meter">m</string>
-	<string name="kilometer">km</string>
+	<string name="m">m</string>
+	<string name="km">km</string>
 	<string name="kilometers_per_hour">キロメートル毎時</string>
-	<string name="mile">マイル</string>
+	<string name="mi">マイル</string>
 	<!-- A unit of measure -->
-	<string name="foot">フィート</string>
+	<string name="ft">フィート</string>
 	<string name="miles_per_hour">マイル毎時</string>
 	<string name="hour">時間</string>
 	<string name="minute">分</string>

--- a/android/res/values-ko/strings.xml
+++ b/android/res/values-ko/strings.xml
@@ -472,12 +472,12 @@
 	<string name="current_location_unknown_message">현재 위치를 알 수 없습니다. 건물 안이나 터널 안에서는 검색할 수 없습니다</string>
 	<string name="current_location_unknown_continue_button">계속</string>
 	<string name="current_location_unknown_stop_button">중지</string>
-	<string name="meter">m</string>
-	<string name="kilometer">km</string>
+	<string name="m">m</string>
+	<string name="km">km</string>
 	<string name="kilometers_per_hour">km/시</string>
-	<string name="mile">mi</string>
+	<string name="mi">mi</string>
 	<!-- A unit of measure -->
-	<string name="foot">풋</string>
+	<string name="ft">풋</string>
 	<string name="miles_per_hour">mph</string>
 	<string name="hour">t</string>
 	<string name="minute">min</string>

--- a/android/res/values-mr/strings.xml
+++ b/android/res/values-mr/strings.xml
@@ -465,12 +465,12 @@
 	<string name="current_location_unknown_message">वर्तमान स्थान अज्ञात आहे. कदाचित तुम्ही एखाद्या इमारतीत किंवा बोगद्यात असाल.</string>
 	<string name="current_location_unknown_continue_button">चालू</string>
 	<string name="current_location_unknown_stop_button">थांबा</string>
-	<string name="meter">m</string>
-	<string name="kilometer">किमी</string>
+	<string name="m">m</string>
+	<string name="km">किमी</string>
 	<string name="kilometers_per_hour">km/h</string>
-	<string name="mile">mi</string>
+	<string name="mi">mi</string>
 	<!-- A unit of measure -->
-	<string name="foot">फूट</string>
+	<string name="ft">फूट</string>
 	<string name="miles_per_hour">mph</string>
 	<string name="hour">तास</string>
 	<string name="minute">मिनिट</string>

--- a/android/res/values-nb/strings.xml
+++ b/android/res/values-nb/strings.xml
@@ -498,12 +498,12 @@
 	<string name="current_location_unknown_message">Gjeldende plassering er ukjent. Du kan være i en bygning eller en tunnel.</string>
 	<string name="current_location_unknown_continue_button">Fortsett</string>
 	<string name="current_location_unknown_stop_button">Stopp</string>
-	<string name="meter">m</string>
-	<string name="kilometer">km</string>
+	<string name="m">m</string>
+	<string name="km">km</string>
 	<string name="kilometers_per_hour">km/t</string>
-	<string name="mile">mi</string>
+	<string name="mi">mi</string>
 	<!-- A unit of measure -->
-	<string name="foot">fot</string>
+	<string name="ft">fot</string>
 	<string name="miles_per_hour">mph</string>
 	<string name="hour">t</string>
 	<string name="minute">min</string>

--- a/android/res/values-nl/strings.xml
+++ b/android/res/values-nl/strings.xml
@@ -494,12 +494,12 @@
 	<string name="current_location_unknown_message">Huidige locatie is onbekend. Misschien bevindt u zich in een gebouw of tunnel.</string>
 	<string name="current_location_unknown_continue_button">Doorgaan</string>
 	<string name="current_location_unknown_stop_button">Stoppen</string>
-	<string name="meter">m</string>
-	<string name="kilometer">km</string>
+	<string name="m">m</string>
+	<string name="km">km</string>
 	<string name="kilometers_per_hour">km/h</string>
-	<string name="mile">mijl</string>
+	<string name="mi">mijl</string>
 	<!-- A unit of measure -->
-	<string name="foot">voet</string>
+	<string name="ft">voet</string>
 	<string name="miles_per_hour">mph</string>
 	<string name="hour">u</string>
 	<string name="minute">min</string>

--- a/android/res/values-pl/strings.xml
+++ b/android/res/values-pl/strings.xml
@@ -498,12 +498,12 @@
 	<string name="current_location_unknown_message">Aktualna lokalizacja jest nieznana. Może znajdujesz się w budynku lub tunelu.</string>
 	<string name="current_location_unknown_continue_button">Kontynuuj</string>
 	<string name="current_location_unknown_stop_button">Stop</string>
-	<string name="meter">m</string>
-	<string name="kilometer">km</string>
+	<string name="m">m</string>
+	<string name="km">km</string>
 	<string name="kilometers_per_hour">km/h</string>
-	<string name="mile">mi</string>
+	<string name="mi">mi</string>
 	<!-- A unit of measure -->
-	<string name="foot">ft</string>
+	<string name="ft">ft</string>
 	<string name="miles_per_hour">mph</string>
 	<string name="hour">godz</string>
 	<string name="minute">min</string>

--- a/android/res/values-pt-rBR/strings.xml
+++ b/android/res/values-pt-rBR/strings.xml
@@ -483,12 +483,12 @@
 	<string name="current_location_unknown_message">A localização atual é desconhecida. Talvez você esteja em um edifício ou túnel.</string>
 	<string name="current_location_unknown_continue_button">Continuar</string>
 	<string name="current_location_unknown_stop_button">Parar</string>
-	<string name="meter">m</string>
-	<string name="kilometer">km</string>
+	<string name="m">m</string>
+	<string name="km">km</string>
 	<string name="kilometers_per_hour">km/h</string>
-	<string name="mile">mi</string>
+	<string name="mi">mi</string>
 	<!-- A unit of measure -->
-	<string name="foot">ft</string>
+	<string name="ft">ft</string>
 	<string name="miles_per_hour">mph</string>
 	<string name="hour">h</string>
 	<string name="minute">min</string>

--- a/android/res/values-pt/strings.xml
+++ b/android/res/values-pt/strings.xml
@@ -479,12 +479,12 @@
 	<string name="current_location_unknown_message">A localização atual é desconhecida. Talvez esteja num edifício ou num túnel.</string>
 	<string name="current_location_unknown_continue_button">Continuar</string>
 	<string name="current_location_unknown_stop_button">Parar</string>
-	<string name="meter">m</string>
-	<string name="kilometer">Km</string>
+	<string name="m">m</string>
+	<string name="km">Km</string>
 	<string name="kilometers_per_hour">km/h</string>
-	<string name="mile">mi</string>
+	<string name="mi">mi</string>
 	<!-- A unit of measure -->
-	<string name="foot">ft</string>
+	<string name="ft">ft</string>
 	<string name="miles_per_hour">mph</string>
 	<string name="hour">h</string>
 	<string name="minute">min</string>

--- a/android/res/values-ro/strings.xml
+++ b/android/res/values-ro/strings.xml
@@ -482,10 +482,10 @@
 	<string name="current_location_unknown_message">Poziția actuală este necunoscută. Poate te afli într-o clădire sau un tunel.</string>
 	<string name="current_location_unknown_continue_button">Continuă</string>
 	<string name="current_location_unknown_stop_button">Oprește</string>
-	<string name="meter">m</string>
-	<string name="kilometer">km</string>
+	<string name="m">m</string>
+	<string name="km">km</string>
 	<string name="kilometers_per_hour">km/h</string>
-	<string name="mile">mi</string>
+	<string name="mi">mi</string>
 	<string name="miles_per_hour">mph</string>
 	<string name="minute">min</string>
 	<string name="placepage_more_button">Mai mult</string>

--- a/android/res/values-ru/strings.xml
+++ b/android/res/values-ru/strings.xml
@@ -501,12 +501,12 @@
 	<string name="current_location_unknown_message">Местоположение не найдено. Возможно, вы находитесь в помещении или в туннеле.</string>
 	<string name="current_location_unknown_continue_button">Продолжить</string>
 	<string name="current_location_unknown_stop_button">Стоп</string>
-	<string name="meter">м</string>
-	<string name="kilometer">км</string>
+	<string name="m">м</string>
+	<string name="km">км</string>
 	<string name="kilometers_per_hour">км/ч</string>
-	<string name="mile">ми</string>
+	<string name="mi">ми</string>
 	<!-- A unit of measure -->
-	<string name="foot">фут</string>
+	<string name="ft">фут</string>
 	<string name="miles_per_hour">ми/ч</string>
 	<string name="hour">ч</string>
 	<string name="minute">мин</string>

--- a/android/res/values-sk/strings.xml
+++ b/android/res/values-sk/strings.xml
@@ -470,12 +470,12 @@
 	<string name="current_location_unknown_message">Súčasná pozícia je neznáma. Možno sa nachádzate v budove alebo v tuneli.</string>
 	<string name="current_location_unknown_continue_button">Pokračovať</string>
 	<string name="current_location_unknown_stop_button">Zastaviť</string>
-	<string name="meter">m</string>
-	<string name="kilometer">km</string>
+	<string name="m">m</string>
+	<string name="km">km</string>
 	<string name="kilometers_per_hour">km/h</string>
-	<string name="mile">mi</string>
+	<string name="mi">mi</string>
 	<!-- A unit of measure -->
-	<string name="foot">stopa</string>
+	<string name="ft">stopa</string>
 	<string name="miles_per_hour">mph</string>
 	<string name="hour">hod</string>
 	<string name="minute">min</string>

--- a/android/res/values-sv/strings.xml
+++ b/android/res/values-sv/strings.xml
@@ -470,12 +470,12 @@
 	<string name="current_location_unknown_message">Nuvarande plats okänd. Du kanske är i en byggnad eller tunnel.</string>
 	<string name="current_location_unknown_continue_button">Fortsätt</string>
 	<string name="current_location_unknown_stop_button">Stopp</string>
-	<string name="meter">m</string>
-	<string name="kilometer">km</string>
+	<string name="m">m</string>
+	<string name="km">km</string>
 	<string name="kilometers_per_hour">km/h</string>
-	<string name="mile">mile</string>
+	<string name="mi">mile</string>
 	<!-- A unit of measure -->
-	<string name="foot">fot</string>
+	<string name="ft">fot</string>
 	<string name="miles_per_hour">mph</string>
 	<string name="hour">h</string>
 	<string name="minute">min</string>

--- a/android/res/values-th/strings.xml
+++ b/android/res/values-th/strings.xml
@@ -474,12 +474,12 @@
 	<string name="current_location_unknown_message">ไม่ทราบชื่อสถานที่ปัจจุบัน คุณอาจจะอยู่ในอาคาร หรือ ในอุโมงค์</string>
 	<string name="current_location_unknown_continue_button">ดำเนินการต่อ</string>
 	<string name="current_location_unknown_stop_button">หยุด</string>
-	<string name="meter">ม.</string>
-	<string name="kilometer">กม.</string>
+	<string name="m">ม.</string>
+	<string name="km">กม.</string>
 	<string name="kilometers_per_hour">กม./ชม.</string>
-	<string name="mile">ไมล์</string>
+	<string name="mi">ไมล์</string>
 	<!-- A unit of measure -->
-	<string name="foot">ฟุต</string>
+	<string name="ft">ฟุต</string>
 	<string name="miles_per_hour">ไมล์/ชม.</string>
 	<string name="hour">ชม.</string>
 	<string name="minute">น.</string>

--- a/android/res/values-tr/strings.xml
+++ b/android/res/values-tr/strings.xml
@@ -76,7 +76,7 @@
 	<!-- Should be used in the bookmarks-only context, see bookmarks_and_tracks if tracks are also implied. -->
 	<string name="bookmarks">Yer İmleri</string>
 	<!-- "Bookmarks and Tracks" dialog title, also sync it with iphone/plist.txt -->
-	<string name="bookmarks_and_tracks">Yer İmleri ve kayıtlar</string>
+	<string name="bookmarks_and_tracks">Yer İmleri ve Kayıtlar</string>
 	<!-- Default bookmark list name -->
 	<string name="core_my_places">Yerlerim</string>
 	<!-- Add bookmark dialog - bookmark name -->
@@ -199,7 +199,7 @@
 	<!-- Confirmation in downloading countries dialog -->
 	<string name="are_you_sure">Devam etmek istediğinizden emin misiniz?</string>
 	<!-- Title for tracks category in bookmarks manager -->
-	<string name="tracks_title">Kayıtlar</string>
+	<string name="tracks_title">Yol Kayıtları</string>
 	<!-- Length of track in cell that describes route -->
 	<string name="length">Uzunluk</string>
 	<string name="share_my_location">Konumumu Paylaş</string>
@@ -261,7 +261,7 @@
 	<!-- Toast text when compass calibration may improve the correctness of the current position arrow -->
 	<string name="compass_calibration_recommended">Pusulayı kalibre etmek için telefonu sekiz şeklinde hareket ettirerek ok yönünü iyileştirin.</string>
 	<!-- Toast text when compass calibration may improve the correctness of the current position arrow -->
-	<string name="compass_calibration_required">Pusulayı kalibre etmek ve haritadaki ok yönünü sabitlemek için telefonu sekiz şeklinde hareket ettirin.</string>
+	<string name="compass_calibration_required">Pusulayı kalibre etmek ve haritadaki ok yönünü düzeltmek için telefonu sekiz şeklinde hareket ettirin.</string>
 	<!-- Update all button text -->
 	<string name="downloader_update_all_button">Tümünü güncelle</string>
 	<!-- Cancel all button text -->
@@ -391,9 +391,9 @@
 	<!-- Edit open hours/set time and minutes dialog -->
 	<string name="next_button">Sonraki</string>
 	<!-- Tab title in the Edit Opening Hours time picker -->
-	<string name="editor_time_from">Den itibaren</string>
+	<string name="editor_time_from">Açılış</string>
 	<!-- Tab title in the Edit Opening Hours time picker -->
-	<string name="editor_time_to">A</string>
+	<string name="editor_time_to">Kapanış</string>
 	<string name="editor_time_add">Plan Ekle</string>
 	<string name="editor_time_delete">Planı Sil</string>
 	<!-- Text for allday switch. -->
@@ -498,12 +498,12 @@
 	<string name="current_location_unknown_message">Geçerli konum bilinmiyor. Muhtemelen bir bina veya tünelin içindesiniz.</string>
 	<string name="current_location_unknown_continue_button">Devam</string>
 	<string name="current_location_unknown_stop_button">Dur</string>
-	<string name="meter">m</string>
-	<string name="kilometer">km</string>
+	<string name="m">m</string>
+	<string name="km">km</string>
 	<string name="kilometers_per_hour">km/s</string>
-	<string name="mile">mil</string>
+	<string name="mi">mil</string>
 	<!-- A unit of measure -->
-	<string name="foot">fit</string>
+	<string name="ft">fit</string>
 	<string name="miles_per_hour">saatte mil</string>
 	<string name="hour">sa</string>
 	<string name="minute">dk</string>
@@ -783,7 +783,7 @@
 	<string name="type.amenity.casino">Kumarhane</string>
 	<string name="type.amenity.charging_station">Şarj İstasyonu</string>
 	<string name="type.amenity.charging_station.bicycle">Bisiklet Şarj İstasyonu</string>
-	<string name="type.amenity.charging_station.motorcar">Otomobil Şarj İstasyonu</string>
+	<string name="type.amenity.charging_station.motorcar">Araç Şarj İstasyonu</string>
 	<string name="type.amenity.childcare">Kreş</string>
 	<string name="type.amenity.cinema">Sinema</string>
 	<string name="type.leisure.bowling_alley">Bowling pisti</string>
@@ -795,7 +795,7 @@
 	<string name="type.amenity.doctors">Doktor</string>
 	<string name="type.amenity.drinking_water">İçme Suyu</string>
 	<string name="type.amenity.driving_school">Sürücü Kursu</string>
-	<string name="type.amenity.money_transfer">Para transferi</string>
+	<string name="type.amenity.money_transfer">Para Aktarımı</string>
 	<string name="type.amenity.music_school">Müzik Okulu</string>
 	<string name="type.amenity.language_school">Dil Okulu</string>
 	<string name="type.office.diplomatic">Büyükelçilik</string>
@@ -815,7 +815,7 @@
 	<string name="type.amenity.internet_cafe">İnternet Kafe</string>
 	<string name="type.amenity.kindergarten">Anaokulu</string>
 	<string name="type.amenity.library">Kütüphane</string>
-	<string name="type.amenity.loading_dock">Yükleme alanı</string>
+	<string name="type.amenity.loading_dock">Yükleme Alanı</string>
 	<string name="type.amenity.marketplace">Pazaryeri</string>
 	<string name="type.amenity.motorcycle_parking">Motosiklet Parkı</string>
 	<string name="type.amenity.nightclub">Gece Kulübü</string>
@@ -954,12 +954,12 @@
 	<string name="type.craft.handicraft">El İşi</string>
 	<!-- Heating, Ventilation, and Air Conditioning -->
 	<string name="type.craft.hvac">Klimacı</string>
-	<string name="type.craft.key_cutter">Anahtar kesme</string>
+	<string name="type.craft.key_cutter">Anahtar Kopyalama</string>
 	<string name="type.craft.locksmith">Çilingir</string>
 	<string name="type.craft.metal_construction">Dökümcü</string>
 	<string name="type.craft.painter">Boyacı</string>
 	<string name="type.craft.photographer">Fotoğraf Stüdyosu</string>
-	<string name="type.shop.camera">Kamera Dükkanı</string>
+	<string name="type.shop.camera">Kamera Mağazası</string>
 	<string name="type.craft.plumber">Tesisatçı</string>
 	<string name="type.craft.sawmill">Kereste Fabrikası</string>
 	<string name="type.craft.shoemaker">Ayakkabı Tamircisi</string>
@@ -1456,21 +1456,21 @@
 	<string name="type.place.village">Köy</string>
 	<string name="type.power">Enerji</string>
 	<string name="type.power.generator">Jeneratör</string>
-	<string name="type.power.generator.solar">Güneş jeneratörü</string>
-	<string name="type.power.generator.wind">Rüzgar jeneratörü</string>
-	<string name="type.power.generator.gas">Gaz türbini santrali</string>
-	<string name="type.power.generator.hydro">Hidroelektrik santral</string>
+	<string name="type.power.generator.solar">Güneş Paneli</string>
+	<string name="type.power.generator.wind">Rüzgar Türbini</string>
+	<string name="type.power.generator.gas">Gaz Türbini Santrali</string>
+	<string name="type.power.generator.hydro">Hidroelektrik Santrali</string>
 	<string name="type.power.line">Elektrik Hattı</string>
 	<string name="type.power.line.underground">Yeraltı Elektrik Hattı</string>
 	<string name="type.power.minor_line">Küçük Elektrik Hattı</string>
-	<string name="type.power.plant">Enerji santrali</string>
-	<string name="type.power.plant.coal">Kömür santrali</string>
-	<string name="type.power.plant.gas">Gaz türbini santrali</string>
-	<string name="type.power.plant.hydro">Hidroelektrik santral</string>
-	<string name="type.power.plant.solar">Güneş enerjili elektrik santrali</string>
-	<string name="type.power.plant.wind">Rüzgar santrali</string>
-	<string name="type.power.pole">Elektrik Kulesi</string>
-	<string name="type.power.station">Elektrik İstasyonu</string>
+	<string name="type.power.plant">Elektrik Santrali</string>
+	<string name="type.power.plant.coal">Kömür Santrali</string>
+	<string name="type.power.plant.gas">Gaz Türbini Santrali</string>
+	<string name="type.power.plant.hydro">Hidroelektrik Santrali</string>
+	<string name="type.power.plant.solar">Güneş Enerjisi Santrali</string>
+	<string name="type.power.plant.wind">Rüzgar Santrali</string>
+	<string name="type.power.pole">Elektrik Direği</string>
+	<string name="type.power.station">Elektrik Santrali</string>
 	<string name="type.power.substation">Trafo</string>
 	<string name="type.power.tower">Elektrik Kulesi</string>
 	<string name="type.public_transport">Toplu Taşıma</string>
@@ -1751,20 +1751,20 @@
 	<string name="type.shop">Mağaza</string>
 	<string name="type.shop.alcohol">İçki dükkanı</string>
 	<string name="type.shop.bakery">Fırın</string>
-	<string name="type.shop.bathroom_furnishing">Banyo Mobilyaları</string>
+	<string name="type.shop.bathroom_furnishing">Banyo Mobilya Mağazası</string>
 	<string name="type.shop.beauty">Güzellik Salonu</string>
 	<string name="type.shop.beverages">İçecekler</string>
 	<string name="type.shop.bicycle">Bisikletçi</string>
 	<string name="type.shop.bookmaker">Bahisçi</string>
 	<string name="type.shop.books">Kitapçı</string>
 	<string name="type.shop.butcher">Kasap</string>
-	<string name="type.shop.cannabis">Kenevir dükkanı</string>
+	<string name="type.shop.cannabis">Kenevir Mağazası</string>
 	<string name="type.shop.car">Otomobil Mağazası</string>
 	<string name="type.shop.car_parts">Araba Parçaları</string>
 	<string name="type.shop.car_repair">Oto Tamir</string>
 	<string name="type.shop.car_repair.tyres">Lastik Tamiri</string>
 	<string name="type.shop.caravan">Karavan Bayiliği</string>
-	<string name="type.shop.carpet">Halılar</string>
+	<string name="type.shop.carpet">Halıcı</string>
 	<string name="type.shop.chemist">Temizlik Ürünleri Mağazası</string>
 	<string name="type.shop.chocolate">Mağaza</string>
 	<string name="type.shop.clothes">Giyim Mağazası</string>
@@ -1774,7 +1774,7 @@
 	<string name="type.shop.convenience">Bakkal</string>
 	<string name="type.shop.copyshop">Kopyalama Merkezi</string>
 	<string name="type.shop.cosmetics">Bakım ürünleri</string>
-	<string name="type.shop.curtain">Perdeler</string>
+	<string name="type.shop.curtain">Perdeci</string>
 	<string name="type.shop.deli">Şarküteri Dükkanı</string>
 	<string name="type.shop.department_store">Büyük Mağaza</string>
 	<string name="type.shop.doityourself">Hırdavatçı</string>
@@ -1788,15 +1788,15 @@
 	<string name="type.shop.funeral_directors">Cenaze Levazımcısı</string>
 	<string name="type.shop.furniture">Mobilya Mağazası</string>
 	<string name="type.shop.garden_centre">Bahçe Mağazası</string>
-	<string name="type.shop.gas">Gaz deposu</string>
+	<string name="type.shop.gas">Gaz İstasyonu</string>
 	<string name="type.shop.gift">Hediyelik Eşya Mağazası</string>
 	<string name="type.shop.greengrocer">Manav</string>
 	<string name="type.shop.grocery">Market</string>
 	<string name="type.shop.hairdresser">Kuaför</string>
 	<string name="type.shop.hardware">Donanım mağazası</string>
 	<string name="type.shop.health_food">Sağlık Gıda Mağazası</string>
-	<string name="type.shop.herbalist">Şifalı bitkiler mağazası</string>
-	<string name="type.shop.hifi">HiFi Ses</string>
+	<string name="type.shop.herbalist">Aktar</string>
+	<string name="type.shop.hifi">Plakçı</string>
 	<string name="type.shop.houseware">Ev Eşyaları Dükkanı</string>
 	<string name="type.shop.jewelry">Kuyumcu</string>
 	<string name="type.shop.kiosk">Büfe</string>
@@ -1807,17 +1807,17 @@
 	<string name="type.shop.mobile_phone">Cep Telefonu Mağazası</string>
 	<string name="type.shop.money_lender">Mağaza</string>
 	<string name="type.shop.motorcycle">Motosiklet Dükkanı</string>
-	<string name="type.shop.motorcycle_repair">Motosiklet Tamiri</string>
+	<string name="type.shop.motorcycle_repair">Motosiklet Tamircisi</string>
 	<string name="type.shop.music">Mağaza</string>
 	<string name="type.shop.musical_instrument">Mağaza</string>
 	<string name="type.shop.newsagent">Gazete Standı</string>
 	<string name="type.shop.optician">Gözlükçü</string>
 	<string name="type.shop.outdoor">Dış Mekan Ekipmanları</string>
-	<string name="type.shop.outpost">Alım noktası</string>
+	<string name="type.shop.outpost">Alım Noktası</string>
 	<string name="type.shop.pastry">Hamur işi</string>
 	<string name="type.shop.pawnbroker">Tefeci</string>
 	<string name="type.shop.pet">Evcil Hayvan Mağazası</string>
-	<string name="type.shop.pet_grooming">Evcil Hayvan Bakımı</string>
+	<string name="type.shop.pet_grooming">Evcil Hayvan Bakıcısı</string>
 	<string name="type.shop.photo">Fotoğrafçı</string>
 	<string name="type.shop.seafood">Deniz Ürünleri Mağazası</string>
 	<string name="type.shop.second_hand">İkinci El Mağazası</string>
@@ -1835,14 +1835,14 @@
 	<string name="type.shop.video">Video Mağazası</string>
 	<string name="type.shop.video_games">Video Oyunları Mağazası</string>
 	<string name="type.shop.wine">Şarap Mağazası</string>
-	<string name="type.shop.agrarian">Tarım dükkanı</string>
+	<string name="type.shop.agrarian">Zirai Ürünler Mağazası</string>
 	<string name="type.shop.antiques">Antikalar</string>
-	<string name="type.shop.appliance">Beyaz eşya dükkanı</string>
+	<string name="type.shop.appliance">Beyaz Eşya Mağazası</string>
 	<!-- maybe change to Art Gallery for en-US when supported -->
 	<string name="type.shop.art">Sanat Mağazası</string>
 	<string name="type.shop.baby_goods">Çocuk mağazası</string>
 	<string name="type.shop.bag">Çanta Mağazası</string>
-	<string name="type.shop.bed">Yatak dükkanı</string>
+	<string name="type.shop.bed">Yatak Mağazası</string>
 	<string name="type.shop.boutique">Butik</string>
 	<string name="type.shop.charity">Hayır Dükkanı</string>
 	<string name="type.shop.cheese">Peynir Dükkanı</string>
@@ -1934,7 +1934,7 @@
 	<string name="type.waterway">Su Yolu</string>
 	<string name="type.waterway.canal">Kanal</string>
 	<string name="type.waterway.canal.tunnel">Kanal</string>
-	<string name="type.waterway.fish_pass">Balık merdiveni</string>
+	<string name="type.waterway.fish_pass">Balık Geçidi</string>
 	<string name="type.waterway.dam">Baraj</string>
 	<string name="type.waterway.ditch">Hendek</string>
 	<string name="type.waterway.ditch.tunnel">Hendek</string>

--- a/android/res/values-uk/strings.xml
+++ b/android/res/values-uk/strings.xml
@@ -493,12 +493,12 @@
 	<string name="current_location_unknown_message">Місцезнаходження не знайдено. Можливо, ви знаходитесь у приміщенні або тунелі.</string>
 	<string name="current_location_unknown_continue_button">Продовжити</string>
 	<string name="current_location_unknown_stop_button">Зупинити</string>
-	<string name="meter">м</string>
-	<string name="kilometer">км</string>
+	<string name="m">м</string>
+	<string name="km">км</string>
 	<string name="kilometers_per_hour">км/год</string>
-	<string name="mile">ми</string>
+	<string name="mi">ми</string>
 	<!-- A unit of measure -->
-	<string name="foot">фут</string>
+	<string name="ft">фут</string>
 	<string name="miles_per_hour">ми/год</string>
 	<string name="hour">год</string>
 	<string name="minute">хв</string>

--- a/android/res/values-vi/strings.xml
+++ b/android/res/values-vi/strings.xml
@@ -472,12 +472,12 @@
 	<string name="current_location_unknown_message">Chưa biết địa điểm hiện tại. Có thể bạn đang ở trong một tòa nhà hoặc đường hầm.</string>
 	<string name="current_location_unknown_continue_button">Tiếp tục</string>
 	<string name="current_location_unknown_stop_button">Dừng</string>
-	<string name="meter">m</string>
-	<string name="kilometer">km</string>
+	<string name="m">m</string>
+	<string name="km">km</string>
 	<string name="kilometers_per_hour">km/giờ</string>
-	<string name="mile">dặm</string>
+	<string name="mi">dặm</string>
 	<!-- A unit of measure -->
-	<string name="foot">ft</string>
+	<string name="ft">ft</string>
 	<string name="miles_per_hour">mph</string>
 	<string name="hour">giờ</string>
 	<string name="minute">phút</string>

--- a/android/res/values-zh-rTW/strings.xml
+++ b/android/res/values-zh-rTW/strings.xml
@@ -486,12 +486,12 @@
 	<string name="current_location_unknown_message">目前位置未知，可能您在建築物內或隧道內。</string>
 	<string name="current_location_unknown_continue_button">繼續</string>
 	<string name="current_location_unknown_stop_button">停止</string>
-	<string name="meter">公尺</string>
-	<string name="kilometer">公里</string>
+	<string name="m">公尺</string>
+	<string name="km">公里</string>
 	<string name="kilometers_per_hour">公里每小時</string>
-	<string name="mile">英哩</string>
+	<string name="mi">英哩</string>
 	<!-- A unit of measure -->
-	<string name="foot">英尺</string>
+	<string name="ft">英尺</string>
 	<string name="miles_per_hour">英哩每小時</string>
 	<string name="hour">小時</string>
 	<string name="minute">分鐘</string>

--- a/android/res/values-zh/strings.xml
+++ b/android/res/values-zh/strings.xml
@@ -482,12 +482,12 @@
 	<string name="current_location_unknown_message">当前位置未知，可能您在建筑内或隧道内。</string>
 	<string name="current_location_unknown_continue_button">继续</string>
 	<string name="current_location_unknown_stop_button">停止</string>
-	<string name="meter">米</string>
-	<string name="kilometer">公里</string>
+	<string name="m">米</string>
+	<string name="km">公里</string>
 	<string name="kilometers_per_hour">公里每小时</string>
-	<string name="mile">英里</string>
+	<string name="mi">英里</string>
 	<!-- A unit of measure -->
-	<string name="foot">英尺</string>
+	<string name="ft">英尺</string>
 	<string name="miles_per_hour">英里每小时</string>
 	<string name="hour">小時</string>
 	<string name="minute">分鐘</string>

--- a/android/res/values/strings.xml
+++ b/android/res/values/strings.xml
@@ -523,12 +523,12 @@
 	<string name="current_location_unknown_message">Current location is unknown. You may be in a building or tunnel.</string>
 	<string name="current_location_unknown_continue_button">Continue</string>
 	<string name="current_location_unknown_stop_button">Stop</string>
-	<string name="meter">m</string>
-	<string name="kilometer">km</string>
+	<string name="m">m</string>
+	<string name="km">km</string>
 	<string name="kilometers_per_hour">km/h</string>
-	<string name="mile">mi</string>
+	<string name="mi">mi</string>
 	<!-- A unit of measure -->
-	<string name="foot">ft</string>
+	<string name="ft">ft</string>
 	<string name="miles_per_hour">mph</string>
 	<string name="hour">h</string>
 	<string name="minute">min</string>

--- a/android/src/app/organicmaps/ChartController.java
+++ b/android/src/app/organicmaps/ChartController.java
@@ -182,8 +182,8 @@ public class ChartController implements OnChartValueSelectedListener, Initializa
     mChart.setData(data);
     mChart.animateX(CHART_ANIMATION_DURATION);
 
-    mMinAltitude.setText(Framework.nativeFormatAltitude(info.getMinAltitude()));
-    mMaxAltitude.setText(Framework.nativeFormatAltitude(info.getMaxAltitude()));
+    mMinAltitude.setText(Framework.nativeFormatAltitude(info.getMinAltitude()).toString(mContext));
+    mMaxAltitude.setText(Framework.nativeFormatAltitude(info.getMaxAltitude()).toString(mContext));
 
     highlightActivePointManually();
   }

--- a/android/src/app/organicmaps/Framework.java
+++ b/android/src/app/organicmaps/Framework.java
@@ -18,6 +18,7 @@ import app.organicmaps.routing.RoutePointInfo;
 import app.organicmaps.routing.RoutingInfo;
 import app.organicmaps.routing.TransitRouteInfo;
 import app.organicmaps.settings.SettingsPrefsFragment;
+import app.organicmaps.util.Distance;
 import app.organicmaps.widget.placepage.PlacePageData;
 import app.organicmaps.util.Constants;
 
@@ -171,7 +172,7 @@ public class Framework
 
   public static native String nativeFormatLatLon(double lat, double lon, int coordFormat);
 
-  public static native String nativeFormatAltitude(double alt);
+  public static native Distance nativeFormatAltitude(double alt);
 
   public static native String nativeFormatSpeed(double speed);
 

--- a/android/src/app/organicmaps/bookmarks/Holders.java
+++ b/android/src/app/organicmaps/bookmarks/Holders.java
@@ -367,7 +367,7 @@ public class Holders
       final Location loc = LocationHelper.INSTANCE.getSavedLocation();
 
       String distanceValue = loc == null ? "" : bookmark.getDistance(loc.getLatitude(),
-                                                                     loc.getLongitude(), 0.0);
+                                                                     loc.getLongitude(), 0.0).toString(mDistance.getContext());
       String separator = "";
       if (!distanceValue.isEmpty() && !bookmark.getFeatureType().isEmpty())
         separator = " • ";
@@ -412,7 +412,7 @@ public class Holders
       mDistance.setText(new StringBuilder().append(mDistance.getContext()
                                                             .getString(R.string.length))
                                            .append(" ")
-                                           .append(track.getLengthString())
+                                           .append(track.getLength().toString(mDistance.getContext()))
                                            .toString());
       Drawable circle = Graphics.drawCircle(track.getColor(), R.dimen.track_circle_size,
                                             mIcon.getContext().getResources());

--- a/android/src/app/organicmaps/bookmarks/data/BookmarkInfo.java
+++ b/android/src/app/organicmaps/bookmarks/data/BookmarkInfo.java
@@ -4,6 +4,7 @@ import androidx.annotation.IntRange;
 import androidx.annotation.NonNull;
 
 import app.organicmaps.Framework;
+import app.organicmaps.util.Distance;
 import app.organicmaps.util.GeoUtils;
 
 public class BookmarkInfo
@@ -71,7 +72,7 @@ public class BookmarkInfo
   }
 
   @NonNull
-  public String getDistance(double latitude, double longitude, double v)
+  public Distance getDistance(double latitude, double longitude, double v)
   {
     return getDistanceAndAzimuth(latitude, longitude, v).getDistance();
   }

--- a/android/src/app/organicmaps/bookmarks/data/DistanceAndAzimut.java
+++ b/android/src/app/organicmaps/bookmarks/data/DistanceAndAzimut.java
@@ -1,11 +1,13 @@
 package app.organicmaps.bookmarks.data;
 
+import app.organicmaps.util.Distance;
+
 public class DistanceAndAzimut
 {
-  private final String mDistance;
+  private final Distance mDistance;
   private final double mAzimuth;
 
-  public String getDistance()
+  public Distance getDistance()
   {
     return mDistance;
   }
@@ -15,7 +17,7 @@ public class DistanceAndAzimut
     return mAzimuth;
   }
 
-  public DistanceAndAzimut(String distance, double azimuth)
+  public DistanceAndAzimut(Distance distance, double azimuth)
   {
     mDistance = distance;
     mAzimuth = azimuth;

--- a/android/src/app/organicmaps/bookmarks/data/Track.java
+++ b/android/src/app/organicmaps/bookmarks/data/Track.java
@@ -1,25 +1,27 @@
 package app.organicmaps.bookmarks.data;
 
+import app.organicmaps.util.Distance;
+
 public class Track
 {
   private final long mTrackId;
   private final long mCategoryId;
   private final String mName;
-  private final String mLengthString;
+  private final Distance mLength;
   private final int mColor;
 
-  Track(long trackId, long categoryId, String name, String lengthString, int color)
+  Track(long trackId, long categoryId, String name, Distance length, int color)
   {
     mTrackId = trackId;
     mCategoryId = categoryId;
     mName = name;
-    mLengthString = lengthString;
+    mLength = length;
     mColor = color;
   }
 
   public String getName() { return mName; }
 
-  public String getLengthString() { return mLengthString;}
+  public Distance getLength() { return mLength;}
 
   public int getColor() { return mColor; }
 

--- a/android/src/app/organicmaps/routing/NavigationController.java
+++ b/android/src/app/organicmaps/routing/NavigationController.java
@@ -183,11 +183,7 @@ public class NavigationController implements Application.ActivityLifecycleCallba
   {
     if (info.distToTurn.isValid())
     {
-      SpannableStringBuilder nextTurnDistance = Utils.formatUnitsText(mFrame.getContext(),
-                                                                      R.dimen.text_size_nav_number,
-                                                                      R.dimen.text_size_nav_dimension,
-                                                                      info.distToTurn.mDistanceStr,
-                                                                      info.distToTurn.getUnitsStr(mFrame.getContext()));
+      SpannableStringBuilder nextTurnDistance = Utils.formatDistance(mFrame.getContext(), info.distToTurn);
       mNextTurnDistance.setText(nextTurnDistance);
       info.carDirection.setTurnDrawable(mNextTurnImage);
     }
@@ -215,9 +211,7 @@ public class NavigationController implements Application.ActivityLifecycleCallba
 
   private void updatePedestrian(RoutingInfo info)
   {
-    mNextTurnDistance.setText(
-        Utils.formatUnitsText(mFrame.getContext(), R.dimen.text_size_nav_number,
-                              R.dimen.text_size_nav_dimension, info.distToTurn.mDistanceStr, info.distToTurn.getUnitsStr(mFrame.getContext())));
+    mNextTurnDistance.setText(Utils.formatDistance(mFrame.getContext(), info.distToTurn));
 
     info.pedestrianTurnDirection.setTurnDrawable(mNextTurnImage);
   }

--- a/android/src/app/organicmaps/routing/NavigationController.java
+++ b/android/src/app/organicmaps/routing/NavigationController.java
@@ -181,13 +181,13 @@ public class NavigationController implements Application.ActivityLifecycleCallba
 
   private void updateVehicle(RoutingInfo info)
   {
-    if (!TextUtils.isEmpty(info.distToTurn))
+    if (info.distToTurn.isValid())
     {
       SpannableStringBuilder nextTurnDistance = Utils.formatUnitsText(mFrame.getContext(),
                                                                       R.dimen.text_size_nav_number,
                                                                       R.dimen.text_size_nav_dimension,
-                                                                      info.distToTurn,
-                                                                      info.turnUnits);
+                                                                      info.distToTurn.mDistanceStr,
+                                                                      info.distToTurn.getUnitsStr(mFrame.getContext()));
       mNextTurnDistance.setText(nextTurnDistance);
       info.carDirection.setTurnDrawable(mNextTurnImage);
     }
@@ -217,7 +217,7 @@ public class NavigationController implements Application.ActivityLifecycleCallba
   {
     mNextTurnDistance.setText(
         Utils.formatUnitsText(mFrame.getContext(), R.dimen.text_size_nav_number,
-                              R.dimen.text_size_nav_dimension, info.distToTurn, info.turnUnits));
+                              R.dimen.text_size_nav_dimension, info.distToTurn.mDistanceStr, info.distToTurn.getUnitsStr(mFrame.getContext())));
 
     info.pedestrianTurnDirection.setTurnDrawable(mNextTurnImage);
   }

--- a/android/src/app/organicmaps/routing/NavigationController.java
+++ b/android/src/app/organicmaps/routing/NavigationController.java
@@ -181,12 +181,9 @@ public class NavigationController implements Application.ActivityLifecycleCallba
 
   private void updateVehicle(RoutingInfo info)
   {
-    if (info.distToTurn.isValid())
-    {
-      SpannableStringBuilder nextTurnDistance = Utils.formatDistance(mFrame.getContext(), info.distToTurn);
-      mNextTurnDistance.setText(nextTurnDistance);
-      info.carDirection.setTurnDrawable(mNextTurnImage);
-    }
+    SpannableStringBuilder nextTurnDistance = Utils.formatDistance(mFrame.getContext(), info.distToTurn);
+    mNextTurnDistance.setText(nextTurnDistance);
+    info.carDirection.setTurnDrawable(mNextTurnImage);
 
     if (RoutingInfo.CarDirection.isRoundAbout(info.carDirection))
       UiUtils.setTextAndShow(mCircleExit, String.valueOf(info.exitNum));

--- a/android/src/app/organicmaps/routing/NavigationService.java
+++ b/android/src/app/organicmaps/routing/NavigationService.java
@@ -234,7 +234,7 @@ public class NavigationService extends Service
           .append(": ")
           .append(Utils.calculateFinishTime(routingInfo.totalTimeInSeconds));
       mRemoteViews.setImageViewResource(R.id.navigation_icon, routingInfo.carDirection.getTurnRes());
-      mRemoteViews.setTextViewText(R.id.navigation_distance_text, routingInfo.distToTurn + " " + routingInfo.turnUnits);
+      mRemoteViews.setTextViewText(R.id.navigation_distance_text, routingInfo.distToTurn.toString(getApplicationContext()));
     }
     mRemoteViews.setTextViewText(R.id.navigation_secondary_text, stringBuilderNavigationSecondaryText
         .toString());

--- a/android/src/app/organicmaps/routing/RoutingBottomMenuController.java
+++ b/android/src/app/organicmaps/routing/RoutingBottomMenuController.java
@@ -307,7 +307,7 @@ final class RoutingBottomMenuController implements View.OnClickListener
     String dot = "\u00A0• ";
     initDotBuilderSequence(context, dot, builder);
 
-    String dist = routingInfo.distToTarget + "\u00A0" + routingInfo.targetUnits;
+    String dist = routingInfo.distToTarget.mDistanceStr + "\u00A0" + routingInfo.distToTarget.getUnitsStr(context);
     initDistanceBuilderSequence(context, dist, builder);
 
     return builder;

--- a/android/src/app/organicmaps/routing/RoutingBottomMenuController.java
+++ b/android/src/app/organicmaps/routing/RoutingBottomMenuController.java
@@ -264,7 +264,7 @@ final class RoutingBottomMenuController implements View.OnClickListener
     {
       mAltitudeChart.setImageBitmap(bm);
       UiUtils.show(mAltitudeChart);
-      final String unit = limits.isMetricUnits ? mAltitudeDifference.getResources().getString(R.string.meter) : mAltitudeDifference.getResources().getString(R.string.foot);
+      final String unit = limits.isMetricUnits ? mAltitudeDifference.getResources().getString(R.string.m) : mAltitudeDifference.getResources().getString(R.string.ft);
       mAltitudeDifference.setText(String.format(Locale.getDefault(), "↗ %d %s ↘ %d %s",
                                                 limits.totalAscent, unit,
                                                 limits.totalDescent, unit));

--- a/android/src/app/organicmaps/routing/RoutingBottomMenuController.java
+++ b/android/src/app/organicmaps/routing/RoutingBottomMenuController.java
@@ -307,8 +307,7 @@ final class RoutingBottomMenuController implements View.OnClickListener
     String dot = "\u00A0• ";
     initDotBuilderSequence(context, dot, builder);
 
-    String dist = routingInfo.distToTarget.mDistanceStr + "\u00A0" + routingInfo.distToTarget.getUnitsStr(context);
-    initDistanceBuilderSequence(context, dist, builder);
+    initDistanceBuilderSequence(context, routingInfo.distToTarget.toString(context), builder);
 
     return builder;
   }

--- a/android/src/app/organicmaps/routing/RoutingController.java
+++ b/android/src/app/organicmaps/routing/RoutingController.java
@@ -973,10 +973,8 @@ public class RoutingController implements Initializable<Void>
     long hours = TimeUnit.SECONDS.toHours(seconds);
     String min = context.getString(R.string.minute);
     String hour = context.getString(R.string.hour);
-    SpannableStringBuilder displayedH = Utils.formatTime(context, textSize, unitsSize,
-                                                         String.valueOf(hours), hour);
-    SpannableStringBuilder displayedM = Utils.formatTime(context, textSize, unitsSize,
-                                                         String.valueOf(minutes), min);
+    SpannableStringBuilder displayedH = Utils.formatTime(context, textSize, unitsSize, String.valueOf(hours), hour);
+    SpannableStringBuilder displayedM = Utils.formatTime(context, textSize, unitsSize, String.valueOf(minutes), min);
     return hours == 0 ? displayedM : TextUtils.concat(displayedH + "\u00A0", displayedM);
   }
 

--- a/android/src/app/organicmaps/routing/RoutingController.java
+++ b/android/src/app/organicmaps/routing/RoutingController.java
@@ -973,10 +973,10 @@ public class RoutingController implements Initializable<Void>
     long hours = TimeUnit.SECONDS.toHours(seconds);
     String min = context.getString(R.string.minute);
     String hour = context.getString(R.string.hour);
-    SpannableStringBuilder displayedH = Utils.formatUnitsText(context, textSize, unitsSize,
-                                                              String.valueOf(hours), hour);
-    SpannableStringBuilder displayedM = Utils.formatUnitsText(context, textSize, unitsSize,
-                                                              String.valueOf(minutes), min);
+    SpannableStringBuilder displayedH = Utils.formatTime(context, textSize, unitsSize,
+                                                         String.valueOf(hours), hour);
+    SpannableStringBuilder displayedM = Utils.formatTime(context, textSize, unitsSize,
+                                                         String.valueOf(minutes), min);
     return hours == 0 ? displayedM : TextUtils.concat(displayedH + "\u00A0", displayedM);
   }
 

--- a/android/src/app/organicmaps/routing/RoutingInfo.java
+++ b/android/src/app/organicmaps/routing/RoutingInfo.java
@@ -6,15 +6,14 @@ import androidx.annotation.DrawableRes;
 import androidx.annotation.NonNull;
 
 import app.organicmaps.R;
+import app.organicmaps.util.Distance;
 
 public class RoutingInfo
 {
   // Target (end point of route).
-  public final String distToTarget;
-  public final String targetUnits;
+  public final Distance distToTarget;
   // Next turn.
-  public final String distToTurn;
-  public final String turnUnits;
+  public final Distance distToTurn;
 
   public final int totalTimeInSeconds;
   // Current street name.
@@ -133,15 +132,13 @@ public class RoutingInfo
     }
   }
 
-  public RoutingInfo(String distToTarget, String units, String distTurn, String turnSuffix, String currentStreet, String nextStreet, double completionPercent,
+  public RoutingInfo(Distance distToTarget, Distance distToTurn, String currentStreet, String nextStreet, double completionPercent,
                      int vehicleTurnOrdinal, int vehicleNextTurnOrdinal, int pedestrianTurnOrdinal, int exitNum,
                      int totalTime, SingleLaneInfo[] lanes, boolean speedLimitExceeded,
                      boolean shouldPlayWarningSignal)
   {
     this.distToTarget = distToTarget;
-    this.targetUnits = units;
-    this.turnUnits = turnSuffix;
-    this.distToTurn = distTurn;
+    this.distToTurn = distToTurn;
     this.currentStreet = currentStreet;
     this.nextStreet = nextStreet;
     this.totalTimeInSeconds = totalTime;

--- a/android/src/app/organicmaps/search/SearchAdapter.java
+++ b/android/src/app/organicmaps/search/SearchAdapter.java
@@ -139,7 +139,7 @@ class SearchAdapter extends RecyclerView.Adapter<SearchAdapter.SearchDataViewHol
       formatOpeningHours(mResult);
       UiUtils.setTextAndHideIfEmpty(mDescription, mResult.getFormattedDescription(mFrame.getContext()));
       UiUtils.setTextAndHideIfEmpty(mRegion, mResult.description.region);
-      UiUtils.setTextAndHideIfEmpty(mDistance, mResult.description.distance);
+      UiUtils.setTextAndHideIfEmpty(mDistance, mResult.description.distance.toString(mFrame.getContext()));
     }
 
     private void formatOpeningHours(SearchResult result)

--- a/android/src/app/organicmaps/search/SearchResult.java
+++ b/android/src/app/organicmaps/search/SearchResult.java
@@ -11,6 +11,7 @@ import android.text.style.StyleSpan;
 import androidx.annotation.NonNull;
 
 import app.organicmaps.bookmarks.data.FeatureId;
+import app.organicmaps.util.Distance;
 import app.organicmaps.util.Utils;
 
 /**
@@ -36,7 +37,7 @@ public class SearchResult implements PopularityProvider
     public final FeatureId featureId;
     public final String featureType;
     public final String region;
-    public final String distance;
+    public final Distance distance;
     public final String cuisine;
     public final String brand;
     public final String airportIata;
@@ -46,7 +47,7 @@ public class SearchResult implements PopularityProvider
     public final int minutesUntilClosed;
     public final boolean hasPopularityHigherPriority;
 
-    public Description(FeatureId featureId, String featureType, String region, String distance,
+    public Description(FeatureId featureId, String featureType, String region, Distance distance,
                        String cuisine, String brand, String airportIata, String roadShields,
                        int openNow, int minutesUntilOpen, int minutesUntilClosed,
                        boolean hasPopularityHigherPriority)

--- a/android/src/app/organicmaps/util/Distance.java
+++ b/android/src/app/organicmaps/util/Distance.java
@@ -7,8 +7,6 @@ import androidx.annotation.StringRes;
 
 import app.organicmaps.R;
 
-import java.util.Objects;
-
 public final class Distance
 {
   /**
@@ -31,6 +29,8 @@ public final class Distance
     }
   }
 
+  private static final char NON_BREAKING_SPACE = '\u00A0';
+
   public final double mDistance;
   @NonNull
   public final String mDistanceStr;
@@ -45,21 +45,31 @@ public final class Distance
 
   public boolean isValid()
   {
-    final double EPS = 1e-5;
-    return mDistance > EPS;
+    return mDistance >= 0.0;
   }
 
   @NonNull
   public String getUnitsStr(@NonNull final Context context)
   {
-    Objects.requireNonNull(context);
     return context.getString(mUnits.mStringRes);
   }
 
   @NonNull
   public String toString(@NonNull final Context context)
   {
-    final char nonBreakingSpace = '\u00A0';
-    return mDistanceStr + nonBreakingSpace + getUnitsStr(context);
+    if (!isValid())
+      return "";
+
+    return mDistanceStr + NON_BREAKING_SPACE + getUnitsStr(context);
+  }
+
+  @NonNull
+  @Override
+  public String toString()
+  {
+    if (!isValid())
+      return "";
+
+    return mDistanceStr + NON_BREAKING_SPACE + mUnits.toString();
   }
 }

--- a/android/src/app/organicmaps/util/Distance.java
+++ b/android/src/app/organicmaps/util/Distance.java
@@ -1,0 +1,59 @@
+package app.organicmaps.util;
+
+import android.content.Context;
+
+import androidx.annotation.NonNull;
+import androidx.annotation.StringRes;
+
+import app.organicmaps.R;
+
+import java.util.Objects;
+
+public class Distance
+{
+  public enum Units
+  {
+    Meters(R.string.meter),
+    Kilometers(R.string.kilometer),
+    Feet(R.string.foot),
+    Miles(R.string.mile);
+
+    @StringRes
+    public final int mStringRes;
+
+    Units(@StringRes int stringRes)
+    {
+      mStringRes = stringRes;
+    }
+  }
+
+  public final double mDistance;
+  public final String mDistanceStr;
+  public final Units mUnits;
+
+  public Distance(double distance, String distanceStr, Units units)
+  {
+    mDistance = distance;
+    mDistanceStr = distanceStr;
+    mUnits = units;
+  }
+
+  public boolean isValid()
+  {
+    final double EPS = 1e-5;
+    return mDistance > EPS;
+  }
+
+  @NonNull
+  public String getUnitsStr(@NonNull final Context context)
+  {
+    Objects.requireNonNull(context);
+    return context.getString(mUnits.mStringRes);
+  }
+
+  @NonNull
+  public String toString(@NonNull final Context context)
+  {
+    return mDistanceStr + " " + getUnitsStr(context);
+  }
+}

--- a/android/src/app/organicmaps/util/Distance.java
+++ b/android/src/app/organicmaps/util/Distance.java
@@ -11,14 +11,14 @@ public final class Distance
 {
   /**
    * IMPORTANT : Order of enum values MUST BE the same
-   * with native LaneWay enum (see platform/distance.hpp for details).
+   * with native Distance::Units enum (see platform/distance.hpp for details).
    */
   public enum Units
   {
-    Meters(R.string.meter),
-    Kilometers(R.string.kilometer),
-    Feet(R.string.foot),
-    Miles(R.string.mile);
+    Meters(R.string.m),
+    Kilometers(R.string.km),
+    Feet(R.string.ft),
+    Miles(R.string.mi);
 
     @StringRes
     public final int mStringRes;
@@ -43,11 +43,6 @@ public final class Distance
     mUnits = Units.values()[unitsIndex];
   }
 
-  public boolean isValid()
-  {
-    return mDistance >= 0.0;
-  }
-
   @NonNull
   public String getUnitsStr(@NonNull final Context context)
   {
@@ -57,9 +52,6 @@ public final class Distance
   @NonNull
   public String toString(@NonNull final Context context)
   {
-    if (!isValid())
-      return "";
-
     return mDistanceStr + NON_BREAKING_SPACE + getUnitsStr(context);
   }
 
@@ -67,9 +59,6 @@ public final class Distance
   @Override
   public String toString()
   {
-    if (!isValid())
-      return "";
-
     return mDistanceStr + NON_BREAKING_SPACE + mUnits.toString();
   }
 }

--- a/android/src/app/organicmaps/util/Distance.java
+++ b/android/src/app/organicmaps/util/Distance.java
@@ -9,8 +9,12 @@ import app.organicmaps.R;
 
 import java.util.Objects;
 
-public class Distance
+public final class Distance
 {
+  /**
+   * IMPORTANT : Order of enum values MUST BE the same
+   * with native LaneWay enum (see platform/distance.hpp for details).
+   */
   public enum Units
   {
     Meters(R.string.meter),
@@ -28,14 +32,15 @@ public class Distance
   }
 
   public final double mDistance;
+  @NonNull
   public final String mDistanceStr;
   public final Units mUnits;
 
-  public Distance(double distance, String distanceStr, Units units)
+  public Distance(double distance, @NonNull String distanceStr, byte unitsIndex)
   {
     mDistance = distance;
     mDistanceStr = distanceStr;
-    mUnits = units;
+    mUnits = Units.values()[unitsIndex];
   }
 
   public boolean isValid()
@@ -54,6 +59,7 @@ public class Distance
   @NonNull
   public String toString(@NonNull final Context context)
   {
-    return mDistanceStr + " " + getUnitsStr(context);
+    final char nonBreakingSpace = '\u00A0';
+    return mDistanceStr + nonBreakingSpace + getUnitsStr(context);
   }
 }

--- a/android/src/app/organicmaps/util/StringUtils.java
+++ b/android/src/app/organicmaps/util/StringUtils.java
@@ -25,7 +25,7 @@ public class StringUtils
   public static native String[] nativeFilterContainsNormalized(String[] strings, String substr);
 
   public static native Pair<String, String> nativeFormatSpeedAndUnits(double metersPerSecond);
-  public static native String nativeFormatDistance(double meters);
+  public static native Distance nativeFormatDistance(double meters);
   @NonNull
   public static native Pair<String, String> nativeGetLocalizedDistanceUnits();
   @NonNull

--- a/android/src/app/organicmaps/util/StringUtils.java
+++ b/android/src/app/organicmaps/util/StringUtils.java
@@ -27,10 +27,6 @@ public class StringUtils
   public static native Pair<String, String> nativeFormatSpeedAndUnits(double metersPerSecond);
   public static native String nativeFormatDistance(double meters);
   @NonNull
-  public static native String nativeFormatDistanceWithLocalization(double meters,
-                                                                   @NonNull String high,
-                                                                   @NonNull String low);
-  @NonNull
   public static native Pair<String, String> nativeGetLocalizedDistanceUnits();
   @NonNull
   public static native Pair<String, String> nativeGetLocalizedAltitudeUnits();

--- a/android/src/app/organicmaps/util/Utils.java
+++ b/android/src/app/organicmaps/util/Utils.java
@@ -367,7 +367,7 @@ public class Utils
   @NonNull
   public static SpannableStringBuilder formatDistance(Context context, @NonNull Distance distance)
   {
-    final SpannableStringBuilder res = new SpannableStringBuilder(distance.mDistanceStr).append("\u00A0").append(distance.getUnitsStr(context));
+    final SpannableStringBuilder res = new SpannableStringBuilder(distance.toString(context));
     res.setSpan(
         new AbsoluteSizeSpan(UiUtils.dimen(context, R.dimen.text_size_nav_number), false),
         0, distance.mDistanceStr.length(), Spanned.SPAN_EXCLUSIVE_EXCLUSIVE);

--- a/android/src/app/organicmaps/util/Utils.java
+++ b/android/src/app/organicmaps/util/Utils.java
@@ -356,11 +356,24 @@ public class Utils
       NavUtils.navigateUpFromSameTask(activity);
   }
 
-  public static SpannableStringBuilder formatUnitsText(Context context, @DimenRes int size, @DimenRes int units, String dimension, String unitText)
+  public static SpannableStringBuilder formatTime(Context context, @DimenRes int size, @DimenRes int units, String dimension, String unitText)
   {
     final SpannableStringBuilder res = new SpannableStringBuilder(dimension).append("\u00A0").append(unitText);
     res.setSpan(new AbsoluteSizeSpan(UiUtils.dimen(context, size), false), 0, dimension.length(), Spanned.SPAN_EXCLUSIVE_EXCLUSIVE);
     res.setSpan(new AbsoluteSizeSpan(UiUtils.dimen(context, units), false), dimension.length(), res.length(), Spanned.SPAN_EXCLUSIVE_EXCLUSIVE);
+    return res;
+  }
+
+  @NonNull
+  public static SpannableStringBuilder formatDistance(Context context, @NonNull Distance distance)
+  {
+    final SpannableStringBuilder res = new SpannableStringBuilder(distance.mDistanceStr).append("\u00A0").append(distance.getUnitsStr(context));
+    res.setSpan(
+        new AbsoluteSizeSpan(UiUtils.dimen(context, R.dimen.text_size_nav_number), false),
+        0, distance.mDistanceStr.length(), Spanned.SPAN_EXCLUSIVE_EXCLUSIVE);
+    res.setSpan(
+        new AbsoluteSizeSpan(UiUtils.dimen(context, R.dimen.text_size_nav_dimension), false),
+        distance.mDistanceStr.length(), res.length(), Spanned.SPAN_EXCLUSIVE_EXCLUSIVE);
     return res;
   }
 

--- a/android/src/app/organicmaps/widget/menu/NavMenu.java
+++ b/android/src/app/organicmaps/widget/menu/NavMenu.java
@@ -228,8 +228,8 @@ public class NavMenu
   {
     updateSpeedView(info);
     updateTime(info.totalTimeInSeconds);
-    mDistanceValue.setText(info.distToTarget);
-    mDistanceUnits.setText(info.targetUnits);
+    mDistanceValue.setText(info.distToTarget.mDistanceStr);
+    mDistanceUnits.setText(info.distToTarget.getUnitsStr(mActivity.getApplicationContext()));
     mRouteProgress.setProgress((int) info.completionPercent);
   }
 

--- a/android/src/app/organicmaps/widget/placepage/AxisValueFormatter.java
+++ b/android/src/app/organicmaps/widget/placepage/AxisValueFormatter.java
@@ -5,12 +5,10 @@ import androidx.annotation.NonNull;
 import com.github.mikephil.charting.charts.BarLineChartBase;
 import com.github.mikephil.charting.formatter.DefaultValueFormatter;
 import app.organicmaps.Framework;
-import app.organicmaps.util.StringUtils;
 
 public class AxisValueFormatter extends DefaultValueFormatter
 {
   private static final int DEF_DIGITS = 1;
-  private static final int ONE_KM = 1000;
   @NonNull
   private final BarLineChartBase mChart;
 
@@ -23,9 +21,6 @@ public class AxisValueFormatter extends DefaultValueFormatter
   @Override
   public String getFormattedValue(float value)
   {
-    if (mChart.getVisibleXRange() <= ONE_KM)
-      return Framework.nativeFormatAltitude(value);
-
-    return StringUtils.nativeFormatDistance(value);
+    return Framework.nativeFormatAltitude(value).toString(mChart.getContext());
   }
 }

--- a/android/src/app/organicmaps/widget/placepage/DirectionFragment.java
+++ b/android/src/app/organicmaps/widget/placepage/DirectionFragment.java
@@ -119,7 +119,7 @@ public class DirectionFragment extends BaseMwmDialogFragment
       final DistanceAndAzimut distanceAndAzimuth =
           Framework.nativeGetDistanceAndAzimuthFromLatLon(mMapObject.getLat(), mMapObject.getLon(),
                                                           location.getLatitude(), location.getLongitude(), 0.0);
-      mTvDistance.setText(distanceAndAzimuth.getDistance());
+      mTvDistance.setText(distanceAndAzimuth.getDistance().toString(requireContext()));
     }
   }
 

--- a/android/src/app/organicmaps/widget/placepage/ElevationProfileViewRenderer.java
+++ b/android/src/app/organicmaps/widget/placepage/ElevationProfileViewRenderer.java
@@ -1,5 +1,6 @@
 package app.organicmaps.widget.placepage;
 
+import android.content.Context;
 import android.os.Bundle;
 import android.view.View;
 import android.widget.RelativeLayout;
@@ -15,7 +16,6 @@ import app.organicmaps.R;
 import app.organicmaps.bookmarks.data.ElevationInfo;
 import app.organicmaps.routing.RoutingController;
 import app.organicmaps.util.UiUtils;
-import app.organicmaps.util.Utils;
 
 import java.util.Objects;
 
@@ -64,14 +64,16 @@ public class ElevationProfileViewRenderer implements PlacePageViewRenderer<Place
   @Override
   public void render(@NonNull PlacePageData data)
   {
+    final Context context = mAscent.getContext();
+
     mElevationInfo = (ElevationInfo) data;
     mChartController.setData(mElevationInfo);
     mTitle.setText(mElevationInfo.getName());
     setDifficulty(mElevationInfo.getDifficulty());
-    mAscent.setText(formatDistance(mElevationInfo.getAscent()));
-    mDescent.setText(formatDistance(mElevationInfo.getDescent()));
-    mMaxAltitude.setText(formatDistance(mElevationInfo.getMaxAltitude()));
-    mMinAltitude.setText(formatDistance(mElevationInfo.getMinAltitude()));
+    mAscent.setText(formatDistance(context, mElevationInfo.getAscent()));
+    mDescent.setText(formatDistance(context, mElevationInfo.getDescent()));
+    mMaxAltitude.setText(formatDistance(context, mElevationInfo.getMaxAltitude()));
+    mMinAltitude.setText(formatDistance(context, mElevationInfo.getMinAltitude()));
     UiUtils.hideIf(mElevationInfo.getDuration() == 0, mTimeContainer);
     mTime.setText(RoutingController.formatRoutingTime(mTitle.getContext(),
                                                       (int) mElevationInfo.getDuration(),
@@ -79,9 +81,9 @@ public class ElevationProfileViewRenderer implements PlacePageViewRenderer<Place
   }
 
   @NonNull
-  private static String formatDistance(int distance)
+  private static String formatDistance(final Context context, int distance)
   {
-    return Framework.nativeFormatAltitude(distance);
+    return Framework.nativeFormatAltitude(distance).toString(context);
   }
 
   @Override

--- a/android/src/app/organicmaps/widget/placepage/FloatingMarkerView.java
+++ b/android/src/app/organicmaps/widget/placepage/FloatingMarkerView.java
@@ -184,8 +184,8 @@ public class FloatingMarkerView extends RelativeLayout implements IMarker
   private void updatePointValues(@NonNull Entry entry)
   {
     mDistanceTextView.setText(R.string.elevation_profile_distance);
-    mDistanceValueView.setText(StringUtils.nativeFormatDistance(entry.getX()));
-    mAltitudeView.setText(Framework.nativeFormatAltitude(entry.getY()));
+    mDistanceValueView.setText(StringUtils.nativeFormatDistance(entry.getX()).toString(mDistanceValueView.getContext()));
+    mAltitudeView.setText(Framework.nativeFormatAltitude(entry.getY()).toString(mAltitudeView.getContext()));
   }
 
   private void updateHorizontal(@NonNull Highlight highlight)

--- a/android/src/app/organicmaps/widget/placepage/PlacePageView.java
+++ b/android/src/app/organicmaps/widget/placepage/PlacePageView.java
@@ -50,6 +50,7 @@ import app.organicmaps.widget.placepage.sections.PlacePageWikipediaFragment;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
+import java.util.Objects;
 
 import static android.view.View.GONE;
 import static android.view.View.VISIBLE;
@@ -421,7 +422,7 @@ public class PlacePageView extends Fragment implements View.OnClickListener,
     {
       double altitude = l.getAltitude();
       builder.append(altitude >= 0 ? "▲" : "▼");
-      builder.append(Framework.nativeFormatAltitude(altitude));
+      builder.append(Framework.nativeFormatAltitude(altitude).toString(requireContext()));
     }
     if (l.hasSpeed())
       builder.append("   ")
@@ -443,7 +444,7 @@ public class PlacePageView extends Fragment implements View.OnClickListener,
     double lon = mMapObject.getLon();
     DistanceAndAzimut distanceAndAzimuth =
         Framework.nativeGetDistanceAndAzimuthFromLatLon(lat, lon, l.getLatitude(), l.getLongitude(), 0.0);
-    mTvDistance.setText(distanceAndAzimuth.getDistance());
+    mTvDistance.setText(distanceAndAzimuth.getDistance().toString(requireContext()));
   }
 
   private void refreshLatLon()

--- a/data/strings/strings.txt
+++ b/data/strings/strings.txt
@@ -15106,7 +15106,7 @@
     zh-Hans = 3. 使用应用时选择
     zh-Hant = 3. 使用應用時選擇
 
-  [meter]
+  [m]
     tags = android,ios
     en = m
     ar = متر
@@ -15145,7 +15145,7 @@
     zh-Hans = 米
     zh-Hant = 公尺
 
-  [kilometer]
+  [km]
     tags = android,ios
     en = km
     ar = كم
@@ -15222,7 +15222,7 @@
     zh-Hans = 公里每小时
     zh-Hant = 公里每小時
 
-  [mile]
+  [mi]
     tags = android,ios
     en = mi
     ar = ميل
@@ -15261,7 +15261,7 @@
     zh-Hans = 英里
     zh-Hant = 英哩
 
-  [foot]
+  [ft]
     comment = A unit of measure
     tags = android,ios
     en = ft

--- a/data/strings/types_strings.txt
+++ b/data/strings/types_strings.txt
@@ -18012,7 +18012,6 @@
 
   [type.power.plant.hydro]
     ref = type.power.generator.hydro
-    tr = Hidroelektrik Santrali
 
   [type.power.plant.solar]
     en = Solar Power Plant

--- a/indexer/map_object.cpp
+++ b/indexer/map_object.cpp
@@ -10,6 +10,7 @@
 
 #include "platform/localization.hpp"
 #include "platform/measurement_utils.hpp"
+#include "platform/distance.hpp"
 
 #include "base/logging.hpp"
 #include "base/string_utils.hpp"
@@ -186,7 +187,7 @@ string MapObject::GetElevationFormatted() const
   {
     double value;
     if (strings::to_double(sv, value))
-      return measurement_utils::FormatAltitude(value);
+      return platform::Distance::CreateAltitudeFormatted(value).ToString();
     else
       LOG(LWARNING, ("Invalid elevation metadata:", sv));
   }

--- a/iphone/Maps/Classes/CarPlay/Templates Data/RouteInfo.swift
+++ b/iphone/Maps/Classes/CarPlay/Templates Data/RouteInfo.swift
@@ -39,7 +39,7 @@ class RouteInfo: NSObject {
 
 
   /// > Warning: Order of enum values MUST BE the same with
-  /// > native ``LaneWay`` enum (see platform/distance.hpp for details).
+  /// > native ``Distance::Units`` enum (see platform/distance.hpp for details).
   class func unitLength(for targetUnitsIndex: UInt8) -> UnitLength {
     switch targetUnitsIndex {
     case 0:

--- a/iphone/Maps/Classes/CarPlay/Templates Data/RouteInfo.swift
+++ b/iphone/Maps/Classes/CarPlay/Templates Data/RouteInfo.swift
@@ -4,8 +4,8 @@ class RouteInfo: NSObject {
   let targetDistance: String
   let targetUnits: UnitLength
   let distanceToTurn: String
-  let streetName: String
   let turnUnits: UnitLength
+  let streetName: String
   let turnImageName: String?
   let nextTurnImageName: String?
   let speedMps: Double
@@ -14,10 +14,10 @@ class RouteInfo: NSObject {
 
   @objc init(timeToTarget: TimeInterval,
              targetDistance: String,
-             targetUnits: String,
+             targetUnitsIndex: UInt8,
              distanceToTurn: String,
+             turnUnitsIndex: UInt8,
              streetName: String,
-             turnUnits: String,
              turnImageName: String?,
              nextTurnImageName: String?,
              speedMps: Double,
@@ -25,10 +25,10 @@ class RouteInfo: NSObject {
              roundExitNumber: Int) {
     self.timeToTarget = timeToTarget
     self.targetDistance = targetDistance
-    self.targetUnits = RouteInfo.unitLength(for: targetUnits)
+    self.targetUnits = RouteInfo.unitLength(for: targetUnitsIndex)
     self.distanceToTurn = distanceToTurn
+    self.turnUnits = RouteInfo.unitLength(for: turnUnitsIndex)
     self.streetName = streetName;
-    self.turnUnits = RouteInfo.unitLength(for: turnUnits)
     self.turnImageName = turnImageName
     self.nextTurnImageName = nextTurnImageName
     self.speedMps = speedMps
@@ -37,16 +37,19 @@ class RouteInfo: NSObject {
     self.roundExitNumber = roundExitNumber
   }
 
-  class func unitLength(for targetUnits: String) -> UnitLength {
-    switch targetUnits {
-    case "mi":
-      return .miles
-    case "ft":
-      return .feet
-    case "km":
-      return .kilometers
-    case "m":
+
+  /// > Warning: Order of enum values MUST BE the same with
+  /// > native ``LaneWay`` enum (see platform/distance.hpp for details).
+  class func unitLength(for targetUnitsIndex: UInt8) -> UnitLength {
+    switch targetUnitsIndex {
+    case 0:
       return .meters
+    case 1:
+      return .kilometers
+    case 2:
+      return .feet
+    case 3:
+      return .miles
     default:
       return .meters
     }

--- a/iphone/Maps/Classes/CustomViews/NavigationDashboard/MWMNavigationDashboardManager+Entity.mm
+++ b/iphone/Maps/Classes/CustomViews/NavigationDashboard/MWMNavigationDashboardManager+Entity.mm
@@ -165,11 +165,11 @@ NSAttributedString *estimate(NSTimeInterval time, NSString *distance, NSString *
   if (auto entity = self.entity) {
     entity.isValid = YES;
     entity.timeToTarget = info.m_time;
-    entity.targetDistance = @(info.m_distToTarget.c_str());
-    entity.targetUnits = [self localizedUnitLength:@(info.m_targetUnitsSuffix.c_str())];
+    entity.targetDistance = @(info.m_distToTarget.GetDistanceString().c_str());
+    entity.targetUnits = [self localizedUnitLength:@(info.m_distToTarget.GetUnitsString().c_str())];
     entity.progress = info.m_completionPercent;
-    entity.distanceToTurn = @(info.m_distToTurn.c_str());
-    entity.turnUnits = [self localizedUnitLength:@(info.m_turnUnitsSuffix.c_str())];
+    entity.distanceToTurn = @(info.m_distToTurn.GetDistanceString().c_str());
+    entity.turnUnits = [self localizedUnitLength:@(info.m_distToTurn.GetUnitsString().c_str())];
     entity.streetName = @(info.m_displayedStreetName.c_str());
     entity.speedLimitMps = info.m_speedLimitMps;
 

--- a/iphone/Maps/Core/Framework/ProxyObjects/Routing/MWMRoutingManager.mm
+++ b/iphone/Maps/Core/Framework/ProxyObjects/Routing/MWMRoutingManager.mm
@@ -80,7 +80,6 @@
   if (!self.isRoutingActive) { return  nil; }
   routing::FollowingInfo info;
   self.rm.GetRouteFollowingInfo(info);
-  if (!info.IsValid()) { return nil; }
   CLLocation * lastLocation = [MWMLocationManager lastLocation];
   double speedMps = 0;
   if (lastLocation && lastLocation.speed >= 0) {

--- a/iphone/Maps/Core/Framework/ProxyObjects/Routing/MWMRoutingManager.mm
+++ b/iphone/Maps/Core/Framework/ProxyObjects/Routing/MWMRoutingManager.mm
@@ -95,10 +95,10 @@
 
   MWMRouteInfo *objCInfo = [[MWMRouteInfo alloc] initWithTimeToTarget:info.m_time
                                                        targetDistance:@(info.m_distToTarget.GetDistanceString().c_str())
-                                                          targetUnits:@(info.m_distToTarget.GetUnitsString().c_str())
+                                                     targetUnitsIndex:static_cast<UInt8>(info.m_distToTarget.GetUnits())
                                                        distanceToTurn:@(info.m_distToTurn.GetDistanceString().c_str())
+                                                       turnUnitsIndex:static_cast<UInt8>(info.m_distToTurn.GetUnits())
                                                            streetName:@(info.m_displayedStreetName.c_str())
-                                                            turnUnits:@(info.m_distToTurn.GetUnitsString().c_str())
                                                         turnImageName:[self turnImageName:info.m_turn isPrimary:YES]
                                                     nextTurnImageName:[self turnImageName:info.m_nextTurn isPrimary:NO]
                                                              speedMps:speedMps

--- a/iphone/Maps/Core/Framework/ProxyObjects/Routing/MWMRoutingManager.mm
+++ b/iphone/Maps/Core/Framework/ProxyObjects/Routing/MWMRoutingManager.mm
@@ -94,11 +94,11 @@
   }
 
   MWMRouteInfo *objCInfo = [[MWMRouteInfo alloc] initWithTimeToTarget:info.m_time
-                                                       targetDistance:@(info.m_distToTarget.c_str())
-                                                          targetUnits:@(info.m_targetUnitsSuffix.c_str())
-                                                       distanceToTurn:@(info.m_distToTurn.c_str())
+                                                       targetDistance:@(info.m_distToTarget.GetDistanceString().c_str())
+                                                          targetUnits:@(info.m_distToTarget.GetUnitsString().c_str())
+                                                       distanceToTurn:@(info.m_distToTurn.GetDistanceString().c_str())
                                                            streetName:@(info.m_displayedStreetName.c_str())
-                                                            turnUnits:@(info.m_turnUnitsSuffix.c_str())
+                                                            turnUnits:@(info.m_distToTurn.GetUnitsString().c_str())
                                                         turnImageName:[self turnImageName:info.m_turn isPrimary:YES]
                                                     nextTurnImageName:[self turnImageName:info.m_nextTurn isPrimary:NO]
                                                              speedMps:speedMps

--- a/iphone/Maps/Core/Location/MWMLocationHelpers.h
+++ b/iphone/Maps/Core/Location/MWMLocationHelpers.h
@@ -2,7 +2,7 @@
 
 #include "platform/localization.hpp"
 #include "platform/location.hpp"
-#include "platform/measurement_utils.hpp"
+#include "platform/distance.hpp"
 
 #include "geometry/mercator.hpp"
 
@@ -13,8 +13,7 @@ static inline NSString * formattedDistance(double const & meters) {
   if (meters < 0.)
     return nil;
 
-  auto const localizedUnits = platform::GetLocalizedDistanceUnits();
-  return @(measurement_utils::FormatDistanceWithLocalization(meters, localizedUnits.m_high, localizedUnits.m_low).c_str());
+  return @(platform::Distance::CreateFormatted(meters).ToString().c_str());
 }
 
 static inline ms::LatLon ToLatLon(m2::PointD const & p) { return mercator::ToLatLon(p); }

--- a/iphone/Maps/Core/Routing/MWMRouter.mm
+++ b/iphone/Maps/Core/Routing/MWMRouter.mm
@@ -345,8 +345,6 @@ char const *kRenderAltitudeImagesQueueLabel = "mapsme.mwmrouter.renderAltitudeIm
   routing::FollowingInfo info;
   rm.GetRouteFollowingInfo(info);
   auto navManager = [MWMNavigationDashboardManager sharedManager];
-  if (!info.IsValid())
-    return;
   if ([MWMRouter type] == MWMRouterTypePublicTransport)
     [navManager updateTransitInfo:rm.GetTransitRouteInfo()];
   else

--- a/iphone/Maps/Core/Routing/MWMRouter.mm
+++ b/iphone/Maps/Core/Routing/MWMRouter.mm
@@ -17,6 +17,7 @@
 
 #include "platform/local_country_file_utils.hpp"
 #include "platform/localization.hpp"
+#include "platform/distance.hpp"
 
 using namespace routing;
 
@@ -390,10 +391,8 @@ char const *kRenderAltitudeImagesQueueLabel = "mapsme.mwmrouter.renderAltitudeIm
       altitudes->CalculateAscentDescent(totalAscentM, totalDescentM);
 
       auto const localizedUnits = platform::GetLocalizedAltitudeUnits();
-      router.totalAscent = 
-        @(measurement_utils::FormatAltitudeWithLocalization(totalAscentM, localizedUnits.m_low).c_str());
-      router.totalDescent = 
-        @(measurement_utils::FormatAltitudeWithLocalization(totalDescentM, localizedUnits.m_low).c_str());
+      router.totalAscent = @(platform::Distance::CreateAltitudeFormatted(totalAscentM).ToString().c_str());
+      router.totalDescent = @(platform::Distance::CreateAltitudeFormatted(totalDescentM).ToString().c_str());
     }
 
     dispatch_async(dispatch_get_main_queue(), ^{

--- a/iphone/Maps/LocalizedStrings/ar.lproj/Localizable.strings
+++ b/iphone/Maps/LocalizedStrings/ar.lproj/Localizable.strings
@@ -765,16 +765,16 @@
 /* iOS Dialog for the case when the location permission is not granted */
 "location_services_disabled_3" = "3. اختيار التفعيل أثناء استخدام التطبيق";
 
-"meter" = "متر";
+"m" = "متر";
 
-"kilometer" = "كم";
+"km" = "كم";
 
 "kilometers_per_hour" = "كم/ساعة";
 
-"mile" = "ميل";
+"mi" = "ميل";
 
 /* A unit of measure */
-"foot" = "قدم";
+"ft" = "قدم";
 
 "miles_per_hour" = "ميل/ساعة";
 

--- a/iphone/Maps/LocalizedStrings/be.lproj/Localizable.strings
+++ b/iphone/Maps/LocalizedStrings/be.lproj/Localizable.strings
@@ -765,16 +765,16 @@
 /* iOS Dialog for the case when the location permission is not granted */
 "location_services_disabled_3" = "3. Выберыце \"Падчас выкарыстання праграмы\"";
 
-"meter" = "м";
+"m" = "м";
 
-"kilometer" = "км";
+"km" = "км";
 
 "kilometers_per_hour" = "км/г";
 
-"mile" = "міля";
+"mi" = "міля";
 
 /* A unit of measure */
-"foot" = "фут";
+"ft" = "фут";
 
 "miles_per_hour" = "міль/г";
 

--- a/iphone/Maps/LocalizedStrings/bg.lproj/Localizable.strings
+++ b/iphone/Maps/LocalizedStrings/bg.lproj/Localizable.strings
@@ -765,16 +765,16 @@
 /* iOS Dialog for the case when the location permission is not granted */
 "location_services_disabled_3" = "3. Избиране на Докато приложението се използва";
 
-"meter" = "м";
+"m" = "м";
 
-"kilometer" = "км";
+"km" = "км";
 
 "kilometers_per_hour" = "km/h";
 
-"mile" = "ми";
+"mi" = "ми";
 
 /* A unit of measure */
-"foot" = "фут";
+"ft" = "фут";
 
 "miles_per_hour" = "mph";
 

--- a/iphone/Maps/LocalizedStrings/ca.lproj/Localizable.strings
+++ b/iphone/Maps/LocalizedStrings/ca.lproj/Localizable.strings
@@ -765,16 +765,16 @@
 /* iOS Dialog for the case when the location permission is not granted */
 "location_services_disabled_3" = "3. Trieu \"Mentre s'usa l'aplicació\"";
 
-"meter" = "m";
+"m" = "m";
 
-"kilometer" = "km";
+"km" = "km";
 
 "kilometers_per_hour" = "km/h";
 
-"mile" = "mi";
+"mi" = "mi";
 
 /* A unit of measure */
-"foot" = "ft";
+"ft" = "ft";
 
 "miles_per_hour" = "mph";
 

--- a/iphone/Maps/LocalizedStrings/cs.lproj/Localizable.strings
+++ b/iphone/Maps/LocalizedStrings/cs.lproj/Localizable.strings
@@ -765,16 +765,16 @@
 /* iOS Dialog for the case when the location permission is not granted */
 "location_services_disabled_3" = "3. Vyberte při používání aplikace";
 
-"meter" = "m";
+"m" = "m";
 
-"kilometer" = "km";
+"km" = "km";
 
 "kilometers_per_hour" = "km/h";
 
-"mile" = "mil";
+"mi" = "mil";
 
 /* A unit of measure */
-"foot" = "stopa";
+"ft" = "stopa";
 
 "miles_per_hour" = "mil/h";
 

--- a/iphone/Maps/LocalizedStrings/da.lproj/Localizable.strings
+++ b/iphone/Maps/LocalizedStrings/da.lproj/Localizable.strings
@@ -765,16 +765,16 @@
 /* iOS Dialog for the case when the location permission is not granted */
 "location_services_disabled_3" = "3. Vælg Mens app'en bruges";
 
-"meter" = "m";
+"m" = "m";
 
-"kilometer" = "km";
+"km" = "km";
 
 "kilometers_per_hour" = "km/t";
 
-"mile" = "mil";
+"mi" = "mil";
 
 /* A unit of measure */
-"foot" = "fod";
+"ft" = "fod";
 
 "miles_per_hour" = "mph";
 

--- a/iphone/Maps/LocalizedStrings/de.lproj/Localizable.strings
+++ b/iphone/Maps/LocalizedStrings/de.lproj/Localizable.strings
@@ -765,16 +765,16 @@
 /* iOS Dialog for the case when the location permission is not granted */
 "location_services_disabled_3" = "3. Wählen Sie „Beim Verwenden der App“";
 
-"meter" = "m";
+"m" = "m";
 
-"kilometer" = "km";
+"km" = "km";
 
 "kilometers_per_hour" = "km/h";
 
-"mile" = "mi";
+"mi" = "mi";
 
 /* A unit of measure */
-"foot" = "ft";
+"ft" = "ft";
 
 "miles_per_hour" = "mph";
 

--- a/iphone/Maps/LocalizedStrings/el.lproj/Localizable.strings
+++ b/iphone/Maps/LocalizedStrings/el.lproj/Localizable.strings
@@ -765,16 +765,16 @@
 /* iOS Dialog for the case when the location permission is not granted */
 "location_services_disabled_3" = "3. Επιλέξτε ενώ χρησιμοποιείτε την εφαρμογή";
 
-"meter" = "m";
+"m" = "m";
 
-"kilometer" = "km";
+"km" = "km";
 
 "kilometers_per_hour" = "km/h";
 
-"mile" = "mi";
+"mi" = "mi";
 
 /* A unit of measure */
-"foot" = "ft";
+"ft" = "ft";
 
 "miles_per_hour" = "mph";
 

--- a/iphone/Maps/LocalizedStrings/en-GB.lproj/Localizable.strings
+++ b/iphone/Maps/LocalizedStrings/en-GB.lproj/Localizable.strings
@@ -765,16 +765,16 @@
 /* iOS Dialog for the case when the location permission is not granted */
 "location_services_disabled_3" = "3. Select While Using the App";
 
-"meter" = "m";
+"m" = "m";
 
-"kilometer" = "km";
+"km" = "km";
 
 "kilometers_per_hour" = "km/h";
 
-"mile" = "mi";
+"mi" = "mi";
 
 /* A unit of measure */
-"foot" = "ft";
+"ft" = "ft";
 
 "miles_per_hour" = "mph";
 

--- a/iphone/Maps/LocalizedStrings/en.lproj/Localizable.strings
+++ b/iphone/Maps/LocalizedStrings/en.lproj/Localizable.strings
@@ -765,16 +765,16 @@
 /* iOS Dialog for the case when the location permission is not granted */
 "location_services_disabled_3" = "3. Select While Using the App";
 
-"meter" = "m";
+"m" = "m";
 
-"kilometer" = "km";
+"km" = "km";
 
 "kilometers_per_hour" = "km/h";
 
-"mile" = "mi";
+"mi" = "mi";
 
 /* A unit of measure */
-"foot" = "ft";
+"ft" = "ft";
 
 "miles_per_hour" = "mph";
 

--- a/iphone/Maps/LocalizedStrings/es-MX.lproj/Localizable.strings
+++ b/iphone/Maps/LocalizedStrings/es-MX.lproj/Localizable.strings
@@ -765,16 +765,16 @@
 /* iOS Dialog for the case when the location permission is not granted */
 "location_services_disabled_3" = "3. Seleccionar al usar la aplicación";
 
-"meter" = "m";
+"m" = "m";
 
-"kilometer" = "km";
+"km" = "km";
 
 "kilometers_per_hour" = "km/h";
 
-"mile" = "mi";
+"mi" = "mi";
 
 /* A unit of measure */
-"foot" = "pie";
+"ft" = "pie";
 
 "miles_per_hour" = "mph";
 

--- a/iphone/Maps/LocalizedStrings/es.lproj/Localizable.strings
+++ b/iphone/Maps/LocalizedStrings/es.lproj/Localizable.strings
@@ -765,16 +765,16 @@
 /* iOS Dialog for the case when the location permission is not granted */
 "location_services_disabled_3" = "3. Seleccionar al usar la aplicación";
 
-"meter" = "m";
+"m" = "m";
 
-"kilometer" = "km";
+"km" = "km";
 
 "kilometers_per_hour" = "km/h";
 
-"mile" = "mi";
+"mi" = "mi";
 
 /* A unit of measure */
-"foot" = "pie";
+"ft" = "pie";
 
 "miles_per_hour" = "mph";
 

--- a/iphone/Maps/LocalizedStrings/et.lproj/Localizable.strings
+++ b/iphone/Maps/LocalizedStrings/et.lproj/Localizable.strings
@@ -765,16 +765,16 @@
 /* iOS Dialog for the case when the location permission is not granted */
 "location_services_disabled_3" = "3. Vali \"Rakenduse kasutamise ajal\"";
 
-"meter" = "m";
+"m" = "m";
 
-"kilometer" = "km";
+"km" = "km";
 
 "kilometers_per_hour" = "km/h";
 
-"mile" = "mi";
+"mi" = "mi";
 
 /* A unit of measure */
-"foot" = "jalga";
+"ft" = "jalga";
 
 "miles_per_hour" = "mph";
 

--- a/iphone/Maps/LocalizedStrings/eu.lproj/Localizable.strings
+++ b/iphone/Maps/LocalizedStrings/eu.lproj/Localizable.strings
@@ -765,16 +765,16 @@
 /* iOS Dialog for the case when the location permission is not granted */
 "location_services_disabled_3" = "3. Hautatu aplikazioa erabiltzean";
 
-"meter" = "m";
+"m" = "m";
 
-"kilometer" = "km";
+"km" = "km";
 
 "kilometers_per_hour" = "km/h";
 
-"mile" = "mi";
+"mi" = "mi";
 
 /* A unit of measure */
-"foot" = "oin";
+"ft" = "oin";
 
 "miles_per_hour" = "mph";
 

--- a/iphone/Maps/LocalizedStrings/fa.lproj/Localizable.strings
+++ b/iphone/Maps/LocalizedStrings/fa.lproj/Localizable.strings
@@ -765,16 +765,16 @@
 /* iOS Dialog for the case when the location permission is not granted */
 "location_services_disabled_3" = "3. Select While Using the App";
 
-"meter" = "متر";
+"m" = "متر";
 
-"kilometer" = "کیلومتر";
+"km" = "کیلومتر";
 
 "kilometers_per_hour" = "کیلومتربرساعت (km/h)";
 
-"mile" = "مایل";
+"mi" = "مایل";
 
 /* A unit of measure */
-"foot" = "فوت";
+"ft" = "فوت";
 
 "miles_per_hour" = "مایل بر ساعت (mph)";
 

--- a/iphone/Maps/LocalizedStrings/fi.lproj/Localizable.strings
+++ b/iphone/Maps/LocalizedStrings/fi.lproj/Localizable.strings
@@ -765,16 +765,16 @@
 /* iOS Dialog for the case when the location permission is not granted */
 "location_services_disabled_3" = "3. Valitse sovellusta käytettäessä";
 
-"meter" = "m";
+"m" = "m";
 
-"kilometer" = "km";
+"km" = "km";
 
 "kilometers_per_hour" = "km/h";
 
-"mile" = "mi";
+"mi" = "mi";
 
 /* A unit of measure */
-"foot" = "ft";
+"ft" = "ft";
 
 "miles_per_hour" = "mph";
 

--- a/iphone/Maps/LocalizedStrings/fr.lproj/Localizable.strings
+++ b/iphone/Maps/LocalizedStrings/fr.lproj/Localizable.strings
@@ -765,16 +765,16 @@
 /* iOS Dialog for the case when the location permission is not granted */
 "location_services_disabled_3" = "3. Sélectionner tout en utilisant l'app";
 
-"meter" = "m";
+"m" = "m";
 
-"kilometer" = "km";
+"km" = "km";
 
 "kilometers_per_hour" = "km/h";
 
-"mile" = "mi";
+"mi" = "mi";
 
 /* A unit of measure */
-"foot" = "ft";
+"ft" = "ft";
 
 "miles_per_hour" = "mph";
 

--- a/iphone/Maps/LocalizedStrings/he.lproj/Localizable.strings
+++ b/iphone/Maps/LocalizedStrings/he.lproj/Localizable.strings
@@ -765,16 +765,16 @@
 /* iOS Dialog for the case when the location permission is not granted */
 "location_services_disabled_3" = "3. Select While Using the App";
 
-"meter" = "m";
+"m" = "m";
 
-"kilometer" = "km";
+"km" = "km";
 
 "kilometers_per_hour" = "km/h";
 
-"mile" = "mi";
+"mi" = "mi";
 
 /* A unit of measure */
-"foot" = "ft";
+"ft" = "ft";
 
 "miles_per_hour" = "mph";
 

--- a/iphone/Maps/LocalizedStrings/hu.lproj/Localizable.strings
+++ b/iphone/Maps/LocalizedStrings/hu.lproj/Localizable.strings
@@ -765,16 +765,16 @@
 /* iOS Dialog for the case when the location permission is not granted */
 "location_services_disabled_3" = "3. Kiválaszt az alkalmazás használata alatt";
 
-"meter" = "m";
+"m" = "m";
 
-"kilometer" = "km";
+"km" = "km";
 
 "kilometers_per_hour" = "km/h";
 
-"mile" = "mf";
+"mi" = "mf";
 
 /* A unit of measure */
-"foot" = "ft";
+"ft" = "ft";
 
 "miles_per_hour" = "mph";
 

--- a/iphone/Maps/LocalizedStrings/id.lproj/Localizable.strings
+++ b/iphone/Maps/LocalizedStrings/id.lproj/Localizable.strings
@@ -765,16 +765,16 @@
 /* iOS Dialog for the case when the location permission is not granted */
 "location_services_disabled_3" = "3. Pilih While Using the App";
 
-"meter" = "m";
+"m" = "m";
 
-"kilometer" = "km";
+"km" = "km";
 
 "kilometers_per_hour" = "km/j";
 
-"mile" = "mil";
+"mi" = "mil";
 
 /* A unit of measure */
-"foot" = "kaki";
+"ft" = "kaki";
 
 "miles_per_hour" = "mpj";
 

--- a/iphone/Maps/LocalizedStrings/it.lproj/Localizable.strings
+++ b/iphone/Maps/LocalizedStrings/it.lproj/Localizable.strings
@@ -765,16 +765,16 @@
 /* iOS Dialog for the case when the location permission is not granted */
 "location_services_disabled_3" = "3. Seleziona Mentre usi l'app";
 
-"meter" = "m";
+"m" = "m";
 
-"kilometer" = "km";
+"km" = "km";
 
 "kilometers_per_hour" = "km/h";
 
-"mile" = "mi";
+"mi" = "mi";
 
 /* A unit of measure */
-"foot" = "ft";
+"ft" = "ft";
 
 "miles_per_hour" = "mph";
 

--- a/iphone/Maps/LocalizedStrings/ja.lproj/Localizable.strings
+++ b/iphone/Maps/LocalizedStrings/ja.lproj/Localizable.strings
@@ -765,16 +765,16 @@
 /* iOS Dialog for the case when the location permission is not granted */
 "location_services_disabled_3" = "3. アプリの使用中を選択してください";
 
-"meter" = "m";
+"m" = "m";
 
-"kilometer" = "km";
+"km" = "km";
 
 "kilometers_per_hour" = "キロメートル毎時";
 
-"mile" = "マイル";
+"mi" = "マイル";
 
 /* A unit of measure */
-"foot" = "フィート";
+"ft" = "フィート";
 
 "miles_per_hour" = "マイル毎時";
 

--- a/iphone/Maps/LocalizedStrings/ko.lproj/Localizable.strings
+++ b/iphone/Maps/LocalizedStrings/ko.lproj/Localizable.strings
@@ -765,16 +765,16 @@
 /* iOS Dialog for the case when the location permission is not granted */
 "location_services_disabled_3" = "3. 앱 사용 중에 선택";
 
-"meter" = "m";
+"m" = "m";
 
-"kilometer" = "km";
+"km" = "km";
 
 "kilometers_per_hour" = "km/시";
 
-"mile" = "mi";
+"mi" = "mi";
 
 /* A unit of measure */
-"foot" = "풋";
+"ft" = "풋";
 
 "miles_per_hour" = "mph";
 

--- a/iphone/Maps/LocalizedStrings/mr.lproj/Localizable.strings
+++ b/iphone/Maps/LocalizedStrings/mr.lproj/Localizable.strings
@@ -765,16 +765,16 @@
 /* iOS Dialog for the case when the location permission is not granted */
 "location_services_disabled_3" = "३. \"ऍप वापरत असताना\" निवडा";
 
-"meter" = "m";
+"m" = "m";
 
-"kilometer" = "किमी";
+"km" = "किमी";
 
 "kilometers_per_hour" = "km/h";
 
-"mile" = "mi";
+"mi" = "mi";
 
 /* A unit of measure */
-"foot" = "फूट";
+"ft" = "फूट";
 
 "miles_per_hour" = "mph";
 

--- a/iphone/Maps/LocalizedStrings/nb.lproj/Localizable.strings
+++ b/iphone/Maps/LocalizedStrings/nb.lproj/Localizable.strings
@@ -765,16 +765,16 @@
 /* iOS Dialog for the case when the location permission is not granted */
 "location_services_disabled_3" = "3.Velg når appen er i bruk";
 
-"meter" = "m";
+"m" = "m";
 
-"kilometer" = "km";
+"km" = "km";
 
 "kilometers_per_hour" = "km/t";
 
-"mile" = "mi";
+"mi" = "mi";
 
 /* A unit of measure */
-"foot" = "fot";
+"ft" = "fot";
 
 "miles_per_hour" = "mph";
 

--- a/iphone/Maps/LocalizedStrings/nl.lproj/Localizable.strings
+++ b/iphone/Maps/LocalizedStrings/nl.lproj/Localizable.strings
@@ -765,16 +765,16 @@
 /* iOS Dialog for the case when the location permission is not granted */
 "location_services_disabled_3" = "3. Selecteer Terwijl Je de App Gebruikt";
 
-"meter" = "m";
+"m" = "m";
 
-"kilometer" = "km";
+"km" = "km";
 
 "kilometers_per_hour" = "km/h";
 
-"mile" = "mijl";
+"mi" = "mijl";
 
 /* A unit of measure */
-"foot" = "voet";
+"ft" = "voet";
 
 "miles_per_hour" = "mph";
 

--- a/iphone/Maps/LocalizedStrings/pl.lproj/Localizable.strings
+++ b/iphone/Maps/LocalizedStrings/pl.lproj/Localizable.strings
@@ -765,16 +765,16 @@
 /* iOS Dialog for the case when the location permission is not granted */
 "location_services_disabled_3" = "3. Zaznacz Podczas korzystania z aplikacji";
 
-"meter" = "m";
+"m" = "m";
 
-"kilometer" = "km";
+"km" = "km";
 
 "kilometers_per_hour" = "km/h";
 
-"mile" = "mi";
+"mi" = "mi";
 
 /* A unit of measure */
-"foot" = "ft";
+"ft" = "ft";
 
 "miles_per_hour" = "mph";
 

--- a/iphone/Maps/LocalizedStrings/pt-BR.lproj/Localizable.strings
+++ b/iphone/Maps/LocalizedStrings/pt-BR.lproj/Localizable.strings
@@ -765,16 +765,16 @@
 /* iOS Dialog for the case when the location permission is not granted */
 "location_services_disabled_3" = "3. Selecione \"Durante uso do aplicativo\"";
 
-"meter" = "m";
+"m" = "m";
 
-"kilometer" = "km";
+"km" = "km";
 
 "kilometers_per_hour" = "km/h";
 
-"mile" = "mi";
+"mi" = "mi";
 
 /* A unit of measure */
-"foot" = "ft";
+"ft" = "ft";
 
 "miles_per_hour" = "mph";
 

--- a/iphone/Maps/LocalizedStrings/pt.lproj/Localizable.strings
+++ b/iphone/Maps/LocalizedStrings/pt.lproj/Localizable.strings
@@ -765,16 +765,16 @@
 /* iOS Dialog for the case when the location permission is not granted */
 "location_services_disabled_3" = "3. Selecione \"Durante a utilização da aplicação\"";
 
-"meter" = "m";
+"m" = "m";
 
-"kilometer" = "Km";
+"km" = "Km";
 
 "kilometers_per_hour" = "km/h";
 
-"mile" = "mi";
+"mi" = "mi";
 
 /* A unit of measure */
-"foot" = "ft";
+"ft" = "ft";
 
 "miles_per_hour" = "mph";
 

--- a/iphone/Maps/LocalizedStrings/ro.lproj/Localizable.strings
+++ b/iphone/Maps/LocalizedStrings/ro.lproj/Localizable.strings
@@ -765,16 +765,16 @@
 /* iOS Dialog for the case when the location permission is not granted */
 "location_services_disabled_3" = "3. Alege „În timp ce folosești aplicația”";
 
-"meter" = "m";
+"m" = "m";
 
-"kilometer" = "km";
+"km" = "km";
 
 "kilometers_per_hour" = "km/h";
 
-"mile" = "mi";
+"mi" = "mi";
 
 /* A unit of measure */
-"foot" = "ft";
+"ft" = "ft";
 
 "miles_per_hour" = "mph";
 

--- a/iphone/Maps/LocalizedStrings/ru.lproj/Localizable.strings
+++ b/iphone/Maps/LocalizedStrings/ru.lproj/Localizable.strings
@@ -765,16 +765,16 @@
 /* iOS Dialog for the case when the location permission is not granted */
 "location_services_disabled_3" = "3. Выберите «При использовании программы»";
 
-"meter" = "м";
+"m" = "м";
 
-"kilometer" = "км";
+"km" = "км";
 
 "kilometers_per_hour" = "км/ч";
 
-"mile" = "ми";
+"mi" = "ми";
 
 /* A unit of measure */
-"foot" = "фут";
+"ft" = "фут";
 
 "miles_per_hour" = "ми/ч";
 

--- a/iphone/Maps/LocalizedStrings/sk.lproj/Localizable.strings
+++ b/iphone/Maps/LocalizedStrings/sk.lproj/Localizable.strings
@@ -765,16 +765,16 @@
 /* iOS Dialog for the case when the location permission is not granted */
 "location_services_disabled_3" = "3. Vyberte si počas používania aplikácie";
 
-"meter" = "m";
+"m" = "m";
 
-"kilometer" = "km";
+"km" = "km";
 
 "kilometers_per_hour" = "km/h";
 
-"mile" = "mi";
+"mi" = "mi";
 
 /* A unit of measure */
-"foot" = "stopa";
+"ft" = "stopa";
 
 "miles_per_hour" = "mph";
 

--- a/iphone/Maps/LocalizedStrings/sv.lproj/Localizable.strings
+++ b/iphone/Maps/LocalizedStrings/sv.lproj/Localizable.strings
@@ -765,16 +765,16 @@
 /* iOS Dialog for the case when the location permission is not granted */
 "location_services_disabled_3" = "3. Välj Medan appen används";
 
-"meter" = "m";
+"m" = "m";
 
-"kilometer" = "km";
+"km" = "km";
 
 "kilometers_per_hour" = "km/h";
 
-"mile" = "mile";
+"mi" = "mile";
 
 /* A unit of measure */
-"foot" = "fot";
+"ft" = "fot";
 
 "miles_per_hour" = "mph";
 

--- a/iphone/Maps/LocalizedStrings/sw.lproj/Localizable.strings
+++ b/iphone/Maps/LocalizedStrings/sw.lproj/Localizable.strings
@@ -765,16 +765,16 @@
 /* iOS Dialog for the case when the location permission is not granted */
 "location_services_disabled_3" = "3. Select While Using the App";
 
-"meter" = "m";
+"m" = "m";
 
-"kilometer" = "km";
+"km" = "km";
 
 "kilometers_per_hour" = "km/h";
 
-"mile" = "mi";
+"mi" = "mi";
 
 /* A unit of measure */
-"foot" = "ft";
+"ft" = "ft";
 
 "miles_per_hour" = "mph";
 

--- a/iphone/Maps/LocalizedStrings/th.lproj/Localizable.strings
+++ b/iphone/Maps/LocalizedStrings/th.lproj/Localizable.strings
@@ -765,16 +765,16 @@
 /* iOS Dialog for the case when the location permission is not granted */
 "location_services_disabled_3" = "3. เลือกในขณะใช้แอป";
 
-"meter" = "ม.";
+"m" = "ม.";
 
-"kilometer" = "กม.";
+"km" = "กม.";
 
 "kilometers_per_hour" = "กม./ชม.";
 
-"mile" = "ไมล์";
+"mi" = "ไมล์";
 
 /* A unit of measure */
-"foot" = "ฟุต";
+"ft" = "ฟุต";
 
 "miles_per_hour" = "ไมล์/ชม.";
 

--- a/iphone/Maps/LocalizedStrings/tr.lproj/Localizable.strings
+++ b/iphone/Maps/LocalizedStrings/tr.lproj/Localizable.strings
@@ -75,7 +75,7 @@
 "bookmarks" = "Yer İmleri";
 
 /* "Bookmarks and Tracks" dialog title, also sync it with iphone/plist.txt */
-"bookmarks_and_tracks" = "Yer İmleri ve kayıtlar";
+"bookmarks_and_tracks" = "Yer İmleri ve Kayıtlar";
 
 /* Default bookmark list name */
 "core_my_places" = "Yerlerim";
@@ -200,7 +200,7 @@
 "data_version" = "OpenStreetMap verileri: %@";
 
 /* Title for tracks category in bookmarks manager */
-"tracks_title" = "Kayıtlar";
+"tracks_title" = "Yol Kayıtları";
 
 /* Length of track in cell that describes route */
 "length" = "Uzunluk";
@@ -319,10 +319,10 @@
 "report_a_bug" = "Hata bildir";
 
 /* Alert text */
-"email_error_body" = "E-posta istemcisi henüz kurulmamış. Lütfen e-posta istemcisini yapılandırın ya da bize %@ adresinden ulaşmak için başka bir yöntem deneyin";
+"email_error_body" = "E-posta istemcisi henüz kurulmamış. Lütfen e-posta istemcisini yapılandırın veya bize %@ adresinden ulaşmak için başka bir yöntem deneyin";
 
 /* Alert title */
-"email_error_title" = "Posta gönderme hatası";
+"email_error_title" = "E-Posta gönderme hatası";
 
 /* Settings item title */
 "pref_calibration_title" = "Pusula kalibrasyonu";
@@ -765,16 +765,16 @@
 /* iOS Dialog for the case when the location permission is not granted */
 "location_services_disabled_3" = "3. \"Uygulamayı Kullanırken\"i Seçin";
 
-"meter" = "m";
+"m" = "m";
 
-"kilometer" = "km";
+"km" = "km";
 
 "kilometers_per_hour" = "km/s";
 
-"mile" = "mil";
+"mi" = "mil";
 
 /* A unit of measure */
-"foot" = "fit";
+"ft" = "fit";
 
 "miles_per_hour" = "saatte mil";
 
@@ -1225,13 +1225,13 @@
 "placepage_delete_track_button" = "Kaydı Sil";
 
 /* Placeholder for track name input on track edit screen */
-"placepage_track_name_hint" = "Kayıt Adı";
+"placepage_track_name_hint" = "Yol Kaydı Adı";
 
 /* move track or bookmark from the list button text */
 "move" = "Taşı";
 
 /* edit track screen title */
-"track_title" = "Kayıt";
+"track_title" = "Yol Kaydı";
 
 /* Telegram group url for the "?" About page */
 "telegram_url" = "https://t.me/OrganicMapsTR";
@@ -1328,7 +1328,7 @@
 
 "type.amenity.charging_station.bicycle" = "Bisiklet Şarj İstasyonu";
 
-"type.amenity.charging_station.motorcar" = "Otomobil Şarj İstasyonu";
+"type.amenity.charging_station.motorcar" = "Araç Şarj İstasyonu";
 
 "type.amenity.childcare" = "Kreş";
 
@@ -1352,7 +1352,7 @@
 
 "type.amenity.driving_school" = "Sürücü Kursu";
 
-"type.amenity.money_transfer" = "Para transferi";
+"type.amenity.money_transfer" = "Para Aktarımı";
 
 "type.amenity.music_school" = "Müzik Okulu";
 
@@ -1390,7 +1390,7 @@
 
 "type.amenity.library" = "Kütüphane";
 
-"type.amenity.loading_dock" = "Yükleme alanı";
+"type.amenity.loading_dock" = "Yükleme Alanı";
 
 "type.amenity.marketplace" = "Pazaryeri";
 
@@ -1676,7 +1676,7 @@
 /* Heating, Ventilation, and Air Conditioning */
 "type.craft.hvac" = "Klimacı";
 
-"type.craft.key_cutter" = "Anahtar kesme";
+"type.craft.key_cutter" = "Anahtar Kopyalama";
 
 "type.craft.locksmith" = "Çilingir";
 
@@ -1686,7 +1686,7 @@
 
 "type.craft.photographer" = "Fotoğraf Stüdyosu";
 
-"type.shop.camera" = "Kamera Dükkanı";
+"type.shop.camera" = "Kamera Mağazası";
 
 "type.craft.plumber" = "Tesisatçı";
 
@@ -2676,13 +2676,13 @@
 
 "type.power.generator" = "Jeneratör";
 
-"type.power.generator.solar" = "Güneş jeneratörü";
+"type.power.generator.solar" = "Güneş Paneli";
 
-"type.power.generator.wind" = "Rüzgar jeneratörü";
+"type.power.generator.wind" = "Rüzgar Türbini";
 
-"type.power.generator.gas" = "Gaz türbini santrali";
+"type.power.generator.gas" = "Gaz Türbini Santrali";
 
-"type.power.generator.hydro" = "Hidroelektrik santral";
+"type.power.generator.hydro" = "Hidroelektrik Santrali";
 
 "type.power.line" = "Elektrik Hattı";
 
@@ -2690,21 +2690,21 @@
 
 "type.power.minor_line" = "Küçük Elektrik Hattı";
 
-"type.power.plant" = "Enerji santrali";
+"type.power.plant" = "Elektrik Santrali";
 
-"type.power.plant.coal" = "Kömür santrali";
+"type.power.plant.coal" = "Kömür Santrali";
 
-"type.power.plant.gas" = "Gaz türbini santrali";
+"type.power.plant.gas" = "Gaz Türbini Santrali";
 
-"type.power.plant.hydro" = "Hidroelektrik santral";
+"type.power.plant.hydro" = "Hidroelektrik Santrali";
 
-"type.power.plant.solar" = "Güneş enerjili elektrik santrali";
+"type.power.plant.solar" = "Güneş Enerjisi Santrali";
 
-"type.power.plant.wind" = "Rüzgar santrali";
+"type.power.plant.wind" = "Rüzgar Santrali";
 
-"type.power.pole" = "Elektrik Kulesi";
+"type.power.pole" = "Elektrik Direği";
 
-"type.power.station" = "Elektrik İstasyonu";
+"type.power.station" = "Elektrik Santrali";
 
 "type.power.substation" = "Trafo";
 
@@ -3276,7 +3276,7 @@
 
 "type.shop.bakery" = "Fırın";
 
-"type.shop.bathroom_furnishing" = "Banyo Mobilyaları";
+"type.shop.bathroom_furnishing" = "Banyo Mobilya Mağazası";
 
 "type.shop.beauty" = "Güzellik Salonu";
 
@@ -3290,7 +3290,7 @@
 
 "type.shop.butcher" = "Kasap";
 
-"type.shop.cannabis" = "Kenevir dükkanı";
+"type.shop.cannabis" = "Kenevir Mağazası";
 
 "type.shop.car" = "Otomobil Mağazası";
 
@@ -3302,7 +3302,7 @@
 
 "type.shop.caravan" = "Karavan Bayiliği";
 
-"type.shop.carpet" = "Halılar";
+"type.shop.carpet" = "Halıcı";
 
 "type.shop.chemist" = "Temizlik Ürünleri Mağazası";
 
@@ -3322,7 +3322,7 @@
 
 "type.shop.cosmetics" = "Bakım ürünleri";
 
-"type.shop.curtain" = "Perdeler";
+"type.shop.curtain" = "Perdeci";
 
 "type.shop.deli" = "Şarküteri Dükkanı";
 
@@ -3350,7 +3350,7 @@
 
 "type.shop.garden_centre" = "Bahçe Mağazası";
 
-"type.shop.gas" = "Gaz deposu";
+"type.shop.gas" = "Gaz İstasyonu";
 
 "type.shop.gift" = "Hediyelik Eşya Mağazası";
 
@@ -3364,9 +3364,9 @@
 
 "type.shop.health_food" = "Sağlık Gıda Mağazası";
 
-"type.shop.herbalist" = "Şifalı bitkiler mağazası";
+"type.shop.herbalist" = "Aktar";
 
-"type.shop.hifi" = "HiFi Ses";
+"type.shop.hifi" = "Plakçı";
 
 "type.shop.houseware" = "Ev Eşyaları Dükkanı";
 
@@ -3388,7 +3388,7 @@
 
 "type.shop.motorcycle" = "Motosiklet Dükkanı";
 
-"type.shop.motorcycle_repair" = "Motosiklet Tamiri";
+"type.shop.motorcycle_repair" = "Motosiklet Tamircisi";
 
 "type.shop.music" = "Mağaza";
 
@@ -3400,7 +3400,7 @@
 
 "type.shop.outdoor" = "Dış Mekan Ekipmanları";
 
-"type.shop.outpost" = "Alım noktası";
+"type.shop.outpost" = "Alım Noktası";
 
 "type.shop.pastry" = "Hamur işi";
 
@@ -3408,7 +3408,7 @@
 
 "type.shop.pet" = "Evcil Hayvan Mağazası";
 
-"type.shop.pet_grooming" = "Evcil Hayvan Bakımı";
+"type.shop.pet_grooming" = "Evcil Hayvan Bakıcısı";
 
 "type.shop.photo" = "Fotoğrafçı";
 
@@ -3444,11 +3444,11 @@
 
 "type.shop.wine" = "Şarap Mağazası";
 
-"type.shop.agrarian" = "Tarım dükkanı";
+"type.shop.agrarian" = "Zirai Ürünler Mağazası";
 
 "type.shop.antiques" = "Antikalar";
 
-"type.shop.appliance" = "Beyaz eşya dükkanı";
+"type.shop.appliance" = "Beyaz Eşya Mağazası";
 
 /* maybe change to Art Gallery for en-US when supported */
 "type.shop.art" = "Sanat Mağazası";
@@ -3457,7 +3457,7 @@
 
 "type.shop.bag" = "Çanta Mağazası";
 
-"type.shop.bed" = "Yatak dükkanı";
+"type.shop.bed" = "Yatak Mağazası";
 
 "type.shop.boutique" = "Butik";
 
@@ -3640,7 +3640,7 @@
 
 "type.waterway.canal.tunnel" = "Kanal";
 
-"type.waterway.fish_pass" = "Balık merdiveni";
+"type.waterway.fish_pass" = "Balık Geçidi";
 
 "type.waterway.dam" = "Baraj";
 

--- a/iphone/Maps/LocalizedStrings/uk.lproj/Localizable.strings
+++ b/iphone/Maps/LocalizedStrings/uk.lproj/Localizable.strings
@@ -765,16 +765,16 @@
 /* iOS Dialog for the case when the location permission is not granted */
 "location_services_disabled_3" = "3. Оберіть \"Під час роботи програми\"";
 
-"meter" = "м";
+"m" = "м";
 
-"kilometer" = "км";
+"km" = "км";
 
 "kilometers_per_hour" = "км/год";
 
-"mile" = "ми";
+"mi" = "ми";
 
 /* A unit of measure */
-"foot" = "фут";
+"ft" = "фут";
 
 "miles_per_hour" = "ми/год";
 

--- a/iphone/Maps/LocalizedStrings/vi.lproj/Localizable.strings
+++ b/iphone/Maps/LocalizedStrings/vi.lproj/Localizable.strings
@@ -765,16 +765,16 @@
 /* iOS Dialog for the case when the location permission is not granted */
 "location_services_disabled_3" = "3. Chọn Khi Đang Dùng Ứng dụng";
 
-"meter" = "m";
+"m" = "m";
 
-"kilometer" = "km";
+"km" = "km";
 
 "kilometers_per_hour" = "km/giờ";
 
-"mile" = "dặm";
+"mi" = "dặm";
 
 /* A unit of measure */
-"foot" = "ft";
+"ft" = "ft";
 
 "miles_per_hour" = "mph";
 

--- a/iphone/Maps/LocalizedStrings/zh-Hans.lproj/Localizable.strings
+++ b/iphone/Maps/LocalizedStrings/zh-Hans.lproj/Localizable.strings
@@ -765,16 +765,16 @@
 /* iOS Dialog for the case when the location permission is not granted */
 "location_services_disabled_3" = "3. 使用应用时选择";
 
-"meter" = "米";
+"m" = "米";
 
-"kilometer" = "公里";
+"km" = "公里";
 
 "kilometers_per_hour" = "公里每小时";
 
-"mile" = "英里";
+"mi" = "英里";
 
 /* A unit of measure */
-"foot" = "英尺";
+"ft" = "英尺";
 
 "miles_per_hour" = "英里每小时";
 

--- a/iphone/Maps/LocalizedStrings/zh-Hant.lproj/Localizable.strings
+++ b/iphone/Maps/LocalizedStrings/zh-Hant.lproj/Localizable.strings
@@ -765,16 +765,16 @@
 /* iOS Dialog for the case when the location permission is not granted */
 "location_services_disabled_3" = "3. 使用應用時選擇";
 
-"meter" = "公尺";
+"m" = "公尺";
 
-"kilometer" = "公里";
+"km" = "公里";
 
 "kilometers_per_hour" = "公里每小時";
 
-"mile" = "英哩";
+"mi" = "英哩";
 
 /* A unit of measure */
-"foot" = "英尺";
+"ft" = "英尺";
 
 "miles_per_hour" = "英哩每小時";
 

--- a/iphone/Maps/UI/Search/TableView/MWMSearchCommonCell.mm
+++ b/iphone/Maps/UI/Search/TableView/MWMSearchCommonCell.mm
@@ -8,7 +8,7 @@
 #include "geometry/mercator.hpp"
 
 #include "platform/localization.hpp"
-#include "platform/measurement_utils.hpp"
+#include "platform/distance.hpp"
 
 
 @interface MWMSearchCommonCell ()
@@ -69,12 +69,9 @@
   {
     if (result.HasPoint())
     {
-      auto const localizedUnits = platform::GetLocalizedDistanceUnits();
       distanceInMeters =
           mercator::DistanceOnEarth(lastLocation.mercator, result.GetFeatureCenter());
-      std::string distanceStr = measurement_utils::FormatDistanceWithLocalization(distanceInMeters,
-                                                                                  localizedUnits.m_high,
-                                                                                  localizedUnits.m_low);
+      std::string distanceStr = platform::Distance::CreateFormatted(distanceInMeters).ToString();
       self.distanceLabel.text = @(distanceStr.c_str());
     }
   }

--- a/map/framework.cpp
+++ b/map/framework.cpp
@@ -1401,7 +1401,7 @@ void Framework::FillSearchResultsMarks(SearchResultsIterT beg, SearchResultsIter
 
 bool Framework::GetDistanceAndAzimut(m2::PointD const & point,
                                      double lat, double lon, double north,
-                                     string & distance, double & azimut)
+                                     platform::Distance & distance, double & azimut)
 {
 #ifdef FIXED_LOCATION
   m_fixedPos.GetLat(lat);
@@ -1412,7 +1412,7 @@ bool Framework::GetDistanceAndAzimut(m2::PointD const & point,
   double const d = ms::DistanceOnEarth(lat, lon, mercator::YToLat(point.y), mercator::XToLon(point.x));
 
   // Distance may be less than 1.0
-  distance = measurement_utils::FormatDistance(d);
+  distance = platform::Distance::CreateFormatted(d);
 
   // We calculate azimuth even when distance is very short (d ~ 0),
   // because return value has 2 states (near me or far from me).

--- a/map/framework.hpp
+++ b/map/framework.hpp
@@ -46,6 +46,7 @@
 
 #include "platform/location.hpp"
 #include "platform/platform.hpp"
+#include "platform/distance.hpp"
 
 #include "routing/router.hpp"
 
@@ -470,12 +471,12 @@ public:
   /// Calculate distance and direction to POI for the given position.
   /// @param[in]  point             POI's position;
   /// @param[in]  lat, lon, north   Current position and heading from north;
-  /// @param[out] distance          Formatted distance string;
+  /// @param[out] distance          Distance to point from (lat, lon);
   /// @param[out] azimut            Azimut to point from (lat, lon);
   /// @return true  If the POI is near the current position (distance < 25 km);
   bool GetDistanceAndAzimut(m2::PointD const & point,
                             double lat, double lon, double north,
-                            std::string & distance, double & azimut);
+                            platform::Distance & distance, double & azimut);
 
   /// @name Manipulating with model view
   m2::PointD PtoG(m2::PointD const & p) const { return m_currentModelView.PtoG(p); }

--- a/map/routing_manager.cpp
+++ b/map/routing_manager.cpp
@@ -626,7 +626,7 @@ void RoutingManager::CreateRoadWarningMarks(RoadWarningsCollection && roadWarnin
         mark->SetIndex(static_cast<uint32_t>(i));
         mark->SetRoadWarningType(type);
         mark->SetFeatureId(routeInfo.m_featureId);
-        std::string distanceStr = measurement_utils::FormatDistance(routeInfo.m_distance);
+        std::string distanceStr = platform::Distance::CreateFormatted(routeInfo.m_distance).ToString();
         mark->SetDistance(distanceStr);
       }
     }

--- a/platform/CMakeLists.txt
+++ b/platform/CMakeLists.txt
@@ -11,6 +11,8 @@ set(SRC
   country_defines.hpp
   country_file.cpp
   country_file.hpp
+  distance.cpp
+  distance.hpp
   downloader_defines.hpp
   downloader_utils.cpp
   downloader_utils.hpp

--- a/platform/distance.cpp
+++ b/platform/distance.cpp
@@ -55,33 +55,11 @@ Distance MilesTo(double distance, Distance::Units units)
   }
 }
 
-Distance NauticalMilesTo(double distance, Distance::Units units)
-{
-  switch (units)
-  {
-  case Distance::Units::Meters:
-    return Distance(measurement_utils::NauticalMilesToMeters(distance), Distance::Units::Meters);
-  default: UNREACHABLE();
-  }
-}
-
-Distance InchesTo(double distance, Distance::Units units)
-{
-  switch (units)
-  {
-  case Distance::Units::Meters:
-    return Distance(measurement_utils::InchesToMeters(distance), Distance::Units::Meters);
-  default: UNREACHABLE();
-  }
-}
-
 double WithPrecision(double value, uint8_t precision)
 {
-  std::ostringstream ss;
-  ss << std::setprecision(precision) << std::fixed << value;
-  return std::atof(ss.str().c_str());
+  double const factor = std::pow(10, precision);
+  return std::round(value * factor) / factor;
 }
-
 }  // namespace
 
 Distance::Distance() : Distance(0.0) {}
@@ -111,8 +89,6 @@ Distance Distance::To(Distance::Units units) const
   case Units::Kilometers: return KilometersTo(m_distance, units);
   case Units::Feet: return FeetTo(m_distance, units);
   case Units::Miles: return MilesTo(m_distance, units);
-  case Units::NauticalMiles: return NauticalMilesTo(m_distance, units);
-  case Units::Inches: return InchesTo(m_distance, units);
   default: UNREACHABLE();
   }
 }
@@ -136,13 +112,10 @@ std::string Distance::GetDistanceString() const
   return os.str();
 }
 
-// LocalizedStrings are supported only on iOS (Android is broken)
+// LocalizedStrings for this case are supported only on iOS
 #if defined(OMIM_OS_IPHONE)
 std::string Distance::GetUnitsString() const
 {
-  ASSERT_NOT_EQUAL(m_units, Units::NauticalMiles, ("OSM-only units are not supported"));
-  ASSERT_NOT_EQUAL(m_units, Units::Inches, ("OSM-only units are not supported"));
-
   switch (m_units)
   {
   case Units::Meters: return GetLocalizedString("meter");
@@ -155,9 +128,6 @@ std::string Distance::GetUnitsString() const
 #else
 std::string Distance::GetUnitsString() const
 {
-  ASSERT_NOT_EQUAL(m_units, Units::NauticalMiles, ("OSM-only units are not supported"));
-  ASSERT_NOT_EQUAL(m_units, Units::Inches, ("OSM-only units are not supported"));
-
   switch (m_units)
   {
   case Units::Meters: return "m";
@@ -171,9 +141,6 @@ std::string Distance::GetUnitsString() const
 
 Distance Distance::GetFormattedDistance() const
 {
-  ASSERT_NOT_EQUAL(m_units, Units::NauticalMiles, ("OSM-only units are not supported"));
-  ASSERT_NOT_EQUAL(m_units, Units::Inches, ("OSM-only units are not supported"));
-
   double constexpr roundingThreshold = 100.0;
   double constexpr highUnitThreshold = 1000.0;
 
@@ -238,8 +205,6 @@ std::string DebugPrint(Distance::Units units)
   case Distance::Units::Kilometers: return "Distance::Units::Kilometers";
   case Distance::Units::Feet: return "Distance::Units::Feet";
   case Distance::Units::Miles: return "Distance::Units::Miles";
-  case Distance::Units::NauticalMiles: return "Distance::Units::NauticalMiles";
-  case Distance::Units::Inches: return "Distance::Units::Inches";
   default: UNREACHABLE();
   }
 }

--- a/platform/distance.cpp
+++ b/platform/distance.cpp
@@ -89,8 +89,6 @@ Distance Distance::CreateAltitudeFormatted(double meters)
   return elevation;
 }
 
-bool Distance::IsValid() const { return m_distance >= 0.0; }
-
 bool Distance::IsLowUnits() const { return m_units == Units::Meters || m_units == Units::Feet; }
 
 bool Distance::IsHighUnits() const { return !IsLowUnits(); }
@@ -129,34 +127,21 @@ std::string Distance::GetDistanceString() const
   return os.str();
 }
 
-#if defined(OMIM_OS_IPHONE) || defined(OMIM_OS_ANDROID)
 std::string Distance::GetUnitsString() const
 {
   switch (m_units)
   {
-  case Units::Meters: return GetLocalizedString("meter");
-  case Units::Kilometers: return GetLocalizedString("kilometer");
-  case Units::Feet: return GetLocalizedString("foot");
-  case Units::Miles: return GetLocalizedString("mile");
+  case Units::Meters: return GetLocalizedString("m");
+  case Units::Kilometers: return GetLocalizedString("km");
+  case Units::Feet: return GetLocalizedString("ft");
+  case Units::Miles: return GetLocalizedString("mi");
   default: UNREACHABLE();
   }
 }
-#else
-std::string Distance::GetUnitsString() const
-{
-  switch (m_units)
-  {
-  case Units::Meters: return "m";
-  case Units::Kilometers: return "km";
-  case Units::Feet: return "ft";
-  case Units::Miles: return "mi";
-  default: UNREACHABLE();
-  }
-}
-#endif
 
 Distance Distance::GetFormattedDistance() const
 {
+  ASSERT_GREATER_OR_EQUAL(m_distance, 0.0, ("Distance is not valid: ", *this));
   Distance newDistance = *this;
   int precision = 0;
 
@@ -197,9 +182,6 @@ Distance Distance::GetFormattedDistance() const
 
 std::string Distance::ToString() const
 {
-  if (!IsValid())
-    return "";
-
   return GetDistanceString() + " " + GetUnitsString();
 }
 

--- a/platform/distance.cpp
+++ b/platform/distance.cpp
@@ -1,0 +1,246 @@
+#include "distance.hpp"
+
+#include "platform/localization.hpp"
+#include "platform/measurement_utils.hpp"
+
+#include "base/assert.hpp"
+
+namespace platform
+{
+namespace
+{
+Distance MetersTo(double distance, Distance::Units units)
+{
+  switch (units)
+  {
+  case Distance::Units::Kilometers: return Distance(distance / 1000, Distance::Units::Kilometers);
+  case Distance::Units::Feet:
+    return Distance(measurement_utils::MetersToFeet(distance), Distance::Units::Feet);
+  case Distance::Units::Miles:
+    return Distance(measurement_utils::MetersToMiles(distance), Distance::Units::Miles);
+  default: UNREACHABLE();
+  }
+}
+
+Distance KilometersTo(double distance, Distance::Units units)
+{
+  return MetersTo(distance * 1000, units);
+}
+
+Distance FeetTo(double distance, Distance::Units units)
+{
+  switch (units)
+  {
+  case Distance::Units::Meters:
+    return Distance(measurement_utils::FeetToMeters(distance), Distance::Units::Meters);
+  case Distance::Units::Kilometers:
+    return Distance(measurement_utils::FeetToMeters(distance) / 1000, Distance::Units::Kilometers);
+  case Distance::Units::Miles:
+    return Distance(measurement_utils::FeetToMiles(distance), Distance::Units::Miles);
+  default: UNREACHABLE();
+  }
+}
+
+Distance MilesTo(double distance, Distance::Units units)
+{
+  switch (units)
+  {
+  case Distance::Units::Meters:
+    return Distance(measurement_utils::MilesToMeters(distance), Distance::Units::Meters);
+  case Distance::Units::Kilometers:
+    return Distance(measurement_utils::MilesToMeters(distance) / 1000, Distance::Units::Kilometers);
+  case Distance::Units::Feet:
+    return Distance(measurement_utils::MilesToFeet(distance), Distance::Units::Feet);
+  default: UNREACHABLE();
+  }
+}
+
+Distance NauticalMilesTo(double distance, Distance::Units units)
+{
+  switch (units)
+  {
+  case Distance::Units::Meters:
+    return Distance(measurement_utils::NauticalMilesToMeters(distance), Distance::Units::Meters);
+  default: UNREACHABLE();
+  }
+}
+
+Distance InchesTo(double distance, Distance::Units units)
+{
+  switch (units)
+  {
+  case Distance::Units::Meters:
+    return Distance(measurement_utils::InchesToMeters(distance), Distance::Units::Meters);
+  default: UNREACHABLE();
+  }
+}
+
+double WithPrecision(double value, uint8_t precision)
+{
+  std::ostringstream ss;
+  ss << std::setprecision(precision) << std::fixed << value;
+  return std::atof(ss.str().c_str());
+}
+
+}  // namespace
+
+Distance::Distance() : Distance(0.0) {}
+
+Distance::Distance(double distanceInMeters) : Distance(distanceInMeters, Units::Meters) {}
+
+Distance::Distance(double distance, platform::Distance::Units units)
+  : m_distance(distance), m_units(units)
+{
+}
+
+Distance Distance::CreateFormatted(double distanceInMeters)
+{
+  return Distance(distanceInMeters).ToPlatformUnitsFormatted();
+}
+
+bool Distance::IsValid() const { return m_distance > std::numeric_limits<double>::epsilon(); }
+
+Distance Distance::To(Distance::Units units) const
+{
+  if (m_units == units)
+    return *this;
+
+  switch (m_units)
+  {
+  case Units::Meters: return MetersTo(m_distance, units);
+  case Units::Kilometers: return KilometersTo(m_distance, units);
+  case Units::Feet: return FeetTo(m_distance, units);
+  case Units::Miles: return MilesTo(m_distance, units);
+  case Units::NauticalMiles: return NauticalMilesTo(m_distance, units);
+  case Units::Inches: return InchesTo(m_distance, units);
+  default: UNREACHABLE();
+  }
+}
+
+Distance Distance::ToPlatformUnitsFormatted() const
+{
+  return To(measurement_utils::GetMeasurementUnits() == measurement_utils::Units::Metric
+                ? Units::Meters
+                : Units::Feet)
+      .GetFormattedDistance();
+}
+
+double Distance::GetDistance() const { return m_distance; }
+
+Distance::Units Distance::GetUnits() const { return m_units; }
+
+std::string Distance::GetDistanceString() const
+{
+  std::ostringstream os;
+  os << std::defaultfloat << m_distance;
+  return os.str();
+}
+
+// LocalizedStrings are supported only on iOS (Android is broken)
+#if defined(OMIM_OS_IPHONE)
+std::string Distance::GetUnitsString() const
+{
+  ASSERT_NOT_EQUAL(m_units, Units::NauticalMiles, ("OSM-only units are not supported"));
+  ASSERT_NOT_EQUAL(m_units, Units::Inches, ("OSM-only units are not supported"));
+
+  switch (m_units)
+  {
+  case Units::Meters: return GetLocalizedString("meter");
+  case Units::Kilometers: return GetLocalizedString("kilometer");
+  case Units::Feet: return GetLocalizedString("foot");
+  case Units::Miles: return GetLocalizedString("mile");
+  default: UNREACHABLE();
+  }
+}
+#else
+std::string Distance::GetUnitsString() const
+{
+  ASSERT_NOT_EQUAL(m_units, Units::NauticalMiles, ("OSM-only units are not supported"));
+  ASSERT_NOT_EQUAL(m_units, Units::Inches, ("OSM-only units are not supported"));
+
+  switch (m_units)
+  {
+  case Units::Meters: return "m";
+  case Units::Kilometers: return "km";
+  case Units::Feet: return "ft";
+  case Units::Miles: return "mi";
+  default: UNREACHABLE();
+  }
+}
+#endif
+
+Distance Distance::GetFormattedDistance() const
+{
+  ASSERT_NOT_EQUAL(m_units, Units::NauticalMiles, ("OSM-only units are not supported"));
+  ASSERT_NOT_EQUAL(m_units, Units::Inches, ("OSM-only units are not supported"));
+
+  double constexpr roundingThreshold = 100.0;
+  double constexpr highUnitThreshold = 1000.0;
+
+  double newDistance = m_distance;
+  Units newUnits = m_units;
+  int precision = 0;
+
+  if (newUnits == Units::Meters || newUnits == Units::Feet)
+  {
+    // Round distances over roundingThreshold units to roundingThreshold units, e.g. 112 -> 110,
+    // 998 -> 1000
+    if (newDistance > roundingThreshold)
+      newDistance = round(newDistance / 10) * 10;
+
+    if (newDistance >= highUnitThreshold)
+    {
+      switch (m_units)
+      {
+      case Units::Meters:
+        newUnits = Units::Kilometers;
+        newDistance /= 1000.0;
+        break;
+      case Units::Feet:
+        newUnits = Units::Miles;
+        newDistance /= 5280.0;
+        break;
+      default: UNREACHABLE();
+      }
+    }
+    else
+      precision = 1;
+
+    // For distances of 10.0 high units and over round to a whole number, e.g. 9.98 -> 10,
+    // 10.9 -> 11
+    if (newDistance >= 10.0)
+    {
+      newDistance = round(newDistance);
+      precision = 0;
+    }
+  }
+
+  if (newUnits == Units::Kilometers || newUnits == Units::Miles)
+  {
+    // Round distances over roundingThreshold units to roundingThreshold units, e.g. 112 -> 110,
+    // 998 -> 1000
+    if (newDistance > roundingThreshold)
+      newDistance = round(newDistance / 10) * 10;
+
+    precision = newDistance > 10.0 ? 0 : 1;
+  }
+
+  return Distance(WithPrecision(newDistance, precision), newUnits);
+}
+
+std::string Distance::ToString() const { return GetDistanceString() + " " + GetUnitsString(); }
+
+std::string DebugPrint(Distance::Units units)
+{
+  switch (units)
+  {
+  case Distance::Units::Meters: return "Distance::Units::Meters";
+  case Distance::Units::Kilometers: return "Distance::Units::Kilometers";
+  case Distance::Units::Feet: return "Distance::Units::Feet";
+  case Distance::Units::Miles: return "Distance::Units::Miles";
+  case Distance::Units::NauticalMiles: return "Distance::Units::NauticalMiles";
+  case Distance::Units::Inches: return "Distance::Units::Inches";
+  default: UNREACHABLE();
+  }
+}
+}  // namespace platform

--- a/platform/distance.hpp
+++ b/platform/distance.hpp
@@ -31,12 +31,11 @@ public:
   Distance(double distance, Units units);
 
   static Distance CreateFormatted(double distanceInMeters);
-  /// Creates formatted distance in low units.
+  /// Creates formatted distance in low units (to display altitude/elevation info).
   /// \example CreateAltitudeFormatted(10000) -> 32808 ft
-  /// \warning GetFormattedDistance() will transform it to the high units
+  /// \warning GetFormattedDistance() will transform it to high units
   static Distance CreateAltitudeFormatted(double meters);
 
-  bool IsValid() const;
   bool IsLowUnits() const;
   bool IsHighUnits() const;
 

--- a/platform/distance.hpp
+++ b/platform/distance.hpp
@@ -9,16 +9,17 @@ namespace platform
 class Distance
 {
 public:
+  /*!
+   * \warning The order of values below shall not be changed.
+   * \warning The values of Units shall be synchronized with values of Distance.Units enum in
+   * java (see app.organicmaps.util.Distance for details).
+   */
   enum class Units
   {
-    Meters = 1,
-    Kilometers = 2,
-    Feet = 3,
-    Miles = 4,
-
-    // OSM-only
-    NauticalMiles = 5,
-    Inches = 6
+    Meters = 0,
+    Kilometers = 1,
+    Feet = 2,
+    Miles = 3
   };
 
   Distance();
@@ -27,26 +28,26 @@ public:
 
   explicit Distance(double distance, Units units);
 
-  [[nodiscard]] static Distance CreateFormatted(double distanceInMeters);
+  static Distance CreateFormatted(double distanceInMeters);
 
   bool IsValid() const;
 
-  [[nodiscard]] Distance To(Units units) const;
-  [[nodiscard]] Distance ToPlatformUnitsFormatted() const;
+  Distance To(Units units) const;
+  Distance ToPlatformUnitsFormatted() const;
 
   double GetDistance() const;
   Units GetUnits() const;
 
-  [[nodiscard]] std::string GetDistanceString() const;
-  [[nodiscard]] std::string GetUnitsString() const;
+  std::string GetDistanceString() const;
+  std::string GetUnitsString() const;
 
   /// Formats distance in the following way:
   /// * rounds distances over 100 units to 10 units, e.g. 112 -> 110, 998 -> 1000
   /// * for distances of 10.0 high units and over rounds to a whole number, e.g. 9.98 -> 10, 10.9 -> 11
   /// * use high units for distances of 1000 units and over, e.g. 1000m -> 1.0km, 1290m -> 1.3km, 1000ft -> 0.2mi
-  [[nodiscard]] Distance GetFormattedDistance() const;
+  Distance GetFormattedDistance() const;
 
-  [[nodiscard]] std::string ToString() const;
+  std::string ToString() const;
 
 private:
   double m_distance;

--- a/platform/distance.hpp
+++ b/platform/distance.hpp
@@ -1,0 +1,57 @@
+#pragma once
+
+#include "platform/measurement_utils.hpp"
+
+#include <string>
+
+namespace platform
+{
+class Distance
+{
+public:
+  enum class Units
+  {
+    Meters = 1,
+    Kilometers = 2,
+    Feet = 3,
+    Miles = 4,
+
+    // OSM-only
+    NauticalMiles = 5,
+    Inches = 6
+  };
+
+  Distance();
+
+  explicit Distance(double distanceInMeters);
+
+  explicit Distance(double distance, Units units);
+
+  [[nodiscard]] static Distance CreateFormatted(double distanceInMeters);
+
+  bool IsValid() const;
+
+  [[nodiscard]] Distance To(Units units) const;
+  [[nodiscard]] Distance ToPlatformUnitsFormatted() const;
+
+  double GetDistance() const;
+  Units GetUnits() const;
+
+  [[nodiscard]] std::string GetDistanceString() const;
+  [[nodiscard]] std::string GetUnitsString() const;
+
+  /// Formats distance in the following way:
+  /// * rounds distances over 100 units to 10 units, e.g. 112 -> 110, 998 -> 1000
+  /// * for distances of 10.0 high units and over rounds to a whole number, e.g. 9.98 -> 10, 10.9 -> 11
+  /// * use high units for distances of 1000 units and over, e.g. 1000m -> 1.0km, 1290m -> 1.3km, 1000ft -> 0.2mi
+  [[nodiscard]] Distance GetFormattedDistance() const;
+
+  [[nodiscard]] std::string ToString() const;
+
+private:
+  double m_distance;
+  Units m_units;
+};
+
+std::string DebugPrint(Distance::Units units);
+}  // namespace platform

--- a/platform/distance.hpp
+++ b/platform/distance.hpp
@@ -13,6 +13,8 @@ public:
    * \warning The order of values below shall not be changed.
    * \warning The values of Units shall be synchronized with values of Distance.Units enum in
    * java (see app.organicmaps.util.Distance for details).
+   * \warning The values of Units shall be synchronized with values of unitLength func in
+   * swift (see iphone/Maps/Classes/CarPlay/Templates Data/RouteInfo.swift for details).
    */
   enum class Units
   {
@@ -26,11 +28,17 @@ public:
 
   explicit Distance(double distanceInMeters);
 
-  explicit Distance(double distance, Units units);
+  Distance(double distance, Units units);
 
   static Distance CreateFormatted(double distanceInMeters);
+  /// Creates formatted distance in low units.
+  /// \example CreateAltitudeFormatted(10000) -> 32808 ft
+  /// \warning GetFormattedDistance() will transform it to the high units
+  static Distance CreateAltitudeFormatted(double meters);
 
   bool IsValid() const;
+  bool IsLowUnits() const;
+  bool IsHighUnits() const;
 
   Distance To(Units units) const;
   Distance ToPlatformUnitsFormatted() const;
@@ -48,6 +56,8 @@ public:
   Distance GetFormattedDistance() const;
 
   std::string ToString() const;
+
+  friend std::string DebugPrint(Distance const & d) { return d.ToString(); }
 
 private:
   double m_distance;

--- a/platform/localization.cpp
+++ b/platform/localization.cpp
@@ -18,11 +18,11 @@ enum class MeasurementType
 
 const LocalizedUnits & GetLocalizedUnits(measurement_utils::Units units, MeasurementType measurementType)
 {
-  static LocalizedUnits UnitsLenghImperial = {GetLocalizedString("foot"), GetLocalizedString("mile")};
-  static LocalizedUnits UnitsLenghMetric = {GetLocalizedString("meter"), GetLocalizedString("kilometer")};
+  static LocalizedUnits UnitsLenghImperial = {GetLocalizedString("ft"), GetLocalizedString("mi")};
+  static LocalizedUnits UnitsLenghMetric = {GetLocalizedString("m"), GetLocalizedString("km")};
 
-  static LocalizedUnits UnitsSpeedImperial = {GetLocalizedString("foot"), GetLocalizedString("miles_per_hour")};
-  static LocalizedUnits UnitsSpeedMetric = {GetLocalizedString("meter"), GetLocalizedString("kilometers_per_hour")};
+  static LocalizedUnits UnitsSpeedImperial = {GetLocalizedString("ft"), GetLocalizedString("miles_per_hour")};
+  static LocalizedUnits UnitsSpeedMetric = {GetLocalizedString("m"), GetLocalizedString("kilometers_per_hour")};
 
   switch (measurementType)
   {

--- a/platform/measurement_utils.hpp
+++ b/platform/measurement_utils.hpp
@@ -21,6 +21,7 @@ Units GetMeasurementUnits();
 
 inline double MetersToMiles(double m) { return m * 0.000621371192; }
 inline double MilesToMeters(double mi) { return mi * 1609.344; }
+inline double MilesToFeet(double mi) { return mi * 5280.0; }
 inline double MiphToKmph(double miph) { return MilesToMeters(miph) / 1000.0; }
 inline double KmphToMiph(double kmph) { return MetersToMiles(kmph * 1000.0); }
 inline double MpsToKmph(double mps) { return mps * 3.6; }

--- a/platform/measurement_utils.hpp
+++ b/platform/measurement_utils.hpp
@@ -27,7 +27,7 @@ inline double KmphToMiph(double kmph) { return MetersToMiles(kmph * 1000.0); }
 inline double MpsToKmph(double mps) { return mps * 3.6; }
 inline double MetersToFeet(double m) { return m * 3.2808399; }
 inline double FeetToMeters(double ft) { return ft * 0.3048; }
-inline double FeetToMiles(double ft) { return ft * 5280; }
+inline double FeetToMiles(double ft) { return ft * 0.00018939; }
 inline double InchesToMeters(double in) { return in / 39.370; }
 inline double NauticalMilesToMeters(double nmi) { return nmi * 1852; }
 inline double constexpr KmphToMps(double kmph) { return kmph * 1000 / 3600; }
@@ -35,16 +35,6 @@ inline double constexpr KmphToMps(double kmph) { return kmph * 1000 / 3600; }
 double ToSpeedKmPH(double speed, Units units);
 double MpsToUnits(double mps, Units units);
 
-/// Takes into an account user settings [metric, imperial]
-/// @param[in] m meters
-/// @param[out] res formatted std::string for search
-/// @return should be direction arrow drawed? false if distance is to small (< 1.0)
-std::string FormatDistance(double distanceInMeters);
-std::string FormatDistanceWithLocalization(double m, OptionalStringRef high, OptionalStringRef low);
-
-/// @return Localized meters or feets string for altitude, depending on current measurement units.
-std::string FormatAltitude(double altitudeInMeters);
-std::string FormatAltitudeWithLocalization(double altitudeInMeters, OptionalStringRef localizedUnits);
 /// @return Speed value string (without suffix) in km/h for Metric and in mph for Imperial.
 std::string FormatSpeedNumeric(double metersPerSecond, Units units);
 

--- a/platform/measurement_utils.hpp
+++ b/platform/measurement_utils.hpp
@@ -2,13 +2,10 @@
 
 #include "geometry/point2d.hpp"
 
-#include <optional>
 #include <string>
 
 namespace measurement_utils
 {
-using OptionalStringRef = std::optional<std::string> const &;
-
 enum class Units
 {
   Metric = 0,

--- a/platform/platform_tests/CMakeLists.txt
+++ b/platform/platform_tests/CMakeLists.txt
@@ -3,6 +3,7 @@ project(platform_tests)
 set(SRC
   apk_test.cpp
   country_file_tests.cpp
+  distance_tests.cpp
   downloader_tests/downloader_test.cpp
   downloader_utils_tests.cpp
   get_text_by_id_tests.cpp

--- a/platform/platform_tests/distance_tests.cpp
+++ b/platform/platform_tests/distance_tests.cpp
@@ -2,15 +2,13 @@
 
 #include "platform/distance.hpp"
 
-using namespace std;
-
 namespace platform
 {
 UNIT_TEST(Distance_IsValid)
 {
   TEST_EQUAL(Distance(0.0).IsValid(), false, ());
   TEST_EQUAL(Distance(-1).IsValid(), false, ());
-  TEST_EQUAL(Distance(numeric_limits<double>::epsilon()).IsValid(), false, ());
+  TEST_EQUAL(Distance(std::numeric_limits<double>::epsilon()).IsValid(), false, ());
   TEST_EQUAL(Distance(1).IsValid(), true, ());
   TEST_EQUAL(Distance(1243.2, Distance::Units::Feet).IsValid(), true, ());
 }
@@ -27,9 +25,6 @@ UNIT_TEST(Distance_GetUnits)
              ());
   TEST_EQUAL(Distance(1234, Distance::Units::Feet).GetUnits(), Distance::Units::Feet, ());
   TEST_EQUAL(Distance(1234, Distance::Units::Miles).GetUnits(), Distance::Units::Miles, ());
-  TEST_EQUAL(Distance(1234, Distance::Units::NauticalMiles).GetUnits(),
-             Distance::Units::NauticalMiles, ());
-  TEST_EQUAL(Distance(1234, Distance::Units::Inches).GetUnits(), Distance::Units::Inches, ());
 }
 
 UNIT_TEST(Distance_GetUnitsString)

--- a/platform/platform_tests/distance_tests.cpp
+++ b/platform/platform_tests/distance_tests.cpp
@@ -1,0 +1,132 @@
+#include "testing/testing.hpp"
+
+#include "platform/distance.hpp"
+
+using namespace std;
+
+namespace platform
+{
+UNIT_TEST(Distance_IsValid)
+{
+  TEST_EQUAL(Distance(0.0).IsValid(), false, ());
+  TEST_EQUAL(Distance(-1).IsValid(), false, ());
+  TEST_EQUAL(Distance(numeric_limits<double>::epsilon()).IsValid(), false, ());
+  TEST_EQUAL(Distance(1).IsValid(), true, ());
+  TEST_EQUAL(Distance(1243.2, Distance::Units::Feet).IsValid(), true, ());
+}
+
+UNIT_TEST(Distance_Conversions)
+{
+  // TODO
+}
+
+UNIT_TEST(Distance_GetUnits)
+{
+  TEST_EQUAL(Distance(1234).GetUnits(), Distance::Units::Meters, ());
+  TEST_EQUAL(Distance(1234, Distance::Units::Kilometers).GetUnits(), Distance::Units::Kilometers,
+             ());
+  TEST_EQUAL(Distance(1234, Distance::Units::Feet).GetUnits(), Distance::Units::Feet, ());
+  TEST_EQUAL(Distance(1234, Distance::Units::Miles).GetUnits(), Distance::Units::Miles, ());
+  TEST_EQUAL(Distance(1234, Distance::Units::NauticalMiles).GetUnits(),
+             Distance::Units::NauticalMiles, ());
+  TEST_EQUAL(Distance(1234, Distance::Units::Inches).GetUnits(), Distance::Units::Inches, ());
+}
+
+UNIT_TEST(Distance_GetUnitsString)
+{
+  TEST_EQUAL(Distance(1234).GetUnitsString(), "m", ());
+  TEST_EQUAL(Distance(1234, Distance::Units::Meters).GetUnitsString(), "m", ());
+  TEST_EQUAL(Distance(1234, Distance::Units::Kilometers).GetUnitsString(), "km", ());
+  TEST_EQUAL(Distance(1234, Distance::Units::Feet).GetUnitsString(), "ft", ());
+  TEST_EQUAL(Distance(1234, Distance::Units::Miles).GetUnitsString(), "mi", ());
+}
+
+UNIT_TEST(Distance_FormattedDistance)
+{
+  struct TestData
+  {
+    Distance distance;
+    double formattedDistance;
+    Distance::Units formattedUnits;
+    std::string formattedDistanceString;
+    std::string formattedString;
+  };
+  // clang-format off
+  std::vector<TestData> testData{
+    // From Meters to Meters
+    {Distance(0,       Distance::Units::Meters),     0,    Distance::Units::Meters,     "0",    "0 m"},
+    {Distance(1,       Distance::Units::Meters),     1,    Distance::Units::Meters,     "1",    "1 m"},
+    {Distance(1.234,   Distance::Units::Meters),     1.2,  Distance::Units::Meters,     "1.2",  "1.2 m"},
+    {Distance(9.99,    Distance::Units::Meters),     10,   Distance::Units::Meters,     "10",   "10 m"},
+    {Distance(10.01,   Distance::Units::Meters),     10,   Distance::Units::Meters,     "10",   "10 m"},
+    {Distance(64.2,    Distance::Units::Meters),     64,   Distance::Units::Meters,     "64",   "64 m"},
+
+    // From Kilometers to Kilometers
+    {Distance(0,       Distance::Units::Kilometers), 0,    Distance::Units::Kilometers, "0",    "0 km"},
+    {Distance(1.234,   Distance::Units::Kilometers), 1.2,  Distance::Units::Kilometers, "1.2",  "1.2 km"},
+    {Distance(10,      Distance::Units::Kilometers), 10,   Distance::Units::Kilometers, "10",   "10 km"},
+    {Distance(99.99,   Distance::Units::Kilometers), 100,  Distance::Units::Kilometers, "100",  "100 km"},
+    {Distance(100.01,  Distance::Units::Kilometers), 100,  Distance::Units::Kilometers, "100",  "100 km"},
+    {Distance(1000,    Distance::Units::Kilometers), 1000, Distance::Units::Kilometers, "1000", "1000 km"},
+    {Distance(1234,    Distance::Units::Kilometers), 1230, Distance::Units::Kilometers, "1230", "1230 km"},
+
+    // From Feet to Feet
+    {Distance(0,       Distance::Units::Feet),       0,    Distance::Units::Feet,       "0",    "0 ft"},
+    {Distance(1,       Distance::Units::Feet),       1,    Distance::Units::Feet,       "1",    "1 ft"},
+    {Distance(9.99,    Distance::Units::Feet),       10,   Distance::Units::Feet,       "10",   "10 ft"},
+    {Distance(10.01,   Distance::Units::Feet),       10,   Distance::Units::Feet,       "10",   "10 ft"},
+
+    // From Miles to Miles
+    {Distance(0,       Distance::Units::Miles),      0,    Distance::Units::Miles,      "0",    "0 mi"},
+    {Distance(1,       Distance::Units::Miles),      1,    Distance::Units::Miles,      "1",    "1 mi"},
+    {Distance(1.234,   Distance::Units::Miles),      1.2,  Distance::Units::Miles,      "1.2",  "1.2 mi"},
+    {Distance(9.99,    Distance::Units::Miles),      10,   Distance::Units::Miles,      "10",   "10 mi"},
+    {Distance(10.01,   Distance::Units::Miles),      10,   Distance::Units::Miles,      "10",   "10 mi"},
+    {Distance(998,     Distance::Units::Miles),      1000, Distance::Units::Miles,      "1000", "1000 mi"},
+    {Distance(999,     Distance::Units::Miles),      1000, Distance::Units::Miles,      "1000", "1000 mi"},
+
+    // From Meters to Kilometers
+    {Distance(999,     Distance::Units::Meters),     1,    Distance::Units::Kilometers, "1",    "1 km"},
+    {Distance(1000,    Distance::Units::Meters),     1,    Distance::Units::Kilometers, "1",    "1 km"},
+    {Distance(1100,    Distance::Units::Meters),     1.1,  Distance::Units::Kilometers, "1.1",  "1.1 km"},
+    {Distance(1500,    Distance::Units::Meters),     1.5,  Distance::Units::Kilometers, "1.5",  "1.5 km"},
+    {Distance(287'386, Distance::Units::Meters),     290,  Distance::Units::Kilometers, "290",  "290 km"},
+
+    // From Feet to Miles
+    {Distance(999,     Distance::Units::Feet),       0.2,  Distance::Units::Miles,      "0.2",  "0.2 mi"},
+    {Distance(1000,    Distance::Units::Feet),       0.2,  Distance::Units::Miles,      "0.2",  "0.2 mi"},
+    {Distance(1150,    Distance::Units::Feet),       0.2,  Distance::Units::Miles,      "0.2",  "0.2 mi"},
+    {Distance(5280,    Distance::Units::Feet),       1,    Distance::Units::Miles,      "1",    "1 mi"},
+    {Distance(7920,    Distance::Units::Feet),       1.5,  Distance::Units::Miles,      "1.5",  "1.5 mi"},
+    {Distance(10560,   Distance::Units::Feet),       2,    Distance::Units::Miles,      "2",    "2 mi"},
+    {Distance(100'000, Distance::Units::Feet),       19,   Distance::Units::Miles,      "19",   "19 mi"},
+
+    // Rounding checks: 112 -> 110, 998 -> 1000
+    {Distance(115,     Distance::Units::Kilometers), 120,  Distance::Units::Kilometers, "120",  "120 km"},
+    {Distance(130,     Distance::Units::Kilometers), 130,  Distance::Units::Kilometers, "130",  "130 km"},
+    {Distance(980,     Distance::Units::Kilometers), 980,  Distance::Units::Kilometers, "980",  "980 km"},
+    {Distance(1050,    Distance::Units::Kilometers), 1050, Distance::Units::Kilometers, "1050", "1050 km"},
+
+    {Distance(105,     Distance::Units::Miles),      110,  Distance::Units::Miles,      "110",  "110 mi"},
+    {Distance(145,     Distance::Units::Miles),      150,  Distance::Units::Miles,      "150",  "150 mi"},
+    {Distance(1150,    Distance::Units::Miles),      1150, Distance::Units::Miles,      "1150", "1150 mi"},
+
+    {Distance(95,      Distance::Units::Feet),       95,   Distance::Units::Feet,       "95",   "95 ft"},
+    {Distance(125,     Distance::Units::Feet),       130,  Distance::Units::Feet,       "130",  "130 ft"},
+    {Distance(991,     Distance::Units::Feet),       990,  Distance::Units::Feet,       "990",  "990 ft"},
+  };
+  // clang-format on
+  for (TestData const & data : testData)
+  {
+    Distance const formattedDistance = data.distance.GetFormattedDistance();
+    // Run two times to verify that nothing breaks after second format
+    for (const auto & d : {formattedDistance, formattedDistance.GetFormattedDistance()})
+    {
+      TEST_EQUAL(d.GetDistance(), data.formattedDistance, ());
+      TEST_EQUAL(d.GetUnits(), data.formattedUnits, ());
+      TEST_EQUAL(d.GetDistanceString(), data.formattedDistanceString, ());
+      TEST_EQUAL(d.ToString(), data.formattedString, ());
+    }
+  }
+}
+}  // namespace platform

--- a/platform/platform_tests/distance_tests.cpp
+++ b/platform/platform_tests/distance_tests.cpp
@@ -1,28 +1,210 @@
 #include "testing/testing.hpp"
 
 #include "platform/distance.hpp"
+#include "platform/measurement_utils.hpp"
+#include "platform/settings.hpp"
 
 namespace platform
 {
+struct ScopedSettings
+{
+  /// Saves/restores previous units and sets new units for a scope.
+  explicit ScopedSettings(measurement_utils::Units newUnits)
+    : m_oldUnits(measurement_utils::Units::Metric)
+  {
+    m_wasSet = settings::Get(settings::kMeasurementUnits, m_oldUnits);
+    settings::Set(settings::kMeasurementUnits, newUnits);
+  }
+
+  ~ScopedSettings()
+  {
+    if (m_wasSet)
+      settings::Set(settings::kMeasurementUnits, m_oldUnits);
+    else
+      settings::Delete(settings::kMeasurementUnits);
+  }
+
+  bool m_wasSet;
+  measurement_utils::Units m_oldUnits;
+};
+
+UNIT_TEST(Distance_CreateFormatted)
+{
+  {
+    ScopedSettings guard(measurement_utils::Units::Metric);
+
+    Distance d = Distance::CreateFormatted(100);
+    TEST_EQUAL(d.GetUnits(), Distance::Units::Meters, ());
+    TEST_ALMOST_EQUAL_ULPS(d.GetDistance(), 100.0, ());
+    TEST_EQUAL(d.GetDistanceString(), "100", ());
+    TEST_EQUAL(d.ToString(), "100 m", ());
+  }
+  {
+    ScopedSettings guard(measurement_utils::Units::Imperial);
+
+    Distance d = Distance::CreateFormatted(100);
+    TEST_EQUAL(d.GetUnits(), Distance::Units::Feet, ());
+    TEST_ALMOST_EQUAL_ULPS(d.GetDistance(), 330.0, ());
+    TEST_EQUAL(d.GetDistanceString(), "330", ());
+    TEST_EQUAL(d.ToString(), "330 ft", ());
+  }
+}
+
+UNIT_TEST(Distance_CreateAltitudeFormatted)
+{
+  {
+    ScopedSettings guard(measurement_utils::Units::Metric);
+
+    Distance d = Distance::CreateAltitudeFormatted(5);
+    TEST_EQUAL(d.GetUnits(), Distance::Units::Meters, ());
+    TEST_ALMOST_EQUAL_ULPS(d.GetDistance(), 5.0, ());
+    TEST_EQUAL(d.GetDistanceString(), "5", ());
+    TEST_EQUAL(d.ToString(), "5 m", ());
+  }
+  {
+    ScopedSettings guard(measurement_utils::Units::Imperial);
+
+    Distance d = Distance::CreateAltitudeFormatted(10000);
+    TEST_EQUAL(d.GetUnits(), Distance::Units::Feet, ());
+    TEST_ALMOST_EQUAL_ULPS(d.GetDistance(), 32808.0, ());
+    TEST_EQUAL(d.GetDistanceString(), "32808", ());
+    TEST_EQUAL(d.ToString(), "32808 ft", ());
+  }
+}
+
 UNIT_TEST(Distance_IsValid)
 {
-  TEST_EQUAL(Distance(0.0).IsValid(), false, ());
+  TEST_EQUAL(Distance(0.0).IsValid(), true, ());
   TEST_EQUAL(Distance(-1).IsValid(), false, ());
-  TEST_EQUAL(Distance(std::numeric_limits<double>::epsilon()).IsValid(), false, ());
+  TEST_EQUAL(Distance(std::numeric_limits<double>::epsilon()).IsValid(), true, ());
   TEST_EQUAL(Distance(1).IsValid(), true, ());
   TEST_EQUAL(Distance(1243.2, Distance::Units::Feet).IsValid(), true, ());
 }
 
-UNIT_TEST(Distance_Conversions)
+UNIT_TEST(Distance_IsLowUnits)
 {
-  // TODO
+  TEST_EQUAL(Distance(0.0, Distance::Units::Meters).IsLowUnits(), true, ());
+  TEST_EQUAL(Distance(0.0, Distance::Units::Feet).IsLowUnits(), true, ());
+  TEST_EQUAL(Distance(0.0, Distance::Units::Kilometers).IsLowUnits(), false, ());
+  TEST_EQUAL(Distance(0.0, Distance::Units::Miles).IsLowUnits(), false, ());
+}
+
+UNIT_TEST(Distance_IsHighUnits)
+{
+  TEST_EQUAL(Distance(0.0, Distance::Units::Meters).IsHighUnits(), false, ());
+  TEST_EQUAL(Distance(0.0, Distance::Units::Feet).IsHighUnits(), false, ());
+  TEST_EQUAL(Distance(0.0, Distance::Units::Kilometers).IsHighUnits(), true, ());
+  TEST_EQUAL(Distance(0.0, Distance::Units::Miles).IsHighUnits(), true, ());
+}
+
+UNIT_TEST(Distance_To)
+{
+  using Units = Distance::Units;
+
+  struct TestData
+  {
+    double initialDistance;
+    Distance::Units initialUnits;
+    Distance::Units to;
+    double newDistance;
+    Distance::Units newUnits;
+  };
+  // clang-format off
+  std::vector<TestData> testData{
+    {0.1,       Units::Meters,     Units::Feet,       0,    Units::Feet},
+    {0.3,       Units::Meters,     Units::Feet,       1,    Units::Feet},
+    {0.3048,    Units::Meters,     Units::Feet,       1,    Units::Feet},
+    {0.4573,    Units::Meters,     Units::Feet,       2,    Units::Feet},
+    {0.9,       Units::Meters,     Units::Feet,       3,    Units::Feet},
+    {3,         Units::Meters,     Units::Feet,       10,   Units::Feet},
+    {30.17,     Units::Meters,     Units::Feet,       99,   Units::Feet},
+    {30.33,     Units::Meters,     Units::Feet,       100,  Units::Feet},
+    {30.49,     Units::Meters,     Units::Feet,       100,  Units::Feet},
+    {33.5,      Units::Meters,     Units::Feet,       110,  Units::Feet},
+    {302,       Units::Meters,     Units::Feet,       990,  Units::Feet},
+    {304.7,     Units::Meters,     Units::Feet,       0.2,  Units::Miles},
+    {304.8,     Units::Meters,     Units::Feet,       0.2,  Units::Miles},
+    {402.3,     Units::Meters,     Units::Feet,       0.2,  Units::Miles},
+    {402.4,     Units::Meters,     Units::Feet,       0.3,  Units::Miles},
+    {482.8,     Units::Meters,     Units::Feet,       0.3,  Units::Miles},
+    {1609.3,    Units::Meters,     Units::Feet,       1,    Units::Miles},
+    {1610,      Units::Meters,     Units::Feet,       1,    Units::Miles},
+    {1770,      Units::Meters,     Units::Feet,       1.1,  Units::Miles},
+    {15933,     Units::Meters,     Units::Feet,       9.9,  Units::Miles},
+    {16093,     Units::Meters,     Units::Feet,       10,   Units::Miles},
+    {16093.5,   Units::Meters,     Units::Feet,       10,   Units::Miles},
+    {16898.113, Units::Meters,     Units::Feet,       11,   Units::Miles},
+    {16898.113, Units::Meters,     Units::Kilometers, 17,   Units::Kilometers},
+    {302,       Units::Meters,     Units::Miles,      0.2,  Units::Miles},
+    {0.1,       Units::Kilometers, Units::Meters,     100,  Units::Meters},
+    {12,        Units::Kilometers, Units::Feet,       7.5,  Units::Miles},
+    {0.1,       Units::Kilometers, Units::Feet,       330,  Units::Feet},
+    {110,       Units::Feet,       Units::Meters,     34,   Units::Meters},
+    {1100,      Units::Feet,       Units::Kilometers, 0.3,  Units::Kilometers},
+    {1100,      Units::Feet,       Units::Meters,     340,  Units::Meters},
+    {1100,      Units::Feet,       Units::Miles,      0.2,  Units::Miles},
+    {0.2,       Units::Miles,      Units::Meters,     320,  Units::Meters},
+    {11,        Units::Miles,      Units::Meters,     18,   Units::Kilometers},
+    {11,        Units::Miles,      Units::Kilometers, 18,   Units::Kilometers},
+    {0.1,       Units::Miles,      Units::Feet,       530,  Units::Feet},
+  };
+  // clang-format on
+  for (TestData const & data : testData)
+  {
+    Distance const formattedDistance =
+        Distance(data.initialDistance, data.initialUnits).To(data.to).GetFormattedDistance();
+    TEST_ALMOST_EQUAL_ULPS(formattedDistance.GetDistance(), data.newDistance, (formattedDistance.ToString()));
+    TEST_EQUAL(formattedDistance.GetUnits(), data.newUnits, (formattedDistance.ToString()));
+  }
+}
+
+UNIT_TEST(Distance_ToPlatformUnitsFormatted)
+{
+  {
+    ScopedSettings guard(measurement_utils::Units::Metric);
+
+    Distance d{11, Distance::Units::Feet};
+    Distance newDistance = d.ToPlatformUnitsFormatted();
+
+    TEST_EQUAL(newDistance.GetUnits(), Distance::Units::Meters, (d.ToString()));
+    TEST_ALMOST_EQUAL_ULPS(newDistance.GetDistance(), 3.0, (d.ToString()));
+    TEST_EQUAL(newDistance.GetDistanceString(), "3", (d.ToString()));
+    TEST_EQUAL(newDistance.ToString(), "3 m", (d.ToString()));
+
+    d = Distance{11, Distance::Units::Kilometers};
+    newDistance = d.ToPlatformUnitsFormatted();
+
+    TEST_EQUAL(newDistance.GetUnits(), Distance::Units::Kilometers, (d.ToString()));
+    TEST_ALMOST_EQUAL_ULPS(newDistance.GetDistance(), 11.0, (d.ToString()));
+    TEST_EQUAL(newDistance.GetDistanceString(), "11", (d.ToString()));
+    TEST_EQUAL(newDistance.ToString(), "11 km", (d.ToString()));
+  }
+
+  {
+    ScopedSettings guard(measurement_utils::Units::Imperial);
+
+    Distance d{11, Distance::Units::Feet};
+    Distance newDistance = d.ToPlatformUnitsFormatted();
+
+    TEST_EQUAL(newDistance.GetUnits(), Distance::Units::Feet, (d.ToString()));
+    TEST_ALMOST_EQUAL_ULPS(newDistance.GetDistance(), 11.0, (d.ToString()));
+    TEST_EQUAL(newDistance.GetDistanceString(), "11", (d.ToString()));
+    TEST_EQUAL(newDistance.ToString(), "11 ft", (d.ToString()));
+
+    d = Distance{11, Distance::Units::Kilometers};
+    newDistance = d.ToPlatformUnitsFormatted();
+
+    TEST_EQUAL(newDistance.GetUnits(), Distance::Units::Miles, (d.ToString()));
+    TEST_ALMOST_EQUAL_ULPS(newDistance.GetDistance(), 6.8, (d.ToString()));
+    TEST_EQUAL(newDistance.GetDistanceString(), "6.8", (d.ToString()));
+    TEST_EQUAL(newDistance.ToString(), "6.8 mi", (d.ToString()));
+  }
 }
 
 UNIT_TEST(Distance_GetUnits)
 {
   TEST_EQUAL(Distance(1234).GetUnits(), Distance::Units::Meters, ());
-  TEST_EQUAL(Distance(1234, Distance::Units::Kilometers).GetUnits(), Distance::Units::Kilometers,
-             ());
+  TEST_EQUAL(Distance(1234, Distance::Units::Kilometers).GetUnits(), Distance::Units::Kilometers, ());
   TEST_EQUAL(Distance(1234, Distance::Units::Feet).GetUnits(), Distance::Units::Feet, ());
   TEST_EQUAL(Distance(1234, Distance::Units::Miles).GetUnits(), Distance::Units::Miles, ());
 }
@@ -38,77 +220,96 @@ UNIT_TEST(Distance_GetUnitsString)
 
 UNIT_TEST(Distance_FormattedDistance)
 {
+  using Units = Distance::Units;
+
   struct TestData
   {
     Distance distance;
     double formattedDistance;
-    Distance::Units formattedUnits;
+    Units formattedUnits;
     std::string formattedDistanceString;
     std::string formattedString;
   };
   // clang-format off
   std::vector<TestData> testData{
     // From Meters to Meters
-    {Distance(0,       Distance::Units::Meters),     0,    Distance::Units::Meters,     "0",    "0 m"},
-    {Distance(1,       Distance::Units::Meters),     1,    Distance::Units::Meters,     "1",    "1 m"},
-    {Distance(1.234,   Distance::Units::Meters),     1.2,  Distance::Units::Meters,     "1.2",  "1.2 m"},
-    {Distance(9.99,    Distance::Units::Meters),     10,   Distance::Units::Meters,     "10",   "10 m"},
-    {Distance(10.01,   Distance::Units::Meters),     10,   Distance::Units::Meters,     "10",   "10 m"},
-    {Distance(64.2,    Distance::Units::Meters),     64,   Distance::Units::Meters,     "64",   "64 m"},
+    {Distance(0,       Units::Meters),     0,    Units::Meters,     "0",    "0 m"},
+    {Distance(0.3,     Units::Meters),     0,    Units::Meters,     "0",    "0 m"},
+    {Distance(0.9,     Units::Meters),     1,    Units::Meters,     "1",    "1 m"},
+    {Distance(1,       Units::Meters),     1,    Units::Meters,     "1",    "1 m"},
+    {Distance(1.234,   Units::Meters),     1,    Units::Meters,     "1",    "1 m"},
+    {Distance(9.99,    Units::Meters),     10,   Units::Meters,     "10",   "10 m"},
+    {Distance(10.01,   Units::Meters),     10,   Units::Meters,     "10",   "10 m"},
+    {Distance(10.4,    Units::Meters),     10,   Units::Meters,     "10",   "10 m"},
+    {Distance(10.5,    Units::Meters),     11,   Units::Meters,     "11",   "11 m"},
+    {Distance(10.51,   Units::Meters),     11,   Units::Meters,     "11",   "11 m"},
+    {Distance(64.2,    Units::Meters),     64,   Units::Meters,     "64",   "64 m"},
+    {Distance(99,      Units::Meters),     99,   Units::Meters,     "99",   "99 m"},
+    {Distance(100,     Units::Meters),     100,  Units::Meters,     "100",  "100 m"},
+    {Distance(101,     Units::Meters),     100,  Units::Meters,     "100",  "100 m"},
+    {Distance(109,     Units::Meters),     110,  Units::Meters,     "110",  "110 m"},
+    {Distance(991,     Units::Meters),     990,  Units::Meters,     "990",  "990 m"},
 
     // From Kilometers to Kilometers
-    {Distance(0,       Distance::Units::Kilometers), 0,    Distance::Units::Kilometers, "0",    "0 km"},
-    {Distance(1.234,   Distance::Units::Kilometers), 1.2,  Distance::Units::Kilometers, "1.2",  "1.2 km"},
-    {Distance(10,      Distance::Units::Kilometers), 10,   Distance::Units::Kilometers, "10",   "10 km"},
-    {Distance(99.99,   Distance::Units::Kilometers), 100,  Distance::Units::Kilometers, "100",  "100 km"},
-    {Distance(100.01,  Distance::Units::Kilometers), 100,  Distance::Units::Kilometers, "100",  "100 km"},
-    {Distance(1000,    Distance::Units::Kilometers), 1000, Distance::Units::Kilometers, "1000", "1000 km"},
-    {Distance(1234,    Distance::Units::Kilometers), 1230, Distance::Units::Kilometers, "1230", "1230 km"},
+    {Distance(0,       Units::Kilometers), 0,    Units::Kilometers, "0",    "0 km"},
+    {Distance(1.234,   Units::Kilometers), 1.2,  Units::Kilometers, "1.2",  "1.2 km"},
+    {Distance(10,      Units::Kilometers), 10,   Units::Kilometers, "10",   "10 km"},
+    {Distance(99.99,   Units::Kilometers), 100,  Units::Kilometers, "100",  "100 km"},
+    {Distance(100.01,  Units::Kilometers), 100,  Units::Kilometers, "100",  "100 km"},
+    {Distance(115,     Units::Kilometers), 120,  Units::Kilometers, "120",  "120 km"},
+    {Distance(130,     Units::Kilometers), 130,  Units::Kilometers, "130",  "130 km"},
+    {Distance(980,     Units::Kilometers), 980,  Units::Kilometers, "980",  "980 km"},
+    {Distance(1000,    Units::Kilometers), 1000, Units::Kilometers, "1000", "1000 km"},
+    {Distance(1050,    Units::Kilometers), 1050, Units::Kilometers, "1050", "1050 km"},
+    {Distance(1234,    Units::Kilometers), 1230, Units::Kilometers, "1230", "1230 km"},
 
     // From Feet to Feet
-    {Distance(0,       Distance::Units::Feet),       0,    Distance::Units::Feet,       "0",    "0 ft"},
-    {Distance(1,       Distance::Units::Feet),       1,    Distance::Units::Feet,       "1",    "1 ft"},
-    {Distance(9.99,    Distance::Units::Feet),       10,   Distance::Units::Feet,       "10",   "10 ft"},
-    {Distance(10.01,   Distance::Units::Feet),       10,   Distance::Units::Feet,       "10",   "10 ft"},
+    {Distance(0,       Units::Feet),       0,    Units::Feet,       "0",    "0 ft"},
+    {Distance(1,       Units::Feet),       1,    Units::Feet,       "1",    "1 ft"},
+    {Distance(9.99,    Units::Feet),       10,   Units::Feet,       "10",   "10 ft"},
+    {Distance(10.01,   Units::Feet),       10,   Units::Feet,       "10",   "10 ft"},
+    {Distance(95,      Units::Feet),       95,   Units::Feet,       "95",   "95 ft"},
+    {Distance(125,     Units::Feet),       130,  Units::Feet,       "130",  "130 ft"},
+    {Distance(991,     Units::Feet),       990,  Units::Feet,       "990",  "990 ft"},
 
     // From Miles to Miles
-    {Distance(0,       Distance::Units::Miles),      0,    Distance::Units::Miles,      "0",    "0 mi"},
-    {Distance(1,       Distance::Units::Miles),      1,    Distance::Units::Miles,      "1",    "1 mi"},
-    {Distance(1.234,   Distance::Units::Miles),      1.2,  Distance::Units::Miles,      "1.2",  "1.2 mi"},
-    {Distance(9.99,    Distance::Units::Miles),      10,   Distance::Units::Miles,      "10",   "10 mi"},
-    {Distance(10.01,   Distance::Units::Miles),      10,   Distance::Units::Miles,      "10",   "10 mi"},
-    {Distance(998,     Distance::Units::Miles),      1000, Distance::Units::Miles,      "1000", "1000 mi"},
-    {Distance(999,     Distance::Units::Miles),      1000, Distance::Units::Miles,      "1000", "1000 mi"},
+    {Distance(0,       Units::Miles),      0,    Units::Miles,      "0",    "0 mi"},
+    {Distance(1,       Units::Miles),      1,    Units::Miles,      "1",    "1 mi"},
+    {Distance(1.234,   Units::Miles),      1.2,  Units::Miles,      "1.2",  "1.2 mi"},
+    {Distance(9.99,    Units::Miles),      10,   Units::Miles,      "10",   "10 mi"},
+    {Distance(10.01,   Units::Miles),      10,   Units::Miles,      "10",   "10 mi"},
+    {Distance(105,     Units::Miles),      110,  Units::Miles,      "110",  "110 mi"},
+    {Distance(145,     Units::Miles),      150,  Units::Miles,      "150",  "150 mi"},
+    {Distance(998,     Units::Miles),      1000, Units::Miles,      "1000", "1000 mi"},
+    {Distance(999,     Units::Miles),      1000, Units::Miles,      "1000", "1000 mi"},
+    {Distance(1150,    Units::Miles),      1150, Units::Miles,      "1150", "1150 mi"},
 
     // From Meters to Kilometers
-    {Distance(999,     Distance::Units::Meters),     1,    Distance::Units::Kilometers, "1",    "1 km"},
-    {Distance(1000,    Distance::Units::Meters),     1,    Distance::Units::Kilometers, "1",    "1 km"},
-    {Distance(1100,    Distance::Units::Meters),     1.1,  Distance::Units::Kilometers, "1.1",  "1.1 km"},
-    {Distance(1500,    Distance::Units::Meters),     1.5,  Distance::Units::Kilometers, "1.5",  "1.5 km"},
-    {Distance(287'386, Distance::Units::Meters),     290,  Distance::Units::Kilometers, "290",  "290 km"},
+    {Distance(999,     Units::Meters),     1,    Units::Kilometers, "1",    "1 km"},
+    {Distance(1000,    Units::Meters),     1,    Units::Kilometers, "1",    "1 km"},
+    {Distance(1001,    Units::Meters),     1,    Units::Kilometers, "1",    "1 km"},
+    {Distance(1100,    Units::Meters),     1.1,  Units::Kilometers, "1.1",  "1.1 km"},
+    {Distance(1140,    Units::Meters),     1.1,  Units::Kilometers, "1.1",  "1.1 km"},
+    {Distance(1151,    Units::Meters),     1.2,  Units::Kilometers, "1.2",  "1.2 km"},
+    {Distance(1500,    Units::Meters),     1.5,  Units::Kilometers, "1.5",  "1.5 km"},
+    {Distance(1549.9,  Units::Meters),     1.5,  Units::Kilometers, "1.5",  "1.5 km"},
+    {Distance(1550,    Units::Meters),     1.6,  Units::Kilometers, "1.6",  "1.6 km"},
+    {Distance(1551,    Units::Meters),     1.6,  Units::Kilometers, "1.6",  "1.6 km"},
+    {Distance(9949,    Units::Meters),     9.9,  Units::Kilometers, "9.9",  "9.9 km"},
+    {Distance(9992,    Units::Meters),     10,   Units::Kilometers, "10",   "10 km"},
+    {Distance(10000,   Units::Meters),     10,   Units::Kilometers, "10",   "10 km"},
+    {Distance(10499.9, Units::Meters),     10,   Units::Kilometers, "10",   "10 km"},
+    {Distance(10501,   Units::Meters),     11,   Units::Kilometers, "11",   "11 km"},
+    {Distance(287'386, Units::Meters),     290,  Units::Kilometers, "290",  "290 km"},
 
     // From Feet to Miles
-    {Distance(999,     Distance::Units::Feet),       0.2,  Distance::Units::Miles,      "0.2",  "0.2 mi"},
-    {Distance(1000,    Distance::Units::Feet),       0.2,  Distance::Units::Miles,      "0.2",  "0.2 mi"},
-    {Distance(1150,    Distance::Units::Feet),       0.2,  Distance::Units::Miles,      "0.2",  "0.2 mi"},
-    {Distance(5280,    Distance::Units::Feet),       1,    Distance::Units::Miles,      "1",    "1 mi"},
-    {Distance(7920,    Distance::Units::Feet),       1.5,  Distance::Units::Miles,      "1.5",  "1.5 mi"},
-    {Distance(10560,   Distance::Units::Feet),       2,    Distance::Units::Miles,      "2",    "2 mi"},
-    {Distance(100'000, Distance::Units::Feet),       19,   Distance::Units::Miles,      "19",   "19 mi"},
-
-    // Rounding checks: 112 -> 110, 998 -> 1000
-    {Distance(115,     Distance::Units::Kilometers), 120,  Distance::Units::Kilometers, "120",  "120 km"},
-    {Distance(130,     Distance::Units::Kilometers), 130,  Distance::Units::Kilometers, "130",  "130 km"},
-    {Distance(980,     Distance::Units::Kilometers), 980,  Distance::Units::Kilometers, "980",  "980 km"},
-    {Distance(1050,    Distance::Units::Kilometers), 1050, Distance::Units::Kilometers, "1050", "1050 km"},
-
-    {Distance(105,     Distance::Units::Miles),      110,  Distance::Units::Miles,      "110",  "110 mi"},
-    {Distance(145,     Distance::Units::Miles),      150,  Distance::Units::Miles,      "150",  "150 mi"},
-    {Distance(1150,    Distance::Units::Miles),      1150, Distance::Units::Miles,      "1150", "1150 mi"},
-
-    {Distance(95,      Distance::Units::Feet),       95,   Distance::Units::Feet,       "95",   "95 ft"},
-    {Distance(125,     Distance::Units::Feet),       130,  Distance::Units::Feet,       "130",  "130 ft"},
-    {Distance(991,     Distance::Units::Feet),       990,  Distance::Units::Feet,       "990",  "990 ft"},
+    {Distance(999,     Units::Feet),       0.2,  Units::Miles,      "0.2",  "0.2 mi"},
+    {Distance(1000,    Units::Feet),       0.2,  Units::Miles,      "0.2",  "0.2 mi"},
+    {Distance(1150,    Units::Feet),       0.2,  Units::Miles,      "0.2",  "0.2 mi"},
+    {Distance(5280,    Units::Feet),       1,    Units::Miles,      "1",    "1 mi"},
+    {Distance(7920,    Units::Feet),       1.5,  Units::Miles,      "1.5",  "1.5 mi"},
+    {Distance(10560,   Units::Feet),       2,    Units::Miles,      "2",    "2 mi"},
+    {Distance(100'000, Units::Feet),       19,   Units::Miles,      "19",   "19 mi"},
   };
   // clang-format on
   for (TestData const & data : testData)
@@ -117,10 +318,10 @@ UNIT_TEST(Distance_FormattedDistance)
     // Run two times to verify that nothing breaks after second format
     for (const auto & d : {formattedDistance, formattedDistance.GetFormattedDistance()})
     {
-      TEST_EQUAL(d.GetDistance(), data.formattedDistance, ());
-      TEST_EQUAL(d.GetUnits(), data.formattedUnits, ());
-      TEST_EQUAL(d.GetDistanceString(), data.formattedDistanceString, ());
-      TEST_EQUAL(d.ToString(), data.formattedString, ());
+      TEST_ALMOST_EQUAL_ULPS(d.GetDistance(), data.formattedDistance, (data.distance.ToString()));
+      TEST_EQUAL(d.GetUnits(), data.formattedUnits, (data.distance.ToString()));
+      TEST_EQUAL(d.GetDistanceString(), data.formattedDistanceString, (data.distance.ToString()));
+      TEST_EQUAL(d.ToString(), data.formattedString, (data.distance.ToString()));
     }
   }
 }

--- a/platform/platform_tests/distance_tests.cpp
+++ b/platform/platform_tests/distance_tests.cpp
@@ -72,15 +72,6 @@ UNIT_TEST(Distance_CreateAltitudeFormatted)
   }
 }
 
-UNIT_TEST(Distance_IsValid)
-{
-  TEST_EQUAL(Distance(0.0).IsValid(), true, ());
-  TEST_EQUAL(Distance(-1).IsValid(), false, ());
-  TEST_EQUAL(Distance(std::numeric_limits<double>::epsilon()).IsValid(), true, ());
-  TEST_EQUAL(Distance(1).IsValid(), true, ());
-  TEST_EQUAL(Distance(1243.2, Distance::Units::Feet).IsValid(), true, ());
-}
-
 UNIT_TEST(Distance_IsLowUnits)
 {
   TEST_EQUAL(Distance(0.0, Distance::Units::Meters).IsLowUnits(), true, ());

--- a/platform/platform_tests/measurement_tests.cpp
+++ b/platform/platform_tests/measurement_tests.cpp
@@ -1,113 +1,13 @@
 #include "testing/testing.hpp"
 
 #include "platform/measurement_utils.hpp"
-#include "platform/settings.hpp"
 
 #include "base/math.hpp"
 
 #include <string>
-#include <utility>
 
 using namespace measurement_utils;
-using namespace settings;
 
-struct ScopedSettings
-{
-  ScopedSettings() { m_wasSet = Get(kMeasurementUnits, m_oldUnits); }
-
-  /// Saves/restores previous units and sets new units for a scope.
-  explicit ScopedSettings(Units newUnits) : ScopedSettings()
-  {
-    Set(kMeasurementUnits, newUnits);
-  }
-
-  ~ScopedSettings()
-  {
-    if (m_wasSet)
-      Set(kMeasurementUnits, m_oldUnits);
-    else
-      Delete(kMeasurementUnits);
-  }
-
-  bool m_wasSet;
-  Units m_oldUnits;
-};
-
-UNIT_TEST(Measurement_Smoke)
-{
-  {
-    ScopedSettings guard(Units::Metric);
-
-    using Pair = std::pair<double, char const *>;
-
-    Pair arr[] = {
-      {0.3, "0 m"},
-      {0.9, "1 m"},
-      {10.0, "10 m"},
-      {10.4, "10 m"},
-      {10.5, "11 m"},
-      {10.51, "11 m"},
-      {99.0, "99 m"},
-      {100.0, "100 m"},
-      {101.0, "100 m"},
-      {109.0, "110 m"},
-      {991.0, "990 m"},
-      {999.0, "1.0 km"},
-      {1000.0, "1.0 km"},
-      {1001.0, "1.0 km"},
-      {1100.0, "1.1 km"},
-      {1140.0, "1.1 km"},
-      {1151.0, "1.2 km"},
-      {1500.0, "1.5 km"},
-      {1549.9, "1.5 km"},
-      {1550.0, "1.6 km"},
-      {1551.0, "1.6 km"},
-      {9949.0, "9.9 km"},
-      {9992.0, "10 km"},
-      {10000.0, "10 km"},
-      {10499.9, "10 km"},
-      {10501.0, "11 km"}
-    };
-
-    for (size_t i = 0; i < ARRAY_SIZE(arr); ++i)
-      TEST_EQUAL(FormatDistance(arr[i].first), arr[i].second, (arr[i]));
-  }
-
-  {
-    ScopedSettings guard(Units::Imperial);
-
-    using Pair = std::pair<double, char const *>;
-
-    Pair arr[] = {
-      {0.1, "0 ft"},
-      {0.3, "1 ft"},
-      {0.3048, "1 ft"},
-      {0.4573, "2 ft"},
-      {0.9, "3 ft"},
-      {3.0, "10 ft"},
-      {30.17, "99 ft"},
-      {30.33, "100 ft"},
-      {30.49, "100 ft"},
-      {33.5, "110 ft"},
-      {302.0, "990 ft"},
-      {304.7, "0.2 mi"},
-      {304.8, "0.2 mi"},
-      {402.3, "0.2 mi"},
-      {402.4, "0.3 mi"},
-      {482.8, "0.3 mi"},
-      {1609.3, "1.0 mi"},
-      {1610.0, "1.0 mi"},
-      {1770.0, "1.1 mi"},
-      {15933, "9.9 mi"},
-      {16093.0, "10 mi"},
-      {16093.5, "10 mi"},
-      {16898.113, "11 mi"}
-    };
-
-    for (size_t i = 0; i < ARRAY_SIZE(arr); ++i)
-      TEST_EQUAL(FormatDistance(arr[i].first), arr[i].second, (arr[i]));
-  }
-}
 
 UNIT_TEST(LatLonToDMS_Origin)
 {
@@ -150,15 +50,6 @@ UNIT_TEST(FormatOsmLink)
   TEST(link == "https://osm.org/go/AAAAAA?m=" || link == "https://osm.org/go/~~~~~~?m=", (link));
   link = FormatOsmLink(90, 180, 10);
   TEST(link == "https://osm.org/go/AAAAAA?m=" || link == "https://osm.org/go/~~~~~~?m=", (link));
-}
-
-UNIT_TEST(FormatAltitude)
-{
-  ScopedSettings guard;
-  settings::Set(settings::kMeasurementUnits, Units::Imperial);
-  TEST_EQUAL(FormatAltitude(10000), "32808 ft", ());
-  settings::Set(settings::kMeasurementUnits, Units::Metric);
-  TEST_EQUAL(FormatAltitude(5), "5 m", ());
 }
 
 UNIT_TEST(FormatSpeedNumeric)

--- a/qt/draw_widget.cpp
+++ b/qt/draw_widget.cpp
@@ -490,9 +490,9 @@ void DrawWidget::SubmitFakeLocationPoint(m2::PointD const & pt)
     routingManager.GetRouteFollowingInfo(loc);
     if (routingManager.GetCurrentRouterType() == routing::RouterType::Pedestrian)
     {
-      LOG(LDEBUG, ("Distance:", loc.m_distToTarget + loc.m_targetUnitsSuffix, "Time:", loc.m_time,
+      LOG(LDEBUG, ("Distance:", loc.m_distToTarget.ToString(), "Time:", loc.m_time,
                    DebugPrint(loc.m_pedestrianTurn),
-                   "in", loc.m_distToTurn + loc.m_turnUnitsSuffix,
+                   "in", loc.m_distToTurn.ToString(),
                    loc.m_targetName.empty() ? "" : "to " + loc.m_targetName ));
     }
     else
@@ -501,9 +501,9 @@ void DrawWidget::SubmitFakeLocationPoint(m2::PointD const & pt)
       if (loc.m_speedLimitMps > 0)
         speed = "SpeedLimit: " + measurement_utils::FormatSpeedNumeric(loc.m_speedLimitMps, measurement_utils::Units::Metric);
 
-      LOG(LDEBUG, ("Distance:", loc.m_distToTarget + loc.m_targetUnitsSuffix, "Time:", loc.m_time, speed,
+      LOG(LDEBUG, ("Distance:", loc.m_distToTarget.ToString(), "Time:", loc.m_time, speed,
                    GetTurnString(loc.m_turn), (loc.m_exitNum != 0 ? ":" + std::to_string(loc.m_exitNum) : ""),
-                   "in", loc.m_distToTurn + loc.m_turnUnitsSuffix,
+                   "in", loc.m_distToTurn.ToString(),
                    loc.m_targetName.empty() ? "" : "to " + loc.m_targetName ));
     }
   }

--- a/qt/draw_widget.cpp
+++ b/qt/draw_widget.cpp
@@ -425,7 +425,7 @@ void DrawWidget::keyReleaseEvent(QKeyEvent * e)
 
 std::string DrawWidget::GetDistance(search::Result const & res) const
 {
-  std::string dist;
+  platform::Distance dist;
   if (auto const position = m_framework.GetCurrentPosition())
   {
     auto const ll = mercator::ToLatLon(*position);
@@ -433,7 +433,7 @@ std::string DrawWidget::GetDistance(search::Result const & res) const
     (void)m_framework.GetDistanceAndAzimut(res.GetFeatureCenter(), ll.m_lat, ll.m_lon, -1.0, dist,
                                            dummy);
   }
-  return dist;
+  return dist.ToString();
 }
 
 void DrawWidget::CreateFeature()
@@ -490,7 +490,7 @@ void DrawWidget::SubmitFakeLocationPoint(m2::PointD const & pt)
     routingManager.GetRouteFollowingInfo(loc);
     if (routingManager.GetCurrentRouterType() == routing::RouterType::Pedestrian)
     {
-      LOG(LDEBUG, ("Distance:", loc.m_distToTarget.ToString(), "Time:", loc.m_time,
+      LOG(LDEBUG, ("Distance:", loc.m_distToTarget, "Time:", loc.m_time,
                    DebugPrint(loc.m_pedestrianTurn),
                    "in", loc.m_distToTurn.ToString(),
                    loc.m_targetName.empty() ? "" : "to " + loc.m_targetName ));
@@ -501,7 +501,7 @@ void DrawWidget::SubmitFakeLocationPoint(m2::PointD const & pt)
       if (loc.m_speedLimitMps > 0)
         speed = "SpeedLimit: " + measurement_utils::FormatSpeedNumeric(loc.m_speedLimitMps, measurement_utils::Units::Metric);
 
-      LOG(LDEBUG, ("Distance:", loc.m_distToTarget.ToString(), "Time:", loc.m_time, speed,
+      LOG(LDEBUG, ("Distance:", loc.m_distToTarget, "Time:", loc.m_time, speed,
                    GetTurnString(loc.m_turn), (loc.m_exitNum != 0 ? ":" + std::to_string(loc.m_exitNum) : ""),
                    "in", loc.m_distToTurn.ToString(),
                    loc.m_targetName.empty() ? "" : "to " + loc.m_targetName ));

--- a/routing/following_info.hpp
+++ b/routing/following_info.hpp
@@ -51,7 +51,7 @@ public:
   /// @name Formatted covered distance.
   platform::Distance m_distToTarget;
 
-  /// @name Formated distance to next turn with measurement unit suffix
+  /// @name Formatted distance to the next turn.
   //@{
   platform::Distance m_distToTurn;
   turns::CarDirection m_turn;

--- a/routing/following_info.hpp
+++ b/routing/following_info.hpp
@@ -2,6 +2,8 @@
 
 #include "geometry/latlon.hpp"
 
+#include "platform/distance.hpp"
+
 #include "routing/turns.hpp"
 #include "routing/turns_sound_settings.hpp"
 
@@ -44,18 +46,14 @@ public:
     }
   };
 
-  bool IsValid() const { return !m_distToTarget.empty(); }
+  bool IsValid() const { return m_distToTarget.IsValid(); }
 
-  /// @name Formatted covered distance with measurement units suffix.
-  //@{
-  std::string m_distToTarget;
-  std::string m_targetUnitsSuffix;
-  //@}
+  /// @name Formatted covered distance.
+  platform::Distance m_distToTarget;
 
   /// @name Formated distance to next turn with measurement unit suffix
   //@{
-  std::string m_distToTurn;
-  std::string m_turnUnitsSuffix;
+  platform::Distance m_distToTurn;
   turns::CarDirection m_turn;
   /// Turn after m_turn. Returns NoTurn if there is no turns after.
   turns::CarDirection m_nextTurn;

--- a/routing/following_info.hpp
+++ b/routing/following_info.hpp
@@ -46,8 +46,6 @@ public:
     }
   };
 
-  bool IsValid() const { return m_distToTarget.IsValid(); }
-
   /// @name Formatted covered distance.
   platform::Distance m_distToTarget;
 

--- a/routing/routing_session.cpp
+++ b/routing/routing_session.cpp
@@ -389,17 +389,17 @@ void RoutingSession::GetRouteFollowingInfo(FollowingInfo & info) const
   if (!IsNavigable())
   {
     info = FollowingInfo();
-    FormatDistance(m_route->GetTotalDistanceMeters(), info.m_distToTarget, info.m_targetUnitsSuffix);
+    info.m_distToTarget = platform::Distance::CreateFormatted(m_route->GetTotalDistanceMeters());
     info.m_time = static_cast<int>(std::max(kMinimumETASec, m_route->GetCurrentTimeToEndSec()));
     return;
   }
 
-  FormatDistance(m_route->GetCurrentDistanceToEndMeters(), info.m_distToTarget, info.m_targetUnitsSuffix);
+  info.m_distToTarget = platform::Distance::CreateFormatted(m_route->GetTotalDistanceMeters());
 
   double distanceToTurnMeters = 0.;
   turns::TurnItem turn;
   m_route->GetNearestTurn(distanceToTurnMeters, turn);
-  FormatDistance(distanceToTurnMeters, info.m_distToTurn, info.m_turnUnitsSuffix);
+  info.m_distToTurn = platform::Distance::CreateFormatted(distanceToTurnMeters);
   info.m_turn = turn.m_turn;
 
   SpeedInUnits speedLimit;

--- a/routing/routing_session.cpp
+++ b/routing/routing_session.cpp
@@ -6,6 +6,7 @@
 #include "platform/location.hpp"
 #include "platform/measurement_utils.hpp"
 #include "platform/platform.hpp"
+#include "platform/distance.hpp"
 
 #include "geometry/angles.hpp"
 #include "geometry/mercator.hpp"
@@ -37,13 +38,9 @@ using namespace traffic;
 
 void FormatDistance(double dist, std::string & value, std::string & suffix)
 {
-  /// @todo Make better formatting of distance and units.
-  value = measurement_utils::FormatDistance(dist);
-
-  size_t const delim = value.find(' ');
-  ASSERT(delim != std::string::npos, ());
-  suffix = value.substr(delim + 1);
-  value.erase(delim);
+  platform::Distance d = platform::Distance::CreateFormatted(dist);
+  value = d.GetDistanceString();
+  suffix = d.GetUnitsString();
 }
 
 RoutingSession::RoutingSession()

--- a/xcode/platform/platform.xcodeproj/project.pbxproj
+++ b/xcode/platform/platform.xcodeproj/project.pbxproj
@@ -7,6 +7,10 @@
 	objects = {
 
 /* Begin PBXBuildFile section */
+		1669C8402A30DCD200530AD1 /* distance.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 1669C83E2A30DCD200530AD1 /* distance.cpp */; };
+		1669C8412A30DCD200530AD1 /* distance.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 1669C83E2A30DCD200530AD1 /* distance.cpp */; };
+		1669C8422A30DCD200530AD1 /* distance.hpp in Headers */ = {isa = PBXBuildFile; fileRef = 1669C83F2A30DCD200530AD1 /* distance.hpp */; };
+		168EFCC22A30EB7400F71EE8 /* distance_tests.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 168EFCC12A30EB7400F71EE8 /* distance_tests.cpp */; };
 		333A416F21C3E13B00AF26F6 /* http_session_manager.mm in Sources */ = {isa = PBXBuildFile; fileRef = 333A416D21C3E13A00AF26F6 /* http_session_manager.mm */; };
 		333A417021C3E13B00AF26F6 /* http_session_manager.h in Headers */ = {isa = PBXBuildFile; fileRef = 333A416E21C3E13B00AF26F6 /* http_session_manager.h */; };
 		34C624BD1DABCCD100510300 /* socket_apple.mm in Sources */ = {isa = PBXBuildFile; fileRef = 34C624BB1DABCCD100510300 /* socket_apple.mm */; };
@@ -132,6 +136,9 @@
 /* End PBXBuildFile section */
 
 /* Begin PBXFileReference section */
+		1669C83E2A30DCD200530AD1 /* distance.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = distance.cpp; sourceTree = "<group>"; };
+		1669C83F2A30DCD200530AD1 /* distance.hpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.h; path = distance.hpp; sourceTree = "<group>"; };
+		168EFCC12A30EB7400F71EE8 /* distance_tests.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = distance_tests.cpp; sourceTree = "<group>"; };
 		333A416D21C3E13A00AF26F6 /* http_session_manager.mm */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.objcpp; path = http_session_manager.mm; sourceTree = "<group>"; };
 		333A416E21C3E13B00AF26F6 /* http_session_manager.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = http_session_manager.h; sourceTree = "<group>"; };
 		344D8A2E204945D000CF532F /* platform_ios.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = platform_ios.h; sourceTree = "<group>"; };
@@ -307,6 +314,7 @@
 		675340DE1C58C405002CF0D9 /* platform_tests */ = {
 			isa = PBXGroup;
 			children = (
+				168EFCC12A30EB7400F71EE8 /* distance_tests.cpp */,
 				675341001C58C4C9002CF0D9 /* apk_test.cpp */,
 				675341011C58C4C9002CF0D9 /* country_file_tests.cpp */,
 				675341021C58C4C9002CF0D9 /* get_text_by_id_tests.cpp */,
@@ -370,6 +378,8 @@
 		6753437A1A3F5CF500A0A8C3 /* platform */ = {
 			isa = PBXGroup;
 			children = (
+				1669C83E2A30DCD200530AD1 /* distance.cpp */,
+				1669C83F2A30DCD200530AD1 /* distance.hpp */,
 				675343861A3F5D5900A0A8C3 /* apple_location_service.mm */,
 				3DFACF302432421C00A29A94 /* background_downloader_ios.h */,
 				3DFACF2F2432421C00A29A94 /* background_downloader_ios.mm */,
@@ -528,6 +538,7 @@
 				6741250F1B4C00CC00A3E828 /* local_country_file.hpp in Headers */,
 				3D15ACE2214A707900F725D5 /* localization.hpp in Headers */,
 				D5B191CF2386C7E4009CD0D6 /* http_uploader_background.hpp in Headers */,
+				1669C8422A30DCD200530AD1 /* distance.hpp in Headers */,
 				3DE8B98F1DEC3115000E6083 /* network_policy.hpp in Headers */,
 				675343CF1A3F5D5A00A0A8C3 /* preferred_languages.hpp in Headers */,
 				3D30587D1D8320E4004AC712 /* http_client.hpp in Headers */,
@@ -709,6 +720,7 @@
 				675343CE1A3F5D5A00A0A8C3 /* preferred_languages.cpp in Sources */,
 				675343B91A3F5D5A00A0A8C3 /* http_thread_apple.mm in Sources */,
 				3DFACF312432421C00A29A94 /* background_downloader_ios.mm in Sources */,
+				1669C8402A30DCD200530AD1 /* distance.cpp in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -725,8 +737,10 @@
 				6783389D1C6DE59200FD6263 /* measurement_tests.cpp in Sources */,
 				678338971C6DE59200FD6263 /* country_file_tests.cpp in Sources */,
 				678338951C6DE59200FD6263 /* testingmain.cpp in Sources */,
+				1669C8412A30DCD200530AD1 /* distance.cpp in Sources */,
 				44CAB5F62A1F926800819330 /* utm_mgrs_utils_tests.cpp in Sources */,
 				F6DF735A1EC9EAE700D8BA0B /* string_storage_base.cpp in Sources */,
+				168EFCC22A30EB7400F71EE8 /* distance_tests.cpp in Sources */,
 				6783389B1C6DE59200FD6263 /* local_country_file_tests.cpp in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;


### PR DESCRIPTION
This PR solves 2 problems:
1. Broken translations in Android
2. Android Auto requires explicitly specifying remaining distance in `double` and units for it in `Meters/Kilometers/Feet/Miles`

Problem 2 can be solved by parsing "old" string values for distance and units as the translation is broken and we always have units in en: `m/km/ft/mi`. When translations fixed - Android Auto is broken.

I believe, this is a better solution.
What do you think? If this approach is OK, I will continue the implementation. 
* refactor `measurment_utils`
* add `Distance` class to other places where the translation is broken
* and so on

Potentionaly, it may be extended, f.e. with arithmetic operations to use it directly during route calculations.

Please, check UTs to better understand how it works now.

| Before | After |
|--------|--------|
| <img width="300" src="https://github.com/organicmaps/organicmaps/assets/10351358/a15385cf-2981-455a-a44d-6ae28790c1e8"/> | <img width="300" src="https://github.com/organicmaps/organicmaps/assets/10351358/d8a94c2a-c1ae-4da4-9aad-85569d41ca48"/> |
| <img width="300" src="https://github.com/organicmaps/organicmaps/assets/10351358/4541e0ed-15b5-46ba-8ff0-89e5d0b75e54"/> | <img width="300" src="https://github.com/organicmaps/organicmaps/assets/10351358/2c61feb5-48a3-481a-8aa9-b2480bec8163"/> | 

<img width="600" alt="image" src="https://github.com/organicmaps/organicmaps/assets/10351358/48bcba54-f2a7-45b5-a303-a082d553509e">
