### PR TITLE
Fix bookmark icon for playground

### DIFF
--- a/map/bookmark_helpers.cpp
+++ b/map/bookmark_helpers.cpp
@@ -69,7 +69,6 @@ std::map<std::string, BookmarkMatchInfo> const kFeatureTypeToBookmarkMatchInfo =
   {"amenity-cinema", {kml::BookmarkIcon::Entertainment, BookmarkBaseType::Entertainment}},
   {"amenity-nightclub", {kml::BookmarkIcon::Entertainment, BookmarkBaseType::Entertainment}},
   {"amenity-theatre", {kml::BookmarkIcon::Entertainment, BookmarkBaseType::Entertainment}},
-  {"leisure-playground", {kml::BookmarkIcon::Park, BookmarkBaseType::Park}},
   {"leisure-water_park", {kml::BookmarkIcon::Entertainment, BookmarkBaseType::Entertainment}},
   {"shop-bookmaker", {kml::BookmarkIcon::Entertainment, BookmarkBaseType::Entertainment}},
   {"tourism-theme_park", {kml::BookmarkIcon::Entertainment, BookmarkBaseType::Entertainment}},

--- a/map/bookmark_helpers.cpp
+++ b/map/bookmark_helpers.cpp
@@ -69,7 +69,7 @@ std::map<std::string, BookmarkMatchInfo> const kFeatureTypeToBookmarkMatchInfo =
   {"amenity-cinema", {kml::BookmarkIcon::Entertainment, BookmarkBaseType::Entertainment}},
   {"amenity-nightclub", {kml::BookmarkIcon::Entertainment, BookmarkBaseType::Entertainment}},
   {"amenity-theatre", {kml::BookmarkIcon::Entertainment, BookmarkBaseType::Entertainment}},
-  {"leisure-playground", {kml::BookmarkIcon::Entertainment, BookmarkBaseType::Entertainment}},
+  {"leisure-playground", {kml::BookmarkIcon::Park, BookmarkBaseType::Park}},
   {"leisure-water_park", {kml::BookmarkIcon::Entertainment, BookmarkBaseType::Entertainment}},
   {"shop-bookmaker", {kml::BookmarkIcon::Entertainment, BookmarkBaseType::Entertainment}},
   {"tourism-theme_park", {kml::BookmarkIcon::Entertainment, BookmarkBaseType::Entertainment}},


### PR DESCRIPTION
**Overview:**
This pull request fixes #6665, where an incorrect bookmark icon (Entertainment) was displayed instead of the appropriate one (Park) for 'leisure-playground.'

**Changes Made:**
- Updated the code in `map/bookmark_helpers.cpp` to use the correct bookmark icon for 'leisure-playground.'
- Replaced the previous icon assignment (Entertainment) with the appropriate one (Park).

**Testing:**
- Tested the updated code to ensure that the correct icon (Park) is now displayed for 'leisure-playground.'
- Verified that other bookmark icons and functionalities remain unaffected.

**Dependencies:**
No dependencies on other pull requests.

