### PR TITLE
[android] Fix import bookmark crash

### DIFF
--- a/android/app/src/main/java/app/organicmaps/bookmarks/BookmarkCategoriesFragment.java
+++ b/android/app/src/main/java/app/organicmaps/bookmarks/BookmarkCategoriesFragment.java
@@ -2,6 +2,7 @@ package app.organicmaps.bookmarks;
 
 import android.app.Activity;
 import android.app.ProgressDialog;
+import android.content.ActivityNotFoundException;
 import android.content.ContentResolver;
 import android.content.Context;
 import android.content.Intent;
@@ -240,8 +241,7 @@ public class BookmarkCategoriesFragment extends BaseMwmRecyclerFragment<Bookmark
   }
 
   @Override
-  public void onImportButtonClick()
-  {
+  public void onImportButtonClick() {
     Intent intent = new Intent(Intent.ACTION_OPEN_DOCUMENT_TREE);
 
     // Sic: EXTRA_INITIAL_URI doesn't work
@@ -254,8 +254,19 @@ public class BookmarkCategoriesFragment extends BaseMwmRecyclerFragment<Bookmark
 
     if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.M)
       intent.putExtra(DocumentsContract.EXTRA_EXCLUDE_SELF, true);
-    startActivityForResult(intent, REQ_CODE_IMPORT_DIRECTORY);
+
+    try {
+      startActivityForResult(intent, REQ_CODE_IMPORT_DIRECTORY);
+    } catch (ActivityNotFoundException e) {
+      Toast.makeText(getContext(), R.string.file_manager_recommended, Toast.LENGTH_LONG).show();
+      Intent marketIntent = new Intent(Intent.ACTION_VIEW);
+      marketIntent.setData(Uri.parse("market://details?id=com.google.android.apps.nbu.files"));
+      if (marketIntent.resolveActivity(getContext().getPackageManager()) != null) {
+        startActivity(marketIntent);
+      }
+    }
   }
+
 
   @Override
   public void onItemClick(@NonNull View v, @NonNull BookmarkCategory category)

--- a/android/app/src/main/res/values/strings.xml
+++ b/android/app/src/main/res/values/strings.xml
@@ -300,6 +300,8 @@
 	<!-- Text in menu + Button in the main Help dialog -->
 	<string name="report_a_bug">Report a bug</string>
 	<!-- Toast text when compass calibration may improve the correctness of the current position arrow -->
+	<string name="file_manager_recommended">Missing suitable file manager app! Please install one to select folders.</string>
+	<!-- Toast text when there is no app to show a folder selection dialog -->
 	<string name="compass_calibration_recommended">Improve arrow direction by moving the phone in a figure-eight motion to calibrate the compass.</string>
 	<!-- Toast text when compass calibration may improve the correctness of the current position arrow -->
 	<string name="compass_calibration_required">Move the phone in a figure-eight motion to calibrate the compass and fix the arrow direction on the map.</string>


### PR DESCRIPTION
Fixes #8415

This PR fixes a crash that occurs when the "Import Bookmarks" button is pressed. The crash was caused by an ActivityNotFoundException due to the absence of an app that can handle the OPEN_DOCUMENT_TREE intent.

- Added a try-catch block to handle the ActivityNotFoundException.
- Display a toast message to inform the user that a suitable file manager app is not installed.
- Redirect the user to the Google Play Store to download a suitable file manager app.


![Screenshot_20240608-222253](https://github.com/organicmaps/organicmaps/assets/112623116/ef60c08e-cb5e-4b72-9c6b-75297c889c48)

