### PR TITLE
[editor] Fix parsing of 'off' opening hours

### DIFF
--- a/editor/editor_tests/ui2oh_test.cpp
+++ b/editor/editor_tests/ui2oh_test.cpp
@@ -361,8 +361,7 @@ UNIT_TEST(OpeningHours2TimeTableSet_off)
     TEST(MakeTimeTableSet(oh, tts), ());
     TEST_EQUAL(tts.Size(), 1, ());
 
-    TEST_EQUAL(tts.GetUnhandledDays(),
-               OpeningDays({osmoh::Weekday::Monday}), ());
+    TEST_EQUAL(tts.GetUnhandledDays(), OpeningDays({osmoh::Weekday::Monday}), ());
 
     auto const tt = tts.Get(0);
 

--- a/editor/editor_tests/ui2oh_test.cpp
+++ b/editor/editor_tests/ui2oh_test.cpp
@@ -352,6 +352,23 @@ UNIT_TEST(OpeningHours2TimeTableSet_off)
     TEST_EQUAL(tt.GetExcludeTime()[0].GetStart().GetHourMinutes().GetHoursCount(), 11, ());
     TEST_EQUAL(tt.GetExcludeTime()[0].GetEnd().GetHourMinutes().GetHoursCount(), 13, ());
   }
+  {
+    OpeningHours oh("Mo off; Tu-Su 09:00-17:00");
+    TEST(oh.IsValid(), ());
+
+    TimeTableSet tts;
+
+    TEST(MakeTimeTableSet(oh, tts), ());
+    TEST_EQUAL(tts.Size(), 1, ());
+
+    TEST_EQUAL(tts.GetUnhandledDays(),
+               OpeningDays({osmoh::Weekday::Monday}), ());
+
+    auto const tt = tts.Get(0);
+
+    TEST_EQUAL(tt.GetOpeningTime().GetStart().GetHourMinutes().GetHoursCount(), 9, ());
+    TEST_EQUAL(tt.GetOpeningTime().GetEnd().GetHourMinutes().GetHoursCount(), 17, ());
+  }
 }
 
 UNIT_TEST(OpeningHours2TimeTableSet_plus)

--- a/editor/ui2oh.cpp
+++ b/editor/ui2oh.cpp
@@ -340,9 +340,9 @@ bool MakeTimeTableSet(osmoh::OpeningHours const & oh, ui::TimeTableSet & tts)
 
     if (rulePart.GetModifier() == osmoh::RuleSequence::Modifier::Closed)
     {
-      // off modifier in the first part in oh is useless.
+      // Off modifier in the first part in oh is useless. Skip it.
       if (first == true)
-        return false;
+        continue;
 
       if (!ExcludeRulePart(rulePart, tts))
         return false;
@@ -374,6 +374,14 @@ bool MakeTimeTableSet(osmoh::OpeningHours const & oh, ui::TimeTableSet & tts)
     first = false;
     if (!appended)
       return false;
+  }
+
+  // Check if no OH rule has been correctly processed.
+  if (first)
+  {
+    // No OH rule has been correctly processed.
+    // Set OH parsing as invalid.
+    return false;
   }
 
   return true;


### PR DESCRIPTION
This PR fixes the parsing of the "opening hours" strings that start with an "off" statement.

One example of opening hours not being processed correctly is the opening_hours tag `Mo off; Tu-Su 12:00-16:30, 19:00-24:00` of [this restaurant in OSM](https://www.openstreetmap.org/node/9592619990).

Current opening hours parsing implementation does not like "off" statements if they are located in the first place, so this PR reorders the statements by placing the "off" ones at the end of the list.

This PR closes [PR 1612](https://github.com/organicmaps/organicmaps/issues/1612)