### PR TITLE
[android] Fix Spanish and Portuguese TTS text selection

### DIFF
--- a/android/app/src/main/res/values/strings-tts.xml
+++ b/android/app/src/main/res/values/strings-tts.xml
@@ -23,7 +23,7 @@
     <item>ca</item>
     <item>da</item>
     <item>de</item>
-    <item>es-ES:es-ES</item>
+    <item>es-ES:es</item>
     <item>es-MX:es-MX</item>
     <item>eu</item>
     <item>fr</item>
@@ -34,7 +34,7 @@
     <item>nl</item>
     <item>nb</item>
     <item>pl</item>
-    <item>pt-PT:pt-PT</item>
+    <item>pt-PT:pt</item>
     <item>pt-BR:pt-BR</item>
     <item>ro</item>
     <item>sk</item>


### PR DESCRIPTION
This PR fixes [Issue 7154](https://github.com/organicmaps/organicmaps/issues/7154), using the correct language code for plain Spanish & Portuguese language codes for the selection of TTS texts for driving instructions.

This change has been tested on the Android Studio emulator and on an actual Android device running Android 9.