### PR TITLE
[ios] Fix bug when the user's 'saved bookmark' tab icon has wrong selected color and icon

### DIFF
--- a/iphone/Maps/UI/PlacePage/PlacePageLayout/ActionBar/MWMActionBarButton.m
+++ b/iphone/Maps/UI/PlacePage/PlacePageLayout/ActionBar/MWMActionBarButton.m
@@ -201,7 +201,11 @@ NSString *titleForButton(MWMActionBarButtonType type, BOOL isSelected) {
 
 - (void)traitCollectionDidChange:(UITraitCollection *)previousTraitCollection {
   [super traitCollectionDidChange:previousTraitCollection];
-  [self.button setSelected:false];
+  if (@available(iOS 13.0, *)) {
+    if ([self.traitCollection hasDifferentColorAppearanceComparedToTraitCollection:previousTraitCollection])
+      // Update button for the current selection state.
+      [self.button setSelected:self.button.isSelected];
+  }
 }
 
 - (UIView *)hitTest:(CGPoint)point withEvent:(UIEvent *)event {


### PR DESCRIPTION
Closes https://github.com/organicmaps/organicmaps/issues/7567

This bug is caused by https://github.com/organicmaps/organicmaps/pull/7292

Sometimes when the `traitCollectionDidChange` was called by the system during the view's initialization from nib on a device this icon was redrawn in a wrong way: the icon changed its state from selected to deselected by mistake.

This PF fixes this bug. 

Before:
https://github.com/organicmaps/organicmaps/assets/79797627/cb3668af-e53c-4cbf-9417-be3e689c47d2

After:
https://github.com/organicmaps/organicmaps/assets/79797627/4c6409f3-018c-4205-b733-242ebd1c6a0b

![Simulator Screen Recording - iPhone 15 Pro - 2024-03-16 at 13 57 18](https://github.com/organicmaps/organicmaps/assets/79797627/c0680c9a-6b96-43b9-950b-5eeb5c3dabeb)
