### PR TITLE
[android] Fix import bookmarks crash

### DIFF
--- a/android/app/src/main/java/app/organicmaps/bookmarks/BookmarkCategoriesFragment.java
+++ b/android/app/src/main/java/app/organicmaps/bookmarks/BookmarkCategoriesFragment.java
@@ -2,6 +2,7 @@ package app.organicmaps.bookmarks;
 
 import android.app.Activity;
 import android.app.ProgressDialog;
+import android.content.ActivityNotFoundException;
 import android.content.ContentResolver;
 import android.content.Context;
 import android.content.Intent;
@@ -240,8 +241,7 @@ public class BookmarkCategoriesFragment extends BaseMwmRecyclerFragment<Bookmark
   }
 
   @Override
-  public void onImportButtonClick()
-  {
+  public void onImportButtonClick() {
     Intent intent = new Intent(Intent.ACTION_OPEN_DOCUMENT_TREE);
 
     // Sic: EXTRA_INITIAL_URI doesn't work
@@ -254,7 +254,18 @@ public class BookmarkCategoriesFragment extends BaseMwmRecyclerFragment<Bookmark
 
     if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.M)
       intent.putExtra(DocumentsContract.EXTRA_EXCLUDE_SELF, true);
-    startActivityForResult(intent, REQ_CODE_IMPORT_DIRECTORY);
+
+    try {
+      startActivityForResult(intent, REQ_CODE_IMPORT_DIRECTORY);
+    } catch (ActivityNotFoundException e) {
+      Toast.makeText(getContext(), R.string.file_manager_recommended, Toast.LENGTH_LONG).show();
+
+      Intent marketIntent = new Intent(Intent.ACTION_VIEW);
+      marketIntent.setData(Uri.parse("market://details?id=com.google.android.apps.nbu.files"));
+      if (marketIntent.resolveActivity(getContext().getPackageManager()) != null) {
+        startActivity(marketIntent);
+      }
+    }
   }
 
   @Override

--- a/android/app/src/main/java/app/organicmaps/bookmarks/BookmarkCategoriesFragment.java
+++ b/android/app/src/main/java/app/organicmaps/bookmarks/BookmarkCategoriesFragment.java
@@ -241,7 +241,8 @@ public class BookmarkCategoriesFragment extends BaseMwmRecyclerFragment<Bookmark
   }
 
   @Override
-  public void onImportButtonClick() {
+  public void onImportButtonClick()
+  {
     Intent intent = new Intent(Intent.ACTION_OPEN_DOCUMENT_TREE);
 
     // Sic: EXTRA_INITIAL_URI doesn't work
@@ -257,7 +258,8 @@ public class BookmarkCategoriesFragment extends BaseMwmRecyclerFragment<Bookmark
 
     try {
       startActivityForResult(intent, REQ_CODE_IMPORT_DIRECTORY);
-    } catch (ActivityNotFoundException e) {
+    }
+    catch (ActivityNotFoundException e) {
       Toast.makeText(getContext(), R.string.file_manager_recommended, Toast.LENGTH_LONG).show();
 
       Intent marketIntent = new Intent(Intent.ACTION_VIEW);

--- a/android/app/src/main/res/values/strings.xml
+++ b/android/app/src/main/res/values/strings.xml
@@ -300,6 +300,8 @@
 	<!-- Text in menu + Button in the main Help dialog -->
 	<string name="report_a_bug">Report a bug</string>
 	<!-- Toast text when compass calibration may improve the correctness of the current position arrow -->
+	<string name="file_manager_recommended">Missing suitable file manager app! Please install one to select folders.</string>
+	<!-- Toast text when there is no app to show a folder selection dialog -->
 	<string name="compass_calibration_recommended">Improve arrow direction by moving the phone in a figure-eight motion to calibrate the compass.</string>
 	<!-- Toast text when compass calibration may improve the correctness of the current position arrow -->
 	<string name="compass_calibration_required">Move the phone in a figure-eight motion to calibrate the compass and fix the arrow direction on the map.</string>

--- a/data/strings/strings.txt
+++ b/data/strings/strings.txt
@@ -7411,6 +7411,53 @@
     zh-Hans = 指南针校准
     zh-Hant = 指南針校準
 
+  [file_manager_recommended]
+    comment = Toast text when there is no app to show a folder selection dialog
+    tags = android
+    en = Missing suitable file manager app! Please install one to select folders.
+    af = Geskikte lêerbestuurder-toep nie gevind nie! Installeer asseblief een om vouers te kies.
+    ar = لم يتم العثور على تطبيق مدير ملفات مناسب! يرجى تثبيت واحد لتحديد المجلدات.
+    az = Uyğun fayl meneceri tətbiqi yoxdur! Qovluqları seçmək üçün birini quraşdırın.
+    be = Падыходзячага дадатку для кіравання файламі не знойдзена! Калі ласка, усталюйце адзін для выбару тэчак.
+    bg = Липсва подходяща програма за управление на файлове! Моля, инсталирайте една, за да избирате папки.
+    ca = Falten aplicacions de gestor de fitxers adequades! Instal·leu-ne una per seleccionar carpetes.
+    cs = Chybí vhodná aplikace správce souborů! Nainstalujte jednu pro výběr složek.
+    da = Mangler en passende filhåndteringsapp! Installér en for at vælge mapper.
+    de = Geeignete Dateimanager-App fehlt! Bitte installieren Sie eine, um Ordner auszuwählen.
+    el = Λείπει κατάλληλη εφαρμογή διαχείρισης αρχείων! Εγκαταστήστε μία για να επιλέξετε φακέλους.
+    es = ¡Falta una aplicación de administrador de archivos adecuada! Instale una para seleccionar carpetas.
+    es-MX = ¡Falta una aplicación de administrador de archivos adecuada! Instale una para seleccionar carpetas.
+    et = Puudub sobiv failihalduri rakendus! Palun installige üks kaustade valimiseks.
+    eu = Ez da egoki fitxategi-kudeatzaile aplikaziorik aurkitu! Mesedez, instalatu bat karpetak hautatzeko.
+    fa = برنامه مدیریت فایل مناسبی وجود ندارد! لطفاً یکی را برای انتخاب پوشه‌ها نصب کنید.
+    fi = Sopiva tiedostonhallintasovellus puuttuu! Asenna sellainen kansioiden valitsemista varten.
+    fr = Aucune application de gestion de fichiers adaptée trouvée ! Veuillez en installer une pour sélectionner des dossiers.
+    he = אין אפליקציית ניהול קבצים מתאימה! התקן אחת כדי לבחור תיקיות.
+    hi = उपयुक्त फ़ाइल प्रबंधक ऐप गायब है! कृपया फ़ोल्डर चुनने के लिए एक स्थापित करें।
+    hu = Hiányzik egy megfelelő fájlkezelő alkalmazás! Kérjük, telepítsen egyet a mappák kiválasztásához.
+    id = Aplikasi pengelola file yang sesuai tidak ada! Harap instal satu untuk memilih folder.
+    it = Manca un'app di gestione file adatta! Installane una per selezionare le cartelle.
+    ja = 適切なファイルマネージャーアプリが見つかりません！フォルダーを選択するためにアプリをインストールしてください。
+    ko = 적절한 파일 관리자 앱이 없습니다! 폴더를 선택하려면 하나를 설치하세요.
+    lt = Trūksta tinkamos failų tvarkytuvės programėlės! Įdiekite vieną, kad pasirinktumėte aplankus.
+    mr = योग्य फाईल मॅनेजर अॅप नाही! फोल्डर निवडण्यासाठी कृपया एक स्थापित करा.
+    nb = Mangler en passende filbehandler-app! Installer en for å velge mapper.
+    nl = Geschikte bestandsbeheer-app ontbreekt! Installeer er een om mappen te selecteren.
+    pl = Brak odpowiedniej aplikacji do zarządzania plikami! Proszę zainstalować jedną, aby wybrać foldery.
+    pt = Falta uma aplicação de gestor de ficheiros adequada! Por favor, instale uma para selecionar pastas.
+    pt-BR = Faltando aplicativo de gerenciador de arquivos adequado! Por favor, instale um para selecionar pastas.
+    ro = Lipsește o aplicație potrivită pentru managerul de fișiere! Vă rugăm să instalați una pentru a selecta dosare.
+    ru = Отсутствует подходящее приложение для управления файлами! Пожалуйста, установите одно для выбора папок.
+    sk = Chýba vhodná aplikácia správcu súborov! Nainštalujte si jednu na výber priečinkov.
+    sv = Lämplig filhanteringsapp saknas! Installera en för att välja mappar.
+    sw = Programu inayofaa ya msimamizi wa faili haikupatikana! Tafadhali sakinisha moja ili kuchagua folda.
+    th = ไม่มีแอปตัวจัดการไฟล์ที่เหมาะสม! โปรดติดตั้งแอปหนึ่งเพื่อตัวเลือกโฟลเดอร์
+    tr = Uygun dosya yöneticisi uygulaması bulunamadı! Klasörleri seçmek için bir tane yükleyin.
+    uk = Відсутня відповідна програма для керування файлами! Будь ласка, встановіть одну для вибору папок.
+    vi = Thiếu ứng dụng quản lý tệp thích hợp! Vui lòng cài đặt một ứng dụng để chọn thư mục.
+    zh-Hans = 缺少合适的文件管理应用！请安装一个以选择文件夹。
+    zh-Hant = 缺少合適的文件管理應用！請安裝一個以選擇文件夾。
+
   [compass_calibration_recommended]
     comment = Toast text when compass calibration may improve the correctness of the current position arrow
     tags = android


### PR DESCRIPTION
Fixes #8415 

This PR fixes a crash that occurs when the "Import Bookmarks" button is pressed. The crash was caused by an ActivityNotFoundException due to the absence of an app that can handle the OPEN_DOCUMENT_TREE intent.

- Added a try-catch block to gracefully handle the ActivityNotFoundException.
- Added a toast message to inform the user that a suitable file manager app is not installed.
- Redirect the user to the Google Play Store to download a suitable file manager app.

![Screenshot_20240608-222253](https://github.com/organicmaps/organicmaps/assets/112623116/b7821d4b-6c5c-41c9-b522-72db2ad3daf6)
