### PR TITLE
[drape] Refactor apply_feature_functors

### DIFF
--- a/drape_frontend/apply_feature_functors.cpp
+++ b/drape_frontend/apply_feature_functors.cpp
@@ -222,7 +222,7 @@ std::string GetRoadShieldSymbolName(ftypes::RoadShield const & shield, double fo
     result = shield.m_name.size() <= 2 ? "shield-us-hw-thin" : "shield-us-hw-wide";
   else
   {
-    ASSERT(false, ());
+    ASSERT(false, ("This shield type doesn't support symbols:", shield.m_type));
   }
 
   if (fontScale > 1.0)
@@ -366,8 +366,8 @@ void BaseApplyFeature::FillCommonParams(CommonOverlayViewParams & p) const
 }
 
 void ApplyPointFeature::ExtractCaptionParams(CaptionDefProto const * primaryProto,
-                                            CaptionDefProto const * secondaryProto,
-                                            TextViewParams & params) const
+                                             CaptionDefProto const * secondaryProto,
+                                             TextViewParams & params) const
 {
   FillCommonParams(params);
   params.m_depthLayer = DepthLayer::OverlayLayer;
@@ -380,7 +380,7 @@ void ApplyPointFeature::ExtractCaptionParams(CaptionDefProto const * primaryProt
   CaptionDefProtoToFontDecl(primaryProto, decl);
   titleDecl.m_primaryTextFont = decl;
   titleDecl.m_anchor = GetAnchor(primaryProto->offset_x(), primaryProto->offset_y());
-  // TODO: remove offsets processing as de-facto "text-offset: *" is used to define anchors only.
+  // TODO(pastk) : remove offsets processing as de-facto "text-offset: *" is used to define anchors only.
   titleDecl.m_primaryOffset = GetOffset(primaryProto->offset_x(), primaryProto->offset_y());
   titleDecl.m_primaryOptional = primaryProto->is_optional();
 
@@ -424,7 +424,7 @@ double BaseApplyFeature::PriorityToDepth(int priority, drule::rule_type_t ruleTy
   {
     // Note we don't adjust priorities of "point-styles" according to layer=*,
     // because their priorities are used for displacement logic only.
-    /// @todo we might want to hide e.g. a trash bin under man_made=bridge or a bench on underground railway station?
+    /// @todo(pastk) we might want to hide e.g. a trash bin under man_made=bridge or a bench on underground railway station?
 
     // Check overlays priorities range.
     ASSERT(-drule::kOverlaysMaxPriority <= depth && depth < drule::kOverlaysMaxPriority, (depth, m_f.GetID()));
@@ -564,7 +564,7 @@ void ApplyAreaFeature::operator()(m2::PointD const & p1, m2::PointD const & p2, 
 
   m2::PointD const v1 = p2 - p1;
   m2::PointD const v2 = p3 - p1;
-  //TODO : degenerate triangles filtering should be done in the generator.
+  //TODO(pastk) : degenerate triangles filtering should be done in the generator.
   // ASSERT(!v1.IsAlmostZero() && !v2.IsAlmostZero(), ());
   if (v1.IsAlmostZero() || v2.IsAlmostZero())
     return;
@@ -572,7 +572,7 @@ void ApplyAreaFeature::operator()(m2::PointD const & p1, m2::PointD const & p2, 
   double const crossProduct = m2::CrossProduct(v1.Normalize(), v2.Normalize());
   double constexpr kEps = 1e-7;
   // ASSERT_GREATER_OR_EQUAL(fabs(crossProduct), kEps, (fabs(crossProduct), p1, p2, p3, m_f.DebugString(19, true)));
-  // TODO : e.g. a landuse-meadow has a following triangle with two identical points:
+  // TODO(pastk) : e.g. a landuse-meadow has a following triangle with two identical points:
   // m2::Point<d>(8.5829683287662987823, 53.929641499591184584)
   // m2::Point<d>(8.5830675705005887721, 53.930025055483156393)
   // m2::Point<d>(8.5830675705005887721, 53.930025055483156393)
@@ -597,7 +597,7 @@ void ApplyAreaFeature::ProcessBuildingPolygon(m2::PointD const & p1, m2::PointD 
 {
   // For building we must filter degenerate polygons because now we have to reconstruct
   // building outline by bunch of polygons.
-  // TODO : filter degenerates in the generator.(see a TODO above).
+  // TODO(pastk) : filter degenerates in the generator.(see a TODO above).
   m2::PointD const v1 = p2 - p1;
   m2::PointD const v2 = p3 - p1;
   if (v1.IsAlmostZero() || v2.IsAlmostZero())
@@ -636,7 +636,7 @@ int ApplyAreaFeature::GetIndex(m2::PointD const & pt)
 {
   for (size_t i = 0; i < m_points.size(); i++)
   {
-    // TODO : should be possible to use exact match.
+    // TODO(pastk) : should be possible to use exact match.
     if (pt.EqualDxDy(m_points[i], mercator::kPointEqualityEps))
       return static_cast<int>(i);
   }
@@ -672,7 +672,7 @@ m2::PointD ApplyAreaFeature::CalculateNormal(m2::PointD const & p1, m2::PointD c
 void ApplyAreaFeature::BuildEdges(int vertexIndex1, int vertexIndex2, int vertexIndex3, bool twoSide)
 {
   // Check if triangle is degenerate.
-  // TODO : filter degenerates in the generator.
+  // TODO(pastk) : filter degenerates in the generator.
   if (vertexIndex1 == vertexIndex2 || vertexIndex2 == vertexIndex3 || vertexIndex1 == vertexIndex3)
     return;
 
@@ -779,7 +779,7 @@ ApplyLineFeatureGeometry::ApplyLineFeatureGeometry(TileKey const & tileKey, TIns
                                                    FeatureType & f, double currentScaleGtoP)
   : TBase(tileKey, insertShape, f, CaptionDescription())
   , m_currentScaleGtoP(currentScaleGtoP)
-  // TODO: calculate just once in the RuleDrawer.
+  // TODO(pastk) : calculate just once in the RuleDrawer.
   , m_minSegmentSqrLength(base::Pow2(4.0 * df::VisualParams::Instance().GetVisualScale() / currentScaleGtoP))
   , m_simplify(tileKey.m_zoomLevel >= 10 && tileKey.m_zoomLevel <= 12)
 {
@@ -821,7 +821,7 @@ void ApplyLineFeatureGeometry::ProcessLineRules(Stylist::LineRulesT const & line
   if (!ftypes::IsIsolineChecker::Instance()(m_f))
   {
     // A line crossing the tile several times will be split in several parts.
-    // TODO : use feature's pre-calculated limitRect when possible.
+    // TODO(pastk) : use feature's pre-calculated limitRect when possible.
     m_clippedSplines = m2::ClipSplineByRect(m_tileRect, m_spline);
   }
   else

--- a/drape_frontend/apply_feature_functors.cpp
+++ b/drape_frontend/apply_feature_functors.cpp
@@ -13,7 +13,6 @@
 
 #include "editor/osm_editor.hpp"
 
-#include "indexer/drawing_rules.hpp"
 #include "indexer/drules_include.hpp"
 #include "indexer/feature_source.hpp"
 #include "indexer/map_style_reader.hpp"
@@ -37,7 +36,6 @@
 #include <limits>
 #include <map>
 #include <mutex>
-
 
 namespace df
 {
@@ -119,11 +117,10 @@ private:
 };
 #endif
 
-void ExtractLineParams(::LineRuleProto const * lineRule, df::LineViewParams & params)
+void ExtractLineParams(LineRuleProto const * lineRule, LineViewParams & params)
 {
   double const scale = df::VisualParams::Instance().GetVisualScale();
   params.m_color = ToDrapeColor(lineRule->color());
-  ASSERT_GREATER(lineRule->width(), 0, ("Zero width line (no pathsym)"));
   params.m_width = static_cast<float>(std::max(lineRule->width() * scale, 1.0));
 
   if (lineRule->has_dashdot())
@@ -217,13 +214,18 @@ bool IsSymbolRoadShield(ftypes::RoadShield const & shield)
 
 std::string GetRoadShieldSymbolName(ftypes::RoadShield const & shield, double fontScale)
 {
+  ASSERT(IsSymbolRoadShield(shield), ());
   std::string result = "";
   if (shield.m_type == ftypes::RoadShieldType::US_Interstate)
     result = shield.m_name.size() <= 2 ? "shield-us-i-thin" : "shield-us-i-wide";
   else if (shield.m_type == ftypes::RoadShieldType::US_Highway)
     result = shield.m_name.size() <= 2 ? "shield-us-hw-thin" : "shield-us-hw-wide";
+  else
+  {
+    ASSERT(false, ());
+  }
 
-  if (!result.empty() && fontScale > 1.0)
+  if (fontScale > 1.0)
     result += "-scaled";
 
   return result;
@@ -306,6 +308,7 @@ dp::Anchor GetShieldAnchor(uint8_t shieldIndex, uint8_t shieldCount)
       else if (shieldIndex == 2) return dp::RightTop;
       return dp::LeftTop;
   }
+  // A single shield.
   return dp::Center;
 }
 
@@ -355,10 +358,22 @@ BaseApplyFeature::BaseApplyFeature(TileKey const & tileKey, TInsertShapeFn const
   ASSERT(m_insertShape != nullptr, ());
 }
 
-void BaseApplyFeature::ExtractCaptionParams(CaptionDefProto const * primaryProto,
+void BaseApplyFeature::FillCommonParams(CommonOverlayViewParams & p) const
+{
+  p.m_rank = m_f.GetRank();
+  p.m_tileCenter = m_tileRect.Center();
+  p.m_featureId = m_f.GetID();
+}
+
+void ApplyPointFeature::ExtractCaptionParams(CaptionDefProto const * primaryProto,
                                             CaptionDefProto const * secondaryProto,
                                             TextViewParams & params) const
 {
+  FillCommonParams(params);
+  params.m_depthLayer = DepthLayer::OverlayLayer;
+  params.m_depthTestEnabled = false;
+  params.m_posZ = m_posZ;
+
   auto & titleDecl = params.m_titleDecl;
 
   dp::FontDecl decl;
@@ -421,93 +436,38 @@ double BaseApplyFeature::PriorityToDepth(int priority, drule::rule_type_t ruleTy
 }
 
 ApplyPointFeature::ApplyPointFeature(TileKey const & tileKey, TInsertShapeFn const & insertShape, FeatureType & f,
-                                     CaptionDescription const & captions, float posZ)
+                                     CaptionDescription const & captions)
   : TBase(tileKey, insertShape, f, captions)
-  , m_posZ(posZ)
-  , m_symbolDepth(dp::kMinDepth)
 {}
 
-void ApplyPointFeature::operator()(m2::PointD const & point, bool hasArea)
+void ApplyPointFeature::ProcessPointRules(SymbolRuleProto const * symbolRule, CaptionRuleProto const * captionRule,
+                                          CaptionRuleProto const * houseNumberRule, m2::PointD const & centerPoint,
+                                          ref_ptr<dp::TextureManager> texMng)
 {
-  m_hasArea = hasArea;
-  m_centerPoint = point;
-
   // TODO: This is only one place of cross-dependency with Editor.
   auto const & editor = osm::Editor::Instance();
   auto const featureStatus = editor.GetFeatureStatus(m_f.GetID());
-  m_createdByEditor = featureStatus == FeatureStatus::Created;
-  m_obsoleteInEditor = featureStatus == FeatureStatus::Obsolete;
-}
+  bool const createdByEditor = featureStatus == FeatureStatus::Created;
+  bool const obsoleteInEditor = featureStatus == FeatureStatus::Obsolete;
 
-void ApplyPointFeature::ProcessPointRule(drule::BaseRule const * rule, bool isHouseNumber)
-{
-  SymbolRuleProto const * symRule = rule->GetSymbol();
-  if (symRule)
-  {
-    m_symbolDepth = PriorityToDepth(symRule->priority(), drule::symbol, 0);
-    m_symbolRule = symRule;
-    return;
-  }
-
-  CaptionDefProto const * capRule = rule->GetCaption(0);
-  if (capRule)
-  {
-    CaptionDefProto const * auxRule = rule->GetCaption(1);
-    TextViewParams params;
-
-    if (isHouseNumber)
-      params.m_titleDecl.m_primaryText = m_captions.GetHouseNumberText();
-    else
-    {
-      params.m_titleDecl.m_primaryText = m_captions.GetMainText();
-      if (auxRule != nullptr)
-        params.m_titleDecl.m_secondaryText = m_captions.GetAuxText();
-    }
-    ASSERT(!params.m_titleDecl.m_primaryText.empty(), ());
-
-    ExtractCaptionParams(capRule, auxRule, params);
-    params.m_depth = PriorityToDepth(rule->GetCaptionsPriority(), drule::caption, 0);
-    params.m_featureId = m_f.GetID();
-    params.m_tileCenter = m_tileRect.Center();
-    params.m_depthLayer = DepthLayer::OverlayLayer;
-    params.m_depthTestEnabled = false;
-    params.m_rank = m_f.GetRank();
-    params.m_posZ = m_posZ;
-    params.m_hasArea = m_hasArea;
-    params.m_createdByEditor = m_createdByEditor;
-
-    if (isHouseNumber)
-      m_hnParams = params;
-    else
-      m_textParams = params;
-  }
-}
-
-void ApplyPointFeature::Finish(ref_ptr<dp::TextureManager> texMng)
-{
   m2::PointF symbolSize(0.0f, 0.0f);
 
-  bool const hasIcon = m_symbolRule != nullptr;
-  auto const & visualParams = df::VisualParams::Instance();
-  double const mainScale = visualParams.GetVisualScale();
-  if (hasIcon)
+  if (symbolRule)
   {
-    double const poiExtendScale = visualParams.GetPoiExtendScale();
-
     PoiSymbolViewParams params;
-    params.m_featureId = m_f.GetID();
-    params.m_tileCenter = m_tileRect.Center();
-    params.m_depthTestEnabled = false;
-    params.m_depth = m_symbolDepth;
+    FillCommonParams(params);
     params.m_depthLayer = DepthLayer::OverlayLayer;
-    params.m_rank = m_f.GetRank();
-    params.m_symbolName = m_symbolRule->name();
-    ASSERT_GREATER_OR_EQUAL(m_symbolRule->min_distance(), 0, ());
-    params.m_extendingSize = static_cast<uint32_t>(mainScale * m_symbolRule->min_distance() * poiExtendScale);
+    params.m_depthTestEnabled = false;
+    params.m_depth = PriorityToDepth(symbolRule->priority(), drule::symbol, 0);
+    params.m_symbolName = symbolRule->name();
+    ASSERT_GREATER_OR_EQUAL(symbolRule->min_distance(), 0, ());
+    auto const & vp = df::VisualParams::Instance();
+    params.m_extendingSize = static_cast<uint32_t>(vp.GetVisualScale() * symbolRule->min_distance() *
+                                                   vp.GetPoiExtendScale());
     params.m_posZ = m_posZ;
-    params.m_hasArea = m_hasArea;
-    params.m_prioritized = m_createdByEditor;
-    if (m_obsoleteInEditor)
+    params.m_hasArea = HasArea();
+    params.m_prioritized = createdByEditor;
+    if (obsoleteInEditor)
       params.m_maskColor = kPoiDeletedMaskColor;
 
     dp::TextureManager::SymbolRegion region;
@@ -515,43 +475,66 @@ void ApplyPointFeature::Finish(ref_ptr<dp::TextureManager> texMng)
     symbolSize = region.GetPixelSize();
 
     if (region.IsValid())
-      m_insertShape(make_unique_dp<PoiSymbolShape>(m_centerPoint, params, m_tileKey, 0 /* textIndex */));
+      m_insertShape(make_unique_dp<PoiSymbolShape>(centerPoint, params, m_tileKey, 0 /* textIndex */));
     else
       LOG(LERROR, ("Style error. Symbol name must be valid for feature", m_f.GetID()));
   }
 
-  bool const hasText = !m_textParams.m_titleDecl.m_primaryText.empty();
-  bool const hasHouseNumber = !m_hnParams.m_titleDecl.m_primaryText.empty();
-  if (hasText)
+  if (captionRule)
   {
+    TextViewParams params;
+    CaptionDefProto const * capRule = &captionRule->primary();
+    CaptionDefProto const * auxRule = captionRule->has_secondary() ? &captionRule->secondary() : nullptr;
+
+    params.m_titleDecl.m_primaryText = m_captions.GetMainText();
+    if (auxRule)
+      params.m_titleDecl.m_secondaryText = m_captions.GetAuxText();
+    ASSERT(!params.m_titleDecl.m_primaryText.empty(), ());
+
+    ExtractCaptionParams(capRule, auxRule, params);
+    params.m_depth = PriorityToDepth(captionRule->priority(), drule::caption, 0);
+    params.m_hasArea = HasArea();
+    params.m_createdByEditor = createdByEditor;
+
     /// @todo Hardcoded styles-bug patch. The patch is ok, but probably should enhance (or fire assert) styles?
     /// @see https://github.com/organicmaps/organicmaps/issues/2573
-    if ((hasIcon || hasHouseNumber) && m_textParams.m_titleDecl.m_anchor == dp::Anchor::Center)
+    if ((symbolRule || houseNumberRule) && params.m_titleDecl.m_anchor == dp::Anchor::Center)
     {
-      ASSERT(!hasIcon, ("A `text-offset: *` is not set in styles.", m_f.GetID(), m_textParams.m_titleDecl.m_primaryText));
-      m_textParams.m_titleDecl.m_anchor = GetAnchor(0, 1);
+      ASSERT(!symbolRule, ("A `text-offset: *` is not set in styles.", m_f.GetID(), params.m_titleDecl.m_primaryText));
+      params.m_titleDecl.m_anchor = GetAnchor(0, 1);
     }
 
-    m_textParams.m_startOverlayRank = hasIcon ? dp::OverlayRank1 : dp::OverlayRank0;
-    auto shape = make_unique_dp<TextShape>(m_centerPoint, m_textParams, m_tileKey, symbolSize,
+    params.m_startOverlayRank = symbolRule ? dp::OverlayRank1 : dp::OverlayRank0;
+    auto shape = make_unique_dp<TextShape>(centerPoint, params, m_tileKey, symbolSize,
                                            m2::PointF(0.0f, 0.0f) /* symbolOffset */,
                                            dp::Center /* symbolAnchor */, 0 /* textIndex */);
     m_insertShape(std::move(shape));
   }
 
-  if (hasHouseNumber)
+  if (houseNumberRule)
   {
+    TextViewParams params;
+    CaptionDefProto const * capRule = &houseNumberRule->primary();
+
+    params.m_titleDecl.m_primaryText = m_captions.GetHouseNumberText();
+    ASSERT(!params.m_titleDecl.m_primaryText.empty(), ());
+
+    ExtractCaptionParams(capRule, nullptr, params);
+    params.m_depth = PriorityToDepth(houseNumberRule->priority(), drule::caption, 0);
+    params.m_hasArea = HasArea();
+    params.m_createdByEditor = createdByEditor;
+
     // If icon or main text exists then put housenumber above them.
-    if (hasIcon || hasText)
+    if (symbolRule || captionRule)
     {
-      m_hnParams.m_titleDecl.m_anchor = GetAnchor(0, -1);
-      if (hasIcon)
+      params.m_titleDecl.m_anchor = GetAnchor(0, -1);
+      if (symbolRule)
       {
-        m_hnParams.m_titleDecl.m_primaryOptional = true;
-        m_hnParams.m_startOverlayRank = dp::OverlayRank1;
+        params.m_titleDecl.m_primaryOptional = true;
+        params.m_startOverlayRank = dp::OverlayRank1;
       }
     }
-    m_insertShape(make_unique_dp<TextShape>(m_centerPoint, m_hnParams, m_tileKey, symbolSize,
+    m_insertShape(make_unique_dp<TextShape>(centerPoint, params, m_tileKey, symbolSize,
                                             m2::PointF(0.0f, 0.0f) /* symbolOffset */,
                                             dp::Center /* symbolAnchor */, 0 /* textIndex */));
   }
@@ -561,12 +544,14 @@ ApplyAreaFeature::ApplyAreaFeature(TileKey const & tileKey, TInsertShapeFn const
                                    FeatureType & f, double currentScaleGtoP, bool isBuilding,
                                    bool skipAreaGeometry, float minPosZ, float posZ,
                                    CaptionDescription const & captions)
-  : TBase(tileKey, insertShape, f, captions, posZ)
+  : TBase(tileKey, insertShape, f, captions)
   , m_minPosZ(minPosZ)
   , m_isBuilding(isBuilding)
   , m_skipAreaGeometry(skipAreaGeometry)
   , m_currentScaleGtoP(currentScaleGtoP)
-{}
+{
+  m_posZ = posZ;
+}
 
 void ApplyAreaFeature::operator()(m2::PointD const & p1, m2::PointD const & p2, m2::PointD const & p3)
 {
@@ -579,11 +564,18 @@ void ApplyAreaFeature::operator()(m2::PointD const & p1, m2::PointD const & p2, 
 
   m2::PointD const v1 = p2 - p1;
   m2::PointD const v2 = p3 - p1;
+  //TODO : degenerate triangles filtering should be done in the generator.
+  // ASSERT(!v1.IsAlmostZero() && !v2.IsAlmostZero(), ());
   if (v1.IsAlmostZero() || v2.IsAlmostZero())
     return;
 
   double const crossProduct = m2::CrossProduct(v1.Normalize(), v2.Normalize());
   double constexpr kEps = 1e-7;
+  // ASSERT_GREATER_OR_EQUAL(fabs(crossProduct), kEps, (fabs(crossProduct), p1, p2, p3, m_f.DebugString(19, true)));
+  // TODO : e.g. a landuse-meadow has a following triangle with two identical points:
+  // m2::Point<d>(8.5829683287662987823, 53.929641499591184584)
+  // m2::Point<d>(8.5830675705005887721, 53.930025055483156393)
+  // m2::Point<d>(8.5830675705005887721, 53.930025055483156393)
   if (fabs(crossProduct) < kEps)
     return;
 
@@ -605,6 +597,7 @@ void ApplyAreaFeature::ProcessBuildingPolygon(m2::PointD const & p1, m2::PointD 
 {
   // For building we must filter degenerate polygons because now we have to reconstruct
   // building outline by bunch of polygons.
+  // TODO : filter degenerates in the generator.(see a TODO above).
   m2::PointD const v1 = p2 - p1;
   m2::PointD const v2 = p3 - p1;
   if (v1.IsAlmostZero() || v2.IsAlmostZero())
@@ -643,6 +636,7 @@ int ApplyAreaFeature::GetIndex(m2::PointD const & pt)
 {
   for (size_t i = 0; i < m_points.size(); i++)
   {
+    // TODO : should be possible to use exact match.
     if (pt.EqualDxDy(m_points[i], mercator::kPointEqualityEps))
       return static_cast<int>(i);
   }
@@ -678,6 +672,7 @@ m2::PointD ApplyAreaFeature::CalculateNormal(m2::PointD const & p1, m2::PointD c
 void ApplyAreaFeature::BuildEdges(int vertexIndex1, int vertexIndex2, int vertexIndex3, bool twoSide)
 {
   // Check if triangle is degenerate.
+  // TODO : filter degenerates in the generator.
   if (vertexIndex1 == vertexIndex2 || vertexIndex2 == vertexIndex3 || vertexIndex1 == vertexIndex3)
     return;
 
@@ -726,66 +721,76 @@ void ApplyAreaFeature::CalculateBuildingOutline(bool calculateNormals, BuildingO
   }
 }
 
-void ApplyAreaFeature::ProcessAreaRule(drule::BaseRule const * rule, double areaDepth, bool isHatching)
+void ApplyAreaFeature::ProcessAreaRules(AreaRuleProto const * areaRule, AreaRuleProto const * hatchingRule)
 {
-  AreaRuleProto const * areaRule = rule->GetArea();
-  ASSERT(areaRule != nullptr, ());
-  if (!m_triangles.empty())
+  ASSERT(areaRule || hatchingRule, ());
+  ASSERT(HasGeometry(), ());
+
+  double areaDepth = drule::kBaseDepthBgBySize - 1;
+
+  if (hatchingRule)
   {
-    AreaViewParams params;
-    params.m_tileCenter = m_tileRect.Center();
-    params.m_depth = PriorityToDepth(areaRule->priority(), drule::area, areaDepth);
-    params.m_color = ToDrapeColor(areaRule->color());
-    params.m_rank = m_f.GetRank();
-    params.m_minPosZ = m_minPosZ;
-    params.m_posZ = m_posZ;
-    params.m_hatching = isHatching;
-    params.m_baseGtoPScale = static_cast<float>(m_currentScaleGtoP);
+    ASSERT_GREATER_OR_EQUAL(hatchingRule->priority(), drule::kBasePriorityFg, ());
+    ProcessRule(hatchingRule, areaDepth, true);
+  }
 
-    BuildingOutline outline;
-    if (m_isBuilding && !params.m_hatching)
-    {
-      /// @todo Make borders work for non-building areas too.
-      outline.m_generateOutline = areaRule->has_border() &&
-                                  areaRule->color() != areaRule->border().color() &&
-                                  areaRule->border().width() > 0.0;
-      if (outline.m_generateOutline)
-        params.m_outlineColor = ToDrapeColor(areaRule->border().color());
-
-      bool const calculateNormals = m_posZ > 0.0;
-      if (calculateNormals || outline.m_generateOutline)
-        CalculateBuildingOutline(calculateNormals, outline);
-
-      params.m_is3D = !outline.m_indices.empty() && calculateNormals;
-    }
-
-    m_insertShape(make_unique_dp<AreaShape>(params.m_hatching ? m_triangles : std::move(m_triangles),
-                                            std::move(outline), params));
+  if (areaRule)
+  {
+    // Calculate areaDepth for BG-by-size areas only.
+    if (areaRule->priority() < drule::kBasePriorityBgTop)
+      areaDepth = drule::CalcAreaBySizeDepth(m_f);
+    ProcessRule(areaRule, areaDepth, false);
   }
 }
 
+void ApplyAreaFeature::ProcessRule(AreaRuleProto const * areaRule, double areaDepth, bool isHatching)
+{
+  AreaViewParams params;
+  params.m_tileCenter = m_tileRect.Center();
+  params.m_depth = PriorityToDepth(areaRule->priority(), drule::area, areaDepth);
+  params.m_color = ToDrapeColor(areaRule->color());
+  params.m_rank = m_f.GetRank();
+  params.m_minPosZ = m_minPosZ;
+  params.m_posZ = m_posZ;
+  params.m_hatching = isHatching;
+  params.m_baseGtoPScale = m_currentScaleGtoP;
+
+  BuildingOutline outline;
+  if (m_isBuilding && !isHatching)
+  {
+    /// @todo Make borders work for non-building areas too.
+    outline.m_generateOutline = areaRule->has_border() &&
+                                areaRule->color() != areaRule->border().color() &&
+                                areaRule->border().width() > 0.0;
+    if (outline.m_generateOutline)
+      params.m_outlineColor = ToDrapeColor(areaRule->border().color());
+
+    bool const calculateNormals = m_posZ > 0.0;
+    if (calculateNormals || outline.m_generateOutline)
+      CalculateBuildingOutline(calculateNormals, outline);
+
+    params.m_is3D = !outline.m_indices.empty() && calculateNormals;
+  }
+
+  m_insertShape(make_unique_dp<AreaShape>(m_triangles, std::move(outline), params));
+}
+
 ApplyLineFeatureGeometry::ApplyLineFeatureGeometry(TileKey const & tileKey, TInsertShapeFn const & insertShape,
-                                                   FeatureType & f, double currentScaleGtoP,
-                                                   size_t pointsCount, bool smooth)
+                                                   FeatureType & f, double currentScaleGtoP)
   : TBase(tileKey, insertShape, f, CaptionDescription())
-  , m_currentScaleGtoP(static_cast<float>(currentScaleGtoP))
+  , m_currentScaleGtoP(currentScaleGtoP)
+  // TODO: calculate just once in the RuleDrawer.
   , m_minSegmentSqrLength(base::Pow2(4.0 * df::VisualParams::Instance().GetVisualScale() / currentScaleGtoP))
   , m_simplify(tileKey.m_zoomLevel >= 10 && tileKey.m_zoomLevel <= 12)
-  , m_smooth(smooth)
-  , m_initialPointsCount(pointsCount)
-#ifdef LINES_GENERATION_CALC_FILTERED_POINTS
-  , m_readCount(0)
-#endif
-{}
+{
+  m_spline.Reset(new m2::Spline(f.GetPointsCount()));
+}
 
 void ApplyLineFeatureGeometry::operator() (m2::PointD const & point)
 {
 #ifdef LINES_GENERATION_CALC_FILTERED_POINTS
   ++m_readCount;
 #endif
-
-  if (m_spline.IsNull())
-    m_spline.Reset(new m2::Spline(m_initialPointsCount));
 
   if (m_spline->IsEmpty())
   {
@@ -808,38 +813,33 @@ void ApplyLineFeatureGeometry::operator() (m2::PointD const & point)
   }
 }
 
-bool ApplyLineFeatureGeometry::HasGeometry() const
+void ApplyLineFeatureGeometry::ProcessLineRules(Stylist::LineRulesT const & lineRules)
 {
-  return m_spline->IsValid();
-}
-
-void ApplyLineFeatureGeometry::ProcessLineRule(drule::BaseRule const * rule)
-{
+  ASSERT(!lineRules.empty(), ());
   ASSERT(HasGeometry(), ());
 
-  LineRuleProto const * pLineRule = rule->GetLine();
-  ASSERT(pLineRule != nullptr, ());
-
-  if (!m_smooth)
+  if (!ftypes::IsIsolineChecker::Instance()(m_f))
   {
     // A line crossing the tile several times will be split in several parts.
+    // TODO : use feature's pre-calculated limitRect when possible.
     m_clippedSplines = m2::ClipSplineByRect(m_tileRect, m_spline);
   }
   else
   {
     // Isolines smoothing.
+    ASSERT_EQUAL(lineRules.size(), 1, ());
     m2::GuidePointsForSmooth guidePointsForSmooth;
     std::vector<std::vector<m2::PointD>> clippedPaths;
     auto extTileRect = m_tileRect;
     extTileRect.Inflate(m_tileRect.SizeX() * 0.3, m_tileRect.SizeY() * 0.3);
-    m2::ClipPathByRectBeforeSmooth(extTileRect, m_spline->GetPath(), guidePointsForSmooth,
-                                   clippedPaths);
+    m2::ClipPathByRectBeforeSmooth(extTileRect, m_spline->GetPath(), guidePointsForSmooth, clippedPaths);
+
     if (clippedPaths.empty())
       return;
 
     m2::SmoothPaths(guidePointsForSmooth, 4 /* newPointsPerSegmentCount */, m2::kCentripetalAlpha, clippedPaths);
 
-    m_clippedSplines.clear();
+    ASSERT(m_clippedSplines.empty(), ());
     std::function<void (m2::SharedSpline &&)> inserter = base::MakeBackInsertFunctor(m_clippedSplines);
     for (auto & path : clippedPaths)
       m2::ClipPathByRect(m_tileRect, std::move(path), inserter);
@@ -848,11 +848,21 @@ void ApplyLineFeatureGeometry::ProcessLineRule(drule::BaseRule const * rule)
   if (m_clippedSplines.empty())
     return;
 
-  double const depth = PriorityToDepth(pLineRule->priority(), drule::line, 0);
+  for (auto const & r : lineRules)
+    ProcessRule(r);
 
-  if (pLineRule->has_pathsym())
+#ifdef LINES_GENERATION_CALC_FILTERED_POINTS
+  LinesStat::Get().InsertLine(m_f.GetID(), m_tileKey.m_zoomLevel, m_readCount, static_cast<int>(m_spline->GetSize()));
+#endif
+}
+
+void ApplyLineFeatureGeometry::ProcessRule(LineRuleProto const * lineRule)
+{
+  double const depth = PriorityToDepth(lineRule->priority(), drule::line, 0);
+
+  if (lineRule->has_pathsym())
   {
-    PathSymProto const & symRule = pLineRule->pathsym();
+    PathSymProto const & symRule = lineRule->pathsym();
     PathSymbolViewParams params;
     params.m_tileCenter = m_tileRect.Center();
     params.m_depth = depth;
@@ -870,7 +880,7 @@ void ApplyLineFeatureGeometry::ProcessLineRule(drule::BaseRule const * rule)
   {
     LineViewParams params;
     params.m_tileCenter = m_tileRect.Center();
-    ExtractLineParams(pLineRule, params);
+    ExtractLineParams(lineRule, params);
     params.m_depth = depth;
     params.m_rank = m_f.GetRank();
     params.m_baseGtoPScale = m_currentScaleGtoP;
@@ -881,43 +891,15 @@ void ApplyLineFeatureGeometry::ProcessLineRule(drule::BaseRule const * rule)
   }
 }
 
-void ApplyLineFeatureGeometry::Finish()
-{
-#ifdef LINES_GENERATION_CALC_FILTERED_POINTS
-  LinesStat::Get().InsertLine(m_f.GetID(), m_tileKey.m_zoomLevel, m_readCount, static_cast<int>(m_spline->GetSize()));
-#endif
-}
-
 ApplyLineFeatureAdditional::ApplyLineFeatureAdditional(TileKey const & tileKey, TInsertShapeFn const & insertShape,
                                                        FeatureType & f, double currentScaleGtoP,
                                                        CaptionDescription const & captions,
                                                        std::vector<m2::SharedSpline> const & clippedSplines)
   : TBase(tileKey, insertShape, f, captions)
   , m_clippedSplines(clippedSplines)
-  , m_currentScaleGtoP(static_cast<float>(currentScaleGtoP))
-  , m_captionDepth(0.0f)
-  , m_shieldDepth(0.0f)
-  , m_captionRule(nullptr)
-  , m_shieldRule(nullptr)
-{}
-
-void ApplyLineFeatureAdditional::ProcessLineRule(drule::BaseRule const * rule)
+  , m_currentScaleGtoP(currentScaleGtoP)
 {
   ASSERT(!m_clippedSplines.empty(), ());
-
-  ShieldRuleProto const * pShieldRule = rule->GetShield();
-  if (pShieldRule != nullptr)
-  {
-    m_shieldRule = pShieldRule;
-    m_shieldDepth = PriorityToDepth(pShieldRule->priority(), drule::shield, 0);
-  }
-
-  CaptionDefProto const * pCaptionRule = rule->GetCaption(0);
-  if (pCaptionRule != nullptr && pCaptionRule->height() > 2 && !m_captions.GetMainText().empty())
-  {
-    m_captionRule = pCaptionRule;
-    m_captionDepth = PriorityToDepth(rule->GetCaptionsPriority(), drule::pathtext, 0);
-  }
 }
 
 void ApplyLineFeatureAdditional::GetRoadShieldsViewParams(ref_ptr<dp::TextureManager> texMng,
@@ -928,7 +910,7 @@ void ApplyLineFeatureAdditional::GetRoadShieldsViewParams(ref_ptr<dp::TextureMan
                                                           PoiSymbolViewParams & poiParams,
                                                           m2::PointD & shieldPixelSize)
 {
-  ASSERT (m_shieldRule != nullptr, ());
+  ASSERT(m_shieldRule, ());
 
   std::string const & roadNumber = shield.m_name;
   double const mainScale = df::VisualParams::Instance().GetVisualScale();
@@ -939,23 +921,20 @@ void ApplyLineFeatureAdditional::GetRoadShieldsViewParams(ref_ptr<dp::TextureMan
   double const borderHeight = 1.5 * mainScale;
   m2::PointF const shieldTextOffset = GetShieldOffset(anchor, borderWidth, borderHeight);
 
-  // Text properties.
   dp::FontDecl font;
   ShieldRuleProtoToFontDecl(m_shieldRule, font);
   UpdateRoadShieldTextFont(font, shield);
-  textParams.m_tileCenter = m_tileRect.Center();
+
+  FillCommonParams(textParams);
+  textParams.m_depthLayer = DepthLayer::OverlayLayer;
   textParams.m_depthTestEnabled = false;
   textParams.m_depth = m_shieldDepth;
-  textParams.m_depthLayer = DepthLayer::OverlayLayer;
-  textParams.m_rank = m_f.GetRank();
-  textParams.m_featureId = m_f.GetID();
   textParams.m_titleDecl.m_anchor = anchor;
   textParams.m_titleDecl.m_primaryText = roadNumber;
   textParams.m_titleDecl.m_primaryTextFont = font;
   textParams.m_titleDecl.m_primaryOffset = shieldOffset + shieldTextOffset;
   textParams.m_titleDecl.m_primaryOptional = false;
   textParams.m_titleDecl.m_secondaryOptional = false;
-  textParams.m_extendingSize = 0;
   textParams.m_startOverlayRank = dp::OverlayRank1;
 
   TextLayout textLayout;
@@ -967,17 +946,13 @@ void ApplyLineFeatureAdditional::GetRoadShieldsViewParams(ref_ptr<dp::TextureMan
   textParams.m_limitedText = true;
   textParams.m_limits = shieldPixelSize * 0.9;
 
-  bool needAdditionalText = false;
-
+  // A colored box road shield.
   if (IsColoredRoadShield(shield))
   {
-    // Generated symbol properties.
-    symbolParams.m_featureId = m_f.GetID();
-    symbolParams.m_tileCenter = m_tileRect.Center();
+    FillCommonParams(symbolParams);
+    symbolParams.m_depthLayer = DepthLayer::OverlayLayer;
     symbolParams.m_depthTestEnabled = true;
     symbolParams.m_depth = m_shieldDepth;
-    symbolParams.m_depthLayer = DepthLayer::OverlayLayer;
-    symbolParams.m_rank = m_f.GetRank();
     symbolParams.m_anchor = anchor;
     symbolParams.m_offset = shieldOffset;
     symbolParams.m_shape = ColoredSymbolViewParams::Shape::RoundedRectangle;
@@ -991,26 +966,15 @@ void ApplyLineFeatureAdditional::GetRoadShieldsViewParams(ref_ptr<dp::TextureMan
     symbolParams.m_sizeInPixels = shieldPixelSize;
     symbolParams.m_outlineWidth = GetRoadShieldOutlineWidth(symbolParams.m_outlineWidth, shield);
     symbolParams.m_color = GetRoadShieldColor(symbolParams.m_color, shield);
-
-    needAdditionalText = !shield.m_additionalText.empty() &&
-                         (anchor & dp::Top || anchor & dp::Center);
   }
-
-  // Image symbol properties.
-  if (IsSymbolRoadShield(shield))
+  // A road shield using an icon.
+  else if (IsSymbolRoadShield(shield))
   {
-    std::string symbolName = GetRoadShieldSymbolName(shield, fontScale);
-    poiParams.m_featureId = m_f.GetID();
-    poiParams.m_tileCenter = m_tileRect.Center();
-    poiParams.m_depth = m_shieldDepth;
-    poiParams.m_depthTestEnabled = false;
+    FillCommonParams(poiParams);
     poiParams.m_depthLayer = DepthLayer::OverlayLayer;
-    poiParams.m_rank = m_f.GetRank();
-    poiParams.m_symbolName = symbolName;
-    poiParams.m_extendingSize = 0;
-    poiParams.m_posZ = 0.0f;
-    poiParams.m_hasArea = false;
-    poiParams.m_prioritized = false;
+    poiParams.m_depthTestEnabled = false;
+    poiParams.m_depth = m_shieldDepth;
+    poiParams.m_symbolName = GetRoadShieldSymbolName(shield, fontScale);
     poiParams.m_maskColor.clear();
     poiParams.m_anchor = anchor;
     poiParams.m_offset = GetShieldOffset(anchor, 0.5, 0.5);
@@ -1021,12 +985,9 @@ void ApplyLineFeatureAdditional::GetRoadShieldsViewParams(ref_ptr<dp::TextureMan
     float const symBorderHeight = (region.GetPixelSize().y - textLayout.GetPixelHeight()) * 0.5f;
     textParams.m_titleDecl.m_primaryOffset = poiParams.m_offset + GetShieldOffset(anchor, symBorderWidth, symBorderHeight);
     shieldPixelSize = region.GetPixelSize();
-
-    needAdditionalText = !symbolName.empty() && !shield.m_additionalText.empty() &&
-                         (anchor & dp::Top || anchor & dp::Center);
   }
 
-  if (needAdditionalText)
+  if (!shield.m_additionalText.empty() && (anchor & dp::Top || anchor & dp::Center))
   {
     auto & titleDecl = textParams.m_titleDecl;
     titleDecl.m_secondaryText = shield.m_additionalText;
@@ -1057,28 +1018,40 @@ bool ApplyLineFeatureAdditional::CheckShieldsNearby(m2::PointD const & shieldPos
   return true;
 }
 
-void ApplyLineFeatureAdditional::Finish(ref_ptr<dp::TextureManager> texMng,
-                                        ftypes::RoadShieldsSetT const & roadShields,
-                                        GeneratedRoadShields & generatedRoadShields)
+void ApplyLineFeatureAdditional::ProcessAdditionalLineRules(PathTextRuleProto const * pathtextRule,
+                                                            ShieldRuleProto const * shieldRule,
+                                                            ref_ptr<dp::TextureManager> texMng,
+                                                            ftypes::RoadShieldsSetT const & roadShields,
+                                                            GeneratedRoadShields & generatedRoadShields)
 {
-  if (m_clippedSplines.empty())
-    return;
+  ASSERT(pathtextRule || shieldRule, ());
 
   auto const vs = static_cast<float>(df::VisualParams::Instance().GetVisualScale());
 
   std::vector<m2::PointD> shieldPositions;
-  if (m_shieldRule != nullptr && !roadShields.empty())
-    shieldPositions.reserve(m_clippedSplines.size() * 3);
-
-  if (m_captionRule != nullptr)
+  ASSERT((shieldRule && !roadShields.empty()) || !(shieldRule && !roadShields.empty()),
+         (roadShields.empty(), shieldRule == nullptr));
+  if (shieldRule)
   {
+    m_shieldRule = shieldRule;
+    m_shieldDepth = PriorityToDepth(shieldRule->priority(), drule::shield, 0);
+    shieldPositions.reserve(m_clippedSplines.size() * 3);
+  }
+
+  if (pathtextRule)
+  {
+    ASSERT(!m_captions.GetMainText().empty(), ());
+    m_captionRule = &pathtextRule->primary();
+    ASSERT_GREATER_OR_EQUAL(m_captionRule->height(), kMinVisibleFontSize / df::kMaxVisualScale, ());
+    m_captionDepth = PriorityToDepth(pathtextRule->priority(), drule::pathtext, 0);
+
     dp::FontDecl fontDecl;
     CaptionDefProtoToFontDecl(m_captionRule, fontDecl);
     PathTextViewParams params;
-    params.m_tileCenter = m_tileRect.Center();
-    params.m_featureId = m_f.GetID();
+    FillCommonParams(params);
+    params.m_depthLayer = DepthLayer::OverlayLayer;
+    params.m_depthTestEnabled = false;
     params.m_depth = m_captionDepth;
-    params.m_rank = m_f.GetRank();
     params.m_mainText = m_captions.GetMainText();
     params.m_auxText = m_captions.GetAuxText();
     params.m_textFont = fontDecl;
@@ -1095,14 +1068,14 @@ void ApplyLineFeatureAdditional::Finish(ref_ptr<dp::TextureManager> texMng,
 
       // Position shields inbetween captions.
       // If there is only one center position then the shield and the caption will compete for it.
-      if (m_shieldRule != nullptr && !roadShields.empty())
+      if (m_shieldRule)
         CalculateRoadShieldPositions(shape->GetOffsets(), spline, shieldPositions);
 
       m_insertShape(std::move(shape));
       textIndex++;
     }
   }
-  else if (m_shieldRule != nullptr && !roadShields.empty())
+  else if (m_shieldRule)
   {
     // Position shields without captions.
     for (auto const & spline : m_clippedSplines)
@@ -1120,7 +1093,6 @@ void ApplyLineFeatureAdditional::Finish(ref_ptr<dp::TextureManager> texMng,
     return;
 
   // Set default shield's icon min distance.
-  ASSERT(m_shieldRule != nullptr, ());
   int minDistance = m_shieldRule->min_distance();
   ASSERT_GREATER_OR_EQUAL(minDistance, 0, ());
   if (minDistance <= 0)

--- a/drape_frontend/apply_feature_functors.hpp
+++ b/drape_frontend/apply_feature_functors.hpp
@@ -8,6 +8,7 @@
 #include "drape/pointers.hpp"
 
 #include "indexer/drawing_rule_def.hpp"
+#include "indexer/drawing_rules.hpp"
 #include "indexer/road_shields_parser.hpp"
 
 #include "geometry/point2d.hpp"
@@ -17,8 +18,6 @@
 #include <vector>
 
 class CaptionDefProto;
-class ShieldRuleProto;
-class SymbolRuleProto;
 
 namespace dp
 {
@@ -43,9 +42,7 @@ public:
   virtual ~BaseApplyFeature() = default;
 
 protected:
-  void ExtractCaptionParams(CaptionDefProto const * primaryProto,
-                            CaptionDefProto const * secondaryProto,
-                            TextViewParams & params) const;
+  void FillCommonParams(CommonOverlayViewParams & p) const;
   double PriorityToDepth(int priority, drule::rule_type_t ruleType, double areaDepth) const;
 
   TInsertShapeFn m_insertShape;
@@ -62,24 +59,19 @@ class ApplyPointFeature : public BaseApplyFeature
 
 public:
   ApplyPointFeature(TileKey const & tileKey, TInsertShapeFn const & insertShape, FeatureType & f,
-                    CaptionDescription const & captions, float posZ);
+                    CaptionDescription const & captions);
 
-  void operator()(m2::PointD const & point, bool hasArea);
-  void ProcessPointRule(drule::BaseRule const * rule, bool isHouseNumber);
-  void Finish(ref_ptr<dp::TextureManager> texMng);
+  void ProcessPointRules(SymbolRuleProto const * symbolRule, CaptionRuleProto const * captionRule,
+                         CaptionRuleProto const * houseNumberRule, m2::PointD const & centerPoint,
+                         ref_ptr<dp::TextureManager> texMng);
 
 protected:
-  float const m_posZ;
-
+  void ExtractCaptionParams(CaptionDefProto const * primaryProto,
+                            CaptionDefProto const * secondaryProto,
+                            TextViewParams & params) const;
+  float m_posZ = 0.0f;
 private:
-  TextViewParams m_textParams;
-  TextViewParams m_hnParams;
-  m2::PointD m_centerPoint;
-  SymbolRuleProto const * m_symbolRule = nullptr;
-  float m_symbolDepth;
-  bool m_hasArea = false;
-  bool m_createdByEditor = false;
-  bool m_obsoleteInEditor = false;
+  virtual bool HasArea() const { return false; }
 };
 
 class ApplyAreaFeature : public ApplyPointFeature
@@ -92,10 +84,9 @@ public:
                    bool skipAreaGeometry, float minPosZ, float posZ,
                    CaptionDescription const & captions);
 
-  using TBase::operator ();
-
   void operator()(m2::PointD const & p1, m2::PointD const & p2, m2::PointD const & p3);
-  void ProcessAreaRule(drule::BaseRule const * rule, double areaDepth, bool isHatching);
+  bool HasGeometry() const { return !m_triangles.empty(); }
+  void ProcessAreaRules(AreaRuleProto const * areaRule, AreaRuleProto const * hatchingRule);
 
   struct Edge
   {
@@ -127,6 +118,9 @@ public:
   };
 
 private:
+  bool HasArea() const override { return true; }
+
+  void ProcessRule(AreaRuleProto const * areaRule, double areaDepth, bool isHatching);
   void ProcessBuildingPolygon(m2::PointD const & p1, m2::PointD const & p2, m2::PointD const & p3);
   void CalculateBuildingOutline(bool calculateNormals, BuildingOutline & outline);
   int GetIndex(m2::PointD const & pt);
@@ -150,27 +144,26 @@ class ApplyLineFeatureGeometry : public BaseApplyFeature
 
 public:
   ApplyLineFeatureGeometry(TileKey const & tileKey, TInsertShapeFn const & insertShape,
-                           FeatureType & f, double currentScaleGtoP, size_t pointsCount, bool smooth);
+                           FeatureType & f, double currentScaleGtoP);
 
   void operator() (m2::PointD const & point);
-  bool HasGeometry() const;
-  void ProcessLineRule(drule::BaseRule const *  rule);
-  void Finish();
+  bool HasGeometry() const { return m_spline->IsValid(); }
+  void ProcessLineRules(Stylist::LineRulesT const & lineRules);
 
   std::vector<m2::SharedSpline> const & GetClippedSplines() const { return m_clippedSplines; }
 
 private:
+  void ProcessRule(LineRuleProto const * lineRule);
+
   m2::SharedSpline m_spline;
   std::vector<m2::SharedSpline> m_clippedSplines;
-  float m_currentScaleGtoP;
-  double m_minSegmentSqrLength;
+  double const m_currentScaleGtoP;
+  double const m_minSegmentSqrLength;
   m2::PointD m_lastAddedPoint;
-  bool m_simplify;
-  bool m_smooth;
-  size_t m_initialPointsCount;
+  bool const m_simplify;
 
 #ifdef LINES_GENERATION_CALC_FILTERED_POINTS
-  int m_readCount;
+  int m_readCount = 0;
 #endif
 };
 
@@ -184,9 +177,9 @@ public:
                              FeatureType & f, double currentScaleGtoP, CaptionDescription const & captions,
                              std::vector<m2::SharedSpline> const & clippedSplines);
 
-  void ProcessLineRule(drule::BaseRule const * rule);
-  void Finish(ref_ptr<dp::TextureManager> texMng, ftypes::RoadShieldsSetT const & roadShields,
-              GeneratedRoadShields & generatedRoadShields);
+  void ProcessAdditionalLineRules(PathTextRuleProto const * pathtextRule, ShieldRuleProto const * shieldRule,
+                                  ref_ptr<dp::TextureManager> texMng, ftypes::RoadShieldsSetT const & roadShields,
+                                  GeneratedRoadShields & generatedRoadShields);
 
 private:
   void GetRoadShieldsViewParams(ref_ptr<dp::TextureManager> texMng,
@@ -202,10 +195,10 @@ private:
                           std::vector<m2::RectD> & shields);
 
   std::vector<m2::SharedSpline> m_clippedSplines;
-  float m_currentScaleGtoP;
-  float m_captionDepth, m_shieldDepth;
-  CaptionDefProto const * m_captionRule;
-  ShieldRuleProto const * m_shieldRule;
+  double const m_currentScaleGtoP;
+  float m_captionDepth = 0.0f, m_shieldDepth = 0.0f;
+  CaptionDefProto const * m_captionRule = nullptr;
+  ShieldRuleProto const * m_shieldRule = nullptr;
 };
 
 extern dp::Color ToDrapeColor(uint32_t src);

--- a/drape_frontend/apply_feature_functors.hpp
+++ b/drape_frontend/apply_feature_functors.hpp
@@ -120,7 +120,7 @@ public:
 private:
   bool HasArea() const override { return true; }
 
-  void ProcessRule(AreaRuleProto const * areaRule, double areaDepth, bool isHatching);
+  void ProcessRule(AreaRuleProto const & areaRule, double areaDepth, bool isHatching);
   void ProcessBuildingPolygon(m2::PointD const & p1, m2::PointD const & p2, m2::PointD const & p3);
   void CalculateBuildingOutline(bool calculateNormals, BuildingOutline & outline);
   int GetIndex(m2::PointD const & pt);
@@ -153,7 +153,7 @@ public:
   std::vector<m2::SharedSpline> const & GetClippedSplines() const { return m_clippedSplines; }
 
 private:
-  void ProcessRule(LineRuleProto const * lineRule);
+  void ProcessRule(LineRuleProto const & lineRule);
 
   m2::SharedSpline m_spline;
   std::vector<m2::SharedSpline> m_clippedSplines;

--- a/drape_frontend/line_shape.cpp
+++ b/drape_frontend/line_shape.cpp
@@ -294,7 +294,6 @@ public:
   struct BuilderParams : BaseBuilderParams
   {
     dp::TextureManager::StippleRegion m_stipple;
-    float m_glbHalfWidth;
     float m_baseGtoP;
   };
 
@@ -538,8 +537,7 @@ void LineShape::Prepare(ref_ptr<dp::TextureManager> textures) const
     DashedLineBuilder::BuilderParams p;
     commonParamsBuilder(p);
     p.m_stipple = maskRegion;
-    p.m_baseGtoP = m_params.m_baseGtoPScale;
-    p.m_glbHalfWidth = p.m_pxHalfWidth / m_params.m_baseGtoPScale;
+    p.m_baseGtoP = static_cast<float>(m_params.m_baseGtoPScale);
 
     auto builder = std::make_unique<DashedLineBuilder>(p, m_spline->GetPath().size());
     Construct<DashedLineBuilder>(*builder);

--- a/drape_frontend/rule_drawer.cpp
+++ b/drape_frontend/rule_drawer.cpp
@@ -446,7 +446,7 @@ void RuleDrawer::operator()(FeatureType & f)
     size_t const index = shape->GetType();
     ASSERT_LESS(index, m_mapShapes.size(), ());
 
-    // TODO: MinZoom was used for optimization in RenderGroup::UpdateCanBeDeletedStatus(), but is long time broken.
+    // TODO(pastk) : MinZoom was used for optimization in RenderGroup::UpdateCanBeDeletedStatus(), but is long time broken.
     // See https://github.com/organicmaps/organicmaps/pull/5903 for details.
     shape->SetFeatureMinZoom(0);
     m_mapShapes[index].push_back(std::move(shape));

--- a/drape_frontend/rule_drawer.cpp
+++ b/drape_frontend/rule_drawer.cpp
@@ -13,7 +13,6 @@
 #include "indexer/feature_visibility.hpp"
 #include "indexer/ftypes_matcher.hpp"
 #include "indexer/map_style_reader.hpp"
-#include "indexer/road_shields_parser.hpp"
 #include "indexer/scales.hpp"
 
 #include "geometry/clipping.hpp"
@@ -168,7 +167,6 @@ RuleDrawer::RuleDrawer(TCheckCancelledCallback const & checkCancelled,
   , m_context(engineContext)
   , m_customFeaturesContext(engineContext->GetCustomFeaturesContext().lock())
   , m_deviceLang(deviceLang)
-  , m_wasCancelled(false)
 {
   ASSERT(m_checkCancelled != nullptr, ());
 
@@ -286,8 +284,7 @@ void RuleDrawer::ProcessAreaAndPointStyle(FeatureType & f, Stylist const & s, TI
     areaMinHeight = static_cast<float>((rectMercator.SizeX() + rectMercator.SizeY()) * 0.5);
   }
 
-  bool applyPointStyle = s.m_symbolRule != nullptr || s.m_captionRule != nullptr ||
-                         s.m_houseNumberRule != nullptr;
+  bool applyPointStyle = s.m_symbolRule || s.m_captionRule || s.m_houseNumberRule;
   if (applyPointStyle)
   {
     if (!is3dBuilding)
@@ -298,63 +295,35 @@ void RuleDrawer::ProcessAreaAndPointStyle(FeatureType & f, Stylist const & s, TI
     applyPointStyle = m_globalRect.IsPointInside(featureCenter);
   }
 
-  double areaDepth = drule::kBaseDepthBgBySize - 1;
   ApplyAreaFeature apply(m_context->GetTileKey(), insertShape, f,
                          m_currentScaleGtoP, isBuilding,
                          m_context->Is3dBuildingsEnabled() && isBuildingOutline /* skipAreaGeometry */,
                          areaMinHeight /* minPosZ */, areaHeight /* posZ */,
                          s.GetCaptionDescription());
-  if (s.m_areaRule != nullptr || s.m_hatchingRule != nullptr)
-  {
+  if (s.m_areaRule || s.m_hatchingRule)
     f.ForEachTriangle(apply, m_zoomLevel);
-    /// @todo areaDepth is not needed for FG and BG-top areas.
-    areaDepth = drule::CalcAreaBySizeDepth(f);
-  }
-  if (applyPointStyle)
-    apply(featureCenter, true /* hasArea */); // ApplyPointFeature::operator()()
 
-  if (CheckCancelled())
-    return;
-
-  if (s.m_hatchingRule != nullptr)
-    apply.ProcessAreaRule(s.m_hatchingRule, areaDepth, true);
-  if (s.m_areaRule != nullptr)
-    apply.ProcessAreaRule(s.m_areaRule, areaDepth, false);
+  if (apply.HasGeometry())
+    apply.ProcessAreaRules(s.m_areaRule, s.m_hatchingRule);
 
   /// @todo Can we put this check in the beginning of this function?
   if (applyPointStyle && !IsDiscardCustomFeature(f.GetID()))
   {
-    // Process point style.
-    if (s.m_symbolRule != nullptr)
-      apply.ProcessPointRule(s.m_symbolRule, false);
-    if (s.m_captionRule != nullptr)
-      apply.ProcessPointRule(s.m_captionRule, false);
-    if (s.m_houseNumberRule != nullptr)
-      apply.ProcessPointRule(s.m_houseNumberRule, true);
-    apply.Finish(m_context->GetTextureManager()); // ApplyPointFeature::Finish()
+    apply.ProcessPointRules(s.m_symbolRule, s.m_captionRule, s.m_houseNumberRule,
+                            featureCenter, m_context->GetTextureManager());
   }
 }
 
 void RuleDrawer::ProcessLineStyle(FeatureType & f, Stylist const & s, TInsertShapeFn const & insertShape)
 {
-  bool const smooth = ftypes::IsIsolineChecker::Instance()(f);
-
-  ApplyLineFeatureGeometry applyGeom(m_context->GetTileKey(), insertShape, f, m_currentScaleGtoP,
-                                     f.GetPointsCount(), smooth);
+  ApplyLineFeatureGeometry applyGeom(m_context->GetTileKey(), insertShape, f, m_currentScaleGtoP);
   f.ForEachPoint(applyGeom, m_zoomLevel);
 
-  if (CheckCancelled())
-    return;
-
   if (applyGeom.HasGeometry())
-  {
-    for (auto const & r : s.m_lineRules)
-      applyGeom.ProcessLineRule(r);
-  }
-  applyGeom.Finish();
+    applyGeom.ProcessLineRules(s.m_lineRules);
 
   std::vector<m2::SharedSpline> clippedSplines;
-  bool needAdditional = s.m_pathtextRule != nullptr || s.m_shieldRule != nullptr;
+  bool needAdditional = s.m_pathtextRule || s.m_shieldRule;
   if (needAdditional)
   {
     auto const metalineSpline = m_context->GetMetalineManager()->GetMetaline(f.GetID());
@@ -380,12 +349,9 @@ void RuleDrawer::ProcessLineStyle(FeatureType & f, Stylist const & s, TInsertSha
   {
     ApplyLineFeatureAdditional applyAdditional(m_context->GetTileKey(), insertShape, f, m_currentScaleGtoP,
                                                s.GetCaptionDescription(), clippedSplines);
-    if (s.m_pathtextRule != nullptr)
-      applyAdditional.ProcessLineRule(s.m_pathtextRule);
-    if (s.m_shieldRule != nullptr)
-      applyAdditional.ProcessLineRule(s.m_shieldRule);
-    applyAdditional.Finish(m_context->GetTextureManager(), ftypes::GetRoadShields(f),
-                           m_generatedRoadShields);
+    applyAdditional.ProcessAdditionalLineRules(s.m_pathtextRule, s.m_shieldRule,
+                                               m_context->GetTextureManager(), s.m_roadShields,
+                                               m_generatedRoadShields);
   }
 
   if (m_context->IsTrafficEnabled() && m_zoomLevel >= kRoadClass0ZoomLevel)
@@ -431,19 +397,9 @@ void RuleDrawer::ProcessPointStyle(FeatureType & f, Stylist const & s, TInsertSh
   if (IsDiscardCustomFeature(f.GetID()))
     return;
 
-  ApplyPointFeature apply(m_context->GetTileKey(), insertShape, f, s.GetCaptionDescription(), 0.0f /* posZ */);
-  apply(f.GetCenter(), false /* hasArea */);
-
-  if (CheckCancelled())
-    return;
-
-  if (s.m_symbolRule != nullptr)
-    apply.ProcessPointRule(s.m_symbolRule, false);
-  if (s.m_captionRule != nullptr)
-    apply.ProcessPointRule(s.m_captionRule, false);
-  if (s.m_houseNumberRule != nullptr)
-    apply.ProcessPointRule(s.m_houseNumberRule, true);
-  apply.Finish(m_context->GetTextureManager());
+  ApplyPointFeature apply(m_context->GetTileKey(), insertShape, f, s.GetCaptionDescription());
+  apply.ProcessPointRules(s.m_symbolRule, s.m_captionRule, s.m_houseNumberRule,
+                          f.GetCenter(), m_context->GetTextureManager());
 }
 
 void RuleDrawer::operator()(FeatureType & f)
@@ -457,27 +413,25 @@ void RuleDrawer::operator()(FeatureType & f)
        !ftypes::IsBuildingChecker::Instance()(types)))
     return;
 
+  if (ftypes::IsCoastlineChecker::Instance()(types) && !CheckCoastlines(f))
+    return;
+
   Stylist const s(f, m_zoomLevel, m_deviceLang);
 
   // No drawing rules.
-  if (s.m_symbolRule == nullptr && s.m_captionRule == nullptr && s.m_houseNumberRule == nullptr &&
-      s.m_lineRules.empty() && s.m_areaRule == nullptr && s.m_hatchingRule == nullptr)
-    return;
-
-  if (s.m_isCoastline && !CheckCoastlines(f))
+  if (!s.m_symbolRule && !s.m_captionRule && !s.m_houseNumberRule &&
+      s.m_lineRules.empty() && !s.m_areaRule && !s.m_hatchingRule)
     return;
 
 #ifdef DEBUG
   // Validate mixing of feature styles.
   bool const hasLine = !s.m_lineRules.empty();
-  bool const hasLineAdd = s.m_shieldRule != nullptr || s.m_pathtextRule != nullptr;
-  bool const hasPoint = s.m_symbolRule != nullptr || s.m_captionRule != nullptr || s.m_houseNumberRule != nullptr;
-  bool const hasArea = s.m_areaRule != nullptr || s.m_hatchingRule != nullptr;
+  bool const hasLineAdd = s.m_shieldRule || s.m_pathtextRule;
+  bool const hasPoint = s.m_symbolRule || s.m_captionRule || s.m_houseNumberRule;
+  bool const hasArea = s.m_areaRule || s.m_hatchingRule;
 
   ASSERT(!((hasLine || hasLineAdd) && (hasPoint || hasArea)),
          ("Line drules mixed with point/area ones", f.DebugString(m_zoomLevel, true)));
-
-  // TODO : validate in the styles generator.
   ASSERT(!hasLineAdd || hasLine, ("Pathtext/shield without a line drule", f.DebugString(m_zoomLevel, true)));
 #endif
 
@@ -510,7 +464,7 @@ void RuleDrawer::operator()(FeatureType & f)
   }
   else
   {
-    ASSERT(s.m_symbolRule != nullptr || s.m_captionRule != nullptr || s.m_houseNumberRule != nullptr, ());
+    ASSERT(s.m_symbolRule || s.m_captionRule || s.m_houseNumberRule, ());
     ASSERT(geomType == feature::GeomType::Point, ());
     ProcessPointStyle(f, s, insertShape);
   }

--- a/drape_frontend/rule_drawer.hpp
+++ b/drape_frontend/rule_drawer.hpp
@@ -72,15 +72,16 @@ private:
   std::unordered_set<m2::Spline const *> m_usedMetalines;
 
   m2::RectD m_globalRect;
-  uint8_t m_zoomLevel;
   double m_currentScaleGtoP;
   double m_trafficScalePtoG;
 
   TrafficSegmentsGeometry m_trafficGeometry;
 
   std::array<TMapShapes, df::MapShapeTypeCount> m_mapShapes;
-  bool m_wasCancelled;
 
   GeneratedRoadShields m_generatedRoadShields;
+
+  uint8_t m_zoomLevel = 0;
+  bool m_wasCancelled = false;
 };
 }  // namespace df

--- a/drape_frontend/shape_view_params.hpp
+++ b/drape_frontend/shape_view_params.hpp
@@ -74,7 +74,7 @@ struct AreaViewParams : CommonViewParams
   float m_posZ = 0.0f;
   bool m_is3D = false;
   bool m_hatching = false;
-  float m_baseGtoPScale = 1.0f;
+  double m_baseGtoPScale = 1.0f;
 };
 
 struct LineViewParams : CommonViewParams
@@ -85,7 +85,7 @@ struct LineViewParams : CommonViewParams
   dp::LineCap m_cap;
   dp::LineJoin m_join;
   dp::PenPatternT m_pattern;
-  float m_baseGtoPScale = 1.0f;
+  double m_baseGtoPScale = 1.0f;
   int m_zoomLevel = -1;
 };
 
@@ -105,16 +105,15 @@ struct PathTextViewParams : CommonOverlayViewParams
   dp::FontDecl m_textFont;
   std::string m_mainText;
   std::string m_auxText;
-  float m_baseGtoPScale = 1.0f;
+  double m_baseGtoPScale = 1.0f;
 };
 
 struct PathSymbolViewParams : CommonViewParams
 {
-  FeatureID m_featureID;
   std::string m_symbolName;
   float m_offset = 0.0f;
   float m_step = 0.0f;
-  float m_baseGtoPScale = 1.0f;
+  double m_baseGtoPScale = 1.0f;
 };
 
 struct ColoredSymbolViewParams : CommonOverlayViewParams

--- a/drape_frontend/shape_view_params.hpp
+++ b/drape_frontend/shape_view_params.hpp
@@ -74,7 +74,7 @@ struct AreaViewParams : CommonViewParams
   float m_posZ = 0.0f;
   bool m_is3D = false;
   bool m_hatching = false;
-  double m_baseGtoPScale = 1.0f;
+  double m_baseGtoPScale = 1.0;
 };
 
 struct LineViewParams : CommonViewParams
@@ -85,7 +85,7 @@ struct LineViewParams : CommonViewParams
   dp::LineCap m_cap;
   dp::LineJoin m_join;
   dp::PenPatternT m_pattern;
-  double m_baseGtoPScale = 1.0f;
+  double m_baseGtoPScale = 1.0;
   int m_zoomLevel = -1;
 };
 
@@ -105,7 +105,7 @@ struct PathTextViewParams : CommonOverlayViewParams
   dp::FontDecl m_textFont;
   std::string m_mainText;
   std::string m_auxText;
-  double m_baseGtoPScale = 1.0f;
+  double m_baseGtoPScale = 1.0;
 };
 
 struct PathSymbolViewParams : CommonViewParams
@@ -113,7 +113,7 @@ struct PathSymbolViewParams : CommonViewParams
   std::string m_symbolName;
   float m_offset = 0.0f;
   float m_step = 0.0f;
-  double m_baseGtoPScale = 1.0f;
+  double m_baseGtoPScale = 1.0;
 };
 
 struct ColoredSymbolViewParams : CommonOverlayViewParams

--- a/drape_frontend/stylist.cpp
+++ b/drape_frontend/stylist.cpp
@@ -45,7 +45,7 @@ void CaptionDescription::Init(FeatureType & f, int8_t deviceLang, int zoomLevel,
                               feature::GeomType geomType, bool auxCaptionExists)
 {
   feature::NameParamsOut out;
-  // TODO: remove forced secondary text for all lines and set it via styles for major roads and rivers only.
+  // TODO(pastk) : remove forced secondary text for all lines and set it via styles for major roads and rivers only.
   // ATM even minor paths/streams/etc use secondary which makes their pathtexts take much more space.
   if (zoomLevel > scales::GetUpperWorldScale() && (auxCaptionExists || geomType == feature::GeomType::Line))
   {
@@ -75,13 +75,13 @@ void CaptionDescription::Init(FeatureType & f, int8_t deviceLang, int zoomLevel,
   if (m_mainText.size() > kMaxTextSize)
     m_mainText = m_mainText.substr(0, kMaxTextSize) + "...";
 
-  // TODO : its better to determine housenumbers minZoom once upon drules load and cache it,
+  // TODO(pastk) : its better to determine housenumbers minZoom once upon drules load and cache it,
   // but it'd mean a lot of housenumbers-specific logic in otherwise generic RulesHolder..
   uint8_t constexpr kHousenumbersMinZoom = 16;
   if (geomType != feature::GeomType::Line && zoomLevel >= kHousenumbersMinZoom &&
       (auxCaptionExists || m_mainText.empty()))
   {
-    // TODO: its not obvious that a housenumber display is dependent on a secondary caption drule existance in styles.
+    // TODO(pastk) : its not obvious that a housenumber display is dependent on a secondary caption drule existance in styles.
     m_houseNumberText = f.GetHouseNumber();
     if (!m_houseNumberText.empty() && !m_mainText.empty() && m_houseNumberText.find(m_mainText) != std::string::npos)
       m_mainText.clear();
@@ -137,7 +137,7 @@ void Stylist::ProcessKey(FeatureType & f, drule::Key const & key)
       m_areaRule = dRule->GetArea();
     }
     break;
-  // TODO : check if circle/waymarker support exists still (not used in styles ATM).
+  // TODO(pastk) : check if circle/waymarker support exists still (not used in styles ATM).
   case drule::circle:
   case drule::waymarker:
   default:

--- a/drape_frontend/stylist.hpp
+++ b/drape_frontend/stylist.hpp
@@ -3,6 +3,7 @@
 #include "indexer/ftypes_matcher.hpp"
 #include "indexer/drawing_rule_def.hpp"
 #include "indexer/drawing_rules.hpp"
+#include "indexer/road_shields_parser.hpp"
 
 #include "base/buffer_vector.hpp"
 
@@ -47,16 +48,18 @@ private:
 class Stylist
 {
 public:
-  bool m_isCoastline = false;
+  SymbolRuleProto const * m_symbolRule = nullptr;
+  CaptionRuleProto const * m_captionRule = nullptr;
+  CaptionRuleProto const * m_houseNumberRule = nullptr;
+  PathTextRuleProto const * m_pathtextRule = nullptr;
+  ShieldRuleProto const * m_shieldRule = nullptr;
+  AreaRuleProto const * m_areaRule = nullptr;
+  AreaRuleProto const * m_hatchingRule = nullptr;
 
-  drule::BaseRule const * m_symbolRule = nullptr;
-  drule::BaseRule const * m_captionRule = nullptr;
-  drule::BaseRule const * m_houseNumberRule = nullptr;
-  drule::BaseRule const * m_pathtextRule = nullptr;
-  drule::BaseRule const * m_shieldRule = nullptr;
-  drule::BaseRule const * m_areaRule = nullptr;
-  drule::BaseRule const * m_hatchingRule = nullptr;
-  buffer_vector<drule::BaseRule const *, 4> m_lineRules;
+  using LineRulesT = buffer_vector<LineRuleProto const *, 4>;
+  LineRulesT m_lineRules;
+
+  ftypes::RoadShieldsSetT m_roadShields;
 
   Stylist(FeatureType & f, uint8_t zoomLevel, int8_t deviceLang);
 

--- a/drape_frontend/visual_params.cpp
+++ b/drape_frontend/visual_params.cpp
@@ -27,20 +27,6 @@ static bool g_isInited = false;
 #define ASSERT_INITED
 #endif
 
-double const VisualParams::kMdpiScale = 1.0;
-double const VisualParams::kHdpiScale = 1.5;
-double const VisualParams::kXhdpiScale = 2.0;
-double const VisualParams::k6plusScale = 2.4;
-double const VisualParams::kXxhdpiScale = 3.0;
-double const VisualParams::kXxxhdpiScale = 3.5;
-
-VisualParams::VisualParams()
-  : m_tileSize(0)
-  , m_visualScale(0.0)
-  , m_poiExtendScale(0.1) // found empirically
-  , m_fontScale(1.0)
-{}
-
 VisualParams & VisualParams::Instance()
 {
   static VisualParams vizParams;

--- a/drape_frontend/visual_params.hpp
+++ b/drape_frontend/visual_params.hpp
@@ -73,9 +73,9 @@ private:
   GlyphVisualParams m_glyphVisualParams;
 
   uint32_t m_tileSize = 0;
-  double m_visualScale = 0.0f;
-  double m_poiExtendScale = 0.1f; // Found empirically.
-  std::atomic<double> m_fontScale = 1.0f;
+  double m_visualScale = 0.0;
+  double m_poiExtendScale = 0.1; // Found empirically.
+  std::atomic<double> m_fontScale = 1.0;
 
   DISALLOW_COPY_AND_MOVE(VisualParams);
 };

--- a/drape_frontend/visual_params.hpp
+++ b/drape_frontend/visual_params.hpp
@@ -19,12 +19,16 @@ double constexpr kMaxVisualScale = 4.0;
 class VisualParams
 {
 public:
-  static double const kMdpiScale;
-  static double const kHdpiScale;
-  static double const kXhdpiScale;
-  static double const k6plusScale;
-  static double const kXxhdpiScale;
-  static double const kXxxhdpiScale;
+  static double constexpr kMdpiScale = 1.0;
+  static double constexpr kHdpiScale = 1.5;
+  static double constexpr kXhdpiScale = 2.0;
+  static double constexpr k6plusScale = 2.4;
+  static double constexpr kXxhdpiScale = 3.0;
+  static double constexpr kXxxhdpiScale = 3.5;
+
+  static_assert(kMdpiScale < kHdpiScale && kHdpiScale < kXhdpiScale &&
+                kXhdpiScale < k6plusScale && k6plusScale < kXxhdpiScale &&
+                kXxhdpiScale < kXxxhdpiScale && kXxxhdpiScale <= kMaxVisualScale);
 
   static void Init(double vs, uint32_t tileSize);
   static VisualParams & Instance();
@@ -64,13 +68,14 @@ public:
   void SetVisualScale(double visualScale);
 
 private:
-  VisualParams();
+  VisualParams() = default;
 
-  uint32_t m_tileSize;
-  double m_visualScale;
-  double m_poiExtendScale;
   GlyphVisualParams m_glyphVisualParams;
-  std::atomic<double> m_fontScale;
+
+  uint32_t m_tileSize = 0;
+  double m_visualScale = 0.0f;
+  double m_poiExtendScale = 0.1f; // Found empirically.
+  std::atomic<double> m_fontScale = 1.0f;
 
   DISALLOW_COPY_AND_MOVE(VisualParams);
 };

--- a/geometry/rect2d.hpp
+++ b/geometry/rect2d.hpp
@@ -42,8 +42,7 @@ public:
 
   Rect(T minX, T minY, T maxX, T maxY) : m_minX(minX), m_minY(minY), m_maxX(maxX), m_maxY(maxY)
   {
-    ASSERT(minX <= maxX, ());
-    ASSERT(minY <= maxY, ());
+    ASSERT(minX <= maxX && minY <= maxY, (minX, maxX, minY, maxY));
   }
 
   Rect(Point<T> const & p1, Point<T> const & p2)

--- a/indexer/drawing_rule_def.hpp
+++ b/indexer/drawing_rule_def.hpp
@@ -80,9 +80,6 @@ static double constexpr kBaseDepthFg = 0,
   /// drawing type of rule - can be one of ...
   enum rule_type_t { line, area, symbol, caption, circle, pathtext, waymarker, shield, count_of_rules };
 
-  /// @todo not used.
-  enum text_type_t { text_type_name = 0, text_type_housename, text_type_housenumber };
-
   typedef buffer_vector<Key, 16> KeysT;
   void MakeUnique(KeysT & keys);
   double CalcAreaBySizeDepth(FeatureType & f);

--- a/indexer/drawing_rules.cpp
+++ b/indexer/drawing_rules.cpp
@@ -147,7 +147,7 @@ namespace
       explicit Line(LineRuleProto const & r)
         : m_line(r)
       {
-        CHECK(r.has_pathsym() || r.width() > 0, ("Zero width line w/o path symbol)")); //pastk
+        ASSERT(r.has_pathsym() || r.width() > 0, ("Zero width line w/o path symbol)"));
       }
 
       virtual LineRuleProto const * GetLine() const { return &m_line; }
@@ -178,7 +178,7 @@ namespace
       explicit Caption(CaptionRuleProto const & r)
         : m_caption(r)
       {
-        CHECK(r.has_primary(),()); //pastk
+        ASSERT(r.has_primary(),());
       }
 
       virtual CaptionRuleProto const * GetCaption() const { return &m_caption; }

--- a/indexer/drawing_rules.cpp
+++ b/indexer/drawing_rules.cpp
@@ -23,16 +23,6 @@ using namespace std;
 namespace
 {
   uint32_t const DEFAULT_BG_COLOR = 0xEEEEDD;
-
-  drule::text_type_t GetTextType(string const & text)
-  {
-    if (text == "addr:housename")
-      return drule::text_type_housename;
-    else if (text == "addr:housenumber")
-      return drule::text_type_housenumber;
-
-    return drule::text_type_name;
-  }
 } // namespace
 
 LineRuleProto const * BaseRule::GetLine() const
@@ -50,17 +40,12 @@ SymbolRuleProto const * BaseRule::GetSymbol() const
   return 0;
 }
 
-CaptionDefProto const * BaseRule::GetCaption(int) const
+CaptionRuleProto const * BaseRule::GetCaption() const
 {
   return 0;
 }
 
-text_type_t BaseRule::GetCaptionTextType(int) const
-{
-  return text_type_name;
-}
-
-int BaseRule::GetCaptionsPriority() const
+PathTextRuleProto const * BaseRule::GetPathtext() const
 {
   return 0;
 }
@@ -159,7 +144,11 @@ namespace
     {
       LineRuleProto m_line;
     public:
-      explicit Line(LineRuleProto const & r) : m_line(r) {}
+      explicit Line(LineRuleProto const & r)
+        : m_line(r)
+      {
+        CHECK(r.has_pathsym() || r.width() > 0, ("Zero width line w/o path symbol)")); //pastk
+      }
 
       virtual LineRuleProto const * GetLine() const { return &m_line; }
     };
@@ -182,57 +171,27 @@ namespace
       virtual SymbolRuleProto const * GetSymbol() const { return &m_symbol; }
     };
 
-    template <class T> class CaptionT : public BaseRule
+    class Caption : public BaseRule
     {
-      T m_caption;
-
-      text_type_t m_textTypePrimary;
-      text_type_t m_textTypeSecondary;
-
+      CaptionRuleProto m_caption;
     public:
-      explicit CaptionT(T const & r)
-        : m_caption(r), m_textTypePrimary(text_type_name), m_textTypeSecondary(text_type_name)
+      explicit Caption(CaptionRuleProto const & r)
+        : m_caption(r)
       {
-        if (!m_caption.primary().text().empty())
-          m_textTypePrimary = GetTextType(m_caption.primary().text());
-
-        if (m_caption.has_secondary() && !m_caption.secondary().text().empty())
-          m_textTypeSecondary = GetTextType(m_caption.secondary().text());
+        CHECK(r.has_primary(),()); //pastk
       }
 
-      virtual CaptionDefProto const * GetCaption(int i) const
-      {
-        if (i == 0)
-          return &m_caption.primary();
-        else
-        {
-          ASSERT_EQUAL ( i, 1, () );
-          if (m_caption.has_secondary())
-            return &m_caption.secondary();
-          else
-            return 0;
-        }
-      }
-
-      virtual int GetCaptionsPriority() const
-      {
-        return m_caption.priority();
-      }
-
-      virtual text_type_t GetCaptionTextType(int i) const
-      {
-        if (i == 0)
-          return m_textTypePrimary;
-        else
-        {
-          ASSERT_EQUAL ( i, 1, () );
-          return m_textTypeSecondary;
-        }
-      }
+      virtual CaptionRuleProto const * GetCaption() const { return &m_caption; }
     };
 
-    typedef CaptionT<CaptionRuleProto> Caption;
-    typedef CaptionT<PathTextRuleProto> PathText;
+    class PathText : public BaseRule
+    {
+      PathTextRuleProto m_pathtext;
+    public:
+      explicit PathText(PathTextRuleProto const & r) : m_pathtext(r) {}
+
+      virtual PathTextRuleProto const * GetPathtext() const { return &m_pathtext; }
+    };
 
     class Shield : public BaseRule
     {

--- a/indexer/drawing_rules.hpp
+++ b/indexer/drawing_rules.hpp
@@ -19,7 +19,8 @@
 class LineRuleProto;
 class AreaRuleProto;
 class SymbolRuleProto;
-class CaptionDefProto;
+class CaptionRuleProto;
+class PathTextRuleProto;
 class ShieldRuleProto;
 class ContainerProto;
 class FeatureType;
@@ -36,9 +37,8 @@ namespace drule
     virtual LineRuleProto const * GetLine() const;
     virtual AreaRuleProto const * GetArea() const;
     virtual SymbolRuleProto const * GetSymbol() const;
-    virtual CaptionDefProto const * GetCaption(int) const;
-    virtual text_type_t GetCaptionTextType(int) const;
-    virtual int GetCaptionsPriority() const;
+    virtual CaptionRuleProto const * GetCaption() const;
+    virtual PathTextRuleProto const * GetPathtext() const;
     virtual ShieldRuleProto const * GetShield() const;
 
     // Test feature by runtime feature style selector

--- a/map/transit/transit_reader.cpp
+++ b/map/transit/transit_reader.cpp
@@ -165,7 +165,7 @@ void ReadTransitTask::Do()
 
     if (featureInfo.m_isGate)
     {
-      //TODO: there should be a simpler way to just get a symbol name.
+      //TODO(pastk): there should be a simpler way to just get a symbol name.
       df::Stylist stylist(ft, 19, 0);
       if (stylist.m_symbolRule != nullptr)
         featureInfo.m_gateSymbolName = stylist.m_symbolRule->name();

--- a/map/transit/transit_reader.cpp
+++ b/map/transit/transit_reader.cpp
@@ -168,11 +168,7 @@ void ReadTransitTask::Do()
       //TODO: there should be a simpler way to just get a symbol name.
       df::Stylist stylist(ft, 19, 0);
       if (stylist.m_symbolRule != nullptr)
-      {
-        auto const * symRule = stylist.m_symbolRule->GetSymbol();
-        ASSERT(symRule != nullptr, ());
-        featureInfo.m_gateSymbolName = symRule->name();
-      }
+        featureInfo.m_gateSymbolName = stylist.m_symbolRule->name();
     }
     featureInfo.m_point = feature::GetCenter(ft);
   }, features);


### PR DESCRIPTION
Follow-up to #6034.

Optimizations:
- don't parse a road ref if there is no shield drule
- don't process a shield drule if there are no road shields in a ref
- call ClipSplineByRect() once per linear feature (not for each line drule)
- calculate areaDepth for BG-by-size areas only

...and many minor things like replace redundant checks with asserts, less params wrapping and passing, simpler structure, etc.

P.S. I'll squash and sign commits after review.