### PR TITLE
[android] Run Monkey in the production mode on real devices

### DIFF
--- a/.github/workflows/android-beta.yaml
+++ b/.github/workflows/android-beta.yaml
@@ -76,7 +76,7 @@ jobs:
         run: |
           cmake --version
           ninja --version
-          ./gradlew -Pfirebase -x lint -x lintVitalGoogleBeta assembleGoogleBeta uploadCrashlyticsSymbolFileGoogleBeta uploadCrashlyticsMappingFileGoogleBeta
+          ./gradlew -Pfirebase assembleGoogleBeta uploadCrashlyticsSymbolFileGoogleBeta uploadCrashlyticsMappingFileGoogleBeta
 
       - name: Upload beta apk to App Distribution
         shell: bash

--- a/.github/workflows/android-monkey.yaml
+++ b/.github/workflows/android-monkey.yaml
@@ -31,8 +31,8 @@ jobs:
     outputs:
       updated: ${{ steps.check.outputs.updated }}
 
-  android-google-debug:
-    name: Android Google Debug
+  android-google-beta:
+    name: Android Google Beta
     runs-on: ubuntu-latest
     needs: precondition
     if: ${{ needs.precondition.outputs.updated != '' }}
@@ -76,25 +76,20 @@ jobs:
         run: |
           cmake --version
           ninja --version
-          ./gradlew -Pfirebase -Parm64-v8a -Parmeabi-v7a -Px86_64 assembleGoogleDebug uploadCrashlyticsSymbolFileGoogleDebug
+          ./gradlew -Pfirebase -Parm64 -Parmeabi-v7a assembleGoogleBeta uploadCrashlyticsSymbolFileGoogleBeta uploadCrashlyticsMappingFileGoogleBeta
 
       - name: Run monkey
         run: |
           gcloud auth activate-service-account --key-file android/app/firebase-test-lab.json
           gcloud config set project omapsapp
-          gcloud firebase test android run --app ./android/app/build/outputs/apk/google/debug/OrganicMaps-*-google-debug.apk \
+          gcloud firebase test android run --app ./android/app/build/outputs/apk/google/beta/OrganicMaps-*-google-beta.apk \
             --device model=husky,version=34 \
-            --device model=cheetah,version=33 \
+            --device model=tangorpro,version=33,orientation=landscape \
             --device model=bluejay,version=32 \
             --device model=a51,version=31 \
-            --device model=f2q,version=30 \
-            --device model=a10,version=29 \
-            --device model=Pixel2.arm,version=30 \
-            --device model=MediumPhone.arm,version=29 \
-            --device model=MediumPhone.arm,version=28 \
-            --device model=MediumPhone.arm,version=27 \
-            --device model=Pixel2.arm,version=26,orientation=landscape \
-            --device model=Nexus6,version=25 \
-            --device model=NexusLowRes,version=24 \
-            --device model=NexusLowRes,version=23,orientation=landscape \
+            --device model=f2q,version=30,orientation=landscape \
+            --device model=a10,version=29,orientation=landscape \
+            --device model=cactus,version=27 \
+            --device model=sailfish,version=25 \
+            --device model=hammerhead,version=23 \
             --timeout 15m


### PR DESCRIPTION
The debug mode occasionally fails on random asserts which are not very critical for the production. The debug mode also does not have R8 enabled, which causes certain bugs to leak into production. Use Beta instead.

This PR also removes virtual x86_64 devices from the list because they fail randomly during rendering due to inconsistency of OpenGL emulation.