### PR TITLE
[ios] Fix isolines reminder being displayed on top of other dialogs

### DIFF
--- a/iphone/Maps/Classes/CustomAlert/Toast/Toast.swift
+++ b/iphone/Maps/Classes/CustomAlert/Toast/Toast.swift
@@ -17,11 +17,8 @@ final class Toast: NSObject {
     return toast
   }
   
-  @objc static func hideAll(){
-    var toastsCopy = toasts
-    toastsCopy.forEach {
-      $0.hide()
-    }
+  @objc static func hideAll() {
+    toasts.forEach { $0.hide() }
   }
   
   private init(_ text: String) {
@@ -99,9 +96,9 @@ final class Toast: NSObject {
     timer?.invalidate()
     if self.blurView.superview != nil {
       UIView.animate(withDuration: kDefaultAnimationDuration,
-                     animations: { self.blurView.alpha = 0 }) { [self] _ in self.blurView.removeFromSuperview() }
+                     animations: { self.blurView.alpha = 0 }) { [self] _ in
+        self.blurView.removeFromSuperview()
+        Self.toasts.removeAll(where: { $0 === self }) }
     }
-    
-    Self.toasts.removeAll(where: { $0 === self })
   }
 }

--- a/iphone/Maps/Classes/CustomAlert/Toast/Toast.swift
+++ b/iphone/Maps/Classes/CustomAlert/Toast/Toast.swift
@@ -7,6 +7,7 @@ final class Toast: NSObject {
   }
 
   private var blurView = UIVisualEffectView(effect: UIBlurEffect(style: .dark))
+  private var timer: Timer?
 
   @objc static func toast(withText text: String) -> Toast {
     return Toast(text)
@@ -33,6 +34,10 @@ final class Toast: NSObject {
         label.topAnchor.constraint(equalTo: blurView.contentView.topAnchor, constant: 8),
         label.bottomAnchor.constraint(equalTo: blurView.contentView.bottomAnchor, constant: -8)
     ])
+  }
+  
+  deinit {
+    timer?.invalidate()
   }
 
   @objc func show() {
@@ -72,15 +77,22 @@ final class Toast: NSObject {
       self.blurView.alpha = 1
     }
 
-    Timer.scheduledTimer(timeInterval: 3,
-                         target: self,
-                         selector: #selector(onTimer),
-                         userInfo: nil,
-                         repeats: false)
+    timer = Timer.scheduledTimer(timeInterval: 3,
+                                 target: self,
+                                 selector: #selector(onTimer),
+                                 userInfo: nil,
+                                 repeats: false)
+  }
+  
+  @objc func hide() {
+    timer?.invalidate()
+    if self.blurView.superview != nil {
+      UIView.animate(withDuration: kDefaultAnimationDuration,
+                     animations: { self.blurView.alpha = 0 }) { [self] _ in self.blurView.removeFromSuperview() }
+    }
   }
 
   @objc private func onTimer() {
-    UIView.animate(withDuration: kDefaultAnimationDuration,
-                   animations: { self.blurView.alpha = 0 }) { [self] _ in self.blurView.removeFromSuperview() }
+    hide()
   }
 }

--- a/iphone/Maps/Classes/CustomAlert/Toast/Toast.swift
+++ b/iphone/Maps/Classes/CustomAlert/Toast/Toast.swift
@@ -9,10 +9,21 @@ final class Toast: NSObject {
   private var blurView = UIVisualEffectView(effect: UIBlurEffect(style: .dark))
   private var timer: Timer?
 
-  @objc static func toast(withText text: String) -> Toast {
-    return Toast(text)
-  }
+  private static var toasts: [Toast] = []
 
+  @objc static func toast(withText text: String) -> Toast {
+    let toast = Toast(text)
+    toasts.append(toast)
+    return toast
+  }
+  
+  @objc static func hideAll(){
+    var toastsCopy = toasts
+    toastsCopy.forEach {
+      $0.hide()
+    }
+  }
+  
   private init(_ text: String) {
     blurView.layer.setCorner(radius: 8)
     blurView.clipsToBounds = true
@@ -79,7 +90,7 @@ final class Toast: NSObject {
 
     timer = Timer.scheduledTimer(timeInterval: 3,
                                  target: self,
-                                 selector: #selector(onTimer),
+                                 selector: #selector(hide),
                                  userInfo: nil,
                                  repeats: false)
   }
@@ -90,9 +101,7 @@ final class Toast: NSObject {
       UIView.animate(withDuration: kDefaultAnimationDuration,
                      animations: { self.blurView.alpha = 0 }) { [self] _ in self.blurView.removeFromSuperview() }
     }
-  }
-
-  @objc private func onTimer() {
-    hide()
+    
+    Self.toasts.removeAll(where: { $0 === self })
   }
 }

--- a/iphone/Maps/Classes/CustomViews/MapViewControls/TrafficButton/MWMTrafficButtonViewController.mm
+++ b/iphone/Maps/Classes/CustomViews/MapViewControls/TrafficButton/MWMTrafficButtonViewController.mm
@@ -36,6 +36,7 @@ NSArray<UIImage *> *imagesWithName(NSString *name) {
 @property(nonatomic) NSLayoutConstraint *topOffset;
 @property(nonatomic) NSLayoutConstraint *leftOffset;
 @property(nonatomic) CGRect availableArea;
+@property(nonatomic) MWMToast *toast;
 
 @end
 
@@ -61,6 +62,11 @@ NSArray<UIImage *> *imagesWithName(NSString *name) {
 
 - (void)dealloc {
   [StyleManager.shared removeListener:self];
+}
+
+- (void)viewWillDisappear:(BOOL)animated {
+  [super viewWillDisappear:animated];
+  [self.toast hide];
 }
 
 - (void)configLayout {
@@ -110,7 +116,8 @@ NSArray<UIImage *> *imagesWithName(NSString *name) {
       break;
     case MWMMapOverlayTrafficStateNoData:
       btn.imageName = @"btn_traffic_on";
-      [[MWMToast toastWithText:L(@"traffic_data_unavailable")] show];
+      self.toast = [MWMToast toastWithText:L(@"traffic_data_unavailable")];
+      [self.toast show];
       break;
     case MWMMapOverlayTrafficStateNetworkError:
       [MWMMapOverlayManager setTrafficEnabled:NO];
@@ -118,11 +125,13 @@ NSArray<UIImage *> *imagesWithName(NSString *name) {
       break;
     case MWMMapOverlayTrafficStateExpiredData:
       btn.imageName = @"btn_traffic_outdated";
-      [[MWMToast toastWithText:L(@"traffic_update_maps_text")] show];
+      self.toast = [MWMToast toastWithText:L(@"traffic_update_maps_text")];
+      [self.toast show];
       break;
     case MWMMapOverlayTrafficStateExpiredApp:
       btn.imageName = @"btn_traffic_outdated";
-      [[MWMToast toastWithText:L(@"traffic_update_app_message")] show];
+      self.toast = [MWMToast toastWithText:L(@"traffic_update_app_message")];
+      [self.toast show];
       break;
   }
 }
@@ -133,7 +142,8 @@ NSArray<UIImage *> *imagesWithName(NSString *name) {
       break;
     case MWMMapOverlayIsolinesStateEnabled:
       if (![MWMMapOverlayManager isolinesVisible])
-        [[MWMToast toastWithText:L(@"isolines_toast_zooms_1_10")] show];
+        self.toast = [MWMToast toastWithText:L(@"isolines_toast_zooms_1_10")];
+        [self.toast show];
       break;
     case MWMMapOverlayIsolinesStateExpiredData:
       [MWMAlertViewController.activeAlertController presentInfoAlert:L(@"isolines_activation_error_dialog")];
@@ -157,7 +167,8 @@ NSArray<UIImage *> *imagesWithName(NSString *name) {
   } else if ([MWMMapOverlayManager transitEnabled]) {
     btn.imageName = @"btn_subway_on";
     if ([MWMMapOverlayManager transitState] == MWMMapOverlayTransitStateNoData)
-      [[MWMToast toastWithText:L(@"subway_data_unavailable")] show];
+      self.toast = [MWMToast toastWithText:L(@"subway_data_unavailable")];
+    [self.toast show];
   } else if ([MWMMapOverlayManager isoLinesEnabled]) {
     btn.imageName = @"btn_isoMap_on";
     [self handleIsolinesState:[MWMMapOverlayManager isolinesState]];

--- a/iphone/Maps/Classes/CustomViews/MapViewControls/TrafficButton/MWMTrafficButtonViewController.mm
+++ b/iphone/Maps/Classes/CustomViews/MapViewControls/TrafficButton/MWMTrafficButtonViewController.mm
@@ -36,7 +36,6 @@ NSArray<UIImage *> *imagesWithName(NSString *name) {
 @property(nonatomic) NSLayoutConstraint *topOffset;
 @property(nonatomic) NSLayoutConstraint *leftOffset;
 @property(nonatomic) CGRect availableArea;
-@property(nonatomic) MWMToast *toast;
 
 @end
 
@@ -66,7 +65,7 @@ NSArray<UIImage *> *imagesWithName(NSString *name) {
 
 - (void)viewWillDisappear:(BOOL)animated {
   [super viewWillDisappear:animated];
-  [self.toast hide];
+  [MWMToast hideAll];
 }
 
 - (void)configLayout {
@@ -116,8 +115,7 @@ NSArray<UIImage *> *imagesWithName(NSString *name) {
       break;
     case MWMMapOverlayTrafficStateNoData:
       btn.imageName = @"btn_traffic_on";
-      self.toast = [MWMToast toastWithText:L(@"traffic_data_unavailable")];
-      [self.toast show];
+      [[MWMToast toastWithText:L(@"traffic_data_unavailable")] show];
       break;
     case MWMMapOverlayTrafficStateNetworkError:
       [MWMMapOverlayManager setTrafficEnabled:NO];
@@ -125,13 +123,11 @@ NSArray<UIImage *> *imagesWithName(NSString *name) {
       break;
     case MWMMapOverlayTrafficStateExpiredData:
       btn.imageName = @"btn_traffic_outdated";
-      self.toast = [MWMToast toastWithText:L(@"traffic_update_maps_text")];
-      [self.toast show];
+      [[MWMToast toastWithText:L(@"traffic_update_maps_text")] show];
       break;
     case MWMMapOverlayTrafficStateExpiredApp:
       btn.imageName = @"btn_traffic_outdated";
-      self.toast = [MWMToast toastWithText:L(@"traffic_update_app_message")];
-      [self.toast show];
+      [[MWMToast toastWithText:L(@"traffic_update_app_message")] show];
       break;
   }
 }
@@ -142,8 +138,7 @@ NSArray<UIImage *> *imagesWithName(NSString *name) {
       break;
     case MWMMapOverlayIsolinesStateEnabled:
       if (![MWMMapOverlayManager isolinesVisible])
-        self.toast = [MWMToast toastWithText:L(@"isolines_toast_zooms_1_10")];
-        [self.toast show];
+        [[MWMToast toastWithText:L(@"isolines_toast_zooms_1_10")] show];
       break;
     case MWMMapOverlayIsolinesStateExpiredData:
       [MWMAlertViewController.activeAlertController presentInfoAlert:L(@"isolines_activation_error_dialog")];
@@ -167,8 +162,7 @@ NSArray<UIImage *> *imagesWithName(NSString *name) {
   } else if ([MWMMapOverlayManager transitEnabled]) {
     btn.imageName = @"btn_subway_on";
     if ([MWMMapOverlayManager transitState] == MWMMapOverlayTransitStateNoData)
-      self.toast = [MWMToast toastWithText:L(@"subway_data_unavailable")];
-    [self.toast show];
+      [[MWMToast toastWithText:L(@"subway_data_unavailable")] show];
   } else if ([MWMMapOverlayManager isoLinesEnabled]) {
     btn.imageName = @"btn_isoMap_on";
     [self handleIsolinesState:[MWMMapOverlayManager isolinesState]];


### PR DESCRIPTION
Fixing issue #7555 by adding capability to hide toast when view disappears.  Also addressed potential other cases.

https://github.com/organicmaps/organicmaps/assets/156805389/b8c4d10a-56ca-4544-9417-61b4eab98f79

Tested on iPhone 15 simulator