### PR TITLE
[C++20] Fixed warning

### DIFF
--- a/generator/osm2type.cpp
+++ b/generator/osm2type.cpp
@@ -795,7 +795,7 @@ string DeterminePathGrade(OsmElement * p)
 
   string scale = p->GetTag("sac_scale");
   string visibility = p->GetTag("trail_visibility");
-  
+
   if (scale.empty() && visibility.empty())
     return {};
 
@@ -1391,7 +1391,7 @@ void GetNameAndType(OsmElement * p, FeatureBuilderParams & params,
           // atoi error value (0) should match empty layer constant.
           static_assert(feature::LAYER_EMPTY == 0);
           params.layer = atoi(v.c_str());
-          params.layer = base::Clamp(params.layer, int8_t(feature::LAYER_LOW), int8_t(feature::LAYER_HIGH));
+          params.layer = base::Clamp(params.layer, int8_t{feature::LAYER_LOW}, int8_t{feature::LAYER_HIGH});
         }
       }},
   });

--- a/indexer/drawing_rule_def.hpp
+++ b/indexer/drawing_rule_def.hpp
@@ -45,7 +45,7 @@ static double constexpr kBasePriorityFg = 0,
 static double constexpr kBaseDepthFg = 0,
                         // layer=-10/10 gives an overall FG range of [-10000;11000).
                         kMaxLayeredDepthFg = kBaseDepthFg + (1 + feature::LAYER_HIGH) * kLayerPriorityRange,
-                        kMinLayeredDepthFg = kBaseDepthFg + feature::LAYER_LOW * kLayerPriorityRange,
+                        kMinLayeredDepthFg = kBaseDepthFg + int8_t{feature::LAYER_LOW} * kLayerPriorityRange,
                         // Split the background layer space as 100 for BG-top and 900 for BG-by-size.
                         kBgTopRangeFraction = 0.1,
                         kDepthRangeBgTop = kBgTopRangeFraction * kLayerPriorityRange,
@@ -55,7 +55,7 @@ static double constexpr kBaseDepthFg = 0,
                         // And BG-by-size range is [-11000,-10100).
                         kBaseDepthBgBySize = kBaseDepthBgTop - kDepthRangeBgBySize,
                         // Minimum BG depth for layer=-10 is -21000.
-                        kMinLayeredDepthBg = kBaseDepthBgBySize + feature::LAYER_LOW * kLayerPriorityRange;
+                        kMinLayeredDepthBg = kBaseDepthBgBySize + int8_t{feature::LAYER_LOW} * kLayerPriorityRange;
 
   class Key
   {


### PR DESCRIPTION
```
warning: arithmetic between enumeration type 'feature::Layer' and floating-point type 'const double' is deprecated [-Wdeprecated-enum-float-conversion]
```