### PR TITLE
Removed annoying zoom in route planning mode

### DIFF
--- a/map/routing_manager.cpp
+++ b/map/routing_manager.cpp
@@ -999,11 +999,14 @@ void RoutingManager::BuildRoute(uint32_t timeoutSec)
   if (IsRoutingActive())
     CloseRouting(false /* remove route points */);
 
-  // Show preview.
-  m2::RectD rect = ShowPreviewSegments(routePoints);
-  rect.Scale(kRouteScaleMultiplier);
-  m_drapeEngine.SafeCall(&df::DrapeEngine::SetModelViewRect, rect, true /* applyRotation */,
-                         -1 /* zoom */, true /* isAnim */, true /* useVisibleViewport */);
+  // Route points preview.
+  // Disabled preview zoom to fix https://github.com/organicmaps/organicmaps/issues/5409.
+  // Uncomment next lines to enable back zoom on route point add/remove.
+
+  //m2::RectD rect = ShowPreviewSegments(routePoints);
+  //rect.Scale(kRouteScaleMultiplier);
+  //m_drapeEngine.SafeCall(&df::DrapeEngine::SetModelViewRect, rect, true /* applyRotation */,
+  //                       -1 /* zoom */, true /* isAnim */, true /* useVisibleViewport */);
 
   m_routingSession.ClearPositionAccumulator();
   m_routingSession.SetUserCurrentPosition(routePoints.front().m_position);


### PR DESCRIPTION
When new point added/removed OM zooms to show all route points.

Removed this zoom. Only final zoom left (after route build finishes):

| Before | After |
| ---- | ---- |
| <video src="https://github.com/organicmaps/organicmaps/assets/720808/17164931-c59c-4ca8-8e50-02dee8da54a5"/> | <video src="https://github.com/organicmaps/organicmaps/assets/720808/5e617120-4ec3-4337-b0fd-b8cf577c41ba" />|

Closes #5409