### PR TITLE
[drape] Refactor Stylist and RuleDrawer 

### DIFF
--- a/drape/utils/projection.hpp
+++ b/drape/utils/projection.hpp
@@ -2,6 +2,8 @@
 
 #include "drape/drape_global.hpp"
 
+#include "indexer/drawing_rule_def.hpp"
+
 #include <array>
 
 namespace dp
@@ -9,6 +11,9 @@ namespace dp
 /// @todo: asymmetric values lead to in-range polygons being clipped still, might be a bug in projection matrix?
 float constexpr kMinDepth = -25000.0f;
 float constexpr kMaxDepth = 25000.0f;
+
+static_assert(kMinDepth <= drule::kMinLayeredDepthBg && drule::kMaxLayeredDepthFg <= kMaxDepth);
+static_assert(kMinDepth <= -drule::kOverlaysMaxPriority && drule::kOverlaysMaxPriority <= kMaxDepth);
 
 std::array<float, 16> MakeProjection(dp::ApiVersion apiVersion, float left, float right,
                                      float bottom, float top);

--- a/drape_frontend/rule_drawer.hpp
+++ b/drape_frontend/rule_drawer.hpp
@@ -26,6 +26,14 @@ namespace df
 class EngineContext;
 class Stylist;
 
+/*
+ * RuleDrawer() is invoked for each feature in the tile.
+ * It creates a Stylist which filters suitable drawing rules for the feature.
+ * Then passes on the drawing rules to ApplyPoint/Area/LineFeature objects
+ * which create corresponding MapShape objects (which might in turn create OverlayHandles).
+ * The RuleDrawer flushes geometry MapShapes immediately for each feature,
+ * while overlay MapShapes are flushed altogether after all features are processed.
+ */
 class RuleDrawer
 {
 public:
@@ -45,11 +53,11 @@ public:
 #endif
 
 private:
-  void ProcessAreaStyle(FeatureType & f, Stylist const & s, TInsertShapeFn const & insertShape);
+  void ProcessAreaAndPointStyle(FeatureType & f, Stylist const & s, TInsertShapeFn const & insertShape);
   void ProcessLineStyle(FeatureType & f, Stylist const & s, TInsertShapeFn const & insertShape);
   void ProcessPointStyle(FeatureType & f, Stylist const & s, TInsertShapeFn const & insertShape);
 
-  bool CheckCoastlines(FeatureType & f, Stylist const & s);
+  bool CheckCoastlines(FeatureType & f);
 
   bool CheckCancelled();
 
@@ -64,6 +72,7 @@ private:
   std::unordered_set<m2::Spline const *> m_usedMetalines;
 
   m2::RectD m_globalRect;
+  uint8_t m_zoomLevel;
   double m_currentScaleGtoP;
   double m_trafficScalePtoG;
 

--- a/drape_frontend/stylist.cpp
+++ b/drape_frontend/stylist.cpp
@@ -1,12 +1,8 @@
 #include "drape_frontend/stylist.hpp"
-#include "drape/utils/projection.hpp"
 
 #include "indexer/classificator.hpp"
 #include "indexer/feature.hpp"
-#include "indexer/feature_utils.hpp"
 #include "indexer/feature_visibility.hpp"
-#include "indexer/drawing_rules.hpp"
-#include "indexer/drules_include.hpp"
 #include "indexer/scales.hpp"
 
 #include <algorithm>
@@ -14,224 +10,6 @@
 
 namespace df
 {
-namespace
-{
-/*
-* The overall rendering depth range [dp::kMinDepth;dp::kMaxDepth] is divided
-* into following specific depth ranges:
-* FG - foreground lines and areas (buildings..), rendered on top of other geometry always,
-*      even if a fg feature is layer=-10 (e.g. tunnels should be visibile over landcover and water).
-* BG-top - rendered just on top of BG-by-size range, because ordering by size
-*      doesn't always work with e.g. water mapped over a forest,
-*      so water should be on top of other landcover always,
-*      but linear waterways should be hidden beneath it.
-* BG-by-size - landcover areas rendered in bbox size order, smaller areas are above larger ones.
-* Still, a BG-top water area with layer=-1 should go below other landcover,
-* and a layer=1 landcover area should be displayed above water,
-* so BG-top and BG-by-size should share the same "layer" space.
-*/
-
-// Priority values coming from style files are expected to be separated into following ranges.
-static double constexpr kBasePriorityFg = 0,
-                        kBasePriorityBgTop = -1000,
-                        kBasePriorityBgBySize = -2000;
-
-// Define depth ranges boundaries to accomodate for all possible layer=* values.
-// One layer space is drule::kLayerPriorityRange (1000). So each +1/-1 layer value shifts
-// depth of the drule by -1000/+1000.
-
-                        // FG depth range: [0;1000).
-static double constexpr kBaseDepthFg = 0,
-                        // layer=-10/10 gives an overall FG range of [-10000;11000).
-                        kMaxLayeredDepthFg = kBaseDepthFg + (1 + feature::LAYER_HIGH) * drule::kLayerPriorityRange,
-                        kMinLayeredDepthFg = kBaseDepthFg + feature::LAYER_LOW * drule::kLayerPriorityRange,
-                        // Split the background layer space as 100 for BG-top and 900 for BG-by-size.
-                        kBgTopRangeFraction = 0.1,
-                        kDepthRangeBgTop = kBgTopRangeFraction * drule::kLayerPriorityRange,
-                        kDepthRangeBgBySize = drule::kLayerPriorityRange - kDepthRangeBgTop,
-                        // So the BG-top range is [-10100,-10000).
-                        kBaseDepthBgTop = kMinLayeredDepthFg - kDepthRangeBgTop,
-                        // And BG-by-size range is [-11000,-11000).
-                        kBaseDepthBgBySize = kBaseDepthBgTop - kDepthRangeBgBySize,
-                        // Minimum BG depth for layer=-10 is -21000.
-                        kMinLayeredDepthBg = kBaseDepthBgBySize + feature::LAYER_LOW * drule::kLayerPriorityRange;
-
-static_assert(dp::kMinDepth <= kMinLayeredDepthBg && kMaxLayeredDepthFg <= dp::kMaxDepth);
-static_assert(dp::kMinDepth <= -drule::kOverlaysMaxPriority && drule::kOverlaysMaxPriority <= dp::kMaxDepth);
-
-enum Type
-{
-  Line      = 1 << 0,
-  Area      = 1 << 1,
-  Symbol    = 1 << 2,
-  Caption   = 1 << 3,
-  Circle    = 1 << 4,
-  PathText  = 1 << 5,
-  Waymarker = 1 << 6,
-  Shield    = 1 << 7,
-  CountOfType = Shield + 1
-};
-
-inline drule::rule_type_t Convert(Type t)
-{
-  switch (t)
-  {
-  case Line     : return drule::line;
-  case Area     : return drule::area;
-  case Symbol   : return drule::symbol;
-  case Caption  : return drule::caption;
-  case Circle   : return drule::circle;
-  case PathText : return drule::pathtext;
-  case Waymarker: return drule::waymarker;
-  case Shield   : return drule::shield;
-  default:
-    return drule::count_of_rules;
-  }
-}
-
-inline bool IsTypeOf(drule::Key const & key, int flags)
-{
-  int currentFlag = Line;
-  while (currentFlag < CountOfType)
-  {
-    Type const type = Type(flags & currentFlag);
-    if (type != 0 && key.m_type == Convert(type))
-      return true;
-
-    currentFlag <<= 1;
-  }
-
-  return false;
-}
-
-class Aggregator
-{
-public:
-  Aggregator(FeatureType & f, feature::GeomType const type, int const zoomLevel, size_t const keyCount)
-    : m_pointStyleFound(false)
-    , m_lineStyleFound(false)
-    , m_captionRule({ nullptr, 0, false, false })
-    , m_f(f)
-    , m_geomType(type)
-    , m_zoomLevel(zoomLevel)
-    , m_areaDepth(0)
-  {
-    m_rules.reserve(keyCount);
-    Init();
-  }
-
-  void AggregateKeys(drule::KeysT const & keys)
-  {
-    for (auto const & key : keys)
-      ProcessKey(key);
-  }
-
-  void AggregateStyleFlags(drule::KeysT const & keys, bool const nameExists)
-  {
-    for (auto const & key : keys)
-    {
-      bool const isNonEmptyCaption = IsTypeOf(key, Caption) && nameExists;
-      m_pointStyleFound |= (IsTypeOf(key, Symbol | Circle) || isNonEmptyCaption);
-      m_lineStyleFound  |= IsTypeOf(key, Line);
-    }
-  }
-
-  bool m_pointStyleFound;
-  bool m_lineStyleFound;
-  TRuleWrapper m_captionRule;
-  buffer_vector<TRuleWrapper, 8> m_rules;
-
-private:
-  void ProcessKey(drule::Key const & key)
-  {
-    double depth = key.m_priority;
-
-    if (IsTypeOf(key, Area | Line))
-    {
-      if (depth < kBasePriorityBgTop)
-      {
-        ASSERT(IsTypeOf(key, Area), (m_f.GetID()));
-        ASSERT_GREATER_OR_EQUAL(depth, kBasePriorityBgBySize, (m_f.GetID()));
-        // Prioritize BG-by-size areas by their bbox sizes instead of style-set priorities.
-        depth = m_areaDepth;
-      }
-      else if (depth < kBasePriorityFg)
-      {
-        // Adjust BG-top features depth range so that it sits just above the BG-by-size range.
-        depth = kBaseDepthBgTop + (depth - kBasePriorityBgTop) * kBgTopRangeFraction;
-      }
-
-      // Shift the depth according to layer=* value.
-      // Note we don't adjust priorities of "point-styles" according to layer=*,
-      // because their priorities are used for displacement logic only.
-      /// @todo we might want to hide e.g. a trash bin under man_made=bridge or a bench on underground railway station?
-      if (m_featureLayer != feature::LAYER_EMPTY)
-      {
-        depth += m_featureLayer * drule::kLayerPriorityRange;
-      }
-    }
-    else
-    {
-      // Check overlays priorities range.
-      ASSERT(-drule::kOverlaysMaxPriority <= depth && depth < drule::kOverlaysMaxPriority, (depth, m_f.GetID()));
-    }
-    // Check no features are clipped by the depth range constraints.
-    ASSERT(dp::kMinDepth <= depth && depth <= dp::kMaxDepth, (depth, m_f.GetID(), m_featureLayer));
-
-    drule::BaseRule const * const dRule = drule::rules().Find(key);
-    if (dRule == nullptr)
-      return;
-    TRuleWrapper const rule({ dRule, static_cast<float>(depth), key.m_hatching, false });
-
-    if (dRule->GetCaption(0) != nullptr)
-    {
-      // Don't add a caption rule to m_rules immediately, put aside for further processing.
-      m_captionRule = rule;
-    }
-    else
-    {
-      // Lines can have zero width only if they have path symbols along.
-      ASSERT(dRule->GetLine() == nullptr || dRule->GetLine()->width() > 0 || dRule->GetLine()->has_pathsym(), ());
-
-      m_rules.push_back(rule);
-    }
-  }
-
-  void Init()
-  {
-    m_featureLayer = m_f.GetLayer();
-
-    if (m_geomType == feature::GeomType::Area)
-    {
-      // Calculate depth based on areas' bbox sizes instead of style-set priorities.
-      m2::RectD const r = m_f.GetLimitRect(m_zoomLevel);
-      // Raw areas' size range is about (1e-11, 3000).
-      double const areaSize = r.SizeX() * r.SizeY();
-      // Compacted range is approx (-37;13).
-      double constexpr kMinSize = -37,
-                       kMaxSize = 13,
-                       kStretchFactor = kDepthRangeBgBySize / (kMaxSize - kMinSize);
-
-      // Use log2() to have more precision distinguishing smaller areas.
-      /// @todo We still can get here with areaSize == 0.
-      double const areaSizeCompact = std::max(kMinSize, (areaSize > 0) ? std::log2(areaSize) : kMinSize);
-
-      // Adjust the range to fit into [kBaseDepthBgBySize, kBaseDepthBgTop].
-      m_areaDepth = kBaseDepthBgBySize + (kMaxSize - areaSizeCompact) * kStretchFactor;
-
-      ASSERT(kBaseDepthBgBySize <= m_areaDepth && m_areaDepth <= kBaseDepthBgTop,
-             (m_areaDepth, areaSize, areaSizeCompact, m_f.GetID()));
-    }
-  }
-
-  FeatureType & m_f;
-  feature::GeomType m_geomType;
-  int const m_zoomLevel;
-  int m_featureLayer;
-  double m_areaDepth;
-};
-}  // namespace
-
 IsHatchingTerritoryChecker::IsHatchingTerritoryChecker()
 {
   Classificator const & c = classif();
@@ -262,13 +40,13 @@ bool IsHatchingTerritoryChecker::IsMatched(uint32_t type) const
   return std::find(iEnd3, m_types.end(), PrepareToMatch(type, 2)) != m_types.end();
 }
 
-void CaptionDescription::Init(FeatureType & f, int8_t deviceLang, int const zoomLevel,
-                              feature::GeomType const type, bool const auxCaptionExists)
+void CaptionDescription::Init(FeatureType & f, int8_t deviceLang, int zoomLevel,
+                              feature::GeomType geomType, bool auxCaptionExists)
 {
   feature::NameParamsOut out;
   // TODO: remove forced secondary text for all lines and set it via styles for major roads and rivers only.
   // ATM even minor paths/streams/etc use secondary which makes their pathtexts take much more space.
-  if (zoomLevel > scales::GetUpperWorldScale() && (auxCaptionExists || type == feature::GeomType::Line))
+  if (zoomLevel > scales::GetUpperWorldScale() && (auxCaptionExists || geomType == feature::GeomType::Line))
   {
     // Get both primary and secondary/aux names.
     f.GetPreferredNames(true /* allowTranslit */, deviceLang, out);
@@ -299,7 +77,8 @@ void CaptionDescription::Init(FeatureType & f, int8_t deviceLang, int const zoom
   // TODO : its better to determine housenumbers minZoom once upon drules load and cache it,
   // but it'd mean a lot of housenumbers-specific logic in otherwise generic RulesHolder..
   uint8_t constexpr kHousenumbersMinZoom = 16;
-  if (zoomLevel >= kHousenumbersMinZoom && (auxCaptionExists || m_mainText.empty()))
+  if (geomType != feature::GeomType::Line && zoomLevel >= kHousenumbersMinZoom &&
+      (auxCaptionExists || m_mainText.empty()))
   {
     // TODO: its not obvious that a housenumber display is dependent on a secondary caption drule existance in styles.
     m_houseNumberText = f.GetHouseNumber();
@@ -308,14 +87,69 @@ void CaptionDescription::Init(FeatureType & f, int8_t deviceLang, int const zoom
   }
 }
 
-bool InitStylist(FeatureType & f, int8_t deviceLang, int const zoomLevel, bool buildings3d, Stylist & s)
+void Stylist::ProcessKey(FeatureType & f, drule::Key const & key)
+{
+  drule::BaseRule const * const dRule = drule::rules().Find(key);
+
+  auto const geomType = f.GetGeomType();
+  switch (key.m_type)
+  {
+  case drule::symbol:
+    ASSERT(dRule->GetSymbol() != nullptr && m_symbolRule == nullptr &&
+           (geomType == feature::GeomType::Point || geomType == feature::GeomType::Area),
+           (m_symbolRule == nullptr, geomType, f.DebugString(0, true)));
+    m_symbolRule = dRule;
+    break;
+  case drule::pathtext:
+  case drule::caption:
+    ASSERT(dRule->GetCaption(0) != nullptr, (f.DebugString(0, true)));
+    if (key.m_type == drule::caption)
+    {
+      ASSERT(m_captionRule == nullptr && (geomType == feature::GeomType::Point || geomType == feature::GeomType::Area),
+             (geomType, f.DebugString(0, true)));
+      m_captionRule = dRule;
+    }
+    else
+    {
+      ASSERT(m_pathtextRule == nullptr && geomType == feature::GeomType::Line,
+             (geomType, f.DebugString(0, true)));
+      m_pathtextRule = dRule;
+    }
+    break;
+  case drule::shield:
+    ASSERT(dRule->GetShield() != nullptr && m_shieldRule == nullptr && geomType == feature::GeomType::Line,
+           (m_shieldRule == nullptr, geomType, f.DebugString(0, true)));
+    m_shieldRule = dRule;
+    break;
+  case drule::line:
+    ASSERT(dRule->GetLine() != nullptr && geomType == feature::GeomType::Line, (geomType, f.DebugString(0, true)));
+    m_lineRules.push_back(dRule);
+    break;
+  case drule::area:
+    ASSERT(dRule->GetArea() != nullptr && geomType == feature::GeomType::Area, (geomType, f.DebugString(0, true)));
+    if (key.m_hatching)
+    {
+      ASSERT(m_hatchingRule == nullptr, (f.DebugString(0, true)));
+      m_hatchingRule = dRule;
+    }
+    else
+    {
+      ASSERT(m_areaRule == nullptr, (f.DebugString(0, true)));
+      m_areaRule = dRule;
+    }
+    break;
+  // TODO : check if circle/waymarker support exists still (not used in styles ATM).
+  case drule::circle:
+  case drule::waymarker:
+  default:
+    ASSERT(false, (key.m_type, f.DebugString(0, true)));
+    return;
+  }
+}
+
+Stylist::Stylist(FeatureType & f, uint8_t zoomLevel, int8_t deviceLang)
 {
   feature::TypesHolder const types(f);
-
-  if (!buildings3d && ftypes::IsBuildingPartChecker::Instance()(types) &&
-      !ftypes::IsBuildingChecker::Instance()(types))
-    return false;
-
   Classificator const & cl = classif();
 
   uint32_t mainOverlayType = 0;
@@ -350,7 +184,9 @@ bool InitStylist(FeatureType & f, int8_t deviceLang, int const zoomLevel, bool b
     for (auto & k : typeKeys)
     {
       // Take overlay drules from the main type only.
-      if (t == mainOverlayType || !IsTypeOf(k, Caption | Symbol | Shield | PathText))
+      if (t == mainOverlayType ||
+          (k.m_type != drule::caption && k.m_type != drule::symbol &&
+           k.m_type != drule::shield && k.m_type != drule::pathtext))
       {
         if (hasHatching && k.m_type == drule::area)
           k.m_hatching = true;
@@ -362,41 +198,21 @@ bool InitStylist(FeatureType & f, int8_t deviceLang, int const zoomLevel, bool b
   feature::FilterRulesByRuntimeSelector(f, zoomLevel, keys);
 
   if (keys.empty())
-    return false;
+    return;
 
   // Leave only one area drule and an optional hatching drule.
   drule::MakeUnique(keys);
 
-  s.m_isCoastline = types.Has(cl.GetCoastType());
+  for (auto const & key : keys)
+    ProcessKey(f, key);
 
-  switch (geomType)
+  if (m_captionRule != nullptr || m_pathtextRule != nullptr)
   {
-  case feature::GeomType::Point:
-    s.m_pointStyleExists = true;
-    break;
-  case feature::GeomType::Line :
-    s.m_lineStyleExists = true;
-    break;
-  case feature::GeomType::Area :
-    s.m_areaStyleExists = true;
-    break;
-  default:
-    ASSERT(false, ());
-    return false;
-  }
+    bool const auxExists = (m_captionRule != nullptr && m_captionRule->GetCaption(1) != nullptr) ||
+                           (m_pathtextRule != nullptr && m_pathtextRule->GetCaption(1) != nullptr);
+    m_captionDescriptor.Init(f, deviceLang, zoomLevel, geomType, auxExists);
 
-  Aggregator aggregator(f, geomType, zoomLevel, keys.size());
-  aggregator.AggregateKeys(keys);
-
-  if (aggregator.m_captionRule.m_rule != nullptr)
-  {
-    s.m_captionDescriptor.Init(f, deviceLang, zoomLevel, geomType,
-                               aggregator.m_captionRule.m_rule->GetCaption(1) != nullptr);
-
-    if (s.m_captionDescriptor.IsNameExists())
-      aggregator.m_rules.push_back(aggregator.m_captionRule);
-
-    if (s.m_captionDescriptor.IsHouseNumberExists())
+    if (m_captionDescriptor.IsHouseNumberExists())
     {
       bool isGood = true;
       if (zoomLevel < scales::GetUpperStyleScale())
@@ -419,33 +235,35 @@ bool InitStylist(FeatureType & f, int8_t deviceLang, int const zoomLevel, bool b
       {
         // Use building-address' caption drule to display house numbers.
         static auto const addressType = cl.GetTypeByPath({"building", "address"});
-        drule::KeysT addressKeys;
-        cl.GetObject(addressType)->GetSuitable(zoomLevel, geomType, addressKeys);
-        if (!addressKeys.empty())
+        if (mainOverlayType == addressType)
         {
-          // A caption drule exists for this zoom level.
-          ASSERT(addressKeys.size() == 1 && addressKeys[0].m_type == drule::caption,
-                 ("building-address should contain a caption drule only"));
-          drule::BaseRule const * const dRule = drule::rules().Find(addressKeys[0]);
-          ASSERT(dRule != nullptr, ());
-          TRuleWrapper const hnRule({ dRule, static_cast<float>(addressKeys[0].m_priority),
-                                      false, true /* m_isHouseNumber*/ });
-          aggregator.m_rules.push_back(hnRule);
+          // Optimization: just duplicate the drule if the main type is building-address.
+          ASSERT(m_captionRule != nullptr, ());
+          m_houseNumberRule = m_captionRule;
+        }
+        else
+        {
+          drule::KeysT addressKeys;
+          cl.GetObject(addressType)->GetSuitable(zoomLevel, geomType, addressKeys);
+          if (!addressKeys.empty())
+          {
+            // A caption drule exists for this zoom level.
+            ASSERT(addressKeys.size() == 1 && addressKeys[0].m_type == drule::caption,
+                   ("building-address should contain a caption drule only"));
+            m_houseNumberRule = drule::rules().Find(addressKeys[0]);
+          }
         }
       }
     }
+
+    if (!m_captionDescriptor.IsNameExists())
+    {
+      m_captionRule = nullptr;
+      m_pathtextRule = nullptr;
+    }
   }
 
-  aggregator.AggregateStyleFlags(keys, s.m_captionDescriptor.IsNameExists() || s.m_captionDescriptor.IsHouseNumberExists());
-
-  if (aggregator.m_pointStyleFound)
-    s.m_pointStyleExists = true;
-  if (aggregator.m_lineStyleFound)
-    s.m_lineStyleExists = true;
-
-  s.m_rules.swap(aggregator.m_rules);
-
-  return true;
+  m_isCoastline = types.Has(cl.GetCoastType());
 }
 
 }  // namespace df

--- a/drape_frontend/stylist.hpp
+++ b/drape_frontend/stylist.hpp
@@ -2,6 +2,7 @@
 
 #include "indexer/ftypes_matcher.hpp"
 #include "indexer/drawing_rule_def.hpp"
+#include "indexer/drawing_rules.hpp"
 
 #include "base/buffer_vector.hpp"
 
@@ -26,18 +27,9 @@ private:
   size_t m_type3end;
 };
 
-struct TRuleWrapper
-{
-  drule::BaseRule const * m_rule;
-  float m_depth;
-  bool m_hatching;
-  bool m_isHouseNumber;
-};
-
 struct CaptionDescription
 {
-  void Init(FeatureType & f, int8_t deviceLang, int const zoomLevel,
-            feature::GeomType const type, bool const auxCaptionExists);
+  void Init(FeatureType & f, int8_t deviceLang, int zoomLevel, feature::GeomType geomType, bool auxCaptionExists);
 
   std::string const & GetMainText() const { return m_mainText; }
   std::string const & GetAuxText() const { return m_auxText; }
@@ -56,30 +48,24 @@ class Stylist
 {
 public:
   bool m_isCoastline = false;
-  bool m_areaStyleExists = false;
-  bool m_lineStyleExists = false;
-  bool m_pointStyleExists = false;
+
+  drule::BaseRule const * m_symbolRule = nullptr;
+  drule::BaseRule const * m_captionRule = nullptr;
+  drule::BaseRule const * m_houseNumberRule = nullptr;
+  drule::BaseRule const * m_pathtextRule = nullptr;
+  drule::BaseRule const * m_shieldRule = nullptr;
+  drule::BaseRule const * m_areaRule = nullptr;
+  drule::BaseRule const * m_hatchingRule = nullptr;
+  buffer_vector<drule::BaseRule const *, 4> m_lineRules;
+
+  Stylist(FeatureType & f, uint8_t zoomLevel, int8_t deviceLang);
 
   CaptionDescription const & GetCaptionDescription() const { return m_captionDescriptor; }
 
-  template <class ToDo> void ForEachRule(ToDo && toDo) const
-  {
-    for (auto const & r : m_rules)
-      toDo(r);
-  }
-
-  bool IsEmpty() const { return m_rules.empty(); }
-
 private:
-  friend bool InitStylist(FeatureType & f, int8_t deviceLang, int const zoomLevel, bool buildings3d,
-                          Stylist & s);
-
-  typedef buffer_vector<TRuleWrapper, 8> rules_t;
-  rules_t m_rules;
+  void ProcessKey(FeatureType & f, drule::Key const & key);
 
   CaptionDescription m_captionDescriptor;
 };
 
-bool InitStylist(FeatureType & f, int8_t deviceLang, int const zoomLevel, bool buildings3d,
-                 Stylist & s);
 }  // namespace df

--- a/indexer/classificator.cpp
+++ b/indexer/classificator.cpp
@@ -239,7 +239,7 @@ namespace
         //{ line, area, symbol, caption, circle, pathtext, waymarker, shield }, see drule::Key::rule_type_t
         { 0, 0, 1, 1, 1, 0, 0, 0 },   // fpoint
         { 1, 0, 0, 0, 0, 1, 0, 1 },   // fline
-        { 1, 1, 1, 1, 1, 0, 0, 0 }    // farea (!!! different from IsDrawableLike(): here area feature can use point and line styles)
+        { 0, 1, 1, 1, 1, 0, 0, 0 }    // farea (!!! different from IsDrawableLike(): here area feature can use point styles)
       };
 
       if (visible[ft][i->m_type] == 1)

--- a/indexer/drawing_rule_def.hpp
+++ b/indexer/drawing_rule_def.hpp
@@ -2,6 +2,8 @@
 
 #include "base/buffer_vector.hpp"
 
+#include "indexer/feature.hpp"
+
 namespace drule
 {
 
@@ -15,17 +17,57 @@ double constexpr kLayerPriorityRange = 1000;
 // for optional captions which are below all other overlays.
 int32_t constexpr kOverlaysMaxPriority = 10000;
 
+/*
+* Besides overlays, the overall rendering depth range [dp::kMinDepth;dp::kMaxDepth] is divided
+* into following specific depth ranges:
+* FG - foreground lines and areas (buildings..), rendered on top of other geometry always,
+*      even if a fg feature is layer=-10 (e.g. tunnels should be visibile over landcover and water).
+* BG-top - rendered just on top of BG-by-size range, because ordering by size
+*      doesn't always work with e.g. water mapped over a forest,
+*      so water should be on top of other landcover always,
+*      but linear waterways should be hidden beneath it.
+* BG-by-size - landcover areas rendered in bbox size order, smaller areas are above larger ones.
+* Still, a BG-top water area with layer=-1 should go below other landcover,
+* and a layer=1 landcover area should be displayed above water,
+* so BG-top and BG-by-size should share the same "layer" space.
+*/
+
+// Priority values coming from style files are expected to be separated into following ranges.
+static double constexpr kBasePriorityFg = 0,
+                        kBasePriorityBgTop = -1000,
+                        kBasePriorityBgBySize = -2000;
+
+// Define depth ranges boundaries to accomodate for all possible layer=* values.
+// One layer space is drule::kLayerPriorityRange (1000). So each +1/-1 layer value shifts
+// depth of the drule by -1000/+1000.
+
+                        // FG depth range: [0;1000).
+static double constexpr kBaseDepthFg = 0,
+                        // layer=-10/10 gives an overall FG range of [-10000;11000).
+                        kMaxLayeredDepthFg = kBaseDepthFg + (1 + feature::LAYER_HIGH) * kLayerPriorityRange,
+                        kMinLayeredDepthFg = kBaseDepthFg + feature::LAYER_LOW * kLayerPriorityRange,
+                        // Split the background layer space as 100 for BG-top and 900 for BG-by-size.
+                        kBgTopRangeFraction = 0.1,
+                        kDepthRangeBgTop = kBgTopRangeFraction * kLayerPriorityRange,
+                        kDepthRangeBgBySize = kLayerPriorityRange - kDepthRangeBgTop,
+                        // So the BG-top range is [-10100,-10000).
+                        kBaseDepthBgTop = kMinLayeredDepthFg - kDepthRangeBgTop,
+                        // And BG-by-size range is [-11000,-10100).
+                        kBaseDepthBgBySize = kBaseDepthBgTop - kDepthRangeBgBySize,
+                        // Minimum BG depth for layer=-10 is -21000.
+                        kMinLayeredDepthBg = kBaseDepthBgBySize + feature::LAYER_LOW * kLayerPriorityRange;
+
   class Key
   {
   public:
-    int m_scale = -1;
+    uint8_t m_scale = -1;
     int m_type = -1;
     size_t m_index = std::numeric_limits<size_t>::max(); // an index to RulesHolder.m_dRules[]
     int m_priority = -1;
     bool m_hatching = false;
 
     Key() = default;
-    Key(int s, int t, size_t i) : m_scale(s), m_type(t), m_index(i), m_priority(-1) {}
+    Key(uint8_t s, int t, size_t i) : m_scale(s), m_type(t), m_index(i), m_priority(-1) {}
 
     bool operator==(Key const & r) const
     {
@@ -43,4 +85,5 @@ int32_t constexpr kOverlaysMaxPriority = 10000;
 
   typedef buffer_vector<Key, 16> KeysT;
   void MakeUnique(KeysT & keys);
+  double CalcAreaBySizeDepth(FeatureType & f);
 }

--- a/indexer/drawing_rules.cpp
+++ b/indexer/drawing_rules.cpp
@@ -35,7 +35,7 @@ namespace
   }
 } // namespace
 
-LineDefProto const * BaseRule::GetLine() const
+LineRuleProto const * BaseRule::GetLine() const
 {
   return 0;
 }
@@ -58,6 +58,11 @@ CaptionDefProto const * BaseRule::GetCaption(int) const
 text_type_t BaseRule::GetCaptionTextType(int) const
 {
   return text_type_name;
+}
+
+int BaseRule::GetCaptionsPriority() const
+{
+  return 0;
 }
 
 ShieldRuleProto const * BaseRule::GetShield() const
@@ -152,21 +157,11 @@ namespace
   {
     class Line : public BaseRule
     {
-      LineDefProto m_line;
+      LineRuleProto m_line;
     public:
-      explicit Line(LineRuleProto const & r)
-      {
-        m_line.set_color(r.color());
-        m_line.set_width(r.width());
-        m_line.set_join(r.join());
-        m_line.set_cap(r.cap());
-        if (r.has_dashdot())
-          *(m_line.mutable_dashdot()) = r.dashdot();
-        if (r.has_pathsym())
-          *(m_line.mutable_pathsym()) = r.pathsym();
-      }
+      explicit Line(LineRuleProto const & r) : m_line(r) {}
 
-      virtual LineDefProto const * GetLine() const { return &m_line; }
+      virtual LineRuleProto const * GetLine() const { return &m_line; }
     };
 
     class Area : public BaseRule
@@ -217,6 +212,11 @@ namespace
           else
             return 0;
         }
+      }
+
+      virtual int GetCaptionsPriority() const
+      {
+        return m_caption.priority();
       }
 
       virtual text_type_t GetCaptionTextType(int i) const

--- a/indexer/drawing_rules.hpp
+++ b/indexer/drawing_rules.hpp
@@ -16,7 +16,7 @@
 #include <unordered_map>
 #include <vector>
 
-class LineDefProto;
+class LineRuleProto;
 class AreaRuleProto;
 class SymbolRuleProto;
 class CaptionDefProto;
@@ -33,11 +33,12 @@ namespace drule
     BaseRule() = default;
     virtual ~BaseRule() = default;
 
-    virtual LineDefProto const * GetLine() const;
+    virtual LineRuleProto const * GetLine() const;
     virtual AreaRuleProto const * GetArea() const;
     virtual SymbolRuleProto const * GetSymbol() const;
     virtual CaptionDefProto const * GetCaption(int) const;
     virtual text_type_t GetCaptionTextType(int) const;
+    virtual int GetCaptionsPriority() const;
     virtual ShieldRuleProto const * GetShield() const;
 
     // Test feature by runtime feature style selector

--- a/indexer/feature.cpp
+++ b/indexer/feature.cpp
@@ -263,7 +263,7 @@ feature::GeomType FeatureType::GetGeomType() const
   {
   case HeaderGeomType::Line: return GeomType::Line;
   case HeaderGeomType::Area: return GeomType::Area;
-  default: return GeomType::Point;
+  default: return GeomType::Point; // HeaderGeomType::Point/PointEx
   }
 }
 
@@ -682,19 +682,13 @@ string FeatureType::DebugString(int scale, bool includeKeyPoint)
 
   case GeomType::Line:
     if (m_points.empty())
-    {
-      ASSERT(scale != FeatureType::WORST_GEOMETRY && scale != FeatureType::BEST_GEOMETRY, (scale));
       return res;
-    }
     keyPoint = m_points.front();
     break;
 
   case GeomType::Area:
     if (m_triangles.empty())
-    {
-      ASSERT(scale != FeatureType::WORST_GEOMETRY && scale != FeatureType::BEST_GEOMETRY, (scale));
       return res;
-    }
 
     ASSERT_GREATER(m_triangles.size(), 2, ());
     keyPoint = (m_triangles[0] + m_triangles[1] + m_triangles[2]) / 3.0;

--- a/indexer/feature_algo.cpp
+++ b/indexer/feature_algo.cpp
@@ -22,6 +22,8 @@ m2::PointD GetCenter(FeatureType & f, int scale)
   {
     return f.GetCenter();
   }
+  /// @todo cache calculated area and line centers, as calculation could be quite heavy for big features (and
+  /// involves geometry reading) and a center could be requested multiple times during e.g. search, PP opening, etc.
   case GeomType::Line:
   {
     m2::CalculatePolyLineCenter doCalc;

--- a/map/style_tests/dashes_test.cpp
+++ b/map/style_tests/dashes_test.cpp
@@ -13,7 +13,7 @@ UNIT_TEST(Test_Dashes)
   {
     drule::rules().ForEachRule([](drule::BaseRule const * rule)
     {
-      LineDefProto const * const line = rule->GetLine();
+      LineRuleProto const * const line = rule->GetLine();
       if (nullptr == line || !line->has_dashdot())
         return;
 

--- a/map/transit/transit_reader.cpp
+++ b/map/transit/transit_reader.cpp
@@ -165,15 +165,13 @@ void ReadTransitTask::Do()
 
     if (featureInfo.m_isGate)
     {
-      df::Stylist stylist;
-      if (df::InitStylist(ft, 0, 19, false, stylist))
+      //TODO: there should be a simpler way to just get a symbol name.
+      df::Stylist stylist(ft, 19, 0);
+      if (stylist.m_symbolRule != nullptr)
       {
-        stylist.ForEachRule([&](df::TRuleWrapper const & rule)
-        {
-          auto const * symRule = rule.m_rule->GetSymbol();
-          if (symRule != nullptr)
-            featureInfo.m_gateSymbolName = symRule->name();
-        });
+        auto const * symRule = stylist.m_symbolRule->GetSymbol();
+        ASSERT(symRule != nullptr, ());
+        featureInfo.m_gateSymbolName = symRule->name();
       }
     }
     featureInfo.m_point = feature::GetCenter(ft);


### PR DESCRIPTION
Depends on housenumbers PRs, so please check the last commit only!

Simplify the structure, reduce same parameters passing and storing several times, better division of classes' responsibilities, many smaller optimizations (like don't do various pre-processing if there are no drules that will use it), get rid of TRuleWrapper...

I plan to continue refactoring the related code in subsequent PRs:
- optimize drules filtering in Stylist and get rid of Key.m_hatching
- simplify apply_feature_functors and its communication with the RuleDrawer