### PR TITLE
[coding] Simplify MemWriter::Write.

### DIFF
--- a/coding/writer.hpp
+++ b/coding/writer.hpp
@@ -55,36 +55,34 @@ public:
     static_assert(sizeof(typename ContainerT::value_type) == 1, "");
   }
 
-  void Seek(uint64_t pos) override { m_Pos = base::asserted_cast<uintptr_t>(pos); }
+  void Seek(uint64_t pos) override { m_Pos = base::asserted_cast<size_t>(pos); }
 
   uint64_t Pos() const override { return m_Pos; }
 
   void Write(void const * p, size_t size) override
   {
     if (size == 0)
-        return;
+      return;
 
-    auto freeSize = static_cast<intptr_t>(m_Data.size() - m_Pos);
-    if (freeSize <= 0)
+    size_t const newSize = m_Pos + size;
+    if (m_Data.size() < newSize)
     {
-      m_Data.resize(static_cast<size_t>(m_Pos + size));
-      freeSize = size;
+      // Assume the same alloc strategy as in std::vector.
+      size_t const cap = m_Data.capacity();
+      if (cap < newSize)
+        m_Data.reserve(std::max(newSize, cap * 2));
+
+      m_Data.resize(newSize);
     }
 
-    memcpy(&m_Data[static_cast<size_t>(m_Pos)], p, std::min(size, static_cast<size_t>(freeSize)));
-
-    if (size > static_cast<size_t>(freeSize))
-    {
-      uint8_t const * it = reinterpret_cast<uint8_t const *>(p);
-      m_Data.insert(m_Data.end(), it + freeSize, it + size);
-    }
+    memcpy(m_Data.data() + m_Pos, p, size);
 
     m_Pos += size;
   }
 
 private:
   ContainerT & m_Data;
-  uint64_t m_Pos;
+  size_t m_Pos;
 };
 
 // Original writer should not be used when SubWriter is active!


### PR DESCRIPTION
Follow up #6961

```if (freeSize <= 0)``` is not a good strategy because it calls resize every time regular Write is called.

CC @Osyotr
