### PR TITLE
[ios] Fix: show FAQ sceen after About when educational hint is enabled

### DIFF
--- a/iphone/Maps/UI/BottomMenu/TabBar/BottomTabBarInteractor.swift
+++ b/iphone/Maps/UI/BottomMenu/TabBar/BottomTabBarInteractor.swift
@@ -34,7 +34,11 @@ extension BottomTabBarInteractor: BottomTabBarInteractorProtocol {
   }
   
   func openFaq() {
-    MapViewController.shared()?.navigationController?.pushViewController(FaqController(), animated: true)
+    guard let navigationController = MapViewController.shared()?.navigationController else { return }
+    let aboutController = AboutController(onDidAppearCompletionHandler: {
+      navigationController.pushViewController(FaqController(), animated: true)
+    })
+    navigationController.pushViewController(aboutController, animated: true)
   }
   
   func openBookmarks() {

--- a/iphone/Maps/UI/Help/AboutController.swift
+++ b/iphone/Maps/UI/Help/AboutController.swift
@@ -16,9 +16,29 @@ final class AboutController: MWMViewController, UITableViewDataSource, UITableVi
     df.timeStyle = .none
     return String(format: L("data_version"), df.string(from:mapsDate), mapsVersionInt)
   }
+  
+  private var onDidAppearCompletionHandler: (() -> Void)?
+
+  init(onDidAppearCompletionHandler: (() -> Void)? = nil) {
+    self.onDidAppearCompletionHandler = onDidAppearCompletionHandler
+    super.init(nibName: nil, bundle: nil)
+  }
+
+  @available(*, unavailable)
+  required init?(coder: NSCoder) {
+    fatalError("init(coder:) has not been implemented")
+  }
 
   private func isDonateEnabled() -> Bool {
     return Settings.donateUrl() != nil
+  }
+  
+  override func viewDidAppear(_ animated: Bool) {
+    super.viewDidAppear(animated)
+    if let completionHandler = onDidAppearCompletionHandler {
+      completionHandler()
+      onDidAppearCompletionHandler = nil
+    }
   }
 
   override func loadView() {


### PR DESCRIPTION
Fix to https://github.com/organicmaps/organicmaps/pull/6446

In this PR when the red badge on the first ("?") tab is active About screen will be opened first, and then FAQ.

![Simulator Screen Recording - iPhone 14 Pro - 2023-11-15 at 23 08 40](https://github.com/organicmaps/organicmaps/assets/79797627/892aac86-3878-4acb-a795-a8f16d335eda)
