### PR TITLE
[android] Enable Java 17 language features

### DIFF
--- a/android/app/build.gradle
+++ b/android/app/build.gradle
@@ -160,6 +160,12 @@ def osName = System.properties['os.name'].toLowerCase()
 project.ext.appId = 'app.organicmaps'
 project.ext.appName = 'Organic Maps'
 
+java {
+  toolchain {
+    languageVersion.set(JavaLanguageVersion.of(17))
+  }
+}
+
 android {
   namespace 'app.organicmaps'
 
@@ -411,8 +417,8 @@ android {
   }
 
   compileOptions {
-    sourceCompatibility JavaVersion.VERSION_11
-    targetCompatibility JavaVersion.VERSION_11
+    sourceCompatibility JavaVersion.VERSION_17
+    targetCompatibility JavaVersion.VERSION_17
   }
   packagingOptions.jniLibs {
     excludes += [


### PR DESCRIPTION
Almost all the new Java 12-17 **language** features can be used now:

- Text Blocks
   https://docs.oracle.com/en/java/javase/15/text-blocks/index.html

- Pattern Matching for switch Expressions and Statements
  https://docs.oracle.com/en/java/javase/17/language/pattern-matching-switch-expressions-and-statements.html

- Pattern Matching for instanceof
  https://docs.oracle.com/en/java/javase/16/language/pattern-matching-instanceof-operator.html

- Sealed Classes
   https://docs.oracle.com/en/java/javase/17/language/sealed-classes-and-interfaces.html

- Record Classes
   https://docs.oracle.com/en/java/javase/16/language/records.html
   This feature requires `java.lang.Record` class which is not available on old devices, but R8/D8 compiler in Android does so-called 'desugaring'. https://android-developers.googleblog.com/2023/06/records-in-android-studio-flamingo.html

More details on https://docs.oracle.com/en/java/javase/17/language/java-language-changes.html

Please note that Java 17 support doesn't extend to the new system classes and APIs as they may not be available on old devices. The build toolchain validates APIs based on the value minSdk setting, which is still API=21. Certain APIs are available even on the old devices via R8/D8 'desugaring'. See https://developer.android.com/build/jdks#compileSdk for details.