### PR TITLE
[android] better user profile (initial layout)

### DIFF
--- a/CONTRIBUTORS
+++ b/CONTRIBUTORS
@@ -17,6 +17,7 @@ Organic Maps contributions:
   Konstantin Pastbin
   Nishant Bhandari <nishantbhandari0019@gmail.com>
   Sebastiao Sousa <sebastiao.sousa@tecnico.ulisboa.pt>
+  Harry Bond <me@hbond.xyz>
 
 Organic Maps translations:
   Karina Kordon

--- a/android/app/src/main/cpp/app/organicmaps/editor/OsmOAuth.cpp
+++ b/android/app/src/main/cpp/app/organicmaps/editor/OsmOAuth.cpp
@@ -71,6 +71,15 @@ Java_app_organicmaps_editor_OsmOAuth_nativeGetOsmChangesetsCount(JNIEnv * env, j
 }
 
 JNIEXPORT jstring JNICALL
+Java_app_organicmaps_editor_OsmOAuth_nativeGetOsmProfilePictureUrl(JNIEnv * env, jclass, jstring oauthToken)
+{
+  UserPreferences prefs;
+  if (LoadOsmUserPreferences(jni::ToNativeString(env, oauthToken), prefs))
+    return jni::ToJavaString(env, prefs.m_imageUrl);
+  return nullptr;
+}
+
+JNIEXPORT jstring JNICALL
 Java_app_organicmaps_editor_OsmOAuth_nativeGetHistoryUrl(JNIEnv * env, jclass, jstring user)
 {
   return jni::ToJavaString(env, OsmOAuth::ServerAuth().GetHistoryURL(jni::ToNativeString(env, user)));

--- a/android/app/src/main/java/app/organicmaps/editor/OsmOAuth.java
+++ b/android/app/src/main/java/app/organicmaps/editor/OsmOAuth.java
@@ -2,6 +2,7 @@ package app.organicmaps.editor;
 
 import android.content.Context;
 import android.content.SharedPreferences;
+import android.graphics.Bitmap;
 
 import androidx.annotation.NonNull;
 import androidx.annotation.Nullable;
@@ -68,6 +69,12 @@ public final class OsmOAuth
     return MwmApplication.prefs(context).getString(PREF_OSM_USERNAME, "");
   }
 
+  public static Bitmap getProfilePicture(@NonNull Context context)
+  {
+    //TODO(HB): load and store image in cache here
+    return null;
+  }
+
   public static void setAuthorization(@NonNull Context context, String oauthToken, String username)
   {
     MwmApplication.prefs(context).edit()
@@ -102,6 +109,10 @@ public final class OsmOAuth
   @WorkerThread
   @Nullable
   public static native String nativeGetOsmUsername(String oauthToken);
+
+  @WorkerThread
+  @Nullable
+  public static native String nativeGetOsmProfilePictureUrl(String oauthToken);
 
   @WorkerThread
   @NonNull

--- a/android/app/src/main/res/drawable/profile_generic.xml
+++ b/android/app/src/main/res/drawable/profile_generic.xml
@@ -1,0 +1,10 @@
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:width="1000dp"
+    android:height="1000dp"
+    android:viewportWidth="1000"
+    android:viewportHeight="1000">
+  <path
+      android:pathData="m500,500q-103.1,0 -176.6,-73.4t-73.4,-176.6 73.4,-176.6 176.6,-73.4 176.6,73.4 73.4,176.6 -73.4,176.6 -176.6,73.4zM0,1000v-175q0,-53.1 27.3,-97.7t72.7,-68q96.9,-48.4 196.9,-72.7t203.1,-24.2 203.1,24.2 196.9,72.7q45.3,23.4 72.7,68t27.3,97.7v175z"
+      android:strokeWidth="1.5625"
+      android:fillColor="#fff"/>
+</vector>

--- a/android/app/src/main/res/layout/fragment_osm_profile.xml
+++ b/android/app/src/main/res/layout/fragment_osm_profile.xml
@@ -24,103 +24,102 @@
       android:scaleType="center"
       app:srcCompat="@drawable/ic_logout"
       android:contentDescription="@string/logout" />
-  </androidx.appcompat.widget.Toolbar>
-
-  <ScrollView
-    android:layout_width="match_parent"
-    android:layout_height="match_parent"
-    android:fillViewport="true">
-    <LinearLayout
+    </androidx.appcompat.widget.Toolbar>
+  <FrameLayout
       android:layout_width="match_parent"
-      android:layout_height="match_parent"
-      android:clipChildren="false"
-      android:clipToPadding="false"
-      android:orientation="vertical"
-      tools:ignore="ScrollViewSize">
+      android:layout_height="wrap_content"
+      android:padding="@dimen/margin_base"
+      android:background="?colorPrimary">
+    <ProgressBar
+        android:id="@+id/user_profile_loading"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:layout_gravity="center"
+        android:indeterminateTint="@color/text_light"
+        android:visibility="invisible"
+        tools:visibility="visible" />
+    <LinearLayout
+        android:id="@+id/block_user_info"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:layout_gravity="center"
+        android:orientation="horizontal">
+      <ImageView
+          android:id="@+id/user_profile_image"
+          android:layout_width="100dp"
+          android:layout_height="match_parent"
+          android:importantForAccessibility="no"
+          app:srcCompat="@drawable/profile_generic" />
       <LinearLayout
-        android:id="@+id/block_edits"
+          android:id="@+id/text"
+          android:layout_marginStart="@dimen/margin_base"
+          android:layout_width="0dp"
+          android:layout_weight="1"
+          android:layout_height="wrap_content"
+          android:orientation="vertical">
+        <androidx.appcompat.widget.AppCompatTextView
+            android:id="@+id/user_profile_name"
+            android:layout_width="match_parent"
+            android:layout_height="match_parent"
+            android:textColor="@color/text_light"
+            tools:ignore="UnusedAttribute"
+            android:breakStrategy="balanced"
+            android:autoSizeMinTextSize="@dimen/text_size_body_3"
+            android:autoSizeTextType="uniform"
+            android:textSize="25sp"
+            tools:text="Long Username" />
+        <androidx.appcompat.widget.AppCompatTextView
+            android:id="@+id/user_sent_edits"
+            android:layout_width="match_parent"
+            android:layout_height="match_parent"
+            android:textColor="@color/text_light"
+            android:textSize="35sp"
+            android:textStyle="bold"
+            tools:text="2,000,000" />
+        <androidx.appcompat.widget.AppCompatTextView
+            android:id="@+id/verified_changes_text"
+            android:layout_width="match_parent"
+            android:layout_height="match_parent"
+            android:textSize="@dimen/text_size_body_1"
+            android:text="@string/editor_profile_changes"
+            android:textColor="@color/white_primary" />
+      </LinearLayout>
+    </LinearLayout>
+  </FrameLayout>
+  <androidx.constraintlayout.widget.ConstraintLayout
+      android:layout_width="match_parent"
+      android:layout_height="0dp"
+      android:layout_weight="1"
+      android:padding="@dimen/margin_base">
+    <TextView
+        android:id="@+id/osm_history"
         android:layout_width="match_parent"
         android:layout_height="wrap_content"
-        android:animateLayoutChanges="true"
-        android:background="?colorPrimary"
-        android:orientation="vertical"
-        android:padding="@dimen/margin_base">
-        <LinearLayout
-          android:id="@+id/sent_edits"
-          android:layout_width="match_parent"
-          android:layout_height="wrap_content"
-          android:paddingBottom="@dimen/margin_base"
-          android:orientation="vertical">
-          <FrameLayout
-            android:layout_width="match_parent"
-            android:layout_height="112dp">
-            <TextView
-              android:id="@+id/edits_count"
-              android:layout_width="match_parent"
-              android:layout_height="match_parent"
-              android:gravity="center"
-              android:textColor="@color/text_light"
-              android:textSize="96sp"
-              android:textStyle="bold"
-              tools:text="244"/>
-            <ProgressBar
-              android:id="@+id/edits_count_progress"
-              android:layout_width="match_parent"
-              android:layout_height="match_parent"
-              android:layout_gravity="center"
-              android:padding="@dimen/margin_base"
-              android:indeterminateTint="@color/text_light"
-              android:visibility="gone"
-              tools:visibility="visible"/>
-          </FrameLayout>
-
-          <TextView
-            android:layout_width="match_parent"
-            android:layout_height="wrap_content"
-            android:gravity="center"
-            android:text="@string/editor_profile_changes"
-            android:textAppearance="@style/MwmTextAppearance.Body1"
-            android:textColor="@color/white_primary"
-            android:textStyle="bold"/>
-
-        </LinearLayout>
-      </LinearLayout>
-      <androidx.constraintlayout.widget.ConstraintLayout
+        android:layout_alignParentTop="true"
+        android:background="?clickableBackground"
+        android:gravity="center"
+        android:paddingTop="@dimen/margin_half"
+        android:paddingBottom="@dimen/margin_half"
+        android:text="@string/history"
+        android:textAppearance="@style/MwmTextAppearance.Body4"
+        android:textColor="?colorAccent"
+        android:textSize="@dimen/text_size_body_1"
+        app:layout_constraintTop_toTopOf="parent"/>
+    <TextView
+        android:id="@+id/about_osm"
         android:layout_width="match_parent"
-        android:layout_height="0dp"
-        android:layout_weight="1"
-        android:padding="@dimen/margin_base">
-        <TextView
-          android:id="@+id/osm_history"
-          android:layout_width="match_parent"
-          android:layout_height="wrap_content"
-          android:layout_alignParentTop="true"
-          android:background="?clickableBackground"
-          android:gravity="center"
-          android:paddingTop="@dimen/margin_half"
-          android:paddingBottom="@dimen/margin_half"
-          android:text="@string/history"
-          android:textAppearance="@style/MwmTextAppearance.Body4"
-          android:textColor="?colorAccent"
-          android:textSize="@dimen/text_size_body_1"
-          app:layout_constraintTop_toTopOf="parent"/>
-        <TextView
-          android:id="@+id/about_osm"
-          android:layout_width="match_parent"
-          android:layout_height="wrap_content"
-          android:layout_alignParentBottom="true"
-          android:background="?clickableBackground"
-          android:gravity="center"
-          android:paddingTop="@dimen/margin_half"
-          android:paddingBottom="@dimen/margin_half"
-          android:text="@string/editor_more_about_osm"
-          android:textAppearance="@style/MwmTextAppearance.Body4"
-          android:textColor="?colorAccent"
-          android:textSize="@dimen/text_size_body_4"
-          app:layout_constraintBottom_toBottomOf="parent"
-          app:layout_constraintTop_toBottomOf="@+id/osm_history"
-          app:layout_constraintVertical_bias="1" />
-      </androidx.constraintlayout.widget.ConstraintLayout>
-    </LinearLayout>
-  </ScrollView>
+        android:layout_height="wrap_content"
+        android:layout_alignParentBottom="true"
+        android:background="?clickableBackground"
+        android:gravity="center"
+        android:paddingTop="@dimen/margin_half"
+        android:paddingBottom="@dimen/margin_half"
+        android:text="@string/editor_more_about_osm"
+        android:textAppearance="@style/MwmTextAppearance.Body4"
+        android:textColor="?colorAccent"
+        android:textSize="@dimen/text_size_body_4"
+        app:layout_constraintBottom_toBottomOf="parent"
+        app:layout_constraintTop_toBottomOf="@+id/osm_history"
+        app:layout_constraintVertical_bias="1" />
+  </androidx.constraintlayout.widget.ConstraintLayout>
 </LinearLayout>


### PR DESCRIPTION
Some work towards a better user profile page. 

Sadly i'm gonna be really busy for the next couple of months, so loading the profile image will have to wait (although it's somewhat working at [redauburn/organicmaps/android-user-profile](https://github.com/RedAuburn/organicmaps/tree/android-user-profile), albeit in the wrong place...)

i thought i may as well submit this stripped down version though, which has a new user info layout, displays the username, and formats the changeset count according to locale.

before/after:

![cvbfdfdfg](https://github.com/organicmaps/organicmaps/assets/26939824/201099ea-f046-486d-b75b-53b5bb9232a1)


generic profile image from https://svgsilh.com/image/378368.html (CC0)


