### PR TITLE
[ios] Match the iOS primary OM color with the Android

### DIFF
--- a/iphone/Maps/Core/Theme/Colors.swift
+++ b/iphone/Maps/Core/Theme/Colors.swift
@@ -1,7 +1,7 @@
 class DayColors: IColors {
   var clear = UIColor.clear
   var primaryDark = UIColor(24, 128, 68, alpha100)
-  var primary = UIColor(32, 152, 82, alpha100)
+  var primary = UIColor(0, 108, 53, alpha100)
   var secondary = UIColor(45, 137, 83, alpha100)
   // Light green color
   var primaryLight = UIColor(36, 180, 98, alpha100)


### PR DESCRIPTION
This PR updates the primary OM color in the iOS to match with the Android.

## Android:
<img width="300" alt="image" src="https://github.com/organicmaps/organicmaps/assets/79797627/2e9c8760-9619-4a12-b64e-159c2bdb9f85"> <img width="300" alt="image" src="https://github.com/organicmaps/organicmaps/assets/79797627/26d16b80-8fd6-4b29-b281-b060d84fa5f5">

## iOS:
### Before/After:
<img width="600" alt="image" src="https://github.com/organicmaps/organicmaps/assets/79797627/7e3cc7c6-5942-43fa-807b-8ffd682eaae3">
<img width="600" alt="image" src="https://github.com/organicmaps/organicmaps/assets/79797627/197ff8ca-ea2b-4794-951c-c66de76d9c74">
<img width="600" alt="image" src="https://github.com/organicmaps/organicmaps/assets/79797627/8fc9f515-19a4-46d5-9a17-fbb8c30bb49d">
<img width="600" alt="image" src="https://github.com/organicmaps/organicmaps/assets/79797627/c629bab9-e513-4c00-8c33-161ed934aba4">
<img width="600" alt="image" src="https://github.com/organicmaps/organicmaps/assets/79797627/afbd95c9-14e8-4415-99e8-424caec32241">


### This change does not affect the Dark color theme and Routing:
<img width="600" alt="image" src="https://github.com/organicmaps/organicmaps/assets/79797627/83cce0cc-6983-4d51-98a0-153d6901e2f8">
<img width="600" alt="image" src="https://github.com/organicmaps/organicmaps/assets/79797627/c7822a2b-1940-4a86-b185-56a7c494ad4e">
