### PR TITLE
[android] Move buildConfig property in module

### DIFF
--- a/android/app/build.gradle
+++ b/android/app/build.gradle
@@ -158,6 +158,7 @@ android {
 
   buildFeatures {
     dataBinding = true
+    buildConfig = true
   }
   // All properties are read from gradle.properties file
   compileSdk propCompileSdkVersion.toInteger()

--- a/android/gradle.properties
+++ b/android/gradle.properties
@@ -6,7 +6,6 @@ org.gradle.caching=true
 org.gradle.jvmargs=-Xmx1024m -Xms256m
 android.useAndroidX=true
 android.native.buildOutput=verbose
-android.defaults.buildfeatures.buildconfig=true
 android.nonTransitiveRClass=false
 android.nonFinalResIds=false
 


### PR DESCRIPTION
A warning is present at the start of the build -> https://github.com/organicmaps/organicmaps/actions/runs/7439832491/job/20240162696?pr=7109#step:5:24
Because in latest versions of gradle, buildConfig in gradle.properties is deprecated, we need to specify property in each module of the project -> https://stackoverflow.com/questions/74634321/fixing-the-build-type-contains-custom-buildconfig-fields-but-the-feature-is-di