### PR TITLE
[3party] Fixed HTTP 504 for freetype git submodule

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -37,7 +37,7 @@
   url = https://github.com/unicode-org/icu.git
 [submodule "3party/freetype/freetype"]
 	path = 3party/freetype/freetype
-	url = https://gitlab.freedesktop.org/freetype/freetype.git
+	url = https://github.com/organicmaps/freetype.git
 [submodule "3party/googletest"]
 	path = 3party/googletest
 	url = https://github.com/google/googletest.git


### PR DESCRIPTION
freetype was forked into https://github.com/organicmaps/freetype