### PR TITLE
[tools] Migrate all the scripts to Python3

### DIFF
--- a/generator/pygen/example.py
+++ b/generator/pygen/example.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 import argparse
 import os
 import timeit

--- a/generator/pygen/setup.py
+++ b/generator/pygen/setup.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 # -*- coding: utf-8 -*-
 import os
 import sys

--- a/kml/pykmlib/setup.py
+++ b/kml/pykmlib/setup.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 # -*- coding: utf-8 -*-
 import os
 import sys

--- a/pyhelpers/setup.py
+++ b/pyhelpers/setup.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 # -*- coding: utf-8 -*-
 import inspect
 import linecache

--- a/search/pysearch/setup.py
+++ b/search/pysearch/setup.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 # -*- coding: utf-8 -*-
 import os
 import sys

--- a/tools/download_statistics/aggregator.py
+++ b/tools/download_statistics/aggregator.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 #coding: utf-8
 
 from collections import defaultdict

--- a/tools/download_statistics/resolver.py
+++ b/tools/download_statistics/resolver.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 #coding: utf-8
 
 import geoip2.database

--- a/tools/python/InstrumentsTraceParser.py
+++ b/tools/python/InstrumentsTraceParser.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python2.7
+#!/usr/bin/env python3
 
 from __future__ import print_function
 import struct

--- a/tools/python/airmaps/setup.py
+++ b/tools/python/airmaps/setup.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 import os
 import sys
 

--- a/tools/python/booking_hotels_quality.py
+++ b/tools/python/booking_hotels_quality.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 # coding: utf8
 from __future__ import print_function
 

--- a/tools/python/categories_converter.py
+++ b/tools/python/categories_converter.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python2.7
+#!/usr/bin/env python3
 #coding: utf8
 from __future__ import print_function
 

--- a/tools/python/convert_strings.py
+++ b/tools/python/convert_strings.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 import argparse
 import csv
 import sys

--- a/tools/python/data/all/setup.py
+++ b/tools/python/data/all/setup.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 import os
 import sys
 

--- a/tools/python/data/borders/setup.py
+++ b/tools/python/data/borders/setup.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 import os
 import sys
 import tarfile

--- a/tools/python/data/essential/setup.py
+++ b/tools/python/data/essential/setup.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 import os
 import sys
 

--- a/tools/python/data/fonts/setup.py
+++ b/tools/python/data/fonts/setup.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 import os
 import sys
 

--- a/tools/python/data/styles/setup.py
+++ b/tools/python/data/styles/setup.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 import os
 import sys
 

--- a/tools/python/data_files/setup.py
+++ b/tools/python/data_files/setup.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 import os
 import sys
 

--- a/tools/python/descriptions/setup.py
+++ b/tools/python/descriptions/setup.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 import os
 import sys
 

--- a/tools/python/generate_styles_override.py
+++ b/tools/python/generate_styles_override.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 
 import sys
 import os

--- a/tools/python/maps_generator/setup.py
+++ b/tools/python/maps_generator/setup.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 import os
 import sys
 

--- a/tools/python/mwm/setup.py
+++ b/tools/python/mwm/setup.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 import os
 import sys
 

--- a/tools/python/opentable_restaurants.py
+++ b/tools/python/opentable_restaurants.py
@@ -1,4 +1,4 @@
-#! /usr/bin/env python2.7
+#!/usr/bin/env python3
 # coding: utf-8
 
 from __future__ import print_function

--- a/tools/python/po_parser.py
+++ b/tools/python/po_parser.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python2.7
+#!/usr/bin/env python3
 #coding: utf8
 from __future__ import print_function
 

--- a/tools/python/post_generation/setup.py
+++ b/tools/python/post_generation/setup.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 import os
 import sys
 

--- a/tools/python/road_runner.py
+++ b/tools/python/road_runner.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/env python3
 # -*- coding: utf-8 -*-
 
 import os, sys, json

--- a/tools/python/stylesheet/cat_stat.py
+++ b/tools/python/stylesheet/cat_stat.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 
 """
 First lists tags used by Organic Maps

--- a/tools/python/stylesheet/drules_dump.py
+++ b/tools/python/stylesheet/drules_dump.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/env python3
 # Dumps hashes of protobuffed drules
 import sys, re
 import itertools

--- a/tools/python/stylesheet/drules_to_mapcss.py
+++ b/tools/python/stylesheet/drules_to_mapcss.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 # -*- coding: utf-8 -*-
 import csv
 import os

--- a/tools/python/taxi_csv_to_json.py
+++ b/tools/python/taxi_csv_to_json.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 # coding: utf8
 
 from argparse import ArgumentParser

--- a/tools/python/testlog_to_xml_converter.py
+++ b/tools/python/testlog_to_xml_converter.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 
 '''
 This script generates jUnit-style xml files from the log written by our tests.

--- a/tools/python/tts_languages.py
+++ b/tools/python/tts_languages.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 from __future__ import print_function
 from optparse import OptionParser
 import re

--- a/tools/python_tests/permissions_test.py
+++ b/tools/python_tests/permissions_test.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 
 import logging
 import re

--- a/tools/unix/diff_features.py
+++ b/tools/unix/diff_features.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/env python3
 import sys, re
 
 RE_STAT = re.compile(r'(?:\d+\. )?([\w:|-]+?)\|: size = (\d+); count = (\d+); length = ([0-9.e+-]+) m; area = ([0-9.e+-]+) m.\s*')

--- a/tools/unix/diff_size.py
+++ b/tools/unix/diff_size.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/env python3
 import os, sys
 
 if len(sys.argv) < 3:

--- a/tracking/pytracking/setup.py
+++ b/tracking/pytracking/setup.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 # -*- coding: utf-8 -*-
 import os
 import sys

--- a/traffic/pytraffic/setup.py
+++ b/traffic/pytraffic/setup.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 # -*- coding: utf-8 -*-
 import os
 import sys


### PR DESCRIPTION
I was working on #5060 when I realized that some scripts are still partially or fully configured to run on Python 2.7.
This makes little sense when the official installation document lists Python3 as a requirement with no mention of 2.7.

This change ensures that everyone uses the latest Python3 and scripts work as intended.