### PR TITLE
[android-auto] Widgets fix

### DIFF
--- a/android/app/build.gradle
+++ b/android/app/build.gradle
@@ -85,6 +85,9 @@ dependencies {
     implementation 'com.google.firebase:firebase-crashlytics-ndk'
   }
 
+  implementation 'androidx.car.app:app:1.4.0-alpha01'
+  // Fix for app/organicmaps/util/FileUploadWorker.java:14: error: cannot access ListenableFuture
+  implementation 'com.google.guava:guava:29.0-android'
   // This line is added as a workaround for duplicate classes error caused by some outdated dependency:
   // > A failure occurred while executing com.android.build.gradle.internal.tasks.CheckDuplicatesRunnable
   // We don't use Kotlin, but some dependencies are actively using it.

--- a/android/app/src/main/AndroidManifest.xml
+++ b/android/app/src/main/AndroidManifest.xml
@@ -44,6 +44,9 @@
   //-->
   <uses-permission-sdk-23 android:name="android.permission.POST_NOTIFICATIONS"/>
 
+  <uses-permission android:name="androidx.car.app.NAVIGATION_TEMPLATES"/>
+  <uses-permission android:name="androidx.car.app.ACCESS_SURFACE"/>
+
   <queries>
     <intent>
       <action android:name="android.intent.action.TTS_SERVICE"/>
@@ -850,6 +853,15 @@
     <activity
       android:name="app.organicmaps.settings.DrivingOptionsActivity"
       android:label="@string/driving_options_title"/>
+    <service
+        android:name="app.organicmaps.car.NavigationCarAppService"
+        android:foregroundServiceType="location"
+        android:exported="true">
+      <intent-filter>
+        <action android:name="androidx.car.app.CarAppService" />
+        <category android:name="androidx.car.app.category.NAVIGATION" />
+      </intent-filter>
+    </service>
 
     <service
         android:name=".routing.NavigationService"
@@ -883,6 +895,14 @@
     <meta-data android:name="android.webkit.WebView.EnableSafeBrowsing" android:value="false" />
     <!-- Disable Google's anonymous stats collection -->
     <meta-data android:name="android.webkit.WebView.MetricsOptOut" android:value="true" />
+
+    <!-- For android Auto -->
+    <meta-data android:name="com.google.android.gms.car.application"
+        android:resource="@xml/automotive_app_desc"/>
+
+    <meta-data
+        android:name="androidx.car.app.minCarApiLevel"
+        android:value="1"/>
 
   </application>
 </manifest>

--- a/android/app/src/main/cpp/app/organicmaps/Framework.cpp
+++ b/android/app/src/main/cpp/app/organicmaps/Framework.cpp
@@ -261,6 +261,12 @@ bool Framework::IsDrapeEngineCreated() const
   return m_work.IsDrapeEngineCreated();
 }
 
+void Framework::UpdateDpi(int dpi)
+{
+  ASSERT_GREATER(dpi, 0, ());
+  m_work.UpdateVisualScale(dp::VisualScale(dpi));
+}
+
 void Framework::Resize(JNIEnv * env, jobject jSurface, int w, int h)
 {
   if (m_vulkanContextFactory)
@@ -480,9 +486,9 @@ void Framework::Scale(double factor, m2::PointD const & pxPoint, bool isAnim)
   m_work.Scale(factor, pxPoint, isAnim);
 }
 
-void Framework::Move(double factorX, double factorY, bool isAnim)
+void Framework::Scroll(double distanceX, double distanceY)
 {
-  m_work.Move(factorX, factorY, isAnim);
+  m_work.Scroll(distanceX, distanceY);
 }
 
 void Framework::Touch(int action, Finger const & f1, Finger const & f2, uint8_t maskedPointer)
@@ -903,9 +909,12 @@ Java_app_organicmaps_Framework_nativePlacePageActivationListener(JNIEnv *env, jc
 }
 
 JNIEXPORT void JNICALL
-Java_app_organicmaps_Framework_nativeRemovePlacePageActivationListener(JNIEnv *env, jclass)
+Java_app_organicmaps_Framework_nativeRemovePlacePageActivationListener(JNIEnv *env, jclass, jobject jListener)
 {
   if (g_placePageActivationListener == nullptr)
+    return;
+
+  if (!env->IsSameObject(g_placePageActivationListener, jListener))
     return;
 
   frm()->SetPlacePageListeners({} /* onOpen */, {} /* onClose */, {} /* onUpdate */);

--- a/android/app/src/main/cpp/app/organicmaps/Framework.hpp
+++ b/android/app/src/main/cpp/app/organicmaps/Framework.hpp
@@ -93,6 +93,7 @@ namespace android
     bool CreateDrapeEngine(JNIEnv * env, jobject jSurface, int densityDpi, bool firstLaunch,
                            bool launchByDeepLink, uint32_t appVersionCode);
     bool IsDrapeEngineCreated() const;
+    void UpdateDpi(int dpi);
     bool DestroySurfaceOnDetach();
     void DetachSurface(bool destroySurface);
     bool AttachSurface(JNIEnv * env, jobject jSurface);
@@ -130,7 +131,7 @@ namespace android
 
     void Scale(double factor, m2::PointD const & pxPoint, bool isAnim);
 
-    void Move(double factorX, double factorY, bool isAnim);
+    void Scroll(double distanceX, double distanceY);
 
     void Touch(int action, Finger const & f1, Finger const & f2, uint8_t maskedPointer);
 

--- a/android/app/src/main/cpp/app/organicmaps/Map.cpp
+++ b/android/app/src/main/cpp/app/organicmaps/Map.cpp
@@ -39,6 +39,12 @@ Java_app_organicmaps_Map_nativeIsEngineCreated(JNIEnv *, jclass)
   return g_framework->IsDrapeEngineCreated();
 }
 
+JNIEXPORT void JNICALL
+Java_app_organicmaps_Map_nativeUpdateEngineDpi(JNIEnv *, jclass, jint dpi)
+{
+  return g_framework->UpdateDpi(dpi);
+}
+
 JNIEXPORT jboolean JNICALL
 Java_app_organicmaps_Map_nativeShowMapForUrl(JNIEnv * env, jclass, jstring url)
 {
@@ -131,13 +137,6 @@ Java_app_organicmaps_Map_nativeCompassUpdated(JNIEnv *, jclass, jdouble north, j
 }
 
 JNIEXPORT void JNICALL
-Java_app_organicmaps_Map_nativeMove(
-  JNIEnv *, jclass, jdouble factorX, jdouble factorY, jboolean isAnim)
-{
-  g_framework->Move(factorX, factorY, isAnim);
-}
-
-JNIEXPORT void JNICALL
 Java_app_organicmaps_Map_nativeScalePlus(JNIEnv *, jclass)
 {
   g_framework->Scale(::Framework::SCALE_MAG);
@@ -150,7 +149,14 @@ Java_app_organicmaps_Map_nativeScaleMinus(JNIEnv *, jclass)
 }
 
 JNIEXPORT void JNICALL
-Java_app_organicmaps_Map_nativeScale(
+Java_app_organicmaps_Map_nativeOnScroll(
+  JNIEnv *, jclass, jdouble distanceX, jdouble distanceY)
+{
+  g_framework->Scroll(distanceX, distanceY);
+}
+
+JNIEXPORT void JNICALL
+Java_app_organicmaps_Map_nativeOnScale(
   JNIEnv *, jclass, jdouble factor, jdouble focusX, jdouble focusY, jboolean isAnim)
 {
   g_framework->Scale(factor, {focusX, focusY}, isAnim);

--- a/android/app/src/main/java/app/organicmaps/Framework.java
+++ b/android/app/src/main/java/app/organicmaps/Framework.java
@@ -185,7 +185,7 @@ public class Framework
 
   public static native void nativePlacePageActivationListener(@NonNull PlacePageActivationListener listener);
 
-  public static native void nativeRemovePlacePageActivationListener();
+  public static native void nativeRemovePlacePageActivationListener(@NonNull PlacePageActivationListener listener);
 
 //  @UiThread
 //  public static native String nativeGetOutdatedCountriesString();

--- a/android/app/src/main/java/app/organicmaps/Map.java
+++ b/android/app/src/main/java/app/organicmaps/Map.java
@@ -126,10 +126,9 @@ public final class Map
   /**
    * Moves my position arrow to the given offset.
    *
-   * @param context Context.
    * @param offsetY Pixel offset from the bottom.
    */
-  public void updateMyPositionRoutingOffset(final Context context, int offsetY)
+  public void updateMyPositionRoutingOffset(int offsetY)
   {
     nativeUpdateMyPositionRoutingOffset(offsetY);
   }

--- a/android/app/src/main/java/app/organicmaps/Map.java
+++ b/android/app/src/main/java/app/organicmaps/Map.java
@@ -7,6 +7,7 @@ import android.view.Surface;
 
 import androidx.annotation.Nullable;
 
+import app.organicmaps.display.DisplayType;
 import app.organicmaps.location.LocationHelper;
 import app.organicmaps.util.Config;
 import app.organicmaps.util.UiUtils;
@@ -50,6 +51,8 @@ public final class Map
   public static final int INVALID_POINTER_MASK = 0xFF;
   public static final int INVALID_TOUCH_ID = -1;
 
+  private final DisplayType mDisplayType;
+
   private int mCurrentCompassOffsetX;
   private int mCurrentCompassOffsetY;
   private int mBottomWidgetOffsetX;
@@ -68,8 +71,11 @@ public final class Map
   @Nullable
   private CallbackUnsupported mCallbackUnsupported;
 
-  public Map()
+  private static int currentDpi = 0;
+
+  public Map(DisplayType mapType)
   {
+    mDisplayType = mapType;
     onCreate(false);
   }
 
@@ -139,6 +145,12 @@ public final class Map
     Logger.d(TAG, "mSurfaceCreated = " + mSurfaceCreated);
     if (nativeIsEngineCreated())
     {
+      if (currentDpi != surfaceDpi)
+      {
+        currentDpi = surfaceDpi;
+        nativeUpdateEngineDpi(currentDpi);
+        setupWidgets(context, surfaceFrame.width(), surfaceFrame.height());
+      }
       if (!nativeAttachSurface(surface))
       {
         if (mCallbackUnsupported != null)
@@ -257,9 +269,9 @@ public final class Map
     return mSurfaceCreated;
   }
 
-  public void onScroll(float distanceX, float distanceY)
+  public void onScroll(double distanceX, double distanceY)
   {
-    Map.nativeMove(-distanceX / ((float) mWidth), distanceY / ((float) mHeight), false);
+    Map.nativeOnScroll(distanceX, distanceY);
   }
 
   public static void zoomIn()
@@ -274,7 +286,7 @@ public final class Map
 
   public static void onScale(double factor, double focusX, double focusY, boolean isAnim)
   {
-    nativeScale(factor, focusX, focusY, isAnim);
+    nativeOnScale(factor, focusX, focusY, isAnim);
   }
 
   public static void onTouch(int actionType, MotionEvent event, int pointerIndex)
@@ -291,9 +303,10 @@ public final class Map
     }
   }
 
-  public static void onTouch(float x, float y)
+  public static void onClick(float x, float y)
   {
-    nativeOnTouch(Map.NATIVE_ACTION_UP, 0, x, y, Map.INVALID_TOUCH_ID, 0, 0, 0);
+    nativeOnTouch(NATIVE_ACTION_DOWN, 0, x, y, Map.INVALID_TOUCH_ID, 0, 0, 0);
+    nativeOnTouch(NATIVE_ACTION_UP, 0, x, y, Map.INVALID_TOUCH_ID, 0, 0, 0);
   }
 
   public static boolean isEngineCreated()
@@ -314,7 +327,9 @@ public final class Map
     nativeCleanWidgets();
     updateBottomWidgetsOffset(context, mBottomWidgetOffsetX, mBottomWidgetOffsetY);
     nativeSetupWidget(WIDGET_SCALE_FPS_LABEL, UiUtils.dimen(context, R.dimen.margin_base), UiUtils.dimen(context, R.dimen.margin_base), ANCHOR_LEFT_TOP);
-    updateCompassOffset(context, mCurrentCompassOffsetX, mCurrentCompassOffsetY, false);
+    // Don't show compass on car display
+    if (mDisplayType == DisplayType.Device)
+      updateCompassOffset(context, mCurrentCompassOffsetX, mCurrentCompassOffsetY, false);
   }
 
   private void updateRulerOffset(final Context context, int offsetX, int offsetY)
@@ -348,6 +363,7 @@ public final class Map
                                                    boolean isLaunchByDeepLink,
                                                    int appVersionCode);
   private static native boolean nativeIsEngineCreated();
+  private static native void nativeUpdateEngineDpi(int dpi);
   private static native void nativeSetRenderingInitializationFinishedListener(
       @Nullable MapRenderingListener listener);
   private static native boolean nativeShowMapForUrl(String url);
@@ -368,9 +384,9 @@ public final class Map
   private static native void nativeCompassUpdated(double north, boolean forceRedraw);
 
   // Events
-  private static native void nativeMove(double factorX, double factorY, boolean isAnim);
   private static native void nativeScalePlus();
   private static native void nativeScaleMinus();
-  private static native void nativeScale(double factor, double focusX, double focusY, boolean isAnim);
+  private static native void nativeOnScroll(double distanceX, double distanceY);
+  private static native void nativeOnScale(double factor, double focusX, double focusY, boolean isAnim);
   private static native void nativeOnTouch(int actionType, int id1, float x1, float y1, int id2, float x2, float y2, int maskedPointer);
 }

--- a/android/app/src/main/java/app/organicmaps/Map.java
+++ b/android/app/src/main/java/app/organicmaps/Map.java
@@ -325,16 +325,22 @@ public final class Map
 
     nativeCleanWidgets();
     updateBottomWidgetsOffset(context, mBottomWidgetOffsetX, mBottomWidgetOffsetY);
-    nativeSetupWidget(WIDGET_SCALE_FPS_LABEL, UiUtils.dimen(context, R.dimen.margin_base), UiUtils.dimen(context, R.dimen.margin_base), ANCHOR_LEFT_TOP);
-    // Don't show compass on car display
     if (mDisplayType == DisplayType.Device)
+    {
+      nativeSetupWidget(WIDGET_SCALE_FPS_LABEL, UiUtils.dimen(context, R.dimen.margin_base), UiUtils.dimen(context, R.dimen.margin_base) * 2, ANCHOR_LEFT_TOP);
       updateCompassOffset(context, mCurrentCompassOffsetX, mCurrentCompassOffsetY, false);
+    }
+    else
+    {
+      nativeSetupWidget(WIDGET_SCALE_FPS_LABEL, UiUtils.dimen(context, R.dimen.margin_base), mHeight - UiUtils.dimen(context, R.dimen.margin_base) * 5, ANCHOR_LEFT_TOP);
+      updateCompassOffset(context, mWidth, mCurrentCompassOffsetY, true);
+    }
   }
 
   private void updateRulerOffset(final Context context, int offsetX, int offsetY)
   {
     nativeSetupWidget(WIDGET_RULER,
-        UiUtils.dimen(context, R.dimen.margin_ruler) + offsetX,
+        UiUtils.dimen(context, R.dimen.margin_base) + offsetX,
         mHeight - UiUtils.dimen(context, R.dimen.margin_ruler) - offsetY,
         ANCHOR_LEFT_BOTTOM);
     if (mSurfaceCreated)
@@ -344,7 +350,7 @@ public final class Map
   private void updateAttributionOffset(final Context context, int offsetX, int offsetY)
   {
     nativeSetupWidget(WIDGET_COPYRIGHT,
-        UiUtils.dimen(context, R.dimen.margin_ruler) + offsetX,
+        UiUtils.dimen(context, R.dimen.margin_base) + offsetX,
         mHeight - UiUtils.dimen(context, R.dimen.margin_ruler) - offsetY,
         ANCHOR_LEFT_BOTTOM);
     if (mSurfaceCreated)
@@ -361,31 +367,48 @@ public final class Map
                                                    boolean firstLaunch,
                                                    boolean isLaunchByDeepLink,
                                                    int appVersionCode);
+
   private static native boolean nativeIsEngineCreated();
+
   private static native void nativeUpdateEngineDpi(int dpi);
+
   private static native void nativeSetRenderingInitializationFinishedListener(
       @Nullable MapRenderingListener listener);
+
   private static native boolean nativeShowMapForUrl(String url);
 
   // Surface
   private static native boolean nativeAttachSurface(Surface surface);
+
   private static native void nativeDetachSurface(boolean destroySurface);
+
   private static native void nativeSurfaceChanged(Surface surface, int w, int h);
+
   private static native boolean nativeDestroySurfaceOnDetach();
+
   private static native void nativePauseSurfaceRendering();
+
   private static native void nativeResumeSurfaceRendering();
 
   // Widgets
   private static native void nativeApplyWidgets();
+
   private static native void nativeCleanWidgets();
+
   private static native void nativeUpdateMyPositionRoutingOffset(int offsetY);
+
   private static native void nativeSetupWidget(int widget, float x, float y, int anchor);
+
   private static native void nativeCompassUpdated(double north, boolean forceRedraw);
 
   // Events
   private static native void nativeScalePlus();
+
   private static native void nativeScaleMinus();
+
   private static native void nativeOnScroll(double distanceX, double distanceY);
+
   private static native void nativeOnScale(double factor, double focusX, double focusY, boolean isAnim);
+
   private static native void nativeOnTouch(int actionType, int id1, float x1, float y1, int id2, float x2, float y2, int maskedPointer);
 }

--- a/android/app/src/main/java/app/organicmaps/MapFragment.java
+++ b/android/app/src/main/java/app/organicmaps/MapFragment.java
@@ -15,13 +15,14 @@ import androidx.annotation.Nullable;
 import androidx.core.content.res.ConfigurationHelper;
 
 import app.organicmaps.base.BaseMwmFragment;
+import app.organicmaps.display.DisplayType;
 import app.organicmaps.util.log.Logger;
 import com.google.android.material.dialog.MaterialAlertDialogBuilder;
 
 public class MapFragment extends BaseMwmFragment implements View.OnTouchListener, SurfaceHolder.Callback
 {
   private static final String TAG = MapFragment.class.getSimpleName();
-  private final Map mMap = new Map();
+  private final Map mMap = new Map(DisplayType.Device);
 
   public void updateCompassOffset(int offsetX, int offsetY)
   {
@@ -51,6 +52,7 @@ public class MapFragment extends BaseMwmFragment implements View.OnTouchListener
   @Override
   public void surfaceCreated(SurfaceHolder surfaceHolder)
   {
+    Logger.d(TAG);
     int densityDpi;
 
     if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.R)
@@ -64,19 +66,21 @@ public class MapFragment extends BaseMwmFragment implements View.OnTouchListener
   @Override
   public void surfaceChanged(SurfaceHolder surfaceHolder, int format, int width, int height)
   {
+    Logger.d(TAG);
     mMap.onSurfaceChanged(requireContext(), surfaceHolder.getSurface(), surfaceHolder.getSurfaceFrame(), surfaceHolder.isCreating());
   }
 
   @Override
   public void surfaceDestroyed(SurfaceHolder surfaceHolder)
   {
-    Logger.d(TAG, "surfaceDestroyed");
-    destroySurface();
+    Logger.d(TAG);
+    mMap.onSurfaceDestroyed(requireActivity().isChangingConfigurations(), true);
   }
 
   @Override
   public void onAttach(Context context)
   {
+    Logger.d(TAG);
     super.onAttach(context);
     mMap.setMapRenderingListener((MapRenderingListener) context);
     mMap.setCallbackUnsupported(this::reportUnsupported);
@@ -85,6 +89,7 @@ public class MapFragment extends BaseMwmFragment implements View.OnTouchListener
   @Override
   public void onDetach()
   {
+    Logger.d(TAG);
     super.onDetach();
     mMap.setMapRenderingListener(null);
     mMap.setCallbackUnsupported(null);
@@ -93,6 +98,7 @@ public class MapFragment extends BaseMwmFragment implements View.OnTouchListener
   @Override
   public void onCreate(Bundle b)
   {
+    Logger.d(TAG);
     super.onCreate(b);
     setRetainInstance(true);
     boolean launchByDeepLink = false;
@@ -105,28 +111,31 @@ public class MapFragment extends BaseMwmFragment implements View.OnTouchListener
   @Override
   public void onStart()
   {
+    Logger.d(TAG);
     super.onStart();
     mMap.onStart();
-    Logger.d(TAG, "onStart");
   }
 
+  @Override
   public void onStop()
   {
+    Logger.d(TAG);
     super.onStop();
     mMap.onStop();
-    Logger.d(TAG, "onStop");
   }
 
   @Override
   public void onPause()
   {
-    mMap.onPause(requireContext());
+    Logger.d(TAG);
     super.onPause();
+    mMap.onPause(requireContext());
   }
 
   @Override
   public void onResume()
   {
+    Logger.d(TAG);
     super.onResume();
     mMap.onResume();
   }
@@ -134,7 +143,8 @@ public class MapFragment extends BaseMwmFragment implements View.OnTouchListener
   @Override
   public View onCreateView(LayoutInflater inflater, @Nullable ViewGroup container, @Nullable Bundle savedInstanceState)
   {
-    View view = inflater.inflate(R.layout.fragment_map, container, false);
+    Logger.d(TAG);
+    final View view = inflater.inflate(R.layout.fragment_map, container, false);
     final SurfaceView mSurfaceView = view.findViewById(R.id.map_surfaceview);
     mSurfaceView.getHolder().addCallback(this);
     return view;

--- a/android/app/src/main/java/app/organicmaps/MapFragment.java
+++ b/android/app/src/main/java/app/organicmaps/MapFragment.java
@@ -11,12 +11,14 @@ import android.view.SurfaceView;
 import android.view.View;
 import android.view.ViewGroup;
 
+import androidx.annotation.NonNull;
 import androidx.annotation.Nullable;
 import androidx.core.content.res.ConfigurationHelper;
 
 import app.organicmaps.base.BaseMwmFragment;
 import app.organicmaps.display.DisplayType;
 import app.organicmaps.util.log.Logger;
+
 import com.google.android.material.dialog.MaterialAlertDialogBuilder;
 
 public class MapFragment extends BaseMwmFragment implements View.OnTouchListener, SurfaceHolder.Callback
@@ -36,7 +38,7 @@ public class MapFragment extends BaseMwmFragment implements View.OnTouchListener
 
   public void updateMyPositionRoutingOffset(int offsetY)
   {
-    mMap.updateMyPositionRoutingOffset(requireContext(), offsetY);
+    mMap.updateMyPositionRoutingOffset(offsetY);
   }
 
   public void destroySurface()
@@ -50,7 +52,7 @@ public class MapFragment extends BaseMwmFragment implements View.OnTouchListener
   }
 
   @Override
-  public void surfaceCreated(SurfaceHolder surfaceHolder)
+  public void surfaceCreated(@NonNull SurfaceHolder surfaceHolder)
   {
     Logger.d(TAG);
     int densityDpi;
@@ -71,7 +73,7 @@ public class MapFragment extends BaseMwmFragment implements View.OnTouchListener
   }
 
   @Override
-  public void surfaceDestroyed(SurfaceHolder surfaceHolder)
+  public void surfaceDestroyed(@NonNull SurfaceHolder surfaceHolder)
   {
     Logger.d(TAG);
     mMap.onSurfaceDestroyed(requireActivity().isChangingConfigurations(), true);
@@ -192,7 +194,6 @@ public class MapFragment extends BaseMwmFragment implements View.OnTouchListener
         .show();
   }
 
-  @SuppressWarnings("deprecation")
   private int getDensityDpiOld()
   {
     final DisplayMetrics metrics = new DisplayMetrics();

--- a/android/app/src/main/java/app/organicmaps/MapPlaceholderFragment.java
+++ b/android/app/src/main/java/app/organicmaps/MapPlaceholderFragment.java
@@ -1,0 +1,25 @@
+package app.organicmaps;
+
+import android.os.Bundle;
+import android.view.LayoutInflater;
+import android.view.View;
+import android.view.ViewGroup;
+
+import androidx.annotation.NonNull;
+import androidx.annotation.Nullable;
+
+import app.organicmaps.base.BaseMwmFragment;
+import app.organicmaps.display.DisplayManager;
+import app.organicmaps.display.DisplayType;
+
+public class MapPlaceholderFragment extends BaseMwmFragment
+{
+  @Nullable
+  @Override
+  public View onCreateView(@NonNull LayoutInflater inflater, @Nullable ViewGroup container, @Nullable Bundle savedInstanceState)
+  {
+    final View view = inflater.inflate(R.layout.fragment_map_placeholder, container, false);
+    view.findViewById(R.id.btn_continue).setOnClickListener((var x) -> DisplayManager.from(requireContext()).changeDisplay(DisplayType.Device));
+    return view;
+  }
+}

--- a/android/app/src/main/java/app/organicmaps/MapRenderingListener.java
+++ b/android/app/src/main/java/app/organicmaps/MapRenderingListener.java
@@ -1,8 +1,10 @@
 package app.organicmaps;
 
-interface MapRenderingListener
+public interface MapRenderingListener
 {
-  void onRenderingCreated();
-  void onRenderingRestored();
-  void onRenderingInitializationFinished();
+  default void onRenderingCreated() {}
+
+  default void onRenderingRestored() {}
+
+  default void onRenderingInitializationFinished() {}
 }

--- a/android/app/src/main/java/app/organicmaps/SplashActivity.java
+++ b/android/app/src/main/java/app/organicmaps/SplashActivity.java
@@ -6,7 +6,6 @@ import static android.Manifest.permission.ACCESS_FINE_LOCATION;
 import android.app.Activity;
 import android.content.Context;
 import android.content.Intent;
-import android.content.pm.PackageManager;
 import android.os.Bundle;
 
 import androidx.activity.result.ActivityResultLauncher;
@@ -15,11 +14,11 @@ import androidx.annotation.NonNull;
 import androidx.annotation.Nullable;
 import androidx.annotation.StringRes;
 import androidx.appcompat.app.AppCompatActivity;
-import androidx.core.app.ActivityCompat;
 
 import app.organicmaps.location.LocationHelper;
 import app.organicmaps.util.Config;
 import app.organicmaps.util.Counters;
+import app.organicmaps.util.LocationUtils;
 import app.organicmaps.util.ThemeUtils;
 import app.organicmaps.util.concurrency.UiThread;
 import app.organicmaps.util.log.Logger;
@@ -27,7 +26,7 @@ import com.google.android.material.dialog.MaterialAlertDialogBuilder;
 
 import java.io.IOException;
 
-public class SplashActivity extends AppCompatActivity
+public class SplashActivity extends AppCompatActivity implements MwmApplication.ProcessNavigationListener
 {
   private static final String TAG = SplashActivity.class.getSimpleName();
   private static final String EXTRA_ACTIVITY_TO_START = "extra_activity_to_start";
@@ -97,8 +96,7 @@ public class SplashActivity extends AppCompatActivity
     super.onResume();
     if (mCanceled)
       return;
-    if (!Config.isLocationRequested() && ActivityCompat.checkSelfPermission(this, ACCESS_COARSE_LOCATION)
-        != PackageManager.PERMISSION_GRANTED)
+    if (!Config.isLocationRequested() && !LocationUtils.checkCoarseLocationPermission(this))
     {
       Logger.d(TAG, "Requesting location permissions");
       mPermissionRequest.launch(new String[]{
@@ -152,9 +150,7 @@ public class SplashActivity extends AppCompatActivity
       return;
     }
 
-    if (Counters.isFirstLaunch(this) &&
-        (ActivityCompat.checkSelfPermission(this, ACCESS_COARSE_LOCATION) == PackageManager.PERMISSION_GRANTED ||
-         ActivityCompat.checkSelfPermission(this, ACCESS_FINE_LOCATION) == PackageManager.PERMISSION_GRANTED))
+    if (Counters.isFirstLaunch(this) && LocationUtils.checkLocationPermission(this))
     {
       final LocationHelper locationHelper = app.getLocationHelper();
       locationHelper.onEnteredIntoFirstRun();
@@ -168,6 +164,7 @@ public class SplashActivity extends AppCompatActivity
 
   // Called from MwmApplication::nativeInitFramework like callback.
   @SuppressWarnings({"unused", "unchecked"})
+  @Override
   public void processNavigation()
   {
     Intent input = getIntent();

--- a/android/app/src/main/java/app/organicmaps/car/NavigationCarAppService.java
+++ b/android/app/src/main/java/app/organicmaps/car/NavigationCarAppService.java
@@ -80,9 +80,9 @@ public final class NavigationCarAppService extends CarAppService
 
   private void createNotificationChannel()
   {
-    NotificationManager notificationManager = getSystemService(NotificationManager.class);
     if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.O)
     {
+      NotificationManager notificationManager = getSystemService(NotificationManager.class);
       CharSequence name = "Car App Service";
       NotificationChannel serviceChannel =
           new NotificationChannel(CHANNEL_ID, name, NotificationManager.IMPORTANCE_HIGH);

--- a/android/app/src/main/java/app/organicmaps/car/NavigationCarAppService.java
+++ b/android/app/src/main/java/app/organicmaps/car/NavigationCarAppService.java
@@ -1,0 +1,111 @@
+package app.organicmaps.car;
+
+import android.app.Notification;
+import android.app.NotificationChannel;
+import android.app.NotificationManager;
+import android.os.Build;
+
+import androidx.annotation.NonNull;
+import androidx.annotation.Nullable;
+import androidx.car.app.CarAppService;
+import androidx.car.app.Session;
+import androidx.car.app.SessionInfo;
+import androidx.car.app.validation.HostValidator;
+import androidx.core.app.NotificationCompat;
+import androidx.lifecycle.DefaultLifecycleObserver;
+import androidx.lifecycle.LifecycleOwner;
+
+import app.organicmaps.BuildConfig;
+import app.organicmaps.R;
+
+public final class NavigationCarAppService extends CarAppService
+{
+  /**
+   * Navigation session channel id.
+   */
+  public static final String CHANNEL_ID = "NavigationSessionChannel";
+
+  /**
+   * The identifier for the notification displayed for the foreground service.
+   */
+  private static final int NOTIFICATION_ID = 97654321;
+
+  @NonNull
+  @Override
+  public HostValidator createHostValidator()
+  {
+    if (BuildConfig.DEBUG)
+      return HostValidator.ALLOW_ALL_HOSTS_VALIDATOR;
+
+    return new HostValidator.Builder(getApplicationContext())
+        .addAllowedHosts(androidx.car.app.R.array.hosts_allowlist_sample)
+        .build();
+  }
+
+  @NonNull
+  @Override
+  public Session onCreateSession(@Nullable SessionInfo sessionInfo)
+  {
+    createNotificationChannel();
+
+    // Turn the car app service into a foreground service in order to make sure we can use all
+    // granted "while-in-use" permissions (e.g. location) in the app's process.
+    // The "while-in-use" location permission is granted as long as there is a foreground
+    // service running in a process in which location access takes place. Here, we set this
+    // service, and not NavigationService (which runs only during navigation), as a
+    // foreground service because we need location access even when not navigating. If
+    // location access is needed only during navigation, we can set NavigationService as a
+    // foreground service instead.
+    // See https://developer.android.com/reference/com/google/android/libraries/car/app
+    // /CarAppService#accessing-location for more details.
+    startForeground(NOTIFICATION_ID, getNotification());
+    final NavigationSession navigationSession = new NavigationSession(sessionInfo);
+    navigationSession.getLifecycle().addObserver(new DefaultLifecycleObserver()
+    {
+      @Override
+      public void onDestroy(@NonNull LifecycleOwner owner)
+      {
+        stopForeground(true);
+      }
+    });
+    return navigationSession;
+  }
+
+  @NonNull
+  @Override
+  public Session onCreateSession()
+  {
+    return onCreateSession(null);
+  }
+
+  private void createNotificationChannel()
+  {
+    NotificationManager notificationManager = getSystemService(NotificationManager.class);
+    if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.O)
+    {
+      CharSequence name = "Car App Service";
+      NotificationChannel serviceChannel =
+          new NotificationChannel(CHANNEL_ID, name, NotificationManager.IMPORTANCE_HIGH);
+      notificationManager.createNotificationChannel(serviceChannel);
+    }
+  }
+
+  /**
+   * Returns the {@link NotificationCompat} used as part of the foreground service.
+   */
+  private Notification getNotification()
+  {
+    NotificationCompat.Builder builder =
+        new NotificationCompat.Builder(this, CHANNEL_ID)
+            .setContentTitle("Navigation App")
+            .setContentText("App is running")
+            .setSmallIcon(R.mipmap.ic_launcher);
+
+    if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.O)
+    {
+      builder.setChannelId(CHANNEL_ID);
+      builder.setPriority(NotificationManager.IMPORTANCE_HIGH);
+    }
+    return builder.build();
+  }
+}

--- a/android/app/src/main/java/app/organicmaps/car/NavigationSession.java
+++ b/android/app/src/main/java/app/organicmaps/car/NavigationSession.java
@@ -1,0 +1,350 @@
+package app.organicmaps.car;
+
+import static android.Manifest.permission.ACCESS_FINE_LOCATION;
+
+import android.content.Intent;
+import android.content.res.Configuration;
+import android.location.Location;
+
+import androidx.annotation.NonNull;
+import androidx.annotation.Nullable;
+import androidx.annotation.RequiresPermission;
+import androidx.car.app.Screen;
+import androidx.car.app.ScreenManager;
+import androidx.car.app.Session;
+import androidx.car.app.SessionInfo;
+import androidx.car.app.navigation.NavigationManager;
+import androidx.car.app.navigation.NavigationManagerCallback;
+import androidx.car.app.navigation.model.Trip;
+import androidx.lifecycle.DefaultLifecycleObserver;
+import androidx.lifecycle.LifecycleOwner;
+
+import app.organicmaps.Framework;
+import app.organicmaps.Map;
+import app.organicmaps.R;
+import app.organicmaps.bookmarks.data.MapObject;
+import app.organicmaps.car.screens.NavigationScreen;
+import app.organicmaps.car.screens.PlaceScreen;
+import app.organicmaps.car.screens.RequestPermissionsScreen;
+import app.organicmaps.car.screens.base.BaseScreen;
+import app.organicmaps.car.screens.hacks.PopToRootHack;
+import app.organicmaps.car.util.IntentUtils;
+import app.organicmaps.car.util.RoutingUtils;
+import app.organicmaps.car.util.ThemeUtils;
+import app.organicmaps.display.DisplayChangedListener;
+import app.organicmaps.display.DisplayManager;
+import app.organicmaps.display.DisplayType;
+import app.organicmaps.MwmApplication;
+import app.organicmaps.car.screens.ErrorScreen;
+import app.organicmaps.car.screens.MapPlaceholderScreen;
+import app.organicmaps.car.screens.base.BaseMapScreen;
+import app.organicmaps.car.screens.MapScreen;
+import app.organicmaps.location.LocationHelper;
+import app.organicmaps.location.LocationListener;
+import app.organicmaps.location.LocationState;
+import app.organicmaps.location.SensorHelper;
+import app.organicmaps.location.SensorListener;
+import app.organicmaps.routing.RoutingController;
+import app.organicmaps.routing.RoutingInfo;
+import app.organicmaps.util.LocationUtils;
+import app.organicmaps.sound.TtsPlayer;
+import app.organicmaps.util.log.Logger;
+import app.organicmaps.widget.placepage.PlacePageData;
+
+import java.io.IOException;
+
+public final class NavigationSession extends Session implements DefaultLifecycleObserver, LocationListener,
+    SensorListener, LocationState.ModeChangeListener, DisplayChangedListener, Framework.PlacePageActivationListener,
+    NavigationManagerCallback, MwmApplication.ProcessNavigationListener
+{
+  private static final String TAG = NavigationSession.class.getSimpleName();
+
+  @Nullable
+  private final SessionInfo mSessionInfo;
+  @NonNull
+  private final SurfaceRenderer mSurfaceRenderer;
+  @NonNull
+  private final ScreenManager mScreenManager;
+  @NonNull
+  private final NavigationManager mNavigationManager;
+  private boolean mInitFailed = false;
+
+  public NavigationSession(@Nullable SessionInfo sessionInfo)
+  {
+    getLifecycle().addObserver(this);
+    mSessionInfo = sessionInfo;
+    mSurfaceRenderer = new SurfaceRenderer(getCarContext(), getLifecycle());
+    mScreenManager = getCarContext().getCarService(ScreenManager.class);
+    mNavigationManager = getCarContext().getCarService(NavigationManager.class);
+  }
+
+  @Override
+  public void onCarConfigurationChanged(@NonNull Configuration newConfiguration)
+  {
+    Logger.d(TAG, "New configuration: " + newConfiguration);
+
+    if (mSurfaceRenderer.isRenderingActive())
+    {
+      ThemeUtils.update(getCarContext());
+      mScreenManager.getTop().invalidate();
+    }
+  }
+
+  @NonNull
+  @Override
+  public Screen onCreateScreen(@NonNull Intent intent)
+  {
+    Logger.d(TAG);
+
+    Logger.i(TAG, "Session info: " + mSessionInfo);
+    Logger.i(TAG, "API Level: " + getCarContext().getCarAppApiLevel());
+    if (mSessionInfo != null)
+      Logger.i(TAG, "Supported templates: " + mSessionInfo.getSupportedTemplates(getCarContext().getCarAppApiLevel()));
+    Logger.i(TAG, "Host info: " + getCarContext().getHostInfo());
+    Logger.i(TAG, "Car configuration: " + getCarContext().getResources().getConfiguration());
+
+    final MapScreen mapScreen = new MapScreen(getCarContext(), mSurfaceRenderer);
+
+    if (mInitFailed)
+      return new ErrorScreen.Builder(getCarContext()).setErrorMessage(R.string.dialog_error_storage_message).build();
+
+    if (!LocationUtils.checkFineLocationPermission(getCarContext()))
+    {
+      mScreenManager.push(mapScreen);
+      return new RequestPermissionsScreen(getCarContext(), this::onLocationPermissionsGranted);
+    }
+
+    return mapScreen;
+  }
+
+  @Override
+  public void onNewIntent(@NonNull Intent intent)
+  {
+    Logger.d(TAG, intent.toString());
+    // TODO (AndrewShkrob): This logic will need to be revised when we introduce support for adding stops during navigation or route planning.
+    // Skip navigation intents during navigation
+    if (RoutingController.get().isNavigating())
+      return;
+
+    IntentUtils.processIntent(getCarContext(), mSurfaceRenderer, intent);
+  }
+
+  @Override
+  public void onCreate(@NonNull LifecycleOwner owner)
+  {
+    Logger.d(TAG);
+    final DisplayManager displayManager = DisplayManager.from(getCarContext());
+    displayManager.addListener(DisplayType.Car, this);
+    getLifecycle().addObserver(displayManager.getObserverFor(DisplayType.Car));
+    init();
+  }
+
+  @Override
+  public void onStart(@NonNull LifecycleOwner owner)
+  {
+    Logger.d(TAG);
+    mNavigationManager.setNavigationManagerCallback(this);
+    if (DisplayManager.from(getCarContext()).isCarDisplayUsed())
+    {
+      LocationState.nativeSetListener(this);
+      onMyPositionModeChanged(LocationState.nativeGetMode());
+      Framework.nativePlacePageActivationListener(this);
+    }
+    SensorHelper.from(getCarContext()).addListener(this);
+    final LocationHelper locationHelper = LocationHelper.from(getCarContext());
+    locationHelper.addListener(this);
+    if (LocationUtils.checkFineLocationPermission(getCarContext()))
+      locationHelper.start();
+
+    if (DisplayManager.from(getCarContext()).isCarDisplayUsed())
+      ThemeUtils.update(getCarContext());
+  }
+
+  @Override
+  public void onResume(@NonNull LifecycleOwner owner)
+  {
+    Logger.d(TAG);
+    init();
+  }
+
+  @Override
+  public void onStop(@NonNull LifecycleOwner owner)
+  {
+    Logger.d(TAG);
+    LocationHelper.from(getCarContext()).removeListener(this);
+    SensorHelper.from(getCarContext()).removeListener(this);
+    if (DisplayManager.from(getCarContext()).isCarDisplayUsed())
+    {
+      LocationState.nativeRemoveListener();
+      Framework.nativeRemovePlacePageActivationListener(this);
+    }
+  }
+
+  private void init()
+  {
+    mInitFailed = false;
+    try
+    {
+      MwmApplication.from(getCarContext()).init(this);
+    } catch (IOException e)
+    {
+      mInitFailed = true;
+      Logger.e(TAG, "Failed to initialize the app.");
+    }
+  }
+
+  // Called from MwmApplication::nativeInitFramework like callback.
+  @SuppressWarnings({"unused", "unchecked"})
+  @Override
+  public void processNavigation()
+  {
+    // TODO: figure out how to initialize MwmApplication in one place.
+    // See {@link SplashActivity.init() }
+  }
+
+  @RequiresPermission(ACCESS_FINE_LOCATION)
+  private void onLocationPermissionsGranted()
+  {
+    LocationHelper.from(getCarContext()).start();
+  }
+
+  @Override
+  public void onMyPositionModeChanged(int newMode)
+  {
+    final Screen screen = mScreenManager.getTop();
+    if (screen instanceof BaseMapScreen)
+      screen.invalidate();
+  }
+
+  @Override
+  public void onLocationUpdated(@NonNull Location location)
+  {
+    if (!RoutingController.get().isNavigating())
+      return;
+
+    final String[] turnNotifications = Framework.nativeGenerateNotifications();
+    if (turnNotifications != null)
+      TtsPlayer.INSTANCE.playTurnNotifications(getCarContext(), turnNotifications);
+    updateTrip();
+
+    // TODO: consider to create callback mechanism to transfer 'ROUTE_IS_FINISHED' event from
+    // the core to the platform code (https://github.com/organicmaps/organicmaps/issues/3589),
+    // because calling the native method 'nativeIsRouteFinished'
+    // too often can result in poor UI performance.
+    if (Framework.nativeIsRouteFinished())
+      RoutingController.get().cancel();
+  }
+
+  @Override
+  public void onCompassUpdated(double north)
+  {
+    Map.onCompassUpdated(north, false);
+    if (RoutingController.get().isNavigating())
+      updateTrip();
+  }
+
+  @Override
+  public void onDisplayChanged(@NonNull final DisplayType newDisplayType)
+  {
+    Logger.d(TAG);
+    final Screen screen = mScreenManager.getTop();
+    final boolean isMapPlaceholderScreenShown = screen instanceof MapPlaceholderScreen;
+    final boolean isPermissionsOrErrorScreenShown = screen instanceof RequestPermissionsScreen || screen instanceof ErrorScreen;
+    final RoutingController routingController = RoutingController.get();
+    if (newDisplayType == DisplayType.Car)
+    {
+      onStart(this);
+      mSurfaceRenderer.enable();
+
+      // If we have Permissions or Error Screen in Screen Manager (either on the top of the stack or after MapPlaceholderScreen) do nothing
+      if (isPermissionsOrErrorScreenShown)
+        return;
+      mScreenManager.pop();
+      if (mScreenManager.getTop() instanceof RequestPermissionsScreen || mScreenManager.getTop() instanceof ErrorScreen)
+        return;
+
+      routingController.restore();
+      mScreenManager.popToRoot();
+      if (routingController.isNavigating())
+        mScreenManager.push(new NavigationScreen(getCarContext(), mSurfaceRenderer));
+      else if (routingController.isPlanning() && routingController.getEndPoint() != null)
+        mScreenManager.push(new PlaceScreen.Builder(getCarContext(), mSurfaceRenderer).setMapObject(routingController.getEndPoint()).build());
+      mSurfaceRenderer.enable();
+      ThemeUtils.update(getCarContext());
+      Framework.nativePlacePageActivationListener(this);
+    }
+    else if (newDisplayType == DisplayType.Device && !isMapPlaceholderScreenShown)
+    {
+      onStop(this);
+      mSurfaceRenderer.disable();
+
+      final BaseScreen mapPlaceholderScreen = new MapPlaceholderScreen(getCarContext());
+
+      if (isPermissionsOrErrorScreenShown)
+      {
+        mScreenManager.push(mapPlaceholderScreen);
+      }
+      else
+      {
+        final PopToRootHack hack = new PopToRootHack.Builder(getCarContext()).setScreenToPush(mapPlaceholderScreen).build();
+        mScreenManager.push(hack);
+        routingController.onSaveState();
+      }
+    }
+  }
+
+  @Override
+  public void onPlacePageActivated(@NonNull PlacePageData data)
+  {
+    Logger.d(TAG);
+    // TODO (AndrewShkrob): Will be implemented later. "Add stop" and another functionality
+    final Screen screen = mScreenManager.getTop();
+    if (screen instanceof NavigationScreen)
+    {
+      Framework.nativeDeactivatePopup();
+      return;
+    }
+    final MapObject mapObject = (MapObject) data;
+    if (screen instanceof PlaceScreen)
+    {
+      final PlaceScreen placeScreen = (PlaceScreen) screen;
+      if (placeScreen.getMapObject().getFeatureId().equals(mapObject.getFeatureId()))
+      {
+        placeScreen.updateMapObject(mapObject);
+        return;
+      }
+    }
+    final PlaceScreen placeScreen = new PlaceScreen.Builder(getCarContext(), mSurfaceRenderer).setMapObject(mapObject).build();
+    if (RoutingController.get().isNavigating())
+      mScreenManager.push(placeScreen);
+    else
+    {
+      final PopToRootHack hack = new PopToRootHack.Builder(getCarContext()).setScreenToPush(placeScreen).build();
+      mScreenManager.push(hack);
+    }
+  }
+
+  @Override
+  public void onPlacePageDeactivated(boolean switchFullScreenMode)
+  {
+    if (mScreenManager.getTop() instanceof PlaceScreen)
+      mScreenManager.popToRoot();
+  }
+
+  @Override
+  public void onStopNavigation()
+  {
+    if (mScreenManager.getTop() instanceof NavigationScreen)
+      ((NavigationScreen) mScreenManager.getTop()).stopNavigation();
+  }
+
+  private void updateTrip()
+  {
+    mNavigationManager.navigationStarted();
+    final RoutingInfo info = Framework.nativeGetRouteFollowingInfo();
+    final Trip trip = RoutingUtils.createTrip(getCarContext(), info, RoutingController.get().getEndPoint());
+    mNavigationManager.updateTrip(trip);
+    if (mScreenManager.getTop() instanceof NavigationScreen)
+      mScreenManager.getTop().invalidate();
+  }
+}

--- a/android/app/src/main/java/app/organicmaps/car/NavigationSession.java
+++ b/android/app/src/main/java/app/organicmaps/car/NavigationSession.java
@@ -4,7 +4,6 @@ import static android.Manifest.permission.ACCESS_FINE_LOCATION;
 
 import android.content.Intent;
 import android.content.res.Configuration;
-import android.location.Location;
 
 import androidx.annotation.NonNull;
 import androidx.annotation.Nullable;
@@ -13,9 +12,6 @@ import androidx.car.app.Screen;
 import androidx.car.app.ScreenManager;
 import androidx.car.app.Session;
 import androidx.car.app.SessionInfo;
-import androidx.car.app.navigation.NavigationManager;
-import androidx.car.app.navigation.NavigationManagerCallback;
-import androidx.car.app.navigation.model.Trip;
 import androidx.lifecycle.DefaultLifecycleObserver;
 import androidx.lifecycle.LifecycleOwner;
 
@@ -23,39 +19,33 @@ import app.organicmaps.Framework;
 import app.organicmaps.Map;
 import app.organicmaps.R;
 import app.organicmaps.bookmarks.data.MapObject;
-import app.organicmaps.car.screens.NavigationScreen;
+import app.organicmaps.car.hacks.PopToRootHack;
+import app.organicmaps.car.screens.MapPlaceholderScreen;
 import app.organicmaps.car.screens.PlaceScreen;
 import app.organicmaps.car.screens.RequestPermissionsScreen;
-import app.organicmaps.car.screens.base.BaseScreen;
-import app.organicmaps.car.screens.hacks.PopToRootHack;
 import app.organicmaps.car.util.IntentUtils;
-import app.organicmaps.car.util.RoutingUtils;
 import app.organicmaps.car.util.ThemeUtils;
 import app.organicmaps.display.DisplayChangedListener;
 import app.organicmaps.display.DisplayManager;
 import app.organicmaps.display.DisplayType;
 import app.organicmaps.MwmApplication;
 import app.organicmaps.car.screens.ErrorScreen;
-import app.organicmaps.car.screens.MapPlaceholderScreen;
 import app.organicmaps.car.screens.base.BaseMapScreen;
 import app.organicmaps.car.screens.MapScreen;
 import app.organicmaps.location.LocationHelper;
-import app.organicmaps.location.LocationListener;
 import app.organicmaps.location.LocationState;
 import app.organicmaps.location.SensorHelper;
 import app.organicmaps.location.SensorListener;
 import app.organicmaps.routing.RoutingController;
-import app.organicmaps.routing.RoutingInfo;
 import app.organicmaps.util.LocationUtils;
-import app.organicmaps.sound.TtsPlayer;
 import app.organicmaps.util.log.Logger;
 import app.organicmaps.widget.placepage.PlacePageData;
 
 import java.io.IOException;
 
-public final class NavigationSession extends Session implements DefaultLifecycleObserver, LocationListener,
+public final class NavigationSession extends Session implements DefaultLifecycleObserver,
     SensorListener, LocationState.ModeChangeListener, DisplayChangedListener, Framework.PlacePageActivationListener,
-    NavigationManagerCallback, MwmApplication.ProcessNavigationListener
+    MwmApplication.ProcessNavigationListener
 {
   private static final String TAG = NavigationSession.class.getSimpleName();
 
@@ -65,8 +55,6 @@ public final class NavigationSession extends Session implements DefaultLifecycle
   private final SurfaceRenderer mSurfaceRenderer;
   @NonNull
   private final ScreenManager mScreenManager;
-  @NonNull
-  private final NavigationManager mNavigationManager;
   private boolean mInitFailed = false;
 
   public NavigationSession(@Nullable SessionInfo sessionInfo)
@@ -75,7 +63,6 @@ public final class NavigationSession extends Session implements DefaultLifecycle
     mSessionInfo = sessionInfo;
     mSurfaceRenderer = new SurfaceRenderer(getCarContext(), getLifecycle());
     mScreenManager = getCarContext().getCarService(ScreenManager.class);
-    mNavigationManager = getCarContext().getCarService(NavigationManager.class);
   }
 
   @Override
@@ -143,7 +130,7 @@ public final class NavigationSession extends Session implements DefaultLifecycle
   public void onStart(@NonNull LifecycleOwner owner)
   {
     Logger.d(TAG);
-    mNavigationManager.setNavigationManagerCallback(this);
+    restoreRoute();
     if (DisplayManager.from(getCarContext()).isCarDisplayUsed())
     {
       LocationState.nativeSetListener(this);
@@ -151,10 +138,8 @@ public final class NavigationSession extends Session implements DefaultLifecycle
       Framework.nativePlacePageActivationListener(this);
     }
     SensorHelper.from(getCarContext()).addListener(this);
-    final LocationHelper locationHelper = LocationHelper.from(getCarContext());
-    locationHelper.addListener(this);
     if (LocationUtils.checkFineLocationPermission(getCarContext()))
-      locationHelper.start();
+      LocationHelper.from(getCarContext()).start();
 
     if (DisplayManager.from(getCarContext()).isCarDisplayUsed())
       ThemeUtils.update(getCarContext());
@@ -171,7 +156,6 @@ public final class NavigationSession extends Session implements DefaultLifecycle
   public void onStop(@NonNull LifecycleOwner owner)
   {
     Logger.d(TAG);
-    LocationHelper.from(getCarContext()).removeListener(this);
     SensorHelper.from(getCarContext()).removeListener(this);
     if (DisplayManager.from(getCarContext()).isCarDisplayUsed())
     {
@@ -216,135 +200,84 @@ public final class NavigationSession extends Session implements DefaultLifecycle
       screen.invalidate();
   }
 
-  @Override
-  public void onLocationUpdated(@NonNull Location location)
-  {
-    if (!RoutingController.get().isNavigating())
-      return;
-
-    final String[] turnNotifications = Framework.nativeGenerateNotifications();
-    if (turnNotifications != null)
-      TtsPlayer.INSTANCE.playTurnNotifications(getCarContext(), turnNotifications);
-    updateTrip();
-
-    // TODO: consider to create callback mechanism to transfer 'ROUTE_IS_FINISHED' event from
-    // the core to the platform code (https://github.com/organicmaps/organicmaps/issues/3589),
-    // because calling the native method 'nativeIsRouteFinished'
-    // too often can result in poor UI performance.
-    if (Framework.nativeIsRouteFinished())
-      RoutingController.get().cancel();
-  }
-
-  @Override
   public void onCompassUpdated(double north)
   {
     Map.onCompassUpdated(north, false);
-    if (RoutingController.get().isNavigating())
-      updateTrip();
   }
 
   @Override
   public void onDisplayChanged(@NonNull final DisplayType newDisplayType)
   {
     Logger.d(TAG);
-    final Screen screen = mScreenManager.getTop();
-    final boolean isMapPlaceholderScreenShown = screen instanceof MapPlaceholderScreen;
-    final boolean isPermissionsOrErrorScreenShown = screen instanceof RequestPermissionsScreen || screen instanceof ErrorScreen;
-    final RoutingController routingController = RoutingController.get();
+    final Screen topScreen = mScreenManager.getTop();
     if (newDisplayType == DisplayType.Car)
     {
       onStart(this);
       mSurfaceRenderer.enable();
 
       // If we have Permissions or Error Screen in Screen Manager (either on the top of the stack or after MapPlaceholderScreen) do nothing
-      if (isPermissionsOrErrorScreenShown)
+      if (isPermissionsOrErrorScreen(topScreen))
         return;
       mScreenManager.pop();
-      if (mScreenManager.getTop() instanceof RequestPermissionsScreen || mScreenManager.getTop() instanceof ErrorScreen)
+      if (isPermissionsOrErrorScreen(mScreenManager.getTop()))
         return;
 
-      routingController.restore();
-      mScreenManager.popToRoot();
-      if (routingController.isNavigating())
-        mScreenManager.push(new NavigationScreen(getCarContext(), mSurfaceRenderer));
-      else if (routingController.isPlanning() && routingController.getEndPoint() != null)
-        mScreenManager.push(new PlaceScreen.Builder(getCarContext(), mSurfaceRenderer).setMapObject(routingController.getEndPoint()).build());
-      mSurfaceRenderer.enable();
       ThemeUtils.update(getCarContext());
-      Framework.nativePlacePageActivationListener(this);
     }
-    else if (newDisplayType == DisplayType.Device && !isMapPlaceholderScreenShown)
+    else if (newDisplayType == DisplayType.Device)
     {
       onStop(this);
       mSurfaceRenderer.disable();
 
-      final BaseScreen mapPlaceholderScreen = new MapPlaceholderScreen(getCarContext());
-
-      if (isPermissionsOrErrorScreenShown)
-      {
+      final MapPlaceholderScreen mapPlaceholderScreen = new MapPlaceholderScreen(getCarContext());
+      if (isPermissionsOrErrorScreen(topScreen))
         mScreenManager.push(mapPlaceholderScreen);
-      }
       else
-      {
-        final PopToRootHack hack = new PopToRootHack.Builder(getCarContext()).setScreenToPush(mapPlaceholderScreen).build();
-        mScreenManager.push(hack);
-        routingController.onSaveState();
-      }
+        mScreenManager.push(new PopToRootHack.Builder(getCarContext()).setScreenToPush(mapPlaceholderScreen).build());
     }
   }
 
   @Override
   public void onPlacePageActivated(@NonNull PlacePageData data)
   {
-    Logger.d(TAG);
-    // TODO (AndrewShkrob): Will be implemented later. "Add stop" and another functionality
-    final Screen screen = mScreenManager.getTop();
-    if (screen instanceof NavigationScreen)
+    final MapObject mapObject = (MapObject) data;
+    // Don't display the PlaceScreen for 'MY_POSITION' or during navigation
+    // TODO (AndrewShkrob): Implement the 'Add stop' functionality
+    if (mapObject.isMyPosition() || RoutingController.get().isNavigating())
     {
       Framework.nativeDeactivatePopup();
       return;
     }
-    final MapObject mapObject = (MapObject) data;
-    if (screen instanceof PlaceScreen)
-    {
-      final PlaceScreen placeScreen = (PlaceScreen) screen;
-      if (placeScreen.getMapObject().getFeatureId().equals(mapObject.getFeatureId()))
-      {
-        placeScreen.updateMapObject(mapObject);
-        return;
-      }
-    }
     final PlaceScreen placeScreen = new PlaceScreen.Builder(getCarContext(), mSurfaceRenderer).setMapObject(mapObject).build();
-    if (RoutingController.get().isNavigating())
-      mScreenManager.push(placeScreen);
-    else
-    {
-      final PopToRootHack hack = new PopToRootHack.Builder(getCarContext()).setScreenToPush(placeScreen).build();
-      mScreenManager.push(hack);
-    }
+    final PopToRootHack hack = new PopToRootHack.Builder(getCarContext()).setScreenToPush(placeScreen).build();
+    mScreenManager.push(hack);
   }
 
   @Override
   public void onPlacePageDeactivated(boolean switchFullScreenMode)
   {
-    if (mScreenManager.getTop() instanceof PlaceScreen)
-      mScreenManager.popToRoot();
+    // The function is called when we close the PlaceScreen or when we enter the navigation mode.
+    // We only need to handle the first case
+    if (!(mScreenManager.getTop() instanceof PlaceScreen))
+      return;
+
+    RoutingController.get().cancel();
+    mScreenManager.popToRoot();
   }
 
-  @Override
-  public void onStopNavigation()
+  private void restoreRoute()
   {
-    if (mScreenManager.getTop() instanceof NavigationScreen)
-      ((NavigationScreen) mScreenManager.getTop()).stopNavigation();
+    final RoutingController routingController = RoutingController.get();
+    if (routingController.isPlanning() || routingController.isNavigating() || routingController.hasSavedRoute())
+    {
+      final PlaceScreen placeScreen = new PlaceScreen.Builder(getCarContext(), mSurfaceRenderer).setMapObject(routingController.getEndPoint()).build();
+      final PopToRootHack hack = new PopToRootHack.Builder(getCarContext()).setScreenToPush(placeScreen).build();
+      mScreenManager.push(hack);
+    }
   }
 
-  private void updateTrip()
+  private boolean isPermissionsOrErrorScreen(@NonNull Screen screen)
   {
-    mNavigationManager.navigationStarted();
-    final RoutingInfo info = Framework.nativeGetRouteFollowingInfo();
-    final Trip trip = RoutingUtils.createTrip(getCarContext(), info, RoutingController.get().getEndPoint());
-    mNavigationManager.updateTrip(trip);
-    if (mScreenManager.getTop() instanceof NavigationScreen)
-      mScreenManager.getTop().invalidate();
+    return screen instanceof RequestPermissionsScreen || screen instanceof ErrorScreen;
   }
 }

--- a/android/app/src/main/java/app/organicmaps/car/SurfaceRenderer.java
+++ b/android/app/src/main/java/app/organicmaps/car/SurfaceRenderer.java
@@ -40,6 +40,7 @@ public class SurfaceRenderer implements DefaultLifecycleObserver, SurfaceCallbac
     mIsRunning = true;
     lifecycle.addObserver(this);
     mMap.setMapRenderingListener(this);
+    mMap.updateMyPositionRoutingOffset(0);
   }
 
   @Override
@@ -186,6 +187,7 @@ public class SurfaceRenderer implements DefaultLifecycleObserver, SurfaceCallbac
     mMap.onSurfaceDestroyed(false, true);
     mMap.onStop();
     mMap.setCallbackUnsupported(null);
+    mMap.setMapRenderingListener(null);
 
     mIsRunning = false;
   }
@@ -201,6 +203,8 @@ public class SurfaceRenderer implements DefaultLifecycleObserver, SurfaceCallbac
     mCarContext.getCarService(AppManager.class).setSurfaceCallback(this);
     mMap.onStart();
     mMap.setCallbackUnsupported(this::reportUnsupported);
+    mMap.setMapRenderingListener(this);
+    mMap.updateMyPositionRoutingOffset(0);
 
     mIsRunning = true;
   }

--- a/android/app/src/main/java/app/organicmaps/car/SurfaceRenderer.java
+++ b/android/app/src/main/java/app/organicmaps/car/SurfaceRenderer.java
@@ -1,0 +1,225 @@
+package app.organicmaps.car;
+
+import android.graphics.Rect;
+
+import androidx.annotation.NonNull;
+import androidx.car.app.AppManager;
+import androidx.car.app.CarContext;
+import androidx.car.app.CarToast;
+import androidx.car.app.SurfaceCallback;
+import androidx.car.app.SurfaceContainer;
+import androidx.lifecycle.DefaultLifecycleObserver;
+import androidx.lifecycle.Lifecycle;
+import androidx.lifecycle.LifecycleOwner;
+
+import app.organicmaps.Framework;
+import app.organicmaps.Map;
+import app.organicmaps.MapRenderingListener;
+import app.organicmaps.R;
+import app.organicmaps.settings.UnitLocale;
+import app.organicmaps.util.log.Logger;
+
+import static app.organicmaps.display.DisplayType.Car;
+
+public class SurfaceRenderer implements DefaultLifecycleObserver, SurfaceCallback, MapRenderingListener
+{
+  private static final String TAG = SurfaceRenderer.class.getSimpleName();
+
+  private final CarContext mCarContext;
+  private final Map mMap = new Map(Car);
+
+  @NonNull
+  private Rect mVisibleArea = new Rect();
+
+  private boolean mIsRunning;
+
+  public SurfaceRenderer(@NonNull CarContext carContext, @NonNull Lifecycle lifecycle)
+  {
+    Logger.d(TAG, "SurfaceRenderer()");
+    mCarContext = carContext;
+    mIsRunning = true;
+    lifecycle.addObserver(this);
+    mMap.setMapRenderingListener(this);
+  }
+
+  @Override
+  public void onSurfaceAvailable(@NonNull SurfaceContainer surfaceContainer)
+  {
+    Logger.d(TAG, "Surface available " + surfaceContainer);
+    mMap.onSurfaceCreated(
+        mCarContext,
+        surfaceContainer.getSurface(),
+        new Rect(0, 0, surfaceContainer.getWidth(), surfaceContainer.getHeight()),
+        surfaceContainer.getDpi()
+    );
+  }
+
+  @Override
+  public void onVisibleAreaChanged(@NonNull Rect visibleArea)
+  {
+    Logger.d(TAG, "Visible area changed. visibleArea: " + visibleArea);
+    mVisibleArea = visibleArea;
+
+    if (!mVisibleArea.isEmpty())
+      Framework.nativeSetVisibleRect(mVisibleArea.left, mVisibleArea.top, mVisibleArea.right, mVisibleArea.bottom);
+  }
+
+  @Override
+  public void onStableAreaChanged(@NonNull Rect stableArea)
+  {
+    Logger.d(TAG, "Stable area changed. stableArea: " + stableArea);
+
+    if (!stableArea.isEmpty())
+      Framework.nativeSetVisibleRect(stableArea.left, stableArea.top, stableArea.right, stableArea.bottom);
+    else if (!mVisibleArea.isEmpty())
+      Framework.nativeSetVisibleRect(mVisibleArea.left, mVisibleArea.top, mVisibleArea.right, mVisibleArea.bottom);
+  }
+
+  @Override
+  public void onSurfaceDestroyed(@NonNull SurfaceContainer surfaceContainer)
+  {
+    Logger.d(TAG, "Surface destroyed");
+    mMap.onSurfaceDestroyed(false, true);
+  }
+
+  @Override
+  public void onCreate(@NonNull LifecycleOwner owner)
+  {
+    Logger.d(TAG);
+    mCarContext.getCarService(AppManager.class).setSurfaceCallback(this);
+
+    // TODO (AndrewShkrob): Properly process deep links from other apps on AA.
+    boolean launchByDeepLink = false;
+    mMap.onCreate(launchByDeepLink);
+  }
+
+  @Override
+  public void onStart(@NonNull LifecycleOwner owner)
+  {
+    Logger.d(TAG);
+    mMap.onStart();
+    mMap.setCallbackUnsupported(this::reportUnsupported);
+  }
+
+  @Override
+  public void onStop(@NonNull LifecycleOwner owner)
+  {
+    Logger.d(TAG);
+    mMap.onStop();
+    mMap.setCallbackUnsupported(null);
+  }
+
+  @Override
+  public void onPause(@NonNull LifecycleOwner owner)
+  {
+    Logger.d(TAG);
+    mMap.onPause(mCarContext);
+  }
+
+  @Override
+  public void onResume(@NonNull LifecycleOwner owner)
+  {
+    Logger.d(TAG);
+    mMap.onResume();
+  }
+
+  @Override
+  public void onScroll(float distanceX, float distanceY)
+  {
+    Logger.d(TAG, "distanceX: " + distanceX + ", distanceY: " + distanceY);
+    mMap.onScroll(distanceX, distanceY);
+  }
+
+  @Override
+  public void onFling(float velocityX, float velocityY)
+  {
+    Logger.d(TAG, "velocityX: " + velocityX + ", velocityY: " + velocityY);
+  }
+
+  public void onZoomIn()
+  {
+    Map.zoomIn();
+  }
+
+  public void onZoomOut()
+  {
+    Map.zoomOut();
+  }
+
+  @Override
+  public void onScale(float focusX, float focusY, float scaleFactor)
+  {
+    Logger.d(TAG, "focusX: " + focusX + ", focusY: " + focusY + ", scaleFactor: " + scaleFactor);
+    float x = focusX;
+    float y = focusY;
+
+    if (!mVisibleArea.isEmpty())
+    {
+      // If a focal point value is negative, use the center point of the visible area.
+      if (x < 0)
+        x = mVisibleArea.centerX();
+      if (y < 0)
+        y = mVisibleArea.centerY();
+    }
+
+    final boolean animated = Float.compare(scaleFactor, 2f) == 0;
+
+    Map.onScale(scaleFactor, x, y, animated);
+  }
+
+  @Override
+  public void onClick(float x, float y)
+  {
+    Logger.d(TAG, "x: " + x + ", y: " + y);
+    Map.onClick(x, y);
+  }
+
+  public void disable()
+  {
+    if (!mIsRunning)
+    {
+      Logger.e(TAG, "Already disabled");
+      return;
+    }
+
+    mCarContext.getCarService(AppManager.class).setSurfaceCallback(null);
+    mMap.onSurfaceDestroyed(false, true);
+    mMap.onStop();
+    mMap.setCallbackUnsupported(null);
+
+    mIsRunning = false;
+  }
+
+  public void enable()
+  {
+    if (mIsRunning)
+    {
+      Logger.e(TAG, "Already enabled");
+      return;
+    }
+
+    mCarContext.getCarService(AppManager.class).setSurfaceCallback(this);
+    mMap.onStart();
+    mMap.setCallbackUnsupported(this::reportUnsupported);
+
+    mIsRunning = true;
+  }
+
+  public boolean isRenderingActive()
+  {
+    return mIsRunning;
+  }
+
+  private void reportUnsupported()
+  {
+    String message = mCarContext.getString(R.string.unsupported_phone);
+    Logger.e(TAG, message);
+    CarToast.makeText(mCarContext, message, CarToast.LENGTH_LONG).show();
+  }
+
+  @Override
+  public void onRenderingCreated()
+  {
+    UnitLocale.initializeCurrentUnits();
+  }
+}

--- a/android/app/src/main/java/app/organicmaps/car/SurfaceRenderer.java
+++ b/android/app/src/main/java/app/organicmaps/car/SurfaceRenderer.java
@@ -40,7 +40,6 @@ public class SurfaceRenderer implements DefaultLifecycleObserver, SurfaceCallbac
     mIsRunning = true;
     lifecycle.addObserver(this);
     mMap.setMapRenderingListener(this);
-    mMap.updateMyPositionRoutingOffset(0);
   }
 
   @Override
@@ -53,6 +52,7 @@ public class SurfaceRenderer implements DefaultLifecycleObserver, SurfaceCallbac
         new Rect(0, 0, surfaceContainer.getWidth(), surfaceContainer.getHeight()),
         surfaceContainer.getDpi()
     );
+    mMap.updateBottomWidgetsOffset(mCarContext, -1, -1);
   }
 
   @Override

--- a/android/app/src/main/java/app/organicmaps/car/hacks/PopToRootHack.java
+++ b/android/app/src/main/java/app/organicmaps/car/hacks/PopToRootHack.java
@@ -1,4 +1,4 @@
-package app.organicmaps.car.screens.hacks;
+package app.organicmaps.car.hacks;
 
 import static java.util.Objects.requireNonNull;
 

--- a/android/app/src/main/java/app/organicmaps/car/screens/BookmarksScreen.java
+++ b/android/app/src/main/java/app/organicmaps/car/screens/BookmarksScreen.java
@@ -1,0 +1,169 @@
+package app.organicmaps.car.screens;
+
+import static java.util.Objects.requireNonNull;
+
+import android.graphics.drawable.Drawable;
+import android.location.Location;
+import android.text.SpannableStringBuilder;
+import android.text.Spanned;
+
+import androidx.annotation.NonNull;
+import androidx.annotation.Nullable;
+import androidx.car.app.CarContext;
+import androidx.car.app.constraints.ConstraintManager;
+import androidx.car.app.model.Action;
+import androidx.car.app.model.CarIcon;
+import androidx.car.app.model.DistanceSpan;
+import androidx.car.app.model.ForegroundCarColorSpan;
+import androidx.car.app.model.Header;
+import androidx.car.app.model.ItemList;
+import androidx.car.app.model.Row;
+import androidx.car.app.model.Template;
+import androidx.car.app.navigation.model.MapTemplate;
+import androidx.core.graphics.drawable.IconCompat;
+
+import app.organicmaps.R;
+import app.organicmaps.bookmarks.data.BookmarkCategory;
+import app.organicmaps.bookmarks.data.BookmarkInfo;
+import app.organicmaps.bookmarks.data.BookmarkManager;
+import app.organicmaps.car.SurfaceRenderer;
+import app.organicmaps.car.util.Colors;
+import app.organicmaps.car.util.RoutingHelpers;
+import app.organicmaps.car.util.UiHelpers;
+import app.organicmaps.car.screens.base.BaseMapScreen;
+import app.organicmaps.location.LocationHelper;
+import app.organicmaps.util.Distance;
+import app.organicmaps.util.Graphics;
+
+import java.util.ArrayList;
+import java.util.List;
+
+public class BookmarksScreen extends BaseMapScreen
+{
+  private final int MAX_CATEGORIES_SIZE;
+
+  @Nullable
+  private BookmarkCategory mBookmarkCategory;
+
+  public BookmarksScreen(@NonNull CarContext carContext, @NonNull SurfaceRenderer surfaceRenderer)
+  {
+    super(carContext, surfaceRenderer);
+    final ConstraintManager constraintManager = getCarContext().getCarService(ConstraintManager.class);
+    MAX_CATEGORIES_SIZE = constraintManager.getContentLimit(ConstraintManager.CONTENT_LIMIT_TYPE_LIST);
+  }
+
+  private BookmarksScreen(@NonNull CarContext carContext, @NonNull SurfaceRenderer surfaceRenderer, @NonNull BookmarkCategory bookmarkCategory)
+  {
+    this(carContext, surfaceRenderer);
+    mBookmarkCategory = bookmarkCategory;
+  }
+
+  @NonNull
+  @Override
+  public Template onGetTemplate()
+  {
+    final MapTemplate.Builder builder = new MapTemplate.Builder();
+    builder.setHeader(createHeader());
+    builder.setMapController(UiHelpers.createMapController(getCarContext(), getSurfaceRenderer()));
+    builder.setItemList(mBookmarkCategory == null ? createBookmarkCategoriesList() : createBookmarksList());
+    return builder.build();
+  }
+
+  @NonNull
+  private Header createHeader()
+  {
+    final Header.Builder builder = new Header.Builder();
+    builder.setStartHeaderAction(Action.BACK);
+    builder.setTitle(mBookmarkCategory == null ? getCarContext().getString(R.string.bookmarks) : mBookmarkCategory.getName());
+    return builder.build();
+  }
+
+  @NonNull
+  private ItemList createBookmarkCategoriesList()
+  {
+    final List<BookmarkCategory> bookmarkCategories = getBookmarks();
+    final int categoriesSize = Math.min(bookmarkCategories.size(), MAX_CATEGORIES_SIZE);
+
+    ItemList.Builder builder = new ItemList.Builder();
+    for (int i = 0; i < categoriesSize; ++i)
+    {
+      final BookmarkCategory bookmarkCategory = bookmarkCategories.get(i);
+
+      Row.Builder itemBuilder = new Row.Builder();
+      itemBuilder.setTitle(bookmarkCategory.getName());
+      itemBuilder.addText(bookmarkCategory.getDescription());
+      itemBuilder.setOnClickListener(() -> getScreenManager().push(new BookmarksScreen(getCarContext(), getSurfaceRenderer(), bookmarkCategory)));
+      itemBuilder.setBrowsable(true);
+      builder.addItem(itemBuilder.build());
+    }
+    return builder.build();
+  }
+
+  @NonNull
+  private ItemList createBookmarksList()
+  {
+    final long bookmarkCategoryId = requireNonNull(mBookmarkCategory).getId();
+    final int bookmarkCategoriesSize = Math.min(mBookmarkCategory.getBookmarksCount(), MAX_CATEGORIES_SIZE);
+
+    ItemList.Builder builder = new ItemList.Builder();
+    for (int i = 0; i < bookmarkCategoriesSize; ++i)
+    {
+      final long bookmarkId = BookmarkManager.INSTANCE.getBookmarkIdByPosition(bookmarkCategoryId, i);
+      final BookmarkInfo bookmarkInfo = new BookmarkInfo(bookmarkCategoryId, bookmarkId);
+
+      final Row.Builder itemBuilder = new Row.Builder();
+      itemBuilder.setTitle(bookmarkInfo.getName());
+      if (!bookmarkInfo.getAddress().isEmpty())
+        itemBuilder.addText(bookmarkInfo.getAddress());
+      final CharSequence description = getDescription(bookmarkInfo);
+      if (description.length() != 0)
+        itemBuilder.addText(description);
+      final Drawable icon = Graphics.drawCircleAndImage(bookmarkInfo.getIcon().argb(),
+          R.dimen.track_circle_size,
+          bookmarkInfo.getIcon().getResId(),
+          R.dimen.bookmark_icon_size,
+          getCarContext());
+      itemBuilder.setImage(new CarIcon.Builder(IconCompat.createWithBitmap(Graphics.drawableToBitmap(icon))).build());
+      itemBuilder.setOnClickListener(() -> BookmarkManager.INSTANCE.showBookmarkOnMap(bookmarkId));
+      builder.addItem(itemBuilder.build());
+    }
+    return builder.build();
+  }
+
+  @NonNull
+  private CharSequence getDescription(final BookmarkInfo bookmark)
+  {
+    final SpannableStringBuilder result = new SpannableStringBuilder(" ");
+    final Location loc = LocationHelper.from(getCarContext()).getSavedLocation();
+    if (loc != null)
+    {
+      final Distance distance = bookmark.getDistance(loc.getLatitude(), loc.getLongitude(), 0.0);
+      result.setSpan(DistanceSpan.create(RoutingHelpers.createDistance(distance)), 0, 1, Spanned.SPAN_EXCLUSIVE_EXCLUSIVE);
+      result.setSpan(ForegroundCarColorSpan.create(Colors.DISTANCE), 0, 1, Spanned.SPAN_EXCLUSIVE_EXCLUSIVE);
+    }
+
+    if (loc != null && !bookmark.getFeatureType().isEmpty())
+    {
+      result.append(" • ");
+      result.append(bookmark.getFeatureType());
+    }
+
+    return result;
+  }
+
+  @NonNull
+  private static List<BookmarkCategory> getBookmarks()
+  {
+    final List<BookmarkCategory> bookmarkCategories = new ArrayList<>(BookmarkManager.INSTANCE.getCategories());
+
+    final List<BookmarkCategory> toRemove = new ArrayList<>();
+    for (final BookmarkCategory bookmarkCategory : bookmarkCategories)
+    {
+      if (bookmarkCategory.getBookmarksCount() == 0 || !bookmarkCategory.isVisible())
+        toRemove.add(bookmarkCategory);
+    }
+    bookmarkCategories.removeAll(toRemove);
+
+    return bookmarkCategories;
+  }
+}

--- a/android/app/src/main/java/app/organicmaps/car/screens/CategoriesScreen.java
+++ b/android/app/src/main/java/app/organicmaps/car/screens/CategoriesScreen.java
@@ -1,0 +1,106 @@
+package app.organicmaps.car.screens;
+
+import androidx.annotation.DrawableRes;
+import androidx.annotation.NonNull;
+import androidx.annotation.StringRes;
+import androidx.car.app.CarContext;
+import androidx.car.app.constraints.ConstraintManager;
+import androidx.car.app.model.Action;
+import androidx.car.app.model.CarIcon;
+import androidx.car.app.model.Header;
+import androidx.car.app.model.ItemList;
+import androidx.car.app.model.Row;
+import androidx.car.app.model.Template;
+import androidx.car.app.navigation.model.MapTemplate;
+import androidx.core.graphics.drawable.IconCompat;
+
+import app.organicmaps.R;
+import app.organicmaps.car.SurfaceRenderer;
+import app.organicmaps.car.screens.search.SearchOnMapScreen;
+import app.organicmaps.car.util.ThemeUtils;
+import app.organicmaps.car.util.UiHelpers;
+import app.organicmaps.car.screens.base.BaseMapScreen;
+
+import java.util.Arrays;
+import java.util.List;
+
+public class CategoriesScreen extends BaseMapScreen
+{
+  private static class CategoryData
+  {
+    @StringRes
+    public final int nameResId;
+
+    @DrawableRes
+    public final int iconResId;
+    @DrawableRes
+    public final int iconNightResId;
+
+    public CategoryData(@StringRes int nameResId, @DrawableRes int iconResId, @DrawableRes int iconNightResId)
+    {
+      this.nameResId = nameResId;
+      this.iconResId = iconResId;
+      this.iconNightResId = iconNightResId;
+    }
+  }
+
+  // TODO (AndrewShkrob): discuss categories and their priority for this list
+  private static final List<CategoryData> CATEGORIES = Arrays.asList(
+      new CategoryData(R.string.fuel, R.drawable.ic_category_fuel, R.drawable.ic_category_fuel_night),
+      new CategoryData(R.string.parking, R.drawable.ic_category_parking, R.drawable.ic_category_parking_night),
+      new CategoryData(R.string.eat, R.drawable.ic_category_eat, R.drawable.ic_category_eat_night),
+      new CategoryData(R.string.food, R.drawable.ic_category_food, R.drawable.ic_category_food_night),
+      new CategoryData(R.string.hotel, R.drawable.ic_category_hotel, R.drawable.ic_category_hotel_night),
+      new CategoryData(R.string.toilet, R.drawable.ic_category_toilet, R.drawable.ic_category_toilet_night),
+      new CategoryData(R.string.rv, R.drawable.ic_category_rv, R.drawable.ic_category_rv_night)
+  );
+
+  private final int MAX_CATEGORIES_SIZE;
+
+  public CategoriesScreen(@NonNull CarContext carContext, @NonNull SurfaceRenderer surfaceRenderer)
+  {
+    super(carContext, surfaceRenderer);
+    final ConstraintManager constraintManager = getCarContext().getCarService(ConstraintManager.class);
+    MAX_CATEGORIES_SIZE = constraintManager.getContentLimit(ConstraintManager.CONTENT_LIMIT_TYPE_LIST);
+  }
+
+  @NonNull
+  @Override
+  public Template onGetTemplate()
+  {
+    final MapTemplate.Builder builder = new MapTemplate.Builder();
+    builder.setHeader(createHeader());
+    builder.setMapController(UiHelpers.createMapController(getCarContext(), getSurfaceRenderer()));
+    builder.setItemList(createCategoriesList());
+    return builder.build();
+  }
+
+  @NonNull
+  private Header createHeader()
+  {
+    final Header.Builder builder = new Header.Builder();
+    builder.setStartHeaderAction(Action.BACK);
+    builder.setTitle(getCarContext().getString(R.string.categories));
+    return builder.build();
+  }
+
+  @NonNull
+  private ItemList createCategoriesList()
+  {
+    final boolean isNightMode = ThemeUtils.isNightMode(getCarContext());
+    final ItemList.Builder builder = new ItemList.Builder();
+    final int categoriesSize = Math.min(CATEGORIES.size(), MAX_CATEGORIES_SIZE);
+    for (int i = 0; i < categoriesSize; ++i)
+    {
+      final Row.Builder itemBuilder = new Row.Builder();
+      final String title = getCarContext().getString(CATEGORIES.get(i).nameResId);
+      @DrawableRes final int iconResId = isNightMode ? CATEGORIES.get(i).iconNightResId : CATEGORIES.get(i).iconResId;
+
+      itemBuilder.setTitle(title);
+      itemBuilder.setImage(new CarIcon.Builder(IconCompat.createWithResource(getCarContext(), iconResId)).build());
+      itemBuilder.setOnClickListener(() -> getScreenManager().push(new SearchOnMapScreen.Builder(getCarContext(), getSurfaceRenderer()).setCategory(title).build()));
+      builder.addItem(itemBuilder.build());
+    }
+    return builder.build();
+  }
+}

--- a/android/app/src/main/java/app/organicmaps/car/screens/ErrorScreen.java
+++ b/android/app/src/main/java/app/organicmaps/car/screens/ErrorScreen.java
@@ -1,0 +1,80 @@
+package app.organicmaps.car.screens;
+
+import androidx.annotation.NonNull;
+import androidx.annotation.StringRes;
+import androidx.car.app.CarContext;
+import androidx.car.app.model.Action;
+import androidx.car.app.model.MessageTemplate;
+import androidx.car.app.model.ParkedOnlyOnClickListener;
+import androidx.car.app.model.Template;
+
+import app.organicmaps.R;
+import app.organicmaps.car.screens.base.BaseScreen;
+import app.organicmaps.car.util.Colors;
+
+public class ErrorScreen extends BaseScreen
+{
+  @StringRes
+  private final int mErrorMessage;
+
+  private final boolean mIsCloseable;
+
+  private ErrorScreen(@NonNull Builder builder)
+  {
+    super(builder.mCarContext);
+    mErrorMessage = builder.mErrorMessage;
+    mIsCloseable = builder.mIsCloseable;
+  }
+
+  @NonNull
+  @Override
+  public Template onGetTemplate()
+  {
+    final MessageTemplate.Builder builder = new MessageTemplate.Builder(getCarContext().getString(mErrorMessage));
+    builder.setHeaderAction(Action.APP_ICON);
+    builder.setTitle(getCarContext().getString(R.string.app_name));
+    if (mIsCloseable)
+    {
+      builder.addAction(new Action.Builder()
+          .setBackgroundColor(Colors.BUTTON_ACCEPT)
+          .setTitle(getCarContext().getString(R.string.close))
+          .setOnClickListener(ParkedOnlyOnClickListener.create(this::finish)).build()
+      );
+    }
+
+    return builder.build();
+  }
+
+  public static class Builder
+  {
+    @NonNull
+    private final CarContext mCarContext;
+
+    @StringRes
+    private int mErrorMessage;
+
+    private boolean mIsCloseable;
+
+    public Builder(@NonNull CarContext carContext)
+    {
+      mCarContext = carContext;
+    }
+
+    public Builder setErrorMessage(@StringRes int errorMessage)
+    {
+      mErrorMessage = errorMessage;
+      return this;
+    }
+
+    public Builder setCloseable(boolean isCloseable)
+    {
+      mIsCloseable = isCloseable;
+      return this;
+    }
+
+    public ErrorScreen build()
+    {
+      return new ErrorScreen(this);
+    }
+  }
+}

--- a/android/app/src/main/java/app/organicmaps/car/screens/MapPlaceholderScreen.java
+++ b/android/app/src/main/java/app/organicmaps/car/screens/MapPlaceholderScreen.java
@@ -1,0 +1,36 @@
+package app.organicmaps.car.screens;
+
+import androidx.annotation.NonNull;
+import androidx.car.app.CarContext;
+import androidx.car.app.model.Action;
+import androidx.car.app.model.CarIcon;
+import androidx.car.app.model.MessageTemplate;
+import androidx.car.app.model.Template;
+import androidx.core.graphics.drawable.IconCompat;
+
+import app.organicmaps.car.screens.base.BaseScreen;
+import app.organicmaps.display.DisplayManager;
+import app.organicmaps.display.DisplayType;
+import app.organicmaps.R;
+
+public class MapPlaceholderScreen extends BaseScreen
+{
+  public MapPlaceholderScreen(@NonNull CarContext carContext)
+  {
+    super(carContext);
+  }
+
+  @NonNull
+  @Override
+  public Template onGetTemplate()
+  {
+    final MessageTemplate.Builder builder = new MessageTemplate.Builder(getCarContext().getString(R.string.aa_used_on_the_phone_screen));
+    builder.setHeaderAction(Action.APP_ICON);
+    builder.setTitle(getCarContext().getString(R.string.app_name));
+    builder.setIcon(new CarIcon.Builder(IconCompat.createWithResource(getCarContext(), R.drawable.ic_phone_android)).build());
+    builder.addAction(new Action.Builder().setTitle(getCarContext().getString(R.string.aa_continue_in_the_car))
+        .setOnClickListener(() -> DisplayManager.from(getCarContext()).changeDisplay(DisplayType.Car)).build());
+
+    return builder.build();
+  }
+}

--- a/android/app/src/main/java/app/organicmaps/car/screens/MapScreen.java
+++ b/android/app/src/main/java/app/organicmaps/car/screens/MapScreen.java
@@ -1,0 +1,115 @@
+package app.organicmaps.car.screens;
+
+import androidx.annotation.NonNull;
+import androidx.car.app.CarContext;
+import androidx.car.app.model.Action;
+import androidx.car.app.model.CarIcon;
+import androidx.car.app.model.Header;
+import androidx.car.app.model.Item;
+import androidx.car.app.model.ItemList;
+import androidx.car.app.model.Row;
+import androidx.car.app.model.Template;
+import androidx.car.app.navigation.model.MapTemplate;
+import androidx.core.graphics.drawable.IconCompat;
+
+import app.organicmaps.R;
+import app.organicmaps.car.SurfaceRenderer;
+import app.organicmaps.car.util.UiHelpers;
+import app.organicmaps.car.screens.base.BaseMapScreen;
+import app.organicmaps.car.screens.search.SearchScreen;
+
+public class MapScreen extends BaseMapScreen
+{
+  public MapScreen(@NonNull CarContext carContext, @NonNull SurfaceRenderer surfaceRenderer)
+  {
+    super(carContext, surfaceRenderer);
+  }
+
+  @NonNull
+  @Override
+  public Template onGetTemplate()
+  {
+    final MapTemplate.Builder builder = new MapTemplate.Builder();
+    builder.setHeader(createHeader());
+    builder.setMapController(UiHelpers.createMapController(getCarContext(), getSurfaceRenderer()));
+    builder.setActionStrip(UiHelpers.createSettingsActionStrip(this, getSurfaceRenderer()));
+    builder.setItemList(createList());
+    return builder.build();
+  }
+
+  @NonNull
+  private Header createHeader()
+  {
+    final Header.Builder builder = new Header.Builder();
+    builder.setStartHeaderAction(new Action.Builder(Action.APP_ICON).build());
+    builder.setTitle(getCarContext().getString(R.string.app_name));
+    return builder.build();
+  }
+
+  @NonNull
+  private ItemList createList()
+  {
+    final ItemList.Builder builder = new ItemList.Builder();
+    builder.addItem(createSearchItem());
+    builder.addItem(createCategoriesItem());
+    builder.addItem(createBookmarksItem());
+    return builder.build();
+  }
+
+  @NonNull
+  private Item createSearchItem()
+  {
+    final CarIcon iconSearch = new CarIcon.Builder(IconCompat.createWithResource(getCarContext(), R.drawable.ic_search)).build();
+
+    final Row.Builder builder = new Row.Builder();
+    builder.setTitle(getCarContext().getString(R.string.search));
+    builder.setImage(iconSearch);
+    builder.setBrowsable(true);
+    builder.setOnClickListener(this::openSearch);
+    return builder.build();
+  }
+
+  @NonNull
+  private Item createCategoriesItem()
+  {
+    final Row.Builder builder = new Row.Builder();
+    builder.setTitle(getCarContext().getString(R.string.categories));
+    builder.setBrowsable(true);
+    builder.setOnClickListener(this::openCategories);
+    return builder.build();
+  }
+
+  @NonNull
+  private Item createBookmarksItem()
+  {
+    final Row.Builder builder = new Row.Builder();
+    builder.setTitle(getCarContext().getString(R.string.bookmarks));
+    builder.setBrowsable(true);
+    builder.setOnClickListener(this::openBookmarks);
+    return builder.build();
+  }
+
+  private void openSearch()
+  {
+    // Details in UiHelpers.createSettingsAction()
+    if (getScreenManager().getTop() != this)
+      return;
+    getScreenManager().push(new SearchScreen.Builder(getCarContext(), getSurfaceRenderer()).build());
+  }
+
+  private void openCategories()
+  {
+    // Details in UiHelpers.createSettingsAction()
+    if (getScreenManager().getTop() != this)
+      return;
+    getScreenManager().push(new CategoriesScreen(getCarContext(), getSurfaceRenderer()));
+  }
+
+  private void openBookmarks()
+  {
+    // Details in UiHelpers.createSettingsAction()
+    if (getScreenManager().getTop() != this)
+      return;
+    getScreenManager().push(new BookmarksScreen(getCarContext(), getSurfaceRenderer()));
+  }
+}

--- a/android/app/src/main/java/app/organicmaps/car/screens/NavigationScreen.java
+++ b/android/app/src/main/java/app/organicmaps/car/screens/NavigationScreen.java
@@ -1,5 +1,7 @@
 package app.organicmaps.car.screens;
 
+import android.location.Location;
+
 import androidx.annotation.DrawableRes;
 import androidx.annotation.NonNull;
 import androidx.annotation.Nullable;
@@ -10,6 +12,7 @@ import androidx.car.app.model.ActionStrip;
 import androidx.car.app.model.CarIcon;
 import androidx.car.app.model.Template;
 import androidx.car.app.navigation.NavigationManager;
+import androidx.car.app.navigation.NavigationManagerCallback;
 import androidx.car.app.navigation.model.NavigationTemplate;
 import androidx.car.app.navigation.model.Step;
 import androidx.car.app.navigation.model.TravelEstimate;
@@ -17,6 +20,7 @@ import androidx.car.app.navigation.model.Trip;
 import androidx.core.graphics.drawable.IconCompat;
 import androidx.lifecycle.LifecycleOwner;
 
+import app.organicmaps.Framework;
 import app.organicmaps.R;
 import app.organicmaps.car.SurfaceRenderer;
 import app.organicmaps.car.screens.settings.DrivingOptionsScreen;
@@ -25,28 +29,30 @@ import app.organicmaps.car.util.RoutingUtils;
 import app.organicmaps.car.util.ThemeUtils;
 import app.organicmaps.car.util.UiHelpers;
 import app.organicmaps.car.screens.base.BaseMapScreen;
+import app.organicmaps.location.LocationHelper;
+import app.organicmaps.location.LocationListener;
 import app.organicmaps.routing.RoutingController;
+import app.organicmaps.routing.RoutingInfo;
 import app.organicmaps.sound.TtsPlayer;
-import app.organicmaps.util.ThemeSwitcher;
 import app.organicmaps.util.log.Logger;
 
 import java.util.List;
 import java.util.Objects;
 
-public class NavigationScreen extends BaseMapScreen implements RoutingController.Container
+public class NavigationScreen extends BaseMapScreen implements RoutingController.Container, NavigationManagerCallback, LocationListener
 {
   private static final String TAG = NavigationScreen.class.getSimpleName();
 
   @NonNull
-  private final NavigationManager mNavigationManager;
-  @NonNull
   private final RoutingController mRoutingController;
+  @NonNull
+  private final NavigationManager mNavigationManager;
 
   public NavigationScreen(@NonNull CarContext carContext, @NonNull SurfaceRenderer surfaceRenderer)
   {
     super(carContext, surfaceRenderer);
-    mNavigationManager = carContext.getCarService(NavigationManager.class);
     mRoutingController = RoutingController.get();
+    mNavigationManager = carContext.getCarService(NavigationManager.class);
   }
 
   @NonNull
@@ -67,41 +73,60 @@ public class NavigationScreen extends BaseMapScreen implements RoutingController
   }
 
   @Override
-  public void onResume(@NonNull LifecycleOwner owner)
+  public void onStopNavigation()
   {
-    mRoutingController.attach(this);
-    mRoutingController.restore();
-    if (mRoutingController.isPlanning())
-      mRoutingController.start();
-  }
-
-  @Override
-  public void onPause(@NonNull LifecycleOwner owner)
-  {
-    mRoutingController.detach();
-  }
-
-  @Override
-  public void onNavigationStarted()
-  {
-    ThemeSwitcher.INSTANCE.restart(true);
-    mNavigationManager.navigationStarted();
+    LocationHelper.from(getCarContext()).removeListener(this);
+    mRoutingController.cancel();
   }
 
   @Override
   public void onNavigationCancelled()
   {
-    ThemeSwitcher.INSTANCE.restart(true);
-    mNavigationManager.navigationEnded();
-    RoutingUtils.resetTrip();
-    // TODO (AndrewShkrob): Handle "Stop" click and "Navigation finished" actions separately. Add localized string.
+    // TODO (AndrewShkrob): Add localized string.
     CarToast.makeText(getCarContext(), "Navigation finished", CarToast.LENGTH_LONG).show();
+    finish();
     getScreenManager().popToRoot();
   }
 
-  public void stopNavigation()
+  @Override
+  public void onCreate(@NonNull LifecycleOwner owner)
   {
-    mRoutingController.cancel();
+    mRoutingController.attach(this);
+    ThemeUtils.update(getCarContext());
+    mNavigationManager.setNavigationManagerCallback(this);
+    mNavigationManager.navigationStarted();
+
+    LocationHelper.from(getCarContext()).addListener(this);
+  }
+
+  @Override
+  public void onDestroy(@NonNull LifecycleOwner owner)
+  {
+    LocationHelper.from(getCarContext()).removeListener(this);
+
+    if (mRoutingController.isNavigating())
+      mRoutingController.onSaveState();
+    mRoutingController.detach();
+    ThemeUtils.update(getCarContext());
+    mNavigationManager.navigationEnded();
+    mNavigationManager.clearNavigationManagerCallback();
+    RoutingUtils.resetTrip();
+  }
+
+  @Override
+  public void onLocationUpdated(@NonNull Location location)
+  {
+    final String[] turnNotifications = Framework.nativeGenerateNotifications();
+    if (turnNotifications != null)
+      TtsPlayer.INSTANCE.playTurnNotifications(getCarContext(), turnNotifications);
+    updateTrip();
+
+    // TODO: consider to create callback mechanism to transfer 'ROUTE_IS_FINISHED' event from
+    // the core to the platform code (https://github.com/organicmaps/organicmaps/issues/3589),
+    // because calling the native method 'nativeIsRouteFinished'
+    // too often can result in poor UI performance.
+    if (Framework.nativeIsRouteFinished())
+      RoutingController.get().cancel();
   }
 
   @NonNull
@@ -109,7 +134,7 @@ public class NavigationScreen extends BaseMapScreen implements RoutingController
   {
     final Action.Builder stopActionBuilder = new Action.Builder();
     stopActionBuilder.setTitle(getCarContext().getString(R.string.current_location_unknown_stop_button));
-    stopActionBuilder.setOnClickListener(this::stopNavigation);
+    stopActionBuilder.setOnClickListener(mRoutingController::cancel);
 
     final ActionStrip.Builder builder = new ActionStrip.Builder();
     builder.addAction(createTtsAction());
@@ -178,5 +203,13 @@ public class NavigationScreen extends BaseMapScreen implements RoutingController
     });
 
     return ttsActionBuilder.build();
+  }
+
+  private void updateTrip()
+  {
+    final RoutingInfo info = Framework.nativeGetRouteFollowingInfo();
+    final Trip trip = RoutingUtils.createTrip(getCarContext(), info, RoutingController.get().getEndPoint());
+    mNavigationManager.updateTrip(trip);
+    invalidate();
   }
 }

--- a/android/app/src/main/java/app/organicmaps/car/screens/NavigationScreen.java
+++ b/android/app/src/main/java/app/organicmaps/car/screens/NavigationScreen.java
@@ -1,0 +1,182 @@
+package app.organicmaps.car.screens;
+
+import androidx.annotation.DrawableRes;
+import androidx.annotation.NonNull;
+import androidx.annotation.Nullable;
+import androidx.car.app.CarContext;
+import androidx.car.app.CarToast;
+import androidx.car.app.model.Action;
+import androidx.car.app.model.ActionStrip;
+import androidx.car.app.model.CarIcon;
+import androidx.car.app.model.Template;
+import androidx.car.app.navigation.NavigationManager;
+import androidx.car.app.navigation.model.NavigationTemplate;
+import androidx.car.app.navigation.model.Step;
+import androidx.car.app.navigation.model.TravelEstimate;
+import androidx.car.app.navigation.model.Trip;
+import androidx.core.graphics.drawable.IconCompat;
+import androidx.lifecycle.LifecycleOwner;
+
+import app.organicmaps.R;
+import app.organicmaps.car.SurfaceRenderer;
+import app.organicmaps.car.screens.settings.DrivingOptionsScreen;
+import app.organicmaps.car.util.Colors;
+import app.organicmaps.car.util.RoutingUtils;
+import app.organicmaps.car.util.ThemeUtils;
+import app.organicmaps.car.util.UiHelpers;
+import app.organicmaps.car.screens.base.BaseMapScreen;
+import app.organicmaps.routing.RoutingController;
+import app.organicmaps.sound.TtsPlayer;
+import app.organicmaps.util.ThemeSwitcher;
+import app.organicmaps.util.log.Logger;
+
+import java.util.List;
+import java.util.Objects;
+
+public class NavigationScreen extends BaseMapScreen implements RoutingController.Container
+{
+  private static final String TAG = NavigationScreen.class.getSimpleName();
+
+  @NonNull
+  private final NavigationManager mNavigationManager;
+  @NonNull
+  private final RoutingController mRoutingController;
+
+  public NavigationScreen(@NonNull CarContext carContext, @NonNull SurfaceRenderer surfaceRenderer)
+  {
+    super(carContext, surfaceRenderer);
+    mNavigationManager = carContext.getCarService(NavigationManager.class);
+    mRoutingController = RoutingController.get();
+  }
+
+  @NonNull
+  @Override
+  public Template onGetTemplate()
+  {
+    final NavigationTemplate.Builder builder = new NavigationTemplate.Builder();
+    builder.setBackgroundColor(ThemeUtils.isNightMode(getCarContext()) ? Colors.NAVIGATION_TEMPLATE_BACKGROUND_NIGHT : Colors.NAVIGATION_TEMPLATE_BACKGROUND_DAY);
+    builder.setActionStrip(createActionStrip());
+    builder.setMapActionStrip(UiHelpers.createMapActionStrip(getCarContext(), getSurfaceRenderer()));
+
+    final TravelEstimate destinationTravelEstimate = getDestinationTravelEstimate();
+    if (destinationTravelEstimate != null)
+      builder.setDestinationTravelEstimate(getDestinationTravelEstimate());
+
+    builder.setNavigationInfo(getNavigationInfo());
+    return builder.build();
+  }
+
+  @Override
+  public void onResume(@NonNull LifecycleOwner owner)
+  {
+    mRoutingController.attach(this);
+    mRoutingController.restore();
+    if (mRoutingController.isPlanning())
+      mRoutingController.start();
+  }
+
+  @Override
+  public void onPause(@NonNull LifecycleOwner owner)
+  {
+    mRoutingController.detach();
+  }
+
+  @Override
+  public void onNavigationStarted()
+  {
+    ThemeSwitcher.INSTANCE.restart(true);
+    mNavigationManager.navigationStarted();
+  }
+
+  @Override
+  public void onNavigationCancelled()
+  {
+    ThemeSwitcher.INSTANCE.restart(true);
+    mNavigationManager.navigationEnded();
+    RoutingUtils.resetTrip();
+    // TODO (AndrewShkrob): Handle "Stop" click and "Navigation finished" actions separately. Add localized string.
+    CarToast.makeText(getCarContext(), "Navigation finished", CarToast.LENGTH_LONG).show();
+    getScreenManager().popToRoot();
+  }
+
+  public void stopNavigation()
+  {
+    mRoutingController.cancel();
+  }
+
+  @NonNull
+  private ActionStrip createActionStrip()
+  {
+    final Action.Builder stopActionBuilder = new Action.Builder();
+    stopActionBuilder.setTitle(getCarContext().getString(R.string.current_location_unknown_stop_button));
+    stopActionBuilder.setOnClickListener(this::stopNavigation);
+
+    final ActionStrip.Builder builder = new ActionStrip.Builder();
+    builder.addAction(createTtsAction());
+    builder.addAction(UiHelpers.createSettingsActionForResult(this, getSurfaceRenderer(), this::onSettingsResult));
+    builder.addAction(stopActionBuilder.build());
+    return builder.build();
+  }
+
+  @Nullable
+  private TravelEstimate getDestinationTravelEstimate()
+  {
+    final Trip trip = RoutingUtils.getLastTrip();
+
+    if (trip.isLoading())
+      return null;
+
+    List<TravelEstimate> travelEstimates = trip.getDestinationTravelEstimates();
+    if (travelEstimates.size() != 1)
+      throw new RuntimeException("TravelEstimates size must be 1");
+
+    return travelEstimates.get(0);
+  }
+
+  @NonNull
+  private NavigationTemplate.NavigationInfo getNavigationInfo()
+  {
+    final androidx.car.app.navigation.model.RoutingInfo.Builder builder = new androidx.car.app.navigation.model.RoutingInfo.Builder();
+    final Trip trip = RoutingUtils.getLastTrip();
+
+    if (trip.isLoading())
+    {
+      builder.setLoading(true);
+      return builder.build();
+    }
+
+    final List<Step> steps = trip.getSteps();
+    final List<TravelEstimate> stepsEstimates = trip.getStepTravelEstimates();
+    if (steps.isEmpty())
+      throw new RuntimeException("Steps size must be at least 1");
+
+    builder.setCurrentStep(steps.get(0), Objects.requireNonNull(stepsEstimates.get(0).getRemainingDistance()));
+    if (steps.size() > 1)
+      builder.setNextStep(steps.get(1));
+
+    return builder.build();
+  }
+
+  private void onSettingsResult(@Nullable Object result)
+  {
+    if (result == null || result != DrivingOptionsScreen.DRIVING_OPTIONS_RESULT_CHANGED)
+      return;
+
+    // TODO (AndrewShkrob): Need to rebuild the route with updated driving options
+    Logger.d(TAG, "Driving options changed");
+  }
+
+  @NonNull
+  private Action createTtsAction()
+  {
+    final Action.Builder ttsActionBuilder = new Action.Builder();
+    @DrawableRes final int imgRes = TtsPlayer.isEnabled() ? R.drawable.ic_voice_on : R.drawable.ic_voice_off;
+    ttsActionBuilder.setIcon(new CarIcon.Builder(IconCompat.createWithResource(getCarContext(), imgRes)).build());
+    ttsActionBuilder.setOnClickListener(() -> {
+      TtsPlayer.setEnabled(!TtsPlayer.isEnabled());
+      invalidate();
+    });
+
+    return ttsActionBuilder.build();
+  }
+}

--- a/android/app/src/main/java/app/organicmaps/car/screens/PlaceScreen.java
+++ b/android/app/src/main/java/app/organicmaps/car/screens/PlaceScreen.java
@@ -1,0 +1,370 @@
+package app.organicmaps.car.screens;
+
+import static android.text.Spanned.SPAN_EXCLUSIVE_EXCLUSIVE;
+import static android.text.Spanned.SPAN_INCLUSIVE_INCLUSIVE;
+import static java.util.Objects.requireNonNull;
+
+import android.content.Intent;
+import android.net.Uri;
+import android.text.SpannableString;
+
+import androidx.annotation.NonNull;
+import androidx.annotation.Nullable;
+import androidx.car.app.CarContext;
+import androidx.car.app.CarToast;
+import androidx.car.app.model.Action;
+import androidx.car.app.model.CarIcon;
+import androidx.car.app.model.DistanceSpan;
+import androidx.car.app.model.DurationSpan;
+import androidx.car.app.model.ForegroundCarColorSpan;
+import androidx.car.app.model.Header;
+import androidx.car.app.model.Pane;
+import androidx.car.app.model.Row;
+import androidx.car.app.model.Template;
+import androidx.car.app.navigation.model.MapTemplate;
+import androidx.core.graphics.drawable.IconCompat;
+import androidx.lifecycle.LifecycleOwner;
+
+import app.organicmaps.Framework;
+import app.organicmaps.R;
+import app.organicmaps.bookmarks.data.BookmarkManager;
+import app.organicmaps.bookmarks.data.MapObject;
+import app.organicmaps.bookmarks.data.Metadata;
+import app.organicmaps.car.SurfaceRenderer;
+import app.organicmaps.car.screens.settings.DrivingOptionsScreen;
+import app.organicmaps.car.util.Colors;
+import app.organicmaps.car.util.RoutingHelpers;
+import app.organicmaps.car.util.UiHelpers;
+import app.organicmaps.car.screens.base.BaseMapScreen;
+import app.organicmaps.car.util.OnBackPressedCallback;
+import app.organicmaps.location.LocationHelper;
+import app.organicmaps.routing.RoutingController;
+import app.organicmaps.routing.RoutingInfo;
+import app.organicmaps.util.Config;
+import app.organicmaps.util.log.Logger;
+
+public class PlaceScreen extends BaseMapScreen implements OnBackPressedCallback.Callback, RoutingController.Container
+{
+  private static final String TAG = PlaceScreen.class.getSimpleName();
+
+  @NonNull
+  private MapObject mMapObject;
+
+  @NonNull
+  private final RoutingController mRoutingController;
+
+  @NonNull
+  private final OnBackPressedCallback mOnBackPressedCallback;
+
+  private PlaceScreen(@NonNull Builder builder)
+  {
+    super(builder.mCarContext, builder.mSurfaceRenderer);
+    mMapObject = requireNonNull(builder.mMapObject);
+    mRoutingController = RoutingController.get();
+    mOnBackPressedCallback = new OnBackPressedCallback(getCarContext(), this);
+  }
+
+  @NonNull
+  @Override
+  public Template onGetTemplate()
+  {
+    final MapTemplate.Builder builder = new MapTemplate.Builder();
+    builder.setHeader(createHeader());
+    builder.setActionStrip(UiHelpers.createSettingsActionStrip(this, getSurfaceRenderer()));
+    builder.setMapController(UiHelpers.createMapController(getCarContext(), getSurfaceRenderer()));
+    builder.setPane(createPane());
+
+    return builder.build();
+  }
+
+  @NonNull
+  public MapObject getMapObject()
+  {
+    return mMapObject;
+  }
+
+  @NonNull
+  private Header createHeader()
+  {
+    final Header.Builder builder = new Header.Builder();
+    builder.setStartHeaderAction(Action.BACK);
+    getCarContext().getOnBackPressedDispatcher().addCallback(this, mOnBackPressedCallback);
+    if (!mMapObject.isMyPosition() && !mRoutingController.isBuilding() && !mRoutingController.isBuilt())
+      builder.addEndHeaderAction(createBookmarkAction());
+    if (mRoutingController.isBuilt())
+      builder.addEndHeaderAction(createDrivingOptionsAction());
+
+    return builder.build();
+  }
+
+  @NonNull
+  private Pane createPane()
+  {
+    final Pane.Builder builder = new Pane.Builder();
+
+    if (mRoutingController.isBuilding())
+    {
+      builder.setLoading(true);
+      return builder.build();
+    }
+
+    builder.addRow(getPlaceDescription());
+    if (mRoutingController.isBuilt())
+      builder.addRow(getPlaceRouteInfo());
+
+    final Row placeOpeningHours = UiHelpers.getPlaceOpeningHoursRow(mMapObject, getCarContext());
+    if (placeOpeningHours != null)
+      builder.addRow(placeOpeningHours);
+
+    if (!mMapObject.isMyPosition())
+      createPaneActions(builder);
+
+    return builder.build();
+  }
+
+  @NonNull
+  private Row getPlaceDescription()
+  {
+    final Row.Builder builder = new Row.Builder();
+    builder.setTitle(mMapObject.getTitle());
+    if (!mMapObject.getSubtitle().isEmpty())
+      builder.addText(mMapObject.getSubtitle());
+    String address = mMapObject.getAddress();
+    if (address.isEmpty())
+      address = Framework.nativeGetAddress(mMapObject.getLat(), mMapObject.getLon());
+    if (!address.isEmpty())
+      builder.addText(address);
+    return builder.build();
+  }
+
+  @NonNull
+  private Row getPlaceRouteInfo()
+  {
+    final RoutingInfo routingInfo = RoutingController.get().getCachedRoutingInfo();
+    if (routingInfo == null)
+      throw new IllegalStateException("routingInfo == null");
+
+    final Row.Builder builder = new Row.Builder();
+
+    final SpannableString time = new SpannableString(" ");
+    time.setSpan(DurationSpan.create(routingInfo.totalTimeInSeconds), 0, 1, SPAN_INCLUSIVE_INCLUSIVE);
+    builder.setTitle(time);
+
+    final SpannableString distance = new SpannableString(" ");
+    distance.setSpan(DistanceSpan.create(RoutingHelpers.createDistance(routingInfo.distToTarget)), 0, 1, SPAN_INCLUSIVE_INCLUSIVE);
+    distance.setSpan(ForegroundCarColorSpan.create(Colors.DISTANCE), 0, 1, SPAN_EXCLUSIVE_EXCLUSIVE);
+    builder.addText(distance);
+
+    return builder.build();
+  }
+
+  private void createPaneActions(@NonNull Pane.Builder builder)
+  {
+    final String phoneNumber = getFirstPhoneNumber(mMapObject);
+    if (!phoneNumber.isEmpty())
+    {
+      final Action.Builder openDialBuilder = new Action.Builder();
+      openDialBuilder.setIcon(new CarIcon.Builder(IconCompat.createWithResource(getCarContext(), R.drawable.ic_phone)).build());
+      openDialBuilder.setOnClickListener(() -> getCarContext().startCarApp(new Intent(Intent.ACTION_DIAL, Uri.parse("tel:" + phoneNumber))));
+      builder.addAction(openDialBuilder.build());
+    }
+
+    final Action.Builder startRouteBuilder = new Action.Builder();
+    startRouteBuilder.setBackgroundColor(Colors.START_NAVIGATION);
+
+    if (mRoutingController.isNavigating())
+    {
+      startRouteBuilder.setFlags(Action.FLAG_PRIMARY);
+      startRouteBuilder.setTitle(getCarContext().getString(R.string.placepage_add_stop));
+      startRouteBuilder.setIcon(new CarIcon.Builder(IconCompat.createWithResource(getCarContext(), R.drawable.ic_route_via)).build());
+      startRouteBuilder.setOnClickListener(() -> mRoutingController.addStop(mMapObject));
+    }
+    else if (mRoutingController.isBuilt())
+    {
+      startRouteBuilder.setFlags(Action.FLAG_DEFAULT);
+      startRouteBuilder.setTitle(getCarContext().getString(R.string.p2p_start));
+      startRouteBuilder.setIcon(new CarIcon.Builder(IconCompat.createWithResource(getCarContext(), R.drawable.ic_follow_and_rotate)).build());
+      startRouteBuilder.setOnClickListener(() -> getScreenManager().push(new NavigationScreen(getCarContext(), getSurfaceRenderer())));
+    }
+    else
+    {
+      startRouteBuilder.setFlags(Action.FLAG_DEFAULT);
+      startRouteBuilder.setTitle(getCarContext().getString(R.string.p2p_to_here));
+      startRouteBuilder.setIcon(new CarIcon.Builder(IconCompat.createWithResource(getCarContext(), R.drawable.ic_route_to)).build());
+      startRouteBuilder.setOnClickListener(() -> {
+        mRoutingController.setRouterType(Framework.ROUTER_TYPE_VEHICLE);
+        mRoutingController.prepare(LocationHelper.from(getCarContext()).getMyPosition(), mMapObject);
+        Framework.nativeDeactivatePopup();
+      });
+    }
+
+    builder.addAction(startRouteBuilder.build());
+  }
+
+  @NonNull
+  private Action createBookmarkAction()
+  {
+    final Action.Builder builder = new Action.Builder();
+    final CarIcon.Builder iconBuilder = new CarIcon.Builder(IconCompat.createWithResource(getCarContext(), R.drawable.ic_bookmarks));
+    if (mMapObject.isBookmark())
+      iconBuilder.setTint(Colors.BOOKMARK_SAVED);
+    builder.setIcon(iconBuilder.build());
+    builder.setOnClickListener(() -> {
+      // TODO(AndrewShkrob): Bookmarks not working while mRoutingController.isPlanning()
+      if (mMapObject.isBookmark())
+        Framework.nativeDeleteBookmarkFromMapObject();
+      else
+        BookmarkManager.INSTANCE.addNewBookmark(mMapObject.getLat(), mMapObject.getLon());
+    });
+    return builder.build();
+  }
+
+  @NonNull
+  private Action createDrivingOptionsAction()
+  {
+    return new Action.Builder()
+        .setIcon(new CarIcon.Builder(IconCompat.createWithResource(getCarContext(), R.drawable.ic_settings)).build())
+        .setOnClickListener(() -> getScreenManager().pushForResult(new DrivingOptionsScreen(getCarContext(), getSurfaceRenderer()), this::onDrivingOptionsResult))
+        .build();
+  }
+
+  private void onDrivingOptionsResult(@Nullable Object result)
+  {
+    if (result == null || result != DrivingOptionsScreen.DRIVING_OPTIONS_RESULT_CHANGED)
+      return;
+
+    // Driving Options changed. Let's rebuild the route
+    mRoutingController.rebuildLastRoute();
+  }
+
+  @NonNull
+  private static String getFirstPhoneNumber(@NonNull MapObject mapObject)
+  {
+    if (!mapObject.hasMetadata())
+      return "";
+
+    final String phones = mapObject.getMetadata(Metadata.MetadataType.FMD_PHONE_NUMBER);
+    return phones.split(";", 1)[0];
+  }
+
+  @Override
+  public void onBuiltRoute()
+  {
+    invalidate();
+  }
+
+  @Override
+  public void onPlanningStarted()
+  {
+    invalidate();
+  }
+
+  @Override
+  public void onPlanningCancelled()
+  {
+    invalidate();
+  }
+
+  @Override
+  public void showRoutePlan(boolean show, @Nullable Runnable completionListener)
+  {
+    if (completionListener != null)
+      completionListener.run();
+  }
+
+  @Override
+  public void onCommonBuildError(int lastResultCode, @NonNull String[] lastMissingMaps)
+  {
+    // TODO(AndrewShkrob): show download maps request
+    Logger.e(TAG, "lastResultCode: " + lastResultCode + ", lastMissingMaps: " + String.join(", ", lastMissingMaps));
+    CarToast.makeText(getCarContext(), R.string.unable_to_calc_alert_title, CarToast.LENGTH_LONG).show();
+    mRoutingController.cancel();
+    Framework.nativeShowFeature(mMapObject.getFeatureId());
+  }
+
+  @Override
+  public void onDrivingOptionsBuildError()
+  {
+    Logger.e(TAG, "");
+    CarToast.makeText(getCarContext(), R.string.unable_to_calc_alert_title, CarToast.LENGTH_LONG).show();
+    mRoutingController.cancel();
+    Framework.nativeShowFeature(mMapObject.getFeatureId());
+  }
+
+  @Override
+  public void onCreate(@NonNull LifecycleOwner owner)
+  {
+    mRoutingController.attach(this);
+    if (mRoutingController.isBuilt() && mRoutingController.getEndPoint() != mMapObject)
+      mRoutingController.cancel();
+    else if (mRoutingController.isPlanning() && mRoutingController.getLastRouterType() != Framework.ROUTER_TYPE_VEHICLE)
+    {
+      mRoutingController.setRouterType(Framework.ROUTER_TYPE_VEHICLE);
+      mRoutingController.rebuildLastRoute();
+    }
+  }
+
+  @Override
+  public void onDestroy(@NonNull LifecycleOwner owner)
+  {
+    mRoutingController.detach();
+  }
+
+  @Override
+  public void onBackPressed()
+  {
+    if (!mRoutingController.isNavigating())
+      mRoutingController.cancel();
+    Framework.nativeDeactivatePopup();
+  }
+
+  /**
+   * Called when MapObject is updated but FeatureId remains unchanged.
+   * For example when MapObject is added or removed from bookmarks
+   *
+   * @param newMapObject updated MapObject with same FeatureId
+   */
+  public void updateMapObject(@NonNull MapObject newMapObject)
+  {
+    if (!mMapObject.getFeatureId().equals(newMapObject.getFeatureId()))
+    {
+      Logger.e(TAG, newMapObject.getFeatureId() + " != " + mMapObject.getFeatureId());
+      return;
+    }
+    mMapObject = newMapObject;
+    invalidate();
+  }
+
+  /**
+   * A builder of {@link PlaceScreen}.
+   */
+  public static final class Builder
+  {
+    @NonNull
+    private final CarContext mCarContext;
+    @NonNull
+    private final SurfaceRenderer mSurfaceRenderer;
+    @Nullable
+    private MapObject mMapObject;
+
+    public Builder(@NonNull final CarContext carContext, @NonNull final SurfaceRenderer surfaceRenderer)
+    {
+      mCarContext = carContext;
+      mSurfaceRenderer = surfaceRenderer;
+    }
+
+    public Builder setMapObject(@NonNull MapObject mapObject)
+    {
+      mMapObject = mapObject;
+      return this;
+    }
+
+    @NonNull
+    public PlaceScreen build()
+    {
+      if (mMapObject == null)
+        throw new IllegalStateException("MapObject must be set");
+      return new PlaceScreen(this);
+    }
+  }
+}

--- a/android/app/src/main/java/app/organicmaps/car/screens/PlaceScreen.java
+++ b/android/app/src/main/java/app/organicmaps/car/screens/PlaceScreen.java
@@ -2,7 +2,6 @@ package app.organicmaps.car.screens;
 
 import static android.text.Spanned.SPAN_EXCLUSIVE_EXCLUSIVE;
 import static android.text.Spanned.SPAN_INCLUSIVE_INCLUSIVE;
-import static java.util.Objects.requireNonNull;
 
 import android.content.Intent;
 import android.net.Uri;
@@ -40,15 +39,19 @@ import app.organicmaps.car.util.OnBackPressedCallback;
 import app.organicmaps.location.LocationHelper;
 import app.organicmaps.routing.RoutingController;
 import app.organicmaps.routing.RoutingInfo;
-import app.organicmaps.util.Config;
 import app.organicmaps.util.log.Logger;
+
+import java.util.Objects;
 
 public class PlaceScreen extends BaseMapScreen implements OnBackPressedCallback.Callback, RoutingController.Container
 {
   private static final String TAG = PlaceScreen.class.getSimpleName();
 
-  @NonNull
+  private static final int ROUTER_TYPE = Framework.ROUTER_TYPE_VEHICLE;
+
+  @Nullable
   private MapObject mMapObject;
+  private boolean mIsBuildError = false;
 
   @NonNull
   private final RoutingController mRoutingController;
@@ -59,7 +62,7 @@ public class PlaceScreen extends BaseMapScreen implements OnBackPressedCallback.
   private PlaceScreen(@NonNull Builder builder)
   {
     super(builder.mCarContext, builder.mSurfaceRenderer);
-    mMapObject = requireNonNull(builder.mMapObject);
+    mMapObject = builder.mMapObject;
     mRoutingController = RoutingController.get();
     mOnBackPressedCallback = new OnBackPressedCallback(getCarContext(), this);
   }
@@ -77,10 +80,34 @@ public class PlaceScreen extends BaseMapScreen implements OnBackPressedCallback.
     return builder.build();
   }
 
-  @NonNull
-  public MapObject getMapObject()
+  @Override
+  public void onCreate(@NonNull LifecycleOwner owner)
   {
-    return mMapObject;
+    mRoutingController.restore();
+    if (mRoutingController.isNavigating())
+    {
+      showNavigation(true);
+      return;
+    }
+
+    mRoutingController.attach(this);
+    if (mMapObject == null)
+      mRoutingController.restoreRoute();
+    else
+    {
+      if (mRoutingController.getLastRouterType() != ROUTER_TYPE)
+        mRoutingController.setRouterType(ROUTER_TYPE);
+      if (!mRoutingController.isPlanning() || (mRoutingController.isPlanning() && !MapObject.same(mMapObject, mRoutingController.getEndPoint())))
+        mRoutingController.prepare(LocationHelper.from(getCarContext()).getMyPosition(), mMapObject);
+    }
+  }
+
+  @Override
+  public void onDestroy(@NonNull LifecycleOwner owner)
+  {
+    if (mRoutingController.isPlanning())
+      mRoutingController.onSaveState();
+    mRoutingController.detach();
   }
 
   @NonNull
@@ -89,11 +116,7 @@ public class PlaceScreen extends BaseMapScreen implements OnBackPressedCallback.
     final Header.Builder builder = new Header.Builder();
     builder.setStartHeaderAction(Action.BACK);
     getCarContext().getOnBackPressedDispatcher().addCallback(this, mOnBackPressedCallback);
-    if (!mMapObject.isMyPosition() && !mRoutingController.isBuilding() && !mRoutingController.isBuilt())
-      builder.addEndHeaderAction(createBookmarkAction());
-    if (mRoutingController.isBuilt())
-      builder.addEndHeaderAction(createDrivingOptionsAction());
-
+    builder.addEndHeaderAction(createDrivingOptionsAction());
     return builder.build();
   }
 
@@ -101,23 +124,23 @@ public class PlaceScreen extends BaseMapScreen implements OnBackPressedCallback.
   private Pane createPane()
   {
     final Pane.Builder builder = new Pane.Builder();
+    final RoutingInfo routingInfo = Framework.nativeGetRouteFollowingInfo();
 
-    if (mRoutingController.isBuilding())
+    if (routingInfo == null && !mIsBuildError)
     {
       builder.setLoading(true);
       return builder.build();
     }
 
     builder.addRow(getPlaceDescription());
-    if (mRoutingController.isBuilt())
-      builder.addRow(getPlaceRouteInfo());
+    if (routingInfo != null)
+      builder.addRow(getPlaceRouteInfo(routingInfo));
 
-    final Row placeOpeningHours = UiHelpers.getPlaceOpeningHoursRow(mMapObject, getCarContext());
+    final Row placeOpeningHours = UiHelpers.getPlaceOpeningHoursRow(Objects.requireNonNull(mMapObject), getCarContext());
     if (placeOpeningHours != null)
       builder.addRow(placeOpeningHours);
 
-    if (!mMapObject.isMyPosition())
-      createPaneActions(builder);
+    createPaneActions(builder);
 
     return builder.build();
   }
@@ -125,6 +148,8 @@ public class PlaceScreen extends BaseMapScreen implements OnBackPressedCallback.
   @NonNull
   private Row getPlaceDescription()
   {
+    Objects.requireNonNull(mMapObject);
+
     final Row.Builder builder = new Row.Builder();
     builder.setTitle(mMapObject.getTitle());
     if (!mMapObject.getSubtitle().isEmpty())
@@ -138,12 +163,8 @@ public class PlaceScreen extends BaseMapScreen implements OnBackPressedCallback.
   }
 
   @NonNull
-  private Row getPlaceRouteInfo()
+  private Row getPlaceRouteInfo(@NonNull RoutingInfo routingInfo)
   {
-    final RoutingInfo routingInfo = RoutingController.get().getCachedRoutingInfo();
-    if (routingInfo == null)
-      throw new IllegalStateException("routingInfo == null");
-
     final Row.Builder builder = new Row.Builder();
 
     final SpannableString time = new SpannableString(" ");
@@ -160,6 +181,8 @@ public class PlaceScreen extends BaseMapScreen implements OnBackPressedCallback.
 
   private void createPaneActions(@NonNull Pane.Builder builder)
   {
+    Objects.requireNonNull(mMapObject);
+
     final String phoneNumber = getFirstPhoneNumber(mMapObject);
     if (!phoneNumber.isEmpty())
     {
@@ -169,34 +192,16 @@ public class PlaceScreen extends BaseMapScreen implements OnBackPressedCallback.
       builder.addAction(openDialBuilder.build());
     }
 
+    // Don't show `Start` button when build error.
+    if (mIsBuildError)
+      return;
+
     final Action.Builder startRouteBuilder = new Action.Builder();
     startRouteBuilder.setBackgroundColor(Colors.START_NAVIGATION);
-
-    if (mRoutingController.isNavigating())
-    {
-      startRouteBuilder.setFlags(Action.FLAG_PRIMARY);
-      startRouteBuilder.setTitle(getCarContext().getString(R.string.placepage_add_stop));
-      startRouteBuilder.setIcon(new CarIcon.Builder(IconCompat.createWithResource(getCarContext(), R.drawable.ic_route_via)).build());
-      startRouteBuilder.setOnClickListener(() -> mRoutingController.addStop(mMapObject));
-    }
-    else if (mRoutingController.isBuilt())
-    {
-      startRouteBuilder.setFlags(Action.FLAG_DEFAULT);
-      startRouteBuilder.setTitle(getCarContext().getString(R.string.p2p_start));
-      startRouteBuilder.setIcon(new CarIcon.Builder(IconCompat.createWithResource(getCarContext(), R.drawable.ic_follow_and_rotate)).build());
-      startRouteBuilder.setOnClickListener(() -> getScreenManager().push(new NavigationScreen(getCarContext(), getSurfaceRenderer())));
-    }
-    else
-    {
-      startRouteBuilder.setFlags(Action.FLAG_DEFAULT);
-      startRouteBuilder.setTitle(getCarContext().getString(R.string.p2p_to_here));
-      startRouteBuilder.setIcon(new CarIcon.Builder(IconCompat.createWithResource(getCarContext(), R.drawable.ic_route_to)).build());
-      startRouteBuilder.setOnClickListener(() -> {
-        mRoutingController.setRouterType(Framework.ROUTER_TYPE_VEHICLE);
-        mRoutingController.prepare(LocationHelper.from(getCarContext()).getMyPosition(), mMapObject);
-        Framework.nativeDeactivatePopup();
-      });
-    }
+    startRouteBuilder.setFlags(Action.FLAG_PRIMARY);
+    startRouteBuilder.setTitle(getCarContext().getString(R.string.p2p_start));
+    startRouteBuilder.setIcon(new CarIcon.Builder(IconCompat.createWithResource(getCarContext(), R.drawable.ic_follow_and_rotate)).build());
+    startRouteBuilder.setOnClickListener(mRoutingController::start);
 
     builder.addAction(startRouteBuilder.build());
   }
@@ -248,91 +253,62 @@ public class PlaceScreen extends BaseMapScreen implements OnBackPressedCallback.
   }
 
   @Override
-  public void onBuiltRoute()
+  public void onBackPressed()
   {
-    invalidate();
+    mRoutingController.cancel();
   }
 
   @Override
-  public void onPlanningStarted()
+  public void showRoutePlan(boolean show, @Nullable Runnable completionListener)
   {
+    if (!show)
+      return;
+
+    if (completionListener != null)
+      completionListener.run();
+  }
+
+  @Override
+  public void showNavigation(boolean show)
+  {
+    if (show)
+      getScreenManager().push(new NavigationScreen(getCarContext(), getSurfaceRenderer()));
+  }
+
+  @Override
+  public void onBuiltRoute()
+  {
+    Framework.nativeDeactivatePopup();
+    mMapObject = mRoutingController.getEndPoint();
     invalidate();
   }
 
   @Override
   public void onPlanningCancelled()
   {
-    invalidate();
-  }
-
-  @Override
-  public void showRoutePlan(boolean show, @Nullable Runnable completionListener)
-  {
-    if (completionListener != null)
-      completionListener.run();
+    Framework.nativeDeactivatePopup();
   }
 
   @Override
   public void onCommonBuildError(int lastResultCode, @NonNull String[] lastMissingMaps)
   {
-    // TODO(AndrewShkrob): show download maps request
+    // TODO(AndrewShkrob): Show the download maps request
     Logger.e(TAG, "lastResultCode: " + lastResultCode + ", lastMissingMaps: " + String.join(", ", lastMissingMaps));
     CarToast.makeText(getCarContext(), R.string.unable_to_calc_alert_title, CarToast.LENGTH_LONG).show();
-    mRoutingController.cancel();
-    Framework.nativeShowFeature(mMapObject.getFeatureId());
+    mIsBuildError = true;
+    invalidate();
   }
 
   @Override
   public void onDrivingOptionsBuildError()
   {
-    Logger.e(TAG, "");
-    CarToast.makeText(getCarContext(), R.string.unable_to_calc_alert_title, CarToast.LENGTH_LONG).show();
-    mRoutingController.cancel();
-    Framework.nativeShowFeature(mMapObject.getFeatureId());
+    onCommonBuildError(-1, new String[0]);
   }
 
   @Override
-  public void onCreate(@NonNull LifecycleOwner owner)
+  public void onDrivingOptionsWarning()
   {
-    mRoutingController.attach(this);
-    if (mRoutingController.isBuilt() && mRoutingController.getEndPoint() != mMapObject)
-      mRoutingController.cancel();
-    else if (mRoutingController.isPlanning() && mRoutingController.getLastRouterType() != Framework.ROUTER_TYPE_VEHICLE)
-    {
-      mRoutingController.setRouterType(Framework.ROUTER_TYPE_VEHICLE);
-      mRoutingController.rebuildLastRoute();
-    }
-  }
-
-  @Override
-  public void onDestroy(@NonNull LifecycleOwner owner)
-  {
-    mRoutingController.detach();
-  }
-
-  @Override
-  public void onBackPressed()
-  {
-    if (!mRoutingController.isNavigating())
-      mRoutingController.cancel();
-    Framework.nativeDeactivatePopup();
-  }
-
-  /**
-   * Called when MapObject is updated but FeatureId remains unchanged.
-   * For example when MapObject is added or removed from bookmarks
-   *
-   * @param newMapObject updated MapObject with same FeatureId
-   */
-  public void updateMapObject(@NonNull MapObject newMapObject)
-  {
-    if (!mMapObject.getFeatureId().equals(newMapObject.getFeatureId()))
-    {
-      Logger.e(TAG, newMapObject.getFeatureId() + " != " + mMapObject.getFeatureId());
-      return;
-    }
-    mMapObject = newMapObject;
-    invalidate();
+    onCommonBuildError(-1, new String[0]);
   }
 
   /**
@@ -353,7 +329,7 @@ public class PlaceScreen extends BaseMapScreen implements OnBackPressedCallback.
       mSurfaceRenderer = surfaceRenderer;
     }
 
-    public Builder setMapObject(@NonNull MapObject mapObject)
+    public Builder setMapObject(@Nullable MapObject mapObject)
     {
       mMapObject = mapObject;
       return this;
@@ -362,8 +338,6 @@ public class PlaceScreen extends BaseMapScreen implements OnBackPressedCallback.
     @NonNull
     public PlaceScreen build()
     {
-      if (mMapObject == null)
-        throw new IllegalStateException("MapObject must be set");
       return new PlaceScreen(this);
     }
   }

--- a/android/app/src/main/java/app/organicmaps/car/screens/RequestPermissionsScreen.java
+++ b/android/app/src/main/java/app/organicmaps/car/screens/RequestPermissionsScreen.java
@@ -1,0 +1,87 @@
+package app.organicmaps.car.screens;
+
+import static android.Manifest.permission.ACCESS_COARSE_LOCATION;
+import static android.Manifest.permission.ACCESS_FINE_LOCATION;
+
+import androidx.annotation.NonNull;
+import androidx.car.app.CarContext;
+import androidx.car.app.model.Action;
+import androidx.car.app.model.CarIcon;
+import androidx.car.app.model.MessageTemplate;
+import androidx.car.app.model.ParkedOnlyOnClickListener;
+import androidx.car.app.model.Template;
+import androidx.core.graphics.drawable.IconCompat;
+import androidx.lifecycle.LifecycleOwner;
+
+import app.organicmaps.R;
+import app.organicmaps.car.screens.base.BaseScreen;
+import app.organicmaps.car.util.Colors;
+import app.organicmaps.util.LocationUtils;
+
+import java.util.Arrays;
+import java.util.List;
+
+public class RequestPermissionsScreen extends BaseScreen
+{
+  public interface PermissionsGrantedCallback
+  {
+    void onPermissionsGranted();
+  }
+
+  private static final List<String> LOCATION_PERMISSIONS = Arrays.asList(ACCESS_COARSE_LOCATION, ACCESS_FINE_LOCATION);
+
+  @NonNull
+  private final PermissionsGrantedCallback mPermissionsGrantedCallback;
+
+  public RequestPermissionsScreen(@NonNull CarContext carContext, @NonNull PermissionsGrantedCallback permissionsGrantedCallback)
+  {
+    super(carContext);
+    mPermissionsGrantedCallback = permissionsGrantedCallback;
+  }
+
+  @NonNull
+  @Override
+  public Template onGetTemplate()
+  {
+    final MessageTemplate.Builder builder = new MessageTemplate.Builder(getCarContext().getString(R.string.aa_location_permissions_request));
+    final Action grantPermissions = new Action.Builder()
+        .setTitle(getCarContext().getString(R.string.aa_grant_permissions))
+        .setBackgroundColor(Colors.BUTTON_ACCEPT)
+        .setOnClickListener(ParkedOnlyOnClickListener.create(() -> getCarContext().requestPermissions(LOCATION_PERMISSIONS, this::onRequestPermissionsResult)))
+        .build();
+
+    builder.setHeaderAction(Action.APP_ICON);
+    builder.setTitle(getCarContext().getString(R.string.app_name));
+    builder.setIcon(new CarIcon.Builder(IconCompat.createWithResource(getCarContext(), R.drawable.ic_location_off)).build());
+    builder.addAction(grantPermissions);
+    return builder.build();
+  }
+
+  @Override
+  public void onResume(@NonNull LifecycleOwner owner)
+  {
+    // Let's review the permissions once more, as we might enter this function following an ErrorScreen situation
+    // where the user manually enabled location permissions.
+    if (LocationUtils.checkFineLocationPermission(getCarContext()))
+    {
+      mPermissionsGrantedCallback.onPermissionsGranted();
+      finish();
+    }
+  }
+
+  private void onRequestPermissionsResult(@NonNull List<String> grantedPermissions, @NonNull List<String> rejectedPermissions)
+  {
+    if (grantedPermissions.isEmpty())
+    {
+      getScreenManager().push(new ErrorScreen.Builder(getCarContext())
+          .setErrorMessage(R.string.location_is_disabled_long_text)
+          .setCloseable(true)
+          .build()
+      );
+      return;
+    }
+
+    mPermissionsGrantedCallback.onPermissionsGranted();
+    finish();
+  }
+}

--- a/android/app/src/main/java/app/organicmaps/car/screens/base/BaseMapScreen.java
+++ b/android/app/src/main/java/app/organicmaps/car/screens/base/BaseMapScreen.java
@@ -1,0 +1,24 @@
+package app.organicmaps.car.screens.base;
+
+import androidx.annotation.NonNull;
+import androidx.car.app.CarContext;
+
+import app.organicmaps.car.SurfaceRenderer;
+
+public abstract class BaseMapScreen extends BaseScreen
+{
+  @NonNull
+  private final SurfaceRenderer mSurfaceRenderer;
+
+  public BaseMapScreen(@NonNull CarContext carContext, @NonNull SurfaceRenderer surfaceRenderer)
+  {
+    super(carContext);
+    mSurfaceRenderer = surfaceRenderer;
+  }
+
+  @NonNull
+  protected SurfaceRenderer getSurfaceRenderer()
+  {
+    return mSurfaceRenderer;
+  }
+}

--- a/android/app/src/main/java/app/organicmaps/car/screens/base/BaseScreen.java
+++ b/android/app/src/main/java/app/organicmaps/car/screens/base/BaseScreen.java
@@ -1,0 +1,15 @@
+package app.organicmaps.car.screens.base;
+
+import androidx.annotation.NonNull;
+import androidx.car.app.CarContext;
+import androidx.car.app.Screen;
+import androidx.lifecycle.DefaultLifecycleObserver;
+
+public abstract class BaseScreen extends Screen implements DefaultLifecycleObserver
+{
+  public BaseScreen(@NonNull CarContext carContext)
+  {
+    super(carContext);
+    getLifecycle().addObserver(this);
+  }
+}

--- a/android/app/src/main/java/app/organicmaps/car/screens/hacks/PopToRootHack.java
+++ b/android/app/src/main/java/app/organicmaps/car/screens/hacks/PopToRootHack.java
@@ -1,0 +1,116 @@
+package app.organicmaps.car.screens.hacks;
+
+import static java.util.Objects.requireNonNull;
+
+import android.os.Handler;
+import android.os.Looper;
+
+import androidx.annotation.NonNull;
+import androidx.annotation.Nullable;
+import androidx.car.app.CarContext;
+import androidx.car.app.model.Template;
+import androidx.car.app.navigation.model.RoutePreviewNavigationTemplate;
+import androidx.lifecycle.LifecycleOwner;
+
+import app.organicmaps.car.screens.base.BaseScreen;
+
+/**
+ * This class is used to provide a working solution for next the two actions:
+ * <ul>
+ *   <li> {@code popToRoot();}
+ *   <li> {@code push(new Screen());}
+ * </ul>
+ * <p>
+ * When you run the following code:
+ * <pre>
+ * {@code
+ *   ScreenManager.popToRoot();
+ *   ScreenManager.push(new Screen());
+ * }
+ * </pre>
+ * the first {@code popToRoot} action won't be applied and a new {@link androidx.car.app.Screen} will be pushed to the top of the stack.
+ * <p>
+ * Actually, the {@code popToRoot} action <b>will</b> be applied and the screen stack will be cleared.
+ * It will contain only two screens: the root and the newly pushed.
+ * But the steps counter won't be reset after {@code popToRoot}.
+ * It will be increased by one as if we just push a new screen without {@code popToRoot} action.
+ * <p>
+ * To decrease a step counter, it is required to display a previous screen.
+ * For example we're on step 4 and we're making a {@code popToRoot} action.
+ * The step counter will be decreased to 1 after {@code RootScreen.onStart()/onResume()} call.
+ * <p>
+ * How it works?
+ * <p>
+ * In {@link #onStart(LifecycleOwner)} we call {@code getScreenManager().popToRoot();}
+ * <p>
+ * The screen ({@link PopToRootHack} class) should begin to destroy - all the lifecycle methods should be called step by step.
+ * <p>
+ * In {@link #onStop(LifecycleOwner)} we post {@code getScreenManager().push(mScreenToPush);} to the main thread.
+ * This mean when the main thread will be free, it will execute our code - it will push a new screen.
+ * This will happen when {@link PopToRootHack} will be destroyed and the root screen will be displayed.
+ */
+public final class PopToRootHack extends BaseScreen
+{
+  private static final Handler mHandler = new Handler(Looper.getMainLooper());
+  private static final RoutePreviewNavigationTemplate mTemplate = new RoutePreviewNavigationTemplate.Builder().setLoading(true).build();
+
+  @NonNull
+  private final BaseScreen mScreenToPush;
+
+  private PopToRootHack(@NonNull Builder builder)
+  {
+    super(builder.mCarContext);
+    mScreenToPush = requireNonNull(builder.mScreenToPush);
+  }
+
+  @NonNull
+  @Override
+  public Template onGetTemplate()
+  {
+    getScreenManager().popToRoot();
+    return mTemplate;
+  }
+
+  @Override
+  public void onStart(@NonNull LifecycleOwner owner)
+  {
+    getScreenManager().popToRoot();
+  }
+
+  @Override
+  public void onStop(@NonNull LifecycleOwner owner)
+  {
+    mHandler.post(() -> getScreenManager().push(mScreenToPush));
+  }
+
+  /**
+   * A builder of {@link PopToRootHack}.
+   */
+  public static final class Builder
+  {
+    @NonNull
+    private final CarContext mCarContext;
+    @Nullable
+    private BaseScreen mScreenToPush;
+
+    public Builder(@NonNull final CarContext carContext)
+    {
+      mCarContext = carContext;
+    }
+
+    @NonNull
+    public Builder setScreenToPush(@NonNull BaseScreen screenToPush)
+    {
+      mScreenToPush = screenToPush;
+      return this;
+    }
+
+    @NonNull
+    public PopToRootHack build()
+    {
+      if (mScreenToPush == null)
+        throw new IllegalStateException("You must specify Screen that will be pushed to the ScreenManager after the popToRoot() action");
+      return new PopToRootHack(this);
+    }
+  }
+}

--- a/android/app/src/main/java/app/organicmaps/car/screens/search/SearchOnMapScreen.java
+++ b/android/app/src/main/java/app/organicmaps/car/screens/search/SearchOnMapScreen.java
@@ -1,0 +1,207 @@
+package app.organicmaps.car.screens.search;
+
+import androidx.annotation.NonNull;
+import androidx.annotation.Nullable;
+import androidx.car.app.CarContext;
+import androidx.car.app.constraints.ConstraintManager;
+import androidx.car.app.model.Action;
+import androidx.car.app.model.CarIcon;
+import androidx.car.app.model.Header;
+import androidx.car.app.model.ItemList;
+import androidx.car.app.model.Row;
+import androidx.car.app.model.Template;
+import androidx.car.app.navigation.model.PlaceListNavigationTemplate;
+import androidx.core.graphics.drawable.IconCompat;
+import androidx.lifecycle.LifecycleOwner;
+
+import app.organicmaps.R;
+import app.organicmaps.bookmarks.data.MapObject;
+import app.organicmaps.car.SurfaceRenderer;
+import app.organicmaps.car.screens.base.BaseMapScreen;
+import app.organicmaps.car.util.UiHelpers;
+import app.organicmaps.location.LocationHelper;
+import app.organicmaps.search.NativeSearchListener;
+import app.organicmaps.search.SearchEngine;
+import app.organicmaps.search.SearchRecents;
+import app.organicmaps.search.SearchResult;
+import app.organicmaps.util.Language;
+
+public class SearchOnMapScreen extends BaseMapScreen implements NativeSearchListener
+{
+  private final int MAX_RESULTS_SIZE;
+
+  @NonNull
+  private final String mQuery;
+  @NonNull
+  private final String mLocale;
+  private final boolean mIsCategory;
+
+  @Nullable
+  private ItemList mResults = null;
+
+  private SearchOnMapScreen(@NonNull Builder builder)
+  {
+    super(builder.mCarContext, builder.mSurfaceRenderer);
+    final ConstraintManager constraintManager = getCarContext().getCarService(ConstraintManager.class);
+    MAX_RESULTS_SIZE = constraintManager.getContentLimit(ConstraintManager.CONTENT_LIMIT_TYPE_PLACE_LIST);
+
+    mQuery = builder.mQuery;
+    mLocale = builder.mLocale;
+    mIsCategory = builder.mIsCategory;
+  }
+
+  @NonNull
+  @Override
+  public Template onGetTemplate()
+  {
+    final PlaceListNavigationTemplate.Builder builder = new PlaceListNavigationTemplate.Builder();
+    builder.setHeader(createHeader());
+    builder.setMapActionStrip(UiHelpers.createMapActionStrip(getCarContext(), getSurfaceRenderer()));
+    if (mResults == null)
+      builder.setLoading(true);
+    else
+      builder.setItemList(mResults);
+    return builder.build();
+  }
+
+  @Override
+  public void onResultsUpdate(@NonNull SearchResult[] results, long timestamp)
+  {
+    if (mResults != null)
+      return;
+
+    final ItemList.Builder builder = new ItemList.Builder();
+    builder.setNoItemsMessage(getCarContext().getString(R.string.search_not_found));
+    final int resultsSize = Math.min(results.length, MAX_RESULTS_SIZE);
+    for (int i = 0; i < resultsSize; i++)
+      builder.addItem(createResultItem(results[i], i));
+    mResults = builder.build();
+
+    invalidate();
+  }
+
+  @NonNull
+  private Row createResultItem(@NonNull SearchResult result, int resultIndex)
+  {
+    final Row.Builder builder = new Row.Builder();
+    if (result.type == SearchResult.TYPE_RESULT)
+    {
+      final String title = result.getTitle(getCarContext());
+      builder.setTitle(title);
+      builder.addText(result.getFormattedDescription(getCarContext()));
+
+      final CharSequence openingHours = SearchUiHelpers.getOpeningHoursText(getCarContext(), result);
+      final CharSequence distance = SearchUiHelpers.getDistanceText(result);
+      final CharSequence openingHoursAndDistanceText = SearchUiHelpers.getOpeningHoursAndDistanceText(openingHours, distance);
+      if (openingHoursAndDistanceText.length() != 0)
+        builder.addText(openingHoursAndDistanceText);
+      if (distance.length() == 0)
+      {
+        // All non-browsable rows must have a distance span attached to either its title or texts
+        builder.setBrowsable(true);
+      }
+
+      builder.setOnClickListener(() -> {
+        SearchRecents.add(title, getCarContext());
+        SearchEngine.INSTANCE.cancel();
+        SearchEngine.INSTANCE.showResult(resultIndex);
+        getScreenManager().popToRoot();
+      });
+    }
+    else
+    {
+      builder.setBrowsable(true);
+      builder.setTitle(result.suggestion);
+      builder.setImage(new CarIcon.Builder(IconCompat.createWithResource(getCarContext(), R.drawable.ic_search)).build());
+      builder.setOnClickListener(() -> getScreenManager().push(new Builder(getCarContext(), getSurfaceRenderer()).setQuery(result.suggestion).build()));
+    }
+    return builder.build();
+  }
+
+  @Override
+  public void onStart(@NonNull LifecycleOwner owner)
+  {
+    SearchEngine.INSTANCE.addListener(this);
+  }
+
+  @Override
+  public void onResume(@NonNull LifecycleOwner owner)
+  {
+    SearchEngine.INSTANCE.cancel();
+
+    final MapObject location = LocationHelper.from(getCarContext()).getMyPosition();
+    final boolean hasLocation = location != null;
+    final double lat = hasLocation ? location.getLat() : 0;
+    final double lon = hasLocation ? location.getLon() : 0;
+
+    SearchEngine.INSTANCE.searchInteractive(mQuery, mIsCategory, mLocale, System.nanoTime(), true /* isMapAndTable */, hasLocation, lat, lon);
+  }
+
+  @Override
+  public void onStop(@NonNull LifecycleOwner owner)
+  {
+    SearchEngine.INSTANCE.removeListener(this);
+    SearchEngine.INSTANCE.cancel();
+  }
+
+  @NonNull
+  private Header createHeader()
+  {
+    final Header.Builder builder = new Header.Builder();
+    builder.setStartHeaderAction(Action.BACK);
+    builder.setTitle(mQuery);
+    return builder.build();
+  }
+
+  /**
+   * A builder of {@link SearchOnMapScreen}.
+   */
+  public static final class Builder
+  {
+    @NonNull
+    private final CarContext mCarContext;
+    @NonNull
+    private final SurfaceRenderer mSurfaceRenderer;
+
+    @NonNull
+    private String mQuery = "";
+    @NonNull
+    private String mLocale;
+    private boolean mIsCategory;
+
+    public Builder(@NonNull CarContext carContext, @NonNull SurfaceRenderer surfaceRenderer)
+    {
+      mCarContext = carContext;
+      mSurfaceRenderer = surfaceRenderer;
+      mLocale = Language.getKeyboardLocale(mCarContext);
+    }
+
+    public Builder setCategory(@NonNull String category)
+    {
+      mIsCategory = true;
+      mQuery = category;
+      return this;
+    }
+
+    public Builder setQuery(@NonNull String query)
+    {
+      mIsCategory = false;
+      mQuery = query;
+      return this;
+    }
+
+    public Builder setLocale(@NonNull String locale)
+    {
+      mLocale = locale;
+      return this;
+    }
+
+    @NonNull
+    public SearchOnMapScreen build()
+    {
+      if (mQuery.isEmpty())
+        throw new IllegalStateException("Search query is empty");
+      return new SearchOnMapScreen(this);
+    }
+  }
+}

--- a/android/app/src/main/java/app/organicmaps/car/screens/search/SearchScreen.java
+++ b/android/app/src/main/java/app/organicmaps/car/screens/search/SearchScreen.java
@@ -1,0 +1,234 @@
+package app.organicmaps.car.screens.search;
+
+import androidx.annotation.NonNull;
+import androidx.annotation.Nullable;
+import androidx.car.app.CarContext;
+import androidx.car.app.constraints.ConstraintManager;
+import androidx.car.app.model.Action;
+import androidx.car.app.model.ActionStrip;
+import androidx.car.app.model.CarIcon;
+import androidx.car.app.model.ItemList;
+import androidx.car.app.model.Row;
+import androidx.car.app.model.SearchTemplate;
+import androidx.car.app.model.Template;
+import androidx.core.graphics.drawable.IconCompat;
+import androidx.lifecycle.LifecycleOwner;
+
+import app.organicmaps.R;
+import app.organicmaps.bookmarks.data.MapObject;
+import app.organicmaps.car.SurfaceRenderer;
+import app.organicmaps.car.screens.base.BaseMapScreen;
+import app.organicmaps.location.LocationHelper;
+import app.organicmaps.search.NativeSearchListener;
+import app.organicmaps.search.SearchEngine;
+import app.organicmaps.search.SearchRecents;
+import app.organicmaps.search.SearchResult;
+import app.organicmaps.util.Language;
+
+public class SearchScreen extends BaseMapScreen implements SearchTemplate.SearchCallback, NativeSearchListener
+{
+  private final int MAX_RESULTS_SIZE;
+
+  @NonNull
+  private String mQuery = "";
+  @NonNull
+  private String mLocale;
+
+  @Nullable
+  private ItemList mResults = null;
+
+  private SearchScreen(@NonNull Builder builder)
+  {
+    super(builder.mCarContext, builder.mSurfaceRenderer);
+    final ConstraintManager constraintManager = getCarContext().getCarService(ConstraintManager.class);
+    MAX_RESULTS_SIZE = constraintManager.getContentLimit(ConstraintManager.CONTENT_LIMIT_TYPE_LIST);
+
+    mLocale = builder.mLocale;
+    onSearchSubmitted(builder.mQuery);
+  }
+
+  @NonNull
+  @Override
+  public Template onGetTemplate()
+  {
+    final SearchTemplate.Builder builder = new SearchTemplate.Builder(this);
+    builder.setHeaderAction(Action.BACK);
+    builder.setShowKeyboardByDefault(false);
+    if (mQuery.isEmpty() && mResults == null)
+    {
+      if (!loadRecents())
+        builder.setShowKeyboardByDefault(true);
+    }
+    if (!mQuery.isEmpty() && mResults != null && !mResults.getItems().isEmpty())
+      builder.setActionStrip(createActionStrip());
+    if (mResults == null)
+      builder.setLoading(true);
+    else
+      builder.setItemList(mResults);
+    builder.setInitialSearchText(mQuery);
+    builder.setSearchHint(getCarContext().getString(R.string.search));
+    return builder.build();
+  }
+
+  @Override
+  public void onSearchTextChanged(@NonNull String searchText)
+  {
+    if (mQuery.equals(searchText))
+      return;
+    mQuery = searchText;
+    mLocale = Language.getKeyboardLocale(getCarContext());
+    mResults = null;
+
+    SearchEngine.INSTANCE.cancel();
+
+    if (mQuery.isEmpty())
+    {
+      invalidate();
+      return;
+    }
+
+    final MapObject location = LocationHelper.from(getCarContext()).getMyPosition();
+    final boolean hasLocation = location != null;
+    final double lat = hasLocation ? location.getLat() : 0;
+    final double lon = hasLocation ? location.getLon() : 0;
+
+    SearchEngine.INSTANCE.search(getCarContext(), mQuery, false, System.nanoTime(), hasLocation, lat, lon);
+    invalidate();
+  }
+
+  @Override
+  public void onSearchSubmitted(@NonNull String searchText)
+  {
+    onSearchTextChanged(searchText);
+  }
+
+  @Override
+  public void onStart(@NonNull LifecycleOwner owner)
+  {
+    SearchEngine.INSTANCE.addListener(this);
+  }
+
+  @Override
+  public void onStop(@NonNull LifecycleOwner owner)
+  {
+    SearchEngine.INSTANCE.removeListener(this);
+    SearchEngine.INSTANCE.cancel();
+  }
+
+  @Override
+  public void onResultsUpdate(@NonNull SearchResult[] results, long timestamp)
+  {
+    final ItemList.Builder builder = new ItemList.Builder();
+    builder.setNoItemsMessage(getCarContext().getString(R.string.search_not_found));
+    final int resultsSize = Math.min(results.length, MAX_RESULTS_SIZE);
+    for (int i = 0; i < resultsSize; i++)
+      builder.addItem(createResultItem(results[i], i));
+    mResults = builder.build();
+    invalidate();
+  }
+
+  @NonNull
+  private Row createResultItem(@NonNull SearchResult result, int resultIndex)
+  {
+    final Row.Builder builder = new Row.Builder();
+    if (result.type == SearchResult.TYPE_RESULT)
+    {
+      final String title = result.getTitle(getCarContext());
+      builder.setTitle(title);
+      builder.addText(result.getFormattedDescription(getCarContext()));
+      final CharSequence openingHoursAndDistance = SearchUiHelpers.getOpeningHoursAndDistanceText(getCarContext(), result);
+      if (openingHoursAndDistance.length() != 0)
+        builder.addText(openingHoursAndDistance);
+      builder.setOnClickListener(() -> {
+        SearchRecents.add(title, getCarContext());
+        SearchEngine.INSTANCE.cancel();
+        SearchEngine.INSTANCE.showResult(resultIndex);
+        getScreenManager().popToRoot();
+      });
+    }
+    else
+    {
+      builder.setBrowsable(true);
+      builder.setTitle(result.suggestion);
+      builder.setImage(new CarIcon.Builder(IconCompat.createWithResource(getCarContext(), R.drawable.ic_search)).build());
+      builder.setOnClickListener(() -> onSearchSubmitted(result.suggestion));
+    }
+    return builder.build();
+  }
+
+  private boolean loadRecents()
+  {
+    final CarIcon iconRecent = new CarIcon.Builder(IconCompat.createWithResource(getCarContext(), R.drawable.ic_search_recent)).build();
+
+    final ItemList.Builder builder = new ItemList.Builder();
+    builder.setNoItemsMessage(getCarContext().getString(R.string.search_history_text));
+    SearchRecents.refresh();
+    final int recentsSize = Math.min(SearchRecents.getSize(), MAX_RESULTS_SIZE);
+    for (int i = 0; i < recentsSize; ++i)
+    {
+      final Row.Builder itemBuilder = new Row.Builder();
+      final String title = SearchRecents.get(i);
+      itemBuilder.setTitle(title);
+      itemBuilder.setImage(iconRecent);
+      itemBuilder.setOnClickListener(() -> onSearchSubmitted(title));
+      builder.addItem(itemBuilder.build());
+    }
+    mResults = builder.build();
+
+    return recentsSize != 0;
+  }
+
+  @NonNull
+  private ActionStrip createActionStrip()
+  {
+    final Action.Builder builder = new Action.Builder();
+    builder.setIcon(new CarIcon.Builder(IconCompat.createWithResource(getCarContext(), R.drawable.ic_show_on_map)).build());
+    builder.setOnClickListener(() ->
+        getScreenManager().push(new SearchOnMapScreen.Builder(getCarContext(), getSurfaceRenderer()).setQuery(mQuery).setLocale(mLocale).build()));
+
+    return new ActionStrip.Builder().addAction(builder.build()).build();
+  }
+
+  /**
+   * A builder of {@link SearchScreen}.
+   */
+  public static final class Builder
+  {
+    @NonNull
+    private final CarContext mCarContext;
+    @NonNull
+    private final SurfaceRenderer mSurfaceRenderer;
+
+    @NonNull
+    private String mQuery = "";
+    @NonNull
+    private String mLocale;
+
+    public Builder(@NonNull CarContext carContext, @NonNull SurfaceRenderer surfaceRenderer)
+    {
+      mCarContext = carContext;
+      mSurfaceRenderer = surfaceRenderer;
+
+      mLocale = Language.getKeyboardLocale(mCarContext);
+    }
+
+    @NonNull
+    public Builder setQuery(@NonNull String query)
+    {
+      mQuery = query;
+      return this;
+    }
+
+    public Builder setLocale(@NonNull String locale)
+    {
+      mLocale = locale;
+      return this;
+    }
+
+    @NonNull
+    public SearchScreen build()
+    {
+      return new SearchScreen(this);
+    }
+  }
+}

--- a/android/app/src/main/java/app/organicmaps/car/screens/search/SearchUiHelpers.java
+++ b/android/app/src/main/java/app/organicmaps/car/screens/search/SearchUiHelpers.java
@@ -1,0 +1,95 @@
+package app.organicmaps.car.screens.search;
+
+import android.text.SpannableStringBuilder;
+import android.text.Spanned;
+
+import androidx.annotation.NonNull;
+import androidx.car.app.CarContext;
+import androidx.car.app.model.CarColor;
+import androidx.car.app.model.DistanceSpan;
+import androidx.car.app.model.ForegroundCarColorSpan;
+
+import app.organicmaps.R;
+import app.organicmaps.car.util.Colors;
+import app.organicmaps.car.util.RoutingHelpers;
+import app.organicmaps.search.SearchResult;
+
+public final class SearchUiHelpers
+{
+  @NonNull
+  public static CharSequence getOpeningHoursAndDistanceText(@NonNull CarContext carContext, @NonNull SearchResult searchResult)
+  {
+    final CharSequence openingHours = getOpeningHoursText(carContext, searchResult);
+    final CharSequence distance = getDistanceText(searchResult);
+
+    return getOpeningHoursAndDistanceText(openingHours, distance);
+  }
+
+  @NonNull
+  public static CharSequence getOpeningHoursAndDistanceText(@NonNull CharSequence openingHours, @NonNull CharSequence distance)
+  {
+    final SpannableStringBuilder result = new SpannableStringBuilder();
+    if (openingHours.length() != 0)
+      result.append(openingHours);
+    if (result.length() != 0 && distance.length() != 0)
+      result.append(" • ");
+    if (distance.length() != 0)
+      result.append(distance);
+
+    return result;
+  }
+
+  @NonNull
+  public static CharSequence getDistanceText(@NonNull SearchResult searchResult)
+  {
+    if (!searchResult.description.distance.isValid())
+      return "";
+
+    final SpannableStringBuilder distance = new SpannableStringBuilder(" ");
+    distance.setSpan(DistanceSpan.create(RoutingHelpers.createDistance(searchResult.description.distance)), 0, 1, Spanned.SPAN_EXCLUSIVE_EXCLUSIVE);
+    distance.setSpan(ForegroundCarColorSpan.create(Colors.DISTANCE), 0, 1, Spanned.SPAN_EXCLUSIVE_EXCLUSIVE);
+    return distance;
+  }
+
+  @NonNull
+  public static CharSequence getOpeningHoursText(@NonNull CarContext carContext, @NonNull SearchResult searchResult)
+  {
+    final SpannableStringBuilder result = new SpannableStringBuilder();
+
+    String text = "";
+    CarColor color = Colors.DEFAULT;
+    switch (searchResult.description.openNow)
+    {
+    case SearchResult.OPEN_NOW_YES:
+      if (searchResult.description.minutesUntilClosed < 60)   // less than 1 hour
+      {
+        final String time = searchResult.description.minutesUntilClosed + " " +
+            carContext.getString(R.string.minute);
+        text = carContext.getString(R.string.closes_in, time);
+        color = Colors.OPENING_HOURS_CLOSES_SOON;
+      }
+      else
+      {
+        text = carContext.getString(R.string.editor_time_open);
+        color = Colors.OPENING_HOURS_OPEN;
+      }
+      break;
+    case SearchResult.OPEN_NOW_NO:
+      if (searchResult.description.minutesUntilOpen < 60) // less than 1 hour
+      {
+        final String time = searchResult.description.minutesUntilOpen + " " +
+            carContext.getString(R.string.minute);
+        text = carContext.getString(R.string.opens_in, time);
+      }
+      else
+        text = carContext.getString(R.string.closed);
+      color = Colors.OPENING_HOURS_CLOSED;
+      break;
+    }
+
+    result.append(text);
+    result.setSpan(ForegroundCarColorSpan.create(color), 0, result.length(), Spanned.SPAN_INCLUSIVE_EXCLUSIVE);
+
+    return result;
+  }
+}

--- a/android/app/src/main/java/app/organicmaps/car/screens/settings/DrivingOptionsScreen.java
+++ b/android/app/src/main/java/app/organicmaps/car/screens/settings/DrivingOptionsScreen.java
@@ -1,0 +1,131 @@
+package app.organicmaps.car.screens.settings;
+
+import androidx.annotation.NonNull;
+import androidx.annotation.StringRes;
+import androidx.car.app.CarContext;
+import androidx.car.app.model.Action;
+import androidx.car.app.model.CarIcon;
+import androidx.car.app.model.Header;
+import androidx.car.app.model.ItemList;
+import androidx.car.app.model.Row;
+import androidx.car.app.model.Template;
+import androidx.car.app.navigation.model.MapTemplate;
+import androidx.core.graphics.drawable.IconCompat;
+import androidx.lifecycle.LifecycleOwner;
+
+import app.organicmaps.R;
+import app.organicmaps.car.SurfaceRenderer;
+import app.organicmaps.car.util.UiHelpers;
+import app.organicmaps.car.screens.base.BaseMapScreen;
+import app.organicmaps.routing.RoutingOptions;
+import app.organicmaps.settings.RoadType;
+
+import java.util.HashMap;
+import java.util.Map;
+
+public class DrivingOptionsScreen extends BaseMapScreen
+{
+  public static final Object DRIVING_OPTIONS_RESULT_CHANGED = 0x1;
+
+  private static class DrivingOption
+  {
+    public final RoadType roadType;
+
+    @StringRes
+    public int text;
+
+    public DrivingOption(RoadType roadType, @StringRes int text)
+    {
+      this.roadType = roadType;
+      this.text = text;
+    }
+  }
+
+  private final DrivingOption[] mDrivingOptions = {
+      new DrivingOption(RoadType.Toll, R.string.avoid_tolls),
+      new DrivingOption(RoadType.Dirty, R.string.avoid_unpaved),
+      new DrivingOption(RoadType.Ferry, R.string.avoid_ferry),
+      new DrivingOption(RoadType.Motorway, R.string.avoid_motorways)
+  };
+
+  @NonNull
+  private final CarIcon mCheckboxIcon;
+  @NonNull
+  private final CarIcon mCheckboxSelectedIcon;
+
+  @NonNull
+  private final Map<RoadType, Boolean> mInitialDrivingOptionsState = new HashMap<>();
+
+  public DrivingOptionsScreen(@NonNull CarContext carContext, @NonNull SurfaceRenderer surfaceRenderer)
+  {
+    super(carContext, surfaceRenderer);
+    mCheckboxIcon = new CarIcon.Builder(IconCompat.createWithResource(carContext, R.drawable.ic_check_box)).build();
+    mCheckboxSelectedIcon = new CarIcon.Builder(IconCompat.createWithResource(carContext, R.drawable.ic_check_box_checked)).build();
+
+    initDrivingOptionsState();
+  }
+
+  @NonNull
+  @Override
+  public Template onGetTemplate()
+  {
+    final MapTemplate.Builder builder = new MapTemplate.Builder();
+    builder.setHeader(createHeader());
+    builder.setMapController(UiHelpers.createMapController(getCarContext(), getSurfaceRenderer()));
+    builder.setItemList(createDrivingOptionsList());
+    return builder.build();
+  }
+
+  @Override
+  public void onStop(@NonNull LifecycleOwner owner)
+  {
+    for (final DrivingOption drivingOption : mDrivingOptions)
+    {
+      if (Boolean.TRUE.equals(mInitialDrivingOptionsState.get(drivingOption.roadType)) != RoutingOptions.hasOption(drivingOption.roadType))
+      {
+        setResult(DRIVING_OPTIONS_RESULT_CHANGED);
+        return;
+      }
+    }
+  }
+
+  @NonNull
+  private Header createHeader()
+  {
+    final Header.Builder builder = new Header.Builder();
+    builder.setStartHeaderAction(Action.BACK);
+    builder.setTitle(getCarContext().getString(R.string.driving_options_subheader));
+    return builder.build();
+  }
+
+  @NonNull
+  private ItemList createDrivingOptionsList()
+  {
+    final ItemList.Builder builder = new ItemList.Builder();
+    for (final DrivingOption drivingOption : mDrivingOptions)
+      builder.addItem(createDrivingOptionCheckbox(drivingOption.roadType, drivingOption.text));
+    return builder.build();
+  }
+
+  @NonNull
+  private Row createDrivingOptionCheckbox(RoadType roadType, @StringRes int titleRes)
+  {
+    final Row.Builder builder = new Row.Builder();
+    builder.setTitle(getCarContext().getString(titleRes));
+    builder.setOnClickListener(() -> {
+      if (RoutingOptions.hasOption(roadType))
+        RoutingOptions.removeOption(roadType);
+      else
+        RoutingOptions.addOption(roadType);
+      invalidate();
+    });
+    builder.setImage(RoutingOptions.hasOption(roadType) ? mCheckboxSelectedIcon : mCheckboxIcon);
+    return builder.build();
+  }
+
+  private void initDrivingOptionsState()
+  {
+    for (final DrivingOption drivingOption : mDrivingOptions)
+      mInitialDrivingOptionsState.put(drivingOption.roadType, RoutingOptions.hasOption(drivingOption.roadType));
+  }
+}

--- a/android/app/src/main/java/app/organicmaps/car/screens/settings/HelpScreen.java
+++ b/android/app/src/main/java/app/organicmaps/car/screens/settings/HelpScreen.java
@@ -1,0 +1,74 @@
+package app.organicmaps.car.screens.settings;
+
+import androidx.annotation.NonNull;
+import androidx.car.app.CarContext;
+import androidx.car.app.model.Action;
+import androidx.car.app.model.Header;
+import androidx.car.app.model.Item;
+import androidx.car.app.model.ItemList;
+import androidx.car.app.model.Row;
+import androidx.car.app.model.Template;
+import androidx.car.app.navigation.model.MapTemplate;
+
+import app.organicmaps.BuildConfig;
+import app.organicmaps.Framework;
+import app.organicmaps.R;
+import app.organicmaps.car.SurfaceRenderer;
+import app.organicmaps.car.util.UiHelpers;
+import app.organicmaps.car.screens.base.BaseMapScreen;
+import app.organicmaps.util.DateUtils;
+
+public class HelpScreen extends BaseMapScreen
+{
+  public HelpScreen(@NonNull CarContext carContext, @NonNull SurfaceRenderer surfaceRenderer)
+  {
+    super(carContext, surfaceRenderer);
+  }
+
+  @NonNull
+  @Override
+  public Template onGetTemplate()
+  {
+    final MapTemplate.Builder builder = new MapTemplate.Builder();
+    builder.setHeader(createHeader());
+    builder.setMapController(UiHelpers.createMapController(getCarContext(), getSurfaceRenderer()));
+    builder.setItemList(createSettingsList());
+    return builder.build();
+  }
+
+  @NonNull
+  private Header createHeader()
+  {
+    final Header.Builder builder = new Header.Builder();
+    builder.setStartHeaderAction(Action.BACK);
+    builder.setTitle(getCarContext().getString(R.string.help));
+    return builder.build();
+  }
+
+  @NonNull
+  private ItemList createSettingsList()
+  {
+    final ItemList.Builder builder = new ItemList.Builder();
+    builder.addItem(createVersionInfo());
+    builder.addItem(createDataVersionInfo());
+    return builder.build();
+  }
+
+  @NonNull
+  private Item createVersionInfo()
+  {
+    return new Row.Builder()
+        .setTitle(getCarContext().getString(R.string.app_name))
+        .addText(BuildConfig.VERSION_NAME)
+        .build();
+  }
+
+  @NonNull
+  private Item createDataVersionInfo()
+  {
+    return new Row.Builder()
+        .setTitle(getCarContext().getString(R.string.data_version, ""))
+        .addText(DateUtils.getShortDateFormatter().format(Framework.getDataVersion()))
+        .build();
+  }
+}

--- a/android/app/src/main/java/app/organicmaps/car/screens/settings/SettingsScreen.java
+++ b/android/app/src/main/java/app/organicmaps/car/screens/settings/SettingsScreen.java
@@ -1,0 +1,124 @@
+package app.organicmaps.car.screens.settings;
+
+import androidx.annotation.NonNull;
+import androidx.annotation.StringRes;
+import androidx.car.app.CarContext;
+import androidx.car.app.model.Action;
+import androidx.car.app.model.CarIcon;
+import androidx.car.app.model.Header;
+import androidx.car.app.model.Item;
+import androidx.car.app.model.ItemList;
+import androidx.car.app.model.Row;
+import androidx.car.app.model.Template;
+import androidx.car.app.navigation.model.MapTemplate;
+import androidx.core.graphics.drawable.IconCompat;
+
+import app.organicmaps.R;
+import app.organicmaps.car.SurfaceRenderer;
+import app.organicmaps.car.util.ThemeUtils;
+import app.organicmaps.car.util.UiHelpers;
+import app.organicmaps.car.screens.base.BaseMapScreen;
+import app.organicmaps.util.Config;
+
+public class SettingsScreen extends BaseMapScreen
+{
+  private interface PrefsGetter
+  {
+    boolean get();
+  }
+
+  private interface PrefsSetter
+  {
+    void set(boolean newValue);
+  }
+
+  @NonNull
+  private final CarIcon mCheckboxIcon;
+  @NonNull
+  private final CarIcon mCheckboxSelectedIcon;
+
+  public SettingsScreen(@NonNull CarContext carContext, @NonNull SurfaceRenderer surfaceRenderer)
+  {
+    super(carContext, surfaceRenderer);
+    mCheckboxIcon = new CarIcon.Builder(IconCompat.createWithResource(carContext, R.drawable.ic_check_box)).build();
+    mCheckboxSelectedIcon = new CarIcon.Builder(IconCompat.createWithResource(carContext, R.drawable.ic_check_box_checked)).build();
+  }
+
+  @NonNull
+  @Override
+  public Template onGetTemplate()
+  {
+    final MapTemplate.Builder builder = new MapTemplate.Builder();
+    builder.setHeader(createHeader());
+    builder.setMapController(UiHelpers.createMapController(getCarContext(), getSurfaceRenderer()));
+    builder.setItemList(createSettingsList());
+    return builder.build();
+  }
+
+  @NonNull
+  private Header createHeader()
+  {
+    final Header.Builder builder = new Header.Builder();
+    builder.setStartHeaderAction(Action.BACK);
+    builder.setTitle(getCarContext().getString(R.string.settings));
+    return builder.build();
+  }
+
+  @NonNull
+  private ItemList createSettingsList()
+  {
+    final ItemList.Builder builder = new ItemList.Builder();
+    builder.addItem(createThemeItem());
+    builder.addItem(createRoutingOptionsItem());
+    builder.addItem(createSharedPrefsCheckbox(R.string.big_font, Config::isLargeFontsSize, Config::setLargeFontsSize));
+    builder.addItem(createSharedPrefsCheckbox(R.string.transliteration_title, Config::isTransliteration, Config::setTransliteration));
+    builder.addItem(createHelpItem());
+    return builder.build();
+  }
+
+  @NonNull
+  private Item createThemeItem()
+  {
+    final Row.Builder builder = new Row.Builder();
+    builder.setTitle(getCarContext().getString(R.string.pref_map_style_title));
+    builder.addText(getCarContext().getString(ThemeUtils.getThemeMode(getCarContext()).getTitleId()));
+    builder.setOnClickListener(() -> getScreenManager().push(new ThemeScreen(getCarContext(), getSurfaceRenderer())));
+    builder.setBrowsable(true);
+    return builder.build();
+  }
+
+  @NonNull
+  private Item createRoutingOptionsItem()
+  {
+    final Row.Builder builder = new Row.Builder();
+    builder.setTitle(getCarContext().getString(R.string.driving_options_title));
+    builder.setOnClickListener(() -> getScreenManager().pushForResult(new DrivingOptionsScreen(getCarContext(), getSurfaceRenderer()), this::setResult));
+    builder.setBrowsable(true);
+    return builder.build();
+  }
+
+  @NonNull
+  private Item createHelpItem()
+  {
+    final Row.Builder builder = new Row.Builder();
+    builder.setTitle(getCarContext().getString(R.string.help));
+    builder.setOnClickListener(() -> getScreenManager().push(new HelpScreen(getCarContext(), getSurfaceRenderer())));
+    builder.setBrowsable(true);
+    return builder.build();
+  }
+
+  @NonNull
+  private Row createSharedPrefsCheckbox(@StringRes int titleRes, @NonNull PrefsGetter getter, @NonNull PrefsSetter setter)
+  {
+    final boolean getterValue = getter.get();
+
+    final Row.Builder builder = new Row.Builder();
+    builder.setTitle(getCarContext().getString(titleRes));
+    builder.setOnClickListener(() -> {
+      setter.set(!getterValue);
+      invalidate();
+    });
+    builder.setImage(getterValue ? mCheckboxSelectedIcon : mCheckboxIcon);
+    return builder.build();
+  }
+}

--- a/android/app/src/main/java/app/organicmaps/car/screens/settings/ThemeScreen.java
+++ b/android/app/src/main/java/app/organicmaps/car/screens/settings/ThemeScreen.java
@@ -1,0 +1,82 @@
+package app.organicmaps.car.screens.settings;
+
+import androidx.annotation.NonNull;
+import androidx.car.app.CarContext;
+import androidx.car.app.model.Action;
+import androidx.car.app.model.CarIcon;
+import androidx.car.app.model.Header;
+import androidx.car.app.model.ItemList;
+import androidx.car.app.model.Row;
+import androidx.car.app.model.Template;
+import androidx.car.app.navigation.model.MapTemplate;
+import androidx.core.graphics.drawable.IconCompat;
+
+import app.organicmaps.R;
+import app.organicmaps.car.SurfaceRenderer;
+import app.organicmaps.car.screens.base.BaseMapScreen;
+import app.organicmaps.car.util.ThemeUtils;
+import app.organicmaps.car.util.UiHelpers;
+
+public class ThemeScreen extends BaseMapScreen
+{
+  @NonNull
+  private final CarIcon mRadioButtonIcon;
+  @NonNull
+  private final CarIcon mRadioButtonSelectedIcon;
+
+  public ThemeScreen(@NonNull CarContext carContext, @NonNull SurfaceRenderer surfaceRenderer)
+  {
+    super(carContext, surfaceRenderer);
+    mRadioButtonIcon = new CarIcon.Builder(IconCompat.createWithResource(carContext, R.drawable.ic_radio_button_unchecked)).build();
+    mRadioButtonSelectedIcon = new CarIcon.Builder(IconCompat.createWithResource(carContext, R.drawable.ic_radio_button_checked)).build();
+  }
+
+  @NonNull
+  @Override
+  public Template onGetTemplate()
+  {
+    final MapTemplate.Builder builder = new MapTemplate.Builder();
+    builder.setHeader(createHeader());
+    builder.setMapController(UiHelpers.createMapController(getCarContext(), getSurfaceRenderer()));
+    builder.setItemList(createRadioButtons());
+    return builder.build();
+  }
+
+  @NonNull
+  private Header createHeader()
+  {
+    final Header.Builder builder = new Header.Builder();
+    builder.setStartHeaderAction(Action.BACK);
+    builder.setTitle(getCarContext().getString(R.string.pref_map_style_title));
+    return builder.build();
+  }
+
+  @NonNull
+  private ItemList createRadioButtons()
+  {
+    final ItemList.Builder builder = new ItemList.Builder();
+    final ThemeUtils.ThemeMode currentThemeMode = ThemeUtils.getThemeMode(getCarContext());
+    builder.addItem(createRadioButton(ThemeUtils.ThemeMode.AUTO, currentThemeMode));
+    builder.addItem(createRadioButton(ThemeUtils.ThemeMode.NIGHT, currentThemeMode));
+    builder.addItem(createRadioButton(ThemeUtils.ThemeMode.LIGHT, currentThemeMode));
+    return builder.build();
+  }
+
+  @NonNull
+  private Row createRadioButton(@NonNull ThemeUtils.ThemeMode themeMode, @NonNull ThemeUtils.ThemeMode currentThemeMode)
+  {
+    final Row.Builder builder = new Row.Builder();
+    builder.setTitle(getCarContext().getString(themeMode.getTitleId()));
+    builder.setOnClickListener(() -> {
+      if (themeMode == currentThemeMode)
+        return;
+      ThemeUtils.setThemeMode(getCarContext(), themeMode);
+      invalidate();
+    });
+    if (themeMode == currentThemeMode)
+      builder.setImage(mRadioButtonSelectedIcon);
+    else
+      builder.setImage(mRadioButtonIcon);
+    return builder.build();
+  }
+}

--- a/android/app/src/main/java/app/organicmaps/car/util/Colors.java
+++ b/android/app/src/main/java/app/organicmaps/car/util/Colors.java
@@ -1,0 +1,20 @@
+package app.organicmaps.car.util;
+
+import androidx.car.app.model.CarColor;
+
+public final class Colors
+{
+  public static final CarColor DEFAULT = CarColor.DEFAULT;
+  public static final CarColor DISTANCE = CarColor.BLUE;
+  public static final CarColor LOCATION_TINT = CarColor.BLUE;
+  public static final CarColor BOOKMARK_SAVED = CarColor.YELLOW;
+  public static final CarColor OPENING_HOURS_OPEN = CarColor.GREEN;
+  public static final CarColor OPENING_HOURS_CLOSES_SOON = CarColor.YELLOW;
+  public static final CarColor OPENING_HOURS_CLOSED = CarColor.RED;
+  public static final CarColor START_NAVIGATION = CarColor.GREEN;
+  public static final CarColor NAVIGATION_TEMPLATE_BACKGROUND_DAY = CarColor.GREEN;
+  public static final CarColor NAVIGATION_TEMPLATE_BACKGROUND_NIGHT = CarColor.DEFAULT;
+  public static final CarColor BUTTON_ACCEPT = CarColor.GREEN;
+
+  private Colors() {}
+}

--- a/android/app/src/main/java/app/organicmaps/car/util/IntentUtils.java
+++ b/android/app/src/main/java/app/organicmaps/car/util/IntentUtils.java
@@ -1,0 +1,77 @@
+package app.organicmaps.car.util;
+
+import android.content.Intent;
+
+import androidx.annotation.NonNull;
+import androidx.car.app.CarContext;
+import androidx.car.app.ScreenManager;
+
+import app.organicmaps.Framework;
+import app.organicmaps.Map;
+import app.organicmaps.api.ParsedSearchRequest;
+import app.organicmaps.api.ParsingResult;
+import app.organicmaps.car.SurfaceRenderer;
+import app.organicmaps.car.screens.hacks.PopToRootHack;
+import app.organicmaps.car.screens.search.SearchScreen;
+import app.organicmaps.intent.Factory;
+
+public final class IntentUtils
+{
+  private static final int SEARCH_IN_VIEWPORT_ZOOM = 16;
+
+  // TODO (AndrewShkrob): As of now, the core functionality does not encompass support for the queries 2-3.
+  // https://developer.android.com/reference/androidx/car/app/CarContext#startCarApp(android.content.Intent)
+  // The data URI scheme must be either a latitude,longitude pair, or a + separated string query as follows:
+  //   1) "geo:12.345,14.8767" for a latitude, longitude pair.
+  //   2) "geo:0,0?q=123+Main+St,+Seattle,+WA+98101" for an address.
+  //   3) "geo:0,0?q=a+place+name" for a place to search for.
+  public static void processIntent(@NonNull CarContext carContext, @NonNull SurfaceRenderer surfaceRenderer, @NonNull Intent intent)
+  {
+    final String action = intent.getAction();
+    if (action == null || !intent.getAction().equals(CarContext.ACTION_NAVIGATE))
+      return;
+
+    String url = Factory.GeoIntentProcessor.processIntent(intent);
+    if (url == null)
+      return;
+
+    final ParsingResult result = Framework.nativeParseAndSetApiUrl(url);
+    final ScreenManager screenManager = carContext.getCarService(ScreenManager.class);
+
+    screenManager.popToRoot();
+
+    if (result.getUrlType() == ParsingResult.TYPE_INCORRECT)
+    {
+      Map.showMapForUrl(url);
+      return;
+    }
+
+    if (!result.isSuccess())
+      return;
+
+    switch (result.getUrlType())
+    {
+    case ParsingResult.TYPE_INCORRECT:
+    case ParsingResult.TYPE_MAP:
+      Map.showMapForUrl(url);
+      return;
+    case ParsingResult.TYPE_SEARCH:
+      final ParsedSearchRequest request = Framework.nativeGetParsedSearchRequest();
+      final double[] latlon = Framework.nativeGetParsedCenterLatLon();
+      if (latlon[0] != 0.0 || latlon[1] != 0.0)
+      {
+        Framework.nativeStopLocationFollow();
+        Framework.nativeSetViewportCenter(latlon[0], latlon[1], SEARCH_IN_VIEWPORT_ZOOM);
+      }
+      final SearchScreen.Builder builder = new SearchScreen.Builder(carContext, surfaceRenderer);
+      builder.setQuery(request.mQuery);
+      if (request.mLocale != null)
+        builder.setLocale(request.mLocale);
+
+      screenManager.push(new PopToRootHack.Builder(carContext).setScreenToPush(builder.build()).build());
+    default:
+    }
+  }
+
+  private IntentUtils() {}
+}

--- a/android/app/src/main/java/app/organicmaps/car/util/IntentUtils.java
+++ b/android/app/src/main/java/app/organicmaps/car/util/IntentUtils.java
@@ -11,7 +11,7 @@ import app.organicmaps.Map;
 import app.organicmaps.api.ParsedSearchRequest;
 import app.organicmaps.api.ParsingResult;
 import app.organicmaps.car.SurfaceRenderer;
-import app.organicmaps.car.screens.hacks.PopToRootHack;
+import app.organicmaps.car.hacks.PopToRootHack;
 import app.organicmaps.car.screens.search.SearchScreen;
 import app.organicmaps.intent.Factory;
 

--- a/android/app/src/main/java/app/organicmaps/car/util/LanesDrawable.java
+++ b/android/app/src/main/java/app/organicmaps/car/util/LanesDrawable.java
@@ -1,0 +1,136 @@
+package app.organicmaps.car.util;
+
+import android.content.Context;
+import android.graphics.Canvas;
+import android.graphics.ColorFilter;
+import android.graphics.PixelFormat;
+import android.graphics.Rect;
+import android.graphics.drawable.Drawable;
+
+import androidx.annotation.ColorInt;
+import androidx.annotation.ColorRes;
+import androidx.annotation.DimenRes;
+import androidx.annotation.NonNull;
+import androidx.annotation.Nullable;
+import androidx.appcompat.content.res.AppCompatResources;
+
+import app.organicmaps.R;
+import app.organicmaps.routing.SingleLaneInfo;
+
+import java.util.Objects;
+
+public class LanesDrawable extends Drawable
+{
+  @ColorRes
+  private static final int ACTIVE_LANE_TINT_RES = R.color.white_primary;
+  @ColorRes
+  private static final int INACTIVE_LANE_TINT_RES = R.color.icon_tint_light;
+  @ColorRes
+  private static final int INACTIVE_LANE_TINT_NIGHT_RES = R.color.icon_tint_light_night;
+
+  @DimenRes
+  private static final int MARGIN_RES = R.dimen.margin_quarter;
+
+  private static class TintColorInfo
+  {
+    @ColorInt
+    public final int mActiveLaneTint;
+    @ColorInt
+    public final int mInactiveLaneTint;
+
+    public TintColorInfo(@ColorInt int activeLaneTint, @ColorInt int inactiveLaneTint)
+    {
+      mActiveLaneTint = activeLaneTint;
+      mInactiveLaneTint = inactiveLaneTint;
+    }
+  }
+
+  private static class LaneDrawable
+  {
+    private final Drawable mDrawable;
+    private final Rect mRect;
+    private final int mTintColor;
+
+    private LaneDrawable(@NonNull final Context context, @NonNull SingleLaneInfo laneInfo, int horizontalOffset, TintColorInfo colorInfo)
+    {
+      mDrawable = Objects.requireNonNull(AppCompatResources.getDrawable(context, laneInfo.mLane[0].mTurnRes));
+
+      final int width = mDrawable.getIntrinsicWidth();
+      final int height = mDrawable.getIntrinsicHeight();
+
+      mRect = new Rect(horizontalOffset, 0, horizontalOffset + width, height);
+      mTintColor = laneInfo.mIsActive ? colorInfo.mActiveLaneTint : colorInfo.mInactiveLaneTint;
+    }
+
+    private void draw(@NonNull final Canvas canvas)
+    {
+      mDrawable.setTint(mTintColor);
+      mDrawable.setBounds(mRect);
+      mDrawable.draw(canvas);
+    }
+  }
+
+  @NonNull
+  private final LaneDrawable[] mLanes;
+
+  private final int mWidth;
+  private final int mHeight;
+
+  public LanesDrawable(@NonNull final Context context, @NonNull SingleLaneInfo[] lanes, boolean isDarkMode)
+  {
+    final int mMargin = context.getResources().getDimensionPixelSize(MARGIN_RES);
+    final TintColorInfo tintColorInfo = getTintColorInfo(context, isDarkMode);
+
+    mLanes = new LaneDrawable[lanes.length];
+
+    int totalWidth = 0;
+    for (int i = 0; i < lanes.length; ++i)
+    {
+      mLanes[i] = new LaneDrawable(context, lanes[i], totalWidth + mMargin, tintColorInfo);
+      totalWidth += mLanes[i].mRect.width() + mMargin * 2;
+    }
+
+    mWidth = totalWidth;
+    mHeight = mLanes[0].mRect.height();
+  }
+
+  @Override
+  public int getIntrinsicWidth()
+  {
+    return mWidth;
+  }
+
+  @Override
+  public int getIntrinsicHeight()
+  {
+    return mHeight;
+  }
+
+  @Override
+  public void draw(@NonNull Canvas canvas)
+  {
+    for (final LaneDrawable drawable : mLanes)
+      drawable.draw(canvas);
+  }
+
+  @Override
+  public void setAlpha(int alpha) {}
+
+  @Override
+  public void setColorFilter(@Nullable ColorFilter colorFilter) {}
+
+  @Override
+  public int getOpacity()
+  {
+    return PixelFormat.UNKNOWN;
+  }
+
+  @NonNull
+  private static TintColorInfo getTintColorInfo(@NonNull final Context context, boolean isDarkMode)
+  {
+    final int activeLaneTint = context.getColor(ACTIVE_LANE_TINT_RES);
+    final int inactiveLaneTint = context.getColor(!isDarkMode ? INACTIVE_LANE_TINT_RES : INACTIVE_LANE_TINT_NIGHT_RES);
+
+    return new TintColorInfo(activeLaneTint, inactiveLaneTint);
+  }
+}

--- a/android/app/src/main/java/app/organicmaps/car/util/LanesDrawable.java
+++ b/android/app/src/main/java/app/organicmaps/car/util/LanesDrawable.java
@@ -13,6 +13,7 @@ import androidx.annotation.DimenRes;
 import androidx.annotation.NonNull;
 import androidx.annotation.Nullable;
 import androidx.appcompat.content.res.AppCompatResources;
+import androidx.core.content.ContextCompat;
 
 import app.organicmaps.R;
 import app.organicmaps.routing.SingleLaneInfo;
@@ -128,8 +129,8 @@ public class LanesDrawable extends Drawable
   @NonNull
   private static TintColorInfo getTintColorInfo(@NonNull final Context context, boolean isDarkMode)
   {
-    final int activeLaneTint = context.getColor(ACTIVE_LANE_TINT_RES);
-    final int inactiveLaneTint = context.getColor(!isDarkMode ? INACTIVE_LANE_TINT_RES : INACTIVE_LANE_TINT_NIGHT_RES);
+    final int activeLaneTint = ContextCompat.getColor(context, ACTIVE_LANE_TINT_RES);
+    final int inactiveLaneTint = ContextCompat.getColor(context, !isDarkMode ? INACTIVE_LANE_TINT_RES : INACTIVE_LANE_TINT_NIGHT_RES);
 
     return new TintColorInfo(activeLaneTint, inactiveLaneTint);
   }

--- a/android/app/src/main/java/app/organicmaps/car/util/OnBackPressedCallback.java
+++ b/android/app/src/main/java/app/organicmaps/car/util/OnBackPressedCallback.java
@@ -1,0 +1,30 @@
+package app.organicmaps.car.util;
+
+import androidx.annotation.NonNull;
+import androidx.car.app.CarContext;
+import androidx.car.app.ScreenManager;
+
+public class OnBackPressedCallback extends androidx.activity.OnBackPressedCallback
+{
+  public interface Callback
+  {
+    void onBackPressed();
+  }
+
+  private final ScreenManager mScreenManager;
+  private final Callback mCallback;
+
+  public OnBackPressedCallback(@NonNull CarContext carContext, @NonNull Callback callback)
+  {
+    super(true);
+    mScreenManager = carContext.getCarService(ScreenManager.class);
+    mCallback = callback;
+  }
+
+  @Override
+  public void handleOnBackPressed()
+  {
+    mCallback.onBackPressed();
+    mScreenManager.pop();
+  }
+}

--- a/android/app/src/main/java/app/organicmaps/car/util/RoutingHelpers.java
+++ b/android/app/src/main/java/app/organicmaps/car/util/RoutingHelpers.java
@@ -1,0 +1,138 @@
+package app.organicmaps.car.util;
+
+import androidx.annotation.NonNull;
+import androidx.car.app.CarContext;
+import androidx.car.app.model.CarIcon;
+import androidx.car.app.model.Distance;
+import androidx.car.app.navigation.model.LaneDirection;
+import androidx.car.app.navigation.model.Maneuver;
+import androidx.core.graphics.drawable.IconCompat;
+
+import app.organicmaps.routing.RoutingInfo;
+import app.organicmaps.routing.SingleLaneInfo;
+
+public final class RoutingHelpers
+{
+  private RoutingHelpers() {}
+
+  @NonNull
+  public static Distance createDistance(@NonNull final app.organicmaps.util.Distance distance)
+  {
+    int displayUnit;
+    switch (distance.mUnits)
+    {
+    case Kilometers:
+      displayUnit = distance.mDistance >= 10.0 ? Distance.UNIT_KILOMETERS : Distance.UNIT_KILOMETERS_P1;
+      break;
+    case Feet:
+      displayUnit = Distance.UNIT_FEET;
+      break;
+    case Miles:
+      displayUnit = distance.mDistance >= 10.0 ? Distance.UNIT_MILES : Distance.UNIT_MILES_P1;
+      break;
+    case Meters:
+    default:
+      displayUnit = Distance.UNIT_METERS;
+      break;
+    }
+
+    return Distance.create(distance.mDistance, displayUnit);
+  }
+
+  @NonNull
+  public static LaneDirection createLaneDirection(@NonNull SingleLaneInfo.LaneWay laneWay, boolean isRecommended)
+  {
+    int shape = LaneDirection.SHAPE_UNKNOWN;
+    switch (laneWay)
+    {
+    case REVERSE:
+      shape = LaneDirection.SHAPE_U_TURN_LEFT;
+      break;
+    case SHARP_LEFT:
+      shape = LaneDirection.SHAPE_SHARP_LEFT;
+      break;
+    case LEFT:
+      shape = LaneDirection.SHAPE_NORMAL_LEFT;
+      break;
+    case SLIGHT_LEFT:
+    case MERGE_TO_LEFT:
+      shape = LaneDirection.SHAPE_SLIGHT_LEFT;
+      break;
+    case SLIGHT_RIGHT:
+    case MERGE_TO_RIGHT:
+      shape = LaneDirection.SHAPE_SLIGHT_RIGHT;
+      break;
+    case THROUGH:
+      shape = LaneDirection.SHAPE_STRAIGHT;
+      break;
+    case RIGHT:
+      shape = LaneDirection.SHAPE_NORMAL_RIGHT;
+      break;
+    case SHARP_RIGHT:
+      shape = LaneDirection.SHAPE_SHARP_RIGHT;
+      break;
+    }
+
+    return LaneDirection.create(shape, isRecommended);
+  }
+
+  @NonNull
+  public static Maneuver createManeuver(@NonNull final CarContext context, @NonNull RoutingInfo.CarDirection carDirection, int roundaboutExitNum)
+  {
+    int maneuverType = Maneuver.TYPE_UNKNOWN;
+    switch (carDirection)
+    {
+    case NO_TURN:
+    case GO_STRAIGHT:
+      maneuverType = Maneuver.TYPE_STRAIGHT;
+      break;
+    case TURN_RIGHT:
+      maneuverType = Maneuver.TYPE_TURN_NORMAL_RIGHT;
+      break;
+    case TURN_SHARP_RIGHT:
+      maneuverType = Maneuver.TYPE_TURN_SHARP_RIGHT;
+      break;
+    case TURN_SLIGHT_RIGHT:
+      maneuverType = Maneuver.TYPE_TURN_SLIGHT_RIGHT;
+      break;
+    case TURN_LEFT:
+      maneuverType = Maneuver.TYPE_TURN_NORMAL_LEFT;
+      break;
+    case TURN_SHARP_LEFT:
+      maneuverType = Maneuver.TYPE_TURN_SHARP_LEFT;
+      break;
+    case TURN_SLIGHT_LEFT:
+      maneuverType = Maneuver.TYPE_TURN_SLIGHT_LEFT;
+      break;
+    case U_TURN_LEFT:
+      maneuverType = Maneuver.TYPE_U_TURN_LEFT;
+      break;
+    case U_TURN_RIGHT:
+      maneuverType = Maneuver.TYPE_U_TURN_RIGHT;
+      break;
+    // TODO (AndrewShkrob): add support for CW (clockwise) directions
+    case ENTER_ROUND_ABOUT:
+    case STAY_ON_ROUND_ABOUT:
+    case LEAVE_ROUND_ABOUT:
+      maneuverType = Maneuver.TYPE_ROUNDABOUT_ENTER_AND_EXIT_CCW;
+      break;
+    case START_AT_THE_END_OF_STREET:
+      maneuverType = Maneuver.TYPE_DEPART;
+      break;
+    case REACHED_YOUR_DESTINATION:
+      maneuverType = Maneuver.TYPE_DESTINATION;
+      break;
+    case EXIT_HIGHWAY_TO_LEFT:
+      maneuverType = Maneuver.TYPE_OFF_RAMP_SLIGHT_LEFT;
+      break;
+    case EXIT_HIGHWAY_TO_RIGHT:
+      maneuverType = Maneuver.TYPE_OFF_RAMP_SLIGHT_RIGHT;
+      break;
+    }
+    final Maneuver.Builder builder = new Maneuver.Builder(maneuverType);
+    if (maneuverType == Maneuver.TYPE_ROUNDABOUT_ENTER_AND_EXIT_CCW)
+      builder.setRoundaboutExitNumber(roundaboutExitNum > 0 ? roundaboutExitNum : 1);
+    builder.setIcon(new CarIcon.Builder(IconCompat.createWithResource(context, carDirection.getTurnRes())).build());
+    return builder.build();
+  }
+}

--- a/android/app/src/main/java/app/organicmaps/car/util/RoutingUtils.java
+++ b/android/app/src/main/java/app/organicmaps/car/util/RoutingUtils.java
@@ -1,0 +1,127 @@
+package app.organicmaps.car.util;
+
+import android.graphics.Bitmap;
+import android.text.TextUtils;
+
+import androidx.annotation.NonNull;
+import androidx.annotation.Nullable;
+import androidx.car.app.CarContext;
+import androidx.car.app.model.CarIcon;
+import androidx.car.app.model.DateTimeWithZone;
+import androidx.car.app.navigation.model.Destination;
+import androidx.car.app.navigation.model.Lane;
+import androidx.car.app.navigation.model.Step;
+import androidx.car.app.navigation.model.TravelEstimate;
+import androidx.car.app.navigation.model.Trip;
+import androidx.core.graphics.drawable.IconCompat;
+
+import app.organicmaps.bookmarks.data.MapObject;
+import app.organicmaps.routing.RoutingInfo;
+import app.organicmaps.routing.SingleLaneInfo;
+import app.organicmaps.util.Graphics;
+
+import java.util.Calendar;
+import java.util.Objects;
+
+public final class RoutingUtils
+{
+  @NonNull
+  private static Trip mCachedTrip = new Trip.Builder().setLoading(true).build();
+
+  private RoutingUtils() {}
+
+  @NonNull
+  public static Trip getLastTrip()
+  {
+    return mCachedTrip;
+  }
+
+  public static void resetTrip()
+  {
+    mCachedTrip = new Trip.Builder().setLoading(true).build();
+  }
+
+  @NonNull
+  public static Trip createTrip(@NonNull final CarContext context, @Nullable final RoutingInfo info, @Nullable MapObject endPoint)
+  {
+    final Trip.Builder builder = new Trip.Builder();
+
+    if (info == null || !info.distToTarget.isValid() || !info.distToTurn.isValid())
+    {
+      builder.setLoading(true);
+      return builder.build();
+    }
+
+    builder.setCurrentRoad(info.currentStreet);
+
+    // Destination
+    final Destination.Builder destinationBuilder = new Destination.Builder();
+    if (endPoint != null)
+    {
+      destinationBuilder.setName(endPoint.getName());
+      destinationBuilder.setAddress(Objects.requireNonNullElse(endPoint.getAddress(), ""));
+    }
+    else
+      destinationBuilder.setName(" ");
+
+    builder.addDestination(destinationBuilder.build(), createTravelEstimate(info.distToTarget, info.totalTimeInSeconds));
+
+    // TODO (AndrewShkrob): Use real distance and time estimates
+    builder.addStep(createCurrentStep(context, info), createTravelEstimate(info.distToTurn, 0));
+    if (!TextUtils.isEmpty(info.nextStreet))
+      builder.addStep(createNextStep(context, info), createTravelEstimate(app.organicmaps.util.Distance.EMPTY, 0));
+    mCachedTrip = builder.build();
+    return mCachedTrip;
+  }
+
+  @NonNull
+  private static Step createCurrentStep(@NonNull final CarContext context, @NonNull RoutingInfo info)
+  {
+    final Step.Builder builder = new Step.Builder();
+    builder.setCue(info.currentStreet);
+    builder.setRoad(info.currentStreet);
+    builder.setManeuver(RoutingHelpers.createManeuver(context, info.carDirection, info.exitNum));
+    if (info.lanes != null)
+    {
+      for (final SingleLaneInfo laneInfo : info.lanes)
+      {
+        final Lane.Builder laneBuilder = new Lane.Builder();
+        for (final SingleLaneInfo.LaneWay laneWay : laneInfo.mLane)
+          laneBuilder.addDirection(RoutingHelpers.createLaneDirection(laneWay, laneInfo.mIsActive));
+        builder.addLane(laneBuilder.build());
+      }
+      final LanesDrawable lanesDrawable = new LanesDrawable(context, info.lanes, ThemeUtils.isNightMode(context));
+      final Bitmap lanesBitmap = Graphics.drawableToBitmap(lanesDrawable);
+      builder.setLanesImage(new CarIcon.Builder(IconCompat.createWithBitmap(lanesBitmap)).build());
+    }
+
+    return builder.build();
+  }
+
+  @NonNull
+  private static Step createNextStep(@NonNull final CarContext context, @NonNull RoutingInfo info)
+  {
+    final Step.Builder builder = new Step.Builder();
+    builder.setCue(info.nextStreet);
+    builder.setManeuver(RoutingHelpers.createManeuver(context, info.nextCarDirection, 0));
+
+    return builder.build();
+  }
+
+  @NonNull
+  private static TravelEstimate createTravelEstimate(@NonNull app.organicmaps.util.Distance distance, int time)
+  {
+    final TravelEstimate.Builder builder = new TravelEstimate.Builder(RoutingHelpers.createDistance(distance), createTimeEstimate(time));
+    builder.setRemainingTimeSeconds(time);
+    builder.setRemainingDistanceColor(Colors.DISTANCE);
+    return builder.build();
+  }
+
+  @NonNull
+  private static DateTimeWithZone createTimeEstimate(int seconds)
+  {
+    final Calendar currentTime = Calendar.getInstance();
+    currentTime.add(Calendar.SECOND, seconds);
+    return DateTimeWithZone.create(currentTime.getTimeInMillis(), currentTime.getTimeZone());
+  }
+}

--- a/android/app/src/main/java/app/organicmaps/car/util/ThemeUtils.java
+++ b/android/app/src/main/java/app/organicmaps/car/util/ThemeUtils.java
@@ -1,0 +1,113 @@
+package app.organicmaps.car.util;
+
+import android.annotation.SuppressLint;
+import android.content.Context;
+import android.content.SharedPreferences;
+
+import androidx.annotation.NonNull;
+import androidx.annotation.StringRes;
+import androidx.annotation.UiThread;
+import androidx.car.app.CarContext;
+
+import app.organicmaps.Framework;
+import app.organicmaps.R;
+import app.organicmaps.routing.RoutingController;
+
+public final class ThemeUtils
+{
+  public enum ThemeMode
+  {
+    AUTO(R.string.auto, R.string.theme_auto),
+    LIGHT(R.string.off, R.string.theme_default),
+    NIGHT(R.string.on, R.string.theme_night);
+
+    ThemeMode(@StringRes int titleId, @StringRes int prefsKeyId)
+    {
+      mTitleId = titleId;
+      mPrefsKeyId = prefsKeyId;
+    }
+
+    @StringRes
+    public int getTitleId()
+    {
+      return mTitleId;
+    }
+
+    @StringRes
+    public int getPrefsKeyId()
+    {
+      return mPrefsKeyId;
+    }
+
+    @StringRes
+    private final int mTitleId;
+    @StringRes
+    private final int mPrefsKeyId;
+  }
+
+  private static final String ANDROID_AUTO_PREFERENCES_FILE_KEY = "ANDROID_AUTO_PREFERENCES_FILE_KEY";
+  private static final String THEME_KEY = "ANDROID_AUTO_THEME_MODE";
+
+  @UiThread
+  public static void update(@NonNull CarContext context)
+  {
+    final ThemeMode oldThemeMode = getThemeMode(context);
+    update(context, oldThemeMode);
+  }
+
+  @UiThread
+  public static void update(@NonNull CarContext context, @NonNull ThemeMode oldThemeMode)
+  {
+    final ThemeMode newThemeMode = oldThemeMode == ThemeMode.AUTO ? (context.isDarkMode() ? ThemeMode.NIGHT : ThemeMode.LIGHT) : oldThemeMode;
+
+    @Framework.MapStyle
+    int newMapStyle;
+    if (newThemeMode == ThemeMode.NIGHT)
+      newMapStyle = RoutingController.get().isVehicleNavigation() ? Framework.MAP_STYLE_VEHICLE_DARK : Framework.MAP_STYLE_DARK;
+    else
+      newMapStyle = RoutingController.get().isVehicleNavigation() ? Framework.MAP_STYLE_VEHICLE_CLEAR : Framework.MAP_STYLE_CLEAR;
+
+    if (Framework.nativeGetMapStyle() != newMapStyle)
+      Framework.nativeSetMapStyle(newMapStyle);
+  }
+
+  public static boolean isNightMode(@NonNull CarContext context)
+  {
+    final ThemeMode themeMode = getThemeMode(context);
+    return themeMode == ThemeMode.NIGHT || (themeMode == ThemeMode.AUTO && context.isDarkMode());
+  }
+
+  @SuppressLint("ApplySharedPref")
+  @UiThread
+  public static void setThemeMode(@NonNull CarContext context, @NonNull ThemeMode themeMode)
+  {
+    getSharedPreferences(context).edit().putString(THEME_KEY, context.getString(themeMode.getPrefsKeyId())).commit();
+    update(context, themeMode);
+  }
+
+  @NonNull
+  public static ThemeMode getThemeMode(@NonNull CarContext context)
+  {
+    final String autoTheme = context.getString(R.string.theme_auto);
+    final String lightTheme = context.getString(R.string.theme_default);
+    final String nightTheme = context.getString(R.string.theme_night);
+    final String themeMode = getSharedPreferences(context).getString(THEME_KEY, autoTheme);
+
+    if (themeMode.equals(autoTheme))
+      return ThemeMode.AUTO;
+    else if (themeMode.equals(lightTheme))
+      return ThemeMode.LIGHT;
+    else if (themeMode.equals(nightTheme))
+      return ThemeMode.NIGHT;
+    else
+      throw new IllegalArgumentException("Unsupported value");
+  }
+
+  @NonNull
+  private static SharedPreferences getSharedPreferences(@NonNull CarContext context)
+  {
+    return context.getSharedPreferences(ANDROID_AUTO_PREFERENCES_FILE_KEY, Context.MODE_PRIVATE);
+  }
+
+  private ThemeUtils() {}
+}

--- a/android/app/src/main/java/app/organicmaps/car/util/UiHelpers.java
+++ b/android/app/src/main/java/app/organicmaps/car/util/UiHelpers.java
@@ -1,0 +1,195 @@
+package app.organicmaps.car.util;
+
+import androidx.annotation.DrawableRes;
+import androidx.annotation.NonNull;
+import androidx.annotation.Nullable;
+import androidx.car.app.CarContext;
+import androidx.car.app.OnScreenResultListener;
+import androidx.car.app.Screen;
+import androidx.car.app.model.Action;
+import androidx.car.app.model.ActionStrip;
+import androidx.car.app.model.CarColor;
+import androidx.car.app.model.CarIcon;
+import androidx.car.app.model.Row;
+import androidx.car.app.navigation.model.MapController;
+import androidx.core.graphics.drawable.IconCompat;
+
+import app.organicmaps.R;
+import app.organicmaps.bookmarks.data.MapObject;
+import app.organicmaps.bookmarks.data.Metadata;
+import app.organicmaps.car.SurfaceRenderer;
+import app.organicmaps.car.screens.base.BaseMapScreen;
+import app.organicmaps.car.screens.settings.SettingsScreen;
+import app.organicmaps.editor.OpeningHours;
+import app.organicmaps.editor.data.Timetable;
+import app.organicmaps.location.LocationHelper;
+import app.organicmaps.location.LocationState;
+import app.organicmaps.util.LocationUtils;
+import app.organicmaps.util.Utils;
+
+import java.util.Calendar;
+
+public final class UiHelpers
+{
+  @NonNull
+  public static ActionStrip createSettingsActionStrip(@NonNull BaseMapScreen mapScreen, @NonNull SurfaceRenderer surfaceRenderer)
+  {
+    return new ActionStrip.Builder().addAction(createSettingsAction(mapScreen, surfaceRenderer)).build();
+  }
+
+  @NonNull
+  public static ActionStrip createMapActionStrip(@NonNull CarContext context, @NonNull SurfaceRenderer surfaceRenderer)
+  {
+    final CarIcon iconPlus = new CarIcon.Builder(IconCompat.createWithResource(context, R.drawable.ic_plus)).build();
+    final CarIcon iconMinus = new CarIcon.Builder(IconCompat.createWithResource(context, R.drawable.ic_minus)).build();
+
+    final Action panAction = new Action.Builder(Action.PAN).build();
+    final Action location = createLocationButton(context);
+    final Action zoomIn = new Action.Builder().setIcon(iconPlus).setOnClickListener(surfaceRenderer::onZoomIn).build();
+    final Action zoomOut = new Action.Builder().setIcon(iconMinus).setOnClickListener(surfaceRenderer::onZoomOut).build();
+    return new ActionStrip.Builder()
+        .addAction(panAction)
+        .addAction(zoomIn)
+        .addAction(zoomOut)
+        .addAction(location)
+        .build();
+  }
+
+  @NonNull
+  public static MapController createMapController(@NonNull CarContext context, @NonNull SurfaceRenderer surfaceRenderer)
+  {
+    return new MapController.Builder().setMapActionStrip(createMapActionStrip(context, surfaceRenderer)).build();
+  }
+
+  @NonNull
+  public static Action createSettingsAction(@NonNull BaseMapScreen mapScreen, @NonNull SurfaceRenderer surfaceRenderer)
+  {
+    return createSettingsAction(mapScreen, surfaceRenderer, null);
+  }
+
+  @NonNull
+  public static Action createSettingsActionForResult(@NonNull BaseMapScreen mapScreen, @NonNull SurfaceRenderer surfaceRenderer, @NonNull OnScreenResultListener onScreenResultListener)
+  {
+    return createSettingsAction(mapScreen, surfaceRenderer, onScreenResultListener);
+  }
+
+  @NonNull
+  private static Action createSettingsAction(@NonNull BaseMapScreen mapScreen, @NonNull SurfaceRenderer surfaceRenderer, @Nullable OnScreenResultListener onScreenResultListener)
+  {
+    final CarContext context = mapScreen.getCarContext();
+    final CarIcon iconSettings = new CarIcon.Builder(IconCompat.createWithResource(context, R.drawable.ic_settings)).build();
+
+    return new Action.Builder().setIcon(iconSettings).setOnClickListener(() -> {
+      // Action.onClickListener for the Screen A maybe called even if the Screen B is shown now.
+      // We need to check it
+      // This may happen when we use PopToRootHack:
+      //   * ScreenManager.popToRoot()
+      //   * The root screen (A) is shown for a while
+      //   * User clicks on some action
+      //   * ScreenManager.push(new Screen())
+      //   * New screen (B) is displayed now
+      //   * Action.onClickListener is called for action from root screen (A)
+      if (mapScreen.getScreenManager().getTop() != mapScreen)
+        return;
+      final Screen settingsScreen = new SettingsScreen(context, surfaceRenderer);
+      if (onScreenResultListener != null)
+        mapScreen.getScreenManager().pushForResult(settingsScreen, onScreenResultListener);
+      else
+        mapScreen.getScreenManager().push(settingsScreen);
+    }).build();
+  }
+
+  @Nullable
+  public static Row getPlaceOpeningHoursRow(@NonNull MapObject place, @NonNull CarContext context)
+  {
+    if (!place.hasMetadata())
+      return null;
+
+    final String ohStr = place.getMetadata(Metadata.MetadataType.FMD_OPEN_HOURS);
+    final Timetable[] timetables = OpeningHours.nativeTimetablesFromString(ohStr);
+    final boolean isEmptyTT = (timetables == null || timetables.length == 0);
+
+    if (ohStr.isEmpty() && isEmptyTT)
+      return null;
+
+    final Row.Builder builder = new Row.Builder();
+    builder.setImage(new CarIcon.Builder(IconCompat.createWithResource(context, R.drawable.ic_operating_hours)).build());
+
+    if (isEmptyTT)
+      builder.setTitle(ohStr);
+    else if (timetables[0].isFullWeek())
+    {
+      if (timetables[0].isFullday)
+        builder.setTitle(context.getString(R.string.twentyfour_seven));
+      else
+        builder.setTitle(timetables[0].workingTimespan.toWideString());
+    }
+    else
+    {
+      boolean containsCurrentWeekday = false;
+      final int currentDay = Calendar.getInstance().get(Calendar.DAY_OF_WEEK);
+      for (final Timetable tt : timetables)
+      {
+        if (tt.containsWeekday(currentDay))
+        {
+          containsCurrentWeekday = true;
+          String openTime;
+
+          if (tt.isFullday)
+            openTime = Utils.unCapitalize(context.getString(R.string.editor_time_allday));
+          else
+            openTime = tt.workingTimespan.toWideString();
+
+          builder.setTitle(openTime);
+
+          break;
+        }
+      }
+      // Show that place is closed today.
+      if (!containsCurrentWeekday)
+        builder.setTitle(context.getString(R.string.day_off_today));
+    }
+
+    return builder.build();
+  }
+
+  @NonNull
+  private static Action createLocationButton(@NonNull CarContext context)
+  {
+    final Action.Builder builder = new Action.Builder();
+    final int locationMode = LocationState.nativeGetMode();
+    CarColor tintColor = Colors.DEFAULT;
+
+    @DrawableRes int drawableRes;
+    switch (locationMode)
+    {
+    case LocationState.PENDING_POSITION:
+    case LocationState.NOT_FOLLOW_NO_POSITION:
+      drawableRes = R.drawable.ic_location_off;
+      break;
+    case LocationState.NOT_FOLLOW:
+      drawableRes = R.drawable.ic_not_follow;
+      break;
+    case LocationState.FOLLOW:
+      drawableRes = R.drawable.ic_follow;
+      tintColor = Colors.LOCATION_TINT;
+      break;
+    case LocationState.FOLLOW_AND_ROTATE:
+      drawableRes = R.drawable.ic_follow_and_rotate;
+      tintColor = Colors.LOCATION_TINT;
+      break;
+    default:
+      throw new IllegalArgumentException("Invalid button mode: " + locationMode);
+    }
+
+    final CarIcon icon = new CarIcon.Builder(IconCompat.createWithResource(context, drawableRes)).setTint(tintColor).build();
+    builder.setIcon(icon);
+    builder.setOnClickListener(() -> {
+      LocationState.nativeSwitchToNextMode();
+      final LocationHelper locationHelper = LocationHelper.from(context);
+      if (!locationHelper.isActive() && LocationUtils.checkFineLocationPermission(context))
+        locationHelper.start();
+    });
+    return builder.build();
+  }
+}

--- a/android/app/src/main/java/app/organicmaps/display/DisplayChangedListener.java
+++ b/android/app/src/main/java/app/organicmaps/display/DisplayChangedListener.java
@@ -1,0 +1,8 @@
+package app.organicmaps.display;
+
+import androidx.annotation.NonNull;
+
+public interface DisplayChangedListener
+{
+  void onDisplayChanged(@NonNull final DisplayType newDisplayType);
+}

--- a/android/app/src/main/java/app/organicmaps/display/DisplayManager.java
+++ b/android/app/src/main/java/app/organicmaps/display/DisplayManager.java
@@ -1,0 +1,359 @@
+package app.organicmaps.display;
+
+import android.content.Context;
+import android.os.Handler;
+import android.os.Looper;
+import android.os.Message;
+
+import androidx.annotation.NonNull;
+import androidx.annotation.Nullable;
+import androidx.lifecycle.Lifecycle;
+import androidx.lifecycle.LifecycleEventObserver;
+import androidx.lifecycle.LifecycleOwner;
+
+import app.organicmaps.MwmApplication;
+import app.organicmaps.util.log.Logger;
+
+public class DisplayManager implements Handler.Callback
+{
+  private static final String TAG = DisplayManager.class.getSimpleName();
+
+  // See description in updateDisplay()
+  private static final int MESSAGE_CHANGE_DISPLAY_TO_CAR = 0x01;
+  private static final int MESSAGE_CHANGE_DISPLAY_TO_DEVICE = 0x02;
+  private static final int MESSAGE_DELAY = 100; // 0.1s
+
+  private class DisplayLifecycleObserver implements LifecycleEventObserver
+  {
+    @NonNull
+    private final DisplayHolder displayHolder;
+
+    public DisplayLifecycleObserver(@NonNull DisplayHolder displayHolder)
+    {
+      this.displayHolder = displayHolder;
+    }
+
+    @Override
+    public void onStateChanged(@NonNull LifecycleOwner source, @NonNull Lifecycle.Event event)
+    {
+      Logger.d(TAG, "Source: " + source + " Event: " + event);
+      displayHolder.lastEvent = event;
+
+      updateDisplay();
+    }
+  }
+
+  private static class DisplayHolder
+  {
+    boolean isConnected = false;
+    boolean notify = false;
+    Lifecycle.Event lastEvent;
+    DisplayChangedListener listener;
+    DisplayLifecycleObserver lifecycleObserver;
+
+    public void destroy()
+    {
+      isConnected = false;
+      notify = false;
+      lastEvent = null;
+      listener = null;
+      lifecycleObserver = null;
+    }
+  }
+
+  @NonNull
+  private DisplayType mCurrentDisplayType = DisplayType.Device;
+  @Nullable
+  private DisplayHolder mDevice;
+  @Nullable
+  private DisplayHolder mCar;
+
+  private final Handler mCallbackHandler = new Handler(Looper.getMainLooper(), this);
+
+  @NonNull
+  public static DisplayManager from(@NonNull Context context)
+  {
+    final MwmApplication app = (MwmApplication) context.getApplicationContext();
+    return app.getDisplayManager();
+  }
+
+  public boolean isCarConnected()
+  {
+    return mCar != null;
+  }
+
+  public boolean isDeviceConnected()
+  {
+    return mDevice != null;
+  }
+
+  public boolean isCarDisplayUsed()
+  {
+    return mCurrentDisplayType == DisplayType.Car;
+  }
+
+  public boolean isDeviceDisplayUsed()
+  {
+    return mCurrentDisplayType == DisplayType.Device;
+  }
+
+  public void addListener(@NonNull final DisplayType displayType, @NonNull final DisplayChangedListener listener)
+  {
+    Logger.d(TAG, "displayType = " + displayType + ", listener = " + listener);
+
+    if (displayType == DisplayType.Device && mDevice == null)
+    {
+      mDevice = new DisplayHolder();
+      mDevice.isConnected = true;
+      mDevice.notify = true;
+      mDevice.listener = listener;
+    }
+    else if (displayType == DisplayType.Car && mCar == null)
+    {
+      mCar = new DisplayHolder();
+      mCar.isConnected = true;
+      mCar.notify = true;
+      mCar.listener = listener;
+    }
+
+    if (isCarConnected() && !isDeviceConnected())
+      mCurrentDisplayType = displayType;
+  }
+
+  public LifecycleEventObserver getObserverFor(@NonNull final DisplayType displayType)
+  {
+    Logger.d(TAG, "displayType = " + displayType);
+
+    if (displayType == DisplayType.Device && mDevice != null)
+      return mDevice.lifecycleObserver = new DisplayLifecycleObserver(mDevice);
+    else if (displayType == DisplayType.Car && mCar != null)
+      return mCar.lifecycleObserver = new DisplayLifecycleObserver(mCar);
+
+    throw new RuntimeException("Display holder for " + displayType + " is not initialized");
+  }
+
+  private void updateDisplay()
+  {
+    Logger.d(TAG);
+
+    final boolean isDeviceDestroyed = mDevice != null && mDevice.lastEvent == Lifecycle.Event.ON_DESTROY;
+    final boolean isCarDestroyed = mCar != null && mCar.lastEvent == Lifecycle.Event.ON_DESTROY;
+
+    // Device is destroyed due to the one of the following reasons:
+    // 1. Configuration changes (rotation, theme and so on)
+    // 2. Entering navigation mode
+    // 3. Application is closed
+    // When Car is not connected we don't need to change display type.
+    // If device was destroyed due to reasons 1-2,
+    // mDevice will be created with the actual information about the new activity after Activity.onCreate() call
+    if (isDeviceDestroyed)
+    {
+      destroyDisplayHolder(mDevice);
+
+      // Process configuration change case (also works for navigation case)
+      if (isDeviceDisplayUsed() && isCarConnected())
+        // We can't check whether the device changing its configuration or not
+        // Let's post a delayed message to the handler notifying that display should be changed to car if device is still not connected
+        mCallbackHandler.sendEmptyMessageDelayed(MESSAGE_CHANGE_DISPLAY_TO_CAR, MESSAGE_DELAY);
+      return;
+    }
+
+    // This happens when Android Auto is disconnected or when the application is stopped (if only car connected)
+    if (isCarDestroyed)
+    {
+      destroyDisplayHolder(mCar);
+
+      if (isDeviceConnected())
+      {
+        mDevice.notify = true;
+        notifyDisplayChange(DisplayType.Device);
+      }
+
+      // We don't care about what's going on next when car and device are disconnected -> application will be stopped
+      return;
+    }
+
+    // Only device connected. The most common case
+    if (isDeviceConnected() && !isCarConnected())
+    {
+      if (mCurrentDisplayType != DisplayType.Device)
+      {
+        mDevice.notify = true;
+        notifyDisplayChange(DisplayType.Device);
+        return;
+      }
+    }
+
+    // Only car connected
+    if (isCarConnected() && !isDeviceConnected())
+    {
+      if (mCurrentDisplayType != DisplayType.Car)
+      {
+        mCar.notify = true;
+        notifyDisplayChange(DisplayType.Car);
+        return;
+      }
+    }
+
+    if (isDeviceConnected() && isCarConnected())
+    {
+      // 1. Map was used on Car
+      // 2. Car disconnected
+      // 3. Show map on Device
+      // Activity is being recreated when Android Auto disconnected. We have to handle it
+      if (isCarDisplayUsed() && mDevice.lastEvent == Lifecycle.Event.ON_START)
+      {
+        // Let's post a delayed message to the handler notifying that display should be changed to device if car is disconnected
+        mCallbackHandler.sendEmptyMessageDelayed(MESSAGE_CHANGE_DISPLAY_TO_DEVICE, MESSAGE_DELAY);
+        return;
+      }
+
+      // 1. Map was shown on Device
+      // 2. MwmActivity.onStop() called
+      // 3. Car is launched
+      // Let's show map on Car because it's the case when we hide application on the phone without closing it
+      if (isDeviceDisplayUsed() && mDevice.lastEvent == Lifecycle.Event.ON_STOP && mCar.lastEvent == Lifecycle.Event.ON_CREATE)
+      {
+        mDevice.notify = true;
+        mCar.notify = true;
+        notifyDisplayChange(DisplayType.Car);
+        return;
+      }
+
+      // Car was connected after Device
+      // Notify car
+      if (mCar.lastEvent == Lifecycle.Event.ON_CREATE)
+      {
+        mCar.notify = true;
+        notifyDisplayChange(mCurrentDisplayType);
+        return;
+      }
+
+      // Device was connected after Car
+      // Notify device
+      if (mDevice.lastEvent == Lifecycle.Event.ON_CREATE)
+      {
+        mDevice.notify = true;
+        notifyDisplayChange(mCurrentDisplayType);
+        return;
+      }
+
+      // 1. Map was shown on Device
+      // 2. MwmActivity.onStop() called
+      // 3. Map is shown on Car
+      // Reason: we need to disable controls on device
+      if (mDevice.lastEvent == Lifecycle.Event.ON_RESUME && isCarDisplayUsed())
+      {
+        mDevice.notify = true;
+        notifyDisplayChange(mCurrentDisplayType);
+      }
+    }
+  }
+
+  private void notifyDisplayChange(@NonNull final DisplayType newDisplayType)
+  {
+    Logger.d(TAG, "newDisplayType = " + newDisplayType);
+
+    mCurrentDisplayType = newDisplayType;
+
+    if (mCurrentDisplayType == DisplayType.Device)
+      mCallbackHandler.post(this::onDisplayTypeChangedToDevice);
+    else if (mCurrentDisplayType == DisplayType.Car)
+      mCallbackHandler.post(this::onDisplayTypeChangedToCar);
+  }
+
+  public void changeDisplay(@NonNull final DisplayType newDisplayType)
+  {
+    Logger.d(TAG, "newDisplayType = " + newDisplayType);
+
+    if (mCurrentDisplayType == newDisplayType)
+      return;
+
+    if (isCarConnected())
+    {
+      assert mCar != null;
+      mCar.notify = true;
+    }
+    if (isDeviceConnected())
+    {
+      assert mDevice != null;
+      mDevice.notify = true;
+    }
+
+    notifyDisplayChange(newDisplayType);
+  }
+
+  private void onDisplayTypeChangedToDevice()
+  {
+    Logger.d(TAG);
+
+    if (mCar != null && mCar.notify)
+    {
+      mCar.listener.onDisplayChanged(DisplayType.Device);
+      mCar.notify = false;
+    }
+    if (mDevice != null && mDevice.notify)
+    {
+      mDevice.listener.onDisplayChanged(DisplayType.Device);
+      mDevice.notify = false;
+    }
+  }
+
+  private void onDisplayTypeChangedToCar()
+  {
+    Logger.d(TAG);
+
+    if (mDevice != null && mDevice.notify)
+    {
+      mDevice.listener.onDisplayChanged(DisplayType.Car);
+      mDevice.notify = false;
+    }
+    if (mCar != null && mCar.notify)
+    {
+      mCar.listener.onDisplayChanged(DisplayType.Car);
+      mCar.notify = false;
+    }
+  }
+
+  private void destroyDisplayHolder(DisplayHolder holder)
+  {
+    if (holder == null)
+      return;
+    Logger.d(TAG, holder == mDevice ? "device" : "car");
+
+    holder.destroy();
+    if (holder == mDevice)
+      mDevice = null;
+    else if (holder == mCar)
+      mCar = null;
+  }
+
+  @Override
+  public boolean handleMessage(@NonNull Message msg)
+  {
+    Logger.d(TAG, "" + msg.what);
+    if (msg.what == MESSAGE_CHANGE_DISPLAY_TO_CAR)
+    {
+      // Device still not connected. It's not a configuration change case. Switch display to car
+      if (!isDeviceConnected() && isCarConnected())
+      {
+        assert mCar != null;
+        mCar.notify = true;
+        notifyDisplayChange(DisplayType.Car);
+      }
+      return true;
+    }
+    else if (msg.what == MESSAGE_CHANGE_DISPLAY_TO_DEVICE)
+    {
+      // Car disconnected. Let's switch display to Device
+      if (isDeviceConnected() && !isCarConnected())
+      {
+        assert mDevice != null;
+        mDevice.notify = true;
+        notifyDisplayChange(DisplayType.Device);
+      }
+      return true;
+    }
+    return false;
+  }
+}

--- a/android/app/src/main/java/app/organicmaps/display/DisplayType.java
+++ b/android/app/src/main/java/app/organicmaps/display/DisplayType.java
@@ -1,0 +1,7 @@
+package app.organicmaps.display;
+
+public enum DisplayType
+{
+  Device,
+  Car
+}

--- a/android/app/src/main/java/app/organicmaps/intent/Factory.java
+++ b/android/app/src/main/java/app/organicmaps/intent/Factory.java
@@ -14,7 +14,6 @@ import androidx.fragment.app.FragmentManager;
 import app.organicmaps.DownloadResourcesLegacyActivity;
 import app.organicmaps.Framework;
 import app.organicmaps.Map;
-import app.organicmaps.MapFragment;
 import app.organicmaps.MwmActivity;
 import app.organicmaps.MwmApplication;
 import app.organicmaps.api.ParsedMwmRequest;
@@ -45,6 +44,15 @@ public class Factory
     @Override
     public MapTask process(@NonNull Intent intent)
     {
+      final String uri = processIntent(intent);
+      if (uri == null)
+        return null;
+      return new OpenUrlTask(uri);
+    }
+
+    @Nullable
+    public static String processIntent(@NonNull Intent intent)
+    {
       final Uri uri = intent.getData();
       if (uri == null)
         return null;
@@ -54,7 +62,7 @@ public class Factory
       SearchEngine.INSTANCE.cancelInteractiveSearch();
       final ParsedMwmRequest request = ParsedMwmRequest.extractFromIntent(intent);
       ParsedMwmRequest.setCurrentRequest(request);
-      return new OpenUrlTask(uri.toString());
+      return uri.toString();
     }
   }
 

--- a/android/app/src/main/java/app/organicmaps/location/LocationHelper.java
+++ b/android/app/src/main/java/app/organicmaps/location/LocationHelper.java
@@ -2,7 +2,6 @@ package app.organicmaps.location;
 
 import static android.Manifest.permission.ACCESS_COARSE_LOCATION;
 import static android.Manifest.permission.ACCESS_FINE_LOCATION;
-import static android.content.pm.PackageManager.PERMISSION_GRANTED;
 
 import android.app.PendingIntent;
 import android.content.Context;
@@ -13,7 +12,6 @@ import androidx.annotation.NonNull;
 import androidx.annotation.Nullable;
 import androidx.annotation.RequiresPermission;
 import androidx.annotation.UiThread;
-import androidx.core.content.ContextCompat;
 
 import app.organicmaps.Framework;
 import app.organicmaps.MwmApplication;
@@ -317,7 +315,7 @@ public class LocationHelper implements BaseLocationProvider.Listener
     Logger.i(TAG);
     checkForAgpsUpdates();
 
-    if (ContextCompat.checkSelfPermission(mContext, ACCESS_FINE_LOCATION) == PERMISSION_GRANTED)
+    if (LocationUtils.checkFineLocationPermission(mContext))
       SensorHelper.from(mContext).start();
 
     final long oldInterval = mInterval;
@@ -357,8 +355,7 @@ public class LocationHelper implements BaseLocationProvider.Listener
       Logger.i(TAG, "Location updates are stopped by the user manually.");
       return;
     }
-    else if (ContextCompat.checkSelfPermission(mContext, ACCESS_FINE_LOCATION) != PERMISSION_GRANTED &&
-             ContextCompat.checkSelfPermission(mContext, ACCESS_COARSE_LOCATION) != PERMISSION_GRANTED)
+    else if (!LocationUtils.checkLocationPermission(mContext))
     {
       Logger.i(TAG, "Permissions ACCESS_FINE_LOCATION and ACCESS_COARSE_LOCATION are not granted");
       return;

--- a/android/app/src/main/java/app/organicmaps/routing/SingleLaneInfo.java
+++ b/android/app/src/main/java/app/organicmaps/routing/SingleLaneInfo.java
@@ -5,8 +5,8 @@ import app.organicmaps.R;
 
 public class SingleLaneInfo
 {
-  LaneWay[] mLane;
-  boolean mIsActive;
+  public LaneWay[] mLane;
+  public boolean mIsActive;
 
   /**
    * IMPORTANT : Order of enum values MUST BE the same

--- a/android/app/src/main/java/app/organicmaps/search/SearchEngine.java
+++ b/android/app/src/main/java/app/organicmaps/search/SearchEngine.java
@@ -158,13 +158,6 @@ public enum SearchEngine implements NativeSearchListener,
   }
 
   @MainThread
-  public void searchInteractive(@NonNull Context context, @NonNull String query, boolean isCategory,
-                                long timestamp, boolean isMapAndTable, boolean hasLocation, double lat, double lon)
-  {
-    searchInteractive(query, isCategory, Language.getKeyboardLocale(context), timestamp, isMapAndTable, hasLocation, lat, lon);
-  }
-
-  @MainThread
   public boolean searchInBookmarks(@NonNull String query, long categoryId, long timestamp)
   {
     return nativeRunSearchInBookmarks(query.getBytes(StandardCharsets.UTF_8), categoryId, timestamp);

--- a/android/app/src/main/java/app/organicmaps/util/Distance.java
+++ b/android/app/src/main/java/app/organicmaps/util/Distance.java
@@ -9,6 +9,8 @@ import app.organicmaps.R;
 
 public final class Distance
 {
+  public static final Distance EMPTY = new Distance(0.0, "", (byte) 0);
+
   /**
    * IMPORTANT : Order of enum values MUST BE the same
    * with native Distance::Units enum (see platform/distance.hpp for details).

--- a/android/app/src/main/java/app/organicmaps/util/LocationUtils.java
+++ b/android/app/src/main/java/app/organicmaps/util/LocationUtils.java
@@ -1,5 +1,8 @@
 package app.organicmaps.util;
 
+import static android.Manifest.permission.ACCESS_FINE_LOCATION;
+import static android.content.pm.PackageManager.PERMISSION_GRANTED;
+
 import android.content.Context;
 import android.location.Location;
 import android.location.LocationManager;
@@ -8,6 +11,7 @@ import android.provider.Settings;
 import android.view.Surface;
 
 import androidx.annotation.NonNull;
+import androidx.core.content.ContextCompat;
 
 public class LocationUtils
 {
@@ -110,5 +114,20 @@ public class LocationUtils
       e.printStackTrace();
       return false;
     }
+  }
+
+  public static boolean checkFineLocationPermission(@NonNull Context context)
+  {
+    return ContextCompat.checkSelfPermission(context, ACCESS_FINE_LOCATION) == PERMISSION_GRANTED;
+  }
+
+  public static boolean checkCoarseLocationPermission(@NonNull Context context)
+  {
+    return ContextCompat.checkSelfPermission(context, ACCESS_FINE_LOCATION) == PERMISSION_GRANTED;
+  }
+
+  public static boolean checkLocationPermission(@NonNull Context context)
+  {
+    return checkFineLocationPermission(context) || checkCoarseLocationPermission(context);
   }
 }

--- a/android/app/src/main/java/app/organicmaps/util/ThemeSwitcher.java
+++ b/android/app/src/main/java/app/organicmaps/util/ThemeSwitcher.java
@@ -11,6 +11,7 @@ import app.organicmaps.Framework;
 import app.organicmaps.MwmApplication;
 import app.organicmaps.R;
 import app.organicmaps.base.Initializable;
+import app.organicmaps.display.DisplayManager;
 import app.organicmaps.downloader.DownloaderStatusIcon;
 import app.organicmaps.location.LocationHelper;
 import app.organicmaps.routing.RoutingController;
@@ -134,6 +135,10 @@ public enum ThemeSwitcher implements Initializable<Context>
 
   private void SetMapStyle(@Framework.MapStyle int style)
   {
+    // Because of the distinct behavior in auto theme, Android Auto employs its own mechanism for theme switching.
+    // For the Android Auto theme switcher, please consult the app.organicmaps.car.util.ThemeUtils module.
+    if (DisplayManager.from(mContext).isCarDisplayUsed())
+      return;
     // If rendering is not active we can mark map style, because all graphics
     // will be recreated after rendering activation.
     if (mRendererActive)

--- a/android/app/src/main/java/app/organicmaps/widget/placepage/PlacePageUtils.java
+++ b/android/app/src/main/java/app/organicmaps/widget/placepage/PlacePageUtils.java
@@ -9,6 +9,7 @@ import androidx.annotation.NonNull;
 import app.organicmaps.Framework;
 import app.organicmaps.R;
 import app.organicmaps.util.Utils;
+import app.organicmaps.display.DisplayManager;
 import com.google.android.material.bottomsheet.BottomSheetBehavior;
 
 import java.util.List;
@@ -18,6 +19,9 @@ public class PlacePageUtils
   static void updateMapViewport(@NonNull View parent, int placePageDistanceToTop, int viewportMinHeight)
   {
     parent.post(() -> {
+      // Because of the post(), this lambda is called after the car.SurfaceRenderer.onStableAreaChanged() and breaks the visibleRect configuration
+      if (DisplayManager.from(parent.getContext()).isCarDisplayUsed())
+        return;
       final int screenWidth = parent.getWidth();
       if (placePageDistanceToTop >= viewportMinHeight)
         Framework.nativeSetVisibleRect(0, 0, screenWidth, placePageDistanceToTop);

--- a/android/app/src/main/res/drawable/ic_car_connected.xml
+++ b/android/app/src/main/res/drawable/ic_car_connected.xml
@@ -1,0 +1,23 @@
+<layer-list xmlns:android="http://schemas.android.com/apk/res/android">
+  <item>
+    <shape>
+      <size
+          android:width="120dp"
+          android:height="120dp" />
+      <solid android:color="@color/base_accent" />
+      <corners android:radius="16dp" />
+    </shape>
+  </item>
+  <item>
+    <vector
+        android:width="15dp"
+        android:height="15dp"
+        android:viewportWidth="15"
+        android:viewportHeight="15">
+      <path
+          android:pathData="M13.84,6.852,12.6,5.7,11.5,3.5a1.05,1.05,0,0,0-.9-.5H4.4a1.05,1.05,0,0,0-.9.5L2.4,5.7,1.16,6.852A.5.5,0,0,0,1,7.219V11.5a.5.5,0,0,0,.5.5h2c.2,0,.5-.2.5-.4V11h7v.5c0,.2.2.5.4.5h2.1a.5.5,0,0,0,.5-.5V7.219A.5.5,0,0,0,13.84,6.852ZM4.5,4h6l1,2h-8ZM5,8.6c0,.2-.3.4-.5.4H2.4C2.2,9,2,8.7,2,8.5V7.4c.1-.3.3-.5.6-.4l2,.4c.2,0,.4.3.4.5Zm8-.1c0,.2-.2.5-.4.5H10.5c-.2,0-.5-.2-.5-.4V7.9c0-.2.2-.5.4-.5l2-.4c.3-.1.5.1.6.4Z"
+          android:fillColor="#ffffff"
+          android:fillType="evenOdd"/>
+    </vector>
+  </item>
+</layer-list>

--- a/android/app/src/main/res/drawable/ic_check_box.xml
+++ b/android/app/src/main/res/drawable/ic_check_box.xml
@@ -1,0 +1,5 @@
+<vector android:height="24dp"
+    android:viewportHeight="24" android:viewportWidth="24"
+    android:width="24dp" xmlns:android="http://schemas.android.com/apk/res/android">
+    <path android:fillColor="@android:color/white" android:pathData="M19,5v14H5V5h14m0,-2H5c-1.1,0 -2,0.9 -2,2v14c0,1.1 0.9,2 2,2h14c1.1,0 2,-0.9 2,-2V5c0,-1.1 -0.9,-2 -2,-2z"/>
+</vector>

--- a/android/app/src/main/res/drawable/ic_check_box_checked.xml
+++ b/android/app/src/main/res/drawable/ic_check_box_checked.xml
@@ -1,0 +1,5 @@
+<vector android:height="24dp"
+    android:viewportHeight="24" android:viewportWidth="24"
+    android:width="24dp" xmlns:android="http://schemas.android.com/apk/res/android">
+    <path android:fillColor="@android:color/white" android:pathData="M19,3L5,3c-1.11,0 -2,0.9 -2,2v14c0,1.1 0.89,2 2,2h14c1.11,0 2,-0.9 2,-2L21,5c0,-1.1 -0.89,-2 -2,-2zM10,17l-5,-5 1.41,-1.41L10,14.17l7.59,-7.59L19,8l-9,9z"/>
+</vector>

--- a/android/app/src/main/res/drawable/ic_phone_android.xml
+++ b/android/app/src/main/res/drawable/ic_phone_android.xml
@@ -1,0 +1,5 @@
+<vector android:height="24dp" android:tint="#FFFFFF"
+    android:viewportHeight="24" android:viewportWidth="24"
+    android:width="24dp" xmlns:android="http://schemas.android.com/apk/res/android">
+    <path android:fillColor="@android:color/white" android:pathData="M16,1L8,1C6.34,1 5,2.34 5,4v16c0,1.66 1.34,3 3,3h8c1.66,0 3,-1.34 3,-3L19,4c0,-1.66 -1.34,-3 -3,-3zM14,21h-4v-1h4v1zM17.25,18L6.75,18L6.75,4h10.5v14z"/>
+</vector>

--- a/android/app/src/main/res/drawable/ic_radio_button_checked.xml
+++ b/android/app/src/main/res/drawable/ic_radio_button_checked.xml
@@ -1,0 +1,5 @@
+<vector android:height="24dp" android:tint="#FFFFFF"
+    android:viewportHeight="24" android:viewportWidth="24"
+    android:width="24dp" xmlns:android="http://schemas.android.com/apk/res/android">
+    <path android:fillColor="@android:color/white" android:pathData="M12,7c-2.76,0 -5,2.24 -5,5s2.24,5 5,5 5,-2.24 5,-5 -2.24,-5 -5,-5zM12,2C6.48,2 2,6.48 2,12s4.48,10 10,10 10,-4.48 10,-10S17.52,2 12,2zM12,20c-4.42,0 -8,-3.58 -8,-8s3.58,-8 8,-8 8,3.58 8,8 -3.58,8 -8,8z"/>
+</vector>

--- a/android/app/src/main/res/drawable/ic_radio_button_unchecked.xml
+++ b/android/app/src/main/res/drawable/ic_radio_button_unchecked.xml
@@ -1,0 +1,5 @@
+<vector android:height="24dp" android:tint="#FFFFFF"
+    android:viewportHeight="24" android:viewportWidth="24"
+    android:width="24dp" xmlns:android="http://schemas.android.com/apk/res/android">
+    <path android:fillColor="@android:color/white" android:pathData="M12,2C6.48,2 2,6.48 2,12s4.48,10 10,10 10,-4.48 10,-10S17.52,2 12,2zM12,20c-4.42,0 -8,-3.58 -8,-8s3.58,-8 8,-8 8,3.58 8,8 -3.58,8 -8,8z"/>
+</vector>

--- a/android/app/src/main/res/layout/fragment_map_placeholder.xml
+++ b/android/app/src/main/res/layout/fragment_map_placeholder.xml
@@ -1,0 +1,49 @@
+<?xml version="1.0" encoding="utf-8"?>
+<LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    android:layout_width="match_parent"
+    android:layout_height="match_parent"
+    android:background="?windowBackgroundForced"
+    android:gravity="center"
+    android:orientation="vertical">
+
+  <androidx.appcompat.widget.AppCompatImageView
+      android:layout_width="wrap_content"
+      android:layout_height="wrap_content"
+      android:layout_margin="32dp"
+      android:src="@drawable/ic_car_connected" />
+
+  <LinearLayout
+      android:layout_width="match_parent"
+      android:layout_height="wrap_content"
+      android:layout_marginEnd="32dp"
+      android:layout_marginStart="32dp"
+      android:gravity="center"
+      android:orientation="vertical">
+
+    <TextView
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:layout_marginBottom="8dp"
+        android:text="@string/aa_connected_title"
+        android:textAlignment="center"
+        android:textAppearance="@style/TextAppearance.MaterialComponents.Headline4"
+        android:textStyle="bold" />
+
+    <TextView
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:text="@string/aa_used_on_the_car_screen"
+        android:textAlignment="center"
+        android:textAppearance="@style/TextAppearance.MaterialComponents.Body1" />
+  </LinearLayout>
+
+  <Button
+      android:id="@+id/btn_continue"
+      style="@style/MwmWidget.Button.Accent"
+      android:layout_width="match_parent"
+      android:layout_height="wrap_content"
+      android:layout_marginEnd="32dp"
+      android:layout_marginStart="32dp"
+      android:layout_marginTop="24dp"
+      android:text="@string/aa_continue_on_the_phone" />
+</LinearLayout>

--- a/android/app/src/main/res/values-fr/strings.xml
+++ b/android/app/src/main/res/values-fr/strings.xml
@@ -746,6 +746,20 @@
 	<string name="osm_wiki_about_url">https://wiki.openstreetmap.org/wiki/FR:À_propos_d’OpenStreetMap</string>
 	<!-- Tip #00 -->
 	<string name="app_tip_00">Merci d\'utiliser nos cartes créées par la communauté !</string>
+	<!-- Text on the Android Auto placeholder screen that maps are displayed on the phone screen -->
+	<string name="aa_used_on_the_phone_screen">Vous utilisez maintenant Organic Maps sur l’écran du téléphone</string>
+	<!-- Text on the phone placeholder screen that maps are displayed on the car screen -->
+	<string name="aa_used_on_the_car_screen">Vous utilisez maintenant Organic Maps sur l\'écran de la voiture</string>
+	<!-- Displayed on the phone screen. Android Auto connected -->
+	<string name="aa_connected_title">Vous êtes connecté à Android Auto</string>
+	<!-- Displayed on the phone screen. Button to display maps on the phone screen instead of a car -->
+	<string name="aa_continue_on_the_phone">Aller sur le téléphone</string>
+	<!-- Displayed on the Android Auto screen. Button to display maps on the car screen instead of a phone. Must be no more than 18 symbols! -->
+	<string name="aa_continue_in_the_car">Afficher dans la voiture</string>
+	<!-- Ask user to grant location permissions -->
+	<string name="aa_location_permissions_request">L\'application a besoin de l\'accès à la localisation pour la navigation.</string>
+	<!-- Displayed on the Android Auto screen. Grant Permissions button. Must be no more than 18 symbols! -->
+	<string name="aa_grant_permissions">Accorder l\'accès</string>
 
 	<!-- SECTION: Types -->
 	<string name="type.addr_interpolation">Adresse/Bloc</string>

--- a/android/app/src/main/res/values-ru/strings.xml
+++ b/android/app/src/main/res/values-ru/strings.xml
@@ -754,6 +754,20 @@
 	<string name="osm_wiki_about_url">https://wiki.openstreetmap.org/wiki/RU:О_проекте</string>
 	<!-- Tip #00 -->
 	<string name="app_tip_00">Спасибо, что пользуетесь нашими картами, созданными сообществом!</string>
+	<!-- Text on the Android Auto placeholder screen that maps are displayed on the phone screen -->
+	<string name="aa_used_on_the_phone_screen">Сейчас Вы используете Organic Maps на экране телефона</string>
+	<!-- Text on the phone placeholder screen that maps are displayed on the car screen -->
+	<string name="aa_used_on_the_car_screen">Сейчас Вы используете Organic Maps на экране автомобиля</string>
+	<!-- Displayed on the phone screen. Android Auto connected -->
+	<string name="aa_connected_title">Вы подключены к Android Auto</string>
+	<!-- Displayed on the phone screen. Button to display maps on the phone screen instead of a car -->
+	<string name="aa_continue_on_the_phone">Продолжить в телефоне</string>
+	<!-- Displayed on the Android Auto screen. Button to display maps on the car screen instead of a phone. Must be no more than 18 symbols! -->
+	<string name="aa_continue_in_the_car">Продолжить в авто</string>
+	<!-- Ask user to grant location permissions -->
+	<string name="aa_location_permissions_request">Этому приложению необходим доступ к вашему местоположению для навигации.</string>
+	<!-- Displayed on the Android Auto screen. Grant Permissions button. Must be no more than 18 symbols! -->
+	<string name="aa_grant_permissions">Разрешить</string>
 
 	<!-- SECTION: Types -->
 	<string name="type.addr_interpolation">Адрес/Блок</string>

--- a/android/app/src/main/res/values/strings.xml
+++ b/android/app/src/main/res/values/strings.xml
@@ -776,6 +776,20 @@
 	<string name="comma_separated_pair">%1$s, %2$s</string>
 	<!-- Tip #00 -->
 	<string name="app_tip_00">Thank you for using our community-built maps!</string>
+	<!-- Text on the Android Auto placeholder screen that maps are displayed on the phone screen -->
+	<string name="aa_used_on_the_phone_screen">You are now using Organic Maps on the phone screen</string>
+	<!-- Text on the phone placeholder screen that maps are displayed on the car screen -->
+	<string name="aa_used_on_the_car_screen">You are now using Organic Maps on the car screen</string>
+	<!-- Displayed on the phone screen. Android Auto connected -->
+	<string name="aa_connected_title">You are connected to Android Auto</string>
+	<!-- Displayed on the phone screen. Button to display maps on the phone screen instead of a car -->
+	<string name="aa_continue_on_the_phone">Continue on the phone</string>
+	<!-- Displayed on the Android Auto screen. Button to display maps on the car screen instead of a phone. Must be no more than 18 symbols! -->
+	<string name="aa_continue_in_the_car">To the car screen</string>
+	<!-- Ask user to grant location permissions -->
+	<string name="aa_location_permissions_request">This application requires access to your location for navigation purposes.</string>
+	<!-- Displayed on the Android Auto screen. Grant Permissions button. Must be no more than 18 symbols! -->
+	<string name="aa_grant_permissions">Grant Permissions</string>
 
 	<!-- SECTION: Types -->
 	<string name="type.addr_interpolation">Address/Block</string>

--- a/android/app/src/main/res/xml/automotive_app_desc.xml
+++ b/android/app/src/main/res/xml/automotive_app_desc.xml
@@ -1,0 +1,4 @@
+<?xml version="1.0" encoding="utf-8"?>
+<automotiveApp>
+  <uses name="template" />
+</automotiveApp>

--- a/data/strings/strings.txt
+++ b/data/strings/strings.txt
@@ -26894,3 +26894,52 @@
     vi = Cảm ơn bạn đã sử dụng bản đồ do cộng đồng xây dựng của chúng tôi!
     zh-Hans = 感谢您使用我们的社区地图！
     zh-Hant = 感謝您使用我們社區構建的地圖！
+
+  [aa_used_on_the_phone_screen]
+    comment = Text on the Android Auto placeholder screen that maps are displayed on the phone screen
+    tags = android
+    en = You are now using Organic Maps on the phone screen
+    fr = Vous utilisez maintenant Organic Maps sur l’écran du téléphone
+    ru = Сейчас Вы используете Organic Maps на экране телефона
+
+  [aa_used_on_the_car_screen]
+    comment = Text on the phone placeholder screen that maps are displayed on the car screen
+    tags = android
+    en = You are now using Organic Maps on the car screen
+    fr = Vous utilisez maintenant Organic Maps sur l'écran de la voiture
+    ru = Сейчас Вы используете Organic Maps на экране автомобиля
+
+  [aa_connected_title]
+    comment = Displayed on the phone screen. Android Auto connected
+    tags = android
+    en = You are connected to Android Auto
+    fr = Vous êtes connecté à Android Auto
+    ru = Вы подключены к Android Auto
+
+  [aa_continue_on_the_phone]
+    comment = Displayed on the phone screen. Button to display maps on the phone screen instead of a car
+    tags = android
+    en = Continue on the phone
+    fr = Aller sur le téléphone
+    ru = Продолжить в телефоне
+
+  [aa_continue_in_the_car]
+    comment = Displayed on the Android Auto screen. Button to display maps on the car screen instead of a phone. Must be no more than 18 symbols!
+    tags = android
+    en = To the car screen
+    fr = Afficher dans la voiture
+    ru = Продолжить в авто
+
+  [aa_location_permissions_request]
+    comment = Ask user to grant location permissions
+    tags = android
+    en = This application requires access to your location for navigation purposes.
+    fr = L'application a besoin de l'accès à la localisation pour la navigation.
+    ru = Этому приложению необходим доступ к вашему местоположению для навигации.
+
+  [aa_grant_permissions]
+    comment = Displayed on the Android Auto screen. Grant Permissions button. Must be no more than 18 symbols!
+    tags = android
+    en = Grant Permissions
+    fr = Accorder l'accès
+    ru = Разрешить

--- a/drape/stipple_pen_resource.cpp
+++ b/drape/stipple_pen_resource.cpp
@@ -186,8 +186,9 @@ void StipplePenIndex::UploadResources(ref_ptr<dp::GraphicsContext> context, ref_
 
   // Assume that all patterns are initialized when creating texture (ReserveResource) and uploaded once.
   // Should provide additional logic like in ColorPalette::UploadResources, if we want multiple uploads.
-  if (m_uploadCalled)
-    LOG(LERROR, ("Multiple stipple pen texture uploads are not supported"));
+  // TODO: https://github.com/organicmaps/organicmaps/issues/4539
+  //  if (m_uploadCalled)
+  //    LOG(LERROR, ("Multiple stipple pen texture uploads are not supported"));
   m_uploadCalled = true;
 
   uint32_t height = 0;

--- a/drape_frontend/drape_engine.cpp
+++ b/drape_frontend/drape_engine.cpp
@@ -192,6 +192,11 @@ void DrapeEngine::Move(double factorX, double factorY, bool isAnim)
   AddUserEvent(make_unique_dp<MoveEvent>(factorX, factorY, isAnim));
 }
 
+void DrapeEngine::Scroll(double distanceX, double distanceY)
+{
+  AddUserEvent(make_unique_dp<ScrollEvent>(distanceX, distanceY));
+}
+
 void DrapeEngine::Rotate(double azimuth, bool isAnim)
 {
   AddUserEvent(make_unique_dp<RotateEvent>(azimuth, isAnim, nullptr /* parallelAnimCreator */));

--- a/drape_frontend/drape_engine.hpp
+++ b/drape_frontend/drape_engine.hpp
@@ -122,6 +122,7 @@ public:
   void AddTouchEvent(TouchEvent const & event);
   void Scale(double factor, m2::PointD const & pxPoint, bool isAnim);
   void Move(double factorX, double factorY, bool isAnim);
+  void Scroll(double distanceX, double distanceY);
   void Rotate(double azimuth, bool isAnim);
 
   void ScaleAndSetCenter(m2::PointD const & centerPt, double scaleFactor, bool isAnim,

--- a/drape_frontend/drape_frontend_tests/user_event_stream_tests.cpp
+++ b/drape_frontend/drape_frontend_tests/user_event_stream_tests.cpp
@@ -31,6 +31,7 @@ public:
   void OnDragStarted() override {}
   void OnDragEnded(m2::PointD const & /* distance */) override {}
   void OnRotated() override {}
+  void OnScrolled(m2::PointD const & distance) override {}
 
   void OnScaleStarted() override {}
   void CorrectScalePoint(m2::PointD & pt) const override {}

--- a/drape_frontend/frontend_renderer.cpp
+++ b/drape_frontend/frontend_renderer.cpp
@@ -2069,6 +2069,11 @@ void FrontendRenderer::OnRotated()
   m_myPositionController->Rotated();
 }
 
+void FrontendRenderer::OnScrolled(m2::PointD const & distance)
+{
+  m_myPositionController->Scrolled(distance);
+}
+
 void FrontendRenderer::CorrectScalePoint(m2::PointD & pt) const
 {
   m_myPositionController->CorrectScalePoint(pt);

--- a/drape_frontend/frontend_renderer.hpp
+++ b/drape_frontend/frontend_renderer.hpp
@@ -227,6 +227,7 @@ private:
 
   void OnScaleStarted() override;
   void OnRotated() override;
+  void OnScrolled(m2::PointD const & distance) override;
   void CorrectScalePoint(m2::PointD & pt) const override;
   void CorrectScalePoint(m2::PointD & pt1, m2::PointD & pt2) const override;
   void CorrectGlobalScalePoint(m2::PointD & pt) const override;

--- a/drape_frontend/gui/layer_render.cpp
+++ b/drape_frontend/gui/layer_render.cpp
@@ -158,8 +158,8 @@ class ScaleFpsLabelHandle : public MutableLabelHandle
 {
   using TBase = MutableLabelHandle;
 public:
-  ScaleFpsLabelHandle(uint32_t id, ref_ptr<dp::TextureManager> textures, std::string const & apiLabel)
-    : TBase(id, dp::LeftBottom, m2::PointF::Zero(), textures)
+  ScaleFpsLabelHandle(uint32_t id, ref_ptr<dp::TextureManager> textures, std::string const & apiLabel, Position const & position)
+    : TBase(id, position.m_anchor, position.m_pixelPivot, textures)
     , m_apiLabel(apiLabel)
   {
     SetIsVisible(true);
@@ -183,10 +183,6 @@ public:
       SetContent(ss.str());
     }
 
-    auto const vs = static_cast<float>(df::VisualParams::Instance().GetVisualScale());
-    m2::PointF offset(10.0f * vs, 30.0f * vs);
-
-    SetPivot(glsl::ToVec2(m2::PointF(screen.PixelRect().LeftBottom()) + offset));
     return TBase::Update(screen);
   }
 
@@ -380,7 +376,7 @@ m2::PointF LayerCacher::CacheScaleFpsLabel(ref_ptr<dp::GraphicsContext> context,
   params.m_font = DrapeGui::GetGuiTextFont();
   params.m_pivot = position.m_pixelPivot;
   auto const apiVersion = context->GetApiVersion();
-  params.m_handleCreator = [textures, apiVersion](dp::Anchor, m2::PointF const &)
+  params.m_handleCreator = [textures, apiVersion, &position](dp::Anchor, m2::PointF const &)
   {
     std::string apiLabel;
     switch (apiVersion)
@@ -391,7 +387,7 @@ m2::PointF LayerCacher::CacheScaleFpsLabel(ref_ptr<dp::GraphicsContext> context,
     case dp::ApiVersion::Vulkan: apiLabel = "V"; break;
     case dp::ApiVersion::Invalid: CHECK(false, ("Invalid API version.")); break;
     }
-    return make_unique_dp<ScaleFpsLabelHandle>(EGuiHandle::GuiHandleScaleLabel, textures, apiLabel);
+    return make_unique_dp<ScaleFpsLabelHandle>(EGuiHandle::GuiHandleScaleLabel, textures, apiLabel, position);
   };
 
   drape_ptr<ShapeRenderer> scaleRenderer = make_unique_dp<ShapeRenderer>();

--- a/drape_frontend/my_position_controller.cpp
+++ b/drape_frontend/my_position_controller.cpp
@@ -274,6 +274,20 @@ void MyPositionController::Rotated()
     m_wasRotationInScaling = true;
 }
 
+void MyPositionController::Scrolled(m2::PointD const & distance)
+{
+  if (m_mode == location::PendingPosition)
+  {
+    ChangeMode(location::NotFollowNoPosition);
+    return;
+  }
+
+  if (distance.Length() > 0)
+    StopLocationFollow();
+
+  UpdateViewport(kDoNotChangeZoom);
+}
+
 void MyPositionController::ResetRoutingNotFollowTimer(bool blockTimer)
 {
   if (m_isInRouting)

--- a/drape_frontend/my_position_controller.hpp
+++ b/drape_frontend/my_position_controller.hpp
@@ -94,6 +94,8 @@ public:
 
   void Rotated();
 
+  void Scrolled(m2::PointD const & distance);
+
   void ResetRoutingNotFollowTimer(bool blockTimer = false);
   void ResetBlockAutoZoomTimer();
 

--- a/drape_frontend/user_event_stream.cpp
+++ b/drape_frontend/user_event_stream.cpp
@@ -251,6 +251,13 @@ ScreenBase const & UserEventStream::ProcessEvents(bool & modelViewChanged, bool 
         breakAnim = OnNewVisibleViewport(viewportEvent);
       }
       break;
+    case UserEvent::EventType::Scroll:
+      {
+        ref_ptr<ScrollEvent> scrollEvent = make_ref(e);
+        breakAnim = OnScroll(scrollEvent);
+        TouchCancel(m_touches);
+      }
+      break;
 
     default:
       ASSERT(false, ());
@@ -455,6 +462,23 @@ bool UserEventStream::OnNewVisibleViewport(ref_ptr<SetVisibleViewportEvent> view
     return SetScreen(screen, true /* isAnim */);
   }
   return false;
+}
+
+bool UserEventStream::OnScroll(ref_ptr<ScrollEvent> scrollEvent)
+{
+  double const distanceX = scrollEvent->GetDistanceX();
+  double const distanceY = scrollEvent->GetDistanceY();
+
+  ScreenBase screen;
+  GetTargetScreen(screen);
+  screen.Move(-distanceX, -distanceY);
+
+  ShrinkAndScaleInto(screen, df::GetWorldRect());
+
+  if (m_listener)
+    m_listener->OnScrolled({-distanceX, -distanceY});
+
+  return SetScreen(screen, false);
 }
 
 bool UserEventStream::SetAngle(double azimuth, bool isAnim, TAnimationCreator const & parallelAnimCreator)

--- a/drape_frontend/user_event_stream.hpp
+++ b/drape_frontend/user_event_stream.hpp
@@ -41,7 +41,8 @@ public:
     FollowAndRotate,
     AutoPerspective,
     VisibleViewport,
-    Move
+    Move,
+    Scroll
   };
 
   virtual ~UserEvent() = default;
@@ -377,6 +378,24 @@ private:
   m2::RectD m_rect;
 };
 
+class ScrollEvent : public UserEvent
+{
+public:
+    ScrollEvent(double distanceX, double distanceY)
+              : m_distanceX(distanceX)
+              , m_distanceY(distanceY)
+    {}
+
+    EventType GetType() const override { return UserEvent::EventType::Scroll; }
+
+    double GetDistanceX() const { return m_distanceX; }
+    double GetDistanceY() const { return m_distanceY; }
+
+private:
+    double m_distanceX;
+    double m_distanceY;
+};
+
 class UserEventStream
 {
 public:
@@ -395,6 +414,7 @@ public:
 
     virtual void OnScaleStarted() = 0;
     virtual void OnRotated() = 0;
+    virtual void OnScrolled(m2::PointD const & distance) = 0;
     virtual void CorrectScalePoint(m2::PointD & pt) const = 0;
     virtual void CorrectGlobalScalePoint(m2::PointD & pt) const = 0;
     virtual void CorrectScalePoint(m2::PointD & pt1, m2::PointD & pt2) const = 0;
@@ -455,6 +475,7 @@ private:
   bool OnSetCenter(ref_ptr<SetCenterEvent> centerEvent);
   bool OnRotate(ref_ptr<RotateEvent> rotateEvent);
   bool OnNewVisibleViewport(ref_ptr<SetVisibleViewportEvent> viewportEvent);
+  bool OnScroll(ref_ptr<ScrollEvent> scrollEvent);
 
   bool SetAngle(double azimuth, bool isAnim, TAnimationCreator const & parallelAnimCreator = nullptr);
   bool SetRect(m2::RectD rect, int zoom, bool applyRotation, bool isAnim,

--- a/iphone/Maps/Classes/Widgets/MWMMapWidgets.mm
+++ b/iphone/Maps/Classes/Widgets/MWMMapWidgets.mm
@@ -27,7 +27,7 @@
   m_skin->Resize(p.m_surfaceWidth, p.m_surfaceHeight);
   m_skin->ForEach(
       [&p](gui::EWidget widget, gui::Position const & pos) { p.m_widgetsInitInfo[widget] = pos; });
-  p.m_widgetsInitInfo[gui::WIDGET_SCALE_FPS_LABEL] = gui::Position(dp::LeftBottom);
+  p.m_widgetsInitInfo[gui::WIDGET_SCALE_FPS_LABEL] = gui::Position(m2::PointF(self.visualScale * 10, self.visualScale * 45), dp::LeftTop);
 }
 
 - (void)resize:(CGSize)size

--- a/map/framework.cpp
+++ b/map/framework.cpp
@@ -1079,6 +1079,12 @@ void Framework::Move(double factorX, double factorY, bool isAnim)
     m_drapeEngine->Move(factorX, factorY, isAnim);
 }
 
+void Framework::Scroll(double distanceX, double distanceY)
+{
+  if (m_drapeEngine != nullptr)
+    m_drapeEngine->Scroll(distanceX, distanceY);
+}
+
 void Framework::Rotate(double azimuth, bool isAnim)
 {
   if (m_drapeEngine != nullptr)

--- a/map/framework.hpp
+++ b/map/framework.hpp
@@ -536,6 +536,8 @@ public:
   /// factorY = 1.5 moves the map one and a half size up.
   void Move(double factorX, double factorY, bool isAnim);
 
+  void Scroll(double distanceX, double distanceY);
+
   void Rotate(double azimuth, bool isAnim);
 
   void TouchEvent(df::TouchEvent const & touch);


### PR DESCRIPTION
Fixed compass widget displaying after switching from AA
Adjusted FPS widget offset for AA and device
Adjusted Ruler widget offsets for both device and AA from `10dp` to `16dp`

| AA | AA |
|--------|--------|
| <img width="399" alt="image" src="https://github.com/organicmaps/organicmaps/assets/10351358/a5f443d8-adb6-4795-abea-59012752f558"> | <img width="566" alt="image" src="https://github.com/organicmaps/organicmaps/assets/10351358/9bf14749-7d94-4b87-902c-cee5980f5c27"> | 

| Before | After |
|--------|--------|
| <img width="200" alt="image" src="https://github.com/organicmaps/organicmaps/assets/10351358/737be337-c0ad-4f2e-9397-2797aa245b47"> | <img width="200" alt="image" src="https://github.com/organicmaps/organicmaps/assets/10351358/931c1029-818f-4667-88a7-a12d618b9b37"> |
| <img width="200" alt="image" src="https://github.com/organicmaps/organicmaps/assets/10351358/021ae88a-a6a6-4884-9bfa-6651001fe4e6"> | <img width="200" alt="image" src="https://github.com/organicmaps/organicmaps/assets/10351358/29d83c78-3386-46a8-bcb2-a766f4215537"> | 

| Before | After |
|--------|--------|
| <img width="300" alt="image" src="https://github.com/organicmaps/organicmaps/assets/10351358/68be9c8e-9c43-43be-8123-3ae71464f38a"> | <img width="300" alt="image" src="https://github.com/organicmaps/organicmaps/assets/10351358/ffe51610-bcf2-471a-ab39-aab659d9b57a"> |
| | <img width="300" alt="image" src="https://github.com/organicmaps/organicmaps/assets/10351358/e69c27d7-1259-40ae-9c56-f367f0bb3f73"> |

> [!NOTE]
> * The FPS widget on the device was adjusted because in 90% of the time, the data is not visible due to the status bar.
> * The Ruler widget was adjusted because the Android Auto screen has rounded corners that cut off the widget. I assume something similar may also happen on the device.