### PR TITLE
[gpx] Add application/vnd.google-earth.kmz+xml mime type

### DIFF
--- a/android/app/src/main/AndroidManifest.xml
+++ b/android/app/src/main/AndroidManifest.xml
@@ -150,6 +150,7 @@
         <data android:mimeType="application/vnd.google-earth.kmz"/>
         <data android:mimeType="application/gpx"/>
         <data android:mimeType="application/gpx+xml"/>
+        <data android:mimeType="application/vnd.google-earth.kmz+xml"/>
       </intent-filter>
 
       <intent-filter>
@@ -159,6 +160,7 @@
         <data android:mimeType="application/vnd.google-earth.kmz"/>
         <data android:mimeType="application/gpx"/>
         <data android:mimeType="application/gpx+xml"/>
+        <data android:mimeType="application/vnd.google-earth.kmz+xml"/>
       </intent-filter>
 
       <intent-filter>


### PR DESCRIPTION
Trying to fix #7277 
@rtsisyk could you please test a build from my branch using setup that you have for #7277 
We don't have this mime type now, but I was not able to reproduce an issue - sample kmz is loaded fine from WA with OM release build.