### PR TITLE
[android] Fix text color in dark mode in bookmark category settings

### DIFF
--- a/android/app/src/main/res/layout/fragment_bookmark_category_settings.xml
+++ b/android/app/src/main/res/layout/fragment_bookmark_category_settings.xml
@@ -35,6 +35,7 @@
         android:layout_height="wrap_content">
         <com.google.android.material.textfield.TextInputEditText
           android:id="@+id/edit_list_name_view"
+          style="@style/MwmWidget.PlacePage.EditText"
           android:hint="@string/list"
           android:layout_weight="1"
           android:layout_width="0dp"
@@ -53,6 +54,7 @@
     </LinearLayout>
     <com.google.android.material.textfield.TextInputEditText
       android:id="@+id/edit_description"
+      style="@style/MwmWidget.PlacePage.EditText"
       android:background="@null"
       android:hint="@string/bookmark_list_description_hint"
       android:minHeight="@dimen/height_item_multiline"


### PR DESCRIPTION
Closes #6468

I have re-used style using in [fragment_edit_bookmark](https://github.com/organicmaps/organicmaps/blob/master/android/app/src/main/res/layout/fragment_edit_bookmark.xml)

||Before|After|
|-|-|-|
|Hint|<img src="https://github.com/organicmaps/organicmaps/assets/87148630/722d63bc-839d-420b-b893-a09ec2d77bfe" height=300 />|<img src="https://github.com/organicmaps/organicmaps/assets/87148630/e3251769-a426-447a-81f5-a2eed6087f86" height=300 />
|Filled|<img src="https://github.com/organicmaps/organicmaps/assets/87148630/256bf860-5789-433b-bd26-7df95301f8a7" height=300 />|<img src="https://github.com/organicmaps/organicmaps/assets/87148630/99ced0cf-812b-4f9f-8d66-fafe5455ebfa" height=300 />|
