### PR TITLE
[ios] Fix crash for the "Export all bookmarks" on iPad

### DIFF
--- a/iphone/Maps/Bookmarks/Categories/BMCView/BMCViewController.swift
+++ b/iphone/Maps/Bookmarks/Categories/BMCView/BMCViewController.swift
@@ -88,7 +88,7 @@ final class BMCViewController: MWMViewController {
     }
   }
 
-  private func shareAllCategories() {
+  private func shareAllCategories(anchor: UIView?) {
     viewModel.shareAllCategories {
       switch $0 {
       case let .success(url):
@@ -96,7 +96,7 @@ final class BMCViewController: MWMViewController {
         { [weak self] _, _, _, _ in
           self?.viewModel?.finishShareCategory()
         }
-        shareController?.present(inParentViewController: self, anchorView: nil)
+        shareController?.present(inParentViewController: self, anchorView: anchor)
       case let .error(title, text):
         MWMAlertViewController.activeAlert().presentInfoAlert(title, text: text)
       }
@@ -269,7 +269,7 @@ extension BMCViewController: UITableViewDelegate {
     case .actions:
       switch viewModel.action(at: indexPath.row) {
       case .create: createNewCategory()
-      case .exportAll: shareAllCategories()
+      case .exportAll: shareAllCategories(anchor: tableView.cellForRow(at: indexPath))
       }
     default:
       assertionFailure()


### PR DESCRIPTION
When the user taps the "Export all bookmarks" on iPad the app will crash with error:

`UIKitCore: -[UIPopoverPresentationController presentationTransitionWillBegin] + 2672`

This is because there no `anchor view` is provided for the UIPopoverPresentationController (share vc).
This property can be nil for iPhone but must not be nil for the iPad.

This PR fixes this issue.

<img width="500" alt="image" src="https://github.com/organicmaps/organicmaps/assets/79797627/e0383353-8c25-4603-9a63-0e9e48da9b31">

