### PR TITLE
[android] Update the Google Play release procedure

### DIFF
--- a/.github/workflows/android-release.yaml
+++ b/.github/workflows/android-release.yaml
@@ -31,7 +31,7 @@ jobs:
           # TODO: Find a way to refactor FDroid versioning without that additional commit.
           build=$(($(tools/unix/version.sh ios_build) + 1))
           code=$(($(tools/unix/version.sh android_code) + 1))
-          tag=$version-$build-android
+          tag=$version-$build-android-rc
           echo "::set-output name=version::$version"
           echo "::set-output name=build::$build"
           echo "::set-output name=tag::$tag"
@@ -165,6 +165,7 @@ jobs:
           name: ${{ needs.tag.outputs.tag }}
           tag_name: ${{ needs.tag.outputs.tag }}
           discussion_category_name: 'Announcements'
+          prerelease: true
           files: |
             ./android/app/build/outputs/apk/web/release/OrganicMaps-${{ needs.tag.outputs.code }}-web-release.apk
             ./android/app/build/outputs/apk/web/release/OrganicMaps-${{ needs.tag.outputs.code }}-web-release.apk.sha256sum

--- a/android/app/build.gradle
+++ b/android/app/build.gradle
@@ -33,7 +33,7 @@ buildscript {
       println('Building without Google Firebase Services')
     }
 
-    classpath('com.github.triplet.gradle:play-publisher:3.8.6')
+    classpath('com.github.triplet.gradle:play-publisher:3.9.1')
     classpath('ru.cian:huawei-publish-gradle-plugin:1.4.2')
   }
 }
@@ -442,8 +442,7 @@ task prepareGoogleReleaseListing {
 
 play {
   enabled.set(false)
-  track.set('production')
-  userFraction.set(Double.valueOf(0.10)) // 10%
+  track.set('alpha')
   defaultToAppBundles.set(true)
   releaseStatus.set(ReleaseStatus.IN_PROGRESS)
   serviceAccountCredentials.set(file('google-play.json'))


### PR DESCRIPTION
Before all new Google Play releases were published for phased 10% rollout
in the Production track. Now, a new Google Play release is initially
uploaded into "Closed Beta" track for 100% rollout and then promoted into
"Production" track after testing. The "Closed Beta" track (misleadingly
called "alpha" in the code) is invite-only and currently contains about
~1k users imported Firebase App Tester databases. Invited users can opt in
to install new pre-release versions for testing directly via Google Play.

<img src="https://github.com/organicmaps/product/assets/1799054/06028ce6-1abd-4b42-9b4a-042915bedaa4"  width="350px">
<img src="https://github.com/organicmaps/product/assets/1799054/2220f5e4-fbe6-4173-a192-1ba9f9259944" width="350px">

Android releases are now initially tagged with `YYYY.MM.DD-x-android-rc`
(release-candidate) tags instead of `YYYY.MM.DD-x-android`. The production
`YYYY.MM.DD-x-android` tag is added after promotion in Google Play. This
kicks-off the F-Droid process as well. Huawei's version remains unpublished
until Android gets a green light in Google Play.

This change has two primary outcomes:

1. Users now can receive pre-production ("rc") via Google Play.
   This change uses invite-only "Closed Beta" track, but it can be
   changed to "Open Beta" track later.

2. Android versions in Google Play are now published after pre-production
   testing in a separate track in Google Play. Meanwhile, Google Play
   runs Monkey for free in such tracks and sends useful pre-prod reports.

There are no changes in Firebase App Tester - it works as usual. The primary
difference between App Tester and Google Play Open/Closed Beta is that
AppTester uses "app.organicmaps.beta" applicationId while Google Play uses
"app.organicmaps" id. This efficiently means that versions from App Testers
can be installed in parallel with Google Play, while Google Play's
Open/Closed version update the production app.

Please don't get confused with the word "beta" used in different places.
Google Play Open/Closed Beta actually will receive only pre-production
quality builds. App Tester probably can continue to be used both for
pre-production and ad-hoc experiemental version ("alpha"?).

Signed-off-by: Roman Tsisyk <roman@tsisyk.com>
