### PR TITLE
[android] [ios] Split the deactivate PP and switch fullscreen mode logic

### DIFF
--- a/android/app/src/main/java/app/organicmaps/Framework.java
+++ b/android/app/src/main/java/app/organicmaps/Framework.java
@@ -76,7 +76,12 @@ public class Framework
     // Called from JNI
     @Keep
     @SuppressWarnings("unused")
-    void onPlacePageDeactivated(boolean switchFullScreenMode);
+    void onPlacePageDeactivated();
+
+    // Called from JNI
+    @Keep
+    @SuppressWarnings("unused")
+    void onSwitchFullScreenMode();
   }
 
   public interface RoutingListener

--- a/android/app/src/main/java/app/organicmaps/MwmActivity.java
+++ b/android/app/src/main/java/app/organicmaps/MwmActivity.java
@@ -1229,22 +1229,22 @@ public class MwmActivity extends BaseMwmFragmentActivity
   // Called from JNI.
   @Override
   @SuppressWarnings("unused")
-  public void onPlacePageDeactivated(boolean switchFullScreenMode)
+  public void onPlacePageDeactivated()
   {
-    if (switchFullScreenMode)
-    {
-      if ((mPanelAnimator != null && mPanelAnimator.isVisible()) ||
-          UiUtils.isVisible(mSearchController.getToolbar()))
-        return;
+    closePlacePage();
+  }
 
-      setFullscreen(!isFullscreen());
-      if (isFullscreen())
-        showFullscreenToastIfNeeded();
-    }
-    else
-    {
-      closePlacePage();
-    }
+  // Called from JNI.
+  @Override
+  @SuppressWarnings("unused")
+  public void onSwitchFullScreenMode()
+  {
+    if ((mPanelAnimator != null && mPanelAnimator.isVisible()) || UiUtils.isVisible(mSearchController.getToolbar()))
+      return;
+
+    setFullscreen(!isFullscreen());
+    if (isFullscreen())
+      showFullscreenToastIfNeeded();
   }
 
   private void setFullscreen(boolean isFullscreen)

--- a/android/app/src/main/java/app/organicmaps/car/CarAppSession.java
+++ b/android/app/src/main/java/app/organicmaps/car/CarAppSession.java
@@ -252,7 +252,7 @@ public final class CarAppSession extends Session implements DefaultLifecycleObse
   }
 
   @Override
-  public void onPlacePageDeactivated(boolean switchFullScreenMode)
+  public void onPlacePageDeactivated()
   {
     // The function is called when we close the PlaceScreen or when we enter the navigation mode.
     // We only need to handle the first case
@@ -261,6 +261,12 @@ public final class CarAppSession extends Session implements DefaultLifecycleObse
 
     RoutingController.get().cancel();
     mScreenManager.popToRoot();
+  }
+
+  @Override
+  public void onSwitchFullScreenMode()
+  {
+    // No fullscreen mode in AndroidAuto. Do nothing.
   }
 
   private void restoreRoute()

--- a/iphone/CoreApi/CoreApi/Framework/MWMFrameworkHelper.h
+++ b/iphone/CoreApi/CoreApi/Framework/MWMFrameworkHelper.h
@@ -24,7 +24,7 @@ NS_SWIFT_NAME(FrameworkHelper)
 + (void)zoomMap:(MWMZoomMode)mode;
 + (void)moveMap:(UIOffset)offset;
 + (void)scrollMap:(double)distanceX :(double) distanceY;
-+ (void)deactivateMapSelection:(BOOL)notifyUI NS_SWIFT_NAME(deactivateMapSelection(notifyUI:));
++ (void)deactivateMapSelection;
 + (void)switchMyPositionMode;
 + (void)stopLocationFollow;
 + (NSArray<NSString *> *)obtainLastSearchQueries;

--- a/iphone/CoreApi/CoreApi/Framework/MWMFrameworkHelper.mm
+++ b/iphone/CoreApi/CoreApi/Framework/MWMFrameworkHelper.mm
@@ -116,8 +116,8 @@
   GetFramework().Scroll(distanceX, distanceY);
 }
 
-+ (void)deactivateMapSelection:(BOOL)notifyUI {
-  GetFramework().DeactivateMapSelection(notifyUI);
++ (void)deactivateMapSelection {
+  GetFramework().DeactivateMapSelection();
 }
 
 + (void)switchMyPositionMode {

--- a/iphone/Maps/Bookmarks/BookmarksCoordinator.swift
+++ b/iphone/Maps/Bookmarks/BookmarksCoordinator.swift
@@ -68,7 +68,7 @@ import UIKit
                         animations: {
                           navigationController.setViewControllers(controllers, animated: false)
       }, completion: nil)
-      FrameworkHelper.deactivateMapSelection(notifyUI: true)
+      FrameworkHelper.deactivateMapSelection()
       self.bookmarksControllers = nil
     case .closed:
       navigationController.popToRootViewController(animated: true)

--- a/iphone/Maps/Classes/MapViewController.mm
+++ b/iphone/Maps/Classes/MapViewController.mm
@@ -131,7 +131,7 @@ NSString *const kPP2BookmarkEditingSegue = @"PP2BookmarkEditing";
 }
 
 - (void)dismissPlacePage {
-  GetFramework().DeactivateMapSelection(true);
+  GetFramework().DeactivateMapSelection();
 }
 
 - (void)hideRegularPlacePage {
@@ -150,7 +150,7 @@ NSString *const kPP2BookmarkEditingSegue = @"PP2BookmarkEditing";
   self.controlsManager.trafficButtonHidden = NO;
 }
 
-- (void)onMapObjectDeselected:(bool)switchFullScreenMode {
+- (void)onMapObjectDeselected {
   [self hidePlacePage];
 
   MWMSearchManager * searchManager = MWMSearchManager.manager;
@@ -163,16 +163,11 @@ NSString *const kPP2BookmarkEditingSegue = @"PP2BookmarkEditing";
       searchManager.state = MWMSearchManagerStateHidden;
     }
   }
+}
 
-  if (!switchFullScreenMode)
-    return;
-
-  // TODO(AB): Switch to full screen mode directly from the tap, in one place, instead of
-  // every call to onMapObjectDeselected.
-  if (DeepLinkHandler.shared.isLaunchedByDeeplink)
-    return;
-
-  BOOL const isSearchHidden = searchManager.state == MWMSearchManagerStateHidden;
+- (void)onSwitchFullScreen {
+  BOOL const isNavigationDashboardHidden = [MWMNavigationDashboardManager sharedManager].state == MWMNavigationDashboardStateHidden;
+  BOOL const isSearchHidden = MWMSearchManager.manager.state == MWMSearchManagerStateHidden;
   if (isSearchHidden && isNavigationDashboardHidden) {
     self.controlsManager.hidden = !self.controlsManager.hidden;
   }
@@ -444,8 +439,9 @@ NSString *const kPP2BookmarkEditingSegue = @"PP2BookmarkEditing";
   Framework &f = GetFramework();
   // TODO: Review and improve this code.
   f.SetPlacePageListeners([self]() { [self onMapObjectSelected]; },
-                          [self](bool switchFullScreen) { [self onMapObjectDeselected:switchFullScreen]; },
-                          [self]() { [self onMapObjectUpdated]; });
+                          [self]() { [self onMapObjectDeselected]; },
+                          [self]() { [self onMapObjectUpdated]; },
+                          [self]() { [self onSwitchFullScreen]; });
   // TODO: Review and improve this code.
   f.SetMyPositionModeListener([self](location::EMyPositionMode mode, bool routingActive) {
     // TODO: Two global listeners are subscribed to the same event from the core.

--- a/iphone/Maps/Core/Routing/MWMRouter.mm
+++ b/iphone/Maps/Core/Routing/MWMRouter.mm
@@ -433,7 +433,7 @@ char const *kRenderAltitudeImagesQueueLabel = "mapsme.mwmrouter.renderAltitudeIm
 
 - (void)onRouteReady:(BOOL)hasWarnings {
   self.routingOptions = [MWMRoutingOptions new];
-  GetFramework().DeactivateMapSelection(true);
+  GetFramework().DeactivateMapSelection();
 
   auto startPoint = [MWMRouter startPoint];
   if (!startPoint || !startPoint.isMyPosition) {

--- a/iphone/Maps/UI/PlacePage/PlacePageManager/MWMPlacePageManager.mm
+++ b/iphone/Maps/UI/PlacePage/PlacePageManager/MWMPlacePageManager.mm
@@ -30,7 +30,7 @@ using namespace storage;
   return GetFramework().HasPlacePageInfo();
 }
 
-- (void)closePlacePage { GetFramework().DeactivateMapSelection(true); }
+- (void)closePlacePage { GetFramework().DeactivateMapSelection(); }
 
 - (void)routeFrom:(PlacePageData *)data {
   MWMRoutePoint *point = [self routePoint:data withType:MWMRoutePointTypeStart intermediateIndex:0];

--- a/iphone/Maps/UI/Search/MWMSearchManager.mm
+++ b/iphone/Maps/UI/Search/MWMSearchManager.mm
@@ -216,7 +216,7 @@ const CGFloat kWidthForiPad = 320;
   [self.navigationController popToRootViewControllerAnimated:NO];
 
   self.searchBarView.state = SearchBarStateReady;
-  GetFramework().DeactivateMapSelection(true);
+  GetFramework().DeactivateMapSelection();
   [self animateConstraints:^{
     self.contentViewTopHidden.priority = UILayoutPriorityDefaultLow;
     self.contentViewBottomHidden.priority = UILayoutPriorityDefaultLow;
@@ -237,7 +237,7 @@ const CGFloat kWidthForiPad = 320;
   [self.navigationController popToRootViewControllerAnimated:NO];
 
   self.searchBarView.state = SearchBarStateReady;
-  GetFramework().DeactivateMapSelection(true);
+  GetFramework().DeactivateMapSelection();
   [self updateTableSearchActionBar];
   auto const navigationManagerState = [MWMNavigationDashboardManager sharedManager].state;
   if (navigationManagerState == MWMNavigationDashboardStateHidden) {
@@ -265,7 +265,7 @@ const CGFloat kWidthForiPad = 320;
   auto const navigationManagerState = [MWMNavigationDashboardManager sharedManager].state;
   [self viewHidden:navigationManagerState != MWMNavigationDashboardStateHidden];
   self.controlsManager.menuState = MWMBottomMenuStateHidden;
-  GetFramework().DeactivateMapSelection(true);
+  GetFramework().DeactivateMapSelection();
   [MWMSearch setSearchOnMap:YES];
   [self.tableViewController reloadData];
 

--- a/map/framework.cpp
+++ b/map/framework.cpp
@@ -1911,7 +1911,7 @@ void Framework::DeactivateMapSelection()
   if (m_onPlacePageClose)
     m_onPlacePageClose();
 
-  if (m_currentPlacePageInfo.has_value())
+  if (m_currentPlacePageInfo)
   {
     DeactivateHotelSearchMark();
 

--- a/map/framework.hpp
+++ b/map/framework.hpp
@@ -308,7 +308,8 @@ private:
   void DeactivateHotelSearchMark();
 
 public:
-  void DeactivateMapSelection(bool notifyUI);
+  void DeactivateMapSelection();
+  void SwitchFullScreen();
   /// Used to "refresh" UI in some cases (e.g. feature editing).
   void UpdatePlacePageInfoForCurrentSelection(
       std::optional<place_page::BuildInfo> const & overrideInfo = {});
@@ -319,13 +320,15 @@ public:
     using OnOpen = std::function<void()>;
     /// Called to notify UI that object on a map was deselected (UI should hide Place Page).
     /// If switchFullScreenMode is true, ui can [optionally] enter or exit full screen mode.
-    using OnClose = std::function<void(bool /*switchFullScreenMode*/)>;
+    using OnClose = std::function<void()>;
     using OnUpdate = std::function<void()>;
+    using OnSwitchFullScreen = std::function<void()>;
   };
 
   void SetPlacePageListeners(PlacePageEvent::OnOpen onOpen,
                              PlacePageEvent::OnClose onClose,
-                             PlacePageEvent::OnUpdate onUpdate);
+                             PlacePageEvent::OnUpdate onUpdate,
+                             PlacePageEvent::OnSwitchFullScreen onSwitchFullScreen);
   bool HasPlacePageInfo() const { return m_currentPlacePageInfo.has_value(); }
   place_page::Info const & GetCurrentPlacePageInfo() const;
   place_page::Info & GetCurrentPlacePageInfo();
@@ -368,6 +371,7 @@ private:
   PlacePageEvent::OnOpen m_onPlacePageOpen;
   PlacePageEvent::OnClose m_onPlacePageClose;
   PlacePageEvent::OnUpdate m_onPlacePageUpdate;
+  PlacePageEvent::OnSwitchFullScreen m_onSwitchFullScreen;
 
 private:
   std::vector<m2::TriangleD> GetSelectedFeatureTriangles() const;

--- a/map/mwm_url.cpp
+++ b/map/mwm_url.cpp
@@ -436,7 +436,7 @@ void ParsedMapApi::ExecuteMapApiRequest(Framework & fm) const
   }
 
   // Always hide current map selection.
-  fm.DeactivateMapSelection(true /* notifyUI */);
+  fm.DeactivateMapSelection();
 
   // Set viewport and stop follow mode.
   fm.StopLocationFollow();

--- a/qt/draw_widget.cpp
+++ b/qt/draw_widget.cpp
@@ -89,7 +89,7 @@ DrawWidget::DrawWidget(Framework & framework, std::unique_ptr<ScreenshotParams> 
   setFocusPolicy(Qt::StrongFocus);
 
   m_framework.SetPlacePageListeners([this]() { ShowPlacePage(); },
-                                    {} /* onClose */, {} /* onUpdate */);
+                                    {} /* onClose */, {} /* onUpdate */, {} /*onSwitchFullScreen */);
 
   auto & routingManager = m_framework.GetRoutingManager();
 
@@ -703,7 +703,7 @@ void DrawWidget::ShowPlacePage()
   break;
   default: break;
   }
-  m_framework.DeactivateMapSelection(false);
+  m_framework.DeactivateMapSelection();
 }
 
 void DrawWidget::SetRuler(bool enabled)

--- a/search/search_quality/assessment_tool/main_view.cpp
+++ b/search/search_quality/assessment_tool/main_view.cpp
@@ -77,8 +77,9 @@ MainView::MainView(Framework & framework, QRect const & screenGeometry)
         FeatureInfoDialog dialog(this /* parent */, mapObject, address, m_sampleLocale);
         dialog.exec();
       },
-      [this](bool /* switchFullScreenMode */) { m_selectedFeature = FeatureID(); },
-      {} /* onUpdate */);
+      [this]() { m_selectedFeature = FeatureID(); },
+      {} /* onUpdate */,
+      {} /* onSwitchFullScreenMode */);
 }
 
 MainView::~MainView()


### PR DESCRIPTION
Closes https://github.com/organicmaps/organicmaps/issues/8442

The old logic when the dismissing method should control not only the PP dismissing but also the fullscreen mode toggling contains too many responsibilities, and produces unexpected behavior (if the PP is opened and the user long taps on the map the PP will be dismissed but the side buttons not - ios, or deeplink handling hides the side buttons - ios), and hard to read and debug.

This PR continues https://github.com/organicmaps/organicmaps/pull/7876 and splits the `DeactivateMapSelection(bool notifyUI)` into the `DeactivateMapSelection()` and `SwitchFullScreen()`.
The additional callback `m_onSwitchFullScreen = std::move(onSwitchFullScreen);` was added.

Fullscreen mode switching is blocked when:
- navigation mode is active
- searching is active

Todo:
- [x] implement a fix in Android. I've failed to handle all these JNI methods... @strump Can you please help me and split the methods in android?

Results:
enter/exit the fullscreen mode independently from the PP
![Simulator Screen Recording - iPhone 15 - 2024-06-11 at 16 37 12](https://github.com/organicmaps/organicmaps/assets/79797627/355eafc2-28a7-4216-8e10-bf0fffe55605)

entering the fullscreen mode is inactive during the navigation or searching
![Simulator Screen Recording - iPhone 15 - 2024-06-11 at 15 17 39](https://github.com/organicmaps/organicmaps/assets/79797627/4361ae19-1228-4142-a517-863edf7e18b8)

