### PR TITLE
[strings] Polish translation for "import bookmarks and tracks"

### DIFF
--- a/android/res/values-de/strings.xml
+++ b/android/res/values-de/strings.xml
@@ -74,7 +74,7 @@
 	<!-- Should be used in the bookmarks-only context, see bookmarks_and_tracks if tracks are also implied. -->
 	<string name="bookmarks">Lesezeichen</string>
 	<!-- "Bookmarks and Tracks" dialog title, also sync it with iphone/plist.txt -->
-	<string name="bookmarks_and_tracks">Lesezeichen und Strecken</string>
+	<string name="bookmarks_and_tracks">Lesezeichen und Tracks</string>
 	<!-- Default bookmark list name -->
 	<string name="core_my_places">Meine Orte</string>
 	<!-- Add bookmark dialog - bookmark name -->
@@ -197,7 +197,7 @@
 	<!-- Confirmation in downloading countries dialog -->
 	<string name="are_you_sure">Möchten Sie wirklich fortfahren?</string>
 	<!-- Title for tracks category in bookmarks manager -->
-	<string name="tracks_title">Strecken</string>
+	<string name="tracks_title">Tracks</string>
 	<!-- Length of track in cell that describes route -->
 	<string name="length">Länge</string>
 	<string name="share_my_location">Meinen Standort teilen</string>
@@ -450,7 +450,7 @@
 	<string name="level">Stockwerk</string>
 	<string name="downloader_delete_map_dialog">Alle Kartenänderungen werden zusammen mit der Karte gelöscht.</string>
 	<string name="downloader_update_maps">Karten aktualisieren</string>
-	<string name="downloader_mwm_migration_dialog">Um eine Strecke zu erstellen, müssen Sie alle Karten aktualisieren und dann die Strecken erneut planen.</string>
+	<string name="downloader_mwm_migration_dialog">Um eine Route zu erstellen, müssen Sie alle Karten aktualisieren und dann die Route erneut planen.</string>
 	<string name="downloader_search_field_hint">Karte finden</string>
 	<string name="common_check_internet_connection_dialog">Bitte überprüfen Sie Ihre Einstellungen und stellen Sie sicher, dass Ihr Gerät mit dem Internet verbunden ist.</string>
 	<string name="downloader_no_space_title">Nicht genug Speicherplatz</string>
@@ -602,8 +602,8 @@
 	  <item quantity="other">%d Orte</item>
 	</plurals>
 	<plurals name="tracks">
-	  <item quantity="one">%d Strecke</item>
-	  <item quantity="other">%d Strecken</item>
+	  <item quantity="one">%d Track</item>
+	  <item quantity="other">%d Tracks</item>
 	</plurals>
 	<!-- used to choose between the Google and Android location services -->
 	<string name="subtittle_opt_out">Standortdienste</string>

--- a/android/res/values-pl/strings.xml
+++ b/android/res/values-pl/strings.xml
@@ -580,7 +580,7 @@
 	<string name="bookmark_lists_show_all">Pokaż wszystkie</string>
 	<string name="bookmarks_create_new_group">Utwórz nową listę</string>
 	<!-- Bookmark categories screen, button that opens folder selection dialog to import KML/KMZ/GPX/KMB files -->
-	<string name="bookmarks_import">Importuj zakładki i utwory</string>
+	<string name="bookmarks_import">Importuj zakładki i trasy</string>
 	<string name="bookmarks_error_message_share_general">Nie można udostępnić z powodu błędu aplikacji</string>
 	<string name="bookmarks_error_title_share_empty">Błąd udostępniania</string>
 	<string name="bookmarks_error_message_share_empty">Nie można udostępnić pustej listy</string>

--- a/data/strings/strings.txt
+++ b/data/strings/strings.txt
@@ -18681,7 +18681,7 @@
     mr = बुकमार्क आणि ट्रॅक आयात करा
     nb = Importer bokmerker og spor
     nl = Bladwijzers en tracks importeren
-    pl = Importuj zakładki i utwory
+    pl = Importuj zakładki i trasy
     pt = Importar favoritos e trilhas
     ro = Importați marcaje și piese
     ru = Импортировать метки и треки

--- a/iphone/Maps/LocalizedStrings/de.lproj/InfoPlist.strings
+++ b/iphone/Maps/LocalizedStrings/de.lproj/InfoPlist.strings
@@ -10,7 +10,7 @@
 "search" = "Suche";
 
 /* Used in home screen quick actions. */
-"bookmarks_and_tracks" = "Lesezeichen und Strecken";
+"bookmarks_and_tracks" = "Lesezeichen und Tracks";
 
 /* Used in home screen quick actions. */
 "route" = "Route";

--- a/iphone/Maps/LocalizedStrings/de.lproj/Localizable.strings
+++ b/iphone/Maps/LocalizedStrings/de.lproj/Localizable.strings
@@ -75,7 +75,7 @@
 "bookmarks" = "Lesezeichen";
 
 /* "Bookmarks and Tracks" dialog title, also sync it with iphone/plist.txt */
-"bookmarks_and_tracks" = "Lesezeichen und Strecken";
+"bookmarks_and_tracks" = "Lesezeichen und Tracks";
 
 /* Default bookmark list name */
 "core_my_places" = "Meine Orte";
@@ -200,7 +200,7 @@
 "data_version" = "OpenStreetMap-Daten: %@";
 
 /* Title for tracks category in bookmarks manager */
-"tracks_title" = "Strecken";
+"tracks_title" = "Tracks";
 
 /* Length of track in cell that describes route */
 "length" = "Länge";
@@ -242,7 +242,7 @@
 "pref_tts_other_section_title" = "Weitere";
 
 /* Settings «Map» category: «Record track» title */
-"pref_track_record_title" = "Letzte Strecke";
+"pref_track_record_title" = "Letzter Track";
 
 "pref_map_auto_zoom" = "Auto-Zoom";
 
@@ -1220,16 +1220,16 @@
 "whats_new_auto_update_button_later" = "Später manuell aktualisieren";
 
 /* Delete track button on track edit screen */
-"placepage_delete_track_button" = "Strecke löschen";
+"placepage_delete_track_button" = "Track löschen";
 
 /* Placeholder for track name input on track edit screen */
-"placepage_track_name_hint" = "Name der Strecke";
+"placepage_track_name_hint" = "Name des Tracks";
 
 /* move track or bookmark from the list button text */
 "move" = "verschieben";
 
 /* edit track screen title */
-"track_title" = "Strecke";
+"track_title" = "Track";
 
 /* Telegram group url for the "?" About page */
 "telegram_url" = "https://t.me/OrganicMapsApp";

--- a/iphone/Maps/LocalizedStrings/de.lproj/Localizable.stringsdict
+++ b/iphone/Maps/LocalizedStrings/de.lproj/Localizable.stringsdict
@@ -69,9 +69,9 @@
       <key>NSStringFormatValueTypeKey</key>
       <string>d</string>
       <key>one</key>
-      <string>%d Strecke</string>
+      <string>%d Track</string>
       <key>other</key>
-      <string>%d Strecken</string>
+      <string>%d Tracks</string>
     </dict>
   </dict>
 </dict>


### PR DESCRIPTION
Small fix for https://github.com/organicmaps/organicmaps/pull/5369 ("utwory" actually means "music tracks" 😅)

Strings regeneration added also some german translations, probably because `tools/unix/generate_localizations.sh` was not run before 🤔.