### PR TITLE
[base][drape] Fix `deleted operator <<` of char32_t on C++20

### DIFF
--- a/base/internal/message.hpp
+++ b/base/internal/message.hpp
@@ -28,6 +28,7 @@ std::string DebugPrint(std::string const & t);
 inline std::string DebugPrint(char const * t);
 inline std::string DebugPrint(char * t) { return DebugPrint(static_cast<char const *>(t)); }
 inline std::string DebugPrint(char t);
+inline std::string DebugPrint(char32_t t);
 
 /// @name We are going step-by-step to C++20. Use UTF8 string literals instead.
 /// @{
@@ -95,6 +96,13 @@ inline std::string DebugPrint(std::u32string const & utf32)
 inline std::string DebugPrint(std::u32string_view utf32)
 {
   return internal::ToUtf8(utf32);
+}
+
+inline std::string DebugPrint(char32_t t)
+{
+  std::ostringstream out;
+  out << std::hex << static_cast<uint32_t>(t);
+  return out.str();
 }
 
 inline std::string DebugPrint(std::chrono::time_point<std::chrono::system_clock> const & ts)

--- a/drape/drape_tests/bidi_tests.cpp
+++ b/drape/drape_tests/bidi_tests.cpp
@@ -32,11 +32,11 @@ UNIT_TEST(Bidi_Print)
   {
     auto const s = strings::MakeUniString(utf8);
     for (auto const ucp : s)
-      std::cout << std::hex << ucp << ", ";
+      std::cout << std::hex << static_cast<uint32_t>(ucp) << ", ";
 
     std::cout << std::endl;
     for (auto const ucp : bidi::log2vis(s))
-      std::cout << std::hex << ucp << ", ";
+      std::cout << std::hex << static_cast<uint32_t>(ucp) << ", ";
 
     std::cout << std::endl;
   };

--- a/drape/utils/glyph_usage_tracker.cpp
+++ b/drape/utils/glyph_usage_tracker.cpp
@@ -16,14 +16,14 @@ std::string GlyphUsageTracker::GlyphUsageStatistic::ToString() const
   ss << " Invalid glyphs count = " << m_invalidGlyphs.size() << "\n";
   ss << " Invalid glyphs: { ";
   for (auto const & it : m_invalidGlyphs)
-    ss << it.first << "(" << it.second << ") ";
+    ss << std::hex << static_cast<uint32_t>(it.first) << std::dec << "(" << it.second << ") ";
   ss << "}\n";
 
   ss << " Unexpected glyphs count = " << m_unexpectedGlyphs.size() << "\n";
   ss << " Unexpected glyphs: {\n";
   for (auto const & it : m_unexpectedGlyphs)
   {
-    ss << "   glyph = " << it.first << ", unique usages = " << it.second.m_counter
+    ss << "   glyph = " << std::hex << static_cast<uint32_t>(it.first) << std::dec << ", unique usages = " << it.second.m_counter
        << ", group = " << it.second.m_group << ", expected groups = { ";
 
     for (auto const & gr : it.second.m_expectedGroups)


### PR DESCRIPTION
Commit f05be9bf713a6ad7e686695de89296b728a26176,
changed `UniChar` from  `uint32_t` to `char32_t`.
Unlike `uint32_t` the `char32_t` has explicitly
deleted `<<` operator in C++20, and this operator
has been in use on `UniChar`.