### PR TITLE
Do not show "Routing options enabled"  when using ruler

### DIFF
--- a/android/app/src/main/java/app/organicmaps/routing/RoutingController.java
+++ b/android/app/src/main/java/app/organicmaps/routing/RoutingController.java
@@ -198,7 +198,7 @@ public class RoutingController
 
   private boolean isDrivingOptionsBuildError()
   {
-    return !ResultCodesHelper.isMoreMapsNeeded(mLastResultCode) && RoutingOptions.hasAnyOptions();
+    return !ResultCodesHelper.isMoreMapsNeeded(mLastResultCode) && RoutingOptions.hasAnyOptions() && !isRulerRouterType();
   }
 
   private void setState(State newState)

--- a/android/app/src/main/java/app/organicmaps/routing/RoutingPlanController.java
+++ b/android/app/src/main/java/app/organicmaps/routing/RoutingPlanController.java
@@ -306,7 +306,7 @@ public class RoutingPlanController extends ToolbarController
   {
     mDrivingOptionsBtnContainer.addOnLayoutChangeListener(mDriverOptionsLayoutListener);
     UiUtils.show(mDrivingOptionsBtnContainer);
-    boolean hasAnyOptions = RoutingOptions.hasAnyOptions();
+    boolean hasAnyOptions = RoutingOptions.hasAnyOptions() && !isRulerType();
     UiUtils.showIf(hasAnyOptions, mDrivingOptionsImage);
     TextView title = mDrivingOptionsBtnContainer.findViewById(R.id.driving_options_btn_title);
     title.setText(hasAnyOptions ? R.string.change_driving_options_btn

--- a/iphone/Maps/Core/Routing/MWMRouter.mm
+++ b/iphone/Maps/Core/Routing/MWMRouter.mm
@@ -575,7 +575,7 @@ char const *kRenderAltitudeImagesQueueLabel = "mapsme.mwmrouter.renderAltitudeIm
 }
 
 + (BOOL)hasActiveDrivingOptions {
-  return [MWMRoutingOptions new].hasOptions;
+  return [MWMRoutingOptions new].hasOptions && self.type != MWMRouterTypeRuler;
 }
 
 + (void)avoidRoadTypeAndRebuild:(MWMRoadType)type {


### PR DESCRIPTION
Do not show "Routing options enabled"  when using ruler.

Based on https://github.com/organicmaps/organicmaps/pull/3601.

Closes #6579.