### PR TITLE
[android] Fix non-unity build errors

### DIFF
--- a/android/app/src/main/cpp/app/organicmaps/util/StringUtils.cpp
+++ b/android/app/src/main/cpp/app/organicmaps/util/StringUtils.cpp
@@ -1,4 +1,6 @@
 #include "app/organicmaps/core/jni_helper.hpp"
+#include "app/organicmaps/core/jni_java_methods.hpp"
+#include "app/organicmaps/util/Distance.hpp"
 
 #include "indexer/search_string_utils.hpp"
 


### PR DESCRIPTION
Missing namespaces and includes caused C++ compilation errors when using `export UNITY_DISABLE=1` before building.