### PR TITLE
[android] Add icon on dowload layout

### DIFF
--- a/android/app/src/main/res/layout/activity_download_resources.xml
+++ b/android/app/src/main/res/layout/activity_download_resources.xml
@@ -19,12 +19,17 @@
       android:orientation="vertical"
       app:layout_constraintBottom_toBottomOf="parent"
       app:layout_constraintTop_toTopOf="parent">
+      <ImageView
+        android:layout_width="90dp"
+        android:layout_height="90dp"
+        android:src="@drawable/ic_download"
+        app:tint="?android:colorAccent"/>
       <TextView
         android:id="@+id/head_message"
         style="?fontHeadline6"
         android:layout_width="match_parent"
         android:layout_height="wrap_content"
-        android:layout_marginTop="@dimen/margin_base_plus"
+        android:layout_marginTop="@dimen/margin_base"
         android:gravity="center"
         android:text="@string/download_map_title" />
       <TextView


### PR DESCRIPTION
From maps.me has been forked, custom illustrations have been removed from different layout.
This PR adds icon like illustration on the download layout.

|Nexus 5 - Portrait|Pixel 7 - Landscape|
|-|-|
|<img src="https://github.com/organicmaps/organicmaps/assets/87148630/46d433fd-b00b-4727-8cf1-68c430e84039" height=300 />|<img src="https://github.com/organicmaps/organicmaps/assets/87148630/1a9d9d25-f6b3-4f3c-a0e4-3d5d10a5923a" height=200 />|

I have set a fixed size, I know it's not the best option, but I'm not sure is necessary to use a custom size following the size of devices.