### PR TITLE
Python3 dependency

### DIFF
--- a/docs/INSTALL.md
+++ b/docs/INSTALL.md
@@ -383,7 +383,7 @@ The `build_omim.sh` script basically runs these commands:
 
 Linux, MacOS, or Windows should work to build Organic Maps for Android.
 
-Ensure that you have at least 30GB of free space.
+Ensure that you have at least 30GB of free space and Python 3 installed.
 
 Install [Android Studio](https://developer.android.com/studio).
 


### PR DESCRIPTION
Compiling on Nixos (Linux) and got

```
CMake Error at CMakeLists.txt:309 (message):
  Could not find python3 to use in qt/, shaders/ and 3party/.
```

Worth specifying all dependencies -- if this isn't required for Windows or something we can say so of course.