### PR TITLE
[ios] Add default email client support to about menu

### DIFF
--- a/iphone/Maps/UI/Help/AboutController/AboutController.swift
+++ b/iphone/Maps/UI/Help/AboutController/AboutController.swift
@@ -482,7 +482,7 @@ private extension AboutController {
       return false
     }
     
-    func openDefaultApp(subject: String, body: String, recipients: [String]) -> Bool {
+    func openDefaultMailApp(subject: String, body: String, recipients: [String]) -> Bool {
       var components = URLComponents(string: "mailto:\(recipients.joined(separator: ";"))")
       components?.queryItems = [
         URLQueryItem(name: "subject", value: subject),
@@ -507,7 +507,7 @@ private extension AboutController {
     }
     
     // From iOS 14, it is possible to change the default mail app, and mailto should open a default mail app.
-    if openDefaultApp(subject: subject, body: body, recipients: toRecipients){
+    if openDefaultMailApp(subject: subject, body: body, recipients: toRecipients){
       return
     } else {
       let text = String(format:L("email_error_body"), toRecipients.joined(separator: ";"))

--- a/iphone/Maps/UI/Help/AboutController/AboutController.swift
+++ b/iphone/Maps/UI/Help/AboutController/AboutController.swift
@@ -509,14 +509,6 @@ private extension AboutController {
     // From iOS 14, it is possible to change the default mail app, and mailto should open a default mail app.
     if openDefaultApp(subject: subject, body: body, recipients: toRecipients){
       return
-    } else if MWMMailViewController.canSendMail() {
-      let vc = MWMMailViewController()
-      vc.mailComposeDelegate = self
-      vc.setSubject(subject)
-      vc.setMessageBody(body, isHTML:false)
-      vc.setToRecipients(toRecipients)
-      vc.navigationBar.tintColor = UIColor.whitePrimaryText()
-      self.present(vc, animated: true, completion:nil)
     } else {
       let text = String(format:L("email_error_body"), toRecipients.joined(separator: ";"))
       let alert = UIAlertController(title: L("email_error_title"), message: text, preferredStyle: .alert)
@@ -524,13 +516,6 @@ private extension AboutController {
       alert.addAction(action)
       present(alert, animated: true, completion: nil)
     }
-  }
-}
-
-// MARK: - MFMailComposeViewControllerDelegate
-extension AboutController: MFMailComposeViewControllerDelegate {
-  func mailComposeController(_ controller: MFMailComposeViewController, didFinishWith result: MFMailComposeResult, error: Error?) {
-    self.dismiss(animated: true, completion: nil)
   }
 }
 

--- a/iphone/Maps/UI/Help/AboutController/AboutController.swift
+++ b/iphone/Maps/UI/Help/AboutController/AboutController.swift
@@ -507,7 +507,7 @@ private extension AboutController {
     }
     
     // From iOS 14, it is possible to change the default mail app, and mailto should open a default mail app.
-    if openDefaultMailApp(subject: subject, body: body, recipients: toRecipients){
+    if openDefaultMailApp(subject: subject, body: body, recipients: toRecipients) {
       return
     } else {
       let text = String(format:L("email_error_body"), toRecipients.joined(separator: ";"))

--- a/iphone/Maps/UI/Help/AboutController/AboutController.swift
+++ b/iphone/Maps/UI/Help/AboutController/AboutController.swift
@@ -492,14 +492,13 @@ private extension AboutController {
       return
     }
     // From iOS 14, it is possible to change the default mail app, and mailto should open a default mail app.
-    if MWMMailViewController.canSendMail() {
-      let vc = MWMMailViewController()
-      vc.mailComposeDelegate = self
-      vc.setSubject(subject)
-      vc.setMessageBody(body, isHTML:false)
-      vc.setToRecipients(toRecipients)
-      vc.navigationBar.tintColor = UIColor.whitePrimaryText()
-      self.present(vc, animated: true, completion:nil)
+    let encodedSubject = subject.addingPercentEncoding(withAllowedCharacters: .urlQueryAllowed) ?? ""
+    let encodedBody = body.addingPercentEncoding(withAllowedCharacters: .urlQueryAllowed) ?? ""
+    let correctEncodedBody = encodedBody.replacingOccurrences(of: "%0A", with: "%0D%0A")
+    
+    if let url = URL(string: "mailto:\(toRecipients)?subject=\(encodedSubject)&body=\(correctEncodedBody)"),
+      UIApplication.shared.canOpenURL(url) {
+          UIApplication.shared.open(url)
     } else {
       let text = String(format:L("email_error_body"), toRecipients.joined(separator: ";"))
       let alert = UIAlertController(title: L("email_error_title"), message: text, preferredStyle: .alert)


### PR DESCRIPTION
These changes are to add default email client support in the about menu. Issue #7758.

I tested it on my ipad 11 running 17.0.3

I would post a video but opening the email app does share some personal info