### PR TITLE
[drape] Optimize Spline direction/length calculations.

### DIFF
--- a/drape_frontend/apply_feature_functors.cpp
+++ b/drape_frontend/apply_feature_functors.cpp
@@ -777,7 +777,7 @@ void ApplyLineFeatureGeometry::operator() (m2::PointD const & point)
   {
     if (m_simplify &&
         ((m_spline->GetSize() > 1 && point.SquaredLength(m_lastAddedPoint) < m_minSegmentSqrLength) ||
-        m_spline->IsPrelonging(point)))
+          m_spline->IsProlonging(point)))
     {
       m_spline->ReplacePoint(point);
     }

--- a/drape_frontend/drape_frontend_tests/path_text_test.cpp
+++ b/drape_frontend/drape_frontend_tests/path_text_test.cpp
@@ -6,7 +6,7 @@
 
 namespace
 {
-bool IsSmooth(m2::Spline const & spline)
+bool IsSmooth(m2::SplineEx const & spline)
 {
   for (size_t i = 0, sz = spline.GetDirections().size(); i + 1 < sz; ++i)
   {
@@ -19,14 +19,14 @@ bool IsSmooth(m2::Spline const & spline)
 
 UNIT_TEST(Rounding_Spline)
 {
-  m2::Spline spline1;
+  m2::SplineEx spline1;
   df::AddPointAndRound(spline1, m2::PointD(0, 200));
   df::AddPointAndRound(spline1, m2::PointD(0, 0));
   df::AddPointAndRound(spline1, m2::PointD(200, 0));
   TEST(IsSmooth(spline1), ());
   TEST(spline1.GetSize() == 8, ());
 
-  m2::Spline spline2;
+  m2::SplineEx spline2;
   df::AddPointAndRound(spline2, m2::PointD(-200, 0));
   df::AddPointAndRound(spline2, m2::PointD(0, 0));
   df::AddPointAndRound(spline2, m2::PointD(200, 200));
@@ -34,21 +34,21 @@ UNIT_TEST(Rounding_Spline)
   TEST(IsSmooth(spline2), ());
   TEST(spline2.GetSize() == 8, ());
 
-  m2::Spline spline3;
+  m2::SplineEx spline3;
   df::AddPointAndRound(spline3, m2::PointD(200, 100));
   df::AddPointAndRound(spline3, m2::PointD(0, 0));
   df::AddPointAndRound(spline3, m2::PointD(200, 0));
   TEST(!IsSmooth(spline3), ());
   TEST(spline3.GetSize() == 3, ());
 
-  m2::Spline spline4;
+  m2::SplineEx spline4;
   df::AddPointAndRound(spline4, m2::PointD(-200, 5));
   df::AddPointAndRound(spline4, m2::PointD(0, 0));
   df::AddPointAndRound(spline4, m2::PointD(200, 5));
   TEST(IsSmooth(spline4), ());
   TEST(spline4.GetSize() == 3, ());
 
-  m2::Spline spline5;
+  m2::SplineEx spline5;
   df::AddPointAndRound(spline5, m2::PointD(200, 5));
   df::AddPointAndRound(spline5, m2::PointD(0, 0));
   df::AddPointAndRound(spline5, m2::PointD(200, -5));

--- a/drape_frontend/line_shape.hpp
+++ b/drape_frontend/line_shape.hpp
@@ -47,6 +47,8 @@ private:
     return glsl::ToVec2(ConvertToLocal(vertex, m_params.m_tileCenter, kShapeCoordScalar));
   }
 
+  template <class FnT> void ForEachSplineSection(FnT && fn) const;
+
   template <typename TBuilder>
   void Construct(TBuilder & builder) const;
 

--- a/drape_frontend/path_text_handle.hpp
+++ b/drape_frontend/path_text_handle.hpp
@@ -28,15 +28,14 @@ public:
   std::vector<double> const & GetOffsets() const;
 
 private:
-  m2::Spline::iterator GetProjectedPoint(std::vector<m2::Spline> const & splines,
-                                         m2::PointD const & pt) const;
+  m2::Spline::iterator GetProjectedPoint(m2::PointD const & pt) const;
 
 private:
   std::vector<m2::PointD> m_globalPivots;
   std::vector<double> m_globalOffsets;
   m2::SharedSpline m_globalSpline;
 
-  std::vector<m2::Spline> m_pixel3dSplines;
+  std::vector<m2::SplineEx> m_pixel3dSplines;
   std::vector<m2::Spline::iterator> m_centerPointIters;
   std::vector<m2::PointD> m_centerGlobalPivots;
 
@@ -72,5 +71,5 @@ private:
 };
 
 bool IsValidSplineTurn(m2::PointD const & normalizedDir1, m2::PointD const & normalizedDir2);
-void AddPointAndRound(m2::Spline & spline, m2::PointD const & pt);
+void AddPointAndRound(m2::SplineEx & spline, m2::PointD const & pt);
 }  // namespace df

--- a/drape_frontend/shape_view_params.hpp
+++ b/drape_frontend/shape_view_params.hpp
@@ -18,7 +18,7 @@
 
 namespace df
 {
-double const kShapeCoordScalar = 1000;
+double constexpr kShapeCoordScalar = 1000;
 int constexpr kBuildingOutlineSize = 16;
 uint32_t constexpr kStartUserMarkOverlayIndex = 1000;
 

--- a/drape_frontend/user_mark_shapes.cpp
+++ b/drape_frontend/user_mark_shapes.cpp
@@ -534,7 +534,7 @@ void ProcessSplineSegmentRects(m2::SharedSpline const & spline, double maxSegmen
     auto itEnd = spline->GetPoint(length + maxSegmentLength);
     if (itEnd.BeginAgain())
     {
-      double const lastSegmentLength = spline->GetLengths().back();
+      double const lastSegmentLength = spline->GetLastLength();
       itEnd = spline->GetPoint(splineFullLength - lastSegmentLength / 2.0);
       splineRect.Add(spline->GetPath().back());
     }

--- a/geometry/spline.cpp
+++ b/geometry/spline.cpp
@@ -5,45 +5,53 @@
 namespace m2
 {
 Spline::Spline(std::vector<PointD> const & path)
+  : m_position(path)
 {
-  Init(path);
+  InitDirections();
 }
 
 Spline::Spline(std::vector<PointD> && path)
+  : m_position(std::move(path))
 {
-  Init(std::move(path));
+  InitDirections();
 }
 
 Spline::Spline(size_t reservedSize)
 {
-  ASSERT_LESS(0, reservedSize, ());
+  ASSERT_GREATER(reservedSize, 0, ());
   m_position.reserve(reservedSize);
   m_direction.reserve(reservedSize - 1);
   m_length.reserve(reservedSize - 1);
 }
 
+SplineEx::SplineEx(size_t reservedSize)
+  : Spline(reservedSize)
+{
+}
+
 void Spline::AddPoint(PointD const & pt)
 {
-  /// TODO remove this check when fix generator.
-  /// Now we have line objects with zero length segments
-  /// https://jira.mail.ru/browse/MAPSME-3561
-  if (!IsEmpty() && (pt - m_position.back()).IsAlmostZero())
-    return;
-
-  if (IsEmpty())
-    m_position.push_back(pt);
-  else
+  if (!IsEmpty())
   {
-    PointD dir = pt - m_position.back();
-    m_position.push_back(pt);
-    m_length.push_back(dir.Length());
-    m_direction.push_back(dir.Normalize());
+    /// @todo remove this check when fix generator.
+    /// Now we have line objects with zero length segments
+    /// https://jira.mail.ru/browse/MAPSME-3561
+    PointD const dir = pt - m_position.back();
+    if (dir.IsAlmostZero())
+      return;
+
+    double const len = dir.Length();
+    ASSERT_GREATER(len, 0, ());
+    m_length.push_back(len);
+    m_direction.push_back(dir / len);
   }
+
+  m_position.push_back(pt);
 }
 
 void Spline::ReplacePoint(PointD const & pt)
 {
-  ASSERT(m_position.size() > 1, ());
+  ASSERT_GREATER(m_position.size(), 1, ());
   ASSERT(!m_length.empty(), ());
   ASSERT(!m_direction.empty(), ());
   m_position.pop_back();
@@ -52,20 +60,20 @@ void Spline::ReplacePoint(PointD const & pt)
   AddPoint(pt);
 }
 
-bool Spline::IsPrelonging(PointD const & pt)
+bool Spline::IsProlonging(PointD const & pt) const
 {
-  if (m_position.size() < 2)
+  size_t const sz = m_position.size();
+  if (sz < 2)
     return false;
 
   PointD dir = pt - m_position.back();
   if (dir.IsAlmostZero())
     return true;
-
   dir = dir.Normalize();
-  PointD prevDir = m_direction.back().Normalize();
 
-  double const MAX_ANGLE_THRESHOLD = 0.995;
-  return std::fabs(DotProduct(prevDir, dir)) > MAX_ANGLE_THRESHOLD;
+  ASSERT(!m_direction.empty(), ());
+  // Some cos(angle) == 1 (angle == 0) threshold.
+  return std::fabs(DotProduct(m_direction.back(), dir)) > 0.995;
 }
 
 size_t Spline::GetSize() const
@@ -103,21 +111,28 @@ double Spline::GetLength() const
   return std::accumulate(m_length.begin(), m_length.end(), 0.0);
 }
 
-template <typename T>
-void Spline::Init(T && path)
+double Spline::GetLastLength() const
 {
-  ASSERT_GREATER(path.size(), 1, ());
-  m_position = std::forward<T>(path);
-  size_t cnt = m_position.size() - 1;
-  m_direction = std::vector<PointD>(cnt);
-  m_length = std::vector<double>(cnt);
+  ASSERT(!m_length.empty(), ());
+  return m_length.back();
+}
 
-  for (size_t i = 0; i < cnt; ++i)
+void Spline::InitDirections()
+{
+  ASSERT_GREATER(m_position.size(), 1, ());
+  size_t const sz = m_position.size() - 1;
+
+  ASSERT(m_direction.empty() && m_length.empty(), ());
+  m_direction.resize(sz);
+  m_length.resize(sz);
+
+  for (size_t i = 0; i < sz; ++i)
   {
     m_direction[i] = m_position[i + 1] - m_position[i];
-    m_length[i] = m_direction[i].Length();
-    ASSERT_GREATER(m_length[i], 0, (i));
-    m_direction[i] = m_direction[i].Normalize();
+    double const len = m_direction[i].Length();
+    ASSERT_GREATER(len, 0, (i));
+    m_length[i] = len;
+    m_direction[i] = m_direction[i] / len;
   }
 }
 

--- a/geometry/spline.cpp
+++ b/geometry/spline.cpp
@@ -117,6 +117,12 @@ double Spline::GetLastLength() const
   return m_length.back();
 }
 
+std::pair<PointD, double> Spline::GetTangentAndLength(size_t i) const
+{
+  ASSERT_LESS(i, m_length.size(), ());
+  return { m_direction[i], m_length[i] };
+}
+
 void Spline::InitDirections()
 {
   ASSERT_GREATER(m_position.size(), 1, ());

--- a/geometry/spline.hpp
+++ b/geometry/spline.hpp
@@ -77,6 +77,8 @@ public:
 
   double GetLength() const;
   double GetLastLength() const;
+  /// @return for (i) -> (i + 1) section.
+  std::pair<PointD, double> GetTangentAndLength(size_t i) const;
 
 protected:
   void InitDirections();

--- a/geometry/spline.hpp
+++ b/geometry/spline.hpp
@@ -50,11 +50,10 @@ public:
 
   void AddPoint(PointD const & pt);
   void ReplacePoint(PointD const & pt);
-  bool IsPrelonging(PointD const & pt);
+  bool IsProlonging(PointD const & pt) const;
+
   size_t GetSize() const;
   std::vector<PointD> const & GetPath() const { return m_position; }
-  std::vector<double> const & GetLengths() const { return m_length; }
-  std::vector<PointD> const & GetDirections() const { return m_direction; }
   void Clear();
 
   iterator GetPoint(double step) const;
@@ -77,14 +76,23 @@ public:
   bool IsValid() const;
 
   double GetLength() const;
+  double GetLastLength() const;
 
-private:
-  template <typename T>
-  void Init(T && path);
+protected:
+  void InitDirections();
 
   std::vector<PointD> m_position;
   std::vector<PointD> m_direction;
   std::vector<double> m_length;
+};
+
+class SplineEx : public Spline
+{
+public:
+  explicit SplineEx(size_t reservedSize = 2);
+
+  std::vector<double> const & GetLengths() const { return m_length; }
+  std::vector<PointD> const & GetDirections() const { return m_direction; }
 };
 
 class SharedSpline


### PR DESCRIPTION
- One more case to optimize Spline::IsProlonging when simplify mode (z10-12). Need refactor ClipSpline routine for separate Spline and SplineEx cases.
- Make simplification in shape coordinates (LineShape::Construct) where we calculate normals and tangents?

Done: If the tile picture is good, can keep only the second commit and calculate reusable tangent/length always.

https://github.com/organicmaps/organicmaps/issues/6137
Closes https://github.com/organicmaps/organicmaps/issues/3295
Closes https://github.com/organicmaps/organicmaps/issues/1734
Closes https://github.com/organicmaps/organicmaps/issues/4702