### PR TITLE
[styles] Removed shop=vacant

### DIFF
--- a/data/replaced_tags.txt
+++ b/data/replaced_tags.txt
@@ -46,6 +46,7 @@ shop=money_transfer : amenity=money_transfer
 shop=estate_agent : office=estate_agent
 shop=locksmith : craft=locksmith
 shop=auction_house : shop=auction
+shop=vacant : disused:shop=yes
 ford=boat : highway=ford
 ford=intermittent : highway=ford
 ford=seasonal : highway=ford


### PR DESCRIPTION
closes #3156

Removed `shop=vacant` by replacing it with `disused:shop=yes` in `data/replace_tats.txt`

before
![Bildschirmfoto vom 2024-04-02 17-31-17](https://github.com/organicmaps/organicmaps/assets/79519062/9ab1f79d-b660-4732-a2e5-36a1f71cf01d)

now
![Bildschirmfoto vom 2024-04-02 18-11-21](https://github.com/organicmaps/organicmaps/assets/79519062/3b2ab6e5-cc3f-4936-b1e7-2bcc415b520d)

OSM: https://www.openstreetmap.org/node/4338842100
