### PR TITLE
[ios] Unique version/build number for each branch.

### DIFF
--- a/tools/unix/version.sh
+++ b/tools/unix/version.sh
@@ -80,10 +80,11 @@ Where format is one of the following arguments (shows current values):
 EOF
 }
 
+init
+
 if [ -z ${1:-} ] || [[ ! $(type -t "$1") == function ]]; then
   usage
   exit 1
 else
-  init
   "$1"
 fi

--- a/tools/unix/version.sh
+++ b/tools/unix/version.sh
@@ -31,7 +31,9 @@ function ios_version {
 }
 
 function ios_build {
-  echo "$COUNT"
+  MINOR=$((16#${GIT_HASH:0:4}))
+  PATCH=$((16#${GIT_HASH:4:4}))
+  echo "$COUNT.$MINOR.$PATCH"
 }
 
 function  android_name {


### PR DESCRIPTION
Use today's commits count and two numbers from commit hash in the build number
    
Now it looks like this:
    
      ios_version    2024.03.27
      ios_build      1.44211.31960
    
And allows deploying different versions from branches into the TestFlight without clashing