### PR TITLE
[android][ios] Replace `om://` links with `geo:`

### DIFF
--- a/android/app/src/main/cpp/app/organicmaps/Framework.cpp
+++ b/android/app/src/main/cpp/app/organicmaps/Framework.cpp
@@ -56,6 +56,8 @@
 #include "base/math.hpp"
 #include "base/sunrise_sunset.hpp"
 
+#include "ge0/url_generator.hpp"
+
 #include "3party/open-location-code/openlocationcode.h"
 
 #include <cstdint>
@@ -937,7 +939,16 @@ Java_app_organicmaps_Framework_nativeGetGe0Url(JNIEnv * env, jclass, jdouble lat
 {
   ::Framework * fr = frm();
   double const scale = (zoomLevel > 0 ? zoomLevel : fr->GetDrawScale());
-  string const url = fr->CodeGe0url(lat, lon, scale, jni::ToNativeString(env, name));
+  string const url = ge0::GenerateShortShowMapUrl(lat, lon, scale, jni::ToNativeString(env, name));
+  return jni::ToJavaString(env, url);
+}
+
+JNIEXPORT jstring JNICALL
+Java_app_organicmaps_Framework_nativeGetGeoUri(JNIEnv * env, jclass, jdouble lat, jdouble lon, jdouble zoomLevel, jstring name)
+{
+  ::Framework * fr = frm();
+  double const scale = (zoomLevel > 0 ? zoomLevel : fr->GetDrawScale());
+  string const url = ge0::GenerateGeoUri(lat, lon, scale, jni::ToNativeString(env, name));
   return jni::ToJavaString(env, url);
 }
 
@@ -997,6 +1008,10 @@ Java_app_organicmaps_Framework_nativeFormatLatLon(JNIEnv * env, jclass, jdouble 
       else
          return nullptr;
     }
+    case android::CoordinatesFormat::GeoUri: // geo: URI
+      return jni::ToJavaString(env, ge0::GenerateGeoUri(lat, lon, 14, ""));
+    case android::CoordinatesFormat::Ge0Url: // ge0: URL
+      return jni::ToJavaString(env, ge0::GenerateShortShowMapUrl(lat, lon, 14, ""));
   }
 }
 

--- a/android/app/src/main/cpp/app/organicmaps/Framework.hpp
+++ b/android/app/src/main/cpp/app/organicmaps/Framework.hpp
@@ -46,7 +46,9 @@ namespace android
     OLCFull = 2,       // Open location code, full format
     OSMLink = 3,       // Link to the OSM. E.g. https://osm.org/go/xcXjyqQlq-?m=
     UTM = 4,           // Universal Transverse Mercator
-    MGRS = 5           // Military Grid Reference System
+    MGRS = 5,          // Military Grid Reference System
+    GeoUri = 6,        // geo: link, e.g. geo:37.786971,-122.399677
+    Ge0Url = 7,        // Organic Maps deep link, e.g. https://omaps.app/o4B4pYZsRs
   };
 
   // Keep in sync `public @interface ChoosePositionMode`in Framework.java.

--- a/android/app/src/main/cpp/app/organicmaps/bookmarks/data/BookmarkManager.cpp
+++ b/android/app/src/main/cpp/app/organicmaps/bookmarks/data/BookmarkManager.cpp
@@ -807,13 +807,6 @@ Java_app_organicmaps_bookmarks_data_BookmarkManager_nativeGetBookmarkScale(
 }
 
 JNIEXPORT jstring JNICALL
-Java_app_organicmaps_bookmarks_data_BookmarkManager_nativeEncode2Ge0Url(
-  JNIEnv * env, jclass, jlong bmk, jboolean addName)
-{
-  return jni::ToJavaString(env, frm()->CodeGe0url(getBookmark(bmk), addName));
-}
-
-JNIEXPORT jstring JNICALL
 Java_app_organicmaps_bookmarks_data_BookmarkManager_nativeGetBookmarkAddress(
   JNIEnv * env, jclass, jlong bmkId)
 {

--- a/android/app/src/main/java/app/organicmaps/Framework.java
+++ b/android/app/src/main/java/app/organicmaps/Framework.java
@@ -189,6 +189,7 @@ public class Framework
   public static native String nativeFormatSpeed(double speed);
 
   public static native String nativeGetGe0Url(double lat, double lon, double zoomLevel, String name);
+  public static native String nativeGetGeoUri(double lat, double lon, double zoomLevel, String name);
 
   public static native String nativeGetAddress(double lat, double lon);
 

--- a/android/app/src/main/java/app/organicmaps/bookmarks/data/Bookmark.java
+++ b/android/app/src/main/java/app/organicmaps/bookmarks/data/Bookmark.java
@@ -136,16 +136,4 @@ public class Bookmark extends MapObject
   {
     return BookmarkManager.INSTANCE.getBookmarkDescription(mBookmarkId);
   }
-
-  @NonNull
-  public String getGe0Url(boolean addName)
-  {
-    return BookmarkManager.INSTANCE.encode2Ge0Url(mBookmarkId, addName);
-  }
-
-  @NonNull
-  public String getHttpGe0Url(boolean addName)
-  {
-    return getGe0Url(addName).replaceFirst(Constants.Url.SHORT_SHARE_PREFIX, Constants.Url.HTTP_SHARE_PREFIX);
-  }
 }

--- a/android/app/src/main/java/app/organicmaps/bookmarks/data/BookmarkManager.java
+++ b/android/app/src/main/java/app/organicmaps/bookmarks/data/BookmarkManager.java
@@ -649,12 +649,6 @@ public enum BookmarkManager
     return nativeGetBookmarkScale(bookmarkId);
   }
 
-  @NonNull
-  public String encode2Ge0Url(@IntRange(from = 0) long bookmarkId, boolean addName)
-  {
-    return nativeEncode2Ge0Url(bookmarkId, addName);
-  }
-
   public void setBookmarkParams(@IntRange(from = 0) long bookmarkId, @NonNull String name,
                                 @Icon.PredefinedColor int color, @NonNull String descr)
   {
@@ -855,10 +849,6 @@ public enum BookmarkManager
   private static native String nativeGetBookmarkDescription(@IntRange(from = 0) long bookmarkId);
 
   private static native double nativeGetBookmarkScale(@IntRange(from = 0) long bookmarkId);
-
-  @NonNull
-  private static native String nativeEncode2Ge0Url(@IntRange(from = 0) long bookmarkId,
-                                                   boolean addName);
 
   private static native void nativeSetBookmarkParams(@IntRange(from = 0) long bookmarkId,
                                                      @NonNull String name,

--- a/android/app/src/main/java/app/organicmaps/util/SharingUtils.java
+++ b/android/app/src/main/java/app/organicmaps/util/SharingUtils.java
@@ -33,11 +33,11 @@ public class SharingUtils
     final String subject = context.getString(R.string.share);
     intent.putExtra(Intent.EXTRA_SUBJECT, subject);
 
-    final String geoUrl = Framework.nativeGetGe0Url(loc.getLatitude(), loc.getLongitude(), Framework
+    final String ge0Url = Framework.nativeGetGe0Url(loc.getLatitude(), loc.getLongitude(), Framework
         .nativeGetDrawScale(), "");
-    final String httpUrl = Framework.getHttpGe0Url(loc.getLatitude(), loc.getLongitude(), Framework
+    final String geoUri = Framework.nativeGetGeoUri(loc.getLatitude(), loc.getLongitude(), Framework
         .nativeGetDrawScale(), "");
-    final String text = context.getString(R.string.my_position_share_sms, geoUrl, httpUrl);
+    final String text = context.getString(R.string.my_position_share_sms, ge0Url, geoUri);
     intent.putExtra(Intent.EXTRA_TEXT, text);
 
     context.startActivity(Intent.createChooser(intent, context.getString(R.string.share)));
@@ -53,12 +53,12 @@ public class SharingUtils
                            context.getString(R.string.bookmark_share_email_subject);
     intent.putExtra(Intent.EXTRA_SUBJECT, subject);
 
-    final String geoUrl = Framework.nativeGetGe0Url(object.getLat(), object.getLon(),
+    final String ge0Url = Framework.nativeGetGe0Url(object.getLat(), object.getLon(),
                                                     object.getScale(), object.getName());
-    final String httpUrl = Framework.getHttpGe0Url(object.getLat(), object.getLon(),
-                                                   object.getScale(), object.getName());
+    final String geoUri = Framework.nativeGetGeoUri(object.getLat(), object.getLon(),
+                                                     object.getScale(), object.getName());
     final String address = TextUtils.isEmpty(object.getAddress()) ? object.getName() : object.getAddress();
-    final String text = context.getString(R.string.my_position_share_email, address, geoUrl, httpUrl);
+    final String text = context.getString(R.string.my_position_share_email, address, ge0Url, geoUri);
     intent.putExtra(Intent.EXTRA_TEXT, text);
 
     context.startActivity(Intent.createChooser(intent, context.getString(R.string.share)));

--- a/android/app/src/main/java/app/organicmaps/widget/placepage/CoordinatesFormat.java
+++ b/android/app/src/main/java/app/organicmaps/widget/placepage/CoordinatesFormat.java
@@ -7,7 +7,9 @@ public enum CoordinatesFormat
   OLCFull(2, "OLC", false),           // Open location code, full format
   OSMLink(3, "osm.org", false),       // Link to the OSM. E.g. https://osm.org/go/xcXjyqQlq-?m=
   UTM(4, "UTM", true),                // Universal Transverse Mercator
-  MGRS(5, "MGRS", true);              // Military Grid Reference System
+  MGRS(5, "MGRS", true),              // Military Grid Reference System
+  GeoUri(6, "geo", false),            // geo: link, e.g. geo:37.786971,-122.399677
+  Ge0Url(7, "omaps.app", false);      // Organic Maps deep link, e.g. https://omaps.app/o4B4pYZsRs
 
   private final int id;
   private final String label;

--- a/android/app/src/main/java/app/organicmaps/widget/placepage/PlacePageView.java
+++ b/android/app/src/main/java/app/organicmaps/widget/placepage/PlacePageView.java
@@ -73,12 +73,14 @@ public class PlacePageView extends Fragment implements View.OnClickListener,
   private static final String LINKS_FRAGMENT_TAG = "LINKS_FRAGMENT_TAG";
 
   private static final List<CoordinatesFormat> visibleCoordsFormat =
-      Arrays.asList(CoordinatesFormat.LatLonDMS,
-                    CoordinatesFormat.LatLonDecimal,
+      Arrays.asList(CoordinatesFormat.LatLonDecimal,
+                    CoordinatesFormat.LatLonDMS,
                     CoordinatesFormat.OLCFull,
+                    CoordinatesFormat.GeoUri,
                     CoordinatesFormat.UTM,
                     CoordinatesFormat.MGRS,
-                    CoordinatesFormat.OSMLink);
+                    CoordinatesFormat.OSMLink,
+                    CoordinatesFormat.Ge0Url);
   private View mFrame;
   // Preview.
   private ViewGroup mPreview;

--- a/ge0/ge0_tests/parser_tests.cpp
+++ b/ge0/ge0_tests/parser_tests.cpp
@@ -243,7 +243,7 @@ UNIT_TEST(LatLonFullAndClippedCoordinates)
     for (double lon = -180; lon < 180; lon += 0.7)
     {
       string const buf = ge0::GenerateShortShowMapUrl(lat, lon, 4, "");
-      size_t const coordInd = buf.find("://") + 4;
+      size_t const coordInd = 19; // strlen("https://omaps.app/") + 1
       for (int i = 9; i >= 1; --i)
       {
         string const str = buf.substr(coordInd, i);
@@ -255,8 +255,8 @@ UNIT_TEST(LatLonFullAndClippedCoordinates)
         double const epsLon = GetLonEpsilon(coordSize);
         double const difLat = fabs(lat - latTmp);
         double const difLon = fabs(lon - lonTmp);
-        TEST(difLat <= epsLat, (str, lat, latTmp, lon, lonTmp, difLat, epsLat));
-        TEST(difLon <= epsLon, (str, lat, latTmp, lon, lonTmp, difLon, epsLon));
+        TEST(difLat <= epsLat, (buf, str, lat, latTmp, lon, lonTmp, difLat, epsLat));
+        TEST(difLon <= epsLon, (buf, str, lat, latTmp, lon, lonTmp, difLon, epsLon));
         maxLatDiffForCoordSize[coordSize] = max(maxLatDiffForCoordSize[coordSize], difLat);
         maxLonDiffForCoordSize[coordSize] = max(maxLonDiffForCoordSize[coordSize], difLon);
       }

--- a/ge0/url_generator.cpp
+++ b/ge0/url_generator.cpp
@@ -1,8 +1,11 @@
 #include "ge0/url_generator.hpp"
 
+#include "coding/url.hpp"
 #include "base/assert.hpp"
 
 #include <cmath>
+#include <iomanip>
+#include <sstream>
 
 namespace
 {
@@ -83,8 +86,8 @@ namespace ge0
 {
 std::string GenerateShortShowMapUrl(double lat, double lon, double zoom, std::string const & name)
 {
-  size_t constexpr schemaLength = 5;  // strlen("om://")
-  std::string urlSample = "om://ZCoordba64";
+  size_t constexpr schemaLength = 18;  // strlen("https://omaps.app/")
+  std::string urlSample = "https://omaps.app/ZCoordba64";
 
   int const zoomI = (zoom <= 4 ? 0 : (zoom >= 19.75 ? 63 : static_cast<int>((zoom - 4) * 4)));
   urlSample[schemaLength] = Base64Char(zoomI);
@@ -98,6 +101,17 @@ std::string GenerateShortShowMapUrl(double lat, double lon, double zoom, std::st
   }
 
   return urlSample;
+}
+
+std::string GenerateGeoUri(double lat, double lon, double zoom, std::string const & name)
+{
+  std::ostringstream oss;
+  oss << "geo:" << std::fixed << std::setprecision(7) << lat << ',' << lon << "?z=" << std::setprecision(1) << zoom;
+
+  if (!name.empty())
+    oss << '(' << url::UrlEncode(name) << ')';
+
+  return oss.str();
 }
 
 char Base64Char(int x)

--- a/ge0/url_generator.hpp
+++ b/ge0/url_generator.hpp
@@ -19,6 +19,23 @@ inline static int const kMaxCoordBits = kMaxPointBytes * 3;
 // om://ZCoordba64/Name
 std::string GenerateShortShowMapUrl(double lat, double lon, double zoomLevel, std::string const & name);
 
+// Generates a geo: uri.
+//
+// - https://datatracker.ietf.org/doc/html/rfc5870
+// - https://developer.android.com/guide/components/intents-common#Maps
+// - https://developers.google.com/maps/documentation/urls/android-intents
+//
+// URL format:
+//     
+//     +--------------------------------  lat
+//     |            +-------------------- lon
+//     |            |               +---- zoom
+//     |            |               | +-- url-encoded name
+//     |            |               | |
+//     |            |               | |
+// geo:54.683486138,25.289361259&z=14(Forto%20dvaras)
+std::string GenerateGeoUri(double lat, double lon, double zoom, std::string const & name);
+
 // Exposed for testing.
 char Base64Char(int x);
 int LatToInt(double lat, int maxValue);

--- a/iphone/CoreApi/CoreApi/PlacePageData/Common/PlacePageInfoData.mm
+++ b/iphone/CoreApi/CoreApi/PlacePageData/Common/PlacePageInfoData.mm
@@ -84,10 +84,12 @@ using namespace osm;
     _atm = rawData.HasAtm() ? NSLocalizedString(@"type.amenity.atm", nil) : nil;
       
     _address = rawData.GetAddress().empty() ? nil : @(rawData.GetAddress().c_str());
-    _coordFormats = @[@(rawData.GetFormattedCoordinate(place_page::CoordinatesFormat::LatLonDMS).c_str()),
-                      @(rawData.GetFormattedCoordinate(place_page::CoordinatesFormat::LatLonDecimal).c_str()),
+    _coordFormats = @[@(rawData.GetFormattedCoordinate(place_page::CoordinatesFormat::LatLonDecimal).c_str()),
+                      @(rawData.GetFormattedCoordinate(place_page::CoordinatesFormat::LatLonDMS).c_str()),
                       @(rawData.GetFormattedCoordinate(place_page::CoordinatesFormat::OLCFull).c_str()),
+                      @(rawData.GetFormattedCoordinate(place_page::CoordinatesFormat::GeoUri).c_str()),
                       @(rawData.GetFormattedCoordinate(place_page::CoordinatesFormat::OSMLink).c_str()),
+                      @(rawData.GetFormattedCoordinate(place_page::CoordinatesFormat::Ge0Url).c_str()),
                       @(rawData.GetFormattedCoordinate(place_page::CoordinatesFormat::UTM).c_str()),
                       @(rawData.GetFormattedCoordinate(place_page::CoordinatesFormat::MGRS).c_str())];
   }

--- a/map/framework.cpp
+++ b/map/framework.cpp
@@ -2289,20 +2289,6 @@ StringsBundle const & Framework::GetStringsBundle()
   return m_stringsBundle;
 }
 
-// static
-string Framework::CodeGe0url(Bookmark const * bmk, bool addName)
-{
-  double lat = mercator::YToLat(bmk->GetPivot().y);
-  double lon = mercator::XToLon(bmk->GetPivot().x);
-  return ge0::GenerateShortShowMapUrl(lat, lon, bmk->GetScale(), addName ? bmk->GetPreferredName() : "");
-}
-
-// static
-string Framework::CodeGe0url(double lat, double lon, double zoomLevel, string const & name)
-{
-  return ge0::GenerateShortShowMapUrl(lat, lon, zoomLevel, name);
-}
-
 string Framework::GenerateApiBackUrl(ApiMarkPoint const & point) const
 {
   string res = m_parsedMapApi.GetGlobalBackUrl();

--- a/map/framework.hpp
+++ b/map/framework.hpp
@@ -649,9 +649,6 @@ public:
                               double bearing, double speed, double elapsedSeconds);
 
 public:
-  static std::string CodeGe0url(Bookmark const * bmk, bool addName);
-  static std::string CodeGe0url(double lat, double lon, double zoomLevel, std::string const & name);
-
   /// @name Api
   std::string GenerateApiBackUrl(ApiMarkPoint const & point) const;
   url_scheme::ParsedMapApi const & GetApiDataHolder() const { return m_parsedMapApi; }

--- a/map/place_page_info.cpp
+++ b/map/place_page_info.cpp
@@ -9,6 +9,8 @@
 #include "platform/measurement_utils.hpp"
 #include "platform/preferred_languages.hpp"
 
+#include "ge0/url_generator.hpp"
+
 #include "geometry/mercator.hpp"
 
 #include "base/assert.hpp"
@@ -336,6 +338,10 @@ std::string Info::GetFormattedCoordinate(CoordinatesFormat coordsFormat) const
       else
         return "MGRS: " + mgrsCoords;
     }
+    case CoordinatesFormat::GeoUri: // geo: URI
+      return ge0::GenerateGeoUri(lat, lon, 14, "");
+    case CoordinatesFormat::Ge0Url: // ge0: URL
+      return ge0::GenerateShortShowMapUrl(lat, lon, 14, "");
   }
 }
 

--- a/map/place_page_info.hpp
+++ b/map/place_page_info.hpp
@@ -41,7 +41,9 @@ enum class CoordinatesFormat
   OLCFull, // Open location code, long format
   OSMLink, // Link to osm.org
   UTM, // Universal Transverse Mercator
-  MGRS // Military Grid Reference System
+  MGRS, // Military Grid Reference System
+  GeoUri, // geo: link, e.g. geo:37.786971,-122.399677
+  Ge0Url, // Organic Maps deep link, e.g. https://omaps.app/o4B4pYZsRs
 };
 
 struct BuildInfo


### PR DESCRIPTION
`om://ZCoordba64/Name` and `https://omaps.app/ZCoordba64/Name` links are absolutely interchangeable. Unlike `om://`, `https://` links are automatically highlighted in most apps, including iMessages/SMS, WhatsApp, Telegram and many others.

Replace `om://ZCoordba64/Name` with `geo:lat,lon(Name)` when sharing.

Add `https://omaps.app` and `geo:` to the coordinates drop-down list.

----------------

Before:

```
Check out
Nicosia
Capital
https://omaps.app/oyx1Fac8Zv/Nicosia
om://oyx1Fac8Zv/Nicosia
```

After:

```
Check out
Nicosia
Capital
https://omaps.app/cyx1Fac8Zv/Nicosia
geo:35.1746494,33.3638788?z=11.0(Nicosia)
```

New links:

<img src="https://github.com/organicmaps/organicmaps/assets/1799054/f994200e-06b8-44b6-8857-c355394f4875" width="350px">
