### PR TITLE
[placepage] Show all types (filtering only POIs)

### DIFF
--- a/indexer/map_object.hpp
+++ b/indexer/map_object.hpp
@@ -103,8 +103,11 @@ public:
   void AssignMetadata(feature::Metadata & dest) const { dest = m_metadata; }
 
 protected:
-  /// @returns "the best" type to display in UI.
+  /// @returns "the best" single type to display in UI.
   std::string GetLocalizedType() const;
+    
+  /// @returns all localized POI types separated by kFieldsSeparator to display in UI.
+  std::string GetAllLocalizedTypes() const;
 
   FeatureID m_featureID;
   m2::PointD m_mercator;

--- a/map/place_page_info.cpp
+++ b/map/place_page_info.cpp
@@ -122,7 +122,7 @@ std::string Info::FormatSubtitle(bool withType) const
     append(m_bookmarkCategoryName);
 
   if (withType)
-    append(GetLocalizedType());
+    append(GetAllLocalizedTypes());
 
   // Flats.
   auto const flats = GetMetadata(feature::Metadata::FMD_FLATS);


### PR DESCRIPTION
Retrying to add all types to Place Page. Now it should be better than https://github.com/organicmaps/organicmaps/pull/8238, as it will only show types matched by existing checker `IsPoiChecker`. This should filter out useless stuff and internal things like psurface-*.

https://github.com/organicmaps/organicmaps/blob/32fa5823167212791b94a35bbfe0c682d99f2d64/indexer/ftypes_matcher.cpp#L461-L482

* Related to https://github.com/organicmaps/organicmaps/issues/3744
* Related to https://github.com/organicmaps/organicmaps/issues/4025#issuecomment-1807217279
* Related to https://github.com/organicmaps/organicmaps/issues/6882
* Fixes https://github.com/organicmaps/organicmaps/issues/8355
