### PR TITLE
[map] Fix the viewport when opening a geo: link

### DIFF
--- a/map/framework.cpp
+++ b/map/framework.cpp
@@ -959,11 +959,11 @@ m2::PointD const & Framework::GetViewportCenter() const
   return m_currentModelView.GetOrg();
 }
 
-void Framework::SetViewportCenter(m2::PointD const & pt, int zoomLevel /* = -1 */,
-                                  bool isAnim /* = true */)
+void Framework::SetViewportCenter(m2::PointD const & pt, int zoomLevel /* = -1 */, bool isAnim /* = true */,
+                                  bool trackVisibleViewport /* = false */)
 {
   if (m_drapeEngine != nullptr)
-    m_drapeEngine->SetModelViewCenter(pt, zoomLevel, isAnim, false /* trackVisibleViewport */);
+    m_drapeEngine->SetModelViewCenter(pt, zoomLevel, isAnim, trackVisibleViewport);
 }
 
 m2::RectD Framework::GetCurrentViewport() const

--- a/map/framework.hpp
+++ b/map/framework.hpp
@@ -497,7 +497,8 @@ public:
   m2::PointD GetVisiblePixelCenter() const;
 
   m2::PointD const & GetViewportCenter() const;
-  void SetViewportCenter(m2::PointD const & pt, int zoomLevel = -1, bool isAnim = true);
+  void SetViewportCenter(m2::PointD const & pt, int zoomLevel = -1, bool isAnim = true,
+                         bool trackVisibleViewport = false);
 
   m2::RectD GetCurrentViewport() const;
   void SetVisibleViewport(m2::RectD const & rect);

--- a/map/mwm_url.cpp
+++ b/map/mwm_url.cpp
@@ -461,7 +461,9 @@ void ParsedMapApi::ExecuteMapApiRequest(Framework & fm)
 
   // ShowRect function interferes with ActivateMapSelection and we have strange behaviour as a result.
   // Use more obvious SetModelViewCenter here.
-  fm.SetViewportCenter(center, zoomLevel, true, true);
+  /// @todo Funny, but animation is still present, but now centering works fine.
+  /// Looks like there is one more set viewport call somewhere.
+  fm.SetViewportCenter(center, zoomLevel, false /* isAnim */, true /* trackVisibleViewport */);
 
   // Don't show the place page in case of multiple points.
   if (m_mapPoints.size() > 1)

--- a/map/mwm_url.cpp
+++ b/map/mwm_url.cpp
@@ -461,7 +461,7 @@ void ParsedMapApi::ExecuteMapApiRequest(Framework & fm)
 
   // ShowRect function interferes with ActivateMapSelection and we have strange behaviour as a result.
   // Use more obvious SetModelViewCenter here.
-  fm.SetViewportCenter(center, zoomLevel, true);
+  fm.SetViewportCenter(center, zoomLevel, true, true);
 
   // Don't show the place page in case of multiple points.
   if (m_mapPoints.size() > 1)


### PR DESCRIPTION
Re-add lost trackVisibleViewport=true from the original implementation.

## 

Original code:

https://github.com/organicmaps/organicmaps/blob/3fc5d227ff7131a993c8fafc09b8fe3249d9a6ab/map/framework.cpp#L1811-L1812