### PR TITLE
Remove subways bg, add line casing

### DIFF
--- a/drape_frontend/frontend_renderer.cpp
+++ b/drape_frontend/frontend_renderer.cpp
@@ -1615,7 +1615,7 @@ void FrontendRenderer::RenderTransitSchemeLayer(ScreenBase const & modelView)
   {
     DEBUG_LABEL(m_context, "Transit Scheme");
     m_context->Clear(dp::ClearBits::DepthBit, dp::kClearBitsStoreAll);
-    RenderTransitBackground();
+    //RenderTransitBackground();
     m_transitSchemeRenderer->RenderTransit(m_context, make_ref(m_gpuProgramManager), modelView,
                                            make_ref(m_postprocessRenderer), m_frameValues,
                                            make_ref(m_debugRectRenderer));

--- a/drape_frontend/transit_scheme_builder.cpp
+++ b/drape_frontend/transit_scheme_builder.cpp
@@ -38,6 +38,7 @@ std::array<float, 20> constexpr kTransitLinesWidthInPixel =
 
 namespace
 {
+float constexpr kCasingLineDepth = -1.0f;
 float constexpr kBaseLineDepth = 0.0f;
 float constexpr kDepthPerLine = 1.0f;
 float constexpr kBaseMarkerDepth = 300.0f;
@@ -430,7 +431,7 @@ void TransitSchemeBuilder::GenerateLinesSubway(MwmSchemeData const & scheme, dp:
         shape.second.m_forwardLines.size() + shape.second.m_backwardLines.size();
     float shapeOffset =
         -static_cast<float>(linesCount / 2) * 2.0f - static_cast<float>(linesCount % 2) + 1.0f;
-    size_t constexpr shapeOffsetIncrement = 2.0f;
+    float constexpr shapeOffsetIncrement = 2.0f;
 
     std::vector<std::pair<dp::Color, routing::transit::LineId>> coloredLines;
 
@@ -451,6 +452,7 @@ void TransitSchemeBuilder::GenerateLinesSubway(MwmSchemeData const & scheme, dp:
       coloredLines.emplace_back(color, *it);
     }
 
+    auto const casingColor = dp::Color(255, 255, 255, 160);
     for (auto const & coloredLine : coloredLines)
     {
       auto const & colorConst = coloredLine.first;
@@ -459,6 +461,8 @@ void TransitSchemeBuilder::GenerateLinesSubway(MwmSchemeData const & scheme, dp:
 
       GenerateLine(context, shape.second.m_polyline, scheme.m_pivot, colorConst, shapeOffset,
                    kTransitLineHalfWidth, depth, batcher);
+      GenerateLine(context, shape.second.m_polyline, scheme.m_pivot, casingColor, shapeOffset,
+                   kTransitLineHalfWidth + 0.5f, kCasingLineDepth, batcher);
 
       shapeOffset += shapeOffsetIncrement;
     }
@@ -1128,8 +1132,7 @@ void TransitSchemeBuilder::GenerateLine(ref_ptr<dp::GraphicsContext> context,
   using TV = TransitStaticVertex;
 
   TGeometryBuffer geometry;
-  auto const color = glsl::vec4(colorConst.GetRedF(), colorConst.GetGreenF(), colorConst.GetBlueF(),
-                                1.0f /* alpha */);
+  auto const color = glsl::vec4(colorConst.GetRedF(), colorConst.GetGreenF(), colorConst.GetBlueF(), colorConst.GetAlphaF());
   size_t const kAverageSize = path.size() * 6;
   size_t const kAverageCapSize = 12;
   geometry.reserve(kAverageSize + kAverageCapSize * 2);


### PR DESCRIPTION
- closes https://github.com/organicmaps/organicmaps/issues/6915

![image](https://github.com/organicmaps/organicmaps/assets/18434508/a8989d09-e070-4ef9-a49e-5d31f4883ea6)

![image](https://github.com/organicmaps/organicmaps/assets/18434508/2303eb12-c23e-4fa0-9a79-0f22a69ae9d4)


TODO
- put casing color and opacity into styles
- night mode
- add casing/outline to stop circles
- ? render lines under POI icons/labels ? (now they're above everything)

- related to https://github.com/organicmaps/organicmaps/issues/3508