### PR TITLE
[drape] Fix map style not updating automatically on Android with Vulkan

### DIFF
--- a/drape_frontend/base_renderer.hpp
+++ b/drape_frontend/base_renderer.hpp
@@ -52,6 +52,8 @@ public:
 
   bool IsRenderingEnabled() const;
 
+  dp::ApiVersion GetApiVersion() const { return m_apiVersion; };
+
 protected:
   dp::ApiVersion m_apiVersion;
   ref_ptr<ThreadsCommutator> m_commutator;

--- a/drape_frontend/drape_engine.hpp
+++ b/drape_frontend/drape_engine.hpp
@@ -248,6 +248,8 @@ public:
 
   void SetCustomArrow3d(std::optional<Arrow3dCustomDecl> arrow3dCustomDecl);
 
+  dp::ApiVersion GetApiVersion() const { return m_frontend->GetApiVersion(); };
+
 private:
   void AddUserEvent(drape_ptr<UserEvent> && e);
   void PostUserEvent(drape_ptr<UserEvent> && e);

--- a/map/framework.cpp
+++ b/map/framework.cpp
@@ -2612,7 +2612,13 @@ bool Framework::ParseDrapeDebugCommand(string const & query)
   if (desiredStyle != MapStyleCount)
   {
 #if defined(OMIM_OS_ANDROID)
-    MarkMapStyle(desiredStyle);
+    if (m_drapeEngine->GetApiVersion() == dp::ApiVersion::Vulkan)
+    {
+      // See comment in android/jni/app/organicmaps/Framework.cpp Framework::MarkMapStyle().
+      SetMapStyle(desiredStyle);
+    }
+    else
+      MarkMapStyle(desiredStyle);
 #else
     SetMapStyle(desiredStyle);
 #endif


### PR DESCRIPTION
When Vulkan rendering is used and e.g. `?vlight` entered in search the screen doesn't update to the new style until e.g. zoom level is changed. It doesn't happen with OGL.

This fixes it for Vulkan by forcing map style update.