### PR TITLE
[ios] Hint for RouteTo button to make routes without Point2Point tab

### DIFF
--- a/iphone/Maps/UI/BottomMenu/TabBar/BottomTabBarInteractor.swift
+++ b/iphone/Maps/UI/BottomMenu/TabBar/BottomTabBarInteractor.swift
@@ -1,6 +1,7 @@
 protocol BottomTabBarInteractorProtocol: AnyObject {
   func openSearch()
   func openHelp()
+  func openFaq()
   func openBookmarks()
   func openMenu()
 }
@@ -30,6 +31,10 @@ extension BottomTabBarInteractor: BottomTabBarInteractorProtocol {
   
   func openHelp() {
     MapViewController.shared()?.navigationController?.pushViewController(AboutController(), animated: true)
+  }
+  
+  func openFaq() {
+    MapViewController.shared()?.navigationController?.pushViewController(FaqController(), animated: true)
   }
   
   func openBookmarks() {

--- a/iphone/Maps/UI/BottomMenu/TabBar/BottomTabBarPresenter.swift
+++ b/iphone/Maps/UI/BottomMenu/TabBar/BottomTabBarPresenter.swift
@@ -1,7 +1,7 @@
 protocol BottomTabBarPresenterProtocol: AnyObject {
   func configure()
   func onSearchButtonPressed()
-  func onHelpButtonPressed()
+  func onHelpButtonPressed(withBadge: Bool)
   func onBookmarksButtonPressed()
   func onMenuButtonPressed()
 }
@@ -21,15 +21,15 @@ extension BottomTabBarPresenter: BottomTabBarPresenterProtocol {
   func onSearchButtonPressed() {
     interactor.openSearch()
   }
-  
-  func onHelpButtonPressed() {
-    interactor.openHelp()
+
+  func onHelpButtonPressed(withBadge: Bool) {
+    withBadge ? interactor.openFaq() : interactor.openHelp()
   }
-  
+
   func onBookmarksButtonPressed() {
     interactor.openBookmarks()
   }
-  
+
   func onMenuButtonPressed() {
     interactor.openMenu()
   }

--- a/iphone/Maps/UI/BottomMenu/TabBar/BottomTabBarViewController.swift
+++ b/iphone/Maps/UI/BottomMenu/TabBar/BottomTabBarViewController.swift
@@ -1,3 +1,6 @@
+
+private let kUDDidShowFirstTimeRoutingEducationalHint = "kUDDidShowFirstTimeRoutingEducationalHint"
+
 class BottomTabBarViewController: UIViewController {
   var presenter: BottomTabBarPresenterProtocol!
   
@@ -6,6 +9,7 @@ class BottomTabBarViewController: UIViewController {
   @IBOutlet var bookmarksButton: MWMButton!
   @IBOutlet var moreButton: MWMButton!
   @IBOutlet var downloadBadge: UIView!
+  @IBOutlet var helpBadge: UIView!
   
   private var avaliableArea = CGRect.zero
   @objc var isHidden: Bool = false {
@@ -25,24 +29,20 @@ class BottomTabBarViewController: UIViewController {
     return MWMMapViewControlsManager.manager()?.tabBarController
   }
   
+  override func viewDidLoad() {
+    super.viewDidLoad()
+    presenter.configure()
+    
+    MWMSearchManager.add(self)
+  }
+  
   override func viewWillAppear(_ animated: Bool) {
     super.viewWillAppear(animated)
     if Settings.isNY() {
       helpButton.setTitle("🎄", for: .normal)
       helpButton.setImage(nil, for: .normal)
     }
-  }
-
-  override func viewDidLoad() {
-    super.viewDidLoad()
-    presenter.configure()
     updateBadge()
-
-    MWMSearchManager.add(self)
-  }
-  
-  override func viewDidAppear(_ animated: Bool) {
-    super.viewDidAppear(animated)
   }
   
   deinit {
@@ -56,9 +56,14 @@ class BottomTabBarViewController: UIViewController {
   @IBAction func onSearchButtonPressed(_ sender: Any) {
     presenter.onSearchButtonPressed()
   }
-
+  
   @IBAction func onHelpButtonPressed(_ sender: Any) {
-    presenter.onHelpButtonPressed()
+    if !helpBadge.isHidden {
+      presenter.onHelpButtonPressed(withBadge: true)
+      setHelpBadgeShown()
+    } else {
+      presenter.onHelpButtonPressed(withBadge: false)
+    }
   }
   
   @IBAction func onBookmarksButtonPressed(_ sender: Any) {
@@ -68,7 +73,6 @@ class BottomTabBarViewController: UIViewController {
   @IBAction func onMenuButtonPressed(_ sender: Any) {
     presenter.onMenuButtonPressed()
   }
-  
   
   private func updateAvailableArea(_ frame:CGRect) {
     avaliableArea = frame
@@ -90,8 +94,8 @@ class BottomTabBarViewController: UIViewController {
                      delay: 0,
                      options: [.beginFromCurrentState],
                      animations: {
-                      self.view.frame = newFrame
-                      self.view.alpha = alpha
+        self.view.frame = newFrame
+        self.view.alpha = alpha
       }, completion: nil)
     } else {
       self.view.frame = newFrame
@@ -101,11 +105,22 @@ class BottomTabBarViewController: UIViewController {
   
   private func updateBadge() {
     downloadBadge.isHidden = isApplicationBadgeHidden
+    helpBadge.isHidden = !needsToShowHelpBadge()
+  }
+}
+
+// MARK: - Help badge
+private extension BottomTabBarViewController {
+  private func needsToShowHelpBadge() -> Bool {
+    !UserDefaults.standard.bool(forKey: kUDDidShowFirstTimeRoutingEducationalHint)
+  }
+  
+  private func setHelpBadgeShown() {
+    UserDefaults.standard.set(true, forKey: kUDDidShowFirstTimeRoutingEducationalHint)
   }
 }
 
 // MARK: - MWMSearchManagerObserver
-
 extension BottomTabBarViewController: MWMSearchManagerObserver {
   func onSearchManagerStateChanged() {
     let state = MWMSearchManager.manager().state;

--- a/iphone/Maps/UI/BottomMenu/TabBar/BottomTabBarViewController.xib
+++ b/iphone/Maps/UI/BottomMenu/TabBar/BottomTabBarViewController.xib
@@ -12,6 +12,7 @@
             <connections>
                 <outlet property="bookmarksButton" destination="dgG-ki-3tB" id="md5-3T-9tb"/>
                 <outlet property="downloadBadge" destination="uDI-ZC-4wx" id="fAf-cy-Ozn"/>
+                <outlet property="helpBadge" destination="0pe-0n-d1F" id="pua-oN-kIZ"/>
                 <outlet property="helpButton" destination="dzf-7Z-N6a" id="ORg-VO-5ar"/>
                 <outlet property="moreButton" destination="svD-yi-GrZ" id="kjk-ZW-nZN"/>
                 <outlet property="searchButton" destination="No0-ld-JX3" id="m5F-UT-j94"/>
@@ -82,12 +83,24 @@
                                 <userDefinedRuntimeAttribute type="string" keyPath="styleName" value="Badge"/>
                             </userDefinedRuntimeAttributes>
                         </view>
+                        <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="0pe-0n-d1F" userLabel="HelpBadge">
+                            <rect key="frame" x="49.5" y="11" width="10" height="10"/>
+                            <color key="backgroundColor" red="1" green="0.0" blue="0.0" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
+                            <constraints>
+                                <constraint firstAttribute="height" constant="10" id="FgD-lk-SxR"/>
+                                <constraint firstAttribute="width" constant="10" id="OwT-jV-hqZ"/>
+                            </constraints>
+                            <userDefinedRuntimeAttributes>
+                                <userDefinedRuntimeAttribute type="string" keyPath="styleName" value="Badge"/>
+                            </userDefinedRuntimeAttributes>
+                        </view>
                     </subviews>
                     <accessibility key="accessibilityConfiguration" identifier="MainButtons"/>
                     <constraints>
                         <constraint firstAttribute="height" constant="48" id="69A-eu-uLp"/>
                         <constraint firstItem="No0-ld-JX3" firstAttribute="centerY" secondItem="vum-s3-PHx" secondAttribute="centerY" id="8nL-zT-Y7b"/>
                         <constraint firstItem="No0-ld-JX3" firstAttribute="height" secondItem="vum-s3-PHx" secondAttribute="height" id="9eR-I7-7at"/>
+                        <constraint firstItem="0pe-0n-d1F" firstAttribute="centerX" secondItem="dzf-7Z-N6a" secondAttribute="centerX" constant="8" id="Ab0-g9-N4P"/>
                         <constraint firstItem="svD-yi-GrZ" firstAttribute="leading" secondItem="dgG-ki-3tB" secondAttribute="trailing" id="Bsa-EZ-etN"/>
                         <constraint firstItem="svD-yi-GrZ" firstAttribute="height" secondItem="vum-s3-PHx" secondAttribute="height" id="Fde-um-JL6"/>
                         <constraint firstItem="dgG-ki-3tB" firstAttribute="width" secondItem="vum-s3-PHx" secondAttribute="width" multiplier="0.25" id="FvH-gW-qvX"/>
@@ -97,6 +110,7 @@
                         <constraint firstItem="dgG-ki-3tB" firstAttribute="height" secondItem="vum-s3-PHx" secondAttribute="height" id="Rs8-Hl-CAc"/>
                         <constraint firstItem="uDI-ZC-4wx" firstAttribute="centerX" secondItem="svD-yi-GrZ" secondAttribute="centerX" constant="8" id="XNb-Ba-Hn7"/>
                         <constraint firstItem="dzf-7Z-N6a" firstAttribute="centerY" secondItem="vum-s3-PHx" secondAttribute="centerY" id="Zug-zY-KIX"/>
+                        <constraint firstItem="0pe-0n-d1F" firstAttribute="centerY" secondItem="dzf-7Z-N6a" secondAttribute="centerY" constant="-8" id="pgw-rN-LCe"/>
                         <constraint firstItem="No0-ld-JX3" firstAttribute="width" secondItem="vum-s3-PHx" secondAttribute="width" multiplier="0.25" id="qZh-XR-VeU"/>
                         <constraint firstItem="No0-ld-JX3" firstAttribute="leading" secondItem="dzf-7Z-N6a" secondAttribute="trailing" id="sZ7-Yb-gag"/>
                         <constraint firstItem="svD-yi-GrZ" firstAttribute="centerY" secondItem="vum-s3-PHx" secondAttribute="centerY" id="sja-hO-YY3"/>

--- a/iphone/Maps/UI/PlacePage/PlacePageLayout/ActionBar/MWMActionBarButton.m
+++ b/iphone/Maps/UI/PlacePage/PlacePageLayout/ActionBar/MWMActionBarButton.m
@@ -3,6 +3,8 @@
 #import "MWMCircularProgress.h"
 #import "SwiftBridge.h"
 
+static NSString * const kUDDidHighlightRouteToButton = @"kUDDidHighlightPoint2PointButton";
+
 NSString *titleForButton(MWMActionBarButtonType type, BOOL isSelected) {
   switch (type) {
     case MWMActionBarButtonTypeDownload:
@@ -53,6 +55,8 @@ NSString *titleForButton(MWMActionBarButtonType type, BOOL isSelected) {
 - (void)configButton:(BOOL)isSelected enabled:(BOOL)isEnabled {
   self.label.text = titleForButton(self.type, isSelected);
   self.extraBackground.hidden = YES;
+  self.button.coloring = MWMButtonColoringBlack;
+  
   switch (self.type) {
     case MWMActionBarButtonTypeDownload: {
       if (self.mapDownloadProgress)
@@ -106,6 +110,8 @@ NSString *titleForButton(MWMActionBarButtonType type, BOOL isSelected) {
       break;
     case MWMActionBarButtonTypeRouteTo:
       [self.button setImage:[UIImage imageNamed:@"ic_route_to"] forState:UIControlStateNormal];
+      if ([self needsToHighlightRouteToButton])
+        self.button.coloring = MWMButtonColoringBlue;
       break;
     case MWMActionBarButtonTypeShare:
       [self.button setImage:[UIImage imageNamed:@"ic_menu_share"] forState:UIControlStateNormal];
@@ -129,6 +135,7 @@ NSString *titleForButton(MWMActionBarButtonType type, BOOL isSelected) {
       [self.button setImage:[UIImage imageNamed:@"ic_avoid_ferry"] forState:UIControlStateNormal];
       break;
   }
+  
   self.button.enabled = isEnabled;
 }
 
@@ -150,7 +157,9 @@ NSString *titleForButton(MWMActionBarButtonType type, BOOL isSelected) {
 - (IBAction)tap {
   if (self.type == MWMActionBarButtonTypeBookmark)
     [self setBookmarkSelected:!self.button.isSelected];
-
+  if (self.type == MWMActionBarButtonTypeRouteTo)
+    [self disableRouteToButtonHighlight];
+  
   [self.delegate tapOnButtonWithType:self.type];
 }
 
@@ -180,6 +189,14 @@ NSString *titleForButton(MWMActionBarButtonType type, BOOL isSelected) {
   UIImageView *animationIV = btn.imageView;
   animationIV.animationImages = animationImages;
   animationIV.animationRepeatCount = 1;
+}
+
+- (BOOL)needsToHighlightRouteToButton {
+  return ![NSUserDefaults.standardUserDefaults boolForKey:kUDDidHighlightRouteToButton];
+}
+
+- (void)disableRouteToButtonHighlight {
+  [NSUserDefaults.standardUserDefaults setBool:true forKey:kUDDidHighlightRouteToButton];
 }
 
 @end

--- a/iphone/Maps/UI/PlacePage/PlacePageLayout/ActionBar/MWMActionBarButton.xib
+++ b/iphone/Maps/UI/PlacePage/PlacePageLayout/ActionBar/MWMActionBarButton.xib
@@ -1,9 +1,9 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<document type="com.apple.InterfaceBuilder3.CocoaTouch.XIB" version="3.0" toolsVersion="15705" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" colorMatched="YES">
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.XIB" version="3.0" toolsVersion="21701" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" colorMatched="YES">
     <device id="retina6_1" orientation="portrait" appearance="light"/>
     <dependencies>
         <deployment identifier="iOS"/>
-        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="15706"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="21679"/>
         <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
     </dependencies>
     <objects>
@@ -19,9 +19,6 @@
                 </view>
                 <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="W07-Hz-J60" customClass="MWMButton">
                     <rect key="frame" x="0.0" y="2" width="80" height="33"/>
-                    <userDefinedRuntimeAttributes>
-                        <userDefinedRuntimeAttribute type="string" keyPath="styleName" value="MWMBlack"/>
-                    </userDefinedRuntimeAttributes>
                     <connections>
                         <action selector="tap" destination="iN0-l3-epB" eventType="touchUpInside" id="yKY-7K-Wyl"/>
                     </connections>


### PR DESCRIPTION
Closes https://github.com/organicmaps/organicmaps/issues/6256

## Problem
The point-to-point button was removed, so it needs to educate users to build routes.

## Solving
In this PR as mentioned in https://github.com/organicmaps/organicmaps/issues/6256 was added:
1. tint for RouteTo tab when the user tap on some location
2. red badge to the "?" (help) tab that routes the user to the FAQ screen
Both hints **appear once** only for:
- the first app launch after installation 
or 
- the first launch after the app is updated from the previous version to the current

![Simulator Screen Recording - iPhone 14 Pro - 2023-10-31 at 23 43 28](https://github.com/organicmaps/organicmaps/assets/79797627/67355769-4086-488f-b7b5-f36737b372df)