### PR TITLE
[ios] add unit test target

### DIFF
--- a/iphone/Maps/Classes/MapViewController.mm
+++ b/iphone/Maps/Classes/MapViewController.mm
@@ -372,7 +372,7 @@ NSString *const kPP2BookmarkEditingSegue = @"PP2BookmarkEditing";
 
 - (void)viewDidLayoutSubviews {
   [super viewDidLayoutSubviews];
-  if (!self.mapView.drapeEngineCreated)
+  if (!self.mapView.drapeEngineCreated && !MapsAppDelegate.isDrapeDisabled)
     [self.mapView createDrapeEngine];
 }
 

--- a/iphone/Maps/Classes/MapsAppDelegate.h
+++ b/iphone/Maps/Classes/MapsAppDelegate.h
@@ -33,6 +33,8 @@ NS_ASSUME_NONNULL_BEGIN
 
 - (NSUInteger)badgeNumber;
 
++ (BOOL)isDrapeDisabled;
+
 @end
 
 NS_ASSUME_NONNULL_END

--- a/iphone/Maps/Classes/MapsAppDelegate.mm
+++ b/iphone/Maps/Classes/MapsAppDelegate.mm
@@ -229,6 +229,14 @@ using namespace osm_auth_ios;
   LOG(LINFO, ("applicationDidBecomeActive - end"));
 }
 
+// TODO: Drape enabling is skipped during the test run due to the app crashing in teardown. This is a temporary solution. Drape should be properly disabled instead of merely skipping the enabling process.
++ (BOOL)isDrapeDisabled {
+  NSProcessInfo * processInfo = [NSProcessInfo processInfo];
+  NSArray<NSString *> * launchArguments = [processInfo arguments];
+  BOOL isTests = [launchArguments containsObject:@"-IsTests"];
+  return isTests;
+}
+
 - (BOOL)application:(UIApplication *)application
   continueUserActivity:(NSUserActivity *)userActivity
     restorationHandler:(void (^)(NSArray<id<UIUserActivityRestoring>> *_Nullable))restorationHandler {

--- a/iphone/Maps/Maps.xcodeproj/project.pbxproj
+++ b/iphone/Maps/Maps.xcodeproj/project.pbxproj
@@ -464,6 +464,7 @@
 		ED0B1C312BC2951F00FB8EDD /* PrivacyInfo.xcprivacy in Resources */ = {isa = PBXBuildFile; fileRef = ED0B1C302BC2951F00FB8EDD /* PrivacyInfo.xcprivacy */; };
 		ED1080A72B791CFE0023F27E /* SocialMediaCollectionViewHeader.swift in Sources */ = {isa = PBXBuildFile; fileRef = ED1080A62B791CFE0023F27E /* SocialMediaCollectionViewHeader.swift */; };
 		ED1263AB2B6F99F900AD99F3 /* UIView+AddSeparator.swift in Sources */ = {isa = PBXBuildFile; fileRef = ED1263AA2B6F99F900AD99F3 /* UIView+AddSeparator.swift */; };
+		ED1ADA332BC6B1B40029209F /* CarPlayServiceTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = ED1ADA322BC6B1B40029209F /* CarPlayServiceTests.swift */; };
 		ED3EAC202B03C88100220A4A /* BottomTabBarButton.swift in Sources */ = {isa = PBXBuildFile; fileRef = ED3EAC1F2B03C88100220A4A /* BottomTabBarButton.swift */; };
 		ED9966802B94FBC20083CE55 /* ColorPicker.swift in Sources */ = {isa = PBXBuildFile; fileRef = ED99667D2B94FBC20083CE55 /* ColorPicker.swift */; };
 		EDBD68072B625724005DD151 /* LocationServicesDisabledAlert.xib in Resources */ = {isa = PBXBuildFile; fileRef = EDBD68062B625724005DD151 /* LocationServicesDisabledAlert.xib */; };
@@ -1348,6 +1349,7 @@
 		ED0B1C302BC2951F00FB8EDD /* PrivacyInfo.xcprivacy */ = {isa = PBXFileReference; lastKnownFileType = text.xml; path = PrivacyInfo.xcprivacy; sourceTree = "<group>"; };
 		ED1080A62B791CFE0023F27E /* SocialMediaCollectionViewHeader.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SocialMediaCollectionViewHeader.swift; sourceTree = "<group>"; };
 		ED1263AA2B6F99F900AD99F3 /* UIView+AddSeparator.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "UIView+AddSeparator.swift"; sourceTree = "<group>"; };
+		ED1ADA322BC6B1B40029209F /* CarPlayServiceTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CarPlayServiceTests.swift; sourceTree = "<group>"; };
 		ED3EAC1F2B03C88100220A4A /* BottomTabBarButton.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BottomTabBarButton.swift; sourceTree = "<group>"; };
 		ED48BBB817C2B1E2003E7E92 /* CircleView.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = CircleView.h; sourceTree = "<group>"; };
 		ED48BBB917C2B1E2003E7E92 /* CircleView.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = CircleView.m; sourceTree = "<group>"; };
@@ -1775,6 +1777,7 @@
 		29B97314FDCFA39411CA2CEA /* Maps */ = {
 			isa = PBXGroup;
 			children = (
+				ED1ADA312BC6B19E0029209F /* Tests */,
 				FA456C4026BDCC8E00B83C20 /* shaders.xcodeproj */,
 				FA36B8011540388B004560CC /* Bookmarks */,
 				3454D7981E07F045004AF2AD /* Categories */,
@@ -2958,6 +2961,14 @@
 				CDCA278F2248F3B800167D87 /* MWMLocationModeListener.h */,
 			);
 			path = Location;
+			sourceTree = "<group>";
+		};
+		ED1ADA312BC6B19E0029209F /* Tests */ = {
+			isa = PBXGroup;
+			children = (
+				ED1ADA322BC6B1B40029209F /* CarPlayServiceTests.swift */,
+			);
+			path = Tests;
 			sourceTree = "<group>";
 		};
 		ED99667C2B94FBC20083CE55 /* ColorPicker */ = {
@@ -4439,6 +4450,7 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				ED1ADA332BC6B1B40029209F /* CarPlayServiceTests.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};

--- a/iphone/Maps/Maps.xcodeproj/project.pbxproj
+++ b/iphone/Maps/Maps.xcodeproj/project.pbxproj
@@ -642,6 +642,13 @@
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
+		ED097E7A2BB80C320006ED01 /* PBXContainerItemProxy */ = {
+			isa = PBXContainerItemProxy;
+			containerPortal = 29B97313FDCFA39411CA2CEA /* Project object */;
+			proxyType = 1;
+			remoteGlobalIDString = 6741A93D1BF340DE002C974C;
+			remoteInfo = OMaps;
+		};
 		FA456C4626BDCC8E00B83C20 /* PBXContainerItemProxy */ = {
 			isa = PBXContainerItemProxy;
 			containerPortal = FA456C4026BDCC8E00B83C20 /* shaders.xcodeproj */;
@@ -1337,6 +1344,7 @@
 		CDCA278C2248F34C00167D87 /* MWMRouterResultCode.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = MWMRouterResultCode.h; sourceTree = "<group>"; };
 		CDCA278F2248F3B800167D87 /* MWMLocationModeListener.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = MWMLocationModeListener.h; sourceTree = "<group>"; };
 		CDE0F3AD225B8D45008BA5C3 /* MWMSpeedCameraManagerMode.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = MWMSpeedCameraManagerMode.h; sourceTree = "<group>"; };
+		ED097E762BB80C320006ED01 /* OMapsTests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = OMapsTests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
 		ED0B1C302BC2951F00FB8EDD /* PrivacyInfo.xcprivacy */ = {isa = PBXFileReference; lastKnownFileType = text.xml; path = PrivacyInfo.xcprivacy; sourceTree = "<group>"; };
 		ED1080A62B791CFE0023F27E /* SocialMediaCollectionViewHeader.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SocialMediaCollectionViewHeader.swift; sourceTree = "<group>"; };
 		ED1263AA2B6F99F900AD99F3 /* UIView+AddSeparator.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "UIView+AddSeparator.swift"; sourceTree = "<group>"; };
@@ -1713,6 +1721,13 @@
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
+		ED097E732BB80C320006ED01 /* Frameworks */ = {
+			isa = PBXFrameworksBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
 /* End PBXFrameworksBuildPhase section */
 
 /* Begin PBXGroup section */
@@ -1752,6 +1767,7 @@
 			isa = PBXGroup;
 			children = (
 				6741AA5D1BF340DE002C974C /* Organic Maps (Debug).app */,
+				ED097E762BB80C320006ED01 /* OMapsTests.xctest */,
 			);
 			name = Products;
 			sourceTree = "<group>";
@@ -1777,6 +1793,7 @@
 				19C28FACFE9D520D11CA2CBB /* Products */,
 				29B97317FDCFA39411CA2CEA /* Resources */,
 				F6E2FBFB1E097B9F0083EBEC /* UI */,
+				ED1ADA312BC6B19E0029209F /* Tests */,
 			);
 			indentWidth = 2;
 			name = Maps;
@@ -3674,6 +3691,24 @@
 			productReference = 6741AA5D1BF340DE002C974C /* Organic Maps (Debug).app */;
 			productType = "com.apple.product-type.application";
 		};
+		ED097E752BB80C320006ED01 /* OMapsTests */ = {
+			isa = PBXNativeTarget;
+			buildConfigurationList = ED097E802BB80C330006ED01 /* Build configuration list for PBXNativeTarget "OMapsTests" */;
+			buildPhases = (
+				ED097E722BB80C320006ED01 /* Sources */,
+				ED097E732BB80C320006ED01 /* Frameworks */,
+				ED097E742BB80C320006ED01 /* Resources */,
+			);
+			buildRules = (
+			);
+			dependencies = (
+				ED097E7B2BB80C320006ED01 /* PBXTargetDependency */,
+			);
+			name = OMapsTests;
+			productName = OMapsTests;
+			productReference = ED097E762BB80C320006ED01 /* OMapsTests.xctest */;
+			productType = "com.apple.product-type.bundle.unit-test";
+		};
 /* End PBXNativeTarget section */
 
 /* Begin PBXProject section */
@@ -3759,6 +3794,7 @@
 			projectRoot = "";
 			targets = (
 				6741A93D1BF340DE002C974C /* OMaps */,
+				ED097E752BB80C320006ED01 /* OMapsTests */,
 			);
 		};
 /* End PBXProject section */
@@ -3950,6 +3986,13 @@
 				340E1EFE1E2F614400CE49BF /* Welcome.storyboard in Resources */,
 				6741A9521BF340DE002C974C /* World.mwm in Resources */,
 				6741A9751BF340DE002C974C /* WorldCoasts.mwm in Resources */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		ED097E742BB80C320006ED01 /* Resources */ = {
+			isa = PBXResourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -4392,9 +4435,21 @@
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
+		ED097E722BB80C320006ED01 /* Sources */ = {
+			isa = PBXSourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
 /* End PBXSourcesBuildPhase section */
 
 /* Begin PBXTargetDependency section */
+		ED097E7B2BB80C320006ED01 /* PBXTargetDependency */ = {
+			isa = PBXTargetDependency;
+			target = 6741A93D1BF340DE002C974C /* OMaps */;
+			targetProxy = ED097E7A2BB80C320006ED01 /* PBXContainerItemProxy */;
+		};
 		FA456C4D26BDCC9400B83C20 /* PBXTargetDependency */ = {
 			isa = PBXTargetDependency;
 			name = shaders_metal;
@@ -4596,6 +4651,26 @@
 			};
 			name = Release;
 		};
+		ED097E7C2BB80C330006ED01 /* Debug */ = {
+			isa = XCBuildConfiguration;
+			baseConfigurationReference = 347526FA1DC0B00F00918CF5 /* common-debug.xcconfig */;
+			buildSettings = {
+				BUNDLE_LOADER = "$(TEST_HOST)";
+				PRODUCT_BUNDLE_IDENTIFIER = com.organicmaps.app.OMapsTests;
+				TEST_HOST = "$(BUILT_PRODUCTS_DIR)/Organic Maps (Debug).app/$(BUNDLE_EXECUTABLE_FOLDER_PATH)/Organic Maps (Debug)";
+			};
+			name = Debug;
+		};
+		ED097E7D2BB80C330006ED01 /* Release */ = {
+			isa = XCBuildConfiguration;
+			baseConfigurationReference = 347526FB1DC0B00F00918CF5 /* common-release.xcconfig */;
+			buildSettings = {
+				BUNDLE_LOADER = "$(TEST_HOST)";
+				PRODUCT_BUNDLE_IDENTIFIER = com.organicmaps.app.OMapsTests;
+				TEST_HOST = "$(BUILT_PRODUCTS_DIR)/Organic Maps (Debug).app/$(BUNDLE_EXECUTABLE_FOLDER_PATH)/Organic Maps (Debug)";
+			};
+			name = Release;
+		};
 		FAAB411B149BA84700C245B1 /* Debug */ = {
 			isa = XCBuildConfiguration;
 			baseConfigurationReference = 347526FA1DC0B00F00918CF5 /* common-debug.xcconfig */;
@@ -4695,6 +4770,15 @@
 			buildConfigurations = (
 				FAAB411B149BA84700C245B1 /* Debug */,
 				FABB561E149CD957006969C0 /* Release */,
+			);
+			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = Debug;
+		};
+		ED097E802BB80C330006ED01 /* Build configuration list for PBXNativeTarget "OMapsTests" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				ED097E7C2BB80C330006ED01 /* Debug */,
+				ED097E7D2BB80C330006ED01 /* Release */,
 			);
 			defaultConfigurationIsVisible = 0;
 			defaultConfigurationName = Debug;

--- a/iphone/Maps/Maps.xcodeproj/project.pbxproj
+++ b/iphone/Maps/Maps.xcodeproj/project.pbxproj
@@ -1777,7 +1777,6 @@
 		29B97314FDCFA39411CA2CEA /* Maps */ = {
 			isa = PBXGroup;
 			children = (
-				ED1ADA312BC6B19E0029209F /* Tests */,
 				FA456C4026BDCC8E00B83C20 /* shaders.xcodeproj */,
 				FA36B8011540388B004560CC /* Bookmarks */,
 				3454D7981E07F045004AF2AD /* Categories */,
@@ -4668,7 +4667,12 @@
 			baseConfigurationReference = 347526FA1DC0B00F00918CF5 /* common-debug.xcconfig */;
 			buildSettings = {
 				BUNDLE_LOADER = "$(TEST_HOST)";
-				PRODUCT_BUNDLE_IDENTIFIER = com.organicmaps.app.OMapsTests;
+				CODE_SIGN_STYLE = Manual;
+				DEVELOPMENT_TEAM = "";
+				"DEVELOPMENT_TEAM[sdk=iphoneos*]" = 9Z6432XD7L;
+				"DEVELOPMENT_TEAM[sdk=macosx*]" = 9Z6432XD7L;
+				PRODUCT_BUNDLE_IDENTIFIER = app.organicmaps.debug.tests;
+				PROVISIONING_PROFILE_SPECIFIER = "";
 				TEST_HOST = "$(BUILT_PRODUCTS_DIR)/Organic Maps (Debug).app/$(BUNDLE_EXECUTABLE_FOLDER_PATH)/Organic Maps (Debug)";
 			};
 			name = Debug;
@@ -4678,7 +4682,11 @@
 			baseConfigurationReference = 347526FB1DC0B00F00918CF5 /* common-release.xcconfig */;
 			buildSettings = {
 				BUNDLE_LOADER = "$(TEST_HOST)";
-				PRODUCT_BUNDLE_IDENTIFIER = com.organicmaps.app.OMapsTests;
+				CODE_SIGN_STYLE = Manual;
+				"DEVELOPMENT_TEAM[sdk=iphoneos*]" = 9Z6432XD7L;
+				"DEVELOPMENT_TEAM[sdk=macosx*]" = 9Z6432XD7L;
+				PRODUCT_BUNDLE_IDENTIFIER = app.organicmaps.release.tests;
+				PROVISIONING_PROFILE_SPECIFIER = "";
 				TEST_HOST = "$(BUILT_PRODUCTS_DIR)/Organic Maps (Debug).app/$(BUNDLE_EXECUTABLE_FOLDER_PATH)/Organic Maps (Debug)";
 			};
 			name = Release;

--- a/iphone/Maps/Maps.xcodeproj/xcshareddata/xcschemes/OMaps.xcscheme
+++ b/iphone/Maps/Maps.xcodeproj/xcshareddata/xcschemes/OMaps.xcscheme
@@ -28,6 +28,17 @@
       selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
       shouldUseLaunchSchemeArgsEnv = "YES">
       <Testables>
+         <TestableReference
+            skipped = "NO"
+            parallelizable = "YES">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "ED097E752BB80C320006ED01"
+               BuildableName = "OMapsTests.xctest"
+               BlueprintName = "OMapsTests"
+               ReferencedContainer = "container:Maps.xcodeproj">
+            </BuildableReference>
+         </TestableReference>
       </Testables>
    </TestAction>
    <LaunchAction

--- a/iphone/Maps/Maps.xcodeproj/xcshareddata/xcschemes/OMaps.xcscheme
+++ b/iphone/Maps/Maps.xcodeproj/xcshareddata/xcschemes/OMaps.xcscheme
@@ -26,7 +26,22 @@
       buildConfiguration = "Debug"
       selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
       selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
-      shouldUseLaunchSchemeArgsEnv = "YES">
+      shouldUseLaunchSchemeArgsEnv = "NO">
+      <MacroExpansion>
+         <BuildableReference
+            BuildableIdentifier = "primary"
+            BlueprintIdentifier = "ED097E752BB80C320006ED01"
+            BuildableName = "OMapsTests.xctest"
+            BlueprintName = "OMapsTests"
+            ReferencedContainer = "container:Maps.xcodeproj">
+         </BuildableReference>
+      </MacroExpansion>
+      <CommandLineArguments>
+         <CommandLineArgument
+            argument = "-IsTests"
+            isEnabled = "YES">
+         </CommandLineArgument>
+      </CommandLineArguments>
       <Testables>
          <TestableReference
             skipped = "NO"

--- a/iphone/Maps/Tests/CarPlayServiceTests.swift
+++ b/iphone/Maps/Tests/CarPlayServiceTests.swift
@@ -1,0 +1,40 @@
+import XCTest
+@testable import Organic_Maps__Debug_
+
+final class CarPlayServiceTests: XCTestCase {
+
+  var carPlayService: CarPlayService!
+
+  override func setUp() {
+    super.setUp()
+    carPlayService = CarPlayService()
+  }
+
+  override func tearDown() {
+    carPlayService = nil
+    super.tearDown()
+  }
+
+  func testCreateEstimates() {
+    let routeInfo = RouteInfo(timeToTarget: 100,
+                              targetDistance: 25.2,
+                              targetUnitsIndex: 1, // km
+                              distanceToTurn: 0.5,
+                              turnUnitsIndex: 0, // m
+                              streetName: "Niamiha",
+                              turnImageName: nil,
+                              nextTurnImageName: nil,
+                              speedMps: 40.5,
+                              speedLimitMps: 60,
+                              roundExitNumber: 0)
+    let estimates = carPlayService.createEstimates(routeInfo: routeInfo)
+
+    guard let estimates else {
+      XCTFail("Estimates should not be nil.")
+      return
+    }
+
+    XCTAssertEqual(estimates.distanceRemaining, Measurement<UnitLength>(value: 25.2, unit: .kilometers))
+    XCTAssertEqual(estimates.timeRemaining, 100)
+  }
+}

--- a/iphone/Maps/UI/CarPlay/CarPlayMapViewController.swift
+++ b/iphone/Maps/UI/CarPlay/CarPlayMapViewController.swift
@@ -22,7 +22,7 @@ final class CarPlayMapViewController: MWMViewController {
 
   override func viewDidLayoutSubviews() {
     super.viewDidLayoutSubviews()
-    if mapView?.drapeEngineCreated == false {
+    if mapView?.drapeEngineCreated == false && !MapsAppDelegate.isDrapeDisabled() {
       mapView?.createDrapeEngine()
     }
     updateVisibleViewPortState(viewPortState)


### PR DESCRIPTION
This PR adds the `Unit test target` to iOS.

---
### How to add unit tests
The easiest way to add some tests:
1. select in the XCode `File -> New -> File...`
2. find and select `Unit Test Case Class`
3. pay attention that `OMapsTest` target is selected
<img width="350" alt="image" src="https://github.com/organicmaps/organicmaps/assets/79797627/f77b5030-0cbe-42e9-a6d2-a88f38fd4002">

4. Save into `Tests` directory
5. Add the line  `@testable import Organic_Maps__Debug_` below `import XCTest` to get access to all OM public and internal classes.
6. Write your tests
7. Select a simulator as a run destination to run test cases. 

--- 
### Example of use
As an example the test case for the `CarPlayService` method `createEstimates` (thanks to @fabwu for fix) was added:

Before the fix we can see that test case the with coma-separator used for the distace initialization fails and with dot passes:
<img width="1340" alt="image" src="https://github.com/organicmaps/organicmaps/assets/79797627/6d211136-89d5-4dc2-b706-37f7bc12a5ec">

After fix (using the double instead of the string):
<img width="851" alt="image" src="https://github.com/organicmaps/organicmaps/assets/79797627/35ee076b-8a0b-4037-9449-df956f456467">

---
### Important
At least one issue should be resolved to merge this PR:
When we run testcases and they are finished, the app fails with error in the `SharedBufferManager`:

<img width="1728" alt="image" src="https://github.com/organicmaps/organicmaps/assets/79797627/fcb19181-1c36-47f1-b521-e2d1265d1e53">

 You still can see passed/failed tests but error is annoying. This bug may affect async tests.

