### PR TITLE
[linux] Use OpenGL ES 3.0 instead of desktop OpenGL

### DIFF
--- a/drape/gl_functions.cpp
+++ b/drape/gl_functions.cpp
@@ -550,7 +550,7 @@ void GLFunctions::glDisable(glConst mode)
 void GLFunctions::glClearDepthValue(double depth)
 {
   ASSERT_NOT_EQUAL(CurrentApiVersion, dp::ApiVersion::Invalid, ());
-#if defined(OMIM_OS_IPHONE) || defined(OMIM_OS_ANDROID)
+#if defined(OMIM_OS_IPHONE) || defined(OMIM_OS_ANDROID) || defined(OMIM_OS_LINUX)
   GLCHECK(::glClearDepthf(static_cast<GLclampf>(depth)));
 #else
   GLCHECK(::glClearDepth(depth));

--- a/qt/qt_common/helpers.cpp
+++ b/qt/qt_common/helpers.cpp
@@ -53,14 +53,23 @@ void SetDefaultSurfaceFormat(QString const & platformName)
   fmt.setSwapBehavior(QSurfaceFormat::DoubleBuffer);
   fmt.setSwapInterval(1);
   fmt.setDepthBufferSize(16);
+#if defined(OMIM_OS_LINUX)
+  fmt.setRenderableType(QSurfaceFormat::OpenGLES);
+  fmt.setProfile(QSurfaceFormat::CompatibilityProfile);
+#endif
 
   // Set proper OGL version now (needed for "cocoa" or "xcb"), but have troubles with "wayland" devices.
   // It will be resolved later in MapWidget::initializeGL when OGL context is available.
   if (platformName != QString("wayland"))
   {
+#if defined(OMIM_OS_LINUX)
+    LOG(LINFO, ("Set default OpenGL version to ES 3.0"));
+    fmt.setVersion(3, 0);
+#else
     LOG(LINFO, ("Set default OGL version to 3.2"));
     fmt.setProfile(QSurfaceFormat::CoreProfile);
     fmt.setVersion(3, 2);
+#endif
   }
 
 #ifdef ENABLE_OPENGL_DIAGNOSTICS

--- a/shaders/gl_program_pool.cpp
+++ b/shaders/gl_program_pool.cpp
@@ -14,7 +14,7 @@ GLProgramPool::GLProgramPool(dp::ApiVersion apiVersion)
 
   if (m_apiVersion == dp::ApiVersion::OpenGLES3)
   {
-#ifdef OMIM_OS_DESKTOP
+#if defined(OMIM_OS_DESKTOP) && !defined(OMIM_OS_LINUX)
     m_baseDefines = std::string(GL3_SHADER_VERSION) + "#define GLES3\n";
 #else
     m_baseDefines = std::string(GLES3_SHADER_VERSION);

--- a/shaders/gl_shaders_preprocessor.py
+++ b/shaders/gl_shaders_preprocessor.py
@@ -230,6 +230,7 @@ def write_implementation_file(programs_def, shader_index, shader_dir, impl_file,
 
         file.write("namespace gpu\n")
         file.write("{\n")
+        # TODO: Drop this GL3_SHADER_VERSION once MacOS code has been migrated to Metal
         file.write("char const * GL3_SHADER_VERSION = \"#version 150 core \\n\";\n")
         file.write("char const * GLES3_SHADER_VERSION = \"#version 300 es \\n\";\n\n")
 


### PR DESCRIPTION
Fixes:
1. https://github.com/flathub/app.organicmaps.desktop/issues/50
2. The annoying `drape/gl_functions.cpp:1150 CheckGLError(): SrcPoint  drape/gl_functions.cpp:1126 glLineWidth():  GLError: GL_INVALID_VALUE` on the current `master` , which flooded the logs in debug mode.