### PR TITLE
Add recycling, elevation to search result description

### DIFF
--- a/android/app/src/main/cpp/app/organicmaps/editor/Editor.cpp
+++ b/android/app/src/main/cpp/app/organicmaps/editor/Editor.cpp
@@ -7,6 +7,7 @@
 
 #include "indexer/cuisines.hpp"
 #include "indexer/editable_map_object.hpp"
+#include "indexer/feature_utils.hpp"
 #include "indexer/validate_and_format_contacts.hpp"
 
 #include "coding/string_utf8_multilang.hpp"
@@ -142,13 +143,13 @@ Java_app_organicmaps_editor_Editor_nativeGetMaxEditableBuildingLevels(JNIEnv *, 
 JNIEXPORT jboolean JNICALL
 Java_app_organicmaps_editor_Editor_nativeHasWifi(JNIEnv *, jclass)
 {
-  return g_editableMapObject.GetInternet() == osm::Internet::Wlan;
+  return g_editableMapObject.GetInternet() == feature::Internet::Wlan;
 }
 
 JNIEXPORT void JNICALL
 Java_app_organicmaps_editor_Editor_nativeSetHasWifi(JNIEnv *, jclass, jboolean hasWifi)
 {
-  g_editableMapObject.SetInternet(hasWifi ? osm::Internet::Wlan : osm::Internet::Unknown);
+  g_editableMapObject.SetInternet(hasWifi ? feature::Internet::Wlan : feature::Internet::Unknown);
 }
 
 JNIEXPORT jboolean JNICALL

--- a/indexer/editable_map_object.cpp
+++ b/indexer/editable_map_object.cpp
@@ -442,7 +442,7 @@ bool EditableMapObject::IsValidMetadata(MetadataID type, std::string const & val
   case MetadataID::FMD_STARS:
   {
     uint32_t stars;
-    return strings::to_uint(value, stars) && stars > 0 && stars <= kMaxStarsCount;
+    return strings::to_uint(value, stars) && stars > 0 && stars <= feature::kMaxStarsCount;
   }
   case MetadataID::FMD_ELE:
   {

--- a/indexer/editable_map_object.cpp
+++ b/indexer/editable_map_object.cpp
@@ -493,16 +493,16 @@ void EditableMapObject::SetOpeningHours(std::string oh)
   m_metadata.Set(MetadataID::FMD_OPEN_HOURS, std::move(oh));
 }
 
-void EditableMapObject::SetInternet(Internet internet)
+void EditableMapObject::SetInternet(feature::Internet internet)
 {
   m_metadata.Set(MetadataID::FMD_INTERNET, DebugPrint(internet));
 
   uint32_t const wifiType = ftypes::IsWifiChecker::Instance().GetType();
   bool const hasWiFi = m_types.Has(wifiType);
 
-  if (hasWiFi && internet != Internet::Wlan)
+  if (hasWiFi && internet != feature::Internet::Wlan)
     m_types.Remove(wifiType);
-  else if (!hasWiFi && internet == Internet::Wlan)
+  else if (!hasWiFi && internet == feature::Internet::Wlan)
     m_types.Add(wifiType);
 }
 

--- a/indexer/editable_map_object.hpp
+++ b/indexer/editable_map_object.hpp
@@ -3,6 +3,7 @@
 #include "indexer/feature_data.hpp"
 #include "indexer/feature_decl.hpp"
 #include "indexer/feature_meta.hpp"
+#include "indexer/feature_utils.hpp"
 #include "indexer/map_object.hpp"
 
 #include "coding/string_utf8_multilang.hpp"
@@ -130,7 +131,7 @@ public:
   bool UpdateMetadataValue(std::string_view key, std::string value);
 
   void SetOpeningHours(std::string oh);
-  void SetInternet(Internet internet);
+  void SetInternet(feature::Internet internet);
 
   /// @param[in] cuisine is a vector of osm cuisine ids.
 private:

--- a/indexer/feature_utils.cpp
+++ b/indexer/feature_utils.cpp
@@ -467,7 +467,7 @@ string GetReadableWheelchairType(TypesHolder const & types)
 ftraits::WheelchairAvailability GetWheelchairType(TypesHolder const & types)
 {
   auto const opt = ftraits::Wheelchair::GetValue(types);
-  return opt ? *opt : ftraits::WheelchairAvailability::No;
+  return opt ? *opt : ftraits::WheelchairAvailability::Unknown;
 }
 
 bool HasAtm(TypesHolder const & types)

--- a/indexer/feature_utils.cpp
+++ b/indexer/feature_utils.cpp
@@ -464,6 +464,12 @@ string GetReadableWheelchairType(TypesHolder const & types)
   return readableTypes[0];
 }
 
+ftraits::WheelchairAvailability GetWheelchairType(TypesHolder const & types)
+{
+  auto const opt = ftraits::Wheelchair::GetValue(types);
+  return opt ? *opt : ftraits::WheelchairAvailability::No;
+}
+
 bool HasAtm(TypesHolder const & types)
 {
   auto const & isAtmType = ftypes::IsATMChecker::Instance();

--- a/indexer/feature_utils.cpp
+++ b/indexer/feature_utils.cpp
@@ -7,6 +7,7 @@
 #include "indexer/scales.hpp"
 
 #include "platform/localization.hpp"
+#include "platform/distance.hpp"
 
 #include "coding/string_utf8_multilang.hpp"
 #include "coding/transliteration.hpp"
@@ -316,6 +317,7 @@ FeatureEstimator const & GetFeatureEstimator()
 }  // namespace
 
 static constexpr std::string_view kStarSymbol = "★";
+static constexpr std::string_view kMountainSymbol= "▲";
 
 NameParamsIn::NameParamsIn(StringUtf8Multilang const & src_, RegionData const & regionData_,
                            std::string_view deviceLang_, bool allowTranslit_)
@@ -480,6 +482,19 @@ string FormatStars(uint8_t starsCount)
   for (int i = 0; i < starsCount && i < kMaxStarsCount; ++i)
     stars.append(kStarSymbol);
   return stars;
+}
+
+string FormatElevation(string_view elevation)
+{
+  if (!elevation.empty())
+  {
+    double value;
+    if (strings::to_double(elevation, value))
+        return std::string{kMountainSymbol} + platform::Distance::FormatAltitude(value);
+    else
+      LOG(LWARNING, ("Invalid elevation metadata:", elevation));
+  }
+  return {};
 }
 
 } // namespace feature

--- a/indexer/feature_utils.cpp
+++ b/indexer/feature_utils.cpp
@@ -315,6 +315,8 @@ FeatureEstimator const & GetFeatureEstimator()
 }
 }  // namespace
 
+static constexpr std::string_view kStarSymbol = "★";
+
 NameParamsIn::NameParamsIn(StringUtf8Multilang const & src_, RegionData const & regionData_,
                            std::string_view deviceLang_, bool allowTranslit_)
   : NameParamsIn(src_, regionData_, StringUtf8Multilang::GetLangIndex(deviceLang_), allowTranslit_)
@@ -470,6 +472,14 @@ bool HasToilets(TypesHolder const & types)
 {
   auto const & isToiletsType = ftypes::IsToiletsChecker::Instance();
   return isToiletsType(types);
+}
+
+string FormatStars(uint8_t starsCount)
+{
+  std::string stars;
+  for (int i = 0; i < starsCount && i < kMaxStarsCount; ++i)
+    stars.append(kStarSymbol);
+  return stars;
 }
 
 } // namespace feature

--- a/indexer/feature_utils.cpp
+++ b/indexer/feature_utils.cpp
@@ -503,4 +503,41 @@ string FormatElevation(string_view elevation)
   return {};
 }
 
+constexpr char const * kWlan = "wlan";
+constexpr char const * kWired = "wired";
+constexpr char const * kTerminal = "terminal";
+constexpr char const * kYes = "yes";
+constexpr char const * kNo = "no";
+
+string DebugPrint(Internet internet)
+{
+  switch (internet)
+  {
+  case Internet::No: return kNo;
+  case Internet::Yes: return kYes;
+  case Internet::Wlan: return kWlan;
+  case Internet::Wired: return kWired;
+  case Internet::Terminal: return kTerminal;
+  case Internet::Unknown: break;
+  }
+  return {};
+}
+
+Internet InternetFromString(std::string_view inet)
+{
+  if (inet.empty())
+    return Internet::Unknown;
+  if (inet.find(kWlan) != string::npos)
+    return Internet::Wlan;
+  if (inet.find(kWired) != string::npos)
+    return Internet::Wired;
+  if (inet.find(kTerminal) != string::npos)
+    return Internet::Terminal;
+  if (inet == kYes)
+    return Internet::Yes;
+  if (inet == kNo)
+    return Internet::No;
+  return Internet::Unknown;
+}
+
 } // namespace feature

--- a/indexer/feature_utils.hpp
+++ b/indexer/feature_utils.hpp
@@ -3,6 +3,8 @@
 #include <string>
 #include <vector>
 
+#include "indexer/ftraits.hpp"
+
 struct FeatureID;
 class StringUtf8Multilang;
 
@@ -10,6 +12,7 @@ namespace feature
 {
   static constexpr uint8_t kMaxStarsCount = 7;
   static constexpr std::string_view kFieldsSeparator = " • ";
+  static constexpr std::string_view kWheelchairSymbol = "♿️";
 
   // Address house numbers interpolation.
   enum class InterpolType { None, Odd, Even, Any };
@@ -134,6 +137,9 @@ namespace feature
 
   // Returns readable wheelchair type.
   std::string GetReadableWheelchairType(TypesHolder const & types);
+  
+  /// @returns wheelchair availability.
+  ftraits::WheelchairAvailability GetWheelchairType(TypesHolder const & types);
 
   /// Returns true if feature has ATM type.
   bool HasAtm(TypesHolder const & types);

--- a/indexer/feature_utils.hpp
+++ b/indexer/feature_utils.hpp
@@ -144,4 +144,7 @@ namespace feature
   /// @returns starsCount of ★ symbol.
   std::string FormatStars(uint8_t starsCount);
 
+  /// @returns formatted elevation with ▲ symbol and units.
+  std::string FormatElevation(std::string_view elevation);
+
 }  // namespace feature

--- a/indexer/feature_utils.hpp
+++ b/indexer/feature_utils.hpp
@@ -8,6 +8,7 @@ class StringUtf8Multilang;
 
 namespace feature
 {
+  static constexpr uint8_t kMaxStarsCount = 7;
   static constexpr std::string_view kFieldsSeparator = " • ";
 
   // Address house numbers interpolation.
@@ -139,5 +140,8 @@ namespace feature
 
   /// Returns true if feature has Toilets type.
   bool HasToilets(TypesHolder const & types);
+
+  /// @returns starsCount of ★ symbol.
+  std::string FormatStars(uint8_t starsCount);
 
 }  // namespace feature

--- a/indexer/feature_utils.hpp
+++ b/indexer/feature_utils.hpp
@@ -16,6 +16,20 @@ namespace feature
   static constexpr std::string_view kAtmSymbol = "💳";
   static constexpr std::string_view kWheelchairSymbol = "♿️";
 
+  /// OSM internet_access tag values.
+  enum class Internet
+  {
+    Unknown,  //!< Internet state is unknown (default).
+    Wlan,     //!< Wireless Internet access is present.
+    Terminal, //!< A computer with internet service.
+    Wired,    //!< Wired Internet access is present.
+    Yes,      //!< Unspecified Internet access is available.
+    No        //!< There is definitely no any Internet access.
+  };
+  std::string DebugPrint(Internet internet);
+  /// @param[in]  inet  Should be lowercase like in DebugPrint.
+  Internet InternetFromString(std::string_view inet);
+
   // Address house numbers interpolation.
   enum class InterpolType { None, Odd, Even, Any };
 

--- a/indexer/feature_utils.hpp
+++ b/indexer/feature_utils.hpp
@@ -12,6 +12,8 @@ namespace feature
 {
   static constexpr uint8_t kMaxStarsCount = 7;
   static constexpr std::string_view kFieldsSeparator = " • ";
+  static constexpr std::string_view kToiletsSymbol = "🚻";
+  static constexpr std::string_view kAtmSymbol = "💳";
   static constexpr std::string_view kWheelchairSymbol = "♿️";
 
   // Address house numbers interpolation.

--- a/indexer/ftraits.hpp
+++ b/indexer/ftraits.hpp
@@ -73,7 +73,8 @@ enum class WheelchairAvailability
 {
   No,
   Yes,
-  Limited
+  Limited,
+  Unknown
 };
 
 inline std::string DebugPrint(WheelchairAvailability wheelchair)
@@ -83,6 +84,7 @@ inline std::string DebugPrint(WheelchairAvailability wheelchair)
   case WheelchairAvailability::No: return "No";
   case WheelchairAvailability::Yes: return "Yes";
   case WheelchairAvailability::Limited: return "Limited";
+  case WheelchairAvailability::Unknown: return "Unknown";
   }
   UNREACHABLE();
 }

--- a/indexer/indexer_tests/editable_map_object_test.cpp
+++ b/indexer/indexer_tests/editable_map_object_test.cpp
@@ -4,6 +4,7 @@
 #include "indexer/classificator_loader.hpp"
 #include "indexer/editable_map_object.hpp"
 #include "indexer/feature.hpp"
+#include "indexer/feature_utils.hpp"
 #include "indexer/validate_and_format_contacts.hpp"
 
 #include <string>
@@ -336,7 +337,7 @@ UNIT_TEST(EditableMapObject_SetInternet)
   auto types = emo.GetTypes();
   TEST(types.Has(wifiType), ());
 
-  auto const setInternetAndCheck = [wifiType](EditableMapObject & emo, osm::Internet internet, bool hasWifi)
+  auto const setInternetAndCheck = [wifiType](EditableMapObject & emo, feature::Internet internet, bool hasWifi)
   {
     emo.SetInternet(internet);
 
@@ -345,30 +346,30 @@ UNIT_TEST(EditableMapObject_SetInternet)
     TEST_EQUAL(types.Has(wifiType), hasWifi, ());
   };
 
-  setInternetAndCheck(emo, osm::Internet::No, false);
-  setInternetAndCheck(emo, osm::Internet::Yes, false);
-  setInternetAndCheck(emo, osm::Internet::Wired, false);
-  setInternetAndCheck(emo, osm::Internet::Wlan, true);
-  setInternetAndCheck(emo, osm::Internet::Unknown, false);
-  setInternetAndCheck(emo, osm::Internet::Terminal, false);
+  setInternetAndCheck(emo, feature::Internet::No, false);
+  setInternetAndCheck(emo, feature::Internet::Yes, false);
+  setInternetAndCheck(emo, feature::Internet::Wired, false);
+  setInternetAndCheck(emo, feature::Internet::Wlan, true);
+  setInternetAndCheck(emo, feature::Internet::Unknown, false);
+  setInternetAndCheck(emo, feature::Internet::Terminal, false);
 
   EditableMapObject bunkerEmo;
   bunkerEmo.SetType(classif().GetTypeByPath({"military", "bunker"}));
   types = bunkerEmo.GetTypes();
   TEST(!types.Has(wifiType), ());
 
-  setInternetAndCheck(bunkerEmo, osm::Internet::Wlan, true);
-  setInternetAndCheck(bunkerEmo, osm::Internet::No, false);
-  setInternetAndCheck(bunkerEmo, osm::Internet::Wlan, true);
-  setInternetAndCheck(bunkerEmo, osm::Internet::Yes, false);
-  setInternetAndCheck(bunkerEmo, osm::Internet::Wlan, true);
-  setInternetAndCheck(bunkerEmo, osm::Internet::Wired, false);
-  setInternetAndCheck(bunkerEmo, osm::Internet::Wlan, true);
-  setInternetAndCheck(bunkerEmo, osm::Internet::Unknown, false);
-  setInternetAndCheck(bunkerEmo, osm::Internet::Wlan, true);
-  setInternetAndCheck(bunkerEmo, osm::Internet::Terminal, false);
-  setInternetAndCheck(bunkerEmo, osm::Internet::Wlan, true);
-  setInternetAndCheck(bunkerEmo, osm::Internet::Wlan, true);
+  setInternetAndCheck(bunkerEmo, feature::Internet::Wlan, true);
+  setInternetAndCheck(bunkerEmo, feature::Internet::No, false);
+  setInternetAndCheck(bunkerEmo, feature::Internet::Wlan, true);
+  setInternetAndCheck(bunkerEmo, feature::Internet::Yes, false);
+  setInternetAndCheck(bunkerEmo, feature::Internet::Wlan, true);
+  setInternetAndCheck(bunkerEmo, feature::Internet::Wired, false);
+  setInternetAndCheck(bunkerEmo, feature::Internet::Wlan, true);
+  setInternetAndCheck(bunkerEmo, feature::Internet::Unknown, false);
+  setInternetAndCheck(bunkerEmo, feature::Internet::Wlan, true);
+  setInternetAndCheck(bunkerEmo, feature::Internet::Terminal, false);
+  setInternetAndCheck(bunkerEmo, feature::Internet::Wlan, true);
+  setInternetAndCheck(bunkerEmo, feature::Internet::Wlan, true);
 }
 
 UNIT_TEST(EditableMapObject_RemoveFakeNames)
@@ -663,7 +664,7 @@ UNIT_TEST(EditableMapObject_FromFeatureType)
   emo.SetName(names);
 
   emo.SetMetadata(feature::Metadata::FMD_WEBSITE, "https://some.thing.org");
-  emo.SetInternet(osm::Internet::Wlan);
+  emo.SetInternet(feature::Internet::Wlan);
 
   emo.SetPointType();
   emo.SetMercator(m2::PointD(1.0, 1.0));

--- a/indexer/map_object.cpp
+++ b/indexer/map_object.cpp
@@ -203,20 +203,6 @@ int MapObject::GetStars() const
   return count;
 }
 
-string MapObject::GetElevationFormatted() const
-{
-  auto const sv = m_metadata.Get(MetadataID::FMD_ELE);
-  if (!sv.empty())
-  {
-    double value;
-    if (strings::to_double(sv, value))
-      return platform::Distance::FormatAltitude(value);
-    else
-      LOG(LWARNING, ("Invalid elevation metadata:", sv));
-  }
-  return {};
-}
-
 ftraits::WheelchairAvailability MapObject::GetWheelchairType() const
 {
   auto const opt = ftraits::Wheelchair::GetValue(m_types);

--- a/indexer/map_object.cpp
+++ b/indexer/map_object.cpp
@@ -2,7 +2,6 @@
 
 #include "indexer/feature.hpp"
 #include "indexer/feature_algo.hpp"
-#include "indexer/feature_utils.hpp"
 #include "indexer/ftypes_matcher.hpp"
 #include "indexer/road_shields_parser.hpp"
 
@@ -18,29 +17,6 @@
 namespace osm
 {
 using namespace std;
-
-namespace
-{
-constexpr char const * kWlan = "wlan";
-constexpr char const * kWired = "wired";
-constexpr char const * kTerminal = "terminal";
-constexpr char const * kYes = "yes";
-constexpr char const * kNo = "no";
-}  // namespace
-
-string DebugPrint(osm::Internet internet)
-{
-  switch (internet)
-  {
-  case Internet::No: return kNo;
-  case Internet::Yes: return kYes;
-  case Internet::Wlan: return kWlan;
-  case Internet::Wired: return kWired;
-  case Internet::Terminal: return kTerminal;
-  case Internet::Unknown: break;
-  }
-  return {};
-}
 
 void MapObject::SetFromFeatureType(FeatureType & ft)
 {
@@ -123,31 +99,14 @@ std::string_view MapObject::GetMetadata(MetadataID type) const
   return m_metadata.Get(type);
 }
 
-Internet InternetFromString(std::string_view inet)
-{
-  if (inet.empty())
-    return Internet::Unknown;
-  if (inet.find(kWlan) != string::npos)
-    return Internet::Wlan;
-  if (inet.find(kWired) != string::npos)
-    return Internet::Wired;
-  if (inet.find(kTerminal) != string::npos)
-    return Internet::Terminal;
-  if (inet == kYes)
-    return Internet::Yes;
-  if (inet == kNo)
-    return Internet::No;
-  return Internet::Unknown;
-}
-
 std::string_view MapObject::GetOpeningHours() const
 {
   return m_metadata.Get(MetadataID::FMD_OPEN_HOURS);
 }
 
-Internet MapObject::GetInternet() const
+feature::Internet MapObject::GetInternet() const
 {
-  return InternetFromString(m_metadata.Get(MetadataID::FMD_INTERNET));
+  return feature::InternetFromString(m_metadata.Get(MetadataID::FMD_INTERNET));
 }
 
 vector<string> MapObject::GetCuisines() const { return feature::GetCuisines(m_types); }

--- a/indexer/map_object.cpp
+++ b/indexer/map_object.cpp
@@ -203,12 +203,6 @@ int MapObject::GetStars() const
   return count;
 }
 
-ftraits::WheelchairAvailability MapObject::GetWheelchairType() const
-{
-  auto const opt = ftraits::Wheelchair::GetValue(m_types);
-  return opt ? *opt : ftraits::WheelchairAvailability::No;
-}
-
 bool MapObject::IsPointType() const { return m_geomType == feature::GeomType::Point; }
 bool MapObject::IsBuilding() const { return ftypes::IsBuildingChecker::Instance()(m_types); }
 bool MapObject::IsPublicTransportStop() const { return ftypes::IsPublicTransportStopChecker::Instance()(m_types); }

--- a/indexer/map_object.hpp
+++ b/indexer/map_object.hpp
@@ -104,9 +104,6 @@ public:
 
   /// @returns true if feature has Toilets type.
   bool HasToilets() const;
-
-  /// @returns formatted elevation in feet or meters, or empty string.
-  std::string GetElevationFormatted() const;
   /// @}
 
   bool IsPointType() const;

--- a/indexer/map_object.hpp
+++ b/indexer/map_object.hpp
@@ -97,7 +97,6 @@ public:
   std::string_view GetOpeningHours() const;
   Internet GetInternet() const;
   int GetStars() const;
-  ftraits::WheelchairAvailability GetWheelchairType() const;
 
   /// @returns true if feature has ATM type.
   bool HasAtm() const;

--- a/indexer/map_object.hpp
+++ b/indexer/map_object.hpp
@@ -33,9 +33,7 @@ Internet InternetFromString(std::string_view inet);
 class MapObject
 {
 public:
-  static constexpr std::string_view kStarSymbol = "★";
   static constexpr std::string_view kToiletsSymbol = "🚻";
-  static constexpr uint8_t kMaxStarsCount = 7;
 
   void SetFromFeatureType(FeatureType & ft);
 

--- a/indexer/map_object.hpp
+++ b/indexer/map_object.hpp
@@ -33,8 +33,6 @@ Internet InternetFromString(std::string_view inet);
 class MapObject
 {
 public:
-  static constexpr std::string_view kToiletsSymbol = "🚻";
-
   void SetFromFeatureType(FeatureType & ft);
 
   FeatureID const & GetID() const;

--- a/indexer/map_object.hpp
+++ b/indexer/map_object.hpp
@@ -3,6 +3,7 @@
 #include "indexer/feature_data.hpp"
 #include "indexer/feature_decl.hpp"
 #include "indexer/feature_meta.hpp"
+#include "indexer/feature_utils.hpp"
 #include "indexer/ftraits.hpp"
 
 #include "geometry/latlon.hpp"
@@ -15,20 +16,6 @@
 namespace osm
 {
 class EditableMapObject;
-
-/// OSM internet_access tag values.
-enum class Internet
-{
-  Unknown,  //!< Internet state is unknown (default).
-  Wlan,     //!< Wireless Internet access is present.
-  Terminal, //!< A computer with internet service.
-  Wired,    //!< Wired Internet access is present.
-  Yes,      //!< Unspecified Internet access is available.
-  No        //!< There is definitely no any Internet access.
-};
-std::string DebugPrint(Internet internet);
-/// @param[in]  inet  Should be lowercase like in DebugPrint.
-Internet InternetFromString(std::string_view inet);
 
 class MapObject
 {
@@ -93,7 +80,7 @@ public:
   std::string FormatRoadShields() const;
 
   std::string_view GetOpeningHours() const;
-  Internet GetInternet() const;
+  feature::Internet GetInternet() const;
   int GetStars() const;
 
   /// @returns true if feature has ATM type.

--- a/iphone/CoreApi/CoreApi/PlacePageData/Common/PlacePageInfoData.mm
+++ b/iphone/CoreApi/CoreApi/PlacePageData/Common/PlacePageInfoData.mm
@@ -73,7 +73,7 @@ using namespace osm;
         case MetadataID::FMD_CONTACT_LINE: _line = ToNSString(value); break;
         case MetadataID::FMD_OPERATOR: _ppOperator = ToNSString(value); break;
         case MetadataID::FMD_INTERNET:
-          _wifiAvailable = (rawData.GetInternet() == osm::Internet::No)
+          _wifiAvailable = (rawData.GetInternet() == feature::Internet::No)
               ? NSLocalizedString(@"no_available", nil) : NSLocalizedString(@"yes_available", nil);
           break;
         case MetadataID::FMD_LEVEL: _level = ToNSString(value); break;

--- a/iphone/Maps/UI/Editor/MWMEditorViewController.mm
+++ b/iphone/Maps/UI/Editor/MWMEditorViewController.mm
@@ -504,7 +504,7 @@ void registerCellsForTableView(std::vector<MWMEditorCellID> const & cells, UITab
     [tCell configWithDelegate:self
                          icon:[UIImage imageNamed:@"ic_placepage_wifi"]
                          text:L(@"wifi")
-                           on:m_mapObject.GetInternet() == osm::Internet::Wlan];
+                           on:m_mapObject.GetInternet() == feature::Internet::Wlan];
     break;
   }
   case MWMEditorCellTypeAdditionalName:
@@ -930,7 +930,7 @@ void registerCellsForTableView(std::vector<MWMEditorCellID> const & cells, UITab
   switch ([self cellTypeForIndexPath:indexPath])
   {
   case MetadataID::FMD_INTERNET:
-    m_mapObject.SetInternet(changeSwitch ? osm::Internet::Wlan : osm::Internet::Unknown);
+    m_mapObject.SetInternet(changeSwitch ? feature::Internet::Wlan : feature::Internet::Unknown);
     break;
   default: NSAssert(false, @"Invalid field for changeSwitch"); break;
   }

--- a/map/place_page_info.cpp
+++ b/map/place_page_info.cpp
@@ -19,7 +19,6 @@
 
 namespace place_page
 {
-static constexpr std::string_view kMountainSymbol= "▲";
 static constexpr std::string_view kWheelchairSymbol = "♿️";
 static constexpr std::string_view kAtmSymbol = "💳";
 
@@ -172,9 +171,9 @@ std::string Info::FormatSubtitle(bool withType) const
   }
 
   // Elevation.
-  auto const eleStr = GetElevationFormatted();
+  auto const eleStr = feature::FormatElevation(GetMetadata(MetadataID::FMD_ELE));
   if (!eleStr.empty())
-    append(std::string{kMountainSymbol} + eleStr);
+    append(eleStr);
 
   // ATM
   if (HasAtm())

--- a/map/place_page_info.cpp
+++ b/map/place_page_info.cpp
@@ -19,7 +19,6 @@
 
 namespace place_page
 {
-static constexpr std::string_view kAtmSymbol = "💳";
 
 bool Info::IsBookmark() const
 {
@@ -176,7 +175,7 @@ std::string Info::FormatSubtitle(bool withType) const
 
   // ATM
   if (HasAtm())
-    append(kAtmSymbol);
+    append(feature::kAtmSymbol);
 
   // Internet.
   if (HasWifi())
@@ -184,7 +183,7 @@ std::string Info::FormatSubtitle(bool withType) const
 
   // Toilets.
   if (HasToilets())
-    append(kToiletsSymbol);
+    append(feature::kToiletsSymbol);
 
   // Wheelchair
   if (feature::GetWheelchairType(m_types) == ftraits::WheelchairAvailability::Yes)

--- a/map/place_page_info.cpp
+++ b/map/place_page_info.cpp
@@ -149,7 +149,7 @@ std::string Info::FormatSubtitle(bool withType) const
     append(roadShields);
 
   // Stars.
-  auto const stars = FormatStars();
+  auto const stars = feature::FormatStars(GetStars());
   if (!stars.empty())
     append(stars);
 
@@ -311,14 +311,6 @@ kml::LocalizableString Info::FormatNewBookmarkName() const
   }
 
   return bookmarkName;
-}
-
-std::string Info::FormatStars() const
-{
-  std::string stars;
-  for (int i = 0; i < GetStars(); ++i)
-    stars.append(MapObject::kStarSymbol);
-  return stars;
 }
 
 std::string Info::GetFormattedCoordinate(CoordinatesFormat coordsFormat) const

--- a/map/place_page_info.cpp
+++ b/map/place_page_info.cpp
@@ -19,7 +19,6 @@
 
 namespace place_page
 {
-static constexpr std::string_view kWheelchairSymbol = "♿️";
 static constexpr std::string_view kAtmSymbol = "💳";
 
 bool Info::IsBookmark() const
@@ -188,8 +187,8 @@ std::string Info::FormatSubtitle(bool withType) const
     append(kToiletsSymbol);
 
   // Wheelchair
-  if (GetWheelchairType() == ftraits::WheelchairAvailability::Yes)
-    append(kWheelchairSymbol);
+  if (feature::GetWheelchairType(m_types) == ftraits::WheelchairAvailability::Yes)
+    append(feature::kWheelchairSymbol);
 
   // Fee.
   auto const fee = GetLocalizedFeeType();

--- a/map/place_page_info.hpp
+++ b/map/place_page_info.hpp
@@ -219,8 +219,6 @@ public:
 private:
   std::string FormatSubtitle(bool withType) const;
   std::string GetBookmarkName();
-  /// @returns empty string or GetStars() count of ★ symbol.
-  std::string FormatStars() const;
 
   place_page::BuildInfo m_buildInfo;
 

--- a/map/place_page_info.hpp
+++ b/map/place_page_info.hpp
@@ -121,7 +121,7 @@ public:
   /// @returns true if Back API button should be displayed.
   bool HasApiUrl() const { return !m_apiUrl.empty(); }
   /// TODO: Support all possible Internet types in UI. @See MapObject::GetInternet().
-  bool HasWifi() const { return GetInternet() == osm::Internet::Wlan; }
+  bool HasWifi() const { return GetInternet() == feature::Internet::Wlan; }
   /// Should be used by UI code to generate cool name for new bookmarks.
   // TODO: Tune new bookmark name. May be add address or some other data.
   kml::LocalizableString FormatNewBookmarkName() const;

--- a/qt/editor_dialog.cpp
+++ b/qt/editor_dialog.cpp
@@ -1,6 +1,7 @@
 #include "qt/editor_dialog.hpp"
 
 #include "indexer/editable_map_object.hpp"
+#include "indexer/feature_utils.hpp"
 
 #include "base/string_utils.hpp"
 
@@ -113,12 +114,12 @@ EditorDialog::EditorDialog(QWidget * parent, osm::EditableMapObject & emo)
       {
         grid->addWidget(new QLabel(kInternetObjectName), row, 0);
         QComboBox * cmb = new QComboBox();
-        std::string const values[] = {DebugPrint(osm::Internet::Unknown),
-                                      DebugPrint(osm::Internet::Wlan),
-                                      DebugPrint(osm::Internet::Wired),
-                                      DebugPrint(osm::Internet::Terminal),
-                                      DebugPrint(osm::Internet::Yes),
-                                      DebugPrint(osm::Internet::No)};
+        std::string const values[] = {DebugPrint(feature::Internet::Unknown),
+                                      DebugPrint(feature::Internet::Wlan),
+                                      DebugPrint(feature::Internet::Wired),
+                                      DebugPrint(feature::Internet::Terminal),
+                                      DebugPrint(feature::Internet::Yes),
+                                      DebugPrint(feature::Internet::No)};
         for (auto const & v : values)
           cmb->addItem(v.c_str());
         cmb->setCurrentText(DebugPrint(emo.GetInternet()).c_str());
@@ -216,7 +217,7 @@ void EditorDialog::OnSave()
     if (prop == PropID::FMD_INTERNET)
     {
       QComboBox * cmb = findChild<QComboBox *>(kInternetObjectName);
-      m_feature.SetInternet(osm::InternetFromString(cmb->currentText().toStdString()));
+      m_feature.SetInternet(feature::InternetFromString(cmb->currentText().toStdString()));
       continue;
     }
     if (prop == PropID::FMD_POSTCODE) // already set above

--- a/search/intermediate_result.cpp
+++ b/search/intermediate_result.cpp
@@ -286,13 +286,11 @@ void FillDetails(FeatureType & ft, Result::Details & details)
 
   feature::TypesHolder const typesHolder(ft);
 
+  std::string stars;
   uint8_t starsCount = 0;
   bool const isHotel = ftypes::IsHotelChecker::Instance()(typesHolder);
   if (isHotel && strings::to_uint(ft.GetMetadata(feature::Metadata::FMD_STARS), starsCount))
-    starsCount = std::min(starsCount, osm::MapObject::kMaxStarsCount);
-  std::string stars;
-  for (int i = 0; i < starsCount; ++i)
-    stars.append(osm::MapObject::kStarSymbol);
+    stars = feature::FormatStars(starsCount);
 
   auto const cuisines = feature::GetLocalizedCuisines(typesHolder);
   auto const cuisine = strings::JoinStrings(cuisines, feature::kFieldsSeparator);

--- a/search/intermediate_result.cpp
+++ b/search/intermediate_result.cpp
@@ -295,6 +295,8 @@ void FillDetails(FeatureType & ft, Result::Details & details)
   auto const cuisines = feature::GetLocalizedCuisines(typesHolder);
   auto const cuisine = strings::JoinStrings(cuisines, feature::kFieldsSeparator);
 
+  auto const recycling = strings::JoinStrings(feature::GetLocalizedRecyclingTypes(typesHolder), feature::kFieldsSeparator);
+
   auto const roadShields = ftypes::GetRoadShieldsNames(ft);
   auto const roadShield = strings::JoinStrings(roadShields, feature::kFieldsSeparator);
 
@@ -319,6 +321,7 @@ void FillDetails(FeatureType & ft, Result::Details & details)
   append(brand);
   append(elevation);
   append(cuisine);
+  append(recycling);
   append(fee);
   
   details.m_description = std::move(description);

--- a/search/intermediate_result.cpp
+++ b/search/intermediate_result.cpp
@@ -300,6 +300,8 @@ void FillDetails(FeatureType & ft, Result::Details & details)
 
   auto const fee = feature::GetLocalizedFeeType(typesHolder);
 
+  auto const elevation = feature::FormatElevation(ft.GetMetadata(feature::Metadata::FMD_ELE));
+
   std::string description;
 
   auto const append = [&description](std::string_view sv)
@@ -315,6 +317,7 @@ void FillDetails(FeatureType & ft, Result::Details & details)
   append(airportIata);
   append(roadShield);
   append(brand);
+  append(elevation);
   append(cuisine);
   append(fee);
   

--- a/search/search_integration_tests/search_edited_features_test.cpp
+++ b/search/search_integration_tests/search_edited_features_test.cpp
@@ -52,7 +52,7 @@ UNIT_CLASS_TEST(SearchEditedFeaturesTest, Smoke)
 
     TEST(ResultsMatch("Wifi", Rules{}), ());
 
-    EditFeature(cafeId, [](osm::EditableMapObject & emo) { emo.SetInternet(osm::Internet::Wlan); });
+    EditFeature(cafeId, [](osm::EditableMapObject & emo) { emo.SetInternet(feature::Internet::Wlan); });
 
     TEST(ResultsMatch("Wifi", rules), ());
     TEST(ResultsMatch("wifi bar quahog", rules), ());
@@ -73,7 +73,7 @@ UNIT_CLASS_TEST(SearchEditedFeaturesTest, NonamePoi)
 
     TEST(ResultsMatch("Eat ", rules), ());
 
-    EditFeature(cafeId, [](osm::EditableMapObject & emo) { emo.SetInternet(osm::Internet::Wlan); });
+    EditFeature(cafeId, [](osm::EditableMapObject & emo) { emo.SetInternet(feature::Internet::Wlan); });
 
     TEST(ResultsMatch("Eat ", rules), ());
   }


### PR DESCRIPTION
This PR adds recycling, WiFi, operator, wheelchair, ATM, elevation information to search result description. 

Also changed the WiFi indicator from string to 🛜 symbol. 

<img src="https://github.com/organicmaps/organicmaps/assets/47610359/70ec6014-eb02-4f68-bbbd-9c2d4f567f90" width="320"/> <img src="https://github.com/organicmaps/organicmaps/assets/47610359/aa66b2df-4fce-49c9-b091-5fb792a8c12a" width="320"/> <img src="https://github.com/organicmaps/organicmaps/assets/47610359/d9a169a3-86ff-461a-8b8f-73e67a4d0eea" width="320"/> <img src="https://github.com/organicmaps/organicmaps/assets/47610359/99f05c53-8b0c-40af-8a56-b66b482932db" width="320"/>
