### PR TITLE
Treat GPX track segments as part of the singular track they belong to

### DIFF
--- a/kml/kml_tests/gpx_tests.cpp
+++ b/kml/kml_tests/gpx_tests.cpp
@@ -72,14 +72,31 @@ UNIT_TEST(Gpx_Test_Route)
           <ele>0.0</ele>
       </trkpt>
     </trkseg>
+    <trkseg>
+      <trkpt lat="55.23955053156179" lon="25.114990234375004">
+          <ele>131.5</ele>
+      </trkpt>
+      <trkpt lat="54.32933804825253" lon="25.136718750000004">
+          <ele>0.0</ele>
+      </trkpt>
+    </trkseg>
 </trk>
 </gpx>
 )";
 
   kml::FileData const dataFromText = loadGpxFromString(input);
-  auto line = dataFromText.m_tracksData[0].m_geometry.m_lines[0];
-  TEST_EQUAL(line.size(), 3, ());
-  TEST_EQUAL(line[0], geometry::PointWithAltitude(mercator::FromLatLon(54.23955053156179, 24.114990234375004), 131), ());
+  auto const & lines = dataFromText.m_tracksData[0].m_geometry.m_lines;
+  TEST_EQUAL(lines.size(), 2, ());
+  {
+    auto const & line = lines[0];
+    TEST_EQUAL(line.size(), 3, ());
+    TEST_EQUAL(line.back(), geometry::PointWithAltitude(mercator::FromLatLon(54.05293900056246, 25.72998046875), 0), ());
+  }
+  {
+    auto const & line = lines[1];
+    TEST_EQUAL(line.size(), 2, ());
+    TEST_EQUAL(line.back(), geometry::PointWithAltitude(mercator::FromLatLon(54.32933804825253, 25.136718750000004), 0), ());
+  }
 }
 
 

--- a/kml/serdes_gpx.cpp
+++ b/kml/serdes_gpx.cpp
@@ -220,7 +220,7 @@ void GpxParser::Pop(std::string_view tag)
     m_altitude = geometry::kInvalidAltitude;
   }
 
-  if (tag == gpx::kRte || tag == gpx::kTrkSeg || tag == gpx::kWpt)
+  if (tag == gpx::kRte || tag == gpx::kTrk || tag == gpx::kWpt)
   {
     if (MakeValid())
     {


### PR DESCRIPTION
Some properties like name or colors were not applied to the entire "trk" track in GPX imports when the "trk" included multiple "trkseg" segments, but only to the first "trkseg" segment.
Now it imports multiple "trkseg" that are part of one "trk" as one


In the example below the color would have only applied to the first track segment, not the entire track

```
<trk>
    <extensions>
        <color>0000ff</color>
    </extensions>
    <trkseg>
    <trkpt lat="58.208378" lon="26.374915">
    </trkpt>
    <trkpt lat="58.208407" lon="26.374831">
    </trkpt>
    </trkseg>
    <trkseg>
    <trkpt lat="55.208378" lon="25.374915">
    </trkpt>
    <trkpt lat="55.208407" lon="25.374831">
    </trkpt>
    </trkseg>
</trk>
```