### PR TITLE
[iOS] Fixed titles capitalization

### DIFF
--- a/iphone/Maps/UI/Editor/MWMEditorViewController.mm
+++ b/iphone/Maps/UI/Editor/MWMEditorViewController.mm
@@ -199,7 +199,7 @@ void registerCellsForTableView(std::vector<MWMEditorCellID> const & cells, UITab
 - (void)configNavBar
 {
   self.title =
-      L(self.isCreating ? @"editor_add_place_title" : @"editor_edit_place_title").capitalizedString;
+      L(self.isCreating ? @"editor_add_place_title" : @"editor_edit_place_title");
   self.navigationItem.rightBarButtonItem =
       [[UIBarButtonItem alloc] initWithBarButtonSystemItem:UIBarButtonSystemItemSave
                                                     target:self

--- a/iphone/Maps/UI/Editor/OpeningHours/MWMOpeningHoursEditorViewController.mm
+++ b/iphone/Maps/UI/Editor/OpeningHours/MWMOpeningHoursEditorViewController.mm
@@ -56,7 +56,7 @@ extern NSDictionary * const kMWMOpeningHoursEditorTableCells = @{
 
 - (void)configNavBar
 {
-  self.title = L(@"editor_time_title").capitalizedString;
+  self.title = L(@"editor_time_title");
   self.navigationItem.rightBarButtonItem =
       [[UIBarButtonItem alloc] initWithBarButtonSystemItem:UIBarButtonSystemItemDone
                                                     target:self

--- a/iphone/Maps/UI/Editor/Street/MWMStreetEditorViewController.mm
+++ b/iphone/Maps/UI/Editor/Street/MWMStreetEditorViewController.mm
@@ -27,7 +27,7 @@
 
 - (void)configNavBar
 {
-  self.title = L(@"choose_street").capitalizedString;
+  self.title = L(@"choose_street");
   self.navigationItem.leftBarButtonItem =
       [[UIBarButtonItem alloc] initWithBarButtonSystemItem:UIBarButtonSystemItemCancel
                                                     target:self


### PR DESCRIPTION
After #8147 I realized at least 2 pages where there in unnecessary capitalization in titles:

![IMG_3350](https://github.com/organicmaps/organicmaps/assets/86851490/1636c9a1-66a0-420b-8b34-1aad0ba59cf4)
![IMG_3349](https://github.com/organicmaps/organicmaps/assets/86851490/f65fcabd-a26e-492e-814a-528f8f26dce8)

Probably not necessary to English strings, but to Romance languages it is a bit weird.

Anyway, I think this PR fixes these two cases, if you agree.

Also, if you search for `.capitalizedString` in the whole repository there's another case: [iphone/Maps/UI/Editor/MWMEditorViewController.mm](https://github.com/organicmaps/organicmaps/blob/bed3b121462036d946056d059fc1c4065e3dd91a/iphone/Maps/UI/Editor/MWMEditorViewController.mm#L202)

I didn't edit this case because I couldn't find where, but if you wish I can also remove there (or feel free to edit this PR).