### PR TITLE
[transit] Do not continue execution with an uninitialized osmIdNum

### DIFF
--- a/transit/transit_graph_data.cpp
+++ b/transit/transit_graph_data.cpp
@@ -184,8 +184,11 @@ void DeserializerFromJson::operator()(FeatureIdentifiers & id, char const * name
   string osmIdStr;
   GetField(osmIdStr, name);
   uint64_t osmIdNum;
-  CHECK(strings::to_uint64(osmIdStr, osmIdNum),
-        ("Cann't convert osm id string:", osmIdStr, "to a number."));
+  if (!strings::to_uint64(osmIdStr, osmIdNum))
+  {
+    CHECK(false, ("Can't convert osm id string:", osmIdStr, "to a number."));
+    std::abort();
+  }
   base::GeoObjectId const osmId(osmIdNum);
   auto const it = m_osmIdToFeatureIds.find(osmId);
   if (it != m_osmIdToFeatureIds.cend())


### PR DESCRIPTION
Fixes the following warning:
transit_graph_data.cpp:189:41: warning: ‘osmIdNum’ may be used uninitialized [-Wmaybe-uninitialized]