### PR TITLE
[bookmarks][android] Remove max limit of searchable bookmarks

### DIFF
--- a/android/app/src/main/cpp/app/organicmaps/bookmarks/data/BookmarkManager.cpp
+++ b/android/app/src/main/cpp/app/organicmaps/bookmarks/data/BookmarkManager.cpp
@@ -563,13 +563,6 @@ Java_app_organicmaps_bookmarks_data_BookmarkManager_nativeIsUsedCategoryName(
   return static_cast<jboolean>(frm()->GetBookmarkManager().IsUsedCategoryName(ToNativeString(env, name)));
 }
 
-JNIEXPORT jboolean JNICALL
-Java_app_organicmaps_bookmarks_data_BookmarkManager_nativeIsSearchAllowed(
-        JNIEnv *, jclass, jlong catId)
-{
-  return static_cast<jboolean>(frm()->GetBookmarkManager().IsSearchAllowed(static_cast<kml::MarkGroupId>(catId)));
-}
-
 JNIEXPORT void JNICALL
 Java_app_organicmaps_bookmarks_data_BookmarkManager_nativePrepareForSearch(
         JNIEnv *, jclass, jlong catId)

--- a/android/app/src/main/java/app/organicmaps/bookmarks/BookmarksListFragment.java
+++ b/android/app/src/main/java/app/organicmaps/bookmarks/BookmarksListFragment.java
@@ -297,7 +297,7 @@ public class BookmarksListFragment extends BaseMwmRecyclerFragment<ConcatAdapter
 
   private void updateSearchVisibility()
   {
-    if (isEmpty() || !isSearchAllowed())
+    if (isEmpty())
     {
       UiUtils.hide(mSearchContainer);
     }
@@ -533,12 +533,6 @@ public class BookmarksListFragment extends BaseMwmRecyclerFragment<ConcatAdapter
            && getBookmarkListAdapter().getItemCount() == 0;
   }
 
-  private boolean isSearchAllowed()
-  {
-    BookmarkCategory category = mCategoryDataSource.getData();
-    return BookmarkManager.INSTANCE.isSearchAllowed(category.getId());
-  }
-
   private boolean isLastOwnedCategory()
   {
     return BookmarkManager.INSTANCE.getCategories().size() == 1;
@@ -636,7 +630,7 @@ public class BookmarksListFragment extends BaseMwmRecyclerFragment<ConcatAdapter
     inflater.inflate(R.menu.option_menu_bookmarks, menu);
 
     MenuItem itemSearch = menu.findItem(R.id.bookmarks_search);
-    itemSearch.setVisible(!isEmpty() && isSearchAllowed());
+    itemSearch.setVisible(!isEmpty());
   }
 
   @Override
@@ -646,7 +640,7 @@ public class BookmarksListFragment extends BaseMwmRecyclerFragment<ConcatAdapter
 
     boolean visible = !mSearchMode && !isEmpty();
     MenuItem itemSearch = menu.findItem(R.id.bookmarks_search);
-    itemSearch.setVisible(visible && isSearchAllowed());
+    itemSearch.setVisible(visible);
 
     MenuItem itemMore = menu.findItem(R.id.bookmarks_more);
     if (mLastSortTimestamp != 0)

--- a/android/app/src/main/java/app/organicmaps/bookmarks/data/BookmarkManager.java
+++ b/android/app/src/main/java/app/organicmaps/bookmarks/data/BookmarkManager.java
@@ -537,8 +537,6 @@ public enum BookmarkManager
     return nativeIsUsedCategoryName(name);
   }
 
-  public boolean isSearchAllowed(long catId) { return nativeIsSearchAllowed(catId); }
-
   public void prepareForSearch(long catId) { nativePrepareForSearch(catId); }
 
   public boolean areAllCategoriesVisible()
@@ -802,8 +800,6 @@ public enum BookmarkManager
   private static native boolean nativeIsAsyncBookmarksLoadingInProgress();
 
   private static native boolean nativeIsUsedCategoryName(@NonNull String name);
-
-  private static native boolean nativeIsSearchAllowed(long catId);
 
   private static native void nativePrepareForSearch(long catId);
 

--- a/map/bookmark_manager.cpp
+++ b/map/bookmark_manager.cpp
@@ -1497,30 +1497,6 @@ bool BookmarkManager::IsVisible(kml::MarkGroupId groupId) const
   return GetGroup(groupId)->IsVisible();
 }
 
-bool BookmarkManager::IsSearchAllowed(kml::MarkGroupId groupId) const
-{
-  CHECK_THREAD_CHECKER(m_threadChecker, ());
-  CHECK(m_callbacks.m_getSearchAPI != nullptr, ());
-  auto & searchAPI = m_callbacks.m_getSearchAPI();
-
-  if (searchAPI.IsIndexingOfBookmarkGroupEnabled(groupId))
-    return true;
-
-  size_t indexedBookmarksCount = 0;
-  for (auto const indexableGroupId : searchAPI.GetIndexableGroups())
-  {
-    auto const it = m_categories.find(indexableGroupId);
-    if (it != m_categories.end())
-      indexedBookmarksCount += it->second->GetUserMarks().size();
-  }
-
-  /// @todo This function is actually called on Android only. Probably, there was some problems
-  /// with indexing large sets of bookmarks, but iOS works good at the same time?
-  auto const bookmarksCount = GetUserMarkIds(groupId).size();
-  auto const maxCount = SearchAPI::GetMaximumPossibleNumberOfBookmarksToIndex();
-  return indexedBookmarksCount + bookmarksCount <= maxCount;
-}
-
 void BookmarkManager::PrepareForSearch(kml::MarkGroupId groupId)
 {
   CHECK_THREAD_CHECKER(m_threadChecker, ());

--- a/map/bookmark_manager.hpp
+++ b/map/bookmark_manager.hpp
@@ -260,7 +260,6 @@ public:
   void SetLastSortingType(kml::MarkGroupId groupId, SortingType sortingType);
   void ResetLastSortingType(kml::MarkGroupId groupId);
 
-  bool IsSearchAllowed(kml::MarkGroupId groupId) const;
   void PrepareForSearch(kml::MarkGroupId groupId);
 
   bool IsVisible(kml::MarkGroupId groupId) const;

--- a/map/search_api.cpp
+++ b/map/search_api.cpp
@@ -31,8 +31,6 @@ using BookmarkIdDoc = pair<bookmarks::Id, bookmarks::Doc>;
 double const kDistEqualQueryMeters = 100.0;
 double const kDistEqualQueryMercator = mercator::MetersToMercator(kDistEqualQueryMeters);
 
-size_t const kMaximumPossibleNumberOfBookmarksToIndex = 5000;
-
 // Cancels search query by |handle|.
 void CancelQuery(weak_ptr<ProcessorHandle> & handle)
 {
@@ -321,12 +319,6 @@ void SearchAPI::EnableIndexingOfBookmarksDescriptions(bool enable)
   m_engine.EnableIndexingOfBookmarksDescriptions(enable);
 }
 
-// static
-size_t SearchAPI::GetMaximumPossibleNumberOfBookmarksToIndex()
-{
-  return kMaximumPossibleNumberOfBookmarksToIndex;
-}
-
 void SearchAPI::EnableIndexingOfBookmarkGroup(kml::MarkGroupId const & groupId, bool enable)
 {
   if (enable)
@@ -335,11 +327,6 @@ void SearchAPI::EnableIndexingOfBookmarkGroup(kml::MarkGroupId const & groupId, 
     m_indexableGroups.erase(groupId);
 
   m_engine.EnableIndexingOfBookmarkGroup(KmlGroupIdToSearchGroupId(groupId), enable);
-}
-
-bool SearchAPI::IsIndexingOfBookmarkGroupEnabled(kml::MarkGroupId const & groupId)
-{
-  return m_indexableGroups.count(groupId) > 0;
 }
 
 unordered_set<kml::MarkGroupId> const & SearchAPI::GetIndexableGroups() const

--- a/map/search_api.hpp
+++ b/map/search_api.hpp
@@ -118,18 +118,11 @@ public:
 
   void EnableIndexingOfBookmarksDescriptions(bool enable);
 
-  // A hint on the maximum number of bookmarks that can be stored in the
-  // search index for bookmarks. It is advisable that the client send
-  // OnBookmarksDeleted if the limit is crossed.
-  // The limit is not enforced by the Search API.
-  static size_t GetMaximumPossibleNumberOfBookmarksToIndex();
-
   // By default all created bookmarks are saved in BookmarksProcessor
   // but we do not index them in an attempt to save time and memory.
   // This method must be used to enable or disable indexing all current and future
   // bookmarks belonging to |groupId|.
   void EnableIndexingOfBookmarkGroup(kml::MarkGroupId const & groupId, bool enable);
-  bool IsIndexingOfBookmarkGroupEnabled(kml::MarkGroupId const & groupId);
   std::unordered_set<kml::MarkGroupId> const & GetIndexableGroups() const;
 
   // Returns the bookmarks search to its default, pre-launch state.


### PR DESCRIPTION
Closes #5544 

It looks like this limit was originally placed for performance reasons (though I do not know why only on Android) but it is clear that this limit does not make much sense currently. Indexing and searching through 5000+ bookmarks should not crash a device given that this restriction didn't even apply to the iPhone in the first place without any problems.