### PR TITLE
[ios] Change the bookmarks/tracks color from the color icon modally

### DIFF
--- a/iphone/CoreApi/CoreApi/Bookmarks/MWMBookmarksManager.h
+++ b/iphone/CoreApi/CoreApi/Bookmarks/MWMBookmarksManager.h
@@ -102,6 +102,9 @@ NS_SWIFT_NAME(BookmarksManager)
                  color:(MWMBookmarkColor)color
            description:(NSString *)description;
 
+- (void)updateBookmark:(MWMMarkID)bookmarkId
+              setColor:(MWMBookmarkColor)color;
+
 - (void)moveBookmark:(MWMMarkID)bookmarkId
            toGroupId:(MWMMarkGroupID)groupId;
 
@@ -109,6 +112,9 @@ NS_SWIFT_NAME(BookmarksManager)
          setGroupId:(MWMMarkGroupID)groupId
               color:(UIColor *)color
               title:(NSString *)title;
+
+- (void)updateTrack:(MWMTrackID)trackId
+           setColor:(UIColor *)color;
 
 - (void)moveTrack:(MWMTrackID)trackId
         toGroupId:(MWMMarkGroupID)groupId;

--- a/iphone/CoreApi/CoreApi/Bookmarks/MWMBookmarksManager.mm
+++ b/iphone/CoreApi/CoreApi/Bookmarks/MWMBookmarksManager.mm
@@ -680,6 +680,21 @@ static BookmarkManager::SortingType convertSortingTypeToCore(MWMBookmarksSorting
     bookmark->SetCustomName(title.UTF8String);
 }
 
+- (void)updateBookmark:(MWMMarkID)bookmarkId
+              setColor:(MWMBookmarkColor)color {
+  auto editSession = self.bm.GetEditSession();
+
+  auto bookmark = editSession.GetBookmarkForEdit(bookmarkId);
+  if (!bookmark)
+    return;
+
+  auto kmlColor = convertBookmarkColor(color);
+  if (kmlColor != bookmark->GetColor())
+    self.bm.SetLastEditedBmColor(kmlColor);
+
+  bookmark->SetColor(kmlColor);
+}
+
 - (void)moveBookmark:(MWMMarkID)bookmarkId
            toGroupId:(MWMMarkGroupID)groupId {
     auto const currentGroupId = self.bm.GetBookmark(bookmarkId)->GetGroupId();
@@ -708,6 +723,21 @@ static BookmarkManager::SortingType convertSortingTypeToCore(MWMBookmarksSorting
       track->SetColor(newColor);
 
     track->SetName(title.UTF8String);
+}
+
+- (void)updateTrack:(MWMTrackID)trackId
+              setColor:(UIColor *)color {
+    auto editSession = self.bm.GetEditSession();
+
+    auto track = editSession.GetTrackForEdit(trackId);
+    if (!track)
+      return;
+
+    auto const currentColor = track->GetColor(0);
+    auto const newColor = [MWMBookmarksManager getColorFromUIColor:color];
+
+    if (newColor != currentColor)
+      track->SetColor(newColor);
 }
 
 - (void)moveTrack:(MWMTrackID)trackId

--- a/iphone/Maps/Bookmarks/BookmarksList/BookmarksListInterfaces.swift
+++ b/iphone/Maps/Bookmarks/BookmarksList/BookmarksListInterfaces.swift
@@ -30,12 +30,14 @@ protocol IBookmarkViewModel {
   var bookmarkName: String { get }
   var subtitle: String { get }
   var image: UIImage { get }
+  var colorDidTapAction: (() -> Void)? { get }
 }
 
 protocol ITrackViewModel {
   var trackName: String { get }
   var subtitle: String { get }
   var image: UIImage { get }
+  var colorDidTapAction: (() -> Void)? { get }
 }
 
 protocol ISubgroupViewModel {
@@ -57,6 +59,7 @@ protocol IBookmarksListView: AnyObject {
   func setSections(_ sections: [IBookmarksListSectionViewModel])
   func setMoreItemTitle(_ itemTitle: String)
   func showMenu(_ items: [IBookmarksListMenuItem])
+  func showColorPicker(with pickerType: ColorPickerType, _ completion: ((UIColor) -> Void)?)
   func enableEditing(_ enable: Bool)
   func share(_ url: URL, completion: @escaping () -> Void)
   func showError(title: String, message: String)

--- a/iphone/Maps/Bookmarks/BookmarksList/BookmarksListPresenter.swift
+++ b/iphone/Maps/Bookmarks/BookmarksList/BookmarksListPresenter.swift
@@ -371,8 +371,7 @@ extension BookmarksListPresenter: SelectBookmarkGroupViewControllerDelegate {
                                      didSelect groupTitle: String,
                                      groupId: MWMMarkGroupID) {
 
-      let nc = viewController.navigationController
-      defer { nc?.popViewController(animated: true) }
+      defer { viewController.dismiss(animated: true) }
 
       guard groupId != bookmarkGroup.categoryId else { return }
       
@@ -392,7 +391,9 @@ extension BookmarksListPresenter: SelectBookmarkGroupViewControllerDelegate {
       } else {
         // if there are no bookmarks or tracks in current group no need to show this group
         // e.g. popping view controller 2 times
-        nc?.popViewController(animated: false)
+        if let rootNavigationController = viewController.presentingViewController as? UINavigationController {
+          rootNavigationController.popViewController(animated: false)
+        }
       }
     }
 }

--- a/iphone/Maps/Bookmarks/BookmarksList/BookmarksListRouter.swift
+++ b/iphone/Maps/Bookmarks/BookmarksList/BookmarksListRouter.swift
@@ -65,7 +65,8 @@ extension BookmarksListRouter: IBookmarksListRouter {
                    delegate: SelectBookmarkGroupViewControllerDelegate?) {
     let groupViewController = SelectBookmarkGroupViewController(groupName: groupName, groupId: groupId)
     groupViewController.delegate = delegate
-    mapViewController.navigationController?.pushViewController(groupViewController, animated: true)
+    let navigationController = UINavigationController(rootViewController: groupViewController)
+    mapViewController.present(navigationController, animated: true, completion: nil)
   }
   
   func editBookmark(bookmarkId: MWMMarkID, completion: @escaping (Bool) -> Void) {

--- a/iphone/Maps/Bookmarks/BookmarksList/BookmarksListViewController.swift
+++ b/iphone/Maps/Bookmarks/BookmarksList/BookmarksListViewController.swift
@@ -223,6 +223,10 @@ extension BookmarksListViewController: IBookmarksListView {
     present(actionSheet, animated: true)
   }
 
+  func showColorPicker(with pickerType: ColorPickerType, _ completionHandler: ((UIColor) -> Void)?) {
+    ColorPicker.shared.present(from: self, pickerType: pickerType, completionHandler: completionHandler)
+  }
+
   func enableEditing(_ enable: Bool) {
     canEdit = enable
     navigationItem.rightBarButtonItem = enable ? editButtonItem : nil

--- a/iphone/Maps/Bookmarks/BookmarksList/Cells/BookmarkCell.swift
+++ b/iphone/Maps/Bookmarks/BookmarksList/Cells/BookmarkCell.swift
@@ -3,9 +3,22 @@ final class BookmarkCell: UITableViewCell {
   @IBOutlet private var bookmarkTitleLabel: UILabel!
   @IBOutlet private var bookmarkSubtitleLabel: UILabel!
 
+  private var bookmarkColorDidTapAction: (() -> Void)?
+
+  override func awakeFromNib() {
+    super.awakeFromNib()
+    let tapGesture = UITapGestureRecognizer(target: self, action: #selector(colorDidTapAction(_:)))
+    bookmarkImageView.addGestureRecognizer(tapGesture)
+  }
+
   func config(_ bookmark: IBookmarkViewModel) {
     bookmarkImageView.image = bookmark.image
     bookmarkTitleLabel.text = bookmark.bookmarkName
     bookmarkSubtitleLabel.text = bookmark.subtitle
+    bookmarkColorDidTapAction = bookmark.colorDidTapAction
+  }
+
+  @objc private func colorDidTapAction(_ sender: UITapGestureRecognizer) {
+    bookmarkColorDidTapAction?()
   }
 }

--- a/iphone/Maps/Bookmarks/BookmarksList/Cells/BookmarkCell.xib
+++ b/iphone/Maps/Bookmarks/BookmarksList/Cells/BookmarkCell.xib
@@ -17,8 +17,9 @@
                 <rect key="frame" x="0.0" y="0.0" width="320" height="64"/>
                 <autoresizingMask key="autoresizingMask"/>
                 <subviews>
-                    <imageView clipsSubviews="YES" userInteractionEnabled="NO" contentMode="center" horizontalHuggingPriority="251" verticalHuggingPriority="251" translatesAutoresizingMaskIntoConstraints="NO" id="J5x-wl-wyb">
+                    <imageView clipsSubviews="YES" contentMode="center" horizontalHuggingPriority="251" verticalHuggingPriority="251" translatesAutoresizingMaskIntoConstraints="NO" id="J5x-wl-wyb">
                         <rect key="frame" x="0.0" y="0.0" width="56" height="64"/>
+                        <gestureRecognizers/>
                         <constraints>
                             <constraint firstAttribute="width" constant="56" id="cgW-tP-nDZ"/>
                         </constraints>
@@ -56,6 +57,7 @@
                 </constraints>
             </tableViewCellContentView>
             <viewLayoutGuide key="safeArea" id="njF-e1-oar"/>
+            <gestureRecognizers/>
             <connections>
                 <outlet property="bookmarkImageView" destination="J5x-wl-wyb" id="JIb-pt-prZ"/>
                 <outlet property="bookmarkSubtitleLabel" destination="CTi-lg-1FN" id="5IW-bp-l8N"/>

--- a/iphone/Maps/Bookmarks/BookmarksList/Cells/TrackCell.swift
+++ b/iphone/Maps/Bookmarks/BookmarksList/Cells/TrackCell.swift
@@ -3,9 +3,22 @@ final class TrackCell: UITableViewCell {
   @IBOutlet private var trackTitleLabel: UILabel!
   @IBOutlet private var trackSubtitleLabel: UILabel!
 
+  private var trackColorDidTapAction: (() -> Void)?
+
+  override func awakeFromNib() {
+    super.awakeFromNib()
+    let tapGesture = UITapGestureRecognizer(target: self, action: #selector(colorDidTapAction(_:)))
+    trackImageView.addGestureRecognizer(tapGesture)
+  }
+
   func config(_ track: ITrackViewModel) {
     trackImageView.image = track.image
     trackTitleLabel.text = track.trackName
     trackSubtitleLabel.text = track.subtitle
+    trackColorDidTapAction = track.colorDidTapAction
+  }
+
+  @objc private func colorDidTapAction(_ sender: UITapGestureRecognizer) {
+    trackColorDidTapAction?()
   }
 }

--- a/iphone/Maps/Bookmarks/BookmarksList/Cells/TrackCell.xib
+++ b/iphone/Maps/Bookmarks/BookmarksList/Cells/TrackCell.xib
@@ -17,7 +17,7 @@
                 <rect key="frame" x="0.0" y="0.0" width="320" height="64"/>
                 <autoresizingMask key="autoresizingMask"/>
                 <subviews>
-                    <imageView clipsSubviews="YES" userInteractionEnabled="NO" contentMode="center" horizontalHuggingPriority="251" verticalHuggingPriority="251" translatesAutoresizingMaskIntoConstraints="NO" id="4MZ-Tg-LGR">
+                    <imageView clipsSubviews="YES" contentMode="center" horizontalHuggingPriority="251" verticalHuggingPriority="251" translatesAutoresizingMaskIntoConstraints="NO" id="4MZ-Tg-LGR">
                         <rect key="frame" x="0.0" y="0.0" width="56" height="64"/>
                         <constraints>
                             <constraint firstAttribute="width" constant="56" id="DbI-Xy-IiN"/>

--- a/iphone/Maps/Maps.xcodeproj/project.pbxproj
+++ b/iphone/Maps/Maps.xcodeproj/project.pbxproj
@@ -466,8 +466,10 @@
 		ED1080A72B791CFE0023F27E /* SocialMediaCollectionViewHeader.swift in Sources */ = {isa = PBXBuildFile; fileRef = ED1080A62B791CFE0023F27E /* SocialMediaCollectionViewHeader.swift */; };
 		ED1263AB2B6F99F900AD99F3 /* UIView+AddSeparator.swift in Sources */ = {isa = PBXBuildFile; fileRef = ED1263AA2B6F99F900AD99F3 /* UIView+AddSeparator.swift */; };
 		ED3EAC202B03C88100220A4A /* BottomTabBarButton.swift in Sources */ = {isa = PBXBuildFile; fileRef = ED3EAC1F2B03C88100220A4A /* BottomTabBarButton.swift */; };
+		ED9966802B94FBC20083CE55 /* ColorPicker.swift in Sources */ = {isa = PBXBuildFile; fileRef = ED99667D2B94FBC20083CE55 /* ColorPicker.swift */; };
 		EDBD68072B625724005DD151 /* LocationServicesDisabledAlert.xib in Resources */ = {isa = PBXBuildFile; fileRef = EDBD68062B625724005DD151 /* LocationServicesDisabledAlert.xib */; };
 		EDBD680B2B62572E005DD151 /* LocationServicesDisabledAlert.swift in Sources */ = {isa = PBXBuildFile; fileRef = EDBD680A2B62572E005DD151 /* LocationServicesDisabledAlert.swift */; };
+		EDC3573B2B7B5029001AE9CA /* CALayer+SetCorner.swift in Sources */ = {isa = PBXBuildFile; fileRef = EDC3573A2B7B5029001AE9CA /* CALayer+SetCorner.swift */; };
 		EDE243DD2B6D2E640057369B /* AboutController.swift in Sources */ = {isa = PBXBuildFile; fileRef = EDE243D52B6CF3980057369B /* AboutController.swift */; };
 		EDE243E52B6D3F400057369B /* OSMView.swift in Sources */ = {isa = PBXBuildFile; fileRef = EDE243E42B6D3F400057369B /* OSMView.swift */; };
 		EDE243E72B6D55610057369B /* InfoView.swift in Sources */ = {isa = PBXBuildFile; fileRef = EDE243E02B6D3EA00057369B /* InfoView.swift */; };
@@ -477,7 +479,6 @@
 		EDFDFB4C2B722C9C0013A44C /* InfoTableViewCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = EDFDFB4B2B722C9C0013A44C /* InfoTableViewCell.swift */; };
 		EDFDFB522B726F1A0013A44C /* ButtonsStackView.swift in Sources */ = {isa = PBXBuildFile; fileRef = EDFDFB512B726F1A0013A44C /* ButtonsStackView.swift */; };
 		EDFDFB612B74E2500013A44C /* DonationView.swift in Sources */ = {isa = PBXBuildFile; fileRef = EDFDFB602B74E2500013A44C /* DonationView.swift */; };
-		EDC3573B2B7B5029001AE9CA /* CALayer+SetCorner.swift in Sources */ = {isa = PBXBuildFile; fileRef = EDC3573A2B7B5029001AE9CA /* CALayer+SetCorner.swift */; };
 		F607C1881C032A8800B53A87 /* resources-hdpi_clear in Resources */ = {isa = PBXBuildFile; fileRef = F607C1831C032A8800B53A87 /* resources-hdpi_clear */; };
 		F607C18A1C032A8800B53A87 /* resources-hdpi_dark in Resources */ = {isa = PBXBuildFile; fileRef = F607C1841C032A8800B53A87 /* resources-hdpi_dark */; };
 		F623DA6C1C9C2731006A3436 /* opening_hours_how_to_edit.html in Resources */ = {isa = PBXBuildFile; fileRef = F623DA6A1C9C2731006A3436 /* opening_hours_how_to_edit.html */; };
@@ -1344,8 +1345,10 @@
 		ED3EAC1F2B03C88100220A4A /* BottomTabBarButton.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BottomTabBarButton.swift; sourceTree = "<group>"; };
 		ED48BBB817C2B1E2003E7E92 /* CircleView.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = CircleView.h; sourceTree = "<group>"; };
 		ED48BBB917C2B1E2003E7E92 /* CircleView.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = CircleView.m; sourceTree = "<group>"; };
+		ED99667D2B94FBC20083CE55 /* ColorPicker.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ColorPicker.swift; sourceTree = "<group>"; };
 		EDBD68062B625724005DD151 /* LocationServicesDisabledAlert.xib */ = {isa = PBXFileReference; lastKnownFileType = file.xib; path = LocationServicesDisabledAlert.xib; sourceTree = "<group>"; };
 		EDBD680A2B62572E005DD151 /* LocationServicesDisabledAlert.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LocationServicesDisabledAlert.swift; sourceTree = "<group>"; };
+		EDC3573A2B7B5029001AE9CA /* CALayer+SetCorner.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "CALayer+SetCorner.swift"; sourceTree = "<group>"; };
 		EDE243D52B6CF3980057369B /* AboutController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AboutController.swift; sourceTree = "<group>"; };
 		EDE243E02B6D3EA00057369B /* InfoView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = InfoView.swift; sourceTree = "<group>"; };
 		EDE243E42B6D3F400057369B /* OSMView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OSMView.swift; sourceTree = "<group>"; };
@@ -1355,7 +1358,6 @@
 		EDFDFB4B2B722C9C0013A44C /* InfoTableViewCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = InfoTableViewCell.swift; sourceTree = "<group>"; };
 		EDFDFB512B726F1A0013A44C /* ButtonsStackView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ButtonsStackView.swift; sourceTree = "<group>"; };
 		EDFDFB602B74E2500013A44C /* DonationView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DonationView.swift; sourceTree = "<group>"; };
-		EDC3573A2B7B5029001AE9CA /* CALayer+SetCorner.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "CALayer+SetCorner.swift"; sourceTree = "<group>"; };
 		EE026F0511D6AC0D00645242 /* classificator.txt */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text; name = classificator.txt; path = ../../data/classificator.txt; sourceTree = SOURCE_ROOT; };
 		EE164810135CEE49003B8A3E /* 06_code2000.ttf */ = {isa = PBXFileReference; lastKnownFileType = file; name = 06_code2000.ttf; path = ../../data/06_code2000.ttf; sourceTree = SOURCE_ROOT; };
 		EE583CBA12F773F00042CBE3 /* unicode_blocks.txt */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text; name = unicode_blocks.txt; path = ../../data/unicode_blocks.txt; sourceTree = "<group>"; };
@@ -2936,6 +2938,14 @@
 			path = Location;
 			sourceTree = "<group>";
 		};
+		ED99667C2B94FBC20083CE55 /* ColorPicker */ = {
+			isa = PBXGroup;
+			children = (
+				ED99667D2B94FBC20083CE55 /* ColorPicker.swift */,
+			);
+			path = ColorPicker;
+			sourceTree = "<group>";
+		};
 		EDFDFB412B7108090013A44C /* AboutController */ = {
 			isa = PBXGroup;
 			children = (
@@ -3148,6 +3158,7 @@
 		F6E2FBFB1E097B9F0083EBEC /* UI */ = {
 			isa = PBXGroup;
 			children = (
+				ED99667C2B94FBC20083CE55 /* ColorPicker */,
 				F69018B51E9E5FEB00B3C10B /* Autoupdate */,
 				34E7760D1F14B165003040B3 /* AvailableArea */,
 				349D1AC21E2E325B004A2006 /* BottomMenu */,
@@ -4082,6 +4093,7 @@
 				34AB66051FC5AA320078E451 /* MWMNavigationDashboardManager+Entity.mm in Sources */,
 				993DF12A23F6BDB100AC231A /* Style.swift in Sources */,
 				34ABA6171C2D185C00FE1BEC /* MWMAuthorizationOSMLoginViewController.mm in Sources */,
+				ED9966802B94FBC20083CE55 /* ColorPicker.swift in Sources */,
 				993DF10423F6BDB100AC231A /* UIView+styleName.swift in Sources */,
 				998927302449DE1500260CE2 /* TabBarArea.swift in Sources */,
 				995739042355CAA30019AEE7 /* PageIndicator.swift in Sources */,

--- a/iphone/Maps/UI/ColorPicker/ColorPicker.swift
+++ b/iphone/Maps/UI/ColorPicker/ColorPicker.swift
@@ -1,0 +1,76 @@
+enum ColorPickerType {
+  case defaultColorPicker(UIColor)
+  case bookmarkColorPicker(BookmarkColor)
+}
+
+final class ColorPicker: NSObject {
+
+  static let shared = ColorPicker()
+
+  private var onUpdateColorHandler: ((UIColor) -> Void)?
+
+  // MARK: - Public
+  /// Presents a color picker view controller modally from a specified root view controller.
+  ///
+  /// - Uses native color picker on the iOS 14.0+ for the `defaultColorPicker` type on iPhone and iPad.
+  /// - For the rest of the iOS versions, `bookmarkColorPicker` type and iPad designed for Mac uses a custom color picker.
+  ///
+  func present(from rootViewController: UIViewController, pickerType: ColorPickerType, completionHandler: ((UIColor) -> Void)?) {
+    onUpdateColorHandler = completionHandler
+    let colorPickerViewController: UIViewController
+
+    switch pickerType {
+    case .defaultColorPicker(let color):
+      if #available(iOS 14.0, *), !ProcessInfo.processInfo.isiOSAppOnMac {
+        colorPickerViewController = defaultColorPickerViewController(with: color)
+      } else {
+        colorPickerViewController = bookmarksColorPickerViewController(with: BookmarkColor.bookmarkColor(from: color) ?? .none)
+      }
+    case .bookmarkColorPicker(let bookmarkColor):
+      colorPickerViewController = bookmarksColorPickerViewController(with: bookmarkColor)
+    }
+    rootViewController.present(colorPickerViewController, animated: true)
+  }
+
+  // MARK: - Private
+  @available(iOS 14.0, *)
+  private func defaultColorPickerViewController(with selectedColor: UIColor) -> UIViewController {
+    let colorPickerController = UIColorPickerViewController()
+    colorPickerController.supportsAlpha = false
+    colorPickerController.selectedColor = selectedColor
+    colorPickerController.delegate = self
+    return colorPickerController
+  }
+
+  private func bookmarksColorPickerViewController(with selectedColor: BookmarkColor) -> UIViewController {
+    let bookmarksColorViewController = BookmarkColorViewController(bookmarkColor: selectedColor)
+    bookmarksColorViewController.delegate = self
+    // The navigation controller is used for getting the navigation item with the title and the close button.
+    let navigationController = UINavigationController(rootViewController: bookmarksColorViewController)
+    return navigationController
+  }
+}
+
+// MARK: - BookmarkColorViewControllerDelegate
+extension ColorPicker: BookmarkColorViewControllerDelegate {
+  func bookmarkColorViewController(_ viewController: BookmarkColorViewController, didSelect bookmarkColor: BookmarkColor) {
+    onUpdateColorHandler?(bookmarkColor.color)
+    onUpdateColorHandler = nil
+    viewController.dismiss(animated: true)
+  }
+}
+
+// MARK: - UIColorPickerViewControllerDelegate
+extension ColorPicker: UIColorPickerViewControllerDelegate {
+  @available(iOS 14.0, *)
+  func colorPickerViewControllerDidFinish(_ viewController: UIColorPickerViewController) {
+    onUpdateColorHandler?(viewController.selectedColor)
+    onUpdateColorHandler = nil
+    viewController.dismiss(animated: true, completion: nil)
+  }
+
+  @available(iOS 14.0, *)
+  func colorPickerViewControllerDidSelectColor(_ viewController: UIColorPickerViewController) {
+    onUpdateColorHandler?(viewController.selectedColor)
+  }
+}

--- a/iphone/Maps/UI/EditBookmark/BookmarkColorViewController.swift
+++ b/iphone/Maps/UI/EditBookmark/BookmarkColorViewController.swift
@@ -22,6 +22,11 @@ final class BookmarkColorViewController: MWMTableViewController {
   override func viewDidLoad() {
     super.viewDidLoad()
     title = L("change_color")
+    navigationItem.leftBarButtonItem = UIBarButtonItem(barButtonSystemItem: .cancel, target: self, action: #selector(cancelButtonDidTap))
+  }
+
+  @objc private func cancelButtonDidTap() {
+    dismiss(animated: true, completion: nil)
   }
 
   override func tableView(_ tableView: UITableView, numberOfRowsInSection section: Int) -> Int {

--- a/iphone/Maps/UI/EditBookmark/EditBookmarkViewController.swift
+++ b/iphone/Maps/UI/EditBookmark/EditBookmarkViewController.swift
@@ -144,9 +144,7 @@ final class EditBookmarkViewController: MWMTableViewController {
     case .color:
       openColorPicker()
     case .bookmarkGroup:
-      let groupViewController = SelectBookmarkGroupViewController(groupName: bookmarkGroupTitle ?? "", groupId: bookmarkGroupId)
-      groupViewController.delegate = self
-      navigationController?.pushViewController(groupViewController, animated: true)
+      openGroupPicker()
     default:
       break
     }
@@ -173,11 +171,16 @@ final class EditBookmarkViewController: MWMTableViewController {
   @objc private func openColorPicker() {
     ColorPicker.shared.present(from: self, pickerType: .bookmarkColorPicker(bookmarkColor), completionHandler: { [weak self] color in
       self?.bookmarkColor = BookmarkColor.bookmarkColor(from: color)
-      self?.tableView.reloadRows(at: [IndexPath(row: InfoSectionRows.color.rawValue, section: Sections.info.rawValue)],
-                           with: .none)
+      self?.tableView.reloadRows(at: [IndexPath(row: InfoSectionRows.color.rawValue, section: Sections.info.rawValue)], with: .none)
     })
   }
 
+  private func openGroupPicker() {
+    let groupViewController = SelectBookmarkGroupViewController(groupName: bookmarkGroupTitle ?? "", groupId: bookmarkGroupId)
+    let navigationController = UINavigationController(rootViewController: groupViewController)
+    groupViewController.delegate = self
+    present(navigationController, animated: true, completion: nil)
+  }
 }
 
 extension EditBookmarkViewController: BookmarkTitleCellDelegate {
@@ -212,23 +215,13 @@ extension EditBookmarkViewController: MWMButtonCellDelegate {
   }
 }
 
-extension EditBookmarkViewController: BookmarkColorViewControllerDelegate {
-  func bookmarkColorViewController(_ viewController: BookmarkColorViewController, didSelect color: BookmarkColor) {
-    goBack()
-    bookmarkColor = color
-    tableView.reloadRows(at: [IndexPath(row: InfoSectionRows.color.rawValue, section: Sections.info.rawValue)],
-                         with: .none)
-  }
-}
-
 extension EditBookmarkViewController: SelectBookmarkGroupViewControllerDelegate {
   func bookmarkGroupViewController(_ viewController: SelectBookmarkGroupViewController,
                                    didSelect groupTitle: String,
                                    groupId: MWMMarkGroupID) {
-    goBack()
+    viewController.dismiss(animated: true)
     bookmarkGroupTitle = groupTitle
     bookmarkGroupId = groupId
-    tableView.reloadRows(at: [IndexPath(row: InfoSectionRows.bookmarkGroup.rawValue, section: Sections.info.rawValue)],
-                         with: .none)
+    tableView.reloadRows(at: [IndexPath(row: InfoSectionRows.bookmarkGroup.rawValue, section: Sections.info.rawValue)], with: .none)
   }
 }

--- a/iphone/Maps/UI/EditBookmark/EditBookmarkViewController.swift
+++ b/iphone/Maps/UI/EditBookmark/EditBookmarkViewController.swift
@@ -139,11 +139,10 @@ final class EditBookmarkViewController: MWMTableViewController {
   }
 
   override func tableView(_ tableView: UITableView, didSelectRowAt indexPath: IndexPath) {
+    tableView.deselectRow(at: indexPath, animated: true)
     switch InfoSectionRows(rawValue: indexPath.row) {
     case .color:
-      let colorViewController = BookmarkColorViewController(bookmarkColor: bookmarkColor)
-      colorViewController.delegate = self
-      navigationController?.pushViewController(colorViewController, animated: true)
+      openColorPicker()
     case .bookmarkGroup:
       let groupViewController = SelectBookmarkGroupViewController(groupName: bookmarkGroupTitle ?? "", groupId: bookmarkGroupId)
       groupViewController.delegate = self
@@ -170,6 +169,15 @@ final class EditBookmarkViewController: MWMTableViewController {
     editingCompleted?(true)
     goBack()
   }
+
+  @objc private func openColorPicker() {
+    ColorPicker.shared.present(from: self, pickerType: .bookmarkColorPicker(bookmarkColor), completionHandler: { [weak self] color in
+      self?.bookmarkColor = BookmarkColor.bookmarkColor(from: color)
+      self?.tableView.reloadRows(at: [IndexPath(row: InfoSectionRows.color.rawValue, section: Sections.info.rawValue)],
+                           with: .none)
+    })
+  }
+
 }
 
 extension EditBookmarkViewController: BookmarkTitleCellDelegate {

--- a/iphone/Maps/UI/EditBookmark/EditTrackViewController.swift
+++ b/iphone/Maps/UI/EditBookmark/EditTrackViewController.swift
@@ -116,9 +116,7 @@ final class EditTrackViewController: MWMTableViewController {
     case .color:
       openColorPicker()
     case .bookmarkGroup:
-      let groupViewController = SelectBookmarkGroupViewController(groupName: trackGroupTitle ?? "", groupId: trackGroupId)
-      groupViewController.delegate = self
-      navigationController?.pushViewController(groupViewController, animated: true)
+      openGroupPicker()
     default:
       break
     }
@@ -145,6 +143,12 @@ final class EditTrackViewController: MWMTableViewController {
     })
   }
 
+  private func openGroupPicker() {
+    let groupViewController = SelectBookmarkGroupViewController(groupName: trackGroupTitle ?? "", groupId: trackGroupId)
+    groupViewController.delegate = self
+    let navigationController = UINavigationController(rootViewController: groupViewController)
+    present(navigationController, animated: true, completion: nil)
+  }
 }
 
 extension EditTrackViewController: BookmarkTitleCellDelegate {
@@ -164,7 +168,7 @@ extension EditTrackViewController: MWMButtonCellDelegate {
 
 extension EditTrackViewController: BookmarkColorViewControllerDelegate {
   func bookmarkColorViewController(_ viewController: BookmarkColorViewController, didSelect bookmarkColor: BookmarkColor) {
-    goBack()
+    viewController.dismiss(animated: true)
     updateColor(bookmarkColor.color)
   }
 }
@@ -174,24 +178,10 @@ extension EditTrackViewController: SelectBookmarkGroupViewControllerDelegate {
   func bookmarkGroupViewController(_ viewController: SelectBookmarkGroupViewController,
                                    didSelect groupTitle: String,
                                    groupId: MWMMarkGroupID) {
-    goBack()
+    viewController.dismiss(animated: true)
     trackGroupTitle = groupTitle
     trackGroupId = groupId
     tableView.reloadRows(at: [IndexPath(row: InfoSectionRows.bookmarkGroup.rawValue, section: Sections.info.rawValue)],
                          with: .none)
-  }
-}
-
-// MARK: - UIColorPickerViewControllerDelegate
-extension EditTrackViewController: UIColorPickerViewControllerDelegate {
-  @available(iOS 14.0, *)
-  func colorPickerViewControllerDidFinish(_ viewController: UIColorPickerViewController) {
-    updateColor(viewController.selectedColor)
-    dismiss(animated: true, completion: nil)
-  }
-
-  @available(iOS 14.0, *)
-  func colorPickerViewControllerDidSelectColor(_ viewController: UIColorPickerViewController) {
-    updateColor(viewController.selectedColor)
   }
 }

--- a/iphone/Maps/UI/EditBookmark/EditTrackViewController.swift
+++ b/iphone/Maps/UI/EditBookmark/EditTrackViewController.swift
@@ -114,19 +114,7 @@ final class EditTrackViewController: MWMTableViewController {
     tableView.deselectRow(at: indexPath, animated: true)
     switch InfoSectionRows(rawValue: indexPath.row) {
     case .color:
-      if #available(iOS 14.0, *) {
-        let colorPickerController = UIColorPickerViewController()
-        colorPickerController.supportsAlpha = false
-        colorPickerController.delegate = self
-        colorPickerController.selectedColor = trackColor
-        present(colorPickerController, animated: true)
-      } else {
-        // For iOS < 14.0 when the color cannot be mapped to predefined it will not be selected in the table view.
-        let trackColor = BookmarkColor.bookmarkColor(from: trackColor) ?? .none
-        let colorViewController = BookmarkColorViewController(bookmarkColor: trackColor)
-        colorViewController.delegate = self
-        navigationController?.pushViewController(colorViewController, animated: true)
-      }
+      openColorPicker()
     case .bookmarkGroup:
       let groupViewController = SelectBookmarkGroupViewController(groupName: trackGroupTitle ?? "", groupId: trackGroupId)
       groupViewController.delegate = self
@@ -150,6 +138,13 @@ final class EditTrackViewController: MWMTableViewController {
     tableView.reloadRows(at: [IndexPath(row: InfoSectionRows.color.rawValue, section: Sections.info.rawValue)],
                          with: .none)
   }
+
+  @objc private func openColorPicker() {
+    ColorPicker.shared.present(from: self, pickerType: .defaultColorPicker(trackColor), completionHandler: { [weak self] color in
+      self?.updateColor(color)
+    })
+  }
+
 }
 
 extension EditTrackViewController: BookmarkTitleCellDelegate {

--- a/iphone/Maps/UI/EditBookmark/SelectBookmarkGroupViewController.swift
+++ b/iphone/Maps/UI/EditBookmark/SelectBookmarkGroupViewController.swift
@@ -24,6 +24,7 @@ final class SelectBookmarkGroupViewController: MWMTableViewController {
     super.init(style: .grouped)
   }
 
+  @available(*, unavailable)
   required init?(coder: NSCoder) {
     fatalError("init(coder:) has not been implemented")
   }
@@ -31,6 +32,11 @@ final class SelectBookmarkGroupViewController: MWMTableViewController {
   override func viewDidLoad() {
     super.viewDidLoad()
     title = L("bookmark_sets");
+    navigationItem.leftBarButtonItem = UIBarButtonItem(barButtonSystemItem: .cancel, target: self, action: #selector(cancelButtonDidTap))
+  }
+
+  @objc private func cancelButtonDidTap() {
+    dismiss(animated: true, completion: nil)
   }
 
   override func numberOfSections(in tableView: UITableView) -> Int {


### PR DESCRIPTION
This PR implements:
1. Modal presentation for the color selection
When a user want to quickly change a single option there is better solution to make the screen modal. Why modal? Apple's hig says:
> Help people perform a distinct, narrowly scoped task without **losing track of their previous context**

https://developer.apple.com/design/human-interface-guidelines/modality

2. Modal presentation for the category selection (to match with the color selection)
3. Possibility to change color by tapping on the `circle color icon` without opening the `Edit bookmark` screen (it's really faster to change color now!)
4. New reusable ColorPicker class that:
 - use native color picking for tracks if > iOS14.0
 - use old color picking for all other cases and `iPad designed for Mac` (because on mac this color picker have bad design)
 
Tested on: 
iPhone 11Pro ios17.2
iPhone 6 ios12.5
iPhone 15 pro 17.2 (sim)
iPad 5air 5 (sim)
iPad designed for Mac

Results:

![Simulator Screen Recording - iPhone 15 Pro - 2024-03-01 at 14 04 54](https://github.com/organicmaps/organicmaps/assets/79797627/39dc0640-5ef9-47e4-9560-5395c5d38eee)
![Simulator Screen Recording - iPhone 15 Pro - 2024-03-01 at 14 05 06](https://github.com/organicmaps/organicmaps/assets/79797627/05ff5012-7f9c-493b-8f43-e5b1a75f40eb)
![Simulator Screen Recording - iPhone 15 Pro - 2024-03-01 at 14 33 37](https://github.com/organicmaps/organicmaps/assets/79797627/13ba6c9a-dd70-4685-a1b4-2e7363e310f3)
![Simulator Screen Recording - iPad Air (5th generation) - 2024-03-01 at 14 38 25](https://github.com/organicmaps/organicmaps/assets/79797627/67518d56-7756-4c9c-9b15-4cf182d4635d)

<img width="600" alt="image" src="https://github.com/organicmaps/organicmaps/assets/79797627/008ac80f-271f-447e-a3a0-0d0fc9b0f4ef">
<img width="600" alt="image" src="https://github.com/organicmaps/organicmaps/assets/79797627/73df0c9b-2841-4a64-b6c2-f7a8c90697ac">
