### PR TITLE
[android] capitalise each word in editable name fields

### DIFF
--- a/android/app/src/main/res/layout/edit_bookmark_common.xml
+++ b/android/app/src/main/res/layout/edit_bookmark_common.xml
@@ -26,7 +26,7 @@
         android:layout_width="match_parent"
         android:layout_height="wrap_content"
         android:hint="@string/name"
-        android:inputType="textCapSentences"
+        android:inputType="textCapWords"
         android:singleLine="true" />
     </app.organicmaps.widget.CustomTextInputLayout>
   </LinearLayout>

--- a/android/app/src/main/res/layout/item_localized_name.xml
+++ b/android/app/src/main/res/layout/item_localized_name.xml
@@ -19,7 +19,7 @@
       android:id="@+id/input"
       style="@style/MwmWidget.Editor.FieldLayout.EditText"
       android:hint="@string/editor_edit_place_name_hint"
-      android:inputType="textCapSentences"
+      android:inputType="textCapWords"
       android:singleLine="true" />
   </com.google.android.material.textfield.TextInputLayout>
   <ImageButton


### PR DESCRIPTION
Capitalising each word makes much more sense for name fields, as names are usually in title case. (this is also the default in StreetComplete)


https://github.com/organicmaps/organicmaps/assets/26939824/53540eb3-dedc-4721-8578-707f54a98146

