### PR TITLE
[3party] Upgrade freetype to 2.13.1

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -37,7 +37,7 @@
   url = https://github.com/unicode-org/icu.git
 [submodule "3party/freetype/freetype"]
 	path = 3party/freetype/freetype
-	url = https://github.com/freetype/freetype.git
+	url = https://gitlab.freedesktop.org/freetype/freetype.git
 [submodule "3party/googletest"]
 	path = 3party/googletest
 	url = https://github.com/google/googletest.git


### PR DESCRIPTION
Also change the git submodule to Gitlab, because Github is not kept in sync.

Required for #4281