### PR TITLE
[mac] Fixes linker error for bsdiff_tests

### DIFF
--- a/platform/CMakeLists.txt
+++ b/platform/CMakeLists.txt
@@ -191,7 +191,13 @@ target_link_libraries(${PROJECT_NAME}
   $<$<BOOL:${PLATFORM_DESKTOP}>:Qt6::Core>
   $<$<BOOL:${PLATFORM_LINUX}>:Qt6::Network>
   $<$<BOOL:${QT_POSITIONING}>:Qt6::Positioning>
-  $<$<BOOL:${PLATFORM_MAC}>:-framework\ Foundation -framework\ SystemConfiguration -framework\ CoreLocation -framework\ CFNetwork>
+  $<$<BOOL:${PLATFORM_MAC}>:
+    -framework\ Foundation
+    -framework\ SystemConfiguration
+    -framework\ CoreLocation
+    -framework\ CFNetwork
+    -framework\ Security  # SecPKCS12Import
+    >
 )
 
 omim_add_test_subdirectory(platform_tests_support)


### PR DESCRIPTION
ld: warning: ignoring duplicate libraries: 'libbase.a' Undefined symbols for architecture arm64:
  "_SecPKCS12Import", referenced from:
      -[MultipartUploadTask extractIdentityWithCertData:certPassword:] in libplatform.a[2](unity_0_mm.mm.o)
  "_kSecImportExportPassphrase", referenced from:
      -[MultipartUploadTask extractIdentityWithCertData:certPassword:] in libplatform.a[2](unity_0_mm.mm.o)
  "_kSecImportItemCertChain", referenced from:
      -[MultipartUploadTask extractIdentityWithCertData:certPassword:] in libplatform.a[2](unity_0_mm.mm.o)
  "_kSecImportItemIdentity", referenced from:
      -[MultipartUploadTask extractIdentityWithCertData:certPassword:] in libplatform.a[2](unity_0_mm.mm.o)
ld: symbol(s) not found for architecture arm64