### PR TITLE
[android] Fixing application launch on Android 13.

### DIFF
--- a/android/app/build.gradle
+++ b/android/app/build.gradle
@@ -283,7 +283,7 @@ android {
     android.applicationVariants.all { variant ->
       def task = variant.name.capitalize()
       project.task(type: Exec, "run${task}", dependsOn: "install${task}") {
-        commandLine android.getAdbExe(), 'shell', 'monkey', '-p', applicationId, '-c', 'android.intent.category.LAUNCHER', '1'
+        commandLine android.getAdbExe(), 'shell', 'am', 'start', '-n', "$applicationId/app.organicmaps.DownloadResourcesActivity", '-a', 'android.intent.action.MAIN', '-c', 'android.intent.category.LAUNCHER'
       }
     }
   }

--- a/android/app/build.gradle
+++ b/android/app/build.gradle
@@ -283,7 +283,7 @@ android {
     android.applicationVariants.all { variant ->
       def task = variant.name.capitalize()
       project.task(type: Exec, "run${task}", dependsOn: "install${task}") {
-        commandLine android.getAdbExe(), 'shell', 'am', 'start', '-n', "${applicationId}/app.organicmaps.SplashActivity"
+        commandLine android.getAdbExe(), 'shell', 'monkey', '-p', applicationId, '-c', 'android.intent.category.LAUNCHER', '1'
       }
     }
   }


### PR DESCRIPTION
Currently the last step of gradle build is

```shell
adb shell am start -n "app.organicmaps.debug/app.organicmaps.SplashActivity"
```

But this command fails with Android 13

```
Starting: Intent { cmp=app.organicmaps.debug/app.organicmaps.SplashActivity }
Error type 3
Error: Activity class {app.organicmaps.debug/app.organicmaps.SplashActivity} does not exist.
```

Found solution here: https://stackoverflow.com/a/29931521
App is started with `adb shell monkey -p app.organicmaps.debug -c android.intent.category.LAUNCHER 1`.
Tested with Android 13 and 11.

## Update 2023.09.18
Replaced `adb monkey` with:

`adb shell am start -n "app.organicmaps.debug/app.organicmaps.DownloadResourcesActivity" -a android.intent.action.MAIN -c android.intent.category.LAUNCHER`

Verified with Android 13 and 11.