### PR TITLE
[packaging] Add screenshot captions to appstream metadata

### DIFF
--- a/packaging/app.organicmaps.desktop.metainfo.xml
+++ b/packaging/app.organicmaps.desktop.metainfo.xml
@@ -98,15 +98,19 @@
   <screenshots>
     <screenshot type="default">
       <image>https://organicmaps.app/images/screenshots/Desktop_light_routing.png</image>
+      <caption>Routing in dark mode</caption>
     </screenshot>
     <screenshot>
       <image>https://organicmaps.app/images/screenshots/Desktop_dark_routing.png</image>
+      <caption>Routing in light mode</caption>
     </screenshot>
     <screenshot>
       <image>https://organicmaps.app/images/screenshots/Desktop_light_overview.png</image>
+      <caption>Map overview in light mode</caption>
     </screenshot>
     <screenshot>
       <image>https://organicmaps.app/images/screenshots/Desktop_dark_overview.png</image>
+      <caption>Map overview in dark mode</caption>
     </screenshot>
   </screenshots>
 


### PR DESCRIPTION
Fixes the following warning:
````
"warnings": [
    "appstream-screenshot-missing-caption"
],
"info": [
    "appstream-screenshot-missing-caption: One or more screenshots are missing captions in the Metainfo file"
],
````
emitted by the validation command (on the already compiled and built repo).

See the occurence in:
https://buildbot.flathub.org/#/builders/26/builds/16574/steps/11/logs/stdio

Also the `Run appstreamcli in pedantic mode` step of the `validate-appstream` GH Action job reports the detailed line numbers:
````
P: app.organicmaps.desktop:99: screenshot-no-caption
P: app.organicmaps.desktop:102: screenshot-no-caption
P: app.organicmaps.desktop:105: screenshot-no-caption
P: app.organicmaps.desktop:108: screenshot-no-caption
````