### PR TITLE
[android] Disable R8 optimizations

### DIFF
--- a/android/app/proguard-rules.pro
+++ b/android/app/proguard-rules.pro
@@ -25,3 +25,6 @@
 
 # Disable obfuscation since it is open-source app.
 -dontobfuscate
+# R8 crypts the source line numbers in all log messages.
+# https://github.com/organicmaps/organicmaps/issues/6559#issuecomment-1812039926
+-dontoptimize


### PR DESCRIPTION
The source line numbers in the log messages are transformed by R8 in the complex way, that requires `mapping.txt` to recover the real number. Disable R8 optimizations for now until we figure out how to maintain the history of `mapping.txt` for all releases.

Closes #6559