### PR TITLE
Add main type to search description and remove duplicate type

### DIFF
--- a/indexer/feature_utils.hpp
+++ b/indexer/feature_utils.hpp
@@ -8,6 +8,8 @@ class StringUtf8Multilang;
 
 namespace feature
 {
+  static constexpr std::string_view kFieldsSeparator = " • ";
+
   // Address house numbers interpolation.
   enum class InterpolType { None, Odd, Even, Any };
 

--- a/indexer/map_object.cpp
+++ b/indexer/map_object.cpp
@@ -181,12 +181,12 @@ bool MapObject::HasToilets() const
 
 string MapObject::FormatCuisines() const
 {
-  return strings::JoinStrings(GetLocalizedCuisines(), kFieldsSeparator);
+  return strings::JoinStrings(GetLocalizedCuisines(), feature::kFieldsSeparator);
 }
 
 string MapObject::FormatRoadShields() const
 {
-  return strings::JoinStrings(m_roadShields, kFieldsSeparator);
+  return strings::JoinStrings(m_roadShields, feature::kFieldsSeparator);
 }
 
 int MapObject::GetStars() const

--- a/indexer/map_object.hpp
+++ b/indexer/map_object.hpp
@@ -33,7 +33,6 @@ Internet InternetFromString(std::string_view inet);
 class MapObject
 {
 public:
-  static constexpr std::string_view kFieldsSeparator = " • ";
   static constexpr std::string_view kStarSymbol = "★";
   static constexpr std::string_view kToiletsSymbol = "🚻";
   static constexpr uint8_t kMaxStarsCount = 7;

--- a/iphone/Maps/UI/Search/TableView/MWMSearchCommonCell.xib
+++ b/iphone/Maps/UI/Search/TableView/MWMSearchCommonCell.xib
@@ -123,7 +123,7 @@
                     <constraint firstItem="HGm-lZ-JNr" firstAttribute="leading" secondItem="H2p-sc-9uM" secondAttribute="leading" constant="16" id="sq9-C3-M3R"/>
                     <constraint firstAttribute="bottom" secondItem="HGm-lZ-JNr" secondAttribute="bottom" id="vJc-aE-MsA"/>
                     <constraint firstAttribute="trailing" secondItem="SDd-3c-YeL" secondAttribute="trailing" constant="16" id="vay-ux-6dA"/>
-                    <constraint firstItem="SDd-3c-YeL" firstAttribute="top" secondItem="5UO-MD-Hgx" secondAttribute="top" id="wXg-ce-SnG"/>
+                    <constraint firstItem="SDd-3c-YeL" firstAttribute="bottom" secondItem="5UO-MD-Hgx" secondAttribute="bottom" id="wXg-ce-SnG"/>
                     <constraint firstAttribute="trailing" secondItem="HGm-lZ-JNr" secondAttribute="trailing" id="xt0-86-Efu"/>
                 </constraints>
             </tableViewCellContentView>

--- a/map/framework.cpp
+++ b/map/framework.cpp
@@ -2666,7 +2666,7 @@ bool Framework::ParseEditorDebugCommand(search::SearchParams const & params)
 
       search::Result res(feature::GetCenter(*ft), string(ft->GetReadableName()));
       res.SetAddress(std::move(edit.second));
-      res.FromFeature(fid, feature::TypesHolder(*ft).GetBestType(), {});
+      res.FromFeature(fid, feature::TypesHolder(*ft).GetBestType(), 0, {});
 
       results.AddResultNoChecks(std::move(res));
     }

--- a/map/place_page_info.cpp
+++ b/map/place_page_info.cpp
@@ -115,7 +115,7 @@ std::string Info::FormatSubtitle(bool withType) const
   auto const append = [&result](std::string_view sv)
   {
     if (!result.empty())
-      result += kFieldsSeparator;
+      result += feature::kFieldsSeparator;
     result += sv;
   };
 
@@ -226,7 +226,7 @@ void Info::SetTitlesForBookmark()
   subtitle.push_back(m_bookmarkCategoryName);
   if (!m_bookmarkData.m_featureTypes.empty())
     subtitle.push_back(GetLocalizedFeatureType(m_bookmarkData.m_featureTypes));
-  m_uiSubtitle = strings::JoinStrings(subtitle, kFieldsSeparator);
+  m_uiSubtitle = strings::JoinStrings(subtitle, feature::kFieldsSeparator);
 }
 
 void Info::SetCustomName(std::string const & name)
@@ -370,7 +370,7 @@ void Info::SetRoadType(FeatureType & ft, RoadWarningMarkType type, std::string c
   {
     if (!m_uiTitle.empty())
     {
-      m_uiTitle += kFieldsSeparator;
+      m_uiTitle += feature::kFieldsSeparator;
       m_uiTitle += str;
     }
     else
@@ -380,7 +380,7 @@ void Info::SetRoadType(FeatureType & ft, RoadWarningMarkType type, std::string c
   auto const addSubtitle = [this](std::string_view sv)
   {
     if (!m_uiSubtitle.empty())
-      m_uiSubtitle += kFieldsSeparator;
+      m_uiSubtitle += feature::kFieldsSeparator;
     m_uiSubtitle += sv;
   };
 

--- a/search/intermediate_result.cpp
+++ b/search/intermediate_result.cpp
@@ -295,29 +295,29 @@ void FillDetails(FeatureType & ft, Result::Details & details)
     stars.append(osm::MapObject::kStarSymbol);
 
   auto const cuisines = feature::GetLocalizedCuisines(typesHolder);
-  auto const cuisine = strings::JoinStrings(cuisines, osm::MapObject::kFieldsSeparator);
+  auto const cuisine = strings::JoinStrings(cuisines, feature::kFieldsSeparator);
 
   auto const roadShields = ftypes::GetRoadShieldsNames(ft);
-  auto const roadShield = strings::JoinStrings(roadShields, osm::MapObject::kFieldsSeparator);
+  auto const roadShield = strings::JoinStrings(roadShields, feature::kFieldsSeparator);
 
   auto const fee = feature::GetLocalizedFeeType(typesHolder);
     
   std::string description;
   
   if (!stars.empty())
-    description.append(osm::MapObject::kFieldsSeparator).append(stars);
+    description.append(feature::kFieldsSeparator).append(stars);
   if (!airportIata.empty())
-    description.append(osm::MapObject::kFieldsSeparator).append(airportIata);
+    description.append(feature::kFieldsSeparator).append(airportIata);
   if (!roadShield.empty())
-    description.append(osm::MapObject::kFieldsSeparator).append(roadShield);
+    description.append(feature::kFieldsSeparator).append(roadShield);
   if (!brand.empty())
-    description.append(osm::MapObject::kFieldsSeparator).append(brand);
+    description.append(feature::kFieldsSeparator).append(brand);
   if (!cuisine.empty())
-    description.append(osm::MapObject::kFieldsSeparator).append(cuisine);
+    description.append(feature::kFieldsSeparator).append(cuisine);
   if (feature::HasToilets(typesHolder))
-    description.append(osm::MapObject::kFieldsSeparator).append(osm::MapObject::kToiletsSymbol);
+    description.append(feature::kFieldsSeparator).append(osm::MapObject::kToiletsSymbol);
   if (!fee.empty())
-    description.append(osm::MapObject::kFieldsSeparator).append(fee);
+    description.append(feature::kFieldsSeparator).append(fee);
   
   details.m_description = std::move(description);
 

--- a/search/intermediate_result.cpp
+++ b/search/intermediate_result.cpp
@@ -301,23 +301,24 @@ void FillDetails(FeatureType & ft, Result::Details & details)
   auto const roadShield = strings::JoinStrings(roadShields, feature::kFieldsSeparator);
 
   auto const fee = feature::GetLocalizedFeeType(typesHolder);
-    
+
   std::string description;
+
+  auto const append = [&description](std::string_view sv)
+  {
+    if (sv.empty())
+      return;
+    if (!description.empty())
+      description += feature::kFieldsSeparator;
+    description += sv;
+  };
   
-  if (!stars.empty())
-    description.append(feature::kFieldsSeparator).append(stars);
-  if (!airportIata.empty())
-    description.append(feature::kFieldsSeparator).append(airportIata);
-  if (!roadShield.empty())
-    description.append(feature::kFieldsSeparator).append(roadShield);
-  if (!brand.empty())
-    description.append(feature::kFieldsSeparator).append(brand);
-  if (!cuisine.empty())
-    description.append(feature::kFieldsSeparator).append(cuisine);
-  if (feature::HasToilets(typesHolder))
-    description.append(feature::kFieldsSeparator).append(osm::MapObject::kToiletsSymbol);
-  if (!fee.empty())
-    description.append(feature::kFieldsSeparator).append(fee);
+  append(stars);
+  append(airportIata);
+  append(roadShield);
+  append(brand);
+  append(cuisine);
+  append(fee);
   
   details.m_description = std::move(description);
 

--- a/search/ranker.cpp
+++ b/search/ranker.cpp
@@ -727,7 +727,7 @@ Result Ranker::MakeResult(RankerResult const & rankerResult, bool needAddress, b
   {
   case RankerResult::Type::Feature:
   case RankerResult::Type::Building:
-    res.FromFeature(rankerResult.GetID(), rankerResult.GetBestType(&m_params.m_preferredTypes), rankerResult.m_details);
+    res.FromFeature(rankerResult.GetID(), rankerResult.GetBestType(), rankerResult.GetBestType(&m_params.m_preferredTypes), rankerResult.m_details);
     break;
   case RankerResult::Type::LatLon: res.SetType(Result::Type::LatLon); break;
   case RankerResult::Type::Postcode: res.SetType(Result::Type::Postcode); break;

--- a/search/result.cpp
+++ b/search/result.cpp
@@ -4,6 +4,7 @@
 #include "search/geometry_utils.hpp"
 
 #include "indexer/classificator.hpp"
+#include "indexer/feature_utils.hpp"
 
 #include "platform/localization.hpp"
 
@@ -75,7 +76,21 @@ std::string Result::GetLocalizedFeatureType() const
 std::string Result::GetFeatureDescription() const
 {
   ASSERT_EQUAL(m_resultType, Type::Feature, ());
-  return GetLocalizedFeatureType() + GetDescription();
+  std::string featureDescription;
+  
+  auto const append = [&featureDescription](std::string_view sv)
+  {
+    if (!featureDescription.empty())
+      featureDescription += feature::kFieldsSeparator;
+    featureDescription += sv;
+  };
+  
+  append(GetLocalizedFeatureType());
+  
+  if (!GetDescription().empty())
+    append(GetDescription());
+  
+  return featureDescription;
 }
 
 m2::PointD Result::GetFeatureCenter() const

--- a/search/result.cpp
+++ b/search/result.cpp
@@ -18,11 +18,12 @@ namespace search
 {
 using namespace std;
 
-void Result::FromFeature(FeatureID const & id, uint32_t featureType, Details const & details)
+void Result::FromFeature(FeatureID const & id, uint32_t mainType, uint32_t featureType, Details const & details)
 {
   m_id = id;
   ASSERT(m_id.IsValid(), ());
 
+  m_mainType = mainType;
   m_featureType = featureType;
   m_details = details;
   m_resultType = Type::Feature;
@@ -64,7 +65,7 @@ FeatureID const & Result::GetFeatureID() const
 uint32_t Result::GetFeatureType() const
 {
   ASSERT_EQUAL(m_resultType, Type::Feature, ());
-  return m_featureType;
+  return m_mainType;
 }
 
 std::string GetLocalizedTypeName(uint32_t type)
@@ -75,7 +76,7 @@ std::string GetLocalizedTypeName(uint32_t type)
 std::string Result::GetLocalizedFeatureType() const
 {
   ASSERT_EQUAL(m_resultType, Type::Feature, ());
-  return GetLocalizedTypeName(m_featureType);
+  return GetLocalizedTypeName(m_mainType);
 }
 
 std::string Result::GetFeatureDescription() const
@@ -90,7 +91,10 @@ std::string Result::GetFeatureDescription() const
     featureDescription += sv;
   };
   
-  append(GetLocalizedTypeName(m_featureType));
+  append(GetLocalizedTypeName(m_mainType));
+  
+  if (m_mainType != m_featureType && m_featureType != 0)
+    append(GetLocalizedTypeName(m_featureType));
   
   if (!GetDescription().empty())
     append(GetDescription());

--- a/search/result.cpp
+++ b/search/result.cpp
@@ -67,10 +67,15 @@ uint32_t Result::GetFeatureType() const
   return m_featureType;
 }
 
+std::string GetLocalizedTypeName(uint32_t type)
+{
+  return platform::GetLocalizedTypeName(classif().GetReadableObjectName(type));
+}
+
 std::string Result::GetLocalizedFeatureType() const
 {
   ASSERT_EQUAL(m_resultType, Type::Feature, ());
-  return platform::GetLocalizedTypeName(classif().GetReadableObjectName(m_featureType));
+  return GetLocalizedTypeName(m_featureType);
 }
 
 std::string Result::GetFeatureDescription() const
@@ -85,7 +90,7 @@ std::string Result::GetFeatureDescription() const
     featureDescription += sv;
   };
   
-  append(GetLocalizedFeatureType());
+  append(GetLocalizedTypeName(m_featureType));
   
   if (!GetDescription().empty())
     append(GetDescription());

--- a/search/result.cpp
+++ b/search/result.cpp
@@ -91,7 +91,8 @@ std::string Result::GetFeatureDescription() const
     featureDescription += sv;
   };
   
-  append(GetLocalizedTypeName(m_mainType));
+  if (!m_str.empty())
+    append(GetLocalizedTypeName(m_mainType));
   
   if (m_mainType != m_featureType && m_featureType != 0)
     append(GetLocalizedTypeName(m_featureType));

--- a/search/result.hpp
+++ b/search/result.hpp
@@ -59,7 +59,7 @@ public:
   static auto constexpr kPopularityHighPriorityMinDistance = 50000.0;
 
   Result(m2::PointD const & pt, std::string const & name) : m_center(pt), m_str(name) {}
-  void FromFeature(FeatureID const & id, uint32_t featureType, Details const & details);
+  void FromFeature(FeatureID const & id, uint32_t mainType, uint32_t featureType, Details const & details);
 
   void SetAddress(std::string && address) { m_address = std::move(address); }
   void SetType(Result::Type type) { m_resultType = type; }
@@ -148,6 +148,7 @@ private:
   m2::PointD m_center;
   std::string m_str;
   std::string m_address;
+  uint32_t m_mainType = 0;
   uint32_t m_featureType = 0;
   std::string m_suggestionStr;
   buffer_vector<std::pair<uint16_t, uint16_t>, 4> m_hightlightRanges;

--- a/search/result.hpp
+++ b/search/result.hpp
@@ -59,7 +59,7 @@ public:
   static auto constexpr kPopularityHighPriorityMinDistance = 50000.0;
 
   Result(m2::PointD const & pt, std::string const & name) : m_center(pt), m_str(name) {}
-  void FromFeature(FeatureID const & id, uint32_t mainType, uint32_t featureType, Details const & details);
+  void FromFeature(FeatureID const & id, uint32_t mainType, uint32_t matchedType, Details const & details);
 
   void SetAddress(std::string && address) { m_address = std::move(address); }
   void SetType(Result::Type type) { m_resultType = type; }
@@ -149,7 +149,7 @@ private:
   std::string m_str;
   std::string m_address;
   uint32_t m_mainType = 0;
-  uint32_t m_featureType = 0;
+  uint32_t m_matchedType = 0;
   std::string m_suggestionStr;
   buffer_vector<std::pair<uint16_t, uint16_t>, 4> m_hightlightRanges;
 

--- a/search/search_tests/results_tests.cpp
+++ b/search/search_tests/results_tests.cpp
@@ -18,7 +18,7 @@ UNIT_TEST(Results_Sorting)
   for (uint32_t i = 5; i != 0; --i)
   {
     search::Result res(m2::PointD::Zero(), {});
-    res.FromFeature({id, i}, 0, {});
+    res.FromFeature({id, i}, 0, 0, {});
     r.AddResultNoChecks(std::move(res));
   }
 


### PR DESCRIPTION
In this PR:
* Add the main type (Restaurant, petrol station, bank...) of a search result when searching for a minor type (Toilets, compressed air, ATM...).
* Remove the duplicated type from the description when it is already shown in the title.

--

* Fixes https://github.com/organicmaps/organicmaps/issues/1648

-- 

Before/After:

<img src="https://github.com/organicmaps/organicmaps/assets/47610359/c37ec5f4-b41c-4319-868f-b3c06e8d4953" width="320"/> <img src="https://github.com/organicmaps/organicmaps/assets/47610359/d3adf1af-48de-4e29-87dd-da5b245386e6" width="320"/>
<img src="https://github.com/organicmaps/organicmaps/assets/47610359/b0b7fb31-3fe3-4bef-9133-27ae139d93b2" width="320"/> <img src="https://github.com/organicmaps/organicmaps/assets/47610359/dd45de2e-f6fc-4f3e-b6d2-68df9dff36d9" width="320"/>
<img src="https://github.com/organicmaps/organicmaps/assets/47610359/e8cdced0-3a16-443c-9ad0-56a0798db0a1" width="320"/> <img src="https://github.com/organicmaps/organicmaps/assets/47610359/5ebfe1d0-e0d4-45df-a859-8d9666fe98c3" width="320"/>


