### PR TITLE
[android] Make Web-Release icon color distinguishable from Google-Release

### DIFF
--- a/android/app/src/webRelease/res/values/colors.xml
+++ b/android/app/src/webRelease/res/values/colors.xml
@@ -1,0 +1,5 @@
+<?xml version="1.0" encoding="utf-8"?>
+<resources>
+  <!-- Make Web-Release icon color distinguishable from Google-Release. //-->
+  <color name="logo">#209852</color>
+</resources>


### PR DESCRIPTION
Since #7359 Web-Release can be installed alongside Google-Release. Change the icon color for Web-Release to be distinguishable.

![image](https://github.com/organicmaps/organicmaps/assets/1799054/f4a50bd6-ffab-4236-aeac-23f100b2fa0a)
