### PR TITLE
[3party] Treat utfcpp as a system header

### DIFF
--- a/3party/utf8cpp/include/utf8cpp
+++ b/3party/utf8cpp/include/utf8cpp
@@ -1,0 +1,1 @@
+../../utfcpp/source

--- a/base/internal/message.cpp
+++ b/base/internal/message.cpp
@@ -2,7 +2,7 @@
 
 #include "std/target_os.hpp"
 
-#include "3party/utfcpp/source/utf8/unchecked.h"
+#include <utf8cpp/utf8/unchecked.h>
 
 std::string DebugPrint(std::string const & t)
 {

--- a/base/string_utils.hpp
+++ b/base/string_utils.hpp
@@ -18,7 +18,7 @@
 #include <string_view>
 #include <type_traits>
 
-#include "3party/utfcpp/source/utf8/unchecked.h"
+#include <utf8cpp/utf8/unchecked.h>
 
 /// All methods work with strings in utf-8 format
 namespace strings

--- a/cmake/OmimConfig.cmake
+++ b/cmake/OmimConfig.cmake
@@ -3,6 +3,6 @@ set(OMIM_WARNING_FLAGS
   $<$<NOT:$<CXX_COMPILER_ID:MSVC>>:-Wall -Wextra -Wpedantic>
   $<$<NOT:$<CXX_COMPILER_ID:MSVC>>:-Wno-unused-parameter>  # We have a lot of functions with unused parameters
 )
-set(3PARTY_INCLUDE_DIRS "${OMIM_ROOT}/3party/boost")
+set(3PARTY_INCLUDE_DIRS "${OMIM_ROOT}/3party/boost" "${OMIM_ROOT}/3party/utf8cpp/include")
 set(OMIM_DATA_DIR "${OMIM_ROOT}/data")
 set(OMIM_USER_RESOURCES_DIR "${OMIM_ROOT}/data")

--- a/coding/coding_tests/string_utf8_multilang_tests.cpp
+++ b/coding/coding_tests/string_utf8_multilang_tests.cpp
@@ -4,7 +4,7 @@
 
 #include "base/control_flow.hpp"
 
-#include "3party/utfcpp/source/utf8.h"
+#include <utf8cpp/utf8.h>
 
 #include <cstddef>
 #include <string>

--- a/indexer/search_string_utils.cpp
+++ b/indexer/search_string_utils.cpp
@@ -12,7 +12,7 @@
 #include <queue>
 #include <vector>
 
-#include "3party/utfcpp/source/utf8/unchecked.h"
+#include <utf8cpp/utf8/unchecked.h>
 
 namespace search
 {

--- a/shaders/CMakeLists.txt
+++ b/shaders/CMakeLists.txt
@@ -143,7 +143,7 @@ if (PLATFORM_IPHONE)
 endif()
 
 # Do not include glm's CMakeLists.txt, because it's outdated and not necessary.
-target_include_directories(${PROJECT_NAME} PUBLIC ${OMIM_ROOT}/3party/glm)
+target_include_directories(${PROJECT_NAME} PUBLIC ${OMIM_ROOT}/3party/glm ${OMIM_ROOT}/3party/utf8cpp/include)
 
 target_link_libraries(${PROJECT_NAME} drape)
 

--- a/xcode/common.xcconfig
+++ b/xcode/common.xcconfig
@@ -5,7 +5,7 @@ QT_PATH[arch=arm64] = /opt/homebrew/opt/qt@5
 BOOST_ROOT = $(OMIM_ROOT)/3party/boost
 
 // jansson is included in many libs, and is also used in headers (leaks to other libs)
-HEADER_SEARCH_PATHS = $(inherited) $(OMIM_ROOT) $(BOOST_ROOT) $(OMIM_ROOT)/3party/jansson $(OMIM_ROOT)/3party/jansson/jansson/src
+HEADER_SEARCH_PATHS = $(inherited) $(OMIM_ROOT) $(BOOST_ROOT) $(OMIM_ROOT)/3party/jansson $(OMIM_ROOT)/3party/jansson/jansson/src $(OMIM_ROOT)/3party/utf8cpp/include
 FRAMEWORK_SEARCH_PATHS[sdk=macosx*] = $(QT_PATH)/lib
 
 // Deployment target

--- a/xcode/cppjansson/cppjansson.xcodeproj/project.pbxproj
+++ b/xcode/cppjansson/cppjansson.xcodeproj/project.pbxproj
@@ -158,9 +158,7 @@
 			baseConfigurationReference = 71407E71294CB35000FBD9A4 /* common-debug.xcconfig */;
 			buildSettings = {
 				HEADER_SEARCH_PATHS = (
-                    "$(PROJECT_DIR)/../../",
-                    "$(PROJECT_DIR)/../../3party/jansson",
-                    "$(PROJECT_DIR)/../../3party/jansson/jansson/src",
+					"$(inherited)",
                 );
 			};
 			name = Debug;
@@ -170,9 +168,7 @@
 			baseConfigurationReference = 71407E74294CB37700FBD9A4 /* common-release.xcconfig */;
 			buildSettings = {
 				HEADER_SEARCH_PATHS = (
-                    "$(PROJECT_DIR)/../../",
-                    "$(PROJECT_DIR)/../../3party/jansson",
-                    "$(PROJECT_DIR)/../../3party/jansson/jansson/src",
+					"$(inherited)",
                 );
 			};
 			name = Release;


### PR DESCRIPTION
* For compiler diagnostics
* For dependency management
* Extra symlink directory 3party/utf8cpp/include/utf8cpp/ added for xcode iPhone builds to have the same directory structure, (utf8cpp/utf8/unchecked.h) which would be created by CMake. See: https://github.com/nemtrif/utfcpp/blob /925e7147ece348a170f4fea3a7f94ee72b433030/CMakeLists.txt And: https://github.com/nemtrif/utfcpp/issues/54