### PR TITLE
[android] Reduce frequency of Android Monkey

### DIFF
--- a/.github/workflows/android-monkey.yaml
+++ b/.github/workflows/android-monkey.yaml
@@ -2,7 +2,7 @@ name: Android Monkey
 on:
   workflow_dispatch: # Manual trigger
   schedule:
-    - cron:  '0 5 * * *' # Once per day at 05:00 UTC
+    - cron:  '0 5 * * 0' # Once per week at 05:00 UTC
 
 env:
   JAVA_HOME: /usr/lib/jvm/temurin-17-jdk-amd64  # Java 17 is required for Android Gradle 8 plugin


### PR DESCRIPTION
Fixes #7054
Now cron executes Android Monkey on per week Sunday at 05:00
Let's discuss to find the best frequency
Syntax -> https://crontab.guru/examples.html