### PR TITLE
[android] Fixed crash when opening PP displaying 24h opening hours with 12h system time format

### DIFF
--- a/android/app/src/main/java/app/organicmaps/editor/data/HoursMinutes.java
+++ b/android/app/src/main/java/app/organicmaps/editor/data/HoursMinutes.java
@@ -21,7 +21,9 @@ public class HoursMinutes implements Parcelable
   public final long minutes;
   private final boolean m24HourFormat;
 
-  public HoursMinutes(@IntRange(from = 0, to = 23) long hours,
+  // 24 hours or even 25 and higher values are used in OSM data and passed here from JNI calls.
+  // Example: 18:00-24:00
+  public HoursMinutes(@IntRange(from = 0, to = 24) long hours,
                       @IntRange(from = 0, to = 59) long minutes, boolean is24HourFormat)
   {
     this.hours = hours;
@@ -43,7 +45,8 @@ public class HoursMinutes implements Parcelable
     if (m24HourFormat)
       return StringUtils.formatUsingUsLocale("%02d:%02d", hours, minutes);
 
-    final LocalTime localTime = LocalTime.of((int) hours, (int) minutes);
+    // Formatting a string here with hours outside of 0-23 range causes DateTimeException.
+    final LocalTime localTime = LocalTime.of((int) hours % 24, (int) minutes);
     return localTime.format(DateTimeFormatter.ofPattern("hh:mm a"));
   }
 


### PR DESCRIPTION
The fix for another crash caused by ede7eda0c00df40a6cb23330ee888cbc64eca50e

CC @Isira-Seneviratne @rtsisyk 

```
03-19 16:26:26.539 E/AndroidRuntime( 2828): FATAL EXCEPTION: main
03-19 16:26:26.539 E/AndroidRuntime( 2828): Process: app.organicmaps, PID: 2828
03-19 16:26:26.539 E/AndroidRuntime( 2828): j$.time.DateTimeException: Invalid value for HourOfDay (valid values 0 - 23): 24
03-19 16:26:26.539 E/AndroidRuntime( 2828):  at j$.time.temporal.ValueRange.checkValidValue(Unknown Source:13)
03-19 16:26:26.539 E/AndroidRuntime( 2828):  at j$.time.temporal.ChronoField.checkValidValue(Unknown Source:4)
03-19 16:26:26.539 E/AndroidRuntime( 2828):  at j$.time.LocalTime.of(Unknown Source:3)
03-19 16:26:26.539 E/AndroidRuntime( 2828):  at app.organicmaps.editor.data.HoursMinutes.toString(HoursMinutes.java:46)
03-19 16:26:26.539 E/AndroidRuntime( 2828):  at java.lang.String.valueOf(String.java:2827)
03-19 16:26:26.539 E/AndroidRuntime( 2828):  at java.lang.StringBuilder.append(StringBuilder.java:132)
03-19 16:26:26.539 E/AndroidRuntime( 2828):  at app.organicmaps.editor.data.Timespan.toWideString(Timespan.java:27)
03-19 16:26:26.539 E/AndroidRuntime( 2828):  at app.organicmaps.widget.placepage.sections.PlacePageOpeningHoursFragment.refreshOpeningHours(PlacePageOpeningHoursFragment.java:133)
03-19 16:26:26.539 E/AndroidRuntime( 2828):  at app.organicmaps.widget.placepage.sections.PlacePageOpeningHoursFragment.onChanged(PlacePageOpeningHoursFragment.java:198)
03-19 16:26:26.539 E/AndroidRuntime( 2828):  at app.organicmaps.widget.placepage.sections.PlacePageOpeningHoursFragment.onChanged(PlacePageOpeningHoursFragment.java:34)
03-19 16:26:26.539 E/AndroidRuntime( 2828):  at androidx.lifecycle.LiveData.considerNotify(LiveData.java:133)
03-19 16:26:26.539 E/AndroidRuntime( 2828):  at androidx.lifecycle.LiveData.dispatchingValue(LiveData.java:146)
03-19 16:26:26.539 E/AndroidRuntime( 2828):  at androidx.lifecycle.LiveData$ObserverWrapper.activeStateChanged(LiveData.java:483)
03-19 16:26:26.539 E/AndroidRuntime( 2828):  at androidx.lifecycle.LiveData$LifecycleBoundObserver.onStateChanged(LiveData.java:440)
03-19 16:26:26.539 E/AndroidRuntime( 2828):  at androidx.lifecycle.LifecycleRegistry$ObserverWithState.dispatchEvent(LifecycleRegistry.kt:322)
03-19 16:26:26.539 E/AndroidRuntime( 2828):  at androidx.lifecycle.LifecycleRegistry.addObserver(LifecycleRegistry.kt:199)
03-19 16:26:26.539 E/AndroidRuntime( 2828):  at androidx.lifecycle.LiveData.observe(LiveData.java:205)
03-19 16:26:26.539 E/AndroidRuntime( 2828):  at app.organicmaps.widget.placepage.sections.PlacePageOpeningHoursFragment.onStart(PlacePageOpeningHoursFragment.java:184)
```