### PR TITLE
[ios] Fix opening hours icons

### DIFF
--- a/iphone/Maps/Bookmarks/BookmarksList/Cells/SubgroupCell.xib
+++ b/iphone/Maps/Bookmarks/BookmarksList/Cells/SubgroupCell.xib
@@ -23,8 +23,8 @@
                             <constraint firstAttribute="width" constant="56" id="aar-GM-DaJ"/>
                         </constraints>
                         <userDefinedRuntimeAttributes>
-                            <userDefinedRuntimeAttribute type="image" keyPath="offImage" value="radioBtnOff"/>
-                            <userDefinedRuntimeAttribute type="image" keyPath="onImage" value="radioBtnOn"/>
+                            <userDefinedRuntimeAttribute type="image" keyPath="offImage" value="ic_eye_off"/>
+                            <userDefinedRuntimeAttribute type="image" keyPath="onImage" value="ic_eye_on"/>
                         </userDefinedRuntimeAttributes>
                         <connections>
                             <action selector="onCheck:" destination="KGk-i7-Jjw" eventType="valueChanged" id="xp2-kL-Hgu"/>
@@ -81,7 +81,7 @@
     </objects>
     <resources>
         <image name="ic_disclosure" width="24" height="24"/>
-        <image name="radioBtnOff" width="22" height="22"/>
-        <image name="radioBtnOn" width="22" height="22"/>
+        <image name="ic_eye_off" width="24" height="24"/>
+        <image name="ic_eye_on" width="24" height="24"/>
     </resources>
 </document>

--- a/iphone/Maps/Bookmarks/Categories/Categories/BMCCategoryCell.xib
+++ b/iphone/Maps/Bookmarks/Categories/Categories/BMCCategoryCell.xib
@@ -24,8 +24,8 @@
                             <constraint firstAttribute="width" constant="56" id="iRO-vl-eYM"/>
                         </constraints>
                         <userDefinedRuntimeAttributes>
-                            <userDefinedRuntimeAttribute type="image" keyPath="offImage" value="radioBtnOff"/>
-                            <userDefinedRuntimeAttribute type="image" keyPath="onImage" value="radioBtnOn"/>
+                            <userDefinedRuntimeAttribute type="image" keyPath="offImage" value="ic_eye_off"/>
+                            <userDefinedRuntimeAttribute type="image" keyPath="onImage" value="ic_eye_on"/>
                         </userDefinedRuntimeAttributes>
                         <connections>
                             <action selector="onVisibleChanged:" destination="KGk-i7-Jjw" eventType="valueChanged" id="fV8-pr-hNc"/>
@@ -89,7 +89,7 @@
         </tableViewCell>
     </objects>
     <resources>
-        <image name="radioBtnOff" width="22" height="22"/>
-        <image name="radioBtnOn" width="22" height="22"/>
+        <image name="ic_eye_off" width="24" height="24"/>
+        <image name="ic_eye_on" width="24" height="24"/>
     </resources>
 </document>

--- a/iphone/Maps/Images.xcassets/ic_eye_off.imageset/Contents.json
+++ b/iphone/Maps/Images.xcassets/ic_eye_off.imageset/Contents.json
@@ -1,0 +1,15 @@
+{
+  "images" : [
+    {
+      "filename" : "ic_eye_off.svg",
+      "idiom" : "universal"
+    }
+  ],
+  "info" : {
+    "author" : "xcode",
+    "version" : 1
+  },
+  "properties" : {
+    "template-rendering-intent" : "template"
+  }
+}

--- a/iphone/Maps/Images.xcassets/ic_eye_off.imageset/ic_eye_off.svg
+++ b/iphone/Maps/Images.xcassets/ic_eye_off.imageset/ic_eye_off.svg
@@ -1,0 +1,5 @@
+<svg width="24" height="24" viewBox="0 0 24 24" xmlns="http://www.w3.org/2000/svg">
+  <path d="m3 3 18 18" stroke="#000" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" paint-order="fill markers stroke"/>
+  <path d="M14.121 14.121A3 3 0 0 1 12 15a3 3 0 0 1-3-3 3 3 0 0 1 .879-2.121" paint-order="fill markers stroke"/>
+  <path d="M7.16 7.16C5.194 8.146 3.4 9.76 2 12h0c3.6 5.759 9.79 7.372 14.84 4.84M19.764 14.766A14.25 14.25 0 0 0 22 12h0c-2.713-4.34-6.897-6.326-10.956-5.957" fill="none" stroke="#000" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" paint-order="fill markers stroke"/>
+</svg>

--- a/iphone/Maps/Images.xcassets/ic_eye_on.imageset/Contents.json
+++ b/iphone/Maps/Images.xcassets/ic_eye_on.imageset/Contents.json
@@ -1,0 +1,15 @@
+{
+  "images" : [
+    {
+      "filename" : "ic_eye_on.svg",
+      "idiom" : "universal"
+    }
+  ],
+  "info" : {
+    "author" : "xcode",
+    "version" : 1
+  },
+  "properties" : {
+    "template-rendering-intent" : "template"
+  }
+}

--- a/iphone/Maps/Images.xcassets/ic_eye_on.imageset/ic_eye_on.svg
+++ b/iphone/Maps/Images.xcassets/ic_eye_on.imageset/ic_eye_on.svg
@@ -1,0 +1,4 @@
+<svg width="24" height="24" viewBox="0 0 24 24" xmlns="http://www.w3.org/2000/svg">
+  <path d="M2 12c5 8 15 8 20 0-5-8-15-8-20 0Z" fill="none" stroke="#000" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" paint-order="fill markers stroke"/>
+  <circle cx="12" cy="12" r="3" paint-order="fill markers stroke"/>
+</svg>


### PR DESCRIPTION
Closes https://github.com/organicmaps/organicmaps/issues/7566

This PR fixes the issue caused by the previous PR https://github.com/organicmaps/organicmaps/pull/7508 when `eye icon` is used by mistake not only for the BMCViewController (categories list) but for the Opening hours too.

Tested on: 
iPhone 6 iOS12.5 (device)
iPhone 11pro iOS17.2 (device)
iPhone 15pro iOS17.2 (sim)

Result: eye icons are implemented only for the bookmarks lit cells and for the opening hours icon is reverted.
<img width="350" alt="image" src="https://github.com/organicmaps/organicmaps/assets/79797627/2516aaaa-adea-420f-89a4-22f6950f46f4"> <img width="350" alt="image" src="https://github.com/organicmaps/organicmaps/assets/79797627/3c1b23f9-dc5b-451a-81c1-e83fe272e032">

