### PR TITLE
[editor] Fixed bug overwriting existing features

### DIFF
--- a/editor/changeset_wrapper.cpp
+++ b/editor/changeset_wrapper.cpp
@@ -247,6 +247,11 @@ void ChangesetWrapper::Delete(editor::XMLFeature node)
   m_deleted_types[GetTypeForFeature(node)]++;
 }
 
+void ChangesetWrapper::AddChangesetTag(std::string key, std::string value)
+{
+  m_changesetComments.emplace(std::move(key), std::move(value));
+}
+
 std::string ChangesetWrapper::TypeCountToString(TypeCount const & typeCount)
 {
   if (typeCount.empty())

--- a/editor/changeset_wrapper.hpp
+++ b/editor/changeset_wrapper.hpp
@@ -49,6 +49,9 @@ public:
   /// Throws exceptions from above list.
   void Delete(editor::XMLFeature node);
 
+  /// Add a tag to the changeset
+  void AddChangesetTag(std::string key, std::string value);
+
   /// Allows to see exception details in OSM changesets for easier debugging.
   void SetErrorDescription(std::string const & error);
 

--- a/editor/osm_editor.cpp
+++ b/editor/osm_editor.cpp
@@ -646,8 +646,10 @@ void Editor::UploadChanges(string const & oauthToken, ChangesetTags tags,
               }
               else
               {
-                LOG(LDEBUG, ("Create case: uploading patched feature", osmFeature));
-                changeset.Modify(osmFeature);
+                LOG(LDEBUG, ("Create case: uploading new feature", feature));
+                // There is another node nearby, but it is saver to upload a new node (#2298).
+                changeset.AddChangesetTag("info:feature_close_by", "yes");
+                changeset.Create(feature);
               }
             }
             catch (ChangesetWrapper::OsmObjectWasDeletedException const &)


### PR DESCRIPTION
fixes #2298

This PR solves the problem that, when adding a node at a location where a different node is located already, the tags of the new feature are added to the existing node. This often leads to nonsense combinations (see #2298) and can also make address nodes unusable.

Test:
- Bug in current Play Store version: https://www.openstreetmap.org/changeset/149696066
- This PR doesn't overwrite the old node, but creates a new node: https://www.openstreetmap.org/changeset/149697572
   The existing node remains untouched: https://www.openstreetmap.org/node/11257500263