### PR TITLE
[editor] Caves can be added

### DIFF
--- a/data/editor.config
+++ b/data/editor.config
@@ -506,6 +506,10 @@
       <type id="leisure-swimming_pool" can_add="no">
         <include group="poi_internet" />
       </type>
+      <type id="natural-cave_entrance" group="historic">
+        <include field="name" />
+        <include field="wikipedia" />
+      </type>
       <type id="natural-geyser">
         <include field="name" />
       </type>


### PR DESCRIPTION
Closes #5892

Note that FMD_WIKIPEDIA is not handled in `MWMEditorViewController`::`- (void)fillCell:(UITableViewCell * _Nonnull)cell atIndexPath:(NSIndexPath * _Nonnull)indexPath` and asserts there. 

The validation or transformation for Wiki URLs is also missing.

As a temporary workaround, Wikipedia fields can be removed from the editor.config.

Upd: looks like Wikipedia fields are enabled for a long time. So we can leave them as is.