### PR TITLE
[strings] Shorten the speed camera string

### DIFF
--- a/data/strings/strings.txt
+++ b/data/strings/strings.txt
@@ -23207,7 +23207,7 @@
   [pref_tts_speedcams_auto]
     comment = Speed camera settings menu option - Warn (about speedcams) if risk of exceeding speed limit
     tags = android,ios
-    en = Warn if there is a risk of exceeding the speed limit
+    en = Warn when exceeding the speed limit
     af = Waarsku indien daar ’n risiko is dat die grens oorskry word
     ar = حذرني  إذا هناك احتمالية تجاوز الحد الأقصى للسرعة
     az = Sürət həddini aşmaq riski varsa, xəbərdarlıq edin
@@ -24577,6 +24577,7 @@
 
   [capacity]
     comment = To indicate the capacity of car parkings, bicycle parkings, electric vehicle charging stations...
+    tags = android,ios
     en = Capacity: %@
     af = Kapasiteit: %@
     ar = السعة: %@


### PR DESCRIPTION
@organicmaps/translations please propose a shorter/cleaner translation, if possible, for this string, like it is done in English (can English be phrased better btw?):

```
  [pref_tts_speedcams_auto]
    comment = Speed camera settings menu option - Warn (about speedcams) if risk of exceeding speed limit
    tags = android,ios
    en = Warn when exceeding the speed limit
    af = Waarsku indien daar ’n risiko is dat die grens oorskry word
    ar = حذرني  إذا هناك احتمالية تجاوز الحد الأقصى للسرعة
    az = Sürət həddini aşmaq riski varsa, xəbərdarlıq edin
    be = Папярэджваць пры перавышэнні хуткасці
    bg = Предупреждава ако има риск от превишаване на ограничението на скоростта
    ca = Avisa si hi ha risc d'excedir el límit de velocitat
    cs = Upozorňovat pokud hrozí riziko překročení rychlosti
    da = Advar hvis der er en risiko for, at hastighedsgrænsen overskrides
    de = Warnen wenn die Gefahr einer Geschwindigkeitsüberschreitung besteht
    el = Να ειδοποιούμαι αν υπάρχει κίνδυνος να υπερβώ το όριο ταχύτητας
    es = Alertar si existe el riesgo de exceder el límite de velocidad
    es-MX = Avisar si existe el riesgo de exceder el límite de velocidad
    et = Hoiatused kui on oht ületada piirkiirust
    eu = Ohartarazten du abiadura muga gainditzeko arriskua badago
    fa = در صورتی که خطر تجاوز از سرعت مجاز وجود داشت، نسبت هشدار دهد
    fi = Varoita jos tuntuu siltä, että nopeusrajan ylitys on mahdollista
    fr = Alerte sonore en cas de risque de dépassement de la limite de vitesse
    he = הזהר אם יש חשש להפרזה במהירות
    hu = Figyelmeztetés ha van kockázat a sebesség korlátozás megsértéséről
    id = Peringatkan saat terdapat risiko melebihi batas kecepatan
    it = Avvisare in caso di rischio eccesso velocità
    ja = 速度制限超過の危険性がある場合には、自動速度違反取締装置について警告します
    ko = 속도 제한 초과 위험이 있을때 경고하기
    lt = įspėti jei yra greičio viršijimo rizika
    mr = वेगमर्यादा ओलांडण्याचा धोका असल्यास चेतावणी द्या
    nb = Advarsel hvis det er fare for å overskride fartsgrensen
    nl = Waarschuw als er een risico bestaat dat de snelheidslimiet wordt overschreden
    pl = Ostrzegaj jeśli istnieje ryzyko przekroczenia ograniczenia prędkości
    pt = Avisar se houver risco de exceder o limite de velocidade
    pt-BR = Avisar se houver risco de ultrapassar o limite de velocidade
    ro = Avertizează dacă există riscul depășirii limitei de viteză
    ru = Предупреждать при превышении скорости
    sk = Upozornenie ak existuje riziko prekročenia rýchlostného limitu
    sv = Varna om det finns risk att överskrida hastighetsgränsen
    sw = Onyo iwapo kuna hatari yoyote ya kuzidi ukomo wa mwendo-kasi
    th = เตือนเกี่ยวกับกล้องตรวจจับความเร็วหากมีความเป็นได้ว่าจะขับเร็วเกิดกำหนด
    tr = Hız sınırını aşma riski varsa uyar
    uk = Попереджати при перевищенні швидкості
    vi = Cảnh báo nếu có nguy cơ vượt quá giới hạn tốc độ
    zh-Hans = 如果存在超出速度限制的风险，则对速度摄像头发出警告
    zh-Hant = 如果存在超出速度限制的風險，則對速度照相機發出警告

```