### PR TITLE
[android] Reduce Android Studio warnings

### DIFF
--- a/android/app/src/main/java/app/organicmaps/MapFragment.java
+++ b/android/app/src/main/java/app/organicmaps/MapFragment.java
@@ -167,27 +167,24 @@ public class MapFragment extends BaseMwmFragment implements View.OnTouchListener
     int pointerIndex = event.getActionIndex();
     switch (action)
     {
-    case MotionEvent.ACTION_POINTER_UP:
-      action = Map.NATIVE_ACTION_UP;
-      break;
-    case MotionEvent.ACTION_UP:
-      action = Map.NATIVE_ACTION_UP;
-      pointerIndex = 0;
-      break;
-    case MotionEvent.ACTION_POINTER_DOWN:
-      action = Map.NATIVE_ACTION_DOWN;
-      break;
-    case MotionEvent.ACTION_DOWN:
-      action = Map.NATIVE_ACTION_DOWN;
-      pointerIndex = 0;
-      break;
-    case MotionEvent.ACTION_MOVE:
-      action = Map.NATIVE_ACTION_MOVE;
-      pointerIndex = Map.INVALID_POINTER_MASK;
-      break;
-    case MotionEvent.ACTION_CANCEL:
-      action = Map.NATIVE_ACTION_CANCEL;
-      break;
+      case MotionEvent.ACTION_POINTER_UP -> action = Map.NATIVE_ACTION_UP;
+      case MotionEvent.ACTION_UP ->
+      {
+        action = Map.NATIVE_ACTION_UP;
+        pointerIndex = 0;
+      }
+      case MotionEvent.ACTION_POINTER_DOWN -> action = Map.NATIVE_ACTION_DOWN;
+      case MotionEvent.ACTION_DOWN ->
+      {
+        action = Map.NATIVE_ACTION_DOWN;
+        pointerIndex = 0;
+      }
+      case MotionEvent.ACTION_MOVE ->
+      {
+        action = Map.NATIVE_ACTION_MOVE;
+        pointerIndex = Map.INVALID_POINTER_MASK;
+      }
+      case MotionEvent.ACTION_CANCEL -> action = Map.NATIVE_ACTION_CANCEL;
     }
     Map.onTouch(action, event, pointerIndex);
     return true;

--- a/android/app/src/main/java/app/organicmaps/MwmActivity.java
+++ b/android/app/src/main/java/app/organicmaps/MwmActivity.java
@@ -70,7 +70,6 @@ import app.organicmaps.location.SensorHelper;
 import app.organicmaps.location.SensorListener;
 import app.organicmaps.maplayer.MapButtonsController;
 import app.organicmaps.maplayer.MapButtonsViewModel;
-import app.organicmaps.maplayer.Mode;
 import app.organicmaps.maplayer.ToggleMapLayerFragment;
 import app.organicmaps.maplayer.isolines.IsolinesManager;
 import app.organicmaps.maplayer.isolines.IsolinesState;
@@ -578,9 +577,7 @@ public class MwmActivity extends BaseMwmFragmentActivity
 
     mPointChooserToolbar = mPointChooser.findViewById(R.id.toolbar_point_chooser);
     UiUtils.showHomeUpButton(mPointChooserToolbar);
-    mPointChooserToolbar.setNavigationOnClickListener(v -> {
-      closePositionChooser();
-    });
+    mPointChooserToolbar.setNavigationOnClickListener(v -> closePositionChooser());
     mPointChooser.findViewById(R.id.done).setOnClickListener(
         v ->
         {
@@ -729,33 +726,23 @@ public class MwmActivity extends BaseMwmFragmentActivity
   {
     switch (button)
     {
-      case zoomIn:
-        Map.zoomIn();
-        break;
-      case zoomOut:
-        Map.zoomOut();
-        break;
-      case myPosition:
+      case zoomIn -> Map.zoomIn();
+      case zoomOut -> Map.zoomOut();
+      case myPosition ->
+      {
         Logger.i(LOCATION_TAG, "The location button pressed");
         // Calls onMyPositionModeChanged(mode + 1).
         LocationState.nativeSwitchToNextMode();
-        break;
-      case toggleMapLayer:
-        toggleMapLayerBottomSheet();
-        break;
-      case bookmarks:
-        showBookmarks();
-        break;
-      case search:
-        showSearch("");
-        break;
-      case menu:
+      }
+      case toggleMapLayer -> toggleMapLayerBottomSheet();
+      case bookmarks -> showBookmarks();
+      case search -> showSearch("");
+      case menu ->
+      {
         closeFloatingPanels();
         showBottomSheet(MAIN_MENU_ID);
-        break;
-      case help:
-        showHelp();
-        break;
+      }
+      case help -> showHelp();
     }
   }
 

--- a/android/app/src/main/java/app/organicmaps/PanelAnimator.java
+++ b/android/app/src/main/java/app/organicmaps/PanelAnimator.java
@@ -75,7 +75,7 @@ class PanelAnimator
     mAnimationTrackListeners.finishIterate();
 
     ValueAnimator animator = ValueAnimator.ofFloat(-mWidth, 0.0f);
-    animator.addUpdateListener(animation -> track(animation));
+    animator.addUpdateListener(this::track);
     animator.addListener(new UiUtils.SimpleAnimatorListener()
     {
       @Override
@@ -106,7 +106,7 @@ class PanelAnimator
     mAnimationTrackListeners.finishIterate();
 
     ValueAnimator animator = ValueAnimator.ofFloat(0.0f, -mWidth);
-    animator.addUpdateListener(animation -> track(animation));
+    animator.addUpdateListener(this::track);
     animator.addListener(new UiUtils.SimpleAnimatorListener()
     {
       @Override

--- a/android/app/src/main/java/app/organicmaps/SplashActivity.java
+++ b/android/app/src/main/java/app/organicmaps/SplashActivity.java
@@ -46,14 +46,7 @@ public class SplashActivity extends AppCompatActivity
   private ActivityResultLauncher<Intent> mApiRequest;
 
   @NonNull
-  private final Runnable mInitCoreDelayedTask = new Runnable()
-  {
-    @Override
-    public void run()
-    {
-      init();
-    }
-  };
+  private final Runnable mInitCoreDelayedTask = this::init;
 
   @NonNull
   public static void start(@NonNull Context context,

--- a/android/app/src/main/java/app/organicmaps/bookmarks/BookmarkCategoriesAdapter.java
+++ b/android/app/src/main/java/app/organicmaps/bookmarks/BookmarkCategoriesAdapter.java
@@ -68,39 +68,38 @@ public class BookmarkCategoriesAdapter extends BaseBookmarkCategoryAdapter<Recyc
     LayoutInflater inflater = LayoutInflater.from(parent.getContext());
     switch (viewType)
     {
-    case TYPE_ACTION_HEADER:
-    {
-      View header = inflater.inflate(R.layout.item_bookmark_group_list_header, parent, false);
-      return new Holders.HeaderViewHolder(header);
-    }
-    case TYPE_CATEGORY_ITEM:
-    {
-      View view = inflater.inflate(R.layout.item_bookmark_category, parent, false);
-      final CategoryViewHolder holder = new CategoryViewHolder(view);
-      view.setOnClickListener(new CategoryItemClickListener(holder));
-      view.setOnLongClickListener(new LongClickListener(holder));
-      return holder;
-    }
-    case TYPE_ACTION_ADD:
-    {
-      View item = inflater.inflate(R.layout.item_bookmark_create_group, parent, false);
-      item.setOnClickListener(v -> {
-        if (mCategoryListCallback != null)
-          mCategoryListCallback.onAddButtonClick();
-      });
-      return new Holders.GeneralViewHolder(item);
-    }
-    case TYPE_ACTION_IMPORT:
-    {
-      View item = inflater.inflate(R.layout.item_bookmark_import, parent, false);
-      item.setOnClickListener(v -> {
-        if (mCategoryListCallback != null)
-          mCategoryListCallback.onImportButtonClick();
-      });
-      return new Holders.GeneralViewHolder(item);
-    }
-    default:
-      throw new AssertionError("Invalid item type: " + viewType);
+      case TYPE_ACTION_HEADER ->
+      {
+        View header = inflater.inflate(R.layout.item_bookmark_group_list_header, parent, false);
+        return new HeaderViewHolder(header);
+      }
+      case TYPE_CATEGORY_ITEM ->
+      {
+        View view = inflater.inflate(R.layout.item_bookmark_category, parent, false);
+        final CategoryViewHolder holder = new CategoryViewHolder(view);
+        view.setOnClickListener(new CategoryItemClickListener(holder));
+        view.setOnLongClickListener(new LongClickListener(holder));
+        return holder;
+      }
+      case TYPE_ACTION_ADD ->
+      {
+        View item = inflater.inflate(R.layout.item_bookmark_create_group, parent, false);
+        item.setOnClickListener(v -> {
+          if (mCategoryListCallback != null)
+            mCategoryListCallback.onAddButtonClick();
+        });
+        return new Holders.GeneralViewHolder(item);
+      }
+      case TYPE_ACTION_IMPORT ->
+      {
+        View item = inflater.inflate(R.layout.item_bookmark_import, parent, false);
+        item.setOnClickListener(v -> {
+          if (mCategoryListCallback != null)
+            mCategoryListCallback.onImportButtonClick();
+        });
+        return new Holders.GeneralViewHolder(item);
+      }
+      default -> throw new AssertionError("Invalid item type: " + viewType);
     }
   }
 
@@ -110,44 +109,39 @@ public class BookmarkCategoriesAdapter extends BaseBookmarkCategoryAdapter<Recyc
     int type = getItemViewType(position);
     switch (type)
     {
-    case TYPE_ACTION_HEADER:
-    {
-      HeaderViewHolder headerViewHolder = (HeaderViewHolder) holder;
-      headerViewHolder.setAction(mMassOperationAction,
-          BookmarkManager.INSTANCE.areAllCategoriesInvisible());
-      headerViewHolder.getText().setText(R.string.bookmark_lists);
-      break;
-    }
-    case TYPE_CATEGORY_ITEM:
-    {
-      final BookmarkCategory category = getCategoryByPosition(toCategoryPosition(position));
-      CategoryViewHolder categoryHolder = (CategoryViewHolder) holder;
-      categoryHolder.setEntity(category);
-      categoryHolder.setName(category.getName());
-      categoryHolder.setSize();
-      categoryHolder.setVisibilityState(category.isVisible());
-      ToggleVisibilityClickListener visibilityListener = new ToggleVisibilityClickListener(categoryHolder);
-      categoryHolder.setVisibilityListener(visibilityListener);
-      CategoryItemMoreClickListener moreClickListener = new CategoryItemMoreClickListener(categoryHolder);
-      categoryHolder.setMoreButtonClickListener(moreClickListener);
-      break;
-    }
-    case TYPE_ACTION_ADD:
-    {
-      Holders.GeneralViewHolder generalViewHolder = (Holders.GeneralViewHolder) holder;
-      generalViewHolder.getImage().setImageResource(R.drawable.ic_checkbox_add);
-      generalViewHolder.getText().setText(R.string.bookmarks_create_new_group);
-      break;
-    }
-    case TYPE_ACTION_IMPORT:
-    {
-      Holders.GeneralViewHolder generalViewHolder = (Holders.GeneralViewHolder) holder;
-      generalViewHolder.getImage().setImageResource(R.drawable.ic_checkbox_add);
-      generalViewHolder.getText().setText(R.string.bookmarks_import);
-      break;
-    }
-    default:
-      throw new AssertionError("Invalid item type: " + type);
+      case TYPE_ACTION_HEADER ->
+      {
+        HeaderViewHolder headerViewHolder = (HeaderViewHolder) holder;
+        headerViewHolder.setAction(mMassOperationAction,
+                                   BookmarkManager.INSTANCE.areAllCategoriesInvisible());
+        headerViewHolder.getText().setText(R.string.bookmark_lists);
+      }
+      case TYPE_CATEGORY_ITEM ->
+      {
+        final BookmarkCategory category = getCategoryByPosition(toCategoryPosition(position));
+        CategoryViewHolder categoryHolder = (CategoryViewHolder) holder;
+        categoryHolder.setEntity(category);
+        categoryHolder.setName(category.getName());
+        categoryHolder.setSize();
+        categoryHolder.setVisibilityState(category.isVisible());
+        ToggleVisibilityClickListener visibilityListener = new ToggleVisibilityClickListener(categoryHolder);
+        categoryHolder.setVisibilityListener(visibilityListener);
+        CategoryItemMoreClickListener moreClickListener = new CategoryItemMoreClickListener(categoryHolder);
+        categoryHolder.setMoreButtonClickListener(moreClickListener);
+      }
+      case TYPE_ACTION_ADD ->
+      {
+        Holders.GeneralViewHolder generalViewHolder = (Holders.GeneralViewHolder) holder;
+        generalViewHolder.getImage().setImageResource(R.drawable.ic_checkbox_add);
+        generalViewHolder.getText().setText(R.string.bookmarks_create_new_group);
+      }
+      case TYPE_ACTION_IMPORT ->
+      {
+        Holders.GeneralViewHolder generalViewHolder = (Holders.GeneralViewHolder) holder;
+        generalViewHolder.getImage().setImageResource(R.drawable.ic_checkbox_add);
+        generalViewHolder.getText().setText(R.string.bookmarks_import);
+      }
+      default -> throw new AssertionError("Invalid item type: " + type);
     }
   }
 

--- a/android/app/src/main/java/app/organicmaps/bookmarks/BookmarkCategoriesFragment.java
+++ b/android/app/src/main/java/app/organicmaps/bookmarks/BookmarkCategoriesFragment.java
@@ -286,48 +286,42 @@ public class BookmarkCategoriesFragment extends BaseMwmRecyclerFragment<Bookmark
       return;
     switch (requestCode)
     {
-    case REQ_CODE_DELETE_CATEGORY:
-    {
-      onDeleteActionSelected(getSelectedCategory());
-      return;
-    }
-    case REQ_CODE_IMPORT_DIRECTORY:
-    {
-      if (data == null)
-        throw new AssertionError("Data is null");
+      case REQ_CODE_DELETE_CATEGORY -> onDeleteActionSelected(getSelectedCategory());
+      case REQ_CODE_IMPORT_DIRECTORY ->
+      {
+        if (data == null)
+          throw new AssertionError("Data is null");
 
-      final Context context = requireActivity();
-      final Uri rootUri = data.getData();
-      final ProgressDialog dialog = new ProgressDialog(context, R.style.MwmTheme_ProgressDialog);
-      dialog.setMessage(getString(R.string.wait_several_minutes));
-      dialog.setProgressStyle(ProgressDialog.STYLE_SPINNER);
-      dialog.setIndeterminate(true);
-      dialog.setCancelable(false);
-      dialog.show();
-      Logger.d(TAG, "Importing bookmarks from " + rootUri);
-      MwmApplication app = MwmApplication.from(context);
-      final File tempDir = new File(StorageUtils.getTempPath(app));
-      final ContentResolver resolver = context.getContentResolver();
-      ThreadPool.getStorage().execute(() -> {
-        AtomicInteger found = new AtomicInteger(0);
-        StorageUtils.listContentProviderFilesRecursively(
-            resolver, rootUri, uri -> {
-              if (BookmarkManager.INSTANCE.importBookmarksFile(resolver, uri, tempDir))
-                found.incrementAndGet();
-            });
-        UiThread.run(() -> {
-          if (dialog.isShowing())
-            dialog.dismiss();
-          int found_val = found.get();
-          String message = context.getResources().getQuantityString(
-              R.plurals.bookmarks_detect_message, found_val, found_val);
-          Toast.makeText(requireContext(), message, Toast.LENGTH_LONG).show();
+        final Context context = requireActivity();
+        final Uri rootUri = data.getData();
+        final ProgressDialog dialog = new ProgressDialog(context, R.style.MwmTheme_ProgressDialog);
+        dialog.setMessage(getString(R.string.wait_several_minutes));
+        dialog.setProgressStyle(ProgressDialog.STYLE_SPINNER);
+        dialog.setIndeterminate(true);
+        dialog.setCancelable(false);
+        dialog.show();
+        Logger.d(TAG, "Importing bookmarks from " + rootUri);
+        MwmApplication app = MwmApplication.from(context);
+        final File tempDir = new File(StorageUtils.getTempPath(app));
+        final ContentResolver resolver = context.getContentResolver();
+        ThreadPool.getStorage().execute(() -> {
+          AtomicInteger found = new AtomicInteger(0);
+          StorageUtils.listContentProviderFilesRecursively(
+              resolver, rootUri, uri -> {
+                if (BookmarkManager.INSTANCE.importBookmarksFile(resolver, uri, tempDir))
+                  found.incrementAndGet();
+              });
+          UiThread.run(() -> {
+            if (dialog.isShowing())
+              dialog.dismiss();
+            int found_val = found.get();
+            String message = context.getResources().getQuantityString(
+                R.plurals.bookmarks_detect_message, found_val, found_val);
+            Toast.makeText(requireContext(), message, Toast.LENGTH_LONG).show();
+          });
         });
-      });
-      break;
-    }
-    default:
-      throw new AssertionError("Invalid requestCode: " + requestCode);
+      }
+      default -> throw new AssertionError("Invalid requestCode: " + requestCode);
     }
   }
 

--- a/android/app/src/main/java/app/organicmaps/bookmarks/BookmarkListAdapter.java
+++ b/android/app/src/main/java/app/organicmaps/bookmarks/BookmarkListAdapter.java
@@ -363,7 +363,7 @@ public class BookmarkListAdapter extends RecyclerView.Adapter<Holders.BaseBookma
   {
     if (searchResults != null)
     {
-      mSearchResults = new ArrayList<Long>(searchResults.length);
+      mSearchResults = new ArrayList<>(searchResults.length);
       for (long id : searchResults)
         mSearchResults.add(id);
     }

--- a/android/app/src/main/java/app/organicmaps/bookmarks/BookmarksListFragment.java
+++ b/android/app/src/main/java/app/organicmaps/bookmarks/BookmarksListFragment.java
@@ -31,7 +31,6 @@ import app.organicmaps.bookmarks.data.BookmarkSharingResult;
 import app.organicmaps.bookmarks.data.CategoryDataSource;
 import app.organicmaps.bookmarks.data.SortedBlock;
 import app.organicmaps.bookmarks.data.Track;
-import app.organicmaps.intent.Factory;
 import app.organicmaps.location.LocationHelper;
 import app.organicmaps.search.NativeBookmarkSearchListener;
 import app.organicmaps.search.SearchEngine;
@@ -534,17 +533,12 @@ public class BookmarksListFragment extends BaseMwmRecyclerFragment<ConcatAdapter
 
     switch (adapter.getItemViewType(position))
     {
-      case BookmarkListAdapter.TYPE_SECTION:
-      case BookmarkListAdapter.TYPE_DESC:
+      case BookmarkListAdapter.TYPE_SECTION, BookmarkListAdapter.TYPE_DESC ->
+      {
         return;
-
-      case BookmarkListAdapter.TYPE_BOOKMARK:
-        onBookmarkClicked(position, intent, adapter);
-        break;
-
-      case BookmarkListAdapter.TYPE_TRACK:
-        onTrackClicked(position, intent, adapter);
-        break;
+      }
+      case BookmarkListAdapter.TYPE_BOOKMARK -> onBookmarkClicked(position, intent, adapter);
+      case BookmarkListAdapter.TYPE_TRACK -> onTrackClicked(position, intent, adapter);
     }
 
     intent.addFlags(Intent.FLAG_ACTIVITY_CLEAR_TOP);

--- a/android/app/src/main/java/app/organicmaps/bookmarks/BookmarksSharingHelper.java
+++ b/android/app/src/main/java/app/organicmaps/bookmarks/BookmarksSharingHelper.java
@@ -42,18 +42,16 @@ public enum BookmarksSharingHelper
 
     switch (result.getCode())
     {
-      case BookmarkSharingResult.SUCCESS:
-        SharingUtils.shareBookmarkFile(context, result.getSharingPath());
-        break;
-      case BookmarkSharingResult.EMPTY_CATEGORY:
-        new MaterialAlertDialogBuilder(context, R.style.MwmTheme_AlertDialog)
-            .setTitle(R.string.bookmarks_error_title_share_empty)
-            .setMessage(R.string.bookmarks_error_message_share_empty)
-            .setPositiveButton(R.string.ok, null)
-            .show();
-        break;
-      case BookmarkSharingResult.ARCHIVE_ERROR:
-      case BookmarkSharingResult.FILE_ERROR:
+      case BookmarkSharingResult.SUCCESS ->
+          SharingUtils.shareBookmarkFile(context, result.getSharingPath());
+      case BookmarkSharingResult.EMPTY_CATEGORY ->
+          new MaterialAlertDialogBuilder(context, R.style.MwmTheme_AlertDialog)
+              .setTitle(R.string.bookmarks_error_title_share_empty)
+              .setMessage(R.string.bookmarks_error_message_share_empty)
+              .setPositiveButton(R.string.ok, null)
+              .show();
+      case BookmarkSharingResult.ARCHIVE_ERROR, BookmarkSharingResult.FILE_ERROR ->
+      {
         new MaterialAlertDialogBuilder(context, R.style.MwmTheme_AlertDialog)
             .setTitle(R.string.dialog_routing_system_error)
             .setMessage(R.string.bookmarks_error_message_share_general)
@@ -61,9 +59,8 @@ public enum BookmarksSharingHelper
             .show();
         String catName = BookmarkManager.INSTANCE.getCategoryById(result.getCategoryId()).getName();
         Logger.e(TAG, "Failed to share bookmark category '" + catName + "', error code: " + result.getCode());
-        break;
-      default:
-        throw new AssertionError("Unsupported bookmark sharing code: " + result.getCode());
+      }
+      default -> throw new AssertionError("Unsupported bookmark sharing code: " + result.getCode());
     }
   }
 }

--- a/android/app/src/main/java/app/organicmaps/bookmarks/OperationStatus.java
+++ b/android/app/src/main/java/app/organicmaps/bookmarks/OperationStatus.java
@@ -28,7 +28,7 @@ public class OperationStatus implements Parcelable
     mError = ParcelCompat.readParcelable(in, Error.class.getClassLoader(), Error.class);
   }
 
-  public static final Creator<OperationStatus> CREATOR = new Creator<OperationStatus>()
+  public static final Creator<OperationStatus> CREATOR = new Creator<>()
   {
     @Override
     public OperationStatus createFromParcel(Parcel in)

--- a/android/app/src/main/java/app/organicmaps/bookmarks/data/BookmarkCategory.java
+++ b/android/app/src/main/java/app/organicmaps/bookmarks/data/BookmarkCategory.java
@@ -147,7 +147,7 @@ public class BookmarkCategory implements Parcelable
     this.mIsVisible = in.readByte() != 0;
   }
 
-  public static final Creator<BookmarkCategory> CREATOR = new Creator<BookmarkCategory>()
+  public static final Creator<BookmarkCategory> CREATOR = new Creator<>()
   {
     @Override
     public BookmarkCategory createFromParcel(Parcel source)

--- a/android/app/src/main/java/app/organicmaps/bookmarks/data/ElevationInfo.java
+++ b/android/app/src/main/java/app/organicmaps/bookmarks/data/ElevationInfo.java
@@ -155,7 +155,7 @@ public class ElevationInfo implements PlacePageData
       mAltitude = in.readInt();
     }
 
-    public static final Creator<Point> CREATOR = new Creator<Point>()
+    public static final Creator<Point> CREATOR = new Creator<>()
     {
       @Override
       public Point createFromParcel(Parcel in)
@@ -194,7 +194,7 @@ public class ElevationInfo implements PlacePageData
     }
   }
 
-  public static final Creator<ElevationInfo> CREATOR = new Creator<ElevationInfo>()
+  public static final Creator<ElevationInfo> CREATOR = new Creator<>()
   {
     @Override
     public ElevationInfo createFromParcel(Parcel in)

--- a/android/app/src/main/java/app/organicmaps/bookmarks/data/Error.java
+++ b/android/app/src/main/java/app/organicmaps/bookmarks/data/Error.java
@@ -52,7 +52,7 @@ public class Error implements Parcelable
            '}';
   }
 
-  public static final Creator<Error> CREATOR = new Creator<Error>()
+  public static final Creator<Error> CREATOR = new Creator<>()
   {
     @Override
     public Error createFromParcel(Parcel in)

--- a/android/app/src/main/java/app/organicmaps/bookmarks/data/FeatureId.java
+++ b/android/app/src/main/java/app/organicmaps/bookmarks/data/FeatureId.java
@@ -13,7 +13,7 @@ import androidx.annotation.NonNull;
 /// Just creating in JNI and assigning ..
 public class FeatureId implements Parcelable
 {
-  public static final Creator<FeatureId> CREATOR = new Creator<FeatureId>()
+  public static final Creator<FeatureId> CREATOR = new Creator<>()
   {
     @Override
     public FeatureId createFromParcel(Parcel in)

--- a/android/app/src/main/java/app/organicmaps/bookmarks/data/Icon.java
+++ b/android/app/src/main/java/app/organicmaps/bookmarks/data/Icon.java
@@ -245,7 +245,7 @@ public class Icon implements Parcelable
     return mColor;
   }
 
-  public static final Parcelable.Creator<Icon> CREATOR = new Parcelable.Creator<Icon>()
+  public static final Parcelable.Creator<Icon> CREATOR = new Parcelable.Creator<>()
   {
     public Icon createFromParcel(Parcel in)
     {

--- a/android/app/src/main/java/app/organicmaps/bookmarks/data/MapObject.java
+++ b/android/app/src/main/java/app/organicmaps/bookmarks/data/MapObject.java
@@ -50,8 +50,8 @@ public class MapObject implements PlacePageData
   public static final int OPENING_MODE_DETAILS = 2;
   public static final int OPENING_MODE_FULL = 3;
 
-  private static String kHttp = "http://";
-  private static String kHttps = "https://";
+  private static final String kHttp = "http://";
+  private static final String kHttps = "https://";
 
   @NonNull
   private final FeatureId mFeatureId;

--- a/android/app/src/main/java/app/organicmaps/bookmarks/data/Metadata.java
+++ b/android/app/src/main/java/app/organicmaps/bookmarks/data/Metadata.java
@@ -124,7 +124,7 @@ public class Metadata implements Parcelable
     return metadata;
   }
 
-  public static final Creator<Metadata> CREATOR = new Creator<Metadata>()
+  public static final Creator<Metadata> CREATOR = new Creator<>()
   {
     @Override
     public Metadata createFromParcel(Parcel source)

--- a/android/app/src/main/java/app/organicmaps/bookmarks/data/ParcelablePointD.java
+++ b/android/app/src/main/java/app/organicmaps/bookmarks/data/ParcelablePointD.java
@@ -40,7 +40,7 @@ public class ParcelablePointD implements Parcelable
     this.y = y;
   }
 
-  public static final Parcelable.Creator<ParcelablePointD> CREATOR = new Parcelable.Creator<ParcelablePointD>()
+  public static final Parcelable.Creator<ParcelablePointD> CREATOR = new Parcelable.Creator<>()
   {
     public ParcelablePointD createFromParcel(Parcel in)
     {

--- a/android/app/src/main/java/app/organicmaps/bookmarks/data/Result.java
+++ b/android/app/src/main/java/app/organicmaps/bookmarks/data/Result.java
@@ -46,7 +46,7 @@ public class Result implements Parcelable
            '}';
   }
 
-  public static final Creator<Result> CREATOR = new Creator<Result>()
+  public static final Creator<Result> CREATOR = new Creator<>()
   {
     @Override
     public Result createFromParcel(Parcel in)

--- a/android/app/src/main/java/app/organicmaps/car/util/IntentUtils.java
+++ b/android/app/src/main/java/app/organicmaps/car/util/IntentUtils.java
@@ -10,7 +10,6 @@ import androidx.car.app.ScreenManager;
 
 import app.organicmaps.Framework;
 import app.organicmaps.Map;
-import app.organicmaps.MwmActivity;
 import app.organicmaps.api.Const;
 import app.organicmaps.api.ParsedSearchRequest;
 import app.organicmaps.api.RequestType;
@@ -85,7 +84,6 @@ public final class IntentUtils
       return;
     case RequestType.CROSSHAIR:
       Logger.e(TAG, "Crosshair API is not supported by Android Auto: " + uri);
-      return;
     }
   }
 

--- a/android/app/src/main/java/app/organicmaps/car/util/RoutingHelpers.java
+++ b/android/app/src/main/java/app/organicmaps/car/util/RoutingHelpers.java
@@ -18,23 +18,14 @@ public final class RoutingHelpers
   @NonNull
   public static Distance createDistance(@NonNull final app.organicmaps.util.Distance distance)
   {
-    int displayUnit;
-    switch (distance.mUnits)
+    int displayUnit = switch (distance.mUnits)
     {
-    case Kilometers:
-      displayUnit = distance.mDistance >= 10.0 ? Distance.UNIT_KILOMETERS : Distance.UNIT_KILOMETERS_P1;
-      break;
-    case Feet:
-      displayUnit = Distance.UNIT_FEET;
-      break;
-    case Miles:
-      displayUnit = distance.mDistance >= 10.0 ? Distance.UNIT_MILES : Distance.UNIT_MILES_P1;
-      break;
-    case Meters:
-    default:
-      displayUnit = Distance.UNIT_METERS;
-      break;
-    }
+      case Kilometers ->
+          distance.mDistance >= 10.0 ? Distance.UNIT_KILOMETERS : Distance.UNIT_KILOMETERS_P1;
+      case Feet -> Distance.UNIT_FEET;
+      case Miles -> distance.mDistance >= 10.0 ? Distance.UNIT_MILES : Distance.UNIT_MILES_P1;
+      default -> Distance.UNIT_METERS;
+    };
 
     return Distance.create(distance.mDistance, displayUnit);
   }

--- a/android/app/src/main/java/app/organicmaps/car/util/UiHelpers.java
+++ b/android/app/src/main/java/app/organicmaps/car/util/UiHelpers.java
@@ -161,23 +161,20 @@ public final class UiHelpers
     @DrawableRes int drawableRes;
     switch (locationMode)
     {
-    case LocationState.PENDING_POSITION:
-    case LocationState.NOT_FOLLOW_NO_POSITION:
-      drawableRes = R.drawable.ic_location_off;
-      break;
-    case LocationState.NOT_FOLLOW:
-      drawableRes = R.drawable.ic_not_follow;
-      break;
-    case LocationState.FOLLOW:
-      drawableRes = R.drawable.ic_follow;
-      tintColor = Colors.LOCATION_TINT;
-      break;
-    case LocationState.FOLLOW_AND_ROTATE:
-      drawableRes = R.drawable.ic_follow_and_rotate;
-      tintColor = Colors.LOCATION_TINT;
-      break;
-    default:
-      throw new IllegalArgumentException("Invalid button mode: " + locationMode);
+      case LocationState.PENDING_POSITION, LocationState.NOT_FOLLOW_NO_POSITION ->
+          drawableRes = R.drawable.ic_location_off;
+      case LocationState.NOT_FOLLOW -> drawableRes = R.drawable.ic_not_follow;
+      case LocationState.FOLLOW ->
+      {
+        drawableRes = R.drawable.ic_follow;
+        tintColor = Colors.LOCATION_TINT;
+      }
+      case LocationState.FOLLOW_AND_ROTATE ->
+      {
+        drawableRes = R.drawable.ic_follow_and_rotate;
+        tintColor = Colors.LOCATION_TINT;
+      }
+      default -> throw new IllegalArgumentException("Invalid button mode: " + locationMode);
     }
 
     final CarIcon icon = new CarIcon.Builder(IconCompat.createWithResource(context, drawableRes)).setTint(tintColor).build();

--- a/android/app/src/main/java/app/organicmaps/downloader/BottomPanel.java
+++ b/android/app/src/main/java/app/organicmaps/downloader/BottomPanel.java
@@ -7,6 +7,7 @@ import com.google.android.material.floatingactionbutton.FloatingActionButton;
 import app.organicmaps.R;
 import app.organicmaps.util.StringUtils;
 import app.organicmaps.util.UiUtils;
+import static app.organicmaps.downloader.CountryItem.*;
 
 class BottomPanel
 {
@@ -29,14 +30,7 @@ class BottomPanel
     public void onClick(View v)
     {
       final String country = mFragment.getCurrentRoot();
-      MapManager.warnOn3gUpdate(mFragment.requireActivity(), country, new Runnable()
-      {
-        @Override
-        public void run()
-        {
-          MapManager.nativeUpdate(country);
-        }
-      });
+      MapManager.warnOn3gUpdate(mFragment.requireActivity(), country, () -> MapManager.nativeUpdate(country));
     }
   };
 
@@ -103,29 +97,15 @@ class BottomPanel
       {
         switch (status)
         {
-        case CountryItem.STATUS_UPDATABLE:
-          UpdateInfo info = MapManager.nativeGetUpdateInfo(root);
-          setUpdateAllState(info);
-          break;
-
-        case CountryItem.STATUS_DOWNLOADABLE:  // Special case for "Countries" node when no maps currently downloaded.
-        case CountryItem.STATUS_DONE:
-        case CountryItem.STATUS_PARTLY:
-          show = false;
-          break;
-
-        case CountryItem.STATUS_PROGRESS:
-        case CountryItem.STATUS_APPLYING:
-        case CountryItem.STATUS_ENQUEUED:
-          setCancelState();
-          break;
-
-        case CountryItem.STATUS_FAILED:
-          setDownloadAllState();
-          break;
-
-        default:
-          throw new IllegalArgumentException("Inappropriate status for \"" + root + "\": " + status);
+          case STATUS_UPDATABLE ->
+          {
+            UpdateInfo info = MapManager.nativeGetUpdateInfo(root);
+            setUpdateAllState(info);
+          }  // Special case for "Countries" node when no maps currently downloaded.
+          case STATUS_DOWNLOADABLE, STATUS_DONE, STATUS_PARTLY -> show = false;
+          case STATUS_PROGRESS, STATUS_APPLYING, STATUS_ENQUEUED -> setCancelState();
+          case STATUS_FAILED -> setDownloadAllState();
+          default -> throw new IllegalArgumentException("Inappropriate status for \"" + root + "\": " + status);
         }
       }
       else
@@ -135,23 +115,14 @@ class BottomPanel
         {
           switch (status)
           {
-          case CountryItem.STATUS_UPDATABLE:
-            UpdateInfo info = MapManager.nativeGetUpdateInfo(root);
-            setUpdateAllState(info);
-            break;
-
-          case CountryItem.STATUS_DONE:
-            show = false;
-            break;
-
-          case CountryItem.STATUS_PROGRESS:
-          case CountryItem.STATUS_APPLYING:
-          case CountryItem.STATUS_ENQUEUED:
-            setCancelState();
-            break;
-
-          default:
-            setDownloadAllState();
+            case STATUS_UPDATABLE ->
+            {
+              UpdateInfo info = MapManager.nativeGetUpdateInfo(root);
+              setUpdateAllState(info);
+            }
+            case STATUS_DONE -> show = false;
+            case STATUS_PROGRESS, STATUS_APPLYING, STATUS_ENQUEUED -> setCancelState();
+            default -> setDownloadAllState();
           }
         }
       }

--- a/android/app/src/main/java/app/organicmaps/downloader/DownloaderAdapter.java
+++ b/android/app/src/main/java/app/organicmaps/downloader/DownloaderAdapter.java
@@ -387,40 +387,24 @@ class DownloaderAdapter extends RecyclerView.Adapter<DownloaderAdapter.ViewHolde
     {
       switch (mItem.status)
       {
-      case CountryItem.STATUS_DONE:
-      case CountryItem.STATUS_PROGRESS:
-      case CountryItem.STATUS_APPLYING:
-      case CountryItem.STATUS_ENQUEUED:
-        processLongClick();
-        break;
-
-      case CountryItem.STATUS_DOWNLOADABLE:
-      case CountryItem.STATUS_PARTLY:
-        if (clickOnStatus)
-          onDownloadActionSelected(mItem, DownloaderAdapter.this);
-        else
-          processLongClick();
-        break;
-
-      case CountryItem.STATUS_FAILED:
-        RetryFailedDownloadConfirmationListener listener =
-            new RetryFailedDownloadConfirmationListener(mActivity.getApplication());
-        MapManager.warn3gAndRetry(mActivity, mItem.id, listener);
-        break;
-
-      case CountryItem.STATUS_UPDATABLE:
-        MapManager.warnOn3gUpdate(mActivity, mItem.id, new Runnable()
+        case CountryItem.STATUS_DONE, CountryItem.STATUS_PROGRESS, CountryItem.STATUS_APPLYING, CountryItem.STATUS_ENQUEUED ->
+            processLongClick();
+        case CountryItem.STATUS_DOWNLOADABLE, CountryItem.STATUS_PARTLY ->
         {
-          @Override
-          public void run()
-          {
-            MapManager.nativeUpdate(mItem.id);
-          }
-        });
-        break;
-
-      default:
-        throw new IllegalArgumentException("Inappropriate item status: " + mItem.status);
+          if (clickOnStatus)
+            onDownloadActionSelected(mItem, DownloaderAdapter.this);
+          else
+            processLongClick();
+        }
+        case CountryItem.STATUS_FAILED ->
+        {
+          RetryFailedDownloadConfirmationListener listener =
+              new RetryFailedDownloadConfirmationListener(mActivity.getApplication());
+          MapManager.warn3gAndRetry(mActivity, mItem.id, listener);
+        }
+        case CountryItem.STATUS_UPDATABLE ->
+            MapManager.warnOn3gUpdate(mActivity, mItem.id, () -> MapManager.nativeUpdate(mItem.id));
+        default -> throw new IllegalArgumentException("Inappropriate item status: " + mItem.status);
       }
     }
 
@@ -473,26 +457,16 @@ class DownloaderAdapter extends RecyclerView.Adapter<DownloaderAdapter.ViewHolde
       mFoundName = frame.findViewById(R.id.found_name);
       mSize = frame.findViewById(R.id.size);
 
-      frame.setOnClickListener(new View.OnClickListener()
-      {
-        @Override
-        public void onClick(View v)
-        {
-          if (mItem.isExpandable())
-            goDeeper(mItem, true);
-          else
-            processClick(false);
-        }
+      frame.setOnClickListener(v -> {
+        if (mItem.isExpandable())
+          goDeeper(mItem, true);
+        else
+          processClick(false);
       });
 
-      frame.setOnLongClickListener(new View.OnLongClickListener()
-      {
-        @Override
-        public boolean onLongClick(View v)
-        {
-          processLongClick();
-          return true;
-        }
+      frame.setOnLongClickListener(v -> {
+        processLongClick();
+        return true;
       });
     }
 
@@ -584,31 +558,32 @@ class DownloaderAdapter extends RecyclerView.Adapter<DownloaderAdapter.ViewHolde
       {
         switch (ci.category)
         {
-          case CountryItem.CATEGORY_NEAR_ME:
+          case CountryItem.CATEGORY_NEAR_ME ->
+          {
             if (ci.category != prev)
             {
               headerId = CountryItem.CATEGORY_NEAR_ME;
               mItemsAndHeader.add(new GenericItem(mActivity.getString(R.string.downloader_near_me_subtitle)));
               prev = ci.category;
             }
-            break;
-
-          case CountryItem.CATEGORY_DOWNLOADED:
+          }
+          case CountryItem.CATEGORY_DOWNLOADED ->
+          {
             if (ci.category != prev)
             {
               headerId = CountryItem.CATEGORY_DOWNLOADED;
               mItemsAndHeader.add(new GenericItem(mActivity.getString(R.string.downloader_downloaded_subtitle)));
               prev = ci.category;
             }
-            break;
-          default:
+          }
+          default ->
+          {
             int prevHeader = headerId;
             headerId = CountryItem.CATEGORY_AVAILABLE + ci.name.charAt(0);
-
             if (headerId != prevHeader)
               mItemsAndHeader.add(new GenericItem(StringUtils.toUpperCase(ci.name.substring(0, 1))));
-
             prev = ci.category;
+          }
         }
         ci.headerId = headerId;
       }

--- a/android/app/src/main/java/app/organicmaps/downloader/DownloaderStatusIcon.java
+++ b/android/app/src/main/java/app/organicmaps/downloader/DownloaderStatusIcon.java
@@ -41,24 +41,14 @@ public class DownloaderStatusIcon
 
   protected @AttrRes int selectIcon(CountryItem country)
   {
-    switch (country.status)
+    return switch (country.status)
     {
-    case CountryItem.STATUS_DONE:
-      return R.attr.status_done;
-
-    case CountryItem.STATUS_DOWNLOADABLE:
-    case CountryItem.STATUS_PARTLY:
-      return R.attr.status_downloadable;
-
-    case CountryItem.STATUS_FAILED:
-      return R.attr.status_failed;
-
-    case CountryItem.STATUS_UPDATABLE:
-      return R.attr.status_updatable;
-
-    default:
-      throw new IllegalArgumentException("Inappropriate item status: " + country.status);
-    }
+      case CountryItem.STATUS_DONE -> R.attr.status_done;
+      case CountryItem.STATUS_DOWNLOADABLE, CountryItem.STATUS_PARTLY -> R.attr.status_downloadable;
+      case CountryItem.STATUS_FAILED -> R.attr.status_failed;
+      case CountryItem.STATUS_UPDATABLE -> R.attr.status_updatable;
+      default -> throw new IllegalArgumentException("Inappropriate item status: " + country.status);
+    };
   }
 
   private @DrawableRes int resolveIcon(@AttrRes int iconAttr)

--- a/android/app/src/main/java/app/organicmaps/editor/CuisineAdapter.java
+++ b/android/app/src/main/java/app/organicmaps/editor/CuisineAdapter.java
@@ -109,14 +109,7 @@ public class CuisineAdapter extends RecyclerView.Adapter<CuisineAdapter.ViewHold
       cuisine = itemView.findViewById(R.id.cuisine);
       selected = itemView.findViewById(R.id.selected);
       selected.setOnCheckedChangeListener(this);
-      itemView.setOnClickListener(new View.OnClickListener()
-      {
-        @Override
-        public void onClick(View v)
-        {
-          selected.toggle();
-        }
-      });
+      itemView.setOnClickListener(v -> selected.toggle());
     }
 
     public void bind(int position)

--- a/android/app/src/main/java/app/organicmaps/editor/EditorFragment.java
+++ b/android/app/src/main/java/app/organicmaps/editor/EditorFragment.java
@@ -576,19 +576,13 @@ public class EditorFragment extends BaseMwmFragment implements View.OnClickListe
 
     switch (Editor.nativeGetMapObjectStatus())
     {
-    case Editor.CREATED:
-      mReset.setText(R.string.editor_remove_place_button);
-      break;
-    case Editor.MODIFIED:
-      mReset.setText(R.string.editor_reset_edits_button);
-      break;
-    case Editor.UNTOUCHED:
-      mReset.setText(R.string.editor_place_doesnt_exist);
-      break;
-    case Editor.DELETED:
-      throw new IllegalStateException("Can't delete already deleted feature.");
-    case Editor.OBSOLETE:
-      throw new IllegalStateException("Obsolete objects cannot be reverted.");
+      case Editor.CREATED -> mReset.setText(R.string.editor_remove_place_button);
+      case Editor.MODIFIED -> mReset.setText(R.string.editor_reset_edits_button);
+      case Editor.UNTOUCHED -> mReset.setText(R.string.editor_place_doesnt_exist);
+      case Editor.DELETED ->
+          throw new IllegalStateException("Can't delete already deleted feature.");
+      case Editor.OBSOLETE ->
+          throw new IllegalStateException("Obsolete objects cannot be reverted.");
     }
   }
 
@@ -602,19 +596,13 @@ public class EditorFragment extends BaseMwmFragment implements View.OnClickListe
 
     switch (Editor.nativeGetMapObjectStatus())
     {
-    case Editor.CREATED:
-      rollback(Editor.CREATED);
-      break;
-    case Editor.MODIFIED:
-      rollback(Editor.MODIFIED);
-      break;
-    case Editor.UNTOUCHED:
-      placeDoesntExist();
-      break;
-    case Editor.DELETED:
-      throw new IllegalStateException("Can't delete already deleted feature.");
-    case Editor.OBSOLETE:
-      throw new IllegalStateException("Obsolete objects cannot be reverted.");
+      case Editor.CREATED -> rollback(Editor.CREATED);
+      case Editor.MODIFIED -> rollback(Editor.MODIFIED);
+      case Editor.UNTOUCHED -> placeDoesntExist();
+      case Editor.DELETED ->
+          throw new IllegalStateException("Can't delete already deleted feature.");
+      case Editor.OBSOLETE ->
+          throw new IllegalStateException("Obsolete objects cannot be reverted.");
     }
   }
 

--- a/android/app/src/main/java/app/organicmaps/editor/EditorHostFragment.java
+++ b/android/app/src/main/java/app/organicmaps/editor/EditorHostFragment.java
@@ -170,15 +170,8 @@ public class EditorHostFragment extends BaseMwmToolbarFragment implements View.O
   {
     switch (mMode)
     {
-    case OPENING_HOURS:
-    case STREET:
-    case CUISINE:
-    case LANGUAGE:
-    case PHONE:
-      editMapObject();
-      break;
-    default:
-      Utils.navigateToParent(requireActivity());
+      case OPENING_HOURS, STREET, CUISINE, LANGUAGE, PHONE -> editMapObject();
+      default -> Utils.navigateToParent(requireActivity());
     }
     return true;
   }
@@ -290,45 +283,46 @@ public class EditorHostFragment extends BaseMwmToolbarFragment implements View.O
     {
       switch (mMode)
       {
-      case OPENING_HOURS:
-        final String timetables = ((TimetableContainerFragment) getChildFragmentManager().findFragmentByTag(TimetableContainerFragment.class.getName())).getTimetable();
-        Editor.nativeSetOpeningHours(timetables);
-        editMapObject();
-        break;
-      case STREET:
-        setStreet(((StreetFragment) getChildFragmentManager().findFragmentByTag(StreetFragment.class.getName())).getStreet());
-        break;
-      case CUISINE:
-        String[] cuisines = ((CuisineFragment) getChildFragmentManager().findFragmentByTag(CuisineFragment.class.getName())).getCuisines();
-        Editor.nativeSetSelectedCuisines(cuisines);
-        editMapObject();
-        break;
-      case LANGUAGE:
-        editMapObject();
-        break;
-      case MAP_OBJECT:
-        if (!setEdits())
-          return;
-
-        // Save object edits
-        if (!MwmApplication.prefs(requireContext()).contains(NOOB_ALERT_SHOWN))
+        case OPENING_HOURS ->
         {
-          showNoobDialog();
-        }
-        else
-        {
-          saveNote();
-          saveMapObjectEdits();
-        }
-        break;
-      case PHONE:
-        final String phone = ((PhoneFragment) getChildFragmentManager().findFragmentByTag(PhoneFragment.class.getName())).getPhone();
-        if (Editor.nativeIsPhoneValid(phone))
-        {
-          Editor.nativeSetPhone(phone);
+          final String timetables = ((TimetableContainerFragment) getChildFragmentManager().findFragmentByTag(TimetableContainerFragment.class.getName())).getTimetable();
+          Editor.nativeSetOpeningHours(timetables);
           editMapObject();
         }
-        break;
+        case STREET ->
+            setStreet(((StreetFragment) getChildFragmentManager().findFragmentByTag(StreetFragment.class.getName())).getStreet());
+        case CUISINE ->
+        {
+          String[] cuisines = ((CuisineFragment) getChildFragmentManager().findFragmentByTag(CuisineFragment.class.getName())).getCuisines();
+          Editor.nativeSetSelectedCuisines(cuisines);
+          editMapObject();
+        }
+        case LANGUAGE -> editMapObject();
+        case MAP_OBJECT ->
+        {
+          if (!setEdits())
+            return;
+
+          // Save object edits
+          if (!MwmApplication.prefs(requireContext()).contains(NOOB_ALERT_SHOWN))
+          {
+            showNoobDialog();
+          }
+          else
+          {
+            saveNote();
+            saveMapObjectEdits();
+          }
+        }
+        case PHONE ->
+        {
+          final String phone = ((PhoneFragment) getChildFragmentManager().findFragmentByTag(PhoneFragment.class.getName())).getPhone();
+          if (Editor.nativeIsPhoneValid(phone))
+          {
+            Editor.nativeSetPhone(phone);
+            editMapObject();
+          }
+        }
       }
     }
   }

--- a/android/app/src/main/java/app/organicmaps/editor/LanguagesAdapter.java
+++ b/android/app/src/main/java/app/organicmaps/editor/LanguagesAdapter.java
@@ -48,14 +48,7 @@ public class LanguagesAdapter extends RecyclerView.Adapter<LanguagesAdapter.Hold
     {
       super(itemView);
       name = (TextView) itemView;
-      itemView.setOnClickListener(new View.OnClickListener()
-      {
-        @Override
-        public void onClick(View v)
-        {
-          mFragment.onLanguageSelected(mLanguages[getBindingAdapterPosition()]);
-        }
-      });
+      itemView.setOnClickListener(v -> mFragment.onLanguageSelected(mLanguages[getBindingAdapterPosition()]));
     }
 
     public void bind(int position)

--- a/android/app/src/main/java/app/organicmaps/editor/StreetAdapter.java
+++ b/android/app/src/main/java/app/organicmaps/editor/StreetAdapter.java
@@ -130,14 +130,7 @@ public class StreetAdapter extends RecyclerView.Adapter<StreetAdapter.BaseViewHo
     public AddViewHolder(View itemView)
     {
       super(itemView);
-      itemView.setOnClickListener(new View.OnClickListener()
-      {
-        @Override
-        public void onClick(View v)
-        {
-          addStreet();
-        }
-      });
+      itemView.setOnClickListener(v -> addStreet());
     }
   }
 }

--- a/android/app/src/main/java/app/organicmaps/editor/TimetableContainerFragment.java
+++ b/android/app/src/main/java/app/organicmaps/editor/TimetableContainerFragment.java
@@ -158,12 +158,8 @@ public class TimetableContainerFragment extends BaseMwmFragment implements Timet
 
     switch (mMode)
     {
-      case SIMPLE:
-        setMode(Mode.ADVANCED, filledTimetables);
-        break;
-      case ADVANCED:
-        setMode(Mode.SIMPLE, filledTimetables);
-        break;
+      case SIMPLE -> setMode(Mode.ADVANCED, filledTimetables);
+      case ADVANCED -> setMode(Mode.SIMPLE, filledTimetables);
     }
   }
 

--- a/android/app/src/main/java/app/organicmaps/editor/data/FeatureCategory.java
+++ b/android/app/src/main/java/app/organicmaps/editor/data/FeatureCategory.java
@@ -50,7 +50,7 @@ public class FeatureCategory implements Parcelable
     dest.writeString(mLocalizedTypeName);
   }
 
-  public static final Creator<FeatureCategory> CREATOR = new Creator<FeatureCategory>()
+  public static final Creator<FeatureCategory> CREATOR = new Creator<>()
   {
     @Override
     public FeatureCategory createFromParcel(Parcel source)

--- a/android/app/src/main/java/app/organicmaps/editor/data/HoursMinutes.java
+++ b/android/app/src/main/java/app/organicmaps/editor/data/HoursMinutes.java
@@ -66,7 +66,7 @@ public class HoursMinutes implements Parcelable
     dest.writeByte((byte) (m24HourFormat ? 1 : 0));
   }
 
-  public static final Creator<HoursMinutes> CREATOR = new Creator<HoursMinutes>()
+  public static final Creator<HoursMinutes> CREATOR = new Creator<>()
   {
     @Override
     public HoursMinutes createFromParcel(Parcel in)

--- a/android/app/src/main/java/app/organicmaps/help/FaqFragment.java
+++ b/android/app/src/main/java/app/organicmaps/help/FaqFragment.java
@@ -38,13 +38,8 @@ public class FaqFragment extends BaseMwmFragment
     {
       switch (which)
       {
-        case 0:
-          sendGeneralFeedback();
-          break;
-
-        case 1:
-          reportBug();
-          break;
+        case 0 -> sendGeneralFeedback();
+        case 1 -> reportBug();
       }
     }
   };

--- a/android/app/src/main/java/app/organicmaps/help/HelpFragment.java
+++ b/android/app/src/main/java/app/organicmaps/help/HelpFragment.java
@@ -47,7 +47,7 @@ public class HelpFragment extends BaseMwmFragment implements View.OnClickListene
     final boolean isLandscape = getResources().getConfiguration().orientation == Configuration.ORIENTATION_LANDSCAPE;
 
     final String dataVersion = DateUtils.getShortDateFormatter().format(Framework.getDataVersion());
-    final TextView osmPresentationView = (TextView) root.findViewById(R.id.osm_presentation);
+    final TextView osmPresentationView = root.findViewById(R.id.osm_presentation);
     if (osmPresentationView != null)
       osmPresentationView.setText(getString(R.string.osm_presentation, dataVersion));
 

--- a/android/app/src/main/java/app/organicmaps/intent/Factory.java
+++ b/android/app/src/main/java/app/organicmaps/intent/Factory.java
@@ -54,9 +54,7 @@ public class Factory
       MwmApplication app = MwmApplication.from(activity);
       final File tempDir = new File(StorageUtils.getTempPath(app));
       final ContentResolver resolver = activity.getContentResolver();
-      ThreadPool.getStorage().execute(() -> {
-        BookmarkManager.INSTANCE.importBookmarksFile(resolver, uri, tempDir);
-      });
+      ThreadPool.getStorage().execute(() -> BookmarkManager.INSTANCE.importBookmarksFile(resolver, uri, tempDir));
       return false;
     }
   }

--- a/android/app/src/main/java/app/organicmaps/location/LocationHelper.java
+++ b/android/app/src/main/java/app/organicmaps/location/LocationHelper.java
@@ -3,7 +3,6 @@ package app.organicmaps.location;
 import static android.Manifest.permission.ACCESS_COARSE_LOCATION;
 import static android.Manifest.permission.ACCESS_FINE_LOCATION;
 
-import android.annotation.SuppressLint;
 import android.app.PendingIntent;
 import android.content.Context;
 import android.location.Location;
@@ -282,18 +281,13 @@ public class LocationHelper implements BaseLocationProvider.Listener
       return INTERVAL_NAVIGATION_MS;
 
     final int mode = Map.isEngineCreated() ? LocationState.getMode() : LocationState.NOT_FOLLOW_NO_POSITION;
-    switch (mode)
+    return switch (mode)
     {
-      case LocationState.PENDING_POSITION:
-      case LocationState.FOLLOW:
-      case LocationState.FOLLOW_AND_ROTATE:
-        return INTERVAL_FOLLOW_MS;
-      case LocationState.NOT_FOLLOW:
-      case LocationState.NOT_FOLLOW_NO_POSITION:
-        return INTERVAL_NOT_FOLLOW_MS;
-      default:
-        throw new IllegalArgumentException("Unsupported location mode: " + mode);
-    }
+      case LocationState.PENDING_POSITION, LocationState.FOLLOW, LocationState.FOLLOW_AND_ROTATE ->
+          INTERVAL_FOLLOW_MS;
+      case LocationState.NOT_FOLLOW, LocationState.NOT_FOLLOW_NO_POSITION -> INTERVAL_NOT_FOLLOW_MS;
+      default -> throw new IllegalArgumentException("Unsupported location mode: " + mode);
+    };
   }
 
   /**

--- a/android/app/src/main/java/app/organicmaps/location/LocationState.java
+++ b/android/app/src/main/java/app/organicmaps/location/LocationState.java
@@ -75,25 +75,14 @@ public final class LocationState
 
   public static String nameOf(@Value int mode)
   {
-    switch (mode)
+    return switch (mode)
     {
-      case PENDING_POSITION:
-        return "PENDING_POSITION";
-
-      case NOT_FOLLOW_NO_POSITION:
-        return "NOT_FOLLOW_NO_POSITION";
-
-      case NOT_FOLLOW:
-        return "NOT_FOLLOW";
-
-      case FOLLOW:
-        return "FOLLOW";
-
-      case FOLLOW_AND_ROTATE:
-        return "FOLLOW_AND_ROTATE";
-
-      default:
-        return "Unknown: " + mode;
-    }
+      case PENDING_POSITION -> "PENDING_POSITION";
+      case NOT_FOLLOW_NO_POSITION -> "NOT_FOLLOW_NO_POSITION";
+      case NOT_FOLLOW -> "NOT_FOLLOW";
+      case FOLLOW -> "FOLLOW";
+      case FOLLOW_AND_ROTATE -> "FOLLOW_AND_ROTATE";
+      default -> "Unknown: " + mode;
+    };
   }
 }

--- a/android/app/src/main/java/app/organicmaps/routing/NavigationService.java
+++ b/android/app/src/main/java/app/organicmaps/routing/NavigationService.java
@@ -7,7 +7,6 @@ import static android.content.pm.PackageManager.PERMISSION_GRANTED;
 
 import android.annotation.SuppressLint;
 import android.app.ForegroundServiceStartNotAllowedException;
-import android.app.Notification;
 import android.app.NotificationManager;
 import android.app.PendingIntent;
 import android.app.Service;

--- a/android/app/src/main/java/app/organicmaps/routing/ResultCodesHelper.java
+++ b/android/app/src/main/java/app/organicmaps/routing/ResultCodesHelper.java
@@ -137,18 +137,17 @@ public class ResultCodesHelper
     if (missingCount <= 0)
       return false;
 
-    switch (resultCode)
+    return switch (resultCode)
     {
-      case INCONSISTENT_MWM_ROUTE:
-      case ROUTE_NOT_FOUND_REDRESS_ROUTE_ERROR:
-      case ROUTING_FILE_NOT_EXIST:
-      case NEED_MORE_MAPS:
-      case ROUTE_NOT_FOUND:
-      case FILE_TOO_OLD:
-        return true;
-    }
-
-    return false;
+      case INCONSISTENT_MWM_ROUTE,
+          ROUTE_NOT_FOUND_REDRESS_ROUTE_ERROR,
+          ROUTING_FILE_NOT_EXIST,
+          NEED_MORE_MAPS,
+          ROUTE_NOT_FOUND,
+          FILE_TOO_OLD ->
+          true;
+      default -> false;
+    };
   }
 
   public static boolean isMoreMapsNeeded(int resultCode)

--- a/android/app/src/main/java/app/organicmaps/routing/RoutePointInfo.java
+++ b/android/app/src/main/java/app/organicmaps/routing/RoutePointInfo.java
@@ -14,7 +14,7 @@ import java.lang.annotation.RetentionPolicy;
 @SuppressWarnings("unused")
 public class RoutePointInfo implements Parcelable
 {
-  public static final Creator<RoutePointInfo> CREATOR = new Creator<RoutePointInfo>()
+  public static final Creator<RoutePointInfo> CREATOR = new Creator<>()
   {
     @Override
     public RoutePointInfo createFromParcel(Parcel in)

--- a/android/app/src/main/java/app/organicmaps/routing/RoutingErrorDialogFragment.java
+++ b/android/app/src/main/java/app/organicmaps/routing/RoutingErrorDialogFragment.java
@@ -117,14 +117,7 @@ public class RoutingErrorDialogFragment extends BaseRoutingErrorDialogFragment
     if (button == null)
       return;
 
-    button.setOnClickListener(new View.OnClickListener()
-    {
-      @Override
-      public void onClick(View v)
-      {
-        startDownload();
-      }
-    });
+    button.setOnClickListener(v -> startDownload());
   }
 
   @Override

--- a/android/app/src/main/java/app/organicmaps/routing/RoutingPlanController.java
+++ b/android/app/src/main/java/app/organicmaps/routing/RoutingPlanController.java
@@ -219,7 +219,7 @@ public class RoutingPlanController extends ToolbarController
     UiUtils.invisible(mProgressVehicle, mProgressPedestrian, mProgressTransit,
                       mProgressBicycle, mProgressRuler);
     WheelProgressView progressView;
-    switch(router)
+    switch (router)
     {
     case Framework.ROUTER_TYPE_VEHICLE:
       mRouterTypes.check(R.id.vehicle);

--- a/android/app/src/main/java/app/organicmaps/routing/RoutingPlanInplaceController.java
+++ b/android/app/src/main/java/app/organicmaps/routing/RoutingPlanInplaceController.java
@@ -63,14 +63,7 @@ public class RoutingPlanInplaceController extends RoutingPlanController
   {
     if (!checkFrameHeight())
     {
-      getFrame().post(new Runnable()
-      {
-        @Override
-        public void run()
-        {
-          animateFrame(show, completion);
-        }
-      });
+      getFrame().post(() -> animateFrame(show, completion));
       return null;
     }
 

--- a/android/app/src/main/java/app/organicmaps/routing/TransitStepView.java
+++ b/android/app/src/main/java/app/organicmaps/routing/TransitStepView.java
@@ -103,17 +103,13 @@ public class TransitStepView extends View implements MultilineLayoutManager.Sque
   @ColorInt
   private static int getBackgroundColor(@NonNull Context context, @NonNull TransitStepInfo info)
   {
-    switch (info.getType())
+    return switch (info.getType())
     {
-      case PEDESTRIAN:
-        return ThemeUtils.getColor(context, R.attr.transitPedestrianBackground);
-      case RULER:
-        return ThemeUtils.getColor(context, R.attr.transitRulerBackground);
-      case INTERMEDIATE_POINT:
-        return ThemeUtils.getColor(context, androidx.appcompat.R.attr.colorPrimary);
-      default:
-        return info.getColor();
-    }
+      case PEDESTRIAN -> ThemeUtils.getColor(context, R.attr.transitPedestrianBackground);
+      case RULER -> ThemeUtils.getColor(context, R.attr.transitRulerBackground);
+      case INTERMEDIATE_POINT -> ThemeUtils.getColor(context, androidx.appcompat.R.attr.colorPrimary);
+      default -> info.getColor();
+    };
   }
 
   @Override

--- a/android/app/src/main/java/app/organicmaps/search/Popularity.java
+++ b/android/app/src/main/java/app/organicmaps/search/Popularity.java
@@ -49,7 +49,7 @@ public class Popularity implements Parcelable
     this.mType = Type.values()[tmpMPopularity];
   }
 
-  public static final Creator<Popularity> CREATOR = new Creator<Popularity>()
+  public static final Creator<Popularity> CREATOR = new Creator<>()
   {
     @Override
     public Popularity createFromParcel(Parcel source)

--- a/android/app/src/main/java/app/organicmaps/search/SearchAdapter.java
+++ b/android/app/src/main/java/app/organicmaps/search/SearchAdapter.java
@@ -148,7 +148,8 @@ class SearchAdapter extends RecyclerView.Adapter<SearchAdapter.SearchDataViewHol
 
       switch (result.description.openNow)
       {
-        case SearchResult.OPEN_NOW_YES:
+        case SearchResult.OPEN_NOW_YES ->
+        {
           if (result.description.minutesUntilClosed < 60)   // less than 1 hour
           {
             final String time = result.description.minutesUntilClosed + " " +
@@ -163,9 +164,9 @@ class SearchAdapter extends RecyclerView.Adapter<SearchAdapter.SearchDataViewHol
             UiUtils.setTextAndShow(mOpen, resources.getString(R.string.editor_time_open));
             mOpen.setTextColor(ContextCompat.getColor(mSearchFragment.getContext(), R.color.base_green));
           }
-          break;
-
-        case SearchResult.OPEN_NOW_NO:
+        }
+        case SearchResult.OPEN_NOW_NO ->
+        {
           if (result.description.minutesUntilOpen < 60) // less than 1 hour
           {
             final String time = result.description.minutesUntilOpen + " " +
@@ -180,11 +181,8 @@ class SearchAdapter extends RecyclerView.Adapter<SearchAdapter.SearchDataViewHol
             UiUtils.setTextAndShow(mOpen, resources.getString(R.string.closed));
             mOpen.setTextColor(ContextCompat.getColor(mSearchFragment.getContext(), R.color.base_red));
           }
-          break;
-
-        default:
-          UiUtils.hide(mOpen);
-          break;
+        }
+        default -> UiUtils.hide(mOpen);
       }
     }
 
@@ -213,18 +211,14 @@ class SearchAdapter extends RecyclerView.Adapter<SearchAdapter.SearchDataViewHol
   {
     final LayoutInflater inflater = LayoutInflater.from(parent.getContext());
 
-    switch (viewType)
+    return switch (viewType)
     {
-      case SearchResult.TYPE_SUGGEST:
-      case SearchResult.TYPE_PURE_SUGGEST:
-        return new SuggestViewHolder(inflater.inflate(R.layout.item_search_suggest, parent, false));
-
-      case SearchResult.TYPE_RESULT:
-        return new ResultViewHolder(inflater.inflate(R.layout.item_search_result, parent, false));
-
-      default:
-        throw new IllegalArgumentException("Unhandled view type given");
-    }
+      case SearchResult.TYPE_SUGGEST, SearchResult.TYPE_PURE_SUGGEST ->
+          new SuggestViewHolder(inflater.inflate(R.layout.item_search_suggest, parent, false));
+      case SearchResult.TYPE_RESULT ->
+          new ResultViewHolder(inflater.inflate(R.layout.item_search_result, parent, false));
+      default -> throw new IllegalArgumentException("Unhandled view type given");
+    };
   }
 
   @Override

--- a/android/app/src/main/java/app/organicmaps/search/SearchHistoryAdapter.java
+++ b/android/app/src/main/java/app/organicmaps/search/SearchHistoryAdapter.java
@@ -52,14 +52,7 @@ class SearchHistoryAdapter extends RecyclerView.Adapter<SearchHistoryAdapter.Vie
     {
       case TYPE_ITEM:
         res = new ViewHolder(LayoutInflater.from(viewGroup.getContext()).inflate(R.layout.item_search_recent, viewGroup, false));
-        res.mText.setOnClickListener(new View.OnClickListener()
-        {
-          @Override
-          public void onClick(View v)
-          {
-            mSearchToolbarController.setQuery(res.mText.getText());
-          }
-        });
+        res.mText.setOnClickListener(v -> mSearchToolbarController.setQuery(res.mText.getText()));
         break;
 
       case TYPE_CLEAR:

--- a/android/app/src/main/java/app/organicmaps/search/SearchResult.java
+++ b/android/app/src/main/java/app/organicmaps/search/SearchResult.java
@@ -13,7 +13,6 @@ import androidx.annotation.NonNull;
 
 import app.organicmaps.bookmarks.data.FeatureId;
 import app.organicmaps.util.Distance;
-import app.organicmaps.util.Utils;
 
 /**
  * Class instances are created from native code.

--- a/android/app/src/main/java/app/organicmaps/util/Graphics.java
+++ b/android/app/src/main/java/app/organicmaps/util/Graphics.java
@@ -1,7 +1,6 @@
 package app.organicmaps.util;
 
 import android.content.Context;
-import android.content.res.ColorStateList;
 import android.content.res.Resources;
 import android.graphics.Bitmap;
 import android.graphics.Canvas;

--- a/android/app/src/main/java/app/organicmaps/util/InputUtils.java
+++ b/android/app/src/main/java/app/organicmaps/util/InputUtils.java
@@ -62,14 +62,7 @@ public class InputUtils
     if (input == null)
       return;
 
-    UiThread.runLater(new Runnable()
-    {
-      @Override
-      public void run()
-      {
-        showKeyboardSync(input);
-      }
-    }, delay);
+    UiThread.runLater(() -> showKeyboardSync(input), delay);
   }
 
   public static void showKeyboard(View input)

--- a/android/app/src/main/java/app/organicmaps/util/LocationUtils.java
+++ b/android/app/src/main/java/app/organicmaps/util/LocationUtils.java
@@ -29,17 +29,13 @@ public class LocationUtils
     double correction = 0;
     switch (displayOrientation)
     {
-    case Surface.ROTATION_0:
-      return angle;
-    case Surface.ROTATION_90:
-      correction = Math.PI / 2.0;
-      break;
-    case Surface.ROTATION_180:
-      correction = Math.PI;
-      break;
-    case Surface.ROTATION_270:
-      correction = (3.0 * Math.PI / 2.0);
-      break;
+      case Surface.ROTATION_0 ->
+      {
+        return angle;
+      }
+      case Surface.ROTATION_90 -> correction = Math.PI / 2.0;
+      case Surface.ROTATION_180 -> correction = Math.PI;
+      case Surface.ROTATION_270 -> correction = (3.0 * Math.PI / 2.0);
     }
 
     return correctAngle(angle, correction);

--- a/android/app/src/main/java/app/organicmaps/util/SharedPropertiesUtils.java
+++ b/android/app/src/main/java/app/organicmaps/util/SharedPropertiesUtils.java
@@ -62,17 +62,11 @@ public final class SharedPropertiesUtils
   public static boolean shouldShowNewMarkerForLayerMode(@NonNull Context context,
                                                         @NonNull Mode mode)
   {
-    switch (mode)
+    return switch (mode)
     {
-      case SUBWAY:
-      case TRAFFIC:
-      case ISOLINES:
-        return false;
-      default:
-        return getBoolean(context, PREFS_SHOULD_SHOW_LAYER_MARKER_FOR + mode.name()
-                                                                            .toLowerCase(Locale.ENGLISH),
-                          true);
-    }
+      case SUBWAY, TRAFFIC, ISOLINES -> false;
+      default -> getBoolean(context, PREFS_SHOULD_SHOW_LAYER_MARKER_FOR + mode.name().toLowerCase(Locale.ENGLISH), true);
+    };
   }
 
   public static void setLayerMarkerShownForLayerMode(@NonNull Context context, @NonNull Mode mode)

--- a/android/app/src/main/java/app/organicmaps/util/concurrency/ThreadPool.java
+++ b/android/app/src/main/java/app/organicmaps/util/concurrency/ThreadPool.java
@@ -16,7 +16,7 @@ public class ThreadPool
   private static ThreadPoolExecutor create(int poolSize, int allowedTime)
   {
     ThreadPoolExecutor res = new ThreadPoolExecutor(poolSize, poolSize, allowedTime, TimeUnit.SECONDS,
-                                                    new LinkedBlockingQueue<Runnable>());
+                                                    new LinkedBlockingQueue<>());
     res.allowCoreThreadTimeOut(true);
     return res;
   }

--- a/android/app/src/main/java/app/organicmaps/util/log/LogsManager.java
+++ b/android/app/src/main/java/app/organicmaps/util/log/LogsManager.java
@@ -236,7 +236,7 @@ public final class LogsManager
       .append(" (API ").append(Build.VERSION.SDK_INT).append(')');
     if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.M)
       sb.append(", security patch level: ").append(Build.VERSION.SECURITY_PATCH);
-    sb.append(", os.version: " + System.getProperty("os.version", "N/A"))
+    sb.append(", os.version: ").append(System.getProperty("os.version", "N/A"))
       .append("\nDevice: ");
     if (!StringUtils.toLowerCase(Build.MODEL).startsWith(StringUtils.toLowerCase(Build.MANUFACTURER)))
       sb.append(Build.MANUFACTURER).append(' ');

--- a/android/app/src/main/java/app/organicmaps/widget/menu/MyPositionButton.java
+++ b/android/app/src/main/java/app/organicmaps/widget/menu/MyPositionButton.java
@@ -59,27 +59,15 @@ public class MyPositionButton
     Context context = mButton.getContext();
     if (image == null)
     {
-      @DrawableRes int drawableRes;
-      switch (mode)
+      @DrawableRes int drawableRes = switch (mode)
       {
-        case LocationState.PENDING_POSITION:
-          drawableRes = ThemeUtils.getResource(context, R.attr.myPositionButtonAnimation);
-          break;
-        case LocationState.NOT_FOLLOW_NO_POSITION:
-          drawableRes = R.drawable.ic_location_off;
-          break;
-        case LocationState.NOT_FOLLOW:
-          drawableRes = R.drawable.ic_not_follow;
-          break;
-        case LocationState.FOLLOW:
-          drawableRes = R.drawable.ic_follow;
-          break;
-        case LocationState.FOLLOW_AND_ROTATE:
-          drawableRes = R.drawable.ic_follow_and_rotate;
-          break;
-        default:
-          throw new IllegalArgumentException("Invalid button mode: " + mode);
-      }
+        case LocationState.PENDING_POSITION -> ThemeUtils.getResource(context, R.attr.myPositionButtonAnimation);
+        case LocationState.NOT_FOLLOW_NO_POSITION -> R.drawable.ic_location_off;
+        case LocationState.NOT_FOLLOW -> R.drawable.ic_not_follow;
+        case LocationState.FOLLOW -> R.drawable.ic_follow;
+        case LocationState.FOLLOW_AND_ROTATE -> R.drawable.ic_follow_and_rotate;
+        default -> throw new IllegalArgumentException("Invalid button mode: " + mode);
+      };
       image = ResourcesCompat.getDrawable(resources, drawableRes, context.getTheme());
       mIcons.put(mode, image);
     }

--- a/android/app/src/main/java/app/organicmaps/widget/placepage/EditBookmarkFragment.java
+++ b/android/app/src/main/java/app/organicmaps/widget/placepage/EditBookmarkFragment.java
@@ -111,24 +111,10 @@ public class EditBookmarkFragment extends BaseMwmDialogFragment implements View.
       return windowInsets;
     });
     final ImageView imageView = toolbar.findViewById(R.id.save);
-    imageView.setOnClickListener(new View.OnClickListener()
-    {
-      @Override
-      public void onClick(View v)
-      {
-        saveBookmark();
-      }
-    });
+    imageView.setOnClickListener(v -> saveBookmark());
     UiUtils.showHomeUpButton(toolbar);
     toolbar.setTitle(R.string.description);
-    toolbar.setNavigationOnClickListener(new View.OnClickListener()
-    {
-      @Override
-      public void onClick(View v)
-      {
-        dismiss();
-      }
-    });
+    toolbar.setNavigationOnClickListener(v -> dismiss());
   }
 
   private void saveBookmark()

--- a/android/app/src/main/java/app/organicmaps/widget/placepage/PlacePageController.java
+++ b/android/app/src/main/java/app/organicmaps/widget/placepage/PlacePageController.java
@@ -156,17 +156,13 @@ public class PlacePageController extends Fragment implements
   @NonNull
   private static PlacePageButtons.ButtonType toPlacePageButton(@NonNull RoadWarningMarkType type)
   {
-    switch (type)
+    return switch (type)
     {
-      case DIRTY:
-        return PlacePageButtons.ButtonType.ROUTE_AVOID_UNPAVED;
-      case FERRY:
-        return PlacePageButtons.ButtonType.ROUTE_AVOID_FERRY;
-      case TOLL:
-        return PlacePageButtons.ButtonType.ROUTE_AVOID_TOLL;
-      default:
-        throw new AssertionError("Unsupported road warning type: " + type);
-    }
+      case DIRTY -> PlacePageButtons.ButtonType.ROUTE_AVOID_UNPAVED;
+      case FERRY -> PlacePageButtons.ButtonType.ROUTE_AVOID_FERRY;
+      case TOLL -> PlacePageButtons.ButtonType.ROUTE_AVOID_TOLL;
+      default -> throw new AssertionError("Unsupported road warning type: " + type);
+    };
   }
 
   private void stopCustomPeekHeightAnimation()
@@ -363,42 +359,15 @@ public class PlacePageController extends Fragment implements
   {
     switch (item)
     {
-      case BOOKMARK_SAVE:
-      case BOOKMARK_DELETE:
-        onBookmarkBtnClicked();
-        break;
-
-      case BACK:
-        onBackBtnClicked();
-        break;
-
-      case ROUTE_FROM:
-        onRouteFromBtnClicked();
-        break;
-
-      case ROUTE_TO:
-        onRouteToBtnClicked();
-        break;
-
-      case ROUTE_ADD:
-        onRouteAddBtnClicked();
-        break;
-
-      case ROUTE_REMOVE:
-        onRouteRemoveBtnClicked();
-        break;
-
-      case ROUTE_AVOID_TOLL:
-        onAvoidTollBtnClicked();
-        break;
-
-      case ROUTE_AVOID_UNPAVED:
-        onAvoidUnpavedBtnClicked();
-        break;
-
-      case ROUTE_AVOID_FERRY:
-        onAvoidFerryBtnClicked();
-        break;
+      case BOOKMARK_SAVE, BOOKMARK_DELETE -> onBookmarkBtnClicked();
+      case BACK -> onBackBtnClicked();
+      case ROUTE_FROM -> onRouteFromBtnClicked();
+      case ROUTE_TO -> onRouteToBtnClicked();
+      case ROUTE_ADD -> onRouteAddBtnClicked();
+      case ROUTE_REMOVE -> onRouteRemoveBtnClicked();
+      case ROUTE_AVOID_TOLL -> onAvoidTollBtnClicked();
+      case ROUTE_AVOID_UNPAVED -> onAvoidUnpavedBtnClicked();
+      case ROUTE_AVOID_FERRY -> onAvoidFerryBtnClicked();
     }
   }
 

--- a/android/app/src/main/java/app/organicmaps/widget/placepage/PlacePageUtils.java
+++ b/android/app/src/main/java/app/organicmaps/widget/placepage/PlacePageUtils.java
@@ -57,23 +57,16 @@ public class PlacePageUtils
   @NonNull
   static String toString(@BottomSheetBehavior.State int state)
   {
-    switch (state)
+    return switch (state)
     {
-      case BottomSheetBehavior.STATE_EXPANDED:
-        return "EXPANDED";
-      case BottomSheetBehavior.STATE_COLLAPSED:
-        return "COLLAPSED";
-      case BottomSheetBehavior.STATE_HALF_EXPANDED:
-        return "HALF_EXPANDED";
-      case BottomSheetBehavior.STATE_DRAGGING:
-        return "DRAGGING";
-      case BottomSheetBehavior.STATE_SETTLING:
-        return "SETTLING";
-      case BottomSheetBehavior.STATE_HIDDEN:
-        return "HIDDEN";
-      default:
-        throw new AssertionError("Unsupported state detected: " + state);
-    }
+      case BottomSheetBehavior.STATE_EXPANDED -> "EXPANDED";
+      case BottomSheetBehavior.STATE_COLLAPSED -> "COLLAPSED";
+      case BottomSheetBehavior.STATE_HALF_EXPANDED -> "HALF_EXPANDED";
+      case BottomSheetBehavior.STATE_DRAGGING -> "DRAGGING";
+      case BottomSheetBehavior.STATE_SETTLING -> "SETTLING";
+      case BottomSheetBehavior.STATE_HIDDEN -> "HIDDEN";
+      default -> throw new AssertionError("Unsupported state detected: " + state);
+    };
   }
 
   public static void copyToClipboard(Context context, View frame, String text)

--- a/android/app/src/main/java/app/organicmaps/widget/placepage/sections/PlaceOpeningHoursAdapter.java
+++ b/android/app/src/main/java/app/organicmaps/widget/placepage/sections/PlaceOpeningHoursAdapter.java
@@ -43,9 +43,9 @@ public class PlaceOpeningHoursAdapter extends RecyclerView.Adapter<PlaceOpeningH
       final int weekDay = weekDays.get(i);
 
       final Timetable tt = findScheduleForWeekDay(timetables, weekDay);
+      final int startWeekDay = weekDays.get(i);
       if (tt != null)
       {
-        final int startWeekDay = weekDays.get(i);
         while (i < weekDays.size() && tt.containsWeekday(weekDays.get(i)))
           i++;
 
@@ -55,7 +55,6 @@ public class PlaceOpeningHoursAdapter extends RecyclerView.Adapter<PlaceOpeningH
       }
       else
       {
-        final int startWeekDay = weekDays.get(i);
         // Search next working day in timetables.
         while (i + 1 < weekDays.size())
         {


### PR DESCRIPTION
This PR updates the syntax of Java code following warnings generated by Android Studio.
- Updated switch format only when code doesn't take more space
- Removed unused imports
- Replaced statement lambda with expression lambda (only when code stays on one line to keep good readability)
- Replaced lambda with method reference
- Removed type between `<>` when type is already explicit
- Make variable final
- Removed redundant TextView cast
- Replaced `+` by `.append()`

I didn't fix all warnings, because I don't know all the impacts of changes suggested by IDE.

⚠ Need to be tested