### PR TITLE
[android] Use same cursor styles in bookmarks fields

### DIFF
--- a/android/app/src/main/res/layout/dialog_edit_text.xml
+++ b/android/app/src/main/res/layout/dialog_edit_text.xml
@@ -20,7 +20,7 @@
     app:hintEnabled="false">
     <com.google.android.material.textfield.TextInputEditText
       android:id="@+id/et__input"
-      style="@style/MwmWidget.PlacePage.EditText"
+      style="@style/MwmWidget.Editor.CustomTextInput"
       android:layout_width="match_parent"
       android:layout_height="wrap_content"
       android:inputType="text|textCapSentences"

--- a/android/app/src/main/res/layout/edit_bookmark_common.xml
+++ b/android/app/src/main/res/layout/edit_bookmark_common.xml
@@ -27,7 +27,7 @@
       app:endIconTint="?android:textColorSecondary">
       <com.google.android.material.textfield.TextInputEditText
         android:id="@+id/et__bookmark_name"
-        style="@style/MwmWidget.PlacePage.EditText"
+        style="@style/MwmWidget.Editor.CustomTextInput"
         android:layout_width="match_parent"
         android:layout_height="wrap_content"
         android:hint="@string/name"
@@ -93,7 +93,7 @@
     app:layout_constraintTop_toBottomOf="@+id/rl__bookmark_set">
     <com.google.android.material.textfield.TextInputEditText
       android:id="@+id/et__description"
-      style="@style/MwmWidget.PlacePage.EditText"
+      style="@style/MwmWidget.Editor.CustomTextInput"
       android:layout_width="match_parent"
       android:layout_height="wrap_content"
       android:padding="@dimen/margin_half_double_plus"

--- a/android/app/src/main/res/layout/fragment_bookmark_category_settings.xml
+++ b/android/app/src/main/res/layout/fragment_bookmark_category_settings.xml
@@ -38,7 +38,7 @@
           app:endIconTint="?android:textColorSecondary">
         <com.google.android.material.textfield.TextInputEditText
           android:id="@+id/edit_list_name_view"
-          style="@style/MwmWidget.PlacePage.EditText"
+          style="@style/MwmWidget.Editor.CustomTextInput"
           android:hint="@string/list"
           android:layout_width="match_parent"
           android:layout_height="wrap_content" />
@@ -49,7 +49,7 @@
       android:textColorHint="?android:textColorSecondary">
     <com.google.android.material.textfield.TextInputEditText
       android:id="@+id/edit_description"
-      style="@style/MwmWidget.PlacePage.EditText"
+      style="@style/MwmWidget.Editor.CustomTextInput"
       android:hint="@string/bookmark_list_description_hint"
       android:minHeight="@dimen/height_item_multiline"
       android:paddingStart="@dimen/margin_base"

--- a/android/app/src/main/res/layout/fragment_edit_description.xml
+++ b/android/app/src/main/res/layout/fragment_edit_description.xml
@@ -32,7 +32,7 @@
     app:layout_constraintTop_toBottomOf="@+id/toolbar">
     <com.google.android.material.textfield.TextInputEditText
       android:id="@+id/et__description"
-      style="@style/MwmWidget.PlacePage.EditText"
+      style="@style/MwmWidget.Editor.CustomTextInput"
       android:layout_width="match_parent"
       android:layout_height="wrap_content"
       android:hint="@string/edit_description_hint"

--- a/android/app/src/main/res/values/styles.xml
+++ b/android/app/src/main/res/values/styles.xml
@@ -117,15 +117,6 @@
     <item name="cornerSize">50%</item>
   </style>
 
-
-  <style name="MwmWidget.PlacePage.EditText" parent="Widget.AppCompat.EditText">
-    <item name="android:imeOptions">actionDone</item>
-    <item name="android:textAppearance">@style/MwmTextAppearance.PlacePage</item>
-    <item name="android:textColorHint">?secondary</item>
-    <item name="android:textCursorDrawable">@null</item>
-    <item name="android:fontFamily">@string/robotoRegular</item>
-  </style>
-
   <style name="MwmWidget.ToolbarStyle" parent="ThemeOverlay.MaterialComponents.Dark.ActionBar">
     <item name="android:background">?colorPrimary</item>
     <item name="android:displayOptions">homeAsUp|showTitle</item>


### PR DESCRIPTION
A user on Telegram has reported cursor in the bookmarks fields is different from the cursor on fields in the editor.
This PR uses editor styles in bookmarks to use the same cursor everywhere.
No visual difference except cursor in blue
It seems the size of the text is a little more big

|Before|After|
|-|-|
|<img src="https://github.com/organicmaps/organicmaps/assets/87148630/36781370-31e8-4ee3-a40b-59c499def90e" height=500 />|<img src="https://github.com/organicmaps/organicmaps/assets/87148630/eebbd8ae-6d33-416b-a2f7-861fc66a43cc" height=500 />|
|<img src="https://github.com/organicmaps/organicmaps/assets/87148630/a762ad92-8f3e-41b3-9b01-904406152afb" height=500 />|<img src="https://github.com/organicmaps/organicmaps/assets/87148630/27f9afb9-7341-4441-a4fd-16d9864478c7" height=500 />|

