### PR TITLE
[android] Remove elevation in OSM fragment

### DIFF
--- a/android/app/src/main/res/layout-land/fragment_osm_login.xml
+++ b/android/app/src/main/res/layout-land/fragment_osm_login.xml
@@ -8,7 +8,8 @@
   android:orientation="vertical">
   <include
     android:id="@+id/toolbar"
-    layout="@layout/toolbar_default" />
+    layout="@layout/toolbar_default"
+    style="@style/MwmWidget.ToolbarStyle.NoElevation"/>
   <ScrollView
     android:layout_width="match_parent"
     android:layout_height="match_parent"

--- a/android/app/src/main/res/layout/fragment_osm_login.xml
+++ b/android/app/src/main/res/layout/fragment_osm_login.xml
@@ -8,7 +8,8 @@
   android:orientation="vertical">
   <include
     android:id="@+id/toolbar"
-    layout="@layout/toolbar_default" />
+    layout="@layout/toolbar_default"
+    style="@style/MwmWidget.ToolbarStyle.NoElevation"/>
   <ScrollView
     android:layout_width="match_parent"
     android:layout_height="match_parent"


### PR DESCRIPTION
This PR applies noelevation toolbar theme on OSM_fragment.
Elevation on the toolbar is used in case in view is scrollable.
In our case, this fragment is not scrollable.
We have other layouts with default elevation but remove this need more work especially when toolbar is not set in xml layout.

Tested in Pixel 6 - Android 14 in light and dark mode
