### PR TITLE
Save produced json in a more compact UTF-8 format

### DIFF
--- a/map/routing_manager.cpp
+++ b/map/routing_manager.cpp
@@ -151,7 +151,7 @@ string SerializeRoutePoints(vector<RouteMarkData> const & points)
     json_array_append_new(pointsNode.get(), pointNode.release());
   }
   unique_ptr<char, JSONFreeDeleter> buffer(
-    json_dumps(pointsNode.get(), JSON_COMPACT | JSON_ENSURE_ASCII));
+    json_dumps(pointsNode.get(), JSON_COMPACT));
   return string(buffer.get());
 }
 

--- a/search/search_quality/helpers.cpp
+++ b/search/search_quality/helpers.cpp
@@ -60,7 +60,7 @@ void CheckLocale()
     ToJSONObject(*root, "coord", coord);
 
     unique_ptr<char, JSONFreeDeleter> buffer(
-        json_dumps(root.get(), JSON_COMPACT | JSON_ENSURE_ASCII));
+        json_dumps(root.get(), JSON_COMPACT));
 
     line.append(buffer.get());
   }

--- a/search/search_quality/sample.cpp
+++ b/search/search_quality/sample.cpp
@@ -150,7 +150,7 @@ void Sample::SerializeToJSONLines(vector<Sample> const & samples, string & lines
   for (auto const & sample : samples)
   {
     unique_ptr<char, JSONFreeDeleter> buffer(
-        json_dumps(sample.SerializeToJSON().get(), JSON_COMPACT | JSON_ENSURE_ASCII));
+        json_dumps(sample.SerializeToJSON().get(), JSON_COMPACT));
     lines.append(buffer.get());
     lines.push_back('\n');
   }

--- a/storage/diff_scheme/diff_scheme_loader.cpp
+++ b/storage/diff_scheme/diff_scheme_loader.cpp
@@ -43,7 +43,7 @@ string SerializeCheckerData(LocalMapsInfo const & info)
   auto const root = base::NewJSONObject();
   json_object_set_new(root.get(), kMwmsKey, mwmsArrayNode.release());
   ToJSONObject(*root, kMaxVersionKey, info.m_currentDataVersion);
-  unique_ptr<char, JSONFreeDeleter> buffer(json_dumps(root.get(), JSON_COMPACT | JSON_ENSURE_ASCII));
+  unique_ptr<char, JSONFreeDeleter> buffer(json_dumps(root.get(), JSON_COMPACT));
   return buffer.get();
 }
 

--- a/tools/python/maps_generator/generator/stages_declaration.py
+++ b/tools/python/maps_generator/generator/stages_declaration.py
@@ -366,7 +366,7 @@ class StageCountriesTxt(Stage):
             )
 
         with open(env.paths.counties_txt_path, "w") as f:
-            json.dump(countries, f, ensure_ascii=True, indent=1)
+            json.dump(countries, f, ensure_ascii=False, indent=1)
 
 
 @outer_stage

--- a/tools/python/post_generation/__main__.py
+++ b/tools/python/post_generation/__main__.py
@@ -100,9 +100,9 @@ The post_generation commands are:
         )
         if args.output:
             with open(args.output, "w") as f:
-                json.dump(countries, f, ensure_ascii=True, indent=1)
+                json.dump(countries, f, ensure_ascii=False, indent=1)
         else:
-            print(json.dumps(countries, ensure_ascii=True, indent=1))
+            print(json.dumps(countries, ensure_ascii=False, indent=1))
 
     @staticmethod
     def inject_promo_ids():
@@ -152,7 +152,7 @@ The post_generation commands are:
         )
 
         with open(args.output, "w") as f:
-            json.dump(countries, f, ensure_ascii=True, indent=1)
+            json.dump(countries, f, ensure_ascii=False, indent=1)
 
 
 PostGeneration()


### PR DESCRIPTION
This change will reduce the size of generated countries.txt from 405K to 355K, which is beneficial for app size and for future transfers over the wire.