### PR TITLE
[android] Fix PT router overriding previous mode if subway layer active

### DIFF
--- a/android/app/src/main/java/app/organicmaps/routing/RoutingController.java
+++ b/android/app/src/main/java/app/organicmaps/routing/RoutingController.java
@@ -351,7 +351,7 @@ public class RoutingController
   private void initLastRouteType(@Nullable MapObject startPoint, @Nullable MapObject endPoint,
                                  boolean fromApi)
   {
-    if (isSubwayEnabled() && !fromApi)
+    if (shouldForceTransitRoute(fromApi))
     {
       mLastRouterType = Framework.ROUTER_TYPE_TRANSIT;
       return;
@@ -365,6 +365,11 @@ public class RoutingController
   private boolean isSubwayEnabled()
   {
     return mContainer != null && mContainer.isSubwayEnabled();
+  }
+
+  private boolean shouldForceTransitRoute(boolean fromApi)
+  {
+    return mState == State.NONE && isSubwayEnabled() && !fromApi;
   }
 
   public void prepare(final @Nullable MapObject startPoint, final @Nullable MapObject endPoint,


### PR DESCRIPTION
The public transportation router was forcibly overriding the previously selected mode whenever the planning activity was resumed, with the subway layer active. For instance, if you started a route planning (which automatically uses PT when that layer is on), switched to car mode and then changed some driving options, when you got back to the planning screen, the router would have changed back to PT, instead of keeping it on car.

This occurred because of `RoutingController#rebuildLastRoute`, called whenever an activity (such as the driving options) concluded, which would, indirectly, call `RoutingController#initLastRouteType`. This method is responsible for defaulting the router to the most adequate type for the start+finish point combo, or, if the subway layer is selected, to set it to public transportaton.

So, the fix was rather simple -- instead of only checking if the the subway layer is active (and if we're not comming from a link, but that isn't relevant here), we also check if we were already planning something, or if we're starting a new route plan. We only want to reset the mode to PT on the latter case.

Fixes: #7701