### PR TITLE
[classif] Don't treat bicycle=yes as a shared path

### DIFF
--- a/data/mapcss-mapping.csv
+++ b/data/mapcss-mapping.csv
@@ -117,8 +117,8 @@ natural|water|lake;[natural=water][water=lake];;name;int_name;50;
 # ~3M usages. TODO: consolidate all other footway=link/etc. values into highway-footway-minor.
 highway|footway|crossing;[highway=footway][footway=crossing];;name;int_name;51;
 waterway|riverbank;52;
-# 1M+ usages.
-highway|path|bicycle;[highway=path][bicycle=yes],[highway=path][bicycle=designated],[highway=path][bicycle=permissive];;;;53;
+# 600k+ usages.
+highway|path|bicycle;[highway=path][bicycle=designated];;;;53;
 landuse|meadow;54;
 highway|living_street;55;
 man_made|survey_point;56;
@@ -221,8 +221,7 @@ leisure|garden|residential;[leisure=garden][garden:type=residential];;name;int_n
 amenity|fire_station;138;
 landuse|retail;139;
 leisure|nature_reserve;140;
-# TODO: ~1M usages, use a short ID.
-highway|footway|bicycle;[highway=footway][bicycle=yes],[highway=footway][bicycle=designated],[highway=footway][bicycle=permissive];;;;141;
+highway|footway|bicycle;[highway=footway][bicycle=designated];;;;141;
 tourism|information;142;
 highway|motorway_link|bridge;[highway=motorway_link][bridge?];;name;int_name;143;
 # Usually there is something else in place of the old railway, e.g. highway=path,

--- a/data/styles/clear/include/Roads.mapcss
+++ b/data/styles/clear/include/Roads.mapcss
@@ -639,8 +639,8 @@ line|z13-[highway=pedestrian],
 line|z13-[highway=ford]
 {color: @pedestrian;opacity: 0.85;}
 line|z13-[highway=cycleway],
-line|z14-[highway=footway][bicycle=yes]::cycleline,
-line|z14-[highway=path][bicycle=yes]::cycleline,
+line|z14-[highway=footway][bicycle=designated]::cycleline,
+line|z14-[highway=path][bicycle=designated]::cycleline,
 {color: @cycleway; opacity: 0.5;}
 line|z13-[highway=construction],
 {color: @construction;opacity: 0.7;}
@@ -674,7 +674,7 @@ line|z14-[highway=bridleway]
 {color: @bridleway;opacity: 0.6;}
 line|z15-[highway=footway],
 {color: @footway;opacity: 0.75;}
-line|z14-[highway=footway][bicycle=yes],
+line|z14-[highway=footway][bicycle=designated],
 {color: @footway; opacity: 0.85;}
 line|z15-[highway=steps],
 {color: @footway;opacity: 0.85;}
@@ -755,28 +755,28 @@ line|z16-[highway=pedestrian][bridge?]::bridgeblack,
 line|z13[highway=cycleway]
 {width: 0.9;}
 line|z14[highway=cycleway],
-line|z14[highway=footway][bicycle=yes]::cycleline,
-line|z14[highway=path][bicycle=yes]::cycleline,
+line|z14[highway=footway][bicycle=designated]::cycleline,
+line|z14[highway=path][bicycle=designated]::cycleline,
 {width: 1.1;}
 line|z15[highway=cycleway]
-line|z15[highway=footway][bicycle=yes]::cycleline,
-line|z15[highway=path][bicycle=yes]::cycleline,
+line|z15[highway=footway][bicycle=designated]::cycleline,
+line|z15[highway=path][bicycle=designated]::cycleline,
 {width: 1.2;}
 line|z16[highway=cycleway],
-line|z16[highway=footway][bicycle=yes]::cycleline,
-line|z16[highway=path][bicycle=yes]::cycleline,
+line|z16[highway=footway][bicycle=designated]::cycleline,
+line|z16[highway=path][bicycle=designated]::cycleline,
 {width: 1.3; opacity: 0.6;}
 line|z17[highway=cycleway],
-line|z17[highway=footway][bicycle=yes]::cycleline,
-line|z17[highway=path][bicycle=yes]::cycleline,
+line|z17[highway=footway][bicycle=designated]::cycleline,
+line|z17[highway=path][bicycle=designated]::cycleline,
 {width: 1.4; opacity: 0.6;}
 line|z18[highway=cycleway],
-line|z18[highway=footway][bicycle=yes]::cycleline,
-line|z18[highway=path][bicycle=yes]::cycleline,
+line|z18[highway=footway][bicycle=designated]::cycleline,
+line|z18[highway=path][bicycle=designated]::cycleline,
 {width: 1.6; opacity: 0.8;}
 line|z19-[highway=cycleway],
-line|z19-[highway=footway][bicycle=yes]::cycleline,
-line|z19-[highway=path][bicycle=yes]::cycleline,
+line|z19-[highway=footway][bicycle=designated]::cycleline,
+line|z19-[highway=path][bicycle=designated]::cycleline,
 {width: 1.8; opacity: 0.8;}
 
 line|z17[highway=cycleway][tunnel?]::tunnelBackground
@@ -871,17 +871,17 @@ line|z18[highway=path],
 line|z19-[highway=path],
 {width: 3.7; dashes: 8,4.5; opacity: 0.8;}
 
-line|z14[highway=path][bicycle=yes],
+line|z14[highway=path][bicycle=designated],
 {width: 0.9; dashes: 3.5,2.7;}
-line|z15[highway=path][bicycle=yes],
+line|z15[highway=path][bicycle=designated],
 {width: 1.1; dashes: 3.5,2.7;}
-line|z16[highway=path][bicycle=yes],
+line|z16[highway=path][bicycle=designated],
 {width: 1.5; dashes: 4,3.2;}
-line|z17[highway=path][bicycle=yes],
+line|z17[highway=path][bicycle=designated],
 {width: 2; dashes: 4,3.2;}
-line|z18[highway=path][bicycle=yes],
+line|z18[highway=path][bicycle=designated],
 {width: 2.8; dashes: 6,4.7; opacity: 0.8;}
-line|z19-[highway=path][bicycle=yes],
+line|z19-[highway=path][bicycle=designated],
 {width: 3.7; dashes: 8,6.2; opacity: 0.8;}
 
 line|z14[highway=path][_path_grade=difficult],
@@ -940,17 +940,17 @@ line|z18[highway=footway]
 line|z19-[highway=footway],
 {width: 4.2; dashes: 10,3.5; opacity: 1;}
 
-line|z14[highway=footway][bicycle=yes],
+line|z14[highway=footway][bicycle=designated],
 {width: 1.1; dashes: 4,3.2; opacity: 0.7;}
-line|z15[highway=footway][bicycle=yes],
+line|z15[highway=footway][bicycle=designated],
 {width: 1.5; dashes: 5,3.5;}
-line|z16[highway=footway][bicycle=yes],
+line|z16[highway=footway][bicycle=designated],
 {width: 2; dashes: 5,3.5;}
-line|z17[highway=footway][bicycle=yes],
+line|z17[highway=footway][bicycle=designated],
 {width: 2.4; dashes: 6,4.2; opacity: 1;}
-line|z18[highway=footway][bicycle=yes],
+line|z18[highway=footway][bicycle=designated],
 {width: 3.2; dashes: 8,5.5; opacity: 1;}
-line|z19-[highway=footway][bicycle=yes],
+line|z19-[highway=footway][bicycle=designated],
 {width: 4.2; dashes: 10,6.7; opacity: 1;}
 
 /* Don't display sidewalks and pedestrian crossings on z15. */

--- a/data/styles/outdoors/include/Roads.mapcss
+++ b/data/styles/outdoors/include/Roads.mapcss
@@ -100,8 +100,8 @@ line|z11-[highway=bridleway],
 {color: @path; opacity: 1;}
 
 line|z11-[highway=cycleway],
-line|z12-[highway=footway][bicycle=yes]::cycleline,
-line|z12-[highway=path][bicycle=yes]::cycleline,
+line|z12-[highway=footway][bicycle=designated]::cycleline,
+line|z12-[highway=path][bicycle=designated]::cycleline,
 {color: @cycleway; opacity: 1;}
 
 line|z11[highway=track],
@@ -159,30 +159,30 @@ line|z18-[piste:type=hike],
 line|z18-[highway=footway],
 {width: 4; dashes: 8,4.5;}
 
-line|z13-[highway=path][bicycle=yes],
-line|z13-[highway=footway][bicycle=yes],
+line|z13-[highway=path][bicycle=designated],
+line|z13-[highway=footway][bicycle=designated],
 {opacity: 0.8;}
 
-line|z12[highway=path][bicycle=yes],
-line|z12[highway=footway][bicycle=yes],
+line|z12[highway=path][bicycle=designated],
+line|z12[highway=footway][bicycle=designated],
 {width: 1.1; dashes: 3.5,2.5; opacity: 0.7;}
-line|z13[highway=path][bicycle=yes],
-line|z13[highway=footway][bicycle=yes],
+line|z13[highway=path][bicycle=designated],
+line|z13[highway=footway][bicycle=designated],
 {width: 1.3; dashes: 4,3;}
-line|z14[highway=path][bicycle=yes],
-line|z14[highway=footway][bicycle=yes],
+line|z14[highway=path][bicycle=designated],
+line|z14[highway=footway][bicycle=designated],
 {width: 1.6; dashes: 4,3;}
-line|z15[highway=path][bicycle=yes],
-line|z15[highway=footway][bicycle=yes],
+line|z15[highway=path][bicycle=designated],
+line|z15[highway=footway][bicycle=designated],
 {width: 2; dashes: 6,4.5;}
-line|z16[highway=path][bicycle=yes],
-line|z16[highway=footway][bicycle=yes],
+line|z16[highway=path][bicycle=designated],
+line|z16[highway=footway][bicycle=designated],
 {width: 2.6; dashes: 6,4.5;}
-line|z17[highway=path][bicycle=yes],
-line|z17[highway=footway][bicycle=yes],
+line|z17[highway=path][bicycle=designated],
+line|z17[highway=footway][bicycle=designated],
 {width: 3.3; dashes: 8,6;}
-line|z18-[highway=path][bicycle=yes],
-line|z18-[highway=footway][bicycle=yes],
+line|z18-[highway=path][bicycle=designated],
+line|z18-[highway=footway][bicycle=designated],
 {width: 4; dashes: 8,6; opacity: 1;}
 
 line|z11[highway=path][_path_grade=difficult],
@@ -243,32 +243,32 @@ line|z18-[highway=bridleway],
 line|z11[highway=cycleway],
 {width: 0.9; opacity: 0.7;}
 line|z12[highway=cycleway],
-line|z12[highway=footway][bicycle=yes]::cycleline,
-line|z12[highway=path][bicycle=yes]::cycleline,
+line|z12[highway=footway][bicycle=designated]::cycleline,
+line|z12[highway=path][bicycle=designated]::cycleline,
 {width: 1; opacity: 0.7;}
 line|z13[highway=cycleway],
-line|z13[highway=footway][bicycle=yes]::cycleline,
-line|z13[highway=path][bicycle=yes]::cycleline,
+line|z13[highway=footway][bicycle=designated]::cycleline,
+line|z13[highway=path][bicycle=designated]::cycleline,
 {width: 1.1; opacity: 0.8;}
 line|z14[highway=cycleway],
-line|z14[highway=footway][bicycle=yes]::cycleline,
-line|z14[highway=path][bicycle=yes]::cycleline,
+line|z14[highway=footway][bicycle=designated]::cycleline,
+line|z14[highway=path][bicycle=designated]::cycleline,
 {width: 1.3;}
 line|z15[highway=cycleway],
-line|z15[highway=footway][bicycle=yes]::cycleline,
-line|z15[highway=path][bicycle=yes]::cycleline,
+line|z15[highway=footway][bicycle=designated]::cycleline,
+line|z15[highway=path][bicycle=designated]::cycleline,
 {width: 1.5;}
 line|z16[highway=cycleway],
-line|z16[highway=footway][bicycle=yes]::cycleline,
-line|z16[highway=path][bicycle=yes]::cycleline,
+line|z16[highway=footway][bicycle=designated]::cycleline,
+line|z16[highway=path][bicycle=designated]::cycleline,
 {width: 1.7;}
 line|z17[highway=cycleway],
-line|z17[highway=footway][bicycle=yes]::cycleline,
-line|z17[highway=path][bicycle=yes]::cycleline,
+line|z17[highway=footway][bicycle=designated]::cycleline,
+line|z17[highway=path][bicycle=designated]::cycleline,
 {width: 2;}
 line|z18-[highway=cycleway],
-line|z18-[highway=footway][bicycle=yes]::cycleline,
-line|z18-[highway=path][bicycle=yes]::cycleline,
+line|z18-[highway=footway][bicycle=designated]::cycleline,
+line|z18-[highway=path][bicycle=designated]::cycleline,
 {width: 2.4;}
 
 

--- a/generator/generator_tests/osm_type_test.cpp
+++ b/generator/generator_tests/osm_type_test.cpp
@@ -772,7 +772,7 @@ UNIT_CLASS_TEST(TestWithClassificator, OsmType_Hwtag)
     auto const params = GetFeatureBuilderParams(tags);
 
     TEST_EQUAL(params.m_types.size(), 3, (params));
-    TEST(params.IsTypeExist(GetType({"highway", "path", "bicycle"})), (params));
+    TEST(params.IsTypeExist(GetType({"highway", "path"})), (params));
     TEST(params.IsTypeExist(GetType({"hwtag", "yesfoot"})), ());
     TEST(params.IsTypeExist(GetType({"hwtag", "yesbicycle"})), ());
   }
@@ -813,7 +813,7 @@ UNIT_CLASS_TEST(TestWithClassificator, OsmType_Hwtag)
     auto const params = GetFeatureBuilderParams(tags);
 
     TEST_EQUAL(params.m_types.size(), 8, (params));
-    TEST(params.IsTypeExist(GetType({"highway", "footway", "bicycle"})), (params));
+    TEST(params.IsTypeExist(GetType({"highway", "footway"})), (params));
     TEST(params.IsTypeExist(GetType({"hwtag", "yesbicycle"})), ());
     TEST(!params.IsTypeExist(GetType({"hwtag", "yesfoot"})), ());
 
@@ -3049,7 +3049,7 @@ UNIT_CLASS_TEST(TestWithClassificator, OsmType_HighwayTypesConversion)
 {
   using Type = std::vector<std::string>;
   std::vector<std::pair<Type, Tags>> const conversions = {
-    {{"highway", "cycleway"}, {{"highway", "path"}, {"foot", "no"}, {"bicycle", "yes"}}},
+    {{"highway", "cycleway"}, {{"highway", "path"}, {"foot", "no"}, {"bicycle", "designated"}}},
 
     // Paved etc. paths to footways.
     {{"highway", "footway"}, {{"highway", "path"}, {"surface", "paved"}}},

--- a/generator/osm2type.cpp
+++ b/generator/osm2type.cpp
@@ -724,7 +724,7 @@ string DetermineSurfaceAndHighwayType(OsmElement * p)
         LOG(LDEBUG, ("Add a separate footway to", DebugPrintID(*p), p->m_tags));
         p->AddTag("highway", kFootway);
       }
-      else if (p->HasTag("foot", "no") && (p->HasTag("bicycle", "yes") || p->HasTag("bicycle", "designated")))
+      else if (p->HasTag("foot", "no") && p->HasTag("bicycle", "designated"))
         ConvertTo(kCycleway);
       else if (!p->HasTag("foot", "no"))
         ConvertPathOrFootway(false /* toPath */);


### PR DESCRIPTION
Follow-up to https://github.com/organicmaps/organicmaps/pull/7878

Treating all `bicycle=yes` ways as shared paths was a mistake, see
- https://github.com/organicmaps/organicmaps/pull/8018

This patch makes only `bicycle=designated` ways treated as shared (with a special rendering). E.g. for footways it means ~8-9 times less will be "shared".

It doesn't affect routing which should be fixed also IMO.