### PR TITLE
[linux] Indicate compatibility with mobile form factor

### DIFF
--- a/qt/res/OrganicMaps.desktop
+++ b/qt/res/OrganicMaps.desktop
@@ -9,3 +9,4 @@ TryExec=OMaps
 Exec=OMaps
 Categories=Maps;Education;Geography;Geoscience;Qt;
 Keywords=Map;Maps;Offline Maps;OMaps;Organic Maps;OrganicMaps;OSM;OpenStreetMap;
+X-KDE-FormFactor=desktop;tablet;handset;


### PR DESCRIPTION
So on mobile Linux UIs like Phosh and Plasma,
the Organic Maps icon shows up immediately,
without the need for the user to tap on "Show All Apps".