### PR TITLE
[ios] Fix distance freeze for locales with comma as decimal seperator

### DIFF
--- a/iphone/Maps/Classes/CarPlay/CarPlayRouter.swift
+++ b/iphone/Maps/Classes/CarPlay/CarPlayRouter.swift
@@ -242,11 +242,7 @@ extension CarPlayRouter {
   }
 
   private func createEstimates(_ routeInfo: RouteInfo) -> CPTravelEstimates? {
-    guard let distance = Double(routeInfo.distanceToTurn) else {
-      return nil
-    }
-
-    let measurement = Measurement(value: distance, unit: routeInfo.turnUnits)
+    let measurement = Measurement(value: routeInfo.distanceToTurn, unit: routeInfo.turnUnits)
     return CPTravelEstimates(distanceRemaining: measurement, timeRemaining: 0.0)
   }
 

--- a/iphone/Maps/Classes/CarPlay/CarPlayService.swift
+++ b/iphone/Maps/Classes/CarPlay/CarPlayService.swift
@@ -654,14 +654,8 @@ extension CarPlayService {
   }
 
   func createEstimates(routeInfo: RouteInfo) -> CPTravelEstimates? {
-    if let distance = Double(routeInfo.targetDistance) {
-      let measurement = Measurement(value: distance,
-                                    unit: routeInfo.targetUnits)
-      let estimates = CPTravelEstimates(distanceRemaining: measurement,
-                                        timeRemaining: routeInfo.timeToTarget)
-      return estimates
-    }
-    return nil
+    let measurement = Measurement(value: routeInfo.targetDistance, unit: routeInfo.targetUnits)
+    return CPTravelEstimates(distanceRemaining: measurement, timeRemaining: routeInfo.timeToTarget)
   }
 
   func applyUndefinedEstimates(template: CPMapTemplate, trip: CPTrip) {

--- a/iphone/Maps/Classes/CarPlay/Templates Data/RouteInfo.swift
+++ b/iphone/Maps/Classes/CarPlay/Templates Data/RouteInfo.swift
@@ -1,9 +1,9 @@
 @objc(MWMRouteInfo)
 class RouteInfo: NSObject {
   let timeToTarget: TimeInterval
-  let targetDistance: String
+  let targetDistance: Double
   let targetUnits: UnitLength
-  let distanceToTurn: String
+  let distanceToTurn: Double
   let turnUnits: UnitLength
   let streetName: String
   let turnImageName: String?
@@ -13,9 +13,9 @@ class RouteInfo: NSObject {
   let roundExitNumber: Int
 
   @objc init(timeToTarget: TimeInterval,
-             targetDistance: String,
+             targetDistance: Double,
              targetUnitsIndex: UInt8,
-             distanceToTurn: String,
+             distanceToTurn: Double,
              turnUnitsIndex: UInt8,
              streetName: String,
              turnImageName: String?,

--- a/iphone/Maps/Core/Framework/ProxyObjects/Routing/MWMRoutingManager.mm
+++ b/iphone/Maps/Core/Framework/ProxyObjects/Routing/MWMRoutingManager.mm
@@ -95,9 +95,9 @@
   }
 
   MWMRouteInfo *objCInfo = [[MWMRouteInfo alloc] initWithTimeToTarget:info.m_time
-                                                       targetDistance:@(info.m_distToTarget.GetDistanceString().c_str())
+                                                     targetDistance: info.m_distToTarget.GetDistance()
                                                      targetUnitsIndex:static_cast<UInt8>(info.m_distToTarget.GetUnits())
-                                                       distanceToTurn:@(info.m_distToTurn.GetDistanceString().c_str())
+                                                       distanceToTurn:info.m_distToTurn.GetDistance()
                                                        turnUnitsIndex:static_cast<UInt8>(info.m_distToTurn.GetUnits())
                                                            streetName:@(info.m_displayedStreetName.c_str())
                                                         turnImageName:[self turnImageName:info.m_turn isPrimary:YES]


### PR DESCRIPTION
Use NumberFormatter to parse distance instead of Double.

Fixes #6209
Fixes #6478