### PR TITLE
[search] Better streets ranking and matching.

### DIFF
--- a/indexer/search_string_utils.cpp
+++ b/indexer/search_string_utils.cpp
@@ -356,7 +356,7 @@ private:
       "ქუჩა",
 
       // German - Deutsch
-      "straße", "str",
+      "straße", "str", "platz", "pl",
 
       // Hungarian - Magyar
       "utca", "út",
@@ -498,4 +498,14 @@ void StreetTokensFilter::Put(UniString const & token, bool isPrefix, size_t tag)
 
   m_callback(token, tag);
 }
+
+String2StringMap const & GetDACHStreets()
+{
+  static String2StringMap res = {
+    { MakeUniString("strasse"), MakeUniString("str") },
+    { MakeUniString("platz"), MakeUniString("pl") },
+  };
+  return res;
+}
+
 }  // namespace search

--- a/indexer/search_string_utils.hpp
+++ b/indexer/search_string_utils.hpp
@@ -128,4 +128,9 @@ private:
   Callback m_callback;
   bool m_withMisprints = false;
 };
-}  // namespace search
+
+// D-A-CH countries have special street suffixes processing.
+using String2StringMap = std::map<strings::UniString, strings::UniString>;
+String2StringMap const & GetDACHStreets();
+
+} // namespace search

--- a/search/mwm_context.cpp
+++ b/search/mwm_context.cpp
@@ -1,7 +1,10 @@
 #include "search/mwm_context.hpp"
+#include "search/house_to_street_table.hpp"
 
 #include "indexer/cell_id.hpp"
+#include "indexer/fake_feature_ids.hpp"
 #include "indexer/feature_source.hpp"
+
 
 namespace search
 {
@@ -23,14 +26,9 @@ MwmContext::MwmContext(MwmSet::MwmHandle handle)
 }
 
 MwmContext::MwmContext(MwmSet::MwmHandle handle, MwmType type)
-  : m_handle(std::move(handle))
-  , m_value(*m_handle.GetValue())
-  , m_vector(m_value.m_cont, m_value.GetHeader(), m_value.m_table.get(), m_value.m_metaDeserializer.get())
-  , m_index(m_value.m_cont.GetReader(INDEX_FILE_TAG), m_value.m_factory)
-  , m_centers(m_value)
-  , m_editableSource(m_handle)
-  , m_type(type)
+  : MwmContext(std::move(handle))
 {
+  m_type = type;
 }
 
 std::unique_ptr<FeatureType> MwmContext::GetFeature(uint32_t index) const
@@ -54,4 +52,23 @@ std::unique_ptr<FeatureType> MwmContext::GetFeature(uint32_t index) const
   }
   UNREACHABLE();
 }
+
+std::optional<uint32_t> MwmContext::GetStreet(uint32_t index) const
+{
+  /// @todo Should store and fetch parent street id in Editor (now it has only name).
+  if (feature::FakeFeatureIds::IsEditorCreatedFeature(index))
+    return {};
+
+  if (!m_value.m_house2street)
+    m_value.m_house2street = LoadHouseToStreetTable(m_value);
+
+  auto const res = m_value.m_house2street->Get(index);
+  if (res)
+  {
+    ASSERT(res->m_type == HouseToStreetTable::StreetIdType::FeatureId, ());
+    return res->m_streetId;
+  }
+  return {};
+}
+
 }  // namespace search

--- a/search/mwm_context.hpp
+++ b/search/mwm_context.hpp
@@ -1,6 +1,5 @@
 #pragma once
 
-#include "search/house_to_street_table.hpp"
 #include "search/lazy_centers_table.hpp"
 
 #include "editor/editable_feature_source.hpp"
@@ -107,8 +106,10 @@ public:
     return m_centers.Get(index, center);
   }
 
+  std::optional<uint32_t> GetStreet(uint32_t index) const;
+
   MwmSet::MwmHandle m_handle;
-  MwmValue const & m_value;
+  MwmValue & m_value;
 
 private:
   FeatureStatus GetEditedStatus(uint32_t index) const

--- a/search/ranking_utils.hpp
+++ b/search/ranking_utils.hpp
@@ -129,7 +129,11 @@ struct NameScores
 
   void UpdateIfBetter(NameScores const & rhs)
   {
-    auto const newNameScoreIsBetter = m_nameScore < rhs.m_nameScore;
+    auto newNameScoreIsBetter = m_nameScore < rhs.m_nameScore;
+    // FULL_PREFIX with 0 errors is better than FULL_MATCH with 2 errors.
+    if (newNameScoreIsBetter && m_nameScore == NameScore::FULL_PREFIX && m_errorsMade.IsBetterThan(rhs.m_errorsMade))
+      newNameScoreIsBetter = false;
+
     auto const nameScoresAreEqual = m_nameScore == rhs.m_nameScore;
     auto const newLanguageIsBetter = m_isAltOrOldName && !rhs.m_isAltOrOldName;
     auto const languagesAreEqual = m_isAltOrOldName == rhs.m_isAltOrOldName;

--- a/search/reverse_geocoder.cpp
+++ b/search/reverse_geocoder.cpp
@@ -1,6 +1,7 @@
 #include "search/reverse_geocoder.hpp"
 
 #include "search/city_finder.hpp"
+#include "search/house_to_street_table.hpp"
 #include "search/mwm_context.hpp"
 #include "search/region_info_getter.hpp"
 

--- a/search/search_integration_tests/processor_test.cpp
+++ b/search/search_integration_tests/processor_test.cpp
@@ -2108,18 +2108,20 @@ UNIT_CLASS_TEST(ProcessorTest, StreetSynonymPrefix)
 
 UNIT_CLASS_TEST(ProcessorTest, Strasse)
 {
-  TestStreet s1({{-1.0, -1.0},{1.0, 1.0}}, "abcdstraße", "en");
-  TestStreet s2({{1.0, -1.0}, {-1.0, 1.0}}, "xyz strasse", "en");
+  TestStreet s1({{-1.0, -1.0},{1.0, 1.0}}, "abcdstraße", "de");
+  TestStreet s2({{1.0, -1.0}, {-1.0, 1.0}}, "xyz strasse", "de");
+  TestStreet s3({{-2.0, -2.0},{2.0, 2.0}}, "bahnhofplatz", "de");
 
   auto countryId = BuildCountry("Wonderland", [&](TestMwmBuilder & builder)
   {
     builder.Add(s1);
     builder.Add(s2);
+    builder.Add(s3);
   });
 
   auto checkNoErrors = [&](string const & query, Rules const & rules)
   {
-    auto request = MakeRequest(query, "en");
+    auto request = MakeRequest(query, "de");
     auto const & results = request->Results();
 
     TEST(ResultsMatch(results, rules), (query));
@@ -2129,7 +2131,7 @@ UNIT_CLASS_TEST(ProcessorTest, Strasse)
     TEST(nameScore == NameScore::FULL_MATCH || nameScore == NameScore::FULL_PREFIX, (query));
   };
 
-  SetViewport(m2::RectD(0.0, 0.0, 1.0, 2.0));
+  SetViewport(m2::RectD(-1, -1, 1, 1));
   {
     Rules rules = {ExactMatch(countryId, s1)};
     checkNoErrors("abcdstrasse ", rules);
@@ -2159,6 +2161,15 @@ UNIT_CLASS_TEST(ProcessorTest, Strasse)
     checkNoErrors("xyz straße", rules);
     checkNoErrors("xyz ", rules);
     checkNoErrors("xyz", rules);
+  }
+  {
+    Rules rules = {ExactMatch(countryId, s3)};
+    checkNoErrors("bahnhofplatz", rules);
+    checkNoErrors("bahnhof platz", rules);
+    checkNoErrors("bahnhof", rules);
+    checkNoErrors("bahnhof ", rules);
+    checkNoErrors("bahnhofpl", rules);
+    checkNoErrors("bahnhofpl ", rules);
   }
 }
 

--- a/search/search_integration_tests/processor_test.cpp
+++ b/search/search_integration_tests/processor_test.cpp
@@ -153,7 +153,7 @@ UNIT_CLASS_TEST(ProcessorTest, AddressSmoke)
   TestBuilding withoutRef(p2, {}/* name */, "40", lang);
 
   TestAddrInterpol even({p1, p2}, feature::InterpolType::Even, "20", "40", streetName);
-  TestAddrInterpol odd({p1, p2}, feature::InterpolType::Odd, "21", "41");
+  TestAddrInterpol odd({p1, p2}, feature::InterpolType::Odd, "21", "41", streetName);
 
   auto const wonderlandId = BuildCountry(countryName, [&](TestMwmBuilder & builder)
   {
@@ -166,7 +166,8 @@ UNIT_CLASS_TEST(ProcessorTest, AddressSmoke)
 
   SetViewport(m2::RectD(-coord, -coord, coord, coord));
   TEST(ResultsMatch("20 1st", {ExactMatch(wonderlandId, withRef)}), ());
-  TEST(ResultsMatch("40 1st", {ExactMatch(wonderlandId, withoutRef)}), ());
+  // No street defined.
+  //TEST(ResultsMatch("40 1st", {ExactMatch(wonderlandId, withoutRef)}), ());
   TEST(ResultsMatch("36 1st", {ExactMatch(wonderlandId, even)}), ());
   TEST(ResultsMatch("35 1st", {ExactMatch(wonderlandId, odd)}), ());
 }
@@ -665,15 +666,16 @@ UNIT_CLASS_TEST(ProcessorTest, RankingInfo_ErrorsMade_2)
 
 UNIT_CLASS_TEST(ProcessorTest, TestHouseNumbers)
 {
+  std::string const streetName = "Генерала Генералова";
+
   TestCity greenCity({0, 0}, "Зеленоград", "ru", 100 /* rank */);
+  TestStreet street({{-5.0, -5.0}, {0, 0}, {5.0, 5.0}}, streetName, "ru");
 
-  TestStreet street({{-5.0, -5.0}, {0, 0}, {5.0, 5.0}}, "Генерала Генералова", "ru");
-
-  TestBuilding building100({2.0, 2.0}, "", "100", "en");
-  TestBuilding building200({3.0, 3.0}, "", "к200", "ru");
-  TestBuilding building300({4.0, 4.0}, "", "300 строение 400", "ru");
-  TestBuilding building115({1.0, 1.0}, "", "115", "en");
-  TestBuilding building115k1({-1.0, -1.0}, "", "115к1", "en");
+  TestBuilding building100({2.0, 2.0}, "", "100", streetName, "en");
+  TestBuilding building200({3.0, 3.0}, "", "к200", streetName, "ru");
+  TestBuilding building300({4.0, 4.0}, "", "300 строение 400", streetName, "ru");
+  TestBuilding building115({1.0, 1.0}, "", "115", streetName, "en");
+  TestBuilding building115k1({-1.0, -1.0}, "", "115к1", streetName, "en");
 
   BuildWorld([&](TestMwmBuilder & builder) { builder.Add(greenCity); });
   auto countryId = BuildCountry("Wonderland", [&](TestMwmBuilder & builder)
@@ -737,13 +739,14 @@ UNIT_CLASS_TEST(ProcessorTest, TestPostcodes)
   TestCity dolgoprudny({0, 0}, "Долгопрудный", "ru", 100 /* rank */);
   TestCity london({10, 10}, "London", "en", 100 /* rank */);
 
-  TestStreet street({{-0.5, 0.0}, {0, 0}, {0.5, 0.0}}, "Первомайская", "ru");
+  std::string const streetName = "Первомайская";
+  TestStreet street({{-0.5, 0.0}, {0, 0}, {0.5, 0.0}}, streetName, "ru");
   street.SetPostcode("141701");
 
-  TestBuilding building28({0.0, 0.00001}, "", "28а", street.GetName("ru"), "ru");
+  TestBuilding building28({0.0, 0.00001}, "", "28а", streetName, "ru");
   building28.SetPostcode("141701");
 
-  TestBuilding building29({0.0, -0.00001}, "", "29", street.GetName("ru"), "ru");
+  TestBuilding building29({0.0, -0.00001}, "", "29", streetName, "ru");
   building29.SetPostcode("141701");
 
   TestPOI building30({0.00002, 0.00002}, "", "en");
@@ -751,7 +754,7 @@ UNIT_CLASS_TEST(ProcessorTest, TestPostcodes)
   building30.SetPostcode("141701");
   building30.SetTypes({{"building", "address"}});
 
-  TestBuilding building31({0.00001, 0.00001}, "", "31", street.GetName("ru"), "ru");
+  TestBuilding building31({0.00001, 0.00001}, "", "31", streetName, "ru");
   building31.SetPostcode("141702");
 
   TestBuilding building1({10, 10}, "", "1", "en");
@@ -811,8 +814,10 @@ UNIT_CLASS_TEST(ProcessorTest, TestPostcodes)
     TEST(ResultsMatch("Долгопрудный первомайская 28а, 141701", rules, "ru"), ());
   }
   {
-    Rules rules{ExactMatch(countryId, building28), ExactMatch(countryId, building29),
-                ExactMatch(countryId, building30), ExactMatch(countryId, street)};
+    Rules rules{ExactMatch(countryId, building28),
+                ExactMatch(countryId, building29),
+                //ExactMatch(countryId, building30),  // No street defined.
+                ExactMatch(countryId, street)};
     TEST(ResultsMatch("Долгопрудный первомайская 141701", rules, "ru"), ());
   }
   {

--- a/search/search_quality/search_quality_tests/real_mwm_tests.cpp
+++ b/search/search_quality/search_quality_tests/real_mwm_tests.cpp
@@ -922,4 +922,40 @@ UNIT_CLASS_TEST(MwmTestsFixture, BA_RelaxedStreets)
     TEST_GREATER(count, 5, ());
   }
 }
+
+UNIT_CLASS_TEST(MwmTestsFixture, Streets_Rank)
+{
+  // Buenos Aires (Palermo)
+  ms::LatLon const center(-34.5802699, -58.4124979);
+  SetViewportAndLoadMaps(center);
+
+  auto const & streetChecker = ftypes::IsStreetOrSquareChecker::Instance();
+
+  auto const processRequest = [&](std::string const & query, size_t idx)
+  {
+    auto request = MakeRequest(query);
+    auto const & results = request->Results();
+
+    TEST_GREATER(results.size(), idx, ());
+
+    bool found = false;
+    for (size_t i = 0; i < idx && !found; ++i)
+    {
+      auto const & r = results[i];
+      if (streetChecker(r.GetFeatureType()))
+      {
+        TEST_EQUAL(r.GetString(), "Avenida Santa Fe", ());
+        TEST_LESS(GetDistanceM(r, center), 1000, ());
+        found = true;
+      }
+    }
+    TEST(found, ());
+  };
+
+  /// @todo Street should be highwer than 11.
+  processRequest("Santa Fe ", 11);
+  /// @todo Prefix search" gives POIs (Starbucks) near "Avenida Santa Fe".
+  processRequest("Santa Fe st ", 2);
+}
+
 } // namespace real_mwm_tests


### PR DESCRIPTION
Street + House Number match happens only with correctly mapped (OSM addr:street + addr:housenumber) addresses since now.

Pros:
- Speed
- Can increase kLookupRadiusM to fix some fancy cases like here https://github.com/organicmaps/organicmaps/issues/5971
- Prepare for addr:place (also only exact mapping)

Cons:
- Can't find some bad OSM-mapped addresses, but they may be ambiguous.

This approach is good since we are going to integrate other open address sources (like https://openaddresses.io/)