### PR TITLE
[ios] Transit panel scrollable

### DIFF
--- a/iphone/Maps/Classes/CustomViews/NavigationDashboard/Views/RoutePreview/MWMiPhoneRoutePreview.xib
+++ b/iphone/Maps/Classes/CustomViews/NavigationDashboard/Views/RoutePreview/MWMiPhoneRoutePreview.xib
@@ -22,7 +22,7 @@
             <autoresizingMask key="autoresizingMask" flexibleMinX="YES" flexibleMaxX="YES" flexibleMaxY="YES"/>
             <subviews>
                 <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="Ib5-qh-Cmo">
-                    <rect key="frame" x="0.0" y="34" width="320" height="48"/>
+                    <rect key="frame" x="0.0" y="48" width="320" height="48"/>
                     <subviews>
                         <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" adjustsImageWhenHighlighted="NO" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="ZXA-Og-q2I">
                             <rect key="frame" x="72.5" y="12" width="175" height="24"/>
@@ -54,10 +54,10 @@
                     </userDefinedRuntimeAttributes>
                 </view>
                 <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="WqK-Yb-PmP" customClass="SolidTouchView">
-                    <rect key="frame" x="0.0" y="20" width="320" height="14"/>
+                    <rect key="frame" x="0.0" y="20" width="320" height="28"/>
                     <subviews>
                         <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="wpf-tw-Coz" userLabel="Back">
-                            <rect key="frame" x="0.0" y="0.0" width="14" height="14"/>
+                            <rect key="frame" x="0.0" y="0.0" width="28" height="28"/>
                             <accessibility key="accessibilityConfiguration" identifier="goBackButton"/>
                             <constraints>
                                 <constraint firstAttribute="width" secondItem="wpf-tw-Coz" secondAttribute="height" multiplier="1:1" id="CvM-v4-Hlm"/>
@@ -68,7 +68,7 @@
                             </connections>
                         </button>
                         <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="oQc-l8-sZH" userLabel="Buttons Box">
-                            <rect key="frame" x="106" y="4" width="108" height="6"/>
+                            <rect key="frame" x="78" y="4" width="164" height="20"/>
                             <subviews>
                                 <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="cZF-Ha-2tB">
                                     <rect key="frame" x="6" y="0.0" width="40" height="40"/>
@@ -82,7 +82,7 @@
                                     </constraints>
                                 </view>
                                 <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="6D3-QF-6wm">
-                                    <rect key="frame" x="54" y="0.0" width="6" height="6"/>
+                                    <rect key="frame" x="54" y="0.0" width="20" height="20"/>
                                     <color key="backgroundColor" white="0.0" alpha="0.0" colorSpace="calibratedWhite"/>
                                     <accessibility key="accessibilityConfiguration" identifier="routePedestrian"/>
                                     <constraints>
@@ -90,7 +90,7 @@
                                     </constraints>
                                 </view>
                                 <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="yIt-eq-pV5">
-                                    <rect key="frame" x="68" y="0.0" width="6" height="6"/>
+                                    <rect key="frame" x="82" y="0.0" width="20" height="20"/>
                                     <color key="backgroundColor" red="0.0" green="0.0" blue="0.0" alpha="0.0" colorSpace="custom" customColorSpace="sRGB"/>
                                     <accessibility key="accessibilityConfiguration" identifier="routeAuto"/>
                                     <constraints>
@@ -98,7 +98,7 @@
                                     </constraints>
                                 </view>
                                 <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="FuO-c6-y9C" userLabel="Bicycle">
-                                    <rect key="frame" x="82" y="0.0" width="6" height="6"/>
+                                    <rect key="frame" x="110" y="0.0" width="20" height="20"/>
                                     <color key="backgroundColor" red="0.0" green="0.0" blue="0.0" alpha="0.0" colorSpace="custom" customColorSpace="sRGB"/>
                                     <accessibility key="accessibilityConfiguration" identifier="routeBicycle"/>
                                     <constraints>
@@ -106,7 +106,7 @@
                                     </constraints>
                                 </view>
                                 <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="15Q-ZN-NzE" userLabel="Ruler">
-                                    <rect key="frame" x="96" y="0.0" width="6" height="6"/>
+                                    <rect key="frame" x="138" y="0.0" width="20" height="20"/>
                                     <color key="backgroundColor" white="0.0" alpha="0.0" colorSpace="calibratedWhite"/>
                                     <accessibility key="accessibilityConfiguration" identifier="routeRuler"/>
                                     <constraints>
@@ -405,7 +405,7 @@
                     </userDefinedRuntimeAttributes>
                 </view>
                 <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Label" textAlignment="natural" lineBreakMode="tailTruncation" numberOfLines="3" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="Iu4-M8-t6g">
-                    <rect key="frame" x="16" y="12" width="41.5" height="20"/>
+                    <rect key="frame" x="16" y="12" width="41.5" height="20.5"/>
                     <constraints>
                         <constraint firstAttribute="height" relation="greaterThanOrEqual" constant="20" id="qgy-7x-cjR"/>
                     </constraints>
@@ -413,33 +413,50 @@
                     <nil key="textColor"/>
                     <nil key="highlightedColor"/>
                 </label>
-                <collectionView userInteractionEnabled="NO" contentMode="scaleToFill" alwaysBounceVertical="YES" alwaysBounceHorizontal="YES" scrollEnabled="NO" showsHorizontalScrollIndicator="NO" showsVerticalScrollIndicator="NO" delaysContentTouches="NO" canCancelContentTouches="NO" bouncesZoom="NO" dataMode="none" prefetchingEnabled="NO" translatesAutoresizingMaskIntoConstraints="NO" id="RVh-LF-kSn" customClass="TransportTransitStepsCollectionView" customModule="Organic_Maps" customModuleProvider="target">
-                    <rect key="frame" x="16" y="44" width="288" height="20"/>
-                    <color key="backgroundColor" white="0.0" alpha="0.0" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
+                <scrollView clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="GZd-C3-csB">
+                    <rect key="frame" x="16" y="48.5" width="288" height="15.5"/>
+                    <subviews>
+                        <collectionView userInteractionEnabled="NO" contentMode="scaleToFill" alwaysBounceVertical="YES" alwaysBounceHorizontal="YES" scrollEnabled="NO" showsHorizontalScrollIndicator="NO" showsVerticalScrollIndicator="NO" delaysContentTouches="NO" canCancelContentTouches="NO" bouncesZoom="NO" dataMode="none" prefetchingEnabled="NO" translatesAutoresizingMaskIntoConstraints="NO" id="RVh-LF-kSn" customClass="TransportTransitStepsCollectionView" customModule="Organic_Maps" customModuleProvider="target">
+                            <rect key="frame" x="0.0" y="0.0" width="288" height="20"/>
+                            <color key="backgroundColor" white="0.0" alpha="0.0" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
+                            <constraints>
+                                <constraint firstAttribute="height" relation="greaterThanOrEqual" constant="20" id="eGu-Mr-auv"/>
+                            </constraints>
+                            <collectionViewLayout key="collectionViewLayout" id="d3P-nT-IFD" customClass="TransportTransitFlowLayout" customModule="Organic_Maps" customModuleProvider="target"/>
+                        </collectionView>
+                    </subviews>
                     <constraints>
-                        <constraint firstAttribute="height" relation="greaterThanOrEqual" constant="20" id="eGu-Mr-auv"/>
+                        <constraint firstAttribute="height" relation="lessThanOrEqual" constant="100" id="IGc-CI-aOh"/>
+                        <constraint firstAttribute="height" secondItem="RVh-LF-kSn" secondAttribute="height" priority="500" id="NQX-zx-17G"/>
+                        <constraint firstItem="RVh-LF-kSn" firstAttribute="width" secondItem="gf4-x6-D2B" secondAttribute="width" id="d10-d7-7DD"/>
+                        <constraint firstItem="RVh-LF-kSn" firstAttribute="leading" secondItem="k3L-Ml-bDX" secondAttribute="leading" id="fhs-TD-7km"/>
+                        <constraint firstItem="RVh-LF-kSn" firstAttribute="trailing" secondItem="k3L-Ml-bDX" secondAttribute="trailing" id="jZG-5W-KKC"/>
+                        <constraint firstItem="RVh-LF-kSn" firstAttribute="top" secondItem="k3L-Ml-bDX" secondAttribute="top" id="lDC-Pw-RQO"/>
+                        <constraint firstItem="RVh-LF-kSn" firstAttribute="bottom" secondItem="k3L-Ml-bDX" secondAttribute="bottom" id="yz7-c7-AZq"/>
                     </constraints>
-                    <collectionViewLayout key="collectionViewLayout" id="d3P-nT-IFD" customClass="TransportTransitFlowLayout" customModule="Organic_Maps" customModuleProvider="target"/>
-                </collectionView>
+                    <viewLayoutGuide key="contentLayoutGuide" id="k3L-Ml-bDX"/>
+                    <viewLayoutGuide key="frameLayoutGuide" id="gf4-x6-D2B"/>
+                </scrollView>
             </subviews>
             <viewLayoutGuide key="safeArea" id="YJK-Xe-9oN"/>
             <color key="backgroundColor" white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
             <constraints>
+                <constraint firstAttribute="bottom" secondItem="GZd-C3-csB" secondAttribute="bottom" constant="16" id="3OD-DZ-eZI"/>
                 <constraint firstItem="Iu4-M8-t6g" firstAttribute="leading" secondItem="iWi-pM-AJF" secondAttribute="leading" constant="16" id="5Ge-fx-3pw"/>
                 <constraint firstAttribute="height" relation="greaterThanOrEqual" constant="40" id="CQk-tf-wu9"/>
-                <constraint firstItem="RVh-LF-kSn" firstAttribute="top" secondItem="Iu4-M8-t6g" secondAttribute="bottom" constant="12" id="DOH-Jl-zYW"/>
-                <constraint firstItem="RVh-LF-kSn" firstAttribute="leading" secondItem="Iu4-M8-t6g" secondAttribute="leading" id="Jo0-dN-03y"/>
+                <constraint firstAttribute="trailing" secondItem="GZd-C3-csB" secondAttribute="trailing" constant="16" id="FUK-GV-FoZ"/>
+                <constraint firstItem="GZd-C3-csB" firstAttribute="top" secondItem="Iu4-M8-t6g" secondAttribute="bottom" constant="16" id="JrG-NF-7zG"/>
                 <constraint firstItem="Iu4-M8-t6g" firstAttribute="top" secondItem="iWi-pM-AJF" secondAttribute="top" constant="12" id="Zyw-PT-55a"/>
-                <constraint firstAttribute="bottom" secondItem="RVh-LF-kSn" secondAttribute="bottom" constant="16" id="b0R-Xj-EVN"/>
                 <constraint firstAttribute="bottom" secondItem="uA3-5h-DWb" secondAttribute="bottom" constant="-100" id="jN1-5h-bPC"/>
+                <constraint firstItem="GZd-C3-csB" firstAttribute="leading" secondItem="Iu4-M8-t6g" secondAttribute="leading" id="ktT-ZB-5HK"/>
                 <constraint firstItem="uA3-5h-DWb" firstAttribute="top" secondItem="iWi-pM-AJF" secondAttribute="top" id="nhC-d5-VpO"/>
-                <constraint firstAttribute="trailing" secondItem="RVh-LF-kSn" secondAttribute="trailing" constant="16" id="nhh-en-tgm"/>
                 <constraint firstAttribute="trailing" secondItem="uA3-5h-DWb" secondAttribute="trailing" constant="-100" id="wP2-ul-QVl"/>
                 <constraint firstItem="uA3-5h-DWb" firstAttribute="leading" secondItem="iWi-pM-AJF" secondAttribute="leading" constant="-100" id="zCP-aF-HvA"/>
             </constraints>
             <freeformSimulatedSizeMetrics key="simulatedDestinationMetrics"/>
             <connections>
                 <outlet property="etaLabel" destination="Iu4-M8-t6g" id="hJe-KS-ctT"/>
+                <outlet property="stepsCollectionScrollView" destination="GZd-C3-csB" id="fFk-g4-SOl"/>
                 <outlet property="stepsCollectionView" destination="RVh-LF-kSn" id="3uG-nE-mt3"/>
                 <outlet property="stepsCollectionViewHeight" destination="eGu-Mr-auv" id="K2J-yO-yQ5"/>
             </connections>

--- a/iphone/Maps/Classes/CustomViews/NavigationDashboard/Views/RoutePreview/RoutePreviewStatus/TransportRoutePreviewStatus.swift
+++ b/iphone/Maps/Classes/CustomViews/NavigationDashboard/Views/RoutePreview/RoutePreviewStatus/TransportRoutePreviewStatus.swift
@@ -61,6 +61,11 @@ final class TransportRoutePreviewStatus: SolidTouchView {
       self.animateConstraints(animations: {
         self.stepsCollectionViewHeight.constant = self.stepsCollectionView.contentSize.height
       })
+
+      if let sv = self.stepsCollectionScrollView {
+        let bottomOffset = CGPoint(x: 0, y: sv.contentSize.height - sv.bounds.size.height)
+        sv.setContentOffset(bottomOffset, animated: true)
+      }
     }
   }
 

--- a/iphone/Maps/Classes/CustomViews/NavigationDashboard/Views/RoutePreview/RoutePreviewStatus/TransportRoutePreviewStatus.swift
+++ b/iphone/Maps/Classes/CustomViews/NavigationDashboard/Views/RoutePreview/RoutePreviewStatus/TransportRoutePreviewStatus.swift
@@ -3,6 +3,7 @@ final class TransportRoutePreviewStatus: SolidTouchView {
   @IBOutlet private weak var etaLabel: UILabel!
   @IBOutlet private weak var stepsCollectionView: TransportTransitStepsCollectionView!
   @IBOutlet private weak var stepsCollectionViewHeight: NSLayoutConstraint!
+  @IBOutlet private weak var stepsCollectionScrollView: UIScrollView?
 
   @objc weak var ownerView: UIView!
 
@@ -51,6 +52,7 @@ final class TransportRoutePreviewStatus: SolidTouchView {
     stepsCollectionView.steps = info.transitSteps
 
     stepsCollectionView.isHidden = info.transitSteps.isEmpty
+    stepsCollectionScrollView?.isHidden = info.transitSteps.isEmpty
   }
 
   private func updateHeight() {


### PR DESCRIPTION
Closes #5880.

Demo:

https://github.com/organicmaps/organicmaps/assets/720808/96203ebe-9bc4-4639-9aea-11cca0c7646f

Also scrollable on iPad:

<img src="https://github.com/organicmaps/organicmaps/assets/720808/0d79117a-c6c1-44f4-bf0c-ea50a8adf3ef" width="300px"/>


| Layout before | Layout after |
| ---- | ---- |
| <img alt="layout-before" src="https://github.com/organicmaps/organicmaps/assets/720808/0eb3205c-73c9-40f5-9685-00dc7a2d7261" width="300px"/> | <img alt="layout-after" src="https://github.com/organicmaps/organicmaps/assets/720808/afc2517e-17fa-431f-8a01-68fabdee0240" width="300px"/> |

**Question:** Is max height enough?