### PR TITLE
[styles] Display address nodes from z17

### DIFF
--- a/indexer/scales.hpp
+++ b/indexer/scales.hpp
@@ -29,7 +29,7 @@ namespace scales
   /// Default scale in adding-new-place mode.
   constexpr int GetAddNewPlaceScale() { return 18; }
   /// Lower scale when standalone point housenumbers (of building-address type) become visible.
-  constexpr int GetPointHousenumbersScale() { return 18; }
+  constexpr int GetPointHousenumbersScale() { return 17; }
 
   int GetMinAllowableIn3dScale();
 


### PR DESCRIPTION
closes #6182
improves #5976

- This PR displays address nodes from z17 on to make the rendering of address nodes more consistent with the rendering of address areas.

Current rendering for areas displays "small" buildings at z18, "medium" at z17 and "big" ones at z16. For nodes, where the size of the coresponding building is unknown, it is now assumed that they are "medium" sized instead of "small". 
Nodes are often used for big residential buildings with several entrances, so mapping as nodes is no indicator for low importance.

| Now | Before |
|--------|--------|
| ![Screenshot_2023-10-05-17-07-44-472_app organicmaps beta](https://github.com/organicmaps/organicmaps/assets/79519062/4aef6aa4-5b2c-40ac-9ecf-686f73a61241) | ![Screenshot_2023-10-05-15-47-03-274_app organicmaps](https://github.com/organicmaps/organicmaps/assets/79519062/afbe618b-2f0d-49da-96d1-ce43d78ae867) | 

(https://www.openstreetmap.org/way/205359465#map=17/52.58913/13.41054)