### PR TITLE
[platform] remove redundant `=` from osm.org/go link

### DIFF
--- a/platform/measurement_utils.cpp
+++ b/platform/measurement_utils.cpp
@@ -215,8 +215,8 @@ string FormatOsmLink(double lat, double lon, int zoom)
 
   for (int i = 0; i < (zoom + 8) % 3; ++i)
     osmUrl += "-";
-
-  return osmUrl + "?m=";
+  // ?m tells OSM to display a marker 
+  return osmUrl + "?m";
 }
 
 bool OSMDistanceToMeters(string const & osmRawValue, double & outMeters)


### PR DESCRIPTION
from: `https://osm.org/go/0EEFEVaz-?m=`
to: `https://osm.org/go/0EEFEVaz-?m`

tiny fix, looks a bit strange to have an empty query string