### PR TITLE
[ios] Change the views rounded corners to the superellipses

### DIFF
--- a/iphone/DatePicker/DatePicker/Cells/RangeFirstCell.swift
+++ b/iphone/DatePicker/DatePicker/Cells/RangeFirstCell.swift
@@ -7,6 +7,9 @@ final class RangeFirstCell: Cell {
     contentView.addSubview(rangeBgView)
     rangeBgView.alignToSuperview(UIEdgeInsets(top: 4, left: 4, bottom: -4, right: 0))
     rangeBgView.layer.cornerRadius = 8
+    if #available(iOS 13.0, *) {
+      rangeBgView.layer.cornerCurve = .continuous
+    }
     rangeBgView.layer.maskedCorners = [.layerMinXMinYCorner, .layerMinXMaxYCorner]
     super.addSubviews()
   }

--- a/iphone/DatePicker/DatePicker/Cells/RangeLastCell.swift
+++ b/iphone/DatePicker/DatePicker/Cells/RangeLastCell.swift
@@ -7,6 +7,9 @@ final class RangeLastCell: Cell {
     contentView.addSubview(rangeBgView)
     rangeBgView.alignToSuperview(UIEdgeInsets(top: 4, left: 0, bottom: -4, right: -4))
     rangeBgView.layer.cornerRadius = 8
+    if #available(iOS 13.0, *) {
+      rangeBgView.layer.cornerCurve = .continuous
+    }
     rangeBgView.layer.maskedCorners = [.layerMaxXMinYCorner, .layerMaxXMaxYCorner]
     super.addSubviews()
   }

--- a/iphone/DatePicker/DatePicker/Cells/RangeSingleCell.swift
+++ b/iphone/DatePicker/DatePicker/Cells/RangeSingleCell.swift
@@ -7,6 +7,9 @@ final class RangeSingleCell: Cell {
     contentView.addSubview(rangeBgView)
     rangeBgView.alignToSuperview(UIEdgeInsets(top: 4, left: 4, bottom: -4, right: -4))
     rangeBgView.layer.cornerRadius = 8
+    if #available(iOS 13.0, *) {
+      rangeBgView.layer.cornerCurve = .continuous
+    }
     super.addSubviews()
   }
 

--- a/iphone/DatePicker/DatePicker/Cells/SelectedSingleCell.swift
+++ b/iphone/DatePicker/DatePicker/Cells/SelectedSingleCell.swift
@@ -7,6 +7,9 @@ class SelectedSingleCell: Cell {
     contentView.addSubview(selectedBgView)
     selectedBgView.alignToSuperview(UIEdgeInsets(top: 4, left: 4, bottom: -4, right: -4))
     selectedBgView.layer.cornerRadius = 8
+    if #available(iOS 13.0, *) {
+      selectedBgView.layer.cornerCurve = .continuous
+    }
     super.addSubviews()
   }
 

--- a/iphone/Maps/Categories/CALayer+SetCorner.swift
+++ b/iphone/Maps/Categories/CALayer+SetCorner.swift
@@ -1,0 +1,13 @@
+extension CALayer {
+  func setCorner(radius: CGFloat,
+                 curve: CALayerCornerCurve? = nil,
+                 corners: CACornerMask? = nil) {
+    cornerRadius = radius
+    if let corners {
+      maskedCorners = corners
+    }
+    if #available(iOS 13.0, *) {
+      cornerCurve = curve ?? .continuous
+    }
+  }
+}

--- a/iphone/Maps/Categories/UIView+Snapshot.swift
+++ b/iphone/Maps/Categories/UIView+Snapshot.swift
@@ -13,7 +13,7 @@ extension UIView {
       snapshot.layer.contents = contents
       snapshot.layer.bounds = layer.bounds
     }
-    snapshot.layer.cornerRadius = layer.cornerRadius
+    snapshot.layer.setCorner(radius: layer.cornerRadius)
     snapshot.layer.masksToBounds = layer.masksToBounds
     snapshot.contentMode = contentMode
     snapshot.transform = transform

--- a/iphone/Maps/Classes/Components/Modal/AlertPresentationController.swift
+++ b/iphone/Maps/Classes/Components/Modal/AlertPresentationController.swift
@@ -8,7 +8,7 @@ final class AlertPresentationController: DimmedModalPresentationController {
 
   override func presentationTransitionWillBegin() {
     super.presentationTransitionWillBegin()
-    presentedViewController.view.layer.cornerRadius = 12
+    presentedViewController.view.layer.setCorner(radius: 12)
     presentedViewController.view.clipsToBounds = true
     guard let containerView = containerView, let presentedView = presentedView else { return }
     containerView.addSubview(presentedView)

--- a/iphone/Maps/Classes/Components/Modal/IPadModalPresentationController.swift
+++ b/iphone/Maps/Classes/Components/Modal/IPadModalPresentationController.swift
@@ -17,7 +17,7 @@ override var frameOfPresentedViewInContainerView: CGRect {
 
   override func presentationTransitionWillBegin() {
     super.presentationTransitionWillBegin()
-    presentedViewController.view.layer.cornerRadius = 8
+    presentedViewController.view.layer.setCorner(radius: 8)
     presentedViewController.view.clipsToBounds = true
     guard let containerView = containerView, let presentedView = presentedView else { return }
     containerView.addSubview(presentedView)

--- a/iphone/Maps/Classes/Components/Modal/PromoBookingPresentationController.swift
+++ b/iphone/Maps/Classes/Components/Modal/PromoBookingPresentationController.swift
@@ -16,7 +16,7 @@ final class PromoBookingPresentationController: DimmedModalPresentationControlle
   
   override func presentationTransitionWillBegin() {
     super.presentationTransitionWillBegin()
-    presentedViewController.view.layer.cornerRadius = 8
+    presentedViewController.view.layer.setCorner(radius: 8)
     presentedViewController.view.clipsToBounds = true
     guard let containerView = containerView, let presentedView = presentedView else { return } 
     containerView.addSubview(presentedView)

--- a/iphone/Maps/Classes/CustomAlert/Toast/Toast.swift
+++ b/iphone/Maps/Classes/CustomAlert/Toast/Toast.swift
@@ -13,7 +13,7 @@ final class Toast: NSObject {
   }
 
   private init(_ text: String) {
-    blurView.layer.cornerRadius = 8
+    blurView.layer.setCorner(radius: 8)
     blurView.clipsToBounds = true
     blurView.alpha = 0
 

--- a/iphone/Maps/Classes/CustomViews/NavigationDashboard/Views/MWMNavigationInfoView.mm
+++ b/iphone/Maps/Classes/CustomViews/NavigationDashboard/Views/MWMNavigationInfoView.mm
@@ -365,6 +365,9 @@ BOOL defaultOrientation(CGSize const &size) {
         (defaultOrientation(availableArea.size) ? kSearchButtonsViewHeightPortrait
                                                 : kSearchButtonsViewHeightLandscape) /
         2;
+      if (@available(iOS 13.0, *)) {
+        self.searchButtonsView.layer.cornerCurve = kCACornerCurveContinuous;
+      }
       self.streetNameTopOffsetConstraint.constant = self.additionalStreetNameTopOffset;
     }];
   });

--- a/iphone/Maps/Classes/CustomViews/NavigationDashboard/Views/RoutePreview/RoutePreviewStatus/TransportTransitSteps/TransportRuler.swift
+++ b/iphone/Maps/Classes/CustomViews/NavigationDashboard/Views/RoutePreview/RoutePreviewStatus/TransportTransitSteps/TransportRuler.swift
@@ -10,7 +10,7 @@ final class TransportRuler: TransportTransitCell {
 
   @IBOutlet private weak var background: UIView! {
     didSet {
-      background.layer.cornerRadius = Config.backgroundCornerRadius
+      background.layer.setCorner(radius: Config.backgroundCornerRadius)
       background.backgroundColor = Config.backgroundColor
     }
   }

--- a/iphone/Maps/Classes/CustomViews/NavigationDashboard/Views/RoutePreview/RoutePreviewStatus/TransportTransitSteps/TransportTransitPedestrian.swift
+++ b/iphone/Maps/Classes/CustomViews/NavigationDashboard/Views/RoutePreview/RoutePreviewStatus/TransportTransitSteps/TransportTransitPedestrian.swift
@@ -7,7 +7,7 @@ final class TransportTransitPedestrian: TransportTransitCell {
 
   @IBOutlet private weak var background: UIView! {
     didSet {
-      background.layer.cornerRadius = Config.backgroundCornerRadius
+      background.layer.setCorner(radius: Config.backgroundCornerRadius)
       background.backgroundColor = Config.backgroundColor
     }
   }

--- a/iphone/Maps/Classes/CustomViews/NavigationDashboard/Views/RoutePreview/RoutePreviewStatus/TransportTransitSteps/TransportTransitTrain.swift
+++ b/iphone/Maps/Classes/CustomViews/NavigationDashboard/Views/RoutePreview/RoutePreviewStatus/TransportTransitSteps/TransportTransitTrain.swift
@@ -8,7 +8,7 @@ final class TransportTransitTrain: TransportTransitCell {
 
   @IBOutlet private weak var background: UIView! {
     didSet {
-      background.layer.cornerRadius = Config.backgroundCornerRadius
+      background.layer.setCorner(radius: Config.backgroundCornerRadius)
     }
   }
 

--- a/iphone/Maps/Core/Theme/Renderers/UISearchBarRenderer.swift
+++ b/iphone/Maps/Core/Theme/Renderers/UISearchBarRenderer.swift
@@ -27,7 +27,6 @@ class UISearchBarRenderer: UIViewRenderer {
     var searchTextField: UITextField?
     if #available(iOS 13, *) {
       searchTextField = control.searchTextField
-      control.searchTextField.layer.cornerCurve = .continuous
     }
     
     // Default search bar implementation adds the grey transparent image for background. This code removes it and updates the corner radius. This is not working on iPad designed for mac.
@@ -35,8 +34,7 @@ class UISearchBarRenderer: UIViewRenderer {
     } else {
       control.setSearchFieldBackgroundImage(UIImage(), for: .normal)
     }
-    
-    searchTextField?.layer.cornerRadius = 8
+    searchTextField?.layer.setCorner(radius: 8)
     searchTextField?.layer.masksToBounds = true
 
     // Placeholder color

--- a/iphone/Maps/Core/Theme/Renderers/UITextFieldRenderer.swift
+++ b/iphone/Maps/Core/Theme/Renderers/UITextFieldRenderer.swift
@@ -20,11 +20,8 @@ extension UITextField {
 class UITextFieldRenderer {
   class func render(_ control: UITextField, style: Style) {
     if let cornerRadius = style.cornerRadius {
-      control.layer.cornerRadius = cornerRadius
+      control.layer.setCorner(radius: cornerRadius)
       control.clipsToBounds = true
-      if #available(iOS 13.0, *) {
-        control.layer.cornerCurve = .continuous
-      }
     }
     control.borderStyle = .none
     var placeholderAttributes = [NSAttributedString.Key : Any]()

--- a/iphone/Maps/Core/Theme/Renderers/UIViewRenderer.swift
+++ b/iphone/Maps/Core/Theme/Renderers/UIViewRenderer.swift
@@ -54,5 +54,8 @@ class UIViewRenderer {
     if let round = style.round, round == true {
       control.layer.cornerRadius = control.size.height / 2
     }
+    if #available(iOS 13.0, *) {
+      control.layer.cornerCurve = .continuous
+    }
   }
 }

--- a/iphone/Maps/Maps.xcodeproj/project.pbxproj
+++ b/iphone/Maps/Maps.xcodeproj/project.pbxproj
@@ -467,6 +467,7 @@
 		ED3EAC202B03C88100220A4A /* BottomTabBarButton.swift in Sources */ = {isa = PBXBuildFile; fileRef = ED3EAC1F2B03C88100220A4A /* BottomTabBarButton.swift */; };
 		EDBD68072B625724005DD151 /* LocationServicesDisabledAlert.xib in Resources */ = {isa = PBXBuildFile; fileRef = EDBD68062B625724005DD151 /* LocationServicesDisabledAlert.xib */; };
 		EDBD680B2B62572E005DD151 /* LocationServicesDisabledAlert.swift in Sources */ = {isa = PBXBuildFile; fileRef = EDBD680A2B62572E005DD151 /* LocationServicesDisabledAlert.swift */; };
+		EDC3573B2B7B5029001AE9CA /* CALayer+SetCorner.swift in Sources */ = {isa = PBXBuildFile; fileRef = EDC3573A2B7B5029001AE9CA /* CALayer+SetCorner.swift */; };
 		F607C1881C032A8800B53A87 /* resources-hdpi_clear in Resources */ = {isa = PBXBuildFile; fileRef = F607C1831C032A8800B53A87 /* resources-hdpi_clear */; };
 		F607C18A1C032A8800B53A87 /* resources-hdpi_dark in Resources */ = {isa = PBXBuildFile; fileRef = F607C1841C032A8800B53A87 /* resources-hdpi_dark */; };
 		F623DA6C1C9C2731006A3436 /* opening_hours_how_to_edit.html in Resources */ = {isa = PBXBuildFile; fileRef = F623DA6A1C9C2731006A3436 /* opening_hours_how_to_edit.html */; };
@@ -1335,6 +1336,7 @@
 		ED48BBB917C2B1E2003E7E92 /* CircleView.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = CircleView.m; sourceTree = "<group>"; };
 		EDBD68062B625724005DD151 /* LocationServicesDisabledAlert.xib */ = {isa = PBXFileReference; lastKnownFileType = file.xib; path = LocationServicesDisabledAlert.xib; sourceTree = "<group>"; };
 		EDBD680A2B62572E005DD151 /* LocationServicesDisabledAlert.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LocationServicesDisabledAlert.swift; sourceTree = "<group>"; };
+		EDC3573A2B7B5029001AE9CA /* CALayer+SetCorner.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "CALayer+SetCorner.swift"; sourceTree = "<group>"; };
 		EE026F0511D6AC0D00645242 /* classificator.txt */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text; name = classificator.txt; path = ../../data/classificator.txt; sourceTree = SOURCE_ROOT; };
 		EE164810135CEE49003B8A3E /* 06_code2000.ttf */ = {isa = PBXFileReference; lastKnownFileType = file; name = 06_code2000.ttf; path = ../../data/06_code2000.ttf; sourceTree = SOURCE_ROOT; };
 		EE583CBA12F773F00042CBE3 /* unicode_blocks.txt */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text; name = unicode_blocks.txt; path = ../../data/unicode_blocks.txt; sourceTree = "<group>"; };
@@ -2094,6 +2096,7 @@
 				99E2B0112368A8C700FFABC5 /* MWMCategory+PlacesCountTitle.swift */,
 				9957FAE0237AE04900855F48 /* MWMMapViewControlsManager+AddPlace.h */,
 				471A7BB7247FE3C300A0D4C1 /* URL+Query.swift */,
+				EDC3573A2B7B5029001AE9CA /* CALayer+SetCorner.swift */,
 			);
 			path = Categories;
 			sourceTree = "<group>";
@@ -4233,6 +4236,7 @@
 				99012851244732DB00C72B10 /* BottomTabBarViewController.swift in Sources */,
 				F63AF5061EA6162400A1DB98 /* FilterTypeCell.swift in Sources */,
 				993DF10623F6BDB100AC231A /* UIColor+rgba.swift in Sources */,
+				EDC3573B2B7B5029001AE9CA /* CALayer+SetCorner.swift in Sources */,
 				47E3C7332111F4D8008B3B27 /* CoverVerticalDismissalAnimator.swift in Sources */,
 				471AB99423ABA3BD00F56D49 /* SearchMapsDataSource.swift in Sources */,
 				47CA68F1250B54AF00671019 /* BookmarkCell.swift in Sources */,

--- a/iphone/Maps/UI/BottomMenu/Menu/BottomMenuViewController.swift
+++ b/iphone/Maps/UI/BottomMenu/Menu/BottomMenuViewController.swift
@@ -25,8 +25,7 @@ class BottomMenuViewController: MWMViewController {
   override func viewDidLoad() {
     super.viewDidLoad()
     
-    tableView.layer.cornerRadius = 8
-    tableView.layer.maskedCorners = [.layerMinXMinYCorner, .layerMaxXMinYCorner]
+    tableView.layer.setCorner(radius: 8, corners: [.layerMinXMinYCorner, .layerMaxXMinYCorner])
     tableView.sectionFooterHeight = 0
     
     tableView.dataSource = presenter

--- a/iphone/Maps/UI/BottomMenu/Menu/Cells/BottomMenuLayerButton.swift
+++ b/iphone/Maps/UI/BottomMenu/Menu/Cells/BottomMenuLayerButton.swift
@@ -13,6 +13,7 @@ final class BottomMenuLayerButton: VerticallyAlignedButton {
 
   override func layoutSubviews() {
     super.layoutSubviews()
+    imageView.layer.masksToBounds = true
     updateBadge()
   }
 

--- a/iphone/Maps/UI/BottomMenu/TabBar/BottomTabBarButton.swift
+++ b/iphone/Maps/UI/BottomMenu/TabBar/BottomTabBarButton.swift
@@ -24,9 +24,6 @@ class BottomTabBarButtonRenderer {
     if let backgroundColor = style.backgroundColor {
       control.backgroundColor = backgroundColor
     }
-    if #available(iOS 13.0, *) {
-      control.layer.cornerCurve = .continuous
-    }
   }
 }
 

--- a/iphone/Maps/UI/PlacePage/PlacePageViewController.swift
+++ b/iphone/Maps/UI/PlacePage/PlacePageViewController.swift
@@ -65,15 +65,13 @@ final class PlacePageScrollView: UIScrollView {
     bgView.alignToSuperview()
 
     scrollView.decelerationRate = .fast
-    scrollView.layer.cornerRadius = 10
-    scrollView.layer.maskedCorners = [.layerMinXMinYCorner, .layerMaxXMinYCorner]
+    scrollView.backgroundColor = .clear
+    
+    stackView.backgroundColor = .clear
 
-    stackView.layer.cornerRadius = 10
-    stackView.layer.maskedCorners = [.layerMinXMinYCorner, .layerMaxXMinYCorner]
-
-    actionBarContainerView.layer.cornerRadius = 10
+    let cornersToMask: CACornerMask = alternativeSizeClass(iPhone: [], iPad: [.layerMinXMaxYCorner, .layerMaxXMaxYCorner])
+    actionBarContainerView.layer.setCorner(radius: 16, corners: cornersToMask)
     actionBarContainerView.layer.masksToBounds = true
-    actionBarContainerView.layer.maskedCorners = [.layerMinXMaxYCorner, .layerMaxXMaxYCorner]
 
     // See https://github.com/organicmaps/organicmaps/issues/6917 for the details.
     if #available(iOS 13.0, *), previousTraitCollection == nil {

--- a/iphone/Maps/UI/PlacePage/Views/DifficultyView.swift
+++ b/iphone/Maps/UI/PlacePage/Views/DifficultyView.swift
@@ -43,7 +43,7 @@ class DifficultyView: UIView {
     for _ in 0..<difficultyLevelCount {
       let view = UIView()
       stackView.addArrangedSubview(view)
-      view.layer.cornerRadius = bulletSize.height / 2
+      view.layer.setCorner(radius: bulletSize.height / 2)
       views.append(view)
     }
   }


### PR DESCRIPTION
## Description
If you look closely, you’ll not find a sharp corner in any Apple product. Al UI in Apple’s apps and products are smoothly-rounded. This is because Apple always uses `superellipses` for the rectangle's corners rounding (`squircle`) .

![image](https://github.com/organicmaps/organicmaps/assets/79797627/a2d2cee9-6d21-45aa-9d07-150de2e4d123)

To read more about superellipses:
https://blog.minimal.app/rounded-corners-in-the-apple-ecosystem/
https://habr.com/ru/companies/droider/articles/517298/

## Solution
This PR implements this small fix for UI elements to slightly improve the app's visual smoothness.

Since ios13 UIKit introduced the continuous corner curve style:
`public static let continuous: CALayerCornerCurve`
This property should be always set manually so I move it into the extension.

## Before/After:
<img width="400" alt="image" src="https://github.com/organicmaps/organicmaps/assets/79797627/7ffc4f5e-56da-4955-9bcb-e8c3c932e856"> <img width="400" alt="image" src="https://github.com/organicmaps/organicmaps/assets/79797627/85b3dad1-f2d3-4b1b-bf13-eeeb6b6e95a3">


<img width="60" alt="image" src="https://github.com/organicmaps/organicmaps/assets/79797627/733e1ef6-23f5-4280-8f01-f541fd1d4472"> 
<img width="60" alt="image" src="https://github.com/organicmaps/organicmaps/assets/79797627/b4f5da87-0ab5-4464-85b3-7f6905bc2f61">


<img width="120" alt="image" src="https://github.com/organicmaps/organicmaps/assets/79797627/da91aedb-fabe-47d7-a000-c2788f6179e5"> 
<img width="120" alt="image" src="https://github.com/organicmaps/organicmaps/assets/79797627/55349c84-54df-4ded-be5d-d5a7175e1a68">

 <img width="100" alt="image" src="https://github.com/organicmaps/organicmaps/assets/79797627/f41ec7b6-0ffe-4632-9eda-d14d5e30037d"> <img width="100" alt="image" src="https://github.com/organicmaps/organicmaps/assets/79797627/bfd0407a-80fd-44a0-95f3-ad68b0bcb336">


<img width="160" alt="image" src="https://github.com/organicmaps/organicmaps/assets/79797627/733549e6-a35b-4f6c-95e8-6a4601fb3415"> <img width="160" alt="image" src="https://github.com/organicmaps/organicmaps/assets/79797627/3e672d0a-037e-4c1b-9a04-f5e345611667">

## Aditional notes:
It would be better to increase a little bit some corner radiuses to make the app not so edgy.

For example:
<img width="714" alt="image" src="https://github.com/organicmaps/organicmaps/assets/79797627/d11f0d19-702c-4ec8-809e-d6914b72f65a">
<img width="722" alt="image" src="https://github.com/organicmaps/organicmaps/assets/79797627/e081064a-0274-4a2b-a0cd-88196f5761b1">
<img width="795" alt="image" src="https://github.com/organicmaps/organicmaps/assets/79797627/07525aa9-ffd8-4277-87b9-23cd240891d0">


