### PR TITLE
[ios] fix search bars for iOS12

### DIFF
--- a/iphone/Maps/Core/Theme/Renderers/UISearchBarRenderer.swift
+++ b/iphone/Maps/Core/Theme/Renderers/UISearchBarRenderer.swift
@@ -24,26 +24,43 @@ extension UISearchBar {
 class UISearchBarRenderer: UIViewRenderer {
   class func render(_ control: UISearchBar, style: Style) {
     super.render(control, style: style)
-    var searchTextField: UITextField?
     if #available(iOS 13, *) {
-      searchTextField = control.searchTextField
-    }
-    
-    // Default search bar implementation adds the grey transparent image for background. This code removes it and updates the corner radius. This is not working on iPad designed for mac.
-    if #available(iOS 14.0, *), ProcessInfo.processInfo.isiOSAppOnMac {
+      var searchTextField = control.searchTextField
+      // Default search bar implementation adds the grey transparent image for background. This code removes it and updates the corner radius. This is not working on iPad designed for mac.
+      if #available(iOS 14.0, *), ProcessInfo.processInfo.isiOSAppOnMac {
+      } else {
+        control.setSearchFieldBackgroundImage(UIImage(), for: .normal)
+      }
+      searchTextField.layer.setCorner(radius: 8)
+      searchTextField.layer.masksToBounds = true
+      // Placeholder color
+      if let placeholder = searchTextField.placeholder {
+        searchTextField.attributedPlaceholder = NSAttributedString(string: placeholder, attributes: [.foregroundColor: UIColor.gray])
+      }
+      if let backgroundColor = style.backgroundColor {
+        searchTextField.backgroundColor = backgroundColor
+      }
+      if let font = style.font {
+        searchTextField.font = font
+      }
+      if let fontColor = style.fontColor {
+        searchTextField.textColor = fontColor
+      }
+      if let tintColor = style.tintColor {
+        searchTextField.leftView?.tintColor = tintColor
+        // Placeholder indicator color
+        searchTextField.tintColor = tintColor
+        // Clear button image
+        let clearButtonImage = UIImage(named: "ic_clear")?.withRenderingMode(.alwaysTemplate).withTintColor(tintColor)
+        control.setImage(clearButtonImage, for: .clear, state: .normal)
+      }
     } else {
-      control.setSearchFieldBackgroundImage(UIImage(), for: .normal)
-    }
-    searchTextField?.layer.setCorner(radius: 8)
-    searchTextField?.layer.masksToBounds = true
-
-    // Placeholder color
-    if let placeholder = searchTextField?.placeholder {
-      searchTextField?.attributedPlaceholder = NSAttributedString(string: placeholder, attributes: [.foregroundColor: UIColor.gray])
-    }
-    
-    if let backgroundColor = style.backgroundColor {
-      searchTextField?.backgroundColor = backgroundColor
+      // Default search bar implementation for iOS12 adds the dark grey transparent image for background. This code removes it and replace with the custom image accordingly to the documentation - see 'setSearchFieldBackgroundImage'.
+      if let backgroundColor = style.backgroundColor {
+        let image = getSearchBarBackgroundImage(color: backgroundColor)
+        control.setSearchFieldBackgroundImage(image, for: .normal)
+        control.searchTextPositionAdjustment = UIOffset(horizontal: 6.0, vertical: 0.0)
+      }
     }
     if let barTintColor = style.barTintColor {
       let position = control.delegate?.position?(for: control) ?? control.barPosition
@@ -51,28 +68,9 @@ class UISearchBarRenderer: UIViewRenderer {
       control.setBackgroundImage(barTintColor.getImage(), for: position, barMetrics: .default)
       control.backgroundColor = barTintColor
     }
-    if let font = style.font {
-      searchTextField?.font = font
-    }
-    if let fontColor = style.fontColor {
-      searchTextField?.textColor = fontColor
-    }
     if let fontColorDetailed = style.fontColorDetailed {
       // Cancel button color
       control.tintColor = fontColorDetailed
-    }
-    if let tintColor = style.tintColor {
-      searchTextField?.leftView?.tintColor = tintColor
-      // Placeholder indicator color
-      searchTextField?.tintColor = tintColor
-      // Clear button image
-      let clearButtonImage: UIImage?
-      if #available(iOS 13.0, *) {
-        clearButtonImage = UIImage(named: "ic_clear")?.withRenderingMode(.alwaysTemplate).withTintColor(tintColor)
-      } else {
-        clearButtonImage = UIImage(named: "ic_search_clear_14")
-      }
-      control.setImage(clearButtonImage, for: .clear, state: .normal)
     }
   }
 
@@ -86,10 +84,43 @@ class UISearchBarRenderer: UIViewRenderer {
         UITextField.appearance(whenContainedInInstancesOf: [UISearchBar.self]).font = font
       }
       if let fontColor = style.fontColor {
+        UITextField.appearance(whenContainedInInstancesOf: [UISearchBar.self]).defaultTextAttributes = [.foregroundColor: fontColor]
         UITextField.appearance(whenContainedInInstancesOf: [UISearchBar.self]).textColor = fontColor
         UITextField.appearance(whenContainedInInstancesOf: [UISearchBar.self]).leftView?.tintColor = fontColor
         UITextField.appearance(whenContainedInInstancesOf: [UISearchBar.self]).tintColor = fontColor
       }
     }
+  }
+
+  @available(iOS, deprecated: 13.0)
+  private static let kiOS12DefaultSystemTextFieldHeight = 36
+
+  @available(iOS, deprecated: 13.0)
+  private static var searchBarBackgroundColor: UIColor?
+
+  @available(iOS, deprecated: 13.0)
+  private static var searchBarBackgroundImage: UIImage?
+
+  // Draws the background image for the UITextField using the default system's text field height.
+  // This approach is used only for iOS 12.
+  @available(iOS, deprecated: 13.0)
+  private static func getSearchBarBackgroundImage(color: UIColor) -> UIImage? {
+    if color != searchBarBackgroundColor {
+      let size = CGSize(width: kiOS12DefaultSystemTextFieldHeight, height: kiOS12DefaultSystemTextFieldHeight)
+      UIGraphicsBeginImageContextWithOptions(size, false, 0.0)
+      guard let context = UIGraphicsGetCurrentContext() else { return nil }
+      let rect = CGRect(origin: .zero, size: size)
+      let cornerRadius = CGFloat(8)
+      let path = UIBezierPath(roundedRect: rect, byRoundingCorners: [.topLeft, .topRight, .bottomLeft, .bottomRight], cornerRadii: CGSize(width: cornerRadius, height: cornerRadius))
+      context.addPath(path.cgPath)
+      context.setFillColor(color.cgColor)
+      context.fillPath()
+      let image = UIGraphicsGetImageFromCurrentImageContext()
+      UIGraphicsEndImageContext()
+      searchBarBackgroundImage = image
+      searchBarBackgroundColor = color
+      return image
+    }
+    return searchBarBackgroundImage
   }
 }

--- a/iphone/Maps/UI/Search/SearchBar.swift
+++ b/iphone/Maps/UI/Search/SearchBar.swift
@@ -34,6 +34,7 @@ final class SearchBar: SolidTouchView {
     updateLeftView()
     searchTextField.leftViewMode = UITextField.ViewMode.always
     searchTextField.leftView = UIView(frame: CGRect(x: 0, y: 0, width: 32, height: 32))
+    searchTextField.applyTheme()
   }
 
   private func updateLeftView() {


### PR DESCRIPTION
This PF continues https://github.com/organicmaps/organicmaps/pull/7236 and fixes some issues for iOS12.

### Bud description
Usually UIKit exends UIImage to the TextField's edges and 1.0 size is enough to render proper image. But it works properly only scince iOS13 and doesn't work on iOS12 (which doesn't extend height).
`control.setSearchFieldBackgroundImage(UIImage(), for: .normal) `is not working on iOS 12 and breaks layout and colors.
But this call is needed to remove defalut tinted image from TextField's background when UISearchController is used.

How this bug looks on iOS12:
<img src="https://github.com/organicmaps/organicmaps/assets/79797627/bb1daa11-f39a-4b5c-9a1f-a6b0059870f2" width="250">  <img src="https://github.com/organicmaps/organicmaps/assets/79797627/9affc86b-658d-4ce7-b4d4-73ee727d9242" width="250"> 

Tested on iOS 12.5 (iPhone 6).

<img src="http s://github.com/organicmaps/organicmaps/assets/79797627/9eebddf7-7513-4e69-aa57-64fc102b32e4" width="250"> 
<img src="https://github.com/organicmaps/organicmaps/assets/79797627/a41d7ece-07e5-4aa7-840c-77564ab60bb0" width="250">
<img src="https://github.com/organicmaps/organicmaps/assets/79797627/24f15ca9-bb69-4ae1-b890-3b3d5d62ebf3" width="250"> 
<img src="https://github.com/organicmaps/organicmaps/assets/79797627/ef18a3e3-3c2e-41c0-a1ab-b08432653d9e" width="250">
<img src="https://github.com/organicmaps/organicmaps/assets/79797627/8eaf8bdb-86be-4f74-a83a-e77eceb58060" width="250">