### PR TITLE
[ios] Match Spedcam strings with Android, fix `never` and `stop` strings issues

### DIFF
--- a/android/app/src/main/res/values-ar/strings.xml
+++ b/android/app/src/main/res/values-ar/strings.xml
@@ -521,7 +521,6 @@
 	<string name="editor_operator">المالك</string>
 	<string name="downloader_no_downloaded_maps_title">لم تقم بتنزيل أية خرائط</string>
 	<string name="downloader_no_downloaded_maps_message">قم بتنزيل خرائط للبحث عن مكان واستخدام الملاحة بدون اتصال بالإنترنت.</string>
-	<string name="stop">إيقاف</string>
 	<!-- abbreviation for meters -->
 	<string name="m">متر</string>
 	<!-- abbreviation for kilometers -->
@@ -652,10 +651,6 @@
 	<string name="bookmark_list_description_hint">اكتب وصفًا (نص أو html)</string>
 	<string name="not_shared">خاص</string>
 	<string name="speedcams_alert_title">تحذيرات كاميرات السرعة</string>
-	<!-- Generic «Always» string -->
-	<string name="always">مفعل دائماً</string>
-	<!-- Generic «Never» string -->
-	<string name="never">معطل دائماً</string>
 	<string name="place_description_title">وصف المكان</string>
 	<!-- this text will be shown in application notification preferences opposite checkbox which enable/disable downloader notifications. Devices on Android 8+ are affected. -->
 	<string name="notification_channel_downloader">مُنزّل الخريطة</string>

--- a/android/app/src/main/res/values-az/strings.xml
+++ b/android/app/src/main/res/values-az/strings.xml
@@ -508,7 +508,6 @@
 	<string name="editor_operator">Sahibi</string>
 	<string name="downloader_no_downloaded_maps_title">Siz heç bir xəritə endirməmisiniz</string>
 	<string name="downloader_no_downloaded_maps_message">Ünvanları tapmaq və oflayn naviqasiya etmək üçün xəritələri endirin.</string>
-	<string name="stop">Dayan</string>
 	<!-- abbreviation for meters -->
 	<string name="m">m</string>
 	<!-- abbreviation for kilometers -->
@@ -639,10 +638,6 @@
 	<string name="bookmark_list_description_hint">Təsvir yazın (mətn və ya html)</string>
 	<string name="not_shared">Gizli</string>
 	<string name="speedcams_alert_title">Sürət kameraları</string>
-	<!-- Generic «Always» string -->
-	<string name="always">Həmişə</string>
-	<!-- Generic «Never» string -->
-	<string name="never">Heç vaxt</string>
 	<string name="place_description_title">Məkan Təsviri</string>
 	<!-- this text will be shown in application notification preferences opposite checkbox which enable/disable downloader notifications. Devices on Android 8+ are affected. -->
 	<string name="notification_channel_downloader">Xəritə yükləyicisi</string>

--- a/android/app/src/main/res/values-be/strings.xml
+++ b/android/app/src/main/res/values-be/strings.xml
@@ -506,7 +506,6 @@
 	<string name="editor_operator">Уладальнік</string>
 	<string name="downloader_no_downloaded_maps_title">Вы не спампавалі ніводнай мапы</string>
 	<string name="downloader_no_downloaded_maps_message">Спампуйце мапы, каб шукаць месцы і карыстацца навігацыяй без інтэрнэту.</string>
-	<string name="stop">Спыніць</string>
 	<!-- abbreviation for meters -->
 	<string name="m">м</string>
 	<!-- abbreviation for kilometers -->
@@ -636,15 +635,11 @@
 	<string name="bookmark_list_description_hint">Дабаўце апісанне (тэкст альбо html)</string>
 	<string name="not_shared">Прыватны</string>
 	<string name="speedcams_alert_title">Камеры хуткасці</string>
-	<!-- Generic «Always» string -->
-	<string name="always">Заўсёды</string>
-	<!-- Generic «Never» string -->
-	<string name="never">Ніколі</string>
 	<string name="place_description_title">Апісанне месца</string>
 	<!-- this text will be shown in application notification preferences opposite checkbox which enable/disable downloader notifications. Devices on Android 8+ are affected. -->
 	<string name="notification_channel_downloader">Спампоўка мапаў</string>
 	<!-- Speed camera settings menu option - Warn (about speedcams) if risk of exceeding speed limit -->
-	<string name="pref_tts_speedcams_auto">Папярэджваць калі ёсць рызыка перавышэння дазволенай хуткасці</string>
+	<string name="pref_tts_speedcams_auto">Папярэджваць пры перавышэнні хуткасці</string>
 	<!-- Speed camera settings menu option - Always warn (about speedcams) -->
 	<string name="pref_tts_speedcams_always">Заўсёды папярэджваць</string>
 	<!-- Speed camera settings menu option - Never warn (about speedcams) -->

--- a/android/app/src/main/res/values-bg/strings.xml
+++ b/android/app/src/main/res/values-bg/strings.xml
@@ -474,7 +474,6 @@
 	<string name="editor_operator">Собственик</string>
 	<string name="downloader_no_downloaded_maps_title">Не сте изтеглили никакви карти</string>
 	<string name="downloader_no_downloaded_maps_message">Изтеглете картите, от които се нуждаете, за да намирате места и да навигирате без интернет.</string>
-	<string name="stop">Стоп</string>
 	<!-- abbreviation for meters -->
 	<string name="m">м</string>
 	<!-- abbreviation for kilometers -->
@@ -597,10 +596,6 @@
 	<string name="bookmark_list_description_hint">Добавяне на описание (текст или html)</string>
 	<string name="not_shared">Лично</string>
 	<string name="speedcams_alert_title">Камери за скорост</string>
-	<!-- Generic «Always» string -->
-	<string name="always">Винаги</string>
-	<!-- Generic «Never» string -->
-	<string name="never">Никога</string>
 	<string name="place_description_title">Описание на мястото</string>
 	<!-- this text will be shown in application notification preferences opposite checkbox which enable/disable downloader notifications. Devices on Android 8+ are affected. -->
 	<string name="notification_channel_downloader">Изтегляне на карти</string>

--- a/android/app/src/main/res/values-ca/strings.xml
+++ b/android/app/src/main/res/values-ca/strings.xml
@@ -501,7 +501,6 @@
 	<string name="editor_operator">Propietari</string>
 	<string name="downloader_no_downloaded_maps_title">No heu baixat cap mapa</string>
 	<string name="downloader_no_downloaded_maps_message">Baixeu mapes per a cercar una ubicacio i usar la navegació sense connexió.</string>
-	<string name="stop">Atura\'t</string>
 	<!-- abbreviation for meters -->
 	<string name="m">m</string>
 	<!-- abbreviation for kilometers -->
@@ -636,10 +635,6 @@
 	<string name="bookmark_list_description_hint">Escriviu una descripció (text o html)</string>
 	<string name="not_shared">Privat</string>
 	<string name="speedcams_alert_title">Radars</string>
-	<!-- Generic «Always» string -->
-	<string name="always">Sempre</string>
-	<!-- Generic «Never» string -->
-	<string name="never">Mai</string>
 	<string name="place_description_title">Descripció del lloc</string>
 	<!-- this text will be shown in application notification preferences opposite checkbox which enable/disable downloader notifications. Devices on Android 8+ are affected. -->
 	<string name="notification_channel_downloader">Descàrrega de mapes</string>

--- a/android/app/src/main/res/values-cs/strings.xml
+++ b/android/app/src/main/res/values-cs/strings.xml
@@ -488,7 +488,6 @@
 	<string name="editor_operator">Operátor</string>
 	<string name="downloader_no_downloaded_maps_title">Nemáte stažené žádné mapy</string>
 	<string name="downloader_no_downloaded_maps_message">Stáhněte si mapy a hledejte cestu a její cíl, i když jste offline.</string>
-	<string name="stop">Zastavit</string>
 	<!-- abbreviation for meters -->
 	<string name="m">m</string>
 	<!-- abbreviation for kilometers -->
@@ -614,10 +613,6 @@
 	<string name="bookmark_list_description_hint">Přidejte popis (text nebo html)</string>
 	<string name="not_shared">Osobní účet</string>
 	<string name="speedcams_alert_title">Detektory rychlosti</string>
-	<!-- Generic «Always» string -->
-	<string name="always">Vždy</string>
-	<!-- Generic «Never» string -->
-	<string name="never">Nikdy</string>
 	<string name="place_description_title">Popis místa</string>
 	<!-- this text will be shown in application notification preferences opposite checkbox which enable/disable downloader notifications. Devices on Android 8+ are affected. -->
 	<string name="notification_channel_downloader">Nahrávání map</string>

--- a/android/app/src/main/res/values-da/strings.xml
+++ b/android/app/src/main/res/values-da/strings.xml
@@ -484,7 +484,6 @@
 	<string name="editor_operator">Bruger</string>
 	<string name="downloader_no_downloaded_maps_title">Du har ikke hentet alle kort</string>
 	<string name="downloader_no_downloaded_maps_message">Download kort for at finde position og navigere offline.</string>
-	<string name="stop">Stop</string>
 	<!-- abbreviation for meters -->
 	<string name="m">m</string>
 	<!-- abbreviation for kilometers -->
@@ -609,10 +608,6 @@
 	<string name="bookmark_list_description_hint">Lav en beskrivelse (tekst eller html)</string>
 	<string name="not_shared">Privat</string>
 	<string name="speedcams_alert_title">Fartkameraer</string>
-	<!-- Generic «Always» string -->
-	<string name="always">Altid</string>
-	<!-- Generic «Never» string -->
-	<string name="never">Aldrig</string>
 	<string name="place_description_title">Beskrivelse af sted</string>
 	<!-- this text will be shown in application notification preferences opposite checkbox which enable/disable downloader notifications. Devices on Android 8+ are affected. -->
 	<string name="notification_channel_downloader">Korthenter</string>

--- a/android/app/src/main/res/values-de/strings.xml
+++ b/android/app/src/main/res/values-de/strings.xml
@@ -504,7 +504,6 @@
 	<string name="editor_operator">Betreiber oder Eigentümer</string>
 	<string name="downloader_no_downloaded_maps_title">Keine Karten geladen</string>
 	<string name="downloader_no_downloaded_maps_message">Laden Sie die für die Suche nach Orten erforderlichen Karten und verwenden Sie die Navigation offline.</string>
-	<string name="stop">Anhalten</string>
 	<!-- abbreviation for meters -->
 	<string name="m">m</string>
 	<!-- abbreviation for kilometers -->
@@ -639,10 +638,6 @@
 	<string name="bookmark_list_description_hint">Fügen Sie die Beschreibung hinzu (Text oder html)</string>
 	<string name="not_shared">Persönlich</string>
 	<string name="speedcams_alert_title">Blitzer</string>
-	<!-- Generic «Always» string -->
-	<string name="always">Immer</string>
-	<!-- Generic «Never» string -->
-	<string name="never">Niemals</string>
 	<string name="place_description_title">Ortsbeschreibung</string>
 	<!-- this text will be shown in application notification preferences opposite checkbox which enable/disable downloader notifications. Devices on Android 8+ are affected. -->
 	<string name="notification_channel_downloader">Karten werden geladen</string>

--- a/android/app/src/main/res/values-el/strings.xml
+++ b/android/app/src/main/res/values-el/strings.xml
@@ -485,7 +485,6 @@
 	<string name="editor_operator">Ιδιοκτήτης</string>
 	<string name="downloader_no_downloaded_maps_title">Δεν έχετε κατεβάσει χάρτες</string>
 	<string name="downloader_no_downloaded_maps_message">Κατεβάστε χάρτες για να αναζητήσετε μια τοποθεσία και να χρησιμοποιήσετε την πλοήγησης χωρίς σύνδεση.</string>
-	<string name="stop">Στοπ</string>
 	<string name="placepage_more_button">Περισσότερα</string>
 	<!-- A referral link on the place page for some hotels -->
 	<string name="more_on_kayak">Φωτογραφίες, κριτικές, κράτηση</string>
@@ -596,10 +595,6 @@
 	<string name="bookmark_list_description_hint">Πληκτρολογήστε μια περιγραφή (κείμενο ή html)</string>
 	<string name="not_shared">Προσωπικός</string>
 	<string name="speedcams_alert_title">Κάμερες Ταχύτητας</string>
-	<!-- Generic «Always» string -->
-	<string name="always">Πάντα</string>
-	<!-- Generic «Never» string -->
-	<string name="never">Ποτέ</string>
 	<string name="place_description_title">Περιγραφή μέρους</string>
 	<!-- this text will be shown in application notification preferences opposite checkbox which enable/disable downloader notifications. Devices on Android 8+ are affected. -->
 	<string name="notification_channel_downloader">Κατέβασμα χαρτών</string>

--- a/android/app/src/main/res/values-es-rMX/strings.xml
+++ b/android/app/src/main/res/values-es-rMX/strings.xml
@@ -124,10 +124,6 @@
 	<string name="bookmark_list_description_hint">Introduzca una descripción (texto o html)</string>
 	<string name="not_shared">Privado</string>
 	<string name="speedcams_alert_title">Cámaras de velocidad</string>
-	<!-- Generic «Always» string -->
-	<string name="always">Siempre</string>
-	<!-- Generic «Never» string -->
-	<string name="never">Nunca</string>
 	<string name="place_description_title">Descripción de lugares</string>
 	<!-- this text will be shown in application notification preferences opposite checkbox which enable/disable downloader notifications. Devices on Android 8+ are affected. -->
 	<string name="notification_channel_downloader">Descargar mapas</string>

--- a/android/app/src/main/res/values-es/strings.xml
+++ b/android/app/src/main/res/values-es/strings.xml
@@ -508,7 +508,6 @@
 	<string name="editor_operator">Operador</string>
 	<string name="downloader_no_downloaded_maps_title">No ha descargado ningún mapa</string>
 	<string name="downloader_no_downloaded_maps_message">Descargue mapas para encontrar la ubicación y navegar sin conexión.</string>
-	<string name="stop">Detener</string>
 	<!-- abbreviation for meters -->
 	<string name="m">m</string>
 	<!-- abbreviation for kilometers -->
@@ -643,10 +642,6 @@
 	<string name="bookmark_list_description_hint">Agregue una descripción (texto o html)</string>
 	<string name="not_shared">Privado</string>
 	<string name="speedcams_alert_title">Cámaras de velocidad</string>
-	<!-- Generic «Always» string -->
-	<string name="always">Siempre</string>
-	<!-- Generic «Never» string -->
-	<string name="never">Nunca</string>
 	<string name="place_description_title">Descripción del lugar</string>
 	<!-- this text will be shown in application notification preferences opposite checkbox which enable/disable downloader notifications. Devices on Android 8+ are affected. -->
 	<string name="notification_channel_downloader">Descargar mapas</string>

--- a/android/app/src/main/res/values-et/strings.xml
+++ b/android/app/src/main/res/values-et/strings.xml
@@ -500,7 +500,6 @@
 	<string name="editor_operator">Omanik</string>
 	<string name="downloader_no_downloaded_maps_title">Sa ei ole kaarte alla laadinud</string>
 	<string name="downloader_no_downloaded_maps_message">Lae alla kaardid asukoha otsimiseks ja võrguühenduseta navigeerimise kasutamiseks.</string>
-	<string name="stop">Lõpeta</string>
 	<!-- abbreviation for meters -->
 	<string name="m">m</string>
 	<!-- abbreviation for kilometers -->
@@ -634,10 +633,6 @@
 	<string name="bookmark_list_description_hint">Sisesta kirjeldus (tekst või html)</string>
 	<string name="not_shared">Privaatne</string>
 	<string name="speedcams_alert_title">Kiiruskaamerad</string>
-	<!-- Generic «Always» string -->
-	<string name="always">Alati</string>
-	<!-- Generic «Never» string -->
-	<string name="never">Mitte kunagi</string>
 	<string name="place_description_title">Koha kirjeldus</string>
 	<!-- this text will be shown in application notification preferences opposite checkbox which enable/disable downloader notifications. Devices on Android 8+ are affected. -->
 	<string name="notification_channel_downloader">Kaartide allalaadija</string>

--- a/android/app/src/main/res/values-eu/strings.xml
+++ b/android/app/src/main/res/values-eu/strings.xml
@@ -506,7 +506,6 @@
 	<string name="editor_operator">Eragilea</string>
 	<string name="downloader_no_downloaded_maps_title">Ez duzu maparik deskargatu</string>
 	<string name="downloader_no_downloaded_maps_message">Deskargatu mapak kokapena aurkitzeko eta lineaz kanpo nabigatzeko.</string>
-	<string name="stop">Gelditu</string>
 	<!-- abbreviation for meters -->
 	<string name="m">m</string>
 	<!-- abbreviation for kilometers -->
@@ -641,10 +640,6 @@
 	<string name="bookmark_list_description_hint">Gehitu deskribapen bat (testua edo html)</string>
 	<string name="not_shared">Pribatua</string>
 	<string name="speedcams_alert_title">Abiadura kamerak</string>
-	<!-- Generic «Always» string -->
-	<string name="always">Beti</string>
-	<!-- Generic «Never» string -->
-	<string name="never">Inoiz ez</string>
 	<string name="place_description_title">Tokiaren deskribapena</string>
 	<!-- this text will be shown in application notification preferences opposite checkbox which enable/disable downloader notifications. Devices on Android 8+ are affected. -->
 	<string name="notification_channel_downloader">Deskargatu mapak</string>

--- a/android/app/src/main/res/values-fa/strings.xml
+++ b/android/app/src/main/res/values-fa/strings.xml
@@ -479,7 +479,6 @@
 	<string name="editor_operator">مالک</string>
 	<string name="downloader_no_downloaded_maps_title">شما هیچ نقشه دانلود شده ای ندارید</string>
 	<string name="downloader_no_downloaded_maps_message">برای جست وجو یک مکان و استفاده از قابلیت ناوبری، نقشه‌ها را دانلود کنید.</string>
-	<string name="stop">توقف</string>
 	<!-- abbreviation for meters -->
 	<string name="m">متر</string>
 	<!-- abbreviation for kilometers -->
@@ -607,10 +606,6 @@
 	<string name="bookmark_list_description_hint">یک توضیح (متن یا html) تایپ نمایید</string>
 	<string name="not_shared">خصوصی</string>
 	<string name="speedcams_alert_title">دوربین‌های سرعت</string>
-	<!-- Generic «Always» string -->
-	<string name="always">همیشه</string>
-	<!-- Generic «Never» string -->
-	<string name="never">هرگز</string>
 	<string name="place_description_title">توضیحات محل</string>
 	<!-- this text will be shown in application notification preferences opposite checkbox which enable/disable downloader notifications. Devices on Android 8+ are affected. -->
 	<string name="notification_channel_downloader">دانلود کننده نقشه</string>

--- a/android/app/src/main/res/values-fi/strings.xml
+++ b/android/app/src/main/res/values-fi/strings.xml
@@ -510,7 +510,6 @@
 	<string name="editor_operator">Operaattori</string>
 	<string name="downloader_no_downloaded_maps_title">Et ole ladannut yhtään karttaa</string>
 	<string name="downloader_no_downloaded_maps_message">Lataa karttoja löytääksesi paikkoja ja navigoidaksesi offline-tilassa.</string>
-	<string name="stop">Pysäytä</string>
 	<!-- abbreviation for meters -->
 	<string name="m">m</string>
 	<!-- abbreviation for kilometers -->
@@ -645,10 +644,6 @@
 	<string name="bookmark_list_description_hint">Lisää kuvaus (teksti tai html)</string>
 	<string name="not_shared">Yksityinen</string>
 	<string name="speedcams_alert_title">Nopeuskamerat</string>
-	<!-- Generic «Always» string -->
-	<string name="always">Aina</string>
-	<!-- Generic «Never» string -->
-	<string name="never">Ei koskaan</string>
 	<string name="place_description_title">Paikan kuvaus</string>
 	<!-- this text will be shown in application notification preferences opposite checkbox which enable/disable downloader notifications. Devices on Android 8+ are affected. -->
 	<string name="notification_channel_downloader">Karttojen lataaminen</string>

--- a/android/app/src/main/res/values-fr/strings.xml
+++ b/android/app/src/main/res/values-fr/strings.xml
@@ -510,7 +510,6 @@
 	<string name="editor_operator">Opérateur</string>
 	<string name="downloader_no_downloaded_maps_title">Vous n\'avez téléchargé aucune carte</string>
 	<string name="downloader_no_downloaded_maps_message">Téléchargez des cartes pour rechercher un lieu et utiliser la navigation hors ligne</string>
-	<string name="stop">Arrêter</string>
 	<!-- abbreviation for meters -->
 	<string name="m">m</string>
 	<!-- abbreviation for kilometers -->
@@ -644,10 +643,6 @@
 	<string name="bookmark_list_description_hint">Tapez une description (texte ou html)</string>
 	<string name="not_shared">Privé</string>
 	<string name="speedcams_alert_title">Radars de vitesse</string>
-	<!-- Generic «Always» string -->
-	<string name="always">Toujours</string>
-	<!-- Generic «Never» string -->
-	<string name="never">Jamais</string>
 	<string name="place_description_title">Description d\'endroit</string>
 	<!-- this text will be shown in application notification preferences opposite checkbox which enable/disable downloader notifications. Devices on Android 8+ are affected. -->
 	<string name="notification_channel_downloader">Téléchargeur carte</string>

--- a/android/app/src/main/res/values-hi/strings.xml
+++ b/android/app/src/main/res/values-hi/strings.xml
@@ -409,10 +409,6 @@
 	<string name="layers_title">मानचित्र शैलियाँ और परतें</string>
 	<string name="export_file">फ़ाइल निर्यात करें</string>
 	<string name="speedcams_alert_title">गति कैमरा</string>
-	<!-- Generic «Always» string -->
-	<string name="always">हमेशा</string>
-	<!-- Generic «Never» string -->
-	<string name="never">कभी नहीं</string>
 	<string name="power_managment_title">बिजली की बचत अवस्थाt</string>
 	<string name="power_managment_description">कुछ कार्यक्षमता की कीमत पर बिजली के उपयोग को कम करने का प्रयास करें।</string>
 	<string name="enable_logging_warning_message">सहायता संवाद में \"बग की रिपोर्ट करें\" का उपयोग करके हमें अपनी समस्या के बारे में विस्तृत डायग्नोस्टिक लॉग रिकॉर्ड करने और मैन्युअल रूप से भेजने के लिए इस विकल्प को अस्थायी रूप से सक्षम करें। लॉग में स्थान की जानकारी शामिल हो सकती है.</string>

--- a/android/app/src/main/res/values-hu/strings.xml
+++ b/android/app/src/main/res/values-hu/strings.xml
@@ -496,7 +496,6 @@
 	<string name="editor_operator">Üzemeltető</string>
 	<string name="downloader_no_downloaded_maps_title">Még nem töltött le térképet</string>
 	<string name="downloader_no_downloaded_maps_message">Töltse le a szükséges térképeket, hogy megtalálja a helyet és internet nélkül is navigálhasson.</string>
-	<string name="stop">Leállítás</string>
 	<!-- abbreviation for meters -->
 	<string name="m">m</string>
 	<!-- abbreviation for kilometers -->
@@ -621,10 +620,6 @@
 	<string name="bookmark_list_description_hint">Leírás hozzáadása (szöveg vagy html)</string>
 	<string name="not_shared">Privát</string>
 	<string name="speedcams_alert_title">Sebességmérő kamerák</string>
-	<!-- Generic «Always» string -->
-	<string name="always">Mindig</string>
-	<!-- Generic «Never» string -->
-	<string name="never">Soha</string>
 	<string name="place_description_title">A hely ismertetése</string>
 	<!-- this text will be shown in application notification preferences opposite checkbox which enable/disable downloader notifications. Devices on Android 8+ are affected. -->
 	<string name="notification_channel_downloader">Kártyák letöltése</string>

--- a/android/app/src/main/res/values-in/strings.xml
+++ b/android/app/src/main/res/values-in/strings.xml
@@ -484,7 +484,6 @@
 	<string name="editor_operator">Pemilik</string>
 	<string name="downloader_no_downloaded_maps_title">Tidak ada peta apa pun yang diunduh</string>
 	<string name="downloader_no_downloaded_maps_message">Unduh peta untuk menemukan lokasi dan bernavigasi secara offline.</string>
-	<string name="stop">Berhenti</string>
 	<!-- abbreviation for meters -->
 	<string name="m">m</string>
 	<!-- abbreviation for kilometers -->
@@ -609,10 +608,6 @@
 	<string name="bookmark_list_description_hint">Ketikkan deskripsi (teks atau html)</string>
 	<string name="not_shared">Pribadi</string>
 	<string name="speedcams_alert_title">Kamera cepat</string>
-	<!-- Generic «Always» string -->
-	<string name="always">Selalu</string>
-	<!-- Generic «Never» string -->
-	<string name="never">Tidak pernah</string>
 	<string name="place_description_title">Deskripsi Tempat</string>
 	<!-- this text will be shown in application notification preferences opposite checkbox which enable/disable downloader notifications. Devices on Android 8+ are affected. -->
 	<string name="notification_channel_downloader">Pengunduh peta</string>

--- a/android/app/src/main/res/values-it/strings.xml
+++ b/android/app/src/main/res/values-it/strings.xml
@@ -494,7 +494,6 @@
 	<string name="editor_operator">Proprietario</string>
 	<string name="downloader_no_downloaded_maps_title">Non hai scaricato mappe</string>
 	<string name="downloader_no_downloaded_maps_message">Scarica mappe per trovare un luogo e navigare offline.</string>
-	<string name="stop">Ferma</string>
 	<!-- abbreviation for meters -->
 	<string name="m">m</string>
 	<!-- abbreviation for kilometers -->
@@ -626,10 +625,6 @@
 	<string name="bookmark_list_description_hint">Scrivi una descrizione (testo o html)</string>
 	<string name="not_shared">Personale</string>
 	<string name="speedcams_alert_title">Autovelox</string>
-	<!-- Generic «Always» string -->
-	<string name="always">Sempre</string>
-	<!-- Generic «Never» string -->
-	<string name="never">Mai</string>
 	<string name="place_description_title">Descrizione luogo</string>
 	<!-- this text will be shown in application notification preferences opposite checkbox which enable/disable downloader notifications. Devices on Android 8+ are affected. -->
 	<string name="notification_channel_downloader">Scaricamento mappe</string>
@@ -2007,7 +2002,7 @@
 	<string name="type.tourism.caravan_site">Area per campeggiatori</string>
 	<string name="type.tourism.chalet">Chalet</string>
 	<string name="type.tourism.gallery">Galleria</string>
-	<string name="type.tourism.guest_house">Casa degli Ospiti</string>
+	<string name="type.tourism.guest_house">Affittacamere</string>
 	<string name="type.tourism.hostel">Ostello</string>
 	<string name="type.tourism.hotel">Hotel</string>
 	<string name="type.tourism.information">Informazione</string>

--- a/android/app/src/main/res/values-iw/strings.xml
+++ b/android/app/src/main/res/values-iw/strings.xml
@@ -500,7 +500,6 @@
 	<string name="editor_operator">בעלים</string>
 	<string name="downloader_no_downloaded_maps_title">לא הורדת אף מפה</string>
 	<string name="downloader_no_downloaded_maps_message">הורד מפה כדי לחפש ולנווט ללא חיבור לאינטרנט.</string>
-	<string name="stop">הפסק</string>
 	<!-- abbreviation for meters -->
 	<string name="m">מ׳</string>
 	<!-- abbreviation for kilometers -->
@@ -634,10 +633,6 @@
 	<string name="bookmark_list_description_hint">הזן תיאור (טקסט או HTML)</string>
 	<string name="not_shared">פרטי</string>
 	<string name="speedcams_alert_title">מצלמות מהירות</string>
-	<!-- Generic «Always» string -->
-	<string name="always">תמיד</string>
-	<!-- Generic «Never» string -->
-	<string name="never">אף פעם</string>
 	<string name="place_description_title">תיאור מיקום</string>
 	<!-- this text will be shown in application notification preferences opposite checkbox which enable/disable downloader notifications. Devices on Android 8+ are affected. -->
 	<string name="notification_channel_downloader">מוריד המפות</string>

--- a/android/app/src/main/res/values-ja/strings.xml
+++ b/android/app/src/main/res/values-ja/strings.xml
@@ -510,7 +510,6 @@
 	<string name="editor_operator">オペレーター</string>
 	<string name="downloader_no_downloaded_maps_title">マップをダウンロードしていません</string>
 	<string name="downloader_no_downloaded_maps_message">ロケーションの検索とオフラインナビゲートのためにマップをダウンロードしてください。</string>
-	<string name="stop">止める</string>
 	<!-- abbreviation for meters -->
 	<string name="m">m</string>
 	<!-- abbreviation for kilometers -->
@@ -641,10 +640,6 @@
 	<string name="bookmark_list_description_hint">説明(テキストまたはhtml)を記入してください</string>
 	<string name="not_shared">非公開</string>
 	<string name="speedcams_alert_title">自動速度違反取締装置</string>
-	<!-- Generic «Always» string -->
-	<string name="always">常時</string>
-	<!-- Generic «Never» string -->
-	<string name="never">無効</string>
 	<string name="place_description_title">場所の説明</string>
 	<!-- this text will be shown in application notification preferences opposite checkbox which enable/disable downloader notifications. Devices on Android 8+ are affected. -->
 	<string name="notification_channel_downloader">マップダウンローダー</string>

--- a/android/app/src/main/res/values-ko/strings.xml
+++ b/android/app/src/main/res/values-ko/strings.xml
@@ -482,7 +482,6 @@
 	<string name="editor_operator">소유자</string>
 	<string name="downloader_no_downloaded_maps_title">지도를 다운로드하지 않았습니다</string>
 	<string name="downloader_no_downloaded_maps_message">오프라인으로 위치를 검색하려면 지도를 다운로드하세요.</string>
-	<string name="stop">중지</string>
 	<!-- abbreviation for meters -->
 	<string name="m">m</string>
 	<!-- abbreviation for kilometers -->
@@ -606,10 +605,6 @@
 	<string name="bookmark_list_description_hint">묘사를 적으세요 (글자 혹은 html)</string>
 	<string name="not_shared">개인</string>
 	<string name="speedcams_alert_title">속도 감시 카메라</string>
-	<!-- Generic «Always» string -->
-	<string name="always">항상</string>
-	<!-- Generic «Never» string -->
-	<string name="never">안함</string>
 	<string name="place_description_title">장소 묘사</string>
 	<!-- this text will be shown in application notification preferences opposite checkbox which enable/disable downloader notifications. Devices on Android 8+ are affected. -->
 	<string name="notification_channel_downloader">맵 다운로더</string>

--- a/android/app/src/main/res/values-mr/strings.xml
+++ b/android/app/src/main/res/values-mr/strings.xml
@@ -479,7 +479,6 @@
 	<string name="editor_operator">मालक</string>
 	<string name="downloader_no_downloaded_maps_title">तुम्ही कोणतेही नकाशे डाउनलोड केलेले नाहीत</string>
 	<string name="downloader_no_downloaded_maps_message">स्थान शोधण्यासाठी नकाशे डाउनलोड करा आणि ऑफलाइन मार्गनिर्देशन वापरा.</string>
-	<string name="stop">थांबा</string>
 	<!-- abbreviation for meters -->
 	<string name="m">m</string>
 	<!-- abbreviation for kilometers -->
@@ -609,10 +608,6 @@
 	<string name="bookmark_list_description_hint">वर्णन लिहा (मजकूर किंवा html)</string>
 	<string name="not_shared">खाजगी</string>
 	<string name="speedcams_alert_title">वेग कॅमेरे</string>
-	<!-- Generic «Always» string -->
-	<string name="always">नेहमी</string>
-	<!-- Generic «Never» string -->
-	<string name="never">कधीच नाही</string>
 	<string name="place_description_title">ठिकाणाचे वर्णन</string>
 	<!-- this text will be shown in application notification preferences opposite checkbox which enable/disable downloader notifications. Devices on Android 8+ are affected. -->
 	<string name="notification_channel_downloader">नकाशा डाउनलोडक</string>

--- a/android/app/src/main/res/values-nb/strings.xml
+++ b/android/app/src/main/res/values-nb/strings.xml
@@ -508,7 +508,6 @@
 	<string name="editor_operator">Eier</string>
 	<string name="downloader_no_downloaded_maps_title">Du har ikke lastet ned noen kart</string>
 	<string name="downloader_no_downloaded_maps_message">Last ned kart for å finne plasseringen og navigere frakoblet.</string>
-	<string name="stop">Stopp</string>
 	<!-- abbreviation for meters -->
 	<string name="m">m</string>
 	<!-- abbreviation for kilometers -->
@@ -640,10 +639,6 @@
 	<string name="bookmark_list_description_hint">Lag en beskrivelse (text or html)</string>
 	<string name="not_shared">Privat</string>
 	<string name="speedcams_alert_title">Fartskamera</string>
-	<!-- Generic «Always» string -->
-	<string name="always">Alltid</string>
-	<!-- Generic «Never» string -->
-	<string name="never">Aldri</string>
 	<string name="place_description_title">Plasser beskrivelse</string>
 	<!-- this text will be shown in application notification preferences opposite checkbox which enable/disable downloader notifications. Devices on Android 8+ are affected. -->
 	<string name="notification_channel_downloader">Nedlast kart</string>

--- a/android/app/src/main/res/values-nl/strings.xml
+++ b/android/app/src/main/res/values-nl/strings.xml
@@ -504,7 +504,6 @@
 	<string name="editor_operator">Uitvoerder</string>
 	<string name="downloader_no_downloaded_maps_title">U hebt geen kaarten gedownload</string>
 	<string name="downloader_no_downloaded_maps_message">Download kaarten om een locatie te zoeken en offline te navigeren.</string>
-	<string name="stop">Stoppen</string>
 	<!-- abbreviation for meters -->
 	<string name="m">m</string>
 	<!-- abbreviation for kilometers -->
@@ -636,10 +635,6 @@
 	<string name="bookmark_list_description_hint">Maak een beschrijving aan (tekst of html)</string>
 	<string name="not_shared">Privé</string>
 	<string name="speedcams_alert_title">Snelheidscamera\'s</string>
-	<!-- Generic «Always» string -->
-	<string name="always">Altijd</string>
-	<!-- Generic «Never» string -->
-	<string name="never">Nooit</string>
 	<string name="place_description_title">Plaatsbeschrijving</string>
 	<!-- this text will be shown in application notification preferences opposite checkbox which enable/disable downloader notifications. Devices on Android 8+ are affected. -->
 	<string name="notification_channel_downloader">Kaartdownloader</string>

--- a/android/app/src/main/res/values-pl/strings.xml
+++ b/android/app/src/main/res/values-pl/strings.xml
@@ -508,7 +508,6 @@
 	<string name="editor_operator">Operator</string>
 	<string name="downloader_no_downloaded_maps_title">Nie pobrano żadnych map</string>
 	<string name="downloader_no_downloaded_maps_message">Aby znajdować miejsca i nawigować bez połączenia z internetem, musisz pobrać mapy.</string>
-	<string name="stop">Stop</string>
 	<!-- abbreviation for meters -->
 	<string name="m">m</string>
 	<!-- abbreviation for kilometers -->
@@ -641,10 +640,6 @@
 	<string name="bookmark_list_description_hint">Dodaj opis (tekst lub html)</string>
 	<string name="not_shared">Osobisty</string>
 	<string name="speedcams_alert_title">Fotoradary</string>
-	<!-- Generic «Always» string -->
-	<string name="always">Zawsze</string>
-	<!-- Generic «Never» string -->
-	<string name="never">Nigdy</string>
 	<string name="place_description_title">Opis miejsca</string>
 	<!-- this text will be shown in application notification preferences opposite checkbox which enable/disable downloader notifications. Devices on Android 8+ are affected. -->
 	<string name="notification_channel_downloader">Pobieranie map</string>

--- a/android/app/src/main/res/values-pt-rBR/strings.xml
+++ b/android/app/src/main/res/values-pt-rBR/strings.xml
@@ -482,7 +482,6 @@
 	<string name="editor_operator">Operador</string>
 	<string name="downloader_no_downloaded_maps_title">Você não fez o download de nenhum mapa</string>
 	<string name="downloader_no_downloaded_maps_message">Baixe mapas para pesquisar locais e usar navegação offline.</string>
-	<string name="stop">Parar</string>
 	<!-- abbreviation for meters -->
 	<string name="m">m</string>
 	<!-- abbreviation for kilometers -->
@@ -604,10 +603,6 @@
 	<string name="bookmark_list_description_hint">Digite uma descrição (texto ou html)</string>
 	<string name="not_shared">Privado</string>
 	<string name="speedcams_alert_title">Câmeras de trânsito</string>
-	<!-- Generic «Always» string -->
-	<string name="always">Sempre</string>
-	<!-- Generic «Never» string -->
-	<string name="never">Nunca</string>
 	<string name="place_description_title">Descrição do lugar</string>
 	<!-- this text will be shown in application notification preferences opposite checkbox which enable/disable downloader notifications. Devices on Android 8+ are affected. -->
 	<string name="notification_channel_downloader">Downloader do mapa</string>

--- a/android/app/src/main/res/values-pt/strings.xml
+++ b/android/app/src/main/res/values-pt/strings.xml
@@ -489,7 +489,6 @@
 	<string name="editor_operator">Operador</string>
 	<string name="downloader_no_downloaded_maps_title">Não descarregou quaisquer mapas</string>
 	<string name="downloader_no_downloaded_maps_message">Descarregar mapas para encontrar a localização e navegar offline.</string>
-	<string name="stop">Parar</string>
 	<!-- abbreviation for meters -->
 	<string name="m">m</string>
 	<!-- abbreviation for kilometers -->
@@ -617,10 +616,6 @@
 	<string name="bookmark_list_description_hint">Introduza uma descrição (texto ou html)</string>
 	<string name="not_shared">Privado</string>
 	<string name="speedcams_alert_title">Radares de velocidade</string>
-	<!-- Generic «Always» string -->
-	<string name="always">Sempre</string>
-	<!-- Generic «Never» string -->
-	<string name="never">Nunca</string>
 	<string name="place_description_title">Descrição do local</string>
 	<!-- this text will be shown in application notification preferences opposite checkbox which enable/disable downloader notifications. Devices on Android 8+ are affected. -->
 	<string name="notification_channel_downloader">Descarregador de mapas</string>

--- a/android/app/src/main/res/values-ro/strings.xml
+++ b/android/app/src/main/res/values-ro/strings.xml
@@ -494,7 +494,6 @@
 	<string name="editor_operator">Proprietar</string>
 	<string name="downloader_no_downloaded_maps_title">Nu ai descărcat nicio hartă</string>
 	<string name="downloader_no_downloaded_maps_message">Descarcă hărți pentru a căuta un loc și a naviga fără conectare la internet.</string>
-	<string name="stop">Oprește</string>
 	<!-- abbreviation for meters -->
 	<string name="m">m</string>
 	<!-- abbreviation for kilometers -->
@@ -627,10 +626,6 @@
 	<string name="bookmark_list_description_hint">Adaugă o descriere (text sau html)</string>
 	<string name="not_shared">Personal</string>
 	<string name="speedcams_alert_title">Radare</string>
-	<!-- Generic «Always» string -->
-	<string name="always">Mereu</string>
-	<!-- Generic «Never» string -->
-	<string name="never">Niciodată</string>
 	<string name="place_description_title">Descrierea locului</string>
 	<!-- this text will be shown in application notification preferences opposite checkbox which enable/disable downloader notifications. Devices on Android 8+ are affected. -->
 	<string name="notification_channel_downloader">Descărcarea hărților</string>

--- a/android/app/src/main/res/values-ru/strings.xml
+++ b/android/app/src/main/res/values-ru/strings.xml
@@ -511,7 +511,6 @@
 	<string name="editor_operator">Владелец</string>
 	<string name="downloader_no_downloaded_maps_title">У вас нет загруженных карт</string>
 	<string name="downloader_no_downloaded_maps_message">Загрузите необходимые карты, чтобы находить места и пользоваться навигацией без интернета.</string>
-	<string name="stop">Стоп</string>
 	<!-- abbreviation for meters -->
 	<string name="m">м</string>
 	<!-- abbreviation for kilometers -->
@@ -650,15 +649,11 @@
 	<string name="bookmark_list_description_hint">Добавьте описание (текст или html)</string>
 	<string name="not_shared">Личный</string>
 	<string name="speedcams_alert_title">Камеры скорости</string>
-	<!-- Generic «Always» string -->
-	<string name="always">Всегда</string>
-	<!-- Generic «Never» string -->
-	<string name="never">Никогда</string>
 	<string name="place_description_title">Описание места</string>
 	<!-- this text will be shown in application notification preferences opposite checkbox which enable/disable downloader notifications. Devices on Android 8+ are affected. -->
 	<string name="notification_channel_downloader">Загрузка карт</string>
 	<!-- Speed camera settings menu option - Warn (about speedcams) if risk of exceeding speed limit -->
-	<string name="pref_tts_speedcams_auto">Предупреждать если есть риск превышения скоростного лимита</string>
+	<string name="pref_tts_speedcams_auto">Предупреждать при превышении скорости</string>
 	<!-- Speed camera settings menu option - Always warn (about speedcams) -->
 	<string name="pref_tts_speedcams_always">Всегда предупреждать</string>
 	<!-- Speed camera settings menu option - Never warn (about speedcams) -->

--- a/android/app/src/main/res/values-sk/strings.xml
+++ b/android/app/src/main/res/values-sk/strings.xml
@@ -506,7 +506,6 @@
 	<string name="editor_operator">Prevádzkovateľ</string>
 	<string name="downloader_no_downloaded_maps_title">Neprevzali ste žiadne mapy</string>
 	<string name="downloader_no_downloaded_maps_message">Prevziať mapy na nájdenie pozície a navigovanie off-line.</string>
-	<string name="stop">Zastaviť</string>
 	<!-- abbreviation for meters -->
 	<string name="m">m</string>
 	<!-- abbreviation for kilometers -->
@@ -639,10 +638,6 @@
 	<string name="bookmark_list_description_hint">Zadajte popis (text alebo html)</string>
 	<string name="not_shared">Súkromné</string>
 	<string name="speedcams_alert_title">Rýchlostné kamery</string>
-	<!-- Generic «Always» string -->
-	<string name="always">Vždy</string>
-	<!-- Generic «Never» string -->
-	<string name="never">Nikdy</string>
 	<string name="place_description_title">Popis miesta</string>
 	<!-- this text will be shown in application notification preferences opposite checkbox which enable/disable downloader notifications. Devices on Android 8+ are affected. -->
 	<string name="notification_channel_downloader">Sťahovač máp</string>

--- a/android/app/src/main/res/values-sv/strings.xml
+++ b/android/app/src/main/res/values-sv/strings.xml
@@ -480,7 +480,6 @@
 	<string name="editor_operator">Användare</string>
 	<string name="downloader_no_downloaded_maps_title">Du har inte laddat ner några kartor</string>
 	<string name="downloader_no_downloaded_maps_message">Ladda ner kartor för att hitta platsen och navigera offline.</string>
-	<string name="stop">Stopp</string>
 	<!-- abbreviation for meters -->
 	<string name="m">m</string>
 	<!-- abbreviation for kilometers -->
@@ -607,10 +606,6 @@
 	<string name="bookmark_list_description_hint">Lägg till en beskrivning (text eller html)</string>
 	<string name="not_shared">Personlig</string>
 	<string name="speedcams_alert_title">Hastighetskameror</string>
-	<!-- Generic «Always» string -->
-	<string name="always">Alltid</string>
-	<!-- Generic «Never» string -->
-	<string name="never">Aldrig</string>
 	<string name="place_description_title">Beskrivning av platsen</string>
 	<!-- this text will be shown in application notification preferences opposite checkbox which enable/disable downloader notifications. Devices on Android 8+ are affected. -->
 	<string name="notification_channel_downloader">Kartladdning</string>

--- a/android/app/src/main/res/values-sw/strings.xml
+++ b/android/app/src/main/res/values-sw/strings.xml
@@ -169,10 +169,6 @@
 	<string name="bookmark_list_description_hint">Andika maelezo (maneno au html)</string>
 	<string name="not_shared">Faragha</string>
 	<string name="speedcams_alert_title">Kamera za mwendo-kasi</string>
-	<!-- Generic «Always» string -->
-	<string name="always">Mara kwa Mara</string>
-	<!-- Generic «Never» string -->
-	<string name="never">Kamwe</string>
 	<string name="place_description_title">Maelezo ya Eneo</string>
 	<!-- this text will be shown in application notification preferences opposite checkbox which enable/disable downloader notifications. Devices on Android 8+ are affected. -->
 	<string name="notification_channel_downloader">Kipakua Ramani</string>

--- a/android/app/src/main/res/values-th/strings.xml
+++ b/android/app/src/main/res/values-th/strings.xml
@@ -484,7 +484,6 @@
 	<string name="editor_operator">เจ้าของ</string>
 	<string name="downloader_no_downloaded_maps_title">คุณยังไม่ได้ดาวน์โหลดแผนที่</string>
 	<string name="downloader_no_downloaded_maps_message">ดาวน์โหลดแผนที่เพื่อค้นหาสถานที่ และนำทางแบบออฟไลน์</string>
-	<string name="stop">หยุด</string>
 	<!-- abbreviation for meters -->
 	<string name="m">ม.</string>
 	<!-- abbreviation for kilometers -->
@@ -608,10 +607,6 @@
 	<string name="bookmark_list_description_hint">พิมพ์รายละเอียด (ข้อความหรือ html)</string>
 	<string name="not_shared">ส่วนตัว</string>
 	<string name="speedcams_alert_title">กล้องตรวจจับความเร็ว</string>
-	<!-- Generic «Always» string -->
-	<string name="always">ทุกครั้ง</string>
-	<!-- Generic «Never» string -->
-	<string name="never">ไม่ต้องเตือน</string>
 	<string name="place_description_title">รายละเอียดของสถานที่</string>
 	<!-- this text will be shown in application notification preferences opposite checkbox which enable/disable downloader notifications. Devices on Android 8+ are affected. -->
 	<string name="notification_channel_downloader">ตัวดาวน์โหลดแผนที่</string>

--- a/android/app/src/main/res/values-tr/strings.xml
+++ b/android/app/src/main/res/values-tr/strings.xml
@@ -508,7 +508,6 @@
 	<string name="editor_operator">İşletmeci</string>
 	<string name="downloader_no_downloaded_maps_title">Hiç harita indirmediniz</string>
 	<string name="downloader_no_downloaded_maps_message">Çevrimdışı olarak adres bulmak ve gezinmek için haritaları indirin.</string>
-	<string name="stop">Dur</string>
 	<!-- abbreviation for meters -->
 	<string name="m">m</string>
 	<!-- abbreviation for kilometers -->
@@ -639,10 +638,6 @@
 	<string name="bookmark_list_description_hint">Bir açıklama yazın (metin veya html)</string>
 	<string name="not_shared">Gizli</string>
 	<string name="speedcams_alert_title">Hız kameraları</string>
-	<!-- Generic «Always» string -->
-	<string name="always">Her zaman</string>
-	<!-- Generic «Never» string -->
-	<string name="never">Asla</string>
 	<string name="place_description_title">Yer Açıklaması</string>
 	<!-- this text will be shown in application notification preferences opposite checkbox which enable/disable downloader notifications. Devices on Android 8+ are affected. -->
 	<string name="notification_channel_downloader">Harita indirici</string>

--- a/android/app/src/main/res/values-uk/strings.xml
+++ b/android/app/src/main/res/values-uk/strings.xml
@@ -510,7 +510,6 @@
 	<string name="editor_operator">Власник</string>
 	<string name="downloader_no_downloaded_maps_title">Ви не маєте завантажених мап</string>
 	<string name="downloader_no_downloaded_maps_message">Завантажте необхідні мапи, щоб знаходити місця та користуватися навігацією без iнтернету.</string>
-	<string name="stop">Зупинити</string>
 	<!-- abbreviation for meters -->
 	<string name="m">м</string>
 	<!-- abbreviation for kilometers -->
@@ -643,15 +642,11 @@
 	<string name="bookmark_list_description_hint">Додайте опис (текст чи html)</string>
 	<string name="not_shared">Особистий</string>
 	<string name="speedcams_alert_title">Камери швидкості</string>
-	<!-- Generic «Always» string -->
-	<string name="always">Завжди</string>
-	<!-- Generic «Never» string -->
-	<string name="never">Ніколи</string>
 	<string name="place_description_title">Опис місця</string>
 	<!-- this text will be shown in application notification preferences opposite checkbox which enable/disable downloader notifications. Devices on Android 8+ are affected. -->
 	<string name="notification_channel_downloader">Завантаження мап</string>
 	<!-- Speed camera settings menu option - Warn (about speedcams) if risk of exceeding speed limit -->
-	<string name="pref_tts_speedcams_auto">Попереджати якщо є ризик перевищення швидкісного ліміту</string>
+	<string name="pref_tts_speedcams_auto">Попереджати при перевищенні швидкості</string>
 	<!-- Speed camera settings menu option - Always warn (about speedcams) -->
 	<string name="pref_tts_speedcams_always">Завжди попереджати</string>
 	<!-- Speed camera settings menu option - Never warn (about speedcams) -->

--- a/android/app/src/main/res/values-vi/strings.xml
+++ b/android/app/src/main/res/values-vi/strings.xml
@@ -482,7 +482,6 @@
 	<string name="editor_operator">Đơn vị điều hành</string>
 	<string name="downloader_no_downloaded_maps_title">Bạn chưa tải về bất kỳ bản đồ nào</string>
 	<string name="downloader_no_downloaded_maps_message">Tải về bản đồ để tìm địa điểm và định hướng ngoại tuyến.</string>
-	<string name="stop">Dừng</string>
 	<!-- abbreviation for meters -->
 	<string name="m">m</string>
 	<!-- abbreviation for kilometers -->
@@ -607,10 +606,6 @@
 	<string name="bookmark_list_description_hint">Đánh vào một mô tả (văn bản hoặc html)</string>
 	<string name="not_shared">Riêng tư</string>
 	<string name="speedcams_alert_title">Tăn tốc độ máy ảnh</string>
-	<!-- Generic «Always» string -->
-	<string name="always">Luôn luôn</string>
-	<!-- Generic «Never» string -->
-	<string name="never">Không bao giờ</string>
 	<string name="place_description_title">Mô tả Địa điểm</string>
 	<!-- this text will be shown in application notification preferences opposite checkbox which enable/disable downloader notifications. Devices on Android 8+ are affected. -->
 	<string name="notification_channel_downloader">Trình tải xuống bản đồ</string>

--- a/android/app/src/main/res/values-zh-rTW/strings.xml
+++ b/android/app/src/main/res/values-zh-rTW/strings.xml
@@ -496,7 +496,6 @@
 	<string name="editor_operator">營運者</string>
 	<string name="downloader_no_downloaded_maps_title">您尚未下載任何地圖</string>
 	<string name="downloader_no_downloaded_maps_message">下載地圖來尋找位置和離線瀏覽。</string>
-	<string name="stop">停止</string>
 	<!-- abbreviation for meters -->
 	<string name="m">公尺</string>
 	<!-- abbreviation for kilometers -->
@@ -624,10 +623,6 @@
 	<string name="bookmark_list_description_hint">增加說明(文字或html)</string>
 	<string name="not_shared">私人</string>
 	<string name="speedcams_alert_title">超速照相機</string>
-	<!-- Generic «Always» string -->
-	<string name="always">總是</string>
-	<!-- Generic «Never» string -->
-	<string name="never">從不</string>
 	<string name="place_description_title">地點說明</string>
 	<!-- this text will be shown in application notification preferences opposite checkbox which enable/disable downloader notifications. Devices on Android 8+ are affected. -->
 	<string name="notification_channel_downloader">載入地圖</string>

--- a/android/app/src/main/res/values-zh/strings.xml
+++ b/android/app/src/main/res/values-zh/strings.xml
@@ -493,7 +493,6 @@
 	<string name="editor_operator">运营者</string>
 	<string name="downloader_no_downloaded_maps_title">您尚未下载任何地图</string>
 	<string name="downloader_no_downloaded_maps_message">下载地图来查找位置和离线浏览</string>
-	<string name="stop">停止</string>
 	<!-- abbreviation for meters -->
 	<string name="m">米</string>
 	<!-- abbreviation for kilometers -->
@@ -617,10 +616,6 @@
 	<string name="bookmark_list_description_hint">请添加说明（文字或html）</string>
 	<string name="not_shared">私人</string>
 	<string name="speedcams_alert_title">高速摄像机</string>
-	<!-- Generic «Always» string -->
-	<string name="always">总是</string>
-	<!-- Generic «Never» string -->
-	<string name="never">从不</string>
 	<string name="place_description_title">地点说明</string>
 	<!-- this text will be shown in application notification preferences opposite checkbox which enable/disable downloader notifications. Devices on Android 8+ are affected. -->
 	<string name="notification_channel_downloader">加载地图</string>

--- a/android/app/src/main/res/values/strings.xml
+++ b/android/app/src/main/res/values/strings.xml
@@ -533,7 +533,6 @@
 	<string name="editor_operator">Owner</string>
 	<string name="downloader_no_downloaded_maps_title">You haven\'t downloaded any maps</string>
 	<string name="downloader_no_downloaded_maps_message">Download maps to search and navigate offline.</string>
-	<string name="stop">Stop</string>
 	<!-- abbreviation for meters -->
 	<string name="m">m</string>
 	<!-- abbreviation for kilometers -->
@@ -668,10 +667,6 @@
 	<string name="bookmark_list_description_hint">Enter a description (text or html)</string>
 	<string name="not_shared">Private</string>
 	<string name="speedcams_alert_title">Speed cameras</string>
-	<!-- Generic «Always» string -->
-	<string name="always">Always</string>
-	<!-- Generic «Never» string -->
-	<string name="never">Never</string>
 	<string name="place_description_title">Place Description</string>
 	<!-- this text will be shown in application notification preferences opposite checkbox which enable/disable downloader notifications. Devices on Android 8+ are affected. -->
 	<string name="notification_channel_downloader">Map downloader</string>

--- a/data/strings/strings.txt
+++ b/data/strings/strings.txt
@@ -16482,49 +16482,6 @@
     zh-Hans = 下载地图来查找位置和离线浏览
     zh-Hant = 下載地圖來尋找位置和離線瀏覽。
 
-  [stop]
-    tags = android,ios
-    en = Stop
-    af = Stop
-    ar = إيقاف
-    az = Dayan
-    be = Спыніць
-    bg = Стоп
-    ca = Atura't
-    cs = Zastavit
-    da = Stop
-    de = Anhalten
-    el = Στοπ
-    es = Detener
-    et = Lõpeta
-    eu = Gelditu
-    fa = توقف
-    fi = Pysäytä
-    fr = Arrêter
-    he = הפסק
-    hu = Leállítás
-    id = Berhenti
-    it = Ferma
-    ja = 止める
-    ko = 중지
-    lt = Stabdyti
-    mr = थांबा
-    nb = Stopp
-    nl = Stoppen
-    pl = Stop
-    pt = Parar
-    pt-BR = Parar
-    ro = Oprește
-    ru = Стоп
-    sk = Zastaviť
-    sv = Stopp
-    th = หยุด
-    tr = Dur
-    uk = Зупинити
-    vi = Dừng
-    zh-Hans = 停止
-    zh-Hant = 停止
-
   [current_location_unknown_error_title]
     tags = ios
     en = Current location is unknown.
@@ -23156,100 +23113,6 @@
     zh-Hans = 高速摄像机
     zh-Hant = 超速照相機
 
-  [always]
-    comment = Generic «Always» string
-    tags = android,ios
-    en = Always
-    af = Altyd
-    ar = مفعل دائماً
-    az = Həmişə
-    be = Заўсёды
-    bg = Винаги
-    ca = Sempre
-    cs = Vždy
-    da = Altid
-    de = Immer
-    el = Πάντα
-    es = Siempre
-    es-MX = Siempre
-    et = Alati
-    eu = Beti
-    fa = همیشه
-    fi = Aina
-    fr = Toujours
-    he = תמיד
-    hi = हमेशा
-    hu = Mindig
-    id = Selalu
-    it = Sempre
-    ja = 常時
-    ko = 항상
-    lt = Visada
-    mr = नेहमी
-    nb = Alltid
-    nl = Altijd
-    pl = Zawsze
-    pt = Sempre
-    pt-BR = Sempre
-    ro = Mereu
-    ru = Всегда
-    sk = Vždy
-    sv = Alltid
-    sw = Mara kwa Mara
-    th = ทุกครั้ง
-    tr = Her zaman
-    uk = Завжди
-    vi = Luôn luôn
-    zh-Hans = 总是
-    zh-Hant = 總是
-
-  [never]
-    comment = Generic «Never» string
-    tags = android,ios
-    en = Never
-    af = Nooit
-    ar = معطل دائماً
-    az = Heç vaxt
-    be = Ніколі
-    bg = Никога
-    ca = Mai
-    cs = Nikdy
-    da = Aldrig
-    de = Niemals
-    el = Ποτέ
-    es = Nunca
-    es-MX = Nunca
-    et = Mitte kunagi
-    eu = Inoiz ez
-    fa = هرگز
-    fi = Ei koskaan
-    fr = Jamais
-    he = אף פעם
-    hi = कभी नहीं
-    hu = Soha
-    id = Tidak pernah
-    it = Mai
-    ja = 無効
-    ko = 안함
-    lt = Niekada
-    mr = कधीच नाही
-    nb = Aldri
-    nl = Nooit
-    pl = Nigdy
-    pt = Nunca
-    pt-BR = Nunca
-    ro = Niciodată
-    ru = Никогда
-    sk = Nikdy
-    sv = Aldrig
-    sw = Kamwe
-    th = ไม่ต้องเตือน
-    tr = Asla
-    uk = Ніколи
-    vi = Không bao giờ
-    zh-Hans = 从不
-    zh-Hant = 從不
-
   [place_description_title]
     tags = android,ios
     en = Place Description
@@ -23343,12 +23206,12 @@
 
   [pref_tts_speedcams_auto]
     comment = Speed camera settings menu option - Warn (about speedcams) if risk of exceeding speed limit
-    tags = android
+    tags = android,ios
     en = Warn if there is a risk of exceeding the speed limit
     af = Waarsku indien daar ’n risiko is dat die grens oorskry word
     ar = حذرني  إذا هناك احتمالية تجاوز الحد الأقصى للسرعة
     az = Sürət həddini aşmaq riski varsa, xəbərdarlıq edin
-    be = Папярэджваць калі ёсць рызыка перавышэння дазволенай хуткасці
+    be = Папярэджваць пры перавышэнні хуткасці
     bg = Предупреждава ако има риск от превишаване на ограничението на скоростта
     ca = Avisa si hi ha risc d'excedir el límit de velocitat
     cs = Upozorňovat pokud hrozí riziko překročení rychlosti
@@ -23376,20 +23239,20 @@
     pt = Avisar se houver risco de exceder o limite de velocidade
     pt-BR = Avisar se houver risco de ultrapassar o limite de velocidade
     ro = Avertizează dacă există riscul depășirii limitei de viteză
-    ru = Предупреждать если есть риск превышения скоростного лимита
+    ru = Предупреждать при превышении скорости
     sk = Upozornenie ak existuje riziko prekročenia rýchlostného limitu
     sv = Varna om det finns risk att överskrida hastighetsgränsen
     sw = Onyo iwapo kuna hatari yoyote ya kuzidi ukomo wa mwendo-kasi
     th = เตือนเกี่ยวกับกล้องตรวจจับความเร็วหากมีความเป็นได้ว่าจะขับเร็วเกิดกำหนด
     tr = Hız sınırını aşma riski varsa uyar
-    uk = Попереджати якщо є ризик перевищення швидкісного ліміту
+    uk = Попереджати при перевищенні швидкості
     vi = Cảnh báo nếu có nguy cơ vượt quá giới hạn tốc độ
     zh-Hans = 如果存在超出速度限制的风险，则对速度摄像头发出警告
     zh-Hant = 如果存在超出速度限制的風險，則對速度照相機發出警告
 
   [pref_tts_speedcams_always]
     comment = Speed camera settings menu option - Always warn (about speedcams)
-    tags = android
+    tags = android,ios
     en = Always warn
     af = Waarsku altyd
     ar = حذرني دائما من
@@ -23435,7 +23298,7 @@
 
   [pref_tts_speedcams_never]
     comment = Speed camera settings menu option - Never warn (about speedcams)
-    tags = android
+    tags = android,ios
     en = Never warn
     af = Waarsku nooit
     ar = لا تحذرني من أبداً
@@ -23478,51 +23341,6 @@
     vi = Không bao giờ cảnh báo
     zh-Hans = 永远不会对摄像头发出警告
     zh-Hant = 永遠不會對照相機發出警告
-
-  [speedcams_notice_message]
-    tags = ios
-    en = Auto - Warn about speedcams if there is a risk of exceeding the speed limit\nAlways - Always warn about speedcams\nNever - Never warn about speedcams
-    af = Outomaties – Waarsku oor spoedkameras indien daar ’n risiko is dat die grens oorskry word\nAltyd – Waarsku altyd oor spoedkameras\nNooit – Waarsku nooit oor spoedkameras
-    ar = تلقائياً - حذرني عن كاميرات السرعة إذا هناك احتمالية تجاوز الحد الأقصى للسرعة\nمفعل دائماً - حذرني دائما من كاميرات السرعة \n معطل دائماً - لا تحذرني من كاميرات السرعة أبداً
-    az = Avtomatik - Sürət həddini aşmaq riski varsa, sürət kameraları barədə xəbərdarlıq edin\nHəmişə sürət kameraları haqqında xəbərdar edin\nHeç sürət kameraları haqqında xəbərdar etməyin
-    be = Аўтаматычна - Папярэджваць пра камеры хуткасці, калі ёсць рызыка перавышэння дазволенай хуткасці.\nЗаўсёды - Заўсёды папярэджваць пра камеры\nНіколі - Ніколі не папярэджваць пра камеры
-    bg = Автоматично - Предупреждава се при камери за скорост, ако има риск от превишаване на ограничението на скоростта\nВинаги - Винаги се продупреждава при камери за скорост\nНикога - Никога не се предупреждава при камери за скорост
-    ca = Automàtic - Avisa dels radars si hi ha risc d'excedir el límit de velocitat\n Sempre - Sempre avisa dels radars\nMai - No avisa mai sobre els radars
-    cs = Automaticky - Upozorňovat na rychlostní radary, pokud hrozí riziko překročení rychlosti\nVždy - Vždy upozorňovat na rychlostní radary\nNikdy - Nikdy neupozorňovat na rychlostní radary
-    da = Auto - Advar om fartkameraer, hvis der er en risiko for, at hastighedsgrænsen overskrides\nAltid - Advar altid om fartkameraer\nAldrig - Advar aldrig om fartkameraer
-    de = Auto - Vor Blitzern warnen, wenn die Gefahr einer Geschwindigkeitsüberschreitung besteht\nImmer - Immer vor Blitzern warnen\nNiemals - Niemals vor Blitzern warnen
-    el = Αυτόματο- Να ειδοποιούμαι για κάμερες αν υπάρχει κίνδυνος να υπερβώ το όριο ταχύτητας\nΠάντα- Πάντα να ειδοποιούμαι για κάμερες\nΠοτέ- Ποτέ να μην ειδοποιούμαι για κάμερες
-    es = Auto - Advierte sobre las cámaras de velocidad si existe el riesgo de exceder el límite de velocidad\nSiempre - Siempre alerta sobre las cámaras\nNunca - Nunca advierte acerca de las cámaras
-    es-MX = Automático - Aviso de las cámaras de velocidad si existe el riesgo de exceder el límite de velocidad\nSiempre - Siempre dar aviso de las cámaras de velocidad\nNunca - Nunca dar aviso de las cámaras de velocidad
-    et = Automaatne - kiiruskaamerate hoiatused, kui on oht ületada piirkiirust\nAlati - hoiata alati kiiruskaamerate eest\nMitte kunagi - ära kunagi hoiata kiiruskaamerate eest
-    eu = Automatikoa - abiadura-kamerei buruz ohartarazten du abiadura muga gainditzeko arriskua badago\nBeti - beti abisatu kamerei buruz\nInoiz - inoiz ez abisatu kamerei buruz
-    fa = خودکار- در صورتی که خطر تجاوز از سرعت مجاز وجود داشت، نسبت به دوربین‌های کنترل سرعت هشدار دهد\nهمیشه-همیشه درباره دوربین‌های کنترل سرعت هشدار دهد\nهرگز-هرگز درباره دوربین‌های کنترل سرعت هشدار ندهد
-    fi = Auto - Varoita nopeuskameroista, jos tuntuu siltä, että nopeusrajan ylitys on mahdollista\nAina - Varoita kameroista aina\nEi koskaan - älä koskaan varoita kameroista
-    fr = Auto - Alerte sur les radars en cas de risque de dépassement de la limite de vitesse\nToujours - Toujours avertir des radars\nJamais - Jamais avertir à propos des radars
-    he = אוטומטי - הזהר מפני מצלמות מהירות אם יש חשש להפרזה במהירות\nתמיד - הזהר מפני מצלמות מהירות תמיד\nאף פעם - אל תזהיר מפני מצלמות מהירות אף פעם
-    hu = Automatikus - Figyelmeztetés a sebesség kamerákról, ha van kockázat a sebesség korlátozás megsértéséről\nMindig - Mindig figyelmeztet a kamerákról\nSoha - Soha ne figyelmezet a kamerákról
-    id = Auto - Peringatkan tentang kamera kecepatan saat terdapat risiko melebihi batas kecepatan\nSelalu - Selalu peringatkan tentang kamera kecepatan\nTidak pernah - Jangan pernah peringatkan tentang kamera kecepatan
-    it = Auto - Avvisare di autovelox in caso di rischio eccesso velocità\nSempre - Avvisare sempre di autovelox\nMai - Non avvisare mai di autovelox
-    ja = 自動－速度制限超過の危険性がある場合には、自動速度違反取締装置について警告します\n常時－自動速度違反取締装置について常に警告します\n無効－自動速度違反取締装置を警告しません
-    ko = 자동 - 속도 제한 초과 위험이 있을때 스피드캠에 대해 경고하기\n항상 - 스피드캠에 대해 항상 경고하기\n절대 아님 - 스피드캠에 대해 경고하지 않기
-    lt = Automatiškai - įspėti apie greičio matuoklius, jei yra greičio viršijimo rizika\nVisada - visada įspėti apie greičio matuoklius\nNiekada - neįspėti apie greičio matuoklius
-    mr = स्वयं - वेगमर्यादा ओलांडण्याचा धोका असल्यास वेगकॅमबद्दल चेतावणी द्या\nनेहमी - नेहमी वेगकॅमबद्दल चेतावणी द्या\nकधीही नाही - वेगकॅमबद्दल कधीही चेतावणी देऊ नका
-    nb = Auto - Advarsel om fartskamera hvis det er fare for å overskride fartsgrensen\nAlltid - Advar alltid om farskameraer\nAldri - Advar aldri om fartskameraer
-    nl = Auto - Waarschuw voor speedcams als er een risico bestaat dat de snelheidslimiet wordt overschreden\nAltijd - Waarschuw altijd voor flitspalen\nNooit - Waarschuw nooit over flitspalen
-    pl = Automatycznie – Ostrzegaj o fotoradarach, jeśli istnieje ryzyko przekroczenia ograniczenia prędkości\nZawsze – Zawsze ostrzegaj o fotoradarach\nNigdy – Nigdy nie ostrzegaj o fotoradarach
-    pt = Automático - avisa sobre os radares de velocidade se houver risco de exceder o limite de velocidade\nSempre - avisa sempre sobre os radares\nNunca - nunca avisar sobre os radares
-    pt-BR = Automático - Avisar sobre radar se houver risco de ultrapassar o limite de velocidade\nSempre - Sempre avisar sobre radares\nNunca - Nunca avisar sobre radares
-    ro = Auto - Avertizează cu privire la radare dacă există riscul depășirii limitei de viteză\nMereu - Avertizează mereu cu privire la radare\nNiciodată - Nu avertiza niciodată cu privire la radare
-    ru = Авто - Предупреждать о камерах скорости, если есть риск превышения скоростного лимита\nВсегда - Всегда предупреждать о камерах\nНикогда - Никогда не предупреждать о камерах
-    sk = Automaticky - Upozornenie na rýchlostné kamery, ak existuje riziko prekročenia rýchlostného limitu\nVždy - Vždy upozorniť na rýchlostné kamery\nNikdy - Nikdy neupozorňovať na rýchlostné kamery
-    sv = Auto - Varna om fartkameror om det finns risk att överskrida hastighetsgränsen\nAlltid - Varna alltid om kameror\nAldrig - Varna aldrig om kameror
-    sw = Auto - Onyo la kuhusu kamera ya mwendo-kasi iwapo kuna hatari yoyote ya kuzidi ukomo wa mwendo-kasi\nMara kwa Mara - Daima onya kuhusu kamera za mwendo-kasi\nKamwe - Kamwe usionye kuhusu kamera za mwendo-kasi
-    th = อัตโนมัติ - เตือนเกี่ยวกับกล้องตรวจจับความเร็วหากมีความเป็นได้ว่าจะขับเร็วเกิดกำหนด\nทุกครั้ง - เตือนเกี่ยวกับกล้องตรวจจับความเร็วเสมอ\nไม่ต้องเตือน - ไม่เคยเตือนเกี่ยวกับกล้องตรวจจับความเร็ว
-    tr = Otomatik - Hız sınırını aşma riski varsa hız kameraları hakkında uyar\nHer zaman - Hız kameraları hakkında her zaman uyar\nAsla - Hız kameraları hakkında hiç bir zaman uyarma
-    uk = Авто - Попереджати про камери швидкості, якщо є ризик перевищення швидкісного ліміту\nЗавжди - Завжди попереджати про камери\nНіколи - Ніколи не попереджати про камери
-    vi = Tự động - Cảnh báo về speedcam nếu có nguy cơ vượt quá giới hạn tốc độ\nLuôn luôn - Luôn cảnh báo về speedcams\nKhông bao giờ - Không bao giờ cảnh báo về speedcams
-    zh-Hans = 自动 - 如果存在超出速度限制的风险，则对速度摄像头发出警告\n总是 - 始终提醒摄像头\n从不 - 永远不会对摄像头发出警告
-    zh-Hant = 自動 - 如果存在超出速度限制的風險，則對速度照相機發出警告\n總是 - 始終提醒照相機\n從不 - 永遠不會對照相機發出警告
 
   [power_managment_title]
     tags = android,ios

--- a/iphone/Maps/Classes/CustomViews/NavigationDashboard/Views/NavigationControlView.xib
+++ b/iphone/Maps/Classes/CustomViews/NavigationDashboard/Views/NavigationControlView.xib
@@ -271,7 +271,7 @@
                             </state>
                             <userDefinedRuntimeAttributes>
                                 <userDefinedRuntimeAttribute type="string" keyPath="styleName" value="FlatRedButton:regular17"/>
-                                <userDefinedRuntimeAttribute type="string" keyPath="localizedText" value="stop"/>
+                                <userDefinedRuntimeAttribute type="string" keyPath="localizedText" value="navigation_stop_button"/>
                             </userDefinedRuntimeAttributes>
                             <connections>
                                 <action selector="stopRoutingButtonAction" destination="-1" eventType="touchUpInside" id="Xvf-fv-3GR"/>

--- a/iphone/Maps/LocalizedStrings/ar.lproj/Localizable.strings
+++ b/iphone/Maps/LocalizedStrings/ar.lproj/Localizable.strings
@@ -779,8 +779,6 @@
 
 "downloader_no_downloaded_maps_message" = "قم بتنزيل خرائط للبحث عن مكان واستخدام الملاحة بدون اتصال بالإنترنت.";
 
-"stop" = "إيقاف";
-
 "current_location_unknown_error_title" = "الموقع الحالي غير معروف.";
 
 "current_location_unknown_error_message" = "حدث خطأ أثناء البحث عن موقعك. تأكد من أن جهازك يعمل بشكل صحيح وأعد المحاولة لاحقًا.";
@@ -1035,15 +1033,16 @@
 
 "speedcams_alert_title" = "تحذيرات كاميرات السرعة";
 
-/* Generic «Always» string */
-"always" = "مفعل دائماً";
-
-/* Generic «Never» string */
-"never" = "معطل دائماً";
-
 "place_description_title" = "وصف المكان";
 
-"speedcams_notice_message" = "تلقائياً - حذرني عن كاميرات السرعة إذا هناك احتمالية تجاوز الحد الأقصى للسرعة\nمفعل دائماً - حذرني دائما من كاميرات السرعة \n معطل دائماً - لا تحذرني من كاميرات السرعة أبداً";
+/* Speed camera settings menu option - Warn (about speedcams) if risk of exceeding speed limit */
+"pref_tts_speedcams_auto" = "حذرني  إذا هناك احتمالية تجاوز الحد الأقصى للسرعة";
+
+/* Speed camera settings menu option - Always warn (about speedcams) */
+"pref_tts_speedcams_always" = "حذرني دائما من";
+
+/* Speed camera settings menu option - Never warn (about speedcams) */
+"pref_tts_speedcams_never" = "لا تحذرني من أبداً";
 
 "power_managment_title" = "وضع توفير الطاقة";
 

--- a/iphone/Maps/LocalizedStrings/az.lproj/Localizable.strings
+++ b/iphone/Maps/LocalizedStrings/az.lproj/Localizable.strings
@@ -779,8 +779,6 @@
 
 "downloader_no_downloaded_maps_message" = "Ünvanları tapmaq və oflayn naviqasiya etmək üçün xəritələri endirin.";
 
-"stop" = "Dayan";
-
 "current_location_unknown_error_title" = "Cari yer məlum deyil.";
 
 "current_location_unknown_error_message" = "Məkanınızı axtararkən xəta baş verdi. Cihazınızın düzgün işlədiyini yoxlayın və sonra yenidən cəhd edin.";
@@ -1035,15 +1033,16 @@
 
 "speedcams_alert_title" = "Sürət kameraları";
 
-/* Generic «Always» string */
-"always" = "Həmişə";
-
-/* Generic «Never» string */
-"never" = "Heç vaxt";
-
 "place_description_title" = "Məkan Təsviri";
 
-"speedcams_notice_message" = "Avtomatik - Sürət həddini aşmaq riski varsa, sürət kameraları barədə xəbərdarlıq edin\nHəmişə sürət kameraları haqqında xəbərdar edin\nHeç sürət kameraları haqqında xəbərdar etməyin";
+/* Speed camera settings menu option - Warn (about speedcams) if risk of exceeding speed limit */
+"pref_tts_speedcams_auto" = "Sürət həddini aşmaq riski varsa, xəbərdarlıq edin";
+
+/* Speed camera settings menu option - Always warn (about speedcams) */
+"pref_tts_speedcams_always" = "Həmişə xəbərdar edin";
+
+/* Speed camera settings menu option - Never warn (about speedcams) */
+"pref_tts_speedcams_never" = "Heç xəbərdar etməyin";
 
 "power_managment_title" = "Enerji qənaət rejimi";
 

--- a/iphone/Maps/LocalizedStrings/be.lproj/Localizable.strings
+++ b/iphone/Maps/LocalizedStrings/be.lproj/Localizable.strings
@@ -779,8 +779,6 @@
 
 "downloader_no_downloaded_maps_message" = "Спампуйце мапы, каб шукаць месцы і карыстацца навігацыяй без інтэрнэту.";
 
-"stop" = "Спыніць";
-
 "current_location_unknown_error_title" = "Месцазнаходжанне невядома.";
 
 "current_location_unknown_error_message" = "Адбылася памылка пры пошуку месцазнаходжання. Праверце, што ваша прылада працуе як трэба, і паспрабуйце зноў.";
@@ -1035,15 +1033,16 @@
 
 "speedcams_alert_title" = "Камеры хуткасці";
 
-/* Generic «Always» string */
-"always" = "Заўсёды";
-
-/* Generic «Never» string */
-"never" = "Ніколі";
-
 "place_description_title" = "Апісанне месца";
 
-"speedcams_notice_message" = "Аўтаматычна - Папярэджваць пра камеры хуткасці, калі ёсць рызыка перавышэння дазволенай хуткасці.\nЗаўсёды - Заўсёды папярэджваць пра камеры\nНіколі - Ніколі не папярэджваць пра камеры";
+/* Speed camera settings menu option - Warn (about speedcams) if risk of exceeding speed limit */
+"pref_tts_speedcams_auto" = "Папярэджваць пры перавышэнні хуткасці";
+
+/* Speed camera settings menu option - Always warn (about speedcams) */
+"pref_tts_speedcams_always" = "Заўсёды папярэджваць";
+
+/* Speed camera settings menu option - Never warn (about speedcams) */
+"pref_tts_speedcams_never" = "Ніколі не папярэджваць";
 
 "power_managment_title" = "Рэжым захавання энергіі";
 

--- a/iphone/Maps/LocalizedStrings/bg.lproj/Localizable.strings
+++ b/iphone/Maps/LocalizedStrings/bg.lproj/Localizable.strings
@@ -779,8 +779,6 @@
 
 "downloader_no_downloaded_maps_message" = "Изтеглете картите, от които се нуждаете, за да намирате места и да навигирате без интернет.";
 
-"stop" = "Стоп";
-
 "current_location_unknown_error_title" = "Настоящото местоположение е неизвестно.";
 
 "current_location_unknown_error_message" = "Възникна грешка при търсенето на вашето местоположение. Проверете дали устройството ви работи правилно и опитайте отново по-късно.";
@@ -1035,15 +1033,16 @@
 
 "speedcams_alert_title" = "Камери за скорост";
 
-/* Generic «Always» string */
-"always" = "Винаги";
-
-/* Generic «Never» string */
-"never" = "Никога";
-
 "place_description_title" = "Описание на мястото";
 
-"speedcams_notice_message" = "Автоматично - Предупреждава се при камери за скорост, ако има риск от превишаване на ограничението на скоростта\nВинаги - Винаги се продупреждава при камери за скорост\nНикога - Никога не се предупреждава при камери за скорост";
+/* Speed camera settings menu option - Warn (about speedcams) if risk of exceeding speed limit */
+"pref_tts_speedcams_auto" = "Предупреждава ако има риск от превишаване на ограничението на скоростта";
+
+/* Speed camera settings menu option - Always warn (about speedcams) */
+"pref_tts_speedcams_always" = "Винаги се продупреждава";
+
+/* Speed camera settings menu option - Never warn (about speedcams) */
+"pref_tts_speedcams_never" = "Никога не се предупреждава";
 
 "power_managment_title" = "Режим пестене на енергия";
 

--- a/iphone/Maps/LocalizedStrings/ca.lproj/Localizable.strings
+++ b/iphone/Maps/LocalizedStrings/ca.lproj/Localizable.strings
@@ -779,8 +779,6 @@
 
 "downloader_no_downloaded_maps_message" = "Baixeu mapes per a cercar una ubicacio i usar la navegació sense connexió.";
 
-"stop" = "Atura't";
-
 "current_location_unknown_error_title" = "Es desconeix la ubicació actual.";
 
 "current_location_unknown_error_message" = "S'ha produït un error en cercar la vostra ubicació. Comproveu que l'aparel funciona correctament i torneu-ho a intentar.";
@@ -1035,15 +1033,16 @@
 
 "speedcams_alert_title" = "Radars";
 
-/* Generic «Always» string */
-"always" = "Sempre";
-
-/* Generic «Never» string */
-"never" = "Mai";
-
 "place_description_title" = "Descripció del lloc";
 
-"speedcams_notice_message" = "Automàtic - Avisa dels radars si hi ha risc d'excedir el límit de velocitat\n Sempre - Sempre avisa dels radars\nMai - No avisa mai sobre els radars";
+/* Speed camera settings menu option - Warn (about speedcams) if risk of exceeding speed limit */
+"pref_tts_speedcams_auto" = "Avisa si hi ha risc d'excedir el límit de velocitat";
+
+/* Speed camera settings menu option - Always warn (about speedcams) */
+"pref_tts_speedcams_always" = "Sempre avisa";
+
+/* Speed camera settings menu option - Never warn (about speedcams) */
+"pref_tts_speedcams_never" = "No n'avisis mai";
 
 "power_managment_title" = "Mode d'estalvi d'energia";
 

--- a/iphone/Maps/LocalizedStrings/cs.lproj/Localizable.strings
+++ b/iphone/Maps/LocalizedStrings/cs.lproj/Localizable.strings
@@ -779,8 +779,6 @@
 
 "downloader_no_downloaded_maps_message" = "Stáhněte si mapy a hledejte cestu a její cíl, i když jste offline.";
 
-"stop" = "Zastavit";
-
 "current_location_unknown_error_title" = "Současná poloha nezjištěna.";
 
 "current_location_unknown_error_message" = "Při zjišťování současné polohy došlo k chybě. Zkontrolujte, že nedošlo k chybě zařízení a pokus prosím opakujte později.";
@@ -1035,15 +1033,16 @@
 
 "speedcams_alert_title" = "Detektory rychlosti";
 
-/* Generic «Always» string */
-"always" = "Vždy";
-
-/* Generic «Never» string */
-"never" = "Nikdy";
-
 "place_description_title" = "Popis místa";
 
-"speedcams_notice_message" = "Automaticky - Upozorňovat na rychlostní radary, pokud hrozí riziko překročení rychlosti\nVždy - Vždy upozorňovat na rychlostní radary\nNikdy - Nikdy neupozorňovat na rychlostní radary";
+/* Speed camera settings menu option - Warn (about speedcams) if risk of exceeding speed limit */
+"pref_tts_speedcams_auto" = "Upozorňovat pokud hrozí riziko překročení rychlosti";
+
+/* Speed camera settings menu option - Always warn (about speedcams) */
+"pref_tts_speedcams_always" = "Vždy upozorňovat";
+
+/* Speed camera settings menu option - Never warn (about speedcams) */
+"pref_tts_speedcams_never" = "Nikdy neupozorňovat";
 
 "power_managment_title" = "Režim spořič baterie";
 

--- a/iphone/Maps/LocalizedStrings/da.lproj/Localizable.strings
+++ b/iphone/Maps/LocalizedStrings/da.lproj/Localizable.strings
@@ -779,8 +779,6 @@
 
 "downloader_no_downloaded_maps_message" = "Download kort for at finde position og navigere offline.";
 
-"stop" = "Stop";
-
 "current_location_unknown_error_title" = "Aktuel position er ukendt.";
 
 "current_location_unknown_error_message" = "Der opstod en fejl under søgning efter din position. Kontrollér at din enhed fungerer korrekt, og prøv igen senere.";
@@ -1035,15 +1033,16 @@
 
 "speedcams_alert_title" = "Fartkameraer";
 
-/* Generic «Always» string */
-"always" = "Altid";
-
-/* Generic «Never» string */
-"never" = "Aldrig";
-
 "place_description_title" = "Beskrivelse af sted";
 
-"speedcams_notice_message" = "Auto - Advar om fartkameraer, hvis der er en risiko for, at hastighedsgrænsen overskrides\nAltid - Advar altid om fartkameraer\nAldrig - Advar aldrig om fartkameraer";
+/* Speed camera settings menu option - Warn (about speedcams) if risk of exceeding speed limit */
+"pref_tts_speedcams_auto" = "Advar hvis der er en risiko for, at hastighedsgrænsen overskrides";
+
+/* Speed camera settings menu option - Always warn (about speedcams) */
+"pref_tts_speedcams_always" = "Advar altid";
+
+/* Speed camera settings menu option - Never warn (about speedcams) */
+"pref_tts_speedcams_never" = "Advar aldrig";
 
 "power_managment_title" = "Strømsparetilstand";
 

--- a/iphone/Maps/LocalizedStrings/de.lproj/Localizable.strings
+++ b/iphone/Maps/LocalizedStrings/de.lproj/Localizable.strings
@@ -779,8 +779,6 @@
 
 "downloader_no_downloaded_maps_message" = "Laden Sie die für die Suche nach Orten erforderlichen Karten und verwenden Sie die Navigation offline.";
 
-"stop" = "Anhalten";
-
 "current_location_unknown_error_title" = "Standort nicht gefunden.";
 
 "current_location_unknown_error_message" = "Bei der Standortsuche ist ein unbekannter Fehler aufgetreten. Prüfen Sie die Funktionstüchtigkeit Ihres Geräts und versuchen Sie es etwas später erneut.";
@@ -1035,15 +1033,16 @@
 
 "speedcams_alert_title" = "Blitzer";
 
-/* Generic «Always» string */
-"always" = "Immer";
-
-/* Generic «Never» string */
-"never" = "Niemals";
-
 "place_description_title" = "Ortsbeschreibung";
 
-"speedcams_notice_message" = "Auto - Vor Blitzern warnen, wenn die Gefahr einer Geschwindigkeitsüberschreitung besteht\nImmer - Immer vor Blitzern warnen\nNiemals - Niemals vor Blitzern warnen";
+/* Speed camera settings menu option - Warn (about speedcams) if risk of exceeding speed limit */
+"pref_tts_speedcams_auto" = "Warnen wenn die Gefahr einer Geschwindigkeitsüberschreitung besteht";
+
+/* Speed camera settings menu option - Always warn (about speedcams) */
+"pref_tts_speedcams_always" = "Immer warnen";
+
+/* Speed camera settings menu option - Never warn (about speedcams) */
+"pref_tts_speedcams_never" = "Niemals warnen";
 
 "power_managment_title" = "Stromsparmodus";
 

--- a/iphone/Maps/LocalizedStrings/el.lproj/Localizable.strings
+++ b/iphone/Maps/LocalizedStrings/el.lproj/Localizable.strings
@@ -779,8 +779,6 @@
 
 "downloader_no_downloaded_maps_message" = "Κατεβάστε χάρτες για να αναζητήσετε μια τοποθεσία και να χρησιμοποιήσετε την πλοήγησης χωρίς σύνδεση.";
 
-"stop" = "Στοπ";
-
 "current_location_unknown_error_title" = "Η τρέχουσα τοποθεσία είναι άγνωστη.";
 
 "current_location_unknown_error_message" = "Παρουσιάστηκε σφάλμα κατά την αναζήτηση της τοποθεσίας σας. Ελέγξτε αν η συσκευή σας λειτουργεί κανονικά και δοκιμάστε ξανά αργότερα.";
@@ -1035,15 +1033,16 @@
 
 "speedcams_alert_title" = "Κάμερες Ταχύτητας";
 
-/* Generic «Always» string */
-"always" = "Πάντα";
-
-/* Generic «Never» string */
-"never" = "Ποτέ";
-
 "place_description_title" = "Περιγραφή μέρους";
 
-"speedcams_notice_message" = "Αυτόματο- Να ειδοποιούμαι για κάμερες αν υπάρχει κίνδυνος να υπερβώ το όριο ταχύτητας\nΠάντα- Πάντα να ειδοποιούμαι για κάμερες\nΠοτέ- Ποτέ να μην ειδοποιούμαι για κάμερες";
+/* Speed camera settings menu option - Warn (about speedcams) if risk of exceeding speed limit */
+"pref_tts_speedcams_auto" = "Να ειδοποιούμαι αν υπάρχει κίνδυνος να υπερβώ το όριο ταχύτητας";
+
+/* Speed camera settings menu option - Always warn (about speedcams) */
+"pref_tts_speedcams_always" = "Πάντα να ειδοποιούμαι";
+
+/* Speed camera settings menu option - Never warn (about speedcams) */
+"pref_tts_speedcams_never" = "Ποτέ να μην ειδοποιούμαι";
 
 "power_managment_title" = "Λειτουργία εξοικονόμησης ενέργειας";
 

--- a/iphone/Maps/LocalizedStrings/en-GB.lproj/Localizable.strings
+++ b/iphone/Maps/LocalizedStrings/en-GB.lproj/Localizable.strings
@@ -779,8 +779,6 @@
 
 "downloader_no_downloaded_maps_message" = "Download maps to search and navigate offline.";
 
-"stop" = "Stop";
-
 "current_location_unknown_error_title" = "Current location is unknown.";
 
 "current_location_unknown_error_message" = "An error occurred while determining your location. Check that your device is working properly and try again later.";
@@ -1035,15 +1033,16 @@
 
 "speedcams_alert_title" = "Speed cameras";
 
-/* Generic «Always» string */
-"always" = "Always";
-
-/* Generic «Never» string */
-"never" = "Never";
-
 "place_description_title" = "Place Description";
 
-"speedcams_notice_message" = "Auto - Warn about speedcams if there is a risk of exceeding the speed limit\nAlways - Always warn about speedcams\nNever - Never warn about speedcams";
+/* Speed camera settings menu option - Warn (about speedcams) if risk of exceeding speed limit */
+"pref_tts_speedcams_auto" = "Warn if there is a risk of exceeding the speed limit";
+
+/* Speed camera settings menu option - Always warn (about speedcams) */
+"pref_tts_speedcams_always" = "Always warn";
+
+/* Speed camera settings menu option - Never warn (about speedcams) */
+"pref_tts_speedcams_never" = "Never warn";
 
 "power_managment_title" = "Power saving mode";
 

--- a/iphone/Maps/LocalizedStrings/en.lproj/Localizable.strings
+++ b/iphone/Maps/LocalizedStrings/en.lproj/Localizable.strings
@@ -779,8 +779,6 @@
 
 "downloader_no_downloaded_maps_message" = "Download maps to search and navigate offline.";
 
-"stop" = "Stop";
-
 "current_location_unknown_error_title" = "Current location is unknown.";
 
 "current_location_unknown_error_message" = "An error occurred while determining your location. Check that your device is working properly and try again later.";
@@ -1035,15 +1033,16 @@
 
 "speedcams_alert_title" = "Speed cameras";
 
-/* Generic «Always» string */
-"always" = "Always";
-
-/* Generic «Never» string */
-"never" = "Never";
-
 "place_description_title" = "Place Description";
 
-"speedcams_notice_message" = "Auto - Warn about speedcams if there is a risk of exceeding the speed limit\nAlways - Always warn about speedcams\nNever - Never warn about speedcams";
+/* Speed camera settings menu option - Warn (about speedcams) if risk of exceeding speed limit */
+"pref_tts_speedcams_auto" = "Warn if there is a risk of exceeding the speed limit";
+
+/* Speed camera settings menu option - Always warn (about speedcams) */
+"pref_tts_speedcams_always" = "Always warn";
+
+/* Speed camera settings menu option - Never warn (about speedcams) */
+"pref_tts_speedcams_never" = "Never warn";
 
 "power_managment_title" = "Power saving mode";
 

--- a/iphone/Maps/LocalizedStrings/es-MX.lproj/Localizable.strings
+++ b/iphone/Maps/LocalizedStrings/es-MX.lproj/Localizable.strings
@@ -779,8 +779,6 @@
 
 "downloader_no_downloaded_maps_message" = "Descargue mapas para encontrar la ubicación y navegar sin conexión.";
 
-"stop" = "Detener";
-
 "current_location_unknown_error_title" = "La ubicación actual es desconocida.";
 
 "current_location_unknown_error_message" = "Se ha producido un error al buscar su ubicación. Compruebe que su dispositivo funciona correctamente e inténtelo más tarde.";
@@ -1035,15 +1033,16 @@
 
 "speedcams_alert_title" = "Cámaras de velocidad";
 
-/* Generic «Always» string */
-"always" = "Siempre";
-
-/* Generic «Never» string */
-"never" = "Nunca";
-
 "place_description_title" = "Descripción de lugares";
 
-"speedcams_notice_message" = "Automático - Aviso de las cámaras de velocidad si existe el riesgo de exceder el límite de velocidad\nSiempre - Siempre dar aviso de las cámaras de velocidad\nNunca - Nunca dar aviso de las cámaras de velocidad";
+/* Speed camera settings menu option - Warn (about speedcams) if risk of exceeding speed limit */
+"pref_tts_speedcams_auto" = "Avisar si existe el riesgo de exceder el límite de velocidad";
+
+/* Speed camera settings menu option - Always warn (about speedcams) */
+"pref_tts_speedcams_always" = "Siempre dar aviso";
+
+/* Speed camera settings menu option - Never warn (about speedcams) */
+"pref_tts_speedcams_never" = "Nunca dar aviso";
 
 "power_managment_title" = "Modo de ahorro de energía";
 

--- a/iphone/Maps/LocalizedStrings/es.lproj/Localizable.strings
+++ b/iphone/Maps/LocalizedStrings/es.lproj/Localizable.strings
@@ -779,8 +779,6 @@
 
 "downloader_no_downloaded_maps_message" = "Descargue mapas para encontrar la ubicación y navegar sin conexión.";
 
-"stop" = "Detener";
-
 "current_location_unknown_error_title" = "La ubicación actual es desconocida.";
 
 "current_location_unknown_error_message" = "Se ha producido un error al buscar su ubicación. Compruebe que su dispositivo funciona correctamente e inténtelo más tarde.";
@@ -1035,15 +1033,16 @@
 
 "speedcams_alert_title" = "Cámaras de velocidad";
 
-/* Generic «Always» string */
-"always" = "Siempre";
-
-/* Generic «Never» string */
-"never" = "Nunca";
-
 "place_description_title" = "Descripción del lugar";
 
-"speedcams_notice_message" = "Auto - Advierte sobre las cámaras de velocidad si existe el riesgo de exceder el límite de velocidad\nSiempre - Siempre alerta sobre las cámaras\nNunca - Nunca advierte acerca de las cámaras";
+/* Speed camera settings menu option - Warn (about speedcams) if risk of exceeding speed limit */
+"pref_tts_speedcams_auto" = "Alertar si existe el riesgo de exceder el límite de velocidad";
+
+/* Speed camera settings menu option - Always warn (about speedcams) */
+"pref_tts_speedcams_always" = "Alertar siempre";
+
+/* Speed camera settings menu option - Never warn (about speedcams) */
+"pref_tts_speedcams_never" = "No alertar nunca";
 
 "power_managment_title" = "Modo de ahorro de energía";
 

--- a/iphone/Maps/LocalizedStrings/et.lproj/Localizable.strings
+++ b/iphone/Maps/LocalizedStrings/et.lproj/Localizable.strings
@@ -779,8 +779,6 @@
 
 "downloader_no_downloaded_maps_message" = "Lae alla kaardid asukoha otsimiseks ja võrguühenduseta navigeerimise kasutamiseks.";
 
-"stop" = "Lõpeta";
-
 "current_location_unknown_error_title" = "Hetkeasukoht on teadmata.";
 
 "current_location_unknown_error_message" = "Teie asukoha otsimisel ilmnes viga. Kontrollige, kas teie seade töötab korralikult ja proovige hiljem uuesti.";
@@ -1035,15 +1033,16 @@
 
 "speedcams_alert_title" = "Kiiruskaamerad";
 
-/* Generic «Always» string */
-"always" = "Alati";
-
-/* Generic «Never» string */
-"never" = "Mitte kunagi";
-
 "place_description_title" = "Koha kirjeldus";
 
-"speedcams_notice_message" = "Automaatne - kiiruskaamerate hoiatused, kui on oht ületada piirkiirust\nAlati - hoiata alati kiiruskaamerate eest\nMitte kunagi - ära kunagi hoiata kiiruskaamerate eest";
+/* Speed camera settings menu option - Warn (about speedcams) if risk of exceeding speed limit */
+"pref_tts_speedcams_auto" = "Hoiatused kui on oht ületada piirkiirust";
+
+/* Speed camera settings menu option - Always warn (about speedcams) */
+"pref_tts_speedcams_always" = "Hoiata alati eest";
+
+/* Speed camera settings menu option - Never warn (about speedcams) */
+"pref_tts_speedcams_never" = "Ära kunagi hoiata eest";
 
 "power_managment_title" = "Energiasäästlik režiim";
 

--- a/iphone/Maps/LocalizedStrings/eu.lproj/Localizable.strings
+++ b/iphone/Maps/LocalizedStrings/eu.lproj/Localizable.strings
@@ -779,8 +779,6 @@
 
 "downloader_no_downloaded_maps_message" = "Deskargatu mapak kokapena aurkitzeko eta lineaz kanpo nabigatzeko.";
 
-"stop" = "Gelditu";
-
 "current_location_unknown_error_title" = "Uneko kokapena ezezaguna da.";
 
 "current_location_unknown_error_message" = "Errore bat gertatu da zure kokapena bilatzean. Egiaztatu gailua behar bezala dabilela eta saiatu berriro geroago.";
@@ -1035,15 +1033,16 @@
 
 "speedcams_alert_title" = "Abiadura kamerak";
 
-/* Generic «Always» string */
-"always" = "Beti";
-
-/* Generic «Never» string */
-"never" = "Inoiz ez";
-
 "place_description_title" = "Tokiaren deskribapena";
 
-"speedcams_notice_message" = "Automatikoa - abiadura-kamerei buruz ohartarazten du abiadura muga gainditzeko arriskua badago\nBeti - beti abisatu kamerei buruz\nInoiz - inoiz ez abisatu kamerei buruz";
+/* Speed camera settings menu option - Warn (about speedcams) if risk of exceeding speed limit */
+"pref_tts_speedcams_auto" = "Ohartarazten du abiadura muga gainditzeko arriskua badago";
+
+/* Speed camera settings menu option - Always warn (about speedcams) */
+"pref_tts_speedcams_always" = "Beti abisatu";
+
+/* Speed camera settings menu option - Never warn (about speedcams) */
+"pref_tts_speedcams_never" = "Inoiz ez abisatu";
 
 "power_managment_title" = "Energia aurrezteko modua";
 

--- a/iphone/Maps/LocalizedStrings/fa.lproj/Localizable.strings
+++ b/iphone/Maps/LocalizedStrings/fa.lproj/Localizable.strings
@@ -779,8 +779,6 @@
 
 "downloader_no_downloaded_maps_message" = "برای جست وجو یک مکان و استفاده از قابلیت ناوبری، نقشه‌ها را دانلود کنید.";
 
-"stop" = "توقف";
-
 "current_location_unknown_error_title" = "مکان فعلیتان ناشناس است.";
 
 "current_location_unknown_error_message" = "خطایی در هنگام جست وجوی مکان شمارخ داده است.بررسی کنیید دستگاهتان به درستی کار می کند و دوباره تلاش کنید.";
@@ -1035,15 +1033,16 @@
 
 "speedcams_alert_title" = "دوربین‌های سرعت";
 
-/* Generic «Always» string */
-"always" = "همیشه";
-
-/* Generic «Never» string */
-"never" = "هرگز";
-
 "place_description_title" = "توضیحات محل";
 
-"speedcams_notice_message" = "خودکار- در صورتی که خطر تجاوز از سرعت مجاز وجود داشت، نسبت به دوربین‌های کنترل سرعت هشدار دهد\nهمیشه-همیشه درباره دوربین‌های کنترل سرعت هشدار دهد\nهرگز-هرگز درباره دوربین‌های کنترل سرعت هشدار ندهد";
+/* Speed camera settings menu option - Warn (about speedcams) if risk of exceeding speed limit */
+"pref_tts_speedcams_auto" = "در صورتی که خطر تجاوز از سرعت مجاز وجود داشت، نسبت هشدار دهد";
+
+/* Speed camera settings menu option - Always warn (about speedcams) */
+"pref_tts_speedcams_always" = "همیشه هشدار دهد";
+
+/* Speed camera settings menu option - Never warn (about speedcams) */
+"pref_tts_speedcams_never" = "هرگز  هشدار ندهد";
 
 "power_managment_title" = "حالت ذخیره انرژی";
 

--- a/iphone/Maps/LocalizedStrings/fi.lproj/Localizable.strings
+++ b/iphone/Maps/LocalizedStrings/fi.lproj/Localizable.strings
@@ -779,8 +779,6 @@
 
 "downloader_no_downloaded_maps_message" = "Lataa karttoja löytääksesi paikkoja ja navigoidaksesi offline-tilassa.";
 
-"stop" = "Pysäytä";
-
 "current_location_unknown_error_title" = "Nykyinen sijainti on tuntematon.";
 
 "current_location_unknown_error_message" = "Tapahtui virhe määritettäessä sijaintiasi. Tarkista laitteesi ja yritä myöhemmin uudelleen.";
@@ -1035,15 +1033,16 @@
 
 "speedcams_alert_title" = "Nopeuskamerat";
 
-/* Generic «Always» string */
-"always" = "Aina";
-
-/* Generic «Never» string */
-"never" = "Ei koskaan";
-
 "place_description_title" = "Paikan kuvaus";
 
-"speedcams_notice_message" = "Auto - Varoita nopeuskameroista, jos tuntuu siltä, että nopeusrajan ylitys on mahdollista\nAina - Varoita kameroista aina\nEi koskaan - älä koskaan varoita kameroista";
+/* Speed camera settings menu option - Warn (about speedcams) if risk of exceeding speed limit */
+"pref_tts_speedcams_auto" = "Varoita jos tuntuu siltä, että nopeusrajan ylitys on mahdollista";
+
+/* Speed camera settings menu option - Always warn (about speedcams) */
+"pref_tts_speedcams_always" = "Varoita aina";
+
+/* Speed camera settings menu option - Never warn (about speedcams) */
+"pref_tts_speedcams_never" = "Älä koskaan varoita";
 
 "power_managment_title" = "Virransäästötila";
 

--- a/iphone/Maps/LocalizedStrings/fr.lproj/Localizable.strings
+++ b/iphone/Maps/LocalizedStrings/fr.lproj/Localizable.strings
@@ -779,8 +779,6 @@
 
 "downloader_no_downloaded_maps_message" = "Téléchargez des cartes pour rechercher un lieu et utiliser la navigation hors ligne";
 
-"stop" = "Arrêter";
-
 "current_location_unknown_error_title" = "L'emplacement actuel est inconnu.";
 
 "current_location_unknown_error_message" = "Une erreur est survenue lors de la recherche de votre emplacement. Vérifiez que le périphérique fonctionne correctement et réessayez ultérieurement";
@@ -1035,15 +1033,16 @@
 
 "speedcams_alert_title" = "Radars de vitesse";
 
-/* Generic «Always» string */
-"always" = "Toujours";
-
-/* Generic «Never» string */
-"never" = "Jamais";
-
 "place_description_title" = "Description d'endroit";
 
-"speedcams_notice_message" = "Auto - Alerte sur les radars en cas de risque de dépassement de la limite de vitesse\nToujours - Toujours avertir des radars\nJamais - Jamais avertir à propos des radars";
+/* Speed camera settings menu option - Warn (about speedcams) if risk of exceeding speed limit */
+"pref_tts_speedcams_auto" = "Alerte sonore en cas de risque de dépassement de la limite de vitesse";
+
+/* Speed camera settings menu option - Always warn (about speedcams) */
+"pref_tts_speedcams_always" = "Toujours avertir";
+
+/* Speed camera settings menu option - Never warn (about speedcams) */
+"pref_tts_speedcams_never" = "Jamais avertir";
 
 "power_managment_title" = "Mode économie d'énergie";
 

--- a/iphone/Maps/LocalizedStrings/he.lproj/Localizable.strings
+++ b/iphone/Maps/LocalizedStrings/he.lproj/Localizable.strings
@@ -779,8 +779,6 @@
 
 "downloader_no_downloaded_maps_message" = "הורד מפה כדי לחפש ולנווט ללא חיבור לאינטרנט.";
 
-"stop" = "הפסק";
-
 "current_location_unknown_error_title" = "המיקום הנוכחי לא ידוע.";
 
 "current_location_unknown_error_message" = "אירעה שגיאה בעת איתור המיקום שלך. יש לוודא שהמכשיר שלך פועל כראוי ולנסות שנית מאוחר יותר.";
@@ -1035,15 +1033,16 @@
 
 "speedcams_alert_title" = "מצלמות מהירות";
 
-/* Generic «Always» string */
-"always" = "תמיד";
-
-/* Generic «Never» string */
-"never" = "אף פעם";
-
 "place_description_title" = "תיאור מיקום";
 
-"speedcams_notice_message" = "אוטומטי - הזהר מפני מצלמות מהירות אם יש חשש להפרזה במהירות\nתמיד - הזהר מפני מצלמות מהירות תמיד\nאף פעם - אל תזהיר מפני מצלמות מהירות אף פעם";
+/* Speed camera settings menu option - Warn (about speedcams) if risk of exceeding speed limit */
+"pref_tts_speedcams_auto" = "הזהר אם יש חשש להפרזה במהירות";
+
+/* Speed camera settings menu option - Always warn (about speedcams) */
+"pref_tts_speedcams_always" = "הזהר  תמיד";
+
+/* Speed camera settings menu option - Never warn (about speedcams) */
+"pref_tts_speedcams_never" = "אל תזהיר אף פעם";
 
 "power_managment_title" = "מצב חיסכון בסוללה";
 

--- a/iphone/Maps/LocalizedStrings/hi.lproj/Localizable.strings
+++ b/iphone/Maps/LocalizedStrings/hi.lproj/Localizable.strings
@@ -779,8 +779,6 @@
 
 "downloader_no_downloaded_maps_message" = "Download maps to search and navigate offline.";
 
-"stop" = "Stop";
-
 "current_location_unknown_error_title" = "Current location is unknown.";
 
 "current_location_unknown_error_message" = "An error occurred while determining your location. Check that your device is working properly and try again later.";
@@ -1035,15 +1033,16 @@
 
 "speedcams_alert_title" = "गति कैमरा";
 
-/* Generic «Always» string */
-"always" = "हमेशा";
-
-/* Generic «Never» string */
-"never" = "कभी नहीं";
-
 "place_description_title" = "Place Description";
 
-"speedcams_notice_message" = "Auto - Warn about speedcams if there is a risk of exceeding the speed limit\nAlways - Always warn about speedcams\nNever - Never warn about speedcams";
+/* Speed camera settings menu option - Warn (about speedcams) if risk of exceeding speed limit */
+"pref_tts_speedcams_auto" = "Warn if there is a risk of exceeding the speed limit";
+
+/* Speed camera settings menu option - Always warn (about speedcams) */
+"pref_tts_speedcams_always" = "Always warn";
+
+/* Speed camera settings menu option - Never warn (about speedcams) */
+"pref_tts_speedcams_never" = "Never warn";
 
 "power_managment_title" = "बिजली की बचत अवस्थाt";
 

--- a/iphone/Maps/LocalizedStrings/hu.lproj/Localizable.strings
+++ b/iphone/Maps/LocalizedStrings/hu.lproj/Localizable.strings
@@ -779,8 +779,6 @@
 
 "downloader_no_downloaded_maps_message" = "Töltse le a szükséges térképeket, hogy megtalálja a helyet és internet nélkül is navigálhasson.";
 
-"stop" = "Leállítás";
-
 "current_location_unknown_error_title" = "Current location is unknown.";
 
 "current_location_unknown_error_message" = "Hiba történt tartózkodási helye keresésekor. Ellenőrizze készüléke működését és próbálkozzon újra.";
@@ -1035,15 +1033,16 @@
 
 "speedcams_alert_title" = "Sebességmérő kamerák";
 
-/* Generic «Always» string */
-"always" = "Mindig";
-
-/* Generic «Never» string */
-"never" = "Soha";
-
 "place_description_title" = "A hely ismertetése";
 
-"speedcams_notice_message" = "Automatikus - Figyelmeztetés a sebesség kamerákról, ha van kockázat a sebesség korlátozás megsértéséről\nMindig - Mindig figyelmeztet a kamerákról\nSoha - Soha ne figyelmezet a kamerákról";
+/* Speed camera settings menu option - Warn (about speedcams) if risk of exceeding speed limit */
+"pref_tts_speedcams_auto" = "Figyelmeztetés ha van kockázat a sebesség korlátozás megsértéséről";
+
+/* Speed camera settings menu option - Always warn (about speedcams) */
+"pref_tts_speedcams_always" = "Mindig figyelmeztet";
+
+/* Speed camera settings menu option - Never warn (about speedcams) */
+"pref_tts_speedcams_never" = "Soha ne figyelmezet";
 
 "power_managment_title" = "Energiatakarékos mód";
 

--- a/iphone/Maps/LocalizedStrings/id.lproj/Localizable.strings
+++ b/iphone/Maps/LocalizedStrings/id.lproj/Localizable.strings
@@ -779,8 +779,6 @@
 
 "downloader_no_downloaded_maps_message" = "Unduh peta untuk menemukan lokasi dan bernavigasi secara offline.";
 
-"stop" = "Berhenti";
-
 "current_location_unknown_error_title" = "Lokasi saat ini tidak diketahui.";
 
 "current_location_unknown_error_message" = "Terjadi kesalahan saat mencari lokasi Anda. Periksa apakah perangkat Anda bekerja dengan benar dan coba lagi nanti.";
@@ -1035,15 +1033,16 @@
 
 "speedcams_alert_title" = "Kamera cepat";
 
-/* Generic «Always» string */
-"always" = "Selalu";
-
-/* Generic «Never» string */
-"never" = "Tidak pernah";
-
 "place_description_title" = "Deskripsi Tempat";
 
-"speedcams_notice_message" = "Auto - Peringatkan tentang kamera kecepatan saat terdapat risiko melebihi batas kecepatan\nSelalu - Selalu peringatkan tentang kamera kecepatan\nTidak pernah - Jangan pernah peringatkan tentang kamera kecepatan";
+/* Speed camera settings menu option - Warn (about speedcams) if risk of exceeding speed limit */
+"pref_tts_speedcams_auto" = "Peringatkan saat terdapat risiko melebihi batas kecepatan";
+
+/* Speed camera settings menu option - Always warn (about speedcams) */
+"pref_tts_speedcams_always" = "Selalu peringatkan";
+
+/* Speed camera settings menu option - Never warn (about speedcams) */
+"pref_tts_speedcams_never" = "Jangan pernah peringatkan";
 
 "power_managment_title" = "Mode hemat daya";
 

--- a/iphone/Maps/LocalizedStrings/it.lproj/Localizable.strings
+++ b/iphone/Maps/LocalizedStrings/it.lproj/Localizable.strings
@@ -779,8 +779,6 @@
 
 "downloader_no_downloaded_maps_message" = "Scarica mappe per trovare un luogo e navigare offline.";
 
-"stop" = "Ferma";
-
 "current_location_unknown_error_title" = "La posizione attuale è sconosciuta.";
 
 "current_location_unknown_error_message" = "Si è verificato un errore durante la ricerca della tua posizione. Controlla che il tuo dispositivo funzioni correttamente e riprova più tardi.";
@@ -1035,15 +1033,16 @@
 
 "speedcams_alert_title" = "Autovelox";
 
-/* Generic «Always» string */
-"always" = "Sempre";
-
-/* Generic «Never» string */
-"never" = "Mai";
-
 "place_description_title" = "Descrizione luogo";
 
-"speedcams_notice_message" = "Auto - Avvisare di autovelox in caso di rischio eccesso velocità\nSempre - Avvisare sempre di autovelox\nMai - Non avvisare mai di autovelox";
+/* Speed camera settings menu option - Warn (about speedcams) if risk of exceeding speed limit */
+"pref_tts_speedcams_auto" = "Avvisare in caso di rischio eccesso velocità";
+
+/* Speed camera settings menu option - Always warn (about speedcams) */
+"pref_tts_speedcams_always" = "Avvisare sempre";
+
+/* Speed camera settings menu option - Never warn (about speedcams) */
+"pref_tts_speedcams_never" = "Non avvisare mai";
 
 "power_managment_title" = "Risparmio energetico";
 
@@ -3781,7 +3780,7 @@
 
 "type.tourism.gallery" = "Galleria";
 
-"type.tourism.guest_house" = "Casa degli Ospiti";
+"type.tourism.guest_house" = "Affittacamere";
 
 "type.tourism.hostel" = "Ostello";
 

--- a/iphone/Maps/LocalizedStrings/ja.lproj/Localizable.strings
+++ b/iphone/Maps/LocalizedStrings/ja.lproj/Localizable.strings
@@ -779,8 +779,6 @@
 
 "downloader_no_downloaded_maps_message" = "ロケーションの検索とオフラインナビゲートのためにマップをダウンロードしてください。";
 
-"stop" = "止める";
-
 "current_location_unknown_error_title" = "現在地は不明です。";
 
 "current_location_unknown_error_message" = "現在地の検索中にエラーが発生しました。 デバイスが正常に動作していることを確認して、もう一度お試しください。";
@@ -1035,15 +1033,16 @@
 
 "speedcams_alert_title" = "自動速度違反取締装置";
 
-/* Generic «Always» string */
-"always" = "常時";
-
-/* Generic «Never» string */
-"never" = "無効";
-
 "place_description_title" = "場所の説明";
 
-"speedcams_notice_message" = "自動－速度制限超過の危険性がある場合には、自動速度違反取締装置について警告します\n常時－自動速度違反取締装置について常に警告します\n無効－自動速度違反取締装置を警告しません";
+/* Speed camera settings menu option - Warn (about speedcams) if risk of exceeding speed limit */
+"pref_tts_speedcams_auto" = "速度制限超過の危険性がある場合には、自動速度違反取締装置について警告します";
+
+/* Speed camera settings menu option - Always warn (about speedcams) */
+"pref_tts_speedcams_always" = "自動速度違反取締装置について常に警告します";
+
+/* Speed camera settings menu option - Never warn (about speedcams) */
+"pref_tts_speedcams_never" = "自動速度違反取締装置を警告しません";
 
 "power_managment_title" = "電力節約モード";
 

--- a/iphone/Maps/LocalizedStrings/ko.lproj/Localizable.strings
+++ b/iphone/Maps/LocalizedStrings/ko.lproj/Localizable.strings
@@ -779,8 +779,6 @@
 
 "downloader_no_downloaded_maps_message" = "오프라인으로 위치를 검색하려면 지도를 다운로드하세요.";
 
-"stop" = "중지";
-
 "current_location_unknown_error_title" = "현재 위치를 알 수 없습니다.";
 
 "current_location_unknown_error_message" = "위치 검색 중 오류가 발생했습니다. 장치가 올바르게 작동되는지 확인하고 다시 시도하세요.";
@@ -1035,15 +1033,16 @@
 
 "speedcams_alert_title" = "속도 감시 카메라";
 
-/* Generic «Always» string */
-"always" = "항상";
-
-/* Generic «Never» string */
-"never" = "안함";
-
 "place_description_title" = "장소 묘사";
 
-"speedcams_notice_message" = "자동 - 속도 제한 초과 위험이 있을때 스피드캠에 대해 경고하기\n항상 - 스피드캠에 대해 항상 경고하기\n절대 아님 - 스피드캠에 대해 경고하지 않기";
+/* Speed camera settings menu option - Warn (about speedcams) if risk of exceeding speed limit */
+"pref_tts_speedcams_auto" = "속도 제한 초과 위험이 있을때 경고하기";
+
+/* Speed camera settings menu option - Always warn (about speedcams) */
+"pref_tts_speedcams_always" = "항상 경고하기";
+
+/* Speed camera settings menu option - Never warn (about speedcams) */
+"pref_tts_speedcams_never" = "경고하지 않기";
 
 "power_managment_title" = "전력 절약 모드";
 

--- a/iphone/Maps/LocalizedStrings/mr.lproj/Localizable.strings
+++ b/iphone/Maps/LocalizedStrings/mr.lproj/Localizable.strings
@@ -779,8 +779,6 @@
 
 "downloader_no_downloaded_maps_message" = "स्थान शोधण्यासाठी नकाशे डाउनलोड करा आणि ऑफलाइन मार्गनिर्देशन वापरा.";
 
-"stop" = "थांबा";
-
 "current_location_unknown_error_title" = "वर्तमान स्थान अज्ञात आहे.";
 
 "current_location_unknown_error_message" = "तुमचे स्थान शोधत असताना एक त्रुटी आढळली. तुमचे उपकरण योग्यरितीने काम करत असल्याचे तपासा आणि नंतर पुन्हा प्रयत्न करा.";
@@ -1035,15 +1033,16 @@
 
 "speedcams_alert_title" = "वेग कॅमेरे";
 
-/* Generic «Always» string */
-"always" = "नेहमी";
-
-/* Generic «Never» string */
-"never" = "कधीच नाही";
-
 "place_description_title" = "ठिकाणाचे वर्णन";
 
-"speedcams_notice_message" = "स्वयं - वेगमर्यादा ओलांडण्याचा धोका असल्यास वेगकॅमबद्दल चेतावणी द्या\nनेहमी - नेहमी वेगकॅमबद्दल चेतावणी द्या\nकधीही नाही - वेगकॅमबद्दल कधीही चेतावणी देऊ नका";
+/* Speed camera settings menu option - Warn (about speedcams) if risk of exceeding speed limit */
+"pref_tts_speedcams_auto" = "वेगमर्यादा ओलांडण्याचा धोका असल्यास चेतावणी द्या";
+
+/* Speed camera settings menu option - Always warn (about speedcams) */
+"pref_tts_speedcams_always" = "नेहमी चेतावणी द्या";
+
+/* Speed camera settings menu option - Never warn (about speedcams) */
+"pref_tts_speedcams_never" = "कधीही चेतावणी देऊ नका";
 
 "power_managment_title" = "ऊर्जा बचत मोड";
 

--- a/iphone/Maps/LocalizedStrings/nb.lproj/Localizable.strings
+++ b/iphone/Maps/LocalizedStrings/nb.lproj/Localizable.strings
@@ -779,8 +779,6 @@
 
 "downloader_no_downloaded_maps_message" = "Last ned kart for å finne plasseringen og navigere frakoblet.";
 
-"stop" = "Stopp";
-
 "current_location_unknown_error_title" = "Gjeldende plassering er ukjent.";
 
 "current_location_unknown_error_message" = "Det oppstod en feil under søking etter plasseringen din. Kontroller at plasseringen din virker som den skal, og prøv på nytt senere.";
@@ -1035,15 +1033,16 @@
 
 "speedcams_alert_title" = "Fartskamera";
 
-/* Generic «Always» string */
-"always" = "Alltid";
-
-/* Generic «Never» string */
-"never" = "Aldri";
-
 "place_description_title" = "Plasser beskrivelse";
 
-"speedcams_notice_message" = "Auto - Advarsel om fartskamera hvis det er fare for å overskride fartsgrensen\nAlltid - Advar alltid om farskameraer\nAldri - Advar aldri om fartskameraer";
+/* Speed camera settings menu option - Warn (about speedcams) if risk of exceeding speed limit */
+"pref_tts_speedcams_auto" = "Advarsel hvis det er fare for å overskride fartsgrensen";
+
+/* Speed camera settings menu option - Always warn (about speedcams) */
+"pref_tts_speedcams_always" = "Advar alltid";
+
+/* Speed camera settings menu option - Never warn (about speedcams) */
+"pref_tts_speedcams_never" = "Advar aldri";
 
 "power_managment_title" = "Strømsparemodus";
 

--- a/iphone/Maps/LocalizedStrings/nl.lproj/Localizable.strings
+++ b/iphone/Maps/LocalizedStrings/nl.lproj/Localizable.strings
@@ -779,8 +779,6 @@
 
 "downloader_no_downloaded_maps_message" = "Download kaarten om een locatie te zoeken en offline te navigeren.";
 
-"stop" = "Stoppen";
-
 "current_location_unknown_error_title" = "Huidige locatie is onbekend.";
 
 "current_location_unknown_error_message" = "Er is een fout opgetreden tijdens het zoeken naar uw locatie. Controleer of uw apparaat goed werkt en probeer het later opnieuw.";
@@ -1035,15 +1033,16 @@
 
 "speedcams_alert_title" = "Snelheidscamera's";
 
-/* Generic «Always» string */
-"always" = "Altijd";
-
-/* Generic «Never» string */
-"never" = "Nooit";
-
 "place_description_title" = "Plaatsbeschrijving";
 
-"speedcams_notice_message" = "Auto - Waarschuw voor speedcams als er een risico bestaat dat de snelheidslimiet wordt overschreden\nAltijd - Waarschuw altijd voor flitspalen\nNooit - Waarschuw nooit over flitspalen";
+/* Speed camera settings menu option - Warn (about speedcams) if risk of exceeding speed limit */
+"pref_tts_speedcams_auto" = "Waarschuw als er een risico bestaat dat de snelheidslimiet wordt overschreden";
+
+/* Speed camera settings menu option - Always warn (about speedcams) */
+"pref_tts_speedcams_always" = "Waarschuw altijd";
+
+/* Speed camera settings menu option - Never warn (about speedcams) */
+"pref_tts_speedcams_never" = "Waarschuw nooit";
 
 "power_managment_title" = "Energiebesparende modus";
 

--- a/iphone/Maps/LocalizedStrings/pl.lproj/Localizable.strings
+++ b/iphone/Maps/LocalizedStrings/pl.lproj/Localizable.strings
@@ -779,8 +779,6 @@
 
 "downloader_no_downloaded_maps_message" = "Aby znajdować miejsca i nawigować bez połączenia z internetem, musisz pobrać mapy.";
 
-"stop" = "Stop";
-
 "current_location_unknown_error_title" = "Aktualna lokalizacja jest nieznana.";
 
 "current_location_unknown_error_message" = "Podczas szukania twojej lokalizacji wystąpił błąd. Sprawdź czy twoje urządzenie działa poprawnie i spróbuj ponownie później.";
@@ -1035,15 +1033,16 @@
 
 "speedcams_alert_title" = "Fotoradary";
 
-/* Generic «Always» string */
-"always" = "Zawsze";
-
-/* Generic «Never» string */
-"never" = "Nigdy";
-
 "place_description_title" = "Opis miejsca";
 
-"speedcams_notice_message" = "Automatycznie – Ostrzegaj o fotoradarach, jeśli istnieje ryzyko przekroczenia ograniczenia prędkości\nZawsze – Zawsze ostrzegaj o fotoradarach\nNigdy – Nigdy nie ostrzegaj o fotoradarach";
+/* Speed camera settings menu option - Warn (about speedcams) if risk of exceeding speed limit */
+"pref_tts_speedcams_auto" = "Ostrzegaj jeśli istnieje ryzyko przekroczenia ograniczenia prędkości";
+
+/* Speed camera settings menu option - Always warn (about speedcams) */
+"pref_tts_speedcams_always" = "Zawsze ostrzegaj";
+
+/* Speed camera settings menu option - Never warn (about speedcams) */
+"pref_tts_speedcams_never" = "Nigdy nie ostrzegaj";
 
 "power_managment_title" = "Tryb oszczędzania energii";
 

--- a/iphone/Maps/LocalizedStrings/pt-BR.lproj/Localizable.strings
+++ b/iphone/Maps/LocalizedStrings/pt-BR.lproj/Localizable.strings
@@ -779,8 +779,6 @@
 
 "downloader_no_downloaded_maps_message" = "Baixe mapas para pesquisar locais e usar navegação offline.";
 
-"stop" = "Parar";
-
 "current_location_unknown_error_title" = "A localização atual é desconhecida.";
 
 "current_location_unknown_error_message" = "Ocorreu um erro na busca por sua localização. Verifique se o seu dispositivo está funcionando corretamente e tente novamente mais tarde.";
@@ -1035,15 +1033,16 @@
 
 "speedcams_alert_title" = "Câmeras de trânsito";
 
-/* Generic «Always» string */
-"always" = "Sempre";
-
-/* Generic «Never» string */
-"never" = "Nunca";
-
 "place_description_title" = "Descrição do lugar";
 
-"speedcams_notice_message" = "Automático - Avisar sobre radar se houver risco de ultrapassar o limite de velocidade\nSempre - Sempre avisar sobre radares\nNunca - Nunca avisar sobre radares";
+/* Speed camera settings menu option - Warn (about speedcams) if risk of exceeding speed limit */
+"pref_tts_speedcams_auto" = "Avisar se houver risco de ultrapassar o limite de velocidade";
+
+/* Speed camera settings menu option - Always warn (about speedcams) */
+"pref_tts_speedcams_always" = "Sempre avisar";
+
+/* Speed camera settings menu option - Never warn (about speedcams) */
+"pref_tts_speedcams_never" = "Nunca avisar";
 
 "power_managment_title" = "Modo de economia de energia";
 

--- a/iphone/Maps/LocalizedStrings/pt.lproj/Localizable.strings
+++ b/iphone/Maps/LocalizedStrings/pt.lproj/Localizable.strings
@@ -779,8 +779,6 @@
 
 "downloader_no_downloaded_maps_message" = "Descarregar mapas para encontrar a localização e navegar offline.";
 
-"stop" = "Parar";
-
 "current_location_unknown_error_title" = "A localização atual é desconhecida.";
 
 "current_location_unknown_error_message" = "Ocorreu um erro ao pesquisar a sua localização. Verifique se o seu dispositivo está a funcionar devidamente e volte a tentar mais tarde.";
@@ -1035,15 +1033,16 @@
 
 "speedcams_alert_title" = "Radares de velocidade";
 
-/* Generic «Always» string */
-"always" = "Sempre";
-
-/* Generic «Never» string */
-"never" = "Nunca";
-
 "place_description_title" = "Descrição do local";
 
-"speedcams_notice_message" = "Automático - avisa sobre os radares de velocidade se houver risco de exceder o limite de velocidade\nSempre - avisa sempre sobre os radares\nNunca - nunca avisar sobre os radares";
+/* Speed camera settings menu option - Warn (about speedcams) if risk of exceeding speed limit */
+"pref_tts_speedcams_auto" = "Avisar se houver risco de exceder o limite de velocidade";
+
+/* Speed camera settings menu option - Always warn (about speedcams) */
+"pref_tts_speedcams_always" = "Sempre avisar";
+
+/* Speed camera settings menu option - Never warn (about speedcams) */
+"pref_tts_speedcams_never" = "Nunca avisar";
 
 "power_managment_title" = "Modo de economia de energia";
 

--- a/iphone/Maps/LocalizedStrings/ro.lproj/Localizable.strings
+++ b/iphone/Maps/LocalizedStrings/ro.lproj/Localizable.strings
@@ -779,8 +779,6 @@
 
 "downloader_no_downloaded_maps_message" = "Descarcă hărți pentru a căuta un loc și a naviga fără conectare la internet.";
 
-"stop" = "Oprește";
-
 "current_location_unknown_error_title" = "Poziția actuală este necunoscută.";
 
 "current_location_unknown_error_message" = "S-a produs o eroare la căutarea poziției tale. Verifică dacă dispozitivul funcționează corect și încearcă din nou.";
@@ -1035,15 +1033,16 @@
 
 "speedcams_alert_title" = "Radare";
 
-/* Generic «Always» string */
-"always" = "Mereu";
-
-/* Generic «Never» string */
-"never" = "Niciodată";
-
 "place_description_title" = "Descrierea locului";
 
-"speedcams_notice_message" = "Auto - Avertizează cu privire la radare dacă există riscul depășirii limitei de viteză\nMereu - Avertizează mereu cu privire la radare\nNiciodată - Nu avertiza niciodată cu privire la radare";
+/* Speed camera settings menu option - Warn (about speedcams) if risk of exceeding speed limit */
+"pref_tts_speedcams_auto" = "Avertizează dacă există riscul depășirii limitei de viteză";
+
+/* Speed camera settings menu option - Always warn (about speedcams) */
+"pref_tts_speedcams_always" = "Avertizează mereu";
+
+/* Speed camera settings menu option - Never warn (about speedcams) */
+"pref_tts_speedcams_never" = "Nu avertiza niciodată";
 
 "power_managment_title" = "Economisire a energiei";
 

--- a/iphone/Maps/LocalizedStrings/ru.lproj/Localizable.strings
+++ b/iphone/Maps/LocalizedStrings/ru.lproj/Localizable.strings
@@ -779,8 +779,6 @@
 
 "downloader_no_downloaded_maps_message" = "Загрузите необходимые карты, чтобы находить места и пользоваться навигацией без интернета.";
 
-"stop" = "Стоп";
-
 "current_location_unknown_error_title" = "Местоположение не найдено.";
 
 "current_location_unknown_error_message" = "При поиске местоположения произошла неизвестная ошибка. Проверьте работоспособность устройства и попробуйте найти местоположение позднее.";
@@ -1035,15 +1033,16 @@
 
 "speedcams_alert_title" = "Камеры скорости";
 
-/* Generic «Always» string */
-"always" = "Всегда";
-
-/* Generic «Never» string */
-"never" = "Никогда";
-
 "place_description_title" = "Описание места";
 
-"speedcams_notice_message" = "Авто - Предупреждать о камерах скорости, если есть риск превышения скоростного лимита\nВсегда - Всегда предупреждать о камерах\nНикогда - Никогда не предупреждать о камерах";
+/* Speed camera settings menu option - Warn (about speedcams) if risk of exceeding speed limit */
+"pref_tts_speedcams_auto" = "Предупреждать при превышении скорости";
+
+/* Speed camera settings menu option - Always warn (about speedcams) */
+"pref_tts_speedcams_always" = "Всегда предупреждать";
+
+/* Speed camera settings menu option - Never warn (about speedcams) */
+"pref_tts_speedcams_never" = "Никогда не предупреждать";
 
 "power_managment_title" = "Режим энергосбережения";
 

--- a/iphone/Maps/LocalizedStrings/sk.lproj/Localizable.strings
+++ b/iphone/Maps/LocalizedStrings/sk.lproj/Localizable.strings
@@ -779,8 +779,6 @@
 
 "downloader_no_downloaded_maps_message" = "Prevziať mapy na nájdenie pozície a navigovanie off-line.";
 
-"stop" = "Zastaviť";
-
 "current_location_unknown_error_title" = "Súčasná pozícia je neznáma.";
 
 "current_location_unknown_error_message" = "Počas vyhľadávania vašej pozície došlo k chybe. Skontrolujte, či zariadenie pracuje správne a skúste to znova.";
@@ -1035,15 +1033,16 @@
 
 "speedcams_alert_title" = "Rýchlostné kamery";
 
-/* Generic «Always» string */
-"always" = "Vždy";
-
-/* Generic «Never» string */
-"never" = "Nikdy";
-
 "place_description_title" = "Popis miesta";
 
-"speedcams_notice_message" = "Automaticky - Upozornenie na rýchlostné kamery, ak existuje riziko prekročenia rýchlostného limitu\nVždy - Vždy upozorniť na rýchlostné kamery\nNikdy - Nikdy neupozorňovať na rýchlostné kamery";
+/* Speed camera settings menu option - Warn (about speedcams) if risk of exceeding speed limit */
+"pref_tts_speedcams_auto" = "Upozornenie ak existuje riziko prekročenia rýchlostného limitu";
+
+/* Speed camera settings menu option - Always warn (about speedcams) */
+"pref_tts_speedcams_always" = "Vždy upozorniť";
+
+/* Speed camera settings menu option - Never warn (about speedcams) */
+"pref_tts_speedcams_never" = "Nikdy neupozorňovať";
 
 "power_managment_title" = "Úsporný režim";
 

--- a/iphone/Maps/LocalizedStrings/sv.lproj/Localizable.strings
+++ b/iphone/Maps/LocalizedStrings/sv.lproj/Localizable.strings
@@ -779,8 +779,6 @@
 
 "downloader_no_downloaded_maps_message" = "Ladda ner kartor för att hitta platsen och navigera offline.";
 
-"stop" = "Stopp";
-
 "current_location_unknown_error_title" = "Den nuvarande platsen är okänd.";
 
 "current_location_unknown_error_message" = "Ett fel inträffade vid sökning efter din plats. Kontrollera att din enhet fungerar och försök igen senare.";
@@ -1035,15 +1033,16 @@
 
 "speedcams_alert_title" = "Hastighetskameror";
 
-/* Generic «Always» string */
-"always" = "Alltid";
-
-/* Generic «Never» string */
-"never" = "Aldrig";
-
 "place_description_title" = "Beskrivning av platsen";
 
-"speedcams_notice_message" = "Auto - Varna om fartkameror om det finns risk att överskrida hastighetsgränsen\nAlltid - Varna alltid om kameror\nAldrig - Varna aldrig om kameror";
+/* Speed camera settings menu option - Warn (about speedcams) if risk of exceeding speed limit */
+"pref_tts_speedcams_auto" = "Varna om det finns risk att överskrida hastighetsgränsen";
+
+/* Speed camera settings menu option - Always warn (about speedcams) */
+"pref_tts_speedcams_always" = "Varna alltid";
+
+/* Speed camera settings menu option - Never warn (about speedcams) */
+"pref_tts_speedcams_never" = "Varna aldrig";
 
 "power_managment_title" = "Energisparläge";
 

--- a/iphone/Maps/LocalizedStrings/sw.lproj/Localizable.strings
+++ b/iphone/Maps/LocalizedStrings/sw.lproj/Localizable.strings
@@ -779,8 +779,6 @@
 
 "downloader_no_downloaded_maps_message" = "Download maps to search and navigate offline.";
 
-"stop" = "Stop";
-
 "current_location_unknown_error_title" = "Current location is unknown.";
 
 "current_location_unknown_error_message" = "An error occurred while determining your location. Check that your device is working properly and try again later.";
@@ -1035,15 +1033,16 @@
 
 "speedcams_alert_title" = "Kamera za mwendo-kasi";
 
-/* Generic «Always» string */
-"always" = "Mara kwa Mara";
-
-/* Generic «Never» string */
-"never" = "Kamwe";
-
 "place_description_title" = "Maelezo ya Eneo";
 
-"speedcams_notice_message" = "Auto - Onyo la kuhusu kamera ya mwendo-kasi iwapo kuna hatari yoyote ya kuzidi ukomo wa mwendo-kasi\nMara kwa Mara - Daima onya kuhusu kamera za mwendo-kasi\nKamwe - Kamwe usionye kuhusu kamera za mwendo-kasi";
+/* Speed camera settings menu option - Warn (about speedcams) if risk of exceeding speed limit */
+"pref_tts_speedcams_auto" = "Onyo iwapo kuna hatari yoyote ya kuzidi ukomo wa mwendo-kasi";
+
+/* Speed camera settings menu option - Always warn (about speedcams) */
+"pref_tts_speedcams_always" = "Daima onya";
+
+/* Speed camera settings menu option - Never warn (about speedcams) */
+"pref_tts_speedcams_never" = "Kamwe usionye";
 
 "power_managment_title" = "Mtindo wa kuokoa nishati";
 

--- a/iphone/Maps/LocalizedStrings/th.lproj/Localizable.strings
+++ b/iphone/Maps/LocalizedStrings/th.lproj/Localizable.strings
@@ -779,8 +779,6 @@
 
 "downloader_no_downloaded_maps_message" = "ดาวน์โหลดแผนที่เพื่อค้นหาสถานที่ และนำทางแบบออฟไลน์";
 
-"stop" = "หยุด";
-
 "current_location_unknown_error_title" = "ไม่ทราบชื่อของที่ตั้งปัจจุบัน";
 
 "current_location_unknown_error_message" = "มีข้อผิดพลาดเกิดขึ้นในขณะที่กำลังหาที่ตั้งที่คุณอยู่ โปรดตรวจสอบอุปกรณ์ของคุณว่าทำงานถูกต้อง และลองใหม่อีกครั้ง";
@@ -1035,15 +1033,16 @@
 
 "speedcams_alert_title" = "กล้องตรวจจับความเร็ว";
 
-/* Generic «Always» string */
-"always" = "ทุกครั้ง";
-
-/* Generic «Never» string */
-"never" = "ไม่ต้องเตือน";
-
 "place_description_title" = "รายละเอียดของสถานที่";
 
-"speedcams_notice_message" = "อัตโนมัติ - เตือนเกี่ยวกับกล้องตรวจจับความเร็วหากมีความเป็นได้ว่าจะขับเร็วเกิดกำหนด\nทุกครั้ง - เตือนเกี่ยวกับกล้องตรวจจับความเร็วเสมอ\nไม่ต้องเตือน - ไม่เคยเตือนเกี่ยวกับกล้องตรวจจับความเร็ว";
+/* Speed camera settings menu option - Warn (about speedcams) if risk of exceeding speed limit */
+"pref_tts_speedcams_auto" = "เตือนเกี่ยวกับกล้องตรวจจับความเร็วหากมีความเป็นได้ว่าจะขับเร็วเกิดกำหนด";
+
+/* Speed camera settings menu option - Always warn (about speedcams) */
+"pref_tts_speedcams_always" = "เตือนเกี่ยวกับกล้องตรวจจับความเร็วเสมอ";
+
+/* Speed camera settings menu option - Never warn (about speedcams) */
+"pref_tts_speedcams_never" = "ไม่เคยเตือนเกี่ยวกับกล้องตรวจจับความเร็ว";
 
 "power_managment_title" = "โหมดประหยัดพลังงาน";
 

--- a/iphone/Maps/LocalizedStrings/tr.lproj/Localizable.strings
+++ b/iphone/Maps/LocalizedStrings/tr.lproj/Localizable.strings
@@ -779,8 +779,6 @@
 
 "downloader_no_downloaded_maps_message" = "Çevrimdışı olarak adres bulmak ve gezinmek için haritaları indirin.";
 
-"stop" = "Dur";
-
 "current_location_unknown_error_title" = "Geçerli konum bilinmiyor.";
 
 "current_location_unknown_error_message" = "Konumunuz aranırken bir hata oluştu. Cihazınızın düzgün çalışıp çalışmadığını kontrol edin ve daha sonra tekrar deneyin.";
@@ -1035,15 +1033,16 @@
 
 "speedcams_alert_title" = "Hız kameraları";
 
-/* Generic «Always» string */
-"always" = "Her zaman";
-
-/* Generic «Never» string */
-"never" = "Asla";
-
 "place_description_title" = "Yer Açıklaması";
 
-"speedcams_notice_message" = "Otomatik - Hız sınırını aşma riski varsa hız kameraları hakkında uyar\nHer zaman - Hız kameraları hakkında her zaman uyar\nAsla - Hız kameraları hakkında hiç bir zaman uyarma";
+/* Speed camera settings menu option - Warn (about speedcams) if risk of exceeding speed limit */
+"pref_tts_speedcams_auto" = "Hız sınırını aşma riski varsa uyar";
+
+/* Speed camera settings menu option - Always warn (about speedcams) */
+"pref_tts_speedcams_always" = "Her zaman uyar";
+
+/* Speed camera settings menu option - Never warn (about speedcams) */
+"pref_tts_speedcams_never" = "Hiç bir zaman uyarma";
 
 "power_managment_title" = "Güç tasarrufu modu";
 

--- a/iphone/Maps/LocalizedStrings/uk.lproj/Localizable.strings
+++ b/iphone/Maps/LocalizedStrings/uk.lproj/Localizable.strings
@@ -779,8 +779,6 @@
 
 "downloader_no_downloaded_maps_message" = "Завантажте необхідні мапи, щоб знаходити місця та користуватися навігацією без iнтернету.";
 
-"stop" = "Зупинити";
-
 "current_location_unknown_error_title" = "Місцезнаходження не знайдено.";
 
 "current_location_unknown_error_message" = "Під час пошуку місцезнаходження сталася невідома помилка. Перевірте працездатність пристрою та спробуйте відшукати місцеположення пізніше.";
@@ -1035,15 +1033,16 @@
 
 "speedcams_alert_title" = "Камери швидкості";
 
-/* Generic «Always» string */
-"always" = "Завжди";
-
-/* Generic «Never» string */
-"never" = "Ніколи";
-
 "place_description_title" = "Опис місця";
 
-"speedcams_notice_message" = "Авто - Попереджати про камери швидкості, якщо є ризик перевищення швидкісного ліміту\nЗавжди - Завжди попереджати про камери\nНіколи - Ніколи не попереджати про камери";
+/* Speed camera settings menu option - Warn (about speedcams) if risk of exceeding speed limit */
+"pref_tts_speedcams_auto" = "Попереджати при перевищенні швидкості";
+
+/* Speed camera settings menu option - Always warn (about speedcams) */
+"pref_tts_speedcams_always" = "Завжди попереджати";
+
+/* Speed camera settings menu option - Never warn (about speedcams) */
+"pref_tts_speedcams_never" = "Ніколи не попереджати";
 
 "power_managment_title" = "Режим енергозбереження";
 

--- a/iphone/Maps/LocalizedStrings/vi.lproj/Localizable.strings
+++ b/iphone/Maps/LocalizedStrings/vi.lproj/Localizable.strings
@@ -779,8 +779,6 @@
 
 "downloader_no_downloaded_maps_message" = "Tải về bản đồ để tìm địa điểm và định hướng ngoại tuyến.";
 
-"stop" = "Dừng";
-
 "current_location_unknown_error_title" = "Chưa biết địa điểm hiện tại.";
 
 "current_location_unknown_error_message" = "Có lỗi khi tìm kiếm địa điểm của bạn. Đảm bảo rằng thiết bị của bạn hoạt động tốt và thử lại sau.";
@@ -1035,15 +1033,16 @@
 
 "speedcams_alert_title" = "Tăn tốc độ máy ảnh";
 
-/* Generic «Always» string */
-"always" = "Luôn luôn";
-
-/* Generic «Never» string */
-"never" = "Không bao giờ";
-
 "place_description_title" = "Mô tả Địa điểm";
 
-"speedcams_notice_message" = "Tự động - Cảnh báo về speedcam nếu có nguy cơ vượt quá giới hạn tốc độ\nLuôn luôn - Luôn cảnh báo về speedcams\nKhông bao giờ - Không bao giờ cảnh báo về speedcams";
+/* Speed camera settings menu option - Warn (about speedcams) if risk of exceeding speed limit */
+"pref_tts_speedcams_auto" = "Cảnh báo nếu có nguy cơ vượt quá giới hạn tốc độ";
+
+/* Speed camera settings menu option - Always warn (about speedcams) */
+"pref_tts_speedcams_always" = "Luôn cảnh báo";
+
+/* Speed camera settings menu option - Never warn (about speedcams) */
+"pref_tts_speedcams_never" = "Không bao giờ cảnh báo";
 
 "power_managment_title" = "Chế độ tiết kiệm năng lượng";
 

--- a/iphone/Maps/LocalizedStrings/zh-Hans.lproj/Localizable.strings
+++ b/iphone/Maps/LocalizedStrings/zh-Hans.lproj/Localizable.strings
@@ -779,8 +779,6 @@
 
 "downloader_no_downloaded_maps_message" = "下载地图来查找位置和离线浏览";
 
-"stop" = "停止";
-
 "current_location_unknown_error_title" = "当前位置未知";
 
 "current_location_unknown_error_message" = "定位到您的当前位置时出错。请检查您的设备是否正常运作，然后再试一次。";
@@ -1035,15 +1033,16 @@
 
 "speedcams_alert_title" = "高速摄像机";
 
-/* Generic «Always» string */
-"always" = "总是";
-
-/* Generic «Never» string */
-"never" = "从不";
-
 "place_description_title" = "地点说明";
 
-"speedcams_notice_message" = "自动 - 如果存在超出速度限制的风险，则对速度摄像头发出警告\n总是 - 始终提醒摄像头\n从不 - 永远不会对摄像头发出警告";
+/* Speed camera settings menu option - Warn (about speedcams) if risk of exceeding speed limit */
+"pref_tts_speedcams_auto" = "如果存在超出速度限制的风险，则对速度摄像头发出警告";
+
+/* Speed camera settings menu option - Always warn (about speedcams) */
+"pref_tts_speedcams_always" = "始终提醒摄像头";
+
+/* Speed camera settings menu option - Never warn (about speedcams) */
+"pref_tts_speedcams_never" = "永远不会对摄像头发出警告";
 
 "power_managment_title" = "省电模式";
 

--- a/iphone/Maps/LocalizedStrings/zh-Hant.lproj/Localizable.strings
+++ b/iphone/Maps/LocalizedStrings/zh-Hant.lproj/Localizable.strings
@@ -779,8 +779,6 @@
 
 "downloader_no_downloaded_maps_message" = "下載地圖來尋找位置和離線瀏覽。";
 
-"stop" = "停止";
-
 "current_location_unknown_error_title" = "目前位置未知。";
 
 "current_location_unknown_error_message" = "定位到您的當前位置時出錯。請檢查您的裝置是否正常運作，然後再試一次。";
@@ -1035,15 +1033,16 @@
 
 "speedcams_alert_title" = "超速照相機";
 
-/* Generic «Always» string */
-"always" = "總是";
-
-/* Generic «Never» string */
-"never" = "從不";
-
 "place_description_title" = "地點說明";
 
-"speedcams_notice_message" = "自動 - 如果存在超出速度限制的風險，則對速度照相機發出警告\n總是 - 始終提醒照相機\n從不 - 永遠不會對照相機發出警告";
+/* Speed camera settings menu option - Warn (about speedcams) if risk of exceeding speed limit */
+"pref_tts_speedcams_auto" = "如果存在超出速度限制的風險，則對速度照相機發出警告";
+
+/* Speed camera settings menu option - Always warn (about speedcams) */
+"pref_tts_speedcams_always" = "始終提醒照相機";
+
+/* Speed camera settings menu option - Never warn (about speedcams) */
+"pref_tts_speedcams_never" = "永遠不會對照相機發出警告";
 
 "power_managment_title" = "省電模式";
 

--- a/iphone/Maps/UI/Settings/MWMTTSSettingsViewController.mm
+++ b/iphone/Maps/UI/Settings/MWMTTSSettingsViewController.mm
@@ -132,9 +132,9 @@ struct CamerasCellStrategy : BaseCellStategy
     NSString * title = nil;
     switch (static_cast<SpeedCameraManagerMode>(indexPath.row))
     {
-    case SpeedCameraManagerMode::Auto: title = L(@"auto"); break;
-    case SpeedCameraManagerMode::Always: title = L(@"always"); break;
-    case SpeedCameraManagerMode::Never: title = L(@"never"); break;
+    case SpeedCameraManagerMode::Auto: title = L(@"pref_tts_speedcams_auto"); break;
+    case SpeedCameraManagerMode::Always: title = L(@"pref_tts_speedcams_always"); break;
+    case SpeedCameraManagerMode::Never: title = L(@"pref_tts_speedcams_never"); break;
     case SpeedCameraManagerMode::MaxValue: CHECK(false, ()); return nil;
     }
 
@@ -161,7 +161,7 @@ struct CamerasCellStrategy : BaseCellStategy
 
   NSString * TitleForHeader() const override { return L(@"speedcams_alert_title"); }
 
-  NSString * TitleForFooter() const override { return L(@"speedcams_notice_message"); }
+  NSString * TitleForFooter() const override { return nil; }
 
   void SelectCell(UITableView * tableView, NSIndexPath * indexPath,
                   MWMTTSSettingsViewController * /* controller */) override


### PR DESCRIPTION
This PR continues https://github.com/organicmaps/organicmaps/pull/6125 for iOS and matches with the Android SppedcamPrefs style.
This PR is also related to the issue: https://github.com/organicmaps/organicmaps/pull/7561#discussion_r1519523787
Details: 
https://github.com/organicmaps/organicmaps/pull/7561#discussion_r1518994774
https://github.com/organicmaps/organicmaps/pull/7561#discussion_r1518995390

### Important!
This PR should be merged after the https://github.com/organicmaps/organicmaps/pull/7581 because the old settings cell implementation doesn't allow making cells with the double-lined titles.

### Changes:
1. `stop` is removed from the strings.txt and in iOS replaced with the `navigation_stop_button` (they are both contains `stop`)
2. `never`, `always` and  `speedcams_notice_message` was removed and replaced with androids's `pref_tts_speedcams_never`, `pref_tts_speedcams_always`, `pref_tts_speedcams_auto`
3. footer from the speedcam prefs was removed 


### Result (before/after):
<img width="350" alt="image" src="https://github.com/organicmaps/organicmaps/assets/79797627/0edc0ac0-3337-48ec-96a8-5352ceabcdbc"> <img width="350" alt="image" src="https://github.com/organicmaps/organicmaps/assets/79797627/f4388fe3-282f-4c66-ad07-0f3ef4eb150f">



