### PR TITLE
[android] Remove the "-rc" tag suffix from the release candidates

### DIFF
--- a/.github/workflows/android-release.yaml
+++ b/.github/workflows/android-release.yaml
@@ -31,7 +31,7 @@ jobs:
           # TODO: Find a way to refactor FDroid versioning without that additional commit.
           build=$(($(tools/unix/version.sh ios_build) + 1))
           code=$(($(tools/unix/version.sh android_code) + 1))
-          tag=$version-$build-android-rc
+          tag=$version-$build-android
           echo "::set-output name=version::$version"
           echo "::set-output name=build::$build"
           echo "::set-output name=tag::$tag"


### PR DESCRIPTION
Tag Android with `YYYY.MM.DD-x-android` instead of `YYYY.MM.DD-x-android` to trigger F-Droid pipeline when the release candidate is published. It typically takes 4-5 days for F-Droid to process submissions. Any defective release candidates can be withdrawn from the queue by submitting a merge request to fdroid/data.

Note: Published GitHub releases are still tagged as "pre-release".

See 9520fd8c "Update the Google Play release procedure"

See https://gitlab.com/fdroid/fdroiddata/-/merge_requests/15000