### PR TITLE
[strings] Use of generic on/off/auto/always/never strings

### DIFF
--- a/android/app/src/main/res/values-ar/strings.xml
+++ b/android/app/src/main/res/values-ar/strings.xml
@@ -215,12 +215,12 @@
 	<string name="pref_zoom_summary">عرض على الشاشة</string>
 	<!-- Settings «Map» category: «Night style» title -->
 	<string name="pref_map_style_title">الوضع الليلي</string>
-	<!-- «Map style» entry value -->
-	<string name="pref_map_style_default">تعطيل</string>
-	<!-- «Map style» entry value -->
-	<string name="pref_map_style_night">تشغيل</string>
-	<!-- «Map style» entry value -->
-	<string name="pref_map_style_auto">تلقائي</string>
+	<!-- Generic «Off» string -->
+	<string name="off">تعطيل</string>
+	<!-- Generic «On» string -->
+	<string name="on">تشغيل</string>
+	<!-- Generic «Auto» string -->
+	<string name="auto">تلقائي</string>
 	<!-- Settings «Map» category: «Perspective view» title -->
 	<string name="pref_map_3d_title">العرض المنظوري</string>
 	<!-- Settings «Map» category: «3D buildings» title -->
@@ -564,8 +564,6 @@
 	<string name="enable_logging">تفعيل التسجيل</string>
 	<!-- Settings: "Send general feedback" button -->
 	<string name="feedback_general">تعقيب عام</string>
-	<string name="on">تشغيل</string>
-	<string name="off">إيقاف</string>
 	<string name="prefs_languages_information">نحن نستخدم نظام تحويل النص إلى كلام (TTS) للتعليمات الصوتية. تستخدم العديد من أجهزة أندرويد نظام Google TTS، يمكنك تنزيله من أو تحديثه من متجر Play (https://play.google.com/store/apps/details?id=com.google.android.tts)</string>
 	<string name="prefs_languages_information_off">بالنسبة لبعض اللغات، ستحتاج إلى تنزيل تطبيق تحويل النص إلى كلام أو حزمة لغات إضافية من متجر التطبيقات(متجر Play، Galaxy Store، App Gallery، FDroid(.\nافتح إعدادات جهازك ثم اللغة والإدخال ثم تحويل النص إلى كلام.\nهنا يمكنك إدارة الإعدادات لأنظمة تحويل النص إلى كلا(على سبيل المثال، تنزيل حزمة اللغة للاستجدام دون اتصال انترنيت)</string>
 	<string name="prefs_languages_information_off_link">لمزيد من المعلومات الرجاء مراجعة هذا الدليل.</string>
@@ -632,9 +630,10 @@
 	<string name="bookmark_list_description_hint">اكتب وصفًا (نص أو html)</string>
 	<string name="not_shared">خاص</string>
 	<string name="speedcams_alert_title">تحذيرات كاميرات السرعة</string>
-	<string name="speedcam_option_auto">تلفائياً</string>
-	<string name="speedcam_option_always">مفعل دائماً</string>
-	<string name="speedcam_option_never">معطل دائماً</string>
+	<!-- Generic «Always» string -->
+	<string name="always">مفعل دائماً</string>
+	<!-- Generic «Never» string -->
+	<string name="never">معطل دائماً</string>
 	<string name="place_description_title">وصف المكان</string>
 	<!-- this text will be shown in application notification preferences opposite checkbox which enable/disable downloader notifications. Devices on Android 8+ are affected. -->
 	<string name="notification_channel_downloader">مُنزّل الخريطة</string>

--- a/android/app/src/main/res/values-be/strings.xml
+++ b/android/app/src/main/res/values-be/strings.xml
@@ -213,12 +213,12 @@
 	<string name="pref_zoom_summary">Паказаць на мапе</string>
 	<!-- Settings «Map» category: «Night style» title -->
 	<string name="pref_map_style_title">Начны рэжым</string>
-	<!-- «Map style» entry value -->
-	<string name="pref_map_style_default">Выключаны</string>
-	<!-- «Map style» entry value -->
-	<string name="pref_map_style_night">Уключаны</string>
-	<!-- «Map style» entry value -->
-	<string name="pref_map_style_auto">Аўтаматычна</string>
+	<!-- Generic «Off» string -->
+	<string name="off">Выключаны</string>
+	<!-- Generic «On» string -->
+	<string name="on">Уключаны</string>
+	<!-- Generic «Auto» string -->
+	<string name="auto">Аўтаматычна</string>
 	<!-- Settings «Map» category: «Perspective view» title -->
 	<string name="pref_map_3d_title">Перспектыўны выгляд</string>
 	<!-- Settings «Map» category: «3D buildings» title -->
@@ -553,8 +553,6 @@
 	<string name="enable_logging">Уключыць вядзенне журналу</string>
 	<!-- Settings: "Send general feedback" button -->
 	<string name="feedback_general">Агульны водгук</string>
-	<string name="on">Укл.</string>
-	<string name="off">Выкл.</string>
 	<string name="prefs_languages_information">Мы ужываем сістэмны сінтэзатар маўлення (TTS). Многія прылады на Android ужываюць Google TTS, вы можаце спампаваць або абнавіць яго праз Google Play (https://play.google.com/store/apps/details?id=com.google.android.tts)</string>
 	<string name="prefs_languages_information_off">Для некаторых моў вам спатрэбіцца ўсталяваць сінтэзатар маўлення або дадатковы моўны пакет з крамы праграм (Google Play, Galaxy Store, App Gallery, F-Droid).\Зайдзіце на вашай прыладзе ў Налады → Мова і ўвод → Маўленне → Сінтэз маўлення.\nТут вы можаце задаць налады сінтэза маўлення (напрыклад, спампаваць моўны пакет для выкарыстання без падключэння да інтэрнэту) або выбраць іншы сінтэзатар маўлення.</string>
 	<string name="prefs_languages_information_off_link">Больш падрабязная інфармацыя знаходзіцца ў гэтым кіраўніцтве.</string>
@@ -624,9 +622,10 @@
 	<string name="bookmark_list_description_hint">Дабаўце апісанне (тэкст альбо html)</string>
 	<string name="not_shared">Прыватны</string>
 	<string name="speedcams_alert_title">Камеры хуткасці</string>
-	<string name="speedcam_option_auto">Аўтаматычна</string>
-	<string name="speedcam_option_always">Заўсёды</string>
-	<string name="speedcam_option_never">Ніколі</string>
+	<!-- Generic «Always» string -->
+	<string name="always">Заўсёды</string>
+	<!-- Generic «Never» string -->
+	<string name="never">Ніколі</string>
 	<string name="place_description_title">Апісанне месца</string>
 	<!-- this text will be shown in application notification preferences opposite checkbox which enable/disable downloader notifications. Devices on Android 8+ are affected. -->
 	<string name="notification_channel_downloader">Спампоўка мапаў</string>

--- a/android/app/src/main/res/values-bg/strings.xml
+++ b/android/app/src/main/res/values-bg/strings.xml
@@ -202,12 +202,12 @@
 	<string name="pref_zoom_summary">Показване на картата</string>
 	<!-- Settings «Map» category: «Night style» title -->
 	<string name="pref_map_style_title">Нощен режим</string>
-	<!-- «Map style» entry value -->
-	<string name="pref_map_style_default">Изключен</string>
-	<!-- «Map style» entry value -->
-	<string name="pref_map_style_night">Включен</string>
-	<!-- «Map style» entry value -->
-	<string name="pref_map_style_auto">Автоматично</string>
+	<!-- Generic «Off» string -->
+	<string name="off">Изключен</string>
+	<!-- Generic «On» string -->
+	<string name="on">Включен</string>
+	<!-- Generic «Auto» string -->
+	<string name="auto">Автоматично</string>
 	<!-- Settings «Map» category: «Perspective view» title -->
 	<string name="pref_map_3d_title">Перспективен изглед</string>
 	<!-- Settings «Map» category: «3D buildings» title -->
@@ -515,8 +515,6 @@
 	<string name="enable_logging">Активиране на запис на дневник</string>
 	<!-- Settings: "Send general feedback" button -->
 	<string name="feedback_general">Обща обратна връзка</string>
-	<string name="on">Вкл.</string>
-	<string name="off">Изкл.</string>
 	<string name="prefs_languages_information">Навигирането се озвучава от системен синтезатор на реч (TTS). Много устройства използват Google TTS, който може да бъде изтеглен или актуализиран от Google Play (https://play.google.com/store/apps/details?id=com.google.android.tts).</string>
 	<string name="prefs_languages_information_off">За някои езици може да се наложи да инсталирате допълнителен синтезатор на реч (TTS) от магазина за приложения (Google Play Магазин, Galaxy Store).\nЗа да настроите синтезатора на реч, отидете в Настройки → Езици и въвеждане → Синтезиран говор.\nТук можете да инсталирате допълнителни езикови пакети или да изберете синтезатор на реч.</string>
 	<string name="prefs_languages_information_off_link">За повече информация вижте това ръководство.</string>
@@ -586,9 +584,10 @@
 	<string name="bookmark_list_description_hint">Добавяне на описание (текст или html)</string>
 	<string name="not_shared">Лично</string>
 	<string name="speedcams_alert_title">Камери за скорост</string>
-	<string name="speedcam_option_auto">Автоматично</string>
-	<string name="speedcam_option_always">Винаги</string>
-	<string name="speedcam_option_never">Никога</string>
+	<!-- Generic «Always» string -->
+	<string name="always">Винаги</string>
+	<!-- Generic «Never» string -->
+	<string name="never">Никога</string>
 	<string name="place_description_title">Описание на мястото</string>
 	<!-- this text will be shown in application notification preferences opposite checkbox which enable/disable downloader notifications. Devices on Android 8+ are affected. -->
 	<string name="notification_channel_downloader">Изтегляне на карти</string>

--- a/android/app/src/main/res/values-ca/strings.xml
+++ b/android/app/src/main/res/values-ca/strings.xml
@@ -204,12 +204,12 @@
 	<string name="pref_zoom_summary">Mostra\'ls al mapa</string>
 	<!-- Settings «Map» category: «Night style» title -->
 	<string name="pref_map_style_title">Mode nocturn</string>
-	<!-- «Map style» entry value -->
-	<string name="pref_map_style_default">Desactivat</string>
-	<!-- «Map style» entry value -->
-	<string name="pref_map_style_night">Activat</string>
-	<!-- «Map style» entry value -->
-	<string name="pref_map_style_auto">Automàtic</string>
+	<!-- Generic «Off» string -->
+	<string name="off">Desactivat</string>
+	<!-- Generic «On» string -->
+	<string name="on">Activat</string>
+	<!-- Generic «Auto» string -->
+	<string name="auto">Automàtic</string>
 	<!-- Settings «Map» category: «Perspective view» title -->
 	<string name="pref_map_3d_title">Vista en perspectiva</string>
 	<!-- Settings «Map» category: «3D buildings» title -->
@@ -548,8 +548,6 @@
 	<string name="enable_logging">Activa el registre</string>
 	<!-- Settings: "Send general feedback" button -->
 	<string name="feedback_general">Opinió general</string>
-	<string name="on">Actiu</string>
-	<string name="off">Inactiu</string>
 	<string name="prefs_languages_information">Usem el sistema de síntesi de veu per a les instruccions de veu. Molts aparells Android use el motor de síntesi de veu de Google, podeu baixar o actualitzar-lo des del Google Play (https://play.google.com/store/apps/details?id=com.google.android.tts)</string>
 	<string name="prefs_languages_information_off">Per a algunes llengües, haureu d\'instal·lar un sintetizador de veu o un paquet de llengua addicional des de la botiga d\'apliacions (Google Play, Galazy Store, FDroid).\nObriu la configuració de l\'aparell → Idioma i entrada → Veu → Sortidda de text a veu.\nAquí podeu gestionar la configuració de la síntesi de veu (per exemple, baixar un paquet de llengua per a ús sense connexió) i triar un altre motor de síntesi de veu.</string>
 	<string name="prefs_languages_information_off_link">Per a més informació, vegeu aquesta guia.</string>
@@ -620,9 +618,10 @@
 	<string name="bookmark_list_description_hint">Escriviu una descripció (text o html)</string>
 	<string name="not_shared">Privat</string>
 	<string name="speedcams_alert_title">Radars</string>
-	<string name="speedcam_option_auto">Automàtic</string>
-	<string name="speedcam_option_always">Sempre</string>
-	<string name="speedcam_option_never">Mai</string>
+	<!-- Generic «Always» string -->
+	<string name="always">Sempre</string>
+	<!-- Generic «Never» string -->
+	<string name="never">Mai</string>
 	<string name="place_description_title">Descripció del lloc</string>
 	<!-- this text will be shown in application notification preferences opposite checkbox which enable/disable downloader notifications. Devices on Android 8+ are affected. -->
 	<string name="notification_channel_downloader">Descàrrega de mapes</string>

--- a/android/app/src/main/res/values-cs/strings.xml
+++ b/android/app/src/main/res/values-cs/strings.xml
@@ -199,12 +199,12 @@
 	<string name="pref_zoom_summary">Zobrazit na obrazovce</string>
 	<!-- Settings «Map» category: «Night style» title -->
 	<string name="pref_map_style_title">Noční režim</string>
-	<!-- «Map style» entry value -->
-	<string name="pref_map_style_default">Vypnuto</string>
-	<!-- «Map style» entry value -->
-	<string name="pref_map_style_night">Zapnuto</string>
-	<!-- «Map style» entry value -->
-	<string name="pref_map_style_auto">Automaticky</string>
+	<!-- Generic «Off» string -->
+	<string name="off">Vypnuto</string>
+	<!-- Generic «On» string -->
+	<string name="on">Zapnuto</string>
+	<!-- Generic «Auto» string -->
+	<string name="auto">Automaticky</string>
 	<!-- Settings «Map» category: «Perspective view» title -->
 	<string name="pref_map_3d_title">Zobrazení perspektivy</string>
 	<!-- Settings «Map» category: «3D buildings» title -->
@@ -532,8 +532,6 @@
 	<string name="enable_logging">Povolit protokolování</string>
 	<!-- Settings: "Send general feedback" button -->
 	<string name="feedback_general">Všeobecné připomínky</string>
-	<string name="on">Zapnout</string>
-	<string name="off">Vypnout</string>
 	<string name="prefs_languages_information">Pro hlasové pokyny používáme systém TTS. Mnoho zařízení se systémem Android používá Google TTS, můžete si ho stáhnout nebo aktualizovat na Google Play (https://play.google.com/store/apps/details?id=com.google.android.tts)</string>
 	<string name="prefs_languages_information_off">U některých jazyků je třeba nainstalovat jiný hlasový syntetizátor nebo další jazykové sady z obchodu s aplikacemi (Google Play, Galaxy Store, App Gallery, FDroid).\nOtevřete nastavení vašeho zařízení → Jazyky a zadávání → Hlasové zadávání → Převod textu na řeč. \nZde můžete spravovat nastavení pro syntézu řeči (například stáhnout jazykový balíček pro použití offline) a vybrat jiný modul převodu textu na řeč.</string>
 	<string name="prefs_languages_information_off_link">Více informací najdete v tomto návodu.</string>
@@ -602,9 +600,10 @@
 	<string name="bookmark_list_description_hint">Přidejte popis (text nebo html)</string>
 	<string name="not_shared">Osobní účet</string>
 	<string name="speedcams_alert_title">Detektory rychlosti</string>
-	<string name="speedcam_option_auto">Automaticky</string>
-	<string name="speedcam_option_always">Vždy</string>
-	<string name="speedcam_option_never">Nikdy</string>
+	<!-- Generic «Always» string -->
+	<string name="always">Vždy</string>
+	<!-- Generic «Never» string -->
+	<string name="never">Nikdy</string>
 	<string name="place_description_title">Popis místa</string>
 	<!-- this text will be shown in application notification preferences opposite checkbox which enable/disable downloader notifications. Devices on Android 8+ are affected. -->
 	<string name="notification_channel_downloader">Nahrávání map</string>

--- a/android/app/src/main/res/values-da/strings.xml
+++ b/android/app/src/main/res/values-da/strings.xml
@@ -195,12 +195,12 @@
 	<string name="pref_zoom_summary">Vis på skærmen</string>
 	<!-- Settings «Map» category: «Night style» title -->
 	<string name="pref_map_style_title">Nattilstand</string>
-	<!-- «Map style» entry value -->
-	<string name="pref_map_style_default">Fra</string>
-	<!-- «Map style» entry value -->
-	<string name="pref_map_style_night">Til</string>
-	<!-- «Map style» entry value -->
-	<string name="pref_map_style_auto">Auto</string>
+	<!-- Generic «Off» string -->
+	<string name="off">Fra</string>
+	<!-- Generic «On» string -->
+	<string name="on">Til</string>
+	<!-- Generic «Auto» string -->
+	<string name="auto">Auto</string>
 	<!-- Settings «Map» category: «Perspective view» title -->
 	<string name="pref_map_3d_title">Perspektivvisning</string>
 	<!-- Settings «Map» category: «3D buildings» title -->
@@ -528,8 +528,6 @@
 	<string name="enable_logging">Aktiver logføring</string>
 	<!-- Settings: "Send general feedback" button -->
 	<string name="feedback_general">Generel feedback</string>
-	<string name="on">Til</string>
-	<string name="off">Fra</string>
 	<string name="prefs_languages_information">Vi bruger systemets TTS til stemmevejledning. Mange Android-enheder bruger Google TTS, du kan hente eller opdatere det via Google Play (https://play.google.com/store/apps/details?id=com.google.android.tts)</string>
 	<string name="prefs_languages_information_off">For nogle sprog skal du installere en anden talesyntese eller en yderligere sprogpakke fra appbutiken (Google Play, Galaxy Store, App Gallery, FDroid).\nÅbn enhedens indstillinger → Sprog og input → Tale → Tekst til tale. Her kan du administrere indstillingerne for talesyntese (f. eks downloade en sprogpakke til brug offline) og vælge et andet tekst-til-tale program.</string>
 	<string name="prefs_languages_information_off_link">Se denne vejledning for flere oplysninger.</string>
@@ -597,9 +595,10 @@
 	<string name="bookmark_list_description_hint">Lav en beskrivelse (tekst eller html)</string>
 	<string name="not_shared">Privat</string>
 	<string name="speedcams_alert_title">Fartkameraer</string>
-	<string name="speedcam_option_auto">Auto</string>
-	<string name="speedcam_option_always">Altid</string>
-	<string name="speedcam_option_never">Aldrig</string>
+	<!-- Generic «Always» string -->
+	<string name="always">Altid</string>
+	<!-- Generic «Never» string -->
+	<string name="never">Aldrig</string>
 	<string name="place_description_title">Beskrivelse af sted</string>
 	<!-- this text will be shown in application notification preferences opposite checkbox which enable/disable downloader notifications. Devices on Android 8+ are affected. -->
 	<string name="notification_channel_downloader">Korthenter</string>

--- a/android/app/src/main/res/values-de/strings.xml
+++ b/android/app/src/main/res/values-de/strings.xml
@@ -212,12 +212,12 @@
 	<string name="pref_zoom_summary">Auf dem Bildschirm anzeigen</string>
 	<!-- Settings «Map» category: «Night style» title -->
 	<string name="pref_map_style_title">Nachtmodus</string>
-	<!-- «Map style» entry value -->
-	<string name="pref_map_style_default">Aus</string>
-	<!-- «Map style» entry value -->
-	<string name="pref_map_style_night">An</string>
-	<!-- «Map style» entry value -->
-	<string name="pref_map_style_auto">Auto</string>
+	<!-- Generic «Off» string -->
+	<string name="off">Aus</string>
+	<!-- Generic «On» string -->
+	<string name="on">An</string>
+	<!-- Generic «Auto» string -->
+	<string name="auto">Auto</string>
 	<!-- Settings «Map» category: «Perspective view» title -->
 	<string name="pref_map_3d_title">Perspektivische Ansicht</string>
 	<!-- Settings «Map» category: «3D buildings» title -->
@@ -555,8 +555,6 @@
 	<string name="enable_logging">Protokollierung aktivieren</string>
 	<!-- Settings: "Send general feedback" button -->
 	<string name="feedback_general">Allgemeines Feedback</string>
-	<string name="on">An</string>
-	<string name="off">Aus</string>
 	<string name="prefs_languages_information">Wir verwenden Text-to-Speech-Systeme für Sprachanweisungen. Viele Android-Geräte nutzen Google-TTS, das Sie bei Google Play (https://play.google.com/store/apps/details?id=com.google.android.tts) herunterladen oder aktualisieren können.</string>
 	<string name="prefs_languages_information_off">Für einige Sprachen müssen Sie einen anderen Sprachgenerator oder ein zusätzliches Sprachpaket aus dem App Store installieren (Google Play, Galaxy Store, App Gallery, FDroid). \nÖffnen Sie die Einstellungen Ihres Gerätes → Sprache und Eingabe → Sprache → Text-to-Speech-Ausgabe. Hier können Sie die Einstellungen für Sprachsynthese verwalten (beispielsweise ein Sprachpaket für die Offline-Verwendung herunterladen) und ein anderes Sprachausgabeprogramm auswählen.</string>
 	<string name="prefs_languages_information_off_link">Weitere Informationen finden Sie in dieser Anleitung.</string>
@@ -627,9 +625,10 @@
 	<string name="bookmark_list_description_hint">Fügen Sie die Beschreibung hinzu (Text oder html)</string>
 	<string name="not_shared">Persönlich</string>
 	<string name="speedcams_alert_title">Blitzer</string>
-	<string name="speedcam_option_auto">Auto</string>
-	<string name="speedcam_option_always">Immer</string>
-	<string name="speedcam_option_never">Niemals</string>
+	<!-- Generic «Always» string -->
+	<string name="always">Immer</string>
+	<!-- Generic «Never» string -->
+	<string name="never">Niemals</string>
 	<string name="place_description_title">Ortsbeschreibung</string>
 	<!-- this text will be shown in application notification preferences opposite checkbox which enable/disable downloader notifications. Devices on Android 8+ are affected. -->
 	<string name="notification_channel_downloader">Karten werden geladen</string>

--- a/android/app/src/main/res/values-el/strings.xml
+++ b/android/app/src/main/res/values-el/strings.xml
@@ -196,12 +196,12 @@
 	<string name="pref_zoom_summary">Εμφάνιση στο χάρτη</string>
 	<!-- Settings «Map» category: «Night style» title -->
 	<string name="pref_map_style_title">Νυχτερινή λειτουργία</string>
-	<!-- «Map style» entry value -->
-	<string name="pref_map_style_default">Απενεργ.</string>
-	<!-- «Map style» entry value -->
-	<string name="pref_map_style_night">Ενεργ.</string>
-	<!-- «Map style» entry value -->
-	<string name="pref_map_style_auto">Αυτόματα</string>
+	<!-- Generic «Off» string -->
+	<string name="off">Απενεργ.</string>
+	<!-- Generic «On» string -->
+	<string name="on">Ενεργ.</string>
+	<!-- Generic «Auto» string -->
+	<string name="auto">Αυτόματα</string>
 	<!-- Settings «Map» category: «Perspective view» title -->
 	<string name="pref_map_3d_title">Προβολή προοπτικής</string>
 	<!-- Settings «Map» category: «3D buildings» title -->
@@ -519,8 +519,6 @@
 	<string name="enable_logging">Ενεργοποίηση δυνατότητας καταγραφής</string>
 	<!-- Settings: "Send general feedback" button -->
 	<string name="feedback_general">Γενικό σχόλιο</string>
-	<string name="on">Ενεργ.</string>
-	<string name="off">Απενεργ.</string>
 	<string name="prefs_languages_information">Χρησιμοποιούμε σύστημα TTS για τις φωνητικές οδηγίες. Αρκετές συσκευές Android χρησιμοποιούν Google TTS, μπορείτε να το κατεβάσετε ή να το ενημερώσετε από το Google Play (https://play.google.com/store/apps/details?id=com.google.android.tts)</string>
 	<string name="prefs_languages_information_off">Για μερικές γλώσσες θα χρειαστεί να εγκαταστήσετε συνθεσάιζερ ομιλίας ή συμπληρωματικό πακέτο γλώσσας από το app store (Google Play, Galaxy Store, App Gallery, FDroid).\nΑνοίξτε τις Ρυθμίσεις της συσκευής σας → Γλώσσα και εισαγωγή → Ομιλία → Μετατροπή κειμένου σε ομιλία.\nΕδώ μπορείτε να διαχειριστείτε τις ρυθμίσεις της σύνθεσης ομιλίας (για παράδειγμα, μπορείτε να κατεβάσετε πακέτο γλώσσας για χρήση εκτός σύνδεσης) και να επιλέξετε άλλη μηχανή μετατροπής κειμένου σε ομιλία.</string>
 	<string name="prefs_languages_information_off_link">Για περισσότερες πληροφορίες δείτε αυτό τον οδηγό.</string>
@@ -588,9 +586,10 @@
 	<string name="bookmark_list_description_hint">Πληκτρολογήστε μια περιγραφή (κείμενο ή html)</string>
 	<string name="not_shared">Προσωπικός</string>
 	<string name="speedcams_alert_title">Κάμερες Ταχύτητας</string>
-	<string name="speedcam_option_auto">Αυτόματο</string>
-	<string name="speedcam_option_always">Πάντα</string>
-	<string name="speedcam_option_never">Ποτέ</string>
+	<!-- Generic «Always» string -->
+	<string name="always">Πάντα</string>
+	<!-- Generic «Never» string -->
+	<string name="never">Ποτέ</string>
 	<string name="place_description_title">Περιγραφή μέρους</string>
 	<!-- this text will be shown in application notification preferences opposite checkbox which enable/disable downloader notifications. Devices on Android 8+ are affected. -->
 	<string name="notification_channel_downloader">Κατέβασμα χαρτών</string>

--- a/android/app/src/main/res/values-es-rMX/strings.xml
+++ b/android/app/src/main/res/values-es-rMX/strings.xml
@@ -8,6 +8,8 @@
 	<string name="recycling">Reciclaje</string>
 	<!-- Search category for water; any changes should be duplicated in categories.txt @water! also used to sort bookmarks by type -->
 	<string name="water">Agua</string>
+	<!-- Generic «Auto» string -->
+	<string name="auto">Automático</string>
 	<!-- red color -->
 	<string name="red">Rojo</string>
 	<!-- yellow color -->
@@ -97,9 +99,10 @@
 	<string name="bookmark_list_description_hint">Introduzca una descripción (texto o html)</string>
 	<string name="not_shared">Privado</string>
 	<string name="speedcams_alert_title">Cámaras de velocidad</string>
-	<string name="speedcam_option_auto">Automático</string>
-	<string name="speedcam_option_always">Siempre</string>
-	<string name="speedcam_option_never">Nunca</string>
+	<!-- Generic «Always» string -->
+	<string name="always">Siempre</string>
+	<!-- Generic «Never» string -->
+	<string name="never">Nunca</string>
 	<string name="place_description_title">Descripción de lugares</string>
 	<!-- this text will be shown in application notification preferences opposite checkbox which enable/disable downloader notifications. Devices on Android 8+ are affected. -->
 	<string name="notification_channel_downloader">Descargar mapas</string>

--- a/android/app/src/main/res/values-es/strings.xml
+++ b/android/app/src/main/res/values-es/strings.xml
@@ -212,12 +212,12 @@
 	<string name="pref_zoom_summary">Visualización en la pantalla</string>
 	<!-- Settings «Map» category: «Night style» title -->
 	<string name="pref_map_style_title">Modo nocturno</string>
-	<!-- «Map style» entry value -->
-	<string name="pref_map_style_default">Desactivado</string>
-	<!-- «Map style» entry value -->
-	<string name="pref_map_style_night">Activado</string>
-	<!-- «Map style» entry value -->
-	<string name="pref_map_style_auto">Automático</string>
+	<!-- Generic «Off» string -->
+	<string name="off">Desactivado</string>
+	<!-- Generic «On» string -->
+	<string name="on">Activado</string>
+	<!-- Generic «Auto» string -->
+	<string name="auto">Automático</string>
 	<!-- Settings «Map» category: «Perspective view» title -->
 	<string name="pref_map_3d_title">Vista en perspectiva</string>
 	<!-- Settings «Map» category: «3D buildings» title -->
@@ -559,8 +559,6 @@
 	<string name="enable_logging">Habilitar historial</string>
 	<!-- Settings: "Send general feedback" button -->
 	<string name="feedback_general">Opinión general</string>
-	<string name="on">Act.</string>
-	<string name="off">Desact.</string>
 	<string name="prefs_languages_information">Utilizamos el sistema TTS para las instrucciones de voz. Muchos dispositivos de Android usan Google TTS. Puede descargar o actualizarlo desde Google Play (https://play.google.com/store/apps/details?id=com.google.android.tts)</string>
 	<string name="prefs_languages_information_off">Para algunos idiomas, debe instalar otro sintetizador de voz o un paquete de idioma adicional desde la tienda de aplicaciones (Google Play, Galaxy Store, App Gallery, FDroid). Abra los Ajustes de su dispositivo → Idioma e introducción → Voz → Opciones texto a voz. Aquí puede administrar la configuración de síntesis de voz (por ejemplo, descargar un paquete de idioma para poder usarlo sin conexión) o seleccionar otro motor de texto a voz.</string>
 	<string name="prefs_languages_information_off_link">Para obtener más información, consulte esta guía.</string>
@@ -631,9 +629,10 @@
 	<string name="bookmark_list_description_hint">Agregue una descripción (texto o html)</string>
 	<string name="not_shared">Privado</string>
 	<string name="speedcams_alert_title">Cámaras de velocidad</string>
-	<string name="speedcam_option_auto">Auto</string>
-	<string name="speedcam_option_always">Siempre</string>
-	<string name="speedcam_option_never">Nunca</string>
+	<!-- Generic «Always» string -->
+	<string name="always">Siempre</string>
+	<!-- Generic «Never» string -->
+	<string name="never">Nunca</string>
 	<string name="place_description_title">Descripción del lugar</string>
 	<!-- this text will be shown in application notification preferences opposite checkbox which enable/disable downloader notifications. Devices on Android 8+ are affected. -->
 	<string name="notification_channel_downloader">Descargar mapas</string>

--- a/android/app/src/main/res/values-et/strings.xml
+++ b/android/app/src/main/res/values-et/strings.xml
@@ -204,12 +204,12 @@
 	<string name="pref_zoom_summary">Kuva kaardil</string>
 	<!-- Settings «Map» category: «Night style» title -->
 	<string name="pref_map_style_title">Öörežiim</string>
-	<!-- «Map style» entry value -->
-	<string name="pref_map_style_default">Väljas</string>
-	<!-- «Map style» entry value -->
-	<string name="pref_map_style_night">Sees</string>
-	<!-- «Map style» entry value -->
-	<string name="pref_map_style_auto">Automaatne</string>
+	<!-- Generic «Off» string -->
+	<string name="off">Väljas</string>
+	<!-- Generic «On» string -->
+	<string name="on">Sees</string>
+	<!-- Generic «Auto» string -->
+	<string name="auto">Automaatne</string>
 	<!-- Settings «Map» category: «Perspective view» title -->
 	<string name="pref_map_3d_title">Perspektiivi vaade</string>
 	<!-- Settings «Map» category: «3D buildings» title -->
@@ -547,8 +547,6 @@
 	<string name="enable_logging">Luba logimine</string>
 	<!-- Settings: "Send general feedback" button -->
 	<string name="feedback_general">Üldine tagasiside</string>
-	<string name="on">Sees</string>
-	<string name="off">Väljas</string>
 	<string name="prefs_languages_information">Hääljuhiste jaoks kasutame TTS süsteemi. Paljud Android-seadmed kasutavad Google\'i TTS-i, saate selle alla laadida või värskendada teenusest Google Play (https:play.google.comstoreappsdetails?id=com.google.android.tts)</string>
 	<string name="prefs_languages_information_off">Mõne keele puhul peate paigaldama kõnesüntesaatori või täiendava keelepaketi rakenduste poest (Google Play, Galaxy Store, App Gallery, FDroid).\nAvage oma seadme seaded → Keel ja sisend → Kõne → Tekst kõneks väljund.\nSiin saate hallata kõnesünteesi seadeid (näiteks alla laadida keelepaketti võrguühenduseta kasutamiseks) ja valida mõne muu teksti kõneks muutmise mootori.</string>
 	<string name="prefs_languages_information_off_link">Lisainfo saamiseks palun vaadake seda juhist.</string>
@@ -618,9 +616,10 @@
 	<string name="bookmark_list_description_hint">Sisesta kirjeldus (tekst või html)</string>
 	<string name="not_shared">Privaatne</string>
 	<string name="speedcams_alert_title">Kiiruskaamerad</string>
-	<string name="speedcam_option_auto">Automaatne</string>
-	<string name="speedcam_option_always">Alati</string>
-	<string name="speedcam_option_never">Mitte kunagi</string>
+	<!-- Generic «Always» string -->
+	<string name="always">Alati</string>
+	<!-- Generic «Never» string -->
+	<string name="never">Mitte kunagi</string>
 	<string name="place_description_title">Koha kirjeldus</string>
 	<!-- this text will be shown in application notification preferences opposite checkbox which enable/disable downloader notifications. Devices on Android 8+ are affected. -->
 	<string name="notification_channel_downloader">Kaartide allalaadija</string>

--- a/android/app/src/main/res/values-eu/strings.xml
+++ b/android/app/src/main/res/values-eu/strings.xml
@@ -212,12 +212,12 @@
 	<string name="pref_zoom_summary">Erakutsi mapan</string>
 	<!-- Settings «Map» category: «Night style» title -->
 	<string name="pref_map_style_title">Gaueko modua</string>
-	<!-- «Map style» entry value -->
-	<string name="pref_map_style_default">Desgaituta</string>
-	<!-- «Map style» entry value -->
-	<string name="pref_map_style_night">Aktibatuta</string>
-	<!-- «Map style» entry value -->
-	<string name="pref_map_style_auto">Automatikoa</string>
+	<!-- Generic «Off» string -->
+	<string name="off">Desgaituta</string>
+	<!-- Generic «On» string -->
+	<string name="on">Aktibatuta</string>
+	<!-- Generic «Auto» string -->
+	<string name="auto">Automatikoa</string>
 	<!-- Settings «Map» category: «Perspective view» title -->
 	<string name="pref_map_3d_title">Perspektiba ikuspegia</string>
 	<!-- Settings «Map» category: «3D buildings» title -->
@@ -557,8 +557,6 @@
 	<string name="enable_logging">Historia gaitu</string>
 	<!-- Settings: "Send general feedback" button -->
 	<string name="feedback_general">Iritzi orokorra</string>
-	<string name="on">Martxan</string>
-	<string name="off">Itzalita</string>
 	<string name="prefs_languages_information">TTS sistema erabiltzen dugu ahots argibideetarako. Android gailu askok Google TTS erabiltzen dute. Google Play-tik deskargatu edo egunera dezakezu (https://play.google.com/store/apps/details?idu003dcom.google.android.tts)</string>
 	<string name="prefs_languages_information_off">Zenbait hizkuntzatan, beste ahots-sintetizadore bat edo hizkuntza-pakete gehigarri bat instalatu behar duzu aplikazio-dendatik (Google Play, Galaxy Store, App Gallery, FDroid). Ireki gailua Ezarpenak > Hizkuntza eta sarrera > Hizkera > Hizketarako testurako aukerak. Hemen ahots-sintesiaren ezarpenak kudea ditzakezu (adibidez, hizkuntza pakete bat deskargatu, konexiorik gabe erabiltzeko) edo testu-hizketarako beste motor bat hauta dezakezu.</string>
 	<string name="prefs_languages_information_off_link">Informazio gehiago lortzeko, ikusi gida hau.</string>
@@ -629,9 +627,10 @@
 	<string name="bookmark_list_description_hint">Gehitu deskribapen bat (testua edo html)</string>
 	<string name="not_shared">Pribatua</string>
 	<string name="speedcams_alert_title">Abiadura kamerak</string>
-	<string name="speedcam_option_auto">Automatikoa</string>
-	<string name="speedcam_option_always">Beti</string>
-	<string name="speedcam_option_never">Inoiz ez</string>
+	<!-- Generic «Always» string -->
+	<string name="always">Beti</string>
+	<!-- Generic «Never» string -->
+	<string name="never">Inoiz ez</string>
 	<string name="place_description_title">Tokiaren deskribapena</string>
 	<!-- this text will be shown in application notification preferences opposite checkbox which enable/disable downloader notifications. Devices on Android 8+ are affected. -->
 	<string name="notification_channel_downloader">Deskargatu mapak</string>

--- a/android/app/src/main/res/values-fa/strings.xml
+++ b/android/app/src/main/res/values-fa/strings.xml
@@ -188,12 +188,12 @@
 	<string name="pref_zoom_summary">نمایش بر روی نقشه</string>
 	<!-- Settings «Map» category: «Night style» title -->
 	<string name="pref_map_style_title">حالت شب</string>
-	<!-- «Map style» entry value -->
-	<string name="pref_map_style_default">خاموش</string>
-	<!-- «Map style» entry value -->
-	<string name="pref_map_style_night">روشن</string>
-	<!-- «Map style» entry value -->
-	<string name="pref_map_style_auto">خودکار</string>
+	<!-- Generic «Off» string -->
+	<string name="off">خاموش</string>
+	<!-- Generic «On» string -->
+	<string name="on">روشن</string>
+	<!-- Generic «Auto» string -->
+	<string name="auto">خودکار</string>
 	<!-- Settings «Map» category: «Perspective view» title -->
 	<string name="pref_map_3d_title">نمای چشم انداز</string>
 	<!-- Settings «Map» category: «3D buildings» title -->
@@ -523,8 +523,6 @@
 	<string name="enable_logging">ورود به سیستم را فعال کنید</string>
 	<!-- Settings: "Send general feedback" button -->
 	<string name="feedback_general">\"تنظیمات: دکمه \"ارسال بازخورد کلی</string>
-	<string name="on">روشن</string>
-	<string name="off">خاموش</string>
 	<string name="prefs_languages_information">ما از TTS سیستم برای دستورالعمل‌های صوتی استفاده می کنیم. بسیاری از دستگاه‌های Android از Google TTS استفاده می کنند، شما می توانید آن را از Google Play دانلود کنید (https://play.google.com/store/apps/details؟id=com.google.android.tts)</string>
 	<string name="prefs_languages_information_off">برای بعضی از زبان‌ها، شما باید speech synthesizer یا یک بسته زبان دیگر را از فروشگاه برنامه (بازار Google Play، Galaxy Store) نصب کنید. \n تنظیمات دستگاه خود را باز کنید. → زبان و ورودی → گفتار → خروجی متن به گفتار. می توانید تنظیمات برای ترکیب گفتار (به عنوان مثال، بسته‌های زبان را برای استفاده آفلاین دانلود کنید) را مدیریت کنید و یک موتور دیگر متن به گفتار را انتخاب کنید.</string>
 	<string name="prefs_languages_information_off_link">برای اطلاعات بیشتر لطفا این راهنما را بررسی کنید.</string>
@@ -595,9 +593,10 @@
 	<string name="bookmark_list_description_hint">یک توضیح (متن یا html) تایپ نمایید</string>
 	<string name="not_shared">خصوصی</string>
 	<string name="speedcams_alert_title">دوربین‌های سرعت</string>
-	<string name="speedcam_option_auto">خودکار</string>
-	<string name="speedcam_option_always">همیشه</string>
-	<string name="speedcam_option_never">هرگز</string>
+	<!-- Generic «Always» string -->
+	<string name="always">همیشه</string>
+	<!-- Generic «Never» string -->
+	<string name="never">هرگز</string>
 	<string name="place_description_title">توضیحات محل</string>
 	<!-- this text will be shown in application notification preferences opposite checkbox which enable/disable downloader notifications. Devices on Android 8+ are affected. -->
 	<string name="notification_channel_downloader">دانلود کننده نقشه</string>

--- a/android/app/src/main/res/values-fi/strings.xml
+++ b/android/app/src/main/res/values-fi/strings.xml
@@ -214,12 +214,12 @@
 	<string name="pref_zoom_summary">Näytä kartalla</string>
 	<!-- Settings «Map» category: «Night style» title -->
 	<string name="pref_map_style_title">Yötila</string>
-	<!-- «Map style» entry value -->
-	<string name="pref_map_style_default">Pois päältä</string>
-	<!-- «Map style» entry value -->
-	<string name="pref_map_style_night">Päällä</string>
-	<!-- «Map style» entry value -->
-	<string name="pref_map_style_auto">Automaattinen</string>
+	<!-- Generic «Off» string -->
+	<string name="off">Pois päältä</string>
+	<!-- Generic «On» string -->
+	<string name="on">Päällä</string>
+	<!-- Generic «Auto» string -->
+	<string name="auto">Automaattinen</string>
 	<!-- Settings «Map» category: «Perspective view» title -->
 	<string name="pref_map_3d_title">Perspektiivinäkymä</string>
 	<!-- Settings «Map» category: «3D buildings» title -->
@@ -559,8 +559,6 @@
 	<string name="enable_logging">Ota loki käyttöön</string>
 	<!-- Settings: "Send general feedback" button -->
 	<string name="feedback_general">Yleinen palaute</string>
-	<string name="on">Käytössä</string>
-	<string name="off">Ei käytössä</string>
 	<string name="prefs_languages_information">Käytämme ääniohjeisiin tekstistä puheeksi -järjestelmää. Monet Android-laitteet käyttävät Googlen tekstistä puheeksi -sovellusta, jonka voit ladata tai päivittää Google Playssä (https://play.google.com/store/apps/details?id=com.google.android.tts)</string>
 	<string name="prefs_languages_information_off">Joidenkin kielien osalta sinun täytyy asentaa toinen puhesyntetisaattori tai lisäkielipaketti sovelluskaupasta (Google Play, Galaxy Store, App Gallery, FDroid). Avaa laitteen asetukset → Kieli ja syöttötapa → Puhe → Teksistä puheeksi -toisto. Täällä voit hallita puhesynteesin asetuksia (esimerkiksi ladata offline-tilassa käytettävän kielipaketin) ja valita toisen tekstistä puheeksi -moottorin.</string>
 	<string name="prefs_languages_information_off_link">Lisätietoja saat tästä oppaasta.</string>
@@ -631,9 +629,10 @@
 	<string name="bookmark_list_description_hint">Lisää kuvaus (teksti tai html)</string>
 	<string name="not_shared">Yksityinen</string>
 	<string name="speedcams_alert_title">Nopeuskamerat</string>
-	<string name="speedcam_option_auto">Auto</string>
-	<string name="speedcam_option_always">Aina</string>
-	<string name="speedcam_option_never">Ei koskaan</string>
+	<!-- Generic «Always» string -->
+	<string name="always">Aina</string>
+	<!-- Generic «Never» string -->
+	<string name="never">Ei koskaan</string>
 	<string name="place_description_title">Paikan kuvaus</string>
 	<!-- this text will be shown in application notification preferences opposite checkbox which enable/disable downloader notifications. Devices on Android 8+ are affected. -->
 	<string name="notification_channel_downloader">Karttojen lataaminen</string>

--- a/android/app/src/main/res/values-fr/strings.xml
+++ b/android/app/src/main/res/values-fr/strings.xml
@@ -214,12 +214,12 @@
 	<string name="pref_zoom_summary">Afficher à l\'écran</string>
 	<!-- Settings «Map» category: «Night style» title -->
 	<string name="pref_map_style_title">Mode nuit</string>
-	<!-- «Map style» entry value -->
-	<string name="pref_map_style_default">Désactivé</string>
-	<!-- «Map style» entry value -->
-	<string name="pref_map_style_night">Activé</string>
-	<!-- «Map style» entry value -->
-	<string name="pref_map_style_auto">Automatique</string>
+	<!-- Generic «Off» string -->
+	<string name="off">Désactivé</string>
+	<!-- Generic «On» string -->
+	<string name="on">Activé</string>
+	<!-- Generic «Auto» string -->
+	<string name="auto">Automatique</string>
 	<!-- Settings «Map» category: «Perspective view» title -->
 	<string name="pref_map_3d_title">Vue en perspective</string>
 	<!-- Settings «Map» category: «3D buildings» title -->
@@ -561,8 +561,6 @@
 	<string name="enable_logging">Activer le journal</string>
 	<!-- Settings: "Send general feedback" button -->
 	<string name="feedback_general">Feedback général</string>
-	<string name="on">On</string>
-	<string name="off">Off</string>
 	<string name="prefs_languages_information">Nous utilisons le système TTS pour les instructions vocales. De nombreux appareils Android utilisent Google TTS, vous pouvez le télécharger ou le mettre à jour depuis Google Play (https://play.google.com/store/apps/details?id=com.google.android.tts)</string>
 	<string name="prefs_languages_information_off">Pour certaines langues, il vous faudra installer un autre logiciel de synthèse vocale ou un pack de langue supplémentaire depuis l’app store (Google Play, Galaxy Store, App Gallery, FDroid). Ouvrez les paramètres de votre appareil → Langue et saisie → Reconnaissance vocale → Saisie vocale. Ici, vous pouvez gérer les paramètres pour la synthèse vocale (par exemple, télécharger un pack de langue pour une utilisation en mode hors ligne) et sélectionner un autre moteur de saisie vocale.</string>
 	<string name="prefs_languages_information_off_link">Pour plus d’informations, veuillez consulter ce guide.</string>
@@ -632,9 +630,10 @@
 	<string name="bookmark_list_description_hint">Tapez une description (texte ou html)</string>
 	<string name="not_shared">Privé</string>
 	<string name="speedcams_alert_title">Radars de vitesse</string>
-	<string name="speedcam_option_auto">Auto</string>
-	<string name="speedcam_option_always">Toujours</string>
-	<string name="speedcam_option_never">Jamais</string>
+	<!-- Generic «Always» string -->
+	<string name="always">Toujours</string>
+	<!-- Generic «Never» string -->
+	<string name="never">Jamais</string>
 	<string name="place_description_title">Description d\'endroit</string>
 	<!-- this text will be shown in application notification preferences opposite checkbox which enable/disable downloader notifications. Devices on Android 8+ are affected. -->
 	<string name="notification_channel_downloader">Téléchargeur carte</string>

--- a/android/app/src/main/res/values-hu/strings.xml
+++ b/android/app/src/main/res/values-hu/strings.xml
@@ -209,12 +209,12 @@
 	<string name="pref_zoom_summary">Mutassa a kijelzőn</string>
 	<!-- Settings «Map» category: «Night style» title -->
 	<string name="pref_map_style_title">Éjszakai üzemmód</string>
-	<!-- «Map style» entry value -->
-	<string name="pref_map_style_default">Ki</string>
-	<!-- «Map style» entry value -->
-	<string name="pref_map_style_night">Be</string>
-	<!-- «Map style» entry value -->
-	<string name="pref_map_style_auto">Automatikus</string>
+	<!-- Generic «Off» string -->
+	<string name="off">Ki</string>
+	<!-- Generic «On» string -->
+	<string name="on">Be</string>
+	<!-- Generic «Auto» string -->
+	<string name="auto">Automatikus</string>
 	<!-- Settings «Map» category: «Perspective view» title -->
 	<string name="pref_map_3d_title">Perspektivikus nézet</string>
 	<!-- Settings «Map» category: «3D buildings» title -->
@@ -540,8 +540,6 @@
 	<string name="enable_logging">Naplózás engedélyezése</string>
 	<!-- Settings: "Send general feedback" button -->
 	<string name="feedback_general">Általános visszajelzés</string>
-	<string name="on">Be</string>
-	<string name="off">Ki</string>
 	<string name="prefs_languages_information">TTS rendszert használunk a hangnavigációhoz. Sok Android-os készülék használja a Google TTS-t; töltse le vagy frissítse a Google Play áruházból (https://play.google.com/store/apps/details?id=com.google.android.tts)</string>
 	<string name="prefs_languages_information_off">Egyes nyelveknél másik beszédszintetizátort vagy további nyelvi csomagot kell telepítenie az alkalmazás-áruházból (Google Play, Galaxy Store, App Gallery, FDroid). Nyissa meg a készülék beállításait → Nyelv és bevitel → Beszéd → Szöveg-beszéd átalakító kimenet. Itt kezelheti a beszédszintézis beállításokat (például nyelvi csomag letöltése kapcsolat nélküli használatra) és másik szövegfelolvasót jelölhe tki.</string>
 	<string name="prefs_languages_information_off_link">További tájékoztatást találhat még ebben az útmutatóban.</string>
@@ -609,9 +607,10 @@
 	<string name="bookmark_list_description_hint">Leírás hozzáadása (szöveg vagy html)</string>
 	<string name="not_shared">Privát</string>
 	<string name="speedcams_alert_title">Sebességmérő kamerák</string>
-	<string name="speedcam_option_auto">Automatikus</string>
-	<string name="speedcam_option_always">Mindig</string>
-	<string name="speedcam_option_never">Soha</string>
+	<!-- Generic «Always» string -->
+	<string name="always">Mindig</string>
+	<!-- Generic «Never» string -->
+	<string name="never">Soha</string>
 	<string name="place_description_title">A hely ismertetése</string>
 	<!-- this text will be shown in application notification preferences opposite checkbox which enable/disable downloader notifications. Devices on Android 8+ are affected. -->
 	<string name="notification_channel_downloader">Kártyák letöltése</string>

--- a/android/app/src/main/res/values-in/strings.xml
+++ b/android/app/src/main/res/values-in/strings.xml
@@ -197,12 +197,12 @@
 	<string name="pref_zoom_summary">Tampilkan pada layar</string>
 	<!-- Settings «Map» category: «Night style» title -->
 	<string name="pref_map_style_title">Mode Malam</string>
-	<!-- «Map style» entry value -->
-	<string name="pref_map_style_default">Tidak Aktif</string>
-	<!-- «Map style» entry value -->
-	<string name="pref_map_style_night">Aktif</string>
-	<!-- «Map style» entry value -->
-	<string name="pref_map_style_auto">Otomatis</string>
+	<!-- Generic «Off» string -->
+	<string name="off">Tidak Aktif</string>
+	<!-- Generic «On» string -->
+	<string name="on">Aktif</string>
+	<!-- Generic «Auto» string -->
+	<string name="auto">Otomatis</string>
 	<!-- Settings «Map» category: «Perspective view» title -->
 	<string name="pref_map_3d_title">Pandangan perspektif</string>
 	<!-- Settings «Map» category: «3D buildings» title -->
@@ -528,8 +528,6 @@
 	<string name="enable_logging">Aktifkan pencatatan</string>
 	<!-- Settings: "Send general feedback" button -->
 	<string name="feedback_general">Umpan Balik Umum</string>
-	<string name="on">On</string>
-	<string name="off">Mati</string>
 	<string name="prefs_languages_information">Kami menggunakan TTS sistem untuk petunjuk suara. Banyak perangkat Android menggunakan Google TTS, Anda dapat mengunduhnya dari Google Play (https://play.google.com/store/apps/details?id=com.google.android.tts)</string>
 	<string name="prefs_languages_information_off">Untuk beberapa bahasa, Anda perlu menginstal synthesizer suara atau paket bahasa tambahan dari toko aplikasi (Google Play, Galaxy Store, App Gallery, FDroid).\nBuka pengaturan perangkat Anda → Language and input (Bahasa dan input) → Speech (Suara) → Text to speech (Teks ke suara).\nDi sini, Anda dapat mengelola pengaturan untuk sintesis suara (contohnya, mengunduh paket bahasa untuk penggunaan tanpa internet) dan memilih mesin tekske suara lain.</string>
 	<string name="prefs_languages_information_off_link">Untuk informasi selengkapnya, bacalah panduan ini.</string>
@@ -597,9 +595,10 @@
 	<string name="bookmark_list_description_hint">Ketikkan deskripsi (teks atau html)</string>
 	<string name="not_shared">Pribadi</string>
 	<string name="speedcams_alert_title">Kamera cepat</string>
-	<string name="speedcam_option_auto">Auto</string>
-	<string name="speedcam_option_always">Selalu</string>
-	<string name="speedcam_option_never">Tidak pernah</string>
+	<!-- Generic «Always» string -->
+	<string name="always">Selalu</string>
+	<!-- Generic «Never» string -->
+	<string name="never">Tidak pernah</string>
 	<string name="place_description_title">Deskripsi Tempat</string>
 	<!-- this text will be shown in application notification preferences opposite checkbox which enable/disable downloader notifications. Devices on Android 8+ are affected. -->
 	<string name="notification_channel_downloader">Pengunduh peta</string>

--- a/android/app/src/main/res/values-it/strings.xml
+++ b/android/app/src/main/res/values-it/strings.xml
@@ -200,12 +200,12 @@
 	<string name="pref_zoom_summary">Mostra sulla mappa</string>
 	<!-- Settings «Map» category: «Night style» title -->
 	<string name="pref_map_style_title">Modalità notturna</string>
-	<!-- «Map style» entry value -->
-	<string name="pref_map_style_default">Spento</string>
-	<!-- «Map style» entry value -->
-	<string name="pref_map_style_night">Acceso</string>
-	<!-- «Map style» entry value -->
-	<string name="pref_map_style_auto">Automatico</string>
+	<!-- Generic «Off» string -->
+	<string name="off">Spento</string>
+	<!-- Generic «On» string -->
+	<string name="on">Acceso</string>
+	<!-- Generic «Auto» string -->
+	<string name="auto">Automatico</string>
 	<!-- Settings «Map» category: «Perspective view» title -->
 	<string name="pref_map_3d_title">Vista in prospettiva</string>
 	<!-- Settings «Map» category: «3D buildings» title -->
@@ -540,8 +540,6 @@
 	<string name="enable_logging">Abilita i registri</string>
 	<!-- Settings: "Send general feedback" button -->
 	<string name="feedback_general">Feedback generale</string>
-	<string name="on">Acceso</string>
-	<string name="off">Spento</string>
 	<string name="prefs_languages_information">Usiamo il TTS di sistema per le istruzioni vocali. Molti dispositivi Android utilizzano Google TTS, che puoi scaricare o aggiornare da Google Play (https://play.google.com/store/apps/details?id=com.google.android.tts)</string>
 	<string name="prefs_languages_information_off">Per alcune lingue, sarà necessario installare un altro sintetizzatore vocale o un language pack aggiuntivo dall\'app store (Google Play, Galaxy Store, App Gallery, FDroid).\nApri le impostazioni del tuo dispositivo → Lingua e inserimento → Da testo a voce → Motore sintesi vocale.\nQui puoi gestire le impostazioni di sintesi vocale (ad esempio, scaricare una lingua per l\'utilizzo offline) e selezionare un altro motore di sintesi vocale.</string>
 	<string name="prefs_languages_information_off_link">Per maggiori informazioni, consulta questa guida.</string>
@@ -612,9 +610,10 @@
 	<string name="bookmark_list_description_hint">Scrivi una descrizione (testo o html)</string>
 	<string name="not_shared">Personale</string>
 	<string name="speedcams_alert_title">Autovelox</string>
-	<string name="speedcam_option_auto">Auto</string>
-	<string name="speedcam_option_always">Sempre</string>
-	<string name="speedcam_option_never">Mai</string>
+	<!-- Generic «Always» string -->
+	<string name="always">Sempre</string>
+	<!-- Generic «Never» string -->
+	<string name="never">Mai</string>
 	<string name="place_description_title">Descrizione luogo</string>
 	<!-- this text will be shown in application notification preferences opposite checkbox which enable/disable downloader notifications. Devices on Android 8+ are affected. -->
 	<string name="notification_channel_downloader">Scaricamento mappe</string>

--- a/android/app/src/main/res/values-ja/strings.xml
+++ b/android/app/src/main/res/values-ja/strings.xml
@@ -193,12 +193,12 @@
 	<string name="pref_zoom_summary">画面上に表示</string>
 	<!-- Settings «Map» category: «Night style» title -->
 	<string name="pref_map_style_title">夜間モード</string>
-	<!-- «Map style» entry value -->
-	<string name="pref_map_style_default">オフ</string>
-	<!-- «Map style» entry value -->
-	<string name="pref_map_style_night">オン</string>
-	<!-- «Map style» entry value -->
-	<string name="pref_map_style_auto">自動</string>
+	<!-- Generic «Off» string -->
+	<string name="off">オフ</string>
+	<!-- Generic «On» string -->
+	<string name="on">オン</string>
+	<!-- Generic «Auto» string -->
+	<string name="auto">自動</string>
 	<!-- Settings «Map» category: «Perspective view» title -->
 	<string name="pref_map_3d_title">パースペクティブ表示</string>
 	<!-- Settings «Map» category: «3D buildings» title -->
@@ -524,8 +524,6 @@
 	<string name="enable_logging">ログを有効化</string>
 	<!-- Settings: "Send general feedback" button -->
 	<string name="feedback_general">一般的なフィードバック</string>
-	<string name="on">オン</string>
-	<string name="off">オフ</string>
 	<string name="prefs_languages_information">音声案内にはシステムの TTS を使用します。多くの Android 端末が Google の TTS を使用しており、Google Play (https://play.google.com/store/apps/details?id=com.google.android.tts) からダウンロードや更新を行うことができます。</string>
 	<string name="prefs_languages_information_off">いくつかの言語では、アプリストアからその他の音声合成または追加の言語パックをインストールする必要があります (Google Play マーケット、Galaxy Store) 。お使いのデバイスで [設定] → [言語と入力] → [音声] → [音声出力] を開いてください。ここで音声合成の設定 (たとえば、オフラインで使用する言語パックのダウンロードなど) を管理し、別の音声合成エンジンを選択することができます。</string>
 	<string name="prefs_languages_information_off_link">詳細については、このガイドをご確認ください。</string>
@@ -592,9 +590,10 @@
 	<string name="bookmark_list_description_hint">説明(テキストまたはhtml)を記入してください</string>
 	<string name="not_shared">非公開</string>
 	<string name="speedcams_alert_title">自動速度違反取締装置</string>
-	<string name="speedcam_option_auto">自動</string>
-	<string name="speedcam_option_always">常時</string>
-	<string name="speedcam_option_never">無効</string>
+	<!-- Generic «Always» string -->
+	<string name="always">常時</string>
+	<!-- Generic «Never» string -->
+	<string name="never">無効</string>
 	<string name="place_description_title">場所の説明</string>
 	<!-- this text will be shown in application notification preferences opposite checkbox which enable/disable downloader notifications. Devices on Android 8+ are affected. -->
 	<string name="notification_channel_downloader">マップダウンローダー</string>

--- a/android/app/src/main/res/values-ko/strings.xml
+++ b/android/app/src/main/res/values-ko/strings.xml
@@ -195,12 +195,12 @@
 	<string name="pref_zoom_summary">화면에 표시</string>
 	<!-- Settings «Map» category: «Night style» title -->
 	<string name="pref_map_style_title">나이트 모드</string>
-	<!-- «Map style» entry value -->
-	<string name="pref_map_style_default">끄기</string>
-	<!-- «Map style» entry value -->
-	<string name="pref_map_style_night">켜기</string>
-	<!-- «Map style» entry value -->
-	<string name="pref_map_style_auto">자동</string>
+	<!-- Generic «Off» string -->
+	<string name="off">끄기</string>
+	<!-- Generic «On» string -->
+	<string name="on">켜기</string>
+	<!-- Generic «Auto» string -->
+	<string name="auto">자동</string>
 	<!-- Settings «Map» category: «Perspective view» title -->
 	<string name="pref_map_3d_title">원근 보기</string>
 	<!-- Settings «Map» category: «3D buildings» title -->
@@ -526,8 +526,6 @@
 	<string name="enable_logging">로깅 사용</string>
 	<!-- Settings: "Send general feedback" button -->
 	<string name="feedback_general">일반 피드백</string>
-	<string name="on">켜기</string>
-	<string name="off">끄기</string>
 	<string name="prefs_languages_information">당사는 음성 지침을 위해 시스템 TTS를 사용합니다. 많은 Android 장치에서 Google TTS를 사용합니다. Google Play(https://play.google.com/store/apps/details?id=com.google.android.tts)에서 Google TTS를 다운로드하거나 업데이트할 수 있습니다.</string>
 	<string name="prefs_languages_information_off">일부 언어의 경우 앱 스토어(Google Play, Galaxy Store, App Gallery, FDroid)에서 다른 음성 합성기 또는 추가 언어 팩을 설치해야 합니다.\n장치의 설정 → 언어 및 입력 → 음성 → 텍스트-음성 변환 출력을 엽니다.\n여기서 음성 합성에 대한 설정을 관리하고(예: 오프라인 사용을 위한 언어 팩 다운로드) 다른 텍스트-음성 변환 엔진을 선택할 수 있습니다.</string>
 	<string name="prefs_languages_information_off_link">자세한 내용을 보려면 이 가이드를 확인하세요.</string>
@@ -594,9 +592,10 @@
 	<string name="bookmark_list_description_hint">묘사를 적으세요 (글자 혹은 html)</string>
 	<string name="not_shared">개인</string>
 	<string name="speedcams_alert_title">속도 감시 카메라</string>
-	<string name="speedcam_option_auto">자동</string>
-	<string name="speedcam_option_always">항상</string>
-	<string name="speedcam_option_never">안함</string>
+	<!-- Generic «Always» string -->
+	<string name="always">항상</string>
+	<!-- Generic «Never» string -->
+	<string name="never">안함</string>
 	<string name="place_description_title">장소 묘사</string>
 	<!-- this text will be shown in application notification preferences opposite checkbox which enable/disable downloader notifications. Devices on Android 8+ are affected. -->
 	<string name="notification_channel_downloader">맵 다운로더</string>

--- a/android/app/src/main/res/values-mr/strings.xml
+++ b/android/app/src/main/res/values-mr/strings.xml
@@ -188,12 +188,12 @@
 	<string name="pref_zoom_summary">नकाशावर दाखवा</string>
 	<!-- Settings «Map» category: «Night style» title -->
 	<string name="pref_map_style_title">रात्र मोड</string>
-	<!-- «Map style» entry value -->
-	<string name="pref_map_style_default">बंद</string>
-	<!-- «Map style» entry value -->
-	<string name="pref_map_style_night">चालू</string>
-	<!-- «Map style» entry value -->
-	<string name="pref_map_style_auto">स्वयं</string>
+	<!-- Generic «Off» string -->
+	<string name="off">बंद</string>
+	<!-- Generic «On» string -->
+	<string name="on">चालू</string>
+	<!-- Generic «Auto» string -->
+	<string name="auto">स्वयं</string>
 	<!-- Settings «Map» category: «Perspective view» title -->
 	<string name="pref_map_3d_title">यथार्थ दृश्य</string>
 	<!-- Settings «Map» category: «3D buildings» title -->
@@ -523,8 +523,6 @@
 	<string name="enable_logging">लॉग चालू करा</string>
 	<!-- Settings: "Send general feedback" button -->
 	<string name="feedback_general">सामान्य अभिप्राय</string>
-	<string name="on">चालू</string>
-	<string name="off">बंद</string>
 	<string name="prefs_languages_information">आम्ही ध्वनी निर्देशांसाठी \"सिस्टम TTS\" वापरतो. अनेक Android उपकरणे \"Google TTS\" वापरतात, जे तुम्ही Google Play वरून डाउनलोड किंवा अद्ययावत करू शकता (https://play.google.com/store/apps/details?idu003dcom.google.android.tts)</string>
 	<string name="prefs_languages_information_off">काही भाषांसाठी, तुम्हाला अँप स्टोअर (Google Play, Galaxy Store, App Gallery, FDroid) वरून स्पीच मिश्रक किंवा अतिरिक्त भाषा संच इन्स्टॉल करावे लागतील.\nतुमच्या उपकरणाची सेटिंग → भाषा आणि इनपुट → स्पीच → \"टेक्स्ट टू स्पीच आउटपुट\" उघडा.\nयेथे तुम्ही स्पीच मिश्रणासाठी सेटिंग व्यवस्थापित करू शकता (उदाहरणार्थ, ऑफलाइन वापरासाठी भाषा संच डाउनलोड करा) आणि दुसरे टेक्स्ट-टू-स्पीच इंजिन निवडा.</string>
 	<string name="prefs_languages_information_off_link">अधिक माहितीसाठी कृपया ही मार्गदर्शिका पहा.</string>
@@ -593,9 +591,10 @@
 	<string name="bookmark_list_description_hint">वर्णन लिहा (मजकूर किंवा html)</string>
 	<string name="not_shared">खाजगी</string>
 	<string name="speedcams_alert_title">वेग कॅमेरे</string>
-	<string name="speedcam_option_auto">स्वयं</string>
-	<string name="speedcam_option_always">नेहमी</string>
-	<string name="speedcam_option_never">कधीच नाही</string>
+	<!-- Generic «Always» string -->
+	<string name="always">नेहमी</string>
+	<!-- Generic «Never» string -->
+	<string name="never">कधीच नाही</string>
 	<string name="place_description_title">ठिकाणाचे वर्णन</string>
 	<!-- this text will be shown in application notification preferences opposite checkbox which enable/disable downloader notifications. Devices on Android 8+ are affected. -->
 	<string name="notification_channel_downloader">नकाशा डाउनलोडक</string>

--- a/android/app/src/main/res/values-nb/strings.xml
+++ b/android/app/src/main/res/values-nb/strings.xml
@@ -214,12 +214,12 @@
 	<string name="pref_zoom_summary">Vis på skjermen</string>
 	<!-- Settings «Map» category: «Night style» title -->
 	<string name="pref_map_style_title">Nattmodus</string>
-	<!-- «Map style» entry value -->
-	<string name="pref_map_style_default">Av</string>
-	<!-- «Map style» entry value -->
-	<string name="pref_map_style_night">På</string>
-	<!-- «Map style» entry value -->
-	<string name="pref_map_style_auto">Auto</string>
+	<!-- Generic «Off» string -->
+	<string name="off">Av</string>
+	<!-- Generic «On» string -->
+	<string name="on">På</string>
+	<!-- Generic «Auto» string -->
+	<string name="auto">Auto</string>
 	<!-- Settings «Map» category: «Perspective view» title -->
 	<string name="pref_map_3d_title">Perspektivvisning</string>
 	<!-- Settings «Map» category: «3D buildings» title -->
@@ -559,8 +559,6 @@
 	<string name="enable_logging">Aktiver loggføring</string>
 	<!-- Settings: "Send general feedback" button -->
 	<string name="feedback_general">Generell tilbakemelding</string>
-	<string name="on">På</string>
-	<string name="off">Av</string>
 	<string name="prefs_languages_information">Vi bruker system TTS for stemmeveiledning. Mange Android-enheter bruker Google TTS, Du kan laste ned eller oppdatere via Google Play (https://play.google.com/store/apps/details?id=com.google.android.tts)</string>
 	<string name="prefs_languages_information_off">For enkelte språk er det nødvendig å installere en annen talesyntese eller en ekstra språkpakke fra appbutikken (Google Play, Galaxy Store, App Gallery, FDroid).\nGå til enhetens innstillinger → Språk og input → Tale → Tekst til tale output.\nHer kan du administrere innstillingene for talesyntese (for eksempel laste ned språkpakke for offline bruk) og velge en annen tekst-til-tale-motor.</string>
 	<string name="prefs_languages_information_off_link">Les denne veiledningen for mer informasjon.</string>
@@ -628,9 +626,10 @@
 	<string name="bookmark_list_description_hint">Lag en beskrivelse (text or html)</string>
 	<string name="not_shared">Privat</string>
 	<string name="speedcams_alert_title">Fartskamera</string>
-	<string name="speedcam_option_auto">Auto</string>
-	<string name="speedcam_option_always">Alltid</string>
-	<string name="speedcam_option_never">Aldri</string>
+	<!-- Generic «Always» string -->
+	<string name="always">Alltid</string>
+	<!-- Generic «Never» string -->
+	<string name="never">Aldri</string>
 	<string name="place_description_title">Plasser beskrivelse</string>
 	<!-- this text will be shown in application notification preferences opposite checkbox which enable/disable downloader notifications. Devices on Android 8+ are affected. -->
 	<string name="notification_channel_downloader">Nedlast kart</string>

--- a/android/app/src/main/res/values-nl/strings.xml
+++ b/android/app/src/main/res/values-nl/strings.xml
@@ -212,12 +212,12 @@
 	<string name="pref_zoom_summary">Weergave op het scherm</string>
 	<!-- Settings «Map» category: «Night style» title -->
 	<string name="pref_map_style_title">Nachtmodus</string>
-	<!-- «Map style» entry value -->
-	<string name="pref_map_style_default">Uit</string>
-	<!-- «Map style» entry value -->
-	<string name="pref_map_style_night">Aan</string>
-	<!-- «Map style» entry value -->
-	<string name="pref_map_style_auto">Automatisch</string>
+	<!-- Generic «Off» string -->
+	<string name="off">Uit</string>
+	<!-- Generic «On» string -->
+	<string name="on">Aan</string>
+	<!-- Generic «Auto» string -->
+	<string name="auto">Automatisch</string>
 	<!-- Settings «Map» category: «Perspective view» title -->
 	<string name="pref_map_3d_title">Perspectiefbeeld</string>
 	<!-- Settings «Map» category: «3D buildings» title -->
@@ -555,8 +555,6 @@
 	<string name="enable_logging">Logboekregistratie inschakelen</string>
 	<!-- Settings: "Send general feedback" button -->
 	<string name="feedback_general">Algemene Feedback</string>
-	<string name="on">Aan</string>
-	<string name="off">Uit</string>
 	<string name="prefs_languages_information">We gebruiken het TTS-systeem voor gesproken instructies. Vele Android toestellen gebruiken Google TTS, u kunt het downloaden of bijwerken in Google Play (https://play.google.com/store/apps/details?id=com.google.android.tts)</string>
 	<string name="prefs_languages_information_off">Voor sommige talen dient u een andere spraaksynthese software of een aanvullende taalpakket te installeren van de app store (Google Play, Galaxy Store, App Gallery, FDroid).\nOpen de instellingen van uw toestel → Taal en invoer → Spraak → Uitvoer voor tekst-naar-spraak.\nHier kunt u instellingen voor spraaksynthese beheren (bijvoorbeeld taalpakket downloaden voor offline gebruik) en een andere tekst-naar-spraak engine selecteren.</string>
 	<string name="prefs_languages_information_off_link">Gelieve deze handleiding te lezen voor meer informatie.</string>
@@ -624,9 +622,10 @@
 	<string name="bookmark_list_description_hint">Maak een beschrijving aan (tekst of html)</string>
 	<string name="not_shared">Privé</string>
 	<string name="speedcams_alert_title">Snelheidscamera\'s</string>
-	<string name="speedcam_option_auto">Auto</string>
-	<string name="speedcam_option_always">Altijd</string>
-	<string name="speedcam_option_never">Nooit</string>
+	<!-- Generic «Always» string -->
+	<string name="always">Altijd</string>
+	<!-- Generic «Never» string -->
+	<string name="never">Nooit</string>
 	<string name="place_description_title">Plaats Beschrijving</string>
 	<!-- this text will be shown in application notification preferences opposite checkbox which enable/disable downloader notifications. Devices on Android 8+ are affected. -->
 	<string name="notification_channel_downloader">Kaart downloader</string>

--- a/android/app/src/main/res/values-pl/strings.xml
+++ b/android/app/src/main/res/values-pl/strings.xml
@@ -212,12 +212,12 @@
 	<string name="pref_zoom_summary">Wyświetla na ekranie</string>
 	<!-- Settings «Map» category: «Night style» title -->
 	<string name="pref_map_style_title">Tryb nocny</string>
-	<!-- «Map style» entry value -->
-	<string name="pref_map_style_default">Wyłączony</string>
-	<!-- «Map style» entry value -->
-	<string name="pref_map_style_night">Włączony</string>
-	<!-- «Map style» entry value -->
-	<string name="pref_map_style_auto">Automatycznie</string>
+	<!-- Generic «Off» string -->
+	<string name="off">Wyłączony</string>
+	<!-- Generic «On» string -->
+	<string name="on">Włączony</string>
+	<!-- Generic «Auto» string -->
+	<string name="auto">Automatycznie</string>
 	<!-- Settings «Map» category: «Perspective view» title -->
 	<string name="pref_map_3d_title">Widok z perspektywy</string>
 	<!-- Settings «Map» category: «3D buildings» title -->
@@ -559,8 +559,6 @@
 	<string name="enable_logging">Włącz zbieranie danych</string>
 	<!-- Settings: "Send general feedback" button -->
 	<string name="feedback_general">Ogólne uwagi</string>
-	<string name="on">Wł.</string>
-	<string name="off">Wył.</string>
 	<string name="prefs_languages_information">Stosujemy system TTS dla komend głosowych. Stosuje go wiele urządzeń z systemem Android, można go pobrać lub zaktualizować z Google Play (https://play.google.com/store/apps/details?id=com.google.android.tts)</string>
 	<string name="prefs_languages_information_off">W przypadku niektórych języków wymagana będzie instalacja innego syntezatora lub pakietu językowego ze strony aplikacji (Google Play, Galaxy Store, App Gallery, FDroid). Otwórz ustawienia urządzenia → Język i klawiatura → Mowa → Przetwarzanie tekstu na mowę.\nMożesz w tym miejscu zarządzać ustawieniami syntezy mowy (np. pobrać pakiet językowy do stosowania offline) i wybrać inny silnik przetwarzania tekstu na mowę.</string>
 	<string name="prefs_languages_information_off_link">Aby uzyskać więcej informacji, spójrz na ten poradnik.</string>
@@ -629,9 +627,10 @@
 	<string name="bookmark_list_description_hint">Dodaj opis (tekst lub html)</string>
 	<string name="not_shared">Osobisty</string>
 	<string name="speedcams_alert_title">Fotoradary</string>
-	<string name="speedcam_option_auto">Automatycznie</string>
-	<string name="speedcam_option_always">Zawsze</string>
-	<string name="speedcam_option_never">Nigdy</string>
+	<!-- Generic «Always» string -->
+	<string name="always">Zawsze</string>
+	<!-- Generic «Never» string -->
+	<string name="never">Nigdy</string>
 	<string name="place_description_title">Opis miejsca</string>
 	<!-- this text will be shown in application notification preferences opposite checkbox which enable/disable downloader notifications. Devices on Android 8+ are affected. -->
 	<string name="notification_channel_downloader">Pobieranie map</string>

--- a/android/app/src/main/res/values-pt-rBR/strings.xml
+++ b/android/app/src/main/res/values-pt-rBR/strings.xml
@@ -210,12 +210,12 @@
 	<string name="pref_zoom_summary">Mostrar na tela</string>
 	<!-- Settings «Map» category: «Night style» title -->
 	<string name="pref_map_style_title">Modo noturno</string>
-	<!-- «Map style» entry value -->
-	<string name="pref_map_style_default">Desligado</string>
-	<!-- «Map style» entry value -->
-	<string name="pref_map_style_night">Ligado</string>
-	<!-- «Map style» entry value -->
-	<string name="pref_map_style_auto">Automático</string>
+	<!-- Generic «Off» string -->
+	<string name="off">Desligado</string>
+	<!-- Generic «On» string -->
+	<string name="on">Ligado</string>
+	<!-- Generic «Auto» string -->
+	<string name="auto">Automático</string>
 	<!-- Settings «Map» category: «Perspective view» title -->
 	<string name="pref_map_3d_title">Visão em perspectiva</string>
 	<!-- Settings «Map» category: «3D buildings» title -->
@@ -539,8 +539,6 @@
 	<string name="enable_logging">Ativar o histórico</string>
 	<!-- Settings: "Send general feedback" button -->
 	<string name="feedback_general">Opinão geral</string>
-	<string name="on">Lig.</string>
-	<string name="off">Deslig.</string>
 	<string name="prefs_languages_information">Utilizamos o sistema TTS (texto-para-voz) para instruções de voz. Muitos dispositivos do Android usam o TTS do Google, você pode baixá-lo ou atualizá-lo no Google Play (https://play.google.com/store/apps/details?id=com.google.android.tts)</string>
 	<string name="prefs_languages_information_off_link">Para obter mais informações, consulte este guia.</string>
 	<string name="transliteration_title">Transliteração para alfabeto latino</string>
@@ -608,9 +606,10 @@
 	<string name="bookmark_list_description_hint">Digite uma descrição (texto ou html)</string>
 	<string name="not_shared">Privado</string>
 	<string name="speedcams_alert_title">Câmeras de trânsito</string>
-	<string name="speedcam_option_auto">Automático</string>
-	<string name="speedcam_option_always">Sempre</string>
-	<string name="speedcam_option_never">Nunca</string>
+	<!-- Generic «Always» string -->
+	<string name="always">Sempre</string>
+	<!-- Generic «Never» string -->
+	<string name="never">Nunca</string>
 	<string name="place_description_title">Descrição do lugar</string>
 	<!-- this text will be shown in application notification preferences opposite checkbox which enable/disable downloader notifications. Devices on Android 8+ are affected. -->
 	<string name="notification_channel_downloader">Downloader do mapa</string>

--- a/android/app/src/main/res/values-pt/strings.xml
+++ b/android/app/src/main/res/values-pt/strings.xml
@@ -200,12 +200,12 @@
 	<string name="pref_zoom_summary">Mostrar no ecrã</string>
 	<!-- Settings «Map» category: «Night style» title -->
 	<string name="pref_map_style_title">Modo noturno</string>
-	<!-- «Map style» entry value -->
-	<string name="pref_map_style_default">Desligado</string>
-	<!-- «Map style» entry value -->
-	<string name="pref_map_style_night">Ligado</string>
-	<!-- «Map style» entry value -->
-	<string name="pref_map_style_auto">Automático</string>
+	<!-- Generic «Off» string -->
+	<string name="off">Desligado</string>
+	<!-- Generic «On» string -->
+	<string name="on">Ligado</string>
+	<!-- Generic «Auto» string -->
+	<string name="auto">Automático</string>
 	<!-- Settings «Map» category: «Perspective view» title -->
 	<string name="pref_map_3d_title">Visão em perspetiva</string>
 	<!-- Settings «Map» category: «3D buildings» title -->
@@ -533,8 +533,6 @@
 	<string name="enable_logging">Ativar o histórico</string>
 	<!-- Settings: "Send general feedback" button -->
 	<string name="feedback_general">Opinão geral</string>
-	<string name="on">Lig.</string>
-	<string name="off">Deslig.</string>
 	<string name="prefs_languages_information">Utilizamos o sistema TTS para as instruções de voz. Muitos dispositivos Android usam o Google TTS, pode transferir ou atualizá-lo a partir do Google Play (https://play.google.com/store/apps/details?id=com.google.android.tts)</string>
 	<string name="prefs_languages_information_off">Para alguns idiomas, precisará de instalar outro sintetizador de voz ou um pacote de idiomas adicional a partir da loja de aplicações (Google Play, Galaxy Store, App Gallery, FDroid). Abra as Configurações do seu dispositivo → Idioma e entrada → Voz → Saída de texto para voz. Aqui pode gerir as configurações de síntese de voz (por exemplo, transferir um pacote de idioma para poder utilizá-lo sem estar ligado à Internet) ou selecionar outro motor de texto para voz.</string>
 	<string name="prefs_languages_information_off_link">Para obter mais informações, consulte este guia.</string>
@@ -605,9 +603,10 @@
 	<string name="bookmark_list_description_hint">Introduza uma descrição (texto ou html)</string>
 	<string name="not_shared">Privado</string>
 	<string name="speedcams_alert_title">Radares de velocidade</string>
-	<string name="speedcam_option_auto">Automático</string>
-	<string name="speedcam_option_always">Sempre</string>
-	<string name="speedcam_option_never">Nunca</string>
+	<!-- Generic «Always» string -->
+	<string name="always">Sempre</string>
+	<!-- Generic «Never» string -->
+	<string name="never">Nunca</string>
 	<string name="place_description_title">Descrição do local</string>
 	<!-- this text will be shown in application notification preferences opposite checkbox which enable/disable downloader notifications. Devices on Android 8+ are affected. -->
 	<string name="notification_channel_downloader">Descarregador de mapas</string>

--- a/android/app/src/main/res/values-ro/strings.xml
+++ b/android/app/src/main/res/values-ro/strings.xml
@@ -200,12 +200,12 @@
 	<string name="pref_zoom_summary">Arată pe hartă</string>
 	<!-- Settings «Map» category: «Night style» title -->
 	<string name="pref_map_style_title">Mod nocturn</string>
-	<!-- «Map style» entry value -->
-	<string name="pref_map_style_default">Oprit</string>
-	<!-- «Map style» entry value -->
-	<string name="pref_map_style_night">Pornit</string>
-	<!-- «Map style» entry value -->
-	<string name="pref_map_style_auto">Automat</string>
+	<!-- Generic «Off» string -->
+	<string name="off">Oprit</string>
+	<!-- Generic «On» string -->
+	<string name="on">Pornit</string>
+	<!-- Generic «Auto» string -->
+	<string name="auto">Automat</string>
 	<!-- Settings «Map» category: «Perspective view» title -->
 	<string name="pref_map_3d_title">Vedere în perspectivă</string>
 	<!-- Settings «Map» category: «3D buildings» title -->
@@ -540,8 +540,6 @@
 	<string name="enable_logging">Activează jurnalizarea</string>
 	<!-- Settings: "Send general feedback" button -->
 	<string name="feedback_general">Părere generală</string>
-	<string name="on">Pornit</string>
-	<string name="off">Oprit</string>
 	<string name="prefs_languages_information">Pentru instrucțiuni vocale utilizăm sistemul TTS. Multe dispozitive Android folosesc Google TTS. Poți descărca sau actualiza aplicația din Google Play (https://play.google.com/store/apps/details?id=com.google.android.tts)</string>
 	<string name="prefs_languages_information_off">Pentru unele limbi trebuie să instalezi alt sintetizator de voce sau un pachet lingvistic suplimentar din Magazinul de aplicații (Google Play, Galaxy Store, App Gallery, FDroid).\nDeschide setările dispozitivului → Limbă → Transformare text în vorbire → Motor preferat.\nAici poți alege motorul de transformare a textului în vorbire și poți descărca o limbă pentru utilizare fără internet.</string>
 	<string name="prefs_languages_information_off_link">Consultă acest ghid pentru informații suplimentare.</string>
@@ -612,9 +610,10 @@
 	<string name="bookmark_list_description_hint">Adaugă o descriere (text sau html)</string>
 	<string name="not_shared">Personal</string>
 	<string name="speedcams_alert_title">Radare</string>
-	<string name="speedcam_option_auto">Auto</string>
-	<string name="speedcam_option_always">Mereu</string>
-	<string name="speedcam_option_never">Niciodată</string>
+	<!-- Generic «Always» string -->
+	<string name="always">Mereu</string>
+	<!-- Generic «Never» string -->
+	<string name="never">Niciodată</string>
 	<string name="place_description_title">Descrierea locului</string>
 	<!-- this text will be shown in application notification preferences opposite checkbox which enable/disable downloader notifications. Devices on Android 8+ are affected. -->
 	<string name="notification_channel_downloader">Descărcarea hărților</string>

--- a/android/app/src/main/res/values-ru/strings.xml
+++ b/android/app/src/main/res/values-ru/strings.xml
@@ -215,12 +215,12 @@
 	<string name="pref_zoom_summary">Показать на карте</string>
 	<!-- Settings «Map» category: «Night style» title -->
 	<string name="pref_map_style_title">Ночной режим</string>
-	<!-- «Map style» entry value -->
-	<string name="pref_map_style_default">Выключен</string>
-	<!-- «Map style» entry value -->
-	<string name="pref_map_style_night">Включен</string>
-	<!-- «Map style» entry value -->
-	<string name="pref_map_style_auto">Автоматически</string>
+	<!-- Generic «Off» string -->
+	<string name="off">Выключен</string>
+	<!-- Generic «On» string -->
+	<string name="on">Включен</string>
+	<!-- Generic «Auto» string -->
+	<string name="auto">Автоматически</string>
 	<!-- Settings «Map» category: «Perspective view» title -->
 	<string name="pref_map_3d_title">Перспективный вид</string>
 	<!-- Settings «Map» category: «3D buildings» title -->
@@ -562,8 +562,6 @@
 	<string name="enable_logging">Включить запись логов</string>
 	<!-- Settings: "Send general feedback" button -->
 	<string name="feedback_general">Отправить отзыв</string>
-	<string name="on">Вкл.</string>
-	<string name="off">Выкл.</string>
 	<string name="prefs_languages_information">Подсказки озвучиваются системным синтезатором речи (TTS). На многих устройствах используется Google TTS, его можно загрузить или обновить в Google Play (https://play.google.com/store/apps/details?id=com.google.android.tts)</string>
 	<string name="prefs_languages_information_off">Для некоторых языков, возможно, необходимо установить дополнительный синтезатор речи (TTS) из магазина приложений (Google Play, Galaxy Store, App Gallery, FDroid).\nЧтобы настроить синтезатор речи, перейдите в Настройки → Язык и ввод → Синтез речи.\nЗдесь можно установить дополнительные языковые пакеты или выбрать синтезатор речи.</string>
 	<string name="prefs_languages_information_off_link">Более подробная информация — в этом руководстве.</string>
@@ -638,9 +636,10 @@
 	<string name="bookmark_list_description_hint">Добавьте описание (текст или html)</string>
 	<string name="not_shared">Личный</string>
 	<string name="speedcams_alert_title">Камеры скорости</string>
-	<string name="speedcam_option_auto">Авто</string>
-	<string name="speedcam_option_always">Всегда</string>
-	<string name="speedcam_option_never">Никогда</string>
+	<!-- Generic «Always» string -->
+	<string name="always">Всегда</string>
+	<!-- Generic «Never» string -->
+	<string name="never">Никогда</string>
 	<string name="place_description_title">Описание места</string>
 	<!-- this text will be shown in application notification preferences opposite checkbox which enable/disable downloader notifications. Devices on Android 8+ are affected. -->
 	<string name="notification_channel_downloader">Загрузка карт</string>

--- a/android/app/src/main/res/values-sk/strings.xml
+++ b/android/app/src/main/res/values-sk/strings.xml
@@ -195,12 +195,12 @@
 	<string name="pref_zoom_summary">Zobraziť na obrazovke</string>
 	<!-- Settings «Map» category: «Night style» title -->
 	<string name="pref_map_style_title">Nočný režim</string>
-	<!-- «Map style» entry value -->
-	<string name="pref_map_style_default">Vypnúť</string>
-	<!-- «Map style» entry value -->
-	<string name="pref_map_style_night">Zapnúť</string>
-	<!-- «Map style» entry value -->
-	<string name="pref_map_style_auto">Automaticky</string>
+	<!-- Generic «Off» string -->
+	<string name="off">Vypnúť</string>
+	<!-- Generic «On» string -->
+	<string name="on">Zapnúť</string>
+	<!-- Generic «Auto» string -->
+	<string name="auto">Automaticky</string>
 	<!-- Settings «Map» category: «Perspective view» title -->
 	<string name="pref_map_3d_title">Perspektívne zobrazenie</string>
 	<!-- Settings «Map» category: «3D buildings» title -->
@@ -524,8 +524,6 @@
 	<string name="enable_logging">Zapnúť zaznamenávanie</string>
 	<!-- Settings: "Send general feedback" button -->
 	<string name="feedback_general">Všeobecné pripomienky</string>
-	<string name="on">Zap.</string>
-	<string name="off">Vyp.</string>
 	<string name="prefs_languages_information">Na hlasové pokyny používame systém TTS. Mnohé zariadenia s Adroidom používajú Google TTS, ktorý si môžete stiahnuť alebo aktualizovať z obchodu Google Play (https://play.google.com/store/apps/details?id=com.google.android.tts)</string>
 	<string name="prefs_languages_information_off">Pre niektoré jazyky bude potrebné nainštalovať syntetizátor reči alebo balík doplnkového jazyka z obchodu s aplikáciami (Google Play, Galaxy Store, App Gallery, FDroid). Otvorte nastavenia zariadenia → Jazyk a vstup → Reč → Prevod textu na reč. Tu môžete spravovať nastavenia pre syntézu reči (napríklad stiahnuť jazykový balík pre použitie v režime offline) a vybrať iný jazyk.</string>
 	<string name="prefs_languages_information_off_link">Viac informácií nájdete v tomto návode.</string>
@@ -594,9 +592,10 @@
 	<string name="bookmark_list_description_hint">Zadajte popis (text alebo html)</string>
 	<string name="not_shared">Súkromné</string>
 	<string name="speedcams_alert_title">Rýchlostné kamery</string>
-	<string name="speedcam_option_auto">Automaticky</string>
-	<string name="speedcam_option_always">Vždy</string>
-	<string name="speedcam_option_never">Nikdy</string>
+	<!-- Generic «Always» string -->
+	<string name="always">Vždy</string>
+	<!-- Generic «Never» string -->
+	<string name="never">Nikdy</string>
 	<string name="place_description_title">Popis miesta</string>
 	<!-- this text will be shown in application notification preferences opposite checkbox which enable/disable downloader notifications. Devices on Android 8+ are affected. -->
 	<string name="notification_channel_downloader">Sťahovač máp</string>

--- a/android/app/src/main/res/values-sv/strings.xml
+++ b/android/app/src/main/res/values-sv/strings.xml
@@ -193,12 +193,12 @@
 	<string name="pref_zoom_summary">Visa på skärmen</string>
 	<!-- Settings «Map» category: «Night style» title -->
 	<string name="pref_map_style_title">Nattläge</string>
-	<!-- «Map style» entry value -->
-	<string name="pref_map_style_default">Av</string>
-	<!-- «Map style» entry value -->
-	<string name="pref_map_style_night">På</string>
-	<!-- «Map style» entry value -->
-	<string name="pref_map_style_auto">Auto</string>
+	<!-- Generic «Off» string -->
+	<string name="off">Av</string>
+	<!-- Generic «On» string -->
+	<string name="on">På</string>
+	<!-- Generic «Auto» string -->
+	<string name="auto">Auto</string>
 	<!-- Settings «Map» category: «Perspective view» title -->
 	<string name="pref_map_3d_title">Perspektivvy</string>
 	<!-- Settings «Map» category: «3D buildings» title -->
@@ -524,8 +524,6 @@
 	<string name="enable_logging">Aktivera loggning</string>
 	<!-- Settings: "Send general feedback" button -->
 	<string name="feedback_general">Allmän feedback</string>
-	<string name="on">På</string>
-	<string name="off">Av</string>
 	<string name="prefs_languages_information">Vi använder TTS-system för röstinstruktioner. Flera Android-enheter använder Google TTS. Du kan ladda ned eller uppdatera det på Google Play (https://play.google.com/store/apps/details?id=com.google.android.tts)</string>
 	<string name="prefs_languages_information_off">För vissa språk måste du installera en annan talsyntes eller ett annat språkpaket från appbutiken (Google Play Market, Galaxy Store).\nÖppna inställningarna på enheten → Språk och inmatning → Tal → Text till tal-uppspelning.\nHär kan du hantera inställningarna för talsyntes (till exempel, ladda ned språkpaket för användning offline) och välja en annan text till tal-motor.</string>
 	<string name="prefs_languages_information_off_link">Kolla in den här guiden för mer information.</string>
@@ -595,9 +593,10 @@
 	<string name="bookmark_list_description_hint">Lägg till en beskrivning (text eller html)</string>
 	<string name="not_shared">Personlig</string>
 	<string name="speedcams_alert_title">Hastighetskameror</string>
-	<string name="speedcam_option_auto">Auto</string>
-	<string name="speedcam_option_always">Alltid</string>
-	<string name="speedcam_option_never">Aldrig</string>
+	<!-- Generic «Always» string -->
+	<string name="always">Alltid</string>
+	<!-- Generic «Never» string -->
+	<string name="never">Aldrig</string>
 	<string name="place_description_title">Beskrivning av platsen</string>
 	<!-- this text will be shown in application notification preferences opposite checkbox which enable/disable downloader notifications. Devices on Android 8+ are affected. -->
 	<string name="notification_channel_downloader">Kartladdning</string>

--- a/android/app/src/main/res/values-sw/strings.xml
+++ b/android/app/src/main/res/values-sw/strings.xml
@@ -38,6 +38,8 @@
 	<string name="rv">Kwa RV</string>
 	<!-- Data version in «About» screen, %@ is replaced by a local, human readable date. -->
 	<string name="data_version">Data ya OpenStreetMap: %s</string>
+	<!-- Generic «Auto» string -->
+	<string name="auto">Auto</string>
 	<!-- A message in Settings/Preferences explaining why is it not possible to enable 3D buildings when max power saving mode is enabled -->
 	<string name="pref_map_3d_buildings_disabled_summary">Majengo ya 3D yamezimwa katika hali ya kuokoa nishati</string>
 	<!-- Text in About menu, opens Organic Maps news website -->
@@ -82,8 +84,6 @@
 	<string name="about_description">Organic Maps ni programu huria na ya chanzo huria ya ramani za nje ya mtandao. Hakuna matangazo. Hakuna ufuatiliaji. Ukiona hitilafu kwenye ramani, tafadhali irekebishe katika OpenStreetMap. Mradi huu umeundwa na wapendaji katika wakati wetu wa bure, kwa hivyo tunahitaji maoni na usaidizi wako.</string>
 	<!-- Settings: "Send general feedback" button -->
 	<string name="feedback_general">Maoni Jumla</string>
-	<string name="on">Washa</string>
-	<string name="off">Zima</string>
 	<string name="prefs_languages_information">Tunatumia maagizo ya sautii ya TTS ya mfumo. Vifaa vingi vya Android vinatumia Google TTS, unaweza kuipakua au kuisasisha kwenye Google Play (https://play.google.com/store/apps/details?id=com.google.android.tts)</string>
 	<string name="prefs_languages_information_off">Kwa baadhi ya lugha, utahitaji kusakinisha programu nyingine ya kusanidi usemi au kifurushi cha ziada cha lugha kutoka kwenye duka la programu-tumizi (Google Play, Galaxy Store, App Gallery, FDroid).\nFungua mipangilio ya kifaa chako → Lugha na Ingizo → Usemi → Tokeo la maandishi kuwa usemi.\nHapa unaweza kusimamia usanidi wa usemi (kwa mfano, kupakua kifurushi cha lugha ili utumie nje ya mtandao) na uchague injini nyingine ya maandishi-kuwa-usemi.</string>
 	<string name="prefs_languages_information_off_link">Kwa maelezo zaidi tafadhali tazama mwongozo huu.</string>
@@ -150,9 +150,10 @@
 	<string name="bookmark_list_description_hint">Andika maelezo (maneno au html)</string>
 	<string name="not_shared">Faragha</string>
 	<string name="speedcams_alert_title">Kamera za mwendo-kasi</string>
-	<string name="speedcam_option_auto">Auto</string>
-	<string name="speedcam_option_always">Mara kwa Mara</string>
-	<string name="speedcam_option_never">Kamwe</string>
+	<!-- Generic «Always» string -->
+	<string name="always">Mara kwa Mara</string>
+	<!-- Generic «Never» string -->
+	<string name="never">Kamwe</string>
 	<string name="place_description_title">Maelezo ya Eneo</string>
 	<!-- this text will be shown in application notification preferences opposite checkbox which enable/disable downloader notifications. Devices on Android 8+ are affected. -->
 	<string name="notification_channel_downloader">Kipakua Ramani</string>

--- a/android/app/src/main/res/values-th/strings.xml
+++ b/android/app/src/main/res/values-th/strings.xml
@@ -197,12 +197,12 @@
 	<string name="pref_zoom_summary">แสดงบนหน้าจอ</string>
 	<!-- Settings «Map» category: «Night style» title -->
 	<string name="pref_map_style_title">โหมดกลางคืน</string>
-	<!-- «Map style» entry value -->
-	<string name="pref_map_style_default">ปิด</string>
-	<!-- «Map style» entry value -->
-	<string name="pref_map_style_night">เปิด</string>
-	<!-- «Map style» entry value -->
-	<string name="pref_map_style_auto">อัตโนมัติ</string>
+	<!-- Generic «Off» string -->
+	<string name="off">ปิด</string>
+	<!-- Generic «On» string -->
+	<string name="on">เปิด</string>
+	<!-- Generic «Auto» string -->
+	<string name="auto">อัตโนมัติ</string>
 	<!-- Settings «Map» category: «Perspective view» title -->
 	<string name="pref_map_3d_title">มุมมองเพอร์สเปกทีฟ</string>
 	<!-- Settings «Map» category: «3D buildings» title -->
@@ -528,8 +528,6 @@
 	<string name="enable_logging">เปิดใช้งานการเก็บล็อก</string>
 	<!-- Settings: "Send general feedback" button -->
 	<string name="feedback_general">ข้อเสนอแนะทั่วไป</string>
-	<string name="on">เปิด</string>
-	<string name="off">ปิด</string>
 	<string name="prefs_languages_information">เราใช้ระบบ TTS สำหรับคำแนะนำด้วยเสียงพูด เครื่องแอนดรอยด์จำนวนมากใช้งาน Google TTS คุณสามารถดาวน์โหลดหรืออัปเดตได้จาก Google Play (https://play.google.com/store/apps/details?id=com.google.android.tts)</string>
 	<string name="prefs_languages_information_off">สำหรับบางภาษาคุณจำเป็นต้องติดตั้งตัวสังเคราะห์เสียงหรือชุดภาษาเพิ่มเติมจากแอปสโตร์ (Google Play, Galaxy Store, App Gallery, FDroid)\nเปิดการตั้งค่าของเครื่องคุณ → ภาษาและการป้อนข้อมูล → คำพูด → เอาต์พุตการอ่านออกเสียง\nที่นี่คุณสามารถจัดการการตั้งค่าสำหรับการสังเคราะห์เสียง (ตัวอย่างเช่น ดาวน์โหลดชุดภาษาสำหรับใช้งานออฟไลน์) และเลือกเครื่องมืออ่านออกเสียงข้อความตัวอื่นได้</string>
 	<string name="prefs_languages_information_off_link">สำหรับข้อมูลเพิ่มเติม กรุณาเข้าชมคำแนะนำนี้</string>
@@ -596,9 +594,10 @@
 	<string name="bookmark_list_description_hint">พิมพ์รายละเอียด (ข้อความหรือ html)</string>
 	<string name="not_shared">ส่วนตัว</string>
 	<string name="speedcams_alert_title">กล้องตรวจจับความเร็ว</string>
-	<string name="speedcam_option_auto">อัตโนมัติ</string>
-	<string name="speedcam_option_always">ทุกครั้ง</string>
-	<string name="speedcam_option_never">ไม่ต้องเตือน</string>
+	<!-- Generic «Always» string -->
+	<string name="always">ทุกครั้ง</string>
+	<!-- Generic «Never» string -->
+	<string name="never">ไม่ต้องเตือน</string>
 	<string name="place_description_title">รายละเอียดของสถานที่</string>
 	<!-- this text will be shown in application notification preferences opposite checkbox which enable/disable downloader notifications. Devices on Android 8+ are affected. -->
 	<string name="notification_channel_downloader">ตัวดาวน์โหลดแผนที่</string>

--- a/android/app/src/main/res/values-tr/strings.xml
+++ b/android/app/src/main/res/values-tr/strings.xml
@@ -214,12 +214,12 @@
 	<string name="pref_zoom_summary">Haritada göster</string>
 	<!-- Settings «Map» category: «Night style» title -->
 	<string name="pref_map_style_title">Gece Modu</string>
-	<!-- «Map style» entry value -->
-	<string name="pref_map_style_default">Kapalı</string>
-	<!-- «Map style» entry value -->
-	<string name="pref_map_style_night">Açık</string>
-	<!-- «Map style» entry value -->
-	<string name="pref_map_style_auto">Otomatik</string>
+	<!-- Generic «Off» string -->
+	<string name="off">Kapalı</string>
+	<!-- Generic «On» string -->
+	<string name="on">Açık</string>
+	<!-- Generic «Auto» string -->
+	<string name="auto">Otomatik</string>
 	<!-- Settings «Map» category: «Perspective view» title -->
 	<string name="pref_map_3d_title">Perspektif görünüm</string>
 	<!-- Settings «Map» category: «3D buildings» title -->
@@ -559,8 +559,6 @@
 	<string name="enable_logging">Günlüğü etkinleştir</string>
 	<!-- Settings: "Send general feedback" button -->
 	<string name="feedback_general">Genel Geri Bildirim</string>
-	<string name="on">Aç</string>
-	<string name="off">Kapat</string>
 	<string name="prefs_languages_information">Sesli yönlendirme için TTS sistemini kullanıyoruz. Çoğu Android cihaz, Google TTS\'yi kullanıyor. Uygulamayı, Google Play\'den indirebilir veya güncelleyebilirsiniz (https://play.google.com/store/apps/details?id=com.google.android.tts)</string>
 	<string name="prefs_languages_information_off">Bazı diller için uygulama mağazasından (Google Play, Galaxy Store, App Gallery, FDroid) farklı bir konuşma sentezleyicisi veya ek bir dil paketi yüklemeniz gerekebilir. Cihaz ayarları → Dil ve Giriş → Konuşma → Metin Okuma seçeneğini açın. Buradan konuşma sentezi ayarlarını yönetebilir (örneğin, çevrimdışı kullanım için bir dil paketini karşıdan yükleyebilir) ve başka bir metin okuma motorunu seçebilirsiniz.</string>
 	<string name="prefs_languages_information_off_link">Daha fazla bilgi için lütfen bu kılavuzu inceleyin.</string>
@@ -627,9 +625,10 @@
 	<string name="bookmark_list_description_hint">Bir açıklama yazın (metin veya html)</string>
 	<string name="not_shared">Gizli</string>
 	<string name="speedcams_alert_title">Hız kameraları</string>
-	<string name="speedcam_option_auto">Otomatik</string>
-	<string name="speedcam_option_always">Her zaman</string>
-	<string name="speedcam_option_never">Asla</string>
+	<!-- Generic «Always» string -->
+	<string name="always">Her zaman</string>
+	<!-- Generic «Never» string -->
+	<string name="never">Asla</string>
 	<string name="place_description_title">Yer Açıklaması</string>
 	<!-- this text will be shown in application notification preferences opposite checkbox which enable/disable downloader notifications. Devices on Android 8+ are affected. -->
 	<string name="notification_channel_downloader">Harita indirici</string>

--- a/android/app/src/main/res/values-uk/strings.xml
+++ b/android/app/src/main/res/values-uk/strings.xml
@@ -208,12 +208,12 @@
 	<string name="pref_zoom_summary">Відображення на екрані</string>
 	<!-- Settings «Map» category: «Night style» title -->
 	<string name="pref_map_style_title">Нічний режим</string>
-	<!-- «Map style» entry value -->
-	<string name="pref_map_style_default">Вимкнуто</string>
-	<!-- «Map style» entry value -->
-	<string name="pref_map_style_night">Увімкнуто</string>
-	<!-- «Map style» entry value -->
-	<string name="pref_map_style_auto">Автоматично</string>
+	<!-- Generic «Off» string -->
+	<string name="off">Вимкнуто</string>
+	<!-- Generic «On» string -->
+	<string name="on">Увімкнуто</string>
+	<!-- Generic «Auto» string -->
+	<string name="auto">Автоматично</string>
 	<!-- Settings «Map» category: «Perspective view» title -->
 	<string name="pref_map_3d_title">Перспективний вид</string>
 	<!-- Settings «Map» category: «3D buildings» title -->
@@ -554,8 +554,6 @@
 	<string name="enable_logging">Включити логіювання</string>
 	<!-- Settings: "Send general feedback" button -->
 	<string name="feedback_general">Загальний відгук</string>
-	<string name="on">Увімкн.</string>
-	<string name="off">Вимкн.</string>
 	<string name="prefs_languages_information">Для озвучування голосових інструкцій ми використовуємо систему TTS. Більшість Android-пристроїв підтримують систему Google TTS. Для завантаження або оновлення перейдіть до магазину Google Play (https://play.google.com/store/apps/details?id=com.google.android.tts)</string>
 	<string name="prefs_languages_information_off">Для деяких мов вам знадобиться встановити інший додаток для синтезу мовлення або додатковий мовний пакет з магазину додатків (Google Play, Galaxy Store, App Gallery, FDroid).\nВідкрийте налаштування пристрою → Мови та введення → Мовлення → Синтез мовлення.\nТут ви можете здійснювати управління налаштуваннями синтезу мовлення (наприклад, завантажити мовний пакет для використання офлайн) або вибрати інший програмний рушій для синтезу мовлення.</string>
 	<string name="prefs_languages_information_off_link">Додаткову інформацію див. у цьому керівництві.</string>
@@ -624,9 +622,10 @@
 	<string name="bookmark_list_description_hint">Додайте опис (текст чи html)</string>
 	<string name="not_shared">Особистий</string>
 	<string name="speedcams_alert_title">Камери швидкості</string>
-	<string name="speedcam_option_auto">Авто</string>
-	<string name="speedcam_option_always">Завжди</string>
-	<string name="speedcam_option_never">Ніколи</string>
+	<!-- Generic «Always» string -->
+	<string name="always">Завжди</string>
+	<!-- Generic «Never» string -->
+	<string name="never">Ніколи</string>
 	<string name="place_description_title">Опис місця</string>
 	<!-- this text will be shown in application notification preferences opposite checkbox which enable/disable downloader notifications. Devices on Android 8+ are affected. -->
 	<string name="notification_channel_downloader">Завантаження мап</string>

--- a/android/app/src/main/res/values-vi/strings.xml
+++ b/android/app/src/main/res/values-vi/strings.xml
@@ -195,12 +195,12 @@
 	<string name="pref_zoom_summary">Hiển thị trên màn hình</string>
 	<!-- Settings «Map» category: «Night style» title -->
 	<string name="pref_map_style_title">Chế độ ban đêm</string>
-	<!-- «Map style» entry value -->
-	<string name="pref_map_style_default">Tắt</string>
-	<!-- «Map style» entry value -->
-	<string name="pref_map_style_night">Bật</string>
-	<!-- «Map style» entry value -->
-	<string name="pref_map_style_auto">Tự động</string>
+	<!-- Generic «Off» string -->
+	<string name="off">Tắt</string>
+	<!-- Generic «On» string -->
+	<string name="on">Bật</string>
+	<!-- Generic «Auto» string -->
+	<string name="auto">Tự động</string>
 	<!-- Settings «Map» category: «Perspective view» title -->
 	<string name="pref_map_3d_title">Góc nhìn phối cảnh</string>
 	<!-- Settings «Map» category: «3D buildings» title -->
@@ -526,8 +526,6 @@
 	<string name="enable_logging">Bật nhật ký</string>
 	<!-- Settings: "Send general feedback" button -->
 	<string name="feedback_general">Phản hồi chung</string>
-	<string name="on">Bật</string>
-	<string name="off">Tắt</string>
 	<string name="prefs_languages_information">Chúng tôi sử dụng TTS hệ thống để hướng dẫn bằng giọng nói. Rất nhiều thiết bị Android sử dụng Google TTS, bạn có thể tải về hoặc cập nhật nó từ Google Play (https://play.google.com/store/apps/details?id=com.google.android.tts)</string>
 	<string name="prefs_languages_information_off">Đối với một số ngôn ngữ, bạn sẽ cần cài đặt một trình tổng hợp lời nói khác hoặc một gói ngôn ngữ bổ sung từ cửa hàng ứng dụng (Google Play, Galaxy Store, App Gallery, FDroid).\nMở cài đặt của thiết bị → Ngôn ngữ và nhập liệu → Lời nói → Đầu ra văn bản sang lời nói.\nTại đây bạn có thể quản lý các cài đặt tổng hợp lời nói (ví dụ, tải về các gói ngôn ngữ để sử dụng ngoại tuyến) và chọn một công cụ chuyển đổi văn bản sang lời nói khác.</string>
 	<string name="prefs_languages_information_off_link">Để biết thêm thông tin, vui lòng kiểm tra bài hướng dẫn này.</string>
@@ -595,9 +593,10 @@
 	<string name="bookmark_list_description_hint">Đánh vào một mô tả (văn bản hoặc html)</string>
 	<string name="not_shared">Riêng tư</string>
 	<string name="speedcams_alert_title">Tăn tốc độ máy ảnh</string>
-	<string name="speedcam_option_auto">Tự động</string>
-	<string name="speedcam_option_always">Luôn luôn</string>
-	<string name="speedcam_option_never">Không bao giờ</string>
+	<!-- Generic «Always» string -->
+	<string name="always">Luôn luôn</string>
+	<!-- Generic «Never» string -->
+	<string name="never">Không bao giờ</string>
 	<string name="place_description_title">Mô tả Địa điểm</string>
 	<!-- this text will be shown in application notification preferences opposite checkbox which enable/disable downloader notifications. Devices on Android 8+ are affected. -->
 	<string name="notification_channel_downloader">Trình tải xuống bản đồ</string>

--- a/android/app/src/main/res/values-zh-rTW/strings.xml
+++ b/android/app/src/main/res/values-zh-rTW/strings.xml
@@ -200,12 +200,12 @@
 	<string name="pref_zoom_summary">在螢幕上顯示</string>
 	<!-- Settings «Map» category: «Night style» title -->
 	<string name="pref_map_style_title">夜間模式</string>
-	<!-- «Map style» entry value -->
-	<string name="pref_map_style_default">關閉</string>
-	<!-- «Map style» entry value -->
-	<string name="pref_map_style_night">開啟</string>
-	<!-- «Map style» entry value -->
-	<string name="pref_map_style_auto">自動</string>
+	<!-- Generic «Off» string -->
+	<string name="off">關閉</string>
+	<!-- Generic «On» string -->
+	<string name="on">開啟</string>
+	<!-- Generic «Auto» string -->
+	<string name="auto">自動</string>
 	<!-- Settings «Map» category: «Perspective view» title -->
 	<string name="pref_map_3d_title">透視圖</string>
 	<!-- Settings «Map» category: «3D buildings» title -->
@@ -544,8 +544,6 @@
 	<string name="enable_logging">啟用記錄</string>
 	<!-- Settings: "Send general feedback" button -->
 	<string name="feedback_general">一般反應</string>
-	<string name="on">開</string>
-	<string name="off">關</string>
 	<string name="prefs_languages_information">我們使用系統 TTS 提供語音指示。許多 Android 裝置使用 Google TTS，您可從 Google Play 下載或更新 (https://play.google.com/store/apps/details?id=com.google.android.tts)</string>
 	<string name="prefs_languages_information_off">對於某些語言，您將需要從 App 商店 (Google Play 商店, Galaxy Store) 安裝其他語音合成器或額外的語言套件。\n開啟您裝置的設定 → 語言與輸入 → 語音 → 文字轉換語音輸出。\n在這裡，您可以管理語音合成器的設定（例如，下載語言套件以供離線使用），並選取其他文字轉換語音引擎。</string>
 	<string name="prefs_languages_information_off_link">如需更多資訊，請參閱本指南。</string>
@@ -612,9 +610,10 @@
 	<string name="bookmark_list_description_hint">增加說明(文字或html)</string>
 	<string name="not_shared">私人</string>
 	<string name="speedcams_alert_title">超速照相機</string>
-	<string name="speedcam_option_auto">自動</string>
-	<string name="speedcam_option_always">總是</string>
-	<string name="speedcam_option_never">從不</string>
+	<!-- Generic «Always» string -->
+	<string name="always">總是</string>
+	<!-- Generic «Never» string -->
+	<string name="never">從不</string>
 	<string name="place_description_title">地點說明</string>
 	<!-- this text will be shown in application notification preferences opposite checkbox which enable/disable downloader notifications. Devices on Android 8+ are affected. -->
 	<string name="notification_channel_downloader">載入地圖</string>

--- a/android/app/src/main/res/values-zh/strings.xml
+++ b/android/app/src/main/res/values-zh/strings.xml
@@ -199,12 +199,12 @@
 	<string name="pref_zoom_summary">在屏幕上显示</string>
 	<!-- Settings «Map» category: «Night style» title -->
 	<string name="pref_map_style_title">夜间模式</string>
-	<!-- «Map style» entry value -->
-	<string name="pref_map_style_default">关闭</string>
-	<!-- «Map style» entry value -->
-	<string name="pref_map_style_night">开启</string>
-	<!-- «Map style» entry value -->
-	<string name="pref_map_style_auto">自动</string>
+	<!-- Generic «Off» string -->
+	<string name="off">关闭</string>
+	<!-- Generic «On» string -->
+	<string name="on">开启</string>
+	<!-- Generic «Auto» string -->
+	<string name="auto">自动</string>
 	<!-- Settings «Map» category: «Perspective view» title -->
 	<string name="pref_map_3d_title">透视图</string>
 	<!-- Settings «Map» category: «3D buildings» title -->
@@ -536,8 +536,6 @@
 	<string name="enable_logging">启用记录</string>
 	<!-- Settings: "Send general feedback" button -->
 	<string name="feedback_general">一般反馈</string>
-	<string name="on">开</string>
-	<string name="off">关</string>
 	<string name="prefs_languages_information">我们为语音指令使用“文字转语音”系统。许多 Android 设备使用 Google 文字转语音，您可以从 Google Play (https://play.google.com/store/apps/details?id=com.google.android.tts) 下载或更新这一功能</string>
 	<string name="prefs_languages_information_off">对于某些语言，您需要从应用商店（Google Play Market、Galaxy Store）中安装其他语音合成器或语言包。\n打开您的设备的设置 → 语言和输入法 → 语音 → 文字转语音 (TTS) 输出。\n您可以在这里管理语音合成的设置（例如，下载语言包供离线使用）和选择其他文字转语音引擎。</string>
 	<string name="prefs_languages_information_off_link">如需了解更多信息，请查阅此指南。</string>
@@ -604,9 +602,10 @@
 	<string name="bookmark_list_description_hint">请添加说明（文字或html）</string>
 	<string name="not_shared">私人</string>
 	<string name="speedcams_alert_title">高速摄像机</string>
-	<string name="speedcam_option_auto">自动</string>
-	<string name="speedcam_option_always">总是</string>
-	<string name="speedcam_option_never">从不</string>
+	<!-- Generic «Always» string -->
+	<string name="always">总是</string>
+	<!-- Generic «Never» string -->
+	<string name="never">从不</string>
 	<string name="place_description_title">地点说明</string>
 	<!-- this text will be shown in application notification preferences opposite checkbox which enable/disable downloader notifications. Devices on Android 8+ are affected. -->
 	<string name="notification_channel_downloader">加载地图</string>

--- a/android/app/src/main/res/values/string-arrays.xml
+++ b/android/app/src/main/res/values/string-arrays.xml
@@ -12,9 +12,9 @@
   </string-array>
 
   <string-array name="map_style">
-    <item>@string/pref_map_style_default</item>
-    <item>@string/pref_map_style_night</item>
-    <item>@string/pref_map_style_auto</item>
+    <item>@string/off</item>
+    <item>@string/on</item>
+    <item>@string/auto</item>
   </string-array>
 
   <string-array name="map_style_values"
@@ -25,9 +25,9 @@
   </string-array>
 
   <string-array name="speed_cameras">
-    <item>@string/speedcam_option_auto</item>
-    <item>@string/speedcam_option_always</item>
-    <item>@string/speedcam_option_never</item>
+    <item>@string/auto</item>
+    <item>@string/always</item>
+    <item>@string/never</item>
   </string-array>
 
   <string-array name="speed_cameras_values" translatable="false">

--- a/android/app/src/main/res/values/strings.xml
+++ b/android/app/src/main/res/values/strings.xml
@@ -215,12 +215,12 @@
 	<string name="pref_zoom_summary">Display on the map</string>
 	<!-- Settings «Map» category: «Night style» title -->
 	<string name="pref_map_style_title">Night Mode</string>
-	<!-- «Map style» entry value -->
-	<string name="pref_map_style_default">Off</string>
-	<!-- «Map style» entry value -->
-	<string name="pref_map_style_night">On</string>
-	<!-- «Map style» entry value -->
-	<string name="pref_map_style_auto">Auto</string>
+	<!-- Generic «Off» string -->
+	<string name="off">Off</string>
+	<!-- Generic «On» string -->
+	<string name="on">On</string>
+	<!-- Generic «Auto» string -->
+	<string name="auto">Auto</string>
 	<!-- Settings «Map» category: «Perspective view» title -->
 	<string name="pref_map_3d_title">Perspective view</string>
 	<!-- Settings «Map» category: «3D buildings» title -->
@@ -584,8 +584,6 @@
 	<string name="enable_logging">Enable logging</string>
 	<!-- Settings: "Send general feedback" button -->
 	<string name="feedback_general">General Feedback</string>
-	<string name="on">On</string>
-	<string name="off">Off</string>
 	<string name="prefs_languages_information">We use system TTS for voice instructions. Many Android devices use Google TTS, you can download or update it from Google Play (https://play.google.com/store/apps/details?id=com.google.android.tts)</string>
 	<string name="prefs_languages_information_off">For some languages, you will need to install a speech synthesizer or an additional language pack from the app store (Google Play, Galaxy Store, App Gallery, FDroid).\nOpen your device\'s settings → Language and input → Speech → Text to speech output.\nHere you can manage settings for speech synthesis (for example, download language pack for offline use) and select another text-to-speech engine.</string>
 	<string name="prefs_languages_information_off_link">For more information please check this guide.</string>
@@ -656,9 +654,10 @@
 	<string name="bookmark_list_description_hint">Enter a description (text or html)</string>
 	<string name="not_shared">Private</string>
 	<string name="speedcams_alert_title">Speed cameras</string>
-	<string name="speedcam_option_auto">Auto</string>
-	<string name="speedcam_option_always">Always</string>
-	<string name="speedcam_option_never">Never</string>
+	<!-- Generic «Always» string -->
+	<string name="always">Always</string>
+	<!-- Generic «Never» string -->
+	<string name="never">Never</string>
 	<string name="place_description_title">Place Description</string>
 	<!-- this text will be shown in application notification preferences opposite checkbox which enable/disable downloader notifications. Devices on Android 8+ are affected. -->
 	<string name="notification_channel_downloader">Map downloader</string>

--- a/data/strings/strings.txt
+++ b/data/strings/strings.txt
@@ -4917,8 +4917,8 @@
     zh-Hans = 夜间模式
     zh-Hant = 夜間模式
 
-  [pref_map_style_default]
-    comment = «Map style» entry value
+  [off]
+    comment = Generic «Off» string
     tags = android,ios
     en = Off
     ar = تعطيل
@@ -4958,8 +4958,8 @@
     zh-Hans = 关闭
     zh-Hant = 關閉
 
-  [pref_map_style_night]
-    comment = «Map style» entry value
+  [on]
+    comment = Generic «On» string
     tags = android,ios
     en = On
     af = Aan
@@ -5000,8 +5000,8 @@
     zh-Hans = 开启
     zh-Hant = 開啟
 
-  [pref_map_style_auto]
-    comment = «Map style» entry value
+  [auto]
+    comment = Generic «Auto» string
     tags = android,ios
     en = Auto
     af = Outomaties
@@ -5014,6 +5014,7 @@
     de = Auto
     el = Αυτόματα
     es = Automático
+    es-MX = Automático
     et = Automaatne
     eu = Automatikoa
     fa = خودکار
@@ -5035,6 +5036,7 @@
     ru = Автоматически
     sk = Automaticky
     sv = Auto
+    sw = Auto
     th = อัตโนมัติ
     tr = Otomatik
     uk = Автоматично
@@ -17980,90 +17982,6 @@
     zh-Hans = 一般反馈
     zh-Hant = 一般反應
 
-  [on]
-    tags = android,ios
-    en = On
-    af = Aan
-    ar = تشغيل
-    be = Укл.
-    bg = Вкл.
-    ca = Actiu
-    cs = Zapnout
-    da = Til
-    de = An
-    el = Ενεργ.
-    es = Act.
-    et = Sees
-    eu = Martxan
-    fa = روشن
-    fi = Käytössä
-    fr = On
-    hu = Be
-    id = On
-    it = Acceso
-    ja = オン
-    ko = 켜기
-    lt = Įjungtas
-    mr = चालू
-    nb = På
-    nl = Aan
-    pl = Wł.
-    pt = Lig.
-    pt-BR = Lig.
-    ro = Pornit
-    ru = Вкл.
-    sk = Zap.
-    sv = På
-    sw = Washa
-    th = เปิด
-    tr = Aç
-    uk = Увімкн.
-    vi = Bật
-    zh-Hans = 开
-    zh-Hant = 開
-
-  [off]
-    tags = android,ios
-    en = Off
-    af = Af
-    ar = إيقاف
-    be = Выкл.
-    bg = Изкл.
-    ca = Inactiu
-    cs = Vypnout
-    da = Fra
-    de = Aus
-    el = Απενεργ.
-    es = Desact.
-    et = Väljas
-    eu = Itzalita
-    fa = خاموش
-    fi = Ei käytössä
-    fr = Off
-    hu = Ki
-    id = Mati
-    it = Spento
-    ja = オフ
-    ko = 끄기
-    lt = Išjungtas
-    mr = बंद
-    nb = Av
-    nl = Uit
-    pl = Wył.
-    pt = Deslig.
-    pt-BR = Deslig.
-    ro = Oprit
-    ru = Выкл.
-    sk = Vyp.
-    sv = Av
-    sw = Zima
-    th = ปิด
-    tr = Kapat
-    uk = Вимкн.
-    vi = Tắt
-    zh-Hans = 关
-    zh-Hant = 關
-
   [prefs_languages_information]
     tags = android
     en = We use system TTS for voice instructions. Many Android devices use Google TTS, you can download or update it from Google Play (https://play.google.com/store/apps/details?id=com.google.android.tts)
@@ -21441,50 +21359,8 @@
     zh-Hans = 高速摄像机
     zh-Hant = 超速照相機
 
-  [speedcam_option_auto]
-    tags = android,ios
-    en = Auto
-    af = Outomaties
-    ar = تلفائياً
-    be = Аўтаматычна
-    bg = Автоматично
-    ca = Automàtic
-    cs = Automaticky
-    da = Auto
-    de = Auto
-    el = Αυτόματο
-    es = Auto
-    es-MX = Automático
-    et = Automaatne
-    eu = Automatikoa
-    fa = خودکار
-    fi = Auto
-    fr = Auto
-    hu = Automatikus
-    id = Auto
-    it = Auto
-    ja = 自動
-    ko = 자동
-    lt = Automatiškai
-    mr = स्वयं
-    nb = Auto
-    nl = Auto
-    pl = Automatycznie
-    pt = Automático
-    pt-BR = Automático
-    ro = Auto
-    ru = Авто
-    sk = Automaticky
-    sv = Auto
-    sw = Auto
-    th = อัตโนมัติ
-    tr = Otomatik
-    uk = Авто
-    vi = Tự động
-    zh-Hans = 自动
-    zh-Hant = 自動
-
-  [speedcam_option_always]
+  [always]
+    comment = Generic «Always» string
     tags = android,ios
     en = Always
     af = Altyd
@@ -21527,7 +21403,8 @@
     zh-Hans = 总是
     zh-Hant = 總是
 
-  [speedcam_option_never]
+  [never]
+    comment = Generic «Never» string
     tags = android,ios
     en = Never
     af = Nooit

--- a/iphone/Maps/LocalizedStrings/ar.lproj/Localizable.strings
+++ b/iphone/Maps/LocalizedStrings/ar.lproj/Localizable.strings
@@ -217,14 +217,14 @@
 /* Settings «Map» category: «Night style» title */
 "pref_map_style_title" = "الوضع الليلي";
 
-/* «Map style» entry value */
-"pref_map_style_default" = "تعطيل";
+/* Generic «Off» string */
+"off" = "تعطيل";
 
-/* «Map style» entry value */
-"pref_map_style_night" = "تشغيل";
+/* Generic «On» string */
+"on" = "تشغيل";
 
-/* «Map style» entry value */
-"pref_map_style_auto" = "تلقائي";
+/* Generic «Auto» string */
+"auto" = "تلقائي";
 
 /* Settings «Map» category: «Perspective view» title */
 "pref_map_3d_title" = "العرض المنظوري";
@@ -887,10 +887,6 @@
 /* "traffic" as in "road congestion" */
 "traffic_data_unavailable" = "البيانات المرورية غير متاحة";
 
-"on" = "تشغيل";
-
-"off" = "إيقاف";
-
 "transliteration_title" = "كتابة جميع الاسماء بالحروف اللاتينية بشكل حرفي";
 
 /* Subway exits for public transport marks on the map */
@@ -995,11 +991,11 @@
 
 "speedcams_alert_title" = "تحذيرات كاميرات السرعة";
 
-"speedcam_option_auto" = "تلفائياً";
+/* Generic «Always» string */
+"always" = "مفعل دائماً";
 
-"speedcam_option_always" = "مفعل دائماً";
-
-"speedcam_option_never" = "معطل دائماً";
+/* Generic «Never» string */
+"never" = "معطل دائماً";
 
 "place_description_title" = "وصف المكان";
 

--- a/iphone/Maps/LocalizedStrings/be.lproj/Localizable.strings
+++ b/iphone/Maps/LocalizedStrings/be.lproj/Localizable.strings
@@ -217,14 +217,14 @@
 /* Settings «Map» category: «Night style» title */
 "pref_map_style_title" = "Начны рэжым";
 
-/* «Map style» entry value */
-"pref_map_style_default" = "Выключаны";
+/* Generic «Off» string */
+"off" = "Выключаны";
 
-/* «Map style» entry value */
-"pref_map_style_night" = "Уключаны";
+/* Generic «On» string */
+"on" = "Уключаны";
 
-/* «Map style» entry value */
-"pref_map_style_auto" = "Аўтаматычна";
+/* Generic «Auto» string */
+"auto" = "Аўтаматычна";
 
 /* Settings «Map» category: «Perspective view» title */
 "pref_map_3d_title" = "Перспектыўны выгляд";
@@ -887,10 +887,6 @@
 /* "traffic" as in "road congestion" */
 "traffic_data_unavailable" = "Інфармацыі пра рух няма";
 
-"on" = "Укл.";
-
-"off" = "Выкл.";
-
 "transliteration_title" = "Транслітарацыя лацінкай";
 
 /* Subway exits for public transport marks on the map */
@@ -995,11 +991,11 @@
 
 "speedcams_alert_title" = "Камеры хуткасці";
 
-"speedcam_option_auto" = "Аўтаматычна";
+/* Generic «Always» string */
+"always" = "Заўсёды";
 
-"speedcam_option_always" = "Заўсёды";
-
-"speedcam_option_never" = "Ніколі";
+/* Generic «Never» string */
+"never" = "Ніколі";
 
 "place_description_title" = "Апісанне месца";
 

--- a/iphone/Maps/LocalizedStrings/bg.lproj/Localizable.strings
+++ b/iphone/Maps/LocalizedStrings/bg.lproj/Localizable.strings
@@ -217,14 +217,14 @@
 /* Settings «Map» category: «Night style» title */
 "pref_map_style_title" = "Нощен режим";
 
-/* «Map style» entry value */
-"pref_map_style_default" = "Изключен";
+/* Generic «Off» string */
+"off" = "Изключен";
 
-/* «Map style» entry value */
-"pref_map_style_night" = "Включен";
+/* Generic «On» string */
+"on" = "Включен";
 
-/* «Map style» entry value */
-"pref_map_style_auto" = "Автоматично";
+/* Generic «Auto» string */
+"auto" = "Автоматично";
 
 /* Settings «Map» category: «Perspective view» title */
 "pref_map_3d_title" = "Перспективен изглед";
@@ -887,10 +887,6 @@
 /* "traffic" as in "road congestion" */
 "traffic_data_unavailable" = "Няма налични данни за трафика";
 
-"on" = "Вкл.";
-
-"off" = "Изкл.";
-
 "transliteration_title" = "Латинска транслитерация";
 
 /* Subway exits for public transport marks on the map */
@@ -995,11 +991,11 @@
 
 "speedcams_alert_title" = "Камери за скорост";
 
-"speedcam_option_auto" = "Автоматично";
+/* Generic «Always» string */
+"always" = "Винаги";
 
-"speedcam_option_always" = "Винаги";
-
-"speedcam_option_never" = "Никога";
+/* Generic «Never» string */
+"never" = "Никога";
 
 "place_description_title" = "Описание на мястото";
 

--- a/iphone/Maps/LocalizedStrings/ca.lproj/Localizable.strings
+++ b/iphone/Maps/LocalizedStrings/ca.lproj/Localizable.strings
@@ -217,14 +217,14 @@
 /* Settings «Map» category: «Night style» title */
 "pref_map_style_title" = "Mode nocturn";
 
-/* «Map style» entry value */
-"pref_map_style_default" = "Desactivat";
+/* Generic «Off» string */
+"off" = "Desactivat";
 
-/* «Map style» entry value */
-"pref_map_style_night" = "Activat";
+/* Generic «On» string */
+"on" = "Activat";
 
-/* «Map style» entry value */
-"pref_map_style_auto" = "Automàtic";
+/* Generic «Auto» string */
+"auto" = "Automàtic";
 
 /* Settings «Map» category: «Perspective view» title */
 "pref_map_3d_title" = "Vista en perspectiva";
@@ -887,10 +887,6 @@
 /* "traffic" as in "road congestion" */
 "traffic_data_unavailable" = "No hi ha dades de trànsit disponibles.";
 
-"on" = "Actiu";
-
-"off" = "Inactiu";
-
 "transliteration_title" = "Translitertació a l'alfabet llatí";
 
 /* Subway exits for public transport marks on the map */
@@ -995,11 +991,11 @@
 
 "speedcams_alert_title" = "Radars";
 
-"speedcam_option_auto" = "Automàtic";
+/* Generic «Always» string */
+"always" = "Sempre";
 
-"speedcam_option_always" = "Sempre";
-
-"speedcam_option_never" = "Mai";
+/* Generic «Never» string */
+"never" = "Mai";
 
 "place_description_title" = "Descripció del lloc";
 

--- a/iphone/Maps/LocalizedStrings/cs.lproj/Localizable.strings
+++ b/iphone/Maps/LocalizedStrings/cs.lproj/Localizable.strings
@@ -217,14 +217,14 @@
 /* Settings «Map» category: «Night style» title */
 "pref_map_style_title" = "Noční režim";
 
-/* «Map style» entry value */
-"pref_map_style_default" = "Vypnuto";
+/* Generic «Off» string */
+"off" = "Vypnuto";
 
-/* «Map style» entry value */
-"pref_map_style_night" = "Zapnuto";
+/* Generic «On» string */
+"on" = "Zapnuto";
 
-/* «Map style» entry value */
-"pref_map_style_auto" = "Automaticky";
+/* Generic «Auto» string */
+"auto" = "Automaticky";
 
 /* Settings «Map» category: «Perspective view» title */
 "pref_map_3d_title" = "Zobrazení perspektivy";
@@ -887,10 +887,6 @@
 /* "traffic" as in "road congestion" */
 "traffic_data_unavailable" = "Data o provozu nejsou k dispozici";
 
-"on" = "Zapnout";
-
-"off" = "Vypnout";
-
 "transliteration_title" = "Přepis do latinky";
 
 /* Subway exits for public transport marks on the map */
@@ -995,11 +991,11 @@
 
 "speedcams_alert_title" = "Detektory rychlosti";
 
-"speedcam_option_auto" = "Automaticky";
+/* Generic «Always» string */
+"always" = "Vždy";
 
-"speedcam_option_always" = "Vždy";
-
-"speedcam_option_never" = "Nikdy";
+/* Generic «Never» string */
+"never" = "Nikdy";
 
 "place_description_title" = "Popis místa";
 

--- a/iphone/Maps/LocalizedStrings/da.lproj/Localizable.strings
+++ b/iphone/Maps/LocalizedStrings/da.lproj/Localizable.strings
@@ -217,14 +217,14 @@
 /* Settings «Map» category: «Night style» title */
 "pref_map_style_title" = "Nattilstand";
 
-/* «Map style» entry value */
-"pref_map_style_default" = "Fra";
+/* Generic «Off» string */
+"off" = "Fra";
 
-/* «Map style» entry value */
-"pref_map_style_night" = "Til";
+/* Generic «On» string */
+"on" = "Til";
 
-/* «Map style» entry value */
-"pref_map_style_auto" = "Auto";
+/* Generic «Auto» string */
+"auto" = "Auto";
 
 /* Settings «Map» category: «Perspective view» title */
 "pref_map_3d_title" = "Perspektivvisning";
@@ -887,10 +887,6 @@
 /* "traffic" as in "road congestion" */
 "traffic_data_unavailable" = "Trafikdata er ikke tilgængelige";
 
-"on" = "Til";
-
-"off" = "Fra";
-
 "transliteration_title" = "Translitteration til latinsk";
 
 /* Subway exits for public transport marks on the map */
@@ -995,11 +991,11 @@
 
 "speedcams_alert_title" = "Fartkameraer";
 
-"speedcam_option_auto" = "Auto";
+/* Generic «Always» string */
+"always" = "Altid";
 
-"speedcam_option_always" = "Altid";
-
-"speedcam_option_never" = "Aldrig";
+/* Generic «Never» string */
+"never" = "Aldrig";
 
 "place_description_title" = "Beskrivelse af sted";
 

--- a/iphone/Maps/LocalizedStrings/de.lproj/Localizable.strings
+++ b/iphone/Maps/LocalizedStrings/de.lproj/Localizable.strings
@@ -217,14 +217,14 @@
 /* Settings «Map» category: «Night style» title */
 "pref_map_style_title" = "Nachtmodus";
 
-/* «Map style» entry value */
-"pref_map_style_default" = "Aus";
+/* Generic «Off» string */
+"off" = "Aus";
 
-/* «Map style» entry value */
-"pref_map_style_night" = "An";
+/* Generic «On» string */
+"on" = "An";
 
-/* «Map style» entry value */
-"pref_map_style_auto" = "Auto";
+/* Generic «Auto» string */
+"auto" = "Auto";
 
 /* Settings «Map» category: «Perspective view» title */
 "pref_map_3d_title" = "Perspektivische Ansicht";
@@ -887,10 +887,6 @@
 /* "traffic" as in "road congestion" */
 "traffic_data_unavailable" = "Verkehrsdaten sind nicht verfügbar";
 
-"on" = "An";
-
-"off" = "Aus";
-
 "transliteration_title" = "Transliteration ins Lateinische";
 
 /* Subway exits for public transport marks on the map */
@@ -995,11 +991,11 @@
 
 "speedcams_alert_title" = "Blitzer";
 
-"speedcam_option_auto" = "Auto";
+/* Generic «Always» string */
+"always" = "Immer";
 
-"speedcam_option_always" = "Immer";
-
-"speedcam_option_never" = "Niemals";
+/* Generic «Never» string */
+"never" = "Niemals";
 
 "place_description_title" = "Ortsbeschreibung";
 

--- a/iphone/Maps/LocalizedStrings/el.lproj/Localizable.strings
+++ b/iphone/Maps/LocalizedStrings/el.lproj/Localizable.strings
@@ -217,14 +217,14 @@
 /* Settings «Map» category: «Night style» title */
 "pref_map_style_title" = "Νυχτερινή λειτουργία";
 
-/* «Map style» entry value */
-"pref_map_style_default" = "Απενεργ.";
+/* Generic «Off» string */
+"off" = "Απενεργ.";
 
-/* «Map style» entry value */
-"pref_map_style_night" = "Ενεργ.";
+/* Generic «On» string */
+"on" = "Ενεργ.";
 
-/* «Map style» entry value */
-"pref_map_style_auto" = "Αυτόματα";
+/* Generic «Auto» string */
+"auto" = "Αυτόματα";
 
 /* Settings «Map» category: «Perspective view» title */
 "pref_map_3d_title" = "Προβολή προοπτικής";
@@ -887,10 +887,6 @@
 /* "traffic" as in "road congestion" */
 "traffic_data_unavailable" = "Οι πληροφορίες για την κίνηση δεν είναι διαθέσιμες";
 
-"on" = "Ενεργ.";
-
-"off" = "Απενεργ.";
-
 "transliteration_title" = "Μεταγραφή στα Λατινικά";
 
 /* Subway exits for public transport marks on the map */
@@ -995,11 +991,11 @@
 
 "speedcams_alert_title" = "Κάμερες Ταχύτητας";
 
-"speedcam_option_auto" = "Αυτόματο";
+/* Generic «Always» string */
+"always" = "Πάντα";
 
-"speedcam_option_always" = "Πάντα";
-
-"speedcam_option_never" = "Ποτέ";
+/* Generic «Never» string */
+"never" = "Ποτέ";
 
 "place_description_title" = "Περιγραφή μέρους";
 

--- a/iphone/Maps/LocalizedStrings/en-GB.lproj/Localizable.strings
+++ b/iphone/Maps/LocalizedStrings/en-GB.lproj/Localizable.strings
@@ -217,14 +217,14 @@
 /* Settings «Map» category: «Night style» title */
 "pref_map_style_title" = "Night Mode";
 
-/* «Map style» entry value */
-"pref_map_style_default" = "Off";
+/* Generic «Off» string */
+"off" = "Off";
 
-/* «Map style» entry value */
-"pref_map_style_night" = "On";
+/* Generic «On» string */
+"on" = "On";
 
-/* «Map style» entry value */
-"pref_map_style_auto" = "Auto";
+/* Generic «Auto» string */
+"auto" = "Auto";
 
 /* Settings «Map» category: «Perspective view» title */
 "pref_map_3d_title" = "Perspective view";
@@ -887,10 +887,6 @@
 /* "traffic" as in "road congestion" */
 "traffic_data_unavailable" = "Traffic data is not available";
 
-"on" = "On";
-
-"off" = "Off";
-
 "transliteration_title" = "Transliteration into Latin alphabet";
 
 /* Subway exits for public transport marks on the map */
@@ -995,11 +991,11 @@
 
 "speedcams_alert_title" = "Speed cameras";
 
-"speedcam_option_auto" = "Auto";
+/* Generic «Always» string */
+"always" = "Always";
 
-"speedcam_option_always" = "Always";
-
-"speedcam_option_never" = "Never";
+/* Generic «Never» string */
+"never" = "Never";
 
 "place_description_title" = "Place Description";
 

--- a/iphone/Maps/LocalizedStrings/en.lproj/Localizable.strings
+++ b/iphone/Maps/LocalizedStrings/en.lproj/Localizable.strings
@@ -217,14 +217,14 @@
 /* Settings «Map» category: «Night style» title */
 "pref_map_style_title" = "Night Mode";
 
-/* «Map style» entry value */
-"pref_map_style_default" = "Off";
+/* Generic «Off» string */
+"off" = "Off";
 
-/* «Map style» entry value */
-"pref_map_style_night" = "On";
+/* Generic «On» string */
+"on" = "On";
 
-/* «Map style» entry value */
-"pref_map_style_auto" = "Auto";
+/* Generic «Auto» string */
+"auto" = "Auto";
 
 /* Settings «Map» category: «Perspective view» title */
 "pref_map_3d_title" = "Perspective view";
@@ -887,10 +887,6 @@
 /* "traffic" as in "road congestion" */
 "traffic_data_unavailable" = "Traffic data is not available";
 
-"on" = "On";
-
-"off" = "Off";
-
 "transliteration_title" = "Transliteration into Latin alphabet";
 
 /* Subway exits for public transport marks on the map */
@@ -995,11 +991,11 @@
 
 "speedcams_alert_title" = "Speed cameras";
 
-"speedcam_option_auto" = "Auto";
+/* Generic «Always» string */
+"always" = "Always";
 
-"speedcam_option_always" = "Always";
-
-"speedcam_option_never" = "Never";
+/* Generic «Never» string */
+"never" = "Never";
 
 "place_description_title" = "Place Description";
 

--- a/iphone/Maps/LocalizedStrings/es-MX.lproj/Localizable.strings
+++ b/iphone/Maps/LocalizedStrings/es-MX.lproj/Localizable.strings
@@ -217,14 +217,14 @@
 /* Settings «Map» category: «Night style» title */
 "pref_map_style_title" = "Modo nocturno";
 
-/* «Map style» entry value */
-"pref_map_style_default" = "Desactivado";
+/* Generic «Off» string */
+"off" = "Desactivado";
 
-/* «Map style» entry value */
-"pref_map_style_night" = "Activado";
+/* Generic «On» string */
+"on" = "Activado";
 
-/* «Map style» entry value */
-"pref_map_style_auto" = "Automático";
+/* Generic «Auto» string */
+"auto" = "Automático";
 
 /* Settings «Map» category: «Perspective view» title */
 "pref_map_3d_title" = "Vista en perspectiva";
@@ -887,10 +887,6 @@
 /* "traffic" as in "road congestion" */
 "traffic_data_unavailable" = "Los datos de tráfico no están disponibles";
 
-"on" = "Act.";
-
-"off" = "Desact.";
-
 "transliteration_title" = "Transliteración al alfabeto latino";
 
 /* Subway exits for public transport marks on the map */
@@ -995,11 +991,11 @@
 
 "speedcams_alert_title" = "Cámaras de velocidad";
 
-"speedcam_option_auto" = "Automático";
+/* Generic «Always» string */
+"always" = "Siempre";
 
-"speedcam_option_always" = "Siempre";
-
-"speedcam_option_never" = "Nunca";
+/* Generic «Never» string */
+"never" = "Nunca";
 
 "place_description_title" = "Descripción de lugares";
 

--- a/iphone/Maps/LocalizedStrings/es.lproj/Localizable.strings
+++ b/iphone/Maps/LocalizedStrings/es.lproj/Localizable.strings
@@ -217,14 +217,14 @@
 /* Settings «Map» category: «Night style» title */
 "pref_map_style_title" = "Modo nocturno";
 
-/* «Map style» entry value */
-"pref_map_style_default" = "Desactivado";
+/* Generic «Off» string */
+"off" = "Desactivado";
 
-/* «Map style» entry value */
-"pref_map_style_night" = "Activado";
+/* Generic «On» string */
+"on" = "Activado";
 
-/* «Map style» entry value */
-"pref_map_style_auto" = "Automático";
+/* Generic «Auto» string */
+"auto" = "Automático";
 
 /* Settings «Map» category: «Perspective view» title */
 "pref_map_3d_title" = "Vista en perspectiva";
@@ -887,10 +887,6 @@
 /* "traffic" as in "road congestion" */
 "traffic_data_unavailable" = "Los datos de tráfico no están disponibles";
 
-"on" = "Act.";
-
-"off" = "Desact.";
-
 "transliteration_title" = "Transliteración al latín";
 
 /* Subway exits for public transport marks on the map */
@@ -995,11 +991,11 @@
 
 "speedcams_alert_title" = "Cámaras de velocidad";
 
-"speedcam_option_auto" = "Auto";
+/* Generic «Always» string */
+"always" = "Siempre";
 
-"speedcam_option_always" = "Siempre";
-
-"speedcam_option_never" = "Nunca";
+/* Generic «Never» string */
+"never" = "Nunca";
 
 "place_description_title" = "Descripción del lugar";
 

--- a/iphone/Maps/LocalizedStrings/et.lproj/Localizable.strings
+++ b/iphone/Maps/LocalizedStrings/et.lproj/Localizable.strings
@@ -217,14 +217,14 @@
 /* Settings «Map» category: «Night style» title */
 "pref_map_style_title" = "Öörežiim";
 
-/* «Map style» entry value */
-"pref_map_style_default" = "Väljas";
+/* Generic «Off» string */
+"off" = "Väljas";
 
-/* «Map style» entry value */
-"pref_map_style_night" = "Sees";
+/* Generic «On» string */
+"on" = "Sees";
 
-/* «Map style» entry value */
-"pref_map_style_auto" = "Automaatne";
+/* Generic «Auto» string */
+"auto" = "Automaatne";
 
 /* Settings «Map» category: «Perspective view» title */
 "pref_map_3d_title" = "Perspektiivi vaade";
@@ -887,10 +887,6 @@
 /* "traffic" as in "road congestion" */
 "traffic_data_unavailable" = "Liiklusinfo ei ole saadaval";
 
-"on" = "Sees";
-
-"off" = "Väljas";
-
 "transliteration_title" = "Transliteratsioon ladina keelde";
 
 /* Subway exits for public transport marks on the map */
@@ -995,11 +991,11 @@
 
 "speedcams_alert_title" = "Kiiruskaamerad";
 
-"speedcam_option_auto" = "Automaatne";
+/* Generic «Always» string */
+"always" = "Alati";
 
-"speedcam_option_always" = "Alati";
-
-"speedcam_option_never" = "Mitte kunagi";
+/* Generic «Never» string */
+"never" = "Mitte kunagi";
 
 "place_description_title" = "Koha kirjeldus";
 

--- a/iphone/Maps/LocalizedStrings/eu.lproj/Localizable.strings
+++ b/iphone/Maps/LocalizedStrings/eu.lproj/Localizable.strings
@@ -217,14 +217,14 @@
 /* Settings «Map» category: «Night style» title */
 "pref_map_style_title" = "Gaueko modua";
 
-/* «Map style» entry value */
-"pref_map_style_default" = "Desgaituta";
+/* Generic «Off» string */
+"off" = "Desgaituta";
 
-/* «Map style» entry value */
-"pref_map_style_night" = "Aktibatuta";
+/* Generic «On» string */
+"on" = "Aktibatuta";
 
-/* «Map style» entry value */
-"pref_map_style_auto" = "Automatikoa";
+/* Generic «Auto» string */
+"auto" = "Automatikoa";
 
 /* Settings «Map» category: «Perspective view» title */
 "pref_map_3d_title" = "Perspektiba ikuspegia";
@@ -887,10 +887,6 @@
 /* "traffic" as in "road congestion" */
 "traffic_data_unavailable" = "Trafiko datuak ez daude eskuragarri";
 
-"on" = "Martxan";
-
-"off" = "Itzalita";
-
 "transliteration_title" = "Latinezko transliterazioa";
 
 /* Subway exits for public transport marks on the map */
@@ -995,11 +991,11 @@
 
 "speedcams_alert_title" = "Abiadura kamerak";
 
-"speedcam_option_auto" = "Automatikoa";
+/* Generic «Always» string */
+"always" = "Beti";
 
-"speedcam_option_always" = "Beti";
-
-"speedcam_option_never" = "Inoiz ez";
+/* Generic «Never» string */
+"never" = "Inoiz ez";
 
 "place_description_title" = "Tokiaren deskribapena";
 

--- a/iphone/Maps/LocalizedStrings/fa.lproj/Localizable.strings
+++ b/iphone/Maps/LocalizedStrings/fa.lproj/Localizable.strings
@@ -217,14 +217,14 @@
 /* Settings «Map» category: «Night style» title */
 "pref_map_style_title" = "حالت شب";
 
-/* «Map style» entry value */
-"pref_map_style_default" = "خاموش";
+/* Generic «Off» string */
+"off" = "خاموش";
 
-/* «Map style» entry value */
-"pref_map_style_night" = "روشن";
+/* Generic «On» string */
+"on" = "روشن";
 
-/* «Map style» entry value */
-"pref_map_style_auto" = "خودکار";
+/* Generic «Auto» string */
+"auto" = "خودکار";
 
 /* Settings «Map» category: «Perspective view» title */
 "pref_map_3d_title" = "نمای چشم انداز";
@@ -887,10 +887,6 @@
 /* "traffic" as in "road congestion" */
 "traffic_data_unavailable" = "اطلاعات ترافیکی موجود نیست";
 
-"on" = "روشن";
-
-"off" = "خاموش";
-
 "transliteration_title" = "ترجمه به لاتین";
 
 /* Subway exits for public transport marks on the map */
@@ -995,11 +991,11 @@
 
 "speedcams_alert_title" = "دوربین‌های سرعت";
 
-"speedcam_option_auto" = "خودکار";
+/* Generic «Always» string */
+"always" = "همیشه";
 
-"speedcam_option_always" = "همیشه";
-
-"speedcam_option_never" = "هرگز";
+/* Generic «Never» string */
+"never" = "هرگز";
 
 "place_description_title" = "توضیحات محل";
 

--- a/iphone/Maps/LocalizedStrings/fi.lproj/Localizable.strings
+++ b/iphone/Maps/LocalizedStrings/fi.lproj/Localizable.strings
@@ -217,14 +217,14 @@
 /* Settings «Map» category: «Night style» title */
 "pref_map_style_title" = "Yötila";
 
-/* «Map style» entry value */
-"pref_map_style_default" = "Pois päältä";
+/* Generic «Off» string */
+"off" = "Pois päältä";
 
-/* «Map style» entry value */
-"pref_map_style_night" = "Päällä";
+/* Generic «On» string */
+"on" = "Päällä";
 
-/* «Map style» entry value */
-"pref_map_style_auto" = "Automaattinen";
+/* Generic «Auto» string */
+"auto" = "Automaattinen";
 
 /* Settings «Map» category: «Perspective view» title */
 "pref_map_3d_title" = "Perspektiivinäkymä";
@@ -887,10 +887,6 @@
 /* "traffic" as in "road congestion" */
 "traffic_data_unavailable" = "Liikennetietoja ei ole saatavilla";
 
-"on" = "Käytössä";
-
-"off" = "Ei käytössä";
-
 "transliteration_title" = "Translitterointi latinalaisiksi aakkosiksi";
 
 /* Subway exits for public transport marks on the map */
@@ -995,11 +991,11 @@
 
 "speedcams_alert_title" = "Nopeuskamerat";
 
-"speedcam_option_auto" = "Auto";
+/* Generic «Always» string */
+"always" = "Aina";
 
-"speedcam_option_always" = "Aina";
-
-"speedcam_option_never" = "Ei koskaan";
+/* Generic «Never» string */
+"never" = "Ei koskaan";
 
 "place_description_title" = "Paikan kuvaus";
 

--- a/iphone/Maps/LocalizedStrings/fr.lproj/Localizable.strings
+++ b/iphone/Maps/LocalizedStrings/fr.lproj/Localizable.strings
@@ -217,14 +217,14 @@
 /* Settings «Map» category: «Night style» title */
 "pref_map_style_title" = "Mode nuit";
 
-/* «Map style» entry value */
-"pref_map_style_default" = "Désactivé";
+/* Generic «Off» string */
+"off" = "Désactivé";
 
-/* «Map style» entry value */
-"pref_map_style_night" = "Activé";
+/* Generic «On» string */
+"on" = "Activé";
 
-/* «Map style» entry value */
-"pref_map_style_auto" = "Automatique";
+/* Generic «Auto» string */
+"auto" = "Automatique";
 
 /* Settings «Map» category: «Perspective view» title */
 "pref_map_3d_title" = "Vue en perspective";
@@ -887,10 +887,6 @@
 /* "traffic" as in "road congestion" */
 "traffic_data_unavailable" = "Les données de circulation ne sont pas disponibles";
 
-"on" = "On";
-
-"off" = "Off";
-
 "transliteration_title" = "Translittération en latin";
 
 /* Subway exits for public transport marks on the map */
@@ -995,11 +991,11 @@
 
 "speedcams_alert_title" = "Radars de vitesse";
 
-"speedcam_option_auto" = "Auto";
+/* Generic «Always» string */
+"always" = "Toujours";
 
-"speedcam_option_always" = "Toujours";
-
-"speedcam_option_never" = "Jamais";
+/* Generic «Never» string */
+"never" = "Jamais";
 
 "place_description_title" = "Description d'endroit";
 

--- a/iphone/Maps/LocalizedStrings/he.lproj/Localizable.strings
+++ b/iphone/Maps/LocalizedStrings/he.lproj/Localizable.strings
@@ -217,14 +217,14 @@
 /* Settings «Map» category: «Night style» title */
 "pref_map_style_title" = "Night Mode";
 
-/* «Map style» entry value */
-"pref_map_style_default" = "Off";
+/* Generic «Off» string */
+"off" = "Off";
 
-/* «Map style» entry value */
-"pref_map_style_night" = "On";
+/* Generic «On» string */
+"on" = "On";
 
-/* «Map style» entry value */
-"pref_map_style_auto" = "Auto";
+/* Generic «Auto» string */
+"auto" = "Auto";
 
 /* Settings «Map» category: «Perspective view» title */
 "pref_map_3d_title" = "Perspective view";
@@ -887,10 +887,6 @@
 /* "traffic" as in "road congestion" */
 "traffic_data_unavailable" = "Traffic data is not available";
 
-"on" = "On";
-
-"off" = "Off";
-
 "transliteration_title" = "תעתיק ללטינית";
 
 /* Subway exits for public transport marks on the map */
@@ -995,11 +991,11 @@
 
 "speedcams_alert_title" = "Speed cameras";
 
-"speedcam_option_auto" = "Auto";
+/* Generic «Always» string */
+"always" = "Always";
 
-"speedcam_option_always" = "Always";
-
-"speedcam_option_never" = "Never";
+/* Generic «Never» string */
+"never" = "Never";
 
 "place_description_title" = "Place Description";
 

--- a/iphone/Maps/LocalizedStrings/hu.lproj/Localizable.strings
+++ b/iphone/Maps/LocalizedStrings/hu.lproj/Localizable.strings
@@ -217,14 +217,14 @@
 /* Settings «Map» category: «Night style» title */
 "pref_map_style_title" = "Éjszakai üzemmód";
 
-/* «Map style» entry value */
-"pref_map_style_default" = "Ki";
+/* Generic «Off» string */
+"off" = "Ki";
 
-/* «Map style» entry value */
-"pref_map_style_night" = "Be";
+/* Generic «On» string */
+"on" = "Be";
 
-/* «Map style» entry value */
-"pref_map_style_auto" = "Automatikus";
+/* Generic «Auto» string */
+"auto" = "Automatikus";
 
 /* Settings «Map» category: «Perspective view» title */
 "pref_map_3d_title" = "Perspektivikus nézet";
@@ -887,10 +887,6 @@
 /* "traffic" as in "road congestion" */
 "traffic_data_unavailable" = "Forgalmi adatok nem állnak rendelkezésre";
 
-"on" = "Be";
-
-"off" = "Ki";
-
 "transliteration_title" = "Átírás latin nyelvre";
 
 /* Subway exits for public transport marks on the map */
@@ -995,11 +991,11 @@
 
 "speedcams_alert_title" = "Sebességmérő kamerák";
 
-"speedcam_option_auto" = "Automatikus";
+/* Generic «Always» string */
+"always" = "Mindig";
 
-"speedcam_option_always" = "Mindig";
-
-"speedcam_option_never" = "Soha";
+/* Generic «Never» string */
+"never" = "Soha";
 
 "place_description_title" = "A hely ismertetése";
 

--- a/iphone/Maps/LocalizedStrings/id.lproj/Localizable.strings
+++ b/iphone/Maps/LocalizedStrings/id.lproj/Localizable.strings
@@ -217,14 +217,14 @@
 /* Settings «Map» category: «Night style» title */
 "pref_map_style_title" = "Mode Malam";
 
-/* «Map style» entry value */
-"pref_map_style_default" = "Tidak Aktif";
+/* Generic «Off» string */
+"off" = "Tidak Aktif";
 
-/* «Map style» entry value */
-"pref_map_style_night" = "Aktif";
+/* Generic «On» string */
+"on" = "Aktif";
 
-/* «Map style» entry value */
-"pref_map_style_auto" = "Otomatis";
+/* Generic «Auto» string */
+"auto" = "Otomatis";
 
 /* Settings «Map» category: «Perspective view» title */
 "pref_map_3d_title" = "Pandangan perspektif";
@@ -887,10 +887,6 @@
 /* "traffic" as in "road congestion" */
 "traffic_data_unavailable" = "Data lalu lintas tidak tersedia";
 
-"on" = "On";
-
-"off" = "Mati";
-
 "transliteration_title" = "Transliterasi ke dalam bahasa Latin";
 
 /* Subway exits for public transport marks on the map */
@@ -995,11 +991,11 @@
 
 "speedcams_alert_title" = "Kamera cepat";
 
-"speedcam_option_auto" = "Auto";
+/* Generic «Always» string */
+"always" = "Selalu";
 
-"speedcam_option_always" = "Selalu";
-
-"speedcam_option_never" = "Tidak pernah";
+/* Generic «Never» string */
+"never" = "Tidak pernah";
 
 "place_description_title" = "Deskripsi Tempat";
 

--- a/iphone/Maps/LocalizedStrings/it.lproj/Localizable.strings
+++ b/iphone/Maps/LocalizedStrings/it.lproj/Localizable.strings
@@ -217,14 +217,14 @@
 /* Settings «Map» category: «Night style» title */
 "pref_map_style_title" = "Modalità notturna";
 
-/* «Map style» entry value */
-"pref_map_style_default" = "Spento";
+/* Generic «Off» string */
+"off" = "Spento";
 
-/* «Map style» entry value */
-"pref_map_style_night" = "Acceso";
+/* Generic «On» string */
+"on" = "Acceso";
 
-/* «Map style» entry value */
-"pref_map_style_auto" = "Automatico";
+/* Generic «Auto» string */
+"auto" = "Automatico";
 
 /* Settings «Map» category: «Perspective view» title */
 "pref_map_3d_title" = "Vista in prospettiva";
@@ -887,10 +887,6 @@
 /* "traffic" as in "road congestion" */
 "traffic_data_unavailable" = "Dati sul traffico non disponibili";
 
-"on" = "Acceso";
-
-"off" = "Spento";
-
 "transliteration_title" = "Trascrizione in latino";
 
 /* Subway exits for public transport marks on the map */
@@ -995,11 +991,11 @@
 
 "speedcams_alert_title" = "Autovelox";
 
-"speedcam_option_auto" = "Auto";
+/* Generic «Always» string */
+"always" = "Sempre";
 
-"speedcam_option_always" = "Sempre";
-
-"speedcam_option_never" = "Mai";
+/* Generic «Never» string */
+"never" = "Mai";
 
 "place_description_title" = "Descrizione luogo";
 

--- a/iphone/Maps/LocalizedStrings/ja.lproj/Localizable.strings
+++ b/iphone/Maps/LocalizedStrings/ja.lproj/Localizable.strings
@@ -217,14 +217,14 @@
 /* Settings «Map» category: «Night style» title */
 "pref_map_style_title" = "夜間モード";
 
-/* «Map style» entry value */
-"pref_map_style_default" = "オフ";
+/* Generic «Off» string */
+"off" = "オフ";
 
-/* «Map style» entry value */
-"pref_map_style_night" = "オン";
+/* Generic «On» string */
+"on" = "オン";
 
-/* «Map style» entry value */
-"pref_map_style_auto" = "自動";
+/* Generic «Auto» string */
+"auto" = "自動";
 
 /* Settings «Map» category: «Perspective view» title */
 "pref_map_3d_title" = "パースペクティブ表示";
@@ -887,10 +887,6 @@
 /* "traffic" as in "road congestion" */
 "traffic_data_unavailable" = "交通データは利用できません";
 
-"on" = "オン";
-
-"off" = "オフ";
-
 "transliteration_title" = "ラテン文字への字訳";
 
 /* Subway exits for public transport marks on the map */
@@ -995,11 +991,11 @@
 
 "speedcams_alert_title" = "自動速度違反取締装置";
 
-"speedcam_option_auto" = "自動";
+/* Generic «Always» string */
+"always" = "常時";
 
-"speedcam_option_always" = "常時";
-
-"speedcam_option_never" = "無効";
+/* Generic «Never» string */
+"never" = "無効";
 
 "place_description_title" = "場所の説明";
 

--- a/iphone/Maps/LocalizedStrings/ko.lproj/Localizable.strings
+++ b/iphone/Maps/LocalizedStrings/ko.lproj/Localizable.strings
@@ -217,14 +217,14 @@
 /* Settings «Map» category: «Night style» title */
 "pref_map_style_title" = "나이트 모드";
 
-/* «Map style» entry value */
-"pref_map_style_default" = "끄기";
+/* Generic «Off» string */
+"off" = "끄기";
 
-/* «Map style» entry value */
-"pref_map_style_night" = "켜기";
+/* Generic «On» string */
+"on" = "켜기";
 
-/* «Map style» entry value */
-"pref_map_style_auto" = "자동";
+/* Generic «Auto» string */
+"auto" = "자동";
 
 /* Settings «Map» category: «Perspective view» title */
 "pref_map_3d_title" = "원근 보기";
@@ -887,10 +887,6 @@
 /* "traffic" as in "road congestion" */
 "traffic_data_unavailable" = "교통 데이터를 사용할 수 없습니다";
 
-"on" = "켜기";
-
-"off" = "끄기";
-
 "transliteration_title" = "라틴어로 음역";
 
 /* Subway exits for public transport marks on the map */
@@ -995,11 +991,11 @@
 
 "speedcams_alert_title" = "속도 감시 카메라";
 
-"speedcam_option_auto" = "자동";
+/* Generic «Always» string */
+"always" = "항상";
 
-"speedcam_option_always" = "항상";
-
-"speedcam_option_never" = "안함";
+/* Generic «Never» string */
+"never" = "안함";
 
 "place_description_title" = "장소 묘사";
 

--- a/iphone/Maps/LocalizedStrings/mr.lproj/Localizable.strings
+++ b/iphone/Maps/LocalizedStrings/mr.lproj/Localizable.strings
@@ -217,14 +217,14 @@
 /* Settings «Map» category: «Night style» title */
 "pref_map_style_title" = "रात्र मोड";
 
-/* «Map style» entry value */
-"pref_map_style_default" = "बंद";
+/* Generic «Off» string */
+"off" = "बंद";
 
-/* «Map style» entry value */
-"pref_map_style_night" = "चालू";
+/* Generic «On» string */
+"on" = "चालू";
 
-/* «Map style» entry value */
-"pref_map_style_auto" = "स्वयं";
+/* Generic «Auto» string */
+"auto" = "स्वयं";
 
 /* Settings «Map» category: «Perspective view» title */
 "pref_map_3d_title" = "यथार्थ दृश्य";
@@ -887,10 +887,6 @@
 /* "traffic" as in "road congestion" */
 "traffic_data_unavailable" = "वाहतूक माहिती उपलब्ध नाही";
 
-"on" = "चालू";
-
-"off" = "बंद";
-
 "transliteration_title" = "लॅटिनमध्ये (इंग्रजीची अक्षरे) लिप्यंतरण";
 
 /* Subway exits for public transport marks on the map */
@@ -995,11 +991,11 @@
 
 "speedcams_alert_title" = "वेग कॅमेरे";
 
-"speedcam_option_auto" = "स्वयं";
+/* Generic «Always» string */
+"always" = "नेहमी";
 
-"speedcam_option_always" = "नेहमी";
-
-"speedcam_option_never" = "कधीच नाही";
+/* Generic «Never» string */
+"never" = "कधीच नाही";
 
 "place_description_title" = "ठिकाणाचे वर्णन";
 

--- a/iphone/Maps/LocalizedStrings/nb.lproj/Localizable.strings
+++ b/iphone/Maps/LocalizedStrings/nb.lproj/Localizable.strings
@@ -217,14 +217,14 @@
 /* Settings «Map» category: «Night style» title */
 "pref_map_style_title" = "Nattmodus";
 
-/* «Map style» entry value */
-"pref_map_style_default" = "Av";
+/* Generic «Off» string */
+"off" = "Av";
 
-/* «Map style» entry value */
-"pref_map_style_night" = "På";
+/* Generic «On» string */
+"on" = "På";
 
-/* «Map style» entry value */
-"pref_map_style_auto" = "Auto";
+/* Generic «Auto» string */
+"auto" = "Auto";
 
 /* Settings «Map» category: «Perspective view» title */
 "pref_map_3d_title" = "Perspektivvisning";
@@ -887,10 +887,6 @@
 /* "traffic" as in "road congestion" */
 "traffic_data_unavailable" = "Trafikkdata er ikke tilgjengelig";
 
-"on" = "På";
-
-"off" = "Av";
-
 "transliteration_title" = "Omskrivning til latin";
 
 /* Subway exits for public transport marks on the map */
@@ -995,11 +991,11 @@
 
 "speedcams_alert_title" = "Fartskamera";
 
-"speedcam_option_auto" = "Auto";
+/* Generic «Always» string */
+"always" = "Alltid";
 
-"speedcam_option_always" = "Alltid";
-
-"speedcam_option_never" = "Aldri";
+/* Generic «Never» string */
+"never" = "Aldri";
 
 "place_description_title" = "Plasser beskrivelse";
 

--- a/iphone/Maps/LocalizedStrings/nl.lproj/Localizable.strings
+++ b/iphone/Maps/LocalizedStrings/nl.lproj/Localizable.strings
@@ -217,14 +217,14 @@
 /* Settings «Map» category: «Night style» title */
 "pref_map_style_title" = "Nachtmodus";
 
-/* «Map style» entry value */
-"pref_map_style_default" = "Uit";
+/* Generic «Off» string */
+"off" = "Uit";
 
-/* «Map style» entry value */
-"pref_map_style_night" = "Aan";
+/* Generic «On» string */
+"on" = "Aan";
 
-/* «Map style» entry value */
-"pref_map_style_auto" = "Automatisch";
+/* Generic «Auto» string */
+"auto" = "Automatisch";
 
 /* Settings «Map» category: «Perspective view» title */
 "pref_map_3d_title" = "Perspectiefbeeld";
@@ -887,10 +887,6 @@
 /* "traffic" as in "road congestion" */
 "traffic_data_unavailable" = "Verkeersgegevens zijn niet beschikbaar";
 
-"on" = "Aan";
-
-"off" = "Uit";
-
 "transliteration_title" = "Transliteratie in het Latijn";
 
 /* Subway exits for public transport marks on the map */
@@ -995,11 +991,11 @@
 
 "speedcams_alert_title" = "Snelheidscamera's";
 
-"speedcam_option_auto" = "Auto";
+/* Generic «Always» string */
+"always" = "Altijd";
 
-"speedcam_option_always" = "Altijd";
-
-"speedcam_option_never" = "Nooit";
+/* Generic «Never» string */
+"never" = "Nooit";
 
 "place_description_title" = "Plaats Beschrijving";
 

--- a/iphone/Maps/LocalizedStrings/pl.lproj/Localizable.strings
+++ b/iphone/Maps/LocalizedStrings/pl.lproj/Localizable.strings
@@ -217,14 +217,14 @@
 /* Settings «Map» category: «Night style» title */
 "pref_map_style_title" = "Tryb nocny";
 
-/* «Map style» entry value */
-"pref_map_style_default" = "Wyłączony";
+/* Generic «Off» string */
+"off" = "Wyłączony";
 
-/* «Map style» entry value */
-"pref_map_style_night" = "Włączony";
+/* Generic «On» string */
+"on" = "Włączony";
 
-/* «Map style» entry value */
-"pref_map_style_auto" = "Automatycznie";
+/* Generic «Auto» string */
+"auto" = "Automatycznie";
 
 /* Settings «Map» category: «Perspective view» title */
 "pref_map_3d_title" = "Widok z perspektywy";
@@ -887,10 +887,6 @@
 /* "traffic" as in "road congestion" */
 "traffic_data_unavailable" = "Dane o ruchu są niedostępne";
 
-"on" = "Wł.";
-
-"off" = "Wył.";
-
 "transliteration_title" = "Transkrypcja na alfabet łaciński";
 
 /* Subway exits for public transport marks on the map */
@@ -995,11 +991,11 @@
 
 "speedcams_alert_title" = "Fotoradary";
 
-"speedcam_option_auto" = "Automatycznie";
+/* Generic «Always» string */
+"always" = "Zawsze";
 
-"speedcam_option_always" = "Zawsze";
-
-"speedcam_option_never" = "Nigdy";
+/* Generic «Never» string */
+"never" = "Nigdy";
 
 "place_description_title" = "Opis miejsca";
 

--- a/iphone/Maps/LocalizedStrings/pt-BR.lproj/Localizable.strings
+++ b/iphone/Maps/LocalizedStrings/pt-BR.lproj/Localizable.strings
@@ -217,14 +217,14 @@
 /* Settings «Map» category: «Night style» title */
 "pref_map_style_title" = "Modo noturno";
 
-/* «Map style» entry value */
-"pref_map_style_default" = "Desligado";
+/* Generic «Off» string */
+"off" = "Desligado";
 
-/* «Map style» entry value */
-"pref_map_style_night" = "Ligado";
+/* Generic «On» string */
+"on" = "Ligado";
 
-/* «Map style» entry value */
-"pref_map_style_auto" = "Automático";
+/* Generic «Auto» string */
+"auto" = "Automático";
 
 /* Settings «Map» category: «Perspective view» title */
 "pref_map_3d_title" = "Visão em perspectiva";
@@ -887,10 +887,6 @@
 /* "traffic" as in "road congestion" */
 "traffic_data_unavailable" = "Não existem dados de tráfego";
 
-"on" = "Lig.";
-
-"off" = "Deslig.";
-
 "transliteration_title" = "Transliteração para alfabeto latino";
 
 /* Subway exits for public transport marks on the map */
@@ -995,11 +991,11 @@
 
 "speedcams_alert_title" = "Câmeras de trânsito";
 
-"speedcam_option_auto" = "Automático";
+/* Generic «Always» string */
+"always" = "Sempre";
 
-"speedcam_option_always" = "Sempre";
-
-"speedcam_option_never" = "Nunca";
+/* Generic «Never» string */
+"never" = "Nunca";
 
 "place_description_title" = "Descrição do lugar";
 

--- a/iphone/Maps/LocalizedStrings/pt.lproj/Localizable.strings
+++ b/iphone/Maps/LocalizedStrings/pt.lproj/Localizable.strings
@@ -217,14 +217,14 @@
 /* Settings «Map» category: «Night style» title */
 "pref_map_style_title" = "Modo noturno";
 
-/* «Map style» entry value */
-"pref_map_style_default" = "Desligado";
+/* Generic «Off» string */
+"off" = "Desligado";
 
-/* «Map style» entry value */
-"pref_map_style_night" = "Ligado";
+/* Generic «On» string */
+"on" = "Ligado";
 
-/* «Map style» entry value */
-"pref_map_style_auto" = "Automático";
+/* Generic «Auto» string */
+"auto" = "Automático";
 
 /* Settings «Map» category: «Perspective view» title */
 "pref_map_3d_title" = "Visão em perspetiva";
@@ -887,10 +887,6 @@
 /* "traffic" as in "road congestion" */
 "traffic_data_unavailable" = "Os dados de tráfego não estão disponíveis";
 
-"on" = "Lig.";
-
-"off" = "Deslig.";
-
 "transliteration_title" = "Transliteração para o latim";
 
 /* Subway exits for public transport marks on the map */
@@ -995,11 +991,11 @@
 
 "speedcams_alert_title" = "Radares de velocidade";
 
-"speedcam_option_auto" = "Automático";
+/* Generic «Always» string */
+"always" = "Sempre";
 
-"speedcam_option_always" = "Sempre";
-
-"speedcam_option_never" = "Nunca";
+/* Generic «Never» string */
+"never" = "Nunca";
 
 "place_description_title" = "Descrição do local";
 

--- a/iphone/Maps/LocalizedStrings/ro.lproj/Localizable.strings
+++ b/iphone/Maps/LocalizedStrings/ro.lproj/Localizable.strings
@@ -217,14 +217,14 @@
 /* Settings «Map» category: «Night style» title */
 "pref_map_style_title" = "Mod nocturn";
 
-/* «Map style» entry value */
-"pref_map_style_default" = "Oprit";
+/* Generic «Off» string */
+"off" = "Oprit";
 
-/* «Map style» entry value */
-"pref_map_style_night" = "Pornit";
+/* Generic «On» string */
+"on" = "Pornit";
 
-/* «Map style» entry value */
-"pref_map_style_auto" = "Automat";
+/* Generic «Auto» string */
+"auto" = "Automat";
 
 /* Settings «Map» category: «Perspective view» title */
 "pref_map_3d_title" = "Vedere în perspectivă";
@@ -887,10 +887,6 @@
 /* "traffic" as in "road congestion" */
 "traffic_data_unavailable" = "Datele privind traficul nu sunt disponibile";
 
-"on" = "Pornit";
-
-"off" = "Oprit";
-
 "transliteration_title" = "Transcrie în alfabet latin";
 
 /* Subway exits for public transport marks on the map */
@@ -995,11 +991,11 @@
 
 "speedcams_alert_title" = "Radare";
 
-"speedcam_option_auto" = "Auto";
+/* Generic «Always» string */
+"always" = "Mereu";
 
-"speedcam_option_always" = "Mereu";
-
-"speedcam_option_never" = "Niciodată";
+/* Generic «Never» string */
+"never" = "Niciodată";
 
 "place_description_title" = "Descrierea locului";
 

--- a/iphone/Maps/LocalizedStrings/ru.lproj/Localizable.strings
+++ b/iphone/Maps/LocalizedStrings/ru.lproj/Localizable.strings
@@ -217,14 +217,14 @@
 /* Settings «Map» category: «Night style» title */
 "pref_map_style_title" = "Ночной режим";
 
-/* «Map style» entry value */
-"pref_map_style_default" = "Выключен";
+/* Generic «Off» string */
+"off" = "Выключен";
 
-/* «Map style» entry value */
-"pref_map_style_night" = "Включен";
+/* Generic «On» string */
+"on" = "Включен";
 
-/* «Map style» entry value */
-"pref_map_style_auto" = "Автоматически";
+/* Generic «Auto» string */
+"auto" = "Автоматически";
 
 /* Settings «Map» category: «Perspective view» title */
 "pref_map_3d_title" = "Перспективный вид";
@@ -887,10 +887,6 @@
 /* "traffic" as in "road congestion" */
 "traffic_data_unavailable" = "Данные о пробках недоступны";
 
-"on" = "Вкл.";
-
-"off" = "Выкл.";
-
 "transliteration_title" = "Латинская транслитерация";
 
 /* Subway exits for public transport marks on the map */
@@ -995,11 +991,11 @@
 
 "speedcams_alert_title" = "Камеры скорости";
 
-"speedcam_option_auto" = "Авто";
+/* Generic «Always» string */
+"always" = "Всегда";
 
-"speedcam_option_always" = "Всегда";
-
-"speedcam_option_never" = "Никогда";
+/* Generic «Never» string */
+"never" = "Никогда";
 
 "place_description_title" = "Описание места";
 

--- a/iphone/Maps/LocalizedStrings/sk.lproj/Localizable.strings
+++ b/iphone/Maps/LocalizedStrings/sk.lproj/Localizable.strings
@@ -217,14 +217,14 @@
 /* Settings «Map» category: «Night style» title */
 "pref_map_style_title" = "Nočný režim";
 
-/* «Map style» entry value */
-"pref_map_style_default" = "Vypnúť";
+/* Generic «Off» string */
+"off" = "Vypnúť";
 
-/* «Map style» entry value */
-"pref_map_style_night" = "Zapnúť";
+/* Generic «On» string */
+"on" = "Zapnúť";
 
-/* «Map style» entry value */
-"pref_map_style_auto" = "Automaticky";
+/* Generic «Auto» string */
+"auto" = "Automaticky";
 
 /* Settings «Map» category: «Perspective view» title */
 "pref_map_3d_title" = "Perspektívne zobrazenie";
@@ -887,10 +887,6 @@
 /* "traffic" as in "road congestion" */
 "traffic_data_unavailable" = "Dopravné informácie nie sú k dispozícii";
 
-"on" = "Zap.";
-
-"off" = "Vyp.";
-
 "transliteration_title" = "Prepis do latinčiny";
 
 /* Subway exits for public transport marks on the map */
@@ -995,11 +991,11 @@
 
 "speedcams_alert_title" = "Rýchlostné kamery";
 
-"speedcam_option_auto" = "Automaticky";
+/* Generic «Always» string */
+"always" = "Vždy";
 
-"speedcam_option_always" = "Vždy";
-
-"speedcam_option_never" = "Nikdy";
+/* Generic «Never» string */
+"never" = "Nikdy";
 
 "place_description_title" = "Popis miesta";
 

--- a/iphone/Maps/LocalizedStrings/sv.lproj/Localizable.strings
+++ b/iphone/Maps/LocalizedStrings/sv.lproj/Localizable.strings
@@ -217,14 +217,14 @@
 /* Settings «Map» category: «Night style» title */
 "pref_map_style_title" = "Nattläge";
 
-/* «Map style» entry value */
-"pref_map_style_default" = "Av";
+/* Generic «Off» string */
+"off" = "Av";
 
-/* «Map style» entry value */
-"pref_map_style_night" = "På";
+/* Generic «On» string */
+"on" = "På";
 
-/* «Map style» entry value */
-"pref_map_style_auto" = "Auto";
+/* Generic «Auto» string */
+"auto" = "Auto";
 
 /* Settings «Map» category: «Perspective view» title */
 "pref_map_3d_title" = "Perspektivvy";
@@ -887,10 +887,6 @@
 /* "traffic" as in "road congestion" */
 "traffic_data_unavailable" = "Trafikdata är inte tillgänglig";
 
-"on" = "På";
-
-"off" = "Av";
-
 "transliteration_title" = "Transkribering till latin";
 
 /* Subway exits for public transport marks on the map */
@@ -995,11 +991,11 @@
 
 "speedcams_alert_title" = "Hastighetskameror";
 
-"speedcam_option_auto" = "Auto";
+/* Generic «Always» string */
+"always" = "Alltid";
 
-"speedcam_option_always" = "Alltid";
-
-"speedcam_option_never" = "Aldrig";
+/* Generic «Never» string */
+"never" = "Aldrig";
 
 "place_description_title" = "Beskrivning av platsen";
 

--- a/iphone/Maps/LocalizedStrings/sw.lproj/Localizable.strings
+++ b/iphone/Maps/LocalizedStrings/sw.lproj/Localizable.strings
@@ -217,14 +217,14 @@
 /* Settings «Map» category: «Night style» title */
 "pref_map_style_title" = "Night Mode";
 
-/* «Map style» entry value */
-"pref_map_style_default" = "Off";
+/* Generic «Off» string */
+"off" = "Off";
 
-/* «Map style» entry value */
-"pref_map_style_night" = "On";
+/* Generic «On» string */
+"on" = "On";
 
-/* «Map style» entry value */
-"pref_map_style_auto" = "Auto";
+/* Generic «Auto» string */
+"auto" = "Auto";
 
 /* Settings «Map» category: «Perspective view» title */
 "pref_map_3d_title" = "Perspective view";
@@ -887,10 +887,6 @@
 /* "traffic" as in "road congestion" */
 "traffic_data_unavailable" = "Traffic data is not available";
 
-"on" = "Washa";
-
-"off" = "Zima";
-
 "transliteration_title" = "Tafsiri kwa lugha ya Kilatini";
 
 /* Subway exits for public transport marks on the map */
@@ -995,11 +991,11 @@
 
 "speedcams_alert_title" = "Kamera za mwendo-kasi";
 
-"speedcam_option_auto" = "Auto";
+/* Generic «Always» string */
+"always" = "Mara kwa Mara";
 
-"speedcam_option_always" = "Mara kwa Mara";
-
-"speedcam_option_never" = "Kamwe";
+/* Generic «Never» string */
+"never" = "Kamwe";
 
 "place_description_title" = "Maelezo ya Eneo";
 

--- a/iphone/Maps/LocalizedStrings/th.lproj/Localizable.strings
+++ b/iphone/Maps/LocalizedStrings/th.lproj/Localizable.strings
@@ -217,14 +217,14 @@
 /* Settings «Map» category: «Night style» title */
 "pref_map_style_title" = "โหมดกลางคืน";
 
-/* «Map style» entry value */
-"pref_map_style_default" = "ปิด";
+/* Generic «Off» string */
+"off" = "ปิด";
 
-/* «Map style» entry value */
-"pref_map_style_night" = "เปิด";
+/* Generic «On» string */
+"on" = "เปิด";
 
-/* «Map style» entry value */
-"pref_map_style_auto" = "อัตโนมัติ";
+/* Generic «Auto» string */
+"auto" = "อัตโนมัติ";
 
 /* Settings «Map» category: «Perspective view» title */
 "pref_map_3d_title" = "มุมมองเพอร์สเปกทีฟ";
@@ -887,10 +887,6 @@
 /* "traffic" as in "road congestion" */
 "traffic_data_unavailable" = "ไม่มีข้อมูลการจราจร";
 
-"on" = "เปิด";
-
-"off" = "ปิด";
-
 "transliteration_title" = "การทับศัพท์เป็นภาษาละติน";
 
 /* Subway exits for public transport marks on the map */
@@ -995,11 +991,11 @@
 
 "speedcams_alert_title" = "กล้องตรวจจับความเร็ว";
 
-"speedcam_option_auto" = "อัตโนมัติ";
+/* Generic «Always» string */
+"always" = "ทุกครั้ง";
 
-"speedcam_option_always" = "ทุกครั้ง";
-
-"speedcam_option_never" = "ไม่ต้องเตือน";
+/* Generic «Never» string */
+"never" = "ไม่ต้องเตือน";
 
 "place_description_title" = "รายละเอียดของสถานที่";
 

--- a/iphone/Maps/LocalizedStrings/tr.lproj/Localizable.strings
+++ b/iphone/Maps/LocalizedStrings/tr.lproj/Localizable.strings
@@ -217,14 +217,14 @@
 /* Settings «Map» category: «Night style» title */
 "pref_map_style_title" = "Gece Modu";
 
-/* «Map style» entry value */
-"pref_map_style_default" = "Kapalı";
+/* Generic «Off» string */
+"off" = "Kapalı";
 
-/* «Map style» entry value */
-"pref_map_style_night" = "Açık";
+/* Generic «On» string */
+"on" = "Açık";
 
-/* «Map style» entry value */
-"pref_map_style_auto" = "Otomatik";
+/* Generic «Auto» string */
+"auto" = "Otomatik";
 
 /* Settings «Map» category: «Perspective view» title */
 "pref_map_3d_title" = "Perspektif görünüm";
@@ -887,10 +887,6 @@
 /* "traffic" as in "road congestion" */
 "traffic_data_unavailable" = "Trafik verileri kullanılamıyor";
 
-"on" = "Aç";
-
-"off" = "Kapat";
-
 "transliteration_title" = "Latin harf çevirisi";
 
 /* Subway exits for public transport marks on the map */
@@ -995,11 +991,11 @@
 
 "speedcams_alert_title" = "Hız kameraları";
 
-"speedcam_option_auto" = "Otomatik";
+/* Generic «Always» string */
+"always" = "Her zaman";
 
-"speedcam_option_always" = "Her zaman";
-
-"speedcam_option_never" = "Asla";
+/* Generic «Never» string */
+"never" = "Asla";
 
 "place_description_title" = "Yer Açıklaması";
 

--- a/iphone/Maps/LocalizedStrings/uk.lproj/Localizable.strings
+++ b/iphone/Maps/LocalizedStrings/uk.lproj/Localizable.strings
@@ -217,14 +217,14 @@
 /* Settings «Map» category: «Night style» title */
 "pref_map_style_title" = "Нічний режим";
 
-/* «Map style» entry value */
-"pref_map_style_default" = "Вимкнуто";
+/* Generic «Off» string */
+"off" = "Вимкнуто";
 
-/* «Map style» entry value */
-"pref_map_style_night" = "Увімкнуто";
+/* Generic «On» string */
+"on" = "Увімкнуто";
 
-/* «Map style» entry value */
-"pref_map_style_auto" = "Автоматично";
+/* Generic «Auto» string */
+"auto" = "Автоматично";
 
 /* Settings «Map» category: «Perspective view» title */
 "pref_map_3d_title" = "Перспективний вид";
@@ -887,10 +887,6 @@
 /* "traffic" as in "road congestion" */
 "traffic_data_unavailable" = "Дані про трафік недоступні";
 
-"on" = "Увімкн.";
-
-"off" = "Вимкн.";
-
 "transliteration_title" = "Транслітерація латинськими літерами";
 
 /* Subway exits for public transport marks on the map */
@@ -995,11 +991,11 @@
 
 "speedcams_alert_title" = "Камери швидкості";
 
-"speedcam_option_auto" = "Авто";
+/* Generic «Always» string */
+"always" = "Завжди";
 
-"speedcam_option_always" = "Завжди";
-
-"speedcam_option_never" = "Ніколи";
+/* Generic «Never» string */
+"never" = "Ніколи";
 
 "place_description_title" = "Опис місця";
 

--- a/iphone/Maps/LocalizedStrings/vi.lproj/Localizable.strings
+++ b/iphone/Maps/LocalizedStrings/vi.lproj/Localizable.strings
@@ -217,14 +217,14 @@
 /* Settings «Map» category: «Night style» title */
 "pref_map_style_title" = "Chế độ ban đêm";
 
-/* «Map style» entry value */
-"pref_map_style_default" = "Tắt";
+/* Generic «Off» string */
+"off" = "Tắt";
 
-/* «Map style» entry value */
-"pref_map_style_night" = "Bật";
+/* Generic «On» string */
+"on" = "Bật";
 
-/* «Map style» entry value */
-"pref_map_style_auto" = "Tự động";
+/* Generic «Auto» string */
+"auto" = "Tự động";
 
 /* Settings «Map» category: «Perspective view» title */
 "pref_map_3d_title" = "Góc nhìn phối cảnh";
@@ -887,10 +887,6 @@
 /* "traffic" as in "road congestion" */
 "traffic_data_unavailable" = "Dữ liệu giao thông không khả dụng";
 
-"on" = "Bật";
-
-"off" = "Tắt";
-
 "transliteration_title" = "Chuyển ngữ sang chữ Latinh";
 
 /* Subway exits for public transport marks on the map */
@@ -995,11 +991,11 @@
 
 "speedcams_alert_title" = "Tăn tốc độ máy ảnh";
 
-"speedcam_option_auto" = "Tự động";
+/* Generic «Always» string */
+"always" = "Luôn luôn";
 
-"speedcam_option_always" = "Luôn luôn";
-
-"speedcam_option_never" = "Không bao giờ";
+/* Generic «Never» string */
+"never" = "Không bao giờ";
 
 "place_description_title" = "Mô tả Địa điểm";
 

--- a/iphone/Maps/LocalizedStrings/zh-Hans.lproj/Localizable.strings
+++ b/iphone/Maps/LocalizedStrings/zh-Hans.lproj/Localizable.strings
@@ -217,14 +217,14 @@
 /* Settings «Map» category: «Night style» title */
 "pref_map_style_title" = "夜间模式";
 
-/* «Map style» entry value */
-"pref_map_style_default" = "关闭";
+/* Generic «Off» string */
+"off" = "关闭";
 
-/* «Map style» entry value */
-"pref_map_style_night" = "开启";
+/* Generic «On» string */
+"on" = "开启";
 
-/* «Map style» entry value */
-"pref_map_style_auto" = "自动";
+/* Generic «Auto» string */
+"auto" = "自动";
 
 /* Settings «Map» category: «Perspective view» title */
 "pref_map_3d_title" = "透视图";
@@ -887,10 +887,6 @@
 /* "traffic" as in "road congestion" */
 "traffic_data_unavailable" = "交通数据不可用";
 
-"on" = "开";
-
-"off" = "关";
-
 "transliteration_title" = "直译成拉丁文";
 
 /* Subway exits for public transport marks on the map */
@@ -995,11 +991,11 @@
 
 "speedcams_alert_title" = "高速摄像机";
 
-"speedcam_option_auto" = "自动";
+/* Generic «Always» string */
+"always" = "总是";
 
-"speedcam_option_always" = "总是";
-
-"speedcam_option_never" = "从不";
+/* Generic «Never» string */
+"never" = "从不";
 
 "place_description_title" = "地点说明";
 

--- a/iphone/Maps/LocalizedStrings/zh-Hant.lproj/Localizable.strings
+++ b/iphone/Maps/LocalizedStrings/zh-Hant.lproj/Localizable.strings
@@ -217,14 +217,14 @@
 /* Settings «Map» category: «Night style» title */
 "pref_map_style_title" = "夜間模式";
 
-/* «Map style» entry value */
-"pref_map_style_default" = "關閉";
+/* Generic «Off» string */
+"off" = "關閉";
 
-/* «Map style» entry value */
-"pref_map_style_night" = "開啟";
+/* Generic «On» string */
+"on" = "開啟";
 
-/* «Map style» entry value */
-"pref_map_style_auto" = "自動";
+/* Generic «Auto» string */
+"auto" = "自動";
 
 /* Settings «Map» category: «Perspective view» title */
 "pref_map_3d_title" = "透視圖";
@@ -887,10 +887,6 @@
 /* "traffic" as in "road congestion" */
 "traffic_data_unavailable" = "無法使用交通資訊";
 
-"on" = "開";
-
-"off" = "關";
-
 "transliteration_title" = "音譯為拉丁文";
 
 /* Subway exits for public transport marks on the map */
@@ -995,11 +991,11 @@
 
 "speedcams_alert_title" = "超速照相機";
 
-"speedcam_option_auto" = "自動";
+/* Generic «Always» string */
+"always" = "總是";
 
-"speedcam_option_always" = "總是";
-
-"speedcam_option_never" = "從不";
+/* Generic «Never» string */
+"never" = "從不";
 
 "place_description_title" = "地點說明";
 

--- a/iphone/Maps/UI/Settings/MWMSettingsViewController.mm
+++ b/iphone/Maps/UI/Settings/MWMSettingsViewController.mm
@@ -184,15 +184,15 @@ using namespace power_management;
     case MWMThemeVehicleDay:
       NSAssert(false, @"Invalid case");
     case MWMThemeDay:
-      nightMode = L(@"pref_map_style_default");
+      nightMode = L(@"off");
       break;
     case MWMThemeVehicleNight:
       NSAssert(false, @"Invalid case");
     case MWMThemeNight:
-      nightMode = L(@"pref_map_style_night");
+      nightMode = L(@"on");
       break;
     case MWMThemeAuto:
-      nightMode = L(@"pref_map_style_auto");
+      nightMode = L(@"auto");
       break;
   }
   [self.nightModeCell configWithTitle:L(@"pref_map_style_title") info:nightMode];

--- a/iphone/Maps/UI/Settings/MWMTTSSettingsViewController.mm
+++ b/iphone/Maps/UI/Settings/MWMTTSSettingsViewController.mm
@@ -132,9 +132,9 @@ struct CamerasCellStrategy : BaseCellStategy
     NSString * title = nil;
     switch (static_cast<SpeedCameraManagerMode>(indexPath.row))
     {
-    case SpeedCameraManagerMode::Auto: title = L(@"speedcam_option_auto"); break;
-    case SpeedCameraManagerMode::Always: title = L(@"speedcam_option_always"); break;
-    case SpeedCameraManagerMode::Never: title = L(@"speedcam_option_never"); break;
+    case SpeedCameraManagerMode::Auto: title = L(@"auto"); break;
+    case SpeedCameraManagerMode::Always: title = L(@"always"); break;
+    case SpeedCameraManagerMode::Never: title = L(@"never"); break;
     case SpeedCameraManagerMode::MaxValue: CHECK(false, ()); return nil;
     }
 

--- a/iphone/Maps/UI/Storyboard/Settings.storyboard
+++ b/iphone/Maps/UI/Storyboard/Settings.storyboard
@@ -646,7 +646,7 @@
                                                     <color key="textColor" red="0.0" green="0.0" blue="0.0" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
                                                     <nil key="highlightedColor"/>
                                                     <userDefinedRuntimeAttributes>
-                                                        <userDefinedRuntimeAttribute type="string" keyPath="localizedText" value="pref_map_style_auto"/>
+                                                        <userDefinedRuntimeAttribute type="string" keyPath="localizedText" value="auto"/>
                                                     </userDefinedRuntimeAttributes>
                                                 </label>
                                             </subviews>
@@ -674,7 +674,7 @@
                                                     <color key="textColor" red="0.0" green="0.0" blue="0.0" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
                                                     <nil key="highlightedColor"/>
                                                     <userDefinedRuntimeAttributes>
-                                                        <userDefinedRuntimeAttribute type="string" keyPath="localizedText" value="pref_map_style_night"/>
+                                                        <userDefinedRuntimeAttribute type="string" keyPath="localizedText" value="on"/>
                                                     </userDefinedRuntimeAttributes>
                                                 </label>
                                             </subviews>
@@ -702,7 +702,7 @@
                                                     <color key="textColor" red="0.0" green="0.0" blue="0.0" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
                                                     <nil key="highlightedColor"/>
                                                     <userDefinedRuntimeAttributes>
-                                                        <userDefinedRuntimeAttribute type="string" keyPath="localizedText" value="pref_map_style_default"/>
+                                                        <userDefinedRuntimeAttribute type="string" keyPath="localizedText" value="off"/>
                                                     </userDefinedRuntimeAttributes>
                                                 </label>
                                             </subviews>


### PR DESCRIPTION
Proposal to change the legend of the "Voice instruction" settings menu.

Currently the used strings are "On/Off", which it's Ok for English, but in other languages these strings are shortened and don't look right in the "Voice instruction" setting page.

-------    Spanish (current)  --------------
![es1](https://github.com/organicmaps/organicmaps/assets/25888296/a790f2ac-f238-45da-8dac-3e6986551947)

-------    Spanish (proposal)  --------------
![es2](https://github.com/organicmaps/organicmaps/assets/25888296/3846530a-b6ad-468d-9feb-c7b347c570a7)

-------    Russian (current)  --------------
![ru1](https://github.com/organicmaps/organicmaps/assets/25888296/5cc817a9-5762-4ccf-b695-b95d7bb3a4dd)

-------    Russian (proposal)  --------------
![ru2](https://github.com/organicmaps/organicmaps/assets/25888296/864e32b0-75fb-4925-b762-3adce37a4128)

Two new strings are added in `data/string/string.txt`, `[pref_tts_on]` and `[pref_tts_off]`, which are a copy of the existing strings `[pref_map_style_night]` and `[pref_map_style_default]` respectively. (Most probably some of these strings may need revision in some languages due to gender and/or plural matching)