### PR TITLE
[ios] Remove OSM login titles capitalization

### DIFF
--- a/iphone/Maps/Classes/CustomViews/Login/MWMAuthorizationLoginViewController.mm
+++ b/iphone/Maps/Classes/CustomViews/Login/MWMAuthorizationLoginViewController.mm
@@ -57,7 +57,7 @@ using namespace osm_auth_ios;
 - (void)configHaveAuth
 {
   NSString * osmUserName = OSMUserName();
-  self.title = osmUserName.length > 0 ? osmUserName : L(@"osm_account").capitalizedString;
+  self.title = osmUserName.length > 0 ? osmUserName : L(@"osm_account");
   self.authView.hidden = YES;
   self.accountView.hidden = NO;
 
@@ -67,7 +67,7 @@ using namespace osm_auth_ios;
 
 - (void)configNoAuth
 {
-  self.title = L(@"profile").capitalizedString;
+  self.title = L(@"profile");
   self.authView.hidden = NO;
   self.accountView.hidden = YES;
 }

--- a/iphone/Maps/Classes/CustomViews/Login/MWMAuthorizationOSMLoginViewController.mm
+++ b/iphone/Maps/Classes/CustomViews/Login/MWMAuthorizationOSMLoginViewController.mm
@@ -29,7 +29,7 @@ using namespace osm;
 - (void)viewDidLoad
 {
   [super viewDidLoad];
-  self.title = L(@"osm_account").capitalizedString;
+  self.title = L(@"osm_account");
   [self checkConnection];
   [self stopSpinner];
 }


### PR DESCRIPTION
This PR fixes https://github.com/organicmaps/organicmaps/issues/8136 only for iOS:

- Remove capitalizedString for “OSM account” title;
- Remove capitalizedString for “OpenStreetMap Profile” title.
![Simulator Screenshot - iPhone 15 Pro Max - 2024-05-11 at 22 25 37](https://github.com/organicmaps/organicmaps/assets/4352168/236a3d3d-c973-43d1-86af-bce63245bd16)
![Simulator Screenshot - iPhone 15 Pro Max - 2024-05-11 at 22 25 42](https://github.com/organicmaps/organicmaps/assets/4352168/99662dc2-6028-4909-a71c-f01269af0f1e)
![Simulator Screenshot - iPhone 15 Pro Max - 2024-05-11 at 22 24 54](https://github.com/organicmaps/organicmaps/assets/4352168/45f966dc-e8b7-48a0-a6c6-9e8ce821b422)
![Simulator Screenshot - iPhone 15 Pro Max - 2024-05-11 at 22 24 58](https://github.com/organicmaps/organicmaps/assets/4352168/f34ed62a-163d-4d40-bca9-4d34a839bd60)

