### PR TITLE
[android] Improve layout performance

### DIFF
--- a/android/app/src/main/res/layout/activity_splash.xml
+++ b/android/app/src/main/res/layout/activity_splash.xml
@@ -9,7 +9,7 @@
   <ImageView
       android:id="@+id/iv__logo"
       android:layout_width="wrap_content"
-      android:layout_height="wrap_content"
+      android:layout_height="0dp"
       android:contentDescription="@null"
       android:src="@drawable/splash"
       android:layout_weight="1000"

--- a/android/app/src/main/res/layout/elevation_profile_internal.xml
+++ b/android/app/src/main/res/layout/elevation_profile_internal.xml
@@ -36,7 +36,8 @@
     android:layout_marginStart="@dimen/margin_base"
     android:layout_marginEnd="@dimen/margin_base"
     android:minHeight="@dimen/elevation_profile_chart_info_min_height"
-    android:orientation="horizontal">
+    android:orientation="horizontal"
+    android:baselineAligned="false">
     <LinearLayout
       android:layout_width="0dp"
       android:layout_height="match_parent"

--- a/android/app/src/main/res/layout/fragment_bookmark_category_settings.xml
+++ b/android/app/src/main/res/layout/fragment_bookmark_category_settings.xml
@@ -29,11 +29,6 @@
       android:paddingTop="@dimen/margin_half_plus"
       android:layout_width="match_parent"
       android:layout_height="wrap_content">
-      <LinearLayout
-        android:orientation="horizontal"
-        android:id="@+id/edit_name_container"
-        android:layout_width="match_parent"
-        android:layout_height="wrap_content">
         <com.google.android.material.textfield.TextInputLayout
           android:id="@+id/edit_list_name_input"
           style="@style/MwmWidget.Editor.CustomTextInput"
@@ -48,7 +43,6 @@
           android:layout_width="match_parent"
           android:layout_height="wrap_content" />
         </com.google.android.material.textfield.TextInputLayout>
-      </LinearLayout>
     </LinearLayout>
     <com.google.android.material.textfield.TextInputLayout
       style="@style/MwmWidget.Editor.CustomTextInput"

--- a/android/app/src/main/res/layout/routing_action_panel.xml
+++ b/android/app/src/main/res/layout/routing_action_panel.xml
@@ -6,7 +6,8 @@
   android:layout_width="match_parent"
   android:layout_height="wrap_content"
   android:minHeight="@dimen/height_block_base"
-  android:background="?cardBackground">
+  android:background="?cardBackground"
+  android:baselineAligned="false">
   <LinearLayout
     android:id="@+id/btn__search_point"
     android:layout_width="0dp"


### PR DESCRIPTION
This PR updates app layouts to improve performance following Android Studio guidelines/warnings.
 - `android:layout_height="0dp"` = When only a single widget in a LinearLayout defines a weight, it is more efficient to assign a width/height of 0dp to it since it will absorb all the remaining space anyway. With a declared width/height of 0dp it does not have to measure its own size first.
 - `android:baselineAligned` = When a LinearLayout is used to distribute the space proportionally between nested layouts, the baseline alignment property should be turned off to make the layout computation faster.
Explanations are from Android Studio
- In fragment_bookmark_category_settings, I have removed `LinearLayout` because this item was used before when layout contained an independent button to clear text in TextView.

- [x] Need to be tested on real device
Tested on Pixel 6 - Android 14