### PR TITLE
[android] PoC - Enable outdoor + isolines together

### DIFF
--- a/android/app/src/main/java/app/organicmaps/Framework.java
+++ b/android/app/src/main/java/app/organicmaps/Framework.java
@@ -38,7 +38,7 @@ import java.util.Locale;
 public class Framework
 {
   @Retention(RetentionPolicy.SOURCE)
-  @IntDef({MAP_STYLE_CLEAR, MAP_STYLE_DARK, MAP_STYLE_VEHICLE_CLEAR, MAP_STYLE_VEHICLE_DARK})
+  @IntDef({MAP_STYLE_CLEAR, MAP_STYLE_DARK, MAP_STYLE_VEHICLE_CLEAR, MAP_STYLE_VEHICLE_DARK, MAP_STYLE_OUTDOORS_CLEAR, MAP_STYLE_OUTDOORS_DARK})
 
   public @interface MapStyle {}
 
@@ -46,6 +46,8 @@ public class Framework
   public static final int MAP_STYLE_DARK = 1;
   public static final int MAP_STYLE_VEHICLE_CLEAR = 3;
   public static final int MAP_STYLE_VEHICLE_DARK = 4;
+  public static final int MAP_STYLE_OUTDOORS_CLEAR = 5;
+  public static final int MAP_STYLE_OUTDOORS_DARK = 6;
 
   @Retention(RetentionPolicy.SOURCE)
   @IntDef({ ROUTER_TYPE_VEHICLE, ROUTER_TYPE_PEDESTRIAN, ROUTER_TYPE_BICYCLE, ROUTER_TYPE_TRANSIT, ROUTER_TYPE_RULER })

--- a/android/app/src/main/java/app/organicmaps/maplayer/Mode.java
+++ b/android/app/src/main/java/app/organicmaps/maplayer/Mode.java
@@ -51,7 +51,7 @@ public enum Mode
         @Override
         public void setEnabled(@NonNull Context context, boolean isEnabled)
         {
-          IsolinesManager.from(context).setEnabled(isEnabled);
+          IsolinesManager.from(context).setEnabled(context, isEnabled);
         }
       };
   

--- a/android/app/src/main/java/app/organicmaps/maplayer/isolines/IsolinesManager.java
+++ b/android/app/src/main/java/app/organicmaps/maplayer/isolines/IsolinesManager.java
@@ -7,6 +7,8 @@ import androidx.annotation.NonNull;
 
 import app.organicmaps.Framework;
 import app.organicmaps.MwmApplication;
+import app.organicmaps.util.ThemeSwitcher;
+import app.organicmaps.util.ThemeUtils;
 
 public class IsolinesManager
 {
@@ -28,17 +30,29 @@ public class IsolinesManager
     nativeAddListener(mListener);
   }
 
-  public void setEnabled(boolean isEnabled)
+  public void setEnabled(@NonNull Context context, boolean isEnabled)
   {
     if (isEnabled == isEnabled())
       return;
 
     Framework.nativeSetIsolinesLayerEnabled(isEnabled);
-  }
-
-  public void toggle()
-  {
-    setEnabled(!isEnabled());
+    @Framework.MapStyle
+    int newMapStyle;
+    if (isEnabled)
+    {
+      if (ThemeUtils.isDefaultTheme(context))
+        newMapStyle = Framework.MAP_STYLE_OUTDOORS_CLEAR;
+      else
+        newMapStyle = Framework.MAP_STYLE_OUTDOORS_DARK;
+    }
+    else
+    {
+      if (ThemeUtils.isDefaultTheme(context))
+        newMapStyle = Framework.MAP_STYLE_CLEAR;
+      else
+        newMapStyle = Framework.MAP_STYLE_DARK;
+    }
+    ThemeSwitcher.SetMapStyle(newMapStyle);
   }
 
   public void initialize()

--- a/android/app/src/main/java/app/organicmaps/util/ThemeSwitcher.java
+++ b/android/app/src/main/java/app/organicmaps/util/ThemeSwitcher.java
@@ -56,7 +56,7 @@ public enum ThemeSwitcher
 
   @SuppressWarnings("NotNullFieldNotInitialized")
   @NonNull
-  private Context mContext;
+  private static Context mContext;
 
   public void initialize(@NonNull Context context)
   {
@@ -98,11 +98,21 @@ public enum ThemeSwitcher
   private void changeMapStyle(@NonNull String newTheme, @NonNull String oldTheme)
   {
     @Framework.MapStyle
-    int style = RoutingController.get().isVehicleNavigation()
-                ? Framework.MAP_STYLE_VEHICLE_CLEAR : Framework.MAP_STYLE_CLEAR;
-    if (ThemeUtils.isNightTheme(mContext, newTheme))
+    int style;
+    if (newTheme.equals(Framework.MAP_STYLE_OUTDOORS_CLEAR) || newTheme.equals(Framework.MAP_STYLE_OUTDOORS_DARK))
+    {
+      style = Framework.MAP_STYLE_OUTDOORS_CLEAR;
+      if (ThemeUtils.isNightTheme(mContext, newTheme))
+        style = Framework.MAP_STYLE_OUTDOORS_DARK;
+    }
+    else
+    {
       style = RoutingController.get().isVehicleNavigation()
-              ? Framework.MAP_STYLE_VEHICLE_DARK : Framework.MAP_STYLE_DARK;
+              ? Framework.MAP_STYLE_VEHICLE_CLEAR : Framework.MAP_STYLE_CLEAR;
+      if (ThemeUtils.isNightTheme(mContext, newTheme))
+        style = RoutingController.get().isVehicleNavigation()
+                ? Framework.MAP_STYLE_VEHICLE_DARK : Framework.MAP_STYLE_DARK;
+    }
 
     if (!newTheme.equals(oldTheme))
     {
@@ -124,7 +134,7 @@ public enum ThemeSwitcher
     }
   }
 
-  private void SetMapStyle(@Framework.MapStyle int style)
+  public static void SetMapStyle(@Framework.MapStyle int style)
   {
     // Because of the distinct behavior in auto theme, Android Auto employs its own mechanism for theme switching.
     // For the Android Auto theme switcher, please consult the app.organicmaps.car.util.ThemeUtils module.


### PR DESCRIPTION
I didn't get the idea of having two separate "Contour lines" and "Outdoor" layers. Why don't enable both? Here is a stripped-down version of #6732 that enables both "Outdoor" and"Contour lines" using the existing button (which can be renamed to "Outdoor" later).

Known issue: the setting is not saved after restart, but I know how to fix it.

<img src="https://github.com/organicmaps/organicmaps/assets/1799054/76a3f7d6-d589-4864-aa79-07566bd5ad23" width="350px">
<img src="https://github.com/organicmaps/organicmaps/assets/1799054/102c9968-1de7-4029-8879-842609a0bdd3" width="350px">
