### PR TITLE
[android-auto] Add a compile-time flag for Android Auto

### DIFF
--- a/android/app/build.gradle
+++ b/android/app/build.gradle
@@ -13,6 +13,7 @@ buildscript {
   def taskName = getGradle().getStartParameter().getTaskRequests().toString().toLowerCase()
   def isFdroid = taskName.contains('fdroid')
   def isBeta = taskName.contains('beta')
+  def isDebug = taskName.contains('debug')
 
   //
   // Please add symlinks to google/java/app/organicmaps/location for each new gms-enabled flavor below:
@@ -23,10 +24,18 @@ buildscript {
   // ```
   ext.googleMobileServicesEnabled = taskName.contains('google') || taskName.contains('huawei') || taskName.contains('web')
 
+  // Firebase Crashlytics compile-time feature flag: -Pfirebase=true|false
+  def googleFirebaseServicesFlag = findProperty('firebase')
   // Enable Firebase for all beta flavors except fdroid only if google-services.json exists.
   def googleFirebaseServicesDefault = isBeta && !isFdroid && file("$projectDir/google-services.json").exists()
-  // Add a parameter to force Firebase.
-  ext.googleFirebaseServicesEnabled = project.hasProperty('firebase') ?: googleFirebaseServicesDefault
+  ext.googleFirebaseServicesEnabled = googleFirebaseServicesFlag ? googleFirebaseServicesFlag.toBoolean() :
+      googleFirebaseServicesDefault
+
+  // Android Auto compile-time feature flag: -Pandroidauto=true|false
+  def androidAutoFlag = findProperty('androidauto')
+  // Enable Android Auto by default for all debug and beta flavors except fdroid.
+  def androidAutoDefault = (isDebug || isBeta) && !isFdroid
+  ext.androidAutoEnabled = androidAutoFlag ? androidAutoFlag.toBoolean() : androidAutoDefault
 
   dependencies {
     classpath 'com.android.tools.build:gradle:8.1.1'
@@ -85,9 +94,16 @@ dependencies {
     implementation 'com.google.firebase:firebase-crashlytics-ndk'
   }
 
-  implementation 'androidx.car.app:app:1.4.0-alpha01'
-  // Fix for app/organicmaps/util/FileUploadWorker.java:14: error: cannot access ListenableFuture
-  implementation 'com.google.guava:guava:29.0-android'
+  if (androidAutoEnabled) {
+    println('Building with Android Auto')
+    implementation 'androidx.car.app:app:1.4.0-beta02'
+    // Fix for app/organicmaps/util/FileUploadWorker.java:14: error: cannot access ListenableFuture
+    // https://github.com/organicmaps/organicmaps/issues/6106
+    implementation 'com.google.guava:guava:32.1.2-android'
+  } else {
+    println('Building without Android Auto')
+  }
+
   // This line is added as a workaround for duplicate classes error caused by some outdated dependency:
   // > A failure occurred while executing com.android.build.gradle.internal.tasks.CheckDuplicatesRunnable
   // We don't use Kotlin, but some dependencies are actively using it.
@@ -216,6 +232,10 @@ android {
     }
 
     setProperty("archivesBaseName", appName.replaceAll("\\s","") + "-" + defaultConfig.versionCode)
+
+    if (!androidAutoEnabled) {
+      sourceSets.main.java.excludes += '**/organicmaps/car'
+    }
   }
 
   flavorDimensions += 'default'
@@ -420,6 +440,7 @@ android.buildTypes.all { buildType ->
   def authority = "\"" + authorityValue + "\""
   buildConfigField 'String', 'FILE_PROVIDER_AUTHORITY', authority
   manifestPlaceholders += [FILE_PROVIDER_PLACEHOLDER : authorityValue]
+  manifestPlaceholders += [ANDROID_AUTO_ENABLED : androidAutoEnabled]
 }
 
 task prepareGoogleReleaseListing {

--- a/android/app/proguard-mwm.txt
+++ b/android/app/proguard-mwm.txt
@@ -38,3 +38,6 @@
 -keep interface androidx.** { *; }
 
 -dontwarn javax.lang.model.element.Modifier
+
+# For Guava used by Android Auto
+-dontwarn java.lang.reflect.AnnotatedType

--- a/android/app/src/main/AndroidManifest.xml
+++ b/android/app/src/main/AndroidManifest.xml
@@ -44,8 +44,8 @@
   //-->
   <uses-permission-sdk-23 android:name="android.permission.POST_NOTIFICATIONS"/>
 
-  <uses-permission android:name="androidx.car.app.NAVIGATION_TEMPLATES"/>
-  <uses-permission android:name="androidx.car.app.ACCESS_SURFACE"/>
+  <uses-permission android:name="androidx.car.app.ACCESS_SURFACE" android:enabled="${ANDROID_AUTO_ENABLED}" />
+  <uses-permission android:name="androidx.car.app.NAVIGATION_TEMPLATES" android:enabled="${ANDROID_AUTO_ENABLED}" />
 
   <queries>
     <intent>
@@ -859,7 +859,8 @@
     <service
         android:name="app.organicmaps.car.CarAppService"
         android:foregroundServiceType="location"
-        android:exported="true">
+        android:exported="true"
+        android:enabled="${ANDROID_AUTO_ENABLED}">
       <intent-filter>
         <action android:name="androidx.car.app.CarAppService" />
         <category android:name="androidx.car.app.category.NAVIGATION" />
@@ -899,13 +900,14 @@
     <!-- Disable Google's anonymous stats collection -->
     <meta-data android:name="android.webkit.WebView.MetricsOptOut" android:value="true" />
 
-    <!-- For android Auto -->
-    <meta-data android:name="com.google.android.gms.car.application"
-        android:resource="@xml/automotive_app_desc"/>
+    <meta-data
+        android:name="com.google.android.gms.car.application"
+        android:resource="@xml/automotive_app_desc"
+        android:enabled="${ANDROID_AUTO_ENABLED}"/>
 
     <meta-data
         android:name="androidx.car.app.minCarApiLevel"
-        android:value="1"/>
-
+        android:value="1"
+        android:enabled="${ANDROID_AUTO_ENABLED}"/>
   </application>
 </manifest>


### PR DESCRIPTION
API=21 is now supported [1], but we don't want to enable Auto on prod yet.

[1]: https://github.com/androidx/androidx/blob/8bfb531bcc16da2aeefb845c18f9748fae069e61/car/app/app/build.gradle#L81