### PR TITLE
Revert "[drape] Added Spline::AddOrProlongPoint."

### DIFF
--- a/drape_frontend/apply_feature_functors.hpp
+++ b/drape_frontend/apply_feature_functors.hpp
@@ -158,8 +158,9 @@ private:
   m2::SharedSpline m_spline;
   std::vector<m2::SharedSpline> m_clippedSplines;
   double const m_currentScaleGtoP;
+  double const m_minSegmentSqrLength;
+  m2::PointD m_lastAddedPoint;
   bool const m_simplify;
-  double const m_minSegSqLength;
 
 #ifdef LINES_GENERATION_CALC_FILTERED_POINTS
   int m_readCount = 0;

--- a/geometry/clipping.cpp
+++ b/geometry/clipping.cpp
@@ -147,6 +147,7 @@ void ClipPathByRectImpl(m2::RectD const & rect, std::vector<m2::PointD> const & 
   int code1 = 0;
   int code2 = 0;
   m2::SharedSpline s;
+  s.Reset(new m2::Spline(sz));
 
   for (size_t i = 0; i < sz - 1; i++)
   {
@@ -155,7 +156,7 @@ void ClipPathByRectImpl(m2::RectD const & rect, std::vector<m2::PointD> const & 
     if (m2::Intersect(rect, p1, p2, code1, code2))
     {
       if (s.IsNull())
-        s = m2::SharedSpline(sz - i);
+        s.Reset(new m2::Spline(sz - i));
 
       s->AddPoint(p1);
       s->AddPoint(p2);
@@ -163,15 +164,15 @@ void ClipPathByRectImpl(m2::RectD const & rect, std::vector<m2::PointD> const & 
       if (code2 != 0 || i + 2 == sz)
       {
         if (s->GetSize() > 1)
-          fn(std::move(s));
-        s.Reset();
+            fn(std::move(s));
+        s.Reset(nullptr);
       }
     }
     else if (!s.IsNull() && !s->IsEmpty())
     {
       if (s->GetSize() > 1)
         fn(std::move(s));
-      s.Reset();
+      s.Reset(nullptr);
     }
   }
 }

--- a/geometry/geometry_tests/clipping_test.cpp
+++ b/geometry/geometry_tests/clipping_test.cpp
@@ -50,7 +50,8 @@ vector<m2::SharedSpline> ConstructSplineList(vector<vector<m2::PointD>> const & 
   result.reserve(segments.size());
   for (size_t i = 0; i < segments.size(); i++)
   {
-    m2::SharedSpline s(segments[i].size());
+    m2::SharedSpline s;
+    s.Reset(new m2::Spline(segments[i].size()));
     for (size_t j = 0; j < segments[i].size(); j++)
       s->AddPoint(segments[i][j]);
     result.push_back(std::move(s));
@@ -211,7 +212,8 @@ UNIT_TEST(Clipping_ClipSplineByRect)
   m2::RectD r(-1.0, -1.0, 1.0, 1.0);
 
   // Intersection.
-  m2::SharedSpline spline1(2);
+  m2::SharedSpline spline1;
+  spline1.Reset(new m2::Spline(2));
   spline1->AddPoint(m2::PointD(-2.0, 0.0));
   spline1->AddPoint(m2::PointD(2.0, 1.0));
   vector<m2::SharedSpline> result1 = m2::ClipSplineByRect(r, spline1);
@@ -219,7 +221,8 @@ UNIT_TEST(Clipping_ClipSplineByRect)
   TEST(CompareSplineLists(result1, expectedResult1), ());
 
   // Intersection. Several segments.
-  m2::SharedSpline spline2(4);
+  m2::SharedSpline spline2;
+  spline2.Reset(new m2::Spline(4));
   spline2->AddPoint(m2::PointD(-2.0, 0.0));
   spline2->AddPoint(m2::PointD(2.0, 1.0));
   spline2->AddPoint(m2::PointD(0.5, -2.0));
@@ -230,7 +233,8 @@ UNIT_TEST(Clipping_ClipSplineByRect)
   TEST(CompareSplineLists(result2, expectedResult2), ());
 
   // Completely outside.
-  m2::SharedSpline spline3(2);
+  m2::SharedSpline spline3;
+  spline3.Reset(new m2::Spline(2));
   spline3->AddPoint(m2::PointD(-2.0, 2.0));
   spline3->AddPoint(m2::PointD(2.0, 3.0));
   vector<m2::SharedSpline> result3 = m2::ClipSplineByRect(r, spline3);
@@ -238,7 +242,8 @@ UNIT_TEST(Clipping_ClipSplineByRect)
   TEST(CompareSplineLists(result3, expectedResult3), ());
 
   // Completely inside.
-  m2::SharedSpline spline4(2);
+  m2::SharedSpline spline4;
+  spline4.Reset(new m2::Spline(2));
   spline4->AddPoint(m2::PointD(-0.5, 0.0));
   spline4->AddPoint(m2::PointD(0.5, 0.5));
   vector<m2::SharedSpline> result4 = m2::ClipSplineByRect(r, spline4);
@@ -246,7 +251,8 @@ UNIT_TEST(Clipping_ClipSplineByRect)
   TEST(CompareSplineLists(result4, expectedResult4), ());
 
   // Intersection. Long spline.
-  m2::SharedSpline spline5(4);
+  m2::SharedSpline spline5;
+  spline5.Reset(new m2::Spline(4));
   spline5->AddPoint(m2::PointD(-2.0, 0.0));
   spline5->AddPoint(m2::PointD(0.0, 0.0));
   spline5->AddPoint(m2::PointD(0.5, 0.5));
@@ -257,7 +263,8 @@ UNIT_TEST(Clipping_ClipSplineByRect)
   TEST(CompareSplineLists(result5, expectedResult5), ());
 
   // Intersection. Several segments.
-  m2::SharedSpline spline6(5);
+  m2::SharedSpline spline6;
+  spline6.Reset(new m2::Spline(5));
   spline6->AddPoint(m2::PointD(-1.0, 0.0));
   spline6->AddPoint(m2::PointD(-0.5, 1.0));
   spline6->AddPoint(m2::PointD(-0.5, 1.000000001));

--- a/geometry/geometry_tests/spline_test.cpp
+++ b/geometry/geometry_tests/spline_test.cpp
@@ -1,5 +1,6 @@
 #include "testing/testing.hpp"
 
+#include "geometry/geometry_tests/equality.hpp"
 #include "geometry/spline.hpp"
 
 #include <vector>
@@ -19,7 +20,7 @@ void TestPointDDir(PointD const & dst, PointD const & src)
   TEST_ALMOST_EQUAL_ULPS(dst.y/len1, src.y/len2, ());
 }
 
-UNIT_TEST(Spline_SmoothedDirections)
+UNIT_TEST(SmoothedDirections)
 {
   vector<PointD> path;
   path.push_back(PointD(0, 0));
@@ -60,7 +61,7 @@ UNIT_TEST(Spline_SmoothedDirections)
   TestPointDDir(itr.m_avrDir, dir12 * 0.5 + dir2 * 0.5);
 }
 
-UNIT_TEST(Spline_UsualDirections)
+UNIT_TEST(UsualDirections)
 {
   vector<PointD> path;
   path.push_back(PointD(0, 0));
@@ -99,7 +100,7 @@ UNIT_TEST(Spline_UsualDirections)
   TestPointDDir(itr.m_dir, dir2);
 }
 
-UNIT_TEST(Spline_Positions)
+UNIT_TEST(Positions)
 {
   vector<PointD> path;
   path.push_back(PointD(0, 0));
@@ -148,7 +149,7 @@ UNIT_TEST(Spline_Positions)
   TestPointDDir(itr.m_pos, PointD(80, 40));
 }
 
-UNIT_TEST(Spline_BeginAgain)
+UNIT_TEST(BeginAgain)
 {
   vector<PointD> path;
   path.push_back(PointD(0, 0));
@@ -187,7 +188,7 @@ UNIT_TEST(Spline_BeginAgain)
   TEST_EQUAL(itr.BeginAgain(), true, ());
 }
 
-UNIT_TEST(Spline_Length)
+UNIT_TEST(Length)
 {
   vector<PointD> path;
   PointD const p1(27.5536633, 64.2492523);
@@ -209,34 +210,4 @@ UNIT_TEST(Spline_Length)
   double len2 = l1 + l2 + l3 + l4;
   TEST_ALMOST_EQUAL_ULPS(len1, len2, ());
 }
-
-bool EqualLast(Spline const & spl, PointD const & pt)
-{
-  return base::AlmostEqualULPs(spl.GetPath().back(), pt);
-}
-
-UNIT_TEST(Spline_AddOrProlong)
-{
-  double constexpr minSegSqLength = 1;
-
-  Spline spl;
-  spl.AddOrProlongPoint({0, 0}, minSegSqLength, false);
-  TEST_EQUAL(spl.GetSize(), 1, ());
-
-  spl.AddOrProlongPoint({1, 1}, minSegSqLength, true);
-  TEST_EQUAL(spl.GetSize(), 2, ());
-
-  spl.AddOrProlongPoint({1.5, 1.5}, minSegSqLength, false);
-  TEST_EQUAL(spl.GetSize(), 2, ());
-  TEST(EqualLast(spl, {1.5, 1.5}), ());
-
-  spl.AddOrProlongPoint({3, 3}, minSegSqLength, true);
-  TEST_EQUAL(spl.GetSize(), 2, ());
-  TEST(EqualLast(spl, {3, 3}), ());
-
-  spl.AddOrProlongPoint({4, 4}, minSegSqLength, false);
-  TEST_EQUAL(spl.GetSize(), 3, ());
-  TEST(EqualLast(spl, {4, 4}), ());
-}
-
 }  // namespace spline_test

--- a/geometry/spline.hpp
+++ b/geometry/spline.hpp
@@ -50,7 +50,7 @@ public:
 
   void AddPoint(PointD const & pt);
   void ReplacePoint(PointD const & pt);
-  void AddOrProlongPoint(PointD const & pt, double minSegSqLength, bool checkAngle);
+  bool IsProlonging(PointD const & pt) const;
 
   size_t GetSize() const;
   std::vector<PointD> const & GetPath() const { return m_position; }
@@ -101,26 +101,19 @@ class SharedSpline
 {
 public:
   SharedSpline() = default;
-  explicit SharedSpline(size_t reservedSize);
   explicit SharedSpline(std::vector<PointD> const & path);
   explicit SharedSpline(std::vector<PointD> && path);
 
-  void Reset() { m_spline.reset(); }
+  bool IsNull() const;
+  void Reset(Spline * spline);
+  //void Reset(std::vector<PointD> const & path);
 
   Spline::iterator CreateIterator() const;
 
-  bool IsNull() const { return m_spline == nullptr; }
-  Spline * operator->()
-  {
-    ASSERT(!IsNull(), ());
-    return m_spline.get();
-  }
-  Spline const * operator->() const { return Get(); }
-  Spline const * Get() const
-  {
-    ASSERT(!IsNull(), ());
-    return m_spline.get();
-  }
+  Spline * operator->();
+  Spline const * operator->() const;
+
+  Spline const * Get() const;
 
 private:
   std::shared_ptr<Spline> m_spline;


### PR DESCRIPTION
This reverts commit 38b1053dc4d86533a90a24d47bc270f4704fb0a9.

The logic with
```
point.SquaredLength(m_lastAddedPoint) < m_minSegmentSqrLength
...
point.SquaredLength(lastAddedPoint) < minSqrLength
```
is broken and the tracks are drawing badly now.