### PR TITLE
[core] Simplified logs output

### DIFF
--- a/base/base.cpp
+++ b/base/base.cpp
@@ -13,9 +13,8 @@ bool OnAssertFailedDefault(SrcPoint const & srcPoint, std::string const & msg)
 {
   auto & logger = LogHelper::Instance();
 
-  std::cerr << "TID(" << logger.GetThreadID() << ") ASSERT FAILED" << std::endl
-            << srcPoint.FileName() << ":" << srcPoint.Line() << std::endl
-            << msg << std::endl;
+  std::cerr << '(' << logger.GetThreadID() << ") ASSERT FAILED" << '\n'
+            << srcPoint.FileName() << ':' << srcPoint.Line() << '\n' << msg << std::endl;
   return true;
 }
 

--- a/base/internal/message.hpp
+++ b/base/internal/message.hpp
@@ -69,7 +69,8 @@ inline std::string DebugPrint(char const * t)
 
 inline std::string DebugPrint(char t)
 {
-  return {1, t};
+  // return {1, t} wrongly constructs "\0x1t" string.
+  return std::string(1, t);
 }
 
 namespace internal

--- a/base/logging.cpp
+++ b/base/logging.cpp
@@ -17,18 +17,19 @@ namespace base
 namespace
 {
 std::mutex g_logMutex;
-std::array<char, NUM_LOG_LEVELS> constexpr kLogLevelNames = {{'D', 'I', 'W', 'E', 'C'}};
 }  // namespace
 
 std::string ToString(LogLevel level)
 {
   auto const & names = GetLogLevelNames();
   CHECK_LESS(level, names.size(), ());
-  return std::string{} + names[level];
+  return ::DebugPrint(names[level]);
 }
 
 std::optional<LogLevel> FromString(std::string const & s)
 {
+  ASSERT(!s.empty(), ("Log level should not be empty"));
+
   auto const & names = GetLogLevelNames();
   const auto it = std::find(names.begin(), names.end(), std::toupper(s[0]));
   if (it == names.end())
@@ -38,6 +39,7 @@ std::optional<LogLevel> FromString(std::string const & s)
 
 std::array<char, NUM_LOG_LEVELS> const & GetLogLevelNames()
 {
+  static std::array<char, NUM_LOG_LEVELS> constexpr kLogLevelNames {'D', 'I', 'W', 'E', 'C'};
   return kLogLevelNames;
 }
 
@@ -59,7 +61,7 @@ int LogHelper::GetThreadID()
 void LogHelper::WriteProlog(std::ostream & s, LogLevel level)
 {
   double const sec = m_timer.ElapsedSeconds();
-  s << kLogLevelNames[level] << '(' << GetThreadID() << ") " << std::fixed << std::setprecision(5) << sec << ' ';
+  s << GetLogLevelNames()[level] << '(' << GetThreadID() << ") " << std::fixed << std::setprecision(5) << sec << ' ';
 }
 
 void LogMessageDefault(LogLevel level, SrcPoint const & srcPoint, std::string const & msg)

--- a/base/logging.cpp
+++ b/base/logging.cpp
@@ -12,37 +12,33 @@
 #include <mutex>
 #include <sstream>
 
+namespace base
+{
 namespace
 {
 std::mutex g_logMutex;
+std::array<char, NUM_LOG_LEVELS> constexpr kLogLevelNames = {{'D', 'I', 'W', 'E', 'C'}};
 }  // namespace
 
-namespace base
-{
 std::string ToString(LogLevel level)
 {
   auto const & names = GetLogLevelNames();
   CHECK_LESS(level, names.size(), ());
-  return names[level];
+  return std::string{} + names[level];
 }
 
-bool FromString(std::string const & s, LogLevel & level)
+std::optional<LogLevel> FromString(std::string const & s)
 {
   auto const & names = GetLogLevelNames();
-  auto it = find(names.begin(), names.end(), s);
+  const auto it = std::find(names.begin(), names.end(), std::toupper(s[0]));
   if (it == names.end())
-    return false;
-  level = static_cast<LogLevel>(std::distance(names.begin(), it));
-  return true;
+    return {};
+  return static_cast<LogLevel>(std::distance(names.begin(), it));
 }
 
-std::array<char const *, NUM_LOG_LEVELS> const & GetLogLevelNames()
+std::array<char, NUM_LOG_LEVELS> const & GetLogLevelNames()
 {
-  // If you're going to modify the behavior of the function, please,
-  // check validity of LogHelper ctor.
-  static std::array<char const *, NUM_LOG_LEVELS> const kNames = {
-      {"DEBUG", "INFO", "WARNING", "ERROR", "CRITICAL"}};
-  return kNames;
+  return kLogLevelNames;
 }
 
 // static
@@ -50,16 +46,6 @@ LogHelper & LogHelper::Instance()
 {
   static LogHelper instance;
   return instance;
-}
-
-LogHelper::LogHelper() : m_threadsCount(0)
-{
-  // This code highly depends on the fact that GetLogLevelNames()
-  // always returns the same constant array of strings.
-
-  m_names = GetLogLevelNames();
-  for (size_t i = 0; i < m_lens.size(); ++i)
-    m_lens[i] = strlen(m_names[i]);
 }
 
 int LogHelper::GetThreadID()
@@ -72,22 +58,16 @@ int LogHelper::GetThreadID()
 
 void LogHelper::WriteProlog(std::ostream & s, LogLevel level)
 {
-  s << "LOG";
-
-  s << " TID(" << GetThreadID() << ")";
-  s << " " << m_names[level];
-
   double const sec = m_timer.ElapsedSeconds();
-  s << " " << std::setfill(' ') << std::setw(static_cast<int>(16 - m_lens[level])) << sec << " ";
+  s << kLogLevelNames[level] << '(' << GetThreadID() << ") " << std::fixed << std::setprecision(5) << sec << ' ';
 }
 
 void LogMessageDefault(LogLevel level, SrcPoint const & srcPoint, std::string const & msg)
 {
-  std::lock_guard lock(g_logMutex);
-
   auto & logger = LogHelper::Instance();
-
   std::ostringstream out;
+
+  std::lock_guard lock(g_logMutex);
   logger.WriteProlog(out, level);
 
   out << DebugPrint(srcPoint) << msg << std::endl;
@@ -98,11 +78,10 @@ void LogMessageDefault(LogLevel level, SrcPoint const & srcPoint, std::string co
 
 void LogMessageTests(LogLevel level, SrcPoint const &, std::string const & msg)
 {
-  std::lock_guard lock(g_logMutex);
-
-  std::ostringstream out;
-  out << msg << std::endl;
-  std::cerr << out.str();
+  {
+    std::lock_guard lock(g_logMutex);
+    std::cerr << msg << std::endl;
+  }
 
   CHECK_LESS(level, g_LogAbortLevel, ("Abort. Log level is too serious", level));
 }

--- a/base/logging.hpp
+++ b/base/logging.hpp
@@ -8,6 +8,7 @@
 #include <array>
 #include <atomic>
 #include <map>
+#include <optional>
 #include <string>
 
 namespace base
@@ -28,24 +29,19 @@ class LogHelper
 public:
   static LogHelper & Instance();
 
-  LogHelper();
-
   int GetThreadID();
   void WriteProlog(std::ostream & s, LogLevel level);
 
 private:
-  int m_threadsCount;
+  int m_threadsCount{0};
   std::map<threads::ThreadID, int> m_threadID;
 
   Timer m_timer;
-
-  std::array<char const *, NUM_LOG_LEVELS> m_names;
-  std::array<size_t, NUM_LOG_LEVELS> m_lens;
 };
 
 std::string ToString(LogLevel level);
-bool FromString(std::string const & s, LogLevel & level);
-std::array<char const *, NUM_LOG_LEVELS> const & GetLogLevelNames();
+std::optional<LogLevel> FromString(std::string const & s);
+std::array<char, NUM_LOG_LEVELS> const & GetLogLevelNames();
 
 using AtomicLogLevel = std::atomic<LogLevel>;
 using LogMessageFn = void (*)(LogLevel level, SrcPoint const &, std::string const &);


### PR DESCRIPTION
Example:

```
I(1) 0.72366 search/processor.cpp:210 SetPreferredLocale(): New preferred locale: en
D(1) 0.72374 search/processor.cpp:229 SetInputLocale(): New input locale: en locale code:
W(2) 0.72979 search/geocoder.cpp:736 CacheWorldLocalities(): Can't find World map file.
```

Before change:
```
LOG TID(1) DEBUG  7.1459e-05 platform/platform_mac.mm:135 Platform: Resources Directory: /
LOG TID(1) DEBUG 0.000118709 platform/platform_mac.mm:136 Platform: Writable Directory: /
LOG TID(1) DEBUG    0.000133 platform/platform_mac.mm:137 Platform: Tmp Directory: /
LOG TID(1) DEBUG 0.000136417 platform/platform_mac.mm:138 Platform: Settings Directory: /
LOG TID(1) INFO  0.000162875 qt/main.cpp:121 main(): Organic Maps 2024.04.22-3-c91add3a-Darwin started, detected CPU cores: 1024
```