### PR TITLE
[ios] Set correct location service activity type for cycling

### DIFF
--- a/iphone/Maps/Core/Location/MWMLocationManager.mm
+++ b/iphone/Maps/Core/Location/MWMLocationManager.mm
@@ -375,7 +375,7 @@ void setShowLocationAlert(BOOL needShow) {
     break;
   case GeoMode::PedestrianRouting:
   case GeoMode::BicycleRouting:
-    locationManager.activityType = CLActivityTypeFitness;
+    locationManager.activityType = CLActivityTypeOtherNavigation;
     break;
   }
 
@@ -484,7 +484,7 @@ void setShowLocationAlert(BOOL needShow) {
 - (void)startUpdatingLocationFor:(CLLocationManager *)manager
 {
   LOG(LINFO, ("startUpdatingLocation"));
-  
+
   [manager startUpdatingLocation];
   if ([CLLocationManager headingAvailable])
     [manager startUpdatingHeading];


### PR DESCRIPTION
> [CLActivityTypeOtherNavigation](https://developer.apple.com/documentation/corelocation/clactivitytype/clactivitytypeothernavigation?language=objc)
The value that indicates positioning for activities that don’t or may not adhere to roads such as cycling, scooters, trains, boats and off-road vehicles.

> [CLActivityTypeFitness](https://developer.apple.com/documentation/corelocation/clactivitytype/clactivitytypefitness?language=objc)
The value that indicates positioning during dedicated fitness sessions, such as walking workouts, running workouts, cycling workouts, and so on.

Note that in the current car navigation mode position will be closer to Apple's road network data:

> [CLActivityTypeAutomotiveNavigation](https://developer.apple.com/documentation/corelocation/clactivitytype/clactivitytypeautomotivenavigation?language=objc)
The value that indicates positioning in an automobile following a road network.