### PR TITLE
[android] Fix missing buttons after restarting the app during navigation

### DIFF
--- a/android/app/src/main/java/app/organicmaps/MwmActivity.java
+++ b/android/app/src/main/java/app/organicmaps/MwmActivity.java
@@ -233,12 +233,6 @@ public class MwmActivity extends BaseMwmFragmentActivity
   }
 
   @Override
-  public void onRenderingRestored()
-  {
-    processIntent();
-  }
-
-  @Override
   public void onRenderingCreated()
   {
     checkMeasurementSystem();
@@ -267,8 +261,8 @@ public class MwmActivity extends BaseMwmFragmentActivity
    */
   private void processIntent()
   {
-    if (!isMapRendererActive())
-      throw new AssertionError("Must be called when rendering is active");
+    if (!Map.isEngineCreated())
+      throw new AssertionError("Must be called with initialized Drape");
 
     final Intent intent = getIntent();
     if (intent == null || intent.getBooleanExtra(EXTRA_CONSUMED, false))
@@ -513,6 +507,16 @@ public class MwmActivity extends BaseMwmFragmentActivity
 
     if (getIntent().getBooleanExtra(EXTRA_UPDATE_THEME, false))
       ThemeSwitcher.INSTANCE.restart(isMapRendererActive());
+
+    /*
+     * onRenderingInitializationFinished() hook is not called when MwmActivity is recreated with the already
+     * initialized Drape engine. This can happen when the activity is swiped away from the most recent app lists
+     * during navigation and then restarted from the launcher. Call this hook explicitly here to run operations
+     * that require initialized Drape, such as restoring navigation and processing incoming intents.
+     * https://github.com/organicmaps/organicmaps/issues/6712
+     */
+    if (Map.isEngineCreated())
+      onRenderingInitializationFinished();
   }
 
   private void refreshLightStatusBar()


### PR DESCRIPTION
Swiping the app away from the recent app lists during navigation doesn't kill the app process because of the active foreground navigation service. The next start of MwmActivity should properly restore all the navigation UI if the background navigation was already in progress. This logic was moved to MwmActivity.onRenderingInitializationFinished() by fe06fc8429 #6556 "Refactor API and Intent processing" to fix weird race conditions when restoring the route without initialized drape.

The issue was that onRenderingInitializationFinished() was not called when MwmActivity was recreated with already initialized native core. Call it explicitly from MwmActivity.onSafeCreate() to initialize navigation UI and handle incoming intents.

Fixes #6712