### PR TITLE
[routing] Removed thread check for Enable TTS.

### DIFF
--- a/routing/routing_session.cpp
+++ b/routing/routing_session.cpp
@@ -710,6 +710,7 @@ void RoutingSession::PushPositionAccumulator(m2::PointD const & position)
 
   m_positionAccumulator.PushNextPoint(position);
 }
+
 void RoutingSession::ClearPositionAccumulator()
 {
   CHECK_THREAD_CHECKER(m_threadChecker, ());
@@ -719,7 +720,10 @@ void RoutingSession::ClearPositionAccumulator()
 
 void RoutingSession::EnableTurnNotifications(bool enable)
 {
-  CHECK_THREAD_CHECKER(m_threadChecker, ());
+  // I suspect that if Android TextToSpeech failed, OnInitListener -> Enable(false) is called from some other thread ..
+  // Anyway, I don't see any sync problems here to make hard thread check.
+  //CHECK_THREAD_CHECKER(m_threadChecker, ());
+
   m_turnNotificationsMgr.Enable(enable);
 }
 


### PR DESCRIPTION
Have 2 logs from Android users like this:

```
12-19 10:20:00.791  9658  9688 W TextToSpeech: System TTS connection error: Failed creating TTS session: java.lang.IllegalStateException: Failed to bind to service Intent { act=android.intent.action.TTS_SERVICE pkg=com.google.android.tts }
12-19 10:20:00.791  9658  9688 E TtsPlayer: TtsPlayer.java:148 lambda$initialize$0(): Failed to initialize TextToSpeach
12-19 10:20:00.791  9658  9688 E OMcore  : routing/routing_session.cpp:722 EnableTurnNotifications(): CHECK(m_threadChecker.CalledOnOriginalThread()) 
```