### PR TITLE
[drape] Fix OGL ES ?debug-rect line widths

### DIFF
--- a/drape_frontend/debug_rect_renderer.cpp
+++ b/drape_frontend/debug_rect_renderer.cpp
@@ -35,6 +35,8 @@ DebugRectRenderer::DebugRectRenderer(ref_ptr<dp::GraphicsContext> context, ref_p
   , m_state(CreateRenderState(gpu::Program::DebugRect, DepthLayer::OverlayLayer))
 {
   m_state.SetDepthTestEnabled(false);
+  m_state.SetDrawAsLine(true);
+  m_state.SetLineWidth(1);
 }
 
 bool DebugRectRenderer::IsEnabled() const
@@ -62,9 +64,9 @@ void DebugRectRenderer::SetArrow(ref_ptr<dp::GraphicsContext> context, m2::Point
   m2::PointF const side = m2::PointF(-dir.y, dir.x);
   PixelPointToScreenSpace(screen, arrowStart, vertices);
   PixelPointToScreenSpace(screen, arrowEnd, vertices);
-  PixelPointToScreenSpace(screen, arrowEnd - dir * 20 + side * 10, vertices);
+  PixelPointToScreenSpace(screen, arrowEnd - dir * 12 + side * 3, vertices);
   PixelPointToScreenSpace(screen, arrowEnd, vertices);
-  PixelPointToScreenSpace(screen, arrowEnd - dir * 20 - side * 10, vertices);
+  PixelPointToScreenSpace(screen, arrowEnd - dir * 12 - side * 3, vertices);
 
   ASSERT_LESS_OR_EQUAL(m_currentArrowMesh, m_arrowMeshes.size(), ());
   if (m_currentArrowMesh == m_arrowMeshes.size())


### PR DESCRIPTION
#5914 made lines thicker in `?debug-rect` mode used for debugging of overlays displacement on linux desktop (it didn't reproduce on android device neither with GL, nor with Vulkan renderer).

The lines are supposed to be 1px wide here:
![image](https://github.com/organicmaps/organicmaps/assets/18434508/ce0f03e0-91c0-44d5-9fb4-fb40779949e7)

Looks like width for these lines was never set explicitly, so some OGL defaults were used or rather line widths set by some other lines drawing functions (and actually ?debug-rect lines were thin still on lower zooms <z12).

This fix sets line width explicitly and also reduces arrows' sizes a bit:
![image](https://github.com/organicmaps/organicmaps/assets/18434508/cf5133eb-76a5-454e-b08d-4d2e189dc722)
