### PR TITLE
[ios][editor] Fix unintended fallthrough in switch-case

### DIFF
--- a/iphone/Maps/UI/Editor/MWMEditorViewController.mm
+++ b/iphone/Maps/UI/Editor/MWMEditorViewController.mm
@@ -965,6 +965,7 @@ void registerCellsForTableView(std::vector<MWMEditorCellID> const & cells, UITab
           m_mapObject.SetMetadata(feature::Metadata::FMD_DRIVE_THROUGH, "");
           break;
       }
+      break;
   default: NSAssert(false, @"Invalid field for changeSegmented"); break;
   }
 }


### PR DESCRIPTION
A break was missing in the switch-case and was causing a fallthrough and a crash in debug. This fixes it.

* Related to https://github.com/organicmaps/organicmaps/pull/7835