### PR TITLE
[String] Fix string usage script

### DIFF
--- a/tools/python/clean_strings_txt.py
+++ b/tools/python/clean_strings_txt.py
@@ -79,6 +79,8 @@ def grep_android():
     ret.update(android_grep_wrapper(grep, ANDROID_JAVA_PLURAL_RE))
     grep = "grep -r -I '@string/' {0}/android/app/src/main/res".format(OMIM_ROOT)
     ret.update(android_grep_wrapper(grep, ANDROID_XML_RE))
+    grep = "grep -r -I '@string/' {0}/android/app/src/google/res".format(OMIM_ROOT)
+    ret.update(android_grep_wrapper(grep, ANDROID_XML_RE))
     grep = "grep -r -I '@string/' {0}/android/app/src/main/AndroidManifest.xml".format(
         OMIM_ROOT)
     ret.update(android_grep_wrapper(grep, ANDROID_XML_RE))


### PR DESCRIPTION
In commit [[strings][android] Google Play only translation for OSM login](https://github.com/organicmaps/organicmaps/commit/9e7a63ed63e1bc8dfabf5a870a5bc80d824d2765) @biodranik added new string `"username"` which is used in a single file `android/app/src/google/res/layout/osm_login_text_input.xml`
But strings generation script fails with `ERROR: there are unused strings` because it doesn't search in `android/app/src/google` resources.

Fix: Added Google subfolder to string usage search