### PR TITLE
[ios] Synchronize the app light/dark appearance with the device

### DIFF
--- a/iphone/Maps/Classes/Components/MWMNavigationController.m
+++ b/iphone/Maps/Classes/Components/MWMNavigationController.m
@@ -22,9 +22,7 @@
   self.navigationItem.leftBarButtonItem.tintColor = [UIColor whitePrimaryText];
   self.navigationItem.rightBarButtonItem.tintColor = [UIColor whitePrimaryText];
 
-  if (@available(iOS 13.0, *)) {
-    [MWMThemeManager setDarkModeEnabled: self.traitCollection.userInterfaceStyle == UIUserInterfaceStyleDark];
-  }
+  [MWMThemeManager invalidate];
 }
 
 - (void)navigationController:(UINavigationController *)navigationController
@@ -68,11 +66,8 @@
 - (void)traitCollectionDidChange:(UITraitCollection *)previousTraitCollection
 {
   [super traitCollectionDidChange: previousTraitCollection];
-  if (@available(iOS 13.0, *)) {
-    if (self.traitCollection.userInterfaceStyle != previousTraitCollection.userInterfaceStyle) {
-      [MWMThemeManager setDarkModeEnabled: self.traitCollection.userInterfaceStyle == UIUserInterfaceStyleDark];
-    }
-  }
+  // Update the app theme when the device appearance is changing.
+  [MWMThemeManager invalidate];
 }
 
 - (BOOL)shouldAutorotate

--- a/iphone/Maps/Classes/CustomAlert/BaseAlert/MWMAlert.mm
+++ b/iphone/Maps/Classes/CustomAlert/BaseAlert/MWMAlert.mm
@@ -266,4 +266,19 @@
   [super layoutSubviews];
 }
 
+- (void)traitCollectionDidChange:(UITraitCollection *)previousTraitCollection {
+  [super traitCollectionDidChange:previousTraitCollection];
+  if (self.traitCollection.userInterfaceStyle != previousTraitCollection.userInterfaceStyle) {
+    [self updateViewStyle:self];
+  }
+}
+
+- (void)updateViewStyle:(UIView *)view {
+  if (!view)
+    return;
+  for (UIView *subview in view.subviews)
+    [self updateViewStyle:subview];
+  [view applyTheme];
+}
+
 @end

--- a/iphone/Maps/Classes/MapsAppDelegate.mm
+++ b/iphone/Maps/Classes/MapsAppDelegate.mm
@@ -410,9 +410,6 @@ using namespace osm_auth_ios;
 - (void)application:(UIApplication *)application
   didConnectCarInterfaceController:(CPInterfaceController *)interfaceController
            toWindow:(CPWindow *)window API_AVAILABLE(ios(12.0)) {
-  if (@available(iOS 13.0, *)) {
-    window.overrideUserInterfaceStyle = UIUserInterfaceStyleUnspecified;
-  }
   [self.carplayService setupWithWindow:window interfaceController:interfaceController];
   [self updateAppearanceFromWindow:self.window toWindow:window isCarplayActivated:YES];
 }

--- a/iphone/Maps/Core/Settings/MWMSettings.mm
+++ b/iphone/Maps/Core/Settings/MWMSettings.mm
@@ -92,6 +92,23 @@ NSString * const kUDTrackWarningAlertWasShown = @"TrackWarningAlertWasShown";
 {
   if ([self theme] == theme)
     return;
+  if (@available(iOS 13.0, *)) {
+    UIUserInterfaceStyle style;
+    switch (theme) {
+      case MWMThemeDay:
+      case MWMThemeVehicleDay:
+        style = UIUserInterfaceStyleLight;
+        break;
+      case MWMThemeNight:
+      case MWMThemeVehicleNight:
+        style = UIUserInterfaceStyleDark;
+        break;
+      case MWMThemeAuto:
+        style = UIUserInterfaceStyleUnspecified;
+        break;
+    }
+    UIApplication.sharedApplication.delegate.window.overrideUserInterfaceStyle = style;
+  }
   auto ud = NSUserDefaults.standardUserDefaults;
   [ud setInteger:theme forKey:kThemeMode];
   BOOL const autoOff = theme != MWMThemeAuto;

--- a/iphone/Maps/Core/Theme/Core/ThemeManager.swift
+++ b/iphone/Maps/Core/Theme/Core/ThemeManager.swift
@@ -4,19 +4,9 @@ final class ThemeManager: NSObject {
 
   private static let instance = ThemeManager()
   private weak var timer: Timer?
-  private var isDarkModeEnabled: Bool = false
-  private static let enableDarkModeBySystem = false
 
   private override init() {
     super.init()
-    if #available(iOS 13.0, *) {
-      MapsAppDelegate.theApp().window.overrideUserInterfaceStyle = .light
-    }
-  }
-
-  @objc static func setDarkModeEnabled(_ val: Bool) {
-    instance.isDarkModeEnabled = val
-    instance.update(theme: Settings.theme())
   }
 
   private func update(theme: MWMTheme) {
@@ -28,7 +18,8 @@ final class ThemeManager: NSObject {
       case .night: fallthrough
       case .vehicleNight: return isVehicleRouting ? .vehicleNight : .night
       case .auto:
-        if #available(iOS 13.0, *), ThemeManager.enableDarkModeBySystem {
+        if #available(iOS 13.0, *) {
+          let isDarkModeEnabled = UIScreen.main.traitCollection.userInterfaceStyle == .dark
           guard isVehicleRouting else { return isDarkModeEnabled ? .night : .day }
           return isDarkModeEnabled ? .vehicleNight : .vehicleDay
         } else {

--- a/iphone/Maps/Core/Theme/Renderers/UITextFieldRenderer.swift
+++ b/iphone/Maps/Core/Theme/Renderers/UITextFieldRenderer.swift
@@ -26,6 +26,7 @@ class UITextFieldRenderer {
         control.layer.cornerCurve = .continuous
       }
     }
+    control.borderStyle = .none
     var placeholderAttributes = [NSAttributedString.Key : Any]()
     if let backgroundColor = style.backgroundColor {
       control.backgroundColor = backgroundColor

--- a/iphone/Maps/UI/CarPlay/CarPlayMapViewController.swift
+++ b/iphone/Maps/UI/CarPlay/CarPlayMapViewController.swift
@@ -201,6 +201,7 @@ final class CarPlayMapViewController: MWMViewController {
 
   override func traitCollectionDidChange(_ previousTraitCollection: UITraitCollection?) {
     super.traitCollectionDidChange(previousTraitCollection)
+    // Triggers the map style updating when CarPlay's 'Appearance' setting is changed.
     ThemeManager.invalidate()
   }
 

--- a/iphone/Maps/UI/PlacePage/Components/PlacePageHeader/PlacePageHeaderViewController.swift
+++ b/iphone/Maps/UI/PlacePage/Components/PlacePageHeader/PlacePageHeaderViewController.swift
@@ -14,8 +14,11 @@ class PlacePageHeaderViewController: UIViewController {
   @IBOutlet private var expandView: UIView!
   @IBOutlet private var shadowView: UIView!
   @IBOutlet private var grabberView: UIView!
-    
-    override func viewDidLoad() {
+
+  private var titleText: String?
+  private var secondaryText: String?
+
+  override func viewDidLoad() {
     super.viewDidLoad()
     presenter?.configure()
     let tap = UITapGestureRecognizer(target: self, action: #selector(onExpandPressed(sender:)))
@@ -32,6 +35,12 @@ class PlacePageHeaderViewController: UIViewController {
 
   @IBAction private func onCloseButtonPressed(_ sender: Any) {
     presenter?.onClosePress()
+  }
+
+  override func traitCollectionDidChange(_ previousTraitCollection: UITraitCollection?) {
+    super.traitCollectionDidChange(previousTraitCollection)
+    guard traitCollection.userInterfaceStyle != previousTraitCollection?.userInterfaceStyle else { return }
+    setTitle(titleText, secondaryTitle: secondaryText)
   }
 }
 
@@ -55,6 +64,8 @@ extension PlacePageHeaderViewController: PlacePageHeaderViewProtocol {
   }
 
   func setTitle(_ title: String?, secondaryTitle: String?) {
+    titleText = title
+    secondaryText = secondaryTitle
     // XCode 13 is not smart enough to detect that title is used below, and requires explicit unwrapped variable.
     guard let unwrappedTitle = title else {
       titleLabel?.attributedText = nil

--- a/iphone/Maps/UI/PlacePage/Components/PlacePageInfoViewController.swift
+++ b/iphone/Maps/UI/PlacePage/Components/PlacePageInfoViewController.swift
@@ -24,6 +24,7 @@ class InfoItemViewController: UIViewController {
         imageView?.styleName = "MWMBlue"
         infoLabel?.styleName = "linkBlueText"
       }
+      accessoryImage.styleName = "MWMBlack"
     }
   }
 
@@ -361,6 +362,7 @@ private extension UIView {
                     color: UIColor?,
                     insets: UIEdgeInsets) {
     let lineView = UIView()
+    lineView.styleName = "Divider"
     lineView.backgroundColor = color ?? .black
     lineView.isUserInteractionEnabled = false
     lineView.translatesAutoresizingMaskIntoConstraints = false

--- a/iphone/Maps/UI/PlacePage/Components/PlacePagePreviewViewController.swift
+++ b/iphone/Maps/UI/PlacePage/Components/PlacePagePreviewViewController.swift
@@ -61,6 +61,12 @@ final class PlacePagePreviewViewController: UIViewController {
     }
   }
 
+  override func traitCollectionDidChange(_ previousTraitCollection: UITraitCollection?) {
+    super.traitCollectionDidChange(previousTraitCollection)
+    guard traitCollection.userInterfaceStyle != previousTraitCollection?.userInterfaceStyle else { return }
+    updateViews()
+  }
+
   private func updateViews() {
     if placePagePreviewData.isMyPosition {
       if let speedAndAltitude = speedAndAltitude {
@@ -91,7 +97,7 @@ final class PlacePagePreviewViewController: UIViewController {
     } else {
       addressContainerView.isHidden = true
     }
-
+    placePageDirectionView?.imageView.changeColoringToOpposite()
     configSchedule()
   }
 

--- a/iphone/Maps/UI/PlacePage/Components/WikiDescriptionViewController.swift
+++ b/iphone/Maps/UI/PlacePage/Components/WikiDescriptionViewController.swift
@@ -20,6 +20,12 @@ class WikiDescriptionViewController: UIViewController {
     updateDescription()
   }
 
+  override func traitCollectionDidChange(_ previousTraitCollection: UITraitCollection?) {
+    super.traitCollectionDidChange(previousTraitCollection)
+    guard traitCollection.userInterfaceStyle != previousTraitCollection?.userInterfaceStyle else { return }
+    updateDescription()
+  }
+
   private func updateDescription() {
     guard let descriptionHtml = descriptionHtml else { return }
 

--- a/iphone/Maps/UI/PlacePage/PlacePage.storyboard
+++ b/iphone/Maps/UI/PlacePage/PlacePage.storyboard
@@ -173,6 +173,9 @@
                                                 <fontDescription key="fontDescription" type="system" pointSize="17"/>
                                                 <nil key="textColor"/>
                                                 <nil key="highlightedColor"/>
+                                                <userDefinedRuntimeAttributes>
+                                                    <userDefinedRuntimeAttribute type="string" keyPath="styleName" value="regular14:blackSecondaryText"/>
+                                                </userDefinedRuntimeAttributes>
                                             </label>
                                             <view hidden="YES" contentMode="scaleToFill" horizontalHuggingPriority="1000" horizontalCompressionResistancePriority="1000" translatesAutoresizingMaskIntoConstraints="NO" id="jaa-Yj-XQR" customClass="PlacePageDirectionView" customModule="Organic_Maps" customModuleProvider="target">
                                                 <rect key="frame" x="0.0" y="0.0" width="69.5" height="50"/>
@@ -741,7 +744,7 @@
                                     <constraint firstAttribute="height" constant="44" id="UK1-MJ-aDf"/>
                                 </constraints>
                                 <userDefinedRuntimeAttributes>
-                                    <userDefinedRuntimeAttribute type="string" keyPath="coloring" value="MWMBlack"/>
+                                    <userDefinedRuntimeAttribute type="string" keyPath="styleName" value="MWMBlack"/>
                                 </userDefinedRuntimeAttributes>
                             </imageView>
                             <stackView opaque="NO" contentMode="scaleToFill" axis="vertical" translatesAutoresizingMaskIntoConstraints="NO" id="6l3-ag-Ii0">

--- a/iphone/Maps/UI/PlacePage/PlacePageLayout/ActionBar/MWMActionBarButton.m
+++ b/iphone/Maps/UI/PlacePage/PlacePageLayout/ActionBar/MWMActionBarButton.m
@@ -199,6 +199,11 @@ NSString *titleForButton(MWMActionBarButtonType type, BOOL isSelected) {
   [NSUserDefaults.standardUserDefaults setBool:true forKey:kUDDidHighlightRouteToButton];
 }
 
+- (void)traitCollectionDidChange:(UITraitCollection *)previousTraitCollection {
+  [super traitCollectionDidChange:previousTraitCollection];
+  [self.button setSelected:false];
+}
+
 - (UIView *)hitTest:(CGPoint)point withEvent:(UIEvent *)event {
   return [self pointInside:point withEvent:event] ? self.button : nil;
 }

--- a/iphone/Maps/UI/PlacePage/PlacePageViewController.swift
+++ b/iphone/Maps/UI/PlacePage/PlacePageViewController.swift
@@ -103,7 +103,8 @@ final class PlacePageScrollView: UIScrollView {
 
   override func traitCollectionDidChange(_ previousTraitCollection: UITraitCollection?) {
     super.traitCollectionDidChange(previousTraitCollection)
-    if self.previousTraitCollection != nil {
+    // Update layout when the device was rotated but skip when the appearance was changed.
+    if self.previousTraitCollection != nil, previousTraitCollection?.userInterfaceStyle == traitCollection.userInterfaceStyle {
       DispatchQueue.main.async {
         self.updateSteps()
         self.showLastStop()

--- a/iphone/Maps/UI/Settings/MWMSettingsViewController.mm
+++ b/iphone/Maps/UI/Settings/MWMSettingsViewController.mm
@@ -52,12 +52,12 @@ using namespace power_management;
 }
 
 - (void)configProfileSection {
-  NSString *userName = osm_auth_ios::OSMUserName();
+  NSString * userName = osm_auth_ios::OSMUserName();
   [self.profileCell configWithTitle:L(@"profile") info:userName.length != 0 ? userName : @""];
 }
 
 - (void)configCommonSection {
-  NSString *units = nil;
+  NSString * units = nil;
   switch ([MWMSettings measurementUnits]) {
     case MWMUnitsMetric:
       units = L(@"kilometres");
@@ -76,8 +76,8 @@ using namespace power_management;
   {
     self.is3dCell.isEnabled = false;
     [self.is3dCell configWithDelegate:self title:L(@"pref_map_3d_buildings_title") isOn:false];
-    UITapGestureRecognizer* tapRecogniser = [[UITapGestureRecognizer alloc] initWithTarget:self
-                                                            action:@selector(show3dBuildingsAlert:)];
+    UITapGestureRecognizer * tapRecogniser = [[UITapGestureRecognizer alloc] initWithTarget:self
+                                                                                     action:@selector(show3dBuildingsAlert:)];
 
     self.is3dCell.gestureRecognizers = @[tapRecogniser];
   }
@@ -92,7 +92,7 @@ using namespace power_management;
                                       title:L(@"autodownload")
                                        isOn:[MWMSettings autoDownloadEnabled]];
 
-  NSString *mobileInternet = nil;
+  NSString * mobileInternet = nil;
   switch ([MWMNetworkPolicy sharedPolicy].permission) {
     case MWMNetworkPolicyPermissionAlways:
       mobileInternet = L(@"mobile_data_option_always");
@@ -108,7 +108,7 @@ using namespace power_management;
   }
   [self.mobileInternetCell configWithTitle:L(@"mobile_data") info:mobileInternet];
 
-  NSString *powerManagement = nil;
+  NSString * powerManagement = nil;
   switch (GetFramework().GetPowerManager().GetScheme()) {
     case Scheme::None:
       break;
@@ -126,7 +126,7 @@ using namespace power_management;
   }
   [self.powerManagementCell configWithTitle:L(@"power_managment_title") info:powerManagement];
 
-  NSString *recentTrack = nil;
+  NSString * recentTrack = nil;
   if (!GpsTracker::Instance().IsEnabled()) {
     recentTrack = L(@"duration_disabled");
   } else {
@@ -163,7 +163,7 @@ using namespace power_management;
                                             title:L(@"pref_calibration_title")
                                              isOn:[MWMSettings compassCalibrationEnabled]];
 
-  NSString *nightMode = nil;
+  NSString * nightMode = nil;
   switch ([MWMSettings theme]) {
     case MWMThemeVehicleDay:
       NSAssert(false, @"Invalid case");
@@ -183,12 +183,12 @@ using namespace power_management;
 }
 
 - (void)show3dBuildingsAlert:(UITapGestureRecognizer *)recognizer {
-  UIAlertController *alert =
-  [UIAlertController alertControllerWithTitle:L(@"pref_map_3d_buildings_title")
+  UIAlertController * alert =
+    [UIAlertController alertControllerWithTitle:L(@"pref_map_3d_buildings_title")
                                       message:L(@"pref_map_3d_buildings_disabled_summary")
                                preferredStyle:UIAlertControllerStyleAlert];
 
-  UIAlertAction *okButton = [UIAlertAction actionWithTitle:@"OK"
+  UIAlertAction * okButton = [UIAlertAction actionWithTitle:@"OK"
                                                       style:UIAlertActionStyleDefault
                                                     handler:nil];
   [alert addAction:okButton];
@@ -204,7 +204,7 @@ using namespace power_management;
 
   [self.autoZoomCell configWithDelegate:self title:L(@"pref_map_auto_zoom") isOn:GetFramework().LoadAutoZoom()];
 
-  NSString *ttsEnabledString = [MWMTextToSpeech isTTSEnabled] ? L(@"on") : L(@"off");
+  NSString * ttsEnabledString = [MWMTextToSpeech isTTSEnabled] ? L(@"on") : L(@"off");
   [self.voiceInstructionsCell configWithTitle:L(@"pref_tts_enable_title") info:ttsEnabledString];
   [self.drivingOptionsCell configWithTitle:L(@"driving_options_title") info:@""];
 }

--- a/iphone/Maps/UI/Settings/MWMSettingsViewController.mm
+++ b/iphone/Maps/UI/Settings/MWMSettingsViewController.mm
@@ -162,23 +162,7 @@ using namespace power_management;
   [self.compassCalibrationCell configWithDelegate:self
                                             title:L(@"pref_calibration_title")
                                              isOn:[MWMSettings compassCalibrationEnabled]];
-}
 
-- (void)show3dBuildingsAlert:(UITapGestureRecognizer *)recognizer {
-  UIAlertController *alert =
-  [UIAlertController alertControllerWithTitle:L(@"pref_map_3d_buildings_title")
-                                      message:L(@"pref_map_3d_buildings_disabled_summary")
-                               preferredStyle:UIAlertControllerStyleAlert];
-
-  UIAlertAction *okButton = [UIAlertAction actionWithTitle:@"OK"
-                                                      style:UIAlertActionStyleDefault
-                                                    handler:nil];
-  [alert addAction:okButton];
-
-  [self presentViewController:alert animated:YES completion:nil];
-}
-
-- (void)configNavigationSection {
   NSString *nightMode = nil;
   switch ([MWMSettings theme]) {
     case MWMThemeVehicleDay:
@@ -196,7 +180,23 @@ using namespace power_management;
       break;
   }
   [self.nightModeCell configWithTitle:L(@"pref_map_style_title") info:nightMode];
+}
 
+- (void)show3dBuildingsAlert:(UITapGestureRecognizer *)recognizer {
+  UIAlertController *alert =
+  [UIAlertController alertControllerWithTitle:L(@"pref_map_3d_buildings_title")
+                                      message:L(@"pref_map_3d_buildings_disabled_summary")
+                               preferredStyle:UIAlertControllerStyleAlert];
+
+  UIAlertAction *okButton = [UIAlertAction actionWithTitle:@"OK"
+                                                      style:UIAlertActionStyleDefault
+                                                    handler:nil];
+  [alert addAction:okButton];
+
+  [self presentViewController:alert animated:YES completion:nil];
+}
+
+- (void)configNavigationSection {
   bool _ = true, on = true;
   auto &f = GetFramework();
   f.Load3dMode(on, _);

--- a/iphone/Maps/UI/Storyboard/Settings.storyboard
+++ b/iphone/Maps/UI/Storyboard/Settings.storyboard
@@ -401,10 +401,6 @@
                                             <outlet property="title" destination="Xqo-QZ-3fd" id="W1h-0a-CQ2"/>
                                         </connections>
                                     </tableViewCell>
-                                </cells>
-                            </tableViewSection>
-                            <tableViewSection headerTitle="НАВИГАЦИЯ" id="E4E-hs-9xW">
-                                <cells>
                                     <tableViewCell contentMode="scaleToFill" selectionStyle="default" accessoryType="disclosureIndicator" hidesAccessoryWhenEditing="NO" indentationLevel="1" indentationWidth="0.0" reuseIdentifier="SettingsTableViewLinkCell" id="QNt-XC-xma" customClass="SettingsTableViewLinkCell" customModule="Organic_Maps" customModuleProvider="target">
                                         <rect key="frame" x="0.0" y="578" width="414" height="44"/>
                                         <autoresizingMask key="autoresizingMask"/>
@@ -440,6 +436,10 @@
                                             <outlet property="title" destination="q7P-cj-3tZ" id="3sG-Xy-G0r"/>
                                         </connections>
                                     </tableViewCell>
+                                </cells>
+                            </tableViewSection>
+                            <tableViewSection headerTitle="НАВИГАЦИЯ" id="E4E-hs-9xW">
+                                <cells>
                                     <tableViewCell contentMode="scaleToFill" selectionStyle="none" hidesAccessoryWhenEditing="NO" indentationLevel="1" indentationWidth="0.0" reuseIdentifier="SettingsTableViewSwitchCell" id="X5R-fv-yd7" customClass="SettingsTableViewSwitchCell" customModule="Organic_Maps" customModuleProvider="target">
                                         <rect key="frame" x="0.0" y="622" width="414" height="44"/>
                                         <autoresizingMask key="autoresizingMask"/>


### PR DESCRIPTION
See https://github.com/organicmaps/organicmaps/issues/749 , not closing it yet as Android part should also be implemented.

### In this PR:
1. Synchronize the auto-switching between light/dark themes to the device when the user selects `Auto` in the OM Settings.
When the On/Off is selected in OM Settings synchronization is disabled.
2. When the user uses CarPlay and Carplay auto-updates content style then the map theme will be changed to it. There is no possibility to force the map theme whiole using the CarPlay (except Carplay's settings). 
3. A lot of bugs related to the auto theme changing were fixed, because with the current `ThemeManager` and `StyleManager` systems UI elements usually support the creation with the current theme, but do not auto-update when the theme is changing.
4. Move the NightMode selection from the `Navigation` section into `General`

Tested on: 
iOS 15.5, 17.2,
iPhone 15 pro, iPoneSE 3gen, iPad, iPad Designed For Mac

![Simulator Screen Recording - iPhone SE (3rd generation) - 2024-02-01 at 14 07 04](https://github.com/organicmaps/organicmaps/assets/79797627/cc6341e1-d256-4ace-bf21-23e41600edaa)

![Simulator Screen Recording - iPhone 15 Pro - 2024-01-31 at 18 43 07]
![Simulator Screen Recording - iPhone 15 Pro - 2024-02-01 at 13 31 42](https://github.com/organicmaps/organicmaps/assets/79797627/a5456d7c-9652-4412-b72d-123b9260e3d9)
![Simulator Screen Recording - iPhone SE (3rd generation) - 2024-02-01 at 13 28 33](https://github.com/organicmaps/organicmaps/assets/79797627/a2600471-cb9f-4756-becf-b0cf8174fced)
(https://github.com/organicmaps/organicmaps/assets/79797627/8f8d0aba-f131-4fd4-86e1-0bcd1dfb0b46)

https://github.com/organicmaps/organicmaps/assets/79797627/b9187811-d6b8-49af-bc35-1fc9f7c7e65f

CarPlay:
Auto
![Main-VideoStream-2024-01-31-14-42-42](https://github.com/organicmaps/organicmaps/assets/79797627/36e23fc4-9b10-4d7f-99d5-9b0d7f402df6)

DarkMapsDisabled
![Main-VideoStream-2024-01-31-14-41-52](https://github.com/organicmaps/organicmaps/assets/79797627/750cd52f-43b6-4bd5-99ff-eda196831c05)
![Main-VideoStream-2024-01-31-14-43-05](https://github.com/organicmaps/organicmaps/assets/79797627/62f3ea02-056f-4ac9-a744-dbfab9527b1b)

DarkMapsEnabled
![Main-VideoStream-2024-01-31-14-42-55](https://github.com/organicmaps/organicmaps/assets/79797627/513fb4ae-23cb-4dd8-962e-399ab4d84a9b)
![Main-VideoStream-2024-01-31-14-43-00](https://github.com/organicmaps/organicmaps/assets/79797627/3995aafc-74eb-4eac-9915-01c17739feba)


