### PR TITLE
[android] Don't show snackbar on Android 13 after copy

### DIFF
--- a/android/app/src/main/java/app/organicmaps/widget/placepage/PlacePageUtils.java
+++ b/android/app/src/main/java/app/organicmaps/widget/placepage/PlacePageUtils.java
@@ -1,6 +1,7 @@
 package app.organicmaps.widget.placepage;
 
 import android.content.Context;
+import android.os.Build;
 import android.view.Menu;
 import android.view.View;
 import android.widget.PopupMenu;
@@ -78,8 +79,11 @@ public class PlacePageUtils
   public static void copyToClipboard(Context context, View frame, String text)
   {
     Utils.copyTextToClipboard(context, text);
-    Utils.showSnackbarAbove(frame.getRootView().findViewById(R.id.pp_buttons_layout), frame,
-                            context.getString(R.string.copied_to_clipboard, text));
+    if (Build.VERSION.SDK_INT < Build.VERSION_CODES.TIRAMISU)
+    {
+      Utils.showSnackbarAbove(frame.getRootView().findViewById(R.id.pp_buttons_layout), frame,
+                              context.getString(R.string.copied_to_clipboard, text));
+    }
   }
 
   public static void showCopyPopup(Context context, View popupAnchor, List<String> items)

--- a/android/app/src/main/java/app/organicmaps/widget/placepage/sections/PlacePageBookmarkFragment.java
+++ b/android/app/src/main/java/app/organicmaps/widget/placepage/sections/PlacePageBookmarkFragment.java
@@ -1,6 +1,7 @@
 package app.organicmaps.widget.placepage.sections;
 
 import android.content.Context;
+import android.os.Build;
 import android.os.Bundle;
 import android.text.TextUtils;
 import android.text.util.Linkify;
@@ -136,8 +137,11 @@ public class PlacePageBookmarkFragment extends Fragment implements View.OnClickL
 
     final Context ctx = requireContext();
     Utils.copyTextToClipboard(ctx, notes);
-    Utils.showSnackbarAbove(mFrame.getRootView().findViewById(R.id.pp_buttons_layout), mFrame,
-                            ctx.getString(R.string.copied_to_clipboard, notes));
+    if (Build.VERSION.SDK_INT < Build.VERSION_CODES.TIRAMISU)
+    {
+      Utils.showSnackbarAbove(mFrame.getRootView().findViewById(R.id.pp_buttons_layout), mFrame,
+                              ctx.getString(R.string.copied_to_clipboard, notes));
+    }
     return true;
   }
 

--- a/android/app/src/main/java/app/organicmaps/widget/placepage/sections/PlacePhoneAdapter.java
+++ b/android/app/src/main/java/app/organicmaps/widget/placepage/sections/PlacePhoneAdapter.java
@@ -1,6 +1,7 @@
 package app.organicmaps.widget.placepage.sections;
 
 import android.content.Context;
+import android.os.Build;
 import android.text.TextUtils;
 import android.view.LayoutInflater;
 import android.view.View;
@@ -87,8 +88,11 @@ public class PlacePhoneAdapter extends RecyclerView.Adapter<PlacePhoneAdapter.Vi
       final String phoneNumber = mPhone.getText().toString();
       final Context ctx = view.getContext();
       Utils.copyTextToClipboard(ctx, phoneNumber);
-      Utils.showSnackbarAbove(view.getRootView().findViewById(R.id.pp_buttons_layout), view,
-                              ctx.getString(R.string.copied_to_clipboard, phoneNumber));
+      if (Build.VERSION.SDK_INT < Build.VERSION_CODES.TIRAMISU)
+      {
+        Utils.showSnackbarAbove(view.getRootView().findViewById(R.id.pp_buttons_layout), view,
+                                ctx.getString(R.string.copied_to_clipboard, phoneNumber));
+      }
       return true;
     }
   }


### PR DESCRIPTION
Android 13 introduces a pop-up to confirm, that text was copied to the clipboard -> more information [here](https://developer.android.com/develop/ui/views/touch-and-input/copy-paste#Feedback)
This PR generates snackbar only on devices with Android 12 and lower