### PR TITLE
[ios][mac] Fix assert/check on shutdown of iOS app on Mac

### DIFF
--- a/base/thread_pool_delayed.cpp
+++ b/base/thread_pool_delayed.cpp
@@ -219,7 +219,6 @@ bool ThreadPool::Shutdown(Exit e)
 
 void ThreadPool::ShutdownAndJoin()
 {
-  ASSERT(m_checker.CalledOnOriginalThread(), ());
   Shutdown(m_exit);
   for (auto & thread : m_threads)
   {

--- a/base/thread_pool_delayed.hpp
+++ b/base/thread_pool_delayed.hpp
@@ -5,7 +5,6 @@
 #include "base/linked_map.hpp"
 #include "base/task_loop.hpp"
 #include "base/thread.hpp"
-#include "base/thread_checker.hpp"
 
 #include <chrono>
 #include <condition_variable>
@@ -162,8 +161,6 @@ private:
 
   TaskId m_immediateLastId;
   TaskId m_delayedLastId;
-
-  ThreadChecker m_checker;
 };
 }  // namespace delayed
 }  // namespace thread_pool

--- a/editor/osm_editor.hpp
+++ b/editor/osm_editor.hpp
@@ -15,6 +15,7 @@
 #include "geometry/rect2d.hpp"
 
 #include "base/atomic_shared_ptr.hpp"
+#include "base/thread_checker.hpp"
 #include "base/timer.hpp"
 
 #include <atomic>

--- a/iphone/Maps/Classes/Components/MWMNavigationController.m
+++ b/iphone/Maps/Classes/Components/MWMNavigationController.m
@@ -60,7 +60,10 @@
 {
   [super traitCollectionDidChange: previousTraitCollection];
   // Update the app theme when the device appearance is changing.
-  [MWMThemeManager invalidate];
+  if ((self.traitCollection.verticalSizeClass != previousTraitCollection.verticalSizeClass)
+      || (self.traitCollection.horizontalSizeClass != previousTraitCollection.horizontalSizeClass)) {
+    [MWMThemeManager invalidate]; 
+  }
 }
 
 - (BOOL)shouldAutorotate


### PR DESCRIPTION
- Removed thread checker for delayed thread pool. It does not really matter which thread destroys the pool. On Mac, thread pools are created on the main thread, but static destructors are called from another system thread. And checker failed for the statically created DrapeRoutine's thread pool.

- Avoid unnecessary MWMThemeManager invalidate on destruction when nothing has changed
- Add missing include

This fix is required to run iOS tests on a Mac build properly.