### PR TITLE
[android] Fix TTS FAQ link

### DIFF
--- a/android/app/src/main/res/values-es/strings.xml
+++ b/android/app/src/main/res/values-es/strings.xml
@@ -765,6 +765,8 @@
 	<string name="enable_show_on_lock_screen_description">Cuando está habilitado, no tiene que desbloquear su dispositivo mientras la aplicación se está ejecutando.</string>
 	<!-- OpenStreetMap text on splash screen -->
 	<string name="splash_subtitle">Datos de mapas de OpenStreetMap</string>
+	<!-- A link to the TTS FAQ -->
+	<string name="tts_info_link">https://organicmaps.app/es/faq/instrucciones-de-voz-tts-en-android/</string>
 	<!-- Translated Organic Maps site, add new translations here: https://github.com/organicmaps/organicmaps.github.io/tree/master/content -->
 	<string name="translated_om_site_url">https://organicmaps.app/es/</string>
 	<!-- Link to OSM wiki for Editor, Profile and About pages -->

--- a/android/app/src/main/res/values-it/strings.xml
+++ b/android/app/src/main/res/values-it/strings.xml
@@ -744,6 +744,8 @@
 	<string name="enable_show_on_lock_screen_description">Quando è abilitata, non è necessario sbloccare il dispositivo ogni volta mentre l\'app è in esecuzione.</string>
 	<!-- OpenStreetMap text on splash screen -->
 	<string name="splash_subtitle">Dati della mappa da OpenStreetMap</string>
+	<!-- A link to the TTS FAQ -->
+	<string name="tts_info_link">https://organicmaps.app/it/faq/sintesi-vocale-tts-su-android/</string>
 	<!-- Translated Organic Maps site, add new translations here: https://github.com/organicmaps/organicmaps.github.io/tree/master/content -->
 	<string name="translated_om_site_url">https://organicmaps.app/it/</string>
 	<!-- Link to OSM wiki for Editor, Profile and About pages -->

--- a/android/app/src/main/res/values-ru/strings.xml
+++ b/android/app/src/main/res/values-ru/strings.xml
@@ -774,6 +774,8 @@
 	<string name="splash_subtitle">Картографические данные из OpenStreetMap</string>
 	<!-- Telegram group url for the "?" About page -->
 	<string name="telegram_url">https://t.me/OrganicMapsRu</string>
+	<!-- A link to the TTS FAQ -->
+	<string name="tts_info_link">https://organicmaps.app/ru/faq/синтез-речи-tts-на-android/</string>
 	<!-- Translated Organic Maps site, add new translations here: https://github.com/organicmaps/organicmaps.github.io/tree/master/content -->
 	<string name="translated_om_site_url">https://organicmaps.app/ru/</string>
 	<!-- Link to OSM wiki for Editor, Profile and About pages -->

--- a/android/app/src/main/res/values/donottranslate.xml
+++ b/android/app/src/main/res/values/donottranslate.xml
@@ -25,8 +25,6 @@
   <string name="pref_tts_info" translatable="false">TtsInfo</string>
   <string name="pref_tts_info_link" translatable="false">TtsInfoLink</string>
   <string name="pref_tts_speed_cameras" translatable="false">SpeedCameras</string>
-  <!-- TODO: Move to another domain. -->
-  <string name="tts_info_link" translatable="false">https://mapsme.zendesk.com/hc/en-us/articles/208628985-How-can-I-check-TTS-settings-on-my-Android-device-</string>
   <string name="prefs_routing" translatable="false">RoutingOptions</string>
   <string name="pref_autodownload" translatable="false">AutoDownloadMap</string>
   <string name="pref_3d" translatable="false">3D</string>

--- a/android/app/src/main/res/values/strings.xml
+++ b/android/app/src/main/res/values/strings.xml
@@ -794,6 +794,8 @@
 	<string name="telegram_url">https://t.me/OrganicMapsApp</string>
 	<!-- Instagram account url for the "?" About page -->
 	<string name="instagram_url">https://www.instagram.com/organicmaps.app</string>
+	<!-- A link to the TTS FAQ -->
+	<string name="tts_info_link">https://organicmaps.app/faq/text-to-speech-android-tts/</string>
 	<!-- Translated Organic Maps site, add new translations here: https://github.com/organicmaps/organicmaps.github.io/tree/master/content -->
 	<string name="translated_om_site_url">https://organicmaps.app/</string>
 	<!-- Link to OSM wiki for Editor, Profile and About pages -->

--- a/data/strings/strings.txt
+++ b/data/strings/strings.txt
@@ -28905,6 +28905,14 @@
     en = https://www.instagram.com/organicmaps.app
     tr = https://www.instagram.com/organicmapstr
 
+  [tts_info_link]
+    comment = A link to the TTS FAQ
+    tags = android
+    en = https://organicmaps.app/faq/text-to-speech-android-tts/
+    es = https://organicmaps.app/es/faq/instrucciones-de-voz-tts-en-android/
+    it = https://organicmaps.app/it/faq/sintesi-vocale-tts-su-android/
+    ru = https://organicmaps.app/ru/faq/синтез-речи-tts-на-android/
+
   [translated_om_site_url]
     comment = Translated Organic Maps site, add new translations here: https://github.com/organicmaps/organicmaps.github.io/tree/master/content
     tags = android,ios


### PR DESCRIPTION
Fixes #2383

Any help with testing en, ru, es, it and some other language (with a fallback to en) is appreciated.

@organicmaps/translations-fr @organicmaps/translations-de is it possible to ask for help and translate the TTS FAQ also to German and French? You may also add localized screenshots if necessary, an example of other translations is here: https://github.com/organicmaps/organicmaps.github.io/tree/master/content/faq/text-to-speech-android-tts

It will appear here: https://organicmaps.app/faq/text-to-speech-android-tts/