### PR TITLE
Revert "[editor] Fixed bug overwriting existing features"

### DIFF
--- a/editor/changeset_wrapper.cpp
+++ b/editor/changeset_wrapper.cpp
@@ -247,11 +247,6 @@ void ChangesetWrapper::Delete(editor::XMLFeature node)
   m_deleted_types[GetTypeForFeature(node)]++;
 }
 
-void ChangesetWrapper::AddChangesetTag(std::string key, std::string value)
-{
-  m_changesetComments.emplace(std::move(key), std::move(value));
-}
-
 std::string ChangesetWrapper::TypeCountToString(TypeCount const & typeCount)
 {
   if (typeCount.empty())

--- a/editor/changeset_wrapper.hpp
+++ b/editor/changeset_wrapper.hpp
@@ -49,9 +49,6 @@ public:
   /// Throws exceptions from above list.
   void Delete(editor::XMLFeature node);
 
-  /// Add a tag to the changeset
-  void AddChangesetTag(std::string key, std::string value);
-
   /// Allows to see exception details in OSM changesets for easier debugging.
   void SetErrorDescription(std::string const & error);
 

--- a/editor/osm_editor.cpp
+++ b/editor/osm_editor.cpp
@@ -646,10 +646,8 @@ void Editor::UploadChanges(string const & oauthToken, ChangesetTags tags,
               }
               else
               {
-                LOG(LDEBUG, ("Create case: uploading new feature", feature));
-                // There is another node nearby, but it is saver to upload a new node (#2298).
-                changeset.AddChangesetTag("info:feature_close_by", "yes");
-                changeset.Create(feature);
+                LOG(LDEBUG, ("Create case: uploading patched feature", osmFeature));
+                changeset.Modify(osmFeature);
               }
             }
             catch (ChangesetWrapper::OsmObjectWasDeletedException const &)


### PR DESCRIPTION
This doesn't work well in many cases:
https://github.com/organicmaps/organicmaps/issues/8125

This reverts commit 3c9c54eda61d84609bdcf5f298d0abb26e3f4281.

Reopens #2298, closes #8125, reverts #7853