### PR TITLE
[android] Improve the changing of location refresh intervals and fix NavigationService

### DIFF
--- a/android/app/src/main/java/app/organicmaps/MwmActivity.java
+++ b/android/app/src/main/java/app/organicmaps/MwmActivity.java
@@ -1527,6 +1527,7 @@ public class MwmActivity extends BaseMwmFragmentActivity
 
     mRoutingPlanInplaceController.hideDrivingOptionsView();
     NavigationService.stopService(this);
+    LocationHelper.from(this).restartWithNewMode();
     mMapButtonsViewModel.setSearchOption(null);
     mMapButtonsViewModel.setLayoutMode(MapButtonsController.LayoutMode.regular);
     refreshLightStatusBar();
@@ -1699,6 +1700,7 @@ public class MwmActivity extends BaseMwmFragmentActivity
     RoutingController controller = RoutingController.get();
     if (controller.isPlanning())
       showAddStartOrFinishFrame(controller, true);
+    LocationHelper.from(this).restartWithNewMode();
   }
 
   /**

--- a/android/app/src/main/java/app/organicmaps/location/LocationHelper.java
+++ b/android/app/src/main/java/app/organicmaps/location/LocationHelper.java
@@ -29,7 +29,6 @@ import java.util.Set;
 
 public class LocationHelper implements BaseLocationProvider.Listener
 {
-  private static final long INTERVAL_FOLLOW_AND_ROTATE_MS = 0;
   private static final long INTERVAL_FOLLOW_MS = 0;
   private static final long INTERVAL_NOT_FOLLOW_MS = 3000;
   private static final long INTERVAL_NAVIGATION_MS = 0;
@@ -239,13 +238,12 @@ public class LocationHelper implements BaseLocationProvider.Listener
     final int mode = LocationState.nativeGetMode();
     switch (mode)
     {
+      case LocationState.PENDING_POSITION:
       case LocationState.FOLLOW:
-        return INTERVAL_FOLLOW_MS;
       case LocationState.FOLLOW_AND_ROTATE:
-        return INTERVAL_FOLLOW_AND_ROTATE_MS;
+        return INTERVAL_FOLLOW_MS;
       case LocationState.NOT_FOLLOW:
       case LocationState.NOT_FOLLOW_NO_POSITION:
-      case LocationState.PENDING_POSITION:
         return INTERVAL_NOT_FOLLOW_MS;
       default:
         throw new IllegalArgumentException("Unsupported location mode: " + mode);


### PR DESCRIPTION
For all location modes other than NOT_FOLLOW location should be updated as soon as possible. Also, keep in mind that Android updates GPS data only once every second.

Add a comment why NavigationService cannot be STICKY. Remove LocationHelper::restart() from NavigationService::onDestroy() as asked by @vng.

Fixes #6091