### PR TITLE
[ios] [carplay] fix CarPlay instructions UI colors ans style

### DIFF
--- a/iphone/Maps/Classes/CarPlay/CarPlayRouter.swift
+++ b/iphone/Maps/Classes/CarPlay/CarPlayRouter.swift
@@ -268,8 +268,7 @@ extension CarPlayRouter {
     primaryManeuver.instructionVariants = [instructionVariant]
     if let imageName = routeInfo.turnImageName,
       let symbol = UIImage(named: imageName) {
-      primaryManeuver.symbolSet = CPImageSet(lightContentImage: symbol,
-                                             darkContentImage: symbol)
+      primaryManeuver.symbolImage = symbol
     }
     if let estimates = createEstimates(routeInfo) {
       primaryManeuver.initialTravelEstimates = estimates
@@ -280,8 +279,7 @@ extension CarPlayRouter {
       let secondaryManeuver = CPManeuver()
       secondaryManeuver.userInfo = CPConstants.Maneuvers.secondary
       secondaryManeuver.instructionVariants = [L("then_turn")]
-      secondaryManeuver.symbolSet = CPImageSet(lightContentImage: symbol,
-                                               darkContentImage: symbol)
+      secondaryManeuver.symbolImage = symbol
       maneuvers.append(secondaryManeuver)
     }
     return maneuvers

--- a/iphone/Maps/Classes/CarPlay/CarPlayService.swift
+++ b/iphone/Maps/Classes/CarPlay/CarPlayService.swift
@@ -97,6 +97,18 @@ final class CarPlayService: NSObject {
     }
     return .unspecified
   }
+  
+  private var rootTemplateStyle: CPTripEstimateStyle {
+    get {
+      if #available(iOS 13.0, *) {
+        return sessionConfiguration?.contentStyle == .light ? .light : .dark
+      }
+      return .dark
+    }
+    set {
+      (interfaceController?.rootTemplate as? CPMapTemplate)?.tripEstimateStyle = newValue
+    }
+  }
 
   private func applyRootViewController() {
     guard let window = window else { return }
@@ -114,6 +126,7 @@ final class CarPlayService: NSObject {
   private func applyBaseRootTemplate() {
     let mapTemplate = MapTemplateBuilder.buildBaseTemplate(positionMode: currentPositionMode)
     mapTemplate.mapDelegate = self
+    mapTemplate.tripEstimateStyle = rootTemplateStyle
     interfaceController?.setRootTemplate(mapTemplate, animated: true)
     FrameworkHelper.rotateMap(0.0, animated: false)
   }
@@ -124,6 +137,7 @@ final class CarPlayService: NSObject {
     interfaceController?.setRootTemplate(mapTemplate, animated: true)
     router?.startNavigationSession(forTrip: trip, template: mapTemplate)
     if let estimates = createEstimates(routeInfo: routeInfo) {
+      mapTemplate.tripEstimateStyle = rootTemplateStyle
       mapTemplate.updateEstimates(estimates, for: trip)
     }
 
@@ -314,7 +328,9 @@ extension CarPlayService: CPSessionConfigurationDelegate {
   @available(iOS 13.0, *)
   func sessionConfiguration(_ sessionConfiguration: CPSessionConfiguration,
                             contentStyleChanged contentStyle: CPContentStyle) {
-    window?.overrideUserInterfaceStyle = contentStyle == .light ? .light : .dark
+    let isLight = contentStyle == .light
+    window?.overrideUserInterfaceStyle = isLight ? .light : .dark
+    rootTemplateStyle = isLight ? .light : .dark
   }
 }
 

--- a/iphone/Maps/Classes/CarPlay/Template Builders/MapTemplateBuilder.swift
+++ b/iphone/Maps/Classes/CarPlay/Template Builders/MapTemplateBuilder.swift
@@ -16,6 +16,11 @@ final class MapTemplateBuilder {
     case redirectRoute
     case endRoute
   }
+  
+  private enum Constants {
+    static let carPlayGuidanceBackgroundColor = UIColor(46, 100, 51, 1.0)
+  }
+  
   // MARK: - CPMapTemplate builders
   class func buildBaseTemplate(positionMode: MWMMyPositionMode) -> CPMapTemplate {
     let mapTemplate = CPMapTemplate()
@@ -100,6 +105,7 @@ final class MapTemplateBuilder {
       CarPlayService.shared.cancelCurrentTrip()
     }
     mapTemplate.trailingNavigationBarButtons = [endButton]
+    mapTemplate.guidanceBackgroundColor = Constants.carPlayGuidanceBackgroundColor
   }
   
   // MARK: - Conditional navigation buttons


### PR DESCRIPTION
Closes https://github.com/organicmaps/organicmaps/issues/6379
Closes https://github.com/organicmaps/organicmaps/issues/2706

## Fixes and improvements:
1. Change the background color for CarPlay instructions to green, so all maneuver icon in the light/dark theme is visible and have good contrast according to WCAG.
2. Fix the trip estimates view background (black bottom view that always starts with black style) so it now has the correct theme style and reacts to theme changing properly (by adding the `rootTemplateStyle` property that helps to update the style of the view, which by default always use .dark style).
---
## Notes:
Tested only in the simulator, so it needs to be tested on real CarPlay!

<img width="798" alt="image" src="https://github.com/organicmaps/organicmaps/assets/79797627/24152511-4e25-46b5-95ed-50de1e0ff62f">
<img width="803" alt="image" src="https://github.com/organicmaps/organicmaps/assets/79797627/d00443da-11d2-445d-8863-e36830b01b5d">

![Screen Recording 2023-10-29 at 01 16 25](https://github.com/organicmaps/organicmaps/assets/79797627/e9844997-b529-46fe-9b62-c70287f50e9d)
![Screen Recording 2023-10-29 at 01 18 37](https://github.com/organicmaps/organicmaps/assets/79797627/eaaf5acd-405a-4dbf-993d-d98364be97d9)
