### PR TITLE
[ios] fix compile error in the MWMTextToSpeechTest

### DIFF
--- a/iphone/Maps/Tests/Core/TextToSpeech/MWMTextToSpeechTests.mm
+++ b/iphone/Maps/Tests/Core/TextToSpeech/MWMTextToSpeechTests.mm
@@ -10,7 +10,7 @@
 - (void)testAvailableLanguages {
   MWMTextToSpeech * tts = [MWMTextToSpeech tts];
   std::vector<std::pair<std::string, std::string>> langs = tts.availableLanguages;
-  auto const defaultLang = std::make_pair("en-US", "English (United States)");
+  decltype(langs)::value_type const defaultLang = std::make_pair("en-US", "English (United States)");
   XCTAssertTrue(std::find(langs.begin(), langs.end(), defaultLang) != langs.end());
 }
 - (void)testTranslateLocaleWithTwineString {


### PR DESCRIPTION
This pr fixes the error in some xcodes:

```
/Applications/Xcode.app/Contents/Developer/Platforms/iPhoneOS.platform/Developer/SDKs/iPhoneOS17.2.sdk/usr/include/c++/v1/__algorithm/find.h:25:18 

Invalid operands to binary expression ('std::pair<std::string, std::string>' and 'const std::pair<const char *, const char *>')
```