### PR TITLE
Disable reordering when a point is appended to a ruler route

### DIFF
--- a/map/routing_manager.cpp
+++ b/map/routing_manager.cpp
@@ -881,8 +881,7 @@ void RoutingManager::ContinueRouteToPoint(RouteMarkData && markData)
 
   markData.m_intermediateIndex = routePoints.GetRoutePointsCount();
   markData.m_isVisible = !markData.m_isMyPosition;
-  routePoints.AddRoutePoint(move(markData));
-  ReorderIntermediatePoints();
+  routePoints.AddRoutePoint(std::move(markData));
 }
 
 void RoutingManager::RemoveRoutePoint(RouteMarkType type, size_t intermediateIndex)


### PR DESCRIPTION
When new point is added to ruler route no points reordering is applied.

| Before | After |
| ----- | ----- |
| <video src="https://github.com/organicmaps/organicmaps/assets/720808/5620114f-7bb2-4e79-8e0d-671b3ab7408a"/> | <video src="https://github.com/organicmaps/organicmaps/assets/720808/ad8f6036-bb51-4b53-9fb8-c01995d266bf" /> |
