### PR TITLE
[android] Use new result APIs

### DIFF
--- a/android/app/src/main/java/app/organicmaps/MwmActivity.java
+++ b/android/app/src/main/java/app/organicmaps/MwmActivity.java
@@ -157,7 +157,11 @@ public class MwmActivity extends BaseMwmFragmentActivity
                                                      EditorHostFragment.class.getName(),
                                                      ReportFragment.class.getName() };
 
-  public static final int REQ_CODE_DRIVING_OPTIONS = 6;
+  public final ActivityResultLauncher<Intent> startDrivingOptionsForResult = registerForActivityResult(new ActivityResultContracts.StartActivityForResult(), activityResult ->
+  {
+     if( activityResult.getResultCode() == Activity.RESULT_OK)
+      rebuildLastRoute();
+  });
 
   private static final String MAIN_MENU_ID = "MAIN_MENU_BOTTOM_SHEET";
   private static final String LAYERS_MENU_ID = "LAYERS_MENU_BOTTOM_SHEET";
@@ -614,7 +618,7 @@ public class MwmActivity extends BaseMwmFragmentActivity
 
     if (!mIsTabletLayout)
     {
-      mRoutingPlanInplaceController = new RoutingPlanInplaceController(this, this, this);
+      mRoutingPlanInplaceController = new RoutingPlanInplaceController(this, startDrivingOptionsForResult, this, this);
       removeCurrentFragment(false);
     }
 
@@ -1016,18 +1020,6 @@ public class MwmActivity extends BaseMwmFragmentActivity
       mRoutingPlanInplaceController.restoreState(savedInstanceState);
 
     mPowerSaveDisclaimerShown = savedInstanceState.getBoolean(POWER_SAVE_DISCLAIMER_SHOWN, false);
-  }
-
-  @Override
-  protected void onActivityResult(int requestCode, int resultCode, Intent data)
-  {
-    super.onActivityResult(requestCode, resultCode, data);
-
-    if (resultCode != Activity.RESULT_OK)
-      return;
-
-    if (requestCode == REQ_CODE_DRIVING_OPTIONS)
-      rebuildLastRoute();
   }
 
   private void rebuildLastRoute()
@@ -1693,7 +1685,7 @@ public class MwmActivity extends BaseMwmFragmentActivity
     mAlertDialog = new MaterialAlertDialogBuilder(this, R.style.MwmTheme_AlertDialog)
         .setTitle(R.string.unable_to_calc_alert_title)
         .setMessage(R.string.unable_to_calc_alert_subtitle)
-        .setPositiveButton(R.string.settings, (dialog, which) -> DrivingOptionsActivity.start(this))
+        .setPositiveButton(R.string.settings, (dialog, which) -> DrivingOptionsActivity.start(this, startDrivingOptionsForResult))
         .setNegativeButton(R.string.cancel, null)
         .setOnDismissListener(dialog -> mAlertDialog = null)
         .show();

--- a/android/app/src/main/java/app/organicmaps/bookmarks/BookmarkCategorySettingsActivity.java
+++ b/android/app/src/main/java/app/organicmaps/bookmarks/BookmarkCategorySettingsActivity.java
@@ -2,6 +2,7 @@ package app.organicmaps.bookmarks;
 
 import android.content.Intent;
 
+import androidx.activity.result.ActivityResultLauncher;
 import androidx.annotation.NonNull;
 import androidx.fragment.app.Fragment;
 
@@ -11,7 +12,6 @@ import app.organicmaps.bookmarks.data.BookmarkCategory;
 
 public class BookmarkCategorySettingsActivity extends BaseMwmFragmentActivity
 {
-  public static final int REQUEST_CODE = 107;
   public static final String EXTRA_BOOKMARK_CATEGORY = "bookmark_category";
 
   @Override
@@ -32,11 +32,11 @@ public class BookmarkCategorySettingsActivity extends BaseMwmFragmentActivity
     return BookmarkCategorySettingsFragment.class;
   }
 
-  public static void startForResult(@NonNull Fragment fragment,
+  public static void startForResult(@NonNull Fragment fragment, ActivityResultLauncher<Intent> startBookmarkSettingsForResult,
                                            @NonNull BookmarkCategory category)
   {
     android.content.Intent intent = new Intent(fragment.requireActivity(), BookmarkCategorySettingsActivity.class)
         .putExtra(EXTRA_BOOKMARK_CATEGORY, category);
-    fragment.startActivityForResult(intent, REQUEST_CODE);
+    startBookmarkSettingsForResult.launch(intent);
   }
 }

--- a/android/app/src/main/java/app/organicmaps/bookmarks/BookmarkListActivity.java
+++ b/android/app/src/main/java/app/organicmaps/bookmarks/BookmarkListActivity.java
@@ -3,6 +3,7 @@ package app.organicmaps.bookmarks;
 import android.content.Intent;
 import android.os.Bundle;
 
+import androidx.activity.result.ActivityResultLauncher;
 import androidx.annotation.CallSuper;
 import androidx.annotation.NonNull;
 import androidx.annotation.StyleRes;
@@ -57,11 +58,11 @@ public class BookmarkListActivity extends BaseToolbarActivity
     return R.layout.bookmarks_activity;
   }
 
-  static void startForResult(@NonNull Fragment fragment, @NonNull BookmarkCategory category)
+  static void startForResult(@NonNull Fragment fragment, ActivityResultLauncher<Intent> startBookmarkListForResult, @NonNull BookmarkCategory category)
   {
     Bundle args = new Bundle();
     Intent intent = new Intent(fragment.requireActivity(), BookmarkListActivity.class);
     intent.putExtra(BookmarksListFragment.EXTRA_CATEGORY, category);
-    fragment.startActivityForResult(intent, BookmarkCategoriesFragment.REQ_CODE_DELETE_CATEGORY);
+    startBookmarkListForResult.launch(intent);
   }
 }

--- a/android/app/src/main/java/app/organicmaps/bookmarks/BookmarksListFragment.java
+++ b/android/app/src/main/java/app/organicmaps/bookmarks/BookmarksListFragment.java
@@ -14,6 +14,7 @@ import android.view.ViewGroup;
 import android.widget.ImageView;
 
 import androidx.activity.result.ActivityResultLauncher;
+import androidx.activity.result.contract.ActivityResultContracts;
 import androidx.annotation.CallSuper;
 import androidx.annotation.NonNull;
 import androidx.annotation.Nullable;
@@ -74,6 +75,15 @@ public class BookmarksListFragment extends BaseMwmRecyclerFragment<ConcatAdapter
   private static final String OPTIONS_MENU_ID = "OPTIONS_MENU_BOTTOM_SHEET";
 
   private ActivityResultLauncher<SharingUtils.SharingIntent> shareLauncher;
+  private final ActivityResultLauncher<Intent> startBookmarkListForResult = registerForActivityResult(new ActivityResultContracts.StartActivityForResult(), activityResult -> {
+    System.out.println("resultCode: " + activityResult.getResultCode());
+    handleActivityResult();
+  });
+
+  private final ActivityResultLauncher<Intent> startBookmarkSettingsForResult = registerForActivityResult(new ActivityResultContracts.StartActivityForResult(), activityResult -> {
+    System.out.println("resultCode: " + activityResult.getResultCode());
+    handleActivityResult();
+  });
 
   @SuppressWarnings("NotNullFieldNotInitialized")
   @NonNull
@@ -140,7 +150,9 @@ public class BookmarksListFragment extends BaseMwmRecyclerFragment<ConcatAdapter
 
     BookmarkCollectionAdapter adapter = new BookmarkCollectionAdapter(getCategoryOrThrow(),
                                                                       mCategoryItems);
-    adapter.setOnClickListener((v, item) -> BookmarkListActivity.startForResult(this, item));
+    adapter.setOnClickListener((v, item) -> {
+      BookmarkListActivity.startForResult(this, startBookmarkListForResult, item);
+    });
 
     return adapter;
   }
@@ -756,7 +768,7 @@ public class BookmarksListFragment extends BaseMwmRecyclerFragment<ConcatAdapter
 
   private void onSettingsOptionSelected()
   {
-    BookmarkCategorySettingsActivity.startForResult(this, mCategoryDataSource.getData());
+    BookmarkCategorySettingsActivity.startForResult(this, startBookmarkSettingsForResult, mCategoryDataSource.getData());
   }
 
   private void onDeleteOptionSelected()
@@ -812,11 +824,8 @@ public class BookmarksListFragment extends BaseMwmRecyclerFragment<ConcatAdapter
     BookmarksSharingHelper.INSTANCE.onPreparedFileForSharing(requireActivity(), shareLauncher, result);
   }
 
-  @Override
-  @SuppressWarnings("deprecation") // https://github.com/organicmaps/organicmaps/issues/3630
-  public void onActivityResult(int requestCode, int resultCode, Intent data)
+  private void handleActivityResult()
   {
-    super.onActivityResult(requestCode, resultCode, data);
     getBookmarkListAdapter().notifyDataSetChanged();
     ActionBar actionBar = ((AppCompatActivity) requireActivity()).getSupportActionBar();
     actionBar.setTitle(mCategoryDataSource.getData().getName());

--- a/android/app/src/main/java/app/organicmaps/downloader/DownloaderFragment.java
+++ b/android/app/src/main/java/app/organicmaps/downloader/DownloaderFragment.java
@@ -5,6 +5,8 @@ import android.os.Bundle;
 import android.view.View;
 import android.view.WindowManager;
 
+import androidx.activity.result.ActivityResultLauncher;
+import androidx.activity.result.contract.ActivityResultContracts;
 import androidx.annotation.CallSuper;
 import androidx.annotation.Keep;
 import androidx.annotation.NonNull;
@@ -38,6 +40,8 @@ public class DownloaderFragment extends BaseMwmRecyclerFragment<DownloaderAdapte
   private boolean mSearchRunning;
 
   private int mSubscriberSlot;
+
+  final ActivityResultLauncher<Intent> startVoiceRecognitionForResult = registerForActivityResult(new ActivityResultContracts.StartActivityForResult(), activityResult -> mToolbarController.onVoiceRecognitionResult(activityResult));
 
   private final RecyclerView.OnScrollListener mScrollListener = new RecyclerView.OnScrollListener() {
     @Override
@@ -210,13 +214,6 @@ public class DownloaderFragment extends BaseMwmRecyclerFragment<DownloaderAdapte
     return mAdapter;
   }
 
-  @Override
-  @SuppressWarnings("deprecation") // https://github.com/organicmaps/organicmaps/issues/3630
-  public void onActivityResult(int requestCode, int resultCode, Intent data)
-  {
-    super.onActivityResult(requestCode, resultCode, data);
-    mToolbarController.onActivityResult(requestCode, resultCode, data);
-  }
 
   @NonNull
   @Override

--- a/android/app/src/main/java/app/organicmaps/downloader/DownloaderToolbarController.java
+++ b/android/app/src/main/java/app/organicmaps/downloader/DownloaderToolbarController.java
@@ -58,10 +58,9 @@ class DownloaderToolbarController extends SearchToolbarController
   }
 
   @Override
-  @SuppressWarnings("deprecated") // https://github.com/organicmaps/organicmaps/issues/3630
-  protected void startVoiceRecognition(Intent intent, int code)
+  protected void startVoiceRecognition(Intent intent)
   {
-    mFragment.startActivityForResult(intent, code);
+    mFragment.startVoiceRecognitionForResult.launch(intent);
   }
 
   @Override

--- a/android/app/src/main/java/app/organicmaps/routing/RoutingPlanController.java
+++ b/android/app/src/main/java/app/organicmaps/routing/RoutingPlanController.java
@@ -1,12 +1,14 @@
 package app.organicmaps.routing;
 
 import android.app.Activity;
+import android.content.Intent;
 import android.os.Bundle;
 import android.view.View;
 import android.widget.CompoundButton;
 import android.widget.RadioGroup;
 import android.widget.TextView;
 
+import androidx.activity.result.ActivityResultLauncher;
 import androidx.annotation.DrawableRes;
 import androidx.annotation.IdRes;
 import androidx.annotation.NonNull;
@@ -78,6 +80,7 @@ public class RoutingPlanController extends ToolbarController
   }
 
   RoutingPlanController(View root, Activity activity,
+                        ActivityResultLauncher<Intent> startDrivingOptionsForResult,
                         @NonNull RoutingPlanInplaceController.RoutingPlanListener routingPlanListener,
                         @Nullable RoutingBottomMenuListener listener)
   {
@@ -103,7 +106,7 @@ public class RoutingPlanController extends ToolbarController
     View btn = mDrivingOptionsBtnContainer.findViewById(R.id.driving_options_btn);
     mDrivingOptionsImage = mFrame.findViewById(R.id.driving_options_btn_img);
 
-    btn.setOnClickListener(v -> DrivingOptionsActivity.start(requireActivity()));
+    btn.setOnClickListener(v -> DrivingOptionsActivity.start(requireActivity(), startDrivingOptionsForResult));
     mDriverOptionsLayoutListener = new SelfTerminatedDrivingOptionsLayoutListener();
     mAnimToggle = MwmApplication.from(activity.getApplicationContext())
                                 .getResources().getInteger(R.integer.anim_default);

--- a/android/app/src/main/java/app/organicmaps/routing/RoutingPlanFragment.java
+++ b/android/app/src/main/java/app/organicmaps/routing/RoutingPlanFragment.java
@@ -7,9 +7,9 @@ import android.view.ViewGroup;
 
 import androidx.annotation.NonNull;
 import androidx.annotation.Nullable;
-import androidx.fragment.app.FragmentActivity;
 
 import app.organicmaps.Framework;
+import app.organicmaps.MwmActivity;
 import app.organicmaps.R;
 import app.organicmaps.base.BaseMwmFragment;
 
@@ -21,15 +21,9 @@ public class RoutingPlanFragment extends BaseMwmFragment
   @Override
   public View onCreateView(LayoutInflater inflater, @Nullable ViewGroup container, @Nullable Bundle savedInstanceState)
   {
-    final FragmentActivity activity = requireActivity();
+    final MwmActivity activity = (MwmActivity) requireActivity();
     View res = inflater.inflate(R.layout.fragment_routing, container, false);
-    RoutingBottomMenuListener listener = null;
-    if (activity instanceof RoutingBottomMenuListener)
-      listener = (RoutingBottomMenuListener) activity;
-
-    RoutingPlanInplaceController.RoutingPlanListener planListener =
-        (RoutingPlanInplaceController.RoutingPlanListener) activity;
-    mPlanController = new RoutingPlanController(res, activity, planListener, listener);
+    mPlanController = new RoutingPlanController(res, activity, activity.startDrivingOptionsForResult, activity, activity);
     return res;
   }
 

--- a/android/app/src/main/java/app/organicmaps/routing/RoutingPlanInplaceController.java
+++ b/android/app/src/main/java/app/organicmaps/routing/RoutingPlanInplaceController.java
@@ -2,8 +2,10 @@ package app.organicmaps.routing;
 
 import android.animation.Animator;
 import android.animation.ValueAnimator;
+import android.content.Intent;
 import android.os.Bundle;
 
+import androidx.activity.result.ActivityResultLauncher;
 import androidx.annotation.NonNull;
 import androidx.annotation.Nullable;
 
@@ -20,10 +22,11 @@ public class RoutingPlanInplaceController extends RoutingPlanController
   private Animator mAnimator;
 
   public RoutingPlanInplaceController(@NonNull MwmActivity activity,
+                                      ActivityResultLauncher<Intent> startDrivingOptionsForResult,
                                       @NonNull RoutingPlanListener routingPlanListener,
                                       @NonNull RoutingBottomMenuListener listener)
   {
-    super(activity.findViewById(R.id.routing_plan_frame), activity, routingPlanListener, listener);
+    super(activity.findViewById(R.id.routing_plan_frame), activity, startDrivingOptionsForResult, routingPlanListener, listener);
     mRoutingPlanListener = routingPlanListener;
   }
 

--- a/android/app/src/main/java/app/organicmaps/search/SearchFragment.java
+++ b/android/app/src/main/java/app/organicmaps/search/SearchFragment.java
@@ -10,6 +10,8 @@ import android.view.LayoutInflater;
 import android.view.View;
 import android.view.ViewGroup;
 
+import androidx.activity.result.ActivityResultLauncher;
+import androidx.activity.result.contract.ActivityResultContracts;
 import androidx.annotation.CallSuper;
 import androidx.annotation.NonNull;
 import androidx.annotation.Nullable;
@@ -113,10 +115,9 @@ public class SearchFragment extends BaseMwmFragment
     }
 
     @Override
-    @SuppressWarnings("deprecation") // https://github.com/organicmaps/organicmaps/issues/3630
-    protected void startVoiceRecognition(Intent intent, int code)
+    protected void startVoiceRecognition(Intent intent)
     {
-      startActivityForResult(intent, code);
+      startVoiceRecognitionForResult.launch(intent);
     }
 
     @Override
@@ -167,6 +168,11 @@ public class SearchFragment extends BaseMwmFragment
   @Nullable
   private String mInitialLocale;
   private boolean mInitialSearchOnMap = false;
+
+  private final ActivityResultLauncher<Intent> startVoiceRecognitionForResult = registerForActivityResult(new ActivityResultContracts.StartActivityForResult(), activityResult ->
+  {
+    mToolbarController.onVoiceRecognitionResult(activityResult);
+  });
 
   private final LocationListener mLocationListener = new LocationListener()
   {
@@ -523,14 +529,6 @@ public class SearchFragment extends BaseMwmFragment
     updateFrames();
     mSearchAdapter.refreshData(results);
     mToolbarController.showProgress(true);
-  }
-
-  @Override
-  @SuppressWarnings("deprecation") // https://github.com/organicmaps/organicmaps/issues/3630
-  public void onActivityResult(int requestCode, int resultCode, Intent data)
-  {
-    super.onActivityResult(requestCode, resultCode, data);
-    mToolbarController.onActivityResult(requestCode, resultCode, data);
   }
 
   @Override

--- a/android/app/src/main/java/app/organicmaps/settings/DrivingOptionsActivity.java
+++ b/android/app/src/main/java/app/organicmaps/settings/DrivingOptionsActivity.java
@@ -3,10 +3,9 @@ package app.organicmaps.settings;
 import android.app.Activity;
 import android.content.Intent;
 
+import androidx.activity.result.ActivityResultLauncher;
 import androidx.annotation.NonNull;
 import androidx.fragment.app.Fragment;
-
-import app.organicmaps.MwmActivity;
 import app.organicmaps.base.BaseMwmFragmentActivity;
 
 public class DrivingOptionsActivity extends BaseMwmFragmentActivity
@@ -17,9 +16,9 @@ public class DrivingOptionsActivity extends BaseMwmFragmentActivity
     return DrivingOptionsFragment.class;
   }
 
-  public static void start(@NonNull Activity activity)
+  public static void start(@NonNull Activity activity, ActivityResultLauncher<Intent> startDrivingOptionsForResult)
   {
     Intent intent = new Intent(activity, DrivingOptionsActivity.class);
-    activity.startActivityForResult(intent, MwmActivity.REQ_CODE_DRIVING_OPTIONS);
+    startDrivingOptionsForResult.launch(intent);
   }
 }

--- a/android/app/src/main/java/app/organicmaps/util/UiUtils.java
+++ b/android/app/src/main/java/app/organicmaps/util/UiUtils.java
@@ -18,6 +18,8 @@ import android.view.WindowManager;
 import android.widget.Button;
 import android.widget.TextView;
 
+import androidx.activity.result.ActivityResult;
+import androidx.activity.result.ActivityResultLauncher;
 import androidx.annotation.AnyRes;
 import androidx.annotation.AttrRes;
 import androidx.annotation.ColorInt;
@@ -32,7 +34,6 @@ import androidx.core.graphics.Insets;
 import androidx.core.view.WindowCompat;
 import androidx.core.view.WindowInsetsCompat;
 import androidx.core.view.WindowInsetsControllerCompat;
-import androidx.fragment.app.Fragment;
 import androidx.recyclerview.widget.RecyclerView;
 import app.organicmaps.MwmApplication;
 import app.organicmaps.R;
@@ -362,10 +363,9 @@ public final class UiUtils
     }
   }
 
-  @SuppressWarnings("deprecation") // https://github.com/organicmaps/organicmaps/issues/3630
-  public static void startActivityForResult(@NonNull Fragment fragment, @NonNull Intent intent, int requestCode)
+  public static void startActivityForResult(ActivityResultLauncher<Intent> startForResult, @NonNull Intent intent)
   {
-    fragment.startActivityForResult(intent, requestCode);
+    startForResult.launch(intent);
   }
 
   // utility class

--- a/android/app/src/main/java/app/organicmaps/widget/SearchToolbarController.java
+++ b/android/app/src/main/java/app/organicmaps/widget/SearchToolbarController.java
@@ -10,6 +10,7 @@ import android.view.KeyEvent;
 import android.view.View;
 import android.view.inputmethod.EditorInfo;
 
+import androidx.activity.result.ActivityResult;
 import androidx.annotation.NonNull;
 import androidx.annotation.Nullable;
 import androidx.annotation.StringRes;
@@ -22,7 +23,6 @@ import com.google.android.material.textfield.TextInputEditText;
 
 public class SearchToolbarController extends ToolbarController implements View.OnClickListener
 {
-  private static final int REQUEST_VOICE_RECOGNITION = 0xCA11;
   @Nullable
   private final View mToolbarContainer;
   @NonNull
@@ -107,7 +107,7 @@ public class SearchToolbarController extends ToolbarController implements View.O
     clear();
   }
 
-  protected void startVoiceRecognition(Intent intent, int code)
+  protected void startVoiceRecognition(Intent intent)
   {
     throw new RuntimeException("To be used startVoiceRecognition() must be implemented by descendant class");
   }
@@ -130,7 +130,7 @@ public class SearchToolbarController extends ToolbarController implements View.O
     try
     {
       startVoiceRecognition(InputUtils.createIntentForVoiceRecognition(
-          requireActivity().getString(getVoiceInputPrompt())), REQUEST_VOICE_RECOGNITION);
+          requireActivity().getString(getVoiceInputPrompt())));
     }
     catch (ActivityNotFoundException e)
     {
@@ -210,14 +210,18 @@ public class SearchToolbarController extends ToolbarController implements View.O
     UiUtils.showIf(show, mSearchContainer);
   }
 
-  public void onActivityResult(int requestCode, int resultCode, Intent data)
+  public void onVoiceRecognitionResult(ActivityResult activityResult)
   {
-    if (requestCode == REQUEST_VOICE_RECOGNITION && resultCode == Activity.RESULT_OK)
-    {
-      String result = InputUtils.getBestRecognitionResult(data);
-      if (!TextUtils.isEmpty(result))
-        setQuery(result);
-    }
+      if(activityResult.getResultCode() == Activity.RESULT_OK)
+      {
+        if (activityResult.getData() == null)
+        {
+          return;
+        }
+        String recognitionResult = InputUtils.getBestRecognitionResult(activityResult.getData());
+        if (!TextUtils.isEmpty(recognitionResult))
+          setQuery(recognitionResult);
+      }
   }
 
   public void setHint(@StringRes int hint)


### PR DESCRIPTION
Fixes: #3630

There's only one file [ProgressDialogFragment](https://github.com/organicmaps/organicmaps/blob/5c18ca362d9090def7206466357a511f324e9fac/android/app/src/main/java/app/organicmaps/dialog/ProgressDialogFragment.java#L32) where the use of `onActivityResult()` is still present. I couldn't find from where this Dialog was getting launched so was not able to register for result.

This dialog fragment is not being used, so should it be removed?