### PR TITLE
Fix the Arabic language in a string in strings.txt

### DIFF
--- a/data/strings/strings.txt
+++ b/data/strings/strings.txt
@@ -16996,7 +16996,7 @@
     tags = android,ios
     en = OpenStreetMap editors will check the changes and contact you if they have any questions.
     af = OpenStraatMap-redigeerders sal die verandeirnge nagaan en u kontak indien hulle vrae het.
-    ar = .ﺔﻠﺌﺳﺃ ﻱﺃ ﻢﻬﻳﺪﻟ ﻥﺎﻛ ﺍﺫﺇ ﻚﻌﻣ ﻥﻮﻠﺻﺍﻮﺘﻳﻭ ﺕﺍﺮﻴﻴﻐﺘﻟﺍ ﻦﻣ OpenStreetMap ﻭﺭﺮﺤﻣ ﻖﻘﺤﺘﻴﺳ
+    ar = سيتحقق محررو خرائط الشارع المفتوح من التغييرات ويتواصلون معك إذا كان لديهم أي أسئلة.
     be = Рэдактары OpenStreetMap правераць змены і звяжуцца з вамі, калі ў іх узнікнуць пытанні.
     bg = Редакторите на OpenStreetMap ще проверят промените и ще се свържат с вас, ако имат въпроси.
     ca = Revisarem els canvis. Si tenim cap pregunta contactem amb vós via correu electrònic.


### PR DESCRIPTION
The Arabic language was wrong, as the script places the letters from left to right, while the Arabic language is written and read from right to left. And any Arabic reader will not understand it as it look like gibberish. I corrected the Arabic and made it right to left, and the name of the OpenStreetMaps was written in English instead of Arabic, which may have been the reason for reversing the entire Arabic text to start from the left.