### PR TITLE
[qt] More contrast download button text color

### DIFF
--- a/qt/mainwindow.cpp
+++ b/qt/mainwindow.cpp
@@ -447,6 +447,8 @@ Framework & MainWindow::GetFramework() const
 
 void MainWindow::CreateCountryStatusControls()
 {
+  setStyleSheet("QPushButton { color: black; } QLabel { color: black; }");
+
   QHBoxLayout * mainLayout = new QHBoxLayout();
   m_downloadButton = new QPushButton("Download");
   mainLayout->addWidget(m_downloadButton, 0, Qt::AlignHCenter);


### PR DESCRIPTION
I don't know how to fix artifacts on the left and on the right. They appeared after upgrading from Qt5 to Qt6

<img width="568" alt="image" src="https://github.com/organicmaps/organicmaps/assets/170263/5a632d87-ef27-4dd2-add3-d434a9607752">
