### PR TITLE
[android] Update dimensions to improve roundabout exit number and place page

### DIFF
--- a/android/app/src/main/res/layout/place_page_preview.xml
+++ b/android/app/src/main/res/layout/place_page_preview.xml
@@ -97,8 +97,8 @@
         <com.google.android.material.button.MaterialButton
           android:id="@+id/share_button"
           style="@style/Widget.MaterialComponents.Button.UnelevatedButton"
-          android:layout_width="48dp"
-          android:layout_height="48dp"
+          android:layout_width="@dimen/place_page_top_button"
+          android:layout_height="@dimen/place_page_top_button"
           android:background="?attr/selectableItemBackgroundBorderless"
           android:contentDescription="@string/share"
           android:insetLeft="0dp"
@@ -115,8 +115,8 @@
         <com.google.android.material.button.MaterialButton
           android:id="@+id/close_button"
           style="@style/Widget.MaterialComponents.Button.UnelevatedButton"
-          android:layout_width="48dp"
-          android:layout_height="48dp"
+          android:layout_width="@dimen/place_page_top_button"
+          android:layout_height="@dimen/place_page_top_button"
           android:layout_marginStart="@dimen/margin_quarter"
           android:background="?attr/selectableItemBackgroundBorderless"
           android:contentDescription="@string/close"

--- a/android/app/src/main/res/values/dimens.xml
+++ b/android/app/src/main/res/values/dimens.xml
@@ -44,7 +44,7 @@
 
   <dimen name="place_page_width">320dp</dimen>
   <dimen name="place_page_buttons_height">56dp</dimen>
-  <dimen name="place_page_top_button">36dp</dimen>
+  <dimen name="place_page_top_button">40dp</dimen>
 
   <dimen name="downloader_status_size">40dp</dimen>
   <dimen name="search_progress_size">32dp</dimen>

--- a/android/app/src/main/res/values/font_sizes.xml
+++ b/android/app/src/main/res/values/font_sizes.xml
@@ -56,7 +56,7 @@
 
   <dimen name="text_size_nav_street">17sp</dimen>
   <dimen name="text_size_nav_next_turn">24sp</dimen>
-  <dimen name="text_size_nav_circle_exit">20sp</dimen>
+  <dimen name="text_size_nav_circle_exit">22sp</dimen>
   <dimen name="text_size_nav_number">24sp</dimen>
   <dimen name="text_size_nav_dimension">20sp</dimen>
   <dimen name="text_size_nav_menu_number">28sp</dimen>


### PR DESCRIPTION
This PR:
- Increase the size of the roundabout exit number (As requested by user in Telegram)
- Reduce the size place page button (Roman has seen the height of the place page increase after this PR #6776)

|Before|After|Max size font|
|-|-|-|
|<img src="https://github.com/organicmaps/organicmaps/assets/87148630/a54dff5a-2d06-457d-b8a3-acc64a220af6" height=300 />|<img src="https://github.com/organicmaps/organicmaps/assets/87148630/b58107f9-7993-46b5-b799-8c4c7579321c" height=300 />|<img src="https://github.com/organicmaps/organicmaps/assets/87148630/7888e39c-d172-48ba-9139-1b92956d4892" height=300 />|

|Before 6776|January release|After|
|-|-|-|
|<img src="https://github.com/organicmaps/organicmaps/assets/87148630/1d5a154f-2bd5-495f-aab3-214690db978e" height=300 />|<img src="https://github.com/organicmaps/organicmaps/assets/87148630/038c21ff-14d6-4dd9-a374-1dd6b6c82fd4" height=300 />|<img src="https://github.com/organicmaps/organicmaps/assets/87148630/82ddf10b-8699-495d-b49d-d232cfa5970d" height=300 />|