### PR TITLE
[Android] backurl API fixes

### DIFF
--- a/android/src/app/organicmaps/intent/Factory.java
+++ b/android/src/app/organicmaps/intent/Factory.java
@@ -202,13 +202,6 @@ public class Factory
     {
       final ParsingResult result = Framework.nativeParseAndSetApiUrl(getUrl());
 
-      // TODO: Kernel recognizes "mapsme://", "mwm://" and "mapswithme://" schemas only!!!
-      if (result.getUrlType() == ParsingResult.TYPE_INCORRECT)
-        return Map.showMapForUrl(getUrl());
-
-      if (!result.isSuccess())
-        return false;
-
       final Uri uri = Uri.parse(getUrl());
       final String backUrl = uri.getQueryParameter("backurl");
       if (!TextUtils.isEmpty(backUrl))
@@ -217,6 +210,13 @@ public class Factory
         if (intent != null)
           intent.putExtra(MwmActivity.EXTRA_BACK_URL, backUrl);
       }
+      
+      // TODO: Kernel recognizes "mapsme://", "mwm://" and "mapswithme://" schemas only!!!
+      if (result.getUrlType() == ParsingResult.TYPE_INCORRECT)
+        return Map.showMapForUrl(getUrl());
+
+      if (!result.isSuccess())
+        return false;
 
       switch (result.getUrlType())
       {

--- a/android/src/app/organicmaps/intent/Factory.java
+++ b/android/src/app/organicmaps/intent/Factory.java
@@ -211,7 +211,7 @@ public class Factory
           intent.putExtra(MwmActivity.EXTRA_BACK_URL, backUrl);
       }
 
-      // TODO: Kernel recognizes "mapsme://", "mwm://" and "mapswithme://" schemas only!!!
+      // Kernel recognizes "om://", "mapsme://", "mwm://" and "mapswithme://" schemes only!!!
       if (result.getUrlType() == ParsingResult.TYPE_INCORRECT)
         return Map.showMapForUrl(getUrl());
 

--- a/android/src/app/organicmaps/intent/Factory.java
+++ b/android/src/app/organicmaps/intent/Factory.java
@@ -210,7 +210,7 @@ public class Factory
         if (intent != null)
           intent.putExtra(MwmActivity.EXTRA_BACK_URL, backUrl);
       }
-      
+
       // TODO: Kernel recognizes "mapsme://", "mwm://" and "mapswithme://" schemas only!!!
       if (result.getUrlType() == ParsingResult.TYPE_INCORRECT)
         return Map.showMapForUrl(getUrl());


### PR DESCRIPTION
This allows the 'backurl' API argument to be used in all launch scenarios.