### PR TITLE
Use char32_t instead of uint32_t for UniChar

### DIFF
--- a/base/base_tests/string_utils_test.cpp
+++ b/base/base_tests/string_utils_test.cpp
@@ -46,9 +46,10 @@ UNIT_TEST(LowerUniChar)
     if (!semicolon)
       continue;
 
-    std::istringstream stream((std::string(*semicolon)));
-    strings::UniChar uc;
+    std::istringstream stream{std::string{*semicolon}};
+    uint32_t uc;
     stream >> std::hex >> uc;
+    ASSERT(stream, ("Overflow"));
     ++semicolon;
 
     auto const type = *semicolon;
@@ -64,7 +65,7 @@ UNIT_TEST(LowerUniChar)
     {
       stream.clear();
       stream.str(std::string(*spacer));
-      strings::UniChar smallCode;
+      uint32_t smallCode;
       stream >> std::hex >> smallCode;
       us.push_back(smallCode);
       ++spacer;

--- a/base/internal/message.cpp
+++ b/base/internal/message.cpp
@@ -39,4 +39,11 @@ std::string ToUtf8(std::u16string_view utf16)
   utf8::unchecked::utf16to8(utf16.begin(), utf16.end(), utf8.begin());
   return utf8;
 }
+
+std::string ToUtf8(std::u32string_view utf32)
+{
+  std::string utf8;
+  utf8::unchecked::utf32to8(utf32.begin(), utf32.end(), utf8.begin());
+  return utf8;
+}
 }  // namespace internal

--- a/base/internal/message.hpp
+++ b/base/internal/message.hpp
@@ -66,6 +66,7 @@ inline std::string DebugPrint(char t)
 namespace internal
 {
 std::string ToUtf8(std::u16string_view utf16);
+std::string ToUtf8(std::u32string_view utf32);
 }  // namespace internal
 
 inline std::string DebugPrint(std::u16string const & utf16)
@@ -76,6 +77,16 @@ inline std::string DebugPrint(std::u16string const & utf16)
 inline std::string DebugPrint(std::u16string_view utf16)
 {
   return internal::ToUtf8(utf16);
+}
+
+inline std::string DebugPrint(std::u32string const & utf32)
+{
+  return internal::ToUtf8(utf32);
+}
+
+inline std::string DebugPrint(std::u32string_view utf32)
+{
+  return internal::ToUtf8(utf32);
 }
 
 inline std::string DebugPrint(std::chrono::time_point<std::chrono::system_clock> const & ts)

--- a/base/string_utils.hpp
+++ b/base/string_utils.hpp
@@ -23,7 +23,7 @@
 /// All methods work with strings in utf-8 format
 namespace strings
 {
-using UniChar = uint32_t;
+using UniChar = char32_t;
 // typedef buffer_vector<UniChar, 32> UniString;
 
 /// Make new type, not typedef. Need to specialize DebugPrint.

--- a/drape/glyph_manager.cpp
+++ b/drape/glyph_manager.cpp
@@ -82,8 +82,7 @@ void ParseUniBlocks(std::string const & uniBlocksFile, ToDo toDo)
   while (true)
   {
     std::string name;
-    strings::UniChar start;
-    strings::UniChar end;
+    uint32_t start, end;
     fin >> name >> std::hex >> start >> std::hex >> end;
     if (!fin)
       break;

--- a/indexer/indexer_tests/trie_test.cpp
+++ b/indexer/indexer_tests/trie_test.cpp
@@ -33,12 +33,12 @@ struct ChildNodeInfo
 
   uint32_t Size() const { return m_size; }
   bool IsLeaf() const { return m_isLeaf; }
-  uint32_t const * GetEdge() const { return &m_edge[0]; }
+  trie::TrieChar const * GetEdge() const { return &m_edge[0]; }
   size_t GetEdgeSize() const { return m_edge.size(); }
 
   bool m_isLeaf;
   uint32_t m_size;
-  vector<uint32_t> m_edge;
+  vector<trie::TrieChar> m_edge;
 };
 
 // The SingleValueSerializer and ValueList classes are similar to

--- a/indexer/succinct_trie_builder.hpp
+++ b/indexer/succinct_trie_builder.hpp
@@ -96,7 +96,7 @@ void WriteInLevelOrder(TNode * root, std::vector<TNode *> & levelOrder)
 template <typename TWriter, typename TIter, typename TValueList>
 void BuildSuccinctTrie(TWriter & writer, TIter const beg, TIter const end)
 {
-  using TrieChar = uint32_t;
+  using TrieChar = char32_t;
   using TTrieString = buffer_vector<TrieChar, 32>;
   using TNode = Node<TValueList>;
   using TEntry = typename TIter::value_type;

--- a/indexer/trie.hpp
+++ b/indexer/trie.hpp
@@ -11,12 +11,12 @@
 
 namespace trie
 {
-using TrieChar = uint32_t;
+using TrieChar = char32_t;
 
 // 95 is a good value for the default baseChar, since both small and capital latin letters
 // are less than +/- 32 from it and thus can fit into supershort edge.
 // However 0 is used because the first byte is actually language id.
-uint32_t constexpr kDefaultChar = 0;
+TrieChar constexpr kDefaultChar = 0;
 
 template <typename ValueList>
 struct Iterator


### PR DESCRIPTION
That allows to use std::u32string_view in the code, adding useful std::basic_string_view methods