### PR TITLE
[Android] Placepage doesn't exit fullscreen mode

### DIFF
--- a/android/app/src/main/java/app/organicmaps/MwmActivity.java
+++ b/android/app/src/main/java/app/organicmaps/MwmActivity.java
@@ -904,6 +904,9 @@ public class MwmActivity extends BaseMwmFragmentActivity
   public void startLocationToPoint(final @Nullable MapObject endPoint)
   {
     closeFloatingPanels();
+    if (isFullscreen())
+      setFullscreen(false);
+
     if (LocationState.getMode() == LocationState.NOT_FOLLOW_NO_POSITION)
     {
       // Calls onMyPositionModeChanged(PENDING_POSITION).
@@ -1248,7 +1251,9 @@ public class MwmActivity extends BaseMwmFragmentActivity
 
   private void setFullscreen(boolean isFullscreen)
   {
-    if (RoutingController.get().isNavigating())
+    if (RoutingController.get().isNavigating()
+            || RoutingController.get().isBuilding()
+            || RoutingController.get().isPlanning())
       return;
 
     mMapButtonsViewModel.setButtonsHidden(isFullscreen);

--- a/android/app/src/main/java/app/organicmaps/MwmActivity.java
+++ b/android/app/src/main/java/app/organicmaps/MwmActivity.java
@@ -1221,7 +1221,6 @@ public class MwmActivity extends BaseMwmFragmentActivity
   @SuppressWarnings("unused")
   public void onPlacePageActivated(@NonNull PlacePageData data)
   {
-    setFullscreen(false);
     // This will open the place page
     mPlacePageViewModel.setMapObject((MapObject) data);
   }

--- a/android/app/src/main/java/app/organicmaps/MwmActivity.java
+++ b/android/app/src/main/java/app/organicmaps/MwmActivity.java
@@ -1248,9 +1248,7 @@ public class MwmActivity extends BaseMwmFragmentActivity
 
   private void setFullscreen(boolean isFullscreen)
   {
-    if (RoutingController.get().isNavigating()
-        || RoutingController.get().isBuilding()
-        || RoutingController.get().isPlanning())
+    if (RoutingController.get().isNavigating())
       return;
 
     mMapButtonsViewModel.setButtonsHidden(isFullscreen);
@@ -2022,6 +2020,7 @@ public class MwmActivity extends BaseMwmFragmentActivity
       return;
 
     closeFloatingPanels();
+    setFullscreen(false);
     RoutingController.get().start();
   }
 

--- a/android/app/src/main/java/app/organicmaps/MwmActivity.java
+++ b/android/app/src/main/java/app/organicmaps/MwmActivity.java
@@ -1246,7 +1246,10 @@ public class MwmActivity extends BaseMwmFragmentActivity
 
     setFullscreen(!isFullscreen());
     if (isFullscreen())
+    {
+      closePlacePage();
       showFullscreenToastIfNeeded();
+    }
   }
 
   private void setFullscreen(boolean isFullscreen)

--- a/android/app/src/main/java/app/organicmaps/util/UiUtils.java
+++ b/android/app/src/main/java/app/organicmaps/util/UiUtils.java
@@ -14,6 +14,7 @@ import android.view.View;
 import android.view.ViewGroup;
 import android.view.ViewTreeObserver;
 import android.view.Window;
+import android.view.WindowManager;
 import android.widget.Button;
 import android.widget.TextView;
 
@@ -229,15 +230,26 @@ public final class UiUtils
   public static void setFullscreen(@NonNull Activity activity, boolean fullscreen)
   {
     final Window window = activity.getWindow();
-    final View decorView = window.getDecorView();
-    WindowInsetsControllerCompat wic = Objects.requireNonNull(WindowCompat.getInsetsController(window, decorView));
-    if (fullscreen)
+
+    if (android.os.Build.VERSION.SDK_INT < android.os.Build.VERSION_CODES.R)
     {
-      wic.hide(WindowInsetsCompat.Type.systemBars());
-      wic.setSystemBarsBehavior(WindowInsetsControllerCompat.BEHAVIOR_SHOW_TRANSIENT_BARS_BY_SWIPE);
+      if (fullscreen)
+        window.setFlags(WindowManager.LayoutParams.FLAG_FULLSCREEN, WindowManager.LayoutParams.FLAG_FULLSCREEN);
+      else
+        window.clearFlags(WindowManager.LayoutParams.FLAG_FULLSCREEN);
     }
     else
-      wic.show(WindowInsetsCompat.Type.systemBars());
+    {
+      final View decorView = window.getDecorView();
+      WindowInsetsControllerCompat wic = Objects.requireNonNull(WindowCompat.getInsetsController(window, decorView));
+      if (fullscreen)
+      {
+        wic.hide(WindowInsetsCompat.Type.systemBars());
+        wic.setSystemBarsBehavior(WindowInsetsControllerCompat.BEHAVIOR_SHOW_TRANSIENT_BARS_BY_SWIPE);
+      }
+      else
+        wic.show(WindowInsetsCompat.Type.systemBars());
+    }
   }
 
   public static void setupTransparentStatusBar(@NonNull Activity activity)

--- a/android/app/src/main/java/app/organicmaps/util/UiUtils.java
+++ b/android/app/src/main/java/app/organicmaps/util/UiUtils.java
@@ -233,6 +233,9 @@ public final class UiUtils
 
     if (android.os.Build.VERSION.SDK_INT < android.os.Build.VERSION_CODES.R)
     {
+      // On older versions of Android there is layout issue on exit from fullscreen mode.
+      // For such versions we use old-style fullscreen mode.
+      // See https://github.com/organicmaps/organicmaps/pull/8551 for details
       if (fullscreen)
         window.setFlags(WindowManager.LayoutParams.FLAG_FULLSCREEN, WindowManager.LayoutParams.FLAG_FULLSCREEN);
       else


### PR DESCRIPTION
As @pastk asked in [comment](https://github.com/organicmaps/organicmaps/pull/8443#issuecomment-2185319015)

Changed android behaviour: in fullscreen mode opening a placepage doesn't exit fullscreen mode.

https://github.com/organicmaps/organicmaps/assets/720808/9ad2d727-ff52-42c8-89e2-0a04010a6b7c

## Update 2024-06-25

Now OM exits fullscreen mode before starting navigation.

Also in route planning mode you can enter/exit fullscreen mode with a long tap.