### PR TITLE
[android] Add 'androidx' dependencies to build.gradle

### DIFF
--- a/android/app/build.gradle
+++ b/android/app/build.gradle
@@ -402,6 +402,7 @@ dependencies {
   implementation 'net.jcip:jcip-annotations:1.0'
 
   // Test Dependencies
+  androidTestImplementation 'androidx.test.ext:junit:1.1.5'
   testImplementation 'junit:junit:4.13.2'
   testImplementation 'org.mockito:mockito-core:5.8.0'
   testImplementation 'org.mockito:mockito-inline:5.2.0'


### PR DESCRIPTION
After updating Android Studio to version Iguana (2023.2.1), I get many `error: cannot find symbol xxxxx` java build errors.

This PR adds to the `android/app/build.gradle` file a couple of needed `androidx.*` dependencies.