### PR TITLE
[ios] Fix background color for search cells selected state

### DIFF
--- a/iphone/Maps/Core/Theme/GlobalStyleSheet.swift
+++ b/iphone/Maps/Core/Theme/GlobalStyleSheet.swift
@@ -88,6 +88,7 @@ class GlobalStyleSheet: IStyleSheet {
 
     theme.add(styleName: "Background") { (s) -> (Void) in
       s.backgroundColor = colors.white
+      s.backgroundColorSelected = colors.pressBackground
     }
 
     theme.add(styleName: "PressBackground") { (s) -> (Void) in


### PR DESCRIPTION
Closes https://github.com/organicmaps/organicmaps/issues/6703

This PR implements a background color for the `"Backgroung" styleName` from the custom style managing system.
This change will affect all elements that have selected state and the `"Backgroung" styleName`.

Another approach is to create a new style for the current cell class, but it causes different selected styles for different cells and affects the consistence of an app UI.

<img width="196" alt="image" src="https://github.com/organicmaps/organicmaps/assets/79797627/96a5b9ae-b959-468f-8129-5ec8c7f8f3de">
<img width="235" alt="image" src="https://github.com/organicmaps/organicmaps/assets/79797627/59b6204d-9d9e-44cb-a90b-56e863119d60">
