### PR TITLE
[android]Migrate EditText to TextInputEditText

### DIFF
--- a/android/app/src/main/java/app/organicmaps/bookmarks/BookmarkCategorySettingsFragment.java
+++ b/android/app/src/main/java/app/organicmaps/bookmarks/BookmarkCategorySettingsFragment.java
@@ -9,7 +9,6 @@ import android.view.MenuInflater;
 import android.view.MenuItem;
 import android.view.View;
 import android.view.ViewGroup;
-import android.widget.EditText;
 
 import androidx.annotation.NonNull;
 import androidx.annotation.Nullable;
@@ -20,6 +19,7 @@ import app.organicmaps.bookmarks.data.BookmarkCategory;
 import app.organicmaps.bookmarks.data.BookmarkManager;
 import app.organicmaps.util.Utils;
 import com.google.android.material.dialog.MaterialAlertDialogBuilder;
+import com.google.android.material.textfield.TextInputEditText;
 
 import java.util.Objects;
 
@@ -33,11 +33,11 @@ public class BookmarkCategorySettingsFragment extends BaseMwmToolbarFragment
 
   @SuppressWarnings("NullableProblems")
   @NonNull
-  private EditText mEditDescView;
+  private TextInputEditText mEditDescView;
 
   @SuppressWarnings("NullableProblems")
   @NonNull
-  private EditText mEditCategoryNameView;
+  private TextInputEditText mEditCategoryNameView;
 
   @Override
   public void onCreate(@Nullable Bundle savedInstanceState)

--- a/android/app/src/main/java/app/organicmaps/dialog/EditTextDialogFragment.java
+++ b/android/app/src/main/java/app/organicmaps/dialog/EditTextDialogFragment.java
@@ -9,7 +9,6 @@ import android.text.InputFilter;
 import android.text.TextUtils;
 import android.view.View;
 import android.widget.Button;
-import android.widget.EditText;
 import android.widget.TextView;
 
 import androidx.annotation.NonNull;
@@ -21,6 +20,7 @@ import androidx.fragment.app.FragmentActivity;
 import androidx.fragment.app.FragmentManager;
 import com.google.android.material.dialog.MaterialAlertDialogBuilder;
 import com.google.android.material.textfield.TextInputLayout;
+import com.google.android.material.textfield.TextInputEditText;
 import app.organicmaps.R;
 import app.organicmaps.base.BaseMwmDialogFragment;
 import app.organicmaps.util.InputUtils;
@@ -41,7 +41,7 @@ public class EditTextDialogFragment extends BaseMwmDialogFragment
   @Nullable
   private String mInitialText;
   private String mHint;
-  private EditText mEtInput;
+  private TextInputEditText mEtInput;
   private TextInputLayout mEtInputLayout;
   private Button mPositiveButton;
   private Validator mInputValidator;

--- a/android/app/src/main/java/app/organicmaps/editor/AdvancedTimetableFragment.java
+++ b/android/app/src/main/java/app/organicmaps/editor/AdvancedTimetableFragment.java
@@ -7,7 +7,6 @@ import android.view.LayoutInflater;
 import android.view.View;
 import android.view.ViewGroup;
 import android.webkit.WebView;
-import android.widget.EditText;
 import android.widget.ImageView;
 import android.widget.TextView;
 
@@ -21,12 +20,13 @@ import app.organicmaps.util.Constants;
 import app.organicmaps.util.Graphics;
 import app.organicmaps.util.InputUtils;
 import app.organicmaps.util.UiUtils;
+import com.google.android.material.textfield.TextInputEditText;
 
 public class AdvancedTimetableFragment extends BaseMwmFragment
                                        implements View.OnClickListener, TimetableProvider
 {
   private boolean mIsExampleShown;
-  private EditText mInput;
+  private TextInputEditText mInput;
   private WebView mExample;
   private TextView mExamplesTitle;
   private static ImageView mSaveButton;
@@ -128,7 +128,7 @@ public class AdvancedTimetableFragment extends BaseMwmFragment
     setTextChangedListener(mInput, mListener);
   }
 
-  private static void setTextChangedListener(@Nullable EditText input,
+  private static void setTextChangedListener(@Nullable TextInputEditText input,
                                              @Nullable TimetableChangedListener listener)
   {
     if (input == null || listener == null)

--- a/android/app/src/main/java/app/organicmaps/editor/EditorFragment.java
+++ b/android/app/src/main/java/app/organicmaps/editor/EditorFragment.java
@@ -10,7 +10,6 @@ import android.view.LayoutInflater;
 import android.view.View;
 import android.view.ViewGroup;
 import android.view.ViewTreeObserver;
-import android.widget.EditText;
 import android.widget.ImageView;
 import android.widget.TextView;
 
@@ -26,6 +25,7 @@ import androidx.recyclerview.widget.RecyclerView;
 
 import com.google.android.material.dialog.MaterialAlertDialogBuilder;
 import com.google.android.material.textfield.TextInputLayout;
+import com.google.android.material.textfield.TextInputEditText;
 import app.organicmaps.Framework;
 import app.organicmaps.R;
 import app.organicmaps.base.BaseMwmFragment;
@@ -95,9 +95,9 @@ public class EditorFragment extends BaseMwmFragment implements View.OnClickListe
   private TextView mMoreLanguages;
 
   private TextView mStreet;
-  private EditText mHouseNumber;
+  private TextInputEditText mHouseNumber;
   private View mBlockLevels;
-  private EditText mBuildingLevels;
+  private TextInputEditText mBuildingLevels;
 
   // Define Metadata entries, that have more tricky logic, separately.
   private TextView mPhone;
@@ -108,7 +108,7 @@ public class EditorFragment extends BaseMwmFragment implements View.OnClickListe
   // Default Metadata entries.
   private final class MetadataEntry
   {
-    EditText mEdit;
+    TextInputEditText mEdit;
     TextInputLayout mInput;
   }
   Map<Metadata.MetadataType, MetadataEntry> mMetadata = new HashMap<>();
@@ -134,7 +134,7 @@ public class EditorFragment extends BaseMwmFragment implements View.OnClickListe
   private View mEmptyOpeningHours;
   private TextView mOpeningHours;
   private View mEditOpeningHours;
-  private EditText mDescription;
+  private TextInputEditText mDescription;
   private final Map<Metadata.MetadataType, View> mDetailsBlocks = new HashMap<>();
   private TextView mReset;
 
@@ -251,7 +251,7 @@ public class EditorFragment extends BaseMwmFragment implements View.OnClickListe
 
     for (var e : mMetadata.entrySet())
     {
-      final EditText edit = e.getValue().mEdit;
+      final TextInputEditText edit = e.getValue().mEdit;
       if (!Editor.nativeIsMetadataValid(e.getKey().toInt(), edit.getText().toString()))
       {
         edit.requestFocus();
@@ -476,22 +476,22 @@ public class EditorFragment extends BaseMwmFragment implements View.OnClickListe
     mDetailsBlocks.put(Metadata.MetadataType.FMD_INTERNET, blockWifi);
   }
 
-  private static EditText findInput(View blockWithInput)
+  private static TextInputEditText findInput(View blockWithInput)
   {
-    return (EditText) blockWithInput.findViewById(R.id.input);
+    return (TextInputEditText) blockWithInput.findViewById(R.id.input);
   }
 
-  private EditText findInputAndInitBlock(View blockWithInput, @DrawableRes int icon, @StringRes int hint)
+  private TextInputEditText findInputAndInitBlock(View blockWithInput, @DrawableRes int icon, @StringRes int hint)
   {
     return findInputAndInitBlock(blockWithInput, icon, getString(hint));
   }
 
-  private static EditText findInputAndInitBlock(View blockWithInput, @DrawableRes int icon, String hint)
+  private static TextInputEditText findInputAndInitBlock(View blockWithInput, @DrawableRes int icon, String hint)
   {
     ((ImageView) blockWithInput.findViewById(R.id.icon)).setImageResource(icon);
     final TextInputLayout input = blockWithInput.findViewById(R.id.custom_input);
     input.setHint(hint);
-    return (EditText) input.findViewById(R.id.input);
+    return (TextInputEditText) input.findViewById(R.id.input);
   }
 
   @Override

--- a/android/app/src/main/java/app/organicmaps/editor/MultilanguageAdapter.java
+++ b/android/app/src/main/java/app/organicmaps/editor/MultilanguageAdapter.java
@@ -3,12 +3,12 @@ package app.organicmaps.editor;
 import android.view.LayoutInflater;
 import android.view.View;
 import android.view.ViewGroup;
-import android.widget.EditText;
 
 import androidx.annotation.NonNull;
 import androidx.recyclerview.widget.RecyclerView;
 
 import com.google.android.material.textfield.TextInputLayout;
+import com.google.android.material.textfield.TextInputEditText;
 import app.organicmaps.R;
 import app.organicmaps.editor.data.LocalizedName;
 import app.organicmaps.util.StringUtils;
@@ -92,7 +92,7 @@ public class MultilanguageAdapter extends RecyclerView.Adapter<MultilanguageAdap
 
   public class Holder extends RecyclerView.ViewHolder
   {
-    EditText input;
+    TextInputEditText input;
     TextInputLayout inputLayout;
 
     public Holder(View itemView)

--- a/android/app/src/main/java/app/organicmaps/editor/OsmLoginFragment.java
+++ b/android/app/src/main/java/app/organicmaps/editor/OsmLoginFragment.java
@@ -7,7 +7,6 @@ import android.view.LayoutInflater;
 import android.view.View;
 import android.view.ViewGroup;
 import android.widget.Button;
-import android.widget.EditText;
 import android.widget.ProgressBar;
 import android.widget.TextView;
 
@@ -25,14 +24,15 @@ import app.organicmaps.util.UiUtils;
 import app.organicmaps.util.concurrency.ThreadPool;
 import app.organicmaps.util.concurrency.UiThread;
 import com.google.android.material.dialog.MaterialAlertDialogBuilder;
+import com.google.android.material.textfield.TextInputEditText;
 
 public class OsmLoginFragment extends BaseMwmToolbarFragment
 {
   private ProgressBar mProgress;
   private Button mLoginButton;
   private Button mLostPasswordButton;
-  private EditText mLoginInput;
-  private EditText mPasswordInput;
+  private TextInputEditText mLoginInput;
+  private TextInputEditText mPasswordInput;
 
   @Nullable
   @Override

--- a/android/app/src/main/java/app/organicmaps/editor/PhoneListAdapter.java
+++ b/android/app/src/main/java/app/organicmaps/editor/PhoneListAdapter.java
@@ -4,13 +4,13 @@ import android.text.TextUtils;
 import android.view.LayoutInflater;
 import android.view.View;
 import android.view.ViewGroup;
-import android.widget.EditText;
 import android.widget.ImageView;
 
 import androidx.annotation.NonNull;
 import androidx.recyclerview.widget.RecyclerView;
 
 import com.google.android.material.textfield.TextInputLayout;
+import com.google.android.material.textfield.TextInputEditText;
 import app.organicmaps.R;
 import app.organicmaps.util.StringUtils;
 import app.organicmaps.util.UiUtils;
@@ -98,7 +98,7 @@ public class PhoneListAdapter extends RecyclerView.Adapter<PhoneListAdapter.View
   protected class ViewHolder extends RecyclerView.ViewHolder implements View.OnClickListener
   {
     private int mPosition = -1;
-    private final EditText mInput;
+    private final TextInputEditText mInput;
     private final ImageView deleteButton;
 
     public ViewHolder(@NonNull View itemView)

--- a/android/app/src/main/java/app/organicmaps/editor/ReportFragment.java
+++ b/android/app/src/main/java/app/organicmaps/editor/ReportFragment.java
@@ -5,7 +5,6 @@ import android.text.TextUtils;
 import android.view.LayoutInflater;
 import android.view.View;
 import android.view.ViewGroup;
-import android.widget.EditText;
 
 import androidx.annotation.IntRange;
 import androidx.annotation.NonNull;
@@ -14,13 +13,14 @@ import androidx.annotation.Nullable;
 import app.organicmaps.R;
 import app.organicmaps.base.BaseMwmToolbarFragment;
 import app.organicmaps.util.UiUtils;
+import com.google.android.material.textfield.TextInputEditText;
 
 public class ReportFragment extends BaseMwmToolbarFragment implements View.OnClickListener
 {
   private View mSimpleProblems;
   private View mAdvancedProblem;
   private View mSave;
-  private EditText mProblemInput;
+  private TextInputEditText mProblemInput;
 
   private boolean mAdvancedMode;
   @IntRange(from = 0, to = 3)

--- a/android/app/src/main/java/app/organicmaps/widget/SearchToolbarController.java
+++ b/android/app/src/main/java/app/organicmaps/widget/SearchToolbarController.java
@@ -9,7 +9,6 @@ import android.text.TextWatcher;
 import android.view.KeyEvent;
 import android.view.View;
 import android.view.inputmethod.EditorInfo;
-import android.widget.EditText;
 
 import androidx.annotation.NonNull;
 import androidx.annotation.Nullable;
@@ -19,6 +18,7 @@ import app.organicmaps.R;
 import app.organicmaps.util.InputUtils;
 import app.organicmaps.util.StringUtils;
 import app.organicmaps.util.UiUtils;
+import com.google.android.material.textfield.TextInputEditText;
 
 public class SearchToolbarController extends ToolbarController implements View.OnClickListener
 {
@@ -30,7 +30,7 @@ public class SearchToolbarController extends ToolbarController implements View.O
   @NonNull
   private final View mBack;
   @NonNull
-  private final EditText mQuery;
+  private final TextInputEditText mQuery;
   private boolean mFromCategory = false;
   @NonNull
   private final View mProgress;

--- a/android/app/src/main/java/app/organicmaps/widget/placepage/EditBookmarkFragment.java
+++ b/android/app/src/main/java/app/organicmaps/widget/placepage/EditBookmarkFragment.java
@@ -7,7 +7,6 @@ import android.text.TextUtils;
 import android.view.LayoutInflater;
 import android.view.View;
 import android.view.ViewGroup;
-import android.widget.EditText;
 import android.widget.ImageView;
 import android.widget.TextView;
 
@@ -28,6 +27,7 @@ import app.organicmaps.bookmarks.data.BookmarkManager;
 import app.organicmaps.bookmarks.data.Icon;
 import app.organicmaps.util.Graphics;
 import app.organicmaps.util.UiUtils;
+import com.google.android.material.textfield.TextInputEditText;
 
 import java.util.List;
 
@@ -36,8 +36,8 @@ public class EditBookmarkFragment extends BaseMwmDialogFragment implements View.
   public static final String EXTRA_CATEGORY_ID = "CategoryId";
   public static final String EXTRA_BOOKMARK_ID = "BookmarkId";
 
-  private EditText mEtDescription;
-  private EditText mEtName;
+  private TextInputEditText mEtDescription;
+  private TextInputEditText mEtName;
   private TextView mTvBookmarkGroup;
   private ImageView mIvColor;
   private BookmarkCategory mBookmarkCategory;

--- a/android/app/src/main/res/layout/dialog_edit_text.xml
+++ b/android/app/src/main/res/layout/dialog_edit_text.xml
@@ -18,7 +18,7 @@
     android:layout_width="match_parent"
     android:layout_height="wrap_content"
     app:hintEnabled="false">
-    <EditText
+    <com.google.android.material.textfield.TextInputEditText
       android:id="@+id/et__input"
       style="@style/MwmWidget.PlacePage.EditText"
       android:layout_width="match_parent"

--- a/android/app/src/main/res/layout/edit_bookmark_common.xml
+++ b/android/app/src/main/res/layout/edit_bookmark_common.xml
@@ -20,7 +20,7 @@
       android:layout_width="match_parent"
       android:layout_height="wrap_content"
       android:textColorHint="?android:textColorSecondary">
-      <EditText
+      <com.google.android.material.textfield.TextInputEditText
         android:id="@+id/et__bookmark_name"
         style="@style/MwmWidget.PlacePage.EditText"
         android:layout_width="match_parent"
@@ -82,7 +82,7 @@
     android:layout_below="@id/rl__bookmark_set"
     android:layout_margin="@dimen/margin_half"
     android:textColorHint="?android:textColorSecondary">
-    <EditText
+    <com.google.android.material.textfield.TextInputEditText
       android:id="@+id/et__description"
       style="@style/MwmWidget.PlacePage.EditText"
       android:layout_width="match_parent"

--- a/android/app/src/main/res/layout/fragment_bookmark_category_settings.xml
+++ b/android/app/src/main/res/layout/fragment_bookmark_category_settings.xml
@@ -33,7 +33,7 @@
         android:id="@+id/edit_name_container"
         android:layout_width="match_parent"
         android:layout_height="wrap_content">
-        <EditText
+        <com.google.android.material.textfield.TextInputEditText
           android:id="@+id/edit_list_name_view"
           android:hint="@string/list"
           android:layout_weight="1"
@@ -51,7 +51,7 @@
           android:layout_height="@dimen/margin_base_plus"/>
       </LinearLayout>
     </LinearLayout>
-    <EditText
+    <com.google.android.material.textfield.TextInputEditText
       android:id="@+id/edit_description"
       android:background="@null"
       android:hint="@string/bookmark_list_description_hint"

--- a/android/app/src/main/res/layout/fragment_edit_description.xml
+++ b/android/app/src/main/res/layout/fragment_edit_description.xml
@@ -28,7 +28,7 @@
     android:layout_below="@id/toolbar"
     android:paddingStart="@dimen/margin_base"
     android:paddingEnd="@dimen/margin_base">
-    <EditText
+    <com.google.android.material.textfield.TextInputEditText
       android:id="@+id/et__description"
       style="@style/MwmWidget.PlacePage.EditText"
       android:layout_width="match_parent"

--- a/android/app/src/main/res/layout/fragment_editor.xml
+++ b/android/app/src/main/res/layout/fragment_editor.xml
@@ -277,7 +277,7 @@
           android:gravity="center_vertical"
           android:minHeight="74dp"
           android:textColorHint="?android:textColorSecondary">
-          <EditText
+          <com.google.android.material.textfield.TextInputEditText
             android:id="@+id/input"
             style="@style/MwmWidget.Editor.FieldLayout.EditText"
             android:inputType="textMultiLine"

--- a/android/app/src/main/res/layout/fragment_osm_login.xml
+++ b/android/app/src/main/res/layout/fragment_osm_login.xml
@@ -64,7 +64,7 @@
         style="@style/MwmWidget.Editor.CustomTextInput"
         android:layout_marginTop="@dimen/margin_half"
         android:textColorHint="?android:textColorSecondary">
-        <EditText
+        <com.google.android.material.textfield.TextInputEditText
           android:id="@+id/osm_username"
           style="@style/MwmWidget.Editor.FieldLayout.EditText"
           android:autofillHints="emailAddress"
@@ -74,7 +74,7 @@
         style="@style/MwmWidget.Editor.CustomTextInput"
         android:layout_marginTop="@dimen/margin_base"
         android:textColorHint="?android:textColorSecondary">
-        <EditText
+        <com.google.android.material.textfield.TextInputEditText
           android:id="@+id/osm_password"
           style="@style/MwmWidget.Editor.FieldLayout.EditText"
           android:autofillHints="password"

--- a/android/app/src/main/res/layout/fragment_report.xml
+++ b/android/app/src/main/res/layout/fragment_report.xml
@@ -66,7 +66,7 @@
         android:layout_height="wrap_content"
         android:orientation="vertical">
 
-        <EditText
+        <com.google.android.material.textfield.TextInputEditText
           android:id="@+id/input"
           android:layout_width="match_parent"
           android:layout_height="128dp"

--- a/android/app/src/main/res/layout/fragment_timetable_advanced.xml
+++ b/android/app/src/main/res/layout/fragment_timetable_advanced.xml
@@ -20,7 +20,7 @@
       card_view:cardCornerRadius="2dp"
       card_view:cardElevation="4dp">
 
-      <EditText
+      <com.google.android.material.textfield.TextInputEditText
         android:id="@+id/et__timetable"
         android:layout_width="match_parent"
         android:layout_height="wrap_content"

--- a/android/app/src/main/res/layout/item_editor_input.xml
+++ b/android/app/src/main/res/layout/item_editor_input.xml
@@ -14,7 +14,7 @@
     android:layout_centerVertical="true"
     android:layout_marginStart="54dp"
     android:textColorHint="?android:textColorSecondary">
-    <EditText
+    <com.google.android.material.textfield.TextInputEditText
       android:id="@+id/input"
       style="@style/MwmWidget.Editor.FieldLayout.EditText"
       tools:hint="Hint"

--- a/android/app/src/main/res/layout/item_localized_name.xml
+++ b/android/app/src/main/res/layout/item_localized_name.xml
@@ -15,7 +15,7 @@
     android:layout_height="wrap_content"
     android:layout_weight="1"
     android:textColorHint="?android:textColorSecondary">
-    <EditText
+    <com.google.android.material.textfield.TextInputEditText
       android:id="@+id/input"
       style="@style/MwmWidget.Editor.FieldLayout.EditText"
       android:hint="@string/editor_edit_place_name_hint"

--- a/android/app/src/main/res/layout/item_phone.xml
+++ b/android/app/src/main/res/layout/item_phone.xml
@@ -25,7 +25,7 @@
         android:layout_toEndOf="@id/phone_icon"
         android:layout_toStartOf="@id/delete_icon"
         android:textColorHint="?android:textColorSecondary">
-        <EditText
+        <com.google.android.material.textfield.TextInputEditText
             android:id="@+id/input"
             style="@style/MwmWidget.Editor.FieldLayout.EditText"
             tools:hint="Hint"

--- a/android/app/src/main/res/layout/toolbar_search_controls.xml
+++ b/android/app/src/main/res/layout/toolbar_search_controls.xml
@@ -18,7 +18,7 @@
     android:scaleType="center"
     tools:src="@drawable/ic_down" />
 
-  <EditText
+  <com.google.android.material.textfield.TextInputEditText
     android:id="@+id/query"
     style="@style/MwmTextAppearance.Toolbar.Search"
     android:layout_width="0dp"


### PR DESCRIPTION
Closes #2117

This PR migrated EditText to Material TextInputEditText
I have tested:
- Login Fragment
- Edit bookmarks
- Edit list bookmarks
- Edit number phone
- Edit opening_hours
- Edit name POI
- DialogFragment to add street name in editor
- DialogFragment to add new list