### PR TITLE
[bookmarks] Use list of categories ids in java/cpp

### DIFF
--- a/android/app/src/main/java/app/organicmaps/bookmarks/BookmarksSharingHelper.java
+++ b/android/app/src/main/java/app/organicmaps/bookmarks/BookmarksSharingHelper.java
@@ -14,6 +14,11 @@ import app.organicmaps.util.SharingUtils;
 import app.organicmaps.util.log.Logger;
 import com.google.android.material.dialog.MaterialAlertDialogBuilder;
 
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+
+
 public enum BookmarksSharingHelper
 {
   INSTANCE;
@@ -25,13 +30,18 @@ public enum BookmarksSharingHelper
 
   public void prepareBookmarkCategoryForSharing(@NonNull Activity context, long catId)
   {
+    showProgressDialog(context);
+    BookmarkManager.INSTANCE.prepareCategoriesForSharing(new long[]{catId});
+  }
+
+  private void showProgressDialog(@NonNull Activity context)
+  {
     mProgressDialog = new ProgressDialog(context, R.style.MwmTheme_ProgressDialog);
     mProgressDialog.setMessage(context.getString(R.string.please_wait));
     mProgressDialog.setProgressStyle(ProgressDialog.STYLE_SPINNER);
     mProgressDialog.setIndeterminate(true);
     mProgressDialog.setCancelable(false);
     mProgressDialog.show();
-    BookmarkManager.INSTANCE.prepareCategoryForSharing(catId);
   }
 
   public void onPreparedFileForSharing(@NonNull FragmentActivity context,
@@ -57,8 +67,10 @@ public enum BookmarksSharingHelper
             .setMessage(R.string.bookmarks_error_message_share_general)
             .setPositiveButton(R.string.ok, null)
             .show();
-        String catName = BookmarkManager.INSTANCE.getCategoryById(result.getCategoryId()).getName();
-        Logger.e(TAG, "Failed to share bookmark category '" + catName + "', error code: " + result.getCode());
+        List<String> names = new ArrayList<>();
+        for (long categoryId : result.getCategoriesIds())
+          names.add(BookmarkManager.INSTANCE.getCategoryById(categoryId).getName());
+        Logger.e(TAG, "Failed to share bookmark categories " + names + ", error code: " + result.getCode());
       }
       default -> throw new AssertionError("Unsupported bookmark sharing code: " + result.getCode());
     }

--- a/android/app/src/main/java/app/organicmaps/bookmarks/data/BookmarkManager.java
+++ b/android/app/src/main/java/app/organicmaps/bookmarks/data/BookmarkManager.java
@@ -559,9 +559,9 @@ public enum BookmarkManager
     nativeSetChildCategoriesVisibility(catId, visible);
   }
 
-  public void prepareCategoryForSharing(long catId)
+  public void prepareCategoriesForSharing(long[] catIds)
   {
-    nativePrepareFileForSharing(catId);
+    nativePrepareFileForSharing(catIds);
   }
 
   public void setNotificationsEnabled(boolean enabled)
@@ -799,7 +799,7 @@ public enum BookmarkManager
 
   private static native void nativeSetAllCategoriesVisibility(boolean visible);
 
-  private static native void nativePrepareFileForSharing(long catId);
+  private static native void nativePrepareFileForSharing(long[] catIds);
 
   private static native boolean nativeIsCategoryEmpty(long catId);
 

--- a/android/app/src/main/java/app/organicmaps/bookmarks/data/BookmarkSharingResult.java
+++ b/android/app/src/main/java/app/organicmaps/bookmarks/data/BookmarkSharingResult.java
@@ -21,7 +21,7 @@ public class BookmarkSharingResult
   public static final int ARCHIVE_ERROR = 2;
   public static final int FILE_ERROR = 3;
 
-  private final long mCategoryId;
+  private final long[] mCategoriesIds;
   @Code
   private final int mCode;
   @NonNull
@@ -30,19 +30,19 @@ public class BookmarkSharingResult
   @SuppressWarnings("unused")
   private final String mErrorString;
 
-  private BookmarkSharingResult(long categoryId, @Code int code,
+  public BookmarkSharingResult(long[] categoriesIds, @Code int code,
                                 @NonNull String sharingPath,
                                 @NonNull String errorString)
   {
-    mCategoryId = categoryId;
+    mCategoriesIds = categoriesIds;
     mCode = code;
     mSharingPath = sharingPath;
     mErrorString = errorString;
   }
 
-  public long getCategoryId()
+  public long[] getCategoriesIds()
   {
-    return mCategoryId;
+    return mCategoriesIds;
   }
 
   public int getCode()

--- a/android/app/src/main/java/app/organicmaps/bookmarks/data/BookmarkSharingResult.java
+++ b/android/app/src/main/java/app/organicmaps/bookmarks/data/BookmarkSharingResult.java
@@ -30,9 +30,7 @@ public class BookmarkSharingResult
   @SuppressWarnings("unused")
   private final String mErrorString;
 
-  public BookmarkSharingResult(long[] categoriesIds, @Code int code,
-                                @NonNull String sharingPath,
-                                @NonNull String errorString)
+  public BookmarkSharingResult(long[] categoriesIds, @Code int code, @NonNull String sharingPath, @NonNull String errorString)
   {
     mCategoriesIds = categoriesIds;
     mCode = code;

--- a/iphone/CoreApi/CoreApi/Bookmarks/MWMBookmarksManager.mm
+++ b/iphone/CoreApi/CoreApi/Bookmarks/MWMBookmarksManager.mm
@@ -577,8 +577,7 @@ static BookmarkManager::SortingType convertSortingTypeToCore(MWMBookmarksSorting
     {
     case BookmarkManager::SharingResult::Code::Success:
     {
-      self.shareCategoryURL = [NSURL fileURLWithPath:@(sharingResult.m_sharingPath.c_str())
-                                            isDirectory:NO];
+      self.shareCategoryURL = [NSURL fileURLWithPath:@(sharingResult.m_sharingPath.c_str()) isDirectory:NO];
       ASSERT(self.shareCategoryURL, ("Invalid share category url"));
       status = MWMBookmarksShareStatusSuccess;
       break;
@@ -593,7 +592,7 @@ static BookmarkManager::SortingType convertSortingTypeToCore(MWMBookmarksSorting
       status = MWMBookmarksShareStatusFileError;
       break;
     }
-    
+
     [self loopObservers:^(id<MWMBookmarksObserver> observer) {
       if ([observer respondsToSelector:@selector(onBookmarksCategoryFilePrepared:)])
         [observer onBookmarksCategoryFilePrepared:status];
@@ -611,7 +610,7 @@ static BookmarkManager::SortingType convertSortingTypeToCore(MWMBookmarksSorting
 {
   if (!self.shareCategoryURL)
     return;
-  
+
   base::DeleteFileX(self.shareCategoryURL.path.UTF8String);
   self.shareCategoryURL = nil;
 }
@@ -693,7 +692,7 @@ static BookmarkManager::SortingType convertSortingTypeToCore(MWMBookmarksSorting
     if (!track) {
         return;
     }
-    
+
     track->SetName(title.UTF8String);
 }
 

--- a/iphone/CoreApi/CoreApi/Bookmarks/MWMBookmarksManager.mm
+++ b/iphone/CoreApi/CoreApi/Bookmarks/MWMBookmarksManager.mm
@@ -570,7 +570,7 @@ static BookmarkManager::SortingType convertSortingTypeToCore(MWMBookmarksSorting
 
 - (void)shareCategory:(MWMMarkGroupID)groupId
 {
-  self.bm.PrepareFileForSharing(groupId, [self](auto sharingResult)
+  self.bm.PrepareFileForSharing({groupId}, [self](auto sharingResult)
   {
     MWMBookmarksShareStatus status;
     switch (sharingResult.m_code)

--- a/map/bookmark_manager.hpp
+++ b/map/bookmark_manager.hpp
@@ -316,31 +316,31 @@ public:
       FileError
     };
 
-    SharingResult(kml::MarkGroupId categoryId, std::string const & sharingPath)
-      : m_categoryId(categoryId)
+    SharingResult(kml::GroupIdCollection const & categoriesIds, std::string const & sharingPath)
+      : m_categoriesIds(categoriesIds)
       , m_code(Code::Success)
       , m_sharingPath(sharingPath)
     {}
 
-    SharingResult(kml::MarkGroupId categoryId, Code code)
-      : m_categoryId(categoryId)
+    SharingResult(kml::GroupIdCollection const & categoriesIds, Code code)
+      : m_categoriesIds(categoriesIds)
       , m_code(code)
     {}
 
-    SharingResult(kml::MarkGroupId categoryId, Code code, std::string const & errorString)
-      : m_categoryId(categoryId)
+    SharingResult(kml::GroupIdCollection const & categoriesIds, Code code, std::string const & errorString)
+      : m_categoriesIds(categoriesIds)
       , m_code(code)
       , m_errorString(errorString)
     {}
 
-    kml::MarkGroupId m_categoryId;
+    kml::MarkIdCollection m_categoriesIds;
     Code m_code;
     std::string m_sharingPath;
     std::string m_errorString;
   };
 
   using SharingHandler = platform::SafeCallback<void(SharingResult const & result)>;
-  void PrepareFileForSharing(kml::MarkGroupId categoryId, SharingHandler && handler);
+  void PrepareFileForSharing(kml::GroupIdCollection const & categoriesIds, SharingHandler && handler);
 
   bool IsCategoryEmpty(kml::MarkGroupId categoryId) const;
 

--- a/map/bookmark_manager.hpp
+++ b/map/bookmark_manager.hpp
@@ -316,21 +316,21 @@ public:
       FileError
     };
 
-    SharingResult(kml::GroupIdCollection const & categoriesIds, std::string const & sharingPath)
+    SharingResult(kml::GroupIdCollection && categoriesIds, std::string && sharingPath)
       : m_categoriesIds(categoriesIds)
       , m_code(Code::Success)
-      , m_sharingPath(sharingPath)
+      , m_sharingPath(std::move(sharingPath))
     {}
 
-    SharingResult(kml::GroupIdCollection const & categoriesIds, Code code)
-      : m_categoriesIds(categoriesIds)
+    SharingResult(kml::GroupIdCollection && categoriesIds, Code code)
+      : m_categoriesIds(std::move(categoriesIds))
       , m_code(code)
     {}
 
-    SharingResult(kml::GroupIdCollection const & categoriesIds, Code code, std::string const & errorString)
-      : m_categoriesIds(categoriesIds)
+    SharingResult(kml::GroupIdCollection && categoriesIds, Code code, std::string && errorString)
+      : m_categoriesIds(std::move(categoriesIds))
       , m_code(code)
-      , m_errorString(errorString)
+      , m_errorString(std::move(errorString))
     {}
 
     kml::MarkIdCollection m_categoriesIds;
@@ -340,7 +340,7 @@ public:
   };
 
   using SharingHandler = platform::SafeCallback<void(SharingResult const & result)>;
-  void PrepareFileForSharing(kml::GroupIdCollection const & categoriesIds, SharingHandler && handler);
+  void PrepareFileForSharing(kml::GroupIdCollection && categoriesIds, SharingHandler && handler);
 
   bool IsCategoryEmpty(kml::MarkGroupId categoryId) const;
 

--- a/qt/bookmark_dialog.cpp
+++ b/qt/bookmark_dialog.cpp
@@ -170,7 +170,7 @@ void BookmarkDialog::OnExportClick()
   if (name.isEmpty())
     return;
 
-  m_framework.GetBookmarkManager().PrepareFileForSharing(categoryIt->second,
+  m_framework.GetBookmarkManager().PrepareFileForSharing({categoryIt->second},
     [this, name](BookmarkManager::SharingResult const & result)
   {
     if (result.m_code == BookmarkManager::SharingResult::Code::Success)


### PR DESCRIPTION
Refactoring required for #995 - still only one bookmark is exported, but code from ui to c++ works with list of categories now - as suggested in https://github.com/organicmaps/organicmaps/issues/995#issuecomment-1897763732.
I fixed iOS code to make it compile, but need help with test - I don't have an opportunity to run it.