### PR TITLE
[ios] fix broken details cells on Editing place screen

### DIFF
--- a/data/editor.config
+++ b/data/editor.config
@@ -89,10 +89,11 @@
           <option value="yes" />
         </value>
       </field>
-      <field name="ele">
-        <tag k="ele" />
-        <value type="number" />
-      </field>
+      <!-- Uncomment this and other ele fields when the code supports it. -->
+<!--      <field name="ele">-->
+<!--        <tag k="ele" />-->
+<!--        <value type="number" />-->
+<!--      </field>-->
       <!-- Skipping FMD_TURN_LANES. -->
       <field name="email">
         <tag k="email" />
@@ -101,9 +102,10 @@
       <field name="postcode">
         <tag k="addr:postcode" />
       </field>
-      <field name="wikipedia" editable="no">
-        <tag k="wikipedia" />
-      </field>
+      <!-- Uncomment this and other wiki fields when the code supports it. -->
+<!--      <field name="wikipedia" editable="no">-->
+<!--        <tag k="wikipedia" />-->
+<!--      </field>-->
       <!-- Skipping FMD_MAXSPEED. -->
       <field name="flats">
         <tag k="addr:flats" />
@@ -176,11 +178,11 @@
     <types>
       <type id="aeroway-aerodrome" editable="no">
         <include group="poi" />
-        <include field="ele" />
+<!--        <include field="ele" />-->
       </type>
       <type id="aeroway-airport" editable="no">
         <include group="poi" />
-        <include field="ele" />
+<!--        <include field="ele" />-->
       </type>
       <type id="amenity-atm" group="banking" priority="low">
         <include field="opening_hours" />
@@ -470,27 +472,27 @@
       </type>
       <type id="historic-archaeological_site" group="historic" can_add="no">
         <include group="poi" />
-        <include field="wikipedia" />
+<!--        <include field="wikipedia" />-->
       </type>
       <type id="historic-castle" group="historic">
         <include group="poi" />
-        <include field="wikipedia" />
+<!--        <include field="wikipedia" />-->
       </type>
       <type id="historic-memorial" group="historic">
         <include field="name" />
-        <include field="wikipedia" />
+<!--        <include field="wikipedia" />-->
       </type>
       <type id="historic-monument" group="historic">
         <include field="name" />
-        <include field="wikipedia" />
+<!--        <include field="wikipedia" />-->
       </type>
       <type id="historic-ruins" group="historic">
         <include field="name" />
-        <include field="wikipedia" />
+<!--        <include field="wikipedia" />-->
       </type>
       <type id="landuse-cemetery" can_add="no">
         <include group="poi" />
-        <include field="wikipedia" />
+<!--        <include field="wikipedia" />-->
       </type>
       <type id="leisure-garden" can_add="no">
         <include group="poi_internet" />
@@ -501,14 +503,14 @@
       </type>
       <type id="leisure-stadium" can_add="no">
         <include group="poi" />
-        <include field="wikipedia" />
+<!--        <include field="wikipedia" />-->
       </type>
       <type id="leisure-swimming_pool" can_add="no">
         <include group="poi_internet" />
       </type>
       <type id="natural-cave_entrance" group="historic">
         <include field="name" />
-        <include field="wikipedia" />
+<!--        <include field="wikipedia" />-->
       </type>
       <type id="natural-geyser">
         <include field="name" />
@@ -518,8 +520,8 @@
       </type>
       <type id="natural-peak" can_add="no">
         <include field="name" />
-        <include field="wikipedia" />
-        <include field="ele" />
+<!--        <include field="wikipedia" />-->
+<!--        <include field="ele" />-->
       </type>
       <type id="natural-spring">
         <include field="name" />
@@ -527,7 +529,7 @@
       <type id="waterway-waterfall">
         <include field="name" />
         <include field="height" />
-        <include field="wikipedia" />
+<!--        <include field="wikipedia" />-->
       </type>
       <type id="office" can_add="no">
         <include group="poi_internet" />
@@ -555,15 +557,15 @@
       </type>
       <type id="place-farm" can_add="no">
         <include group="poi_internet" />
-        <include field="wikipedia" />
+<!--        <include field="wikipedia" />-->
       </type>
       <type id="place-hamlet" can_add="no">
         <include field="name" />
-        <include field="wikipedia" />
+<!--        <include field="wikipedia" />-->
       </type>
       <type id="place-village" can_add="no">
         <include field="name" />
-        <include field="wikipedia" />
+<!--        <include field="wikipedia" />-->
       </type>
       <type id="railway-halt" editable="no" can_add="no">
         <include field="name" />
@@ -781,7 +783,7 @@
       </type>
       <type id="tourism-alpine_hut" group="accomodation" can_add="no">
         <include group="poi_internet" />
-        <include field="ele" />
+<!--        <include field="ele" />-->
         <include field="opening_hours" />
         <include field="website" />
       </type>
@@ -793,7 +795,7 @@
       </type>
       <type id="tourism-attraction">
         <include group="poi_internet" />
-        <include field="wikipedia" />
+<!--        <include field="wikipedia" />-->
       </type>
       <type id="tourism-camp_site" group="accomodation">
         <include group="poi_internet" />


### PR DESCRIPTION
Reference issue: https://github.com/organicmaps/organicmaps/issues/6453

### Solution:
Temporarily remove unsupported types `elevation` and `wikipedia` from `data/editor.config`
So unsupported data will not break the layout of the Details section.

### Notes
Supporting these types will be implemented in the future.

Before:
<img width="396" alt="image" src="https://github.com/organicmaps/organicmaps/assets/79797627/1025a783-8d72-47c3-8b9a-742ecabb3cec">

After:
<img width="451" alt="image" src="https://github.com/organicmaps/organicmaps/assets/79797627/48f8160b-b934-49bb-a510-ebb9ca92eb86">
