### PR TITLE
[docs] Remove Outdoor style from GSOC projects

### DIFF
--- a/README.md
+++ b/README.md
@@ -112,7 +112,7 @@ Beloved institutional sponsors below have provided targeted grants to cover some
       <a href="https://summerofcode.withgoogle.com/"><img src="docs/sponsors/gsoc.svg" alt="Google Summer of Code" width="200px"></a>
     </td>
     <td>
-      <a href="https://summerofcode.withgoogle.com/">Google</a> backed 5 student's projects in the Google Summer of Code program during <a href="https://summerofcode.withgoogle.com/programs/2022/organizations/organic-maps">2022</a> and <a href="https://summerofcode.withgoogle.com/programs/2023/organizations/organic-maps">2023</a> programs. Noteworthy projects included Android Auto, Outdoor Style, and Wikipedia Dump Extractor.
+      <a href="https://summerofcode.withgoogle.com/">Google</a> backed 5 student's projects in the Google Summer of Code program during <a href="https://summerofcode.withgoogle.com/programs/2022/organizations/organic-maps">2022</a> and <a href="https://summerofcode.withgoogle.com/programs/2023/organizations/organic-maps">2023</a> programs. Noteworthy projects included Android Auto and Wikipedia Dump Extractor.
     </td>
   </tr>
   <tr>


### PR DESCRIPTION
Outdoor Style wasn't a GSOC project.

(The project was about internal refactoring of the styles system, so not really user-facing, hence little point mentioning it).
