### PR TITLE
[core] Show address even if housenumber is empty

### DIFF
--- a/indexer/feature.cpp
+++ b/indexer/feature.cpp
@@ -806,6 +806,12 @@ string const & FeatureType::GetHouseNumber()
   return m_params.house.Get();
 }
 
+bool const FeatureType::HasStreetName()
+{
+  ParseCommon();
+  return !m_params.name.IsEmpty();
+}
+
 string_view FeatureType::GetName(int8_t lang)
 {
   if (!HasName())

--- a/indexer/feature.hpp
+++ b/indexer/feature.hpp
@@ -150,6 +150,8 @@ public:
 
   std::string const & GetHouseNumber();
 
+  bool const HasStreetName();
+
   /// @name Get names for feature.
   //@{
   void GetPreferredNames(bool allowTranslit, int8_t deviceLang, feature::NameParamsOut & out);

--- a/search/ranker.cpp
+++ b/search/ranker.cpp
@@ -302,7 +302,13 @@ ftypes::LocalityType GetLocalityIndex(feature::TypesHolder const & types)
 // TODO: Format street and house number according to local country's rules.
 string FormatStreetAndHouse(ReverseGeocoder::Address const & addr)
 {
-  return addr.GetStreetName() + ", " + addr.GetHouseNumber();
+  std::string const streetName = addr.GetStreetName();
+  std::string const houseNumber = addr.GetHouseNumber();
+
+  if (houseNumber.empty())
+    return streetName;
+  else
+    return streetName + ", " + houseNumber;
 }
 
 // TODO: Share common formatting code for search results and place page.

--- a/search/reverse_geocoder.cpp
+++ b/search/reverse_geocoder.cpp
@@ -275,7 +275,7 @@ void ReverseGeocoder::GetNearbyBuildings(m2::PointD const & center, double radiu
   auto const addBuilding = [&](FeatureType & ft)
   {
     std::string const & hn = GetHouseNumber(ft);
-    if (hn.empty())
+    if (hn.empty() && !ft.HasStreetName())
       return;
 
     auto const distance = feature::GetMinDistanceMeters(ft, center);


### PR DESCRIPTION
Show the street name in address fields in place page and search results even if housenumber is empty.

* Fixes https://github.com/organicmaps/organicmaps/issues/8207

 ---

https://www.openstreetmap.org/node/11459806170#map=19/42.80858/-1.66593
https://omaps.app/0n_T5CE03X/Apesteguía_sofás
om://0n_T5CE03X/Apesteguía_sofás

<img src="https://github.com/organicmaps/organicmaps/assets/47610359/95ef6042-5731-4a57-85f1-6a617e274969" width="320"/> <img src="https://github.com/organicmaps/organicmaps/assets/47610359/b3177778-52fd-465e-9872-9433590700bd" width="320"/>

---

https://www.openstreetmap.org/node/5137318626#map=19/41.44830/2.24691
https://omaps.app/4yonrSaA-J/Café_Caracas
om://4yonrSaA-J/Café_Caracas
<img src="https://github.com/organicmaps/organicmaps/assets/47610359/9d1a084f-8a6e-48a3-adaf-f41175a36a7f" width="320"/> <img src="https://github.com/organicmaps/organicmaps/assets/47610359/55e67948-47e0-44f5-a075-d314d45561d0" width="320"/>