### PR TITLE
[android] Bolder and Bigger Text

### DIFF
--- a/android/app/src/main/res/layout/layout_nav_top.xml
+++ b/android/app/src/main/res/layout/layout_nav_top.xml
@@ -16,7 +16,7 @@
     android:elevation="@dimen/nav_elevation"
     app:layout_constraintTop_toTopOf="parent"
     android:clickable="true"
-    android:background="?cardBackground">
+    android:background="#01735C">
     <RelativeLayout
       android:layout_width="match_parent"
       android:layout_height="@dimen/nav_street_height"

--- a/android/app/src/main/res/values/font_sizes.xml
+++ b/android/app/src/main/res/values/font_sizes.xml
@@ -54,7 +54,7 @@
   <dimen name="text_size_routing_plan_detail_intermediate">20sp</dimen>
   <dimen name="text_size_time_picker">56sp</dimen>
 
-  <dimen name="text_size_nav_street">17sp</dimen>
+  <dimen name="text_size_nav_street">19sp</dimen>
   <dimen name="text_size_nav_next_turn">24sp</dimen>
   <dimen name="text_size_nav_circle_exit">20sp</dimen>
   <dimen name="text_size_nav_number">24sp</dimen>

--- a/android/app/src/main/res/values/styles-text.xml
+++ b/android/app/src/main/res/values/styles-text.xml
@@ -163,7 +163,8 @@
   <style name="MwmTextAppearance.NavStreet">
     <item name="android:textSize">@dimen/text_size_nav_street</item>
     <item name="android:fontFamily">@string/robotoMedium</item>
-    <item name="android:textColor">?android:textColorPrimary</item>
+    <item name="android:textStyle">bold</item>
+    <item name="android:textColor">?android:textColorPrimaryInverse</item>
   </style>
 
   <style name="MwmTextAppearance.NavNextTurn">


### PR DESCRIPTION
**Overview:**
This pull request fixes #5316, where Users are requesting bolder and bigger text for street names to enhance visibility.

**Changes Made:**
- In the `layout_nav_top.xml` file: The background color for the navigation layout is changed from `white` to `#01735C` (road sign green).
- In the `font_sizes.xml` file:The text size for the street name (`text_size_nav_street`) is increased from 17sp to 19sp.
-In the `styles-text.xml` file:The style named `MwmTextAppearance.NavStreet` is updated to include bold text style.

**Testing:**
- Tested the updated code to ensure that updated code is working as expected.
- Verified that other functionalities remain unaffected.
![Screenshot from 2024-01-03 13-10-40](https://github.com/organicmaps/organicmaps/assets/76656712/95f3e6ff-062f-481c-b655-38579b15500b)


**Dependencies:**
No dependencies on other pull requests.

