### PR TITLE
[ios] Fix the layout of the toast message

### DIFF
--- a/iphone/Maps/Classes/CustomAlert/Toast/Toast.swift
+++ b/iphone/Maps/Classes/CustomAlert/Toast/Toast.swift
@@ -58,9 +58,9 @@ final class Toast: NSObject {
     
     let topConstraint: NSLayoutConstraint
     if alignment == .bottom {
-      topConstraint = blurView.bottomAnchor.constraint(equalTo: view.bottomAnchor, constant: -50)
+      topConstraint = blurView.bottomAnchor.constraint(equalTo: view.safeAreaLayoutGuide.bottomAnchor, constant: -63)
     } else {
-      topConstraint = blurView.topAnchor.constraint(equalTo: view.topAnchor, constant: 50)
+      topConstraint = blurView.topAnchor.constraint(equalTo: view.safeAreaLayoutGuide.topAnchor, constant: 50)
     }
     
     NSLayoutConstraint.activate([


### PR DESCRIPTION
Closes #6726 
Closes #2556

In this PR:
1. the toast layout changed from `visualFormat` to `anchors` constraints (because using string literals for layout is bad practice, hard to read and debug)
2. adjust toast position (63pt constraint is used because the tabbar buttons height is 48 so spacing will be 15 on devices with rounded edges and 5 on SE-like devices (that have additional 10pt spacing from bottom))

<img width="422" alt="image" src="https://github.com/organicmaps/organicmaps/assets/79797627/c45ba227-5b03-4da3-b1b7-fa19de6dd2de">
