### PR TITLE
fix/[android] Smoother corners for the place page.

### DIFF
--- a/android/app/src/main/res/layout/place_page_container_fragment.xml
+++ b/android/app/src/main/res/layout/place_page_container_fragment.xml
@@ -22,8 +22,7 @@
     <RelativeLayout
       android:id="@+id/placepage_container"
       android:layout_width="match_parent"
-      android:layout_height="wrap_content"
-      android:background="?panel">
+      android:layout_height="wrap_content">
       <androidx.fragment.app.FragmentContainerView
         android:id="@+id/placepage_fragment"
         android:layout_width="match_parent"

--- a/android/app/src/main/res/layout/place_page_preview.xml
+++ b/android/app/src/main/res/layout/place_page_preview.xml
@@ -5,7 +5,6 @@
   xmlns:tools="http://schemas.android.com/tools"
   android:layout_width="match_parent"
   android:layout_height="wrap_content"
-  android:background="?ppBackground"
   android:orientation="vertical"
   android:paddingBottom="@dimen/margin_quarter">
   <include


### PR DESCRIPTION
fixes #6215

The bottom sheet of the places page did not have round corners due to unnecessary implementations of a few drawables as backgrounds. I solved this issue.

IMAGES : 

<img width="300" src="https://github.com/organicmaps/organicmaps/assets/61724808/4769e7d4-1a5a-4159-b6d5-0595f1aed867" /> 

<img width="550" src="https://github.com/organicmaps/organicmaps/assets/61724808/a4c6b1ba-7977-41a1-8492-d2a037ffe9db" />

<img width="550" src="https://github.com/organicmaps/organicmaps/assets/61724808/8d1e5638-3b1a-47bc-af05-c02e1b7afb76" />

