### PR TITLE
[translations] German translation for hiking and cycle paths

### DIFF
--- a/android/app/src/main/res/values-de/strings.xml
+++ b/android/app/src/main/res/values-de/strings.xml
@@ -1218,13 +1218,13 @@
 	<string name="type.highway.motorway_link.bridge">Brücke</string>
 	<!-- These translations are used for all type.highway.*.tunnel. -->
 	<string name="type.highway.motorway_link.tunnel">Tunnel</string>
-	<string name="type.highway.path">Weg</string>
+	<string name="type.highway.path">Pfad</string>
 	<!-- Hiking trail tagged as sac_scale=demanding_mountain_hiking (3 of 6) or trail_visibility=bad. -->
-	<string name="type.highway.path.difficult">Weg</string>
+	<string name="type.highway.path.difficult">Schwieriger oder kaum erkennbarer Pfad</string>
 	<!-- Hiking trail tagged as sac_scale=alpine_hiking (4+ of 6) or trail_visibility=horrible or more extreme. -->
-	<string name="type.highway.path.expert">Weg</string>
-	<string name="type.highway.path.bicycle">Radweg</string>
-	<string name="type.highway.footway.bicycle">Radweg</string>
+	<string name="type.highway.path.expert">Alpinwanderweg oder wegloser Pfad</string>
+	<string name="type.highway.path.bicycle">Rad- und Fußweg</string>
+	<string name="type.highway.footway.bicycle">Rad- und Fußweg</string>
 	<!-- These translations are used for all type.highway.*.bridge. -->
 	<string name="type.highway.path.bridge">Brücke</string>
 	<string name="type.highway.path.horse">Reitweg</string>

--- a/data/strings/types_strings.txt
+++ b/data/strings/types_strings.txt
@@ -12485,7 +12485,7 @@
     az = Yol
     cs = Cesta
     da = Sti
-    de = Weg
+    de = Pfad
     el = Διαδρομή
     es = Camino
     et = Rada
@@ -12520,12 +12520,14 @@
     comment = Hiking trail tagged as sac_scale=demanding_mountain_hiking (3 of 6) or trail_visibility=bad.
     ref = type.highway.path
     en = Difficult or Indistinct Trail
+    de = Schwieriger oder kaum erkennbarer Pfad
     ru = Сложная или плохо видимая тропа
 
   [type.highway.path.expert]
     comment = Hiking trail tagged as sac_scale=alpine_hiking (4+ of 6) or trail_visibility=horrible or more extreme.
     ref = type.highway.path
     en = Expert or Indiscernible Trail
+    de = Alpinwanderweg oder wegloser Pfad
     ru = Очень сложная или неразличимая тропа
 
   [type.highway.path.bicycle]
@@ -12534,7 +12536,7 @@
     af = Fiets- en voetpad
     ar = مسار للمشاة والدراجات معاً
     az = Velosiped və Gəzinti Yolu
-    de = Radweg
+    de = Rad- und Fußweg
     es = Camino para bicicletas
     et = Jalgratta- ja jalgtee
     fi = Pyörä- ja jalkatie
@@ -13550,6 +13552,7 @@
 
   [type.area_highway.path]
     ref = type.highway.path
+    de = Weg
 
   [type.area_highway.pedestrian]
     ref = type.highway.pedestrian

--- a/iphone/Maps/LocalizedStrings/de.lproj/Localizable.strings
+++ b/iphone/Maps/LocalizedStrings/de.lproj/Localizable.strings
@@ -2098,17 +2098,17 @@
 /* These translations are used for all type.highway.*.tunnel. */
 "type.highway.motorway_link.tunnel" = "Tunnel";
 
-"type.highway.path" = "Weg";
+"type.highway.path" = "Pfad";
 
 /* Hiking trail tagged as sac_scale=demanding_mountain_hiking (3 of 6) or trail_visibility=bad. */
-"type.highway.path.difficult" = "Weg";
+"type.highway.path.difficult" = "Schwieriger oder kaum erkennbarer Pfad";
 
 /* Hiking trail tagged as sac_scale=alpine_hiking (4+ of 6) or trail_visibility=horrible or more extreme. */
-"type.highway.path.expert" = "Weg";
+"type.highway.path.expert" = "Alpinwanderweg oder wegloser Pfad";
 
-"type.highway.path.bicycle" = "Radweg";
+"type.highway.path.bicycle" = "Rad- und Fußweg";
 
-"type.highway.footway.bicycle" = "Radweg";
+"type.highway.footway.bicycle" = "Rad- und Fußweg";
 
 /* These translations are used for all type.highway.*.bridge. */
 "type.highway.path.bridge" = "Brücke";


### PR DESCRIPTION
- Added German translations for the new Cycle & Foot Paths category as well as for the new Hiking categories. 
- Changed translation for unmade paths to "Pfad"
- Kept the old "Weg" for `area:highway=path`