### PR TITLE
[Android] Transit steps info is now scrollable.

### DIFF
--- a/android/app/src/main/java/app/organicmaps/MwmActivity.java
+++ b/android/app/src/main/java/app/organicmaps/MwmActivity.java
@@ -829,7 +829,11 @@ public class MwmActivity extends BaseMwmFragmentActivity
 
   private void initMainMenu()
   {
-    mMainMenu = new MainMenu(findViewById(R.id.menu_frame), this::updateBottomWidgetsOffset);
+    final View menuFrame = findViewById(R.id.menu_frame);
+    mMainMenu = new MainMenu(menuFrame, () -> {
+      this.updateBottomWidgetsOffset();
+      mPlacePageViewModel.setPlacePageDistanceToTop(menuFrame.getTop());
+    });
 
     if (mIsTabletLayout)
     {

--- a/android/app/src/main/java/app/organicmaps/routing/RoutingBottomMenuController.java
+++ b/android/app/src/main/java/app/organicmaps/routing/RoutingBottomMenuController.java
@@ -19,6 +19,7 @@ import android.text.style.TypefaceSpan;
 import android.view.View;
 import android.widget.Button;
 import android.widget.ImageView;
+import android.widget.ScrollView;
 import android.widget.TextView;
 
 import androidx.annotation.IdRes;
@@ -183,6 +184,11 @@ final class RoutingBottomMenuController implements View.OnClickListener
     rv.setAdapter(adapter);
     adapter.setItems(info.getTransitSteps());
 
+    final ScrollView parentScroll = (ScrollView)rv.getParent();
+    if (parentScroll != null)
+      // Scroll to bottom
+      parentScroll.postDelayed(() -> parentScroll.fullScroll(ScrollView.FOCUS_DOWN), 100);
+
     TextView totalTimeView = mTransitFrame.findViewById(R.id.total_time);
     totalTimeView.setText(RoutingController.formatRoutingTime(mContext, info.getTotalTime(),
                                                             R.dimen.text_size_routing_number));
@@ -210,6 +216,11 @@ final class RoutingBottomMenuController implements View.OnClickListener
       rv.addItemDecoration(mTransitViewDecorator);
       rv.setAdapter(adapter);
       adapter.setItems(pointsToRulerSteps(points));
+
+      final ScrollView parentScroll = (ScrollView)rv.getParent();
+      if (parentScroll != null)
+        // Scroll to bottom
+        parentScroll.postDelayed(() -> parentScroll.fullScroll(ScrollView.FOCUS_DOWN), 100);
     }
     else
       UiUtils.hide(rv); // Show only distance between start and finish

--- a/android/app/src/main/java/app/organicmaps/routing/RoutingBottomMenuController.java
+++ b/android/app/src/main/java/app/organicmaps/routing/RoutingBottomMenuController.java
@@ -33,11 +33,11 @@ import app.organicmaps.R;
 import app.organicmaps.bookmarks.data.DistanceAndAzimut;
 import app.organicmaps.location.LocationHelper;
 import app.organicmaps.util.Distance;
-import app.organicmaps.widget.recycler.DotDividerItemDecoration;
-import app.organicmaps.widget.recycler.MultilineLayoutManager;
 import app.organicmaps.util.Graphics;
 import app.organicmaps.util.ThemeUtils;
 import app.organicmaps.util.UiUtils;
+import app.organicmaps.widget.recycler.DotDividerItemDecoration;
+import app.organicmaps.widget.recycler.MultilineLayoutManager;
 
 import java.util.LinkedList;
 import java.util.List;

--- a/android/app/src/main/java/app/organicmaps/routing/RoutingBottomMenuController.java
+++ b/android/app/src/main/java/app/organicmaps/routing/RoutingBottomMenuController.java
@@ -184,10 +184,7 @@ final class RoutingBottomMenuController implements View.OnClickListener
     rv.setAdapter(adapter);
     adapter.setItems(info.getTransitSteps());
 
-    final ScrollView parentScroll = (ScrollView)rv.getParent();
-    if (parentScroll != null)
-      // Scroll to bottom
-      parentScroll.postDelayed(() -> parentScroll.fullScroll(ScrollView.FOCUS_DOWN), 100);
+    scrollToBottom(rv);
 
     TextView totalTimeView = mTransitFrame.findViewById(R.id.total_time);
     totalTimeView.setText(RoutingController.formatRoutingTime(mContext, info.getTotalTime(),
@@ -217,10 +214,7 @@ final class RoutingBottomMenuController implements View.OnClickListener
       rv.setAdapter(adapter);
       adapter.setItems(pointsToRulerSteps(points));
 
-      final ScrollView parentScroll = (ScrollView)rv.getParent();
-      if (parentScroll != null)
-        // Scroll to bottom
-        parentScroll.postDelayed(() -> parentScroll.fullScroll(ScrollView.FOCUS_DOWN), 100);
+      scrollToBottom(rv);
     }
     else
       UiUtils.hide(rv); // Show only distance between start and finish
@@ -382,6 +376,14 @@ final class RoutingBottomMenuController implements View.OnClickListener
       String arrivalTime = RoutingController.formatArrivalTime(rinfo.totalTimeInSeconds);
       mArrival.setText(arrivalTime);
     }
+  }
+
+  // Scroll RecyclerView to bottom using parent ScrollView.
+  private static void scrollToBottom(RecyclerView rv)
+  {
+    final ScrollView parentScroll = (ScrollView) rv.getParent();
+    if (parentScroll != null)
+      parentScroll.postDelayed(() -> parentScroll.fullScroll(ScrollView.FOCUS_DOWN), 100);
   }
 
   @NonNull

--- a/android/app/src/main/res/layout/routing_bottom_panel_transit.xml
+++ b/android/app/src/main/res/layout/routing_bottom_panel_transit.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<RelativeLayout
+<androidx.constraintlayout.widget.ConstraintLayout
   xmlns:android="http://schemas.android.com/apk/res/android"
   xmlns:app="http://schemas.android.com/apk/res-auto"
   xmlns:tools="http://schemas.android.com/tools"
@@ -14,39 +14,49 @@
     android:id="@+id/total_time"
     android:layout_width="wrap_content"
     android:layout_height="wrap_content"
-    android:layout_alignParentTop="true"
-    android:layout_alignParentStart="true"
+    app:layout_constraintStart_toStartOf="parent"
+    app:layout_constraintTop_toTopOf="parent"
     style="@style/MwmWidget.TextView.PlanDetail.Number.Time"
     tools:text="40 min"/>
   <TextView
     android:id="@+id/dot"
-    android:layout_toEndOf="@id/total_time"
     style="@style/MwmWidget.TextView.PlanDetail.Number.Secondary"
     android:layout_marginStart="@dimen/margin_quarter_plus"
-    android:layout_marginEnd="@dimen/margin_quarter_plus"
     android:layout_marginTop="@dimen/margin_eighth"
+    android:layout_marginEnd="@dimen/margin_quarter_plus"
     android:text="•"
+    app:layout_constraintStart_toEndOf="@id/total_time"
+    app:layout_constraintTop_toTopOf="parent"
     tools:ignore="HardcodedText"/>
   <ImageView
     android:id="@+id/pedestrian_icon"
-    android:layout_alignBottom="@id/total_time"
-    android:layout_toEndOf="@id/dot"
     android:layout_width="wrap_content"
     android:layout_height="wrap_content"
+    android:layout_marginStart="@dimen/margin_quarter_plus"
     android:src="@drawable/ic_20px_route_planning_walk"
+    app:layout_constraintBottom_toBottomOf="@id/total_time"
+    app:layout_constraintStart_toEndOf="@id/dot"
     app:tint="?iconTint"/>
   <TextView
     android:id="@+id/total_distance"
-    android:layout_toEndOf="@id/pedestrian_icon"
     style="@style/MwmWidget.TextView.PlanDetail.Number.Secondary"
     android:layout_width="wrap_content"
     android:layout_height="wrap_content"
+    app:layout_constraintStart_toEndOf="@id/pedestrian_icon"
+    app:layout_constraintTop_toTopOf="parent"
     tools:text="1 km"/>
-  <androidx.recyclerview.widget.RecyclerView
-    android:id="@+id/transit_recycler_view"
-    android:layout_marginTop="@dimen/margin_half_plus"
-    android:layout_alignParentStart="true"
-    android:layout_below="@id/total_time"
+  <ScrollView
     android:layout_width="match_parent"
-    android:layout_height="wrap_content"/>
-</RelativeLayout>
+    android:layout_height="wrap_content"
+    app:layout_constraintHeight_max="150dp"
+    android:layout_marginTop="@dimen/margin_half_plus"
+    app:layout_constraintStart_toStartOf="parent"
+    app:layout_constraintTop_toBottomOf="@id/total_time"
+    android:scrollbarAlwaysDrawVerticalTrack="true">
+
+    <androidx.recyclerview.widget.RecyclerView
+      android:id="@+id/transit_recycler_view"
+      android:layout_width="match_parent"
+      android:layout_height="wrap_content"/>
+  </ScrollView>
+</androidx.constraintlayout.widget.ConstraintLayout>


### PR DESCRIPTION
In case of big number of ruler steps bottom panel becomes too big. See #5880 for sample

Added scrolling to the panel layout.

Result:
https://github.com/organicmaps/organicmaps/assets/720808/0ec1b719-588a-444d-a556-6bc167d3ff88

**Note:** this is temporary solution. The best approach is to draw segment length on the map itself.