### PR TITLE
[ios] add default OSLog Logger for ios>14.0 to release

### DIFF
--- a/iphone/Maps/Common/Common.swift
+++ b/iphone/Maps/Common/Common.swift
@@ -1,4 +1,5 @@
 import Foundation
+import OSLog
 
 private func IPAD() -> Bool { return UI_USER_INTERFACE_IDIOM() == .pad }
 
@@ -27,18 +28,42 @@ func statusBarHeight() -> CGFloat {
   return min(statusBarSize.height, statusBarSize.width)
 }
 
+private let enableLoggingInRelease = true
+
 func LOG(_ level: LogLevel,
          _ message: @autoclosure () -> Any,
          functionName: StaticString = #function,
          fileName: StaticString = #file,
          lineNumber: UInt = #line) {
-  if (Logger.canLog(level)) {
-    let shorFileName = URL(string: "\(fileName)")?.lastPathComponent ?? ""
-    let formattedMessage = "\(shorFileName):\(lineNumber) \(functionName): \(message())"
+
+  let shortFileName = URL(string: "\(fileName)")?.lastPathComponent ?? ""
+  let formattedMessage = "\(shortFileName):\(lineNumber) \(functionName): \(message())"
+
+  if #available(iOS 14.0, *), enableLoggingInRelease {
+    os.Logger.logger.log(level: OSLogLevelFromLogLevel(level), "\(formattedMessage, privacy: .public)")
+  } else if Logger.canLog(level) {
     Logger.log(level, message: formattedMessage)
+  }
+}
+
+private func OSLogLevelFromLogLevel(_ level: LogLevel) -> OSLogType {
+  switch level {
+  case .error: return .error
+  case .info: return .info
+  case .debug: return .debug
+  case .critical: return .fault
+  case .warning: return .default
+  @unknown default:
+    fatalError()
   }
 }
 
 struct Weak<T> where T: AnyObject {
   weak var value: T?
+}
+
+@available(iOS 14.0, *)
+private extension os.Logger {
+  static let subsystem = Bundle.main.bundleIdentifier!
+  static let logger = Logger(subsystem: subsystem, category: "OM")
 }


### PR DESCRIPTION
This PR adds logging using the default OSLogger for ios>14.0 during the release.
This PR does not affect the core logging.
