### PR TITLE
[drape][Vulkan] Improve descriptor sets allocation

### DIFF
--- a/drape/vulkan/vulkan_layers.hpp
+++ b/drape/vulkan/vulkan_layers.hpp
@@ -40,7 +40,7 @@ private:
   std::vector<char const *> m_deviceLayers;
   std::vector<char const *> m_deviceExtensions;
 
-  VkDebugReportCallbackEXT m_reportCallback = 0;
+  VkDebugReportCallbackEXT m_reportCallback = nullptr;
 
   PFN_vkCreateDebugReportCallbackEXT m_vkCreateDebugReportCallbackEXT = nullptr;
   PFN_vkDestroyDebugReportCallbackEXT m_vkDestroyDebugReportCallbackEXT = nullptr;

--- a/drape/vulkan/vulkan_object_manager.cpp
+++ b/drape/vulkan/vulkan_object_manager.cpp
@@ -51,8 +51,6 @@ VulkanObjectManager::VulkanObjectManager(VkDevice device, VkPhysicalDeviceLimits
 
   for (auto & descriptorsToDestroy : m_descriptorsToDestroy)
     descriptorsToDestroy.reserve(kAvgDestroyCount);
-
-  CreateDescriptorPool();
 }
 
 VulkanObjectManager::~VulkanObjectManager()
@@ -190,34 +188,36 @@ DescriptorSetGroup VulkanObjectManager::CreateDescriptorSetGroup(ref_ptr<VulkanG
 {
   CHECK(std::this_thread::get_id() == m_renderers[ThreadType::Frontend], ());
 
-  CHECK(!m_descriptorPools.empty(), ());
-
   DescriptorSetGroup s;
   VkDescriptorSetLayout layout = program->GetDescriptorSetLayout();
   VkDescriptorSetAllocateInfo allocInfo = {};
+
+  // Find a pool with available sets.
+  uint32_t poolIndex = 0;
+  while (poolIndex < m_descriptorPools.size() &&
+         m_descriptorPools[poolIndex].m_availableSetsCount == 0)
+  {
+    ++poolIndex;
+  }
+
+  // No such a pool, create one.
+  if (poolIndex == m_descriptorPools.size())
+  {
+    CreateDescriptorPool();
+    poolIndex = m_descriptorPools.size() - 1;
+  }
+
+  // Allocate a descriptor set.
   allocInfo.sType = VK_STRUCTURE_TYPE_DESCRIPTOR_SET_ALLOCATE_INFO;
-  allocInfo.descriptorPool = s.m_descriptorPool = m_descriptorPools.front();
+  allocInfo.descriptorPool = m_descriptorPools[poolIndex].m_pool;
+  s.m_descriptorPoolIndex = poolIndex;
   allocInfo.pSetLayouts = &layout;
   allocInfo.descriptorSetCount = 1;
 
-  auto result = vkAllocateDescriptorSets(m_device, &allocInfo, &s.m_descriptorSet);
-  if (result != VK_SUCCESS)
-  {
-    for (size_t i = 1; i < m_descriptorPools.size(); ++i)
-    {
-      allocInfo.descriptorPool = s.m_descriptorPool = m_descriptorPools[i];
-      result = vkAllocateDescriptorSets(m_device, &allocInfo, &s.m_descriptorSet);
-      if (result == VK_SUCCESS)
-        break;
-    }
+  // Decrease the available sets count.
+  m_descriptorPools[poolIndex].m_availableSetsCount--;
 
-    if (s.m_descriptorSet == VK_NULL_HANDLE)
-    {
-      CreateDescriptorPool();
-      allocInfo.descriptorPool = s.m_descriptorPool = m_descriptorPools.back();
-      CHECK_VK_CALL(vkAllocateDescriptorSets(m_device, &allocInfo, &s.m_descriptorSet));
-    }
-  }
+  CHECK_VK_CALL(vkAllocateDescriptorSets(m_device, &allocInfo, &s.m_descriptorSet));
   return s;
 }
 
@@ -255,8 +255,10 @@ void VulkanObjectManager::CollectDescriptorSetGroupsUnsafe(DescriptorSetGroupArr
 {
   for (auto const & d : descriptors)
   {
-    CHECK_VK_CALL(vkFreeDescriptorSets(m_device, d.m_descriptorPool,
+    CHECK_LESS(d.m_descriptorPoolIndex, m_descriptorPools.size(), ());
+    CHECK_VK_CALL(vkFreeDescriptorSets(m_device, m_descriptorPools[d.m_descriptorPoolIndex].m_pool,
                                        1 /* count */, &d.m_descriptorSet));
+    m_descriptorPools[d.m_descriptorPoolIndex].m_availableSetsCount++;
   }
   descriptors.clear();
 }
@@ -317,6 +319,16 @@ void VulkanObjectManager::DestroyObjectUnsafe(VulkanObject object)
   CollectObjectsImpl(VulkanObjectArray{object});
 }
 
+void VulkanObjectManager::SetMaxUniformBuffers(uint32_t maxUniformBuffers) 
+{ 
+  m_maxUniformBuffers = maxUniformBuffers;
+}
+
+void VulkanObjectManager::SetMaxImageSamplers(uint32_t maxImageSamplers)
+{
+  m_maxImageSamplers = maxImageSamplers;
+}
+
 uint8_t * VulkanObjectManager::MapUnsafe(VulkanObject object)
 {
   CHECK(!object.m_allocation->m_memoryBlock->m_isBlocked, ());
@@ -368,15 +380,15 @@ void VulkanObjectManager::Fill(VulkanObject object, void const * data, uint32_t 
 
 void VulkanObjectManager::CreateDescriptorPool()
 {
-  // Maximum uniform buffers descriptors count per frame.
-  uint32_t constexpr kMaxUniformBufferDescriptorsCount = 500 * kMaxInflightFrames;
-  // Maximum textures descriptors count per frame.
-  uint32_t constexpr kMaxImageSamplerDescriptorsCount = 1000 * kMaxInflightFrames;
+  // Maximum descriptors sets count in the pool.
+  uint32_t constexpr kMaxDescriptorsSetCount = 256 * kMaxInflightFrames;
 
+  CHECK(m_maxUniformBuffers > 0, ());
+  CHECK(m_maxImageSamplers > 0, ());
   std::vector<VkDescriptorPoolSize> poolSizes =
   {
-    {VK_DESCRIPTOR_TYPE_UNIFORM_BUFFER_DYNAMIC, kMaxUniformBufferDescriptorsCount},
-    {VK_DESCRIPTOR_TYPE_COMBINED_IMAGE_SAMPLER, kMaxImageSamplerDescriptorsCount},
+    {VK_DESCRIPTOR_TYPE_UNIFORM_BUFFER_DYNAMIC, m_maxUniformBuffers * kMaxDescriptorsSetCount},
+    {VK_DESCRIPTOR_TYPE_COMBINED_IMAGE_SAMPLER, m_maxImageSamplers * kMaxDescriptorsSetCount},
   };
 
   VkDescriptorPoolCreateInfo descriptorPoolInfo = {};
@@ -384,17 +396,19 @@ void VulkanObjectManager::CreateDescriptorPool()
   descriptorPoolInfo.flags = VK_DESCRIPTOR_POOL_CREATE_FREE_DESCRIPTOR_SET_BIT;
   descriptorPoolInfo.poolSizeCount = static_cast<uint32_t>(poolSizes.size());
   descriptorPoolInfo.pPoolSizes = poolSizes.data();
-  descriptorPoolInfo.maxSets = kMaxUniformBufferDescriptorsCount + kMaxImageSamplerDescriptorsCount;
+  descriptorPoolInfo.maxSets = kMaxDescriptorsSetCount;
 
-  VkDescriptorPool descriptorPool;
-  CHECK_VK_CALL(vkCreateDescriptorPool(m_device, &descriptorPoolInfo, nullptr, &descriptorPool));
+  DescriptorPool descriptorPool;
+  CHECK_VK_CALL(vkCreateDescriptorPool(m_device, &descriptorPoolInfo, nullptr, &descriptorPool.m_pool));
+  descriptorPool.m_availableSetsCount = descriptorPoolInfo.maxSets;
+
   m_descriptorPools.push_back(descriptorPool);
 }
 
 void VulkanObjectManager::DestroyDescriptorPools()
 {
   for (auto & pool : m_descriptorPools)
-    vkDestroyDescriptorPool(m_device, pool, nullptr);
+    vkDestroyDescriptorPool(m_device, pool.m_pool, nullptr);
 }
 
 VkSampler VulkanObjectManager::GetSampler(SamplerKey const & key)

--- a/drape/vulkan/vulkan_object_manager.cpp
+++ b/drape/vulkan/vulkan_object_manager.cpp
@@ -194,11 +194,8 @@ DescriptorSetGroup VulkanObjectManager::CreateDescriptorSetGroup(ref_ptr<VulkanG
 
   // Find a pool with available sets.
   uint32_t poolIndex = 0;
-  while (poolIndex < m_descriptorPools.size() &&
-         m_descriptorPools[poolIndex].m_availableSetsCount == 0)
-  {
+  while (poolIndex < m_descriptorPools.size() && m_descriptorPools[poolIndex].m_availableSetsCount == 0)
     ++poolIndex;
-  }
 
   // No such a pool, create one.
   if (poolIndex == m_descriptorPools.size())
@@ -319,8 +316,8 @@ void VulkanObjectManager::DestroyObjectUnsafe(VulkanObject object)
   CollectObjectsImpl(VulkanObjectArray{object});
 }
 
-void VulkanObjectManager::SetMaxUniformBuffers(uint32_t maxUniformBuffers) 
-{ 
+void VulkanObjectManager::SetMaxUniformBuffers(uint32_t maxUniformBuffers)
+{
   m_maxUniformBuffers = maxUniformBuffers;
 }
 
@@ -383,8 +380,8 @@ void VulkanObjectManager::CreateDescriptorPool()
   // Maximum descriptors sets count in the pool.
   uint32_t constexpr kMaxDescriptorsSetCount = 256 * kMaxInflightFrames;
 
-  CHECK(m_maxUniformBuffers > 0, ());
-  CHECK(m_maxImageSamplers > 0, ());
+  CHECK_GREATER(m_maxUniformBuffers, 0, ());
+  CHECK_GREATER(m_maxImageSamplers, 0, ());
   std::vector<VkDescriptorPoolSize> poolSizes =
   {
     {VK_DESCRIPTOR_TYPE_UNIFORM_BUFFER_DYNAMIC, m_maxUniformBuffers * kMaxDescriptorsSetCount},

--- a/drape/vulkan/vulkan_object_manager.hpp
+++ b/drape/vulkan/vulkan_object_manager.hpp
@@ -93,6 +93,9 @@ public:
   VulkanMemoryManager const & GetMemoryManager() const { return m_memoryManager; };
   VkSampler GetSampler(SamplerKey const & key);
 
+  void SetMaxUniformBuffers(uint32_t maxUniformBuffers);
+  void SetMaxImageSamplers(uint32_t maxImageSamplers);
+
 private:
   using DescriptorSetGroupArray = std::vector<DescriptorSetGroup>;
   using VulkanObjectArray = std::vector<VulkanObject>;
@@ -110,13 +113,21 @@ private:
   std::array<std::thread::id, ThreadType::Count> m_renderers = {};
   std::array<std::array<VulkanObjectArray, kMaxInflightFrames>, ThreadType::Count> m_queuesToDestroy = {};
 
-  std::vector<VkDescriptorPool> m_descriptorPools;
+  struct DescriptorPool
+  {
+    VkDescriptorPool m_pool;
+    uint32_t m_availableSetsCount = 0;
+  };
+  std::vector<DescriptorPool> m_descriptorPools;
 
   std::array<DescriptorSetGroupArray, kMaxInflightFrames> m_descriptorsToDestroy;
 
   std::map<SamplerKey, VkSampler> m_samplers;
 
   uint32_t m_currentInflightFrameIndex = 0;
+
+  uint32_t m_maxUniformBuffers = 0;
+  uint32_t m_maxImageSamplers = 0;
 
   std::mutex m_mutex;
   std::mutex m_samplerMutex;

--- a/drape/vulkan/vulkan_param_descriptor.hpp
+++ b/drape/vulkan/vulkan_param_descriptor.hpp
@@ -6,6 +6,7 @@
 
 #include <array>
 #include <cstdint>
+#include <limits>
 #include <string>
 #include <vector>
 
@@ -37,7 +38,7 @@ size_t constexpr kMaxDescriptorSets = 8;
 struct DescriptorSetGroup
 {
   VkDescriptorSet m_descriptorSet = {};
-  VkDescriptorPool m_descriptorPool = {};
+  uint32_t m_descriptorPoolIndex = std::numeric_limits<uint32_t>::max();
 
   std::array<uint32_t, kMaxDescriptorSets> m_ids = {};
   bool m_updated = false;
@@ -45,7 +46,7 @@ struct DescriptorSetGroup
   explicit operator bool()
   {
     return m_descriptorSet != VK_NULL_HANDLE &&
-           m_descriptorPool != VK_NULL_HANDLE;
+           m_descriptorPoolIndex != std::numeric_limits<uint32_t>::max();
   }
 
   void Update(VkDevice device, std::vector<ParamDescriptor> const & descriptors);

--- a/shaders/program_manager.cpp
+++ b/shaders/program_manager.cpp
@@ -87,7 +87,8 @@ void ProgramManager::InitForOpenGL(ref_ptr<dp::GraphicsContext> context)
 void ProgramManager::InitForVulkan(ref_ptr<dp::GraphicsContext> context)
 {
   m_pool = make_unique_dp<vulkan::VulkanProgramPool>(context);
-  m_paramsSetter = make_unique_dp<vulkan::VulkanProgramParamsSetter>(context);
+  m_paramsSetter = make_unique_dp<vulkan::VulkanProgramParamsSetter>(context, 
+                     make_ref(static_cast<vulkan::VulkanProgramPool *>(m_pool.get())));
 }
 
 void ProgramManager::DestroyForVulkan(ref_ptr<dp::GraphicsContext> context)

--- a/shaders/program_manager.cpp
+++ b/shaders/program_manager.cpp
@@ -9,7 +9,6 @@
 
 #include "base/logging.hpp"
 
-#include "std/target_os.hpp"
 #include "gl_program_params.hpp"
 
 #include <algorithm>
@@ -55,7 +54,7 @@ void ProgramManager::Destroy(ref_ptr<dp::GraphicsContext> context)
     DestroyForVulkan(context);
   }
 }
-  
+
 void ProgramManager::InitForOpenGL(ref_ptr<dp::GraphicsContext> context)
 {
   std::string globalDefines;
@@ -69,26 +68,26 @@ void ProgramManager::InitForOpenGL(ref_ptr<dp::GraphicsContext> context)
     globalDefines.append("#define ENABLE_VTF\n");  // VTF == Vertex Texture Fetch
   }
 #endif
-  
+
   if (dp::SupportManager::Instance().IsSamsungGoogleNexus())
     globalDefines.append("#define SAMSUNG_GOOGLE_NEXUS\n");
-  
+
   auto const apiVersion = context->GetApiVersion();
   if (apiVersion == dp::ApiVersion::OpenGLES3)
     globalDefines.append("#define GLES3\n");
-  
+
   m_pool = make_unique_dp<GLProgramPool>(apiVersion);
   ref_ptr<GLProgramPool> pool = make_ref(m_pool);
   pool->SetDefines(globalDefines);
-  
+
   m_paramsSetter = make_unique_dp<GLProgramParamsSetter>();
 }
 
 void ProgramManager::InitForVulkan(ref_ptr<dp::GraphicsContext> context)
 {
   m_pool = make_unique_dp<vulkan::VulkanProgramPool>(context);
-  m_paramsSetter = make_unique_dp<vulkan::VulkanProgramParamsSetter>(context, 
-                     make_ref(static_cast<vulkan::VulkanProgramPool *>(m_pool.get())));
+  m_paramsSetter = make_unique_dp<vulkan::VulkanProgramParamsSetter>(context,
+      make_ref(static_cast<vulkan::VulkanProgramPool *>(m_pool.get())));
 }
 
 void ProgramManager::DestroyForVulkan(ref_ptr<dp::GraphicsContext> context)

--- a/shaders/vulkan_program_params.cpp
+++ b/shaders/vulkan_program_params.cpp
@@ -1,5 +1,7 @@
 #include "shaders/vulkan_program_params.hpp"
 
+#include "shaders/vulkan_program_pool.hpp"
+
 #include "drape/vulkan/vulkan_base_context.hpp"
 #include "drape/vulkan/vulkan_gpu_program.hpp"
 #include "drape/vulkan/vulkan_utils.hpp"
@@ -31,10 +33,14 @@ VulkanProgramParamsSetter::UniformBuffer CreateUniformBuffer(VkDevice device,
 }
 }  // namespace
 
-VulkanProgramParamsSetter::VulkanProgramParamsSetter(ref_ptr<dp::vulkan::VulkanBaseContext> context)
+VulkanProgramParamsSetter::VulkanProgramParamsSetter(ref_ptr<dp::vulkan::VulkanBaseContext> context,
+                                                     ref_ptr<VulkanProgramPool> programPool)
 {
   using namespace dp::vulkan;
   m_objectManager = context->GetObjectManager();
+  m_objectManager->SetMaxUniformBuffers(programPool->GetMaxUniformBuffers());
+  m_objectManager->SetMaxImageSamplers(programPool->GetMaxImageSamplers());
+
   for (auto & ub : m_uniformBuffers)
   {
     ub.emplace_back(CreateUniformBuffer(context->GetDevice(), m_objectManager,

--- a/shaders/vulkan_program_params.hpp
+++ b/shaders/vulkan_program_params.hpp
@@ -16,6 +16,8 @@ namespace gpu
 {
 namespace vulkan
 {
+class VulkanProgramPool;
+
 class VulkanProgramParamsSetter : public ProgramParamsSetter
 {
 public:
@@ -24,9 +26,10 @@ public:
     dp::vulkan::VulkanObject m_object;
     uint8_t * m_pointer = nullptr;
     uint32_t m_freeOffset = 0;
-  };
+};
 
-  explicit VulkanProgramParamsSetter(ref_ptr<dp::vulkan::VulkanBaseContext> context);
+  VulkanProgramParamsSetter(ref_ptr<dp::vulkan::VulkanBaseContext> context,
+                            ref_ptr<VulkanProgramPool> programPool);
   ~VulkanProgramParamsSetter() override;
 
   void Destroy(ref_ptr<dp::vulkan::VulkanBaseContext> context);

--- a/shaders/vulkan_program_params.hpp
+++ b/shaders/vulkan_program_params.hpp
@@ -28,8 +28,7 @@ public:
     uint32_t m_freeOffset = 0;
 };
 
-  VulkanProgramParamsSetter(ref_ptr<dp::vulkan::VulkanBaseContext> context,
-                            ref_ptr<VulkanProgramPool> programPool);
+  VulkanProgramParamsSetter(ref_ptr<dp::vulkan::VulkanBaseContext> context, ref_ptr<VulkanProgramPool> programPool);
   ~VulkanProgramParamsSetter() override;
 
   void Destroy(ref_ptr<dp::vulkan::VulkanBaseContext> context);

--- a/shaders/vulkan_program_pool.cpp
+++ b/shaders/vulkan_program_pool.cpp
@@ -28,7 +28,7 @@ int8_t constexpr kInvalidBindingIndex = -1;
 uint32_t constexpr kMaxUniformBuffers = 1;
 
 std::string const kShadersDir = "vulkan_shaders";
-std::string const kShadersReflecton = "reflection.json";
+std::string const kShadersReflection = "reflection.json";
 std::string const kShadersPackFile = "shaders_pack.spv";
 
 std::vector<uint8_t> ReadShadersPackFile(std::string const & filename)
@@ -122,8 +122,8 @@ std::map<uint8_t, ReflectionData> ReadReflectionFile(std::string const & filenam
   for (auto & d : reflectionFile.m_reflectionData)
   {
     auto const index = d.m_programIndex;
-    std::sort(d.m_info.m_textures.begin(), d.m_info.m_textures.end(),
-              [](auto const & a, auto const & b) {
+    std::ranges::sort(d.m_info.m_textures, [](auto const & a, auto const & b)
+              {
                 return a.m_index < b.m_index;
               });
     result.insert(std::make_pair(index, std::move(d)));
@@ -183,16 +183,14 @@ std::vector<VkDescriptorSetLayoutBinding> GetLayoutBindings(ReflectionInfo const
   if (!reflectionInfo.m_textures.empty())
     bindingIndex = static_cast<uint32_t>(reflectionInfo.m_textures.back().m_index) + 1;
 
-  for (uint32_t i = static_cast<uint32_t>(reflectionInfo.m_textures.size());
-       i < maxTextureBindings; ++i)
-  {
-    VkDescriptorSetLayoutBinding emptyBinding = {};
-    emptyBinding.descriptorType = VK_DESCRIPTOR_TYPE_COMBINED_IMAGE_SAMPLER;
-    emptyBinding.binding = bindingIndex++;
-    emptyBinding.descriptorCount = 1;
-    emptyBinding.stageFlags = VK_SHADER_STAGE_FRAGMENT_BIT;
-    result.push_back(std::move(emptyBinding));
-  }
+  for (uint32_t i = static_cast<uint32_t>(reflectionInfo.m_textures.size()); i < maxTextureBindings; ++i)
+    result.push_back({
+      .binding = bindingIndex++,
+      .descriptorType = VK_DESCRIPTOR_TYPE_COMBINED_IMAGE_SAMPLER,
+      .descriptorCount = 1,
+      .stageFlags = VK_SHADER_STAGE_FRAGMENT_BIT,
+      .pImmutableSamplers = nullptr,
+    });
 
   return result;
 }
@@ -221,27 +219,21 @@ VulkanProgramPool::VulkanProgramPool(ref_ptr<dp::GraphicsContext> context)
   ref_ptr<dp::vulkan::VulkanBaseContext> vulkanContext = context;
   VkDevice device = vulkanContext->GetDevice();
 
-  auto reflection = ReadReflectionFile(base::JoinPath(kShadersDir, kShadersReflecton));
+  auto reflection = ReadReflectionFile(base::JoinPath(kShadersDir, kShadersReflection));
   CHECK_EQUAL(reflection.size(), static_cast<size_t>(Program::ProgramsCount), ());
 
   auto packFileData = ReadShadersPackFile(base::JoinPath(kShadersDir, kShadersPackFile));
 
   for (size_t i = 0; i < static_cast<size_t>(Program::ProgramsCount); ++i)
-  {
-    m_maxImageSamplers = std::max(m_maxImageSamplers, 
-                                  static_cast<uint32_t>(reflection[i].m_info.m_textures.size()));
-  }
+    m_maxImageSamplers = std::max(m_maxImageSamplers, static_cast<uint32_t>(reflection[i].m_info.m_textures.size()));
 
   for (size_t i = 0; i < static_cast<size_t>(Program::ProgramsCount); ++i)
   {
     auto const & refl = reflection[i];
-    m_programData[i].m_vertexShader = LoadShaderModule(device, packFileData,
-                                                       refl.m_vsOffset, refl.m_vsSize);
-    m_programData[i].m_fragmentShader = LoadShaderModule(device, packFileData,
-                                                         refl.m_fsOffset, refl.m_fsSize);
-    auto bindings = GetLayoutBindings(refl.m_info, m_maxImageSamplers);
-    CHECK(bindings.size() == kMaxUniformBuffers + m_maxImageSamplers, 
-          ("Incorrect bindings count."));
+    m_programData[i].m_vertexShader = LoadShaderModule(device, packFileData, refl.m_vsOffset, refl.m_vsSize);
+    m_programData[i].m_fragmentShader = LoadShaderModule(device, packFileData, refl.m_fsOffset, refl.m_fsSize);
+    auto const bindings = GetLayoutBindings(refl.m_info, m_maxImageSamplers);
+    CHECK(bindings.size() == kMaxUniformBuffers + m_maxImageSamplers, ("Incorrect bindings count."));
 
     VkDescriptorSetLayoutCreateInfo descriptorLayout  = {};
     descriptorLayout.sType = VK_STRUCTURE_TYPE_DESCRIPTOR_SET_LAYOUT_CREATE_INFO;

--- a/shaders/vulkan_program_pool.hpp
+++ b/shaders/vulkan_program_pool.hpp
@@ -21,6 +21,9 @@ public:
   void Destroy(ref_ptr<dp::GraphicsContext> context);
   drape_ptr<dp::GpuProgram> Get(Program program) override;
 
+  uint32_t GetMaxUniformBuffers() const;
+  uint32_t GetMaxImageSamplers() const;
+
 private:
   struct ProgramData
   {
@@ -31,6 +34,7 @@ private:
     dp::vulkan::VulkanGpuProgram::TextureBindings m_textureBindings;
   };
   std::array<ProgramData, static_cast<size_t>(Program::ProgramsCount)> m_programData;
+  uint32_t m_maxImageSamplers = 0;
 };
 }  // namespace vulkan
 }  // namespace gpu


### PR DESCRIPTION
# Motivation:
Current implementation call `vkAllocateDescriptorSets` multiple times until it finishes successfully. It's not efficient and may cause validation issues.
Example:
```
OMcore                  app.organicmaps.debug                E  vulkan/vulkan_layers.cpp:162 DebugReportCallbackImpl(): Vulkan Diagnostics [ Validation ] [ DESCRIPTOR_POOL ] [OBJ: 18065711617638662146 LOC: 1434762579 ]: Validation Error: [ VUID-VkDescriptorSetAllocateInfo-apiVersion-07896 ] Object 0: handle = 0xfab64d0000000002, type = VK_OBJECT_TYPE_DESCRIPTOR_POOL; | MessageID = 0x5584bd53 | vkAllocateDescriptorSets():  Unable to allocate 1 descriptors of type VK_DESCRIPTOR_TYPE_UNIFORM_BUFFER_DYNAMIC from VkDescriptorPool 0xfab64d0000000002[]. This pool only has 0 descriptors of this type remaining. The Vulkan spec states: If the VK_KHR_maintenance1 extension is not enabled and VkPhysicalDeviceProperties::apiVersion is less than Vulkan 1.1, descriptorPool must have enough free descriptor capacity remaining to allocate the descriptor sets of the specified layouts (https://www.khronos.org/registry/vulkan/specs/1.3-extensions/html/vkspec.html#VUID-VkDescriptorSetAllocateInfo-apiVersion-07896)
```


# New approach:
We calculate descriptor's pool capacity and check if there is enough space in it. 
According to Vulkan's spec (https://registry.khronos.org/vulkan/specs/1.3-extensions/man/html/VkDescriptorPoolCreateInfo.html):
> If a descriptor pool has not had any descriptor sets freed since it was created or most recently reset then fragmentation must not cause an allocation failure (note that this is always the case for a pool created without the VK_DESCRIPTOR_POOL_CREATE_FREE_DESCRIPTOR_SET_BIT bit set). Additionally, if all sets allocated from the pool since it was created or most recently reset use the same number of descriptors (of each type) and the requested allocation also uses that same number of descriptors (of each type), then fragmentation must not cause an allocation failure.

It means that we need to maintain the same descriptors set size to avoid fragmentation.