### PR TITLE
Improve page dialog (user)

### DIFF
--- a/qt/place_page_dialog_user.cpp
+++ b/qt/place_page_dialog_user.cpp
@@ -30,9 +30,7 @@ std::string getShortDescription(std::string description)
     description = description.substr(3, paragraphEnd - 3);
 
   if (description.length() > kMaxLengthOfPlacePageDescription)
-  {
-    description = description.substr(0, kMaxLengthOfPlacePageDescription-3) + "...";
-  }
+    description = description.substr(0, kMaxLengthOfPlacePageDescription - 3) + "...";
 
   return description;
 }

--- a/qt/place_page_dialog_user.cpp
+++ b/qt/place_page_dialog_user.cpp
@@ -24,15 +24,18 @@ static int constexpr kMinWidthOfShortDescription = 390;
 
 std::string getShortDescription(std::string description)
 {
-  auto const paragraphStart = description.find("<p>");
-  auto const paragraphEnd = description.find("</p>");
+  std::string_view view(description);
+
+  auto const paragraphStart = view.find("<p>");
+  auto const paragraphEnd = view.find("</p>");
+
   if (paragraphStart == 0 && paragraphEnd != std::string::npos)
-    description = description.substr(3, paragraphEnd - 3);
+    view = view.substr(3, paragraphEnd - 3);
 
-  if (description.length() > kMaxLengthOfPlacePageDescription)
-    description = description.substr(0, kMaxLengthOfPlacePageDescription - 3) + "...";
+  if (view.length() > kMaxLengthOfPlacePageDescription)
+    return std::string(view.substr(0, kMaxLengthOfPlacePageDescription - 3)) + "...";
 
-  return description;
+  return std::string(view);
 }
 
 std::string_view stripSchemeFromURI(std::string_view uri) {

--- a/qt/place_page_dialog_user.cpp
+++ b/qt/place_page_dialog_user.cpp
@@ -27,7 +27,7 @@ std::string getShortDescription(std::string description)
   auto const paragraphStart = description.find("<p>");
   auto const paragraphEnd = description.find("</p>");
   if (paragraphStart == 0 && paragraphEnd != std::string::npos)
-    description = description.substr(3, paragraphEnd-3);
+    description = description.substr(3, paragraphEnd - 3);
 
   if (description.length() > kMaxLengthOfPlacePageDescription)
   {

--- a/qt/place_page_dialog_user.cpp
+++ b/qt/place_page_dialog_user.cpp
@@ -67,7 +67,8 @@ PlacePageDialogUser::PlacePageDialogUser(QWidget * parent, place_page::Info cons
   {
     QVBoxLayout * header = new QVBoxLayout();
 
-    if (!title.empty()){
+    if (!title.empty())
+    {
       QLabel * titleLabel = new QLabel(QString::fromStdString("<h1>" + title + "</h1>"));
       titleLabel->setWordWrap(true);
       header->addWidget(titleLabel);

--- a/qt/place_page_dialog_user.cpp
+++ b/qt/place_page_dialog_user.cpp
@@ -22,6 +22,21 @@ namespace
 static int constexpr kMaxLengthOfPlacePageDescription = 500;
 static int constexpr kMinWidthOfShortDescription = 390;
 
+std::string getShortDescription(std::string description)
+{
+  size_t paragraphStart = description.find("<p>");
+  size_t paragraphEnd = description.find("</p>");
+  if (paragraphStart == 0 && paragraphEnd != std::string::npos)
+    description = description.substr(3, paragraphEnd-3);
+
+  if (description.length() > kMaxLengthOfPlacePageDescription)
+  {
+    description = description.substr(0, kMaxLengthOfPlacePageDescription-3) + "...";
+  }
+
+  return description;
+}
+
 std::string_view stripSchemeFromURI(std::string_view uri) {
   for (std::string_view prefix : {"https://", "http://"})
   {
@@ -52,14 +67,23 @@ PlacePageDialogUser::PlacePageDialogUser(QWidget * parent, place_page::Info cons
   {
     QVBoxLayout * header = new QVBoxLayout();
 
-    if (!title.empty())
-      header->addWidget(new QLabel(QString::fromStdString("<h1>" + title + "</h1>")));
+    if (!title.empty()){
+      QLabel * titleLabel = new QLabel(QString::fromStdString("<h1>" + title + "</h1>"));
+      titleLabel->setWordWrap(true);
+      header->addWidget(titleLabel);
+    }
 
-    if (auto subTitle = info.GetSubtitle(); !subTitle.empty())
-      header->addWidget(new QLabel(QString::fromStdString(subTitle)));
+    if (auto subTitle = info.GetSubtitle(); !subTitle.empty()){
+      QLabel * subtitleLabel = new QLabel(QString::fromStdString(subTitle));
+      subtitleLabel->setWordWrap(true);
+      header->addWidget(subtitleLabel);
+    }
 
-    if (auto addressFormatted = address.FormatAddress(); !addressFormatted.empty())
-      header->addWidget(new QLabel(QString::fromStdString(addressFormatted)));
+    if (auto addressFormatted = address.FormatAddress(); !addressFormatted.empty()){
+      QLabel * addressLabel = new QLabel(QString::fromStdString(addressFormatted));
+      addressLabel->setWordWrap(true);
+      header->addWidget(addressLabel);
+    }
 
     layout->addLayout(header);
   }
@@ -79,6 +103,7 @@ PlacePageDialogUser::PlacePageDialogUser(QWidget * parent, place_page::Info cons
       data->addWidget(new QLabel(QString::fromStdString(key)), row, 0);
       QLabel * label = new QLabel(QString::fromStdString(value));
       label->setTextInteractionFlags(Qt::TextSelectableByMouse);
+      label->setWordWrap(true);
       if (isLink)
       {
         label->setOpenExternalLinks(true);
@@ -106,7 +131,14 @@ PlacePageDialogUser::PlacePageDialogUser(QWidget * parent, place_page::Info cons
     // Description
     if (auto description = info.GetWikiDescription(); !description.empty())
     {
-      QPushButton * wikiButton = new QPushButton("Wikipedia Description");
+      auto descriptionShort = getShortDescription(description);
+
+      QLabel * value = new QLabel(QString::fromStdString(descriptionShort));
+      value->setWordWrap(true);
+
+      data->addWidget(value, row++, 0, 1, 2);
+
+      QPushButton * wikiButton = new QPushButton("More...", value);
       wikiButton->setAutoDefault(false);
       connect(wikiButton, &QAbstractButton::clicked, this, [this, description, title]()
       {
@@ -179,7 +211,6 @@ PlacePageDialogUser::PlacePageDialogUser(QWidget * parent, place_page::Info cons
 
       addSocialNetworkWidget("Facebook", feature::Metadata::EType::FMD_CONTACT_FACEBOOK);
       addSocialNetworkWidget("Instagram", feature::Metadata::EType::FMD_CONTACT_INSTAGRAM);
-      addSocialNetworkWidget("Instagram", feature::Metadata::EType::FMD_CONTACT_INSTAGRAM);
       addSocialNetworkWidget("Twitter", feature::Metadata::EType::FMD_CONTACT_TWITTER);
       addSocialNetworkWidget("VK", feature::Metadata::EType::FMD_CONTACT_VK);
       addSocialNetworkWidget("Line", feature::Metadata::EType::FMD_CONTACT_LINE);
@@ -187,11 +218,13 @@ PlacePageDialogUser::PlacePageDialogUser(QWidget * parent, place_page::Info cons
 
     if (auto wikimedia_commons = info.GetMetadata(feature::Metadata::EType::FMD_WIKIMEDIA_COMMONS); !wikimedia_commons.empty())
     {
+      data->addWidget(new QLabel("Wikimedia Commons"), row, 0);
+
       QLabel * value = new QLabel(QString::fromStdString("<a href='" + feature::Metadata::ToWikimediaCommonsURL(std::string(wikimedia_commons)) + "'>Wikimedia Commons</a>"));
       value->setOpenExternalLinks(true);
       value->setTextInteractionFlags(Qt::TextBrowserInteraction);
 
-      data->addWidget(value, row++, 0);
+      data->addWidget(value, row++, 1);
     }
 
     // Level fragment
@@ -209,8 +242,13 @@ PlacePageDialogUser::PlacePageDialogUser(QWidget * parent, place_page::Info cons
       addEntry("Coordinates", strings::to_string_dac(ll.m_lat, 7) + ", " + strings::to_string_dac(ll.m_lon, 7));
     }
 
+    data->setColumnStretch(0, 0);
+    data->setColumnStretch(1, 1);
+
     layout->addLayout(data);
   }
+
+  layout->addStretch(); 
 
   {
     QHLine * line = new QHLine();

--- a/qt/place_page_dialog_user.cpp
+++ b/qt/place_page_dialog_user.cpp
@@ -79,7 +79,8 @@ PlacePageDialogUser::PlacePageDialogUser(QWidget * parent, place_page::Info cons
       header->addWidget(subtitleLabel);
     }
 
-    if (auto addressFormatted = address.FormatAddress(); !addressFormatted.empty()){
+    if (auto const addressFormatted = address.FormatAddress(); !addressFormatted.empty())
+    {
       QLabel * addressLabel = new QLabel(QString::fromStdString(addressFormatted));
       addressLabel->setWordWrap(true);
       header->addWidget(addressLabel);

--- a/qt/place_page_dialog_user.cpp
+++ b/qt/place_page_dialog_user.cpp
@@ -22,7 +22,7 @@ namespace
 static int constexpr kMaxLengthOfPlacePageDescription = 500;
 static int constexpr kMinWidthOfShortDescription = 390;
 
-std::string getShortDescription(std::string description)
+std::string getShortDescription(const std::string & description)
 {
   std::string_view view(description);
 
@@ -133,7 +133,7 @@ PlacePageDialogUser::PlacePageDialogUser(QWidget * parent, place_page::Info cons
     }
 
     // Description
-    if (auto description = info.GetWikiDescription(); !description.empty())
+    if (const auto & description = info.GetWikiDescription(); !description.empty())
     {
       auto descriptionShort = getShortDescription(description);
 

--- a/qt/place_page_dialog_user.cpp
+++ b/qt/place_page_dialog_user.cpp
@@ -73,7 +73,8 @@ PlacePageDialogUser::PlacePageDialogUser(QWidget * parent, place_page::Info cons
       header->addWidget(titleLabel);
     }
 
-    if (auto subTitle = info.GetSubtitle(); !subTitle.empty()){
+    if (auto const subTitle = info.GetSubtitle(); !subTitle.empty())
+    {
       QLabel * subtitleLabel = new QLabel(QString::fromStdString(subTitle));
       subtitleLabel->setWordWrap(true);
       header->addWidget(subtitleLabel);

--- a/qt/place_page_dialog_user.cpp
+++ b/qt/place_page_dialog_user.cpp
@@ -24,8 +24,8 @@ static int constexpr kMinWidthOfShortDescription = 390;
 
 std::string getShortDescription(std::string description)
 {
-  size_t paragraphStart = description.find("<p>");
-  size_t paragraphEnd = description.find("</p>");
+  auto const paragraphStart = description.find("<p>");
+  auto const paragraphEnd = description.find("</p>");
   if (paragraphStart == 0 && paragraphEnd != std::string::npos)
     description = description.substr(3, paragraphEnd-3);
 


### PR DESCRIPTION
1. Adds short description to place page dialog.
2. Adds word-wrap for all long fields.
3. Bug fix: removes duplicate Instagram.
4. Adds some layout stretching.

Points 2 and 4 are in preparation to move the page dialog to a panel to the left of the map :slightly_smiling_face: (which I'll do in a separate PR). This will hopefully make the place page less of a nuisance when one specific place is selected but you still want to explore the surroundings, giving a more intuitive experience that is also consistent with the mobile version (where you can select a place, and then drag the map around to  see the surroundings).

| Before | After |
|-|-|
| ![image](https://github.com/organicmaps/organicmaps/assets/43684166/24f696d4-8ed5-420b-9afa-ec1ba4f597ce) | ![image](https://github.com/organicmaps/organicmaps/assets/43684166/53bc96bc-663f-48f8-bccc-063ed69dfa6a) |

@biodranik @Ferenc- 