### PR TITLE
[ios] fix: Text trimming on the Menu screen on small screen #7605

### DIFF
--- a/iphone/Maps/UI/BottomMenu/Menu/Cells/BottomMenuItemCell.swift
+++ b/iphone/Maps/UI/BottomMenu/Menu/Cells/BottomMenuItemCell.swift
@@ -6,6 +6,8 @@ class BottomMenuItemCell: UITableViewCell {
   @IBOutlet private var badgeCountLabel: UILabel!
   @IBOutlet private var separator: UIView!
   @IBOutlet private var icon: UIImageView!
+  @IBOutlet private var badgeSpacingConstraint: NSLayoutConstraint!
+  @IBOutlet private var badgeBackgroundWidthConstraint: NSLayoutConstraint!
   var anchorView: UIView {
     get {
       return icon
@@ -20,6 +22,13 @@ class BottomMenuItemCell: UITableViewCell {
     label.text = title
     badgeBackground.isHidden = badgeCount == 0
     badgeCountLabel.text = "\(badgeCount)"
+    if badgeCount == 0 {
+      badgeSpacingConstraint.constant = 0
+      badgeBackgroundWidthConstraint.constant = 0
+    } else {
+      badgeSpacingConstraint.constant = 8
+      badgeBackgroundWidthConstraint.constant = 32
+    }
     isEnabled = enabled
     icon.setStyleAndApply(isEnabled ? "MWMBlack" : "MWMGray")
     label.setStyleAndApply(isEnabled ? "blackPrimaryText" : "blackHintText")
@@ -31,6 +40,8 @@ class BottomMenuItemCell: UITableViewCell {
     icon.setStyleAndApply("MWMBlue")
     label.setStyleAndApply("linkBlueText")
     badgeBackground.isHidden = true
+    badgeSpacingConstraint.constant = 0
+    badgeBackgroundWidthConstraint.constant = 0
     isEnabled = true
     isPromo = true
   }

--- a/iphone/Maps/UI/BottomMenu/Menu/Cells/BottomMenuItemCell.xib
+++ b/iphone/Maps/UI/BottomMenu/Menu/Cells/BottomMenuItemCell.xib
@@ -91,7 +91,9 @@
             </constraints>
             <connections>
                 <outlet property="badgeBackground" destination="con-tP-3dJ" id="vH5-Rd-uqS"/>
+                <outlet property="badgeBackgroundWidthConstraint" destination="ubK-0L-pDn" id="D3B-sV-eGO"/>
                 <outlet property="badgeCountLabel" destination="FT9-8n-RZm" id="HLY-2S-do9"/>
+                <outlet property="badgeSpacingConstraint" destination="RJA-NS-MXP" id="Hpf-eq-1C1"/>
                 <outlet property="icon" destination="8oJ-8z-qRL" id="qcD-Kv-c5l"/>
                 <outlet property="label" destination="5Uc-o1-PsF" id="y4l-b6-MCt"/>
                 <outlet property="separator" destination="4OJ-wN-dY4" id="Kkv-HO-0eK"/>


### PR DESCRIPTION
Sorry, i'm creating a new PR to close out issue 7605. I inadvertently closed it as it was on the main branch. I created a new branch and am pushed the same commit as before. 

Here is a link to the previous PR:

https://github.com/organicmaps/organicmaps/pull/7689

Text from previous PR:
Update the xib and swift files related to BottomMenuItemCell to address the issue seen in fixed https://github.com/organicmaps/organicmaps/issues/7605 issue.

![image](https://github.com/organicmaps/organicmaps/assets/156805389/2bfa8c54-1ab2-4d11-8763-df0a18768d5a)

Fixes #6213 as seen here:

![image](https://github.com/organicmaps/organicmaps/assets/156805389/58015578-30d4-4ade-85a4-8c6aff8bc327)

Tested on Simulator iPhone SE 1st gen iOS 15