### PR TITLE
Add sorting bookmarks and tracks by name

### DIFF
--- a/android/app/src/main/java/app/organicmaps/bookmarks/ChooseBookmarksSortingTypeFragment.java
+++ b/android/app/src/main/java/app/organicmaps/bookmarks/ChooseBookmarksSortingTypeFragment.java
@@ -74,6 +74,8 @@ public class ChooseBookmarksSortingTypeFragment extends BaseMwmDialogFragment
           return R.id.sort_by_distance;
         case BookmarkManager.SORT_BY_TIME:
           return R.id.sort_by_time;
+        case BookmarkManager.SORT_BY_NAME:
+          return R.id.sort_by_name;
       }
     }
     return R.id.sort_by_default;
@@ -88,7 +90,7 @@ public class ChooseBookmarksSortingTypeFragment extends BaseMwmDialogFragment
     if (args == null)
       throw new AssertionError("Arguments of choose sorting type view can't be null.");
 
-    UiUtils.hide(view, R.id.sort_by_type, R.id.sort_by_distance, R.id.sort_by_time);
+    UiUtils.hide(view, R.id.sort_by_type, R.id.sort_by_distance, R.id.sort_by_time, R.id.sort_by_name);
 
     @BookmarkManager.SortingType
     int[] availableSortingTypes = args.getIntArray(EXTRA_SORTING_TYPES);
@@ -151,5 +153,7 @@ public class ChooseBookmarksSortingTypeFragment extends BaseMwmDialogFragment
       setSortingType(BookmarkManager.SORT_BY_DISTANCE);
     else if (id == R.id.sort_by_time)
       setSortingType(BookmarkManager.SORT_BY_TIME);
+    else if (id == R.id.sort_by_name)
+      setSortingType(BookmarkManager.SORT_BY_NAME);
   }
 }

--- a/android/app/src/main/java/app/organicmaps/bookmarks/data/BookmarkManager.java
+++ b/android/app/src/main/java/app/organicmaps/bookmarks/data/BookmarkManager.java
@@ -63,12 +63,13 @@ public enum BookmarkManager
   public static final int CLOUD_NOT_ENOUGH_DISK_SPACE = 2;
 
   @Retention(RetentionPolicy.SOURCE)
-  @IntDef({ SORT_BY_TYPE, SORT_BY_DISTANCE, SORT_BY_TIME })
+  @IntDef({ SORT_BY_TYPE, SORT_BY_DISTANCE, SORT_BY_TIME, SORT_BY_NAME })
   public @interface SortingType {}
 
   public static final int SORT_BY_TYPE = 0;
   public static final int SORT_BY_DISTANCE = 1;
   public static final int SORT_BY_TIME = 2;
+  public static final int SORT_BY_NAME = 3;
 
   // These values have to match the values of kml::CompilationType from kml/types.hpp
   public static final int CATEGORY = 0;

--- a/android/app/src/main/res/layout/dialog_sorting_types.xml
+++ b/android/app/src/main/res/layout/dialog_sorting_types.xml
@@ -36,6 +36,15 @@
 
     <RadioButton
       style="?fontSubtitle1"
+      android:id="@+id/sort_by_name"
+      android:layout_width="match_parent"
+      android:layout_height="wrap_content"
+      android:padding="@dimen/margin_half_double_plus"
+      android:checked="false"
+      android:text="@string/by_name"/>
+
+    <RadioButton
+      style="?fontSubtitle1"
       android:id="@+id/sort_by_type"
       android:layout_width="match_parent"
       android:layout_height="wrap_content"

--- a/android/app/src/main/res/values-ar/strings.xml
+++ b/android/app/src/main/res/values-ar/strings.xml
@@ -700,6 +700,8 @@
 	<string name="by_distance">حسب المسافة</string>
 	<!-- Android -->
 	<string name="by_date">حسب التاريخ</string>
+	<!-- Android -->
+	<string name="by_name">بالاسم</string>
 	<string name="week_ago_sorttype">منذ أسبوع</string>
 	<string name="month_ago_sorttype">منذ شهر</string>
 	<string name="moremonth_ago_sorttype">منذ أكثر من شهر</string>

--- a/android/app/src/main/res/values-az/strings.xml
+++ b/android/app/src/main/res/values-az/strings.xml
@@ -685,6 +685,8 @@
 	<string name="by_distance">Məsafəyə görə</string>
 	<!-- Android -->
 	<string name="by_date">Tarixə görə</string>
+	<!-- Android -->
+	<string name="by_name">Ada görə</string>
 	<string name="week_ago_sorttype">Bir həftə əvvəl</string>
 	<string name="month_ago_sorttype">Bir ay əvvəl</string>
 	<string name="moremonth_ago_sorttype">Bir aydan çox əvvəl</string>

--- a/android/app/src/main/res/values-be/strings.xml
+++ b/android/app/src/main/res/values-be/strings.xml
@@ -684,6 +684,8 @@
 	<string name="by_distance">Па адлегласці</string>
 	<!-- Android -->
 	<string name="by_date">Па даце</string>
+	<!-- Android -->
+	<string name="by_name">Па імені</string>
 	<string name="week_ago_sorttype">Тыдзень таму</string>
 	<string name="month_ago_sorttype">Месяц таму</string>
 	<string name="moremonth_ago_sorttype">Больш за месяц таму</string>

--- a/android/app/src/main/res/values-bg/strings.xml
+++ b/android/app/src/main/res/values-bg/strings.xml
@@ -641,6 +641,8 @@
 	<string name="by_distance">По разстояние</string>
 	<!-- Android -->
 	<string name="by_date">По дата</string>
+	<!-- Android -->
+	<string name="by_name">По име</string>
 
 	<!-- SECTION: Bookmark types used for sorting -->
 	<string name="search_in_the_list">Търсене в списъка</string>

--- a/android/app/src/main/res/values-ca/strings.xml
+++ b/android/app/src/main/res/values-ca/strings.xml
@@ -680,6 +680,8 @@
 	<string name="by_distance">Per distància</string>
 	<!-- Android -->
 	<string name="by_date">Per data</string>
+	<!-- Android -->
+	<string name="by_name">Per nom</string>
 	<string name="week_ago_sorttype">Fa una setmana</string>
 	<string name="month_ago_sorttype">Fa un mes</string>
 	<string name="moremonth_ago_sorttype">Fa més d\'un mes</string>

--- a/android/app/src/main/res/values-cs/strings.xml
+++ b/android/app/src/main/res/values-cs/strings.xml
@@ -662,6 +662,8 @@
 	<string name="by_distance">Podle vzdálenosti</string>
 	<!-- Android -->
 	<string name="by_date">Podle data</string>
+	<!-- Android -->
+	<string name="by_name">Podle jména</string>
 	<string name="week_ago_sorttype">Před týdnem</string>
 	<string name="month_ago_sorttype">Před měsícem</string>
 	<string name="moremonth_ago_sorttype">Více než před měsícem</string>

--- a/android/app/src/main/res/values-da/strings.xml
+++ b/android/app/src/main/res/values-da/strings.xml
@@ -657,6 +657,8 @@
 	<string name="by_distance">Efter afstand</string>
 	<!-- Android -->
 	<string name="by_date">Efter dato</string>
+	<!-- Android -->
+	<string name="by_name">efter navn</string>
 	<string name="week_ago_sorttype">En uge siden</string>
 	<string name="month_ago_sorttype">En måned siden</string>
 	<string name="moremonth_ago_sorttype">Mere end en måned siden</string>

--- a/android/app/src/main/res/values-de/strings.xml
+++ b/android/app/src/main/res/values-de/strings.xml
@@ -687,6 +687,8 @@
 	<string name="by_distance">Nach Entfernung</string>
 	<!-- Android -->
 	<string name="by_date">Nach Datum</string>
+	<!-- Android -->
+	<string name="by_name">Nach Name</string>
 	<string name="week_ago_sorttype">Vor einer Woche</string>
 	<string name="month_ago_sorttype">Vor einem Monat</string>
 	<string name="moremonth_ago_sorttype">Vor über einem Monat</string>

--- a/android/app/src/main/res/values-el/strings.xml
+++ b/android/app/src/main/res/values-el/strings.xml
@@ -644,6 +644,8 @@
 	<string name="by_distance">Κατά απόσταση</string>
 	<!-- Android -->
 	<string name="by_date">Κατά ημερομηνία</string>
+	<!-- Android -->
+	<string name="by_name">Με όνομα</string>
 	<string name="week_ago_sorttype">Μια βδομάδα πριν</string>
 	<string name="month_ago_sorttype">Ένας μήνας πριν</string>
 	<string name="moremonth_ago_sorttype">Περισσότερο από έναν μήνα πριν</string>

--- a/android/app/src/main/res/values-es-rMX/strings.xml
+++ b/android/app/src/main/res/values-es-rMX/strings.xml
@@ -160,6 +160,8 @@
 	<string name="by_distance">Por distancia</string>
 	<!-- Android -->
 	<string name="by_date">Por fecha</string>
+	<!-- Android -->
+	<string name="by_name">Por nombre</string>
 	<string name="week_ago_sorttype">Hace una semana</string>
 	<string name="month_ago_sorttype">Hace un mes</string>
 	<string name="moremonth_ago_sorttype">Hace más de un mes</string>

--- a/android/app/src/main/res/values-es/strings.xml
+++ b/android/app/src/main/res/values-es/strings.xml
@@ -691,6 +691,8 @@
 	<string name="by_distance">Por distancia</string>
 	<!-- Android -->
 	<string name="by_date">Por fecha</string>
+	<!-- Android -->
+	<string name="by_name">Por nombre</string>
 	<string name="week_ago_sorttype">Hace una semana</string>
 	<string name="month_ago_sorttype">Hace un mes</string>
 	<string name="moremonth_ago_sorttype">Hace más de un mes</string>

--- a/android/app/src/main/res/values-et/strings.xml
+++ b/android/app/src/main/res/values-et/strings.xml
@@ -678,6 +678,8 @@
 	<string name="by_distance">Kauguse järgi</string>
 	<!-- Android -->
 	<string name="by_date">Kuupäeva järgi</string>
+	<!-- Android -->
+	<string name="by_name">Nime järgi</string>
 	<string name="week_ago_sorttype">Nädal tagasi</string>
 	<string name="month_ago_sorttype">Kuu tagasi</string>
 	<string name="moremonth_ago_sorttype">Üle kuu tagasi</string>

--- a/android/app/src/main/res/values-eu/strings.xml
+++ b/android/app/src/main/res/values-eu/strings.xml
@@ -689,6 +689,8 @@
 	<string name="by_distance">Distantziaren arabera</string>
 	<!-- Android -->
 	<string name="by_date">Dataren arabera</string>
+	<!-- Android -->
+	<string name="by_name">Izenaren arabera</string>
 	<string name="week_ago_sorttype">Duela aste bat</string>
 	<string name="month_ago_sorttype">Duela hilabete bat</string>
 	<string name="moremonth_ago_sorttype">Duela hilabete baino gehiago</string>

--- a/android/app/src/main/res/values-fa/strings.xml
+++ b/android/app/src/main/res/values-fa/strings.xml
@@ -655,6 +655,8 @@
 	<string name="by_distance">بر اساس فاصله</string>
 	<!-- Android -->
 	<string name="by_date">بر اساس تاریخ</string>
+	<!-- Android -->
+	<string name="by_name">بر اساس اسم</string>
 	<string name="week_ago_sorttype">یک هفته قبل</string>
 	<string name="month_ago_sorttype">یک ماه قبل</string>
 	<string name="moremonth_ago_sorttype">بیش از یک ماه قبل</string>

--- a/android/app/src/main/res/values-fi/strings.xml
+++ b/android/app/src/main/res/values-fi/strings.xml
@@ -693,6 +693,8 @@
 	<string name="by_distance">Etäisyys</string>
 	<!-- Android -->
 	<string name="by_date">Päivämäärä</string>
+	<!-- Android -->
+	<string name="by_name">Nimen mukaan</string>
 	<string name="week_ago_sorttype">Viikko sitten</string>
 	<string name="month_ago_sorttype">Kuukausi sitten</string>
 	<string name="moremonth_ago_sorttype">Yli kuukausi sitten</string>

--- a/android/app/src/main/res/values-fr/strings.xml
+++ b/android/app/src/main/res/values-fr/strings.xml
@@ -692,6 +692,8 @@
 	<string name="by_distance">Par distance</string>
 	<!-- Android -->
 	<string name="by_date">Par date</string>
+	<!-- Android -->
+	<string name="by_name">Par nom</string>
 	<string name="week_ago_sorttype">Il y a une semaine</string>
 	<string name="month_ago_sorttype">Il y a un mois</string>
 	<string name="moremonth_ago_sorttype">Il y a plus d\'un mois</string>

--- a/android/app/src/main/res/values-hu/strings.xml
+++ b/android/app/src/main/res/values-hu/strings.xml
@@ -669,6 +669,8 @@
 	<string name="by_distance">Távolság szerint</string>
 	<!-- Android -->
 	<string name="by_date">Dátum szerint</string>
+	<!-- Android -->
+	<string name="by_name">Név szerint</string>
 	<string name="week_ago_sorttype">Egy hete</string>
 	<string name="month_ago_sorttype">Egy hónapja</string>
 	<string name="moremonth_ago_sorttype">Több mint egy hónapja</string>

--- a/android/app/src/main/res/values-in/strings.xml
+++ b/android/app/src/main/res/values-in/strings.xml
@@ -657,6 +657,8 @@
 	<string name="by_distance">Per jarak</string>
 	<!-- Android -->
 	<string name="by_date">Per tanggal</string>
+	<!-- Android -->
+	<string name="by_name">Berdasarkan Nama</string>
 	<string name="week_ago_sorttype">Seminggu yang lalu</string>
 	<string name="month_ago_sorttype">Sebulan yang lalu</string>
 	<string name="moremonth_ago_sorttype">Lebih dari sebulan yang lalu</string>

--- a/android/app/src/main/res/values-it/strings.xml
+++ b/android/app/src/main/res/values-it/strings.xml
@@ -674,6 +674,8 @@
 	<string name="by_distance">Per distanza</string>
 	<!-- Android -->
 	<string name="by_date">Per data</string>
+	<!-- Android -->
+	<string name="by_name">Per nome</string>
 	<string name="week_ago_sorttype">Una settimana fa</string>
 	<string name="month_ago_sorttype">Un mese fa</string>
 	<string name="moremonth_ago_sorttype">Più di un mese fa</string>

--- a/android/app/src/main/res/values-iw/strings.xml
+++ b/android/app/src/main/res/values-iw/strings.xml
@@ -682,6 +682,8 @@
 	<string name="by_distance">לפי מרחק</string>
 	<!-- Android -->
 	<string name="by_date">לפי תאריך</string>
+	<!-- Android -->
+	<string name="by_name">לפי שם</string>
 	<string name="week_ago_sorttype">לפני שבוע</string>
 	<string name="month_ago_sorttype">לפני חודש</string>
 	<string name="moremonth_ago_sorttype">לפני יותר מחודש</string>

--- a/android/app/src/main/res/values-ja/strings.xml
+++ b/android/app/src/main/res/values-ja/strings.xml
@@ -652,6 +652,8 @@
 	<string name="by_distance">距離で</string>
 	<!-- Android -->
 	<string name="by_date">日付で</string>
+	<!-- Android -->
+	<string name="by_name">名前で</string>
 	<string name="week_ago_sorttype">1週間前</string>
 	<string name="month_ago_sorttype">1ケ月前</string>
 	<string name="moremonth_ago_sorttype">1ケ月以上前</string>

--- a/android/app/src/main/res/values-ko/strings.xml
+++ b/android/app/src/main/res/values-ko/strings.xml
@@ -654,6 +654,8 @@
 	<string name="by_distance">거리 별</string>
 	<!-- Android -->
 	<string name="by_date">날짜 별</string>
+	<!-- Android -->
+	<string name="by_name">이름별</string>
 	<string name="week_ago_sorttype">일주일 전</string>
 	<string name="month_ago_sorttype">한달 전</string>
 	<string name="moremonth_ago_sorttype">한달 그 이상 전</string>

--- a/android/app/src/main/res/values-mr/strings.xml
+++ b/android/app/src/main/res/values-mr/strings.xml
@@ -653,6 +653,8 @@
 	<string name="by_distance">अंतरानुसार</string>
 	<!-- Android -->
 	<string name="by_date">दिनांकानुसार</string>
+	<!-- Android -->
+	<string name="by_name">नावाने</string>
 	<string name="week_ago_sorttype">गेल्या आठवड्यात</string>
 	<string name="month_ago_sorttype">गेल्या महिन्यात</string>
 	<string name="moremonth_ago_sorttype">एक महिन्यापूर्वी</string>

--- a/android/app/src/main/res/values-nb/strings.xml
+++ b/android/app/src/main/res/values-nb/strings.xml
@@ -688,6 +688,8 @@
 	<string name="by_distance">Etter avstand</string>
 	<!-- Android -->
 	<string name="by_date">Etter dato</string>
+	<!-- Android -->
+	<string name="by_name">Etter navn</string>
 	<string name="week_ago_sorttype">For en uke siden</string>
 	<string name="month_ago_sorttype">For en måned siden</string>
 	<string name="moremonth_ago_sorttype">Mer enn en måned siden</string>

--- a/android/app/src/main/res/values-nl/strings.xml
+++ b/android/app/src/main/res/values-nl/strings.xml
@@ -684,6 +684,8 @@
 	<string name="by_distance">Op afstand</string>
 	<!-- Android -->
 	<string name="by_date">Op datum</string>
+	<!-- Android -->
+	<string name="by_name">Op naam</string>
 	<string name="week_ago_sorttype">Een week geleden</string>
 	<string name="month_ago_sorttype">Een maand geleden</string>
 	<string name="moremonth_ago_sorttype">Meer dan een maand geleden</string>

--- a/android/app/src/main/res/values-pl/strings.xml
+++ b/android/app/src/main/res/values-pl/strings.xml
@@ -689,6 +689,8 @@
 	<string name="by_distance">Wg odległości</string>
 	<!-- Android -->
 	<string name="by_date">Wg daty</string>
+	<!-- Android -->
+	<string name="by_name">Według nazwy</string>
 	<string name="week_ago_sorttype">Tydzień temu</string>
 	<string name="month_ago_sorttype">Miesiąc temu</string>
 	<string name="moremonth_ago_sorttype">Ponad miesiąc temu</string>

--- a/android/app/src/main/res/values-pt/strings.xml
+++ b/android/app/src/main/res/values-pt/strings.xml
@@ -665,6 +665,8 @@
 	<string name="by_distance">Por distância</string>
 	<!-- Android -->
 	<string name="by_date">Por data</string>
+	<!-- Android -->
+	<string name="by_name">Por nome</string>
 	<string name="week_ago_sorttype">Uma semana atrás</string>
 	<string name="month_ago_sorttype">Um mês atrás</string>
 	<string name="moremonth_ago_sorttype">Mais de um mês atrás</string>

--- a/android/app/src/main/res/values-ro/strings.xml
+++ b/android/app/src/main/res/values-ro/strings.xml
@@ -672,6 +672,8 @@
 	<string name="by_distance">După distanță</string>
 	<!-- Android -->
 	<string name="by_date">După dată</string>
+	<!-- Android -->
+	<string name="by_name">După nume</string>
 	<string name="week_ago_sorttype">Acum o săptămână</string>
 	<string name="month_ago_sorttype">Acum o lună</string>
 	<string name="moremonth_ago_sorttype">Acum mai mult de o lună</string>

--- a/android/app/src/main/res/values-ru/strings.xml
+++ b/android/app/src/main/res/values-ru/strings.xml
@@ -698,6 +698,8 @@
 	<string name="by_distance">По расстоянию</string>
 	<!-- Android -->
 	<string name="by_date">По дате</string>
+	<!-- Android -->
+	<string name="by_name">По имени</string>
 	<string name="week_ago_sorttype">Неделю назад</string>
 	<string name="month_ago_sorttype">Месяц назад</string>
 	<string name="moremonth_ago_sorttype">Больше месяца назад</string>

--- a/android/app/src/main/res/values-sk/strings.xml
+++ b/android/app/src/main/res/values-sk/strings.xml
@@ -654,6 +654,8 @@
 	<string name="by_distance">Podľa vzdialenosti</string>
 	<!-- Android -->
 	<string name="by_date">Podľa dátumu</string>
+	<!-- Android -->
+	<string name="by_name">Podľa mena</string>
 	<string name="week_ago_sorttype">Pred týždňom</string>
 	<string name="month_ago_sorttype">Pred mesiacom</string>
 	<string name="moremonth_ago_sorttype">Pred viac ako mesiacom</string>

--- a/android/app/src/main/res/values-sv/strings.xml
+++ b/android/app/src/main/res/values-sv/strings.xml
@@ -655,6 +655,8 @@
 	<string name="by_distance">Efter avstånd</string>
 	<!-- Android -->
 	<string name="by_date">Efter datum</string>
+	<!-- Android -->
+	<string name="by_name">Efter namn</string>
 	<string name="week_ago_sorttype">För en vecka sedan</string>
 	<string name="month_ago_sorttype">För en månad sedan</string>
 	<string name="moremonth_ago_sorttype">För över en månad sedan</string>

--- a/android/app/src/main/res/values-sw/strings.xml
+++ b/android/app/src/main/res/values-sw/strings.xml
@@ -216,6 +216,8 @@
 	<string name="by_distance">Kwa umbali</string>
 	<!-- Android -->
 	<string name="by_date">Kwa tarehe</string>
+	<!-- Android -->
+	<string name="by_name">Kwa Jina</string>
 	<string name="week_ago_sorttype">Wiki moja iliyopita</string>
 	<string name="month_ago_sorttype">Mwezi mmoja uliopita</string>
 	<string name="moremonth_ago_sorttype">Zaidi ya mwezi mmoja uliopita</string>

--- a/android/app/src/main/res/values-th/strings.xml
+++ b/android/app/src/main/res/values-th/strings.xml
@@ -656,6 +656,8 @@
 	<string name="by_distance">ตามระยะทาง</string>
 	<!-- Android -->
 	<string name="by_date">ตามวันที่</string>
+	<!-- Android -->
+	<string name="by_name">ตามชื่อ</string>
 	<string name="week_ago_sorttype">สัปดาห์ที่ผ่านมา</string>
 	<string name="month_ago_sorttype">เดือนที่ผ่านมา</string>
 	<string name="moremonth_ago_sorttype">มากกว่าหนึ่งเดือนที่ผ่านมา</string>

--- a/android/app/src/main/res/values-tr/strings.xml
+++ b/android/app/src/main/res/values-tr/strings.xml
@@ -687,6 +687,8 @@
 	<string name="by_distance">Mesafeye göre</string>
 	<!-- Android -->
 	<string name="by_date">Tarihe göre</string>
+	<!-- Android -->
+	<string name="by_name">İsme göre</string>
 	<string name="week_ago_sorttype">Bir hafta önce</string>
 	<string name="month_ago_sorttype">Bir ay önce</string>
 	<string name="moremonth_ago_sorttype">Bir aydan daha önce</string>

--- a/android/app/src/main/res/values-uk/strings.xml
+++ b/android/app/src/main/res/values-uk/strings.xml
@@ -691,6 +691,8 @@
 	<string name="by_distance">За відстанню</string>
 	<!-- Android -->
 	<string name="by_date">За датою</string>
+	<!-- Android -->
+	<string name="by_name">За назвою</string>
 	<string name="week_ago_sorttype">Тиждень тому</string>
 	<string name="month_ago_sorttype">Місяць тому</string>
 	<string name="moremonth_ago_sorttype">Понад місяць тому</string>

--- a/android/app/src/main/res/values-vi/strings.xml
+++ b/android/app/src/main/res/values-vi/strings.xml
@@ -655,6 +655,8 @@
 	<string name="by_distance">Theo khoảng cách</string>
 	<!-- Android -->
 	<string name="by_date">Theo ngày</string>
+	<!-- Android -->
+	<string name="by_name">Theo Tên</string>
 	<string name="week_ago_sorttype">Tuần trước</string>
 	<string name="month_ago_sorttype">Tháng trước</string>
 	<string name="moremonth_ago_sorttype">Hơn một tháng trước</string>

--- a/android/app/src/main/res/values-zh-rTW/strings.xml
+++ b/android/app/src/main/res/values-zh-rTW/strings.xml
@@ -672,6 +672,8 @@
 	<string name="by_distance">按距離</string>
 	<!-- Android -->
 	<string name="by_date">按時間</string>
+	<!-- Android -->
+	<string name="by_name">按名字</string>
 	<string name="week_ago_sorttype">一週前</string>
 	<string name="month_ago_sorttype">一個月前</string>
 	<string name="moremonth_ago_sorttype">一個多月前</string>

--- a/android/app/src/main/res/values-zh/strings.xml
+++ b/android/app/src/main/res/values-zh/strings.xml
@@ -665,6 +665,8 @@
 	<string name="by_distance">按距离</string>
 	<!-- Android -->
 	<string name="by_date">按时间</string>
+	<!-- Android -->
+	<string name="by_name">按名称</string>
 	<string name="week_ago_sorttype">一周前</string>
 	<string name="month_ago_sorttype">一月前</string>
 	<string name="moremonth_ago_sorttype">一个多月前</string>

--- a/android/app/src/main/res/values/strings.xml
+++ b/android/app/src/main/res/values/strings.xml
@@ -716,6 +716,8 @@
 	<string name="by_distance">By distance</string>
 	<!-- Android -->
 	<string name="by_date">By date</string>
+	<!-- Android -->
+	<string name="by_name">By name</string>
 	<string name="week_ago_sorttype">A week ago</string>
 	<string name="month_ago_sorttype">A month ago</string>
 	<string name="moremonth_ago_sorttype">More than a month ago</string>

--- a/data/strings/strings.txt
+++ b/data/strings/strings.txt
@@ -24991,6 +24991,52 @@
     zh-Hans = 按时间
     zh-Hant = 按時間
 
+  [by_name]
+    comment = Android
+    tags = android
+    en = By name
+    af = Op Naam
+    ar = بالاسم
+    az = Ada görə
+    be = Па імені
+    bg = По име
+    ca = Per nom
+    cs = Podle jména
+    da = efter navn
+    de = Nach Name
+    el = Με όνομα
+    es = Por nombre
+    es-MX = Por nombre
+    et = Nime järgi
+    eu = Izenaren arabera
+    fa = بر اساس اسم
+    fi = Nimen mukaan
+    fr = Par nom
+    he = לפי שם
+    hi = नाम द्वारा
+    hu = Név szerint
+    id = Berdasarkan Nama
+    it = Per nome
+    ja = 名前で
+    ko = 이름별
+    lt = Pagal pavadinimą
+    mr = नावाने
+    nb = Etter navn
+    nl = Op naam
+    pl = Według nazwy
+    pt = Por nome
+    ro = După nume
+    ru = По имени
+    sk = Podľa mena
+    sv = Efter namn
+    sw = Kwa Jina
+    th = ตามชื่อ
+    tr = İsme göre
+    uk = За назвою
+    vi = Theo Tên
+    zh-Hans = 按名称
+    zh-Hant = 按名字
+
   [week_ago_sorttype]
     tags = android,ios
     en = A week ago

--- a/map/bookmark_manager.cpp
+++ b/map/bookmark_manager.cpp
@@ -103,6 +103,7 @@ std::string ToString(BookmarkManager::SortingType type)
   case BookmarkManager::SortingType::ByTime: return "ByTime";
   case BookmarkManager::SortingType::ByType: return "ByType";
   case BookmarkManager::SortingType::ByDistance: return "ByDistance";
+  case BookmarkManager::SortingType::ByName: return "ByName";
   }
   UNREACHABLE();
 }
@@ -115,6 +116,8 @@ bool GetSortingType(std::string const & typeStr, BookmarkManager::SortingType & 
     type = BookmarkManager::SortingType::ByType;
   else if (typeStr == ToString(BookmarkManager::SortingType::ByDistance))
     type = BookmarkManager::SortingType::ByDistance;
+  else if (typeStr == ToString(BookmarkManager::SortingType::ByName))
+    type = BookmarkManager::SortingType::ByName;
   else
     return false;
   return true;
@@ -544,7 +547,8 @@ std::vector<BookmarkManager::SortingType> BookmarkManager::GetAvailableSortingTy
     sortingTypes.push_back(SortingType::ByDistance);
   if (byTimeChecked)
     sortingTypes.push_back(SortingType::ByTime);
-
+  // sorting by name should always be possible
+  sortingTypes.push_back(SortingType::ByName);
   return sortingTypes;
 }
 
@@ -589,6 +593,12 @@ std::string BookmarkManager::GetSortedByTimeBlockName(SortedByTimeBlockType bloc
 std::string BookmarkManager::GetTracksSortedBlockName()
 {
   return platform::GetLocalizedString("tracks_title");
+}
+
+// static
+std::string BookmarkManager::GetBookmarksSortedBlockName()
+{
+  return platform::GetLocalizedString("bookmarks");
 }
 
 // static
@@ -1035,6 +1045,16 @@ void BookmarkManager::SortTracksByTime(std::vector<SortTrackData> & tracks)
             });
 }
 
+// static
+void BookmarkManager::SortTracksByName(std::vector<SortTrackData> & tracks)
+{
+  std::sort(tracks.begin(), tracks.end(),
+            [](SortTrackData const & lbm, SortTrackData const & rbm)
+            {
+              return lbm.m_name < rbm.m_name;
+            });
+}
+
 void BookmarkManager::SortByDistance(std::vector<SortBookmarkData> const & bookmarksForSort,
                                      std::vector<SortTrackData> const & tracksForSort,
                                      m2::PointD const & myPosition,
@@ -1231,6 +1251,35 @@ void BookmarkManager::SortByType(std::vector<SortBookmarkData> const & bookmarks
   }
 }
 
+void BookmarkManager::SortByName(std::vector<SortBookmarkData> const & bookmarksForSort,
+                                 std::vector<SortTrackData> const & tracksForSort,
+                                 SortedBlocksCollection & sortedBlocks)
+{
+  std::vector<SortTrackData> sortedTracks = tracksForSort;
+  SortTracksByName(sortedTracks);
+  AddTracksSortedBlock(sortedTracks, sortedBlocks);
+
+  std::vector<SortBookmarkData const *> sortedMarks;
+  sortedMarks.reserve(bookmarksForSort.size());
+  for (auto const & mark : bookmarksForSort)
+      sortedMarks.push_back(&mark);
+
+  std::sort(sortedMarks.begin(), sortedMarks.end(),
+            [](SortBookmarkData const * lbm, SortBookmarkData const * rbm)
+            {
+              return lbm->m_name < rbm->m_name;
+            });
+
+  // Put all bookmarks into one block
+  SortedBlock bookmarkBlock;
+  bookmarkBlock.m_blockName = GetBookmarksSortedBlockName();
+  for (auto mark : sortedMarks)
+  {
+      bookmarkBlock.m_markIds.push_back(mark->m_id);
+  }
+  sortedBlocks.push_back(bookmarkBlock);
+}
+
 void BookmarkManager::GetSortedCategoryImpl(SortParams const & params,
                                             std::vector<SortBookmarkData> const & bookmarksForSort,
                                             std::vector<SortTrackData> const & tracksForSort,
@@ -1247,6 +1296,9 @@ void BookmarkManager::GetSortedCategoryImpl(SortParams const & params,
     return;
   case SortingType::ByType:
     SortByType(bookmarksForSort, tracksForSort, sortedBlocks);
+    return;
+  case SortingType::ByName:
+    SortByName(bookmarksForSort, tracksForSort, sortedBlocks);
     return;
   }
   UNREACHABLE();

--- a/map/bookmark_manager.hpp
+++ b/map/bookmark_manager.hpp
@@ -222,7 +222,8 @@ public:
   {
     ByType,
     ByDistance,
-    ByTime
+    ByTime,
+    ByName
   };
 
   struct SortedBlock
@@ -368,6 +369,7 @@ public:
   void CreateCategories(KMLDataCollection && dataCollection, bool autoSave = false);
 
   static std::string GetTracksSortedBlockName();
+  static std::string GetBookmarksSortedBlockName();
   static std::string GetOthersSortedBlockName();
   static std::string GetNearMeSortedBlockName();
   enum class SortedByTimeBlockType : uint32_t
@@ -631,6 +633,7 @@ private:
   {
     SortBookmarkData(kml::BookmarkData const & bmData, search::ReverseGeocoder::RegionAddress const & address)
       : m_id(bmData.m_id)
+      , m_name(GetPreferredBookmarkName(bmData))
       , m_point(bmData.m_point)
       , m_type(GetBookmarkBaseType(bmData.m_featureTypes))
       , m_timestamp(bmData.m_timestamp)
@@ -638,6 +641,7 @@ private:
     {}
 
     kml::MarkId m_id;
+    std::string m_name;
     m2::PointD m_point;
     BookmarkBaseType m_type;
     kml::Timestamp m_timestamp;
@@ -648,10 +652,12 @@ private:
   {
     explicit SortTrackData(kml::TrackData const & trackData)
       : m_id(trackData.m_id)
+      , m_name(GetPreferredBookmarkStr(trackData.m_name))
       , m_timestamp(trackData.m_timestamp)
     {}
 
     kml::TrackId m_id;
+    std::string m_name;
     kml::Timestamp m_timestamp;
   };
 
@@ -669,6 +675,9 @@ private:
   static void SortByType(std::vector<SortBookmarkData> const & bookmarksForSort,
                          std::vector<SortTrackData> const & tracksForSort,
                          SortedBlocksCollection & sortedBlocks);
+  static void SortByName(std::vector<SortBookmarkData> const & bookmarksForSort,
+                         std::vector<SortTrackData> const & tracksForSort,
+                         SortedBlocksCollection & sortedBlocks);
 
   using AddressesCollection = std::vector<std::pair<kml::MarkId, search::ReverseGeocoder::RegionAddress>>;
   void PrepareBookmarksAddresses(std::vector<SortBookmarkData> & bookmarksForSort, AddressesCollection & newAddresses);
@@ -676,6 +685,7 @@ private:
   void SetBookmarksAddresses(AddressesCollection const & addresses);
   static void AddTracksSortedBlock(std::vector<SortTrackData> const & sortedTracks, SortedBlocksCollection & sortedBlocks);
   static void SortTracksByTime(std::vector<SortTrackData> & tracks);
+  static void SortTracksByName(std::vector<SortTrackData> & tracks);
 
   kml::MarkId GetTrackSelectionMarkId(kml::TrackId trackId) const;
   int GetTrackSelectionMarkMinZoom(kml::TrackId trackId) const;


### PR DESCRIPTION
This PR adds the ability to sort bookmarks and tracks alphabetically by name (A->Z). This also allows a crude way of custom sorting by prefixing names accordingly.

 Tracks and bookmarks are kept as separate blocks. As there is no concept of reversing the sort order yet, I could add the reverse order as an additional sort type but I wanted to leave that up to discussion first.


| Menu item | Result | Result with tracks and bookmarks |
|--------|--------|--------|
|![Screenshot_20240115-132758](https://github.com/organicmaps/organicmaps/assets/48260138/ff810407-acd4-4c8c-8ca1-30dd1401eb6a)| ![Screenshot_20240115-132804](https://github.com/organicmaps/organicmaps/assets/48260138/fc59be8d-333b-44e5-8931-bda625726f52) | ![Screenshot_20240115-154930](https://github.com/organicmaps/organicmaps/assets/48260138/031afd6e-5b36-4d3a-ae95-d5f100a9ea42)


Fixes (partially) #1066 (as the lists themselves are not sorted) and partially #4250