### PR TITLE
[ios] Fix the circular downloading progress bar layout on the PP screen

### DIFF
--- a/iphone/Maps/Classes/CustomViews/CircularProgress/MWMCircularProgressView.m
+++ b/iphone/Maps/Classes/CustomViews/CircularProgress/MWMCircularProgressView.m
@@ -115,15 +115,8 @@ static CGFloat angleWithProgress(CGFloat progress) { return 2.0 * M_PI * progres
   self.backgroundLayer.fillColor = self.progressLayer.fillColor = UIColor.clearColor.CGColor;
   self.backgroundLayer.lineWidth = self.progressLayer.lineWidth = kLineWidth;
   self.backgroundLayer.strokeColor = self.spinnerBackgroundColor.CGColor;
+  [self updateBackgroundPath];
   self.progressLayer.strokeColor = self.progressLayerColor;
-  CGPoint center = CGPointMake(self.width / 2.0, self.height / 2.0);
-  CGFloat radius = MIN(center.x, center.y) - kLineWidth;
-  UIBezierPath * path = [UIBezierPath bezierPathWithArcCenter:center
-                                                       radius:radius
-                                                   startAngle:angleWithProgress(0.0)
-                                                     endAngle:angleWithProgress(1.0)
-                                                    clockwise:YES];
-  self.backgroundLayer.path = path.CGPath;
   NSString * imageName = self.images[@(self.state)];
   if (imageName)
   {
@@ -143,12 +136,23 @@ static CGFloat angleWithProgress(CGFloat progress) { return 2.0 * M_PI * progres
 
 - (void)updatePath:(CGFloat)progress
 {
+  [self updateBackgroundPath];
   if (progress > 0.0)
   {
     self.state =
         progress < 1.0 ? MWMCircularProgressStateProgress : MWMCircularProgressStateCompleted;
     [self stopSpinner];
   }
+  self.progressLayer.path = [self pathWithProgress:progress].CGPath;
+}
+
+- (void)updateBackgroundPath 
+{
+  self.backgroundLayer.path = [self pathWithProgress:1.0].CGPath;
+}
+
+- (UIBezierPath *)pathWithProgress:(CGFloat)progress
+{
   CGPoint center = CGPointMake(self.width / 2.0, self.height / 2.0);
   CGFloat radius = MIN(center.x, center.y) - kLineWidth;
   UIBezierPath * path = [UIBezierPath bezierPathWithArcCenter:center
@@ -156,9 +160,8 @@ static CGFloat angleWithProgress(CGFloat progress) { return 2.0 * M_PI * progres
                                                    startAngle:angleWithProgress(0.0)
                                                      endAngle:angleWithProgress(progress)
                                                     clockwise:YES];
-  self.progressLayer.path = path.CGPath;
+  return  path;
 }
-
 #pragma mark - Spinner
 
 - (void)startSpinner


### PR DESCRIPTION
Closes https://github.com/organicmaps/organicmaps/issues/7782

I cannot reproduce such a huge mismatch, but I found that the device rotation will trigger the progress bar layout reloading, but the bar's `backgroundLayer` will not update its path.

This PR fixes this issue by refreshing the backgroundLayer's path too.

How to reproduce: 
- Start downloading some maps
- Tap on the some PP in this region
- Rotate the device
- You will see a small gap between bars
- It will be more visible if you open PP in the horizontal orientation and rotate to the vertical.

Tested on:
- [x] iOS 17.2 (iPhone 11 pro - device)
- [x] iOS 15.5 (iPhone 15 pro - simulator)

Before:
<img width="112" alt="image" src="https://github.com/organicmaps/organicmaps/assets/79797627/4a11bb1c-60d0-4588-b303-7007aa0d71d6">
<img width="657" alt="image" src="https://github.com/organicmaps/organicmaps/assets/79797627/09fa0e60-1cea-49bc-91a5-c87dabd8d180">

(it's hard to see it on the gif)
![Simulator Screen Recording - iPhone 15 Pro - 2024-04-05 at 12 26 29](https://github.com/organicmaps/organicmaps/assets/79797627/781b8418-b9c8-46a2-b263-459c833f0797)

After:
![Simulator Screen Recording - iPhone 13 Pro - 2024-04-05 at 12 15 35](https://github.com/organicmaps/organicmaps/assets/79797627/aa60b9f8-78ea-442d-bce7-099e670d1ee3)


