### PR TITLE
[android] Add summary to know when routing options is enabled

### DIFF
--- a/android/app/src/main/java/app/organicmaps/settings/SettingsPrefsFragment.java
+++ b/android/app/src/main/java/app/organicmaps/settings/SettingsPrefsFragment.java
@@ -21,6 +21,7 @@ import app.organicmaps.editor.ProfileActivity;
 import app.organicmaps.help.HelpActivity;
 import app.organicmaps.location.LocationHelper;
 import app.organicmaps.location.LocationProviderFactory;
+import app.organicmaps.routing.RoutingOptions;
 import app.organicmaps.util.Config;
 import app.organicmaps.util.NetworkPolicy;
 import app.organicmaps.util.PowerManagment;
@@ -70,12 +71,19 @@ public class SettingsPrefsFragment extends BaseXmlSettingsFragment
     pref.setSummary(Config.TTS.isEnabled() ? R.string.on : R.string.off);
   }
 
+  private void updateRoutingSettingsPrefsSummary()
+  {
+    final Preference pref = getPreference(getString(R.string.prefs_routing));
+    pref.setSummary(RoutingOptions.hasAnyOptions() ? R.string.on : R.string.off);
+  }
+
   @Override
   public void onResume()
   {
     super.onResume();
 
     updateVoiceInstructionsPrefsSummary();
+    updateRoutingSettingsPrefsSummary();
   }
 
   @Override

--- a/android/app/src/main/res/values/donottranslate.xml
+++ b/android/app/src/main/res/values/donottranslate.xml
@@ -26,6 +26,7 @@
   <string name="pref_tts_speed_cameras" translatable="false">SpeedCameras</string>
   <!-- TODO: Move to another domain. -->
   <string name="tts_info_link" translatable="false">https://mapsme.zendesk.com/hc/en-us/articles/208628985-How-can-I-check-TTS-settings-on-my-Android-device-</string>
+  <string name="prefs_routing" translatable="false">RoutingOptions</string>
   <string name="pref_autodownload" translatable="false">AutoDownloadMap</string>
   <string name="pref_3d" translatable="false">3D</string>
   <string name="pref_3d_buildings" translatable="false">3DBuildings</string>

--- a/android/app/src/main/res/xml/prefs_main.xml
+++ b/android/app/src/main/res/xml/prefs_main.xml
@@ -128,6 +128,7 @@
       android:order="4">
     </Preference>
     <PreferenceScreen
+      android:key="@string/prefs_routing"
       android:order="5"
       android:title="@string/driving_options_title">
       <intent


### PR DESCRIPTION
This PR:
- Add a new preference key `prefs_routing`
- Implement `updateRoutingSettingsPrefsSummary` method to update summary of routing preference when one of routing options was enabled as Andrew has done for TTS preference

|Before|After|
|-|-|
|<img src="https://github.com/organicmaps/organicmaps/assets/87148630/2de4ef09-9366-48f0-94e9-9ba369eaba98" height=500 />|<img src="https://github.com/organicmaps/organicmaps/assets/87148630/c46347b4-5fee-4d58-802b-36bfc9d4c61e" height=500 />|
