### PR TITLE
[Android] Fixed zoom buttons position after Android unlock

### DIFF
--- a/android/app/src/main/java/app/organicmaps/MwmActivity.java
+++ b/android/app/src/main/java/app/organicmaps/MwmActivity.java
@@ -829,9 +829,10 @@ public class MwmActivity extends BaseMwmFragmentActivity
   private void initMainMenu()
   {
     final View menuFrame = findViewById(R.id.menu_frame);
-    mMainMenu = new MainMenu(menuFrame, () -> {
+    mMainMenu = new MainMenu(menuFrame, (visible) -> {
       this.updateBottomWidgetsOffset();
-      mPlacePageViewModel.setPlacePageDistanceToTop(menuFrame.getTop());
+      if (visible)
+        mPlacePageViewModel.setPlacePageDistanceToTop(menuFrame.getTop());
     });
 
     if (mIsTabletLayout)
@@ -1272,11 +1273,9 @@ public class MwmActivity extends BaseMwmFragmentActivity
   @Override
   public void updateMenu()
   {
-    boolean isVisible = adjustMenuLineFrameVisibility();
-    if (!isVisible)
-      return;
+    final RoutingController controller = RoutingController.get();
 
-    if (RoutingController.get().isNavigating())
+    if (controller.isNavigating())
     {
       mNavigationController.show(true);
       closeSearchToolbar(false, false);
@@ -1284,39 +1283,25 @@ public class MwmActivity extends BaseMwmFragmentActivity
       return;
     }
 
-    if (RoutingController.get().isPlanning())
-    {
-      mMainMenu.setState(MainMenu.State.ROUTE_PREPARE, isFullscreen());
-      return;
-    }
-
-    mMainMenu.setState(MainMenu.State.MENU, isFullscreen());
-  }
-
-  private boolean adjustMenuLineFrameVisibility()
-  {
-    final RoutingController controller = RoutingController.get();
-
     if (controller.isBuilt())
     {
       showMainMenu(true);
-      return true;
+      return;
     }
 
     if (controller.isPlanning() || controller.isBuilding() || controller.isErrorEncountered())
     {
       if (showAddStartOrFinishFrame(controller, true))
-      {
-        return true;
-      }
+        return;
 
-      showMainMenu(false);
-      return false;
+      if (controller.isPlanning())
+      {
+        mMainMenu.setState(MainMenu.State.ROUTE_PREPARE, isFullscreen());
+        return;
+      }
     }
 
-    hideRoutingActionFrame();
-    showMainMenu(true);
-    return true;
+    mMainMenu.setState(MainMenu.State.MENU, isFullscreen());
   }
 
   private boolean showAddStartOrFinishFrame(@NonNull RoutingController controller,

--- a/android/app/src/main/java/app/organicmaps/widget/menu/MainMenu.java
+++ b/android/app/src/main/java/app/organicmaps/widget/menu/MainMenu.java
@@ -29,7 +29,7 @@ public class MainMenu
       return;
 
     UiUtils.showIf(show, mFrame);
-    mOnMenuSizeChangedListener.OnMenuSizeChange();
+    mOnMenuSizeChangedListener.OnMenuSizeChange(show);
   }
 
   public int getMenuHeight()
@@ -59,7 +59,7 @@ public class MainMenu
 
   public interface OnMenuSizeChangedListener
   {
-    void OnMenuSizeChange();
+    void OnMenuSizeChange(boolean visible);
   }
 
   private class FrameLayoutChangeListener implements View.OnLayoutChangeListener
@@ -69,7 +69,7 @@ public class MainMenu
                                int oldTop, int oldRight, int oldBottom)
     {
       mMenuHeight = bottom - top;
-      mOnMenuSizeChangedListener.OnMenuSizeChange();
+      mOnMenuSizeChangedListener.OnMenuSizeChange(UiUtils.isVisible(mFrame));
     }
   }
 }


### PR DESCRIPTION
**Problem:** On Android zoom buttons disappear after phone is locked and unlocked.

**First change:** we don't need to adjust zoom buttons using `menuFrame.getTop()` when menu is hidden.

**Second change:** review of `public void updateMenu()` method. It shows and hides menu multiple times in its body. Changed to single action: hide menu once or show once.