### PR TITLE
[Strings] Ukrainan KMZ transliteration fix

### DIFF
--- a/android/app/src/main/res/values-uk/strings.xml
+++ b/android/app/src/main/res/values-uk/strings.xml
@@ -644,7 +644,7 @@
 	<string name="bookmarks_empty_list_title">Список порожній</string>
 	<string name="bookmarks_empty_list_message">Щоб додати нову мітку, натисніть на значок зірочки в картці об’єкта</string>
 	<string name="category_desc_more">…ще</string>
-	<string name="export_file">Експорт КМЗ</string>
+	<string name="export_file">Експорт KMZ</string>
 	<string name="export_file_gpx">Експорт GPX</string>
 	<string name="delete_list">Видалити список</string>
 	<string name="public_access">Публічний доступ</string>

--- a/data/strings/strings.txt
+++ b/data/strings/strings.txt
@@ -22962,7 +22962,7 @@
     sw = Hamisha KMZ
     th = ส่งออก KMZ
     tr = KMZ'yi Dışa Aktar
-    uk = Експорт КМЗ
+    uk = Експорт KMZ
     vi = Xuất KMZ
     zh-Hans = 导出 KMZ
     zh-Hant = 出口KMZ

--- a/iphone/Maps/LocalizedStrings/uk.lproj/Localizable.strings
+++ b/iphone/Maps/LocalizedStrings/uk.lproj/Localizable.strings
@@ -1011,7 +1011,7 @@
 
 "popular_place" = "Popular";
 
-"export_file" = "Експорт КМЗ";
+"export_file" = "Експорт KMZ";
 
 "export_file_gpx" = "Експорт GPX";
 


### PR DESCRIPTION
Found that Ukrainian string contains "КМЗ" instead of "KMZ". Probably machine translation artifact.

Fixed. Regenerated strings.