### PR TITLE
[android] Enable Address Sanitizer (ASAN) for debug and beta

### DIFF
--- a/android/app/src/beta/AndroidManifest.xml
+++ b/android/app/src/beta/AndroidManifest.xml
@@ -1,0 +1,3 @@
+<manifest xmlns:android="http://schemas.android.com/apk/res/android">
+  <application android:gwpAsanMode="always" />
+</manifest>

--- a/android/app/src/debug/AndroidManifest.xml
+++ b/android/app/src/debug/AndroidManifest.xml
@@ -1,0 +1,3 @@
+<manifest xmlns:android="http://schemas.android.com/apk/res/android">
+  <application android:gwpAsanMode="always" />
+</manifest>


### PR DESCRIPTION
GWP-ASan is a native memory allocator feature that helps find use-after-free and heap-buffer-overflow bugs. Its informal name is a recursive acronym, "GWP-ASan Will Provide Allocation SANity". Unlike HWASan or Malloc Debug, GWP-ASan does not require source or recompilation (that is, works with prebuilts), and works on both 32- and 64-bit processes (although 32-bit crashes have less debugging information).

Closes #6633