### PR TITLE
[coding] Fix maybe-uninitialized warning in file_data.cpp

### DIFF
--- a/coding/internal/file_data.cpp
+++ b/coding/internal/file_data.cpp
@@ -4,6 +4,7 @@
 #include "coding/reader.hpp" // For Reader exceptions.
 #include "coding/writer.hpp" // For Writer exceptions.
 
+#include "base/assert.hpp"
 #include "base/exception.hpp"
 #include "base/logging.hpp"
 #include "base/string_utils.hpp"
@@ -77,6 +78,7 @@ string FileData::GetErrorProlog() const
   case OP_WRITE_TRUNCATE: s = "Write truncate"; break;
   case OP_WRITE_EXISTING: s = "Write existing"; break;
   case OP_APPEND: s = "Append"; break;
+  default: UNREACHABLE();
   }
 
   return m_FileName + "; " + s + "; " + strerror(errno);


### PR DESCRIPTION
Fixes the following warning:
file_data.cpp:82:28:  warning: ‘s’ may be used uninitialized [-Wmaybe-uninitialized]