### PR TITLE
[android] Remove lint rule about unused resources

### DIFF
--- a/android/app/build.gradle
+++ b/android/app/build.gradle
@@ -285,8 +285,6 @@ android {
     disable 'CustomSplashScreen'
     // https://github.com/organicmaps/organicmaps/issues/3610
     disable 'InsecureBaseConfiguration'
-    // https://github.com/organicmaps/organicmaps/issues/3608
-    disable 'UnusedResources'
     abortOnError true
   }
 


### PR DESCRIPTION
This PR removes lint rule about unused resources.
I have checked with Android Studio we don't have unused resources and Lint doesn't generate errors or warnings about this.