### PR TITLE
[gpx] Fix usage of uninitialized variable

### DIFF
--- a/data/gpx_test_data/osmand1.gpx
+++ b/data/gpx_test_data/osmand1.gpx
@@ -297,4 +297,32 @@
     <osmand:width>thin</osmand:width>
     <osmand:coloring_type>solid</osmand:coloring_type>
   </extensions>
+  <rte>
+      <rtept lat="51.8981366" lon="19.6027134">
+        <extensions>
+          <osmand:profile>car</osmand:profile>
+          <osmand:trkpt_idx>0</osmand:trkpt_idx>
+        </extensions>
+      </rtept>
+      <rtept lat="51.9014795" lon="19.6762745">
+        <extensions>
+          <osmand:profile>car</osmand:profile>
+          <osmand:trkpt_idx>71</osmand:trkpt_idx>
+        </extensions>
+      </rtept>
+  </rte>
+  <rte>
+    <rtept lat="51.8981366" lon="19.6027134">
+      <extensions>
+        <osmand:profile>car</osmand:profile>
+        <osmand:trkpt_idx>0</osmand:trkpt_idx>
+      </extensions>
+    </rtept>
+    <rtept lat="51.9014795" lon="19.6762745">
+      <extensions>
+        <osmand:profile>car</osmand:profile>
+        <osmand:trkpt_idx>71</osmand:trkpt_idx>
+      </extensions>
+    </rtept>
+  </rte>
 </gpx>

--- a/kml/kml_tests/gpx_tests.cpp
+++ b/kml/kml_tests/gpx_tests.cpp
@@ -213,6 +213,9 @@ UNIT_TEST(OsmandColor1)
   kml::FileData const dataFromFile = loadGpxFromFile("gpx_test_data/osmand1.gpx");
   uint32_t const expected = 0xFF7800FF;
   TEST_EQUAL(expected, dataFromFile.m_tracksData[0].m_layers[0].m_color.m_rgba, ());
+  TEST_EQUAL(expected, dataFromFile.m_tracksData[1].m_layers[0].m_color.m_rgba, ());
+  TEST_EQUAL(expected, dataFromFile.m_tracksData[2].m_layers[0].m_color.m_rgba, ());
+  TEST_EQUAL(expected, dataFromFile.m_tracksData[3].m_layers[0].m_color.m_rgba, ());
 }
 
 UNIT_TEST(OsmandColor2)

--- a/kml/serdes_gpx.cpp
+++ b/kml/serdes_gpx.cpp
@@ -35,6 +35,7 @@ int constexpr kInvalidColor = 0;
 GpxParser::GpxParser(FileData & data)
 : m_data(data)
 , m_categoryData(&m_data.m_categoryData)
+, m_globalColor(kInvalidColor)
 {
   ResetPoint();
 }


### PR DESCRIPTION
![Screenshot from 2023-08-25 22-40-54](https://github.com/organicmaps/organicmaps/assets/128428520/d839ae0b-0f49-4650-a422-29492fe6a962)

I'm not sure that it helps with #5800 because I can't reproduce it, but looks like some wrong usage of variable.
