### PR TITLE
[editor] Removed superfluous name=* restrictions

### DIFF
--- a/indexer/editable_map_object.cpp
+++ b/indexer/editable_map_object.cpp
@@ -352,25 +352,17 @@ void EditableMapObject::SetCuisines(std::vector<std::string> const & cuisines)
 
 void EditableMapObject::SetPointType() { m_geomType = feature::GeomType::Point; }
 
-void EditableMapObject::RemoveBlankAndDuplicationsForDefault()
+void EditableMapObject::RemoveBlankNames()
 {
   StringUtf8Multilang editedName;
-  string_view defaultName;
-  m_name.GetString(StringUtf8Multilang::kDefaultCode, defaultName);
 
-  m_name.ForEach([&defaultName, &editedName](int8_t langCode, string_view name)
+  m_name.ForEach([&editedName](int8_t langCode, string_view name)
   {
-    auto const duplicate = langCode != StringUtf8Multilang::kDefaultCode && defaultName == name;
-    if (!name.empty() && !duplicate)
+    if (!name.empty())
       editedName.AddString(langCode, name);
   });
 
   m_name = editedName;
-}
-
-void EditableMapObject::RemoveNeedlessNames()
-{
-  RemoveBlankAndDuplicationsForDefault();
 }
 
 // static

--- a/indexer/editable_map_object.hpp
+++ b/indexer/editable_map_object.hpp
@@ -117,10 +117,8 @@ public:
 
   /// Special mark that it's a point feature, not area or line.
   void SetPointType();
-  /// Remove blank names and default name duplications.
-  void RemoveBlankAndDuplicationsForDefault();
-  /// Calls RemoveBlankNames or RemoveFakeNames depending on mode.
-  void RemoveNeedlessNames();
+  /// Remove blank names
+  void RemoveBlankNames();
 
   static bool ValidateBuildingLevels(std::string const & buildingLevels);
   static bool ValidateHouseNumber(std::string const & houseNumber);

--- a/indexer/indexer_tests/editable_map_object_test.cpp
+++ b/indexer/indexer_tests/editable_map_object_test.cpp
@@ -371,7 +371,7 @@ UNIT_TEST(EditableMapObject_RemoveBlankNames)
 
   EditableMapObject emo;
   emo.SetName(name);
-  emo.RemoveBlankAndDuplicationsForDefault();
+  emo.RemoveBlankNames();
 
   TEST_EQUAL(getCountOfNames(emo.GetNameMultilang()), 4, ());
 
@@ -383,7 +383,7 @@ UNIT_TEST(EditableMapObject_RemoveBlankNames)
   name.AddString(GetLangCode("de"), "");
 
   emo.SetName(name);
-  emo.RemoveBlankAndDuplicationsForDefault();
+  emo.RemoveBlankNames();
 
   TEST_EQUAL(getCountOfNames(emo.GetNameMultilang()), 2, ());
 
@@ -395,7 +395,7 @@ UNIT_TEST(EditableMapObject_RemoveBlankNames)
   name.AddString(GetLangCode("de"), "");
 
   emo.SetName(name);
-  emo.RemoveBlankAndDuplicationsForDefault();
+  emo.RemoveBlankNames();
 
   TEST_EQUAL(getCountOfNames(emo.GetNameMultilang()), 1, ());
 
@@ -407,7 +407,7 @@ UNIT_TEST(EditableMapObject_RemoveBlankNames)
   name.AddString(GetLangCode("de"), "De name");
 
   emo.SetName(name);
-  emo.RemoveBlankAndDuplicationsForDefault();
+  emo.RemoveBlankNames();
 
   TEST_EQUAL(getCountOfNames(emo.GetNameMultilang()), 1, ());
 }

--- a/map/framework.cpp
+++ b/map/framework.cpp
@@ -3002,7 +3002,7 @@ osm::Editor::SaveResult Framework::SaveEditedMapObject(osm::EditableMapObject em
                       " without a user's input. Feel free to close it if it's wrong).");
   }
 
-  emo.RemoveNeedlessNames();
+  emo.RemoveBlankNames();
 
   auto const result = osm::Editor::Instance().SaveEditedFeature(emo);
 


### PR DESCRIPTION
closes #1481

- Removed code that prevents users from adding a multilingual name in case it is the same as `name=*`. In uni lingual countries the OSM convention is that e.g. `name:de` should be the same as `name`. (see: #1481)

- ~~Allowed users to remove names / submit an empty name. This is e.g. helpful when the name of a POI (e.g. restaurant) changes. OM users can then update the multilingual names in languages they know and remove the wrong names in languages they don't know (no multilingual name is better than a wrong one) (see: #6292)~~