### PR TITLE
[ios] Add the Notes section to the 'Add place to OSM' screen

### DIFF
--- a/iphone/Maps/UI/Editor/MWMEditorViewController.mm
+++ b/iphone/Maps/UI/Editor/MWMEditorViewController.mm
@@ -334,7 +334,7 @@ void registerCellsForTableView(std::vector<MWMEditorCellID> const & cells, UITab
     return mid == MetadataID::FMD_POSTCODE || mid == MetadataID::FMD_BUILDING_LEVELS;
   }), editableProperties.end());
   BOOL const isCreating = self.isCreating;
-  BOOL const showNotesToOSMEditors = !isCreating;
+  BOOL const showNotesToOSMEditors = YES;
 
   if (isNameEditable)
   {


### PR DESCRIPTION
Closes https://github.com/organicmaps/organicmaps/issues/6760

This PR adds the Notes section to the 'Add place to OSM' screen (not only for the Edit screen).
The notes will be sent to the OSM.

<img width="463" alt="image" src="https://github.com/organicmaps/organicmaps/assets/79797627/4d395c72-75a8-489e-88bd-49ab39368a34">
<img width="315" alt="image" src="https://github.com/organicmaps/organicmaps/assets/79797627/c08f9e09-9401-4dc6-a728-eadc607014c5">
<img width="630" alt="image" src="https://github.com/organicmaps/organicmaps/assets/79797627/c9f55627-ff35-4af5-bd61-5ec4214363e2">

<img width="679" alt="image" src="https://github.com/organicmaps/organicmaps/assets/79797627/35ec3a71-3222-4ab7-9470-72e27ca26b8a">

