### PR TITLE
[android] Mark NavigationService as exported=false

### DIFF
--- a/android/app/src/main/AndroidManifest.xml
+++ b/android/app/src/main/AndroidManifest.xml
@@ -854,7 +854,7 @@
     <service
         android:name=".routing.NavigationService"
         android:foregroundServiceType="location"
-        android:exported="true"
+        android:exported="false"
         android:enabled="true"
         android:stopWithTask="false"
         android:permission="android.permission.ACCESS_FINE_LOCATION">


### PR DESCRIPTION
This doesn't cause any issues, just not needed.

From https://developer.android.com/guide/topics/manifest/service-element:

> Whether components of other applications can invoke the service or
> interact with it. It's "true" if they can, and "false" if not. When
> the value is "false", only components of the same application or
> applications with the same user ID can start the service or bind to it.