### PR TITLE
[android] Change preference text color when disabled

### DIFF
--- a/android/app/src/main/res/color/preference_text_color.xml
+++ b/android/app/src/main/res/color/preference_text_color.xml
@@ -1,0 +1,5 @@
+<?xml version="1.0" encoding="utf-8"?>
+<selector xmlns:android="http://schemas.android.com/apk/res/android">
+  <item android:state_enabled="false" android:color="@color/text_dark_subtitle" />
+  <item android:color="@color/text_dark" />
+</selector>

--- a/android/app/src/main/res/color/preference_text_color_night.xml
+++ b/android/app/src/main/res/color/preference_text_color_night.xml
@@ -1,0 +1,5 @@
+<?xml version="1.0" encoding="utf-8"?>
+<selector xmlns:android="http://schemas.android.com/apk/res/android">
+  <item android:state_enabled="false" android:color="@color/text_light_subtitle" />
+  <item android:color="@color/text_light" />
+</selector>

--- a/android/app/src/main/res/values/styles.xml
+++ b/android/app/src/main/res/values/styles.xml
@@ -368,4 +368,16 @@
     <item name="android:textAllCaps">false</item>
   </style>
 
+  <style
+    name="MwmTheme.Preference"
+    parent="@style/PreferenceThemeOverlay.v14.Material">
+    <item name="android:textColor">@color/preference_text_color</item>
+  </style>
+
+  <style
+    name="MwmTheme.Preference.Night"
+    parent="@style/PreferenceThemeOverlay.v14.Material">
+    <item name="android:textColor">@color/preference_text_color_night</item>
+  </style>
+
 </resources>

--- a/android/app/src/main/res/values/themes-base.xml
+++ b/android/app/src/main/res/values/themes-base.xml
@@ -78,7 +78,7 @@
 
     <item name="routingButtonHint">@color/routing_button_tint</item>
 
-    <item name="preferenceTheme">@style/PreferenceThemeOverlay.v14.Material</item>
+    <item name="preferenceTheme">@style/MwmTheme.Preference</item>
 
     <item name="android:listDivider">@drawable/list_divider</item>
 
@@ -211,6 +211,8 @@
     <item name="navigationTheme">@style/MwmTheme.Navigation.Night</item>
 
     <item name="routingButtonHint">@color/routing_button_tint</item>
+
+    <item name="preferenceTheme">@style/MwmTheme.Preference.Night</item>
 
     <item name="android:listDivider">@drawable/list_divider_night</item>
 


### PR DESCRIPTION
This PR changes the color of the preference titles when they are disabled (currently, in some preferences in the voice instruction settings).

Only the color of the titles of preferences are automatically changed (not for the summary). To be able to change the summary color, minSdk value needs to be set to 23, but current minSdk value is set to 21.

**WARNING!!** There's a wrong behavior of the styles after this PR: When switching to Night mode, the color of the tiles remain incorrectly dark: 
![pref_night_mode_wrong](https://github.com/organicmaps/organicmaps/assets/25888296/e69ee411-8ce7-47e2-9eaf-c613d55f1ca9)

If the Settings page is opened again, then the titles are displayed correctly in light color:
![pref_night_mode_right](https://github.com/organicmaps/organicmaps/assets/25888296/09ef3275-3aec-4d77-986d-bf6af0ff3d35)

This PR shall not be merged until this problem is fixed!!
