### PR TITLE
Always seek to end of file when opening in append mode

### DIFF
--- a/coding/internal/file_data.cpp
+++ b/coding/internal/file_data.cpp
@@ -36,8 +36,11 @@ FileData::FileData(string const & fileName, Op op)
   m_File = fopen(fileName.c_str(), modes[op]);
   if (m_File)
   {
+#if defined(_MSC_VER)
+    // Move file pointer to the end of the file to make it consistent with other platforms
     if (op == OP_APPEND)
       fseek64(m_File, 0, SEEK_END);
+#endif
     return;
   }
 

--- a/coding/internal/file_data.cpp
+++ b/coding/internal/file_data.cpp
@@ -35,7 +35,11 @@ FileData::FileData(string const & fileName, Op op)
 
   m_File = fopen(fileName.c_str(), modes[op]);
   if (m_File)
+  {
+    if (op == OP_APPEND)
+      fseek64(m_File, 0, SEEK_END);
     return;
+  }
 
   if (op == OP_WRITE_EXISTING)
   {


### PR DESCRIPTION
C standard does not guarantee that file opened in append mode is seeked to the end. In particular, MSVC CRT does not do that, so ftell64 always returns 0. Fixes some tests on Windows.