### PR TITLE
[android] Improve layer bottomsheet on tablet

### DIFF
--- a/android/app/src/main/res/values-sw600dp/dimens.xml
+++ b/android/app/src/main/res/values-sw600dp/dimens.xml
@@ -1,7 +1,7 @@
 <resources>
   <!-- direction fragment -->
   <dimen name="margin_direction_small">12dp</dimen>
-  <dimen name="margin_direction_big">80dp</dimen>
+  <dimen name="margin_direction_big">50dp</dimen>
   <dimen name="margin_direction_side">40dp</dimen>
   <dimen name="margin_direction_mid">36dp</dimen>
   <dimen name="margin_direction_around_center">80dp</dimen>


### PR DESCRIPTION
Fixes #6409
`margin_direction_big` property is used on layer bottom sheet layout and fragment direction layout like the value of `layout_marginTop` property.
Now on all form factors margin_direction_big has 20dp like value.

|Before|After|
|-|-|
|<img src="https://github.com/organicmaps/organicmaps/assets/87148630/d3c46f12-6faa-4256-bb8e-9920f7f974ea" height=150 />|<img src="https://github.com/organicmaps/organicmaps/assets/87148630/6e7c8e87-d2a1-4add-a215-d80f63bb96d9" height=150 />|
|<img src="https://github.com/organicmaps/organicmaps/assets/87148630/bdf69cc9-1951-4442-8b39-bbabe2a7c26b" height=300 />|<img src="https://github.com/organicmaps/organicmaps/assets/87148630/20069ee7-6c57-4f28-8e51-c763f7ea8641" height=300 />|
|<img src="https://github.com/organicmaps/organicmaps/assets/87148630/d7bb81ad-2c3b-4575-8ae2-e4434b9f4a44" height=300 />|<img src="https://github.com/organicmaps/organicmaps/assets/87148630/7fffbbfb-f9b4-49e4-8f6f-c7e8354d8eda" height=300 />|