### PR TITLE
[ios] Extend bottom tab buttons tappable area by 15pt

### DIFF
--- a/iphone/Maps/UI/BottomMenu/TabBar/BottomTabBarButton.swift
+++ b/iphone/Maps/UI/BottomMenu/TabBar/BottomTabBarButton.swift
@@ -8,6 +8,10 @@ final class BottomTabBarButton: MWMButton {
       BottomTabBarButtonRenderer.render(self, style: style)
     }
   }
+
+  override func point(inside point: CGPoint, with event: UIEvent?) -> Bool {
+    return bounds.insetBy(dx: kExtendedTabBarTappableMargin, dy: kExtendedTabBarTappableMargin).contains(point)
+  }
 }
 
 class BottomTabBarButtonRenderer {

--- a/iphone/Maps/UI/BottomMenu/TabBar/BottomTabBarView.swift
+++ b/iphone/Maps/UI/BottomMenu/TabBar/BottomTabBarView.swift
@@ -1,9 +1,9 @@
-import UIKit
+let kExtendedTabBarTappableMargin: CGFloat = -15
 
-class BottomTabBarView: SolidTouchView {
-  
-  @IBOutlet var mainButtonsView: UIView!
-  
+final class BottomTabBarView: SolidTouchView {
+
+  @IBOutlet var mainButtonsView: ExtendedBottomTabBarContainerView!
+
   override var placePageAreaAffectDirections: MWMAvailableAreaAffectDirections {
     return alternative(iPhone: [], iPad: [.bottom])
   }
@@ -17,14 +17,12 @@ class BottomTabBarView: SolidTouchView {
   }
 
   override func point(inside point: CGPoint, with event: UIEvent?) -> Bool {
-    guard super.point(inside: point, with: event), mainButtonsView.point(inside: convert(point, to: mainButtonsView), with: event) else { return false }
-    for subview in mainButtonsView.subviews {
-      if !subview.isHidden
-          && subview.isUserInteractionEnabled
-          && subview.point(inside: convert(point, to: subview), with: event) {
-        return true
-      }
-    }
-    return false
+    return bounds.insetBy(dx: kExtendedTabBarTappableMargin, dy: kExtendedTabBarTappableMargin).contains(point)
+  }
+}
+
+final class ExtendedBottomTabBarContainerView: UIView {
+  override func point(inside point: CGPoint, with event: UIEvent?) -> Bool {
+    return bounds.insetBy(dx: kExtendedTabBarTappableMargin, dy: kExtendedTabBarTappableMargin).contains(point)
   }
 }

--- a/iphone/Maps/UI/BottomMenu/TabBar/BottomTabBarViewController.xib
+++ b/iphone/Maps/UI/BottomMenu/TabBar/BottomTabBarViewController.xib
@@ -24,7 +24,7 @@
             <rect key="frame" x="0.0" y="0.0" width="373" height="84"/>
             <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
             <subviews>
-                <view opaque="NO" clearsContextBeforeDrawing="NO" contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="vum-s3-PHx" userLabel="MainButtons">
+                <view opaque="NO" clearsContextBeforeDrawing="NO" contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="vum-s3-PHx" userLabel="MainButtons" customClass="ExtendedBottomTabBarContainerView" customModule="Organic_Maps" customModuleProvider="target">
                     <rect key="frame" x="0.0" y="0.0" width="373" height="48"/>
                     <subviews>
                         <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="dzf-7Z-N6a" userLabel="Help" customClass="BottomTabBarButton" customModule="Organic_Maps" customModuleProvider="target">


### PR DESCRIPTION
Sometimes when the user taps on the tab button he misses because the tappable area is defined by the button's bounds.

This PR extends the bottom tab buttons tappable area by 15pt to avoid tap miss.

<img width="703" alt="image" src="https://github.com/organicmaps/organicmaps/assets/79797627/1db8783b-948c-44f2-adc3-712a959f1f50">
