### PR TITLE
[android] Clean layouts and drawables

### DIFF
--- a/android/app/src/main/res/drawable/ic_atm_white.xml
+++ b/android/app/src/main/res/drawable/ic_atm_white.xml
@@ -1,4 +1,4 @@
-<vector xmlns:android="http://schemas.android.com/apk/res/android" xmlns:aapt="http://schemas.android.com/aapt"
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
     android:viewportWidth="48"
     android:viewportHeight="48"
     android:width="48dp"

--- a/android/app/src/main/res/drawable/ic_capacity_white.xml
+++ b/android/app/src/main/res/drawable/ic_capacity_white.xml
@@ -1,4 +1,4 @@
-<vector xmlns:android="http://schemas.android.com/apk/res/android" xmlns:aapt="http://schemas.android.com/aapt"
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
     android:viewportWidth="28"
     android:viewportHeight="28"
     android:width="28dp"

--- a/android/app/src/main/res/drawable/ic_storage_permission.xml
+++ b/android/app/src/main/res/drawable/ic_storage_permission.xml
@@ -1,7 +1,6 @@
 <layer-list xmlns:android="http://schemas.android.com/apk/res/android">
   <item>
-    <shape xmlns:android="http://schemas.android.com/apk/res/android"
-           android:shape="oval">
+    <shape android:shape="oval">
       <solid android:color="@color/black_4"/>
       <size
         android:height="40dp"

--- a/android/app/src/main/res/layout-land/fragment_direction.xml
+++ b/android/app/src/main/res/layout-land/fragment_direction.xml
@@ -1,16 +1,13 @@
 <?xml version="1.0" encoding="utf-8"?>
-<FrameLayout
+<RelativeLayout
   xmlns:android="http://schemas.android.com/apk/res/android"
   xmlns:tools="http://schemas.android.com/tools"
   android:layout_width="match_parent"
   android:layout_height="match_parent"
   android:paddingStart="@dimen/margin_direction_side"
   android:paddingEnd="@dimen/margin_direction_side"
-  tools:background="@color/bg_dialog_translucent">
-  <RelativeLayout
-    android:layout_width="wrap_content"
-    android:layout_height="wrap_content"
-    android:layout_gravity="center">
+  tools:background="@color/bg_dialog_translucent"
+  android:gravity="center">
 
     <app.organicmaps.widget.ArrowView
       android:id="@+id/av__direction"
@@ -56,4 +53,3 @@
         tools:text="9000 km"/>
     </LinearLayout>
   </RelativeLayout>
-</FrameLayout>

--- a/android/app/src/main/res/layout/fragment_prefs_faq.xml
+++ b/android/app/src/main/res/layout/fragment_prefs_faq.xml
@@ -1,13 +1,10 @@
 <?xml version="1.0" encoding="utf-8"?>
-<LinearLayout
+<FrameLayout
   xmlns:android="http://schemas.android.com/apk/res/android"
   android:layout_width="match_parent"
   android:layout_height="match_parent"
+  android:layout_weight="1"
   android:orientation="vertical">
-  <FrameLayout
-    android:layout_width="match_parent"
-    android:layout_height="0dp"
-    android:layout_weight="1">
     <app.organicmaps.widget.ObservableWebView
       android:id="@+id/webview"
       android:layout_width="match_parent"
@@ -28,4 +25,3 @@
     <include layout="@layout/shadow_top" />
     <include layout="@layout/shadow_bottom" />
   </FrameLayout>
-</LinearLayout>

--- a/android/app/src/main/res/layout/indeterminated_progress_dialog.xml
+++ b/android/app/src/main/res/layout/indeterminated_progress_dialog.xml
@@ -1,15 +1,12 @@
 <?xml version="1.0" encoding="utf-8"?>
-<FrameLayout
+<LinearLayout
   xmlns:android="http://schemas.android.com/apk/res/android"
+  android:id="@+id/body"
+  android:orientation="horizontal"
   android:layout_width="match_parent"
-  android:layout_height="wrap_content">
-  <LinearLayout
-    android:id="@+id/body"
-    android:orientation="horizontal"
-    android:layout_width="match_parent"
-    android:layout_height="match_parent"
-    android:baselineAligned="false"
-    android:padding="16dip">
+  android:layout_height="wrap_content"
+  android:baselineAligned="false"
+  android:padding="16dip">
     <ProgressBar
       android:id="@android:id/progress"
       style="?android:attr/progressBarStyle"
@@ -21,5 +18,4 @@
       android:layout_width="match_parent"
       android:layout_height="wrap_content"
       android:layout_gravity="center_vertical"/>
-  </LinearLayout>
-</FrameLayout>
+</LinearLayout>

--- a/android/app/src/main/res/layout/item_search_recent.xml
+++ b/android/app/src/main/res/layout/item_search_recent.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
-<TextView xmlns:android="http://schemas.android.com/apk/res/android"
-          xmlns:app="http://schemas.android.com/apk/res-auto"
-          xmlns:tools="http://schemas.android.com/tools"
-          style="@style/MwmWidget.TextView.Search"
-          app:drawableStartCompat="@drawable/ic_search_recent"
-          tools:text="Some recent query"/>
+<TextView
+  xmlns:app="http://schemas.android.com/apk/res-auto"
+  xmlns:tools="http://schemas.android.com/tools"
+  style="@style/MwmWidget.TextView.Search"
+  app:drawableStartCompat="@drawable/ic_search_recent"
+  tools:text="Some recent query"/>

--- a/android/app/src/main/res/layout/menu_route_plan_line.xml
+++ b/android/app/src/main/res/layout/menu_route_plan_line.xml
@@ -1,11 +1,10 @@
 <?xml version="1.0" encoding="utf-8"?>
 <LinearLayout
-    xmlns:android="http://schemas.android.com/apk/res/android"
-    xmlns:tools="http://schemas.android.com/tools"
-    android:orientation="horizontal"
-    android:background="?cardBackground"
-    android:layout_width="match_parent"
-    android:layout_height="wrap_content">
+  xmlns:android="http://schemas.android.com/apk/res/android"
+  android:orientation="horizontal"
+  android:background="?cardBackground"
+  android:layout_width="match_parent"
+  android:layout_height="wrap_content">
 
   <include layout="@layout/altitude_chart_panel" />
 

--- a/android/app/src/main/res/layout/place_page_fat_shadow.xml
+++ b/android/app/src/main/res/layout/place_page_fat_shadow.xml
@@ -1,10 +1,8 @@
 <?xml version="1.0" encoding="utf-8"?>
 <FrameLayout
   xmlns:android="http://schemas.android.com/apk/res/android"
-  xmlns:tools="http://schemas.android.com/tools"
   android:layout_width="match_parent"
-  android:layout_height="wrap_content"
-  tools:showIn="@layout/place_page_ugc">
+  android:layout_height="wrap_content">
   <android.widget.Space
     android:layout_width="match_parent"
     android:layout_height="@dimen/margin_half"/>

--- a/android/app/src/main/res/layout/place_page_rating_records.xml
+++ b/android/app/src/main/res/layout/place_page_rating_records.xml
@@ -1,7 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <LinearLayout
   xmlns:android="http://schemas.android.com/apk/res/android"
-  xmlns:tools="http://schemas.android.com/tools"
   android:layout_width="match_parent"
   android:layout_height="wrap_content"
   android:background="?cardBackground"

--- a/android/app/src/main/res/layout/placeholder_image.xml
+++ b/android/app/src/main/res/layout/placeholder_image.xml
@@ -6,4 +6,4 @@
   android:layout_width="@dimen/placeholder_size"
   android:layout_height="@dimen/placeholder_size"
   android:layout_marginBottom="@dimen/margin_half_plus"
-  tools:src="@drawable/img_search_empty_history_light"/>
+  tools:src="@drawable/ic_search"/>


### PR DESCRIPTION
This PR cleans resources by using warnings given by Android Studio.

Changes in resources:
- Removes unused declaration namespaces
- Removes unnecessary FrameLayout -> these changes have a good impact on performance
- Removes/updates tools properties that use removed resources

|Before|After|
|-|-|
|<img src="https://github.com/organicmaps/organicmaps/assets/87148630/f1a2ad35-76db-40d1-91f9-4d8ac77f3ac4" height=150 />|<img src="https://github.com/organicmaps/organicmaps/assets/87148630/43b0d73c-546a-4175-bd5c-99dcd0ad8a71" height=150 />|
|<img src="https://github.com/organicmaps/organicmaps/assets/87148630/16cb4b82-cf78-48da-9eb8-5f4fa06a7dab" height=300 />|<img src="https://github.com/organicmaps/organicmaps/assets/87148630/8d3cb468-6713-46bd-ae8c-e0d9175de18e" height=300 />|
|<img src="https://github.com/organicmaps/organicmaps/assets/87148630/18c0f2ff-ec09-4176-aae6-6cf555ea242a" height=300 />|<img src="https://github.com/organicmaps/organicmaps/assets/87148630/f25fde56-5184-4b38-8e42-bbb4bee2c458" height=300 />|
|<img src="https://github.com/organicmaps/organicmaps/assets/87148630/16dfa7f2-35ae-40cb-a892-73c518b9d1dd" height=300 />|<img src="https://github.com/organicmaps/organicmaps/assets/87148630/7214a498-eeff-4de6-ae18-3ff79bbfa092" height=300 />|

For place page layouts, Android Studio suggests removing ImageView and using directly drawables in textView (and maybe giving the ability to remove LinearLayout for each section of the place page), maybe doing these changes, can reduce the personalization of drawables in textView. WDYT?

Tested on Pixel 6 - Android 14