### PR TITLE
[Bookmarks] Add `areAllCategoriesEmpty` method to the bookmarks manager

### DIFF
--- a/iphone/CoreApi/CoreApi/Bookmarks/MWMBookmarkGroup.m
+++ b/iphone/CoreApi/CoreApi/Bookmarks/MWMBookmarkGroup.m
@@ -53,7 +53,7 @@
 }
 
 - (BOOL)isEmpty {
-  return ![self.manager isCategoryNotEmpty:self.categoryId];
+  return [self.manager isCategoryEmpty:self.categoryId];
 }
 
 - (BOOL)hasDescription {

--- a/iphone/CoreApi/CoreApi/Bookmarks/MWMBookmarksManager.h
+++ b/iphone/CoreApi/CoreApi/Bookmarks/MWMBookmarksManager.h
@@ -37,6 +37,7 @@ NS_SWIFT_NAME(BookmarksManager)
 - (BOOL)areBookmarksLoaded;
 - (void)loadBookmarks;
 
+- (BOOL)areAllCategoriesEmpty;
 - (BOOL)isCategoryNotEmpty:(MWMMarkGroupID)groupId;
 - (void)prepareForSearch:(MWMMarkGroupID)groupId;
 - (NSString *)getCategoryName:(MWMMarkGroupID)groupId;

--- a/iphone/CoreApi/CoreApi/Bookmarks/MWMBookmarksManager.h
+++ b/iphone/CoreApi/CoreApi/Bookmarks/MWMBookmarksManager.h
@@ -38,7 +38,7 @@ NS_SWIFT_NAME(BookmarksManager)
 - (void)loadBookmarks;
 
 - (BOOL)areAllCategoriesEmpty;
-- (BOOL)isCategoryNotEmpty:(MWMMarkGroupID)groupId;
+- (BOOL)isCategoryEmpty:(MWMMarkGroupID)groupId;
 - (void)prepareForSearch:(MWMMarkGroupID)groupId;
 - (NSString *)getCategoryName:(MWMMarkGroupID)groupId;
 - (uint64_t)getCategoryMarksCount:(MWMMarkGroupID)groupId;

--- a/iphone/CoreApi/CoreApi/Bookmarks/MWMBookmarksManager.mm
+++ b/iphone/CoreApi/CoreApi/Bookmarks/MWMBookmarksManager.mm
@@ -194,6 +194,11 @@ static BookmarkManager::SortingType convertSortingTypeToCore(MWMBookmarksSorting
 
 #pragma mark - Categories
 
+- (BOOL)areAllCategoriesEmpty
+{
+  return self.bm.AreAllCategoriesEmpty();
+}
+
 - (BOOL)isCategoryNotEmpty:(MWMMarkGroupID)groupId {
   return self.bm.HasBmCategory(groupId) &&
   (self.bm.GetUserMarkIds(groupId).size() + self.bm.GetTrackIds(groupId).size());

--- a/iphone/CoreApi/CoreApi/Bookmarks/MWMBookmarksManager.mm
+++ b/iphone/CoreApi/CoreApi/Bookmarks/MWMBookmarksManager.mm
@@ -199,9 +199,8 @@ static BookmarkManager::SortingType convertSortingTypeToCore(MWMBookmarksSorting
   return self.bm.AreAllCategoriesEmpty();
 }
 
-- (BOOL)isCategoryNotEmpty:(MWMMarkGroupID)groupId {
-  return self.bm.HasBmCategory(groupId) &&
-  (self.bm.GetUserMarkIds(groupId).size() + self.bm.GetTrackIds(groupId).size());
+- (BOOL)isCategoryEmpty:(MWMMarkGroupID)groupId {
+  return self.bm.HasBmCategory(groupId) && self.bm.IsCategoryEmpty(groupId);
 }
 
 - (void)prepareForSearch:(MWMMarkGroupID)groupId {

--- a/map/bookmark_manager.cpp
+++ b/map/bookmark_manager.cpp
@@ -2790,6 +2790,17 @@ void BookmarkManager::PrepareAllFilesForSharing(SharingHandler && handler)
   PrepareFileForSharing(decltype(m_unsortedBmGroupsIdList){m_unsortedBmGroupsIdList}, std::move(handler));
 }
 
+bool BookmarkManager::AreAllCategoriesEmpty() const
+{
+  CHECK_THREAD_CHECKER(m_threadChecker, ());
+  for (auto const & c : m_categories)
+  {
+    if (!c.second->IsEmpty())
+      return false;
+  }
+  return true;
+}
+
 bool BookmarkManager::IsCategoryEmpty(kml::MarkGroupId categoryId) const
 {
   CHECK_THREAD_CHECKER(m_threadChecker, ());

--- a/map/bookmark_manager.hpp
+++ b/map/bookmark_manager.hpp
@@ -346,6 +346,7 @@ public:
   void PrepareFileForSharing(kml::GroupIdCollection && categoriesIds, SharingHandler && handler);
   void PrepareAllFilesForSharing(SharingHandler && handler);
 
+  bool AreAllCategoriesEmpty() const;
   bool IsCategoryEmpty(kml::MarkGroupId categoryId) const;
 
   bool IsUsedCategoryName(std::string const & name) const;


### PR DESCRIPTION
This method is needed to implement the following features:
- hide the `export all` button (https://github.com/organicmaps/organicmaps/issues/8055)
- disable the `backup` button into the icloud sync enabling alert

Also, I've made a small refactoring of the `isCategoryNotEmpty` method to use the already `IsCategoryEmpty` which checks the `empty` (rather than the `cont`).