### PR TITLE
[android] Respect the 'Keep the screen on' setting regardless of the current location mode + fixes

### DIFF
--- a/android/app/src/main/java/app/organicmaps/MwmActivity.java
+++ b/android/app/src/main/java/app/organicmaps/MwmActivity.java
@@ -1082,6 +1082,7 @@ public class MwmActivity extends BaseMwmFragmentActivity
     LocationState.nativeSetListener(this);
     LocationHelper.from(this).addListener(this);
     mSearchController.attach(this);
+    Utils.keepScreenOn(Config.isKeepScreenOnEnabled() || RoutingController.get().isNavigating(), getWindow());
   }
 
   @Override
@@ -1696,11 +1697,6 @@ public class MwmActivity extends BaseMwmFragmentActivity
     RoutingController controller = RoutingController.get();
     if (controller.isPlanning())
       showAddStartOrFinishFrame(controller, true);
-
-    if (newMode == FOLLOW || newMode == FOLLOW_AND_ROTATE)
-      Utils.keepScreenOn(Config.isKeepScreenOnEnabled() || RoutingController.get().isNavigating(), getWindow());
-    else
-      Utils.keepScreenOn(RoutingController.get().isNavigating(), getWindow());
 
     final LocationHelper locationHelper = LocationHelper.from(this);
 

--- a/android/app/src/main/java/app/organicmaps/settings/SettingsPrefsFragment.java
+++ b/android/app/src/main/java/app/organicmaps/settings/SettingsPrefsFragment.java
@@ -742,7 +742,7 @@ public class SettingsPrefsFragment extends BaseXmlSettingsFragment
           if (isKeepScreenOnEnabled != newVal)
           {
             Config.setKeepScreenOnEnabled(newVal);
-            Utils.keepScreenOn(newVal, requireActivity().getWindow());
+            // No need to call Utils.keepScreenOn() here, as relevant activities do it when starting / stopping.
           }
           return true;
         });

--- a/android/app/src/main/java/app/organicmaps/util/Utils.java
+++ b/android/app/src/main/java/app/organicmaps/util/Utils.java
@@ -76,7 +76,7 @@ public class Utils
    */
   public static void keepScreenOn(boolean enable, Window w)
   {
-    Logger.i(TAG, "enabled = " + enable + " window = " + w);
+    Logger.i(TAG, "KeepScreenOn = " + enable + " window = " + w);
     if (enable)
       w.addFlags(android.view.WindowManager.LayoutParams.FLAG_KEEP_SCREEN_ON);
     else
@@ -93,7 +93,7 @@ public class Utils
 
   public static void showOnLockScreen(boolean enable, Activity activity)
   {
-    Logger.i(TAG, "enabled = " + enable + " window = " + activity.getWindow());
+    Logger.i(TAG, "showOnLockScreen = " + enable + " window = " + activity.getWindow());
     if (Build.VERSION.SDK_INT < Build.VERSION_CODES.O_MR1)
       showOnLockScreenOld(enable, activity);
     else


### PR DESCRIPTION
Closes #6669

Also fixes some bugs introduced in #6053 
1. have the setting ON, location current and map centered  - the screen will stay on
  - switch to some other app
  - switch back to OM, the screen will go to sleep after some time (in case there was no location mode change)
2. start navigation - the screen will stay on
  - go to settings, switch the setting to OFF
  - go back to the navigation, the screen will go to sleep after some time (in case there was no location mode change)