### PR TITLE
[ios] Fix location info in sharing activity vc

### DIFF
--- a/iphone/Maps/Classes/Share/MWMShareActivityItem.mm
+++ b/iphone/Maps/Classes/Share/MWMShareActivityItem.mm
@@ -1,10 +1,10 @@
 #import "MWMShareActivityItem.h"
 
-
 #include <CoreApi/Framework.h>
 #import <CoreApi/PlacePageData.h>
 #import <CoreApi/PlacePagePreviewData.h>
 #import <CoreApi/PlacePageInfoData.h>
+#import <LinkPresentation/LPLinkMetadata.h>
 
 NSString * httpGe0Url(NSString * shortUrl)
 {
@@ -101,6 +101,15 @@ NSString * httpGe0Url(NSString * shortUrl)
               subjectForActivityType:(NSString *)activityType
 {
   return [self subjectDefault];
+}
+
+- (LPLinkMetadata *)activityViewControllerLinkMetadata:(UIActivityViewController *)activityViewController API_AVAILABLE(ios(13.0))
+{
+  LPLinkMetadata * metadata = [[LPLinkMetadata alloc] init];
+  metadata.originalURL = [NSURL URLWithString:[self url:NO]];
+  metadata.title = self.isMyPosition ? L(@"core_my_position") : self.data.previewData.title;
+  metadata.iconProvider = [[NSItemProvider alloc] initWithObject:[UIImage imageNamed:@"imgLogo"]];
+  return metadata;
 }
 
 #pragma mark - Message


### PR DESCRIPTION
| Before | After |
| --- | --- |
| <img width="350" alt="image" src="https://github.com/organicmaps/organicmaps/assets/79797627/a93f3014-418b-4c77-af29-40c80b926c6c"> |  <img width="350" alt="image" src="https://github.com/organicmaps/organicmaps/assets/79797627/04e34a76-2425-40ba-b277-e539bd8cd889"> |


And My location:

<img width="350" alt="image" src="https://github.com/organicmaps/organicmaps/assets/79797627/df50e23e-d268-4b95-866b-2527552041f9">
