### PR TITLE
[ios] Properly restore last used bookmarks list for Testflight users

### DIFF
--- a/base/base_tests/file_name_utils_tests.cpp
+++ b/base/base_tests/file_name_utils_tests.cpp
@@ -7,32 +7,44 @@
 UNIT_TEST(FileName_Smoke)
 {
   std::string name = "/Users/xxx/Documents/test.test";
+  TEST_EQUAL(base::FileNameFromFullPath(name), "test.test", ());
   TEST_EQUAL(base::GetFileExtension(name), ".test", ());
   base::GetNameFromFullPath(name);
   TEST_EQUAL(name, "test.test", ());
   base::GetNameFromFullPath(name);
   TEST_EQUAL(name, "test.test", ());
+  TEST_EQUAL(base::FileNameFromFullPath(name), "test.test", ());
   base::GetNameWithoutExt(name);
   TEST_EQUAL(name, "test", ());
 
   name = "C:\\My Documents\\test.test";
+  TEST_EQUAL(base::FileNameFromFullPath(name), "test.test", ());
   TEST_EQUAL(base::GetFileExtension(name), ".test", ());
   base::GetNameFromFullPath(name);
   TEST_EQUAL(name, "test.test", ());
   base::GetNameWithoutExt(name);
   TEST_EQUAL(name, "test", ());
 
+  name = "";
+  TEST_EQUAL(base::FileNameFromFullPath(name), "", ());
+  TEST_EQUAL(base::GetFileExtension(name), std::string(), ());
+  base::GetNameFromFullPath(name);
+  TEST(name.empty(), ());
+
   name = "/";
+  TEST_EQUAL(base::FileNameFromFullPath(name), "", ());
   TEST_EQUAL(base::GetFileExtension(name), std::string(), ());
   base::GetNameFromFullPath(name);
   TEST(name.empty(), ());
 
   name = "C:\\";
+  TEST_EQUAL(base::FileNameFromFullPath(name), "", ());
   TEST_EQUAL(base::GetFileExtension(name), std::string(), ());
   base::GetNameFromFullPath(name);
   TEST(name.empty(), ());
 
   name = "../test";
+  TEST_EQUAL(base::FileNameFromFullPath(name), "test", ());
   TEST_EQUAL(base::GetFileExtension(name), std::string(), ());
   base::GetNameFromFullPath(name);
   TEST_EQUAL(name, "test", ());

--- a/map/bookmark.cpp
+++ b/map/bookmark.cpp
@@ -3,6 +3,7 @@
 
 #include "indexer/scales.hpp"
 
+#include "base/file_name_utils.hpp"
 #include "base/string_utils.hpp"
 
 #include <sstream>
@@ -372,6 +373,11 @@ void BookmarkCategory::SetCustomProperty(std::string const & key, std::string co
 std::string BookmarkCategory::GetName() const
 {
   return GetPreferredBookmarkStr(m_data.m_name);
+}
+
+std::string BookmarkCategory::GetFileNameWithoutPath() const
+{
+  return base::FileNameFromFullPath(m_file);
 }
 
 bool BookmarkCategory::HasElevationProfile() const

--- a/map/bookmark.hpp
+++ b/map/bookmark.hpp
@@ -100,6 +100,7 @@ public:
   void SetFileName(std::string const & fileName) { m_file = fileName; }
   std::string GetName() const;
   std::string const & GetFileName() const { return m_file; }
+  std::string GetFileNameWithoutPath() const;
 
   void EnableAutoSave(bool enable) { m_autoSave = enable; }
   bool IsAutoSaveEnabled() const { return m_autoSave; }

--- a/map/bookmark_manager.cpp
+++ b/map/bookmark_manager.cpp
@@ -1921,13 +1921,17 @@ Track * BookmarkManager::AddTrack(std::unique_ptr<Track> && track)
 
 void BookmarkManager::SaveState() const
 {
-  settings::Set(kLastEditedBookmarkCategory, m_lastCategoryUrl);
+  settings::Set(kLastEditedBookmarkCategory, m_lastCategoryFile);
   settings::Set(kLastEditedBookmarkColor, static_cast<uint32_t>(m_lastColor));
 }
 
 void BookmarkManager::LoadState()
 {
-  settings::TryGet(kLastEditedBookmarkCategory, m_lastCategoryUrl);
+  settings::TryGet(kLastEditedBookmarkCategory, m_lastCategoryFile);
+
+  // Migration to fix a bug with unique full paths for each Testflight installation.
+  if (auto const slashPath = m_lastCategoryFile.find_last_of('/'); slashPath != std::string::npos)
+    m_lastCategoryFile = base::FileNameFromFullPath(m_lastCategoryFile);
 
   uint32_t color;
   if (settings::Get(kLastEditedBookmarkColor, color) &&
@@ -2317,14 +2321,10 @@ kml::MarkGroupId BookmarkManager::LastEditedBMCategory()
   if (HasBmCategory(m_lastEditedGroupId))
     return m_lastEditedGroupId;
 
-  for (auto & cat : m_categories)
-  {
-    if (cat.second->GetFileName() == m_lastCategoryUrl)
-    {
-      m_lastEditedGroupId = cat.first;
-      return m_lastEditedGroupId;
-    }
-  }
+  for (auto const & [groupId, category] : m_categories)
+    if (category->GetFileNameWithoutPath() == m_lastCategoryFile)
+      return m_lastEditedGroupId = groupId;
+
   m_lastEditedGroupId = CheckAndCreateDefaultCategory();
   return m_lastEditedGroupId;
 }
@@ -2337,8 +2337,11 @@ kml::PredefinedColor BookmarkManager::LastEditedBMColor() const
 
 void BookmarkManager::SetLastEditedBmCategory(kml::MarkGroupId groupId)
 {
+  if (m_lastEditedGroupId == groupId)
+    return;
+  
   m_lastEditedGroupId = groupId;
-  m_lastCategoryUrl = GetBmCategory(groupId)->GetFileName();
+  m_lastCategoryFile = GetBmCategory(groupId)->GetFileNameWithoutPath();
   SaveState();
 }
 

--- a/map/bookmark_manager.hpp
+++ b/map/bookmark_manager.hpp
@@ -764,7 +764,7 @@ private:
   CategoriesCollection m_categories;
   kml::GroupIdCollection m_unsortedBmGroupsIdList;
 
-  std::string m_lastCategoryUrl;
+  std::string m_lastCategoryFile;
   kml::MarkGroupId m_lastEditedGroupId = kml::kInvalidMarkGroupId;
   kml::PredefinedColor m_lastColor = kml::PredefinedColor::Red;
   UserMarkLayers m_userMarkLayers;


### PR DESCRIPTION
The full path to sandboxed settings dir on iOS is different for AppStore and for each new version coming from the TestFlight. It causes the last used list to be reset after each newer version is installed.