### PR TITLE
QMenu::addAction is deprecated

### DIFF
--- a/qt/mainwindow.cpp
+++ b/qt/mainwindow.cpp
@@ -152,11 +152,11 @@ MainWindow::MainWindow(Framework & framework,
 #ifndef OMIM_OS_WINDOWS
   QMenu * helpMenu = new QMenu(tr("Help"), this);
   menuBar()->addMenu(helpMenu);
-  helpMenu->addAction(tr("OpenStreetMap Login"), this, SLOT(OnLoginMenuItem()), QKeySequence(Qt::CTRL | Qt::Key_O));
-  helpMenu->addAction(tr("Upload Edits"), this, SLOT(OnUploadEditsMenuItem()), QKeySequence(Qt::CTRL | Qt::Key_U));
-  helpMenu->addAction(tr("Preferences"), this, SLOT(OnPreferences()), QKeySequence(Qt::CTRL | Qt::Key_P));
-  helpMenu->addAction(tr("About"), this, SLOT(OnAbout()), QKeySequence(Qt::Key_F1));
-  helpMenu->addAction(tr("Exit"), this, SLOT(close()), QKeySequence(Qt::CTRL | Qt::Key_Q));
+  helpMenu->addAction(tr("OpenStreetMap Login"), QKeySequence(Qt::CTRL | Qt::Key_O), this, SLOT(OnLoginMenuItem()));
+  helpMenu->addAction(tr("Upload Edits"), QKeySequence(Qt::CTRL | Qt::Key_U), this, SLOT(OnUploadEditsMenuItem()));
+  helpMenu->addAction(tr("Preferences"), QKeySequence(Qt::CTRL | Qt::Key_P), this, SLOT(OnPreferences()));
+  helpMenu->addAction(tr("About"), QKeySequence(Qt::Key_F1), this, SLOT(OnAbout()));
+  helpMenu->addAction(tr("Exit"),QKeySequence(Qt::CTRL | Qt::Key_Q), this, SLOT(close()));
 #else
   {
     // create items in the system menu


### PR DESCRIPTION
Since Qt6 this specialization in QMenu is deprecated. We should use the function from QWidget.
Parameters are in a different order (text, shortcut, receiver, member).

https://doc.qt.io/qt-6/qmenu-obsolete.html