### PR TITLE
[android] Dismiss all alert dialogs when pausing MwmActivity

### DIFF
--- a/android/src/app/organicmaps/DownloadResourcesLegacyActivity.java
+++ b/android/src/app/organicmaps/DownloadResourcesLegacyActivity.java
@@ -1,6 +1,7 @@
 package app.organicmaps;
 
 import android.annotation.SuppressLint;
+import android.app.Dialog;
 import android.content.Intent;
 import android.location.Location;
 import android.os.Bundle;
@@ -63,6 +64,9 @@ public class DownloadResourcesLegacyActivity extends BaseMwmFragmentActivity
   private String mCurrentCountry;
   @Nullable
   private MapTask mMapTaskToForward;
+
+  @Nullable
+  private Dialog mAlertDialog;
 
   @NonNull
   private ActivityResultLauncher<Intent> mApiRequest;
@@ -244,6 +248,9 @@ public class DownloadResourcesLegacyActivity extends BaseMwmFragmentActivity
   {
     super.onPause();
     LocationHelper.INSTANCE.removeListener(mLocationListener);
+    if (mAlertDialog != null && mAlertDialog.isShowing())
+      mAlertDialog.dismiss();
+    mAlertDialog = null;
   }
 
   private void setDownloadMessage(int bytesToDownload)
@@ -432,6 +439,9 @@ public class DownloadResourcesLegacyActivity extends BaseMwmFragmentActivity
 
   private void showErrorDialog(int result)
   {
+    if (mAlertDialog != null && mAlertDialog.isShowing())
+      return;
+
     @StringRes final int titleId;
     @StringRes final int messageId;
 
@@ -458,7 +468,7 @@ public class DownloadResourcesLegacyActivity extends BaseMwmFragmentActivity
       throw new AssertionError("Unexpected result code = " + result);
     }
 
-    new MaterialAlertDialogBuilder(this, R.style.MwmTheme_AlertDialog)
+    mAlertDialog = new MaterialAlertDialogBuilder(this, R.style.MwmTheme_AlertDialog)
         .setTitle(titleId)
         .setMessage(messageId)
         .setCancelable(true)
@@ -467,6 +477,7 @@ public class DownloadResourcesLegacyActivity extends BaseMwmFragmentActivity
           setAction(TRY_AGAIN);
           onTryAgainClicked();
         })
+        .setOnDismissListener(dialog -> mAlertDialog = null)
         .show();
   }
 


### PR DESCRIPTION
This patch fixes `Activity app.organicmaps.MwmActivity has leaked window` when pausing MwmActivity during showing the following error dialogs:

- "Your location hasn't been determined yet"
- "No internet connection"
- "No object can be located here"
- "Update Maps"
- "Unable to calculate route"
- "When following the route, please keep in mind:"
- "Navigation is only available from your current location."
- Dialogs in DownloadResourcesLegacyActivity.

Fixes #5838
See also #4570 d4bf7a73 "Fix a crash on rotation"