### PR TITLE
Disabled zoom after route is built

### DIFF
--- a/map/routing_manager.cpp
+++ b/map/routing_manager.cpp
@@ -412,14 +412,14 @@ void RoutingManager::OnBuildRouteReady(Route const & route, RouterResultCode cod
 
   // Validate route (in case of bicycle routing it can be invalid).
   ASSERT(route.IsValid(), ());
-  if (route.IsValid() && m_currentRouterType != routing::RouterType::Ruler)
-  {
-    m2::RectD routeRect = route.GetPoly().GetLimitRect();
-    routeRect.Scale(kRouteScaleMultiplier);
-    m_drapeEngine.SafeCall(&df::DrapeEngine::SetModelViewRect, routeRect,
-                           true /* applyRotation */, -1 /* zoom */, true /* isAnim */,
-                           true /* useVisibleViewport */);
-  }
+  //if (route.IsValid() && m_currentRouterType != routing::RouterType::Ruler)
+  //{
+    //m2::RectD routeRect = route.GetPoly().GetLimitRect();
+    //routeRect.Scale(kRouteScaleMultiplier); // TODO: Disable zoom
+    //m_drapeEngine.SafeCall(&df::DrapeEngine::SetModelViewRect, routeRect,
+    //                       true /* applyRotation */, -1 /* zoom */, true /* isAnim */,
+    //                       true /* useVisibleViewport */);
+  //}
 
   CallRouteBuilded(hasWarnings ? RouterResultCode::HasWarnings : code, storage::CountriesSet());
 }


### PR DESCRIPTION
As @biodranik asked in #6626, here's OM with disabled zoom on route built success.

Zoom is disabled when new route is built and when stop is added to existing route.