### PR TITLE
Intermediate points fix with ruler

### DIFF
--- a/map/routing_manager.cpp
+++ b/map/routing_manager.cpp
@@ -870,7 +870,7 @@ void RoutingManager::ContinueRouteToPoint(RouteMarkData && markData)
   // Finish point is now Intermediate point
   RouteMarkPoint * finishMarkData = routePoints.GetRoutePointForEdit(RouteMarkType::Finish);
   finishMarkData->SetRoutePointType(RouteMarkType::Intermediate);
-  finishMarkData->SetIntermediateIndex(routePoints.GetRoutePointsCount()-1);
+  finishMarkData->SetIntermediateIndex(routePoints.GetRoutePointsCount() - 2);
 
   if (markData.m_isMyPosition)
   {
@@ -879,7 +879,7 @@ void RoutingManager::ContinueRouteToPoint(RouteMarkData && markData)
       routePoints.RemoveRoutePoint(mark->GetRoutePointType(), mark->GetIntermediateIndex());
   }
 
-  markData.m_intermediateIndex = routePoints.GetRoutePointsCount();
+  markData.m_intermediateIndex = routePoints.GetRoutePointsCount() - 1;
   markData.m_isVisible = !markData.m_isMyPosition;
   routePoints.AddRoutePoint(std::move(markData));
 }


### PR DESCRIPTION
Bug:
![photo_2023-09-19_16-48-54](https://github.com/organicmaps/organicmaps/assets/720808/281782cb-a76c-40ed-ac8a-321ad2d019b8)

Intermediate points are numbered from 0 even if on the map we see them starting from 1.