### PR TITLE
[android] remove long press to copy for some fields

### DIFF
--- a/android/app/src/main/java/app/organicmaps/widget/placepage/PlacePageView.java
+++ b/android/app/src/main/java/app/organicmaps/widget/placepage/PlacePageView.java
@@ -234,7 +234,6 @@ public class PlacePageView extends Fragment implements View.OnClickListener,
     mWifi = mFrame.findViewById(R.id.ll__place_wifi);
     mTvWiFi = mFrame.findViewById(R.id.tv__place_wifi);
     mOperator = mFrame.findViewById(R.id.ll__place_operator);
-    mOperator.setOnClickListener(this);
     mTvOperator = mFrame.findViewById(R.id.tv__place_operator);
     mLevel = mFrame.findViewById(R.id.ll__place_level);
     mTvLevel = mFrame.findViewById(R.id.tv__place_level);
@@ -257,11 +256,6 @@ public class PlacePageView extends Fragment implements View.OnClickListener,
     mEditTopSpace = mFrame.findViewById(R.id.edit_top_space);
     latlon.setOnLongClickListener(this);
     address.setOnLongClickListener(this);
-    mOperator.setOnLongClickListener(this);
-    mLevel.setOnLongClickListener(this);
-    mAtm.setOnLongClickListener(this);
-    mCapacity.setOnLongClickListener(this);
-    mWheelchair.setOnLongClickListener(this);
 
     mDownloaderIcon = new DownloaderStatusIcon(mPreview.findViewById(R.id.downloader_status_frame));
 


### PR DESCRIPTION
no reason to have an onLongClickListener for these, currently a long-press just copies the value (eg. '-1' for level, 'Full Wheelchair Access' for wheelchair etc.)  which is kinda useless.
