### PR TITLE
[ios]  Fix the bug when the same language can be added multiple times to the additional languages list

### DIFF
--- a/iphone/Maps/UI/Editor/MWMEditorViewController.mm
+++ b/iphone/Maps/UI/Editor/MWMEditorViewController.mm
@@ -1105,9 +1105,7 @@ void registerCellsForTableView(std::vector<MWMEditorCellID> const & cells, UITab
   else if ([segue.identifier isEqualToString:kAdditionalNamesEditorSegue])
   {
     MWMEditorAdditionalNamesTableViewController * dvc = segue.destinationViewController;
-    [dvc configWithDelegate:self
-                               name:m_mapObject.GetNameMultilang()
-        additionalSkipLanguageCodes:extractLanguageCodes(m_mapObject.GetNamesDataSource().names)];
+    [dvc configWithDelegate:self name:m_mapObject.GetNameMultilang() additionalSkipLanguageCodes:m_newAdditionalLanguages];
   }
 }
 


### PR DESCRIPTION
This PR fixes the bug when the same language can be added multiple times to the additional languages list.

Tested on:
- [x] iPhone 11pro (17.2) device
- [x] iPad designed for macOS

### Before:
<img width="455" alt="image" src="https://github.com/organicmaps/organicmaps/assets/79797627/515afce6-d427-429d-b8ea-93a7636f025c">

https://github.com/organicmaps/organicmaps/assets/79797627/6e23d3bd-f087-45ab-9ceb-20235c7bbdf6

### After:
Edit:
![Simulator Screen Recording - iPhone 15 Pro - 2024-05-06 at 17 25 32](https://github.com/organicmaps/organicmaps/assets/79797627/b3f05492-d33f-4bb5-aced-102abef2cc74)
Add:
![Simulator Screen Recording - iPhone 15 Pro - 2024-05-06 at 17 21 52](https://github.com/organicmaps/organicmaps/assets/79797627/0de88a17-ea78-45c9-a471-3911a015899d)

