### PR TITLE
[android] Migrate help fragment to Material

### DIFF
--- a/android/app/src/main/java/app/organicmaps/help/HelpFragment.java
+++ b/android/app/src/main/java/app/organicmaps/help/HelpFragment.java
@@ -6,7 +6,6 @@ import android.text.TextUtils;
 import android.view.LayoutInflater;
 import android.view.View;
 import android.view.ViewGroup;
-import android.widget.TextView;
 
 import androidx.annotation.IdRes;
 import androidx.annotation.NonNull;
@@ -21,14 +20,16 @@ import app.organicmaps.util.Constants;
 import app.organicmaps.util.DateUtils;
 import app.organicmaps.util.Graphics;
 import app.organicmaps.util.Utils;
+import com.google.android.material.button.MaterialButton;
+import com.google.android.material.textview.MaterialTextView;
 
 public class HelpFragment extends BaseMwmFragment implements View.OnClickListener
 {
   private String mDonateUrl;
 
-  private TextView setupItem(@IdRes int id, boolean tint, @NonNull View frame)
+  private MaterialTextView setupItem(@IdRes int id, boolean tint, @NonNull View frame)
   {
-    final TextView view = frame.findViewById(id);
+    final MaterialTextView view = frame.findViewById(id);
     view.setOnClickListener(this);
     if (tint)
       Graphics.tint(view);
@@ -41,13 +42,13 @@ public class HelpFragment extends BaseMwmFragment implements View.OnClickListene
     mDonateUrl = Config.getDonateUrl(requireContext());
     View root = inflater.inflate(R.layout.about, container, false);
 
-    ((TextView) root.findViewById(R.id.version))
+    ((MaterialTextView) root.findViewById(R.id.version))
         .setText(BuildConfig.VERSION_NAME);
 
     final boolean isLandscape = getResources().getConfiguration().orientation == Configuration.ORIENTATION_LANDSCAPE;
 
     final String dataVersion = DateUtils.getShortDateFormatter().format(Framework.getDataVersion());
-    final TextView osmPresentationView = root.findViewById(R.id.osm_presentation);
+    final MaterialTextView osmPresentationView = root.findViewById(R.id.osm_presentation);
     if (osmPresentationView != null)
       osmPresentationView.setText(getString(R.string.osm_presentation, dataVersion));
 
@@ -63,15 +64,15 @@ public class HelpFragment extends BaseMwmFragment implements View.OnClickListene
     setupItem(R.id.mastodon, false, root);
     setupItem(R.id.openstreetmap, true, root);
     setupItem(R.id.faq, true, root);
-    setupItem(R.id.report, isLandscape, root);
+    root.findViewById(R.id.report).setOnClickListener(this);
 
-    final TextView supportUsView = root.findViewById(R.id.support_us);
+    final MaterialTextView supportUsView = root.findViewById(R.id.support_us);
     if (BuildConfig.FLAVOR.equals("google") && !TextUtils.isEmpty(mDonateUrl))
       supportUsView.setVisibility(View.GONE);
     else
-      setupItem(R.id.support_us, true, root);
+      root.findViewById(R.id.support_us).setOnClickListener(this);
 
-    final TextView donateView = root.findViewById(R.id.donate);
+    final MaterialButton donateView = root.findViewById(R.id.donate);
     if (TextUtils.isEmpty(mDonateUrl))
       donateView.setVisibility(View.GONE);
     else
@@ -79,7 +80,7 @@ public class HelpFragment extends BaseMwmFragment implements View.OnClickListene
       if (Config.isNY())
         donateView.setCompoundDrawablesRelativeWithIntrinsicBounds(R.drawable.ic_christmas_tree, 0,
             R.drawable.ic_christmas_tree, 0);
-      setupItem(R.id.donate, isLandscape, root);
+      root.findViewById(R.id.donate).setOnClickListener(this);
     }
 
     if (BuildConfig.REVIEW_URL.isEmpty())

--- a/android/app/src/main/res/layout-land/about.xml
+++ b/android/app/src/main/res/layout-land/about.xml
@@ -32,7 +32,7 @@
           app:layout_constraintTop_toTopOf="parent"
           app:layout_constraintVertical_bias="0.5">
 
-          <TextView
+          <com.google.android.material.textview.MaterialTextView
             android:id="@+id/version"
             android:layout_width="match_parent"
             android:layout_height="wrap_content"
@@ -42,7 +42,7 @@
             android:textIsSelectable="true"
             tools:text="2021.10.15-15-Google" />
 
-          <TextView
+          <com.google.android.material.textview.MaterialTextView
             android:layout_width="match_parent"
             android:layout_height="wrap_content"
             android:text="@string/about_headline"
@@ -52,7 +52,7 @@
             app:layout_constraintTop_toTopOf="@id/version" />
         </LinearLayout>
 
-        <ImageView
+        <com.google.android.material.imageview.ShapeableImageView
           android:id="@+id/imageView3"
           android:layout_width="@dimen/about_logo"
           android:layout_height="@dimen/about_logo"
@@ -84,7 +84,7 @@
             android:orientation="vertical"
             android:layout_gravity="center">
 
-          <TextView
+          <com.google.android.material.textview.MaterialTextView
             android:layout_width="wrap_content"
             android:layout_height="match_parent"
             android:layout_marginBottom="@dimen/margin_half"
@@ -92,7 +92,7 @@
             android:textAppearance="@style/MwmTextAppearance.Body1"
             android:textColor="?android:textColorPrimary" />
 
-          <TextView
+          <com.google.android.material.textview.MaterialTextView
             android:layout_width="wrap_content"
             android:layout_height="match_parent"
             android:layout_marginBottom="@dimen/margin_half"
@@ -100,7 +100,7 @@
             android:textAppearance="@style/MwmTextAppearance.Body1"
             android:textColor="?android:textColorPrimary" />
 
-          <TextView
+          <com.google.android.material.textview.MaterialTextView
             android:layout_width="wrap_content"
             android:layout_height="match_parent"
             android:layout_marginBottom="@dimen/margin_half"
@@ -111,7 +111,7 @@
         </LinearLayout>
       </androidx.constraintlayout.widget.ConstraintLayout>
 
-      <TextView
+      <com.google.android.material.textview.MaterialTextView
         android:layout_width="match_parent"
         android:layout_height="wrap_content"
         android:gravity="center"
@@ -129,7 +129,7 @@
         android:layout_height="wrap_content"
         android:layout_marginBottom="@dimen/margin_half">
 
-        <ImageView
+        <com.google.android.material.imageview.ShapeableImageView
           android:id="@+id/osm_logo"
           android:layout_width="@dimen/osm_logo"
           android:layout_height="@dimen/osm_logo"
@@ -141,7 +141,7 @@
           app:layout_constraintStart_toStartOf="parent"
           app:layout_constraintTop_toTopOf="parent" />
 
-        <TextView
+        <com.google.android.material.textview.MaterialTextView
           android:id="@+id/osm_presentation"
           android:layout_width="0dp"
           android:layout_height="wrap_content"
@@ -163,7 +163,7 @@
         android:layout_height="wrap_content"
         android:layout_margin="@dimen/margin_half"
         android:orientation="horizontal">
-        <Button
+        <com.google.android.material.button.MaterialButton
           android:id="@+id/donate"
           style="@style/MwmWidget.Button.Accent"
           android:layout_width="0dp"
@@ -180,12 +180,11 @@
           app:layout_constraintStart_toStartOf="parent"
           app:layout_constraintTop_toTopOf="parent"
           app:layout_constraintVertical_bias="0.5" />
-        <Button
+        <com.google.android.material.button.MaterialButton
           android:id="@+id/report"
           style="@style/MwmWidget.Button"
           android:layout_width="0dp"
           android:layout_height="wrap_content"
-          android:background="@color/light_gray"
           android:fontFamily="@string/robotoMedium"
           android:text="@string/report_a_bug"
           android:textAlignment="center"
@@ -199,85 +198,85 @@
           app:layout_constraintVertical_bias="0.5" />
       </androidx.constraintlayout.widget.ConstraintLayout>
 
-      <TextView
+      <com.google.android.material.textview.MaterialTextView
         android:id="@+id/faq"
         style="@style/MwmWidget.TextView.Item"
         android:text="@string/faq"
         app:drawableStartCompat="@drawable/ic_question_mark" />
 
-      <TextView
+      <com.google.android.material.textview.MaterialTextView
         android:id="@+id/support_us"
         style="@style/MwmWidget.TextView.Item"
         android:text="@string/how_to_support_us"
         app:drawableStartCompat="@drawable/ic_donate" />
 
-      <TextView
+      <com.google.android.material.textview.MaterialTextView
         android:id="@+id/news"
         style="@style/MwmWidget.TextView.Item"
         android:text="@string/news"
         app:drawableStartCompat="@drawable/ic_news" />
 
-      <TextView
+      <com.google.android.material.textview.MaterialTextView
         android:id="@+id/rate"
         style="@style/MwmWidget.TextView.Item"
         android:text="@string/rate_the_app"
         app:drawableStartCompat="@drawable/ic_rate" />
 
-      <TextView
+      <com.google.android.material.textview.MaterialTextView
         android:id="@+id/telegram"
         style="@style/MwmWidget.TextView.Item"
         android:text="@string/telegram"
         app:drawableStartCompat="@drawable/ic_telegram" />
 
-      <TextView
+      <com.google.android.material.textview.MaterialTextView
         android:id="@+id/github"
         style="@style/MwmWidget.TextView.Item"
         android:text="@string/github"
         app:drawableStartCompat="@drawable/ic_github" />
 
-      <TextView
+      <com.google.android.material.textview.MaterialTextView
         android:id="@+id/web"
         style="@style/MwmWidget.TextView.Item"
         android:text="@string/website"
         app:drawableStartCompat="@drawable/ic_website" />
 
-      <TextView
+      <com.google.android.material.textview.MaterialTextView
         android:id="@+id/email"
         style="@style/MwmWidget.TextView.Item"
         android:text="@string/email"
         app:drawableStartCompat="@drawable/ic_email" />
 
-      <TextView
+      <com.google.android.material.textview.MaterialTextView
         android:id="@+id/matrix"
         style="@style/MwmWidget.TextView.Item"
         android:text="@string/matrix"
         app:drawableStartCompat="@drawable/ic_matrix" />
 
-      <TextView
+      <com.google.android.material.textview.MaterialTextView
         android:id="@+id/mastodon"
         style="@style/MwmWidget.TextView.Item"
         android:text="@string/mastodon"
         app:drawableStartCompat="@drawable/ic_mastodon" />
 
-      <TextView
+      <com.google.android.material.textview.MaterialTextView
         android:id="@+id/facebook"
         style="@style/MwmWidget.TextView.Item"
         android:text="@string/facebook"
         app:drawableStartCompat="@drawable/ic_facebook" />
 
-      <TextView
+      <com.google.android.material.textview.MaterialTextView
         android:id="@+id/twitter"
         style="@style/MwmWidget.TextView.Item"
         android:text="@string/twitter"
         app:drawableStartCompat="@drawable/ic_twitterx" />
 
-      <TextView
+      <com.google.android.material.textview.MaterialTextView
         android:id="@+id/instagram"
         style="@style/MwmWidget.TextView.Item"
         android:text="@string/instagram"
         app:drawableStartCompat="@drawable/ic_instagram" />
 
-      <TextView
+      <com.google.android.material.textview.MaterialTextView
         android:id="@+id/openstreetmap"
         style="@style/MwmWidget.TextView.Item"
         android:text="@string/openstreetmap"
@@ -290,17 +289,17 @@
         android:layout_marginTop="@dimen/margin_quarter"
         android:background="?dividerHorizontal" />
 
-      <TextView
+      <com.google.android.material.textview.MaterialTextView
         android:id="@+id/privacy_policy"
         style="@style/MwmWidget.TextView.Item"
         android:text="@string/privacy_policy" />
 
-      <TextView
+      <com.google.android.material.textview.MaterialTextView
         android:id="@+id/term_of_use_link"
         style="@style/MwmWidget.TextView.Item"
         android:text="@string/terms_of_use" />
 
-      <TextView
+      <com.google.android.material.textview.MaterialTextView
         android:id="@+id/copyright"
         style="@style/MwmWidget.TextView.Item"
         android:text="@string/copyright" />

--- a/android/app/src/main/res/layout/about.xml
+++ b/android/app/src/main/res/layout/about.xml
@@ -16,7 +16,7 @@
       android:orientation="vertical"
       android:padding="@dimen/margin_base">
 
-    <ImageView
+    <com.google.android.material.imageview.ShapeableImageView
         android:layout_width="@dimen/about_logo"
         android:layout_height="@dimen/about_logo"
         android:layout_gravity="center_horizontal"
@@ -26,7 +26,7 @@
         app:srcCompat="@drawable/logo"
         app:tint="?attr/colorLogo" />
 
-    <TextView
+    <com.google.android.material.textview.MaterialTextView
         android:id="@+id/version"
         android:layout_width="match_parent"
         android:layout_height="wrap_content"
@@ -37,7 +37,7 @@
         android:textIsSelectable="true"
         tools:text="2021.10.15-15-Google" />
 
-    <TextView
+    <com.google.android.material.textview.MaterialTextView
         android:layout_width="match_parent"
         android:layout_height="wrap_content"
         android:layout_marginBottom="@dimen/margin_base"
@@ -46,7 +46,7 @@
         android:textAppearance="@style/MwmTextAppearance.Headline"
         android:textColor="?android:textColorPrimary" />
 
-    <TextView
+    <com.google.android.material.textview.MaterialTextView
         android:layout_width="match_parent"
         android:layout_height="match_parent"
         android:layout_marginBottom="@dimen/margin_half"
@@ -54,7 +54,7 @@
         android:textAppearance="@style/MwmTextAppearance.Body1"
         android:textColor="?android:textColorPrimary" />
 
-    <TextView
+    <com.google.android.material.textview.MaterialTextView
         android:layout_width="match_parent"
         android:layout_height="wrap_content"
         android:layout_marginBottom="@dimen/margin_half"
@@ -62,7 +62,7 @@
         android:textAppearance="@style/MwmTextAppearance.Body1"
         android:textColor="?android:textColorPrimary" />
 
-    <TextView
+    <com.google.android.material.textview.MaterialTextView
         android:layout_width="match_parent"
         android:layout_height="wrap_content"
         android:layout_marginBottom="@dimen/margin_half"
@@ -70,7 +70,7 @@
         android:textAppearance="@style/MwmTextAppearance.Body1"
         android:textColor="?android:textColorPrimary" />
 
-    <TextView
+    <com.google.android.material.textview.MaterialTextView
         android:layout_width="match_parent"
         android:layout_height="wrap_content"
         android:layout_marginBottom="@dimen/margin_half"
@@ -84,7 +84,7 @@
         android:layout_width="match_parent"
         android:layout_height="wrap_content">
 
-      <ImageView
+      <com.google.android.material.imageview.ShapeableImageView
           android:id="@+id/osm_logo"
           android:layout_width="@dimen/osm_logo"
           android:layout_height="@dimen/osm_logo"
@@ -95,7 +95,7 @@
           app:layout_constraintStart_toStartOf="parent"
           app:layout_constraintTop_toTopOf="parent" />
 
-      <TextView
+      <com.google.android.material.textview.MaterialTextView
           android:id="@+id/osm_presentation"
           android:layout_width="0dp"
           android:layout_height="wrap_content"
@@ -111,7 +111,7 @@
           app:layout_constraintTop_toTopOf="parent" />
     </androidx.constraintlayout.widget.ConstraintLayout>
 
-    <Button
+    <com.google.android.material.button.MaterialButton
         android:id="@+id/donate"
         style="@style/MwmWidget.Button.Accent"
         android:layout_width="match_parent"
@@ -121,96 +121,95 @@
         android:padding="@dimen/margin_quarter"
         android:text="@string/donate" />
 
-    <Button
+    <com.google.android.material.button.MaterialButton
         android:id="@+id/report"
         style="@style/MwmWidget.Button"
         android:layout_width="match_parent"
         android:layout_height="wrap_content"
         android:layout_marginTop="@dimen/margin_base"
-        android:background="@color/light_gray"
         android:fontFamily="@string/robotoMedium"
         android:text="@string/report_a_bug"
         android:textColor="@color/text_dark" />
 
-    <TextView
+    <com.google.android.material.textview.MaterialTextView
       android:id="@+id/faq"
       style="@style/MwmWidget.TextView.Item"
       android:text="@string/faq"
       app:drawableStartCompat="@drawable/ic_question_mark" />
 
-    <TextView
+    <com.google.android.material.textview.MaterialTextView
         android:id="@+id/support_us"
         style="@style/MwmWidget.TextView.Item"
         android:text="@string/how_to_support_us"
         app:drawableStartCompat="@drawable/ic_donate" />
 
-    <TextView
+    <com.google.android.material.textview.MaterialTextView
         android:id="@+id/news"
         style="@style/MwmWidget.TextView.Item"
         android:text="@string/news"
         app:drawableStartCompat="@drawable/ic_news" />
 
-    <TextView
+    <com.google.android.material.textview.MaterialTextView
         android:id="@+id/rate"
         style="@style/MwmWidget.TextView.Item"
         android:text="@string/rate_the_app"
         app:drawableStartCompat="@drawable/ic_rate" />
 
-    <TextView
+    <com.google.android.material.textview.MaterialTextView
         android:id="@+id/telegram"
         style="@style/MwmWidget.TextView.Item"
         android:text="@string/telegram"
         app:drawableStartCompat="@drawable/ic_telegram" />
 
-    <TextView
+    <com.google.android.material.textview.MaterialTextView
         android:id="@+id/github"
         style="@style/MwmWidget.TextView.Item"
         android:text="@string/github"
         app:drawableStartCompat="@drawable/ic_github" />
 
-    <TextView
+    <com.google.android.material.textview.MaterialTextView
         android:id="@+id/web"
         style="@style/MwmWidget.TextView.Item"
         android:text="@string/website"
         app:drawableStartCompat="@drawable/ic_website" />
 
-    <TextView
+    <com.google.android.material.textview.MaterialTextView
         android:id="@+id/email"
         style="@style/MwmWidget.TextView.Item"
         android:text="@string/email"
         app:drawableStartCompat="@drawable/ic_email" />
 
-    <TextView
+    <com.google.android.material.textview.MaterialTextView
         android:id="@+id/matrix"
         style="@style/MwmWidget.TextView.Item"
         android:text="@string/matrix"
         app:drawableStartCompat="@drawable/ic_matrix" />
 
-    <TextView
+    <com.google.android.material.textview.MaterialTextView
         android:id="@+id/mastodon"
         style="@style/MwmWidget.TextView.Item"
         android:text="@string/mastodon"
         app:drawableStartCompat="@drawable/ic_mastodon" />
 
-    <TextView
+    <com.google.android.material.textview.MaterialTextView
         android:id="@+id/facebook"
         style="@style/MwmWidget.TextView.Item"
         android:text="@string/facebook"
         app:drawableStartCompat="@drawable/ic_facebook" />
 
-    <TextView
+    <com.google.android.material.textview.MaterialTextView
         android:id="@+id/twitter"
         style="@style/MwmWidget.TextView.Item"
         android:text="@string/twitter"
         app:drawableStartCompat="@drawable/ic_twitterx" />
 
-    <TextView
+    <com.google.android.material.textview.MaterialTextView
         android:id="@+id/instagram"
         style="@style/MwmWidget.TextView.Item"
         android:text="@string/instagram"
         app:drawableStartCompat="@drawable/ic_instagram" />
 
-    <TextView
+    <com.google.android.material.textview.MaterialTextView
         android:id="@+id/openstreetmap"
         style="@style/MwmWidget.TextView.Item"
         android:text="@string/openstreetmap"
@@ -223,17 +222,17 @@
         android:layout_marginTop="@dimen/margin_quarter"
         android:background="?dividerHorizontal" />
 
-    <TextView
+    <com.google.android.material.textview.MaterialTextView
         android:id="@+id/privacy_policy"
         style="@style/MwmWidget.TextView.Item"
         android:text="@string/privacy_policy" />
 
-    <TextView
+    <com.google.android.material.textview.MaterialTextView
         android:id="@+id/term_of_use_link"
         style="@style/MwmWidget.TextView.Item"
         android:text="@string/terms_of_use" />
 
-    <TextView
+    <com.google.android.material.textview.MaterialTextView
         android:id="@+id/copyright"
         style="@style/MwmWidget.TextView.Item"
         android:text="@string/copyright" />

--- a/android/app/src/main/res/values/styles.xml
+++ b/android/app/src/main/res/values/styles.xml
@@ -45,6 +45,7 @@
     <item name="android:layout_width">wrap_content</item>
     <item name="android:layout_height">wrap_content</item>
     <item name="android:background">?buttonBackground</item>
+    <item name="backgroundTint">@color/light_gray</item>
     <item name="android:stateListAnimator">@null</item>
     <item name="android:fontFamily">@string/robotoMedium</item>
     <item name="android:textAllCaps">true</item>
@@ -53,6 +54,7 @@
 
   <style name="MwmWidget.Button.Accent">
     <item name="android:background">?accentButtonBackground</item>
+    <item name="backgroundTint">?colorAccent</item>
     <item name="android:textColor">?accentButtonTextColor</item>
   </style>
 


### PR DESCRIPTION
This PR migrates view items in material items in Help Fragment
I will migrate all screens to simplify migration to Material 3 in the future
I have migrated:
- TextView -> MaterialTextView
- ImageView -> ShapeableImageView

This PR can introduce regression on UI for app styles which doesn't use MaterialTheme like parent theme
It also can generate castClassException

Screenshots are coming
|Before|After|
|-|-|

Todo:
- [ ] Fix secondary color of button