### PR TITLE
[android] Fix text color on ProgressDialog

### DIFF
--- a/android/app/src/main/java/app/organicmaps/bookmarks/BookmarkCategoriesFragment.java
+++ b/android/app/src/main/java/app/organicmaps/bookmarks/BookmarkCategoriesFragment.java
@@ -298,7 +298,7 @@ public class BookmarkCategoriesFragment extends BaseMwmRecyclerFragment<Bookmark
 
       final Context context = requireActivity();
       final Uri rootUri = data.getData();
-      final ProgressDialog dialog = new ProgressDialog(context, R.style.MwmTheme_AlertDialog);
+      final ProgressDialog dialog = new ProgressDialog(context, R.style.MwmTheme_ProgressDialog);
       dialog.setMessage(getString(R.string.wait_several_minutes));
       dialog.setProgressStyle(ProgressDialog.STYLE_SPINNER);
       dialog.setIndeterminate(true);

--- a/android/app/src/main/java/app/organicmaps/bookmarks/BookmarksSharingHelper.java
+++ b/android/app/src/main/java/app/organicmaps/bookmarks/BookmarksSharingHelper.java
@@ -25,7 +25,7 @@ public enum BookmarksSharingHelper
 
   public void prepareBookmarkCategoryForSharing(@NonNull Activity context, long catId)
   {
-    mProgressDialog = new ProgressDialog(context, R.style.MwmTheme_AlertDialog);
+    mProgressDialog = new ProgressDialog(context, R.style.MwmTheme_ProgressDialog);
     mProgressDialog.setMessage(context.getString(R.string.please_wait));
     mProgressDialog.setProgressStyle(ProgressDialog.STYLE_SPINNER);
     mProgressDialog.setIndeterminate(true);

--- a/android/app/src/main/java/app/organicmaps/settings/StoragePathFragment.java
+++ b/android/app/src/main/java/app/organicmaps/settings/StoragePathFragment.java
@@ -104,7 +104,7 @@ public class StoragePathFragment extends BaseSettingsFragment
   @SuppressWarnings("deprecation") // https://github.com/organicmaps/organicmaps/issues/3629
   private Dialog showProgressDialog()
   {
-    final ProgressDialog dialog = new ProgressDialog(requireActivity(), R.style.MwmTheme_AlertDialog);
+    final ProgressDialog dialog = new ProgressDialog(requireActivity(), R.style.MwmTheme_ProgressDialog);
     dialog.setMessage(getString(R.string.wait_several_minutes));
     dialog.setProgressStyle(ProgressDialog.STYLE_SPINNER);
     dialog.setIndeterminate(true);

--- a/android/app/src/main/res/values/themes.xml
+++ b/android/app/src/main/res/values/themes.xml
@@ -151,6 +151,10 @@
     <item name="android:background">@color/bg_cards_night</item>
   </style>
 
+  <style name="MwmTheme.ProgressDialog" parent="MwmTheme.AlertDialog">
+    <item name="android:textColor">?textDialogTheme</item>
+  </style>
+
   <style name="MwmTheme.Downloader">
     <item name="status_done">@drawable/ic_downloader_done</item>
     <item name="status_downloadable">@drawable/ic_downloader_download</item>


### PR DESCRIPTION
Fixes #6469
I have created a new style because add textColor property on the main alertDialog style applies color also on buttons text.

|Before|After|
|-|-|
|<img src="https://github.com/organicmaps/organicmaps/assets/87148630/051c3389-5fb5-455c-9099-31abbefbd298" height=300 />|<img src="https://github.com/organicmaps/organicmaps/assets/87148630/e7a29d59-dc4c-4d4d-ad77-b8e712ab01ea" height=300 />|
|<img src="https://github.com/organicmaps/organicmaps/assets/87148630/b927d747-5e10-4b62-bc7c-80ef27776fb1" height=300 />|<img src="https://github.com/organicmaps/organicmaps/assets/87148630/b96489fb-5023-4049-9df4-3c26e2844a9f" height=300 />|

Tested on
- Pixel 6 - Android 14
- Samsung Galaxy Tab S6 Lite - Android 13
- Honor 8 - Android 8
- Lenovo Yoga Tab 2 - Android 5