### PR TITLE
Display website in Place Page without http(s):// prefixes and trailing slashes

### DIFF
--- a/android/app/src/main/java/app/organicmaps/bookmarks/data/Metadata.java
+++ b/android/app/src/main/java/app/organicmaps/bookmarks/data/Metadata.java
@@ -22,7 +22,8 @@ public class Metadata implements Parcelable
     FMD_FAX_NUMBER(4),
     FMD_STARS(5),
     FMD_OPERATOR(6),
-    FMD_URL(7),
+    // Removed and is not used in the core. Use FMD_WEBSITE instead.
+    //FMD_URL(7),
     FMD_WEBSITE(8),
     FMD_INTERNET(9),
     FMD_ELE(10),

--- a/android/app/src/main/java/app/organicmaps/widget/placepage/sections/PlacePageLinksFragment.java
+++ b/android/app/src/main/java/app/organicmaps/widget/placepage/sections/PlacePageLinksFragment.java
@@ -94,7 +94,7 @@ public class PlacePageLinksFragment extends Fragment implements Observer<MapObje
     case FMD_EXTERNAL_URI:
       return getExternalUrl(mapObject);
     case FMD_WEBSITE:
-      return getWebsiteUrl(mapObject);
+      return getWebsiteUrl(mapObject, false /* strip */);
     case FMD_CONTACT_FACEBOOK:
     case FMD_CONTACT_INSTAGRAM:
     case FMD_CONTACT_TWITTER:
@@ -202,7 +202,9 @@ public class PlacePageLinksFragment extends Fragment implements Observer<MapObje
     final List<String> items = new ArrayList<>();
     items.add(url);
 
-    final String metadata = type == Metadata.MetadataType.FMD_WEBSITE ? getWebsiteUrl(mMapObject) : mMapObject.getMetadata(type);
+    final String metadata = type == Metadata.MetadataType.FMD_WEBSITE
+        ? getWebsiteUrl(mMapObject, false /* strip */)
+        : mMapObject.getMetadata(type);
     // Add user names for social media if available
     if (!metadata.equals(url) && isSocialUsername(type))
       items.add(metadata);
@@ -237,17 +239,26 @@ public class PlacePageLinksFragment extends Fragment implements Observer<MapObje
     return kayakUri;
   }
 
-  private static String getWebsiteUrl(MapObject mapObject)
+  private static String kHttp = "http://";
+  private static String kHttps = "https://";
+
+  private static String getWebsiteUrl(MapObject mapObject, boolean strip)
   {
-    String website = mapObject.getMetadata(Metadata.MetadataType.FMD_WEBSITE);
-    String url = mapObject.getMetadata(Metadata.MetadataType.FMD_URL);
-    return TextUtils.isEmpty(website) ? url : website;
+    final String website = mapObject.getMetadata(Metadata.MetadataType.FMD_WEBSITE);
+    final int len = website.length();
+    if (strip && len > 1)
+    {
+      final int start = website.startsWith(kHttps) ? kHttps.length() : (website.startsWith(kHttp) ? kHttp.length() : 0);
+      final int end = website.endsWith("/") ? len - 1 : len;
+      return website.substring(start, end);
+    }
+    return website;
   }
 
   private void refreshLinks()
   {
     UiUtils.showIf(getExternalUrl(mMapObject) != null, mKayak);
-    refreshMetadataOrHide(getWebsiteUrl(mMapObject), mWebsite, mTvWebsite);
+    refreshMetadataOrHide(getWebsiteUrl(mMapObject, true /* strip */), mWebsite, mTvWebsite);
     String wikimedia_commons = mMapObject.getMetadata(Metadata.MetadataType.FMD_WIKIMEDIA_COMMONS);
     String wikimedia_commons_text = TextUtils.isEmpty(wikimedia_commons) ? "" : getResources().getString(R.string.wikimedia_commons);
     refreshMetadataOrHide(wikimedia_commons_text, mWikimedia, mTvWikimedia);

--- a/data/editor.config
+++ b/data/editor.config
@@ -59,9 +59,9 @@
       <field name="operator">
         <tag k="operator" />
       </field>
-      <!-- What is FMD_URL? -->
       <field name="website">
         <tag k="website" />
+        <!-- url tags are converted to website in the generator -->
         <alt k="url" />
         <alt k="contact:website" />
       </field>

--- a/iphone/Maps/UI/PlacePage/Components/PlacePageInfoViewController.swift
+++ b/iphone/Maps/UI/PlacePage/Components/PlacePageInfoViewController.swift
@@ -136,7 +136,8 @@ class PlacePageInfoViewController: UIViewController {
     }
 
     if let website = placePageInfoData.website {
-      websiteView = createInfoItem(website, icon: UIImage(named: "ic_placepage_website"), style: .link) { [weak self] in
+      // Strip website url only when the value is displayed, to avoid issues when it's opened or edited.
+      websiteView = createInfoItem(stripUrl(str: website), icon: UIImage(named: "ic_placepage_website"), style: .link) { [weak self] in
         self?.delegate?.didPressWebsite()
       }
     }
@@ -246,6 +247,16 @@ class PlacePageInfoViewController: UIViewController {
     addChild(viewController)
     stackView.addArrangedSubviewWithSeparator(viewController.view)
     viewController.didMove(toParent: self)
+  }
+
+  private static let kHttp = "http://"
+  private static let kHttps = "https://"
+
+  private func stripUrl(str: String) -> String {
+    let dropFromStart = str.hasPrefix(PlacePageInfoViewController.kHttps) ? PlacePageInfoViewController.kHttps.count
+        : (str.hasPrefix(PlacePageInfoViewController.kHttp) ? PlacePageInfoViewController.kHttp.count : 0);
+    let dropFromEnd = str.hasSuffix("/") ? 1 : 0;
+    return String(str.dropFirst(dropFromStart).dropLast(dropFromEnd))
   }
 }
 


### PR DESCRIPTION
Let's make OM a bit more beautiful.

|Before | After|
|---|---|
|<img width="272" alt="выява" src="https://github.com/organicmaps/organicmaps/assets/170263/3f3a1c50-39b0-4d12-b364-8972dac6e0b5">|<img width="272" alt="выява" src="https://github.com/organicmaps/organicmaps/assets/170263/220ffb57-9f03-48e8-b264-bf83ad6f04c4">|
