### PR TITLE
Fix social contacts parsing on edits loading

### DIFF
--- a/editor/editor_tests/xml_feature_test.cpp
+++ b/editor/editor_tests/xml_feature_test.cpp
@@ -499,18 +499,6 @@ UNIT_TEST(XMLFeature_SocialContactsProcessing)
     osm::EditableMapObject emo;
     editor::FromXML(xmlFeature, emo);
 
-    // Read and write "contact:facebook" to apply normalization.
-    std::string contactFacebook(emo.GetMetadata(feature::Metadata::FMD_CONTACT_FACEBOOK));
-    emo.SetMetadata(osm::MapObject::MetadataID::FMD_CONTACT_FACEBOOK, contactFacebook);
-
-    // Read and write "contact:instagram" to apply normalization.
-    std::string contactInstagram(emo.GetMetadata(feature::Metadata::FMD_CONTACT_INSTAGRAM));
-    emo.SetMetadata(osm::MapObject::MetadataID::FMD_CONTACT_INSTAGRAM, contactInstagram);
-
-    // Read and write "contact:line" to apply normalization.
-    std::string contactLine(emo.GetMetadata(feature::Metadata::FMD_CONTACT_LINE));
-    emo.SetMetadata(osm::MapObject::MetadataID::FMD_CONTACT_LINE, contactLine);
-
     auto convertedFt = editor::ToXML(emo, true);
 
     TEST(convertedFt.HasTag("contact:facebook"), ());
@@ -541,18 +529,6 @@ UNIT_TEST(XMLFeature_SocialContactsProcessing_clean)
 
     osm::EditableMapObject emo;
     editor::FromXML(xmlFeature, emo);
-
-    // Read and write "contact:facebook" to apply normalization.
-    std::string contactFacebook(emo.GetMetadata(feature::Metadata::FMD_CONTACT_FACEBOOK));
-    emo.SetMetadata(osm::MapObject::MetadataID::FMD_CONTACT_FACEBOOK, contactFacebook);
-
-    // Read and write "contact:instagram" to apply normalization.
-    std::string contactInstagram(emo.GetMetadata(feature::Metadata::FMD_CONTACT_INSTAGRAM));
-    emo.SetMetadata(osm::MapObject::MetadataID::FMD_CONTACT_INSTAGRAM, contactInstagram);
-
-    // Read and write "contact:line" to apply normalization.
-    std::string contactLine(emo.GetMetadata(feature::Metadata::FMD_CONTACT_LINE));
-    emo.SetMetadata(osm::MapObject::MetadataID::FMD_CONTACT_LINE, contactLine);
 
     auto convertedFt = editor::ToXML(emo, true);
 

--- a/indexer/editable_map_object.cpp
+++ b/indexer/editable_map_object.cpp
@@ -483,7 +483,7 @@ bool EditableMapObject::UpdateMetadataValue(string_view key, string value)
   if (!feature::Metadata::TypeFromString(key, type))
     return false;
 
-  m_metadata.Set(type, std::move(value));
+  SetMetadata(type, std::move(value));
   return true;
 }
 


### PR DESCRIPTION
The issue #5509 is caused by edits save/load. When POI is modified it's saved on device in OSM XML format using `editor::ToXML(...)` method with explicit social contacts processing. Function `editor::ApplyPatch(...)` loads OSM XML but skips social contacts normalization.

Method `EditableMapObject::UpdateMetadataValue` is used only within `xml_feature.cpp` so this fix should not affect OM functionality.

Closes #5509.