### PR TITLE
Discard similar geometry

### DIFF
--- a/generator/generator_tool/generator_tool.cpp
+++ b/generator/generator_tool/generator_tool.cpp
@@ -172,8 +172,10 @@ DEFINE_string(us_postcodes_dataset, "", "Path to dataset with US postcodes.");
 // Printing stuff.
 DEFINE_bool(stats_general, false, "Print file and feature stats.");
 DEFINE_bool(stats_geometry, false, "Print outer geometry stats.");
-DEFINE_double(stats_geometry_dup_factor, 1.5, "Consider feature's geometry scale "
-              "duplicating a more detailed one if it has <dup_factor less elements.");
+DEFINE_uint64(stats_geom_min_diff, 5, "Consider feature's geometry scale "
+              "similar to a more detailed one if it has <min_diff less elements.");
+DEFINE_double(stats_geom_min_factor, 2.0f, "Consider feature's geometry scale "
+              "similar to a more detailed one if it has <min_factor times less elements.");
 DEFINE_bool(stats_types, false, "Print feature stats by type.");
 DEFINE_bool(dump_types, false, "Prints all types combinations and their total count.");
 DEFINE_bool(dump_prefixes, false, "Prints statistics on feature's' name prefixes.");
@@ -595,7 +597,8 @@ MAIN_WITH_ERROR_HANDLING([](int argc, char ** argv)
   {
     LOG(LINFO, ("Calculating statistics for", dataFile));
     auto file = OfstreamWithExceptions(genInfo.GetIntermediateFileName(FLAGS_output, STATS_EXTENSION));
-    stats::MapInfo info(FLAGS_stats_geometry_dup_factor);
+    file << std::fixed << std::setprecision(1);
+    stats::MapInfo info(FLAGS_stats_geom_min_diff, FLAGS_stats_geom_min_factor);
     stats::CalcStats(dataFile, info);
 
     if (FLAGS_stats_general)

--- a/generator/statistics.hpp
+++ b/generator/statistics.hpp
@@ -64,9 +64,13 @@ namespace stats
 
   struct MapInfo
   {
-    explicit MapInfo(double geometryDupFactor) : m_geometryDupFactor(geometryDupFactor) {}
+    explicit MapInfo(int geomMinDiff, double geomMinFactor)
+      : m_geomMinDiff(geomMinDiff)
+      , m_geomMinFactor(geomMinFactor)
+    {}
 
-    double m_geometryDupFactor;
+    size_t m_geomMinDiff;
+    double m_geomMinFactor;
 
     std::map<feature::GeomType, GeneralInfo> m_byGeomType;
     std::map<ClassifType, GeneralInfo> m_byClassifType;
@@ -74,10 +78,11 @@ namespace stats
     std::map<AreaType, GeneralInfo> m_byAreaSize;
 
     GeomStats m_byLineGeom, m_byAreaGeom,
-              m_byLineGeomCompared, m_byAreaGeomCompared,
+              m_byLineGeomComparedS, m_byLineGeomComparedD,
+              m_byAreaGeomComparedS, m_byAreaGeomComparedD,
               m_byLineGeomDup, m_byAreaGeomDup;
 
-    GeneralInfo m_inner[3];
+    GeneralInfo m_innerPoints, m_innerFirstPoints, m_innerStrips, m_innerSize;
   };
 
   void PrintFileContainerStats(std::ostream & os, std::string const & fPath);

--- a/indexer/feature.cpp
+++ b/indexer/feature.cpp
@@ -385,8 +385,10 @@ void FeatureType::ParseHeader2()
     }
     else
     {
-      // Outer geometry: first point is stored in the header still.
+      // Outer geometry: first (base) point is stored in the header still.
+      auto const * start = src.PtrUint8();
       m_points.emplace_back(serial::LoadPoint(src, cp));
+      m_innerStats.m_firstPoints = CalcOffset(src, start);
       ReadOffsets(*m_loadInfo, src, ptsMask, m_offsets.m_pts);
     }
   }

--- a/indexer/feature.cpp
+++ b/indexer/feature.cpp
@@ -89,10 +89,15 @@ int GetScaleIndex(SharedLoadInfo const & loadInfo, int scale,
     int const lastScale = loadInfo.GetLastScale();
     if (scale > lastScale)
       scale = lastScale;
-    while (ind < count && scale > loadInfo.GetScale(ind))
+    // If there is no geometry for the requested scale
+    // fallback to the next more detailed one.
+    while (ind < count && (scale > loadInfo.GetScale(ind) || offsets[ind] == kInvalidOffset))
       ++ind;
+    // Some WorldCoasts features have idx == 0 geometry only and its possible
+    // other features to be visible on e.g. idx == 1 only,
+    // but then they shouldn't be attempted to be drawn using other geom scales.
     ASSERT_LESS(ind, count, ("No suitable geometry scale range in the map file."));
-    return (offsets[ind] != kInvalidOffset ? ind : -1);
+    return (ind < count ? ind : -1);
   }
   }
 
@@ -332,29 +337,18 @@ void FeatureType::ParseHeader2()
   CHECK(m_loadInfo, ());
   ParseCommon();
 
-  uint8_t ptsCount = 0, ptsMask = 0, trgCount = 0, trgMask = 0;
+  uint8_t elemsCount = 0, geomScalesMask = 0;
   BitSource bitSource(m_data.data() + m_offsets.m_header2);
   auto const headerGeomType = static_cast<HeaderGeomType>(Header(m_data) & HEADER_MASK_GEOMTYPE);
 
-  if (headerGeomType == HeaderGeomType::Line)
+  if (headerGeomType == HeaderGeomType::Line || headerGeomType == HeaderGeomType::Area)
   {
-    ptsCount = bitSource.Read(4);
-    if (ptsCount == 0)
-    {
-      // Outer geometry: read offsets mask.
-      ptsMask = bitSource.Read(4);
-    }
+    elemsCount = bitSource.Read(4);
+    // For outer geometry read the geom scales (offsets) mask.
+    if (elemsCount == 0)
+      geomScalesMask = bitSource.Read(4);
     else
-      ASSERT_GREATER(ptsCount, 1, ());
-  }
-  else if (headerGeomType == HeaderGeomType::Area)
-  {
-    trgCount = bitSource.Read(4);
-    if (trgCount == 0)
-    {
-      // Outer geometry: read offsets mask.
-      trgMask = bitSource.Read(4);
-    }
+      ASSERT(headerGeomType == HeaderGeomType::Area || elemsCount > 1, ());
   }
 
   ArrayByteSource src(bitSource.RoundPtr());
@@ -362,14 +356,14 @@ void FeatureType::ParseHeader2()
 
   if (headerGeomType == HeaderGeomType::Line)
   {
-    if (ptsCount > 0)
+    if (elemsCount > 0)
     {
       // Inner geometry.
       // Number of bytes in simplification mask:
       // first and last points are never simplified/discarded,
       // 2 bits are used per each other point, i.e.
       // 3-6 pts - 1 byte, 7-10 pts - 2b, 11-14 pts - 3b.
-      int const count = ((ptsCount - 2) + 4 - 1) / 4;
+      int const count = ((elemsCount - 2) + 4 - 1) / 4;
       ASSERT_LESS(count, 4, ());
 
       for (int i = 0; i < count; ++i)
@@ -379,9 +373,9 @@ void FeatureType::ParseHeader2()
       }
 
       auto const * start = src.PtrUint8();
-      src = ArrayByteSource(serial::LoadInnerPath(start, ptsCount, cp, m_points));
+      src = ArrayByteSource(serial::LoadInnerPath(start, elemsCount, cp, m_points));
       // TODO: here and further m_innerStats is needed for stats calculation in generator_tool only
-      m_innerStats.m_points = static_cast<uint32_t>(src.PtrUint8() - start);
+      m_innerStats.m_points = CalcOffset(src, start);
     }
     else
     {
@@ -389,24 +383,24 @@ void FeatureType::ParseHeader2()
       auto const * start = src.PtrUint8();
       m_points.emplace_back(serial::LoadPoint(src, cp));
       m_innerStats.m_firstPoints = CalcOffset(src, start);
-      ReadOffsets(*m_loadInfo, src, ptsMask, m_offsets.m_pts);
+      ReadOffsets(*m_loadInfo, src, geomScalesMask, m_offsets.m_pts);
     }
   }
   else if (headerGeomType == HeaderGeomType::Area)
   {
-    if (trgCount > 0)
+    if (elemsCount > 0)
     {
       // Inner geometry (strips).
-      trgCount += 2;
+      elemsCount += 2;
 
       auto const * start = src.PtrUint8();
-      src = ArrayByteSource(serial::LoadInnerTriangles(start, trgCount, cp, m_triangles));
+      src = ArrayByteSource(serial::LoadInnerTriangles(start, elemsCount, cp, m_triangles));
       m_innerStats.m_strips = CalcOffset(src, start);
     }
     else
     {
       // Outer geometry.
-      ReadOffsets(*m_loadInfo, src, trgMask, m_offsets.m_trg);
+      ReadOffsets(*m_loadInfo, src, geomScalesMask, m_offsets.m_trg);
     }
   }
   // Size of the whole header incl. inner geometry / triangles.
@@ -486,8 +480,7 @@ void FeatureType::ParseGeometry(int scale)
 
 FeatureType::GeomStat FeatureType::GetOuterGeometryStats()
 {
-  ASSERT(!m_parsed.m_points, ("Geometry had been parsed already!"));
-  CHECK(m_loadInfo, ());
+  CHECK(m_loadInfo && m_parsed.m_header2 && !m_parsed.m_points, ("Call geometry stats first and once!"));
   size_t const scalesCount = m_loadInfo->GetScalesCount();
   ASSERT_LESS_OR_EQUAL(scalesCount, DataHeader::kMaxScalesCount, ("MWM has too many geometry scales!"));
   FeatureType::GeomStat res;
@@ -563,8 +556,7 @@ void FeatureType::ParseTriangles(int scale)
 
 FeatureType::GeomStat FeatureType::GetOuterTrianglesStats()
 {
-  ASSERT(!m_parsed.m_triangles, ("Triangles had been parsed already!"));
-  CHECK(m_loadInfo, ());
+  CHECK(m_loadInfo && m_parsed.m_header2 && !m_parsed.m_triangles, ("Call geometry stats first and once!"));
   int const scalesCount = m_loadInfo->GetScalesCount();
   ASSERT_LESS_OR_EQUAL(scalesCount, static_cast<int>(DataHeader::kMaxScalesCount), ("MWM has too many geometry scales!"));
   FeatureType::GeomStat res;
@@ -641,7 +633,7 @@ StringUtf8Multilang const & FeatureType::GetNames()
   return m_params.name;
 }
 
-string FeatureType::DebugString(int scale)
+string FeatureType::DebugString(int scale, bool includeKeyPoint)
 {
   ParseCommon();
 
@@ -659,6 +651,9 @@ string FeatureType::DebugString(int scale)
     res += paramsStr;
     res += "\n";
   }
+
+  if (!includeKeyPoint)
+    return res;
 
   ParseGeometryAndTriangles(scale);
   m2::PointD keyPoint;

--- a/indexer/feature.hpp
+++ b/indexer/feature.hpp
@@ -169,7 +169,7 @@ public:
   //@{
   struct InnerGeomStat
   {
-    uint32_t m_points = 0, m_strips = 0, m_size = 0;
+    uint32_t m_points = 0, m_firstPoints = 0, m_strips = 0, m_size = 0;
   };
 
   InnerGeomStat GetInnerStats() const { return m_innerStats; }

--- a/indexer/feature.hpp
+++ b/indexer/feature.hpp
@@ -138,7 +138,7 @@ public:
   }
   //@}
 
-  std::string DebugString(int scale);
+  std::string DebugString(int scale, bool includeKeyPoint = true);
 
   std::string const & GetHouseNumber();
 


### PR DESCRIPTION
Closes #2927.

If a geometry is too similar to a more detailed geom scale then discard it and use the more detailed one for rendering.

Pros and cons:
`+` smaller mwms
`+` slightly better rendering quality as some features stay detailed on more zoom levels
`-` slightly slower reading and rendering (could be offset somewhat by more efficient file cache utilisation)

With the current settings (`kGeomMinDiff = 8` and `kGeomMinFactor=2.0`) some geom scales of my test mwms were reduced 3 times, though overall impact on geometry size and mwm size is quite modest. The biggest mwm size reduction I saw was 13%, but its w/o isolines, wiki descriptions, etc.
Isolines are likely to be well optimizable - I'm yet to test it.

Sample optimization stats for Auckland, NZ (4% mwm reduction):
(`similar` lines are what gets discarded)
```
Outer LINE geometry
    geom0: size =     36907: elements =     13735; features =    3515; elems/feats =   3.9; bytes/elems =  2.7
    geom1: size =    275951: elements =    102445; features =   19367; elems/feats =   5.3; bytes/elems =  2.7
    geom2: size =   1929023: elements =    693934; features =   60533; elems/feats =  11.5; bytes/elems =  2.8
    geom3: size =   6821746: elements =   2915472; features =   67466; elems/feats =  43.2; bytes/elems =  2.3
Geometry of features present on adjacent geom scales incl. very similar geometries
(when number of elements is <8 less or <2.0x times less)
geom0 vs geom1: size difference =  2.7x; elems difference =  2.5x; features =    3515
    geom0: size =     36907; elements =     13735; elems/feats =   3.9
    geom1: size =    101233; elements =     34677; elems/feats =   9.9
    similar: size =     16551 (44%); elements =      7310; features =    3026; elems/feats =   2.4
geom1 vs geom2: size difference =  2.3x; elems difference =  2.2x; features =   19367
    geom1: size =    275951; elements =    102445; elems/feats =   5.3
    geom2: size =    634572; elements =    224415; elems/feats =  11.6
    similar: size =    134208 (48%); elements =     54979; features =   16244; elems/feats =   3.4
geom2 vs geom3: size difference =  3.3x; elems difference =  3.9x; features =   60533
    geom2: size =   1929023; elements =    693934; elems/feats =  11.5
    geom3: size =   6360765; elements =   2702164; elems/feats =  44.6
    similar: size =    167209 ( 8%); elements =     58540; features =    2153; elems/feats =  27.2

Outer AREA geometry
    trg0: size =    287072: elements =     54154; features =    5147; elems/feats =  10.5; bytes/elems =  5.3
    trg1: size =   1787854: elements =    381387; features =   35110; elems/feats =  10.9; bytes/elems =  4.7
    trg2: size =   6523761: elements =   1724169; features =   67530; elems/feats =  25.5; bytes/elems =  3.8
    trg3: size =  23613755: elements =   6962510; features =  371249; elems/feats =  18.8; bytes/elems =  3.4
Geometry of features present on adjacent geom scales incl. very similar geometries
(when number of elements is <8 less or <2.0x times less)
trg0 vs trg1: size difference =  3.3x; elems difference =  4.5x; features =    5147
    trg0: size =    287072; elements =     54154; elems/feats =  10.5
    trg1: size =    948876; elements =    243949; elems/feats =  47.4
    similar: size =     21349 ( 7%); elements =      2220; features =     989; elems/feats =   2.2
trg1 vs trg2: size difference =  2.5x; elems difference =  3.2x; features =   35110
    trg1: size =   1787854; elements =    381387; elems/feats =  10.9
    trg2: size =   4515493; elements =   1221404; elems/feats =  34.8
    similar: size =    265253 (14%); elements =     36123; features =   11357; elems/feats =   3.2
trg2 vs trg3: size difference =  2.2x; elems difference =  2.3x; features =   67530
    trg2: size =   6523761; elements =   1724169; elems/feats =  25.5
    trg3: size =  14076154; elements =   4032470; elems/feats =  59.7
    similar: size =   3084246 (47%); elements =    839420; features =   22009; elems/feats =  38.1
```

I did some crude benchmarks and there might be ~5% overall render time increase for big cities at z10.
So the current settings `kGeomMinDiff = 8` and `kGeomMinFactor=2.0` seems to be too aggressive.
I'll experiment with more conservative values and with isolines.

Otherwise the code is good to review!
