### PR TITLE
[android] Make Drape the source of truth for the location mode changes

### DIFF
--- a/android/app/src/main/cpp/app/organicmaps/LocationState.cpp
+++ b/android/app/src/main/cpp/app/organicmaps/LocationState.cpp
@@ -35,7 +35,9 @@ Java_app_organicmaps_location_LocationState_nativeSwitchToNextMode(JNIEnv * env,
 JNIEXPORT jint JNICALL
 Java_app_organicmaps_location_LocationState_nativeGetMode(JNIEnv * env, jclass clazz)
 {
-  ASSERT(g_framework, ());
+  // GetMyPositionMode() is initialized only after drape creation.
+  // https://github.com/organicmaps/organicmaps/issues/1128#issuecomment-1784435190
+  ASSERT(g_framework && g_framework->IsDrapeEngineCreated(), ());
   return g_framework->GetMyPositionMode();
 }
 

--- a/android/app/src/main/java/app/organicmaps/MwmApplication.java
+++ b/android/app/src/main/java/app/organicmaps/MwmApplication.java
@@ -363,7 +363,7 @@ public class MwmApplication extends Application implements Application.ActivityL
       Logger.i(LOCATION_TAG, "Android Auto is active, keeping location in the background");
     else if (RoutingController.get().isNavigating())
       Logger.i(LOCATION_TAG, "Navigation is in progress, keeping location in the background");
-    else if (!Map.isEngineCreated() || LocationState.nativeGetMode() == LocationState.PENDING_POSITION)
+    else if (!Map.isEngineCreated() || LocationState.getMode() == LocationState.PENDING_POSITION)
       Logger.i(LOCATION_TAG, "PENDING_POSITION mode, keeping location in the background");
     else
     {

--- a/android/app/src/main/java/app/organicmaps/car/CarAppSession.java
+++ b/android/app/src/main/java/app/organicmaps/car/CarAppSession.java
@@ -137,7 +137,6 @@ public final class CarAppSession extends Session implements DefaultLifecycleObse
     if (mDisplayManager.isCarDisplayUsed())
     {
       LocationState.nativeSetListener(this);
-      onMyPositionModeChanged(LocationState.nativeGetMode());
       Framework.nativePlacePageActivationListener(this);
     }
     SensorHelper.from(getCarContext()).addListener(this);

--- a/android/app/src/main/java/app/organicmaps/car/util/UiHelpers.java
+++ b/android/app/src/main/java/app/organicmaps/car/util/UiHelpers.java
@@ -14,6 +14,7 @@ import androidx.car.app.model.Row;
 import androidx.car.app.navigation.model.MapController;
 import androidx.core.graphics.drawable.IconCompat;
 
+import app.organicmaps.Map;
 import app.organicmaps.R;
 import app.organicmaps.bookmarks.data.MapObject;
 import app.organicmaps.bookmarks.data.Metadata;
@@ -157,7 +158,7 @@ public final class UiHelpers
   private static Action createLocationButton(@NonNull CarContext context)
   {
     final Action.Builder builder = new Action.Builder();
-    final int locationMode = LocationState.nativeGetMode();
+    final int locationMode = Map.isEngineCreated() ? LocationState.getMode() : LocationState.NOT_FOLLOW_NO_POSITION;
     CarColor tintColor = Colors.DEFAULT;
 
     @DrawableRes int drawableRes;

--- a/android/app/src/main/java/app/organicmaps/location/LocationState.java
+++ b/android/app/src/main/java/app/organicmaps/location/LocationState.java
@@ -4,6 +4,8 @@ import androidx.annotation.IntDef;
 import androidx.annotation.Keep;
 import androidx.annotation.NonNull;
 
+import app.organicmaps.Map;
+
 import java.lang.annotation.Retention;
 import java.lang.annotation.RetentionPolicy;
 
@@ -48,7 +50,7 @@ public final class LocationState
 
   public static native void nativeSwitchToNextMode();
   @Value
-  public static native int nativeGetMode();
+  private static native int nativeGetMode();
 
   public static native void nativeSetListener(@NonNull ModeChangeListener listener);
   public static native void nativeRemoveListener();
@@ -63,21 +65,15 @@ public final class LocationState
 
   private LocationState() {}
 
-  /**
-   * Checks if location state on the map is active (so its not turned off or pending).
-   */
-  static boolean isTurnedOn()
+  @Value
+  public static int getMode()
   {
-    return hasLocation(nativeGetMode());
+    if (!Map.isEngineCreated())
+      throw new IllegalStateException("Location mode is undefined until engine is created");
+    return nativeGetMode();
   }
 
-  static boolean hasLocation(int mode)
-  {
-    return (mode > NOT_FOLLOW_NO_POSITION);
-  }
-
-  @SuppressWarnings("unused")
-  static String nameOf(@Value int mode)
+  public static String nameOf(@Value int mode)
   {
     switch (mode)
     {

--- a/android/app/src/main/java/app/organicmaps/routing/NavigationService.java
+++ b/android/app/src/main/java/app/organicmaps/routing/NavigationService.java
@@ -1,5 +1,6 @@
 package app.organicmaps.routing;
 
+import static android.Manifest.permission.ACCESS_COARSE_LOCATION;
 import static android.Manifest.permission.ACCESS_FINE_LOCATION;
 import static android.Manifest.permission.POST_NOTIFICATIONS;
 import static android.content.pm.PackageManager.PERMISSION_GRANTED;
@@ -241,6 +242,7 @@ public class NavigationService extends Service implements LocationListener
   }
 
   @Override
+  @RequiresPermission(anyOf = {ACCESS_COARSE_LOCATION, ACCESS_FINE_LOCATION})
   public void onLocationUpdated(@NonNull Location location)
   {
     // Ignore any pending notifications when service is being stopping.

--- a/android/app/src/main/java/app/organicmaps/widget/menu/MyPositionButton.java
+++ b/android/app/src/main/java/app/organicmaps/widget/menu/MyPositionButton.java
@@ -15,6 +15,8 @@ import androidx.annotation.NonNull;
 import androidx.core.content.res.ResourcesCompat;
 import androidx.core.widget.ImageViewCompat;
 import com.google.android.material.floatingactionbutton.FloatingActionButton;
+
+import app.organicmaps.Map;
 import app.organicmaps.R;
 import app.organicmaps.location.LocationState;
 import app.organicmaps.util.ThemeUtils;
@@ -36,7 +38,8 @@ public class MyPositionButton
     mButton.setOnClickListener(listener);
     mIcons.clear();
     mFollowPaddingShift = (int) (FOLLOW_SHIFT * button.getResources().getDisplayMetrics().density);
-    update(LocationState.nativeGetMode());
+    final int locationMode = Map.isEngineCreated() ? LocationState.getMode() : LocationState.NOT_FOLLOW_NO_POSITION;
+    update(locationMode);
   }
 
   public void update(int mode)


### PR DESCRIPTION
[android] Make Drape the source of truth for the location mode changes

Drape changes the location mode under the hood in multiple cases, which
creates the discrepancy between Android <-> Drape state. Trust Drape
and do all location mode transitions only via onMyPositionModeChanged().

Follow up #1128 #4376 #6098 #6465 #6466

Signed-off-by: Roman Tsisyk <roman@tsisyk.com>