### PR TITLE
[android] Clean ToolbarStyle themes

### DIFF
--- a/android/app/src/main/res/layout/routing_plan.xml
+++ b/android/app/src/main/res/layout/routing_plan.xml
@@ -2,7 +2,6 @@
 <LinearLayout
   xmlns:android="http://schemas.android.com/apk/res/android"
   xmlns:tools="http://schemas.android.com/tools"
-  xmlns:app="http://schemas.android.com/apk/res-auto"
   android:id="@+id/routing_plan_frame"
   android:layout_width="match_parent"
   android:layout_height="wrap_content"
@@ -16,7 +15,6 @@
       style="@style/MwmWidget.ToolbarStyle"
       android:theme="@style/MwmWidget.ToolbarTheme"
       android:layout_width="match_parent"
-      app:contentInsetStart="0dp"
       android:layout_height="wrap_content"
       android:elevation="0dp">
 

--- a/android/app/src/main/res/layout/toolbar_with_search.xml
+++ b/android/app/src/main/res/layout/toolbar_with_search.xml
@@ -1,13 +1,11 @@
 <?xml version="1.0" encoding="utf-8"?>
 <androidx.appcompat.widget.Toolbar
   xmlns:android="http://schemas.android.com/apk/res/android"
-  xmlns:app="http://schemas.android.com/apk/res-auto"
   android:id="@+id/toolbar"
   style="@style/MwmWidget.ToolbarStyle"
   android:layout_width="match_parent"
   android:layout_height="wrap_content"
-  android:theme="@style/MwmWidget.ToolbarTheme"
-  app:contentInsetStart="@dimen/dp_0">
+  android:theme="@style/MwmWidget.ToolbarTheme">
   <LinearLayout
     android:id="@+id/toolbar_container"
     android:layout_width="match_parent"

--- a/android/app/src/main/res/layout/toolbar_with_search_no_elevation.xml
+++ b/android/app/src/main/res/layout/toolbar_with_search_no_elevation.xml
@@ -1,13 +1,11 @@
 <?xml version="1.0" encoding="utf-8"?>
 <androidx.appcompat.widget.Toolbar
   xmlns:android="http://schemas.android.com/apk/res/android"
-  xmlns:app="http://schemas.android.com/apk/res-auto"
   android:id="@+id/toolbar"
   style="@style/MwmWidget.ToolbarStyle.NoElevation"
   android:layout_width="match_parent"
   android:layout_height="wrap_content"
-  android:theme="@style/MwmWidget.ToolbarTheme"
-  app:contentInsetStart="@dimen/dp_0">
+  android:theme="@style/MwmWidget.ToolbarTheme">
   <LinearLayout
     android:layout_width="match_parent"
     android:layout_height="wrap_content"

--- a/android/app/src/main/res/values/styles.xml
+++ b/android/app/src/main/res/values/styles.xml
@@ -128,12 +128,10 @@
 
   <style name="MwmWidget.ToolbarStyle" parent="ThemeOverlay.MaterialComponents.Dark.ActionBar">
     <item name="android:background">?colorPrimary</item>
-    <item name="android:elevation">@dimen/appbar_elevation</item>
     <item name="android:displayOptions">homeAsUp|showTitle</item>
-    <item name="contentInsetStart">72dp</item>
+    <item name="contentInsetStart">0dp</item>
     <item name="android:titleTextAppearance">@style/MwmTextAppearance.Toolbar.Title</item>
     <item name="titleTextAppearance">@style/MwmTextAppearance.Toolbar.Title</item>
-    <item name="android:contentInsetStart">72dp</item>
   </style>
 
   <style name="MwmWidget.ToolbarStyle.Light">


### PR DESCRIPTION
This PR remove useless properties of Toolbar themes:
- Is not necessary to specify `android:elevation=4dp` in themes because the default value in material theme is 4dp.
- `contentInsetStart` property has no effect on elements in the toolbar (this property specifies where elements start in the toolbar), I have kept 0dp value for all layouts because somes layouts already 0dp value.
- `android:contentInsetStart` property has no effect (During tests on device and Android Studio Preview)

Tested on Pixel 6 - Android 14 and Honor 8 - Android 8 in Light and Dark mode and in RTL