### PR TITLE
[android] Revert 401a3a808dc708ce0e191abe17f1ea05fd301fa0

### DIFF
--- a/android/app/src/main/java/app/organicmaps/routing/RoutingErrorDialogFragment.java
+++ b/android/app/src/main/java/app/organicmaps/routing/RoutingErrorDialogFragment.java
@@ -57,7 +57,11 @@ public class RoutingErrorDialogFragment extends BaseRoutingErrorDialogFragment
   {
     if (mNeedMoreMaps && mCancelled) {
       mCancelled = false;
-      RoutingController.get().cancel();
+
+      /// @todo Actually, should cancel if there is no valid route only.
+      // I didn't realize how to distinguish NEED_MORE_MAPS but valid route is present.
+      // Should refactor RoutingController states.
+      //RoutingController.get().cancel();
     }
 
     super.onDismiss(dialog);


### PR DESCRIPTION
Reopen https://github.com/organicmaps/organicmaps/issues/6126
Reverts https://github.com/organicmaps/organicmaps/pull/6427

Now more important logic is broken:
- A valid (but maybe longer) route is built
- the app asks to download more maps
- Press later (not now)

Should keep the valid route.

