### PR TITLE
[android] Improve performance of some layouts

### DIFF
--- a/android/app/src/main/res/layout/color_row.xml
+++ b/android/app/src/main/res/layout/color_row.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<RelativeLayout xmlns:android="http://schemas.android.com/apk/res/android"
+<LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
                 android:layout_width="wrap_content"
                 android:layout_height="wrap_content"
                 android:background="?clickableBackground">
@@ -9,9 +9,9 @@
       android:layout_width="@dimen/track_circle_size"
       android:layout_height="@dimen/track_circle_size"
       android:layout_margin="@dimen/margin_half"
-      android:layout_centerInParent="true"
+      android:layout_gravity="center"
       android:background="@null"
       android:contentDescription="@null"
       android:scaleType="center"/>
 
-</RelativeLayout>
+</LinearLayout>

--- a/android/app/src/main/res/layout/fragment_edit_bookmark.xml
+++ b/android/app/src/main/res/layout/fragment_edit_bookmark.xml
@@ -11,9 +11,6 @@
     android:layout_width="match_parent"
     android:layout_height="wrap_content"
     android:theme="@style/MwmWidget.ToolbarTheme">
-    <RelativeLayout
-      android:layout_width="match_parent"
-      android:layout_height="?attr/actionBarSize">
       <ImageView
         app:tint="@color/image_view"
         android:id="@+id/save"
@@ -22,10 +19,9 @@
         android:layout_height="?actionBarSize"
         android:layout_alignParentEnd="true"
         android:background="?attr/selectableItemBackgroundBorderless"
-        android:layout_gravity="center_vertical"
+        android:layout_gravity="end|center_vertical"
         android:scaleType="centerInside"
         android:contentDescription="@string/save" />
-    </RelativeLayout>
   </androidx.appcompat.widget.Toolbar>
   <FrameLayout
     style="@style/MwmWidget.FrameLayout.Elevation"

--- a/android/app/src/main/res/layout/fragment_editor_host.xml
+++ b/android/app/src/main/res/layout/fragment_editor_host.xml
@@ -14,7 +14,7 @@
     android:layout_height="?attr/actionBarSize"
     android:theme="@style/MwmWidget.ToolbarTheme">
 
-    <RelativeLayout
+    <androidx.constraintlayout.widget.ConstraintLayout
       android:id="@+id/toolbar_inner_layout"
       android:layout_gravity="end|center_vertical"
       android:layout_width="match_parent"
@@ -33,12 +33,13 @@
         android:layout_width="?actionBarSize"
         android:layout_height="?actionBarSize"
         android:layout_alignParentEnd="true"
-        android:layout_gravity="end|center_vertical"
         android:background="?selectableItemBackgroundBorderless"
         android:scaleType="centerInside"
-        app:srcCompat="@drawable/ic_done"/>
+        app:srcCompat="@drawable/ic_done"
+        app:layout_constraintEnd_toEndOf="parent"
+        app:layout_constraintTop_toTopOf="parent"/>
 
-    </RelativeLayout>
+    </androidx.constraintlayout.widget.ConstraintLayout>
 
   </androidx.appcompat.widget.Toolbar>
 

--- a/android/app/src/main/res/layout/fragment_osm_profile.xml
+++ b/android/app/src/main/res/layout/fragment_osm_profile.xml
@@ -1,10 +1,10 @@
 <?xml version="1.0" encoding="utf-8"?>
 <LinearLayout
   xmlns:android="http://schemas.android.com/apk/res/android"
+  xmlns:app="http://schemas.android.com/apk/res-auto"
   xmlns:tools="http://schemas.android.com/tools"
   android:layout_width="match_parent"
   android:layout_height="match_parent"
-  xmlns:app="http://schemas.android.com/apk/res-auto"
   android:orientation="vertical">
   <androidx.appcompat.widget.Toolbar
     android:id="@+id/toolbar"
@@ -85,7 +85,7 @@
 
         </LinearLayout>
       </LinearLayout>
-      <RelativeLayout
+      <androidx.constraintlayout.widget.ConstraintLayout
         android:layout_width="match_parent"
         android:layout_height="0dp"
         android:layout_weight="1"
@@ -102,7 +102,8 @@
           android:text="@string/history"
           android:textAppearance="@style/MwmTextAppearance.Body4"
           android:textColor="?colorAccent"
-          android:textSize="@dimen/text_size_body_1" />
+          android:textSize="@dimen/text_size_body_1"
+          app:layout_constraintTop_toTopOf="parent"/>
         <TextView
           android:id="@+id/about_osm"
           android:layout_width="match_parent"
@@ -115,8 +116,11 @@
           android:text="@string/editor_more_about_osm"
           android:textAppearance="@style/MwmTextAppearance.Body4"
           android:textColor="?colorAccent"
-          android:textSize="@dimen/text_size_body_4" />
-      </RelativeLayout>
+          android:textSize="@dimen/text_size_body_4"
+          app:layout_constraintBottom_toBottomOf="parent"
+          app:layout_constraintTop_toBottomOf="@+id/osm_history"
+          app:layout_constraintVertical_bias="1" />
+      </androidx.constraintlayout.widget.ConstraintLayout>
     </LinearLayout>
   </ScrollView>
 </LinearLayout>

--- a/android/app/src/main/res/layout/item_bookmark_group_list_header.xml
+++ b/android/app/src/main/res/layout/item_bookmark_group_list_header.xml
@@ -1,6 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
-<RelativeLayout
+<androidx.constraintlayout.widget.ConstraintLayout
   xmlns:android="http://schemas.android.com/apk/res/android"
+  xmlns:app="http://schemas.android.com/apk/res-auto"
   xmlns:tools="http://schemas.android.com/tools"
   android:layout_width="match_parent"
   android:layout_height="wrap_content"
@@ -17,6 +18,8 @@
     android:layout_height="wrap_content"
     android:layout_alignParentStart="true"
     android:paddingTop="@dimen/margin_half_plus"
+    app:layout_constraintStart_toStartOf="parent"
+    app:layout_constraintTop_toTopOf="parent"
     tools:text="@string/categories" />
   <TextView
     android:id="@+id/button"
@@ -29,5 +32,8 @@
     android:paddingTop="@dimen/margin_half_plus"
     android:text="@string/bookmark_lists_hide_all"
     android:textAllCaps="true"
-    android:textColor="?colorAccent" />
-</RelativeLayout>
+    android:textColor="?colorAccent"
+    app:layout_constraintBottom_toBottomOf="parent"
+    app:layout_constraintEnd_toEndOf="parent"
+    app:layout_constraintTop_toTopOf="parent" />
+</androidx.constraintlayout.widget.ConstraintLayout>

--- a/android/app/src/main/res/layout/item_editor_input.xml
+++ b/android/app/src/main/res/layout/item_editor_input.xml
@@ -1,19 +1,29 @@
 <?xml version="1.0" encoding="utf-8"?>
-<RelativeLayout
+<androidx.constraintlayout.widget.ConstraintLayout
   xmlns:android="http://schemas.android.com/apk/res/android"
+  xmlns:app="http://schemas.android.com/apk/res-auto"
   xmlns:tools="http://schemas.android.com/tools"
   style="@style/MwmWidget.Editor.MetadataBlock">
   <ImageView
     android:id="@+id/icon"
     style="@style/MwmWidget.Editor.MetadataIcon"
+    app:layout_constraintBottom_toBottomOf="parent"
+    app:layout_constraintEnd_toStartOf="@+id/custom_input"
+    app:layout_constraintStart_toStartOf="parent"
+    app:layout_constraintTop_toTopOf="parent"
     tools:ignore="ContentDescription"
     tools:src="@drawable/ic_phone" />
   <com.google.android.material.textfield.TextInputLayout
     android:id="@+id/custom_input"
     style="@style/MwmWidget.Editor.CustomTextInput"
+    android:layout_width="0dp"
     android:layout_centerVertical="true"
-    android:layout_marginStart="54dp"
-    android:textColorHint="?android:textColorSecondary">
+    android:layout_marginStart="14dp"
+    android:textColorHint="?android:textColorSecondary"
+    app:layout_constraintBottom_toBottomOf="parent"
+    app:layout_constraintEnd_toEndOf="parent"
+    app:layout_constraintStart_toEndOf="@+id/icon"
+    app:layout_constraintTop_toTopOf="parent">
     <com.google.android.material.textfield.TextInputEditText
       android:id="@+id/input"
       style="@style/MwmWidget.Editor.FieldLayout.EditText"
@@ -21,4 +31,4 @@
       android:padding="@dimen/margin_half_double_plus"
       tools:text="Input" />
   </com.google.android.material.textfield.TextInputLayout>
-</RelativeLayout>
+</androidx.constraintlayout.widget.ConstraintLayout>

--- a/android/app/src/main/res/layout/item_phone.xml
+++ b/android/app/src/main/res/layout/item_phone.xml
@@ -1,30 +1,34 @@
-<RelativeLayout
+<androidx.constraintlayout.widget.ConstraintLayout
     xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
     xmlns:tools="http://schemas.android.com/tools"
     android:layout_width="match_parent"
     android:layout_height="@dimen/height_item_oneline"
     android:background="?clickableBackground"
-    android:gravity="center_vertical"
-    android:orientation="horizontal"
     android:paddingStart="@dimen/margin_half_plus"
     android:paddingEnd="@dimen/margin_half">
 
     <ImageView
         android:id="@+id/phone_icon"
         style="@style/MwmWidget.Editor.MetadataIcon"
+        app:layout_constraintBottom_toBottomOf="parent"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintTop_toTopOf="parent"
+        app:layout_constraintEnd_toStartOf="@+id/phone_input"
         tools:ignore="ContentDescription"
-        tools:src="@drawable/ic_phone"
-        android:layout_alignParentStart="true"/>
+        tools:src="@drawable/ic_phone"/>
 
     <com.google.android.material.textfield.TextInputLayout
         android:id="@+id/phone_input"
-        android:layout_width="match_parent"
+        android:layout_width="0dp"
         android:layout_height="wrap_content"
-        android:layout_centerVertical="true"
         android:layout_marginStart="@dimen/margin_half"
-        android:layout_toEndOf="@id/phone_icon"
         android:layout_toStartOf="@id/delete_icon"
-        android:textColorHint="?android:textColorSecondary">
+        android:textColorHint="?android:textColorSecondary"
+        app:layout_constraintBottom_toBottomOf="parent"
+        app:layout_constraintEnd_toStartOf="@+id/delete_icon"
+        app:layout_constraintStart_toEndOf="@+id/phone_icon"
+        app:layout_constraintTop_toTopOf="parent">
         <com.google.android.material.textfield.TextInputEditText
             android:id="@+id/input"
             style="@style/MwmWidget.Editor.FieldLayout.EditText"
@@ -34,11 +38,16 @@
     </com.google.android.material.textfield.TextInputLayout>
 
     <ImageView
-        android:id="@+id/delete_icon"
-        style="@style/MwmWidget.Editor.MetadataIcon"
-        tools:ignore="ContentDescription"
-        tools:src="@drawable/ic_delete"
-        android:layout_centerVertical="true"
-        android:layout_alignParentEnd="true"/>
+      android:id="@+id/delete_icon"
+      style="@style/MwmWidget.Editor.MetadataIcon"
+      android:layout_marginStart="@dimen/margin_half"
+      android:layout_marginTop="@dimen/margin_half"
+      android:layout_marginEnd="@dimen/margin_half"
+      android:layout_marginBottom="@dimen/margin_half"
+      app:layout_constraintBottom_toBottomOf="parent"
+      app:layout_constraintEnd_toEndOf="parent"
+      app:layout_constraintTop_toTopOf="parent"
+      tools:ignore="ContentDescription"
+      tools:src="@drawable/ic_delete" />
 
-</RelativeLayout>
+</androidx.constraintlayout.widget.ConstraintLayout>

--- a/android/app/src/main/res/layout/item_street.xml
+++ b/android/app/src/main/res/layout/item_street.xml
@@ -1,6 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
-<RelativeLayout
+<androidx.constraintlayout.widget.ConstraintLayout
   xmlns:android="http://schemas.android.com/apk/res/android"
+  xmlns:app="http://schemas.android.com/apk/res-auto"
   xmlns:tools="http://schemas.android.com/tools"
   android:layout_width="match_parent"
   android:layout_height="@dimen/height_item_oneline"
@@ -14,15 +15,21 @@
     android:id="@+id/selected"
     android:layout_width="48dp"
     android:layout_height="48dp"
-    android:layout_centerVertical="true"
-    android:layout_marginEnd="@dimen/margin_base"/>
+    android:gravity="center_vertical"
+    android:layout_marginEnd="@dimen/margin_base"
+    app:layout_constraintBottom_toBottomOf="parent"
+    app:layout_constraintStart_toStartOf="parent"
+    app:layout_constraintTop_toTopOf="parent"/>
 
   <LinearLayout
     android:layout_width="match_parent"
     android:layout_height="wrap_content"
     android:layout_centerVertical="true"
     android:layout_marginStart="60dp"
-    android:orientation="vertical">
+    android:orientation="vertical"
+    app:layout_constraintBottom_toBottomOf="parent"
+    app:layout_constraintStart_toEndOf="@+id/selected"
+    app:layout_constraintTop_toTopOf="parent">
 
     <TextView
       android:id="@+id/street_default"
@@ -42,4 +49,4 @@
 
   </LinearLayout>
 
-</RelativeLayout>
+</androidx.constraintlayout.widget.ConstraintLayout>


### PR DESCRIPTION
Google recommends using ConstraintLayout instead RelativeLayout and LinearLayout.
More information [here](https://developer.android.com/topic/performance/rendering/optimizing-view-hierarchies?hl=en#managing) And ConstraintLayout needs less calculation to generate a view

I have tested on Pixel 6 - Android 14 with max size police and max size UI in portrait and landscape mode.
I don't add screenshots because there are no UI differences.