### PR TITLE
Fixed selection of a POI with bookmark when bookmark is not selected

### DIFF
--- a/map/framework.cpp
+++ b/map/framework.cpp
@@ -2178,6 +2178,14 @@ place_page::Info Framework::BuildPlacePageInfo(place_page::BuildInfo const & bui
     // Selection circle should match feature
     FillFeatureInfo(selectedFeature, outInfo);
 
+    if (!outInfo.IsBookmark() && !isBuildingSelected)
+    {
+      // Search for a bookmark at POI position instead of tap position
+      auto mark = FindBookMarkInPosition(outInfo.GetMercator());
+      if (mark)
+        FillBookmarkInfo(*static_cast<Bookmark const *>(mark), outInfo);
+    }
+
     if (isBuildingSelected)
       outInfo.SetMercator(buildInfo.m_mercator); // Move selection circle to tap position inside a building.
   }
@@ -2255,6 +2263,26 @@ UserMark const * Framework::FindUserMarkInTapPosition(place_page::BuildInfo cons
     {
       return type == UserMark::Type::TRACK_INFO || type == UserMark::Type::TRACK_SELECTION;
     });
+  return mark;
+}
+
+UserMark const * Framework::FindBookMarkInPosition(m2::PointD const & mercator) const
+{
+  auto const & bm = GetBookmarkManager();
+
+  UserMark const * mark = bm.FindNearestUserMark(
+      [this, &mercator](UserMark::Type type)
+      {
+        if (type == UserMark::Type::BOOKMARK || type == UserMark::Type::TRACK_INFO)
+          return df::TapInfo::GetBookmarkTapRect(mercator, m_currentModelView);
+
+        if (type == UserMark::Type::ROUTING || type == UserMark::Type::ROAD_WARNING)
+          return df::TapInfo::GetRoutingPointTapRect(mercator, m_currentModelView);
+
+        return df::TapInfo::GetDefaultTapRect(mercator, m_currentModelView);
+      },
+      [](UserMark::Type type) { return true; });
+
   return mark;
 }
 

--- a/map/framework.hpp
+++ b/map/framework.hpp
@@ -362,6 +362,7 @@ private:
   void BuildTrackPlacePage(Track::TrackSelectionInfo const & trackSelectionInfo, place_page::Info & info);
   Track::TrackSelectionInfo FindTrackInTapPosition(place_page::BuildInfo const & buildInfo) const;
   UserMark const * FindUserMarkInTapPosition(place_page::BuildInfo const & buildInfo) const;
+  UserMark const * FindBookMarkInPosition(m2::PointD const & mercator) const;
   FeatureID FindBuildingAtPoint(m2::PointD const & mercator) const;
 
   void UpdateMinBuildingsTapZoom();


### PR DESCRIPTION
Closes #4141

![poi-with-bookmark](https://github.com/user-attachments/assets/ce60761b-76ab-43cf-9d59-87b85ce30051)

When user taps on the map we do next steps:

1. Search for a bookmark at the tap position
2. Search for a POI at the tap position
3. Search for a building at the tap position.
4. Search for any feature at the tap position

I added additional bookmark search after POI is selected.