### PR TITLE
[ios][placepage] Allow multiline attributes in Place Page

### DIFF
--- a/iphone/Maps/UI/PlacePage/PlacePage.storyboard
+++ b/iphone/Maps/UI/PlacePage/PlacePage.storyboard
@@ -629,8 +629,8 @@
                                     <userDefinedRuntimeAttribute type="string" keyPath="coloring" value="MWMBlack"/>
                                 </userDefinedRuntimeAttributes>
                             </imageView>
-                            <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" horizontalCompressionResistancePriority="250" text="Label" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="8eU-Fj-XRv" customClass="CopyLabel" customModule="Organic_Maps" customModuleProvider="target">
-                                <rect key="frame" x="56" y="0.0" width="287" height="44"/>
+                            <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" horizontalCompressionResistancePriority="250" text="Label" textAlignment="natural" lineBreakMode="tailTruncation" numberOfLines="0" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="8eU-Fj-XRv" customClass="CopyLabel" customModule="Organic_Maps" customModuleProvider="target">
+                                <rect key="frame" x="56" y="10" width="287" height="24"/>
                                 <color key="backgroundColor" white="0.0" alpha="0.0" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
                                 <fontDescription key="fontDescription" type="system" pointSize="17"/>
                                 <nil key="textColor"/>
@@ -655,15 +655,16 @@
                         <color key="backgroundColor" systemColor="systemBackgroundColor"/>
                         <gestureRecognizers/>
                         <constraints>
-                            <constraint firstAttribute="bottom" secondItem="l7d-ck-nSv" secondAttribute="bottom" id="AV5-Tu-LK4"/>
-                            <constraint firstAttribute="bottom" secondItem="8eU-Fj-XRv" secondAttribute="bottom" id="Cu6-uK-4Ox"/>
+                            <constraint firstItem="l7d-ck-nSv" firstAttribute="centerY" secondItem="oz0-2o-icQ" secondAttribute="centerY" id="6b5-ly-VY4"/>
+                            <constraint firstAttribute="bottom" relation="greaterThanOrEqual" secondItem="l7d-ck-nSv" secondAttribute="bottom" id="AV5-Tu-LK4"/>
+                            <constraint firstAttribute="bottom" secondItem="8eU-Fj-XRv" secondAttribute="bottom" constant="10" id="Cu6-uK-4Ox"/>
                             <constraint firstItem="onF-JL-5dZ" firstAttribute="leading" secondItem="8eU-Fj-XRv" secondAttribute="trailing" id="Y7d-Lw-sIv"/>
                             <constraint firstItem="l7d-ck-nSv" firstAttribute="leading" secondItem="oz0-2o-icQ" secondAttribute="leading" id="ZKa-Nx-mMv"/>
                             <constraint firstItem="8eU-Fj-XRv" firstAttribute="leading" secondItem="l7d-ck-nSv" secondAttribute="trailing" id="fPc-6Q-inb"/>
-                            <constraint firstItem="l7d-ck-nSv" firstAttribute="top" secondItem="oz0-2o-icQ" secondAttribute="top" id="mvH-dY-Evu"/>
+                            <constraint firstItem="l7d-ck-nSv" firstAttribute="top" relation="greaterThanOrEqual" secondItem="oz0-2o-icQ" secondAttribute="top" id="mvH-dY-Evu"/>
                             <constraint firstItem="xdh-hy-Bxo" firstAttribute="trailing" secondItem="onF-JL-5dZ" secondAttribute="trailing" constant="8" id="oIb-Tv-InY"/>
                             <constraint firstItem="onF-JL-5dZ" firstAttribute="centerY" secondItem="oz0-2o-icQ" secondAttribute="centerY" id="sxb-OB-j2b"/>
-                            <constraint firstItem="8eU-Fj-XRv" firstAttribute="top" secondItem="oz0-2o-icQ" secondAttribute="top" id="wix-sM-o7T"/>
+                            <constraint firstItem="8eU-Fj-XRv" firstAttribute="top" secondItem="oz0-2o-icQ" secondAttribute="top" constant="10" id="wix-sM-o7T"/>
                         </constraints>
                         <userDefinedRuntimeAttributes>
                             <userDefinedRuntimeAttribute type="string" keyPath="styleName" value="Background"/>

--- a/iphone/Maps/UI/PlacePage/PlacePage.storyboard
+++ b/iphone/Maps/UI/PlacePage/PlacePage.storyboard
@@ -618,53 +618,56 @@
                         <rect key="frame" x="0.0" y="0.0" width="375" height="44"/>
                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                         <subviews>
-                            <imageView clipsSubviews="YES" userInteractionEnabled="NO" contentMode="center" horizontalHuggingPriority="251" verticalHuggingPriority="251" image="ic_operator" translatesAutoresizingMaskIntoConstraints="NO" id="l7d-ck-nSv">
-                                <rect key="frame" x="0.0" y="0.0" width="56" height="44"/>
-                                <color key="backgroundColor" white="0.0" alpha="0.0" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
+                            <stackView opaque="NO" contentMode="scaleToFill" alignment="center" translatesAutoresizingMaskIntoConstraints="NO" id="LQd-fA-r9c">
+                                <rect key="frame" x="0.0" y="0.0" width="367" height="44"/>
+                                <subviews>
+                                    <imageView clipsSubviews="YES" userInteractionEnabled="NO" contentMode="center" horizontalHuggingPriority="251" verticalHuggingPriority="251" image="ic_operator" translatesAutoresizingMaskIntoConstraints="NO" id="l7d-ck-nSv">
+                                        <rect key="frame" x="0.0" y="0.0" width="56" height="44"/>
+                                        <color key="backgroundColor" white="0.0" alpha="0.0" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
+                                        <constraints>
+                                            <constraint firstAttribute="height" constant="44" id="dbx-It-HsN"/>
+                                            <constraint firstAttribute="width" constant="56" id="uhV-yT-jBd"/>
+                                        </constraints>
+                                        <userDefinedRuntimeAttributes>
+                                            <userDefinedRuntimeAttribute type="string" keyPath="coloring" value="MWMBlack"/>
+                                        </userDefinedRuntimeAttributes>
+                                    </imageView>
+                                    <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" horizontalCompressionResistancePriority="250" text="Label" textAlignment="natural" lineBreakMode="tailTruncation" numberOfLines="0" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="8eU-Fj-XRv" customClass="CopyLabel" customModule="Organic_Maps" customModuleProvider="target">
+                                        <rect key="frame" x="56" y="10" width="311" height="24"/>
+                                        <color key="backgroundColor" white="0.0" alpha="0.0" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
+                                        <fontDescription key="fontDescription" type="system" pointSize="17"/>
+                                        <nil key="textColor"/>
+                                        <nil key="highlightedColor"/>
+                                        <userDefinedRuntimeAttributes>
+                                            <userDefinedRuntimeAttribute type="string" keyPath="styleName" value="regular16:blackPrimaryText"/>
+                                        </userDefinedRuntimeAttributes>
+                                    </label>
+                                    <imageView hidden="YES" userInteractionEnabled="NO" contentMode="center" horizontalHuggingPriority="251" verticalHuggingPriority="251" image="ic_placepage_change" translatesAutoresizingMaskIntoConstraints="NO" id="onF-JL-5dZ">
+                                        <rect key="frame" x="367" y="10" width="24" height="24"/>
+                                        <color key="backgroundColor" white="0.0" alpha="0.0" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
+                                        <constraints>
+                                            <constraint firstAttribute="width" constant="24" id="4f7-wJ-RNQ"/>
+                                            <constraint firstAttribute="height" constant="24" id="JCX-T3-d68"/>
+                                        </constraints>
+                                        <userDefinedRuntimeAttributes>
+                                            <userDefinedRuntimeAttribute type="string" keyPath="coloring" value="MWMBlack"/>
+                                        </userDefinedRuntimeAttributes>
+                                    </imageView>
+                                </subviews>
                                 <constraints>
-                                    <constraint firstAttribute="height" constant="44" id="dbx-It-HsN"/>
-                                    <constraint firstAttribute="width" constant="56" id="uhV-yT-jBd"/>
+                                    <constraint firstAttribute="bottom" secondItem="8eU-Fj-XRv" secondAttribute="bottom" constant="10" id="Oju-fx-VZb"/>
+                                    <constraint firstItem="8eU-Fj-XRv" firstAttribute="top" secondItem="LQd-fA-r9c" secondAttribute="top" constant="10" id="iCj-QI-o3i"/>
                                 </constraints>
-                                <userDefinedRuntimeAttributes>
-                                    <userDefinedRuntimeAttribute type="string" keyPath="coloring" value="MWMBlack"/>
-                                </userDefinedRuntimeAttributes>
-                            </imageView>
-                            <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" horizontalCompressionResistancePriority="250" text="Label" textAlignment="natural" lineBreakMode="tailTruncation" numberOfLines="0" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="8eU-Fj-XRv" customClass="CopyLabel" customModule="Organic_Maps" customModuleProvider="target">
-                                <rect key="frame" x="56" y="10" width="287" height="24"/>
-                                <color key="backgroundColor" white="0.0" alpha="0.0" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
-                                <fontDescription key="fontDescription" type="system" pointSize="17"/>
-                                <nil key="textColor"/>
-                                <nil key="highlightedColor"/>
-                                <userDefinedRuntimeAttributes>
-                                    <userDefinedRuntimeAttribute type="string" keyPath="styleName" value="regular16:blackPrimaryText"/>
-                                </userDefinedRuntimeAttributes>
-                            </label>
-                            <imageView hidden="YES" userInteractionEnabled="NO" contentMode="center" horizontalHuggingPriority="251" verticalHuggingPriority="251" image="ic_placepage_change" translatesAutoresizingMaskIntoConstraints="NO" id="onF-JL-5dZ">
-                                <rect key="frame" x="343" y="10" width="24" height="24"/>
-                                <color key="backgroundColor" white="0.0" alpha="0.0" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
-                                <constraints>
-                                    <constraint firstAttribute="width" constant="24" id="4f7-wJ-RNQ"/>
-                                    <constraint firstAttribute="height" constant="24" id="JCX-T3-d68"/>
-                                </constraints>
-                                <userDefinedRuntimeAttributes>
-                                    <userDefinedRuntimeAttribute type="string" keyPath="coloring" value="MWMBlack"/>
-                                </userDefinedRuntimeAttributes>
-                            </imageView>
+                            </stackView>
                         </subviews>
                         <viewLayoutGuide key="safeArea" id="xdh-hy-Bxo"/>
                         <color key="backgroundColor" systemColor="systemBackgroundColor"/>
                         <gestureRecognizers/>
                         <constraints>
-                            <constraint firstItem="l7d-ck-nSv" firstAttribute="centerY" secondItem="oz0-2o-icQ" secondAttribute="centerY" id="6b5-ly-VY4"/>
-                            <constraint firstAttribute="bottom" relation="greaterThanOrEqual" secondItem="l7d-ck-nSv" secondAttribute="bottom" id="AV5-Tu-LK4"/>
-                            <constraint firstAttribute="bottom" secondItem="8eU-Fj-XRv" secondAttribute="bottom" constant="10" id="Cu6-uK-4Ox"/>
-                            <constraint firstItem="onF-JL-5dZ" firstAttribute="leading" secondItem="8eU-Fj-XRv" secondAttribute="trailing" id="Y7d-Lw-sIv"/>
-                            <constraint firstItem="l7d-ck-nSv" firstAttribute="leading" secondItem="oz0-2o-icQ" secondAttribute="leading" id="ZKa-Nx-mMv"/>
-                            <constraint firstItem="8eU-Fj-XRv" firstAttribute="leading" secondItem="l7d-ck-nSv" secondAttribute="trailing" id="fPc-6Q-inb"/>
-                            <constraint firstItem="l7d-ck-nSv" firstAttribute="top" relation="greaterThanOrEqual" secondItem="oz0-2o-icQ" secondAttribute="top" id="mvH-dY-Evu"/>
-                            <constraint firstItem="xdh-hy-Bxo" firstAttribute="trailing" secondItem="onF-JL-5dZ" secondAttribute="trailing" constant="8" id="oIb-Tv-InY"/>
-                            <constraint firstItem="onF-JL-5dZ" firstAttribute="centerY" secondItem="oz0-2o-icQ" secondAttribute="centerY" id="sxb-OB-j2b"/>
-                            <constraint firstItem="8eU-Fj-XRv" firstAttribute="top" secondItem="oz0-2o-icQ" secondAttribute="top" constant="10" id="wix-sM-o7T"/>
+                            <constraint firstAttribute="trailing" secondItem="LQd-fA-r9c" secondAttribute="trailing" constant="8" id="Foi-HR-gnE"/>
+                            <constraint firstItem="LQd-fA-r9c" firstAttribute="top" secondItem="oz0-2o-icQ" secondAttribute="top" id="K4k-Mo-mLZ"/>
+                            <constraint firstAttribute="bottom" secondItem="LQd-fA-r9c" secondAttribute="bottom" id="dC0-Xu-45b"/>
+                            <constraint firstItem="LQd-fA-r9c" firstAttribute="leading" secondItem="oz0-2o-icQ" secondAttribute="leading" id="ggJ-Q6-6Ir"/>
                         </constraints>
                         <userDefinedRuntimeAttributes>
                             <userDefinedRuntimeAttribute type="string" keyPath="styleName" value="Background"/>


### PR DESCRIPTION
Currently, in iOS long attributes in the Place Page get cropped to a single line. In Android they span multiple lines if needed. This PR allows multiline attributes in the Place Page in iOS. This can be specially useful for languages other than English that have longer texts.

Before/After:

<img src="https://github.com/organicmaps/organicmaps/assets/47610359/424e141d-211a-43c0-b556-3b6f72cf87c3" width="320"/> <img src="https://github.com/organicmaps/organicmaps/assets/47610359/9e231f9c-f67b-4a9f-8778-f52747c5e642" width="320"/>

--

How it currently looks in Android:

<img src="https://github.com/organicmaps/organicmaps/assets/47610359/b016dc11-c9f8-4a34-a709-2bb7d2c9a2ab" width="320"/>
