### PR TITLE
[strings] Fix Polish translations

### DIFF
--- a/android/app/src/main/res/values-pl/strings.xml
+++ b/android/app/src/main/res/values-pl/strings.xml
@@ -621,6 +621,24 @@
 	  <item quantity="two">Znaleziono %d pliki. Zobaczysz je po konwersji.</item>
 	</plurals>
 	<string name="restore">Przywróć</string>
+	<plurals name="objects">
+	  <item quantity="few">%d obiekty</item>
+	  <item quantity="many">%d obiektów</item>
+	  <item quantity="one">%d obiekt</item>
+	  <item quantity="other">%d obiektu</item>
+	</plurals>
+	<plurals name="places">
+	  <item quantity="few">%d miejsca</item>
+	  <item quantity="many">%d miejsc</item>
+	  <item quantity="one">%d miejsce</item>
+	  <item quantity="other">%d miejsca</item>
+	</plurals>
+	<plurals name="tracks">
+	  <item quantity="few">%d trasy</item>
+	  <item quantity="many">%d tras</item>
+	  <item quantity="one">%d trasa</item>
+	  <item quantity="other">%d trasy</item>
+	</plurals>
 	<!-- Settings privacy group in settings screen -->
 	<string name="privacy">Prywatność</string>
 	<string name="privacy_policy">Polityka prywatności</string>

--- a/data/strings/strings.txt
+++ b/data/strings/strings.txt
@@ -22244,6 +22244,7 @@
     pl:few = %d obiekty
     pl:many = %d obiektów
     pl:one = %d obiekt
+    pl:other = %d obiektu
     pt-BR:one = %d objeto
     pt-BR:other = %d objetos
     pt:one = %d objeto
@@ -22312,6 +22313,7 @@
     pl:few = %d miejsca
     pl:many = %d miejsc
     pl:one = %d miejsce
+    pl:other = %d miejsca
     pt-BR:one = %d lugar
     pt-BR:other = %d lugares
     pt:one = %d lugar
@@ -22376,6 +22378,7 @@
     pl:few = %d trasy
     pl:many = %d tras
     pl:one = %d trasa
+    pl:other = %d trasy
     pt-BR:one = %d percurso
     pt-BR:other = %d percursos
     pt:one = %d percurso

--- a/iphone/Maps/LocalizedStrings/pl.lproj/Localizable.stringsdict
+++ b/iphone/Maps/LocalizedStrings/pl.lproj/Localizable.stringsdict
@@ -60,7 +60,7 @@
       <key>one</key>
       <string>%d obiekt</string>
       <key>other</key>
-      <string>%d objects</string>
+      <string>%d obiektu</string>
     </dict>
   </dict>
 
@@ -81,7 +81,7 @@
       <key>one</key>
       <string>%d trasa</string>
       <key>other</key>
-      <string>%d tracks</string>
+      <string>%d trasy</string>
     </dict>
   </dict>
 </dict>


### PR DESCRIPTION
Fixes issue discovered in this comment: https://github.com/organicmaps/organicmaps/commit/0c3eb4f900957e615068c0d43bc2e46f451bc9a8#r143440343

A good example of how translations should work is here: https://localizely.com/language-plural-rules/

The main rule: `other` key should always be present to work. Our twine implementation doesn't handle it properly when `other` is missing. See 37a92fac952cc7f090ab708847a66598a2406b93 for details.

