### PR TITLE
[editor] Use name in local language

### DIFF
--- a/android/app/src/main/cpp/app/organicmaps/editor/Editor.cpp
+++ b/android/app/src/main/cpp/app/organicmaps/editor/Editor.cpp
@@ -236,26 +236,14 @@ Java_app_organicmaps_editor_Editor_nativeIsBuilding(JNIEnv * env, jclass clazz)
 }
 
 JNIEXPORT jobject JNICALL
-Java_app_organicmaps_editor_Editor_nativeGetNamesDataSource(JNIEnv * env, jclass, jboolean needFakes)
+Java_app_organicmaps_editor_Editor_nativeGetNamesDataSource(JNIEnv * env, jclass)
 {
-  auto const namesDataSource = g_editableMapObject.GetNamesDataSource(needFakes);
+  auto const namesDataSource = g_editableMapObject.GetNamesDataSource();
 
   jobjectArray names = jni::ToJavaArray(env, g_localNameClazz, namesDataSource.names, ToJavaName);
   jsize const mandatoryNamesCount = static_cast<jsize>(namesDataSource.mandatoryNamesCount);
 
   return env->NewObject(g_namesDataSourceClassID, g_namesDataSourceConstructorID, names, mandatoryNamesCount);
-}
-
-JNIEXPORT jstring JNICALL
-Java_app_organicmaps_editor_Editor_nativeGetDefaultName(JNIEnv * env, jclass)
-{
-  return jni::ToJavaString(env, g_editableMapObject.GetDefaultName());
-}
-
-JNIEXPORT void JNICALL
-Java_app_organicmaps_editor_Editor_nativeEnableNamesAdvancedMode(JNIEnv *, jclass)
-{
-  g_editableMapObject.EnableNamesAdvancedMode();
 }
 
 JNIEXPORT void JNICALL

--- a/android/app/src/main/java/app/organicmaps/editor/Editor.java
+++ b/android/app/src/main/java/app/organicmaps/editor/Editor.java
@@ -92,9 +92,7 @@ public final class Editor
   public static native boolean nativeIsPointType();
   public static native boolean nativeIsBuilding();
 
-  public static native NamesDataSource nativeGetNamesDataSource(boolean needFakes);
-  public static native String nativeGetDefaultName();
-  public static native void nativeEnableNamesAdvancedMode();
+  public static native NamesDataSource nativeGetNamesDataSource();
   public static native void nativeSetNames(@NonNull LocalizedName[] names);
   public static native LocalizedName nativeMakeLocalizedName(String langCode, String name);
   public static native Language[] nativeGetSupportedLanguages();

--- a/android/app/src/main/java/app/organicmaps/editor/EditorHostFragment.java
+++ b/android/app/src/main/java/app/organicmaps/editor/EditorHostFragment.java
@@ -103,9 +103,9 @@ public class EditorHostFragment extends BaseMwmToolbarFragment implements View.O
     mMandatoryNamesCount = mandatoryNamesCount;
   }
 
-  private void fillNames(boolean needFakes)
+  private void fillNames()
   {
-    NamesDataSource namesDataSource = Editor.nativeGetNamesDataSource(needFakes);
+    NamesDataSource namesDataSource = Editor.nativeGetNamesDataSource();
     setNames(namesDataSource.getNames());
     setMandatoryNamesCount(namesDataSource.getMandatoryNamesCount());
     editMapObject();
@@ -135,7 +135,7 @@ public class EditorHostFragment extends BaseMwmToolbarFragment implements View.O
       mIsNewObject = getArguments().getBoolean(EditorActivity.EXTRA_NEW_OBJECT, false);
     getToolbarController().setTitle(getTitle());
 
-    fillNames(true /* addFakes */);
+    fillNames();
   }
 
   @StringRes
@@ -403,13 +403,6 @@ public class EditorHostFragment extends BaseMwmToolbarFragment implements View.O
   public void onLanguageSelected(Language lang)
   {
     String name = "";
-    if (lang.code.equals(Language.DEFAULT_LANG_CODE))
-    {
-      fillNames(false /* addFakes */);
-      name = Editor.nativeGetDefaultName();
-      Editor.nativeEnableNamesAdvancedMode();
-    }
-
     addName(Editor.nativeMakeLocalizedName(lang.code, name));
     editMapObject(true /* focusToLastName */);
   }

--- a/android/app/src/main/java/app/organicmaps/editor/LanguagesFragment.java
+++ b/android/app/src/main/java/app/organicmaps/editor/LanguagesFragment.java
@@ -38,15 +38,7 @@ public class LanguagesFragment extends BaseMwmRecyclerFragment<LanguagesAdapter>
         languages.add(lang);
     }
 
-    Collections.sort(languages, (lhs, rhs) -> {
-      // Default name can be changed, but it should be last in list of names.
-      if (lhs.isDefaultLang() && !rhs.isDefaultLang())
-        return 1;
-      if (!lhs.isDefaultLang() && rhs.isDefaultLang())
-        return -1;
-
-      return lhs.name.compareTo(rhs.name);
-    });
+    Collections.sort(languages, Comparator.comparing(lhs -> lhs.name));
 
     return new LanguagesAdapter(this, languages.toArray(new Language[languages.size()]));
   }

--- a/android/app/src/main/java/app/organicmaps/editor/MultilanguageAdapter.java
+++ b/android/app/src/main/java/app/organicmaps/editor/MultilanguageAdapter.java
@@ -10,6 +10,7 @@ import androidx.recyclerview.widget.RecyclerView;
 import com.google.android.material.textfield.TextInputLayout;
 import com.google.android.material.textfield.TextInputEditText;
 import app.organicmaps.R;
+import app.organicmaps.editor.data.Language;
 import app.organicmaps.editor.data.LocalizedName;
 import app.organicmaps.util.StringUtils;
 import app.organicmaps.util.UiUtils;
@@ -43,7 +44,10 @@ public class MultilanguageAdapter extends RecyclerView.Adapter<MultilanguageAdap
   {
     LocalizedName name = mNames.get(position);
     holder.input.setText(name.name);
-    holder.inputLayout.setHint(name.langName);
+    if (name.lang.equals(Language.DEFAULT_LANG_CODE))
+      holder.inputLayout.setHint(holder.itemView.getContext().getString(R.string.editor_default_language_hint));
+    else
+      holder.inputLayout.setHint(name.langName);
   }
 
   @Override

--- a/android/app/src/main/java/app/organicmaps/editor/data/Language.java
+++ b/android/app/src/main/java/app/organicmaps/editor/data/Language.java
@@ -20,9 +20,4 @@ public class Language
     this.code = code;
     this.name = name;
   }
-
-  public boolean isDefaultLang()
-  {
-    return code.equals(DEFAULT_LANG_CODE);
-  }
 }

--- a/android/app/src/main/res/values-ar/strings.xml
+++ b/android/app/src/main/res/values-ar/strings.xml
@@ -490,6 +490,8 @@
 	<string name="editor_edit_place_title">يتم التعديل</string>
 	<string name="editor_add_place_title">يتم الإضافة</string>
 	<string name="editor_edit_place_name_hint">اسم المكان</string>
+	<!-- The second part of the editor_edit_place_name_hint to explain that name should be entered in a local language, see https://wiki.openstreetmap.org/wiki/Key:name -->
+	<string name="editor_default_language_hint">كما هو مكتوب باللغة المحلية</string>
 	<string name="editor_edit_place_category_title">الفئة</string>
 	<string name="detailed_problem_description">وصف مفصّل للمشكلة</string>
 	<string name="editor_report_problem_other_title">مشكلة أخرى</string>

--- a/android/app/src/main/res/values-az/strings.xml
+++ b/android/app/src/main/res/values-az/strings.xml
@@ -477,6 +477,8 @@
 	<string name="editor_edit_place_title">Redaktə</string>
 	<string name="editor_add_place_title">Əlavə</string>
 	<string name="editor_edit_place_name_hint">Yerin adı</string>
+	<!-- The second part of the editor_edit_place_name_hint to explain that name should be entered in a local language, see https://wiki.openstreetmap.org/wiki/Key:name -->
+	<string name="editor_default_language_hint">Yerli dildə yazıldığı kimi</string>
 	<string name="editor_edit_place_category_title">Kateqoriya</string>
 	<string name="detailed_problem_description">Problemin ətraflı təsviri</string>
 	<string name="editor_report_problem_other_title">Fərqli problem</string>

--- a/android/app/src/main/res/values-be/strings.xml
+++ b/android/app/src/main/res/values-be/strings.xml
@@ -475,6 +475,8 @@
 	<string name="editor_edit_place_title">Рэдагаванне</string>
 	<string name="editor_add_place_title">Даданне</string>
 	<string name="editor_edit_place_name_hint">Назва месца</string>
+	<!-- The second part of the editor_edit_place_name_hint to explain that name should be entered in a local language, see https://wiki.openstreetmap.org/wiki/Key:name -->
+	<string name="editor_default_language_hint">На мясцовай мове</string>
 	<string name="editor_edit_place_category_title">Катэгорыя</string>
 	<string name="detailed_problem_description">Падрабязнае апісанне праблемы</string>
 	<string name="editor_report_problem_other_title">Іншая праблема</string>

--- a/android/app/src/main/res/values-bg/strings.xml
+++ b/android/app/src/main/res/values-bg/strings.xml
@@ -443,6 +443,8 @@
 	<string name="editor_edit_place_title">Редактиране</string>
 	<string name="editor_add_place_title">Добавяне</string>
 	<string name="editor_edit_place_name_hint">Име на мястото</string>
+	<!-- The second part of the editor_edit_place_name_hint to explain that name should be entered in a local language, see https://wiki.openstreetmap.org/wiki/Key:name -->
+	<string name="editor_default_language_hint">Както е написано на местния език</string>
 	<string name="editor_edit_place_category_title">Категория</string>
 	<string name="detailed_problem_description">Подробно описание на проблема</string>
 	<string name="editor_report_problem_other_title">Друг проблем</string>

--- a/android/app/src/main/res/values-ca/strings.xml
+++ b/android/app/src/main/res/values-ca/strings.xml
@@ -470,6 +470,8 @@
 	<string name="editor_edit_place_title">Edició</string>
 	<string name="editor_add_place_title">Addició</string>
 	<string name="editor_edit_place_name_hint">Nom del lloc</string>
+	<!-- The second part of the editor_edit_place_name_hint to explain that name should be entered in a local language, see https://wiki.openstreetmap.org/wiki/Key:name -->
+	<string name="editor_default_language_hint">Com està escrit en la llengua local</string>
 	<string name="editor_edit_place_category_title">Categoria</string>
 	<string name="detailed_problem_description">Descripció detallada del problema</string>
 	<string name="editor_report_problem_other_title">Un altre problema</string>

--- a/android/app/src/main/res/values-cs/strings.xml
+++ b/android/app/src/main/res/values-cs/strings.xml
@@ -457,6 +457,8 @@
 	<string name="editor_edit_place_title">Probíhají úpravy</string>
 	<string name="editor_add_place_title">Probíhá přidávání</string>
 	<string name="editor_edit_place_name_hint">Název místa</string>
+	<!-- The second part of the editor_edit_place_name_hint to explain that name should be entered in a local language, see https://wiki.openstreetmap.org/wiki/Key:name -->
+	<string name="editor_default_language_hint">Jak je napsáno v místním jazyce</string>
 	<string name="editor_edit_place_category_title">Kategorie</string>
 	<string name="detailed_problem_description">Detailní popis problému</string>
 	<string name="editor_report_problem_other_title">Jiný problém</string>

--- a/android/app/src/main/res/values-da/strings.xml
+++ b/android/app/src/main/res/values-da/strings.xml
@@ -453,6 +453,8 @@
 	<string name="editor_edit_place_title">Redigerer</string>
 	<string name="editor_add_place_title">Tilføjer</string>
 	<string name="editor_edit_place_name_hint">Stedets navn</string>
+	<!-- The second part of the editor_edit_place_name_hint to explain that name should be entered in a local language, see https://wiki.openstreetmap.org/wiki/Key:name -->
+	<string name="editor_default_language_hint">Som det står skrevet på det lokale sprog</string>
 	<string name="editor_edit_place_category_title">Kategori</string>
 	<string name="detailed_problem_description">Detaljeret beskrivelse af problemet</string>
 	<string name="editor_report_problem_other_title">Et anderledes problem</string>

--- a/android/app/src/main/res/values-de/strings.xml
+++ b/android/app/src/main/res/values-de/strings.xml
@@ -473,6 +473,8 @@
 	<string name="editor_edit_place_title">Wird bearbeitet</string>
 	<string name="editor_add_place_title">Wird hinzugefügt</string>
 	<string name="editor_edit_place_name_hint">Name des Ortes</string>
+	<!-- The second part of the editor_edit_place_name_hint to explain that name should be entered in a local language, see https://wiki.openstreetmap.org/wiki/Key:name -->
+	<string name="editor_default_language_hint">Wie in der lokalen Sprache geschrieben</string>
 	<string name="editor_edit_place_category_title">Kategorie</string>
 	<string name="detailed_problem_description">Detaillierte Beschreibung eines Problems</string>
 	<string name="editor_report_problem_other_title">Ein anderes Problem</string>

--- a/android/app/src/main/res/values-el/strings.xml
+++ b/android/app/src/main/res/values-el/strings.xml
@@ -478,6 +478,8 @@
 	<string name="editor_edit_place_title">Επεξεργασία</string>
 	<string name="editor_add_place_title">Προσθήκη</string>
 	<string name="editor_edit_place_name_hint">Όνομα τοποθεσίας</string>
+	<!-- The second part of the editor_edit_place_name_hint to explain that name should be entered in a local language, see https://wiki.openstreetmap.org/wiki/Key:name -->
+	<string name="editor_default_language_hint">Όπως είναι γραμμένο στην τοπική γλώσσα</string>
 	<string name="editor_edit_place_category_title">Κατηγορία</string>
 	<string name="detailed_problem_description">Λεπτομερής περιγραφή του θέματος</string>
 	<string name="editor_report_problem_other_title">Διαφορετικό πρόβλημα</string>

--- a/android/app/src/main/res/values-es/strings.xml
+++ b/android/app/src/main/res/values-es/strings.xml
@@ -477,6 +477,8 @@
 	<string name="editor_edit_place_title">Editar</string>
 	<string name="editor_add_place_title">Añadir</string>
 	<string name="editor_edit_place_name_hint">Nombre del lugar</string>
+	<!-- The second part of the editor_edit_place_name_hint to explain that name should be entered in a local language, see https://wiki.openstreetmap.org/wiki/Key:name -->
+	<string name="editor_default_language_hint">Como está escrito en la lengua local</string>
 	<string name="editor_edit_place_category_title">Categoría</string>
 	<string name="detailed_problem_description">Descripción detallada del problema</string>
 	<string name="editor_report_problem_other_title">Un problema diferente</string>

--- a/android/app/src/main/res/values-et/strings.xml
+++ b/android/app/src/main/res/values-et/strings.xml
@@ -469,6 +469,8 @@
 	<string name="editor_edit_place_title">Muutmine</string>
 	<string name="editor_add_place_title">Lisamine</string>
 	<string name="editor_edit_place_name_hint">Koha nimi</string>
+	<!-- The second part of the editor_edit_place_name_hint to explain that name should be entered in a local language, see https://wiki.openstreetmap.org/wiki/Key:name -->
+	<string name="editor_default_language_hint">Nagu on kirjutatud kohalikus keeles</string>
 	<string name="editor_edit_place_category_title">Kategooria</string>
 	<string name="detailed_problem_description">Probleemi üksikasjalik kirjeldus</string>
 	<string name="editor_report_problem_other_title">Erinev probleem</string>

--- a/android/app/src/main/res/values-eu/strings.xml
+++ b/android/app/src/main/res/values-eu/strings.xml
@@ -475,6 +475,8 @@
 	<string name="editor_edit_place_title">Editatzen</string>
 	<string name="editor_add_place_title">Gehitzen</string>
 	<string name="editor_edit_place_name_hint">Tokiaren izena</string>
+	<!-- The second part of the editor_edit_place_name_hint to explain that name should be entered in a local language, see https://wiki.openstreetmap.org/wiki/Key:name -->
+	<string name="editor_default_language_hint">Bertako hizkuntzan idatzita dagoenez</string>
 	<string name="editor_edit_place_category_title">Kategoria</string>
 	<string name="detailed_problem_description">Arazoaren deskribapen zehatza</string>
 	<string name="editor_report_problem_other_title">Beste arazo bat</string>

--- a/android/app/src/main/res/values-fa/strings.xml
+++ b/android/app/src/main/res/values-fa/strings.xml
@@ -448,6 +448,8 @@
 	<string name="editor_edit_place_title">درحال ویرایش</string>
 	<string name="editor_add_place_title">درحال افزودن</string>
 	<string name="editor_edit_place_name_hint">نام مکان</string>
+	<!-- The second part of the editor_edit_place_name_hint to explain that name should be entered in a local language, see https://wiki.openstreetmap.org/wiki/Key:name -->
+	<string name="editor_default_language_hint">همانطور که به زبان محلی نوشته شده است</string>
 	<string name="editor_edit_place_category_title">دسته بندی</string>
 	<string name="detailed_problem_description">توضیح مفصل در مورد مشکل</string>
 	<string name="editor_report_problem_other_title">مشکلی دیگر</string>

--- a/android/app/src/main/res/values-fi/strings.xml
+++ b/android/app/src/main/res/values-fi/strings.xml
@@ -479,6 +479,8 @@
 	<string name="editor_edit_place_title">Muokkaus</string>
 	<string name="editor_add_place_title">Lisääminen</string>
 	<string name="editor_edit_place_name_hint">Paikan nimi</string>
+	<!-- The second part of the editor_edit_place_name_hint to explain that name should be entered in a local language, see https://wiki.openstreetmap.org/wiki/Key:name -->
+	<string name="editor_default_language_hint">Paikallisella kielellä kirjoitettuna</string>
 	<string name="editor_edit_place_category_title">Kategoria</string>
 	<string name="detailed_problem_description">Ongelman tarkka kuvaus</string>
 	<string name="editor_report_problem_other_title">Eri ongelma</string>

--- a/android/app/src/main/res/values-fr/strings.xml
+++ b/android/app/src/main/res/values-fr/strings.xml
@@ -479,6 +479,8 @@
 	<string name="editor_edit_place_title">Modification</string>
 	<string name="editor_add_place_title">Ajout</string>
 	<string name="editor_edit_place_name_hint">Nom du lieu</string>
+	<!-- The second part of the editor_edit_place_name_hint to explain that name should be entered in a local language, see https://wiki.openstreetmap.org/wiki/Key:name -->
+	<string name="editor_default_language_hint">Comme c\'est écrit dans la langue locale</string>
 	<string name="editor_edit_place_category_title">Catégorie</string>
 	<string name="detailed_problem_description">Description détaillée du problème</string>
 	<string name="editor_report_problem_other_title">Autre problème</string>

--- a/android/app/src/main/res/values-hi/strings.xml
+++ b/android/app/src/main/res/values-hi/strings.xml
@@ -363,6 +363,8 @@
 	<string name="editor_focus_map_on_location">ऑब्जेक्ट का सही स्थान चुनने के लिए मानचित्र को खींचें।</string>
 	<string name="editor_add_place_title">जोड़ना</string>
 	<string name="editor_edit_place_name_hint">स्थान का नाम</string>
+	<!-- The second part of the editor_edit_place_name_hint to explain that name should be entered in a local language, see https://wiki.openstreetmap.org/wiki/Key:name -->
+	<string name="editor_default_language_hint">जैसा कि स्थानीय भाषा में लिखा गया है</string>
 	<string name="editor_edit_place_category_title">वर्ग</string>
 	<string name="placepage_add_business_button">व्यवसाय जोड़ें</string>
 	<!-- Text in About and OSM Login screens. First %@ is replaced by a local, human readable date. -->

--- a/android/app/src/main/res/values-hu/strings.xml
+++ b/android/app/src/main/res/values-hu/strings.xml
@@ -465,6 +465,8 @@
 	<string name="editor_edit_place_title">Szerkesztés</string>
 	<string name="editor_add_place_title">Hozzáadás</string>
 	<string name="editor_edit_place_name_hint">Hely neve</string>
+	<!-- The second part of the editor_edit_place_name_hint to explain that name should be entered in a local language, see https://wiki.openstreetmap.org/wiki/Key:name -->
+	<string name="editor_default_language_hint">Ahogy a helyi nyelven írva van</string>
 	<string name="editor_edit_place_category_title">Kategória</string>
 	<string name="detailed_problem_description">A probléma részletes leírása</string>
 	<string name="editor_report_problem_other_title">Különböző problémaDifferent problem</string>

--- a/android/app/src/main/res/values-in/strings.xml
+++ b/android/app/src/main/res/values-in/strings.xml
@@ -453,6 +453,8 @@
 	<string name="editor_edit_place_title">Mengedit</string>
 	<string name="editor_add_place_title">Menambahkan</string>
 	<string name="editor_edit_place_name_hint">Nama tempat</string>
+	<!-- The second part of the editor_edit_place_name_hint to explain that name should be entered in a local language, see https://wiki.openstreetmap.org/wiki/Key:name -->
+	<string name="editor_default_language_hint">Seperti yang tertulis dalam bahasa lokal</string>
 	<string name="editor_edit_place_category_title">Kategori</string>
 	<string name="detailed_problem_description">Gambaran terperinci tentang masalah</string>
 	<string name="editor_report_problem_other_title">Masalah yang berbeda</string>

--- a/android/app/src/main/res/values-it/strings.xml
+++ b/android/app/src/main/res/values-it/strings.xml
@@ -463,6 +463,8 @@
 	<string name="editor_edit_place_title">Modifica</string>
 	<string name="editor_add_place_title">Aggiungi</string>
 	<string name="editor_edit_place_name_hint">Nome del luogo</string>
+	<!-- The second part of the editor_edit_place_name_hint to explain that name should be entered in a local language, see https://wiki.openstreetmap.org/wiki/Key:name -->
+	<string name="editor_default_language_hint">Come è scritto nella lingua locale</string>
 	<string name="editor_edit_place_category_title">Categoria</string>
 	<string name="detailed_problem_description">Descrizione dettagliata del problema</string>
 	<string name="editor_report_problem_other_title">Un problema diverso</string>

--- a/android/app/src/main/res/values-iw/strings.xml
+++ b/android/app/src/main/res/values-iw/strings.xml
@@ -469,6 +469,8 @@
 	<string name="editor_edit_place_title">עריכת מקום</string>
 	<string name="editor_add_place_title">הוספת מקום</string>
 	<string name="editor_edit_place_name_hint">שם המקום</string>
+	<!-- The second part of the editor_edit_place_name_hint to explain that name should be entered in a local language, see https://wiki.openstreetmap.org/wiki/Key:name -->
+	<string name="editor_default_language_hint">כפי שנכתב בשפה המקומית</string>
 	<string name="editor_edit_place_category_title">קטגוריה</string>
 	<string name="detailed_problem_description">תאור מפורט של הבעיה</string>
 	<string name="editor_report_problem_other_title">בעיה אחרת</string>

--- a/android/app/src/main/res/values-ja/strings.xml
+++ b/android/app/src/main/res/values-ja/strings.xml
@@ -479,6 +479,8 @@
 	<string name="editor_edit_place_title">編集中</string>
 	<string name="editor_add_place_title">追加中</string>
 	<string name="editor_edit_place_name_hint">場所の名前</string>
+	<!-- The second part of the editor_edit_place_name_hint to explain that name should be entered in a local language, see https://wiki.openstreetmap.org/wiki/Key:name -->
+	<string name="editor_default_language_hint">現地の言葉でこう書かれている。</string>
 	<string name="editor_edit_place_category_title">カテゴリ</string>
 	<string name="detailed_problem_description">問題の詳細な説明</string>
 	<string name="editor_report_problem_other_title">異なる問題</string>

--- a/android/app/src/main/res/values-ko/strings.xml
+++ b/android/app/src/main/res/values-ko/strings.xml
@@ -451,6 +451,8 @@
 	<string name="editor_edit_place_title">편집 중</string>
 	<string name="editor_add_place_title">첨가 중</string>
 	<string name="editor_edit_place_name_hint">장소 이름</string>
+	<!-- The second part of the editor_edit_place_name_hint to explain that name should be entered in a local language, see https://wiki.openstreetmap.org/wiki/Key:name -->
+	<string name="editor_default_language_hint">현지 언어로 작성되었으므로</string>
 	<string name="editor_edit_place_category_title">범주</string>
 	<string name="detailed_problem_description">문제에 대한 자세한 설명</string>
 	<string name="editor_report_problem_other_title">다른 문제</string>

--- a/android/app/src/main/res/values-mr/strings.xml
+++ b/android/app/src/main/res/values-mr/strings.xml
@@ -448,6 +448,8 @@
 	<string name="editor_edit_place_title">संपादन</string>
 	<string name="editor_add_place_title">जोडणे</string>
 	<string name="editor_edit_place_name_hint">ठिकाणाचे नाव</string>
+	<!-- The second part of the editor_edit_place_name_hint to explain that name should be entered in a local language, see https://wiki.openstreetmap.org/wiki/Key:name -->
+	<string name="editor_default_language_hint">स्थानिक भाषेत लिहिल्याप्रमाणे</string>
 	<string name="editor_edit_place_category_title">प्रवर्ग</string>
 	<string name="detailed_problem_description">समस्येचे तपशिलात वर्णन</string>
 	<string name="editor_report_problem_other_title">वेगळी समस्या</string>

--- a/android/app/src/main/res/values-nb/strings.xml
+++ b/android/app/src/main/res/values-nb/strings.xml
@@ -477,6 +477,8 @@
 	<string name="editor_edit_place_title">Redigerer</string>
 	<string name="editor_add_place_title">Legger til</string>
 	<string name="editor_edit_place_name_hint">Navn på stedet</string>
+	<!-- The second part of the editor_edit_place_name_hint to explain that name should be entered in a local language, see https://wiki.openstreetmap.org/wiki/Key:name -->
+	<string name="editor_default_language_hint">Som det står skrevet på det lokale språket</string>
 	<string name="editor_edit_place_category_title">Kategori</string>
 	<string name="detailed_problem_description">Detaljert beskrivelse av problemet</string>
 	<string name="editor_report_problem_other_title">Et annet problem</string>

--- a/android/app/src/main/res/values-nl/strings.xml
+++ b/android/app/src/main/res/values-nl/strings.xml
@@ -473,6 +473,8 @@
 	<string name="editor_edit_place_title">Aan het aanpassen</string>
 	<string name="editor_add_place_title">Aan het toevoegen</string>
 	<string name="editor_edit_place_name_hint">Naam van de plaats</string>
+	<!-- The second part of the editor_edit_place_name_hint to explain that name should be entered in a local language, see https://wiki.openstreetmap.org/wiki/Key:name -->
+	<string name="editor_default_language_hint">Zoals het in de plaatselijke taal geschreven staat</string>
 	<string name="editor_edit_place_category_title">Categorie</string>
 	<string name="detailed_problem_description">Gedetailleerde probleemomschrijving</string>
 	<string name="editor_report_problem_other_title">Een ander probleem</string>

--- a/android/app/src/main/res/values-pl/strings.xml
+++ b/android/app/src/main/res/values-pl/strings.xml
@@ -477,6 +477,8 @@
 	<string name="editor_edit_place_title">Edycja</string>
 	<string name="editor_add_place_title">Dodawanie</string>
 	<string name="editor_edit_place_name_hint">Nazwa miejsca</string>
+	<!-- The second part of the editor_edit_place_name_hint to explain that name should be entered in a local language, see https://wiki.openstreetmap.org/wiki/Key:name -->
+	<string name="editor_default_language_hint">Jak napisano w lokalnym języku</string>
 	<string name="editor_edit_place_category_title">Kategoria</string>
 	<string name="detailed_problem_description">Szczegółowy opis problemu</string>
 	<string name="editor_report_problem_other_title">Inny problem</string>

--- a/android/app/src/main/res/values-pt/strings.xml
+++ b/android/app/src/main/res/values-pt/strings.xml
@@ -458,6 +458,8 @@
 	<string name="editor_edit_place_title">Edição</string>
 	<string name="editor_add_place_title">A adicionar</string>
 	<string name="editor_edit_place_name_hint">Nome do lugar</string>
+	<!-- The second part of the editor_edit_place_name_hint to explain that name should be entered in a local language, see https://wiki.openstreetmap.org/wiki/Key:name -->
+	<string name="editor_default_language_hint">Como escrito na língua local</string>
 	<string name="editor_edit_place_category_title">Categoria</string>
 	<string name="detailed_problem_description">Descrição detalhada do problema</string>
 	<string name="editor_report_problem_other_title">Um problema diferente</string>

--- a/android/app/src/main/res/values-ro/strings.xml
+++ b/android/app/src/main/res/values-ro/strings.xml
@@ -463,6 +463,8 @@
 	<string name="editor_edit_place_title">Modifică</string>
 	<string name="editor_add_place_title">Adaugă</string>
 	<string name="editor_edit_place_name_hint">Numele locului</string>
+	<!-- The second part of the editor_edit_place_name_hint to explain that name should be entered in a local language, see https://wiki.openstreetmap.org/wiki/Key:name -->
+	<string name="editor_default_language_hint">Așa cum este scris în limba locală</string>
 	<string name="editor_edit_place_category_title">Categorie</string>
 	<string name="detailed_problem_description">Descriere detaliată a problemei</string>
 	<string name="editor_report_problem_other_title">Altă problemă</string>

--- a/android/app/src/main/res/values-ru/strings.xml
+++ b/android/app/src/main/res/values-ru/strings.xml
@@ -480,6 +480,8 @@
 	<string name="editor_edit_place_title">Редактирование</string>
 	<string name="editor_add_place_title">Добавление</string>
 	<string name="editor_edit_place_name_hint">Название места</string>
+	<!-- The second part of the editor_edit_place_name_hint to explain that name should be entered in a local language, see https://wiki.openstreetmap.org/wiki/Key:name -->
+	<string name="editor_default_language_hint">На местном языке</string>
 	<string name="editor_edit_place_category_title">Категория</string>
 	<string name="detailed_problem_description">Подробное описание проблемы</string>
 	<string name="editor_report_problem_other_title">Другая проблема</string>

--- a/android/app/src/main/res/values-sk/strings.xml
+++ b/android/app/src/main/res/values-sk/strings.xml
@@ -475,6 +475,8 @@
 	<string name="editor_edit_place_title">Úprava</string>
 	<string name="editor_add_place_title">Nové</string>
 	<string name="editor_edit_place_name_hint">Názov miesta</string>
+	<!-- The second part of the editor_edit_place_name_hint to explain that name should be entered in a local language, see https://wiki.openstreetmap.org/wiki/Key:name -->
+	<string name="editor_default_language_hint">Tak, ako sa píše v miestnom jazyku</string>
 	<string name="editor_edit_place_category_title">Kategória</string>
 	<string name="detailed_problem_description">Podrobný popis problému</string>
 	<string name="editor_report_problem_other_title">Iný problém</string>

--- a/android/app/src/main/res/values-sv/strings.xml
+++ b/android/app/src/main/res/values-sv/strings.xml
@@ -449,6 +449,8 @@
 	<string name="editor_edit_place_title">Redigerar</string>
 	<string name="editor_add_place_title">Lägger till</string>
 	<string name="editor_edit_place_name_hint">Namn på platsen</string>
+	<!-- The second part of the editor_edit_place_name_hint to explain that name should be entered in a local language, see https://wiki.openstreetmap.org/wiki/Key:name -->
+	<string name="editor_default_language_hint">Som det står skrivet på det lokala språket</string>
 	<string name="editor_edit_place_category_title">Kategori</string>
 	<string name="detailed_problem_description">Detaljerad beskrivning av ett problem</string>
 	<string name="editor_report_problem_other_title">Ett annat problem</string>

--- a/android/app/src/main/res/values-sw/strings.xml
+++ b/android/app/src/main/res/values-sw/strings.xml
@@ -92,6 +92,8 @@
 	<!-- SECTION: Strings for downloading map from search -->
 	<string name="login_osm">Ingia kwa OpenStreetMap</string>
 	<string name="level">Ghorofa</string>
+	<!-- The second part of the editor_edit_place_name_hint to explain that name should be entered in a local language, see https://wiki.openstreetmap.org/wiki/Key:name -->
+	<string name="editor_default_language_hint">Kama ilivyoandikwa katika lugha ya kienyeji</string>
 	<!-- Text in About and OSM Login screens. First %@ is replaced by a local, human readable date. -->
 	<string name="osm_presentation">Data ya OpenStreetMap iliyoundwa na jumuiya kufikia %s. Pata maelezo zaidi kuhusu jinsi ya kuhariri na kusasisha ramani katika OpenStreetMap.org</string>
 	<string name="editor_other_info">Tuma ujumbe kwenye vihariri vya OSM</string>

--- a/android/app/src/main/res/values-th/strings.xml
+++ b/android/app/src/main/res/values-th/strings.xml
@@ -453,6 +453,8 @@
 	<string name="editor_edit_place_title">กำลังแก้ไข</string>
 	<string name="editor_add_place_title">กำลังเพิ่ม</string>
 	<string name="editor_edit_place_name_hint">ชื่อสถานที่</string>
+	<!-- The second part of the editor_edit_place_name_hint to explain that name should be entered in a local language, see https://wiki.openstreetmap.org/wiki/Key:name -->
+	<string name="editor_default_language_hint">ตามที่เขียนเป็นภาษาท้องถิ่น</string>
 	<string name="editor_edit_place_category_title">หมวดหมู่</string>
 	<string name="detailed_problem_description">คำอธิบายปัญหาอย่างละเอียด</string>
 	<string name="editor_report_problem_other_title">ปัญหาอีกอย่างหนึ่ง</string>

--- a/android/app/src/main/res/values-tr/strings.xml
+++ b/android/app/src/main/res/values-tr/strings.xml
@@ -477,6 +477,8 @@
 	<string name="editor_edit_place_title">Düzenleme</string>
 	<string name="editor_add_place_title">Ekleme</string>
 	<string name="editor_edit_place_name_hint">Yerin adı</string>
+	<!-- The second part of the editor_edit_place_name_hint to explain that name should be entered in a local language, see https://wiki.openstreetmap.org/wiki/Key:name -->
+	<string name="editor_default_language_hint">Yerel dilde yazıldığı gibi</string>
 	<string name="editor_edit_place_category_title">Kategori</string>
 	<string name="detailed_problem_description">Sorunun ayrıntılı açıklaması</string>
 	<string name="editor_report_problem_other_title">Farklı bir sorun</string>

--- a/android/app/src/main/res/values-uk/strings.xml
+++ b/android/app/src/main/res/values-uk/strings.xml
@@ -479,6 +479,8 @@
 	<string name="editor_edit_place_title">Редагування</string>
 	<string name="editor_add_place_title">Додавання</string>
 	<string name="editor_edit_place_name_hint">Назва місця</string>
+	<!-- The second part of the editor_edit_place_name_hint to explain that name should be entered in a local language, see https://wiki.openstreetmap.org/wiki/Key:name -->
+	<string name="editor_default_language_hint">Місцевою мовою</string>
 	<string name="editor_edit_place_category_title">Категорія</string>
 	<string name="detailed_problem_description">Детальний опис проблеми</string>
 	<string name="editor_report_problem_other_title">Інші проблема</string>

--- a/android/app/src/main/res/values-vi/strings.xml
+++ b/android/app/src/main/res/values-vi/strings.xml
@@ -451,6 +451,8 @@
 	<string name="editor_edit_place_title">Chỉnh sửa</string>
 	<string name="editor_add_place_title">Nhập</string>
 	<string name="editor_edit_place_name_hint">Tên địa điểm</string>
+	<!-- The second part of the editor_edit_place_name_hint to explain that name should be entered in a local language, see https://wiki.openstreetmap.org/wiki/Key:name -->
+	<string name="editor_default_language_hint">Vì nó được viết bằng ngôn ngữ địa phương</string>
 	<string name="editor_edit_place_category_title">Thể loại</string>
 	<string name="detailed_problem_description">Mô tả chi tiết của vấn đề</string>
 	<string name="editor_report_problem_other_title">Một vấn đề khác</string>

--- a/android/app/src/main/res/values-zh-rTW/strings.xml
+++ b/android/app/src/main/res/values-zh-rTW/strings.xml
@@ -465,6 +465,8 @@
 	<string name="editor_edit_place_title">編輯中</string>
 	<string name="editor_add_place_title">新增中</string>
 	<string name="editor_edit_place_name_hint">該地點的名稱</string>
+	<!-- The second part of the editor_edit_place_name_hint to explain that name should be entered in a local language, see https://wiki.openstreetmap.org/wiki/Key:name -->
+	<string name="editor_default_language_hint">因為它是用當地語言寫的</string>
 	<string name="editor_edit_place_category_title">類別</string>
 	<string name="detailed_problem_description">問題的詳細描述</string>
 	<string name="editor_report_problem_other_title">不同的問題</string>

--- a/android/app/src/main/res/values-zh/strings.xml
+++ b/android/app/src/main/res/values-zh/strings.xml
@@ -462,6 +462,8 @@
 	<string name="editor_edit_place_title">编辑中</string>
 	<string name="editor_add_place_title">添加中</string>
 	<string name="editor_edit_place_name_hint">该地点的名称</string>
+	<!-- The second part of the editor_edit_place_name_hint to explain that name should be entered in a local language, see https://wiki.openstreetmap.org/wiki/Key:name -->
+	<string name="editor_default_language_hint">当地语言写道</string>
 	<string name="editor_edit_place_category_title">类别</string>
 	<string name="detailed_problem_description">问题的详细描述</string>
 	<string name="editor_report_problem_other_title">一个不同的问题</string>

--- a/android/app/src/main/res/values/strings.xml
+++ b/android/app/src/main/res/values/strings.xml
@@ -502,6 +502,8 @@
 	<string name="editor_edit_place_title">Editing</string>
 	<string name="editor_add_place_title">Adding</string>
 	<string name="editor_edit_place_name_hint">Name of the place</string>
+	<!-- The second part of the editor_edit_place_name_hint to explain that name should be entered in a local language, see https://wiki.openstreetmap.org/wiki/Key:name -->
+	<string name="editor_default_language_hint">As it is written in the local language</string>
 	<string name="editor_edit_place_category_title">Category</string>
 	<string name="detailed_problem_description">Detailed description of the issue</string>
 	<string name="editor_report_problem_other_title">Different problem</string>

--- a/data/strings/strings.txt
+++ b/data/strings/strings.txt
@@ -15303,6 +15303,51 @@
     zh-Hans = 该地点的名称
     zh-Hant = 該地點的名稱
 
+  [editor_default_language_hint]
+    tags = android,ios
+    comment = The second part of the editor_edit_place_name_hint to explain that name should be entered in a local language, see https://wiki.openstreetmap.org/wiki/Key:name
+    en = As it is written in the local language
+    af = Soos dit in die plaaslike taal geskryf is
+    ar = كما هو مكتوب باللغة المحلية
+    az = Yerli dildə yazıldığı kimi
+    be = На мясцовай мове
+    bg = Както е написано на местния език
+    ca = Com està escrit en la llengua local
+    cs = Jak je napsáno v místním jazyce
+    da = Som det står skrevet på det lokale sprog
+    de = Wie in der lokalen Sprache geschrieben
+    el = Όπως είναι γραμμένο στην τοπική γλώσσα
+    es = Como está escrito en la lengua local
+    et = Nagu on kirjutatud kohalikus keeles
+    eu = Bertako hizkuntzan idatzita dagoenez
+    fa = همانطور که به زبان محلی نوشته شده است
+    fi = Paikallisella kielellä kirjoitettuna
+    fr = Comme c'est écrit dans la langue locale
+    he = כפי שנכתב בשפה המקומית
+    hi = जैसा कि स्थानीय भाषा में लिखा गया है
+    hu = Ahogy a helyi nyelven írva van
+    id = Seperti yang tertulis dalam bahasa lokal
+    it = Come è scritto nella lingua locale
+    ja = 現地の言葉でこう書かれている。
+    ko = 현지 언어로 작성되었으므로
+    lt = Kaip rašoma vietos kalba
+    mr = स्थानिक भाषेत लिहिल्याप्रमाणे
+    nb = Som det står skrevet på det lokale språket
+    nl = Zoals het in de plaatselijke taal geschreven staat
+    pl = Jak napisano w lokalnym języku
+    pt = Como escrito na língua local
+    ro = Așa cum este scris în limba locală
+    ru = На местном языке
+    sk = Tak, ako sa píše v miestnom jazyku
+    sv = Som det står skrivet på det lokala språket
+    sw = Kama ilivyoandikwa katika lugha ya kienyeji
+    th = ตามที่เขียนเป็นภาษาท้องถิ่น
+    tr = Yerel dilde yazıldığı gibi
+    uk = Місцевою мовою
+    vi = Vì nó được viết bằng ngôn ngữ địa phương
+    zh-Hans = 当地语言写道
+    zh-Hant = 因為它是用當地語言寫的
+
   [editor_edit_place_category_title]
     tags = android,ios
     en = Category

--- a/indexer/editable_map_object.cpp
+++ b/indexer/editable_map_object.cpp
@@ -24,8 +24,7 @@ namespace
 bool ExtractName(StringUtf8Multilang const & names, int8_t const langCode,
                  vector<osm::LocalizedName> & result)
 {
-  if (StringUtf8Multilang::kUnsupportedLanguageCode == langCode ||
-      StringUtf8Multilang::kDefaultCode == langCode)
+  if (StringUtf8Multilang::kUnsupportedLanguageCode == langCode)
   {
     return false;
   }
@@ -44,113 +43,6 @@ bool ExtractName(StringUtf8Multilang const & names, int8_t const langCode,
   result.emplace_back(langCode, name);
 
   return true;
-}
-
-size_t PushMwmLanguages(StringUtf8Multilang const & names, vector<int8_t> const & mwmLanguages,
-                        vector<osm::LocalizedName> & result)
-{
-  size_t count = 0;
-  static size_t const kMaxCountMwmLanguages = 2;
-
-  for (size_t i = 0; i < mwmLanguages.size() && count < kMaxCountMwmLanguages; ++i)
-  {
-    if (ExtractName(names, mwmLanguages[i], result))
-      ++count;
-  }
-
-  return count;
-}
-
-osm::FakeNames MakeFakeSource(StringUtf8Multilang const & source,
-                              vector<int8_t> const & mwmLanguages, StringUtf8Multilang & fakeSource)
-{
-  string_view defaultName;
-  // Fake names works for mono language (official) speaking countries-only.
-  if (mwmLanguages.size() != 1 || !source.GetString(StringUtf8Multilang::kDefaultCode, defaultName))
-    return {};
-
-  osm::FakeNames fakeNames;
-  fakeSource = source;
-
-  // Mwm name has higher priority then English name.
-  for (auto const code : {mwmLanguages.front(), StringUtf8Multilang::kEnglishCode})
-  {
-    string_view tempName;
-    if (!source.GetString(code, tempName))
-    {
-      tempName = defaultName;
-      fakeSource.AddString(code, defaultName);
-    }
-    fakeNames.m_names.emplace_back(code, std::string(tempName));
-  }
-
-  fakeNames.m_defaultName = defaultName;
-  return fakeNames;
-}
-
-// Tries to set default name from the localized name. Returns false when there's no such localized name.
-bool TryToFillDefaultNameFromCode(int8_t const code, StringUtf8Multilang & names)
-{
-  string_view newDefaultName;
-  if (code != StringUtf8Multilang::kUnsupportedLanguageCode)
-    names.GetString(code, newDefaultName);
-
-  // Default name can not be empty.
-  if (!newDefaultName.empty())
-  {
-    names.AddString(StringUtf8Multilang::kDefaultCode, newDefaultName);
-    return true;
-  }
-
-  return false;
-}
-
-// Tries to set default name to any non-empty localized name.
-// This is the case when fake names were cleared.
-void TryToFillDefaultNameFromAnyLanguage(StringUtf8Multilang & names)
-{
-  names.ForEach([&names](int8_t langCode, string_view name)
-  {
-    if (name.empty() || langCode == StringUtf8Multilang::kDefaultCode)
-      return base::ControlFlow::Continue;
-
-    names.AddString(StringUtf8Multilang::kDefaultCode, name);
-    return base::ControlFlow::Break;
-  });
-}
-
-void RemoveFakesFromName(osm::FakeNames const & fakeNames, StringUtf8Multilang & name)
-{
-  vector<int8_t> codesToExclude;
-  string_view defaultName;
-  name.GetString(StringUtf8Multilang::kDefaultCode, defaultName);
-
-  for (auto const & item : fakeNames.m_names)
-  {
-    string_view tempName;
-    if (!name.GetString(item.m_code, tempName))
-      continue;
-
-    // No need to save in case when name is empty, duplicate of default name or was not changed.
-    if (tempName.empty() || tempName == defaultName ||
-        (tempName == item.m_filledName && tempName == fakeNames.m_defaultName))
-    {
-      codesToExclude.push_back(item.m_code);
-    }
-  }
-
-  if (codesToExclude.empty())
-    return;
-
-  StringUtf8Multilang nameWithoutFakes;
-  name.ForEach([&codesToExclude, &nameWithoutFakes](int8_t langCode, string_view value)
-  {
-    auto const it = find(codesToExclude.begin(), codesToExclude.end(), langCode);
-    if (it == codesToExclude.end())
-      nameWithoutFakes.AddString(langCode, value);
-  });
-
-  name = nameWithoutFakes;
 }
 }  // namespace
 
@@ -193,7 +85,7 @@ vector<MapObject::MetadataID> EditableMapObject::GetEditableProperties() const
   return props;
 }
 
-NamesDataSource EditableMapObject::GetNamesDataSource(bool needFakes /* = true */)
+NamesDataSource EditableMapObject::GetNamesDataSource()
 {
   auto const mwmInfo = GetID().m_mwmId.GetInfo();
 
@@ -204,19 +96,6 @@ NamesDataSource EditableMapObject::GetNamesDataSource(bool needFakes /* = true *
   mwmInfo->GetRegionData().GetLanguages(mwmLanguages);
 
   auto const userLangCode = StringUtf8Multilang::GetLangIndex(languages::GetCurrentNorm());
-
-  if (needFakes)
-  {
-    StringUtf8Multilang fakeSource;
-    m_fakeNames = MakeFakeSource(m_name, mwmLanguages, fakeSource);
-
-    if (!m_fakeNames.m_names.empty())
-      return GetNamesDataSource(fakeSource, mwmLanguages, userLangCode);
-  }
-  else
-  {
-    RemoveFakeNames(m_fakeNames, m_name);
-  }
 
   return GetNamesDataSource(m_name, mwmLanguages, userLangCode);
 }
@@ -229,24 +108,14 @@ NamesDataSource EditableMapObject::GetNamesDataSource(StringUtf8Multilang const 
   NamesDataSource result;
   auto & names = result.names;
   auto & mandatoryCount = result.mandatoryNamesCount;
-  // Push Mwm languages.
-  mandatoryCount = PushMwmLanguages(source, mwmLanguages, names);
 
-  // Push english name.
-  if (ExtractName(source, StringUtf8Multilang::kEnglishCode, names))
-    ++mandatoryCount;
-
-  // Push user's language.
-  if (ExtractName(source, userLangCode, names))
+  // Push default/native for country language.
+  if (ExtractName(source, StringUtf8Multilang::kDefaultCode, names))
     ++mandatoryCount;
 
   // Push other languages.
   source.ForEach([&names, mandatoryCount](int8_t const code, string_view name)
   {
-    // Exclude default name.
-    if (StringUtf8Multilang::kDefaultCode == code)
-      return;
-
     auto const mandatoryNamesEnd = names.begin() + mandatoryCount;
     // Exclude languages which are already in container (languages with top priority).
     auto const it = find_if(
@@ -308,30 +177,6 @@ void EditableMapObject::SetName(StringUtf8Multilang const & name) { m_name = nam
 void EditableMapObject::SetName(string_view name, int8_t langCode)
 {
   strings::Trim(name);
-
-  if (m_namesAdvancedMode)
-  {
-    m_name.AddString(langCode, name);
-    return;
-  }
-
-  if (!name.empty() && !m_name.HasString(StringUtf8Multilang::kDefaultCode))
-  {
-    const auto mwmInfo = GetID().m_mwmId.GetInfo();
-
-    if (mwmInfo)
-    {
-      vector<int8_t> mwmLanguages;
-      mwmInfo->GetRegionData().GetLanguages(mwmLanguages);
-
-      if (CanUseAsDefaultName(langCode, mwmLanguages))
-      {
-        m_name.AddString(StringUtf8Multilang::kDefaultCode, name);
-        return;
-      }
-    }
-  }
-
   m_name.AddString(langCode, name);
 }
 
@@ -348,43 +193,6 @@ bool EditableMapObject::CanUseAsDefaultName(int8_t const lang, vector<int8_t> co
   }
 
   return false;
-}
-
-// static
-void EditableMapObject::RemoveFakeNames(FakeNames const & fakeNames, StringUtf8Multilang & name)
-{
-  if (fakeNames.m_names.empty())
-    return;
-
-  int8_t newDefaultNameCode = StringUtf8Multilang::kUnsupportedLanguageCode;
-  size_t changedCount = 0;
-  string_view defaultName;
-  name.GetString(StringUtf8Multilang::kDefaultCode, defaultName);
-
-  // New default name calculation priority: 1. name on mwm language, 2. english name.
-  for (auto it = fakeNames.m_names.rbegin(); it != fakeNames.m_names.rend(); ++it)
-  {
-    string_view tempName;
-    if (!name.GetString(it->m_code, tempName))
-      continue;
-
-    if (tempName != it->m_filledName)
-    {
-      if (!tempName.empty())
-        newDefaultNameCode = it->m_code;
-
-      ++changedCount;
-    }
-  }
-
-  // If all previously filled fake names were changed - try to change the default name.
-  if (changedCount == fakeNames.m_names.size())
-  {
-    if (!TryToFillDefaultNameFromCode(newDefaultNameCode, name))
-      TryToFillDefaultNameFromAnyLanguage(name);
-  }
-
-  RemoveFakesFromName(fakeNames, name);
 }
 
 void EditableMapObject::SetMercator(m2::PointD const & center) { m_mercator = center; }
@@ -562,9 +370,6 @@ void EditableMapObject::RemoveBlankAndDuplicationsForDefault()
 
 void EditableMapObject::RemoveNeedlessNames()
 {
-  if (!IsNamesAdvancedModeEnabled())
-    RemoveFakeNames(m_fakeNames, m_name);
-
   RemoveBlankAndDuplicationsForDefault();
 }
 

--- a/indexer/editable_map_object.hpp
+++ b/indexer/editable_map_object.hpp
@@ -47,38 +47,13 @@ struct LocalizedName
 };
 
 /// Class which contains vector of localized names with following priority:
-///  1. Names for Mwm languages
-///  2. User`s language name
-///  3. Other names
+///  1. Default Name
+///  2. Other names
 /// and mandatoryNamesCount - count of names which should be always shown.
 struct NamesDataSource
 {
   std::vector<LocalizedName> names;
   size_t mandatoryNamesCount = 0;
-};
-
-struct FakeName
-{
-  FakeName(int8_t code, std::string filledName)
-    : m_code(code)
-    , m_filledName(filledName)
-  {
-  }
-
-  int8_t m_code;
-  std::string m_filledName;
-};
-/// Contains information about fake names which were added for user convenience.
-struct FakeNames
-{
-  void Clear()
-  {
-    m_names.clear();
-    m_defaultName.clear();
-  }
-
-  std::vector<FakeName> m_names;
-  std::string m_defaultName;
 };
 
 struct LocalizedStreet
@@ -102,7 +77,7 @@ public:
   std::vector<MetadataID> GetEditableProperties() const;
 
   /// See comment for NamesDataSource class.
-  NamesDataSource GetNamesDataSource(bool addFakes = true);
+  NamesDataSource GetNamesDataSource();
   LocalizedStreet const & GetStreet() const;
   std::vector<LocalizedStreet> const & GetNearbyStreets() const;
 
@@ -142,9 +117,6 @@ public:
 
   /// Special mark that it's a point feature, not area or line.
   void SetPointType();
-  /// Enables advanced mode with direct access to default name and disables any recalculations.
-  void EnableNamesAdvancedMode() { m_namesAdvancedMode = true; }
-  bool IsNamesAdvancedModeEnabled() const { return m_namesAdvancedMode; }
   /// Remove blank names and default name duplications.
   void RemoveBlankAndDuplicationsForDefault();
   /// Calls RemoveBlankNames or RemoveFakeNames depending on mode.
@@ -166,8 +138,6 @@ public:
   static NamesDataSource GetNamesDataSource(StringUtf8Multilang const & source,
                                             std::vector<int8_t> const & nativeMwmLanguages,
                                             int8_t const userLanguage);
-  /// Removes fake names (which were added for user convenience) from name.
-  static void RemoveFakeNames(FakeNames const & fakeNames, StringUtf8Multilang & name);
 
   /// Compares editable fields connected with feature ignoring street.
   friend bool AreObjectsEqualIgnoringStreet(EditableMapObject const & lhs, EditableMapObject const & rhs);
@@ -176,7 +146,5 @@ private:
   LocalizedStreet m_street;
   std::vector<LocalizedStreet> m_nearbyStreets;
   EditableProperties m_editableProperties;
-  FakeNames m_fakeNames;
-  bool m_namesAdvancedMode = false;
 };
 }  // namespace osm

--- a/indexer/indexer_tests/editable_map_object_test.cpp
+++ b/indexer/indexer_tests/editable_map_object_test.cpp
@@ -275,54 +275,35 @@ UNIT_TEST(EditableMapObject_GetNamesDataSource)
   auto const namesDataSource = EditableMapObject::GetNamesDataSource(
       emo.GetNameMultilang(), nativeMwmLanguages, GetLangCode("ko"));
 
-  TEST_EQUAL(namesDataSource.names.size(), 9, ("All names except the default should be pushed into "
-                                           "data source plus empty mandatory names"));
-  TEST_EQUAL(namesDataSource.mandatoryNamesCount, 4,
-             ("Mandatory names count should be equal to Mwm languages + user`s language"));
-  TEST_EQUAL(namesDataSource.names[0].m_code, GetLangCode("de"),
-             ("German must be first because it is first in the list of languages for MWM"));
-  TEST_EQUAL(namesDataSource.names[1].m_code, GetLangCode("fr"),
-             ("French must be second because it is second in the list of languages for MWM"));
-  TEST_EQUAL(namesDataSource.names[2].m_code, GetLangCode("en"),
-             ("English name should be placed after Mwm languages"));
-  TEST_EQUAL(namesDataSource.names[3].m_code, GetLangCode("ko"),
-             ("Korean should be fourth because the user’s langue must be followed by English."));
+  TEST_EQUAL(namesDataSource.names.size(), 9,("All names including the default should be pushed into data source"));
+  TEST_EQUAL(namesDataSource.mandatoryNamesCount, 1,("Mandatory names count should always be 1"));
+  TEST_EQUAL(namesDataSource.names[0].m_code, GetLangCode("default"),("Default is always first in the list"));
 
   {
     vector<int8_t> nativeMwmLanguages = {GetLangCode("de"), GetLangCode("fr")};
 
     auto const namesDataSource = EditableMapObject::GetNamesDataSource(
         emo.GetNameMultilang(), nativeMwmLanguages, GetLangCode("fr"));
-    TEST_EQUAL(namesDataSource.names.size(), 9,
-               ("All names + empty mandatory names should be pushed into "
-                "the data source, except the default one."));
-    TEST_EQUAL(namesDataSource.mandatoryNamesCount, 3,
-               ("Mandatory names count should be equal to MWM languages + "
-                "The English language + user`s language. Excluding repetiton"));
+    TEST_EQUAL(namesDataSource.names.size(), 9,("All names including the default should be pushed into data source"));
+    TEST_EQUAL(namesDataSource.mandatoryNamesCount, 1,("Mandatory names count should always be 1"));
   }
   {
     vector<int8_t> nativeMwmLanguages = {GetLangCode("fr"), GetLangCode("en")};
 
     auto const namesDataSource = EditableMapObject::GetNamesDataSource(
         emo.GetNameMultilang(), nativeMwmLanguages, GetLangCode("fr"));
-    TEST_EQUAL(namesDataSource.names.size(), 9,
-               ("All names + empty mandatory names should be pushed into "
-                "the data source, except the default one."));
-    TEST_EQUAL(namesDataSource.mandatoryNamesCount, 2,
-               ("Mandatory names count should be equal to MWM languages + "
-                "The English language + user`s language. Excluding repetiton"));
+    TEST_EQUAL(namesDataSource.names.size(), 9,("All names including the default should be pushed into data source"));
+    TEST_EQUAL(namesDataSource.mandatoryNamesCount, 1,("Mandatory names count should always be 1"));
   }
   {
     vector<int8_t> nativeMwmLanguages = {GetLangCode("en"), GetLangCode("en")};
 
     auto const namesDataSource = EditableMapObject::GetNamesDataSource(
         emo.GetNameMultilang(), nativeMwmLanguages, GetLangCode("en"));
-    TEST_EQUAL(namesDataSource.names.size(), 8,
-               ("All names + empty mandatory names should be pushed into "
-                "the data source, except the default one."));
+    TEST_EQUAL(namesDataSource.names.size(), 9,
+               ("All names including the default should be pushed into data source"));
     TEST_EQUAL(namesDataSource.mandatoryNamesCount, 1,
-               ("Mandatory names count should be equal to MWM languages + "
-                "The English language + user`s language. Excluding repetiton"));
+               ("Mandatory names count should always be 1"));
   }
 }
 
@@ -370,221 +351,6 @@ UNIT_TEST(EditableMapObject_SetInternet)
   setInternetAndCheck(bunkerEmo, feature::Internet::Terminal, false);
   setInternetAndCheck(bunkerEmo, feature::Internet::Wlan, true);
   setInternetAndCheck(bunkerEmo, feature::Internet::Wlan, true);
-}
-
-UNIT_TEST(EditableMapObject_RemoveFakeNames)
-{
-  EditableMapObject emo;
-  StringUtf8Multilang name;
-  osm::FakeNames fakeNames;
-
-  name.AddString(GetLangCode("default"), "Default name");
-  name.AddString(GetLangCode("ru"), "Default name");
-  name.AddString(GetLangCode("en"), "Default name");
-  fakeNames.m_names.push_back({GetLangCode("ru"), "Default name"});
-  fakeNames.m_names.push_back({GetLangCode("en"), "Default name"});
-  fakeNames.m_defaultName = "Default name";
-
-  EditableMapObject::RemoveFakeNames(fakeNames, name);
-
-  CheckExpectations(name, {{"default", "Default name"}});
-
-  name.Clear();
-  fakeNames.Clear();
-
-  name.AddString(GetLangCode("default"), "Default name");
-  name.AddString(GetLangCode("ru"), "Changed name");
-  name.AddString(GetLangCode("en"), "Default name");
-  fakeNames.m_names.push_back({GetLangCode("ru"), "Default name"});
-  fakeNames.m_names.push_back({GetLangCode("en"), "Default name"});
-  fakeNames.m_defaultName = "Default name";
-
-  EditableMapObject::RemoveFakeNames(fakeNames, name);
-
-  CheckExpectations(name, {{"default", "Default name"}, {"ru", "Changed name"}});
-
-  name.Clear();
-  fakeNames.Clear();
-
-  name.AddString(GetLangCode("default"), "Default name");
-  name.AddString(GetLangCode("ru"), "Default name");
-  name.AddString(GetLangCode("en"), "Changed name");
-  fakeNames.m_names.push_back({GetLangCode("ru"), "Default name"});
-  fakeNames.m_names.push_back({GetLangCode("en"), "Default name"});
-  fakeNames.m_defaultName = "Default name";
-
-  EditableMapObject::RemoveFakeNames(fakeNames, name);
-
-  CheckExpectations(name, {{"default", "Default name"}, {"en", "Changed name"}});
-
-  name.Clear();
-  fakeNames.Clear();
-
-  name.AddString(GetLangCode("default"), "Default name");
-  name.AddString(GetLangCode("ru"), "Changed name");
-  name.AddString(GetLangCode("en"), "Changed name");
-  fakeNames.m_names.push_back({GetLangCode("ru"), "Default name"});
-  fakeNames.m_names.push_back({GetLangCode("en"), "Default name"});
-  fakeNames.m_defaultName = "Default name";
-
-  EditableMapObject::RemoveFakeNames(fakeNames, name);
-
-  CheckExpectations(name, {{"default", "Changed name"}});
-
-  name.Clear();
-  fakeNames.Clear();
-
-  name.AddString(GetLangCode("default"), "Default name");
-  name.AddString(GetLangCode("ru"), "Changed name ru");
-  name.AddString(GetLangCode("en"), "Changed name en");
-  fakeNames.m_names.push_back({GetLangCode("ru"), "Default name"});
-  fakeNames.m_names.push_back({GetLangCode("en"), "Default name"});
-  fakeNames.m_defaultName = "Default name";
-
-  EditableMapObject::RemoveFakeNames(fakeNames, name);
-
-  CheckExpectations(name, {{"default", "Changed name ru"}, {"en", "Changed name en"}});
-
-  name.Clear();
-  fakeNames.Clear();
-
-  name.AddString(GetLangCode("default"), "Changed by other logic");
-  name.AddString(GetLangCode("ru"), "Default name");
-  name.AddString(GetLangCode("en"), "Changed name en");
-  fakeNames.m_names.push_back({GetLangCode("ru"), "Default name"});
-  fakeNames.m_names.push_back({GetLangCode("en"), "Default name"});
-  fakeNames.m_defaultName = "Default name";
-
-  EditableMapObject::RemoveFakeNames(fakeNames, name);
-
-  CheckExpectations(name, {{"default", "Changed by other logic"}, {"en", "Changed name en"}});
-
-  name.Clear();
-  fakeNames.Clear();
-
-  name.AddString(GetLangCode("default"), "Changed by other logic");
-  name.AddString(GetLangCode("ru"), "Changed name ru");
-  name.AddString(GetLangCode("en"), "Changed name en");
-  fakeNames.m_names.push_back({GetLangCode("ru"), "Default name"});
-  fakeNames.m_names.push_back({GetLangCode("en"), "Default name"});
-  fakeNames.m_defaultName = "Default name";
-
-  EditableMapObject::RemoveFakeNames(fakeNames, name);
-
-  CheckExpectations(name, {{"default", "Changed name ru"}, {"en", "Changed name en"}});
-
-  name.Clear();
-  fakeNames.Clear();
-
-  name.AddString(GetLangCode("default"), "Changed by other logic");
-  name.AddString(GetLangCode("ru"), "Default name");
-  name.AddString(GetLangCode("en"), "Default name");
-  fakeNames.m_names.push_back({GetLangCode("ru"), "Default name"});
-  fakeNames.m_names.push_back({GetLangCode("en"), "Default name"});
-  fakeNames.m_defaultName = "Default name";
-
-  EditableMapObject::RemoveFakeNames(fakeNames, name);
-
-  CheckExpectations(name, {{"default", "Changed by other logic"}});
-
-  name.Clear();
-  fakeNames.Clear();
-
-  name.AddString(GetLangCode("default"), "Default name");
-  name.AddString(GetLangCode("ru"), "");
-  name.AddString(GetLangCode("en"), "Changed name en");
-  fakeNames.m_names.push_back({GetLangCode("ru"), "Default name"});
-  fakeNames.m_names.push_back({GetLangCode("en"), "Default name"});
-  fakeNames.m_defaultName = "Default name";
-
-  EditableMapObject::RemoveFakeNames(fakeNames, name);
-
-  CheckExpectations(name, {{"default", "Changed name en"}});
-
-  name.Clear();
-  fakeNames.Clear();
-
-  name.AddString(GetLangCode("default"), "Default name");
-  name.AddString(GetLangCode("ru"), "");
-  name.AddString(GetLangCode("en"), "");
-  fakeNames.m_names.push_back({GetLangCode("ru"), "Default name"});
-  fakeNames.m_names.push_back({GetLangCode("en"), "Default name"});
-  fakeNames.m_defaultName = "Default name";
-
-  EditableMapObject::RemoveFakeNames(fakeNames, name);
-
-  CheckExpectations(name, {{"default", "Default name"}});
-
-  name.Clear();
-  fakeNames.Clear();
-
-  name.AddString(GetLangCode("default"), "Changed by other logic");
-  name.AddString(GetLangCode("ru"), "");
-  name.AddString(GetLangCode("en"), "");
-  name.AddString(GetLangCode("de"), "Deutch name");
-  fakeNames.m_names.push_back({GetLangCode("ru"), "Default name"});
-  fakeNames.m_names.push_back({GetLangCode("en"), "Default name"});
-  fakeNames.m_defaultName = "Default name";
-
-  EditableMapObject::RemoveFakeNames(fakeNames, name);
-
-  CheckExpectations(name, {{"default", "Deutch name"}, {"de", "Deutch name"}});
-
-  name.Clear();
-  fakeNames.Clear();
-
-  name.AddString(GetLangCode("default"), "Default name");
-  name.AddString(GetLangCode("ru"), "Test name");
-  name.AddString(GetLangCode("en"), "Default name");
-  fakeNames.m_names.push_back({GetLangCode("ru"), "Test name"});
-  fakeNames.m_names.push_back({GetLangCode("en"), "Default name"});
-  fakeNames.m_defaultName = "Default name";
-
-  EditableMapObject::RemoveFakeNames(fakeNames, name);
-
-  CheckExpectations(name, {{"default", "Default name"}, {"ru", "Test name"}});
-
-  name.Clear();
-  fakeNames.Clear();
-
-  name.AddString(GetLangCode("default"), "Default name");
-  name.AddString(GetLangCode("ru"), "Test name changed");
-  name.AddString(GetLangCode("en"), "Default name changed");
-  fakeNames.m_names.push_back({GetLangCode("ru"), "Test name"});
-  fakeNames.m_names.push_back({GetLangCode("en"), "Default name"});
-  fakeNames.m_defaultName = "Default name";
-
-  EditableMapObject::RemoveFakeNames(fakeNames, name);
-
-  CheckExpectations(name, {{"default", "Test name changed"}, {"en", "Default name changed"}});
-
-  name.Clear();
-  fakeNames.Clear();
-
-  name.AddString(GetLangCode("default"), "Default name");
-  name.AddString(GetLangCode("ru"), "Test name");
-  name.AddString(GetLangCode("en"), "Second test name changed");
-  fakeNames.m_names.push_back({GetLangCode("ru"), "Test name"});
-  fakeNames.m_names.push_back({GetLangCode("en"), "Second test name"});
-  fakeNames.m_defaultName = "Default name";
-
-  EditableMapObject::RemoveFakeNames(fakeNames, name);
-
-  CheckExpectations(name, {{"default", "Default name"}, {"ru", "Test name"}, {"en", "Second test name changed"}});
-
-  name.Clear();
-  fakeNames.Clear();
-
-  name.AddString(GetLangCode("default"), "Default name");
-  name.AddString(GetLangCode("ru"), "");
-  name.AddString(GetLangCode("en"), "Second test name changed");
-  fakeNames.m_names.push_back({GetLangCode("ru"), "Test name"});
-  fakeNames.m_names.push_back({GetLangCode("en"), "Second test name"});
-  fakeNames.m_defaultName = "Default name";
-
-  EditableMapObject::RemoveFakeNames(fakeNames, name);
-
-  CheckExpectations(name, {{"default", "Second test name changed"}});
 }
 
 UNIT_TEST(EditableMapObject_RemoveBlankNames)

--- a/iphone/Maps/LocalizedStrings/ar.lproj/Localizable.strings
+++ b/iphone/Maps/LocalizedStrings/ar.lproj/Localizable.strings
@@ -705,6 +705,9 @@
 
 "editor_edit_place_name_hint" = "اسم المكان";
 
+/* The second part of the editor_edit_place_name_hint to explain that name should be entered in a local language, see https://wiki.openstreetmap.org/wiki/Key:name */
+"editor_default_language_hint" = "كما هو مكتوب باللغة المحلية";
+
 "editor_edit_place_category_title" = "الفئة";
 
 "whatsnew_editor_message_1" = "قم بإضافة أماكن جديدة للخريطة، وعدل أماكن حالية مباشرة من التطبيق.";

--- a/iphone/Maps/LocalizedStrings/az.lproj/Localizable.strings
+++ b/iphone/Maps/LocalizedStrings/az.lproj/Localizable.strings
@@ -705,6 +705,9 @@
 
 "editor_edit_place_name_hint" = "Yerin adı";
 
+/* The second part of the editor_edit_place_name_hint to explain that name should be entered in a local language, see https://wiki.openstreetmap.org/wiki/Key:name */
+"editor_default_language_hint" = "Yerli dildə yazıldığı kimi";
+
 "editor_edit_place_category_title" = "Kateqoriya";
 
 "whatsnew_editor_message_1" = "Xəritəyə yeni yerlər əlavə edin və mövcud yerləri birbaşa tətbiqdən redaktə edin.";

--- a/iphone/Maps/LocalizedStrings/be.lproj/Localizable.strings
+++ b/iphone/Maps/LocalizedStrings/be.lproj/Localizable.strings
@@ -705,6 +705,9 @@
 
 "editor_edit_place_name_hint" = "Назва месца";
 
+/* The second part of the editor_edit_place_name_hint to explain that name should be entered in a local language, see https://wiki.openstreetmap.org/wiki/Key:name */
+"editor_default_language_hint" = "На мясцовай мове";
+
 "editor_edit_place_category_title" = "Катэгорыя";
 
 "whatsnew_editor_message_1" = "Стварайце на мапе новыя месцы і рэдагуйце існуючыя прама ў праграме.";

--- a/iphone/Maps/LocalizedStrings/bg.lproj/Localizable.strings
+++ b/iphone/Maps/LocalizedStrings/bg.lproj/Localizable.strings
@@ -705,6 +705,9 @@
 
 "editor_edit_place_name_hint" = "Име на мястото";
 
+/* The second part of the editor_edit_place_name_hint to explain that name should be entered in a local language, see https://wiki.openstreetmap.org/wiki/Key:name */
+"editor_default_language_hint" = "Както е написано на местния език";
+
 "editor_edit_place_category_title" = "Категория";
 
 "whatsnew_editor_message_1" = "Добавяне на нови места в картата и редакция на съществуващите директно от приложението.";

--- a/iphone/Maps/LocalizedStrings/ca.lproj/Localizable.strings
+++ b/iphone/Maps/LocalizedStrings/ca.lproj/Localizable.strings
@@ -705,6 +705,9 @@
 
 "editor_edit_place_name_hint" = "Nom del lloc";
 
+/* The second part of the editor_edit_place_name_hint to explain that name should be entered in a local language, see https://wiki.openstreetmap.org/wiki/Key:name */
+"editor_default_language_hint" = "Com està escrit en la llengua local";
+
 "editor_edit_place_category_title" = "Categoria";
 
 "whatsnew_editor_message_1" = "Afegiu llocs al mapa, i editeu-ne els existents directament des de l'aplicació.";

--- a/iphone/Maps/LocalizedStrings/cs.lproj/Localizable.strings
+++ b/iphone/Maps/LocalizedStrings/cs.lproj/Localizable.strings
@@ -705,6 +705,9 @@
 
 "editor_edit_place_name_hint" = "Název místa";
 
+/* The second part of the editor_edit_place_name_hint to explain that name should be entered in a local language, see https://wiki.openstreetmap.org/wiki/Key:name */
+"editor_default_language_hint" = "Jak je napsáno v místním jazyce";
+
 "editor_edit_place_category_title" = "Kategorie";
 
 "whatsnew_editor_message_1" = "Přidejte na mapu nová místa a upravte existující místa přímo z aplikace.";

--- a/iphone/Maps/LocalizedStrings/da.lproj/Localizable.strings
+++ b/iphone/Maps/LocalizedStrings/da.lproj/Localizable.strings
@@ -705,6 +705,9 @@
 
 "editor_edit_place_name_hint" = "Stedets navn";
 
+/* The second part of the editor_edit_place_name_hint to explain that name should be entered in a local language, see https://wiki.openstreetmap.org/wiki/Key:name */
+"editor_default_language_hint" = "Som det står skrevet på det lokale sprog";
+
 "editor_edit_place_category_title" = "Kategori";
 
 "whatsnew_editor_message_1" = "Tilføj nye steder til kortet og redigér eksisterende direkte fra app'en.";

--- a/iphone/Maps/LocalizedStrings/de.lproj/Localizable.strings
+++ b/iphone/Maps/LocalizedStrings/de.lproj/Localizable.strings
@@ -705,6 +705,9 @@
 
 "editor_edit_place_name_hint" = "Name des Ortes";
 
+/* The second part of the editor_edit_place_name_hint to explain that name should be entered in a local language, see https://wiki.openstreetmap.org/wiki/Key:name */
+"editor_default_language_hint" = "Wie in der lokalen Sprache geschrieben";
+
 "editor_edit_place_category_title" = "Kategorie";
 
 "whatsnew_editor_message_1" = "Fügen Sie auf der Karte einen neuen Ort hinzu und bearbeiten Sie existierende Orte direkt in der App.";

--- a/iphone/Maps/LocalizedStrings/el.lproj/Localizable.strings
+++ b/iphone/Maps/LocalizedStrings/el.lproj/Localizable.strings
@@ -705,6 +705,9 @@
 
 "editor_edit_place_name_hint" = "Όνομα τοποθεσίας";
 
+/* The second part of the editor_edit_place_name_hint to explain that name should be entered in a local language, see https://wiki.openstreetmap.org/wiki/Key:name */
+"editor_default_language_hint" = "Όπως είναι γραμμένο στην τοπική γλώσσα";
+
 "editor_edit_place_category_title" = "Κατηγορία";
 
 "whatsnew_editor_message_1" = "Προσθέστε νέες τοποθεσίες στο χάρτη, και επεξεργαστείτε τις υπάρχουσες απευθείας από την εφαρμογή.";

--- a/iphone/Maps/LocalizedStrings/en-GB.lproj/Localizable.strings
+++ b/iphone/Maps/LocalizedStrings/en-GB.lproj/Localizable.strings
@@ -705,6 +705,9 @@
 
 "editor_edit_place_name_hint" = "Name of the place";
 
+/* The second part of the editor_edit_place_name_hint to explain that name should be entered in a local language, see https://wiki.openstreetmap.org/wiki/Key:name */
+"editor_default_language_hint" = "As it is written in the local language";
+
 "editor_edit_place_category_title" = "Category";
 
 "whatsnew_editor_message_1" = "Add new places to the map, and edit existing ones directly from the app.";

--- a/iphone/Maps/LocalizedStrings/en.lproj/Localizable.strings
+++ b/iphone/Maps/LocalizedStrings/en.lproj/Localizable.strings
@@ -705,6 +705,9 @@
 
 "editor_edit_place_name_hint" = "Name of the place";
 
+/* The second part of the editor_edit_place_name_hint to explain that name should be entered in a local language, see https://wiki.openstreetmap.org/wiki/Key:name */
+"editor_default_language_hint" = "As it is written in the local language";
+
 "editor_edit_place_category_title" = "Category";
 
 "whatsnew_editor_message_1" = "Add new places to the map, and edit existing ones directly from the app.";

--- a/iphone/Maps/LocalizedStrings/es-MX.lproj/Localizable.strings
+++ b/iphone/Maps/LocalizedStrings/es-MX.lproj/Localizable.strings
@@ -705,6 +705,9 @@
 
 "editor_edit_place_name_hint" = "Nombre del lugar";
 
+/* The second part of the editor_edit_place_name_hint to explain that name should be entered in a local language, see https://wiki.openstreetmap.org/wiki/Key:name */
+"editor_default_language_hint" = "Como está escrito en la lengua local";
+
 "editor_edit_place_category_title" = "Categoría";
 
 "whatsnew_editor_message_1" = "Añadir lugares nuevos al mapa y editar los lugares actuales directamente desde la aplicación.";

--- a/iphone/Maps/LocalizedStrings/es.lproj/Localizable.strings
+++ b/iphone/Maps/LocalizedStrings/es.lproj/Localizable.strings
@@ -705,6 +705,9 @@
 
 "editor_edit_place_name_hint" = "Nombre del lugar";
 
+/* The second part of the editor_edit_place_name_hint to explain that name should be entered in a local language, see https://wiki.openstreetmap.org/wiki/Key:name */
+"editor_default_language_hint" = "Como está escrito en la lengua local";
+
 "editor_edit_place_category_title" = "Categoría";
 
 "whatsnew_editor_message_1" = "Añadir lugares nuevos al mapa y editar los lugares actuales directamente desde la aplicación.";

--- a/iphone/Maps/LocalizedStrings/et.lproj/Localizable.strings
+++ b/iphone/Maps/LocalizedStrings/et.lproj/Localizable.strings
@@ -705,6 +705,9 @@
 
 "editor_edit_place_name_hint" = "Koha nimi";
 
+/* The second part of the editor_edit_place_name_hint to explain that name should be entered in a local language, see https://wiki.openstreetmap.org/wiki/Key:name */
+"editor_default_language_hint" = "Nagu on kirjutatud kohalikus keeles";
+
 "editor_edit_place_category_title" = "Kategooria";
 
 "whatsnew_editor_message_1" = "Lisa kaardile uusi kohti ja muuda olemasolevaid otse rakenduses.";

--- a/iphone/Maps/LocalizedStrings/eu.lproj/Localizable.strings
+++ b/iphone/Maps/LocalizedStrings/eu.lproj/Localizable.strings
@@ -705,6 +705,9 @@
 
 "editor_edit_place_name_hint" = "Tokiaren izena";
 
+/* The second part of the editor_edit_place_name_hint to explain that name should be entered in a local language, see https://wiki.openstreetmap.org/wiki/Key:name */
+"editor_default_language_hint" = "Bertako hizkuntzan idatzita dagoenez";
+
 "editor_edit_place_category_title" = "Kategoria";
 
 "whatsnew_editor_message_1" = "Gehitu toki berriak mapan eta editatu uneko tokiak zuzenean aplikaziotik.";

--- a/iphone/Maps/LocalizedStrings/fa.lproj/Localizable.strings
+++ b/iphone/Maps/LocalizedStrings/fa.lproj/Localizable.strings
@@ -705,6 +705,9 @@
 
 "editor_edit_place_name_hint" = "نام مکان";
 
+/* The second part of the editor_edit_place_name_hint to explain that name should be entered in a local language, see https://wiki.openstreetmap.org/wiki/Key:name */
+"editor_default_language_hint" = "همانطور که به زبان محلی نوشته شده است";
+
 "editor_edit_place_category_title" = "دسته بندی";
 
 "whatsnew_editor_message_1" = "اضافه کردن مکان به نقشه و ویرایش آن مستقیما از طریق این اپلیکیشن.";

--- a/iphone/Maps/LocalizedStrings/fi.lproj/Localizable.strings
+++ b/iphone/Maps/LocalizedStrings/fi.lproj/Localizable.strings
@@ -705,6 +705,9 @@
 
 "editor_edit_place_name_hint" = "Paikan nimi";
 
+/* The second part of the editor_edit_place_name_hint to explain that name should be entered in a local language, see https://wiki.openstreetmap.org/wiki/Key:name */
+"editor_default_language_hint" = "Paikallisella kielellä kirjoitettuna";
+
 "editor_edit_place_category_title" = "Kategoria";
 
 "whatsnew_editor_message_1" = "Lisää karttaan uusia paikkoja ja muokkaa sovelluksessa olevia karttoja suoraan sovelluksessa.";

--- a/iphone/Maps/LocalizedStrings/fr.lproj/Localizable.strings
+++ b/iphone/Maps/LocalizedStrings/fr.lproj/Localizable.strings
@@ -705,6 +705,9 @@
 
 "editor_edit_place_name_hint" = "Nom du lieu";
 
+/* The second part of the editor_edit_place_name_hint to explain that name should be entered in a local language, see https://wiki.openstreetmap.org/wiki/Key:name */
+"editor_default_language_hint" = "Comme c'est écrit dans la langue locale";
+
 "editor_edit_place_category_title" = "Catégorie";
 
 "whatsnew_editor_message_1" = "Ajoutez de nouveaux lieux sur la carte et modifiez les lieux existants directement depuis l'appli.";

--- a/iphone/Maps/LocalizedStrings/he.lproj/Localizable.strings
+++ b/iphone/Maps/LocalizedStrings/he.lproj/Localizable.strings
@@ -705,6 +705,9 @@
 
 "editor_edit_place_name_hint" = "שם המקום";
 
+/* The second part of the editor_edit_place_name_hint to explain that name should be entered in a local language, see https://wiki.openstreetmap.org/wiki/Key:name */
+"editor_default_language_hint" = "כפי שנכתב בשפה המקומית";
+
 "editor_edit_place_category_title" = "קטגוריה";
 
 "whatsnew_editor_message_1" = "הוספת מקומות חדשים למפה, ועריכת מקומות קיימים ישירות מהאפליקציה.";

--- a/iphone/Maps/LocalizedStrings/hi.lproj/Localizable.strings
+++ b/iphone/Maps/LocalizedStrings/hi.lproj/Localizable.strings
@@ -705,6 +705,9 @@
 
 "editor_edit_place_name_hint" = "स्थान का नाम";
 
+/* The second part of the editor_edit_place_name_hint to explain that name should be entered in a local language, see https://wiki.openstreetmap.org/wiki/Key:name */
+"editor_default_language_hint" = "जैसा कि स्थानीय भाषा में लिखा गया है";
+
 "editor_edit_place_category_title" = "वर्ग";
 
 "whatsnew_editor_message_1" = "Add new places to the map, and edit existing ones directly from the app.";

--- a/iphone/Maps/LocalizedStrings/hu.lproj/Localizable.strings
+++ b/iphone/Maps/LocalizedStrings/hu.lproj/Localizable.strings
@@ -705,6 +705,9 @@
 
 "editor_edit_place_name_hint" = "Hely neve";
 
+/* The second part of the editor_edit_place_name_hint to explain that name should be entered in a local language, see https://wiki.openstreetmap.org/wiki/Key:name */
+"editor_default_language_hint" = "Ahogy a helyi nyelven írva van";
+
 "editor_edit_place_category_title" = "Kategória";
 
 "whatsnew_editor_message_1" = "Adj hozzá új helyeket a térképhez, és szerkeszd a meglévőket közvetlenül az alkalmazásból.";

--- a/iphone/Maps/LocalizedStrings/id.lproj/Localizable.strings
+++ b/iphone/Maps/LocalizedStrings/id.lproj/Localizable.strings
@@ -705,6 +705,9 @@
 
 "editor_edit_place_name_hint" = "Nama tempat";
 
+/* The second part of the editor_edit_place_name_hint to explain that name should be entered in a local language, see https://wiki.openstreetmap.org/wiki/Key:name */
+"editor_default_language_hint" = "Seperti yang tertulis dalam bahasa lokal";
+
 "editor_edit_place_category_title" = "Kategori";
 
 "whatsnew_editor_message_1" = "Tambahkan tempat-tempat baru di peta, dan edit peta-peta yang ada langsung dari aplikasi.";

--- a/iphone/Maps/LocalizedStrings/it.lproj/Localizable.strings
+++ b/iphone/Maps/LocalizedStrings/it.lproj/Localizable.strings
@@ -705,6 +705,9 @@
 
 "editor_edit_place_name_hint" = "Nome del luogo";
 
+/* The second part of the editor_edit_place_name_hint to explain that name should be entered in a local language, see https://wiki.openstreetmap.org/wiki/Key:name */
+"editor_default_language_hint" = "Come è scritto nella lingua locale";
+
 "editor_edit_place_category_title" = "Categoria";
 
 "whatsnew_editor_message_1" = "Aggiungi nuovi luoghi sulla mappa e modifica quelli esistenti direttamente dall'app.";

--- a/iphone/Maps/LocalizedStrings/ja.lproj/Localizable.strings
+++ b/iphone/Maps/LocalizedStrings/ja.lproj/Localizable.strings
@@ -705,6 +705,9 @@
 
 "editor_edit_place_name_hint" = "場所の名前";
 
+/* The second part of the editor_edit_place_name_hint to explain that name should be entered in a local language, see https://wiki.openstreetmap.org/wiki/Key:name */
+"editor_default_language_hint" = "現地の言葉でこう書かれている。";
+
 "editor_edit_place_category_title" = "カテゴリ";
 
 "whatsnew_editor_message_1" = "アプリから直接地図に新しい場所を追加したり、既存の場所を編集できます。";

--- a/iphone/Maps/LocalizedStrings/ko.lproj/Localizable.strings
+++ b/iphone/Maps/LocalizedStrings/ko.lproj/Localizable.strings
@@ -705,6 +705,9 @@
 
 "editor_edit_place_name_hint" = "장소 이름";
 
+/* The second part of the editor_edit_place_name_hint to explain that name should be entered in a local language, see https://wiki.openstreetmap.org/wiki/Key:name */
+"editor_default_language_hint" = "현지 언어로 작성되었으므로";
+
 "editor_edit_place_category_title" = "범주";
 
 "whatsnew_editor_message_1" = "지도에 새로운 장소를 추가하고 응용 프로그램에서 직접 기존 편집 할 수 있습니다.";

--- a/iphone/Maps/LocalizedStrings/mr.lproj/Localizable.strings
+++ b/iphone/Maps/LocalizedStrings/mr.lproj/Localizable.strings
@@ -705,6 +705,9 @@
 
 "editor_edit_place_name_hint" = "ठिकाणाचे नाव";
 
+/* The second part of the editor_edit_place_name_hint to explain that name should be entered in a local language, see https://wiki.openstreetmap.org/wiki/Key:name */
+"editor_default_language_hint" = "स्थानिक भाषेत लिहिल्याप्रमाणे";
+
 "editor_edit_place_category_title" = "प्रवर्ग";
 
 "whatsnew_editor_message_1" = "नकाशावर नवीन ठिकाणे जोडा आणि विद्यमान ठिकाणे थेट ऍप मधून संपादित करा.";

--- a/iphone/Maps/LocalizedStrings/nb.lproj/Localizable.strings
+++ b/iphone/Maps/LocalizedStrings/nb.lproj/Localizable.strings
@@ -705,6 +705,9 @@
 
 "editor_edit_place_name_hint" = "Navn på stedet";
 
+/* The second part of the editor_edit_place_name_hint to explain that name should be entered in a local language, see https://wiki.openstreetmap.org/wiki/Key:name */
+"editor_default_language_hint" = "Som det står skrevet på det lokale språket";
+
 "editor_edit_place_category_title" = "Kategori";
 
 "whatsnew_editor_message_1" = "Legg til nye steder i kartet og rediger eksisterende steder direkte fra appen.";

--- a/iphone/Maps/LocalizedStrings/nl.lproj/Localizable.strings
+++ b/iphone/Maps/LocalizedStrings/nl.lproj/Localizable.strings
@@ -705,6 +705,9 @@
 
 "editor_edit_place_name_hint" = "Naam van de plaats";
 
+/* The second part of the editor_edit_place_name_hint to explain that name should be entered in a local language, see https://wiki.openstreetmap.org/wiki/Key:name */
+"editor_default_language_hint" = "Zoals het in de plaatselijke taal geschreven staat";
+
 "editor_edit_place_category_title" = "Categorie";
 
 "whatsnew_editor_message_1" = "Voeg nieuwe plaatsen toe aan de kaart en bewerk de bestaande rechtstreeks vanuit de app.";

--- a/iphone/Maps/LocalizedStrings/pl.lproj/Localizable.strings
+++ b/iphone/Maps/LocalizedStrings/pl.lproj/Localizable.strings
@@ -705,6 +705,9 @@
 
 "editor_edit_place_name_hint" = "Nazwa miejsca";
 
+/* The second part of the editor_edit_place_name_hint to explain that name should be entered in a local language, see https://wiki.openstreetmap.org/wiki/Key:name */
+"editor_default_language_hint" = "Jak napisano w lokalnym języku";
+
 "editor_edit_place_category_title" = "Kategoria";
 
 "whatsnew_editor_message_1" = "Dodawaj nowe miejsca do mapy i edytuj już istniejące bezpośrednio z poziomu aplikacji.";

--- a/iphone/Maps/LocalizedStrings/pt-BR.lproj/Localizable.strings
+++ b/iphone/Maps/LocalizedStrings/pt-BR.lproj/Localizable.strings
@@ -705,6 +705,9 @@
 
 "editor_edit_place_name_hint" = "Nome do lugar";
 
+/* The second part of the editor_edit_place_name_hint to explain that name should be entered in a local language, see https://wiki.openstreetmap.org/wiki/Key:name */
+"editor_default_language_hint" = "Como escrito na língua local";
+
 "editor_edit_place_category_title" = "Categoria";
 
 "whatsnew_editor_message_1" = "Adicione novos lugares ao mapa e edite os já existentes diretamente no aplicativo.";

--- a/iphone/Maps/LocalizedStrings/pt.lproj/Localizable.strings
+++ b/iphone/Maps/LocalizedStrings/pt.lproj/Localizable.strings
@@ -705,6 +705,9 @@
 
 "editor_edit_place_name_hint" = "Nome do lugar";
 
+/* The second part of the editor_edit_place_name_hint to explain that name should be entered in a local language, see https://wiki.openstreetmap.org/wiki/Key:name */
+"editor_default_language_hint" = "Como escrito na língua local";
+
 "editor_edit_place_category_title" = "Categoria";
 
 "whatsnew_editor_message_1" = "Adicione novos lugares ao mapa e edite os já existentes diretamente a partir da aplicação.";

--- a/iphone/Maps/LocalizedStrings/ro.lproj/Localizable.strings
+++ b/iphone/Maps/LocalizedStrings/ro.lproj/Localizable.strings
@@ -705,6 +705,9 @@
 
 "editor_edit_place_name_hint" = "Numele locului";
 
+/* The second part of the editor_edit_place_name_hint to explain that name should be entered in a local language, see https://wiki.openstreetmap.org/wiki/Key:name */
+"editor_default_language_hint" = "Așa cum este scris în limba locală";
+
 "editor_edit_place_category_title" = "Categorie";
 
 "whatsnew_editor_message_1" = "Adaugă locuri noi pe hartă și modifică-le pe cele existente direct din aplicație.";

--- a/iphone/Maps/LocalizedStrings/ru.lproj/Localizable.strings
+++ b/iphone/Maps/LocalizedStrings/ru.lproj/Localizable.strings
@@ -705,6 +705,9 @@
 
 "editor_edit_place_name_hint" = "Название места";
 
+/* The second part of the editor_edit_place_name_hint to explain that name should be entered in a local language, see https://wiki.openstreetmap.org/wiki/Key:name */
+"editor_default_language_hint" = "На местном языке";
+
 "editor_edit_place_category_title" = "Категория";
 
 "whatsnew_editor_message_1" = "Добавляйте новые объекты и редактируйте старые прямо из приложения.";

--- a/iphone/Maps/LocalizedStrings/sk.lproj/Localizable.strings
+++ b/iphone/Maps/LocalizedStrings/sk.lproj/Localizable.strings
@@ -705,6 +705,9 @@
 
 "editor_edit_place_name_hint" = "Názov miesta";
 
+/* The second part of the editor_edit_place_name_hint to explain that name should be entered in a local language, see https://wiki.openstreetmap.org/wiki/Key:name */
+"editor_default_language_hint" = "Tak, ako sa píše v miestnom jazyku";
+
 "editor_edit_place_category_title" = "Kategória";
 
 "whatsnew_editor_message_1" = "Na mapu môžete pridávať nové miesta a upravovať tie, ktoré sú už pridané.";

--- a/iphone/Maps/LocalizedStrings/sv.lproj/Localizable.strings
+++ b/iphone/Maps/LocalizedStrings/sv.lproj/Localizable.strings
@@ -705,6 +705,9 @@
 
 "editor_edit_place_name_hint" = "Namn på platsen";
 
+/* The second part of the editor_edit_place_name_hint to explain that name should be entered in a local language, see https://wiki.openstreetmap.org/wiki/Key:name */
+"editor_default_language_hint" = "Som det står skrivet på det lokala språket";
+
 "editor_edit_place_category_title" = "Kategori";
 
 "whatsnew_editor_message_1" = "Lägg till nya platser till kartan och redigera de befintliga direkt från appen.";

--- a/iphone/Maps/LocalizedStrings/sw.lproj/Localizable.strings
+++ b/iphone/Maps/LocalizedStrings/sw.lproj/Localizable.strings
@@ -705,6 +705,9 @@
 
 "editor_edit_place_name_hint" = "Name of the place";
 
+/* The second part of the editor_edit_place_name_hint to explain that name should be entered in a local language, see https://wiki.openstreetmap.org/wiki/Key:name */
+"editor_default_language_hint" = "Kama ilivyoandikwa katika lugha ya kienyeji";
+
 "editor_edit_place_category_title" = "Category";
 
 "whatsnew_editor_message_1" = "Add new places to the map, and edit existing ones directly from the app.";

--- a/iphone/Maps/LocalizedStrings/th.lproj/Localizable.strings
+++ b/iphone/Maps/LocalizedStrings/th.lproj/Localizable.strings
@@ -705,6 +705,9 @@
 
 "editor_edit_place_name_hint" = "ชื่อสถานที่";
 
+/* The second part of the editor_edit_place_name_hint to explain that name should be entered in a local language, see https://wiki.openstreetmap.org/wiki/Key:name */
+"editor_default_language_hint" = "ตามที่เขียนเป็นภาษาท้องถิ่น";
+
 "editor_edit_place_category_title" = "หมวดหมู่";
 
 "whatsnew_editor_message_1" = "เพิ่มสถานที่ใหม่ ๆ ไปยังแผนที่ และแก้ไขสถานที่ที่มีอยู่เดิมจากแอปโดยตรง";

--- a/iphone/Maps/LocalizedStrings/tr.lproj/Localizable.strings
+++ b/iphone/Maps/LocalizedStrings/tr.lproj/Localizable.strings
@@ -705,6 +705,9 @@
 
 "editor_edit_place_name_hint" = "Yerin adı";
 
+/* The second part of the editor_edit_place_name_hint to explain that name should be entered in a local language, see https://wiki.openstreetmap.org/wiki/Key:name */
+"editor_default_language_hint" = "Yerel dilde yazıldığı gibi";
+
 "editor_edit_place_category_title" = "Kategori";
 
 "whatsnew_editor_message_1" = "Doğrudan uygulamadan haritaya yeni yerler ekleyin ve mevcut yerleri düzenleyin.";

--- a/iphone/Maps/LocalizedStrings/uk.lproj/Localizable.strings
+++ b/iphone/Maps/LocalizedStrings/uk.lproj/Localizable.strings
@@ -705,6 +705,9 @@
 
 "editor_edit_place_name_hint" = "Назва місця";
 
+/* The second part of the editor_edit_place_name_hint to explain that name should be entered in a local language, see https://wiki.openstreetmap.org/wiki/Key:name */
+"editor_default_language_hint" = "Місцевою мовою";
+
 "editor_edit_place_category_title" = "Категорія";
 
 "whatsnew_editor_message_1" = "Додати нові місця до мапи і редагувати існуючі місця прямо з програми.";

--- a/iphone/Maps/LocalizedStrings/vi.lproj/Localizable.strings
+++ b/iphone/Maps/LocalizedStrings/vi.lproj/Localizable.strings
@@ -705,6 +705,9 @@
 
 "editor_edit_place_name_hint" = "Tên địa điểm";
 
+/* The second part of the editor_edit_place_name_hint to explain that name should be entered in a local language, see https://wiki.openstreetmap.org/wiki/Key:name */
+"editor_default_language_hint" = "Vì nó được viết bằng ngôn ngữ địa phương";
+
 "editor_edit_place_category_title" = "Thể loại";
 
 "whatsnew_editor_message_1" = "Nhập các địa điểm mới vào bản đồ, và trực tiếp chỉnh sửa những địa điểm hiện có trên ứng dụng.";

--- a/iphone/Maps/LocalizedStrings/zh-Hans.lproj/Localizable.strings
+++ b/iphone/Maps/LocalizedStrings/zh-Hans.lproj/Localizable.strings
@@ -705,6 +705,9 @@
 
 "editor_edit_place_name_hint" = "该地点的名称";
 
+/* The second part of the editor_edit_place_name_hint to explain that name should be entered in a local language, see https://wiki.openstreetmap.org/wiki/Key:name */
+"editor_default_language_hint" = "当地语言写道";
+
 "editor_edit_place_category_title" = "类别";
 
 "whatsnew_editor_message_1" = "添加新地点到该地图，并直接通过此应用编辑已存在的地点。";

--- a/iphone/Maps/LocalizedStrings/zh-Hant.lproj/Localizable.strings
+++ b/iphone/Maps/LocalizedStrings/zh-Hant.lproj/Localizable.strings
@@ -705,6 +705,9 @@
 
 "editor_edit_place_name_hint" = "該地點的名稱";
 
+/* The second part of the editor_edit_place_name_hint to explain that name should be entered in a local language, see https://wiki.openstreetmap.org/wiki/Key:name */
+"editor_default_language_hint" = "因為它是用當地語言寫的";
+
 "editor_edit_place_category_title" = "類別";
 
 "whatsnew_editor_message_1" = "新增新地點到該地圖，並直接通過此應用程式編輯已存在的地點。";

--- a/iphone/Maps/UI/Editor/Cells/MWMEditorAdditionalNameTableViewCell.xib
+++ b/iphone/Maps/UI/Editor/Cells/MWMEditorAdditionalNameTableViewCell.xib
@@ -1,9 +1,9 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<document type="com.apple.InterfaceBuilder3.CocoaTouch.XIB" version="3.0" toolsVersion="19529" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" colorMatched="YES">
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.XIB" version="3.0" toolsVersion="22505" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" colorMatched="YES">
     <device id="retina6_1" orientation="portrait" appearance="light"/>
     <dependencies>
         <deployment identifier="iOS"/>
-        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="19519"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="22504"/>
         <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
     </dependencies>
     <objects>
@@ -16,33 +16,34 @@
                 <rect key="frame" x="0.0" y="0.0" width="320" height="44"/>
                 <autoresizingMask key="autoresizingMask"/>
                 <subviews>
-                    <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="zh-classical" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="efb-nS-cjm">
-                        <rect key="frame" x="16" y="13.5" width="80" height="17"/>
-                        <color key="backgroundColor" white="0.0" alpha="0.0" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
-                        <constraints>
-                            <constraint firstAttribute="height" constant="17" id="8qF-WG-0JP"/>
-                            <constraint firstAttribute="width" constant="80" id="RUn-7a-x8R"/>
-                        </constraints>
-                        <fontDescription key="fontDescription" type="system" pointSize="14"/>
-                        <color key="textColor" red="0.0" green="0.0" blue="0.0" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
-                        <nil key="highlightedColor"/>
-                        <userDefinedRuntimeAttributes>
-                            <userDefinedRuntimeAttribute type="string" keyPath="styleName" value="regular14:blackSecondaryText"/>
-                        </userDefinedRuntimeAttributes>
-                    </label>
-                    <textField opaque="NO" clipsSubviews="YES" contentMode="scaleToFill" horizontalCompressionResistancePriority="499" contentHorizontalAlignment="left" contentVerticalAlignment="center" textAlignment="natural" minimumFontSize="17" clearButtonMode="whileEditing" translatesAutoresizingMaskIntoConstraints="NO" id="9BY-PA-dlA">
-                        <rect key="frame" x="100" y="16" width="204" height="12"/>
-                        <color key="backgroundColor" white="0.0" alpha="0.0" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
-                        <fontDescription key="fontDescription" type="system" pointSize="17"/>
-                        <textInputTraits key="textInputTraits"/>
-                        <userDefinedRuntimeAttributes>
-                            <userDefinedRuntimeAttribute type="string" keyPath="styleName" value="regular17:blackPrimaryText"/>
-                            <userDefinedRuntimeAttribute type="string" keyPath="localizedPlaceholder" value="editor_edit_place_name_hint"/>
-                        </userDefinedRuntimeAttributes>
-                        <connections>
-                            <outlet property="delegate" destination="hfo-cP-AGX" id="jkD-0x-Ods"/>
-                        </connections>
-                    </textField>
+                    <stackView opaque="NO" contentMode="scaleToFill" axis="vertical" distribution="fillProportionally" alignment="top" spacing="3" translatesAutoresizingMaskIntoConstraints="NO" id="eca-XW-QZR">
+                        <rect key="frame" x="16" y="16" width="288" height="12"/>
+                        <subviews>
+                            <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="zh-classical" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="efb-nS-cjm">
+                                <rect key="frame" x="0.0" y="0.0" width="77" height="5"/>
+                                <color key="backgroundColor" white="0.0" alpha="0.0" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
+                                <fontDescription key="fontDescription" type="system" pointSize="14"/>
+                                <color key="textColor" red="0.0" green="0.0" blue="0.0" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
+                                <nil key="highlightedColor"/>
+                                <userDefinedRuntimeAttributes>
+                                    <userDefinedRuntimeAttribute type="string" keyPath="styleName" value="regular14:blackSecondaryText"/>
+                                </userDefinedRuntimeAttributes>
+                            </label>
+                            <textField opaque="NO" clipsSubviews="YES" contentMode="scaleToFill" horizontalCompressionResistancePriority="499" contentHorizontalAlignment="left" contentVerticalAlignment="center" minimumFontSize="17" clearButtonMode="whileEditing" translatesAutoresizingMaskIntoConstraints="NO" id="9BY-PA-dlA">
+                                <rect key="frame" x="0.0" y="8" width="5" height="4"/>
+                                <color key="backgroundColor" white="0.0" alpha="0.0" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
+                                <fontDescription key="fontDescription" type="system" pointSize="17"/>
+                                <textInputTraits key="textInputTraits"/>
+                                <userDefinedRuntimeAttributes>
+                                    <userDefinedRuntimeAttribute type="string" keyPath="styleName" value="regular17:blackPrimaryText"/>
+                                    <userDefinedRuntimeAttribute type="string" keyPath="localizedPlaceholder" value="editor_edit_place_name_hint"/>
+                                </userDefinedRuntimeAttributes>
+                                <connections>
+                                    <outlet property="delegate" destination="hfo-cP-AGX" id="jkD-0x-Ods"/>
+                                </connections>
+                            </textField>
+                        </subviews>
+                    </stackView>
                     <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Label" textAlignment="natural" lineBreakMode="tailTruncation" numberOfLines="0" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" preferredMaxLayoutWidth="252" translatesAutoresizingMaskIntoConstraints="NO" id="SZa-Bj-se1">
                         <rect key="frame" x="60" y="32" width="252" height="0.0"/>
                         <color key="backgroundColor" red="0.0" green="0.0" blue="0.0" alpha="0.0" colorSpace="custom" customColorSpace="sRGB"/>
@@ -60,14 +61,11 @@
                 <constraints>
                     <constraint firstItem="SZa-Bj-se1" firstAttribute="leading" secondItem="JQH-ks-NoC" secondAttribute="leading" constant="60" id="BcS-gb-9vl"/>
                     <constraint firstAttribute="trailing" secondItem="SZa-Bj-se1" secondAttribute="trailing" constant="8" id="EBU-G3-tgp"/>
-                    <constraint firstAttribute="trailing" secondItem="9BY-PA-dlA" secondAttribute="trailing" constant="16" id="EPW-QQ-h4A"/>
-                    <constraint firstItem="efb-nS-cjm" firstAttribute="centerY" secondItem="9BY-PA-dlA" secondAttribute="centerY" id="KMC-QU-FKv"/>
+                    <constraint firstItem="eca-XW-QZR" firstAttribute="top" secondItem="JQH-ks-NoC" secondAttribute="top" constant="16" id="FJ5-Zj-wLR"/>
+                    <constraint firstAttribute="trailing" secondItem="eca-XW-QZR" secondAttribute="trailing" constant="16" id="NZO-C9-ZCS"/>
+                    <constraint firstItem="SZa-Bj-se1" firstAttribute="top" secondItem="eca-XW-QZR" secondAttribute="bottom" constant="4" id="T9Z-G5-LVc"/>
                     <constraint firstAttribute="bottom" secondItem="SZa-Bj-se1" secondAttribute="bottom" constant="12" id="TdX-jx-CpD"/>
-                    <constraint firstItem="efb-nS-cjm" firstAttribute="leading" secondItem="JQH-ks-NoC" secondAttribute="leading" constant="16" id="aeA-g6-24D"/>
-                    <constraint firstItem="9BY-PA-dlA" firstAttribute="leading" secondItem="efb-nS-cjm" secondAttribute="trailing" constant="4" id="bE7-50-JFQ"/>
-                    <constraint firstAttribute="bottom" secondItem="efb-nS-cjm" secondAttribute="bottom" priority="750" constant="12" id="fZC-8Q-bPw"/>
-                    <constraint firstItem="SZa-Bj-se1" firstAttribute="top" secondItem="9BY-PA-dlA" secondAttribute="bottom" constant="4" id="gPQ-Bf-Pgf"/>
-                    <constraint firstItem="9BY-PA-dlA" firstAttribute="top" secondItem="JQH-ks-NoC" secondAttribute="top" constant="16" id="qga-k9-pOr"/>
+                    <constraint firstItem="eca-XW-QZR" firstAttribute="leading" secondItem="JQH-ks-NoC" secondAttribute="leading" constant="16" id="dbb-bG-8uT"/>
                 </constraints>
                 <userDefinedRuntimeAttributes>
                     <userDefinedRuntimeAttribute type="string" keyPath="styleName" value="Background"/>
@@ -82,7 +80,7 @@
                 <outlet property="languageLabel" destination="efb-nS-cjm" id="13M-9D-Qbf"/>
                 <outlet property="textField" destination="9BY-PA-dlA" id="SCv-JL-5TL"/>
             </connections>
-            <point key="canvasLocation" x="342" y="257"/>
+            <point key="canvasLocation" x="340.57971014492756" y="256.47321428571428"/>
         </tableViewCell>
     </objects>
 </document>


### PR DESCRIPTION
### :exclamation: **Helb for ios needed**
I don't have a mac nor an iphone, so I can't implement the ios part. I tried to make changes without Xcode, but that didn't work without a  proper IDE.

That's why I need someone who can mirror the changes done on Android to ios. Moreover the layout of the editing page needs to be change to have enough room for the "As it is written in the local language" string.

---

### [editor] Use name in local language

As we can see in #762, #1478, #1481, #3378, #442 and other issues, OM has problems with handeling name tags. This is not a small bug but a fundametal problem with the approach OM uses. Hiding the default `name=*` from the users and then trying to do conversions that are assumed to be save leads to unpredictable behaviour and breaks osm data.

I think it's best to not do any conversions in the editor but just present the actual osm data to the users. Just having one name field (for most features) will also make the editing UX simpler. At the moment many people get confused by the two name fields and use them for short-name and long-name or invent translations where there are none (e.g. most Restaurants don't have multilingual names and adding e.g. `name:en` doesn't really make sense) (Source: changeset observation)

This PR consists of two changes. 
- Firstly it changes the languages that are shown to the user by default. Previously english, the user's language and the countrie's language the POI is in was shown. Now only `name=*` / `Native for each country` / "As it is written in the local language" is shown.

- Moreover, name conversions for displaying and saving names, that caused problems are removed. Previously OM would e.g. display the `name` value in `name:en` in case `name:en` is empty.

### Todo
- [x] core
- [x] Android
- [x] Test changes and upload data to OSM
- [x] ios
- [x] add translations

### Examples

Most OSM features just have a `name` tag. For these places OM previously used to convert the `name` Tag and display it as german and english (note that the english name is totally made up by OM here). When saving, name changes are not forwarded to 'name' but to 'name:de' or 'name:en' while the outdated 'name' value stays in the OSM database. An example for this feature type is (https://www.openstreetmap.org/way/308082258)

| This PR| Before |
|--------|--------|
|  ![Screenshot_2023-10-09-21-25-52-111_app organicmaps beta](https://github.com/organicmaps/organicmaps/assets/79519062/106389bf-e746-4ae0-a3d5-cd1552738ff9) | ![Screenshot_2023-10-09-21-25-19-441_app organicmaps](https://github.com/organicmaps/organicmaps/assets/79519062/7e3fea82-b7b3-4406-9f5a-a7f8fa1f3d8b) |

For features with several languages the picture is similar. The englisch value that shows up in the latest release is made up by OM as well. (https://www.openstreetmap.org/relation/147095)
| This PR | Before |
|--------|--------|
| ![Screenshot_2023-10-09-21-27-13-420_app organicmaps beta](https://github.com/organicmaps/organicmaps/assets/79519062/566baa00-ffcc-465a-b96f-01ee3e26dc58)| ![Screenshot_2023-10-09-21-26-42-204_app organicmaps](https://github.com/organicmaps/organicmaps/assets/79519062/06df345c-306f-4032-b076-52e47efe375b) |
|![Screenshot_2023-10-09-21-27-22-523_app organicmaps beta](https://github.com/organicmaps/organicmaps/assets/79519062/13b2889e-dfab-459d-84c8-c71cac5409cf)|![Screenshot_2023-10-09-21-26-51-884_app organicmaps](https://github.com/organicmaps/organicmaps/assets/79519062/d217bb36-7750-477d-81d1-152b5261636e)|

Creating new features looks like this
| This PR | Before |
|--------|--------|
| ![Screenshot_2023-10-09-21-28-49-750_app organicmaps beta](https://github.com/organicmaps/organicmaps/assets/79519062/77051041-c430-406b-8654-4dd9df97d15c)| ![Screenshot_2023-10-09-21-28-34-494_app organicmaps](https://github.com/organicmaps/organicmaps/assets/79519062/303b37a2-69e6-49b8-9363-da71701e3156) |


