### PR TITLE
[android] Implement auto hide on downloader fragment

### DIFF
--- a/android/app/src/main/java/app/organicmaps/downloader/DownloaderFragment.java
+++ b/android/app/src/main/java/app/organicmaps/downloader/DownloaderFragment.java
@@ -1,6 +1,7 @@
 package app.organicmaps.downloader;
 
 import android.content.Intent;
+import android.os.Build;
 import android.os.Bundle;
 import android.view.View;
 import android.view.WindowManager;
@@ -19,6 +20,7 @@ import app.organicmaps.search.SearchEngine;
 import app.organicmaps.widget.PlaceholderView;
 import app.organicmaps.util.bottomsheet.MenuBottomSheetFragment;
 import app.organicmaps.util.bottomsheet.MenuBottomSheetItem;
+import com.google.android.material.floatingactionbutton.FloatingActionButton;
 
 import java.util.ArrayList;
 import java.util.List;
@@ -37,6 +39,8 @@ public class DownloaderFragment extends BaseMwmRecyclerFragment<DownloaderAdapte
   private boolean mSearchRunning;
 
   private int mSubscriberSlot;
+
+  private FloatingActionButton mFab;
 
   private final RecyclerView.OnScrollListener mScrollListener = new RecyclerView.OnScrollListener() {
     @Override
@@ -125,6 +129,16 @@ public class DownloaderFragment extends BaseMwmRecyclerFragment<DownloaderAdapte
   public void onViewCreated(@NonNull View view, @Nullable Bundle savedInstanceState)
   {
     super.onViewCreated(view, savedInstanceState);
+    mFab = view.findViewById(R.id.fab);
+    if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.M)
+    {
+      getRecyclerView().setOnScrollChangeListener((v, scrollX, scrollY, oldScrollX, oldScrollY) -> {
+        if (scrollY > oldScrollY)
+          mFab.hide();
+        else
+          mFab.show();
+      });
+    }
     mSubscriberSlot = MapManager.nativeSubscribe(new MapManager.StorageCallback()
     {
       @Override

--- a/android/app/src/main/res/layout/fragment_downloader.xml
+++ b/android/app/src/main/res/layout/fragment_downloader.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<RelativeLayout
+<androidx.coordinatorlayout.widget.CoordinatorLayout
   xmlns:android="http://schemas.android.com/apk/res/android"
   xmlns:app="http://schemas.android.com/apk/res-auto"
   xmlns:tools="http://schemas.android.com/tools"
@@ -8,44 +8,37 @@
   android:layout_width="match_parent"
   android:layout_height="match_parent">
   <include layout="@layout/toolbar_with_search"/>
-
-  <Button
-    android:id="@+id/action"
-    android:layout_width="match_parent"
-    android:layout_height="@dimen/height_block_base"
-    android:layout_alignParentBottom="true"
-    style="@style/MwmWidget.Button.Primary"
-    tools:text="@string/downloader_update_all_button"/>
-
   <include
     layout="@layout/recycler_default"
     android:layout_width="match_parent"
     android:layout_height="match_parent"
-    android:layout_below="@id/toolbar"
-    android:layout_above="@id/action"/>
-
-  <com.google.android.material.floatingactionbutton.FloatingActionButton
-    android:id="@+id/fab"
-    android:layout_width="wrap_content"
-    android:layout_height="wrap_content"
-    android:layout_above="@id/action"
-    android:layout_alignWithParentIfMissing="true"
-    android:layout_alignParentEnd="true"
-    android:layout_marginEnd="@dimen/margin_base"
-    android:layout_marginBottom="@dimen/margin_base"
-    app:tint="?android:textColorPrimaryInverse"
-    app:srcCompat="@drawable/ic_plus"/>
+    android:layout_marginTop="?actionBarSize"/>
 
   <app.organicmaps.widget.PlaceholderView
     android:id="@+id/placeholder"
     android:layout_width="match_parent"
     android:layout_height="match_parent"
-    android:layout_below="@id/toolbar"
-    android:layout_above="@id/action"
     android:paddingStart="@dimen/margin_double_and_half"
     android:paddingEnd="@dimen/margin_double_and_half"
     android:paddingTop="@dimen/placeholder_margin_top"
     android:gravity="center_horizontal"
     android:visibility="gone"
     tools:visibility="visible"/>
-</RelativeLayout>
+  <Button
+    android:id="@+id/action"
+    android:layout_width="match_parent"
+    android:layout_height="@dimen/height_block_base"
+    android:layout_gravity="bottom"
+    style="@style/MwmWidget.Button.Primary"
+    tools:text="@string/downloader_update_all_button"/>
+  <com.google.android.material.floatingactionbutton.FloatingActionButton
+    android:id="@+id/fab"
+    android:layout_width="wrap_content"
+    android:layout_height="wrap_content"
+    android:layout_gravity="bottom|end"
+    android:layout_marginEnd="@dimen/margin_base"
+    android:layout_marginBottom="@dimen/margin_quadruple"
+    app:tint="?android:textColorPrimaryInverse"
+    app:srcCompat="@drawable/ic_plus" />
+
+</androidx.coordinatorlayout.widget.CoordinatorLayout>


### PR DESCRIPTION
Fixes #5064
Closes #5085 #5248

This PR rework fragment downloader screen:
- Replace RelativeLayout by CoordinatorLayout (more modern component and offer better performance)
- Reorganize order of items in layout
- Use `app:layout_behavior` property to implement auto hide

|Before|After|
|-|-|
|<img src="https://github.com/organicmaps/organicmaps/assets/87148630/383059a6-4aa3-42fc-bf1e-229557545e7f" height=300 />|<img src="https://github.com/organicmaps/organicmaps/assets/87148630/ed22ccbf-da99-43cf-be59-c52071968e83" height=300/>|

https://github.com/organicmaps/organicmaps/assets/87148630/326318ae-26ef-4ad7-842f-ec4a202b4e29

https://github.com/organicmaps/organicmaps/assets/87148630/ade5ee28-5c24-4d86-9f29-870ec50e1ea8

