### PR TITLE
[drape] Use global constant for the base font size and removed unused vars

### DIFF
--- a/drape/font_constants.hpp
+++ b/drape/font_constants.hpp
@@ -3,4 +3,5 @@
 namespace dp
 {
 int constexpr kSdfBorder = 4;
+int constexpr kBaseFontSizePixels = 22;
 }  // namespace dp

--- a/drape/font_texture.cpp
+++ b/drape/font_texture.cpp
@@ -8,6 +8,8 @@
 #include <functional>
 #include <iterator>
 
+#include "font_constants.hpp"
+
 namespace dp
 {
 GlyphPacker::GlyphPacker(const m2::PointU & size)
@@ -173,8 +175,8 @@ bool GlyphIndex::CanBeGlyphPacked(uint32_t glyphsCount) const
     return false;
 
   float constexpr kGlyphScalar = 1.5f;
-  auto const baseSize = static_cast<uint32_t>(m_mng->GetBaseGlyphHeight() * kGlyphScalar);
-  return m_packer.CanBePacked(glyphsCount, baseSize, baseSize);
+  auto constexpr baseSizePixels = static_cast<uint32_t>(kBaseFontSizePixels * kGlyphScalar);
+  return m_packer.CanBePacked(glyphsCount, baseSizePixels, baseSizePixels);
 }
 
 size_t GlyphIndex::GetPendingNodesCount()

--- a/drape/glyph.hpp
+++ b/drape/glyph.hpp
@@ -34,9 +34,6 @@ struct GlyphImage
   uint32_t m_width;
   uint32_t m_height;
 
-  uint32_t m_bitmapRows;
-  int m_bitmapPitch;
-
   SharedBufferManager::shared_buffer_ptr_t m_data;
 };
 

--- a/drape/glyph_manager.cpp
+++ b/drape/glyph_manager.cpp
@@ -287,8 +287,6 @@ struct GlyphManager::Impl
   TUniBlocks m_blocks;
   TUniBlockIter m_lastUsedBlock;
   std::vector<std::unique_ptr<Font>> m_fonts;
-
-  uint32_t m_baseGlyphHeight;
 };
 
 // Destructor is defined where pimpl's destructor is already known.
@@ -297,8 +295,6 @@ GlyphManager::~GlyphManager() = default;
 GlyphManager::GlyphManager(Params const & params)
   : m_impl(std::make_unique<Impl>())
 {
-  m_impl->m_baseGlyphHeight = params.m_baseGlyphHeight;
-
   using TFontAndBlockName = std::pair<std::string, std::string>;
   using TFontLst = buffer_vector<TFontAndBlockName, 64>;
 
@@ -450,11 +446,6 @@ GlyphManager::GlyphManager(Params const & params)
 
 }
 
-uint32_t GlyphManager::GetBaseGlyphHeight() const
-{
-  return m_impl->m_baseGlyphHeight;
-}
-
 int GlyphManager::GetFontIndex(strings::UniChar unicodePoint)
 {
   auto iter = m_impl->m_blocks.cend();
@@ -519,7 +510,7 @@ Glyph GlyphManager::GetGlyph(strings::UniChar unicodePoint)
     return GetInvalidGlyph();
 
   auto const & f = m_impl->m_fonts[fontIndex];
-  Glyph glyph = f->GetGlyph(unicodePoint, m_impl->m_baseGlyphHeight);
+  Glyph glyph = f->GetGlyph(unicodePoint, kBaseFontSizePixels);
   glyph.m_fontIndex = fontIndex;
   return glyph;
 }
@@ -556,7 +547,7 @@ Glyph const & GlyphManager::GetInvalidGlyph() const
     strings::UniChar constexpr kInvalidGlyphCode = 0x9;
     int constexpr kFontId = 0;
     ASSERT(!m_impl->m_fonts.empty(), ());
-    s_glyph = m_impl->m_fonts[kFontId]->GetGlyph(kInvalidGlyphCode, m_impl->m_baseGlyphHeight);
+    s_glyph = m_impl->m_fonts[kFontId]->GetGlyph(kInvalidGlyphCode, kBaseFontSizePixels);
     s_glyph.m_metrics.m_isValid = false;
     s_glyph.m_fontIndex = kFontId;
     s_glyph.m_code = kInvalidGlyphCode;

--- a/drape/glyph_manager.cpp
+++ b/drape/glyph_manager.cpp
@@ -168,7 +168,7 @@ public:
     }
 
     Glyph result;
-    result.m_image = {bitmap.width, bitmap.rows, bitmap.rows, bitmap.pitch, data};
+    result.m_image = {bitmap.width, bitmap.rows, data};
     // Glyph image has SDF borders that should be taken into an account.
     result.m_metrics = {float(glyph->advance.x >> 16), float(glyph->advance.y >> 16),
                         float(bbox.xMin + kSdfBorder), float(bbox.yMin + kSdfBorder), true};

--- a/drape/glyph_manager.hpp
+++ b/drape/glyph_manager.hpp
@@ -24,8 +24,6 @@ public:
     std::string m_blacklist;
 
     std::vector<std::string> m_fonts;
-
-    uint32_t m_baseGlyphHeight = 22;
   };
 
   explicit GlyphManager(Params const & params);
@@ -37,8 +35,6 @@ public:
   bool AreGlyphsReady(strings::UniString const & str) const;
 
   Glyph const & GetInvalidGlyph() const;
-
-  uint32_t GetBaseGlyphHeight() const;
 
 private:
   int GetFontIndex(strings::UniChar unicodePoint);

--- a/drape/texture_manager.cpp
+++ b/drape/texture_manager.cpp
@@ -1,7 +1,8 @@
 #include "drape/texture_manager.hpp"
 
-#include "drape/gl_functions.hpp"
+#include "drape/font_constants.hpp"
 #include "drape/font_texture.hpp"
+#include "drape/gl_functions.hpp"
 #include "drape/symbols_texture.hpp"
 #include "drape/static_texture.hpp"
 #include "drape/stipple_pen_resource.hpp"
@@ -473,9 +474,8 @@ void TextureManager::Init(ref_ptr<dp::GraphicsContext> context, Params const & p
   // Initialize glyphs.
   m_glyphManager = make_unique_dp<GlyphManager>(params.m_glyphMngParams);
   uint32_t constexpr textureSquare = kGlyphsTextureSize * kGlyphsTextureSize;
-  uint32_t const baseGlyphHeight =
-      static_cast<uint32_t>(params.m_glyphMngParams.m_baseGlyphHeight * kGlyphAreaMultiplier);
-  uint32_t const averageGlyphSquare = baseGlyphHeight * baseGlyphHeight;
+  uint32_t constexpr baseGlyphHeightPixels = static_cast<uint32_t>(dp::kBaseFontSizePixels * kGlyphAreaMultiplier);
+  uint32_t constexpr averageGlyphSquare = baseGlyphHeightPixels * baseGlyphHeightPixels;
   m_maxGlypsCount = static_cast<uint32_t>(ceil(kGlyphAreaCoverage * textureSquare / averageGlyphSquare));
 
   m_isInitialized = true;

--- a/drape_frontend/backend_renderer.cpp
+++ b/drape_frontend/backend_renderer.cpp
@@ -761,7 +761,6 @@ void BackendRenderer::InitContextDependentResources()
   params.m_glyphMngParams.m_uniBlocks = "unicode_blocks.txt";
   params.m_glyphMngParams.m_whitelist = "fonts_whitelist.txt";
   params.m_glyphMngParams.m_blacklist = "fonts_blacklist.txt";
-  params.m_glyphMngParams.m_baseGlyphHeight = VisualParams::Instance().GetGlyphBaseSize();
   GetPlatform().GetFontNames(params.m_glyphMngParams.m_fonts);
   if (m_arrow3dCustomDecl.has_value())
   {

--- a/drape_frontend/gui/gui_text.cpp
+++ b/drape_frontend/gui/gui_text.cpp
@@ -9,6 +9,7 @@
 #include "base/string_utils.hpp"
 
 #include "drape/bidi.hpp"
+#include "drape/font_constants.hpp"
 
 #include <algorithm>
 #include <array>
@@ -158,9 +159,7 @@ void StaticLabel::CacheStaticText(std::string const & text, char const * delim,
   glsl::vec2 colorTex = glsl::ToVec2(color.GetTexRect().Center());
   glsl::vec2 outlineTex = glsl::ToVec2(outline.GetTexRect().Center());
 
-  df::VisualParams const & vparams = df::VisualParams::Instance();
-  auto const textRatio = font.m_size * static_cast<float>(vparams.GetVisualScale()) /
-                         vparams.GetGlyphBaseSize();
+  auto const textRatio = font.m_size * static_cast<float>(df::VisualParams::Instance().GetVisualScale() / dp::kBaseFontSizePixels);
 
   buffer_vector<float, 4> lineLengths;
   lineLengths.reserve(buffers.size());
@@ -333,9 +332,7 @@ void MutableLabel::Precache(PrecacheParams const & params, PrecacheResult & resu
 {
   SetMaxLength(static_cast<uint16_t>(params.m_maxLength));
   result.m_state.SetMaskTexture(SetAlphabet(params.m_alphabet, mng));
-  df::VisualParams const & vparams = df::VisualParams::Instance();
-  m_textRatio = params.m_font.m_size * static_cast<float>(vparams.GetVisualScale()) /
-                vparams.GetGlyphBaseSize();
+  m_textRatio = params.m_font.m_size * static_cast<float>(df::VisualParams::Instance().GetVisualScale()) / dp::kBaseFontSizePixels;
 
   dp::TextureManager::ColorRegion color;
   dp::TextureManager::ColorRegion outlineColor;

--- a/drape_frontend/text_layout.cpp
+++ b/drape_frontend/text_layout.cpp
@@ -3,6 +3,7 @@
 #include "drape_frontend/visual_params.hpp"
 
 #include "drape/bidi.hpp"
+#include "drape/font_constants.hpp"
 
 #include <algorithm>
 #include <iterator>  // std::reverse_iterator
@@ -295,8 +296,7 @@ void TextLayout::Init(strings::UniString && text, float fontSize, ref_ptr<dp::Te
   m_text = std::move(text);
   auto const & vpi = VisualParams::Instance();
   float const fontScale = static_cast<float>(vpi.GetFontScale());
-  float const baseSize = static_cast<float>(vpi.GetGlyphBaseSize());
-  m_textSizeRatio = fontSize * fontScale / baseSize;
+  m_textSizeRatio = fontSize * fontScale / dp::kBaseFontSizePixels;
   textures->GetGlyphRegions(m_text, m_metrics);
 }
 
@@ -330,7 +330,7 @@ float TextLayout::GetPixelLength() const
 
 float TextLayout::GetPixelHeight() const
 {
-  return m_textSizeRatio * VisualParams::Instance().GetGlyphBaseSize();
+  return m_textSizeRatio * dp::kBaseFontSizePixels;
 }
 
 strings::UniString const & TextLayout::GetText() const

--- a/drape_frontend/visual_params.cpp
+++ b/drape_frontend/visual_params.cpp
@@ -52,12 +52,6 @@ void VisualParams::Init(double vs, uint32_t tileSize)
   LOG(LINFO, ("Visual scale =", vs, "; Tile size =", tileSize, "; Resources =", GetResourcePostfix(vs)));
 }
 
-uint32_t VisualParams::GetGlyphBaseSize() const
-{
-  ASSERT_INITED;
-  return 22;
-}
-
 double VisualParams::GetFontScale() const
 {
   ASSERT_INITED;

--- a/drape_frontend/visual_params.hpp
+++ b/drape_frontend/visual_params.hpp
@@ -59,7 +59,6 @@ public:
 
   GlyphVisualParams const & GetGlyphVisualParams() const;
   uint32_t GetGlyphSdfScale() const;
-  uint32_t GetGlyphBaseSize() const;
   double GetFontScale() const;
   void SetFontScale(double fontScale);
 


### PR DESCRIPTION
All glyphs are rendered to the texture in SDF mode, with the same base size.

They are scaled to the necessary size when the text is rendered to another texture.