### PR TITLE
Add operator to parkings

### DIFF
--- a/generator/osm2meta.cpp
+++ b/generator/osm2meta.cpp
@@ -111,7 +111,8 @@ std::string MetadataTagProcessorImpl::ValidateAndFormat_operator(std::string con
       ftypes::IsPostOfficeChecker::Instance()(t) ||
       ftypes::IsCarSharingChecker::Instance()(t) ||
       ftypes::IsCarRentalChecker::Instance()(t) ||
-      ftypes::IsBicycleRentalChecker::Instance()(t))
+      ftypes::IsBicycleRentalChecker::Instance()(t) ||
+      ftypes::IsParkingChecker::Instance()(t))
   {
     return v;
   }

--- a/indexer/ftypes_matcher.cpp
+++ b/indexer/ftypes_matcher.cpp
@@ -241,6 +241,12 @@ IsBicycleRentalChecker::IsBicycleRentalChecker()
   m_types.push_back(c.GetTypeByPath({"amenity", "bicycle_rental"}));
 }
 
+IsParkingChecker::IsParkingChecker() : BaseChecker(2 /* level */)
+{
+  Classificator const & c = classif();
+  m_types.push_back(c.GetTypeByPath({"amenity", "parking"}));
+}
+
 IsRecyclingCentreChecker::IsRecyclingCentreChecker() : BaseChecker(3 /* level */)
 {
   Classificator const & c = classif();

--- a/indexer/ftypes_matcher.hpp
+++ b/indexer/ftypes_matcher.hpp
@@ -126,6 +126,14 @@ public:
   DECLARE_CHECKER_INSTANCE(IsBicycleRentalChecker);
 };
 
+class IsParkingChecker : public BaseChecker
+{
+  IsParkingChecker();
+
+public:
+  DECLARE_CHECKER_INSTANCE(IsParkingChecker);
+};
+
 class IsRecyclingCentreChecker : public BaseChecker
 {
   IsRecyclingCentreChecker();


### PR DESCRIPTION
This PR adds the operator tag to parkings. This can be specially useful for paid parkings where you may want to know which parking app you are gonna have to use to pay before getting there.

<img src="https://github.com/organicmaps/organicmaps/assets/47610359/72525dd8-f10f-4850-8bd0-59122fce5472" width="320"/>
