### PR TITLE
[ios] Fix CarPlay placeholder text on dark theme

### DIFF
--- a/iphone/Maps/Classes/CarPlay/CarplayPlaceholderView.swift
+++ b/iphone/Maps/Classes/CarPlay/CarplayPlaceholderView.swift
@@ -27,7 +27,7 @@ class CarplayPlaceholderView: UIView {
 
     descriptionLabel.text = L("car_used_on_the_car_screen")
     descriptionLabel.font = UIFont.bold24()
-    descriptionLabel.textColor = UIColor.blackSecondaryText()
+    descriptionLabel.textColor = UIColor.darkText.withAlphaComponent(0.6)
     descriptionLabel.textAlignment = .center
     descriptionLabel.numberOfLines = 0
     containerView.addSubview(descriptionLabel)


### PR DESCRIPTION
CarPlay placeholder text color was adaptable (different for light/dark theme), but background is nonadaptable. As a quick fix, make text color nonadaptable too.

Before, dark/light:
<img src="https://github.com/organicmaps/organicmaps/assets/1800899/b7644582-71bd-437c-b315-003e30d60a7b" width="300"> <img src="https://github.com/organicmaps/organicmaps/assets/1800899/6bec7551-4c3c-4f75-801c-ef79f404191e" width="300">

After, dark/light:
<img src="https://github.com/organicmaps/organicmaps/assets/1800899/6e4f88ba-d15b-4894-82fe-3b72d2dea657" width="300"> <img src="https://github.com/organicmaps/organicmaps/assets/1800899/36503114-6735-40b5-abce-4b6393a86b5e" width="300">
