### PR TITLE
[android] fix the overlapping of bottom sheet and map buttons

### DIFF
--- a/android/app/src/main/res/layout/layout_nav_bottom_numbers.xml
+++ b/android/app/src/main/res/layout/layout_nav_bottom_numbers.xml
@@ -2,7 +2,7 @@
 <LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
   xmlns:tools="http://schemas.android.com/tools"
   android:layout_width="match_parent"
-  android:layout_height="wrap_content"
+  android:layout_height="65sp"
   android:gravity="center_vertical"
   android:orientation="horizontal"
   tools:background="#3000FF00"

--- a/android/app/src/main/res/values/dimens.xml
+++ b/android/app/src/main/res/values/dimens.xml
@@ -112,7 +112,7 @@
   <dimen name="nav_button_height">@dimen/primary_button_min_height</dimen>
   <dimen name="nav_icon_size">48dp</dimen>
   <dimen name="nav_bottom_gap">12dp</dimen>
-  <dimen name="nav_menu_height">70sp</dimen>
+  <dimen name="nav_menu_height">80sp</dimen>
   <dimen name="nav_menu_content_height">64dp</dimen>
   <dimen name="nav_menu_landscape_width">360dp</dimen>
 


### PR DESCRIPTION
fix #7085 

1 - Increased height of map buttons by changing nav_menu_height value from 70sp to 80sp,  in order to create more space for bottom sheet nav.
2 - Increased and fixed the size of text containing layout in order to avoid fluctuations in size of bottom sheet during navigation due to change in text.

![fix1](https://github.com/organicmaps/organicmaps/assets/120750626/c96290d4-cd57-412a-9d73-a73ca7a09656)
