### PR TITLE
Display drules with automatic priorities as comments in priorities files

### DIFF
--- a/data/styles/clear/include/priorities_1_BG-by-size.prio.txt
+++ b/data/styles/clear/include/priorities_1_BG-by-size.prio.txt
@@ -1,5 +1,6 @@
 # This file is automatically re-formatted and re-sorted in priorities descending order
-# when generate_drules.sh is run. Custom formatting and comments are not preserved.
+# when generate_drules.sh is run. All comments (automatic priorities of e.g. optional captions, drule types visibilities, etc.)
+# are generated automatically for information only. Custom formatting and comments are not preserved.
 #
 # BG-by-size geometry: background areas rendered below BG-top and everything else.
 # Smaller areas are rendered above larger ones (area's size is estimated as the size of its' bounding box).
@@ -13,41 +14,41 @@
 # - BG-top: water (linear and areal)
 # - BG-by-size: landcover areas sorted by their size
 
-leisure-stadium                                     # area z15- (also has caption z13-, icon z13-)
+leisure-stadium                                     # area z15- (also has icon z13-, caption(optional) z13-)
 === 250
 
-amenity-place_of_worship                            # area z16- (also has caption z14-, icon z14-)
-amenity-place_of_worship-buddhist                   # area z16- (also has caption z14-, icon z14-)
-amenity-place_of_worship-christian                  # area z16- (also has caption z14-, icon z14-)
-amenity-place_of_worship-hindu                      # area z16- (also has caption z14-, icon z14-)
-amenity-place_of_worship-jewish                     # area z16- (also has caption z14-, icon z14-)
-amenity-place_of_worship-muslim                     # area z16- (also has caption z14-, icon z14-)
-amenity-place_of_worship-shinto                     # area z16- (also has caption z14-, icon z14-)
-amenity-place_of_worship-taoist                     # area z16- (also has caption z14-, icon z14-)
+amenity-place_of_worship                            # area z16- (also has icon z14-, caption(optional) z14-)
+amenity-place_of_worship-buddhist                   # area z16- (also has icon z14-, caption(optional) z14-)
+amenity-place_of_worship-christian                  # area z16- (also has icon z14-, caption(optional) z14-)
+amenity-place_of_worship-hindu                      # area z16- (also has icon z14-, caption(optional) z14-)
+amenity-place_of_worship-jewish                     # area z16- (also has icon z14-, caption(optional) z14-)
+amenity-place_of_worship-muslim                     # area z16- (also has icon z14-, caption(optional) z14-)
+amenity-place_of_worship-shinto                     # area z16- (also has icon z14-, caption(optional) z14-)
+amenity-place_of_worship-taoist                     # area z16- (also has icon z14-, caption(optional) z14-)
 === 240
 
-amenity-doctors                                     # area z14- (also has caption z17-, icon z17-)
-leisure-swimming_pool                               # area z13- (also has caption z17-, icon z17-)
-leisure-swimming_pool-private                       # area z13- (also has caption z17-, icon z17-)
+amenity-doctors                                     # area z14- (also has icon z17-, caption(optional) z17-)
+leisure-swimming_pool                               # area z13- (also has icon z17-, caption(optional) z17-)
+leisure-swimming_pool-private                       # area z13- (also has icon z17-, caption(optional) z17-)
 === 230
 
-landuse-landfill                                    # area z15- (also has caption z15-, icon z15-)
+landuse-landfill                                    # area z15- (also has icon z15-, caption(optional) z15-)
 === 220
 
-sport-multi                                         # area z15- (also has caption z17-, icon z17-)
-sport-soccer                                        # area z15- (also has caption z17-, icon z17-)
+sport-multi                                         # area z15- (also has icon z17-, caption(optional) z17-)
+sport-soccer                                        # area z15- (also has icon z17-, caption(optional) z17-)
 === 210
 
-leisure-playground                                  # area z16- (also has caption z17-, icon z17-)
+leisure-playground                                  # area z16- (also has icon z17-, caption(optional) z17-)
 === 200
 
-amenity-fountain                                    # area z16- (also has caption z16-, icon z16-)
+amenity-fountain                                    # area z16- (also has icon z16-, caption(optional) z16-)
 === 190
 
-amenity-grave_yard                                  # area z14- (also has caption z17-, icon z17-)
-amenity-grave_yard-christian                        # area z14- (also has caption z17-, icon z17-)
-landuse-cemetery                                    # area z14- (also has caption z15-, icon z15-)
-landuse-cemetery-christian                          # area z14- (also has caption z15-, icon z15-)
+amenity-grave_yard                                  # area z14- (also has icon z17-, caption(optional) z17-)
+amenity-grave_yard-christian                        # area z14- (also has icon z17-, caption(optional) z17-)
+landuse-cemetery                                    # area z14- (also has icon z15-, caption(optional) z15-)
+landuse-cemetery-christian                          # area z14- (also has icon z15-, caption(optional) z15-)
 === 180
 
 highway-pedestrian-area                             # area z14- (also has line z13-, pathtext z14-)
@@ -60,7 +61,7 @@ leisure-track-area                                  # area z15- (also has captio
 aeroway-terminal                                    # area z14- (also has caption z15-)
 === 150
 
-leisure-golf_course                                 # area z12- (also has caption z17-, icon z17-)
+leisure-golf_course                                 # area z12- (also has icon z17-, caption(optional) z17-)
 === 140
 
 natural-scrub                                       # area z14-
@@ -78,16 +79,16 @@ public_transport-platform                           # area z16- (also has captio
 railway-platform                                    # area z16- (also has caption z16-)
 === 110
 
-amenity-parking                                     # area z15- (also has caption z18-, icon z16-)
-amenity-parking-fee                                 # area z15- (also has caption z18-, icon z16-)
-amenity-parking-lane                                # area z15- (also has caption z18-, icon z17-)
-amenity-parking-multi-storey                        # area z15- (also has caption z18-, icon z16-)
-amenity-parking-no-access                           # area z15- (also has caption z18-, icon z16-)
-amenity-parking-park_and_ride                       # area z15- (also has caption z18-, icon z16-)
-amenity-parking-permissive                          # area z15- (also has caption z18-, icon z16-)
-amenity-parking-private                             # area z15- (also has caption z18-, icon z18-)
-amenity-parking-street_side                         # area z15- (also has caption z18-, icon z17-)
-amenity-parking-underground                         # area z15- (also has caption z18-, icon z16-)
+amenity-parking                                     # area z15- (also has icon z16-, caption(optional) z18-)
+amenity-parking-fee                                 # area z15- (also has icon z16-, caption(optional) z18-)
+amenity-parking-lane                                # area z15- (also has icon z17-, caption(optional) z18-)
+amenity-parking-multi-storey                        # area z15- (also has icon z16-, caption(optional) z18-)
+amenity-parking-no-access                           # area z15- (also has icon z16-, caption(optional) z18-)
+amenity-parking-park_and_ride                       # area z15- (also has icon z16-, caption(optional) z18-)
+amenity-parking-permissive                          # area z15- (also has icon z16-, caption(optional) z18-)
+amenity-parking-private                             # area z15- (also has icon z18-, caption(optional) z18-)
+amenity-parking-street_side                         # area z15- (also has icon z17-, caption(optional) z18-)
+amenity-parking-underground                         # area z15- (also has icon z16-, caption(optional) z18-)
 === 100
 
 natural-wetland                                     # area z11- (also has caption z16-)
@@ -104,22 +105,22 @@ landuse-orchard                                     # area z12- (also has captio
 landuse-recreation_ground                           # area z12- (also has caption z15-)
 landuse-village_green                               # area z12-
 landuse-vineyard                                    # area z12- (also has caption z15-)
-leisure-pitch                                       # area z15- (also has caption z17-, icon z17-)
+leisure-pitch                                       # area z15- (also has icon z17-, caption(optional) z17-)
 natural-bare_rock                                   # area z12- (also has caption z14-)
 === 80
 
-leisure-garden                                      # area z12- (also has caption z16-, icon z16-)
+leisure-garden                                      # area z12- (also has icon z16-, caption(optional) z16-)
 leisure-garden-residential                          # area z12- (also has caption z18-)
-leisure-park                                        # area z10- (also has caption z14-, icon z14-)
-leisure-park-no-access                              # area z10- (also has caption z14-, icon z14-)
-leisure-park-permissive                             # area z10- (also has caption z14-, icon z14-)
-leisure-park-private                                # area z10- (also has caption z14-, icon z14-)
+leisure-park                                        # area z10- (also has icon z14-, caption(optional) z14-)
+leisure-park-no-access                              # area z10- (also has icon z14-, caption(optional) z14-)
+leisure-park-permissive                             # area z10- (also has icon z14-, caption(optional) z14-)
+leisure-park-private                                # area z10- (also has icon z14-, caption(optional) z14-)
 === 70
 
-landuse-forest                                      # area z10- (also has caption z13-, icon z12-)
-landuse-forest-coniferous                           # area z10- (also has caption z13-, icon z12-)
-landuse-forest-deciduous                            # area z10- (also has caption z13-, icon z12-)
-landuse-forest-mixed                                # area z10- (also has caption z13-, icon z12-)
+landuse-forest                                      # area z10- (also has icon z12-, caption(optional) z13-)
+landuse-forest-coniferous                           # area z10- (also has icon z12-, caption(optional) z13-)
+landuse-forest-deciduous                            # area z10- (also has icon z12-, caption(optional) z13-)
+landuse-forest-mixed                                # area z10- (also has icon z12-, caption(optional) z13-)
 === 60
 
 landuse-churchyard                                  # area z15-
@@ -129,17 +130,17 @@ landuse-quarry                                      # area z15- (also has captio
 landuse-railway                                     # area z15- (also has caption z15-)
 === 50
 
-amenity-college                                     # area z15- (also has caption z16-, icon z16-)
-amenity-hospital                                    # area z14- (also has caption z15-, icon z14-)
-amenity-kindergarten                                # area z15- (also has caption z17-, icon z17-)
-amenity-school                                      # area z15- (also has caption z17-, icon z17-)
-amenity-university                                  # area z14- (also has caption z14-, icon z14-)
+amenity-college                                     # area z15- (also has icon z16-, caption(optional) z16-)
+amenity-hospital                                    # area z14- (also has icon z14-, caption(optional) z15-)
+amenity-kindergarten                                # area z15- (also has icon z17-, caption(optional) z17-)
+amenity-school                                      # area z15- (also has icon z17-, caption(optional) z17-)
+amenity-university                                  # area z14- (also has icon z14-, caption(optional) z14-)
 === 40
 
-aeroway-aerodrome                                   # area z10- (also has caption z14-, icon z14-)
-aeroway-aerodrome-international                     # area z10- (also has caption z10-, icon z7-)
+aeroway-aerodrome                                   # area z10- (also has icon z14-, caption(optional) z14-)
+aeroway-aerodrome-international                     # area z10- (also has icon z7-, caption(optional) z10-)
 landuse-education                                   # area z15-
-leisure-beach_resort                                # area z10- (also has caption z16-, icon z16-)
+leisure-beach_resort                                # area z10- (also has icon z16-, caption(optional) z16-)
 natural-beach                                       # area z10- (also has caption z15-)
 natural-beach-gravel                                # area z10- (also has caption z15-)
 natural-beach-sand                                  # area z10- (also has caption z15-)

--- a/data/styles/clear/include/priorities_2_BG-top.prio.txt
+++ b/data/styles/clear/include/priorities_2_BG-top.prio.txt
@@ -1,5 +1,6 @@
 # This file is automatically re-formatted and re-sorted in priorities descending order
-# when generate_drules.sh is run. Custom formatting and comments are not preserved.
+# when generate_drules.sh is run. All comments (automatic priorities of e.g. optional captions, drule types visibilities, etc.)
+# are generated automatically for information only. Custom formatting and comments are not preserved.
 #
 # BG-top geometry: background lines and areas that should be always below foreground ones
 # (including e.g. layer=-10 underwater tunnels), but above background areas sorted by size (BG-by-size),
@@ -27,7 +28,7 @@ natural-water-reservoir                             # area z1- (also has caption
 natural-water-river                                 # area z1- (also has caption z10-)
 natural-water-tunnel                                # area z15-
 waterway-dock                                       # area z1-
-waterway-riverbank                                  # area z1- and line z10- (also has pathtext z11-)
+waterway-riverbank                                  # line z10- and area z1- (also has pathtext z11-)
 === 20
 
 natural-strait                                      # line z13- (also has caption z13-)

--- a/data/styles/clear/include/priorities_3_FG.prio.txt
+++ b/data/styles/clear/include/priorities_3_FG.prio.txt
@@ -1,5 +1,6 @@
 # This file is automatically re-formatted and re-sorted in priorities descending order
-# when generate_drules.sh is run. Custom formatting and comments are not preserved.
+# when generate_drules.sh is run. All comments (automatic priorities of e.g. optional captions, drule types visibilities, etc.)
+# are generated automatically for information only. Custom formatting and comments are not preserved.
 #
 # FG geometry: foreground lines and areas (e.g. buildings) are rendered always below overlays
 # and always on top of background geometry (BG-top & BG-by-size) even if a foreground feature
@@ -38,10 +39,10 @@ aerialway-t-bar                                     # line z13- (also has line::
 historic-citywalls                                  # line z14-
 === 360
 
-power-line                                          # line z19 (also has line::dash z19)
+power-line                                          # line z19- (also has line::dash z19-)
 === 350
 
-power-line::dash                                    # line::dash z19 (also has line z19)
+power-line::dash                                    # line::dash z19- (also has line z19-)
 === 340
 
 highway-cycleway                                    # line z13- (also has pathtext z15-)
@@ -80,6 +81,10 @@ highway-world_level                                 # line z4-9
 highway-world_towns_level                           # line z6-9
 === 310
 
+# highway-motorway-tunnel                           # line(casing) z12- (also has line z7-, pathtext z10-, shield z10-)
+# highway-trunk-tunnel                              # line(casing) z12- (also has line z7-, pathtext z10-, shield z10-)
+# === 309
+
 highway-motorway_link                               # line z10- (also has pathtext z10-, shield z10-)
 highway-motorway_link-bridge                        # line z10- (also has line::bridgeblack z14-, line::bridgewhite z14-, pathtext z10-, shield z10-)
 highway-motorway_link-tunnel                        # line z10- (also has line(casing) z12-, pathtext z10-, shield z10-)
@@ -87,6 +92,10 @@ highway-trunk_link                                  # line z10- (also has pathte
 highway-trunk_link-bridge                           # line z10- (also has line::bridgeblack z14-, line::bridgewhite z14-, pathtext z10-, shield z10-)
 highway-trunk_link-tunnel                           # line z10- (also has line(casing) z12-, pathtext z10-, shield z10-)
 === 300
+
+# highway-motorway_link-tunnel                      # line(casing) z12- (also has line z10-, pathtext z10-, shield z10-)
+# highway-trunk_link-tunnel                         # line(casing) z12- (also has line z10-, pathtext z10-, shield z10-)
+# === 299
 
 highway-primary                                     # line z8- (also has pathtext z10-, shield z10-)
 highway-primary-bridge                              # line z8- (also has line::bridgeblack z14-, line::bridgewhite z14-, pathtext z10-, shield z10-)
@@ -105,32 +114,48 @@ railway-rail-tourism-bridge::dash                   # line::dash z16- (also has 
 railway-rail-tourism-tunnel::dash                   # line::dash z16- (also has line z10-, line(casing) z14-, pathtext z14-)
 === 290
 
+# highway-primary-tunnel                            # line(casing) z14- (also has line z8-, pathtext z10-, shield z10-)
+# === 289
+
 highway-primary_link                                # line z11- (also has pathtext z10-, shield z11-)
 highway-primary_link-bridge                         # line z11- (also has line::bridgeblack z14-, line::bridgewhite z14-, pathtext z10-, shield z11-)
 highway-primary_link-tunnel                         # line z11- (also has line(casing) z14-, pathtext z10-, shield z11-)
 railway-rail-branch                                 # line z11- (also has line::dash z16-)
 railway-rail-branch-bridge                          # line z11- (also has line::bridgeblack z16-, line::bridgewhite z13-, line::dash z16-)
-railway-rail-branch-tunnel                          # line z11- (also has line(casing) z14-, line::dash z16-)
+railway-rail-branch-tunnel                          # line z11- (also has line::dash z16-, line(casing) z14-)
 railway-rail-highspeed                              # line z10- (also has line::dash z16-)
 railway-rail-highspeed-bridge                       # line z10- (also has line::bridgeblack z16-, line::bridgewhite z13-, line::dash z16-)
-railway-rail-highspeed-tunnel                       # line z10- (also has line(casing) z14-, line::dash z16-)
+railway-rail-highspeed-tunnel                       # line z10- (also has line::dash z16-, line(casing) z14-)
 railway-rail-main                                   # line z10- (also has line::dash z16-)
 railway-rail-main-bridge                            # line z10- (also has line::bridgeblack z16-, line::bridgewhite z13-, line::dash z16-)
-railway-rail-main-tunnel                            # line z10- (also has line(casing) z14-, line::dash z16-)
+railway-rail-main-tunnel                            # line z10- (also has line::dash z16-, line(casing) z14-)
 railway-rail-tourism                                # line z10- (also has line::dash z16-, pathtext z14-)
 railway-rail-tourism-bridge                         # line z10- (also has line::bridgeblack z16-, line::bridgewhite z13-, line::dash z16-, pathtext z14-)
-railway-rail-tourism-tunnel                         # line z10- (also has line(casing) z14-, line::dash z16-, pathtext z14-)
+railway-rail-tourism-tunnel                         # line z10- (also has line::dash z16-, line(casing) z14-, pathtext z14-)
 === 280
+
+# highway-primary_link-tunnel                       # line(casing) z14- (also has line z11-, pathtext z10-, shield z11-)
+# railway-rail-branch-tunnel                        # line(casing) z14- (also has line z11-, line::dash z16-)
+# railway-rail-highspeed-tunnel                     # line(casing) z14- (also has line z10-, line::dash z16-)
+# railway-rail-main-tunnel                          # line(casing) z14- (also has line z10-, line::dash z16-)
+# railway-rail-tourism-tunnel                       # line(casing) z14- (also has line z10-, line::dash z16-, pathtext z14-)
+# === 279
 
 highway-secondary                                   # line z10- (also has pathtext z10-, shield z12-)
 highway-secondary-bridge                            # line z10- (also has line::bridgeblack z14-, line::bridgewhite z14-, pathtext z10-, shield z12-)
 highway-secondary-tunnel                            # line z10- (also has line(casing) z16-, pathtext z10-, shield z12-)
 === 270
 
+# highway-secondary-tunnel                          # line(casing) z16- (also has line z10-, pathtext z10-, shield z12-)
+# === 269
+
 highway-secondary_link                              # line z14- (also has pathtext z16-)
 highway-secondary_link-bridge                       # line z14- (also has line::bridgeblack z14-, line::bridgewhite z14-, pathtext z16-)
 highway-secondary_link-tunnel                       # line z14- (also has line(casing) z16-, pathtext z16-)
 === 260
+
+# highway-secondary_link-tunnel                     # line(casing) z16- (also has line z14-, pathtext z16-)
+# === 259
 
 highway-residential                                 # line z12- (also has pathtext z13-, shield z18-)
 highway-residential-area                            # line z12- (also has pathtext z13-, shield z18-)
@@ -141,10 +166,17 @@ highway-tertiary-bridge                             # line z11- (also has line::
 highway-tertiary-tunnel                             # line z11- (also has line(casing) z16-, pathtext z12-, shield z15-)
 === 250
 
+# highway-residential-tunnel                        # line(casing) z16- (also has line z12-, pathtext z13-, shield z18-)
+# highway-tertiary-tunnel                           # line(casing) z16- (also has line z11-, pathtext z12-, shield z15-)
+# === 249
+
 highway-tertiary_link                               # line z15- (also has pathtext z18-)
 highway-tertiary_link-bridge                        # line z15- (also has line::bridgeblack z15-, line::bridgewhite z15-, pathtext z18-)
 highway-tertiary_link-tunnel                        # line z15- (also has line(casing) z16-, pathtext z18-)
 === 240
+
+# highway-tertiary_link-tunnel                      # line(casing) z16- (also has line z15-, pathtext z18-)
+# === 239
 
 highway-living_street                               # line z12- (also has pathtext z14-)
 highway-living_street-bridge                        # line z12- (also has pathtext z14-)
@@ -158,16 +190,20 @@ highway-unclassified-bridge                         # line z11- (also has line::
 highway-unclassified-tunnel                         # line z11- (also has line(casing) z16-, pathtext z13-)
 === 230
 
+# highway-living_street-tunnel                      # line(casing) z16- (also has line z12-, pathtext z14-)
+# highway-unclassified-tunnel                       # line(casing) z16- (also has line z11-, pathtext z13-)
+# === 229
+
 railway-light_rail::dash                            # line::dash z16- (also has line z13-)
 railway-light_rail-bridge::dash                     # line::dash z16- (also has line z13-, line::bridgeblack z16-, line::bridgewhite z13-)
 railway-rail::dash                                  # line::dash z16- (also has line z11-)
 railway-rail-bridge::dash                           # line::dash z16- (also has line z11-, line::bridgeblack z16-, line::bridgewhite z13-)
 railway-rail-service::dash                          # line::dash z17- (also has line z16-)
 railway-rail-service-bridge::dash                   # line::dash z17- (also has line z16-, line::bridgeblack z16-, line::bridgewhite z16-)
-railway-rail-service-tunnel::dash                   # line::dash z17- (also has line z16-, line(casing) z16-)
+railway-rail-service-tunnel::dash                   # line::dash z17- (also has line(casing) z16-, line z16-)
 railway-rail-spur::dash                             # line::dash z17- (also has line z15-)
 railway-rail-spur-bridge::dash                      # line::dash z17- (also has line z15-, line::bridgeblack z16-, line::bridgewhite z15-)
-railway-rail-spur-tunnel::dash                      # line::dash z17- (also has line z15-, line(casing) z15-)
+railway-rail-spur-tunnel::dash                      # line::dash z17- (also has line(casing) z15-, line z15-)
 railway-rail-tunnel::dash                           # line::dash z16- (also has line z11-, line(casing) z14-)
 railway-rail-utility::dash                          # line::dash z17- (also has line z13-)
 railway-rail-utility-bridge::dash                   # line::dash z17- (also has line z13-, line::bridgeblack z16-, line::bridgewhite z13-)
@@ -186,20 +222,29 @@ railway-rail-service-tunnel                         # line z16- (also has line(c
 railway-rail-spur                                   # line z15- (also has line::dash z17-)
 railway-rail-spur-bridge                            # line z15- (also has line::bridgeblack z16-, line::bridgewhite z15-, line::dash z17-)
 railway-rail-spur-tunnel                            # line z15- (also has line(casing) z15-, line::dash z17-)
-railway-rail-tunnel                                 # line z11- (also has line(casing) z14-, line::dash z16-)
+railway-rail-tunnel                                 # line z11- (also has line::dash z16-, line(casing) z14-)
 railway-rail-utility                                # line z13- (also has line::dash z17-)
 railway-rail-utility-bridge                         # line z13- (also has line::bridgeblack z16-, line::bridgewhite z13-, line::dash z17-)
-railway-rail-utility-tunnel                         # line z13- (also has line(casing) z14-, line::dash z17-)
+railway-rail-utility-tunnel                         # line z13- (also has line::dash z17-, line(casing) z14-)
 railway-subway                                      # line z13- (also has line::dash z16-)
 railway-subway-bridge                               # line z13- (also has line::bridgeblack z16-, line::bridgewhite z13-, line::dash z16-)
 === 210
 
+# railway-rail-service-tunnel                       # line(casing) z16- (also has line z16-, line::dash z17-)
+# railway-rail-spur-tunnel                          # line(casing) z15- (also has line z15-, line::dash z17-)
+# railway-rail-tunnel                               # line(casing) z14- (also has line z11-, line::dash z16-)
+# railway-rail-utility-tunnel                       # line(casing) z14- (also has line z13-, line::dash z17-)
+# === 209
+
 highway-ford                                        # line z13- (also has icon z16-, pathtext z16-)
 highway-pedestrian                                  # line z13- (also has pathtext z14-)
-highway-pedestrian-area                             # area z14- and line z13- (also has pathtext z14-)
+highway-pedestrian-area                             # line z13- and area z14- (also has pathtext z14-)
 highway-pedestrian-bridge                           # line z13- (also has line::bridgeblack z14-, line::bridgewhite z13-, pathtext z14-)
 highway-pedestrian-tunnel                           # line z13- (also has line(casing) z16-, pathtext z14-)
 === 200
+
+# highway-pedestrian-tunnel                         # line(casing) z16- (also has line z13-, pathtext z14-)
+# === 199
 
 highway-busway                                      # line z15- (also has pathtext z16-)
 highway-busway-bridge                               # line z15- (also has pathtext z16-)
@@ -215,7 +260,7 @@ highway-service-tunnel                              # line z15- (also has pathte
 
 highway-footway                                     # line z15- (also has pathtext z15-)
 highway-footway-alpine_hiking                       # line z14- (also has pathtext z15-)
-highway-footway-area                                # area z14- and line z15- (also has pathtext z15-)
+highway-footway-area                                # line z15- and area z14- (also has pathtext z15-)
 highway-footway-bridge                              # line z15- (also has pathtext z15-)
 highway-footway-demanding_alpine_hiking             # line z14- (also has pathtext z15-)
 highway-footway-demanding_mountain_hiking           # line z14- (also has pathtext z15-)
@@ -385,16 +430,16 @@ highway-steps-tunnel::tunnelCasing                  # line::tunnelCasing z17- (a
 railway-light_rail-bridge::bridgeblack              # line::bridgeblack z16- (also has line z13-, line::bridgewhite z13-, line::dash z16-)
 === 40
 
-man_made-breakwater                                 # area z12- and line z14- (also has caption z17-)
-man_made-pier                                       # area z12- and line z14- (also has caption z17-)
-waterway-dam                                        # area z14- and line z14- (also has pathtext z15-)
+man_made-breakwater                                 # line z14- and area z12- (also has caption z17-)
+man_made-pier                                       # line z14- and area z12- (also has caption z17-)
+waterway-dam                                        # line z14- and area z14- (also has pathtext z15-)
 === 30
 
-boundary-national_park                              # area z10- (also has caption z12-, icon z11-)
-boundary-protected_area-1                           # area z10- (also has caption z12-, icon z11-)
-landuse-military                                    # area z12- (also has caption z17-, icon z16-)
-landuse-military-danger_area                        # area z10- (also has caption z17-, icon z16-)
-leisure-nature_reserve                              # area z10- (also has caption z12-, icon z11-)
+boundary-national_park                              # area z10- (also has icon z11-, caption(optional) z12-)
+boundary-protected_area-1                           # area z10- (also has icon z11-, caption(optional) z12-)
+landuse-military                                    # area z12- (also has icon z16-, caption(optional) z17-)
+landuse-military-danger_area                        # area z10- (also has icon z16-, caption(optional) z17-)
+leisure-nature_reserve                              # area z10- (also has icon z11-, caption(optional) z12-)
 === 20
 
 man_made-bridge                                     # area z14-

--- a/data/styles/clear/include/priorities_4_overlays.prio.txt
+++ b/data/styles/clear/include/priorities_4_overlays.prio.txt
@@ -1,9 +1,10 @@
 # This file is automatically re-formatted and re-sorted in priorities descending order
-# when generate_drules.sh is run. Custom formatting and comments are not preserved.
+# when generate_drules.sh is run. All comments (automatic priorities of e.g. optional captions, drule types visibilities, etc.)
+# are generated automatically for information only. Custom formatting and comments are not preserved.
 #
 # Overlays (icons, captions, path texts and shields) are rendered on top of all the geometry (lines, areas).
 # Overlays don't overlap each other, instead the ones with higher priority displace the less important ones.
-# Optional captions (which have an icon) are displayed only if there are no other overlays in their way
+# Optional captions (which have an icon) are usually displayed only if there are no other overlays in their way
 # (technically, max overlays priority value (10000) is subtracted from their priorities automatically).
 #
 # Priorities ranges' rendering order overview:
@@ -21,7 +22,8 @@ place-ocean                                         # caption z1-
 place-country                                       # caption z3-
 === 7600
 
-place-city-capital-2                                # caption z4- and icon z4-
+place-city-capital-2                                # icon z4- (also has caption(mandatory) z4-)
+# place-city-capital-2                              # caption(mandatory) z4- (also has icon z4-)
 === 7550
 
 place-city-capital-3                                # caption z4-
@@ -50,7 +52,7 @@ place-state-USA                                     # caption z5-10
 place-state                                         # caption z6-10
 === 7250
 
-aeroway-aerodrome-international                     # caption z10- and icon z7- (also has area z10-)
+aeroway-aerodrome-international                     # icon z7- (also has caption(optional) z10-, area z10-)
 === 7200
 
 place-island                                        # caption z9-
@@ -62,21 +64,21 @@ place-town                                          # caption z8-
 place-suburb                                        # caption z10-14
 === 7050
 
-railway-station-subway-moscow                       # caption z12-15 and icon z11-
-railway-station-subway-spb                          # caption z12-16 and icon z11-
+railway-station-subway-moscow                       # icon z11- (also has caption(optional) z12-15)
+railway-station-subway-spb                          # icon z11- (also has caption(optional) z12-16)
 === 7000
 
-aeroway-aerodrome                                   # caption z14- and icon z14- (also has area z10-)
+aeroway-aerodrome                                   # icon z14- (also has caption(optional) z14-, area z10-)
 isoline-step_1000                                   # pathtext z11- (also has line z11-)
 === 6950
 
 place-village                                       # caption z11-
 === 6900
 
-railway-station                                     # caption z12- and icon z12-
+railway-station                                     # icon z12- (also has caption(optional) z12-)
 === 6850
 
-amenity-ferry_terminal                              # caption z16- and icon z11-
+amenity-ferry_terminal                              # icon z11- (also has caption(optional) z16-)
 === 6800
 
 highway-motorway                                    # pathtext z10- and shield z10- (also has line z7-)
@@ -87,168 +89,168 @@ highway-trunk-bridge                                # pathtext z10- and shield z
 highway-trunk-tunnel                                # pathtext z10- and shield z10- (also has line z7-, line(casing) z12-)
 === 6750
 
-boundary-national_park                              # caption z12- and icon z11- (also has area z10-)
-boundary-protected_area                             # caption z12- and icon z11-
-boundary-protected_area-1                           # caption z12- and icon z11- (also has area z10-)
-boundary-protected_area-2                           # caption z12- and icon z11-
-boundary-protected_area-3                           # caption z12- and icon z11-
-boundary-protected_area-4                           # caption z12- and icon z11-
-boundary-protected_area-5                           # caption z12- and icon z11-
-boundary-protected_area-6                           # caption z12- and icon z11-
-leisure-nature_reserve                              # caption z12- and icon z11- (also has area z10-)
+boundary-national_park                              # icon z11- (also has caption(optional) z12-, area z10-)
+boundary-protected_area                             # icon z11- (also has caption(optional) z12-)
+boundary-protected_area-1                           # icon z11- (also has caption(optional) z12-, area z10-)
+boundary-protected_area-2                           # icon z11- (also has caption(optional) z12-)
+boundary-protected_area-3                           # icon z11- (also has caption(optional) z12-)
+boundary-protected_area-4                           # icon z11- (also has caption(optional) z12-)
+boundary-protected_area-5                           # icon z11- (also has caption(optional) z12-)
+boundary-protected_area-6                           # icon z11- (also has caption(optional) z12-)
+leisure-nature_reserve                              # icon z11- (also has caption(optional) z12-, area z10-)
 === 6700
 
 landuse-reservoir                                   # caption z10- (also has area z12-)
 natural-water-lake                                  # caption z10- (also has area z1-)
 natural-water-reservoir                             # caption z10- (also has area z1-)
-railway-station-funicular                           # caption z12- and icon z12-
-railway-station-light_rail                          # caption z12- and icon z12-
-railway-station-monorail                            # caption z12- and icon z12-
-railway-station-subway-adana                        # caption z14- and icon z12-
-railway-station-subway-algiers                      # caption z14- and icon z12-
-railway-station-subway-almaty                       # caption z14- and icon z12-
-railway-station-subway-amsterdam                    # caption z14- and icon z12-
-railway-station-subway-beijing                      # caption z14- and icon z12-
-railway-station-subway-berlin                       # caption z14- and icon z12-
-railway-station-subway-buenos_aires                 # caption z14- and icon z12-
-railway-station-subway-istanbul                     # caption z14- and icon z12-
-railway-station-subway-kiev                         # caption z12- and icon z12-
-railway-station-subway-la                           # caption z14- and icon z12-
-railway-station-subway-lisboa                       # caption z14- and icon z12-
-railway-station-subway-london                       # caption z14- and icon z12-
-railway-station-subway-madrid                       # caption z14- and icon z12-
-railway-station-subway-mexico                       # caption z14- and icon z12-
-railway-station-subway-minsk                        # caption z12- and icon z12-
-railway-station-subway-newyork                      # caption z14- and icon z12-
-railway-station-subway-paris                        # caption z14- and icon z12-
-railway-station-subway-roma                         # caption z14- and icon z12-
-railway-station-subway-sf                           # caption z14- and icon z12-
-railway-station-subway-shanghai                     # caption z14- and icon z12-
-railway-station-subway-stockholm                    # caption z14- and icon z12-
-railway-station-subway-tokyo                        # caption z14- and icon z12-
-railway-station-subway-vienna                       # caption z14- and icon z12-
+railway-station-funicular                           # icon z12- (also has caption(optional) z12-)
+railway-station-light_rail                          # icon z12- (also has caption(optional) z12-)
+railway-station-monorail                            # icon z12- (also has caption(optional) z12-)
+railway-station-subway-adana                        # icon z12- (also has caption(optional) z14-)
+railway-station-subway-algiers                      # icon z12- (also has caption(optional) z14-)
+railway-station-subway-almaty                       # icon z12- (also has caption(optional) z14-)
+railway-station-subway-amsterdam                    # icon z12- (also has caption(optional) z14-)
+railway-station-subway-beijing                      # icon z12- (also has caption(optional) z14-)
+railway-station-subway-berlin                       # icon z12- (also has caption(optional) z14-)
+railway-station-subway-buenos_aires                 # icon z12- (also has caption(optional) z14-)
+railway-station-subway-istanbul                     # icon z12- (also has caption(optional) z14-)
+railway-station-subway-kiev                         # icon z12- (also has caption(optional) z12-)
+railway-station-subway-la                           # icon z12- (also has caption(optional) z14-)
+railway-station-subway-lisboa                       # icon z12- (also has caption(optional) z14-)
+railway-station-subway-london                       # icon z12- (also has caption(optional) z14-)
+railway-station-subway-madrid                       # icon z12- (also has caption(optional) z14-)
+railway-station-subway-mexico                       # icon z12- (also has caption(optional) z14-)
+railway-station-subway-minsk                        # icon z12- (also has caption(optional) z12-)
+railway-station-subway-newyork                      # icon z12- (also has caption(optional) z14-)
+railway-station-subway-paris                        # icon z12- (also has caption(optional) z14-)
+railway-station-subway-roma                         # icon z12- (also has caption(optional) z14-)
+railway-station-subway-sf                           # icon z12- (also has caption(optional) z14-)
+railway-station-subway-shanghai                     # icon z12- (also has caption(optional) z14-)
+railway-station-subway-stockholm                    # icon z12- (also has caption(optional) z14-)
+railway-station-subway-tokyo                        # icon z12- (also has caption(optional) z14-)
+railway-station-subway-vienna                       # icon z12- (also has caption(optional) z14-)
 === 6650
 
-barrier-toll_booth                                  # caption z14- and icon z12-
+barrier-toll_booth                                  # icon z12- (also has caption(optional) z14-)
 === 6600
 
-historic-castle                                     # caption z12- and icon z12-
-historic-castle-castrum                             # caption z12- and icon z12-
-historic-castle-defensive                           # caption z12- and icon z12-
-historic-castle-fortified_church                    # caption z12- and icon z12-
-historic-castle-fortress                            # caption z12- and icon z12-
-historic-castle-hillfort                            # caption z12- and icon z12-
-historic-castle-kremlin                             # caption z12- and icon z12-
-historic-castle-manor                               # caption z12- and icon z12-
-historic-castle-palace                              # caption z12- and icon z12-
-historic-castle-shiro                               # caption z12- and icon z12-
-historic-castle-stately                             # caption z12- and icon z12-
-historic-fort                                       # caption z12- and icon z12-
+historic-castle                                     # icon z12- (also has caption(optional) z12-)
+historic-castle-castrum                             # icon z12- (also has caption(optional) z12-)
+historic-castle-defensive                           # icon z12- (also has caption(optional) z12-)
+historic-castle-fortified_church                    # icon z12- (also has caption(optional) z12-)
+historic-castle-fortress                            # icon z12- (also has caption(optional) z12-)
+historic-castle-hillfort                            # icon z12- (also has caption(optional) z12-)
+historic-castle-kremlin                             # icon z12- (also has caption(optional) z12-)
+historic-castle-manor                               # icon z12- (also has caption(optional) z12-)
+historic-castle-palace                              # icon z12- (also has caption(optional) z12-)
+historic-castle-shiro                               # icon z12- (also has caption(optional) z12-)
+historic-castle-stately                             # icon z12- (also has caption(optional) z12-)
+historic-fort                                       # icon z12- (also has caption(optional) z12-)
 === 6550
 
-aerialway-station                                   # caption z15- and icon z12-
+aerialway-station                                   # icon z12- (also has caption(optional) z15-)
 === 6500
 
-natural-peak                                        # caption z13- and icon z12-
-natural-volcano                                     # caption z10- and icon z10-
+natural-peak                                        # icon z12- (also has caption(optional) z13-)
+natural-volcano                                     # icon z10- (also has caption(optional) z10-)
 === 6450
 
 isoline-step_500                                    # pathtext z12- (also has line z11-)
 natural-water-river                                 # caption z10- (also has area z1-)
 === 6400
 
-amenity-bus_station                                 # caption z14- and icon z13-
+amenity-bus_station                                 # icon z13- (also has caption(optional) z14-)
 === 6350
 
-railway-station-subway                              # caption z14- and icon z13-
-railway-station-subway-ankara                       # caption z14- and icon z13-
-railway-station-subway-athens                       # caption z14- and icon z13-
-railway-station-subway-baku                         # caption z14- and icon z13-
-railway-station-subway-bangkok                      # caption z14- and icon z13-
-railway-station-subway-barcelona                    # caption z14- and icon z13-
-railway-station-subway-bengalore                    # caption z14- and icon z13-
-railway-station-subway-bilbao                       # caption z14- and icon z13-
-railway-station-subway-brasilia                     # caption z14- and icon z13-
-railway-station-subway-brescia                      # caption z14- and icon z13-
-railway-station-subway-brussels                     # caption z14- and icon z13-
-railway-station-subway-bucharest                    # caption z14- and icon z13-
-railway-station-subway-budapest                     # caption z14- and icon z13-
-railway-station-subway-bursa                        # caption z14- and icon z13-
-railway-station-subway-cairo                        # caption z14- and icon z13-
-railway-station-subway-caracas                      # caption z14- and icon z13-
-railway-station-subway-catania                      # caption z14- and icon z13-
-railway-station-subway-changchun                    # caption z14- and icon z13-
-railway-station-subway-chengdu                      # caption z14- and icon z13-
-railway-station-subway-chicago                      # caption z14- and icon z13-
-railway-station-subway-chongqing                    # caption z14- and icon z13-
-railway-station-subway-dalian                       # caption z14- and icon z13-
-railway-station-subway-delhi                        # caption z14- and icon z13-
-railway-station-subway-dnepro                       # caption z14- and icon z13-
-railway-station-subway-dubai                        # caption z14- and icon z13-
-railway-station-subway-ekb                          # caption z14- and icon z13-
-railway-station-subway-fukuoka                      # caption z14- and icon z13-
-railway-station-subway-glasgow                      # caption z14- and icon z13-
-railway-station-subway-guangzhou                    # caption z14- and icon z13-
-railway-station-subway-hamburg                      # caption z14- and icon z13-
-railway-station-subway-helsinki                     # caption z14- and icon z13-
-railway-station-subway-hiroshima                    # caption z14- and icon z13-
-railway-station-subway-isfahan                      # caption z14- and icon z13-
-railway-station-subway-izmir                        # caption z14- and icon z13-
-railway-station-subway-kazan                        # caption z14- and icon z13-
-railway-station-subway-kharkiv                      # caption z14- and icon z13-
-railway-station-subway-kobe                         # caption z14- and icon z13-
-railway-station-subway-kolkata                      # caption z14- and icon z13-
-railway-station-subway-kunming                      # caption z14- and icon z13-
-railway-station-subway-kyoto                        # caption z14- and icon z13-
-railway-station-subway-lausanne                     # caption z14- and icon z13-
-railway-station-subway-lille                        # caption z14- and icon z13-
-railway-station-subway-lima                         # caption z14- and icon z13-
-railway-station-subway-lyon                         # caption z14- and icon z13-
-railway-station-subway-malaga                       # caption z14- and icon z13-
-railway-station-subway-manila                       # caption z14- and icon z13-
-railway-station-subway-maracaibo                    # caption z14- and icon z13-
-railway-station-subway-mashhad                      # caption z14- and icon z13-
-railway-station-subway-mecca                        # caption z14- and icon z13-
-railway-station-subway-medellin                     # caption z14- and icon z13-
-railway-station-subway-milan                        # caption z14- and icon z13-
-railway-station-subway-montreal                     # caption z14- and icon z13-
-railway-station-subway-munchen                      # caption z14- and icon z13-
-railway-station-subway-nagoya                       # caption z14- and icon z13-
-railway-station-subway-nnov                         # caption z14- and icon z13-
-railway-station-subway-novosibirsk                  # caption z14- and icon z13-
-railway-station-subway-osaka                        # caption z14- and icon z13-
-railway-station-subway-oslo                         # caption z14- and icon z13-
-railway-station-subway-palma                        # caption z14- and icon z13-
-railway-station-subway-panama                       # caption z14- and icon z13-
-railway-station-subway-philadelphia                 # caption z14- and icon z13-
-railway-station-subway-pyongyang                    # caption z14- and icon z13-
-railway-station-subway-rennes                       # caption z14- and icon z13-
-railway-station-subway-rio                          # caption z14- and icon z13-
-railway-station-subway-rotterdam                    # caption z14- and icon z13-
-railway-station-subway-samara                       # caption z14- and icon z13-
-railway-station-subway-santiago                     # caption z14- and icon z13-
-railway-station-subway-santo_domingo                # caption z14- and icon z13-
-railway-station-subway-saopaulo                     # caption z14- and icon z13-
-railway-station-subway-sapporo                      # caption z14- and icon z13-
-railway-station-subway-sendai                       # caption z14- and icon z13-
-railway-station-subway-shiraz                       # caption z14- and icon z13-
-railway-station-subway-sofia                        # caption z14- and icon z13-
-railway-station-subway-tabriz                       # caption z14- and icon z13-
-railway-station-subway-taipei                       # caption z14- and icon z13-
-railway-station-subway-taoyuan                      # caption z14- and icon z13-
-railway-station-subway-tashkent                     # caption z14- and icon z13-
-railway-station-subway-tbilisi                      # caption z14- and icon z13-
-railway-station-subway-tehran                       # caption z14- and icon z13-
-railway-station-subway-tianjin                      # caption z14- and icon z13-
-railway-station-subway-valencia                     # caption z14- and icon z13-
-railway-station-subway-warszawa                     # caption z14- and icon z13-
-railway-station-subway-washington                   # caption z14- and icon z13-
-railway-station-subway-wuhan                        # caption z14- and icon z13-
-railway-station-subway-yerevan                      # caption z14- and icon z13-
-railway-station-subway-yokohama                     # caption z14- and icon z13-
+railway-station-subway                              # icon z13- (also has caption(optional) z14-)
+railway-station-subway-ankara                       # icon z13- (also has caption(optional) z14-)
+railway-station-subway-athens                       # icon z13- (also has caption(optional) z14-)
+railway-station-subway-baku                         # icon z13- (also has caption(optional) z14-)
+railway-station-subway-bangkok                      # icon z13- (also has caption(optional) z14-)
+railway-station-subway-barcelona                    # icon z13- (also has caption(optional) z14-)
+railway-station-subway-bengalore                    # icon z13- (also has caption(optional) z14-)
+railway-station-subway-bilbao                       # icon z13- (also has caption(optional) z14-)
+railway-station-subway-brasilia                     # icon z13- (also has caption(optional) z14-)
+railway-station-subway-brescia                      # icon z13- (also has caption(optional) z14-)
+railway-station-subway-brussels                     # icon z13- (also has caption(optional) z14-)
+railway-station-subway-bucharest                    # icon z13- (also has caption(optional) z14-)
+railway-station-subway-budapest                     # icon z13- (also has caption(optional) z14-)
+railway-station-subway-bursa                        # icon z13- (also has caption(optional) z14-)
+railway-station-subway-cairo                        # icon z13- (also has caption(optional) z14-)
+railway-station-subway-caracas                      # icon z13- (also has caption(optional) z14-)
+railway-station-subway-catania                      # icon z13- (also has caption(optional) z14-)
+railway-station-subway-changchun                    # icon z13- (also has caption(optional) z14-)
+railway-station-subway-chengdu                      # icon z13- (also has caption(optional) z14-)
+railway-station-subway-chicago                      # icon z13- (also has caption(optional) z14-)
+railway-station-subway-chongqing                    # icon z13- (also has caption(optional) z14-)
+railway-station-subway-dalian                       # icon z13- (also has caption(optional) z14-)
+railway-station-subway-delhi                        # icon z13- (also has caption(optional) z14-)
+railway-station-subway-dnepro                       # icon z13- (also has caption(optional) z14-)
+railway-station-subway-dubai                        # icon z13- (also has caption(optional) z14-)
+railway-station-subway-ekb                          # icon z13- (also has caption(optional) z14-)
+railway-station-subway-fukuoka                      # icon z13- (also has caption(optional) z14-)
+railway-station-subway-glasgow                      # icon z13- (also has caption(optional) z14-)
+railway-station-subway-guangzhou                    # icon z13- (also has caption(optional) z14-)
+railway-station-subway-hamburg                      # icon z13- (also has caption(optional) z14-)
+railway-station-subway-helsinki                     # icon z13- (also has caption(optional) z14-)
+railway-station-subway-hiroshima                    # icon z13- (also has caption(optional) z14-)
+railway-station-subway-isfahan                      # icon z13- (also has caption(optional) z14-)
+railway-station-subway-izmir                        # icon z13- (also has caption(optional) z14-)
+railway-station-subway-kazan                        # icon z13- (also has caption(optional) z14-)
+railway-station-subway-kharkiv                      # icon z13- (also has caption(optional) z14-)
+railway-station-subway-kobe                         # icon z13- (also has caption(optional) z14-)
+railway-station-subway-kolkata                      # icon z13- (also has caption(optional) z14-)
+railway-station-subway-kunming                      # icon z13- (also has caption(optional) z14-)
+railway-station-subway-kyoto                        # icon z13- (also has caption(optional) z14-)
+railway-station-subway-lausanne                     # icon z13- (also has caption(optional) z14-)
+railway-station-subway-lille                        # icon z13- (also has caption(optional) z14-)
+railway-station-subway-lima                         # icon z13- (also has caption(optional) z14-)
+railway-station-subway-lyon                         # icon z13- (also has caption(optional) z14-)
+railway-station-subway-malaga                       # icon z13- (also has caption(optional) z14-)
+railway-station-subway-manila                       # icon z13- (also has caption(optional) z14-)
+railway-station-subway-maracaibo                    # icon z13- (also has caption(optional) z14-)
+railway-station-subway-mashhad                      # icon z13- (also has caption(optional) z14-)
+railway-station-subway-mecca                        # icon z13- (also has caption(optional) z14-)
+railway-station-subway-medellin                     # icon z13- (also has caption(optional) z14-)
+railway-station-subway-milan                        # icon z13- (also has caption(optional) z14-)
+railway-station-subway-montreal                     # icon z13- (also has caption(optional) z14-)
+railway-station-subway-munchen                      # icon z13- (also has caption(optional) z14-)
+railway-station-subway-nagoya                       # icon z13- (also has caption(optional) z14-)
+railway-station-subway-nnov                         # icon z13- (also has caption(optional) z14-)
+railway-station-subway-novosibirsk                  # icon z13- (also has caption(optional) z14-)
+railway-station-subway-osaka                        # icon z13- (also has caption(optional) z14-)
+railway-station-subway-oslo                         # icon z13- (also has caption(optional) z14-)
+railway-station-subway-palma                        # icon z13- (also has caption(optional) z14-)
+railway-station-subway-panama                       # icon z13- (also has caption(optional) z14-)
+railway-station-subway-philadelphia                 # icon z13- (also has caption(optional) z14-)
+railway-station-subway-pyongyang                    # icon z13- (also has caption(optional) z14-)
+railway-station-subway-rennes                       # icon z13- (also has caption(optional) z14-)
+railway-station-subway-rio                          # icon z13- (also has caption(optional) z14-)
+railway-station-subway-rotterdam                    # icon z13- (also has caption(optional) z14-)
+railway-station-subway-samara                       # icon z13- (also has caption(optional) z14-)
+railway-station-subway-santiago                     # icon z13- (also has caption(optional) z14-)
+railway-station-subway-santo_domingo                # icon z13- (also has caption(optional) z14-)
+railway-station-subway-saopaulo                     # icon z13- (also has caption(optional) z14-)
+railway-station-subway-sapporo                      # icon z13- (also has caption(optional) z14-)
+railway-station-subway-sendai                       # icon z13- (also has caption(optional) z14-)
+railway-station-subway-shiraz                       # icon z13- (also has caption(optional) z14-)
+railway-station-subway-sofia                        # icon z13- (also has caption(optional) z14-)
+railway-station-subway-tabriz                       # icon z13- (also has caption(optional) z14-)
+railway-station-subway-taipei                       # icon z13- (also has caption(optional) z14-)
+railway-station-subway-taoyuan                      # icon z13- (also has caption(optional) z14-)
+railway-station-subway-tashkent                     # icon z13- (also has caption(optional) z14-)
+railway-station-subway-tbilisi                      # icon z13- (also has caption(optional) z14-)
+railway-station-subway-tehran                       # icon z13- (also has caption(optional) z14-)
+railway-station-subway-tianjin                      # icon z13- (also has caption(optional) z14-)
+railway-station-subway-valencia                     # icon z13- (also has caption(optional) z14-)
+railway-station-subway-warszawa                     # icon z13- (also has caption(optional) z14-)
+railway-station-subway-washington                   # icon z13- (also has caption(optional) z14-)
+railway-station-subway-wuhan                        # icon z13- (also has caption(optional) z14-)
+railway-station-subway-yerevan                      # icon z13- (also has caption(optional) z14-)
+railway-station-subway-yokohama                     # icon z13- (also has caption(optional) z14-)
 === 6300
 
-railway-halt                                        # caption z13- and icon z13-
+railway-halt                                        # icon z13- (also has caption(optional) z13-)
 === 6250
 
 highway-primary                                     # pathtext z10- and shield z10- (also has line z8-)
@@ -270,23 +272,23 @@ highway-primary_link-bridge                         # pathtext z10- and shield z
 highway-primary_link-tunnel                         # pathtext z10- and shield z11- (also has line z11-, line(casing) z14-)
 === 6100
 
-tourism-zoo                                         # caption z13- and icon z13-
+tourism-zoo                                         # icon z13- (also has caption(optional) z13-)
 === 6050
 
-leisure-stadium                                     # caption z13- and icon z13- (also has area z15-)
+leisure-stadium                                     # icon z13- (also has caption(optional) z13-, area z15-)
 === 6000
 
-tourism-museum                                      # caption z13- and icon z13-
+tourism-museum                                      # icon z13- (also has caption(optional) z13-)
 === 5950
 
-historic-monument                                   # caption z13- and icon z13-
+historic-monument                                   # icon z13- (also has caption(optional) z13-)
 === 5900
 
-historic-city_gate                                  # caption z13- and icon z13-
+historic-city_gate                                  # icon z13- (also has caption(optional) z13-)
 === 5850
 
-railway-tram_stop                                   # caption z17- and icon z14-
-waterway-waterfall                                  # caption z11- and icon z11-
+railway-tram_stop                                   # icon z14- (also has caption(optional) z17-)
+waterway-waterfall                                  # icon z11- (also has caption(optional) z11-)
 === 5800
 
 place-hamlet                                        # caption z13-
@@ -296,8 +298,8 @@ place-locality                                      # caption z13-
 place-neighbourhood                                 # caption z13-
 === 5700
 
-amenity-charging_station-motorcar                   # caption z14- and icon z14-
-amenity-fuel                                        # caption z14- and icon z14-
+amenity-charging_station-motorcar                   # icon z14- (also has caption(optional) z14-)
+amenity-fuel                                        # icon z14- (also has caption(optional) z14-)
 === 5650
 
 highway-secondary                                   # pathtext z10- and shield z12- (also has line z10-)
@@ -305,70 +307,70 @@ highway-secondary-bridge                            # pathtext z10- and shield z
 highway-secondary-tunnel                            # pathtext z10- and shield z12- (also has line z10-, line(casing) z16-)
 === 5600
 
-shop-mall                                           # caption z14- and icon z14-
+shop-mall                                           # icon z14- (also has caption(optional) z14-)
 === 5550
 
-place-square                                        # caption z14- and icon z14-
-tourism-theme_park                                  # caption z14- and icon z14-
+place-square                                        # icon z14- (also has caption(optional) z14-)
+tourism-theme_park                                  # icon z14- (also has caption(optional) z14-)
 === 5500
 
-amenity-community_centre                            # caption z15- and icon z15-
+amenity-community_centre                            # icon z15- (also has caption(optional) z15-)
 === 5450
 
-amenity-theatre                                     # caption z14- and icon z14-
+amenity-theatre                                     # icon z14- (also has caption(optional) z14-)
 === 5400
 
-man_made-lighthouse                                 # caption z14- and icon z14-
+man_made-lighthouse                                 # icon z14- (also has caption(optional) z14-)
 === 5350
 
-highway-services                                    # caption z14- and icon z14-
+highway-services                                    # icon z14- (also has caption(optional) z14-)
 === 5300
 
-mountain_pass                                       # caption z14- and icon z14-
-natural-saddle                                      # caption z14- and icon z14-
+mountain_pass                                       # icon z14- (also has caption(optional) z14-)
+natural-saddle                                      # icon z14- (also has caption(optional) z14-)
 === 5250
 
-natural-geyser                                      # caption z14- and icon z14-
-natural-hot_spring                                  # caption z14- and icon z14-
-natural-spring                                      # caption z14- and icon z14-
+natural-geyser                                      # icon z14- (also has caption(optional) z14-)
+natural-hot_spring                                  # icon z14- (also has caption(optional) z14-)
+natural-spring                                      # icon z14- (also has caption(optional) z14-)
 === 5200
 
 railway-rail-tourism                                # pathtext z14- (also has line z10-, line::dash z16-)
 railway-rail-tourism-bridge                         # pathtext z14- (also has line z10-, line::bridgeblack z16-, line::bridgewhite z13-, line::dash z16-)
-railway-rail-tourism-tunnel                         # pathtext z14- (also has line z10-, line(casing) z14-, line::dash z16-)
+railway-rail-tourism-tunnel                         # pathtext z14- (also has line z10-, line::dash z16-, line(casing) z14-)
 === 5150
 
-amenity-hospital                                    # caption z15- and icon z14- (also has area z14-)
-amenity-university                                  # caption z14- and icon z14- (also has area z14-)
+amenity-hospital                                    # icon z14- (also has caption(optional) z15-, area z14-)
+amenity-university                                  # icon z14- (also has caption(optional) z14-, area z14-)
 === 5100
 
-leisure-park                                        # caption z14- and icon z14- (also has area z10-)
-leisure-park-permissive                             # caption z14- and icon z14- (also has area z10-)
-natural-cave_entrance                               # caption z11- and icon z11-
+leisure-park                                        # icon z14- (also has caption(optional) z14-, area z10-)
+leisure-park-permissive                             # icon z14- (also has caption(optional) z14-, area z10-)
+natural-cave_entrance                               # icon z11- (also has caption(optional) z11-)
 === 5050
 
-tourism-attraction                                  # caption z14- and icon z14-
+tourism-attraction                                  # icon z14- (also has caption(optional) z14-)
 === 5000
 
-tourism-viewpoint                                   # caption z14- and icon z14-
+tourism-viewpoint                                   # icon z14- (also has caption(optional) z14-)
 === 4950
 
-amenity-place_of_worship-buddhist                   # caption z14- and icon z14- (also has area z16-)
-amenity-place_of_worship-christian                  # caption z14- and icon z14- (also has area z16-)
-amenity-place_of_worship-hindu                      # caption z14- and icon z14- (also has area z16-)
-amenity-place_of_worship-jewish                     # caption z14- and icon z14- (also has area z16-)
-amenity-place_of_worship-muslim                     # caption z14- and icon z14- (also has area z16-)
-amenity-place_of_worship-shinto                     # caption z14- and icon z14- (also has area z16-)
-amenity-place_of_worship-taoist                     # caption z14- and icon z14- (also has area z16-)
+amenity-place_of_worship-buddhist                   # icon z14- (also has caption(optional) z14-, area z16-)
+amenity-place_of_worship-christian                  # icon z14- (also has caption(optional) z14-, area z16-)
+amenity-place_of_worship-hindu                      # icon z14- (also has caption(optional) z14-, area z16-)
+amenity-place_of_worship-jewish                     # icon z14- (also has caption(optional) z14-, area z16-)
+amenity-place_of_worship-muslim                     # icon z14- (also has caption(optional) z14-, area z16-)
+amenity-place_of_worship-shinto                     # icon z14- (also has caption(optional) z14-, area z16-)
+amenity-place_of_worship-taoist                     # icon z14- (also has caption(optional) z14-, area z16-)
 === 4900
 
-amenity-place_of_worship                            # caption z14- and icon z14- (also has area z16-)
+amenity-place_of_worship                            # icon z14- (also has caption(optional) z14-, area z16-)
 === 4850
 
-landuse-forest                                      # caption z13- and icon z12- (also has area z10-)
-landuse-forest-coniferous                           # caption z13- and icon z12- (also has area z10-)
-landuse-forest-deciduous                            # caption z13- and icon z12- (also has area z10-)
-landuse-forest-mixed                                # caption z13- and icon z12- (also has area z10-)
+landuse-forest                                      # icon z12- (also has caption(optional) z13-, area z10-)
+landuse-forest-coniferous                           # icon z12- (also has caption(optional) z13-, area z10-)
+landuse-forest-deciduous                            # icon z12- (also has caption(optional) z13-, area z10-)
+landuse-forest-mixed                                # icon z12- (also has caption(optional) z13-, area z10-)
 === 4800
 
 natural-water                                       # caption z10- (also has area z1-)
@@ -392,52 +394,52 @@ natural-cape                                        # caption z14-
 place-isolated_dwelling                             # caption z14-
 === 4500
 
-railway-subway_entrance-moscow                      # caption z15- and icon z15-
+railway-subway_entrance-moscow                      # icon z15- (also has caption(optional) z15-)
 === 4450
 
-waterway-dam                                        # pathtext z15- (also has area z14-, line z14-)
+waterway-dam                                        # pathtext z15- (also has line z14-, area z14-)
 === 4400
 
-railway-subway_entrance-spb                         # caption z16- and icon z15-
+railway-subway_entrance-spb                         # icon z15- (also has caption(optional) z16-)
 === 4350
 
-tourism-gallery                                     # caption z15- and icon z15-
+tourism-gallery                                     # icon z15- (also has caption(optional) z15-)
 === 4300
 
-historic-battlefield                                # caption z15- and icon z15-
-historic-memorial                                   # caption z15- and icon z15-
-historic-memorial-sculpture                         # caption z15- and icon z15-
-historic-memorial-statue                            # caption z15- and icon z15-
-historic-memorial-war_memorial                      # caption z15- and icon z15-
-tourism-artwork                                     # caption z15- and icon z15-
-tourism-artwork-architecture                        # caption z15- and icon z15-
-tourism-artwork-painting                            # caption z15- and icon z15-
-tourism-artwork-sculpture                           # caption z15- and icon z15-
-tourism-artwork-statue                              # caption z15- and icon z15-
+historic-battlefield                                # icon z15- (also has caption(optional) z15-)
+historic-memorial                                   # icon z15- (also has caption(optional) z15-)
+historic-memorial-sculpture                         # icon z15- (also has caption(optional) z15-)
+historic-memorial-statue                            # icon z15- (also has caption(optional) z15-)
+historic-memorial-war_memorial                      # icon z15- (also has caption(optional) z15-)
+tourism-artwork                                     # icon z15- (also has caption(optional) z15-)
+tourism-artwork-architecture                        # icon z15- (also has caption(optional) z15-)
+tourism-artwork-painting                            # icon z15- (also has caption(optional) z15-)
+tourism-artwork-sculpture                           # icon z15- (also has caption(optional) z15-)
+tourism-artwork-statue                              # icon z15- (also has caption(optional) z15-)
 === 4250
 
-tourism-attraction-animal                           # caption z14- and icon z14-
-tourism-attraction-specified                        # caption z14- and icon z14-
+tourism-attraction-animal                           # icon z14- (also has caption(optional) z14-)
+tourism-attraction-specified                        # icon z14- (also has caption(optional) z14-)
 === 4200
 
-amenity-cafe                                        # caption z15- and icon z15-
+amenity-cafe                                        # icon z15- (also has caption(optional) z15-)
 === 4150
 
-amenity-restaurant                                  # caption z15- and icon z15-
+amenity-restaurant                                  # icon z15- (also has caption(optional) z15-)
 === 4100
 
-amenity-fast_food                                   # caption z15- and icon z15-
-amenity-food_court                                  # caption z15- and icon z15-
+amenity-fast_food                                   # icon z15- (also has caption(optional) z15-)
+amenity-food_court                                  # icon z15- (also has caption(optional) z15-)
 === 4050
 
-amenity-bar                                         # caption z15- and icon z15-
+amenity-bar                                         # icon z15- (also has caption(optional) z15-)
 === 4000
 
-amenity-biergarten                                  # caption z15- and icon z15-
-amenity-pub                                         # caption z15- and icon z15-
+amenity-biergarten                                  # icon z15- (also has caption(optional) z15-)
+amenity-pub                                         # icon z15- (also has caption(optional) z15-)
 === 3950
 
-barrier-border_control                              # caption z15- and icon z15-
+barrier-border_control                              # icon z15- (also has caption(optional) z15-)
 === 3900
 
 aerialway-cable_car                                 # pathtext z15- (also has line z12-, line::dash z12-)
@@ -450,19 +452,19 @@ aerialway-mixed_lift                                # pathtext z15- (also has li
 aerialway-platter                                   # pathtext z15- (also has line z13-, line::dash z13-)
 aerialway-rope_tow                                  # pathtext z15- (also has line z13-, line::dash z13-)
 aerialway-t-bar                                     # pathtext z15- (also has line z13-, line::dash z13-)
-shop-car_repair-tyres                               # caption z15- and icon z15-
+shop-car_repair-tyres                               # icon z15- (also has caption(optional) z15-)
 === 3850
 
-highway-rest_area                                   # caption z15- and icon z15-
-tourism-camp_site                                   # caption z15- and icon z15-
-tourism-caravan_site                                # caption z16- and icon z16-
+highway-rest_area                                   # icon z15- (also has caption(optional) z15-)
+tourism-camp_site                                   # icon z15- (also has caption(optional) z15-)
+tourism-caravan_site                                # icon z16- (also has caption(optional) z16-)
 === 3800
 
-amenity-sanitary_dump_station                       # caption z15- and icon z15-
+amenity-sanitary_dump_station                       # icon z15- (also has caption(optional) z15-)
 === 3750
 
-amenity-drinking_water                              # caption z19 and icon z15-
-amenity-water_point                                 # caption z19 and icon z15-
+amenity-drinking_water                              # icon z15- (also has caption(optional) z19-)
+amenity-water_point                                 # icon z15- (also has caption(optional) z19-)
 man_made-water_tap                                  # icon z15-
 man_made-water_well                                 # icon z15-
 === 3700
@@ -493,138 +495,138 @@ natural-beach-sand                                  # caption z15- (also has are
 === 3350
 
 place-farm                                          # caption z14-
-railway-subway_entrance                             # caption z17- and icon z16-
-railway-subway_entrance-adana                       # caption z17- and icon z16-
-railway-subway_entrance-algiers                     # caption z17- and icon z16-
-railway-subway_entrance-almaty                      # caption z17- and icon z16-
-railway-subway_entrance-amsterdam                   # caption z17- and icon z16-
-railway-subway_entrance-ankara                      # caption z17- and icon z16-
-railway-subway_entrance-athens                      # caption z17- and icon z16-
-railway-subway_entrance-baku                        # caption z17- and icon z16-
-railway-subway_entrance-bangkok                     # caption z17- and icon z16-
-railway-subway_entrance-barcelona                   # caption z17- and icon z16-
-railway-subway_entrance-beijing                     # caption z17- and icon z16-
-railway-subway_entrance-bengalore                   # caption z17- and icon z16-
-railway-subway_entrance-berlin                      # caption z17- and icon z16-
-railway-subway_entrance-bilbao                      # caption z17- and icon z16-
-railway-subway_entrance-brasilia                    # caption z17- and icon z16-
-railway-subway_entrance-brescia                     # caption z17- and icon z16-
-railway-subway_entrance-brussels                    # caption z17- and icon z16-
-railway-subway_entrance-bucharest                   # caption z17- and icon z16-
-railway-subway_entrance-budapest                    # caption z17- and icon z16-
-railway-subway_entrance-buenos_aires                # caption z17- and icon z16-
-railway-subway_entrance-bursa                       # caption z17- and icon z16-
-railway-subway_entrance-cairo                       # caption z17- and icon z16-
-railway-subway_entrance-caracas                     # caption z17- and icon z16-
-railway-subway_entrance-catania                     # caption z17- and icon z16-
-railway-subway_entrance-changchun                   # caption z17- and icon z16-
-railway-subway_entrance-chengdu                     # caption z17- and icon z16-
-railway-subway_entrance-chicago                     # caption z17- and icon z16-
-railway-subway_entrance-chongqing                   # caption z17- and icon z16-
-railway-subway_entrance-dalian                      # caption z17- and icon z16-
-railway-subway_entrance-delhi                       # caption z17- and icon z16-
-railway-subway_entrance-dnepro                      # caption z17- and icon z16-
-railway-subway_entrance-dubai                       # caption z17- and icon z16-
-railway-subway_entrance-ekb                         # caption z17- and icon z16-
-railway-subway_entrance-fukuoka                     # caption z17- and icon z16-
-railway-subway_entrance-glasgow                     # caption z17- and icon z16-
-railway-subway_entrance-guangzhou                   # caption z17- and icon z16-
-railway-subway_entrance-hamburg                     # caption z17- and icon z16-
-railway-subway_entrance-helsinki                    # caption z17- and icon z16-
-railway-subway_entrance-hiroshima                   # caption z17- and icon z16-
-railway-subway_entrance-isfahan                     # caption z17- and icon z16-
-railway-subway_entrance-istanbul                    # caption z17- and icon z16-
-railway-subway_entrance-izmir                       # caption z17- and icon z16-
-railway-subway_entrance-kazan                       # caption z17- and icon z16-
-railway-subway_entrance-kharkiv                     # caption z17- and icon z16-
-railway-subway_entrance-kiev                        # caption z17- and icon z16-
-railway-subway_entrance-kobe                        # caption z17- and icon z16-
-railway-subway_entrance-kolkata                     # caption z17- and icon z16-
-railway-subway_entrance-kunming                     # caption z17- and icon z16-
-railway-subway_entrance-kyoto                       # caption z17- and icon z16-
-railway-subway_entrance-la                          # caption z17- and icon z16-
-railway-subway_entrance-lausanne                    # caption z17- and icon z16-
-railway-subway_entrance-lille                       # caption z17- and icon z16-
-railway-subway_entrance-lima                        # caption z17- and icon z16-
-railway-subway_entrance-lisboa                      # caption z17- and icon z16-
-railway-subway_entrance-london                      # caption z17- and icon z16-
-railway-subway_entrance-lyon                        # caption z17- and icon z16-
-railway-subway_entrance-madrid                      # caption z17- and icon z16-
-railway-subway_entrance-malaga                      # caption z17- and icon z16-
-railway-subway_entrance-manila                      # caption z17- and icon z16-
-railway-subway_entrance-maracaibo                   # caption z17- and icon z16-
-railway-subway_entrance-mashhad                     # caption z17- and icon z16-
-railway-subway_entrance-mecca                       # caption z17- and icon z16-
-railway-subway_entrance-medellin                    # caption z17- and icon z16-
-railway-subway_entrance-mexico                      # caption z17- and icon z16-
-railway-subway_entrance-milan                       # caption z17- and icon z16-
-railway-subway_entrance-minsk                       # caption z17- and icon z16-
-railway-subway_entrance-montreal                    # caption z17- and icon z16-
-railway-subway_entrance-munchen                     # caption z17- and icon z16-
-railway-subway_entrance-nagoya                      # caption z17- and icon z16-
-railway-subway_entrance-newyork                     # caption z17- and icon z16-
-railway-subway_entrance-nnov                        # caption z17- and icon z16-
-railway-subway_entrance-novosibirsk                 # caption z17- and icon z16-
-railway-subway_entrance-osaka                       # caption z17- and icon z16-
-railway-subway_entrance-oslo                        # caption z17- and icon z16-
-railway-subway_entrance-palma                       # caption z17- and icon z16-
-railway-subway_entrance-panama                      # caption z17- and icon z16-
-railway-subway_entrance-paris                       # caption z17- and icon z16-
-railway-subway_entrance-philadelphia                # caption z17- and icon z16-
-railway-subway_entrance-pyongyang                   # caption z17- and icon z16-
-railway-subway_entrance-rennes                      # caption z17- and icon z16-
-railway-subway_entrance-rio                         # caption z17- and icon z16-
-railway-subway_entrance-roma                        # caption z17- and icon z16-
-railway-subway_entrance-rotterdam                   # caption z17- and icon z16-
-railway-subway_entrance-samara                      # caption z17- and icon z16-
-railway-subway_entrance-santiago                    # caption z17- and icon z16-
-railway-subway_entrance-santo_domingo               # caption z17- and icon z16-
-railway-subway_entrance-saopaulo                    # caption z17- and icon z16-
-railway-subway_entrance-sapporo                     # caption z17- and icon z16-
-railway-subway_entrance-sendai                      # caption z17- and icon z16-
-railway-subway_entrance-sf                          # caption z17- and icon z16-
-railway-subway_entrance-shanghai                    # caption z17- and icon z16-
-railway-subway_entrance-shiraz                      # caption z17- and icon z16-
-railway-subway_entrance-sofia                       # caption z17- and icon z16-
-railway-subway_entrance-stockholm                   # caption z17- and icon z16-
-railway-subway_entrance-tabriz                      # caption z17- and icon z16-
-railway-subway_entrance-taipei                      # caption z17- and icon z16-
-railway-subway_entrance-taoyuan                     # caption z17- and icon z16-
-railway-subway_entrance-tashkent                    # caption z17- and icon z16-
-railway-subway_entrance-tbilisi                     # caption z17- and icon z16-
-railway-subway_entrance-tehran                      # caption z17- and icon z16-
-railway-subway_entrance-tianjin                     # caption z17- and icon z16-
-railway-subway_entrance-tokyo                       # caption z17- and icon z16-
-railway-subway_entrance-valencia                    # caption z17- and icon z16-
-railway-subway_entrance-vienna                      # caption z17- and icon z16-
-railway-subway_entrance-warszawa                    # caption z17- and icon z16-
-railway-subway_entrance-washington                  # caption z17- and icon z16-
-railway-subway_entrance-wuhan                       # caption z17- and icon z16-
-railway-subway_entrance-yerevan                     # caption z17- and icon z16-
-railway-subway_entrance-yokohama                    # caption z17- and icon z16-
+railway-subway_entrance                             # icon z16- (also has caption(optional) z17-)
+railway-subway_entrance-adana                       # icon z16- (also has caption(optional) z17-)
+railway-subway_entrance-algiers                     # icon z16- (also has caption(optional) z17-)
+railway-subway_entrance-almaty                      # icon z16- (also has caption(optional) z17-)
+railway-subway_entrance-amsterdam                   # icon z16- (also has caption(optional) z17-)
+railway-subway_entrance-ankara                      # icon z16- (also has caption(optional) z17-)
+railway-subway_entrance-athens                      # icon z16- (also has caption(optional) z17-)
+railway-subway_entrance-baku                        # icon z16- (also has caption(optional) z17-)
+railway-subway_entrance-bangkok                     # icon z16- (also has caption(optional) z17-)
+railway-subway_entrance-barcelona                   # icon z16- (also has caption(optional) z17-)
+railway-subway_entrance-beijing                     # icon z16- (also has caption(optional) z17-)
+railway-subway_entrance-bengalore                   # icon z16- (also has caption(optional) z17-)
+railway-subway_entrance-berlin                      # icon z16- (also has caption(optional) z17-)
+railway-subway_entrance-bilbao                      # icon z16- (also has caption(optional) z17-)
+railway-subway_entrance-brasilia                    # icon z16- (also has caption(optional) z17-)
+railway-subway_entrance-brescia                     # icon z16- (also has caption(optional) z17-)
+railway-subway_entrance-brussels                    # icon z16- (also has caption(optional) z17-)
+railway-subway_entrance-bucharest                   # icon z16- (also has caption(optional) z17-)
+railway-subway_entrance-budapest                    # icon z16- (also has caption(optional) z17-)
+railway-subway_entrance-buenos_aires                # icon z16- (also has caption(optional) z17-)
+railway-subway_entrance-bursa                       # icon z16- (also has caption(optional) z17-)
+railway-subway_entrance-cairo                       # icon z16- (also has caption(optional) z17-)
+railway-subway_entrance-caracas                     # icon z16- (also has caption(optional) z17-)
+railway-subway_entrance-catania                     # icon z16- (also has caption(optional) z17-)
+railway-subway_entrance-changchun                   # icon z16- (also has caption(optional) z17-)
+railway-subway_entrance-chengdu                     # icon z16- (also has caption(optional) z17-)
+railway-subway_entrance-chicago                     # icon z16- (also has caption(optional) z17-)
+railway-subway_entrance-chongqing                   # icon z16- (also has caption(optional) z17-)
+railway-subway_entrance-dalian                      # icon z16- (also has caption(optional) z17-)
+railway-subway_entrance-delhi                       # icon z16- (also has caption(optional) z17-)
+railway-subway_entrance-dnepro                      # icon z16- (also has caption(optional) z17-)
+railway-subway_entrance-dubai                       # icon z16- (also has caption(optional) z17-)
+railway-subway_entrance-ekb                         # icon z16- (also has caption(optional) z17-)
+railway-subway_entrance-fukuoka                     # icon z16- (also has caption(optional) z17-)
+railway-subway_entrance-glasgow                     # icon z16- (also has caption(optional) z17-)
+railway-subway_entrance-guangzhou                   # icon z16- (also has caption(optional) z17-)
+railway-subway_entrance-hamburg                     # icon z16- (also has caption(optional) z17-)
+railway-subway_entrance-helsinki                    # icon z16- (also has caption(optional) z17-)
+railway-subway_entrance-hiroshima                   # icon z16- (also has caption(optional) z17-)
+railway-subway_entrance-isfahan                     # icon z16- (also has caption(optional) z17-)
+railway-subway_entrance-istanbul                    # icon z16- (also has caption(optional) z17-)
+railway-subway_entrance-izmir                       # icon z16- (also has caption(optional) z17-)
+railway-subway_entrance-kazan                       # icon z16- (also has caption(optional) z17-)
+railway-subway_entrance-kharkiv                     # icon z16- (also has caption(optional) z17-)
+railway-subway_entrance-kiev                        # icon z16- (also has caption(optional) z17-)
+railway-subway_entrance-kobe                        # icon z16- (also has caption(optional) z17-)
+railway-subway_entrance-kolkata                     # icon z16- (also has caption(optional) z17-)
+railway-subway_entrance-kunming                     # icon z16- (also has caption(optional) z17-)
+railway-subway_entrance-kyoto                       # icon z16- (also has caption(optional) z17-)
+railway-subway_entrance-la                          # icon z16- (also has caption(optional) z17-)
+railway-subway_entrance-lausanne                    # icon z16- (also has caption(optional) z17-)
+railway-subway_entrance-lille                       # icon z16- (also has caption(optional) z17-)
+railway-subway_entrance-lima                        # icon z16- (also has caption(optional) z17-)
+railway-subway_entrance-lisboa                      # icon z16- (also has caption(optional) z17-)
+railway-subway_entrance-london                      # icon z16- (also has caption(optional) z17-)
+railway-subway_entrance-lyon                        # icon z16- (also has caption(optional) z17-)
+railway-subway_entrance-madrid                      # icon z16- (also has caption(optional) z17-)
+railway-subway_entrance-malaga                      # icon z16- (also has caption(optional) z17-)
+railway-subway_entrance-manila                      # icon z16- (also has caption(optional) z17-)
+railway-subway_entrance-maracaibo                   # icon z16- (also has caption(optional) z17-)
+railway-subway_entrance-mashhad                     # icon z16- (also has caption(optional) z17-)
+railway-subway_entrance-mecca                       # icon z16- (also has caption(optional) z17-)
+railway-subway_entrance-medellin                    # icon z16- (also has caption(optional) z17-)
+railway-subway_entrance-mexico                      # icon z16- (also has caption(optional) z17-)
+railway-subway_entrance-milan                       # icon z16- (also has caption(optional) z17-)
+railway-subway_entrance-minsk                       # icon z16- (also has caption(optional) z17-)
+railway-subway_entrance-montreal                    # icon z16- (also has caption(optional) z17-)
+railway-subway_entrance-munchen                     # icon z16- (also has caption(optional) z17-)
+railway-subway_entrance-nagoya                      # icon z16- (also has caption(optional) z17-)
+railway-subway_entrance-newyork                     # icon z16- (also has caption(optional) z17-)
+railway-subway_entrance-nnov                        # icon z16- (also has caption(optional) z17-)
+railway-subway_entrance-novosibirsk                 # icon z16- (also has caption(optional) z17-)
+railway-subway_entrance-osaka                       # icon z16- (also has caption(optional) z17-)
+railway-subway_entrance-oslo                        # icon z16- (also has caption(optional) z17-)
+railway-subway_entrance-palma                       # icon z16- (also has caption(optional) z17-)
+railway-subway_entrance-panama                      # icon z16- (also has caption(optional) z17-)
+railway-subway_entrance-paris                       # icon z16- (also has caption(optional) z17-)
+railway-subway_entrance-philadelphia                # icon z16- (also has caption(optional) z17-)
+railway-subway_entrance-pyongyang                   # icon z16- (also has caption(optional) z17-)
+railway-subway_entrance-rennes                      # icon z16- (also has caption(optional) z17-)
+railway-subway_entrance-rio                         # icon z16- (also has caption(optional) z17-)
+railway-subway_entrance-roma                        # icon z16- (also has caption(optional) z17-)
+railway-subway_entrance-rotterdam                   # icon z16- (also has caption(optional) z17-)
+railway-subway_entrance-samara                      # icon z16- (also has caption(optional) z17-)
+railway-subway_entrance-santiago                    # icon z16- (also has caption(optional) z17-)
+railway-subway_entrance-santo_domingo               # icon z16- (also has caption(optional) z17-)
+railway-subway_entrance-saopaulo                    # icon z16- (also has caption(optional) z17-)
+railway-subway_entrance-sapporo                     # icon z16- (also has caption(optional) z17-)
+railway-subway_entrance-sendai                      # icon z16- (also has caption(optional) z17-)
+railway-subway_entrance-sf                          # icon z16- (also has caption(optional) z17-)
+railway-subway_entrance-shanghai                    # icon z16- (also has caption(optional) z17-)
+railway-subway_entrance-shiraz                      # icon z16- (also has caption(optional) z17-)
+railway-subway_entrance-sofia                       # icon z16- (also has caption(optional) z17-)
+railway-subway_entrance-stockholm                   # icon z16- (also has caption(optional) z17-)
+railway-subway_entrance-tabriz                      # icon z16- (also has caption(optional) z17-)
+railway-subway_entrance-taipei                      # icon z16- (also has caption(optional) z17-)
+railway-subway_entrance-taoyuan                     # icon z16- (also has caption(optional) z17-)
+railway-subway_entrance-tashkent                    # icon z16- (also has caption(optional) z17-)
+railway-subway_entrance-tbilisi                     # icon z16- (also has caption(optional) z17-)
+railway-subway_entrance-tehran                      # icon z16- (also has caption(optional) z17-)
+railway-subway_entrance-tianjin                     # icon z16- (also has caption(optional) z17-)
+railway-subway_entrance-tokyo                       # icon z16- (also has caption(optional) z17-)
+railway-subway_entrance-valencia                    # icon z16- (also has caption(optional) z17-)
+railway-subway_entrance-vienna                      # icon z16- (also has caption(optional) z17-)
+railway-subway_entrance-warszawa                    # icon z16- (also has caption(optional) z17-)
+railway-subway_entrance-washington                  # icon z16- (also has caption(optional) z17-)
+railway-subway_entrance-wuhan                       # icon z16- (also has caption(optional) z17-)
+railway-subway_entrance-yerevan                     # icon z16- (also has caption(optional) z17-)
+railway-subway_entrance-yokohama                    # icon z16- (also has caption(optional) z17-)
 === 3300
 
-amenity-charging_station                            # caption z16- and icon z16-
-amenity-charging_station-bicycle                    # caption z16- and icon z16-
+amenity-charging_station                            # icon z16- (also has caption(optional) z16-)
+amenity-charging_station-bicycle                    # icon z16- (also has caption(optional) z16-)
 landuse-allotments                                  # caption z15- (also has area z12-)
-landuse-cemetery                                    # caption z15- and icon z15- (also has area z14-)
-landuse-cemetery-christian                          # caption z15- and icon z15- (also has area z14-)
+landuse-cemetery                                    # icon z15- (also has caption(optional) z15-, area z14-)
+landuse-cemetery-christian                          # icon z15- (also has caption(optional) z15-, area z14-)
 landuse-farmland                                    # caption z15- (also has area z10-)
 landuse-orchard                                     # caption z15- (also has area z12-)
 landuse-vineyard                                    # caption z15- (also has area z12-)
-shop-supermarket                                    # caption z16- and icon z16-
-tourism-alpine_hut                                  # caption z16- and icon z16-
-tourism-chalet                                      # caption z16- and icon z16-
-tourism-information-office                          # caption z16- and icon z16-
-tourism-wilderness_hut                              # caption z16- and icon z16-
+shop-supermarket                                    # icon z16- (also has caption(optional) z16-)
+tourism-alpine_hut                                  # icon z16- (also has caption(optional) z16-)
+tourism-chalet                                      # icon z16- (also has caption(optional) z16-)
+tourism-information-office                          # icon z16- (also has caption(optional) z16-)
+tourism-wilderness_hut                              # icon z16- (also has caption(optional) z16-)
 === 3250
 
-highway-bus_stop                                    # caption z17- and icon z16-
+highway-bus_stop                                    # icon z16- (also has caption(optional) z17-)
 === 3200
 
-amenity-pharmacy                                    # caption z17- and icon z16-
+amenity-pharmacy                                    # icon z16- (also has caption(optional) z17-)
 highway-pedestrian                                  # pathtext z14- (also has line z13-)
-highway-pedestrian-area                             # pathtext z14- (also has area z14-, line z13-)
+highway-pedestrian-area                             # pathtext z14- (also has line z13-, area z14-)
 highway-pedestrian-bridge                           # pathtext z14- (also has line z13-, line::bridgeblack z14-, line::bridgewhite z13-)
 highway-pedestrian-tunnel                           # pathtext z14- (also has line z13-, line(casing) z16-)
 highway-tertiary                                    # pathtext z12- and shield z15- (also has line z11-)
@@ -632,7 +634,7 @@ highway-tertiary-bridge                             # pathtext z12- and shield z
 highway-tertiary-tunnel                             # pathtext z12- and shield z15- (also has line z11-, line(casing) z16-)
 natural-strait                                      # caption z13- (also has line z13-)
 waterway-river                                      # pathtext z11- (also has line z10-)
-waterway-riverbank                                  # pathtext z11- (also has area z1-, line z10-)
+waterway-riverbank                                  # pathtext z11- (also has line z10-, area z1-)
 === 3150
 
 highway-unclassified                                # pathtext z13- (also has line z11-)
@@ -641,7 +643,7 @@ highway-unclassified-bridge                         # pathtext z13- (also has li
 highway-unclassified-tunnel                         # pathtext z13- (also has line z11-, line(casing) z16-)
 === 3100
 
-amenity-fountain                                    # caption z16- and icon z16- (also has area z16-)
+amenity-fountain                                    # icon z16- (also has caption(optional) z16-, area z16-)
 highway-raceway                                     # pathtext z16- (also has line z14-)
 === 3050
 
@@ -662,7 +664,7 @@ highway-cycleway-bridge                             # pathtext z15- (also has li
 highway-cycleway-permissive                         # pathtext z15- (also has line z13-)
 highway-cycleway-tunnel                             # pathtext z15- (also has line z13-)
 highway-footway                                     # pathtext z15- (also has line z15-)
-highway-footway-area                                # pathtext z15- (also has area z14-, line z15-)
+highway-footway-area                                # pathtext z15- (also has line z15-, area z14-)
 highway-footway-bridge                              # pathtext z15- (also has line z15-)
 highway-footway-tunnel                              # pathtext z15- (also has line z15-, line::tunnelBackground z17-, line::tunnelCasing z17-)
 highway-tertiary_link                               # pathtext z18- (also has line z15-)
@@ -670,7 +672,7 @@ highway-tertiary_link-bridge                        # pathtext z18- (also has li
 highway-tertiary_link-tunnel                        # pathtext z18- (also has line z15-, line(casing) z16-)
 === 2950
 
-historic-ship                                       # caption z16- and icon z16-
+historic-ship                                       # icon z16- (also has caption(optional) z16-)
 natural-water-basin                                 # caption z10- (also has area z1-)
 natural-water-lock                                  # caption z10- (also has area z1-)
 waterway-canal                                      # pathtext z13- (also has line z13-)
@@ -680,9 +682,9 @@ waterway-stream-ephemeral                           # pathtext z13- (also has li
 waterway-stream-intermittent                        # pathtext z13- (also has line z13-)
 === 2900
 
-amenity-shelter                                     # caption z16- and icon z16-
+amenity-shelter                                     # icon z16- (also has caption(optional) z16-)
 highway-ford                                        # icon z16- and pathtext z16- (also has line z13-)
-tourism-information                                 # caption z16- and icon z16-
+tourism-information                                 # icon z16- (also has caption(optional) z16-)
 === 2850
 
 highway-bridleway                                   # pathtext z15- (also has line z14-)
@@ -731,132 +733,132 @@ highway-track-permissive                            # pathtext z15- (also has li
 highway-track-tunnel                                # pathtext z15- (also has line z14-)
 === 2800
 
-tourism-hotel                                       # caption z16- and icon z16-
-tourism-resort                                      # caption z16- and icon z16-
+tourism-hotel                                       # icon z16- (also has caption(optional) z16-)
+tourism-resort                                      # icon z16- (also has caption(optional) z16-)
 === 2750
 
-tourism-motel                                       # caption z16- and icon z16-
+tourism-motel                                       # icon z16- (also has caption(optional) z16-)
 === 2700
 
-tourism-hostel                                      # caption z16- and icon z16-
+tourism-hostel                                      # icon z16- (also has caption(optional) z16-)
 === 2650
 
-tourism-apartment                                   # caption z16- and icon z16-
-tourism-guest_house                                 # caption z16- and icon z16-
+tourism-apartment                                   # icon z16- (also has caption(optional) z16-)
+tourism-guest_house                                 # icon z16- (also has caption(optional) z16-)
 === 2600
 
-amenity-ice_cream                                   # caption z19 and icon z16-
+amenity-ice_cream                                   # icon z16- (also has caption(optional) z19-)
 === 2550
 
-aeroway-helipad                                     # caption z16- and icon z16-
-amenity-bank                                        # caption z16- and icon z16-
-amenity-marketplace                                 # caption z16- and icon z16-
-amenity-nightclub                                   # caption z16- and icon z16-
-amenity-townhall                                    # caption z16- and icon z16-
-shop-caravan                                        # caption z16- and icon z16-
+aeroway-helipad                                     # icon z16- (also has caption(optional) z16-)
+amenity-bank                                        # icon z16- (also has caption(optional) z16-)
+amenity-marketplace                                 # icon z16- (also has caption(optional) z16-)
+amenity-nightclub                                   # icon z16- (also has caption(optional) z16-)
+amenity-townhall                                    # icon z16- (also has caption(optional) z16-)
+shop-caravan                                        # icon z16- (also has caption(optional) z16-)
 === 2500
 
 highway-construction                                # pathtext z15- (also has line z13-)
 highway-living_street                               # pathtext z14- (also has line z12-)
 highway-living_street-bridge                        # pathtext z14- (also has line z12-)
 highway-living_street-tunnel                        # pathtext z14- (also has line z12-, line(casing) z16-)
-leisure-picnic_table                                # caption z16- and icon z16-
-shop-antiques                                       # caption z16- and icon z16-
-shop-charity                                        # caption z16- and icon z16-
-shop-second_hand                                    # caption z16- and icon z16-
-tourism-picnic_site                                 # caption z16- and icon z16-
+leisure-picnic_table                                # icon z16- (also has caption(optional) z16-)
+shop-antiques                                       # icon z16- (also has caption(optional) z16-)
+shop-charity                                        # icon z16- (also has caption(optional) z16-)
+shop-second_hand                                    # icon z16- (also has caption(optional) z16-)
+tourism-picnic_site                                 # icon z16- (also has caption(optional) z16-)
 === 2450
 
-shop-alcohol                                        # caption z16- and icon z16-
-shop-art                                            # caption z16- and icon z16-
-shop-auction                                        # caption z16- and icon z16-
-shop-bakery                                         # caption z16- and icon z16-
-shop-beauty                                         # caption z16- and icon z16-
-shop-beverages                                      # caption z16- and icon z16-
-shop-bicycle                                        # caption z16- and icon z16-
-shop-bookmaker                                      # caption z16- and icon z16-
-shop-books                                          # caption z16- and icon z16-
-shop-butcher                                        # caption z16- and icon z16-
-shop-camera                                         # caption z16- and icon z16-
-shop-car                                            # caption z16- and icon z16-
-shop-car_parts                                      # caption z16- and icon z16-
-shop-car_repair                                     # caption z16- and icon z16-
-shop-cheese                                         # caption z16- and icon z16-
-shop-chemist                                        # caption z16- and icon z16-
-shop-chocolate                                      # caption z16- and icon z16-
-shop-clothes                                        # caption z16- and icon z16-
-shop-collector                                      # caption z18- and icon z16-
-shop-computer                                       # caption z16- and icon z16-
-shop-confectionery                                  # caption z16- and icon z16-
-shop-convenience                                    # caption z16- and icon z16-
-shop-copyshop                                       # caption z16- and icon z16-
-shop-cosmetics                                      # caption z16- and icon z16-
-shop-deli                                           # caption z16- and icon z16-
-shop-department_store                               # caption z16- and icon z16-
-shop-doityourself                                   # caption z16- and icon z16-
-shop-dry_cleaning                                   # caption z16- and icon z16-
-shop-electronics                                    # caption z16- and icon z16-
-shop-erotic                                         # caption z16- and icon z16-
-shop-fabric                                         # caption z16- and icon z16-
-shop-farm                                           # caption z16- and icon z16-
-shop-florist                                        # caption z16- and icon z16-
-shop-funeral_directors                              # caption z16- and icon z16-
-shop-furniture                                      # caption z16- and icon z16-
-shop-garden_centre                                  # caption z16- and icon z16-
-shop-gift                                           # caption z16- and icon z16-
-shop-greengrocer                                    # caption z16- and icon z16-
-shop-grocery                                        # caption z16- and icon z16-
-shop-hairdresser                                    # caption z16- and icon z16-
-shop-hardware                                       # caption z16- and icon z16-
-shop-health_food                                    # caption z16- and icon z16-
-shop-houseware                                      # caption z16- and icon z16-
-shop-interior_decoration                            # caption z16- and icon z16-
-shop-jewelry                                        # caption z16- and icon z16-
-shop-kiosk                                          # caption z16- and icon z16-
-shop-kitchen                                        # caption z16- and icon z16-
-shop-laundry                                        # caption z16- and icon z16-
-shop-mobile_phone                                   # caption z16- and icon z16-
-shop-motorcycle                                     # caption z16- and icon z16-
-shop-music                                          # caption z16- and icon z16-
-shop-musical_instrument                             # caption z16- and icon z16-
-shop-optician                                       # caption z16- and icon z16-
-shop-outdoor                                        # caption z16- and icon z16-
-shop-pastry                                         # caption z16- and icon z16-
-shop-pet                                            # caption z16- and icon z16-
-shop-photo                                          # caption z16- and icon z16-
-shop-seafood                                        # caption z16- and icon z16-
-shop-sewing                                         # caption z16- and icon z16-
-shop-shoes                                          # caption z16- and icon z16-
-shop-sports                                         # caption z16- and icon z16-
-shop-stationery                                     # caption z16- and icon z16-
-shop-tattoo                                         # caption z16- and icon z16-
-shop-ticket                                         # caption z16- and icon z16-
-shop-toys                                           # caption z16- and icon z16-
-shop-tyres                                          # caption z16- and icon z16-
-shop-video                                          # caption z16- and icon z16-
-shop-video_games                                    # caption z16- and icon z16-
-shop-wine                                           # caption z16- and icon z16-
+shop-alcohol                                        # icon z16- (also has caption(optional) z16-)
+shop-art                                            # icon z16- (also has caption(optional) z16-)
+shop-auction                                        # icon z16- (also has caption(optional) z16-)
+shop-bakery                                         # icon z16- (also has caption(optional) z16-)
+shop-beauty                                         # icon z16- (also has caption(optional) z16-)
+shop-beverages                                      # icon z16- (also has caption(optional) z16-)
+shop-bicycle                                        # icon z16- (also has caption(optional) z16-)
+shop-bookmaker                                      # icon z16- (also has caption(optional) z16-)
+shop-books                                          # icon z16- (also has caption(optional) z16-)
+shop-butcher                                        # icon z16- (also has caption(optional) z16-)
+shop-camera                                         # icon z16- (also has caption(optional) z16-)
+shop-car                                            # icon z16- (also has caption(optional) z16-)
+shop-car_parts                                      # icon z16- (also has caption(optional) z16-)
+shop-car_repair                                     # icon z16- (also has caption(optional) z16-)
+shop-cheese                                         # icon z16- (also has caption(optional) z16-)
+shop-chemist                                        # icon z16- (also has caption(optional) z16-)
+shop-chocolate                                      # icon z16- (also has caption(optional) z16-)
+shop-clothes                                        # icon z16- (also has caption(optional) z16-)
+shop-collector                                      # icon z16- (also has caption(optional) z18-)
+shop-computer                                       # icon z16- (also has caption(optional) z16-)
+shop-confectionery                                  # icon z16- (also has caption(optional) z16-)
+shop-convenience                                    # icon z16- (also has caption(optional) z16-)
+shop-copyshop                                       # icon z16- (also has caption(optional) z16-)
+shop-cosmetics                                      # icon z16- (also has caption(optional) z16-)
+shop-deli                                           # icon z16- (also has caption(optional) z16-)
+shop-department_store                               # icon z16- (also has caption(optional) z16-)
+shop-doityourself                                   # icon z16- (also has caption(optional) z16-)
+shop-dry_cleaning                                   # icon z16- (also has caption(optional) z16-)
+shop-electronics                                    # icon z16- (also has caption(optional) z16-)
+shop-erotic                                         # icon z16- (also has caption(optional) z16-)
+shop-fabric                                         # icon z16- (also has caption(optional) z16-)
+shop-farm                                           # icon z16- (also has caption(optional) z16-)
+shop-florist                                        # icon z16- (also has caption(optional) z16-)
+shop-funeral_directors                              # icon z16- (also has caption(optional) z16-)
+shop-furniture                                      # icon z16- (also has caption(optional) z16-)
+shop-garden_centre                                  # icon z16- (also has caption(optional) z16-)
+shop-gift                                           # icon z16- (also has caption(optional) z16-)
+shop-greengrocer                                    # icon z16- (also has caption(optional) z16-)
+shop-grocery                                        # icon z16- (also has caption(optional) z16-)
+shop-hairdresser                                    # icon z16- (also has caption(optional) z16-)
+shop-hardware                                       # icon z16- (also has caption(optional) z16-)
+shop-health_food                                    # icon z16- (also has caption(optional) z16-)
+shop-houseware                                      # icon z16- (also has caption(optional) z16-)
+shop-interior_decoration                            # icon z16- (also has caption(optional) z16-)
+shop-jewelry                                        # icon z16- (also has caption(optional) z16-)
+shop-kiosk                                          # icon z16- (also has caption(optional) z16-)
+shop-kitchen                                        # icon z16- (also has caption(optional) z16-)
+shop-laundry                                        # icon z16- (also has caption(optional) z16-)
+shop-mobile_phone                                   # icon z16- (also has caption(optional) z16-)
+shop-motorcycle                                     # icon z16- (also has caption(optional) z16-)
+shop-music                                          # icon z16- (also has caption(optional) z16-)
+shop-musical_instrument                             # icon z16- (also has caption(optional) z16-)
+shop-optician                                       # icon z16- (also has caption(optional) z16-)
+shop-outdoor                                        # icon z16- (also has caption(optional) z16-)
+shop-pastry                                         # icon z16- (also has caption(optional) z16-)
+shop-pet                                            # icon z16- (also has caption(optional) z16-)
+shop-photo                                          # icon z16- (also has caption(optional) z16-)
+shop-seafood                                        # icon z16- (also has caption(optional) z16-)
+shop-sewing                                         # icon z16- (also has caption(optional) z16-)
+shop-shoes                                          # icon z16- (also has caption(optional) z16-)
+shop-sports                                         # icon z16- (also has caption(optional) z16-)
+shop-stationery                                     # icon z16- (also has caption(optional) z16-)
+shop-tattoo                                         # icon z16- (also has caption(optional) z16-)
+shop-ticket                                         # icon z16- (also has caption(optional) z16-)
+shop-toys                                           # icon z16- (also has caption(optional) z16-)
+shop-tyres                                          # icon z16- (also has caption(optional) z16-)
+shop-video                                          # icon z16- (also has caption(optional) z16-)
+shop-video_games                                    # icon z16- (also has caption(optional) z16-)
+shop-wine                                           # icon z16- (also has caption(optional) z16-)
 === 2400
 
-amenity-hunting_stand                               # caption z18- and icon z18-
-amenity-taxi                                        # caption z16- and icon z16-
-amenity-veterinary                                  # caption z16- and icon z16-
-barrier-lift_gate                                   # caption z16- and icon z16-
-leisure-dog_park                                    # caption z16- and icon z16-
-leisure-water_park                                  # caption z16- and icon z16-
-man_made-windmill                                   # caption z16- and icon z16-
+amenity-hunting_stand                               # icon z18- (also has caption(optional) z18-)
+amenity-taxi                                        # icon z16- (also has caption(optional) z16-)
+amenity-veterinary                                  # icon z16- (also has caption(optional) z16-)
+barrier-lift_gate                                   # icon z16- (also has caption(optional) z16-)
+leisure-dog_park                                    # icon z16- (also has caption(optional) z16-)
+leisure-water_park                                  # icon z16- (also has caption(optional) z16-)
+man_made-windmill                                   # icon z16- (also has caption(optional) z16-)
 === 2350
 
-amenity-conference_centre                           # caption z16- and icon z16-
-amenity-events_venue                                # caption z16- and icon z16-
-amenity-exhibition_centre                           # caption z16- and icon z16-
-historic-boundary_stone                             # caption z16- and icon z16-
-historic-gallows                                    # caption z17- and icon z16-
-historic-pillory                                    # caption z17- and icon z16-
-historic-tomb                                       # caption z16- and icon z16-
-historic-wayside_cross                              # caption z16- and icon z16-
-historic-wayside_shrine                             # caption z17- and icon z16-
-man_made-chimney                                    # caption z18- and icon z16-
+amenity-conference_centre                           # icon z16- (also has caption(optional) z16-)
+amenity-events_venue                                # icon z16- (also has caption(optional) z16-)
+amenity-exhibition_centre                           # icon z16- (also has caption(optional) z16-)
+historic-boundary_stone                             # icon z16- (also has caption(optional) z16-)
+historic-gallows                                    # icon z16- (also has caption(optional) z17-)
+historic-pillory                                    # icon z16- (also has caption(optional) z17-)
+historic-tomb                                       # icon z16- (also has caption(optional) z16-)
+historic-wayside_cross                              # icon z16- (also has caption(optional) z16-)
+historic-wayside_shrine                             # icon z16- (also has caption(optional) z17-)
+man_made-chimney                                    # icon z16- (also has caption(optional) z18-)
 === 2300
 
 highway-busway                                      # pathtext z16- (also has line z15-)
@@ -867,44 +869,44 @@ highway-busway-tunnel                               # pathtext z16- (also has li
 waterway-lock_gate                                  # icon z16-
 === 2200
 
-leisure-marina                                      # caption z16- and icon z16-
+leisure-marina                                      # icon z16- (also has caption(optional) z16-)
 === 2100
 
-leisure-garden                                      # caption z16- and icon z16- (also has area z12-)
+leisure-garden                                      # icon z16- (also has caption(optional) z16-, area z12-)
 === 2050
 
-amenity-college                                     # caption z16- and icon z16- (also has area z15-)
-landuse-military                                    # caption z17- and icon z16- (also has area z12-)
-landuse-military-danger_area                        # caption z17- and icon z16- (also has area z10-)
+amenity-college                                     # icon z16- (also has caption(optional) z16-, area z15-)
+landuse-military                                    # icon z16- (also has caption(optional) z17-, area z12-)
+landuse-military-danger_area                        # icon z16- (also has caption(optional) z17-, area z10-)
 === 2000
 
-leisure-beach_resort                                # caption z16- and icon z16- (also has area z10-)
+leisure-beach_resort                                # icon z16- (also has caption(optional) z16-, area z10-)
 === 1950
 
-barrier-block                                       # caption z16- and icon z16-
-barrier-bollard                                     # caption z16- and icon z16-
-barrier-chain                                       # caption z16- and icon z16-
-barrier-entrance                                    # caption z16- and icon z16-
-barrier-gate                                        # caption z16- and icon z16-
-barrier-kissing_gate                                # caption z16- and icon z16-
-barrier-stile                                       # caption z16- and icon z16-
-barrier-swing_gate                                  # caption z16- and icon z16-
-barrier-turnstile                                   # caption z16- and icon z16-
+barrier-block                                       # icon z16- (also has caption(optional) z16-)
+barrier-bollard                                     # icon z16- (also has caption(optional) z16-)
+barrier-chain                                       # icon z16- (also has caption(optional) z16-)
+barrier-entrance                                    # icon z16- (also has caption(optional) z16-)
+barrier-gate                                        # icon z16- (also has caption(optional) z16-)
+barrier-kissing_gate                                # icon z16- (also has caption(optional) z16-)
+barrier-stile                                       # icon z16- (also has caption(optional) z16-)
+barrier-swing_gate                                  # icon z16- (also has caption(optional) z16-)
+barrier-turnstile                                   # icon z16- (also has caption(optional) z16-)
 man_made-mast                                       # icon z16-
-man_made-silo                                       # caption z18- and icon z16-
-man_made-storage_tank                               # caption z18- and icon z16-
-man_made-works                                      # caption z18- and icon z16-
+man_made-silo                                       # icon z16- (also has caption(optional) z18-)
+man_made-storage_tank                               # icon z16- (also has caption(optional) z18-)
+man_made-works                                      # icon z16- (also has caption(optional) z18-)
 power-tower                                         # icon z16-
 === 1900
 
-leisure-park-no-access                              # caption z14- and icon z14- (also has area z10-)
-leisure-park-private                                # caption z14- and icon z14- (also has area z10-)
+leisure-park-no-access                              # icon z14- (also has caption(optional) z14-, area z10-)
+leisure-park-private                                # icon z14- (also has caption(optional) z14-, area z10-)
 === 1850
 
 landuse-construction                                # caption z15- (also has area z15-)
 landuse-farmyard                                    # caption z15- (also has area z10-)
 landuse-industrial                                  # caption z15- (also has area z15-)
-landuse-landfill                                    # caption z15- and icon z15- (also has area z15-)
+landuse-landfill                                    # icon z15- (also has caption(optional) z15-, area z15-)
 landuse-quarry                                      # caption z15- (also has area z15-)
 landuse-railway                                     # caption z15- (also has area z15-)
 === 1800
@@ -924,132 +926,132 @@ natural-wetland-bog                                 # caption z16- (also has are
 natural-wetland-marsh                               # caption z16- (also has area z11-)
 === 1600
 
-historic-memorial-cross                             # caption z17- and icon z17-
+historic-memorial-cross                             # icon z17- (also has caption(optional) z17-)
 === 1550
 
-amenity-cinema                                      # caption z17- and icon z17-
-amenity-clinic                                      # caption z17- and icon z17-
-amenity-courthouse                                  # caption z17- and icon z17-
-amenity-dentist                                     # caption z17- and icon z17-
-amenity-doctors                                     # caption z17- and icon z17- (also has area z14-)
-amenity-police                                      # caption z17- and icon z17-
-amenity-post_office                                 # caption z17- and icon z17-
-amenity-prison                                      # caption z17- and icon z17-
-healthcare-alternative                              # caption z17- and icon z17-
-healthcare-audiologist                              # caption z17- and icon z17-
-healthcare-blood_donation                           # caption z17- and icon z17-
-healthcare-laboratory                               # caption z17- and icon z17-
-healthcare-optometrist                              # caption z17- and icon z17-
-healthcare-physiotherapist                          # caption z17- and icon z17-
-healthcare-podiatrist                               # caption z17- and icon z17-
-healthcare-psychotherapist                          # caption z17- and icon z17-
-healthcare-sample_collection                        # caption z17- and icon z17-
-healthcare-speech_therapist                         # caption z17- and icon z17-
-historic-archaeological_site                        # caption z17- and icon z17-
-leisure-bowling_alley                               # caption z17- and icon z17-
-leisure-swimming_pool                               # caption z17- and icon z17- (also has area z13-)
-leisure-swimming_pool-private                       # caption z17- and icon z17- (also has area z13-)
-office-diplomatic                                   # caption z17- and icon z17-
-office-lawyer                                       # caption z17- and icon z17-
+amenity-cinema                                      # icon z17- (also has caption(optional) z17-)
+amenity-clinic                                      # icon z17- (also has caption(optional) z17-)
+amenity-courthouse                                  # icon z17- (also has caption(optional) z17-)
+amenity-dentist                                     # icon z17- (also has caption(optional) z17-)
+amenity-doctors                                     # icon z17- (also has caption(optional) z17-, area z14-)
+amenity-police                                      # icon z17- (also has caption(optional) z17-)
+amenity-post_office                                 # icon z17- (also has caption(optional) z17-)
+amenity-prison                                      # icon z17- (also has caption(optional) z17-)
+healthcare-alternative                              # icon z17- (also has caption(optional) z17-)
+healthcare-audiologist                              # icon z17- (also has caption(optional) z17-)
+healthcare-blood_donation                           # icon z17- (also has caption(optional) z17-)
+healthcare-laboratory                               # icon z17- (also has caption(optional) z17-)
+healthcare-optometrist                              # icon z17- (also has caption(optional) z17-)
+healthcare-physiotherapist                          # icon z17- (also has caption(optional) z17-)
+healthcare-podiatrist                               # icon z17- (also has caption(optional) z17-)
+healthcare-psychotherapist                          # icon z17- (also has caption(optional) z17-)
+healthcare-sample_collection                        # icon z17- (also has caption(optional) z17-)
+healthcare-speech_therapist                         # icon z17- (also has caption(optional) z17-)
+historic-archaeological_site                        # icon z17- (also has caption(optional) z17-)
+leisure-bowling_alley                               # icon z17- (also has caption(optional) z17-)
+leisure-swimming_pool                               # icon z17- (also has caption(optional) z17-, area z13-)
+leisure-swimming_pool-private                       # icon z17- (also has caption(optional) z17-, area z13-)
+office-diplomatic                                   # icon z17- (also has caption(optional) z17-)
+office-lawyer                                       # icon z17- (also has caption(optional) z17-)
 railway-level_crossing                              # icon z17-
 === 1500
 
-aeroway-gate                                        # caption z17- and icon z17-
-amenity-bicycle_rental                              # caption z17- and icon z17-
-amenity-bicycle_repair_station                      # caption z17- and icon z17-
-amenity-bureau_de_change                            # caption z18- and icon z17-
-amenity-car_wash                                    # caption z17- and icon z17-
-amenity-money_transfer                              # caption z18- and icon z17-
-shop-pawnbroker                                     # caption z17- and icon z17-
-sport-skiing                                        # caption z17- and icon z17-
-sport-tennis                                        # caption z17- and icon z17-
+aeroway-gate                                        # icon z17- (also has caption(optional) z17-)
+amenity-bicycle_rental                              # icon z17- (also has caption(optional) z17-)
+amenity-bicycle_repair_station                      # icon z17- (also has caption(optional) z17-)
+amenity-bureau_de_change                            # icon z17- (also has caption(optional) z18-)
+amenity-car_wash                                    # icon z17- (also has caption(optional) z17-)
+amenity-money_transfer                              # icon z17- (also has caption(optional) z18-)
+shop-pawnbroker                                     # icon z17- (also has caption(optional) z17-)
+sport-skiing                                        # icon z17- (also has caption(optional) z17-)
+sport-tennis                                        # icon z17- (also has caption(optional) z17-)
 === 1450
 
-sport-american_football                             # caption z17- and icon z17-
-sport-athletics                                     # caption z17- and icon z17-
-sport-badminton                                     # caption z17- and icon z17-
-sport-baseball                                      # caption z17- and icon z17-
-sport-basketball                                    # caption z17- and icon z17-
-sport-beachvolleyball                               # caption z17- and icon z17-
-sport-field_hockey                                  # caption z17- and icon z17-
-sport-golf                                          # caption z17- and icon z17-
-sport-gymnastics                                    # caption z17- and icon z17-
-sport-handball                                      # caption z17- and icon z17-
-sport-ice_hockey                                    # caption z17- and icon z17-
-sport-padel                                         # caption z17- and icon z17-
-sport-pelota                                        # caption z17- and icon z17-
-sport-skateboard                                    # caption z17- and icon z17-
-sport-swimming                                      # caption z17- and icon z17-
-sport-table_tennis                                  # caption z17- and icon z17-
-sport-volleyball                                    # caption z17- and icon z17-
-sport-yoga                                          # caption z17- and icon z17-
+sport-american_football                             # icon z17- (also has caption(optional) z17-)
+sport-athletics                                     # icon z17- (also has caption(optional) z17-)
+sport-badminton                                     # icon z17- (also has caption(optional) z17-)
+sport-baseball                                      # icon z17- (also has caption(optional) z17-)
+sport-basketball                                    # icon z17- (also has caption(optional) z17-)
+sport-beachvolleyball                               # icon z17- (also has caption(optional) z17-)
+sport-field_hockey                                  # icon z17- (also has caption(optional) z17-)
+sport-golf                                          # icon z17- (also has caption(optional) z17-)
+sport-gymnastics                                    # icon z17- (also has caption(optional) z17-)
+sport-handball                                      # icon z17- (also has caption(optional) z17-)
+sport-ice_hockey                                    # icon z17- (also has caption(optional) z17-)
+sport-padel                                         # icon z17- (also has caption(optional) z17-)
+sport-pelota                                        # icon z17- (also has caption(optional) z17-)
+sport-skateboard                                    # icon z17- (also has caption(optional) z17-)
+sport-swimming                                      # icon z17- (also has caption(optional) z17-)
+sport-table_tennis                                  # icon z17- (also has caption(optional) z17-)
+sport-volleyball                                    # icon z17- (also has caption(optional) z17-)
+sport-yoga                                          # icon z17- (also has caption(optional) z17-)
 === 1400
 
-sport-10pin                                         # caption z17- and icon z17-
-sport-9pin                                          # caption z17- and icon z17-
-sport-archery                                       # caption z17- and icon z17-
-sport-australian_football                           # caption z17- and icon z17-
-sport-bowls                                         # caption z17- and icon z17-
-sport-chess                                         # caption z17- and icon z17-
-sport-climbing                                      # caption z17- and icon z17-
-sport-cricket                                       # caption z17- and icon z17-
-sport-curling                                       # caption z17- and icon z17-
-sport-diving                                        # caption z17- and icon z17-
-sport-equestrian                                    # caption z17- and icon z17-
-sport-futsal                                        # caption z17- and icon z17-
-sport-scuba_diving                                  # caption z17- and icon z17-
-sport-shooting                                      # caption z17- and icon z17-
+sport-10pin                                         # icon z17- (also has caption(optional) z17-)
+sport-9pin                                          # icon z17- (also has caption(optional) z17-)
+sport-archery                                       # icon z17- (also has caption(optional) z17-)
+sport-australian_football                           # icon z17- (also has caption(optional) z17-)
+sport-bowls                                         # icon z17- (also has caption(optional) z17-)
+sport-chess                                         # icon z17- (also has caption(optional) z17-)
+sport-climbing                                      # icon z17- (also has caption(optional) z17-)
+sport-cricket                                       # icon z17- (also has caption(optional) z17-)
+sport-curling                                       # icon z17- (also has caption(optional) z17-)
+sport-diving                                        # icon z17- (also has caption(optional) z17-)
+sport-equestrian                                    # icon z17- (also has caption(optional) z17-)
+sport-futsal                                        # icon z17- (also has caption(optional) z17-)
+sport-scuba_diving                                  # icon z17- (also has caption(optional) z17-)
+sport-shooting                                      # icon z17- (also has caption(optional) z17-)
 === 1350
 
-shop-massage                                        # caption z18- and icon z17-
-shop-money_lender                                   # caption z17- and icon z17-
-shop-newsagent                                      # caption z18- and icon z17-
-shop-variety_store                                  # caption z17- and icon z17-
-sport-multi                                         # caption z17- and icon z17- (also has area z15-)
-sport-soccer                                        # caption z17- and icon z17- (also has area z15-)
+shop-massage                                        # icon z17- (also has caption(optional) z18-)
+shop-money_lender                                   # icon z17- (also has caption(optional) z17-)
+shop-newsagent                                      # icon z17- (also has caption(optional) z18-)
+shop-variety_store                                  # icon z17- (also has caption(optional) z17-)
+sport-multi                                         # icon z17- (also has caption(optional) z17-, area z15-)
+sport-soccer                                        # icon z17- (also has caption(optional) z17-, area z15-)
 === 1300
 
-amenity-casino                                      # caption z17- and icon z17-
-amenity-childcare                                   # caption z17- and icon z17-
-craft-beekeeper                                     # caption z18- and icon z17-
-craft-blacksmith                                    # caption z18- and icon z17-
-craft-brewery                                       # caption z18- and icon z17-
-craft-carpenter                                     # caption z18- and icon z17-
-craft-confectionery                                 # caption z18- and icon z17-
-craft-electrician                                   # caption z18- and icon z17-
-craft-electronics_repair                            # caption z18- and icon z17-
-craft-gardener                                      # caption z18- and icon z17-
-craft-metal_construction                            # caption z18- and icon z17-
-craft-painter                                       # caption z18- and icon z17-
-craft-photographer                                  # caption z18- and icon z17-
-craft-plumber                                       # caption z18- and icon z17-
-craft-sawmill                                       # caption z18- and icon z17-
-craft-shoemaker                                     # caption z18- and icon z17-
-craft-tailor                                        # caption z18- and icon z17-
-historic-ruins                                      # caption z17- and icon z17-
-leisure-playground                                  # caption z17- and icon z17- (also has area z16-)
-power-station                                       # caption z17- and icon z17-
+amenity-casino                                      # icon z17- (also has caption(optional) z17-)
+amenity-childcare                                   # icon z17- (also has caption(optional) z17-)
+craft-beekeeper                                     # icon z17- (also has caption(optional) z18-)
+craft-blacksmith                                    # icon z17- (also has caption(optional) z18-)
+craft-brewery                                       # icon z17- (also has caption(optional) z18-)
+craft-carpenter                                     # icon z17- (also has caption(optional) z18-)
+craft-confectionery                                 # icon z17- (also has caption(optional) z18-)
+craft-electrician                                   # icon z17- (also has caption(optional) z18-)
+craft-electronics_repair                            # icon z17- (also has caption(optional) z18-)
+craft-gardener                                      # icon z17- (also has caption(optional) z18-)
+craft-metal_construction                            # icon z17- (also has caption(optional) z18-)
+craft-painter                                       # icon z17- (also has caption(optional) z18-)
+craft-photographer                                  # icon z17- (also has caption(optional) z18-)
+craft-plumber                                       # icon z17- (also has caption(optional) z18-)
+craft-sawmill                                       # icon z17- (also has caption(optional) z18-)
+craft-shoemaker                                     # icon z17- (also has caption(optional) z18-)
+craft-tailor                                        # icon z17- (also has caption(optional) z18-)
+historic-ruins                                      # icon z17- (also has caption(optional) z17-)
+leisure-playground                                  # icon z17- (also has caption(optional) z17-, area z16-)
+power-station                                       # icon z17- (also has caption(optional) z17-)
 === 1250
 
-amenity-parcel_locker                               # caption z17- and icon z17-
-amenity-recycling                                   # caption z19 and icon z17-
-amenity-recycling-centre                            # caption z19 and icon z17-
-amenity-shower                                      # caption z17- and icon z17-
-amenity-vending_machine-fuel                        # caption z18- and icon z18-
-amenity-vending_machine-parking_tickets             # caption z17- and icon z17-
-amenity-vending_machine-public_transport_tickets    # caption z17- and icon z17-
-amenity-waste_transfer_station                      # caption z19 and icon z17-
+amenity-parcel_locker                               # icon z17- (also has caption(optional) z17-)
+amenity-recycling                                   # icon z17- (also has caption(optional) z19-)
+amenity-recycling-centre                            # icon z17- (also has caption(optional) z19-)
+amenity-shower                                      # icon z17- (also has caption(optional) z17-)
+amenity-vending_machine-fuel                        # icon z18- (also has caption(optional) z18-)
+amenity-vending_machine-parking_tickets             # icon z17- (also has caption(optional) z17-)
+amenity-vending_machine-public_transport_tickets    # icon z17- (also has caption(optional) z17-)
+amenity-waste_transfer_station                      # icon z17- (also has caption(optional) z19-)
 === 1200
 
 highway-elevator                                    # icon z17-
 === 1150
 
-amenity-grave_yard                                  # caption z17- and icon z17- (also has area z14-)
-amenity-grave_yard-christian                        # caption z17- and icon z17- (also has area z14-)
-cemetery-grave                                      # caption z17- and icon z17-
+amenity-grave_yard                                  # icon z17- (also has caption(optional) z17-, area z14-)
+amenity-grave_yard-christian                        # icon z17- (also has caption(optional) z17-, area z14-)
+cemetery-grave                                      # icon z17- (also has caption(optional) z17-)
 === 1100
 
-leisure-golf_course                                 # caption z17- and icon z17- (also has area z12-)
+leisure-golf_course                                 # icon z17- (also has caption(optional) z17-, area z12-)
 === 1050
 
 isoline-step_10                                     # pathtext z17- (also has line z15-)
@@ -1057,24 +1059,24 @@ isoline-step_50                                     # pathtext z16- (also has li
 isoline-zero                                        # pathtext z17- (also has line z15-)
 === 1000
 
-leisure-pitch                                       # caption z17- and icon z17- (also has area z15-)
+leisure-pitch                                       # icon z17- (also has caption(optional) z17-, area z15-)
 === 950
 
-amenity-kindergarten                                # caption z17- and icon z17- (also has area z15-)
-amenity-school                                      # caption z17- and icon z17- (also has area z15-)
+amenity-kindergarten                                # icon z17- (also has caption(optional) z17-, area z15-)
+amenity-school                                      # icon z17- (also has caption(optional) z17-, area z15-)
 === 900
 
-amenity-arts_centre                                 # caption z17- and icon z17-
-amenity-driving_school                              # caption z19 and icon z17-
-amenity-language_school                             # caption z19 and icon z17-
-amenity-music_school                                # caption z19 and icon z17-
-amenity-nursing_home                                # caption z17- and icon z17-
-amenity-payment_terminal                            # caption z17- and icon z17-
-leisure-fitness_centre                              # caption z17- and icon z17-
-leisure-fitness_station                             # caption z17- and icon z17-
-leisure-ice_rink                                    # caption z17- and icon z17-
-leisure-sauna                                       # caption z17- and icon z17-
-leisure-sports_centre                               # caption z17- and icon z17-
+amenity-arts_centre                                 # icon z17- (also has caption(optional) z17-)
+amenity-driving_school                              # icon z17- (also has caption(optional) z19-)
+amenity-language_school                             # icon z17- (also has caption(optional) z19-)
+amenity-music_school                                # icon z17- (also has caption(optional) z19-)
+amenity-nursing_home                                # icon z17- (also has caption(optional) z17-)
+amenity-payment_terminal                            # icon z17- (also has caption(optional) z17-)
+leisure-fitness_centre                              # icon z17- (also has caption(optional) z17-)
+leisure-fitness_station                             # icon z17- (also has caption(optional) z17-)
+leisure-ice_rink                                    # icon z17- (also has caption(optional) z17-)
+leisure-sauna                                       # icon z17- (also has caption(optional) z17-)
+leisure-sports_centre                               # icon z17- (also has caption(optional) z17-)
 man_made-tower-communication                        # icon z17-
 power-generator                                     # icon z17-
 power-generator-gas                                 # icon z17-
@@ -1096,8 +1098,8 @@ junction-roundabout                                 # caption z17-
 public_transport-platform                           # caption z17- (also has area z16-)
 === 750
 
-man_made-breakwater                                 # caption z17- (also has area z12-, line z14-)
-man_made-pier                                       # caption z17- (also has area z12-, line z14-)
+man_made-breakwater                                 # caption z17- (also has line z14-, area z12-)
+man_made-pier                                       # caption z17- (also has line z14-, area z12-)
 === 700
 
 landuse-commercial                                  # caption z17-
@@ -1109,71 +1111,71 @@ leisure-recreation_ground                           # caption z17-
 leisure-slipway                                     # caption z17-
 === 650
 
-historic-memorial-plaque                            # caption z18- and icon z18-
+historic-memorial-plaque                            # icon z18- (also has caption(optional) z18-)
 === 600
 
-amenity-atm                                         # caption z18- and icon z18-
-amenity-brothel                                     # caption z18- and icon z18-
-amenity-car_rental                                  # caption z18- and icon z18-
-amenity-car_sharing                                 # caption z18- and icon z18-
-amenity-fire_station                                # caption z18- and icon z18-
-amenity-library                                     # caption z18- and icon z18-
-amenity-stripclub                                   # caption z18- and icon z18-
-office                                              # caption z18- and icon z18-
-office-company                                      # caption z18- and icon z18-
-office-estate_agent                                 # caption z18- and icon z18-
-office-government                                   # caption z18- and icon z18-
-office-insurance                                    # caption z18- and icon z18-
-office-ngo                                          # caption z18- and icon z18-
-office-telecommunication                            # caption z18- and icon z18-
+amenity-atm                                         # icon z18- (also has caption(optional) z18-)
+amenity-brothel                                     # icon z18- (also has caption(optional) z18-)
+amenity-car_rental                                  # icon z18- (also has caption(optional) z18-)
+amenity-car_sharing                                 # icon z18- (also has caption(optional) z18-)
+amenity-fire_station                                # icon z18- (also has caption(optional) z18-)
+amenity-library                                     # icon z18- (also has caption(optional) z18-)
+amenity-stripclub                                   # icon z18- (also has caption(optional) z18-)
+office                                              # icon z18- (also has caption(optional) z18-)
+office-company                                      # icon z18- (also has caption(optional) z18-)
+office-estate_agent                                 # icon z18- (also has caption(optional) z18-)
+office-government                                   # icon z18- (also has caption(optional) z18-)
+office-insurance                                    # icon z18- (also has caption(optional) z18-)
+office-ngo                                          # icon z18- (also has caption(optional) z18-)
+office-telecommunication                            # icon z18- (also has caption(optional) z18-)
 === 550
 
-shop                                                # caption z18- and icon z18-
-shop-agrarian                                       # caption z18- and icon z18-
-shop-appliance                                      # caption z18- and icon z18-
-shop-baby_goods                                     # caption z18- and icon z18-
-shop-bag                                            # caption z18- and icon z18-
-shop-bathroom_furnishing                            # caption z18- and icon z18-
-shop-bed                                            # caption z18- and icon z18-
-shop-boutique                                       # caption z18- and icon z18-
-shop-cannabis                                       # caption z18- and icon z18-
-shop-carpet                                         # caption z18- and icon z18-
-shop-coffee                                         # caption z18- and icon z18-
-shop-craft                                          # caption z18- and icon z18-
-shop-curtain                                        # caption z18- and icon z18-
-shop-dairy                                          # caption z18- and icon z18-
-shop-electrical                                     # caption z18- and icon z18-
-shop-fashion_accessories                            # caption z18- and icon z18-
-shop-fishing                                        # caption z18- and icon z18-
-shop-gas                                            # caption z18- and icon z18-
-shop-herbalist                                      # caption z18- and icon z18-
-shop-hifi                                           # caption z18- and icon z18-
-shop-lottery                                        # caption z18- and icon z18-
-shop-medical_supply                                 # caption z18- and icon z18-
-shop-motorcycle_repair                              # caption z18- and icon z18-
-shop-nutrition_supplements                          # caption z18- and icon z18-
-shop-outpost                                        # caption z18- and icon z18-
-shop-paint                                          # caption z18- and icon z18-
-shop-perfumery                                      # caption z18- and icon z18-
-shop-pet_grooming                                   # caption z18- and icon z18-
-shop-storage_rental                                 # caption z18- and icon z18-
-shop-tea                                            # caption z18- and icon z18-
-shop-tobacco                                        # caption z18- and icon z18-
-shop-trade                                          # caption z18- and icon z18-
-shop-travel_agency                                  # caption z18- and icon z18-
-shop-watches                                        # caption z18- and icon z18-
-shop-wholesale                                      # caption z18- and icon z18-
+shop                                                # icon z18- (also has caption(optional) z18-)
+shop-agrarian                                       # icon z18- (also has caption(optional) z18-)
+shop-appliance                                      # icon z18- (also has caption(optional) z18-)
+shop-baby_goods                                     # icon z18- (also has caption(optional) z18-)
+shop-bag                                            # icon z18- (also has caption(optional) z18-)
+shop-bathroom_furnishing                            # icon z18- (also has caption(optional) z18-)
+shop-bed                                            # icon z18- (also has caption(optional) z18-)
+shop-boutique                                       # icon z18- (also has caption(optional) z18-)
+shop-cannabis                                       # icon z18- (also has caption(optional) z18-)
+shop-carpet                                         # icon z18- (also has caption(optional) z18-)
+shop-coffee                                         # icon z18- (also has caption(optional) z18-)
+shop-craft                                          # icon z18- (also has caption(optional) z18-)
+shop-curtain                                        # icon z18- (also has caption(optional) z18-)
+shop-dairy                                          # icon z18- (also has caption(optional) z18-)
+shop-electrical                                     # icon z18- (also has caption(optional) z18-)
+shop-fashion_accessories                            # icon z18- (also has caption(optional) z18-)
+shop-fishing                                        # icon z18- (also has caption(optional) z18-)
+shop-gas                                            # icon z18- (also has caption(optional) z18-)
+shop-herbalist                                      # icon z18- (also has caption(optional) z18-)
+shop-hifi                                           # icon z18- (also has caption(optional) z18-)
+shop-lottery                                        # icon z18- (also has caption(optional) z18-)
+shop-medical_supply                                 # icon z18- (also has caption(optional) z18-)
+shop-motorcycle_repair                              # icon z18- (also has caption(optional) z18-)
+shop-nutrition_supplements                          # icon z18- (also has caption(optional) z18-)
+shop-outpost                                        # icon z18- (also has caption(optional) z18-)
+shop-paint                                          # icon z18- (also has caption(optional) z18-)
+shop-perfumery                                      # icon z18- (also has caption(optional) z18-)
+shop-pet_grooming                                   # icon z18- (also has caption(optional) z18-)
+shop-storage_rental                                 # icon z18- (also has caption(optional) z18-)
+shop-tea                                            # icon z18- (also has caption(optional) z18-)
+shop-tobacco                                        # icon z18- (also has caption(optional) z18-)
+shop-trade                                          # icon z18- (also has caption(optional) z18-)
+shop-travel_agency                                  # icon z18- (also has caption(optional) z18-)
+shop-watches                                        # icon z18- (also has caption(optional) z18-)
+shop-wholesale                                      # icon z18- (also has caption(optional) z18-)
 === 500
 
-amenity-bbq                                         # caption z18- and icon z18-
-amenity-internet_cafe                               # caption z19 and icon z18-
-amenity-public_bookcase                             # caption z19
-amenity-toilets                                     # caption z18- and icon z18-
-craft-handicraft                                    # caption z18- and icon z18-
-craft-hvac                                          # caption z18- and icon z18-
-craft-key_cutter                                    # caption z18- and icon z18-
-craft-locksmith                                     # caption z18- and icon z18-
-craft-winery                                        # caption z18- and icon z18-
+amenity-bbq                                         # icon z18- (also has caption(optional) z18-)
+amenity-internet_cafe                               # icon z18- (also has caption(optional) z19-)
+amenity-public_bookcase                             # caption z19-
+amenity-toilets                                     # icon z18- (also has caption(optional) z18-)
+craft-handicraft                                    # icon z18- (also has caption(optional) z18-)
+craft-hvac                                          # icon z18- (also has caption(optional) z18-)
+craft-key_cutter                                    # icon z18- (also has caption(optional) z18-)
+craft-locksmith                                     # icon z18- (also has caption(optional) z18-)
+craft-winery                                        # icon z18- (also has caption(optional) z18-)
 === 450
 
 building                                            # caption z16- (also has area z14-)
@@ -1181,76 +1183,959 @@ building-garage                                     # caption z16- (also has are
 building-has_parts                                  # caption z16- (also has area z14-)
 === 400
 
-amenity-parking                                     # caption z18- and icon z16- (also has area z15-)
-amenity-parking-fee                                 # caption z18- and icon z16- (also has area z15-)
-amenity-parking-multi-storey                        # caption z18- and icon z16- (also has area z15-)
-amenity-parking-park_and_ride                       # caption z18- and icon z16- (also has area z15-)
-amenity-parking-underground                         # caption z18- and icon z16- (also has area z15-)
+amenity-parking                                     # icon z16- (also has caption(optional) z18-, area z15-)
+amenity-parking-fee                                 # icon z16- (also has caption(optional) z18-, area z15-)
+amenity-parking-multi-storey                        # icon z16- (also has caption(optional) z18-, area z15-)
+amenity-parking-park_and_ride                       # icon z16- (also has caption(optional) z18-, area z15-)
+amenity-parking-underground                         # icon z16- (also has caption(optional) z18-, area z15-)
 === 300
 
-amenity-bicycle_parking                             # caption z17- and icon z17-
-amenity-motorcycle_parking                          # caption z17- and icon z17-
-amenity-parking-permissive                          # caption z18- and icon z16- (also has area z15-)
-amenity-parking_entrance                            # caption z19 and icon z17-
-amenity-parking_entrance-permissive                 # caption z19 and icon z17-
+amenity-bicycle_parking                             # icon z17- (also has caption(optional) z17-)
+amenity-motorcycle_parking                          # icon z17- (also has caption(optional) z17-)
+amenity-parking-permissive                          # icon z16- (also has caption(optional) z18-, area z15-)
+amenity-parking_entrance                            # icon z17- (also has caption(optional) z19-)
+amenity-parking_entrance-permissive                 # icon z17- (also has caption(optional) z19-)
 === 250
 
-amenity-post_box                                    # caption z18- and icon z18-
-amenity-recycling-container                         # caption z19 and icon z17-
+amenity-post_box                                    # icon z18- (also has caption(optional) z18-)
+amenity-recycling-container                         # icon z17- (also has caption(optional) z19-)
 building-address                                    # caption z16-
-historic-memorial-stolperstein                      # caption z19 and icon z19
+historic-memorial-stolperstein                      # icon z19- (also has caption(optional) z19-)
 leisure-garden-residential                          # caption z18- (also has area z12-)
 === 200
 
-entrance-main                                       # caption z18- and icon z18-
+entrance-main                                       # icon z18- (also has caption(optional) z18-)
 === 170
 
-amenity-parking-lane                                # caption z18- and icon z17- (also has area z15-)
-amenity-parking-street_side                         # caption z18- and icon z17- (also has area z15-)
+amenity-parking-lane                                # icon z17- (also has caption(optional) z18-, area z15-)
+amenity-parking-street_side                         # icon z17- (also has caption(optional) z18-, area z15-)
 === 150
 
-amenity-parking-no-access                           # caption z18- and icon z16- (also has area z15-)
-amenity-parking-private                             # caption z18- and icon z18- (also has area z15-)
+amenity-parking-no-access                           # icon z16- (also has caption(optional) z18-, area z15-)
+amenity-parking-private                             # icon z18- (also has caption(optional) z18-, area z15-)
 amenity-parking_entrance-private                    # WARNING: no style defined (the type will be not included into map data)
 === 100
 
-man_made-survey_point                               # caption z16- and icon z16-
-tourism-information-board                           # caption z16- and icon z16-
-tourism-information-guidepost                       # caption z16- and icon z16-
-tourism-information-map                             # caption z16- and icon z16-
+#
+# All automatic optional captions priorities are below 0.
+# They follow the order of their correspoding icons.
+#
+
+# aeroway-aerodrome-international                   # caption(optional) z10- (also has icon z7-, area z10-)
+# === -2800
+
+# railway-station-subway-moscow                     # caption(optional) z12-15 (also has icon z11-)
+# railway-station-subway-spb                        # caption(optional) z12-16 (also has icon z11-)
+# === -3000
+
+# aeroway-aerodrome                                 # caption(optional) z14- (also has icon z14-, area z10-)
+# === -3050
+
+# railway-station                                   # caption(optional) z12- (also has icon z12-)
+# === -3150
+
+# amenity-ferry_terminal                            # caption(optional) z16- (also has icon z11-)
+# === -3200
+
+# boundary-national_park                            # caption(optional) z12- (also has icon z11-, area z10-)
+# boundary-protected_area                           # caption(optional) z12- (also has icon z11-)
+# boundary-protected_area-1                         # caption(optional) z12- (also has icon z11-, area z10-)
+# boundary-protected_area-2                         # caption(optional) z12- (also has icon z11-)
+# boundary-protected_area-3                         # caption(optional) z12- (also has icon z11-)
+# boundary-protected_area-4                         # caption(optional) z12- (also has icon z11-)
+# boundary-protected_area-5                         # caption(optional) z12- (also has icon z11-)
+# boundary-protected_area-6                         # caption(optional) z12- (also has icon z11-)
+# leisure-nature_reserve                            # caption(optional) z12- (also has icon z11-, area z10-)
+# === -3300
+
+# railway-station-funicular                         # caption(optional) z12- (also has icon z12-)
+# railway-station-light_rail                        # caption(optional) z12- (also has icon z12-)
+# railway-station-monorail                          # caption(optional) z12- (also has icon z12-)
+# railway-station-subway-adana                      # caption(optional) z14- (also has icon z12-)
+# railway-station-subway-algiers                    # caption(optional) z14- (also has icon z12-)
+# railway-station-subway-almaty                     # caption(optional) z14- (also has icon z12-)
+# railway-station-subway-amsterdam                  # caption(optional) z14- (also has icon z12-)
+# railway-station-subway-beijing                    # caption(optional) z14- (also has icon z12-)
+# railway-station-subway-berlin                     # caption(optional) z14- (also has icon z12-)
+# railway-station-subway-buenos_aires               # caption(optional) z14- (also has icon z12-)
+# railway-station-subway-istanbul                   # caption(optional) z14- (also has icon z12-)
+# railway-station-subway-kiev                       # caption(optional) z12- (also has icon z12-)
+# railway-station-subway-la                         # caption(optional) z14- (also has icon z12-)
+# railway-station-subway-lisboa                     # caption(optional) z14- (also has icon z12-)
+# railway-station-subway-london                     # caption(optional) z14- (also has icon z12-)
+# railway-station-subway-madrid                     # caption(optional) z14- (also has icon z12-)
+# railway-station-subway-mexico                     # caption(optional) z14- (also has icon z12-)
+# railway-station-subway-minsk                      # caption(optional) z12- (also has icon z12-)
+# railway-station-subway-newyork                    # caption(optional) z14- (also has icon z12-)
+# railway-station-subway-paris                      # caption(optional) z14- (also has icon z12-)
+# railway-station-subway-roma                       # caption(optional) z14- (also has icon z12-)
+# railway-station-subway-sf                         # caption(optional) z14- (also has icon z12-)
+# railway-station-subway-shanghai                   # caption(optional) z14- (also has icon z12-)
+# railway-station-subway-stockholm                  # caption(optional) z14- (also has icon z12-)
+# railway-station-subway-tokyo                      # caption(optional) z14- (also has icon z12-)
+# railway-station-subway-vienna                     # caption(optional) z14- (also has icon z12-)
+# === -3350
+
+# barrier-toll_booth                                # caption(optional) z14- (also has icon z12-)
+# === -3400
+
+# historic-castle                                   # caption(optional) z12- (also has icon z12-)
+# historic-castle-castrum                           # caption(optional) z12- (also has icon z12-)
+# historic-castle-defensive                         # caption(optional) z12- (also has icon z12-)
+# historic-castle-fortified_church                  # caption(optional) z12- (also has icon z12-)
+# historic-castle-fortress                          # caption(optional) z12- (also has icon z12-)
+# historic-castle-hillfort                          # caption(optional) z12- (also has icon z12-)
+# historic-castle-kremlin                           # caption(optional) z12- (also has icon z12-)
+# historic-castle-manor                             # caption(optional) z12- (also has icon z12-)
+# historic-castle-palace                            # caption(optional) z12- (also has icon z12-)
+# historic-castle-shiro                             # caption(optional) z12- (also has icon z12-)
+# historic-castle-stately                           # caption(optional) z12- (also has icon z12-)
+# historic-fort                                     # caption(optional) z12- (also has icon z12-)
+# === -3450
+
+# aerialway-station                                 # caption(optional) z15- (also has icon z12-)
+# === -3500
+
+# natural-peak                                      # caption(optional) z13- (also has icon z12-)
+# natural-volcano                                   # caption(optional) z10- (also has icon z10-)
+# === -3550
+
+# amenity-bus_station                               # caption(optional) z14- (also has icon z13-)
+# === -3650
+
+# railway-station-subway                            # caption(optional) z14- (also has icon z13-)
+# railway-station-subway-ankara                     # caption(optional) z14- (also has icon z13-)
+# railway-station-subway-athens                     # caption(optional) z14- (also has icon z13-)
+# railway-station-subway-baku                       # caption(optional) z14- (also has icon z13-)
+# railway-station-subway-bangkok                    # caption(optional) z14- (also has icon z13-)
+# railway-station-subway-barcelona                  # caption(optional) z14- (also has icon z13-)
+# railway-station-subway-bengalore                  # caption(optional) z14- (also has icon z13-)
+# railway-station-subway-bilbao                     # caption(optional) z14- (also has icon z13-)
+# railway-station-subway-brasilia                   # caption(optional) z14- (also has icon z13-)
+# railway-station-subway-brescia                    # caption(optional) z14- (also has icon z13-)
+# railway-station-subway-brussels                   # caption(optional) z14- (also has icon z13-)
+# railway-station-subway-bucharest                  # caption(optional) z14- (also has icon z13-)
+# railway-station-subway-budapest                   # caption(optional) z14- (also has icon z13-)
+# railway-station-subway-bursa                      # caption(optional) z14- (also has icon z13-)
+# railway-station-subway-cairo                      # caption(optional) z14- (also has icon z13-)
+# railway-station-subway-caracas                    # caption(optional) z14- (also has icon z13-)
+# railway-station-subway-catania                    # caption(optional) z14- (also has icon z13-)
+# railway-station-subway-changchun                  # caption(optional) z14- (also has icon z13-)
+# railway-station-subway-chengdu                    # caption(optional) z14- (also has icon z13-)
+# railway-station-subway-chicago                    # caption(optional) z14- (also has icon z13-)
+# railway-station-subway-chongqing                  # caption(optional) z14- (also has icon z13-)
+# railway-station-subway-dalian                     # caption(optional) z14- (also has icon z13-)
+# railway-station-subway-delhi                      # caption(optional) z14- (also has icon z13-)
+# railway-station-subway-dnepro                     # caption(optional) z14- (also has icon z13-)
+# railway-station-subway-dubai                      # caption(optional) z14- (also has icon z13-)
+# railway-station-subway-ekb                        # caption(optional) z14- (also has icon z13-)
+# railway-station-subway-fukuoka                    # caption(optional) z14- (also has icon z13-)
+# railway-station-subway-glasgow                    # caption(optional) z14- (also has icon z13-)
+# railway-station-subway-guangzhou                  # caption(optional) z14- (also has icon z13-)
+# railway-station-subway-hamburg                    # caption(optional) z14- (also has icon z13-)
+# railway-station-subway-helsinki                   # caption(optional) z14- (also has icon z13-)
+# railway-station-subway-hiroshima                  # caption(optional) z14- (also has icon z13-)
+# railway-station-subway-isfahan                    # caption(optional) z14- (also has icon z13-)
+# railway-station-subway-izmir                      # caption(optional) z14- (also has icon z13-)
+# railway-station-subway-kazan                      # caption(optional) z14- (also has icon z13-)
+# railway-station-subway-kharkiv                    # caption(optional) z14- (also has icon z13-)
+# railway-station-subway-kobe                       # caption(optional) z14- (also has icon z13-)
+# railway-station-subway-kolkata                    # caption(optional) z14- (also has icon z13-)
+# railway-station-subway-kunming                    # caption(optional) z14- (also has icon z13-)
+# railway-station-subway-kyoto                      # caption(optional) z14- (also has icon z13-)
+# railway-station-subway-lausanne                   # caption(optional) z14- (also has icon z13-)
+# railway-station-subway-lille                      # caption(optional) z14- (also has icon z13-)
+# railway-station-subway-lima                       # caption(optional) z14- (also has icon z13-)
+# railway-station-subway-lyon                       # caption(optional) z14- (also has icon z13-)
+# railway-station-subway-malaga                     # caption(optional) z14- (also has icon z13-)
+# railway-station-subway-manila                     # caption(optional) z14- (also has icon z13-)
+# railway-station-subway-maracaibo                  # caption(optional) z14- (also has icon z13-)
+# railway-station-subway-mashhad                    # caption(optional) z14- (also has icon z13-)
+# railway-station-subway-mecca                      # caption(optional) z14- (also has icon z13-)
+# railway-station-subway-medellin                   # caption(optional) z14- (also has icon z13-)
+# railway-station-subway-milan                      # caption(optional) z14- (also has icon z13-)
+# railway-station-subway-montreal                   # caption(optional) z14- (also has icon z13-)
+# railway-station-subway-munchen                    # caption(optional) z14- (also has icon z13-)
+# railway-station-subway-nagoya                     # caption(optional) z14- (also has icon z13-)
+# railway-station-subway-nnov                       # caption(optional) z14- (also has icon z13-)
+# railway-station-subway-novosibirsk                # caption(optional) z14- (also has icon z13-)
+# railway-station-subway-osaka                      # caption(optional) z14- (also has icon z13-)
+# railway-station-subway-oslo                       # caption(optional) z14- (also has icon z13-)
+# railway-station-subway-palma                      # caption(optional) z14- (also has icon z13-)
+# railway-station-subway-panama                     # caption(optional) z14- (also has icon z13-)
+# railway-station-subway-philadelphia               # caption(optional) z14- (also has icon z13-)
+# railway-station-subway-pyongyang                  # caption(optional) z14- (also has icon z13-)
+# railway-station-subway-rennes                     # caption(optional) z14- (also has icon z13-)
+# railway-station-subway-rio                        # caption(optional) z14- (also has icon z13-)
+# railway-station-subway-rotterdam                  # caption(optional) z14- (also has icon z13-)
+# railway-station-subway-samara                     # caption(optional) z14- (also has icon z13-)
+# railway-station-subway-santiago                   # caption(optional) z14- (also has icon z13-)
+# railway-station-subway-santo_domingo              # caption(optional) z14- (also has icon z13-)
+# railway-station-subway-saopaulo                   # caption(optional) z14- (also has icon z13-)
+# railway-station-subway-sapporo                    # caption(optional) z14- (also has icon z13-)
+# railway-station-subway-sendai                     # caption(optional) z14- (also has icon z13-)
+# railway-station-subway-shiraz                     # caption(optional) z14- (also has icon z13-)
+# railway-station-subway-sofia                      # caption(optional) z14- (also has icon z13-)
+# railway-station-subway-tabriz                     # caption(optional) z14- (also has icon z13-)
+# railway-station-subway-taipei                     # caption(optional) z14- (also has icon z13-)
+# railway-station-subway-taoyuan                    # caption(optional) z14- (also has icon z13-)
+# railway-station-subway-tashkent                   # caption(optional) z14- (also has icon z13-)
+# railway-station-subway-tbilisi                    # caption(optional) z14- (also has icon z13-)
+# railway-station-subway-tehran                     # caption(optional) z14- (also has icon z13-)
+# railway-station-subway-tianjin                    # caption(optional) z14- (also has icon z13-)
+# railway-station-subway-valencia                   # caption(optional) z14- (also has icon z13-)
+# railway-station-subway-warszawa                   # caption(optional) z14- (also has icon z13-)
+# railway-station-subway-washington                 # caption(optional) z14- (also has icon z13-)
+# railway-station-subway-wuhan                      # caption(optional) z14- (also has icon z13-)
+# railway-station-subway-yerevan                    # caption(optional) z14- (also has icon z13-)
+# railway-station-subway-yokohama                   # caption(optional) z14- (also has icon z13-)
+# === -3700
+
+# railway-halt                                      # caption(optional) z13- (also has icon z13-)
+# === -3750
+
+# tourism-zoo                                       # caption(optional) z13- (also has icon z13-)
+# === -3950
+
+# leisure-stadium                                   # caption(optional) z13- (also has icon z13-, area z15-)
+# === -4000
+
+# tourism-museum                                    # caption(optional) z13- (also has icon z13-)
+# === -4050
+
+# historic-monument                                 # caption(optional) z13- (also has icon z13-)
+# === -4100
+
+# historic-city_gate                                # caption(optional) z13- (also has icon z13-)
+# === -4150
+
+# railway-tram_stop                                 # caption(optional) z17- (also has icon z14-)
+# waterway-waterfall                                # caption(optional) z11- (also has icon z11-)
+# === -4200
+
+# amenity-charging_station-motorcar                 # caption(optional) z14- (also has icon z14-)
+# amenity-fuel                                      # caption(optional) z14- (also has icon z14-)
+# === -4350
+
+# shop-mall                                         # caption(optional) z14- (also has icon z14-)
+# === -4450
+
+# place-square                                      # caption(optional) z14- (also has icon z14-)
+# tourism-theme_park                                # caption(optional) z14- (also has icon z14-)
+# === -4500
+
+# amenity-community_centre                          # caption(optional) z15- (also has icon z15-)
+# === -4550
+
+# amenity-theatre                                   # caption(optional) z14- (also has icon z14-)
+# === -4600
+
+# man_made-lighthouse                               # caption(optional) z14- (also has icon z14-)
+# === -4650
+
+# highway-services                                  # caption(optional) z14- (also has icon z14-)
+# === -4700
+
+# mountain_pass                                     # caption(optional) z14- (also has icon z14-)
+# natural-saddle                                    # caption(optional) z14- (also has icon z14-)
+# === -4750
+
+# natural-geyser                                    # caption(optional) z14- (also has icon z14-)
+# natural-hot_spring                                # caption(optional) z14- (also has icon z14-)
+# natural-spring                                    # caption(optional) z14- (also has icon z14-)
+# === -4800
+
+# amenity-hospital                                  # caption(optional) z15- (also has icon z14-, area z14-)
+# amenity-university                                # caption(optional) z14- (also has icon z14-, area z14-)
+# === -4900
+
+# leisure-park                                      # caption(optional) z14- (also has icon z14-, area z10-)
+# leisure-park-permissive                           # caption(optional) z14- (also has icon z14-, area z10-)
+# natural-cave_entrance                             # caption(optional) z11- (also has icon z11-)
+# === -4950
+
+# tourism-attraction                                # caption(optional) z14- (also has icon z14-)
+# === -5000
+
+# tourism-viewpoint                                 # caption(optional) z14- (also has icon z14-)
+# === -5050
+
+# amenity-place_of_worship-buddhist                 # caption(optional) z14- (also has icon z14-, area z16-)
+# amenity-place_of_worship-christian                # caption(optional) z14- (also has icon z14-, area z16-)
+# amenity-place_of_worship-hindu                    # caption(optional) z14- (also has icon z14-, area z16-)
+# amenity-place_of_worship-jewish                   # caption(optional) z14- (also has icon z14-, area z16-)
+# amenity-place_of_worship-muslim                   # caption(optional) z14- (also has icon z14-, area z16-)
+# amenity-place_of_worship-shinto                   # caption(optional) z14- (also has icon z14-, area z16-)
+# amenity-place_of_worship-taoist                   # caption(optional) z14- (also has icon z14-, area z16-)
+# === -5100
+
+# amenity-place_of_worship                          # caption(optional) z14- (also has icon z14-, area z16-)
+# === -5150
+
+# landuse-forest                                    # caption(optional) z13- (also has icon z12-, area z10-)
+# landuse-forest-coniferous                         # caption(optional) z13- (also has icon z12-, area z10-)
+# landuse-forest-deciduous                          # caption(optional) z13- (also has icon z12-, area z10-)
+# landuse-forest-mixed                              # caption(optional) z13- (also has icon z12-, area z10-)
+# === -5200
+
+# railway-subway_entrance-moscow                    # caption(optional) z15- (also has icon z15-)
+# === -5550
+
+# railway-subway_entrance-spb                       # caption(optional) z16- (also has icon z15-)
+# === -5650
+
+# tourism-gallery                                   # caption(optional) z15- (also has icon z15-)
+# === -5700
+
+# historic-battlefield                              # caption(optional) z15- (also has icon z15-)
+# historic-memorial                                 # caption(optional) z15- (also has icon z15-)
+# historic-memorial-sculpture                       # caption(optional) z15- (also has icon z15-)
+# historic-memorial-statue                          # caption(optional) z15- (also has icon z15-)
+# historic-memorial-war_memorial                    # caption(optional) z15- (also has icon z15-)
+# tourism-artwork                                   # caption(optional) z15- (also has icon z15-)
+# tourism-artwork-architecture                      # caption(optional) z15- (also has icon z15-)
+# tourism-artwork-painting                          # caption(optional) z15- (also has icon z15-)
+# tourism-artwork-sculpture                         # caption(optional) z15- (also has icon z15-)
+# tourism-artwork-statue                            # caption(optional) z15- (also has icon z15-)
+# === -5750
+
+# tourism-attraction-animal                         # caption(optional) z14- (also has icon z14-)
+# tourism-attraction-specified                      # caption(optional) z14- (also has icon z14-)
+# === -5800
+
+# amenity-cafe                                      # caption(optional) z15- (also has icon z15-)
+# === -5850
+
+# amenity-restaurant                                # caption(optional) z15- (also has icon z15-)
+# === -5900
+
+# amenity-fast_food                                 # caption(optional) z15- (also has icon z15-)
+# amenity-food_court                                # caption(optional) z15- (also has icon z15-)
+# === -5950
+
+# amenity-bar                                       # caption(optional) z15- (also has icon z15-)
+# === -6000
+
+# amenity-biergarten                                # caption(optional) z15- (also has icon z15-)
+# amenity-pub                                       # caption(optional) z15- (also has icon z15-)
+# === -6050
+
+# barrier-border_control                            # caption(optional) z15- (also has icon z15-)
+# === -6100
+
+# shop-car_repair-tyres                             # caption(optional) z15- (also has icon z15-)
+# === -6150
+
+# highway-rest_area                                 # caption(optional) z15- (also has icon z15-)
+# tourism-camp_site                                 # caption(optional) z15- (also has icon z15-)
+# tourism-caravan_site                              # caption(optional) z16- (also has icon z16-)
+# === -6200
+
+# amenity-sanitary_dump_station                     # caption(optional) z15- (also has icon z15-)
+# === -6250
+
+# amenity-drinking_water                            # caption(optional) z19- (also has icon z15-)
+# amenity-water_point                               # caption(optional) z19- (also has icon z15-)
+# === -6300
+
+# railway-subway_entrance                           # caption(optional) z17- (also has icon z16-)
+# railway-subway_entrance-adana                     # caption(optional) z17- (also has icon z16-)
+# railway-subway_entrance-algiers                   # caption(optional) z17- (also has icon z16-)
+# railway-subway_entrance-almaty                    # caption(optional) z17- (also has icon z16-)
+# railway-subway_entrance-amsterdam                 # caption(optional) z17- (also has icon z16-)
+# railway-subway_entrance-ankara                    # caption(optional) z17- (also has icon z16-)
+# railway-subway_entrance-athens                    # caption(optional) z17- (also has icon z16-)
+# railway-subway_entrance-baku                      # caption(optional) z17- (also has icon z16-)
+# railway-subway_entrance-bangkok                   # caption(optional) z17- (also has icon z16-)
+# railway-subway_entrance-barcelona                 # caption(optional) z17- (also has icon z16-)
+# railway-subway_entrance-beijing                   # caption(optional) z17- (also has icon z16-)
+# railway-subway_entrance-bengalore                 # caption(optional) z17- (also has icon z16-)
+# railway-subway_entrance-berlin                    # caption(optional) z17- (also has icon z16-)
+# railway-subway_entrance-bilbao                    # caption(optional) z17- (also has icon z16-)
+# railway-subway_entrance-brasilia                  # caption(optional) z17- (also has icon z16-)
+# railway-subway_entrance-brescia                   # caption(optional) z17- (also has icon z16-)
+# railway-subway_entrance-brussels                  # caption(optional) z17- (also has icon z16-)
+# railway-subway_entrance-bucharest                 # caption(optional) z17- (also has icon z16-)
+# railway-subway_entrance-budapest                  # caption(optional) z17- (also has icon z16-)
+# railway-subway_entrance-buenos_aires              # caption(optional) z17- (also has icon z16-)
+# railway-subway_entrance-bursa                     # caption(optional) z17- (also has icon z16-)
+# railway-subway_entrance-cairo                     # caption(optional) z17- (also has icon z16-)
+# railway-subway_entrance-caracas                   # caption(optional) z17- (also has icon z16-)
+# railway-subway_entrance-catania                   # caption(optional) z17- (also has icon z16-)
+# railway-subway_entrance-changchun                 # caption(optional) z17- (also has icon z16-)
+# railway-subway_entrance-chengdu                   # caption(optional) z17- (also has icon z16-)
+# railway-subway_entrance-chicago                   # caption(optional) z17- (also has icon z16-)
+# railway-subway_entrance-chongqing                 # caption(optional) z17- (also has icon z16-)
+# railway-subway_entrance-dalian                    # caption(optional) z17- (also has icon z16-)
+# railway-subway_entrance-delhi                     # caption(optional) z17- (also has icon z16-)
+# railway-subway_entrance-dnepro                    # caption(optional) z17- (also has icon z16-)
+# railway-subway_entrance-dubai                     # caption(optional) z17- (also has icon z16-)
+# railway-subway_entrance-ekb                       # caption(optional) z17- (also has icon z16-)
+# railway-subway_entrance-fukuoka                   # caption(optional) z17- (also has icon z16-)
+# railway-subway_entrance-glasgow                   # caption(optional) z17- (also has icon z16-)
+# railway-subway_entrance-guangzhou                 # caption(optional) z17- (also has icon z16-)
+# railway-subway_entrance-hamburg                   # caption(optional) z17- (also has icon z16-)
+# railway-subway_entrance-helsinki                  # caption(optional) z17- (also has icon z16-)
+# railway-subway_entrance-hiroshima                 # caption(optional) z17- (also has icon z16-)
+# railway-subway_entrance-isfahan                   # caption(optional) z17- (also has icon z16-)
+# railway-subway_entrance-istanbul                  # caption(optional) z17- (also has icon z16-)
+# railway-subway_entrance-izmir                     # caption(optional) z17- (also has icon z16-)
+# railway-subway_entrance-kazan                     # caption(optional) z17- (also has icon z16-)
+# railway-subway_entrance-kharkiv                   # caption(optional) z17- (also has icon z16-)
+# railway-subway_entrance-kiev                      # caption(optional) z17- (also has icon z16-)
+# railway-subway_entrance-kobe                      # caption(optional) z17- (also has icon z16-)
+# railway-subway_entrance-kolkata                   # caption(optional) z17- (also has icon z16-)
+# railway-subway_entrance-kunming                   # caption(optional) z17- (also has icon z16-)
+# railway-subway_entrance-kyoto                     # caption(optional) z17- (also has icon z16-)
+# railway-subway_entrance-la                        # caption(optional) z17- (also has icon z16-)
+# railway-subway_entrance-lausanne                  # caption(optional) z17- (also has icon z16-)
+# railway-subway_entrance-lille                     # caption(optional) z17- (also has icon z16-)
+# railway-subway_entrance-lima                      # caption(optional) z17- (also has icon z16-)
+# railway-subway_entrance-lisboa                    # caption(optional) z17- (also has icon z16-)
+# railway-subway_entrance-london                    # caption(optional) z17- (also has icon z16-)
+# railway-subway_entrance-lyon                      # caption(optional) z17- (also has icon z16-)
+# railway-subway_entrance-madrid                    # caption(optional) z17- (also has icon z16-)
+# railway-subway_entrance-malaga                    # caption(optional) z17- (also has icon z16-)
+# railway-subway_entrance-manila                    # caption(optional) z17- (also has icon z16-)
+# railway-subway_entrance-maracaibo                 # caption(optional) z17- (also has icon z16-)
+# railway-subway_entrance-mashhad                   # caption(optional) z17- (also has icon z16-)
+# railway-subway_entrance-mecca                     # caption(optional) z17- (also has icon z16-)
+# railway-subway_entrance-medellin                  # caption(optional) z17- (also has icon z16-)
+# railway-subway_entrance-mexico                    # caption(optional) z17- (also has icon z16-)
+# railway-subway_entrance-milan                     # caption(optional) z17- (also has icon z16-)
+# railway-subway_entrance-minsk                     # caption(optional) z17- (also has icon z16-)
+# railway-subway_entrance-montreal                  # caption(optional) z17- (also has icon z16-)
+# railway-subway_entrance-munchen                   # caption(optional) z17- (also has icon z16-)
+# railway-subway_entrance-nagoya                    # caption(optional) z17- (also has icon z16-)
+# railway-subway_entrance-newyork                   # caption(optional) z17- (also has icon z16-)
+# railway-subway_entrance-nnov                      # caption(optional) z17- (also has icon z16-)
+# railway-subway_entrance-novosibirsk               # caption(optional) z17- (also has icon z16-)
+# railway-subway_entrance-osaka                     # caption(optional) z17- (also has icon z16-)
+# railway-subway_entrance-oslo                      # caption(optional) z17- (also has icon z16-)
+# railway-subway_entrance-palma                     # caption(optional) z17- (also has icon z16-)
+# railway-subway_entrance-panama                    # caption(optional) z17- (also has icon z16-)
+# railway-subway_entrance-paris                     # caption(optional) z17- (also has icon z16-)
+# railway-subway_entrance-philadelphia              # caption(optional) z17- (also has icon z16-)
+# railway-subway_entrance-pyongyang                 # caption(optional) z17- (also has icon z16-)
+# railway-subway_entrance-rennes                    # caption(optional) z17- (also has icon z16-)
+# railway-subway_entrance-rio                       # caption(optional) z17- (also has icon z16-)
+# railway-subway_entrance-roma                      # caption(optional) z17- (also has icon z16-)
+# railway-subway_entrance-rotterdam                 # caption(optional) z17- (also has icon z16-)
+# railway-subway_entrance-samara                    # caption(optional) z17- (also has icon z16-)
+# railway-subway_entrance-santiago                  # caption(optional) z17- (also has icon z16-)
+# railway-subway_entrance-santo_domingo             # caption(optional) z17- (also has icon z16-)
+# railway-subway_entrance-saopaulo                  # caption(optional) z17- (also has icon z16-)
+# railway-subway_entrance-sapporo                   # caption(optional) z17- (also has icon z16-)
+# railway-subway_entrance-sendai                    # caption(optional) z17- (also has icon z16-)
+# railway-subway_entrance-sf                        # caption(optional) z17- (also has icon z16-)
+# railway-subway_entrance-shanghai                  # caption(optional) z17- (also has icon z16-)
+# railway-subway_entrance-shiraz                    # caption(optional) z17- (also has icon z16-)
+# railway-subway_entrance-sofia                     # caption(optional) z17- (also has icon z16-)
+# railway-subway_entrance-stockholm                 # caption(optional) z17- (also has icon z16-)
+# railway-subway_entrance-tabriz                    # caption(optional) z17- (also has icon z16-)
+# railway-subway_entrance-taipei                    # caption(optional) z17- (also has icon z16-)
+# railway-subway_entrance-taoyuan                   # caption(optional) z17- (also has icon z16-)
+# railway-subway_entrance-tashkent                  # caption(optional) z17- (also has icon z16-)
+# railway-subway_entrance-tbilisi                   # caption(optional) z17- (also has icon z16-)
+# railway-subway_entrance-tehran                    # caption(optional) z17- (also has icon z16-)
+# railway-subway_entrance-tianjin                   # caption(optional) z17- (also has icon z16-)
+# railway-subway_entrance-tokyo                     # caption(optional) z17- (also has icon z16-)
+# railway-subway_entrance-valencia                  # caption(optional) z17- (also has icon z16-)
+# railway-subway_entrance-vienna                    # caption(optional) z17- (also has icon z16-)
+# railway-subway_entrance-warszawa                  # caption(optional) z17- (also has icon z16-)
+# railway-subway_entrance-washington                # caption(optional) z17- (also has icon z16-)
+# railway-subway_entrance-wuhan                     # caption(optional) z17- (also has icon z16-)
+# railway-subway_entrance-yerevan                   # caption(optional) z17- (also has icon z16-)
+# railway-subway_entrance-yokohama                  # caption(optional) z17- (also has icon z16-)
+# === -6700
+
+# amenity-charging_station                          # caption(optional) z16- (also has icon z16-)
+# amenity-charging_station-bicycle                  # caption(optional) z16- (also has icon z16-)
+# landuse-cemetery                                  # caption(optional) z15- (also has icon z15-, area z14-)
+# landuse-cemetery-christian                        # caption(optional) z15- (also has icon z15-, area z14-)
+# shop-supermarket                                  # caption(optional) z16- (also has icon z16-)
+# tourism-alpine_hut                                # caption(optional) z16- (also has icon z16-)
+# tourism-chalet                                    # caption(optional) z16- (also has icon z16-)
+# tourism-information-office                        # caption(optional) z16- (also has icon z16-)
+# tourism-wilderness_hut                            # caption(optional) z16- (also has icon z16-)
+# === -6750
+
+# highway-bus_stop                                  # caption(optional) z17- (also has icon z16-)
+# === -6800
+
+# amenity-pharmacy                                  # caption(optional) z17- (also has icon z16-)
+# === -6850
+
+# amenity-fountain                                  # caption(optional) z16- (also has icon z16-, area z16-)
+# === -6950
+
+# historic-ship                                     # caption(optional) z16- (also has icon z16-)
+# === -7100
+
+# amenity-shelter                                   # caption(optional) z16- (also has icon z16-)
+# tourism-information                               # caption(optional) z16- (also has icon z16-)
+# === -7150
+
+# tourism-hotel                                     # caption(optional) z16- (also has icon z16-)
+# tourism-resort                                    # caption(optional) z16- (also has icon z16-)
+# === -7250
+
+# tourism-motel                                     # caption(optional) z16- (also has icon z16-)
+# === -7300
+
+# tourism-hostel                                    # caption(optional) z16- (also has icon z16-)
+# === -7350
+
+# tourism-apartment                                 # caption(optional) z16- (also has icon z16-)
+# tourism-guest_house                               # caption(optional) z16- (also has icon z16-)
+# === -7400
+
+# amenity-ice_cream                                 # caption(optional) z19- (also has icon z16-)
+# === -7450
+
+# aeroway-helipad                                   # caption(optional) z16- (also has icon z16-)
+# amenity-bank                                      # caption(optional) z16- (also has icon z16-)
+# amenity-marketplace                               # caption(optional) z16- (also has icon z16-)
+# amenity-nightclub                                 # caption(optional) z16- (also has icon z16-)
+# amenity-townhall                                  # caption(optional) z16- (also has icon z16-)
+# shop-caravan                                      # caption(optional) z16- (also has icon z16-)
+# === -7500
+
+# leisure-picnic_table                              # caption(optional) z16- (also has icon z16-)
+# shop-antiques                                     # caption(optional) z16- (also has icon z16-)
+# shop-charity                                      # caption(optional) z16- (also has icon z16-)
+# shop-second_hand                                  # caption(optional) z16- (also has icon z16-)
+# tourism-picnic_site                               # caption(optional) z16- (also has icon z16-)
+# === -7550
+
+# shop-alcohol                                      # caption(optional) z16- (also has icon z16-)
+# shop-art                                          # caption(optional) z16- (also has icon z16-)
+# shop-auction                                      # caption(optional) z16- (also has icon z16-)
+# shop-bakery                                       # caption(optional) z16- (also has icon z16-)
+# shop-beauty                                       # caption(optional) z16- (also has icon z16-)
+# shop-beverages                                    # caption(optional) z16- (also has icon z16-)
+# shop-bicycle                                      # caption(optional) z16- (also has icon z16-)
+# shop-bookmaker                                    # caption(optional) z16- (also has icon z16-)
+# shop-books                                        # caption(optional) z16- (also has icon z16-)
+# shop-butcher                                      # caption(optional) z16- (also has icon z16-)
+# shop-camera                                       # caption(optional) z16- (also has icon z16-)
+# shop-car                                          # caption(optional) z16- (also has icon z16-)
+# shop-car_parts                                    # caption(optional) z16- (also has icon z16-)
+# shop-car_repair                                   # caption(optional) z16- (also has icon z16-)
+# shop-cheese                                       # caption(optional) z16- (also has icon z16-)
+# shop-chemist                                      # caption(optional) z16- (also has icon z16-)
+# shop-chocolate                                    # caption(optional) z16- (also has icon z16-)
+# shop-clothes                                      # caption(optional) z16- (also has icon z16-)
+# shop-collector                                    # caption(optional) z18- (also has icon z16-)
+# shop-computer                                     # caption(optional) z16- (also has icon z16-)
+# shop-confectionery                                # caption(optional) z16- (also has icon z16-)
+# shop-convenience                                  # caption(optional) z16- (also has icon z16-)
+# shop-copyshop                                     # caption(optional) z16- (also has icon z16-)
+# shop-cosmetics                                    # caption(optional) z16- (also has icon z16-)
+# shop-deli                                         # caption(optional) z16- (also has icon z16-)
+# shop-department_store                             # caption(optional) z16- (also has icon z16-)
+# shop-doityourself                                 # caption(optional) z16- (also has icon z16-)
+# shop-dry_cleaning                                 # caption(optional) z16- (also has icon z16-)
+# shop-electronics                                  # caption(optional) z16- (also has icon z16-)
+# shop-erotic                                       # caption(optional) z16- (also has icon z16-)
+# shop-fabric                                       # caption(optional) z16- (also has icon z16-)
+# shop-farm                                         # caption(optional) z16- (also has icon z16-)
+# shop-florist                                      # caption(optional) z16- (also has icon z16-)
+# shop-funeral_directors                            # caption(optional) z16- (also has icon z16-)
+# shop-furniture                                    # caption(optional) z16- (also has icon z16-)
+# shop-garden_centre                                # caption(optional) z16- (also has icon z16-)
+# shop-gift                                         # caption(optional) z16- (also has icon z16-)
+# shop-greengrocer                                  # caption(optional) z16- (also has icon z16-)
+# shop-grocery                                      # caption(optional) z16- (also has icon z16-)
+# shop-hairdresser                                  # caption(optional) z16- (also has icon z16-)
+# shop-hardware                                     # caption(optional) z16- (also has icon z16-)
+# shop-health_food                                  # caption(optional) z16- (also has icon z16-)
+# shop-houseware                                    # caption(optional) z16- (also has icon z16-)
+# shop-interior_decoration                          # caption(optional) z16- (also has icon z16-)
+# shop-jewelry                                      # caption(optional) z16- (also has icon z16-)
+# shop-kiosk                                        # caption(optional) z16- (also has icon z16-)
+# shop-kitchen                                      # caption(optional) z16- (also has icon z16-)
+# shop-laundry                                      # caption(optional) z16- (also has icon z16-)
+# shop-mobile_phone                                 # caption(optional) z16- (also has icon z16-)
+# shop-motorcycle                                   # caption(optional) z16- (also has icon z16-)
+# shop-music                                        # caption(optional) z16- (also has icon z16-)
+# shop-musical_instrument                           # caption(optional) z16- (also has icon z16-)
+# shop-optician                                     # caption(optional) z16- (also has icon z16-)
+# shop-outdoor                                      # caption(optional) z16- (also has icon z16-)
+# shop-pastry                                       # caption(optional) z16- (also has icon z16-)
+# shop-pet                                          # caption(optional) z16- (also has icon z16-)
+# shop-photo                                        # caption(optional) z16- (also has icon z16-)
+# shop-seafood                                      # caption(optional) z16- (also has icon z16-)
+# shop-sewing                                       # caption(optional) z16- (also has icon z16-)
+# shop-shoes                                        # caption(optional) z16- (also has icon z16-)
+# shop-sports                                       # caption(optional) z16- (also has icon z16-)
+# shop-stationery                                   # caption(optional) z16- (also has icon z16-)
+# shop-tattoo                                       # caption(optional) z16- (also has icon z16-)
+# shop-ticket                                       # caption(optional) z16- (also has icon z16-)
+# shop-toys                                         # caption(optional) z16- (also has icon z16-)
+# shop-tyres                                        # caption(optional) z16- (also has icon z16-)
+# shop-video                                        # caption(optional) z16- (also has icon z16-)
+# shop-video_games                                  # caption(optional) z16- (also has icon z16-)
+# shop-wine                                         # caption(optional) z16- (also has icon z16-)
+# === -7600
+
+# amenity-hunting_stand                             # caption(optional) z18- (also has icon z18-)
+# amenity-taxi                                      # caption(optional) z16- (also has icon z16-)
+# amenity-veterinary                                # caption(optional) z16- (also has icon z16-)
+# barrier-lift_gate                                 # caption(optional) z16- (also has icon z16-)
+# leisure-dog_park                                  # caption(optional) z16- (also has icon z16-)
+# leisure-water_park                                # caption(optional) z16- (also has icon z16-)
+# man_made-windmill                                 # caption(optional) z16- (also has icon z16-)
+# === -7650
+
+# amenity-conference_centre                         # caption(optional) z16- (also has icon z16-)
+# amenity-events_venue                              # caption(optional) z16- (also has icon z16-)
+# amenity-exhibition_centre                         # caption(optional) z16- (also has icon z16-)
+# historic-boundary_stone                           # caption(optional) z16- (also has icon z16-)
+# historic-gallows                                  # caption(optional) z17- (also has icon z16-)
+# historic-pillory                                  # caption(optional) z17- (also has icon z16-)
+# historic-tomb                                     # caption(optional) z16- (also has icon z16-)
+# historic-wayside_cross                            # caption(optional) z16- (also has icon z16-)
+# historic-wayside_shrine                           # caption(optional) z17- (also has icon z16-)
+# man_made-chimney                                  # caption(optional) z18- (also has icon z16-)
+# === -7700
+
+# leisure-marina                                    # caption(optional) z16- (also has icon z16-)
+# === -7900
+
+# leisure-garden                                    # caption(optional) z16- (also has icon z16-, area z12-)
+# === -7950
+
+# amenity-college                                   # caption(optional) z16- (also has icon z16-, area z15-)
+# landuse-military                                  # caption(optional) z17- (also has icon z16-, area z12-)
+# landuse-military-danger_area                      # caption(optional) z17- (also has icon z16-, area z10-)
+# === -8000
+
+# leisure-beach_resort                              # caption(optional) z16- (also has icon z16-, area z10-)
+# === -8050
+
+# barrier-block                                     # caption(optional) z16- (also has icon z16-)
+# barrier-bollard                                   # caption(optional) z16- (also has icon z16-)
+# barrier-chain                                     # caption(optional) z16- (also has icon z16-)
+# barrier-entrance                                  # caption(optional) z16- (also has icon z16-)
+# barrier-gate                                      # caption(optional) z16- (also has icon z16-)
+# barrier-kissing_gate                              # caption(optional) z16- (also has icon z16-)
+# barrier-stile                                     # caption(optional) z16- (also has icon z16-)
+# barrier-swing_gate                                # caption(optional) z16- (also has icon z16-)
+# barrier-turnstile                                 # caption(optional) z16- (also has icon z16-)
+# man_made-silo                                     # caption(optional) z18- (also has icon z16-)
+# man_made-storage_tank                             # caption(optional) z18- (also has icon z16-)
+# man_made-works                                    # caption(optional) z18- (also has icon z16-)
+# === -8100
+
+# leisure-park-no-access                            # caption(optional) z14- (also has icon z14-, area z10-)
+# leisure-park-private                              # caption(optional) z14- (also has icon z14-, area z10-)
+# === -8150
+
+# landuse-landfill                                  # caption(optional) z15- (also has icon z15-, area z15-)
+# === -8200
+
+# historic-memorial-cross                           # caption(optional) z17- (also has icon z17-)
+# === -8450
+
+# amenity-cinema                                    # caption(optional) z17- (also has icon z17-)
+# amenity-clinic                                    # caption(optional) z17- (also has icon z17-)
+# amenity-courthouse                                # caption(optional) z17- (also has icon z17-)
+# amenity-dentist                                   # caption(optional) z17- (also has icon z17-)
+# amenity-doctors                                   # caption(optional) z17- (also has icon z17-, area z14-)
+# amenity-police                                    # caption(optional) z17- (also has icon z17-)
+# amenity-post_office                               # caption(optional) z17- (also has icon z17-)
+# amenity-prison                                    # caption(optional) z17- (also has icon z17-)
+# healthcare-alternative                            # caption(optional) z17- (also has icon z17-)
+# healthcare-audiologist                            # caption(optional) z17- (also has icon z17-)
+# healthcare-blood_donation                         # caption(optional) z17- (also has icon z17-)
+# healthcare-laboratory                             # caption(optional) z17- (also has icon z17-)
+# healthcare-optometrist                            # caption(optional) z17- (also has icon z17-)
+# healthcare-physiotherapist                        # caption(optional) z17- (also has icon z17-)
+# healthcare-podiatrist                             # caption(optional) z17- (also has icon z17-)
+# healthcare-psychotherapist                        # caption(optional) z17- (also has icon z17-)
+# healthcare-sample_collection                      # caption(optional) z17- (also has icon z17-)
+# healthcare-speech_therapist                       # caption(optional) z17- (also has icon z17-)
+# historic-archaeological_site                      # caption(optional) z17- (also has icon z17-)
+# leisure-bowling_alley                             # caption(optional) z17- (also has icon z17-)
+# leisure-swimming_pool                             # caption(optional) z17- (also has icon z17-, area z13-)
+# leisure-swimming_pool-private                     # caption(optional) z17- (also has icon z17-, area z13-)
+# office-diplomatic                                 # caption(optional) z17- (also has icon z17-)
+# office-lawyer                                     # caption(optional) z17- (also has icon z17-)
+# === -8500
+
+# aeroway-gate                                      # caption(optional) z17- (also has icon z17-)
+# amenity-bicycle_rental                            # caption(optional) z17- (also has icon z17-)
+# amenity-bicycle_repair_station                    # caption(optional) z17- (also has icon z17-)
+# amenity-bureau_de_change                          # caption(optional) z18- (also has icon z17-)
+# amenity-car_wash                                  # caption(optional) z17- (also has icon z17-)
+# amenity-money_transfer                            # caption(optional) z18- (also has icon z17-)
+# shop-pawnbroker                                   # caption(optional) z17- (also has icon z17-)
+# sport-skiing                                      # caption(optional) z17- (also has icon z17-)
+# sport-tennis                                      # caption(optional) z17- (also has icon z17-)
+# === -8550
+
+# sport-american_football                           # caption(optional) z17- (also has icon z17-)
+# sport-athletics                                   # caption(optional) z17- (also has icon z17-)
+# sport-badminton                                   # caption(optional) z17- (also has icon z17-)
+# sport-baseball                                    # caption(optional) z17- (also has icon z17-)
+# sport-basketball                                  # caption(optional) z17- (also has icon z17-)
+# sport-beachvolleyball                             # caption(optional) z17- (also has icon z17-)
+# sport-field_hockey                                # caption(optional) z17- (also has icon z17-)
+# sport-golf                                        # caption(optional) z17- (also has icon z17-)
+# sport-gymnastics                                  # caption(optional) z17- (also has icon z17-)
+# sport-handball                                    # caption(optional) z17- (also has icon z17-)
+# sport-ice_hockey                                  # caption(optional) z17- (also has icon z17-)
+# sport-padel                                       # caption(optional) z17- (also has icon z17-)
+# sport-pelota                                      # caption(optional) z17- (also has icon z17-)
+# sport-skateboard                                  # caption(optional) z17- (also has icon z17-)
+# sport-swimming                                    # caption(optional) z17- (also has icon z17-)
+# sport-table_tennis                                # caption(optional) z17- (also has icon z17-)
+# sport-volleyball                                  # caption(optional) z17- (also has icon z17-)
+# sport-yoga                                        # caption(optional) z17- (also has icon z17-)
+# === -8600
+
+# sport-10pin                                       # caption(optional) z17- (also has icon z17-)
+# sport-9pin                                        # caption(optional) z17- (also has icon z17-)
+# sport-archery                                     # caption(optional) z17- (also has icon z17-)
+# sport-australian_football                         # caption(optional) z17- (also has icon z17-)
+# sport-bowls                                       # caption(optional) z17- (also has icon z17-)
+# sport-chess                                       # caption(optional) z17- (also has icon z17-)
+# sport-climbing                                    # caption(optional) z17- (also has icon z17-)
+# sport-cricket                                     # caption(optional) z17- (also has icon z17-)
+# sport-curling                                     # caption(optional) z17- (also has icon z17-)
+# sport-diving                                      # caption(optional) z17- (also has icon z17-)
+# sport-equestrian                                  # caption(optional) z17- (also has icon z17-)
+# sport-futsal                                      # caption(optional) z17- (also has icon z17-)
+# sport-scuba_diving                                # caption(optional) z17- (also has icon z17-)
+# sport-shooting                                    # caption(optional) z17- (also has icon z17-)
+# === -8650
+
+# shop-massage                                      # caption(optional) z18- (also has icon z17-)
+# shop-money_lender                                 # caption(optional) z17- (also has icon z17-)
+# shop-newsagent                                    # caption(optional) z18- (also has icon z17-)
+# shop-variety_store                                # caption(optional) z17- (also has icon z17-)
+# sport-multi                                       # caption(optional) z17- (also has icon z17-, area z15-)
+# sport-soccer                                      # caption(optional) z17- (also has icon z17-, area z15-)
+# === -8700
+
+# amenity-casino                                    # caption(optional) z17- (also has icon z17-)
+# amenity-childcare                                 # caption(optional) z17- (also has icon z17-)
+# craft-beekeeper                                   # caption(optional) z18- (also has icon z17-)
+# craft-blacksmith                                  # caption(optional) z18- (also has icon z17-)
+# craft-brewery                                     # caption(optional) z18- (also has icon z17-)
+# craft-carpenter                                   # caption(optional) z18- (also has icon z17-)
+# craft-confectionery                               # caption(optional) z18- (also has icon z17-)
+# craft-electrician                                 # caption(optional) z18- (also has icon z17-)
+# craft-electronics_repair                          # caption(optional) z18- (also has icon z17-)
+# craft-gardener                                    # caption(optional) z18- (also has icon z17-)
+# craft-metal_construction                          # caption(optional) z18- (also has icon z17-)
+# craft-painter                                     # caption(optional) z18- (also has icon z17-)
+# craft-photographer                                # caption(optional) z18- (also has icon z17-)
+# craft-plumber                                     # caption(optional) z18- (also has icon z17-)
+# craft-sawmill                                     # caption(optional) z18- (also has icon z17-)
+# craft-shoemaker                                   # caption(optional) z18- (also has icon z17-)
+# craft-tailor                                      # caption(optional) z18- (also has icon z17-)
+# historic-ruins                                    # caption(optional) z17- (also has icon z17-)
+# leisure-playground                                # caption(optional) z17- (also has icon z17-, area z16-)
+# power-station                                     # caption(optional) z17- (also has icon z17-)
+# === -8750
+
+# amenity-parcel_locker                             # caption(optional) z17- (also has icon z17-)
+# amenity-recycling                                 # caption(optional) z19- (also has icon z17-)
+# amenity-recycling-centre                          # caption(optional) z19- (also has icon z17-)
+# amenity-shower                                    # caption(optional) z17- (also has icon z17-)
+# amenity-vending_machine-fuel                      # caption(optional) z18- (also has icon z18-)
+# amenity-vending_machine-parking_tickets           # caption(optional) z17- (also has icon z17-)
+# amenity-vending_machine-public_transport_tickets  # caption(optional) z17- (also has icon z17-)
+# amenity-waste_transfer_station                    # caption(optional) z19- (also has icon z17-)
+# === -8800
+
+# amenity-grave_yard                                # caption(optional) z17- (also has icon z17-, area z14-)
+# amenity-grave_yard-christian                      # caption(optional) z17- (also has icon z17-, area z14-)
+# cemetery-grave                                    # caption(optional) z17- (also has icon z17-)
+# === -8900
+
+# leisure-golf_course                               # caption(optional) z17- (also has icon z17-, area z12-)
+# === -8950
+
+# leisure-pitch                                     # caption(optional) z17- (also has icon z17-, area z15-)
+# === -9050
+
+# amenity-kindergarten                              # caption(optional) z17- (also has icon z17-, area z15-)
+# amenity-school                                    # caption(optional) z17- (also has icon z17-, area z15-)
+# === -9100
+
+# amenity-arts_centre                               # caption(optional) z17- (also has icon z17-)
+# amenity-driving_school                            # caption(optional) z19- (also has icon z17-)
+# amenity-language_school                           # caption(optional) z19- (also has icon z17-)
+# amenity-music_school                              # caption(optional) z19- (also has icon z17-)
+# amenity-nursing_home                              # caption(optional) z17- (also has icon z17-)
+# amenity-payment_terminal                          # caption(optional) z17- (also has icon z17-)
+# leisure-fitness_centre                            # caption(optional) z17- (also has icon z17-)
+# leisure-fitness_station                           # caption(optional) z17- (also has icon z17-)
+# leisure-ice_rink                                  # caption(optional) z17- (also has icon z17-)
+# leisure-sauna                                     # caption(optional) z17- (also has icon z17-)
+# leisure-sports_centre                             # caption(optional) z17- (also has icon z17-)
+# === -9150
+
+# historic-memorial-plaque                          # caption(optional) z18- (also has icon z18-)
+# === -9400
+
+# amenity-atm                                       # caption(optional) z18- (also has icon z18-)
+# amenity-brothel                                   # caption(optional) z18- (also has icon z18-)
+# amenity-car_rental                                # caption(optional) z18- (also has icon z18-)
+# amenity-car_sharing                               # caption(optional) z18- (also has icon z18-)
+# amenity-fire_station                              # caption(optional) z18- (also has icon z18-)
+# amenity-library                                   # caption(optional) z18- (also has icon z18-)
+# amenity-stripclub                                 # caption(optional) z18- (also has icon z18-)
+# office                                            # caption(optional) z18- (also has icon z18-)
+# office-company                                    # caption(optional) z18- (also has icon z18-)
+# office-estate_agent                               # caption(optional) z18- (also has icon z18-)
+# office-government                                 # caption(optional) z18- (also has icon z18-)
+# office-insurance                                  # caption(optional) z18- (also has icon z18-)
+# office-ngo                                        # caption(optional) z18- (also has icon z18-)
+# office-telecommunication                          # caption(optional) z18- (also has icon z18-)
+# === -9450
+
+# shop                                              # caption(optional) z18- (also has icon z18-)
+# shop-agrarian                                     # caption(optional) z18- (also has icon z18-)
+# shop-appliance                                    # caption(optional) z18- (also has icon z18-)
+# shop-baby_goods                                   # caption(optional) z18- (also has icon z18-)
+# shop-bag                                          # caption(optional) z18- (also has icon z18-)
+# shop-bathroom_furnishing                          # caption(optional) z18- (also has icon z18-)
+# shop-bed                                          # caption(optional) z18- (also has icon z18-)
+# shop-boutique                                     # caption(optional) z18- (also has icon z18-)
+# shop-cannabis                                     # caption(optional) z18- (also has icon z18-)
+# shop-carpet                                       # caption(optional) z18- (also has icon z18-)
+# shop-coffee                                       # caption(optional) z18- (also has icon z18-)
+# shop-craft                                        # caption(optional) z18- (also has icon z18-)
+# shop-curtain                                      # caption(optional) z18- (also has icon z18-)
+# shop-dairy                                        # caption(optional) z18- (also has icon z18-)
+# shop-electrical                                   # caption(optional) z18- (also has icon z18-)
+# shop-fashion_accessories                          # caption(optional) z18- (also has icon z18-)
+# shop-fishing                                      # caption(optional) z18- (also has icon z18-)
+# shop-gas                                          # caption(optional) z18- (also has icon z18-)
+# shop-herbalist                                    # caption(optional) z18- (also has icon z18-)
+# shop-hifi                                         # caption(optional) z18- (also has icon z18-)
+# shop-lottery                                      # caption(optional) z18- (also has icon z18-)
+# shop-medical_supply                               # caption(optional) z18- (also has icon z18-)
+# shop-motorcycle_repair                            # caption(optional) z18- (also has icon z18-)
+# shop-nutrition_supplements                        # caption(optional) z18- (also has icon z18-)
+# shop-outpost                                      # caption(optional) z18- (also has icon z18-)
+# shop-paint                                        # caption(optional) z18- (also has icon z18-)
+# shop-perfumery                                    # caption(optional) z18- (also has icon z18-)
+# shop-pet_grooming                                 # caption(optional) z18- (also has icon z18-)
+# shop-storage_rental                               # caption(optional) z18- (also has icon z18-)
+# shop-tea                                          # caption(optional) z18- (also has icon z18-)
+# shop-tobacco                                      # caption(optional) z18- (also has icon z18-)
+# shop-trade                                        # caption(optional) z18- (also has icon z18-)
+# shop-travel_agency                                # caption(optional) z18- (also has icon z18-)
+# shop-watches                                      # caption(optional) z18- (also has icon z18-)
+# shop-wholesale                                    # caption(optional) z18- (also has icon z18-)
+# === -9500
+
+# amenity-bbq                                       # caption(optional) z18- (also has icon z18-)
+# amenity-internet_cafe                             # caption(optional) z19- (also has icon z18-)
+# amenity-toilets                                   # caption(optional) z18- (also has icon z18-)
+# craft-handicraft                                  # caption(optional) z18- (also has icon z18-)
+# craft-hvac                                        # caption(optional) z18- (also has icon z18-)
+# craft-key_cutter                                  # caption(optional) z18- (also has icon z18-)
+# craft-locksmith                                   # caption(optional) z18- (also has icon z18-)
+# craft-winery                                      # caption(optional) z18- (also has icon z18-)
+# === -9550
+
+# amenity-parking                                   # caption(optional) z18- (also has icon z16-, area z15-)
+# amenity-parking-fee                               # caption(optional) z18- (also has icon z16-, area z15-)
+# amenity-parking-multi-storey                      # caption(optional) z18- (also has icon z16-, area z15-)
+# amenity-parking-park_and_ride                     # caption(optional) z18- (also has icon z16-, area z15-)
+# amenity-parking-underground                       # caption(optional) z18- (also has icon z16-, area z15-)
+# === -9700
+
+# amenity-bicycle_parking                           # caption(optional) z17- (also has icon z17-)
+# amenity-motorcycle_parking                        # caption(optional) z17- (also has icon z17-)
+# amenity-parking-permissive                        # caption(optional) z18- (also has icon z16-, area z15-)
+# amenity-parking_entrance                          # caption(optional) z19- (also has icon z17-)
+# amenity-parking_entrance-permissive               # caption(optional) z19- (also has icon z17-)
+# === -9750
+
+# amenity-post_box                                  # caption(optional) z18- (also has icon z18-)
+# amenity-recycling-container                       # caption(optional) z19- (also has icon z17-)
+# historic-memorial-stolperstein                    # caption(optional) z19- (also has icon z19-)
+# === -9800
+
+# entrance-main                                     # caption(optional) z18- (also has icon z18-)
+# === -9830
+
+# amenity-parking-lane                              # caption(optional) z18- (also has icon z17-, area z15-)
+# amenity-parking-street_side                       # caption(optional) z18- (also has icon z17-, area z15-)
+# === -9850
+
+# amenity-parking-no-access                         # caption(optional) z18- (also has icon z16-, area z15-)
+# amenity-parking-private                           # caption(optional) z18- (also has icon z18-, area z15-)
+# === -9900
+
+man_made-survey_point                               # icon z16- (also has caption(optional) z16-)
+tourism-information-board                           # icon z16- (also has caption(optional) z16-)
+tourism-information-guidepost                       # icon z16- (also has caption(optional) z16-)
+tourism-information-map                             # icon z16- (also has caption(optional) z16-)
 === -9950
 
-amenity-telephone                                   # caption z19 and icon z17-
-entrance                                            # caption z19 and icon z19
+amenity-telephone                                   # icon z17- (also has caption(optional) z19-)
+entrance                                            # icon z19- (also has caption(optional) z19-)
 === -9960
 
-amenity-parking_space                               # caption z19
-amenity-parking_space-disabled                      # caption z19 and icon z18-
-amenity-parking_space-permissive                    # caption z19
-amenity-parking_space-private                       # caption z19
-amenity-parking_space-underground                   # caption z19
-amenity-vending_machine                             # caption z18- and icon z18-
-amenity-vending_machine-cigarettes                  # caption z18- and icon z18-
-amenity-vending_machine-coffee                      # caption z18- and icon z18-
-amenity-vending_machine-condoms                     # caption z18- and icon z18-
-amenity-vending_machine-drinks                      # caption z18- and icon z18-
-amenity-vending_machine-excrement_bags              # caption z18- and icon z18-
-amenity-vending_machine-food                        # caption z18- and icon z18-
-amenity-vending_machine-newspapers                  # caption z18- and icon z18-
-amenity-vending_machine-sweets                      # caption z18- and icon z18-
+amenity-parking_space                               # caption z19-
+amenity-parking_space-disabled                      # icon z18- (also has caption(optional) z19-)
+amenity-parking_space-permissive                    # caption z19-
+amenity-parking_space-private                       # caption z19-
+amenity-parking_space-underground                   # caption z19-
+amenity-vending_machine                             # icon z18- (also has caption(optional) z18-)
+amenity-vending_machine-cigarettes                  # icon z18- (also has caption(optional) z18-)
+amenity-vending_machine-coffee                      # icon z18- (also has caption(optional) z18-)
+amenity-vending_machine-condoms                     # icon z18- (also has caption(optional) z18-)
+amenity-vending_machine-drinks                      # icon z18- (also has caption(optional) z18-)
+amenity-vending_machine-excrement_bags              # icon z18- (also has caption(optional) z18-)
+amenity-vending_machine-food                        # icon z18- (also has caption(optional) z18-)
+amenity-vending_machine-newspapers                  # icon z18- (also has caption(optional) z18-)
+amenity-vending_machine-sweets                      # icon z18- (also has caption(optional) z18-)
 === -9970
 
-amenity-bench                                       # caption z19 and icon z18-
-amenity-waste_disposal                              # caption z18- and icon z18-
-emergency-defibrillator                             # caption z18- and icon z18-
+amenity-bench                                       # icon z18- (also has caption(optional) z19-)
+amenity-waste_disposal                              # icon z18- (also has caption(optional) z18-)
+emergency-defibrillator                             # icon z18- (also has caption(optional) z18-)
 emergency-phone                                     # icon z17-
 === -9980
 
-amenity-waste_basket                                # caption z19 and icon z18-
-emergency-fire_hydrant                              # caption z18- and icon z18-
-power-substation                                    # caption z19 and icon z19
+amenity-waste_basket                                # icon z18- (also has caption(optional) z19-)
+emergency-fire_hydrant                              # icon z18- (also has caption(optional) z18-)
+power-substation                                    # icon z19- (also has caption(optional) z19-)
 === -9990
 
-amenity-loading_dock                                # caption z18- and icon z18-
-entrance-exit                                       # caption z18- and icon z18-
+# amenity-bench                                     # caption(optional) z19- (also has icon z18-)
+amenity-loading_dock                                # icon z18- (also has caption(optional) z18-)
+# amenity-loading_dock                              # caption(optional) z18- (also has icon z18-)
+# amenity-parking_space-disabled                    # caption(optional) z19- (also has icon z18-)
+# amenity-telephone                                 # caption(optional) z19- (also has icon z17-)
+# amenity-vending_machine                           # caption(optional) z18- (also has icon z18-)
+# amenity-vending_machine-cigarettes                # caption(optional) z18- (also has icon z18-)
+# amenity-vending_machine-coffee                    # caption(optional) z18- (also has icon z18-)
+# amenity-vending_machine-condoms                   # caption(optional) z18- (also has icon z18-)
+# amenity-vending_machine-drinks                    # caption(optional) z18- (also has icon z18-)
+# amenity-vending_machine-excrement_bags            # caption(optional) z18- (also has icon z18-)
+# amenity-vending_machine-food                      # caption(optional) z18- (also has icon z18-)
+# amenity-vending_machine-newspapers                # caption(optional) z18- (also has icon z18-)
+# amenity-vending_machine-sweets                    # caption(optional) z18- (also has icon z18-)
+# amenity-waste_basket                              # caption(optional) z19- (also has icon z18-)
+# amenity-waste_disposal                            # caption(optional) z18- (also has icon z18-)
+# emergency-defibrillator                           # caption(optional) z18- (also has icon z18-)
+# emergency-fire_hydrant                            # caption(optional) z18- (also has icon z18-)
+# entrance                                          # caption(optional) z19- (also has icon z19-)
+entrance-exit                                       # icon z18- (also has caption(optional) z18-)
+# entrance-exit                                     # caption(optional) z18- (also has icon z18-)
+# man_made-survey_point                             # caption(optional) z16- (also has icon z16-)
+# power-substation                                  # caption(optional) z19- (also has icon z19-)
+# tourism-information-board                         # caption(optional) z16- (also has icon z16-)
+# tourism-information-guidepost                     # caption(optional) z16- (also has icon z16-)
+# tourism-information-map                           # caption(optional) z16- (also has icon z16-)
 === -10000

--- a/data/styles/vehicle/include/priorities_1_BG-by-size.prio.txt
+++ b/data/styles/vehicle/include/priorities_1_BG-by-size.prio.txt
@@ -1,5 +1,6 @@
 # This file is automatically re-formatted and re-sorted in priorities descending order
-# when generate_drules.sh is run. Custom formatting and comments are not preserved.
+# when generate_drules.sh is run. All comments (automatic priorities of e.g. optional captions, drule types visibilities, etc.)
+# are generated automatically for information only. Custom formatting and comments are not preserved.
 #
 # BG-by-size geometry: background areas rendered below BG-top and everything else.
 # Smaller areas are rendered above larger ones (area's size is estimated as the size of its' bounding box).
@@ -13,22 +14,22 @@
 # - BG-top: water (linear and areal)
 # - BG-by-size: landcover areas sorted by their size
 
-amenity-parking                                     # area z15- (also has caption z16-, icon z15-)
-amenity-parking-fee                                 # area z15- (also has caption z16-, icon z15-)
+amenity-parking                                     # area z15- (also has icon z15-, caption(optional) z16-)
+amenity-parking-fee                                 # area z15- (also has icon z15-, caption(optional) z16-)
 amenity-parking-lane                                # area z15- (also has icon z17-)
-amenity-parking-multi-storey                        # area z15- (also has caption z16-, icon z15-)
-amenity-parking-no-access                           # area z15- (also has caption z16-, icon z15-)
-amenity-parking-park_and_ride                       # area z15- (also has caption z16-, icon z15-)
-amenity-parking-permissive                          # area z15- (also has caption z16-, icon z15-)
-amenity-parking-private                             # area z15- (also has caption z17-, icon z17-)
+amenity-parking-multi-storey                        # area z15- (also has icon z15-, caption(optional) z16-)
+amenity-parking-no-access                           # area z15- (also has icon z15-, caption(optional) z16-)
+amenity-parking-park_and_ride                       # area z15- (also has icon z15-, caption(optional) z16-)
+amenity-parking-permissive                          # area z15- (also has icon z15-, caption(optional) z16-)
+amenity-parking-private                             # area z15- (also has icon z17-, caption(optional) z17-)
 amenity-parking-street_side                         # area z15- (also has icon z17-)
-amenity-parking-underground                         # area z15- (also has caption z16-, icon z15-)
+amenity-parking-underground                         # area z15- (also has icon z15-, caption(optional) z16-)
 === 160
 
 leisure-stadium                                     # area z15-
 === 150
 
-leisure-nature_reserve                              # area z10- (also has caption z12-, icon z12-)
+leisure-nature_reserve                              # area z10- (also has icon z12-, caption(optional) z12-)
 === 140
 
 amenity-parking_space                               # area z15-
@@ -75,16 +76,16 @@ natural-scrub                                       # area z14-
 
 leisure-garden                                      # area z12-
 leisure-garden-residential                          # area z12-
-leisure-park                                        # area z10- (also has caption z14-, icon z14-)
-leisure-park-no-access                              # area z10- (also has caption z14-, icon z14-)
-leisure-park-permissive                             # area z10- (also has caption z14-, icon z14-)
-leisure-park-private                                # area z10- (also has caption z14-, icon z14-)
+leisure-park                                        # area z10- (also has icon z14-, caption(optional) z14-)
+leisure-park-no-access                              # area z10- (also has icon z14-, caption(optional) z14-)
+leisure-park-permissive                             # area z10- (also has icon z14-, caption(optional) z14-)
+leisure-park-private                                # area z10- (also has icon z14-, caption(optional) z14-)
 === 60
 
-landuse-forest                                      # area z10- (also has caption z12-, icon z12-)
-landuse-forest-coniferous                           # area z10- (also has caption z12-, icon z12-)
-landuse-forest-deciduous                            # area z10- (also has caption z12-, icon z12-)
-landuse-forest-mixed                                # area z10- (also has caption z12-, icon z12-)
+landuse-forest                                      # area z10- (also has icon z12-, caption(optional) z12-)
+landuse-forest-coniferous                           # area z10- (also has icon z12-, caption(optional) z12-)
+landuse-forest-deciduous                            # area z10- (also has icon z12-, caption(optional) z12-)
+landuse-forest-mixed                                # area z10- (also has icon z12-, caption(optional) z12-)
 === 50
 
 landuse-churchyard                                  # area z15-
@@ -95,8 +96,8 @@ landuse-quarry                                      # area z15- (also has captio
 landuse-railway                                     # area z15- (also has caption z15-)
 === 40
 
-aeroway-aerodrome                                   # area z10- (also has caption z14-, icon z14-)
-aeroway-aerodrome-international                     # area z10- (also has caption z10-, icon z7-)
+aeroway-aerodrome                                   # area z10- (also has icon z14-, caption(optional) z14-)
+aeroway-aerodrome-international                     # area z10- (also has icon z7-, caption(optional) z10-)
 leisure-beach_resort                                # area z10- (also has caption z15-)
 natural-beach                                       # area z10- (also has caption z15-)
 natural-beach-gravel                                # area z10- (also has caption z15-)

--- a/data/styles/vehicle/include/priorities_2_BG-top.prio.txt
+++ b/data/styles/vehicle/include/priorities_2_BG-top.prio.txt
@@ -1,5 +1,6 @@
 # This file is automatically re-formatted and re-sorted in priorities descending order
-# when generate_drules.sh is run. Custom formatting and comments are not preserved.
+# when generate_drules.sh is run. All comments (automatic priorities of e.g. optional captions, drule types visibilities, etc.)
+# are generated automatically for information only. Custom formatting and comments are not preserved.
 #
 # BG-top geometry: background lines and areas that should be always below foreground ones
 # (including e.g. layer=-10 underwater tunnels), but above background areas sorted by size (BG-by-size),
@@ -26,7 +27,7 @@ natural-water-pond                                  # area z1- (also has caption
 natural-water-reservoir                             # area z1- (also has caption z10-)
 natural-water-river                                 # area z1- (also has caption z10-)
 waterway-dock                                       # area z1-
-waterway-riverbank                                  # area z1- and line z10- (also has pathtext z11-)
+waterway-riverbank                                  # line z10- and area z1- (also has pathtext z11-)
 === 20
 
 waterway-ditch                                      # line z17-

--- a/data/styles/vehicle/include/priorities_3_FG.prio.txt
+++ b/data/styles/vehicle/include/priorities_3_FG.prio.txt
@@ -1,5 +1,6 @@
 # This file is automatically re-formatted and re-sorted in priorities descending order
-# when generate_drules.sh is run. Custom formatting and comments are not preserved.
+# when generate_drules.sh is run. All comments (automatic priorities of e.g. optional captions, drule types visibilities, etc.)
+# are generated automatically for information only. Custom formatting and comments are not preserved.
 #
 # FG geometry: foreground lines and areas (e.g. buildings) are rendered always below overlays
 # and always on top of background geometry (BG-top & BG-by-size) even if a foreground feature
@@ -40,25 +41,41 @@ railway-tram-tunnel                                 # line z16- (also has line::
 === 260
 
 highway-motorway                                    # line z7- (also has line(casing) z14-, pathtext z10-, shield z10-)
-highway-motorway-bridge                             # line z7- (also has line(casing) z14-, line::bridgeblack z13-, line::bridgewhite z13-, pathtext z10-, shield z10-)
+highway-motorway-bridge                             # line z7- (also has line::bridgeblack z13-, line::bridgewhite z13-, line(casing) z14-, pathtext z10-, shield z10-)
 highway-motorway-tunnel                             # line z7- (also has line(casing) z12-, pathtext z10-, shield z10-)
 highway-trunk                                       # line z7- (also has line(casing) z14-, pathtext z10-, shield z10-)
-highway-trunk-bridge                                # line z7- (also has line(casing) z14-, line::bridgeblack z13-, line::bridgewhite z13-, pathtext z10-, shield z10-)
+highway-trunk-bridge                                # line z7- (also has line::bridgeblack z13-, line::bridgewhite z13-, line(casing) z14-, pathtext z10-, shield z10-)
 highway-trunk-tunnel                                # line z7- (also has line(casing) z12-, pathtext z10-, shield z10-)
 highway-world_level                                 # line z4-9
 highway-world_towns_level                           # line z6-9
 === 250
 
+# highway-motorway                                  # line(casing) z14- (also has line z7-, pathtext z10-, shield z10-)
+# highway-motorway-bridge                           # line(casing) z14- (also has line z7-, line::bridgeblack z13-, line::bridgewhite z13-, pathtext z10-, shield z10-)
+# highway-motorway-tunnel                           # line(casing) z12- (also has line z7-, pathtext z10-, shield z10-)
+# highway-trunk                                     # line(casing) z14- (also has line z7-, pathtext z10-, shield z10-)
+# highway-trunk-bridge                              # line(casing) z14- (also has line z7-, line::bridgeblack z13-, line::bridgewhite z13-, pathtext z10-, shield z10-)
+# highway-trunk-tunnel                              # line(casing) z12- (also has line z7-, pathtext z10-, shield z10-)
+# === 249
+
 highway-motorway_link                               # line z10- (also has line(casing) z14-, pathtext z10-, shield z10-)
-highway-motorway_link-bridge                        # line z10- (also has line(casing) z14-, line::bridgeblack z14-, line::bridgewhite z14-, pathtext z10-, shield z10-)
+highway-motorway_link-bridge                        # line z10- (also has line::bridgeblack z14-, line::bridgewhite z14-, line(casing) z14-, pathtext z10-, shield z10-)
 highway-motorway_link-tunnel                        # line z10- (also has line(casing) z12-, pathtext z10-, shield z10-)
 highway-trunk_link                                  # line z10- (also has line(casing) z14-, pathtext z10-, shield z10-)
-highway-trunk_link-bridge                           # line z10- (also has line(casing) z14-, line::bridgeblack z14-, line::bridgewhite z14-, pathtext z10-, shield z10-)
+highway-trunk_link-bridge                           # line z10- (also has line::bridgeblack z14-, line::bridgewhite z14-, line(casing) z14-, pathtext z10-, shield z10-)
 highway-trunk_link-tunnel                           # line z10- (also has line(casing) z12-, pathtext z10-, shield z10-)
 === 240
 
+# highway-motorway_link                             # line(casing) z14- (also has line z10-, pathtext z10-, shield z10-)
+# highway-motorway_link-bridge                      # line(casing) z14- (also has line z10-, line::bridgeblack z14-, line::bridgewhite z14-, pathtext z10-, shield z10-)
+# highway-motorway_link-tunnel                      # line(casing) z12- (also has line z10-, pathtext z10-, shield z10-)
+# highway-trunk_link                                # line(casing) z14- (also has line z10-, pathtext z10-, shield z10-)
+# highway-trunk_link-bridge                         # line(casing) z14- (also has line z10-, line::bridgeblack z14-, line::bridgewhite z14-, pathtext z10-, shield z10-)
+# highway-trunk_link-tunnel                         # line(casing) z12- (also has line z10-, pathtext z10-, shield z10-)
+# === 239
+
 highway-primary                                     # line z8- (also has line(casing) z14-, pathtext z10-, shield z10-)
-highway-primary-bridge                              # line z8- (also has line(casing) z14-, line::bridgeblack z14-, line::bridgewhite z14-, pathtext z10-, shield z10-)
+highway-primary-bridge                              # line z8- (also has line::bridgeblack z14-, line::bridgewhite z14-, line(casing) z14-, pathtext z10-, shield z10-)
 highway-primary-tunnel                              # line z8- (also has line(casing) z14-, pathtext z10-, shield z10-)
 railway-rail-branch::dash                           # line::dash z16- (also has line z11-)
 railway-rail-branch-bridge::dash                    # line::dash z16- (also has line z11-, line::bridgeblack z16-, line::bridgewhite z14-)
@@ -74,46 +91,84 @@ railway-rail-tourism-bridge::dash                   # line::dash z16- (also has 
 railway-rail-tourism-tunnel::dash                   # line::dash z16- (also has line z10-, line(casing) z14-, pathtext z16-)
 === 230
 
+# highway-primary                                   # line(casing) z14- (also has line z8-, pathtext z10-, shield z10-)
+# highway-primary-bridge                            # line(casing) z14- (also has line z8-, line::bridgeblack z14-, line::bridgewhite z14-, pathtext z10-, shield z10-)
+# highway-primary-tunnel                            # line(casing) z14- (also has line z8-, pathtext z10-, shield z10-)
+# === 229
+
 highway-primary_link                                # line z11- (also has line(casing) z14-, pathtext z10-, shield z11-)
-highway-primary_link-bridge                         # line z11- (also has line(casing) z14-, line::bridgeblack z14-, line::bridgewhite z14-, pathtext z10-, shield z11-)
+highway-primary_link-bridge                         # line z11- (also has line::bridgeblack z14-, line::bridgewhite z14-, line(casing) z14-, pathtext z10-, shield z11-)
 highway-primary_link-tunnel                         # line z11- (also has line(casing) z14-, pathtext z10-, shield z11-)
 railway-rail-branch                                 # line z11- (also has line::dash z16-)
 railway-rail-branch-bridge                          # line z11- (also has line::bridgeblack z16-, line::bridgewhite z14-, line::dash z16-)
-railway-rail-branch-tunnel                          # line z11- (also has line(casing) z14-, line::dash z16-)
+railway-rail-branch-tunnel                          # line z11- (also has line::dash z16-, line(casing) z14-)
 railway-rail-highspeed                              # line z10- (also has line::dash z16-)
 railway-rail-highspeed-bridge                       # line z10- (also has line::bridgeblack z16-, line::bridgewhite z14-, line::dash z16-)
-railway-rail-highspeed-tunnel                       # line z10- (also has line(casing) z14-, line::dash z16-)
+railway-rail-highspeed-tunnel                       # line z10- (also has line::dash z16-, line(casing) z14-)
 railway-rail-main                                   # line z10- (also has line::dash z16-)
 railway-rail-main-bridge                            # line z10- (also has line::bridgeblack z16-, line::bridgewhite z14-, line::dash z16-)
-railway-rail-main-tunnel                            # line z10- (also has line(casing) z14-, line::dash z16-)
+railway-rail-main-tunnel                            # line z10- (also has line::dash z16-, line(casing) z14-)
 railway-rail-tourism                                # line z10- (also has line::dash z16-, pathtext z16-)
 railway-rail-tourism-bridge                         # line z10- (also has line::bridgeblack z16-, line::bridgewhite z14-, line::dash z16-, pathtext z16-)
-railway-rail-tourism-tunnel                         # line z10- (also has line(casing) z14-, line::dash z16-, pathtext z16-)
+railway-rail-tourism-tunnel                         # line z10- (also has line::dash z16-, line(casing) z14-, pathtext z16-)
 === 220
 
+# highway-primary_link                              # line(casing) z14- (also has line z11-, pathtext z10-, shield z11-)
+# highway-primary_link-bridge                       # line(casing) z14- (also has line z11-, line::bridgeblack z14-, line::bridgewhite z14-, pathtext z10-, shield z11-)
+# highway-primary_link-tunnel                       # line(casing) z14- (also has line z11-, pathtext z10-, shield z11-)
+# railway-rail-branch-tunnel                        # line(casing) z14- (also has line z11-, line::dash z16-)
+# railway-rail-highspeed-tunnel                     # line(casing) z14- (also has line z10-, line::dash z16-)
+# railway-rail-main-tunnel                          # line(casing) z14- (also has line z10-, line::dash z16-)
+# railway-rail-tourism-tunnel                       # line(casing) z14- (also has line z10-, line::dash z16-, pathtext z16-)
+# === 219
+
 highway-secondary                                   # line z10- (also has line(casing) z14-, pathtext z10-, shield z12-)
-highway-secondary-bridge                            # line z10- (also has line(casing) z14-, line::bridgeblack z14-, line::bridgewhite z14-, pathtext z10-, shield z12-)
+highway-secondary-bridge                            # line z10- (also has line::bridgeblack z14-, line::bridgewhite z14-, line(casing) z14-, pathtext z10-, shield z12-)
 highway-secondary-tunnel                            # line z10- (also has line(casing) z14-, pathtext z10-, shield z12-)
 === 210
 
+# highway-secondary                                 # line(casing) z14- (also has line z10-, pathtext z10-, shield z12-)
+# highway-secondary-bridge                          # line(casing) z14- (also has line z10-, line::bridgeblack z14-, line::bridgewhite z14-, pathtext z10-, shield z12-)
+# highway-secondary-tunnel                          # line(casing) z14- (also has line z10-, pathtext z10-, shield z12-)
+# === 209
+
 highway-secondary_link                              # line z14- (also has line(casing) z14-, pathtext z16-)
-highway-secondary_link-bridge                       # line z14- (also has line(casing) z14-, line::bridgeblack z14-, line::bridgewhite z14-, pathtext z16-)
+highway-secondary_link-bridge                       # line z14- (also has line::bridgeblack z14-, line::bridgewhite z14-, line(casing) z14-, pathtext z16-)
 highway-secondary_link-tunnel                       # line z14- (also has line(casing) z14-, pathtext z16-)
 === 200
 
+# highway-secondary_link                            # line(casing) z14- (also has line z14-, pathtext z16-)
+# highway-secondary_link-bridge                     # line(casing) z14- (also has line z14-, line::bridgeblack z14-, line::bridgewhite z14-, pathtext z16-)
+# highway-secondary_link-tunnel                     # line(casing) z14- (also has line z14-, pathtext z16-)
+# === 199
+
 highway-residential                                 # line z12- (also has line(casing) z15-, pathtext z12-, shield z18-)
 highway-residential-area                            # line z12- (also has line(casing) z15-, pathtext z12-, shield z18-)
-highway-residential-bridge                          # line z12- (also has line(casing) z15-, line::bridgeblack z14-, line::bridgewhite z14-, pathtext z12-, shield z18-)
+highway-residential-bridge                          # line z12- (also has line::bridgeblack z14-, line::bridgewhite z14-, line(casing) z15-, pathtext z12-, shield z18-)
 highway-residential-tunnel                          # line z12- (also has line(casing) z15-, pathtext z12-, shield z18-)
 highway-tertiary                                    # line z11- (also has line(casing) z15-, pathtext z12-, shield z15-)
-highway-tertiary-bridge                             # line z11- (also has line(casing) z15-, line::bridgeblack z14-, line::bridgewhite z14-, pathtext z12-, shield z15-)
+highway-tertiary-bridge                             # line z11- (also has line::bridgeblack z14-, line::bridgewhite z14-, line(casing) z15-, pathtext z12-, shield z15-)
 highway-tertiary-tunnel                             # line z11- (also has line(casing) z15-, pathtext z12-, shield z15-)
 === 190
 
+# highway-residential                               # line(casing) z15- (also has line z12-, pathtext z12-, shield z18-)
+# highway-residential-area                          # line(casing) z15- (also has line z12-, pathtext z12-, shield z18-)
+# highway-residential-bridge                        # line(casing) z15- (also has line z12-, line::bridgeblack z14-, line::bridgewhite z14-, pathtext z12-, shield z18-)
+# highway-residential-tunnel                        # line(casing) z15- (also has line z12-, pathtext z12-, shield z18-)
+# highway-tertiary                                  # line(casing) z15- (also has line z11-, pathtext z12-, shield z15-)
+# highway-tertiary-bridge                           # line(casing) z15- (also has line z11-, line::bridgeblack z14-, line::bridgewhite z14-, pathtext z12-, shield z15-)
+# highway-tertiary-tunnel                           # line(casing) z15- (also has line z11-, pathtext z12-, shield z15-)
+# === 189
+
 highway-tertiary_link                               # line z15- (also has line(casing) z15-, pathtext z18-)
-highway-tertiary_link-bridge                        # line z15- (also has line(casing) z15-, line::bridgeblack z15-, line::bridgewhite z15-, pathtext z18-)
+highway-tertiary_link-bridge                        # line z15- (also has line::bridgeblack z15-, line::bridgewhite z15-, line(casing) z15-, pathtext z18-)
 highway-tertiary_link-tunnel                        # line z15- (also has line(casing) z15-, pathtext z18-)
 === 180
+
+# highway-tertiary_link                             # line(casing) z15- (also has line z15-, pathtext z18-)
+# highway-tertiary_link-bridge                      # line(casing) z15- (also has line z15-, line::bridgeblack z15-, line::bridgewhite z15-, pathtext z18-)
+# highway-tertiary_link-tunnel                      # line(casing) z15- (also has line z15-, pathtext z18-)
+# === 179
 
 highway-living_street                               # line z12- (also has pathtext z14-)
 highway-living_street-bridge                        # line z12- (also has pathtext z14-)
@@ -127,16 +182,20 @@ highway-unclassified-bridge                         # line z11- (also has line::
 highway-unclassified-tunnel                         # line z11- (also has line(casing) z16-, pathtext z14-)
 === 170
 
+# highway-living_street-tunnel                      # line(casing) z16- (also has line z12-, pathtext z14-)
+# highway-unclassified-tunnel                       # line(casing) z16- (also has line z11-, pathtext z14-)
+# === 169
+
 railway-light_rail::dash                            # line::dash z16- (also has line z13-)
 railway-light_rail-bridge::dash                     # line::dash z16- (also has line z13-, line::bridgeblack z16-, line::bridgewhite z14-)
 railway-rail::dash                                  # line::dash z16- (also has line z11-)
 railway-rail-bridge::dash                           # line::dash z16- (also has line z11-, line::bridgeblack z16-, line::bridgewhite z14-)
 railway-rail-service::dash                          # line::dash z17- (also has line z16-)
 railway-rail-service-bridge::dash                   # line::dash z17- (also has line z16-, line::bridgeblack z16-, line::bridgewhite z16-)
-railway-rail-service-tunnel::dash                   # line::dash z17- (also has line z16-, line(casing) z16-)
+railway-rail-service-tunnel::dash                   # line::dash z17- (also has line(casing) z16-, line z16-)
 railway-rail-spur::dash                             # line::dash z17- (also has line z15-)
 railway-rail-spur-bridge::dash                      # line::dash z17- (also has line z15-, line::bridgeblack z16-, line::bridgewhite z15-)
-railway-rail-spur-tunnel::dash                      # line::dash z17- (also has line z15-, line(casing) z15-)
+railway-rail-spur-tunnel::dash                      # line::dash z17- (also has line(casing) z15-, line z15-)
 railway-rail-tunnel::dash                           # line::dash z16- (also has line z11-, line(casing) z14-)
 railway-rail-utility::dash                          # line::dash z17- (also has line z13-)
 railway-rail-utility-bridge::dash                   # line::dash z17- (also has line z13-, line::bridgeblack z16-, line::bridgewhite z14-)
@@ -155,13 +214,19 @@ railway-rail-service-tunnel                         # line z16- (also has line(c
 railway-rail-spur                                   # line z15- (also has line::dash z17-)
 railway-rail-spur-bridge                            # line z15- (also has line::bridgeblack z16-, line::bridgewhite z15-, line::dash z17-)
 railway-rail-spur-tunnel                            # line z15- (also has line(casing) z15-, line::dash z17-)
-railway-rail-tunnel                                 # line z11- (also has line(casing) z14-, line::dash z16-)
+railway-rail-tunnel                                 # line z11- (also has line::dash z16-, line(casing) z14-)
 railway-rail-utility                                # line z13- (also has line::dash z17-)
 railway-rail-utility-bridge                         # line z13- (also has line::bridgeblack z16-, line::bridgewhite z14-, line::dash z17-)
-railway-rail-utility-tunnel                         # line z13- (also has line(casing) z14-, line::dash z17-)
+railway-rail-utility-tunnel                         # line z13- (also has line::dash z17-, line(casing) z14-)
 railway-subway                                      # line z13- (also has line::dash z16-)
 railway-subway-bridge                               # line z13- (also has line::bridgeblack z16-, line::bridgewhite z14-, line::dash z16-)
 === 150
+
+# railway-rail-service-tunnel                       # line(casing) z16- (also has line z16-, line::dash z17-)
+# railway-rail-spur-tunnel                          # line(casing) z15- (also has line z15-, line::dash z17-)
+# railway-rail-tunnel                               # line(casing) z14- (also has line z11-, line::dash z16-)
+# railway-rail-utility-tunnel                       # line(casing) z14- (also has line z13-, line::dash z17-)
+# === 149
 
 highway-service                                     # line z14- (also has pathtext z16-)
 highway-service-area                                # line z14- (also has pathtext z16-)
@@ -219,17 +284,17 @@ railway-preserved-bridge                            # line z16- (also has line::
 railway-preserved-tunnel                            # line z16-
 === 120
 
-highway-motorway-bridge::bridgewhite                # line::bridgewhite z13- (also has line z7-, line(casing) z14-, line::bridgeblack z13-, pathtext z10-, shield z10-)
-highway-motorway_link-bridge::bridgewhite           # line::bridgewhite z14- (also has line z10-, line(casing) z14-, line::bridgeblack z14-, pathtext z10-, shield z10-)
-highway-primary-bridge::bridgewhite                 # line::bridgewhite z14- (also has line z8-, line(casing) z14-, line::bridgeblack z14-, pathtext z10-, shield z10-)
-highway-primary_link-bridge::bridgewhite            # line::bridgewhite z14- (also has line z11-, line(casing) z14-, line::bridgeblack z14-, pathtext z10-, shield z11-)
-highway-residential-bridge::bridgewhite             # line::bridgewhite z14- (also has line z12-, line(casing) z15-, line::bridgeblack z14-, pathtext z12-, shield z18-)
-highway-secondary-bridge::bridgewhite               # line::bridgewhite z14- (also has line z10-, line(casing) z14-, line::bridgeblack z14-, pathtext z10-, shield z12-)
-highway-secondary_link-bridge::bridgewhite          # line::bridgewhite z14- (also has line z14-, line(casing) z14-, line::bridgeblack z14-, pathtext z16-)
-highway-tertiary-bridge::bridgewhite                # line::bridgewhite z14- (also has line z11-, line(casing) z15-, line::bridgeblack z14-, pathtext z12-, shield z15-)
-highway-tertiary_link-bridge::bridgewhite           # line::bridgewhite z15- (also has line z15-, line(casing) z15-, line::bridgeblack z15-, pathtext z18-)
-highway-trunk-bridge::bridgewhite                   # line::bridgewhite z13- (also has line z7-, line(casing) z14-, line::bridgeblack z13-, pathtext z10-, shield z10-)
-highway-trunk_link-bridge::bridgewhite              # line::bridgewhite z14- (also has line z10-, line(casing) z14-, line::bridgeblack z14-, pathtext z10-, shield z10-)
+highway-motorway-bridge::bridgewhite                # line::bridgewhite z13- (also has line z7-, line::bridgeblack z13-, line(casing) z14-, pathtext z10-, shield z10-)
+highway-motorway_link-bridge::bridgewhite           # line::bridgewhite z14- (also has line z10-, line::bridgeblack z14-, line(casing) z14-, pathtext z10-, shield z10-)
+highway-primary-bridge::bridgewhite                 # line::bridgewhite z14- (also has line z8-, line::bridgeblack z14-, line(casing) z14-, pathtext z10-, shield z10-)
+highway-primary_link-bridge::bridgewhite            # line::bridgewhite z14- (also has line z11-, line::bridgeblack z14-, line(casing) z14-, pathtext z10-, shield z11-)
+highway-residential-bridge::bridgewhite             # line::bridgewhite z14- (also has line z12-, line::bridgeblack z14-, line(casing) z15-, pathtext z12-, shield z18-)
+highway-secondary-bridge::bridgewhite               # line::bridgewhite z14- (also has line z10-, line::bridgeblack z14-, line(casing) z14-, pathtext z10-, shield z12-)
+highway-secondary_link-bridge::bridgewhite          # line::bridgewhite z14- (also has line z14-, line::bridgeblack z14-, line(casing) z14-, pathtext z16-)
+highway-tertiary-bridge::bridgewhite                # line::bridgewhite z14- (also has line z11-, line::bridgeblack z14-, line(casing) z15-, pathtext z12-, shield z15-)
+highway-tertiary_link-bridge::bridgewhite           # line::bridgewhite z15- (also has line z15-, line::bridgeblack z15-, line(casing) z15-, pathtext z18-)
+highway-trunk-bridge::bridgewhite                   # line::bridgewhite z13- (also has line z7-, line::bridgeblack z13-, line(casing) z14-, pathtext z10-, shield z10-)
+highway-trunk_link-bridge::bridgewhite              # line::bridgewhite z14- (also has line z10-, line::bridgeblack z14-, line(casing) z14-, pathtext z10-, shield z10-)
 highway-unclassified-bridge::bridgewhite            # line::bridgewhite z14- (also has line z11-, line::bridgeblack z14-, pathtext z14-)
 railway-abandoned-bridge::bridgewhite               # line::bridgewhite z16- (also has line z16-, line::bridgeblack z16-)
 railway-preserved-bridge::bridgewhite               # line::bridgewhite z16- (also has line z16-, line::bridgeblack z16-)
@@ -244,17 +309,17 @@ railway-rail-utility-bridge::bridgewhite            # line::bridgewhite z14- (al
 railway-subway-bridge::bridgewhite                  # line::bridgewhite z14- (also has line z13-, line::bridgeblack z16-, line::dash z16-)
 === 110
 
-highway-motorway-bridge::bridgeblack                # line::bridgeblack z13- (also has line z7-, line(casing) z14-, line::bridgewhite z13-, pathtext z10-, shield z10-)
-highway-motorway_link-bridge::bridgeblack           # line::bridgeblack z14- (also has line z10-, line(casing) z14-, line::bridgewhite z14-, pathtext z10-, shield z10-)
-highway-primary-bridge::bridgeblack                 # line::bridgeblack z14- (also has line z8-, line(casing) z14-, line::bridgewhite z14-, pathtext z10-, shield z10-)
-highway-primary_link-bridge::bridgeblack            # line::bridgeblack z14- (also has line z11-, line(casing) z14-, line::bridgewhite z14-, pathtext z10-, shield z11-)
-highway-residential-bridge::bridgeblack             # line::bridgeblack z14- (also has line z12-, line(casing) z15-, line::bridgewhite z14-, pathtext z12-, shield z18-)
-highway-secondary-bridge::bridgeblack               # line::bridgeblack z14- (also has line z10-, line(casing) z14-, line::bridgewhite z14-, pathtext z10-, shield z12-)
-highway-secondary_link-bridge::bridgeblack          # line::bridgeblack z14- (also has line z14-, line(casing) z14-, line::bridgewhite z14-, pathtext z16-)
-highway-tertiary-bridge::bridgeblack                # line::bridgeblack z14- (also has line z11-, line(casing) z15-, line::bridgewhite z14-, pathtext z12-, shield z15-)
-highway-tertiary_link-bridge::bridgeblack           # line::bridgeblack z15- (also has line z15-, line(casing) z15-, line::bridgewhite z15-, pathtext z18-)
-highway-trunk-bridge::bridgeblack                   # line::bridgeblack z13- (also has line z7-, line(casing) z14-, line::bridgewhite z13-, pathtext z10-, shield z10-)
-highway-trunk_link-bridge::bridgeblack              # line::bridgeblack z14- (also has line z10-, line(casing) z14-, line::bridgewhite z14-, pathtext z10-, shield z10-)
+highway-motorway-bridge::bridgeblack                # line::bridgeblack z13- (also has line z7-, line::bridgewhite z13-, line(casing) z14-, pathtext z10-, shield z10-)
+highway-motorway_link-bridge::bridgeblack           # line::bridgeblack z14- (also has line z10-, line::bridgewhite z14-, line(casing) z14-, pathtext z10-, shield z10-)
+highway-primary-bridge::bridgeblack                 # line::bridgeblack z14- (also has line z8-, line::bridgewhite z14-, line(casing) z14-, pathtext z10-, shield z10-)
+highway-primary_link-bridge::bridgeblack            # line::bridgeblack z14- (also has line z11-, line::bridgewhite z14-, line(casing) z14-, pathtext z10-, shield z11-)
+highway-residential-bridge::bridgeblack             # line::bridgeblack z14- (also has line z12-, line::bridgewhite z14-, line(casing) z15-, pathtext z12-, shield z18-)
+highway-secondary-bridge::bridgeblack               # line::bridgeblack z14- (also has line z10-, line::bridgewhite z14-, line(casing) z14-, pathtext z10-, shield z12-)
+highway-secondary_link-bridge::bridgeblack          # line::bridgeblack z14- (also has line z14-, line::bridgewhite z14-, line(casing) z14-, pathtext z16-)
+highway-tertiary-bridge::bridgeblack                # line::bridgeblack z14- (also has line z11-, line::bridgewhite z14-, line(casing) z15-, pathtext z12-, shield z15-)
+highway-tertiary_link-bridge::bridgeblack           # line::bridgeblack z15- (also has line z15-, line::bridgewhite z15-, line(casing) z15-, pathtext z18-)
+highway-trunk-bridge::bridgeblack                   # line::bridgeblack z13- (also has line z7-, line::bridgewhite z13-, line(casing) z14-, pathtext z10-, shield z10-)
+highway-trunk_link-bridge::bridgeblack              # line::bridgeblack z14- (also has line z10-, line::bridgewhite z14-, line(casing) z14-, pathtext z10-, shield z10-)
 highway-unclassified-bridge::bridgeblack            # line::bridgeblack z14- (also has line z11-, line::bridgewhite z14-, pathtext z14-)
 railway-abandoned-bridge::bridgeblack               # line::bridgeblack z16- (also has line z16-, line::bridgewhite z16-)
 railway-preserved-bridge::bridgeblack               # line::bridgeblack z16- (also has line z16-, line::bridgewhite z16-)
@@ -300,9 +365,9 @@ railway-light_rail-bridge::bridgewhite              # line::bridgewhite z14- (al
 railway-light_rail-bridge::bridgeblack              # line::bridgeblack z16- (also has line z13-, line::bridgewhite z14-, line::dash z16-)
 === 30
 
-man_made-breakwater                                 # area z13- and line z15-
-man_made-pier                                       # area z13- and line z15-
-waterway-dam                                        # area z15- and line z15-
+man_made-breakwater                                 # line z15- and area z13-
+man_made-pier                                       # line z15- and area z13-
+waterway-dam                                        # line z15- and area z15-
 === 20
 
 man_made-bridge                                     # area z16-

--- a/data/styles/vehicle/include/priorities_4_overlays.prio.txt
+++ b/data/styles/vehicle/include/priorities_4_overlays.prio.txt
@@ -1,9 +1,10 @@
 # This file is automatically re-formatted and re-sorted in priorities descending order
-# when generate_drules.sh is run. Custom formatting and comments are not preserved.
+# when generate_drules.sh is run. All comments (automatic priorities of e.g. optional captions, drule types visibilities, etc.)
+# are generated automatically for information only. Custom formatting and comments are not preserved.
 #
 # Overlays (icons, captions, path texts and shields) are rendered on top of all the geometry (lines, areas).
 # Overlays don't overlap each other, instead the ones with higher priority displace the less important ones.
-# Optional captions (which have an icon) are displayed only if there are no other overlays in their way
+# Optional captions (which have an icon) are usually displayed only if there are no other overlays in their way
 # (technically, max overlays priority value (10000) is subtracted from their priorities automatically).
 #
 # Priorities ranges' rendering order overview:
@@ -16,48 +17,48 @@ highway-speed_camera                                # icon z13-
 === 4400
 
 highway-motorway                                    # pathtext z10- and shield z10- (also has line z7-, line(casing) z14-)
-highway-motorway-bridge                             # pathtext z10- and shield z10- (also has line z7-, line(casing) z14-, line::bridgeblack z13-, line::bridgewhite z13-)
+highway-motorway-bridge                             # pathtext z10- and shield z10- (also has line z7-, line::bridgeblack z13-, line::bridgewhite z13-, line(casing) z14-)
 highway-motorway-tunnel                             # pathtext z10- and shield z10- (also has line z7-, line(casing) z12-)
 highway-trunk                                       # pathtext z10- and shield z10- (also has line z7-, line(casing) z14-)
-highway-trunk-bridge                                # pathtext z10- and shield z10- (also has line z7-, line(casing) z14-, line::bridgeblack z13-, line::bridgewhite z13-)
+highway-trunk-bridge                                # pathtext z10- and shield z10- (also has line z7-, line::bridgeblack z13-, line::bridgewhite z13-, line(casing) z14-)
 highway-trunk-tunnel                                # pathtext z10- and shield z10- (also has line z7-, line(casing) z12-)
 === 4350
 
 highway-primary                                     # pathtext z10- and shield z10- (also has line z8-, line(casing) z14-)
-highway-primary-bridge                              # pathtext z10- and shield z10- (also has line z8-, line(casing) z14-, line::bridgeblack z14-, line::bridgewhite z14-)
+highway-primary-bridge                              # pathtext z10- and shield z10- (also has line z8-, line::bridgeblack z14-, line::bridgewhite z14-, line(casing) z14-)
 highway-primary-tunnel                              # pathtext z10- and shield z10- (also has line z8-, line(casing) z14-)
 === 4300
 
 highway-motorway_link                               # pathtext z10- and shield z10- (also has line z10-, line(casing) z14-)
-highway-motorway_link-bridge                        # pathtext z10- and shield z10- (also has line z10-, line(casing) z14-, line::bridgeblack z14-, line::bridgewhite z14-)
+highway-motorway_link-bridge                        # pathtext z10- and shield z10- (also has line z10-, line::bridgeblack z14-, line::bridgewhite z14-, line(casing) z14-)
 highway-motorway_link-tunnel                        # pathtext z10- and shield z10- (also has line z10-, line(casing) z12-)
 highway-trunk_link                                  # pathtext z10- and shield z10- (also has line z10-, line(casing) z14-)
-highway-trunk_link-bridge                           # pathtext z10- and shield z10- (also has line z10-, line(casing) z14-, line::bridgeblack z14-, line::bridgewhite z14-)
+highway-trunk_link-bridge                           # pathtext z10- and shield z10- (also has line z10-, line::bridgeblack z14-, line::bridgewhite z14-, line(casing) z14-)
 highway-trunk_link-tunnel                           # pathtext z10- and shield z10- (also has line z10-, line(casing) z12-)
 === 4250
 
 highway-motorway_junction                           # caption z15-
 highway-primary_link                                # pathtext z10- and shield z11- (also has line z11-, line(casing) z14-)
-highway-primary_link-bridge                         # pathtext z10- and shield z11- (also has line z11-, line(casing) z14-, line::bridgeblack z14-, line::bridgewhite z14-)
+highway-primary_link-bridge                         # pathtext z10- and shield z11- (also has line z11-, line::bridgeblack z14-, line::bridgewhite z14-, line(casing) z14-)
 highway-primary_link-tunnel                         # pathtext z10- and shield z11- (also has line z11-, line(casing) z14-)
-highway-services                                    # caption z13- and icon z12-
+highway-services                                    # icon z12- (also has caption(optional) z13-)
 === 4200
 
 highway-ford                                        # icon z14-
-highway-rest_area                                   # caption z14- and icon z14-
+highway-rest_area                                   # icon z14- (also has caption(optional) z14-)
 highway-secondary                                   # pathtext z10- and shield z12- (also has line z10-, line(casing) z14-)
-highway-secondary-bridge                            # pathtext z10- and shield z12- (also has line z10-, line(casing) z14-, line::bridgeblack z14-, line::bridgewhite z14-)
+highway-secondary-bridge                            # pathtext z10- and shield z12- (also has line z10-, line::bridgeblack z14-, line::bridgewhite z14-, line(casing) z14-)
 highway-secondary-tunnel                            # pathtext z10- and shield z12- (also has line z10-, line(casing) z14-)
 === 4150
 
 highway-tertiary                                    # pathtext z12- and shield z15- (also has line z11-, line(casing) z15-)
-highway-tertiary-bridge                             # pathtext z12- and shield z15- (also has line z11-, line(casing) z15-, line::bridgeblack z14-, line::bridgewhite z14-)
+highway-tertiary-bridge                             # pathtext z12- and shield z15- (also has line z11-, line::bridgeblack z14-, line::bridgewhite z14-, line(casing) z15-)
 highway-tertiary-tunnel                             # pathtext z12- and shield z15- (also has line z11-, line(casing) z15-)
 === 4100
 
-highway-secondary_link                              # pathtext z16- (also has line z14-, line(casing) z14-)
-highway-secondary_link-bridge                       # pathtext z16- (also has line z14-, line(casing) z14-, line::bridgeblack z14-, line::bridgewhite z14-)
-highway-secondary_link-tunnel                       # pathtext z16- (also has line z14-, line(casing) z14-)
+highway-secondary_link                              # pathtext z16- (also has line(casing) z14-, line z14-)
+highway-secondary_link-bridge                       # pathtext z16- (also has line z14-, line::bridgeblack z14-, line::bridgewhite z14-, line(casing) z14-)
+highway-secondary_link-tunnel                       # pathtext z16- (also has line(casing) z14-, line z14-)
 === 4050
 
 highway-unclassified                                # pathtext z14- (also has line z11-)
@@ -68,7 +69,7 @@ highway-unclassified-tunnel                         # pathtext z14- (also has li
 
 highway-residential                                 # pathtext z12- and shield z18- (also has line z12-, line(casing) z15-)
 highway-residential-area                            # pathtext z12- and shield z18- (also has line z12-, line(casing) z15-)
-highway-residential-bridge                          # pathtext z12- and shield z18- (also has line z12-, line(casing) z15-, line::bridgeblack z14-, line::bridgewhite z14-)
+highway-residential-bridge                          # pathtext z12- and shield z18- (also has line z12-, line::bridgeblack z14-, line::bridgewhite z14-, line(casing) z15-)
 highway-residential-tunnel                          # pathtext z12- and shield z18- (also has line z12-, line(casing) z15-)
 === 3950
 
@@ -77,9 +78,9 @@ highway-road-bridge                                 # pathtext z14- (also has li
 highway-road-tunnel                                 # pathtext z14- (also has line z12-)
 === 3900
 
-highway-tertiary_link                               # pathtext z18- (also has line z15-, line(casing) z15-)
-highway-tertiary_link-bridge                        # pathtext z18- (also has line z15-, line(casing) z15-, line::bridgeblack z15-, line::bridgewhite z15-)
-highway-tertiary_link-tunnel                        # pathtext z18- (also has line z15-, line(casing) z15-)
+highway-tertiary_link                               # pathtext z18- (also has line(casing) z15-, line z15-)
+highway-tertiary_link-bridge                        # pathtext z18- (also has line z15-, line::bridgeblack z15-, line::bridgewhite z15-, line(casing) z15-)
+highway-tertiary_link-tunnel                        # pathtext z18- (also has line(casing) z15-, line z15-)
 === 3850
 
 place-continent                                     # caption z1-2
@@ -91,7 +92,8 @@ place-ocean                                         # caption z1-
 place-country                                       # caption z3-
 === 3700
 
-place-city-capital-2                                # caption z4- and icon z4-
+place-city-capital-2                                # icon z4- (also has caption(mandatory) z4-)
+# place-city-capital-2                              # caption(mandatory) z4- (also has icon z4-)
 === 3650
 
 place-city-capital-3                                # caption z4-
@@ -120,29 +122,29 @@ place-state-USA                                     # caption z5-10
 place-state                                         # caption z6-10
 === 3350
 
-aeroway-aerodrome-international                     # caption z10- and icon z7- (also has area z10-)
+aeroway-aerodrome-international                     # icon z7- (also has caption(optional) z10-, area z10-)
 === 3300
 
 place-town                                          # caption z8-
 === 3250
 
-amenity-charging_station-motorcar                   # caption z14- and icon z14-
-amenity-fuel                                        # caption z12- and icon z12-
+amenity-charging_station-motorcar                   # icon z14- (also has caption(optional) z14-)
+amenity-fuel                                        # icon z12- (also has caption(optional) z12-)
 === 3200
 
-amenity-charging_station                            # caption z16- and icon z16-
-amenity-vending_machine-fuel                        # caption z17- and icon z17-
+amenity-charging_station                            # icon z16- (also has caption(optional) z16-)
+amenity-vending_machine-fuel                        # icon z17- (also has caption(optional) z17-)
 === 3150
 
-railway-station-subway-moscow                       # caption z12- and icon z11-
-railway-station-subway-spb                          # caption z12- and icon z11-
+railway-station-subway-moscow                       # icon z11- (also has caption(optional) z12-)
+railway-station-subway-spb                          # icon z11- (also has caption(optional) z12-)
 === 3100
 
-aeroway-aerodrome                                   # caption z14- and icon z14- (also has area z10-)
+aeroway-aerodrome                                   # icon z14- (also has caption(optional) z14-, area z10-)
 place-village                                       # caption z11-
 === 3050
 
-railway-station                                     # caption z13- and icon z12-
+railway-station                                     # icon z12- (also has caption(optional) z13-)
 === 3000
 
 landuse-reservoir                                   # caption z10- (also has area z12-)
@@ -150,12 +152,12 @@ natural-water-lake                                  # caption z10- (also has are
 natural-water-reservoir                             # caption z10- (also has area z1-)
 === 2950
 
-railway-station-funicular                           # caption z13- and icon z12-
-railway-station-light_rail                          # caption z13- and icon z12-
-railway-station-monorail                            # caption z13- and icon z12-
+railway-station-funicular                           # icon z12- (also has caption(optional) z13-)
+railway-station-light_rail                          # icon z12- (also has caption(optional) z13-)
+railway-station-monorail                            # icon z12- (also has caption(optional) z13-)
 === 2900
 
-barrier-toll_booth                                  # caption z14- and icon z12-
+barrier-toll_booth                                  # icon z12- (also has caption(optional) z14-)
 === 2850
 
 junction                                            # caption z17-
@@ -163,29 +165,29 @@ junction-circular                                   # caption z17-
 junction-roundabout                                 # caption z17-
 === 2800
 
-barrier-lift_gate                                   # caption z16- and icon z16-
+barrier-lift_gate                                   # icon z16- (also has caption(optional) z16-)
 === 2750
 
 railway-level_crossing                              # icon z17-
 === 2700
 
-amenity-car_wash                                    # caption z17- and icon z17-
-amenity-vending_machine-parking_tickets             # caption z17- and icon z17-
+amenity-car_wash                                    # icon z17- (also has caption(optional) z17-)
+amenity-vending_machine-parking_tickets             # icon z17- (also has caption(optional) z17-)
 shop-car_parts                                      # icon z17-
 shop-car_repair                                     # icon z17-
-shop-car_repair-tyres                               # caption z15- and icon z15-
+shop-car_repair-tyres                               # icon z15- (also has caption(optional) z15-)
 === 2650
 
-amenity-sanitary_dump_station                       # caption z15- and icon z15-
+amenity-sanitary_dump_station                       # icon z15- (also has caption(optional) z15-)
 shop-caravan                                        # icon z17-
 === 2600
 
-amenity-parking                                     # caption z16- and icon z15- (also has area z15-)
-amenity-parking-fee                                 # caption z16- and icon z15- (also has area z15-)
-amenity-parking-multi-storey                        # caption z16- and icon z15- (also has area z15-)
-amenity-parking-park_and_ride                       # caption z16- and icon z15- (also has area z15-)
-amenity-parking-permissive                          # caption z16- and icon z15- (also has area z15-)
-amenity-parking-underground                         # caption z16- and icon z15- (also has area z15-)
+amenity-parking                                     # icon z15- (also has caption(optional) z16-, area z15-)
+amenity-parking-fee                                 # icon z15- (also has caption(optional) z16-, area z15-)
+amenity-parking-multi-storey                        # icon z15- (also has caption(optional) z16-, area z15-)
+amenity-parking-park_and_ride                       # icon z15- (also has caption(optional) z16-, area z15-)
+amenity-parking-permissive                          # icon z15- (also has caption(optional) z16-, area z15-)
+amenity-parking-underground                         # icon z15- (also has caption(optional) z16-, area z15-)
 === 2550
 
 amenity-motorcycle_parking                          # icon z17-
@@ -197,33 +199,33 @@ amenity-parking-lane                                # icon z17- (also has area z
 amenity-parking-street_side                         # icon z17- (also has area z15-)
 === 2520
 
-boundary-national_park                              # caption z12- and icon z12-
-boundary-protected_area                             # caption z12- and icon z12-
-boundary-protected_area-1                           # caption z12- and icon z12-
-boundary-protected_area-2                           # caption z12- and icon z12-
-boundary-protected_area-3                           # caption z12- and icon z12-
-boundary-protected_area-4                           # caption z12- and icon z12-
-boundary-protected_area-5                           # caption z12- and icon z12-
-boundary-protected_area-6                           # caption z12- and icon z12-
-leisure-nature_reserve                              # caption z12- and icon z12- (also has area z10-)
+boundary-national_park                              # icon z12- (also has caption(optional) z12-)
+boundary-protected_area                             # icon z12- (also has caption(optional) z12-)
+boundary-protected_area-1                           # icon z12- (also has caption(optional) z12-)
+boundary-protected_area-2                           # icon z12- (also has caption(optional) z12-)
+boundary-protected_area-3                           # icon z12- (also has caption(optional) z12-)
+boundary-protected_area-4                           # icon z12- (also has caption(optional) z12-)
+boundary-protected_area-5                           # icon z12- (also has caption(optional) z12-)
+boundary-protected_area-6                           # icon z12- (also has caption(optional) z12-)
+leisure-nature_reserve                              # icon z12- (also has caption(optional) z12-, area z10-)
 === 2500
 
-historic-castle                                     # caption z15- and icon z12-
-historic-castle-castrum                             # caption z15- and icon z12-
-historic-castle-defensive                           # caption z15- and icon z12-
-historic-castle-fortified_church                    # caption z15- and icon z12-
-historic-castle-fortress                            # caption z15- and icon z12-
-historic-castle-hillfort                            # caption z15- and icon z12-
-historic-castle-kremlin                             # caption z15- and icon z12-
-historic-castle-manor                               # caption z15- and icon z12-
-historic-castle-palace                              # caption z15- and icon z12-
-historic-castle-shiro                               # caption z15- and icon z12-
-historic-castle-stately                             # caption z15- and icon z12-
-historic-fort                                       # caption z15- and icon z12-
+historic-castle                                     # icon z12- (also has caption(optional) z15-)
+historic-castle-castrum                             # icon z12- (also has caption(optional) z15-)
+historic-castle-defensive                           # icon z12- (also has caption(optional) z15-)
+historic-castle-fortified_church                    # icon z12- (also has caption(optional) z15-)
+historic-castle-fortress                            # icon z12- (also has caption(optional) z15-)
+historic-castle-hillfort                            # icon z12- (also has caption(optional) z15-)
+historic-castle-kremlin                             # icon z12- (also has caption(optional) z15-)
+historic-castle-manor                               # icon z12- (also has caption(optional) z15-)
+historic-castle-palace                              # icon z12- (also has caption(optional) z15-)
+historic-castle-shiro                               # icon z12- (also has caption(optional) z15-)
+historic-castle-stately                             # icon z12- (also has caption(optional) z15-)
+historic-fort                                       # icon z12- (also has caption(optional) z15-)
 === 2450
 
-amenity-car_rental                                  # caption z18- and icon z18-
-amenity-car_sharing                                 # caption z18- and icon z18-
+amenity-car_rental                                  # icon z18- (also has caption(optional) z18-)
+amenity-car_sharing                                 # icon z18- (also has caption(optional) z18-)
 shop-car                                            # icon z17-
 === 2400
 
@@ -238,14 +240,14 @@ highway-service-bridge                              # pathtext z16- (also has li
 highway-service-tunnel                              # pathtext z16- (also has line z14-)
 === 2300
 
-leisure-park                                        # caption z14- and icon z14- (also has area z10-)
-leisure-park-permissive                             # caption z14- and icon z14- (also has area z10-)
+leisure-park                                        # icon z14- (also has caption(optional) z14-, area z10-)
+leisure-park-permissive                             # icon z14- (also has caption(optional) z14-, area z10-)
 === 2250
 
-landuse-forest                                      # caption z12- and icon z12- (also has area z10-)
-landuse-forest-coniferous                           # caption z12- and icon z12- (also has area z10-)
-landuse-forest-deciduous                            # caption z12- and icon z12- (also has area z10-)
-landuse-forest-mixed                                # caption z12- and icon z12- (also has area z10-)
+landuse-forest                                      # icon z12- (also has caption(optional) z12-, area z10-)
+landuse-forest-coniferous                           # icon z12- (also has caption(optional) z12-, area z10-)
+landuse-forest-deciduous                            # icon z12- (also has caption(optional) z12-, area z10-)
+landuse-forest-mixed                                # icon z12- (also has caption(optional) z12-, area z10-)
 === 2200
 
 highway-service-busway                              # pathtext z16- (also has line z14-)
@@ -259,120 +261,120 @@ place-island                                        # caption z12-14
 natural-water-river                                 # caption z10- (also has area z1-)
 === 2050
 
-railway-station-subway                              # caption z13- and icon z13-
-railway-station-subway-adana                        # caption z13- and icon z12-
-railway-station-subway-algiers                      # caption z13- and icon z12-
-railway-station-subway-almaty                       # caption z13- and icon z12-
-railway-station-subway-amsterdam                    # caption z13- and icon z13-
-railway-station-subway-ankara                       # caption z13- and icon z13-
-railway-station-subway-athens                       # caption z13- and icon z13-
-railway-station-subway-baku                         # caption z13- and icon z13-
-railway-station-subway-bangkok                      # caption z13- and icon z13-
-railway-station-subway-barcelona                    # caption z13- and icon z13-
-railway-station-subway-beijing                      # caption z13- and icon z13-
-railway-station-subway-bengalore                    # caption z13- and icon z13-
-railway-station-subway-berlin                       # caption z13- and icon z13-
-railway-station-subway-bilbao                       # caption z13- and icon z13-
-railway-station-subway-brasilia                     # caption z13- and icon z13-
-railway-station-subway-brescia                      # caption z13- and icon z13-
-railway-station-subway-brussels                     # caption z13- and icon z13-
-railway-station-subway-bucharest                    # caption z13- and icon z13-
-railway-station-subway-budapest                     # caption z13- and icon z13-
-railway-station-subway-buenos_aires                 # caption z13- and icon z13-
-railway-station-subway-bursa                        # caption z13- and icon z13-
-railway-station-subway-cairo                        # caption z13- and icon z13-
-railway-station-subway-caracas                      # caption z13- and icon z13-
-railway-station-subway-catania                      # caption z13- and icon z13-
-railway-station-subway-changchun                    # caption z13- and icon z13-
-railway-station-subway-chengdu                      # caption z13- and icon z13-
-railway-station-subway-chicago                      # caption z13- and icon z13-
-railway-station-subway-chongqing                    # caption z13- and icon z13-
-railway-station-subway-dalian                       # caption z13- and icon z13-
-railway-station-subway-delhi                        # caption z13- and icon z13-
-railway-station-subway-dnepro                       # caption z13- and icon z13-
-railway-station-subway-dubai                        # caption z13- and icon z13-
-railway-station-subway-ekb                          # caption z13- and icon z13-
-railway-station-subway-fukuoka                      # caption z13- and icon z13-
-railway-station-subway-glasgow                      # caption z13- and icon z13-
-railway-station-subway-guangzhou                    # caption z13- and icon z13-
-railway-station-subway-hamburg                      # caption z13- and icon z13-
-railway-station-subway-helsinki                     # caption z13- and icon z13-
-railway-station-subway-hiroshima                    # caption z13- and icon z13-
-railway-station-subway-isfahan                      # caption z13- and icon z13-
-railway-station-subway-istanbul                     # caption z13- and icon z13-
-railway-station-subway-izmir                        # caption z13- and icon z13-
-railway-station-subway-kazan                        # caption z13- and icon z13-
-railway-station-subway-kharkiv                      # caption z13- and icon z13-
-railway-station-subway-kiev                         # caption z13- and icon z13-
-railway-station-subway-kobe                         # caption z13- and icon z13-
-railway-station-subway-kolkata                      # caption z13- and icon z13-
-railway-station-subway-kunming                      # caption z13- and icon z13-
-railway-station-subway-kyoto                        # caption z13- and icon z13-
-railway-station-subway-la                           # caption z13- and icon z13-
-railway-station-subway-lausanne                     # caption z13- and icon z13-
-railway-station-subway-lille                        # caption z13- and icon z13-
-railway-station-subway-lima                         # caption z13- and icon z13-
-railway-station-subway-lisboa                       # caption z13- and icon z13-
-railway-station-subway-london                       # caption z13- and icon z13-
-railway-station-subway-lyon                         # caption z13- and icon z13-
-railway-station-subway-madrid                       # caption z13- and icon z13-
-railway-station-subway-malaga                       # caption z13- and icon z13-
-railway-station-subway-manila                       # caption z13- and icon z13-
-railway-station-subway-maracaibo                    # caption z13- and icon z13-
-railway-station-subway-mashhad                      # caption z13- and icon z13-
-railway-station-subway-mecca                        # caption z13- and icon z13-
-railway-station-subway-medellin                     # caption z13- and icon z13-
-railway-station-subway-mexico                       # caption z13- and icon z13-
-railway-station-subway-milan                        # caption z13- and icon z13-
-railway-station-subway-minsk                        # caption z13- and icon z13-
-railway-station-subway-montreal                     # caption z13- and icon z13-
-railway-station-subway-munchen                      # caption z13- and icon z13-
-railway-station-subway-nagoya                       # caption z13- and icon z13-
-railway-station-subway-newyork                      # caption z13- and icon z13-
-railway-station-subway-nnov                         # caption z13- and icon z13-
-railway-station-subway-novosibirsk                  # caption z13- and icon z13-
-railway-station-subway-osaka                        # caption z13- and icon z13-
-railway-station-subway-oslo                         # caption z13- and icon z13-
-railway-station-subway-palma                        # caption z13- and icon z13-
-railway-station-subway-panama                       # caption z13- and icon z13-
-railway-station-subway-paris                        # caption z13- and icon z13-
-railway-station-subway-philadelphia                 # caption z13- and icon z13-
-railway-station-subway-pyongyang                    # caption z13- and icon z13-
-railway-station-subway-rennes                       # caption z13- and icon z13-
-railway-station-subway-rio                          # caption z13- and icon z13-
-railway-station-subway-roma                         # caption z13- and icon z13-
-railway-station-subway-rotterdam                    # caption z13- and icon z13-
-railway-station-subway-samara                       # caption z13- and icon z13-
-railway-station-subway-santiago                     # caption z13- and icon z13-
-railway-station-subway-santo_domingo                # caption z13- and icon z13-
-railway-station-subway-saopaulo                     # caption z13- and icon z13-
-railway-station-subway-sapporo                      # caption z13- and icon z13-
-railway-station-subway-sendai                       # caption z13- and icon z13-
-railway-station-subway-sf                           # caption z13- and icon z13-
-railway-station-subway-shanghai                     # caption z13- and icon z13-
-railway-station-subway-shiraz                       # caption z13- and icon z13-
-railway-station-subway-sofia                        # caption z13- and icon z13-
-railway-station-subway-stockholm                    # caption z13- and icon z13-
-railway-station-subway-tabriz                       # caption z13- and icon z13-
-railway-station-subway-taipei                       # caption z13- and icon z13-
-railway-station-subway-taoyuan                      # caption z13- and icon z13-
-railway-station-subway-tashkent                     # caption z13- and icon z13-
-railway-station-subway-tbilisi                      # caption z13- and icon z13-
-railway-station-subway-tehran                       # caption z13- and icon z13-
-railway-station-subway-tianjin                      # caption z13- and icon z13-
-railway-station-subway-tokyo                        # caption z13- and icon z13-
-railway-station-subway-valencia                     # caption z13- and icon z13-
-railway-station-subway-vienna                       # caption z13- and icon z13-
-railway-station-subway-warszawa                     # caption z13- and icon z13-
-railway-station-subway-washington                   # caption z13- and icon z13-
-railway-station-subway-wuhan                        # caption z13- and icon z13-
-railway-station-subway-yerevan                      # caption z13- and icon z13-
-railway-station-subway-yokohama                     # caption z13- and icon z13-
+railway-station-subway                              # icon z13- (also has caption(optional) z13-)
+railway-station-subway-adana                        # icon z12- (also has caption(optional) z13-)
+railway-station-subway-algiers                      # icon z12- (also has caption(optional) z13-)
+railway-station-subway-almaty                       # icon z12- (also has caption(optional) z13-)
+railway-station-subway-amsterdam                    # icon z13- (also has caption(optional) z13-)
+railway-station-subway-ankara                       # icon z13- (also has caption(optional) z13-)
+railway-station-subway-athens                       # icon z13- (also has caption(optional) z13-)
+railway-station-subway-baku                         # icon z13- (also has caption(optional) z13-)
+railway-station-subway-bangkok                      # icon z13- (also has caption(optional) z13-)
+railway-station-subway-barcelona                    # icon z13- (also has caption(optional) z13-)
+railway-station-subway-beijing                      # icon z13- (also has caption(optional) z13-)
+railway-station-subway-bengalore                    # icon z13- (also has caption(optional) z13-)
+railway-station-subway-berlin                       # icon z13- (also has caption(optional) z13-)
+railway-station-subway-bilbao                       # icon z13- (also has caption(optional) z13-)
+railway-station-subway-brasilia                     # icon z13- (also has caption(optional) z13-)
+railway-station-subway-brescia                      # icon z13- (also has caption(optional) z13-)
+railway-station-subway-brussels                     # icon z13- (also has caption(optional) z13-)
+railway-station-subway-bucharest                    # icon z13- (also has caption(optional) z13-)
+railway-station-subway-budapest                     # icon z13- (also has caption(optional) z13-)
+railway-station-subway-buenos_aires                 # icon z13- (also has caption(optional) z13-)
+railway-station-subway-bursa                        # icon z13- (also has caption(optional) z13-)
+railway-station-subway-cairo                        # icon z13- (also has caption(optional) z13-)
+railway-station-subway-caracas                      # icon z13- (also has caption(optional) z13-)
+railway-station-subway-catania                      # icon z13- (also has caption(optional) z13-)
+railway-station-subway-changchun                    # icon z13- (also has caption(optional) z13-)
+railway-station-subway-chengdu                      # icon z13- (also has caption(optional) z13-)
+railway-station-subway-chicago                      # icon z13- (also has caption(optional) z13-)
+railway-station-subway-chongqing                    # icon z13- (also has caption(optional) z13-)
+railway-station-subway-dalian                       # icon z13- (also has caption(optional) z13-)
+railway-station-subway-delhi                        # icon z13- (also has caption(optional) z13-)
+railway-station-subway-dnepro                       # icon z13- (also has caption(optional) z13-)
+railway-station-subway-dubai                        # icon z13- (also has caption(optional) z13-)
+railway-station-subway-ekb                          # icon z13- (also has caption(optional) z13-)
+railway-station-subway-fukuoka                      # icon z13- (also has caption(optional) z13-)
+railway-station-subway-glasgow                      # icon z13- (also has caption(optional) z13-)
+railway-station-subway-guangzhou                    # icon z13- (also has caption(optional) z13-)
+railway-station-subway-hamburg                      # icon z13- (also has caption(optional) z13-)
+railway-station-subway-helsinki                     # icon z13- (also has caption(optional) z13-)
+railway-station-subway-hiroshima                    # icon z13- (also has caption(optional) z13-)
+railway-station-subway-isfahan                      # icon z13- (also has caption(optional) z13-)
+railway-station-subway-istanbul                     # icon z13- (also has caption(optional) z13-)
+railway-station-subway-izmir                        # icon z13- (also has caption(optional) z13-)
+railway-station-subway-kazan                        # icon z13- (also has caption(optional) z13-)
+railway-station-subway-kharkiv                      # icon z13- (also has caption(optional) z13-)
+railway-station-subway-kiev                         # icon z13- (also has caption(optional) z13-)
+railway-station-subway-kobe                         # icon z13- (also has caption(optional) z13-)
+railway-station-subway-kolkata                      # icon z13- (also has caption(optional) z13-)
+railway-station-subway-kunming                      # icon z13- (also has caption(optional) z13-)
+railway-station-subway-kyoto                        # icon z13- (also has caption(optional) z13-)
+railway-station-subway-la                           # icon z13- (also has caption(optional) z13-)
+railway-station-subway-lausanne                     # icon z13- (also has caption(optional) z13-)
+railway-station-subway-lille                        # icon z13- (also has caption(optional) z13-)
+railway-station-subway-lima                         # icon z13- (also has caption(optional) z13-)
+railway-station-subway-lisboa                       # icon z13- (also has caption(optional) z13-)
+railway-station-subway-london                       # icon z13- (also has caption(optional) z13-)
+railway-station-subway-lyon                         # icon z13- (also has caption(optional) z13-)
+railway-station-subway-madrid                       # icon z13- (also has caption(optional) z13-)
+railway-station-subway-malaga                       # icon z13- (also has caption(optional) z13-)
+railway-station-subway-manila                       # icon z13- (also has caption(optional) z13-)
+railway-station-subway-maracaibo                    # icon z13- (also has caption(optional) z13-)
+railway-station-subway-mashhad                      # icon z13- (also has caption(optional) z13-)
+railway-station-subway-mecca                        # icon z13- (also has caption(optional) z13-)
+railway-station-subway-medellin                     # icon z13- (also has caption(optional) z13-)
+railway-station-subway-mexico                       # icon z13- (also has caption(optional) z13-)
+railway-station-subway-milan                        # icon z13- (also has caption(optional) z13-)
+railway-station-subway-minsk                        # icon z13- (also has caption(optional) z13-)
+railway-station-subway-montreal                     # icon z13- (also has caption(optional) z13-)
+railway-station-subway-munchen                      # icon z13- (also has caption(optional) z13-)
+railway-station-subway-nagoya                       # icon z13- (also has caption(optional) z13-)
+railway-station-subway-newyork                      # icon z13- (also has caption(optional) z13-)
+railway-station-subway-nnov                         # icon z13- (also has caption(optional) z13-)
+railway-station-subway-novosibirsk                  # icon z13- (also has caption(optional) z13-)
+railway-station-subway-osaka                        # icon z13- (also has caption(optional) z13-)
+railway-station-subway-oslo                         # icon z13- (also has caption(optional) z13-)
+railway-station-subway-palma                        # icon z13- (also has caption(optional) z13-)
+railway-station-subway-panama                       # icon z13- (also has caption(optional) z13-)
+railway-station-subway-paris                        # icon z13- (also has caption(optional) z13-)
+railway-station-subway-philadelphia                 # icon z13- (also has caption(optional) z13-)
+railway-station-subway-pyongyang                    # icon z13- (also has caption(optional) z13-)
+railway-station-subway-rennes                       # icon z13- (also has caption(optional) z13-)
+railway-station-subway-rio                          # icon z13- (also has caption(optional) z13-)
+railway-station-subway-roma                         # icon z13- (also has caption(optional) z13-)
+railway-station-subway-rotterdam                    # icon z13- (also has caption(optional) z13-)
+railway-station-subway-samara                       # icon z13- (also has caption(optional) z13-)
+railway-station-subway-santiago                     # icon z13- (also has caption(optional) z13-)
+railway-station-subway-santo_domingo                # icon z13- (also has caption(optional) z13-)
+railway-station-subway-saopaulo                     # icon z13- (also has caption(optional) z13-)
+railway-station-subway-sapporo                      # icon z13- (also has caption(optional) z13-)
+railway-station-subway-sendai                       # icon z13- (also has caption(optional) z13-)
+railway-station-subway-sf                           # icon z13- (also has caption(optional) z13-)
+railway-station-subway-shanghai                     # icon z13- (also has caption(optional) z13-)
+railway-station-subway-shiraz                       # icon z13- (also has caption(optional) z13-)
+railway-station-subway-sofia                        # icon z13- (also has caption(optional) z13-)
+railway-station-subway-stockholm                    # icon z13- (also has caption(optional) z13-)
+railway-station-subway-tabriz                       # icon z13- (also has caption(optional) z13-)
+railway-station-subway-taipei                       # icon z13- (also has caption(optional) z13-)
+railway-station-subway-taoyuan                      # icon z13- (also has caption(optional) z13-)
+railway-station-subway-tashkent                     # icon z13- (also has caption(optional) z13-)
+railway-station-subway-tbilisi                      # icon z13- (also has caption(optional) z13-)
+railway-station-subway-tehran                       # icon z13- (also has caption(optional) z13-)
+railway-station-subway-tianjin                      # icon z13- (also has caption(optional) z13-)
+railway-station-subway-tokyo                        # icon z13- (also has caption(optional) z13-)
+railway-station-subway-valencia                     # icon z13- (also has caption(optional) z13-)
+railway-station-subway-vienna                       # icon z13- (also has caption(optional) z13-)
+railway-station-subway-warszawa                     # icon z13- (also has caption(optional) z13-)
+railway-station-subway-washington                   # icon z13- (also has caption(optional) z13-)
+railway-station-subway-wuhan                        # icon z13- (also has caption(optional) z13-)
+railway-station-subway-yerevan                      # icon z13- (also has caption(optional) z13-)
+railway-station-subway-yokohama                     # icon z13- (also has caption(optional) z13-)
 === 2000
 
-barrier-border_control                              # caption z15- and icon z15-
-historic-city_gate                                  # caption z15- and icon z13-
-historic-monument                                   # caption z15- and icon z13-
+barrier-border_control                              # icon z15- (also has caption(optional) z15-)
+historic-city_gate                                  # icon z13- (also has caption(optional) z15-)
+historic-monument                                   # icon z13- (also has caption(optional) z15-)
 === 1950
 
 place-hamlet                                        # caption z13-
@@ -381,16 +383,16 @@ place-hamlet                                        # caption z13-
 place-locality                                      # caption z13-
 === 1850
 
-tourism-viewpoint                                   # caption z15- and icon z14-
+tourism-viewpoint                                   # icon z14- (also has caption(optional) z15-)
 === 1800
 
-railway-halt                                        # caption z14- and icon z14-
+railway-halt                                        # icon z14- (also has caption(optional) z14-)
 === 1750
 
-tourism-theme_park                                  # caption z15- and icon z14-
+tourism-theme_park                                  # icon z14- (also has caption(optional) z15-)
 === 1700
 
-shop-supermarket                                    # caption z14- and icon z14-
+shop-supermarket                                    # icon z14- (also has caption(optional) z14-)
 === 1650
 
 highway-pedestrian                                  # pathtext z14-
@@ -402,14 +404,14 @@ highway-pedestrian-tunnel                           # pathtext z14-
 natural-strait                                      # caption z13-
 waterway-river                                      # pathtext z11- (also has line z10-)
 waterway-river-tunnel                               # pathtext z11-
-waterway-riverbank                                  # pathtext z11- (also has area z1-, line z10-)
+waterway-riverbank                                  # pathtext z11- (also has line z10-, area z1-)
 === 1550
 
 natural-water                                       # caption z10- (also has area z1-)
 natural-water-basin                                 # caption z10- (also has area z1-)
 natural-water-lock                                  # caption z10- (also has area z1-)
 natural-water-pond                                  # caption z10- (also has area z1-)
-shop-mall                                           # caption z14- and icon z14-
+shop-mall                                           # icon z14- (also has caption(optional) z14-)
 waterway-canal                                      # pathtext z13-
 waterway-canal-tunnel                               # pathtext z13-
 === 1500
@@ -423,41 +425,41 @@ place-farm                                          # caption z14-
 place-isolated_dwelling                             # caption z14-
 === 1400
 
-tourism-zoo                                         # caption z15- and icon z15-
+tourism-zoo                                         # icon z15- (also has caption(optional) z15-)
 === 1350
 
-tourism-museum                                      # caption z15- and icon z15-
+tourism-museum                                      # icon z15- (also has caption(optional) z15-)
 === 1300
 
-tourism-gallery                                     # caption z15- and icon z15-
+tourism-gallery                                     # icon z15- (also has caption(optional) z15-)
 === 1250
 
-historic-battlefield                                # caption z15- and icon z15-
-historic-memorial                                   # caption z15- and icon z15-
-historic-memorial-sculpture                         # caption z15- and icon z15-
-historic-memorial-statue                            # caption z15- and icon z15-
-historic-memorial-war_memorial                      # caption z15- and icon z15-
-tourism-attraction                                  # caption z15- and icon z15-
-tourism-attraction-animal                           # caption z15- and icon z15-
-tourism-attraction-specified                        # caption z15- and icon z15-
+historic-battlefield                                # icon z15- (also has caption(optional) z15-)
+historic-memorial                                   # icon z15- (also has caption(optional) z15-)
+historic-memorial-sculpture                         # icon z15- (also has caption(optional) z15-)
+historic-memorial-statue                            # icon z15- (also has caption(optional) z15-)
+historic-memorial-war_memorial                      # icon z15- (also has caption(optional) z15-)
+tourism-attraction                                  # icon z15- (also has caption(optional) z15-)
+tourism-attraction-animal                           # icon z15- (also has caption(optional) z15-)
+tourism-attraction-specified                        # icon z15- (also has caption(optional) z15-)
 === 1200
 
-amenity-community_centre                            # caption z16- and icon z16-
-tourism-artwork                                     # caption z15- and icon z15-
-tourism-artwork-architecture                        # caption z15- and icon z15-
-tourism-artwork-painting                            # caption z15- and icon z15-
-tourism-artwork-sculpture                           # caption z15- and icon z15-
-tourism-artwork-statue                              # caption z15- and icon z15-
+amenity-community_centre                            # icon z16- (also has caption(optional) z16-)
+tourism-artwork                                     # icon z15- (also has caption(optional) z15-)
+tourism-artwork-architecture                        # icon z15- (also has caption(optional) z15-)
+tourism-artwork-painting                            # icon z15- (also has caption(optional) z15-)
+tourism-artwork-sculpture                           # icon z15- (also has caption(optional) z15-)
+tourism-artwork-statue                              # icon z15- (also has caption(optional) z15-)
 === 1150
 
-amenity-cafe                                        # caption z15- and icon z15-
-amenity-theatre                                     # caption z15- and icon z15-
+amenity-cafe                                        # icon z15- (also has caption(optional) z15-)
+amenity-theatre                                     # icon z15- (also has caption(optional) z15-)
 === 1100
 
-amenity-university                                  # caption z15- and icon z15-
+amenity-university                                  # icon z15- (also has caption(optional) z15-)
 === 1050
 
-amenity-hospital                                    # caption z15- and icon z15-
+amenity-hospital                                    # icon z15- (also has caption(optional) z15-)
 === 1000
 
 aeroway-terminal                                    # caption z15- (also has area z14-)
@@ -469,34 +471,34 @@ natural-beach-gravel                                # caption z15- (also has are
 natural-beach-sand                                  # caption z15- (also has area z10-)
 === 900
 
-amenity-charging_station-bicycle                    # caption z16- and icon z16-
+amenity-charging_station-bicycle                    # icon z16- (also has caption(optional) z16-)
 === 850
 
-historic-boundary_stone                             # caption z16- and icon z16-
-historic-gallows                                    # caption z16- and icon z16-
-historic-pillory                                    # caption z16- and icon z16-
-historic-ship                                       # caption z16- and icon z16-
-historic-tomb                                       # caption z16- and icon z16-
-historic-wayside_cross                              # caption z16- and icon z16-
-historic-wayside_shrine                             # caption z17- and icon z16-
+historic-boundary_stone                             # icon z16- (also has caption(optional) z16-)
+historic-gallows                                    # icon z16- (also has caption(optional) z16-)
+historic-pillory                                    # icon z16- (also has caption(optional) z16-)
+historic-ship                                       # icon z16- (also has caption(optional) z16-)
+historic-tomb                                       # icon z16- (also has caption(optional) z16-)
+historic-wayside_cross                              # icon z16- (also has caption(optional) z16-)
+historic-wayside_shrine                             # icon z16- (also has caption(optional) z17-)
 === 800
 
-amenity-restaurant                                  # caption z16- and icon z16-
+amenity-restaurant                                  # icon z16- (also has caption(optional) z16-)
 === 750
 
 railway-rail-tourism                                # pathtext z16- (also has line z10-, line::dash z16-)
 railway-rail-tourism-bridge                         # pathtext z16- (also has line z10-, line::bridgeblack z16-, line::bridgewhite z14-, line::dash z16-)
-railway-rail-tourism-tunnel                         # pathtext z16- (also has line z10-, line(casing) z14-, line::dash z16-)
+railway-rail-tourism-tunnel                         # pathtext z16- (also has line z10-, line::dash z16-, line(casing) z14-)
 === 700
 
-amenity-place_of_worship                            # caption z17- and icon z16-
-amenity-place_of_worship-buddhist                   # caption z17- and icon z16-
-amenity-place_of_worship-christian                  # caption z17- and icon z16-
-amenity-place_of_worship-hindu                      # caption z17- and icon z16-
-amenity-place_of_worship-jewish                     # caption z17- and icon z16-
-amenity-place_of_worship-muslim                     # caption z17- and icon z16-
-amenity-place_of_worship-shinto                     # caption z17- and icon z16-
-amenity-place_of_worship-taoist                     # caption z17- and icon z16-
+amenity-place_of_worship                            # icon z16- (also has caption(optional) z17-)
+amenity-place_of_worship-buddhist                   # icon z16- (also has caption(optional) z17-)
+amenity-place_of_worship-christian                  # icon z16- (also has caption(optional) z17-)
+amenity-place_of_worship-hindu                      # icon z16- (also has caption(optional) z17-)
+amenity-place_of_worship-jewish                     # icon z16- (also has caption(optional) z17-)
+amenity-place_of_worship-muslim                     # icon z16- (also has caption(optional) z17-)
+amenity-place_of_worship-shinto                     # icon z16- (also has caption(optional) z17-)
+amenity-place_of_worship-taoist                     # icon z16- (also has caption(optional) z17-)
 === 650
 
 waterway-lock_gate                                  # icon z16-
@@ -507,121 +509,121 @@ amenity-events_venue                                # icon z16-
 amenity-exhibition_centre                           # icon z16-
 amenity-water_point                                 # icon z16-
 building-train_station                              # caption z18- (also has area z15-)
-railway-subway_entrance                             # caption z17- and icon z16-
-railway-subway_entrance-adana                       # caption z17- and icon z16-
-railway-subway_entrance-algiers                     # caption z17- and icon z16-
-railway-subway_entrance-almaty                      # caption z17- and icon z16-
-railway-subway_entrance-amsterdam                   # caption z17- and icon z16-
-railway-subway_entrance-ankara                      # caption z17- and icon z16-
-railway-subway_entrance-athens                      # caption z17- and icon z16-
-railway-subway_entrance-baku                        # caption z17- and icon z16-
-railway-subway_entrance-bangkok                     # caption z17- and icon z16-
-railway-subway_entrance-barcelona                   # caption z17- and icon z16-
-railway-subway_entrance-beijing                     # caption z17- and icon z16-
-railway-subway_entrance-bengalore                   # caption z17- and icon z16-
-railway-subway_entrance-berlin                      # caption z17- and icon z16-
-railway-subway_entrance-bilbao                      # caption z17- and icon z16-
-railway-subway_entrance-brasilia                    # caption z17- and icon z16-
-railway-subway_entrance-brescia                     # caption z17- and icon z16-
-railway-subway_entrance-brussels                    # caption z17- and icon z16-
-railway-subway_entrance-bucharest                   # caption z17- and icon z16-
-railway-subway_entrance-budapest                    # caption z17- and icon z16-
-railway-subway_entrance-buenos_aires                # caption z17- and icon z16-
-railway-subway_entrance-bursa                       # caption z17- and icon z16-
-railway-subway_entrance-cairo                       # caption z17- and icon z16-
-railway-subway_entrance-caracas                     # caption z17- and icon z16-
-railway-subway_entrance-catania                     # caption z17- and icon z16-
-railway-subway_entrance-changchun                   # caption z17- and icon z16-
-railway-subway_entrance-chengdu                     # caption z17- and icon z16-
-railway-subway_entrance-chicago                     # caption z17- and icon z16-
-railway-subway_entrance-chongqing                   # caption z17- and icon z16-
-railway-subway_entrance-dalian                      # caption z17- and icon z16-
-railway-subway_entrance-delhi                       # caption z17- and icon z16-
-railway-subway_entrance-dnepro                      # caption z17- and icon z16-
-railway-subway_entrance-dubai                       # caption z17- and icon z16-
-railway-subway_entrance-ekb                         # caption z17- and icon z16-
-railway-subway_entrance-fukuoka                     # caption z17- and icon z16-
-railway-subway_entrance-glasgow                     # caption z17- and icon z16-
-railway-subway_entrance-guangzhou                   # caption z17- and icon z16-
-railway-subway_entrance-hamburg                     # caption z17- and icon z16-
-railway-subway_entrance-helsinki                    # caption z17- and icon z16-
-railway-subway_entrance-hiroshima                   # caption z17- and icon z16-
-railway-subway_entrance-isfahan                     # caption z17- and icon z16-
-railway-subway_entrance-istanbul                    # caption z17- and icon z16-
-railway-subway_entrance-izmir                       # caption z17- and icon z16-
-railway-subway_entrance-kazan                       # caption z17- and icon z16-
-railway-subway_entrance-kharkiv                     # caption z17- and icon z16-
-railway-subway_entrance-kiev                        # caption z17- and icon z16-
-railway-subway_entrance-kobe                        # caption z17- and icon z16-
-railway-subway_entrance-kolkata                     # caption z17- and icon z16-
-railway-subway_entrance-kunming                     # caption z17- and icon z16-
-railway-subway_entrance-kyoto                       # caption z17- and icon z16-
-railway-subway_entrance-la                          # caption z17- and icon z16-
-railway-subway_entrance-lausanne                    # caption z17- and icon z16-
-railway-subway_entrance-lille                       # caption z17- and icon z16-
-railway-subway_entrance-lima                        # caption z17- and icon z16-
-railway-subway_entrance-lisboa                      # caption z17- and icon z16-
-railway-subway_entrance-london                      # caption z17- and icon z16-
-railway-subway_entrance-lyon                        # caption z17- and icon z16-
-railway-subway_entrance-madrid                      # caption z17- and icon z16-
-railway-subway_entrance-malaga                      # caption z17- and icon z16-
-railway-subway_entrance-manila                      # caption z17- and icon z16-
-railway-subway_entrance-maracaibo                   # caption z17- and icon z16-
-railway-subway_entrance-mashhad                     # caption z17- and icon z16-
-railway-subway_entrance-mecca                       # caption z17- and icon z16-
-railway-subway_entrance-medellin                    # caption z17- and icon z16-
-railway-subway_entrance-mexico                      # caption z17- and icon z16-
-railway-subway_entrance-milan                       # caption z17- and icon z16-
-railway-subway_entrance-minsk                       # caption z17- and icon z16-
-railway-subway_entrance-montreal                    # caption z17- and icon z16-
-railway-subway_entrance-moscow                      # caption z16- and icon z16-
-railway-subway_entrance-munchen                     # caption z17- and icon z16-
-railway-subway_entrance-nagoya                      # caption z17- and icon z16-
-railway-subway_entrance-newyork                     # caption z17- and icon z16-
-railway-subway_entrance-nnov                        # caption z17- and icon z16-
-railway-subway_entrance-novosibirsk                 # caption z17- and icon z16-
-railway-subway_entrance-osaka                       # caption z17- and icon z16-
-railway-subway_entrance-oslo                        # caption z17- and icon z16-
-railway-subway_entrance-palma                       # caption z17- and icon z16-
-railway-subway_entrance-panama                      # caption z17- and icon z16-
-railway-subway_entrance-paris                       # caption z17- and icon z16-
-railway-subway_entrance-philadelphia                # caption z17- and icon z16-
-railway-subway_entrance-pyongyang                   # caption z17- and icon z16-
-railway-subway_entrance-rennes                      # caption z17- and icon z16-
-railway-subway_entrance-rio                         # caption z17- and icon z16-
-railway-subway_entrance-roma                        # caption z17- and icon z16-
-railway-subway_entrance-rotterdam                   # caption z17- and icon z16-
-railway-subway_entrance-samara                      # caption z17- and icon z16-
-railway-subway_entrance-santiago                    # caption z17- and icon z16-
-railway-subway_entrance-santo_domingo               # caption z17- and icon z16-
-railway-subway_entrance-saopaulo                    # caption z17- and icon z16-
-railway-subway_entrance-sapporo                     # caption z17- and icon z16-
-railway-subway_entrance-sendai                      # caption z17- and icon z16-
-railway-subway_entrance-sf                          # caption z17- and icon z16-
-railway-subway_entrance-shanghai                    # caption z17- and icon z16-
-railway-subway_entrance-shiraz                      # caption z17- and icon z16-
-railway-subway_entrance-sofia                       # caption z17- and icon z16-
-railway-subway_entrance-spb                         # caption z16- and icon z16-
-railway-subway_entrance-stockholm                   # caption z17- and icon z16-
-railway-subway_entrance-tabriz                      # caption z17- and icon z16-
-railway-subway_entrance-taipei                      # caption z17- and icon z16-
-railway-subway_entrance-taoyuan                     # caption z17- and icon z16-
-railway-subway_entrance-tashkent                    # caption z17- and icon z16-
-railway-subway_entrance-tbilisi                     # caption z17- and icon z16-
-railway-subway_entrance-tehran                      # caption z17- and icon z16-
-railway-subway_entrance-tianjin                     # caption z17- and icon z16-
-railway-subway_entrance-tokyo                       # caption z17- and icon z16-
-railway-subway_entrance-valencia                    # caption z17- and icon z16-
-railway-subway_entrance-vienna                      # caption z17- and icon z16-
-railway-subway_entrance-warszawa                    # caption z17- and icon z16-
-railway-subway_entrance-washington                  # caption z17- and icon z16-
-railway-subway_entrance-wuhan                       # caption z17- and icon z16-
-railway-subway_entrance-yerevan                     # caption z17- and icon z16-
-railway-subway_entrance-yokohama                    # caption z17- and icon z16-
+railway-subway_entrance                             # icon z16- (also has caption(optional) z17-)
+railway-subway_entrance-adana                       # icon z16- (also has caption(optional) z17-)
+railway-subway_entrance-algiers                     # icon z16- (also has caption(optional) z17-)
+railway-subway_entrance-almaty                      # icon z16- (also has caption(optional) z17-)
+railway-subway_entrance-amsterdam                   # icon z16- (also has caption(optional) z17-)
+railway-subway_entrance-ankara                      # icon z16- (also has caption(optional) z17-)
+railway-subway_entrance-athens                      # icon z16- (also has caption(optional) z17-)
+railway-subway_entrance-baku                        # icon z16- (also has caption(optional) z17-)
+railway-subway_entrance-bangkok                     # icon z16- (also has caption(optional) z17-)
+railway-subway_entrance-barcelona                   # icon z16- (also has caption(optional) z17-)
+railway-subway_entrance-beijing                     # icon z16- (also has caption(optional) z17-)
+railway-subway_entrance-bengalore                   # icon z16- (also has caption(optional) z17-)
+railway-subway_entrance-berlin                      # icon z16- (also has caption(optional) z17-)
+railway-subway_entrance-bilbao                      # icon z16- (also has caption(optional) z17-)
+railway-subway_entrance-brasilia                    # icon z16- (also has caption(optional) z17-)
+railway-subway_entrance-brescia                     # icon z16- (also has caption(optional) z17-)
+railway-subway_entrance-brussels                    # icon z16- (also has caption(optional) z17-)
+railway-subway_entrance-bucharest                   # icon z16- (also has caption(optional) z17-)
+railway-subway_entrance-budapest                    # icon z16- (also has caption(optional) z17-)
+railway-subway_entrance-buenos_aires                # icon z16- (also has caption(optional) z17-)
+railway-subway_entrance-bursa                       # icon z16- (also has caption(optional) z17-)
+railway-subway_entrance-cairo                       # icon z16- (also has caption(optional) z17-)
+railway-subway_entrance-caracas                     # icon z16- (also has caption(optional) z17-)
+railway-subway_entrance-catania                     # icon z16- (also has caption(optional) z17-)
+railway-subway_entrance-changchun                   # icon z16- (also has caption(optional) z17-)
+railway-subway_entrance-chengdu                     # icon z16- (also has caption(optional) z17-)
+railway-subway_entrance-chicago                     # icon z16- (also has caption(optional) z17-)
+railway-subway_entrance-chongqing                   # icon z16- (also has caption(optional) z17-)
+railway-subway_entrance-dalian                      # icon z16- (also has caption(optional) z17-)
+railway-subway_entrance-delhi                       # icon z16- (also has caption(optional) z17-)
+railway-subway_entrance-dnepro                      # icon z16- (also has caption(optional) z17-)
+railway-subway_entrance-dubai                       # icon z16- (also has caption(optional) z17-)
+railway-subway_entrance-ekb                         # icon z16- (also has caption(optional) z17-)
+railway-subway_entrance-fukuoka                     # icon z16- (also has caption(optional) z17-)
+railway-subway_entrance-glasgow                     # icon z16- (also has caption(optional) z17-)
+railway-subway_entrance-guangzhou                   # icon z16- (also has caption(optional) z17-)
+railway-subway_entrance-hamburg                     # icon z16- (also has caption(optional) z17-)
+railway-subway_entrance-helsinki                    # icon z16- (also has caption(optional) z17-)
+railway-subway_entrance-hiroshima                   # icon z16- (also has caption(optional) z17-)
+railway-subway_entrance-isfahan                     # icon z16- (also has caption(optional) z17-)
+railway-subway_entrance-istanbul                    # icon z16- (also has caption(optional) z17-)
+railway-subway_entrance-izmir                       # icon z16- (also has caption(optional) z17-)
+railway-subway_entrance-kazan                       # icon z16- (also has caption(optional) z17-)
+railway-subway_entrance-kharkiv                     # icon z16- (also has caption(optional) z17-)
+railway-subway_entrance-kiev                        # icon z16- (also has caption(optional) z17-)
+railway-subway_entrance-kobe                        # icon z16- (also has caption(optional) z17-)
+railway-subway_entrance-kolkata                     # icon z16- (also has caption(optional) z17-)
+railway-subway_entrance-kunming                     # icon z16- (also has caption(optional) z17-)
+railway-subway_entrance-kyoto                       # icon z16- (also has caption(optional) z17-)
+railway-subway_entrance-la                          # icon z16- (also has caption(optional) z17-)
+railway-subway_entrance-lausanne                    # icon z16- (also has caption(optional) z17-)
+railway-subway_entrance-lille                       # icon z16- (also has caption(optional) z17-)
+railway-subway_entrance-lima                        # icon z16- (also has caption(optional) z17-)
+railway-subway_entrance-lisboa                      # icon z16- (also has caption(optional) z17-)
+railway-subway_entrance-london                      # icon z16- (also has caption(optional) z17-)
+railway-subway_entrance-lyon                        # icon z16- (also has caption(optional) z17-)
+railway-subway_entrance-madrid                      # icon z16- (also has caption(optional) z17-)
+railway-subway_entrance-malaga                      # icon z16- (also has caption(optional) z17-)
+railway-subway_entrance-manila                      # icon z16- (also has caption(optional) z17-)
+railway-subway_entrance-maracaibo                   # icon z16- (also has caption(optional) z17-)
+railway-subway_entrance-mashhad                     # icon z16- (also has caption(optional) z17-)
+railway-subway_entrance-mecca                       # icon z16- (also has caption(optional) z17-)
+railway-subway_entrance-medellin                    # icon z16- (also has caption(optional) z17-)
+railway-subway_entrance-mexico                      # icon z16- (also has caption(optional) z17-)
+railway-subway_entrance-milan                       # icon z16- (also has caption(optional) z17-)
+railway-subway_entrance-minsk                       # icon z16- (also has caption(optional) z17-)
+railway-subway_entrance-montreal                    # icon z16- (also has caption(optional) z17-)
+railway-subway_entrance-moscow                      # icon z16- (also has caption(optional) z16-)
+railway-subway_entrance-munchen                     # icon z16- (also has caption(optional) z17-)
+railway-subway_entrance-nagoya                      # icon z16- (also has caption(optional) z17-)
+railway-subway_entrance-newyork                     # icon z16- (also has caption(optional) z17-)
+railway-subway_entrance-nnov                        # icon z16- (also has caption(optional) z17-)
+railway-subway_entrance-novosibirsk                 # icon z16- (also has caption(optional) z17-)
+railway-subway_entrance-osaka                       # icon z16- (also has caption(optional) z17-)
+railway-subway_entrance-oslo                        # icon z16- (also has caption(optional) z17-)
+railway-subway_entrance-palma                       # icon z16- (also has caption(optional) z17-)
+railway-subway_entrance-panama                      # icon z16- (also has caption(optional) z17-)
+railway-subway_entrance-paris                       # icon z16- (also has caption(optional) z17-)
+railway-subway_entrance-philadelphia                # icon z16- (also has caption(optional) z17-)
+railway-subway_entrance-pyongyang                   # icon z16- (also has caption(optional) z17-)
+railway-subway_entrance-rennes                      # icon z16- (also has caption(optional) z17-)
+railway-subway_entrance-rio                         # icon z16- (also has caption(optional) z17-)
+railway-subway_entrance-roma                        # icon z16- (also has caption(optional) z17-)
+railway-subway_entrance-rotterdam                   # icon z16- (also has caption(optional) z17-)
+railway-subway_entrance-samara                      # icon z16- (also has caption(optional) z17-)
+railway-subway_entrance-santiago                    # icon z16- (also has caption(optional) z17-)
+railway-subway_entrance-santo_domingo               # icon z16- (also has caption(optional) z17-)
+railway-subway_entrance-saopaulo                    # icon z16- (also has caption(optional) z17-)
+railway-subway_entrance-sapporo                     # icon z16- (also has caption(optional) z17-)
+railway-subway_entrance-sendai                      # icon z16- (also has caption(optional) z17-)
+railway-subway_entrance-sf                          # icon z16- (also has caption(optional) z17-)
+railway-subway_entrance-shanghai                    # icon z16- (also has caption(optional) z17-)
+railway-subway_entrance-shiraz                      # icon z16- (also has caption(optional) z17-)
+railway-subway_entrance-sofia                       # icon z16- (also has caption(optional) z17-)
+railway-subway_entrance-spb                         # icon z16- (also has caption(optional) z16-)
+railway-subway_entrance-stockholm                   # icon z16- (also has caption(optional) z17-)
+railway-subway_entrance-tabriz                      # icon z16- (also has caption(optional) z17-)
+railway-subway_entrance-taipei                      # icon z16- (also has caption(optional) z17-)
+railway-subway_entrance-taoyuan                     # icon z16- (also has caption(optional) z17-)
+railway-subway_entrance-tashkent                    # icon z16- (also has caption(optional) z17-)
+railway-subway_entrance-tbilisi                     # icon z16- (also has caption(optional) z17-)
+railway-subway_entrance-tehran                      # icon z16- (also has caption(optional) z17-)
+railway-subway_entrance-tianjin                     # icon z16- (also has caption(optional) z17-)
+railway-subway_entrance-tokyo                       # icon z16- (also has caption(optional) z17-)
+railway-subway_entrance-valencia                    # icon z16- (also has caption(optional) z17-)
+railway-subway_entrance-vienna                      # icon z16- (also has caption(optional) z17-)
+railway-subway_entrance-warszawa                    # icon z16- (also has caption(optional) z17-)
+railway-subway_entrance-washington                  # icon z16- (also has caption(optional) z17-)
+railway-subway_entrance-wuhan                       # icon z16- (also has caption(optional) z17-)
+railway-subway_entrance-yerevan                     # icon z16- (also has caption(optional) z17-)
+railway-subway_entrance-yokohama                    # icon z16- (also has caption(optional) z17-)
 === 550
 
-amenity-parking-no-access                           # caption z16- and icon z15- (also has area z15-)
-amenity-parking-private                             # caption z17- and icon z17- (also has area z15-)
+amenity-parking-no-access                           # icon z15- (also has caption(optional) z16-, area z15-)
+amenity-parking-private                             # icon z17- (also has caption(optional) z17-, area z15-)
 === 500
 
 natural-wetland                                     # caption z16- (also has area z11-)
@@ -629,24 +631,24 @@ natural-wetland-bog                                 # caption z16- (also has are
 natural-wetland-marsh                               # caption z16- (also has area z11-)
 === 450
 
-railway-tram_stop                                   # caption z17- and icon z17-
+railway-tram_stop                                   # icon z17- (also has caption(optional) z17-)
 === 400
 
-historic-memorial-cross                             # caption z17- and icon z17-
+historic-memorial-cross                             # icon z17- (also has caption(optional) z17-)
 === 350
 
-amenity-arts_centre                                 # caption z17- and icon z17-
-historic-archaeological_site                        # caption z17- and icon z17-
-historic-ruins                                      # caption z17- and icon z17-
+amenity-arts_centre                                 # icon z17- (also has caption(optional) z17-)
+historic-archaeological_site                        # icon z17- (also has caption(optional) z17-)
+historic-ruins                                      # icon z17- (also has caption(optional) z17-)
 === 300
 
-amenity-fast_food                                   # caption z17- and icon z17-
+amenity-fast_food                                   # icon z17- (also has caption(optional) z17-)
 === 250
 
-amenity-bank                                        # caption z17- and icon z17-
-amenity-parcel_locker                               # caption z17- and icon z17-
+amenity-bank                                        # icon z17- (also has caption(optional) z17-)
+amenity-parcel_locker                               # icon z17- (also has caption(optional) z17-)
 amenity-police                                      # icon z17-
-amenity-post_office                                 # caption z17- and icon z17-
+amenity-post_office                                 # icon z17- (also has caption(optional) z17-)
 shop-motorcycle                                     # icon z17-
 === 200
 
@@ -655,8 +657,8 @@ landuse-quarry                                      # caption z15- (also has are
 landuse-railway                                     # caption z15- (also has area z15-)
 === 150
 
-leisure-park-no-access                              # caption z14- and icon z14- (also has area z10-)
-leisure-park-private                                # caption z14- and icon z14- (also has area z10-)
+leisure-park-no-access                              # icon z14- (also has caption(optional) z14-, area z10-)
+leisure-park-private                                # icon z14- (also has caption(optional) z14-, area z10-)
 === 100
 
 building                                            # caption z18- (also has area z15-)
@@ -666,3 +668,434 @@ building-has_parts                                  # caption z18- (also has are
 building-address                                    # caption z18-
 building-garage                                     # caption z18- (also has area z15-)
 === 30
+
+#
+# All automatic optional captions priorities are below 0.
+# They follow the order of their correspoding icons.
+#
+
+# highway-services                                  # caption(optional) z13- (also has icon z12-)
+# === -5800
+
+# highway-rest_area                                 # caption(optional) z14- (also has icon z14-)
+# === -5850
+
+# aeroway-aerodrome-international                   # caption(optional) z10- (also has icon z7-, area z10-)
+# === -6700
+
+# amenity-charging_station-motorcar                 # caption(optional) z14- (also has icon z14-)
+# amenity-fuel                                      # caption(optional) z12- (also has icon z12-)
+# === -6800
+
+# amenity-charging_station                          # caption(optional) z16- (also has icon z16-)
+# amenity-vending_machine-fuel                      # caption(optional) z17- (also has icon z17-)
+# === -6850
+
+# railway-station-subway-moscow                     # caption(optional) z12- (also has icon z11-)
+# railway-station-subway-spb                        # caption(optional) z12- (also has icon z11-)
+# === -6900
+
+# aeroway-aerodrome                                 # caption(optional) z14- (also has icon z14-, area z10-)
+# === -6950
+
+# railway-station                                   # caption(optional) z13- (also has icon z12-)
+# === -7000
+
+# railway-station-funicular                         # caption(optional) z13- (also has icon z12-)
+# railway-station-light_rail                        # caption(optional) z13- (also has icon z12-)
+# railway-station-monorail                          # caption(optional) z13- (also has icon z12-)
+# === -7100
+
+# barrier-toll_booth                                # caption(optional) z14- (also has icon z12-)
+# === -7150
+
+# barrier-lift_gate                                 # caption(optional) z16- (also has icon z16-)
+# === -7250
+
+# amenity-car_wash                                  # caption(optional) z17- (also has icon z17-)
+# amenity-vending_machine-parking_tickets           # caption(optional) z17- (also has icon z17-)
+# shop-car_repair-tyres                             # caption(optional) z15- (also has icon z15-)
+# === -7350
+
+# amenity-sanitary_dump_station                     # caption(optional) z15- (also has icon z15-)
+# === -7400
+
+# amenity-parking                                   # caption(optional) z16- (also has icon z15-, area z15-)
+# amenity-parking-fee                               # caption(optional) z16- (also has icon z15-, area z15-)
+# amenity-parking-multi-storey                      # caption(optional) z16- (also has icon z15-, area z15-)
+# amenity-parking-park_and_ride                     # caption(optional) z16- (also has icon z15-, area z15-)
+# amenity-parking-permissive                        # caption(optional) z16- (also has icon z15-, area z15-)
+# amenity-parking-underground                       # caption(optional) z16- (also has icon z15-, area z15-)
+# === -7450
+
+# boundary-national_park                            # caption(optional) z12- (also has icon z12-)
+# boundary-protected_area                           # caption(optional) z12- (also has icon z12-)
+# boundary-protected_area-1                         # caption(optional) z12- (also has icon z12-)
+# boundary-protected_area-2                         # caption(optional) z12- (also has icon z12-)
+# boundary-protected_area-3                         # caption(optional) z12- (also has icon z12-)
+# boundary-protected_area-4                         # caption(optional) z12- (also has icon z12-)
+# boundary-protected_area-5                         # caption(optional) z12- (also has icon z12-)
+# boundary-protected_area-6                         # caption(optional) z12- (also has icon z12-)
+# leisure-nature_reserve                            # caption(optional) z12- (also has icon z12-, area z10-)
+# === -7500
+
+# historic-castle                                   # caption(optional) z15- (also has icon z12-)
+# historic-castle-castrum                           # caption(optional) z15- (also has icon z12-)
+# historic-castle-defensive                         # caption(optional) z15- (also has icon z12-)
+# historic-castle-fortified_church                  # caption(optional) z15- (also has icon z12-)
+# historic-castle-fortress                          # caption(optional) z15- (also has icon z12-)
+# historic-castle-hillfort                          # caption(optional) z15- (also has icon z12-)
+# historic-castle-kremlin                           # caption(optional) z15- (also has icon z12-)
+# historic-castle-manor                             # caption(optional) z15- (also has icon z12-)
+# historic-castle-palace                            # caption(optional) z15- (also has icon z12-)
+# historic-castle-shiro                             # caption(optional) z15- (also has icon z12-)
+# historic-castle-stately                           # caption(optional) z15- (also has icon z12-)
+# historic-fort                                     # caption(optional) z15- (also has icon z12-)
+# === -7550
+
+# amenity-car_rental                                # caption(optional) z18- (also has icon z18-)
+# amenity-car_sharing                               # caption(optional) z18- (also has icon z18-)
+# === -7600
+
+# leisure-park                                      # caption(optional) z14- (also has icon z14-, area z10-)
+# leisure-park-permissive                           # caption(optional) z14- (also has icon z14-, area z10-)
+# === -7750
+
+# landuse-forest                                    # caption(optional) z12- (also has icon z12-, area z10-)
+# landuse-forest-coniferous                         # caption(optional) z12- (also has icon z12-, area z10-)
+# landuse-forest-deciduous                          # caption(optional) z12- (also has icon z12-, area z10-)
+# landuse-forest-mixed                              # caption(optional) z12- (also has icon z12-, area z10-)
+# === -7800
+
+# railway-station-subway                            # caption(optional) z13- (also has icon z13-)
+# railway-station-subway-adana                      # caption(optional) z13- (also has icon z12-)
+# railway-station-subway-algiers                    # caption(optional) z13- (also has icon z12-)
+# railway-station-subway-almaty                     # caption(optional) z13- (also has icon z12-)
+# railway-station-subway-amsterdam                  # caption(optional) z13- (also has icon z13-)
+# railway-station-subway-ankara                     # caption(optional) z13- (also has icon z13-)
+# railway-station-subway-athens                     # caption(optional) z13- (also has icon z13-)
+# railway-station-subway-baku                       # caption(optional) z13- (also has icon z13-)
+# railway-station-subway-bangkok                    # caption(optional) z13- (also has icon z13-)
+# railway-station-subway-barcelona                  # caption(optional) z13- (also has icon z13-)
+# railway-station-subway-beijing                    # caption(optional) z13- (also has icon z13-)
+# railway-station-subway-bengalore                  # caption(optional) z13- (also has icon z13-)
+# railway-station-subway-berlin                     # caption(optional) z13- (also has icon z13-)
+# railway-station-subway-bilbao                     # caption(optional) z13- (also has icon z13-)
+# railway-station-subway-brasilia                   # caption(optional) z13- (also has icon z13-)
+# railway-station-subway-brescia                    # caption(optional) z13- (also has icon z13-)
+# railway-station-subway-brussels                   # caption(optional) z13- (also has icon z13-)
+# railway-station-subway-bucharest                  # caption(optional) z13- (also has icon z13-)
+# railway-station-subway-budapest                   # caption(optional) z13- (also has icon z13-)
+# railway-station-subway-buenos_aires               # caption(optional) z13- (also has icon z13-)
+# railway-station-subway-bursa                      # caption(optional) z13- (also has icon z13-)
+# railway-station-subway-cairo                      # caption(optional) z13- (also has icon z13-)
+# railway-station-subway-caracas                    # caption(optional) z13- (also has icon z13-)
+# railway-station-subway-catania                    # caption(optional) z13- (also has icon z13-)
+# railway-station-subway-changchun                  # caption(optional) z13- (also has icon z13-)
+# railway-station-subway-chengdu                    # caption(optional) z13- (also has icon z13-)
+# railway-station-subway-chicago                    # caption(optional) z13- (also has icon z13-)
+# railway-station-subway-chongqing                  # caption(optional) z13- (also has icon z13-)
+# railway-station-subway-dalian                     # caption(optional) z13- (also has icon z13-)
+# railway-station-subway-delhi                      # caption(optional) z13- (also has icon z13-)
+# railway-station-subway-dnepro                     # caption(optional) z13- (also has icon z13-)
+# railway-station-subway-dubai                      # caption(optional) z13- (also has icon z13-)
+# railway-station-subway-ekb                        # caption(optional) z13- (also has icon z13-)
+# railway-station-subway-fukuoka                    # caption(optional) z13- (also has icon z13-)
+# railway-station-subway-glasgow                    # caption(optional) z13- (also has icon z13-)
+# railway-station-subway-guangzhou                  # caption(optional) z13- (also has icon z13-)
+# railway-station-subway-hamburg                    # caption(optional) z13- (also has icon z13-)
+# railway-station-subway-helsinki                   # caption(optional) z13- (also has icon z13-)
+# railway-station-subway-hiroshima                  # caption(optional) z13- (also has icon z13-)
+# railway-station-subway-isfahan                    # caption(optional) z13- (also has icon z13-)
+# railway-station-subway-istanbul                   # caption(optional) z13- (also has icon z13-)
+# railway-station-subway-izmir                      # caption(optional) z13- (also has icon z13-)
+# railway-station-subway-kazan                      # caption(optional) z13- (also has icon z13-)
+# railway-station-subway-kharkiv                    # caption(optional) z13- (also has icon z13-)
+# railway-station-subway-kiev                       # caption(optional) z13- (also has icon z13-)
+# railway-station-subway-kobe                       # caption(optional) z13- (also has icon z13-)
+# railway-station-subway-kolkata                    # caption(optional) z13- (also has icon z13-)
+# railway-station-subway-kunming                    # caption(optional) z13- (also has icon z13-)
+# railway-station-subway-kyoto                      # caption(optional) z13- (also has icon z13-)
+# railway-station-subway-la                         # caption(optional) z13- (also has icon z13-)
+# railway-station-subway-lausanne                   # caption(optional) z13- (also has icon z13-)
+# railway-station-subway-lille                      # caption(optional) z13- (also has icon z13-)
+# railway-station-subway-lima                       # caption(optional) z13- (also has icon z13-)
+# railway-station-subway-lisboa                     # caption(optional) z13- (also has icon z13-)
+# railway-station-subway-london                     # caption(optional) z13- (also has icon z13-)
+# railway-station-subway-lyon                       # caption(optional) z13- (also has icon z13-)
+# railway-station-subway-madrid                     # caption(optional) z13- (also has icon z13-)
+# railway-station-subway-malaga                     # caption(optional) z13- (also has icon z13-)
+# railway-station-subway-manila                     # caption(optional) z13- (also has icon z13-)
+# railway-station-subway-maracaibo                  # caption(optional) z13- (also has icon z13-)
+# railway-station-subway-mashhad                    # caption(optional) z13- (also has icon z13-)
+# railway-station-subway-mecca                      # caption(optional) z13- (also has icon z13-)
+# railway-station-subway-medellin                   # caption(optional) z13- (also has icon z13-)
+# railway-station-subway-mexico                     # caption(optional) z13- (also has icon z13-)
+# railway-station-subway-milan                      # caption(optional) z13- (also has icon z13-)
+# railway-station-subway-minsk                      # caption(optional) z13- (also has icon z13-)
+# railway-station-subway-montreal                   # caption(optional) z13- (also has icon z13-)
+# railway-station-subway-munchen                    # caption(optional) z13- (also has icon z13-)
+# railway-station-subway-nagoya                     # caption(optional) z13- (also has icon z13-)
+# railway-station-subway-newyork                    # caption(optional) z13- (also has icon z13-)
+# railway-station-subway-nnov                       # caption(optional) z13- (also has icon z13-)
+# railway-station-subway-novosibirsk                # caption(optional) z13- (also has icon z13-)
+# railway-station-subway-osaka                      # caption(optional) z13- (also has icon z13-)
+# railway-station-subway-oslo                       # caption(optional) z13- (also has icon z13-)
+# railway-station-subway-palma                      # caption(optional) z13- (also has icon z13-)
+# railway-station-subway-panama                     # caption(optional) z13- (also has icon z13-)
+# railway-station-subway-paris                      # caption(optional) z13- (also has icon z13-)
+# railway-station-subway-philadelphia               # caption(optional) z13- (also has icon z13-)
+# railway-station-subway-pyongyang                  # caption(optional) z13- (also has icon z13-)
+# railway-station-subway-rennes                     # caption(optional) z13- (also has icon z13-)
+# railway-station-subway-rio                        # caption(optional) z13- (also has icon z13-)
+# railway-station-subway-roma                       # caption(optional) z13- (also has icon z13-)
+# railway-station-subway-rotterdam                  # caption(optional) z13- (also has icon z13-)
+# railway-station-subway-samara                     # caption(optional) z13- (also has icon z13-)
+# railway-station-subway-santiago                   # caption(optional) z13- (also has icon z13-)
+# railway-station-subway-santo_domingo              # caption(optional) z13- (also has icon z13-)
+# railway-station-subway-saopaulo                   # caption(optional) z13- (also has icon z13-)
+# railway-station-subway-sapporo                    # caption(optional) z13- (also has icon z13-)
+# railway-station-subway-sendai                     # caption(optional) z13- (also has icon z13-)
+# railway-station-subway-sf                         # caption(optional) z13- (also has icon z13-)
+# railway-station-subway-shanghai                   # caption(optional) z13- (also has icon z13-)
+# railway-station-subway-shiraz                     # caption(optional) z13- (also has icon z13-)
+# railway-station-subway-sofia                      # caption(optional) z13- (also has icon z13-)
+# railway-station-subway-stockholm                  # caption(optional) z13- (also has icon z13-)
+# railway-station-subway-tabriz                     # caption(optional) z13- (also has icon z13-)
+# railway-station-subway-taipei                     # caption(optional) z13- (also has icon z13-)
+# railway-station-subway-taoyuan                    # caption(optional) z13- (also has icon z13-)
+# railway-station-subway-tashkent                   # caption(optional) z13- (also has icon z13-)
+# railway-station-subway-tbilisi                    # caption(optional) z13- (also has icon z13-)
+# railway-station-subway-tehran                     # caption(optional) z13- (also has icon z13-)
+# railway-station-subway-tianjin                    # caption(optional) z13- (also has icon z13-)
+# railway-station-subway-tokyo                      # caption(optional) z13- (also has icon z13-)
+# railway-station-subway-valencia                   # caption(optional) z13- (also has icon z13-)
+# railway-station-subway-vienna                     # caption(optional) z13- (also has icon z13-)
+# railway-station-subway-warszawa                   # caption(optional) z13- (also has icon z13-)
+# railway-station-subway-washington                 # caption(optional) z13- (also has icon z13-)
+# railway-station-subway-wuhan                      # caption(optional) z13- (also has icon z13-)
+# railway-station-subway-yerevan                    # caption(optional) z13- (also has icon z13-)
+# railway-station-subway-yokohama                   # caption(optional) z13- (also has icon z13-)
+# === -8000
+
+# barrier-border_control                            # caption(optional) z15- (also has icon z15-)
+# historic-city_gate                                # caption(optional) z15- (also has icon z13-)
+# historic-monument                                 # caption(optional) z15- (also has icon z13-)
+# === -8050
+
+# tourism-viewpoint                                 # caption(optional) z15- (also has icon z14-)
+# === -8200
+
+# railway-halt                                      # caption(optional) z14- (also has icon z14-)
+# === -8250
+
+# tourism-theme_park                                # caption(optional) z15- (also has icon z14-)
+# === -8300
+
+# shop-supermarket                                  # caption(optional) z14- (also has icon z14-)
+# === -8350
+
+# shop-mall                                         # caption(optional) z14- (also has icon z14-)
+# === -8500
+
+# tourism-zoo                                       # caption(optional) z15- (also has icon z15-)
+# === -8650
+
+# tourism-museum                                    # caption(optional) z15- (also has icon z15-)
+# === -8700
+
+# tourism-gallery                                   # caption(optional) z15- (also has icon z15-)
+# === -8750
+
+# historic-battlefield                              # caption(optional) z15- (also has icon z15-)
+# historic-memorial                                 # caption(optional) z15- (also has icon z15-)
+# historic-memorial-sculpture                       # caption(optional) z15- (also has icon z15-)
+# historic-memorial-statue                          # caption(optional) z15- (also has icon z15-)
+# historic-memorial-war_memorial                    # caption(optional) z15- (also has icon z15-)
+# tourism-attraction                                # caption(optional) z15- (also has icon z15-)
+# tourism-attraction-animal                         # caption(optional) z15- (also has icon z15-)
+# tourism-attraction-specified                      # caption(optional) z15- (also has icon z15-)
+# === -8800
+
+# amenity-community_centre                          # caption(optional) z16- (also has icon z16-)
+# tourism-artwork                                   # caption(optional) z15- (also has icon z15-)
+# tourism-artwork-architecture                      # caption(optional) z15- (also has icon z15-)
+# tourism-artwork-painting                          # caption(optional) z15- (also has icon z15-)
+# tourism-artwork-sculpture                         # caption(optional) z15- (also has icon z15-)
+# tourism-artwork-statue                            # caption(optional) z15- (also has icon z15-)
+# === -8850
+
+# amenity-cafe                                      # caption(optional) z15- (also has icon z15-)
+# amenity-theatre                                   # caption(optional) z15- (also has icon z15-)
+# === -8900
+
+# amenity-university                                # caption(optional) z15- (also has icon z15-)
+# === -8950
+
+# amenity-hospital                                  # caption(optional) z15- (also has icon z15-)
+# === -9000
+
+# amenity-charging_station-bicycle                  # caption(optional) z16- (also has icon z16-)
+# === -9150
+
+# historic-boundary_stone                           # caption(optional) z16- (also has icon z16-)
+# historic-gallows                                  # caption(optional) z16- (also has icon z16-)
+# historic-pillory                                  # caption(optional) z16- (also has icon z16-)
+# historic-ship                                     # caption(optional) z16- (also has icon z16-)
+# historic-tomb                                     # caption(optional) z16- (also has icon z16-)
+# historic-wayside_cross                            # caption(optional) z16- (also has icon z16-)
+# historic-wayside_shrine                           # caption(optional) z17- (also has icon z16-)
+# === -9200
+
+# amenity-restaurant                                # caption(optional) z16- (also has icon z16-)
+# === -9250
+
+# amenity-place_of_worship                          # caption(optional) z17- (also has icon z16-)
+# amenity-place_of_worship-buddhist                 # caption(optional) z17- (also has icon z16-)
+# amenity-place_of_worship-christian                # caption(optional) z17- (also has icon z16-)
+# amenity-place_of_worship-hindu                    # caption(optional) z17- (also has icon z16-)
+# amenity-place_of_worship-jewish                   # caption(optional) z17- (also has icon z16-)
+# amenity-place_of_worship-muslim                   # caption(optional) z17- (also has icon z16-)
+# amenity-place_of_worship-shinto                   # caption(optional) z17- (also has icon z16-)
+# amenity-place_of_worship-taoist                   # caption(optional) z17- (also has icon z16-)
+# === -9350
+
+# railway-subway_entrance                           # caption(optional) z17- (also has icon z16-)
+# railway-subway_entrance-adana                     # caption(optional) z17- (also has icon z16-)
+# railway-subway_entrance-algiers                   # caption(optional) z17- (also has icon z16-)
+# railway-subway_entrance-almaty                    # caption(optional) z17- (also has icon z16-)
+# railway-subway_entrance-amsterdam                 # caption(optional) z17- (also has icon z16-)
+# railway-subway_entrance-ankara                    # caption(optional) z17- (also has icon z16-)
+# railway-subway_entrance-athens                    # caption(optional) z17- (also has icon z16-)
+# railway-subway_entrance-baku                      # caption(optional) z17- (also has icon z16-)
+# railway-subway_entrance-bangkok                   # caption(optional) z17- (also has icon z16-)
+# railway-subway_entrance-barcelona                 # caption(optional) z17- (also has icon z16-)
+# railway-subway_entrance-beijing                   # caption(optional) z17- (also has icon z16-)
+# railway-subway_entrance-bengalore                 # caption(optional) z17- (also has icon z16-)
+# railway-subway_entrance-berlin                    # caption(optional) z17- (also has icon z16-)
+# railway-subway_entrance-bilbao                    # caption(optional) z17- (also has icon z16-)
+# railway-subway_entrance-brasilia                  # caption(optional) z17- (also has icon z16-)
+# railway-subway_entrance-brescia                   # caption(optional) z17- (also has icon z16-)
+# railway-subway_entrance-brussels                  # caption(optional) z17- (also has icon z16-)
+# railway-subway_entrance-bucharest                 # caption(optional) z17- (also has icon z16-)
+# railway-subway_entrance-budapest                  # caption(optional) z17- (also has icon z16-)
+# railway-subway_entrance-buenos_aires              # caption(optional) z17- (also has icon z16-)
+# railway-subway_entrance-bursa                     # caption(optional) z17- (also has icon z16-)
+# railway-subway_entrance-cairo                     # caption(optional) z17- (also has icon z16-)
+# railway-subway_entrance-caracas                   # caption(optional) z17- (also has icon z16-)
+# railway-subway_entrance-catania                   # caption(optional) z17- (also has icon z16-)
+# railway-subway_entrance-changchun                 # caption(optional) z17- (also has icon z16-)
+# railway-subway_entrance-chengdu                   # caption(optional) z17- (also has icon z16-)
+# railway-subway_entrance-chicago                   # caption(optional) z17- (also has icon z16-)
+# railway-subway_entrance-chongqing                 # caption(optional) z17- (also has icon z16-)
+# railway-subway_entrance-dalian                    # caption(optional) z17- (also has icon z16-)
+# railway-subway_entrance-delhi                     # caption(optional) z17- (also has icon z16-)
+# railway-subway_entrance-dnepro                    # caption(optional) z17- (also has icon z16-)
+# railway-subway_entrance-dubai                     # caption(optional) z17- (also has icon z16-)
+# railway-subway_entrance-ekb                       # caption(optional) z17- (also has icon z16-)
+# railway-subway_entrance-fukuoka                   # caption(optional) z17- (also has icon z16-)
+# railway-subway_entrance-glasgow                   # caption(optional) z17- (also has icon z16-)
+# railway-subway_entrance-guangzhou                 # caption(optional) z17- (also has icon z16-)
+# railway-subway_entrance-hamburg                   # caption(optional) z17- (also has icon z16-)
+# railway-subway_entrance-helsinki                  # caption(optional) z17- (also has icon z16-)
+# railway-subway_entrance-hiroshima                 # caption(optional) z17- (also has icon z16-)
+# railway-subway_entrance-isfahan                   # caption(optional) z17- (also has icon z16-)
+# railway-subway_entrance-istanbul                  # caption(optional) z17- (also has icon z16-)
+# railway-subway_entrance-izmir                     # caption(optional) z17- (also has icon z16-)
+# railway-subway_entrance-kazan                     # caption(optional) z17- (also has icon z16-)
+# railway-subway_entrance-kharkiv                   # caption(optional) z17- (also has icon z16-)
+# railway-subway_entrance-kiev                      # caption(optional) z17- (also has icon z16-)
+# railway-subway_entrance-kobe                      # caption(optional) z17- (also has icon z16-)
+# railway-subway_entrance-kolkata                   # caption(optional) z17- (also has icon z16-)
+# railway-subway_entrance-kunming                   # caption(optional) z17- (also has icon z16-)
+# railway-subway_entrance-kyoto                     # caption(optional) z17- (also has icon z16-)
+# railway-subway_entrance-la                        # caption(optional) z17- (also has icon z16-)
+# railway-subway_entrance-lausanne                  # caption(optional) z17- (also has icon z16-)
+# railway-subway_entrance-lille                     # caption(optional) z17- (also has icon z16-)
+# railway-subway_entrance-lima                      # caption(optional) z17- (also has icon z16-)
+# railway-subway_entrance-lisboa                    # caption(optional) z17- (also has icon z16-)
+# railway-subway_entrance-london                    # caption(optional) z17- (also has icon z16-)
+# railway-subway_entrance-lyon                      # caption(optional) z17- (also has icon z16-)
+# railway-subway_entrance-madrid                    # caption(optional) z17- (also has icon z16-)
+# railway-subway_entrance-malaga                    # caption(optional) z17- (also has icon z16-)
+# railway-subway_entrance-manila                    # caption(optional) z17- (also has icon z16-)
+# railway-subway_entrance-maracaibo                 # caption(optional) z17- (also has icon z16-)
+# railway-subway_entrance-mashhad                   # caption(optional) z17- (also has icon z16-)
+# railway-subway_entrance-mecca                     # caption(optional) z17- (also has icon z16-)
+# railway-subway_entrance-medellin                  # caption(optional) z17- (also has icon z16-)
+# railway-subway_entrance-mexico                    # caption(optional) z17- (also has icon z16-)
+# railway-subway_entrance-milan                     # caption(optional) z17- (also has icon z16-)
+# railway-subway_entrance-minsk                     # caption(optional) z17- (also has icon z16-)
+# railway-subway_entrance-montreal                  # caption(optional) z17- (also has icon z16-)
+# railway-subway_entrance-moscow                    # caption(optional) z16- (also has icon z16-)
+# railway-subway_entrance-munchen                   # caption(optional) z17- (also has icon z16-)
+# railway-subway_entrance-nagoya                    # caption(optional) z17- (also has icon z16-)
+# railway-subway_entrance-newyork                   # caption(optional) z17- (also has icon z16-)
+# railway-subway_entrance-nnov                      # caption(optional) z17- (also has icon z16-)
+# railway-subway_entrance-novosibirsk               # caption(optional) z17- (also has icon z16-)
+# railway-subway_entrance-osaka                     # caption(optional) z17- (also has icon z16-)
+# railway-subway_entrance-oslo                      # caption(optional) z17- (also has icon z16-)
+# railway-subway_entrance-palma                     # caption(optional) z17- (also has icon z16-)
+# railway-subway_entrance-panama                    # caption(optional) z17- (also has icon z16-)
+# railway-subway_entrance-paris                     # caption(optional) z17- (also has icon z16-)
+# railway-subway_entrance-philadelphia              # caption(optional) z17- (also has icon z16-)
+# railway-subway_entrance-pyongyang                 # caption(optional) z17- (also has icon z16-)
+# railway-subway_entrance-rennes                    # caption(optional) z17- (also has icon z16-)
+# railway-subway_entrance-rio                       # caption(optional) z17- (also has icon z16-)
+# railway-subway_entrance-roma                      # caption(optional) z17- (also has icon z16-)
+# railway-subway_entrance-rotterdam                 # caption(optional) z17- (also has icon z16-)
+# railway-subway_entrance-samara                    # caption(optional) z17- (also has icon z16-)
+# railway-subway_entrance-santiago                  # caption(optional) z17- (also has icon z16-)
+# railway-subway_entrance-santo_domingo             # caption(optional) z17- (also has icon z16-)
+# railway-subway_entrance-saopaulo                  # caption(optional) z17- (also has icon z16-)
+# railway-subway_entrance-sapporo                   # caption(optional) z17- (also has icon z16-)
+# railway-subway_entrance-sendai                    # caption(optional) z17- (also has icon z16-)
+# railway-subway_entrance-sf                        # caption(optional) z17- (also has icon z16-)
+# railway-subway_entrance-shanghai                  # caption(optional) z17- (also has icon z16-)
+# railway-subway_entrance-shiraz                    # caption(optional) z17- (also has icon z16-)
+# railway-subway_entrance-sofia                     # caption(optional) z17- (also has icon z16-)
+# railway-subway_entrance-spb                       # caption(optional) z16- (also has icon z16-)
+# railway-subway_entrance-stockholm                 # caption(optional) z17- (also has icon z16-)
+# railway-subway_entrance-tabriz                    # caption(optional) z17- (also has icon z16-)
+# railway-subway_entrance-taipei                    # caption(optional) z17- (also has icon z16-)
+# railway-subway_entrance-taoyuan                   # caption(optional) z17- (also has icon z16-)
+# railway-subway_entrance-tashkent                  # caption(optional) z17- (also has icon z16-)
+# railway-subway_entrance-tbilisi                   # caption(optional) z17- (also has icon z16-)
+# railway-subway_entrance-tehran                    # caption(optional) z17- (also has icon z16-)
+# railway-subway_entrance-tianjin                   # caption(optional) z17- (also has icon z16-)
+# railway-subway_entrance-tokyo                     # caption(optional) z17- (also has icon z16-)
+# railway-subway_entrance-valencia                  # caption(optional) z17- (also has icon z16-)
+# railway-subway_entrance-vienna                    # caption(optional) z17- (also has icon z16-)
+# railway-subway_entrance-warszawa                  # caption(optional) z17- (also has icon z16-)
+# railway-subway_entrance-washington                # caption(optional) z17- (also has icon z16-)
+# railway-subway_entrance-wuhan                     # caption(optional) z17- (also has icon z16-)
+# railway-subway_entrance-yerevan                   # caption(optional) z17- (also has icon z16-)
+# railway-subway_entrance-yokohama                  # caption(optional) z17- (also has icon z16-)
+# === -9450
+
+# amenity-parking-no-access                         # caption(optional) z16- (also has icon z15-, area z15-)
+# amenity-parking-private                           # caption(optional) z17- (also has icon z17-, area z15-)
+# === -9500
+
+# railway-tram_stop                                 # caption(optional) z17- (also has icon z17-)
+# === -9600
+
+# historic-memorial-cross                           # caption(optional) z17- (also has icon z17-)
+# === -9650
+
+# amenity-arts_centre                               # caption(optional) z17- (also has icon z17-)
+# historic-archaeological_site                      # caption(optional) z17- (also has icon z17-)
+# historic-ruins                                    # caption(optional) z17- (also has icon z17-)
+# === -9700
+
+# amenity-fast_food                                 # caption(optional) z17- (also has icon z17-)
+# === -9750
+
+# amenity-bank                                      # caption(optional) z17- (also has icon z17-)
+# amenity-parcel_locker                             # caption(optional) z17- (also has icon z17-)
+# amenity-post_office                               # caption(optional) z17- (also has icon z17-)
+# === -9800
+
+# leisure-park-no-access                            # caption(optional) z14- (also has icon z14-, area z10-)
+# leisure-park-private                              # caption(optional) z14- (also has icon z14-, area z10-)
+# === -9900


### PR DESCRIPTION
Depends on: https://github.com/organicmaps/kothic/pull/18

Optional captions with automatically set priorities and automatic casing lines with an auto -1 priorities are all visible in priorities files now. So now icons could be placed in-between or after them easily.

There are no actual priority changes here.