### PR TITLE
[android] Use system locale for map size and download progress strings

### DIFF
--- a/android/app/src/main/java/app/organicmaps/downloader/CountrySuggestFragment.java
+++ b/android/app/src/main/java/app/organicmaps/downloader/CountrySuggestFragment.java
@@ -192,7 +192,7 @@ public class CountrySuggestFragment extends BaseMwmFragment implements View.OnCl
 
   private void updateProgress()
   {
-    String text = StringUtils.formatUsingUsLocale("%1$s %2$.2f%%", getString(R.string.downloader_downloading),
+    String text = StringUtils.formatUsingSystemLocale("%1$s %2$.2f%%", getString(R.string.downloader_downloading),
       mDownloadingCountry.progress);
     mTvProgress.setText(text);
     mWpvDownloadProgress.setProgress(Math.round(mDownloadingCountry.progress));

--- a/android/app/src/main/java/app/organicmaps/downloader/OnmapDownloader.java
+++ b/android/app/src/main/java/app/organicmaps/downloader/OnmapDownloader.java
@@ -140,7 +140,7 @@ public class OnmapDownloader implements MwmActivity.LeftAnimationTrackListener
         {
           mProgress.setPending(false);
           mProgress.setProgress(Math.round(mCurrentCountry.progress));
-          sizeText = StringUtils.formatUsingUsLocale("%1$s %2$.2f%%",
+          sizeText = StringUtils.formatUsingSystemLocale("%1$s %2$.2f%%",
               mActivity.getString(R.string.downloader_downloading), mCurrentCountry.progress);
         }
         else

--- a/android/app/src/main/java/app/organicmaps/util/StringUtils.java
+++ b/android/app/src/main/java/app/organicmaps/util/StringUtils.java
@@ -19,6 +19,11 @@ public class StringUtils
     return String.format(Locale.US, pattern, args);
   }
 
+  public static String formatUsingSystemLocale(String pattern, Object... args)
+  {
+    return String.format(Locale.getDefault(), pattern, args);
+  }
+
   public static native boolean nativeIsHtml(String text);
 
   public static native boolean nativeContainsNormalized(String str, String substr);
@@ -49,6 +54,7 @@ public class StringUtils
   /**
    * Formats size in bytes to "x MB" or "x.x GB" format.
    * Small values rounded to 1 MB without fractions.
+   * Decimal separator character depends on system locale.
    *
    * @param context context for getString()
    * @param size size in bytes
@@ -66,7 +72,7 @@ public class StringUtils
     }
 
     float value = ((float) size / Constants.GB);
-    return formatUsingUsLocale("%1$.1f %2$s", value, MwmApplication.from(context).getString(R.string.gb));
+    return formatUsingSystemLocale("%1$.1f %2$s", value, MwmApplication.from(context).getString(R.string.gb));
   }
 
   public static boolean isRtl()


### PR DESCRIPTION
On Android, make use of system locale decimal separator for the formatting of strings of map size and strings of map download progress.