### PR TITLE
[android] prevent interaction with place page on closing

### DIFF
--- a/android/src/app/organicmaps/widget/placepage/PlacePageController.java
+++ b/android/src/app/organicmaps/widget/placepage/PlacePageController.java
@@ -205,8 +205,18 @@ public class PlacePageController extends Fragment implements
     return items;
   }
 
+  private void setPlacePageInteractions(boolean enabled)
+  {
+    // Prevent place page scrolling when playing the close animation
+    mPlacePageBehavior.setDraggable(enabled);
+    mPlacePage.setNestedScrollingEnabled(enabled);
+    // Prevent user interaction with place page content when closing
+    mPlacePageContainer.setEnabled(enabled);
+  }
+
   private void close()
   {
+    setPlacePageInteractions(false);
     mPlacePageBehavior.setState(BottomSheetBehavior.STATE_HIDDEN);
   }
 
@@ -577,6 +587,7 @@ public class PlacePageController extends Fragment implements
     mMapObject = mapObject;
     if (mapObject != null)
     {
+      setPlacePageInteractions(true);
       // Only collapse the place page if the data is different from the one already available
       mShouldCollapse = PlacePageUtils.isHiddenState(mPlacePageBehavior.getState()) || !MapObject.same(mPreviousMapObject, mMapObject);
       mPreviousMapObject = mMapObject;
@@ -586,7 +597,8 @@ public class PlacePageController extends Fragment implements
           mapObject,
           MapObject.isOfType(MapObject.API_POINT, mMapObject),
           !MapObject.isOfType(MapObject.MY_POSITION, mMapObject));
-    } else
+    }
+    else
       close();
   }
 


### PR DESCRIPTION
Prevents user from grabbing the place page and clicking on its elements while the close animation is playing.

Before this PR, users could grab the place page before it was fully closed and reopen it. This would result in an invalid state where the code would think the place page is closed but it would still be visible on screen.

An other issue was that users could still click on elements while the place page was closing. For example open the PP, tap on an empty map area to close it and very quickly tap on the compass arrow in the place page. The tap on the button would register and you would see the full screen compass view. Again this is not a valid UI state.

Complements https://github.com/organicmaps/organicmaps/pull/5353

@biodranik @Jean-BaptisteC can you please try this PR? 