### PR TITLE
[android] Change color for disabled texts

### DIFF
--- a/android/app/src/main/res/color/text_color_primary.xml
+++ b/android/app/src/main/res/color/text_color_primary.xml
@@ -1,0 +1,5 @@
+<?xml version="1.0" encoding="utf-8"?>
+<selector xmlns:android="http://schemas.android.com/apk/res/android">
+  <item android:state_enabled="false" android:color="@color/text_dark_subtitle" />
+  <item android:color="@color/text_dark" />
+</selector>

--- a/android/app/src/main/res/color/text_color_primary_dark.xml
+++ b/android/app/src/main/res/color/text_color_primary_dark.xml
@@ -1,0 +1,5 @@
+<?xml version="1.0" encoding="utf-8"?>
+<selector xmlns:android="http://schemas.android.com/apk/res/android">
+  <item android:state_enabled="false" android:color="@color/text_light_subtitle" />
+  <item android:color="@color/text_light" />
+</selector>

--- a/android/app/src/main/res/color/text_color_secondary.xml
+++ b/android/app/src/main/res/color/text_color_secondary.xml
@@ -1,0 +1,5 @@
+<?xml version="1.0" encoding="utf-8"?>
+<selector xmlns:android="http://schemas.android.com/apk/res/android">
+  <item android:state_enabled="false" android:color="@color/text_dark_hint" />
+  <item android:color="@color/text_dark_subtitle" />
+</selector>

--- a/android/app/src/main/res/color/text_color_secondary_dark.xml
+++ b/android/app/src/main/res/color/text_color_secondary_dark.xml
@@ -1,0 +1,5 @@
+<?xml version="1.0" encoding="utf-8"?>
+<selector xmlns:android="http://schemas.android.com/apk/res/android">
+  <item android:state_enabled="false" android:color="@color/text_light_hint" />
+  <item android:color="@color/text_light_subtitle" />
+</selector>

--- a/android/app/src/main/res/values/themes-base.xml
+++ b/android/app/src/main/res/values/themes-base.xml
@@ -9,9 +9,9 @@
     <item name="android:textViewStyle">@style/MwmWidget.TextView</item>
     <item name="android:forceDarkAllowed" tools:targetApi="Q">false</item>
 
-    <item name="android:textColorPrimary">@color/text_dark</item>
+    <item name="android:textColorPrimary">@color/text_color_primary</item>
     <item name="android:textColorPrimaryInverse">@color/text_light</item>
-    <item name="android:textColorSecondary">@color/text_dark_subtitle</item>
+    <item name="android:textColorSecondary">@color/text_color_secondary</item>
     <item name="android:windowBackground">?windowBackgroundForced</item>
     <item name="android:colorPrimaryDark">@color/bg_primary_dark</item>
     <item name="android:windowSoftInputMode">stateUnspecified|adjustPan</item>
@@ -142,9 +142,9 @@
     <item name="android:textViewStyle">@style/MwmWidget.TextView</item>
     <item name="android:forceDarkAllowed" tools:targetApi="Q">false</item>
 
-    <item name="android:textColorPrimary">@color/text_light</item>
+    <item name="android:textColorPrimary">@color/text_color_primary_dark</item>
     <item name="android:textColorPrimaryInverse">@color/text_dark</item>
-    <item name="android:textColorSecondary">@color/text_light_subtitle</item>
+    <item name="android:textColorSecondary">@color/text_color_secondary_dark</item>
     <item name="android:windowBackground">?windowBackgroundForced</item>
     <item name="android:colorPrimaryDark">@color/bg_primary_dark_night</item>
     <item name="android:windowSoftInputMode">stateUnspecified|adjustPan</item>


### PR DESCRIPTION
This PR enables the change of colors (dimming) when the Preferences are disabled (currently, in the Settings Page for the "Voice Instructions"), for better location of enabled/disabled controls:

![pref_day_enabled](https://github.com/organicmaps/organicmaps/assets/25888296/f52f4587-5c3f-411d-a1ef-db6bf56840bc)   ![pref_day_disabled](https://github.com/organicmaps/organicmaps/assets/25888296/17eb5fa4-22e0-4dce-bd92-69c3039539ca)

![pref_night_enabled](https://github.com/organicmaps/organicmaps/assets/25888296/eb89f662-b21e-4b8a-b0b5-1cc0d00e9403)   ![pref_night_disabled](https://github.com/organicmaps/organicmaps/assets/25888296/4bbdb699-6ce2-436f-94ed-5be2d57724ef)