### PR TITLE
transit/world_feed/test: allow git repo configuraion

### DIFF
--- a/transit/world_feed/world_feed_integration_tests/CMakeLists.txt
+++ b/transit/world_feed/world_feed_integration_tests/CMakeLists.txt
@@ -10,7 +10,9 @@ target_link_libraries(${PROJECT_NAME}
 )
 
 # This test requires additional data from the other repository
-set(TEST_DATA_REPO_URL "https://github.com/organicmaps/world_feed_integration_tests_data.git")
+if(NOT TEST_DATA_REPO_URL)
+	set(TEST_DATA_REPO_URL "https://github.com/organicmaps/world_feed_integration_tests_data.git")
+endif()
 set(DESTINATION_FOLDER "${OMIM_DATA_DIR}/world_feed_integration_tests_data/")
 
 add_custom_command(


### PR DESCRIPTION
The world_feed_integration_tests clone a repo during the test phase. Downloading data is forbidden in some distributions (like Gentoo) during building and testing phase. With this patch, TEST_DATA_REPO_URL can be set externally, thus preventing a network connection by providing a locally vendored repo.