### PR TITLE
[Android] Fix Spanish and Portugal TTS       #100thPR🥳🥳🥳

### DIFF
--- a/android/app/src/main/res/values/strings-tts.xml
+++ b/android/app/src/main/res/values/strings-tts.xml
@@ -23,8 +23,8 @@
     <item>ca</item>
     <item>da</item>
     <item>de</item>
-    <item>es</item>
-    <item>es-MX</item>
+    <item>es-ES:es-ES</item>
+    <item>es-MX:es-MX</item>
     <item>eu</item>
     <item>fr</item>
     <item>hr</item>
@@ -34,8 +34,8 @@
     <item>nl</item>
     <item>nb</item>
     <item>pl</item>
-    <item>pt</item>
-    <item>pt-BR</item>
+    <item>pt-PT:pt-PT</item>
+    <item>pt-BR:pt-BR</item>
     <item>ro</item>
     <item>sk</item>
     <item>fi</item>


### PR DESCRIPTION
## This is a fix for #6289 and https://github.com/organicmaps/organicmaps/issues/6756


https://github.com/organicmaps/organicmaps/assets/55664068/002361d3-8490-404c-b1cc-477e37630f07

Please turn on the volume to listen to the voices in different languages.