### PR TITLE
[android] fix the overlapping of map buttons in RTL map planning

### DIFF
--- a/android/app/src/main/res/layout/map_buttons_layout_planning.xml
+++ b/android/app/src/main/res/layout/map_buttons_layout_planning.xml
@@ -60,6 +60,7 @@
       android:layout_width="wrap_content"
       android:layout_height="wrap_content"
       android:layout_alignParentBottom="true"
-      app:layout_constraintBottom_toBottomOf="parent" />
+      app:layout_constraintBottom_toBottomOf="parent"
+      app:layout_constraintStart_toStartOf="parent" />
   </androidx.constraintlayout.widget.ConstraintLayout>
 </androidx.constraintlayout.widget.ConstraintLayout>


### PR DESCRIPTION
Fixes #7680 

Resolved the overlap issue

![fix_1](https://github.com/organicmaps/organicmaps/assets/120750626/c0e6d74a-a2b8-4285-a0d6-530a5a351cde)


