### PR TITLE
[android] Remove textAllCaps property in button styles

### DIFF
--- a/android/app/src/main/res/layout/accept_decline_button_container.xml
+++ b/android/app/src/main/res/layout/accept_decline_button_container.xml
@@ -25,7 +25,6 @@
         android:fontFamily="@string/robotoMedium"
         android:gravity="center"
         android:letterSpacing="0.01"
-        android:textAllCaps="true"
         android:textAppearance="?android:attr/textAppearanceMedium"
         android:textSize="@dimen/text_size_body_3"
         android:textStyle="normal"

--- a/android/app/src/main/res/layout/fragment_editor.xml
+++ b/android/app/src/main/res/layout/fragment_editor.xml
@@ -196,7 +196,6 @@
               android:background="?clickableBackground"
               android:gravity="center_vertical"
               android:text="@string/edit"
-              android:textAllCaps="true"
               android:layout_width="wrap_content"
               android:layout_height="match_parent"
               android:layout_alignParentEnd="true"

--- a/android/app/src/main/res/layout/fragment_phone.xml
+++ b/android/app/src/main/res/layout/fragment_phone.xml
@@ -31,7 +31,6 @@
         android:gravity="center_vertical"
         android:padding="@dimen/margin_base"
         android:text="@string/editor_add_phone"
-        android:textAllCaps="true"
         android:textAppearance="@style/MwmTextAppearance.Body3"
         android:textColor="?colorAccent"/>
 

--- a/android/app/src/main/res/layout/fragment_timetable.xml
+++ b/android/app/src/main/res/layout/fragment_timetable.xml
@@ -31,7 +31,6 @@
     android:gravity="center_vertical"
     android:padding="@dimen/margin_base"
     android:text="@string/editor_time_advanced"
-    android:textAllCaps="true"
     android:textAppearance="@style/MwmTextAppearance.Body3"
     android:textColor="?colorAccent" />
 

--- a/android/app/src/main/res/layout/item_bookmark_create_group.xml
+++ b/android/app/src/main/res/layout/item_bookmark_create_group.xml
@@ -24,7 +24,6 @@
     android:layout_marginStart="@dimen/margin_half"
     android:fontFamily="@string/robotoMedium"
     android:text="@string/bookmarks_create_new_group"
-    android:textAllCaps="true"
-    android:textAppearance="@style/MwmTextAppearance.Body3"
+    android:textAppearance="@style/MwmTextAppearance.Body2"
     android:textColor="?colorAccent"/>
 </LinearLayout>

--- a/android/app/src/main/res/layout/item_bookmark_group_list_header.xml
+++ b/android/app/src/main/res/layout/item_bookmark_group_list_header.xml
@@ -20,7 +20,6 @@
     tools:text="@string/categories" />
   <TextView
     android:id="@+id/button"
-    style="?fontSubtitle2"
     android:layout_width="wrap_content"
     android:layout_height="wrap_content"
     android:layout_alignParentEnd="true"
@@ -28,6 +27,6 @@
     android:background="?selectableItemBackground"
     android:paddingTop="@dimen/margin_half_plus"
     android:text="@string/bookmark_lists_hide_all"
-    android:textAllCaps="true"
+    android:textAppearance="@style/MwmTextAppearance.Body2"
     android:textColor="?colorAccent" />
 </RelativeLayout>

--- a/android/app/src/main/res/layout/item_bookmark_import.xml
+++ b/android/app/src/main/res/layout/item_bookmark_import.xml
@@ -24,7 +24,6 @@
     android:layout_marginStart="@dimen/margin_half"
     android:fontFamily="@string/robotoMedium"
     android:text="@string/bookmarks_import"
-    android:textAllCaps="true"
-    android:textAppearance="@style/MwmTextAppearance.Body3"
+    android:textAppearance="@style/MwmTextAppearance.Body2"
     android:textColor="?colorAccent"/>
 </LinearLayout>

--- a/android/app/src/main/res/layout/item_opening_hours.xml
+++ b/android/app/src/main/res/layout/item_opening_hours.xml
@@ -67,7 +67,6 @@
     android:gravity="center_vertical"
     android:minHeight="@dimen/height_block_base"
     android:text="@string/edit_opening_hours"
-    android:textAllCaps="true"
     android:textAppearance="@style/MwmTextAppearance.Body1"
     android:textColor="?colorAccent"/>
 

--- a/android/app/src/main/res/layout/item_timetable.xml
+++ b/android/app/src/main/res/layout/item_timetable.xml
@@ -268,7 +268,6 @@
         android:background="?clickableBackground"
         android:padding="@dimen/margin_half_plus"
         android:text="@string/editor_time_add_closed"
-        android:textAllCaps="true"
         android:textAppearance="@style/MwmTextAppearance.Body1"
         android:textColor="?colorAccent"/>
 
@@ -281,7 +280,6 @@
       android:background="?clickableBackground"
       android:padding="@dimen/margin_half_plus"
       android:text="@string/editor_time_delete"
-      android:textAllCaps="true"
       android:textAppearance="@style/MwmTextAppearance.Body1"
       android:textColor="@color/base_red"/>
 

--- a/android/app/src/main/res/values/styles-place_page.xml
+++ b/android/app/src/main/res/values/styles-place_page.xml
@@ -54,7 +54,6 @@
   </style>
 
   <style name="PlacePageMetadataText.Button">
-    <item name="android:textAllCaps">true</item>
     <item name="android:gravity">center_vertical</item>
     <item name="android:textAppearance">@style/MwmTextAppearance.PlacePage.Accent</item>
   </style>

--- a/android/app/src/main/res/values/styles-text.xml
+++ b/android/app/src/main/res/values/styles-text.xml
@@ -96,7 +96,7 @@
   <style name="MwmTextAppearance.Button">
     <item name="android:textSize">@dimen/text_size_button</item>
     <item name="android:textColor">?colorAccent</item>
-    <item name="android:textAllCaps">true</item>
+    <item name="android:textAllCaps">false</item>
   </style>
 
   <style name="MwmTextAppearance.Button.Red">
@@ -124,7 +124,6 @@
 
   <style name="MwmTextAppearance.Toolbar.Title.Button">
     <item name="android:textSize">@dimen/text_size_body_3</item>
-    <item name="android:textAllCaps">true</item>
   </style>
 
   <style name="MwmTextAppearance.NavMenu">

--- a/android/app/src/main/res/values/styles.xml
+++ b/android/app/src/main/res/values/styles.xml
@@ -47,7 +47,7 @@
     <item name="android:background">?buttonBackground</item>
     <item name="android:stateListAnimator">@null</item>
     <item name="android:fontFamily">@string/robotoMedium</item>
-    <item name="android:textAllCaps">true</item>
+    <item name="android:textAllCaps">false</item>
     <item name="android:letterSpacing">0.04</item>
   </style>
 
@@ -64,7 +64,6 @@
     <item name="android:background">?clickableBackground</item>
     <item name="android:textSize">@dimen/text_size_button</item>
     <item name="android:textColor">?buttonDialogTextColor</item>
-    <item name="android:textAllCaps">true</item>
     <item name="android:fontFamily">@string/robotoMedium</item>
     <item name="android:lines">1</item>
     <item name="android:gravity">center_vertical|end</item>
@@ -93,7 +92,6 @@
     <item name="android:textSize">@dimen/text_size_body_3</item>
     <item name="android:paddingStart">@dimen/margin_base</item>
     <item name="android:paddingEnd">@dimen/margin_base</item>
-    <item name="textAllCaps">true</item>
     <item name="android:gravity">center</item>
   </style>
 
@@ -272,7 +270,6 @@
   <style name="MwmWidget.Tab">
     <item name="android:layout_width">wrap_content</item>
     <item name="android:layout_height">wrap_content</item>
-    <item name="android:textAllCaps">true</item>
     <item name="android:textAppearance">@style/MwmTextAppearance.Body3</item>
     <item name="android:gravity">center</item>
   </style>

--- a/android/app/src/main/res/values/themes.xml
+++ b/android/app/src/main/res/values/themes.xml
@@ -58,6 +58,7 @@
     <item name="android:textColorPrimary">?textDialogTheme</item>
     <item name="android:textSize">@dimen/text_size_body_1</item>
     <item name="android:windowTitleStyle">@style/MwmTheme.DialogTitleStyle.Light</item>
+    <item name="textAllCaps">false</item>
   </style>
 
   <style name="MwmTheme.DialogTitleBase">
@@ -78,6 +79,7 @@
     <item name="android:textSize">@dimen/text_size_body_1</item>
     <!-- Used for the title in the dialog -->
     <item name="android:windowTitleStyle">@style/MwmTheme.DialogTitleStyle.Night</item>
+    <item name="textAllCaps">false</item>
   </style>
 
   <style name="MwmTheme.DialogTitleStyle.Night" parent="MwmTheme.DialogTitleBase">


### PR DESCRIPTION
This PR removes `textAllCaps` property in the majority of cases in buttons.
Looks better without caps on texts and are less bigger.

I have kept textAllCaps in place page button and button to enable routing options (because without caps text is too small).

I think this PR needs feedback from users (to see if text is enough big without caps), maybe integrate these changes in the next beta?

|Before|After|
|-|-|
|<img src="https://github.com/organicmaps/organicmaps/assets/87148630/c4546e33-9628-4f85-9695-c309a9a5b281" height=300 />|<img src="https://github.com/organicmaps/organicmaps/assets/87148630/1ac0323e-36a4-49ff-921e-7f3dd4aa9893" height=300 />|
|<img src="https://github.com/organicmaps/organicmaps/assets/87148630/c1dc126d-f505-4ece-a5e4-ed283b111195" height=300 />|<img src="https://github.com/organicmaps/organicmaps/assets/87148630/620d4b30-0c7b-4a19-9915-e0d2c738f0ec" height=300 />|
|<img src="https://github.com/organicmaps/organicmaps/assets/87148630/77f2a9c2-c222-4448-a9d3-63eb65da8d7b" height=300 />|<img src="https://github.com/organicmaps/organicmaps/assets/87148630/9d4af32e-86c3-4060-ad36-8b2f82a0ccf7" height=300 />|
|<img src="https://github.com/organicmaps/organicmaps/assets/87148630/d1c316fb-37b5-480a-961a-1e59080aebb5" height=300 />|<img src="https://github.com/organicmaps/organicmaps/assets/87148630/18634607-2f00-4976-8e2f-eacc0067942c" height=300 />

Todo:
- [ ] Update translations (some translations don't have the first letter in caps)