### PR TITLE
[ios] fix alignment of rtl languages in bottom menu

### DIFF
--- a/iphone/Maps/UI/BottomMenu/Menu/Cells/BottomMenuItemCell.xib
+++ b/iphone/Maps/UI/BottomMenu/Menu/Cells/BottomMenuItemCell.xib
@@ -26,7 +26,7 @@
                             <userDefinedRuntimeAttribute type="string" keyPath="styleName" value="MWMBlack"/>
                         </userDefinedRuntimeAttributes>
                     </imageView>
-                    <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Label" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="5Uc-o1-PsF">
+                    <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Label" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="5Uc-o1-PsF">
                         <rect key="frame" x="60" y="14" width="298" height="20"/>
                         <fontDescription key="fontDescription" type="system" pointSize="17"/>
                         <color key="textColor" red="0.0" green="0.0" blue="0.0" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>


### PR DESCRIPTION
to fix issue #7863 relating to rtl languages.

Tested on iPad pro 11 simulator:

here in arabic:
<img width="652" alt="image" src="https://github.com/organicmaps/organicmaps/assets/156805389/39c378f9-3751-4139-8ac3-81cdc80154ad">

in hebrew:
<img width="662" alt="image" src="https://github.com/organicmaps/organicmaps/assets/156805389/dbfa0a15-76ba-45af-b1d0-db7f088493ef">



in english:
<img width="658" alt="image" src="https://github.com/organicmaps/organicmaps/assets/156805389/b770195b-4be5-4743-a24c-7b5f88ff7526">
