### PR TITLE
[android] Remove Android Studio warnings

### DIFF
--- a/android/app/src/main/java/app/organicmaps/MwmActivity.java
+++ b/android/app/src/main/java/app/organicmaps/MwmActivity.java
@@ -12,7 +12,6 @@ import android.location.Location;
 import android.net.Uri;
 import android.os.Build;
 import android.os.Bundle;
-import android.text.Html;
 import android.text.TextUtils;
 import android.text.method.LinkMovementMethod;
 import android.view.KeyEvent;
@@ -318,9 +317,7 @@ public class MwmActivity extends BaseMwmFragmentActivity
 
       // Notify user to re-login
       dismissAlertDialog();
-      final DialogInterface.OnClickListener navigateToLoginHandler = (DialogInterface dialog, int which) -> {
-        startActivity(new Intent(MwmActivity.this, OsmLoginActivity.class));
-      };
+      final DialogInterface.OnClickListener navigateToLoginHandler = (DialogInterface dialog, int which) -> startActivity(new Intent(MwmActivity.this, OsmLoginActivity.class));
 
       final int marginBase = getResources().getDimensionPixelSize(R.dimen.margin_base);
       final float textSize = getResources().getDimension(R.dimen.line_spacing_extra_1);

--- a/android/app/src/main/java/app/organicmaps/bookmarks/BookmarkCollectionAdapter.java
+++ b/android/app/src/main/java/app/organicmaps/bookmarks/BookmarkCollectionAdapter.java
@@ -71,7 +71,7 @@ public class BookmarkCollectionAdapter extends RecyclerView.Adapter<RecyclerView
     mItemsCategory = itemsCategories;
 
     mSectionCount = 0;
-    if (mItemsCategory.size() > 0)
+    if (!mItemsCategory.isEmpty())
       mCategorySectionIndex = mSectionCount++;
   }
 

--- a/android/app/src/main/java/app/organicmaps/bookmarks/ChooseBookmarkCategoryFragment.java
+++ b/android/app/src/main/java/app/organicmaps/bookmarks/ChooseBookmarkCategoryFragment.java
@@ -84,7 +84,7 @@ public class ChooseBookmarkCategoryFragment extends BaseMwmDialogFragment
 
     List<BookmarkCategory> bookmarkCategories = mAdapter.getBookmarkCategories();
 
-    if (bookmarkCategories.size() == 0)
+    if (bookmarkCategories.isEmpty())
       throw new AssertionError("BookmarkCategories are empty");
 
     int categoryPosition = -1;

--- a/android/app/src/main/java/app/organicmaps/bookmarks/data/BookmarkManager.java
+++ b/android/app/src/main/java/app/organicmaps/bookmarks/data/BookmarkManager.java
@@ -136,8 +136,7 @@ public enum BookmarkManager
   @Nullable
   public Bookmark addNewBookmark(double lat, double lon)
   {
-    final Bookmark bookmark = nativeAddBookmarkToLastEditedCategory(lat, lon);
-    return bookmark;
+    return nativeAddBookmarkToLastEditedCategory(lat, lon);
   }
 
   public void addLoadingListener(@NonNull BookmarksLoadingListener listener)
@@ -932,10 +931,10 @@ public enum BookmarkManager
   {
     default void onBookmarksLoadingStarted() {}
     default void onBookmarksLoadingFinished() {}
-    default void onBookmarksFileUnsupported(@NonNull Uri uri) {};
-    default void onBookmarksFileDownloadFailed(@NonNull Uri uri, @NonNull String string) {};
-    default void onBookmarksFileImportSuccessful() {};
-    default void onBookmarksFileImportFailed() {};
+    default void onBookmarksFileUnsupported(@NonNull Uri uri) {}
+    default void onBookmarksFileDownloadFailed(@NonNull Uri uri, @NonNull String string) {}
+    default void onBookmarksFileImportSuccessful() {}
+    default void onBookmarksFileImportFailed() {}
   }
 
   public interface BookmarksSortingListener

--- a/android/app/src/main/java/app/organicmaps/editor/EditorFragment.java
+++ b/android/app/src/main/java/app/organicmaps/editor/EditorFragment.java
@@ -7,7 +7,6 @@ import android.text.TextUtils;
 import android.view.LayoutInflater;
 import android.view.View;
 import android.view.ViewGroup;
-import android.view.ViewTreeObserver;
 import android.widget.ImageView;
 import android.widget.TextView;
 

--- a/android/app/src/main/java/app/organicmaps/editor/FeatureCategoryFragment.java
+++ b/android/app/src/main/java/app/organicmaps/editor/FeatureCategoryFragment.java
@@ -21,6 +21,7 @@ import app.organicmaps.util.Language;
 import app.organicmaps.util.Utils;
 
 import java.util.Arrays;
+import java.util.Comparator;
 
 public class FeatureCategoryFragment extends BaseMwmRecyclerFragment<FeatureCategoryAdapter>
 {
@@ -102,8 +103,7 @@ public class FeatureCategoryFragment extends BaseMwmRecyclerFragment<FeatureCate
       categories[i] = new FeatureCategory(creatableTypes[i], localizedType);
     }
 
-    Arrays.sort(categories, (lhs, rhs) ->
-      lhs.getLocalizedTypeName().compareTo(rhs.getLocalizedTypeName()));
+    Arrays.sort(categories, Comparator.comparing(FeatureCategory::getLocalizedTypeName));
 
     return categories;
   }

--- a/android/app/src/main/java/app/organicmaps/editor/OsmLoginFragment.java
+++ b/android/app/src/main/java/app/organicmaps/editor/OsmLoginFragment.java
@@ -11,7 +11,6 @@ import android.widget.TextView;
 
 import androidx.annotation.NonNull;
 import androidx.annotation.Nullable;
-import androidx.annotation.Size;
 
 import app.organicmaps.Framework;
 import app.organicmaps.R;

--- a/android/app/src/main/java/app/organicmaps/editor/PhoneListAdapter.java
+++ b/android/app/src/main/java/app/organicmaps/editor/PhoneListAdapter.java
@@ -38,7 +38,7 @@ public class PhoneListAdapter extends RecyclerView.Adapter<PhoneListAdapter.View
       phonesData.add(p);
     }
 
-    if (phonesData.size() == 0) phonesData.add("");
+    if (phonesData.isEmpty()) phonesData.add("");
   }
 
   @NonNull

--- a/android/app/src/main/java/app/organicmaps/editor/SimpleTimetableAdapter.java
+++ b/android/app/src/main/java/app/organicmaps/editor/SimpleTimetableAdapter.java
@@ -43,7 +43,7 @@ class SimpleTimetableAdapter extends RecyclerView.Adapter<SimpleTimetableAdapter
 
   private final Fragment mFragment;
 
-  private List<Timetable> mItems = new ArrayList<>();
+  private List<Timetable> mItems;
   private Timetable mComplementItem;
   private int mPickingPosition;
 

--- a/android/app/src/main/java/app/organicmaps/location/AndroidNativeProvider.java
+++ b/android/app/src/main/java/app/organicmaps/location/AndroidNativeProvider.java
@@ -60,7 +60,7 @@ class AndroidNativeProvider extends BaseLocationProvider
 
   @NonNull
   private final LocationManager mLocationManager;
-  private Set<String> mProviders;
+  private final Set<String> mProviders;
 
   @NonNull
   final private NativeLocationListener mNativeLocationListener = new NativeLocationListener();

--- a/android/app/src/main/java/app/organicmaps/location/LocationHelper.java
+++ b/android/app/src/main/java/app/organicmaps/location/LocationHelper.java
@@ -56,7 +56,7 @@ public class LocationHelper implements BaseLocationProvider.Listener
   private boolean mActive;
 
   @NonNull
-  private GnssStatusCompat.Callback mGnssStatusCallback = new GnssStatusCompat.Callback()
+  private final GnssStatusCompat.Callback mGnssStatusCallback = new GnssStatusCompat.Callback()
   {
     @Override
     public void onStarted()

--- a/android/app/src/main/java/app/organicmaps/location/RouteSimulationProvider.java
+++ b/android/app/src/main/java/app/organicmaps/location/RouteSimulationProvider.java
@@ -15,7 +15,7 @@ class RouteSimulationProvider extends BaseLocationProvider
   private static final String TAG = RouteSimulationProvider.class.getSimpleName();
   private static final long INTERVAL_MS = 1000;
 
-  private JunctionInfo[] mPoints;
+  private final JunctionInfo[] mPoints;
   private int mCurrentPoint = 0;
   private boolean mActive = false;
 

--- a/android/app/src/main/java/app/organicmaps/maplayer/SearchWheel.java
+++ b/android/app/src/main/java/app/organicmaps/maplayer/SearchWheel.java
@@ -35,7 +35,7 @@ public class SearchWheel implements View.OnClickListener
   private final View.OnClickListener mOnSearchPressedListener;
   @NonNull
   private final View.OnClickListener mOnSearchCanceledListener;
-  private MapButtonsViewModel mMapButtonsViewModel;
+  private final MapButtonsViewModel mMapButtonsViewModel;
 
   private static final long CLOSE_DELAY_MILLIS = 5000L;
   private final Runnable mCloseRunnable = new Runnable() {

--- a/android/app/src/main/java/app/organicmaps/routing/BaseRoutingErrorDialogFragment.java
+++ b/android/app/src/main/java/app/organicmaps/routing/BaseRoutingErrorDialogFragment.java
@@ -7,7 +7,6 @@ import android.graphics.drawable.ColorDrawable;
 import android.os.Bundle;
 import android.view.View;
 import android.view.ViewGroup;
-import android.view.ViewTreeObserver;
 import android.widget.ExpandableListAdapter;
 import android.widget.ExpandableListView;
 import android.widget.TextView;

--- a/android/app/src/main/java/app/organicmaps/search/CategoriesAdapter.java
+++ b/android/app/src/main/java/app/organicmaps/search/CategoriesAdapter.java
@@ -129,14 +129,14 @@ class CategoriesAdapter extends RecyclerView.Adapter<CategoriesAdapter.ViewHolde
   {
     View view;
     ViewHolder viewHolder;
-    switch (viewType)
+    if (viewType == TYPE_CATEGORY)
     {
-      case TYPE_CATEGORY:
-        view = mInflater.inflate(R.layout.item_search_category, parent, false);
-        viewHolder = new ViewHolder(view, (TextView) view);
-        break;
-      default:
-        throw new AssertionError("Unsupported type detected: " + viewType);
+      view = mInflater.inflate(R.layout.item_search_category, parent, false);
+      viewHolder = new ViewHolder(view, (TextView) view);
+    }
+    else
+    {
+      throw new AssertionError("Unsupported type detected: " + viewType);
     }
 
     viewHolder.setupClickListeners();

--- a/android/app/src/main/java/app/organicmaps/search/TabAdapter.java
+++ b/android/app/src/main/java/app/organicmaps/search/TabAdapter.java
@@ -107,7 +107,7 @@ class TabAdapter extends FragmentPagerAdapter
   private final List<Class<? extends Fragment>> mClasses = new ArrayList<>();
   private final SparseArray<Fragment> mFragments = new SparseArray<>();
   private OnTabSelectedListener mTabSelectedListener;
-  private TabLayout mTabs;
+  private final TabLayout mTabs;
   TabAdapter(FragmentManager fragmentManager, ViewPager pager, TabLayout tabs)
   {
     super(fragmentManager);

--- a/android/app/src/main/java/app/organicmaps/settings/StorageItem.java
+++ b/android/app/src/main/java/app/organicmaps/settings/StorageItem.java
@@ -25,7 +25,7 @@ public class StorageItem
   {
     if (o == this)
       return true;
-    if (o == null || !(o instanceof StorageItem))
+    if (!(o instanceof StorageItem))
       return false;
     StorageItem other = (StorageItem) o;
     return mPath.equals(other.mPath);

--- a/android/app/src/main/java/app/organicmaps/util/Utils.java
+++ b/android/app/src/main/java/app/organicmaps/util/Utils.java
@@ -191,7 +191,7 @@ public class Utils
     for (final K key : map.keySet())
     {
       final String keyVal = key + "=" + map.get(key);
-      if (joined.length() > 0)
+      if (!joined.isEmpty())
         joined = TextUtils.join(",", new Object[]{joined, keyVal});
       else
         joined = keyVal;

--- a/android/app/src/main/java/app/organicmaps/util/bottomsheet/MenuBottomSheetFragment.java
+++ b/android/app/src/main/java/app/organicmaps/util/bottomsheet/MenuBottomSheetFragment.java
@@ -74,7 +74,7 @@ public class MenuBottomSheetFragment extends BottomSheetDialogFragment
     if (getArguments() != null)
     {
       String title = getArguments().getString("title");
-      if (title != null && title.length() > 0)
+      if (title != null && !title.isEmpty())
       {
         titleView.setVisibility(View.VISIBLE);
         titleView.setText(title);
@@ -125,7 +125,7 @@ public class MenuBottomSheetFragment extends BottomSheetDialogFragment
       if (getArguments() != null)
       {
         String id = getArguments().getString("id");
-        if (id != null && id.length() > 0)
+        if (id != null && !id.isEmpty())
           mMenuBottomSheetItems = bottomSheetInterface.getMenuBottomSheetItems(id);
       }
     }
@@ -134,7 +134,7 @@ public class MenuBottomSheetFragment extends BottomSheetDialogFragment
       if (getArguments() != null)
       {
         String id = getArguments().getString("id");
-        if (id != null && id.length() > 0)
+        if (id != null && !id.isEmpty())
         {
           mMenuBottomSheetItems = bottomSheetInterfaceWithHeader.getMenuBottomSheetItems(id);
           mHeaderFragment = bottomSheetInterfaceWithHeader.getMenuBottomSheetFragment(id);

--- a/android/app/src/main/java/app/organicmaps/widget/placepage/BookmarkColorDialogFragment.java
+++ b/android/app/src/main/java/app/organicmaps/widget/placepage/BookmarkColorDialogFragment.java
@@ -5,7 +5,6 @@ import android.app.Dialog;
 import android.os.Bundle;
 import android.view.LayoutInflater;
 import android.view.View;
-import android.widget.AdapterView;
 import android.widget.GridView;
 
 import androidx.annotation.NonNull;

--- a/android/app/src/main/java/app/organicmaps/widget/placepage/DirectionFragment.java
+++ b/android/app/src/main/java/app/organicmaps/widget/placepage/DirectionFragment.java
@@ -5,7 +5,6 @@ import android.os.Bundle;
 import android.view.LayoutInflater;
 import android.view.View;
 import android.view.ViewGroup;
-import android.view.ViewTreeObserver;
 import android.widget.TextView;
 
 import androidx.annotation.NonNull;

--- a/android/app/src/main/java/app/organicmaps/widget/placepage/sections/PlacePhoneAdapter.java
+++ b/android/app/src/main/java/app/organicmaps/widget/placepage/sections/PlacePhoneAdapter.java
@@ -19,7 +19,7 @@ import java.util.ArrayList;
 public class PlacePhoneAdapter extends RecyclerView.Adapter<PlacePhoneAdapter.ViewHolder>
 {
 
-  private ArrayList<String> mPhoneData = new ArrayList<>();
+  private final ArrayList<String> mPhoneData = new ArrayList<>();
 
   public PlacePhoneAdapter() {}
 


### PR DESCRIPTION
This PR fixes some Android Studio warnings:
- Remove unused imports
- Replace StringBuilder with String
- Use lambda
- Replace `.size == 0` by `isEmpty()`
- Remove useless semicolons
- Remove redundant type
- Use final on variables when possible