### PR TITLE
[debug] Add ?all-types debug command to show all internal types

### DIFF
--- a/android/app/src/main/res/layout/place_page_preview.xml
+++ b/android/app/src/main/res/layout/place_page_preview.xml
@@ -68,7 +68,6 @@
         android:layout_height="wrap_content"
         android:layout_marginTop="@dimen/margin_quarter"
         android:ellipsize="end"
-        android:maxLines="2"
         android:textAppearance="@style/MwmTextAppearance.Body3"
         tools:background="#300000F0"
         tools:text="Subtitle, very very very very very very very long" />

--- a/docs/DEBUG_COMMANDS.md
+++ b/docs/DEBUG_COMMANDS.md
@@ -65,3 +65,8 @@ All the following commands require an app restart:
 ## GPS
 
 - `?gpstrackaccuracy:XXX`: Changes the accuracy of the GPS while recording tracks. Replace `XXX` by the desired horizontal accuracy. Works only on iOS for now.
+
+## Place Page
+
+- `?all-types`: Shows all internal types in place page
+- `?no-all-types`: Disables showing all internal types in place page

--- a/indexer/map_object.cpp
+++ b/indexer/map_object.cpp
@@ -136,6 +136,20 @@ std::string MapObject::GetLocalizedAllTypes(bool withMainType) const
   return oss.str();
 }
 
+std::string MapObject::GetAllReadableTypes() const
+{
+  ASSERT(!m_types.Empty(), ());
+  feature::TypesHolder copy(m_types);
+  copy.SortBySpec();
+
+  std::ostringstream oss;
+
+  for (auto const type : copy)
+    oss << classif().GetReadableObjectName(type) << feature::kFieldsSeparator;
+  
+  return oss.str();
+}
+
 std::string_view MapObject::GetMetadata(MetadataID type) const
 {
   return m_metadata.Get(type);

--- a/indexer/map_object.hpp
+++ b/indexer/map_object.hpp
@@ -109,6 +109,9 @@ protected:
   /// @returns "the best" single type to display in UI.
   std::string GetLocalizedType() const;
 
+  /// @returns all readable internal types separated by kFieldsSeparator for debugging.
+  std::string GetAllReadableTypes() const;
+    
   FeatureID m_featureID;
   m2::PointD m_mercator;
 

--- a/map/framework.cpp
+++ b/map/framework.cpp
@@ -3,6 +3,7 @@
 #include "map/gps_tracker.hpp"
 #include "map/user_mark.hpp"
 #include "map/track_mark.hpp"
+#include "map/place_page_info.hpp"
 
 #include "ge0/url_generator.hpp"
 
@@ -2838,6 +2839,21 @@ bool Framework::ParseRoutingDebugCommand(search::SearchParams const & params)
   return false;
 }
 
+bool Framework::ParseAllTypesDebugCommand(search::SearchParams const & params)
+{
+  if (params.m_query == "?all-types")
+  {
+    settings::Set(place_page::kDebugAllTypesSetting, true);
+    return true;
+  }
+  else if (params.m_query == "?no-all-types")
+  {
+    settings::Set(place_page::kDebugAllTypesSetting, false);
+    return true;
+  }
+  return false;
+}
+
 // Editable map object helper functions.
 namespace
 {
@@ -3238,6 +3254,8 @@ bool Framework::ParseSearchQueryCommand(search::SearchParams const & params)
   if (ParseEditorDebugCommand(params))
     return true;
   if (ParseRoutingDebugCommand(params))
+    return true;
+  if (ParseAllTypesDebugCommand(params))
     return true;
   return false;
 }

--- a/map/framework.hpp
+++ b/map/framework.hpp
@@ -607,6 +607,8 @@ private:
 
   /// This function can be used for enabling some experimental features for routing.
   bool ParseRoutingDebugCommand(search::SearchParams const & params);
+    
+  bool ParseAllTypesDebugCommand(search::SearchParams const & params);
 
   void FillFeatureInfo(FeatureID const & fid, place_page::Info & info) const;
   /// @param customTitle, if not empty, overrides any other calculated name.

--- a/map/place_page_info.cpp
+++ b/map/place_page_info.cpp
@@ -12,6 +12,7 @@
 #include "platform/utm_mgrs_utils.hpp"
 #include "platform/distance.hpp"
 #include "platform/duration.hpp"
+#include "platform/settings.hpp"
 
 #include "geometry/mercator.hpp"
 
@@ -205,6 +206,12 @@ std::string Info::FormatSubtitle(bool withTypes, bool withMainType) const
   auto const fee = GetLocalizedFeeType();
   if (!fee.empty())
     append(fee);
+
+  // Debug types
+  bool debugAllTypesSetting = false;
+  settings::TryGet(kDebugAllTypesSetting, debugAllTypesSetting);
+  if (debugAllTypesSetting)
+    append(GetAllReadableTypes());
 
   return result;
 }

--- a/map/place_page_info.hpp
+++ b/map/place_page_info.hpp
@@ -20,6 +20,8 @@
 
 namespace place_page
 {
+std::string_view constexpr kDebugAllTypesSetting = "DebugAllTypes";
+
 enum class OpeningMode
 {
   Preview = 0,


### PR DESCRIPTION
New debug command which has been helpful while working on PR https://github.com/organicmaps/organicmaps/pull/8481. 

- `?all-types`: Shows all internal types in place page
- `?no-all-types`: Disables showing all internal types in place page