### PR TITLE
[android] Support ACTION_SEND_MULTIPLE

### DIFF
--- a/android/app/src/main/AndroidManifest.xml
+++ b/android/app/src/main/AndroidManifest.xml
@@ -155,6 +155,7 @@
 
       <intent-filter>
         <action android:name="android.intent.action.SEND"/>
+        <action android:name="android.intent.action.SEND_MULTIPLE"/>
         <category android:name="android.intent.category.DEFAULT"/>
         <data android:mimeType="application/vnd.google-earth.kml+xml"/>
         <data android:mimeType="application/vnd.google-earth.kmz"/>

--- a/android/app/src/main/java/app/organicmaps/bookmarks/data/BookmarkManager.java
+++ b/android/app/src/main/java/app/organicmaps/bookmarks/data/BookmarkManager.java
@@ -494,6 +494,13 @@ public enum BookmarkManager
     return true;
   }
 
+  @WorkerThread
+  public void importBookmarksFiles(@NonNull ContentResolver resolver, @NonNull List<Uri> uris, @NonNull File tempDir)
+  {
+    for (Uri uri: uris)
+      importBookmarksFile(resolver, uri, tempDir);
+  }
+
   public boolean isAsyncBookmarksLoadingInProgress()
   {
     return nativeIsAsyncBookmarksLoadingInProgress();


### PR DESCRIPTION
Tested with Google Drive.

GPS Logger and Samsung Files are not supported because they don't set mime-type. Changing mimtType to "*/*" fixes the issue, but makes the app default handler for any files, which is annoying.

```
<intent-filter>
  <action android:name="android.intent.action.SEND_MULTIPLE"/>
  <category android:name="android.intent.category.DEFAULT"/>
 <data android:mimeType="*/*"/>
</intent-filter>
```

Closes #5402