### PR TITLE
[routing] Fix #2833: Manually placed route origin is no longer replaced by current location after app restart

### DIFF
--- a/map/routing_mark.hpp
+++ b/map/routing_mark.hpp
@@ -22,6 +22,7 @@ struct RouteMarkData
   bool m_isVisible = true;
   bool m_isMyPosition = false;
   bool m_isPassed = false;
+  bool m_replaceWithMyPosition = false;
   m2::PointD m_position;
 };
 


### PR DESCRIPTION
The application replaced the origin point solely based on if it had found the user's location. Added a parameter to the RouteMarkData struct which is saved alongside the start point. This is used on start up to determine if the origin point of the route should be kept or replaced with the user's location (if one is found).