### PR TITLE
[android] Fix NPE in AlertDialog.setOnShowListener() lambda

### DIFF
--- a/android/app/src/main/java/app/organicmaps/dialog/EditTextDialogFragment.java
+++ b/android/app/src/main/java/app/organicmaps/dialog/EditTextDialogFragment.java
@@ -128,7 +128,10 @@ public class EditTextDialogFragment extends BaseMwmDialogFragment
     // Wait till alert is shown to get mPositiveButton.
     editTextDialog.setOnShowListener((dialog) -> {
       mPositiveButton = editTextDialog.getButton(DialogInterface.BUTTON_POSITIVE);
-      this.validateInput(requireActivity(), mInitialText);
+      final FragmentActivity activity = getActivity();
+      if (activity == null)
+        return;
+      this.validateInput(activity, mInitialText);
     });
 
     // Setup validation on input edit.
@@ -137,7 +140,10 @@ public class EditTextDialogFragment extends BaseMwmDialogFragment
       @Override
       public void onTextChanged(CharSequence s, int start, int before, int count)
       {
-        EditTextDialogFragment.this.validateInput(requireActivity(), s.toString());
+        final FragmentActivity activity = getActivity();
+        if (activity == null)
+          return;
+        EditTextDialogFragment.this.validateInput(activity, s.toString());
       }
     });
 


### PR DESCRIPTION
Touching at the same time Add street and back button generates two events in the event loop - one to show EditTextDialogFragment and another is to close the activity. `editTextDialog.setOnShowListener((dialog) -> {` callback is called when activity has gone already.

##

I can't repro it reliably, but this fix should work.