### PR TITLE
[bookmarks] [ios] Mark deleted categories with `.deleted` postfix instead of file deletion

### DIFF
--- a/map/bookmark_helpers.cpp
+++ b/map/bookmark_helpers.cpp
@@ -252,17 +252,19 @@ std::string GenerateUniqueFileName(std::string const & path, std::string name, s
     name.resize(name.size() - ext.size());
 
   size_t counter = 1;
-  std::string suffix, res;
+  std::string suffix, resultFilePath, deletedFilePath;
   do
   {
-    res = name;
-    res = base::JoinPath(path, res.append(suffix).append(ext));
-    if (!Platform::IsFileExistsByFullPath(res))
+    resultFilePath = name;
+    deletedFilePath = name;
+    resultFilePath = base::JoinPath(path, resultFilePath.append(suffix).append(ext));
+    deletedFilePath = base::JoinPath(path, deletedFilePath.append(suffix).append(ext).append(kDeletedExtension));
+    if (!Platform::IsFileExistsByFullPath(resultFilePath) && !Platform::IsFileExistsByFullPath(deletedFilePath))
       break;
     suffix = strings::to_string(counter++);
   } while (true);
 
-  return res;
+  return resultFilePath;
 }
 
 std::string GenerateValidAndUniqueFilePathForKML(std::string const & fileName)
@@ -281,6 +283,15 @@ std::string GenerateValidAndUniqueFilePathForGPX(std::string const & fileName)
     filePath = kDefaultBookmarksFileName;
 
   return GenerateUniqueFileName(GetBookmarksDirectory(), std::move(filePath), kGpxExtension);
+}
+
+std::string GenerateValidAndUniqueDeletedFilePath(std::string const & fileName)
+{
+  std::string filePath = RemoveInvalidSymbols(fileName);
+  if (filePath.empty())
+    filePath = kDefaultBookmarksFileName;
+
+  return GenerateUniqueFileName(GetBookmarksDirectory(), std::move(filePath), kDeletedExtension);
 }
 
 std::string const kDefaultBookmarksFileName = "Bookmarks";

--- a/map/bookmark_helpers.hpp
+++ b/map/bookmark_helpers.hpp
@@ -69,6 +69,7 @@ std::string_view constexpr kKmzExtension = ".kmz";
 std::string_view constexpr kKmlExtension = ".kml";
 std::string_view constexpr kKmbExtension = ".kmb";
 std::string_view constexpr kGpxExtension = ".gpx";
+std::string_view constexpr kDeletedExtension = ".deleted";
 extern std::string const kDefaultBookmarksFileName;
 
 enum class KmlFileType
@@ -96,6 +97,7 @@ std::string RemoveInvalidSymbols(std::string const & name);
 std::string GenerateUniqueFileName(const std::string & path, std::string name, std::string_view ext = kKmlExtension);
 std::string GenerateValidAndUniqueFilePathForKML(std::string const & fileName);
 std::string GenerateValidAndUniqueFilePathForGPX(std::string const & fileName);
+std::string GenerateValidAndUniqueDeletedFilePath(std::string const & fileName);
 /// @}
 
 /// @name SerDes helpers.

--- a/map/bookmark_manager.hpp
+++ b/map/bookmark_manager.hpp
@@ -161,8 +161,11 @@ public:
     void SetCategoryAccessRules(kml::MarkGroupId categoryId, kml::AccessRules accessRules);
     void SetCategoryCustomProperty(kml::MarkGroupId categoryId, std::string const & key,
                                    std::string const & value);
-    bool DeleteBmCategory(kml::MarkGroupId groupId);
-
+    
+    /// Removes the category from the list of categories and deletes the related file.
+    /// - Parameters:
+    ///   - permanently: If true (default value), the file will be removed from the disk. If false, the file will be set as deleted.
+    bool DeleteBmCategory(kml::MarkGroupId groupId, bool permanently = true);
     void NotifyChanges();
 
   private:
@@ -378,6 +381,13 @@ public:
   bool HasRecentlyDeletedBookmark() const { return m_recentlyDeletedBookmark.operator bool(); };
   void ResetRecentlyDeletedBookmark();
 
+  bool HasRecentlyDeletedCategories() const;
+  BookmarkManager::KMLDataCollectionPtr GetRecentlyDeletedCategories();
+  bool IsRecentlyDeletedCategory(std::string const & filePath) const;
+
+  void RecoverRecentlyDeletedCategoriesAtPaths(std::vector<std::string> const & filePaths);
+  void DeleteRecentlyDeletedCategoriesAtPaths(std::vector<std::string> const & filePaths);
+
   // Used for LoadBookmarks() and unit tests only. Does *not* update last modified time.
   void CreateCategories(KMLDataCollection && dataCollection, bool autoSave = false);
 
@@ -581,8 +591,9 @@ private:
   void SetCategoryTags(kml::MarkGroupId categoryId, std::vector<std::string> const & tags);
   void SetCategoryAccessRules(kml::MarkGroupId categoryId, kml::AccessRules accessRules);
   void SetCategoryCustomProperty(kml::MarkGroupId categoryId, std::string const & key, std::string const & value);
-  bool DeleteBmCategory(kml::MarkGroupId groupId, bool deleteFile);
+  bool DeleteBmCategory(kml::MarkGroupId groupId, bool permanently);
   void ClearCategories();
+  void UpdateLastModifiedTime(const std::string & filePath);
 
   void MoveBookmark(kml::MarkId bmID, kml::MarkGroupId curGroupID, kml::MarkGroupId newGroupID);
   void UpdateBookmark(kml::MarkId bmId, kml::BookmarkData const & bm);

--- a/map/map_tests/bookmarks_test.cpp
+++ b/map/map_tests/bookmarks_test.cpp
@@ -1530,4 +1530,47 @@ UNIT_CLASS_TEST(Runner, Bookmarks_BrokenFile)
   auto kmlData = LoadKmlFile(fileName, KmlFileType::Binary);
   TEST(kmlData == nullptr, ());
 }
+
+UNIT_CLASS_TEST(Runner, Bookmarks_RecentlyDeleted)
+{
+  BookmarkManager bmManager(BM_CALLBACKS);
+  bmManager.EnableTestMode(true);
+  auto const dir = GetBookmarksDirectory();
+  bool const delDirOnExit = Platform::MkDir(dir) == Platform::ERR_OK;
+  SCOPE_GUARD(dirDeleter, [&](){ if (delDirOnExit) (void)Platform::RmDir(dir); });
+
+  std::string const filePath = base::JoinPath(dir, "file" + std::string{kKmlExtension});
+  BookmarkManager::KMLDataCollection kmlDataCollection;
+  kmlDataCollection.emplace_back(filePath, LoadKmlData(MemReader(kmlString, std::strlen(kmlString)), KmlFileType::Text));
+
+  FileWriter w(filePath);
+  w.Write(kmlDataCollection.data(), kmlDataCollection.size());
+
+  TEST(kmlDataCollection.back().second, ());
+  bmManager.CreateCategories(std::move(kmlDataCollection));
+  TEST_EQUAL(bmManager.GetBmGroupsCount(), 1, ());
+
+  auto const groupId = bmManager.GetUnsortedBmGroupsIdList().front();
+
+  bmManager.GetEditSession().DeleteBmCategory(groupId, false /* permanently */);
+  TEST_EQUAL(bmManager.GetBmGroupsCount(), 0, ());
+
+  auto const deletedCategories = bmManager.GetRecentlyDeletedCategories();
+  TEST_EQUAL(deletedCategories->size(), 1, ());
+  TEST(bmManager.HasRecentlyDeletedCategories(), ());
+
+  auto const & deletedCategory = deletedCategories->front();
+  TEST_EQUAL(base::GetFileExtension(deletedCategory.first), std::string{kDeletedExtension}, ());
+
+  auto const deletedFilePath = filePath + std::string{kDeletedExtension};
+  TEST_EQUAL(deletedCategory.first, deletedFilePath, ());
+
+  bmManager.DeleteRecentlyDeletedCategoriesAtPaths({ deletedFilePath });
+  TEST_EQUAL(bmManager.GetBmGroupsCount(), 0, ());
+  TEST_EQUAL(bmManager.GetRecentlyDeletedCategories()->size(), 0, ());
+  TEST(!bmManager.HasRecentlyDeletedCategories(), ());
+
+  TEST(!Platform::IsFileExistsByFullPath(filePath), ());
+  TEST(!Platform::IsFileExistsByFullPath(deletedFilePath), ());
+}
 } // namespace bookmarks_test


### PR DESCRIPTION
The base part of the #7978 

This PR changes the categories deletion process from removing the file to the marking it with the '.deleted' prefix.

 `file.km` -> User presses "Delete category" -> `file.km.deleted`

#### Key points:
1. This PR **doesn't changes the iCloud sync process**. The deleted files will not be visible to sync and will not appear in the cloud local container. So sync the behavior doesnt changed.
2. This behavior doesn't affect Android (because there is no sense in deleting the categories without the UI restoring them). But can be easily implemented by passing the  `permanently = false` into the `DeleteBmCategory` method
3.  When the user deletes a category it will be removed from the categories list and the related file will be marked with the `.deleted` extension
4.  When the user deletes the category `file.kml` and creates (or imports) a new category with the same name the newly created file will have the `file1.kml` name to avoid conflicts with the "old" `file.kml` + `file.kml.deleted`. This allows to recover the `file.kml.deleted` without renaming
