### PR TITLE
[android] Import .gpx and .gpx.xml files from Google Files app

### DIFF
--- a/android/app/src/main/AndroidManifest.xml
+++ b/android/app/src/main/AndroidManifest.xml
@@ -318,6 +318,18 @@
         <data android:pathPattern="/.*\\..*\\..*\\..*\\..*\\..*\\..*\\..*\\.kmb" />
         <data android:pathPattern="/.*\\..*\\..*\\..*\\..*\\..*\\..*\\..*\\.KMB" />
       </intent-filter>
+
+      <!-- Catches .gpx and .gpx.xml files opened from Google Files app -->
+      <intent-filter>
+        <action android:name="android.intent.action.VIEW" />
+        <category android:name="android.intent.category.DEFAULT" />
+        <data android:scheme="content" />
+        <data android:host="*" />
+        <data android:mimeType="application/octet-stream" />
+        <data android:mimeType="application/xml" />
+        <data android:mimeType="text/xml" />
+      </intent-filter>
+
     </activity>
 
     <activity

--- a/android/app/src/main/java/app/organicmaps/bookmarks/data/BookmarkManager.java
+++ b/android/app/src/main/java/app/organicmaps/bookmarks/data/BookmarkManager.java
@@ -454,6 +454,13 @@ public enum BookmarkManager
         return filename;
     }
 
+    // Samsung browser adds .xml extension to downloaded gpx files.
+    // Duplicate files have " (1).xml", " (2).xml" suffixes added.
+    final String gpxExt = ".gpx";
+    final int gpxStart = lowerCaseFilename.lastIndexOf(gpxExt);
+    if (gpxStart != -1)
+      return filename.substring(0, gpxStart + gpxExt.length());
+
     // Try get guess extension from the mime type.
     final String mime = resolver.getType(uri);
     if (mime != null)


### PR DESCRIPTION
Google Files app uses incorrect binary mime type when opening gpx files, this change allows to import gpx from Google Files app into Organic Maps.

Samsung browser adds .xml extension to downloaded files, this change also allows to import such files.