### PR TITLE
[android] Migrate to Material LinearProgressIndicator

### DIFF
--- a/android/app/src/main/java/app/organicmaps/DownloadResourcesLegacyActivity.java
+++ b/android/app/src/main/java/app/organicmaps/DownloadResourcesLegacyActivity.java
@@ -9,7 +9,6 @@ import android.text.TextUtils;
 import android.view.View;
 import android.widget.Button;
 import android.widget.CheckBox;
-import android.widget.ProgressBar;
 import android.widget.TextView;
 
 import androidx.activity.result.ActivityResultLauncher;
@@ -33,6 +32,7 @@ import app.organicmaps.util.StringUtils;
 import app.organicmaps.util.UiUtils;
 import app.organicmaps.util.Utils;
 import com.google.android.material.dialog.MaterialAlertDialogBuilder;
+import com.google.android.material.progressindicator.LinearProgressIndicator;
 
 import java.util.List;
 
@@ -51,7 +51,7 @@ public class DownloadResourcesLegacyActivity extends BaseMwmFragmentActivity
   private static final int ERR_FILE_IN_PROGRESS = -6;
 
   private TextView mTvMessage;
-  private ProgressBar mProgress;
+  private LinearProgressIndicator mProgress;
   private Button mBtnDownload;
   private CheckBox mChbDownloadCountry;
 

--- a/android/app/src/main/res/layout/button_with_progress.xml
+++ b/android/app/src/main/res/layout/button_with_progress.xml
@@ -2,6 +2,7 @@
 <LinearLayout
   xmlns:android="http://schemas.android.com/apk/res/android"
   xmlns:tools="http://schemas.android.com/tools"
+  xmlns:app="http://schemas.android.com/apk/res-auto"
   android:layout_width="match_parent"
   android:layout_height="wrap_content"
   android:orientation="vertical">
@@ -14,16 +15,17 @@
     android:textAppearance="?fontBody2"
     android:visibility="gone"
     tools:visibility="visible"/>
-  <ProgressBar
+  <com.google.android.material.progressindicator.LinearProgressIndicator
     android:id="@+id/progressbar"
-    style="@style/Widget.AppCompat.ProgressBar.Horizontal"
+    style="@style/Widget.MaterialComponents.LinearProgressIndicator"
     android:layout_width="match_parent"
     android:layout_height="wrap_content"
     android:layout_marginStart="@dimen/margin_base_plus"
     android:layout_marginTop="@dimen/margin_base"
     android:layout_marginEnd="@dimen/margin_base_plus"
     android:layout_marginBottom="@dimen/margin_base"
-    android:indeterminate="false" />
+    android:indeterminate="false"
+    app:indicatorColor="?android:colorAccent"/>
   <Button
     android:id="@+id/btn_download_resources"
     style="@style/MwmWidget.Button.Primary"


### PR DESCRIPTION
This PR migrate appcompat progressbar to Material LinearProgressIndicator.
I have also tried to migrate the circular progress bar to CircularProgressIndicator but he has an issue [#2116](https://github.com/material-components/material-components-android/issues/2116)

|Before|After|
|-|-|
|<img src="https://github.com/organicmaps/organicmaps/assets/87148630/5be9b5a0-207f-43a3-989f-3e1f2ac73b25" height=100 />|<img src="https://github.com/organicmaps/organicmaps/assets/87148630/09ce7977-fe2a-40b4-bd11-50236240038a" height=100 />|

I have added a new property to keep the same indicate color (default property uses colorPrimary app)
The margin under Progress Indicator has been reduced and Track color is in default in blue.
More information here -> https://github.com/material-components/material-components-android/blob/master/docs/components/ProgressIndicator.md
