### PR TITLE
[packaging] Fix `metainfo-launchable-tag-wrong-value`

### DIFF
--- a/packaging/app.organicmaps.desktop.metainfo.xml
+++ b/packaging/app.organicmaps.desktop.metainfo.xml
@@ -94,7 +94,7 @@
   <url type="vcs-browser">https://github.com/organicmaps/organicmaps/</url>
   <url type="contribute">https://github.com/organicmaps/organicmaps/blob/master/docs/CONTRIBUTING.md</url>
 
-  <launchable type="desktop-id">OrganicMaps.desktop</launchable>
+  <launchable type="desktop-id">app.organicmaps.desktop.desktop</launchable>
   <screenshots>
     <screenshot type="default">
       <image>https://organicmaps.app/images/screenshots/Desktop_light_routing.png</image>


### PR DESCRIPTION
Error emitted by the validation command (on the already compiled and built repo):
````
flatpak run --command=flatpak-builder-lint org.flatpak.Builder --exceptions repo repo'
````
in the `Validate build` step of the `flathub` builds.