### PR TITLE
[ios] Fix: "place does not exist" alert text color

### DIFF
--- a/iphone/Maps/Classes/CustomAlert/CreateBookmarkCategory/MWMBCCreateCategoryAlert.xib
+++ b/iphone/Maps/Classes/CustomAlert/CreateBookmarkCategory/MWMBCCreateCategoryAlert.xib
@@ -62,7 +62,7 @@
                                 <constraint firstItem="xlp-ke-FxI" firstAttribute="height" secondItem="otE-Ct-TPM" secondAttribute="height" id="tj3-TS-dmp"/>
                             </constraints>
                             <userDefinedRuntimeAttributes>
-                                <userDefinedRuntimeAttribute type="string" keyPath="styleName" value="AlertViewTextField"/>
+                                <userDefinedRuntimeAttribute type="string" keyPath="styleName" value="AlertViewTextFieldContainer"/>
                             </userDefinedRuntimeAttributes>
                         </view>
                         <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="uxx-Di-f1Q" userLabel="hDivider">

--- a/iphone/Maps/Classes/CustomAlert/MWMPlaceDoesntExistAlert.xib
+++ b/iphone/Maps/Classes/CustomAlert/MWMPlaceDoesntExistAlert.xib
@@ -58,9 +58,8 @@
                                     <fontDescription key="fontDescription" type="system" pointSize="14"/>
                                     <textInputTraits key="textInputTraits"/>
                                     <userDefinedRuntimeAttributes>
-                                        <userDefinedRuntimeAttribute type="string" keyPath="styleName" value="regular14:blackPrimaryText"/>
+                                        <userDefinedRuntimeAttribute type="string" keyPath="styleName" value="AlertViewTextField"/>
                                         <userDefinedRuntimeAttribute type="string" keyPath="localizedPlaceholder" value="editor_comment_hint"/>
-                                        <userDefinedRuntimeAttribute type="string" keyPath="styleName" value="Background"/>
                                     </userDefinedRuntimeAttributes>
                                 </textField>
                             </subviews>
@@ -73,7 +72,7 @@
                                 <constraint firstItem="0f8-vD-nJT" firstAttribute="height" secondItem="npf-dH-f50" secondAttribute="height" id="zHi-xB-aCQ"/>
                             </constraints>
                             <userDefinedRuntimeAttributes>
-                                <userDefinedRuntimeAttribute type="string" keyPath="styleName" value="AlertViewTextField"/>
+                                <userDefinedRuntimeAttribute type="string" keyPath="styleName" value="AlertViewTextFieldContainer"/>
                             </userDefinedRuntimeAttributes>
                         </view>
                         <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="kEx-DM-ynC" userLabel="hDivider">

--- a/iphone/Maps/Core/Theme/GlobalStyleSheet.swift
+++ b/iphone/Maps/Core/Theme/GlobalStyleSheet.swift
@@ -183,10 +183,16 @@ class GlobalStyleSheet: IStyleSheet {
       s.clip = true
     }
 
-    theme.add(styleName: "AlertViewTextField") { (s) -> (Void) in
+    theme.add(styleName: "AlertViewTextFieldContainer") { (s) -> (Void) in
       s.borderColor = colors.blackDividers
       s.borderWidth = 0.5
       s.backgroundColor = colors.white
+    }
+
+    theme.add(styleName: "AlertViewTextField") { (s) -> Void in
+      s.font = fonts.regular14
+      s.fontColor = colors.blackPrimaryText
+      s.tintColor = colors.blackSecondaryText
     }
 
     theme.add(styleName: "SearchStatusBarView") { (s) -> (Void) in


### PR DESCRIPTION
Caused by https://github.com/organicmaps/organicmaps/issues/7448 in the case

This PR fixes the "Place does not exist" alert wrong text color.

Bug was caused by doubling style name attributes in the textfield:
<img width="378" alt="image" src="https://github.com/organicmaps/organicmaps/assets/79797627/a1d78cfa-9a41-4fbb-b777-6915b33dc7b5">


The second issue will be fixed soon.