### PR TITLE
[strings] Fixed Portuguese exit strings

### DIFF
--- a/data/strings/types_strings.txt
+++ b/data/strings/types_strings.txt
@@ -11343,8 +11343,8 @@
     nb = Utgang
     nl = Ga naar
     pl = Wyjście
-    pt = Sai
-    pt-BR = Sair
+    pt = Saída
+    pt-BR = Saída
     ro = Ieșire
     ru = Выход
     sk = Východ

--- a/data/strings/types_strings.txt
+++ b/data/strings/types_strings.txt
@@ -11344,7 +11344,6 @@
     nl = Ga naar
     pl = Wyjście
     pt = Saída
-    pt-BR = Saída
     ro = Ieșire
     ru = Выход
     sk = Východ


### PR DESCRIPTION
Quick fix: fixed Portuguese exit (entrance/door) strings.

Although PT and PT-BR translations are the same, since it seems OM is moving translations to Weblate, I preferred to have it duplicated. Let's see how it works in the future.