### PR TITLE
[android-auto] Widgets fix

### DIFF
--- a/android/app/src/main/java/app/organicmaps/Map.java
+++ b/android/app/src/main/java/app/organicmaps/Map.java
@@ -325,10 +325,16 @@ public final class Map
 
     nativeCleanWidgets();
     updateBottomWidgetsOffset(context, mBottomWidgetOffsetX, mBottomWidgetOffsetY);
-    nativeSetupWidget(WIDGET_SCALE_FPS_LABEL, UiUtils.dimen(context, R.dimen.margin_base), UiUtils.dimen(context, R.dimen.margin_base), ANCHOR_LEFT_TOP);
-    // Don't show compass on car display
     if (mDisplayType == DisplayType.Device)
+    {
+      nativeSetupWidget(WIDGET_SCALE_FPS_LABEL, UiUtils.dimen(context, R.dimen.margin_base), UiUtils.dimen(context, R.dimen.margin_base) * 2, ANCHOR_LEFT_TOP);
       updateCompassOffset(context, mCurrentCompassOffsetX, mCurrentCompassOffsetY, false);
+    }
+    else
+    {
+      nativeSetupWidget(WIDGET_SCALE_FPS_LABEL, UiUtils.dimen(context, R.dimen.margin_base), mHeight - UiUtils.dimen(context, R.dimen.margin_base) * 5, ANCHOR_LEFT_TOP);
+      updateCompassOffset(context, mWidth, mCurrentCompassOffsetY, true);
+    }
   }
 
   private void updateRulerOffset(final Context context, int offsetX, int offsetY)
@@ -361,31 +367,48 @@ public final class Map
                                                    boolean firstLaunch,
                                                    boolean isLaunchByDeepLink,
                                                    int appVersionCode);
+
   private static native boolean nativeIsEngineCreated();
+
   private static native void nativeUpdateEngineDpi(int dpi);
+
   private static native void nativeSetRenderingInitializationFinishedListener(
       @Nullable MapRenderingListener listener);
+
   private static native boolean nativeShowMapForUrl(String url);
 
   // Surface
   private static native boolean nativeAttachSurface(Surface surface);
+
   private static native void nativeDetachSurface(boolean destroySurface);
+
   private static native void nativeSurfaceChanged(Surface surface, int w, int h);
+
   private static native boolean nativeDestroySurfaceOnDetach();
+
   private static native void nativePauseSurfaceRendering();
+
   private static native void nativeResumeSurfaceRendering();
 
   // Widgets
   private static native void nativeApplyWidgets();
+
   private static native void nativeCleanWidgets();
+
   private static native void nativeUpdateMyPositionRoutingOffset(int offsetY);
+
   private static native void nativeSetupWidget(int widget, float x, float y, int anchor);
+
   private static native void nativeCompassUpdated(double north, boolean forceRedraw);
 
   // Events
   private static native void nativeScalePlus();
+
   private static native void nativeScaleMinus();
+
   private static native void nativeOnScroll(double distanceX, double distanceY);
+
   private static native void nativeOnScale(double factor, double focusX, double focusY, boolean isAnim);
+
   private static native void nativeOnTouch(int actionType, int id1, float x1, float y1, int id2, float x2, float y2, int maskedPointer);
 }

--- a/android/app/src/main/java/app/organicmaps/car/SurfaceRenderer.java
+++ b/android/app/src/main/java/app/organicmaps/car/SurfaceRenderer.java
@@ -64,6 +64,7 @@ public class SurfaceRenderer implements DefaultLifecycleObserver, SurfaceCallbac
         new Rect(0, 0, surfaceContainer.getWidth(), surfaceContainer.getHeight()),
         surfaceContainer.getDpi()
     );
+    mMap.updateBottomWidgetsOffset(mCarContext, -1, -1);
   }
 
   @Override

--- a/drape_frontend/gui/layer_render.cpp
+++ b/drape_frontend/gui/layer_render.cpp
@@ -158,8 +158,8 @@ class ScaleFpsLabelHandle : public MutableLabelHandle
 {
   using TBase = MutableLabelHandle;
 public:
-  ScaleFpsLabelHandle(uint32_t id, ref_ptr<dp::TextureManager> textures, std::string const & apiLabel)
-    : TBase(id, dp::LeftBottom, m2::PointF::Zero(), textures)
+  ScaleFpsLabelHandle(uint32_t id, ref_ptr<dp::TextureManager> textures, std::string const & apiLabel, Position const & position)
+    : TBase(id, position.m_anchor, position.m_pixelPivot, textures)
     , m_apiLabel(apiLabel)
   {
     SetIsVisible(true);
@@ -183,14 +183,6 @@ public:
       SetContent(ss.str());
     }
 
-    auto const vs = static_cast<float>(df::VisualParams::Instance().GetVisualScale());
-    m2::PointF offset(10.0f * vs, 30.0f * vs);
-#ifdef OMIM_OS_IPHONE
-    // Move below dynamic island.
-    offset.y += 30.0f * vs;
-#endif
-
-    SetPivot(glsl::ToVec2(m2::PointF(screen.PixelRect().LeftBottom()) + offset));
     return TBase::Update(screen);
   }
 
@@ -384,7 +376,7 @@ m2::PointF LayerCacher::CacheScaleFpsLabel(ref_ptr<dp::GraphicsContext> context,
   params.m_font = DrapeGui::GetGuiTextFont();
   params.m_pivot = position.m_pixelPivot;
   auto const apiVersion = context->GetApiVersion();
-  params.m_handleCreator = [textures, apiVersion](dp::Anchor, m2::PointF const &)
+  params.m_handleCreator = [textures, apiVersion, &position](dp::Anchor, m2::PointF const &)
   {
     std::string apiLabel;
     switch (apiVersion)
@@ -395,7 +387,7 @@ m2::PointF LayerCacher::CacheScaleFpsLabel(ref_ptr<dp::GraphicsContext> context,
     case dp::ApiVersion::Vulkan: apiLabel = "V"; break;
     case dp::ApiVersion::Invalid: CHECK(false, ("Invalid API version.")); break;
     }
-    return make_unique_dp<ScaleFpsLabelHandle>(EGuiHandle::GuiHandleScaleLabel, textures, apiLabel);
+    return make_unique_dp<ScaleFpsLabelHandle>(EGuiHandle::GuiHandleScaleLabel, textures, apiLabel, position);
   };
 
   drape_ptr<ShapeRenderer> scaleRenderer = make_unique_dp<ShapeRenderer>();

--- a/iphone/Maps/Classes/Widgets/MWMMapWidgets.mm
+++ b/iphone/Maps/Classes/Widgets/MWMMapWidgets.mm
@@ -27,7 +27,7 @@
   m_skin->Resize(p.m_surfaceWidth, p.m_surfaceHeight);
   m_skin->ForEach(
       [&p](gui::EWidget widget, gui::Position const & pos) { p.m_widgetsInitInfo[widget] = pos; });
-  p.m_widgetsInitInfo[gui::WIDGET_SCALE_FPS_LABEL] = gui::Position(dp::LeftBottom);
+  p.m_widgetsInitInfo[gui::WIDGET_SCALE_FPS_LABEL] = gui::Position(m2::PointF(self.visualScale * 10, self.visualScale * 45), dp::LeftTop);
 }
 
 - (void)resize:(CGSize)size

--- a/qt/qt_common/map_widget.cpp
+++ b/qt/qt_common/map_widget.cpp
@@ -103,7 +103,7 @@ void MapWidget::CreateEngine()
   m_skin->ForEach(
       [&p](gui::EWidget widget, gui::Position const & pos) { p.m_widgetsInitInfo[widget] = pos; });
 
-  p.m_widgetsInitInfo[gui::WIDGET_SCALE_FPS_LABEL] = gui::Position(dp::LeftBottom);
+  p.m_widgetsInitInfo[gui::WIDGET_SCALE_FPS_LABEL] = gui::Position(dp::LeftTop);
 
   m_framework.CreateDrapeEngine(make_ref(m_contextFactory), std::move(p));
   m_framework.SetViewportListener(std::bind(&MapWidget::OnViewportChanged, this, std::placeholders::_1));


### PR DESCRIPTION
Fixed compass widget displaying after switching from AA
Adjusted FPS widget offset for AA and device

| AA | AA |
|--------|--------|
| <img width="399" alt="image" src="https://github.com/organicmaps/organicmaps/assets/10351358/a5f443d8-adb6-4795-abea-59012752f558"> | <img width="566" alt="image" src="https://github.com/organicmaps/organicmaps/assets/10351358/9bf14749-7d94-4b87-902c-cee5980f5c27"> | 

| Before | After |
|--------|--------|
| <img width="200" alt="image" src="https://github.com/organicmaps/organicmaps/assets/10351358/737be337-c0ad-4f2e-9397-2797aa245b47"> | <img width="200" alt="image" src="https://github.com/organicmaps/organicmaps/assets/10351358/931c1029-818f-4667-88a7-a12d618b9b37"> |

| Before | After |
|--------|--------|
| <img width="300" alt="image" src="https://github.com/organicmaps/organicmaps/assets/10351358/68be9c8e-9c43-43be-8123-3ae71464f38a"> | <img width="300" alt="image" src="https://github.com/organicmaps/organicmaps/assets/10351358/ffe51610-bcf2-471a-ab39-aab659d9b57a"> |
| | <img width="300" alt="image" src="https://github.com/organicmaps/organicmaps/assets/10351358/e69c27d7-1259-40ae-9c56-f367f0bb3f73"> |

> [!NOTE]
> * The FPS widget on the device was adjusted because in 90% of the time, the data is not visible due to the status bar.