### PR TITLE
[ios] Fix srgb color crash

### DIFF
--- a/iphone/Maps/UI/ColorPicker/ColorPicker.swift
+++ b/iphone/Maps/UI/ColorPicker/ColorPicker.swift
@@ -64,13 +64,13 @@ extension ColorPicker: BookmarkColorViewControllerDelegate {
 extension ColorPicker: UIColorPickerViewControllerDelegate {
   @available(iOS 14.0, *)
   func colorPickerViewControllerDidFinish(_ viewController: UIColorPickerViewController) {
-    onUpdateColorHandler?(viewController.selectedColor)
+    onUpdateColorHandler?(viewController.selectedColor.sRGBColor)
     onUpdateColorHandler = nil
     viewController.dismiss(animated: true, completion: nil)
   }
 
   @available(iOS 14.0, *)
   func colorPickerViewControllerDidSelectColor(_ viewController: UIColorPickerViewController) {
-    onUpdateColorHandler?(viewController.selectedColor)
+    onUpdateColorHandler?(viewController.selectedColor.sRGBColor)
   }
 }

--- a/iphone/Maps/UI/EditBookmark/EditTrackViewController.swift
+++ b/iphone/Maps/UI/EditBookmark/EditTrackViewController.swift
@@ -126,7 +126,7 @@ final class EditTrackViewController: MWMTableViewController {
   
   @objc private func onSave() {
     view.endEditing(true)
-    BookmarksManager.shared().updateTrack(trackId, setGroupId: trackGroupId, color: trackColor.sRGBColor, title: trackTitle ?? "")
+    BookmarksManager.shared().updateTrack(trackId, setGroupId: trackGroupId, color: trackColor, title: trackTitle ?? "")
     editingCompleted(true)
     goBack()
   }


### PR DESCRIPTION
Fix crash caused by the https://github.com/organicmaps/organicmaps/pull/7499 whe non srgb color passed from the ColorPicker.