### PR TITLE
[ios] Interrupt podcasts instead of duck them during TTS

### DIFF
--- a/iphone/Maps/Core/TextToSpeech/MWMTextToSpeech.mm
+++ b/iphone/Maps/Core/TextToSpeech/MWMTextToSpeech.mm
@@ -247,7 +247,9 @@ using Observers = NSHashTable<Observer>;
     }
     if (![[AVAudioSession sharedInstance] setCategory:AVAudioSessionCategoryPlayback
                                                  mode:mode
-                                              options:AVAudioSessionCategoryOptionMixWithOthers | AVAudioSessionCategoryOptionDuckOthers
+                                              options:
+                                                  AVAudioSessionCategoryOptionInterruptSpokenAudioAndMixWithOthers |
+                                                  AVAudioSessionCategoryOptionDuckOthers
                                                 error:nil] ||
         ![[AVAudioSession sharedInstance] setActive:YES error:nil])
       return;


### PR DESCRIPTION
Use AVAudioSessionCategoryOptionInterruptSpokenAudioAndMixWithOthers to interrupt spoken content during TTS.

Apple recommends using this option for navigation apps:

> Set this option if your app’s audio is occasional and spoken, such as in a **turn-by-turn navigation app** or an exercise app. This avoids intelligibility problems when two spoken audio apps mix. If you set this option, also set the [AVAudioSessionCategoryOptionDuckOthers](doc://com.apple.documentation/documentation/avfaudio/avaudiosessioncategoryoptions/avaudiosessioncategoryoptionduckothers?language=objc) option unless you have a specific reason not to. Ducking other audio, rather than interrupting it, is appropriate when the other audio isn’t spoken audio.

[Source](https://developer.apple.com/documentation/avfaudio/avaudiosessioncategoryoptions/avaudiosessioncategoryoptioninterruptspokenaudioandmixwithothers)