### PR TITLE
[ios] Import kml, kmz, gpx files using the default document picker

### DIFF
--- a/android/app/src/main/res/values-bg/strings.xml
+++ b/android/app/src/main/res/values-bg/strings.xml
@@ -559,7 +559,7 @@
 	<string name="bookmark_lists_show_all">Показване на всичко</string>
 	<string name="bookmarks_create_new_group">Създаване на нов списък</string>
 	<!-- Bookmark categories screen, button that opens folder selection dialog to import KML/KMZ/GPX/KMB files -->
-	<string name="bookmarks_import">Импортиране на отметки и песни</string>
+	<string name="bookmarks_import">Импортиране на отметки и маршрути</string>
 	<string name="bookmarks_error_message_share_general">Не е възможно споделяне поради грешка в приложението</string>
 	<string name="bookmarks_error_title_share_empty">Грешка при споделяне</string>
 	<string name="bookmarks_error_message_share_empty">Не може да се споделя празен списък</string>

--- a/data/strings/strings.txt
+++ b/data/strings/strings.txt
@@ -21118,14 +21118,14 @@
     zh-Hant = 創建新列表
 
   [bookmarks_import]
-    tags = android
+    tags = android,ios
     comment = Bookmark categories screen, button that opens folder selection dialog to import KML/KMZ/GPX/KMB files
     en = Import Bookmarks and Tracks
     af = Voer leidrade en snitte in
     ar = استيراد الإشارات المرجعية والمسارات
     az = Əlfəcinləri və fraqmentləri idxal edin
     be = Імпартаваць закладкі і cцежкі
-    bg = Импортиране на отметки и песни
+    bg = Импортиране на отметки и маршрути
     ca = Importa marcadors i les traces
     cs = Import záložek a stop
     da = Importer bogmærker og spor

--- a/iphone/CoreApi/CoreApi/Bookmarks/MWMBookmarksManager.h
+++ b/iphone/CoreApi/CoreApi/Bookmarks/MWMBookmarksManager.h
@@ -36,6 +36,7 @@ NS_SWIFT_NAME(BookmarksManager)
 
 - (BOOL)areBookmarksLoaded;
 - (void)loadBookmarks;
+- (void)loadBookmarkFile:(NSURL *)url;
 - (void)reloadCategoryAtFilePath:(NSString *)filePath;
 - (void)deleteCategoryAtFilePath:(NSString *)filePath;
 

--- a/iphone/CoreApi/CoreApi/Bookmarks/MWMBookmarksManager.mm
+++ b/iphone/CoreApi/CoreApi/Bookmarks/MWMBookmarksManager.mm
@@ -203,6 +203,11 @@ static KmlFileType convertFileTypeToCore(MWMKmlFileType fileType) {
   self.bm.LoadBookmarks();
 }
 
+- (void)loadBookmarkFile:(NSURL *)url
+{
+  self.bm.LoadBookmark(url.path.UTF8String, false /* isTemporaryFile */);
+}
+
 - (void)reloadCategoryAtFilePath:(NSString *)filePath
 {
   self.bm.ReloadBookmark(filePath.UTF8String);

--- a/iphone/Maps/Bookmarks/Categories/Actions/BMCActionsCell.xib
+++ b/iphone/Maps/Bookmarks/Categories/Actions/BMCActionsCell.xib
@@ -20,7 +20,7 @@
                     <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="YDi-5J-vFD">
                         <rect key="frame" x="0.0" y="0.0" width="320" height="44"/>
                         <subviews>
-                            <imageView userInteractionEnabled="NO" contentMode="scaleToFill" horizontalHuggingPriority="251" verticalHuggingPriority="251" image="ic24PxAddCopy" translatesAutoresizingMaskIntoConstraints="NO" id="paw-km-zXg">
+                            <imageView userInteractionEnabled="NO" contentMode="scaleAspectFit" horizontalHuggingPriority="251" verticalHuggingPriority="251" image="ic24PxAddCopy" translatesAutoresizingMaskIntoConstraints="NO" id="paw-km-zXg">
                                 <rect key="frame" x="16" y="10" width="24" height="24"/>
                                 <constraints>
                                     <constraint firstAttribute="height" constant="24" id="S7u-WM-dEL"/>

--- a/iphone/Maps/Bookmarks/Categories/BMCModels.swift
+++ b/iphone/Maps/Bookmarks/Categories/BMCModels.swift
@@ -9,6 +9,7 @@ protocol BMCModel {}
 enum BMCAction: BMCModel {
   case create
   case exportAll
+  case `import`
 }
 
 extension BMCAction {
@@ -18,6 +19,8 @@ extension BMCAction {
       return L("bookmarks_create_new_group")
     case .exportAll:
       return L("bookmarks_export")
+    case .import:
+      return L("bookmarks_import")
     }
   }
 
@@ -27,6 +30,8 @@ extension BMCAction {
       return UIImage(named: "ic24PxAddCopy")!
     case .exportAll:
       return UIImage(named: "ic24PxShare")!
+    case .import:
+      return UIImage(named: "ic24PxImport")!
     }
   }
 }

--- a/iphone/Maps/Bookmarks/Categories/BMCView/BMCViewController.swift
+++ b/iphone/Maps/Bookmarks/Categories/BMCView/BMCViewController.swift
@@ -99,6 +99,12 @@ final class BMCViewController: MWMViewController {
     }
   }
 
+  private func showImportDialog() {
+    DocumentPicker.shared.present(from: self) { [viewModel] urls in
+      viewModel?.importCategories(from: urls)
+    }
+  }
+
   private func openCategorySettings(category: BookmarkGroup) {
     let settingsController = CategorySettingsViewController(bookmarkGroup: BookmarksManager.shared().category(withId: category.categoryId))
     settingsController.delegate = self
@@ -268,6 +274,7 @@ extension BMCViewController: UITableViewDelegate {
       switch viewModel.action(at: indexPath.row) {
       case .create: createNewCategory()
       case .exportAll: shareAllCategories(anchor: tableView.cellForRow(at: indexPath))
+      case .import: showImportDialog()
       }
     default:
       assertionFailure()

--- a/iphone/Maps/Bookmarks/Categories/BMCViewModel/BMCDefaultViewModel.swift
+++ b/iphone/Maps/Bookmarks/Categories/BMCViewModel/BMCDefaultViewModel.swift
@@ -33,6 +33,7 @@ final class BMCDefaultViewModel: NSObject {
 
   private func setActions() {
     actions = [.create]
+    actions.append(.import)
     if !manager.areAllCategoriesEmpty() {
       actions.append(.exportAll)
     }
@@ -139,6 +140,11 @@ extension BMCDefaultViewModel {
 
   func shareAllCategories(handler: @escaping SharingResultCompletionHandler) {
     manager.shareAllCategories(completion: handler)
+  }
+
+  func importCategories(from urls: [URL]) {
+    // TODO: Refactor this call when the multiple files parsing support will be added to the bookmark_manager.
+    urls.forEach(manager.loadBookmarkFile(_:))
   }
 
   func finishShareCategory() {

--- a/iphone/Maps/Core/iCloud/CloudStorageManager.swift
+++ b/iphone/Maps/Core/iCloud/CloudStorageManager.swift
@@ -13,16 +13,6 @@ enum WritingResult {
 typealias VoidResultCompletionHandler = (VoidResult) -> Void
 typealias WritingResultCompletionHandler = (WritingResult) -> Void
 
-// TODO: Remove this type and use custom UTTypeIdentifier that is registered into the Info.plist after updating to the iOS >= 14.0.
-struct FileType {
-  let fileExtension: String
-  let typeIdentifier: String
-}
-
-extension FileType {
-  static let kml = FileType(fileExtension: "kml", typeIdentifier: "com.google.earth.kml")
-}
-
 let kTrashDirectoryName = ".Trash"
 private let kBookmarksDirectoryName = "bookmarks"
 private let kICloudSynchronizationDidChangeEnabledStateNotificationName = "iCloudSynchronizationDidChangeEnabledStateNotification"

--- a/iphone/Maps/Images.xcassets/Sharing/ic24PxImport.imageset/Contents.json
+++ b/iphone/Maps/Images.xcassets/Sharing/ic24PxImport.imageset/Contents.json
@@ -1,7 +1,7 @@
 {
   "images" : [
     {
-      "filename" : "ic24PxShare.svg",
+      "filename" : "ic24PxImport.svg",
       "idiom" : "universal"
     }
   ],

--- a/iphone/Maps/Images.xcassets/Sharing/ic24PxImport.imageset/ic24PxImport.svg
+++ b/iphone/Maps/Images.xcassets/Sharing/ic24PxImport.imageset/ic24PxImport.svg
@@ -1,0 +1,3 @@
+<svg width="24" height="24" xmlns="http://www.w3.org/2000/svg">
+  <path d="M4 16v2.5A1.5 1.5 0 0 0 5.5 20h13a1.5 1.5 0 0 0 1.5-1.5V16M12 3v13m-4-4 4 4 4-4" fill="none" stroke="#000" stroke-width="2" stroke-linejoin="round" paint-order="fill markers stroke" stroke-linecap="round"/>
+</svg>

--- a/iphone/Maps/Images.xcassets/Sharing/ic24PxShare.imageset/ic24PxShare.svg
+++ b/iphone/Maps/Images.xcassets/Sharing/ic24PxShare.imageset/ic24PxShare.svg
@@ -1,0 +1,4 @@
+<svg width="24" height="24" xmlns="http://www.w3.org/2000/svg">
+  <path d="M7.5 7h-2A1.5 1.5 0 0 0 4 8.5v8A1.5 1.5 0 0 0 5.5 18h9a1.5 1.5 0 0 0 1.5-1.5v-8A1.5 1.5 0 0 0 14.5 7h-2" fill="none" stroke="#000" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"/>
+  <path d="M8 19v1.5A1.5 1.5 0 0 0 9.5 22h9a1.5 1.5 0 0 0 1.5-1.5v-8a1.5 1.5 0 0 0-1.5-1.5H17M10 13V1M7 4l3-3 3 3" fill="none" stroke="#000" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"/>
+</svg>

--- a/iphone/Maps/Images.xcassets/Sharing/ic24PxShare.imageset/ic_share.svg
+++ b/iphone/Maps/Images.xcassets/Sharing/ic24PxShare.imageset/ic_share.svg
@@ -1,5 +1,0 @@
-<svg width="24" height="24" viewBox="0 0 24 24" xmlns="http://www.w3.org/2000/svg">
-  <path d="M9 8H6.5A1.5 1.5 135 0 0 5 9.5v8A1.5 1.5 45 0 0 6.5 19h9a1.5 1.5 135 0 0 1.5-1.5v-8A1.5 1.5 45 0 0 15.5 8H13" fill="none" stroke="#000" stroke-width="2" stroke-linejoin="round" paint-order="fill markers stroke"/>
-  <path d="M8 19v1.5A1.5 1.5 45 0 0 9.5 22h9a1.5 1.5 135 0 0 1.5-1.5v-8a1.5 1.5 45 0 0-1.5-1.5H17" fill="none" stroke="#000" stroke-width="2" stroke-linejoin="round" paint-order="fill markers stroke"/>
-  <path d="M11 13V2M8 5l3-3 3 2.907" fill="none" stroke="#000" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" paint-order="fill markers stroke"/>
-</svg>

--- a/iphone/Maps/LocalizedStrings/ar.lproj/Localizable.strings
+++ b/iphone/Maps/LocalizedStrings/ar.lproj/Localizable.strings
@@ -960,6 +960,9 @@
 
 "bookmarks_create_new_group" = "إنشاء قائمة جديدة";
 
+/* Bookmark categories screen, button that opens folder selection dialog to import KML/KMZ/GPX/KMB files */
+"bookmarks_import" = "استيراد الإشارات المرجعية والمسارات";
+
 "downloader_hide_screen" = "إخفاء الشاشة";
 
 "downloader_percent" = "%@ (%@ من %@)";

--- a/iphone/Maps/LocalizedStrings/az.lproj/Localizable.strings
+++ b/iphone/Maps/LocalizedStrings/az.lproj/Localizable.strings
@@ -960,6 +960,9 @@
 
 "bookmarks_create_new_group" = "Yeni siyahı yaradın";
 
+/* Bookmark categories screen, button that opens folder selection dialog to import KML/KMZ/GPX/KMB files */
+"bookmarks_import" = "Əlfəcinləri və fraqmentləri idxal edin";
+
 "downloader_hide_screen" = "Ekranı Gizlət";
 
 "downloader_percent" = "%@ (%@ / %@)";

--- a/iphone/Maps/LocalizedStrings/be.lproj/Localizable.strings
+++ b/iphone/Maps/LocalizedStrings/be.lproj/Localizable.strings
@@ -960,6 +960,9 @@
 
 "bookmarks_create_new_group" = "Стварыць новы спіс";
 
+/* Bookmark categories screen, button that opens folder selection dialog to import KML/KMZ/GPX/KMB files */
+"bookmarks_import" = "Імпартаваць закладкі і cцежкі";
+
 "downloader_hide_screen" = "Схаваць экран";
 
 "downloader_percent" = "%@ (%@ з %@)";

--- a/iphone/Maps/LocalizedStrings/bg.lproj/Localizable.strings
+++ b/iphone/Maps/LocalizedStrings/bg.lproj/Localizable.strings
@@ -960,6 +960,9 @@
 
 "bookmarks_create_new_group" = "Създаване на нов списък";
 
+/* Bookmark categories screen, button that opens folder selection dialog to import KML/KMZ/GPX/KMB files */
+"bookmarks_import" = "Импортиране на отметки и маршрути";
+
 "downloader_hide_screen" = "Скриване на екрана";
 
 "downloader_percent" = "%@ (%@ от %@)";

--- a/iphone/Maps/LocalizedStrings/ca.lproj/Localizable.strings
+++ b/iphone/Maps/LocalizedStrings/ca.lproj/Localizable.strings
@@ -960,6 +960,9 @@
 
 "bookmarks_create_new_group" = "Crea una llista";
 
+/* Bookmark categories screen, button that opens folder selection dialog to import KML/KMZ/GPX/KMB files */
+"bookmarks_import" = "Importa marcadors i les traces";
+
 "downloader_hide_screen" = "Oculta la pantalla";
 
 "downloader_percent" = "%@ (%@ de %@)";

--- a/iphone/Maps/LocalizedStrings/cs.lproj/Localizable.strings
+++ b/iphone/Maps/LocalizedStrings/cs.lproj/Localizable.strings
@@ -960,6 +960,9 @@
 
 "bookmarks_create_new_group" = "Vytvořte nový seznam";
 
+/* Bookmark categories screen, button that opens folder selection dialog to import KML/KMZ/GPX/KMB files */
+"bookmarks_import" = "Import záložek a stop";
+
 "downloader_hide_screen" = "Skrýt obrazovku";
 
 "downloader_percent" = "%@ (%@ z %@)";

--- a/iphone/Maps/LocalizedStrings/da.lproj/Localizable.strings
+++ b/iphone/Maps/LocalizedStrings/da.lproj/Localizable.strings
@@ -960,6 +960,9 @@
 
 "bookmarks_create_new_group" = "Opret ny liste";
 
+/* Bookmark categories screen, button that opens folder selection dialog to import KML/KMZ/GPX/KMB files */
+"bookmarks_import" = "Importer bogmærker og spor";
+
 "downloader_hide_screen" = "Skjul skærm";
 
 "downloader_percent" = "%@ (%@ af %@)";

--- a/iphone/Maps/LocalizedStrings/de.lproj/Localizable.strings
+++ b/iphone/Maps/LocalizedStrings/de.lproj/Localizable.strings
@@ -960,6 +960,9 @@
 
 "bookmarks_create_new_group" = "Neue Liste erstellen";
 
+/* Bookmark categories screen, button that opens folder selection dialog to import KML/KMZ/GPX/KMB files */
+"bookmarks_import" = "Lesezeichen und Tracks importieren";
+
 "downloader_hide_screen" = "Bildschirm ausblenden";
 
 "downloader_percent" = "%@ (%@ von %@)";

--- a/iphone/Maps/LocalizedStrings/el.lproj/Localizable.strings
+++ b/iphone/Maps/LocalizedStrings/el.lproj/Localizable.strings
@@ -960,6 +960,9 @@
 
 "bookmarks_create_new_group" = "Δημιουργία νέας λίστας";
 
+/* Bookmark categories screen, button that opens folder selection dialog to import KML/KMZ/GPX/KMB files */
+"bookmarks_import" = "Εισαγωγή σελιδοδεικτών και διαδρομών";
+
 "downloader_hide_screen" = "Απόκρυψη οθόνης";
 
 "downloader_percent" = "%@ (%@ από %@)";

--- a/iphone/Maps/LocalizedStrings/en-GB.lproj/Localizable.strings
+++ b/iphone/Maps/LocalizedStrings/en-GB.lproj/Localizable.strings
@@ -960,6 +960,9 @@
 
 "bookmarks_create_new_group" = "Create a new list";
 
+/* Bookmark categories screen, button that opens folder selection dialog to import KML/KMZ/GPX/KMB files */
+"bookmarks_import" = "Import Bookmarks and Tracks";
+
 "downloader_hide_screen" = "Hide Screen";
 
 "downloader_percent" = "%@ (%@ of %@)";

--- a/iphone/Maps/LocalizedStrings/en.lproj/Localizable.strings
+++ b/iphone/Maps/LocalizedStrings/en.lproj/Localizable.strings
@@ -960,6 +960,9 @@
 
 "bookmarks_create_new_group" = "Create a new list";
 
+/* Bookmark categories screen, button that opens folder selection dialog to import KML/KMZ/GPX/KMB files */
+"bookmarks_import" = "Import Bookmarks and Tracks";
+
 "downloader_hide_screen" = "Hide Screen";
 
 "downloader_percent" = "%@ (%@ of %@)";

--- a/iphone/Maps/LocalizedStrings/es-MX.lproj/Localizable.strings
+++ b/iphone/Maps/LocalizedStrings/es-MX.lproj/Localizable.strings
@@ -960,6 +960,9 @@
 
 "bookmarks_create_new_group" = "Crear lista nueva";
 
+/* Bookmark categories screen, button that opens folder selection dialog to import KML/KMZ/GPX/KMB files */
+"bookmarks_import" = "Importar marcadores y trazas";
+
 "downloader_hide_screen" = "Ocultar pantalla";
 
 "downloader_percent" = "%@ (%@ de %@)";

--- a/iphone/Maps/LocalizedStrings/es.lproj/Localizable.strings
+++ b/iphone/Maps/LocalizedStrings/es.lproj/Localizable.strings
@@ -960,6 +960,9 @@
 
 "bookmarks_create_new_group" = "Crear nueva lista";
 
+/* Bookmark categories screen, button that opens folder selection dialog to import KML/KMZ/GPX/KMB files */
+"bookmarks_import" = "Importar marcadores y trazas";
+
 "downloader_hide_screen" = "Ocultar pantalla";
 
 "downloader_percent" = "%@ (%@ de %@)";

--- a/iphone/Maps/LocalizedStrings/et.lproj/Localizable.strings
+++ b/iphone/Maps/LocalizedStrings/et.lproj/Localizable.strings
@@ -960,6 +960,9 @@
 
 "bookmarks_create_new_group" = "Loo uus loetelu";
 
+/* Bookmark categories screen, button that opens folder selection dialog to import KML/KMZ/GPX/KMB files */
+"bookmarks_import" = "Importida järjehoidjaid ja lugusid";
+
 "downloader_hide_screen" = "Peida vaade";
 
 "downloader_percent" = "%@ (%@ / %@)";

--- a/iphone/Maps/LocalizedStrings/eu.lproj/Localizable.strings
+++ b/iphone/Maps/LocalizedStrings/eu.lproj/Localizable.strings
@@ -960,6 +960,9 @@
 
 "bookmarks_create_new_group" = "Sortu zerrenda berria";
 
+/* Bookmark categories screen, button that opens folder selection dialog to import KML/KMZ/GPX/KMB files */
+"bookmarks_import" = "Laster-markak eta ibilbideak inportatu";
+
 "downloader_hide_screen" = "Ezkutatu pantaila";
 
 "downloader_percent" = "%@ (%@/%@)";

--- a/iphone/Maps/LocalizedStrings/fa.lproj/Localizable.strings
+++ b/iphone/Maps/LocalizedStrings/fa.lproj/Localizable.strings
@@ -960,6 +960,9 @@
 
 "bookmarks_create_new_group" = "ایجاد لیست جدید";
 
+/* Bookmark categories screen, button that opens folder selection dialog to import KML/KMZ/GPX/KMB files */
+"bookmarks_import" = "وارد کردن نشانکu200cها و آهنگu200cها";
+
 "downloader_hide_screen" = "پنهان کردن صفحه";
 
 "downloader_percent" = "%@ (%@ از %@)";

--- a/iphone/Maps/LocalizedStrings/fi.lproj/Localizable.strings
+++ b/iphone/Maps/LocalizedStrings/fi.lproj/Localizable.strings
@@ -960,6 +960,9 @@
 
 "bookmarks_create_new_group" = "Luo uusi luettelo";
 
+/* Bookmark categories screen, button that opens folder selection dialog to import KML/KMZ/GPX/KMB files */
+"bookmarks_import" = "Kirjanmerkkien ja reittien tuominen";
+
 "downloader_hide_screen" = "Piilota näyttö";
 
 "downloader_percent" = "%@ (%@ / %@)";

--- a/iphone/Maps/LocalizedStrings/fr.lproj/Localizable.strings
+++ b/iphone/Maps/LocalizedStrings/fr.lproj/Localizable.strings
@@ -960,6 +960,9 @@
 
 "bookmarks_create_new_group" = "Créer une nouvelle liste";
 
+/* Bookmark categories screen, button that opens folder selection dialog to import KML/KMZ/GPX/KMB files */
+"bookmarks_import" = "Importer des signets et des parcours";
+
 "downloader_hide_screen" = "Masquer l’écran";
 
 "downloader_percent" = "%@ (%@ de %@)";

--- a/iphone/Maps/LocalizedStrings/he.lproj/Localizable.strings
+++ b/iphone/Maps/LocalizedStrings/he.lproj/Localizable.strings
@@ -960,6 +960,9 @@
 
 "bookmarks_create_new_group" = "צור רשימה חדשה";
 
+/* Bookmark categories screen, button that opens folder selection dialog to import KML/KMZ/GPX/KMB files */
+"bookmarks_import" = "ייבוא סימניות ומסלולים";
+
 "downloader_hide_screen" = "הסתר מסך";
 
 "downloader_percent" = "%@ (%@ מתוך %@)";

--- a/iphone/Maps/LocalizedStrings/hi.lproj/Localizable.strings
+++ b/iphone/Maps/LocalizedStrings/hi.lproj/Localizable.strings
@@ -960,6 +960,9 @@
 
 "bookmarks_create_new_group" = "एक नई सूची बनाएं";
 
+/* Bookmark categories screen, button that opens folder selection dialog to import KML/KMZ/GPX/KMB files */
+"bookmarks_import" = "बुकमार्क और सेटिंग्स आयात करें";
+
 "downloader_hide_screen" = "Hide Screen";
 
 "downloader_percent" = "%@ (%@ of %@)";

--- a/iphone/Maps/LocalizedStrings/hu.lproj/Localizable.strings
+++ b/iphone/Maps/LocalizedStrings/hu.lproj/Localizable.strings
@@ -960,6 +960,9 @@
 
 "bookmarks_create_new_group" = "Új lista létrehozása";
 
+/* Bookmark categories screen, button that opens folder selection dialog to import KML/KMZ/GPX/KMB files */
+"bookmarks_import" = "Könyvjelzők és sávok importálása";
+
 "downloader_hide_screen" = "Képernyő elrejtése";
 
 "downloader_percent" = "%@ (%@ / %@)";

--- a/iphone/Maps/LocalizedStrings/id.lproj/Localizable.strings
+++ b/iphone/Maps/LocalizedStrings/id.lproj/Localizable.strings
@@ -960,6 +960,9 @@
 
 "bookmarks_create_new_group" = "Buat daftar baru";
 
+/* Bookmark categories screen, button that opens folder selection dialog to import KML/KMZ/GPX/KMB files */
+"bookmarks_import" = "Impor penanda dan trek";
+
 "downloader_hide_screen" = "Sembunyikan Layar";
 
 "downloader_percent" = "%@ (%@ dari %@)";

--- a/iphone/Maps/LocalizedStrings/it.lproj/Localizable.strings
+++ b/iphone/Maps/LocalizedStrings/it.lproj/Localizable.strings
@@ -960,6 +960,9 @@
 
 "bookmarks_create_new_group" = "Crea un nuovo elenco";
 
+/* Bookmark categories screen, button that opens folder selection dialog to import KML/KMZ/GPX/KMB files */
+"bookmarks_import" = "Importazione di segnalibri e tracce";
+
 "downloader_hide_screen" = "Nascondi schermata";
 
 "downloader_percent" = "%@ (%@ di %@)";

--- a/iphone/Maps/LocalizedStrings/ja.lproj/Localizable.strings
+++ b/iphone/Maps/LocalizedStrings/ja.lproj/Localizable.strings
@@ -960,6 +960,9 @@
 
 "bookmarks_create_new_group" = "新しいリストを作成する";
 
+/* Bookmark categories screen, button that opens folder selection dialog to import KML/KMZ/GPX/KMB files */
+"bookmarks_import" = "ブックマークとトラックをインポートする";
+
 "downloader_hide_screen" = "画面を非表示";
 
 "downloader_percent" = "%@ (%@ / %@)";

--- a/iphone/Maps/LocalizedStrings/ko.lproj/Localizable.strings
+++ b/iphone/Maps/LocalizedStrings/ko.lproj/Localizable.strings
@@ -960,6 +960,9 @@
 
 "bookmarks_create_new_group" = "새 목록 만들기";
 
+/* Bookmark categories screen, button that opens folder selection dialog to import KML/KMZ/GPX/KMB files */
+"bookmarks_import" = "북마크 및 트랙 가져오기";
+
 "downloader_hide_screen" = "화면 숨기기";
 
 "downloader_percent" = "%@(%@ / %@)";

--- a/iphone/Maps/LocalizedStrings/mr.lproj/Localizable.strings
+++ b/iphone/Maps/LocalizedStrings/mr.lproj/Localizable.strings
@@ -960,6 +960,9 @@
 
 "bookmarks_create_new_group" = "नवीन यादी जोडा";
 
+/* Bookmark categories screen, button that opens folder selection dialog to import KML/KMZ/GPX/KMB files */
+"bookmarks_import" = "बुकमार्क आणि ट्रॅक आयात करा";
+
 "downloader_hide_screen" = "पटल (स्क्रीन) लपवा";
 
 "downloader_percent" = "%@ (%@ पैकी %@)";

--- a/iphone/Maps/LocalizedStrings/nb.lproj/Localizable.strings
+++ b/iphone/Maps/LocalizedStrings/nb.lproj/Localizable.strings
@@ -960,6 +960,9 @@
 
 "bookmarks_create_new_group" = "Opprett ny liste";
 
+/* Bookmark categories screen, button that opens folder selection dialog to import KML/KMZ/GPX/KMB files */
+"bookmarks_import" = "Importer bokmerker og spor";
+
 "downloader_hide_screen" = "Skjul skjerm";
 
 "downloader_percent" = "%@ (%@ av %@)";

--- a/iphone/Maps/LocalizedStrings/nl.lproj/Localizable.strings
+++ b/iphone/Maps/LocalizedStrings/nl.lproj/Localizable.strings
@@ -960,6 +960,9 @@
 
 "bookmarks_create_new_group" = "Nieuwe lijst maken";
 
+/* Bookmark categories screen, button that opens folder selection dialog to import KML/KMZ/GPX/KMB files */
+"bookmarks_import" = "Bladwijzers en tracks importeren";
+
 "downloader_hide_screen" = "Scherm Verbergen";
 
 "downloader_percent" = "%@ (%@ van %@)";

--- a/iphone/Maps/LocalizedStrings/pl.lproj/Localizable.strings
+++ b/iphone/Maps/LocalizedStrings/pl.lproj/Localizable.strings
@@ -960,6 +960,9 @@
 
 "bookmarks_create_new_group" = "Utwórz nową listę";
 
+/* Bookmark categories screen, button that opens folder selection dialog to import KML/KMZ/GPX/KMB files */
+"bookmarks_import" = "Importuj zakładki i trasy";
+
 "downloader_hide_screen" = "Ukryj ekran";
 
 "downloader_percent" = "%@ (%@ z %@)";

--- a/iphone/Maps/LocalizedStrings/pt-BR.lproj/Localizable.strings
+++ b/iphone/Maps/LocalizedStrings/pt-BR.lproj/Localizable.strings
@@ -960,6 +960,9 @@
 
 "bookmarks_create_new_group" = "Criar nova lista";
 
+/* Bookmark categories screen, button that opens folder selection dialog to import KML/KMZ/GPX/KMB files */
+"bookmarks_import" = "Importar favoritos e trilhas";
+
 "downloader_hide_screen" = "Ocultar tela";
 
 "downloader_percent" = "%@ (%@ de %@)";

--- a/iphone/Maps/LocalizedStrings/pt.lproj/Localizable.strings
+++ b/iphone/Maps/LocalizedStrings/pt.lproj/Localizable.strings
@@ -960,6 +960,9 @@
 
 "bookmarks_create_new_group" = "Criar nova lista";
 
+/* Bookmark categories screen, button that opens folder selection dialog to import KML/KMZ/GPX/KMB files */
+"bookmarks_import" = "Importar favoritos e trilhas";
+
 "downloader_hide_screen" = "Ocultar ecrã";
 
 "downloader_percent" = "%@ (%@ de %@)";

--- a/iphone/Maps/LocalizedStrings/ro.lproj/Localizable.strings
+++ b/iphone/Maps/LocalizedStrings/ro.lproj/Localizable.strings
@@ -960,6 +960,9 @@
 
 "bookmarks_create_new_group" = "Creează o listă nouă";
 
+/* Bookmark categories screen, button that opens folder selection dialog to import KML/KMZ/GPX/KMB files */
+"bookmarks_import" = "Importați marcaje și piese";
+
 "downloader_hide_screen" = "Ascunde pagina";
 
 "downloader_percent" = "%@ (%@ din %@)";

--- a/iphone/Maps/LocalizedStrings/ru.lproj/Localizable.strings
+++ b/iphone/Maps/LocalizedStrings/ru.lproj/Localizable.strings
@@ -960,6 +960,9 @@
 
 "bookmarks_create_new_group" = "Создать новый список";
 
+/* Bookmark categories screen, button that opens folder selection dialog to import KML/KMZ/GPX/KMB files */
+"bookmarks_import" = "Импортировать метки и треки";
+
 "downloader_hide_screen" = "Скрыть";
 
 "downloader_percent" = "%@ (%@ из %@)";

--- a/iphone/Maps/LocalizedStrings/sk.lproj/Localizable.strings
+++ b/iphone/Maps/LocalizedStrings/sk.lproj/Localizable.strings
@@ -960,6 +960,9 @@
 
 "bookmarks_create_new_group" = "Vytvoriť nový zoznam";
 
+/* Bookmark categories screen, button that opens folder selection dialog to import KML/KMZ/GPX/KMB files */
+"bookmarks_import" = "Importovanie záložiek a stôp";
+
 "downloader_hide_screen" = "Skryť obrazovku";
 
 "downloader_percent" = "%@ (%@ z %@)";

--- a/iphone/Maps/LocalizedStrings/sv.lproj/Localizable.strings
+++ b/iphone/Maps/LocalizedStrings/sv.lproj/Localizable.strings
@@ -960,6 +960,9 @@
 
 "bookmarks_create_new_group" = "Skapa ny lista";
 
+/* Bookmark categories screen, button that opens folder selection dialog to import KML/KMZ/GPX/KMB files */
+"bookmarks_import" = "Importera bokmärken och spår";
+
 "downloader_hide_screen" = "Dölj skärm";
 
 "downloader_percent" = "%@ (%@ av %@)";

--- a/iphone/Maps/LocalizedStrings/sw.lproj/Localizable.strings
+++ b/iphone/Maps/LocalizedStrings/sw.lproj/Localizable.strings
@@ -960,6 +960,9 @@
 
 "bookmarks_create_new_group" = "Unda orodha mpya";
 
+/* Bookmark categories screen, button that opens folder selection dialog to import KML/KMZ/GPX/KMB files */
+"bookmarks_import" = "Ingiza alamisho na nyimbo";
+
 "downloader_hide_screen" = "Ficha skrini";
 
 "downloader_percent" = "%@ (%@ kati ya %@)";

--- a/iphone/Maps/LocalizedStrings/th.lproj/Localizable.strings
+++ b/iphone/Maps/LocalizedStrings/th.lproj/Localizable.strings
@@ -960,6 +960,9 @@
 
 "bookmarks_create_new_group" = "สร้างรายการใหม่";
 
+/* Bookmark categories screen, button that opens folder selection dialog to import KML/KMZ/GPX/KMB files */
+"bookmarks_import" = "นำเข้าบุ๊กมาร์กและแทร็ก";
+
 "downloader_hide_screen" = "ซ่อนหน้าจอ";
 
 "downloader_percent" = "%@ (%@ จาก %@)";

--- a/iphone/Maps/LocalizedStrings/tr.lproj/Localizable.strings
+++ b/iphone/Maps/LocalizedStrings/tr.lproj/Localizable.strings
@@ -960,6 +960,9 @@
 
 "bookmarks_create_new_group" = "Yeni liste oluştur";
 
+/* Bookmark categories screen, button that opens folder selection dialog to import KML/KMZ/GPX/KMB files */
+"bookmarks_import" = "Yer i̇mlerini ve parçaları i̇çe aktarma";
+
 "downloader_hide_screen" = "Ekranı Gizle";
 
 "downloader_percent" = "%@ (%@ / %@)";

--- a/iphone/Maps/LocalizedStrings/uk.lproj/Localizable.strings
+++ b/iphone/Maps/LocalizedStrings/uk.lproj/Localizable.strings
@@ -960,6 +960,9 @@
 
 "bookmarks_create_new_group" = "Створити новий список";
 
+/* Bookmark categories screen, button that opens folder selection dialog to import KML/KMZ/GPX/KMB files */
+"bookmarks_import" = "Імпортувати мітки та маршрути";
+
 "downloader_hide_screen" = "Приховати екран";
 
 "downloader_percent" = "%@ (%@ з %@)";

--- a/iphone/Maps/LocalizedStrings/vi.lproj/Localizable.strings
+++ b/iphone/Maps/LocalizedStrings/vi.lproj/Localizable.strings
@@ -960,6 +960,9 @@
 
 "bookmarks_create_new_group" = "Tạo danh sách mới";
 
+/* Bookmark categories screen, button that opens folder selection dialog to import KML/KMZ/GPX/KMB files */
+"bookmarks_import" = "Nhập dấu trang và bản nhạc";
+
 "downloader_hide_screen" = "Ẩn Màn hình";
 
 "downloader_percent" = "%@ (%@ / %@)";

--- a/iphone/Maps/LocalizedStrings/zh-Hans.lproj/Localizable.strings
+++ b/iphone/Maps/LocalizedStrings/zh-Hans.lproj/Localizable.strings
@@ -960,6 +960,9 @@
 
 "bookmarks_create_new_group" = "创建新的列表";
 
+/* Bookmark categories screen, button that opens folder selection dialog to import KML/KMZ/GPX/KMB files */
+"bookmarks_import" = "导入书签和轨迹";
+
 "downloader_hide_screen" = "隱藏屏幕";
 
 "downloader_percent" = "%@ (%@ / %@)";

--- a/iphone/Maps/LocalizedStrings/zh-Hant.lproj/Localizable.strings
+++ b/iphone/Maps/LocalizedStrings/zh-Hant.lproj/Localizable.strings
@@ -960,6 +960,9 @@
 
 "bookmarks_create_new_group" = "創建新列表";
 
+/* Bookmark categories screen, button that opens folder selection dialog to import KML/KMZ/GPX/KMB files */
+"bookmarks_import" = "導入書籤和曲目";
+
 "downloader_hide_screen" = "隱藏畫面";
 
 "downloader_percent" = "%@ (%@，共%@)";

--- a/iphone/Maps/Maps.xcodeproj/project.pbxproj
+++ b/iphone/Maps/Maps.xcodeproj/project.pbxproj
@@ -471,6 +471,7 @@
 		ED1263AB2B6F99F900AD99F3 /* UIView+AddSeparator.swift in Sources */ = {isa = PBXBuildFile; fileRef = ED1263AA2B6F99F900AD99F3 /* UIView+AddSeparator.swift */; };
 		ED1ADA332BC6B1B40029209F /* CarPlayServiceTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = ED1ADA322BC6B1B40029209F /* CarPlayServiceTests.swift */; };
 		ED3EAC202B03C88100220A4A /* BottomTabBarButton.swift in Sources */ = {isa = PBXBuildFile; fileRef = ED3EAC1F2B03C88100220A4A /* BottomTabBarButton.swift */; };
+		ED43B8BD2C12063500D07BAA /* DocumentPicker.swift in Sources */ = {isa = PBXBuildFile; fileRef = ED43B8BC2C12063500D07BAA /* DocumentPicker.swift */; };
 		ED63CEB92BDF8F9D006155C4 /* SettingsTableViewiCloudSwitchCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = ED63CEB62BDF8F9C006155C4 /* SettingsTableViewiCloudSwitchCell.swift */; };
 		ED79A5AB2BD7AA9C00952D1F /* LoadingOverlayViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = ED79A5AA2BD7AA9C00952D1F /* LoadingOverlayViewController.swift */; };
 		ED79A5AD2BD7BA0F00952D1F /* UIApplication+LoadingOverlay.swift in Sources */ = {isa = PBXBuildFile; fileRef = ED79A5AC2BD7BA0F00952D1F /* UIApplication+LoadingOverlay.swift */; };
@@ -480,6 +481,7 @@
 		ED79A5D62BDF8D6100952D1F /* iCloudDocumentsDirectoryMonitor.swift in Sources */ = {isa = PBXBuildFile; fileRef = ED79A5CE2BDF8D6100952D1F /* iCloudDocumentsDirectoryMonitor.swift */; };
 		ED79A5D72BDF8D6100952D1F /* SynchronizationStateManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = ED79A5CF2BDF8D6100952D1F /* SynchronizationStateManager.swift */; };
 		ED79A5D82BDF8D6100952D1F /* DefaultLocalDirectoryMonitor.swift in Sources */ = {isa = PBXBuildFile; fileRef = ED79A5D02BDF8D6100952D1F /* DefaultLocalDirectoryMonitor.swift */; };
+		ED7CCC4F2C1362E300E2A737 /* FileType.swift in Sources */ = {isa = PBXBuildFile; fileRef = ED7CCC4E2C1362E300E2A737 /* FileType.swift */; };
 		ED9966802B94FBC20083CE55 /* ColorPicker.swift in Sources */ = {isa = PBXBuildFile; fileRef = ED99667D2B94FBC20083CE55 /* ColorPicker.swift */; };
 		EDBD68072B625724005DD151 /* LocationServicesDisabledAlert.xib in Resources */ = {isa = PBXBuildFile; fileRef = EDBD68062B625724005DD151 /* LocationServicesDisabledAlert.xib */; };
 		EDBD680B2B62572E005DD151 /* LocationServicesDisabledAlert.swift in Sources */ = {isa = PBXBuildFile; fileRef = EDBD680A2B62572E005DD151 /* LocationServicesDisabledAlert.swift */; };
@@ -1377,6 +1379,7 @@
 		ED1263AA2B6F99F900AD99F3 /* UIView+AddSeparator.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "UIView+AddSeparator.swift"; sourceTree = "<group>"; };
 		ED1ADA322BC6B1B40029209F /* CarPlayServiceTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CarPlayServiceTests.swift; sourceTree = "<group>"; };
 		ED3EAC1F2B03C88100220A4A /* BottomTabBarButton.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BottomTabBarButton.swift; sourceTree = "<group>"; };
+		ED43B8BC2C12063500D07BAA /* DocumentPicker.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DocumentPicker.swift; sourceTree = "<group>"; };
 		ED48BBB817C2B1E2003E7E92 /* CircleView.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = CircleView.h; sourceTree = "<group>"; };
 		ED48BBB917C2B1E2003E7E92 /* CircleView.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = CircleView.m; sourceTree = "<group>"; };
 		ED63CEB62BDF8F9C006155C4 /* SettingsTableViewiCloudSwitchCell.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = SettingsTableViewiCloudSwitchCell.swift; sourceTree = "<group>"; };
@@ -1388,6 +1391,7 @@
 		ED79A5CE2BDF8D6100952D1F /* iCloudDocumentsDirectoryMonitor.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = iCloudDocumentsDirectoryMonitor.swift; sourceTree = "<group>"; };
 		ED79A5CF2BDF8D6100952D1F /* SynchronizationStateManager.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = SynchronizationStateManager.swift; sourceTree = "<group>"; };
 		ED79A5D02BDF8D6100952D1F /* DefaultLocalDirectoryMonitor.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = DefaultLocalDirectoryMonitor.swift; sourceTree = "<group>"; };
+		ED7CCC4E2C1362E300E2A737 /* FileType.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FileType.swift; sourceTree = "<group>"; };
 		ED99667D2B94FBC20083CE55 /* ColorPicker.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ColorPicker.swift; sourceTree = "<group>"; };
 		EDBD68062B625724005DD151 /* LocationServicesDisabledAlert.xib */ = {isa = PBXFileReference; lastKnownFileType = file.xib; path = LocationServicesDisabledAlert.xib; sourceTree = "<group>"; };
 		EDBD680A2B62572E005DD151 /* LocationServicesDisabledAlert.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LocationServicesDisabledAlert.swift; sourceTree = "<group>"; };
@@ -3049,6 +3053,15 @@
 			path = Tests;
 			sourceTree = "<group>";
 		};
+		ED43B8B92C12061600D07BAA /* DocumentPicker */ = {
+			isa = PBXGroup;
+			children = (
+				ED7CCC4E2C1362E300E2A737 /* FileType.swift */,
+				ED43B8BC2C12063500D07BAA /* DocumentPicker.swift */,
+			);
+			path = DocumentPicker;
+			sourceTree = "<group>";
+		};
 		ED79A5A92BD7AA7500952D1F /* LoadingOverlay */ = {
 			isa = PBXGroup;
 			children = (
@@ -3322,6 +3335,7 @@
 		F6E2FBFB1E097B9F0083EBEC /* UI */ = {
 			isa = PBXGroup;
 			children = (
+				ED43B8B92C12061600D07BAA /* DocumentPicker */,
 				ED99667C2B94FBC20083CE55 /* ColorPicker */,
 				F69018B51E9E5FEB00B3C10B /* Autoupdate */,
 				34E7760D1F14B165003040B3 /* AvailableArea */,
@@ -4296,6 +4310,7 @@
 				34D3B0181E389D05004100F9 /* EditorAdditionalNamePlaceholderTableViewCell.swift in Sources */,
 				993DF12223F6BDB100AC231A /* UINavigationItemRenderer.swift in Sources */,
 				993DF12B23F6BDB100AC231A /* StyleManager.swift in Sources */,
+				ED43B8BD2C12063500D07BAA /* DocumentPicker.swift in Sources */,
 				470E1674252AD7F2002D201A /* BookmarksListInfoViewController.swift in Sources */,
 				47B9065521C7FA400079C85E /* NSString+MD5.m in Sources */,
 				CDB4D5022231412900104869 /* SettingsTemplateBuilder.swift in Sources */,
@@ -4488,6 +4503,7 @@
 				34AB66621FC5AA330078E451 /* TransportTransitSeparator.swift in Sources */,
 				CDCA2743223F8D1E00167D87 /* ListItemInfo.swift in Sources */,
 				993DF11F23F6BDB100AC231A /* UITableViewCellRenderer.swift in Sources */,
+				ED7CCC4F2C1362E300E2A737 /* FileType.swift in Sources */,
 				4767CDA820AB401000BD8166 /* LinkTextView.swift in Sources */,
 				34763EE71F2F392300F4D2D3 /* MWMTextToSpeech.mm in Sources */,
 				998927402449ECC200260CE2 /* BottomMenuItemCell.swift in Sources */,

--- a/iphone/Maps/UI/DocumentPicker/DocumentPicker.swift
+++ b/iphone/Maps/UI/DocumentPicker/DocumentPicker.swift
@@ -1,0 +1,29 @@
+typealias URLsCompletionHandler = ([URL]) -> Void
+
+final class DocumentPicker: NSObject {
+  static let shared = DocumentPicker()
+  private var completionHandler: URLsCompletionHandler?
+
+  func present(from rootViewController: UIViewController,
+               fileTypes: [FileType] = [.kml, .kmz, .gpx],
+               completionHandler: @escaping URLsCompletionHandler) {
+    self.completionHandler = completionHandler
+    let documentPickerViewController: UIDocumentPickerViewController
+    if #available(iOS 14.0, *) {
+      documentPickerViewController = UIDocumentPickerViewController(forOpeningContentTypes: fileTypes.map(\.utType))
+    } else {
+      documentPickerViewController = UIDocumentPickerViewController(documentTypes: fileTypes.map(\.typeIdentifier), in: .import)
+    }
+    documentPickerViewController.delegate = self
+    // TODO: Enable multiple selection when the multiple files parsing support will be added to the bookmark_manager.
+    documentPickerViewController.allowsMultipleSelection = false
+    rootViewController.present(documentPickerViewController, animated: true)
+  }
+}
+
+// MARK: - UIDocumentPickerDelegate
+extension DocumentPicker: UIDocumentPickerDelegate {
+  func documentPicker(_ controller: UIDocumentPickerViewController, didPickDocumentsAt urls: [URL]) {
+    completionHandler?(urls)
+  }
+}

--- a/iphone/Maps/UI/DocumentPicker/FileType.swift
+++ b/iphone/Maps/UI/DocumentPicker/FileType.swift
@@ -1,0 +1,22 @@
+import UniformTypeIdentifiers
+
+// TODO: Remove this type-wrapper and use custom UTTypeIdentifier that is registered into the Info.plist after updating to the iOS >= 14.0.
+struct FileType {
+  let fileExtension: String
+  let typeIdentifier: String
+}
+
+extension FileType {
+  static let kml = FileType(fileExtension: "kml", typeIdentifier: "com.google.earth.kml")
+  static let kmz = FileType(fileExtension: "kmz", typeIdentifier: "com.google.earth.kmz")
+  static let gpx = FileType(fileExtension: "gpx", typeIdentifier: "com.topografix.gpx")
+}
+
+// MARK: - FileType + UTType
+extension FileType {
+  @available(iOS 14.0, *)
+  var utType: UTType {
+    UTType(filenameExtension: fileExtension)!
+  }
+}
+

--- a/iphone/Maps/UI/DocumentPicker/FileType.swift
+++ b/iphone/Maps/UI/DocumentPicker/FileType.swift
@@ -1,6 +1,6 @@
 import UniformTypeIdentifiers
 
-// TODO: Remove this type-wrapper and use custom UTTypeIdentifier that is registered into the Info.plist after updating to the iOS >= 14.0.
+// TODO: (KK) Remove this type-wrapper and use custom UTTypeIdentifier that is registered into the Info.plist after updating to the iOS >= 14.0.
 struct FileType {
   let fileExtension: String
   let typeIdentifier: String


### PR DESCRIPTION
Closes https://github.com/organicmaps/organicmaps/issues/7866#issuecomment-2154605787

This PR implements the `kml`, `kmz`, `gpx` files importing in iOS using the default `UIDocumentPickerViewController`.

nits:
1. The icon was designed by me and requires an update @euf can you please help?
2. The alerts are stacked one by one so it needs to be updated to handle multiple files importing at once.

---
### Results:
ios 17.2
![Simulator Screen Recording - iPhone 15 Pro - 2024-06-07 at 19 18 08](https://github.com/organicmaps/organicmaps/assets/79797627/e2bd6cea-a031-4913-b021-33f326d03aab)

ios12.5

https://github.com/organicmaps/organicmaps/assets/79797627/c1fe308a-a84b-40fe-984f-4a65a5828e20


