### PR TITLE
[ios]  Fix the AdditionalNameTableViewCell tappable area

### DIFF
--- a/iphone/Maps/UI/Editor/Cells/MWMEditorAdditionalNameTableViewCell.m
+++ b/iphone/Maps/UI/Editor/Cells/MWMEditorAdditionalNameTableViewCell.m
@@ -5,6 +5,7 @@ static CGFloat const kErrorLabelHeight = 16;
 
 @interface MWMEditorAdditionalNameTableViewCell ()
 
+@property(weak, nonatomic) IBOutlet UIStackView * stackView;
 @property(weak, nonatomic) IBOutlet UILabel * languageLabel;
 @property(weak, nonatomic) IBOutlet UITextField * textField;
 @property(weak, nonatomic) IBOutlet UILabel * errorLabel;
@@ -88,6 +89,15 @@ static CGFloat const kErrorLabelHeight = 16;
 {
   [textField resignFirstResponder];
   return YES;
+}
+
+- (UIView *)hitTest:(CGPoint)point withEvent:(UIEvent *)event
+{
+  // Allow to tap on the whole cell to start editing.
+  UIView * view = [super hitTest:point withEvent:event];
+  if (view == self.stackView)
+    return self.textField;
+  return view;
 }
 
 @end

--- a/iphone/Maps/UI/Editor/Cells/MWMEditorAdditionalNameTableViewCell.xib
+++ b/iphone/Maps/UI/Editor/Cells/MWMEditorAdditionalNameTableViewCell.xib
@@ -43,6 +43,9 @@
                                 </connections>
                             </textField>
                         </subviews>
+                        <constraints>
+                            <constraint firstItem="9BY-PA-dlA" firstAttribute="width" secondItem="eca-XW-QZR" secondAttribute="width" id="OSr-03-hPe"/>
+                        </constraints>
                     </stackView>
                     <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Label" textAlignment="natural" lineBreakMode="tailTruncation" numberOfLines="0" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" preferredMaxLayoutWidth="252" translatesAutoresizingMaskIntoConstraints="NO" id="SZa-Bj-se1">
                         <rect key="frame" x="60" y="32" width="252" height="0.0"/>
@@ -78,6 +81,7 @@
                 <outlet property="errorLabel" destination="SZa-Bj-se1" id="hqN-vX-0Hw"/>
                 <outlet property="errorLabelHeight" destination="CPF-uE-pzx" id="X4g-6X-W0e"/>
                 <outlet property="languageLabel" destination="efb-nS-cjm" id="13M-9D-Qbf"/>
+                <outlet property="stackView" destination="eca-XW-QZR" id="RPt-fc-aoR"/>
                 <outlet property="textField" destination="9BY-PA-dlA" id="SCv-JL-5TL"/>
             </connections>
             <point key="canvasLocation" x="340.57971014492756" y="256.47321428571428"/>


### PR DESCRIPTION
This PR fixes the cell layout and increases the tappable zone so that when you tap on any cell area the text field activates.

Before:
<img width="300" alt="image" src="https://github.com/organicmaps/organicmaps/assets/79797627/15a7db02-4fa3-42c3-9c67-bf9a263ae9a7">

After:
<img width="300" alt="image" src="https://github.com/organicmaps/organicmaps/assets/79797627/2ffef1cc-11cb-4cd1-8f17-cc9d0b33c61a">
