### PR TITLE
[packaging] Fix deprecated `developer_name` & missing `developer`

### DIFF
--- a/packaging/app.organicmaps.desktop.metainfo.xml
+++ b/packaging/app.organicmaps.desktop.metainfo.xml
@@ -3,7 +3,9 @@
   <id>app.organicmaps.desktop</id>
 
   <name>Organic Maps</name>
-  <developer_name>The Organic Maps Community</developer_name>
+  <developer id="app.organicmaps">
+    <name>The Organic Maps Community</name>
+  </developer>
   <summary>Free offline maps for everyone</summary>
 
   <metadata_license>CC0-1.0</metadata_license>


### PR DESCRIPTION
Fixes the following two flathub linter warnings:

I: app.organicmaps.desktop:6: developer-name-tag-deprecated
   The toplevel `developer_name` element is deprecated. Please use the `name` element in a
   `developer` block instead.

I: app.organicmaps.desktop:~: developer-info-missing
   This component contains no `developer` element with information about its author.
Signed-off-by: Ferenc Géczi <ferenc.gm@gmail.com>