### PR TITLE
[strings] Fix Spanish 'bench' translation

### DIFF
--- a/data/categories.txt
+++ b/data/categories.txt
@@ -4212,7 +4212,7 @@ pl:Ławka
 pt:2Assento|3Banco
 pt-BR:Assento|Banco de praça
 ro:Banchetă|Bancă|Bancă parc
-es:Banco
+es:Asiento|Banco
 et:Pink
 eu:Bankua
 sv:Bänk

--- a/data/strings/types_strings.txt
+++ b/data/strings/types_strings.txt
@@ -676,7 +676,7 @@
     da = Bænk
     de = Parkbank
     el = Παγκάκι
-    es = Banco
+    es = Asiento
     et = Pink
     eu = Bankua
     fa = سَکو


### PR DESCRIPTION
Closes #6423

A simple attempt to fix the aforementioned problem. It is the same solution as used in Portuguese. Does not change the way things are searched (Bank category, for example), but solves the 2 raised points in the first comment.