### PR TITLE
Set last modified time for imported KML or GPX before saving them

### DIFF
--- a/map/bookmark_manager.cpp
+++ b/map/bookmark_manager.cpp
@@ -202,6 +202,11 @@ bool GetSortingType(std::string const & typeStr, BookmarkManager::SortingType & 
     return false;
   return true;
 }
+
+kml::Timestamp FileModificationTimestamp(std::string const & fullFilePath)
+{
+  return kml::TimestampClock::from_time_t(Platform::GetFileModificationTime(fullFilePath));
+}
 }  // namespace
 
 BookmarkManager::BookmarkManager(Callbacks && callbacks)
@@ -606,7 +611,7 @@ std::vector<BookmarkManager::SortingType> BookmarkManager::GetAvailableSortingTy
     }
 
     if (!byTimeChecked)
-      byTimeChecked = !kml::IsEqual(bookmarkData.m_timestamp, kml::Timestamp());
+      byTimeChecked = !kml::IsEqual(bookmarkData.m_timestamp, kml::Timestamp{});
 
     if (byTypeChecked && byTimeChecked)
       break;
@@ -616,7 +621,7 @@ std::vector<BookmarkManager::SortingType> BookmarkManager::GetAvailableSortingTy
   {
     for (auto trackId : group->GetUserLines())
     {
-      if (!kml::IsEqual(GetTrack(trackId)->GetData().m_timestamp, kml::Timestamp()))
+      if (!kml::IsEqual(GetTrack(trackId)->GetData().m_timestamp, kml::Timestamp{}))
       {
         byTimeChecked = true;
         break;
@@ -1105,7 +1110,7 @@ void BookmarkManager::SortTracksByTime(std::vector<SortTrackData> & tracks)
   bool hasTimestamp = false;
   for (auto const & track : tracks)
   {
-    if (!kml::IsEqual(track.m_timestamp, kml::Timestamp()))
+    if (!kml::IsEqual(track.m_timestamp, kml::Timestamp{}))
     {
       hasTimestamp = true;
       break;
@@ -1217,7 +1222,7 @@ void BookmarkManager::SortByTime(std::vector<SortBookmarkData> const & bookmarks
   for (auto mark : sortedMarks)
   {
     auto currentBlockType = SortedByTimeBlockType::Others;
-    if (mark->m_timestamp != kml::Timestamp())
+    if (mark->m_timestamp != kml::Timestamp{})
       currentBlockType = GetSortedByTimeBlockType(currentTime - mark->m_timestamp);
 
     if (!lastBlockType)
@@ -1941,12 +1946,17 @@ void BookmarkManager::LoadBookmarkRoutine(std::string const & filePath, bool isT
         ASSERT(false, ("Unsupported bookmarks extension", ext));
       }
 
+      base::DeleteFileX(fileToLoad);
+
       if (m_needTeardown)
         return;
 
-      base::DeleteFileX(fileToLoad);
       if (kmlData && (!kmlData->m_tracksData.empty() || !kmlData->m_bookmarksData.empty()))
       {
+        // Set last modified date for imported tracks before saving them, if it wasn't set in KML/GPX file.
+        if (kmlData->m_categoryData.m_lastModified == kml::Timestamp{})
+          kmlData->m_categoryData.m_lastModified = FileModificationTimestamp(filePath);
+
         auto kmlFileToLoad = GenerateValidAndUniqueFilePathForKML(base::GetNameFromFullPathWithoutExt(fileToLoad));
 
         if (!SaveKmlFileSafe(*kmlData, kmlFileToLoad, KmlFileType::Text))
@@ -1960,8 +1970,6 @@ void BookmarkManager::LoadBookmarkRoutine(std::string const & filePath, bool isT
       return;
 
     NotifyAboutFile(!collection->empty() /* success */, filePath, isTemporaryFile);
-
-    UpdateLastModifiedTime(*collection);
     NotifyAboutFinishAsyncLoading(std::move(collection));
   });
 }
@@ -2403,22 +2411,20 @@ UserMarkLayer * BookmarkManager::GetGroup(kml::MarkGroupId groupId) const
   return catIt->second.get();
 }
 
-void BookmarkManager::UpdateLastModifiedTime(KMLDataCollection & collection)
-{
-  for (auto const & [_, c] : collection)
-    c->m_categoryData.m_lastModified = kml::TimestampClock::now();
-}
-
+// Despite the name, this method is called not only for newly created categories, but also for loaded/imported ones.
 void BookmarkManager::CreateCategories(KMLDataCollection && dataCollection, bool autoSave /* = false */)
 {
   CHECK_THREAD_CHECKER(m_threadChecker, ());
   kml::GroupIdSet loadedGroups;
 
-  for (auto const & data : dataCollection)
+  for (auto const & [fileName, fileDataPtr] : dataCollection)
   {
-    auto const & fileName = data.first;
-    auto & fileData = *data.second;
+    auto & fileData = *fileDataPtr;
     auto & categoryData = fileData.m_categoryData;
+
+    // Initialize timestamp for newly created or imported categories.
+    if (categoryData.m_lastModified == kml::Timestamp{})
+      categoryData.m_lastModified = fileName.empty() ? kml::TimestampClock::now() : FileModificationTimestamp(fileName);
 
     if (!UserMarkIdStorage::Instance().CheckIds(fileData) || HasDuplicatedIds(fileData))
     {

--- a/map/bookmark_manager.hpp
+++ b/map/bookmark_manager.hpp
@@ -364,7 +364,6 @@ public:
   bool SaveBookmarkCategory(kml::MarkGroupId groupId);
   bool SaveBookmarkCategory(kml::MarkGroupId groupId, Writer & writer, KmlFileType fileType) const;
 
-  static void UpdateLastModifiedTime(KMLDataCollection & collection);
   // Used for LoadBookmarks() and unit tests only. Does *not* update last modified time.
   void CreateCategories(KMLDataCollection && dataCollection, bool autoSave = false);
 

--- a/map/map_tests/bookmarks_test.cpp
+++ b/map/map_tests/bookmarks_test.cpp
@@ -1063,7 +1063,6 @@ UNIT_CLASS_TEST(Runner, Bookmarks_SpecialXMLNames)
   kmlDataCollection3.emplace_back("" /* filePath */,
                                   LoadKmlData(MemReader(kmlString3, strlen(kmlString3)), KmlFileType::Text));
 
-  bmManager.UpdateLastModifiedTime(kmlDataCollection3);
   bmManager.CreateCategories(std::move(kmlDataCollection3));
 
   TEST_EQUAL(bmManager.GetBmGroupsIdList().size(), 2, ());

--- a/platform/platform.hpp
+++ b/platform/platform.hpp
@@ -237,6 +237,8 @@ public:
 
   /// @return 0 in case of failure.
   static time_t GetFileCreationTime(std::string const & path);
+  /// @return 0 in case of failure.
+  static time_t GetFileModificationTime(std::string const & path);
 
   /// Used to check available free storage space for downloading.
   enum TStorageStatus

--- a/platform/platform_android.cpp
+++ b/platform/platform_android.cpp
@@ -241,3 +241,12 @@ time_t Platform::GetFileCreationTime(std::string const & path)
     return st.st_atim.tv_sec;
   return 0;
 }
+
+// static
+time_t Platform::GetFileModificationTime(std::string const & path)
+{
+  struct stat st;
+  if (0 == stat(path.c_str(), &st))
+    return st.st_mtim.tv_sec;
+  return 0;
+}

--- a/platform/platform_ios.mm
+++ b/platform/platform_ios.mm
@@ -258,6 +258,15 @@ time_t Platform::GetFileCreationTime(std::string const & path)
   return 0;
 }
 
+// static
+time_t Platform::GetFileModificationTime(std::string const & path)
+{
+  struct stat st;
+  if (0 == stat(path.c_str(), &st))
+    return st.st_mtimespec.tv_sec;
+  return 0;
+}
+
 ////////////////////////////////////////////////////////////////////////
 extern Platform & GetPlatform()
 {

--- a/platform/platform_linux.cpp
+++ b/platform/platform_linux.cpp
@@ -278,3 +278,12 @@ time_t Platform::GetFileCreationTime(std::string const & path)
 #endif
   return 0;
 }
+
+// static
+time_t Platform::GetFileModificationTime(std::string const & path)
+{
+  struct stat st;
+  if (0 == stat(path.c_str(), &st))
+    return st.st_mtim.tv_sec;
+  return 0;
+}

--- a/platform/platform_mac.mm
+++ b/platform/platform_mac.mm
@@ -192,3 +192,12 @@ time_t Platform::GetFileCreationTime(std::string const & path)
     return st.st_birthtimespec.tv_sec;
   return 0;
 }
+
+// static
+time_t Platform::GetFileModificationTime(std::string const & path)
+{
+  struct stat st;
+  if (0 == stat(path.c_str(), &st))
+    return st.st_mtimespec.tv_sec;
+  return 0;
+}

--- a/platform/platform_tests/platform_test.cpp
+++ b/platform/platform_tests/platform_test.cpp
@@ -307,3 +307,27 @@ UNIT_TEST(Platform_ThreadRunner)
                  "But app must not be crashed. It is normal behaviour during destruction"));
   });
 }
+
+UNIT_TEST(GetFileCreationTime_GetFileModificationTime)
+{
+  auto const now = std::time(nullptr);
+
+  std::string_view constexpr kContent{"HOHOHO"};
+  std::string const fileName = GetPlatform().WritablePathForFile(TEST_FILE_NAME);
+  {
+    FileWriter testFile(fileName);
+    testFile.Write(kContent.data(), kContent.size());
+  }
+  SCOPE_GUARD(removeTestFile, bind(&base::DeleteFileX, fileName));
+
+  auto const creationTime = Platform::GetFileCreationTime(fileName);
+  TEST_GREATER_OR_EQUAL(creationTime, now, ());
+
+  {
+    FileWriter testFile(fileName);
+    testFile.Write(kContent.data(), kContent.size());
+  }
+
+  auto const modificationTime = Platform::GetFileModificationTime(fileName);
+  TEST_GREATER_OR_EQUAL(modificationTime, creationTime, ());
+}


### PR DESCRIPTION
Fixes #7564

@cyber-toad The fix was easy, there is no need to use the last modified file time because files are often copied anyway just before importing them, due to system restrictions.

@kirylkaveryn can you please test it and confirm that the fix works?