### PR TITLE
[qt] Correctly handle the case when QGeoPositionInfoSource::createSource return a null pointer

### DIFF
--- a/platform/qt_location_service.cpp
+++ b/platform/qt_location_service.cpp
@@ -128,11 +128,7 @@ void QtLocationService::OnSupportedPositioningMethodsChanged()
 
 void QtLocationService::Start()
 {
-  if (!m_positionSource)
-  {
-    LOG(LWARNING, ("No supported source is available for starting the positioning with:", m_positionSource->sourceName().toStdString()));
-  }
-  else
+  if (m_positionSource)
   {
     LOG(LDEBUG, ("Starting Updates from:", m_positionSource->sourceName().toStdString()));
     m_positionSource->startUpdates();
@@ -143,11 +139,7 @@ void QtLocationService::Start()
 
 void QtLocationService::Stop()
 {
-  if (!m_positionSource)
-  {
-    LOG(LWARNING, ("No supported source is available for stopping the positioning with:", m_positionSource->sourceName().toStdString()));
-  }
-  else
+  if (m_positionSource)
   {
     LOG(LDEBUG, ("Stopping Updates from:", m_positionSource->sourceName().toStdString()));
     m_positionSource->stopUpdates();


### PR DESCRIPTION
I am running openSuse Tumbleweed and I have geoclue 2.7.1 installed. I was getting a crash with `'OMaps' terminated by signal SIGSEGV (Address boundary error)` and I traced it back to QGeoPositionInfoSource::createSource returning a null pointer. When starting the service it tries to access its source name, causing the crash.