### PR TITLE
[drape] minVisibleScale-related cleanup and optimization

### DIFF
--- a/drape/overlay_handle.cpp
+++ b/drape/overlay_handle.cpp
@@ -228,26 +228,19 @@ std::string SquareHandle::GetOverlayDebugInfo()
 }
 #endif
 
-/// @param[in] minZoomLevel Minimum visible zoom level (less is better)
 /// @param[in] rank         Rank of the feature (bigger is better)
 /// @param[in] depth        Manual priority from styles (bigger is better)
-/// @todo remove minZoomLevel param from everywhere, its not used anymore.
-uint64_t CalculateOverlayPriority(int minZoomLevel, uint8_t rank, float depth)
+uint64_t CalculateOverlayPriority(uint8_t rank, float depth)
 {
   // Negative range is used for optional captions which are below all other overlays.
   ASSERT(-drule::kOverlaysMaxPriority <= depth && depth < drule::kOverlaysMaxPriority, (depth));
   depth += drule::kOverlaysMaxPriority;
 
-  // Even if minZoomLevel < 0 (-1 is not visible), we will get more consistent |minZoom| value (less is worse).
-  ASSERT_GREATER_OR_EQUAL(minZoomLevel, 0, ());
-  uint8_t const minZoom = 0xFF - static_cast<uint8_t>(minZoomLevel);
-
   // Pack into uint64_t priority value (bigger is better).
-  // [1 byte - zoom][4 bytes - priority][1 byte - rank][2 bytes - 0xFFFF].
-  return (static_cast<uint64_t>(minZoom) << 56) |
-         (static_cast<uint64_t>(depth) << 24) |
+  // [1 byte - 0xFF][4 bytes - priority][1 byte - rank][2 bytes - 0xFFFF].
+  return (static_cast<uint64_t>(depth) << 24) |
          (static_cast<uint64_t>(rank) << 16) |
-         static_cast<uint64_t>(0xFFFF);
+         dp::kPriorityMaskZoomLevel;
 }
 
 uint64_t CalculateSpecialModePriority(uint16_t specialPriority)

--- a/drape/overlay_handle.cpp
+++ b/drape/overlay_handle.cpp
@@ -219,11 +219,8 @@ bool SquareHandle::IsBound() const { return m_isBound; }
 std::string SquareHandle::GetOverlayDebugInfo()
 {
   std::ostringstream out;
-  out << "POI Priority(" << std::hex << std::setw(16) << std::setfill('0') << GetPriority();
-  auto const mask = GetPriorityMask();
-  if (mask != dp::kPriorityMaskAll)
-    out << " mask " << std::setw(16) << mask;
-  out << ") " << std::dec << DebugPrint(GetOverlayID());
+  out << "POI Priority(" << std::hex << std::setw(16) << std::setfill('0') << GetPriority()
+      << ") " << std::dec << DebugPrint(GetOverlayID());
   return out.str();
 }
 #endif

--- a/drape/overlay_handle.hpp
+++ b/drape/overlay_handle.hpp
@@ -35,11 +35,8 @@ enum OverlayRank : uint8_t
 };
 
 uint64_t constexpr kPriorityMaskZoomLevel = 0xFF0000000000FFFF;
-uint64_t constexpr kPriorityMaskManual    = 0x00FFFFFFFF00FFFF;
-uint64_t constexpr kPriorityMaskRank      = 0x0000000000FFFFFF;
-uint64_t constexpr kPriorityMaskAll = kPriorityMaskZoomLevel |
-                                      kPriorityMaskManual |
-                                      kPriorityMaskRank;
+uint64_t constexpr kPriorityMaskAll = std::numeric_limits<uint64_t>::max();
+
 struct OverlayID
 {
   FeatureID m_featureId;
@@ -146,8 +143,6 @@ public:
 
   OverlayID const & GetOverlayID() const { return m_id; }
   uint64_t const & GetPriority() const { return m_priority; }
-
-  virtual uint64_t GetPriorityMask() const { return kPriorityMaskAll; }
 
   virtual bool IsBound() const { return false; }
   virtual bool HasLinearFeatureShape() const { return false; }

--- a/drape/overlay_handle.hpp
+++ b/drape/overlay_handle.hpp
@@ -265,7 +265,7 @@ private:
   bool m_isBound;
 };
 
-uint64_t CalculateOverlayPriority(int minZoomLevel, uint8_t rank, float depth);
+uint64_t CalculateOverlayPriority(uint8_t rank, float depth);
 uint64_t CalculateSpecialModePriority(uint16_t specialPriority);
 uint64_t CalculateSpecialModeUserMarkPriority(uint16_t specialPriority);
 uint64_t CalculateUserMarkPriority(int minZoomLevel, uint16_t specialPriority);

--- a/drape/overlay_tree.cpp
+++ b/drape/overlay_tree.cpp
@@ -39,10 +39,8 @@ public:
 
     if (displayFlagLeft == displayFlagRight)
     {
-      uint64_t const mask = m_enableMask ? l->GetPriorityMask() & r->GetPriorityMask() :
-                            dp::kPriorityMaskAll;
-      uint64_t const priorityLeft = l->GetPriority() & mask;
-      uint64_t const priorityRight = r->GetPriority() & mask;
+      uint64_t const priorityLeft = l->GetPriority();
+      uint64_t const priorityRight = r->GetPriority();
       if (priorityLeft > priorityRight)
         return true;
 
@@ -67,14 +65,8 @@ public:
     bool const displayFlagRight = ((!m_enableMask || r->IsSpecialLayerOverlay()) ? true : r->GetDisplayFlag());
 
     if (displayFlagLeft == displayFlagRight)
-    {
-      uint64_t const mask = m_enableMask ? l->GetPriorityMask() & r->GetPriorityMask() :
-                            dp::kPriorityMaskAll;
-      uint64_t const priorityLeft = l->GetPriority() & mask;
-      uint64_t const priorityRight = r->GetPriority() & mask;
+      return l->GetPriority() == r->GetPriority();
 
-      return priorityLeft == priorityRight;
-    }
     return false;
   }
 

--- a/drape_frontend/apply_feature_functors.hpp
+++ b/drape_frontend/apply_feature_functors.hpp
@@ -37,8 +37,7 @@ class BaseApplyFeature
 {
 public:
   BaseApplyFeature(TileKey const & tileKey, TInsertShapeFn const & insertShape,
-                   FeatureID const & id, int minVisibleScale, uint8_t rank,
-                   CaptionDescription const & captions);
+                   FeatureID const & id, uint8_t rank, CaptionDescription const & captions);
 
   virtual ~BaseApplyFeature() = default;
 
@@ -51,7 +50,6 @@ protected:
   TInsertShapeFn m_insertShape;
   FeatureID m_id;
   CaptionDescription const & m_captions;
-  int m_minVisibleScale;
   uint8_t m_rank;
 
   TileKey const m_tileKey;
@@ -64,9 +62,8 @@ class ApplyPointFeature : public BaseApplyFeature
 
 public:
   ApplyPointFeature(TileKey const & tileKey, TInsertShapeFn const & insertShape,
-                    FeatureID const & id, int minVisibleScale, uint8_t rank,
-                    CaptionDescription const & captions, float posZ,
-                    DepthLayer depthLayer);
+                    FeatureID const & id, uint8_t rank, CaptionDescription const & captions,
+                    float posZ, DepthLayer depthLayer);
 
   void operator()(m2::PointD const & point, bool hasArea);
   void ProcessPointRule(Stylist::TRuleWrapper const & rule);
@@ -94,7 +91,7 @@ class ApplyAreaFeature : public ApplyPointFeature
 public:
   ApplyAreaFeature(TileKey const & tileKey, TInsertShapeFn const & insertShape,
                    FeatureID const & id, double currentScaleGtoP, bool isBuilding,
-                   bool skipAreaGeometry, float minPosZ, float posZ, int minVisibleScale,
+                   bool skipAreaGeometry, float minPosZ, float posZ,
                    uint8_t rank, CaptionDescription const & captions);
 
   using TBase::operator ();
@@ -155,7 +152,7 @@ class ApplyLineFeatureGeometry : public BaseApplyFeature
 
 public:
   ApplyLineFeatureGeometry(TileKey const & tileKey, TInsertShapeFn const & insertShape,
-                           FeatureID const & id, double currentScaleGtoP, int minVisibleScale,
+                           FeatureID const & id, double currentScaleGtoP,
                            uint8_t rank, size_t pointsCount, bool smooth);
 
   void operator() (m2::PointD const & point);
@@ -186,7 +183,7 @@ class ApplyLineFeatureAdditional : public BaseApplyFeature
 
 public:
   ApplyLineFeatureAdditional(TileKey const & tileKey, TInsertShapeFn const & insertShape,
-                             FeatureID const & id, double currentScaleGtoP, int minVisibleScale,
+                             FeatureID const & id, double currentScaleGtoP,
                              uint8_t rank, CaptionDescription const & captions,
                              std::vector<m2::SharedSpline> const & clippedSplines);
 

--- a/drape_frontend/colored_symbol_shape.cpp
+++ b/drape_frontend/colored_symbol_shape.cpp
@@ -321,6 +321,6 @@ uint64_t ColoredSymbolShape::GetOverlayPriority() const
   if (m_params.m_specialDisplacement == SpecialDisplacement::UserMark)
     return dp::CalculateUserMarkPriority(m_params.m_minVisibleScale, m_params.m_specialPriority);
 
-  return dp::CalculateOverlayPriority(m_params.m_minVisibleScale, m_params.m_rank, m_params.m_depth);
+  return dp::CalculateOverlayPriority(m_params.m_rank, m_params.m_depth);
 }
 }  // namespace df

--- a/drape_frontend/frontend_renderer.hpp
+++ b/drape_frontend/frontend_renderer.hpp
@@ -68,6 +68,12 @@ struct TapInfo
   static m2::AnyRectD GetPreciseTapRect(m2::PointD const & mercator, double eps);
 };
 
+/*
+ * A FrontendRenderer holds several RenderLayers, one per each df::DepthLayer,
+ * a rendering order of the layers is set in RenderScene().
+ * Each RenderLayer contains several RenderGroups, one per each tile and RenderState.
+ * Each RenderGroup contains several RenderBuckets holding VertexArrayBuffers and optional OverlayHandles.
+ */
 class FrontendRenderer : public BaseRenderer,
                          public MyPositionController::Listener,
                          public UserEventStream::Listener

--- a/drape_frontend/path_text_shape.cpp
+++ b/drape_frontend/path_text_shape.cpp
@@ -63,8 +63,7 @@ uint64_t PathTextShape::GetOverlayPriority(uint32_t textIndex, size_t textLength
     return dp::CalculateSpecialModePriority(m_params.m_specialPriority);
 
   static uint64_t constexpr kMask = ~static_cast<uint64_t>(0xFFFF);
-  uint64_t priority = dp::CalculateOverlayPriority(m_params.m_minVisibleScale, m_params.m_rank,
-                                                   m_params.m_depth);
+  uint64_t priority = dp::CalculateOverlayPriority(m_params.m_rank, m_params.m_depth);
   priority &= kMask;
   priority |= (static_cast<uint8_t>(textLength) << 8);
   priority |= static_cast<uint8_t>(textIndex);

--- a/drape_frontend/poi_symbol_shape.cpp
+++ b/drape_frontend/poi_symbol_shape.cpp
@@ -235,6 +235,6 @@ uint64_t PoiSymbolShape::GetOverlayPriority() const
   if (m_params.m_specialDisplacement == SpecialDisplacement::UserMark)
     return dp::CalculateUserMarkPriority(m_params.m_minVisibleScale, m_params.m_specialPriority);
 
-  return dp::CalculateOverlayPriority(m_params.m_minVisibleScale, m_params.m_rank, m_params.m_depth);
+  return dp::CalculateOverlayPriority(m_params.m_rank, m_params.m_depth);
 }
 }  // namespace df

--- a/drape_frontend/render_group.cpp
+++ b/drape_frontend/render_group.cpp
@@ -150,7 +150,7 @@ bool RenderGroup::UpdateCanBeDeletedStatus(bool canBeDeleted, int currentZoom, r
 
   for (size_t i = 0; i < m_renderBuckets.size(); )
   {
-    bool visibleBucket = !canBeDeleted && (m_renderBuckets[i]->GetMinZoom() <= currentZoom);
+    bool const visibleBucket = !canBeDeleted && (m_renderBuckets[i]->GetMinZoom() <= currentZoom);
     if (!visibleBucket)
     {
       m_renderBuckets[i]->RemoveOverlayHandles(tree);

--- a/drape_frontend/rule_drawer.hpp
+++ b/drape_frontend/rule_drawer.hpp
@@ -47,12 +47,9 @@ public:
 #endif
 
 private:
-  void ProcessAreaStyle(FeatureType & f, Stylist const & s, TInsertShapeFn const & insertShape,
-                        int & minVisibleScale);
-  void ProcessLineStyle(FeatureType & f, Stylist const & s, TInsertShapeFn const & insertShape,
-                        int & minVisibleScale);
-  void ProcessPointStyle(FeatureType & f, Stylist const & s, TInsertShapeFn const & insertShape,
-                         int & minVisibleScale);
+  void ProcessAreaStyle(FeatureType & f, Stylist const & s, TInsertShapeFn const & insertShape);
+  void ProcessLineStyle(FeatureType & f, Stylist const & s, TInsertShapeFn const & insertShape);
+  void ProcessPointStyle(FeatureType & f, Stylist const & s, TInsertShapeFn const & insertShape);
 
   bool CheckCoastlines(FeatureType & f, Stylist const & s);
 

--- a/drape_frontend/stylist.cpp
+++ b/drape_frontend/stylist.cpp
@@ -365,18 +365,16 @@ bool InitStylist(FeatureType & f, int8_t deviceLang, int const zoomLevel, bool b
     mainOverlayType = *types.cbegin();
   else
   {
-    // Determine main overlays type by priority.
-    // @todo: adjust/optimize depending on the final priorities setup in #4314
-    int overlayMaxPriority = std::numeric_limits<int>::min();
+    // Determine main overlays type by priority. Priorities might be different across zoom levels
+    // so a max value across all zooms is used to make sure main type doesn't change.
+    int overlaysMaxPriority = std::numeric_limits<int>::min();
     for (uint32_t t : types)
     {
-      for (auto const & k : cl.GetObject(t)->GetDrawRules())
+      int const priority = cl.GetObject(t)->GetMaxOverlaysPriority();
+      if (priority > overlaysMaxPriority)
       {
-        if (k.m_priority > overlayMaxPriority && IsTypeOf(k, Caption | Symbol | Shield | PathText))
-        {
-          overlayMaxPriority = k.m_priority;
-          mainOverlayType = t;
-        }
+        overlaysMaxPriority = priority;
+        mainOverlayType = t;
       }
     }
   }

--- a/drape_frontend/text_handle.cpp
+++ b/drape_frontend/text_handle.cpp
@@ -86,11 +86,8 @@ void TextHandle::SetForceUpdateNormals(bool forceUpdate) const
 std::string TextHandle::GetOverlayDebugInfo()
 {
   std::ostringstream out;
-  out << "Text Priority(" << std::hex << std::setw(16) << std::setfill('0') << GetPriority();
-  auto const mask = GetPriorityMask();
-  if (mask != dp::kPriorityMaskAll)
-    out << " mask " << std::setw(16) << mask;
-  out << ") " << std::dec << DebugPrint(GetOverlayID()) << " " << strings::ToUtf8(m_text);
+  out << "Text Priority(" << std::hex << std::setw(16) << std::setfill('0') << GetPriority()
+      << ") " << std::dec << DebugPrint(GetOverlayID()) << " " << strings::ToUtf8(m_text);
   return out.str();
 }
 #endif

--- a/drape_frontend/text_shape.cpp
+++ b/drape_frontend/text_shape.cpp
@@ -453,7 +453,7 @@ uint64_t TextShape::GetOverlayPriority() const
   // (the more text length, the more priority) and index of text.
   // [6 bytes - standard overlay priority][1 byte - length][1 byte - text index].
   static uint64_t constexpr kMask = ~static_cast<uint64_t>(0xFFFF);
-  uint64_t priority = dp::CalculateOverlayPriority(m_params.m_minVisibleScale, m_params.m_rank, m_params.m_depth);
+  uint64_t priority = dp::CalculateOverlayPriority(m_params.m_rank, m_params.m_depth);
   priority &= kMask;
   priority |= (static_cast<uint8_t>(m_params.m_titleDecl.m_primaryText.size()) << 8);
   priority |= static_cast<uint8_t>(m_textIndex);

--- a/indexer/classificator.cpp
+++ b/indexer/classificator.cpp
@@ -54,6 +54,11 @@ void ClassifObject::AddDrawRule(drule::Key const & k)
     if (k == *i)
       return; // already exists
   m_drawRules.insert(i, k);
+
+  if (k.m_priority > m_maxOverlaysPriority &&
+      (k.m_type == drule::symbol || k.m_type == drule::caption ||
+       k.m_type == drule::shield || k.m_type == drule::pathtext))
+    m_maxOverlaysPriority = k.m_priority;
 }
 
 ClassifObjectPtr ClassifObject::BinaryFind(std::string_view const s) const

--- a/indexer/classificator.hpp
+++ b/indexer/classificator.hpp
@@ -90,6 +90,9 @@ public:
   std::vector<drule::Key> const & GetDrawRules() const { return m_drawRules; }
   void GetSuitable(int scale, feature::GeomType gt, drule::KeysT & keys) const;
 
+  // Returns std::numeric_limits<int>::min() if there are no overlay drules.
+  int GetMaxOverlaysPriority() const { return m_maxOverlaysPriority; }
+
   bool IsDrawable(int scale) const;
   bool IsDrawableAny() const;
   bool IsDrawableLike(feature::GeomType gt, bool emptyName = false) const;
@@ -161,6 +164,8 @@ private:
   std::vector<drule::Key> m_drawRules;
   std::vector<ClassifObject> m_objs;
   VisibleMask m_visibility;
+
+  int m_maxOverlaysPriority = std::numeric_limits<int>::min();
 };
 
 inline void swap(ClassifObject & r1, ClassifObject & r2)


### PR DESCRIPTION
1. Removed minVisibleScale param passing which is not used anymore (after #4645).
2. Removed overlays masks handling which is not used anymore (after 3e3d2d36a483beac319a2028fa5cbda79d672bb2).
3. Optimize determining of main overlays type by storing maxOverlaysPriority once per classificator type instead of doing it for every multi-type feature.

4. Try to re-enable some discard render bucket optimization. More on this later.
Upd: moved it from this PR to https://github.com/organicmaps/organicmaps/pull/5921
