### PR TITLE
[styles] Removed shop=vacant from catch-all shop=* classifier.

### DIFF
--- a/data/mapcss-mapping.csv
+++ b/data/mapcss-mapping.csv
@@ -1014,7 +1014,7 @@ shop|greengrocer;939;
 shop|beverages;940;
 shop|toys;941;
 shop|confectionery;942;
-shop;[shop?];;name;int_name;943;
+shop;[shop?][shop!=vacant];;name;int_name;943;
 hwtag|lit;944;
 office|company;945;
 office|telecommunication;946;


### PR DESCRIPTION
Fixes #860
In related issues people suggest supporting it, but the reality is that it's an old alias to `disused:shop=*` (before such prefixes were adopted) which we don't support anyway.