### PR TITLE
[ios] Fix the bottom 'download all' view layout

### DIFF
--- a/iphone/Maps/Categories/UIView+AddSeparator.swift
+++ b/iphone/Maps/Categories/UIView+AddSeparator.swift
@@ -1,0 +1,17 @@
+extension UIView {
+  func addSeparator(thickness: CGFloat = 1.0,
+                    color: UIColor? = StyleManager.shared.theme?.colors.blackDividers,
+                    insets: UIEdgeInsets = .zero) {
+    let lineView = UIView()
+    lineView.backgroundColor = color
+    lineView.isUserInteractionEnabled = false
+    lineView.translatesAutoresizingMaskIntoConstraints = false
+    addSubview(lineView)
+    NSLayoutConstraint.activate([
+      lineView.heightAnchor.constraint(equalToConstant: thickness),
+      lineView.leadingAnchor.constraint(equalTo: leadingAnchor, constant: insets.left),
+      lineView.trailingAnchor.constraint(equalTo: trailingAnchor, constant: -insets.right),
+      lineView.topAnchor.constraint(equalTo: topAnchor, constant: insets.top),
+    ])
+  }
+}

--- a/iphone/Maps/Maps.xcodeproj/project.pbxproj
+++ b/iphone/Maps/Maps.xcodeproj/project.pbxproj
@@ -463,6 +463,7 @@
 		CDCA27842245090900167D87 /* ListenerContainer.swift in Sources */ = {isa = PBXBuildFile; fileRef = CDCA27832245090900167D87 /* ListenerContainer.swift */; };
 		CDCA278622451F5000167D87 /* RouteInfo.swift in Sources */ = {isa = PBXBuildFile; fileRef = CDCA278522451F5000167D87 /* RouteInfo.swift */; };
 		CDCA278E2248F34C00167D87 /* MWMRoutingManager.mm in Sources */ = {isa = PBXBuildFile; fileRef = CDCA278B2248F34C00167D87 /* MWMRoutingManager.mm */; };
+		ED1263AB2B6F99F900AD99F3 /* UIView+AddSeparator.swift in Sources */ = {isa = PBXBuildFile; fileRef = ED1263AA2B6F99F900AD99F3 /* UIView+AddSeparator.swift */; };
 		ED3EAC202B03C88100220A4A /* BottomTabBarButton.swift in Sources */ = {isa = PBXBuildFile; fileRef = ED3EAC1F2B03C88100220A4A /* BottomTabBarButton.swift */; };
 		EDBD68072B625724005DD151 /* LocationServicesDisabledAlert.xib in Resources */ = {isa = PBXBuildFile; fileRef = EDBD68062B625724005DD151 /* LocationServicesDisabledAlert.xib */; };
 		EDBD680B2B62572E005DD151 /* LocationServicesDisabledAlert.swift in Sources */ = {isa = PBXBuildFile; fileRef = EDBD680A2B62572E005DD151 /* LocationServicesDisabledAlert.swift */; };
@@ -1328,6 +1329,7 @@
 		CDCA278C2248F34C00167D87 /* MWMRouterResultCode.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = MWMRouterResultCode.h; sourceTree = "<group>"; };
 		CDCA278F2248F3B800167D87 /* MWMLocationModeListener.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = MWMLocationModeListener.h; sourceTree = "<group>"; };
 		CDE0F3AD225B8D45008BA5C3 /* MWMSpeedCameraManagerMode.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = MWMSpeedCameraManagerMode.h; sourceTree = "<group>"; };
+		ED1263AA2B6F99F900AD99F3 /* UIView+AddSeparator.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "UIView+AddSeparator.swift"; sourceTree = "<group>"; };
 		ED3EAC1F2B03C88100220A4A /* BottomTabBarButton.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BottomTabBarButton.swift; sourceTree = "<group>"; };
 		ED48BBB817C2B1E2003E7E92 /* CircleView.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = CircleView.h; sourceTree = "<group>"; };
 		ED48BBB917C2B1E2003E7E92 /* CircleView.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = CircleView.m; sourceTree = "<group>"; };
@@ -2057,6 +2059,7 @@
 				1DFA2F6820D3B52F00FB2C66 /* UIColor+PartnerColor.h */,
 				1DFA2F6920D3B57400FB2C66 /* UIColor+PartnerColor.m */,
 				3454D7A41E07F045004AF2AD /* UIColor+MapsMeColor.h */,
+				ED1263AA2B6F99F900AD99F3 /* UIView+AddSeparator.swift */,
 				3454D7A51E07F045004AF2AD /* UIColor+MapsMeColor.m */,
 				3488B0181E9D0B230068AFD8 /* UIColor+Modifications.swift */,
 				3454D7A61E07F045004AF2AD /* UIFont+MapsMeFonts.h */,
@@ -4205,6 +4208,7 @@
 				993DF10E23F6BDB100AC231A /* UIButtonRenderer.swift in Sources */,
 				99514BBB23E82B450085D3A7 /* ElevationProfileBuilder.swift in Sources */,
 				34AB66381FC5AA330078E451 /* RouteManagerCell.swift in Sources */,
+				ED1263AB2B6F99F900AD99F3 /* UIView+AddSeparator.swift in Sources */,
 				CD4A1F132305872700F2A6B6 /* PromoBookingPresentationController.swift in Sources */,
 				3472B5D3200F501500DC6CD5 /* BackgroundFetchTaskFrameworkType.swift in Sources */,
 				47E460AD240D737D00385B45 /* OpeinigHoursLocalization.swift in Sources */,

--- a/iphone/Maps/UI/Downloader/DownloadAllView/DownloadAllView.xib
+++ b/iphone/Maps/UI/Downloader/DownloadAllView/DownloadAllView.xib
@@ -59,16 +59,6 @@
                         <constraint firstAttribute="width" constant="36" id="Uo3-uS-WpU"/>
                     </constraints>
                 </view>
-                <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="Ibq-zq-hs6">
-                    <rect key="frame" x="0.0" y="0.0" width="414" height="1"/>
-                    <color key="backgroundColor" systemColor="systemBackgroundColor" cocoaTouchSystemColor="whiteColor"/>
-                    <constraints>
-                        <constraint firstAttribute="height" constant="1" id="BBP-6A-sYn"/>
-                    </constraints>
-                    <userDefinedRuntimeAttributes>
-                        <userDefinedRuntimeAttribute type="string" keyPath="styleName" value="Divider"/>
-                    </userDefinedRuntimeAttributes>
-                </view>
             </subviews>
             <color key="backgroundColor" red="1" green="1" blue="1" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
             <constraints>
@@ -76,12 +66,9 @@
                 <constraint firstItem="cKg-JT-LQ3" firstAttribute="leading" secondItem="iN0-l3-epB" secondAttribute="leading" constant="16" id="2AL-TB-z3U"/>
                 <constraint firstItem="wlz-tD-b2M" firstAttribute="centerY" secondItem="iN0-l3-epB" secondAttribute="centerY" id="8aq-IR-Ffz"/>
                 <constraint firstItem="4vQ-dY-JAM" firstAttribute="top" secondItem="iN0-l3-epB" secondAttribute="top" priority="500" constant="10" id="AOx-bc-GRy"/>
-                <constraint firstItem="Ibq-zq-hs6" firstAttribute="leading" secondItem="iN0-l3-epB" secondAttribute="leading" id="AnG-8o-vZ1"/>
-                <constraint firstAttribute="trailing" secondItem="Ibq-zq-hs6" secondAttribute="trailing" id="DLd-cl-Dvo"/>
                 <constraint firstItem="cKg-JT-LQ3" firstAttribute="centerY" secondItem="iN0-l3-epB" secondAttribute="centerY" id="Ehd-uD-6HS"/>
                 <constraint firstItem="4vQ-dY-JAM" firstAttribute="leading" secondItem="cKg-JT-LQ3" secondAttribute="trailing" constant="18" id="IH6-Jq-o9T"/>
                 <constraint firstItem="NBt-lB-IvV" firstAttribute="centerY" secondItem="iN0-l3-epB" secondAttribute="centerY" id="KUE-7v-eNY"/>
-                <constraint firstItem="Ibq-zq-hs6" firstAttribute="top" secondItem="iN0-l3-epB" secondAttribute="top" id="MY1-1f-b5g"/>
                 <constraint firstAttribute="trailing" secondItem="NBt-lB-IvV" secondAttribute="trailing" constant="16" id="PgQ-HZ-Ui5"/>
                 <constraint firstItem="4vQ-dY-JAM" firstAttribute="centerY" secondItem="cKg-JT-LQ3" secondAttribute="centerY" priority="250" id="gWz-3d-LHv"/>
                 <constraint firstAttribute="bottom" secondItem="mVA-td-yVW" secondAttribute="bottom" constant="10" id="gj3-BP-k3L"/>

--- a/iphone/Maps/UI/Downloader/DownloadMapsViewController.swift
+++ b/iphone/Maps/UI/Downloader/DownloadMapsViewController.swift
@@ -48,7 +48,14 @@ class DownloadMapsViewController: MWMViewController {
     let view = Bundle.main.load(viewClass: DownloadAllView.self)?.first as! DownloadAllView
     view.delegate = self
     downloadAllViewContainer.addSubview(view)
-    view.alignToSuperview()
+    downloadAllViewContainer.addSeparator()
+    view.translatesAutoresizingMaskIntoConstraints = false
+    NSLayoutConstraint.activate([
+      view.leadingAnchor.constraint(equalTo: self.view.safeAreaLayoutGuide.leadingAnchor),
+      view.trailingAnchor.constraint(equalTo: self.view.safeAreaLayoutGuide.trailingAnchor),
+      view.topAnchor.constraint(equalTo: downloadAllViewContainer.topAnchor),
+      view.bottomAnchor.constraint(equalTo: self.view.safeAreaLayoutGuide.bottomAnchor),
+    ])
     return view
   }()
 

--- a/iphone/Maps/UI/PlacePage/Components/PlacePageInfoViewController.swift
+++ b/iphone/Maps/UI/PlacePage/Components/PlacePageInfoViewController.swift
@@ -356,22 +356,3 @@ private extension UIStackView {
     addArrangedSubview(view)
   }
 }
-
-private extension UIView {
-  func addSeparator(thickness: CGFloat,
-                    color: UIColor?,
-                    insets: UIEdgeInsets) {
-    let lineView = UIView()
-    lineView.styleName = "Divider"
-    lineView.backgroundColor = color ?? .black
-    lineView.isUserInteractionEnabled = false
-    lineView.translatesAutoresizingMaskIntoConstraints = false
-    addSubview(lineView)
-    NSLayoutConstraint.activate([
-      lineView.heightAnchor.constraint(equalToConstant: thickness),
-      lineView.leadingAnchor.constraint(equalTo: leadingAnchor, constant: insets.left),
-      lineView.trailingAnchor.constraint(equalTo: trailingAnchor, constant: -insets.right),
-      lineView.topAnchor.constraint(equalTo: topAnchor, constant: insets.top),
-    ])
-  }
-}

--- a/iphone/Maps/UI/Storyboard/Main.storyboard
+++ b/iphone/Maps/UI/Storyboard/Main.storyboard
@@ -898,9 +898,6 @@
                             <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="CDj-ol-HRP">
                                 <rect key="frame" x="59" y="345" width="814" height="64"/>
                                 <color key="backgroundColor" white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
-                                <constraints>
-                                    <constraint firstAttribute="height" constant="64" id="YoQ-gr-frN"/>
-                                </constraints>
                                 <userDefinedRuntimeAttributes>
                                     <userDefinedRuntimeAttribute type="string" keyPath="styleName" value="PressBackground"/>
                                 </userDefinedRuntimeAttributes>
@@ -912,15 +909,16 @@
                         <constraints>
                             <constraint firstItem="CwW-x8-G3j" firstAttribute="top" secondItem="XQZ-0V-SyR" secondAttribute="top" id="5wV-Dv-sjS"/>
                             <constraint firstAttribute="trailing" secondItem="CwW-x8-G3j" secondAttribute="trailing" id="6QL-v4-rNy"/>
-                            <constraint firstItem="dlW-OQ-WMO" firstAttribute="bottom" secondItem="kXO-Oh-2vO" secondAttribute="bottom" id="8Tl-19-ReF"/>
-                            <constraint firstItem="dlW-OQ-WMO" firstAttribute="trailing" secondItem="CDj-ol-HRP" secondAttribute="trailing" id="FLZ-Kr-4dV"/>
-                            <constraint firstItem="kXO-Oh-2vO" firstAttribute="leading" secondItem="dlW-OQ-WMO" secondAttribute="leading" id="M0m-98-7Ev"/>
+                            <constraint firstAttribute="bottom" secondItem="kXO-Oh-2vO" secondAttribute="bottom" id="8Tl-19-ReF"/>
+                            <constraint firstAttribute="trailing" secondItem="CDj-ol-HRP" secondAttribute="trailing" id="FLZ-Kr-4dV"/>
+                            <constraint firstItem="kXO-Oh-2vO" firstAttribute="leading" secondItem="XQZ-0V-SyR" secondAttribute="leading" id="M0m-98-7Ev"/>
                             <constraint firstAttribute="bottom" secondItem="CwW-x8-G3j" secondAttribute="bottom" id="QPk-e4-hZs"/>
                             <constraint firstItem="CwW-x8-G3j" firstAttribute="leading" secondItem="XQZ-0V-SyR" secondAttribute="leading" id="Wvb-0M-kQl"/>
                             <constraint firstItem="CwW-x8-G3j" firstAttribute="top" secondItem="kXO-Oh-2vO" secondAttribute="top" id="eFX-ON-3aD"/>
-                            <constraint firstItem="CDj-ol-HRP" firstAttribute="leading" secondItem="dlW-OQ-WMO" secondAttribute="leading" id="mwH-aX-jCV"/>
-                            <constraint firstItem="dlW-OQ-WMO" firstAttribute="bottom" secondItem="CDj-ol-HRP" secondAttribute="bottom" id="tp7-f9-Sw5"/>
-                            <constraint firstItem="dlW-OQ-WMO" firstAttribute="trailing" secondItem="kXO-Oh-2vO" secondAttribute="trailing" id="yMA-25-2pq"/>
+                            <constraint firstItem="CDj-ol-HRP" firstAttribute="top" secondItem="dlW-OQ-WMO" secondAttribute="bottom" constant="-64" id="j6X-Fl-XrE"/>
+                            <constraint firstItem="CDj-ol-HRP" firstAttribute="leading" secondItem="XQZ-0V-SyR" secondAttribute="leading" id="mwH-aX-jCV"/>
+                            <constraint firstAttribute="bottom" secondItem="CDj-ol-HRP" secondAttribute="bottom" id="tp7-f9-Sw5"/>
+                            <constraint firstAttribute="trailing" secondItem="kXO-Oh-2vO" secondAttribute="trailing" id="yMA-25-2pq"/>
                         </constraints>
                         <userDefinedRuntimeAttributes>
                             <userDefinedRuntimeAttribute type="string" keyPath="styleName" value="PressBackground"/>


### PR DESCRIPTION
PR https://github.com/organicmaps/organicmaps/pull/7236 partly fixes the DownloadMapsVC layout but there are still some problems.

This PR fixes the Download/Update view on the DownloadMapsVC.

Before PR7236:
![IMG_4237](https://github.com/organicmaps/organicmaps/assets/79797627/ef6e041b-66d9-438a-9bc5-420d55aa5fcb)
![IMG_4236](https://github.com/organicmaps/organicmaps/assets/79797627/68c3acc9-34ce-4908-89fd-1dfc70340cae)


After PR7236(for screenshots I forced visibility of the view to show the layout and there is no content because the maps were up-to-date):
<img width="395" alt="image" src="https://github.com/organicmaps/organicmaps/assets/79797627/6c551d99-75ca-4c30-b60d-c522ad2810c6">
<img width="722" alt="image" src="https://github.com/organicmaps/organicmaps/assets/79797627/32160cde-86d3-4604-a3b7-eebfdcb7a76a">

After this PR:
<img width="347" alt="image" src="https://github.com/organicmaps/organicmaps/assets/79797627/1da5d7ca-de24-4781-8e7a-38f0f50658ae">

<img width="728" alt="image" src="https://github.com/organicmaps/organicmaps/assets/79797627/45a10215-1d4a-4c9a-992e-4647bc4bb080">
