### PR TITLE
[ci] Use ccache to decrease build time

### DIFF
--- a/.github/workflows/linux-check.yaml
+++ b/.github/workflows/linux-check.yaml
@@ -26,11 +26,9 @@ jobs:
   linux-no-unity:
     name: Linux no unity build
     runs-on: ubuntu-22.04
-    strategy:
-      fail-fast: false
     # Cancels previous jobs if the same branch or PR was updated again.
     concurrency:
-      group: ${{ github.workflow }}-${{ matrix.compiler.CC }}-${{ matrix.CMAKE_BUILD_TYPE }}-${{ github.event.pull_request.number || github.ref }}
+      group: ${{ github.workflow }}-no-unity-${{ github.event.pull_request.number || github.ref }}
       cancel-in-progress: true
 
     steps:
@@ -63,6 +61,11 @@ jobs:
         shell: bash
         run: ./configure.sh
 
+      - name: Configure ccache
+        uses: hendrikmuhs/ccache-action@v1.2
+        with:
+          key: ${{ github.workflow }}-no-unity
+
       - name: CMake
         shell: bash
         env:
@@ -70,7 +73,9 @@ jobs:
           CXX: clang++-14
         # -g1 should slightly reduce build time.
         run: |
-          cmake . -B build -G Ninja -DCMAKE_BUILD_TYPE=Debug -DCMAKE_CXX_FLAGS=-g1 -DUNITY_DISABLE=ON
+          cmake . -B build -G Ninja -DCMAKE_BUILD_TYPE=Debug \
+            -DCMAKE_C_COMPILER_LAUNCHER=ccache -DCMAKE_CXX_COMPILER_LAUNCHER=ccache \
+            -DCMAKE_CXX_FLAGS=-g1 -DUNITY_DISABLE=ON
 
       - name: Compile
         shell: bash
@@ -85,6 +90,10 @@ jobs:
       matrix:
         compiler: [{ CXX: g++-12, CC: gcc-12 }, { CXX: clang++-14, CC: clang-14 }]
         CMAKE_BUILD_TYPE: [Debug, RelWithDebInfo]
+    # Cancels previous jobs if the same branch or PR was updated again.
+    concurrency:
+      group: ${{ github.workflow }}-unity-${{ matrix.compiler.CC }}-${{ matrix.CMAKE_BUILD_TYPE }}-${{ github.event.pull_request.number || github.ref }}
+      cancel-in-progress: true
 
     steps:
       - name: Free disk space by removing .NET, Android and Haskell
@@ -116,6 +125,11 @@ jobs:
         shell: bash
         run: ./configure.sh
 
+      - name: Configure ccache
+        uses: hendrikmuhs/ccache-action@v1.2
+        with:
+          key: ${{ github.workflow }}-unity-${{ matrix.compiler.CC }}-${{ matrix.CMAKE_BUILD_TYPE }}
+
       - name: CMake
         shell: bash
         env:
@@ -124,7 +138,9 @@ jobs:
         # -g1 should slightly reduce build time.
         run: |
           echo "Building ${{ matrix.CMAKE_BUILD_TYPE }}"
-          cmake . -B build -G Ninja -DCMAKE_BUILD_TYPE=${{ matrix.CMAKE_BUILD_TYPE }} -DCMAKE_C_FLAGS=-g1 -DCMAKE_CXX_FLAGS=-g1
+          cmake . -B build -G Ninja -DCMAKE_BUILD_TYPE=${{ matrix.CMAKE_BUILD_TYPE }} \
+            -DCMAKE_C_COMPILER_LAUNCHER=ccache -DCMAKE_CXX_COMPILER_LAUNCHER=ccache \
+            -DCMAKE_C_FLAGS=-g1 -DCMAKE_CXX_FLAGS=-g1
 
       - name: Compile
         shell: bash

--- a/.github/workflows/macos-check.yaml
+++ b/.github/workflows/macos-check.yaml
@@ -55,11 +55,18 @@ jobs:
         shell: bash
         run: ./configure.sh
 
+      - name: Configure ccache
+        uses: hendrikmuhs/ccache-action@v1.2
+        with:
+          key: ${{ github.workflow }}-${{ matrix.CMAKE_BUILD_TYPE }}
+
       - name: CMake
         shell: bash
         run: |
           echo "Building ${{ matrix.CMAKE_BUILD_TYPE }}"
-          cmake . -B build -G Ninja -DCMAKE_BUILD_TYPE=${{ matrix.CMAKE_BUILD_TYPE }} -DCMAKE_C_FLAGS=-g1 -DCMAKE_CXX_FLAGS=-g1
+          cmake . -B build -G Ninja -DCMAKE_BUILD_TYPE=${{ matrix.CMAKE_BUILD_TYPE }} \
+            -DCMAKE_C_COMPILER_LAUNCHER=ccache -DCMAKE_CXX_COMPILER_LAUNCHER=ccache \
+            -DCMAKE_C_FLAGS=-g1 -DCMAKE_CXX_FLAGS=-g1
 
       - name: Compile
         shell: bash


### PR DESCRIPTION
Use ccache to store C++ caches for each build configuration

Stats:
| Build | Ccache | No Ccache | Increase |
|--------|--------|--------|--------|
| MacOs Debug | 4m44s | 18m41s | 3.9x |
| MacOs RelWithDebInfo | 1m8s | 23m50s | 21x |
| Linux no unity | 7m54s | 33m13s | 4.2x |
| Linux g++ Debug | 3m13s | 17m54s | 5.5x |
| Linux g++ RelWithDebInfo | 31m43s | 35m31s | 1.1x | 
| Linux clang Debug | 2m29s | 15m57s | 6.4x | 
| Linux clang RelWithDebInfo | 2m38s | 22m16s | 8.5x | 