### PR TITLE
[linux] Run GlyphLoadingTest on Linux with GUI

### DIFF
--- a/.github/workflows/linux-check.yaml
+++ b/.github/workflows/linux-check.yaml
@@ -20,9 +20,9 @@ on:
       - packaging/**
       - platform/*apple*
       - platform/*_android*
-      - platform/*_ios* 
-      - platform/*_mac* 
-      - platform/*_win* 
+      - platform/*_ios*
+      - platform/*_mac*
+      - platform/*_win*
       - pyhelpers/**
       - tools/**
       - '!tools/python/test_server/**'
@@ -168,6 +168,7 @@ jobs:
         working-directory: build
         env:
           # drape_tests - requires X Window
+          QT_QPA_PLATFORM: "offscreen"
           # generator_integration_tests - https://github.com/organicmaps/organicmaps/issues/225
           # opening_hours_integration_tests - https://github.com/organicmaps/organicmaps/issues/219
           # opening_hours_supported_features_tests - https://github.com/organicmaps/organicmaps/issues/219

--- a/drape/drape_tests/font_texture_tests.cpp
+++ b/drape/drape_tests/font_texture_tests.cpp
@@ -12,8 +12,6 @@
 #include "drape/font_texture.hpp"
 #include "drape/glyph_manager.hpp"
 
-#include "std/target_os.hpp"
-
 #include <functional>
 
 #include <QtCore/QPoint>
@@ -78,8 +76,7 @@ public:
 
 UNIT_TEST(UploadingGlyphs)
 {
-// This unit test creates window so can't be run in GUI-less Linux machine.
-#ifndef OMIM_OS_LINUX
+  // Set QT_QPA_PLATFORM=offscreen env var to avoid running GUI on Linux
   DrapeRoutine::Init();
   EXPECTGL(glHasExtension(_)).Times(AnyNumber());
   EXPECTGL(glBindTexture(_)).Times(AnyNumber());
@@ -134,5 +131,4 @@ UNIT_TEST(UploadingGlyphs)
 
   RunTestLoop("UploadingGlyphs", std::bind(&UploadedRender::Render, &r, _1));
   DrapeRoutine::Shutdown();
-#endif
 }

--- a/drape/drape_tests/glyph_mng_tests.cpp
+++ b/drape/drape_tests/glyph_mng_tests.cpp
@@ -12,8 +12,6 @@
 
 #include "qt_tstfrm/test_main_loop.hpp"
 
-#include "std/target_os.hpp"
-
 #include <cstring>
 #include <functional>
 #include <iostream>
@@ -87,10 +85,10 @@ private:
 };
 }  // namespace
 
+// This unit test creates a window so can't be run in GUI-less Linux machine.
+// Make sure that the QT_QPA_PLATFORM=offscreen environment variable is set.
 UNIT_TEST(GlyphLoadingTest)
 {
-  // This unit test creates window so can't be run in GUI-less Linux machine.
-#ifndef OMIM_OS_LINUX
   GlyphRenderer renderer;
 
   renderer.SetString("ØŒÆ");
@@ -104,5 +102,4 @@ UNIT_TEST(GlyphLoadingTest)
 
   renderer.SetString("മനക്കലപ്പടി");
   RunTestLoop("Test4", std::bind(&GlyphRenderer::RenderGlyphs, &renderer, _1));
-#endif
 }


### PR DESCRIPTION
Allows to test how fonts are rendered on Linux.

Related to #4281 