### PR TITLE
[ios] Fix "View on map" button visibility on search screen

### DIFF
--- a/iphone/Maps/Core/Search/MWMSearch.mm
+++ b/iphone/Maps/Core/Search/MWMSearch.mm
@@ -267,7 +267,7 @@ using Observers = NSHashTable<Observer>;
 - (void)setSearchCount:(NSInteger)searchCount {
   NSAssert((searchCount >= 0) && ((_searchCount == searchCount - 1) || (_searchCount == searchCount + 1)),
            @"Invalid search count update");
-  if (_searchCount == 0)
+  if (searchCount > 0)
     [self onSearchStarted];
   else if (searchCount == 0)
     [self onSearchCompleted];

--- a/iphone/Maps/UI/Search/MWMSearchView.xib
+++ b/iphone/Maps/UI/Search/MWMSearchView.xib
@@ -199,7 +199,7 @@
             <constraints>
                 <constraint firstAttribute="trailing" secondItem="2gF-Kc-0a7" secondAttribute="trailing" id="Fdx-hX-coi"/>
                 <constraint firstItem="2gF-Kc-0a7" firstAttribute="top" secondItem="d2A-Id-T62" secondAttribute="top" id="Y62-Rf-LAh"/>
-                <constraint firstAttribute="height" constant="36" id="eLk-al-10m"/>
+                <constraint firstAttribute="height" constant="40" id="eLk-al-10m"/>
                 <constraint firstItem="2gF-Kc-0a7" firstAttribute="leading" secondItem="d2A-Id-T62" secondAttribute="leading" id="itE-d4-hzw"/>
                 <constraint firstAttribute="bottom" secondItem="2gF-Kc-0a7" secondAttribute="bottom" id="s4H-Jq-xk9"/>
             </constraints>


### PR DESCRIPTION
Closes https://github.com/organicmaps/organicmaps/issues/6618

### Issue
When the user types in the search textfield the searching process starts on every new char, but ends a few times later.
But the button should be visible due the whole searching process (except not found or empty field).
This PR fixes that problem.

![Simulator Screen Recording - iPhone 14 Pro - 2023-11-28 at 00 41 34](https://github.com/organicmaps/organicmaps/assets/79797627/1745696e-b8c0-4314-be6e-d1fcad42afdb)


Bug was in this method in MWMSearch:
```swift
- (void)setSearchCount:(NSInteger)searchCount {
  NSAssert((searchCount >= 0) && ((_searchCount == searchCount - 1) || (_searchCount == searchCount + 1)),
           @"Invalid search count update");
  if (_searchCount == 0) // <--- CAUSE BUG
    [self onSearchStarted];
  else if (searchCount == 0)
    [self onSearchCompleted];
  _searchCount = searchCount;
}
```
`_searchCount` stores previous search count and can be greater or equal than 0 (because searching continues)
When user deletes all text from the textfield (`searchCount == 0` and the button disappears) and starts typing again (`searchCount` will be >0), `_searchCount` still != 0 and the button will not appear. 
So as a result: the search is in progress, button is hidden.

### Solution
Fix condition check to 
```swift
  if (searchCount > 0) // <--- will always update observers when the searching process is not finished
    [self onSearchStarted];
```
![Simulator Screen Recording - iPhone 14 Pro - 2023-11-28 at 13 01 25](https://github.com/organicmaps/organicmaps/assets/79797627/3ab64e0b-c5a0-4a3a-94e9-0e187863583b)
![Simulator Screen Recording - iPhone 14 Pro - 2023-11-28 at 13 01 38](https://github.com/organicmaps/organicmaps/assets/79797627/9865b95f-33be-49cc-be28-fdae699438b8)


Additional small fix:
The `View on map` button corner radius is 20 and not suitable for height which is 36.
The height was changed to 40 to increase visibility (but it is also OK to change the radius to 18).

Before:
<img width="76" alt="image" src="https://github.com/organicmaps/organicmaps/assets/79797627/f584371e-7521-4c37-b79b-2aec178a416e">

After:
<img width="57" alt="image" src="https://github.com/organicmaps/organicmaps/assets/79797627/590b9468-782f-4457-a8dd-68387c460452">

