### PR TITLE
[Android] Hide "Wikipedia" button if link is not available

### DIFF
--- a/android/app/src/main/java/app/organicmaps/widget/placepage/sections/PlacePageWikipediaFragment.java
+++ b/android/app/src/main/java/app/organicmaps/widget/placepage/sections/PlacePageWikipediaFragment.java
@@ -105,15 +105,21 @@ public class PlacePageWikipediaFragment extends Fragment implements Observer<Map
     }
 
     final String wikipediaLink = mMapObject.getMetadata(Metadata.MetadataType.FMD_WIKIPEDIA);
-    mWiki.setOnClickListener((v) -> {
-      if (!TextUtils.isEmpty(wikipediaLink))
-        Utils.openUrl(requireContext(), wikipediaLink);
-    });
-    mWiki.setOnLongClickListener((v) -> {
-      if (!TextUtils.isEmpty(wikipediaLink))
-        PlacePageUtils.copyToClipboard(requireContext(), mFrame, wikipediaLink);
-      return true;
-    });
+    if (TextUtils.isEmpty(wikipediaLink))
+      UiUtils.hide(mWiki);
+    else
+    {
+      UiUtils.show(mWiki);
+      mWiki.setOnClickListener((v) -> {
+        if (!TextUtils.isEmpty(wikipediaLink))
+          Utils.openUrl(requireContext(), wikipediaLink);
+      });
+      mWiki.setOnLongClickListener((v) -> {
+        if (!TextUtils.isEmpty(wikipediaLink))
+          PlacePageUtils.copyToClipboard(requireContext(), mFrame, wikipediaLink);
+        return true;
+      });
+    }
   }
 
   @Override


### PR DESCRIPTION
See issue #7400.

This quick fix hides Wikipedia button if link to article is not available. This doesn't fix original issue!

<img src="https://github.com/organicmaps/organicmaps/assets/720808/2af94e9a-d836-4a5a-a0bf-84248d45be68" width="300px"/>
