### PR TITLE
[android] Migrate Alert Dialog themes to Material Theming

### DIFF
--- a/android/app/src/main/res/values/themes.xml
+++ b/android/app/src/main/res/values/themes.xml
@@ -51,8 +51,9 @@
     <item name="android:windowBackground">@color/bg_window_night</item>
   </style>
 
-  <style name="MwmTheme.AlertDialog" parent="Theme.AppCompat.Light.Dialog.Alert">
+  <style name="MwmTheme.AlertDialog" parent="Theme.MaterialComponents.Light.Dialog.Alert">
     <item name="colorAccent">?buttonDialogTextColor</item>
+    <item name="colorPrimary">?buttonDialogTextColor</item>
     <item name="android:background">?cardBackground</item>
     <item name="android:textColorPrimary">?textDialogTheme</item>
     <item name="android:textSize">@dimen/text_size_body_1</item>
@@ -68,8 +69,9 @@
     <item name="android:textColor">?titleDialogTheme</item>
   </style>
 
-  <style name="MwmTheme.Night.AlertDialog" parent="Theme.AppCompat.Dialog.Alert">
+  <style name="MwmTheme.Night.AlertDialog" parent="Theme.MaterialComponents.Dialog.Alert">
     <item name="colorAccent">?buttonDialogTextColor</item>
+    <item name="colorPrimary">?buttonDialogTextColor</item>
     <item name="android:background">?cardBackground</item>
     <!-- Used for the message in the dialog -->
     <item name="android:textColorPrimary">?textDialogTheme</item>
@@ -133,15 +135,17 @@
     <item name="android:windowIsTranslucent">true</item>
   </style>
 
-  <style name="MwmMain.DialogFragment.TimePicker" parent="Theme.AppCompat.Light.Dialog.Alert">
+  <style name="MwmMain.DialogFragment.TimePicker" parent="Theme.MaterialComponents.Light.Dialog.Alert">
     <item name="colorAccent">@color/base_accent</item>
+    <item name="colorPrimary">?buttonDialogTextColor</item>
     <item name="android:fontFamily">@string/robotoMedium</item>
     <item name="android:windowBackground">@color/bg_cards</item>
     <item name="android:background">@color/bg_cards</item>
   </style>
 
-  <style name="MwmMain.DialogFragment.TimePicker.Night" parent="Theme.AppCompat.Dialog.Alert">
+  <style name="MwmMain.DialogFragment.TimePicker.Night" parent="Theme.MaterialComponents.Dialog.Alert">
     <item name="colorAccent">@color/base_accent_night</item>
+    <item name="colorPrimary">?buttonDialogTextColor</item>
     <item name="android:fontFamily">@string/robotoMedium</item>
     <item name="android:windowBackground">@color/bg_cards_night</item>
     <item name="android:background">@color/bg_cards_night</item>


### PR DESCRIPTION
This PR updates parent themes using by AlertDialog themes, following this guide https://material.io/blog/migrate-android-material-components

|Before|After|
|-|-|
|<img src="https://github.com/organicmaps/organicmaps/assets/87148630/0938723b-66d2-414d-b4f7-da8811b9a77c" height=300 />|<img src="https://github.com/organicmaps/organicmaps/assets/87148630/552294e1-2d7a-40b4-bebe-bad5086c23c6" height=300 />
|<img src="https://github.com/organicmaps/organicmaps/assets/87148630/059c06f3-a832-4f7f-a80c-05cacfbfbf1b" height=300 />|<img src="https://github.com/organicmaps/organicmaps/assets/87148630/ea988a4f-938a-4910-acb7-dbf0a68b8e8c" height=300 />|

Tested on
- Pixel 6 - Android 14
- Samsung Galaxy Tab S6 Lite - Android 13
- Honor 8 - Android 8
- Lenovo Yoga Tab 2 - Android 5

I have see that changes increase space between letters in buttons, we can only update Typeface property to improve this