### PR TITLE
[ios] Reduce the navigation screen top bar height

### DIFF
--- a/iphone/Maps/Classes/CustomViews/NavigationDashboard/Views/MWMNavigationInfoView.mm
+++ b/iphone/Maps/Classes/CustomViews/NavigationDashboard/Views/MWMNavigationInfoView.mm
@@ -56,6 +56,7 @@ BOOL defaultOrientation(CGSize const &size) {
 @interface MWMNavigationInfoView () <MWMLocationObserver>
 
 @property(weak, nonatomic) IBOutlet UIView *streetNameView;
+@property(weak, nonatomic) IBOutlet NSLayoutConstraint *streetNameTopOffsetConstraint;
 @property(weak, nonatomic) IBOutlet NSLayoutConstraint *streetNameViewHideOffset;
 @property(weak, nonatomic) IBOutlet UILabel *streetNameLabel;
 @property(weak, nonatomic) IBOutlet UIView *turnsView;
@@ -336,6 +337,12 @@ BOOL defaultOrientation(CGSize const &size) {
   self.widthConstraint.active = YES;
   self.heightConstraint = [self.heightAnchor constraintEqualToConstant:ov.frame.size.height];
   self.heightConstraint.active = YES;
+  self.streetNameTopOffsetConstraint.constant = self.additionalStreetNameTopOffset;
+}
+
+// Additional spacing for devices with a small top safe area (such as SE or when the device is in landscape mode).
+- (CGFloat)additionalStreetNameTopOffset {
+  return MapsAppDelegate.theApp.window.safeAreaInsets.top <= 20 ? 10 : 0;;
 }
 
 - (void)refreshLayout {
@@ -358,6 +365,7 @@ BOOL defaultOrientation(CGSize const &size) {
         (defaultOrientation(availableArea.size) ? kSearchButtonsViewHeightPortrait
                                                 : kSearchButtonsViewHeightLandscape) /
         2;
+      self.streetNameTopOffsetConstraint.constant = self.additionalStreetNameTopOffset;
     }];
   });
 }

--- a/iphone/Maps/Classes/CustomViews/NavigationDashboard/Views/MWMNavigationInfoView.xib
+++ b/iphone/Maps/Classes/CustomViews/NavigationDashboard/Views/MWMNavigationInfoView.xib
@@ -125,12 +125,12 @@
                     </accessibility>
                     <constraints>
                         <constraint firstAttribute="bottom" secondItem="WID-Um-Va6" secondAttribute="bottom" id="5ox-Cb-hJc"/>
-                        <constraint firstItem="ShI-bz-5g8" firstAttribute="top" secondItem="YYv-pG-Wkw" secondAttribute="top" constant="24" id="KK1-dA-hII"/>
+                        <constraint firstItem="ShI-bz-5g8" firstAttribute="top" secondItem="YYv-pG-Wkw" secondAttribute="top" id="KK1-dA-hII"/>
                         <constraint firstAttribute="trailing" secondItem="WID-Um-Va6" secondAttribute="trailing" constant="-100" id="f4N-aC-XO3"/>
                         <constraint firstItem="ShI-bz-5g8" firstAttribute="leading" secondItem="YYv-pG-Wkw" secondAttribute="leading" priority="300" constant="112" id="nVP-3U-KG2"/>
                         <constraint firstItem="WID-Um-Va6" firstAttribute="leading" secondItem="YYv-pG-Wkw" secondAttribute="leading" constant="-100" id="s8Q-4n-55U"/>
                         <constraint firstItem="WID-Um-Va6" firstAttribute="top" secondItem="YYv-pG-Wkw" secondAttribute="top" constant="-100" id="spZ-F3-yP2"/>
-                        <constraint firstAttribute="bottom" secondItem="ShI-bz-5g8" secondAttribute="bottom" constant="12" id="w0r-Ip-f9E"/>
+                        <constraint firstAttribute="bottom" secondItem="ShI-bz-5g8" secondAttribute="bottom" constant="10" id="w0r-Ip-f9E"/>
                     </constraints>
                 </view>
                 <view hidden="YES" contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="Aa6-N8-acP" userLabel="Turns" customClass="NavigationTurnsView" customModule="Organic_Maps" customModuleProvider="target">
@@ -406,6 +406,7 @@
                 <outlet property="secondTurnImageView" destination="CKi-sy-dNO" id="A29-2z-4oh"/>
                 <outlet property="secondTurnView" destination="8Zu-Ff-6p2" id="yEK-rY-S50"/>
                 <outlet property="streetNameLabel" destination="ShI-bz-5g8" id="eZd-Es-g0l"/>
+                <outlet property="streetNameTopOffsetConstraint" destination="KK1-dA-hII" id="d2I-37-Guw"/>
                 <outlet property="streetNameView" destination="YYv-pG-Wkw" id="gbk-SH-idq"/>
                 <outlet property="streetNameViewHideOffset" destination="xMz-Tm-KEn" id="Lwv-ep-zvo"/>
                 <outlet property="toastView" destination="Tzc-l6-Vvt" id="gTw-kd-UAJ"/>


### PR DESCRIPTION
Related PR https://github.com/organicmaps/organicmaps/pull/7196

This PR reduces the top bar height when navigation is enabled.

Before/After:
<img width="765" alt="image" src="https://github.com/organicmaps/organicmaps/assets/79797627/e396d1db-9877-4418-a876-8c72f56c9388">
<img width="505" alt="image" src="https://github.com/organicmaps/organicmaps/assets/79797627/017480a6-926c-4a1f-97a8-34a0fc61c8bb">
<img width="608" alt="image" src="https://github.com/organicmaps/organicmaps/assets/79797627/e1e318be-c592-4f2a-90f8-d5c7c3f3d499">
