### PR TITLE
[ios] [android] Fix the issue with renaming the "Night Mode" into the "Appearance" on the Android

### DIFF
--- a/android/app/src/main/res/values-ar/strings.xml
+++ b/android/app/src/main/res/values-ar/strings.xml
@@ -214,11 +214,11 @@
 	<string name="prefs_group_route">الملاحة</string>
 	<string name="pref_zoom_title">أزرار التكبير والتصغير</string>
 	<string name="pref_zoom_summary">عرض على الشاشة</string>
-	<!-- Settings «Map» category: «Appearance» title -->
-	<string name="pref_map_style_title">المظهر</string>
-	<!-- Settings "Appearance" category: "Light" title, should be consistent with the pref_map_style_title translation. -->
+	<!-- Settings «Map» category: «Night style» title -->
+	<string name="pref_map_style_title">الوضع الليلي</string>
+	<!-- Settings "Appearance" category: "Light" title, should be consistent with the pref_appearance_title translation. -->
 	<string name="pref_appearance_light">فاتح</string>
-	<!-- Settings "Appearance" category: "Dark" title, should be consistent with the pref_map_style_title translation. -->
+	<!-- Settings "Appearance" category: "Dark" title, should be consistent with the pref_appearance_title translation. -->
 	<string name="pref_appearance_dark">داكن</string>
 	<!-- Generic «Off» string -->
 	<string name="off">تعطيل</string>

--- a/android/app/src/main/res/values-az/strings.xml
+++ b/android/app/src/main/res/values-az/strings.xml
@@ -213,11 +213,11 @@
 	<string name="prefs_group_route">Naviqasiya</string>
 	<string name="pref_zoom_title">Böyütmə düymələri</string>
 	<string name="pref_zoom_summary">Xəritədə göstər</string>
-	<!-- Settings «Map» category: «Appearance» title -->
-	<string name="pref_map_style_title">Görünüş</string>
-	<!-- Settings "Appearance" category: "Light" title, should be consistent with the pref_map_style_title translation. -->
+	<!-- Settings «Map» category: «Night style» title -->
+	<string name="pref_map_style_title">Gecə rejimi</string>
+	<!-- Settings "Appearance" category: "Light" title, should be consistent with the pref_appearance_title translation. -->
 	<string name="pref_appearance_light">Parlaq</string>
-	<!-- Settings "Appearance" category: "Dark" title, should be consistent with the pref_map_style_title translation. -->
+	<!-- Settings "Appearance" category: "Dark" title, should be consistent with the pref_appearance_title translation. -->
 	<string name="pref_appearance_dark">Tünd</string>
 	<!-- Generic «Off» string -->
 	<string name="off">Bağlı</string>

--- a/android/app/src/main/res/values-be/strings.xml
+++ b/android/app/src/main/res/values-be/strings.xml
@@ -212,11 +212,11 @@
 	<string name="prefs_group_route">Навігацыя</string>
 	<string name="pref_zoom_title">Кнопкі маштабавання</string>
 	<string name="pref_zoom_summary">Паказаць на мапе</string>
-	<!-- Settings «Map» category: «Appearance» title -->
-	<string name="pref_map_style_title">Выгляд</string>
-	<!-- Settings "Appearance" category: "Light" title, should be consistent with the pref_map_style_title translation. -->
+	<!-- Settings «Map» category: «Night style» title -->
+	<string name="pref_map_style_title">Начны рэжым</string>
+	<!-- Settings "Appearance" category: "Light" title, should be consistent with the pref_appearance_title translation. -->
 	<string name="pref_appearance_light">Светлы</string>
-	<!-- Settings "Appearance" category: "Dark" title, should be consistent with the pref_map_style_title translation. -->
+	<!-- Settings "Appearance" category: "Dark" title, should be consistent with the pref_appearance_title translation. -->
 	<string name="pref_appearance_dark">Цемны</string>
 	<!-- Generic «Off» string -->
 	<string name="off">Выключаны</string>

--- a/android/app/src/main/res/values-bg/strings.xml
+++ b/android/app/src/main/res/values-bg/strings.xml
@@ -201,11 +201,11 @@
 	<string name="prefs_group_route">Навигация</string>
 	<string name="pref_zoom_title">Мащабни бутони</string>
 	<string name="pref_zoom_summary">Показване на картата</string>
-	<!-- Settings «Map» category: «Appearance» title -->
-	<string name="pref_map_style_title">Изглед</string>
-	<!-- Settings "Appearance" category: "Light" title, should be consistent with the pref_map_style_title translation. -->
+	<!-- Settings «Map» category: «Night style» title -->
+	<string name="pref_map_style_title">Нощен режим</string>
+	<!-- Settings "Appearance" category: "Light" title, should be consistent with the pref_appearance_title translation. -->
 	<string name="pref_appearance_light">Светъл</string>
-	<!-- Settings "Appearance" category: "Dark" title, should be consistent with the pref_map_style_title translation. -->
+	<!-- Settings "Appearance" category: "Dark" title, should be consistent with the pref_appearance_title translation. -->
 	<string name="pref_appearance_dark">Тъмен</string>
 	<!-- Generic «Off» string -->
 	<string name="off">Изключен</string>

--- a/android/app/src/main/res/values-ca/strings.xml
+++ b/android/app/src/main/res/values-ca/strings.xml
@@ -203,11 +203,11 @@
 	<string name="prefs_group_route">Navegació</string>
 	<string name="pref_zoom_title">Botons de zoom</string>
 	<string name="pref_zoom_summary">Mostra\'ls al mapa</string>
-	<!-- Settings «Map» category: «Appearance» title -->
-	<string name="pref_map_style_title">Aspecte</string>
-	<!-- Settings "Appearance" category: "Light" title, should be consistent with the pref_map_style_title translation. -->
+	<!-- Settings «Map» category: «Night style» title -->
+	<string name="pref_map_style_title">Mode nocturn</string>
+	<!-- Settings "Appearance" category: "Light" title, should be consistent with the pref_appearance_title translation. -->
 	<string name="pref_appearance_light">Clar</string>
-	<!-- Settings "Appearance" category: "Dark" title, should be consistent with the pref_map_style_title translation. -->
+	<!-- Settings "Appearance" category: "Dark" title, should be consistent with the pref_appearance_title translation. -->
 	<string name="pref_appearance_dark">Fosc</string>
 	<!-- Generic «Off» string -->
 	<string name="off">Desactivat</string>

--- a/android/app/src/main/res/values-cs/strings.xml
+++ b/android/app/src/main/res/values-cs/strings.xml
@@ -198,11 +198,11 @@
 	<string name="prefs_group_route">Navigace</string>
 	<string name="pref_zoom_title">Tlačítka přiblížení/oddálení</string>
 	<string name="pref_zoom_summary">Zobrazit na obrazovce</string>
-	<!-- Settings «Map» category: «Appearance» title -->
-	<string name="pref_map_style_title">Vzhled</string>
-	<!-- Settings "Appearance" category: "Light" title, should be consistent with the pref_map_style_title translation. -->
+	<!-- Settings «Map» category: «Night style» title -->
+	<string name="pref_map_style_title">Noční režim</string>
+	<!-- Settings "Appearance" category: "Light" title, should be consistent with the pref_appearance_title translation. -->
 	<string name="pref_appearance_light">Světlý</string>
-	<!-- Settings "Appearance" category: "Dark" title, should be consistent with the pref_map_style_title translation. -->
+	<!-- Settings "Appearance" category: "Dark" title, should be consistent with the pref_appearance_title translation. -->
 	<string name="pref_appearance_dark">Tmavý</string>
 	<!-- Generic «Off» string -->
 	<string name="off">Vypnuto</string>

--- a/android/app/src/main/res/values-da/strings.xml
+++ b/android/app/src/main/res/values-da/strings.xml
@@ -194,11 +194,11 @@
 	<string name="prefs_group_route">Navigation</string>
 	<string name="pref_zoom_title">Zoom knapper</string>
 	<string name="pref_zoom_summary">Vis på skærmen</string>
-	<!-- Settings «Map» category: «Appearance» title -->
-	<string name="pref_map_style_title">Udseende</string>
-	<!-- Settings "Appearance" category: "Light" title, should be consistent with the pref_map_style_title translation. -->
+	<!-- Settings «Map» category: «Night style» title -->
+	<string name="pref_map_style_title">Nattilstand</string>
+	<!-- Settings "Appearance" category: "Light" title, should be consistent with the pref_appearance_title translation. -->
 	<string name="pref_appearance_light">Lys</string>
-	<!-- Settings "Appearance" category: "Dark" title, should be consistent with the pref_map_style_title translation. -->
+	<!-- Settings "Appearance" category: "Dark" title, should be consistent with the pref_appearance_title translation. -->
 	<string name="pref_appearance_dark">Mørk</string>
 	<!-- Generic «Off» string -->
 	<string name="off">Fra</string>

--- a/android/app/src/main/res/values-de/strings.xml
+++ b/android/app/src/main/res/values-de/strings.xml
@@ -211,11 +211,11 @@
 	<string name="prefs_group_route">Navigation</string>
 	<string name="pref_zoom_title">Zoom-Tasten</string>
 	<string name="pref_zoom_summary">Auf dem Bildschirm anzeigen</string>
-	<!-- Settings «Map» category: «Appearance» title -->
-	<string name="pref_map_style_title">Erscheinungsbild</string>
-	<!-- Settings "Appearance" category: "Light" title, should be consistent with the pref_map_style_title translation. -->
+	<!-- Settings «Map» category: «Night style» title -->
+	<string name="pref_map_style_title">Nachtmodus</string>
+	<!-- Settings "Appearance" category: "Light" title, should be consistent with the pref_appearance_title translation. -->
 	<string name="pref_appearance_light">Hell</string>
-	<!-- Settings "Appearance" category: "Dark" title, should be consistent with the pref_map_style_title translation. -->
+	<!-- Settings "Appearance" category: "Dark" title, should be consistent with the pref_appearance_title translation. -->
 	<string name="pref_appearance_dark">Dunkel</string>
 	<!-- Generic «Off» string -->
 	<string name="off">Aus</string>

--- a/android/app/src/main/res/values-el/strings.xml
+++ b/android/app/src/main/res/values-el/strings.xml
@@ -195,11 +195,11 @@
 	<string name="prefs_group_route">Πλοήγηση</string>
 	<string name="pref_zoom_title">Πλήκτρα μεγέθυνσης</string>
 	<string name="pref_zoom_summary">Εμφάνιση στο χάρτη</string>
-	<!-- Settings «Map» category: «Appearance» title -->
-	<string name="pref_map_style_title">Εμφάνιση</string>
-	<!-- Settings "Appearance" category: "Light" title, should be consistent with the pref_map_style_title translation. -->
+	<!-- Settings «Map» category: «Night style» title -->
+	<string name="pref_map_style_title">Νυχτερινή λειτουργία</string>
+	<!-- Settings "Appearance" category: "Light" title, should be consistent with the pref_appearance_title translation. -->
 	<string name="pref_appearance_light">Ανοιχτόχρωμη</string>
-	<!-- Settings "Appearance" category: "Dark" title, should be consistent with the pref_map_style_title translation. -->
+	<!-- Settings "Appearance" category: "Dark" title, should be consistent with the pref_appearance_title translation. -->
 	<string name="pref_appearance_dark">Σκουρόχρωμη</string>
 	<!-- Generic «Off» string -->
 	<string name="off">Απενεργ.</string>

--- a/android/app/src/main/res/values-es/strings.xml
+++ b/android/app/src/main/res/values-es/strings.xml
@@ -211,11 +211,11 @@
 	<string name="prefs_group_route">Navegación</string>
 	<string name="pref_zoom_title">Botones de zoom</string>
 	<string name="pref_zoom_summary">Visualización en la pantalla</string>
-	<!-- Settings «Map» category: «Appearance» title -->
-	<string name="pref_map_style_title">Aspecto</string>
-	<!-- Settings "Appearance" category: "Light" title, should be consistent with the pref_map_style_title translation. -->
+	<!-- Settings «Map» category: «Night style» title -->
+	<string name="pref_map_style_title">Modo nocturno</string>
+	<!-- Settings "Appearance" category: "Light" title, should be consistent with the pref_appearance_title translation. -->
 	<string name="pref_appearance_light">Claro</string>
-	<!-- Settings "Appearance" category: "Dark" title, should be consistent with the pref_map_style_title translation. -->
+	<!-- Settings "Appearance" category: "Dark" title, should be consistent with the pref_appearance_title translation. -->
 	<string name="pref_appearance_dark">Oscuro</string>
 	<!-- Generic «Off» string -->
 	<string name="off">Desactivado</string>

--- a/android/app/src/main/res/values-et/strings.xml
+++ b/android/app/src/main/res/values-et/strings.xml
@@ -203,11 +203,11 @@
 	<string name="prefs_group_route">Navigeerimine</string>
 	<string name="pref_zoom_title">Zoomi nupud</string>
 	<string name="pref_zoom_summary">Kuva kaardil</string>
-	<!-- Settings «Map» category: «Appearance» title -->
-	<string name="pref_map_style_title">Välimus</string>
-	<!-- Settings "Appearance" category: "Light" title, should be consistent with the pref_map_style_title translation. -->
+	<!-- Settings «Map» category: «Night style» title -->
+	<string name="pref_map_style_title">Öörežiim</string>
+	<!-- Settings "Appearance" category: "Light" title, should be consistent with the pref_appearance_title translation. -->
 	<string name="pref_appearance_light">Valgus</string>
-	<!-- Settings "Appearance" category: "Dark" title, should be consistent with the pref_map_style_title translation. -->
+	<!-- Settings "Appearance" category: "Dark" title, should be consistent with the pref_appearance_title translation. -->
 	<string name="pref_appearance_dark">Tume</string>
 	<!-- Generic «Off» string -->
 	<string name="off">Väljas</string>

--- a/android/app/src/main/res/values-eu/strings.xml
+++ b/android/app/src/main/res/values-eu/strings.xml
@@ -211,11 +211,11 @@
 	<string name="prefs_group_route">Nabigazioa</string>
 	<string name="pref_zoom_title">Zoom botoiak</string>
 	<string name="pref_zoom_summary">Erakutsi mapan</string>
-	<!-- Settings «Map» category: «Appearance» title -->
-	<string name="pref_map_style_title">Itxura</string>
-	<!-- Settings "Appearance" category: "Light" title, should be consistent with the pref_map_style_title translation. -->
+	<!-- Settings «Map» category: «Night style» title -->
+	<string name="pref_map_style_title">Gaueko modua</string>
+	<!-- Settings "Appearance" category: "Light" title, should be consistent with the pref_appearance_title translation. -->
 	<string name="pref_appearance_light">Argi</string>
-	<!-- Settings "Appearance" category: "Dark" title, should be consistent with the pref_map_style_title translation. -->
+	<!-- Settings "Appearance" category: "Dark" title, should be consistent with the pref_appearance_title translation. -->
 	<string name="pref_appearance_dark">Iluna</string>
 	<!-- Generic «Off» string -->
 	<string name="off">Desgaituta</string>

--- a/android/app/src/main/res/values-fa/strings.xml
+++ b/android/app/src/main/res/values-fa/strings.xml
@@ -187,11 +187,11 @@
 	<string name="prefs_group_route">مسیریابی</string>
 	<string name="pref_zoom_title">دکمه‌های بزرگنمایی</string>
 	<string name="pref_zoom_summary">نمایش بر روی نقشه</string>
-	<!-- Settings «Map» category: «Appearance» title -->
-	<string name="pref_map_style_title">ظاهری</string>
-	<!-- Settings "Appearance" category: "Light" title, should be consistent with the pref_map_style_title translation. -->
+	<!-- Settings «Map» category: «Night style» title -->
+	<string name="pref_map_style_title">حالت شب</string>
+	<!-- Settings "Appearance" category: "Light" title, should be consistent with the pref_appearance_title translation. -->
 	<string name="pref_appearance_light">نور</string>
-	<!-- Settings "Appearance" category: "Dark" title, should be consistent with the pref_map_style_title translation. -->
+	<!-- Settings "Appearance" category: "Dark" title, should be consistent with the pref_appearance_title translation. -->
 	<string name="pref_appearance_dark">تاریک</string>
 	<!-- Generic «Off» string -->
 	<string name="off">خاموش</string>

--- a/android/app/src/main/res/values-fi/strings.xml
+++ b/android/app/src/main/res/values-fi/strings.xml
@@ -213,11 +213,11 @@
 	<string name="prefs_group_route">Navigointi</string>
 	<string name="pref_zoom_title">Zoomauspainikkeet</string>
 	<string name="pref_zoom_summary">Näytä kartalla</string>
-	<!-- Settings «Map» category: «Appearance» title -->
-	<string name="pref_map_style_title">Ulkoasu</string>
-	<!-- Settings "Appearance" category: "Light" title, should be consistent with the pref_map_style_title translation. -->
+	<!-- Settings «Map» category: «Night style» title -->
+	<string name="pref_map_style_title">Yötila</string>
+	<!-- Settings "Appearance" category: "Light" title, should be consistent with the pref_appearance_title translation. -->
 	<string name="pref_appearance_light">Vaalea</string>
-	<!-- Settings "Appearance" category: "Dark" title, should be consistent with the pref_map_style_title translation. -->
+	<!-- Settings "Appearance" category: "Dark" title, should be consistent with the pref_appearance_title translation. -->
 	<string name="pref_appearance_dark">Tumma</string>
 	<!-- Generic «Off» string -->
 	<string name="off">Pois päältä</string>

--- a/android/app/src/main/res/values-fr/strings.xml
+++ b/android/app/src/main/res/values-fr/strings.xml
@@ -213,11 +213,11 @@
 	<string name="prefs_group_route">Navigation</string>
 	<string name="pref_zoom_title">Boutons de zoom</string>
 	<string name="pref_zoom_summary">Afficher à l\'écran</string>
-	<!-- Settings «Map» category: «Appearance» title -->
-	<string name="pref_map_style_title">Apparence</string>
-	<!-- Settings "Appearance" category: "Light" title, should be consistent with the pref_map_style_title translation. -->
+	<!-- Settings «Map» category: «Night style» title -->
+	<string name="pref_map_style_title">Mode nuit</string>
+	<!-- Settings "Appearance" category: "Light" title, should be consistent with the pref_appearance_title translation. -->
 	<string name="pref_appearance_light">Claire</string>
-	<!-- Settings "Appearance" category: "Dark" title, should be consistent with the pref_map_style_title translation. -->
+	<!-- Settings "Appearance" category: "Dark" title, should be consistent with the pref_appearance_title translation. -->
 	<string name="pref_appearance_dark">Sombre</string>
 	<!-- Generic «Off» string -->
 	<string name="off">Désactivé</string>

--- a/android/app/src/main/res/values-hi/strings.xml
+++ b/android/app/src/main/res/values-hi/strings.xml
@@ -212,11 +212,11 @@
 	<string name="prefs_group_route">मार्गदर्शन</string>
 	<string name="pref_zoom_title">ज़ूम बटन</string>
 	<string name="pref_zoom_summary">मानचित्र पर बटन प्रदर्शित करें</string>
-	<!-- Settings «Map» category: «Appearance» title -->
-	<string name="pref_map_style_title">प्रकटन</string>
-	<!-- Settings "Appearance" category: "Light" title, should be consistent with the pref_map_style_title translation. -->
+	<!-- Settings «Map» category: «Night style» title -->
+	<string name="pref_map_style_title">रात का मोड</string>
+	<!-- Settings "Appearance" category: "Light" title, should be consistent with the pref_appearance_title translation. -->
 	<string name="pref_appearance_light">हल्का</string>
-	<!-- Settings "Appearance" category: "Dark" title, should be consistent with the pref_map_style_title translation. -->
+	<!-- Settings "Appearance" category: "Dark" title, should be consistent with the pref_appearance_title translation. -->
 	<string name="pref_appearance_dark">गहरा</string>
 	<!-- Generic «Off» string -->
 	<string name="off">बंद</string>

--- a/android/app/src/main/res/values-hu/strings.xml
+++ b/android/app/src/main/res/values-hu/strings.xml
@@ -208,11 +208,11 @@
 	<string name="prefs_group_route">Navigáció</string>
 	<string name="pref_zoom_title">Nagyítás/kicsinyítés gombok</string>
 	<string name="pref_zoom_summary">Mutassa a kijelzőn</string>
-	<!-- Settings «Map» category: «Appearance» title -->
-	<string name="pref_map_style_title">Megjelenés</string>
-	<!-- Settings "Appearance" category: "Light" title, should be consistent with the pref_map_style_title translation. -->
+	<!-- Settings «Map» category: «Night style» title -->
+	<string name="pref_map_style_title">Éjszakai üzemmód</string>
+	<!-- Settings "Appearance" category: "Light" title, should be consistent with the pref_appearance_title translation. -->
 	<string name="pref_appearance_light">Világos</string>
-	<!-- Settings "Appearance" category: "Dark" title, should be consistent with the pref_map_style_title translation. -->
+	<!-- Settings "Appearance" category: "Dark" title, should be consistent with the pref_appearance_title translation. -->
 	<string name="pref_appearance_dark">Sötét</string>
 	<!-- Generic «Off» string -->
 	<string name="off">Ki</string>

--- a/android/app/src/main/res/values-in/strings.xml
+++ b/android/app/src/main/res/values-in/strings.xml
@@ -196,11 +196,11 @@
 	<string name="prefs_group_route">Navigasi</string>
 	<string name="pref_zoom_title">Tombol perbesaran</string>
 	<string name="pref_zoom_summary">Tampilkan pada layar</string>
-	<!-- Settings «Map» category: «Appearance» title -->
-	<string name="pref_map_style_title">Tampilan</string>
-	<!-- Settings "Appearance" category: "Light" title, should be consistent with the pref_map_style_title translation. -->
+	<!-- Settings «Map» category: «Night style» title -->
+	<string name="pref_map_style_title">Mode Malam</string>
+	<!-- Settings "Appearance" category: "Light" title, should be consistent with the pref_appearance_title translation. -->
 	<string name="pref_appearance_light">Terang</string>
-	<!-- Settings "Appearance" category: "Dark" title, should be consistent with the pref_map_style_title translation. -->
+	<!-- Settings "Appearance" category: "Dark" title, should be consistent with the pref_appearance_title translation. -->
 	<string name="pref_appearance_dark">Gelap</string>
 	<!-- Generic «Off» string -->
 	<string name="off">Tidak Aktif</string>

--- a/android/app/src/main/res/values-it/strings.xml
+++ b/android/app/src/main/res/values-it/strings.xml
@@ -199,11 +199,11 @@
 	<string name="prefs_group_route">Navigazione</string>
 	<string name="pref_zoom_title">Pulsanti per lo zoom</string>
 	<string name="pref_zoom_summary">Mostra sulla mappa</string>
-	<!-- Settings «Map» category: «Appearance» title -->
-	<string name="pref_map_style_title">Aspetto</string>
-	<!-- Settings "Appearance" category: "Light" title, should be consistent with the pref_map_style_title translation. -->
+	<!-- Settings «Map» category: «Night style» title -->
+	<string name="pref_map_style_title">Modalità notturna</string>
+	<!-- Settings "Appearance" category: "Light" title, should be consistent with the pref_appearance_title translation. -->
 	<string name="pref_appearance_light">Chiaro</string>
-	<!-- Settings "Appearance" category: "Dark" title, should be consistent with the pref_map_style_title translation. -->
+	<!-- Settings "Appearance" category: "Dark" title, should be consistent with the pref_appearance_title translation. -->
 	<string name="pref_appearance_dark">Scuro</string>
 	<!-- Generic «Off» string -->
 	<string name="off">Spento</string>

--- a/android/app/src/main/res/values-iw/strings.xml
+++ b/android/app/src/main/res/values-iw/strings.xml
@@ -209,11 +209,11 @@
 	<string name="prefs_group_route">ניווט</string>
 	<string name="pref_zoom_title">כפתורי זום</string>
 	<string name="pref_zoom_summary">הצג על המסך</string>
-	<!-- Settings «Map» category: «Appearance» title -->
-	<string name="pref_map_style_title">מראה</string>
-	<!-- Settings "Appearance" category: "Light" title, should be consistent with the pref_map_style_title translation. -->
+	<!-- Settings «Map» category: «Night style» title -->
+	<string name="pref_map_style_title">מצב לילה</string>
+	<!-- Settings "Appearance" category: "Light" title, should be consistent with the pref_appearance_title translation. -->
 	<string name="pref_appearance_light">בהיר</string>
-	<!-- Settings "Appearance" category: "Dark" title, should be consistent with the pref_map_style_title translation. -->
+	<!-- Settings "Appearance" category: "Dark" title, should be consistent with the pref_appearance_title translation. -->
 	<string name="pref_appearance_dark">כהה</string>
 	<!-- Generic «Off» string -->
 	<string name="off">כבוי</string>

--- a/android/app/src/main/res/values-ja/strings.xml
+++ b/android/app/src/main/res/values-ja/strings.xml
@@ -211,11 +211,11 @@
 	<string name="prefs_group_route">ナビゲーション</string>
 	<string name="pref_zoom_title">ズームボタン</string>
 	<string name="pref_zoom_summary">画面上に表示</string>
-	<!-- Settings «Map» category: «Appearance» title -->
-	<string name="pref_map_style_title">外観</string>
-	<!-- Settings "Appearance" category: "Light" title, should be consistent with the pref_map_style_title translation. -->
+	<!-- Settings «Map» category: «Night style» title -->
+	<string name="pref_map_style_title">夜間モード</string>
+	<!-- Settings "Appearance" category: "Light" title, should be consistent with the pref_appearance_title translation. -->
 	<string name="pref_appearance_light">ライト</string>
-	<!-- Settings "Appearance" category: "Dark" title, should be consistent with the pref_map_style_title translation. -->
+	<!-- Settings "Appearance" category: "Dark" title, should be consistent with the pref_appearance_title translation. -->
 	<string name="pref_appearance_dark">ダーク</string>
 	<!-- Generic «Off» string -->
 	<string name="off">オフ</string>

--- a/android/app/src/main/res/values-ko/strings.xml
+++ b/android/app/src/main/res/values-ko/strings.xml
@@ -194,11 +194,11 @@
 	<string name="prefs_group_route">네비게이션</string>
 	<string name="pref_zoom_title">확대/축소 버튼</string>
 	<string name="pref_zoom_summary">화면에 표시</string>
-	<!-- Settings «Map» category: «Appearance» title -->
-	<string name="pref_map_style_title">모양</string>
-	<!-- Settings "Appearance" category: "Light" title, should be consistent with the pref_map_style_title translation. -->
+	<!-- Settings «Map» category: «Night style» title -->
+	<string name="pref_map_style_title">나이트 모드</string>
+	<!-- Settings "Appearance" category: "Light" title, should be consistent with the pref_appearance_title translation. -->
 	<string name="pref_appearance_light">라이트</string>
-	<!-- Settings "Appearance" category: "Dark" title, should be consistent with the pref_map_style_title translation. -->
+	<!-- Settings "Appearance" category: "Dark" title, should be consistent with the pref_appearance_title translation. -->
 	<string name="pref_appearance_dark">다크</string>
 	<!-- Generic «Off» string -->
 	<string name="off">끄기</string>

--- a/android/app/src/main/res/values-mr/strings.xml
+++ b/android/app/src/main/res/values-mr/strings.xml
@@ -187,11 +187,11 @@
 	<string name="prefs_group_route">मार्गनिर्देशन</string>
 	<string name="pref_zoom_title">झूम बटणे</string>
 	<string name="pref_zoom_summary">नकाशावर दाखवा</string>
-	<!-- Settings «Map» category: «Appearance» title -->
-	<string name="pref_map_style_title">प्रतिमा</string>
-	<!-- Settings "Appearance" category: "Light" title, should be consistent with the pref_map_style_title translation. -->
+	<!-- Settings «Map» category: «Night style» title -->
+	<string name="pref_map_style_title">रात्र मोड</string>
+	<!-- Settings "Appearance" category: "Light" title, should be consistent with the pref_appearance_title translation. -->
 	<string name="pref_appearance_light">प्रकाश</string>
-	<!-- Settings "Appearance" category: "Dark" title, should be consistent with the pref_map_style_title translation. -->
+	<!-- Settings "Appearance" category: "Dark" title, should be consistent with the pref_appearance_title translation. -->
 	<string name="pref_appearance_dark">अंधार</string>
 	<!-- Generic «Off» string -->
 	<string name="off">बंद</string>

--- a/android/app/src/main/res/values-nb/strings.xml
+++ b/android/app/src/main/res/values-nb/strings.xml
@@ -213,11 +213,11 @@
 	<string name="prefs_group_route">Navigasjon</string>
 	<string name="pref_zoom_title">Zoom-knapper</string>
 	<string name="pref_zoom_summary">Vis på skjermen</string>
-	<!-- Settings «Map» category: «Appearance» title -->
-	<string name="pref_map_style_title">Utseende</string>
-	<!-- Settings "Appearance" category: "Light" title, should be consistent with the pref_map_style_title translation. -->
+	<!-- Settings «Map» category: «Night style» title -->
+	<string name="pref_map_style_title">Nattmodus</string>
+	<!-- Settings "Appearance" category: "Light" title, should be consistent with the pref_appearance_title translation. -->
 	<string name="pref_appearance_light">Lys</string>
-	<!-- Settings "Appearance" category: "Dark" title, should be consistent with the pref_map_style_title translation. -->
+	<!-- Settings "Appearance" category: "Dark" title, should be consistent with the pref_appearance_title translation. -->
 	<string name="pref_appearance_dark">Mørke</string>
 	<!-- Generic «Off» string -->
 	<string name="off">Av</string>

--- a/android/app/src/main/res/values-nl/strings.xml
+++ b/android/app/src/main/res/values-nl/strings.xml
@@ -211,11 +211,11 @@
 	<string name="prefs_group_route">Navigatie</string>
 	<string name="pref_zoom_title">Zoomknoppen</string>
 	<string name="pref_zoom_summary">Weergave op het scherm</string>
-	<!-- Settings «Map» category: «Appearance» title -->
-	<string name="pref_map_style_title">Weergave</string>
-	<!-- Settings "Appearance" category: "Light" title, should be consistent with the pref_map_style_title translation. -->
+	<!-- Settings «Map» category: «Night style» title -->
+	<string name="pref_map_style_title">Nachtmodus</string>
+	<!-- Settings "Appearance" category: "Light" title, should be consistent with the pref_appearance_title translation. -->
 	<string name="pref_appearance_light">Licht</string>
-	<!-- Settings "Appearance" category: "Dark" title, should be consistent with the pref_map_style_title translation. -->
+	<!-- Settings "Appearance" category: "Dark" title, should be consistent with the pref_appearance_title translation. -->
 	<string name="pref_appearance_dark">Donker</string>
 	<!-- Generic «Off» string -->
 	<string name="off">Uit</string>

--- a/android/app/src/main/res/values-pl/strings.xml
+++ b/android/app/src/main/res/values-pl/strings.xml
@@ -211,11 +211,11 @@
 	<string name="prefs_group_route">Nawigacja</string>
 	<string name="pref_zoom_title">Przyciski przybliżania</string>
 	<string name="pref_zoom_summary">Wyświetla na ekranie</string>
-	<!-- Settings «Map» category: «Appearance» title -->
-	<string name="pref_map_style_title">Wygląd</string>
-	<!-- Settings "Appearance" category: "Light" title, should be consistent with the pref_map_style_title translation. -->
+	<!-- Settings «Map» category: «Night style» title -->
+	<string name="pref_map_style_title">Tryb nocny</string>
+	<!-- Settings "Appearance" category: "Light" title, should be consistent with the pref_appearance_title translation. -->
 	<string name="pref_appearance_light">Jasny</string>
-	<!-- Settings "Appearance" category: "Dark" title, should be consistent with the pref_map_style_title translation. -->
+	<!-- Settings "Appearance" category: "Dark" title, should be consistent with the pref_appearance_title translation. -->
 	<string name="pref_appearance_dark">Ciemny</string>
 	<!-- Generic «Off» string -->
 	<string name="off">Wyłączony</string>

--- a/android/app/src/main/res/values-pt-rBR/strings.xml
+++ b/android/app/src/main/res/values-pt-rBR/strings.xml
@@ -209,11 +209,11 @@
 	<string name="prefs_group_route">Navegação</string>
 	<string name="pref_zoom_title">Botões de zoom</string>
 	<string name="pref_zoom_summary">Mostrar na tela</string>
-	<!-- Settings «Map» category: «Appearance» title -->
-	<string name="pref_map_style_title">Aparência</string>
-	<!-- Settings "Appearance" category: "Light" title, should be consistent with the pref_map_style_title translation. -->
+	<!-- Settings «Map» category: «Night style» title -->
+	<string name="pref_map_style_title">Modo noturno</string>
+	<!-- Settings "Appearance" category: "Light" title, should be consistent with the pref_appearance_title translation. -->
 	<string name="pref_appearance_light">Clara</string>
-	<!-- Settings "Appearance" category: "Dark" title, should be consistent with the pref_map_style_title translation. -->
+	<!-- Settings "Appearance" category: "Dark" title, should be consistent with the pref_appearance_title translation. -->
 	<string name="pref_appearance_dark">Escura</string>
 	<!-- Generic «Off» string -->
 	<string name="off">Desligado</string>

--- a/android/app/src/main/res/values-pt/strings.xml
+++ b/android/app/src/main/res/values-pt/strings.xml
@@ -199,11 +199,11 @@
 	<string name="prefs_group_route">Navegação</string>
 	<string name="pref_zoom_title">Botões de ampliação</string>
 	<string name="pref_zoom_summary">Mostrar no ecrã</string>
-	<!-- Settings «Map» category: «Appearance» title -->
-	<string name="pref_map_style_title">Apresentação</string>
-	<!-- Settings "Appearance" category: "Light" title, should be consistent with the pref_map_style_title translation. -->
+	<!-- Settings «Map» category: «Night style» title -->
+	<string name="pref_map_style_title">Modo noturno</string>
+	<!-- Settings "Appearance" category: "Light" title, should be consistent with the pref_appearance_title translation. -->
 	<string name="pref_appearance_light">Tons claros</string>
-	<!-- Settings "Appearance" category: "Dark" title, should be consistent with the pref_map_style_title translation. -->
+	<!-- Settings "Appearance" category: "Dark" title, should be consistent with the pref_appearance_title translation. -->
 	<string name="pref_appearance_dark">Tons escuros</string>
 	<!-- Generic «Off» string -->
 	<string name="off">Desligado</string>

--- a/android/app/src/main/res/values-ro/strings.xml
+++ b/android/app/src/main/res/values-ro/strings.xml
@@ -199,11 +199,11 @@
 	<string name="prefs_group_route">Navigare</string>
 	<string name="pref_zoom_title">Butoane zoom</string>
 	<string name="pref_zoom_summary">Arată pe hartă</string>
-	<!-- Settings «Map» category: «Appearance» title -->
-	<string name="pref_map_style_title">Aspect</string>
-	<!-- Settings "Appearance" category: "Light" title, should be consistent with the pref_map_style_title translation. -->
+	<!-- Settings «Map» category: «Night style» title -->
+	<string name="pref_map_style_title">Mod nocturn</string>
+	<!-- Settings "Appearance" category: "Light" title, should be consistent with the pref_appearance_title translation. -->
 	<string name="pref_appearance_light">Luminos</string>
-	<!-- Settings "Appearance" category: "Dark" title, should be consistent with the pref_map_style_title translation. -->
+	<!-- Settings "Appearance" category: "Dark" title, should be consistent with the pref_appearance_title translation. -->
 	<string name="pref_appearance_dark">Întunecat</string>
 	<!-- Generic «Off» string -->
 	<string name="off">Oprit</string>

--- a/android/app/src/main/res/values-ru/strings.xml
+++ b/android/app/src/main/res/values-ru/strings.xml
@@ -214,11 +214,11 @@
 	<string name="prefs_group_route">Навигация</string>
 	<string name="pref_zoom_title">Кнопки масштаба</string>
 	<string name="pref_zoom_summary">Показать на карте</string>
-	<!-- Settings «Map» category: «Appearance» title -->
-	<string name="pref_map_style_title">Оформление</string>
-	<!-- Settings "Appearance" category: "Light" title, should be consistent with the pref_map_style_title translation. -->
+	<!-- Settings «Map» category: «Night style» title -->
+	<string name="pref_map_style_title">Ночной режим</string>
+	<!-- Settings "Appearance" category: "Light" title, should be consistent with the pref_appearance_title translation. -->
 	<string name="pref_appearance_light">Светлое</string>
-	<!-- Settings "Appearance" category: "Dark" title, should be consistent with the pref_map_style_title translation. -->
+	<!-- Settings "Appearance" category: "Dark" title, should be consistent with the pref_appearance_title translation. -->
 	<string name="pref_appearance_dark">Темное</string>
 	<!-- Generic «Off» string -->
 	<string name="off">Выключен</string>

--- a/android/app/src/main/res/values-sk/strings.xml
+++ b/android/app/src/main/res/values-sk/strings.xml
@@ -194,11 +194,11 @@
 	<string name="prefs_group_route">Navigácia</string>
 	<string name="pref_zoom_title">Tlačidlá priblíženia/oddialenia</string>
 	<string name="pref_zoom_summary">Zobraziť na obrazovke</string>
-	<!-- Settings «Map» category: «Appearance» title -->
-	<string name="pref_map_style_title">Vzhľad</string>
-	<!-- Settings "Appearance" category: "Light" title, should be consistent with the pref_map_style_title translation. -->
+	<!-- Settings «Map» category: «Night style» title -->
+	<string name="pref_map_style_title">Nočný režim</string>
+	<!-- Settings "Appearance" category: "Light" title, should be consistent with the pref_appearance_title translation. -->
 	<string name="pref_appearance_light">Svetlý</string>
-	<!-- Settings "Appearance" category: "Dark" title, should be consistent with the pref_map_style_title translation. -->
+	<!-- Settings "Appearance" category: "Dark" title, should be consistent with the pref_appearance_title translation. -->
 	<string name="pref_appearance_dark">Tmavý</string>
 	<!-- Generic «Off» string -->
 	<string name="off">Vypnúť</string>

--- a/android/app/src/main/res/values-sv/strings.xml
+++ b/android/app/src/main/res/values-sv/strings.xml
@@ -192,11 +192,11 @@
 	<string name="prefs_group_route">Navigering</string>
 	<string name="pref_zoom_title">Zoom-knappar</string>
 	<string name="pref_zoom_summary">Visa på skärmen</string>
-	<!-- Settings «Map» category: «Appearance» title -->
-	<string name="pref_map_style_title">Utseende</string>
-	<!-- Settings "Appearance" category: "Light" title, should be consistent with the pref_map_style_title translation. -->
+	<!-- Settings «Map» category: «Night style» title -->
+	<string name="pref_map_style_title">Nattläge</string>
+	<!-- Settings "Appearance" category: "Light" title, should be consistent with the pref_appearance_title translation. -->
 	<string name="pref_appearance_light">Ljust</string>
-	<!-- Settings "Appearance" category: "Dark" title, should be consistent with the pref_map_style_title translation. -->
+	<!-- Settings "Appearance" category: "Dark" title, should be consistent with the pref_appearance_title translation. -->
 	<string name="pref_appearance_dark">Mörkt</string>
 	<!-- Generic «Off» string -->
 	<string name="off">Av</string>

--- a/android/app/src/main/res/values-th/strings.xml
+++ b/android/app/src/main/res/values-th/strings.xml
@@ -196,11 +196,11 @@
 	<string name="prefs_group_route">การนำทาง</string>
 	<string name="pref_zoom_title">ปุ่มซูม</string>
 	<string name="pref_zoom_summary">แสดงบนหน้าจอ</string>
-	<!-- Settings «Map» category: «Appearance» title -->
-	<string name="pref_map_style_title">รูปแบบ</string>
-	<!-- Settings "Appearance" category: "Light" title, should be consistent with the pref_map_style_title translation. -->
+	<!-- Settings «Map» category: «Night style» title -->
+	<string name="pref_map_style_title">โหมดกลางคืน</string>
+	<!-- Settings "Appearance" category: "Light" title, should be consistent with the pref_appearance_title translation. -->
 	<string name="pref_appearance_light">สว่าง</string>
-	<!-- Settings "Appearance" category: "Dark" title, should be consistent with the pref_map_style_title translation. -->
+	<!-- Settings "Appearance" category: "Dark" title, should be consistent with the pref_appearance_title translation. -->
 	<string name="pref_appearance_dark">มืด</string>
 	<!-- Generic «Off» string -->
 	<string name="off">ปิด</string>

--- a/android/app/src/main/res/values-tr/strings.xml
+++ b/android/app/src/main/res/values-tr/strings.xml
@@ -213,11 +213,11 @@
 	<string name="prefs_group_route">Navigasyon</string>
 	<string name="pref_zoom_title">Yakınlaştırma butonları</string>
 	<string name="pref_zoom_summary">Haritada göster</string>
-	<!-- Settings «Map» category: «Appearance» title -->
-	<string name="pref_map_style_title">Görünüş</string>
-	<!-- Settings "Appearance" category: "Light" title, should be consistent with the pref_map_style_title translation. -->
+	<!-- Settings «Map» category: «Night style» title -->
+	<string name="pref_map_style_title">Gece Modu</string>
+	<!-- Settings "Appearance" category: "Light" title, should be consistent with the pref_appearance_title translation. -->
 	<string name="pref_appearance_light">Açık</string>
-	<!-- Settings "Appearance" category: "Dark" title, should be consistent with the pref_map_style_title translation. -->
+	<!-- Settings "Appearance" category: "Dark" title, should be consistent with the pref_appearance_title translation. -->
 	<string name="pref_appearance_dark">Koyu</string>
 	<!-- Generic «Off» string -->
 	<string name="off">Kapalı</string>

--- a/android/app/src/main/res/values-uk/strings.xml
+++ b/android/app/src/main/res/values-uk/strings.xml
@@ -214,11 +214,11 @@
 	<string name="prefs_group_route">Навігація</string>
 	<string name="pref_zoom_title">Кнопки трансфокації</string>
 	<string name="pref_zoom_summary">Відображення на екрані</string>
-	<!-- Settings «Map» category: «Appearance» title -->
-	<string name="pref_map_style_title">Вигляд</string>
-	<!-- Settings "Appearance" category: "Light" title, should be consistent with the pref_map_style_title translation. -->
+	<!-- Settings «Map» category: «Night style» title -->
+	<string name="pref_map_style_title">Нічний режим</string>
+	<!-- Settings "Appearance" category: "Light" title, should be consistent with the pref_appearance_title translation. -->
 	<string name="pref_appearance_light">Світлий</string>
-	<!-- Settings "Appearance" category: "Dark" title, should be consistent with the pref_map_style_title translation. -->
+	<!-- Settings "Appearance" category: "Dark" title, should be consistent with the pref_appearance_title translation. -->
 	<string name="pref_appearance_dark">Темний</string>
 	<!-- Generic «Off» string -->
 	<string name="off">Вимкнуто</string>

--- a/android/app/src/main/res/values-vi/strings.xml
+++ b/android/app/src/main/res/values-vi/strings.xml
@@ -194,11 +194,11 @@
 	<string name="prefs_group_route">Điều hướng</string>
 	<string name="pref_zoom_title">Nút Phóng to/Thu nhỏ</string>
 	<string name="pref_zoom_summary">Hiển thị trên màn hình</string>
-	<!-- Settings «Map» category: «Appearance» title -->
-	<string name="pref_map_style_title">Giao diện</string>
-	<!-- Settings "Appearance" category: "Light" title, should be consistent with the pref_map_style_title translation. -->
+	<!-- Settings «Map» category: «Night style» title -->
+	<string name="pref_map_style_title">Chế độ ban đêm</string>
+	<!-- Settings "Appearance" category: "Light" title, should be consistent with the pref_appearance_title translation. -->
 	<string name="pref_appearance_light">Sáng</string>
-	<!-- Settings "Appearance" category: "Dark" title, should be consistent with the pref_map_style_title translation. -->
+	<!-- Settings "Appearance" category: "Dark" title, should be consistent with the pref_appearance_title translation. -->
 	<string name="pref_appearance_dark">Tối</string>
 	<!-- Generic «Off» string -->
 	<string name="off">Tắt</string>

--- a/android/app/src/main/res/values-zh-rTW/strings.xml
+++ b/android/app/src/main/res/values-zh-rTW/strings.xml
@@ -199,11 +199,11 @@
 	<string name="prefs_group_route">導航</string>
 	<string name="pref_zoom_title">縮放按鈕</string>
 	<string name="pref_zoom_summary">在螢幕上顯示</string>
-	<!-- Settings «Map» category: «Appearance» title -->
-	<string name="pref_map_style_title">外觀</string>
-	<!-- Settings "Appearance" category: "Light" title, should be consistent with the pref_map_style_title translation. -->
+	<!-- Settings «Map» category: «Night style» title -->
+	<string name="pref_map_style_title">夜間模式</string>
+	<!-- Settings "Appearance" category: "Light" title, should be consistent with the pref_appearance_title translation. -->
 	<string name="pref_appearance_light">淺色</string>
-	<!-- Settings "Appearance" category: "Dark" title, should be consistent with the pref_map_style_title translation. -->
+	<!-- Settings "Appearance" category: "Dark" title, should be consistent with the pref_appearance_title translation. -->
 	<string name="pref_appearance_dark">深色</string>
 	<!-- Generic «Off» string -->
 	<string name="off">關閉</string>

--- a/android/app/src/main/res/values-zh/strings.xml
+++ b/android/app/src/main/res/values-zh/strings.xml
@@ -198,11 +198,11 @@
 	<string name="prefs_group_route">导航</string>
 	<string name="pref_zoom_title">缩放按钮</string>
 	<string name="pref_zoom_summary">在屏幕上显示</string>
-	<!-- Settings «Map» category: «Appearance» title -->
-	<string name="pref_map_style_title">外观</string>
-	<!-- Settings "Appearance" category: "Light" title, should be consistent with the pref_map_style_title translation. -->
+	<!-- Settings «Map» category: «Night style» title -->
+	<string name="pref_map_style_title">夜间模式</string>
+	<!-- Settings "Appearance" category: "Light" title, should be consistent with the pref_appearance_title translation. -->
 	<string name="pref_appearance_light">浅色</string>
-	<!-- Settings "Appearance" category: "Dark" title, should be consistent with the pref_map_style_title translation. -->
+	<!-- Settings "Appearance" category: "Dark" title, should be consistent with the pref_appearance_title translation. -->
 	<string name="pref_appearance_dark">深色</string>
 	<!-- Generic «Off» string -->
 	<string name="off">关闭</string>

--- a/android/app/src/main/res/values/strings.xml
+++ b/android/app/src/main/res/values/strings.xml
@@ -214,11 +214,11 @@
 	<string name="prefs_group_route">Navigation</string>
 	<string name="pref_zoom_title">Zoom buttons</string>
 	<string name="pref_zoom_summary">Display on the map</string>
-	<!-- Settings «Map» category: «Appearance» title -->
-	<string name="pref_map_style_title">Appearance</string>
-	<!-- Settings "Appearance" category: "Light" title, should be consistent with the pref_map_style_title translation. -->
+	<!-- Settings «Map» category: «Night style» title -->
+	<string name="pref_map_style_title">Night Mode</string>
+	<!-- Settings "Appearance" category: "Light" title, should be consistent with the pref_appearance_title translation. -->
 	<string name="pref_appearance_light">Light</string>
-	<!-- Settings "Appearance" category: "Dark" title, should be consistent with the pref_map_style_title translation. -->
+	<!-- Settings "Appearance" category: "Dark" title, should be consistent with the pref_appearance_title translation. -->
 	<string name="pref_appearance_dark">Dark</string>
 	<!-- Generic «Off» string -->
 	<string name="off">Off</string>

--- a/data/strings/strings.txt
+++ b/data/strings/strings.txt
@@ -5149,8 +5149,53 @@
     zh-Hant = 在螢幕上顯示
 
   [pref_map_style_title]
+    comment = Settings «Map» category: «Night style» title
+    tags = android
+    en = Night Mode
+    af = Nagmodus
+    ar = الوضع الليلي
+    az = Gecə rejimi
+    be = Начны рэжым
+    bg = Нощен режим
+    ca = Mode nocturn
+    cs = Noční režim
+    da = Nattilstand
+    de = Nachtmodus
+    el = Νυχτερινή λειτουργία
+    es = Modo nocturno
+    et = Öörežiim
+    eu = Gaueko modua
+    fa = حالت شب
+    fi = Yötila
+    fr = Mode nuit
+    he = מצב לילה
+    hi = रात का मोड
+    hu = Éjszakai üzemmód
+    id = Mode Malam
+    it = Modalità notturna
+    ja = 夜間モード
+    ko = 나이트 모드
+    lt = Nakties režimas
+    mr = रात्र मोड
+    nb = Nattmodus
+    nl = Nachtmodus
+    pl = Tryb nocny
+    pt = Modo noturno
+    pt-BR = Modo noturno
+    ro = Mod nocturn
+    ru = Ночной режим
+    sk = Nočný režim
+    sv = Nattläge
+    th = โหมดกลางคืน
+    tr = Gece Modu
+    uk = Нічний режим
+    vi = Chế độ ban đêm
+    zh-Hans = 夜间模式
+    zh-Hant = 夜間模式
+
+  [pref_appearance_title]
     comment = Settings «Map» category: «Appearance» title
-    tags = android,ios
+    tags = ios
     en = Appearance
     ar = المظهر
     az = Görünüş
@@ -5193,7 +5238,7 @@
     zh-Hant = 外觀
 
   [pref_appearance_light]
-    comment = Settings "Appearance" category: "Light" title, should be consistent with the pref_map_style_title translation.
+    comment = Settings "Appearance" category: "Light" title, should be consistent with the pref_appearance_title translation.
     tags = android,ios
     en = Light
     ar = فاتح
@@ -5237,7 +5282,7 @@
     zh-Hant = 淺色
 
   [pref_appearance_dark]
-    comment = Settings "Appearance" category: "Dark" title, should be consistent with the pref_map_style_title translation.
+    comment = Settings "Appearance" category: "Dark" title, should be consistent with the pref_appearance_title translation.
     tags = android,ios
     en = Dark
     ar = داكن

--- a/iphone/Maps/LocalizedStrings/ar.lproj/Localizable.strings
+++ b/iphone/Maps/LocalizedStrings/ar.lproj/Localizable.strings
@@ -218,12 +218,12 @@
 "pref_zoom_title" = "أزرار التكبير والتصغير";
 
 /* Settings «Map» category: «Appearance» title */
-"pref_map_style_title" = "المظهر";
+"pref_appearance_title" = "المظهر";
 
-/* Settings "Appearance" category: "Light" title, should be consistent with the pref_map_style_title translation. */
+/* Settings "Appearance" category: "Light" title, should be consistent with the pref_appearance_title translation. */
 "pref_appearance_light" = "فاتح";
 
-/* Settings "Appearance" category: "Dark" title, should be consistent with the pref_map_style_title translation. */
+/* Settings "Appearance" category: "Dark" title, should be consistent with the pref_appearance_title translation. */
 "pref_appearance_dark" = "داكن";
 
 /* Generic «Off» string */

--- a/iphone/Maps/LocalizedStrings/az.lproj/Localizable.strings
+++ b/iphone/Maps/LocalizedStrings/az.lproj/Localizable.strings
@@ -218,12 +218,12 @@
 "pref_zoom_title" = "Böyütmə düymələri";
 
 /* Settings «Map» category: «Appearance» title */
-"pref_map_style_title" = "Görünüş";
+"pref_appearance_title" = "Görünüş";
 
-/* Settings "Appearance" category: "Light" title, should be consistent with the pref_map_style_title translation. */
+/* Settings "Appearance" category: "Light" title, should be consistent with the pref_appearance_title translation. */
 "pref_appearance_light" = "Parlaq";
 
-/* Settings "Appearance" category: "Dark" title, should be consistent with the pref_map_style_title translation. */
+/* Settings "Appearance" category: "Dark" title, should be consistent with the pref_appearance_title translation. */
 "pref_appearance_dark" = "Tünd";
 
 /* Generic «Off» string */

--- a/iphone/Maps/LocalizedStrings/be.lproj/Localizable.strings
+++ b/iphone/Maps/LocalizedStrings/be.lproj/Localizable.strings
@@ -218,12 +218,12 @@
 "pref_zoom_title" = "Кнопкі маштабавання";
 
 /* Settings «Map» category: «Appearance» title */
-"pref_map_style_title" = "Выгляд";
+"pref_appearance_title" = "Выгляд";
 
-/* Settings "Appearance" category: "Light" title, should be consistent with the pref_map_style_title translation. */
+/* Settings "Appearance" category: "Light" title, should be consistent with the pref_appearance_title translation. */
 "pref_appearance_light" = "Светлы";
 
-/* Settings "Appearance" category: "Dark" title, should be consistent with the pref_map_style_title translation. */
+/* Settings "Appearance" category: "Dark" title, should be consistent with the pref_appearance_title translation. */
 "pref_appearance_dark" = "Цемны";
 
 /* Generic «Off» string */

--- a/iphone/Maps/LocalizedStrings/bg.lproj/Localizable.strings
+++ b/iphone/Maps/LocalizedStrings/bg.lproj/Localizable.strings
@@ -218,12 +218,12 @@
 "pref_zoom_title" = "Мащабни бутони";
 
 /* Settings «Map» category: «Appearance» title */
-"pref_map_style_title" = "Изглед";
+"pref_appearance_title" = "Изглед";
 
-/* Settings "Appearance" category: "Light" title, should be consistent with the pref_map_style_title translation. */
+/* Settings "Appearance" category: "Light" title, should be consistent with the pref_appearance_title translation. */
 "pref_appearance_light" = "Светъл";
 
-/* Settings "Appearance" category: "Dark" title, should be consistent with the pref_map_style_title translation. */
+/* Settings "Appearance" category: "Dark" title, should be consistent with the pref_appearance_title translation. */
 "pref_appearance_dark" = "Тъмен";
 
 /* Generic «Off» string */

--- a/iphone/Maps/LocalizedStrings/ca.lproj/Localizable.strings
+++ b/iphone/Maps/LocalizedStrings/ca.lproj/Localizable.strings
@@ -218,12 +218,12 @@
 "pref_zoom_title" = "Botons de zoom";
 
 /* Settings «Map» category: «Appearance» title */
-"pref_map_style_title" = "Aspecte";
+"pref_appearance_title" = "Aspecte";
 
-/* Settings "Appearance" category: "Light" title, should be consistent with the pref_map_style_title translation. */
+/* Settings "Appearance" category: "Light" title, should be consistent with the pref_appearance_title translation. */
 "pref_appearance_light" = "Clar";
 
-/* Settings "Appearance" category: "Dark" title, should be consistent with the pref_map_style_title translation. */
+/* Settings "Appearance" category: "Dark" title, should be consistent with the pref_appearance_title translation. */
 "pref_appearance_dark" = "Fosc";
 
 /* Generic «Off» string */

--- a/iphone/Maps/LocalizedStrings/cs.lproj/Localizable.strings
+++ b/iphone/Maps/LocalizedStrings/cs.lproj/Localizable.strings
@@ -218,12 +218,12 @@
 "pref_zoom_title" = "Tlačítka přiblížení/oddálení";
 
 /* Settings «Map» category: «Appearance» title */
-"pref_map_style_title" = "Vzhled";
+"pref_appearance_title" = "Vzhled";
 
-/* Settings "Appearance" category: "Light" title, should be consistent with the pref_map_style_title translation. */
+/* Settings "Appearance" category: "Light" title, should be consistent with the pref_appearance_title translation. */
 "pref_appearance_light" = "Světlý";
 
-/* Settings "Appearance" category: "Dark" title, should be consistent with the pref_map_style_title translation. */
+/* Settings "Appearance" category: "Dark" title, should be consistent with the pref_appearance_title translation. */
 "pref_appearance_dark" = "Tmavý";
 
 /* Generic «Off» string */

--- a/iphone/Maps/LocalizedStrings/da.lproj/Localizable.strings
+++ b/iphone/Maps/LocalizedStrings/da.lproj/Localizable.strings
@@ -218,12 +218,12 @@
 "pref_zoom_title" = "Zoom knapper";
 
 /* Settings «Map» category: «Appearance» title */
-"pref_map_style_title" = "Udseende";
+"pref_appearance_title" = "Udseende";
 
-/* Settings "Appearance" category: "Light" title, should be consistent with the pref_map_style_title translation. */
+/* Settings "Appearance" category: "Light" title, should be consistent with the pref_appearance_title translation. */
 "pref_appearance_light" = "Lys";
 
-/* Settings "Appearance" category: "Dark" title, should be consistent with the pref_map_style_title translation. */
+/* Settings "Appearance" category: "Dark" title, should be consistent with the pref_appearance_title translation. */
 "pref_appearance_dark" = "Mørk";
 
 /* Generic «Off» string */

--- a/iphone/Maps/LocalizedStrings/de.lproj/Localizable.strings
+++ b/iphone/Maps/LocalizedStrings/de.lproj/Localizable.strings
@@ -218,12 +218,12 @@
 "pref_zoom_title" = "Zoom-Tasten";
 
 /* Settings «Map» category: «Appearance» title */
-"pref_map_style_title" = "Erscheinungsbild";
+"pref_appearance_title" = "Erscheinungsbild";
 
-/* Settings "Appearance" category: "Light" title, should be consistent with the pref_map_style_title translation. */
+/* Settings "Appearance" category: "Light" title, should be consistent with the pref_appearance_title translation. */
 "pref_appearance_light" = "Hell";
 
-/* Settings "Appearance" category: "Dark" title, should be consistent with the pref_map_style_title translation. */
+/* Settings "Appearance" category: "Dark" title, should be consistent with the pref_appearance_title translation. */
 "pref_appearance_dark" = "Dunkel";
 
 /* Generic «Off» string */

--- a/iphone/Maps/LocalizedStrings/el.lproj/Localizable.strings
+++ b/iphone/Maps/LocalizedStrings/el.lproj/Localizable.strings
@@ -218,12 +218,12 @@
 "pref_zoom_title" = "Πλήκτρα μεγέθυνσης";
 
 /* Settings «Map» category: «Appearance» title */
-"pref_map_style_title" = "Εμφάνιση";
+"pref_appearance_title" = "Εμφάνιση";
 
-/* Settings "Appearance" category: "Light" title, should be consistent with the pref_map_style_title translation. */
+/* Settings "Appearance" category: "Light" title, should be consistent with the pref_appearance_title translation. */
 "pref_appearance_light" = "Ανοιχτόχρωμη";
 
-/* Settings "Appearance" category: "Dark" title, should be consistent with the pref_map_style_title translation. */
+/* Settings "Appearance" category: "Dark" title, should be consistent with the pref_appearance_title translation. */
 "pref_appearance_dark" = "Σκουρόχρωμη";
 
 /* Generic «Off» string */

--- a/iphone/Maps/LocalizedStrings/en-GB.lproj/Localizable.strings
+++ b/iphone/Maps/LocalizedStrings/en-GB.lproj/Localizable.strings
@@ -218,12 +218,12 @@
 "pref_zoom_title" = "Zoom buttons";
 
 /* Settings «Map» category: «Appearance» title */
-"pref_map_style_title" = "Appearance";
+"pref_appearance_title" = "Appearance";
 
-/* Settings "Appearance" category: "Light" title, should be consistent with the pref_map_style_title translation. */
+/* Settings "Appearance" category: "Light" title, should be consistent with the pref_appearance_title translation. */
 "pref_appearance_light" = "Light";
 
-/* Settings "Appearance" category: "Dark" title, should be consistent with the pref_map_style_title translation. */
+/* Settings "Appearance" category: "Dark" title, should be consistent with the pref_appearance_title translation. */
 "pref_appearance_dark" = "Dark";
 
 /* Generic «Off» string */

--- a/iphone/Maps/LocalizedStrings/en.lproj/Localizable.strings
+++ b/iphone/Maps/LocalizedStrings/en.lproj/Localizable.strings
@@ -218,12 +218,12 @@
 "pref_zoom_title" = "Zoom buttons";
 
 /* Settings «Map» category: «Appearance» title */
-"pref_map_style_title" = "Appearance";
+"pref_appearance_title" = "Appearance";
 
-/* Settings "Appearance" category: "Light" title, should be consistent with the pref_map_style_title translation. */
+/* Settings "Appearance" category: "Light" title, should be consistent with the pref_appearance_title translation. */
 "pref_appearance_light" = "Light";
 
-/* Settings "Appearance" category: "Dark" title, should be consistent with the pref_map_style_title translation. */
+/* Settings "Appearance" category: "Dark" title, should be consistent with the pref_appearance_title translation. */
 "pref_appearance_dark" = "Dark";
 
 /* Generic «Off» string */

--- a/iphone/Maps/LocalizedStrings/es-MX.lproj/Localizable.strings
+++ b/iphone/Maps/LocalizedStrings/es-MX.lproj/Localizable.strings
@@ -218,12 +218,12 @@
 "pref_zoom_title" = "Botones de zoom";
 
 /* Settings «Map» category: «Appearance» title */
-"pref_map_style_title" = "Aspecto";
+"pref_appearance_title" = "Aspecto";
 
-/* Settings "Appearance" category: "Light" title, should be consistent with the pref_map_style_title translation. */
+/* Settings "Appearance" category: "Light" title, should be consistent with the pref_appearance_title translation. */
 "pref_appearance_light" = "Claro";
 
-/* Settings "Appearance" category: "Dark" title, should be consistent with the pref_map_style_title translation. */
+/* Settings "Appearance" category: "Dark" title, should be consistent with the pref_appearance_title translation. */
 "pref_appearance_dark" = "Oscuro";
 
 /* Generic «Off» string */

--- a/iphone/Maps/LocalizedStrings/es.lproj/Localizable.strings
+++ b/iphone/Maps/LocalizedStrings/es.lproj/Localizable.strings
@@ -218,12 +218,12 @@
 "pref_zoom_title" = "Botones de zoom";
 
 /* Settings «Map» category: «Appearance» title */
-"pref_map_style_title" = "Aspecto";
+"pref_appearance_title" = "Aspecto";
 
-/* Settings "Appearance" category: "Light" title, should be consistent with the pref_map_style_title translation. */
+/* Settings "Appearance" category: "Light" title, should be consistent with the pref_appearance_title translation. */
 "pref_appearance_light" = "Claro";
 
-/* Settings "Appearance" category: "Dark" title, should be consistent with the pref_map_style_title translation. */
+/* Settings "Appearance" category: "Dark" title, should be consistent with the pref_appearance_title translation. */
 "pref_appearance_dark" = "Oscuro";
 
 /* Generic «Off» string */

--- a/iphone/Maps/LocalizedStrings/et.lproj/Localizable.strings
+++ b/iphone/Maps/LocalizedStrings/et.lproj/Localizable.strings
@@ -218,12 +218,12 @@
 "pref_zoom_title" = "Zoomi nupud";
 
 /* Settings «Map» category: «Appearance» title */
-"pref_map_style_title" = "Välimus";
+"pref_appearance_title" = "Välimus";
 
-/* Settings "Appearance" category: "Light" title, should be consistent with the pref_map_style_title translation. */
+/* Settings "Appearance" category: "Light" title, should be consistent with the pref_appearance_title translation. */
 "pref_appearance_light" = "Valgus";
 
-/* Settings "Appearance" category: "Dark" title, should be consistent with the pref_map_style_title translation. */
+/* Settings "Appearance" category: "Dark" title, should be consistent with the pref_appearance_title translation. */
 "pref_appearance_dark" = "Tume";
 
 /* Generic «Off» string */

--- a/iphone/Maps/LocalizedStrings/eu.lproj/Localizable.strings
+++ b/iphone/Maps/LocalizedStrings/eu.lproj/Localizable.strings
@@ -218,12 +218,12 @@
 "pref_zoom_title" = "Zoom botoiak";
 
 /* Settings «Map» category: «Appearance» title */
-"pref_map_style_title" = "Itxura";
+"pref_appearance_title" = "Itxura";
 
-/* Settings "Appearance" category: "Light" title, should be consistent with the pref_map_style_title translation. */
+/* Settings "Appearance" category: "Light" title, should be consistent with the pref_appearance_title translation. */
 "pref_appearance_light" = "Argi";
 
-/* Settings "Appearance" category: "Dark" title, should be consistent with the pref_map_style_title translation. */
+/* Settings "Appearance" category: "Dark" title, should be consistent with the pref_appearance_title translation. */
 "pref_appearance_dark" = "Iluna";
 
 /* Generic «Off» string */

--- a/iphone/Maps/LocalizedStrings/fa.lproj/Localizable.strings
+++ b/iphone/Maps/LocalizedStrings/fa.lproj/Localizable.strings
@@ -218,12 +218,12 @@
 "pref_zoom_title" = "دکمه‌های بزرگنمایی";
 
 /* Settings «Map» category: «Appearance» title */
-"pref_map_style_title" = "ظاهری";
+"pref_appearance_title" = "ظاهری";
 
-/* Settings "Appearance" category: "Light" title, should be consistent with the pref_map_style_title translation. */
+/* Settings "Appearance" category: "Light" title, should be consistent with the pref_appearance_title translation. */
 "pref_appearance_light" = "نور";
 
-/* Settings "Appearance" category: "Dark" title, should be consistent with the pref_map_style_title translation. */
+/* Settings "Appearance" category: "Dark" title, should be consistent with the pref_appearance_title translation. */
 "pref_appearance_dark" = "تاریک";
 
 /* Generic «Off» string */

--- a/iphone/Maps/LocalizedStrings/fi.lproj/Localizable.strings
+++ b/iphone/Maps/LocalizedStrings/fi.lproj/Localizable.strings
@@ -218,12 +218,12 @@
 "pref_zoom_title" = "Zoomauspainikkeet";
 
 /* Settings «Map» category: «Appearance» title */
-"pref_map_style_title" = "Ulkoasu";
+"pref_appearance_title" = "Ulkoasu";
 
-/* Settings "Appearance" category: "Light" title, should be consistent with the pref_map_style_title translation. */
+/* Settings "Appearance" category: "Light" title, should be consistent with the pref_appearance_title translation. */
 "pref_appearance_light" = "Vaalea";
 
-/* Settings "Appearance" category: "Dark" title, should be consistent with the pref_map_style_title translation. */
+/* Settings "Appearance" category: "Dark" title, should be consistent with the pref_appearance_title translation. */
 "pref_appearance_dark" = "Tumma";
 
 /* Generic «Off» string */

--- a/iphone/Maps/LocalizedStrings/fr.lproj/Localizable.strings
+++ b/iphone/Maps/LocalizedStrings/fr.lproj/Localizable.strings
@@ -218,12 +218,12 @@
 "pref_zoom_title" = "Boutons de zoom";
 
 /* Settings «Map» category: «Appearance» title */
-"pref_map_style_title" = "Apparence";
+"pref_appearance_title" = "Apparence";
 
-/* Settings "Appearance" category: "Light" title, should be consistent with the pref_map_style_title translation. */
+/* Settings "Appearance" category: "Light" title, should be consistent with the pref_appearance_title translation. */
 "pref_appearance_light" = "Claire";
 
-/* Settings "Appearance" category: "Dark" title, should be consistent with the pref_map_style_title translation. */
+/* Settings "Appearance" category: "Dark" title, should be consistent with the pref_appearance_title translation. */
 "pref_appearance_dark" = "Sombre";
 
 /* Generic «Off» string */

--- a/iphone/Maps/LocalizedStrings/he.lproj/Localizable.strings
+++ b/iphone/Maps/LocalizedStrings/he.lproj/Localizable.strings
@@ -218,12 +218,12 @@
 "pref_zoom_title" = "כפתורי זום";
 
 /* Settings «Map» category: «Appearance» title */
-"pref_map_style_title" = "מראה";
+"pref_appearance_title" = "מראה";
 
-/* Settings "Appearance" category: "Light" title, should be consistent with the pref_map_style_title translation. */
+/* Settings "Appearance" category: "Light" title, should be consistent with the pref_appearance_title translation. */
 "pref_appearance_light" = "בהיר";
 
-/* Settings "Appearance" category: "Dark" title, should be consistent with the pref_map_style_title translation. */
+/* Settings "Appearance" category: "Dark" title, should be consistent with the pref_appearance_title translation. */
 "pref_appearance_dark" = "כהה";
 
 /* Generic «Off» string */

--- a/iphone/Maps/LocalizedStrings/hi.lproj/Localizable.strings
+++ b/iphone/Maps/LocalizedStrings/hi.lproj/Localizable.strings
@@ -218,12 +218,12 @@
 "pref_zoom_title" = "ज़ूम बटन";
 
 /* Settings «Map» category: «Appearance» title */
-"pref_map_style_title" = "प्रकटन";
+"pref_appearance_title" = "प्रकटन";
 
-/* Settings "Appearance" category: "Light" title, should be consistent with the pref_map_style_title translation. */
+/* Settings "Appearance" category: "Light" title, should be consistent with the pref_appearance_title translation. */
 "pref_appearance_light" = "हल्का";
 
-/* Settings "Appearance" category: "Dark" title, should be consistent with the pref_map_style_title translation. */
+/* Settings "Appearance" category: "Dark" title, should be consistent with the pref_appearance_title translation. */
 "pref_appearance_dark" = "गहरा";
 
 /* Generic «Off» string */

--- a/iphone/Maps/LocalizedStrings/hu.lproj/Localizable.strings
+++ b/iphone/Maps/LocalizedStrings/hu.lproj/Localizable.strings
@@ -218,12 +218,12 @@
 "pref_zoom_title" = "Nagyítás/kicsinyítés gombok";
 
 /* Settings «Map» category: «Appearance» title */
-"pref_map_style_title" = "Megjelenés";
+"pref_appearance_title" = "Megjelenés";
 
-/* Settings "Appearance" category: "Light" title, should be consistent with the pref_map_style_title translation. */
+/* Settings "Appearance" category: "Light" title, should be consistent with the pref_appearance_title translation. */
 "pref_appearance_light" = "Világos";
 
-/* Settings "Appearance" category: "Dark" title, should be consistent with the pref_map_style_title translation. */
+/* Settings "Appearance" category: "Dark" title, should be consistent with the pref_appearance_title translation. */
 "pref_appearance_dark" = "Sötét";
 
 /* Generic «Off» string */

--- a/iphone/Maps/LocalizedStrings/id.lproj/Localizable.strings
+++ b/iphone/Maps/LocalizedStrings/id.lproj/Localizable.strings
@@ -218,12 +218,12 @@
 "pref_zoom_title" = "Tombol perbesaran";
 
 /* Settings «Map» category: «Appearance» title */
-"pref_map_style_title" = "Tampilan";
+"pref_appearance_title" = "Tampilan";
 
-/* Settings "Appearance" category: "Light" title, should be consistent with the pref_map_style_title translation. */
+/* Settings "Appearance" category: "Light" title, should be consistent with the pref_appearance_title translation. */
 "pref_appearance_light" = "Terang";
 
-/* Settings "Appearance" category: "Dark" title, should be consistent with the pref_map_style_title translation. */
+/* Settings "Appearance" category: "Dark" title, should be consistent with the pref_appearance_title translation. */
 "pref_appearance_dark" = "Gelap";
 
 /* Generic «Off» string */

--- a/iphone/Maps/LocalizedStrings/it.lproj/Localizable.strings
+++ b/iphone/Maps/LocalizedStrings/it.lproj/Localizable.strings
@@ -218,12 +218,12 @@
 "pref_zoom_title" = "Pulsanti per lo zoom";
 
 /* Settings «Map» category: «Appearance» title */
-"pref_map_style_title" = "Aspetto";
+"pref_appearance_title" = "Aspetto";
 
-/* Settings "Appearance" category: "Light" title, should be consistent with the pref_map_style_title translation. */
+/* Settings "Appearance" category: "Light" title, should be consistent with the pref_appearance_title translation. */
 "pref_appearance_light" = "Chiaro";
 
-/* Settings "Appearance" category: "Dark" title, should be consistent with the pref_map_style_title translation. */
+/* Settings "Appearance" category: "Dark" title, should be consistent with the pref_appearance_title translation. */
 "pref_appearance_dark" = "Scuro";
 
 /* Generic «Off» string */

--- a/iphone/Maps/LocalizedStrings/ja.lproj/Localizable.strings
+++ b/iphone/Maps/LocalizedStrings/ja.lproj/Localizable.strings
@@ -218,12 +218,12 @@
 "pref_zoom_title" = "ズームボタン";
 
 /* Settings «Map» category: «Appearance» title */
-"pref_map_style_title" = "外観";
+"pref_appearance_title" = "外観";
 
-/* Settings "Appearance" category: "Light" title, should be consistent with the pref_map_style_title translation. */
+/* Settings "Appearance" category: "Light" title, should be consistent with the pref_appearance_title translation. */
 "pref_appearance_light" = "ライト";
 
-/* Settings "Appearance" category: "Dark" title, should be consistent with the pref_map_style_title translation. */
+/* Settings "Appearance" category: "Dark" title, should be consistent with the pref_appearance_title translation. */
 "pref_appearance_dark" = "ダーク";
 
 /* Generic «Off» string */

--- a/iphone/Maps/LocalizedStrings/ko.lproj/Localizable.strings
+++ b/iphone/Maps/LocalizedStrings/ko.lproj/Localizable.strings
@@ -218,12 +218,12 @@
 "pref_zoom_title" = "확대/축소 버튼";
 
 /* Settings «Map» category: «Appearance» title */
-"pref_map_style_title" = "모양";
+"pref_appearance_title" = "모양";
 
-/* Settings "Appearance" category: "Light" title, should be consistent with the pref_map_style_title translation. */
+/* Settings "Appearance" category: "Light" title, should be consistent with the pref_appearance_title translation. */
 "pref_appearance_light" = "라이트";
 
-/* Settings "Appearance" category: "Dark" title, should be consistent with the pref_map_style_title translation. */
+/* Settings "Appearance" category: "Dark" title, should be consistent with the pref_appearance_title translation. */
 "pref_appearance_dark" = "다크";
 
 /* Generic «Off» string */

--- a/iphone/Maps/LocalizedStrings/mr.lproj/Localizable.strings
+++ b/iphone/Maps/LocalizedStrings/mr.lproj/Localizable.strings
@@ -218,12 +218,12 @@
 "pref_zoom_title" = "झूम बटणे";
 
 /* Settings «Map» category: «Appearance» title */
-"pref_map_style_title" = "प्रतिमा";
+"pref_appearance_title" = "प्रतिमा";
 
-/* Settings "Appearance" category: "Light" title, should be consistent with the pref_map_style_title translation. */
+/* Settings "Appearance" category: "Light" title, should be consistent with the pref_appearance_title translation. */
 "pref_appearance_light" = "प्रकाश";
 
-/* Settings "Appearance" category: "Dark" title, should be consistent with the pref_map_style_title translation. */
+/* Settings "Appearance" category: "Dark" title, should be consistent with the pref_appearance_title translation. */
 "pref_appearance_dark" = "अंधार";
 
 /* Generic «Off» string */

--- a/iphone/Maps/LocalizedStrings/nb.lproj/Localizable.strings
+++ b/iphone/Maps/LocalizedStrings/nb.lproj/Localizable.strings
@@ -218,12 +218,12 @@
 "pref_zoom_title" = "Zoom-knapper";
 
 /* Settings «Map» category: «Appearance» title */
-"pref_map_style_title" = "Utseende";
+"pref_appearance_title" = "Utseende";
 
-/* Settings "Appearance" category: "Light" title, should be consistent with the pref_map_style_title translation. */
+/* Settings "Appearance" category: "Light" title, should be consistent with the pref_appearance_title translation. */
 "pref_appearance_light" = "Lys";
 
-/* Settings "Appearance" category: "Dark" title, should be consistent with the pref_map_style_title translation. */
+/* Settings "Appearance" category: "Dark" title, should be consistent with the pref_appearance_title translation. */
 "pref_appearance_dark" = "Mørke";
 
 /* Generic «Off» string */

--- a/iphone/Maps/LocalizedStrings/nl.lproj/Localizable.strings
+++ b/iphone/Maps/LocalizedStrings/nl.lproj/Localizable.strings
@@ -218,12 +218,12 @@
 "pref_zoom_title" = "Zoomknoppen";
 
 /* Settings «Map» category: «Appearance» title */
-"pref_map_style_title" = "Weergave";
+"pref_appearance_title" = "Weergave";
 
-/* Settings "Appearance" category: "Light" title, should be consistent with the pref_map_style_title translation. */
+/* Settings "Appearance" category: "Light" title, should be consistent with the pref_appearance_title translation. */
 "pref_appearance_light" = "Licht";
 
-/* Settings "Appearance" category: "Dark" title, should be consistent with the pref_map_style_title translation. */
+/* Settings "Appearance" category: "Dark" title, should be consistent with the pref_appearance_title translation. */
 "pref_appearance_dark" = "Donker";
 
 /* Generic «Off» string */

--- a/iphone/Maps/LocalizedStrings/pl.lproj/Localizable.strings
+++ b/iphone/Maps/LocalizedStrings/pl.lproj/Localizable.strings
@@ -218,12 +218,12 @@
 "pref_zoom_title" = "Przyciski przybliżania";
 
 /* Settings «Map» category: «Appearance» title */
-"pref_map_style_title" = "Wygląd";
+"pref_appearance_title" = "Wygląd";
 
-/* Settings "Appearance" category: "Light" title, should be consistent with the pref_map_style_title translation. */
+/* Settings "Appearance" category: "Light" title, should be consistent with the pref_appearance_title translation. */
 "pref_appearance_light" = "Jasny";
 
-/* Settings "Appearance" category: "Dark" title, should be consistent with the pref_map_style_title translation. */
+/* Settings "Appearance" category: "Dark" title, should be consistent with the pref_appearance_title translation. */
 "pref_appearance_dark" = "Ciemny";
 
 /* Generic «Off» string */

--- a/iphone/Maps/LocalizedStrings/pt-BR.lproj/Localizable.strings
+++ b/iphone/Maps/LocalizedStrings/pt-BR.lproj/Localizable.strings
@@ -218,12 +218,12 @@
 "pref_zoom_title" = "Botões de zoom";
 
 /* Settings «Map» category: «Appearance» title */
-"pref_map_style_title" = "Aparência";
+"pref_appearance_title" = "Aparência";
 
-/* Settings "Appearance" category: "Light" title, should be consistent with the pref_map_style_title translation. */
+/* Settings "Appearance" category: "Light" title, should be consistent with the pref_appearance_title translation. */
 "pref_appearance_light" = "Clara";
 
-/* Settings "Appearance" category: "Dark" title, should be consistent with the pref_map_style_title translation. */
+/* Settings "Appearance" category: "Dark" title, should be consistent with the pref_appearance_title translation. */
 "pref_appearance_dark" = "Escura";
 
 /* Generic «Off» string */

--- a/iphone/Maps/LocalizedStrings/pt.lproj/Localizable.strings
+++ b/iphone/Maps/LocalizedStrings/pt.lproj/Localizable.strings
@@ -218,12 +218,12 @@
 "pref_zoom_title" = "Botões de ampliação";
 
 /* Settings «Map» category: «Appearance» title */
-"pref_map_style_title" = "Apresentação";
+"pref_appearance_title" = "Apresentação";
 
-/* Settings "Appearance" category: "Light" title, should be consistent with the pref_map_style_title translation. */
+/* Settings "Appearance" category: "Light" title, should be consistent with the pref_appearance_title translation. */
 "pref_appearance_light" = "Tons claros";
 
-/* Settings "Appearance" category: "Dark" title, should be consistent with the pref_map_style_title translation. */
+/* Settings "Appearance" category: "Dark" title, should be consistent with the pref_appearance_title translation. */
 "pref_appearance_dark" = "Tons escuros";
 
 /* Generic «Off» string */

--- a/iphone/Maps/LocalizedStrings/ro.lproj/Localizable.strings
+++ b/iphone/Maps/LocalizedStrings/ro.lproj/Localizable.strings
@@ -218,12 +218,12 @@
 "pref_zoom_title" = "Butoane zoom";
 
 /* Settings «Map» category: «Appearance» title */
-"pref_map_style_title" = "Aspect";
+"pref_appearance_title" = "Aspect";
 
-/* Settings "Appearance" category: "Light" title, should be consistent with the pref_map_style_title translation. */
+/* Settings "Appearance" category: "Light" title, should be consistent with the pref_appearance_title translation. */
 "pref_appearance_light" = "Luminos";
 
-/* Settings "Appearance" category: "Dark" title, should be consistent with the pref_map_style_title translation. */
+/* Settings "Appearance" category: "Dark" title, should be consistent with the pref_appearance_title translation. */
 "pref_appearance_dark" = "Întunecat";
 
 /* Generic «Off» string */

--- a/iphone/Maps/LocalizedStrings/ru.lproj/Localizable.strings
+++ b/iphone/Maps/LocalizedStrings/ru.lproj/Localizable.strings
@@ -218,12 +218,12 @@
 "pref_zoom_title" = "Кнопки масштаба";
 
 /* Settings «Map» category: «Appearance» title */
-"pref_map_style_title" = "Оформление";
+"pref_appearance_title" = "Оформление";
 
-/* Settings "Appearance" category: "Light" title, should be consistent with the pref_map_style_title translation. */
+/* Settings "Appearance" category: "Light" title, should be consistent with the pref_appearance_title translation. */
 "pref_appearance_light" = "Светлое";
 
-/* Settings "Appearance" category: "Dark" title, should be consistent with the pref_map_style_title translation. */
+/* Settings "Appearance" category: "Dark" title, should be consistent with the pref_appearance_title translation. */
 "pref_appearance_dark" = "Темное";
 
 /* Generic «Off» string */

--- a/iphone/Maps/LocalizedStrings/sk.lproj/Localizable.strings
+++ b/iphone/Maps/LocalizedStrings/sk.lproj/Localizable.strings
@@ -218,12 +218,12 @@
 "pref_zoom_title" = "Tlačidlá priblíženia/oddialenia";
 
 /* Settings «Map» category: «Appearance» title */
-"pref_map_style_title" = "Vzhľad";
+"pref_appearance_title" = "Vzhľad";
 
-/* Settings "Appearance" category: "Light" title, should be consistent with the pref_map_style_title translation. */
+/* Settings "Appearance" category: "Light" title, should be consistent with the pref_appearance_title translation. */
 "pref_appearance_light" = "Svetlý";
 
-/* Settings "Appearance" category: "Dark" title, should be consistent with the pref_map_style_title translation. */
+/* Settings "Appearance" category: "Dark" title, should be consistent with the pref_appearance_title translation. */
 "pref_appearance_dark" = "Tmavý";
 
 /* Generic «Off» string */

--- a/iphone/Maps/LocalizedStrings/sv.lproj/Localizable.strings
+++ b/iphone/Maps/LocalizedStrings/sv.lproj/Localizable.strings
@@ -218,12 +218,12 @@
 "pref_zoom_title" = "Zoom-knappar";
 
 /* Settings «Map» category: «Appearance» title */
-"pref_map_style_title" = "Utseende";
+"pref_appearance_title" = "Utseende";
 
-/* Settings "Appearance" category: "Light" title, should be consistent with the pref_map_style_title translation. */
+/* Settings "Appearance" category: "Light" title, should be consistent with the pref_appearance_title translation. */
 "pref_appearance_light" = "Ljust";
 
-/* Settings "Appearance" category: "Dark" title, should be consistent with the pref_map_style_title translation. */
+/* Settings "Appearance" category: "Dark" title, should be consistent with the pref_appearance_title translation. */
 "pref_appearance_dark" = "Mörkt";
 
 /* Generic «Off» string */

--- a/iphone/Maps/LocalizedStrings/sw.lproj/Localizable.strings
+++ b/iphone/Maps/LocalizedStrings/sw.lproj/Localizable.strings
@@ -218,12 +218,12 @@
 "pref_zoom_title" = "Zoom buttons";
 
 /* Settings «Map» category: «Appearance» title */
-"pref_map_style_title" = "Appearance";
+"pref_appearance_title" = "Appearance";
 
-/* Settings "Appearance" category: "Light" title, should be consistent with the pref_map_style_title translation. */
+/* Settings "Appearance" category: "Light" title, should be consistent with the pref_appearance_title translation. */
 "pref_appearance_light" = "Light";
 
-/* Settings "Appearance" category: "Dark" title, should be consistent with the pref_map_style_title translation. */
+/* Settings "Appearance" category: "Dark" title, should be consistent with the pref_appearance_title translation. */
 "pref_appearance_dark" = "Dark";
 
 /* Generic «Off» string */

--- a/iphone/Maps/LocalizedStrings/th.lproj/Localizable.strings
+++ b/iphone/Maps/LocalizedStrings/th.lproj/Localizable.strings
@@ -218,12 +218,12 @@
 "pref_zoom_title" = "ปุ่มซูม";
 
 /* Settings «Map» category: «Appearance» title */
-"pref_map_style_title" = "รูปแบบ";
+"pref_appearance_title" = "รูปแบบ";
 
-/* Settings "Appearance" category: "Light" title, should be consistent with the pref_map_style_title translation. */
+/* Settings "Appearance" category: "Light" title, should be consistent with the pref_appearance_title translation. */
 "pref_appearance_light" = "สว่าง";
 
-/* Settings "Appearance" category: "Dark" title, should be consistent with the pref_map_style_title translation. */
+/* Settings "Appearance" category: "Dark" title, should be consistent with the pref_appearance_title translation. */
 "pref_appearance_dark" = "มืด";
 
 /* Generic «Off» string */

--- a/iphone/Maps/LocalizedStrings/tr.lproj/Localizable.strings
+++ b/iphone/Maps/LocalizedStrings/tr.lproj/Localizable.strings
@@ -218,12 +218,12 @@
 "pref_zoom_title" = "Yakınlaştırma butonları";
 
 /* Settings «Map» category: «Appearance» title */
-"pref_map_style_title" = "Görünüş";
+"pref_appearance_title" = "Görünüş";
 
-/* Settings "Appearance" category: "Light" title, should be consistent with the pref_map_style_title translation. */
+/* Settings "Appearance" category: "Light" title, should be consistent with the pref_appearance_title translation. */
 "pref_appearance_light" = "Açık";
 
-/* Settings "Appearance" category: "Dark" title, should be consistent with the pref_map_style_title translation. */
+/* Settings "Appearance" category: "Dark" title, should be consistent with the pref_appearance_title translation. */
 "pref_appearance_dark" = "Koyu";
 
 /* Generic «Off» string */

--- a/iphone/Maps/LocalizedStrings/uk.lproj/Localizable.strings
+++ b/iphone/Maps/LocalizedStrings/uk.lproj/Localizable.strings
@@ -218,12 +218,12 @@
 "pref_zoom_title" = "Кнопки трансфокації";
 
 /* Settings «Map» category: «Appearance» title */
-"pref_map_style_title" = "Вигляд";
+"pref_appearance_title" = "Вигляд";
 
-/* Settings "Appearance" category: "Light" title, should be consistent with the pref_map_style_title translation. */
+/* Settings "Appearance" category: "Light" title, should be consistent with the pref_appearance_title translation. */
 "pref_appearance_light" = "Світлий";
 
-/* Settings "Appearance" category: "Dark" title, should be consistent with the pref_map_style_title translation. */
+/* Settings "Appearance" category: "Dark" title, should be consistent with the pref_appearance_title translation. */
 "pref_appearance_dark" = "Темний";
 
 /* Generic «Off» string */

--- a/iphone/Maps/LocalizedStrings/vi.lproj/Localizable.strings
+++ b/iphone/Maps/LocalizedStrings/vi.lproj/Localizable.strings
@@ -218,12 +218,12 @@
 "pref_zoom_title" = "Nút Phóng to/Thu nhỏ";
 
 /* Settings «Map» category: «Appearance» title */
-"pref_map_style_title" = "Giao diện";
+"pref_appearance_title" = "Giao diện";
 
-/* Settings "Appearance" category: "Light" title, should be consistent with the pref_map_style_title translation. */
+/* Settings "Appearance" category: "Light" title, should be consistent with the pref_appearance_title translation. */
 "pref_appearance_light" = "Sáng";
 
-/* Settings "Appearance" category: "Dark" title, should be consistent with the pref_map_style_title translation. */
+/* Settings "Appearance" category: "Dark" title, should be consistent with the pref_appearance_title translation. */
 "pref_appearance_dark" = "Tối";
 
 /* Generic «Off» string */

--- a/iphone/Maps/LocalizedStrings/zh-Hans.lproj/Localizable.strings
+++ b/iphone/Maps/LocalizedStrings/zh-Hans.lproj/Localizable.strings
@@ -218,12 +218,12 @@
 "pref_zoom_title" = "缩放按钮";
 
 /* Settings «Map» category: «Appearance» title */
-"pref_map_style_title" = "外观";
+"pref_appearance_title" = "外观";
 
-/* Settings "Appearance" category: "Light" title, should be consistent with the pref_map_style_title translation. */
+/* Settings "Appearance" category: "Light" title, should be consistent with the pref_appearance_title translation. */
 "pref_appearance_light" = "浅色";
 
-/* Settings "Appearance" category: "Dark" title, should be consistent with the pref_map_style_title translation. */
+/* Settings "Appearance" category: "Dark" title, should be consistent with the pref_appearance_title translation. */
 "pref_appearance_dark" = "深色";
 
 /* Generic «Off» string */

--- a/iphone/Maps/LocalizedStrings/zh-Hant.lproj/Localizable.strings
+++ b/iphone/Maps/LocalizedStrings/zh-Hant.lproj/Localizable.strings
@@ -218,12 +218,12 @@
 "pref_zoom_title" = "縮放按鈕";
 
 /* Settings «Map» category: «Appearance» title */
-"pref_map_style_title" = "外觀";
+"pref_appearance_title" = "外觀";
 
-/* Settings "Appearance" category: "Light" title, should be consistent with the pref_map_style_title translation. */
+/* Settings "Appearance" category: "Light" title, should be consistent with the pref_appearance_title translation. */
 "pref_appearance_light" = "淺色";
 
-/* Settings "Appearance" category: "Dark" title, should be consistent with the pref_map_style_title translation. */
+/* Settings "Appearance" category: "Dark" title, should be consistent with the pref_appearance_title translation. */
 "pref_appearance_dark" = "深色";
 
 /* Generic «Off» string */

--- a/iphone/Maps/UI/Settings/MWMNightModeController.m
+++ b/iphone/Maps/UI/Settings/MWMNightModeController.m
@@ -16,7 +16,7 @@
 - (void)viewDidLoad
 {
   [super viewDidLoad];
-  self.title = L(@"pref_map_style_title");
+  self.title = L(@"pref_appearance_title");
   SettingsTableViewSelectableCell * selectedCell = nil;
   switch ([MWMSettings theme])
   {

--- a/iphone/Maps/UI/Settings/MWMSettingsViewController.mm
+++ b/iphone/Maps/UI/Settings/MWMSettingsViewController.mm
@@ -179,7 +179,7 @@ using namespace power_management;
       nightMode = L(@"auto");
       break;
   }
-  [self.nightModeCell configWithTitle:L(@"pref_map_style_title") info:nightMode];
+  [self.nightModeCell configWithTitle:L(@"pref_appearance_title") info:nightMode];
 }
 
 - (void)show3dBuildingsAlert:(UITapGestureRecognizer *)recognizer {


### PR DESCRIPTION
This PR fixes the issue caused by the https://github.com/organicmaps/organicmaps/pull/7371 on Android

Before:
<img width="300" alt="image" src="https://github.com/organicmaps/organicmaps/assets/79797627/af5fcf5b-fdd8-4699-933a-d787a2b6665f">


After:
<img width="300" alt="image" src="https://github.com/organicmaps/organicmaps/assets/79797627/9ef4ab11-e310-4e24-af2e-5dce0a23c790">
<img width="300" alt="image" src="https://github.com/organicmaps/organicmaps/assets/79797627/6c500da9-f7b5-4f81-afc8-300b87faf3b9">