### PR TITLE
[bookmarks] Reuse the MarkGroupId during the category reloading

### DIFF
--- a/map/bookmark_manager.cpp
+++ b/map/bookmark_manager.cpp
@@ -472,10 +472,10 @@ void BookmarkManager::OnEditSessionClosed()
 {
   ASSERT_GREATER(m_openedEditSessionsCount, 0, ());
   if (--m_openedEditSessionsCount == 0)
-    NotifyChanges(true);
+    NotifyChanges(true /* saveChangesOnDisk */);
 }
 
-void BookmarkManager::NotifyChanges(bool saveChangesOnDisk /* = true */)
+void BookmarkManager::NotifyChanges(bool saveChangesOnDisk)
 {
   CHECK_THREAD_CHECKER(m_threadChecker, ());
 
@@ -1558,8 +1558,7 @@ kml::MarkGroupId BookmarkManager::GetCategoryByFileName(std::string const & file
   CHECK_THREAD_CHECKER(m_threadChecker, ());
   for (auto const & c : m_categories)
   {
-    std::string categoryFileName = c.second->GetFileName();
-    if (categoryFileName == fileName)
+    if (c.second->GetFileName() == fileName)
       return c.second->GetID();
   }
   return kml::kInvalidMarkGroupId;

--- a/map/bookmark_manager.hpp
+++ b/map/bookmark_manager.hpp
@@ -267,6 +267,7 @@ public:
 
   kml::MarkGroupId CreateBookmarkCategory(kml::CategoryData && data, bool autoSave = true);
   kml::MarkGroupId CreateBookmarkCategory(std::string const & name, bool autoSave = true);
+  void UpdateBookmarkCategory(kml::MarkGroupId & groupId, kml::CategoryData && data, bool autoSave);
 
   BookmarkCategory * CreateBookmarkCompilation(kml::CategoryData && data);
 
@@ -593,7 +594,7 @@ private:
 
   void OnEditSessionOpened();
   void OnEditSessionClosed();
-  void NotifyChanges();
+  void NotifyChanges(bool saveBookmarks);
 
   void SaveState() const;
   void LoadState();
@@ -625,6 +626,8 @@ private:
 
   kml::MarkGroupId CheckAndCreateDefaultCategory();
   void CheckAndResetLastIds();
+
+  kml::MarkGroupId GetCategoryByFileName(std::string const & fileName) const;
 
   std::unique_ptr<kml::FileData> CollectBmGroupKMLData(BookmarkCategory const * group) const;
   KMLDataCollectionPtr PrepareToSaveBookmarks(kml::GroupIdCollection const & groupIdCollection);

--- a/map/bookmark_manager.hpp
+++ b/map/bookmark_manager.hpp
@@ -594,7 +594,7 @@ private:
 
   void OnEditSessionOpened();
   void OnEditSessionClosed();
-  void NotifyChanges(bool saveBookmarks);
+  void NotifyChanges(bool saveChangesOnDisk);
 
   void SaveState() const;
   void LoadState();

--- a/map/map_tests/bookmarks_test.cpp
+++ b/map/map_tests/bookmarks_test.cpp
@@ -1070,8 +1070,9 @@ UNIT_CLASS_TEST(Runner, Bookmarks_SpecialXMLNames)
   BookmarkManager bmManager(BM_CALLBACKS);
   bmManager.EnableTestMode(true);
 
+  auto const file1Name = "file1";
   BookmarkManager::KMLDataCollection kmlDataCollection1;
-  kmlDataCollection1.emplace_back("" /* filePath */,
+  kmlDataCollection1.emplace_back(file1Name /* filePath */,
                                  LoadKmlData(MemReader(kmlString3, strlen(kmlString3)), KmlFileType::Text));
   bmManager.CreateCategories(std::move(kmlDataCollection1));
 
@@ -1096,23 +1097,25 @@ UNIT_CLASS_TEST(Runner, Bookmarks_SpecialXMLNames)
 
   bmManager.GetEditSession().DeleteBmCategory(catId);
 
+  auto const file2Name = "file2";
   BookmarkManager::KMLDataCollection kmlDataCollection2;
-  kmlDataCollection2.emplace_back("" /* filePath */, LoadKmlFile(fileNameTmp, GetActiveKmlFileType()));
+  kmlDataCollection2.emplace_back(file1Name /* filePath */, LoadKmlFile(fileNameTmp, GetActiveKmlFileType()));
   bmManager.CreateCategories(std::move(kmlDataCollection2));
 
   BookmarkManager::KMLDataCollection kmlDataCollection3;
-  kmlDataCollection3.emplace_back("" /* filePath */,
+  kmlDataCollection3.emplace_back(file2Name /* filePath */,
                                   LoadKmlData(MemReader(kmlString3, strlen(kmlString3)), KmlFileType::Text));
 
   bmManager.CreateCategories(std::move(kmlDataCollection3));
 
   TEST_EQUAL(bmManager.GetBmGroupsCount(), 2, ());
-  auto const catId2 = bmManager.GetSortedBmGroupIdList().back();
-  auto const catId3 = bmManager.GetSortedBmGroupIdList().front();
+  auto const catId2 = bmManager.GetSortedBmGroupIdList().front();
+  auto const catId3 = bmManager.GetSortedBmGroupIdList().back();
 
   TEST_EQUAL(bmManager.GetUserMarkIds(catId2).size(), 1, ());
   TEST_EQUAL(bmManager.GetCategoryName(catId2), expectedName, ());
-  TEST(bmManager.GetCategoryFileName(catId2).empty(), ());
+  TEST_EQUAL(bmManager.GetCategoryFileName(catId2), file1Name, ());
+  TEST_EQUAL(bmManager.GetCategoryFileName(catId3), file2Name, ());
 
   auto const bmId1 = *bmManager.GetUserMarkIds(catId2).begin();
   auto const * bm1 = bmManager.GetBookmark(bmId1);


### PR DESCRIPTION
Key points:
1. `CreateCategories` is called to create the category from the parsed data. Now this method re-write the collection without duplication to the MarkGroupId if the fileName is the same. Generation the unique fileNames is responsibility of the `GenerateValidAndUniqueFilePathForKML`
2. `GetCategoryByFileName` returns the MarkGroupId associated with the categotry fileName (filename is actually the file path).
3. `ReloadBookmarkCategory` cleans up the old data from memory and reloads the collection.
4. The parameter `saveBookmarksIfNeeded` was added to the `NotifyChanges` because the reloaded file shouldn't be resaved to prevent the race condition (get new version from cloud -> parse -> re-save -> update cloud -> get from sync -> parse -> re-save...). All new files that were added to the app during the startup or deeplinks will be parsed and re-saved as usual.


This PR doesn't affect the current behavior because we don't reload collections now. But #7641 requires this fix.