### PR TITLE
Set max possible file limit on all platforms

### DIFF
--- a/libs/platform/platform_android.cpp
+++ b/libs/platform/platform_android.cpp
@@ -29,6 +29,7 @@
 Platform::Platform()
 {
   /// @see initialization routine in android/sdk/src/main/cpp/com/.../Platform.hpp
+  pl::SetMaxOpenFileLimit();
 }
 
 #ifdef DEBUG

--- a/libs/platform/platform_ios.mm
+++ b/libs/platform/platform_ios.mm
@@ -31,6 +31,8 @@
 
 Platform::Platform()
 {
+  pl::SetMaxOpenFileLimit();
+
   m_isTablet = UIDevice.currentDevice.userInterfaceIdiom == UIUserInterfaceIdiomPad;
 
   NSBundle * bundle = NSBundle.mainBundle;

--- a/libs/platform/platform_linux.cpp
+++ b/libs/platform/platform_linux.cpp
@@ -2,6 +2,7 @@
 #include "private.h"
 
 #include "platform/gui_thread.hpp"
+#include "platform/platform_unix_impl.hpp"
 #include "platform/socket.hpp"
 
 #include "base/exception.hpp"
@@ -76,6 +77,8 @@ std::unique_ptr<Socket> CreateSocket()
 
 Platform::Platform()
 {
+  pl::SetMaxOpenFileLimit();
+
   using base::JoinPath;
   // Current executable's path with a trailing slash.
   auto const execDir = GetExecutableDir();

--- a/libs/platform/platform_mac.mm
+++ b/libs/platform/platform_mac.mm
@@ -1,5 +1,6 @@
 #include "platform/gui_thread.hpp"
 #include "platform/platform.hpp"
+#include "platform/platform_unix_impl.hpp"
 
 #include "base/file_name_utils.hpp"
 #include "base/logging.hpp"
@@ -24,6 +25,8 @@
 
 Platform::Platform()
 {
+  pl::SetMaxOpenFileLimit();
+
   // OMaps.app/Content/Resources or omim-build-debug for tests.
   std::string const resourcesPath = NSBundle.mainBundle.resourcePath.UTF8String;
   // Omaps.app or omim-build-debug for tests.

--- a/libs/platform/platform_tests/platform_test.cpp
+++ b/libs/platform/platform_tests/platform_test.cpp
@@ -1,6 +1,7 @@
 #include "testing/testing.hpp"
 
 #include "platform/platform.hpp"
+#include "platform/platform_unix_impl.hpp"
 
 #include "coding/file_writer.hpp"
 #include "coding/internal/file_data.hpp"
@@ -9,6 +10,8 @@
 #include "base/logging.hpp"
 #include "base/scope_guard.hpp"
 #include "base/stl_helpers.hpp"
+
+#include "std/target_os.hpp"
 
 #include <algorithm>
 #include <atomic>
@@ -19,6 +22,10 @@
 #include <thread>
 #include <utility>
 #include <vector>
+
+#ifndef OMIM_OS_WINDOWS
+#include <sys/resource.h>
+#endif
 
 #include "defines.hpp"
 
@@ -386,3 +393,23 @@ UNIT_TEST(GetFileCreationTime_GetFileModificationTime_MissingFile)
   TEST_EQUAL(Platform::GetFileCreationTime(missing), 0, ());
   TEST_EQUAL(Platform::GetFileModificationTime(missing), 0, ());
 }
+
+#ifndef OMIM_OS_WINDOWS
+UNIT_TEST(SetMaxOpenFileLimit)
+{
+  struct rlimit original;
+  TEST_EQUAL(getrlimit(RLIMIT_NOFILE, &original), 0, ());
+  SCOPE_GUARD(restoreLimit, [&original]() { setrlimit(RLIMIT_NOFILE, &original); });
+
+  struct rlimit lowered = original;
+  lowered.rlim_cur = 64;
+  TEST_EQUAL(setrlimit(RLIMIT_NOFILE, &lowered), 0, ());
+
+  pl::SetMaxOpenFileLimit();
+
+  struct rlimit raised;
+  TEST_EQUAL(getrlimit(RLIMIT_NOFILE, &raised), 0, ());
+  TEST_GREATER(raised.rlim_cur, lowered.rlim_cur, ());
+  TEST_LESS_OR_EQUAL(raised.rlim_cur, original.rlim_max, ());
+}
+#endif

--- a/libs/platform/platform_unix_impl.cpp
+++ b/libs/platform/platform_unix_impl.cpp
@@ -3,10 +3,13 @@
 
 #include "base/logging.hpp"
 
+#include <algorithm>
+#include <cerrno>
 #include <memory>
 #include <regex>
 
 #include <dirent.h>
+#include <sys/resource.h>
 #include <sys/stat.h>
 #include <sys/types.h>
 #include <unistd.h>
@@ -148,6 +151,32 @@ void EnumerateFilesByRegExp(std::string const & directory, std::string const & r
     if (std::regex_search(name.begin(), name.end(), exp))
       res.push_back(name);
   });
+}
+
+void SetMaxOpenFileLimit()
+{
+  // Search and routing keep many mwm sections open at the same time, while some platforms are very
+  // conservative by default (iOS starts with only 256 allowed open files).
+  // Do not raise the limit to the hard one: it is RLIM_INFINITY on Apple platforms, and a huge
+  // value slows down or breaks the code that iterates over all possible descriptors.
+  rlim_t constexpr kMaxOpenFiles = 8192;
+
+  struct rlimit limit;
+  if (getrlimit(RLIMIT_NOFILE, &limit) != 0)
+  {
+    LOG(LWARNING, ("getrlimit(RLIMIT_NOFILE) has failed with errno", errno));
+    return;
+  }
+
+  if (limit.rlim_cur >= kMaxOpenFiles)
+    return;
+
+  rlim_t const oldLimit = limit.rlim_cur;
+  limit.rlim_cur = std::min(kMaxOpenFiles, limit.rlim_max);
+  if (setrlimit(RLIMIT_NOFILE, &limit) != 0)
+    LOG(LWARNING, ("setrlimit(RLIMIT_NOFILE,", limit.rlim_cur, ") has failed with errno", errno));
+  else
+    LOG(LINFO, ("Increased the open files limit from", oldLimit, "to", limit.rlim_cur));
 }
 
 }  // namespace pl

--- a/libs/platform/platform_unix_impl.hpp
+++ b/libs/platform/platform_unix_impl.hpp
@@ -9,4 +9,7 @@ namespace pl
 void EnumerateFiles(std::string const & directory, std::function<void(char const *)> const & fn);
 
 void EnumerateFilesByRegExp(std::string const & directory, std::string const & regexp, std::vector<std::string> & res);
+
+// Raises the soft limit of simultaneously open files, see the implementation for details.
+void SetMaxOpenFileLimit();
 }  // namespace pl

--- a/libs/platform/platform_win.cpp
+++ b/libs/platform/platform_win.cpp
@@ -9,6 +9,7 @@
 
 #include "std/windows.hpp"
 
+#include <cstdio>
 #include <functional>
 
 #include <direct.h>
@@ -54,6 +55,17 @@ std::unique_ptr<Socket> CreateSocket()
 
 Platform::Platform()
 {
+  // See pl::SetMaxOpenFileLimit() for the rationale. 8192 is the maximum accepted by _setmaxstdio().
+  int constexpr kMaxOpenFiles = 8192;
+  int const oldLimit = ::_getmaxstdio();
+  if (oldLimit < kMaxOpenFiles)
+  {
+    if (::_setmaxstdio(kMaxOpenFiles) == kMaxOpenFiles)
+      LOG(LINFO, ("Increased the open files limit from", oldLimit, "to", kMaxOpenFiles));
+    else
+      LOG(LWARNING, ("_setmaxstdio(", kMaxOpenFiles, ") has failed"));
+  }
+
   std::string path;
   CHECK(GetPathToBinary(path), ("Can't get path to binary"));
 


### PR DESCRIPTION
This PR needs an investigation first:
1. What is the real open file limit?
2. Does changing these settings increase the real file limit?

The test can try to create/open as many files as possible and see when fopen call fails.


Android 14 (Samsung):
```
SetMaxOpenFileLimit(): NOFILE soft limit 32768 hard limit 32768
```

Mac OS X 14 (with patched limit):
```
SetMaxOpenFileLimit(): NOFILE soft limit 1000000 hard limit 9223372036854775807
```

iPhone 13, iOS 17:
```
SetMaxOpenFileLimit(): NOFILE soft limit 256 hard limit 9223372036854775807
```