### PR TITLE
[ios] Fix themes switching issues

### DIFF
--- a/iphone/Maps/Classes/CustomAlert/CreateBookmarkCategory/MWMBCCreateCategoryAlert.xib
+++ b/iphone/Maps/Classes/CustomAlert/CreateBookmarkCategory/MWMBCCreateCategoryAlert.xib
@@ -62,7 +62,7 @@
                                 <constraint firstItem="xlp-ke-FxI" firstAttribute="height" secondItem="otE-Ct-TPM" secondAttribute="height" id="tj3-TS-dmp"/>
                             </constraints>
                             <userDefinedRuntimeAttributes>
-                                <userDefinedRuntimeAttribute type="string" keyPath="styleName" value="AlertViewTextField"/>
+                                <userDefinedRuntimeAttribute type="string" keyPath="styleName" value="AlertViewTextFieldContainer"/>
                             </userDefinedRuntimeAttributes>
                         </view>
                         <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="uxx-Di-f1Q" userLabel="hDivider">

--- a/iphone/Maps/Classes/CustomAlert/MWMPlaceDoesntExistAlert.xib
+++ b/iphone/Maps/Classes/CustomAlert/MWMPlaceDoesntExistAlert.xib
@@ -58,9 +58,8 @@
                                     <fontDescription key="fontDescription" type="system" pointSize="14"/>
                                     <textInputTraits key="textInputTraits"/>
                                     <userDefinedRuntimeAttributes>
-                                        <userDefinedRuntimeAttribute type="string" keyPath="styleName" value="regular14:blackPrimaryText"/>
+                                        <userDefinedRuntimeAttribute type="string" keyPath="styleName" value="AlertViewTextField"/>
                                         <userDefinedRuntimeAttribute type="string" keyPath="localizedPlaceholder" value="editor_comment_hint"/>
-                                        <userDefinedRuntimeAttribute type="string" keyPath="styleName" value="Background"/>
                                     </userDefinedRuntimeAttributes>
                                 </textField>
                             </subviews>
@@ -73,7 +72,7 @@
                                 <constraint firstItem="0f8-vD-nJT" firstAttribute="height" secondItem="npf-dH-f50" secondAttribute="height" id="zHi-xB-aCQ"/>
                             </constraints>
                             <userDefinedRuntimeAttributes>
-                                <userDefinedRuntimeAttribute type="string" keyPath="styleName" value="AlertViewTextField"/>
+                                <userDefinedRuntimeAttribute type="string" keyPath="styleName" value="AlertViewTextFieldContainer"/>
                             </userDefinedRuntimeAttributes>
                         </view>
                         <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="kEx-DM-ynC" userLabel="hDivider">

--- a/iphone/Maps/Core/Settings/MWMSettings.mm
+++ b/iphone/Maps/Core/Settings/MWMSettings.mm
@@ -92,23 +92,6 @@ NSString * const kUDTrackWarningAlertWasShown = @"TrackWarningAlertWasShown";
 {
   if ([self theme] == theme)
     return;
-  if (@available(iOS 13.0, *)) {
-    UIUserInterfaceStyle style;
-    switch (theme) {
-      case MWMThemeDay:
-      case MWMThemeVehicleDay:
-        style = UIUserInterfaceStyleLight;
-        break;
-      case MWMThemeNight:
-      case MWMThemeVehicleNight:
-        style = UIUserInterfaceStyleDark;
-        break;
-      case MWMThemeAuto:
-        style = UIUserInterfaceStyleUnspecified;
-        break;
-    }
-    UIApplication.sharedApplication.delegate.window.overrideUserInterfaceStyle = style;
-  }
   auto ud = NSUserDefaults.standardUserDefaults;
   [ud setInteger:theme forKey:kThemeMode];
   BOOL const autoOff = theme != MWMThemeAuto;

--- a/iphone/Maps/Core/Theme/Core/ThemeManager.swift
+++ b/iphone/Maps/Core/Theme/Core/ThemeManager.swift
@@ -10,6 +10,10 @@ final class ThemeManager: NSObject {
   }
 
   private func update(theme: MWMTheme) {
+    if #available(iOS 13.0, *) {
+      updateSystemUserInterfaceStyle(theme)
+    }
+
     let actualTheme: MWMTheme = { theme in
       let isVehicleRouting = MWMRouter.isRoutingActive() && (MWMRouter.type() == .vehicle)
       switch theme {
@@ -63,6 +67,22 @@ final class ThemeManager: NSObject {
 
   @objc static func invalidate() {
     instance.update(theme: Settings.theme())
+  }
+
+  @available(iOS 13.0, *)
+  private func updateSystemUserInterfaceStyle(_ theme: MWMTheme) {
+    let userInterfaceStyle: UIUserInterfaceStyle = { theme in
+      switch theme {
+      case .day: fallthrough
+      case .vehicleDay: return .light
+      case .night: fallthrough
+      case .vehicleNight: return .dark
+      case .auto: return .unspecified
+      @unknown default:
+        fatalError()
+      }
+    }(theme)
+    UIApplication.shared.delegate?.window??.overrideUserInterfaceStyle = userInterfaceStyle
   }
 
   @available(iOS, deprecated:13.0)

--- a/iphone/Maps/Core/Theme/GlobalStyleSheet.swift
+++ b/iphone/Maps/Core/Theme/GlobalStyleSheet.swift
@@ -183,10 +183,16 @@ class GlobalStyleSheet: IStyleSheet {
       s.clip = true
     }
 
-    theme.add(styleName: "AlertViewTextField") { (s) -> (Void) in
+    theme.add(styleName: "AlertViewTextFieldContainer") { (s) -> (Void) in
       s.borderColor = colors.blackDividers
       s.borderWidth = 0.5
       s.backgroundColor = colors.white
+    }
+
+    theme.add(styleName: "AlertViewTextField") { (s) -> Void in
+      s.font = fonts.regular14
+      s.fontColor = colors.blackPrimaryText
+      s.tintColor = colors.blackSecondaryText
     }
 
     theme.add(styleName: "SearchStatusBarView") { (s) -> (Void) in


### PR DESCRIPTION
Closes  https://github.com/organicmaps/organicmaps/issues/7448

This PR fixes:
#### 1. the "Place does not exist" alert wrong text color.

Bug was caused by doubling style name attributes in the textfield:
<img width="378" alt="image" src="https://github.com/organicmaps/organicmaps/assets/79797627/9ed2936b-87db-4390-94e0-0d74b4d7b178">


#### 2. bug with the wrong colors when themes was not Auto
How to reproduce:
1. Set in the application settings appearance to the light (dark)
2. Terminate the application
3. Change the device's theme to the dark (light)
4. Open the OM
5. Goes to the Bookmarks edit or Settings and change the device's theme again (multiple times)
6. You will see that some elements can change their colors

This bug is caused by the issue in the system theme changing implementation: when the user change the theme in the settings we override the native `window.traitCollection.userInterfaceStyle` in the `MWMSettings setTheme`, but this property is not overridden on the app launch. So there is no mechanism to restore the state of `window.traitCollection.userInterfaceStyle` on the app launch and it can react on the device's theme changing.
This bug was fixed by small refactoring.

Screenrecord with the bug:
(see disappearing of the accessory views in the end of the gif):
![Simulator Screen Recording - iPhone 15 Pro - 2024-02-28 at 15 10 33](https://github.com/organicmaps/organicmaps/assets/79797627/ca2d1aad-9465-4537-a939-d340e5c0371a)

Fixed:
![Simulator Screen Recording - iPhone 15 Pro - 2024-02-28 at 15 06 36](https://github.com/organicmaps/organicmaps/assets/79797627/8fb03fb1-61ee-49b3-82c0-74d2c9ed876b)
