### PR TITLE
[android] Remove buildToolsVersion

### DIFF
--- a/android/app/build.gradle
+++ b/android/app/build.gradle
@@ -40,7 +40,7 @@ buildscript {
   ext.androidAutoEnabled = androidAutoFlag != null ? androidAutoFlag.toBoolean() : androidAutoDefault
 
   dependencies {
-    classpath 'com.android.tools.build:gradle:8.1.2'
+    classpath 'com.android.tools.build:gradle:8.1.3'
 
     if (googleMobileServicesEnabled) {
       println('Building with Google Mobile Services')
@@ -168,7 +168,6 @@ android {
   }
   // All properties are read from gradle.properties file
   compileSdk propCompileSdkVersion.toInteger()
-  buildToolsVersion = propBuildToolsVersion
 
   ndkVersion '26.1.10909125'
 

--- a/android/build.gradle
+++ b/android/build.gradle
@@ -1,5 +1,5 @@
 // Top-level build file where you can add configuration options common to all sub-projects/modules.
 plugins {
-    id 'com.android.application' version '8.1.2' apply false
-    id 'com.android.library' version '8.1.2' apply false
+    id 'com.android.application' version '8.1.3' apply false
+    id 'com.android.library' version '8.1.3' apply false
 }

--- a/android/gradle.properties
+++ b/android/gradle.properties
@@ -1,7 +1,6 @@
 propMinSdkVersion=21
 propTargetSdkVersion=34
 propCompileSdkVersion=34
-propBuildToolsVersion=34.0.0
 
 org.gradle.caching=true
 org.gradle.jvmargs=-Xmx1024m -Xms256m


### PR DESCRIPTION
The project automatically uses a default version of the build tools that Gradle plugin specifies.