### PR TITLE
[ios] Recover the deleted bookmark using the `Recover button` on the place page

### DIFF
--- a/android/app/src/main/cpp/app/organicmaps/bookmarks/data/BookmarkManager.cpp
+++ b/android/app/src/main/cpp/app/organicmaps/bookmarks/data/BookmarkManager.cpp
@@ -879,4 +879,10 @@ Java_app_organicmaps_bookmarks_data_BookmarkManager_nativeRemoveElevationActiveC
 {
   frm()->GetBookmarkManager().SetElevationActivePointChangedCallback(nullptr);
 }
+
+JNIEXPORT jboolean JNICALL
+Java_app_organicmaps_widget_placepage_PlacePageButtonFactory_nativeHasRecentlyDeletedBookmark(JNIEnv *, jclass)
+{
+  return frm()->GetBookmarkManager().HasRecentlyDeletedBookmark();
+}
 }  // extern "C"

--- a/android/app/src/main/java/app/organicmaps/widget/placepage/PlacePageButtonFactory.java
+++ b/android/app/src/main/java/app/organicmaps/widget/placepage/PlacePageButtonFactory.java
@@ -23,7 +23,7 @@ public class PlacePageButtonFactory
       }
       case BOOKMARK_SAVE ->
       {
-        titleId = R.string.save;
+        titleId = nativeHasRecentlyDeletedBookmark() ? R.string.restore : R.string.save;
         yield R.drawable.ic_bookmarks_off;
       }
       case BOOKMARK_DELETE ->
@@ -74,4 +74,6 @@ public class PlacePageButtonFactory
     };
     return new PlacePageButton(titleId, iconId, buttonType);
   }
+
+  private native static boolean nativeHasRecentlyDeletedBookmark();
 }

--- a/android/app/src/main/res/values-ar/strings.xml
+++ b/android/app/src/main/res/values-ar/strings.xml
@@ -630,6 +630,7 @@
 	<plurals name="bookmarks_detect_message">
 	  <item quantity="other">تم العثور على %d ملفات. سوف تراهم بعد التحويل.</item>
 	</plurals>
+	<string name="restore">استعادة</string>
 	<plurals name="objects">
 	  <item quantity="other">غرض %d</item>
 	</plurals>

--- a/android/app/src/main/res/values-az/strings.xml
+++ b/android/app/src/main/res/values-az/strings.xml
@@ -617,6 +617,7 @@
 	<plurals name="bookmarks_detect_message">
 	  <item quantity="other">%d fayl tapıldı. Dönüşümdən sonra onları görəcəksiniz.</item>
 	</plurals>
+	<string name="restore">Bərpa</string>
 	<plurals name="objects">
 	  <item quantity="other">%d obyekt</item>
 	</plurals>

--- a/android/app/src/main/res/values-be/strings.xml
+++ b/android/app/src/main/res/values-be/strings.xml
@@ -608,6 +608,7 @@
 	<string name="please_wait">Пачакайце…</string>
 	<string name="phone_number">Нумар тэлефона</string>
 	<string name="profile">Профіль OpenStreetMap</string>
+	<string name="restore">Аднавіць</string>
 	<plurals name="objects">
 	  <item quantity="few">%d аб\'екты</item>
 	  <item quantity="one">%d аб\'ект</item>

--- a/android/app/src/main/res/values-bg/strings.xml
+++ b/android/app/src/main/res/values-bg/strings.xml
@@ -572,6 +572,7 @@
 	  <item quantity="one">Открит е %d файл. Можете да го видите след конвертирането.</item>
 	  <item quantity="other">Открити са %d файла. Можете да ги видите след конвертирането.</item>
 	</plurals>
+	<string name="restore">Възстановяване</string>
 	<plurals name="objects">
 	  <item quantity="one">%d обект</item>
 	  <item quantity="other">%d обекта</item>

--- a/android/app/src/main/res/values-ca/strings.xml
+++ b/android/app/src/main/res/values-ca/strings.xml
@@ -611,6 +611,7 @@
 	  <item quantity="one">S\'ha trobat %d fitxer. Podeu veure\'l després de la conversió.</item>
 	  <item quantity="other">S\'han trobat %d fiters. Podeu veure\'ls després de la conversió.</item>
 	</plurals>
+	<string name="restore">Restaura</string>
 	<plurals name="objects">
 	  <item quantity="one">%d objecte</item>
 	  <item quantity="other">%d objectes</item>

--- a/android/app/src/main/res/values-cs/strings.xml
+++ b/android/app/src/main/res/values-cs/strings.xml
@@ -591,6 +591,7 @@
 	  <item quantity="one">%d soubor byl nalezen. Uvidíte ji po konverzi.</item>
 	  <item quantity="other">Bylo nalezeno %d souborů. Uvidíte je po konverzi.</item>
 	</plurals>
+	<string name="restore">Obnovit</string>
 	<plurals name="objects">
 	  <item quantity="other">%d místo</item>
 	</plurals>

--- a/android/app/src/main/res/values-da/strings.xml
+++ b/android/app/src/main/res/values-da/strings.xml
@@ -586,6 +586,7 @@
 	  <item quantity="one">%d fil blev fundet. Du vil se det efter konvertering.</item>
 	  <item quantity="other">Der er fundet %d filer. Du vil se dem efter konvertering.</item>
 	</plurals>
+	<string name="restore">Gendan</string>
 	<plurals name="objects">
 	  <item quantity="other">%d sted</item>
 	</plurals>

--- a/android/app/src/main/res/values-de/strings.xml
+++ b/android/app/src/main/res/values-de/strings.xml
@@ -614,6 +614,7 @@
 	  <item quantity="one">%d Datei wurde gefunden. Sie werden sie nach der Konvertierung sehen.</item>
 	  <item quantity="other">%d Dateien wurden gefunden. Sie werden sie nach der Konvertierung sehen.</item>
 	</plurals>
+	<string name="restore">Wiederherstellen</string>
 	<plurals name="objects">
 	  <item quantity="one">%d Objekt</item>
 	  <item quantity="other">%d Objekte</item>

--- a/android/app/src/main/res/values-el/strings.xml
+++ b/android/app/src/main/res/values-el/strings.xml
@@ -614,6 +614,7 @@
 	  <item quantity="one">Βρέθηκε %d αρχείο. Θα το δείτε μετά τη μετατροπή.</item>
 	  <item quantity="other">έχουν βρεθεί %d αρχεία. Θα τα δείτε μετά τη μετατροπή.</item>
 	</plurals>
+	<string name="restore">Επαναφορά</string>
 	<plurals name="objects">
 	  <item quantity="one">%d αντικείμενο</item>
 	  <item quantity="other">%d αντικείμενα</item>

--- a/android/app/src/main/res/values-es-rMX/strings.xml
+++ b/android/app/src/main/res/values-es-rMX/strings.xml
@@ -103,6 +103,7 @@
 	  <item quantity="one">Se encontró %d archivo. Lo verás después de la conversión.</item>
 	  <item quantity="other">Se han encontrado %d archivos. Los verás después de la conversión.</item>
 	</plurals>
+	<string name="restore">Restaurar</string>
 	<plurals name="objects">
 	  <item quantity="other">%d lugar</item>
 	</plurals>

--- a/android/app/src/main/res/values-es/strings.xml
+++ b/android/app/src/main/res/values-es/strings.xml
@@ -618,6 +618,7 @@
 	  <item quantity="one">Se encontró %d archivo. Lo verá después de la conversión.</item>
 	  <item quantity="other">Se han encontrado %d archivos. Los verá después de la conversión.</item>
 	</plurals>
+	<string name="restore">Restaurar</string>
 	<plurals name="objects">
 	  <item quantity="one">%d objeto</item>
 	  <item quantity="other">%d objetos</item>

--- a/android/app/src/main/res/values-et/strings.xml
+++ b/android/app/src/main/res/values-et/strings.xml
@@ -610,6 +610,7 @@
 	  <item quantity="one">%d fail leiti. Näed seda peale teisendamist.</item>
 	  <item quantity="other">%d faili leiti. Näed neid peale teisendamist.</item>
 	</plurals>
+	<string name="restore">Taasta</string>
 	<plurals name="objects">
 	  <item quantity="one">%d objekt</item>
 	  <item quantity="other">%d objekti</item>

--- a/android/app/src/main/res/values-eu/strings.xml
+++ b/android/app/src/main/res/values-eu/strings.xml
@@ -616,6 +616,7 @@
 	  <item quantity="one">fitxategi %d aurkitu da. Elkarrizketaren ondoren ikusiko duzu.</item>
 	  <item quantity="other">%d fitxategi aurkitu dira. Elkarrizketaren ondoren ikusiko dituzu.</item>
 	</plurals>
+	<string name="restore">Berreskuratu</string>
 	<plurals name="objects">
 	  <item quantity="one">objektu %d</item>
 	  <item quantity="other">%d objektu</item>

--- a/android/app/src/main/res/values-fa/strings.xml
+++ b/android/app/src/main/res/values-fa/strings.xml
@@ -582,6 +582,7 @@
 	  <item quantity="one">%d فایل پیدا شد. بعد از تبدیل آن را می‌بینید.</item>
 	  <item quantity="other">%d فایل پیدا شد. بعد از تبدیل آن‌ها را می‌بینید.</item>
 	</plurals>
+	<string name="restore">بازیابی</string>
 	<plurals name="objects">
 	  <item quantity="one">%d شیء</item>
 	  <item quantity="other">%d شیء</item>

--- a/android/app/src/main/res/values-fi/strings.xml
+++ b/android/app/src/main/res/values-fi/strings.xml
@@ -620,6 +620,7 @@
 	  <item quantity="one">%d tiedosto löydettiin. Näet sen muunnoksen jälkeen.</item>
 	  <item quantity="other">%d tiedostoa löydettiin. Näet ne muunnoksen jälkeen.</item>
 	</plurals>
+	<string name="restore">Palauta</string>
 	<plurals name="objects">
 	  <item quantity="one">%d kohde</item>
 	  <item quantity="other">%d kohdetta</item>

--- a/android/app/src/main/res/values-fr/strings.xml
+++ b/android/app/src/main/res/values-fr/strings.xml
@@ -619,6 +619,7 @@
 	  <item quantity="one">%d fichier a été trouvé. Vous le verrez après la conversion.</item>
 	  <item quantity="other">%d fichiers ont été trouvés. Vous les verrez après la conversion.</item>
 	</plurals>
+	<string name="restore">Restaurer</string>
 	<plurals name="objects">
 	  <item quantity="one">%d objet</item>
 	  <item quantity="other">%d objets</item>

--- a/android/app/src/main/res/values-hu/strings.xml
+++ b/android/app/src/main/res/values-hu/strings.xml
@@ -599,6 +599,7 @@
 	  <item quantity="one">%d fájlt találtunk. Látni fogja őket a megtérés után.</item>
 	  <item quantity="other">%d fájl található. Látni fogja őket a megtérés után.</item>
 	</plurals>
+	<string name="restore">Visszaállítás</string>
 	<plurals name="objects">
 	  <item quantity="other">%d hely</item>
 	</plurals>

--- a/android/app/src/main/res/values-in/strings.xml
+++ b/android/app/src/main/res/values-in/strings.xml
@@ -587,6 +587,7 @@
 	  <item quantity="one">%d file ditemukan. Anda akan melihatnya setelah mengonversi.</item>
 	  <item quantity="other">%d file telah ditemukan. Anda akan melihatnya setelah konversi.</item>
 	</plurals>
+	<string name="restore">Mengembalikan</string>
 	<plurals name="objects">
 	  <item quantity="other">tempat %d</item>
 	</plurals>

--- a/android/app/src/main/res/values-it/strings.xml
+++ b/android/app/src/main/res/values-it/strings.xml
@@ -601,6 +601,7 @@
 	  <item quantity="one">%d file è stato trovato. Lo vedrai dopo la conversione.</item>
 	  <item quantity="other">%d file trovati. Li vedrai dopo la conversione.</item>
 	</plurals>
+	<string name="restore">Ripristina</string>
 	<plurals name="objects">
 	  <item quantity="one">%d oggetto</item>
 	  <item quantity="other">%d oggetti</item>

--- a/android/app/src/main/res/values-iw/strings.xml
+++ b/android/app/src/main/res/values-iw/strings.xml
@@ -609,6 +609,7 @@
 	  <item quantity="one">נמצא קובץ %d. יהיה ניתן לראות אותו לאחר ההמרה.</item>
 	  <item quantity="other">נמצאו %d קבצים. יהיה ניתן לראות אותם לאחר ההמרה.</item>
 	</plurals>
+	<string name="restore">שחזור</string>
 	<plurals name="objects">
 	  <item quantity="one">פריט %d</item>
 	  <item quantity="other">%d פריטים</item>

--- a/android/app/src/main/res/values-ja/strings.xml
+++ b/android/app/src/main/res/values-ja/strings.xml
@@ -619,6 +619,7 @@
 	<plurals name="bookmarks_detect_message">
 	  <item quantity="other">%d ファイルが見つかりました。 あなたは変換後にそれらを見るでしょう。</item>
 	</plurals>
+	<string name="restore">復元</string>
 	<plurals name="objects">
 	  <item quantity="other">%dの場所</item>
 	</plurals>

--- a/android/app/src/main/res/values-ko/strings.xml
+++ b/android/app/src/main/res/values-ko/strings.xml
@@ -584,6 +584,7 @@
 	<plurals name="bookmarks_detect_message">
 	  <item quantity="other">%d 파일을 찾았습니다. 회심 후 그들을 볼 수 있습니다.</item>
 	</plurals>
+	<string name="restore">복원</string>
 	<plurals name="objects">
 	  <item quantity="other">%d 장소</item>
 	</plurals>

--- a/android/app/src/main/res/values-mr/strings.xml
+++ b/android/app/src/main/res/values-mr/strings.xml
@@ -582,6 +582,7 @@
 	  <item quantity="one">%d फाईल सापडली. रूपांतरानंतर तुम्ही ती पाहू शकता.</item>
 	  <item quantity="other">%d फाईली सापडल्या. रूपांतरानंतर तुम्ही त्या पाहू शकता.</item>
 	</plurals>
+	<string name="restore">पूर्ववत् करा</string>
 	<plurals name="objects">
 	  <item quantity="other">%d वस्तू</item>
 	</plurals>

--- a/android/app/src/main/res/values-nb/strings.xml
+++ b/android/app/src/main/res/values-nb/strings.xml
@@ -618,6 +618,7 @@
 	  <item quantity="one">%d filen ble funnet. Du vil se dem etter konverteringen.</item>
 	  <item quantity="other">%d filer funnet. Du vil se dem etter konverteringen.</item>
 	</plurals>
+	<string name="restore">Restaurere</string>
 	<plurals name="objects">
 	  <item quantity="other">%d sted</item>
 	</plurals>

--- a/android/app/src/main/res/values-nl/strings.xml
+++ b/android/app/src/main/res/values-nl/strings.xml
@@ -614,6 +614,7 @@
 	  <item quantity="one">%d bestand gevonden. Je ziet het na het converteren.</item>
 	  <item quantity="other">Er zijn %d bestanden gevonden. Je zult ze na de conversie zien.</item>
 	</plurals>
+	<string name="restore">Herstellen</string>
 	<plurals name="objects">
 	  <item quantity="other">%d plaats</item>
 	</plurals>

--- a/android/app/src/main/res/values-pl/strings.xml
+++ b/android/app/src/main/res/values-pl/strings.xml
@@ -618,6 +618,7 @@
 	  <item quantity="other">Znaleziono %d plików. Zobaczysz je po konwersji.</item>
 	  <item quantity="two">Znaleziono %d pliki. Zobaczysz je po konwersji.</item>
 	</plurals>
+	<string name="restore">Przywróć</string>
 	<plurals name="objects">
 	  <item quantity="other">%d miejsce</item>
 	</plurals>

--- a/android/app/src/main/res/values-pt-rBR/strings.xml
+++ b/android/app/src/main/res/values-pt-rBR/strings.xml
@@ -568,6 +568,7 @@
 	  <item quantity="one">%d arquivo foi encontrado. Você vai ver depois da conversão.</item>
 	  <item quantity="other">%d arquivos foram encontrados. Você os verá depois da conversão.</item>
 	</plurals>
+	<string name="restore">Restaurar</string>
 	<plurals name="objects">
 	  <item quantity="one">%d objeto</item>
 	  <item quantity="other">%d objetos</item>

--- a/android/app/src/main/res/values-pt/strings.xml
+++ b/android/app/src/main/res/values-pt/strings.xml
@@ -592,6 +592,7 @@
 	  <item quantity="one">%d ficheiro encontrado. Pode vê-lo depois da conversão.</item>
 	  <item quantity="other">%d ficheiros encontrados. Pode vê-los depois da conversão.</item>
 	</plurals>
+	<string name="restore">Restaurar</string>
 	<plurals name="objects">
 	  <item quantity="one">%d objeto</item>
 	  <item quantity="other">%d objetos</item>

--- a/android/app/src/main/res/values-ro/strings.xml
+++ b/android/app/src/main/res/values-ro/strings.xml
@@ -602,6 +602,7 @@
 	  <item quantity="one">A fost găsit %d fișier. Îl vei vedea după conversiune.</item>
 	  <item quantity="other">Au fost găsite %d fișiere. Le vei vedea după conversiune.</item>
 	</plurals>
+	<string name="restore">Restabilește</string>
 	<plurals name="objects">
 	  <item quantity="one">%d obiect</item>
 	  <item quantity="other">%d obiecte</item>

--- a/android/app/src/main/res/values-ru/strings.xml
+++ b/android/app/src/main/res/values-ru/strings.xml
@@ -622,6 +622,7 @@
 	  <item quantity="one">%d файл был найден. Вы увидите его после конвертации.</item>
 	  <item quantity="other">%d файлов было найдено. Вы увидите их после конвертации.</item>
 	</plurals>
+	<string name="restore">Восстановить</string>
 	<plurals name="objects">
 	  <item quantity="few">%d объекта</item>
 	  <item quantity="one">%d объект</item>

--- a/android/app/src/main/res/values-sk/strings.xml
+++ b/android/app/src/main/res/values-sk/strings.xml
@@ -616,6 +616,7 @@
 	  <item quantity="one">Bol nájdený %d súbor. Uvidíte to po konverzii.</item>
 	  <item quantity="other">Bolo nájdených %d súborov. Uvidíte ich po konverzii.</item>
 	</plurals>
+	<string name="restore">Obnoviť</string>
 	<plurals name="objects">
 	  <item quantity="other">%d miesto</item>
 	</plurals>

--- a/android/app/src/main/res/values-sv/strings.xml
+++ b/android/app/src/main/res/values-sv/strings.xml
@@ -583,6 +583,7 @@
 	  <item quantity="one">%d fil hittades. Du kommer att se den efter omvandlingen.</item>
 	  <item quantity="other">%d filer har hittats. Du kommer att se dem efter omvandlingen.</item>
 	</plurals>
+	<string name="restore">Återställa</string>
 	<plurals name="objects">
 	  <item quantity="one">%d plats</item>
 	  <item quantity="other">%d platser</item>

--- a/android/app/src/main/res/values-sw/strings.xml
+++ b/android/app/src/main/res/values-sw/strings.xml
@@ -154,6 +154,7 @@
 	  <item quantity="one">Faili %d ilipatikana. Utaiona baada ya uongofu.</item>
 	  <item quantity="other">Files %d zimepatikana. Utawaona baada ya uongofu.</item>
 	</plurals>
+	<string name="restore">Rejesha</string>
 	<plurals name="objects">
 	  <item quantity="other">Eneo %d</item>
 	</plurals>

--- a/android/app/src/main/res/values-th/strings.xml
+++ b/android/app/src/main/res/values-th/strings.xml
@@ -586,6 +586,7 @@
 	<plurals name="bookmarks_detect_message">
 	  <item quantity="other">%d ไฟล์ที่ค้นพบ คุณจะเห็นพวกเขาหลังจากการแปลง</item>
 	</plurals>
+	<string name="restore">ฟื้นฟู</string>
 	<plurals name="objects">
 	  <item quantity="other">%d สถานที่</item>
 	</plurals>

--- a/android/app/src/main/res/values-tr/strings.xml
+++ b/android/app/src/main/res/values-tr/strings.xml
@@ -617,6 +617,7 @@
 	<plurals name="bookmarks_detect_message">
 	  <item quantity="other">%d dosya bulundu. Dönüşümden sonra onları göreceksiniz.</item>
 	</plurals>
+	<string name="restore">Geri al</string>
 	<plurals name="objects">
 	  <item quantity="other">%d obje</item>
 	</plurals>

--- a/android/app/src/main/res/values-uk/strings.xml
+++ b/android/app/src/main/res/values-uk/strings.xml
@@ -621,6 +621,7 @@
 	  <item quantity="one">%d файл був знайдений. Ви побачите його після перетворення.</item>
 	  <item quantity="other">%d файлів було знайдено. Ви побачите їх після конвертації.</item>
 	</plurals>
+	<string name="restore">Відновити</string>
 	<plurals name="objects">
 	  <item quantity="other">%d місце</item>
 	</plurals>

--- a/android/app/src/main/res/values-vi/strings.xml
+++ b/android/app/src/main/res/values-vi/strings.xml
@@ -585,6 +585,7 @@
 	  <item quantity="one">%d dã tìm thấy một tệp. Bạn sẽ thấy nó sau khi chuyển đổi.</item>
 	  <item quantity="other">%d tập tin đã được tìm thấy. Bạn sẽ thấy chúng sau khi chuyển đổi.</item>
 	</plurals>
+	<string name="restore">Khôi phục</string>
 	<plurals name="objects">
 	  <item quantity="other">%d nơi</item>
 	</plurals>

--- a/android/app/src/main/res/values-zh-rTW/strings.xml
+++ b/android/app/src/main/res/values-zh-rTW/strings.xml
@@ -602,6 +602,7 @@
 	<plurals name="bookmarks_detect_message">
 	  <item quantity="other">找到%d個文件。 轉換後你會看到它。</item>
 	</plurals>
+	<string name="restore">恢復</string>
 	<plurals name="objects">
 	  <item quantity="other">%d 地點</item>
 	</plurals>

--- a/android/app/src/main/res/values-zh/strings.xml
+++ b/android/app/src/main/res/values-zh/strings.xml
@@ -595,6 +595,7 @@
 	<plurals name="bookmarks_detect_message">
 	  <item quantity="other">找到%d个文件。 转换后你会看到它。</item>
 	</plurals>
+	<string name="restore">恢复</string>
 	<plurals name="objects">
 	  <item quantity="other">%d 地点</item>
 	</plurals>

--- a/android/app/src/main/res/values/strings.xml
+++ b/android/app/src/main/res/values/strings.xml
@@ -643,6 +643,7 @@
 	  <item quantity="one">%d file was found. You can see it after conversion.</item>
 	  <item quantity="other">%d files were found. You can see them after conversion.</item>
 	</plurals>
+	<string name="restore">Restore</string>
 	<plurals name="objects">
 	  <item quantity="one">%d object</item>
 	  <item quantity="other">%d objects</item>

--- a/data/strings/strings.txt
+++ b/data/strings/strings.txt
@@ -22286,7 +22286,7 @@
     zh-Hant = 出現未知錯誤
 
   [restore]
-    tags = ios
+    tags = android,ios
     en = Restore
     af = Stel terug
     ar = استعادة

--- a/iphone/CoreApi/CoreApi/Bookmarks/MWMBookmarksManager.h
+++ b/iphone/CoreApi/CoreApi/Bookmarks/MWMBookmarksManager.h
@@ -143,6 +143,8 @@ NS_SWIFT_NAME(BookmarksManager)
 - (void)moveTrack:(MWMTrackID)trackId
         toGroupId:(MWMMarkGroupID)groupId;
 
+- (BOOL)hasRecentlyDeletedBookmark;
+
 - (instancetype)init __attribute__((unavailable("call +manager instead")));
 - (instancetype)copy __attribute__((unavailable("call +manager instead")));
 - (instancetype)copyWithZone:(NSZone *)zone __attribute__((unavailable("call +manager instead")));

--- a/iphone/CoreApi/CoreApi/Bookmarks/MWMBookmarksManager.mm
+++ b/iphone/CoreApi/CoreApi/Bookmarks/MWMBookmarksManager.mm
@@ -766,6 +766,10 @@ static KmlFileType convertFileTypeToCore(MWMKmlFileType fileType) {
   }
 }
 
+- (BOOL)hasRecentlyDeletedBookmark {
+  return self.bm.HasRecentlyDeletedBookmark();
+}
+
 - (void)setCategory:(MWMMarkGroupID)groupId authorType:(MWMBookmarkGroupAuthorType)author
 {
   switch (author)

--- a/iphone/Maps/UI/PlacePage/Components/ActionBarViewController.swift
+++ b/iphone/Maps/UI/PlacePage/Components/ActionBarViewController.swift
@@ -5,6 +5,7 @@ protocol ActionBarViewControllerDelegate: AnyObject {
 class ActionBarViewController: UIViewController {
   @IBOutlet var stackView: UIStackView!
   var downloadButton: ActionBarButton? = nil
+  var bookmarkButton: ActionBarButton? = nil
   var popoverSourceView: UIView? {
     stackView.arrangedSubviews.last
   }
@@ -50,6 +51,9 @@ class ActionBarViewController: UIViewController {
         downloadButton = button
         updateDownloadButtonState(placePageData.mapNodeAttributes!.nodeStatus)
       }
+      if buttonType == .bookmark {
+        bookmarkButton = button
+      }
     }
   }
 
@@ -61,6 +65,7 @@ class ActionBarViewController: UIViewController {
     visibleButtons.removeAll()
     additionalButtons.removeAll()
     downloadButton = nil
+    bookmarkButton = nil
     configureButtons()
   }
 
@@ -86,6 +91,15 @@ class ActionBarViewController: UIViewController {
     @unknown default:
       fatalError()
     }
+  }
+
+  func updateBookmarkButtonState(isSelected: Bool) {
+    guard let bookmarkButton else { return }
+    if !isSelected && BookmarksManager.shared().hasRecentlyDeletedBookmark() {
+      bookmarkButton.setBookmarkButtonState(.recover)
+      return
+    }
+    bookmarkButton.setBookmarkButtonState(isSelected ? .delete : .save)
   }
 
   private func configButton1() {

--- a/iphone/Maps/UI/PlacePage/PlacePageLayout/ActionBar/MWMActionBarButton.h
+++ b/iphone/Maps/UI/PlacePage/PlacePageLayout/ActionBar/MWMActionBarButton.h
@@ -16,6 +16,12 @@ typedef NS_ENUM(NSInteger, MWMActionBarButtonType) {
   MWMActionBarButtonTypeAvoidFerry
 } NS_SWIFT_NAME(ActionBarButtonType);
 
+typedef NS_ENUM(NSInteger, MWMBookmarksButtonState) {
+  MWMBookmarksButtonStateSave,
+  MWMBookmarksButtonStateDelete,
+  MWMBookmarksButtonStateRecover,
+};
+
 NS_ASSUME_NONNULL_BEGIN
 
 #ifdef __cplusplus
@@ -46,6 +52,8 @@ NS_SWIFT_NAME(ActionBarButton)
                                 buttonType:(MWMActionBarButtonType)type
                                 isSelected:(BOOL)isSelected
                                 isEnabled:(BOOL)isEnabled;
+
+- (void)setBookmarkButtonState:(MWMBookmarksButtonState)state;
 
 @end
 

--- a/iphone/Maps/UI/PlacePage/PlacePageLayout/ActionBar/MWMActionBarButton.m
+++ b/iphone/Maps/UI/PlacePage/PlacePageLayout/ActionBar/MWMActionBarButton.m
@@ -155,20 +155,29 @@ NSString *titleForButton(MWMActionBarButtonType type, BOOL isSelected) {
 }
 
 - (IBAction)tap {
-  if (self.type == MWMActionBarButtonTypeBookmark)
-    [self setBookmarkSelected:!self.button.isSelected];
   if (self.type == MWMActionBarButtonTypeRouteTo)
     [self disableRouteToButtonHighlight];
   
   [self.delegate tapOnButtonWithType:self.type];
 }
 
-- (void)setBookmarkSelected:(BOOL)isSelected {
-  if (isSelected)
-    [self.button.imageView startAnimating];
-
-  self.button.selected = isSelected;
-  self.label.text = L(isSelected ? @"delete" : @"save");
+- (void)setBookmarkButtonState:(MWMBookmarksButtonState)state {
+  switch (state) {
+    case MWMBookmarksButtonStateSave:
+      self.label.text = L(@"save");
+      self.button.selected = false;
+      break;
+    case MWMBookmarksButtonStateDelete:
+      self.label.text = L(@"delete");
+      if (!self.button.selected)
+        [self.button.imageView startAnimating];
+      self.button.selected = true;
+      break;
+    case MWMBookmarksButtonStateRecover:
+      self.label.text = L(@"restore");
+      self.button.selected = false;
+      break;
+  }
 }
 
 - (void)setupBookmarkButton:(BOOL)isSelected {
@@ -178,7 +187,7 @@ NSString *titleForButton(MWMActionBarButtonType type, BOOL isSelected) {
   [btn setImage:[UIImage imageNamed:@"ic_bookmarks_on"] forState:UIControlStateHighlighted];
   [btn setImage:[UIImage imageNamed:@"ic_bookmarks_on"] forState:UIControlStateDisabled];
 
-  [self setBookmarkSelected:isSelected];
+  [btn setSelected:isSelected];
 
   NSUInteger const animationImagesCount = 11;
   NSMutableArray *animationImages = [NSMutableArray arrayWithCapacity:animationImagesCount];

--- a/iphone/Maps/UI/PlacePage/PlacePageLayout/Layouts/PlacePageCommonLayout.swift
+++ b/iphone/Maps/UI/PlacePage/PlacePageLayout/Layouts/PlacePageCommonLayout.swift
@@ -120,9 +120,7 @@ class PlacePageCommonLayout: NSObject, IPlacePageLayout {
 
     placePageData.onBookmarkStatusUpdate = { [weak self] in
       guard let self = self else { return }
-      if self.placePageData.bookmarkData == nil {
-        self.actionBarViewController.resetButtons()
-      }
+      self.actionBarViewController.updateBookmarkButtonState(isSelected: self.placePageData.bookmarkData != nil)
       self.previewViewController.placePagePreviewData = self.placePageData.previewData
       self.updateBookmarkRelatedSections()
     }

--- a/map/bookmark.cpp
+++ b/map/bookmark.cpp
@@ -284,7 +284,8 @@ bool Bookmark::CanFillPlacePageMetadata() const
 
 void Bookmark::Attach(kml::MarkGroupId groupId)
 {
-  ASSERT(m_groupId == kml::kInvalidMarkGroupId, ());
+  ASSERT_NOT_EQUAL(groupId, kml::kInvalidMarkGroupId, ());
+  ASSERT_EQUAL(m_groupId, kml::kInvalidMarkGroupId, ());
   m_groupId = groupId;
 }
 

--- a/map/bookmark_manager.hpp
+++ b/map/bookmark_manager.hpp
@@ -375,6 +375,9 @@ public:
   bool SaveBookmarkCategory(kml::MarkGroupId groupId);
   bool SaveBookmarkCategory(kml::MarkGroupId groupId, Writer & writer, KmlFileType fileType) const;
 
+  bool HasRecentlyDeletedBookmark() const { return m_recentlyDeletedBookmark.operator bool(); };
+  void ResetRecentlyDeletedBookmark();
+
   // Used for LoadBookmarks() and unit tests only. Does *not* update last modified time.
   void CreateCategories(KMLDataCollection && dataCollection, bool autoSave = false);
 
@@ -761,6 +764,8 @@ private:
   kml::MarkId m_trackInfoMarkId = kml::kInvalidMarkId;
   kml::TrackId m_selectedTrackId = kml::kInvalidTrackId;
   m2::PointF m_maxBookmarkSymbolSize;
+
+  std::unique_ptr<Bookmark> m_recentlyDeletedBookmark;
 
   bool m_asyncLoadingInProgress = false;
   struct BookmarkLoaderInfo

--- a/map/framework.cpp
+++ b/map/framework.cpp
@@ -1880,6 +1880,8 @@ void Framework::ActivateMapSelection()
 
   auto & bm = GetBookmarkManager();
 
+  bm.ResetRecentlyDeletedBookmark();
+
   if (m_currentPlacePageInfo->GetSelectedObject() == df::SelectionShape::OBJECT_TRACK)
     bm.OnTrackSelected(m_currentPlacePageInfo->GetTrackId());
   else
@@ -1911,10 +1913,14 @@ void Framework::DeactivateMapSelection(bool notifyUI)
   if (notifyUI && m_onPlacePageClose)
     m_onPlacePageClose(!somethingWasAlreadySelected);
 
+
   if (somethingWasAlreadySelected)
   {
     DeactivateHotelSearchMark();
-    GetBookmarkManager().OnTrackDeselected();
+
+    auto & bm = GetBookmarkManager();
+    bm.OnTrackDeselected();
+    bm.ResetRecentlyDeletedBookmark();
 
     m_currentPlacePageInfo = {};
 


### PR DESCRIPTION
This PR allows recovering accidentally deleted bookmarks from the Place Page while the Place Page isn't closed yet.

When a user closes the Place Page or taps on another POI a recently deleted bookmark will be removed from the memory and restoring it will not be possible.

Fixes #1173
Fixes #4547

Todo:
- [x] implement add the `Recover` title to Android. For now it works correctly, but without the proper word (`Save` is shown where the `Recover` should be). @Jean-BaptisteC can you please help with that?

![Simulator Screen Recording - iPhone 15 Pro - 2024-06-01 at 00 02 10](https://github.com/organicmaps/organicmaps/assets/79797627/e58245af-3edb-4c85-95a2-8a752902f34e)
![Simulator Screen Recording - iPhone 15 Pro - 2024-06-01 at 00 03 45](https://github.com/organicmaps/organicmaps/assets/79797627/00b7322f-e29e-473a-8a7a-e3225588dd08)

https://github.com/organicmaps/organicmaps/assets/79797627/81eda875-bf27-466b-9090-d58547fa2dca

