### PR TITLE
[core][android] Display profile picture in profile page

### DIFF
--- a/android/app/src/main/cpp/app/organicmaps/editor/OsmOAuth.cpp
+++ b/android/app/src/main/cpp/app/organicmaps/editor/OsmOAuth.cpp
@@ -9,6 +9,7 @@
 
 #include "editor/osm_auth.hpp"
 #include "editor/server_api.hpp"
+#include "editor/profile_picture.hpp"
 
 namespace
 {
@@ -86,7 +87,7 @@ Java_app_organicmaps_editor_OsmOAuth_nativeGetOsmUsername(JNIEnv * env, jclass, 
   UserPreferences prefs;
   if (LoadOsmUserPreferences(jni::ToNativeString(env, oauthToken), prefs))
     return jni::ToJavaString(env, prefs.m_displayName);
-  return nullptr;
+  return jstring();
 }
 
 JNIEXPORT jint JNICALL
@@ -99,12 +100,12 @@ Java_app_organicmaps_editor_OsmOAuth_nativeGetOsmChangesetsCount(JNIEnv * env, j
 }
 
 JNIEXPORT jstring JNICALL
-Java_app_organicmaps_editor_OsmOAuth_nativeGetOsmProfilePictureUrl(JNIEnv * env, jclass, jstring oauthToken)
+Java_app_organicmaps_editor_OsmOAuth_nativeGetOsmProfilePicturePath(JNIEnv * env, jclass, jstring oauthToken)
 {
   UserPreferences prefs;
-  if (LoadOsmUserPreferences(jni::ToNativeString(env, oauthToken), prefs))
-    return jni::ToJavaString(env, prefs.m_imageUrl);
-  return nullptr;
+  LoadOsmUserPreferences(jni::ToNativeString(env, oauthToken), prefs);
+  std::string img_path = editor::ProfilePicture::download(prefs.m_imageUrl);
+  return jni::ToJavaString(env, img_path);
 }
 
 JNIEXPORT jstring JNICALL

--- a/android/app/src/main/java/app/organicmaps/settings/SettingsPrefsFragment.java
+++ b/android/app/src/main/java/app/organicmaps/settings/SettingsPrefsFragment.java
@@ -83,7 +83,8 @@ public class SettingsPrefsFragment extends BaseXmlSettingsFragment
     final Preference pref = getPreference(getString(R.string.pref_osm_profile));
     if (OsmOAuth.isAuthorized(requireContext()))
     {
-      final String username = OsmOAuth.getUsername(requireContext());
+      // Only update profile when visiting profile page
+      final String username = OsmOAuth.getUsername(requireContext(), false);
       pref.setSummary(username);
     }
     else

--- a/android/app/src/main/res/layout/fragment_osm_profile.xml
+++ b/android/app/src/main/res/layout/fragment_osm_profile.xml
@@ -49,7 +49,7 @@
           android:layout_width="100dp"
           android:layout_height="match_parent"
           android:importantForAccessibility="no"
-          app:srcCompat="@drawable/profile_generic" />
+          tools:src="@drawable/profile_generic" />
       <LinearLayout
           android:id="@+id/text"
           android:layout_marginStart="@dimen/margin_base"

--- a/defines.hpp
+++ b/defines.hpp
@@ -78,6 +78,7 @@
 #define WORLD_COASTS_FILE_NAME "WorldCoasts"
 
 #define SETTINGS_FILE_NAME "settings.ini"
+#define PROFILE_PICTURE_FILENAME "profile_picture"
 #define MARKETING_SETTINGS_FILE_NAME "marketing_settings.ini"
 
 #define SEARCH_CATEGORIES_FILE_NAME "categories.txt"

--- a/editor/CMakeLists.txt
+++ b/editor/CMakeLists.txt
@@ -26,6 +26,8 @@ set(SRC
   osm_auth.hpp
   osm_editor.cpp
   osm_editor.hpp
+  profile_picture.cpp
+  profile_picture.hpp
   server_api.cpp
   server_api.hpp
   ui2oh.cpp

--- a/editor/profile_picture.cpp
+++ b/editor/profile_picture.cpp
@@ -1,0 +1,54 @@
+#include "editor/profile_picture.hpp"
+
+#include "platform/remote_file.hpp"
+#include "platform/platform.hpp"
+#include "platform/settings.hpp"
+
+#include "filesystem"
+
+// Example pic_url: https://www.openstreetmap.org/rails/active_storage/representations/redirect/eyJfcmFpbHMiOnsiZGF0YSI6MzM1MjcxMDUsInB1ciI6ImJsb2JfaWQifX0=--957a2a99111c97d4b9f4181003c3e69713a221c6/eyJfcmFpbHMiOnsiZGF0YSI6eyJmb3JtYXQiOiJwbmciLCJyZXNpemVfdG9fbGltaXQiOlsxMDAsMTAwXX0sInB1ciI6InZhcmlhdGlvbiJ9fQ==--473f0190a9e741bb16565db85fe650d7b0a9ee69/cat.png
+// Example hash: 473f0190a9e741bb16565db85fe650d7b0a9ee69
+namespace editor
+{
+  std::string ProfilePicture::download(const std::string& pic_url)
+  {
+    std::string image_path = GetPlatform().WritablePathForFile(PROFILE_PICTURE_FILENAME);
+    bool image_exists = std::filesystem::exists(image_path);
+
+    if(!pic_url.empty()) // If internet available
+    {
+      if(pic_url != "none")
+      {
+        // Get new hash (hash start always includes '=--' but is usually '==--')
+        const int hash_start = static_cast<int>(pic_url.rfind("=--") + 3);
+        const int length = static_cast<int>(pic_url.rfind('/') - hash_start);
+        std::string new_hash = pic_url.substr(hash_start, length);
+
+        // Get cached hash
+        std::string current_hash;
+        settings::StringStorage::Instance().GetValue("ProfilePictureHash", current_hash);
+
+        // Download new image
+        if (new_hash != current_hash || !image_exists)
+        {
+          settings::StringStorage::Instance().SetValue("ProfilePictureHash", std::move(new_hash));
+          platform::RemoteFile remoteFile(pic_url);
+          remoteFile.Download(image_path);
+          image_exists = true;
+        }
+      }
+      else
+      {
+        // User has removed profile picture online
+        settings::StringStorage::Instance().DeleteKeyAndValue("ProfilePictureHash");
+        std::filesystem::remove(image_path);
+        image_exists = false;
+      }
+    }
+
+    if(image_exists)
+      return image_path;
+    else
+      return {};
+  }
+}

--- a/editor/profile_picture.hpp
+++ b/editor/profile_picture.hpp
@@ -1,0 +1,14 @@
+#pragma once
+
+#include <string>
+
+namespace editor
+{
+class ProfilePicture
+{
+public:
+    // Returns downloaded image or cached image if one exists.
+    // if not, an empty string is returned.
+    static std::string download(const std::string& pic_url);
+};
+}

--- a/editor/server_api.cpp
+++ b/editor/server_api.cpp
@@ -167,8 +167,9 @@ UserPreferences ServerApi06::GetUserPreferences() const
   pref.m_id = user.attribute("id").as_ullong();
   pref.m_displayName = user.attribute("display_name").as_string();
   pref.m_accountCreated = base::StringToTimestamp(user.attribute("account_created").as_string());
-  pref.m_imageUrl = user.child("img").attribute("href").as_string();
   pref.m_changesets = user.child("changesets").attribute("count").as_uint();
+  // Return "none if profile has no 'img', to differentiate from no network
+  pref.m_imageUrl = user.child("img")? user.child("img").attribute("href").as_string() : "none";
   return pref;
 }
 


### PR DESCRIPTION
Caches image & hash, and uses the hash to check if a new image needs downloading, so works well online and offline.

also moved the networkpolicy check to the placepage, along with bools for functions that access the internet to explicitly specify it, preventing unintentional network access.

also fixes https://github.com/organicmaps/organicmaps/issues/6340

To do:
- ~~needs to respect the networkpolicy.~~ -done
- iOS implementation also needed. (at least to handle editor/server_api's m_imageUrl pref returning "none" sometimes, if not a full implementation)


<img width="300px" src="https://github.com/user-attachments/assets/cb7e0d01-8929-47e0-a1c4-b1c7ea22363d"/>
