### PR TITLE
[platform] remove redundant `=` from osm.org/go link

### DIFF
--- a/platform/measurement_utils.cpp
+++ b/platform/measurement_utils.cpp
@@ -215,8 +215,8 @@ string FormatOsmLink(double lat, double lon, int zoom)
 
   for (int i = 0; i < (zoom + 8) % 3; ++i)
     osmUrl += "-";
-
-  return osmUrl + "?m=";
+  // ?m tells OSM to display a marker 
+  return osmUrl + "?m";
 }
 
 bool OSMDistanceToMeters(string const & osmRawValue, double & outMeters)

--- a/platform/platform_tests/measurement_tests.cpp
+++ b/platform/platform_tests/measurement_tests.cpp
@@ -51,17 +51,17 @@ UNIT_TEST(LatLonToDMS_NoRounding)
 UNIT_TEST(FormatOsmLink)
 {
   // Zero point
-  TEST_EQUAL(FormatOsmLink(0, 0, 5), "https://osm.org/go/wAAAA-?m=", ());
+  TEST_EQUAL(FormatOsmLink(0, 0, 5), "https://osm.org/go/wAAAA-?m", ());
   // Eifel tower
-  TEST_EQUAL(FormatOsmLink(48.85825, 2.29450, 15), "https://osm.org/go/0BOdUs9e--?m=", ());
+  TEST_EQUAL(FormatOsmLink(48.85825, 2.29450, 15), "https://osm.org/go/0BOdUs9e--?m", ());
   // Buenos Aires
-  TEST_EQUAL(FormatOsmLink(-34.6061, -58.4360, 10), "https://osm.org/go/Mnx6SB?m=", ());
+  TEST_EQUAL(FormatOsmLink(-34.6061, -58.4360, 10), "https://osm.org/go/Mnx6SB?m", ());
 
   // Formally, lat = -90 and lat = 90 are the same for OSM links, but Mercator is valid until 85.
   auto link = FormatOsmLink(-90, -180, 10);
-  TEST(link == "https://osm.org/go/AAAAAA?m=" || link == "https://osm.org/go/~~~~~~?m=", (link));
+  TEST(link == "https://osm.org/go/AAAAAA?m" || link == "https://osm.org/go/~~~~~~?m", (link));
   link = FormatOsmLink(90, 180, 10);
-  TEST(link == "https://osm.org/go/AAAAAA?m=" || link == "https://osm.org/go/~~~~~~?m=", (link));
+  TEST(link == "https://osm.org/go/AAAAAA?m" || link == "https://osm.org/go/~~~~~~?m", (link));
 }
 
 UNIT_TEST(FormatSpeedNumeric)


### PR DESCRIPTION
from: `https://osm.org/go/0EEFEVaz-?m=`
to: `https://osm.org/go/0EEFEVaz-?m`

tiny fix, looks a bit strange to have an empty query string