### PR TITLE
Fix deprecations in gradle script

### DIFF
--- a/android/app/build.gradle
+++ b/android/app/build.gradle
@@ -165,8 +165,8 @@ android {
     dataBinding = true
   }
   // All properties are read from gradle.properties file
-  compileSdkVersion propCompileSdkVersion.toInteger()
-  buildToolsVersion propBuildToolsVersion
+  compileSdk propCompileSdkVersion.toInteger()
+  buildToolsVersion = propBuildToolsVersion
 
   ndkVersion '26.0.10792818'
 
@@ -177,8 +177,8 @@ android {
     versionName = ver.V2
     println('Version: ' + versionName)
     println('VersionCode: ' + versionCode)
-    minSdkVersion propMinSdkVersion.toInteger()
-    targetSdkVersion propTargetSdkVersion.toInteger()
+    minSdk propMinSdkVersion.toInteger()
+    targetSdk propTargetSdkVersion.toInteger()
     applicationId project.ext.appId
     buildConfigField 'String', 'SUPPORT_MAIL', '"android@organicmaps.app"'
     // Should be customized in flavors.
@@ -409,7 +409,7 @@ android {
   // TODO: Load all minor files via separate call to ReadAsString which can correctly handle compressed files in zip containers.
   androidResources {
     ignoreAssetsPattern '!.svn:!.git:!.DS_Store:!*.scc:.*:<dir>_*:!CVS:!thumbs.db:!picasa.ini:!*~'
-    noCompress 'txt', 'bin', 'html', 'png', 'json', 'mwm', 'ttf', 'sdf', 'ui', 'config', 'csv', 'spv', 'obj'
+    noCompress = ['txt', 'bin', 'html', 'png', 'json', 'mwm', 'ttf', 'sdf', 'ui', 'config', 'csv', 'spv', 'obj']
   }
 
   compileOptions {


### PR DESCRIPTION
This PR fixes deprecations in build.gradle:
- compileSdkVersion was replaced by compileSdk https://developer.android.com/reference/tools/gradle-api/7.2/com/android/build/api/dsl/CommonExtension#compileSdkVersion(kotlin.Int)
- buildToolsVersion was replaced by buildToolsVersion = https://developer.android.com/reference/tools/gradle-api/7.2/com/android/build/api/dsl/CommonExtension#buildToolsVersion(kotlin.String)
- minSdkVersion was replaced minSdk, just more shorter, same for targetSdkVersion https://stackoverflow.com/questions/67250362/what-is-difference-between-compilesdk-and-compilesdkversion-in-android-studio-gr/67251145#67251145
- noCompress was replaced by noCompress = [Collection] https://developer.android.com/reference/tools/gradle-api/8.1/com/android/build/api/dsl/AndroidResources#noCompress(kotlin.String)