### PR TITLE
[search] Fix warning about deprecated implicit capture of ‘this’

### DIFF
--- a/search/search_quality/assessment_tool/search_request_runner.cpp
+++ b/search/search_quality/assessment_tool/search_request_runner.cpp
@@ -138,7 +138,7 @@ void SearchRequestRunner::RunRequest(size_t index, bool background, size_t times
 
   search::SearchParams params;
   sample.FillSearchParams(params);
-  params.m_onResults = [=](search::Results const & results)
+  params.m_onResults = [=, this](search::Results const & results)
   {
     vector<optional<ResultsEdits::Relevance>> relevances;
     vector<size_t> goldenMatching;


### PR DESCRIPTION
Fixes the following warning:

````
search_request_runner.cpp:141:24: warning: implicit capture of ‘this’ via ‘[=]’ is deprecated in C++20 [-Wdeprecated]
  141 |   params.m_onResults = [=](search::Results const & results)
      |                        ^
search_request_runner.cpp:141:24: note: add explicit ‘this’ or ‘*this’ capture
````