### PR TITLE
[ios] Fixes wikipedia place description text in dark mode

### DIFF
--- a/iphone/Maps/Core/Theme/Extensions/UIColor+hexString.swift
+++ b/iphone/Maps/Core/Theme/Extensions/UIColor+hexString.swift
@@ -1,0 +1,23 @@
+extension UIColor {
+    var hexString: String {
+      let cgColorInRGB = cgColor.converted(to: CGColorSpace(name: CGColorSpace.sRGB)!, intent: .defaultIntent, options: nil)!
+              let colorRef = cgColorInRGB.components
+              let r = colorRef?[0] ?? 0
+              let g = colorRef?[1] ?? 0
+              let b = ((colorRef?.count ?? 0) > 2 ? colorRef?[2] : g) ?? 0
+              let a = cgColor.alpha
+
+              var color = String(
+                  format: "#%02lX%02lX%02lX",
+                  lroundf(Float(r * 255)),
+                  lroundf(Float(g * 255)),
+                  lroundf(Float(b * 255))
+              )
+
+              if a < 1 {
+                  color += String(format: "%02lX", lroundf(Float(a * 255)))
+              }
+
+              return color
+    }
+}

--- a/iphone/Maps/Core/Theme/Extensions/UIColor+hexString.swift
+++ b/iphone/Maps/Core/Theme/Extensions/UIColor+hexString.swift
@@ -31,7 +31,7 @@ extension UIColor {
         convertToHEX(component: b)
       )
 
-      if alpha < 1 {
+      if (alpha < 1) {
         color += String(format: hexColorComponentTemplate, convertToHEX(component: alpha))
       }
 

--- a/iphone/Maps/Core/Theme/Extensions/UIColor+hexString.swift
+++ b/iphone/Maps/Core/Theme/Extensions/UIColor+hexString.swift
@@ -1,23 +1,41 @@
 extension UIColor {
-    var hexString: String {
-      let cgColorInRGB = cgColor.converted(to: CGColorSpace(name: CGColorSpace.sRGB)!, intent: .defaultIntent, options: nil)!
-              let colorRef = cgColorInRGB.components
-              let r = colorRef?[0] ?? 0
-              let g = colorRef?[1] ?? 0
-              let b = ((colorRef?.count ?? 0) > 2 ? colorRef?[2] : g) ?? 0
-              let a = cgColor.alpha
-
-              var color = String(
-                  format: "#%02lX%02lX%02lX",
-                  lroundf(Float(r * 255)),
-                  lroundf(Float(g * 255)),
-                  lroundf(Float(b * 255))
-              )
-
-              if a < 1 {
-                  color += String(format: "%02lX", lroundf(Float(a * 255)))
-              }
-
-              return color
+  private func convertToHEX(component: CGFloat) -> Int {
+    return lroundf(Float(component * 255));
+  }
+  
+  private var hexColorComponentTemplate: String {
+    get {
+      return "%02lX";
     }
+  }
+  
+  private var hexColorTemplate: String {
+    get {
+      return "#\(hexColorComponentTemplate)\(hexColorComponentTemplate)\(hexColorComponentTemplate)";
+    }
+  }
+  
+  var hexString: String {
+    get {
+      let cgColorInRGB = cgColor.converted(to: CGColorSpace(name: CGColorSpace.sRGB)!, intent: .defaultIntent, options: nil)!
+      let colorRef = cgColorInRGB.components
+      let r = colorRef?[0] ?? 0
+      let g = colorRef?[1] ?? 0
+      let b = ((colorRef?.count ?? 0) > 2 ? colorRef?[2] : g) ?? 0
+      let alpha = cgColor.alpha
+      
+      var color = String(
+        format: hexColorTemplate,
+        convertToHEX(component: r),
+        convertToHEX(component: g),
+        convertToHEX(component: b)
+      )
+
+      if alpha < 1 {
+        color += String(format: hexColorComponentTemplate, convertToHEX(component: alpha))
+      }
+
+      return color
+    }
+  }
 }

--- a/iphone/Maps/Maps.xcodeproj/project.pbxproj
+++ b/iphone/Maps/Maps.xcodeproj/project.pbxproj
@@ -435,6 +435,7 @@
 		99F9A0E72462CA1700AE21E0 /* DownloadAllView.xib in Resources */ = {isa = PBXBuildFile; fileRef = 99F9A0E62462CA1700AE21E0 /* DownloadAllView.xib */; };
 		A630D1EA207CA95900976DEA /* Localizable.stringsdict in Resources */ = {isa = PBXBuildFile; fileRef = A630D1E8207CA95900976DEA /* Localizable.stringsdict */; };
 		AA1C7E3E269A2DD600BAADF2 /* EditTrackViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = AA1C7E3D269A2DD600BAADF2 /* EditTrackViewController.swift */; };
+		AC79C8922A65AB9500594C24 /* UIColor+hexString.swift in Sources */ = {isa = PBXBuildFile; fileRef = AC79C8912A65AB9500594C24 /* UIColor+hexString.swift */; };
 		B33D21AF20DAF9F000BAD749 /* Toast.swift in Sources */ = {isa = PBXBuildFile; fileRef = B33D21AE20DAF9F000BAD749 /* Toast.swift */; };
 		B3E3B4FD20D463B700DA8C13 /* BMCCategoriesHeader.xib in Resources */ = {isa = PBXBuildFile; fileRef = B3E3B4FC20D463B700DA8C13 /* BMCCategoriesHeader.xib */; };
 		BB25B1A71FB32767007276FA /* transit_colors.txt in Resources */ = {isa = PBXBuildFile; fileRef = BB25B1A51FB32767007276FA /* transit_colors.txt */; };
@@ -1283,6 +1284,7 @@
 		A630D205207CAA3A00976DEA /* zh-Hant */ = {isa = PBXFileReference; lastKnownFileType = text.plist.stringsdict; name = "zh-Hant"; path = "zh-Hant.lproj/Localizable.stringsdict"; sourceTree = "<group>"; };
 		A630D206207CAA5800976DEA /* zh-Hans */ = {isa = PBXFileReference; lastKnownFileType = text.plist.stringsdict; name = "zh-Hans"; path = "zh-Hans.lproj/Localizable.stringsdict"; sourceTree = "<group>"; };
 		AA1C7E3D269A2DD600BAADF2 /* EditTrackViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EditTrackViewController.swift; sourceTree = "<group>"; };
+		AC79C8912A65AB9500594C24 /* UIColor+hexString.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "UIColor+hexString.swift"; sourceTree = "<group>"; };
 		B33D21AE20DAF9F000BAD749 /* Toast.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Toast.swift; sourceTree = "<group>"; };
 		B3E3B4FC20D463B700DA8C13 /* BMCCategoriesHeader.xib */ = {isa = PBXFileReference; lastKnownFileType = file.xib; path = BMCCategoriesHeader.xib; sourceTree = "<group>"; };
 		BB25B1A51FB32767007276FA /* transit_colors.txt */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text; name = transit_colors.txt; path = ../../data/transit_colors.txt; sourceTree = "<group>"; };
@@ -2588,6 +2590,7 @@
 				993DF0D023F6BDB000AC231A /* UIView+styleName.swift */,
 				993DF0D123F6BDB000AC231A /* UINavigationItem+styleName.swift */,
 				993DF0D223F6BDB000AC231A /* UIColor+rgba.swift */,
+				AC79C8912A65AB9500594C24 /* UIColor+hexString.swift */,
 				993DF0D323F6BDB000AC231A /* UIColor+image.swift */,
 			);
 			path = Extensions;
@@ -4105,6 +4108,7 @@
 				99A906ED23F6F7030005872B /* PlacePagePreviewViewController.swift in Sources */,
 				993DF10223F6BDB100AC231A /* Colors.swift in Sources */,
 				34AB66201FC5AA330078E451 /* RouteStartButton.swift in Sources */,
+				AC79C8922A65AB9500594C24 /* UIColor+hexString.swift in Sources */,
 				99DEF9D723E420F6006BFD21 /* ElevationProfileDescriptionCell.swift in Sources */,
 				993DF11623F6BDB100AC231A /* UIWindowRenderer.swift in Sources */,
 				F660DEE51EAF4F59004DC056 /* MWMLocationManager+SpeedAndAltitude.swift in Sources */,

--- a/iphone/Maps/UI/PlacePage/Components/PlacePageDescriptionViewController.swift
+++ b/iphone/Maps/UI/PlacePage/Components/PlacePageDescriptionViewController.swift
@@ -3,9 +3,9 @@ final class PlacePageDescriptionViewController: WebViewController {
     let scale = UIScreen.main.scale
     let styleTags = """
       <head>
-      <style type=\"text/css\">
-        body{font-family: -apple-system, BlinkMacSystemFont, "Helvetica Neue", Helvetica, Arial, sans-serif, "Apple Color Emoji"; font-size:\(14 * scale); line-height:1.5em;}
-      </style>
+        <style type=\"text/css\">
+          body{font-family: -apple-system, BlinkMacSystemFont, "Helvetica Neue", Helvetica, Arial, sans-serif, "Apple Color Emoji"; font-size:\(14 * scale); line-height:1.5em; color: \(UIColor.isNightMode() ? UIColor.whitePrimaryText().hexString : UIColor.blackPrimaryText().hexString);}
+        </style>
       </head>
       <body>
     """


### PR DESCRIPTION
Added CSS color property in PlacePageDescriptionViewController.swift that is being substituted by particular hexCode of color depending on whether night mode is active or not.

I have decided to retrieve colors from UIColor because in future theme accents might change and this would result in additional work for finding this controller and replacing colors in it.

Fixes: #5364, #3042
Dark theme:
![Simulator Screenshot - iPhone 14 Pro - 2023-07-17 at 20 52 23](https://github.com/organicmaps/organicmaps/assets/12211483/ce2af37a-f3ef-4a52-8cd9-ac13377c797a)
Light theme:
![Simulator Screenshot - iPhone 14 Pro - 2023-07-17 at 20 52 49](https://github.com/organicmaps/organicmaps/assets/12211483/362d1824-b844-4614-ac09-3f3c1bdd70c8)
