### PR TITLE
CMake: enable usage of external gflags

### DIFF
--- a/3party/CMakeLists.txt
+++ b/3party/CMakeLists.txt
@@ -2,7 +2,10 @@
 # Compatibility with CMake < 3.5 will be removed from a future version of CMake.
 set(CMAKE_WARN_DEPRECATED OFF CACHE BOOL "" FORCE)
 
-if (NOT WITH_SYSTEM_PROVIDED_3PARTY)
+if (WITH_SYSTEM_PROVIDED_3PARTY)
+  set(GFLAGS_USE_TARGET_NAMESPACE ON)
+  find_package(gflags REQUIRED GLOBAL)
+else()
   # Configure expat library.
   # Suppress "Policy CMP0077 is not set: option() honors normal variables"
   # for the expat options below.

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -303,7 +303,7 @@ add_subdirectory(3party)
 
 # Not needed for the usual build process, but it fixes QtCreator editor,
 # that doesn't see gflags/gflags.h in binary dir (gflags has tricky cmake configuration).
-if (PLATFORM_DESKTOP)
+if (PLATFORM_DESKTOP AND NOT WITH_SYSTEM_PROVIDED_3PARTY)
   include_directories("${PROJECT_BINARY_DIR}/3party/gflags/include")
 endif()
 


### PR DESCRIPTION
Follow up of PR #6801.

Enables the usage of external gflags library.