### PR TITLE
[ios] Fix estimates when the following type is changing

### DIFF
--- a/iphone/Maps/Classes/CustomViews/NavigationDashboard/MWMNavigationDashboardManager+Entity.mm
+++ b/iphone/Maps/Classes/CustomViews/NavigationDashboard/MWMNavigationDashboardManager+Entity.mm
@@ -237,6 +237,9 @@ NSArray<MWMRouterTransitStepInfo *> *buildRouteTransitSteps(NSArray<MWMRoutePoin
 
 - (void)updateTransitInfo:(TransitRouteInfo const &)info {
   if (auto entity = self.entity) {
+    entity.timeToTarget = info.m_totalTimeInSec;
+    entity.targetDistance = @(info.m_totalPedestrianDistanceStr.c_str());
+    entity.targetUnits = @(info.m_totalPedestrianUnitsSuffix.c_str());
     entity.isValid = YES;
     entity.isWalk = YES;
     entity.showEta = YES;


### PR DESCRIPTION
Closes https://github.com/organicmaps/organicmaps/issues/7509

This bug was caused by the https://github.com/organicmaps/organicmaps/pull/7331 when after selecting the `Transport` routing type some properties (timeToTarget, targetDistance, targetUnits) weren't properly updated estimates.

Tested on:
- iPhone 11Pro 17.2 (device)
- iPhone 6 12.5 (device)

Result:
https://github.com/organicmaps/organicmaps/assets/79797627/0395c109-c4ce-4b21-a9fc-a4a028af1ba3

