### PR TITLE
Add check_date support

### DIFF
--- a/generator/osm2meta.cpp
+++ b/generator/osm2meta.cpp
@@ -503,6 +503,7 @@ void MetadataTagProcessor::operator()(std::string const & k, std::string const &
     break;
   case Metadata::FMD_WEBSITE: valid = ValidateAndFormat_url(v); break;
   case Metadata::FMD_WEBSITE_MENU: valid = ValidateAndFormat_url(v); break;
+  case Metadata::FMD_CHECK_DATE: valid = ValidateAndFormat_url(v); break;
   case Metadata::FMD_CONTACT_FACEBOOK: valid = osm::ValidateAndFormat_facebook(v); break;
   case Metadata::FMD_CONTACT_INSTAGRAM: valid = osm::ValidateAndFormat_instagram(v); break;
   case Metadata::FMD_CONTACT_TWITTER: valid = osm::ValidateAndFormat_twitter(v); break;

--- a/indexer/feature_meta.cpp
+++ b/indexer/feature_meta.cpp
@@ -136,6 +136,8 @@ bool Metadata::TypeFromString(string_view k, Metadata::EType & outType)
     outType = Metadata::FMD_DRIVE_THROUGH;
   else if (k == "website:menu")
     outType = Metadata::FMD_WEBSITE_MENU;
+  else if (k == "check_date")
+    outType = Metadata::FMD_CHECK_DATE;
   else
     return false;
 
@@ -256,6 +258,7 @@ string ToString(Metadata::EType type)
   case Metadata::FMD_LOCAL_REF: return "local_ref";
   case Metadata::FMD_DRIVE_THROUGH: return "drive_through";
   case Metadata::FMD_WEBSITE_MENU: return "website:menu";
+  case Metadata::FMD_CHECK_DATE: return "check_date";
   case Metadata::FMD_COUNT: CHECK(false, ("FMD_COUNT can not be used as a type."));
   };
 

--- a/indexer/feature_meta.hpp
+++ b/indexer/feature_meta.hpp
@@ -152,6 +152,7 @@ public:
     FMD_LOCAL_REF = 44,
     FMD_DRIVE_THROUGH = 45,
     FMD_WEBSITE_MENU = 46,
+    FMD_CHECK_DATE = 47,
     FMD_COUNT
   };
 

--- a/iphone/CoreApi/CoreApi/PlacePageData/Common/PlacePageInfoData.h
+++ b/iphone/CoreApi/CoreApi/PlacePageData/Common/PlacePageInfoData.h
@@ -32,6 +32,7 @@ NS_ASSUME_NONNULL_BEGIN
 @property(nonatomic, readonly, nullable) NSString *wheelchair;
 @property(nonatomic, readonly, nullable) NSString *driveThrough;
 @property(nonatomic, readonly, nullable) NSString *websiteMenu;
+@property(nonatomic, readonly, nullable) NSString *checkDate;
 
 @end
 

--- a/iphone/CoreApi/CoreApi/PlacePageData/Common/PlacePageInfoData.mm
+++ b/iphone/CoreApi/CoreApi/PlacePageData/Common/PlacePageInfoData.mm
@@ -50,6 +50,7 @@ using namespace osm;
           break;
         }
         case MetadataID::FMD_WEBSITE: _website = ToNSString(value); break;
+        case MetadataID::FMD_CHECK_DATE: _checkDate = ToNSString(value); break;
         case MetadataID::FMD_EXTERNAL_URI:
         {
           NSString *countryIsoCode = [[NSLocale currentLocale] objectForKey:NSLocaleCountryCode] ?: @"US";

--- a/iphone/Maps/UI/PlacePage/Components/PlacePageInfoViewController.swift
+++ b/iphone/Maps/UI/PlacePage/Components/PlacePageInfoViewController.swift
@@ -81,6 +81,7 @@ class PlacePageInfoViewController: UIViewController {
   private var phoneView: InfoItemViewController?
   private var websiteView: InfoItemViewController?
   private var websiteMenuView: InfoItemViewController?
+  private var checkDateView: InfoItemViewController?
   private var kayakView: InfoItemViewController?
   private var wikipediaView: InfoItemViewController?
   private var wikimediaCommonsView: InfoItemViewController?
@@ -143,6 +144,9 @@ class PlacePageInfoViewController: UIViewController {
                                  longPressHandler: { [weak self] in
         self?.delegate?.didCopy(phone)
       })
+    }
+    if let checkDate = placePageInfoData.checkDate {
+      checkDateView = createInfoItem(checkDate, icon: UIImage(named: "ic_placepage_operator"))
     }
 
     if let ppOperator = placePageInfoData.ppOperator {


### PR DESCRIPTION
Does two things:
Imports check_date to the map generator
Displays the contents of check_date on POIs
<img width="546" alt="Screenshot 2024-06-10 at 23 00 29" src="https://github.com/organicmaps/organicmaps/assets/62468530/4f2bd8fe-7768-4ea3-8686-1d1100ceb2a5">

Open questions:
* What kind of validation should be done? Likely only wish to include this in the map data if it's formatted as YYYY-MM-DD, and I think the map generator has functionality for validation?
* What's the minimal useful presentation of the information?

Related to #7882 #7036 #6811 