### PR TITLE
[android] Fix Vulkan build error

### DIFF
--- a/drape/vulkan/vulkan_layers.cpp
+++ b/drape/vulkan/vulkan_layers.cpp
@@ -413,8 +413,7 @@ bool Layers::Initialize(VkInstance instance, VkPhysicalDevice physicalDevice)
                     VK_DEBUG_REPORT_DEBUG_BIT_EXT;
     dbgInfo.pfnCallback = DebugReportCallbackImpl;
     dbgInfo.pUserData = nullptr;
-    statusCode = m_vkCreateDebugReportCallbackEXT(instance, &dbgInfo, nullptr,
-                                                  &m_reportCallback);
+    statusCode = m_vkCreateDebugReportCallbackEXT(instance, &dbgInfo, nullptr, &m_reportCallback);
     if (statusCode != VK_SUCCESS)
     {
       LOG_ERROR_VK_CALL(vkCreateDebugReportCallbackEXT, statusCode);

--- a/drape/vulkan/vulkan_layers.hpp
+++ b/drape/vulkan/vulkan_layers.hpp
@@ -40,7 +40,7 @@ private:
   std::vector<char const *> m_deviceLayers;
   std::vector<char const *> m_deviceExtensions;
 
-  VkDebugReportCallbackEXT m_reportCallback = nullptr;
+  VkDebugReportCallbackEXT m_reportCallback {0};
 
   PFN_vkCreateDebugReportCallbackEXT m_vkCreateDebugReportCallbackEXT = nullptr;
   PFN_vkDestroyDebugReportCallbackEXT m_vkDestroyDebugReportCallbackEXT = nullptr;


### PR DESCRIPTION
```
omim/drape/vulkan/vulkan_layers.hpp:43:47: error: cannot initialize a member subobject of type 'VkDebugReportCallbackEXT' (aka 'unsigned long long') with an rvalue of type 'std::nullptr_t'
  VkDebugReportCallbackEXT m_reportCallback = nullptr;
                                              ^~~~~~~
```

CC @renderexpert 