### PR TITLE
[xcode] Disable the tests parallelizing

### DIFF
--- a/iphone/Maps/Maps.xcodeproj/xcshareddata/xcschemes/OMaps.xcscheme
+++ b/iphone/Maps/Maps.xcodeproj/xcshareddata/xcschemes/OMaps.xcscheme
@@ -44,8 +44,7 @@
       </CommandLineArguments>
       <Testables>
          <TestableReference
-            skipped = "NO"
-            parallelizable = "YES">
+            skipped = "NO">
             <BuildableReference
                BuildableIdentifier = "primary"
                BlueprintIdentifier = "ED097E752BB80C320006ED01"


### PR DESCRIPTION
When you run the tests by default Xcode uses the tests parallelizing. When tests are run in parallel, Xcode spins up multiple clones of the simulator. These simulator windows are named “Clone 1” and so on. This makes sense for slow-running UI tests but not for the fast-running unit tests. It takes longer for Xcode to set up the simulator clones.

This PR disables the tests parallelizing.