### PR TITLE
[bookmarks] [ios] Fix bookmarks categories sorting bug

### DIFF
--- a/android/app/src/main/cpp/app/organicmaps/bookmarks/data/BookmarkManager.cpp
+++ b/android/app/src/main/cpp/app/organicmaps/bookmarks/data/BookmarkManager.cpp
@@ -625,16 +625,13 @@ Java_app_organicmaps_bookmarks_data_BookmarkManager_nativeAreNotificationsEnable
 }
 
 JNIEXPORT jobject JNICALL
-Java_app_organicmaps_bookmarks_data_BookmarkManager_nativeGetBookmarkCategory(JNIEnv *env,
-                                                                                  jobject,
-                                                                                  jlong id)
+Java_app_organicmaps_bookmarks_data_BookmarkManager_nativeGetBookmarkCategory(JNIEnv *env, jobject, jlong id)
 {
   return MakeCategory(env, static_cast<kml::MarkGroupId>(id));
 }
 
 JNIEXPORT jobjectArray JNICALL
-Java_app_organicmaps_bookmarks_data_BookmarkManager_nativeGetBookmarkCategories(JNIEnv *env,
-  jobject)
+Java_app_organicmaps_bookmarks_data_BookmarkManager_nativeGetBookmarkCategories(JNIEnv *env, jobject)
 {
   auto const & bm = frm()->GetBookmarkManager();
   auto const & ids = bm.GetSortedBmGroupIdList();
@@ -643,8 +640,7 @@ Java_app_organicmaps_bookmarks_data_BookmarkManager_nativeGetBookmarkCategories(
 }
 
 JNIEXPORT jint JNICALL
-Java_app_organicmaps_bookmarks_data_BookmarkManager_nativeGetBookmarkCategoriesCount(JNIEnv *env,
-                                                                                jobject)
+Java_app_organicmaps_bookmarks_data_BookmarkManager_nativeGetBookmarkCategoriesCount(JNIEnv *env, jobject)
 {
    auto const & bm = frm()->GetBookmarkManager();
    auto const count = bm.GetBmGroupsCount();
@@ -653,9 +649,7 @@ Java_app_organicmaps_bookmarks_data_BookmarkManager_nativeGetBookmarkCategoriesC
 }
 
 JNIEXPORT jobjectArray JNICALL
-Java_app_organicmaps_bookmarks_data_BookmarkManager_nativeGetChildrenCategories(JNIEnv *env,
-                                                                                    jobject,
-                                                                                    jlong parentId)
+Java_app_organicmaps_bookmarks_data_BookmarkManager_nativeGetChildrenCategories(JNIEnv *env, jobject, jlong parentId)
 {
   auto const & bm = frm()->GetBookmarkManager();
   auto const ids = bm.GetChildrenCategories(static_cast<kml::MarkGroupId>(parentId));

--- a/android/app/src/main/cpp/app/organicmaps/bookmarks/data/BookmarkManager.cpp
+++ b/android/app/src/main/cpp/app/organicmaps/bookmarks/data/BookmarkManager.cpp
@@ -637,7 +637,7 @@ Java_app_organicmaps_bookmarks_data_BookmarkManager_nativeGetBookmarkCategories(
   jobject)
 {
   auto const & bm = frm()->GetBookmarkManager();
-  auto const & ids = bm.GetBmGroupsIdList();
+  auto const & ids = bm.GetSortedBmGroupIdList();
 
   return MakeCategories(env, ids);
 }

--- a/android/app/src/main/cpp/app/organicmaps/bookmarks/data/BookmarkManager.cpp
+++ b/android/app/src/main/cpp/app/organicmaps/bookmarks/data/BookmarkManager.cpp
@@ -642,6 +642,16 @@ Java_app_organicmaps_bookmarks_data_BookmarkManager_nativeGetBookmarkCategories(
   return MakeCategories(env, ids);
 }
 
+JNIEXPORT jint JNICALL
+Java_app_organicmaps_bookmarks_data_BookmarkManager_nativeGetBookmarkCategoriesCount(JNIEnv *env,
+                                                                                jobject)
+{
+   auto const & bm = frm()->GetBookmarkManager();
+   auto const count = bm.GetBmGroupsCount();
+
+   return static_cast<jint>(count);
+}
+
 JNIEXPORT jobjectArray JNICALL
 Java_app_organicmaps_bookmarks_data_BookmarkManager_nativeGetChildrenCategories(JNIEnv *env,
                                                                                     jobject,

--- a/android/app/src/main/java/app/organicmaps/bookmarks/BookmarksListFragment.java
+++ b/android/app/src/main/java/app/organicmaps/bookmarks/BookmarksListFragment.java
@@ -517,7 +517,7 @@ public class BookmarksListFragment extends BaseMwmRecyclerFragment<ConcatAdapter
 
   private boolean isLastOwnedCategory()
   {
-    return BookmarkManager.INSTANCE.getCategories().size() == 1;
+    return BookmarkManager.INSTANCE.getCategoriesCount() == 1;
   }
 
   private void updateSortingProgressBar()

--- a/android/app/src/main/java/app/organicmaps/bookmarks/data/BookmarkCategoriesDataProvider.java
+++ b/android/app/src/main/java/app/organicmaps/bookmarks/data/BookmarkCategoriesDataProvider.java
@@ -8,6 +8,7 @@ public interface BookmarkCategoriesDataProvider
 {
   @NonNull
   List<BookmarkCategory> getCategories();
+  int getCategoriesCount();
   @NonNull
   List<BookmarkCategory> getChildrenCategories(long parentId);
   @NonNull

--- a/android/app/src/main/java/app/organicmaps/bookmarks/data/BookmarkManager.java
+++ b/android/app/src/main/java/app/organicmaps/bookmarks/data/BookmarkManager.java
@@ -526,6 +526,10 @@ public enum BookmarkManager
   {
     return mCurrentDataProvider.getCategories();
   }
+  public int getCategoriesCount()
+  {
+    return mCurrentDataProvider.getCategoriesCount();
+  }
 
   @NonNull
   BookmarkCategoriesCache getBookmarkCategoriesCache()
@@ -627,6 +631,7 @@ public enum BookmarkManager
   native BookmarkCategory nativeGetBookmarkCategory(long catId);
   @NonNull
   native BookmarkCategory[] nativeGetBookmarkCategories();
+  native int nativeGetBookmarkCategoriesCount();
   @NonNull
   native BookmarkCategory[] nativeGetChildrenCategories(long catId);
 

--- a/android/app/src/main/java/app/organicmaps/bookmarks/data/CacheBookmarkCategoriesDataProvider.java
+++ b/android/app/src/main/java/app/organicmaps/bookmarks/data/CacheBookmarkCategoriesDataProvider.java
@@ -29,6 +29,12 @@ class CacheBookmarkCategoriesDataProvider implements BookmarkCategoriesDataProvi
     return BookmarkManager.INSTANCE.getBookmarkCategoriesCache().getCategories();
   }
 
+  @Override
+  public int getCategoriesCount()
+  {
+    return BookmarkManager.INSTANCE.nativeGetBookmarkCategoriesCount();
+  }
+
   @NonNull
   @Override
   public List<BookmarkCategory> getChildrenCategories(long parentId)

--- a/android/app/src/main/java/app/organicmaps/bookmarks/data/CoreBookmarkCategoriesDataProvider.java
+++ b/android/app/src/main/java/app/organicmaps/bookmarks/data/CoreBookmarkCategoriesDataProvider.java
@@ -22,6 +22,12 @@ class CoreBookmarkCategoriesDataProvider implements BookmarkCategoriesDataProvid
     return Arrays.asList(categories);
   }
 
+  @Override
+  public int getCategoriesCount()
+  {
+    return BookmarkManager.INSTANCE.nativeGetBookmarkCategoriesCount();
+  }
+
   @NonNull
   @Override
   public List<BookmarkCategory> getChildrenCategories(long parentId)

--- a/iphone/CoreApi/CoreApi/Bookmarks/MWMBookmarksManager.h
+++ b/iphone/CoreApi/CoreApi/Bookmarks/MWMBookmarksManager.h
@@ -91,7 +91,7 @@ NS_SWIFT_NAME(BookmarksManager)
 - (void)setNotificationsEnabled:(BOOL)enabled;
 - (BOOL)areNotificationsEnabled;
 
-- (NSArray<MWMBookmarkGroup *> *)userCategories;
+- (NSArray<MWMBookmarkGroup *> *)sortedUserCategories;
 - (MWMBookmarkGroup *)categoryWithId:(MWMMarkGroupID)groupId;
 - (MWMBookmarkGroup *)categoryForBookmarkId:(MWMMarkID)bookmarkId;
 - (MWMBookmarkGroup *)categoryForTrackId:(MWMTrackID)trackId;

--- a/iphone/CoreApi/CoreApi/Bookmarks/MWMBookmarksManager.h
+++ b/iphone/CoreApi/CoreApi/Bookmarks/MWMBookmarksManager.h
@@ -92,6 +92,7 @@ NS_SWIFT_NAME(BookmarksManager)
 - (BOOL)areNotificationsEnabled;
 
 - (NSArray<MWMBookmarkGroup *> *)sortedUserCategories;
+- (size_t)userCategoriesCount;
 - (MWMBookmarkGroup *)categoryWithId:(MWMMarkGroupID)groupId;
 - (MWMBookmarkGroup *)categoryForBookmarkId:(MWMMarkID)bookmarkId;
 - (MWMBookmarkGroup *)categoryForTrackId:(MWMTrackID)trackId;

--- a/iphone/CoreApi/CoreApi/Bookmarks/MWMBookmarksManager.mm
+++ b/iphone/CoreApi/CoreApi/Bookmarks/MWMBookmarksManager.mm
@@ -199,16 +199,6 @@ static BookmarkManager::SortingType convertSortingTypeToCore(MWMBookmarksSorting
   self.bm.PrepareForSearch(groupId);
 }
 
-- (MWMGroupIDCollection)groupsIdList
-{
-  auto const & list = self.bm.GetBmGroupsIdList();
-  NSMutableArray<NSNumber *> * collection = [[NSMutableArray alloc] initWithCapacity:list.size()];
-
-  for (auto const & groupId : list)
-    [collection addObject:@(groupId)];
-  return collection;
-}
-
 - (NSString *)getCategoryName:(MWMMarkGroupID)groupId
 {
   return @(self.bm.GetCategoryName(groupId).c_str());
@@ -638,8 +628,8 @@ static BookmarkManager::SortingType convertSortingTypeToCore(MWMBookmarksSorting
 
 #pragma mark - Catalog
 
-- (NSArray<MWMBookmarkGroup *> *)userCategories {
-  auto const & list = self.bm.GetBmGroupsIdList();
+- (NSArray<MWMBookmarkGroup *> *)sortedUserCategories {
+  auto const & list = self.bm.GetSortedBmGroupIdList();
   NSMutableArray<MWMBookmarkGroup *> * result = [[NSMutableArray alloc] initWithCapacity:list.size()];
 
   for (auto const & groupId : list)

--- a/iphone/CoreApi/CoreApi/Bookmarks/MWMBookmarksManager.mm
+++ b/iphone/CoreApi/CoreApi/Bookmarks/MWMBookmarksManager.mm
@@ -641,6 +641,10 @@ static BookmarkManager::SortingType convertSortingTypeToCore(MWMBookmarksSorting
   return [[MWMBookmarkGroup alloc] initWithCategoryId:groupId bookmarksManager:self];
 }
 
+- (size_t)userCategoriesCount {
+  return self.bm.GetBmGroupsCount();
+}
+
 - (void)updateBookmark:(MWMMarkID)bookmarkId
             setGroupId:(MWMMarkGroupID)groupId
                  title:(NSString *)title

--- a/iphone/Maps/Bookmarks/BookmarksList/BookmarksListInteractor.swift
+++ b/iphone/Maps/Bookmarks/BookmarksList/BookmarksListInteractor.swift
@@ -163,7 +163,7 @@ extension BookmarksListInteractor: IBookmarksListInteractor {
   }
 
   func canDeleteGroup() -> Bool {
-    bookmarksManager.sortedUserCategories().count > 1
+    bookmarksManager.userCategoriesCount() > 1
   }
 
   func exportFile(_ completion: @escaping (URL?, ExportFileStatus) -> Void) {

--- a/iphone/Maps/Bookmarks/BookmarksList/BookmarksListInteractor.swift
+++ b/iphone/Maps/Bookmarks/BookmarksList/BookmarksListInteractor.swift
@@ -163,7 +163,7 @@ extension BookmarksListInteractor: IBookmarksListInteractor {
   }
 
   func canDeleteGroup() -> Bool {
-    bookmarksManager.userCategories().count > 1
+    bookmarksManager.sortedUserCategories().count > 1
   }
 
   func exportFile(_ completion: @escaping (URL?, ExportFileStatus) -> Void) {

--- a/iphone/Maps/Bookmarks/Categories/BMCViewModel/BMCDefaultViewModel.swift
+++ b/iphone/Maps/Bookmarks/Categories/BMCViewModel/BMCDefaultViewModel.swift
@@ -36,7 +36,7 @@ final class BMCDefaultViewModel: NSObject {
   }
 
   private func setCategories() {
-    categories = manager.userCategories()
+    categories = manager.sortedUserCategories()
   }
 
   private func setActions() {

--- a/iphone/Maps/Bookmarks/Categories/Category settings/CategorySettingsViewController.swift
+++ b/iphone/Maps/Bookmarks/Categories/Category settings/CategorySettingsViewController.swift
@@ -87,7 +87,7 @@ final class CategorySettingsViewController: MWMTableViewController {
       let cell = tableView.dequeueReusableCell(cell: MWMButtonCell.self, indexPath: indexPath)
       cell.configure(with: self,
                      title: L("delete_list"),
-                     enabled: BookmarksManager.shared().userCategories().count > 1)
+                     enabled: BookmarksManager.shared().sortedUserCategories().count > 1)
       return cell
     default:
       fatalError()

--- a/iphone/Maps/Bookmarks/Categories/Category settings/CategorySettingsViewController.swift
+++ b/iphone/Maps/Bookmarks/Categories/Category settings/CategorySettingsViewController.swift
@@ -87,7 +87,7 @@ final class CategorySettingsViewController: MWMTableViewController {
       let cell = tableView.dequeueReusableCell(cell: MWMButtonCell.self, indexPath: indexPath)
       cell.configure(with: self,
                      title: L("delete_list"),
-                     enabled: BookmarksManager.shared().sortedUserCategories().count > 1)
+                     enabled: BookmarksManager.shared().userCategoriesCount() > 1)
       return cell
     default:
       fatalError()

--- a/iphone/Maps/Classes/CarPlay/Template Builders/ListTemplateBuilder.swift
+++ b/iphone/Maps/Classes/CarPlay/Template Builders/ListTemplateBuilder.swift
@@ -73,7 +73,7 @@ final class ListTemplateBuilder {
   
   private class func obtainCategories(template: CPListTemplate) {
     let bookmarkManager = BookmarksManager.shared()
-    let categories = bookmarkManager.userCategories()
+    let categories = bookmarkManager.sortedUserCategories()
     let items: [CPListItem] = categories.compactMap({ category in
       if category.bookmarksCount == 0 { return nil }
       let placesString = category.placesCountTitle()

--- a/iphone/Maps/UI/EditBookmark/SelectBookmarkGroupViewController.swift
+++ b/iphone/Maps/UI/EditBookmark/SelectBookmarkGroupViewController.swift
@@ -16,7 +16,7 @@ final class SelectBookmarkGroupViewController: MWMTableViewController {
   weak var delegate: SelectBookmarkGroupViewControllerDelegate?
   private let groupName: String
   private let groupId: MWMMarkGroupID
-  private let bookmarkGroups = BookmarksManager.shared().userCategories()
+  private let bookmarkGroups = BookmarksManager.shared().sortedUserCategories()
 
   init(groupName: String, groupId: MWMMarkGroupID) {
     self.groupName = groupName

--- a/map/bookmark_manager.cpp
+++ b/map/bookmark_manager.cpp
@@ -2207,7 +2207,25 @@ void BookmarkManager::UpdateBmGroupIdList()
   CHECK_THREAD_CHECKER(m_threadChecker, ());
   size_t const count = m_categories.size();
 
-  // All this routine to get sorted list by last modified time.
+  using PairT = std::pair<kml::MarkGroupId, BookmarkCategory const *>;
+  std::vector<PairT> vec;
+  vec.reserve(count);
+  for (auto const & [markGroupId, categoryPtr] : m_categories)
+    vec.emplace_back(markGroupId, categoryPtr.get());
+
+  m_bmGroupsIdList.clear();
+  m_bmGroupsIdList.resize(count);
+  for (size_t i = 0; i < count; ++i)
+    m_bmGroupsIdList[i] = vec[i].first;
+}
+
+std::vector<kml::MarkGroupId> BookmarkManager::GetSortedBmGroupIdList() const
+{
+  CHECK_THREAD_CHECKER(m_threadChecker, ());
+
+  std::vector<kml::MarkGroupId> sortedList;
+  size_t const count = m_categories.size();
+  sortedList.reserve(count);
 
   using PairT = std::pair<kml::MarkGroupId, BookmarkCategory const *>;
   std::vector<PairT> vec;
@@ -2220,10 +2238,10 @@ void BookmarkManager::UpdateBmGroupIdList()
     return lhs.second->GetLastModifiedTime() > rhs.second->GetLastModifiedTime();
   });
 
-  m_bmGroupsIdList.clear();
-  m_bmGroupsIdList.resize(count);
   for (size_t i = 0; i < count; ++i)
-    m_bmGroupsIdList[i] = vec[i].first;
+    sortedList.push_back(vec[i].first);
+
+  return sortedList;
 }
 
 kml::MarkGroupId BookmarkManager::CreateBookmarkCategory(kml::CategoryData && data, bool autoSave /* = true */)

--- a/map/bookmark_manager.cpp
+++ b/map/bookmark_manager.cpp
@@ -2207,16 +2207,11 @@ void BookmarkManager::UpdateBmGroupIdList()
   CHECK_THREAD_CHECKER(m_threadChecker, ());
   size_t const count = m_categories.size();
 
-  using PairT = std::pair<kml::MarkGroupId, BookmarkCategory const *>;
-  std::vector<PairT> vec;
-  vec.reserve(count);
-  for (auto const & [markGroupId, categoryPtr] : m_categories)
-    vec.emplace_back(markGroupId, categoryPtr.get());
-
   m_unsortedBmGroupsIdList.clear();
   m_unsortedBmGroupsIdList.resize(count);
-  for (size_t i = 0; i < count; ++i)
-    m_unsortedBmGroupsIdList[i] = vec[i].first;
+  size_t i {0};
+  for (auto const & [markGroupId, _] : m_categories)
+    m_unsortedBmGroupsIdList[i++] = markGroupId;
 }
 
 std::vector<kml::MarkGroupId> BookmarkManager::GetSortedBmGroupIdList() const

--- a/map/bookmark_manager.cpp
+++ b/map/bookmark_manager.cpp
@@ -1842,7 +1842,7 @@ void BookmarkManager::LoadMetadata()
 void BookmarkManager::ClearCategories()
 {
   CHECK_THREAD_CHECKER(m_threadChecker, ());
-  for (auto groupId : m_bmGroupsIdList)
+  for (auto groupId : m_unsortedBmGroupsIdList)
   {
     ClearGroup(groupId);
     m_changesTracker.OnDeleteGroup(groupId);
@@ -1850,7 +1850,7 @@ void BookmarkManager::ClearCategories()
 
   m_compilations.clear();
   m_categories.clear();
-  m_bmGroupsIdList.clear();
+  m_unsortedBmGroupsIdList.clear();
 
   m_bookmarks.clear();
   m_tracks.clear();
@@ -2213,10 +2213,10 @@ void BookmarkManager::UpdateBmGroupIdList()
   for (auto const & [markGroupId, categoryPtr] : m_categories)
     vec.emplace_back(markGroupId, categoryPtr.get());
 
-  m_bmGroupsIdList.clear();
-  m_bmGroupsIdList.resize(count);
+  m_unsortedBmGroupsIdList.clear();
+  m_unsortedBmGroupsIdList.resize(count);
   for (size_t i = 0; i < count; ++i)
-    m_bmGroupsIdList[i] = vec[i].first;
+    m_unsortedBmGroupsIdList[i] = vec[i].first;
 }
 
 std::vector<kml::MarkGroupId> BookmarkManager::GetSortedBmGroupIdList() const
@@ -2734,7 +2734,7 @@ void BookmarkManager::PrepareAllFilesForSharing(SharingHandler && handler)
 {
   CHECK_THREAD_CHECKER(m_threadChecker, ());
   ASSERT(handler, ());
-  PrepareFileForSharing(decltype(m_bmGroupsIdList){m_bmGroupsIdList}, std::move(handler));
+  PrepareFileForSharing(decltype(m_unsortedBmGroupsIdList){m_unsortedBmGroupsIdList}, std::move(handler));
 }
 
 bool BookmarkManager::IsCategoryEmpty(kml::MarkGroupId categoryId) const
@@ -2877,7 +2877,7 @@ void BookmarkManager::FilterInvalidTracks(kml::TrackIdCollection & tracks) const
 
 kml::GroupIdSet BookmarkManager::MarksChangesTracker::GetAllGroupIds() const
 {
-  auto const & groupIds = m_bmManager->GetBmGroupsIdList();
+  auto const & groupIds = m_bmManager->GetUnsortedBmGroupsIdList();
   kml::GroupIdSet resultingSet(groupIds.begin(), groupIds.end());
 
   static_assert(UserMark::BOOKMARK == 0);

--- a/map/bookmark_manager.hpp
+++ b/map/bookmark_manager.hpp
@@ -277,6 +277,7 @@ public:
   kml::MarkGroupId GetCategoryId(std::string const & name) const;
 
   kml::GroupIdCollection const & GetBmGroupsIdList() const { return m_bmGroupsIdList; }
+  kml::GroupIdCollection GetSortedBmGroupIdList() const;
   bool HasBmCategory(kml::MarkGroupId groupId) const;
   kml::MarkGroupId LastEditedBMCategory();
   kml::PredefinedColor LastEditedBMColor() const;

--- a/map/bookmark_manager.hpp
+++ b/map/bookmark_manager.hpp
@@ -276,9 +276,9 @@ public:
 
   kml::MarkGroupId GetCategoryId(std::string const & name) const;
 
-  kml::GroupIdCollection const & GetBmGroupsIdList() const { return m_bmGroupsIdList; }
+  kml::GroupIdCollection const & GetUnsortedBmGroupsIdList() const { return m_unsortedBmGroupsIdList; }
   kml::GroupIdCollection GetSortedBmGroupIdList() const;
-  uint16_t GetBmGroupsCount() const { return m_bmGroupsIdList.size(); };
+  size_t GetBmGroupsCount() const { return m_unsortedBmGroupsIdList.size(); };
   bool HasBmCategory(kml::MarkGroupId groupId) const;
   kml::MarkGroupId LastEditedBMCategory();
   kml::PredefinedColor LastEditedBMColor() const;
@@ -726,7 +726,7 @@ private:
   ScreenBase m_viewport;
 
   CategoriesCollection m_categories;
-  kml::GroupIdCollection m_bmGroupsIdList;
+  kml::GroupIdCollection m_unsortedBmGroupsIdList;
 
   std::string m_lastCategoryUrl;
   kml::MarkGroupId m_lastEditedGroupId = kml::kInvalidMarkGroupId;

--- a/map/bookmark_manager.hpp
+++ b/map/bookmark_manager.hpp
@@ -278,6 +278,7 @@ public:
 
   kml::GroupIdCollection const & GetBmGroupsIdList() const { return m_bmGroupsIdList; }
   kml::GroupIdCollection GetSortedBmGroupIdList() const;
+  uint16_t GetBmGroupsCount() const { return m_bmGroupsIdList.size(); };
   bool HasBmCategory(kml::MarkGroupId groupId) const;
   kml::MarkGroupId LastEditedBMCategory();
   kml::PredefinedColor LastEditedBMColor() const;

--- a/map/map_tests/bookmarks_test.cpp
+++ b/map/map_tests/bookmarks_test.cpp
@@ -202,7 +202,7 @@ UNIT_CLASS_TEST(Runner, Bookmarks_ImportKML)
                                  LoadKmlData(MemReader(kmlString, strlen(kmlString)), KmlFileType::Text));
   TEST(kmlDataCollection.back().second, ());
   bmManager.CreateCategories(std::move(kmlDataCollection));
-  TEST_EQUAL(bmManager.GetUnsortedBmGroupsIdList().size(), 1, ());
+  TEST_EQUAL(bmManager.GetBmGroupsCount(), 1, ());
 
   auto const groupId = bmManager.GetUnsortedBmGroupsIdList().front();
   CheckBookmarks(bmManager, groupId);
@@ -228,7 +228,7 @@ UNIT_CLASS_TEST(Runner, Bookmarks_ExportKML)
   kmlDataCollection1.emplace_back("",
                                   LoadKmlData(MemReader(kmlString, strlen(kmlString)), KmlFileType::Text));
   bmManager.CreateCategories(std::move(kmlDataCollection1));
-  TEST_EQUAL(bmManager.GetUnsortedBmGroupsIdList().size(), 1, ());
+  TEST_EQUAL(bmManager.GetBmGroupsCount(), 1, ());
 
   auto const groupId1 = bmManager.GetUnsortedBmGroupsIdList().front();
   CheckBookmarks(bmManager, groupId1);
@@ -249,14 +249,14 @@ UNIT_CLASS_TEST(Runner, Bookmarks_ExportKML)
 
   bmManager.GetEditSession().DeleteBmCategory(groupId1);
   TEST_EQUAL(bmManager.HasBmCategory(groupId1), false, ());
-  TEST_EQUAL(bmManager.GetUnsortedBmGroupsIdList().size(), 0, ());
+  TEST_EQUAL(bmManager.GetBmGroupsCount(), 0, ());
 
   BookmarkManager::KMLDataCollection kmlDataCollection2;
   kmlDataCollection2.emplace_back("", LoadKmlData(FileReader(fileName), GetActiveKmlFileType()));
   TEST(kmlDataCollection2.back().second, ());
 
   bmManager.CreateCategories(std::move(kmlDataCollection2));
-  TEST_EQUAL(bmManager.GetUnsortedBmGroupsIdList().size(), 1, ());
+  TEST_EQUAL(bmManager.GetBmGroupsCount(), 1, ());
 
   auto const groupId2 = bmManager.GetUnsortedBmGroupsIdList().front();
   CheckBookmarks(bmManager, groupId2);
@@ -270,7 +270,7 @@ UNIT_CLASS_TEST(Runner, Bookmarks_ExportKML)
   TEST(kmlDataCollection3.back().second, ());
 
   bmManager.CreateCategories(std::move(kmlDataCollection3), true /* autoSave */);
-  TEST_EQUAL(bmManager.GetUnsortedBmGroupsIdList().size(), 1, ());
+  TEST_EQUAL(bmManager.GetBmGroupsCount(), 1, ());
 
   auto const groupId3 = bmManager.GetUnsortedBmGroupsIdList().front();
   CheckBookmarks(bmManager, groupId3);
@@ -407,7 +407,7 @@ UNIT_TEST(Bookmarks_Getting)
   TEST_NOT_EQUAL(pBm1->GetGroupId(), pBm3->GetGroupId(), ());
   TEST_NOT_EQUAL(pBm1->GetGroupId(), pBm3->GetGroupId(), ());
 
-  TEST_EQUAL(bmManager.GetUnsortedBmGroupsIdList().size(), 3, ());
+  TEST_EQUAL(bmManager.GetBmGroupsCount(), 3, ());
 
   TEST(IsValidBookmark(fm, m2::PointD(40, 20)), ());
   Bookmark const * mark = GetBookmark(fm, m2::PointD(40, 20));
@@ -564,7 +564,7 @@ UNIT_TEST(Bookmarks_AddingMoving)
   bm3.m_color.m_predefinedColor = kml::PredefinedColor::Green;
   auto const * pBm2 = bmManager.GetEditSession().CreateBookmark(std::move(bm3), cat2);
   TEST_NOT_EQUAL(pBm1->GetGroupId(), pBm2->GetGroupId(), ());
-  TEST_EQUAL(bmManager.GetUnsortedBmGroupsIdList().size(), 2, ());
+  TEST_EQUAL(bmManager.GetBmGroupsCount(), 2, ());
   mark = GetBookmarkPxPoint(fm, pixelPoint);
   TEST_EQUAL(bmManager.GetCategoryName(mark->GetGroupId()), "cat1", ());
   TEST_EQUAL(bmManager.GetUserMarkIds(cat1).size(), 2,
@@ -1066,7 +1066,7 @@ UNIT_CLASS_TEST(Runner, Bookmarks_SpecialXMLNames)
   bmManager.UpdateLastModifiedTime(kmlDataCollection3);
   bmManager.CreateCategories(std::move(kmlDataCollection3));
 
-  TEST_EQUAL(bmManager.GetUnsortedBmGroupsIdList().size(), 2, ());
+  TEST_EQUAL(bmManager.GetBmGroupsCount(), 2, ());
   auto const catId2 = bmManager.GetUnsortedBmGroupsIdList().back();
   auto const catId3 = bmManager.GetUnsortedBmGroupsIdList().front();
 
@@ -1095,7 +1095,7 @@ UNIT_CLASS_TEST(Runner, TrackParsingTest_1)
   TEST(kmlDataCollection.back().second, ("KML can't be loaded"));
 
   bmManager.CreateCategories(std::move(kmlDataCollection));
-  TEST_EQUAL(bmManager.GetUnsortedBmGroupsIdList().size(), 1, ());
+  TEST_EQUAL(bmManager.GetBmGroupsCount(), 1, ());
 
   auto catId = bmManager.GetUnsortedBmGroupsIdList().front();
   TEST_EQUAL(bmManager.GetTrackIds(catId).size(), 4, ());
@@ -1150,7 +1150,7 @@ UNIT_CLASS_TEST(Runner, TrackParsingTest_2)
 
   TEST(kmlDataCollection.back().second, ("KML can't be loaded"));
   bmManager.CreateCategories(std::move(kmlDataCollection));
-  TEST_EQUAL(bmManager.GetUnsortedBmGroupsIdList().size(), 1, ());
+  TEST_EQUAL(bmManager.GetBmGroupsCount(), 1, ());
 
   auto catId = bmManager.GetUnsortedBmGroupsIdList().front();
   TEST_EQUAL(bmManager.GetTrackIds(catId).size(), 1, ());
@@ -1403,7 +1403,7 @@ UNIT_CLASS_TEST(Runner, ExportAll)
     kmlDataCollection.emplace_back(file, LoadKmlFile(file, KmlFileType::Gpx));
 
   bmManager.CreateCategories(std::move(kmlDataCollection));
-  TEST_EQUAL(bmManager.GetUnsortedBmGroupsIdList().size(), 4, ());
+  TEST_EQUAL(bmManager.GetBmGroupsCount(), 4, ());
 
   auto categories = bmManager.GetUnsortedBmGroupsIdList();
   auto checker = [](BookmarkManager::SharingResult const & result)

--- a/map/map_tests/bookmarks_test.cpp
+++ b/map/map_tests/bookmarks_test.cpp
@@ -1034,7 +1034,7 @@ UNIT_CLASS_TEST(Runner, Bookmarks_SpecialXMLNames)
                                  LoadKmlData(MemReader(kmlString3, strlen(kmlString3)), KmlFileType::Text));
   bmManager.CreateCategories(std::move(kmlDataCollection1));
 
-  auto const & groupIds = bmManager.GetUnsortedBmGroupsIdList();
+  auto const & groupIds = bmManager.GetSortedBmGroupIdList();
   TEST_EQUAL(groupIds.size(), 1, ());
 
   auto const catId = groupIds.front();
@@ -1067,8 +1067,8 @@ UNIT_CLASS_TEST(Runner, Bookmarks_SpecialXMLNames)
   bmManager.CreateCategories(std::move(kmlDataCollection3));
 
   TEST_EQUAL(bmManager.GetBmGroupsCount(), 2, ());
-  auto const catId2 = bmManager.GetUnsortedBmGroupsIdList().back();
-  auto const catId3 = bmManager.GetUnsortedBmGroupsIdList().front();
+  auto const catId2 = bmManager.GetSortedBmGroupIdList().back();
+  auto const catId3 = bmManager.GetSortedBmGroupIdList().front();
 
   TEST_EQUAL(bmManager.GetUserMarkIds(catId2).size(), 1, ());
   TEST_EQUAL(bmManager.GetCategoryName(catId2), expectedName, ());

--- a/map/map_tests/bookmarks_test.cpp
+++ b/map/map_tests/bookmarks_test.cpp
@@ -202,9 +202,9 @@ UNIT_CLASS_TEST(Runner, Bookmarks_ImportKML)
                                  LoadKmlData(MemReader(kmlString, strlen(kmlString)), KmlFileType::Text));
   TEST(kmlDataCollection.back().second, ());
   bmManager.CreateCategories(std::move(kmlDataCollection));
-  TEST_EQUAL(bmManager.GetBmGroupsIdList().size(), 1, ());
+  TEST_EQUAL(bmManager.GetUnsortedBmGroupsIdList().size(), 1, ());
 
-  auto const groupId = bmManager.GetBmGroupsIdList().front();
+  auto const groupId = bmManager.GetUnsortedBmGroupsIdList().front();
   CheckBookmarks(bmManager, groupId);
 
   // Name should be overridden from the KML
@@ -228,9 +228,9 @@ UNIT_CLASS_TEST(Runner, Bookmarks_ExportKML)
   kmlDataCollection1.emplace_back("",
                                   LoadKmlData(MemReader(kmlString, strlen(kmlString)), KmlFileType::Text));
   bmManager.CreateCategories(std::move(kmlDataCollection1));
-  TEST_EQUAL(bmManager.GetBmGroupsIdList().size(), 1, ());
+  TEST_EQUAL(bmManager.GetUnsortedBmGroupsIdList().size(), 1, ());
 
-  auto const groupId1 = bmManager.GetBmGroupsIdList().front();
+  auto const groupId1 = bmManager.GetUnsortedBmGroupsIdList().front();
   CheckBookmarks(bmManager, groupId1);
 
   TEST_EQUAL(bmManager.IsVisible(groupId1), false, ());
@@ -249,16 +249,16 @@ UNIT_CLASS_TEST(Runner, Bookmarks_ExportKML)
 
   bmManager.GetEditSession().DeleteBmCategory(groupId1);
   TEST_EQUAL(bmManager.HasBmCategory(groupId1), false, ());
-  TEST_EQUAL(bmManager.GetBmGroupsIdList().size(), 0, ());
+  TEST_EQUAL(bmManager.GetUnsortedBmGroupsIdList().size(), 0, ());
 
   BookmarkManager::KMLDataCollection kmlDataCollection2;
   kmlDataCollection2.emplace_back("", LoadKmlData(FileReader(fileName), GetActiveKmlFileType()));
   TEST(kmlDataCollection2.back().second, ());
 
   bmManager.CreateCategories(std::move(kmlDataCollection2));
-  TEST_EQUAL(bmManager.GetBmGroupsIdList().size(), 1, ());
+  TEST_EQUAL(bmManager.GetUnsortedBmGroupsIdList().size(), 1, ());
 
-  auto const groupId2 = bmManager.GetBmGroupsIdList().front();
+  auto const groupId2 = bmManager.GetUnsortedBmGroupsIdList().front();
   CheckBookmarks(bmManager, groupId2);
   TEST_EQUAL(bmManager.IsVisible(groupId2), true, ());
 
@@ -270,9 +270,9 @@ UNIT_CLASS_TEST(Runner, Bookmarks_ExportKML)
   TEST(kmlDataCollection3.back().second, ());
 
   bmManager.CreateCategories(std::move(kmlDataCollection3), true /* autoSave */);
-  TEST_EQUAL(bmManager.GetBmGroupsIdList().size(), 1, ());
+  TEST_EQUAL(bmManager.GetUnsortedBmGroupsIdList().size(), 1, ());
 
-  auto const groupId3 = bmManager.GetBmGroupsIdList().front();
+  auto const groupId3 = bmManager.GetUnsortedBmGroupsIdList().front();
   CheckBookmarks(bmManager, groupId3);
 
   TEST(bmManager.SaveBookmarkCategory(groupId3), ());
@@ -407,7 +407,7 @@ UNIT_TEST(Bookmarks_Getting)
   TEST_NOT_EQUAL(pBm1->GetGroupId(), pBm3->GetGroupId(), ());
   TEST_NOT_EQUAL(pBm1->GetGroupId(), pBm3->GetGroupId(), ());
 
-  TEST_EQUAL(bmManager.GetBmGroupsIdList().size(), 3, ());
+  TEST_EQUAL(bmManager.GetUnsortedBmGroupsIdList().size(), 3, ());
 
   TEST(IsValidBookmark(fm, m2::PointD(40, 20)), ());
   Bookmark const * mark = GetBookmark(fm, m2::PointD(40, 20));
@@ -564,7 +564,7 @@ UNIT_TEST(Bookmarks_AddingMoving)
   bm3.m_color.m_predefinedColor = kml::PredefinedColor::Green;
   auto const * pBm2 = bmManager.GetEditSession().CreateBookmark(std::move(bm3), cat2);
   TEST_NOT_EQUAL(pBm1->GetGroupId(), pBm2->GetGroupId(), ());
-  TEST_EQUAL(bmManager.GetBmGroupsIdList().size(), 2, ());
+  TEST_EQUAL(bmManager.GetUnsortedBmGroupsIdList().size(), 2, ());
   mark = GetBookmarkPxPoint(fm, pixelPoint);
   TEST_EQUAL(bmManager.GetCategoryName(mark->GetGroupId()), "cat1", ());
   TEST_EQUAL(bmManager.GetUserMarkIds(cat1).size(), 2,
@@ -963,7 +963,7 @@ UNIT_CLASS_TEST(Runner, Bookmarks_InnerFolder)
   kmlDataCollection.emplace_back("" /* filePath */,
                                  LoadKmlData(MemReader(kmlString2, strlen(kmlString2)), KmlFileType::Text));
   bmManager.CreateCategories(std::move(kmlDataCollection));
-  auto const & groupIds = bmManager.GetBmGroupsIdList();
+  auto const & groupIds = bmManager.GetUnsortedBmGroupsIdList();
   TEST_EQUAL(groupIds.size(), 1, ());
   TEST_EQUAL(bmManager.GetUserMarkIds(groupIds.front()).size(), 1, ());
 }
@@ -1034,7 +1034,7 @@ UNIT_CLASS_TEST(Runner, Bookmarks_SpecialXMLNames)
                                  LoadKmlData(MemReader(kmlString3, strlen(kmlString3)), KmlFileType::Text));
   bmManager.CreateCategories(std::move(kmlDataCollection1));
 
-  auto const & groupIds = bmManager.GetBmGroupsIdList();
+  auto const & groupIds = bmManager.GetUnsortedBmGroupsIdList();
   TEST_EQUAL(groupIds.size(), 1, ());
 
   auto const catId = groupIds.front();
@@ -1066,9 +1066,9 @@ UNIT_CLASS_TEST(Runner, Bookmarks_SpecialXMLNames)
   bmManager.UpdateLastModifiedTime(kmlDataCollection3);
   bmManager.CreateCategories(std::move(kmlDataCollection3));
 
-  TEST_EQUAL(bmManager.GetBmGroupsIdList().size(), 2, ());
-  auto const catId2 = bmManager.GetBmGroupsIdList().back();
-  auto const catId3 = bmManager.GetBmGroupsIdList().front();
+  TEST_EQUAL(bmManager.GetUnsortedBmGroupsIdList().size(), 2, ());
+  auto const catId2 = bmManager.GetUnsortedBmGroupsIdList().back();
+  auto const catId3 = bmManager.GetUnsortedBmGroupsIdList().front();
 
   TEST_EQUAL(bmManager.GetUserMarkIds(catId2).size(), 1, ());
   TEST_EQUAL(bmManager.GetCategoryName(catId2), expectedName, ());
@@ -1095,9 +1095,9 @@ UNIT_CLASS_TEST(Runner, TrackParsingTest_1)
   TEST(kmlDataCollection.back().second, ("KML can't be loaded"));
 
   bmManager.CreateCategories(std::move(kmlDataCollection));
-  TEST_EQUAL(bmManager.GetBmGroupsIdList().size(), 1, ());
+  TEST_EQUAL(bmManager.GetUnsortedBmGroupsIdList().size(), 1, ());
 
-  auto catId = bmManager.GetBmGroupsIdList().front();
+  auto catId = bmManager.GetUnsortedBmGroupsIdList().front();
   TEST_EQUAL(bmManager.GetTrackIds(catId).size(), 4, ());
 
   array<string, 4> const names = {{"Option1", "Pakkred1", "Pakkred2", "Pakkred3"}};
@@ -1150,9 +1150,9 @@ UNIT_CLASS_TEST(Runner, TrackParsingTest_2)
 
   TEST(kmlDataCollection.back().second, ("KML can't be loaded"));
   bmManager.CreateCategories(std::move(kmlDataCollection));
-  TEST_EQUAL(bmManager.GetBmGroupsIdList().size(), 1, ());
+  TEST_EQUAL(bmManager.GetUnsortedBmGroupsIdList().size(), 1, ());
 
-  auto catId = bmManager.GetBmGroupsIdList().front();
+  auto catId = bmManager.GetUnsortedBmGroupsIdList().front();
   TEST_EQUAL(bmManager.GetTrackIds(catId).size(), 1, ());
   auto const trackId = *bmManager.GetTrackIds(catId).begin();
   auto const * track = bmManager.GetTrack(trackId);
@@ -1403,9 +1403,9 @@ UNIT_CLASS_TEST(Runner, ExportAll)
     kmlDataCollection.emplace_back(file, LoadKmlFile(file, KmlFileType::Gpx));
 
   bmManager.CreateCategories(std::move(kmlDataCollection));
-  TEST_EQUAL(bmManager.GetBmGroupsIdList().size(), 4, ());
+  TEST_EQUAL(bmManager.GetUnsortedBmGroupsIdList().size(), 4, ());
 
-  auto categories = bmManager.GetBmGroupsIdList();
+  auto categories = bmManager.GetUnsortedBmGroupsIdList();
   auto checker = [](BookmarkManager::SharingResult const & result)
   {
     auto kmz = result.m_sharingPath;
@@ -1446,7 +1446,7 @@ UNIT_CLASS_TEST(Runner, ExportSingleUnicode)
   BookmarkManager::KMLDataCollection kmlDataCollection;
   kmlDataCollection.emplace_back(file, LoadKmlFile(file, KmlFileType::Gpx));
   bmManager.CreateCategories(std::move(kmlDataCollection));
-  auto categories = bmManager.GetBmGroupsIdList();
+  auto categories = bmManager.GetUnsortedBmGroupsIdList();
   auto checker = [](BookmarkManager::SharingResult const & result)
   {
     auto kmz = result.m_sharingPath;

--- a/qt/bookmark_dialog.cpp
+++ b/qt/bookmark_dialog.cpp
@@ -268,7 +268,7 @@ void BookmarkDialog::FillTree()
 
   if (!bm.IsAsyncLoadingInProgress())
   {
-    for (auto catId : bm.GetBmGroupsIdList())
+    for (auto catId : bm.GetUnsortedBmGroupsIdList())
     {
       auto categoryItem = CreateTreeItem(bm.GetCategoryName(catId), categoriesItem);
       m_categories[categoryItem] = catId;

--- a/qt/screenshoter.cpp
+++ b/qt/screenshoter.cpp
@@ -201,14 +201,14 @@ void Screenshoter::ProcessNextKml()
 
   auto & bookmarkManager = m_framework.GetBookmarkManager();
   auto es = bookmarkManager.GetEditSession();
-  auto const idList = bookmarkManager.GetBmGroupsIdList();
+  auto const idList = bookmarkManager.GetUnsortedBmGroupsIdList();
   for (auto catId : idList)
     es.DeleteBmCategory(catId);
 
   bookmarkManager.CreateCategories(std::move(collection));
 
   ChangeState(State::WaitPosition);
-  auto const newCatId = bookmarkManager.GetBmGroupsIdList().front();
+  auto const newCatId = bookmarkManager.GetUnsortedBmGroupsIdList().front();
   m_framework.ShowBookmarkCategory(newCatId, false);
   WaitPosition();
 }


### PR DESCRIPTION
Closes https://github.com/organicmaps/organicmaps/issues/3475

This issue contains two bugs:
## 1. Invalid sorting
1. To display the categories list in the ios we use MWMBookmarksManager's :
` (NSArray<MWMBookmarkGroup *> *)userCategories;`
  which calls c++ BoormarkManager's
`auto const & list = self.bm.GetBmGroupsIdList(); `
  which returns
`kml::GroupIdCollection const & GetBmGroupsIdList() const { return m_bmGroupsIdList; }`

`m_bmGroupsIdList` is a sorted list of categories ids
and sorting happens in the method:
```cpp
void BookmarkManager::UpdateBmGroupIdList()
{
  CHECK_THREAD_CHECKER(m_threadChecker, ());
  size_t const count = m_categories.size();

  // All this routine to get sorted list by last modified time.

  using PairT = std::pair<kml::MarkGroupId, BookmarkCategory const *>;
  std::vector<PairT> vec;
  vec.reserve(count);
  for (auto const & [markGroupId, categoryPtr] : m_categories)
    vec.emplace_back(markGroupId, categoryPtr.get());

  std::sort(vec.begin(), vec.end(), [](PairT const & lhs, PairT const & rhs)
  {
    return lhs.second->GetLastModifiedTime() > rhs.second->GetLastModifiedTime();
  });

  m_bmGroupsIdList.clear();
  m_bmGroupsIdList.resize(count);
  for (size_t i = 0; i < count; ++i)
    m_bmGroupsIdList[i] = vec[i].first;
}

```

This method is called only in:
- `CreateBookmarkCategory`
- `DeleteBmCategory`

So when the user adds/removes/updates bookmarks `m_bmGroupsIdList` becomes invalid (in case of sorting).

How to reproduce:
- Add the bookmark to the group
- Open the Bookmarks screen
- The group will be at the same place as earlier
- Terminate app
- Open app
- Group will be at the top of the list (`CreateBookmarkCategory` was called on init so `m_bmGroupsIdList` will be correct until the next editing)

![Simulator Screen Recording - iPhone 15 Pro - 2024-03-07 at 13 59 04](https://github.com/organicmaps/organicmaps/assets/79797627/b292c1c4-8bff-48a2-93f7-dc86b25a45f7)


Solution:
The new method is implemented always to retrieve valid sorted list of IDs:
 `std::vector<kml::MarkGroupId> BookmarkManager::GetSortedBmGroupIdList() const` in the core
and 
`- (NSArray<MWMBookmarkGroup *> *)sortedUserCategories` in the ios
