### PR TITLE
[android] Fix TTS settings not working

### DIFF
--- a/android/app/src/main/java/app/organicmaps/settings/SettingsPrefsFragment.java
+++ b/android/app/src/main/java/app/organicmaps/settings/SettingsPrefsFragment.java
@@ -104,13 +104,21 @@ public class SettingsPrefsFragment extends BaseXmlSettingsFragment
   @Override
   public boolean onPreferenceTreeClick(Preference preference)
   {
-    if (preference.getKey() != null && preference.getKey().equals(getString(R.string.pref_osm_profile)))
+    final String key = preference.getKey();
+    if (key != null)
     {
-      startActivity(new Intent(requireActivity(), ProfileActivity.class));
-    }
-    else if (preference.getKey() != null && preference.getKey().equals(getString(R.string.pref_help)))
-    {
-      startActivity(new Intent(requireActivity(), HelpActivity.class));
+      if (key.equals(getString(R.string.pref_osm_profile)))
+      {
+        startActivity(new Intent(requireActivity(), ProfileActivity.class));
+      }
+      else if (key.equals(getString(R.string.pref_tts_screen)))
+      {
+        getSettingsActivity().stackFragment(VoiceInstructionsSettingsFragment.class, getString(R.string.pref_tts_enable_title), null);
+      }
+      else if (key.equals(getString(R.string.pref_help)))
+      {
+        startActivity(new Intent(requireActivity(), HelpActivity.class));
+      }
     }
     return super.onPreferenceTreeClick(preference);
   }

--- a/android/app/src/main/res/xml/prefs_main.xml
+++ b/android/app/src/main/res/xml/prefs_main.xml
@@ -125,8 +125,7 @@
       android:title="@string/pref_tts_enable_title"
       app:singleLineTitle="false"
       android:persistent="false"
-      android:order="4"
-      app:fragment="app.organicmaps.settings.VoiceInstructionsSettingsFragment">
+      android:order="4">
     </Preference>
     <ListPreference
       android:key="@string/pref_speed_cameras"


### PR DESCRIPTION
PR #7230 introduces a new fragment to manage TTS settings but the property specified in `prefs_main.xml` https://github.com/organicmaps/organicmaps/blob/8297a92c52ec4f720d1f78d3cc3f33b67e268ac7/android/app/src/main/res/xml/prefs_main.xml#L129 to start the TTS fragment doesn't work.
On latest beta, open TTS settings do nothing and hide a crash because we catch the exception -> https://github.com/organicmaps/organicmaps/blob/8297a92c52ec4f720d1f78d3cc3f33b67e268ac7/android/app/src/main/java/app/organicmaps/settings/SettingsActivity.java#L39

This PR:
- Remove property in preference xml file
- Add a new else if in onPreferenceTreeClick method in SettingsPrefsFragment.java to create TTS fragment. I have followed the same logic as how StoragePathFragment is created.

Tested on Pixel 6 - Android 14