### PR TITLE
[android] Increase size of OSM link on OSM profile

### DIFF
--- a/android/app/src/main/res/layout/fragment_osm_profile.xml
+++ b/android/app/src/main/res/layout/fragment_osm_profile.xml
@@ -101,9 +101,8 @@
         android:paddingTop="@dimen/margin_half"
         android:paddingBottom="@dimen/margin_half"
         android:text="@string/history"
-        android:textAppearance="@style/MwmTextAppearance.Body4"
+        android:textAppearance="@style/MwmTextAppearance.Body2"
         android:textColor="?colorAccent"
-        android:textSize="@dimen/text_size_body_1"
         app:layout_constraintTop_toTopOf="parent"/>
     <TextView
         android:id="@+id/about_osm"
@@ -115,9 +114,8 @@
         android:paddingTop="@dimen/margin_half"
         android:paddingBottom="@dimen/margin_half"
         android:text="@string/editor_more_about_osm"
-        android:textAppearance="@style/MwmTextAppearance.Body4"
+        android:textAppearance="@style/MwmTextAppearance.Body3"
         android:textColor="?colorAccent"
-        android:textSize="@dimen/text_size_body_4"
         app:layout_constraintBottom_toBottomOf="parent"
         app:layout_constraintTop_toBottomOf="@+id/osm_history"
         app:layout_constraintVertical_bias="1" />


### PR DESCRIPTION
This PR:
- On osm_history item, I have removed textSize property and and applied MwmTextAppearance.Body2 (Style and size don't change, always 16 sp)
- On about_osm item, I have removed textSize property and applied MwmTextAppearance.Body3 (size of text has changed 12 to 14sp)

|Before|After|
|-|-|
|<img src="https://github.com/user-attachments/assets/59b0757d-8aab-48d4-a38b-daed507b68d4" height=300 />|<img src="https://github.com/user-attachments/assets/c861f8a4-5193-49fc-9043-fb5d9a48d464" height=300 />|