### PR TITLE
[ios] [carplay] fix bug when light estimates view appears on dark maps

### DIFF
--- a/iphone/Maps/Classes/CarPlay/CarPlayService.swift
+++ b/iphone/Maps/Classes/CarPlay/CarPlayService.swift
@@ -37,13 +37,19 @@ final class CarPlayService: NSObject {
     self.window = window
     self.interfaceController = interfaceController
     self.interfaceController?.delegate = self
-    sessionConfiguration = CPSessionConfiguration(delegate: self)
+    let configuration = CPSessionConfiguration(delegate: self)
+    sessionConfiguration = configuration
     // Try to use the CarPlay unit's interface style.
     if #available(iOS 13.0, *) {
-      if sessionConfiguration?.contentStyle == .light {
+      switch configuration.contentStyle {
+      case .light:
+        rootTemplateStyle = .light
         window.overrideUserInterfaceStyle = .light
-      } else {
+      case .dark:
+        rootTemplateStyle = .dark
         window.overrideUserInterfaceStyle = .dark
+      default:
+        rootTemplateStyle = window.overrideUserInterfaceStyle == .light ? .light : .dark
       }
     }
     searchService = CarPlaySearchService()
@@ -98,15 +104,9 @@ final class CarPlayService: NSObject {
     return .unspecified
   }
   
-  private var rootTemplateStyle: CPTripEstimateStyle {
-    get {
-      if #available(iOS 13.0, *) {
-        return sessionConfiguration?.contentStyle == .light ? .light : .dark
-      }
-      return .dark
-    }
-    set {
-      (interfaceController?.rootTemplate as? CPMapTemplate)?.tripEstimateStyle = newValue
+  private var rootTemplateStyle: CPTripEstimateStyle = .light {
+    didSet {
+      (interfaceController?.rootTemplate as? CPMapTemplate)?.tripEstimateStyle = rootTemplateStyle
     }
   }
 

--- a/iphone/Maps/Classes/MapsAppDelegate.mm
+++ b/iphone/Maps/Classes/MapsAppDelegate.mm
@@ -409,11 +409,11 @@ using namespace osm_auth_ios;
 
 - (void)application:(UIApplication *)application
   didConnectCarInterfaceController:(CPInterfaceController *)interfaceController
-                          toWindow:(CPWindow *)window API_AVAILABLE(ios(12.0)) {
-  [self.carplayService setupWithWindow:window interfaceController:interfaceController];
+           toWindow:(CPWindow *)window API_AVAILABLE(ios(12.0)) {
   if (@available(iOS 13.0, *)) {
     window.overrideUserInterfaceStyle = UIUserInterfaceStyleUnspecified;
   }
+  [self.carplayService setupWithWindow:window interfaceController:interfaceController];
   [self updateAppearanceFromWindow:self.window toWindow:window isCarplayActivated:YES];
 }
 


### PR DESCRIPTION
Fix bug in PR: https://github.com/organicmaps/organicmaps/pull/6408 when light estimates view (at the bottom) appears on dark maps.

There are 3 possible states that the user can choose in CarPlay Settings:
<img width="800" alt="image" src="https://github.com/organicmaps/organicmaps/assets/79797627/1dad5949-c367-4a52-b51e-08980a628d9c">


1.  `Always dark` is Selected, `Always Show Dark Map` is `On`: Interface and maps are dark.
<img width="800" alt="image" src="https://github.com/organicmaps/organicmaps/assets/79797627/db7c9c5e-c3d8-42f6-b25d-db0bbbc83fd9">

2. `Always dark` is Selected, `Always Show Dark Map` is `Off`: Interface is  dark, and maps+instructions can be set light/dark by CarPlay
<img width="795" alt="image" src="https://github.com/organicmaps/organicmaps/assets/79797627/83cded7d-676b-43f9-9823-16ee456f123e">
<img width="803" alt="image" src="https://github.com/organicmaps/organicmaps/assets/79797627/2934470f-6db7-435d-b8be-144166c7a4db">

3. `Automatic` is Selected: CarPlay set automatically Interface and maps+instructions theme styles.
<img width="796" alt="image" src="https://github.com/organicmaps/organicmaps/assets/79797627/b820e747-21b2-4dc5-9e35-0677e9f3f936">

