### PR TITLE
[ge0] Fix compilation on gcc 11 when unity build is off

### DIFF
--- a/ge0/parser.hpp
+++ b/ge0/parser.hpp
@@ -1,5 +1,6 @@
 #pragma once
 
+#include <array>
 #include <cstddef>
 #include <cstdint>
 #include <string>


### PR DESCRIPTION
Fixes the following compiler error & note:

```
parser.hpp:10:13: error: 'array' in namespace 'std' does not name a template type
parser.hpp:6:1: note: 'std::array' is defined in header '<array>'; did you forget to '#include <array>'?
```