### PR TITLE
[ios] Fix the route estimates colors when the app appearance was changed

### DIFF
--- a/iphone/Maps/Classes/CustomViews/NavigationDashboard/MWMNavigationDashboardEntity.h
+++ b/iphone/Maps/Classes/CustomViews/NavigationDashboard/MWMNavigationDashboardEntity.h
@@ -3,7 +3,6 @@
 @interface MWMNavigationDashboardEntity : NSObject
 
 @property(copy, nonatomic, readonly) NSArray<MWMRouterTransitStepInfo *> *transitSteps;
-@property(copy, nonatomic, readonly) NSAttributedString *estimate;
 @property(copy, nonatomic, readonly) NSString *distanceToTurn;
 @property(copy, nonatomic, readonly) NSString *streetName;
 @property(copy, nonatomic, readonly) NSString *targetDistance;
@@ -18,6 +17,8 @@
 @property(nonatomic, readonly) UIImage *turnImage;
 
 @property(nonatomic, readonly) NSString * arrival;
+
+- (NSAttributedString *) estimate;
 
 + (NSAttributedString *) estimateDot;
 

--- a/iphone/Maps/Classes/CustomViews/NavigationDashboard/MWMNavigationDashboardManager+Entity.mm
+++ b/iphone/Maps/Classes/CustomViews/NavigationDashboard/MWMNavigationDashboardManager+Entity.mm
@@ -18,12 +18,12 @@
 #include "geometry/distance_on_sphere.hpp"
 
 namespace {
-UIImage *image(routing::turns::CarDirection t, bool isNextTurn) {
+UIImage * image(routing::turns::CarDirection t, bool isNextTurn) {
   if (![MWMLocationManager lastLocation])
     return nil;
 
   using namespace routing::turns;
-  NSString *imageName;
+  NSString * imageName;
   switch (t) {
     case CarDirection::ExitHighwayToRight: imageName = @"ic_exit_highway_to_right"; break;
     case CarDirection::TurnSlightRight: imageName = @"slight_right"; break;
@@ -49,14 +49,13 @@ UIImage *image(routing::turns::CarDirection t, bool isNextTurn) {
   return [UIImage imageNamed:isNextTurn ? [imageName stringByAppendingString:@"_then"] : imageName];
 }
 
-UIImage *image(routing::turns::PedestrianDirection t) {
+UIImage * image(routing::turns::PedestrianDirection t) {
   if (![MWMLocationManager lastLocation])
     return nil;
 
   using namespace routing::turns;
-  NSString *imageName;
-  switch (t)
-  {
+  NSString * imageName;
+  switch (t) {
     case PedestrianDirection::TurnRight: imageName = @"simple_right"; break;
     case PedestrianDirection::TurnLeft: imageName = @"simple_left"; break;
     case PedestrianDirection::ReachedYourDestination: imageName = @"finish_point"; break;
@@ -71,7 +70,7 @@ UIImage *image(routing::turns::PedestrianDirection t) {
 
 NSArray<MWMRouterTransitStepInfo *> *buildRouteTransitSteps(NSArray<MWMRoutePoint *> *points) {
   // Generate step info in format: (Segment 1 distance) (1) (Segment 2 distance) (2) ... (n-1) (Segment N distance).
-  NSMutableArray<MWMRouterTransitStepInfo *> *steps = [NSMutableArray arrayWithCapacity:[points count] * 2 - 1];
+  NSMutableArray<MWMRouterTransitStepInfo *> * steps = [NSMutableArray arrayWithCapacity:[points count] * 2 - 1];
   auto const numPoints = [points count];
   for (int i = 0; i < numPoints - 1; i++) {
     MWMRoutePoint* segmentStart = points[i];
@@ -99,19 +98,19 @@ NSArray<MWMRouterTransitStepInfo *> *buildRouteTransitSteps(NSArray<MWMRoutePoin
 
 @interface MWMNavigationDashboardEntity ()
 
-@property(copy, nonatomic, readwrite) NSArray<MWMRouterTransitStepInfo *> *transitSteps;
-@property(copy, nonatomic, readwrite) NSString *distanceToTurn;
-@property(copy, nonatomic, readwrite) NSString *streetName;
-@property(copy, nonatomic, readwrite) NSString *targetDistance;
-@property(copy, nonatomic, readwrite) NSString *targetUnits;
-@property(copy, nonatomic, readwrite) NSString *turnUnits;
+@property(copy, nonatomic, readwrite) NSArray<MWMRouterTransitStepInfo *> * transitSteps;
+@property(copy, nonatomic, readwrite) NSString * distanceToTurn;
+@property(copy, nonatomic, readwrite) NSString * streetName;
+@property(copy, nonatomic, readwrite) NSString * targetDistance;
+@property(copy, nonatomic, readwrite) NSString * targetUnits;
+@property(copy, nonatomic, readwrite) NSString * turnUnits;
 @property(nonatomic, readwrite) double speedLimitMps;
 @property(nonatomic, readwrite) BOOL isValid;
 @property(nonatomic, readwrite) CGFloat progress;
 @property(nonatomic, readwrite) NSUInteger roundExitNumber;
 @property(nonatomic, readwrite) NSUInteger timeToTarget;
-@property(nonatomic, readwrite) UIImage *nextTurnImage;
-@property(nonatomic, readwrite) UIImage *turnImage;
+@property(nonatomic, readwrite) UIImage * nextTurnImage;
+@property(nonatomic, readwrite) UIImage * turnImage;
 @property(nonatomic, readwrite) BOOL showEta;
 @property(nonatomic, readwrite) BOOL isWalk;
 
@@ -142,13 +141,13 @@ NSArray<MWMRouterTransitStepInfo *> *buildRouteTransitSteps(NSArray<MWMRoutePoin
 
   auto result = [[NSMutableAttributedString alloc] initWithString:@""];
   if (self.showEta) {
-    NSString *eta = [NSDateComponentsFormatter etaStringFrom:self.timeToTarget];
+    NSString * eta = [NSDateComponentsFormatter etaStringFrom:self.timeToTarget];
     [result appendAttributedString:[[NSMutableAttributedString alloc] initWithString:eta attributes:primaryAttributes]];
     [result appendAttributedString:MWMNavigationDashboardEntity.estimateDot];
   }
 
   if (self.isWalk) {
-    UIFont *font = primaryAttributes[NSFontAttributeName];
+    UIFont * font = primaryAttributes[NSFontAttributeName];
     auto textAttachment = [[NSTextAttachment alloc] init];
     auto image = [UIImage imageNamed:@"ic_walk"];
     textAttachment.image = image;
@@ -157,7 +156,7 @@ NSArray<MWMRouterTransitStepInfo *> *buildRouteTransitSteps(NSArray<MWMRoutePoin
     auto const width = image.size.width * height / image.size.height;
     textAttachment.bounds = CGRectIntegral({{0, y}, {width, height}});
 
-    NSMutableAttributedString *attrStringWithImage =
+    NSMutableAttributedString * attrStringWithImage =
     [NSAttributedString attributedStringWithAttachment:textAttachment].mutableCopy;
     [attrStringWithImage addAttributes:secondaryAttributes range:NSMakeRange(0, attrStringWithImage.length)];
     [result appendAttributedString:attrStringWithImage];
@@ -179,9 +178,9 @@ NSArray<MWMRouterTransitStepInfo *> *buildRouteTransitSteps(NSArray<MWMRoutePoin
 
 @interface MWMNavigationDashboardManager ()
 
-@property(copy, nonatomic) NSDictionary *etaAttributes;
-@property(copy, nonatomic) NSDictionary *etaSecondaryAttributes;
-@property(nonatomic) MWMNavigationDashboardEntity *entity;
+@property(copy, nonatomic) NSDictionary * etaAttributes;
+@property(copy, nonatomic) NSDictionary * etaSecondaryAttributes;
+@property(nonatomic) MWMNavigationDashboardEntity * entity;
 
 - (void)onNavigationInfoUpdated;
 
@@ -241,7 +240,7 @@ NSArray<MWMRouterTransitStepInfo *> *buildRouteTransitSteps(NSArray<MWMRoutePoin
     entity.isValid = YES;
     entity.isWalk = YES;
     entity.showEta = YES;
-    NSMutableArray<MWMRouterTransitStepInfo *> *transitSteps = [NSMutableArray new];
+    NSMutableArray<MWMRouterTransitStepInfo *> * transitSteps = [NSMutableArray new];
     for (auto const &stepInfo : info.m_steps)
       [transitSteps addObject:[[MWMRouterTransitStepInfo alloc] initWithStepInfo:stepInfo]];
     entity.transitSteps = transitSteps;

--- a/iphone/Maps/Classes/CustomViews/NavigationDashboard/MWMNavigationDashboardManager.mm
+++ b/iphone/Maps/Classes/CustomViews/NavigationDashboard/MWMNavigationDashboardManager.mm
@@ -259,22 +259,6 @@ NSString *const kNavigationControlViewXibName = @"NavigationControlView";
 }
 #pragma mark - Properties
 
-- (NSDictionary *)etaAttributes {
-  if (!_etaAttributes) {
-    _etaAttributes =
-      @{NSForegroundColorAttributeName: [UIColor blackPrimaryText], NSFontAttributeName: [UIFont medium17]};
-  }
-  return _etaAttributes;
-}
-
-- (NSDictionary *)etaSecondaryAttributes {
-  if (!_etaSecondaryAttributes) {
-    _etaSecondaryAttributes =
-      @{NSForegroundColorAttributeName: [UIColor blackSecondaryText], NSFontAttributeName: [UIFont medium17]};
-  }
-  return _etaSecondaryAttributes;
-}
-
 - (void)setState:(MWMNavigationDashboardState)state {
   if (state == MWMNavigationDashboardStateHidden)
     [MWMSearchManager removeObserver:self];

--- a/iphone/Maps/Classes/CustomViews/NavigationDashboard/Views/RoutePreview/RoutePreviewStatus/BaseRoutePreviewStatus.swift
+++ b/iphone/Maps/Classes/CustomViews/NavigationDashboard/Views/RoutePreview/RoutePreviewStatus/BaseRoutePreviewStatus.swift
@@ -92,6 +92,7 @@ final class BaseRoutePreviewStatus: SolidTouchView {
     super.traitCollectionDidChange(previousTraitCollection)
     updateManageRouteVisibility()
     updateHeight()
+    updateResultsLabel()
   }
 
   private func updateManageRouteVisibility() {
@@ -140,7 +141,7 @@ final class BaseRoutePreviewStatus: SolidTouchView {
   private func updateResultsLabel() {
     guard let info = navigationInfo else { return }
 
-    if let result = info.estimate.mutableCopy() as? NSMutableAttributedString {
+    if let result = info.estimate().mutableCopy() as? NSMutableAttributedString {
       if let elevation = self.elevation {
         result.append(MWMNavigationDashboardEntity.estimateDot())
         result.append(elevation)

--- a/iphone/Maps/Classes/CustomViews/NavigationDashboard/Views/RoutePreview/RoutePreviewStatus/TransportRoutePreviewStatus.swift
+++ b/iphone/Maps/Classes/CustomViews/NavigationDashboard/Views/RoutePreview/RoutePreviewStatus/TransportRoutePreviewStatus.swift
@@ -43,11 +43,11 @@ final class TransportRoutePreviewStatus: SolidTouchView {
     navigationInfo = info
     if (prependDistance) {
       let labelText = NSMutableAttributedString(string: NSLocalizedString("placepage_distance", comment: "") + ": ")
-      labelText.append(info.estimate)
+      labelText.append(info.estimate())
       etaLabel.attributedText = labelText
     }
     else {
-      etaLabel.attributedText = info.estimate
+      etaLabel.attributedText = info.estimate()
     }
     stepsCollectionView.steps = info.transitSteps
 


### PR DESCRIPTION
Fix https://github.com/organicmaps/organicmaps/pull/7292

When the app appearance is changed and the route preview screen is active the estimates colors are not changed properly:

<img src="https://github.com/organicmaps/organicmaps/assets/79797627/4e48d42d-bc08-4465-b73b-d4ee20956c71" width="200">
<img src="https://github.com/organicmaps/organicmaps/assets/79797627/dfa2bba3-84f9-4f21-a7bb-636bf59b194c" width="200">
<img src="https://github.com/organicmaps/organicmaps/assets/79797627/1c2dd660-3a45-4d03-ba8c-5946285348a8" width="200">


### Issue:
This happens because `estimates` is a stored property (of `MWMNavigationDashboardEntity` class) of the `NSAttributedString` type that is built during initialization and cannot be changed dynamically to react to the theme changes.

`@property(copy, nonatomic, readonly) NSAttributedString *estimate;`
```objc
 entity.estimate =
      estimate(info.m_totalTimeInSec, @(info.m_totalPedestrianDistanceStr.c_str()),
               @(info.m_totalPedestrianUnitsSuffix.c_str()), self.etaAttributes, self.etaSecondaryAttributes, YES, YES);

NSAttributedString *estimate(NSTimeInterval time, NSString *distance, NSString *distanceUnits,
                             NSDictionary *primaryAttributes, NSDictionary *secondaryAttributes, BOOL isWalk, BOOL showEta) {
  auto result = [[NSMutableAttributedString alloc] initWithString:@""];
  if (showEta) {
    NSString *eta = [NSDateComponentsFormatter etaStringFrom:time];
    [result appendAttributedString:[[NSMutableAttributedString alloc] initWithString:eta attributes:primaryAttributes]];
    [result appendAttributedString:MWMNavigationDashboardEntity.estimateDot];
  }

  if (isWalk) {
    UIFont *font = primaryAttributes[NSFontAttributeName];
    auto textAttachment = [[NSTextAttachment alloc] init];
    auto image = [UIImage imageNamed:@"ic_walk"];
    textAttachment.image = image;
    auto const height = font.lineHeight;
    auto const y = height - image.size.height;
    auto const width = image.size.width * height / image.size.height;
    textAttachment.bounds = CGRectIntegral({{0, y}, {width, height}});

    NSMutableAttributedString *attrStringWithImage =
      [NSAttributedString attributedStringWithAttachment:textAttachment].mutableCopy;
...

```

### Solution
There is no reason to store such complex NSAttributedString in the instance. 
The logic was moved into the instance method to get string only if it is needed. And when theme is changing attr strinl will be rebuilt with proper colors and formatting.

Result:

![Simulator Screen Recording - iPhone 15 Pro - 2024-02-07 at 14 21 09](https://github.com/organicmaps/organicmaps/assets/79797627/64b51b04-e8ee-416c-b04b-d36679888854)
