### PR TITLE
[strings] Small fix in Ukrainian translation

### DIFF
--- a/android/app/src/main/res/values-uk/strings.xml
+++ b/android/app/src/main/res/values-uk/strings.xml
@@ -471,7 +471,7 @@
 	<string name="editor_profile_changes">Виправлення, що ураховані</string>
 	<string name="editor_focus_map_on_location">Потягніть мапу, щоб вибрати правильне місцезнаходження об’єкту.</string>
 	<string name="editor_edit_place_title">Редагування</string>
-	<string name="editor_add_place_title">Додовання</string>
+	<string name="editor_add_place_title">Додавання</string>
 	<string name="editor_edit_place_name_hint">Назва місця</string>
 	<string name="editor_edit_place_category_title">Категорія</string>
 	<string name="detailed_problem_description">Детальний опис проблеми</string>

--- a/data/strings/strings.txt
+++ b/data/strings/strings.txt
@@ -14574,7 +14574,7 @@
     sv = Lägger till
     th = กำลังเพิ่ม
     tr = Ekleme
-    uk = Додовання
+    uk = Додавання
     vi = Nhập
     zh-Hans = 添加中
     zh-Hant = 新增中

--- a/iphone/Maps/LocalizedStrings/uk.lproj/Localizable.strings
+++ b/iphone/Maps/LocalizedStrings/uk.lproj/Localizable.strings
@@ -692,7 +692,7 @@
 
 "editor_edit_place_title" = "Редагування";
 
-"editor_add_place_title" = "Додовання";
+"editor_add_place_title" = "Додавання";
 
 "editor_edit_place_name_hint" = "Назва місця";
 


### PR DESCRIPTION
Replaced "Додовання" with "Додавання":

![photo_2024-01-14_23-28-33](https://github.com/organicmaps/organicmaps/assets/720808/4ea6482f-27e8-478c-b9db-3252e1b7f55d)
