### PR TITLE
[ios] Implement logging to the file

### DIFF
--- a/base/logging.cpp
+++ b/base/logging.cpp
@@ -64,6 +64,11 @@ void LogHelper::WriteProlog(std::ostream & s, LogLevel level)
   s << GetLogLevelNames()[level] << '(' << GetThreadID() << ") " << std::fixed << std::setprecision(5) << sec << ' ';
 }
 
+void LogHelper::WriteLog(std::ostream & s, SrcPoint const & srcPoint, std::string const & msg)
+{
+  s << DebugPrint(srcPoint) << msg << std::endl;
+}
+
 void LogMessageDefault(LogLevel level, SrcPoint const & srcPoint, std::string const & msg)
 {
   auto & logger = LogHelper::Instance();
@@ -71,8 +76,8 @@ void LogMessageDefault(LogLevel level, SrcPoint const & srcPoint, std::string co
 
   std::lock_guard lock(g_logMutex);
   logger.WriteProlog(out, level);
+  logger.WriteLog(out, srcPoint, msg);
 
-  out << DebugPrint(srcPoint) << msg << std::endl;
   std::cerr << out.str();
 
   CHECK_LESS(level, g_LogAbortLevel, ("Abort. Log level is too serious", level));

--- a/base/logging.hpp
+++ b/base/logging.hpp
@@ -31,6 +31,7 @@ public:
 
   int GetThreadID();
   void WriteProlog(std::ostream & s, LogLevel level);
+  static void WriteLog(std::ostream & s, SrcPoint const & srcPoint, std::string const & msg);
 
 private:
   int m_threadsCount{0};

--- a/data/strings/strings.txt
+++ b/data/strings/strings.txt
@@ -19807,7 +19807,7 @@
     zh-Hant = 無法使用交通資訊
 
   [enable_logging]
-    tags = android
+    tags = android,ios
     en = Enable logging
     af = Staan logboekinskrywing toe
     ar = تفعيل التسجيل
@@ -19849,6 +19849,51 @@
     vi = Bật nhật ký
     zh-Hans = 启用记录
     zh-Hant = 啟用記錄
+
+  [log_file_size]
+    tags = ios
+    en = Log file size: %@
+    af = Loglêergrootte: %@
+    ar = حجم ملف السجل: %@
+    az = Giriş faylının ölçüsü: %@
+    be = Памер файла журнала: %@
+    bg = Размер на регистрационния файл: %@
+    ca = Mida del fitxer de registre: %@
+    cs = Velikost souboru protokolu: %@
+    da = Logfilens størrelse: %@
+    de = Größe der Protokolldatei: %@
+    el = Μέγεθος αρχείου καταγραφής: %@
+    es = Tamaño del archivo de registro: %@
+    et = Logifaili suurus: %@
+    eu = Erregistro fitxategiaren tamaina: %@
+    fa = اندازه فایل گزارش: %@
+    fi = Lokitiedoston koko: %@
+    fr = Taille du fichier journal : %@
+    he = גודל קובץ יומן: %@
+    hi = लॉग फ़ाइल का आकार: %@
+    hu = Naplófájl mérete: %@
+    id = Ukuran file log: %@
+    it = Dimensione del file di registro: %@
+    ja = ログファイルのサイズ: %@
+    ko = 로그 파일 크기: %@
+    lt = Žurnalo failo dydis: %@
+    mr = लॉग फाइल आकार: %@
+    nb = Loggfilstørrelse: %@
+    nl = Grootte logbestand: %@
+    pl = Rozmiar pliku dziennika: %@
+    pt = Tamanho do ficheiro de registo: %@
+    pt-BR = Tamanho do arquivo de registro: %@
+    ro = Dimensiunea fișierului jurnal: %@
+    ru = Размер файла логов: %@
+    sk = Veľkosť súboru protokolu: %@
+    sv = Loggfilens storlek: %@
+    sw = Ukubwa wa faili ya kumbukumbu: %@
+    th = ขนาดไฟล์บันทึก: %@
+    tr = Günlük dosyası boyutu: %@
+    uk = Розмір файлу журналу: %@.
+    vi = Kích thước tệp nhật ký: %@
+    zh-Hans = 日志文件大小： %@
+    zh-Hant = 日誌檔案大小：%@
 
   [feedback_general]
     comment = Settings: "Send general feedback" button
@@ -23899,7 +23944,7 @@
     zh-Hant = 最大程度省電
 
   [enable_logging_warning_message]
-    tags = android
+    tags = android,ios
     en = Enable this option temporarily to record and manually send detailed diagnostic logs about your issue to us using "Report a bug" in the Help dialog. Logs may include location info.
     af = Aktiveer hierdie opsie tydelik om ’n gedetailleerde diagnosestaat van u probleem op te neem en handmatig na ons te stuur d.m.v. die “Rapporteer ’n fout” in die Help-dialoog. Sulke state kan liggingsinligting bevat.
     ar = هذا الخيار يقوم ببدأ تسجيل سجلات التطبيق لإغراض التشخيصة. يمكن أن يكون مفيدًا لفريق الدعم الخاص بنا لحل المشاكل التي تواجهكم داخل التطبيق. قم بتفعيل هذا الخيار بشكل مؤقت فقط في حالة طلب الدعم من Organic Maps.

--- a/iphone/CoreApi/CoreApi/Logger/Logger.h
+++ b/iphone/CoreApi/CoreApi/Logger/Logger.h
@@ -12,8 +12,11 @@ typedef NS_ENUM(NSUInteger, LogLevel) {
 
 @interface Logger : NSObject
 
-+ (void)log:(LogLevel)level message:(NSString*)message;
++ (void)log:(LogLevel)level message:(NSString *)message;
 + (BOOL)canLog:(LogLevel)level;
++ (void)setFileLoggingEnabled:(BOOL)fileLoggingEnabled;
++ (nullable NSURL *)getLogFileURL;
++ (uint64_t)getLogFileSize;
 
 @end
 

--- a/iphone/CoreApi/CoreApi/Logger/Logger.mm
+++ b/iphone/CoreApi/CoreApi/Logger/Logger.mm
@@ -1,32 +1,249 @@
 #import "Logger.h"
-#import "base/logging.hpp"
+#import <OSLog/OSLog.h>
+
+#include "base/logging.hpp"
+#include "coding/zip_creator.hpp"
 
 @interface Logger ()
+
+@property (nullable, nonatomic) NSFileHandle * fileHandle;
+@property (nonnull, nonatomic) os_log_t osLogger;
+/// This property is introduced to avoid the CoreApi => Maps target dependency and stores the MWMSettings.isFileLoggingEnabled value.
+@property (class, nonatomic) BOOL fileLoggingEnabled;
+@property (class, readonly, nonatomic) dispatch_queue_t fileLoggingQueue;
+
++ (Logger *)logger;
++ (void)enableFileLogging;
++ (void)disableFileLogging;
++ (void)logMessageWithLevel:(base::LogLevel)level src:(base::SrcPoint const &)src message:(std::string const &)message;
++ (NSURL *)getZippedLogFile:(NSString *)logFilePath;
++ (void)removeFileAtPath:(NSString *)filePath;
 + (base::LogLevel)baseLevel:(LogLevel)level;
+
 @end
+
+// Subsystem and category are used for the OSLog.
+NSString * const kLoggerSubsystem = [[NSBundle mainBundle] bundleIdentifier];
+NSString * const kLoggerCategory = @"OM";
+NSString * const kLogFileName = @"log.txt";
+NSString * const kZipLogFileExtension = @"zip";
+NSString * const kLogFilePath = [[NSFileManager.defaultManager temporaryDirectory] URLByAppendingPathComponent:kLogFileName].path;
+// TODO: (KK) Review and change this limit after some testing.
+NSUInteger const kMaxLogFileSize = 1024 * 1024 * 100; // 100 MB;
 
 @implementation Logger
 
-+ (void)log:(LogLevel)level message:(NSString*)message {
-  LOG_SHORT([Logger baseLevel:level], (message.UTF8String));
+static BOOL _fileLoggingEnabled = NO;
+
++ (void)initialize
+{
+  if (self == [Logger class]) {
+    SetLogMessageFn(&LogMessage);
+    SetAssertFunction(&AssertMessage);
+  }
+}
+
++ (Logger *)logger {
+  static Logger * logger = nil;
+  static dispatch_once_t onceToken;
+  dispatch_once(&onceToken, ^{
+    logger = [[self alloc] init];
+  });
+  return logger;
+}
+
++ (dispatch_queue_t)fileLoggingQueue {
+  static dispatch_queue_t fileLoggingQueue = nil;
+  static dispatch_once_t onceToken;
+  dispatch_once(&onceToken, ^{
+    dispatch_queue_attr_t attributes = dispatch_queue_attr_make_with_qos_class(DISPATCH_QUEUE_SERIAL, QOS_CLASS_UTILITY, 0);
+    fileLoggingQueue = dispatch_queue_create("app.organicmaps.fileLoggingQueue", attributes);
+  });
+  return fileLoggingQueue;
+}
+
+- (instancetype)init {
+  self = [super init];
+  if (self) {
+    _osLogger = os_log_create(kLoggerSubsystem.UTF8String, kLoggerCategory.UTF8String);
+  }
+  return self;
+}
+
+// MARK: - Public
+
++ (void)setFileLoggingEnabled:(BOOL)fileLoggingEnabled {
+  fileLoggingEnabled ? [self enableFileLogging] : [self disableFileLogging];
+}
+
++ (BOOL)fileLoggingEnabled {
+  return _fileLoggingEnabled;
+}
+
++ (void)log:(LogLevel)level message:(NSString *)message {
+  LOG_SHORT([self baseLevel:level], (message.UTF8String));
 }
 
 + (BOOL)canLog:(LogLevel)level {
   return [Logger baseLevel:level] >= base::g_LogLevel;
 }
 
++ (nullable NSURL *)getLogFileURL {
+  if ([self fileLoggingEnabled]) {
+    if (![NSFileManager.defaultManager fileExistsAtPath:kLogFilePath]) {
+      LOG(LERROR, ("Log file doesn't exist while file logging is enabled:", kLogFilePath.UTF8String));
+      return nil;
+    }
+    return [self getZippedLogFile:kLogFilePath];
+  } else {
+    // Fetch logs from the OSLog store.
+    if (@available(iOS 15.0, *)) {
+      NSError * error;
+      OSLogStore * store = [OSLogStore storeWithScope:OSLogStoreCurrentProcessIdentifier error:&error];
+
+      if (error) {
+        LOG(LERROR, (error.localizedDescription.UTF8String));
+        return nil;
+      }
+
+      NSPredicate * predicate = [NSPredicate predicateWithFormat:@"subsystem == %@", kLoggerSubsystem];
+      OSLogEnumerator * enumerator = [store entriesEnumeratorWithOptions:{} position:nil predicate:predicate error:&error];
+
+      if (error) {
+        LOG(LERROR, (error.localizedDescription.UTF8String));
+        return nil;
+      }
+
+      NSMutableString * logString = [NSMutableString string];
+      NSString * kNewLineStr = @"\n";
+
+      id object;
+      while (object = [enumerator nextObject]) {
+        if ([object isMemberOfClass:[OSLogEntryLog class]]) {
+          [logString appendString:[object composedMessage]];
+          [logString appendString:kNewLineStr];
+        }
+      }
+
+      if (logString.length == 0) {
+        LOG(LINFO, ("OSLog entry is empty."));
+        return nil;
+      }
+
+      [NSFileManager.defaultManager createFileAtPath:kLogFilePath contents:[logString dataUsingEncoding:NSUTF8StringEncoding] attributes:nil];
+      return [self getZippedLogFile:kLogFilePath];
+    } else {
+      return nil;
+    }
+  }
+}
+
++ (uint64_t)getLogFileSize {
+  Logger * logger = [self logger];
+  return logger.fileHandle != nil ? [logger.fileHandle offsetInFile] : 0;
+}
+
+// MARK: - C++ injection
+
+void LogMessage(base::LogLevel level, base::SrcPoint const & src, std::string const & message)
+{
+  [Logger logMessageWithLevel:level src:src message:message];
+  CHECK_LESS(level, base::g_LogAbortLevel, ("Abort. Log level is too serious", level));
+}
+
+bool AssertMessage(base::SrcPoint const & src, std::string const & message)
+{
+  [Logger logMessageWithLevel:base::LCRITICAL src:src message:message];
+  return true;
+}
+
+// MARK: - Private
+
++ (void)enableFileLogging {
+  Logger * logger = [self logger];
+  NSFileManager * fileManager = [NSFileManager defaultManager];
+
+  // Create a log file if it doesn't exist and setup file handle for writing.
+  if (![fileManager fileExistsAtPath:kLogFilePath])
+    [fileManager createFileAtPath:kLogFilePath contents:nil attributes:nil];
+  NSFileHandle * fileHandle = [NSFileHandle fileHandleForWritingAtPath:kLogFilePath];
+  if (fileHandle == nil) {
+    LOG(LERROR, ("Failed to open log file for writing", kLogFilePath.UTF8String));
+    [self disableFileLogging];
+    return;
+  }
+  // Clean up the file if it exceeds the maximum size.
+  if ([fileManager contentsAtPath:kLogFilePath].length > kMaxLogFileSize)
+    [fileHandle truncateFileAtOffset:0];
+
+  logger.fileHandle = fileHandle;
+
+  _fileLoggingEnabled = YES;
+  LOG(LINFO, ("File logging is enabled"));
+}
+
++ (void)disableFileLogging {
+  Logger * logger = [self logger];
+
+  [logger.fileHandle closeFile];
+  logger.fileHandle = nil;
+  [self removeFileAtPath:kLogFilePath];
+
+  _fileLoggingEnabled = NO;
+  LOG(LINFO, ("File logging is disabled"));
+}
+
++ (void)logMessageWithLevel:(base::LogLevel)level src:(base::SrcPoint const &)src message:(std::string const &)message {
+  // Build the log message string.
+  auto & logHelper = base::LogHelper::Instance();
+  std::ostringstream output;
+  // TODO: (KK) Either guard this call, or refactor thread ids in logHelper.
+  logHelper.WriteProlog(output, level);
+  logHelper.WriteLog(output, src, message);
+  
+  auto const logString = output.str();
+
+  Logger * logger = [self logger];
+  // Log the message into the system log.
+  os_log(logger.osLogger, "%{public}s", logString.c_str());
+
+  dispatch_async([self fileLoggingQueue], ^{
+    // Write the log message into the file.
+    NSFileHandle * fileHandle = logger.fileHandle;
+    if (fileHandle != nil) {
+      [fileHandle seekToEndOfFile];
+      [fileHandle writeData:[NSData dataWithBytes:logString.c_str() length:logString.length()]];
+    }
+  });
+}
+
++ (NSURL *)getZippedLogFile:(NSString *)logFilePath {
+  NSString * zipFilePath = [[logFilePath stringByDeletingPathExtension] stringByAppendingPathExtension:kZipLogFileExtension];
+  auto const success = CreateZipFromFiles({logFilePath.UTF8String}, zipFilePath.UTF8String);
+  if (!success) {
+    LOG(LERROR, ("Failed to zip log file:", kLogFilePath.UTF8String, ". The original file will be returned."));
+    return [NSURL fileURLWithPath:logFilePath];
+  }
+  [self removeFileAtPath:kLogFilePath];
+  return [NSURL fileURLWithPath:zipFilePath];
+}
+
++ (void)removeFileAtPath:(NSString *)filePath {
+  if ([NSFileManager.defaultManager fileExistsAtPath:filePath]) {
+    NSError * error;
+    [NSFileManager.defaultManager removeItemAtPath:filePath error:&error];
+    if (error)
+      LOG(LERROR, (error.localizedDescription.UTF8String));
+  }
+}
+
 + (base::LogLevel)baseLevel:(LogLevel)level {
   switch (level) {
-    case LogLevelDebug:
-      return LDEBUG;
-    case LogLevelInfo:
-      return LINFO;
-    case LogLevelWarning:
-      return LWARNING;
-    case LogLevelError:
-      return LERROR;
-    case LogLevelCritical:
-      return LCRITICAL;
+    case LogLevelDebug: return LDEBUG;
+    case LogLevelInfo: return LINFO;
+    case LogLevelWarning: return LWARNING;
+    case LogLevelError: return LERROR;
+    case LogLevelCritical: return LCRITICAL;
   }
 }
 

--- a/iphone/Maps/Common/Common.swift
+++ b/iphone/Maps/Common/Common.swift
@@ -1,5 +1,4 @@
 import Foundation
-import OSLog
 
 private func IPAD() -> Bool { return UI_USER_INTERFACE_IDIOM() == .pad }
 
@@ -28,42 +27,18 @@ func statusBarHeight() -> CGFloat {
   return min(statusBarSize.height, statusBarSize.width)
 }
 
-private let enableLoggingInRelease = true
-
 func LOG(_ level: LogLevel,
          _ message: @autoclosure () -> Any,
          functionName: StaticString = #function,
          fileName: StaticString = #file,
          lineNumber: UInt = #line) {
-
-  let shortFileName = URL(string: "\(fileName)")?.lastPathComponent ?? ""
-  let formattedMessage = "\(shortFileName):\(lineNumber) \(functionName): \(message())"
-
-  if #available(iOS 14.0, *), enableLoggingInRelease {
-    os.Logger.logger.log(level: OSLogLevelFromLogLevel(level), "\(formattedMessage, privacy: .public)")
-  } else if Logger.canLog(level) {
+  if (Logger.canLog(level)) {
+    let shortFileName = URL(string: "\(fileName)")?.lastPathComponent ?? ""
+    let formattedMessage = "\(shortFileName):\(lineNumber) \(functionName): \(message())"
     Logger.log(level, message: formattedMessage)
-  }
-}
-
-private func OSLogLevelFromLogLevel(_ level: LogLevel) -> OSLogType {
-  switch level {
-  case .error: return .error
-  case .info: return .info
-  case .debug: return .debug
-  case .critical: return .fault
-  case .warning: return .default
-  @unknown default:
-    fatalError()
   }
 }
 
 struct Weak<T> where T: AnyObject {
   weak var value: T?
-}
-
-@available(iOS 14.0, *)
-private extension os.Logger {
-  static let subsystem = Bundle.main.bundleIdentifier!
-  static let logger = Logger(subsystem: subsystem, category: "OM")
 }

--- a/iphone/Maps/Core/Settings/MWMSettings.h
+++ b/iphone/Maps/Core/Settings/MWMSettings.h
@@ -37,4 +37,8 @@ NS_SWIFT_NAME(Settings)
 + (BOOL)iCLoudSynchronizationEnabled;
 + (void)setICLoudSynchronizationEnabled:(BOOL)iCLoudSyncEnabled;
 
++ (void)initializeLogging;
++ (BOOL)isFileLoggingEnabled;
++ (void)setFileLoggingEnabled:(BOOL)fileLoggingEnabled;
+
 @end

--- a/iphone/Maps/Core/Settings/MWMSettings.mm
+++ b/iphone/Maps/Core/Settings/MWMSettings.mm
@@ -3,8 +3,8 @@
 #import "MWMMapViewControlsManager.h"
 #import "SwiftBridge.h"
 
-
 #include <CoreApi/Framework.h>
+#include <CoreApi/Logger.h>
 
 namespace
 {
@@ -19,6 +19,7 @@ NSString * const kThemeMode = @"ThemeMode";
 NSString * const kSpotlightLocaleLanguageId = @"SpotlightLocaleLanguageId";
 NSString * const kUDTrackWarningAlertWasShown = @"TrackWarningAlertWasShown";
 NSString * const kiCLoudSynchronizationEnabledKey = @"iCLoudSynchronizationEnabled";
+NSString * const kUDFileLoggingEnabledKey = @"FileLoggingEnabledKey";
 }  // namespace
 
 @implementation MWMSettings
@@ -167,4 +168,21 @@ NSString * const kiCLoudSynchronizationEnabledKey = @"iCLoudSynchronizationEnabl
   [NSUserDefaults.standardUserDefaults setBool:iCLoudSyncEnabled forKey:kiCLoudSynchronizationEnabledKey];
   [NSNotificationCenter.defaultCenter postNotificationName:NSNotification.iCloudSynchronizationDidChangeEnabledState object:nil];
 }
+
++ (void)initializeLogging {
+  static dispatch_once_t onceToken;
+  dispatch_once(&onceToken, ^{
+    [self setFileLoggingEnabled:[self isFileLoggingEnabled]];
+  });
+}
+
++ (BOOL)isFileLoggingEnabled {
+  return [NSUserDefaults.standardUserDefaults boolForKey:kUDFileLoggingEnabledKey];
+}
+
++ (void)setFileLoggingEnabled:(BOOL)fileLoggingEnabled {
+  [NSUserDefaults.standardUserDefaults setBool:fileLoggingEnabled forKey:kUDFileLoggingEnabledKey];
+  [Logger setFileLoggingEnabled:fileLoggingEnabled];
+}
+
 @end

--- a/iphone/Maps/LocalizedStrings/ar.lproj/Localizable.strings
+++ b/iphone/Maps/LocalizedStrings/ar.lproj/Localizable.strings
@@ -923,6 +923,10 @@
 /* "traffic" as in "road congestion" */
 "traffic_data_unavailable" = "البيانات المرورية غير متاحة";
 
+"enable_logging" = "تفعيل التسجيل";
+
+"log_file_size" = "حجم ملف السجل: %@";
+
 "transliteration_title" = "كتابة جميع الاسماء بالحروف اللاتينية بشكل حرفي";
 
 /* Subway exits for public transport marks on the map */
@@ -1050,6 +1054,8 @@
 "power_managment_setting_auto" = "تلقائي";
 
 "power_managment_setting_manual_max" = "توفير الطاقة الأقصى";
+
+"enable_logging_warning_message" = "هذا الخيار يقوم ببدأ تسجيل سجلات التطبيق لإغراض التشخيصة. يمكن أن يكون مفيدًا لفريق الدعم الخاص بنا لحل المشاكل التي تواجهكم داخل التطبيق. قم بتفعيل هذا الخيار بشكل مؤقت فقط في حالة طلب الدعم من Organic Maps.";
 
 "driving_options_title" = "خيارات رسم المسار";
 

--- a/iphone/Maps/LocalizedStrings/az.lproj/Localizable.strings
+++ b/iphone/Maps/LocalizedStrings/az.lproj/Localizable.strings
@@ -923,6 +923,10 @@
 /* "traffic" as in "road congestion" */
 "traffic_data_unavailable" = "Nəqliyyat məlumatları mövcud deyil";
 
+"enable_logging" = "Girişi aktivləşdirin";
+
+"log_file_size" = "Giriş faylının ölçüsü: %@";
+
 "transliteration_title" = "Latın transliterasiyası";
 
 /* Subway exits for public transport marks on the map */
@@ -1050,6 +1054,8 @@
 "power_managment_setting_auto" = "Avtomatik";
 
 "power_managment_setting_manual_max" = "Maksimum enerji qənaəti";
+
+"enable_logging_warning_message" = "Yardım dialoq qutusunda “Problemi bildir” istifadə etməklə probleminizlə bağlı ətraflı diaqnostik jurnalları qeyd etmək və bizə göndərmək üçün bu seçimi müvəqqəti aktivləşdirin. Qeydlərə məkan məlumatı daxil ola bilər";
 
 "driving_options_title" = "Marşrutlaşdırma seçimləri";
 

--- a/iphone/Maps/LocalizedStrings/be.lproj/Localizable.strings
+++ b/iphone/Maps/LocalizedStrings/be.lproj/Localizable.strings
@@ -923,6 +923,10 @@
 /* "traffic" as in "road congestion" */
 "traffic_data_unavailable" = "Інфармацыі пра рух няма";
 
+"enable_logging" = "Уключыць вядзенне журналу";
+
+"log_file_size" = "Памер файла журнала: %@";
+
 "transliteration_title" = "Транслітарацыя лацінкай";
 
 /* Subway exits for public transport marks on the map */
@@ -1050,6 +1054,8 @@
 "power_managment_setting_auto" = "Аўтаматычна";
 
 "power_managment_setting_manual_max" = "Максімальнае захаванне энергіі";
+
+"enable_logging_warning_message" = "Опцыя ўключае запіс журнала падзей для мэтаў дыягностыкі. Гэта можа дапамагчы нашай камандзе вырашаць праблемы з праграмай. Уключайце гэтую опцыю часова, каб запісаць і паслаць нам дэталёвую інфармацыю пра знойденую вамі праблему праз кнопку \"Паведаміць аб памылцы\".";
 
 "driving_options_title" = "Налады пракладкі маршрута";
 

--- a/iphone/Maps/LocalizedStrings/bg.lproj/Localizable.strings
+++ b/iphone/Maps/LocalizedStrings/bg.lproj/Localizable.strings
@@ -923,6 +923,10 @@
 /* "traffic" as in "road congestion" */
 "traffic_data_unavailable" = "Няма налични данни за трафика";
 
+"enable_logging" = "Активиране на запис на дневник";
+
+"log_file_size" = "Размер на регистрационния файл: %@";
+
 "transliteration_title" = "Латинска транслитерация";
 
 /* Subway exits for public transport marks on the map */
@@ -1050,6 +1054,8 @@
 "power_managment_setting_auto" = "Автоматично";
 
 "power_managment_setting_manual_max" = "Максимално пестене на енергия";
+
+"enable_logging_warning_message" = "Тази настройка е разрешена, за да се записват действия за диагностични цели, които помагат на нашия екип да идентифицира проблеми с приложението. Временно активирайте тази настройка само за изпращане на подробна информация за проблема, който сте открили с приложението.";
 
 "driving_options_title" = "Опции за маршрутизация";
 

--- a/iphone/Maps/LocalizedStrings/ca.lproj/Localizable.strings
+++ b/iphone/Maps/LocalizedStrings/ca.lproj/Localizable.strings
@@ -923,6 +923,10 @@
 /* "traffic" as in "road congestion" */
 "traffic_data_unavailable" = "No hi ha dades de trànsit disponibles.";
 
+"enable_logging" = "Activa el registre";
+
+"log_file_size" = "Mida del fitxer de registre: %@";
+
 "transliteration_title" = "Translitertació a l'alfabet llatí";
 
 /* Subway exits for public transport marks on the map */
@@ -1050,6 +1054,8 @@
 "power_managment_setting_auto" = "Automàtic";
 
 "power_managment_setting_manual_max" = "Estalvi d'energia màxim";
+
+"enable_logging_warning_message" = "L'opció activa el registre amb finalitats de diagnòstic. Pot ser útil per al nostre equip per a identificar problemes amb l'aplicació. Activeu aquesta opció temporalment per a enregistgrar i enviar-nos informes detallats sobre el vostre problema.";
 
 "driving_options_title" = "Opcions de la ruta";
 

--- a/iphone/Maps/LocalizedStrings/cs.lproj/Localizable.strings
+++ b/iphone/Maps/LocalizedStrings/cs.lproj/Localizable.strings
@@ -923,6 +923,10 @@
 /* "traffic" as in "road congestion" */
 "traffic_data_unavailable" = "Data o provozu nejsou k dispozici";
 
+"enable_logging" = "Povolit protokolování";
+
+"log_file_size" = "Velikost souboru protokolu: %@";
+
 "transliteration_title" = "Přepis do latinky";
 
 /* Subway exits for public transport marks on the map */
@@ -1050,6 +1054,8 @@
 "power_managment_setting_auto" = "Automatický";
 
 "power_managment_setting_manual_max" = "Maximální šetření baterií";
+
+"enable_logging_warning_message" = "Možnost zapne odesílání dat za diagnostickými účely. To nám pomáhá při řešení problémů s aplikací. Dočasně povolte pro nahrávání a odesílání logů našemu týmu o vašem problému.";
 
 "driving_options_title" = "Možnosti trasy";
 

--- a/iphone/Maps/LocalizedStrings/da.lproj/Localizable.strings
+++ b/iphone/Maps/LocalizedStrings/da.lproj/Localizable.strings
@@ -923,6 +923,10 @@
 /* "traffic" as in "road congestion" */
 "traffic_data_unavailable" = "Trafikdata er ikke tilgængelige";
 
+"enable_logging" = "Aktiver logføring";
+
+"log_file_size" = "Logfilens størrelse: %@";
+
 "transliteration_title" = "Translitteration til latinsk";
 
 /* Subway exits for public transport marks on the map */
@@ -1050,6 +1054,8 @@
 "power_managment_setting_auto" = "Automatisk";
 
 "power_managment_setting_manual_max" = "Maksimum strømbesparelse";
+
+"enable_logging_warning_message" = "Indstillingen aktiverer logning til diagnostiske formål. Det kan være nyttigt for vores supportere, der fejlfinder problemer med appen. Aktiver kun denne mulighed på anmodning fra Organic Maps support.";
 
 "driving_options_title" = "Køre muligheder";
 

--- a/iphone/Maps/LocalizedStrings/de.lproj/Localizable.strings
+++ b/iphone/Maps/LocalizedStrings/de.lproj/Localizable.strings
@@ -923,6 +923,10 @@
 /* "traffic" as in "road congestion" */
 "traffic_data_unavailable" = "Verkehrsdaten sind nicht verfügbar";
 
+"enable_logging" = "Protokollierung aktivieren";
+
+"log_file_size" = "Größe der Protokolldatei: %@";
+
 "transliteration_title" = "Transliteration ins Lateinische";
 
 /* Subway exits for public transport marks on the map */
@@ -1050,6 +1054,8 @@
 "power_managment_setting_auto" = "Auto";
 
 "power_managment_setting_manual_max" = "Maximale Stromsparung";
+
+"enable_logging_warning_message" = "Diese Option wird aktiviert, um Aktivitäten zwecks Diagnostik aufzuzeichnen. Das hilft unserem Team, Probleme mit der App zu erkennen. Aktivieren Sie diese Option, reproduzieren Sie das Problem und senden Sie die Protokolle über die Schaltfläche \"Fehler melden\" an uns.";
 
 "driving_options_title" = "Routenbeschränkungen";
 

--- a/iphone/Maps/LocalizedStrings/el.lproj/Localizable.strings
+++ b/iphone/Maps/LocalizedStrings/el.lproj/Localizable.strings
@@ -923,6 +923,10 @@
 /* "traffic" as in "road congestion" */
 "traffic_data_unavailable" = "Οι πληροφορίες για την κίνηση δεν είναι διαθέσιμες";
 
+"enable_logging" = "Ενεργοποίηση δυνατότητας καταγραφής";
+
+"log_file_size" = "Μέγεθος αρχείου καταγραφής: %@";
+
 "transliteration_title" = "Μεταγραφή στα Λατινικά";
 
 /* Subway exits for public transport marks on the map */
@@ -1050,6 +1054,8 @@
 "power_managment_setting_auto" = "Αυτόματα";
 
 "power_managment_setting_manual_max" = "Πάντα";
+
+"enable_logging_warning_message" = "Αυτή η λειτουργία είναι ενεργοποιημένη για την καταγραφή ενεργειών για διαγνωστικούς σκοπούς. Αυτό βοηθά την ομάδα να εντοπίζει προβλήματα με την εφαρμογή. Να ενεργοποιείτε τη λειτουργία μόνο κατόπιν αιτήματος της υποστήριξης του Organic Maps.";
 
 "driving_options_title" = "Ρυθμίσεις δρομολόγησης";
 

--- a/iphone/Maps/LocalizedStrings/en-GB.lproj/Localizable.strings
+++ b/iphone/Maps/LocalizedStrings/en-GB.lproj/Localizable.strings
@@ -923,6 +923,10 @@
 /* "traffic" as in "road congestion" */
 "traffic_data_unavailable" = "Traffic data is not available";
 
+"enable_logging" = "Enable logging";
+
+"log_file_size" = "Log file size: %@";
+
 "transliteration_title" = "Transliteration into Latin alphabet";
 
 /* Subway exits for public transport marks on the map */
@@ -1050,6 +1054,8 @@
 "power_managment_setting_auto" = "When battery is low";
 
 "power_managment_setting_manual_max" = "Always";
+
+"enable_logging_warning_message" = "Enable this option temporarily to record and manually send detailed diagnostic logs about your issue to us using \"Report a bug\" in the Help dialog. Logs may include location info.";
 
 "driving_options_title" = "Routing options";
 

--- a/iphone/Maps/LocalizedStrings/en.lproj/Localizable.strings
+++ b/iphone/Maps/LocalizedStrings/en.lproj/Localizable.strings
@@ -923,6 +923,10 @@
 /* "traffic" as in "road congestion" */
 "traffic_data_unavailable" = "Traffic data is not available";
 
+"enable_logging" = "Enable logging";
+
+"log_file_size" = "Log file size: %@";
+
 "transliteration_title" = "Transliteration into Latin alphabet";
 
 /* Subway exits for public transport marks on the map */
@@ -1050,6 +1054,8 @@
 "power_managment_setting_auto" = "When battery is low";
 
 "power_managment_setting_manual_max" = "Always";
+
+"enable_logging_warning_message" = "Enable this option temporarily to record and manually send detailed diagnostic logs about your issue to us using \"Report a bug\" in the Help dialog. Logs may include location info.";
 
 "driving_options_title" = "Routing options";
 

--- a/iphone/Maps/LocalizedStrings/es-MX.lproj/Localizable.strings
+++ b/iphone/Maps/LocalizedStrings/es-MX.lproj/Localizable.strings
@@ -923,6 +923,10 @@
 /* "traffic" as in "road congestion" */
 "traffic_data_unavailable" = "Los datos de tráfico no están disponibles";
 
+"enable_logging" = "Habilitar historial";
+
+"log_file_size" = "Tamaño del archivo de registro: %@";
+
 "transliteration_title" = "Transliteración al alfabeto latino";
 
 /* Subway exits for public transport marks on the map */
@@ -1050,6 +1054,8 @@
 "power_managment_setting_auto" = "Automático";
 
 "power_managment_setting_manual_max" = "Máximo ahorro de energía";
+
+"enable_logging_warning_message" = "Esta opción está habilitada para las acciones de registro con fines de diagnóstico. Esto ayuda a nuestro equipo a identificar problemas con la aplicación. Habilite la opción solo a petición del apoyo de Organic Maps.";
 
 "driving_options_title" = "Ajustes de desvío";
 

--- a/iphone/Maps/LocalizedStrings/es.lproj/Localizable.strings
+++ b/iphone/Maps/LocalizedStrings/es.lproj/Localizable.strings
@@ -923,6 +923,10 @@
 /* "traffic" as in "road congestion" */
 "traffic_data_unavailable" = "Los datos de tráfico no están disponibles";
 
+"enable_logging" = "Habilitar historial";
+
+"log_file_size" = "Tamaño del archivo de registro: %@";
+
 "transliteration_title" = "Transliteración al latín";
 
 /* Subway exits for public transport marks on the map */
@@ -1050,6 +1054,8 @@
 "power_managment_setting_auto" = "Automático";
 
 "power_managment_setting_manual_max" = "Ahorro de energía máximo";
+
+"enable_logging_warning_message" = "Esta opción está habilitada para las acciones de registro con fines de diagnóstico. Esto ayuda a nuestro equipo a identificar problemas con la aplicación. Habilite la opción solo a petición del apoyo de Organic Maps.";
 
 "driving_options_title" = "Opciones de enrutamiento";
 

--- a/iphone/Maps/LocalizedStrings/et.lproj/Localizable.strings
+++ b/iphone/Maps/LocalizedStrings/et.lproj/Localizable.strings
@@ -923,6 +923,10 @@
 /* "traffic" as in "road congestion" */
 "traffic_data_unavailable" = "Liiklusinfo ei ole saadaval";
 
+"enable_logging" = "Luba logimine";
+
+"log_file_size" = "Logifaili suurus: %@";
+
 "transliteration_title" = "Transliteratsioon ladina keelde";
 
 /* Subway exits for public transport marks on the map */
@@ -1050,6 +1054,8 @@
 "power_managment_setting_auto" = "Automaatne";
 
 "power_managment_setting_manual_max" = "Maksimaalne energiasääst";
+
+"enable_logging_warning_message" = "See valik lülitab sisse logimise diagnostilistel eesmärkidel. Meie meeskonnale võib olla abi rakendusega seotud probleemide tõrkeotsingul. Lubage see valik ajutiselt, et salvestada ja saata meile oma probleemi üksikasjalikud logid.";
 
 "driving_options_title" = "Marsruutimise valikud";
 

--- a/iphone/Maps/LocalizedStrings/eu.lproj/Localizable.strings
+++ b/iphone/Maps/LocalizedStrings/eu.lproj/Localizable.strings
@@ -923,6 +923,10 @@
 /* "traffic" as in "road congestion" */
 "traffic_data_unavailable" = "Trafiko datuak ez daude eskuragarri";
 
+"enable_logging" = "Historia gaitu";
+
+"log_file_size" = "Erregistro fitxategiaren tamaina: %@";
+
 "transliteration_title" = "Latinezko transliterazioa";
 
 /* Subway exits for public transport marks on the map */
@@ -1050,6 +1054,8 @@
 "power_managment_setting_auto" = "Automatikoa";
 
 "power_managment_setting_manual_max" = "Energia aurrezpen handiena";
+
+"enable_logging_warning_message" = "Aukera hau diagnostiko helburua duten erregistro ekintzetarako gaituta dago. Honek gure taldeari aplikazioarekin arazoak identifikatzen laguntzen dio. Gaitu aukera Organic Maps laguntzari eskatuta soilik.";
 
 "driving_options_title" = "Bideratzeko aukerak";
 

--- a/iphone/Maps/LocalizedStrings/fa.lproj/Localizable.strings
+++ b/iphone/Maps/LocalizedStrings/fa.lproj/Localizable.strings
@@ -923,6 +923,10 @@
 /* "traffic" as in "road congestion" */
 "traffic_data_unavailable" = "اطلاعات ترافیکی موجود نیست";
 
+"enable_logging" = "ورود به سیستم را فعال کنید";
+
+"log_file_size" = "اندازه فایل گزارش: %@";
+
 "transliteration_title" = "ترجمه به لاتین";
 
 /* Subway exits for public transport marks on the map */
@@ -1050,6 +1054,8 @@
 "power_managment_setting_auto" = "خودکار";
 
 "power_managment_setting_manual_max" = "حداکثر ذخیره انرژی";
+
+"enable_logging_warning_message" = "این گزینه ثبت گزارش را برای اهداف تشخیصی فعال می‌کند. برای کارکنان بخش پشتیبانی که مشکلات برنامه را عیب یابی می‌کنند، مفید باشد. این گزینه را تنها در صورت درخواست پشتیبانی Organic Maps فعال کنید.";
 
 "driving_options_title" = "گزینه‌های رانندگی";
 

--- a/iphone/Maps/LocalizedStrings/fi.lproj/Localizable.strings
+++ b/iphone/Maps/LocalizedStrings/fi.lproj/Localizable.strings
@@ -923,6 +923,10 @@
 /* "traffic" as in "road congestion" */
 "traffic_data_unavailable" = "Liikennetietoja ei ole saatavilla";
 
+"enable_logging" = "Ota loki käyttöön";
+
+"log_file_size" = "Lokitiedoston koko: %@";
+
 "transliteration_title" = "Translitterointi latinalaisiksi aakkosiksi";
 
 /* Subway exits for public transport marks on the map */
@@ -1050,6 +1054,8 @@
 "power_managment_setting_auto" = "Automaattinen";
 
 "power_managment_setting_manual_max" = "Täysi virransäästö";
+
+"enable_logging_warning_message" = "Valinta ottaa käyttöön lokikirjaukset diagnostiikkaa varten. Se voi auttaa tukihenkilöstöämme, kun he korjaavat sovelluksen ongelmia. Ota tämä ominaisuus käyttöön vain, jos Organic Maps:n tuki pyytää.";
 
 "driving_options_title" = "Reititysvalinnat";
 

--- a/iphone/Maps/LocalizedStrings/fr.lproj/Localizable.strings
+++ b/iphone/Maps/LocalizedStrings/fr.lproj/Localizable.strings
@@ -923,6 +923,10 @@
 /* "traffic" as in "road congestion" */
 "traffic_data_unavailable" = "Les données de circulation ne sont pas disponibles";
 
+"enable_logging" = "Activer le journal";
+
+"log_file_size" = "Taille du fichier journal : %@";
+
 "transliteration_title" = "Translittération en latin";
 
 /* Subway exits for public transport marks on the map */
@@ -1050,6 +1054,8 @@
 "power_managment_setting_auto" = "Automatique";
 
 "power_managment_setting_manual_max" = "Économie d'énergie maximale";
+
+"enable_logging_warning_message" = "Cette option est activée pour l'identification des actions à des fins de diagnostic. Cela aide l’équipe à identifier les problèmes liés à l’application. Activez cette option uniquement à la demande du support Organic Maps.";
 
 "driving_options_title" = "Paramètres des itinéraires";
 

--- a/iphone/Maps/LocalizedStrings/he.lproj/Localizable.strings
+++ b/iphone/Maps/LocalizedStrings/he.lproj/Localizable.strings
@@ -923,6 +923,10 @@
 /* "traffic" as in "road congestion" */
 "traffic_data_unavailable" = "מידע על עומס תנועה לא זמין.";
 
+"enable_logging" = "הפעל logging";
+
+"log_file_size" = "גודל קובץ יומן: %@";
+
 "transliteration_title" = "תעתיק לאותיות לטיניות";
 
 /* Subway exits for public transport marks on the map */
@@ -1050,6 +1054,8 @@
 "power_managment_setting_auto" = "כשהסוללה חלשה";
 
 "power_managment_setting_manual_max" = "תמיד";
+
+"enable_logging_warning_message" = "הפעל אפשרות זו כדי לתעד ובאופן ידני לשלוח אלינו פרטים דיאגנוסטיים על הבעיה שלך בעזרת הכפתור \"דווח על באג\" בתפריט עזרה. הפרטים עשויים לכלול מידע על מיקום.";
 
 "driving_options_title" = "אפשרויות מסלול";
 

--- a/iphone/Maps/LocalizedStrings/hi.lproj/Localizable.strings
+++ b/iphone/Maps/LocalizedStrings/hi.lproj/Localizable.strings
@@ -923,6 +923,10 @@
 /* "traffic" as in "road congestion" */
 "traffic_data_unavailable" = "Traffic data is not available";
 
+"enable_logging" = "लॉगिंग करने देना";
+
+"log_file_size" = "लॉग फ़ाइल का आकार: %@";
+
 "transliteration_title" = "लैटिन में लिप्यंतरण";
 
 /* Subway exits for public transport marks on the map */
@@ -1050,6 +1054,8 @@
 "power_managment_setting_auto" = "जब बैटरी कम हो";
 
 "power_managment_setting_manual_max" = "हमेशा";
+
+"enable_logging_warning_message" = "सहायता संवाद में \"बग की रिपोर्ट करें\" का उपयोग करके हमें अपनी समस्या के बारे में विस्तृत डायग्नोस्टिक लॉग रिकॉर्ड करने और मैन्युअल रूप से भेजने के लिए इस विकल्प को अस्थायी रूप से सक्षम करें। लॉग में स्थान की जानकारी शामिल हो सकती है.";
 
 "driving_options_title" = "रूटिंग विकल्प";
 

--- a/iphone/Maps/LocalizedStrings/hu.lproj/Localizable.strings
+++ b/iphone/Maps/LocalizedStrings/hu.lproj/Localizable.strings
@@ -923,6 +923,10 @@
 /* "traffic" as in "road congestion" */
 "traffic_data_unavailable" = "Forgalmi adatok nem állnak rendelkezésre";
 
+"enable_logging" = "Naplózás engedélyezése";
+
+"log_file_size" = "Naplófájl mérete: %@";
+
 "transliteration_title" = "Átírás latin betűkre";
 
 /* Subway exits for public transport marks on the map */
@@ -1050,6 +1054,8 @@
 "power_managment_setting_auto" = "Automatikus";
 
 "power_managment_setting_manual_max" = "Maximális energiatakarékosság";
+
+"enable_logging_warning_message" = "Az opció bekapcsolja a diagnosztikai célú naplózást. Hasznos lehet a terméktámogatási csapatunknak, akik elhárítják az alkalmazás hibáit. Csak az Organic Maps terméktámogatásának kérésére kapcsold be ezt az opciót.";
 
 "driving_options_title" = "Útvonaltervezési lehetőségek";
 

--- a/iphone/Maps/LocalizedStrings/id.lproj/Localizable.strings
+++ b/iphone/Maps/LocalizedStrings/id.lproj/Localizable.strings
@@ -923,6 +923,10 @@
 /* "traffic" as in "road congestion" */
 "traffic_data_unavailable" = "Data lalu lintas tidak tersedia";
 
+"enable_logging" = "Aktifkan pencatatan";
+
+"log_file_size" = "Ukuran file log: %@";
+
 "transliteration_title" = "Transliterasi ke dalam bahasa Latin";
 
 /* Subway exits for public transport marks on the map */
@@ -1050,6 +1054,8 @@
 "power_managment_setting_auto" = "Otomatis";
 
 "power_managment_setting_manual_max" = "Hemat daya maksimum";
+
+"enable_logging_warning_message" = "Opsi ini mengaktifkan pencatatan untuk tujuan diagnostik. Bisa amat membantu bagi staf dukungan kami yang memecahkan masalah dalam aplikasi. Aktifkan opsi ini hanya saat diminta oleh dukungan Organic Maps.";
 
 "driving_options_title" = "Pilihan berkendara";
 

--- a/iphone/Maps/LocalizedStrings/it.lproj/Localizable.strings
+++ b/iphone/Maps/LocalizedStrings/it.lproj/Localizable.strings
@@ -923,6 +923,10 @@
 /* "traffic" as in "road congestion" */
 "traffic_data_unavailable" = "Dati sul traffico non disponibili";
 
+"enable_logging" = "Abilita i registri";
+
+"log_file_size" = "Dimensione del file di registro: %@";
+
 "transliteration_title" = "Trascrizione in latino";
 
 /* Subway exits for public transport marks on the map */
@@ -1050,6 +1054,8 @@
 "power_managment_setting_auto" = "Automatico";
 
 "power_managment_setting_manual_max" = "Massimo risparmio energetico";
+
+"enable_logging_warning_message" = "L'opzione attiva i registri per scopi diagnostici. Può essere utile al nostro team per risolvere i problemi dell'app. Abilita temporaneamente questa opzione per registrare e inviarci registri dettagliati sul tuo problema.";
 
 "driving_options_title" = "Impostazioni di deviazione";
 

--- a/iphone/Maps/LocalizedStrings/ja.lproj/Localizable.strings
+++ b/iphone/Maps/LocalizedStrings/ja.lproj/Localizable.strings
@@ -923,6 +923,10 @@
 /* "traffic" as in "road congestion" */
 "traffic_data_unavailable" = "交通データは利用できません";
 
+"enable_logging" = "ログを有効化";
+
+"log_file_size" = "ログファイルのサイズ: %@";
+
 "transliteration_title" = "ラテン文字への翻字";
 
 /* Subway exits for public transport marks on the map */
@@ -1050,6 +1054,8 @@
 "power_managment_setting_auto" = "自動";
 
 "power_managment_setting_manual_max" = "最大電力節約";
+
+"enable_logging_warning_message" = "このオプションは診断目的でのデータ記録を有効にします。これはこのアプリケーションのトラブルシューティングを担当する当社のサポートスタッフの助けになります。このオプションはOrganic Mapsにリクエストされた場合にのみ有効にしてください。";
 
 "driving_options_title" = "経路オプション";
 

--- a/iphone/Maps/LocalizedStrings/ko.lproj/Localizable.strings
+++ b/iphone/Maps/LocalizedStrings/ko.lproj/Localizable.strings
@@ -923,6 +923,10 @@
 /* "traffic" as in "road congestion" */
 "traffic_data_unavailable" = "교통 데이터를 사용할 수 없습니다";
 
+"enable_logging" = "로깅 사용";
+
+"log_file_size" = "로그 파일 크기: %@";
+
 "transliteration_title" = "라틴어로 음역";
 
 /* Subway exits for public transport marks on the map */
@@ -1050,6 +1054,8 @@
 "power_managment_setting_auto" = "자동";
 
 "power_managment_setting_manual_max" = "최대 전력 절약";
+
+"enable_logging_warning_message" = "이 옵션은 진단을 목적으로 로그를 엽니다 이를 통해 앱에 대한 문제를 분석하는 우리의 스탭을 도울 수 있습니다 이 옵션은 오직 Organic Maps 지원 요청에서만 가능합니다.";
 
 "driving_options_title" = "운전 옵션";
 

--- a/iphone/Maps/LocalizedStrings/mr.lproj/Localizable.strings
+++ b/iphone/Maps/LocalizedStrings/mr.lproj/Localizable.strings
@@ -923,6 +923,10 @@
 /* "traffic" as in "road congestion" */
 "traffic_data_unavailable" = "वाहतूक माहिती उपलब्ध नाही";
 
+"enable_logging" = "लॉग चालू करा";
+
+"log_file_size" = "लॉग फाइल आकार: %@";
+
 "transliteration_title" = "लॅटिनमध्ये (इंग्रजीची अक्षरे) लिप्यंतरण";
 
 /* Subway exits for public transport marks on the map */
@@ -1050,6 +1054,8 @@
 "power_managment_setting_auto" = "स्वयंचलित";
 
 "power_managment_setting_manual_max" = "कमाल वीज बचत";
+
+"enable_logging_warning_message" = "निदान करण्याकरिता हा पर्याय लॉगिंग चालू करतो. ह्याने ऍपच्या समस्यांचे निवारण करणे आम्हाला उपयुक्त ठरू शकते. तुमच्या समस्येबद्दल तपशीलवार नोंदी रेकॉर्ड करण्यासाठी आणि आम्हाला पाठवण्यासाठी हा पर्याय तात्पुरता चालू करा.";
 
 "driving_options_title" = "मार्गशोधी पर्याय";
 

--- a/iphone/Maps/LocalizedStrings/nb.lproj/Localizable.strings
+++ b/iphone/Maps/LocalizedStrings/nb.lproj/Localizable.strings
@@ -923,6 +923,10 @@
 /* "traffic" as in "road congestion" */
 "traffic_data_unavailable" = "Trafikkdata er ikke tilgjengelig";
 
+"enable_logging" = "Aktiver loggføring";
+
+"log_file_size" = "Loggfilstørrelse: %@";
+
 "transliteration_title" = "Omskrivning til latin";
 
 /* Subway exits for public transport marks on the map */
@@ -1050,6 +1054,8 @@
 "power_managment_setting_auto" = "Automatisk";
 
 "power_managment_setting_manual_max" = "Maksimum strømsparing";
+
+"enable_logging_warning_message" = "Alternativet slår på logging for diagnostiske formål. Det kan være nyttig for våre supportpersonale som feilsøker problemer med appen. Aktiver dette alternativet bare på forespørsel fra Organic Maps-brukerstøtte.";
 
 "driving_options_title" = "Kjørealternativer";
 

--- a/iphone/Maps/LocalizedStrings/nl.lproj/Localizable.strings
+++ b/iphone/Maps/LocalizedStrings/nl.lproj/Localizable.strings
@@ -923,6 +923,10 @@
 /* "traffic" as in "road congestion" */
 "traffic_data_unavailable" = "Verkeersgegevens zijn niet beschikbaar";
 
+"enable_logging" = "Logboekregistratie inschakelen";
+
+"log_file_size" = "Grootte logbestand: %@";
+
 "transliteration_title" = "Transliteratie in het Latijnse alfabet";
 
 /* Subway exits for public transport marks on the map */
@@ -1050,6 +1054,8 @@
 "power_managment_setting_auto" = "Wanneer batterij bijna leeg is";
 
 "power_managment_setting_manual_max" = "Maximale energiebesparing";
+
+"enable_logging_warning_message" = "Deze optie is ingeschakeld voor logboekregistraties voor diagnostische doeleinden. Het helpt bij het identificeren van problemen met de applicatie. Schakel de optie alleen in op verzoek van Organic Maps-ondersteuning.";
 
 "driving_options_title" = "Route-instellingen";
 

--- a/iphone/Maps/LocalizedStrings/pl.lproj/Localizable.strings
+++ b/iphone/Maps/LocalizedStrings/pl.lproj/Localizable.strings
@@ -923,6 +923,10 @@
 /* "traffic" as in "road congestion" */
 "traffic_data_unavailable" = "Dane o ruchu są niedostępne";
 
+"enable_logging" = "Włącz zbieranie danych";
+
+"log_file_size" = "Rozmiar pliku dziennika: %@";
+
 "transliteration_title" = "Transkrypcja na alfabet łaciński";
 
 /* Subway exits for public transport marks on the map */
@@ -1050,6 +1054,8 @@
 "power_managment_setting_auto" = "Automatycznie";
 
 "power_managment_setting_manual_max" = "Maksymalna oszczędność energii";
+
+"enable_logging_warning_message" = "Ta opcja zostaje włączona do zbierania danych działań w celach diagnostycznych. Pomaga to zespołowi zidentyfikować problemy z aplikacją. Włączaj opcję tylko na żądanie wsparcia technicznego Organic Maps.";
 
 "driving_options_title" = "Ustawienia nawigacji";
 

--- a/iphone/Maps/LocalizedStrings/pt-BR.lproj/Localizable.strings
+++ b/iphone/Maps/LocalizedStrings/pt-BR.lproj/Localizable.strings
@@ -923,6 +923,10 @@
 /* "traffic" as in "road congestion" */
 "traffic_data_unavailable" = "Não existem dados de tráfego";
 
+"enable_logging" = "Ativar o histórico";
+
+"log_file_size" = "Tamanho do arquivo de registro: %@";
+
 "transliteration_title" = "Transliteração para alfabeto latino";
 
 /* Subway exits for public transport marks on the map */
@@ -1050,6 +1054,8 @@
 "power_managment_setting_auto" = "Automático";
 
 "power_managment_setting_manual_max" = "Máxima economia de energia";
+
+"enable_logging_warning_message" = "A opção ativa logging para realizar diagnósticos. Pode ser útil para nossa equipe de suporte que estão solucionando problemas com o aplicativo. Ative esta opção apenas ao ser solicitado pelo suporte do Organic Maps.";
 
 "driving_options_title" = "Opções de trajeto";
 

--- a/iphone/Maps/LocalizedStrings/pt.lproj/Localizable.strings
+++ b/iphone/Maps/LocalizedStrings/pt.lproj/Localizable.strings
@@ -923,6 +923,10 @@
 /* "traffic" as in "road congestion" */
 "traffic_data_unavailable" = "Os dados de tráfego não estão disponíveis";
 
+"enable_logging" = "Ativar o histórico";
+
+"log_file_size" = "Tamanho do ficheiro de registo: %@";
+
 "transliteration_title" = "Transliteração para o latim";
 
 /* Subway exits for public transport marks on the map */
@@ -1050,6 +1054,8 @@
 "power_managment_setting_auto" = "Automático";
 
 "power_managment_setting_manual_max" = "Máxima economia de energia";
+
+"enable_logging_warning_message" = "Esta opção ativa o registo das ações para diagnóstico. Pode ser útil para os programadores descobrirem o problema na aplicação. Ative esta opção apenas a pedido dos programadores do Organic Maps.";
 
 "driving_options_title" = "Configurações de direção";
 

--- a/iphone/Maps/LocalizedStrings/ro.lproj/Localizable.strings
+++ b/iphone/Maps/LocalizedStrings/ro.lproj/Localizable.strings
@@ -923,6 +923,10 @@
 /* "traffic" as in "road congestion" */
 "traffic_data_unavailable" = "Datele privind traficul nu sunt disponibile";
 
+"enable_logging" = "Activează jurnalizarea";
+
+"log_file_size" = "Dimensiunea fișierului jurnal: %@";
+
 "transliteration_title" = "Transcrie în alfabet latin";
 
 /* Subway exits for public transport marks on the map */
@@ -1050,6 +1054,8 @@
 "power_managment_setting_auto" = "Automat";
 
 "power_managment_setting_manual_max" = "Economisire maximă a energiei";
+
+"enable_logging_warning_message" = "Opțiunea activează jurnalizarea în scopuri de diagnosticare. Aceasta poate fi utilă echipei noastre pentru a rezolva problemele cu aplicația. Activează temporar această opțiune pentru a înregistra și a ne trimite jurnale detaliate despre problema ta.";
 
 "driving_options_title" = "Opțiuni de ocolire";
 

--- a/iphone/Maps/LocalizedStrings/ru.lproj/Localizable.strings
+++ b/iphone/Maps/LocalizedStrings/ru.lproj/Localizable.strings
@@ -923,6 +923,10 @@
 /* "traffic" as in "road congestion" */
 "traffic_data_unavailable" = "Данные о пробках недоступны";
 
+"enable_logging" = "Включить запись логов";
+
+"log_file_size" = "Размер файла логов: %@";
+
 "transliteration_title" = "Латинская транслитерация";
 
 /* Subway exits for public transport marks on the map */
@@ -1050,6 +1054,8 @@
 "power_managment_setting_auto" = "Авто";
 
 "power_managment_setting_manual_max" = "Максимальное энергосбережение";
+
+"enable_logging_warning_message" = "Данная настройка включается для записи действий в целях диагностики, чтобы помочь нашей команде выявить проблемы с приложением. Временно включайте эту настройку только для отправки детальной информации о найденной вами проблеме в приложении через кнопку \"Сообщить о проблеме\".";
 
 "driving_options_title" = "Настройки объезда";
 

--- a/iphone/Maps/LocalizedStrings/sk.lproj/Localizable.strings
+++ b/iphone/Maps/LocalizedStrings/sk.lproj/Localizable.strings
@@ -923,6 +923,10 @@
 /* "traffic" as in "road congestion" */
 "traffic_data_unavailable" = "Dopravné informácie nie sú k dispozícii";
 
+"enable_logging" = "Zapnúť zaznamenávanie";
+
+"log_file_size" = "Veľkosť súboru protokolu: %@";
+
 "transliteration_title" = "Prepis do latinky";
 
 /* Subway exits for public transport marks on the map */
@@ -1050,6 +1054,8 @@
 "power_managment_setting_auto" = "Automaticky";
 
 "power_managment_setting_manual_max" = "Maximálna úspora batérie";
+
+"enable_logging_warning_message" = "Týmto zapnete záznamenávanie diagnostických informácií, ktoré môžete poslať našej technickej podpore v prípade problémov s aplikáciou. Záznam môže obsahovať údaje o vašej polohe.";
 
 "driving_options_title" = "Možnosti trasy";
 

--- a/iphone/Maps/LocalizedStrings/sv.lproj/Localizable.strings
+++ b/iphone/Maps/LocalizedStrings/sv.lproj/Localizable.strings
@@ -923,6 +923,10 @@
 /* "traffic" as in "road congestion" */
 "traffic_data_unavailable" = "Trafikdata är inte tillgänglig";
 
+"enable_logging" = "Aktivera loggning";
+
+"log_file_size" = "Loggfilens storlek: %@";
+
 "transliteration_title" = "Transkribering till latin";
 
 /* Subway exits for public transport marks on the map */
@@ -1050,6 +1054,8 @@
 "power_managment_setting_auto" = "Automatiskt";
 
 "power_managment_setting_manual_max" = "Maximal energibesparing";
+
+"enable_logging_warning_message" = "Denna funktion aktiveras för loggning av åtgärder för diagnostiska ändamål. Detta hjälper laget att identifiera problem med applikationen. Slå på funktionen endast på begäran av Organic Maps supporttjänst.";
 
 "driving_options_title" = "Omvägsinställningar";
 

--- a/iphone/Maps/LocalizedStrings/sw.lproj/Localizable.strings
+++ b/iphone/Maps/LocalizedStrings/sw.lproj/Localizable.strings
@@ -923,6 +923,10 @@
 /* "traffic" as in "road congestion" */
 "traffic_data_unavailable" = "Traffic data is not available";
 
+"enable_logging" = "Enable logging";
+
+"log_file_size" = "Ukubwa wa faili ya kumbukumbu: %@";
+
 "transliteration_title" = "Tafsiri kwa lugha ya Kilatini";
 
 /* Subway exits for public transport marks on the map */
@@ -1050,6 +1054,8 @@
 "power_managment_setting_auto" = "Kiotomatiki";
 
 "power_managment_setting_manual_max" = "Upeo wa kuhifadhi nishati";
+
+"enable_logging_warning_message" = "Chaguo huwasha data kwa madhumuni ya uchunguzi. Itakuwa muhimu kwa wafanyakazi wetu ambao wanatatua matatizo ya programu. Washa chaguo hili kwa maombi ya mhudumu wa Organic Maps tu.";
 
 "driving_options_title" = "Machaguo ya njia";
 

--- a/iphone/Maps/LocalizedStrings/th.lproj/Localizable.strings
+++ b/iphone/Maps/LocalizedStrings/th.lproj/Localizable.strings
@@ -923,6 +923,10 @@
 /* "traffic" as in "road congestion" */
 "traffic_data_unavailable" = "ไม่มีข้อมูลการจราจร";
 
+"enable_logging" = "เปิดใช้งานการเก็บล็อก";
+
+"log_file_size" = "ขนาดไฟล์บันทึก: %@";
+
 "transliteration_title" = "การทับศัพท์เป็นภาษาละติน";
 
 /* Subway exits for public transport marks on the map */
@@ -1050,6 +1054,8 @@
 "power_managment_setting_auto" = "อัตโนมัติ";
 
 "power_managment_setting_manual_max" = "ประหยัดพลังงานสูงสุด";
+
+"enable_logging_warning_message" = "ออปชันเพื่อเปิดการบันทึกประวัติการทำงานเพื่อการวินิจฉัย ประวัติดังกล่าวอาจเป็นประโยชน์กับทีมงานช่วยเหลือของเราที่คอยจัดการกับปัญหาที่เจอระหว่างแอปทำงาน โปรดเปิดออปชันดังกล่าวจากการร้องข้อการสนับสนุนจาก Organic Maps เท่านั้น";
 
 "driving_options_title" = "ทางเลือกเส้นทางขับขี่";
 

--- a/iphone/Maps/LocalizedStrings/tr.lproj/Localizable.strings
+++ b/iphone/Maps/LocalizedStrings/tr.lproj/Localizable.strings
@@ -923,6 +923,10 @@
 /* "traffic" as in "road congestion" */
 "traffic_data_unavailable" = "Trafik verileri kullanılamıyor";
 
+"enable_logging" = "Günlüğü etkinleştir";
+
+"log_file_size" = "Günlük dosyası boyutu: %@";
+
 "transliteration_title" = "Latin harf çevirisi";
 
 /* Subway exits for public transport marks on the map */
@@ -1050,6 +1054,8 @@
 "power_managment_setting_auto" = "Otomatik";
 
 "power_managment_setting_manual_max" = "Maksimum güç tasarrufu";
+
+"enable_logging_warning_message" = "Bu seçenek tanılama amacıyla günlüğe kaydetmeyi açar. Ekibimizin uygulamayla ilgili sorunları gidermesine yardımcı olabilir. Sorununuzla ilgili ayrıntılı günlükleri kaydetmek ve bize göndermek için bu seçeneği geçici olarak etkinleştirin.";
 
 "driving_options_title" = "Yönlendirme seçenekleri";
 

--- a/iphone/Maps/LocalizedStrings/uk.lproj/Localizable.strings
+++ b/iphone/Maps/LocalizedStrings/uk.lproj/Localizable.strings
@@ -923,6 +923,10 @@
 /* "traffic" as in "road congestion" */
 "traffic_data_unavailable" = "Дані про трафік недоступні";
 
+"enable_logging" = "Включити логіювання";
+
+"log_file_size" = "Розмір файлу журналу: %@.";
+
 "transliteration_title" = "Транслітерація латинськими літерами";
 
 /* Subway exits for public transport marks on the map */
@@ -1050,6 +1054,8 @@
 "power_managment_setting_auto" = "Автоматично";
 
 "power_managment_setting_manual_max" = "Максимальне енергозбереження";
+
+"enable_logging_warning_message" = "Дана опція вмикається для логування дій з метою діагностики. Це допомагає команді виявити проблеми з додатком. Тимчасово включайте цю настройку тільки для відправки детальної інформації про знайдену вами проблему в додатку через кнопку \"Сповістити про помилку\".";
 
 "driving_options_title" = "Налаштування об’їзду";
 

--- a/iphone/Maps/LocalizedStrings/vi.lproj/Localizable.strings
+++ b/iphone/Maps/LocalizedStrings/vi.lproj/Localizable.strings
@@ -923,6 +923,10 @@
 /* "traffic" as in "road congestion" */
 "traffic_data_unavailable" = "Dữ liệu giao thông không khả dụng";
 
+"enable_logging" = "Bật nhật ký";
+
+"log_file_size" = "Kích thước tệp nhật ký: %@";
+
 "transliteration_title" = "Chuyển ngữ sang chữ Latinh";
 
 /* Subway exits for public transport marks on the map */
@@ -1050,6 +1054,8 @@
 "power_managment_setting_auto" = "Tự động";
 
 "power_managment_setting_manual_max" = "Tiết kiệm năng lượng tối đa";
+
+"enable_logging_warning_message" = "Tùy chọn này được kích hoạt để ghi nhật ký đăng nhập cho mục đích chẩn đoán. Điều này sẽ giúp nhóm chúng tôi làm rõ các vấn đề liên quan đến ứng dụng. Hãy bật tùy chọn này chỉ khi nào có yêu cầu hỗ trợ từ Organic Maps.";
 
 "driving_options_title" = "Thiết lập đi vòng";
 

--- a/iphone/Maps/LocalizedStrings/zh-Hans.lproj/Localizable.strings
+++ b/iphone/Maps/LocalizedStrings/zh-Hans.lproj/Localizable.strings
@@ -923,6 +923,10 @@
 /* "traffic" as in "road congestion" */
 "traffic_data_unavailable" = "交通数据不可用";
 
+"enable_logging" = "启用记录";
+
+"log_file_size" = "日志文件大小： %@";
+
 "transliteration_title" = "直译成拉丁文";
 
 /* Subway exits for public transport marks on the map */
@@ -1050,6 +1054,8 @@
 "power_managment_setting_auto" = "自动";
 
 "power_managment_setting_manual_max" = "最大程度省电";
+
+"enable_logging_warning_message" = "临时启用此选项，以便使用“报告错误”功能在帮助对话框中记录并手动发送有关您的问题的详细诊断日志给我们。日志可能包含位置信息。";
 
 "driving_options_title" = "绕行设置";
 

--- a/iphone/Maps/LocalizedStrings/zh-Hant.lproj/Localizable.strings
+++ b/iphone/Maps/LocalizedStrings/zh-Hant.lproj/Localizable.strings
@@ -923,6 +923,10 @@
 /* "traffic" as in "road congestion" */
 "traffic_data_unavailable" = "無法使用交通資訊";
 
+"enable_logging" = "啟用記錄";
+
+"log_file_size" = "日誌檔案大小：%@";
+
 "transliteration_title" = "音譯為拉丁文";
 
 /* Subway exits for public transport marks on the map */
@@ -1050,6 +1054,8 @@
 "power_managment_setting_auto" = "自動";
 
 "power_managment_setting_manual_max" = "最大程度省電";
+
+"enable_logging_warning_message" = "暫時啟用此選項，以便使用「回報問題」功能在幫助對話框中記錄並手動發送詳細的診斷日誌給我們。日誌可能包含位置資訊。";
 
 "driving_options_title" = "繞行設定";
 

--- a/iphone/Maps/Maps.xcodeproj/project.pbxproj
+++ b/iphone/Maps/Maps.xcodeproj/project.pbxproj
@@ -482,6 +482,7 @@
 		ED79A5D72BDF8D6100952D1F /* SynchronizationStateManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = ED79A5CF2BDF8D6100952D1F /* SynchronizationStateManager.swift */; };
 		ED79A5D82BDF8D6100952D1F /* DefaultLocalDirectoryMonitor.swift in Sources */ = {isa = PBXBuildFile; fileRef = ED79A5D02BDF8D6100952D1F /* DefaultLocalDirectoryMonitor.swift */; };
 		ED7CCC4F2C1362E300E2A737 /* FileType.swift in Sources */ = {isa = PBXBuildFile; fileRef = ED7CCC4E2C1362E300E2A737 /* FileType.swift */; };
+		ED8270F02C2071A3005966DA /* SettingsTableViewDetailedSwitchCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = ED8270EF2C2071A3005966DA /* SettingsTableViewDetailedSwitchCell.swift */; };
 		ED9966802B94FBC20083CE55 /* ColorPicker.swift in Sources */ = {isa = PBXBuildFile; fileRef = ED99667D2B94FBC20083CE55 /* ColorPicker.swift */; };
 		EDBD68072B625724005DD151 /* LocationServicesDisabledAlert.xib in Resources */ = {isa = PBXBuildFile; fileRef = EDBD68062B625724005DD151 /* LocationServicesDisabledAlert.xib */; };
 		EDBD680B2B62572E005DD151 /* LocationServicesDisabledAlert.swift in Sources */ = {isa = PBXBuildFile; fileRef = EDBD680A2B62572E005DD151 /* LocationServicesDisabledAlert.swift */; };
@@ -1394,6 +1395,7 @@
 		ED79A5CF2BDF8D6100952D1F /* SynchronizationStateManager.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = SynchronizationStateManager.swift; sourceTree = "<group>"; };
 		ED79A5D02BDF8D6100952D1F /* DefaultLocalDirectoryMonitor.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = DefaultLocalDirectoryMonitor.swift; sourceTree = "<group>"; };
 		ED7CCC4E2C1362E300E2A737 /* FileType.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FileType.swift; sourceTree = "<group>"; };
+		ED8270EF2C2071A3005966DA /* SettingsTableViewDetailedSwitchCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SettingsTableViewDetailedSwitchCell.swift; sourceTree = "<group>"; };
 		ED99667D2B94FBC20083CE55 /* ColorPicker.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ColorPicker.swift; sourceTree = "<group>"; };
 		EDBD68062B625724005DD151 /* LocationServicesDisabledAlert.xib */ = {isa = PBXFileReference; lastKnownFileType = file.xib; path = LocationServicesDisabledAlert.xib; sourceTree = "<group>"; };
 		EDBD680A2B62572E005DD151 /* LocationServicesDisabledAlert.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LocationServicesDisabledAlert.swift; sourceTree = "<group>"; };
@@ -3726,6 +3728,7 @@
 				F6E2FD381E097BA00083EBEC /* SettingsTableViewLinkCell.swift */,
 				F6E2FD391E097BA00083EBEC /* SettingsTableViewSelectableCell.swift */,
 				F6E2FD3A1E097BA00083EBEC /* SettingsTableViewSwitchCell.swift */,
+				ED8270EF2C2071A3005966DA /* SettingsTableViewDetailedSwitchCell.swift */,
 			);
 			path = Cells;
 			sourceTree = "<group>";
@@ -4445,6 +4448,7 @@
 				3454D7C21E07F045004AF2AD /* NSString+Categories.m in Sources */,
 				34E7761F1F14DB48003040B3 /* PlacePageArea.swift in Sources */,
 				ED79A5D82BDF8D6100952D1F /* DefaultLocalDirectoryMonitor.swift in Sources */,
+				ED8270F02C2071A3005966DA /* SettingsTableViewDetailedSwitchCell.swift in Sources */,
 				4728F69322CF89A400E00028 /* GradientView.swift in Sources */,
 				F6381BF61CD12045004CA943 /* LocaleTranslator.mm in Sources */,
 				9917D17F2397B1D600A7E06E /* IPadModalPresentationController.swift in Sources */,

--- a/iphone/Maps/UI/Settings/Cells/SettingsTableViewDetailedSwitchCell.swift
+++ b/iphone/Maps/UI/Settings/Cells/SettingsTableViewDetailedSwitchCell.swift
@@ -1,0 +1,20 @@
+class SettingsTableViewDetailedSwitchCell: SettingsTableViewSwitchCell {
+
+  override func awakeFromNib() {
+    super.awakeFromNib()
+    styleDetail()
+  }
+
+  @objc
+  func setDetail(_ text: String?) {
+    detailTextLabel?.text = text
+    setNeedsLayout()
+  }
+
+  private func styleDetail() {
+    let detailTextLabelStyle = "regular12:blackSecondaryText"
+    detailTextLabel?.setStyleAndApply(detailTextLabelStyle)
+    detailTextLabel?.numberOfLines = 0
+    detailTextLabel?.lineBreakMode = .byWordWrapping
+  }
+}

--- a/iphone/Maps/UI/Settings/Cells/SettingsTableViewiCloudSwitchCell.swift
+++ b/iphone/Maps/UI/Settings/Cells/SettingsTableViewiCloudSwitchCell.swift
@@ -1,9 +1,4 @@
-final class SettingsTableViewiCloudSwitchCell: SettingsTableViewSwitchCell {
-
-  override func awakeFromNib() {
-    super.awakeFromNib()
-    styleDetail()
-  }
+final class SettingsTableViewiCloudSwitchCell: SettingsTableViewDetailedSwitchCell {
 
   @objc
   func updateWithError(_ error: NSError?) {
@@ -23,12 +18,5 @@ final class SettingsTableViewiCloudSwitchCell: SettingsTableViewSwitchCell {
       detailTextLabel?.text?.removeAll()
     }
     setNeedsLayout()
-  }
-
-  private func styleDetail() {
-    let detailTextLabelStyle = "regular12:blackSecondaryText"
-    detailTextLabel?.setStyleAndApply(detailTextLabelStyle)
-    detailTextLabel?.numberOfLines = 0
-    detailTextLabel?.lineBreakMode = .byWordWrapping
   }
 }

--- a/iphone/Maps/UI/Storyboard/Settings.storyboard
+++ b/iphone/Maps/UI/Storyboard/Settings.storyboard
@@ -1,9 +1,9 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="22505" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES">
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="32700.99.1234" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES">
     <device id="retina6_1" orientation="portrait" appearance="light"/>
     <dependencies>
         <deployment identifier="iOS"/>
-        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="22504"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="22685"/>
         <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
     </dependencies>
     <scenes>
@@ -292,7 +292,7 @@
                                             <autoresizingMask key="autoresizingMask"/>
                                             <subviews>
                                                 <label opaque="NO" multipleTouchEnabled="YES" contentMode="left" insetsLayoutMarginsFromSafeArea="NO" text="iCloud Synchronization (Beta)" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" id="QEX-D4-ejR">
-                                                    <rect key="frame" x="20" y="0.0" width="374" height="44"/>
+                                                    <rect key="frame" x="20" y="6" width="169" height="14.5"/>
                                                     <autoresizingMask key="autoresizingMask"/>
                                                     <color key="backgroundColor" white="0.0" alpha="0.0" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
                                                     <fontDescription key="fontDescription" type="system" pointSize="0.0"/>
@@ -309,12 +309,37 @@
                                             </subviews>
                                         </tableViewCellContentView>
                                     </tableViewCell>
+                                    <tableViewCell contentMode="scaleToFill" selectionStyle="none" hidesAccessoryWhenEditing="NO" indentationLevel="1" indentationWidth="0.0" reuseIdentifier="SettingsTableViewDetailedSwitchCell" textLabel="IuW-8X-Xdf" detailTextLabel="dON-be-sur" style="IBUITableViewCellStyleSubtitle" id="uxV-uf-u44" userLabel="EnadbleLogging" customClass="SettingsTableViewDetailedSwitchCell" customModule="Organic_Maps" customModuleProvider="target">
+                                        <rect key="frame" x="0.0" y="630" width="414" height="44"/>
+                                        <autoresizingMask key="autoresizingMask"/>
+                                        <tableViewCellContentView key="contentView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" tableViewCell="uxV-uf-u44" id="uwY-wf-q0J">
+                                            <rect key="frame" x="0.0" y="0.0" width="414" height="44"/>
+                                            <autoresizingMask key="autoresizingMask"/>
+                                            <subviews>
+                                                <label opaque="NO" multipleTouchEnabled="YES" contentMode="left" insetsLayoutMarginsFromSafeArea="NO" text="SendBugReport" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" id="IuW-8X-Xdf">
+                                                    <rect key="frame" x="20" y="6" width="89.5" height="14.5"/>
+                                                    <autoresizingMask key="autoresizingMask"/>
+                                                    <color key="backgroundColor" white="0.0" alpha="0.0" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
+                                                    <fontDescription key="fontDescription" type="system" pointSize="0.0"/>
+                                                    <nil key="textColor"/>
+                                                    <nil key="highlightedColor"/>
+                                                </label>
+                                                <label opaque="NO" multipleTouchEnabled="YES" contentMode="left" insetsLayoutMarginsFromSafeArea="NO" text="Subtitle" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" id="dON-be-sur">
+                                                    <rect key="frame" x="20" y="22.5" width="44" height="14.5"/>
+                                                    <autoresizingMask key="autoresizingMask"/>
+                                                    <fontDescription key="fontDescription" type="system" pointSize="0.0"/>
+                                                    <nil key="textColor"/>
+                                                    <nil key="highlightedColor"/>
+                                                </label>
+                                            </subviews>
+                                        </tableViewCellContentView>
+                                    </tableViewCell>
                                 </cells>
                             </tableViewSection>
                             <tableViewSection headerTitle="НАВИГАЦИЯ" id="E4E-hs-9xW">
                                 <cells>
                                     <tableViewCell contentMode="scaleToFill" selectionStyle="none" hidesAccessoryWhenEditing="NO" indentationLevel="1" indentationWidth="0.0" reuseIdentifier="SettingsTableViewSwitchCell" textLabel="E7d-pi-YM1" style="IBUITableViewCellStyleDefault" id="X5R-fv-yd7" customClass="SettingsTableViewSwitchCell" customModule="Organic_Maps" customModuleProvider="target">
-                                        <rect key="frame" x="0.0" y="634" width="414" height="44"/>
+                                        <rect key="frame" x="0.0" y="722" width="414" height="44"/>
                                         <autoresizingMask key="autoresizingMask"/>
                                         <tableViewCellContentView key="contentView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" tableViewCell="X5R-fv-yd7" id="s7y-Nu-Y01">
                                             <rect key="frame" x="0.0" y="0.0" width="414" height="44"/>
@@ -332,7 +357,7 @@
                                         </tableViewCellContentView>
                                     </tableViewCell>
                                     <tableViewCell contentMode="scaleToFill" selectionStyle="none" hidesAccessoryWhenEditing="NO" indentationLevel="1" indentationWidth="0.0" reuseIdentifier="SettingsTableViewSwitchCell" textLabel="T7T-10-R9B" style="IBUITableViewCellStyleDefault" id="veW-Fm-2Hl" customClass="SettingsTableViewSwitchCell" customModule="Organic_Maps" customModuleProvider="target">
-                                        <rect key="frame" x="0.0" y="678" width="414" height="44"/>
+                                        <rect key="frame" x="0.0" y="766" width="414" height="44"/>
                                         <autoresizingMask key="autoresizingMask"/>
                                         <tableViewCellContentView key="contentView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" tableViewCell="veW-Fm-2Hl" id="AP7-jd-F4b">
                                             <rect key="frame" x="0.0" y="0.0" width="414" height="44"/>
@@ -350,7 +375,7 @@
                                         </tableViewCellContentView>
                                     </tableViewCell>
                                     <tableViewCell contentMode="scaleToFill" selectionStyle="default" accessoryType="disclosureIndicator" hidesAccessoryWhenEditing="NO" indentationLevel="1" indentationWidth="0.0" reuseIdentifier="SettingsTableViewLinkCell" textLabel="DvL-U3-thq" detailTextLabel="aVn-3D-tVQ" style="IBUITableViewCellStyleValue1" id="nED-2n-gN6" customClass="SettingsTableViewLinkCell" customModule="Organic_Maps" customModuleProvider="target">
-                                        <rect key="frame" x="0.0" y="722" width="414" height="44"/>
+                                        <rect key="frame" x="0.0" y="810" width="414" height="44"/>
                                         <autoresizingMask key="autoresizingMask"/>
                                         <tableViewCellContentView key="contentView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" tableViewCell="nED-2n-gN6" id="2oQ-0g-poj">
                                             <rect key="frame" x="0.0" y="0.0" width="383.5" height="44"/>
@@ -376,22 +401,22 @@
                                         </tableViewCellContentView>
                                     </tableViewCell>
                                     <tableViewCell contentMode="scaleToFill" selectionStyle="default" accessoryType="disclosureIndicator" hidesAccessoryWhenEditing="NO" indentationLevel="1" indentationWidth="0.0" reuseIdentifier="SettingsTableViewLinkCell" textLabel="nJu-c9-12J" detailTextLabel="2ux-Rf-ECf" style="IBUITableViewCellStyleValue1" id="KrE-Sc-fI1" customClass="SettingsTableViewLinkCell" customModule="Organic_Maps" customModuleProvider="target">
-                                        <rect key="frame" x="0.0" y="766" width="414" height="44"/>
+                                        <rect key="frame" x="0.0" y="854" width="414" height="44"/>
                                         <autoresizingMask key="autoresizingMask"/>
                                         <tableViewCellContentView key="contentView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" tableViewCell="KrE-Sc-fI1" id="AKJ-VB-Pzr">
-                                            <rect key="frame" x="0.0" y="0.0" width="383.5" height="44"/>
+                                            <rect key="frame" x="0.0" y="0.0" width="395.5" height="44"/>
                                             <autoresizingMask key="autoresizingMask"/>
                                             <subviews>
-                                                <label opaque="NO" multipleTouchEnabled="YES" contentMode="left" insetsLayoutMarginsFromSafeArea="NO" text="Driving Options" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" id="nJu-c9-12J">
-                                                    <rect key="frame" x="20" y="15" width="88" height="14.5"/>
+                                                <label opaque="NO" multipleTouchEnabled="YES" contentMode="left" ambiguous="YES" insetsLayoutMarginsFromSafeArea="NO" text="Driving Options" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" id="nJu-c9-12J">
+                                                    <rect key="frame" x="8" y="15" width="88" height="14.5"/>
                                                     <autoresizingMask key="autoresizingMask"/>
                                                     <color key="backgroundColor" white="0.0" alpha="0.0" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
                                                     <fontDescription key="fontDescription" type="system" pointSize="0.0"/>
                                                     <nil key="textColor"/>
                                                     <nil key="highlightedColor"/>
                                                 </label>
-                                                <label opaque="NO" multipleTouchEnabled="YES" contentMode="left" insetsLayoutMarginsFromSafeArea="NO" text="Detail" textAlignment="right" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" id="2ux-Rf-ECf">
-                                                    <rect key="frame" x="342.5" y="15" width="33" height="14.5"/>
+                                                <label opaque="NO" multipleTouchEnabled="YES" contentMode="left" ambiguous="YES" insetsLayoutMarginsFromSafeArea="NO" text="Detail" textAlignment="right" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" id="2ux-Rf-ECf">
+                                                    <rect key="frame" x="354.5" y="15" width="33" height="14.5"/>
                                                     <autoresizingMask key="autoresizingMask"/>
                                                     <color key="backgroundColor" white="0.0" alpha="0.0" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
                                                     <fontDescription key="fontDescription" type="system" pointSize="0.0"/>
@@ -416,6 +441,7 @@
                         <outlet property="autoZoomCell" destination="veW-Fm-2Hl" id="zbI-m2-mDP"/>
                         <outlet property="compassCalibrationCell" destination="P5e-67-f4k" id="KcB-EC-S2y"/>
                         <outlet property="drivingOptionsCell" destination="KrE-Sc-fI1" id="XOl-eI-xJX"/>
+                        <outlet property="enableLoggingCell" destination="uxV-uf-u44" id="NcJ-C7-eff"/>
                         <outlet property="fontScaleCell" destination="pri-6G-9Zb" id="rHJ-ZT-lwM"/>
                         <outlet property="iCloudSynchronizationCell" destination="E6M-av-wQu" id="05q-Wq-SQa"/>
                         <outlet property="is3dCell" destination="0Lf-xU-P2U" id="obI-bL-FLh"/>

--- a/iphone/Maps/main.mm
+++ b/iphone/Maps/main.mm
@@ -1,10 +1,11 @@
 #import "MapsAppDelegate.h"
+#import "MWMSettings.h"
 
 #include "platform/platform.hpp"
-#include "platform/settings.hpp"
 
 int main(int argc, char * argv[])
 {
+  [MWMSettings initializeLogging];
   auto & p = GetPlatform();
   LOG(LINFO, ("Organic Maps", p.Version(), "started, detected CPU cores:", p.CpuCores()));
 


### PR DESCRIPTION
This PR implements logging to the file in ios.
Key features:
- all logs are created using the native `os_log` system (since iOS 14.0 logs can be visible in the Console app)
- add an option to the settings screen to enable logging to the file (with the file size)
- logs are written to the file on the serial utility queue so as not to block the main thread
- The `log.log` file will be added to the mail when the `Report a bug` is pressed on the `About` screen

___
<img width="300" alt="image" src="https://github.com/organicmaps/organicmaps/assets/79797627/a8e4a985-926d-4626-a041-0bdffcd69c43">
<img width="300" alt="image" src="https://github.com/organicmaps/organicmaps/assets/79797627/af2e1e34-5e04-429b-b4ba-df6b6df8c60c">

(on the video the string is still not localized...)

https://github.com/organicmaps/organicmaps/assets/79797627/c29c8e14-2d63-4dea-99ef-214ddad411f6

<img width="963" alt="image" src="https://github.com/organicmaps/organicmaps/assets/79797627/509a064d-755e-4133-98b0-90058cff8438">

