### PR TITLE
[android] Trim username and password for Osm login

### DIFF
--- a/android/app/src/main/java/app/organicmaps/editor/OsmLoginFragment.java
+++ b/android/app/src/main/java/app/organicmaps/editor/OsmLoginFragment.java
@@ -63,8 +63,8 @@ public class OsmLoginFragment extends BaseMwmToolbarFragment
   private void login()
   {
     InputUtils.hideKeyboard(mLoginInput);
-    final String username = mLoginInput.getText().toString();
-    final String password = mPasswordInput.getText().toString();
+    final String username = mLoginInput.getText().toString().trim();
+    final String password = mPasswordInput.getText().toString().trim();
     enableInput(false);
     UiUtils.show(mProgress);
     mLoginButton.setText("");


### PR DESCRIPTION
The usage of `trim()` ensures that the username and password variables do not have any trailing whitespaces when they are passed to the `OsmOAuth.nativeAuthWithPassword()` method.

Resolves #4431 