### PR TITLE
[editor] Add flag to changeset when features are merged

### DIFF
--- a/editor/changeset_wrapper.cpp
+++ b/editor/changeset_wrapper.cpp
@@ -236,6 +236,11 @@ void ChangesetWrapper::Modify(editor::XMLFeature node)
   m_modified_types[GetTypeForFeature(node)]++;
 }
 
+void ChangesetWrapper::AddChangesetTag(std::string key, std::string value)
+{
+  m_changesetComments.emplace(std::move(key), std::move(value));
+}
+
 void ChangesetWrapper::Delete(editor::XMLFeature node)
 {
   if (m_changesetId == kInvalidChangesetId)

--- a/editor/changeset_wrapper.hpp
+++ b/editor/changeset_wrapper.hpp
@@ -49,6 +49,9 @@ public:
   /// Throws exceptions from above list.
   void Delete(editor::XMLFeature node);
 
+  /// Add a tag to the changeset
+  void AddChangesetTag(std::string key, std::string value);
+
   /// Allows to see exception details in OSM changesets for easier debugging.
   void SetErrorDescription(std::string const & error);
 

--- a/editor/osm_editor.cpp
+++ b/editor/osm_editor.cpp
@@ -647,6 +647,7 @@ void Editor::UploadChanges(string const & oauthToken, ChangesetTags tags,
               else
               {
                 LOG(LDEBUG, ("Create case: uploading patched feature", osmFeature));
+                changeset.AddChangesetTag("info:features_merged", "yes");
                 changeset.Modify(osmFeature);
               }
             }


### PR DESCRIPTION
Re-added flagging, like in #7853, but for "info:features_merged=yes" instead of "feature_cloes_by". 
The "info:features_merged=yes" tag is added to changesets when the feature merging code is executed. This makes evaluating / making statistics for #2298 possible (see: https://github.com/organicmaps/organicmaps/pull/7853#discussion_r1558308223).

:heavy_check_mark: Tested in https://www.openstreetmap.org/changeset/151378253