### PR TITLE
[android-auto] Navigation intents support

### DIFF
--- a/android/app/src/main/java/app/organicmaps/car/NavigationSession.java
+++ b/android/app/src/main/java/app/organicmaps/car/NavigationSession.java
@@ -22,6 +22,7 @@ import app.organicmaps.bookmarks.data.MapObject;
 import app.organicmaps.car.screens.NavigationScreen;
 import app.organicmaps.car.screens.PlaceScreen;
 import app.organicmaps.car.screens.hacks.PopToRootHack;
+import app.organicmaps.car.util.IntentUtils;
 import app.organicmaps.car.util.RoutingUtils;
 import app.organicmaps.display.DisplayChangedListener;
 import app.organicmaps.display.DisplayManager;
@@ -82,17 +83,29 @@ public final class NavigationSession extends Session implements DefaultLifecycle
   {
     Logger.d(TAG);
 
-    Logger.d(TAG, "Session info: " + mSessionInfo);
-    Logger.d(TAG, "API Level: " + getCarContext().getCarAppApiLevel());
+    Logger.i(TAG, "Session info: " + mSessionInfo);
+    Logger.i(TAG, "API Level: " + getCarContext().getCarAppApiLevel());
     if (mSessionInfo != null)
-      Logger.d(TAG, "Supported templates: " + mSessionInfo.getSupportedTemplates(getCarContext().getCarAppApiLevel()));
-    Logger.d(TAG, "Host info: " + getCarContext().getHostInfo());
-    Logger.d(TAG, "Car configuration: " + getCarContext().getResources().getConfiguration());
+      Logger.i(TAG, "Supported templates: " + mSessionInfo.getSupportedTemplates(getCarContext().getCarAppApiLevel()));
+    Logger.i(TAG, "Host info: " + getCarContext().getHostInfo());
+    Logger.i(TAG, "Car configuration: " + getCarContext().getResources().getConfiguration());
 
     if (mInitFailed)
       return new ErrorScreen(getCarContext());
 
     return new MapScreen(getCarContext(), mSurfaceRenderer);
+  }
+
+  @Override
+  public void onNewIntent(@NonNull Intent intent)
+  {
+    Logger.d(TAG, intent.toString());
+    // TODO (AndrewShkrob): This logic will need to be revised when we introduce support for adding stops during navigation or route planning.
+    // Skip navigation intents during navigation
+    if (RoutingController.get().isNavigating())
+      return;
+
+    IntentUtils.processIntent(getCarContext(), mSurfaceRenderer, intent);
   }
 
   @Override

--- a/android/app/src/main/java/app/organicmaps/car/screens/search/SearchOnMapScreen.java
+++ b/android/app/src/main/java/app/organicmaps/car/screens/search/SearchOnMapScreen.java
@@ -24,6 +24,7 @@ import app.organicmaps.search.NativeSearchListener;
 import app.organicmaps.search.SearchEngine;
 import app.organicmaps.search.SearchRecents;
 import app.organicmaps.search.SearchResult;
+import app.organicmaps.util.Language;
 
 public class SearchOnMapScreen extends BaseMapScreen implements NativeSearchListener
 {
@@ -31,6 +32,8 @@ public class SearchOnMapScreen extends BaseMapScreen implements NativeSearchList
 
   @NonNull
   private final String mQuery;
+  @NonNull
+  private final String mLocale;
   private final boolean mIsCategory;
 
   @Nullable
@@ -43,6 +46,7 @@ public class SearchOnMapScreen extends BaseMapScreen implements NativeSearchList
     MAX_RESULTS_SIZE = constraintManager.getContentLimit(ConstraintManager.CONTENT_LIMIT_TYPE_PLACE_LIST);
 
     mQuery = builder.mQuery;
+    mLocale = builder.mLocale;
     mIsCategory = builder.mIsCategory;
   }
 
@@ -130,7 +134,7 @@ public class SearchOnMapScreen extends BaseMapScreen implements NativeSearchList
     final double lat = hasLocation ? location.getLat() : 0;
     final double lon = hasLocation ? location.getLon() : 0;
 
-    SearchEngine.INSTANCE.searchInteractive(getCarContext(), mQuery, mIsCategory, System.nanoTime(), true /* isMapAndTable */, hasLocation, lat, lon);
+    SearchEngine.INSTANCE.searchInteractive(mQuery, mIsCategory, mLocale, System.nanoTime(), true /* isMapAndTable */, hasLocation, lat, lon);
   }
 
   @Override
@@ -161,12 +165,15 @@ public class SearchOnMapScreen extends BaseMapScreen implements NativeSearchList
 
     @NonNull
     private String mQuery = "";
+    @NonNull
+    private String mLocale;
     private boolean mIsCategory;
 
     public Builder(@NonNull CarContext carContext, @NonNull SurfaceRenderer surfaceRenderer)
     {
       mCarContext = carContext;
       mSurfaceRenderer = surfaceRenderer;
+      mLocale = Language.getKeyboardLocale(mCarContext);
     }
 
     public Builder setCategory(@NonNull String category)
@@ -180,6 +187,12 @@ public class SearchOnMapScreen extends BaseMapScreen implements NativeSearchList
     {
       mIsCategory = false;
       mQuery = query;
+      return this;
+    }
+
+    public Builder setLocale(@NonNull String locale)
+    {
+      mLocale = locale;
       return this;
     }
 

--- a/android/app/src/main/java/app/organicmaps/car/screens/search/SearchScreen.java
+++ b/android/app/src/main/java/app/organicmaps/car/screens/search/SearchScreen.java
@@ -23,6 +23,7 @@ import app.organicmaps.search.NativeSearchListener;
 import app.organicmaps.search.SearchEngine;
 import app.organicmaps.search.SearchRecents;
 import app.organicmaps.search.SearchResult;
+import app.organicmaps.util.Language;
 
 public class SearchScreen extends BaseMapScreen implements SearchTemplate.SearchCallback, NativeSearchListener
 {
@@ -30,6 +31,8 @@ public class SearchScreen extends BaseMapScreen implements SearchTemplate.Search
 
   @NonNull
   private String mQuery = "";
+  @NonNull
+  private String mLocale;
 
   @Nullable
   private ItemList mResults = null;
@@ -40,6 +43,7 @@ public class SearchScreen extends BaseMapScreen implements SearchTemplate.Search
     final ConstraintManager constraintManager = getCarContext().getCarService(ConstraintManager.class);
     MAX_RESULTS_SIZE = constraintManager.getContentLimit(ConstraintManager.CONTENT_LIMIT_TYPE_LIST);
 
+    mLocale = builder.mLocale;
     onSearchSubmitted(builder.mQuery);
   }
 
@@ -72,6 +76,7 @@ public class SearchScreen extends BaseMapScreen implements SearchTemplate.Search
     if (mQuery.equals(searchText))
       return;
     mQuery = searchText;
+    mLocale = Language.getKeyboardLocale(getCarContext());
     mResults = null;
 
     SearchEngine.INSTANCE.cancel();
@@ -179,7 +184,7 @@ public class SearchScreen extends BaseMapScreen implements SearchTemplate.Search
     final Action.Builder builder = new Action.Builder();
     builder.setIcon(new CarIcon.Builder(IconCompat.createWithResource(getCarContext(), R.drawable.ic_show_on_map)).build());
     builder.setOnClickListener(() ->
-        getScreenManager().push(new SearchOnMapScreen.Builder(getCarContext(), getSurfaceRenderer()).setQuery(mQuery).build()));
+        getScreenManager().push(new SearchOnMapScreen.Builder(getCarContext(), getSurfaceRenderer()).setQuery(mQuery).setLocale(mLocale).build()));
 
     return new ActionStrip.Builder().addAction(builder.build()).build();
   }
@@ -196,17 +201,27 @@ public class SearchScreen extends BaseMapScreen implements SearchTemplate.Search
 
     @NonNull
     private String mQuery = "";
+    @NonNull
+    private String mLocale;
 
     public Builder(@NonNull CarContext carContext, @NonNull SurfaceRenderer surfaceRenderer)
     {
       mCarContext = carContext;
       mSurfaceRenderer = surfaceRenderer;
+
+      mLocale = Language.getKeyboardLocale(mCarContext);
     }
 
     @NonNull
     public Builder setQuery(@NonNull String query)
     {
       mQuery = query;
+      return this;
+    }
+
+    public Builder setLocale(@NonNull String locale)
+    {
+      mLocale = locale;
       return this;
     }
 

--- a/android/app/src/main/java/app/organicmaps/car/util/IntentUtils.java
+++ b/android/app/src/main/java/app/organicmaps/car/util/IntentUtils.java
@@ -1,0 +1,77 @@
+package app.organicmaps.car.util;
+
+import android.content.Intent;
+
+import androidx.annotation.NonNull;
+import androidx.car.app.CarContext;
+import androidx.car.app.ScreenManager;
+
+import app.organicmaps.Framework;
+import app.organicmaps.Map;
+import app.organicmaps.api.ParsedSearchRequest;
+import app.organicmaps.api.ParsingResult;
+import app.organicmaps.car.SurfaceRenderer;
+import app.organicmaps.car.screens.hacks.PopToRootHack;
+import app.organicmaps.car.screens.search.SearchScreen;
+import app.organicmaps.intent.Factory;
+
+public final class IntentUtils
+{
+  private static final int SEARCH_IN_VIEWPORT_ZOOM = 16;
+
+  // TODO (AndrewShkrob): As of now, the core functionality does not encompass support for the queries 2-3.
+  // https://developer.android.com/reference/androidx/car/app/CarContext#startCarApp(android.content.Intent)
+  // The data URI scheme must be either a latitude,longitude pair, or a + separated string query as follows:
+  //   1) "geo:12.345,14.8767" for a latitude, longitude pair.
+  //   2) "geo:0,0?q=123+Main+St,+Seattle,+WA+98101" for an address.
+  //   3) "geo:0,0?q=a+place+name" for a place to search for.
+  public static void processIntent(@NonNull CarContext carContext, @NonNull SurfaceRenderer surfaceRenderer, @NonNull Intent intent)
+  {
+    final String action = intent.getAction();
+    if (action == null || !intent.getAction().equals(CarContext.ACTION_NAVIGATE))
+      return;
+
+    String url = Factory.GeoIntentProcessor.processIntent(intent);
+    if (url == null)
+      return;
+
+    final ParsingResult result = Framework.nativeParseAndSetApiUrl(url);
+    final ScreenManager screenManager = carContext.getCarService(ScreenManager.class);
+
+    screenManager.popToRoot();
+
+    if (result.getUrlType() == ParsingResult.TYPE_INCORRECT)
+    {
+      Map.showMapForUrl(url);
+      return;
+    }
+
+    if (!result.isSuccess())
+      return;
+
+    switch (result.getUrlType())
+    {
+    case ParsingResult.TYPE_INCORRECT:
+    case ParsingResult.TYPE_MAP:
+      Map.showMapForUrl(url);
+      return;
+    case ParsingResult.TYPE_SEARCH:
+      final ParsedSearchRequest request = Framework.nativeGetParsedSearchRequest();
+      final double[] latlon = Framework.nativeGetParsedCenterLatLon();
+      if (latlon[0] != 0.0 || latlon[1] != 0.0)
+      {
+        Framework.nativeStopLocationFollow();
+        Framework.nativeSetViewportCenter(latlon[0], latlon[1], SEARCH_IN_VIEWPORT_ZOOM);
+      }
+      final SearchScreen.Builder builder = new SearchScreen.Builder(carContext, surfaceRenderer);
+      builder.setQuery(request.mQuery);
+      if (request.mLocale != null)
+        builder.setLocale(request.mLocale);
+
+      screenManager.push(new PopToRootHack.Builder(carContext).setScreenToPush(builder.build()).build());
+    default:
+    }
+  }
+
+  private IntentUtils() {}
+}

--- a/android/app/src/main/java/app/organicmaps/car/util/UiHelpers.java
+++ b/android/app/src/main/java/app/organicmaps/car/util/UiHelpers.java
@@ -1,9 +1,5 @@
 package app.organicmaps.car.util;
 
-import static android.Manifest.permission.ACCESS_COARSE_LOCATION;
-import static android.Manifest.permission.ACCESS_FINE_LOCATION;
-import static android.content.pm.PackageManager.PERMISSION_GRANTED;
-
 import androidx.annotation.DrawableRes;
 import androidx.annotation.NonNull;
 import androidx.annotation.Nullable;
@@ -16,7 +12,6 @@ import androidx.car.app.model.CarColor;
 import androidx.car.app.model.CarIcon;
 import androidx.car.app.model.Row;
 import androidx.car.app.navigation.model.MapController;
-import androidx.core.app.ActivityCompat;
 import androidx.core.graphics.drawable.IconCompat;
 
 import app.organicmaps.R;
@@ -190,10 +185,8 @@ public final class UiHelpers
     builder.setIcon(icon);
     builder.setOnClickListener(() -> {
       LocationState.nativeSwitchToNextMode();
-      if (LocationHelper.INSTANCE.isActive() && (
-          ActivityCompat.checkSelfPermission(context, ACCESS_FINE_LOCATION) == PERMISSION_GRANTED) ||
-          ActivityCompat.checkSelfPermission(context, ACCESS_COARSE_LOCATION) == PERMISSION_GRANTED)
-        LocationHelper.INSTANCE.start();
+      if (!LocationHelper.INSTANCE.isActive())
+        LocationHelper.INSTANCE.restart();
     });
     return builder.build();
   }

--- a/android/app/src/main/java/app/organicmaps/intent/Factory.java
+++ b/android/app/src/main/java/app/organicmaps/intent/Factory.java
@@ -14,7 +14,6 @@ import androidx.fragment.app.FragmentManager;
 import app.organicmaps.DownloadResourcesLegacyActivity;
 import app.organicmaps.Framework;
 import app.organicmaps.Map;
-import app.organicmaps.MapFragment;
 import app.organicmaps.MwmActivity;
 import app.organicmaps.MwmApplication;
 import app.organicmaps.api.ParsedMwmRequest;
@@ -45,6 +44,15 @@ public class Factory
     @Override
     public MapTask process(@NonNull Intent intent)
     {
+      final String uri = processIntent(intent);
+      if (uri == null)
+        return null;
+      return new OpenUrlTask(uri);
+    }
+
+    @Nullable
+    public static String processIntent(@NonNull Intent intent)
+    {
       final Uri uri = intent.getData();
       if (uri == null)
         return null;
@@ -54,7 +62,7 @@ public class Factory
       SearchEngine.INSTANCE.cancelInteractiveSearch();
       final ParsedMwmRequest request = ParsedMwmRequest.extractFromIntent(intent);
       ParsedMwmRequest.setCurrentRequest(request);
-      return new OpenUrlTask(uri.toString());
+      return uri.toString();
     }
   }
 

--- a/android/app/src/main/java/app/organicmaps/search/SearchEngine.java
+++ b/android/app/src/main/java/app/organicmaps/search/SearchEngine.java
@@ -158,13 +158,6 @@ public enum SearchEngine implements NativeSearchListener,
   }
 
   @MainThread
-  public void searchInteractive(@NonNull Context context, @NonNull String query, boolean isCategory,
-                                long timestamp, boolean isMapAndTable, boolean hasLocation, double lat, double lon)
-  {
-    searchInteractive(query, isCategory, Language.getKeyboardLocale(context), timestamp, isMapAndTable, hasLocation, lat, lon);
-  }
-
-  @MainThread
   public boolean searchInBookmarks(@NonNull String query, long categoryId, long timestamp)
   {
     return nativeRunSearchInBookmarks(query.getBytes(StandardCharsets.UTF_8), categoryId, timestamp);


### PR DESCRIPTION

>An [Intent](https://developer.android.com/reference/android/content/Intent.html) to navigate.
>
>The action must be [ACTION_NAVIGATE](https://developer.android.com/reference/androidx/car/app/CarContext#ACTION_NAVIGATE()).
>The data URI scheme must be either a latitude,longitude pair, or a + separated string query as follows:
>1) "geo:12.345,14.8767" for a latitude, longitude pair.
>2) "geo:0,0?q=123+Main+St,+Seattle,+WA+98101" for an address.
>3) "geo:0,0?q=a+place+name" for a place to search for.

Currently, the core functionality does not include support for queries 2 and 3. However, the logic for handling these queries has been already implemented and tested to the best extent possible.

I encountered an issue where I couldn't send an intent via ADB. Although the intent was successfully dispatched, it wasn't processed as expected.
`./adb shell am startservice -a androidx.car.app.action.NAVIGATE -n app.organicmaps.debug/app.organicmaps.car.NavigationCarAppService -d "geo:0,0?q=50.06370664014736,20.007851471299205"`

You can test it with another AA application. F.e. `EVMap`