### PR TITLE
[android] Fix corrupted GPS follow icon on Xperia E5

### DIFF
--- a/android/app/src/main/res/drawable/ic_follow.xml
+++ b/android/app/src/main/res/drawable/ic_follow.xml
@@ -1,5 +1,5 @@
 <vector android:height="24dp" android:tint="#FFFFFF"
     android:viewportHeight="24" android:viewportWidth="24"
     android:width="24dp" xmlns:android="http://schemas.android.com/apk/res/android">
-    <path android:fillColor="@android:color/white" android:pathData="m20.214641 3.7904477-18 7.5300003v0.97l6.84 2.66 2.6599999 6.84h0.96z"/>
+    <path android:fillColor="@android:color/white" android:pathData="M 20.215 3.79 L 2.215 11.32 L 2.215 12.29 L 9.055 14.95 L 11.715 21.79 L 12.675 21.79 Z"/>
 </vector>


### PR DESCRIPTION
by regenerating path data with https://shapeshifter.design/
Resolves #6063