### PR TITLE
[ios] Fix the fullscreen mode enter/exit behaviour

### DIFF
--- a/iphone/Maps/Classes/MapViewController.mm
+++ b/iphone/Maps/Classes/MapViewController.mm
@@ -91,7 +91,7 @@ NSString *const kPP2BookmarkEditingSegue = @"PP2BookmarkEditing";
 
 @property(nonatomic) BOOL needDeferFocusNotification;
 @property(nonatomic) BOOL deferredFocusValue;
-@property(nonatomic) UIViewController *placePageVC;
+@property(nonatomic) PlacePageViewController *placePageVC;
 @property(nonatomic) IBOutlet UIView *placePageContainer;
 
 @end
@@ -140,12 +140,14 @@ NSString *const kPP2BookmarkEditingSegue = @"PP2BookmarkEditing";
 }
 
 - (void)hideRegularPlacePage {
-  [self.placePageVC.view removeFromSuperview];
-  [self.placePageVC willMoveToParentViewController:nil];
-  [self.placePageVC removeFromParentViewController];
-  self.placePageVC = nil;
-  self.placePageContainer.hidden = YES;
-  [self setPlacePageTopBound:0 duration:0];
+  [self.placePageVC closeAnimatedWithCompletion:^{
+    [self.placePageVC.view removeFromSuperview];
+    [self.placePageVC willMoveToParentViewController:nil];
+    [self.placePageVC removeFromParentViewController];
+    self.placePageVC = nil;
+    self.placePageContainer.hidden = YES;
+    [self setPlacePageTopBound:0 duration:0];
+  }];
 }
 
 - (void)hidePlacePage {
@@ -168,12 +170,17 @@ NSString *const kPP2BookmarkEditingSegue = @"PP2BookmarkEditing";
       searchManager.state = MWMSearchManagerStateHidden;
     }
   }
+  // Always show the controls during the navigation or planning mode.
+  if (!isNavigationDashboardHidden)
+    self.controlsManager.hidden = NO;
 }
 
 - (void)onSwitchFullScreen {
-  BOOL const isNavigationDashboardHidden = [MWMNavigationDashboardManager sharedManager].state == MWMNavigationDashboardStateHidden;
+  BOOL const isNavigationDashboardHidden = MWMNavigationDashboardManager.sharedManager.state == MWMNavigationDashboardStateHidden;
   BOOL const isSearchHidden = MWMSearchManager.manager.state == MWMSearchManagerStateHidden;
   if (isSearchHidden && isNavigationDashboardHidden) {
+    if (!self.controlsManager.hidden)
+      [self dismissPlacePage];
     self.controlsManager.hidden = !self.controlsManager.hidden;
   }
 }

--- a/iphone/Maps/UI/PlacePage/PlacePageBuilder.swift
+++ b/iphone/Maps/UI/PlacePage/PlacePageBuilder.swift
@@ -1,5 +1,5 @@
 @objc class PlacePageBuilder: NSObject {    
-  @objc static func build() -> UIViewController {
+  @objc static func build() -> PlacePageViewController {
     let storyboard = UIStoryboard.instance(.placePage)
     guard let viewController = storyboard.instantiateInitialViewController() as? PlacePageViewController else {
       fatalError()

--- a/iphone/Maps/UI/PlacePage/PlacePagePresenter.swift
+++ b/iphone/Maps/UI/PlacePage/PlacePagePresenter.swift
@@ -33,7 +33,7 @@ extension PlacePagePresenter: PlacePagePresenterProtocol {
   }
 
   func closeAnimated() {
-    view.closeAnimated()
+    view.closeAnimated(completion: nil)
   }
 
   func updateTopBound(_ bound: CGFloat, duration: TimeInterval) {

--- a/iphone/Maps/UI/PlacePage/PlacePageViewController.swift
+++ b/iphone/Maps/UI/PlacePage/PlacePageViewController.swift
@@ -2,7 +2,7 @@ protocol PlacePageViewProtocol: AnyObject {
   var presenter: PlacePagePresenterProtocol! { get set }
 
   func setLayout(_ layout: IPlacePageLayout)
-  func closeAnimated()
+  func closeAnimated(completion: (() -> Void)?)
   func updatePreviewOffset()
   func showNextStop()
   func layoutIfNeeded()
@@ -312,11 +312,13 @@ extension PlacePageViewController: PlacePageViewProtocol {
     }
   }
 
-  func closeAnimated() {
+  @objc
+  func closeAnimated(completion: (() -> Void)? = nil) {
     alternativeSizeClass(iPhone: {
       self.scrollTo(CGPoint(x: 0, y: -self.scrollView.height + 1),
                     forced: true) {
                 self.rootViewController.dismissPlacePage()
+                completion?()
       }
     }, iPad: {
       UIView.animate(withDuration: kDefaultAnimationDuration,
@@ -326,6 +328,7 @@ extension PlacePageViewController: PlacePageViewProtocol {
                       self.view.alpha = 0
       }) { complete in
         self.rootViewController.dismissPlacePage()
+        completion?()
       }
     })
   }


### PR DESCRIPTION
- Long tap activates the Fullscreen mode and hides both the PP and the controls
- The second long tap deactivates the fullscreen mode and puts back the controls
- Controls are always visible on navigation, planning the route, searching modes
- If the fullscreen is enabled and the user opens the PP, the controls will be hidden
- If the fullscreen is enabled and the PP is opened, the longtap will exit the fullscreen without hiding the PP


https://github.com/organicmaps/organicmaps/assets/79797627/bf2fcf2f-698e-467b-8853-3e0ac9b6e08f

https://github.com/organicmaps/organicmaps/assets/79797627/75e99a24-5400-4726-bcd5-693e23b91afc

