### PR TITLE
[editor] Add/allow more types commonly mapped as nodes

### DIFF
--- a/android/app/src/main/res/values-bg/strings.xml
+++ b/android/app/src/main/res/values-bg/strings.xml
@@ -802,7 +802,7 @@
 	<string name="type.craft.key_cutter">Рязане на ключове</string>
 	<string name="type.craft.locksmith">Ключар</string>
 	<string name="type.craft.metal_construction">Метални конструкции</string>
-	<string name="type.craft.painter">Художник</string>
+	<string name="type.craft.painter">Бояджия</string>
 	<string name="type.craft.photographer">Фотограф</string>
 	<string name="type.shop.camera">Магазин за фотоапарати</string>
 	<string name="type.craft.plumber">Водопроводчик</string>

--- a/android/app/src/main/res/values/strings.xml
+++ b/android/app/src/main/res/values/strings.xml
@@ -1094,7 +1094,7 @@
 	<string name="type.craft.key_cutter">Key Cutting</string>
 	<string name="type.craft.locksmith">Locksmith</string>
 	<string name="type.craft.metal_construction">Metal Worker</string>
-	<string name="type.craft.painter">Painter</string>
+	<string name="type.craft.painter">House Painter</string>
 	<string name="type.craft.photographer">Photographer</string>
 	<string name="type.shop.camera">Camera Shop</string>
 	<string name="type.craft.plumber">Plumber</string>

--- a/data/categories.txt
+++ b/data/categories.txt
@@ -10626,10 +10626,10 @@ zh-Hans:锁匠
 zh-Hant:鎖匠
 
 craft-painter
-en:Painter
+en:House Painter|painter|decorator
 ar:رسام
 be:Мастак
-bg:Художник
+bg:Бояджия
 cs:Malíř
 da:Maler
 de:Maler

--- a/data/editor.config
+++ b/data/editor.config
@@ -349,6 +349,22 @@
       <type id="amenity-school" group="education">
         <include group="poi_internet" />
       </type>
+      <type id="amenity-arts_centre">
+        <include group="poi_internet" />
+      </type>
+      <type id="amenity-conference_centre">
+        <include group="poi_internet" />
+      </type>
+      <type id="amenity-events_venue">
+        <include group="poi_internet" />
+      </type>
+      <type id="amenity-exhibition_centre">
+        <include group="poi_internet" />
+      </type>
+      <type id="amenity-public_bath">
+        <include field="name" />
+        <include field="opening_hours" />
+      </type>
       <type id="amenity-taxi" can_add="no">
         <include group="poi" />
       </type>
@@ -891,6 +907,9 @@
       <type id="tourism-apartment" group="accomodation">
         <include group="poi_internet" />
       </type>
+      <type id="tourism-aquarium">
+        <include group="poi_internet" />
+      </type>
       <type id="tourism-artwork">
         <include field="name" />
       </type>
@@ -930,6 +949,9 @@
       </type>
       <type id="tourism-viewpoint">
         <include field="name" />
+      </type>
+      <type id="tourism-zoo">
+        <include group="poi_internet" />
       </type>
       <type id="amenity-bench" />
       <type id="amenity-compressed_air" />

--- a/data/editor.config
+++ b/data/editor.config
@@ -861,9 +861,6 @@
       <type id="shop-boutique" group="shop">
         <include group="poi_internet" />
       </type>
-      <type id="shop-cannabis" group="shop">
-        <include group="poi_internet" />
-      </type>
       <type id="shop-carpet" group="shop">
         <include group="poi_internet" />
       </type>
@@ -976,9 +973,6 @@
       </type>
       <type id="tourism-picnic_site" />
       <type id="leisure-picnic_table" />
-      <type id="amenity-brothel">
-        <include group="poi_internet" />
-      </type>
       <type id="leisure-park">
         <include field="name" />
         <include field="opening_hours" />
@@ -1042,7 +1036,6 @@
         <include field="name" />
         <include field="operator" />
       </type>
-
       <type id="amenity-food_court">
         <include group="poi_internet" />
       </type>
@@ -1052,15 +1045,29 @@
       <type id="amenity-money_transfer">
         <include group="poi_internet" />
       </type>
-      <type id="amenity-stripclub">
+      <type id="amenity-vehicle_inspection">
         <include group="poi_internet" />
       </type>
       <type id="amenity-gambling">
         <include group="poi_internet" />
       </type>
-      <type id="amenity-vehicle_inspection">
+
+      <!-- Displaying following types explicitly in the list of addable features could be controversial.
+           See https://github.com/organicmaps/organicmaps/pull/7709#discussion_r1542074645
+      -->
+      <type id="amenity-brothel" can_add="no">
         <include group="poi_internet" />
       </type>
+      <type id="amenity-stripclub" can_add="no">
+        <include group="poi_internet" />
+      </type>
+      <type id="shop-cannabis" group="shop" can_add="no">
+        <include group="poi_internet" />
+      </type>
+      <type id="shop-erotic" group="shop" can_add="no">
+        <include group="poi_internet" />
+      </type>
+
       <type id="emergency-defibrillator">
       </type>
       <type id="emergency-fire_hydrant">
@@ -1132,9 +1139,6 @@
         <include group="poi_internet" />
       </type>
       <type id="shop-bookmaker">
-        <include group="poi_internet" />
-      </type>
-      <type id="shop-erotic" group="shop">
         <include group="poi_internet" />
       </type>
       <type id="shop-fabric" group="shop">

--- a/data/editor.config
+++ b/data/editor.config
@@ -1106,11 +1106,12 @@
         <include field="name" />
         <include field="operator" />
       </type>
+      <!-- Uncomment after a map style is added
       <type id="man_made-water_tower">
         <include field="name" />
         <include field="operator" />
         <include field="height" />
-      </type>
+      </type>-->
       <type id="man_made-cairn">
         <include field="name" />
       </type>

--- a/data/editor.config
+++ b/data/editor.config
@@ -530,6 +530,46 @@
         <include field="name" />
 <!--        <include field="wikipedia" />-->
       </type>
+      <type id="historic-aircraft" group="historic">
+        <include field="name" />
+      </type>
+      <type id="historic-anchor" group="historic">
+        <include field="name" />
+      </type>
+      <type id="historic-boundary_stone" group="historic">
+        <include field="name" />
+      </type>
+      <type id="historic-cannon" group="historic">
+        <include field="name" />
+      </type>
+      <type id="historic-city_gate" group="historic">
+        <include field="name" />
+      </type>
+      <type id="historic-locomotive" group="historic">
+        <include field="name" />
+      </type>
+      <type id="historic-mine" group="historic">
+        <include field="name" />
+      </type>
+      <type id="historic-stone" group="historic">
+        <include field="name" />
+      </type>
+      <type id="historic-tank" group="historic">
+        <include field="name" />
+      </type>
+      <type id="historic-tomb" group="historic">
+        <include field="name" />
+      </type>
+      <type id="historic-wayside_cross" group="historic">
+        <include field="name" />
+      </type>
+      <type id="historic-wayside_shrine" group="historic">
+        <include field="name" />
+      </type>
+      <type id="historic-wreck" group="historic">
+        <include field="name" />
+      </type>
+
       <!-- Not addable as mapping as a node is uncommon, also ambiguous with amenity-grave_yard -->
       <type id="landuse-cemetery" can_add="no">
         <include group="poi" />

--- a/data/editor.config
+++ b/data/editor.config
@@ -7,7 +7,9 @@
        priority="low" (or "high") is used to override the default natural order priority of types
        when a feature has several e.g. "amenity-bank amenity-atm" - we want the "amenity-bank" preset used here.
   -->
-  <!-- TODO: in e.g. <type id="shop-bag" group="shop"> the "group" doesn't seem to be used. -->
+  <!-- TODO: grouping like in <type id="shop-bag" group="shop"> is not currently used,
+       see https://github.com/organicmaps/organicmaps/pull/7678#issuecomment-2017488467
+   -->
   <editor>
     <!-- TODO: disabling is not implemented, remove? see a todo in Editor::GetEditableProperties() -->
     <disable everywhere="no">
@@ -260,7 +262,7 @@
         <include group="poi_internet" />
         <include field="cuisine" />
       </type>
-      <type id="amenity-ferry_terminal" can_add="no">
+      <type id="amenity-ferry_terminal">
         <include group="poi_internet" />
       </type>
       <type id="amenity-fire_station">
@@ -273,7 +275,7 @@
         <include group="poi_internet" />
         <include field="operator" />
       </type>
-      <type id="amenity-grave_yard" can_add="no">
+      <type id="amenity-grave_yard">
         <include group="poi" />
       </type>
       <type id="amenity-hospital" group="health">
@@ -294,7 +296,7 @@
         <include field="operator" />
         <include field="opening_hours" />
       </type>
-      <type id="amenity-marketplace" group="big_shop" can_add="no">
+      <type id="amenity-marketplace" group="big_shop">
         <include group="poi" />
       </type>
       <type id="amenity-nightclub">
@@ -365,7 +367,7 @@
         <include field="name" />
         <include field="opening_hours" />
       </type>
-      <type id="amenity-taxi" can_add="no">
+      <type id="amenity-taxi">
         <include group="poi" />
       </type>
       <type id="amenity-telephone">
@@ -380,7 +382,7 @@
       <type id="amenity-townhall">
         <include group="poi_internet" />
       </type>
-      <type id="amenity-university" group="education" can_add="no">
+      <type id="amenity-university" group="education">
         <include group="poi_internet" />
       </type>
       <type id="amenity-waste_disposal">
@@ -450,7 +452,7 @@
       <type id="craft-plumber">
         <include group="poi_internet" />
       </type>
-      <type id="craft-sawmill" can_add="no">
+      <type id="craft-sawmill">
         <include group="poi_internet" />
       </type>
       <type id="craft-shoemaker">
@@ -459,7 +461,7 @@
       <type id="craft-tailor">
         <include group="poi_internet" />
       </type>
-      <type id="craft-winery" group="shop" can_add="no">
+      <type id="craft-winery" group="shop">
         <include group="poi_internet" />
       </type>
       <type id="craft-caterer">
@@ -507,7 +509,7 @@
       <type id="highway-bus_stop">
         <include field="name" />
       </type>
-      <type id="historic-archaeological_site" group="historic" can_add="no">
+      <type id="historic-archaeological_site" group="historic">
         <include group="poi" />
 <!--        <include field="wikipedia" />-->
       </type>
@@ -527,23 +529,27 @@
         <include field="name" />
 <!--        <include field="wikipedia" />-->
       </type>
+      <!-- Not addable as mapping as a node is uncommon, also ambigous with amenity-grave_yard -->
       <type id="landuse-cemetery" can_add="no">
         <include group="poi" />
 <!--        <include field="wikipedia" />-->
       </type>
+      <!-- Not addable as mapping as a node is uncommon -->
       <type id="leisure-garden" can_add="no">
         <include group="poi_internet" />
-        <include field="opening_hours" />
       </type>
-      <type id="leisure-sports_centre" can_add="no">
+      <type id="leisure-sports_centre">
         <include group="poi_internet" />
       </type>
+      <!-- Not addable as mapping as a node is uncommon -->
       <type id="leisure-stadium" can_add="no">
-        <include group="poi" />
+        <include group="poi_internet" />
 <!--        <include field="wikipedia" />-->
       </type>
+      <!-- Not addable as mapping as a node is uncommon -->
       <type id="leisure-swimming_pool" can_add="no">
-        <include group="poi_internet" />
+        <include field="name" />
+        <include field="opening_hours" />
       </type>
       <type id="natural-cave_entrance" group="historic">
         <include field="name" />
@@ -555,7 +561,7 @@
       <type id="natural-hot_spring">
         <include field="name" />
       </type>
-      <type id="natural-peak" can_add="no">
+      <type id="natural-peak">
         <include field="name" />
 <!--        <include field="wikipedia" />-->
 <!--        <include field="ele" />-->
@@ -592,7 +598,7 @@
       <type id="office-telecommunication" group="office">
         <include group="poi_internet" />
       </type>
-      <type id="place-farm" can_add="no">
+      <type id="place-farm">
         <include group="poi_internet" />
 <!--        <include field="wikipedia" />-->
       </type>
@@ -628,6 +634,7 @@
         <include field="name" />
       </type>
 
+      <!-- Too generic to be added -->
       <type id="shop" can_add="no">
         <include group="poi_internet" />
       </type>
@@ -715,7 +722,7 @@
       <type id="shop-department_store" group="big_shop">
         <include group="poi_internet" />
       </type>
-      <type id="shop-doityourself" group="shop" can_add="no">
+      <type id="shop-doityourself" group="shop">
         <include group="poi_internet" />
       </type>
       <type id="shop-dry_cleaning">
@@ -739,7 +746,7 @@
       <type id="shop-furniture" group="shop">
         <include group="poi_internet" />
       </type>
-      <type id="shop-garden_centre" group="big_shop" can_add="no">
+      <type id="shop-garden_centre" group="big_shop">
         <include group="poi_internet" />
       </type>
       <type id="shop-gift" group="shop">
@@ -769,7 +776,7 @@
       <type id="shop-jewelry" group="shop">
         <include group="poi_internet" />
       </type>
-      <type id="shop-kiosk" group="shop" can_add="no">
+      <type id="shop-kiosk" group="shop">
         <include group="poi_internet" />
       </type>
       <type id="shop-kitchen" group="shop">
@@ -778,6 +785,7 @@
       <type id="shop-laundry" group="shop">
         <include group="poi_internet" />
       </type>
+      <!-- Not addable as mapping as a node is uncommon -->
       <type id="shop-mall" group="big_shop" can_add="no">
         <include group="poi_internet" />
       </type>
@@ -898,7 +906,7 @@
       <type id="shop-trade" group="shop">
         <include group="poi_internet" />
       </type>
-      <type id="tourism-alpine_hut" group="accomodation" can_add="no">
+      <type id="tourism-alpine_hut" group="accomodation">
         <include group="poi_internet" />
 <!--        <include field="ele" />-->
         <include field="opening_hours" />
@@ -962,7 +970,7 @@
       </type>
       <type id="tourism-picnic_site" />
       <type id="leisure-picnic_table" />
-      <type id="amenity-brothel" can_add="no">
+      <type id="amenity-brothel">
         <include group="poi_internet" />
       </type>
       <type id="leisure-park">
@@ -1055,13 +1063,17 @@
         <include field="phone" />
       </type>
       <type id="highway-rest_area">
+        <include field="name" />
         <include field="internet" />
       </type>
+      <!-- Not addable as mapping as a node is uncommon -->
       <type id="highway-services" can_add="no">
+        <include field="name" />
+        <include field="operator" />
         <include field="internet" />
       </type>
       <type id="leisure-water_park">
-        <include group="poi" />
+        <include group="poi_internet" />
         <include field="operator" />
       </type>
       <type id="leisure-marina">
@@ -1118,7 +1130,7 @@
       <type id="shop-erotic" group="shop">
         <include group="poi_internet" />
       </type>
-      <type id="shop-fabric" group="shop" can_add="no">
+      <type id="shop-fabric" group="shop">
         <include group="poi_internet" />
       </type>
       <type id="shop-funeral_directors">
@@ -1157,7 +1169,7 @@
       <type id="shop-variety_store" group="shop">
         <include group="poi_internet" />
       </type>
-      <type id="shop-video" group="shop" can_add="no">
+      <type id="shop-video" group="shop">
         <include group="poi_internet" />
       </type>
       <type id="shop-wholesale" group="shop">
@@ -1249,22 +1261,25 @@
         <tag k="sport" v="yoga" />
         <include group="poi_internet" />
       </type-->
+      <!-- Not addable as mapping as a node is uncommon -->
       <type id="natural-beach" can_add="no">
         <include field="name" />
       </type>
+      <!-- Not addable as mapping as a node is uncommon -->
       <type id="building" can_add="no">
         <include group="address" />
       </type>
+      <!-- No consensus yet, see https://github.com/organicmaps/organicmaps/issues/6394 -->
       <type id="building-address" can_add="no">
         <include group="address" />
       </type>
       <!-- Uncomment this after a map style is added
       <type id="man_made-surveillance">
       </type-->
-      <type id="tourism-theme_park" can_add="no">
+      <type id="tourism-theme_park">
         <include group="poi_internet" />
       </type>
-      <type id="tourism-wilderness_hut" group="accomodation" can_add="no">
+      <type id="tourism-wilderness_hut" group="accomodation">
         <include group="poi_internet" />
       </type>
       <type id="man_made-water_tap">

--- a/data/editor.config
+++ b/data/editor.config
@@ -228,7 +228,7 @@
         <include group="poi_internet" />
         <include field="operator" />
       </type>
-      <type id="amenity-car_sharing" can_add="no">
+      <type id="amenity-car_sharing">
         <include group="poi" />
         <include field="operator" />
         <include field="website" />
@@ -406,6 +406,7 @@
         <include group="poi" />
         <include field="operator" />
       </type>
+      <!-- Too generic to be added -->
       <type id="craft" can_add="no">
         <include group="poi_internet" />
       </type>
@@ -421,7 +422,7 @@
       <type id="craft-carpenter">
         <include group="poi_internet" />
       </type>
-      <!-- Not addable because ambigous with shop=confectionery -->
+      <!-- Not addable because ambiguous with shop=confectionery -->
       <type id="craft-confectionery" group="shop" can_add="no">
         <include group="poi_internet" />
       </type>
@@ -431,7 +432,7 @@
       <type id="craft-electronics_repair">
         <include group="poi_internet" />
       </type>
-      <type id="craft-gardener" can_add="no">
+      <type id="craft-gardener">
         <include group="poi_internet" />
       </type>
       <type id="craft-handicraft">
@@ -440,10 +441,10 @@
       <type id="craft-hvac" group="shop">
         <include group="poi_internet" />
       </type>
-      <type id="craft-metal_construction" can_add="no">
+      <type id="craft-metal_construction">
         <include group="poi_internet" />
       </type>
-      <type id="craft-painter" can_add="no">
+      <type id="craft-painter">
         <include group="poi_internet" />
       </type>
       <type id="craft-photographer">
@@ -529,7 +530,7 @@
         <include field="name" />
 <!--        <include field="wikipedia" />-->
       </type>
-      <!-- Not addable as mapping as a node is uncommon, also ambigous with amenity-grave_yard -->
+      <!-- Not addable as mapping as a node is uncommon, also ambiguous with amenity-grave_yard -->
       <type id="landuse-cemetery" can_add="no">
         <include group="poi" />
 <!--        <include field="wikipedia" />-->
@@ -574,6 +575,7 @@
         <include field="height" />
 <!--        <include field="wikipedia" />-->
       </type>
+      <!-- Too generic to be added -->
       <type id="office" can_add="no">
         <include group="poi_internet" />
       </type>
@@ -657,6 +659,10 @@
         <include group="poi_internet" />
       </type>
       <type id="shop-bakery" group="shop">
+        <include group="poi_internet" />
+      </type>
+      <!-- Not addable because ambiguous with shop=bakery -->
+      <type id="shop-pastry" group="shop" can_add="no">
         <include group="poi_internet" />
       </type>
       <type id="shop-beauty">

--- a/data/strings/types_strings.txt
+++ b/data/strings/types_strings.txt
@@ -7591,12 +7591,12 @@
     zh-Hant = 鐵工
 
   [type.craft.painter]
-    en = Painter
+    en = House Painter
     af = Verwer
     ar = رسام
     az = Rəssam
     be = Мастак
-    bg = Художник
+    bg = Бояджия
     cs = Malíř
     da = Maler
     de = Maler

--- a/editor/editor_tests/editor_config_test.cpp
+++ b/editor/editor_tests/editor_config_test.cpp
@@ -82,8 +82,12 @@ UNIT_TEST(EditorConfig_GetTypesThatCanBeAdded)
   config.SetConfig(doc);
 
   auto const types = config.GetTypesThatCanBeAdded();
+  // A sample addable type.
   TEST(find(begin(types), end(types), "amenity-cafe") != end(types), ());
-  TEST(find(begin(types), end(types), "natural-peak") == end(types), ());
-  // Marked as "editable=no".
+  // A sample line type.
+  TEST(find(begin(types), end(types), "highway-primary") == end(types), ());
+  // A sample type marked as can_add="no".
+  TEST(find(begin(types), end(types), "landuse-cemetery") == end(types), ());
+  // A sample type marked as editable="no".
   TEST(find(begin(types), end(types), "aeroway-airport") == end(types), ());
 }

--- a/iphone/Maps/LocalizedStrings/bg.lproj/Localizable.strings
+++ b/iphone/Maps/LocalizedStrings/bg.lproj/Localizable.strings
@@ -1778,7 +1778,7 @@
 
 "type.craft.metal_construction" = "Метални конструкции";
 
-"type.craft.painter" = "Художник";
+"type.craft.painter" = "Бояджия";
 
 "type.craft.photographer" = "Фотограф";
 

--- a/iphone/Maps/LocalizedStrings/ca.lproj/Localizable.strings
+++ b/iphone/Maps/LocalizedStrings/ca.lproj/Localizable.strings
@@ -1778,7 +1778,7 @@
 
 "type.craft.metal_construction" = "Metal Worker";
 
-"type.craft.painter" = "Painter";
+"type.craft.painter" = "House Painter";
 
 "type.craft.photographer" = "Photographer";
 

--- a/iphone/Maps/LocalizedStrings/en-GB.lproj/Localizable.strings
+++ b/iphone/Maps/LocalizedStrings/en-GB.lproj/Localizable.strings
@@ -1778,7 +1778,7 @@
 
 "type.craft.metal_construction" = "Metal Worker";
 
-"type.craft.painter" = "Painter";
+"type.craft.painter" = "House Painter";
 
 "type.craft.photographer" = "Photographer";
 

--- a/iphone/Maps/LocalizedStrings/en.lproj/Localizable.strings
+++ b/iphone/Maps/LocalizedStrings/en.lproj/Localizable.strings
@@ -1778,7 +1778,7 @@
 
 "type.craft.metal_construction" = "Metal Worker";
 
-"type.craft.painter" = "Painter";
+"type.craft.painter" = "House Painter";
 
 "type.craft.photographer" = "Photographer";
 

--- a/iphone/Maps/LocalizedStrings/hi.lproj/Localizable.strings
+++ b/iphone/Maps/LocalizedStrings/hi.lproj/Localizable.strings
@@ -1778,7 +1778,7 @@
 
 "type.craft.metal_construction" = "Metal Worker";
 
-"type.craft.painter" = "Painter";
+"type.craft.painter" = "House Painter";
 
 "type.craft.photographer" = "फोटोग्राफर";
 


### PR DESCRIPTION
Many of the following types are better mapped as areas (as a building usually), however:
- its much better to have a node than nothing
- if there is a node, then its more obvious/actionable that it could be further improved
- most renderers (OM included) render them the same (icon & label) regardless whether its an area or node
- people are confused why can't they add a specific POI when they see same POI type present on the map
- https://github.com/organicmaps/organicmaps/issues/6733

I've also checked that:
- OSM wiki allows mapping a particular feature as a node
- at least 20% of mapped features are nodes, so its not uncommon way

Enabled adding which was previously disabled:
(initially when editor config was added many more types had "adding" disabled e.g. hospitals, colleges, townhalls... With the time many were add-enabled)
```
amenity-university - 25% are nodes, likely smaller institutions and branches
tourism-theme_park - 30% are nodes
amenity-grave_yard - 37% are nodes, although wiki doesn't allow explicitly
historic-archaeological_site - 70% are nodes
amenity-marketplace - 40% are nodes
amenity-taxi
amenity-brothel
craft-winery
craft-sawmill
shop-fabric
shop-video
leisure-sports_centre
natural-peak
shop-doityourself
shop-kiosk
tourism-alpine_hut
tourism-wilderness_hut
```



Added previously absent from the editor:
```
amenity-arts_centre
amenity-conference_centre
amenity-events_venue
amenity-exhibition_centre
amenity-public_bath
tourism-aquarium
tourism-zoo
tourism-resort
```

Upd.
Also made addable 
```
amenity-ferry_terminal
place-farm
```

I've reviewed types previously considered ambiguous and made some of them addable:
```
amenity-car_sharing
craft-gardener
shop-garden_center
craft-metal_construction
craft-painter - renamed to House Painter
```