### PR TITLE
[android] align main screen buttons in landscape

### DIFF
--- a/android/app/src/main/res/layout-land/map_buttons_bottom.xml
+++ b/android/app/src/main/res/layout-land/map_buttons_bottom.xml
@@ -12,7 +12,6 @@
     layout="@layout/map_buttons_help"
     android:layout_width="wrap_content"
     android:layout_height="wrap_content"
-    android:layout_marginStart="@dimen/margin_half"
     app:layout_constraintBottom_toBottomOf="parent"
     app:layout_constraintStart_toStartOf="parent" />
   <include
@@ -33,7 +32,6 @@
     layout="@layout/map_buttons_menu"
     android:layout_width="wrap_content"
     android:layout_height="wrap_content"
-    android:layout_marginEnd="@dimen/margin_half"
     app:layout_constraintBottom_toBottomOf="parent"
     app:layout_constraintEnd_toEndOf="parent" />
 </androidx.constraintlayout.widget.ConstraintLayout>


### PR DESCRIPTION
aligns lower buttons with the zoom & position buttons

New/old
(red blocks are same size)
![rect2](https://github.com/user-attachments/assets/94113e51-1d5a-49b9-8e3e-bbbabaac3537)

