### PR TITLE
[ios] Improve the search screen closing animation

### DIFF
--- a/iphone/Maps/UI/Search/MWMSearchManager.mm
+++ b/iphone/Maps/UI/Search/MWMSearchManager.mm
@@ -88,6 +88,11 @@ const CGFloat kWidthForiPad = 320;
   [MWMSearch clear];
 }
 
+- (void)closeSearch {
+  [self.searchTextField endEditing:YES];
+  [self endSearch];
+}
+
 #pragma mark - Actions
 
 - (IBAction)textFieldDidEndEditing:(UITextField *)textField {
@@ -195,7 +200,7 @@ const CGFloat kWidthForiPad = 320;
 
 - (void)changeToHiddenState {
   self.routingTooltipSearch = MWMSearchManagerRoutingTooltipSearchNone;
-  [self endSearch];
+  [self closeSearch];
 
   MWMMapViewControlsManager *controlsManager = self.controlsManager;
   auto const navigationManagerState = [MWMNavigationDashboardManager sharedManager].state;


### PR DESCRIPTION
When the user taps on the Search screen's `close` button:
1. search screen disappears
2. keyboard scrolls down

The overall animation is serial and looks a little bit slow.

This small PR fix that.

Before (real speed/slowmo):
![Simulator Screen Recording - iPhone 15 Pro - 2024-02-17 at 14 31 32](https://github.com/organicmaps/organicmaps/assets/79797627/2416e5b9-6872-40bd-b146-2f50150af98d) ![Simulator Screen Recording - iPhone 15 Pro - 2024-02-17 at 14 31 20](https://github.com/organicmaps/organicmaps/assets/79797627/cc382e40-58f1-440b-8c68-dafb82a14f6b)

After:
![Simulator Screen Recording - iPhone 15 Pro - 2024-02-17 at 14 38 45](https://github.com/organicmaps/organicmaps/assets/79797627/a9f4ced2-183b-4116-af60-26be382ec6a8) ![Simulator Screen Recording - iPhone 15 Pro - 2024-02-17 at 14 38 35](https://github.com/organicmaps/organicmaps/assets/79797627/075ff0e7-fe37-48ac-bfa5-4e92aa439384)