### PR TITLE
Additional fixes for showing all POI types

### DIFF
--- a/indexer/ftypes_matcher.cpp
+++ b/indexer/ftypes_matcher.cpp
@@ -482,6 +482,11 @@ IsPoiChecker::IsPoiChecker() : BaseChecker(1 /* level */)
     m_types.push_back(classif().GetTypeByPath({type}));
 }
 
+IsAmenityChecker::IsAmenityChecker() : BaseChecker(1 /* level */)
+{
+  m_types.push_back(classif().GetTypeByPath({"amenity"}));
+}
+
 AttractionsChecker::AttractionsChecker() : BaseChecker(2 /* level */)
 {
   base::StringIL const primaryAttractionTypes[] = {

--- a/indexer/ftypes_matcher.hpp
+++ b/indexer/ftypes_matcher.hpp
@@ -324,6 +324,15 @@ public:
   DECLARE_CHECKER_INSTANCE(IsPoiChecker);
 };
 
+class IsAmenityChecker : public BaseChecker
+{
+  IsAmenityChecker();
+public:
+  DECLARE_CHECKER_INSTANCE(IsAmenityChecker);
+
+  uint32_t GetType() const { return m_types[0]; }
+};
+
 class AttractionsChecker : public BaseChecker
 {
   size_t m_additionalTypesStart;

--- a/indexer/indexer_tests/editable_map_object_test.cpp
+++ b/indexer/indexer_tests/editable_map_object_test.cpp
@@ -451,4 +451,117 @@ UNIT_TEST(EditableMapObject_FromFeatureType)
   TEST(emo2.IsPointType(), ());
 }
 
+UNIT_TEST(EditableMapObject_GetLocalizedAllTypes)
+{
+  classificator::Load();
+
+  {
+    EditableMapObject emo;
+    feature::TypesHolder types;
+    types.Add(classif().GetTypeByPath({"amenity", "fuel"}));
+    types.Add(classif().GetTypeByPath({"shop"}));
+    types.Add(classif().GetTypeByPath({"building"}));
+    types.Add(classif().GetTypeByPath({"toilets", "yes"}));
+    emo.SetTypes(types);
+    TEST_EQUAL(emo.GetLocalizedAllTypes(true), std::string("amenity-fuel • shop"), ());
+    TEST_EQUAL(emo.GetLocalizedAllTypes(false), std::string("shop"), ());
+  }
+
+  {
+    EditableMapObject emo;
+    feature::TypesHolder types;
+    types.Add(classif().GetTypeByPath({"amenity", "shelter"}));
+    types.Add(classif().GetTypeByPath({"amenity", "bench"}));
+    types.Add(classif().GetTypeByPath({"highway", "bus_stop"}));
+    emo.SetTypes(types);
+    TEST_EQUAL(emo.GetLocalizedAllTypes(true), std::string("highway-bus_stop • amenity-shelter • amenity-bench"), ());
+    TEST_EQUAL(emo.GetLocalizedAllTypes(false), std::string("amenity-shelter • amenity-bench"), ());
+  }
+
+  {
+    EditableMapObject emo;
+    feature::TypesHolder types;
+    types.Add(classif().GetTypeByPath({"leisure", "pitch"}));
+    types.Add(classif().GetTypeByPath({"sport", "soccer"}));
+    emo.SetTypes(types);
+    TEST_EQUAL(emo.GetLocalizedAllTypes(true), std::string("sport-soccer • leisure-pitch"), ());
+    TEST_EQUAL(emo.GetLocalizedAllTypes(false), std::string("leisure-pitch"), ());
+  }
+
+  {
+    EditableMapObject emo;
+    feature::TypesHolder types;
+    types.Add(classif().GetTypeByPath({"craft", "key_cutter"}));
+    emo.SetTypes(types);
+    TEST_EQUAL(emo.GetLocalizedAllTypes(true), std::string("craft-key_cutter"), ());
+    TEST_EQUAL(emo.GetLocalizedAllTypes(false), std::string(""), ());
+  }
+
+  {
+    EditableMapObject emo;
+    feature::TypesHolder types;
+    types.Add(classif().GetTypeByPath({"amenity", "parking_entrance"}));
+    types.Add(classif().GetTypeByPath({"barrier", "gate"}));
+    emo.SetTypes(types);
+    TEST_EQUAL(emo.GetLocalizedAllTypes(true), std::string("barrier-gate • amenity-parking_entrance"), ());
+    TEST_EQUAL(emo.GetLocalizedAllTypes(false), std::string("amenity-parking_entrance"), ());
+  }
+
+  {
+    EditableMapObject emo;
+    feature::TypesHolder types;
+    types.Add(classif().GetTypeByPath({"barrier", "gate"}));
+    emo.SetTypes(types);
+    TEST_EQUAL(emo.GetLocalizedAllTypes(true), std::string("barrier-gate"), ());
+    TEST_EQUAL(emo.GetLocalizedAllTypes(false), std::string(""), ());
+  }
+
+  {
+    EditableMapObject emo;
+    feature::TypesHolder types;
+    types.Add(classif().GetTypeByPath({"entrance", "main"}));
+    emo.SetTypes(types);
+    TEST_EQUAL(emo.GetLocalizedAllTypes(true), std::string("entrance-main"), ());
+    TEST_EQUAL(emo.GetLocalizedAllTypes(false), std::string(""), ());
+  }
+
+  {
+    EditableMapObject emo;
+    feature::TypesHolder types;
+    types.Add(classif().GetTypeByPath({"entrance", "main"}));
+    types.Add(classif().GetTypeByPath({"barrier", "gate"}));
+    emo.SetTypes(types);
+    TEST_EQUAL(emo.GetLocalizedAllTypes(true), std::string("barrier-gate"), ());
+    TEST_EQUAL(emo.GetLocalizedAllTypes(false), std::string(""), ());
+  }
+
+  {
+    EditableMapObject emo;
+    feature::TypesHolder types;
+    types.Add(classif().GetTypeByPath({"amenity"}));
+    emo.SetTypes(types);
+    TEST_EQUAL(emo.GetLocalizedAllTypes(true), std::string("amenity"), ());
+    TEST_EQUAL(emo.GetLocalizedAllTypes(false), std::string(""), ());
+  }
+
+  {
+    EditableMapObject emo;
+    feature::TypesHolder types;
+    types.Add(classif().GetTypeByPath({"shop"}));
+    emo.SetTypes(types);
+    TEST_EQUAL(emo.GetLocalizedAllTypes(true), std::string("shop"), ());
+    TEST_EQUAL(emo.GetLocalizedAllTypes(false), std::string(""), ());
+  }
+
+  {
+    EditableMapObject emo;
+    feature::TypesHolder types;
+    types.Add(classif().GetTypeByPath({"tourism", "artwork"}));
+    types.Add(classif().GetTypeByPath({"amenity"}));
+    emo.SetTypes(types);
+    TEST_EQUAL(emo.GetLocalizedAllTypes(true), std::string("tourism-artwork"), ());
+    TEST_EQUAL(emo.GetLocalizedAllTypes(false), std::string(""), ());
+  }
+}
+
 } // namespace editable_map_object_test

--- a/indexer/map_object.cpp
+++ b/indexer/map_object.cpp
@@ -94,23 +94,35 @@ std::string MapObject::GetLocalizedType() const
   return platform::GetLocalizedTypeName(classif().GetReadableObjectName(copy.GetBestType()));
 }
 
-std::string MapObject::GetAllLocalizedTypes() const
+std::string MapObject::GetLocalizedAllTypes(bool withMainType) const
 {
   ASSERT(!m_types.Empty(), ());
   feature::TypesHolder copy(m_types);
   copy.SortBySpec();
 
   auto const & isPoi = ftypes::IsPoiChecker::Instance();
+  auto const & amenityChecker = ftypes::IsAmenityChecker::Instance();
 
   std::ostringstream oss;
+  bool isMainType = true;
   bool isFirst = true;
   for (auto const type : copy)
   {
-    // Ignore types that are not POI
-    // Ignore general types that have no subtype
-    // But always show the first/main type
-    if (!isFirst && (!isPoi(type) || ftype::GetLevel(type) == 1))
+    if (isMainType && !withMainType)
+    {
+      isMainType = false;
       continue;
+    }
+
+    // Ignore types that are not POI
+    if (!isMainType && !isPoi(type))
+      continue;
+      
+    // Ignore general amenity
+    if (!isMainType && amenityChecker.GetType() == type)
+      continue;
+      
+    isMainType = false;
     
     // Add fields separator between types
     if (isFirst)

--- a/indexer/map_object.hpp
+++ b/indexer/map_object.hpp
@@ -102,12 +102,12 @@ public:
 
   void AssignMetadata(feature::Metadata & dest) const { dest = m_metadata; }
 
+  /// @returns all localized POI types separated by kFieldsSeparator to display in UI.
+  std::string GetLocalizedAllTypes(bool withMainType) const;
+    
 protected:
   /// @returns "the best" single type to display in UI.
   std::string GetLocalizedType() const;
-    
-  /// @returns all localized POI types separated by kFieldsSeparator to display in UI.
-  std::string GetAllLocalizedTypes() const;
 
   FeatureID m_featureID;
   m2::PointD m_mercator;

--- a/map/place_page_info.cpp
+++ b/map/place_page_info.cpp
@@ -108,7 +108,7 @@ void Info::SetMercator(m2::PointD const & mercator)
   m_buildInfo.m_mercator = mercator;
 }
 
-std::string Info::FormatSubtitle(bool withType) const
+std::string Info::FormatSubtitle(bool withMainType) const
 {
   std::string result;
   auto const append = [&result](std::string_view sv)
@@ -121,8 +121,8 @@ std::string Info::FormatSubtitle(bool withType) const
   if (IsBookmark())
     append(m_bookmarkCategoryName);
 
-  if (withType)
-    append(GetAllLocalizedTypes());
+  // Types
+  append(GetLocalizedAllTypes(withMainType));
 
   // Flats.
   auto const flats = GetMetadata(feature::Metadata::FMD_FLATS);

--- a/map/place_page_info.hpp
+++ b/map/place_page_info.hpp
@@ -215,7 +215,7 @@ public:
   df::SelectionShape::ESelectedObject GetSelectedObject() const { return m_selectedObject; }
 
 private:
-  std::string FormatSubtitle(bool withType) const;
+  std::string FormatSubtitle(bool withMainType) const;
   std::string GetBookmarkName();
 
   place_page::BuildInfo m_buildInfo;


### PR DESCRIPTION
Additional fixes after https://github.com/organicmaps/organicmaps/pull/8481. 

* Show level=1 types, allowing to show generic `shop`, but keep discarding generic `amenity`. Related to https://github.com/organicmaps/organicmaps/issues/8590. 
* Show secondary types in subtitle when the POI has no name and the main type is shown in the title. Fixes https://github.com/organicmaps/organicmaps/issues/8591


---

https://www.openstreetmap.org/way/63848074#map=19/43.18253/-0.60851
https://omaps.app/_n_dpiSdC0/Total
om://_n_dpiSdC0/Total

<img src="https://github.com/organicmaps/organicmaps/assets/47610359/cebfdd98-291a-4896-8555-1b3e9cdbc4d9" width="320"/>

---

https://www.openstreetmap.org/way/809647468#map=18/42.81471/-1.59428
https://omaps.app/0n_T5cW_HC/Football
om://0n_T5cW_HC/Football

<img src="https://github.com/organicmaps/organicmaps/assets/47610359/96a4dcb8-b5e6-49e2-a02c-cb565ed57e71" width="320"/>

---
https://www.openstreetmap.org/node/9219269542#map=19/56.63970/47.92440
https://omaps.app/05gSBsr7Ks/Bus_Stop
om://05gSBsr7Ks/Bus_Stop

<img src="https://github.com/organicmaps/organicmaps/assets/47610359/226ef107-aa41-48f0-ac81-2c57df70ffed" width="320"/>



