### PR TITLE
Fix scrolling behavior in the place description window.

### DIFF
--- a/android/src/app/organicmaps/widget/NestedScrollViewClickFixed.java
+++ b/android/src/app/organicmaps/widget/NestedScrollViewClickFixed.java
@@ -763,6 +763,9 @@ public class NestedScrollViewClickFixed extends FrameLayout implements NestedScr
                  * isFinished() is correct.
                  */
                 mScroller.computeScrollOffset();
+                if (!mScroller.isFinished()) {
+                    mScroller.abortAnimation();
+                }
                 mIsBeingDragged = false;
                 startNestedScroll(ViewCompat.SCROLL_AXIS_VERTICAL, ViewCompat.TYPE_TOUCH);
                 break;


### PR DESCRIPTION
Specifically, stop an ongoing fling scrolling when tapping inside the view (or when starting another scrolling).

Steps to reproduce the problem fixed here:
- create/import some bookmark with a very long description
- click on the bookmark place on the map
- start scrolling the place description window swiftly (stop touching the display while still moving the finger)
- the scrolling continues by itself for a while - this is correct
- tap the screen - PROBLEM 1: the tap does not stop the scrolling
- OR start another scrolling - PROBLEM 2: the original scrolling is not stopped and it somehow continues alongside the new scrolling