### PR TITLE
[android] Reworked descriptions in the editor

### DIFF
--- a/android/app/src/main/java/app/organicmaps/editor/EditorFragment.java
+++ b/android/app/src/main/java/app/organicmaps/editor/EditorFragment.java
@@ -4,6 +4,7 @@ import android.content.Context;
 import android.os.Bundle;
 import android.text.InputType;
 import android.text.TextUtils;
+import android.text.method.LinkMovementMethod;
 import android.view.LayoutInflater;
 import android.view.View;
 import android.view.ViewGroup;
@@ -476,7 +477,8 @@ public class EditorFragment extends BaseMwmFragment implements View.OnClickListe
     mOpeningHours.setOnClickListener(this);
     final View cardMore = view.findViewById(R.id.cv__more);
     mDescription = findInput(cardMore);
-    cardMore.findViewById(R.id.about_osm).setOnClickListener(this);
+    TextView osmInfo = view.findViewById(R.id.osm_info);
+    osmInfo.setMovementMethod(LinkMovementMethod.getInstance());
     mReset = view.findViewById(R.id.reset);
     mReset.setOnClickListener(this);
 
@@ -540,8 +542,6 @@ public class EditorFragment extends BaseMwmFragment implements View.OnClickListe
     }
     else if (id == R.id.add_langs)
       mParent.addLanguage();
-    else if (id == R.id.about_osm)
-      Utils.openUrl(requireActivity(), getString(R.string.osm_wiki_about_url));
     else if (id == R.id.reset)
       reset();
     else if (id == R.id.block_outdoor_seating)

--- a/android/app/src/main/res/layout/fragment_editor.xml
+++ b/android/app/src/main/res/layout/fragment_editor.xml
@@ -13,6 +13,14 @@
     android:layout_height="wrap_content"
     android:layout_margin="@dimen/margin_half"
     android:orientation="vertical">
+    <TextView
+        android:id="@+id/osm_info"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:textAlignment="center"
+        android:layout_marginBottom="@dimen/margin_base"
+        android:text="@string/editor_about_osm"
+        android:textAppearance="@style/MwmTextAppearance.Body4"/>
     <androidx.cardview.widget.CardView
       android:id="@+id/cv__category"
       style="@style/MwmWidget.Editor.CardView">
@@ -330,38 +338,23 @@
         android:padding="@dimen/margin_base">
         <TextView
           android:layout_width="match_parent"
-          android:layout_height="32dp"
+          android:layout_height="wrap_content"
+          android:fontFamily="@string/robotoMedium"
           android:text="@string/editor_other_info"
-          android:textAppearance="@style/MwmTextAppearance.Body2"/>
+          android:textAppearance="@style/MwmTextAppearance.Body3"/>
         <com.google.android.material.textfield.TextInputLayout
           android:id="@+id/custom_input"
           style="@style/MwmWidget.Editor.CustomTextInput"
           android:gravity="center_vertical"
           android:minHeight="74dp"
-          android:textColorHint="?android:textColorSecondary">
+          android:textColorHint="?android:textColorSecondary"
+          app:hintEnabled="false">
           <com.google.android.material.textfield.TextInputEditText
             android:id="@+id/input"
             style="@style/MwmWidget.Editor.FieldLayout.EditText"
             android:inputType="textMultiLine"
-            android:hint="@string/editor_detailed_description_hint"/>
+            android:hint="@string/editor_note_hint"/>
         </com.google.android.material.textfield.TextInputLayout>
-        <TextView
-          android:layout_width="match_parent"
-          android:layout_height="wrap_content"
-          android:layout_marginTop="@dimen/margin_half"
-          android:text="@string/editor_detailed_description"
-          android:textAppearance="@style/MwmTextAppearance.Body4"/>
-        <TextView
-          android:id="@+id/about_osm"
-          android:layout_width="match_parent"
-          android:layout_height="wrap_content"
-          android:background="?clickableBackground"
-          android:paddingBottom="@dimen/margin_half"
-          android:paddingTop="@dimen/margin_half"
-          android:text="@string/editor_more_about_osm"
-          android:textAppearance="@style/MwmTextAppearance.Body4"
-          android:textColor="?colorAccent"
-          android:textSize="@dimen/text_size_body_4"/>
       </LinearLayout>
     </androidx.cardview.widget.CardView>
     <androidx.cardview.widget.CardView

--- a/android/app/src/main/res/values-ar/strings.xml
+++ b/android/app/src/main/res/values-ar/strings.xml
@@ -515,9 +515,12 @@
 	<string name="error_enter_correct_zip_code">أدخل الرمز البريدي صالح</string>
 	<!-- Place Page title for long tap -->
 	<string name="core_placepage_unknown_place">مكان غير معروف</string>
-	<string name="editor_other_info">ارسل ملاحظة إلى محرري خريطة الشارع المفتوحة</string>
-	<string name="editor_detailed_description_hint">تعليق مفصّل</string>
-	<string name="editor_detailed_description">سيتم إرسال التغييرات التي اقترحتها إلى مجتمع خريطة الشارع المفتوحة. اذكر التفاصيل التي لا يمكن تحريرها في Organic Maps</string>
+	<!-- Title for OSM note section in the editor -->
+	<string name="editor_other_info">ملاحظة لمتطوعي OpenStreetMap (اختياري)</string>
+	<!-- Hint of the input field in the OSM note section of the editor -->
+	<string name="editor_note_hint">وصف الأخطاء على الخريطة أو الأشياء التي لا يمكن تحريرها باستخدام الخرائط العضوية</string>
+	<!-- Information about OSM at the top of the editing page -->
+	<string name="editor_about_osm">يتم تحميل تعديلاتك على قاعدة البيانات العامة <a href="https://wiki.openstreetmap.org/wiki/Ar:About_OpenStreetMap">OpenStreetMap</a>. يرجى عدم إضافة معلومات شخصية أو محمية بحقوق الطبع والنشر.</string>
 	<string name="editor_more_about_osm">المزيد عن خريطة الشارع المفتوحة</string>
 	<string name="editor_operator">المالك</string>
 	<!-- To indicate the operator of ATMs, bicycle rentals, electric vehicle charging stations... -->

--- a/android/app/src/main/res/values-az/strings.xml
+++ b/android/app/src/main/res/values-az/strings.xml
@@ -502,9 +502,12 @@
 	<string name="error_enter_correct_zip_code">Etibarlı poçt kodu daxil edin</string>
 	<!-- Place Page title for long tap -->
 	<string name="core_placepage_unknown_place">Naməlum yer</string>
-	<string name="editor_other_info">OSM redaktorlarına qeyd göndərin</string>
-	<string name="editor_detailed_description_hint">Ətraflı şərh</string>
-	<string name="editor_detailed_description">Təklif etdiyiniz dəyişikliklər OpenStreetMap icmasına yerləşdiriləcək. Zəhmət olmasa Organic Maps\'da redaktə edilə bilməyən əlavə detalları izah edin.</string>
+	<!-- Title for OSM note section in the editor -->
+	<string name="editor_other_info">OpenStreetMap könüllüləri üçün qeyd (isteğe bağlı)</string>
+	<!-- Hint of the input field in the OSM note section of the editor -->
+	<string name="editor_note_hint">Xəritədəki səhvləri və ya Üzvi Xəritələrdən istifadə edərək redaktə edilə bilməyənləri təsvir edin</string>
+	<!-- Information about OSM at the top of the editing page -->
+	<string name="editor_about_osm">Redaktələriniz ictimai <a href="https://wiki.openstreetmap.org/wiki/Tr:About">OpenStreetMap</a> verilənlər bazasına yüklənir. Zəhmət olmasa şəxsi və ya müəllif hüquqları ilə qorunan məlumatları əlavə etməyin.</string>
 	<string name="editor_more_about_osm">OpenStreetMap haqqında əlavə məlumat</string>
 	<string name="editor_operator">Sahibi</string>
 	<!-- To indicate the operator of ATMs, bicycle rentals, electric vehicle charging stations... -->

--- a/android/app/src/main/res/values-be/strings.xml
+++ b/android/app/src/main/res/values-be/strings.xml
@@ -500,9 +500,12 @@
 	<string name="error_enter_correct_zip_code">Увядзіце правільны паштовы індэкс</string>
 	<!-- Place Page title for long tap -->
 	<string name="core_placepage_unknown_place">Невядомае месца</string>
-	<string name="editor_other_info">Адправіць нататку рэдактарам OSM</string>
-	<string name="editor_detailed_description_hint">Падрабязны каментарый</string>
-	<string name="editor_detailed_description">Прапанаваныя вамі змены будуць дасланы суполцы OpenStreetMap. Апішыце любыя дадатковыя дэталі, якія нельга рэдагаваць у Organic Maps.</string>
+	<!-- Title for OSM note section in the editor -->
+	<string name="editor_other_info">Заўвага для валанцёраў OpenStreetMap (неабавязкова)</string>
+	<!-- Hint of the input field in the OSM note section of the editor -->
+	<string name="editor_note_hint">Апішыце памылкі на карце ці тое, што нельга рэдагаваць з дапамогай Organic Maps</string>
+	<!-- Information about OSM at the top of the editing page -->
+	<string name="editor_about_osm">Вашы праўкі загружаюцца ў публічную базу дадзеных <a href="https://wiki.openstreetmap.org/wiki/About_OpenStreetMap">OpenStreetMap</a>. Калі ласка, не дадавайце асабістую інфармацыю або інфармацыю, абароненую аўтарскім правам.</string>
 	<string name="editor_more_about_osm">Падрабязней пра OpenStreetMap</string>
 	<string name="editor_operator">Уладальнік</string>
 	<!-- To indicate the operator of ATMs, bicycle rentals, electric vehicle charging stations... -->

--- a/android/app/src/main/res/values-bg/strings.xml
+++ b/android/app/src/main/res/values-bg/strings.xml
@@ -468,9 +468,12 @@
 	<string name="error_enter_correct_zip_code">Въведете валиден пощенски код</string>
 	<!-- Place Page title for long tap -->
 	<string name="core_placepage_unknown_place">Неизвестно място</string>
-	<string name="editor_other_info">Изпращане на бележка до редакторите на OSM</string>
-	<string name="editor_detailed_description_hint">Подробен коментар</string>
-	<string name="editor_detailed_description">Предложените от вас промени по картата ще бъдат изпратени до общността на OpenStreetMap. Опишете всички допълнителни подробности, които не могат да бъдат въведени в Organic Maps.</string>
+	<!-- Title for OSM note section in the editor -->
+	<string name="editor_other_info">Забележка към доброволците на OpenStreetMap (по избор)</string>
+	<!-- Hint of the input field in the OSM note section of the editor -->
+	<string name="editor_note_hint">Описване на грешки в картата или неща, които не могат да бъдат редактирани с Organic Maps</string>
+	<!-- Information about OSM at the top of the editing page -->
+	<string name="editor_about_osm">Вашите редакции се качват в публичната база данни <a href="https://wiki.openstreetmap.org/wiki/Bg:About">OpenStreetMap</a>. Моля, не добавяйте лична информация или информация, защитена с авторски права.</string>
 	<string name="editor_more_about_osm">Повече за OpenStreetMap</string>
 	<string name="editor_operator">Собственик</string>
 	<!-- To indicate the operator of ATMs, bicycle rentals, electric vehicle charging stations... -->
@@ -685,6 +688,8 @@
 	<string name="enable_keep_screen_on_description">Когато е разрешено, екранът винаги ще бъде включен при показване на картата.</string>
 	<!-- OpenStreetMap text on splash screen -->
 	<string name="splash_subtitle">Картографски данни от OpenStreetMap</string>
+	<!-- Link to OSM wiki for Editor, Profile and About pages -->
+	<string name="osm_wiki_about_url">https://wiki.openstreetmap.org/wiki/Bg:About</string>
 	<!-- App Tip #00 -->
 	<string name="app_tip_00">Благодарим ви, че използвате нашите карти, създадени от общността!</string>
 	<!-- App tip #01 -->

--- a/android/app/src/main/res/values-ca/strings.xml
+++ b/android/app/src/main/res/values-ca/strings.xml
@@ -501,9 +501,12 @@
 	<string name="error_enter_correct_zip_code">Introduïu un codi postal vàlid</string>
 	<!-- Place Page title for long tap -->
 	<string name="core_placepage_unknown_place">Lloc desconegut</string>
-	<string name="editor_other_info">Envia una nota als editors de l’OSM</string>
-	<string name="editor_detailed_description_hint">Comentari detallat</string>
-	<string name="editor_detailed_description">Heu suggerit canvis en el mapa que s’enviaran a la comunitat de l’OpenStreetMap. Descriviu qualsevol detall addicional que no es pugui editar amb l’Organic Maps.</string>
+	<!-- Title for OSM note section in the editor -->
+	<string name="editor_other_info">Nota per als voluntaris d\'OpenStreetMap (opcional)</string>
+	<!-- Hint of the input field in the OSM note section of the editor -->
+	<string name="editor_note_hint">Descriu errors al mapa o què no es pot editar amb Mapes orgànics</string>
+	<!-- Information about OSM at the top of the editing page -->
+	<string name="editor_about_osm">Les vostres edicions es pengen a la base de dades pública <a href="https://wiki.openstreetmap.org/wiki/Ca:About">OpenStreetMap</a>. Si us plau, no afegiu informació personal o amb drets d\'autor.</string>
 	<string name="editor_more_about_osm">Més sobre l\'OpenStreetMap</string>
 	<string name="editor_operator">Propietari</string>
 	<!-- To indicate the operator of ATMs, bicycle rentals, electric vehicle charging stations... -->

--- a/android/app/src/main/res/values-cs/strings.xml
+++ b/android/app/src/main/res/values-cs/strings.xml
@@ -482,9 +482,12 @@
 	<string name="error_enter_correct_zip_code">Zadejte správné PSČ</string>
 	<!-- Place Page title for long tap -->
 	<string name="core_placepage_unknown_place">Neznámé místo</string>
-	<string name="editor_other_info">Odeslat poznámku editorům OSM</string>
-	<string name="editor_detailed_description_hint">Podrobný komentář</string>
-	<string name="editor_detailed_description">Vámi navržené změny odešleme do komunity OpenStreetMap. Popište podrobnosti, které nelze upravit v Organic Maps.</string>
+	<!-- Title for OSM note section in the editor -->
+	<string name="editor_other_info">Poznámka pro dobrovolníky OpenStreetMap (nepovinné)</string>
+	<!-- Hint of the input field in the OSM note section of the editor -->
+	<string name="editor_note_hint">Popište chyby na mapě nebo věci, které nelze upravit pomocí aplikace Organic Maps.</string>
+	<!-- Information about OSM at the top of the editing page -->
+	<string name="editor_about_osm">Vaše úpravy se nahrají do veřejné databáze <a href="https://wiki.openstreetmap.org/wiki/Cs:Co_je_OpenStreetMap">OpenStreetMap</a>. Nepřidávejte prosím osobní informace nebo informace chráněné autorskými právy.</string>
 	<string name="editor_more_about_osm">Více o projektu OpenStreetMap</string>
 	<string name="editor_operator">Operátor</string>
 	<!-- To indicate the operator of ATMs, bicycle rentals, electric vehicle charging stations... -->
@@ -734,6 +737,8 @@
 	<string name="splash_subtitle">Mapová data z OpenStreetMap</string>
 	<!-- Translated Organic Maps site, add new translations here: https://github.com/organicmaps/organicmaps.github.io/tree/master/content -->
 	<string name="translated_om_site_url">https://organicmaps.app/cs/</string>
+	<!-- Link to OSM wiki for Editor, Profile and About pages -->
+	<string name="osm_wiki_about_url">https://wiki.openstreetmap.org/wiki/Cs:Co_je_OpenStreetMap</string>
 	<!-- App Tip #00 -->
 	<string name="app_tip_00">Děkujeme, že používáte naše komunitní mapy!</string>
 	<!-- App tip #01 -->

--- a/android/app/src/main/res/values-da/strings.xml
+++ b/android/app/src/main/res/values-da/strings.xml
@@ -478,9 +478,12 @@
 	<string name="error_enter_correct_zip_code">Indtast det korrekte postnummer</string>
 	<!-- Place Page title for long tap -->
 	<string name="core_placepage_unknown_place">Ukendt sted</string>
-	<string name="editor_other_info">Send en besked til OSM-redaktører</string>
-	<string name="editor_detailed_description_hint">Detaljerede bemærkninger</string>
-	<string name="editor_detailed_description">Dine foreslåede ændringer vil blive sendt til OpenStreetMap fællesskabet. Beskrive detaljer, som ikke kan redigeres i Organic Maps.</string>
+	<!-- Title for OSM note section in the editor -->
+	<string name="editor_other_info">Note til OpenStreetMap-frivillige (valgfrit)</string>
+	<!-- Hint of the input field in the OSM note section of the editor -->
+	<string name="editor_note_hint">Beskriv fejl på kortet eller ting, der ikke kan redigeres med Organic Maps</string>
+	<!-- Information about OSM at the top of the editing page -->
+	<string name="editor_about_osm">Dine ændringer uploades til den offentlige <a href="https://wiki.openstreetmap.org/wiki/Da:Om_OpenStreetMap">OpenStreetMap</a>-database. Tilføj venligst ikke personlige eller ophavsretligt beskyttede oplysninger.</string>
 	<string name="editor_more_about_osm">Mere om OpenStreetMap</string>
 	<string name="editor_operator">Bruger</string>
 	<!-- To indicate the operator of ATMs, bicycle rentals, electric vehicle charging stations... -->

--- a/android/app/src/main/res/values-de/strings.xml
+++ b/android/app/src/main/res/values-de/strings.xml
@@ -500,9 +500,12 @@
 	<string name="error_enter_correct_zip_code">Geben Sie die korrekte Postleitzahl ein</string>
 	<!-- Place Page title for long tap -->
 	<string name="core_placepage_unknown_place">Unbekannter Ort</string>
-	<string name="editor_other_info">Notiz an Freiwillige von OpenStreetMap senden</string>
-	<string name="editor_detailed_description_hint">Ausführlicher Kommentar</string>
-	<string name="editor_detailed_description">Ihre Änderungsvorschläge für die Karte werden an OpenStreetMap gesendet: Beschreiben Sie die Details der Objekte, die Sie in Organic Maps nicht bearbeiten können.</string>
+	<!-- Title for OSM note section in the editor -->
+	<string name="editor_other_info">Hinweis an Freiwillige von OpenStreetMap (optional)</string>
+	<!-- Hint of the input field in the OSM note section of the editor -->
+	<string name="editor_note_hint">Beschreiben Sie Kartenfehler oder Dinge, die mit Organic Maps nicht bearbeitet werden können</string>
+	<!-- Information about OSM at the top of the editing page -->
+	<string name="editor_about_osm">Ihre Bearbeitungen werden in die öffentliche <a href="https://wiki.openstreetmap.org/wiki/DE:Über_OSM">OpenStreetMap</a> Datenbank hochgeladen. Bitte tragen Sie keine privaten oder urheberrechtlich geschützten Informationen ein.</string>
 	<string name="editor_more_about_osm">Mehr Informationen über OpenStreetMap</string>
 	<string name="editor_operator">Eigentümer</string>
 	<!-- To indicate the operator of ATMs, bicycle rentals, electric vehicle charging stations... -->

--- a/android/app/src/main/res/values-el/strings.xml
+++ b/android/app/src/main/res/values-el/strings.xml
@@ -503,9 +503,12 @@
 	<string name="error_enter_correct_zip_code">Εισάγετε έναν έγκυρο ταχυδρομικό κώδικα</string>
 	<!-- Place Page title for long tap -->
 	<string name="core_placepage_unknown_place">Άγνωστη τοποθεσία</string>
-	<string name="editor_other_info">Σημείωμα στους συντάκτες του OSM</string>
-	<string name="editor_detailed_description_hint">Λεπτομερές σχόλιο</string>
-	<string name="editor_detailed_description">Οι προτεινόμενες αλλαγές θα σταλούν στην Κοινότητα του OpenStreetMap. Περιγράψτε τυχόν πρόσθετα στοιχεία που δεν μπορείτε να επεξεργαστείτε στο Organic Maps.</string>
+	<!-- Title for OSM note section in the editor -->
+	<string name="editor_other_info">Σημείωση για τους εθελοντές του OpenStreetMap (προαιρετική)</string>
+	<!-- Hint of the input field in the OSM note section of the editor -->
+	<string name="editor_note_hint">Περιγράψτε λάθη στο χάρτη ή πράγματα που δεν μπορούν να επεξεργαστούν με τους Organic Maps</string>
+	<!-- Information about OSM at the top of the editing page -->
+	<string name="editor_about_osm">Οι επεξεργασίες σας μεταφορτώνονται στη δημόσια βάση δεδομένων <a href="https://wiki.openstreetmap.org/wiki/El:About_OpenStreetMap">OpenStreetMap</a>. Παρακαλούμε μην προσθέτετε προσωπικές πληροφορίες ή πληροφορίες που προστατεύονται από πνευματικά δικαιώματα.</string>
 	<string name="editor_more_about_osm">Περισσότερα σχετικά με το OpenStreetMap</string>
 	<string name="editor_operator">Ιδιοκτήτης</string>
 	<!-- To indicate the operator of ATMs, bicycle rentals, electric vehicle charging stations... -->

--- a/android/app/src/main/res/values-es-rMX/strings.xml
+++ b/android/app/src/main/res/values-es-rMX/strings.xml
@@ -61,7 +61,6 @@
 	<!-- SECTION: Strings for downloading map from search -->
 	<!-- Text in About and OSM Login screens. First %@ is replaced by a local, human readable date. -->
 	<string name="osm_presentation">Datos de OpenStreetMap creados por la comunidad a partir de %s. Obtenga más información sobre cómo editar y actualizar el mapa en OpenStreetMap.org</string>
-	<string name="editor_other_info">Enviar nota a los editores de OSM</string>
 	<!-- A referral link on the place page for some hotels -->
 	<string name="more_on_kayak">Fotos, reseñas, reservas.</string>
 	<!-- An explanation dialog shown when clicking on more_on_kayak link. -->

--- a/android/app/src/main/res/values-es/strings.xml
+++ b/android/app/src/main/res/values-es/strings.xml
@@ -502,9 +502,12 @@
 	<string name="error_enter_correct_zip_code">Introduzca el código postal correcto</string>
 	<!-- Place Page title for long tap -->
 	<string name="core_placepage_unknown_place">Lugar desconocido</string>
-	<string name="editor_other_info">Enviar nota a los editores de OSM</string>
-	<string name="editor_detailed_description_hint">Comentario detallado</string>
-	<string name="editor_detailed_description">Los cambios que ha sugerido se enviarán a la comunidad de OpenStreetMap. Describa los detalles que no pueden editarse en Organic Maps.</string>
+	<!-- Title for OSM note section in the editor -->
+	<string name="editor_other_info">Nota para los voluntarios de OpenStreetMap (opcional)</string>
+	<!-- Hint of the input field in the OSM note section of the editor -->
+	<string name="editor_note_hint">Describa los errores en el mapa o las cosas que no se pueden editar con Organic Maps</string>
+	<!-- Information about OSM at the top of the editing page -->
+	<string name="editor_about_osm">Sus ediciones se cargan en la base de datos pública <a href="https://wiki.openstreetmap.org/wiki/ES:Acerca_de_OpenStreetMap">OpenStreetMap</a>. Por favor, no añada información personal o protegida por derechos de autor.</string>
 	<string name="editor_more_about_osm">Más acerca de OpenStreetMap</string>
 	<string name="editor_operator">Operador</string>
 	<!-- To indicate the operator of ATMs, bicycle rentals, electric vehicle charging stations... -->

--- a/android/app/src/main/res/values-et/strings.xml
+++ b/android/app/src/main/res/values-et/strings.xml
@@ -494,9 +494,12 @@
 	<string name="error_enter_correct_zip_code">Sisesta korrektne postiindeks</string>
 	<!-- Place Page title for long tap -->
 	<string name="core_placepage_unknown_place">Tundmatu koht</string>
-	<string name="editor_other_info">Saada märkus OSM muutjatele</string>
-	<string name="editor_detailed_description_hint">Üksikasjalik kommentaar</string>
-	<string name="editor_detailed_description">Teie soovitatud kaardimuudatused saadetakse OpenStreetMapi kogukonnale. Kirjeldage kõiki täiendavaid üksikasju, mida ei saa Organic Maps-is muuta.</string>
+	<!-- Title for OSM note section in the editor -->
+	<string name="editor_other_info">Märkus OpenStreetMapi vabatahtlikele (vabatahtlik)</string>
+	<!-- Hint of the input field in the OSM note section of the editor -->
+	<string name="editor_note_hint">Kirjeldage kaardil olevaid vigu või asju, mida ei saa Organic Mapsiga muuta.</string>
+	<!-- Information about OSM at the top of the editing page -->
+	<string name="editor_about_osm">Teie muudatused laaditakse üles avalikku <a href="https://wiki.openstreetmap.org/wiki/About_OpenStreetMap">OpenStreetMap</a> andmebaasi. Palun ärge lisage isiklikku või autoriõigusega kaitstud teavet.</string>
 	<string name="editor_more_about_osm">Rohkem OpenStreetMap kohta</string>
 	<string name="editor_operator">Omanik</string>
 	<!-- To indicate the operator of ATMs, bicycle rentals, electric vehicle charging stations... -->

--- a/android/app/src/main/res/values-eu/strings.xml
+++ b/android/app/src/main/res/values-eu/strings.xml
@@ -500,9 +500,12 @@
 	<string name="error_enter_correct_zip_code">Sartu baliozko posta-kodea</string>
 	<!-- Place Page title for long tap -->
 	<string name="core_placepage_unknown_place">Toki ezezaguna</string>
-	<string name="editor_other_info">Bidali oharra OSM editoreei</string>
-	<string name="editor_detailed_description_hint">Iruzkin zehatza</string>
-	<string name="editor_detailed_description">Iradoki dituzun aldaketak OpenStreetMap komunitatean argitaratuko dira. Deskribatu mapa organikoetan editatu ezin diren xehetasunak.</string>
+	<!-- Title for OSM note section in the editor -->
+	<string name="editor_other_info">OpenStreetMap-eko boluntarioentzako oharra (aukerakoa)</string>
+	<!-- Hint of the input field in the OSM note section of the editor -->
+	<string name="editor_note_hint">Deskribatu mapan akatsak edo mapa organikoak erabiliz editatu ezin dena</string>
+	<!-- Information about OSM at the top of the editing page -->
+	<string name="editor_about_osm">Zure aldaketak <a href="https://wiki.openstreetmap.org/wiki/About_OpenStreetMap">OpenStreetMap</a> datu-base publikora kargatzen dira. Mesedez, ez gehitu informazio pertsonalik edo copyrightdun informaziorik.</string>
 	<string name="editor_more_about_osm">OpenStreetMap-i buruzko informazio gehiago</string>
 	<string name="editor_operator">Eragilea</string>
 	<!-- To indicate the operator of ATMs, bicycle rentals, electric vehicle charging stations... -->

--- a/android/app/src/main/res/values-fa/strings.xml
+++ b/android/app/src/main/res/values-fa/strings.xml
@@ -473,9 +473,12 @@
 	<string name="error_enter_correct_zip_code">یک کد‌ پستی معتبر وارد کنید</string>
 	<!-- Place Page title for long tap -->
 	<string name="core_placepage_unknown_place">مکان ناشناس</string>
-	<string name="editor_other_info">ارسال یادداشت به ویرایش‌کنندگان OSM</string>
-	<string name="editor_detailed_description_hint">اظهار نظر بیشتر</string>
-	<string name="editor_detailed_description">شما یک سری تغییرات در نقشه را برای انجمن OpenStreetMap ارسال کردید.جزئیات اضافی را که نتوانستید در Organic Maps ویرایش کنید را برایشان بنویسید.</string>
+	<!-- Title for OSM note section in the editor -->
+	<string name="editor_other_info">توجه به داوطلبان OpenStreetMap (اختیاری)</string>
+	<!-- Hint of the input field in the OSM note section of the editor -->
+	<string name="editor_note_hint">خطاهای موجود در نقشه یا مواردی که با استفاده از نقشه های ارگانیک قابل ویرایش نیستند را شرح دهید</string>
+	<!-- Information about OSM at the top of the editing page -->
+	<string name="editor_about_osm">ویرایش های شما در پایگاه داده عمومی <a href="https://wiki.openstreetmap.org/wiki/Fa:About_OpenStreetMap">OpenStreetMap</a> آپلود می شود. لطفا اطلاعات شخصی یا دارای حق چاپ را اضافه نکنید.</string>
 	<string name="editor_more_about_osm">در مورد OpenStreetMap بیشتر بدانید</string>
 	<string name="editor_operator">مالک</string>
 	<!-- To indicate the operator of ATMs, bicycle rentals, electric vehicle charging stations... -->

--- a/android/app/src/main/res/values-fi/strings.xml
+++ b/android/app/src/main/res/values-fi/strings.xml
@@ -504,9 +504,12 @@
 	<string name="error_enter_correct_zip_code">Anna kelvollinen postinumero</string>
 	<!-- Place Page title for long tap -->
 	<string name="core_placepage_unknown_place">Tuntematon paikka</string>
-	<string name="editor_other_info">Lähetä muistilappu OSM-toimittajille</string>
-	<string name="editor_detailed_description_hint">Yksityiskohtainen kommentti</string>
-	<string name="editor_detailed_description">Ehdottamasi muutokset lähetetään OpenStreetMap-yhteisöön. Kuvaa tiedot, joita ei voi muokata Organic Maps:ssä.</string>
+	<!-- Title for OSM note section in the editor -->
+	<string name="editor_other_info">Huomautus OpenStreetMapin vapaaehtoisille (valinnainen)</string>
+	<!-- Hint of the input field in the OSM note section of the editor -->
+	<string name="editor_note_hint">Kuvaile kartassa olevia virheitä tai asioita, joita ei voi muokata Organic Mapsilla.</string>
+	<!-- Information about OSM at the top of the editing page -->
+	<string name="editor_about_osm">Muokkauksesi ladataan julkiseen <a href="https://wiki.openstreetmap.org/wiki/About_OpenStreetMap">OpenStreetMap</a>-tietokantaan. Älä lisää henkilökohtaisia tai tekijänoikeudella suojattuja tietoja.</string>
 	<string name="editor_more_about_osm">Lisätietoja OpenStreetMap:sta</string>
 	<string name="editor_operator">Operaattori</string>
 	<!-- To indicate the operator of ATMs, bicycle rentals, electric vehicle charging stations... -->

--- a/android/app/src/main/res/values-fr/strings.xml
+++ b/android/app/src/main/res/values-fr/strings.xml
@@ -507,9 +507,12 @@
 	<string name="error_enter_correct_zip_code">Entrer un code postal correct</string>
 	<!-- Place Page title for long tap -->
 	<string name="core_placepage_unknown_place">Lieu inconnu</string>
-	<string name="editor_other_info">Informer les contributeurs OSM</string>
-	<string name="editor_detailed_description_hint">Commentaire détaillé</string>
-	<string name="editor_detailed_description">Vos modifications suggérées seront envoyées à la communauté OpenStreetMap. Décrivez les détails qui ne peuvent pas être modifiés dans Organic Maps.</string>
+	<!-- Title for OSM note section in the editor -->
+	<string name="editor_other_info">Note aux volontaires OpenStreetMap (facultatif)</string>
+	<!-- Hint of the input field in the OSM note section of the editor -->
+	<string name="editor_note_hint">Décrivez les erreurs sur la carte ou les éléments qui ne peuvent pas être modifiés avec Organic Maps.</string>
+	<!-- Information about OSM at the top of the editing page -->
+	<string name="editor_about_osm">Vos modifications sont téléchargées dans la base de données publique &lt;a href="https://wiki.openstreetmap.org/wiki/FR:%%C3%%80_propos_d%E2%%80%%99OpenStreetMap">OpenStreetMap&lt;/a>. Veuillez ne pas ajouter d\'informations personnelles ou protégées par le droit d\'auteur.</string>
 	<string name="editor_more_about_osm">En savoir plus sur OpenStreetMap</string>
 	<string name="editor_operator">Opérateur</string>
 	<!-- To indicate the operator of ATMs, bicycle rentals, electric vehicle charging stations... -->
@@ -775,7 +778,7 @@
 	<!-- Translated Organic Maps site, add new translations here: https://github.com/organicmaps/organicmaps.github.io/tree/master/content -->
 	<string name="translated_om_site_url">https://organicmaps.app/fr/</string>
 	<!-- Link to OSM wiki for Editor, Profile and About pages -->
-	<string name="osm_wiki_about_url">https://wiki.openstreetmap.org/wiki/FR:À_propos_d’OpenStreetMap</string>
+	<string name="osm_wiki_about_url">https://wiki.openstreetmap.org/wiki/FR:%%C3%%80_propos_d%E2%%80%%99OpenStreetMap</string>
 	<!-- App Tip #00 -->
 	<string name="app_tip_00">Merci d\'utiliser nos cartes créées par la communauté !</string>
 	<!-- App tip #01 -->

--- a/android/app/src/main/res/values-hi/strings.xml
+++ b/android/app/src/main/res/values-hi/strings.xml
@@ -376,9 +376,12 @@
 	<string name="downloader_of">%2$d में से %1$d</string>
 	<!-- Place Page title for long tap -->
 	<string name="core_placepage_unknown_place">अनजान जगह</string>
-	<string name="editor_other_info">OpenStreetMap संपादकों को एक नोट भेजें</string>
-	<string name="editor_detailed_description_hint">विस्तृत टिप्पणी</string>
-	<string name="editor_detailed_description">आपके सुझाए गए मानचित्र परिवर्तन OpenStreetMap समुदाय को भेजे जाएंगे। कृपया किसी भी अतिरिक्त विवरण का वर्णन करें जिसे ऑर्गेनिक मानचित्र में संपादित नहीं किया जा सकता है।</string>
+	<!-- Title for OSM note section in the editor -->
+	<string name="editor_other_info">OpenStreetMap स्वयंसेवकों के लिए नोट (वैकल्पिक)</string>
+	<!-- Hint of the input field in the OSM note section of the editor -->
+	<string name="editor_note_hint">मानचित्र में त्रुटियों का वर्णन करें या ऑर्गेनिक मानचित्र का उपयोग करके क्या संपादित नहीं किया जा सकता है</string>
+	<!-- Information about OSM at the top of the editing page -->
+	<string name="editor_about_osm">आपके संपादन सार्वजनिक <a href="https://wiki.openstreetmap.org/wiki/About_OpenStreetMap">OpenStreetMap</a> डेटाबेस पर अपलोड किए जाते हैं। कृपया व्यक्तिगत या कॉपीराइट जानकारी न जोड़ें।</string>
 	<string name="editor_more_about_osm">OpenStreetMap के बारे में अधिक जानकारी</string>
 	<string name="editor_operator">मालिक</string>
 	<!-- To indicate the operator of ATMs, bicycle rentals, electric vehicle charging stations... -->

--- a/android/app/src/main/res/values-hu/strings.xml
+++ b/android/app/src/main/res/values-hu/strings.xml
@@ -490,9 +490,12 @@
 	<string name="error_enter_correct_zip_code">Írja be a helyes irányítószámot</string>
 	<!-- Place Page title for long tap -->
 	<string name="core_placepage_unknown_place">Ismeretlen hely</string>
-	<string name="editor_other_info">Küldjön jegyzetet az OSM editornak</string>
-	<string name="editor_detailed_description_hint">Részletes megjegyzés</string>
-	<string name="editor_detailed_description">Javasolt változtatásait elküldjük az OpenStreetMap közösségnek. Írja le a további információkat, amelyek nem szerkeszthetők a Organic Maps-ben.</string>
+	<!-- Title for OSM note section in the editor -->
+	<string name="editor_other_info">Megjegyzés az OpenStreetMap önkénteseinek (nem kötelező)</string>
+	<!-- Hint of the input field in the OSM note section of the editor -->
+	<string name="editor_note_hint">Írja le a térképen található hibákat vagy olyan dolgokat, amelyeket nem lehet az Organic Maps segítségével szerkeszteni.</string>
+	<!-- Information about OSM at the top of the editing page -->
+	<string name="editor_about_osm">Az Ön szerkesztései feltöltődnek a nyilvános <a href="https://wiki.openstreetmap.org/wiki/Hu:Névjegy">OpenStreetMap</a> adatbázisba. Kérjük, ne adjon hozzá személyes vagy szerzői jogvédelem alatt álló információkat.</string>
 	<string name="editor_more_about_osm">További részletek az OpenStreetMap-ról</string>
 	<string name="editor_operator">Üzemeltető</string>
 	<!-- To indicate the operator of ATMs, bicycle rentals, electric vehicle charging stations... -->

--- a/android/app/src/main/res/values-in/strings.xml
+++ b/android/app/src/main/res/values-in/strings.xml
@@ -478,9 +478,12 @@
 	<string name="error_enter_correct_zip_code">Masukkan Kode Pos yang benar</string>
 	<!-- Place Page title for long tap -->
 	<string name="core_placepage_unknown_place">Tempat Tidak Dikenal</string>
-	<string name="editor_other_info">Kirim catatan ke editor OSM</string>
-	<string name="editor_detailed_description_hint">Komentar mendetail</string>
-	<string name="editor_detailed_description">Saran perubahan Anda akan dikirimkan ke komunitas OpenStreetMap. Jelaskan detail yang tidak dapat diedit di Organic Maps.</string>
+	<!-- Title for OSM note section in the editor -->
+	<string name="editor_other_info">Catatan untuk relawan OpenStreetMap (opsional)</string>
+	<!-- Hint of the input field in the OSM note section of the editor -->
+	<string name="editor_note_hint">Jelaskan kesalahan pada peta atau hal-hal yang tidak dapat diedit dengan Peta Organik</string>
+	<!-- Information about OSM at the top of the editing page -->
+	<string name="editor_about_osm">Hasil editan Anda akan diunggah ke database <a href="https://wiki.openstreetmap.org/wiki/About_OpenStreetMap">OpenStreetMap</a> publik. Mohon untuk tidak menambahkan informasi pribadi atau informasi yang memiliki hak cipta.</string>
 	<string name="editor_more_about_osm">Selengkapnya tentang OpenStreetMap</string>
 	<string name="editor_operator">Pemilik</string>
 	<!-- To indicate the operator of ATMs, bicycle rentals, electric vehicle charging stations... -->

--- a/android/app/src/main/res/values-it/strings.xml
+++ b/android/app/src/main/res/values-it/strings.xml
@@ -488,9 +488,12 @@
 	<string name="error_enter_correct_zip_code">Inserire il codice postale corretto</string>
 	<!-- Place Page title for long tap -->
 	<string name="core_placepage_unknown_place">Luogo sconosciuto</string>
-	<string name="editor_other_info">Invia un messaggio a OSM</string>
-	<string name="editor_detailed_description_hint">Commento dettagliato</string>
-	<string name="editor_detailed_description">Le modifiche alla mappa da te suggerite saranno inviate alla comunità di OpenStreetMap. Descrivi qualsiasi dettaglio aggiuntivo che non può essere modificato in Organic Maps.</string>
+	<!-- Title for OSM note section in the editor -->
+	<string name="editor_other_info">Nota per i volontari di OpenStreetMap (opzionale)</string>
+	<!-- Hint of the input field in the OSM note section of the editor -->
+	<string name="editor_note_hint">Descriva gli errori sulla mappa o le cose che non possono essere modificate con Organic Maps</string>
+	<!-- Information about OSM at the top of the editing page -->
+	<string name="editor_about_osm">Le sue modifiche vengono caricate nel database pubblico <a href="https://wiki.openstreetmap.org/wiki/IT:About">OpenStreetMap</a>. La preghiamo di non aggiungere informazioni personali o protette da copyright.</string>
 	<string name="editor_more_about_osm">Informazioni su OpenStreetMap</string>
 	<string name="editor_operator">Proprietario</string>
 	<!-- To indicate the operator of ATMs, bicycle rentals, electric vehicle charging stations... -->

--- a/android/app/src/main/res/values-iw/strings.xml
+++ b/android/app/src/main/res/values-iw/strings.xml
@@ -494,9 +494,12 @@
 	<string name="error_enter_correct_zip_code">יש להזין מיקוד תקין</string>
 	<!-- Place Page title for long tap -->
 	<string name="core_placepage_unknown_place">מיקום לא ידוע</string>
-	<string name="editor_other_info">שלח הערה לעורכי OSM</string>
-	<string name="editor_detailed_description_hint">הערה מפורטת</string>
-	<string name="editor_detailed_description">ההצעות שלך לשינוי המפה יישלחו לקהילת OpenStreetMap. יש לתאר פרטים נוספים שלא ניתן לערוך ב-Organic Maps.</string>
+	<!-- Title for OSM note section in the editor -->
+	<string name="editor_other_info">הערה למתנדבי OpenStreetMap (אופציונלי)</string>
+	<!-- Hint of the input field in the OSM note section of the editor -->
+	<string name="editor_note_hint">תארו שגיאות במפה או דברים שלא ניתן לערוך באמצעות Organic Maps</string>
+	<!-- Information about OSM at the top of the editing page -->
+	<string name="editor_about_osm">העריכות שלך מועלות למסד הנתונים הציבורי של <a href="https://wiki.openstreetmap.org/wiki/About_OpenStreetMap">OpenStreetMap</a>. נא לא להוסיף מידע אישי או מוגן בזכויות יוצרים.</string>
 	<string name="editor_more_about_osm">עוד על OpenStreetMap</string>
 	<string name="editor_operator">בעלים</string>
 	<!-- To indicate the operator of ATMs, bicycle rentals, electric vehicle charging stations... -->

--- a/android/app/src/main/res/values-ja/strings.xml
+++ b/android/app/src/main/res/values-ja/strings.xml
@@ -504,9 +504,12 @@
 	<string name="error_enter_correct_zip_code">正しい郵便番号を入力してください</string>
 	<!-- Place Page title for long tap -->
 	<string name="core_placepage_unknown_place">不明な場所</string>
-	<string name="editor_other_info">OSMエディタにメモを送信</string>
-	<string name="editor_detailed_description_hint">詳細コメント</string>
-	<string name="editor_detailed_description">提案した変更は、OpenStreetMapのコミュニティに送信されます。Organic Mapsで編集できない詳細を説明してください。</string>
+	<!-- Title for OSM note section in the editor -->
+	<string name="editor_other_info">OpenStreetMapボランティアへの注意（オプション）</string>
+	<!-- Hint of the input field in the OSM note section of the editor -->
+	<string name="editor_note_hint">地図上のエラーやOrganic Mapsで編集できないものについて説明します。</string>
+	<!-- Information about OSM at the top of the editing page -->
+	<string name="editor_about_osm">あなたの編集は公開されている<a href="https://wiki.openstreetmap.org/wiki/JA:参加する">OpenStreetMap</a>データベースにアップロードされます。個人情報や著作権のある情報は追加しないでください。</string>
 	<string name="editor_more_about_osm">OpenStreetMapについての詳細</string>
 	<string name="editor_operator">オペレーター</string>
 	<!-- To indicate the operator of ATMs, bicycle rentals, electric vehicle charging stations... -->

--- a/android/app/src/main/res/values-ko/strings.xml
+++ b/android/app/src/main/res/values-ko/strings.xml
@@ -476,9 +476,12 @@
 	<string name="error_enter_correct_zip_code">올바른 우편번호를 입력하세요</string>
 	<!-- Place Page title for long tap -->
 	<string name="core_placepage_unknown_place">장소 알 수 없음</string>
-	<string name="editor_other_info">OSM 편집인들에게 쪽지 보내기</string>
-	<string name="editor_detailed_description_hint">상세 설명</string>
-	<string name="editor_detailed_description">귀하가 제안한 변경 사항은 OpenStreetMap 커뮤니티로 전송됩니다. Organic Maps에서 편집할 수 없는 세부정보를 작성해 주세요.</string>
+	<!-- Title for OSM note section in the editor -->
+	<string name="editor_other_info">오픈스트리트맵 자원 봉사자 참고 사항(선택 사항)</string>
+	<!-- Hint of the input field in the OSM note section of the editor -->
+	<string name="editor_note_hint">지도의 오류 또는 오가닉 맵으로 편집할 수 없는 항목에 대해 설명합니다.</string>
+	<!-- Information about OSM at the top of the editing page -->
+	<string name="editor_about_osm">수정한 내용은 공개 <a href="https://wiki.openstreetmap.org/wiki/Ko:OpenStreetMap_소개">OpenStreetMap</a> 데이터베이스에 업로드됩니다. 개인 정보나 저작권이 있는 정보는 추가하지 마세요.</string>
 	<string name="editor_more_about_osm">OpenStreetMap 정보</string>
 	<string name="editor_operator">소유자</string>
 	<!-- To indicate the operator of ATMs, bicycle rentals, electric vehicle charging stations... -->

--- a/android/app/src/main/res/values-mr/strings.xml
+++ b/android/app/src/main/res/values-mr/strings.xml
@@ -469,9 +469,12 @@
 	<string name="error_enter_correct_zip_code">वैध पिनकोड प्रविष्ट करा</string>
 	<!-- Place Page title for long tap -->
 	<string name="core_placepage_unknown_place">अज्ञात ठिकाण</string>
-	<string name="editor_other_info">OpenStreetMap संपादकांना एक चिठ्ठी पाठवा</string>
-	<string name="editor_detailed_description_hint">तपशीलवार टिप्पणी</string>
-	<string name="editor_detailed_description">तुम्ही सुचवलेले नकाशातील बदल OpenStreetMap समुदायाला पाठवले जातील. Organic Maps मध्ये संपादित न करता येणाऱ्या अधिक तपशीलांचे वर्णन करा.</string>
+	<!-- Title for OSM note section in the editor -->
+	<string name="editor_other_info">OpenStreetMap स्वयंसेवकांसाठी टीप (पर्यायी)</string>
+	<!-- Hint of the input field in the OSM note section of the editor -->
+	<string name="editor_note_hint">नकाशामधील त्रुटी किंवा सेंद्रिय नकाशे वापरून काय संपादित केले जाऊ शकत नाही याचे वर्णन करा</string>
+	<!-- Information about OSM at the top of the editing page -->
+	<string name="editor_about_osm">तुमची संपादने सार्वजनिक <a href="https://wiki.openstreetmap.org/wiki/About_OpenStreetMap">OpenStreetMap</a> डेटाबेसवर अपलोड केली जातात. कृपया वैयक्तिक किंवा कॉपीराइट केलेली माहिती जोडू नका.</string>
 	<string name="editor_more_about_osm">OpenStreetMap बद्दल अधिक</string>
 	<string name="editor_operator">मालक</string>
 	<!-- To indicate the operator of ATMs, bicycle rentals, electric vehicle charging stations... -->

--- a/android/app/src/main/res/values-nb/strings.xml
+++ b/android/app/src/main/res/values-nb/strings.xml
@@ -502,9 +502,12 @@
 	<string name="error_enter_correct_zip_code">Angi riktig postnummer</string>
 	<!-- Place Page title for long tap -->
 	<string name="core_placepage_unknown_place">Ukjent sted</string>
-	<string name="editor_other_info">Send et notat til OSM-redaktørene</string>
-	<string name="editor_detailed_description_hint">Detaljert kommentar</string>
-	<string name="editor_detailed_description">De foreslåtte endringene vil sendes til OpenStreetMap-gruppen. Beskriv detaljene som ikke kan redigeres i Organic Maps.</string>
+	<!-- Title for OSM note section in the editor -->
+	<string name="editor_other_info">Merknad til OpenStreetMap-frivillige (valgfritt)</string>
+	<!-- Hint of the input field in the OSM note section of the editor -->
+	<string name="editor_note_hint">Beskriv feil på kartet eller ting som ikke kan redigeres med Organic Maps</string>
+	<!-- Information about OSM at the top of the editing page -->
+	<string name="editor_about_osm">Dine endringer lastes opp til den offentlige <a href="https://wiki.openstreetmap.org/wiki/About_OpenStreetMap">OpenStreetMap</a>-databasen. Vennligst ikke legg til personlig eller opphavsrettsbeskyttet informasjon.</string>
 	<string name="editor_more_about_osm">Mer om OpenStreetMap</string>
 	<string name="editor_operator">Eier</string>
 	<!-- To indicate the operator of ATMs, bicycle rentals, electric vehicle charging stations... -->

--- a/android/app/src/main/res/values-nl/strings.xml
+++ b/android/app/src/main/res/values-nl/strings.xml
@@ -498,9 +498,12 @@
 	<string name="error_enter_correct_zip_code">Voer een geldige postcode in</string>
 	<!-- Place Page title for long tap -->
 	<string name="core_placepage_unknown_place">Onbekende locatie</string>
-	<string name="editor_other_info">Stuur een notitie naar de OSM-editors</string>
-	<string name="editor_detailed_description_hint">Gedetailleerde reactie</string>
-	<string name="editor_detailed_description">Uw voorgestelde wijzigingen worden verzonden naar de OpenStreetMap-gemeenschap. Beschrijf de details die niet kunnen worden bewerkt in Organic Maps.</string>
+	<!-- Title for OSM note section in the editor -->
+	<string name="editor_other_info">Opmerking voor OpenStreetMap vrijwilligers (optioneel)</string>
+	<!-- Hint of the input field in the OSM note section of the editor -->
+	<string name="editor_note_hint">Beschrijf fouten op de kaart of dingen die niet bewerkt kunnen worden met Organic Maps</string>
+	<!-- Information about OSM at the top of the editing page -->
+	<string name="editor_about_osm">Uw bewerkingen worden geüpload naar de openbare &lt;a href="https://wiki.openstreetmap.org/wiki/NL:Wat_is_OpenStreetMap%3F">OpenStreetMap&lt;/a> database. Voeg geen persoonlijke of auteursrechtelijk beschermde informatie toe.</string>
 	<string name="editor_more_about_osm">Meer over OpenStreetMap</string>
 	<string name="editor_operator">Uitvoerder</string>
 	<!-- To indicate the operator of ATMs, bicycle rentals, electric vehicle charging stations... -->

--- a/android/app/src/main/res/values-pl/strings.xml
+++ b/android/app/src/main/res/values-pl/strings.xml
@@ -502,9 +502,12 @@
 	<string name="error_enter_correct_zip_code">Podaj prawidłowy kod pocztowy</string>
 	<!-- Place Page title for long tap -->
 	<string name="core_placepage_unknown_place">Nieznane miejsce</string>
-	<string name="editor_other_info">Poinformuj redaktorów OSM</string>
-	<string name="editor_detailed_description_hint">Szczegółowy komentarz</string>
-	<string name="editor_detailed_description">Twoje sugestie zmian zostaną wysłane do społeczności OpenStreetMap. Opisz szczegóły, których nie można edytować w Organic Maps.</string>
+	<!-- Title for OSM note section in the editor -->
+	<string name="editor_other_info">Uwaga dla wolontariuszy OpenStreetMap (opcjonalnie)</string>
+	<!-- Hint of the input field in the OSM note section of the editor -->
+	<string name="editor_note_hint">Proszę opisać błędy na mapie lub rzeczy, których nie można edytować za pomocą Organic Maps.</string>
+	<!-- Information about OSM at the top of the editing page -->
+	<string name="editor_about_osm">Państwa zmiany są przesyłane do publicznej bazy danych <a href="https://wiki.openstreetmap.org/wiki/Pl:Wstęp">OpenStreetMap</a>. Prosimy nie dodawać informacji osobistych lub chronionych prawem autorskim.</string>
 	<string name="editor_more_about_osm">Więcej o OpenStreetMap</string>
 	<string name="editor_operator">Operator</string>
 	<!-- To indicate the operator of ATMs, bicycle rentals, electric vehicle charging stations... -->

--- a/android/app/src/main/res/values-pt-rBR/strings.xml
+++ b/android/app/src/main/res/values-pt-rBR/strings.xml
@@ -459,9 +459,8 @@
 	<string name="error_enter_correct_zip_code">Informe o CEP correto</string>
 	<!-- Place Page title for long tap -->
 	<string name="core_placepage_unknown_place">Local desconhecido</string>
-	<string name="editor_other_info">Envie uma observação para os editores do OSM</string>
-	<string name="editor_detailed_description_hint">Comentário detalhado</string>
-	<string name="editor_detailed_description">Suas sugestões de mudança serão enviadas para a comunidade OpenStreetMap. Descreva em detalhes o que não pode ser editado com o Organic Maps.</string>
+	<!-- Information about OSM at the top of the editing page -->
+	<string name="editor_about_osm">As suas edições são enviadas à base de dados pública <a href="https://wiki.openstreetmap.org/wiki/Pt:Sobre_o_OpenStreetMap">OpenStreetMap</a>. Não adicione informações pessoais ou protegidas por direitos autorais.</string>
 	<string name="editor_more_about_osm">Mais sobre OpenStreetMap</string>
 	<string name="editor_operator">Operador</string>
 	<!-- To indicate the operator of ATMs, bicycle rentals, electric vehicle charging stations... -->

--- a/android/app/src/main/res/values-pt/strings.xml
+++ b/android/app/src/main/res/values-pt/strings.xml
@@ -483,9 +483,12 @@
 	<string name="error_enter_correct_zip_code">Introduza o código postal correto</string>
 	<!-- Place Page title for long tap -->
 	<string name="core_placepage_unknown_place">Local desconhecido</string>
-	<string name="editor_other_info">Enviar nota aos editores OSM</string>
-	<string name="editor_detailed_description_hint">Comentário detalhado</string>
-	<string name="editor_detailed_description">As suas alterações sugeridas irão ser enviadas para a comunidade OpenStreetMap. Descreva os dados que não podem ser editados no Organic Maps.</string>
+	<!-- Title for OSM note section in the editor -->
+	<string name="editor_other_info">Nota para os voluntários do OpenStreetMap (opcional)</string>
+	<!-- Hint of the input field in the OSM note section of the editor -->
+	<string name="editor_note_hint">Descreva erros no mapa ou coisas que não podem ser editadas com o Organic Maps</string>
+	<!-- Information about OSM at the top of the editing page -->
+	<string name="editor_about_osm">As suas edições são carregadas para a base de dados pública <a href="https://wiki.openstreetmap.org/wiki/Pt:Sobre_o_OpenStreetMap">OpenStreetMap</a>. Por favor, não adicione informações pessoais ou protegidas por direitos de autor.</string>
 	<string name="editor_more_about_osm">Mais sobre o OpenStreetMap</string>
 	<string name="editor_operator">Operador</string>
 	<!-- To indicate the operator of ATMs, bicycle rentals, electric vehicle charging stations... -->

--- a/android/app/src/main/res/values-ro/strings.xml
+++ b/android/app/src/main/res/values-ro/strings.xml
@@ -488,9 +488,12 @@
 	<string name="error_enter_correct_zip_code">Introdu codul poștal corect</string>
 	<!-- Place Page title for long tap -->
 	<string name="core_placepage_unknown_place">Loc necunoscut</string>
-	<string name="editor_other_info">Trimite un mesaj către editorii OSM</string>
-	<string name="editor_detailed_description_hint">Comentariu detaliat</string>
-	<string name="editor_detailed_description">Modificările aduse hărții, sugerate de tine, vor fi trimise comunității OpenStreetMap. Descrie orice detalii suplimentare care nu pot fi modificate în Organic Maps.</string>
+	<!-- Title for OSM note section in the editor -->
+	<string name="editor_other_info">Notă pentru voluntarii OpenStreetMap (opțional)</string>
+	<!-- Hint of the input field in the OSM note section of the editor -->
+	<string name="editor_note_hint">Descrieți erorile de pe hartă sau lucrurile care nu pot fi editate cu Organic Maps</string>
+	<!-- Information about OSM at the top of the editing page -->
+	<string name="editor_about_osm">Edițiile dvs. sunt încărcate în baza de date publică <a href="https://wiki.openstreetmap.org/wiki/About_OpenStreetMap">OpenStreetMap</a>. Vă rugăm să nu adăugați informații personale sau protejate prin drepturi de autor.</string>
 	<string name="editor_more_about_osm">Mai multe despre OpenStreetMap</string>
 	<string name="editor_operator">Proprietar</string>
 	<!-- To indicate the operator of ATMs, bicycle rentals, electric vehicle charging stations... -->

--- a/android/app/src/main/res/values-ru/strings.xml
+++ b/android/app/src/main/res/values-ru/strings.xml
@@ -507,9 +507,12 @@
 	<string name="error_enter_correct_zip_code">Введите корректный почтовый индекс</string>
 	<!-- Place Page title for long tap -->
 	<string name="core_placepage_unknown_place">Неизвестное место</string>
-	<string name="editor_other_info">Отправить заметку редакторам OSM</string>
-	<string name="editor_detailed_description_hint">Подробный комментарий</string>
-	<string name="editor_detailed_description">Предложенные вами изменения на карте будут отправлены в OpenStreetMap. Опишите дополнительные сведения об объекте, которые Organic Maps не позволяет отредактировать.</string>
+	<!-- Title for OSM note section in the editor -->
+	<string name="editor_other_info">Примечание для волонтеров OpenStreetMap (необязательно)</string>
+	<!-- Hint of the input field in the OSM note section of the editor -->
+	<string name="editor_note_hint">Опишите ошибки на карте или то, что нельзя редактировать с помощью Organic Maps</string>
+	<!-- Information about OSM at the top of the editing page -->
+	<string name="editor_about_osm">Ваши правки будут загружены в общедоступную базу данных <a href="https://wiki.openstreetmap.org/wiki/RU:О_проекте">OpenStreetMap</a>. Пожалуйста, не добавляйте личную информацию или информацию, защищенную авторским правом.</string>
 	<string name="editor_more_about_osm">Подробнее об OpenStreetMap</string>
 	<string name="editor_operator">Владелец</string>
 	<!-- To indicate the operator of ATMs, bicycle rentals, electric vehicle charging stations... -->

--- a/android/app/src/main/res/values-sk/strings.xml
+++ b/android/app/src/main/res/values-sk/strings.xml
@@ -500,9 +500,12 @@
 	<string name="error_enter_correct_zip_code">Zadajte správne PSČ</string>
 	<!-- Place Page title for long tap -->
 	<string name="core_placepage_unknown_place">Neznáme miesto</string>
-	<string name="editor_other_info">Odoslať poznámku OSM editorom</string>
-	<string name="editor_detailed_description_hint">Zmazaná poznámka</string>
-	<string name="editor_detailed_description">Vami navrhované zmeny sa odošlú do komunity OpenStreetMap. Popíšte detaily, ktoré sa nedajú upraviť v Organic Maps.</string>
+	<!-- Title for OSM note section in the editor -->
+	<string name="editor_other_info">Poznámka pre dobrovoľníkov OpenStreetMap (nepovinné)</string>
+	<!-- Hint of the input field in the OSM note section of the editor -->
+	<string name="editor_note_hint">Popíšte chyby na mape alebo veci, ktoré sa nedajú upraviť pomocou aplikácie Mapy Organic</string>
+	<!-- Information about OSM at the top of the editing page -->
+	<string name="editor_about_osm">Vaše úpravy sa nahrajú do verejnej databázy <a href="https://wiki.openstreetmap.org/wiki/About_OpenStreetMap">OpenStreetMap</a>. Prosím, nepridávajte osobné informácie alebo informácie chránené autorskými právami.</string>
 	<string name="editor_more_about_osm">Viac o OpenStreetMap</string>
 	<string name="editor_operator">Prevádzkovateľ</string>
 	<!-- To indicate the operator of ATMs, bicycle rentals, electric vehicle charging stations... -->

--- a/android/app/src/main/res/values-sv/strings.xml
+++ b/android/app/src/main/res/values-sv/strings.xml
@@ -474,9 +474,12 @@
 	<string name="error_enter_correct_zip_code">Ange korrekt postnr</string>
 	<!-- Place Page title for long tap -->
 	<string name="core_placepage_unknown_place">Okänd plats</string>
-	<string name="editor_other_info">Skicka en not till OSM-redaktörer</string>
-	<string name="editor_detailed_description_hint">Detaljerad kommentar</string>
-	<string name="editor_detailed_description">Dina föreslagna ändringar kommer att skcikas till OpenStreetMap-communityt. Beskriv detaljerna som inte kan redigeras i Organic Maps.</string>
+	<!-- Title for OSM note section in the editor -->
+	<string name="editor_other_info">Meddelande till OpenStreetMap-volontärer (valfritt)</string>
+	<!-- Hint of the input field in the OSM note section of the editor -->
+	<string name="editor_note_hint">Beskriv fel på kartan eller saker som inte kan redigeras med Organic Maps</string>
+	<!-- Information about OSM at the top of the editing page -->
+	<string name="editor_about_osm">Dina redigeringar laddas upp till den offentliga <a href="https://wiki.openstreetmap.org/wiki/Sv:Om_OpenStreetMap">OpenStreetMap</a>-databasen. Lägg inte till personlig eller upphovsrättsskyddad information.</string>
 	<string name="editor_more_about_osm">Mer om OpenStreetMap</string>
 	<string name="editor_operator">Användare</string>
 	<!-- To indicate the operator of ATMs, bicycle rentals, electric vehicle charging stations... -->

--- a/android/app/src/main/res/values-sw/strings.xml
+++ b/android/app/src/main/res/values-sw/strings.xml
@@ -107,7 +107,12 @@
 	<string name="editor_default_language_hint">Kama ilivyoandikwa katika lugha ya kienyeji</string>
 	<!-- Text in About and OSM Login screens. First %@ is replaced by a local, human readable date. -->
 	<string name="osm_presentation">Data ya OpenStreetMap iliyoundwa na jumuiya kufikia %s. Pata maelezo zaidi kuhusu jinsi ya kuhariri na kusasisha ramani katika OpenStreetMap.org</string>
-	<string name="editor_other_info">Tuma ujumbe kwenye vihariri vya OSM</string>
+	<!-- Title for OSM note section in the editor -->
+	<string name="editor_other_info">Kumbuka kwa wanaojitolea wa OpenStreetMap (si lazima)</string>
+	<!-- Hint of the input field in the OSM note section of the editor -->
+	<string name="editor_note_hint">Eleza hitilafu kwenye ramani au kile ambacho hakiwezi kuhaririwa kwa kutumia Ramani za Kikaboni</string>
+	<!-- Information about OSM at the top of the editing page -->
+	<string name="editor_about_osm">Mabadiliko yako yanapakiwa kwenye hifadhidata ya <a href="https://wiki.openstreetmap.org/wiki/About_OpenStreetMap">OpenStreetMap</a> ya umma. Tafadhali usiongeze maelezo ya kibinafsi au yenye hakimiliki.</string>
 	<string name="editor_category_unsuitable_title">Je, huwezi kupata aina inayofaa?</string>
 	<string name="editor_category_unsuitable_text">Ramani za Kikaboni huruhusu kuongeza kategoria rahisi pekee, hiyo inamaanisha hakuna miji, barabara, maziwa, muhtasari wa majengo, n.k. Tafadhali ongeza kategoria kama hizo moja kwa moja kwenye <a href="https://www.openstreetmap.org">OpenStreetMap.org</a>. Angalia <a href="https://organicmaps.app/faq/editing/advanced-map-editing">mwongozo wetu</a> kwa maagizo ya kina ya hatua kwa hatua.</string>
 	<!-- A referral link on the place page for some hotels -->

--- a/android/app/src/main/res/values-th/strings.xml
+++ b/android/app/src/main/res/values-th/strings.xml
@@ -478,9 +478,12 @@
 	<string name="error_enter_correct_zip_code">กรุณาใส่รหัสไปรษณีย์ที่ถูกต้อง</string>
 	<!-- Place Page title for long tap -->
 	<string name="core_placepage_unknown_place">ไม่ทราบชื่อสถานที่</string>
-	<string name="editor_other_info">ส่งข้อความไปยังตัวปรับแต่ง OSM</string>
-	<string name="editor_detailed_description_hint">ข้อคิดเห็นอย่างละเอียด</string>
-	<string name="editor_detailed_description">คำแนะนำการเปลี่ยนแปลงของคุณจะถูกส่งไปยังกลุ่ม OpenStreetMap โปรดอธิบายรายละเอียดที่ Organic Maps ไม่สามารถแก้ไขได้</string>
+	<!-- Title for OSM note section in the editor -->
+	<string name="editor_other_info">หมายเหตุถึงอาสาสมัคร OpenStreetMap (ไม่บังคับ)</string>
+	<!-- Hint of the input field in the OSM note section of the editor -->
+	<string name="editor_note_hint">อธิบายข้อผิดพลาดในแผนที่หรือสิ่งที่ไม่สามารถแก้ไขได้โดยใช้แผนที่ทั่วไป</string>
+	<!-- Information about OSM at the top of the editing page -->
+	<string name="editor_about_osm">การแก้ไขของคุณจะถูกอัปโหลดไปยังฐานข้อมูล <a href="https://wiki.openstreetmap.org/wiki/About_OpenStreetMap">OpenStreetMap</a> สาธารณะ กรุณาอย่าเพิ่มข้อมูลส่วนบุคคลหรือข้อมูลที่มีลิขสิทธิ์</string>
 	<string name="editor_more_about_osm">ข้อมูลเพิ่มเติมเกี่ยวกับ OpenStreetMap</string>
 	<string name="editor_operator">เจ้าของ</string>
 	<!-- To indicate the operator of ATMs, bicycle rentals, electric vehicle charging stations... -->

--- a/android/app/src/main/res/values-tr/strings.xml
+++ b/android/app/src/main/res/values-tr/strings.xml
@@ -504,9 +504,12 @@
 	<string name="error_enter_correct_zip_code">Geçerli bir posta kodu girin</string>
 	<!-- Place Page title for long tap -->
 	<string name="core_placepage_unknown_place">Bilinmeyen Yer</string>
-	<string name="editor_other_info">OSM editörlerine bir not gönderin</string>
-	<string name="editor_detailed_description_hint">Ayrıntılı yorum</string>
-	<string name="editor_detailed_description">Önerdiğiniz değişiklikler OpenStreetMap topluluğuna gönderilecek. Organic Maps’te düzenlenemeyen ayrıntıları açıklayın.</string>
+	<!-- Title for OSM note section in the editor -->
+	<string name="editor_other_info">OpenStreetMap gönüllülerine not (isteğe bağlı)</string>
+	<!-- Hint of the input field in the OSM note section of the editor -->
+	<string name="editor_note_hint">Haritadaki hataları veya Organik Haritalar ile düzenlenemeyen şeyleri tanımlayın</string>
+	<!-- Information about OSM at the top of the editing page -->
+	<string name="editor_about_osm">Düzenlemeleriniz halka açık <a href="https://wiki.openstreetmap.org/wiki/Tr:About">OpenStreetMap</a> veritabanına yüklenir. Lütfen kişisel veya telif hakkıyla korunan bilgiler eklemeyin.</string>
 	<string name="editor_more_about_osm">OpenStreetMap hakkında ek bilgi</string>
 	<string name="editor_operator">İşletmeci</string>
 	<!-- To indicate the operator of ATMs, bicycle rentals, electric vehicle charging stations... -->

--- a/android/app/src/main/res/values-uk/strings.xml
+++ b/android/app/src/main/res/values-uk/strings.xml
@@ -504,9 +504,12 @@
 	<string name="error_enter_correct_zip_code">Введіть коректний поштовий індекс</string>
 	<!-- Place Page title for long tap -->
 	<string name="core_placepage_unknown_place">Невідоме місце</string>
-	<string name="editor_other_info">Надіслати нотатку редакторам OSM</string>
-	<string name="editor_detailed_description_hint">Докладний коментар</string>
-	<string name="editor_detailed_description">Зміни, що ви запропонували, буде відправлено до OpenStreetMap. Опишіть подробиці про об\'єкт, які не можна редагувати у Organic Maps.</string>
+	<!-- Title for OSM note section in the editor -->
+	<string name="editor_other_info">Примітка для волонтерів OpenStreetMap (необов\'язково)</string>
+	<!-- Hint of the input field in the OSM note section of the editor -->
+	<string name="editor_note_hint">Опишіть помилки на карті або те, що не можна редагувати за допомогою Organic Maps</string>
+	<!-- Information about OSM at the top of the editing page -->
+	<string name="editor_about_osm">Ваші правки завантажуються до публічної бази даних <a href="https://wiki.openstreetmap.org/wiki/Uk:Про_проект">OpenStreetMap</a>. Будь ласка, не додавайте особисту або захищену авторським правом інформацію.</string>
 	<string name="editor_more_about_osm">Більше про OpenStreetMap</string>
 	<string name="editor_operator">Власник</string>
 	<!-- To indicate the operator of ATMs, bicycle rentals, electric vehicle charging stations... -->

--- a/android/app/src/main/res/values-vi/strings.xml
+++ b/android/app/src/main/res/values-vi/strings.xml
@@ -476,9 +476,12 @@
 	<string name="error_enter_correct_zip_code">Nhập Mã ZIP chính xác</string>
 	<!-- Place Page title for long tap -->
 	<string name="core_placepage_unknown_place">Địa Điểm Chưa Biết</string>
-	<string name="editor_other_info">Gửi ghi chú cho ban biên tập OSM</string>
-	<string name="editor_detailed_description_hint">Nhận xét chi tiết</string>
-	<string name="editor_detailed_description">Những thay đổi đề nghị của bạn sẽ được gửi đến cộng đồng OpenStreetMap. Mô tả các chi tiết không thể sửa trong Organic Maps.</string>
+	<!-- Title for OSM note section in the editor -->
+	<string name="editor_other_info">Lưu ý dành cho tình nguyện viên OpenStreetMap (tùy chọn)</string>
+	<!-- Hint of the input field in the OSM note section of the editor -->
+	<string name="editor_note_hint">Mô tả lỗi trên bản đồ hoặc những gì không thể chỉnh sửa bằng Bản đồ không phải trả tiền</string>
+	<!-- Information about OSM at the top of the editing page -->
+	<string name="editor_about_osm">Các chỉnh sửa của bạn sẽ được tải lên cơ sở dữ liệu <a href="https://wiki.openstreetmap.org/wiki/About_OpenStreetMap">OpenStreetMap</a> công khai. Vui lòng không thêm thông tin cá nhân hoặc có bản quyền.</string>
 	<string name="editor_more_about_osm">Thông tin bổ sung về OpenStreetMap</string>
 	<string name="editor_operator">Đơn vị điều hành</string>
 	<!-- To indicate the operator of ATMs, bicycle rentals, electric vehicle charging stations... -->

--- a/android/app/src/main/res/values-zh-rTW/strings.xml
+++ b/android/app/src/main/res/values-zh-rTW/strings.xml
@@ -513,9 +513,12 @@
 	<string name="error_enter_correct_zip_code">輸入正確的郵遞區號</string>
 	<!-- Place Page title for long tap -->
 	<string name="core_placepage_unknown_place">未知地點</string>
-	<string name="editor_other_info">給 OSM 社區發送註解</string>
-	<string name="editor_detailed_description_hint">詳細註釋</string>
-	<string name="editor_detailed_description">您建議的變更將傳送至 OpenStreetMap 社群。說明無法在 Organic Maps 中編輯的詳細資料。</string>
+	<!-- Title for OSM note section in the editor -->
+	<string name="editor_other_info">OpenStreetMap 志工注意事項（可選）</string>
+	<!-- Hint of the input field in the OSM note section of the editor -->
+	<string name="editor_note_hint">描述地圖中的錯誤或無法使用有機地圖編輯的內容</string>
+	<!-- Information about OSM at the top of the editing page -->
+	<string name="editor_about_osm">您的編輯內容將上傳至公用 &lt;a href="https://wiki.openstreetmap.org/wiki/Zh-hant:%1$E9%%97%%9C%2$E6%%96%%BCOpenStreetMap">OpenStreetMap&lt;/a> 資料庫。請不要添加個人或版權資訊。</string>
 	<string name="editor_more_about_osm">關於 OpenStreetMap 的更多資訊</string>
 	<string name="editor_operator">經營者</string>
 	<!-- To indicate the operator of ATMs, bicycle rentals, electric vehicle charging stations... -->

--- a/android/app/src/main/res/values-zh/strings.xml
+++ b/android/app/src/main/res/values-zh/strings.xml
@@ -513,9 +513,12 @@
 	<string name="error_enter_correct_zip_code">输入正确的邮政编码</string>
 	<!-- Place Page title for long tap -->
 	<string name="core_placepage_unknown_place">未知地点</string>
-	<string name="editor_other_info">给 OSM 社区发送标记</string>
-	<string name="editor_detailed_description_hint">详细备注</string>
-	<string name="editor_detailed_description">您建议的更改将发送至 OpenStreetMap 社区。说明无法在 Organic Maps 编辑的详情。</string>
+	<!-- Title for OSM note section in the editor -->
+	<string name="editor_other_info">OpenStreetMap 志愿者须知（可选）</string>
+	<!-- Hint of the input field in the OSM note section of the editor -->
+	<string name="editor_note_hint">描述地图上的错误或无法用有机地图编辑的内容</string>
+	<!-- Information about OSM at the top of the editing page -->
+	<string name="editor_about_osm">您的编辑内容将上传到公共&lt;a href="https://wiki.openstreetmap.org/wiki/Zh-hans:%1$E5%%85%%B3%2$E4%%BA%3$8E">OpenStreetMap&lt;/a>数据库。请勿添加个人或受版权保护的信息。</string>
 	<string name="editor_more_about_osm">关于 OpenStreetMap 的更多信息</string>
 	<string name="editor_operator">经营者</string>
 	<!-- To indicate the operator of ATMs, bicycle rentals, electric vehicle charging stations... -->

--- a/android/app/src/main/res/values/strings.xml
+++ b/android/app/src/main/res/values/strings.xml
@@ -529,9 +529,12 @@
 	<string name="error_enter_correct_zip_code">Enter a valid ZIP code</string>
 	<!-- Place Page title for long tap -->
 	<string name="core_placepage_unknown_place">Unknown Place</string>
-	<string name="editor_other_info">Send a note to OSM editors</string>
-	<string name="editor_detailed_description_hint">Detailed comment</string>
-	<string name="editor_detailed_description">Your suggested map changes will be sent to the OpenStreetMap community. Please describe any additional details that cannot be edited in Organic Maps.</string>
+	<!-- Title for OSM note section in the editor -->
+	<string name="editor_other_info">Note to OpenStreetMap volunteers (optional)</string>
+	<!-- Hint of the input field in the OSM note section of the editor -->
+	<string name="editor_note_hint">Describe errors on the map or things that cannot be edited with Organic Maps</string>
+	<!-- Information about OSM at the top of the editing page -->
+	<string name="editor_about_osm">Your edits are uploaded to the public <a href="https://wiki.openstreetmap.org/wiki/About_OpenStreetMap">OpenStreetMap</a> database. Please do not add personal or copyrighted information.</string>
 	<string name="editor_more_about_osm">More about OpenStreetMap</string>
 	<string name="editor_operator">Owner</string>
 	<!-- To indicate the operator of ATMs, bicycle rentals, electric vehicle charging stations... -->

--- a/data/strings/strings.txt
+++ b/data/strings/strings.txt
@@ -16542,53 +16542,143 @@
     zh-Hant = 未知地點
 
   [editor_other_info]
+    comment = Title for OSM note section in the editor
     tags = android,ios
-    en = Send a note to OSM editors
-    af = Stuur ’n nota aan OSM-wysigers
-    ar = ارسل ملاحظة إلى محرري خريطة الشارع المفتوحة
-    az = OSM redaktorlarına qeyd göndərin
-    be = Адправіць нататку рэдактарам OSM
-    bg = Изпращане на бележка до редакторите на OSM
-    ca = Envia una nota als editors de l’OSM
-    cs = Odeslat poznámku editorům OSM
-    da = Send en besked til OSM-redaktører
-    de = Notiz an Freiwillige von OpenStreetMap senden
-    el = Σημείωμα στους συντάκτες του OSM
-    es = Enviar nota a los editores de OSM
-    es-MX = Enviar nota a los editores de OSM
-    et = Saada märkus OSM muutjatele
-    eu = Bidali oharra OSM editoreei
-    fa = ارسال یادداشت به ویرایش‌کنندگان OSM
-    fi = Lähetä muistilappu OSM-toimittajille
-    fr = Informer les contributeurs OSM
-    he = שלח הערה לעורכי OSM
-    hi = OpenStreetMap संपादकों को एक नोट भेजें
-    hu = Küldjön jegyzetet az OSM editornak
-    id = Kirim catatan ke editor OSM
-    it = Invia un messaggio a OSM
-    ja = OSMエディタにメモを送信
-    ko = OSM 편집인들에게 쪽지 보내기
-    lt = Siųsti pastabą OSM redaktoriams
-    mr = OpenStreetMap संपादकांना एक चिठ्ठी पाठवा
-    nb = Send et notat til OSM-redaktørene
-    nl = Stuur een notitie naar de OSM-editors
-    pl = Poinformuj redaktorów OSM
-    pt = Enviar nota aos editores OSM
-    pt-BR = Envie uma observação para os editores do OSM
-    ro = Trimite un mesaj către editorii OSM
-    ru = Отправить заметку редакторам OSM
-    sk = Odoslať poznámku OSM editorom
-    sv = Skicka en not till OSM-redaktörer
-    sw = Tuma ujumbe kwenye vihariri vya OSM
-    th = ส่งข้อความไปยังตัวปรับแต่ง OSM
-    tr = OSM editörlerine bir not gönderin
-    uk = Надіслати нотатку редакторам OSM
-    vi = Gửi ghi chú cho ban biên tập OSM
-    zh-Hans = 给 OSM 社区发送标记
-    zh-Hant = 給 OSM 社區發送註解
+    en = Note to OpenStreetMap volunteers (optional)
+    af = Nota aan OpenStreetMap-vrywilligers (opsioneel)
+    ar = ملاحظة لمتطوعي OpenStreetMap (اختياري)
+    az = OpenStreetMap könüllüləri üçün qeyd (isteğe bağlı)
+    be = Заўвага для валанцёраў OpenStreetMap (неабавязкова)
+    bg = Забележка към доброволците на OpenStreetMap (по избор)
+    ca = Nota per als voluntaris d'OpenStreetMap (opcional)
+    cs = Poznámka pro dobrovolníky OpenStreetMap (nepovinné)
+    da = Note til OpenStreetMap-frivillige (valgfrit)
+    de = Hinweis an Freiwillige von OpenStreetMap (optional)
+    el = Σημείωση για τους εθελοντές του OpenStreetMap (προαιρετική)
+    es = Nota para los voluntarios de OpenStreetMap (opcional)
+    et = Märkus OpenStreetMapi vabatahtlikele (vabatahtlik)
+    eu = OpenStreetMap-eko boluntarioentzako oharra (aukerakoa)
+    fa = توجه به داوطلبان OpenStreetMap (اختیاری)
+    fi = Huomautus OpenStreetMapin vapaaehtoisille (valinnainen)
+    fr = Note aux volontaires OpenStreetMap (facultatif)
+    he = הערה למתנדבי OpenStreetMap (אופציונלי)
+    hi = OpenStreetMap स्वयंसेवकों के लिए नोट (वैकल्पिक)
+    hu = Megjegyzés az OpenStreetMap önkénteseinek (nem kötelező)
+    id = Catatan untuk relawan OpenStreetMap (opsional)
+    it = Nota per i volontari di OpenStreetMap (opzionale)
+    ja = OpenStreetMapボランティアへの注意（オプション）
+    ko = 오픈스트리트맵 자원 봉사자 참고 사항(선택 사항)
+    lt = Pastaba OpenStreetMap savanoriams (neprivaloma)
+    mr = OpenStreetMap स्वयंसेवकांसाठी टीप (पर्यायी)
+    nb = Merknad til OpenStreetMap-frivillige (valgfritt)
+    nl = Opmerking voor OpenStreetMap vrijwilligers (optioneel)
+    pl = Uwaga dla wolontariuszy OpenStreetMap (opcjonalnie)
+    pt = Nota para os voluntários do OpenStreetMap (opcional)
+    ro = Notă pentru voluntarii OpenStreetMap (opțional)
+    ru = Примечание для волонтеров OpenStreetMap (необязательно)
+    sk = Poznámka pre dobrovoľníkov OpenStreetMap (nepovinné)
+    sv = Meddelande till OpenStreetMap-volontärer (valfritt)
+    sw = Kumbuka kwa wanaojitolea wa OpenStreetMap (si lazima)
+    th = หมายเหตุถึงอาสาสมัคร OpenStreetMap (ไม่บังคับ)
+    tr = OpenStreetMap gönüllülerine not (isteğe bağlı)
+    uk = Примітка для волонтерів OpenStreetMap (необов'язково)
+    vi = Lưu ý dành cho tình nguyện viên OpenStreetMap (tùy chọn)
+    zh-Hans = OpenStreetMap 志愿者须知（可选）
+    zh-Hant = OpenStreetMap 志工注意事項（可選）
+
+  [editor_note_hint]
+    comment = Hint of the input field in the OSM note section of the editor
+    tags = android
+    en = Describe errors on the map or things that cannot be edited with Organic Maps
+    af = Beskryf foute in die kaart of wat nie met Organiese Kaarte geredigeer kan word nie
+    ar = وصف الأخطاء على الخريطة أو الأشياء التي لا يمكن تحريرها باستخدام الخرائط العضوية
+    az = Xəritədəki səhvləri və ya Üzvi Xəritələrdən istifadə edərək redaktə edilə bilməyənləri təsvir edin
+    be = Апішыце памылкі на карце ці тое, што нельга рэдагаваць з дапамогай Organic Maps
+    bg = Описване на грешки в картата или неща, които не могат да бъдат редактирани с Organic Maps
+    ca = Descriu errors al mapa o què no es pot editar amb Mapes orgànics
+    cs = Popište chyby na mapě nebo věci, které nelze upravit pomocí aplikace Organic Maps.
+    da = Beskriv fejl på kortet eller ting, der ikke kan redigeres med Organic Maps
+    de = Beschreiben Sie Kartenfehler oder Dinge, die mit Organic Maps nicht bearbeitet werden können
+    el = Περιγράψτε λάθη στο χάρτη ή πράγματα που δεν μπορούν να επεξεργαστούν με τους Organic Maps
+    es = Describa los errores en el mapa o las cosas que no se pueden editar con Organic Maps
+    et = Kirjeldage kaardil olevaid vigu või asju, mida ei saa Organic Mapsiga muuta.
+    eu = Deskribatu mapan akatsak edo mapa organikoak erabiliz editatu ezin dena
+    fa = خطاهای موجود در نقشه یا مواردی که با استفاده از نقشه های ارگانیک قابل ویرایش نیستند را شرح دهید
+    fi = Kuvaile kartassa olevia virheitä tai asioita, joita ei voi muokata Organic Mapsilla.
+    fr = Décrivez les erreurs sur la carte ou les éléments qui ne peuvent pas être modifiés avec Organic Maps.
+    he = תארו שגיאות במפה או דברים שלא ניתן לערוך באמצעות Organic Maps
+    hi = मानचित्र में त्रुटियों का वर्णन करें या ऑर्गेनिक मानचित्र का उपयोग करके क्या संपादित नहीं किया जा सकता है
+    hu = Írja le a térképen található hibákat vagy olyan dolgokat, amelyeket nem lehet az Organic Maps segítségével szerkeszteni.
+    id = Jelaskan kesalahan pada peta atau hal-hal yang tidak dapat diedit dengan Peta Organik
+    it = Descriva gli errori sulla mappa o le cose che non possono essere modificate con Organic Maps
+    ja = 地図上のエラーやOrganic Mapsで編集できないものについて説明します。
+    ko = 지도의 오류 또는 오가닉 맵으로 편집할 수 없는 항목에 대해 설명합니다.
+    lt = Aprašykite žemėlapyje esančias klaidas arba dalykus, kurių negalima redaguoti naudojant "Organic Maps
+    mr = नकाशामधील त्रुटी किंवा सेंद्रिय नकाशे वापरून काय संपादित केले जाऊ शकत नाही याचे वर्णन करा
+    nb = Beskriv feil på kartet eller ting som ikke kan redigeres med Organic Maps
+    nl = Beschrijf fouten op de kaart of dingen die niet bewerkt kunnen worden met Organic Maps
+    pl = Proszę opisać błędy na mapie lub rzeczy, których nie można edytować za pomocą Organic Maps.
+    pt = Descreva erros no mapa ou coisas que não podem ser editadas com o Organic Maps
+    ro = Descrieți erorile de pe hartă sau lucrurile care nu pot fi editate cu Organic Maps
+    ru = Опишите ошибки на карте или то, что нельзя редактировать с помощью Organic Maps
+    sk = Popíšte chyby na mape alebo veci, ktoré sa nedajú upraviť pomocou aplikácie Mapy Organic
+    sv = Beskriv fel på kartan eller saker som inte kan redigeras med Organic Maps
+    sw = Eleza hitilafu kwenye ramani au kile ambacho hakiwezi kuhaririwa kwa kutumia Ramani za Kikaboni
+    th = อธิบายข้อผิดพลาดในแผนที่หรือสิ่งที่ไม่สามารถแก้ไขได้โดยใช้แผนที่ทั่วไป
+    tr = Haritadaki hataları veya Organik Haritalar ile düzenlenemeyen şeyleri tanımlayın
+    uk = Опишіть помилки на карті або те, що не можна редагувати за допомогою Organic Maps
+    vi = Mô tả lỗi trên bản đồ hoặc những gì không thể chỉnh sửa bằng Bản đồ không phải trả tiền
+    zh-Hans = 描述地图上的错误或无法用有机地图编辑的内容
+    zh-Hant = 描述地圖中的錯誤或無法使用有機地圖編輯的內容
+
+  [editor_about_osm]
+    comment = Information about OSM at the top of the editing page
+    tags = android
+    en = Your edits are uploaded to the public <a href="https://wiki.openstreetmap.org/wiki/About_OpenStreetMap">OpenStreetMap</a> database. Please do not add personal or copyrighted information.
+    af = Jou wysigings word opgelaai na die publieke <a href="https://wiki.openstreetmap.org/wiki/About_OpenStreetMap">OpenStreetMap</a>-databasis. Moet asseblief nie persoonlike of kopiereginligting byvoeg nie.
+    ar = يتم تحميل تعديلاتك على قاعدة البيانات العامة <a href="https://wiki.openstreetmap.org/wiki/Ar:About_OpenStreetMap">OpenStreetMap</a>. يرجى عدم إضافة معلومات شخصية أو محمية بحقوق الطبع والنشر.
+    az = Redaktələriniz ictimai <a href="https://wiki.openstreetmap.org/wiki/Tr:About">OpenStreetMap</a> verilənlər bazasına yüklənir. Zəhmət olmasa şəxsi və ya müəllif hüquqları ilə qorunan məlumatları əlavə etməyin.
+    be = Вашы праўкі загружаюцца ў публічную базу дадзеных <a href="https://wiki.openstreetmap.org/wiki/About_OpenStreetMap">OpenStreetMap</a>. Калі ласка, не дадавайце асабістую інфармацыю або інфармацыю, абароненую аўтарскім правам.
+    bg = Вашите редакции се качват в публичната база данни <a href="https://wiki.openstreetmap.org/wiki/Bg:About">OpenStreetMap</a>. Моля, не добавяйте лична информация или информация, защитена с авторски права.
+    ca = Les vostres edicions es pengen a la base de dades pública <a href="https://wiki.openstreetmap.org/wiki/Ca:About">OpenStreetMap</a>. Si us plau, no afegiu informació personal o amb drets d'autor.
+    cs = Vaše úpravy se nahrají do veřejné databáze <a href="https://wiki.openstreetmap.org/wiki/Cs:Co_je_OpenStreetMap">OpenStreetMap</a>. Nepřidávejte prosím osobní informace nebo informace chráněné autorskými právy.
+    da = Dine ændringer uploades til den offentlige <a href="https://wiki.openstreetmap.org/wiki/Da:Om_OpenStreetMap">OpenStreetMap</a>-database. Tilføj venligst ikke personlige eller ophavsretligt beskyttede oplysninger.
+    de = Ihre Bearbeitungen werden in die öffentliche <a href="https://wiki.openstreetmap.org/wiki/DE:Über_OSM">OpenStreetMap</a> Datenbank hochgeladen. Bitte tragen Sie keine privaten oder urheberrechtlich geschützten Informationen ein.
+    el = Οι επεξεργασίες σας μεταφορτώνονται στη δημόσια βάση δεδομένων <a href="https://wiki.openstreetmap.org/wiki/El:About_OpenStreetMap">OpenStreetMap</a>. Παρακαλούμε μην προσθέτετε προσωπικές πληροφορίες ή πληροφορίες που προστατεύονται από πνευματικά δικαιώματα.
+    es = Sus ediciones se cargan en la base de datos pública <a href="https://wiki.openstreetmap.org/wiki/ES:Acerca_de_OpenStreetMap">OpenStreetMap</a>. Por favor, no añada información personal o protegida por derechos de autor.
+    et = Teie muudatused laaditakse üles avalikku <a href="https://wiki.openstreetmap.org/wiki/About_OpenStreetMap">OpenStreetMap</a> andmebaasi. Palun ärge lisage isiklikku või autoriõigusega kaitstud teavet.
+    eu = Zure aldaketak <a href="https://wiki.openstreetmap.org/wiki/About_OpenStreetMap">OpenStreetMap</a> datu-base publikora kargatzen dira. Mesedez, ez gehitu informazio pertsonalik edo copyrightdun informaziorik.
+    fa = ویرایش های شما در پایگاه داده عمومی <a href="https://wiki.openstreetmap.org/wiki/Fa:About_OpenStreetMap">OpenStreetMap</a> آپلود می شود. لطفا اطلاعات شخصی یا دارای حق چاپ را اضافه نکنید.
+    fi = Muokkauksesi ladataan julkiseen <a href="https://wiki.openstreetmap.org/wiki/About_OpenStreetMap">OpenStreetMap</a>-tietokantaan. Älä lisää henkilökohtaisia tai tekijänoikeudella suojattuja tietoja.
+    fr = Vos modifications sont téléchargées dans la base de données publique <a href="https://wiki.openstreetmap.org/wiki/FR:%C3%80_propos_d%E2%80%99OpenStreetMap">OpenStreetMap</a>. Veuillez ne pas ajouter d'informations personnelles ou protégées par le droit d'auteur.
+    he = העריכות שלך מועלות למסד הנתונים הציבורי של <a href="https://wiki.openstreetmap.org/wiki/About_OpenStreetMap">OpenStreetMap</a>. נא לא להוסיף מידע אישי או מוגן בזכויות יוצרים.
+    hi = आपके संपादन सार्वजनिक <a href="https://wiki.openstreetmap.org/wiki/About_OpenStreetMap">OpenStreetMap</a> डेटाबेस पर अपलोड किए जाते हैं। कृपया व्यक्तिगत या कॉपीराइट जानकारी न जोड़ें।
+    hu = Az Ön szerkesztései feltöltődnek a nyilvános <a href="https://wiki.openstreetmap.org/wiki/Hu:Névjegy">OpenStreetMap</a> adatbázisba. Kérjük, ne adjon hozzá személyes vagy szerzői jogvédelem alatt álló információkat.
+    id = Hasil editan Anda akan diunggah ke database <a href="https://wiki.openstreetmap.org/wiki/About_OpenStreetMap">OpenStreetMap</a> publik. Mohon untuk tidak menambahkan informasi pribadi atau informasi yang memiliki hak cipta.
+    it = Le sue modifiche vengono caricate nel database pubblico <a href="https://wiki.openstreetmap.org/wiki/IT:About">OpenStreetMap</a>. La preghiamo di non aggiungere informazioni personali o protette da copyright.
+    ja = あなたの編集は公開されている<a href="https://wiki.openstreetmap.org/wiki/JA:参加する">OpenStreetMap</a>データベースにアップロードされます。個人情報や著作権のある情報は追加しないでください。
+    ko = 수정한 내용은 공개 <a href="https://wiki.openstreetmap.org/wiki/Ko:OpenStreetMap_소개">OpenStreetMap</a> 데이터베이스에 업로드됩니다. 개인 정보나 저작권이 있는 정보는 추가하지 마세요.
+    lt = Jūsų pakeitimai įkeliami į viešą <a href="https://wiki.openstreetmap.org/wiki/About_OpenStreetMap">OpenStreetMap</a> duomenų bazę. Prašome nedėti asmeninės ar autorių teisėmis apsaugotos informacijos.
+    mr = तुमची संपादने सार्वजनिक <a href="https://wiki.openstreetmap.org/wiki/About_OpenStreetMap">OpenStreetMap</a> डेटाबेसवर अपलोड केली जातात. कृपया वैयक्तिक किंवा कॉपीराइट केलेली माहिती जोडू नका.
+    nb = Dine endringer lastes opp til den offentlige <a href="https://wiki.openstreetmap.org/wiki/About_OpenStreetMap">OpenStreetMap</a>-databasen. Vennligst ikke legg til personlig eller opphavsrettsbeskyttet informasjon.
+    nl = Uw bewerkingen worden geüpload naar de openbare <a href="https://wiki.openstreetmap.org/wiki/NL:Wat_is_OpenStreetMap%3F">OpenStreetMap</a> database. Voeg geen persoonlijke of auteursrechtelijk beschermde informatie toe.
+    pl = Państwa zmiany są przesyłane do publicznej bazy danych <a href="https://wiki.openstreetmap.org/wiki/Pl:Wstęp">OpenStreetMap</a>. Prosimy nie dodawać informacji osobistych lub chronionych prawem autorskim.
+    pt = As suas edições são carregadas para a base de dados pública <a href="https://wiki.openstreetmap.org/wiki/Pt:Sobre_o_OpenStreetMap">OpenStreetMap</a>. Por favor, não adicione informações pessoais ou protegidas por direitos de autor.
+    pt-BR = As suas edições são enviadas à base de dados pública <a href="https://wiki.openstreetmap.org/wiki/Pt:Sobre_o_OpenStreetMap">OpenStreetMap</a>. Não adicione informações pessoais ou protegidas por direitos autorais.
+    ro = Edițiile dvs. sunt încărcate în baza de date publică <a href="https://wiki.openstreetmap.org/wiki/About_OpenStreetMap">OpenStreetMap</a>. Vă rugăm să nu adăugați informații personale sau protejate prin drepturi de autor.
+    ru = Ваши правки будут загружены в общедоступную базу данных <a href="https://wiki.openstreetmap.org/wiki/RU:О_проекте">OpenStreetMap</a>. Пожалуйста, не добавляйте личную информацию или информацию, защищенную авторским правом.
+    sk = Vaše úpravy sa nahrajú do verejnej databázy <a href="https://wiki.openstreetmap.org/wiki/About_OpenStreetMap">OpenStreetMap</a>. Prosím, nepridávajte osobné informácie alebo informácie chránené autorskými právami.
+    sv = Dina redigeringar laddas upp till den offentliga <a href="https://wiki.openstreetmap.org/wiki/Sv:Om_OpenStreetMap">OpenStreetMap</a>-databasen. Lägg inte till personlig eller upphovsrättsskyddad information.
+    sw = Mabadiliko yako yanapakiwa kwenye hifadhidata ya <a href="https://wiki.openstreetmap.org/wiki/About_OpenStreetMap">OpenStreetMap</a> ya umma. Tafadhali usiongeze maelezo ya kibinafsi au yenye hakimiliki.
+    th = การแก้ไขของคุณจะถูกอัปโหลดไปยังฐานข้อมูล <a href="https://wiki.openstreetmap.org/wiki/About_OpenStreetMap">OpenStreetMap</a> สาธารณะ กรุณาอย่าเพิ่มข้อมูลส่วนบุคคลหรือข้อมูลที่มีลิขสิทธิ์
+    tr = Düzenlemeleriniz halka açık <a href="https://wiki.openstreetmap.org/wiki/Tr:About">OpenStreetMap</a> veritabanına yüklenir. Lütfen kişisel veya telif hakkıyla korunan bilgiler eklemeyin.
+    uk = Ваші правки завантажуються до публічної бази даних <a href="https://wiki.openstreetmap.org/wiki/Uk:Про_проект">OpenStreetMap</a>. Будь ласка, не додавайте особисту або захищену авторським правом інформацію.
+    vi = Các chỉnh sửa của bạn sẽ được tải lên cơ sở dữ liệu <a href="https://wiki.openstreetmap.org/wiki/About_OpenStreetMap">OpenStreetMap</a> công khai. Vui lòng không thêm thông tin cá nhân hoặc có bản quyền.
+    zh-Hans = 您的编辑内容将上传到公共<a href="https://wiki.openstreetmap.org/wiki/Zh-hans:%E5%85%B3%E4%BA%8E">OpenStreetMap</a>数据库。请勿添加个人或受版权保护的信息。
+    zh-Hant = 您的編輯內容將上傳至公用 <a href="https://wiki.openstreetmap.org/wiki/Zh-hant:%E9%97%9C%E6%96%BCOpenStreetMap">OpenStreetMap</a> 資料庫。請不要添加個人或版權資訊。
 
   [editor_detailed_description_hint]
-    tags = android,ios
+    tags = ios
     en = Detailed comment
     af = Gedetailleerde kommentaar
     ar = تعليق مفصّل
@@ -16632,7 +16722,7 @@
     zh-Hant = 詳細註釋
 
   [editor_detailed_description]
-    tags = android,ios
+    tags = ios
     en = Your suggested map changes will be sent to the OpenStreetMap community. Please describe any additional details that cannot be edited in Organic Maps.
     af = U het kaartveranderinge voorgestel wat na die OpenStreetMap-gemeenskap gestuur sal word. Beskryf asb. enige bykomende detail wat nie in Organic Maps gewysig kan word nie.
     ar = سيتم إرسال التغييرات التي اقترحتها إلى مجتمع خريطة الشارع المفتوحة. اذكر التفاصيل التي لا يمكن تحريرها في Organic Maps
@@ -29209,13 +29299,15 @@
     en = https://wiki.openstreetmap.org/wiki/About_OpenStreetMap
     ar = https://wiki.openstreetmap.org/wiki/Ar:About_OpenStreetMap
     az = https://wiki.openstreetmap.org/wiki/Tr:About
+    bg = https://wiki.openstreetmap.org/wiki/Bg:About
     ca = https://wiki.openstreetmap.org/wiki/Ca:About
+    cs = https://wiki.openstreetmap.org/wiki/Cs:Co_je_OpenStreetMap
     da = https://wiki.openstreetmap.org/wiki/Da:Om_OpenStreetMap
     de = https://wiki.openstreetmap.org/wiki/DE:Über_OSM
     el = https://wiki.openstreetmap.org/wiki/El:About_OpenStreetMap
     es = https://wiki.openstreetmap.org/wiki/ES:Acerca_de_OpenStreetMap
     fa = https://wiki.openstreetmap.org/wiki/Fa:About_OpenStreetMap
-    fr = https://wiki.openstreetmap.org/wiki/FR:À_propos_d’OpenStreetMap
+    fr = https://wiki.openstreetmap.org/wiki/FR:%C3%80_propos_d%E2%80%99OpenStreetMap
     hu = https://wiki.openstreetmap.org/wiki/Hu:Névjegy
     it = https://wiki.openstreetmap.org/wiki/IT:About
     ja = https://wiki.openstreetmap.org/wiki/JA:参加する

--- a/iphone/Maps/LocalizedStrings/ar.lproj/Localizable.strings
+++ b/iphone/Maps/LocalizedStrings/ar.lproj/Localizable.strings
@@ -750,7 +750,8 @@
 /* Place Page title for long tap */
 "core_placepage_unknown_place" = "مكان غير معروف";
 
-"editor_other_info" = "ارسل ملاحظة إلى محرري خريطة الشارع المفتوحة";
+/* Title for OSM note section in the editor */
+"editor_other_info" = "ملاحظة لمتطوعي OpenStreetMap (اختياري)";
 
 "editor_detailed_description_hint" = "تعليق مفصّل";
 

--- a/iphone/Maps/LocalizedStrings/az.lproj/Localizable.strings
+++ b/iphone/Maps/LocalizedStrings/az.lproj/Localizable.strings
@@ -750,7 +750,8 @@
 /* Place Page title for long tap */
 "core_placepage_unknown_place" = "Naməlum yer";
 
-"editor_other_info" = "OSM redaktorlarına qeyd göndərin";
+/* Title for OSM note section in the editor */
+"editor_other_info" = "OpenStreetMap könüllüləri üçün qeyd (isteğe bağlı)";
 
 "editor_detailed_description_hint" = "Ətraflı şərh";
 

--- a/iphone/Maps/LocalizedStrings/be.lproj/Localizable.strings
+++ b/iphone/Maps/LocalizedStrings/be.lproj/Localizable.strings
@@ -750,7 +750,8 @@
 /* Place Page title for long tap */
 "core_placepage_unknown_place" = "Невядомае месца";
 
-"editor_other_info" = "Адправіць нататку рэдактарам OSM";
+/* Title for OSM note section in the editor */
+"editor_other_info" = "Заўвага для валанцёраў OpenStreetMap (неабавязкова)";
 
 "editor_detailed_description_hint" = "Падрабязны каментарый";
 

--- a/iphone/Maps/LocalizedStrings/bg.lproj/Localizable.strings
+++ b/iphone/Maps/LocalizedStrings/bg.lproj/Localizable.strings
@@ -750,7 +750,8 @@
 /* Place Page title for long tap */
 "core_placepage_unknown_place" = "Неизвестно място";
 
-"editor_other_info" = "Изпращане на бележка до редакторите на OSM";
+/* Title for OSM note section in the editor */
+"editor_other_info" = "Забележка към доброволците на OpenStreetMap (по избор)";
 
 "editor_detailed_description_hint" = "Подробен коментар";
 
@@ -1277,7 +1278,7 @@
 "translated_om_site_url" = "https://organicmaps.app/";
 
 /* Link to OSM wiki for Editor, Profile and About pages */
-"osm_wiki_about_url" = "https://wiki.openstreetmap.org/wiki/About_OpenStreetMap";
+"osm_wiki_about_url" = "https://wiki.openstreetmap.org/wiki/Bg:About";
 
 /* App Tip #00 */
 "app_tip_00" = "Благодарим ви, че използвате нашите карти, създадени от общността!";

--- a/iphone/Maps/LocalizedStrings/ca.lproj/Localizable.strings
+++ b/iphone/Maps/LocalizedStrings/ca.lproj/Localizable.strings
@@ -750,7 +750,8 @@
 /* Place Page title for long tap */
 "core_placepage_unknown_place" = "Lloc desconegut";
 
-"editor_other_info" = "Envia una nota als editors de l’OSM";
+/* Title for OSM note section in the editor */
+"editor_other_info" = "Nota per als voluntaris d'OpenStreetMap (opcional)";
 
 "editor_detailed_description_hint" = "Comentari detallat";
 

--- a/iphone/Maps/LocalizedStrings/cs.lproj/Localizable.strings
+++ b/iphone/Maps/LocalizedStrings/cs.lproj/Localizable.strings
@@ -750,7 +750,8 @@
 /* Place Page title for long tap */
 "core_placepage_unknown_place" = "Neznámé místo";
 
-"editor_other_info" = "Odeslat poznámku editorům OSM";
+/* Title for OSM note section in the editor */
+"editor_other_info" = "Poznámka pro dobrovolníky OpenStreetMap (nepovinné)";
 
 "editor_detailed_description_hint" = "Podrobný komentář";
 
@@ -1277,7 +1278,7 @@
 "translated_om_site_url" = "https://organicmaps.app/cs/";
 
 /* Link to OSM wiki for Editor, Profile and About pages */
-"osm_wiki_about_url" = "https://wiki.openstreetmap.org/wiki/About_OpenStreetMap";
+"osm_wiki_about_url" = "https://wiki.openstreetmap.org/wiki/Cs:Co_je_OpenStreetMap";
 
 /* App Tip #00 */
 "app_tip_00" = "Děkujeme, že používáte naše komunitní mapy!";

--- a/iphone/Maps/LocalizedStrings/da.lproj/Localizable.strings
+++ b/iphone/Maps/LocalizedStrings/da.lproj/Localizable.strings
@@ -750,7 +750,8 @@
 /* Place Page title for long tap */
 "core_placepage_unknown_place" = "Ukendt sted";
 
-"editor_other_info" = "Send en besked til OSM-redaktører";
+/* Title for OSM note section in the editor */
+"editor_other_info" = "Note til OpenStreetMap-frivillige (valgfrit)";
 
 "editor_detailed_description_hint" = "Detaljerede bemærkninger";
 

--- a/iphone/Maps/LocalizedStrings/de.lproj/Localizable.strings
+++ b/iphone/Maps/LocalizedStrings/de.lproj/Localizable.strings
@@ -750,7 +750,8 @@
 /* Place Page title for long tap */
 "core_placepage_unknown_place" = "Unbekannter Ort";
 
-"editor_other_info" = "Notiz an Freiwillige von OpenStreetMap senden";
+/* Title for OSM note section in the editor */
+"editor_other_info" = "Hinweis an Freiwillige von OpenStreetMap (optional)";
 
 "editor_detailed_description_hint" = "Ausführlicher Kommentar";
 

--- a/iphone/Maps/LocalizedStrings/el.lproj/Localizable.strings
+++ b/iphone/Maps/LocalizedStrings/el.lproj/Localizable.strings
@@ -750,7 +750,8 @@
 /* Place Page title for long tap */
 "core_placepage_unknown_place" = "Άγνωστη τοποθεσία";
 
-"editor_other_info" = "Σημείωμα στους συντάκτες του OSM";
+/* Title for OSM note section in the editor */
+"editor_other_info" = "Σημείωση για τους εθελοντές του OpenStreetMap (προαιρετική)";
 
 "editor_detailed_description_hint" = "Λεπτομερές σχόλιο";
 

--- a/iphone/Maps/LocalizedStrings/en-GB.lproj/Localizable.strings
+++ b/iphone/Maps/LocalizedStrings/en-GB.lproj/Localizable.strings
@@ -750,7 +750,8 @@
 /* Place Page title for long tap */
 "core_placepage_unknown_place" = "Unknown Place";
 
-"editor_other_info" = "Send a note to OSM editors";
+/* Title for OSM note section in the editor */
+"editor_other_info" = "Note to OpenStreetMap volunteers (optional)";
 
 "editor_detailed_description_hint" = "Detailed comment";
 

--- a/iphone/Maps/LocalizedStrings/en.lproj/Localizable.strings
+++ b/iphone/Maps/LocalizedStrings/en.lproj/Localizable.strings
@@ -750,7 +750,8 @@
 /* Place Page title for long tap */
 "core_placepage_unknown_place" = "Unknown Place";
 
-"editor_other_info" = "Send a note to OSM editors";
+/* Title for OSM note section in the editor */
+"editor_other_info" = "Note to OpenStreetMap volunteers (optional)";
 
 "editor_detailed_description_hint" = "Detailed comment";
 

--- a/iphone/Maps/LocalizedStrings/es-MX.lproj/Localizable.strings
+++ b/iphone/Maps/LocalizedStrings/es-MX.lproj/Localizable.strings
@@ -750,7 +750,8 @@
 /* Place Page title for long tap */
 "core_placepage_unknown_place" = "Lugar desconocido";
 
-"editor_other_info" = "Enviar nota a los editores de OSM";
+/* Title for OSM note section in the editor */
+"editor_other_info" = "Nota para los voluntarios de OpenStreetMap (opcional)";
 
 "editor_detailed_description_hint" = "Comentario detallado";
 

--- a/iphone/Maps/LocalizedStrings/es.lproj/Localizable.strings
+++ b/iphone/Maps/LocalizedStrings/es.lproj/Localizable.strings
@@ -750,7 +750,8 @@
 /* Place Page title for long tap */
 "core_placepage_unknown_place" = "Lugar desconocido";
 
-"editor_other_info" = "Enviar nota a los editores de OSM";
+/* Title for OSM note section in the editor */
+"editor_other_info" = "Nota para los voluntarios de OpenStreetMap (opcional)";
 
 "editor_detailed_description_hint" = "Comentario detallado";
 

--- a/iphone/Maps/LocalizedStrings/et.lproj/Localizable.strings
+++ b/iphone/Maps/LocalizedStrings/et.lproj/Localizable.strings
@@ -750,7 +750,8 @@
 /* Place Page title for long tap */
 "core_placepage_unknown_place" = "Tundmatu koht";
 
-"editor_other_info" = "Saada märkus OSM muutjatele";
+/* Title for OSM note section in the editor */
+"editor_other_info" = "Märkus OpenStreetMapi vabatahtlikele (vabatahtlik)";
 
 "editor_detailed_description_hint" = "Üksikasjalik kommentaar";
 

--- a/iphone/Maps/LocalizedStrings/eu.lproj/Localizable.strings
+++ b/iphone/Maps/LocalizedStrings/eu.lproj/Localizable.strings
@@ -750,7 +750,8 @@
 /* Place Page title for long tap */
 "core_placepage_unknown_place" = "Toki ezezaguna";
 
-"editor_other_info" = "Bidali oharra OSM editoreei";
+/* Title for OSM note section in the editor */
+"editor_other_info" = "OpenStreetMap-eko boluntarioentzako oharra (aukerakoa)";
 
 "editor_detailed_description_hint" = "Iruzkin zehatza";
 

--- a/iphone/Maps/LocalizedStrings/fa.lproj/Localizable.strings
+++ b/iphone/Maps/LocalizedStrings/fa.lproj/Localizable.strings
@@ -750,7 +750,8 @@
 /* Place Page title for long tap */
 "core_placepage_unknown_place" = "مکان ناشناس";
 
-"editor_other_info" = "ارسال یادداشت به ویرایش‌کنندگان OSM";
+/* Title for OSM note section in the editor */
+"editor_other_info" = "توجه به داوطلبان OpenStreetMap (اختیاری)";
 
 "editor_detailed_description_hint" = "اظهار نظر بیشتر";
 

--- a/iphone/Maps/LocalizedStrings/fi.lproj/Localizable.strings
+++ b/iphone/Maps/LocalizedStrings/fi.lproj/Localizable.strings
@@ -750,7 +750,8 @@
 /* Place Page title for long tap */
 "core_placepage_unknown_place" = "Tuntematon paikka";
 
-"editor_other_info" = "Lähetä muistilappu OSM-toimittajille";
+/* Title for OSM note section in the editor */
+"editor_other_info" = "Huomautus OpenStreetMapin vapaaehtoisille (valinnainen)";
 
 "editor_detailed_description_hint" = "Yksityiskohtainen kommentti";
 

--- a/iphone/Maps/LocalizedStrings/fr.lproj/Localizable.strings
+++ b/iphone/Maps/LocalizedStrings/fr.lproj/Localizable.strings
@@ -750,7 +750,8 @@
 /* Place Page title for long tap */
 "core_placepage_unknown_place" = "Lieu inconnu";
 
-"editor_other_info" = "Informer les contributeurs OSM";
+/* Title for OSM note section in the editor */
+"editor_other_info" = "Note aux volontaires OpenStreetMap (facultatif)";
 
 "editor_detailed_description_hint" = "Commentaire détaillé";
 
@@ -1277,7 +1278,7 @@
 "translated_om_site_url" = "https://organicmaps.app/fr/";
 
 /* Link to OSM wiki for Editor, Profile and About pages */
-"osm_wiki_about_url" = "https://wiki.openstreetmap.org/wiki/FR:À_propos_d’OpenStreetMap";
+"osm_wiki_about_url" = "https://wiki.openstreetmap.org/wiki/FR:%C3%80_propos_d%E2%80%99OpenStreetMap";
 
 /* App Tip #00 */
 "app_tip_00" = "Merci d'utiliser nos cartes créées par la communauté !";

--- a/iphone/Maps/LocalizedStrings/he.lproj/Localizable.strings
+++ b/iphone/Maps/LocalizedStrings/he.lproj/Localizable.strings
@@ -750,7 +750,8 @@
 /* Place Page title for long tap */
 "core_placepage_unknown_place" = "מיקום לא ידוע";
 
-"editor_other_info" = "שלח הערה לעורכי OSM";
+/* Title for OSM note section in the editor */
+"editor_other_info" = "הערה למתנדבי OpenStreetMap (אופציונלי)";
 
 "editor_detailed_description_hint" = "הערה מפורטת";
 

--- a/iphone/Maps/LocalizedStrings/hi.lproj/Localizable.strings
+++ b/iphone/Maps/LocalizedStrings/hi.lproj/Localizable.strings
@@ -750,7 +750,8 @@
 /* Place Page title for long tap */
 "core_placepage_unknown_place" = "अनजान जगह";
 
-"editor_other_info" = "OpenStreetMap संपादकों को एक नोट भेजें";
+/* Title for OSM note section in the editor */
+"editor_other_info" = "OpenStreetMap स्वयंसेवकों के लिए नोट (वैकल्पिक)";
 
 "editor_detailed_description_hint" = "विस्तृत टिप्पणी";
 

--- a/iphone/Maps/LocalizedStrings/hu.lproj/Localizable.strings
+++ b/iphone/Maps/LocalizedStrings/hu.lproj/Localizable.strings
@@ -750,7 +750,8 @@
 /* Place Page title for long tap */
 "core_placepage_unknown_place" = "Ismeretlen hely";
 
-"editor_other_info" = "Küldjön jegyzetet az OSM editornak";
+/* Title for OSM note section in the editor */
+"editor_other_info" = "Megjegyzés az OpenStreetMap önkénteseinek (nem kötelező)";
 
 "editor_detailed_description_hint" = "Részletes megjegyzés";
 

--- a/iphone/Maps/LocalizedStrings/id.lproj/Localizable.strings
+++ b/iphone/Maps/LocalizedStrings/id.lproj/Localizable.strings
@@ -750,7 +750,8 @@
 /* Place Page title for long tap */
 "core_placepage_unknown_place" = "Tempat Tidak Dikenal";
 
-"editor_other_info" = "Kirim catatan ke editor OSM";
+/* Title for OSM note section in the editor */
+"editor_other_info" = "Catatan untuk relawan OpenStreetMap (opsional)";
 
 "editor_detailed_description_hint" = "Komentar mendetail";
 

--- a/iphone/Maps/LocalizedStrings/it.lproj/Localizable.strings
+++ b/iphone/Maps/LocalizedStrings/it.lproj/Localizable.strings
@@ -750,7 +750,8 @@
 /* Place Page title for long tap */
 "core_placepage_unknown_place" = "Luogo sconosciuto";
 
-"editor_other_info" = "Invia un messaggio a OSM";
+/* Title for OSM note section in the editor */
+"editor_other_info" = "Nota per i volontari di OpenStreetMap (opzionale)";
 
 "editor_detailed_description_hint" = "Commento dettagliato";
 

--- a/iphone/Maps/LocalizedStrings/ja.lproj/Localizable.strings
+++ b/iphone/Maps/LocalizedStrings/ja.lproj/Localizable.strings
@@ -750,7 +750,8 @@
 /* Place Page title for long tap */
 "core_placepage_unknown_place" = "不明な場所";
 
-"editor_other_info" = "OSMエディタにメモを送信";
+/* Title for OSM note section in the editor */
+"editor_other_info" = "OpenStreetMapボランティアへの注意（オプション）";
 
 "editor_detailed_description_hint" = "詳細コメント";
 

--- a/iphone/Maps/LocalizedStrings/ko.lproj/Localizable.strings
+++ b/iphone/Maps/LocalizedStrings/ko.lproj/Localizable.strings
@@ -750,7 +750,8 @@
 /* Place Page title for long tap */
 "core_placepage_unknown_place" = "장소 알 수 없음";
 
-"editor_other_info" = "OSM 편집인들에게 쪽지 보내기";
+/* Title for OSM note section in the editor */
+"editor_other_info" = "오픈스트리트맵 자원 봉사자 참고 사항(선택 사항)";
 
 "editor_detailed_description_hint" = "상세 설명";
 

--- a/iphone/Maps/LocalizedStrings/mr.lproj/Localizable.strings
+++ b/iphone/Maps/LocalizedStrings/mr.lproj/Localizable.strings
@@ -750,7 +750,8 @@
 /* Place Page title for long tap */
 "core_placepage_unknown_place" = "अज्ञात ठिकाण";
 
-"editor_other_info" = "OpenStreetMap संपादकांना एक चिठ्ठी पाठवा";
+/* Title for OSM note section in the editor */
+"editor_other_info" = "OpenStreetMap स्वयंसेवकांसाठी टीप (पर्यायी)";
 
 "editor_detailed_description_hint" = "तपशीलवार टिप्पणी";
 

--- a/iphone/Maps/LocalizedStrings/nb.lproj/Localizable.strings
+++ b/iphone/Maps/LocalizedStrings/nb.lproj/Localizable.strings
@@ -750,7 +750,8 @@
 /* Place Page title for long tap */
 "core_placepage_unknown_place" = "Ukjent sted";
 
-"editor_other_info" = "Send et notat til OSM-redaktørene";
+/* Title for OSM note section in the editor */
+"editor_other_info" = "Merknad til OpenStreetMap-frivillige (valgfritt)";
 
 "editor_detailed_description_hint" = "Detaljert kommentar";
 

--- a/iphone/Maps/LocalizedStrings/nl.lproj/Localizable.strings
+++ b/iphone/Maps/LocalizedStrings/nl.lproj/Localizable.strings
@@ -750,7 +750,8 @@
 /* Place Page title for long tap */
 "core_placepage_unknown_place" = "Onbekende locatie";
 
-"editor_other_info" = "Stuur een notitie naar de OSM-editors";
+/* Title for OSM note section in the editor */
+"editor_other_info" = "Opmerking voor OpenStreetMap vrijwilligers (optioneel)";
 
 "editor_detailed_description_hint" = "Gedetailleerde reactie";
 

--- a/iphone/Maps/LocalizedStrings/pl.lproj/Localizable.strings
+++ b/iphone/Maps/LocalizedStrings/pl.lproj/Localizable.strings
@@ -750,7 +750,8 @@
 /* Place Page title for long tap */
 "core_placepage_unknown_place" = "Nieznane miejsce";
 
-"editor_other_info" = "Poinformuj redaktorów OSM";
+/* Title for OSM note section in the editor */
+"editor_other_info" = "Uwaga dla wolontariuszy OpenStreetMap (opcjonalnie)";
 
 "editor_detailed_description_hint" = "Szczegółowy komentarz";
 

--- a/iphone/Maps/LocalizedStrings/pt-BR.lproj/Localizable.strings
+++ b/iphone/Maps/LocalizedStrings/pt-BR.lproj/Localizable.strings
@@ -750,7 +750,8 @@
 /* Place Page title for long tap */
 "core_placepage_unknown_place" = "Local desconhecido";
 
-"editor_other_info" = "Envie uma observação para os editores do OSM";
+/* Title for OSM note section in the editor */
+"editor_other_info" = "Nota para os voluntários do OpenStreetMap (opcional)";
 
 "editor_detailed_description_hint" = "Comentário detalhado";
 

--- a/iphone/Maps/LocalizedStrings/pt.lproj/Localizable.strings
+++ b/iphone/Maps/LocalizedStrings/pt.lproj/Localizable.strings
@@ -750,7 +750,8 @@
 /* Place Page title for long tap */
 "core_placepage_unknown_place" = "Local desconhecido";
 
-"editor_other_info" = "Enviar nota aos editores OSM";
+/* Title for OSM note section in the editor */
+"editor_other_info" = "Nota para os voluntários do OpenStreetMap (opcional)";
 
 "editor_detailed_description_hint" = "Comentário detalhado";
 

--- a/iphone/Maps/LocalizedStrings/ro.lproj/Localizable.strings
+++ b/iphone/Maps/LocalizedStrings/ro.lproj/Localizable.strings
@@ -750,7 +750,8 @@
 /* Place Page title for long tap */
 "core_placepage_unknown_place" = "Loc necunoscut";
 
-"editor_other_info" = "Trimite un mesaj către editorii OSM";
+/* Title for OSM note section in the editor */
+"editor_other_info" = "Notă pentru voluntarii OpenStreetMap (opțional)";
 
 "editor_detailed_description_hint" = "Comentariu detaliat";
 

--- a/iphone/Maps/LocalizedStrings/ru.lproj/Localizable.strings
+++ b/iphone/Maps/LocalizedStrings/ru.lproj/Localizable.strings
@@ -750,7 +750,8 @@
 /* Place Page title for long tap */
 "core_placepage_unknown_place" = "Неизвестное место";
 
-"editor_other_info" = "Отправить заметку редакторам OSM";
+/* Title for OSM note section in the editor */
+"editor_other_info" = "Примечание для волонтеров OpenStreetMap (необязательно)";
 
 "editor_detailed_description_hint" = "Подробный комментарий";
 

--- a/iphone/Maps/LocalizedStrings/sk.lproj/Localizable.strings
+++ b/iphone/Maps/LocalizedStrings/sk.lproj/Localizable.strings
@@ -750,7 +750,8 @@
 /* Place Page title for long tap */
 "core_placepage_unknown_place" = "Neznáme miesto";
 
-"editor_other_info" = "Odoslať poznámku OSM editorom";
+/* Title for OSM note section in the editor */
+"editor_other_info" = "Poznámka pre dobrovoľníkov OpenStreetMap (nepovinné)";
 
 "editor_detailed_description_hint" = "Zmazaná poznámka";
 

--- a/iphone/Maps/LocalizedStrings/sv.lproj/Localizable.strings
+++ b/iphone/Maps/LocalizedStrings/sv.lproj/Localizable.strings
@@ -750,7 +750,8 @@
 /* Place Page title for long tap */
 "core_placepage_unknown_place" = "Okänd plats";
 
-"editor_other_info" = "Skicka en not till OSM-redaktörer";
+/* Title for OSM note section in the editor */
+"editor_other_info" = "Meddelande till OpenStreetMap-volontärer (valfritt)";
 
 "editor_detailed_description_hint" = "Detaljerad kommentar";
 

--- a/iphone/Maps/LocalizedStrings/sw.lproj/Localizable.strings
+++ b/iphone/Maps/LocalizedStrings/sw.lproj/Localizable.strings
@@ -750,7 +750,8 @@
 /* Place Page title for long tap */
 "core_placepage_unknown_place" = "Unknown Place";
 
-"editor_other_info" = "Tuma ujumbe kwenye vihariri vya OSM";
+/* Title for OSM note section in the editor */
+"editor_other_info" = "Kumbuka kwa wanaojitolea wa OpenStreetMap (si lazima)";
 
 "editor_detailed_description_hint" = "Detailed comment";
 

--- a/iphone/Maps/LocalizedStrings/th.lproj/Localizable.strings
+++ b/iphone/Maps/LocalizedStrings/th.lproj/Localizable.strings
@@ -750,7 +750,8 @@
 /* Place Page title for long tap */
 "core_placepage_unknown_place" = "ไม่ทราบชื่อสถานที่";
 
-"editor_other_info" = "ส่งข้อความไปยังตัวปรับแต่ง OSM";
+/* Title for OSM note section in the editor */
+"editor_other_info" = "หมายเหตุถึงอาสาสมัคร OpenStreetMap (ไม่บังคับ)";
 
 "editor_detailed_description_hint" = "ข้อคิดเห็นอย่างละเอียด";
 

--- a/iphone/Maps/LocalizedStrings/tr.lproj/Localizable.strings
+++ b/iphone/Maps/LocalizedStrings/tr.lproj/Localizable.strings
@@ -750,7 +750,8 @@
 /* Place Page title for long tap */
 "core_placepage_unknown_place" = "Bilinmeyen Yer";
 
-"editor_other_info" = "OSM editörlerine bir not gönderin";
+/* Title for OSM note section in the editor */
+"editor_other_info" = "OpenStreetMap gönüllülerine not (isteğe bağlı)";
 
 "editor_detailed_description_hint" = "Ayrıntılı yorum";
 

--- a/iphone/Maps/LocalizedStrings/uk.lproj/Localizable.strings
+++ b/iphone/Maps/LocalizedStrings/uk.lproj/Localizable.strings
@@ -750,7 +750,8 @@
 /* Place Page title for long tap */
 "core_placepage_unknown_place" = "Невідоме місце";
 
-"editor_other_info" = "Надіслати нотатку редакторам OSM";
+/* Title for OSM note section in the editor */
+"editor_other_info" = "Примітка для волонтерів OpenStreetMap (необов'язково)";
 
 "editor_detailed_description_hint" = "Докладний коментар";
 

--- a/iphone/Maps/LocalizedStrings/vi.lproj/Localizable.strings
+++ b/iphone/Maps/LocalizedStrings/vi.lproj/Localizable.strings
@@ -750,7 +750,8 @@
 /* Place Page title for long tap */
 "core_placepage_unknown_place" = "Địa Điểm Chưa Biết";
 
-"editor_other_info" = "Gửi ghi chú cho ban biên tập OSM";
+/* Title for OSM note section in the editor */
+"editor_other_info" = "Lưu ý dành cho tình nguyện viên OpenStreetMap (tùy chọn)";
 
 "editor_detailed_description_hint" = "Nhận xét chi tiết";
 

--- a/iphone/Maps/LocalizedStrings/zh-Hans.lproj/Localizable.strings
+++ b/iphone/Maps/LocalizedStrings/zh-Hans.lproj/Localizable.strings
@@ -750,7 +750,8 @@
 /* Place Page title for long tap */
 "core_placepage_unknown_place" = "未知地点";
 
-"editor_other_info" = "给 OSM 社区发送标记";
+/* Title for OSM note section in the editor */
+"editor_other_info" = "OpenStreetMap 志愿者须知（可选）";
 
 "editor_detailed_description_hint" = "详细备注";
 

--- a/iphone/Maps/LocalizedStrings/zh-Hant.lproj/Localizable.strings
+++ b/iphone/Maps/LocalizedStrings/zh-Hant.lproj/Localizable.strings
@@ -750,7 +750,8 @@
 /* Place Page title for long tap */
 "core_placepage_unknown_place" = "未知地點";
 
-"editor_other_info" = "給 OSM 社區發送註解";
+/* Title for OSM note section in the editor */
+"editor_other_info" = "OpenStreetMap 志工注意事項（可選）";
 
 "editor_detailed_description_hint" = "詳細註釋";
 


### PR DESCRIPTION
Reworked descriptions in the editor:

- Placed info about OSM at the top to prevent people from using the editor for personal notes. Moreover it is a good practice for a privacy focused app to inform users about what and where data is send.
- Improved the hint of the the note field. Currently the description below the field is very misleading and many people use it like a changeset comment as they don't know it's for OSM notes.
- Apart from the slight change in the "Note to OpenStreetMap volunteers" string this PR doesn't affect iOS

| Now | Before |
|--------|--------|
|![%2Fstorage%2Femulated%2F0%2FDCIM%2FScreenshots%2FIMG_20240824_210007](https://github.com/user-attachments/assets/49ff54ea-a773-4a4d-afe2-0670aa52603e)|![Screenshot_2024-08-18-18-17-28-581_app organicmaps](https://github.com/user-attachments/assets/f69e5452-724c-4d9f-8607-9df56bfc839b)|
|![Screenshot_2024-08-24-20-45-21-816_app organicmaps debug](https://github.com/user-attachments/assets/58defcfd-8594-40de-a6de-7c8c5d8d7bdc)|![Screenshot_2024-08-18-18-15-01-604_app organicmaps](https://github.com/user-attachments/assets/da08b60e-8f24-4df8-9c65-4469207812e3)|

### Todo:
- [x] Translations









