### PR TITLE
[core] Add ATM to Place Page

### DIFF
--- a/android/app/src/main/java/app/organicmaps/bookmarks/data/MapObject.java
+++ b/android/app/src/main/java/app/organicmaps/bookmarks/data/MapObject.java
@@ -291,6 +291,11 @@ public class MapObject implements PlacePageData
     return !TextUtils.isEmpty(getMetadata(Metadata.MetadataType.FMD_PHONE_NUMBER));
   }
 
+  public boolean hasAtm()
+  {
+    return mRawTypes.contains("amenity-atm");
+  }
+
   public final boolean isMyPosition()
   {
     return mMapObjectType == MY_POSITION;

--- a/android/app/src/main/java/app/organicmaps/widget/placepage/PlacePageView.java
+++ b/android/app/src/main/java/app/organicmaps/widget/placepage/PlacePageView.java
@@ -97,6 +97,8 @@ public class PlacePageView extends Fragment implements View.OnClickListener,
   private TextView mTvOperator;
   private View mLevel;
   private TextView mTvLevel;
+  private View mAtm;
+  private TextView mTvAtm;
   private View mCuisine;
   private TextView mTvCuisine;
   private View mEntrance;
@@ -232,6 +234,8 @@ public class PlacePageView extends Fragment implements View.OnClickListener,
     mTvOperator = mFrame.findViewById(R.id.tv__place_operator);
     mLevel = mFrame.findViewById(R.id.ll__place_level);
     mTvLevel = mFrame.findViewById(R.id.tv__place_level);
+    mAtm = mFrame.findViewById(R.id.ll__place_atm);
+    mTvAtm = mFrame.findViewById(R.id.tv__place_atm);
     mCuisine = mFrame.findViewById(R.id.ll__place_cuisine);
     mTvCuisine = mFrame.findViewById(R.id.tv__place_cuisine);
     mEntrance = mFrame.findViewById(R.id.ll__place_entrance);
@@ -247,6 +251,7 @@ public class PlacePageView extends Fragment implements View.OnClickListener,
     address.setOnLongClickListener(this);
     mOperator.setOnLongClickListener(this);
     mLevel.setOnLongClickListener(this);
+    mAtm.setOnLongClickListener(this);
 
     mDownloaderIcon = new DownloaderStatusIcon(mPreview.findViewById(R.id.downloader_status_frame));
 
@@ -386,6 +391,7 @@ public class PlacePageView extends Fragment implements View.OnClickListener,
     refreshWiFi();
     refreshMetadataOrHide(mMapObject.getMetadata(Metadata.MetadataType.FMD_FLATS), mEntrance, mTvEntrance);
     refreshMetadataOrHide(mMapObject.getMetadata(Metadata.MetadataType.FMD_LEVEL), mLevel, mTvLevel);
+    refreshMetadataOrHide(mMapObject.hasAtm() ? getString(R.string.type_amenity_atm) : "", mAtm, mTvAtm);
 
 //    showTaxiOffer(mapObject);
 
@@ -552,6 +558,8 @@ public class PlacePageView extends Fragment implements View.OnClickListener,
       items.add(mTvOperator.getText().toString());
     else if (id == R.id.ll__place_level)
       items.add(mTvLevel.getText().toString());
+    else if (id == R.id.ll__place_atm)
+      items.add(mTvAtm.getText().toString());
 
     final Context context = requireContext();
     if (items.size() == 1)

--- a/android/app/src/main/res/drawable/ic_atm_white.xml
+++ b/android/app/src/main/res/drawable/ic_atm_white.xml
@@ -1,0 +1,12 @@
+<vector xmlns:android="http://schemas.android.com/apk/res/android" xmlns:aapt="http://schemas.android.com/aapt"
+    android:viewportWidth="48"
+    android:viewportHeight="48"
+    android:width="48dp"
+    android:height="48dp">
+    <path
+        android:pathData="M39.2 8.8h-30.4c-2.0957 0 -3.8 1.7043 -3.8 3.8v22.8c0 2.0957 1.7043 3.8 3.8 3.8h30.4c2.0957 0 3.8 -1.7043 3.8 -3.8v-22.8c0 -2.0957 -1.7043 -3.8 -3.8 -3.8zm-30.4 3.8h30.4v3.8h-30.4zm0 22.8v-11.4h30.402l0.0019 11.4z"
+        android:fillColor="#FFFFFF" />
+    <path
+        android:pathData="M12.6 27.8H24V31.6H12.6V27.8Z"
+        android:fillColor="#FFFFFF" />
+</vector>

--- a/android/app/src/main/res/layout/place_page_atm.xml
+++ b/android/app/src/main/res/layout/place_page_atm.xml
@@ -1,0 +1,20 @@
+<?xml version="1.0" encoding="utf-8"?>
+<LinearLayout
+  xmlns:android="http://schemas.android.com/apk/res/android"
+  xmlns:tools="http://schemas.android.com/tools"
+  android:id="@+id/ll__place_atm"
+  style="@style/PlacePageItemFrame"
+  android:tag="atm"
+  tools:background="#4000FFFF"
+  tools:visibility="visible">
+
+  <ImageView
+    android:id="@+id/iv__place_atm"
+    style="@style/PlacePageMetadataIcon"
+    android:src="@drawable/ic_atm_white" />
+
+  <TextView
+    android:id="@+id/tv__place_atm"
+    style="@style/PlacePageMetadataText"
+    tools:text="@string/type.amenity.atm" />
+</LinearLayout>

--- a/android/app/src/main/res/layout/place_page_details.xml
+++ b/android/app/src/main/res/layout/place_page_details.xml
@@ -57,6 +57,8 @@
 
     <include layout="@layout/place_page_level" />
 
+    <include layout="@layout/place_page_atm" />
+
     <!-- ToDo: Address is missing compared with iOS. It's shown in title but anyway .. -->
 
     <include layout="@layout/place_page_latlon"/>

--- a/android/app/src/main/res/values-ca/strings.xml
+++ b/android/app/src/main/res/values-ca/strings.xml
@@ -655,9 +655,9 @@
 	<!-- A generic "No" button in dialogs -->
 	<string name="no">No</string>
 	<!-- E.g. "WiFi:Yes" -->
-	<string name="yes_available">sí</string>
+	<string name="yes_available">Sí</string>
 	<!-- E.g. "WiFi:No" -->
-	<string name="no_available">no</string>
+	<string name="no_available">No</string>
 	<string name="trip_finished">Heu arribat!</string>
 	<string name="ok">D\'acord</string>
 	<!-- max. 10 symbols, both iOS and Android -->

--- a/android/app/src/main/res/values-es/strings.xml
+++ b/android/app/src/main/res/values-es/strings.xml
@@ -666,9 +666,9 @@
 	<!-- A generic "No" button in dialogs -->
 	<string name="no">No</string>
 	<!-- E.g. "WiFi:Yes" -->
-	<string name="yes_available">sí</string>
+	<string name="yes_available">Sí</string>
 	<!-- E.g. "WiFi:No" -->
-	<string name="no_available">no</string>
+	<string name="no_available">No</string>
 	<string name="trip_finished">¡Ya ha llegado!</string>
 	<string name="ok">Ok</string>
 	<!-- max. 10 symbols, both iOS and Android -->

--- a/android/app/src/main/res/values-et/strings.xml
+++ b/android/app/src/main/res/values-et/strings.xml
@@ -653,9 +653,9 @@
 	<!-- A generic "No" button in dialogs -->
 	<string name="no">Ei</string>
 	<!-- E.g. "WiFi:Yes" -->
-	<string name="yes_available">jah</string>
+	<string name="yes_available">Jah</string>
 	<!-- E.g. "WiFi:No" -->
-	<string name="no_available">ei</string>
+	<string name="no_available">Ei</string>
 	<string name="trip_finished">Oled kohal!</string>
 	<string name="ok">Ok</string>
 	<!-- max. 10 symbols, both iOS and Android -->

--- a/android/app/src/main/res/values-eu/strings.xml
+++ b/android/app/src/main/res/values-eu/strings.xml
@@ -664,9 +664,9 @@
 	<!-- A generic "No" button in dialogs -->
 	<string name="no">Ez</string>
 	<!-- E.g. "WiFi:Yes" -->
-	<string name="yes_available">bai</string>
+	<string name="yes_available">Bai</string>
 	<!-- E.g. "WiFi:No" -->
-	<string name="no_available">ez</string>
+	<string name="no_available">Ez</string>
 	<string name="trip_finished">Iritsi zara!</string>
 	<string name="ok">Ados</string>
 	<!-- max. 10 symbols, both iOS and Android -->

--- a/android/app/src/main/res/values-fi/strings.xml
+++ b/android/app/src/main/res/values-fi/strings.xml
@@ -668,9 +668,9 @@
 	<!-- A generic "No" button in dialogs -->
 	<string name="no">Ei</string>
 	<!-- E.g. "WiFi:Yes" -->
-	<string name="yes_available">kyllä</string>
+	<string name="yes_available">Kyllä</string>
 	<!-- E.g. "WiFi:No" -->
-	<string name="no_available">ei</string>
+	<string name="no_available">Ei</string>
 	<string name="trip_finished">Olet perillä!</string>
 	<string name="ok">Ok</string>
 	<!-- max. 10 symbols, both iOS and Android -->

--- a/android/app/src/main/res/values-fr/strings.xml
+++ b/android/app/src/main/res/values-fr/strings.xml
@@ -667,9 +667,9 @@
 	<!-- A generic "No" button in dialogs -->
 	<string name="no">Non</string>
 	<!-- E.g. "WiFi:Yes" -->
-	<string name="yes_available">oui</string>
+	<string name="yes_available">Oui</string>
 	<!-- E.g. "WiFi:No" -->
-	<string name="no_available">non</string>
+	<string name="no_available">Non</string>
 	<string name="trip_finished">Vous êtes arrivé !</string>
 	<string name="ok">Ok</string>
 	<!-- max. 10 symbols, both iOS and Android -->

--- a/android/app/src/main/res/values-nl/strings.xml
+++ b/android/app/src/main/res/values-nl/strings.xml
@@ -659,9 +659,9 @@
 	<!-- A generic "No" button in dialogs -->
 	<string name="no">Nee</string>
 	<!-- E.g. "WiFi:Yes" -->
-	<string name="yes_available">ja</string>
+	<string name="yes_available">Ja</string>
 	<!-- E.g. "WiFi:No" -->
-	<string name="no_available">nee</string>
+	<string name="no_available">Nee</string>
 	<string name="trip_finished">U bent aangekomen!</string>
 	<string name="ok">Goed</string>
 	<!-- max. 10 symbols, both iOS and Android -->

--- a/data/strings/strings.txt
+++ b/data/strings/strings.txt
@@ -22842,15 +22842,8 @@
     tags = android,ios
     ref = yes
     be = Ёсць
-    ca = sí
-    es = sí
-    et = jah
-    eu = bai
     fa = بلی
-    fi = kyllä
-    fr = oui
     he = כן
-    nl = ja
     ru = Есть
     tr = Var
 
@@ -22859,13 +22852,6 @@
     tags = android,ios
     ref = no
     be = Няма
-    ca = no
-    es = no
-    et = ei
-    eu = ez
-    fi = ei
-    fr = non
-    nl = nee
     tr = Yok
 
   [trip_finished]

--- a/indexer/feature_utils.cpp
+++ b/indexer/feature_utils.cpp
@@ -438,4 +438,10 @@ string GetLocalizedFeeType(TypesHolder const & types)
   return localized_types[0];
 }
 
+bool HasAtm(TypesHolder const & types)
+{
+    auto const & isAtmType = ftypes::IsATMChecker::Instance();
+    return isAtmType(types);
+}
+
 } // namespace feature

--- a/indexer/feature_utils.hpp
+++ b/indexer/feature_utils.hpp
@@ -129,4 +129,7 @@ namespace feature
   // Returns fee type localized by platform.
   std::string GetLocalizedFeeType(TypesHolder const & types);
 
+  /// Returns true if feature has ATM type.
+  bool HasAtm(TypesHolder const & types);
+
 }  // namespace feature

--- a/indexer/map_object.cpp
+++ b/indexer/map_object.cpp
@@ -168,6 +168,11 @@ string MapObject::GetLocalizedFeeType() const
   return feature::GetLocalizedFeeType(m_types);
 }
 
+bool MapObject::HasAtm() const
+{
+  return feature::HasAtm(m_types);
+}
+
 string MapObject::FormatCuisines() const
 {
   return strings::JoinStrings(GetLocalizedCuisines(), kFieldsSeparator);

--- a/indexer/map_object.hpp
+++ b/indexer/map_object.hpp
@@ -100,6 +100,9 @@ public:
   int GetStars() const;
   ftraits::WheelchairAvailability GetWheelchairType() const;
 
+  /// @returns true if feature has ATM type.
+  bool HasAtm() const;
+
   /// @returns formatted elevation in feet or meters, or empty string.
   std::string GetElevationFormatted() const;
   /// @}

--- a/iphone/CoreApi/CoreApi/PlacePageData/Common/PlacePageInfoData.h
+++ b/iphone/CoreApi/CoreApi/PlacePageData/Common/PlacePageInfoData.h
@@ -27,6 +27,7 @@ NS_ASSUME_NONNULL_BEGIN
 @property(nonatomic, readonly, nullable) NSArray *coordFormats;
 @property(nonatomic, readonly, nullable) NSString *wifiAvailable;
 @property(nonatomic, readonly, nullable) NSString *level;
+@property(nonatomic, readonly, nullable) NSString *atm;
 
 @end
 

--- a/iphone/CoreApi/CoreApi/PlacePageData/Common/PlacePageInfoData.mm
+++ b/iphone/CoreApi/CoreApi/PlacePageData/Common/PlacePageInfoData.mm
@@ -79,7 +79,9 @@ using namespace osm;
           break;
       }
     });
-
+    
+    _atm = rawData.HasAtm() ? NSLocalizedString(@"type.amenity.atm", nil) : nil;
+      
     _address = rawData.GetAddress().empty() ? nil : @(rawData.GetAddress().c_str());
     _coordFormats = @[@(rawData.GetFormattedCoordinate(place_page::CoordinatesFormat::LatLonDMS).c_str()),
                       @(rawData.GetFormattedCoordinate(place_page::CoordinatesFormat::LatLonDecimal).c_str()),

--- a/iphone/Maps/Images.xcassets/Place Page/ic_placepage_atm.imageset/Contents.json
+++ b/iphone/Maps/Images.xcassets/Place Page/ic_placepage_atm.imageset/Contents.json
@@ -1,0 +1,24 @@
+{
+  "images" : [
+    {
+      "filename" : "ic_atm_white.svg",
+      "idiom" : "universal",
+      "scale" : "1x"
+    },
+    {
+      "idiom" : "universal",
+      "scale" : "2x"
+    },
+    {
+      "idiom" : "universal",
+      "scale" : "3x"
+    }
+  ],
+  "info" : {
+    "author" : "xcode",
+    "version" : 1
+  },
+  "properties" : {
+    "template-rendering-intent" : "template"
+  }
+}

--- a/iphone/Maps/Images.xcassets/Place Page/ic_placepage_atm.imageset/ic_atm_white.svg
+++ b/iphone/Maps/Images.xcassets/Place Page/ic_placepage_atm.imageset/ic_atm_white.svg
@@ -1,0 +1,5 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<svg width="48" height="48" version="1.1" viewBox="0 0 48 48" xmlns="http://www.w3.org/2000/svg">
+ <path d="m33.6 14.4h-19.2c-1.3236 0-2.4 1.0764-2.4 2.4v14.4c0 1.3236 1.0764 2.4 2.4 2.4h19.2c1.3236 0 2.4-1.0764 2.4-2.4v-14.4c0-1.3236-1.0764-2.4-2.4-2.4zm-19.2 2.4h19.2v2.4h-19.2zm0 14.4v-7.2h19.201l0.0012 7.2z" fill="#fff" stroke-width="2.4"/>
+ <rect x="16.8" y="26.4" width="7.2" height="2.4" fill="#fff"/>
+</svg>

--- a/iphone/Maps/LocalizedStrings/ca.lproj/Localizable.strings
+++ b/iphone/Maps/LocalizedStrings/ca.lproj/Localizable.strings
@@ -1061,10 +1061,10 @@
 "no" = "No";
 
 /* E.g. "WiFi:Yes" */
-"yes_available" = "sí";
+"yes_available" = "Sí";
 
 /* E.g. "WiFi:No" */
-"no_available" = "no";
+"no_available" = "No";
 
 "trip_finished" = "Heu arribat!";
 

--- a/iphone/Maps/LocalizedStrings/es.lproj/Localizable.strings
+++ b/iphone/Maps/LocalizedStrings/es.lproj/Localizable.strings
@@ -1061,10 +1061,10 @@
 "no" = "No";
 
 /* E.g. "WiFi:Yes" */
-"yes_available" = "sí";
+"yes_available" = "Sí";
 
 /* E.g. "WiFi:No" */
-"no_available" = "no";
+"no_available" = "No";
 
 "trip_finished" = "¡Ya ha llegado!";
 

--- a/iphone/Maps/LocalizedStrings/et.lproj/Localizable.strings
+++ b/iphone/Maps/LocalizedStrings/et.lproj/Localizable.strings
@@ -1061,10 +1061,10 @@
 "no" = "Ei";
 
 /* E.g. "WiFi:Yes" */
-"yes_available" = "jah";
+"yes_available" = "Jah";
 
 /* E.g. "WiFi:No" */
-"no_available" = "ei";
+"no_available" = "Ei";
 
 "trip_finished" = "Oled kohal!";
 

--- a/iphone/Maps/LocalizedStrings/eu.lproj/Localizable.strings
+++ b/iphone/Maps/LocalizedStrings/eu.lproj/Localizable.strings
@@ -1061,10 +1061,10 @@
 "no" = "Ez";
 
 /* E.g. "WiFi:Yes" */
-"yes_available" = "bai";
+"yes_available" = "Bai";
 
 /* E.g. "WiFi:No" */
-"no_available" = "ez";
+"no_available" = "Ez";
 
 "trip_finished" = "Iritsi zara!";
 

--- a/iphone/Maps/LocalizedStrings/fi.lproj/Localizable.strings
+++ b/iphone/Maps/LocalizedStrings/fi.lproj/Localizable.strings
@@ -1061,10 +1061,10 @@
 "no" = "Ei";
 
 /* E.g. "WiFi:Yes" */
-"yes_available" = "kyllä";
+"yes_available" = "Kyllä";
 
 /* E.g. "WiFi:No" */
-"no_available" = "ei";
+"no_available" = "Ei";
 
 "trip_finished" = "Olet perillä!";
 

--- a/iphone/Maps/LocalizedStrings/fr.lproj/Localizable.strings
+++ b/iphone/Maps/LocalizedStrings/fr.lproj/Localizable.strings
@@ -1061,10 +1061,10 @@
 "no" = "Non";
 
 /* E.g. "WiFi:Yes" */
-"yes_available" = "oui";
+"yes_available" = "Oui";
 
 /* E.g. "WiFi:No" */
-"no_available" = "non";
+"no_available" = "Non";
 
 "trip_finished" = "Vous êtes arrivé !";
 

--- a/iphone/Maps/LocalizedStrings/nl.lproj/Localizable.strings
+++ b/iphone/Maps/LocalizedStrings/nl.lproj/Localizable.strings
@@ -1061,10 +1061,10 @@
 "no" = "Nee";
 
 /* E.g. "WiFi:Yes" */
-"yes_available" = "ja";
+"yes_available" = "Ja";
 
 /* E.g. "WiFi:No" */
-"no_available" = "nee";
+"no_available" = "Nee";
 
 "trip_finished" = "U bent aangekomen!";
 

--- a/iphone/Maps/UI/PlacePage/Components/PlacePageInfoViewController.swift
+++ b/iphone/Maps/UI/PlacePage/Components/PlacePageInfoViewController.swift
@@ -89,6 +89,7 @@ class PlacePageInfoViewController: UIViewController {
   private var cuisineView: InfoItemViewController?
   private var operatorView: InfoItemViewController?
   private var wifiView: InfoItemViewController?
+  private var atmView: InfoItemViewController?
   private var addressView: InfoItemViewController?
   private var levelView: InfoItemViewController?
   private var coordinatesView: InfoItemViewController?
@@ -156,6 +157,10 @@ class PlacePageInfoViewController: UIViewController {
 
     if let wifi = placePageInfoData.wifiAvailable {
       wifiView = createInfoItem(wifi, icon: UIImage(named: "ic_placepage_wifi"))
+    }
+    
+    if let atm = placePageInfoData.atm {
+      atmView = createInfoItem(atm, icon: UIImage(named: "ic_placepage_atm"))
     }
 
     if let level = placePageInfoData.level {

--- a/map/place_page_info.cpp
+++ b/map/place_page_info.cpp
@@ -22,6 +22,7 @@ namespace place_page
 char const * const Info::kStarSymbol = "★";
 char const * const Info::kMountainSymbol = "▲";
 char const * const kWheelchairSymbol = "\u267F";
+char const * const kAtmSymbol = "💳";
 
 bool Info::IsBookmark() const
 {
@@ -162,6 +163,10 @@ std::string Info::FormatSubtitle(bool withType) const
   auto const eleStr = GetElevationFormatted();
   if (!eleStr.empty())
     append(kMountainSymbol + eleStr);
+    
+  // ATM
+  if (HasAtm())
+    append(kAtmSymbol);
 
   // Internet.
   if (HasWifi())


### PR DESCRIPTION
* This PR adds ATM description to the Place Page subtitle of features that have an `atm=yes` tagging. Closes https://github.com/organicmaps/organicmaps/issues/3209

This PR is similar to https://github.com/organicmaps/organicmaps/pull/5883 but in this case we are using the already existing ATM type, not new metadata properties. 

<img src="https://github.com/organicmaps/organicmaps/assets/47610359/817ca783-ba65-4de2-ac9f-18d581250ed8" width="310"/>
