### PR TITLE
Fixed UB/assert when parsing GPX

### DIFF
--- a/kml/serdes_gpx.cpp
+++ b/kml/serdes_gpx.cpp
@@ -91,7 +91,7 @@ bool GpxParser::MakeValid()
 
 bool GpxParser::Push(std::string_view tag)
 {
-  m_tags.push_back(tag);
+  m_tags.push_back(std::string{tag});
   if (GetTagFromEnd(0) == gpx::kWpt)
     m_geometryType = GEOMETRY_TYPE_POINT;
   else if (GetTagFromEnd(0) == gpx::kTrkPt || GetTagFromEnd(0) == gpx::kRtePt)

--- a/kml/serdes_gpx.hpp
+++ b/kml/serdes_gpx.hpp
@@ -46,7 +46,7 @@ private:
   CategoryData m_compilationData;
   CategoryData * m_categoryData;  // never null
 
-  std::vector<std::string_view> m_tags;
+  std::vector<std::string> m_tags;
   GeometryType m_geometryType;
   MultiGeometry m_geometry;
   uint32_t m_color;


### PR DESCRIPTION
@cyber-toad My bad, I didn't see on review that you _store_ string_views that may point to already destroyed strings.

Fixes this: https://github.com/organicmaps/organicmaps/actions/runs/5259411718/jobs/9504945838