### PR TITLE
Fix coverage check

### DIFF
--- a/.github/workflows/coverage-check.yaml
+++ b/.github/workflows/coverage-check.yaml
@@ -85,12 +85,14 @@ jobs:
               libgl1-mesa-dev \
               libglvnd-dev \
               qt6-base-dev \
+              libfreetype-dev \
+              libharfbuzz-dev \
               libqt6svg6-dev \
               qt6-positioning-dev \
               libqt6positioning6-plugins \
               libqt6positioning6 \
-              llvm
-          pip install gcovr
+              llvm \
+              gcovr
 
       - name: Configure
         shell: bash


### PR DESCRIPTION
fix coverage check by switching to system-wide gcovr
was broken by https://github.com/organicmaps/organicmaps/pull/8193
due to [PEP 668 – Marking Python base environments as “externally managed”](https://peps.python.org/pep-0668/).


also install libfreetype-dev and libharfbuzz-dev, as it won't run without them