### PR TITLE
[placepage] Remove extra kFieldsSeparator in elevation

### DIFF
--- a/map/place_page_info.cpp
+++ b/map/place_page_info.cpp
@@ -161,10 +161,7 @@ std::string Info::FormatSubtitle(bool withType) const
   // Elevation.
   auto const eleStr = GetElevationFormatted();
   if (!eleStr.empty())
-  {
-    append(kMountainSymbol);
-    append(eleStr);
-  }
+    append(std::string{kMountainSymbol} + eleStr);
     
   // ATM
   if (HasAtm())


### PR DESCRIPTION
In https://github.com/organicmaps/organicmaps/pull/6842 I inadvertently added an unneeded extra `kFieldsSeparator` in the elevation info in the Place Page description.  My mistake. This PR fixes it, going back to the previous behavior by removing the extra `" • "`.

Before #6842:

<img src="https://github.com/organicmaps/organicmaps/assets/47610359/3f0fe2dd-3381-4cb7-a701-fee662072432" width="320"/>

--

After #6842:

<img src="https://github.com/organicmaps/organicmaps/assets/47610359/6bfd497f-5b46-4f3c-94b8-6882e10bacb5" width="320"/>





