### PR TITLE
[android] Fix button to remove closed hours

### DIFF
--- a/android/app/src/main/res/layout/item_timetable_closed_hours.xml
+++ b/android/app/src/main/res/layout/item_timetable_closed_hours.xml
@@ -2,6 +2,7 @@
 <RelativeLayout
   xmlns:android="http://schemas.android.com/apk/res/android"
   xmlns:tools="http://schemas.android.com/tools"
+  xmlns:app="http://schemas.android.com/apk/res-auto"
   android:layout_width="match_parent"
   android:layout_height="@dimen/editor_height_closed"
   android:paddingTop="@dimen/margin_base">
@@ -14,7 +15,8 @@
     android:layout_centerVertical="true"
     android:background="?selectableItemBackgroundBorderless"
     android:scaleType="center"
-    android:src="@drawable/ic_close"/>
+    android:src="@drawable/ic_close"
+    app:tint="?iconTint"/>
 
   <TextView
     android:id="@+id/tv__closed_title"


### PR DESCRIPTION
On the latest version, in editor button to remove closed hours is not visible in light mode.
I have added `iconTint`property to be sure the icon has the right color in light and dark mode.

|Before|After|
|-|-|
|<img src="https://github.com/organicmaps/organicmaps/assets/87148630/68edf8f7-7aa7-49dd-a871-62c30b92be0b" height=350 />|<img src="https://github.com/organicmaps/organicmaps/assets/87148630/8de44d58-ee59-41e5-a8b6-03740d4b1441" height=350 />|
|<img src="https://github.com/organicmaps/organicmaps/assets/87148630/d8c5f98f-6a52-44d8-bd86-aed41c6f0d55" height=350 />|<img src="https://github.com/organicmaps/organicmaps/assets/87148630/d470dd09-2ec1-484f-9236-64fedef6c039" height=350 />|

Tested on Pixel 6 - Android 14