### PR TITLE
[bookmarks] Do not update bookmark list modification time when list visibility is changed

### DIFF
--- a/map/bookmark.cpp
+++ b/map/bookmark.cpp
@@ -324,13 +324,13 @@ void BookmarkCategory::SetIsVisible(bool isVisible)
 
 void BookmarkCategory::SetName(std::string const & name)
 {
-  SetDirty();
+  SetDirty(true /* updateModificationTime */);
   kml::SetDefaultStr(m_data.m_name, name);
 }
 
 void BookmarkCategory::SetDescription(std::string const & desc)
 {
-  SetDirty();
+  SetDirty(true /* updateModificationTime */);
   kml::SetDefaultStr(m_data.m_description, desc);
 }
 
@@ -339,7 +339,7 @@ void BookmarkCategory::SetServerId(std::string const & serverId)
   if (m_serverId == serverId)
     return;
 
-  SetDirty();
+  SetDirty(true /* updateModificationTime */);
   m_serverId = serverId;
 }
 
@@ -348,7 +348,7 @@ void BookmarkCategory::SetTags(std::vector<std::string> const & tags)
   if (m_data.m_tags == tags)
     return;
 
-  SetDirty();
+  SetDirty(true /* updateModificationTime */);
   m_data.m_tags = tags;
 }
 
@@ -358,7 +358,7 @@ void BookmarkCategory::SetCustomProperty(std::string const & key, std::string co
   if (it != m_data.m_properties.end() && it->second == value)
     return;
 
-  SetDirty();
+  SetDirty(true /* updateModificationTime */);
   m_data.m_properties[key] = value;
 }
 
@@ -378,7 +378,7 @@ void BookmarkCategory::SetAuthor(std::string const & name, std::string const & i
   if (m_data.m_authorName == name && m_data.m_authorId == id)
     return;
 
-  SetDirty();
+  SetDirty(true /* updateModificationTime */);
   m_data.m_authorName = name;
   m_data.m_authorId = id;
 }
@@ -388,7 +388,7 @@ void BookmarkCategory::SetAccessRules(kml::AccessRules accessRules)
   if (m_data.m_accessRules == accessRules)
     return;
 
-  SetDirty();
+  SetDirty(true /* updateModificationTime */);
   m_data.m_accessRules = accessRules;
 }
 
@@ -398,8 +398,9 @@ kml::PredefinedColor BookmarkCategory::GetDefaultColor()
   return kml::PredefinedColor::Red;
 }
 
-void BookmarkCategory::SetDirty()
+void BookmarkCategory::SetDirty(bool updateModificationDate)
 {
-  Base::SetDirty();
-  m_data.m_lastModified = kml::TimestampClock::now();
+  Base::SetDirty(updateModificationDate);
+  if (updateModificationDate)
+    m_data.m_lastModified = kml::TimestampClock::now();
 }

--- a/map/bookmark.hpp
+++ b/map/bookmark.hpp
@@ -116,7 +116,7 @@ public:
   void SetTags(std::vector<std::string> const & tags);
   void SetCustomProperty(std::string const & key, std::string const & value);
 
-  void SetDirty() override;
+  void SetDirty(bool updateModificationDate) override;
 
   kml::Timestamp GetLastModifiedTime() const { return m_data.m_lastModified; }
 

--- a/map/bookmark_manager.cpp
+++ b/map/bookmark_manager.cpp
@@ -1577,7 +1577,7 @@ void BookmarkManager::SetIsVisible(kml::MarkGroupId groupId, bool visible)
     {
       auto const parentId = compilationIt->second->GetParentID();
       auto * parentGroup = GetBmCategory(parentId);
-      parentGroup->SetDirty();
+      parentGroup->SetDirty(false /* updateModificationTime */);
       if (visible)  // visible == false handled in InferVisibility
         parentGroup->SetIsVisible(true);
     }
@@ -2836,7 +2836,7 @@ void BookmarkManager::SetChildCategoriesVisibility(kml::MarkGroupId categoryId, 
     if (visible != compilation.IsVisible())
     {
       compilation.SetIsVisible(visible);
-      category.SetDirty();
+      category.SetDirty(false /* updateModificationTime */);
       if (visible)
         category.SetIsVisible(true);
     }

--- a/map/user_mark_layer.cpp
+++ b/map/user_mark_layer.cpp
@@ -37,7 +37,7 @@ void UserMarkLayer::SetIsVisible(bool isVisible)
 {
   if (m_isVisible != isVisible)
   {
-    SetDirty();
+    SetDirty(false /* updateModificationDate */);
     m_isVisible = isVisible;
   }
 }

--- a/map/user_mark_layer.hpp
+++ b/map/user_mark_layer.hpp
@@ -33,7 +33,7 @@ public:
   virtual void SetIsVisible(bool isVisible);
 
 protected:
-  virtual void SetDirty() { m_isDirty = true; }
+  virtual void SetDirty(bool updateModificationDate = true) { m_isDirty = true; }
 
   UserMark::Type m_type;
 


### PR DESCRIPTION
Fixes #7645 by disabling update of the modification time when list visibility is changed.

Below is an initial text for this PR.

---


As we started to honestly sort lists by their modification time, any visibility change that modifies a list, now also changes its order.

There is a benefit in moving hidden lists at the bottom.
Moving enabled lists at the top also makes sense.

But it does not look very intuitive and convenient. Should we avoid any automatic sorting at all and allow only manual sorting? Should we add sort by name instead / in addition?

Another option is to not modify the list "last modified" field when its visibility is changed. Here we have two options:
1. Sort and show checked/visible lists first, at the top.
2. Don't sort and show a mix of checked/unchecked lists.

Any better ideas?

See how it ~works now~ used to work:

### Android
[Screen_recording_20240322_191932.webm](https://github.com/organicmaps/organicmaps/assets/170263/b04bada4-d012-475f-bdd8-6d8a66e24c1d)

### iOS

https://github.com/organicmaps/organicmaps/assets/170263/646ddfa9-f435-4b55-af18-b36216f185a8


