### PR TITLE
Revert "[generator] Use release CHECK to verify FeatureType geometry."

### DIFF
--- a/indexer/feature.cpp
+++ b/indexer/feature.cpp
@@ -704,7 +704,7 @@ m2::RectD FeatureType::GetLimitRect(int scale)
 
   if (m_triangles.empty() && m_points.empty() && (GetGeomType() != GeomType::Point))
   {
-    CHECK(false, (m_id));
+    ASSERT(false, (m_id));
 
     // This function is called during indexing, when we need
     // to check visibility according to feature sizes.
@@ -717,8 +717,8 @@ m2::RectD FeatureType::GetLimitRect(int scale)
 
 m2::RectD const & FeatureType::GetLimitRectChecked() const
 {
-  CHECK(m_parsed.m_points && m_parsed.m_triangles, (m_id));
-  CHECK(m_limitRect.IsValid(), (m_id));
+  ASSERT(m_parsed.m_points && m_parsed.m_triangles, (m_id));
+  ASSERT(m_limitRect.IsValid(), (m_id));
   return m_limitRect;
 }
 


### PR DESCRIPTION
This reverts commit 3919b98c32c28da59e25638aa181e4a890f9bc4c.

Closes https://github.com/organicmaps/organicmaps/issues/7162

This CHECK should be present in the generator branch only.

Relation https://www.openstreetmap.org/relation/14474492 was ill-formed.
