### PR TITLE
[android] Fixed crash on import from Google Play console

### DIFF
--- a/android/app/src/main/java/app/organicmaps/bookmarks/data/BookmarkManager.java
+++ b/android/app/src/main/java/app/organicmaps/bookmarks/data/BookmarkManager.java
@@ -439,7 +439,9 @@ public enum BookmarkManager
     if (filename == null)
     {
       filename = uri.getPath();
-      int cut = filename.lastIndexOf('/');
+      if (filename == null)
+        return null;
+      final int cut = filename.lastIndexOf('/');
       if (cut != -1)
         filename = filename.substring(cut + 1);
     }


### PR DESCRIPTION
https://play.google.com/console/u/0/developers/8084273541548442467/app/4972992444534608608/vitals/crashes/9f663a1423226fb31ff57370a1077148/details?days=28&versionCode=24030904%2C24030318%2C24030203%2C24030102


```
Exception java.lang.NullPointerException: Attempt to invoke virtual method 'int java.lang.String.lastIndexOf(int)' on a null object reference
  at app.organicmaps.bookmarks.data.BookmarkManager.getBookmarksFilenameFromUri (BookmarkManager.java:439)
  at app.organicmaps.bookmarks.data.BookmarkManager.importBookmarksFile (BookmarkManager.java:477)
  at app.organicmaps.intent.Factory$KmzKmlProcessor.lambda$process$0 (Factory.java:55)
  at java.util.concurrent.ThreadPoolExecutor.runWorker (ThreadPoolExecutor.java:1145)
  at java.util.concurrent.ThreadPoolExecutor$Worker.run (ThreadPoolExecutor.java:644)
  at java.lang.Thread.run (Thread.java:1012)
```