### PR TITLE
[android] Fix a crash in processNavigation() called after onDestroy()

### DIFF
--- a/android/app/src/main/java/app/organicmaps/SplashActivity.java
+++ b/android/app/src/main/java/app/organicmaps/SplashActivity.java
@@ -172,6 +172,12 @@ public class SplashActivity extends AppCompatActivity
   @SuppressWarnings({"unused", "unchecked"})
   public void processNavigation()
   {
+    if (isDestroyed())
+    {
+      Logger.w(TAG, "Ignore late callback from core because activity is already destroyed");
+      return;
+    }
+
     Intent input = getIntent();
     Intent result = new Intent(this, DownloadResourcesLegacyActivity.class);
     if (input != null)


### PR DESCRIPTION
```
Exception java.lang.NullPointerException: Attempt to invoke virtual method 'void androidx.activity.result.ActivityResultLauncher.launch(java.lang.Object)' on a null object reference
  at app.organicmaps.SplashActivity.processNavigation (SplashActivity.java)
  at app.organicmaps.MwmApplication.nativeProcessTask (MwmApplication.java)
  at app.organicmaps.MwmApplication.lambda$forwardToMainThread$0 (MwmApplication.java)
  at android.os.Handler.handleCallback (Handler.java:809)
  at android.os.Handler.dispatchMessage (Handler.java:102)
  at android.os.Looper.loop (Looper.java:166)
  at android.app.ActivityThread.main (ActivityThread.java:7555)
  at java.lang.reflect.Method.invoke
  at com.android.internal.os.RuntimeInit$MethodAndArgsCaller.run (RuntimeInit.java:469)
  at com.android.internal.os.ZygoteInit.main (ZygoteInit.java:963)
```

Fixes #6190