### PR TITLE
[ios] Add a loading overlay screen with an activity indicator for the bookmarks sharing

### DIFF
--- a/iphone/Maps/Categories/UIApplication+LoadingOverlay.swift
+++ b/iphone/Maps/Categories/UIApplication+LoadingOverlay.swift
@@ -1,0 +1,24 @@
+extension UIApplication {
+  private static let overlayViewController = LoadingOverlayViewController()
+
+  @objc
+  func showLoadingOverlay(completion: (() -> Void)? = nil) {
+    guard let window = self.windows.first(where: { $0.isKeyWindow }) else {
+      completion?()
+      return
+    }
+
+    DispatchQueue.main.async {
+      UIApplication.overlayViewController.modalPresentationStyle = .overFullScreen
+      UIApplication.overlayViewController.modalTransitionStyle = .crossDissolve
+      window.rootViewController?.present(UIApplication.overlayViewController, animated: true, completion: completion)
+    }
+  }
+
+  @objc
+  func hideLoadingOverlay(completion: (() -> Void)? = nil) {
+    DispatchQueue.main.async {
+      UIApplication.overlayViewController.dismiss(animated: true, completion: completion)
+    }
+  }
+}

--- a/iphone/Maps/Classes/LoadingOverlay/LoadingOverlayViewController.swift
+++ b/iphone/Maps/Classes/LoadingOverlay/LoadingOverlayViewController.swift
@@ -1,0 +1,29 @@
+final class LoadingOverlayViewController: UIViewController {
+  private var activityIndicator: UIActivityIndicatorView = {
+    let indicator: UIActivityIndicatorView
+    if #available(iOS 13.0, *) {
+      indicator = UIActivityIndicatorView(style: .large)
+    } else {
+      indicator = UIActivityIndicatorView(style: .whiteLarge)
+    }
+    indicator.color = .white
+    indicator.startAnimating()
+    indicator.translatesAutoresizingMaskIntoConstraints = false
+    return indicator
+  }()
+
+  override func viewDidLoad() {
+    super.viewDidLoad()
+    view.backgroundColor = UIColor.black.withAlphaComponent(0.3)
+    setupViews()
+  }
+
+  private func setupViews() {
+    view.addSubview(activityIndicator)
+    NSLayoutConstraint.activate([
+      activityIndicator.centerXAnchor.constraint(equalTo: view.centerXAnchor),
+      activityIndicator.centerYAnchor.constraint(equalTo: view.centerYAnchor)
+    ])
+    view.isUserInteractionEnabled = false
+  }
+}

--- a/iphone/Maps/Maps.xcodeproj/project.pbxproj
+++ b/iphone/Maps/Maps.xcodeproj/project.pbxproj
@@ -468,6 +468,8 @@
 		ED1263AB2B6F99F900AD99F3 /* UIView+AddSeparator.swift in Sources */ = {isa = PBXBuildFile; fileRef = ED1263AA2B6F99F900AD99F3 /* UIView+AddSeparator.swift */; };
 		ED1ADA332BC6B1B40029209F /* CarPlayServiceTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = ED1ADA322BC6B1B40029209F /* CarPlayServiceTests.swift */; };
 		ED3EAC202B03C88100220A4A /* BottomTabBarButton.swift in Sources */ = {isa = PBXBuildFile; fileRef = ED3EAC1F2B03C88100220A4A /* BottomTabBarButton.swift */; };
+		ED79A5AB2BD7AA9C00952D1F /* LoadingOverlayViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = ED79A5AA2BD7AA9C00952D1F /* LoadingOverlayViewController.swift */; };
+		ED79A5AD2BD7BA0F00952D1F /* UIApplication+LoadingOverlay.swift in Sources */ = {isa = PBXBuildFile; fileRef = ED79A5AC2BD7BA0F00952D1F /* UIApplication+LoadingOverlay.swift */; };
 		ED9966802B94FBC20083CE55 /* ColorPicker.swift in Sources */ = {isa = PBXBuildFile; fileRef = ED99667D2B94FBC20083CE55 /* ColorPicker.swift */; };
 		EDBD68072B625724005DD151 /* LocationServicesDisabledAlert.xib in Resources */ = {isa = PBXBuildFile; fileRef = EDBD68062B625724005DD151 /* LocationServicesDisabledAlert.xib */; };
 		EDBD680B2B62572E005DD151 /* LocationServicesDisabledAlert.swift in Sources */ = {isa = PBXBuildFile; fileRef = EDBD680A2B62572E005DD151 /* LocationServicesDisabledAlert.swift */; };
@@ -1358,6 +1360,8 @@
 		ED3EAC1F2B03C88100220A4A /* BottomTabBarButton.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BottomTabBarButton.swift; sourceTree = "<group>"; };
 		ED48BBB817C2B1E2003E7E92 /* CircleView.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = CircleView.h; sourceTree = "<group>"; };
 		ED48BBB917C2B1E2003E7E92 /* CircleView.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = CircleView.m; sourceTree = "<group>"; };
+		ED79A5AA2BD7AA9C00952D1F /* LoadingOverlayViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LoadingOverlayViewController.swift; sourceTree = "<group>"; };
+		ED79A5AC2BD7BA0F00952D1F /* UIApplication+LoadingOverlay.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "UIApplication+LoadingOverlay.swift"; sourceTree = "<group>"; };
 		ED99667D2B94FBC20083CE55 /* ColorPicker.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ColorPicker.swift; sourceTree = "<group>"; };
 		EDBD68062B625724005DD151 /* LocationServicesDisabledAlert.xib */ = {isa = PBXFileReference; lastKnownFileType = file.xib; path = LocationServicesDisabledAlert.xib; sourceTree = "<group>"; };
 		EDBD680A2B62572E005DD151 /* LocationServicesDisabledAlert.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LocationServicesDisabledAlert.swift; sourceTree = "<group>"; };
@@ -1741,6 +1745,7 @@
 		080E96DDFE201D6D7F000001 /* Classes */ = {
 			isa = PBXGroup;
 			children = (
+				ED79A5A92BD7AA7500952D1F /* LoadingOverlay */,
 				CDB4D4E2222E8F8200104869 /* CarPlay */,
 				346EDAD81B9F0E15004F8DB5 /* Components */,
 				97B4E9271851DAB300BEC5D7 /* Custom Views */,
@@ -2140,6 +2145,7 @@
 				9957FAE0237AE04900855F48 /* MWMMapViewControlsManager+AddPlace.h */,
 				471A7BB7247FE3C300A0D4C1 /* URL+Query.swift */,
 				EDC3573A2B7B5029001AE9CA /* CALayer+SetCorner.swift */,
+				ED79A5AC2BD7BA0F00952D1F /* UIApplication+LoadingOverlay.swift */,
 			);
 			path = Categories;
 			sourceTree = "<group>";
@@ -2976,6 +2982,14 @@
 				ED1ADA322BC6B1B40029209F /* CarPlayServiceTests.swift */,
 			);
 			path = Tests;
+			sourceTree = "<group>";
+		};
+		ED79A5A92BD7AA7500952D1F /* LoadingOverlay */ = {
+			isa = PBXGroup;
+			children = (
+				ED79A5AA2BD7AA9C00952D1F /* LoadingOverlayViewController.swift */,
+			);
+			path = LoadingOverlay;
 			sourceTree = "<group>";
 		};
 		ED99667C2B94FBC20083CE55 /* ColorPicker */ = {
@@ -4232,6 +4246,7 @@
 				993DF11723F6BDB100AC231A /* UINavigationBarRenderer.swift in Sources */,
 				6741A9E71BF340DE002C974C /* MWMCircularProgressView.m in Sources */,
 				34AC8FDB1EFC07FE00E7F910 /* UILabel+NumberOfVisibleLines.swift in Sources */,
+				ED79A5AD2BD7BA0F00952D1F /* UIApplication+LoadingOverlay.swift in Sources */,
 				9959C75C24599CCD008FD4FD /* DirectionView.swift in Sources */,
 				47CA68D62500448D00671019 /* BookmarksListInteractor.swift in Sources */,
 				4767CD9F20AAD48A00BD8166 /* Checkmark.swift in Sources */,
@@ -4267,6 +4282,7 @@
 				F660DEE51EAF4F59004DC056 /* MWMLocationManager+SpeedAndAltitude.swift in Sources */,
 				F6E2FDF21E097BA00083EBEC /* MWMOpeningHoursAddScheduleTableViewCell.mm in Sources */,
 				3304306D21D4EAFB00317CA3 /* SearchCategoryCell.swift in Sources */,
+				ED79A5AB2BD7AA9C00952D1F /* LoadingOverlayViewController.swift in Sources */,
 				34AB66111FC5AA320078E451 /* NavigationTurnsView.swift in Sources */,
 				475ED78624C7C7300063ADC7 /* ValueStepperViewRenderer.swift in Sources */,
 				3490D2E11CE9DD2500D0B838 /* MWMSideButtonsView.mm in Sources */,


### PR DESCRIPTION
The sharing process may take some time when there are many files and the screen isn't blocked during this process.
Current behavior:

https://github.com/organicmaps/organicmaps/assets/79797627/671f7229-52c2-4d1d-8713-f22e77a0f304
___

This PR adds a loading overlay screen with an activity indicator that disables user interaction while files are being prepared.
The Dimming effect isn't very strong (0,3 alpha) but it can be increased.
Result:

https://github.com/organicmaps/organicmaps/assets/79797627/735279e3-d87e-4faa-92e7-e3e433a65662

<img width="350" alt="image" src="https://github.com/organicmaps/organicmaps/assets/79797627/06c625b5-b70b-41c6-b6df-fb4d96b6c1d8">
<img width="350" alt="image" src="https://github.com/organicmaps/organicmaps/assets/79797627/22d357a6-4d4a-4258-af98-6716ec7e07f7">

<img width="600" alt="image" src="https://github.com/organicmaps/organicmaps/assets/79797627/fb2547b1-cfc2-4ac0-94de-9eef69126df1">


Tested on:
iPhone 11pro (17.2)
iPhone 6 (12.5)
MasOS designed for iPad