### PR TITLE
Fix Vulkan Validation issues on Android

### DIFF
--- a/android/app/src/main/cpp/app/organicmaps/vulkan/android_vulkan_context_factory.cpp
+++ b/android/app/src/main/cpp/app/organicmaps/vulkan/android_vulkan_context_factory.cpp
@@ -118,6 +118,20 @@ AndroidVulkanContextFactory::AndroidVulkanContextFactory(uint32_t appVersionCode
   instanceCreateInfo.enabledLayerCount = m_layers->GetInstanceLayersCount();
   instanceCreateInfo.ppEnabledLayerNames = m_layers->GetInstanceLayers();
 
+  // Enable extra validation features.
+  VkValidationFeaturesEXT validationFeatures = {};
+  const VkValidationFeatureEnableEXT validationFeaturesEnabled[] = {
+      VK_VALIDATION_FEATURE_ENABLE_SYNCHRONIZATION_VALIDATION_EXT};
+  if (m_layers->IsValidationFeaturesEnabled())
+  {
+    validationFeatures.sType = VK_STRUCTURE_TYPE_VALIDATION_FEATURES_EXT;
+    validationFeatures.pNext = nullptr;
+    validationFeatures.enabledValidationFeatureCount = ARRAY_SIZE(validationFeaturesEnabled),
+    validationFeatures.pEnabledValidationFeatures = validationFeaturesEnabled;
+
+    instanceCreateInfo.pNext = &validationFeatures;
+  }
+
   VkResult statusCode;
   statusCode = vkCreateInstance(&instanceCreateInfo, nullptr, &m_vulkanInstance);
   if (statusCode != VK_SUCCESS)

--- a/drape/vulkan/vulkan_base_context.cpp
+++ b/drape/vulkan/vulkan_base_context.cpp
@@ -1049,23 +1049,43 @@ VkRenderPass VulkanBaseContext::CreateRenderPass(uint32_t attachmentsCount, Atta
   subpassDescription.pPreserveAttachments = nullptr;
   subpassDescription.pResolveAttachments = nullptr;
 
-  std::array<VkSubpassDependency, 2> dependencies = {};
+  std::array<VkSubpassDependency, 4> dependencies = {};
 
+  // Write-after-write for depth/stencil attachment.
   dependencies[0].srcSubpass = VK_SUBPASS_EXTERNAL;
   dependencies[0].dstSubpass = 0;
-  dependencies[0].srcStageMask = VK_PIPELINE_STAGE_BOTTOM_OF_PIPE_BIT;
-  dependencies[0].dstStageMask = VK_PIPELINE_STAGE_COLOR_ATTACHMENT_OUTPUT_BIT;
-  dependencies[0].srcAccessMask = VK_ACCESS_MEMORY_READ_BIT;
-  dependencies[0].dstAccessMask = VK_ACCESS_COLOR_ATTACHMENT_READ_BIT | VK_ACCESS_COLOR_ATTACHMENT_WRITE_BIT;
-  dependencies[0].dependencyFlags = VK_DEPENDENCY_BY_REGION_BIT;
+  dependencies[0].srcStageMask = VK_PIPELINE_STAGE_EARLY_FRAGMENT_TESTS_BIT | VK_PIPELINE_STAGE_LATE_FRAGMENT_TESTS_BIT;
+  dependencies[0].dstStageMask = VK_PIPELINE_STAGE_EARLY_FRAGMENT_TESTS_BIT | VK_PIPELINE_STAGE_LATE_FRAGMENT_TESTS_BIT;
+  dependencies[0].srcAccessMask = 0;
+  dependencies[0].dstAccessMask = VK_ACCESS_DEPTH_STENCIL_ATTACHMENT_WRITE_BIT;
+  dependencies[0].dependencyFlags = 0;
 
-  dependencies[1].srcSubpass = 0;
-  dependencies[1].dstSubpass = VK_SUBPASS_EXTERNAL;
+  // Write-after-write for color attachment.
+  dependencies[1].srcSubpass = VK_SUBPASS_EXTERNAL;
+  dependencies[1].dstSubpass = 0;
   dependencies[1].srcStageMask = VK_PIPELINE_STAGE_COLOR_ATTACHMENT_OUTPUT_BIT;
-  dependencies[1].dstStageMask = VK_PIPELINE_STAGE_BOTTOM_OF_PIPE_BIT;
-  dependencies[1].srcAccessMask = VK_ACCESS_COLOR_ATTACHMENT_READ_BIT | VK_ACCESS_COLOR_ATTACHMENT_WRITE_BIT;
-  dependencies[1].dstAccessMask = VK_ACCESS_MEMORY_READ_BIT;
-  dependencies[1].dependencyFlags = VK_DEPENDENCY_BY_REGION_BIT;
+  dependencies[1].dstStageMask = VK_PIPELINE_STAGE_COLOR_ATTACHMENT_OUTPUT_BIT;
+  dependencies[1].srcAccessMask = 0;
+  dependencies[1].dstAccessMask = VK_ACCESS_COLOR_ATTACHMENT_WRITE_BIT;
+  dependencies[1].dependencyFlags = 0;
+
+  // Write-after-read for color attachment.
+  dependencies[2].srcSubpass = VK_SUBPASS_EXTERNAL;
+  dependencies[2].dstSubpass = 0;
+  dependencies[2].srcStageMask = VK_PIPELINE_STAGE_BOTTOM_OF_PIPE_BIT;
+  dependencies[2].dstStageMask = VK_PIPELINE_STAGE_COLOR_ATTACHMENT_OUTPUT_BIT;
+  dependencies[2].srcAccessMask = VK_ACCESS_MEMORY_READ_BIT;
+  dependencies[2].dstAccessMask = VK_ACCESS_COLOR_ATTACHMENT_READ_BIT | VK_ACCESS_COLOR_ATTACHMENT_WRITE_BIT;
+  dependencies[2].dependencyFlags = VK_DEPENDENCY_BY_REGION_BIT;
+
+  // Read-after-write for color attachment.
+  dependencies[3].srcSubpass = 0;
+  dependencies[3].dstSubpass = VK_SUBPASS_EXTERNAL;
+  dependencies[3].srcStageMask = VK_PIPELINE_STAGE_COLOR_ATTACHMENT_OUTPUT_BIT;
+  dependencies[3].dstStageMask = VK_PIPELINE_STAGE_BOTTOM_OF_PIPE_BIT;
+  dependencies[3].srcAccessMask = VK_ACCESS_COLOR_ATTACHMENT_READ_BIT | VK_ACCESS_COLOR_ATTACHMENT_WRITE_BIT;
+  dependencies[3].dstAccessMask = VK_ACCESS_MEMORY_READ_BIT;
+  dependencies[3].dependencyFlags = VK_DEPENDENCY_BY_REGION_BIT;
 
   VkRenderPassCreateInfo renderPassInfo = {};
   renderPassInfo.sType = VK_STRUCTURE_TYPE_RENDER_PASS_CREATE_INFO;

--- a/drape/vulkan/vulkan_base_context.cpp
+++ b/drape/vulkan/vulkan_base_context.cpp
@@ -16,26 +16,6 @@ namespace
 {
 uint32_t constexpr kDefaultStagingBufferSizeInBytes = 3 * 1024 * 1024;
 
-VkImageMemoryBarrier PostRenderBarrier(VkImage image)
-{
-  VkImageMemoryBarrier imageMemoryBarrier = {};
-  imageMemoryBarrier.sType = VK_STRUCTURE_TYPE_IMAGE_MEMORY_BARRIER;
-  imageMemoryBarrier.pNext = nullptr;
-  imageMemoryBarrier.srcAccessMask = VK_ACCESS_COLOR_ATTACHMENT_WRITE_BIT;
-  imageMemoryBarrier.dstAccessMask = VK_ACCESS_SHADER_READ_BIT;
-  imageMemoryBarrier.oldLayout = VK_IMAGE_LAYOUT_COLOR_ATTACHMENT_OPTIMAL;
-  imageMemoryBarrier.newLayout = VK_IMAGE_LAYOUT_SHADER_READ_ONLY_OPTIMAL;
-  imageMemoryBarrier.image = image;
-  imageMemoryBarrier.srcQueueFamilyIndex = VK_QUEUE_FAMILY_IGNORED;
-  imageMemoryBarrier.dstQueueFamilyIndex = VK_QUEUE_FAMILY_IGNORED;
-  imageMemoryBarrier.subresourceRange.aspectMask = VK_IMAGE_ASPECT_COLOR_BIT;
-  imageMemoryBarrier.subresourceRange.baseMipLevel = 0;
-  imageMemoryBarrier.subresourceRange.levelCount = 1;
-  imageMemoryBarrier.subresourceRange.baseArrayLayer = 0;
-  imageMemoryBarrier.subresourceRange.layerCount = 1;
-  return imageMemoryBarrier;
-}
-
 uint16_t PackAttachmentsOperations(VulkanBaseContext::AttachmentsOperations const & operations)
 {
   uint16_t result = 0;
@@ -307,11 +287,12 @@ void VulkanBaseContext::SetFramebuffer(ref_ptr<dp::BaseFramebuffer> framebuffer)
     {
       ref_ptr<Framebuffer> fb = m_currentFramebuffer;
       ref_ptr<VulkanTexture> tex = fb->GetTexture()->GetHardwareTexture();
-      VkImageMemoryBarrier imageBarrier = PostRenderBarrier(tex->GetImage());
-      vkCmdPipelineBarrier(m_renderingCommandBuffers[m_inflightFrameIndex],
-                           VK_PIPELINE_STAGE_COLOR_ATTACHMENT_OUTPUT_BIT,
-                           VK_PIPELINE_STAGE_FRAGMENT_SHADER_BIT, 0, 0,
-                           nullptr, 0, nullptr, 1, &imageBarrier);
+
+      // Allow to use framebuffer in the fragment shader in the next pass.
+      tex->MakeImageLayoutTransition(m_renderingCommandBuffers[m_inflightFrameIndex],
+                                     VK_IMAGE_LAYOUT_SHADER_READ_ONLY_OPTIMAL,
+                                     VK_PIPELINE_STAGE_COLOR_ATTACHMENT_OUTPUT_BIT,
+                                     VK_PIPELINE_STAGE_FRAGMENT_SHADER_BIT);
     }
   }
 
@@ -451,6 +432,51 @@ void VulkanBaseContext::ApplyFramebuffer(std::string const & framebufferLabel)
       fbData.m_framebuffers.resize(1);
       CHECK_VK_CALL(vkCreateFramebuffer(m_device, &frameBufferCreateInfo, nullptr, &fbData.m_framebuffers[0]));
     }
+  }
+
+  // Make transitions for the current color and depth-stencil attachments.
+  if (m_currentFramebuffer != nullptr)
+  {
+    ref_ptr<dp::Framebuffer> framebuffer = m_currentFramebuffer;
+    ref_ptr<VulkanTexture> tex = framebuffer->GetTexture()->GetHardwareTexture();
+    tex->MakeImageLayoutTransition(m_renderingCommandBuffers[m_inflightFrameIndex],
+                                   VK_IMAGE_LAYOUT_COLOR_ATTACHMENT_OPTIMAL,
+                                   VK_PIPELINE_STAGE_COLOR_ATTACHMENT_OUTPUT_BIT,
+                                   VK_PIPELINE_STAGE_FRAGMENT_SHADER_BIT);
+    if (auto ds = framebuffer->GetDepthStencilRef())
+    {
+      ref_ptr<VulkanTexture> dsTex = ds->GetTexture()->GetHardwareTexture();
+      dsTex->MakeImageLayoutTransition(m_renderingCommandBuffers[m_inflightFrameIndex],
+                                       VK_IMAGE_LAYOUT_DEPTH_STENCIL_ATTACHMENT_OPTIMAL,
+                                       VK_PIPELINE_STAGE_LATE_FRAGMENT_TESTS_BIT | VK_PIPELINE_STAGE_EARLY_FRAGMENT_TESTS_BIT,
+                                       VK_PIPELINE_STAGE_TOP_OF_PIPE_BIT | VK_PIPELINE_STAGE_EARLY_FRAGMENT_TESTS_BIT);
+    }
+  }
+  else
+  {
+    VkImageMemoryBarrier imageMemoryBarrier = {};
+    imageMemoryBarrier.sType = VK_STRUCTURE_TYPE_IMAGE_MEMORY_BARRIER;
+    imageMemoryBarrier.pNext = nullptr;
+    imageMemoryBarrier.srcAccessMask = VK_ACCESS_COLOR_ATTACHMENT_WRITE_BIT;
+    imageMemoryBarrier.dstAccessMask = VK_ACCESS_SHADER_READ_BIT | VK_ACCESS_INPUT_ATTACHMENT_READ_BIT;
+    imageMemoryBarrier.oldLayout = VK_IMAGE_LAYOUT_UNDEFINED;
+    imageMemoryBarrier.newLayout = VK_IMAGE_LAYOUT_COLOR_ATTACHMENT_OPTIMAL;
+    imageMemoryBarrier.image = m_swapchainImages[m_imageIndex];
+    imageMemoryBarrier.srcQueueFamilyIndex = VK_QUEUE_FAMILY_IGNORED;
+    imageMemoryBarrier.dstQueueFamilyIndex = VK_QUEUE_FAMILY_IGNORED;
+    imageMemoryBarrier.subresourceRange.aspectMask = VK_IMAGE_ASPECT_COLOR_BIT;
+    imageMemoryBarrier.subresourceRange.baseMipLevel = 0;
+    imageMemoryBarrier.subresourceRange.levelCount = VK_REMAINING_MIP_LEVELS;
+    imageMemoryBarrier.subresourceRange.baseArrayLayer = 0;
+    imageMemoryBarrier.subresourceRange.layerCount = VK_REMAINING_ARRAY_LAYERS;
+    vkCmdPipelineBarrier(m_renderingCommandBuffers[m_inflightFrameIndex], 
+                         VK_PIPELINE_STAGE_COLOR_ATTACHMENT_OUTPUT_BIT, VK_PIPELINE_STAGE_FRAGMENT_SHADER_BIT, 0, 0,
+                         nullptr, 0, nullptr, 1, &imageMemoryBarrier);
+
+    m_depthTexture->MakeImageLayoutTransition(m_renderingCommandBuffers[m_inflightFrameIndex],
+                                              VK_IMAGE_LAYOUT_DEPTH_STENCIL_ATTACHMENT_OPTIMAL,
+                                              VK_PIPELINE_STAGE_LATE_FRAGMENT_TESTS_BIT | VK_PIPELINE_STAGE_EARLY_FRAGMENT_TESTS_BIT,
+                                              VK_PIPELINE_STAGE_TOP_OF_PIPE_BIT | VK_PIPELINE_STAGE_EARLY_FRAGMENT_TESTS_BIT);
   }
 
   m_pipelineKey.m_renderPass = fbData.m_renderPass;
@@ -1051,7 +1077,7 @@ VkRenderPass VulkanBaseContext::CreateRenderPass(uint32_t attachmentsCount, Atta
 
   std::array<VkSubpassDependency, 4> dependencies = {};
 
-  // Write-after-write for depth/stencil attachment.
+  // Write-after-write for depth/stencil attachment (begin render pass).
   dependencies[0].srcSubpass = VK_SUBPASS_EXTERNAL;
   dependencies[0].dstSubpass = 0;
   dependencies[0].srcStageMask = VK_PIPELINE_STAGE_EARLY_FRAGMENT_TESTS_BIT | VK_PIPELINE_STAGE_LATE_FRAGMENT_TESTS_BIT;
@@ -1060,7 +1086,7 @@ VkRenderPass VulkanBaseContext::CreateRenderPass(uint32_t attachmentsCount, Atta
   dependencies[0].dstAccessMask = VK_ACCESS_DEPTH_STENCIL_ATTACHMENT_WRITE_BIT;
   dependencies[0].dependencyFlags = 0;
 
-  // Write-after-write for color attachment.
+  // Write-after-write for color attachment (begin render pass).
   dependencies[1].srcSubpass = VK_SUBPASS_EXTERNAL;
   dependencies[1].dstSubpass = 0;
   dependencies[1].srcStageMask = VK_PIPELINE_STAGE_COLOR_ATTACHMENT_OUTPUT_BIT;
@@ -1069,23 +1095,26 @@ VkRenderPass VulkanBaseContext::CreateRenderPass(uint32_t attachmentsCount, Atta
   dependencies[1].dstAccessMask = VK_ACCESS_COLOR_ATTACHMENT_WRITE_BIT;
   dependencies[1].dependencyFlags = 0;
 
-  // Write-after-read for color attachment.
-  dependencies[2].srcSubpass = VK_SUBPASS_EXTERNAL;
-  dependencies[2].dstSubpass = 0;
-  dependencies[2].srcStageMask = VK_PIPELINE_STAGE_BOTTOM_OF_PIPE_BIT;
-  dependencies[2].dstStageMask = VK_PIPELINE_STAGE_COLOR_ATTACHMENT_OUTPUT_BIT;
-  dependencies[2].srcAccessMask = VK_ACCESS_MEMORY_READ_BIT;
-  dependencies[2].dstAccessMask = VK_ACCESS_COLOR_ATTACHMENT_READ_BIT | VK_ACCESS_COLOR_ATTACHMENT_WRITE_BIT;
+  // Read-after-write and write-after-write for color attachment (end render pass).
+  dependencies[2].srcSubpass = 0;
+  dependencies[2].dstSubpass = VK_SUBPASS_EXTERNAL;
+  dependencies[2].srcStageMask = VK_PIPELINE_STAGE_COLOR_ATTACHMENT_OUTPUT_BIT;
+  dependencies[2].dstStageMask = VK_PIPELINE_STAGE_BOTTOM_OF_PIPE_BIT;
+  dependencies[2].srcAccessMask = VK_ACCESS_COLOR_ATTACHMENT_READ_BIT | 
+                                  VK_ACCESS_COLOR_ATTACHMENT_WRITE_BIT;
+  dependencies[2].dstAccessMask = VK_ACCESS_MEMORY_READ_BIT;
   dependencies[2].dependencyFlags = VK_DEPENDENCY_BY_REGION_BIT;
 
-  // Read-after-write for color attachment.
+  // Write-after-write for depth attachment (end render pass).
+  // Write-after-write happens because of layout transition to the final layout.
   dependencies[3].srcSubpass = 0;
   dependencies[3].dstSubpass = VK_SUBPASS_EXTERNAL;
-  dependencies[3].srcStageMask = VK_PIPELINE_STAGE_COLOR_ATTACHMENT_OUTPUT_BIT;
+  dependencies[3].srcStageMask = VK_PIPELINE_STAGE_EARLY_FRAGMENT_TESTS_BIT | 
+                                 VK_PIPELINE_STAGE_LATE_FRAGMENT_TESTS_BIT;
   dependencies[3].dstStageMask = VK_PIPELINE_STAGE_BOTTOM_OF_PIPE_BIT;
-  dependencies[3].srcAccessMask = VK_ACCESS_COLOR_ATTACHMENT_READ_BIT | VK_ACCESS_COLOR_ATTACHMENT_WRITE_BIT;
-  dependencies[3].dstAccessMask = VK_ACCESS_MEMORY_READ_BIT;
-  dependencies[3].dependencyFlags = VK_DEPENDENCY_BY_REGION_BIT;
+  dependencies[3].srcAccessMask = VK_ACCESS_DEPTH_STENCIL_ATTACHMENT_WRITE_BIT;
+  dependencies[3].dstAccessMask = 0;
+  dependencies[3].dependencyFlags = 0;
 
   VkRenderPassCreateInfo renderPassInfo = {};
   renderPassInfo.sType = VK_STRUCTURE_TYPE_RENDER_PASS_CREATE_INFO;

--- a/drape/vulkan/vulkan_layers.hpp
+++ b/drape/vulkan/vulkan_layers.hpp
@@ -29,6 +29,8 @@ public:
   uint32_t GetDeviceExtensionsCount() const;
   char const * const * GetDeviceExtensions() const;
 
+  bool IsValidationFeaturesEnabled() const;
+
 private:
   bool const m_enableDiagnostics;
 
@@ -43,6 +45,8 @@ private:
   PFN_vkCreateDebugReportCallbackEXT m_vkCreateDebugReportCallbackEXT = nullptr;
   PFN_vkDestroyDebugReportCallbackEXT m_vkDestroyDebugReportCallbackEXT = nullptr;
   PFN_vkDebugReportMessageEXT m_vkDebugReportMessageEXT = nullptr;
+
+  bool m_validationFeaturesEnabled = false;
 };
 }  // namespace vulkan
 }  // namespace dp

--- a/drape/vulkan/vulkan_texture.hpp
+++ b/drape/vulkan/vulkan_texture.hpp
@@ -39,9 +39,16 @@ public:
   VkImage GetImage() const { return m_textureObject.m_image; }
   SamplerKey GetSamplerKey() const;
 
+  void MakeImageLayoutTransition(VkCommandBuffer commandBuffer,
+                                 VkImageLayout newLayout,
+                                 VkPipelineStageFlags srcStageMask,
+                                 VkPipelineStageFlags dstStageMask) const;
+
 private:
   ref_ptr<VulkanObjectManager> m_objectManager;
   VulkanObject m_textureObject;
+  mutable VkImageLayout m_currentLayout = VK_IMAGE_LAYOUT_UNDEFINED;
+  VkImageAspectFlags m_aspectFlags = VK_IMAGE_ASPECT_COLOR_BIT;
   mutable drape_ptr<VulkanStagingBuffer> m_creationStagingBuffer;
   uint32_t m_reservationId = 0;
   bool m_isMutable = false;

--- a/shaders/vulkan_program_params.cpp
+++ b/shaders/vulkan_program_params.cpp
@@ -148,7 +148,7 @@ void VulkanProgramParamsSetter::ApplyBytes(ref_ptr<dp::vulkan::VulkanBaseContext
   dp::vulkan::ParamDescriptor descriptor;
   descriptor.m_type = dp::vulkan::ParamDescriptor::Type::DynamicUniformBuffer;
   descriptor.m_bufferDescriptor.buffer = ub[index].m_object.m_buffer;
-  descriptor.m_bufferDescriptor.range = VK_WHOLE_SIZE;
+  descriptor.m_bufferDescriptor.range = alignedSize;
   descriptor.m_bufferDynamicOffset = alignedOffset;
   descriptor.m_id = static_cast<uint32_t>(index);
   context->ApplyParamDescriptor(std::move(descriptor));


### PR DESCRIPTION
Added extended validation (`VK_VALIDATION_FEATURE_ENABLE_SYNCHRONIZATION_VALIDATION_EXT`) - https://registry.khronos.org/vulkan/specs/1.3-extensions/man/html/VkValidationFeatureEnableEXT.html

The following validation errors are fixed:
1.
```
OMcore                  app.organicmaps.debug                E  vulkan/vulkan_layers.cpp:162 DebugReportCallbackImpl(): Vulkan Diagnostics [ Validation ] [ COMMAND_BUFFER ] [OBJ: 12970367442591508160 LOC: 1611758864 ]: Validation Error: [ VUID-vkCmdBindDescriptorSets-pDescriptorSets-06715 ] Object 0: handle = 0xb400007815f566c0, type = VK_OBJECT_TYPE_COMMAND_BUFFER; Object 1: handle = 0x4a581c0000000195, type = VK_OBJECT_TYPE_DESCRIPTOR_SET; Object 2: handle = 0xa7baa9000000011c, type = VK_OBJECT_TYPE_BUFFER; | MessageID = 0x60117d10 | vkCmdBindDescriptorSets(): pDynamicOffsets[0] is 256, but must be zero since the buffer descriptor's range is VK_WHOLE_SIZE in descriptorSet #0 binding #0 descriptor[0]. The Vulkan spec states: For each dynamic uniform or storage buffer binding in pDescriptorSets, if the range was set with VK_WHOLE_SIZE then pDynamicOffsets which corresponds to the descriptor binding must be 0 (https://www.khronos.org/registry/vulkan/specs/1.3-extensions/html/vkspec.html#VUID-vkCmdBindDescriptorSets-pDescriptorSets-06715)
```

2.
```
OMcore                  app.organicmaps.debug                E  vulkan/vulkan_layers.cpp:170 DebugReportCallbackImpl(): Vulkan Diagnostics [ Validation ] [ RENDER_PASS ] [OBJ: 684740657406804014 LOC: 1544472022 ]: Validation Error: [ SYNC-HAZARD-WRITE-AFTER-WRITE ] Object 0: handle = 0x980b0000000002e, type = VK_OBJECT_TYPE_RENDER_PASS; | MessageID = 0x5c0ec5d6 | vkCmdBeginRenderPass():  Hazard WRITE_AFTER_WRITE vs. layout transition in subpass 0 for attachment 1 aspect depth during load with loadOp VK_ATTACHMENT_LOAD_OP_CLEAR.
```

3.
```
OMcore                  app.organicmaps.debug                I  vulkan/vulkan_layers.cpp:170 DebugReportCallbackImpl(): Vulkan Diagnostics [ Validation ] [ BUFFER ] [OBJ: 15462946592855688298 LOC: 1544472022 ]: Validation Error: [ SYNC-HAZARD-WRITE-AFTER-WRITE ] Object 0: handle = 0xd6976c000000046a, type = VK_OBJECT_TYPE_BUFFER; | MessageID = 0x5c0ec5d6 | vkCmdCopyBuffer():  Hazard WRITE_AFTER_WRITE for dstBuffer VkBuffer 0xd6976c000000046a[], region 0. Access info (usage: SYNC_COPY_TRANSFER_WRITE, prior_usage: SYNC_COPY_TRANSFER_WRITE, write_barriers: SYNC_INDEX_INPUT_INDEX_READ|SYNC_VERTEX_ATTRIBUTE_INPUT_VERTEX_ATTRIBUTE_READ, command: vkCmdCopyBuffer, seq_no: 13, reset_no: 1011).
```

4.
```
OMcore                  app.organicmaps.debug                I  vulkan/vulkan_layers.cpp:170 DebugReportCallbackImpl(): Vulkan Diagnostics [ Validation ] [ QUEUE ] [OBJ: 12970367442600201344 LOC: 1544472022 ]: Validation Error: [ SYNC-HAZARD-WRITE-AFTER-WRITE ] Object 0: handle = 0xb4000078167a0c80, type = VK_OBJECT_TYPE_QUEUE; | MessageID = 0x5c0ec5d6 | vkQueueSubmit():  Hazard WRITE_AFTER_WRITE for entry 0, VkCommandBuffer 0xb4000078167a1b80[], Submitted access info (submitted_usage: SYNC_COPY_TRANSFER_WRITE, command: vkCmdCopyBuffer, seq_no: 1, reset_no: 1011). Access info (prior_usage: SYNC_COPY_TRANSFER_WRITE, write_barriers: SYNC_INDEX_INPUT_INDEX_READ|SYNC_VERTEX_ATTRIBUTE_INPUT_VERTEX_ATTRIBUTE_READ, queue: VkQueue 0xb4000078167a0c80[], submit: 2020, batch: 0, batch_tag: 122569, command: vkCmdCopyBuffer, command_buffer: VkCommandBuffer 0xb4000078167a1900[], seq_no: 1, reset_no: 1011).
```