### PR TITLE
[cmake] Simplified platform variables

### DIFF
--- a/3party/CMakeLists.txt
+++ b/3party/CMakeLists.txt
@@ -42,7 +42,7 @@ endif()
 add_subdirectory(agg)
 add_subdirectory(bsdiff-courgette)
 
-if (NOT LINUX_DETECTED)
+if (NOT PLATFORM_LINUX)
   add_subdirectory(freetype)
   add_subdirectory(icu)
 endif()

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -62,31 +62,22 @@ set(CMAKE_MODULE_PATH ${CMAKE_MODULE_PATH} "${OMIM_ROOT}/cmake")
 include(OmimHelpers)
 include(OmimTesting)
 
-if (CMAKE_SYSTEM_NAME MATCHES "Linux")
-  set(LINUX_DETECTED TRUE)
-endif()
-
-if (CMAKE_SYSTEM_NAME MATCHES "Android")
-  set(ANDROID_DETECTED TRUE)
-  if ((${OS} MATCHES "mac"))
-    set(DARWIN TRUE)
-  endif()
-endif()
-
-
-omim_set_platform_var(PLATFORM_IPHONE "iphone-.*")
-omim_set_platform_var(PLATFORM_ANDROID "android-.*" ${ANDROID_DETECTED})
-omim_set_platform_var(PLATFORM_MAC "macx-.*" ${APPLE})
-omim_set_platform_var(PLATFORM_WIN "win32-.*" ${WIN32})
-omim_set_platform_var(PLATFORM_LINUX "linux-.*" ${LINUX_DETECTED})
-
-if (PLATFORM_LINUX OR PLATFORM_MAC OR PLATFORM_WIN)
-  set(PLATFORM_DESKTOP TRUE)
-else()
+set(PLATFORM_DESKTOP TRUE)
+if (CMAKE_SYSTEM_NAME STREQUAL "Linux")
+  set(PLATFORM_LINUX TRUE)
+elseif (CMAKE_SYSTEM_NAME STREQUAL "Darwin")
+  set(PLATFORM_MAC TRUE)
+elseif (CMAKE_SYSTEM_NAME STREQUAL "Windows")
+  set(PLATFORM_WIN TRUE)
+elseif (CMAKE_SYSTEM_NAME STREQUAL "Android")
+  set(PLATFORM_ANDROID TRUE)
   set(PLATFORM_DESKTOP FALSE)
+elseif (CMAKE_SYSTEM_NAME STREQUAL "iOS")
+  set(PLATFORM_IPHONE TRUE)
+  set(PLATFORM_DESKTOP FALSE)
+else()
+  message(FATAL_ERROR "Unsupported platform: ${CMAKE_SYSTEM_NAME}")
 endif()
-
-# End of setting the target platform
 
 # Sanitizer
 if (PLATFORM_DESKTOP)
@@ -293,7 +284,7 @@ endif()
 
 # Should be on the root level, not in 3party, so tests can get these dependencies.
 # Should go before 3party as harfbuzz is using them.
-if (LINUX_DETECTED)
+if (PLATFORM_LINUX)
   find_package(ICU COMPONENTS uc i18n data REQUIRED)
   find_package(Freetype REQUIRED)
 endif()

--- a/cmake/OmimHelpers.cmake
+++ b/cmake/OmimHelpers.cmake
@@ -1,25 +1,5 @@
 include(OmimConfig)
 
-# Function for setting target platform:
-function(omim_set_platform_var PLATFORM_VAR pattern)
-  set(${PLATFORM_VAR} FALSE PARENT_SCOPE)
-
-  if (NOT PLATFORM)
-    if (${ARGN})
-      list(GET ARGN 0 default_case)
-      if (${default_case})
-        set(${PLATFORM_VAR} TRUE PARENT_SCOPE)
-        message("Setting ${PLATFORM_VAR} to true")
-      endif()
-    endif()
-  else()
-    message("Platform: ${PLATFORM}")
-    if (${PLATFORM} MATCHES ${pattern})
-      set(${PLATFORM_VAR} TRUE PARENT_SCOPE)
-    endif()
-  endif()
-endfunction()
-
 # Functions for using in subdirectories
 function(omim_add_executable executable)
   add_executable(${executable} ${ARGN})

--- a/platform/CMakeLists.txt
+++ b/platform/CMakeLists.txt
@@ -73,7 +73,7 @@ else()
   set(QT_POSITIONING false)
 endif()
 
-if(${PLATFORM_IPHONE})
+if (PLATFORM_IPHONE)
   append(SRC
     background_downloader_ios.h
     background_downloader_ios.mm

--- a/storage/CMakeLists.txt
+++ b/storage/CMakeLists.txt
@@ -48,7 +48,7 @@ set(SRC
   storage_helpers.hpp
 )
 
-if(${PLATFORM_IPHONE})
+if (PLATFORM_IPHONE)
   append(SRC
     background_downloading/downloader_adapter_ios.h
     background_downloading/downloader_adapter_ios.mm


### PR DESCRIPTION
Now build should fail on an unsupported platform until a new platform is explicitly added.