### PR TITLE
[android] Keep location in the background in PENDING_LOCATION mode

### DIFF
--- a/android/app/src/main/java/app/organicmaps/MwmApplication.java
+++ b/android/app/src/main/java/app/organicmaps/MwmApplication.java
@@ -26,6 +26,7 @@ import app.organicmaps.display.DisplayManager;
 import app.organicmaps.downloader.CountryItem;
 import app.organicmaps.downloader.MapManager;
 import app.organicmaps.location.LocationHelper;
+import app.organicmaps.location.LocationState;
 import app.organicmaps.location.SensorHelper;
 import app.organicmaps.maplayer.isolines.IsolinesManager;
 import app.organicmaps.maplayer.subway.SubwayManager;
@@ -356,13 +357,17 @@ public class MwmApplication extends Application implements Application.ActivityL
 
     OsmUploadWork.startActionUploadOsmChanges(this);
 
-    if (RoutingController.get().isNavigating())
-    {
+    if (!mDisplayManager.isDeviceDisplayUsed())
+      Logger.i(LOCATION_TAG, "Android Auto is active, keeping location in the background");
+    else if (RoutingController.get().isNavigating())
       Logger.i(LOCATION_TAG, "Navigation is in progress, keeping location in the background");
-      return;
-    }
-    if (mDisplayManager.isDeviceDisplayUsed())
+    else if (!Map.isEngineCreated() || LocationState.nativeGetMode() == LocationState.PENDING_POSITION)
+      Logger.i(LOCATION_TAG, "PENDING_POSITION mode, keeping location in the background");
+    else
+    {
+      Logger.i(LOCATION_TAG, "Stopping location in the background");
       mLocationHelper.stop();
+    }
   }
 
   private class StorageCallbackImpl implements MapManager.StorageCallback


### PR DESCRIPTION
People don't buy the idea that Organic Maps disables location when goes into the background. Tickets are constantly filed, and I have become tired of explaining that this is a feature rather than a bug.

What happens typically:

1. The user launches Organic Maps.
3. Organic Maps subscribes to GPS updates.
4. The Android system tries to do the cold start of GPS if there were no other GPS-enabled apps before.
5. In certain cases, GPS takes too long to warm up and location doesn't arrive even after 10-20 seconds or even a minute.
6. The user gets tired and switches to other apps to do something productive.
7. Organic Maps disconnects from location services in the background.
8. The Android system deactivates GPS if there are no other apps using it (this is the most important part of the story).
9. The next launch of Organic Maps starts this process from the square one.

The presence of other apps with the background location just doesn't allow the system to shutdown the GPS sensor.

This patch keeps location services in the background if location mode is PENDING_LOCATION. This probably will not help much without adding a foreground service like we did for the navigation. All top vendors like Samsung, OnePlus, Huawei, Xiaomi, Meizu and others will cut off GPS updates eventually (see https://dontkillmyapp.com). However, this small fix should help on LineageOS and other opensource firmwares that are not such power-efficient yet. The majority of the apps stay subscribed to the location updates when go the background. We will do other, but only for case when the location search is in progress.

In context of #4223 and #5999.