### PR TITLE
[qt][platform]: Synchronize geoclue desktopId with desktop file name

### DIFF
--- a/platform/qt_location_service.cpp
+++ b/platform/qt_location_service.cpp
@@ -61,7 +61,7 @@ static location::TLocationSource qStringToTLocationSource(QString const & source
 QtLocationService::QtLocationService(location::LocationObserver & observer, std::string const & sourceName) : LocationService(observer)
 {
   QVariantMap params;
-  params["desktopId"] = "OrganicMaps";
+  params["desktopId"] = "app.organicmaps.desktop";
   m_positionSource = QGeoPositionInfoSource::createSource(QString::fromStdString(sourceName), params, this);
 
   if (!m_positionSource)


### PR DESCRIPTION
* Certain GUI Shells like [Phosh](https://en.wikipedia.org/wiki/Phosh) implement a `geoclue` agent in which the `desktopId` of the application, that requested positioning is checked against the desktop file of the same application for authorization purposes. See the [location manager of Phosh]( https://gitlab.gnome.org/World/Phosh/phosh/-/blob/main/src/location-manager.c?ref_type=heads#L239)

* Needed for https://github.com/flathub/app.organicmaps.desktop/issues/61