### PR TITLE
[drape] Split text into segments needed for proper text shaping with Harfbuzz

### DIFF
--- a/drape/CMakeLists.txt
+++ b/drape/CMakeLists.txt
@@ -85,6 +85,8 @@ set(SRC
   support_manager.hpp
   symbols_texture.cpp
   symbols_texture.hpp
+  harfbuzz_shaping.cpp
+  harfbuzz_shaping.hpp
   texture.cpp
   texture.hpp
   texture_manager.cpp
@@ -180,3 +182,5 @@ target_link_libraries(${PROJECT_NAME}
 )
 
 omim_add_test_subdirectory(drape_tests)
+
+omim_add_tool_subdirectory(fonts_tool)

--- a/drape/drape_tests/glyph_mng_tests.cpp
+++ b/drape/drape_tests/glyph_mng_tests.cpp
@@ -5,30 +5,43 @@
 #include "drape/bidi.hpp"
 #include "drape/font_constants.hpp"
 #include "drape/glyph_manager.hpp"
+#include "drape/harfbuzz_shaping.hpp"
+
+#include "qt_tstfrm/test_main_loop.hpp"
 
 #include "platform/platform.hpp"
 
 #include <QtGui/QPainter>
 
-#include "qt_tstfrm/test_main_loop.hpp"
-
-#include <cstring>
+#include <ft2build.h>
 #include <functional>
 #include <iostream>
-#include <memory>
 #include <vector>
+#include FT_FREETYPE_H
+#include FT_MODULE_H
+#include <harfbuzz/hb-ft.h>
+#include <harfbuzz/hb.h>
 
-using namespace std::placeholders;
-
-namespace
+namespace glyph_mng_tests
 {
 class GlyphRenderer
 {
-  strings::UniString m_toDraw;
+  FT_Library m_freetypeLibrary;
+  strings::UniString m_bidiToDraw;
+  std::string m_utf8;
+  int m_fontPixelSize;
+  char const * m_lang;
+
+  static constexpr FT_Int kSdfSpread {dp::kSdfBorder};
 
 public:
   GlyphRenderer()
   {
+    // Initialize FreeType
+    TEST_EQUAL(0, FT_Init_FreeType(&m_freetypeLibrary), ("Can't initialize FreeType"));
+    for (auto const module : {"sdf", "bsdf"})
+      TEST_EQUAL(0, FT_Property_Set(m_freetypeLibrary, module, "spread", &kSdfSpread), ());
+
     dp::GlyphManager::Params args;
     args.m_uniBlocks = "unicode_blocks.txt";
     args.m_whitelist = "fonts_whitelist.txt";
@@ -38,9 +51,33 @@ public:
     m_mng = std::make_unique<dp::GlyphManager>(args);
   }
 
-  void SetString(std::string const & s)
+  ~GlyphRenderer()
   {
-    m_toDraw = bidi::log2vis(strings::MakeUniString(s));
+    FT_Done_FreeType(m_freetypeLibrary);
+  }
+
+  void SetString(std::string const & s, int fontPixelSize, char const * lang)
+  {
+    m_bidiToDraw = bidi::log2vis(strings::MakeUniString(s));
+    m_utf8 = s;
+    m_fontPixelSize = fontPixelSize;
+    m_lang = lang;
+  }
+
+  static float Smoothstep(float edge0, float edge1, float x)
+  {
+    x = std::clamp((x - edge0) / (edge1 - edge0), 0.0f, 1.0f);
+    return x * x * (3 - 2 * x);
+  }
+
+  static float PixelColorFromDistance(float distance)
+  {
+    //float const normalizedDistance = (distance - 128.f) / 128.f;
+    float const normalizedDistance = distance / 255.f;
+    static constexpr float kFontScale = 1.f;
+    static constexpr float kSmoothing = 0.25f / (kSdfSpread * kFontScale);
+    float const alpha = Smoothstep(0.5f - kSmoothing, 0.5f + kSmoothing, normalizedDistance);
+    return 255.f * alpha;
   }
 
   void RenderGlyphs(QPaintDevice * device)
@@ -48,24 +85,167 @@ public:
     QPainter painter(device);
     painter.fillRect(QRectF(0.0, 0.0, device->width(), device->height()), Qt::white);
 
-    QPoint pen(100, 100);
-    float const ratio = 2.0;
-    for (auto c : m_toDraw)
+    auto const shapedText = m_mng->ShapeText(m_utf8, m_fontPixelSize, m_lang);
+
+    std::cout << "Total width: " << shapedText.m_lineWidthInPixels << '\n';
+    std::cout << "Max height: " << shapedText.m_maxLineHeightInPixels << '\n';
+
+    QPoint pen(10, 50);
+
+    for (auto const & glyph : shapedText.m_glyphs)
+    {
+      constexpr bool kUseSdfBitmap = false;
+      dp::GlyphImage img = m_mng->GetGlyphImage(glyph.m_font, glyph.m_glyphId, m_fontPixelSize, kUseSdfBitmap);
+
+      auto const w = img.m_width;
+      auto const h = img.m_height;
+      // Spaces do not have images.
+      if (w && h)
+      {
+        QPoint currentPen = pen;
+        currentPen.rx() += glyph.m_xOffset;
+        currentPen.ry() -= glyph.m_yOffset;
+        painter.drawImage(currentPen, CreateImage(w, h, img.m_data->data()), QRect(0, 0, w, h));
+      }
+      pen += QPoint(glyph.m_xAdvance, 0);
+
+      img.Destroy();
+    }
+
+    ////////////////////////////////////////////////////////////////////////////
+    // Manual rendering using HB functions.
+    {
+      QPoint hbPen(10, 100);
+
+      auto const hbLanguage = hb_language_from_string(m_lang, -1);
+
+      auto const runs = harfbuzz_shaping::GetTextSegments(m_utf8);
+      for (auto const & segment : runs.m_segments)
+      {
+        hb_buffer_t * buf = hb_buffer_create();
+        hb_buffer_add_utf16(buf, reinterpret_cast<const uint16_t *>(runs.m_text.data()), runs.m_text.size(), segment.m_start, segment.m_length);
+        hb_buffer_set_direction(buf, segment.m_direction);
+        hb_buffer_set_script(buf, segment.m_script);
+        hb_buffer_set_language(buf, hbLanguage);
+
+        // If direction, script, and language are not known.
+        // hb_buffer_guess_segment_properties(buf);
+
+        std::string const lang = m_lang;
+        std::string const fontFileName = lang == "ar" ? "00_NotoNaskhArabic-Regular.ttf" : "07_roboto_medium.ttf";
+
+        auto reader = GetPlatform().GetReader(fontFileName);
+        auto fontFile = reader->GetName();
+        FT_Face face;
+        if (FT_New_Face(m_freetypeLibrary, fontFile.c_str(), 0, &face)) {
+          std::cerr << "Can't load font " << fontFile << '\n';
+          return;
+        }
+        // Set character size
+        FT_Set_Pixel_Sizes(face, 0 , m_fontPixelSize );
+        // This also works.
+        // if (FT_Set_Char_Size(face, 0, m_fontPixelSize << 6, 0, 0)) {
+        //   std::cerr << "Can't set character size\n";
+        //   return;
+        // }
+
+        // Set no transform (identity)
+        //FT_Set_Transform(face, nullptr, nullptr);
+
+        // Load font into HarfBuzz
+        hb_font_t *font = hb_ft_font_create(face, nullptr);
+
+        // Shape!
+        hb_shape(font, buf, nullptr, 0);
+
+        // Get the glyph and position information.
+        unsigned int glyph_count;
+        hb_glyph_info_t *glyph_info    = hb_buffer_get_glyph_infos(buf, &glyph_count);
+        hb_glyph_position_t *glyph_pos = hb_buffer_get_glyph_positions(buf, &glyph_count);
+
+        for (unsigned int i = 0; i < glyph_count; i++)
+        {
+          hb_codepoint_t const glyphid = glyph_info[i].codepoint;
+
+          FT_Int32 const flags =  FT_LOAD_RENDER;
+          FT_Load_Glyph(face, glyphid, flags);
+          FT_Render_Glyph(face->glyph, FT_RENDER_MODE_SDF);
+
+          FT_GlyphSlot slot = face->glyph;
+
+          FT_Bitmap const & ftBitmap = slot->bitmap;
+
+          auto const buffer = ftBitmap.buffer;
+          auto const width = ftBitmap.width;
+          auto const height = ftBitmap.rows;
+
+          for (unsigned h = 0; h < height; ++h)
+          {
+            for (unsigned w = 0; w < width; ++w)
+            {
+              auto curPixelAddr = buffer + h * width + w;
+              float currPixel = *curPixelAddr;
+              currPixel = PixelColorFromDistance(currPixel);
+              *curPixelAddr = static_cast<unsigned char>(currPixel);
+            }
+          }
+
+          auto const bearing_x = slot->metrics.horiBearingX;//slot->bitmap_left;
+          auto const bearing_y = slot->metrics.horiBearingY;//slot->bitmap_top;
+
+          auto const & glyphPos = glyph_pos[i];
+          hb_position_t const x_offset  = (glyphPos.x_offset + bearing_x) >> 6;
+          hb_position_t const y_offset  = (glyphPos.y_offset + bearing_y) >> 6;
+          hb_position_t const x_advance = glyphPos.x_advance >> 6;
+          hb_position_t const y_advance = glyphPos.y_advance >> 6;
+
+          // Empty images are possible for space characters.
+          if (width != 0 && height != 0)
+          {
+            QPoint currentPen = hbPen;
+            currentPen.rx() += x_offset;
+            currentPen.ry() -= y_offset;
+            painter.drawImage(currentPen, CreateImage(width, height, buffer), QRect(kSdfSpread, kSdfSpread, width - 2*kSdfSpread, height - 2*kSdfSpread));
+          }
+          hbPen += QPoint(x_advance, y_advance);
+        }
+
+        // Tidy up.
+        hb_buffer_destroy(buf);
+        hb_font_destroy(font);
+        FT_Done_Face(face);
+      }
+    }
+
+    //////////////////////////////////////////////////////////////////
+    // QT text renderer.
+    {
+      QPoint pen(10, 150);
+      //QFont font("Noto Naskh Arabic");
+      QFont font("Roboto");
+      font.setPixelSize(m_fontPixelSize);
+      //font.setWeight(QFont::Weight::Normal);
+      painter.setFont(font);
+      painter.drawText(pen, QString::fromUtf8(m_utf8.c_str(), m_utf8.size()));
+    }
+
+    //////////////////////////////////////////////////////////////////
+    // Old drape renderer.
+    pen = QPoint(10, 200);
+    for (auto c : m_bidiToDraw)
     {
       auto g = m_mng->GetGlyph(c);
 
       if (g.m_image.m_data)
       {
         uint8_t * d = SharedBufferManager::GetRawPointer(g.m_image.m_data);
-
         QPoint currentPen = pen;
-        currentPen.rx() += g.m_metrics.m_xOffset * ratio;
-        currentPen.ry() -= g.m_metrics.m_yOffset * ratio;
+        currentPen.rx() += g.m_metrics.m_xOffset;
+        currentPen.ry() -= g.m_metrics.m_yOffset;
         painter.drawImage(currentPen, CreateImage(g.m_image.m_width, g.m_image.m_height, d),
-                          QRect(0, 0, g.m_image.m_width, g.m_image.m_height));
+            QRect(dp::kSdfBorder, dp::kSdfBorder, g.m_image.m_width - 2 * dp::kSdfBorder, g.m_image.m_height - 2 * dp::kSdfBorder));
       }
-      pen.rx() += g.m_metrics.m_xAdvance * ratio;
-      pen.ry() += g.m_metrics.m_yAdvance * ratio;
+      pen += QPoint(g.m_metrics.m_xAdvance,  g.m_metrics.m_yAdvance);
 
       g.m_image.Destroy();
     }
@@ -74,7 +254,6 @@ public:
 private:
   std::unique_ptr<dp::GlyphManager> m_mng;
 };
-}  // namespace
 
 // This unit test creates a window so can't be run in GUI-less Linux machine.
 // Make sure that the QT_QPA_PLATFORM=offscreen environment variable is set.
@@ -82,15 +261,33 @@ UNIT_TEST(GlyphLoadingTest)
 {
   GlyphRenderer renderer;
 
-  renderer.SetString("ØŒÆ");
-  RunTestLoop("Test1", std::bind(&GlyphRenderer::RenderGlyphs, &renderer, _1));
+  using namespace std::placeholders;
 
-  renderer.SetString("الحلّة");
-  RunTestLoop("Test2", std::bind(&GlyphRenderer::RenderGlyphs, &renderer, _1));
+  constexpr int fontSize = 27;
 
-  renderer.SetString("گُلها");
-  RunTestLoop("Test3", std::bind(&GlyphRenderer::RenderGlyphs, &renderer, _1));
+  renderer.SetString("Тестовая строка", fontSize, "ru");
+  RunTestLoop("ru", std::bind(&GlyphRenderer::RenderGlyphs, &renderer, _1));
 
-  renderer.SetString("മനക്കലപ്പടി");
-  RunTestLoop("Test4", std::bind(&GlyphRenderer::RenderGlyphs, &renderer, _1));
+  renderer.SetString("ØŒÆ", fontSize, "en");
+  RunTestLoop("en", std::bind(&GlyphRenderer::RenderGlyphs, &renderer, _1));
+
+  renderer.SetString("𫝚 𫝛 𫝜", fontSize, "zh");
+  RunTestLoop("CJK Surrogates", std::bind(&GlyphRenderer::RenderGlyphs, &renderer, _1));
+
+  renderer.SetString("الحلّة گلها"" كسول الزنجبيل القط""56""عين علي (الحربية)""123"" اَلْعَرَبِيَّةُ", fontSize, "ar");
+  RunTestLoop("Arabic1", std::bind(&GlyphRenderer::RenderGlyphs, &renderer, _1));
+
+  renderer.SetString("12345""گُلها""12345""گُلها""12345", fontSize, "ar");
+  RunTestLoop("Arabic2", std::bind(&GlyphRenderer::RenderGlyphs, &renderer, _1));
+
+  renderer.SetString("മനക്കലപ്പടി", fontSize, "ml");
+  RunTestLoop("Malay", std::bind(&GlyphRenderer::RenderGlyphs, &renderer, _1));
+
+  renderer.SetString("Test 12 345 ""گُلها""678 9000 Test", fontSize, "ar");
+  RunTestLoop("Arabic Mixed", std::bind(&GlyphRenderer::RenderGlyphs, &renderer, _1));
+
+  renderer.SetString("NFKC Razdoĺny NFKD Razdoĺny", fontSize, "be");
+  RunTestLoop("Polish", std::bind(&GlyphRenderer::RenderGlyphs, &renderer, _1));
 }
+
+}  // namespace glyph_mng_tests

--- a/drape/fonts_tool/CMakeLists.txt
+++ b/drape/fonts_tool/CMakeLists.txt
@@ -1,0 +1,9 @@
+project(fonts_tool)
+
+set(SRC
+  fonts_tool.cpp
+)
+
+omim_add_executable(${PROJECT_NAME} ${SRC})
+
+target_link_libraries(${PROJECT_NAME} drape)

--- a/drape/fonts_tool/fonts_tool.cpp
+++ b/drape/fonts_tool/fonts_tool.cpp
@@ -1,0 +1,62 @@
+#include "drape/glyph_manager.hpp"
+#include "drape/harfbuzz_shaping.hpp"
+
+#include "platform/platform.hpp"
+
+#include "base/string_utils.hpp"
+
+#include <fstream>
+#include <iostream>
+#include <numeric>  // std::accumulate
+
+void ItemizeLine(std::string & str, dp::GlyphManager & glyphManager)
+{
+  strings::Trim(str);
+  if (str.empty())
+    return;
+
+  auto const segments = harfbuzz_shaping::GetTextSegments(str);
+  for (const auto & run : segments.m_segments)
+  {
+    std::u16string_view sv{segments.m_text.data() + run.m_start, static_cast<size_t>(run.m_length)};
+    std::cout << DebugPrint(sv) << '|';
+  }
+  std::cout << '\n';
+}
+
+int main(int argc, char** argv)
+{
+  if (argc < 2)
+  {
+    std::cout << "Debugging tool to experiment with text segmentation\n";
+    std::cout << "Usage: " << argv[0] << " [text file with utf8 strings or any arbitrary text string]\n";
+    return -1;
+  }
+
+  dp::GlyphManager::Params params;
+  params.m_uniBlocks = "unicode_blocks.txt";
+  params.m_whitelist = "fonts_whitelist.txt";
+  params.m_blacklist = "fonts_blacklist.txt";
+  GetPlatform().GetFontNames(params.m_fonts);
+
+  dp::GlyphManager glyphManager(params);
+
+  if (Platform::IsFileExistsByFullPath(argv[1]))
+  {
+    std::ifstream file(argv[1]);
+    std::string line;
+    while (file.good())
+    {
+      std::getline(file, line);
+      ItemizeLine(line, glyphManager);
+    }
+  }
+  else
+  {
+    // Get all args as one string.
+    std::vector<std::string> const args(argv + 1, argv + argc);
+    auto line = std::accumulate(args.begin(), args.end(), std::string{});
+    ItemizeLine(line, glyphManager);
+  }
+  return 0;
+}

--- a/drape/glyph_manager.hpp
+++ b/drape/glyph_manager.hpp
@@ -14,6 +14,36 @@ namespace dp
 {
 struct UnicodeBlock;
 
+// TODO(AB): Move to a separate file?
+namespace text
+{
+struct GlyphMetrics
+{
+  int16_t m_font;
+  uint16_t m_glyphId;
+  // TODO(AB): Store original font units or floats?
+  int32_t m_xOffset;
+  int32_t m_yOffset;
+  int32_t m_xAdvance;
+  // yAdvance is used only in vertical text layouts.
+};
+
+// TODO(AB): Move to a separate file?
+struct TextMetrics
+{
+  int32_t m_lineWidthInPixels {0};
+  int32_t m_maxLineHeightInPixels {0};
+  std::vector<GlyphMetrics> m_glyphs;
+
+  void AddGlyphMetrics(int16_t font, uint16_t glyphId, int32_t xOffset, int32_t yOffset, int32_t xAdvance, int32_t height)
+  {
+    m_glyphs.push_back({font, glyphId, xOffset, yOffset, xAdvance});
+    m_lineWidthInPixels += xAdvance;
+    m_maxLineHeightInPixels = std::max(m_maxLineHeightInPixels, height);
+  }
+};
+}  // namespace text
+
 class GlyphManager
 {
 public:
@@ -36,13 +66,19 @@ public:
 
   Glyph const & GetInvalidGlyph() const;
 
-private:
   int GetFontIndex(strings::UniChar unicodePoint);
+  int GetFontIndex(std::u16string_view sv);
+
+  text::TextMetrics ShapeText(std::string_view utf8, int fontPixelHeight, int8_t lang);
+  text::TextMetrics ShapeText(std::string_view utf8, int fontPixelHeight, char const * lang);
+
+  GlyphImage GetGlyphImage(int fontIndex, uint16_t glyphId, int pixelHeight, bool sdf);
+
+private:
   // Immutable version can be called from any thread and doesn't require internal synchronization.
   int GetFontIndexImmutable(strings::UniChar unicodePoint) const;
   int FindFontIndexInBlock(UnicodeBlock const & block, strings::UniChar unicodePoint) const;
 
-private:
   struct Impl;
   std::unique_ptr<Impl> m_impl;
 };

--- a/drape/harfbuzz_shaping.cpp
+++ b/drape/harfbuzz_shaping.cpp
@@ -1,0 +1,223 @@
+#include "drape/harfbuzz_shaping.hpp"
+
+#include "base/assert.hpp"
+#include "base/logging.hpp"
+#include "base/string_utils.hpp"
+
+#include <array>
+#include <string>
+
+#include <unicode/ubidi.h>    // ubidi_open, ubidi_setPara
+#include <unicode/uscript.h>  // UScriptCode
+#include <utf8/unchecked.h>
+
+namespace harfbuzz_shaping
+{
+namespace
+{
+// Some Unicode characters may be a part of up to 32 different scripts.
+using TScriptsArray = std::array<UScriptCode, 32>;
+
+// Writes the script and the script extensions of the Unicode codepoint.
+// Returns the number of written scripts.
+size_t GetScriptExtensions(char32_t codepoint, TScriptsArray & scripts)
+{
+  // Fill scripts with the script extensions.
+  UErrorCode icu_error = U_ZERO_ERROR;
+  size_t const count = uscript_getScriptExtensions(static_cast<UChar32>(codepoint), scripts.data(),
+                                                   scripts.max_size(), &icu_error);
+  if (U_FAILURE(icu_error))
+  {
+    LOG(LWARNING, ("uscript_getScriptExtensions failed with error", icu_error));
+    return 0;
+  }
+
+  return count;
+}
+
+// Intersects the script extensions set of codepoint with scripts and returns the updated size of the scripts.
+// The output result will be a subset of the input result (thus resultSize can only be smaller).
+size_t ScriptSetIntersect(char32_t codepoint, TScriptsArray & inOutScripts, size_t inOutScriptsCount)
+{
+  // Each codepoint has a Script property and a Script Extensions (Scx) property.
+  //
+  // The implicit Script property values 'Common' and 'Inherited' indicate that a codepoint is widely used in many
+  // scripts, rather than being associated to a specific script.
+  //
+  // However, some codepoints that are assigned a value of 'Common' or 'Inherited' are not commonly used with all
+  // scripts, but rather only with a limited set of scripts. The Script Extension property is used to specify the set
+  // of script which borrow the codepoint.
+  //
+  // Calls to GetScriptExtensions(...) return the set of scripts where the codepoints can be used.
+  // (see table 7 from http://www.unicode.org/reports/tr24/tr24-29.html)
+  //
+  //     Script       Script Extensions ->  Results
+  //  1) Common       {Common}          ->  {Common}
+  //     Inherited    {Inherited}       ->  {Inherited}
+  //  2) Latin        {Latn}            ->  {Latn}
+  //     Inherited    {Latn}            ->  {Latn}
+  //  3) Common       {Hira Kana}       ->  {Hira Kana}
+  //     Inherited    {Hira Kana}       ->  {Hira Kana}
+  //  4) Devanagari   {Deva Dogr Kthi Mahj}  ->  {Deva Dogr Kthi Mahj}
+  //     Myanmar      {Cakm Mymr Tale}  ->  {Cakm Mymr Tale}
+  //
+  // For most of the codepoints, the script extensions set contains only one element. For CJK codepoints, it's common
+  // to see 3-4 scripts. For really rare cases, the set can go above 20 scripts.
+  TScriptsArray codepointScripts;
+  size_t const codepointScriptsCount = GetScriptExtensions(codepoint, codepointScripts);
+
+  // Implicit script 'inherited' is inheriting scripts from preceding codepoint.
+  if (codepointScriptsCount == 1 && codepointScripts[0] == USCRIPT_INHERITED)
+    return inOutScriptsCount;
+
+  auto const contains = [&codepointScripts, codepointScriptsCount](UScriptCode code)
+  {
+    for (size_t i = 0; i < codepointScriptsCount; ++i)
+      if (codepointScripts[i] == code)
+        return true;
+
+    return false;
+  };
+
+  // Intersect both script sets.
+  ASSERT(!contains(USCRIPT_INHERITED), ());
+  size_t outSize = 0;
+  for (auto const currentScript : inOutScripts)
+  {
+    if (contains(currentScript))
+      inOutScripts[outSize++] = currentScript;
+  }
+
+  return outSize;
+}
+
+// Find the longest sequence of characters from 0 and up to length that have at least one common UScriptCode value.
+// Writes the common script value to script and returns the length of the sequence. Takes the characters' script
+// extensions into account. http://www.unicode.org/reports/tr24/#ScriptX
+//
+// Consider 3 characters with the script values {Kana}, {Hira, Kana}, {Kana}. Without script extensions only the first
+// script in each set would be taken into account, resulting in 3 segments where 1 would be enough.
+size_t ScriptInterval(std::u16string const & text, int32_t start, size_t length, UScriptCode & outScript)
+{
+  ASSERT_GREATER(length, 0U, ());
+
+  auto const begin = text.begin() + start;
+  auto const end = text.begin() + start + static_cast<int32_t>(length);
+  auto iterator = begin;
+
+  auto c32 = utf8::unchecked::next16(iterator);
+
+  TScriptsArray scripts;
+  size_t scriptsSize = GetScriptExtensions(c32, scripts);
+
+  while (iterator != end)
+  {
+    c32 = utf8::unchecked::next16(iterator);
+    scriptsSize = ScriptSetIntersect(c32, scripts, scriptsSize);
+    if (scriptsSize == 0U)
+    {
+      length = iterator - begin;
+      break;
+    }
+  }
+
+  outScript = scripts[0];
+  return length;
+}
+
+// A copy of hb_icu_script_to_script to avoid direct ICU dependency.
+hb_script_t ICUScriptToHarfbuzzScript(UScriptCode script)
+{
+  if (script == USCRIPT_INVALID_CODE)
+    return HB_SCRIPT_INVALID;
+  return hb_script_from_string(uscript_getShortName (script), -1);
+}
+
+void GetSingleTextLineRuns(TextSegments & segments)
+{
+  auto const & text = segments.m_text;
+  auto const textLength = static_cast<int32_t>(text.length());
+
+  // Deliberately not checking for nullptr.
+  thread_local UBiDi * const bidi = ubidi_open();
+  UErrorCode error = U_ZERO_ERROR;
+  ::ubidi_setPara(bidi, text.data(), textLength, UBIDI_DEFAULT_LTR, nullptr, &error);
+  if (U_FAILURE(error))
+  {
+    LOG(LERROR, ("ubidi_setPara failed with code", error));
+    segments.m_segments.emplace_back(0, 0, HB_SCRIPT_UNKNOWN, HB_DIRECTION_INVALID);
+    return;
+  }
+
+  // Split the original text by logical runs, then each logical run by common script and each sequence at special
+  // characters and style boundaries. This invariant holds: bidiRunStart <= scriptRunStart <= breakingRunStart
+  // <= breakingRunEnd <= scriptRunStart <= bidiRunEnd. AB: Breaking runs are dropped now, they may not be needed.
+  for (int32_t bidiRunStart = 0; bidiRunStart < textLength;)
+  {
+    // Determine the longest logical run (e.g. same bidi direction) from this point.
+    int32_t bidiRunBreak = 0;
+    UBiDiLevel bidiLevel = 0;
+    ::ubidi_getLogicalRun(bidi, bidiRunStart, &bidiRunBreak, &bidiLevel);
+    int32_t const bidiRunEnd = bidiRunBreak;
+    ASSERT_LESS(bidiRunStart, bidiRunEnd, ());
+
+    for (int32_t scriptRunStart = bidiRunStart; scriptRunStart < bidiRunEnd;)
+    {
+      // Find the longest sequence of characters that have at least one common UScriptCode value.
+      UScriptCode script = USCRIPT_INVALID_CODE;
+      size_t const scriptRunEnd = ScriptInterval(segments.m_text, scriptRunStart, bidiRunEnd - scriptRunStart, script) + scriptRunStart;
+      ASSERT_LESS(scriptRunStart, base::asserted_cast<int32_t>(scriptRunEnd), ());
+
+      // TODO(AB): May need to break on different unicode blocks, parentheses, and control chars (spaces).
+
+      // TODO(AB): Support vertical layouts if necessary.
+      segments.m_segments.emplace_back(scriptRunStart, scriptRunEnd - scriptRunStart, ICUScriptToHarfbuzzScript(script),
+                                   bidiLevel & 0x01 ? HB_DIRECTION_RTL : HB_DIRECTION_LTR);
+
+      // Move to the next script sequence.
+      scriptRunStart = static_cast<int32_t>(scriptRunEnd);
+    }
+    // Move to the next direction sequence.
+    bidiRunStart = bidiRunEnd;
+  }
+}
+
+void ReorderRTL(TextSegments & segments)
+{
+  // TODO(AB): Optimize implementation to use indexes to segments instead of copying them.
+  auto it = segments.m_segments.begin();
+  auto const end = segments.m_segments.end();
+  // TODO(AB): Line (default rendering) direction is determined by the first segment. It should be defined as
+  // a parameter depending on the language.
+  auto const lineDirection = it->m_direction;
+  while (it != end)
+  {
+    if (it->m_direction == lineDirection)
+      ++it;
+    else
+    {
+      auto const start = it++;
+      while (it != end && it->m_direction != lineDirection)
+        ++it;
+      std::reverse(start, it);
+    }
+  }
+  if (lineDirection != HB_DIRECTION_LTR)
+    std::reverse(segments.m_segments.begin(), end);
+}
+}  // namespace
+
+TextSegments GetTextSegments(std::string_view utf8)
+{
+  ASSERT(!utf8.empty(), ("Shaping of empty strings is not supported"));
+  ASSERT(std::string::npos == utf8.find_first_of("\r\n"), ("Shaping with line breaks is not supported", utf8));
+
+  // TODO(AB): Can unnecessary conversion/allocation be avoided?
+  TextSegments segments {strings::ToUtf16(utf8), {}};
+  // TODO(AB): Runs are not split by breaking chars and by different fonts.
+  GetSingleTextLineRuns(segments);
+  ReorderRTL(segments);
+  return segments;
+}
+
+}  // namespace harfbuzz_shaping

--- a/drape/harfbuzz_shaping.hpp
+++ b/drape/harfbuzz_shaping.hpp
@@ -1,0 +1,39 @@
+#pragma once
+
+#include "std/target_os.hpp"
+
+#include <string>
+#include <vector>
+
+#if defined(OMIM_OS_LINUX) || defined(OMIM_OS_WINDOWS)
+#include <harfbuzz/hb.h>
+#else
+#include <hb.h>
+#endif
+
+namespace harfbuzz_shaping
+{
+struct TextSegment
+{
+  // TODO(AB): Use 1 byte or 2 bytes for memory-efficient caching.
+  int32_t m_start;  // Offset to the segment start in the string.
+  int32_t m_length;
+  hb_script_t m_script;
+  hb_direction_t m_direction;
+
+  TextSegment(int32_t start, int32_t length, hb_script_t script, hb_direction_t direction)
+      : m_start(start), m_length(length), m_script(script), m_direction(direction) {}
+};
+
+struct TextSegments
+{
+  std::u16string m_text;
+  std::vector<TextSegment> m_segments;
+  // TODO(AB): Reverse indexes to order segments instead of moving them.
+  //std::vector<size_t> m_segmentsOrder;
+};
+
+// Finds segments with common properties suitable for harfbuzz in a single line of text without newlines.
+// Any line breaking/trimming should be done by the caller.
+TextSegments GetTextSegments(std::string_view utf8);
+}  // namespace harfbuzz_shaping

--- a/iphone/Maps/Maps.xcodeproj/xcshareddata/xcschemes/OMaps.xcscheme
+++ b/iphone/Maps/Maps.xcodeproj/xcshareddata/xcschemes/OMaps.xcscheme
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <Scheme
-   LastUpgradeVersion = "1530"
+   LastUpgradeVersion = "1540"
    version = "1.3">
    <BuildAction
       parallelizeBuildables = "YES"

--- a/xcode/drape/drape.xcodeproj/project.pbxproj
+++ b/xcode/drape/drape.xcodeproj/project.pbxproj
@@ -146,6 +146,8 @@
 		BBB72EA02118A45800249D4F /* mesh_object.hpp in Headers */ = {isa = PBXBuildFile; fileRef = BBB72E9E2118A45800249D4F /* mesh_object.hpp */; };
 		BBF7916C2142E3A100D27BD8 /* metal_cleaner.mm in Sources */ = {isa = PBXBuildFile; fileRef = BBF7916B2142E3A100D27BD8 /* metal_cleaner.mm */; };
 		BBF7916E2142E42C00D27BD8 /* metal_cleaner.hpp in Headers */ = {isa = PBXBuildFile; fileRef = BBF7916D2142E42C00D27BD8 /* metal_cleaner.hpp */; };
+		FA7BE9CF2BFF1DA600E1AEE5 /* harfbuzz_shaping.cpp in Sources */ = {isa = PBXBuildFile; fileRef = FA7BE9CD2BFF1DA600E1AEE5 /* harfbuzz_shaping.cpp */; };
+		FA7BE9D02BFF1DA600E1AEE5 /* harfbuzz_shaping.hpp in Headers */ = {isa = PBXBuildFile; fileRef = FA7BE9CE2BFF1DA600E1AEE5 /* harfbuzz_shaping.hpp */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXFileReference section */
@@ -291,6 +293,8 @@
 		BBB72E9E2118A45800249D4F /* mesh_object.hpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.h; path = mesh_object.hpp; sourceTree = "<group>"; };
 		BBF7916B2142E3A100D27BD8 /* metal_cleaner.mm */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.objcpp; path = metal_cleaner.mm; sourceTree = "<group>"; };
 		BBF7916D2142E42C00D27BD8 /* metal_cleaner.hpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.h; path = metal_cleaner.hpp; sourceTree = "<group>"; };
+		FA7BE9CD2BFF1DA600E1AEE5 /* harfbuzz_shaping.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = harfbuzz_shaping.cpp; sourceTree = "<group>"; };
+		FA7BE9CE2BFF1DA600E1AEE5 /* harfbuzz_shaping.hpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.h; path = harfbuzz_shaping.hpp; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -461,6 +465,8 @@
 				6743D3431C3533AE0095054B /* support_manager.hpp */,
 				6729A5501A69213A007D5872 /* symbols_texture.cpp */,
 				6729A5511A69213A007D5872 /* symbols_texture.hpp */,
+				FA7BE9CD2BFF1DA600E1AEE5 /* harfbuzz_shaping.cpp */,
+				FA7BE9CE2BFF1DA600E1AEE5 /* harfbuzz_shaping.hpp */,
 				6729A5521A69213A007D5872 /* texture_manager.cpp */,
 				6729A5531A69213A007D5872 /* texture_manager.hpp */,
 				6729A5541A69213A007D5872 /* texture_of_colors.cpp */,
@@ -576,6 +582,7 @@
 				6729A56E1A69213A007D5872 /* buffer_base.hpp in Headers */,
 				6729A58F1A69213A007D5872 /* index_buffer.hpp in Headers */,
 				4577B25821F2035D00864FAC /* vulkan_layers.hpp in Headers */,
+				FA7BE9D02BFF1DA600E1AEE5 /* harfbuzz_shaping.hpp in Headers */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -607,7 +614,7 @@
 			attributes = {
 				BuildIndependentTargetsInParallel = YES;
 				DefaultBuildSystemTypeForWorkspace = Latest;
-				LastUpgradeCheck = 1510;
+				LastUpgradeCheck = 1540;
 				TargetAttributes = {
 					6729A4F01A691F6A007D5872 = {
 						CreatedOnToolsVersion = 6.1.1;
@@ -652,6 +659,7 @@
 				45789EF8213557F7009955CC /* gl_constants.cpp in Sources */,
 				4577B25621F2035D00864FAC /* vulkan_utils.cpp in Sources */,
 				6729A59A1A69213A007D5872 /* render_bucket.cpp in Sources */,
+				FA7BE9CF2BFF1DA600E1AEE5 /* harfbuzz_shaping.cpp in Sources */,
 				4577B25A21F2035D00864FAC /* vulkan_texture.cpp in Sources */,
 				4560F59F213F986E00CC736C /* metal_states.mm in Sources */,
 				4560F5A52142890600CC736C /* metal_gpu_buffer_impl.mm in Sources */,


### PR DESCRIPTION
A part of #4281 

- Added a font_tool to experiment and test runs algorithm
- Updated existing test to show/compare different lang strings rendered in different ways

Harfbuzz shaping requires splitting each string into segments (runs). Each run should have the same:
- font
- direction
- script
- language

The base idea of getting runs is based on the Chromium source code, with some changes and improvements.

There are many TODOs that can be handled later.