### PR TITLE
[android] Refactor handling of links on PlacePage

### DIFF
--- a/android/app/src/main/java/app/organicmaps/bookmarks/data/MapObject.java
+++ b/android/app/src/main/java/app/organicmaps/bookmarks/data/MapObject.java
@@ -9,15 +9,19 @@ import androidx.annotation.NonNull;
 import androidx.annotation.Nullable;
 import androidx.core.os.ParcelCompat;
 
+import app.organicmaps.Framework;
 import app.organicmaps.routing.RoutePointInfo;
 import app.organicmaps.search.Popularity;
+import app.organicmaps.util.Utils;
 import app.organicmaps.widget.placepage.PlacePageData;
 
 import java.lang.annotation.Retention;
 import java.lang.annotation.RetentionPolicy;
 import java.util.ArrayList;
 import java.util.Arrays;
+import java.util.Date;
 import java.util.List;
+import java.util.Objects;
 
 // TODO(yunikkk): Refactor. Displayed information is different from edited information, and it's better to
 // separate them. Simple getters from jni place_page::Info and osm::EditableFeature should be enough.
@@ -46,6 +50,9 @@ public class MapObject implements PlacePageData
   public static final int OPENING_MODE_DETAILS = 2;
   public static final int OPENING_MODE_FULL = 3;
 
+  private static String kHttp = "http://";
+  private static String kHttps = "https://";
+
   @NonNull
   private final FeatureId mFeatureId;
   @MapObjectType
@@ -54,10 +61,11 @@ public class MapObject implements PlacePageData
   private String mTitle;
   @Nullable
   private final String mSecondaryTitle;
-  private String mSubtitle;
+  private final String mSubtitle;
   private double mLat;
   private double mLon;
   private final String mAddress;
+  @NonNull
   private final Metadata mMetadata;
   private final String mApiId;
   private final RoutePointInfo mRoutePointInfo;
@@ -98,7 +106,7 @@ public class MapObject implements PlacePageData
     mAddress = address;
     mLat = lat;
     mLon = lon;
-    mMetadata = metadata;
+    mMetadata = metadata != null ? metadata : new Metadata();
     mApiId = apiId;
     mRoutePointInfo = routePointInfo;
     mOpeningMode = openingMode;
@@ -111,7 +119,7 @@ public class MapObject implements PlacePageData
 
   protected MapObject(@MapObjectType int type, Parcel source)
   {
-    this(ParcelCompat.readParcelable(source, FeatureId.class.getClassLoader(), FeatureId.class), // FeatureId
+    this(Objects.requireNonNull(ParcelCompat.readParcelable(source, FeatureId.class.getClassLoader(), FeatureId.class)), // FeatureId
          type, // MapObjectType
          source.readString(), // Title
          source.readString(), // SecondaryTitle
@@ -123,8 +131,8 @@ public class MapObject implements PlacePageData
          source.readString(), // ApiId;
          ParcelCompat.readParcelable(source, RoutePointInfo.class.getClassLoader(), RoutePointInfo.class), // RoutePointInfo
          source.readInt(), // mOpeningMode
-         ParcelCompat.readParcelable(source, Popularity.class.getClassLoader(), Popularity.class),
-         source.readString(),
+         Objects.requireNonNull(ParcelCompat.readParcelable(source, Popularity.class.getClassLoader(), Popularity.class)),
+         Objects.requireNonNull(source.readString()),
          source.readInt(),
          null // mRawTypes
         );
@@ -258,9 +266,30 @@ public class MapObject implements PlacePageData
     return res == null ? "" : res;
   }
 
-  public boolean hasMetadata()
+  @NonNull
+  public String getWebsiteUrl(boolean strip)
   {
-    return mMetadata != null && !mMetadata.isEmpty();
+    final String website = getMetadata(Metadata.MetadataType.FMD_WEBSITE);
+    final int len = website.length();
+    if (strip && len > 1)
+    {
+      final int start = website.startsWith(kHttps) ? kHttps.length() : (website.startsWith(kHttp) ? kHttp.length() : 0);
+      final int end = website.endsWith("/") ? len - 1 : len;
+      return website.substring(start, end);
+    }
+    return website;
+  }
+
+  @NonNull
+  public String getKayakUrl()
+  {
+    final String uri = getMetadata(Metadata.MetadataType.FMD_EXTERNAL_URI);
+    if (TextUtils.isEmpty(uri))
+      return "";
+    final Date firstDay = new Date();
+    final Date lastDay = new Date(firstDay.getTime() + (1000 * 60 * 60 * 24));
+    final String res = Framework.nativeGetKayakHotelLink(Utils.getCountryCode(), uri, firstDay, lastDay);
+    return res == null ? "" : res;
   }
 
   public String getApiId()
@@ -299,11 +328,6 @@ public class MapObject implements PlacePageData
   public final boolean isBookmark()
   {
     return mMapObjectType == BOOKMARK;
-  }
-
-  public final boolean isApiPoint()
-  {
-    return mMapObjectType == API_POINT;
   }
 
   @Nullable
@@ -380,7 +404,7 @@ public class MapObject implements PlacePageData
     return mFeatureId.hashCode();
   }
 
-  public static final Creator<MapObject> CREATOR = new Creator<MapObject>()
+  public static final Creator<MapObject> CREATOR = new Creator<>()
   {
     @Override
     public MapObject createFromParcel(Parcel source)

--- a/android/app/src/main/java/app/organicmaps/bookmarks/data/Metadata.java
+++ b/android/app/src/main/java/app/organicmaps/bookmarks/data/Metadata.java
@@ -97,11 +97,6 @@ public class Metadata implements Parcelable
     return mMetadataMap.get(type);
   }
 
-  boolean isEmpty()
-  {
-    return mMetadataMap.isEmpty();
-  }
-
   @Override
   public int describeContents()
   {

--- a/android/app/src/main/java/app/organicmaps/car/screens/PlaceScreen.java
+++ b/android/app/src/main/java/app/organicmaps/car/screens/PlaceScreen.java
@@ -6,6 +6,7 @@ import static android.text.Spanned.SPAN_INCLUSIVE_INCLUSIVE;
 import android.content.Intent;
 import android.net.Uri;
 import android.text.SpannableString;
+import android.text.TextUtils;
 
 import androidx.annotation.NonNull;
 import androidx.annotation.Nullable;
@@ -198,9 +199,10 @@ public class PlaceScreen extends BaseMapScreen implements OnBackPressedCallback.
   {
     Objects.requireNonNull(mMapObject);
 
-    final String phoneNumber = getFirstPhoneNumber(mMapObject);
-    if (!phoneNumber.isEmpty())
+    final String phones = mMapObject.getMetadata(Metadata.MetadataType.FMD_PHONE_NUMBER);
+    if (!TextUtils.isEmpty(phones))
     {
+      final String phoneNumber = phones.split(";", 1)[0];
       final Action.Builder openDialBuilder = new Action.Builder();
       openDialBuilder.setIcon(new CarIcon.Builder(IconCompat.createWithResource(getCarContext(), R.drawable.ic_phone)).build());
       openDialBuilder.setOnClickListener(() -> getCarContext().startCarApp(new Intent(Intent.ACTION_DIAL, Uri.parse("tel:" + phoneNumber))));
@@ -240,16 +242,6 @@ public class PlaceScreen extends BaseMapScreen implements OnBackPressedCallback.
 
     // Driving Options changed. Let's rebuild the route
     mRoutingController.rebuildLastRoute();
-  }
-
-  @NonNull
-  private static String getFirstPhoneNumber(@NonNull MapObject mapObject)
-  {
-    if (!mapObject.hasMetadata())
-      return "";
-
-    final String phones = mapObject.getMetadata(Metadata.MetadataType.FMD_PHONE_NUMBER);
-    return phones.split(";", 1)[0];
   }
 
   @Override

--- a/android/app/src/main/java/app/organicmaps/car/util/UiHelpers.java
+++ b/android/app/src/main/java/app/organicmaps/car/util/UiHelpers.java
@@ -103,9 +103,6 @@ public final class UiHelpers
   @Nullable
   public static Row getPlaceOpeningHoursRow(@NonNull MapObject place, @NonNull CarContext context)
   {
-    if (!place.hasMetadata())
-      return null;
-
     final String ohStr = place.getMetadata(Metadata.MetadataType.FMD_OPEN_HOURS);
     final Timetable[] timetables = OpeningHours.nativeTimetablesFromString(ohStr);
     final boolean isEmptyTT = (timetables == null || timetables.length == 0);

--- a/android/app/src/main/java/app/organicmaps/widget/placepage/PlacePageView.java
+++ b/android/app/src/main/java/app/organicmaps/widget/placepage/PlacePageView.java
@@ -142,13 +142,12 @@ public class PlacePageView extends Fragment implements View.OnClickListener,
   private PlacePageViewModel mViewModel;
   private MapObject mMapObject;
 
-  private static void refreshMetadataOrHide(String metadata, View metaLayout, TextView metaTv)
+  private static void refreshMetadataOrHide(@Nullable String metadata, @NonNull View metaLayout, @NonNull TextView metaTv)
   {
     if (!TextUtils.isEmpty(metadata))
     {
       metaLayout.setVisibility(VISIBLE);
-      if (metaTv != null)
-        metaTv.setText(metadata);
+      metaTv.setText(metadata);
     }
     else
       metaLayout.setVisibility(GONE);
@@ -314,14 +313,14 @@ public class PlacePageView extends Fragment implements View.OnClickListener,
 
   private void updateLinksView()
   {
-    final boolean hasLinkAvailable = PlacePageLinksFragment.hasLinkAvailable(mMapObject);
-    updateViewFragment(PlacePageLinksFragment.class, LINKS_FRAGMENT_TAG, R.id.place_page_links_fragment, hasLinkAvailable);
+    updateViewFragment(PlacePageLinksFragment.class, LINKS_FRAGMENT_TAG, R.id.place_page_links_fragment, true);
   }
 
   private void updateOpeningHoursView()
   {
     final String ohStr = mMapObject.getMetadata(Metadata.MetadataType.FMD_OPEN_HOURS);
-    updateViewFragment(PlacePageOpeningHoursFragment.class, OPENING_HOURS_FRAGMENT_TAG, R.id.place_page_opening_hours_fragment, !ohStr.isEmpty());
+    updateViewFragment(PlacePageOpeningHoursFragment.class, OPENING_HOURS_FRAGMENT_TAG,
+        R.id.place_page_opening_hours_fragment, !TextUtils.isEmpty(ohStr));
   }
 
   private void updatePhoneView()

--- a/android/app/src/main/java/app/organicmaps/widget/placepage/sections/PlacePageWikipediaFragment.java
+++ b/android/app/src/main/java/app/organicmaps/widget/placepage/sections/PlacePageWikipediaFragment.java
@@ -105,9 +105,13 @@ public class PlacePageWikipediaFragment extends Fragment implements Observer<Map
     }
 
     final String wikipediaLink = mMapObject.getMetadata(Metadata.MetadataType.FMD_WIKIPEDIA);
-    mWiki.setOnClickListener((v) -> Utils.openUrl(requireContext(), wikipediaLink));
+    mWiki.setOnClickListener((v) -> {
+      if (!TextUtils.isEmpty(wikipediaLink))
+        Utils.openUrl(requireContext(), wikipediaLink);
+    });
     mWiki.setOnLongClickListener((v) -> {
-      PlacePageUtils.copyToClipboard(requireContext(), mFrame, wikipediaLink);
+      if (!TextUtils.isEmpty(wikipediaLink))
+        PlacePageUtils.copyToClipboard(requireContext(), mFrame, wikipediaLink);
       return true;
     });
   }


### PR DESCRIPTION
- Make PlacePageLinksFragment.getLink() non-static as requested on one of the previous code reviews.
- Move getWebsiteUrl() and getKayakUrl() to MapObject.
- Force @NonNull String invariant for getKayakUrl(). Currently all getMetadata() methods return @NonNull Strings. Replacing empty strings with null objects and removing TextUtils.isEmpty() clutter is very error-prone and requires a separate refactoring.
- Fix few lint warnings.