### PR TITLE
[Android] Route info panel re-layout

### DIFF
--- a/android/app/src/main/java/app/organicmaps/routing/RoutingBottomMenuController.java
+++ b/android/app/src/main/java/app/organicmaps/routing/RoutingBottomMenuController.java
@@ -88,7 +88,7 @@ final class RoutingBottomMenuController implements View.OnClickListener
                                                  @Nullable RoutingBottomMenuListener listener)
   {
     View altitudeChartFrame = getViewById(activity, frame, R.id.altitude_chart_panel);
-    View timeEleveationLine = getViewById(activity, frame, R.id.time_elevation_line);
+    View timeElevationLine = getViewById(activity, frame, R.id.time_elevation_line);
     View transitFrame = getViewById(activity, frame, R.id.transit_panel);
     TextView error = (TextView) getViewById(activity, frame, R.id.error);
     Button start = (Button) getViewById(activity, frame, R.id.start);
@@ -99,7 +99,7 @@ final class RoutingBottomMenuController implements View.OnClickListener
     TextView arrival = (TextView) getViewById(activity, frame, R.id.arrival);
     View actionFrame = getViewById(activity, frame, R.id.routing_action_frame);
 
-    return new RoutingBottomMenuController(activity, altitudeChartFrame, timeEleveationLine, transitFrame,
+    return new RoutingBottomMenuController(activity, altitudeChartFrame, timeElevationLine, transitFrame,
                                            error, start, altitudeChart, time, altitudeDifference,
                                            timeVehicle, arrival, actionFrame, listener);
   }
@@ -114,7 +114,7 @@ final class RoutingBottomMenuController implements View.OnClickListener
 
   private RoutingBottomMenuController(@NonNull Activity context,
                                       @NonNull View altitudeChartFrame,
-                                      @NonNull View timeEleveationLine,
+                                      @NonNull View timeElevationLine,
                                       @NonNull View transitFrame,
                                       @NonNull TextView error,
                                       @NonNull Button start,
@@ -128,7 +128,7 @@ final class RoutingBottomMenuController implements View.OnClickListener
   {
     mContext = context;
     mAltitudeChartFrame = altitudeChartFrame;
-    mTimeElevationLine = timeEleveationLine;
+    mTimeElevationLine = timeElevationLine;
     mTransitFrame = transitFrame;
     mError = error;
     mStart = start;
@@ -155,7 +155,7 @@ final class RoutingBottomMenuController implements View.OnClickListener
 
   void showAltitudeChartAndRoutingDetails()
   {
-    UiUtils.hide(mError, mActionFrame, mAltitudeChart, mAltitudeDifference, mTransitFrame);
+    UiUtils.hide(mError, mActionFrame, mAltitudeChart, mTimeElevationLine, mTransitFrame);
 
     if (!RoutingController.get().isVehicleRouterType() && !RoutingController.get().isRulerRouterType())
       showRouteAltitudeChart();

--- a/android/app/src/main/java/app/organicmaps/routing/RoutingBottomMenuController.java
+++ b/android/app/src/main/java/app/organicmaps/routing/RoutingBottomMenuController.java
@@ -60,9 +60,11 @@ final class RoutingBottomMenuController implements View.OnClickListener
   @NonNull
   private final ImageView mAltitudeChart;
   @NonNull
-  private final TextView mAltitudeDifference;
+  private final TextView mTime;
   @NonNull
-  private final View mNumbersFrame;
+  private final TextView mAltitudeDifference;
+  @Nullable
+  private final TextView mArrival;
   @NonNull
   private final View mActionFrame;
   @NonNull
@@ -86,12 +88,13 @@ final class RoutingBottomMenuController implements View.OnClickListener
     TextView error = (TextView) getViewById(activity, frame, R.id.error);
     Button start = (Button) getViewById(activity, frame, R.id.start);
     ImageView altitudeChart = (ImageView) getViewById(activity, frame, R.id.altitude_chart);
+    TextView time = (TextView) getViewById(activity, frame, R.id.time);
     TextView altitudeDifference = (TextView) getViewById(activity, frame, R.id.altitude_difference);
-    View numbersFrame = getViewById(activity, frame, R.id.numbers);
+    TextView arrival = (TextView) getViewById(activity, frame, R.id.arrival);
     View actionFrame = getViewById(activity, frame, R.id.routing_action_frame);
 
-    return new RoutingBottomMenuController(activity, altitudeChartFrame, transitFrame, error, start, altitudeChart, altitudeDifference,
-                                           numbersFrame, actionFrame, listener);
+    return new RoutingBottomMenuController(activity, altitudeChartFrame, transitFrame, error, start, altitudeChart,
+                                           time, altitudeDifference, arrival, actionFrame, listener);
   }
 
   @NonNull
@@ -108,8 +111,9 @@ final class RoutingBottomMenuController implements View.OnClickListener
                                       @NonNull TextView error,
                                       @NonNull Button start,
                                       @NonNull ImageView altitudeChart,
+                                      @NonNull TextView time,
                                       @NonNull TextView altitudeDifference,
-                                      @NonNull View numbersFrame,
+                                      @Nullable TextView arrival,
                                       @NonNull View actionFrame,
                                       @Nullable RoutingBottomMenuListener listener)
   {
@@ -119,8 +123,9 @@ final class RoutingBottomMenuController implements View.OnClickListener
     mError = error;
     mStart = start;
     mAltitudeChart = altitudeChart;
+    mTime = time;
     mAltitudeDifference = altitudeDifference;
-    mNumbersFrame = numbersFrame;
+    mArrival = arrival;
     mActionFrame = actionFrame;
     mActionMessage = actionFrame.findViewById(R.id.tv__message);
     mActionButton = actionFrame.findViewById(R.id.btn__my_position_use);
@@ -155,7 +160,7 @@ final class RoutingBottomMenuController implements View.OnClickListener
   @SuppressLint("SetTextI18n")
   void showTransitInfo(@NonNull TransitRouteInfo info)
   {
-    UiUtils.hide(mError, mAltitudeChartFrame, mActionFrame, mAltitudeChartFrame);
+    UiUtils.hide(mError, mAltitudeChartFrame, mActionFrame);
     showStartButton(false);
     UiUtils.show(mTransitFrame);
     RecyclerView rv = mTransitFrame.findViewById(R.id.transit_recycler_view);
@@ -332,19 +337,18 @@ final class RoutingBottomMenuController implements View.OnClickListener
     final RoutingInfo rinfo = RoutingController.get().getCachedRoutingInfo();
     if (rinfo == null)
     {
-      UiUtils.hide(mNumbersFrame);
+      UiUtils.hide(mTime);
+      UiUtils.hide(mAltitudeDifference);
       return;
     }
 
     Spanned spanned = makeSpannedRoutingDetails(mContext, rinfo);
-    TextView numbersTime = mNumbersFrame.findViewById(R.id.time);
-    numbersTime.setText(spanned);
+    mTime.setText(spanned);
 
-    TextView numbersArrival = mNumbersFrame.findViewById(R.id.arrival);
-    if (numbersArrival != null)
+    if (mArrival != null)
     {
       String arrivalTime = RoutingController.formatArrivalTime(rinfo.totalTimeInSeconds);
-      numbersArrival.setText(arrivalTime);
+      mArrival.setText(arrivalTime);
     }
   }
 

--- a/android/app/src/main/java/app/organicmaps/routing/RoutingBottomMenuController.java
+++ b/android/app/src/main/java/app/organicmaps/routing/RoutingBottomMenuController.java
@@ -50,6 +50,8 @@ final class RoutingBottomMenuController implements View.OnClickListener
   @NonNull
   private final Activity mContext;
   @NonNull
+  private final View mTimeElevationLine;
+  @NonNull
   private final View mAltitudeChartFrame;
   @NonNull
   private final View mTransitFrame;
@@ -63,6 +65,8 @@ final class RoutingBottomMenuController implements View.OnClickListener
   private final TextView mTime;
   @NonNull
   private final TextView mAltitudeDifference;
+  @NonNull
+  private final TextView mTimeVehicle;
   @Nullable
   private final TextView mArrival;
   @NonNull
@@ -84,17 +88,20 @@ final class RoutingBottomMenuController implements View.OnClickListener
                                                  @Nullable RoutingBottomMenuListener listener)
   {
     View altitudeChartFrame = getViewById(activity, frame, R.id.altitude_chart_panel);
+    View timeEleveationLine = getViewById(activity, frame, R.id.time_elevation_line);
     View transitFrame = getViewById(activity, frame, R.id.transit_panel);
     TextView error = (TextView) getViewById(activity, frame, R.id.error);
     Button start = (Button) getViewById(activity, frame, R.id.start);
     ImageView altitudeChart = (ImageView) getViewById(activity, frame, R.id.altitude_chart);
     TextView time = (TextView) getViewById(activity, frame, R.id.time);
+    TextView timeVehicle = (TextView) getViewById(activity, frame, R.id.time_vehicle);
     TextView altitudeDifference = (TextView) getViewById(activity, frame, R.id.altitude_difference);
     TextView arrival = (TextView) getViewById(activity, frame, R.id.arrival);
     View actionFrame = getViewById(activity, frame, R.id.routing_action_frame);
 
-    return new RoutingBottomMenuController(activity, altitudeChartFrame, transitFrame, error, start, altitudeChart,
-                                           time, altitudeDifference, arrival, actionFrame, listener);
+    return new RoutingBottomMenuController(activity, altitudeChartFrame, timeEleveationLine, transitFrame,
+                                           error, start, altitudeChart, time, altitudeDifference,
+                                           timeVehicle, arrival, actionFrame, listener);
   }
 
   @NonNull
@@ -107,24 +114,28 @@ final class RoutingBottomMenuController implements View.OnClickListener
 
   private RoutingBottomMenuController(@NonNull Activity context,
                                       @NonNull View altitudeChartFrame,
+                                      @NonNull View timeEleveationLine,
                                       @NonNull View transitFrame,
                                       @NonNull TextView error,
                                       @NonNull Button start,
                                       @NonNull ImageView altitudeChart,
                                       @NonNull TextView time,
                                       @NonNull TextView altitudeDifference,
+                                      @NonNull TextView timeVehicle,
                                       @Nullable TextView arrival,
                                       @NonNull View actionFrame,
                                       @Nullable RoutingBottomMenuListener listener)
   {
     mContext = context;
     mAltitudeChartFrame = altitudeChartFrame;
+    mTimeElevationLine = timeEleveationLine;
     mTransitFrame = transitFrame;
     mError = error;
     mStart = start;
     mAltitudeChart = altitudeChart;
     mTime = time;
     mAltitudeDifference = altitudeDifference;
+    mTimeVehicle = timeVehicle;
     mArrival = arrival;
     mActionFrame = actionFrame;
     mActionMessage = actionFrame.findViewById(R.id.tv__message);
@@ -312,9 +323,11 @@ final class RoutingBottomMenuController implements View.OnClickListener
   {
     if (RoutingController.get().isVehicleRouterType())
     {
-      UiUtils.hide(mAltitudeChart, mAltitudeDifference);
+      UiUtils.hide(mTimeElevationLine, mAltitudeChart);
       return;
     }
+
+    UiUtils.hide(mTimeVehicle);
 
     int chartWidth = UiUtils.dimen(mContext, R.dimen.altitude_chart_image_width);
     int chartHeight = UiUtils.dimen(mContext, R.dimen.altitude_chart_image_height);
@@ -337,13 +350,21 @@ final class RoutingBottomMenuController implements View.OnClickListener
     final RoutingInfo rinfo = RoutingController.get().getCachedRoutingInfo();
     if (rinfo == null)
     {
-      UiUtils.hide(mTime);
-      UiUtils.hide(mAltitudeDifference);
+      UiUtils.hide(mTimeElevationLine, mTimeVehicle);
       return;
     }
 
     Spanned spanned = makeSpannedRoutingDetails(mContext, rinfo);
-    mTime.setText(spanned);
+    if (RoutingController.get().isVehicleRouterType())
+    {
+      UiUtils.show(mTimeVehicle);
+      mTimeVehicle.setText(spanned);
+    }
+    else
+    {
+      UiUtils.show(mTimeElevationLine);
+      mTime.setText(spanned);
+    }
 
     if (mArrival != null)
     {

--- a/android/app/src/main/res/layout-land/altitude_chart_panel.xml
+++ b/android/app/src/main/res/layout-land/altitude_chart_panel.xml
@@ -58,7 +58,6 @@
       android:layout_height="wrap_content"
       android:layout_width="match_parent"
       android:layout_weight="1"
-      android:layout_gravity="center_vertical"
       android:maxLines="2"
       android:ellipsize="end"
       tools:text="5 h 55 min • 1555km"

--- a/android/app/src/main/res/layout-land/altitude_chart_panel.xml
+++ b/android/app/src/main/res/layout-land/altitude_chart_panel.xml
@@ -1,26 +1,78 @@
 <?xml version="1.0" encoding="utf-8"?>
 
-<LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
-    xmlns:tools="http://schemas.android.com/tools"
-    android:id="@+id/altitude_chart_panel"
-    android:layout_width="0dp"
-    android:layout_height="wrap_content"
-    android:layout_weight="1"
-    android:layout_marginBottom="@dimen/altitude_chart_margin_bottom"
-    android:layout_marginTop="@dimen/altitude_chart_margin_top"
-    android:paddingStart="@dimen/altitude_chart_container_padding_left"
-    android:paddingEnd="@dimen/altitude_chart_container_padding_left"
-    android:paddingBottom="@dimen/altitude_chart_container_padding_bottom"
-    android:orientation="horizontal"
-    tools:showIn="@layout/fragment_routing">
+<LinearLayout
+  xmlns:android="http://schemas.android.com/apk/res/android"
+  xmlns:tools="http://schemas.android.com/tools"
+  android:id="@+id/altitude_chart_panel"
+  android:layout_width="match_parent"
+  android:layout_height="wrap_content"
+  android:layout_weight="1"
+  android:layout_marginTop="@dimen/margin_half"
+  android:layout_marginBottom="@dimen/margin_half"
+  android:paddingStart="@dimen/altitude_chart_container_padding_left"
+  android:paddingEnd="@dimen/altitude_chart_container_padding_left"
+  android:orientation="horizontal"
+  android:gravity="center_vertical"
+  tools:showIn="@layout/fragment_routing">
 
-    <include layout="@layout/routing_details"
-             android:layout_width="wrap_content"
-             android:layout_height="wrap_content"
-             android:layout_marginEnd="@dimen/margin_base_plus"/>
+    <LinearLayout
+      android:id="@+id/time_elevation_line"
+      android:layout_width="wrap_content"
+      android:layout_height="wrap_content"
+      android:layout_weight="0"
+      android:orientation="vertical"
+      android:layout_marginEnd="@dimen/margin_base"
+      android:layout_gravity="center_vertical" >
+        <TextView
+          android:id="@+id/time"
+          android:layout_width="wrap_content"
+          android:layout_height="wrap_content"
+          android:layout_gravity="center_horizontal"
+          android:maxLines="2"
+          android:ellipsize="end"
+          tools:text="5 h 55 min • 1555km"
+          tools:visibility="visible" />
+
+        <TextView
+          android:id="@+id/altitude_difference"
+          android:layout_width="wrap_content"
+          android:layout_height="wrap_content"
+          android:layout_gravity="center_horizontal"
+          android:textAppearance="@style/MwmTextAppearance.Body3"
+          android:fontFamily="@string/robotoMedium"
+          android:textColor="?colorAccent"
+          android:gravity="center"
+          tools:text="↗ 43 m ↘ 88 m"
+          tools:visibility="visible" />
+    </LinearLayout>
 
     <ImageView
-        android:id="@+id/altitude_chart"
-        android:layout_width="match_parent"
-        android:layout_height="match_parent"/>
+      android:id="@+id/altitude_chart"
+      android:layout_height="wrap_content"
+      android:layout_width="match_parent"
+      android:layout_weight="1"
+      android:layout_gravity="center_vertical" />
+
+    <TextView
+      android:id="@+id/time_vehicle"
+      android:layout_height="wrap_content"
+      android:layout_width="match_parent"
+      android:layout_weight="1"
+      android:layout_gravity="center_vertical"
+      android:maxLines="2"
+      android:ellipsize="end"
+      tools:text="5 h 55 min • 1555km"
+      tools:visibility="visible" />
+
+    <Button
+      android:id="@+id/start"
+      style="@style/MwmWidget.Button.Primary"
+      android:layout_width="wrap_content"
+      android:layout_height="wrap_content"
+      android:layout_weight="0"
+      android:layout_gravity="center_vertical"
+      android:layout_marginStart="@dimen/margin_base"
+      android:minWidth="@dimen/start_button_width"
+      android:text="@string/p2p_start"
+      tools:showIn="@layout/menu_route_plan_line" />
 </LinearLayout>

--- a/android/app/src/main/res/layout-w1020dp-land/altitude_chart_panel.xml
+++ b/android/app/src/main/res/layout-w1020dp-land/altitude_chart_panel.xml
@@ -1,23 +1,96 @@
 <?xml version="1.0" encoding="utf-8"?>
 
-<LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
-    xmlns:tools="http://schemas.android.com/tools"
-    android:id="@+id/altitude_chart_panel"
-    android:layout_width="0dp"
-    android:layout_height="wrap_content"
-    android:layout_weight="1"
-    android:layout_marginBottom="@dimen/altitude_chart_margin_bottom"
-    android:layout_marginTop="@dimen/altitude_chart_margin_top"
-    android:paddingStart="@dimen/altitude_chart_container_padding_left"
-    android:paddingEnd="@dimen/altitude_chart_container_padding_left"
-    android:orientation="vertical"
-    tools:showIn="@layout/fragment_routing">
+<LinearLayout
+  xmlns:android="http://schemas.android.com/apk/res/android"
+  xmlns:tools="http://schemas.android.com/tools"
+  android:id="@+id/altitude_chart_panel"
+  android:layout_width="match_parent"
+  android:layout_height="wrap_content"
+  android:layout_weight="1"
+  android:layout_marginTop="@dimen/margin_half"
+  android:layout_marginBottom="@dimen/margin_half"
+  android:paddingStart="@dimen/altitude_chart_container_padding_left"
+  android:paddingEnd="@dimen/altitude_chart_container_padding_left"
+  android:orientation="horizontal"
+  android:gravity="center_vertical"
+  tools:showIn="@layout/fragment_routing">
 
-    <include layout="@layout/routing_details"/>
+    <LinearLayout
+      android:id="@+id/time_elevation_line"
+      android:layout_width="wrap_content"
+      android:layout_height="wrap_content"
+      android:layout_weight="0"
+      android:orientation="vertical"
+      android:layout_marginEnd="@dimen/margin_base"
+      android:layout_gravity="center_vertical" >
+        <TextView
+          android:id="@+id/time"
+          android:layout_width="wrap_content"
+          android:layout_height="wrap_content"
+          android:layout_gravity="center_horizontal"
+          android:maxLines="2"
+          android:ellipsize="end"
+          tools:text="5 h 55 min • 1555km"
+          tools:visibility="visible" />
+
+        <TextView
+          android:id="@+id/altitude_difference"
+          android:layout_width="wrap_content"
+          android:layout_height="wrap_content"
+          android:layout_gravity="center_horizontal"
+          android:textAppearance="@style/MwmTextAppearance.Body3"
+          android:fontFamily="@string/robotoMedium"
+          android:textColor="?colorAccent"
+          android:gravity="center"
+          tools:text="↗ 43 m ↘ 88 m"
+          tools:visibility="visible" />
+    </LinearLayout>
+
+    <LinearLayout
+      android:id="@+id/time_vehicle_arrival_frame"
+      android:layout_width="0dp"
+      android:layout_height="wrap_content"
+      android:layout_weight="1"
+      android:orientation="vertical"
+      android:layout_marginEnd="@dimen/margin_base"
+      android:layout_gravity="top" >
+
+        <TextView
+          android:id="@+id/time_vehicle"
+          android:layout_height="wrap_content"
+          android:layout_width="match_parent"
+          android:maxLines="2"
+          android:ellipsize="end"
+          tools:text="5 h 55 min • 1555km"
+          tools:visibility="visible" />
+
+        <TextView
+          android:id="@+id/arrival"
+          android:layout_width="match_parent"
+          android:layout_height="wrap_content"
+          android:layout_gravity="start"
+          android:layout_marginBottom="10dp"
+          tools:text="Arrival 13:03"
+          style="@style/MwmWidget.TextView.PlanDetail.Number.Secondary"
+          android:textSize="@dimen/text_size_routing_plan_detail_arrival"/>
+    </LinearLayout>
 
     <ImageView
-        android:id="@+id/altitude_chart"
-        android:layout_width="@dimen/altitude_chart_image_width"
-        android:layout_height="@dimen/altitude_chart_image_height"
-        android:layout_marginBottom="8dp"/>
+      android:id="@+id/altitude_chart"
+      android:layout_width="0dp"
+      android:layout_height="wrap_content"
+      android:layout_weight="10"
+      android:layout_gravity="center_vertical" />
+
+    <Button
+      android:id="@+id/start"
+      style="@style/MwmWidget.Button.Primary"
+      android:layout_width="wrap_content"
+      android:layout_height="wrap_content"
+      android:layout_weight="0"
+      android:layout_gravity="center_vertical"
+      android:layout_marginStart="@dimen/margin_base"
+      android:minWidth="@dimen/start_button_width"
+      android:text="@string/p2p_start"
+      tools:showIn="@layout/menu_route_plan_line" />
 </LinearLayout>

--- a/android/app/src/main/res/layout/altitude_chart_panel.xml
+++ b/android/app/src/main/res/layout/altitude_chart_panel.xml
@@ -1,71 +1,85 @@
 <?xml version="1.0" encoding="utf-8"?>
 
-<RelativeLayout
+<LinearLayout
     xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:tools="http://schemas.android.com/tools"
     android:id="@+id/altitude_chart_panel"
     android:layout_width="match_parent"
     android:layout_height="wrap_content"
     android:layout_weight="1"
-    android:layout_marginBottom="@dimen/altitude_chart_margin_bottom"
-    android:layout_marginTop="@dimen/altitude_chart_margin_top"
+    android:layout_marginBottom="@dimen/margin_half"
+    android:layout_marginTop="@dimen/margin_half"
     android:paddingStart="@dimen/altitude_chart_container_padding_left"
     android:paddingEnd="@dimen/altitude_chart_container_padding_left"
+    android:orientation="vertical"
     tools:showIn="@layout/fragment_routing">
 
-    <TextView
-      android:id="@+id/time"
-      android:layout_width="wrap_content"
-      android:layout_marginBottom="@dimen/margin_half"
-      android:layout_marginEnd="@dimen/margin_half"
-      android:maxLines="2"
-      android:ellipsize="end"
-      android:layout_alignParentStart="true"
-      android:orientation="horizontal"
-      android:layout_toStartOf="@id/altitude_difference"
-      android:layout_height="wrap_content"
-      tools:text="5 h 55 min • 1555km"
-      tools:visibility="visible" />
-
-    <TextView
-      android:id="@+id/altitude_difference"
-      android:layout_width="wrap_content"
-      android:layout_height="@dimen/altitude_chart_time_distance_height"
-      android:layout_marginBottom="@dimen/margin_half"
-      android:layout_marginStart="@dimen/margin_half"
-      android:textAppearance="@style/MwmTextAppearance.Body3"
-      android:fontFamily="@string/robotoMedium"
-      android:textColor="?colorAccent"
-      android:layout_gravity="end"
-      android:gravity="center"
-      android:layout_alignParentEnd="true"
-      android:visibility="gone"
-      tools:text="43 m"
-      tools:visibility="visible" />
-
-    <ImageView
-      android:id="@+id/altitude_chart"
-      android:layout_alignParentStart="true"
-      android:layout_below="@id/time"
-      android:layout_toStartOf="@id/start"
-      android:layout_height="wrap_content"
+    <LinearLayout
+      android:id="@+id/time_elevation_line"
       android:layout_width="match_parent"
-      android:layout_marginTop="@dimen/margin_half"
-      android:layout_marginBottom="@dimen/margin_half"
-      android:layout_marginEnd="@dimen/margin_half" />
-
-    <Button
-      android:id="@+id/start"
-      style="@style/MwmWidget.Button.Primary"
-      android:layout_width="wrap_content"
       android:layout_height="wrap_content"
-      android:minWidth="@dimen/start_button_width"
-      android:layout_marginStart="@dimen/margin_half"
+      android:orientation="horizontal"
       android:layout_marginTop="@dimen/margin_half"
-      android:text="@string/p2p_start"
-      tools:showIn="@layout/menu_route_plan_line"
-      android:layout_gravity="center_vertical"
-      android:layout_below="@id/altitude_difference"
-      android:layout_alignParentEnd="true"
-      android:layout_centerVertical="true" />
-</RelativeLayout>
+      android:layout_marginBottom="@dimen/margin_half">
+        <TextView
+          android:id="@+id/time"
+          android:layout_width="0dp"
+          android:layout_height="wrap_content"
+          android:layout_weight="1"
+          android:maxLines="2"
+          android:ellipsize="end"
+          tools:text="5 h 55 min • 1555km"
+          tools:visibility="visible" />
+
+        <TextView
+          android:id="@+id/altitude_difference"
+          android:layout_width="wrap_content"
+          android:layout_height="@dimen/altitude_chart_time_distance_height"
+          android:textAppearance="@style/MwmTextAppearance.Body3"
+          android:fontFamily="@string/robotoMedium"
+          android:textColor="?colorAccent"
+          android:layout_gravity="end"
+          android:gravity="center"
+          android:visibility="gone"
+          tools:text="↗ 43 m ↘ 88 m"
+          tools:visibility="visible" />
+    </LinearLayout>
+
+    <LinearLayout
+      android:layout_width="match_parent"
+      android:layout_height="wrap_content"
+      android:orientation="horizontal"
+      android:gravity="center_vertical" >
+
+        <LinearLayout
+          android:layout_width="match_parent"
+          android:layout_height="wrap_content"
+          android:orientation="vertical"
+          android:layout_weight="1">
+            <ImageView
+              android:id="@+id/altitude_chart"
+              android:layout_height="wrap_content"
+              android:layout_width="match_parent" />
+            <TextView
+              android:id="@+id/time_vehicle"
+              android:layout_height="wrap_content"
+              android:layout_width="match_parent"
+              android:maxLines="2"
+              android:ellipsize="end"
+              tools:text="5 h 55 min • 1555km"
+              tools:visibility="visible" />
+        </LinearLayout>
+
+        <Button
+          android:id="@+id/start"
+          style="@style/MwmWidget.Button.Primary"
+          android:layout_width="wrap_content"
+          android:layout_height="wrap_content"
+          android:layout_weight="0"
+          android:layout_marginStart="@dimen/margin_half"
+          android:minWidth="@dimen/start_button_width"
+          android:text="@string/p2p_start"
+          tools:showIn="@layout/menu_route_plan_line"
+          android:layout_gravity="center_vertical" />
+    </LinearLayout>
+</LinearLayout>

--- a/android/app/src/main/res/layout/altitude_chart_panel.xml
+++ b/android/app/src/main/res/layout/altitude_chart_panel.xml
@@ -1,23 +1,71 @@
 <?xml version="1.0" encoding="utf-8"?>
 
-<LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
+<RelativeLayout
+    xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:tools="http://schemas.android.com/tools"
     android:id="@+id/altitude_chart_panel"
-    android:layout_width="0dp"
+    android:layout_width="match_parent"
     android:layout_height="wrap_content"
     android:layout_weight="1"
     android:layout_marginBottom="@dimen/altitude_chart_margin_bottom"
     android:layout_marginTop="@dimen/altitude_chart_margin_top"
     android:paddingStart="@dimen/altitude_chart_container_padding_left"
     android:paddingEnd="@dimen/altitude_chart_container_padding_left"
-    android:orientation="vertical"
     tools:showIn="@layout/fragment_routing">
 
-    <include layout="@layout/routing_details"/>
+    <TextView
+      android:id="@+id/time"
+      android:layout_width="wrap_content"
+      android:layout_marginBottom="@dimen/margin_half"
+      android:layout_marginEnd="@dimen/margin_half"
+      android:maxLines="2"
+      android:ellipsize="end"
+      android:layout_alignParentStart="true"
+      android:orientation="horizontal"
+      android:layout_toStartOf="@id/altitude_difference"
+      android:layout_height="wrap_content"
+      tools:text="5 h 55 min • 1555km"
+      tools:visibility="visible" />
+
+    <TextView
+      android:id="@+id/altitude_difference"
+      android:layout_width="wrap_content"
+      android:layout_height="@dimen/altitude_chart_time_distance_height"
+      android:layout_marginBottom="@dimen/margin_half"
+      android:layout_marginStart="@dimen/margin_half"
+      android:textAppearance="@style/MwmTextAppearance.Body3"
+      android:fontFamily="@string/robotoMedium"
+      android:textColor="?colorAccent"
+      android:layout_gravity="end"
+      android:gravity="center"
+      android:layout_alignParentEnd="true"
+      android:visibility="gone"
+      tools:text="43 m"
+      tools:visibility="visible" />
 
     <ImageView
-        android:id="@+id/altitude_chart"
-        android:layout_width="match_parent"
-        android:layout_height="match_parent"
-        android:layout_marginBottom="@dimen/margin_half"/>
-</LinearLayout>
+      android:id="@+id/altitude_chart"
+      android:layout_alignParentStart="true"
+      android:layout_below="@id/time"
+      android:layout_toStartOf="@id/start"
+      android:layout_height="wrap_content"
+      android:layout_width="match_parent"
+      android:layout_marginTop="@dimen/margin_half"
+      android:layout_marginBottom="@dimen/margin_half"
+      android:layout_marginEnd="@dimen/margin_half" />
+
+    <Button
+      android:id="@+id/start"
+      style="@style/MwmWidget.Button.Primary"
+      android:layout_width="wrap_content"
+      android:layout_height="wrap_content"
+      android:minWidth="@dimen/start_button_width"
+      android:layout_marginStart="@dimen/margin_half"
+      android:layout_marginTop="@dimen/margin_half"
+      android:text="@string/p2p_start"
+      tools:showIn="@layout/menu_route_plan_line"
+      android:layout_gravity="center_vertical"
+      android:layout_below="@id/altitude_difference"
+      android:layout_alignParentEnd="true"
+      android:layout_centerVertical="true" />
+</RelativeLayout>

--- a/android/app/src/main/res/layout/menu_route_plan_line.xml
+++ b/android/app/src/main/res/layout/menu_route_plan_line.xml
@@ -7,17 +7,9 @@
     android:layout_width="match_parent"
     android:layout_height="wrap_content">
 
-  <include layout="@layout/altitude_chart_panel"
-           tools:visibility="visible"/>
+  <include layout="@layout/altitude_chart_panel" />
 
   <include layout="@layout/routing_bottom_panel_transit"/>
-
-  <include
-    android:layout_width="wrap_content"
-    android:layout_height="wrap_content"
-    android:layout_marginEnd="@dimen/margin_base"
-    android:layout_gravity="center_vertical"
-    layout="@layout/start_button"/>
 
   <TextView
     android:id="@+id/error"


### PR DESCRIPTION
Closes #3320.

There are 6 dirrefent layouts:
* Pedestrian/Bycicle route Portrait
* Pedestrian/Bycicle route Landscape
* Vehicle route Portrait
* Vehicle route Landscape
* Pedestrian route Tablet
* Vehicle route Tablet

## Pedestrian route Portrait
<img alt="cmp-ped-portrait" src="https://github.com/organicmaps/organicmaps/assets/720808/21c885dc-ebea-48c4-b13b-a81a46600c32" width="300px"/>

## Pedestrian route Landscape
<img alt="cmp-ped-land" src="https://github.com/organicmaps/organicmaps/assets/720808/15c56d09-61c7-4778-bb01-c2b279b6e99c" width="300px" />

## Vehicle route Portrait (No changes)
<img alt="cmp-vh-portrait" src="https://github.com/organicmaps/organicmaps/assets/720808/338a7010-2a34-4c28-af3c-8f90b67abce1" width="300px" />

## Vehicle route Landscape (No changes)
<img alt="cmp-vh-land" src="https://github.com/organicmaps/organicmaps/assets/720808/80bebfd7-ca50-4b74-bf82-4efa07a5bc19" width="300px" />

## Pedestrian route Tablet
<img alt="cmp-tablet-pedestrian" src="https://github.com/organicmaps/organicmaps/assets/720808/ca2e0cac-9e08-4a26-bc17-f7a0dea11f49" width="500px" />


## Vehicle route Tablet
<img alt="cmp-tablet-vh" src="https://github.com/organicmaps/organicmaps/assets/720808/b4fab3e8-0bc3-4d2a-a3c9-e20a06a5ca7d" width="500px" />


# Implementation details
Portrait layout was implemented using simple vertical/horizontal layouts:

<img alt="new-both-portrait" src="https://github.com/organicmaps/organicmaps/assets/720808/d389dff8-8c79-4633-9c86-2cd45e8c34de" width="500px" />

To switch Pedestrian-Vehicle mode we hide some elements:

<img alt="new-schema-portrait" src="https://github.com/organicmaps/organicmaps/assets/720808/3a6db2f1-4dae-4f36-8281-da0960ad7ffc" width="500px" />

Landscape layout was implemented using simple vertical/horizontal layouts:
<img alt="new-both-land" src="https://github.com/organicmaps/organicmaps/assets/720808/60f8885c-1587-43f6-ba77-69152e3343d9" width="500px" />

To switch Pedestrian-Vehicle mode we hide some elements:
<img alt="new-schema-land" src="https://github.com/organicmaps/organicmaps/assets/720808/7ee3f04e-e5a3-4ab4-b9b8-16e4f950914d" width="500px" />


## XML Layouts changes
Instead of multiple files `routing_details.xml`, `start_button.xml`, and `altitude_chart_panel.xml` all layout is located in `altitude_chart_panel.xml`.
But we have `RoutingPlanFragment` class which uses `fragment_routing.xml` and `start_button.xml`. This `RoutingPlanFragment` is never used because we have flag `tabletLayout=false`.

Should we delete `RoutingPlanFragment` and all dependants?
