### PR TITLE
Fix sed syntax error

### DIFF
--- a/tools/unix/generate_localizations.sh
+++ b/tools/unix/generate_localizations.sh
@@ -77,7 +77,7 @@ SUPPORTED_LOCALIZATIONS=${SUPPORTED_LOCALIZATIONS/he/iw}
 SUPPORTED_LOCALIZATIONS=${SUPPORTED_LOCALIZATIONS/id/in}
 GRADLE_PROPERTIES="$OMIM_PATH/android/gradle.properties"
 if [ "$SUPPORTED_LOCALIZATIONS" != "$(grep supportedLocalizations "$GRADLE_PROPERTIES")" ]; then
-  sed -i .bak 's/supportedLocalizations.*/'"$SUPPORTED_LOCALIZATIONS"'/' "$GRADLE_PROPERTIES"
+  sed -i.bak 's/supportedLocalizations.*/'"$SUPPORTED_LOCALIZATIONS"'/' "$GRADLE_PROPERTIES"
   rm "$GRADLE_PROPERTIES.bak"
 fi
 


### PR DESCRIPTION
On Ubuntu via WSL the current code complains that `.` is not a command. Presumably sed doesn't like whitespace between `-i` and `.bak` and interprets `.bak` as a sed command instead of an argument to `-i`.

Some websites suggest `sed -i".bak"` as proper syntax, @biodranik suggests that `sed -i.bak` is more portable cross-platform. Either way proper syntax will allow no errors and proper generation of the supportedLocalizations line in the gradle.properties file.