### PR TITLE
[android] Implement new logic to hide clear button in bookmark edit fragments

### DIFF
--- a/android/app/src/main/java/app/organicmaps/bookmarks/BookmarkCategorySettingsFragment.java
+++ b/android/app/src/main/java/app/organicmaps/bookmarks/BookmarkCategorySettingsFragment.java
@@ -1,8 +1,10 @@
 package app.organicmaps.bookmarks;
 
 import android.os.Bundle;
+import android.text.Editable;
 import android.text.InputFilter;
 import android.text.TextUtils;
+import android.text.TextWatcher;
 import android.view.LayoutInflater;
 import android.view.Menu;
 import android.view.MenuInflater;
@@ -72,6 +74,20 @@ public class BookmarkCategorySettingsFragment extends BaseMwmToolbarFragment
     InputFilter[] f = { new InputFilter.LengthFilter(TEXT_LENGTH_LIMIT) };
     mEditCategoryNameView.setFilters(f);
     mEditCategoryNameView.requestFocus();
+    mEditCategoryNameView.addTextChangedListener(new TextWatcher()
+    {
+      @Override
+      public void beforeTextChanged(CharSequence charSequence, int i, int i1, int i2) {}
+
+      @Override
+      public void onTextChanged(CharSequence charSequence, int i, int i1, int i2)
+      {
+        clearNameBtn.setEndIconVisible(charSequence.length() > 0);
+      }
+
+      @Override
+      public void afterTextChanged(Editable editable) {}
+    });
     mEditDescView = root.findViewById(R.id.edit_description);
     mEditDescView.setText(mCategory.getDescription());
   }

--- a/android/app/src/main/java/app/organicmaps/widget/placepage/EditBookmarkFragment.java
+++ b/android/app/src/main/java/app/organicmaps/widget/placepage/EditBookmarkFragment.java
@@ -3,7 +3,9 @@ package app.organicmaps.widget.placepage;
 import android.content.Context;
 import android.graphics.drawable.Drawable;
 import android.os.Bundle;
+import android.text.Editable;
 import android.text.TextUtils;
+import android.text.TextWatcher;
 import android.view.LayoutInflater;
 import android.view.View;
 import android.view.ViewGroup;
@@ -26,8 +28,10 @@ import app.organicmaps.bookmarks.data.BookmarkInfo;
 import app.organicmaps.bookmarks.data.BookmarkManager;
 import app.organicmaps.bookmarks.data.Icon;
 import app.organicmaps.util.Graphics;
+import app.organicmaps.util.InputUtils;
 import app.organicmaps.util.UiUtils;
 import com.google.android.material.textfield.TextInputEditText;
+import com.google.android.material.textfield.TextInputLayout;
 
 import java.util.List;
 
@@ -38,6 +42,8 @@ public class EditBookmarkFragment extends BaseMwmDialogFragment implements View.
 
   private TextInputEditText mEtDescription;
   private TextInputEditText mEtName;
+  @NonNull
+  private TextInputLayout clearNameBtn;
   private TextView mTvBookmarkGroup;
   private ImageView mIvColor;
   private BookmarkCategory mBookmarkCategory;
@@ -94,6 +100,22 @@ public class EditBookmarkFragment extends BaseMwmDialogFragment implements View.
     if (mBookmark != null)
       mIcon = mBookmark.getIcon();
     mEtName = view.findViewById(R.id.et__bookmark_name);
+    clearNameBtn = view.findViewById(R.id.edit_bookmark_name_input);
+    clearNameBtn.setEndIconOnClickListener(v -> clearAndFocus(mEtName));
+    mEtName.addTextChangedListener(new TextWatcher()
+    {
+      @Override
+      public void beforeTextChanged(CharSequence charSequence, int i, int i1, int i2) {}
+
+      @Override
+      public void onTextChanged(CharSequence charSequence, int i, int i1, int i2)
+      {
+        clearNameBtn.setEndIconVisible(charSequence.length() > 0);
+      }
+
+      @Override
+      public void afterTextChanged(Editable editable) {}
+    });
     mEtDescription = view.findViewById(R.id.et__description);
     mTvBookmarkGroup = view.findViewById(R.id.tv__bookmark_set);
     mTvBookmarkGroup.setOnClickListener(this);
@@ -251,5 +273,11 @@ public class EditBookmarkFragment extends BaseMwmDialogFragment implements View.
   public void setEditBookmarkListener(@Nullable EditBookmarkListener listener)
   {
     mListener = listener;
+  }
+  private void clearAndFocus(TextView textView)
+  {
+    textView.getEditableText().clear();
+    textView.requestFocus();
+    InputUtils.showKeyboard(textView);
   }
 }

--- a/android/app/src/main/res/layout/edit_bookmark_common.xml
+++ b/android/app/src/main/res/layout/edit_bookmark_common.xml
@@ -16,10 +16,14 @@
     android:layout_marginEnd="@dimen/margin_half"
     android:orientation="vertical">
     <com.google.android.material.textfield.TextInputLayout
+      android:id="@+id/edit_bookmark_name_input"
       style="?fontBody1"
       android:layout_width="match_parent"
       android:layout_height="wrap_content"
-      android:textColorHint="?android:textColorSecondary">
+      android:textColorHint="?android:textColorSecondary"
+      app:endIconMode="custom"
+      app:endIconDrawable="@drawable/ic_clear_rounded"
+      app:endIconTint="?android:textColorSecondary">
       <com.google.android.material.textfield.TextInputEditText
         android:id="@+id/et__bookmark_name"
         style="@style/MwmWidget.PlacePage.EditText"


### PR DESCRIPTION
This PR following changes here #6549:

- Add a new end icon in TextInput in edit bookmark fragment with logic to clear the field and give focus
- Add a new listener to hide/see clear button if length is up 0 in two fragment uses clear button