### PR TITLE
[base] Add C++20 `char16_t` support to `DebugPrint`

### DIFF
--- a/base/internal/message.hpp
+++ b/base/internal/message.hpp
@@ -27,6 +27,7 @@ template <typename T> inline std::string DebugPrint(T const & t);
 std::string DebugPrint(std::string const & t);
 inline std::string DebugPrint(char const * t);
 inline std::string DebugPrint(char t);
+inline std::string DebugPrint(char16_t t);
 
 template <typename U, typename V> inline std::string DebugPrint(std::pair<U, V> const & p);
 template <typename T> inline std::string DebugPrint(std::list<T> const & v);
@@ -70,6 +71,11 @@ inline std::string DebugPrint(std::u16string const & utf16)
 inline std::string DebugPrint(std::u16string_view utf16)
 {
   return internal::ToUtf8(utf16);
+}
+
+inline std::string DebugPrint(char16_t t)
+{
+  return DebugPrint(std::u16string_view(&t, 1));
 }
 
 inline std::string DebugPrint(char t)


### PR DESCRIPTION
This change is needed for https://github.com/organicmaps/organicmaps/pull/7299.

C++20 deletes a number of operators including
`operator<<(basic_ostream<char, _Traits>&, char16_t) = delete;`. And consequentely the compilation with `--std=c++20` fails with `error: use of deleted function` on `out << t;`. Hence the generic
`template <typename T> inline std::string DebugPrint(T const & t)` needs to be specialized for `char16_t`.
For our purposes, we reuse the built-in `formatter` for `char` in this change.

Note, that simply initializing a string like `{1, t}` would emmit: `warning: narrowing conversion of ‘t’ from ‘char16_t’ to ‘char’`