### PR TITLE
[android] Fix scroll in edit bookmark

### DIFF
--- a/android/app/src/main/res/layout/edit_bookmark_common.xml
+++ b/android/app/src/main/res/layout/edit_bookmark_common.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<androidx.constraintlayout.widget.ConstraintLayout
+<RelativeLayout
   xmlns:android="http://schemas.android.com/apk/res/android"
   xmlns:app="http://schemas.android.com/apk/res-auto"
   xmlns:tools="http://schemas.android.com/tools"
@@ -14,8 +14,7 @@
     android:layout_height="wrap_content"
     android:layout_marginStart="@dimen/margin_half"
     android:layout_marginEnd="@dimen/margin_half"
-    android:orientation="vertical"
-    app:layout_constraintTop_toTopOf="parent">
+    android:orientation="vertical">
     <com.google.android.material.textfield.TextInputLayout
       android:id="@+id/edit_bookmark_name_input"
       style="?fontBody1"
@@ -40,7 +39,7 @@
     android:id="@+id/rl__bookmark_set"
     android:layout_width="match_parent"
     android:layout_height="wrap_content"
-    app:layout_constraintTop_toBottomOf="@+id/ll__bookmark_name"
+    android:layout_below="@+id/ll__bookmark_name"
     android:layout_marginStart="@dimen/margin_half"
     android:layout_marginEnd="@dimen/margin_half">
     <TextView
@@ -89,8 +88,8 @@
     android:layout_height="wrap_content"
     android:layout_below="@id/rl__bookmark_set"
     android:layout_margin="@dimen/margin_half"
-    android:textColorHint="?android:textColorSecondary"
-    app:layout_constraintTop_toBottomOf="@+id/rl__bookmark_set">
+    android:textColorHint="?android:textColorSecondary">
+
     <com.google.android.material.textfield.TextInputEditText
       android:id="@+id/et__description"
       style="@style/MwmWidget.Editor.CustomTextInput"
@@ -100,4 +99,4 @@
       android:hint="@string/edit_description_hint"
       android:inputType="textMultiLine" />
   </com.google.android.material.textfield.TextInputLayout>
-</androidx.constraintlayout.widget.ConstraintLayout>
+</RelativeLayout>

--- a/android/app/src/main/res/layout/fragment_edit_bookmark.xml
+++ b/android/app/src/main/res/layout/fragment_edit_bookmark.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<androidx.constraintlayout.widget.ConstraintLayout
+<RelativeLayout
   xmlns:android="http://schemas.android.com/apk/res/android"
   xmlns:app="http://schemas.android.com/apk/res-auto"
   android:layout_width="match_parent"
@@ -10,8 +10,8 @@
     style="@style/MwmWidget.ToolbarStyle"
     android:layout_width="match_parent"
     android:layout_height="wrap_content"
-    android:theme="@style/MwmWidget.ToolbarTheme"
-    app:layout_constraintTop_toTopOf="parent">
+    android:theme="@style/MwmWidget.ToolbarTheme">
+
       <ImageView
         app:tint="@color/image_view"
         android:id="@+id/save"
@@ -27,8 +27,7 @@
     style="@style/MwmWidget.FrameLayout.Elevation"
     android:layout_width="match_parent"
     android:layout_height="wrap_content"
-    android:layout_below="@id/toolbar"
-    app:layout_constraintTop_toBottomOf="@+id/toolbar">
+    android:layout_below="@id/toolbar">
     <include layout="@layout/edit_bookmark_common" />
   </FrameLayout>
-</androidx.constraintlayout.widget.ConstraintLayout>
+</RelativeLayout>


### PR DESCRIPTION
Fixes #7720

This PR fixes:
- Scroll in InputEditText
- Increase height InputEditText to edit more easily
I have use same structure as fragment_bookmark_category_settings ->NestedScrollView + Linear Layout
- NestedScrollView take all space of screen to improve scroll in InputEditText (I have add margin at the bottom to improve access at the bottom of the InputEditText with keyboard)

|Before|After|
|-|-|
|<img src="https://github.com/organicmaps/organicmaps/assets/87148630/ea0f5e8c-ec69-4d94-832b-9fef38477dd5" height=500 />|<img src="https://github.com/organicmaps/organicmaps/assets/87148630/540b6681-c21f-40c7-bf3b-aa6a59f82a8c" height=500 />|

Before
https://github.com/organicmaps/organicmaps/assets/87148630/b40f3ba1-38e3-41ed-9881-808be49be07f

After
https://github.com/organicmaps/organicmaps/assets/87148630/62e8ad34-2935-42f6-8926-20d9bedfcb45

@map-per can you test changes?