### PR TITLE
[placepage] Add missing local language name

### DIFF
--- a/map/place_page_info.cpp
+++ b/map/place_page_info.cpp
@@ -69,6 +69,7 @@ void Info::SetFromFeatureType(FeatureType & ft)
   else if (!m_primaryFeatureName.empty())
   {
     m_uiTitle = m_primaryFeatureName;
+    m_uiSecondaryTitle = out.secondary;
   }
   else
   {


### PR DESCRIPTION
This PR adds back the missing local language name to the place page. 

I think this may have been lost in the SetFromFeatureType refactoring in https://github.com/organicmaps/organicmaps/pull/7334. @vng PTAL

* Fixes https://github.com/organicmaps/organicmaps/issues/7795

---

<img src="https://github.com/organicmaps/organicmaps/assets/47610359/cb7b1c61-16e3-4d8a-a608-78339f4a25e0" width="320"/>

<img src="https://github.com/organicmaps/organicmaps/assets/47610359/d0d6f877-3f58-4b30-ae8c-5d48b26dde1f" width="320"/>