### PR TITLE
[editor] Removed surveillance and made alpine_hut and wilderness_hut can_add=no

### DIFF
--- a/data/editor.config
+++ b/data/editor.config
@@ -779,7 +779,7 @@
       <type id="shop-watches" group="shop">
         <include group="poi_internet" />
       </type>
-      <type id="tourism-alpine_hut" group="accomodation">
+      <type id="tourism-alpine_hut" group="accomodation" can_add="no">
         <include group="poi_internet" />
         <include field="ele" />
         <include field="opening_hours" />
@@ -1094,12 +1094,13 @@
       <type id="building-address" can_add="no">
         <include group="address" />
       </type>
+      <!-- Uncomment this after a map style is added
       <type id="man_made-surveillance">
-      </type>
+      </type-->
       <type id="tourism-theme_park" can_add="no">
         <include group="poi_internet" />
       </type>
-      <type id="tourism-wilderness_hut" group="accomodation">
+      <type id="tourism-wilderness_hut" group="accomodation" can_add="no">
         <include group="poi_internet" />
       </type>
       <type id="man_made-water_tap">


### PR DESCRIPTION
- Removed `man_made=surveillance` ([Wiki](https://wiki.openstreetmap.org/wiki/Tag:man_made%3Dsurveillance)) form the editor as these features are not rendered on the map. Before you could add "invisible" features (which is asking for confusion and duplicates)
- Prevent users form adding new `tourism=alpine_hut` ([Wiki](https://wiki.openstreetmap.org/wiki/Tag:tourism%3Dalpine_hut)) and `tourism=wilderness_hut` ([Wiki](https://wiki.openstreetmap.org/wiki/Tag:tourism%3Dwilderness_hut)) locations as these places have quite strict/narrow OSM definitions that are not obvious from the name.