### PR TITLE
[android] Fix search bar in cuisine editor

### DIFF
--- a/android/app/src/main/res/layout/fragment_editor_host.xml
+++ b/android/app/src/main/res/layout/fragment_editor_host.xml
@@ -24,18 +24,20 @@
         layout="@layout/toolbar_search_controls"
         android:layout_width="match_parent"
         android:layout_height="match_parent"
-        android:layout_toStartOf="@+id/save"
-        tools:visibility="gone"/>
+        app:layout_constraintEnd_toStartOf="@id/save"
+        app:layout_constraintStart_toStartOf="parent"
+        android:layout_marginEnd="?actionBarSize"
+        tools:visibility="gone" />
 
       <ImageView
         app:tint="@color/image_view"
         android:id="@+id/save"
         android:layout_width="?actionBarSize"
         android:layout_height="?actionBarSize"
-        android:layout_alignParentEnd="true"
         android:background="?selectableItemBackgroundBorderless"
         android:scaleType="centerInside"
         app:srcCompat="@drawable/ic_done"
+        app:layout_constraintBottom_toBottomOf="parent"
         app:layout_constraintEnd_toEndOf="parent"
         app:layout_constraintTop_toTopOf="parent"/>
 


### PR DESCRIPTION
This PR fixes search bar overlapping, this bug was introduced by PR #7267
- I have removed useless attributes used before with relative layout
- Added constraint layout between search bar and button to validate
- Added margin end at the search bar to take to do not overlapping button

|Before|After|
|-|-|
|<img src="https://github.com/organicmaps/organicmaps/assets/87148630/96a7ccb3-15e7-4af9-9857-e9a6720f2f32" height=500 />|<img src="https://github.com/organicmaps/organicmaps/assets/87148630/7f7dd520-573f-494c-bdd7-8dadc469761f" height=500 />|

Todo:

- [x] Fix title of editor