### PR TITLE
Search results description refactor to move code to c++ core

### DIFF
--- a/android/app/src/main/cpp/app/organicmaps/SearchEngine.cpp
+++ b/android/app/src/main/cpp/app/organicmaps/SearchEngine.cpp
@@ -106,22 +106,16 @@ jobject ToJavaResult(Result const & result, search::ProductInfo const & productI
   jni::TScopedLocalRef featureId(env, usermark_helper::CreateFeatureId(env, isFeature ?
                                                                             result.GetFeatureID() :
                                                                             kEmptyFeatureId));
-  string readableType = isFeature ? classif().GetReadableObjectName(result.GetFeatureType()) : "";
+  std::string const localizedType = isFeature ? result.GetLocalizedFeatureType() : "";
 
-  jni::TScopedLocalRef featureType(env, jni::ToJavaString(env, readableType));
+  jni::TScopedLocalRef featureType(env, jni::ToJavaString(env, localizedType));
   jni::TScopedLocalRef address(env, jni::ToJavaString(env, result.GetAddress()));
   jni::TScopedLocalRef dist(env, ToJavaDistance(env, distance));
-  jni::TScopedLocalRef cuisine(env, jni::ToJavaString(env, result.GetCuisine()));
-  jni::TScopedLocalRef brand(env, jni::ToJavaString(env, result.GetBrand()));
-  jni::TScopedLocalRef airportIata(env, jni::ToJavaString(env, result.GetAirportIata()));
-  jni::TScopedLocalRef roadShields(env, jni::ToJavaString(env, result.GetRoadShields()));
-  jni::TScopedLocalRef fee(env, jni::ToJavaString(env, result.GetFee()));
-
+  jni::TScopedLocalRef description(env, jni::ToJavaString(env, result.GetFeatureDescription()));
 
   jni::TScopedLocalRef desc(env, env->NewObject(g_descriptionClass, g_descriptionConstructor,
                                                 featureId.get(), featureType.get(), address.get(),
-                                                dist.get(), cuisine.get(), brand.get(), airportIata.get(),
-                                                roadShields.get(), fee.get(),
+                                                dist.get(), description.get(),
                                                 static_cast<jint>(result.IsOpenNow()),
                                                 result.GetMinutesUntilOpen(),result.GetMinutesUntilClosed(),
                                                 static_cast<jboolean>(popularityHasHigherPriority)));
@@ -133,7 +127,7 @@ jobject ToJavaResult(Result const & result, search::ProductInfo const & productI
                                                       0/*static_cast<jint>(result.GetRankingInfo().m_popularity)*/));
 
   return env->NewObject(g_resultClass, g_resultConstructor, name.get(), desc.get(), ll.m_lat, ll.m_lon,
-                        ranges.get(), result.IsHotel(), result.GetStarsCount(), popularity.get());
+                        ranges.get(), popularity.get());
 }
 
 jobjectArray BuildSearchResults(vector<search::ProductInfo> const & productInfo,
@@ -240,21 +234,19 @@ extern "C"
     g_resultClass = jni::GetGlobalClassRef(env, "app/organicmaps/search/SearchResult");
     g_resultConstructor = jni::GetConstructorID(
         env, g_resultClass,
-        "(Ljava/lang/String;Lapp/organicmaps/search/SearchResult$Description;DD[IZI"
+        "(Ljava/lang/String;Lapp/organicmaps/search/SearchResult$Description;DD[I"
           "Lapp/organicmaps/search/Popularity;)V");
     g_suggestConstructor = jni::GetConstructorID(env, g_resultClass, "(Ljava/lang/String;Ljava/lang/String;DD[I)V");
     g_descriptionClass = jni::GetGlobalClassRef(env, "app/organicmaps/search/SearchResult$Description");
     /*
         Description(FeatureId featureId, String featureType, String region, Distance distance,
-                    String cuisine, String brand, String airportIata, String roadShields,
-                    String fee, int openNow, int minutesUntilOpen, int minutesUntilClosed,
+                    String description, int openNow, int minutesUntilOpen, int minutesUntilClosed,
                     boolean hasPopularityHigherPriority)
     */
     g_descriptionConstructor = jni::GetConstructorID(env, g_descriptionClass,
                                                      "(Lapp/organicmaps/bookmarks/data/FeatureId;"
                                                      "Ljava/lang/String;Ljava/lang/String;Lapp/organicmaps/util/Distance;"
-                                                     "Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;"
-                                                     "Ljava/lang/String;Ljava/lang/String;IIIZ)V");
+                                                     "Ljava/lang/String;IIIZ)V");
 
     g_popularityClass = jni::GetGlobalClassRef(env, "app/organicmaps/search/Popularity");
     g_popularityConstructor = jni::GetConstructorID(env, g_popularityClass, "(I)V");

--- a/android/app/src/main/java/app/organicmaps/car/screens/search/SearchOnMapScreen.java
+++ b/android/app/src/main/java/app/organicmaps/car/screens/search/SearchOnMapScreen.java
@@ -88,7 +88,7 @@ public class SearchOnMapScreen extends BaseMapScreen implements NativeSearchList
     {
       final String title = result.getTitle(getCarContext());
       builder.setTitle(title);
-      builder.addText(result.getFormattedDescription(getCarContext()));
+      builder.addText(result.description.description);
 
       final CharSequence openingHours = SearchUiHelpers.getOpeningHoursText(getCarContext(), result);
       final CharSequence distance = SearchUiHelpers.getDistanceText(result);

--- a/android/app/src/main/java/app/organicmaps/car/screens/search/SearchScreen.java
+++ b/android/app/src/main/java/app/organicmaps/car/screens/search/SearchScreen.java
@@ -135,7 +135,7 @@ public class SearchScreen extends BaseMapScreen implements SearchTemplate.Search
     {
       final String title = result.getTitle(getCarContext());
       builder.setTitle(title);
-      builder.addText(result.getFormattedDescription(getCarContext()));
+      builder.addText(result.description.description);
       final CharSequence openingHoursAndDistance = SearchUiHelpers.getOpeningHoursAndDistanceText(getCarContext(), result);
       if (openingHoursAndDistance.length() != 0)
         builder.addText(openingHoursAndDistance);

--- a/android/app/src/main/java/app/organicmaps/search/SearchAdapter.java
+++ b/android/app/src/main/java/app/organicmaps/search/SearchAdapter.java
@@ -137,7 +137,7 @@ class SearchAdapter extends RecyclerView.Adapter<SearchAdapter.SearchDataViewHol
       setBackground();
 
       formatOpeningHours(mResult);
-      UiUtils.setTextAndHideIfEmpty(mDescription, mResult.getFormattedDescription(mFrame.getContext()));
+      UiUtils.setTextAndHideIfEmpty(mDescription, mResult.description.description);
       UiUtils.setTextAndHideIfEmpty(mRegion, mResult.description.region);
       UiUtils.setTextAndHideIfEmpty(mDistance, mResult.description.distance.toString(mFrame.getContext()));
     }

--- a/android/app/src/main/java/app/organicmaps/search/SearchResult.java
+++ b/android/app/src/main/java/app/organicmaps/search/SearchResult.java
@@ -145,11 +145,4 @@ public class SearchResult
 
     return builder;
   }
-
-  // FIXME: Better format based on result type
-  @NonNull
-  public CharSequence getFormattedDescription(@NonNull Context context)
-  {
-    return description.description;
-  }
 }

--- a/android/app/src/main/java/app/organicmaps/search/SearchResult.java
+++ b/android/app/src/main/java/app/organicmaps/search/SearchResult.java
@@ -44,31 +44,23 @@ public class SearchResult
     public final String featureType;
     public final String region;
     public final Distance distance;
-    public final String cuisine;
-    public final String brand;
-    public final String airportIata;
-    public final String roadShields;
 
-    public final String fee;
+    public final String description;
+
     public final int openNow;
     public final int minutesUntilOpen;
     public final int minutesUntilClosed;
     public final boolean hasPopularityHigherPriority;
 
     public Description(FeatureId featureId, String featureType, String region, Distance distance,
-                       String cuisine, String brand, String airportIata, String roadShields,
-                       String fee, int openNow, int minutesUntilOpen, int minutesUntilClosed,
+                       String description, int openNow, int minutesUntilOpen, int minutesUntilClosed,
                        boolean hasPopularityHigherPriority)
     {
       this.featureId = featureId;
       this.featureType = featureType;
       this.region = region;
       this.distance = distance;
-      this.cuisine = cuisine;
-      this.brand = brand;
-      this.airportIata = airportIata;
-      this.roadShields = roadShields;
-      this.fee = fee;
+      this.description = description;
       this.openNow = openNow;
       this.minutesUntilOpen = minutesUntilOpen;
       this.minutesUntilClosed = minutesUntilClosed;
@@ -87,8 +79,6 @@ public class SearchResult
   // Consecutive pairs of indexes (each pair contains : start index, length), specifying highlighted matches of original query in result
   public final int[] highlightRanges;
 
-  public final int stars;
-  public final boolean isHotel;
   @NonNull
   private final Popularity mPopularity;
 
@@ -98,8 +88,6 @@ public class SearchResult
     this.suggestion = suggestion;
     this.lat = lat;
     this.lon = lon;
-    this.stars = 0;
-    this.isHotel = false;
     this.description = null;
     // Looks like a hack, but it's fine. Otherwise, should make one more ctor and JNI code bloat.
     if (lat == 0 && lon == 0)
@@ -111,12 +99,10 @@ public class SearchResult
   }
 
   public SearchResult(String name, Description description, double lat, double lon, int[] highlightRanges,
-                      boolean isHotel, int stars, @NonNull Popularity popularity)
+                      @NonNull Popularity popularity)
   {
     this.type = TYPE_RESULT;
     this.name = name;
-    this.stars = stars;
-    this.isHotel = isHotel;
     mPopularity = popularity;
     this.suggestion = null;
     this.lat = lat;
@@ -131,9 +117,7 @@ public class SearchResult
     String title = name;
     if (TextUtils.isEmpty(title))
     {
-      title = description != null
-          ? Utils.getLocalizedFeatureType(context, description.featureType)
-          : "";
+      title = description != null ? description.featureType : "";
     }
 
     return title;
@@ -166,30 +150,6 @@ public class SearchResult
   @NonNull
   public CharSequence getFormattedDescription(@NonNull Context context)
   {
-    final String localizedType = Utils.getLocalizedFeatureType(context, description.featureType);
-    final SpannableStringBuilder res = new SpannableStringBuilder(localizedType);
-    final SpannableStringBuilder tail = new SpannableStringBuilder();
-
-    if (!TextUtils.isEmpty(description.airportIata))
-      tail.append(" • ").append(description.airportIata);
-    else if (!TextUtils.isEmpty(description.roadShields))
-      tail.append(" • ").append(description.roadShields);
-    else
-    {
-      if (!TextUtils.isEmpty(description.brand))
-        tail.append(" • ").append(Utils.getLocalizedBrand(context, description.brand));
-      if (!TextUtils.isEmpty(description.cuisine))
-        tail.append(" • ").append(description.cuisine);
-    }
-
-    if (!TextUtils.isEmpty(description.fee))
-      tail.append(" • ").append(description.fee);
-
-    if (isHotel && stars != 0)
-      tail.append(" • ").append("★★★★★★★".substring(0, Math.min(7, stars)));
-
-    res.append(tail);
-
-    return res;
+    return description.description;
   }
 }

--- a/indexer/map_object.cpp
+++ b/indexer/map_object.cpp
@@ -28,8 +28,6 @@ constexpr char const * kYes = "yes";
 constexpr char const * kNo = "no";
 }  // namespace
 
-char const * MapObject::kFieldsSeparator = " • ";
-
 string DebugPrint(osm::Internet internet)
 {
   switch (internet)

--- a/indexer/map_object.hpp
+++ b/indexer/map_object.hpp
@@ -33,7 +33,8 @@ Internet InternetFromString(std::string_view inet);
 class MapObject
 {
 public:
-  static char const * kFieldsSeparator;
+  static constexpr std::string_view kFieldsSeparator = " • ";
+  static constexpr std::string_view kStarSymbol = "★";
   static constexpr uint8_t kMaxStarsCount = 7;
 
   void SetFromFeatureType(FeatureType & ft);

--- a/iphone/Maps/UI/Search/TableView/MWMSearchCommonCell.mm
+++ b/iphone/Maps/UI/Search/TableView/MWMSearchCommonCell.mm
@@ -31,40 +31,8 @@
 
   self.locationLabel.text = @(result.GetAddress().c_str());
   [self.locationLabel sizeToFit];
-
-  int const starsCount = std::min(7, result.GetStarsCount());
-  NSString * cuisine = @(result.GetCuisine().c_str()).capitalizedString;
-  NSString * airportIata = @(result.GetAirportIata().c_str());
-  NSString * roadShields = @(result.GetRoadShields().c_str());
-  NSString * fee = @(result.GetFee().c_str());
-  NSString * brand  = @"";
-  if (!result.GetBrand().empty())
-    brand = @(platform::GetLocalizedBrandName(result.GetBrand()).c_str());
   
-  NSString * description = @"";
-
-  if (result.IsHotel() && starsCount > 0)
-  {
-    static NSString * sevenStars = [NSString stringWithUTF8String:"★★★★★★★"];
-    description = [sevenStars substringToIndex:starsCount];
-  }
-  else if (airportIata.length > 0)
-    description = airportIata;
-  else if (roadShields.length > 0)
-    description = roadShields;
-  else if (brand.length > 0 && cuisine.length > 0)
-    description = [NSString stringWithFormat:@"%@ • %@", brand, cuisine];
-  else if (brand.length > 0)
-    description = brand;
-  else if (cuisine.length > 0)
-    description = cuisine;
-  else if (fee.length > 0)
-    description = fee;
-  
-  if ([description length] == 0)
-    self.infoLabel.text = localizedTypeName;
-  else
-    self.infoLabel.text = [NSString stringWithFormat:@"%@ • %@", localizedTypeName, description];
+  self.infoLabel.text = @(result.GetFeatureDescription().c_str());
 
   CLLocation * lastLocation = [MWMLocationManager lastLocation];
   double distanceInMeters = 0.0;

--- a/iphone/Maps/UI/Search/TableView/MWMSearchTableViewController.mm
+++ b/iphone/Maps/UI/Search/TableView/MWMSearchTableViewController.mm
@@ -11,9 +11,7 @@ NSString *GetLocalizedTypeName(search::Result const &result) {
   if (result.GetResultType() != search::Result::Type::Feature)
     return @"";
 
-  auto const readableType = classif().GetReadableObjectName(result.GetFeatureType());
-
-  return @(platform::GetLocalizedTypeName(readableType).c_str());
+  return @(result.GetLocalizedFeatureType().c_str());
 }
 }
 

--- a/map/framework.cpp
+++ b/map/framework.cpp
@@ -1418,11 +1418,7 @@ void Framework::FillSearchResultsMarks(SearchResultsIterT beg, SearchResultsIter
     {
       auto const fID = r.GetFeatureID();
       mark->SetFoundFeature(fID);
-
-      if (r.m_details.m_isHotel)
-        mark->SetHotelType();
-      else
-        mark->SetFromType(r.GetFeatureType());
+      mark->SetFromType(r.GetFeatureType());
       mark->SetVisited(m_searchMarks.IsVisited(fID));
       mark->SetSelected(m_searchMarks.IsSelected(fID));
     }

--- a/map/place_page_info.cpp
+++ b/map/place_page_info.cpp
@@ -19,10 +19,9 @@
 
 namespace place_page
 {
-char const * const Info::kStarSymbol = "★";
-char const * const Info::kMountainSymbol = "▲";
-char const * const kWheelchairSymbol = "\u267F";
-char const * const kAtmSymbol = "💳";
+static constexpr std::string_view kMountainSymbol= "▲";
+static constexpr std::string_view kWheelchairSymbol = "♿️";
+static constexpr std::string_view kAtmSymbol = "💳";
 
 bool Info::IsBookmark() const
 {
@@ -162,7 +161,10 @@ std::string Info::FormatSubtitle(bool withType) const
   // Elevation.
   auto const eleStr = GetElevationFormatted();
   if (!eleStr.empty())
-    append(kMountainSymbol + eleStr);
+  {
+    append(kMountainSymbol);
+    append(eleStr);
+  }
     
   // ATM
   if (HasAtm())
@@ -301,7 +303,7 @@ std::string Info::FormatStars() const
 {
   std::string stars;
   for (int i = 0; i < GetStars(); ++i)
-    stars.append(kStarSymbol);
+    stars.append(MapObject::kStarSymbol);
   return stars;
 }
 

--- a/map/place_page_info.hpp
+++ b/map/place_page_info.hpp
@@ -104,8 +104,6 @@ struct BuildInfo
 class Info : public osm::MapObject
 {
 public:
-  static char const * const kStarSymbol;
-  static char const * const kMountainSymbol;
 
   void SetBuildInfo(place_page::BuildInfo const & info) { m_buildInfo = info; }
   place_page::BuildInfo const & GetBuildInfo() const { return m_buildInfo; }

--- a/map/search_mark.cpp
+++ b/map/search_mark.cpp
@@ -167,7 +167,15 @@ private:
       {{"shop", "toys"},             SearchMarkType::ShopToys},
       {{"tourism", "theme_park"},    SearchMarkType::ThemePark},
       {{"leisure", "water_park"},    SearchMarkType::WaterPark},
-      {{"tourism", "zoo"},           SearchMarkType::Zoo}
+      {{"tourism", "zoo"},           SearchMarkType::Zoo},
+      {{"tourism", "hotel"},         SearchMarkType::Hotel},
+      {{"tourism", "apartment"},     SearchMarkType::Hotel},
+      {{"tourism", "camp_site"},     SearchMarkType::Hotel},
+      {{"tourism", "chalet"},        SearchMarkType::Hotel},
+      {{"tourism", "guest_house"},   SearchMarkType::Hotel},
+      {{"tourism", "hostel"},        SearchMarkType::Hotel},
+      {{"tourism", "motel"},         SearchMarkType::Hotel},
+      {{"tourism", "resort"},        SearchMarkType::Hotel}
     };
 
     m_searchMarkTypes.reserve(table.size());
@@ -269,11 +277,6 @@ void SearchMarkPoint::SetMatchedName(std::string const & name)
 void SearchMarkPoint::SetFromType(uint32_t type)
 {
   SetAttributeValue(m_type, GetSearchMarkType(type));
-}
-
-void SearchMarkPoint::SetHotelType()
-{
-  SetAttributeValue(m_type, SearchMarkType::Hotel);
 }
 
 void SearchMarkPoint::SetNotFoundType()

--- a/map/search_mark.hpp
+++ b/map/search_mark.hpp
@@ -48,7 +48,6 @@ public:
   void SetMatchedName(std::string const & name);
 
   void SetFromType(uint32_t type);
-  void SetHotelType();
   void SetNotFoundType();
 
   void SetPreparing(bool isPreparing);

--- a/search/result.cpp
+++ b/search/result.cpp
@@ -5,6 +5,8 @@
 
 #include "indexer/classificator.hpp"
 
+#include "platform/localization.hpp"
+
 #include "geometry/mercator.hpp"
 
 #include "base/string_utils.hpp"
@@ -62,6 +64,18 @@ uint32_t Result::GetFeatureType() const
 {
   ASSERT_EQUAL(m_resultType, Type::Feature, ());
   return m_featureType;
+}
+
+std::string Result::GetLocalizedFeatureType() const
+{
+  ASSERT_EQUAL(m_resultType, Type::Feature, ());
+  return platform::GetLocalizedTypeName(classif().GetReadableObjectName(m_featureType));
+}
+
+std::string Result::GetFeatureDescription() const
+{
+  ASSERT_EQUAL(m_resultType, Type::Feature, ());
+  return GetLocalizedFeatureType() + GetDescription();
 }
 
 m2::PointD Result::GetFeatureCenter() const

--- a/search/result.hpp
+++ b/search/result.hpp
@@ -44,30 +44,13 @@ public:
   // Search results details. Considered valid if GetResultType() == Type::Feature.
   struct Details
   {
-    // Valid only if not empty, used for restaurants.
-    std::string m_cuisine;
-
-    // Valid only if not empty, used for airport iata codes.
-    std::string m_airportIata;
-
-    // Valid only if not empty, used for brand name.
-    std::string m_brand;
-
-    // Valid only if not empty, used for roads.
-    std::string m_roadShields;
-
-    // Following fields are used for hotels only.
-    uint8_t m_stars = 0;
-    bool m_isHotel = false;
-
-    // Valid for any result.
     osm::YesNoUnknown m_isOpenNow = osm::Unknown;
 
     uint16_t m_minutesUntilOpen = 0;
 
     uint16_t m_minutesUntilClosed = 0;
       
-    std::string m_fee;
+    std::string m_description;
 
     bool m_isInitialized = false;
   };
@@ -91,17 +74,11 @@ public:
 
   std::string const & GetString() const { return m_str; }
   std::string const & GetAddress() const { return m_address; }
-  std::string const & GetCuisine() const { return m_details.m_cuisine; }
-  std::string const & GetAirportIata() const { return m_details.m_airportIata; }
-  std::string const & GetBrand() const { return m_details.m_brand; }
-  std::string const & GetRoadShields() const { return m_details.m_roadShields; }
-  std::string const & GetFee() const { return m_details.m_fee; }
-  bool IsHotel() const { return m_details.m_isHotel; }
+  std::string const & GetDescription() const { return m_details.m_description; }
 
   osm::YesNoUnknown IsOpenNow() const { return m_details.m_isOpenNow; }
   uint16_t GetMinutesUntilOpen() const { return m_details.m_minutesUntilOpen; }
   uint16_t GetMinutesUntilClosed() const { return m_details.m_minutesUntilClosed; }
-  int GetStarsCount() const { return m_details.m_stars; }
 
   bool IsSuggest() const;
   bool HasPoint() const;
@@ -112,6 +89,12 @@ public:
 
   // Precondition: GetResultType() == Type::Feature.
   uint32_t GetFeatureType() const;
+  
+  // Precondition: GetResultType() == Type::Feature.
+  std::string GetLocalizedFeatureType() const;
+  
+  // Precondition: GetResultType() == Type::Feature.
+  std::string GetFeatureDescription() const;
 
   // Center point of a feature.
   // Precondition: HasPoint() == true.


### PR DESCRIPTION
When I was working on PR https://github.com/organicmaps/organicmaps/pull/5883 I noticed that there was some duplicate code for generating the description details in the search results. There was basically the same code in Objective-C++ for iOS and in Java for Android. So I had to make the changes in two separate places, one for each platform.

In this PR I have moved all the description details generation code to the C++ core to make it simpler. This will make it easier for future PRs as changes will have to be done only in one place. 

Search results user-facing behavior should be the same as before, no changes there.