### PR TITLE
fix crash on PinePhone

### DIFF
--- a/qt/qt_common/map_widget.cpp
+++ b/qt/qt_common/map_widget.cpp
@@ -200,7 +200,7 @@ void MapWidget::Build()
 {
   std::string vertexSrc;
   std::string fragmentSrc;
-  if (m_apiOpenGLES3)
+  if (m_apiOpenGLES3 && context()->format().version() >= qMakePair(3, 2))
   {
     vertexSrc =
         "\


### PR DESCRIPTION
Before setting a shader program requiring GLSL version 1.50 we need to make sure the GL context has appropriate capabilities.

Fixes https://github.com/flathub/app.organicmaps.desktop/issues/36