### PR TITLE
[android-auto] Provide "test drive" mode that simulates driving

### DIFF
--- a/android/app/src/main/cpp/app/organicmaps/Framework.cpp
+++ b/android/app/src/main/cpp/app/organicmaps/Framework.cpp
@@ -1282,6 +1282,29 @@ Java_app_organicmaps_Framework_nativeGetRouteFollowingInfo(JNIEnv * env, jclass)
   return result;
 }
 
+JNIEXPORT jobjectArray JNICALL
+Java_app_organicmaps_Framework_nativeGetRouteJunctionPoints(JNIEnv * env, jclass)
+{
+  vector<m2::PointD> junctionPoints;
+  if (!frm()->GetRoutingManager().RoutingSession().GetRouteJunctionPoints(junctionPoints))
+  {
+    LOG(LWARNING, ("Can't get the route junction points"));
+    return nullptr;
+  }
+
+  static jclass const junctionClazz = jni::GetGlobalClassRef(env, "app/organicmaps/routing/JunctionInfo");
+  // Java signature : JunctionInfo(double lat, double lon)
+  static jmethodID const junctionConstructor = jni::GetConstructorID(env, junctionClazz, "(DD)V");
+
+  return jni::ToJavaArray(env, junctionClazz, junctionPoints,
+    [](JNIEnv * env, m2::PointD const & point)
+    {
+      return env->NewObject(junctionClazz, junctionConstructor,
+                            mercator::YToLat(point.y),
+                            mercator::XToLon(point.x));
+    });
+}
+
 JNIEXPORT jintArray JNICALL
 Java_app_organicmaps_Framework_nativeGenerateRouteAltitudeChartBits(JNIEnv * env, jclass, jint width, jint height, jobject routeAltitudeLimits)
 {

--- a/android/app/src/main/java/app/organicmaps/Framework.java
+++ b/android/app/src/main/java/app/organicmaps/Framework.java
@@ -15,12 +15,12 @@ import app.organicmaps.api.RequestType;
 import app.organicmaps.bookmarks.data.DistanceAndAzimut;
 import app.organicmaps.bookmarks.data.FeatureId;
 import app.organicmaps.bookmarks.data.MapObject;
+import app.organicmaps.routing.JunctionInfo;
 import app.organicmaps.routing.RouteMarkData;
 import app.organicmaps.routing.RoutePointInfo;
 import app.organicmaps.routing.RoutingInfo;
 import app.organicmaps.routing.TransitRouteInfo;
 import app.organicmaps.settings.SettingsPrefsFragment;
-import app.organicmaps.util.Distance;
 import app.organicmaps.widget.placepage.PlacePageData;
 import app.organicmaps.util.Constants;
 
@@ -273,6 +273,9 @@ public class Framework
 
   @Nullable
   public static native RoutingInfo nativeGetRouteFollowingInfo();
+
+  @Nullable
+  public static native JunctionInfo[] nativeGetRouteJunctionPoints();
 
   @Nullable
   public static native final int[] nativeGenerateRouteAltitudeChartBits(int width, int height, RouteAltitudeLimits routeAltitudeLimits);

--- a/android/app/src/main/java/app/organicmaps/car/screens/NavigationScreen.java
+++ b/android/app/src/main/java/app/organicmaps/car/screens/NavigationScreen.java
@@ -30,6 +30,7 @@ import app.organicmaps.car.util.ThemeUtils;
 import app.organicmaps.car.util.UiHelpers;
 import app.organicmaps.location.LocationHelper;
 import app.organicmaps.location.LocationListener;
+import app.organicmaps.routing.JunctionInfo;
 import app.organicmaps.routing.NavigationService;
 import app.organicmaps.routing.RoutingController;
 import app.organicmaps.routing.RoutingInfo;
@@ -91,6 +92,28 @@ public class NavigationScreen extends BaseMapScreen implements RoutingController
     LocationHelper.from(getCarContext()).removeListener(mLocationListener);
     mNavigationCancelled = true;
     mRoutingController.cancel();
+  }
+
+  /**
+   * To verify your app's navigation functionality when you submit it to the Google Play Store, your app must implement
+   * the NavigationManagerCallback.onAutoDriveEnabled callback. When this callback is called, your app must simulate
+   * navigation to the chosen destination when the user begins navigation. Your app can exit this mode whenever
+   * the lifecycle of the current Session reaches the Lifecycle.Event.ON_DESTROY state.
+   * <a href="https://developer.android.com/training/cars/apps/navigation#simulating-navigation">More info</a>
+   */
+  @Override
+  public void onAutoDriveEnabled()
+  {
+    Logger.i(TAG);
+    final JunctionInfo[] points = Framework.nativeGetRouteJunctionPoints();
+    if (points == null)
+    {
+      Logger.e(TAG, "Navigation has not started yet");
+      return;
+    }
+
+    final LocationHelper locationHelper = LocationHelper.from(getCarContext());
+    locationHelper.startNavigationSimulation(points);
   }
 
   @Override

--- a/android/app/src/main/java/app/organicmaps/location/LocationHelper.java
+++ b/android/app/src/main/java/app/organicmaps/location/LocationHelper.java
@@ -3,6 +3,7 @@ package app.organicmaps.location;
 import static android.Manifest.permission.ACCESS_COARSE_LOCATION;
 import static android.Manifest.permission.ACCESS_FINE_LOCATION;
 
+import android.annotation.SuppressLint;
 import android.app.PendingIntent;
 import android.content.Context;
 import android.location.Location;
@@ -21,6 +22,7 @@ import app.organicmaps.Map;
 import app.organicmaps.MwmApplication;
 import app.organicmaps.bookmarks.data.FeatureId;
 import app.organicmaps.bookmarks.data.MapObject;
+import app.organicmaps.routing.JunctionInfo;
 import app.organicmaps.routing.RoutingController;
 import app.organicmaps.util.Config;
 import app.organicmaps.util.LocationUtils;
@@ -231,6 +233,17 @@ public class LocationHelper implements BaseLocationProvider.Listener
         " downgrading to use native provider");
     mLocationProvider.stop();
     mLocationProvider = new AndroidNativeProvider(mContext, this);
+    mActive = true;
+    mLocationProvider.start(mInterval);
+  }
+
+  // RouteSimulationProvider doesn't really require location permissions.
+  @SuppressLint("MissingPermission")
+  public void startNavigationSimulation(JunctionInfo[] points)
+  {
+    Logger.i(TAG);
+    mLocationProvider.stop();
+    mLocationProvider = new RouteSimulationProvider(mContext, this, points);
     mActive = true;
     mLocationProvider.start(mInterval);
   }

--- a/android/app/src/main/java/app/organicmaps/location/RouteSimulationProvider.java
+++ b/android/app/src/main/java/app/organicmaps/location/RouteSimulationProvider.java
@@ -1,0 +1,64 @@
+package app.organicmaps.location;
+
+import android.content.Context;
+import android.location.Location;
+
+import androidx.annotation.NonNull;
+
+import app.organicmaps.routing.JunctionInfo;
+import app.organicmaps.util.LocationUtils;
+import app.organicmaps.util.concurrency.UiThread;
+import app.organicmaps.util.log.Logger;
+
+class RouteSimulationProvider extends BaseLocationProvider
+{
+  private static final String TAG = RouteSimulationProvider.class.getSimpleName();
+  private static final long INTERVAL_MS = 1000;
+
+  private JunctionInfo[] mPoints;
+  private int mCurrentPoint = 0;
+  private boolean mActive = false;
+
+  RouteSimulationProvider(@NonNull Context context, @NonNull Listener listener, JunctionInfo[] points)
+  {
+    super(listener);
+    mPoints = points;
+  }
+
+  @Override
+  public void start(long interval)
+  {
+    Logger.i(TAG);
+    if (mActive)
+      throw new IllegalStateException("Already started");
+    mActive = true;
+    UiThread.runLater(this::nextPoint);
+  }
+
+  @Override
+  public void stop()
+  {
+    Logger.i(TAG);
+    mActive = false;
+  }
+
+  public void nextPoint()
+  {
+    if (!mActive)
+      return;
+    if (mCurrentPoint >= mPoints.length)
+    {
+      Logger.i(TAG, "Finished the final point");
+      mActive = false;
+      return;
+    }
+
+    final Location location = new Location(LocationUtils.FUSED_PROVIDER);
+    location.setLatitude(mPoints[mCurrentPoint].mLat);
+    location.setLongitude(mPoints[mCurrentPoint].mLon);
+    location.setAccuracy(1.0f);
+    mListener.onLocationChanged(location);
+    mCurrentPoint += 1;
+    UiThread.runLater(this::nextPoint, INTERVAL_MS);
+  }
+}

--- a/android/app/src/main/java/app/organicmaps/routing/JunctionInfo.java
+++ b/android/app/src/main/java/app/organicmaps/routing/JunctionInfo.java
@@ -1,0 +1,18 @@
+package app.organicmaps.routing;
+
+import androidx.annotation.Keep;
+
+// Used by JNI.
+@Keep
+@SuppressWarnings("unused")
+public class JunctionInfo
+{
+  public final double mLat;
+  public final double mLon;
+
+  public JunctionInfo(double lat, double lon)
+  {
+    mLat = lat;
+    mLon = lon;
+  }
+}

--- a/routing/routing_session.cpp
+++ b/routing/routing_session.cpp
@@ -786,6 +786,27 @@ bool RoutingSession::IsRouteValid() const
   return m_route && m_route->IsValid();
 }
 
+bool RoutingSession::GetRouteJunctionPoints(std::vector<m2::PointD> & routeJunctionPoints) const
+{
+  CHECK_THREAD_CHECKER(m_threadChecker, ());
+  ASSERT(m_route, ());
+
+  if (!m_route->IsValid())
+    return false;
+
+  auto const & segments = m_route->GetRouteSegments();
+  routeJunctionPoints.reserve(segments.size());
+
+  for (size_t i = 0; i < segments.size(); ++i)
+  {
+    auto const & junction = segments[i].GetJunction();
+    routeJunctionPoints.push_back(junction.GetPoint());
+  }
+
+  ASSERT_EQUAL(routeJunctionPoints.size(), routeJunctionPoints.size(), ());
+  return true;
+}
+
 bool RoutingSession::GetRouteAltitudesAndDistancesM(std::vector<double> & routeSegDistanceM,
                                                     geometry::Altitudes & routeAltitudesM) const
 {

--- a/routing/routing_session.hpp
+++ b/routing/routing_session.hpp
@@ -94,6 +94,10 @@ public:
   bool GetRouteAltitudesAndDistancesM(std::vector<double> & routeSegDistanceM,
                                       geometry::Altitudes & routeAltitudesM) const;
 
+  /// \brief returns coordinates of route junctions.
+  /// \returns true if there is valid route information. If the route is not valid returns false.
+  bool GetRouteJunctionPoints(std::vector<m2::PointD> & routeJunctionPoints) const;
+
   SessionState OnLocationPositionChanged(location::GpsInfo const & info);
   void GetRouteFollowingInfo(FollowingInfo & info) const;
 


### PR DESCRIPTION
https://developer.android.com/training/cars/apps/navigation#simulating-navigation:

> To verify your app's navigation functionality when you submit it to
> the Google Play Store, your app must implement the NavigationManagerCallback
> .onAutoDriveEnabled callback. When this callback is called, your app must
> simulate navigation to the chosen destination when the user begins
> navigation. Your app can exit this mode whenever the lifecycle of
> the current Session reaches the Lifecycle.Event.ON_DESTROY state

```
adb shell dumpsys activity service app.organicmaps.car.CarAppService AUTO_DRIVE
```

Closes #7414

####


https://github.com/organicmaps/organicmaps/assets/1799054/3a981af6-c9b5-4bf4-8519-78c4b7828d00

