### PR TITLE
[drape][gui] Removed unused size

### DIFF
--- a/drape_frontend/gui/choose_position_mark.cpp
+++ b/drape_frontend/gui/choose_position_mark.cpp
@@ -31,8 +31,8 @@ class ChoosePositionMarkHandle : public Handle
   using TBase = Handle;
 
 public:
-  ChoosePositionMarkHandle(uint32_t id, m2::PointF const & pivot, m2::PointF const & size)
-    : Handle(id, dp::Center, pivot, size)
+  ChoosePositionMarkHandle(uint32_t id, m2::PointF const & pivot)
+    : Handle(id, dp::Center, pivot)
   {
     SetIsVisible(true);
   }
@@ -86,9 +86,8 @@ drape_ptr<ShapeRenderer> ChoosePositionMark::Draw(ref_ptr<dp::GraphicsContext> c
 
   provider.InitStream(0, info, make_ref(&vertexes));
 
-  m2::PointF const markSize = region.GetPixelSize();
   drape_ptr<dp::OverlayHandle> handle = make_unique_dp<ChoosePositionMarkHandle>(
-    EGuiHandle::GuiHandleChoosePositionMark, m_position.m_pixelPivot, markSize);
+      GuiHandleChoosePositionMark, m_position.m_pixelPivot);
 
   drape_ptr<ShapeRenderer> renderer = make_unique_dp<ShapeRenderer>();
   dp::Batcher batcher(dp::Batcher::IndexPerQuad, dp::Batcher::VertexPerQuad);

--- a/drape_frontend/gui/compass.cpp
+++ b/drape_frontend/gui/compass.cpp
@@ -91,8 +91,7 @@ private:
 };
 }  // namespace
 
-drape_ptr<ShapeRenderer> Compass::Draw(ref_ptr<dp::GraphicsContext> context,
-                                       m2::PointF & compassSize, ref_ptr<dp::TextureManager> tex,
+drape_ptr<ShapeRenderer> Compass::Draw(ref_ptr<dp::GraphicsContext> context, ref_ptr<dp::TextureManager> tex,
                                        TTapHandler const & tapHandler) const
 {
   dp::TextureManager::SymbolRegion region;
@@ -133,10 +132,9 @@ drape_ptr<ShapeRenderer> Compass::Draw(ref_ptr<dp::GraphicsContext> context,
 
   provider.InitStream(0, info, make_ref(&vertexes));
 
-  compassSize = region.GetPixelSize();
   drape_ptr<dp::OverlayHandle> handle = make_unique_dp<CompassHandle>(EGuiHandle::GuiHandleCompass,
                                                                       m_position.m_pixelPivot,
-                                                                      compassSize, tapHandler);
+                                                                      region.GetPixelSize(), tapHandler);
 
   drape_ptr<ShapeRenderer> renderer = make_unique_dp<ShapeRenderer>();
   dp::Batcher batcher(dp::Batcher::IndexPerQuad, dp::Batcher::VertexPerQuad);

--- a/drape_frontend/gui/compass.hpp
+++ b/drape_frontend/gui/compass.hpp
@@ -9,7 +9,7 @@ class Compass : public Shape
 public:
   explicit Compass(gui::Position const & position) : Shape(position) {}
 
-  drape_ptr<ShapeRenderer> Draw(ref_ptr<dp::GraphicsContext> context, m2::PointF & compassSize,
+  drape_ptr<ShapeRenderer> Draw(ref_ptr<dp::GraphicsContext> context,
                                 ref_ptr<dp::TextureManager> tex,
                                 TTapHandler const & tapHandler) const;
 };

--- a/drape_frontend/gui/copyright_label.cpp
+++ b/drape_frontend/gui/copyright_label.cpp
@@ -27,9 +27,8 @@ class CopyrightHandle : public StaticLabelHandle
 
 public:
   CopyrightHandle(uint32_t id, ref_ptr<dp::TextureManager> textureManager,
-                  dp::Anchor anchor, m2::PointF const & pivot,
-                  m2::PointF const & size, TAlphabet const & alphabet)
-    : TBase(id, textureManager, anchor, pivot, size, alphabet)
+                  dp::Anchor anchor, m2::PointF const & pivot, TAlphabet const & alphabet)
+    : TBase(id, textureManager, anchor, pivot, alphabet)
   {
     SetIsVisible(true);
   }
@@ -73,7 +72,6 @@ CopyrightLabel::CopyrightLabel(Position const & position)
 {}
 
 drape_ptr<ShapeRenderer> CopyrightLabel::Draw(ref_ptr<dp::GraphicsContext> context,
-                                              m2::PointF & size,
                                               ref_ptr<dp::TextureManager> tex) const
 {
   StaticLabel::LabelResult result;
@@ -88,10 +86,9 @@ drape_ptr<ShapeRenderer> CopyrightLabel::Draw(ref_ptr<dp::GraphicsContext> conte
   ASSERT(vertexCount % dp::Batcher::VertexPerQuad == 0, ());
   auto const indexCount = dp::Batcher::IndexPerQuad * vertexCount / dp::Batcher::VertexPerQuad;
 
-  size = m2::PointF(result.m_boundRect.SizeX(), result.m_boundRect.SizeY());
-  drape_ptr<dp::OverlayHandle> handle = make_unique_dp<CopyrightHandle>(EGuiHandle::GuiHandleCopyright,
+  drape_ptr<dp::OverlayHandle> handle = make_unique_dp<CopyrightHandle>(GuiHandleCopyright,
                                                                         tex, m_position.m_anchor,
-                                                                        m_position.m_pixelPivot, size,
+                                                                        m_position.m_pixelPivot,
                                                                         result.m_alphabet);
 
   drape_ptr<ShapeRenderer> renderer = make_unique_dp<ShapeRenderer>();

--- a/drape_frontend/gui/copyright_label.hpp
+++ b/drape_frontend/gui/copyright_label.hpp
@@ -9,8 +9,7 @@ class CopyrightLabel : public Shape
   using TBase = Shape;
 
 public:
-  explicit CopyrightLabel(gui::Position const & position);
-  drape_ptr<ShapeRenderer> Draw(ref_ptr<dp::GraphicsContext> context, m2::PointF & size,
-                                ref_ptr<dp::TextureManager> tex) const;
+  explicit CopyrightLabel(Position const & position);
+  drape_ptr<ShapeRenderer> Draw(ref_ptr<dp::GraphicsContext> context, ref_ptr<dp::TextureManager> tex) const;
 };
 }  // namespace gui

--- a/drape_frontend/gui/gui_text.hpp
+++ b/drape_frontend/gui/gui_text.hpp
@@ -118,7 +118,6 @@ public:
                 ref_ptr<dp::TextureManager> mng);
 
   void SetText(LabelResult & result, std::string text) const;
-  m2::PointF GetAverageSize() const;
 
   using TAlphabetNode = std::pair<strings::UniChar, dp::TextureManager::GlyphRegion>;
   using TAlphabet = std::vector<TAlphabetNode>;
@@ -152,7 +151,6 @@ public:
   bool Update(ScreenBase const & screen) override;
 
   ref_ptr<MutableLabel> GetTextView() const;
-  void UpdateSize(m2::PointF const & size);
 
 protected:
   void SetContent(std::string && content);
@@ -194,7 +192,7 @@ class StaticLabelHandle : public Handle
 
 public:
   StaticLabelHandle(uint32_t id, ref_ptr<dp::TextureManager> textureManager, dp::Anchor anchor,
-                    m2::PointF const & pivot, m2::PointF const & size, TAlphabet const & alphabet);
+                    m2::PointF const & pivot, TAlphabet const & alphabet);
 
   bool Update(ScreenBase const & screen) override;
 

--- a/drape_frontend/gui/layer_render.cpp
+++ b/drape_frontend/gui/layer_render.cpp
@@ -198,7 +198,7 @@ drape_ptr<LayerRenderer> LayerCacher::RecacheWidgets(ref_ptr<dp::GraphicsContext
                                                      TWidgetsInitInfo const & initInfo,
                                                      ref_ptr<dp::TextureManager> textures)
 {
-  using TCacheShape = std::function<m2::PointF(ref_ptr<dp::GraphicsContext>, Position anchor,
+  using TCacheShape = std::function<void(ref_ptr<dp::GraphicsContext>, Position anchor,
                                                ref_ptr<LayerRenderer> renderer,
                                                ref_ptr<dp::TextureManager> textures)>;
   static std::map<EWidget, TCacheShape> cacheFunctions{
@@ -332,42 +332,30 @@ drape_ptr<LayerRenderer> LayerCacher::RecacheDebugLabels(ref_ptr<dp::GraphicsCon
 }
 #endif
 
-m2::PointF LayerCacher::CacheCompass(ref_ptr<dp::GraphicsContext> context,
-                                     Position const & position, ref_ptr<LayerRenderer> renderer,
-                                     ref_ptr<dp::TextureManager> textures)
+void LayerCacher::CacheCompass(ref_ptr<dp::GraphicsContext> context, Position const & position,
+                               ref_ptr<LayerRenderer> renderer, ref_ptr<dp::TextureManager> textures)
 {
-  m2::PointF compassSize;
   Compass compass = Compass(position);
-  drape_ptr<ShapeRenderer> shape = compass.Draw(context, compassSize, textures,
-    std::bind(&DrapeGui::CallOnCompassTappedHandler, &DrapeGui::Instance()));
+  drape_ptr<ShapeRenderer> shape = compass.Draw(context, textures,
+      std::bind(&DrapeGui::CallOnCompassTappedHandler, &DrapeGui::Instance()));
 
   renderer->AddShapeRenderer(WIDGET_COMPASS, std::move(shape));
-
-  return compassSize;
 }
 
-m2::PointF LayerCacher::CacheRuler(ref_ptr<dp::GraphicsContext> context, Position const & position,
-                                   ref_ptr<LayerRenderer> renderer,
-                                   ref_ptr<dp::TextureManager> textures)
+void LayerCacher::CacheRuler(ref_ptr<dp::GraphicsContext> context, Position const & position,
+                             ref_ptr<LayerRenderer> renderer, ref_ptr<dp::TextureManager> textures)
 {
-  m2::PointF rulerSize;
-  renderer->AddShapeRenderer(WIDGET_RULER, Ruler(position).Draw(context, rulerSize, textures));
-  return rulerSize;
+  renderer->AddShapeRenderer(WIDGET_RULER, Ruler(position).Draw(context, textures));
 }
 
-m2::PointF LayerCacher::CacheCopyright(ref_ptr<dp::GraphicsContext> context,
-                                       Position const & position, ref_ptr<LayerRenderer> renderer,
-                                       ref_ptr<dp::TextureManager> textures)
+void LayerCacher::CacheCopyright(ref_ptr<dp::GraphicsContext> context, Position const & position,
+                                 ref_ptr<LayerRenderer> renderer, ref_ptr<dp::TextureManager> textures)
 {
-  m2::PointF size;
-  renderer->AddShapeRenderer(WIDGET_COPYRIGHT, CopyrightLabel(position).Draw(context, size, textures));
-  return size;
+  renderer->AddShapeRenderer(WIDGET_COPYRIGHT, CopyrightLabel(position).Draw(context, textures));
 }
 
-m2::PointF LayerCacher::CacheScaleFpsLabel(ref_ptr<dp::GraphicsContext> context,
-                                           Position const & position,
-                                           ref_ptr<LayerRenderer> renderer,
-                                           ref_ptr<dp::TextureManager> textures)
+void LayerCacher::CacheScaleFpsLabel(ref_ptr<dp::GraphicsContext> context, Position const & position,
+                                     ref_ptr<LayerRenderer> renderer, ref_ptr<dp::TextureManager> textures)
 {
   MutableLabelDrawer::Params params;
   params.m_alphabet = "MGLFPSAUEDVcale: 1234567890/()";
@@ -391,10 +379,8 @@ m2::PointF LayerCacher::CacheScaleFpsLabel(ref_ptr<dp::GraphicsContext> context,
   };
 
   drape_ptr<ShapeRenderer> scaleRenderer = make_unique_dp<ShapeRenderer>();
-  m2::PointF size = MutableLabelDrawer::Draw(context, params, textures,
-    std::bind(&ShapeRenderer::AddShape, scaleRenderer.get(), _1, _2));
+  MutableLabelDrawer::Draw(context, params, textures, std::bind(&ShapeRenderer::AddShape, scaleRenderer.get(), _1, _2));
 
   renderer->AddShapeRenderer(WIDGET_SCALE_FPS_LABEL, std::move(scaleRenderer));
-  return size;
 }
 }  // namespace gui

--- a/drape_frontend/gui/layer_render.hpp
+++ b/drape_frontend/gui/layer_render.hpp
@@ -69,16 +69,15 @@ public:
 #endif
 
 private:
-  m2::PointF CacheCompass(ref_ptr<dp::GraphicsContext> context, Position const & position,
+  void CacheCompass(ref_ptr<dp::GraphicsContext> context, Position const & position,
+                    ref_ptr<LayerRenderer> renderer, ref_ptr<dp::TextureManager> textures);
+  void CacheRuler(ref_ptr<dp::GraphicsContext> context, Position const & position,
+                  ref_ptr<LayerRenderer> renderer, ref_ptr<dp::TextureManager> textures);
+  void CacheCopyright(ref_ptr<dp::GraphicsContext> context, Position const & position,
+                      ref_ptr<LayerRenderer> renderer, ref_ptr<dp::TextureManager> textures);
+  void CacheScaleFpsLabel(ref_ptr<dp::GraphicsContext> context, Position const & position,
                           ref_ptr<LayerRenderer> renderer, ref_ptr<dp::TextureManager> textures);
-  m2::PointF CacheRuler(ref_ptr<dp::GraphicsContext> context, Position const & position,
-                        ref_ptr<LayerRenderer> renderer, ref_ptr<dp::TextureManager> textures);
-  m2::PointF CacheCopyright(ref_ptr<dp::GraphicsContext> context, Position const & position,
-                            ref_ptr<LayerRenderer> renderer, ref_ptr<dp::TextureManager> textures);
-  m2::PointF CacheScaleFpsLabel(ref_ptr<dp::GraphicsContext> context, Position const & position,
-                                ref_ptr<LayerRenderer> renderer,
-                                ref_ptr<dp::TextureManager> textures);
-  m2::PointF CacheWatermark(ref_ptr<dp::GraphicsContext> context, Position const & position,
-                            ref_ptr<LayerRenderer> renderer, ref_ptr<dp::TextureManager> textures);
+  void CacheWatermark(ref_ptr<dp::GraphicsContext> context, Position const & position,
+                      ref_ptr<LayerRenderer> renderer, ref_ptr<dp::TextureManager> textures);
 };
 }  // namespace gui

--- a/drape_frontend/gui/ruler.cpp
+++ b/drape_frontend/gui/ruler.cpp
@@ -119,7 +119,6 @@ private:
     if (!IsVisible())
       return;
 
-    m_size = m2::PointF(helper.GetRulerPixelLength(), 2 * RulerHelper::GetRulerHalfHeight());
     if (IsAppearing())
       m_params.m_length = helper.GetRulerPixelLength();
     m_params.m_position = m_pivot;
@@ -169,23 +168,20 @@ private:
 };
 }  // namespace
 
-drape_ptr<ShapeRenderer> Ruler::Draw(ref_ptr<dp::GraphicsContext> context, m2::PointF & size,
-                                     ref_ptr<dp::TextureManager> tex) const
+drape_ptr<ShapeRenderer> Ruler::Draw(ref_ptr<dp::GraphicsContext> context, ref_ptr<dp::TextureManager> tex) const
 {
   ShapeControl control;
-  size = m2::PointF::Zero();
-  DrawRuler(context, size, control, tex, true);
-  DrawRuler(context, size, control, tex, false);
-  DrawText(context, size, control, tex, true);
-  DrawText(context, size, control, tex, false);
+  DrawRuler(context, control, tex, true);
+  DrawRuler(context, control, tex, false);
+  DrawText(context, control, tex, true);
+  DrawText(context, control, tex, false);
 
   drape_ptr<ShapeRenderer> renderer = make_unique_dp<ShapeRenderer>();
   renderer->AddShapeControl(std::move(control));
   return renderer;
 }
 
-void Ruler::DrawRuler(ref_ptr<dp::GraphicsContext> context, m2::PointF & size,
-                      ShapeControl & control, ref_ptr<dp::TextureManager> tex,
+void Ruler::DrawRuler(ref_ptr<dp::GraphicsContext> context, ShapeControl & control, ref_ptr<dp::TextureManager> tex,
                       bool isAppearing) const
 {
   buffer_vector<RulerVertex, 4> data;
@@ -195,7 +191,6 @@ void Ruler::DrawRuler(ref_ptr<dp::GraphicsContext> context, m2::PointF & size,
 
   glsl::vec2 texCoord = glsl::ToVec2(reg.GetTexRect().Center());
   float const h = RulerHelper::GetRulerHalfHeight();
-  size += m2::PointF(RulerHelper::GetMaxRulerPixelLength(), 2.0f * h);
 
   glsl::vec2 normals[] =
   {
@@ -231,7 +226,7 @@ void Ruler::DrawRuler(ref_ptr<dp::GraphicsContext> context, m2::PointF & size,
   }
 }
 
-void Ruler::DrawText(ref_ptr<dp::GraphicsContext> context, m2::PointF & size,
+void Ruler::DrawText(ref_ptr<dp::GraphicsContext> context,
                      ShapeControl & control, ref_ptr<dp::TextureManager> tex,
                      bool isAppearing) const
 {
@@ -250,8 +245,6 @@ void Ruler::DrawText(ref_ptr<dp::GraphicsContext> context, m2::PointF & size,
                                            isAppearing, tex);
   };
 
-  m2::PointF const textSize = MutableLabelDrawer::Draw(context, params, tex,
-    std::bind(&ShapeControl::AddShape, &control, _1, _2));
-  size.y += (textSize.y + std::abs(RulerHelper::GetVerticalTextOffset()));
+  MutableLabelDrawer::Draw(context, params, tex, std::bind(&ShapeControl::AddShape, &control, _1, _2));
 }
 }  // namespace gui

--- a/drape_frontend/gui/ruler.hpp
+++ b/drape_frontend/gui/ruler.hpp
@@ -7,16 +7,15 @@ namespace gui
 class Ruler : public Shape
 {
 public:
-  explicit Ruler(gui::Position const & position)
+  explicit Ruler(Position const & position)
     : Shape(position)
   {}
-  drape_ptr<ShapeRenderer> Draw(ref_ptr<dp::GraphicsContext> context, m2::PointF & size,
-                                ref_ptr<dp::TextureManager> tex) const;
+  drape_ptr<ShapeRenderer> Draw(ref_ptr<dp::GraphicsContext> context, ref_ptr<dp::TextureManager> tex) const;
 
 private:
-  void DrawRuler(ref_ptr<dp::GraphicsContext> context, m2::PointF & size, ShapeControl & control,
+  void DrawRuler(ref_ptr<dp::GraphicsContext> context, ShapeControl & control,
                  ref_ptr<dp::TextureManager> tex, bool isAppearing) const;
-  void DrawText(ref_ptr<dp::GraphicsContext> context, m2::PointF & size, ShapeControl & control,
+  void DrawText(ref_ptr<dp::GraphicsContext> context, ShapeControl & control,
                 ref_ptr<dp::TextureManager> tex, bool isAppearing) const;
 };
 }  // namespace gui

--- a/drape_frontend/gui/shape.cpp
+++ b/drape_frontend/gui/shape.cpp
@@ -12,11 +12,10 @@
 
 namespace gui
 {
-Handle::Handle(uint32_t id, dp::Anchor anchor, m2::PointF const & pivot, m2::PointF const & size)
+Handle::Handle(uint32_t id, dp::Anchor anchor, m2::PointF const & pivot)
   : dp::OverlayHandle(dp::OverlayID(FeatureID(MwmSet::MwmId{}, id)), anchor, 0 /* priority */,
                       1 /* minVisibleScale */, false /* isBillboard */)
   , m_pivot(glsl::ToVec2(pivot))
-  , m_size(size)
 {}
 
 bool Handle::Update(ScreenBase const & screen)

--- a/drape_frontend/gui/shape.hpp
+++ b/drape_frontend/gui/shape.hpp
@@ -20,8 +20,7 @@ namespace gui
 class Handle : public dp::OverlayHandle
 {
 public:
-  Handle(uint32_t id, dp::Anchor anchor, m2::PointF const & pivot,
-         m2::PointF const & size = m2::PointF::Zero());
+  Handle(uint32_t id, dp::Anchor anchor, m2::PointF const & pivot);
 
   gpu::GuiProgramParams const & GetParams() const { return m_params; }
 
@@ -36,20 +35,20 @@ public:
   m2::RectD GetPixelRect(ScreenBase const & screen, bool perspective) const override;
   void GetPixelShape(ScreenBase const & screen, bool perspective, Rects & rects) const override;
 
-  m2::PointF GetSize() const { return m_size; }
   virtual void SetPivot(glsl::vec2 const & pivot) { m_pivot = pivot; }
 
 protected:
   gpu::GuiProgramParams m_params;
   glsl::vec2 m_pivot;
-  mutable m2::PointF m_size;
 };
 
 class TappableHandle : public Handle
 {
+  m2::PointF m_size;
+
 public:
-  TappableHandle(uint32_t id, dp::Anchor anchor, m2::PointF const & pivot, m2::PointF const & size)
-    : Handle(id, anchor, pivot, size)
+  TappableHandle(uint32_t id, dp::Anchor anchor, m2::PointF const & pivot, m2::PointF size)
+    : Handle(id, anchor, pivot), m_size(size)
   {}
 
   bool IsTapped(m2::RectD const & touchArea) const override;


### PR DESCRIPTION
The removed size is not used in the code. The only case for a tappable GUI element is covered explicitly.

A small speed-up of the renderer never hurts.