### PR TITLE
[ios] Fix the tappable area for the color selection icon in the `Edit` mode

### DIFF
--- a/iphone/Maps/Bookmarks/BookmarksList/Cells/BookmarksListCell.swift
+++ b/iphone/Maps/Bookmarks/BookmarksList/Cells/BookmarksListCell.swift
@@ -31,7 +31,7 @@ final class BookmarksListCell: UITableViewCell {
 
   // Extends the imageView tappable area.
   override func hitTest(_ point: CGPoint, with event: UIEvent?) -> UIView? {
-    if let imageView, imageView.frame.insetBy(dx: Self.extendedImageViewTappableMargin, dy: Self.extendedImageViewTappableMargin).contains(point) {
+    if let imageView, imageView.convert(imageView.bounds, to: self).insetBy(dx: Self.extendedImageViewTappableMargin, dy: Self.extendedImageViewTappableMargin).contains(point) {
       return imageView
     } else {
       return super.hitTest(point, with: event)


### PR DESCRIPTION
### Issue:
When a user enables the editing mode on the Bookmarks screen and taps on the `delete` button the color picking is starting instead of deleting.

Thus PR fixes this issue.

Tested on:
- iPhone 11pro (device)
- iPhone 6 (device)
- iPhone 15pro (sim)
- macOS

### Result:
![Simulator Screen Recording - iPhone 15 Pro - 2024-03-25 at 13 10 32](https://github.com/organicmaps/organicmaps/assets/79797627/a0282c80-107c-49e9-a63d-0b4edbafbe4c)
