### PR TITLE
[ios] [bookmarks] Remove observer pattern during the category files exporting

### DIFF
--- a/iphone/CoreApi/CoreApi/Bookmarks/MWMBookmarksManager.h
+++ b/iphone/CoreApi/CoreApi/Bookmarks/MWMBookmarksManager.h
@@ -85,7 +85,23 @@ NS_SWIFT_NAME(BookmarksManager)
 
 - (MWMTrackIDCollection)trackIdsForCategory:(MWMMarkGroupID)categoryId;
 
+/**
+ Shares a specific category with the given group ID.
+
+ @param groupId The identifier for the category to be shared.
+ @param completion A block that handles the result of the share operation and takes two parameters:
+                   - status: The status of the share operation, of type `MWMBookmarksShareStatus`.
+                   - urlToALocalFile: The local file URL containing the shared data. This parameter is guaranteed to be non-nil only if `status` is `MWMBookmarksShareStatusSuccess`. In other cases, it will be nil.
+*/
 - (void)shareCategory:(MWMMarkGroupID)groupId completion:(SharingResultCompletionHandler)completion;
+
+/**
+ Shares all categories.
+
+ @param completion A block that handles the result of the share operation and takes two parameters:
+                   - status: The status of the share operation, of type `MWMBookmarksShareStatus`.
+                   - urlToALocalFile: The local file URL containing the shared data. This parameter is guaranteed to be non-nil only if `status` is `MWMBookmarksShareStatusSuccess`.  In other cases, it will be nil.
+*/
 - (void)shareAllCategoriesWithCompletion:(SharingResultCompletionHandler)completion;
 - (void)finishShareCategory;
 

--- a/iphone/CoreApi/CoreApi/Bookmarks/MWMBookmarksManager.h
+++ b/iphone/CoreApi/CoreApi/Bookmarks/MWMBookmarksManager.h
@@ -24,6 +24,7 @@ typedef void (^PingCompletionBlock)(BOOL success);
 typedef void (^ElevationPointChangedBlock)(double distance);
 typedef void (^SearchBookmarksCompletionBlock)(NSArray<MWMBookmark *> *bookmarks);
 typedef void (^SortBookmarksCompletionBlock)(NSArray<MWMBookmarksSection *> * _Nullable sortedSections);
+typedef void (^SharingResultCompletionHandler)(MWMBookmarksShareStatus status, NSURL * _Nullable urlToALocalFile);
 
 NS_SWIFT_NAME(BookmarksManager)
 @interface MWMBookmarksManager : NSObject
@@ -84,9 +85,8 @@ NS_SWIFT_NAME(BookmarksManager)
 
 - (MWMTrackIDCollection)trackIdsForCategory:(MWMMarkGroupID)categoryId;
 
-- (void)shareCategory:(MWMMarkGroupID)groupId;
-- (void)shareAllCategories;
-- (NSURL *)shareCategoryURL;
+- (void)shareCategory:(MWMMarkGroupID)groupId completion:(SharingResultCompletionHandler)completion;
+- (void)shareAllCategoriesWithCompletion:(SharingResultCompletionHandler)completion;
 - (void)finishShareCategory;
 
 - (void)setNotificationsEnabled:(BOOL)enabled;

--- a/iphone/CoreApi/CoreApi/Bookmarks/MWMBookmarksObserver.h
+++ b/iphone/CoreApi/CoreApi/Bookmarks/MWMBookmarksObserver.h
@@ -11,7 +11,6 @@ NS_SWIFT_NAME(BookmarksObserver)
 - (void)onBookmarksFileLoadError;
 - (void)onBookmarksCategoryDeleted:(MWMMarkGroupID)groupId;
 - (void)onBookmarkDeleted:(MWMMarkID)bookmarkId;
-- (void)onBookmarksCategoryFilePrepared:(MWMBookmarksShareStatus)status;
 
 @end
 NS_ASSUME_NONNULL_END

--- a/iphone/Maps/Bookmarks/BookmarksList/BookmarksListInterfaces.swift
+++ b/iphone/Maps/Bookmarks/BookmarksList/BookmarksListInterfaces.swift
@@ -106,7 +106,7 @@ protocol IBookmarksListInteractor {
   func updateTrack(_ trackId: MWMTrackID, setGroupId groupId: MWMMarkGroupID)
   func deleteBookmarksGroup()
   func canDeleteGroup() -> Bool
-  func exportFile(_ completion: @escaping (URL?, ExportFileStatus) -> Void)
+  func exportFile(_ completion: @escaping SharingResultCompletionHandler)
   func finishExportFile()
 }
 

--- a/iphone/Maps/Bookmarks/BookmarksList/BookmarksListPresenter.swift
+++ b/iphone/Maps/Bookmarks/BookmarksList/BookmarksListPresenter.swift
@@ -139,17 +139,17 @@ final class BookmarksListPresenter {
       self.router.listSettings(self.bookmarkGroup, delegate: self)
     }))
     moreItems.append(BookmarksListMenuItem(title: L("export_file"), action: { [weak self] in
-      self?.interactor.exportFile { (url, status) in
+      self?.interactor.exportFile { (status, url) in
         switch status {
         case .success:
           guard let url = url else { fatalError() }
           self?.view.share(url) {
             self?.interactor.finishExportFile()
           }
-        case .empty:
+        case .emptyCategory:
           self?.view.showError(title: L("bookmarks_error_title_share_empty"),
                                message: L("bookmarks_error_message_share_empty"))
-        case .error:
+        case .archiveError, .fileError:
           self?.view.showError(title: L("dialog_routing_system_error"),
                                message: L("bookmarks_error_message_share_general"))
         }

--- a/iphone/Maps/Bookmarks/Categories/BMCView/BMCViewController.swift
+++ b/iphone/Maps/Bookmarks/Categories/BMCView/BMCViewController.swift
@@ -74,31 +74,29 @@ final class BMCViewController: MWMViewController {
   }
 
   private func shareCategoryFile(at index: Int, anchor: UIView) {
-    viewModel.shareCategoryFile(at: index) {
-      switch $0 {
-      case let .success(url):
-        let shareController = ActivityViewController.share(for: url, message: L("share_bookmarks_email_body"))
-        { [weak self] _, _, _, _ in
-          self?.viewModel?.finishShareCategory()
-        }
-        shareController?.present(inParentViewController: self, anchorView: anchor)
-      case let .error(title, text):
-        MWMAlertViewController.activeAlert().presentInfoAlert(title, text: text)
-      }
-    }
+    viewModel.shareCategoryFile(at: index, handler: sharingResultHandler(anchorView: anchor))
   }
 
   private func shareAllCategories(anchor: UIView?) {
-    viewModel.shareAllCategories {
-      switch $0 {
-      case let .success(url):
+    viewModel.shareAllCategories(handler: sharingResultHandler(anchorView: anchor))
+  }
+
+  private func sharingResultHandler(anchorView: UIView?) -> SharingResultCompletionHandler {
+    { [weak self] status, url in
+      guard let self else { return }
+      switch status {
+      case .success:
         let shareController = ActivityViewController.share(for: url, message: L("share_bookmarks_email_body"))
         { [weak self] _, _, _, _ in
           self?.viewModel?.finishShareCategory()
         }
-        shareController?.present(inParentViewController: self, anchorView: anchor)
-      case let .error(title, text):
-        MWMAlertViewController.activeAlert().presentInfoAlert(title, text: text)
+        shareController?.present(inParentViewController: self, anchorView: anchorView)
+      case .emptyCategory:
+        MWMAlertViewController.activeAlert().presentInfoAlert(L("bookmarks_error_title_share_empty"),
+                                                              text: L("bookmarks_error_message_share_empty"))
+      case .fileError, .archiveError:
+        MWMAlertViewController.activeAlert().presentInfoAlert(L("dialog_routing_system_error"),
+                                                              text: L("bookmarks_error_message_share_general"))
       }
     }
   }


### PR DESCRIPTION
For now to handle the` file sharing` OM uses the observing pattern tightened to the MWMBookmarksManagers, that is too complex for this straightforward task:
1. subscribe for the observarion
2. register observer
3. send sharing message
4. wait for sharing result
5. handle sharing result
6. notify observers
7. unsubscribe from observing

This is too complex because the c++ method that we interact with uses the completion handlers to return sharing results and there is no sense in wrapping the completion handle into observation:
```cpp
void BookmarkManager::PrepareFileForSharing(kml::GroupIdCollection && categoriesIds, SharingHandler && handler)
```

This PR converts c++ completion handler into the objc and returns to the caller so we can share files easily with the MWMBookmarksManagers and handle result without additional overhead:
```objc
- (void)shareCategory:(MWMMarkGroupID)groupId completion:(SharingResultCompletionHandler)completion;
- (void)shareAllCategoriesWithCompletion:(SharingResultCompletionHandler)completion;
```
https://github.com/organicmaps/organicmaps/assets/79797627/7ceabaa2-0880-41e4-bfed-28c565911950