### PR TITLE
[ios] Fix the app freezing when the PlacePage screen is opening on iOS 14

### DIFF
--- a/iphone/Maps/Classes/CustomAlert/Toast/Toast.swift
+++ b/iphone/Maps/Classes/CustomAlert/Toast/Toast.swift
@@ -44,10 +44,10 @@ final class Toast: NSObject {
   }
 
   @objc func show(in view: UIView?, alignment: Alignment) {
-    guard let view else { return }
+    guard let view = view else { return }
     blurView.translatesAutoresizingMaskIntoConstraints = false
     view.addSubview(blurView)
-    
+
     let leadingConstraint = blurView.leadingAnchor.constraint(greaterThanOrEqualTo: view.leadingAnchor, constant: 16)
     let trailingConstraint = blurView.trailingAnchor.constraint(lessThanOrEqualTo: view.trailingAnchor, constant: -16)
     

--- a/iphone/Maps/UI/PlacePage/PlacePageViewController.swift
+++ b/iphone/Maps/UI/PlacePage/PlacePageViewController.swift
@@ -74,15 +74,16 @@ final class PlacePageScrollView: UIScrollView {
     actionBarContainerView.layer.cornerRadius = 10
     actionBarContainerView.layer.masksToBounds = true
     actionBarContainerView.layer.maskedCorners = [.layerMinXMaxYCorner, .layerMaxXMaxYCorner]
+
+    if previousTraitCollection == nil {
+      scrollView.contentInset = alternativeSizeClass(iPhone: UIEdgeInsets(top: view.height, left: 0, bottom: 0, right: 0),
+                                                     iPad: UIEdgeInsets.zero)
+      scrollView.layoutIfNeeded()
+    }
   }
 
   override func viewDidLayoutSubviews() {
     super.viewDidLayoutSubviews()
-    if previousTraitCollection == nil {
-      scrollView.contentInset = alternativeSizeClass(iPhone: UIEdgeInsets(top: scrollView.height, left: 0, bottom: 0, right: 0),
-                                                     iPad: UIEdgeInsets.zero)
-      updateSteps()
-    }
     panGesture.isEnabled = alternativeSizeClass(iPhone: false, iPad: true)
     previousTraitCollection = traitCollection
   }


### PR DESCRIPTION
Fix PR https://github.com/organicmaps/organicmaps/pull/6200

The app freezes on iOS 14 when the user taps someplace (probably the main thread became deadlocked when scrollView.contentInsets initial values are set to new value and viewDidLayoutSubviews leaves scope).

This PR fixes this issue but it needs some additional test!

App tested and works well now on simulators iOS 14.4, 15.5, 16.4, 17.0.1:
<img width="419" alt="image" src="https://github.com/organicmaps/organicmaps/assets/79797627/f34beba9-7df7-429f-ba97-9056718a0b58">
<img width="384" alt="image" src="https://github.com/organicmaps/organicmaps/assets/79797627/aab5a891-6b62-4c04-ae1e-9762b89ed43a">
<img width="355" alt="image" src="https://github.com/organicmaps/organicmaps/assets/79797627/2ab2d771-7d83-42fc-96cd-f0ac1ff6d545">
<img width="665" alt="image" src="https://github.com/organicmaps/organicmaps/assets/79797627/578eaeb2-c10f-44b3-b3a4-e850d35d5399">
