### PR TITLE
[android] Remove useless methods to start Web Intent and use Utils

### DIFF
--- a/android/app/src/main/java/app/organicmaps/editor/EditorFragment.java
+++ b/android/app/src/main/java/app/organicmaps/editor/EditorFragment.java
@@ -1,8 +1,6 @@
 package app.organicmaps.editor;
 
 import android.content.Context;
-import android.content.Intent;
-import android.net.Uri;
 import android.os.Bundle;
 import android.text.InputType;
 import android.text.TextUtils;
@@ -518,7 +516,7 @@ public class EditorFragment extends BaseMwmFragment implements View.OnClickListe
     else if (id == R.id.add_langs)
       mParent.addLanguage();
     else if (id == R.id.about_osm)
-      startActivity(new Intent((Intent.ACTION_VIEW), Uri.parse(getString(R.string.osm_wiki_about_url))));
+      Utils.openUrl(requireActivity(), getString(R.string.osm_wiki_about_url));
     else if (id == R.id.reset)
       reset();
   }

--- a/android/app/src/main/java/app/organicmaps/editor/OsmLoginFragment.java
+++ b/android/app/src/main/java/app/organicmaps/editor/OsmLoginFragment.java
@@ -1,7 +1,6 @@
 package app.organicmaps.editor;
 
 import android.content.Intent;
-import android.net.Uri;
 import android.os.Bundle;
 import android.view.LayoutInflater;
 import android.view.View;
@@ -21,6 +20,7 @@ import app.organicmaps.util.Constants;
 import app.organicmaps.util.DateUtils;
 import app.organicmaps.util.InputUtils;
 import app.organicmaps.util.UiUtils;
+import app.organicmaps.util.Utils;
 import app.organicmaps.util.concurrency.ThreadPool;
 import app.organicmaps.util.concurrency.UiThread;
 import com.google.android.material.dialog.MaterialAlertDialogBuilder;
@@ -51,9 +51,9 @@ public class OsmLoginFragment extends BaseMwmToolbarFragment
     mLoginButton = view.findViewById(R.id.login);
     mLoginButton.setOnClickListener((v) -> login());
     mLostPasswordButton = view.findViewById(R.id.lost_password);
-    mLostPasswordButton.setOnClickListener((v) -> recoverPassword());
+    mLostPasswordButton.setOnClickListener((v) -> Utils.openUrl(requireActivity(), Constants.Url.OSM_RECOVER_PASSWORD));
     Button registerButton = view.findViewById(R.id.register);
-    registerButton.setOnClickListener((v) -> register());
+    registerButton.setOnClickListener((v) -> Utils.openUrl(requireActivity(), Constants.Url.OSM_REGISTER));
     mProgress = view.findViewById(R.id.osm_login_progress);
     final String dataVersion = DateUtils.getShortDateFormatter().format(Framework.getDataVersion());
     ((TextView) view.findViewById(R.id.osm_presentation))
@@ -82,11 +82,6 @@ public class OsmLoginFragment extends BaseMwmToolbarFragment
     mLoginInput.setEnabled(enable);
     mLoginButton.setEnabled(enable);
     mLostPasswordButton.setEnabled(enable);
-  }
-
-  private void recoverPassword()
-  {
-    startActivity(new Intent(Intent.ACTION_VIEW, Uri.parse(Constants.Url.OSM_RECOVER_PASSWORD)));
   }
 
   private void processAuth(@Size(2) String[] auth, String username)
@@ -118,10 +113,5 @@ public class OsmLoginFragment extends BaseMwmToolbarFragment
     if (extras != null && extras.getBoolean("redirectToProfile", false))
       startActivity(new Intent(requireContext(), ProfileActivity.class));
     requireActivity().finish();
-  }
-
-  private void register()
-  {
-    startActivity(new Intent(Intent.ACTION_VIEW, Uri.parse(Constants.Url.OSM_REGISTER)));
   }
 }

--- a/android/app/src/main/java/app/organicmaps/editor/ProfileFragment.java
+++ b/android/app/src/main/java/app/organicmaps/editor/ProfileFragment.java
@@ -1,7 +1,6 @@
 package app.organicmaps.editor;
 
 import android.content.Intent;
-import android.net.Uri;
 import android.os.Bundle;
 import android.view.LayoutInflater;
 import android.view.View;
@@ -15,6 +14,7 @@ import androidx.annotation.Nullable;
 import app.organicmaps.R;
 import app.organicmaps.base.BaseMwmToolbarFragment;
 import app.organicmaps.util.UiUtils;
+import app.organicmaps.util.Utils;
 import app.organicmaps.util.concurrency.ThreadPool;
 import app.organicmaps.util.concurrency.UiThread;
 import com.google.android.material.dialog.MaterialAlertDialogBuilder;
@@ -49,8 +49,8 @@ public class ProfileFragment extends BaseMwmToolbarFragment
     View sentBlock = editsBlock.findViewById(R.id.sent_edits);
     mEditsSent = sentBlock.findViewById(R.id.edits_count);
     mEditsSentProgress = sentBlock.findViewById(R.id.edits_count_progress);
-    view.findViewById(R.id.about_osm).setOnClickListener((v) -> openOsmAboutUrl());
-    view.findViewById(R.id.osm_history).setOnClickListener((v) -> openOsmHistoryUrl());
+    view.findViewById(R.id.about_osm).setOnClickListener((v) -> Utils.openUrl(requireActivity(), getString(R.string.osm_wiki_about_url)));
+    view.findViewById(R.id.osm_history).setOnClickListener((v) -> Utils.openUrl(requireActivity(), OsmOAuth.getHistoryUrl(requireContext())));
   }
 
   private void refreshViews()
@@ -85,22 +85,12 @@ public class ProfileFragment extends BaseMwmToolbarFragment
   {
     new MaterialAlertDialogBuilder(requireContext(), R.style.MwmTheme_AlertDialog)
         .setMessage(R.string.are_you_sure)
-        .setPositiveButton(R.string.ok, (dialog, which) ->
+        .setPositiveButton(R.string.yes, (dialog, which) ->
         {
           OsmOAuth.clearAuthorization(requireContext());
           refreshViews();
         })
         .setNegativeButton(R.string.no, null)
         .show();
-  }
-
-  private void openOsmAboutUrl()
-  {
-    startActivity(new Intent((Intent.ACTION_VIEW), Uri.parse(getString(R.string.osm_wiki_about_url))));
-  }
-
-  private void openOsmHistoryUrl()
-  {
-    startActivity(new Intent((Intent.ACTION_VIEW), Uri.parse(OsmOAuth.getHistoryUrl(requireContext()))));
   }
 }

--- a/android/app/src/main/java/app/organicmaps/help/HelpFragment.java
+++ b/android/app/src/main/java/app/organicmaps/help/HelpFragment.java
@@ -88,25 +88,10 @@ public class HelpFragment extends BaseMwmFragment implements View.OnClickListene
     setupItem(R.id.copyright, false, root);
     View termOfUseView = root.findViewById(R.id.term_of_use_link);
     View privacyPolicyView = root.findViewById(R.id.privacy_policy);
-    termOfUseView.setOnClickListener(v -> onTermOfUseClick());
-    privacyPolicyView.setOnClickListener(v -> onPrivacyPolicyClick());
+    termOfUseView.setOnClickListener(v -> Utils.openUrl(requireActivity(), getResources().getString(R.string.translated_om_site_url) + "terms/"));
+    privacyPolicyView.setOnClickListener(v -> Utils.openUrl(requireActivity(), getResources().getString(R.string.translated_om_site_url) + "privacy/"));
 
     return root;
-  }
-
-  private void openLink(@NonNull String link)
-  {
-    Utils.openUrl(requireActivity(), link);
-  }
-
-  private void onPrivacyPolicyClick()
-  {
-    openLink(getResources().getString(R.string.translated_om_site_url) + "privacy/");
-  }
-
-  private void onTermOfUseClick()
-  {
-    openLink(getResources().getString(R.string.translated_om_site_url) + "terms/");
   }
 
   @Override
@@ -114,35 +99,35 @@ public class HelpFragment extends BaseMwmFragment implements View.OnClickListene
   {
     final int id = v.getId();
     if (id == R.id.web)
-      openLink(getResources().getString(R.string.translated_om_site_url));
+      Utils.openUrl(requireActivity(), getResources().getString(R.string.translated_om_site_url));
     else if (id == R.id.news)
-      openLink(getResources().getString(R.string.translated_om_site_url) + "news/");
+      Utils.openUrl(requireActivity(), getResources().getString(R.string.translated_om_site_url) + "news/");
     else if (id == R.id.email)
       Utils.sendTo(requireContext(), BuildConfig.SUPPORT_MAIL, "Organic Maps");
     else if (id == R.id.github)
-      openLink(Constants.Url.GITHUB);
+      Utils.openUrl(requireActivity(), Constants.Url.GITHUB);
     else if (id == R.id.telegram)
-      openLink(getString(R.string.telegram_url));
+      Utils.openUrl(requireActivity(), getString(R.string.telegram_url));
     else if (id == R.id.instagram)
-      openLink(getString(R.string.instagram_url));
+      Utils.openUrl(requireActivity(), getString(R.string.instagram_url));
     else if (id == R.id.facebook)
       Utils.showFacebookPage(requireActivity());
     else if (id == R.id.twitter)
-      openLink(Constants.Url.TWITTER);
+      Utils.openUrl(requireActivity(), Constants.Url.TWITTER);
     else if (id == R.id.matrix)
-      openLink(Constants.Url.MATRIX);
+      Utils.openUrl(requireActivity(), Constants.Url.MATRIX);
     else if (id == R.id.mastodon)
-      openLink(Constants.Url.MASTODON);
+      Utils.openUrl(requireActivity(), Constants.Url.MASTODON);
     else if (id == R.id.openstreetmap)
-      openLink(getString(R.string.osm_wiki_about_url));
+      Utils.openUrl(requireActivity(), getString(R.string.osm_wiki_about_url));
     else if (id == R.id.faq)
       ((HelpActivity) requireActivity()).stackFragment(FaqFragment.class, getString(R.string.faq), null);
     else if (id == R.id.report)
       Utils.sendBugReport(requireActivity(), "");
     else if (id == R.id.support_us)
-      openLink(getResources().getString(R.string.translated_om_site_url) + "support-us/");
+      Utils.openUrl(requireActivity(), getResources().getString(R.string.translated_om_site_url) + "support-us/");
     else if (id == R.id.donate)
-      openLink(mDonateUrl);
+      Utils.openUrl(requireActivity(), mDonateUrl);
     else if (id == R.id.rate)
       Utils.openAppInMarket(requireActivity(), BuildConfig.REVIEW_URL);
     else if (id == R.id.copyright)


### PR DESCRIPTION
This PR:
- Update string used in pop-up to disconnect OSM account (replace OK by yes because we ask a question)
- Remove methods to start web Intent and use directly Utils.openUrl (That reduces the number of code lines and better management of catch because some methods use directly start activity without try catch)

Tested in Pixel 6 - Android 14