### PR TITLE
[ios] Fix crash during the bookmark editing on ipad when the PP is open

### DIFF
--- a/iphone/CoreApi/CoreApi/Bookmarks/MWMBookmarksManager.h
+++ b/iphone/CoreApi/CoreApi/Bookmarks/MWMBookmarksManager.h
@@ -61,6 +61,7 @@ NS_SWIFT_NAME(BookmarksManager)
 - (void)setUserCategoriesVisible:(BOOL)isVisible;
 - (void)deleteCategory:(MWMMarkGroupID)groupId;
 - (BOOL)checkCategoryName:(NSString *)name;
+- (BOOL)hasBookmark:(MWMMarkID)bookmarkId;
 - (NSArray<NSNumber *> *)availableSortingTypes:(MWMMarkGroupID)groupId hasMyPosition:(BOOL)hasMyPosition;
 - (void)sortBookmarks:(MWMMarkGroupID)groupId
           sortingType:(MWMBookmarksSortingType)sortingType

--- a/iphone/CoreApi/CoreApi/Bookmarks/MWMBookmarksManager.mm
+++ b/iphone/CoreApi/CoreApi/Bookmarks/MWMBookmarksManager.mm
@@ -339,6 +339,11 @@ static BookmarkManager::SortingType convertSortingTypeToCore(MWMBookmarksSorting
   return !self.bm.IsUsedCategoryName(name.UTF8String);
 }
 
+- (BOOL)hasBookmark:(MWMMarkID)bookmarkId
+{
+  return self.bm.HasBookmark(bookmarkId);
+}
+
 - (NSArray<NSNumber *> *)availableSortingTypes:(MWMMarkGroupID)groupId hasMyPosition:(BOOL)hasMyPosition{
   auto const availableTypes = self.bm.GetAvailableSortingTypes(groupId, hasMyPosition);
   NSMutableArray *result = [NSMutableArray array];

--- a/iphone/Maps/UI/PlacePage/Components/PlacePageInfoViewController.swift
+++ b/iphone/Maps/UI/PlacePage/Components/PlacePageInfoViewController.swift
@@ -48,6 +48,7 @@ class InfoItemViewController: UIViewController {
 }
 
 protocol PlacePageInfoViewControllerDelegate: AnyObject {
+  func viewWillAppear()
   func didPressCall()
   func didPressWebsite()
   func didPressWebsiteMenu()
@@ -335,6 +336,11 @@ class PlacePageInfoViewController: UIViewController {
       coordinatesView?.accessoryImage.image = UIImage(named: "ic_placepage_change")
       coordinatesView?.accessoryImage.isHidden = false
     }
+  }
+
+  override func viewWillAppear(_ animated: Bool) {
+    super.viewWillAppear(animated)
+    delegate?.viewWillAppear()
   }
 
   // MARK: private

--- a/iphone/Maps/UI/PlacePage/PlacePageInteractor.swift
+++ b/iphone/Maps/UI/PlacePage/PlacePageInteractor.swift
@@ -14,6 +14,15 @@ class PlacePageInteractor {
     self.viewController = viewController
     self.mapViewController = mapViewController
   }
+
+  private func updateBookmarkIfNeeded() {
+    guard let bookmarkId = placePageData.bookmarkData?.bookmarkId else { return }
+    if !BookmarksManager.shared().hasBookmark(bookmarkId) {
+      presenter?.closeAnimated()
+    }
+    FrameworkHelper.updatePlacePageData()
+    placePageData.updateBookmarkStatus()
+  }
 }
 
 extension PlacePageInteractor: PlacePageInteractorProtocol {
@@ -25,6 +34,10 @@ extension PlacePageInteractor: PlacePageInteractorProtocol {
 // MARK: - PlacePageInfoViewControllerDelegate
 
 extension PlacePageInteractor: PlacePageInfoViewControllerDelegate {
+  func viewWillAppear() {
+    updateBookmarkIfNeeded()
+  }
+  
   func didPressCall() {
     MWMPlacePageManagerHelper.call(placePageData)
   }

--- a/map/bookmark_manager.cpp
+++ b/map/bookmark_manager.cpp
@@ -2273,6 +2273,13 @@ bool BookmarkManager::HasBmCategory(kml::MarkGroupId groupId) const
   return (IsBookmarkCategory(groupId) && GetBmCategorySafe(groupId) != nullptr);
 }
 
+bool BookmarkManager::HasBookmark(kml::MarkId markId) const
+{
+  CHECK_THREAD_CHECKER(m_threadChecker, ());
+  ASSERT(IsBookmark(markId), ());
+  return (GetBookmark(markId) != nullptr);
+}
+
 void BookmarkManager::UpdateBmGroupIdList()
 {
   CHECK_THREAD_CHECKER(m_threadChecker, ());

--- a/map/bookmark_manager.hpp
+++ b/map/bookmark_manager.hpp
@@ -282,6 +282,7 @@ public:
   kml::GroupIdCollection GetSortedBmGroupIdList() const;
   size_t GetBmGroupsCount() const { return m_unsortedBmGroupsIdList.size(); };
   bool HasBmCategory(kml::MarkGroupId groupId) const;
+  bool HasBookmark(kml::MarkId markId) const;
   kml::MarkGroupId LastEditedBMCategory();
   kml::PredefinedColor LastEditedBMColor() const;
 


### PR DESCRIPTION
Closes https://github.com/organicmaps/organicmaps/issues/8189

This PR fixes the issue when the bookmark/track data on the opened PP isn't updated during the editing from the `Bookmarks - select bm - Edit bookmark` - see #8189.

![Simulator Screen Recording - iPad Air (5th generation) - 2024-05-21 at 21 24 53](https://github.com/organicmaps/organicmaps/assets/79797627/6fa18b97-5a9c-40fe-a5a7-556780b74a74)
