### PR TITLE
[styles] Use a ': none;' syntax for disabling area and icon drules

### DIFF
--- a/data/styles/clear/include/Icons.mapcss
+++ b/data/styles/clear/include/Icons.mapcss
@@ -556,7 +556,7 @@ node|z15-18[historic=memorial][memorial=stolperstein],
 area|z15-18[historic=memorial][memorial=stolperstein],
 node|z15-16[historic=memorial][memorial=cross],
 area|z15-16[historic=memorial][memorial=cross],
-{icon-image: ; text: none;}
+{icon-image: none; text: none;}
 
 node|z18-[historic=memorial][memorial=plaque],
 area|z18-[historic=memorial][memorial=plaque],
@@ -2526,7 +2526,7 @@ area|z16-[amenity=parking][parking=lane],
 /* =no doesn't work in kothic */
 /* node|z16-[amenity=parking][access=no], */
 /* area|z16-[amenity=parking][access=no], */
-{icon-image: ;icon-min-distance: 0;}
+{icon-image: none; icon-min-distance: 0;}
 
 node|z16-[amenity=parking][fee?],
 area|z16-[amenity=parking][fee?],
@@ -2546,7 +2546,7 @@ area|z17-[amenity=parking_entrance],
 {icon-image: parking_entrance-m.svg;}
 node|z17-[amenity=parking_entrance][access=private],
 area|z17-[amenity=parking_entrance][access=private],
-{icon-image: ;text: none;}
+{icon-image: none; text: none;}
 
 node|z18-[amenity=parking][access=private],
 area|z18-[amenity=parking][access=private],

--- a/data/styles/vehicle/include/Icons.mapcss
+++ b/data/styles/vehicle/include/Icons.mapcss
@@ -324,7 +324,7 @@ node|z15-[historic=memorial][memorial=stolperstein],
 area|z15-[historic=memorial][memorial=stolperstein],
 node|z15-16[historic=memorial][memorial=cross],
 area|z15-16[historic=memorial][memorial=cross],
-{icon-image: ; text: none;}
+{icon-image: none; text: none;}
 
 node|z17-[historic=memorial][memorial=cross],
 area|z17-[historic=memorial][memorial=cross],
@@ -900,7 +900,7 @@ node|z15-[amenity=parking][parking=street_side],
 area|z15-[amenity=parking][parking=street_side],
 node|z15-[amenity=parking][parking=lane],
 area|z15-[amenity=parking][parking=lane],
-{icon-image: ;text: none;}
+{icon-image: none; text: none;}
 
 node|z15-[amenity=parking][fee?],
 area|z15-[amenity=parking][fee?],
@@ -921,7 +921,7 @@ area|z16-[amenity=parking_entrance],
 {icon-image: parking_entrance-m.svg; font-size: 12.5;}
 node|z16-[amenity=parking_entrance][access=private],
 area|z16-[amenity=parking_entrance][access=private],
-{icon-image: ;}
+{icon-image: none;}
 
 node|z17-[amenity=motorcycle_parking],
 area|z17-[amenity=motorcycle_parking],


### PR DESCRIPTION
`icon-image: none;` for icons
`fill-color: none;` for areas
(for lines its remains `width: 0;` and `text: none;` for captions)

Kothic change: https://github.com/organicmaps/kothic/pull/19