### PR TITLE
[search] Fix Open/Close sometimes showed in gray color

### DIFF
--- a/iphone/Maps/UI/Search/TableView/MWMSearchCommonCell.xib
+++ b/iphone/Maps/UI/Search/TableView/MWMSearchCommonCell.xib
@@ -93,9 +93,6 @@
                         <fontDescription key="fontDescription" type="system" pointSize="12"/>
                         <color key="textColor" red="0.0" green="0.0" blue="0.0" alpha="0.54000000000000004" colorSpace="custom" customColorSpace="sRGB"/>
                         <nil key="highlightedColor"/>
-                        <userDefinedRuntimeAttributes>
-                            <userDefinedRuntimeAttribute type="string" keyPath="styleName" value="regular12:blackSecondaryText"/>
-                        </userDefinedRuntimeAttributes>
                     </label>
                     <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" verticalCompressionResistancePriority="751" ambiguous="YES" text="Russia, Moscow &amp; Central, Moscow" textAlignment="natural" lineBreakMode="tailTruncation" numberOfLines="0" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="6pc-4s-GyP">
                         <rect key="frame" x="16" y="59" width="220" height="14"/>


### PR DESCRIPTION
* Fix Open/Close sometimes showed in gray color. Closes https://github.com/organicmaps/organicmaps/issues/5832

The Color is set in dynamically in `iphone/Maps/UI/Search/TableView/MWMSearchCommonCell.mm` so `styleName = regular12:blackSecondaryText` is unnecessary in `iphone/Maps/UI/Search/TableView/MWMSearchCommonCell.xib`and was causing this conflict when rendering sometimes.