### PR TITLE
[ios] fix file import using the uidocumentpicker

### DIFF
--- a/iphone/Maps/UI/DocumentPicker/DocumentPicker.swift
+++ b/iphone/Maps/UI/DocumentPicker/DocumentPicker.swift
@@ -10,7 +10,7 @@ final class DocumentPicker: NSObject {
     self.completionHandler = completionHandler
     let documentPickerViewController: UIDocumentPickerViewController
     if #available(iOS 14.0, *) {
-      documentPickerViewController = UIDocumentPickerViewController(forOpeningContentTypes: fileTypes.map(\.utType))
+      documentPickerViewController = UIDocumentPickerViewController(forOpeningContentTypes: fileTypes.map(\.utType), asCopy: true)
     } else {
       documentPickerViewController = UIDocumentPickerViewController(documentTypes: fileTypes.map(\.typeIdentifier), in: .import)
     }


### PR DESCRIPTION
This PR Fixes the #8410
The file should be imported as a copy because the files app will block access after dismissing.