### PR TITLE
[coding] UrlDecode the plus sign '+' as a space

### DIFF
--- a/coding/coding_tests/url_tests.cpp
+++ b/coding/coding_tests/url_tests.cpp
@@ -97,6 +97,7 @@ UNIT_TEST(Url_Decode)
   TEST_EQUAL(UrlDecode(enc2), orig2, ());
   TEST_EQUAL(UrlDecode(enc3), orig3, ());
   TEST_EQUAL(UrlDecode(enc4), orig4, ());
+  TEST_EQUAL(UrlDecode("123+Main+St,+Seattle,+WA+98101"), "123 Main St, Seattle, WA 98101", ());
 }
 
 UNIT_TEST(Url_Invalid)

--- a/coding/url.cpp
+++ b/coding/url.cpp
@@ -174,6 +174,10 @@ string UrlDecode(string_view encodedUrl)
       result += FromHex(encodedUrl.substr(i + 1, 2));
       i += 2;
     }
+    else if (encodedUrl[i] == '+')
+    {
+      result += ' ';
+    }
     else
     {
       result += encodedUrl[i];

--- a/map/map_tests/mwm_url_tests.cpp
+++ b/map/map_tests/mwm_url_tests.cpp
@@ -355,6 +355,14 @@ UNIT_TEST(SearchApiGeoScheme)
     TEST_ALMOST_EQUAL_ABS(latlon.m_lat, 35.3381607, kEps, ());
     TEST_ALMOST_EQUAL_ABS(latlon.m_lon, 33.3290564, kEps, ());
   }
+  {
+    ParsedMapApi api("geo:0,0?q=123+Main+St,+Seattle,+WA+98101");
+    TEST_EQUAL(api.GetRequestType(), UrlType::Search, ());
+    auto const & request = api.GetSearchRequest();
+    ms::LatLon latlon = api.GetCenterLatLon();
+    TEST(!latlon.IsValid(), ());
+    TEST_EQUAL(request.m_query, "123 Main St, Seattle, WA 98101", ());
+  }
 }
 
 UNIT_TEST(CrosshairApi)


### PR DESCRIPTION
`123+Main+St,+Seattle,+WA+98101` is equvivalent to `123%20Main%20St,%20Seattle,%20WA+98101` and should be decoded as `123 Main St, Seattle, WA 98101`.