### PR TITLE
Better categorize Organic Maps in Linux launchers

### DIFF
--- a/qt/res/OrganicMaps.desktop
+++ b/qt/res/OrganicMaps.desktop
@@ -1,6 +1,5 @@
 [Desktop Entry]
 Type=Application
-Version=1.0
 Name=Organic Maps
 Comment=Detailed Offline Maps of the World
 Comment[ru]=Подробная оффлайновая карта мира


### PR DESCRIPTION
The “Utility” category is a better fit for OM than “Education” in launchers like KDE’s Kickoff.

Motivation: https://t.me/organicmaps/40667