### PR TITLE
Add new text in issue templates to reduce duplicate

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -7,6 +7,8 @@ assignees: ''
 
 ---
 
+⚠ Have you searched for similar, already existing issues?
+
 **Describe the issue**
 Please write a clear and concise description of the issue here.
 
@@ -28,7 +30,7 @@ If applicable, add screenshots or screen recordings to help explain your problem
 
 **System information:**
  - Operating system and its version: [iOS 12, Android 10, Ubuntu 22, MacOS Big Sur, etc.]
- - Organic Maps version: [you can find it by tapping the button with the green Organic Maps logo, bottom left of the main screen on Android, or the `?` button on iOS]
+ - Organic Maps version: [you can find it by tapping the button with the green Organic Maps logo]
  - Device Model: [e.g. iPhone 6, Samsung S22]
 
 

--- a/.github/ISSUE_TEMPLATE/feature_request.md
+++ b/.github/ISSUE_TEMPLATE/feature_request.md
@@ -7,6 +7,8 @@ assignees: ''
 
 ---
 
+⚠ Have you searched for similar, already existing issues?
+
 **Is your feature request related to a problem? Please describe.**
 A clear and concise description of what the problem is. For example:
 I'm always frustrated when [...]


### PR DESCRIPTION
I see some OM users create issues to report bugs or ask new features, without checking if the repository have already similar issues.
And manage issues take a lot of time and sometimes it's harder to find similar or duplicates issues

This PR adds the new text in templates, to tell to users to search issues before creating (I hope users read the text template).