### PR TITLE
Switch single tap and long tap behaviour

### DIFF
--- a/android/app/src/main/java/app/organicmaps/MwmActivity.java
+++ b/android/app/src/main/java/app/organicmaps/MwmActivity.java
@@ -1238,6 +1238,8 @@ public class MwmActivity extends BaseMwmFragmentActivity
         return;
 
       setFullscreen(!isFullscreen());
+      if (isFullscreen())
+        showFullscreenToastIfNeeded();
     }
     else
     {
@@ -1261,6 +1263,16 @@ public class MwmActivity extends BaseMwmFragmentActivity
     // Buttons are hidden in position chooser mode but we are not in fullscreen
     return Boolean.TRUE.equals(mMapButtonsViewModel.getButtonsHidden().getValue()) &&
         Framework.nativeGetChoosePositionMode() == Framework.ChoosePositionMode.NONE;
+  }
+
+  private void showFullscreenToastIfNeeded()
+  {
+    // Show the toast only once so new behaviour doesn't confuse users
+    if (!Config.wasLongTapToastShown(this))
+    {
+      Toast.makeText(this, R.string.long_tap_toast, Toast.LENGTH_LONG).show();
+      Config.setLongTapToastShown(this, true);
+    }
   }
 
   @Override

--- a/android/app/src/main/java/app/organicmaps/util/Config.java
+++ b/android/app/src/main/java/app/organicmaps/util/Config.java
@@ -34,6 +34,7 @@ public final class Config
   private static final String KEY_MISC_AGPS_TIMESTAMP = "AGPSTimestamp";
   private static final String KEY_DONATE_URL = "DonateUrl";
   private static final String KEY_PREF_SEARCH_HISTORY = "SearchHistoryEnabled";
+  private static final String KEY_PREF_LONG_TAP_TOAST_SHOWN = "LongTapToastShown";
 
   /**
    * The total number of app launches.
@@ -394,6 +395,18 @@ public final class Config
         .edit()
         .putBoolean(KEY_MISC_FIRST_START_DIALOG_SEEN, true)
         .apply();
+  }
+
+  public static boolean wasLongTapToastShown(@NonNull Context context)
+  {
+    return MwmApplication.prefs(context).getBoolean(KEY_PREF_LONG_TAP_TOAST_SHOWN, false);
+  }
+
+  public static void setLongTapToastShown(@NonNull Context context, Boolean newValue)
+  {
+    MwmApplication.prefs(context).edit()
+         .putBoolean(KEY_PREF_LONG_TAP_TOAST_SHOWN, newValue)
+         .apply();
   }
 
   public static boolean isSearchHistoryEnabled()

--- a/android/app/src/main/res/values-ar/strings.xml
+++ b/android/app/src/main/res/values-ar/strings.xml
@@ -293,6 +293,8 @@
 	<string name="compass_calibration_recommended">قم بتحسين اتجاه السهم عن طريق تحريك الهاتف في حركة على شكل ثمانية لمعايرة البوصلة.</string>
 	<!-- Toast text when compass calibration may improve the correctness of the current position arrow -->
 	<string name="compass_calibration_required">حرك الهاتف في حركة على شكل ثمانية لمعايرة البوصلة وإصلاح اتجاه السهم على الخريطة.</string>
+	<!-- Toast text when user hides UI with a long tap anywhere on the map -->
+	<string name="long_tap_toast">اضغط مطولاً على الخريطة مرة أخرى لرؤية الواجهة</string>
 	<!-- Update all button text -->
 	<string name="downloader_update_all_button">تحديث الكل</string>
 	<!-- Cancel all button text -->

--- a/android/app/src/main/res/values-az/strings.xml
+++ b/android/app/src/main/res/values-az/strings.xml
@@ -280,6 +280,8 @@
 	<string name="compass_calibration_recommended">Kompası kalibrləmək və ox istiqamətini yaxşılaşdırmaq üçün telefonu səkkiz rəqəmi şəklinə çevirin.</string>
 	<!-- Toast text when compass calibration may improve the correctness of the current position arrow -->
 	<string name="compass_calibration_required">Kompası kalibrləmək və xəritədə oxun istiqamətini düzəltmək üçün telefonu səkkiz rəqəmlə hərəkət etdirin.</string>
+	<!-- Toast text when user hides UI with a long tap anywhere on the map -->
+	<string name="long_tap_toast">İnterfeysi görmək üçün yenidən xəritəyə uzun müddət toxunun</string>
 	<!-- Update all button text -->
 	<string name="downloader_update_all_button">Hamısını yeniləyin</string>
 	<!-- Cancel all button text -->

--- a/android/app/src/main/res/values-be/strings.xml
+++ b/android/app/src/main/res/values-be/strings.xml
@@ -279,6 +279,8 @@
 	<string name="compass_calibration_recommended">Палепшыце кірунак стрэлкі, перамяшчаючы тэлефон у выглядзе васьмёркі, каб адкалібраваць компас.</string>
 	<!-- Toast text when compass calibration may improve the correctness of the current position arrow -->
 	<string name="compass_calibration_required">Перамяшчайце тэлефон у выглядзе васьмёркі, каб адкалібраваць компас і зафіксаваць кірунак стрэлкі на карце.</string>
+	<!-- Toast text when user hides UI with a long tap anywhere on the map -->
+	<string name="long_tap_toast">Яшчэ раз доўга націсніце на карту, каб убачыць інтэрфейс</string>
 	<!-- Update all button text -->
 	<string name="downloader_update_all_button">Абнавіць усё</string>
 	<!-- Cancel all button text -->

--- a/android/app/src/main/res/values-bg/strings.xml
+++ b/android/app/src/main/res/values-bg/strings.xml
@@ -267,6 +267,8 @@
 	<string name="compass_calibration_recommended">Подобрете посоката на стрелката, като движите телефона с движение тип \"осмица\", за да калибрирате компаса.</string>
 	<!-- Toast text when compass calibration may improve the correctness of the current position arrow -->
 	<string name="compass_calibration_required">Преместете телефона с движение тип \"осмица\", за да калибрирате компаса и да фиксирате посоката на стрелката върху картата.</string>
+	<!-- Toast text when user hides UI with a long tap anywhere on the map -->
+	<string name="long_tap_toast">Докоснете отново картата, за да видите интерфейса</string>
 	<!-- Update all button text -->
 	<string name="downloader_update_all_button">Обновяване на всичко</string>
 	<!-- Cancel all button text -->

--- a/android/app/src/main/res/values-ca/strings.xml
+++ b/android/app/src/main/res/values-ca/strings.xml
@@ -274,6 +274,8 @@
 	<string name="compass_calibration_recommended">Milloreu la direcció de la fletxa movent el telèfon amb un moviment de vuit per calibrar la brúixola.</string>
 	<!-- Toast text when compass calibration may improve the correctness of the current position arrow -->
 	<string name="compass_calibration_required">Moveu el telèfon amb un moviment de vuit per calibrar la brúixola i fixar la direcció de la fletxa al mapa.</string>
+	<!-- Toast text when user hides UI with a long tap anywhere on the map -->
+	<string name="long_tap_toast">Toqueu llargament el mapa de nou per veure la interfície</string>
 	<!-- Update all button text -->
 	<string name="downloader_update_all_button">Actualitza-ho tot</string>
 	<!-- Cancel all button text -->

--- a/android/app/src/main/res/values-cs/strings.xml
+++ b/android/app/src/main/res/values-cs/strings.xml
@@ -265,6 +265,8 @@
 	<string name="compass_calibration_recommended">Zlepšete směr šipky pohybem telefonu do osmičky a zkalibrujte kompas.</string>
 	<!-- Toast text when compass calibration may improve the correctness of the current position arrow -->
 	<string name="compass_calibration_required">Pohybem telefonu do osmičky zkalibrujte kompas a zafixujte směr šipky na mapě.</string>
+	<!-- Toast text when user hides UI with a long tap anywhere on the map -->
+	<string name="long_tap_toast">Dlouhým klepnutím na mapu znovu zobrazíte rozhraní.</string>
 	<!-- Update all button text -->
 	<string name="downloader_update_all_button">Aktualizovat vše</string>
 	<!-- Cancel all button text -->

--- a/android/app/src/main/res/values-da/strings.xml
+++ b/android/app/src/main/res/values-da/strings.xml
@@ -261,6 +261,8 @@
 	<string name="compass_calibration_recommended">Forbedre pilens retning ved at bevæge telefonen i en ottetalsbevægelse for at kalibrere kompasset.</string>
 	<!-- Toast text when compass calibration may improve the correctness of the current position arrow -->
 	<string name="compass_calibration_required">Bevæg telefonen i en ottetalsbevægelse for at kalibrere kompasset og fastgøre pilens retning på kortet.</string>
+	<!-- Toast text when user hides UI with a long tap anywhere on the map -->
+	<string name="long_tap_toast">Tryk længe på kortet igen for at se grænsefladen</string>
 	<!-- Update all button text -->
 	<string name="downloader_update_all_button">Opdatér alle</string>
 	<!-- Cancel all button text -->

--- a/android/app/src/main/res/values-de/strings.xml
+++ b/android/app/src/main/res/values-de/strings.xml
@@ -278,6 +278,8 @@
 	<string name="compass_calibration_recommended">Verbessern Sie die Pfeilrichtung, indem Sie das Telefon in einer Achterbewegung bewegen, um den Kompass zu kalibrieren.</string>
 	<!-- Toast text when compass calibration may improve the correctness of the current position arrow -->
 	<string name="compass_calibration_required">Bewegen Sie das Telefon in einer Achterbewegung, um den Kompass zu kalibrieren und die Pfeilrichtung auf der Karte festzulegen.</string>
+	<!-- Toast text when user hides UI with a long tap anywhere on the map -->
+	<string name="long_tap_toast">Tippe erneut lange auf die Karte, um das Interface zu sehen</string>
 	<!-- Update all button text -->
 	<string name="downloader_update_all_button">Alle aktualisieren</string>
 	<!-- Cancel all button text -->

--- a/android/app/src/main/res/values-el/strings.xml
+++ b/android/app/src/main/res/values-el/strings.xml
@@ -281,6 +281,8 @@
 	<string name="compass_calibration_recommended">Βελτιώστε την κατεύθυνση των βελών μετακινώντας το τηλέφωνο με μια κίνηση σχήματος οκτώ για να καλιμπράρετε την πυξίδα.</string>
 	<!-- Toast text when compass calibration may improve the correctness of the current position arrow -->
 	<string name="compass_calibration_required">Μετακινήστε το τηλέφωνο με μια κίνηση σχήματος οκτώ για να καλιμπράρετε την πυξίδα και να καθορίσετε την κατεύθυνση του βέλους στο χάρτη.</string>
+	<!-- Toast text when user hides UI with a long tap anywhere on the map -->
+	<string name="long_tap_toast">Πατήστε ξανά παρατεταμένα στο χάρτη για να δείτε το περιβάλλον εργασίας.</string>
 	<!-- Update all button text -->
 	<string name="downloader_update_all_button">Ενημέρωση όλων</string>
 	<!-- Cancel all button text -->

--- a/android/app/src/main/res/values-es/strings.xml
+++ b/android/app/src/main/res/values-es/strings.xml
@@ -280,6 +280,8 @@
 	<string name="compass_calibration_recommended">Mejore la dirección de la flecha moviendo el teléfono en forma de ocho para calibrar la brújula.</string>
 	<!-- Toast text when compass calibration may improve the correctness of the current position arrow -->
 	<string name="compass_calibration_required">Mueva el teléfono en forma de ocho para calibrar la brújula y fijar la dirección de la flecha en el mapa.</string>
+	<!-- Toast text when user hides UI with a long tap anywhere on the map -->
+	<string name="long_tap_toast">Vuelve a pulsar prolongadamente sobre el mapa para ver la interfaz</string>
 	<!-- Update all button text -->
 	<string name="downloader_update_all_button">Actualizar todos</string>
 	<!-- Cancel all button text -->

--- a/android/app/src/main/res/values-et/strings.xml
+++ b/android/app/src/main/res/values-et/strings.xml
@@ -272,6 +272,8 @@
 	<string name="compass_calibration_recommended">Parandage noole suunda, liigutades telefoni kaheksakäigulise liigutusega, et kalibreerida kompass.</string>
 	<!-- Toast text when compass calibration may improve the correctness of the current position arrow -->
 	<string name="compass_calibration_required">Liigutage telefoni kaheksakandilise liigutusega, et kalibreerida kompass ja määrata noole suund kaardil.</string>
+	<!-- Toast text when user hides UI with a long tap anywhere on the map -->
+	<string name="long_tap_toast">Puudutage pikalt kaardil uuesti, et näha kasutajaliidest.</string>
 	<!-- Update all button text -->
 	<string name="downloader_update_all_button">Värskenda kõik</string>
 	<!-- Cancel all button text -->

--- a/android/app/src/main/res/values-eu/strings.xml
+++ b/android/app/src/main/res/values-eu/strings.xml
@@ -280,6 +280,8 @@
 	<string name="compass_calibration_recommended">Hobetu geziaren norabidea telefonoa zortzi irudiko mugimenduan mugituz iparrorratza kalibratzeko.</string>
 	<!-- Toast text when compass calibration may improve the correctness of the current position arrow -->
 	<string name="compass_calibration_required">Mugitu telefonoa zortzi irudiko mugimenduan iparrorratza kalibratzeko eta geziaren norabidea mapan finkatzeko.</string>
+	<!-- Toast text when user hides UI with a long tap anywhere on the map -->
+	<string name="long_tap_toast">Sakatu luze berriro mapan interfazea ikusteko</string>
 	<!-- Update all button text -->
 	<string name="downloader_update_all_button">Eguneratu guztiak</string>
 	<!-- Cancel all button text -->

--- a/android/app/src/main/res/values-fa/strings.xml
+++ b/android/app/src/main/res/values-fa/strings.xml
@@ -254,6 +254,8 @@
 	<string name="compass_calibration_recommended">برای کالیبره کردن قطب نما، جهت پیکان را با حرکت دادن تلفن در یک حرکت شکل هشت بهبود دهید.</string>
 	<!-- Toast text when compass calibration may improve the correctness of the current position arrow -->
 	<string name="compass_calibration_required">تلفن را به شکل هشت حرکت دهید تا قطب نما را کالیبره کنید و جهت پیکان را روی نقشه ثابت کنید.</string>
+	<!-- Toast text when user hides UI with a long tap anywhere on the map -->
+	<string name="long_tap_toast">دوباره روی نقشه ضربه طولانی بزنید تا رابط کاربری را ببینید</string>
 	<!-- Update all button text -->
 	<string name="downloader_update_all_button">آپدیت همه</string>
 	<!-- Cancel all button text -->

--- a/android/app/src/main/res/values-fi/strings.xml
+++ b/android/app/src/main/res/values-fi/strings.xml
@@ -282,6 +282,8 @@
 	<string name="compass_calibration_recommended">Paranna nuolien suuntaa liikuttamalla puhelinta kahdeksikon suuntaisesti kompassin kalibroimiseksi.</string>
 	<!-- Toast text when compass calibration may improve the correctness of the current position arrow -->
 	<string name="compass_calibration_required">Liikuta puhelinta kahdeksikon suuntaisella liikkeellä kompassin kalibroimiseksi ja nuolen suunnan määrittämiseksi kartalla.</string>
+	<!-- Toast text when user hides UI with a long tap anywhere on the map -->
+	<string name="long_tap_toast">Näytä käyttöliittymä napauttamalla karttaa uudelleen pitkään.</string>
 	<!-- Update all button text -->
 	<string name="downloader_update_all_button">Päivitä kaikki</string>
 	<!-- Cancel all button text -->

--- a/android/app/src/main/res/values-fr/strings.xml
+++ b/android/app/src/main/res/values-fr/strings.xml
@@ -282,6 +282,8 @@
 	<string name="compass_calibration_recommended">Améliorez la direction de la flèche en déplaçant le téléphone en huit pour calibrer la boussole.</string>
 	<!-- Toast text when compass calibration may improve the correctness of the current position arrow -->
 	<string name="compass_calibration_required">Déplacez le téléphone en huit pour calibrer la boussole et fixer la direction de la flèche sur la carte.</string>
+	<!-- Toast text when user hides UI with a long tap anywhere on the map -->
+	<string name="long_tap_toast">Appuie à nouveau longuement sur la carte pour voir l\'interface.</string>
 	<!-- Update all button text -->
 	<string name="downloader_update_all_button">Tout mettre à jour</string>
 	<!-- Cancel all button text -->

--- a/android/app/src/main/res/values-hi/strings.xml
+++ b/android/app/src/main/res/values-hi/strings.xml
@@ -287,6 +287,8 @@
 	<string name="copyright">कॉपीराइट</string>
 	<!-- Text in menu + Button in the main Help dialog -->
 	<string name="report_a_bug">एक बग रिपोर्ट करो</string>
+	<!-- Toast text when user hides UI with a long tap anywhere on the map -->
+	<string name="long_tap_toast">इंटरफ़ेस देखने के लिए मानचित्र पर फिर से देर तक टैप करें</string>
 	<!-- Cancel all button text -->
 	<string name="downloader_cancel_all">सब रद्द करो</string>
 	<!-- Downloaded maps list header -->

--- a/android/app/src/main/res/values-hu/strings.xml
+++ b/android/app/src/main/res/values-hu/strings.xml
@@ -275,6 +275,8 @@
 	<string name="compass_calibration_recommended">Javítsa a nyíl irányát a telefon nyolcas mozgatásával az iránytű kalibrálásához.</string>
 	<!-- Toast text when compass calibration may improve the correctness of the current position arrow -->
 	<string name="compass_calibration_required">Mozgassa a telefont egy nyolcas mozdulattal az iránytű kalibrálásához és a nyíl irányának rögzítéséhez a térképen.</string>
+	<!-- Toast text when user hides UI with a long tap anywhere on the map -->
+	<string name="long_tap_toast">Érintse meg újra hosszan a térképet a kezelőfelület megjelenítéséhez.</string>
 	<!-- Update all button text -->
 	<string name="downloader_update_all_button">Mindegyik frissítése</string>
 	<!-- Cancel all button text -->

--- a/android/app/src/main/res/values-in/strings.xml
+++ b/android/app/src/main/res/values-in/strings.xml
@@ -263,6 +263,8 @@
 	<string name="compass_calibration_recommended">Perbaiki arah panah dengan menggerakkan ponsel dalam gerakan angka delapan untuk mengkalibrasi kompas.</string>
 	<!-- Toast text when compass calibration may improve the correctness of the current position arrow -->
 	<string name="compass_calibration_required">Gerakkan ponsel dengan gerakan angka delapan untuk mengkalibrasi kompas dan memperbaiki arah panah pada peta.</string>
+	<!-- Toast text when user hides UI with a long tap anywhere on the map -->
+	<string name="long_tap_toast">Ketuk lama pada peta sekali lagi untuk melihat antarmuka</string>
 	<!-- Update all button text -->
 	<string name="downloader_update_all_button">Perbarui semua</string>
 	<!-- Cancel all button text -->

--- a/android/app/src/main/res/values-it/strings.xml
+++ b/android/app/src/main/res/values-it/strings.xml
@@ -266,6 +266,8 @@
 	<string name="compass_calibration_recommended">Migliorare la direzione della freccia muovendo il telefono con un movimento a otto per calibrare la bussola.</string>
 	<!-- Toast text when compass calibration may improve the correctness of the current position arrow -->
 	<string name="compass_calibration_required">Muovere il telefono con un movimento a otto per calibrare la bussola e fissare la direzione della freccia sulla mappa.</string>
+	<!-- Toast text when user hides UI with a long tap anywhere on the map -->
+	<string name="long_tap_toast">Tocca di nuovo a lungo sulla mappa per visualizzare l\'interfaccia</string>
 	<!-- Update all button text -->
 	<string name="downloader_update_all_button">Aggiorna tutte</string>
 	<!-- Cancel all button text -->

--- a/android/app/src/main/res/values-iw/strings.xml
+++ b/android/app/src/main/res/values-iw/strings.xml
@@ -278,6 +278,8 @@
 	<string name="compass_calibration_recommended">שפר את כיוון החץ על ידי הזזת הטלפון בתנועה של שמונה כדי לכייל את המצפן.</string>
 	<!-- Toast text when compass calibration may improve the correctness of the current position arrow -->
 	<string name="compass_calibration_required">הזז את הטלפון בתנועה של דמות שמונה כדי לכייל את המצפן ולתקן את כיוון החץ במפה.</string>
+	<!-- Toast text when user hides UI with a long tap anywhere on the map -->
+	<string name="long_tap_toast">לחץ לחיצה ארוכה במפה כדי להציג את הממשק</string>
 	<!-- Update all button text -->
 	<string name="downloader_update_all_button">עדכן הכל</string>
 	<!-- Cancel all button text -->

--- a/android/app/src/main/res/values-ja/strings.xml
+++ b/android/app/src/main/res/values-ja/strings.xml
@@ -280,6 +280,8 @@
 	<string name="compass_calibration_recommended">携帯電話を8の字に動かしてコンパスを較正することで、矢印の方向を改善します。</string>
 	<!-- Toast text when compass calibration may improve the correctness of the current position arrow -->
 	<string name="compass_calibration_required">携帯電話を8の字に動かしてコンパスを校正し、地図上の矢印の方向を固定します。</string>
+	<!-- Toast text when user hides UI with a long tap anywhere on the map -->
+	<string name="long_tap_toast">インターフェイスを見るには、もう一度地図をロングタップする。</string>
 	<!-- Update all button text -->
 	<string name="downloader_update_all_button">全てをアップデート</string>
 	<!-- Cancel all button text -->

--- a/android/app/src/main/res/values-ko/strings.xml
+++ b/android/app/src/main/res/values-ko/strings.xml
@@ -261,6 +261,8 @@
 	<string name="compass_calibration_recommended">나침반을 보정하기 위해 휴대폰을 8자 모양으로 움직여 화살표 방향을 개선하세요.</string>
 	<!-- Toast text when compass calibration may improve the correctness of the current position arrow -->
 	<string name="compass_calibration_required">휴대폰을 8자 모양으로 움직여 나침반을 보정하고 지도에서 화살표 방향을 수정합니다.</string>
+	<!-- Toast text when user hides UI with a long tap anywhere on the map -->
+	<string name="long_tap_toast">지도를 다시 길게 탭하면 인터페이스가 표시됩니다.</string>
 	<!-- Update all button text -->
 	<string name="downloader_update_all_button">모두 업데이트</string>
 	<!-- Cancel all button text -->

--- a/android/app/src/main/res/values-mr/strings.xml
+++ b/android/app/src/main/res/values-mr/strings.xml
@@ -250,6 +250,8 @@
 	<string name="compass_calibration_recommended">कंपास कॅलिब्रेट करण्यासाठी फोनला आकृती-आठ मोशनमध्ये हलवून बाणाची दिशा सुधारा.</string>
 	<!-- Toast text when compass calibration may improve the correctness of the current position arrow -->
 	<string name="compass_calibration_required">होकायंत्र कॅलिब्रेट करण्यासाठी आणि नकाशावर बाणाची दिशा निश्चित करण्यासाठी फोनला आकृती-आठ मोशनमध्ये हलवा.</string>
+	<!-- Toast text when user hides UI with a long tap anywhere on the map -->
+	<string name="long_tap_toast">इंटरफेस पाहण्यासाठी पुन्हा नकाशावर दीर्घ टॅप करा</string>
 	<!-- Update all button text -->
 	<string name="downloader_update_all_button">सर्व अद्ययावत</string>
 	<!-- Cancel all button text -->

--- a/android/app/src/main/res/values-nb/strings.xml
+++ b/android/app/src/main/res/values-nb/strings.xml
@@ -282,6 +282,8 @@
 	<string name="compass_calibration_recommended">Forbedre pilretningen ved å bevege telefonen i en åttetallsbevegelse for å kalibrere kompasset.</string>
 	<!-- Toast text when compass calibration may improve the correctness of the current position arrow -->
 	<string name="compass_calibration_required">Beveg telefonen i en åttetallsbevegelse for å kalibrere kompasset og fikse pilretningen på kartet.</string>
+	<!-- Toast text when user hides UI with a long tap anywhere on the map -->
+	<string name="long_tap_toast">Trykk lenge på kartet igjen for å se grensesnittet</string>
 	<!-- Update all button text -->
 	<string name="downloader_update_all_button">Oppdater alle</string>
 	<!-- Cancel all button text -->

--- a/android/app/src/main/res/values-nl/strings.xml
+++ b/android/app/src/main/res/values-nl/strings.xml
@@ -278,6 +278,8 @@
 	<string name="compass_calibration_recommended">Verbeter de richting van de pijl door de telefoon in een achtvormige beweging te bewegen om het kompas te kalibreren.</string>
 	<!-- Toast text when compass calibration may improve the correctness of the current position arrow -->
 	<string name="compass_calibration_required">Beweeg de telefoon in een achtvormige beweging om het kompas te kalibreren en de pijl op de kaart in de juiste richting te doen wijzen.</string>
+	<!-- Toast text when user hides UI with a long tap anywhere on the map -->
+	<string name="long_tap_toast">Tik nogmaals lang op de kaart om de interface te zien</string>
 	<!-- Update all button text -->
 	<string name="downloader_update_all_button">Update alles</string>
 	<!-- Cancel all button text -->

--- a/android/app/src/main/res/values-pl/strings.xml
+++ b/android/app/src/main/res/values-pl/strings.xml
@@ -280,6 +280,8 @@
 	<string name="compass_calibration_recommended">Popraw kierunek strzałki, poruszając telefonem w ruchu w kształcie ósemki, aby skalibrować kompas.</string>
 	<!-- Toast text when compass calibration may improve the correctness of the current position arrow -->
 	<string name="compass_calibration_required">Przesuń telefon ruchem w kształcie ósemki, aby skalibrować kompas i ustalić kierunek strzałki na mapie.</string>
+	<!-- Toast text when user hides UI with a long tap anywhere on the map -->
+	<string name="long_tap_toast">Ponownie dotknij długo mapy, aby wyświetlić interfejs</string>
 	<!-- Update all button text -->
 	<string name="downloader_update_all_button">Aktualizuj wszystkie</string>
 	<!-- Cancel all button text -->

--- a/android/app/src/main/res/values-pt/strings.xml
+++ b/android/app/src/main/res/values-pt/strings.xml
@@ -266,6 +266,8 @@
 	<string name="compass_calibration_recommended">Melhore a direcção das setas movendo o telemóvel num movimento em forma de oito para calibrar a bússola.</string>
 	<!-- Toast text when compass calibration may improve the correctness of the current position arrow -->
 	<string name="compass_calibration_required">Mova o telemóvel num movimento em forma de oito para calibrar a bússola e fixar a direcção da seta no mapa.</string>
+	<!-- Toast text when user hides UI with a long tap anywhere on the map -->
+	<string name="long_tap_toast">Dê um toque longo no mapa novamente para ver a interface</string>
 	<!-- Update all button text -->
 	<string name="downloader_update_all_button">Atualizar tudo</string>
 	<!-- Cancel all button text -->

--- a/android/app/src/main/res/values-ro/strings.xml
+++ b/android/app/src/main/res/values-ro/strings.xml
@@ -266,6 +266,8 @@
 	<string name="compass_calibration_recommended">Îmbunătățiți direcția săgeții prin mișcarea telefonului într-o mișcare în opt pentru a calibra busola.</string>
 	<!-- Toast text when compass calibration may improve the correctness of the current position arrow -->
 	<string name="compass_calibration_required">Mișcați telefonul într-o mișcare în formă de opt pentru a calibra busola și a fixa direcția săgeții pe hartă.</string>
+	<!-- Toast text when user hides UI with a long tap anywhere on the map -->
+	<string name="long_tap_toast">Atingeți lung pe hartă din nou pentru a vedea interfața</string>
 	<!-- Update all button text -->
 	<string name="downloader_update_all_button">Actualizează tot</string>
 	<!-- Cancel all button text -->

--- a/android/app/src/main/res/values-ru/strings.xml
+++ b/android/app/src/main/res/values-ru/strings.xml
@@ -283,6 +283,8 @@
 	<string name="compass_calibration_recommended">Улучшите направление стрелки, перемещая телефон восьмёркой, чтобы откалибровать компас.</string>
 	<!-- Toast text when compass calibration may improve the correctness of the current position arrow -->
 	<string name="compass_calibration_required">Двигайте телефон восьмёркой, чтобы откалибровать компас и зафиксировать направление стрелки на карте.</string>
+	<!-- Toast text when user hides UI with a long tap anywhere on the map -->
+	<string name="long_tap_toast">Долгое нажатие на карту вернёт интерфейс обратно</string>
 	<!-- Update all button text -->
 	<string name="downloader_update_all_button">Обновить все</string>
 	<!-- Cancel all button text -->

--- a/android/app/src/main/res/values-sk/strings.xml
+++ b/android/app/src/main/res/values-sk/strings.xml
@@ -278,6 +278,8 @@
 	<string name="compass_calibration_recommended">Zlepšite smer šípok pohybom telefónu v tvare osmičky, aby ste kalibrovali kompas.</string>
 	<!-- Toast text when compass calibration may improve the correctness of the current position arrow -->
 	<string name="compass_calibration_required">Pohybom telefónu v tvare osmičky kalibrujte kompas a zafixujte smer šípky na mape.</string>
+	<!-- Toast text when user hides UI with a long tap anywhere on the map -->
+	<string name="long_tap_toast">Opätovným dlhým ťuknutím na mapu zobrazíte rozhranie</string>
 	<!-- Update all button text -->
 	<string name="downloader_update_all_button">Aktualizovať všetko</string>
 	<!-- Cancel all button text -->

--- a/android/app/src/main/res/values-sv/strings.xml
+++ b/android/app/src/main/res/values-sv/strings.xml
@@ -259,6 +259,8 @@
 	<string name="compass_calibration_recommended">Förbättra pilens riktning genom att flytta telefonen i en åttarörelse för att kalibrera kompassen.</string>
 	<!-- Toast text when compass calibration may improve the correctness of the current position arrow -->
 	<string name="compass_calibration_required">Flytta telefonen i en åttarörelse för att kalibrera kompassen och fastställa pilens riktning på kartan.</string>
+	<!-- Toast text when user hides UI with a long tap anywhere on the map -->
+	<string name="long_tap_toast">Tryck länge på kartan igen för att se gränssnittet</string>
 	<!-- Update all button text -->
 	<string name="downloader_update_all_button">Uppdatera alla</string>
 	<!-- Cancel all button text -->

--- a/android/app/src/main/res/values-sw/strings.xml
+++ b/android/app/src/main/res/values-sw/strings.xml
@@ -70,6 +70,8 @@
 	<string name="donate">Changia</string>
 	<!-- Button in the main Help dialog -->
 	<string name="how_to_support_us">Saidia mradi</string>
+	<!-- Toast text when user hides UI with a long tap anywhere on the map -->
+	<string name="long_tap_toast">Gusa kwa muda mrefu kwenye ramani tena ili kuona kiolesura</string>
 	<!-- Preference title -->
 	<string name="google_play_services">Huduma za Mahali za Google Play</string>
 	<!-- Preference text -->

--- a/android/app/src/main/res/values-th/strings.xml
+++ b/android/app/src/main/res/values-th/strings.xml
@@ -263,6 +263,8 @@
 	<string name="compass_calibration_recommended">ปรับปรุงทิศทางลูกศรโดยขยับโทรศัพท์เป็นเลขแปดเพื่อปรับเทียบเข็มทิศ</string>
 	<!-- Toast text when compass calibration may improve the correctness of the current position arrow -->
 	<string name="compass_calibration_required">ขยับโทรศัพท์เป็นเลขแปดเพื่อปรับเทียบเข็มทิศและกำหนดทิศทางลูกศรบนแผนที่</string>
+	<!-- Toast text when user hides UI with a long tap anywhere on the map -->
+	<string name="long_tap_toast">แตะยาวบนแผนที่อีกครั้งเพื่อดูอินเทอร์เฟซ</string>
 	<!-- Update all button text -->
 	<string name="downloader_update_all_button">อัปเดตทั้งหมด</string>
 	<!-- Cancel all button text -->

--- a/android/app/src/main/res/values-tr/strings.xml
+++ b/android/app/src/main/res/values-tr/strings.xml
@@ -280,6 +280,8 @@
 	<string name="compass_calibration_recommended">Pusulayı kalibre etmek için telefonu sekiz şeklinde hareket ettirerek ok yönünü iyileştirin.</string>
 	<!-- Toast text when compass calibration may improve the correctness of the current position arrow -->
 	<string name="compass_calibration_required">Pusulayı kalibre etmek ve haritadaki ok yönünü düzeltmek için telefonu sekiz şeklinde hareket ettirin.</string>
+	<!-- Toast text when user hides UI with a long tap anywhere on the map -->
+	<string name="long_tap_toast">Arayüzü görmek için haritaya tekrar uzun dokunun</string>
 	<!-- Update all button text -->
 	<string name="downloader_update_all_button">Tümünü güncelle</string>
 	<!-- Cancel all button text -->

--- a/android/app/src/main/res/values-uk/strings.xml
+++ b/android/app/src/main/res/values-uk/strings.xml
@@ -283,6 +283,8 @@
 	<string name="compass_calibration_recommended">Покращіть напрямок стрілки, повернувши телефон вісімкою, щоб відкалібрувати компас.</string>
 	<!-- Toast text when compass calibration may improve the correctness of the current position arrow -->
 	<string name="compass_calibration_required">Рухайте телефон вісімкою, щоб відкалібрувати компас і зафіксувати напрямок стрілки на карті.</string>
+	<!-- Toast text when user hides UI with a long tap anywhere on the map -->
+	<string name="long_tap_toast">Ще раз потримайте палець на карті, щоб побачити інтерфейс</string>
 	<!-- Update all button text -->
 	<string name="downloader_update_all_button">Оновити всі</string>
 	<!-- Cancel all button text -->

--- a/android/app/src/main/res/values-vi/strings.xml
+++ b/android/app/src/main/res/values-vi/strings.xml
@@ -261,6 +261,8 @@
 	<string name="compass_calibration_recommended">Cải thiện hướng mũi tên bằng cách di chuyển điện thoại theo chuyển động hình số tám để hiệu chỉnh la bàn.</string>
 	<!-- Toast text when compass calibration may improve the correctness of the current position arrow -->
 	<string name="compass_calibration_required">Di chuyển điện thoại theo chuyển động hình số tám để hiệu chỉnh la bàn và cố định hướng mũi tên trên bản đồ.</string>
+	<!-- Toast text when user hides UI with a long tap anywhere on the map -->
+	<string name="long_tap_toast">Nhấn và giữ lại vào bản đồ để xem giao diện</string>
 	<!-- Update all button text -->
 	<string name="downloader_update_all_button">Cập nhật tất cả</string>
 	<!-- Cancel all button text -->

--- a/android/app/src/main/res/values-zh-rTW/strings.xml
+++ b/android/app/src/main/res/values-zh-rTW/strings.xml
@@ -272,6 +272,8 @@
 	<string name="compass_calibration_recommended">通過以八字形移動手機來校準指南針來改善箭頭方向</string>
 	<!-- Toast text when compass calibration may improve the correctness of the current position arrow -->
 	<string name="compass_calibration_required">以 8 字形移動手機以校準指南針並固定地圖上的箭頭方向</string>
+	<!-- Toast text when user hides UI with a long tap anywhere on the map -->
+	<string name="long_tap_toast">再次長按地圖即可看到介面</string>
 	<!-- Update all button text -->
 	<string name="downloader_update_all_button">更新全部</string>
 	<!-- Cancel all button text -->

--- a/android/app/src/main/res/values-zh/strings.xml
+++ b/android/app/src/main/res/values-zh/strings.xml
@@ -269,6 +269,8 @@
 	<string name="compass_calibration_recommended">通过以八字形运动移动手机来改善箭头方向，以校准罗盘。</string>
 	<!-- Toast text when compass calibration may improve the correctness of the current position arrow -->
 	<string name="compass_calibration_required">以八字动作移动手机，校准罗盘，并在地图上固定箭头方向。</string>
+	<!-- Toast text when user hides UI with a long tap anywhere on the map -->
+	<string name="long_tap_toast">再次长按地图查看界面</string>
 	<!-- Update all button text -->
 	<string name="downloader_update_all_button">更新全部</string>
 	<!-- Cancel all button text -->

--- a/android/app/src/main/res/values/strings.xml
+++ b/android/app/src/main/res/values/strings.xml
@@ -303,6 +303,8 @@
 	<string name="compass_calibration_recommended">Improve arrow direction by moving the phone in a figure-eight motion to calibrate the compass.</string>
 	<!-- Toast text when compass calibration may improve the correctness of the current position arrow -->
 	<string name="compass_calibration_required">Move the phone in a figure-eight motion to calibrate the compass and fix the arrow direction on the map.</string>
+	<!-- Toast text when user hides UI with a long tap anywhere on the map -->
+	<string name="long_tap_toast">Long-tap on the map again to see the interface</string>
 	<!-- Update all button text -->
 	<string name="downloader_update_all_button">Update All</string>
 	<!-- Cancel all button text -->

--- a/data/strings/strings.txt
+++ b/data/strings/strings.txt
@@ -7499,6 +7499,51 @@
     zh-Hans = 以八字动作移动手机，校准罗盘，并在地图上固定箭头方向。
     zh-Hant = 以 8 字形移動手機以校準指南針並固定地圖上的箭頭方向
 
+  [long_tap_toast]
+    comment = Toast text when user hides UI with a long tap anywhere on the map
+    tags = android,ios
+    en = Long-tap on the map again to see the interface
+    af = Langtik weer op die kaart om die koppelvlak te sien
+    ar = اضغط مطولاً على الخريطة مرة أخرى لرؤية الواجهة
+    az = İnterfeysi görmək üçün yenidən xəritəyə uzun müddət toxunun
+    be = Яшчэ раз доўга націсніце на карту, каб убачыць інтэрфейс
+    bg = Докоснете отново картата, за да видите интерфейса
+    ca = Toqueu llargament el mapa de nou per veure la interfície
+    cs = Dlouhým klepnutím na mapu znovu zobrazíte rozhraní.
+    da = Tryk længe på kortet igen for at se grænsefladen
+    de = Tippe erneut lange auf die Karte, um das Interface zu sehen
+    el = Πατήστε ξανά παρατεταμένα στο χάρτη για να δείτε το περιβάλλον εργασίας.
+    es = Vuelve a pulsar prolongadamente sobre el mapa para ver la interfaz
+    et = Puudutage pikalt kaardil uuesti, et näha kasutajaliidest.
+    eu = Sakatu luze berriro mapan interfazea ikusteko
+    fa = دوباره روی نقشه ضربه طولانی بزنید تا رابط کاربری را ببینید
+    fi = Näytä käyttöliittymä napauttamalla karttaa uudelleen pitkään.
+    fr = Appuie à nouveau longuement sur la carte pour voir l'interface.
+    he = לחץ לחיצה ארוכה במפה כדי להציג את הממשק
+    hi = इंटरफ़ेस देखने के लिए मानचित्र पर फिर से देर तक टैप करें
+    hu = Érintse meg újra hosszan a térképet a kezelőfelület megjelenítéséhez.
+    id = Ketuk lama pada peta sekali lagi untuk melihat antarmuka
+    it = Tocca di nuovo a lungo sulla mappa per visualizzare l'interfaccia
+    ja = インターフェイスを見るには、もう一度地図をロングタップする。
+    ko = 지도를 다시 길게 탭하면 인터페이스가 표시됩니다.
+    lt = Dar kartą ilgai bakstelėkite žemėlapį, kad pamatytumėte sąsają
+    mr = इंटरफेस पाहण्यासाठी पुन्हा नकाशावर दीर्घ टॅप करा
+    nb = Trykk lenge på kartet igjen for å se grensesnittet
+    nl = Tik nogmaals lang op de kaart om de interface te zien
+    pl = Ponownie dotknij długo mapy, aby wyświetlić interfejs
+    pt = Dê um toque longo no mapa novamente para ver a interface
+    ro = Atingeți lung pe hartă din nou pentru a vedea interfața
+    ru = Долгое нажатие на карту вернёт интерфейс обратно
+    sk = Opätovným dlhým ťuknutím na mapu zobrazíte rozhranie
+    sv = Tryck länge på kartan igen för att se gränssnittet
+    sw = Gusa kwa muda mrefu kwenye ramani tena ili kuona kiolesura
+    th = แตะยาวบนแผนที่อีกครั้งเพื่อดูอินเทอร์เฟซ
+    tr = Arayüzü görmek için haritaya tekrar uzun dokunun
+    uk = Ще раз потримайте палець на карті, щоб побачити інтерфейс
+    vi = Nhấn và giữ lại vào bản đồ để xem giao diện
+    zh-Hans = 再次长按地图查看界面
+    zh-Hant = 再次長按地圖即可看到介面
+
   [downloader_update_all_button]
     comment = Update all button text
     tags = android,ios

--- a/drape_frontend/frontend_renderer.cpp
+++ b/drape_frontend/frontend_renderer.cpp
@@ -1989,7 +1989,8 @@ void FrontendRenderer::OnTap(m2::PointD const & pt, bool isLongTap)
   m2::PointD mercator = screen.PtoG(pxPoint2d);
 
   // Long tap should show/hide the interface. There is no need to detect tapped features.
-  if (isLongTap) {
+  if (isLongTap)
+  {
     m_tapEventInfoHandler({mercator, isLongTap, isMyPosition, FeatureID(), kml::kInvalidMarkId});
     return;
   }

--- a/drape_frontend/frontend_renderer.cpp
+++ b/drape_frontend/frontend_renderer.cpp
@@ -1987,6 +1987,13 @@ void FrontendRenderer::OnTap(m2::PointD const & pt, bool isLongTap)
 
   m2::PointD const pxPoint2d = screen.P3dtoP(pt);
   m2::PointD mercator = screen.PtoG(pxPoint2d);
+
+  // Long tap should show/hide the interface. There is no need to detect tapped features.
+  if (isLongTap) {
+    m_tapEventInfoHandler({mercator, isLongTap, isMyPosition, FeatureID(), kml::kInvalidMarkId});
+    return;
+  }
+
   if (m_myPositionController->IsModeHasPosition())
   {
     m2::PointD const pixelPos = screen.PtoP3d(screen.GtoP(m_myPositionController->Position()));

--- a/iphone/Maps/Classes/CustomViews/MapViewControls/SideButtons/MWMSideButtons.mm
+++ b/iphone/Maps/Classes/CustomViews/MapViewControls/SideButtons/MWMSideButtons.mm
@@ -12,6 +12,7 @@
 namespace
 {
 NSString * const kMWMSideButtonsViewNibName = @"MWMSideButtonsView";
+NSString * const kUDDidShowLongTapToShowSideButtonsToast = @"kUDDidShowLongTapToShowSideButtonsToast";
 }  // namespace
 
 @interface MWMMapViewControlsManager ()
@@ -136,5 +137,21 @@ NSString * const kMWMSideButtonsViewNibName = @"MWMSideButtonsView";
 }
 
 - (BOOL)hidden { return self.sideView.hidden; }
-- (void)setHidden:(BOOL)hidden { [self.sideView setHidden:hidden animated:YES]; }
+- (void)setHidden:(BOOL)hidden 
+{
+  if (!self.hidden && hidden)
+    [self showLongTapToShowSideButtonsToastOnFirstHiding];
+
+  return [self.sideView setHidden:hidden animated:YES];
+}
+
+- (void)showLongTapToShowSideButtonsToastOnFirstHiding
+{
+  if (![NSUserDefaults.standardUserDefaults boolForKey:kUDDidShowLongTapToShowSideButtonsToast])
+  {
+    [[MWMToast toastWithText:L(@"long_tap_toast")] show];
+    [NSUserDefaults.standardUserDefaults setBool:YES forKey:kUDDidShowLongTapToShowSideButtonsToast];
+  }
+}
+
 @end

--- a/iphone/Maps/LocalizedStrings/ar.lproj/Localizable.strings
+++ b/iphone/Maps/LocalizedStrings/ar.lproj/Localizable.strings
@@ -346,6 +346,9 @@
 /* Settings item title */
 "pref_calibration_title" = "معايرة البوصلة";
 
+/* Toast text when user hides UI with a long tap anywhere on the map */
+"long_tap_toast" = "اضغط مطولاً على الخريطة مرة أخرى لرؤية الواجهة";
+
 /* Update all button text */
 "downloader_update_all_button" = "تحديث الكل";
 

--- a/iphone/Maps/LocalizedStrings/az.lproj/Localizable.strings
+++ b/iphone/Maps/LocalizedStrings/az.lproj/Localizable.strings
@@ -346,6 +346,9 @@
 /* Settings item title */
 "pref_calibration_title" = "Kompas kalibrlənməsi";
 
+/* Toast text when user hides UI with a long tap anywhere on the map */
+"long_tap_toast" = "İnterfeysi görmək üçün yenidən xəritəyə uzun müddət toxunun";
+
 /* Update all button text */
 "downloader_update_all_button" = "Hamısını yeniləyin";
 

--- a/iphone/Maps/LocalizedStrings/be.lproj/Localizable.strings
+++ b/iphone/Maps/LocalizedStrings/be.lproj/Localizable.strings
@@ -346,6 +346,9 @@
 /* Settings item title */
 "pref_calibration_title" = "Каліброўка компаса";
 
+/* Toast text when user hides UI with a long tap anywhere on the map */
+"long_tap_toast" = "Яшчэ раз доўга націсніце на карту, каб убачыць інтэрфейс";
+
 /* Update all button text */
 "downloader_update_all_button" = "Абнавіць усё";
 

--- a/iphone/Maps/LocalizedStrings/bg.lproj/Localizable.strings
+++ b/iphone/Maps/LocalizedStrings/bg.lproj/Localizable.strings
@@ -346,6 +346,9 @@
 /* Settings item title */
 "pref_calibration_title" = "Калибриране на компас";
 
+/* Toast text when user hides UI with a long tap anywhere on the map */
+"long_tap_toast" = "Докоснете отново картата, за да видите интерфейса";
+
 /* Update all button text */
 "downloader_update_all_button" = "Обновяване на всичко";
 

--- a/iphone/Maps/LocalizedStrings/ca.lproj/Localizable.strings
+++ b/iphone/Maps/LocalizedStrings/ca.lproj/Localizable.strings
@@ -346,6 +346,9 @@
 /* Settings item title */
 "pref_calibration_title" = "Calibratge de la brúixola";
 
+/* Toast text when user hides UI with a long tap anywhere on the map */
+"long_tap_toast" = "Toqueu llargament el mapa de nou per veure la interfície";
+
 /* Update all button text */
 "downloader_update_all_button" = "Actualitza-ho tot";
 

--- a/iphone/Maps/LocalizedStrings/cs.lproj/Localizable.strings
+++ b/iphone/Maps/LocalizedStrings/cs.lproj/Localizable.strings
@@ -346,6 +346,9 @@
 /* Settings item title */
 "pref_calibration_title" = "Kalibrace kompasu";
 
+/* Toast text when user hides UI with a long tap anywhere on the map */
+"long_tap_toast" = "Dlouhým klepnutím na mapu znovu zobrazíte rozhraní.";
+
 /* Update all button text */
 "downloader_update_all_button" = "Aktualizovat vše";
 

--- a/iphone/Maps/LocalizedStrings/da.lproj/Localizable.strings
+++ b/iphone/Maps/LocalizedStrings/da.lproj/Localizable.strings
@@ -346,6 +346,9 @@
 /* Settings item title */
 "pref_calibration_title" = "Kalibrering af kompas";
 
+/* Toast text when user hides UI with a long tap anywhere on the map */
+"long_tap_toast" = "Tryk længe på kortet igen for at se grænsefladen";
+
 /* Update all button text */
 "downloader_update_all_button" = "Opdatér alle";
 

--- a/iphone/Maps/LocalizedStrings/de.lproj/Localizable.strings
+++ b/iphone/Maps/LocalizedStrings/de.lproj/Localizable.strings
@@ -346,6 +346,9 @@
 /* Settings item title */
 "pref_calibration_title" = "Kompass-Kalibrierung";
 
+/* Toast text when user hides UI with a long tap anywhere on the map */
+"long_tap_toast" = "Tippe erneut lange auf die Karte, um das Interface zu sehen";
+
 /* Update all button text */
 "downloader_update_all_button" = "Alle aktualisieren";
 

--- a/iphone/Maps/LocalizedStrings/el.lproj/Localizable.strings
+++ b/iphone/Maps/LocalizedStrings/el.lproj/Localizable.strings
@@ -346,6 +346,9 @@
 /* Settings item title */
 "pref_calibration_title" = "Καλιμπράρισμα πυξίδας";
 
+/* Toast text when user hides UI with a long tap anywhere on the map */
+"long_tap_toast" = "Πατήστε ξανά παρατεταμένα στο χάρτη για να δείτε το περιβάλλον εργασίας.";
+
 /* Update all button text */
 "downloader_update_all_button" = "Ενημέρωση όλων";
 

--- a/iphone/Maps/LocalizedStrings/en-GB.lproj/Localizable.strings
+++ b/iphone/Maps/LocalizedStrings/en-GB.lproj/Localizable.strings
@@ -346,6 +346,9 @@
 /* Settings item title */
 "pref_calibration_title" = "Compass calibration";
 
+/* Toast text when user hides UI with a long tap anywhere on the map */
+"long_tap_toast" = "Long-tap on the map again to see the interface";
+
 /* Update all button text */
 "downloader_update_all_button" = "Update All";
 

--- a/iphone/Maps/LocalizedStrings/en.lproj/Localizable.strings
+++ b/iphone/Maps/LocalizedStrings/en.lproj/Localizable.strings
@@ -346,6 +346,9 @@
 /* Settings item title */
 "pref_calibration_title" = "Compass calibration";
 
+/* Toast text when user hides UI with a long tap anywhere on the map */
+"long_tap_toast" = "Long-tap on the map again to see the interface";
+
 /* Update all button text */
 "downloader_update_all_button" = "Update All";
 

--- a/iphone/Maps/LocalizedStrings/es-MX.lproj/Localizable.strings
+++ b/iphone/Maps/LocalizedStrings/es-MX.lproj/Localizable.strings
@@ -346,6 +346,9 @@
 /* Settings item title */
 "pref_calibration_title" = "Calibración de la brújula";
 
+/* Toast text when user hides UI with a long tap anywhere on the map */
+"long_tap_toast" = "Vuelve a pulsar prolongadamente sobre el mapa para ver la interfaz";
+
 /* Update all button text */
 "downloader_update_all_button" = "Actualizar todos";
 

--- a/iphone/Maps/LocalizedStrings/es.lproj/Localizable.strings
+++ b/iphone/Maps/LocalizedStrings/es.lproj/Localizable.strings
@@ -346,6 +346,9 @@
 /* Settings item title */
 "pref_calibration_title" = "Calibración de la brújula";
 
+/* Toast text when user hides UI with a long tap anywhere on the map */
+"long_tap_toast" = "Vuelve a pulsar prolongadamente sobre el mapa para ver la interfaz";
+
 /* Update all button text */
 "downloader_update_all_button" = "Actualizar todos";
 

--- a/iphone/Maps/LocalizedStrings/et.lproj/Localizable.strings
+++ b/iphone/Maps/LocalizedStrings/et.lproj/Localizable.strings
@@ -346,6 +346,9 @@
 /* Settings item title */
 "pref_calibration_title" = "Kompassi kalibreerimine";
 
+/* Toast text when user hides UI with a long tap anywhere on the map */
+"long_tap_toast" = "Puudutage pikalt kaardil uuesti, et näha kasutajaliidest.";
+
 /* Update all button text */
 "downloader_update_all_button" = "Värskenda kõik";
 

--- a/iphone/Maps/LocalizedStrings/eu.lproj/Localizable.strings
+++ b/iphone/Maps/LocalizedStrings/eu.lproj/Localizable.strings
@@ -346,6 +346,9 @@
 /* Settings item title */
 "pref_calibration_title" = "Iparrorratzaren kalibrazioa";
 
+/* Toast text when user hides UI with a long tap anywhere on the map */
+"long_tap_toast" = "Sakatu luze berriro mapan interfazea ikusteko";
+
 /* Update all button text */
 "downloader_update_all_button" = "Eguneratu guztiak";
 

--- a/iphone/Maps/LocalizedStrings/fa.lproj/Localizable.strings
+++ b/iphone/Maps/LocalizedStrings/fa.lproj/Localizable.strings
@@ -346,6 +346,9 @@
 /* Settings item title */
 "pref_calibration_title" = "تنظیم کردن قطب نما";
 
+/* Toast text when user hides UI with a long tap anywhere on the map */
+"long_tap_toast" = "دوباره روی نقشه ضربه طولانی بزنید تا رابط کاربری را ببینید";
+
 /* Update all button text */
 "downloader_update_all_button" = "آپدیت همه";
 

--- a/iphone/Maps/LocalizedStrings/fi.lproj/Localizable.strings
+++ b/iphone/Maps/LocalizedStrings/fi.lproj/Localizable.strings
@@ -346,6 +346,9 @@
 /* Settings item title */
 "pref_calibration_title" = "Kompassin kalibrointi";
 
+/* Toast text when user hides UI with a long tap anywhere on the map */
+"long_tap_toast" = "Näytä käyttöliittymä napauttamalla karttaa uudelleen pitkään.";
+
 /* Update all button text */
 "downloader_update_all_button" = "Päivitä kaikki";
 

--- a/iphone/Maps/LocalizedStrings/fr.lproj/Localizable.strings
+++ b/iphone/Maps/LocalizedStrings/fr.lproj/Localizable.strings
@@ -346,6 +346,9 @@
 /* Settings item title */
 "pref_calibration_title" = "Étalonnage de la boussole";
 
+/* Toast text when user hides UI with a long tap anywhere on the map */
+"long_tap_toast" = "Appuie à nouveau longuement sur la carte pour voir l'interface.";
+
 /* Update all button text */
 "downloader_update_all_button" = "Tout mettre à jour";
 

--- a/iphone/Maps/LocalizedStrings/he.lproj/Localizable.strings
+++ b/iphone/Maps/LocalizedStrings/he.lproj/Localizable.strings
@@ -346,6 +346,9 @@
 /* Settings item title */
 "pref_calibration_title" = "כיול המצפן";
 
+/* Toast text when user hides UI with a long tap anywhere on the map */
+"long_tap_toast" = "לחץ לחיצה ארוכה במפה כדי להציג את הממשק";
+
 /* Update all button text */
 "downloader_update_all_button" = "עדכן הכל";
 

--- a/iphone/Maps/LocalizedStrings/hi.lproj/Localizable.strings
+++ b/iphone/Maps/LocalizedStrings/hi.lproj/Localizable.strings
@@ -346,6 +346,9 @@
 /* Settings item title */
 "pref_calibration_title" = "कम्पास अंशांकन";
 
+/* Toast text when user hides UI with a long tap anywhere on the map */
+"long_tap_toast" = "इंटरफ़ेस देखने के लिए मानचित्र पर फिर से देर तक टैप करें";
+
 /* Update all button text */
 "downloader_update_all_button" = "Update All";
 

--- a/iphone/Maps/LocalizedStrings/hu.lproj/Localizable.strings
+++ b/iphone/Maps/LocalizedStrings/hu.lproj/Localizable.strings
@@ -346,6 +346,9 @@
 /* Settings item title */
 "pref_calibration_title" = "Iránytű kalibrálás";
 
+/* Toast text when user hides UI with a long tap anywhere on the map */
+"long_tap_toast" = "Érintse meg újra hosszan a térképet a kezelőfelület megjelenítéséhez.";
+
 /* Update all button text */
 "downloader_update_all_button" = "Mindegyik frissítése";
 

--- a/iphone/Maps/LocalizedStrings/id.lproj/Localizable.strings
+++ b/iphone/Maps/LocalizedStrings/id.lproj/Localizable.strings
@@ -346,6 +346,9 @@
 /* Settings item title */
 "pref_calibration_title" = "Kalibrasi kompas";
 
+/* Toast text when user hides UI with a long tap anywhere on the map */
+"long_tap_toast" = "Ketuk lama pada peta sekali lagi untuk melihat antarmuka";
+
 /* Update all button text */
 "downloader_update_all_button" = "Perbarui semua";
 

--- a/iphone/Maps/LocalizedStrings/it.lproj/Localizable.strings
+++ b/iphone/Maps/LocalizedStrings/it.lproj/Localizable.strings
@@ -346,6 +346,9 @@
 /* Settings item title */
 "pref_calibration_title" = "Calibrazione bussola";
 
+/* Toast text when user hides UI with a long tap anywhere on the map */
+"long_tap_toast" = "Tocca di nuovo a lungo sulla mappa per visualizzare l'interfaccia";
+
 /* Update all button text */
 "downloader_update_all_button" = "Aggiorna tutte";
 

--- a/iphone/Maps/LocalizedStrings/ja.lproj/Localizable.strings
+++ b/iphone/Maps/LocalizedStrings/ja.lproj/Localizable.strings
@@ -346,6 +346,9 @@
 /* Settings item title */
 "pref_calibration_title" = "コンパスの調整";
 
+/* Toast text when user hides UI with a long tap anywhere on the map */
+"long_tap_toast" = "インターフェイスを見るには、もう一度地図をロングタップする。";
+
 /* Update all button text */
 "downloader_update_all_button" = "全てをアップデート";
 

--- a/iphone/Maps/LocalizedStrings/ko.lproj/Localizable.strings
+++ b/iphone/Maps/LocalizedStrings/ko.lproj/Localizable.strings
@@ -346,6 +346,9 @@
 /* Settings item title */
 "pref_calibration_title" = "나침반 보정";
 
+/* Toast text when user hides UI with a long tap anywhere on the map */
+"long_tap_toast" = "지도를 다시 길게 탭하면 인터페이스가 표시됩니다.";
+
 /* Update all button text */
 "downloader_update_all_button" = "모두 업데이트";
 

--- a/iphone/Maps/LocalizedStrings/mr.lproj/Localizable.strings
+++ b/iphone/Maps/LocalizedStrings/mr.lproj/Localizable.strings
@@ -346,6 +346,9 @@
 /* Settings item title */
 "pref_calibration_title" = "होकायंत्र अंशशोधन";
 
+/* Toast text when user hides UI with a long tap anywhere on the map */
+"long_tap_toast" = "इंटरफेस पाहण्यासाठी पुन्हा नकाशावर दीर्घ टॅप करा";
+
 /* Update all button text */
 "downloader_update_all_button" = "सर्व अद्ययावत";
 

--- a/iphone/Maps/LocalizedStrings/nb.lproj/Localizable.strings
+++ b/iphone/Maps/LocalizedStrings/nb.lproj/Localizable.strings
@@ -346,6 +346,9 @@
 /* Settings item title */
 "pref_calibration_title" = "Kompasskalibrering";
 
+/* Toast text when user hides UI with a long tap anywhere on the map */
+"long_tap_toast" = "Trykk lenge på kartet igjen for å se grensesnittet";
+
 /* Update all button text */
 "downloader_update_all_button" = "Oppdater alle";
 

--- a/iphone/Maps/LocalizedStrings/nl.lproj/Localizable.strings
+++ b/iphone/Maps/LocalizedStrings/nl.lproj/Localizable.strings
@@ -346,6 +346,9 @@
 /* Settings item title */
 "pref_calibration_title" = "Kompascalibratie";
 
+/* Toast text when user hides UI with a long tap anywhere on the map */
+"long_tap_toast" = "Tik nogmaals lang op de kaart om de interface te zien";
+
 /* Update all button text */
 "downloader_update_all_button" = "Update alles";
 

--- a/iphone/Maps/LocalizedStrings/pl.lproj/Localizable.strings
+++ b/iphone/Maps/LocalizedStrings/pl.lproj/Localizable.strings
@@ -346,6 +346,9 @@
 /* Settings item title */
 "pref_calibration_title" = "Kalibracja kompasu";
 
+/* Toast text when user hides UI with a long tap anywhere on the map */
+"long_tap_toast" = "Ponownie dotknij długo mapy, aby wyświetlić interfejs";
+
 /* Update all button text */
 "downloader_update_all_button" = "Aktualizuj wszystkie";
 

--- a/iphone/Maps/LocalizedStrings/pt-BR.lproj/Localizable.strings
+++ b/iphone/Maps/LocalizedStrings/pt-BR.lproj/Localizable.strings
@@ -346,6 +346,9 @@
 /* Settings item title */
 "pref_calibration_title" = "Calibração da bússola";
 
+/* Toast text when user hides UI with a long tap anywhere on the map */
+"long_tap_toast" = "Dê um toque longo no mapa novamente para ver a interface";
+
 /* Update all button text */
 "downloader_update_all_button" = "Atualizar tudo";
 

--- a/iphone/Maps/LocalizedStrings/pt.lproj/Localizable.strings
+++ b/iphone/Maps/LocalizedStrings/pt.lproj/Localizable.strings
@@ -346,6 +346,9 @@
 /* Settings item title */
 "pref_calibration_title" = "Calibração da bússola";
 
+/* Toast text when user hides UI with a long tap anywhere on the map */
+"long_tap_toast" = "Dê um toque longo no mapa novamente para ver a interface";
+
 /* Update all button text */
 "downloader_update_all_button" = "Atualizar tudo";
 

--- a/iphone/Maps/LocalizedStrings/ro.lproj/Localizable.strings
+++ b/iphone/Maps/LocalizedStrings/ro.lproj/Localizable.strings
@@ -346,6 +346,9 @@
 /* Settings item title */
 "pref_calibration_title" = "Calibrare busolă";
 
+/* Toast text when user hides UI with a long tap anywhere on the map */
+"long_tap_toast" = "Atingeți lung pe hartă din nou pentru a vedea interfața";
+
 /* Update all button text */
 "downloader_update_all_button" = "Actualizează tot";
 

--- a/iphone/Maps/LocalizedStrings/ru.lproj/Localizable.strings
+++ b/iphone/Maps/LocalizedStrings/ru.lproj/Localizable.strings
@@ -346,6 +346,9 @@
 /* Settings item title */
 "pref_calibration_title" = "Калибровка компаса";
 
+/* Toast text when user hides UI with a long tap anywhere on the map */
+"long_tap_toast" = "Долгое нажатие на карту вернёт интерфейс обратно";
+
 /* Update all button text */
 "downloader_update_all_button" = "Обновить все";
 

--- a/iphone/Maps/LocalizedStrings/sk.lproj/Localizable.strings
+++ b/iphone/Maps/LocalizedStrings/sk.lproj/Localizable.strings
@@ -346,6 +346,9 @@
 /* Settings item title */
 "pref_calibration_title" = "Kalibrácia kompasu";
 
+/* Toast text when user hides UI with a long tap anywhere on the map */
+"long_tap_toast" = "Opätovným dlhým ťuknutím na mapu zobrazíte rozhranie";
+
 /* Update all button text */
 "downloader_update_all_button" = "Aktualizovať všetko";
 

--- a/iphone/Maps/LocalizedStrings/sv.lproj/Localizable.strings
+++ b/iphone/Maps/LocalizedStrings/sv.lproj/Localizable.strings
@@ -346,6 +346,9 @@
 /* Settings item title */
 "pref_calibration_title" = "Kompasskalibrering";
 
+/* Toast text when user hides UI with a long tap anywhere on the map */
+"long_tap_toast" = "Tryck länge på kartan igen för att se gränssnittet";
+
 /* Update all button text */
 "downloader_update_all_button" = "Uppdatera alla";
 

--- a/iphone/Maps/LocalizedStrings/sw.lproj/Localizable.strings
+++ b/iphone/Maps/LocalizedStrings/sw.lproj/Localizable.strings
@@ -346,6 +346,9 @@
 /* Settings item title */
 "pref_calibration_title" = "Compass calibration";
 
+/* Toast text when user hides UI with a long tap anywhere on the map */
+"long_tap_toast" = "Gusa kwa muda mrefu kwenye ramani tena ili kuona kiolesura";
+
 /* Update all button text */
 "downloader_update_all_button" = "Update All";
 

--- a/iphone/Maps/LocalizedStrings/th.lproj/Localizable.strings
+++ b/iphone/Maps/LocalizedStrings/th.lproj/Localizable.strings
@@ -346,6 +346,9 @@
 /* Settings item title */
 "pref_calibration_title" = "การปรับเทียบเข็มทิศ";
 
+/* Toast text when user hides UI with a long tap anywhere on the map */
+"long_tap_toast" = "แตะยาวบนแผนที่อีกครั้งเพื่อดูอินเทอร์เฟซ";
+
 /* Update all button text */
 "downloader_update_all_button" = "อัปเดตทั้งหมด";
 

--- a/iphone/Maps/LocalizedStrings/tr.lproj/Localizable.strings
+++ b/iphone/Maps/LocalizedStrings/tr.lproj/Localizable.strings
@@ -346,6 +346,9 @@
 /* Settings item title */
 "pref_calibration_title" = "Pusula kalibrasyonu";
 
+/* Toast text when user hides UI with a long tap anywhere on the map */
+"long_tap_toast" = "Arayüzü görmek için haritaya tekrar uzun dokunun";
+
 /* Update all button text */
 "downloader_update_all_button" = "Tümünü güncelle";
 

--- a/iphone/Maps/LocalizedStrings/uk.lproj/Localizable.strings
+++ b/iphone/Maps/LocalizedStrings/uk.lproj/Localizable.strings
@@ -346,6 +346,9 @@
 /* Settings item title */
 "pref_calibration_title" = "Калібрування компаса";
 
+/* Toast text when user hides UI with a long tap anywhere on the map */
+"long_tap_toast" = "Ще раз потримайте палець на карті, щоб побачити інтерфейс";
+
 /* Update all button text */
 "downloader_update_all_button" = "Оновити всі";
 

--- a/iphone/Maps/LocalizedStrings/vi.lproj/Localizable.strings
+++ b/iphone/Maps/LocalizedStrings/vi.lproj/Localizable.strings
@@ -346,6 +346,9 @@
 /* Settings item title */
 "pref_calibration_title" = "Chuẩn hóa la bàn";
 
+/* Toast text when user hides UI with a long tap anywhere on the map */
+"long_tap_toast" = "Nhấn và giữ lại vào bản đồ để xem giao diện";
+
 /* Update all button text */
 "downloader_update_all_button" = "Cập nhật tất cả";
 

--- a/iphone/Maps/LocalizedStrings/zh-Hans.lproj/Localizable.strings
+++ b/iphone/Maps/LocalizedStrings/zh-Hans.lproj/Localizable.strings
@@ -346,6 +346,9 @@
 /* Settings item title */
 "pref_calibration_title" = "指南针校准";
 
+/* Toast text when user hides UI with a long tap anywhere on the map */
+"long_tap_toast" = "再次长按地图查看界面";
+
 /* Update all button text */
 "downloader_update_all_button" = "更新全部";
 

--- a/iphone/Maps/LocalizedStrings/zh-Hant.lproj/Localizable.strings
+++ b/iphone/Maps/LocalizedStrings/zh-Hant.lproj/Localizable.strings
@@ -346,6 +346,9 @@
 /* Settings item title */
 "pref_calibration_title" = "指南針校準";
 
+/* Toast text when user hides UI with a long tap anywhere on the map */
+"long_tap_toast" = "再次長按地圖即可看到介面";
+
 /* Update all button text */
 "downloader_update_all_button" = "更新全部";
 

--- a/map/framework.hpp
+++ b/map/framework.hpp
@@ -355,7 +355,7 @@ private:
   std::optional<place_page::Info> m_currentPlacePageInfo;
 
   void OnTapEvent(place_page::BuildInfo const & buildInfo);
-  std::optional<place_page::Info> BuildPlacePageInfo(place_page::BuildInfo const & buildInfo);
+  place_page::Info BuildPlacePageInfo(place_page::BuildInfo const & buildInfo);
   void BuildTrackPlacePage(Track::TrackSelectionInfo const & trackSelectionInfo, place_page::Info & info);
   Track::TrackSelectionInfo FindTrackInTapPosition(place_page::BuildInfo const & buildInfo) const;
   UserMark const * FindUserMarkInTapPosition(place_page::BuildInfo const & buildInfo) const;


### PR DESCRIPTION
Tap on any place - select point.
Long tap on POI - select POI.
Long tap on free space - deselect.

- Closes https://github.com/organicmaps/organicmaps/issues/1894
- Closes #1105 


https://github.com/organicmaps/organicmaps/assets/720808/164f2350-79ba-46cf-a3b9-dcdf2032049c

## Update 2024-04-29

Changed behaviour of building selection: tap on a building centroid (around 5m) then centroid is selected, otherwise tap position is selected.

https://github.com/organicmaps/organicmaps/assets/720808/87096be8-381c-42de-93d2-5d8ad1827344

## Update 2024-05-30

`Android`: Added toast for the first 2 long taps:
`Update 2024-06-06`: toast is shown only once.

https://github.com/organicmaps/organicmaps/assets/720808/7b43e046-cef0-4df3-bdf2-4aa9a0601879
