### PR TITLE
[generator] Don't simplify isolines' source geometry again

### DIFF
--- a/generator/feature_sorter.cpp
+++ b/generator/feature_sorter.cpp
@@ -14,6 +14,7 @@
 #include "indexer/feature_algo.hpp"
 #include "indexer/feature_impl.hpp"
 #include "indexer/feature_processor.hpp"
+#include "indexer/ftypes_matcher.hpp"
 #include "indexer/scales.hpp"
 #include "indexer/scales_patch.hpp"
 
@@ -167,8 +168,11 @@ public:
         // Simplify and serialize geometry.
         Points points;
 
-        // Do not change linear geometry for the upper scale.
-        if (isLine && i == scalesStart && IsCountry() && routing::IsRoad(fb.GetTypes()))
+        // Do not change upper scale (the most detailed) linear geometry
+        // for roads (for more precise distances calculation)
+        // and for isolines (they had been simplified already while being generated).
+        if (isLine && i == scalesStart && IsCountry() &&
+            (routing::IsRoad(fb.GetTypes()) || ftypes::IsIsolineChecker::Instance()(fb.GetTypes())))
           points = holder.GetSourcePoints();
         else
           SimplifyPoints(level, isCoast, rect, holder.GetSourcePoints(), points);

--- a/indexer/scales.cpp
+++ b/indexer/scales.cpp
@@ -55,10 +55,12 @@ namespace scales
 
   double GetEpsilonForSimplify(int level)
   {
-    // Keep better geometries on highest zoom to allow scaling them deeper
+    // Keep better geometries on highest zoom to allow scaling them deeper.
+    // Effectively it leads to x26 precision difference from geom scale 2 to 3.
+    // Keep crude geometries for all other zooms,
+    // x4 precision difference from geom scale 0 to 1 and 1 to 2.
     if (level == GetUpperScale())
       return GetEpsilonImpl(level, 0.4);
-    // Keep crude geometries for all other zooms
     else
       return GetEpsilonImpl(level, 1.3);
   }

--- a/topography_generator/generator.cpp
+++ b/topography_generator/generator.cpp
@@ -622,6 +622,8 @@ void Generator::PackIsolinesForCountry(storage::CountryId const & countryId,
 
       CropContours(countryRect, countryRegions, params.m_maxIsolineLength,
                    params.m_alitudesStepFactor, isolines);
+      // Simplification is done already while processing tiles in ProcessTile().
+      // But now a different simpificationZoom could be applied?
       if (params.m_simplificationZoom > 0)
         SimplifyContours(params.m_simplificationZoom, isolines);
 


### PR DESCRIPTION
No need to simplify isolines' geom3 again - as it was done during the isolines generation already. For me it gives a few percent map generation time speed up.

There could be tiny differences for some isolines of mwms that use profiles`high` and `high_f2` with `simplificationZoom: 17` (same as geom3), e.g. re-simplification could produces 437 points instead of 440. Probably this is because the simplification algo doesn't always produce the most optimal result in the first run.