### PR TITLE
[android-auto] Remove compile-time feature flag for Android Auto

### DIFF
--- a/android/app/build.gradle
+++ b/android/app/build.gradle
@@ -13,8 +13,6 @@ buildscript {
   def taskName = getGradle().getStartParameter().getTaskRequests().toString().toLowerCase()
   def isFdroid = taskName.contains('fdroid')
   def isBeta = taskName.contains('beta')
-  def isDebug = taskName.contains('debug')
-  def isSyncWithFiles = taskName.contains('rundefaulttasksexecutionrequest') // used by Android Studio
 
   //
   // Please add symlinks to google/java/app/organicmaps/location for each new gms-enabled flavor below:
@@ -32,12 +30,6 @@ buildscript {
   ext.googleFirebaseServicesEnabled = googleFirebaseServicesFlag != null ?
       googleFirebaseServicesFlag == '' || googleFirebaseServicesFlag.toBoolean() :
       googleFirebaseServicesDefault
-
-  // Android Auto compile-time feature flag: -Pandroidauto=true|false
-  def androidAutoFlag = findProperty('androidauto')
-  // Enable Android Auto by default for all debug and beta flavors except fdroid.
-  def androidAutoDefault = isSyncWithFiles || ((isDebug || isBeta) && !isFdroid)
-  ext.androidAutoEnabled = androidAutoFlag != null ? androidAutoFlag.toBoolean() : androidAutoDefault
 
   dependencies {
     classpath 'com.android.tools.build:gradle:8.2.0'
@@ -96,16 +88,6 @@ dependencies {
     implementation 'com.google.firebase:firebase-crashlytics-ndk'
   }
 
-  if (androidAutoEnabled) {
-    println('Building with Android Auto')
-    implementation 'androidx.car.app:app:1.4.0-rc01'
-    // Fix for app/organicmaps/util/FileUploadWorker.java:14: error: cannot access ListenableFuture
-    // https://github.com/organicmaps/organicmaps/issues/6106
-    implementation 'com.google.guava:guava:32.1.3-android'
-  } else {
-    println('Building without Android Auto')
-  }
-
   // This line is added as a workaround for duplicate classes error caused by some outdated dependency:
   // > A failure occurred while executing com.android.build.gradle.internal.tasks.CheckDuplicatesRunnable
   // We don't use Kotlin, but some dependencies are actively using it.
@@ -114,6 +96,7 @@ dependencies {
   implementation(platform('org.jetbrains.kotlin:kotlin-bom:1.9.21'))
   implementation 'androidx.annotation:annotation:1.7.0'
   implementation 'androidx.appcompat:appcompat:1.6.1'
+  implementation 'androidx.car.app:app:1.4.0-rc02'
   implementation 'androidx.constraintlayout:constraintlayout:2.1.4'
   implementation 'androidx.fragment:fragment:1.6.2'
   implementation 'androidx.preference:preference:1.2.1'
@@ -122,6 +105,9 @@ dependencies {
   implementation 'androidx.lifecycle:lifecycle-process:2.6.2'
   implementation 'androidx.preference:preference:1.2.1'
   implementation 'com.google.android.material:material:1.10.0'
+  // Fix for app/organicmaps/util/FileUploadWorker.java:14: error: cannot access ListenableFuture
+  // https://github.com/organicmaps/organicmaps/issues/6106
+  implementation 'com.google.guava:guava:32.1.3-android'
   implementation 'com.github.devnullorthrow:MPAndroidChart:3.2.0-alpha'
   implementation 'net.jcip:jcip-annotations:1.0'
 
@@ -237,10 +223,6 @@ android {
     }
 
     setProperty('archivesBaseName', appName.replaceAll('\\s','') + '-' + defaultConfig.versionCode)
-
-    if (!androidAutoEnabled) {
-      sourceSets.main.java.excludes += '**/organicmaps/car'
-    }
   }
 
   flavorDimensions += 'default'
@@ -445,7 +427,6 @@ android.buildTypes.all { buildType ->
   def authority = "\"" + authorityValue + "\""
   buildConfigField 'String', 'FILE_PROVIDER_AUTHORITY', authority
   manifestPlaceholders += [FILE_PROVIDER_PLACEHOLDER : authorityValue]
-  manifestPlaceholders += [ANDROID_AUTO_ENABLED : androidAutoEnabled]
 }
 
 task prepareGoogleReleaseListing {

--- a/android/app/src/main/AndroidManifest.xml
+++ b/android/app/src/main/AndroidManifest.xml
@@ -45,8 +45,8 @@
   //-->
   <uses-permission-sdk-23 android:name="android.permission.POST_NOTIFICATIONS"/>
 
-  <uses-permission android:name="androidx.car.app.ACCESS_SURFACE" android:enabled="${ANDROID_AUTO_ENABLED}" />
-  <uses-permission android:name="androidx.car.app.NAVIGATION_TEMPLATES" android:enabled="${ANDROID_AUTO_ENABLED}" />
+  <uses-permission android:name="androidx.car.app.NAVIGATION_TEMPLATES"/>
+  <uses-permission android:name="androidx.car.app.ACCESS_SURFACE"/>
 
   <queries>
     <intent>
@@ -861,8 +861,7 @@
     <service
         android:name="app.organicmaps.car.CarAppService"
         android:foregroundServiceType="location"
-        android:exported="true"
-        android:enabled="${ANDROID_AUTO_ENABLED}">
+        android:exported="true">
       <intent-filter>
         <action android:name="androidx.car.app.CarAppService" />
         <category android:name="androidx.car.app.category.NAVIGATION" />
@@ -894,12 +893,11 @@
 
     <meta-data
         android:name="com.google.android.gms.car.application"
-        android:resource="@xml/automotive_app_desc"
-        android:enabled="${ANDROID_AUTO_ENABLED}"/>
+        android:resource="@xml/automotive_app_desc"/>
 
     <meta-data
         android:name="androidx.car.app.minCarApiLevel"
-        android:value="5"
-        android:enabled="${ANDROID_AUTO_ENABLED}"/>
+        android:value="5"/>
+
   </application>
 </manifest>


### PR DESCRIPTION
Android Auto has been accepted by Google. Google Play ignores "enabled=false" in AndroidManifest.xml anyway.

This reverts commit 8d17e90b7d5f8ade7d71f61dcf0ae0366c425b17.