### PR TITLE
[ci] Trigger Linux and MacOS builds on push to master

### DIFF
--- a/.github/workflows/linux-check.yaml
+++ b/.github/workflows/linux-check.yaml
@@ -1,6 +1,9 @@
 name: Linux Check
 on:
   workflow_dispatch: # Manual trigger
+  push:
+    branches:
+      - master
   pull_request:
     paths-ignore:
       - .gitignore

--- a/.github/workflows/macos-check.yaml
+++ b/.github/workflows/macos-check.yaml
@@ -1,6 +1,9 @@
 name: macOS Check
 on:
   workflow_dispatch: # Manual trigger
+  push:
+    branches:
+      - master
   pull_request:
     paths-ignore:
       - .gitignore


### PR DESCRIPTION
This PR should create a cache in the master branch that will be accessible for future PRs.

https://docs.github.com/en/actions/using-workflows/caching-dependencies-to-speed-up-workflows#restrictions-for-accessing-a-cache

>Workflow runs can restore caches created in either the current branch or the default branch (usually main).
