### PR TITLE
[ios] Reload the PP content instead of Recreate the entire screen

### DIFF
--- a/iphone/Maps/Classes/MapViewController.mm
+++ b/iphone/Maps/Classes/MapViewController.mm
@@ -105,6 +105,20 @@ NSString *const kPP2BookmarkEditingSegue = @"PP2BookmarkEditing";
 
 #pragma mark - Map Navigation
 
+- (void)showOrUpdatePlacePage {
+  if (!PlacePageData.hasData) {
+    return;
+  }
+
+  self.controlsManager.trafficButtonHidden = YES;
+
+  if (self.placePageVC != nil) {
+    [PlacePageBuilder update:(PlacePageViewController *)self.placePageVC];
+    return;
+  }
+  [self showRegularPlacePage];
+}
+
 - (void)showRegularPlacePage {
   self.placePageVC = [PlacePageBuilder build];
   self.placePageContainer.hidden = NO;
@@ -119,15 +133,6 @@ NSString *const kPP2BookmarkEditingSegue = @"PP2BookmarkEditing";
   ]];
   [self addChildViewController:self.placePageVC];
   [self.placePageVC didMoveToParentViewController:self];
-}
-
-- (void)showPlacePage {
-  if (!PlacePageData.hasData) {
-    return;
-  }
-  
-  self.controlsManager.trafficButtonHidden = YES;
-  [self showRegularPlacePage];
 }
 
 - (void)dismissPlacePage {
@@ -179,8 +184,7 @@ NSString *const kPP2BookmarkEditingSegue = @"PP2BookmarkEditing";
 }
 
 - (void)onMapObjectSelected {
-  [self hidePlacePage];
-  [self showPlacePage];
+  [self showOrUpdatePlacePage];
 }
 
 - (void)onMapObjectUpdated {

--- a/iphone/Maps/UI/PlacePage/Components/PlacePagePreviewViewController.swift
+++ b/iphone/Maps/UI/PlacePage/Components/PlacePagePreviewViewController.swift
@@ -109,15 +109,16 @@ final class PlacePagePreviewViewController: UIViewController {
   }
 
   func updateHeading(_ angle: CGFloat) {
-    heading = angle
     placePageDirectionView?.imageView.isHidden = false
-    UIView.animate(withDuration: kDefaultAnimationDuration,
+    let duration = heading == nil ? .zero : kDefaultAnimationDuration // skip the initial setup animation
+    UIView.animate(withDuration: duration,
                    delay: 0,
                    options: [.beginFromCurrentState, .curveEaseInOut],
                    animations: { [unowned self] in
                     self.placePageDirectionView?.imageView.transform = CGAffineTransform(rotationAngle: CGFloat.pi / 2 - angle)
     })
     fullScreenDirectionView.updateHeading(angle)
+    heading = angle
   }
 
   func updateSpeedAndAltitude(_ speedAndAltitude: String) {

--- a/iphone/Maps/UI/PlacePage/PlacePageBuilder.swift
+++ b/iphone/Maps/UI/PlacePage/PlacePageBuilder.swift
@@ -15,14 +15,33 @@
     } else {
       layout = PlacePageCommonLayout(interactor: interactor, storyboard: storyboard, data: data)
     }
-    let presenter = PlacePagePresenter(view: viewController,
-                                       interactor: interactor,
-                                       layout: layout)
+    let presenter = PlacePagePresenter(view: viewController, interactor: interactor)
 
-    interactor.presenter = presenter
+    viewController.setLayout(layout)
     viewController.presenter = presenter
+    interactor.presenter = presenter
     layout.presenter = presenter
-    
     return viewController
 	}
+
+  @objc static func update(_ viewController: PlacePageViewController) {
+    let data = PlacePageData(localizationProvider: OpeinigHoursLocalization())
+    viewController.isPreviewPlus = data.isPreviewPlus
+    let interactor = PlacePageInteractor(viewController: viewController,
+                                         data: data,
+                                         mapViewController: MapViewController.shared()!)
+    let layout:IPlacePageLayout
+    if data.elevationProfileData != nil {
+      layout = PlacePageElevationLayout(interactor: interactor, storyboard: viewController.storyboard!, data: data)
+    } else {
+      layout = PlacePageCommonLayout(interactor: interactor, storyboard: viewController.storyboard!, data: data)
+    }
+    let presenter = PlacePagePresenter(view: viewController, interactor: interactor)
+
+    viewController.presenter = presenter
+    interactor.presenter = presenter
+    layout.presenter = presenter
+    viewController.updateWithLayout(layout)
+    viewController.updatePreviewOffset()
+  }
 }

--- a/iphone/Maps/UI/PlacePage/PlacePageLayout/Layouts/PlacePageCommonLayout.swift
+++ b/iphone/Maps/UI/PlacePage/PlacePageLayout/Layouts/PlacePageCommonLayout.swift
@@ -190,10 +190,9 @@ extension PlacePageCommonLayout {
       headerViewController.setTitle(title, secondaryTitle: secondaryTitle)
       placePageNavigationViewController.setTitle(title, secondaryTitle: secondaryTitle)
     }
-    self.presenter?.layoutIfNeeded()
+    presenter?.layoutIfNeeded()
     UIView.animate(withDuration: kDefaultAnimationDuration) { [unowned self] in
       self.bookmarkViewController.view.isHidden = !isBookmark
-      self.presenter?.layoutIfNeeded()
     }
   }
 }

--- a/iphone/Maps/UI/PlacePage/PlacePagePresenter.swift
+++ b/iphone/Maps/UI/PlacePage/PlacePagePresenter.swift
@@ -9,15 +9,11 @@ protocol PlacePagePresenterProtocol: AnyObject {
 class PlacePagePresenter: NSObject {
   private weak var view: PlacePageViewProtocol!
   private let interactor: PlacePageInteractorProtocol
-  private let layout: IPlacePageLayout
 
   init(view: PlacePageViewProtocol,
-       interactor: PlacePageInteractorProtocol,
-       layout: IPlacePageLayout) {
+       interactor: PlacePageInteractorProtocol) {
     self.view = view
     self.interactor = interactor
-    self.layout = layout
-    view.setLayout(layout)
   }
 }
 


### PR DESCRIPTION
### Issue
The current PlacePage behavior when a user select/changes the poi is:
1. close the current opened PP screen with animation
2. open a new PP screen with animation
On every tap.

This may be quite distractive and jumpy:
![Simulator Screen Recording - iPhone 15 - 2024-06-12 at 20 34 03](https://github.com/organicmaps/organicmaps/assets/79797627/1a122afb-9d24-481f-a907-7cfa806cf17f)
___
### Solution
This PR implements a small refactoring to `Reload` the PlacePage screen content rather than recreate it.

Benefits:
1. faster
2. less jumping animations

This behavior doesn't affect the iPad (and mac) because the PP on the iPad appears without animation.

Tested on:
- [x] iPhone 11Pro ios 17.5 (device)
- [x] iPhone 6 ios 12.5 (device)
- [x] iPhone 15Pro ios 17.5 (sim)
- [x] iPad 11 ios17.5 (sim)

Because the PlacePage legacy code is quite sensitive for the changes it would be great to make additional manual tests for this implementation for the different devices and ios versions.
___
### Results:

https://github.com/organicmaps/organicmaps/assets/79797627/4596ca71-7897-4cbe-99cc-d164223ab412

https://github.com/organicmaps/organicmaps/assets/79797627/4e671bf3-54f2-4d2c-9c9f-126456ef055a

![Simulator Screen Recording - iPad Air 11-inch (M2) - 2024-06-12 at 20 50 36](https://github.com/organicmaps/organicmaps/assets/79797627/f9c1b03b-f97f-4bcd-a742-08811151ea3c)

