### PR TITLE
[ios] Fix crash when user taps the Menu button during the TabBar hiding animation

### DIFF
--- a/iphone/Maps/UI/BottomMenu/TabBar/BottomTabBarInteractor.swift
+++ b/iphone/Maps/UI/BottomMenu/TabBar/BottomTabBarInteractor.swift
@@ -47,14 +47,16 @@ extension BottomTabBarInteractor: BottomTabBarInteractorProtocol {
   
   func openMenu() {
     guard let state = controlsManager?.menuState else {
-      fatalError()
+      fatalError("ERROR: Failed to retrieve the current MapViewControlsManager's state.")
     }
     switch state {
     case .inactive: controlsManager?.menuState = .active
     case .active: controlsManager?.menuState = .inactive
-    case .hidden: fallthrough
+    case .hidden:
+      // When the current controls manager's state is hidden, accidental taps on the menu button during the hiding animation should be skipped.
+      break;
     case .layers: fallthrough
-    @unknown default: fatalError()
+    @unknown default: fatalError("ERROR: Unexpected MapViewControlsManager's state: \(state)")
     }
   }
 }


### PR DESCRIPTION
## Issue: 
Sometimes the app crashes during the tap on the Menu button.

## Steps to reproduce:
1. tap on the map to hide the bottom bar and side buttons
2. while the hiding animation is in progress tap on the Menu button (you should do it immidietely)
3. app should fail

## Why this happens?
Touching the map on the free area to update the visibility of the controls is handled in the core c++ code.

If you quickly tap on the map to hide the menu and then on the disappearing menu button, there are 2 cases:
1. If you tap super quickly, UIKit processes the second tap faster than the c++ code processes the first one and you can see the menu opening and closing immediately. But this case is rarer because you have to tap extremely fast.
2. If you tap slightly slower on the menu, but still while the hiding button is progress - then the core will first handle it and change the state to `hidden`, and then UIKit will handle the second touch on the button and trigger a `fatalError`.
<img width="532" alt="image" src="https://github.com/organicmaps/organicmaps/assets/79797627/824be49e-93e6-4226-86d8-5d2393da1827">

So, we can have a race condition of controls state here.

## Solution:
1. when the state is `hidden` and the user accidentally presses the Menu button - this action should be skipped, rather than the app throwing a fatal error.
2. additionally user Interaction for the tabBar is disabled when the tabBar is hidden, but it does not prevent race condition and the app still can crash.
