### PR TITLE
[ios] Increase PlacePage TabButton tap interaction area

### DIFF
--- a/iphone/Maps/UI/PlacePage/PlacePageLayout/ActionBar/MWMActionBarButton.m
+++ b/iphone/Maps/UI/PlacePage/PlacePageLayout/ActionBar/MWMActionBarButton.m
@@ -199,4 +199,8 @@ NSString *titleForButton(MWMActionBarButtonType type, BOOL isSelected) {
   [NSUserDefaults.standardUserDefaults setBool:true forKey:kUDDidHighlightRouteToButton];
 }
 
+- (UIView *)hitTest:(CGPoint)point withEvent:(UIEvent *)event {
+  return [self pointInside:point withEvent:event] ? self.button : nil;
+}
+
 @end


### PR DESCRIPTION
### Issue
When the user taps on the PP TabButton the only inner button reacts on tap (see the blue rect). And if the tap hits the text label interaction fails.
![telegram-cloud-photo-size-2-5449821845583942875-y](https://github.com/organicmaps/organicmaps/assets/79797627/6b8df0d3-7734-4ebb-bb5a-16c3072a10f6)

### Solution
This PR increases the "tap zone" and includes both the button and the label.
<img width="742" alt="image" src="https://github.com/organicmaps/organicmaps/assets/79797627/8343d685-1319-4871-8b75-15fbcc51c29d">

