### PR TITLE
[ios] Inconsistent layout in place page on iOS

### DIFF
--- a/iphone/Maps/Core/Theme/Renderers/UITableViewHeaderFooterViewRenderer.swift
+++ b/iphone/Maps/Core/Theme/Renderers/UITableViewHeaderFooterViewRenderer.swift
@@ -15,9 +15,6 @@ class UITableViewHeaderFooterViewRenderer {
     if let backgroundColor = style.backgroundColor {
       control.backgroundView = UIImageView(image: backgroundColor.getImage())
     }
-    if let font = style.font {
-      control.textLabel?.font = font
-    }
     if let fontColor = style.fontColor {
       control.textLabel?.textColor = fontColor
     }

--- a/iphone/Maps/UI/PlacePage/Components/PlacePageInfoViewController.swift
+++ b/iphone/Maps/UI/PlacePage/Components/PlacePageInfoViewController.swift
@@ -9,7 +9,6 @@ class InfoItemViewController: UIViewController {
   @IBOutlet var imageView: UIImageView!
   @IBOutlet var infoLabel: UILabel!
   @IBOutlet var accessoryImage: UIImageView!
-  @IBOutlet var separatorView: UIView!
   @IBOutlet var tapGestureRecognizer: UITapGestureRecognizer!
 
   var tapHandler: TapHandler?
@@ -26,7 +25,6 @@ class InfoItemViewController: UIViewController {
     }
   }
   var canShowMenu = false
-
   @IBAction func onTap(_ sender: UITapGestureRecognizer) {
     tapHandler?()
   }
@@ -223,7 +221,6 @@ class PlacePageInfoViewController: UIViewController {
   }
 
   // MARK: private
-
   private func createInfoItem(_ info: String,
                               icon: UIImage?,
                               style: Style = .regular,
@@ -239,7 +236,36 @@ class PlacePageInfoViewController: UIViewController {
 
   private func addToStack(_ viewController: UIViewController) {
     addChild(viewController)
-    stackView.addArrangedSubview(viewController.view)
+    stackView.addArrangedSubviewWithSeparator(viewController.view)
     viewController.didMove(toParent: self)
+  }
+}
+
+private extension UIStackView {
+  func addArrangedSubviewWithSeparator(_ view: UIView) {
+    if !arrangedSubviews.isEmpty {
+      view.addSeparator(thickness: CGFloat(1.0),
+                        color: StyleManager.shared.theme?.colors.blackDividers,
+                        insets: UIEdgeInsets(top: 0, left: 56, bottom: 0, right: 0))
+    }
+    addArrangedSubview(view)
+  }
+}
+
+private extension UIView {
+  func addSeparator(thickness: CGFloat,
+                    color: UIColor?,
+                    insets: UIEdgeInsets) {
+    let lineView = UIView()
+    lineView.backgroundColor = color ?? .black
+    lineView.isUserInteractionEnabled = false
+    lineView.translatesAutoresizingMaskIntoConstraints = false
+    addSubview(lineView)
+    NSLayoutConstraint.activate([
+      lineView.heightAnchor.constraint(equalToConstant: thickness),
+      lineView.leadingAnchor.constraint(equalTo: leadingAnchor, constant: insets.left),
+      lineView.trailingAnchor.constraint(equalTo: trailingAnchor, constant: -insets.right),
+      lineView.topAnchor.constraint(equalTo: topAnchor, constant: insets.top),
+    ])
   }
 }

--- a/iphone/Maps/UI/PlacePage/PlacePage.storyboard
+++ b/iphone/Maps/UI/PlacePage/PlacePage.storyboard
@@ -1,9 +1,9 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="21225" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES" initialViewController="bX8-ZQ-XDA">
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="21701" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES" initialViewController="bX8-ZQ-XDA">
     <device id="retina4_7" orientation="portrait" appearance="light"/>
     <dependencies>
         <deployment identifier="iOS"/>
-        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="21207"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="21679"/>
         <capability name="Safe area layout guides" minToolsVersion="9.0"/>
         <capability name="Stack View standard spacing" minToolsVersion="9.0"/>
         <capability name="System colors in document resources" minToolsVersion="11.0"/>
@@ -20,17 +20,17 @@
                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                         <subviews>
                             <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="TtY-w3-kOi" userLabel="Background View">
-                                <rect key="frame" x="0.0" y="0.0" width="375" height="667"/>
+                                <rect key="frame" x="0.0" y="20" width="375" height="647"/>
                                 <color key="backgroundColor" systemColor="systemBackgroundColor"/>
                                 <userDefinedRuntimeAttributes>
                                     <userDefinedRuntimeAttribute type="string" keyPath="styleName" value="PPBackgroundView"/>
                                 </userDefinedRuntimeAttributes>
                             </view>
                             <scrollView clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="scaleToFill" bounces="NO" showsHorizontalScrollIndicator="NO" showsVerticalScrollIndicator="NO" bouncesZoom="NO" translatesAutoresizingMaskIntoConstraints="NO" id="dJ0-97-CDh" customClass="PlacePageScrollView" customModule="Organic_Maps" customModuleProvider="target">
-                                <rect key="frame" x="0.0" y="0.0" width="375" height="617"/>
+                                <rect key="frame" x="0.0" y="20" width="375" height="597"/>
                                 <subviews>
                                     <stackView opaque="NO" contentMode="scaleToFill" axis="vertical" spacing="24" translatesAutoresizingMaskIntoConstraints="NO" id="bsv-S8-EiF">
-                                        <rect key="frame" x="0.0" y="0.0" width="375" height="617"/>
+                                        <rect key="frame" x="0.0" y="0.0" width="375" height="597"/>
                                         <color key="backgroundColor" systemColor="systemBackgroundColor"/>
                                         <gestureRecognizers/>
                                     </stackView>
@@ -53,7 +53,7 @@
                                 </connections>
                             </scrollView>
                             <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="RZh-69-00e" userLabel="Divider View">
-                                <rect key="frame" x="0.0" y="617" width="375" height="1"/>
+                                <rect key="frame" x="0.0" y="616" width="375" height="1"/>
                                 <color key="backgroundColor" systemColor="separatorColor"/>
                                 <constraints>
                                     <constraint firstAttribute="height" constant="1" id="G2u-nx-IJt"/>
@@ -63,7 +63,7 @@
                                 </userDefinedRuntimeAttributes>
                             </view>
                             <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="inM-UW-vpv">
-                                <rect key="frame" x="0.0" y="618" width="375" height="49"/>
+                                <rect key="frame" x="0.0" y="617" width="375" height="50"/>
                                 <color key="backgroundColor" systemColor="systemBackgroundColor"/>
                                 <userDefinedRuntimeAttributes>
                                     <userDefinedRuntimeAttribute type="string" keyPath="styleName" value="Background"/>
@@ -86,7 +86,7 @@
                             <constraint firstItem="inM-UW-vpv" firstAttribute="leading" secondItem="WOB-EV-vjA" secondAttribute="leading" id="apX-d6-VvF"/>
                             <constraint firstItem="TtY-w3-kOi" firstAttribute="leading" secondItem="bsv-S8-EiF" secondAttribute="leading" id="hQh-bC-doW"/>
                             <constraint firstItem="gXh-A8-hCx" firstAttribute="bottom" secondItem="TtY-w3-kOi" secondAttribute="bottom" id="iT0-Pn-Zue"/>
-                            <constraint firstItem="RZh-69-00e" firstAttribute="top" secondItem="dJ0-97-CDh" secondAttribute="bottom" id="mk3-a2-JVy"/>
+                            <constraint firstItem="inM-UW-vpv" firstAttribute="top" secondItem="dJ0-97-CDh" secondAttribute="bottom" id="mk3-a2-JVy"/>
                             <constraint firstAttribute="trailing" secondItem="inM-UW-vpv" secondAttribute="trailing" id="oNS-yS-5VJ"/>
                             <constraint firstItem="TtY-w3-kOi" firstAttribute="top" secondItem="bsv-S8-EiF" secondAttribute="top" priority="250" id="r8L-A7-Fbc"/>
                             <constraint firstItem="gXh-A8-hCx" firstAttribute="bottom" secondItem="dJ0-97-CDh" secondAttribute="bottom" constant="50" id="xwz-cT-wns"/>
@@ -124,7 +124,7 @@
                                 <rect key="frame" x="0.0" y="0.0" width="375" height="212"/>
                                 <subviews>
                                     <stackView opaque="NO" contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="YyN-l5-4le">
-                                        <rect key="frame" x="4" y="0.0" width="367" height="50"/>
+                                        <rect key="frame" x="4" y="20" width="367" height="50"/>
                                         <subviews>
                                             <view hidden="YES" contentMode="scaleToFill" horizontalHuggingPriority="750" horizontalCompressionResistancePriority="1000" translatesAutoresizingMaskIntoConstraints="NO" id="Jgo-Sd-tyF">
                                                 <rect key="frame" x="0.0" y="0.0" width="171.5" height="50"/>
@@ -217,10 +217,10 @@
                                         <edgeInsets key="layoutMargins" top="0.0" left="12" bottom="0.0" right="12"/>
                                     </stackView>
                                     <stackView opaque="NO" contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="fKt-f3-qqN">
-                                        <rect key="frame" x="4" y="58" width="367" height="96"/>
+                                        <rect key="frame" x="4" y="78" width="367" height="76"/>
                                         <subviews>
                                             <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" insetsLayoutMarginsFromSafeArea="NO" text="Open" textAlignment="natural" lineBreakMode="tailTruncation" numberOfLines="0" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="caI-ec-meo">
-                                                <rect key="frame" x="12" y="0.0" width="343" height="96"/>
+                                                <rect key="frame" x="12" y="0.0" width="343" height="76"/>
                                                 <fontDescription key="fontDescription" type="system" pointSize="17"/>
                                                 <nil key="textColor"/>
                                                 <nil key="highlightedColor"/>
@@ -346,7 +346,7 @@
                         <rect key="frame" x="0.0" y="0.0" width="375" height="180"/>
                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                         <subviews>
-                            <textView clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="scaleToFill" scrollEnabled="NO" showsHorizontalScrollIndicator="NO" showsVerticalScrollIndicator="NO" editable="NO" textAlignment="natural" translatesAutoresizingMaskIntoConstraints="NO" id="4pU-ex-66e">
+                            <textView clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="scaleToFill" verticalHuggingPriority="750" scrollEnabled="NO" showsHorizontalScrollIndicator="NO" showsVerticalScrollIndicator="NO" editable="NO" textAlignment="natural" translatesAutoresizingMaskIntoConstraints="NO" id="4pU-ex-66e">
                                 <rect key="frame" x="16" y="16" width="343" height="131"/>
                                 <color key="backgroundColor" white="0.0" alpha="0.0" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
                                 <constraints>
@@ -356,12 +356,6 @@
                                 <fontDescription key="fontDescription" type="system" pointSize="16"/>
                                 <textInputTraits key="textInputTraits" autocapitalizationType="sentences"/>
                                 <dataDetectorType key="dataDetectorTypes" phoneNumber="YES" link="YES"/>
-                                <userDefinedRuntimeAttributes>
-                                    <userDefinedRuntimeAttribute type="string" keyPath="styleName" value="regular16:blackPrimaryText"/>
-                                    <userDefinedRuntimeAttribute type="number" keyPath="textContainer.lineFragmentPadding">
-                                        <integer key="value" value="0"/>
-                                    </userDefinedRuntimeAttribute>
-                                </userDefinedRuntimeAttributes>
                             </textView>
                             <button opaque="NO" clipsSubviews="YES" contentMode="scaleToFill" contentHorizontalAlignment="left" contentVerticalAlignment="top" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="soI-1J-JL6">
                                 <rect key="frame" x="16" y="147" width="343" height="33"/>
@@ -379,15 +373,41 @@
                                     <action selector="onMore:" destination="WSQ-QR-4WY" eventType="touchUpInside" id="z5J-UQ-f0u"/>
                                 </connections>
                             </button>
+                            <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="QEp-rn-Kgr" userLabel="Spacing Top">
+                                <rect key="frame" x="0.0" y="0.0" width="375" height="1"/>
+                                <color key="backgroundColor" systemColor="systemBackgroundColor"/>
+                                <constraints>
+                                    <constraint firstAttribute="height" constant="1" id="l15-DI-Ikm"/>
+                                </constraints>
+                                <userDefinedRuntimeAttributes>
+                                    <userDefinedRuntimeAttribute type="string" keyPath="styleName" value="Divider"/>
+                                </userDefinedRuntimeAttributes>
+                            </view>
+                            <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="sb1-VR-dnu" userLabel="Spacing Bottom">
+                                <rect key="frame" x="0.0" y="179" width="375" height="1"/>
+                                <color key="backgroundColor" systemColor="systemBackgroundColor"/>
+                                <constraints>
+                                    <constraint firstAttribute="height" constant="1" id="2ol-iq-Dnr"/>
+                                </constraints>
+                                <userDefinedRuntimeAttributes>
+                                    <userDefinedRuntimeAttribute type="string" keyPath="styleName" value="Divider"/>
+                                </userDefinedRuntimeAttributes>
+                            </view>
                         </subviews>
                         <viewLayoutGuide key="safeArea" id="pcV-Cv-rW6"/>
                         <color key="backgroundColor" systemColor="systemBackgroundColor"/>
                         <constraints>
+                            <constraint firstAttribute="trailing" secondItem="sb1-VR-dnu" secondAttribute="trailing" id="0DE-s1-N8e"/>
+                            <constraint firstAttribute="bottom" secondItem="sb1-VR-dnu" secondAttribute="bottom" id="AUQ-7h-CnS"/>
+                            <constraint firstItem="QEp-rn-Kgr" firstAttribute="top" secondItem="99j-36-7TK" secondAttribute="top" id="Hg5-NP-hKL"/>
                             <constraint firstItem="4pU-ex-66e" firstAttribute="leading" secondItem="99j-36-7TK" secondAttribute="leading" constant="16" id="T4C-Nw-I3N"/>
                             <constraint firstItem="soI-1J-JL6" firstAttribute="leading" secondItem="99j-36-7TK" secondAttribute="leading" constant="16" id="Vac-L0-pTZ"/>
                             <constraint firstAttribute="bottom" secondItem="soI-1J-JL6" secondAttribute="bottom" id="XvI-Sc-kIL"/>
                             <constraint firstAttribute="trailing" secondItem="4pU-ex-66e" secondAttribute="trailing" constant="16" id="bVa-3L-AtD"/>
+                            <constraint firstAttribute="trailing" secondItem="QEp-rn-Kgr" secondAttribute="trailing" id="bzy-12-Exm"/>
+                            <constraint firstItem="sb1-VR-dnu" firstAttribute="leading" secondItem="99j-36-7TK" secondAttribute="leading" id="cjK-6L-rtp"/>
                             <constraint firstItem="4pU-ex-66e" firstAttribute="top" secondItem="99j-36-7TK" secondAttribute="top" constant="16" id="f7d-q9-70I"/>
+                            <constraint firstItem="QEp-rn-Kgr" firstAttribute="leading" secondItem="99j-36-7TK" secondAttribute="leading" id="gU2-VG-YLQ"/>
                             <constraint firstItem="soI-1J-JL6" firstAttribute="top" secondItem="4pU-ex-66e" secondAttribute="bottom" id="i4f-1B-jfo"/>
                             <constraint firstAttribute="trailing" secondItem="soI-1J-JL6" secondAttribute="trailing" constant="16" id="tu6-L8-fUt"/>
                         </constraints>
@@ -413,7 +433,10 @@
                         <rect key="frame" x="0.0" y="0.0" width="375" height="100"/>
                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                         <subviews>
-                            <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="Ojl-qe-MWU">
+                            <stackView opaque="NO" contentMode="scaleToFill" axis="vertical" translatesAutoresizingMaskIntoConstraints="NO" id="pmL-HT-I1N">
+                                <rect key="frame" x="0.0" y="0.0" width="375" height="100"/>
+                            </stackView>
+                            <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="Ojl-qe-MWU" userLabel="Top separator">
                                 <rect key="frame" x="0.0" y="0.0" width="375" height="1"/>
                                 <color key="backgroundColor" systemColor="systemBackgroundColor"/>
                                 <constraints>
@@ -423,10 +446,7 @@
                                     <userDefinedRuntimeAttribute type="string" keyPath="styleName" value="Divider"/>
                                 </userDefinedRuntimeAttributes>
                             </view>
-                            <stackView opaque="NO" contentMode="scaleToFill" axis="vertical" translatesAutoresizingMaskIntoConstraints="NO" id="pmL-HT-I1N">
-                                <rect key="frame" x="0.0" y="1" width="375" height="98"/>
-                            </stackView>
-                            <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="u8Q-Ia-dJM">
+                            <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="u8Q-Ia-dJM" userLabel="Bottom separator">
                                 <rect key="frame" x="0.0" y="99" width="375" height="1"/>
                                 <color key="backgroundColor" systemColor="systemBackgroundColor"/>
                                 <constraints>
@@ -440,12 +460,12 @@
                         <viewLayoutGuide key="safeArea" id="g60-e9-U8G"/>
                         <color key="backgroundColor" systemColor="systemBackgroundColor"/>
                         <constraints>
-                            <constraint firstItem="pmL-HT-I1N" firstAttribute="top" secondItem="Ojl-qe-MWU" secondAttribute="bottom" id="AtT-RR-dJE"/>
+                            <constraint firstAttribute="bottom" secondItem="pmL-HT-I1N" secondAttribute="bottom" id="0Xe-Gp-10C"/>
                             <constraint firstItem="Ojl-qe-MWU" firstAttribute="top" secondItem="uyH-Qn-86F" secondAttribute="top" id="Huk-kl-GY1"/>
+                            <constraint firstAttribute="top" secondItem="pmL-HT-I1N" secondAttribute="top" id="THV-MF-4pC"/>
                             <constraint firstItem="pmL-HT-I1N" firstAttribute="leading" secondItem="uyH-Qn-86F" secondAttribute="leading" id="VNA-7u-TMS"/>
-                            <constraint firstItem="u8Q-Ia-dJM" firstAttribute="top" secondItem="pmL-HT-I1N" secondAttribute="bottom" id="erE-W5-8I9"/>
+                            <constraint firstItem="u8Q-Ia-dJM" firstAttribute="bottom" secondItem="uyH-Qn-86F" secondAttribute="bottom" id="erE-W5-8I9"/>
                             <constraint firstItem="Ojl-qe-MWU" firstAttribute="leading" secondItem="uyH-Qn-86F" secondAttribute="leading" id="hbC-z3-Jvb"/>
-                            <constraint firstAttribute="bottom" secondItem="u8Q-Ia-dJM" secondAttribute="bottom" id="laF-hA-orx"/>
                             <constraint firstAttribute="trailing" secondItem="Ojl-qe-MWU" secondAttribute="trailing" id="m7e-JQ-8Yz"/>
                             <constraint firstAttribute="trailing" secondItem="u8Q-Ia-dJM" secondAttribute="trailing" id="ozT-6W-mau"/>
                             <constraint firstAttribute="trailing" secondItem="pmL-HT-I1N" secondAttribute="trailing" id="sUb-Fg-UED"/>
@@ -463,7 +483,7 @@
                 </viewController>
                 <placeholder placeholderIdentifier="IBFirstResponder" id="UlS-Pw-E6a" userLabel="First Responder" customClass="UIResponder" sceneMemberID="firstResponder"/>
             </objects>
-            <point key="canvasLocation" x="929" y="-289"/>
+            <point key="canvasLocation" x="928.79999999999995" y="-289.65517241379314"/>
         </scene>
         <!--Action Bar View Controller-->
         <scene sceneID="MOc-50-GOI">
@@ -510,7 +530,7 @@
                                 <rect key="frame" x="16" y="16" width="343" height="224"/>
                                 <subviews>
                                     <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="RUc-Qr-8Sb">
-                                        <rect key="frame" x="0.0" y="0.0" width="343" height="164"/>
+                                        <rect key="frame" x="0.0" y="0.0" width="343" height="44"/>
                                         <constraints>
                                             <constraint firstAttribute="height" constant="44" id="OYY-L8-CtC"/>
                                         </constraints>
@@ -525,7 +545,7 @@
                                         </connections>
                                     </button>
                                     <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="bAP-Be-X7d">
-                                        <rect key="frame" x="0.0" y="180" width="343" height="44"/>
+                                        <rect key="frame" x="0.0" y="60" width="343" height="164"/>
                                         <constraints>
                                             <constraint firstAttribute="height" constant="44" id="fBI-zz-Fkk"/>
                                         </constraints>
@@ -541,14 +561,40 @@
                                     </button>
                                 </subviews>
                             </stackView>
+                            <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="hRi-Xr-pFy" userLabel="Spacing Top">
+                                <rect key="frame" x="0.0" y="0.0" width="375" height="1"/>
+                                <color key="backgroundColor" systemColor="systemBackgroundColor"/>
+                                <constraints>
+                                    <constraint firstAttribute="height" constant="1" id="S6g-eX-SKD"/>
+                                </constraints>
+                                <userDefinedRuntimeAttributes>
+                                    <userDefinedRuntimeAttribute type="string" keyPath="styleName" value="Divider"/>
+                                </userDefinedRuntimeAttributes>
+                            </view>
+                            <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="kvs-3m-aX5" userLabel="Spacing Bottom">
+                                <rect key="frame" x="0.0" y="255" width="375" height="1"/>
+                                <color key="backgroundColor" systemColor="systemBackgroundColor"/>
+                                <constraints>
+                                    <constraint firstAttribute="height" constant="1" id="sLf-h1-gaG"/>
+                                </constraints>
+                                <userDefinedRuntimeAttributes>
+                                    <userDefinedRuntimeAttribute type="string" keyPath="styleName" value="Divider"/>
+                                </userDefinedRuntimeAttributes>
+                            </view>
                         </subviews>
                         <viewLayoutGuide key="safeArea" id="wND-VP-FnI"/>
                         <color key="backgroundColor" systemColor="systemBackgroundColor"/>
                         <constraints>
+                            <constraint firstItem="kvs-3m-aX5" firstAttribute="leading" secondItem="uEh-Ml-VWK" secondAttribute="leading" id="2ml-Sl-4Ab"/>
                             <constraint firstAttribute="bottom" secondItem="021-FW-tZO" secondAttribute="bottom" constant="16" id="9ot-3E-Be3"/>
+                            <constraint firstAttribute="trailing" secondItem="kvs-3m-aX5" secondAttribute="trailing" id="EJa-hE-gkc"/>
                             <constraint firstItem="021-FW-tZO" firstAttribute="leading" secondItem="uEh-Ml-VWK" secondAttribute="leading" constant="16" id="Hq9-h5-Znu"/>
                             <constraint firstItem="021-FW-tZO" firstAttribute="top" secondItem="uEh-Ml-VWK" secondAttribute="top" constant="16" id="NQ6-jj-fu0"/>
                             <constraint firstAttribute="trailing" secondItem="021-FW-tZO" secondAttribute="trailing" constant="16" id="Ox1-Cd-PWE"/>
+                            <constraint firstItem="hRi-Xr-pFy" firstAttribute="leading" secondItem="uEh-Ml-VWK" secondAttribute="leading" id="Zhy-TR-brz"/>
+                            <constraint firstAttribute="bottom" secondItem="kvs-3m-aX5" secondAttribute="bottom" id="iEU-H1-Cmq"/>
+                            <constraint firstAttribute="trailing" secondItem="hRi-Xr-pFy" secondAttribute="trailing" id="pQ8-7S-WYf"/>
+                            <constraint firstItem="hRi-Xr-pFy" firstAttribute="top" secondItem="uEh-Ml-VWK" secondAttribute="top" id="sMX-ou-xsp"/>
                         </constraints>
                         <userDefinedRuntimeAttributes>
                             <userDefinedRuntimeAttribute type="string" keyPath="styleName" value="Background"/>
@@ -604,16 +650,6 @@
                                     <userDefinedRuntimeAttribute type="string" keyPath="coloring" value="MWMBlack"/>
                                 </userDefinedRuntimeAttributes>
                             </imageView>
-                            <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="1Ac-Ag-dut">
-                                <rect key="frame" x="56" y="43" width="319" height="1"/>
-                                <color key="backgroundColor" systemColor="systemBackgroundColor"/>
-                                <constraints>
-                                    <constraint firstAttribute="height" constant="1" id="EEb-FZ-zQK"/>
-                                </constraints>
-                                <userDefinedRuntimeAttributes>
-                                    <userDefinedRuntimeAttribute type="string" keyPath="styleName" value="Divider"/>
-                                </userDefinedRuntimeAttributes>
-                            </view>
                         </subviews>
                         <viewLayoutGuide key="safeArea" id="xdh-hy-Bxo"/>
                         <color key="backgroundColor" systemColor="systemBackgroundColor"/>
@@ -621,12 +657,9 @@
                         <constraints>
                             <constraint firstAttribute="bottom" secondItem="l7d-ck-nSv" secondAttribute="bottom" id="AV5-Tu-LK4"/>
                             <constraint firstAttribute="bottom" secondItem="8eU-Fj-XRv" secondAttribute="bottom" id="Cu6-uK-4Ox"/>
-                            <constraint firstAttribute="trailing" secondItem="1Ac-Ag-dut" secondAttribute="trailing" id="KWp-x3-Fcy"/>
-                            <constraint firstItem="1Ac-Ag-dut" firstAttribute="bottom" secondItem="oz0-2o-icQ" secondAttribute="bottom" id="MFU-bG-Yjy"/>
                             <constraint firstItem="onF-JL-5dZ" firstAttribute="leading" secondItem="8eU-Fj-XRv" secondAttribute="trailing" id="Y7d-Lw-sIv"/>
                             <constraint firstItem="l7d-ck-nSv" firstAttribute="leading" secondItem="oz0-2o-icQ" secondAttribute="leading" id="ZKa-Nx-mMv"/>
                             <constraint firstItem="8eU-Fj-XRv" firstAttribute="leading" secondItem="l7d-ck-nSv" secondAttribute="trailing" id="fPc-6Q-inb"/>
-                            <constraint firstItem="1Ac-Ag-dut" firstAttribute="leading" secondItem="l7d-ck-nSv" secondAttribute="trailing" id="khr-Ce-xHs"/>
                             <constraint firstItem="l7d-ck-nSv" firstAttribute="top" secondItem="oz0-2o-icQ" secondAttribute="top" id="mvH-dY-Evu"/>
                             <constraint firstItem="xdh-hy-Bxo" firstAttribute="trailing" secondItem="onF-JL-5dZ" secondAttribute="trailing" constant="8" id="oIb-Tv-InY"/>
                             <constraint firstItem="onF-JL-5dZ" firstAttribute="centerY" secondItem="oz0-2o-icQ" secondAttribute="centerY" id="sxb-OB-j2b"/>
@@ -645,7 +678,6 @@
                         <outlet property="accessoryImage" destination="onF-JL-5dZ" id="EfX-rZ-lGT"/>
                         <outlet property="imageView" destination="l7d-ck-nSv" id="Llp-U6-qLx"/>
                         <outlet property="infoLabel" destination="8eU-Fj-XRv" id="72o-pM-iKo"/>
-                        <outlet property="separatorView" destination="1Ac-Ag-dut" id="9s3-iT-pUP"/>
                         <outlet property="tapGestureRecognizer" destination="pe0-Qk-VTv" id="ysd-CD-jhE"/>
                     </connections>
                 </viewController>
@@ -661,7 +693,7 @@
                     </connections>
                 </pongPressGestureRecognizer>
             </objects>
-            <point key="canvasLocation" x="1567" y="-315"/>
+            <point key="canvasLocation" x="1565.5999999999999" y="-315.74212893553226"/>
         </scene>
         <!--Opening Hours View Controller-->
         <scene sceneID="txO-kw-ZRm">
@@ -729,7 +761,7 @@
                                                 </userDefinedRuntimeAttributes>
                                             </label>
                                             <label opaque="NO" userInteractionEnabled="NO" contentMode="left" verticalHuggingPriority="251" horizontalCompressionResistancePriority="251" text="12:00 - 18:15" textAlignment="right" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="Yw5-Jp-V9B">
-                                                <rect key="frame" x="47.5" y="0.0" width="231.5" height="43.5"/>
+                                                <rect key="frame" x="47.5" y="0.0" width="231.5" height="44"/>
                                                 <color key="backgroundColor" white="0.0" alpha="0.0" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
                                                 <fontDescription key="fontDescription" type="system" pointSize="16"/>
                                                 <nil key="textColor"/>
@@ -745,7 +777,7 @@
                                             <constraint firstItem="Yw5-Jp-V9B" firstAttribute="leading" secondItem="sw2-Oa-u57" secondAttribute="trailing" constant="4" id="9Jg-oZ-8n0"/>
                                             <constraint firstItem="Yw5-Jp-V9B" firstAttribute="top" secondItem="Uvb-Ju-e8X" secondAttribute="top" id="9ee-Eo-f2m"/>
                                             <constraint firstAttribute="bottom" secondItem="sw2-Oa-u57" secondAttribute="bottom" id="RKu-mb-B0V"/>
-                                            <constraint firstAttribute="bottom" secondItem="Yw5-Jp-V9B" secondAttribute="bottom" constant="0.33333333333333215" id="aKL-HR-TXq"/>
+                                            <constraint firstAttribute="bottom" secondItem="Yw5-Jp-V9B" secondAttribute="bottom" id="aKL-HR-TXq"/>
                                             <constraint firstItem="sw2-Oa-u57" firstAttribute="top" secondItem="Uvb-Ju-e8X" secondAttribute="top" id="eGg-GV-YEx"/>
                                             <constraint firstAttribute="trailing" secondItem="Yw5-Jp-V9B" secondAttribute="trailing" id="uAI-9S-bWD"/>
                                         </constraints>
@@ -782,16 +814,6 @@
                                     <userDefinedRuntimeAttribute type="string" keyPath="coloring" value="MWMBlack"/>
                                 </userDefinedRuntimeAttributes>
                             </imageView>
-                            <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="43E-TR-OSz">
-                                <rect key="frame" x="56" y="99" width="319" height="1"/>
-                                <color key="backgroundColor" systemColor="systemBackgroundColor"/>
-                                <constraints>
-                                    <constraint firstAttribute="height" constant="1" id="YSz-cB-2pD"/>
-                                </constraints>
-                                <userDefinedRuntimeAttributes>
-                                    <userDefinedRuntimeAttribute type="string" keyPath="styleName" value="Divider"/>
-                                </userDefinedRuntimeAttributes>
-                            </view>
                         </subviews>
                         <viewLayoutGuide key="safeArea" id="PcM-qb-4Kv"/>
                         <color key="backgroundColor" systemColor="systemBackgroundColor"/>
@@ -799,10 +821,7 @@
                         <constraints>
                             <constraint firstItem="A9s-da-nap" firstAttribute="leading" secondItem="2IW-oU-HLV" secondAttribute="leading" id="2E9-CD-9Tw"/>
                             <constraint firstItem="EVy-Wt-5En" firstAttribute="centerY" secondItem="A9s-da-nap" secondAttribute="centerY" id="2O4-Ge-lKN"/>
-                            <constraint firstAttribute="trailing" secondItem="43E-TR-OSz" secondAttribute="trailing" id="ORJ-zz-5Od"/>
                             <constraint firstAttribute="trailing" secondItem="EVy-Wt-5En" secondAttribute="trailing" constant="8" id="VCX-dn-JVo"/>
-                            <constraint firstAttribute="bottom" secondItem="43E-TR-OSz" secondAttribute="bottom" id="YIW-PC-dgZ"/>
-                            <constraint firstItem="43E-TR-OSz" firstAttribute="leading" secondItem="A9s-da-nap" secondAttribute="trailing" id="bpy-jU-MhU"/>
                             <constraint firstItem="EVy-Wt-5En" firstAttribute="leading" secondItem="6l3-ag-Ii0" secondAttribute="trailing" constant="8" id="en9-qQ-E3G"/>
                             <constraint firstAttribute="bottom" secondItem="6l3-ag-Ii0" secondAttribute="bottom" constant="12" id="hYu-lK-2lS"/>
                             <constraint firstItem="6l3-ag-Ii0" firstAttribute="top" secondItem="2IW-oU-HLV" secondAttribute="top" constant="12" id="kyp-NX-Ol1"/>
@@ -1386,21 +1405,21 @@
                 </viewController>
                 <placeholder placeholderIdentifier="IBFirstResponder" id="fcE-Xu-odc" userLabel="First Responder" customClass="UIResponder" sceneMemberID="firstResponder"/>
             </objects>
-            <point key="canvasLocation" x="929" y="-703"/>
+            <point key="canvasLocation" x="928.79999999999995" y="-703.44827586206907"/>
         </scene>
         <!--Elevation Profile View Controller-->
         <scene sceneID="0yF-nr-ALU">
             <objects>
                 <viewController storyboardIdentifier="ElevationProfileViewController" id="d1y-Na-lDm" customClass="ElevationProfileViewController" customModule="Organic_Maps" customModuleProvider="target" sceneMemberID="viewController">
-                    <view key="view" contentMode="scaleToFill" id="7Mx-au-yIa">
+                    <view key="view" contentMode="scaleToFill" ambiguous="YES" id="7Mx-au-yIa">
                         <rect key="frame" x="0.0" y="0.0" width="375" height="319"/>
                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                         <subviews>
-                            <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="jKi-gT-ZfM">
-                                <rect key="frame" x="0.0" y="0.0" width="375" height="176"/>
+                            <view contentMode="scaleToFill" ambiguous="YES" translatesAutoresizingMaskIntoConstraints="NO" id="jKi-gT-ZfM">
+                                <rect key="frame" x="0.0" y="20" width="375" height="156"/>
                                 <subviews>
-                                    <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="jIS-0e-Ztd" customClass="ChartView" customModule="Chart">
-                                        <rect key="frame" x="16" y="0.0" width="343" height="176"/>
+                                    <view contentMode="scaleToFill" ambiguous="YES" translatesAutoresizingMaskIntoConstraints="NO" id="jIS-0e-Ztd" customClass="ChartView" customModule="Chart">
+                                        <rect key="frame" x="16" y="0.0" width="343" height="156"/>
                                         <color key="backgroundColor" systemColor="systemBackgroundColor"/>
                                     </view>
                                 </subviews>
@@ -1413,7 +1432,7 @@
                                     <constraint firstAttribute="height" constant="176" id="utH-YA-2pe"/>
                                 </constraints>
                             </view>
-                            <collectionView clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="scaleToFill" scrollEnabled="NO" showsHorizontalScrollIndicator="NO" showsVerticalScrollIndicator="NO" dataMode="prototypes" translatesAutoresizingMaskIntoConstraints="NO" id="Xc9-ED-V4K">
+                            <collectionView clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="scaleToFill" ambiguous="YES" scrollEnabled="NO" showsHorizontalScrollIndicator="NO" showsVerticalScrollIndicator="NO" dataMode="prototypes" translatesAutoresizingMaskIntoConstraints="NO" id="Xc9-ED-V4K">
                                 <rect key="frame" x="16" y="192" width="343" height="68"/>
                                 <color key="backgroundColor" white="0.0" alpha="0.0" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
                                 <constraints>
@@ -1488,7 +1507,7 @@
                                     </collectionViewCell>
                                 </cells>
                             </collectionView>
-                            <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" horizontalCompressionResistancePriority="250" text="Difficulty" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="FIo-No-CbK">
+                            <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" horizontalCompressionResistancePriority="250" ambiguous="YES" text="Difficulty" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="FIo-No-CbK">
                                 <rect key="frame" x="16" y="281" width="68" height="20.5"/>
                                 <fontDescription key="fontDescription" type="system" pointSize="17"/>
                                 <nil key="textColor"/>
@@ -1498,7 +1517,7 @@
                                     <userDefinedRuntimeAttribute type="string" keyPath="styleName" value="regular14:blackSecondaryText"/>
                                 </userDefinedRuntimeAttributes>
                             </label>
-                            <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="bc9-z0-p88" customClass="DifficultyView" customModule="Organic_Maps" customModuleProvider="target">
+                            <view contentMode="scaleToFill" ambiguous="YES" translatesAutoresizingMaskIntoConstraints="NO" id="bc9-z0-p88" customClass="DifficultyView" customModule="Organic_Maps" customModuleProvider="target">
                                 <rect key="frame" x="91" y="287" width="40" height="10"/>
                                 <color key="backgroundColor" white="0.66666666666666663" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
                                 <constraints>
@@ -1506,7 +1525,7 @@
                                     <constraint firstAttribute="width" constant="40" id="Sor-5l-zjy"/>
                                 </constraints>
                             </view>
-                            <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="1h 10m" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="dQJ-fW-QVh">
+                            <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" ambiguous="YES" text="1h 10m" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="dQJ-fW-QVh">
                                 <rect key="frame" x="301" y="281" width="58" height="20.5"/>
                                 <fontDescription key="fontDescription" type="boldSystem" pointSize="17"/>
                                 <nil key="textColor"/>
@@ -1515,7 +1534,7 @@
                                     <userDefinedRuntimeAttribute type="string" keyPath="styleName" value="bold17:blackPrimaryText"/>
                                 </userDefinedRuntimeAttributes>
                             </label>
-                            <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Time:" textAlignment="right" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="hoy-lg-Wl9">
+                            <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" ambiguous="YES" text="Time:" textAlignment="right" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="hoy-lg-Wl9">
                                 <rect key="frame" x="249" y="280.5" width="43" height="21"/>
                                 <fontDescription key="fontDescription" type="system" pointSize="17"/>
                                 <nil key="textColor"/>
@@ -1525,13 +1544,13 @@
                                     <userDefinedRuntimeAttribute type="string" keyPath="styleName" value="medium14:blackSecondaryText"/>
                                 </userDefinedRuntimeAttributes>
                             </label>
-                            <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="g6D-fD-0Ug">
+                            <button opaque="NO" contentMode="scaleToFill" ambiguous="YES" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="g6D-fD-0Ug">
                                 <rect key="frame" x="133" y="276.5" width="30" height="30"/>
                                 <connections>
                                     <action selector="onExtendedDifficultyButtonPressed:" destination="d1y-Na-lDm" eventType="touchUpInside" id="4zH-m2-OSE"/>
                                 </connections>
                             </button>
-                            <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="S1" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="GPk-XR-oL1" customClass="InsetsLabel" customModule="Organic_Maps" customModuleProvider="target">
+                            <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" ambiguous="YES" text="S1" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="GPk-XR-oL1" customClass="InsetsLabel" customModule="Organic_Maps" customModuleProvider="target">
                                 <rect key="frame" x="138.5" y="281" width="19" height="20.5"/>
                                 <color key="backgroundColor" white="0.66666666666666663" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
                                 <fontDescription key="fontDescription" type="boldSystem" pointSize="17"/>
@@ -1645,26 +1664,13 @@
                                     </label>
                                 </subviews>
                             </stackView>
-                            <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="eZE-Gl-rKQ">
-                                <rect key="frame" x="56" y="99" width="319" height="1"/>
-                                <color key="backgroundColor" systemColor="systemBackgroundColor"/>
-                                <constraints>
-                                    <constraint firstAttribute="height" constant="1" id="mkQ-1n-CMT"/>
-                                </constraints>
-                                <userDefinedRuntimeAttributes>
-                                    <userDefinedRuntimeAttribute type="string" keyPath="styleName" value="Divider"/>
-                                </userDefinedRuntimeAttributes>
-                            </view>
                         </subviews>
                         <viewLayoutGuide key="safeArea" id="hQb-fZ-zig"/>
                         <color key="backgroundColor" systemColor="systemBackgroundColor"/>
                         <constraints>
-                            <constraint firstItem="eZE-Gl-rKQ" firstAttribute="leading" secondItem="lIJ-bh-coX" secondAttribute="leading" id="EAb-Nf-J9m"/>
-                            <constraint firstAttribute="trailing" secondItem="eZE-Gl-rKQ" secondAttribute="trailing" id="IPN-zL-JOb"/>
                             <constraint firstItem="lIJ-bh-coX" firstAttribute="leading" secondItem="Bn7-Ag-wuu" secondAttribute="leading" constant="56" id="WXv-gZ-ygJ"/>
                             <constraint firstAttribute="bottom" secondItem="lIJ-bh-coX" secondAttribute="bottom" constant="12" id="Wcq-WA-Qd8"/>
                             <constraint firstAttribute="trailing" secondItem="lIJ-bh-coX" secondAttribute="trailing" constant="16" id="hw3-UC-uCp"/>
-                            <constraint firstAttribute="bottom" secondItem="eZE-Gl-rKQ" secondAttribute="bottom" id="snF-4v-t08"/>
                             <constraint firstItem="lIJ-bh-coX" firstAttribute="top" secondItem="Bn7-Ag-wuu" secondAttribute="top" constant="12" id="tpq-hf-4gG"/>
                         </constraints>
                         <userDefinedRuntimeAttributes>
@@ -1687,11 +1693,11 @@
             <objects>
                 <viewController storyboardIdentifier="PlacePageHeaderViewController" id="aB1-Yk-7p4" customClass="PlacePageHeaderViewController" customModule="Organic_Maps" customModuleProvider="target" sceneMemberID="viewController">
                     <view key="view" contentMode="scaleToFill" id="xTs-NP-HcT" customClass="PlacePageHeaderView" customModule="Organic_Maps" customModuleProvider="target">
-                        <rect key="frame" x="0.0" y="0.0" width="375" height="59"/>
+                        <rect key="frame" x="0.0" y="0.0" width="375" height="72"/>
                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                         <subviews>
                             <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="spW-XI-KSY" customClass="PlacePageHeaderView" customModule="Organic_Maps" customModuleProvider="target">
-                                <rect key="frame" x="0.0" y="49" width="375" height="10"/>
+                                <rect key="frame" x="0.0" y="62" width="375" height="10"/>
                                 <color key="backgroundColor" systemColor="systemBackgroundColor"/>
                                 <constraints>
                                     <constraint firstAttribute="height" constant="10" id="aON-3f-qnX"/>
@@ -1701,10 +1707,10 @@
                                 </userDefinedRuntimeAttributes>
                             </view>
                             <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="fqh-H3-eji" customClass="PlacePageHeaderView" customModule="Organic_Maps" customModuleProvider="target">
-                                <rect key="frame" x="0.0" y="0.0" width="375" height="59"/>
+                                <rect key="frame" x="0.0" y="20" width="375" height="52"/>
                                 <subviews>
                                     <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="Gdy-g5-gbM">
-                                        <rect key="frame" x="0.0" y="0.0" width="329" height="59"/>
+                                        <rect key="frame" x="0.0" y="0.0" width="329" height="52"/>
                                         <color key="backgroundColor" white="0.0" alpha="0.0" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
                                     </view>
                                     <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="3HJ-WD-nF5">
@@ -1722,12 +1728,12 @@
                                         </userDefinedRuntimeAttributes>
                                     </view>
                                     <label opaque="NO" userInteractionEnabled="NO" contentMode="left" verticalHuggingPriority="750" text="Хинкальная" textAlignment="natural" lineBreakMode="tailTruncation" numberOfLines="0" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="lR4-to-4wX">
-                                        <rect key="frame" x="16" y="28" width="313" height="24"/>
+                                        <rect key="frame" x="16" y="28" width="313" height="17"/>
                                         <fontDescription key="fontDescription" type="system" weight="medium" pointSize="20"/>
                                         <nil key="textColor"/>
                                         <nil key="highlightedColor"/>
                                     </label>
-                                    <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="yZT-ea-Kac">
+                                    <button opaque="NO" contentMode="scaleToFill" horizontalHuggingPriority="251" horizontalCompressionResistancePriority="1000" contentHorizontalAlignment="center" contentVerticalAlignment="center" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="yZT-ea-Kac">
                                         <rect key="frame" x="333" y="12" width="30" height="30"/>
                                         <constraints>
                                             <constraint firstAttribute="width" constant="30" id="IYz-Cb-KoJ"/>
@@ -1742,7 +1748,7 @@
                                         </connections>
                                     </button>
                                     <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="DHT-jj-Idk">
-                                        <rect key="frame" x="0.0" y="58" width="375" height="1"/>
+                                        <rect key="frame" x="0.0" y="51" width="375" height="1"/>
                                         <color key="backgroundColor" systemColor="systemBackgroundColor"/>
                                         <constraints>
                                             <constraint firstAttribute="height" constant="1" id="9IC-go-aaZ"/>
@@ -1787,7 +1793,7 @@
                             <constraint firstItem="fqh-H3-eji" firstAttribute="bottom" secondItem="My8-Gu-lky" secondAttribute="bottom" id="zkf-gE-4vs"/>
                         </constraints>
                     </view>
-                    <size key="freeformSize" width="375" height="59"/>
+                    <size key="freeformSize" width="375" height="72"/>
                     <connections>
                         <outlet property="expandView" destination="Gdy-g5-gbM" id="rzi-mb-hUi"/>
                         <outlet property="headerView" destination="fqh-H3-eji" id="Z2K-Wd-hRO"/>
@@ -1798,7 +1804,7 @@
                 </viewController>
                 <placeholder placeholderIdentifier="IBFirstResponder" id="0Ew-Om-aj3" userLabel="First Responder" customClass="UIResponder" sceneMemberID="firstResponder"/>
             </objects>
-            <point key="canvasLocation" x="928.79999999999995" y="-1147.3763118440781"/>
+            <point key="canvasLocation" x="928.79999999999995" y="-1141.529235382309"/>
         </scene>
     </scenes>
     <resources>

--- a/iphone/Maps/UI/PlacePage/PlacePageLayout/Layouts/IPlacePageLayout.swift
+++ b/iphone/Maps/UI/PlacePage/PlacePageLayout/Layouts/IPlacePageLayout.swift
@@ -23,8 +23,8 @@ enum PlacePageState {
 
 protocol IPlacePageLayout: AnyObject {
   var presenter: PlacePagePresenterProtocol? { get set }
-  var header: PlacePageHeaderViewController? { get }
-  var viewControllers: [UIViewController] { get }
+  var headerViewControllers: [UIViewController] { get }
+  var bodyViewControllers: [UIViewController] { get }
   var actionBar: ActionBarViewController? { get }
   var navigationBar: UIViewController? { get }
 

--- a/iphone/Maps/UI/PlacePage/PlacePageLayout/Layouts/PlacePageCommonLayout.swift
+++ b/iphone/Maps/UI/PlacePage/PlacePageLayout/Layouts/PlacePageCommonLayout.swift
@@ -1,4 +1,5 @@
 class PlacePageCommonLayout: NSObject, IPlacePageLayout {
+  
   private lazy var distanceFormatter: MKDistanceFormatter = {
     let formatter =  MKDistanceFormatter()
     formatter.unitStyle = .abbreviated
@@ -19,7 +20,11 @@ class PlacePageCommonLayout: NSObject, IPlacePageLayout {
 
   fileprivate var lastLocation: CLLocation?
 
-  lazy var viewControllers: [UIViewController] = {
+  lazy var headerViewControllers: [UIViewController] = {
+    [headerViewController, previewViewController]
+  }()
+
+  lazy var bodyViewControllers: [UIViewController] = {
     return configureViewControllers()
   }()
 
@@ -30,6 +35,10 @@ class PlacePageCommonLayout: NSObject, IPlacePageLayout {
   var navigationBar: UIViewController? {
     return placePageNavigationViewController
   }
+  
+  lazy var headerViewController: PlacePageHeaderViewController = {
+    PlacePageHeaderBuilder.build(data: placePageData.previewData, delegate: interactor, headerType: .flexible)
+  }()
 
   lazy var previewViewController: PlacePagePreviewViewController = {
     let vc = storyboard.instantiateViewController(ofType: PlacePagePreviewViewController.self)
@@ -75,10 +84,6 @@ class PlacePageCommonLayout: NSObject, IPlacePageLayout {
     return vc
   } ()
 
-  lazy var header: PlacePageHeaderViewController? = {
-    return PlacePageHeaderBuilder.build(data: placePageData.previewData, delegate: interactor, headerType: .flexible)
-  } ()
-
   lazy var placePageNavigationViewController: PlacePageHeaderViewController = {
     return PlacePageHeaderBuilder.build(data: placePageData.previewData, delegate: interactor, headerType: .fixed)
   } ()
@@ -91,7 +96,6 @@ class PlacePageCommonLayout: NSObject, IPlacePageLayout {
 
   private func configureViewControllers() -> [UIViewController] {
     var viewControllers = [UIViewController]()
-    viewControllers.append(previewViewController)
     viewControllers.append(wikiDescriptionViewController)
     if let wikiDescriptionHtml = placePageData.wikiDescriptionHtml {
       wikiDescriptionViewController.descriptionHtml = wikiDescriptionHtml
@@ -183,9 +187,9 @@ extension PlacePageCommonLayout {
       bookmarkViewController.bookmarkData = bookmarkData
       isBookmark = true
     }
-    if let title = placePageData.previewData.title {
+    if let title = placePageData.previewData.title, let headerViewController = headerViewControllers.compactMap({ $0 as? PlacePageHeaderViewController }).first {
       let secondaryTitle = placePageData.previewData.secondaryTitle
-      header?.setTitle(title, secondaryTitle: secondaryTitle)
+      headerViewController.setTitle(title, secondaryTitle: secondaryTitle)
       placePageNavigationViewController.setTitle(title, secondaryTitle: secondaryTitle)
     }
     self.presenter?.layoutIfNeeded()

--- a/iphone/Maps/UI/PlacePage/PlacePageLayout/Layouts/PlacePageElevationLayout.swift
+++ b/iphone/Maps/UI/PlacePage/PlacePageLayout/Layouts/PlacePageElevationLayout.swift
@@ -4,7 +4,7 @@ class PlacePageElevationLayout: IPlacePageLayout {
   private let storyboard: UIStoryboard
   weak var presenter: PlacePagePresenterProtocol?
 
-  lazy var viewControllers: [UIViewController] = {
+  lazy var bodyViewControllers: [UIViewController] = {
     return configureViewControllers()
   }()
 
@@ -14,8 +14,8 @@ class PlacePageElevationLayout: IPlacePageLayout {
     return placePageNavigationViewController
   }
 
-  lazy var header: PlacePageHeaderViewController? = {
-    return PlacePageHeaderBuilder.build(data: placePageData.previewData, delegate: interactor, headerType: .flexible)
+  lazy var headerViewControllers: [UIViewController] = {
+    return [PlacePageHeaderBuilder.build(data: placePageData.previewData, delegate: interactor, headerType: .flexible)]
   } ()
 
   lazy var placePageNavigationViewController: PlacePageHeaderViewController = {


### PR DESCRIPTION
Closes https://github.com/organicmaps/organicmaps/issues/5088
Closes #3454

Problems:
1. **Unexpected grey spacing**
Bug caused by changing spacings in UISackView header in PlacePageViewController
```swift
  func addHeader(_ headerViewController: UIViewController) {
    addToStack(headerViewController)
    // TODO: workaround. Custom spacing isn't working if visibility of any arranged subview
    // changes after setting custom spacing
    DispatchQueue.main.async {
      self.stackView.setCustomSpacing(0, after: headerViewController.view)
    }
  }
```
Solving:
Change layout of header. Now place page header is array of VCs (see IPlacePageLayout protocol) in stack view with zero spacing and proper layout. And every PlacePageLayout object should build content of a header.
No runtime changing of spacings.

2. **unexpected "double line"** 
Separators in PlacePageInfo VC's stack view are adding on every view in storyboard manually so there is no option to disable current separator and this cause doubling in some places. 
Solving:
Remove separators from VC's views is SB and add them programmatically only when view is added to stack view. So UIStackView now behave like UITableView in case of separators making:
```swift
  private func addToStack(_ viewController: UIViewController) {
    addChild(viewController)
    stackView.addArrangedSubview(viewController.view,
                                 withSeparator: .default.withInsets(UIEdgeInsets(top: 0, left: 56, bottom: 0, right: 0)))
    viewController.didMove(toParent: self)
  }
```
![IMG_2260](https://github.com/organicmaps/organicmaps/assets/79797627/e175aa20-4373-4452-8480-012b269076d7)

3. **overly large space after Wikipedia article and no lines at top and bottom of article**
Solving: fix contentHuggingPriority for wiki's UITextView and add top/bottom separators
![image](https://github.com/organicmaps/organicmaps/assets/79797627/571ce0ce-fe4f-4c48-a0db-737522cf6813)
4. New bug was found and fixed: when user tap on "more" in wiki info VC to see additional info, and than goes back, style of wiki info became broken (see gif).
![Simulator Screen Recording - iPhone 14 Pro Max - 2023-10-04 at 13 42 58](https://github.com/organicmaps/organicmaps/assets/79797627/2a726c62-595a-4bfb-9c94-c982111cc404)

This happens because there was some User Defined Runtime Attributes set in storyboard and they override styles at runtime.
<img width="324" alt="image" src="https://github.com/organicmaps/organicmaps/assets/79797627/67ce7ef7-cb92-4fe1-abdf-deacd80cdc19">