### PR TITLE
[F-Droid] Remove a referral code from “Photos, reviews, booking”

### DIFF
--- a/android/app/src/main/cpp/app/organicmaps/Framework.cpp
+++ b/android/app/src/main/cpp/app/organicmaps/Framework.cpp
@@ -1903,7 +1903,7 @@ Java_app_organicmaps_Framework_nativeMemoryWarning(JNIEnv *, jclass)
 
 JNIEXPORT jstring JNICALL
 Java_app_organicmaps_Framework_nativeGetKayakHotelLink(JNIEnv * env, jclass, jstring countryIsoCode, jstring uri,
-                                                        jobject firstDay, jobject lastDay)
+                                                        jobject firstDay, jobject lastDay, jboolean isReferral)
 {
   static jmethodID dateGetTime = jni::GetMethodID(env, firstDay, "getTime", "()J");
   jlong firstDaySec = env->CallLongMethod(firstDay, dateGetTime) / 1000L;
@@ -1912,7 +1912,8 @@ Java_app_organicmaps_Framework_nativeGetKayakHotelLink(JNIEnv * env, jclass, jst
   string const url = osm::GetKayakHotelURLFromURI(jni::ToNativeString(env, countryIsoCode),
                                                   jni::ToNativeString(env, uri),
                                                   static_cast<time_t>(firstDaySec),
-                                                  static_cast<time_t>(lastDaySec));
+                                                  static_cast<time_t>(lastDaySec),
+                                                  isReferral);
   return url.empty() ? nullptr : jni::ToJavaString(env, url);
 }
 

--- a/android/app/src/main/java/app/organicmaps/Framework.java
+++ b/android/app/src/main/java/app/organicmaps/Framework.java
@@ -445,9 +445,11 @@ public class Framework
    * @param uri `$HOTEL_NAME,-c$CITY_ID-h$HOTEL_ID` URI.
    * @param startDay the first day of planned stay.
    * @param lastDay the last day of planned stay.
+   * @param isReferral enable referral code to help the project.
    * @return a URL to Kayak's hotel page.
    */
   @Nullable
   public static native String nativeGetKayakHotelLink(@NonNull String countryIsoCode, @NonNull String uri,
-                                                      @NonNull Date firstDay, @NonNull Date lastDay);
+                                                      @NonNull Date firstDay, @NonNull Date lastDay,
+                                                      boolean isReferral);
 }

--- a/android/app/src/main/java/app/organicmaps/MwmActivity.java
+++ b/android/app/src/main/java/app/organicmaps/MwmActivity.java
@@ -1639,7 +1639,7 @@ public class MwmActivity extends BaseMwmFragmentActivity
 
   public void openKayakLink(@NonNull String url)
   {
-    if (Config.isKayakDisclaimerAccepted())
+    if (Config.isKayakDisclaimerAccepted() || !Config.isKayakReferralAllowed())
     {
       Utils.openUrl(this, url);
       return;

--- a/android/app/src/main/java/app/organicmaps/bookmarks/data/MapObject.java
+++ b/android/app/src/main/java/app/organicmaps/bookmarks/data/MapObject.java
@@ -12,6 +12,7 @@ import androidx.core.os.ParcelCompat;
 import app.organicmaps.Framework;
 import app.organicmaps.routing.RoutePointInfo;
 import app.organicmaps.search.Popularity;
+import app.organicmaps.util.Config;
 import app.organicmaps.util.Utils;
 import app.organicmaps.widget.placepage.PlacePageData;
 
@@ -288,7 +289,8 @@ public class MapObject implements PlacePageData
       return "";
     final Date firstDay = new Date();
     final Date lastDay = new Date(firstDay.getTime() + (1000 * 60 * 60 * 24));
-    final String res = Framework.nativeGetKayakHotelLink(Utils.getCountryCode(), uri, firstDay, lastDay);
+    final boolean isReferral = Config.isKayakReferralAllowed();
+    final String res = Framework.nativeGetKayakHotelLink(Utils.getCountryCode(), uri, firstDay, lastDay, isReferral);
     return res == null ? "" : res;
   }
 

--- a/android/app/src/main/java/app/organicmaps/util/Config.java
+++ b/android/app/src/main/java/app/organicmaps/util/Config.java
@@ -228,6 +228,12 @@ public final class Config
     setBool(KEY_MISC_KAYAK_ACCEPTED);
   }
 
+  @SuppressWarnings("ConstantConditions") // BuildConfig
+  public static boolean isKayakReferralAllowed()
+  {
+    return !BuildConfig.FLAVOR.equals("fdroid");
+  }
+
   public static boolean isLocationRequested()
   {
     return getBool(KEY_MISC_LOCATION_REQUESTED);
@@ -357,7 +363,6 @@ public final class Config
     return url;
   }
 
-  @NonNull
   @SuppressWarnings("ConstantConditions") // BuildConfig
   public static boolean isOsmLoginEnabled(@NonNull Context context)
   {

--- a/indexer/kayak.cpp
+++ b/indexer/kayak.cpp
@@ -88,7 +88,7 @@ const map<string, string> KAYAK_DOMAINS = {
 
 string GetKayakHotelURL(const string & countryIsoCode, uint64_t kayakHotelId,
                         const string & kayakHotelName, uint64_t kayakCityId,
-                        time_t firstDay, time_t lastDay)
+                        time_t firstDay, time_t lastDay, bool isReferral)
 {
   // https://www.kayak.com.tr/hotels/Elexus-Hotel-Resort--Spa--Casino,Kyrenia-c7163-h2651619-details/2023-10-03/2023-10-04/1adults
 
@@ -97,7 +97,8 @@ string GetKayakHotelURL(const string & countryIsoCode, uint64_t kayakHotelId,
   url << "https://";
   auto const it = KAYAK_DOMAINS.find(countryIsoCode);
   url << ((it == KAYAK_DOMAINS.end()) ? KAYAK_DOMAINS.find("US")->second : it->second);
-  url << "/in?" << "a=" << KAYAK_AFFILIATE << "&url=";
+  if (isReferral)
+    url << "/in?" << "a=" << KAYAK_AFFILIATE << "&url=";
   url << "/hotels/";
   url << url::Slug(kayakHotelName) << ",";
   url << "-c" << kayakCityId << "-h" << kayakHotelId << "-details";
@@ -114,7 +115,7 @@ string GetKayakHotelURL(const string & countryIsoCode, uint64_t kayakHotelId,
 }
 
 string GetKayakHotelURLFromURI(const string & countryIsoCode, const string & uri,
-                               time_t firstDay, time_t lastDay)
+                               time_t firstDay, time_t lastDay, bool isReferral)
 {
   // Elexus Hotel Resort & Spa & Casino,-c7163-h1696321580
 
@@ -133,7 +134,7 @@ string GetKayakHotelURLFromURI(const string & countryIsoCode, const string & uri
       !to_uint64(uri.substr(c + 3, h - c - 3).c_str(), kayakCityId))
     return {};
 
-  return GetKayakHotelURL(countryIsoCode, kayakHotelId, kayakHotelName, kayakCityId, firstDay, lastDay);
+  return GetKayakHotelURL(countryIsoCode, kayakHotelId, kayakHotelName, kayakCityId, firstDay, lastDay, isReferral);
 }
 
 }  // namespace osm

--- a/indexer/kayak.hpp
+++ b/indexer/kayak.hpp
@@ -8,8 +8,8 @@ namespace osm {
 
 std::string GetKayakHotelURL(const std::string & countryIsoCode, uint64_t kayakHotelId,
                              const std::string & kayakHotelName, uint64_t kayakCityId,
-                             time_t firstDay, time_t lastDay);
+                             time_t firstDay, time_t lastDay, bool isReferral = true);
 
 std::string GetKayakHotelURLFromURI(const std::string & countryIsoCode, const std::string & uri,
-                                    time_t firstDay, time_t lastDay);
+                                    time_t firstDay, time_t lastDay, bool isReferral = true);
 } // namespace osm


### PR DESCRIPTION
The experimental “Photos, reviews, booking” link displayed for certain hotels provides a convenient way to view information about a selected hotel and compare pricing offers using kayak.com third-party service. The referral bonus earned for every booking made through this link contributes to the development of Organic Maps, as explicitly communicated to the user on the first click. The referral bonus is mostly symbolic (it earned ~$100) and is not as important as the convenience of checking information.

F-Droid has decided to mark the entire app with discriminatory “This app contains advertising” anti-feature label just because of the presence of “Photos, reviews, booking”. This decision was motivated by a very particular (mis-)interpretation of F-Droid's ambiguous anti-feature rules that don't provide any clear details. As of now, no clarification of the rules has been provided. We don't have time and intention to deal with this legal vacuum. This patch removes the referral code from the link to dispel all doubts.