### PR TITLE
[ios] Implement iCloud failure alert with bug report and Refactor error handling

### DIFF
--- a/data/strings/strings.txt
+++ b/data/strings/strings.txt
@@ -30258,6 +30258,52 @@
     zh-Hans = 查看菜单
     zh-Hant = 查看選單
 
+  [bugreport_alert_message]
+    comment = Message for the bug report alert.
+    tags = ios
+    en = Would you like to send a bug report to the developers?\nWe rely on our users as Organic Maps doesn't collect any error information automatically. Thank you in advance for supporting Organic Maps!
+    af = Wil jy 'n foutverslag aan die ontwikkelaars stuur?\nOns maak staat op ons gebruikers aangesien Organic Maps nie outomaties enige foutinligting insamel nie. By voorbaat dankie vir die ondersteuning van Organic Maps!
+    ar = هل ترغب في إرسال تقرير عن الأخطاء إلى المطورين؟\nنحن نعتمد على مستخدمينا لأن تطبيق Organic Maps لا يجمع أي معلومات عن الأخطاء تلقائيًا. شكرًا لك مقدمًا على دعم الخرائط العضوية!
+    az = Tərtibatçılara səhv hesabatı göndərmək istərdinizmi?\nÜzvi Xəritələr heç bir səhv məlumatını avtomatik toplamadığından istifadəçilərimizə etibar edirik. Üzvi Xəritələri dəstəklədiyiniz üçün əvvəlcədən təşəkkür edirik!
+    be = Хочаце адправіць справаздачу пра памылку распрацоўшчыкам?\nМы разлічваем на нашых карыстальнікаў, бо Organic Maps не збірае ніякай інфармацыі пра памылкі аўтаматычна. Загадзя дзякуем за падтрымку Organic Maps!
+    bg = Искате ли да изпратите доклад за грешка на разработчиците?\nРазчитаме на нашите потребители, тъй като Organic Maps не събира информация за грешки автоматично. Благодарим ви предварително, че подкрепяте Organic Maps!
+    ca = Voleu enviar un informe d'error als desenvolupadors?\nConfiem en els nostres usuaris, ja que Organic Maps no recull cap informació d'error automàticament. Gràcies per avançat per donar suport a Organic Maps!
+    cs = Chcete poslat vývojářům hlášení o chybě?\nSpoléháme na naše uživatele, protože společnost Organic Maps neshromažďuje žádné informace o chybách automaticky. Předem vám děkujeme za podporu Organic Maps!
+    da = Vil du gerne sende en fejlrapport til udviklerne?\nVi er afhængige af vores brugere, da Organic Maps ikke indsamler nogen fejloplysninger automatisk. Tak på forhånd for at støtte Organic Maps!
+    de = Willst du einen Fehlerbericht an die Entwickler schicken?\nWir sind auf unsere Nutzer angewiesen, da Organic Maps keine Fehlerinformationen automatisch sammelt. Wir danken dir im Voraus für deine Unterstützung von Organic Maps!
+    el = Θα θέλατε να στείλετε μια αναφορά σφάλματος στους προγραμματιστές;\nΒασιζόμαστε στους χρήστες μας, καθώς οι Organic Maps δεν συλλέγουν αυτόματα καμία πληροφορία σφάλματος. Σας ευχαριστούμε εκ των προτέρων για την υποστήριξη των Organic Maps!
+    es = ¿Quieres enviar un informe de error a los desarrolladores?\nConfiamos en nuestros usuarios, ya que Mapas ecológicos no recoge ninguna información sobre errores de forma automática. ¡Gracias de antemano por apoyar a Organic Maps!
+    et = Kas soovite saata arendajatele veateate?\nMe toetume oma kasutajatele, kuna Organic Maps ei kogu automaatselt mingit veateavet. Täname teid juba ette Organic Maps'i toetamise eest!
+    eu = Akatsen txostena bidali nahi diezu garatzaileei?\nGure erabiltzaileengan oinarritzen gara Organic Maps-ek ez baitu automatikoki akatsen informaziorik biltzen. Eskerrik asko aldez aurretik Maps organikoak laguntzeagatik!
+    fa = آیا می خواهید یک گزارش اشکال برای توسعه دهندگان ارسال کنید؟\nما به کاربران خود تکیه می کنیم زیرا نقشه های ارگانیک هیچ گونه اطلاعات خطا را به طور خودکار جمع آوری نمی کند. پیشاپیش از شما برای حمایت از نقشه های ارگانیک سپاسگزاریم!
+    fi = Haluatko lähettää vikailmoituksen kehittäjille?\nLuotamme käyttäjiin, sillä Organic Maps ei kerää virhetietoja automaattisesti. Kiitos etukäteen Organic Mapsin tukemisesta!
+    fr = Veux-tu envoyer un rapport de bogue aux développeurs ?\nNous comptons sur nos utilisateurs, car Organic Maps ne recueille pas automatiquement d'informations sur les erreurs. Merci d'avance de soutenir Organic Maps !
+    he = האם תרצה לשלוח דוח באג למפתחים?\nאנו סומכים על המשתמשים שלנו מכיוון שמפות אורגניות לא אוספות כל מידע על שגיאות באופן אוטומטי. תודה מראש על התמיכה במפות אורגניות!
+    hi = क्या आप डेवलपर्स को बग रिपोर्ट भेजना चाहेंगे?\nहम अपने उपयोगकर्ताओं पर भरोसा करते हैं क्योंकि ऑर्गेनिक मैप्स स्वचालित रूप से कोई त्रुटि जानकारी एकत्र नहीं करता है। ऑर्गेनिक मैप्स का समर्थन करने के लिए अग्रिम धन्यवाद!
+    hu = Szeretne hibajelentést küldeni a fejlesztőknek?\nFelhasználóinkra támaszkodunk, mivel az Organic Maps nem gyűjt automatikusan hibainformációkat. Előre is köszönjük, hogy támogatja az Organic Maps-et!
+    id = Apakah Anda ingin mengirim laporan bug ke pengembang?\nKami mengandalkan pengguna kami karena Organic Maps tidak mengumpulkan informasi kesalahan secara otomatis. Terima kasih sebelumnya karena telah mendukung Peta Organik!
+    it = Vuoi inviare una segnalazione di bug agli sviluppatori?\nCi affidiamo ai nostri utenti perché Organic Maps non raccoglie automaticamente informazioni sugli errori. Ti ringraziamo in anticipo per il supporto a Organic Maps!
+    ja = 開発者にバグレポートを送りたいか？\nオーガニック・マップはエラー情報を自動収集しないため、我々はユーザーに依存している。Organic Mapsを応援してくださりありがとう！
+    ko = 개발자에게 버그 리포트를 보내시겠습니까?\n오가닉 맵은 오류 정보를 자동으로 수집하지 않으므로 사용자의 도움을 받아야 합니다. 오가닉 맵을 이용해 주셔서 미리 감사드립니다!
+    lt = Ar norėtumėte išsiųsti pranešimą apie klaidą kūrėjams?\nMes pasikliaujame savo naudotojais, nes "Organic Maps" nerenka jokios informacijos apie klaidas automatiškai. Iš anksto dėkojame, kad remiate "Organic Maps"!
+    mr = तुम्ही विकासकांना बग अहवाल पाठवू इच्छिता?\nआम्ही आमच्या वापरकर्त्यांवर अवलंबून आहोत कारण सेंद्रिय नकाशे कोणतीही त्रुटी माहिती स्वयंचलितपणे संकलित करत नाही. ऑरगॅनिक नकाशेला समर्थन दिल्याबद्दल आगाऊ धन्यवाद!
+    nb = Vil du sende en feilrapport til utviklerne?\nVi er avhengige av brukerne våre, da Organic Maps ikke samler inn noen feilinformasjon automatisk. Takk på forhånd for at du støtter Organic Maps!
+    nl = Wil je een bugrapport naar de ontwikkelaars sturen?\nWe vertrouwen op onze gebruikers, want Organic Maps verzamelt geen foutinformatie automatisch. Alvast bedankt voor je steun aan Organic Maps!
+    pl = Chcesz wysłać raport o błędzie do deweloperów?\nPolegamy na naszych użytkownikach, ponieważ Organic Maps nie zbiera żadnych informacji o błędach automatycznie. Z góry dziękujemy za wspieranie Organic Maps!
+    pt = Gostarias de enviar um relatório de erro para os programadores?\nContamos com os nossos utilizadores, uma vez que o Organic Maps não recolhe automaticamente qualquer informação de erro. Agradecemos desde já o teu apoio ao Organic Maps!
+    pt-BR = Você gostaria de enviar um relatório de bug para os desenvolvedores?\nDependemos de nossos usuários, pois o Organic Maps não coleta nenhuma informação de erro automaticamente. Agradecemos antecipadamente por você apoiar o Organic Maps!
+    ro = Doriți să trimiteți un raport de eroare dezvoltatorilor?\nNe bazăm pe utilizatorii noștri, deoarece Organic Maps nu colectează automat nicio informație privind erorile. Vă mulțumim anticipat pentru susținerea Organic Maps!
+    ru = Хотите отправить разработчикам сообщение об ошибке?\nМы полагаемся на наших пользователей, так как Organic Maps не собирает информацию об ошибках автоматически. Заранее спасибо за поддержку Organic Maps!
+    sk = Chcete poslať vývojárom hlásenie o chybe?\nSpoliehame sa na našich používateľov, pretože spoločnosť Organic Maps nezhromažďuje žiadne informácie o chybách automaticky. Vopred vám ďakujeme za podporu Organic Maps!
+    sv = Vill du skicka en felrapport till utvecklarna?\nVi förlitar oss på våra användare eftersom organiska kartor inte samlar in någon felinformation automatiskt. Tack på förhand för att du stöder Organic Maps!
+    sw = Je, ungependa kutuma ripoti ya hitilafu kwa wasanidi programu?\nTunategemea watumiaji wetu kwani Ramani za Kikaboni hazikusanyi maelezo yoyote ya hitilafu kiotomatiki. Asante mapema kwa kusaidia Ramani za Organic!
+    th = คุณต้องการส่งรายงานข้อผิดพลาดไปยังนักพัฒนาหรือไม่?\nเราไว้วางใจผู้ใช้ของเราเนื่องจาก Organic Maps จะไม่รวบรวมข้อมูลข้อผิดพลาดใด ๆ โดยอัตโนมัติ ขอขอบคุณล่วงหน้าสำหรับการสนับสนุน Organic Maps!
+    tr = Geliştiricilere bir hata raporu göndermek ister misiniz?\nOrganic Maps otomatik olarak herhangi bir hata bilgisi toplamadığı için kullanıcılarımıza güveniyoruz. Organic Maps'i desteklediğiniz için şimdiden teşekkür ederiz!
+    uk = Бажаєте надіслати розробникам звіт про помилку?\nМи покладаємося на наших користувачів, оскільки Organic Maps не збирає інформацію про помилки автоматично. Заздалегідь дякуємо за підтримку Organic Maps!
+    vi = Bạn có muốn gửi báo cáo lỗi cho nhà phát triển không?\nChúng tôi dựa vào người dùng của mình vì Bản đồ không phải trả tiền không tự động thu thập bất kỳ thông tin lỗi nào. Cảm ơn bạn trước vì đã ủng hộ Organic Maps!
+    zh-Hans = 您想向开发人员发送错误报告吗？\n由于有机地图不会自动收集任何错误信息，因此我们只能依靠我们的用户。感谢您对有机地图的支持！
+    zh-Hant = 您想向開發人員發送錯誤報告嗎？\n我們依賴我們的用戶，因為有機地圖不會自動收集任何錯誤訊息。預先感謝您對有機地圖的支持！
+
   [enable_icloud_synchronization_title]
     comment = Title for the "Enable iCloud Syncronization" alert.
     tags = ios
@@ -30536,6 +30582,52 @@
     vi = Hỗ trợ
     zh-Hans = 备份
     zh-Hant = 备份
+
+  [icloud_synchronization_error_alert_title]
+    comment = Title for the "iCloud synchronization failure" alert.
+    tags = ios
+    en = iCloud synchronization failure
+    af = iCloud-sinchronisasie mislukking
+    ar = فشل مزامنة iCloud
+    az = iCloud sinxronizasiya uğursuzluğu
+    be = Збой сінхранізацыі iCloud
+    bg = Неуспешна синхронизация на iCloud
+    ca = Error de sincronització d'iCloud
+    cs = Selhání synchronizace iCloudu
+    da = Fejl i iCloud-synkronisering
+    de = iCloud-Synchronisierung fehlgeschlagen
+    el = Αποτυχία συγχρονισμού iCloud
+    es = Fallo de sincronización de iCloud
+    et = iCloudi sünkroniseerimise tõrge
+    eu = iCloud sinkronizazioaren hutsegitea
+    fa = همگام سازی iCloud شکست خورده است
+    fi = iCloud-synkronoinnin epäonnistuminen
+    fr = Échec de la synchronisation iCloud
+    he = כשל בסינכרון iCloud
+    hi = iCloud सिंक्रनाइज़ेशन विफलता
+    hu = iCloud-szinkronizálási hiba
+    id = Kegagalan sinkronisasi iCloud
+    it = Mancata sincronizzazione di iCloud
+    ja = iCloud同期の失敗
+    ko = iCloud 동기화 실패
+    lt = "iCloud" sinchronizavimo sutrikimas
+    mr = iCloud सिंक्रोनाइझेशन अयशस्वी
+    nb = iCloud-synkroniseringsfeil
+    nl = Storing iCloud-synchronisatie
+    pl = Błąd synchronizacji iCloud
+    pt = Falha de sincronização do iCloud
+    pt-BR = Falha na sincronização do iCloud
+    ro = Eșecul sincronizării iCloud
+    ru = Сбой синхронизации iCloud
+    sk = Zlyhanie synchronizácie iCloud
+    sv = fel i iCloud-synkroniseringen
+    sw = Imeshindwa kusawazisha iCloud
+    th = การซิงโครไนซ์ iCloud ล้มเหลว
+    tr = iCloud senkronizasyon hatası
+    uk = Збій синхронізації iCloud
+    vi = Lỗi đồng bộ hóa iCloud
+    zh-Hans = iCloud 同步失败
+    zh-Hant = iCloud 同步失敗
 
   [icloud_synchronization_error_connection_error]
     comment = iCloud error message: Failed to synchronize due to connection error

--- a/iphone/Maps/Classes/CustomAlert/AlertController/MWMAlertViewController.h
+++ b/iphone/Maps/Classes/CustomAlert/AlertController/MWMAlertViewController.h
@@ -43,6 +43,7 @@
                                                      callback:(nonnull MWMCheckStringBlock)callback;
 
 - (void)presentBookmarkConversionErrorAlert;
+- (void)presentBugReportAlertWithTitle:(nonnull NSString *)title;
 
 - (void)presentDefaultAlertWithTitle:(nonnull NSString *)title
                              message:(nullable NSString *)message

--- a/iphone/Maps/Classes/CustomAlert/AlertController/MWMAlertViewController.mm
+++ b/iphone/Maps/Classes/CustomAlert/AlertController/MWMAlertViewController.mm
@@ -192,6 +192,10 @@ static NSString *const kAlertControllerNibIdentifier = @"MWMAlertViewController"
   [self displayAlert:[MWMAlert tagsLoadingErrorAlertWithOkBlock:okBlock cancelBlock:cancelBlock]];
 }
 
+- (void)presentBugReportAlertWithTitle:(nonnull NSString *)title {
+  [self displayAlert:[MWMAlert bugReportAlertWithTitle:title]];
+}
+
 - (void)presentDefaultAlertWithTitle:(nonnull NSString *)title
                              message:(nullable NSString *)message
                     rightButtonTitle:(nonnull NSString *)rightButtonTitle

--- a/iphone/Maps/Classes/CustomAlert/BaseAlert/MWMAlert.h
+++ b/iphone/Maps/Classes/CustomAlert/BaseAlert/MWMAlert.h
@@ -34,6 +34,7 @@
 + (MWMAlert *)spinnerAlertWithTitle:(NSString *)title cancel:(MWMVoidBlock)cancel;
 + (MWMAlert *)bookmarkConversionErrorAlert;
 + (MWMAlert *)tagsLoadingErrorAlertWithOkBlock:okBlock cancelBlock:cancelBlock;
++ (MWMAlert *)bugReportAlertWithTitle:(NSString *)title;
 
 + (MWMAlert *)defaultAlertWithTitle:(NSString *)title
                             message:(NSString *)message

--- a/iphone/Maps/Classes/CustomAlert/BaseAlert/MWMAlert.mm
+++ b/iphone/Maps/Classes/CustomAlert/BaseAlert/MWMAlert.mm
@@ -171,6 +171,10 @@
   return [MWMDefaultAlert tagsLoadingErrorAlertWithOkBlock:okBlock cancelBlock:cancelBlock];
 }
 
++ (MWMAlert *)bugReportAlertWithTitle:(NSString *)title {
+  return [MWMDefaultAlert bugReportAlertWithTitle:title];
+}
+
 + (MWMAlert *)defaultAlertWithTitle:(NSString *)title
                             message:(NSString *)message
                    rightButtonTitle:(NSString *)rightButtonTitle

--- a/iphone/Maps/Classes/CustomAlert/DefaultAlert/MWMDefaultAlert.h
+++ b/iphone/Maps/Classes/CustomAlert/DefaultAlert/MWMDefaultAlert.h
@@ -32,8 +32,8 @@
 + (instancetype)infoAlert:(NSString *)title text:(NSString *)text;
 + (instancetype)convertBookmarksWithCount:(NSUInteger)count okBlock:(MWMVoidBlock)okBlock;
 + (instancetype)bookmarkConversionErrorAlert;
-
 + (instancetype)tagsLoadingErrorAlertWithOkBlock:(MWMVoidBlock)okBlock cancelBlock:(MWMVoidBlock)cancelBlock;
++ (instancetype)bugReportAlertWithTitle:(NSString *)title;
 
 + (instancetype)defaultAlertWithTitle:(NSString *)title
                               message:(NSString *)message

--- a/iphone/Maps/Classes/CustomAlert/DefaultAlert/MWMDefaultAlert.mm
+++ b/iphone/Maps/Classes/CustomAlert/DefaultAlert/MWMDefaultAlert.mm
@@ -1,4 +1,5 @@
 #import "MWMDefaultAlert.h"
+#import "SwiftBridge.h"
 
 #include <CoreApi/Framework.h>
 
@@ -343,6 +344,17 @@ static NSString *const kDefaultAlertNibName = @"MWMDefaultAlert";
                                      rightButtonAction:okBlock
                                        log:nil];
   alert.leftButtonAction = cancelBlock;
+  [alert setNeedsCloseAlertAfterEnterBackground];
+  return alert;
+}
+
++ (instancetype)bugReportAlertWithTitle:(NSString *)title {
+  MWMDefaultAlert *alert = [self defaultAlertWithTitle:title
+                                               message:L(@"bugreport_alert_message")
+                                      rightButtonTitle:L(@"report_a_bug")
+                                       leftButtonTitle:L(@"cancel")
+                                     rightButtonAction:^{ [MailComposer sendBugReport]; }
+                                                   log:nil];
   [alert setNeedsCloseAlertAfterEnterBackground];
   return alert;
 }

--- a/iphone/Maps/Core/iCloud/CloudStorageManager.swift
+++ b/iphone/Maps/Core/iCloud/CloudStorageManager.swift
@@ -18,11 +18,23 @@ private let kBookmarksDirectoryName = "bookmarks"
 private let kICloudSynchronizationDidChangeEnabledStateNotificationName = "iCloudSynchronizationDidChangeEnabledStateNotification"
 private let kUDDidFinishInitialCloudSynchronization = "kUDDidFinishInitialCloudSynchronization"
 
+final class CloudStorageSynchronizationState: NSObject {
+  let isAvailable: Bool
+  let isOn: Bool
+  let error: NSError?
+
+  init(isAvailable: Bool, isOn: Bool, error: NSError?) {
+    self.isAvailable = isAvailable
+    self.isOn = isOn
+    self.error = error
+  }
+}
+
 @objc @objcMembers final class CloudStorageManager: NSObject {
 
   fileprivate struct Observation {
     weak var observer: AnyObject?
-    var onErrorCompletionHandler: ((NSError?) -> Void)?
+    var onSynchronizationStateDidChangeHandler: ((CloudStorageSynchronizationState) -> Void)?
   }
 
   let fileManager: FileManager
@@ -33,7 +45,7 @@ private let kUDDidFinishInitialCloudSynchronization = "kUDDidFinishInitialCloudS
   private let synchronizationStateManager: SynchronizationStateManager
   private var fileWriter: SynchronizationFileWriter?
   private var observers = [ObjectIdentifier: CloudStorageManager.Observation]()
-  private var synchronizationError: SynchronizationError? {
+  private var synchronizationError: Error? {
     didSet { notifyObserversOnSynchronizationError(synchronizationError) }
   }
 
@@ -104,13 +116,11 @@ private extension CloudStorageManager {
         guard let self else { return }
         switch result {
         case .failure(let error):
-          self.stopSynchronization()
           self.processError(error)
         case .success(let cloudDirectoryUrl):
           self.localDirectoryMonitor.start { result in
             switch result {
             case .failure(let error):
-              self.stopSynchronization()
               self.processError(error)
             case .success(let localDirectoryUrl):
               self.fileWriter = SynchronizationFileWriter(fileManager: self.fileManager,
@@ -124,13 +134,17 @@ private extension CloudStorageManager {
     }
   }
 
-  func stopSynchronization() {
+  func stopSynchronization(withError error: Error? = nil) {
     LOG(.debug, "Stop synchronization")
     localDirectoryMonitor.stop()
     cloudDirectoryMonitor.stop()
-    synchronizationError = nil
     fileWriter = nil
     synchronizationStateManager.resetState()
+    
+    guard let error else { return }
+    settings.setICLoudSynchronizationEnabled(false)
+    synchronizationError = error
+    MWMAlertViewController.activeAlert().presentBugReportAlert(withTitle: L("icloud_synchronization_error_alert_title"))
   }
 
   func pauseSynchronization() {
@@ -228,53 +242,60 @@ private extension CloudStorageManager {
   func writingResultHandler(for event: OutgoingEvent) -> WritingResultCompletionHandler {
     return { [weak self] result in
       guard let self else { return }
-      DispatchQueue.main.async {
-        switch result {
-        case .success:
-          // Mark that initial synchronization is finished.
-          if case .didFinishInitialSynchronization = event {
-            UserDefaults.standard.set(true, forKey: kUDDidFinishInitialCloudSynchronization)
-          }
-        case .reloadCategoriesAtURLs(let urls):
-          urls.forEach { self.bookmarksManager.reloadCategory(atFilePath: $0.path) }
-        case .deleteCategoriesAtURLs(let urls):
-          urls.forEach { self.bookmarksManager.deleteCategory(atFilePath: $0.path) }
-        case .failure(let error):
-          self.processError(error)
+      switch result {
+      case .success:
+        // Mark that initial synchronization is finished.
+        if case .didFinishInitialSynchronization = event {
+          UserDefaults.standard.set(true, forKey: kUDDidFinishInitialCloudSynchronization)
         }
+      case .reloadCategoriesAtURLs(let urls):
+        DispatchQueue.main.async {
+          urls.forEach { self.bookmarksManager.reloadCategory(atFilePath: $0.path) }
+        }
+      case .deleteCategoriesAtURLs(let urls):
+        DispatchQueue.main.async {
+          urls.forEach { self.bookmarksManager.deleteCategory(atFilePath: $0.path) }
+        }
+      case .failure(let error):
+        self.processError(error)
       }
     }
   }
 
   // MARK: - Error handling
   func processError(_ error: Error) {
-    if let synchronizationError = error as? SynchronizationError {
-      LOG(.debug, "Synchronization error: \(error.localizedDescription)")
-      switch synchronizationError {
-      case .fileUnavailable: break
-      case .fileNotUploadedDueToQuota: break
-      case .ubiquityServerNotAvailable: break
-      case .iCloudIsNotAvailable: fallthrough
-      case .failedToOpenLocalDirectoryFileDescriptor: fallthrough
-      case .failedToRetrieveLocalDirectoryContent: fallthrough
-      case .containerNotFound:
+    switch error {
+    case let syncError as SynchronizationError:
+      switch syncError {
+      case .fileUnavailable,
+           .fileNotUploadedDueToQuota,
+           .ubiquityServerNotAvailable:
+        LOG(.warning, "Synchronization Warning: \(syncError.localizedDescription)")
+        synchronizationError = syncError
+      case .iCloudIsNotAvailable:
+        LOG(.warning, "Synchronization Warning: \(error.localizedDescription)")
         stopSynchronization()
+      case .failedToOpenLocalDirectoryFileDescriptor,
+           .failedToRetrieveLocalDirectoryContent,
+           .containerNotFound,
+           .failedToCreateMetadataItem,
+           .failedToRetrieveMetadataQueryContent:
+        LOG(.error, "Synchronization Error: \(error.localizedDescription)")
+        stopSynchronization(withError: error)
       }
-      self.synchronizationError = synchronizationError
-    } else {
-      // TODO: Handle non-synchronization errors
-      LOG(.debug, "Non-synchronization error: \(error.localizedDescription)")
+    default:
+      LOG(.debug, "Non-synchronization Error: \(error.localizedDescription)")
+      stopSynchronization(withError: error)
     }
   }
 }
 
 // MARK: - CloudStorageManger Observing
 extension CloudStorageManager {
-  func addObserver(_ observer: AnyObject, onErrorCompletionHandler: @escaping (NSError?) -> Void) {
+  func addObserver(_ observer: AnyObject, synchronizationStateDidChangeHandler: @escaping (CloudStorageSynchronizationState) -> Void) {
     let id = ObjectIdentifier(observer)
-    observers[id] = Observation(observer: observer, onErrorCompletionHandler:onErrorCompletionHandler)
-    // Notify the new observer immediately to handle initial state.
-    observers[id]?.onErrorCompletionHandler?(synchronizationError as NSError?)
+    observers[id] = Observation(observer: observer, onSynchronizationStateDidChangeHandler: synchronizationStateDidChangeHandler)
+    notifyObserversOnSynchronizationError(synchronizationError)
   }
 
   func removeObserver(_ observer: AnyObject) {
@@ -282,10 +303,13 @@ extension CloudStorageManager {
     observers.removeValue(forKey: id)
   }
 
-  private func notifyObserversOnSynchronizationError(_ error: SynchronizationError?) {
-    self.observers.removeUnreachable().forEach { _, observable in
+  private func notifyObserversOnSynchronizationError(_ error: Error?) {
+    let state = CloudStorageSynchronizationState(isAvailable: cloudDirectoryMonitor.isCloudAvailable(),
+                                     isOn: settings.iCLoudSynchronizationEnabled(),
+                                     error: error as? NSError)
+    observers.removeUnreachable().forEach { _, observable in
       DispatchQueue.main.async {
-        observable.onErrorCompletionHandler?(error as NSError?)
+        observable.onSynchronizationStateDidChangeHandler?(state)
       }
     }
   }

--- a/iphone/Maps/Core/iCloud/MetadataItem.swift
+++ b/iphone/Maps/Core/iCloud/MetadataItem.swift
@@ -1,28 +1,19 @@
 protocol MetadataItem: Equatable, Hashable {
   var fileName: String { get }
   var fileUrl: URL { get }
-  var fileSize: Int { get }
-  var contentType: String { get }
-  var creationDate: TimeInterval { get }
   var lastModificationDate: TimeInterval { get }
 }
 
 struct LocalMetadataItem: MetadataItem {
   let fileName: String
   let fileUrl: URL
-  let fileSize: Int
-  let contentType: String
-  let creationDate: TimeInterval
   let lastModificationDate: TimeInterval
 }
 
 struct CloudMetadataItem: MetadataItem {
   let fileName: String
   let fileUrl: URL
-  let fileSize: Int
-  let contentType: String
   var isDownloaded: Bool
-  let creationDate: TimeInterval
   var lastModificationDate: TimeInterval
   var isRemoved: Bool
   let downloadingError: NSError?
@@ -31,36 +22,13 @@ struct CloudMetadataItem: MetadataItem {
 }
 
 extension LocalMetadataItem {
-  init(metadataItem: NSMetadataItem) throws {
-    guard let fileName = metadataItem.value(forAttribute: NSMetadataItemFSNameKey) as? String,
-          let fileUrl = metadataItem.value(forAttribute: NSMetadataItemURLKey) as? URL,
-          let fileSize = metadataItem.value(forAttribute: NSMetadataItemFSSizeKey) as? Int,
-          let contentType = metadataItem.value(forAttribute: NSMetadataItemContentTypeKey) as? String,
-          let creationDate = (metadataItem.value(forAttribute: NSMetadataItemFSCreationDateKey) as? Date)?.timeIntervalSince1970.rounded(.down),
-          let lastModificationDate = (metadataItem.value(forAttribute: NSMetadataItemFSContentChangeDateKey) as? Date)?.timeIntervalSince1970.rounded(.down) else {
-      throw NSError(domain: "LocalMetadataItem", code: 0, userInfo: [NSLocalizedDescriptionKey: "Failed to initialize LocalMetadataItem from NSMetadataItem"])
-    }
-    self.fileName = fileName
-    self.fileUrl = fileUrl
-    self.fileSize = fileSize
-    self.contentType = contentType
-    self.creationDate = creationDate
-    self.lastModificationDate = lastModificationDate
-  }
-
   init(fileUrl: URL) throws {
-    let resources = try fileUrl.resourceValues(forKeys: [.fileSizeKey, .typeIdentifierKey, .contentModificationDateKey, .creationDateKey])
-    guard let fileSize = resources.fileSize,
-          let contentType = resources.typeIdentifier,
-          let creationDate = resources.creationDate?.timeIntervalSince1970.rounded(.down),
-          let lastModificationDate = resources.contentModificationDate?.timeIntervalSince1970.rounded(.down) else {
       throw NSError(domain: "LocalMetadataItem", code: 0, userInfo: [NSLocalizedDescriptionKey: "Failed to initialize LocalMetadataItem from URL"])
+    let resources = try fileUrl.resourceValues(forKeys: [.contentModificationDateKey])
+    guard let lastModificationDate = resources.contentModificationDate?.roundedTime else {
     }
     self.fileName = fileUrl.lastPathComponent
     self.fileUrl = fileUrl
-    self.fileSize = fileSize
-    self.contentType = contentType
-    self.creationDate = creationDate
     self.lastModificationDate = lastModificationDate
   }
 
@@ -73,20 +41,14 @@ extension CloudMetadataItem {
   init(metadataItem: NSMetadataItem) throws {
     guard let fileName = metadataItem.value(forAttribute: NSMetadataItemFSNameKey) as? String,
           let fileUrl = metadataItem.value(forAttribute: NSMetadataItemURLKey) as? URL,
-          let fileSize = metadataItem.value(forAttribute: NSMetadataItemFSSizeKey) as? Int,
-          let contentType = metadataItem.value(forAttribute: NSMetadataItemContentTypeKey) as? String,
           let downloadStatus = metadataItem.value(forAttribute: NSMetadataUbiquitousItemDownloadingStatusKey) as? String,
-          let creationDate = (metadataItem.value(forAttribute: NSMetadataItemFSCreationDateKey) as? Date)?.timeIntervalSince1970.rounded(.down),
-          let lastModificationDate = (metadataItem.value(forAttribute: NSMetadataItemFSContentChangeDateKey) as? Date)?.timeIntervalSince1970.rounded(.down),
+          let lastModificationDate = (metadataItem.value(forAttribute: NSMetadataItemFSContentChangeDateKey) as? Date)?.roundedTime,
           let hasUnresolvedConflicts = metadataItem.value(forAttribute: NSMetadataUbiquitousItemHasUnresolvedConflictsKey) as? Bool else {
       throw NSError(domain: "CloudMetadataItem", code: 0, userInfo: [NSLocalizedDescriptionKey: "Failed to initialize CloudMetadataItem from NSMetadataItem"])
     }
     self.fileName = fileName
     self.fileUrl = fileUrl
-    self.fileSize = fileSize
-    self.contentType = contentType
     self.isDownloaded = downloadStatus == NSMetadataUbiquitousItemDownloadingStatusCurrent
-    self.creationDate = creationDate
     self.lastModificationDate = lastModificationDate
     self.isRemoved = CloudMetadataItem.isInTrash(fileUrl)
     self.hasUnresolvedConflicts = hasUnresolvedConflicts
@@ -95,21 +57,15 @@ extension CloudMetadataItem {
   }
 
   init(fileUrl: URL) throws {
-    let resources = try fileUrl.resourceValues(forKeys: [.nameKey, .fileSizeKey, .typeIdentifierKey, .contentModificationDateKey, .creationDateKey, .ubiquitousItemDownloadingStatusKey, .ubiquitousItemHasUnresolvedConflictsKey, .ubiquitousItemDownloadingErrorKey, .ubiquitousItemUploadingErrorKey])
-    guard let fileSize = resources.fileSize,
-          let contentType = resources.typeIdentifier,
-          let creationDate = resources.creationDate?.timeIntervalSince1970.rounded(.down),
-          let downloadStatus = resources.ubiquitousItemDownloadingStatus,
-          let lastModificationDate = resources.contentModificationDate?.timeIntervalSince1970.rounded(.down),
+    let resources = try fileUrl.resourceValues(forKeys: [.nameKey, .contentModificationDateKey, .ubiquitousItemDownloadingStatusKey, .ubiquitousItemHasUnresolvedConflictsKey, .ubiquitousItemDownloadingErrorKey, .ubiquitousItemUploadingErrorKey])
+    guard let downloadStatus = resources.ubiquitousItemDownloadingStatus,
+          let lastModificationDate = resources.contentModificationDate?.roundedTime,
           let hasUnresolvedConflicts = resources.ubiquitousItemHasUnresolvedConflicts else {
       throw NSError(domain: "CloudMetadataItem", code: 0, userInfo: [NSLocalizedDescriptionKey: "Failed to initialize CloudMetadataItem from NSMetadataItem"])
     }
     self.fileName = fileUrl.lastPathComponent
     self.fileUrl = fileUrl
-    self.fileSize = fileSize
-    self.contentType = contentType
     self.isDownloaded = downloadStatus.rawValue == NSMetadataUbiquitousItemDownloadingStatusCurrent
-    self.creationDate = creationDate
     self.lastModificationDate = lastModificationDate
     self.isRemoved = CloudMetadataItem.isInTrash(fileUrl)
     self.hasUnresolvedConflicts = hasUnresolvedConflicts
@@ -152,5 +108,11 @@ extension Array where Element == CloudMetadataItem {
 
   func withUnresolvedConflicts(_ hasUnresolvedConflicts: Bool) -> Self {
     filter { $0.hasUnresolvedConflicts == hasUnresolvedConflicts }
+  }
+}
+
+fileprivate extension Date {
+  var roundedTime: TimeInterval {
+    timeIntervalSince1970.rounded(.down)
   }
 }

--- a/iphone/Maps/Core/iCloud/SynchronizationError.swift
+++ b/iphone/Maps/Core/iCloud/SynchronizationError.swift
@@ -6,6 +6,8 @@
   case containerNotFound
   case failedToOpenLocalDirectoryFileDescriptor
   case failedToRetrieveLocalDirectoryContent
+  case failedToCreateMetadataItem
+  case failedToRetrieveMetadataQueryContent
 }
 
 extension SynchronizationError: LocalizedError {
@@ -21,13 +23,17 @@ extension SynchronizationError: LocalizedError {
       return "Failed to open local directory file descriptor"
     case .failedToRetrieveLocalDirectoryContent:
       return "Failed to retrieve local directory content"
+    case .failedToCreateMetadataItem:
+      return "Failed to create metadata item."
+    case .failedToRetrieveMetadataQueryContent:
+      return "Failed to retrieve NSMetadataQuery content."
     }
   }
 }
 
-extension SynchronizationError {
-  static func fromError(_ error: Error) -> SynchronizationError? {
-    let nsError = error as NSError
+extension Error {
+  var ubiquitousError: SynchronizationError? {
+    let nsError = self as NSError
     switch nsError.code {
       // NSURLUbiquitousItemDownloadingErrorKey contains an error with this code when the item has not been uploaded to iCloud by the other devices yet
     case NSUbiquitousFileUnavailableError:

--- a/iphone/Maps/Core/iCloud/SynchronizationStateManager.swift
+++ b/iphone/Maps/Core/iCloud/SynchronizationStateManager.swift
@@ -215,10 +215,10 @@ final class DefaultSynchronizationStateManager: SynchronizationStateManager {
 
   private static func getItemsWithErrors(_ cloudContents: CloudContents) -> [SynchronizationError] {
      cloudContents.reduce(into: [SynchronizationError](), { partialResult, cloudItem in
-      if let downloadingError = cloudItem.downloadingError, let synchronizationError = SynchronizationError.fromError(downloadingError) {
+       if let downloadingError = cloudItem.downloadingError, let synchronizationError = downloadingError.ubiquitousError {
         partialResult.append(synchronizationError)
       }
-      if let uploadingError = cloudItem.uploadingError, let synchronizationError = SynchronizationError.fromError(uploadingError) {
+       if let uploadingError = cloudItem.uploadingError, let synchronizationError = uploadingError.ubiquitousError {
         partialResult.append(synchronizationError)
       }
     })

--- a/iphone/Maps/LocalizedStrings/ar.lproj/Localizable.strings
+++ b/iphone/Maps/LocalizedStrings/ar.lproj/Localizable.strings
@@ -1335,6 +1335,9 @@
 /* Restaurant or other food place's menu URL field in the Editor */
 "website_menu" = "رابط القائمة";
 
+/* Message for the bug report alert. */
+"bugreport_alert_message" = "هل ترغب في إرسال تقرير عن الأخطاء إلى المطورين؟\nنحن نعتمد على مستخدمينا لأن تطبيق Organic Maps لا يجمع أي معلومات عن الأخطاء تلقائيًا. شكرًا لك مقدمًا على دعم الخرائط العضوية!";
+
 /* Title for the "Enable iCloud Syncronization" alert. */
 "enable_icloud_synchronization_title" = "تمكين مزامنة iCloud";
 
@@ -1353,6 +1356,9 @@
 /* Title for the "Enable iCloud Syncronization" alert's "Backup" action button. */
 "backup" = "دعم";
 
+/* Title for the "iCloud synchronization failure" alert. */
+"icloud_synchronization_error_alert_title" = "فشل مزامنة iCloud";
+
 /* iCloud error message: Failed to synchronize due to connection error */
 "icloud_synchronization_error_connection_error" = "خطأ: فشل المزامنة بسبب خطأ في الاتصال";
 
@@ -1362,7 +1368,7 @@
 /* iCloud error message: iCloud is not available */
 "icloud_synchronization_error_cloud_is_unavailable" = "خطأ: iCloud غير متوفر";
 
-/* Title for the "Open In Another App" buton on the PlacePage. */
+/* Title for the "Open In Another App" button on the PlacePage. */
 "open_in_app" = "فتح في تطبيق آخر";
 
 

--- a/iphone/Maps/LocalizedStrings/az.lproj/Localizable.strings
+++ b/iphone/Maps/LocalizedStrings/az.lproj/Localizable.strings
@@ -1335,6 +1335,9 @@
 /* Restaurant or other food place's menu URL field in the Editor */
 "website_menu" = "Menyu keçidi";
 
+/* Message for the bug report alert. */
+"bugreport_alert_message" = "Tərtibatçılara səhv hesabatı göndərmək istərdinizmi?\nÜzvi Xəritələr heç bir səhv məlumatını avtomatik toplamadığından istifadəçilərimizə etibar edirik. Üzvi Xəritələri dəstəklədiyiniz üçün əvvəlcədən təşəkkür edirik!";
+
 /* Title for the "Enable iCloud Syncronization" alert. */
 "enable_icloud_synchronization_title" = "iCloud Sinxronizasiyasını aktivləşdirin";
 
@@ -1353,6 +1356,9 @@
 /* Title for the "Enable iCloud Syncronization" alert's "Backup" action button. */
 "backup" = "Yedəkləmə";
 
+/* Title for the "iCloud synchronization failure" alert. */
+"icloud_synchronization_error_alert_title" = "iCloud sinxronizasiya uğursuzluğu";
+
 /* iCloud error message: Failed to synchronize due to connection error */
 "icloud_synchronization_error_connection_error" = "Xəta: Bağlantı xətası səbəbindən sinxronizasiya alınmadı";
 
@@ -1362,7 +1368,7 @@
 /* iCloud error message: iCloud is not available */
 "icloud_synchronization_error_cloud_is_unavailable" = "Xəta: iCloud mövcud deyil";
 
-/* Title for the "Open In Another App" buton on the PlacePage. */
+/* Title for the "Open In Another App" button on the PlacePage. */
 "open_in_app" = "Başqa Tətbiqdə Açın";
 
 

--- a/iphone/Maps/LocalizedStrings/be.lproj/Localizable.strings
+++ b/iphone/Maps/LocalizedStrings/be.lproj/Localizable.strings
@@ -1335,6 +1335,9 @@
 /* Restaurant or other food place's menu URL field in the Editor */
 "website_menu" = "Спасылка на меню";
 
+/* Message for the bug report alert. */
+"bugreport_alert_message" = "Хочаце адправіць справаздачу пра памылку распрацоўшчыкам?\nМы разлічваем на нашых карыстальнікаў, бо Organic Maps не збірае ніякай інфармацыі пра памылкі аўтаматычна. Загадзя дзякуем за падтрымку Organic Maps!";
+
 /* Title for the "Enable iCloud Syncronization" alert. */
 "enable_icloud_synchronization_title" = "Уключыць сінхранізацыю з iCloud";
 
@@ -1353,6 +1356,9 @@
 /* Title for the "Enable iCloud Syncronization" alert's "Backup" action button. */
 "backup" = "Рэзервовае капіраванне";
 
+/* Title for the "iCloud synchronization failure" alert. */
+"icloud_synchronization_error_alert_title" = "Збой сінхранізацыі iCloud";
+
 /* iCloud error message: Failed to synchronize due to connection error */
 "icloud_synchronization_error_connection_error" = "Памылка: не ўдалося сінхранізаваць з-за памылкі злучэння";
 
@@ -1362,7 +1368,7 @@
 /* iCloud error message: iCloud is not available */
 "icloud_synchronization_error_cloud_is_unavailable" = "Памылка: iCloud недаступны";
 
-/* Title for the "Open In Another App" buton on the PlacePage. */
+/* Title for the "Open In Another App" button on the PlacePage. */
 "open_in_app" = "Адкрыць у іншай прыладзе";
 
 

--- a/iphone/Maps/LocalizedStrings/bg.lproj/Localizable.strings
+++ b/iphone/Maps/LocalizedStrings/bg.lproj/Localizable.strings
@@ -1335,6 +1335,9 @@
 /* Restaurant or other food place's menu URL field in the Editor */
 "website_menu" = "Връзка към менюто";
 
+/* Message for the bug report alert. */
+"bugreport_alert_message" = "Искате ли да изпратите доклад за грешка на разработчиците?\nРазчитаме на нашите потребители, тъй като Organic Maps не събира информация за грешки автоматично. Благодарим ви предварително, че подкрепяте Organic Maps!";
+
 /* Title for the "Enable iCloud Syncronization" alert. */
 "enable_icloud_synchronization_title" = "Активиране на синхронизацията с iCloud";
 
@@ -1353,6 +1356,9 @@
 /* Title for the "Enable iCloud Syncronization" alert's "Backup" action button. */
 "backup" = "Резервно копие";
 
+/* Title for the "iCloud synchronization failure" alert. */
+"icloud_synchronization_error_alert_title" = "Неуспешна синхронизация на iCloud";
+
 /* iCloud error message: Failed to synchronize due to connection error */
 "icloud_synchronization_error_connection_error" = "Грешка: Не успя да се синхронизира поради грешка при свързването";
 
@@ -1362,7 +1368,7 @@
 /* iCloud error message: iCloud is not available */
 "icloud_synchronization_error_cloud_is_unavailable" = "Грешка: iCloud не е наличен";
 
-/* Title for the "Open In Another App" buton on the PlacePage. */
+/* Title for the "Open In Another App" button on the PlacePage. */
 "open_in_app" = "Отваряне в друго приложение";
 
 

--- a/iphone/Maps/LocalizedStrings/ca.lproj/Localizable.strings
+++ b/iphone/Maps/LocalizedStrings/ca.lproj/Localizable.strings
@@ -1335,6 +1335,9 @@
 /* Restaurant or other food place's menu URL field in the Editor */
 "website_menu" = "Enllaç del menú";
 
+/* Message for the bug report alert. */
+"bugreport_alert_message" = "Voleu enviar un informe d'error als desenvolupadors?\nConfiem en els nostres usuaris, ja que Organic Maps no recull cap informació d'error automàticament. Gràcies per avançat per donar suport a Organic Maps!";
+
 /* Title for the "Enable iCloud Syncronization" alert. */
 "enable_icloud_synchronization_title" = "Activa la sincronització d'iCloud";
 
@@ -1353,6 +1356,9 @@
 /* Title for the "Enable iCloud Syncronization" alert's "Backup" action button. */
 "backup" = "Còpia de seguretat";
 
+/* Title for the "iCloud synchronization failure" alert. */
+"icloud_synchronization_error_alert_title" = "Error de sincronització d'iCloud";
+
 /* iCloud error message: Failed to synchronize due to connection error */
 "icloud_synchronization_error_connection_error" = "Error: no s'ha pogut sincronitzar a causa d'un error de connexió";
 
@@ -1362,7 +1368,7 @@
 /* iCloud error message: iCloud is not available */
 "icloud_synchronization_error_cloud_is_unavailable" = "Error: iCloud no està disponible";
 
-/* Title for the "Open In Another App" buton on the PlacePage. */
+/* Title for the "Open In Another App" button on the PlacePage. */
 "open_in_app" = "Obre en una altra aplicació";
 
 

--- a/iphone/Maps/LocalizedStrings/cs.lproj/Localizable.strings
+++ b/iphone/Maps/LocalizedStrings/cs.lproj/Localizable.strings
@@ -1335,6 +1335,9 @@
 /* Restaurant or other food place's menu URL field in the Editor */
 "website_menu" = "Odkaz na menu";
 
+/* Message for the bug report alert. */
+"bugreport_alert_message" = "Chcete poslat vývojářům hlášení o chybě?\nSpoléháme na naše uživatele, protože společnost Organic Maps neshromažďuje žádné informace o chybách automaticky. Předem vám děkujeme za podporu Organic Maps!";
+
 /* Title for the "Enable iCloud Syncronization" alert. */
 "enable_icloud_synchronization_title" = "Povolení synchronizace s iCloudem";
 
@@ -1353,6 +1356,9 @@
 /* Title for the "Enable iCloud Syncronization" alert's "Backup" action button. */
 "backup" = "Záloha";
 
+/* Title for the "iCloud synchronization failure" alert. */
+"icloud_synchronization_error_alert_title" = "Selhání synchronizace iCloudu";
+
 /* iCloud error message: Failed to synchronize due to connection error */
 "icloud_synchronization_error_connection_error" = "Chyba: Nepodařilo se synchronizovat z důvodu chyby připojení";
 
@@ -1362,7 +1368,7 @@
 /* iCloud error message: iCloud is not available */
 "icloud_synchronization_error_cloud_is_unavailable" = "Chyba: iCloud není k dispozici";
 
-/* Title for the "Open In Another App" buton on the PlacePage. */
+/* Title for the "Open In Another App" button on the PlacePage. */
 "open_in_app" = "Otevřít v jiné aplikaci";
 
 

--- a/iphone/Maps/LocalizedStrings/da.lproj/Localizable.strings
+++ b/iphone/Maps/LocalizedStrings/da.lproj/Localizable.strings
@@ -1335,6 +1335,9 @@
 /* Restaurant or other food place's menu URL field in the Editor */
 "website_menu" = "Link til menu";
 
+/* Message for the bug report alert. */
+"bugreport_alert_message" = "Vil du gerne sende en fejlrapport til udviklerne?\nVi er afhængige af vores brugere, da Organic Maps ikke indsamler nogen fejloplysninger automatisk. Tak på forhånd for at støtte Organic Maps!";
+
 /* Title for the "Enable iCloud Syncronization" alert. */
 "enable_icloud_synchronization_title" = "Aktivér iCloud-synkronisering";
 
@@ -1353,6 +1356,9 @@
 /* Title for the "Enable iCloud Syncronization" alert's "Backup" action button. */
 "backup" = "Sikkerhedskopiering";
 
+/* Title for the "iCloud synchronization failure" alert. */
+"icloud_synchronization_error_alert_title" = "Fejl i iCloud-synkronisering";
+
 /* iCloud error message: Failed to synchronize due to connection error */
 "icloud_synchronization_error_connection_error" = "Fejl: Kunne ikke synkronisere på grund af forbindelsesfejl";
 
@@ -1362,7 +1368,7 @@
 /* iCloud error message: iCloud is not available */
 "icloud_synchronization_error_cloud_is_unavailable" = "Fejl: iCloud er ikke tilgængelig";
 
-/* Title for the "Open In Another App" buton on the PlacePage. */
+/* Title for the "Open In Another App" button on the PlacePage. */
 "open_in_app" = "Åbn i en anden app";
 
 

--- a/iphone/Maps/LocalizedStrings/de.lproj/Localizable.strings
+++ b/iphone/Maps/LocalizedStrings/de.lproj/Localizable.strings
@@ -1335,6 +1335,9 @@
 /* Restaurant or other food place's menu URL field in the Editor */
 "website_menu" = "Link zur Speisekarte";
 
+/* Message for the bug report alert. */
+"bugreport_alert_message" = "Willst du einen Fehlerbericht an die Entwickler schicken?\nWir sind auf unsere Nutzer angewiesen, da Organic Maps keine Fehlerinformationen automatisch sammelt. Wir danken dir im Voraus für deine Unterstützung von Organic Maps!";
+
 /* Title for the "Enable iCloud Syncronization" alert. */
 "enable_icloud_synchronization_title" = "Aktiviere die iCloud-Syncronisierung";
 
@@ -1353,6 +1356,9 @@
 /* Title for the "Enable iCloud Syncronization" alert's "Backup" action button. */
 "backup" = "Sicherung";
 
+/* Title for the "iCloud synchronization failure" alert. */
+"icloud_synchronization_error_alert_title" = "iCloud-Synchronisierung fehlgeschlagen";
+
 /* iCloud error message: Failed to synchronize due to connection error */
 "icloud_synchronization_error_connection_error" = "Fehler: Synchronisierung aufgrund eines Verbindungsfehlers fehlgeschlagen";
 
@@ -1362,7 +1368,7 @@
 /* iCloud error message: iCloud is not available */
 "icloud_synchronization_error_cloud_is_unavailable" = "Fehler: iCloud ist nicht verfügbar";
 
-/* Title for the "Open In Another App" buton on the PlacePage. */
+/* Title for the "Open In Another App" button on the PlacePage. */
 "open_in_app" = "In einer anderen App öffnen";
 
 

--- a/iphone/Maps/LocalizedStrings/el.lproj/Localizable.strings
+++ b/iphone/Maps/LocalizedStrings/el.lproj/Localizable.strings
@@ -1335,6 +1335,9 @@
 /* Restaurant or other food place's menu URL field in the Editor */
 "website_menu" = "Σύνδεσμος μενού";
 
+/* Message for the bug report alert. */
+"bugreport_alert_message" = "Θα θέλατε να στείλετε μια αναφορά σφάλματος στους προγραμματιστές;\nΒασιζόμαστε στους χρήστες μας, καθώς οι Organic Maps δεν συλλέγουν αυτόματα καμία πληροφορία σφάλματος. Σας ευχαριστούμε εκ των προτέρων για την υποστήριξη των Organic Maps!";
+
 /* Title for the "Enable iCloud Syncronization" alert. */
 "enable_icloud_synchronization_title" = "Ενεργοποίηση συγχρονισμού iCloud";
 
@@ -1353,6 +1356,9 @@
 /* Title for the "Enable iCloud Syncronization" alert's "Backup" action button. */
 "backup" = "Δημιουργία αντιγράφων ασφαλείας";
 
+/* Title for the "iCloud synchronization failure" alert. */
+"icloud_synchronization_error_alert_title" = "Αποτυχία συγχρονισμού iCloud";
+
 /* iCloud error message: Failed to synchronize due to connection error */
 "icloud_synchronization_error_connection_error" = "Σφάλμα: Αποτυχία συγχρονισμού λόγω σφάλματος σύνδεσης";
 
@@ -1362,7 +1368,7 @@
 /* iCloud error message: iCloud is not available */
 "icloud_synchronization_error_cloud_is_unavailable" = "Σφάλμα: Το iCloud δεν είναι διαθέσιμο";
 
-/* Title for the "Open In Another App" buton on the PlacePage. */
+/* Title for the "Open In Another App" button on the PlacePage. */
 "open_in_app" = "Άνοιγμα σε άλλη εφαρμογή";
 
 

--- a/iphone/Maps/LocalizedStrings/en-GB.lproj/Localizable.strings
+++ b/iphone/Maps/LocalizedStrings/en-GB.lproj/Localizable.strings
@@ -1335,6 +1335,9 @@
 /* Restaurant or other food place's menu URL field in the Editor */
 "website_menu" = "Menu Link";
 
+/* Message for the bug report alert. */
+"bugreport_alert_message" = "Would you like to send a bug report to the developers?\nWe rely on our users as Organic Maps doesn't collect any error information automatically. Thank you in advance for supporting Organic Maps!";
+
 /* Title for the "Enable iCloud Syncronization" alert. */
 "enable_icloud_synchronization_title" = "Enable iCloud Syncronization";
 
@@ -1353,6 +1356,9 @@
 /* Title for the "Enable iCloud Syncronization" alert's "Backup" action button. */
 "backup" = "Backup";
 
+/* Title for the "iCloud synchronization failure" alert. */
+"icloud_synchronization_error_alert_title" = "iCloud synchronization failure";
+
 /* iCloud error message: Failed to synchronize due to connection error */
 "icloud_synchronization_error_connection_error" = "Error: Failed to synchronize due to connection error";
 
@@ -1362,7 +1368,7 @@
 /* iCloud error message: iCloud is not available */
 "icloud_synchronization_error_cloud_is_unavailable" = "Error: iCloud is not available";
 
-/* Title for the "Open In Another App" buton on the PlacePage. */
+/* Title for the "Open In Another App" button on the PlacePage. */
 "open_in_app" = "Open In Another App";
 
 

--- a/iphone/Maps/LocalizedStrings/en.lproj/Localizable.strings
+++ b/iphone/Maps/LocalizedStrings/en.lproj/Localizable.strings
@@ -1335,6 +1335,9 @@
 /* Restaurant or other food place's menu URL field in the Editor */
 "website_menu" = "Menu Link";
 
+/* Message for the bug report alert. */
+"bugreport_alert_message" = "Would you like to send a bug report to the developers?\nWe rely on our users as Organic Maps doesn't collect any error information automatically. Thank you in advance for supporting Organic Maps!";
+
 /* Title for the "Enable iCloud Syncronization" alert. */
 "enable_icloud_synchronization_title" = "Enable iCloud Syncronization";
 
@@ -1353,6 +1356,9 @@
 /* Title for the "Enable iCloud Syncronization" alert's "Backup" action button. */
 "backup" = "Backup";
 
+/* Title for the "iCloud synchronization failure" alert. */
+"icloud_synchronization_error_alert_title" = "iCloud synchronization failure";
+
 /* iCloud error message: Failed to synchronize due to connection error */
 "icloud_synchronization_error_connection_error" = "Error: Failed to synchronize due to connection error";
 
@@ -1362,7 +1368,7 @@
 /* iCloud error message: iCloud is not available */
 "icloud_synchronization_error_cloud_is_unavailable" = "Error: iCloud is not available";
 
-/* Title for the "Open In Another App" buton on the PlacePage. */
+/* Title for the "Open In Another App" button on the PlacePage. */
 "open_in_app" = "Open In Another App";
 
 

--- a/iphone/Maps/LocalizedStrings/es-MX.lproj/Localizable.strings
+++ b/iphone/Maps/LocalizedStrings/es-MX.lproj/Localizable.strings
@@ -1335,6 +1335,9 @@
 /* Restaurant or other food place's menu URL field in the Editor */
 "website_menu" = "Enlace al menú";
 
+/* Message for the bug report alert. */
+"bugreport_alert_message" = "¿Quieres enviar un informe de error a los desarrolladores?\nConfiamos en nuestros usuarios, ya que Mapas ecológicos no recoge ninguna información sobre errores de forma automática. ¡Gracias de antemano por apoyar a Organic Maps!";
+
 /* Title for the "Enable iCloud Syncronization" alert. */
 "enable_icloud_synchronization_title" = "Habilitar la sincronización de iCloud";
 
@@ -1353,6 +1356,9 @@
 /* Title for the "Enable iCloud Syncronization" alert's "Backup" action button. */
 "backup" = "Respaldo";
 
+/* Title for the "iCloud synchronization failure" alert. */
+"icloud_synchronization_error_alert_title" = "Fallo de sincronización de iCloud";
+
 /* iCloud error message: Failed to synchronize due to connection error */
 "icloud_synchronization_error_connection_error" = "Error: No se ha podido sincronizar debido a un error de conexión";
 
@@ -1362,7 +1368,7 @@
 /* iCloud error message: iCloud is not available */
 "icloud_synchronization_error_cloud_is_unavailable" = "Error: iCloud no está disponible";
 
-/* Title for the "Open In Another App" buton on the PlacePage. */
+/* Title for the "Open In Another App" button on the PlacePage. */
 "open_in_app" = "Abrir en otra aplicación";
 
 

--- a/iphone/Maps/LocalizedStrings/es.lproj/Localizable.strings
+++ b/iphone/Maps/LocalizedStrings/es.lproj/Localizable.strings
@@ -1335,6 +1335,9 @@
 /* Restaurant or other food place's menu URL field in the Editor */
 "website_menu" = "Enlace al menú";
 
+/* Message for the bug report alert. */
+"bugreport_alert_message" = "¿Quieres enviar un informe de error a los desarrolladores?\nConfiamos en nuestros usuarios, ya que Mapas ecológicos no recoge ninguna información sobre errores de forma automática. ¡Gracias de antemano por apoyar a Organic Maps!";
+
 /* Title for the "Enable iCloud Syncronization" alert. */
 "enable_icloud_synchronization_title" = "Activar la sincronización con iCloud";
 
@@ -1353,6 +1356,9 @@
 /* Title for the "Enable iCloud Syncronization" alert's "Backup" action button. */
 "backup" = "Copia de seguridad";
 
+/* Title for the "iCloud synchronization failure" alert. */
+"icloud_synchronization_error_alert_title" = "Fallo de sincronización de iCloud";
+
 /* iCloud error message: Failed to synchronize due to connection error */
 "icloud_synchronization_error_connection_error" = "Error: No se ha podido sincronizar debido a un error de conexión";
 
@@ -1362,7 +1368,7 @@
 /* iCloud error message: iCloud is not available */
 "icloud_synchronization_error_cloud_is_unavailable" = "Error: iCloud no está disponible";
 
-/* Title for the "Open In Another App" buton on the PlacePage. */
+/* Title for the "Open In Another App" button on the PlacePage. */
 "open_in_app" = "Abrir en otra aplicación";
 
 

--- a/iphone/Maps/LocalizedStrings/et.lproj/Localizable.strings
+++ b/iphone/Maps/LocalizedStrings/et.lproj/Localizable.strings
@@ -1335,6 +1335,9 @@
 /* Restaurant or other food place's menu URL field in the Editor */
 "website_menu" = "Menüü link";
 
+/* Message for the bug report alert. */
+"bugreport_alert_message" = "Kas soovite saata arendajatele veateate?\nMe toetume oma kasutajatele, kuna Organic Maps ei kogu automaatselt mingit veateavet. Täname teid juba ette Organic Maps'i toetamise eest!";
+
 /* Title for the "Enable iCloud Syncronization" alert. */
 "enable_icloud_synchronization_title" = "Lubage iCloudi sünkroniseerimine";
 
@@ -1353,6 +1356,9 @@
 /* Title for the "Enable iCloud Syncronization" alert's "Backup" action button. */
 "backup" = "Varukoopia";
 
+/* Title for the "iCloud synchronization failure" alert. */
+"icloud_synchronization_error_alert_title" = "iCloudi sünkroniseerimise tõrge";
+
 /* iCloud error message: Failed to synchronize due to connection error */
 "icloud_synchronization_error_connection_error" = "Viga: Sünkroniseerimine ebaõnnestus ühenduse vea tõttu.";
 
@@ -1362,7 +1368,7 @@
 /* iCloud error message: iCloud is not available */
 "icloud_synchronization_error_cloud_is_unavailable" = "Viga: iCloud ei ole saadaval";
 
-/* Title for the "Open In Another App" buton on the PlacePage. */
+/* Title for the "Open In Another App" button on the PlacePage. */
 "open_in_app" = "Avatud teises rakenduses";
 
 

--- a/iphone/Maps/LocalizedStrings/eu.lproj/Localizable.strings
+++ b/iphone/Maps/LocalizedStrings/eu.lproj/Localizable.strings
@@ -1335,6 +1335,9 @@
 /* Restaurant or other food place's menu URL field in the Editor */
 "website_menu" = "Menuaren esteka";
 
+/* Message for the bug report alert. */
+"bugreport_alert_message" = "Akatsen txostena bidali nahi diezu garatzaileei?\nGure erabiltzaileengan oinarritzen gara Organic Maps-ek ez baitu automatikoki akatsen informaziorik biltzen. Eskerrik asko aldez aurretik Maps organikoak laguntzeagatik!";
+
 /* Title for the "Enable iCloud Syncronization" alert. */
 "enable_icloud_synchronization_title" = "Gaitu iCloud sinkronizazioa";
 
@@ -1353,6 +1356,9 @@
 /* Title for the "Enable iCloud Syncronization" alert's "Backup" action button. */
 "backup" = "Babeskopia";
 
+/* Title for the "iCloud synchronization failure" alert. */
+"icloud_synchronization_error_alert_title" = "iCloud sinkronizazioaren hutsegitea";
+
 /* iCloud error message: Failed to synchronize due to connection error */
 "icloud_synchronization_error_connection_error" = "Errorea: Ezin izan da sinkronizatu konexio-errore baten ondorioz";
 
@@ -1362,7 +1368,7 @@
 /* iCloud error message: iCloud is not available */
 "icloud_synchronization_error_cloud_is_unavailable" = "Errorea: iCloud ez dago erabilgarri";
 
-/* Title for the "Open In Another App" buton on the PlacePage. */
+/* Title for the "Open In Another App" button on the PlacePage. */
 "open_in_app" = "Ireki beste aplikazio batean";
 
 

--- a/iphone/Maps/LocalizedStrings/fa.lproj/Localizable.strings
+++ b/iphone/Maps/LocalizedStrings/fa.lproj/Localizable.strings
@@ -1335,6 +1335,9 @@
 /* Restaurant or other food place's menu URL field in the Editor */
 "website_menu" = "لینک منو";
 
+/* Message for the bug report alert. */
+"bugreport_alert_message" = "آیا می خواهید یک گزارش اشکال برای توسعه دهندگان ارسال کنید؟\nما به کاربران خود تکیه می کنیم زیرا نقشه های ارگانیک هیچ گونه اطلاعات خطا را به طور خودکار جمع آوری نمی کند. پیشاپیش از شما برای حمایت از نقشه های ارگانیک سپاسگزاریم!";
+
 /* Title for the "Enable iCloud Syncronization" alert. */
 "enable_icloud_synchronization_title" = "همگام سازی iCloud را فعال کنید";
 
@@ -1353,6 +1356,9 @@
 /* Title for the "Enable iCloud Syncronization" alert's "Backup" action button. */
 "backup" = "پشتیبان گیری";
 
+/* Title for the "iCloud synchronization failure" alert. */
+"icloud_synchronization_error_alert_title" = "همگام سازی iCloud شکست خورده است";
+
 /* iCloud error message: Failed to synchronize due to connection error */
 "icloud_synchronization_error_connection_error" = "خطا: به دلیل خطای اتصال همگام سازی نشد";
 
@@ -1362,7 +1368,7 @@
 /* iCloud error message: iCloud is not available */
 "icloud_synchronization_error_cloud_is_unavailable" = "خطا: iCloud در دسترس نیست";
 
-/* Title for the "Open In Another App" buton on the PlacePage. */
+/* Title for the "Open In Another App" button on the PlacePage. */
 "open_in_app" = "در یک برنامه دیگر باز کنید";
 
 

--- a/iphone/Maps/LocalizedStrings/fi.lproj/Localizable.strings
+++ b/iphone/Maps/LocalizedStrings/fi.lproj/Localizable.strings
@@ -1335,6 +1335,9 @@
 /* Restaurant or other food place's menu URL field in the Editor */
 "website_menu" = "Valikkolinkki";
 
+/* Message for the bug report alert. */
+"bugreport_alert_message" = "Haluatko lähettää vikailmoituksen kehittäjille?\nLuotamme käyttäjiin, sillä Organic Maps ei kerää virhetietoja automaattisesti. Kiitos etukäteen Organic Mapsin tukemisesta!";
+
 /* Title for the "Enable iCloud Syncronization" alert. */
 "enable_icloud_synchronization_title" = "Ota iCloud-synkronointi käyttöön";
 
@@ -1353,6 +1356,9 @@
 /* Title for the "Enable iCloud Syncronization" alert's "Backup" action button. */
 "backup" = "Varmuuskopiointi";
 
+/* Title for the "iCloud synchronization failure" alert. */
+"icloud_synchronization_error_alert_title" = "iCloud-synkronoinnin epäonnistuminen";
+
 /* iCloud error message: Failed to synchronize due to connection error */
 "icloud_synchronization_error_connection_error" = "Virhe: Synkronointi epäonnistui yhteysvirheen vuoksi.";
 
@@ -1362,7 +1368,7 @@
 /* iCloud error message: iCloud is not available */
 "icloud_synchronization_error_cloud_is_unavailable" = "Virhe: iCloud ei ole käytettävissä";
 
-/* Title for the "Open In Another App" buton on the PlacePage. */
+/* Title for the "Open In Another App" button on the PlacePage. */
 "open_in_app" = "Avaa toisessa sovelluksessa";
 
 

--- a/iphone/Maps/LocalizedStrings/fr.lproj/Localizable.strings
+++ b/iphone/Maps/LocalizedStrings/fr.lproj/Localizable.strings
@@ -1335,6 +1335,9 @@
 /* Restaurant or other food place's menu URL field in the Editor */
 "website_menu" = "Lien vers le menu";
 
+/* Message for the bug report alert. */
+"bugreport_alert_message" = "Veux-tu envoyer un rapport de bogue aux développeurs ?\nNous comptons sur nos utilisateurs, car Organic Maps ne recueille pas automatiquement d'informations sur les erreurs. Merci d'avance de soutenir Organic Maps !";
+
 /* Title for the "Enable iCloud Syncronization" alert. */
 "enable_icloud_synchronization_title" = "Activer la synchronisation iCloud";
 
@@ -1353,6 +1356,9 @@
 /* Title for the "Enable iCloud Syncronization" alert's "Backup" action button. */
 "backup" = "Sauvegarde";
 
+/* Title for the "iCloud synchronization failure" alert. */
+"icloud_synchronization_error_alert_title" = "Échec de la synchronisation iCloud";
+
 /* iCloud error message: Failed to synchronize due to connection error */
 "icloud_synchronization_error_connection_error" = "Erreur : La synchronisation a échoué en raison d'une erreur de connexion";
 
@@ -1362,7 +1368,7 @@
 /* iCloud error message: iCloud is not available */
 "icloud_synchronization_error_cloud_is_unavailable" = "Erreur : iCloud n'est pas disponible";
 
-/* Title for the "Open In Another App" buton on the PlacePage. */
+/* Title for the "Open In Another App" button on the PlacePage. */
 "open_in_app" = "Ouvrir dans une autre application";
 
 

--- a/iphone/Maps/LocalizedStrings/he.lproj/Localizable.strings
+++ b/iphone/Maps/LocalizedStrings/he.lproj/Localizable.strings
@@ -1335,6 +1335,9 @@
 /* Restaurant or other food place's menu URL field in the Editor */
 "website_menu" = "קישור לתפריט";
 
+/* Message for the bug report alert. */
+"bugreport_alert_message" = "האם תרצה לשלוח דוח באג למפתחים?\nאנו סומכים על המשתמשים שלנו מכיוון שמפות אורגניות לא אוספות כל מידע על שגיאות באופן אוטומטי. תודה מראש על התמיכה במפות אורגניות!";
+
 /* Title for the "Enable iCloud Syncronization" alert. */
 "enable_icloud_synchronization_title" = "הפעל סנכרון iCloud";
 
@@ -1353,6 +1356,9 @@
 /* Title for the "Enable iCloud Syncronization" alert's "Backup" action button. */
 "backup" = "גיבוי";
 
+/* Title for the "iCloud synchronization failure" alert. */
+"icloud_synchronization_error_alert_title" = "כשל בסינכרון iCloud";
+
 /* iCloud error message: Failed to synchronize due to connection error */
 "icloud_synchronization_error_connection_error" = "שגיאה: הסנכרון נכשל עקב שגיאת חיבור";
 
@@ -1362,7 +1368,7 @@
 /* iCloud error message: iCloud is not available */
 "icloud_synchronization_error_cloud_is_unavailable" = "שגיאה: iCloud אינו זמין";
 
-/* Title for the "Open In Another App" buton on the PlacePage. */
+/* Title for the "Open In Another App" button on the PlacePage. */
 "open_in_app" = "פתח באפליקציה אחרת";
 
 

--- a/iphone/Maps/LocalizedStrings/hi.lproj/Localizable.strings
+++ b/iphone/Maps/LocalizedStrings/hi.lproj/Localizable.strings
@@ -1335,6 +1335,9 @@
 /* Restaurant or other food place's menu URL field in the Editor */
 "website_menu" = "मेनू लिंक";
 
+/* Message for the bug report alert. */
+"bugreport_alert_message" = "क्या आप डेवलपर्स को बग रिपोर्ट भेजना चाहेंगे?\nहम अपने उपयोगकर्ताओं पर भरोसा करते हैं क्योंकि ऑर्गेनिक मैप्स स्वचालित रूप से कोई त्रुटि जानकारी एकत्र नहीं करता है। ऑर्गेनिक मैप्स का समर्थन करने के लिए अग्रिम धन्यवाद!";
+
 /* Title for the "Enable iCloud Syncronization" alert. */
 "enable_icloud_synchronization_title" = "iCloud सिंक्रोनाइज़ेशन सक्षम करें";
 
@@ -1353,6 +1356,9 @@
 /* Title for the "Enable iCloud Syncronization" alert's "Backup" action button. */
 "backup" = "बैकअप";
 
+/* Title for the "iCloud synchronization failure" alert. */
+"icloud_synchronization_error_alert_title" = "iCloud सिंक्रनाइज़ेशन विफलता";
+
 /* iCloud error message: Failed to synchronize due to connection error */
 "icloud_synchronization_error_connection_error" = "त्रुटि: कनेक्शन त्रुटि के कारण सिंक्रनाइज़ करने में विफल";
 
@@ -1362,7 +1368,7 @@
 /* iCloud error message: iCloud is not available */
 "icloud_synchronization_error_cloud_is_unavailable" = "त्रुटि: iCloud उपलब्ध नहीं है";
 
-/* Title for the "Open In Another App" buton on the PlacePage. */
+/* Title for the "Open In Another App" button on the PlacePage. */
 "open_in_app" = "किसी अन्य ऐप में खोलें";
 
 

--- a/iphone/Maps/LocalizedStrings/hu.lproj/Localizable.strings
+++ b/iphone/Maps/LocalizedStrings/hu.lproj/Localizable.strings
@@ -1335,6 +1335,9 @@
 /* Restaurant or other food place's menu URL field in the Editor */
 "website_menu" = "Menü link";
 
+/* Message for the bug report alert. */
+"bugreport_alert_message" = "Szeretne hibajelentést küldeni a fejlesztőknek?\nFelhasználóinkra támaszkodunk, mivel az Organic Maps nem gyűjt automatikusan hibainformációkat. Előre is köszönjük, hogy támogatja az Organic Maps-et!";
+
 /* Title for the "Enable iCloud Syncronization" alert. */
 "enable_icloud_synchronization_title" = "iCloud-szinkronizálás engedélyezése";
 
@@ -1353,6 +1356,9 @@
 /* Title for the "Enable iCloud Syncronization" alert's "Backup" action button. */
 "backup" = "Biztonsági mentés";
 
+/* Title for the "iCloud synchronization failure" alert. */
+"icloud_synchronization_error_alert_title" = "iCloud-szinkronizálási hiba";
+
 /* iCloud error message: Failed to synchronize due to connection error */
 "icloud_synchronization_error_connection_error" = "Hiba: A szinkronizálás sikertelen volt a kapcsolat hibája miatt.";
 
@@ -1362,7 +1368,7 @@
 /* iCloud error message: iCloud is not available */
 "icloud_synchronization_error_cloud_is_unavailable" = "Hiba: Az iCloud nem elérhető";
 
-/* Title for the "Open In Another App" buton on the PlacePage. */
+/* Title for the "Open In Another App" button on the PlacePage. */
 "open_in_app" = "Megnyitás egy másik alkalmazásban";
 
 

--- a/iphone/Maps/LocalizedStrings/id.lproj/Localizable.strings
+++ b/iphone/Maps/LocalizedStrings/id.lproj/Localizable.strings
@@ -1335,6 +1335,9 @@
 /* Restaurant or other food place's menu URL field in the Editor */
 "website_menu" = "Tautan menu";
 
+/* Message for the bug report alert. */
+"bugreport_alert_message" = "Apakah Anda ingin mengirim laporan bug ke pengembang?\nKami mengandalkan pengguna kami karena Organic Maps tidak mengumpulkan informasi kesalahan secara otomatis. Terima kasih sebelumnya karena telah mendukung Peta Organik!";
+
 /* Title for the "Enable iCloud Syncronization" alert. */
 "enable_icloud_synchronization_title" = "Mengaktifkan Sinkronisasi iCloud";
 
@@ -1353,6 +1356,9 @@
 /* Title for the "Enable iCloud Syncronization" alert's "Backup" action button. */
 "backup" = "Cadangan";
 
+/* Title for the "iCloud synchronization failure" alert. */
+"icloud_synchronization_error_alert_title" = "Kegagalan sinkronisasi iCloud";
+
 /* iCloud error message: Failed to synchronize due to connection error */
 "icloud_synchronization_error_connection_error" = "Kesalahan: Gagal menyinkronkan karena kesalahan koneksi";
 
@@ -1362,7 +1368,7 @@
 /* iCloud error message: iCloud is not available */
 "icloud_synchronization_error_cloud_is_unavailable" = "Kesalahan: iCloud tidak tersedia";
 
-/* Title for the "Open In Another App" buton on the PlacePage. */
+/* Title for the "Open In Another App" button on the PlacePage. */
 "open_in_app" = "Buka di Aplikasi Lain";
 
 

--- a/iphone/Maps/LocalizedStrings/it.lproj/Localizable.strings
+++ b/iphone/Maps/LocalizedStrings/it.lproj/Localizable.strings
@@ -1335,6 +1335,9 @@
 /* Restaurant or other food place's menu URL field in the Editor */
 "website_menu" = "Link al menu";
 
+/* Message for the bug report alert. */
+"bugreport_alert_message" = "Vuoi inviare una segnalazione di bug agli sviluppatori?\nCi affidiamo ai nostri utenti perché Organic Maps non raccoglie automaticamente informazioni sugli errori. Ti ringraziamo in anticipo per il supporto a Organic Maps!";
+
 /* Title for the "Enable iCloud Syncronization" alert. */
 "enable_icloud_synchronization_title" = "Abilita la sincronizzazione con iCloud";
 
@@ -1353,6 +1356,9 @@
 /* Title for the "Enable iCloud Syncronization" alert's "Backup" action button. */
 "backup" = "Backup";
 
+/* Title for the "iCloud synchronization failure" alert. */
+"icloud_synchronization_error_alert_title" = "Mancata sincronizzazione di iCloud";
+
 /* iCloud error message: Failed to synchronize due to connection error */
 "icloud_synchronization_error_connection_error" = "Errore: Impossibile sincronizzare a causa di un errore di connessione";
 
@@ -1362,7 +1368,7 @@
 /* iCloud error message: iCloud is not available */
 "icloud_synchronization_error_cloud_is_unavailable" = "Errore: iCloud non è disponibile";
 
-/* Title for the "Open In Another App" buton on the PlacePage. */
+/* Title for the "Open In Another App" button on the PlacePage. */
 "open_in_app" = "Apri in un'altra applicazione";
 
 

--- a/iphone/Maps/LocalizedStrings/ja.lproj/Localizable.strings
+++ b/iphone/Maps/LocalizedStrings/ja.lproj/Localizable.strings
@@ -1335,6 +1335,9 @@
 /* Restaurant or other food place's menu URL field in the Editor */
 "website_menu" = "メニューリンク";
 
+/* Message for the bug report alert. */
+"bugreport_alert_message" = "開発者にバグレポートを送りたいか？\nオーガニック・マップはエラー情報を自動収集しないため、我々はユーザーに依存している。Organic Mapsを応援してくださりありがとう！";
+
 /* Title for the "Enable iCloud Syncronization" alert. */
 "enable_icloud_synchronization_title" = "iCloud同期を有効にする";
 
@@ -1353,6 +1356,9 @@
 /* Title for the "Enable iCloud Syncronization" alert's "Backup" action button. */
 "backup" = "バックアップ";
 
+/* Title for the "iCloud synchronization failure" alert. */
+"icloud_synchronization_error_alert_title" = "iCloud同期の失敗";
+
 /* iCloud error message: Failed to synchronize due to connection error */
 "icloud_synchronization_error_connection_error" = "エラー：接続エラーにより同期に失敗した";
 
@@ -1362,7 +1368,7 @@
 /* iCloud error message: iCloud is not available */
 "icloud_synchronization_error_cloud_is_unavailable" = "エラー：iCloudが利用できない";
 
-/* Title for the "Open In Another App" buton on the PlacePage. */
+/* Title for the "Open In Another App" button on the PlacePage. */
 "open_in_app" = "別のアプリで開く";
 
 

--- a/iphone/Maps/LocalizedStrings/ko.lproj/Localizable.strings
+++ b/iphone/Maps/LocalizedStrings/ko.lproj/Localizable.strings
@@ -1335,6 +1335,9 @@
 /* Restaurant or other food place's menu URL field in the Editor */
 "website_menu" = "메뉴 링크";
 
+/* Message for the bug report alert. */
+"bugreport_alert_message" = "개발자에게 버그 리포트를 보내시겠습니까?\n오가닉 맵은 오류 정보를 자동으로 수집하지 않으므로 사용자의 도움을 받아야 합니다. 오가닉 맵을 이용해 주셔서 미리 감사드립니다!";
+
 /* Title for the "Enable iCloud Syncronization" alert. */
 "enable_icloud_synchronization_title" = "iCloud 동기화 활성화";
 
@@ -1353,6 +1356,9 @@
 /* Title for the "Enable iCloud Syncronization" alert's "Backup" action button. */
 "backup" = "백업";
 
+/* Title for the "iCloud synchronization failure" alert. */
+"icloud_synchronization_error_alert_title" = "iCloud 동기화 실패";
+
 /* iCloud error message: Failed to synchronize due to connection error */
 "icloud_synchronization_error_connection_error" = "오류입니다: 연결 오류로 인해 동기화하지 못했습니다.";
 
@@ -1362,7 +1368,7 @@
 /* iCloud error message: iCloud is not available */
 "icloud_synchronization_error_cloud_is_unavailable" = "오류: iCloud를 사용할 수 없습니다.";
 
-/* Title for the "Open In Another App" buton on the PlacePage. */
+/* Title for the "Open In Another App" button on the PlacePage. */
 "open_in_app" = "다른 앱에서 열기";
 
 

--- a/iphone/Maps/LocalizedStrings/mr.lproj/Localizable.strings
+++ b/iphone/Maps/LocalizedStrings/mr.lproj/Localizable.strings
@@ -1335,6 +1335,9 @@
 /* Restaurant or other food place's menu URL field in the Editor */
 "website_menu" = "मेनू लिंक";
 
+/* Message for the bug report alert. */
+"bugreport_alert_message" = "तुम्ही विकासकांना बग अहवाल पाठवू इच्छिता?\nआम्ही आमच्या वापरकर्त्यांवर अवलंबून आहोत कारण सेंद्रिय नकाशे कोणतीही त्रुटी माहिती स्वयंचलितपणे संकलित करत नाही. ऑरगॅनिक नकाशेला समर्थन दिल्याबद्दल आगाऊ धन्यवाद!";
+
 /* Title for the "Enable iCloud Syncronization" alert. */
 "enable_icloud_synchronization_title" = "iCloud सिंक्रोनाइझेशन सक्षम करा";
 
@@ -1353,6 +1356,9 @@
 /* Title for the "Enable iCloud Syncronization" alert's "Backup" action button. */
 "backup" = "बॅकअप";
 
+/* Title for the "iCloud synchronization failure" alert. */
+"icloud_synchronization_error_alert_title" = "iCloud सिंक्रोनाइझेशन अयशस्वी";
+
 /* iCloud error message: Failed to synchronize due to connection error */
 "icloud_synchronization_error_connection_error" = "त्रुटी: कनेक्शन त्रुटीमुळे सिंक्रोनाइझ करण्यात अयशस्वी";
 
@@ -1362,7 +1368,7 @@
 /* iCloud error message: iCloud is not available */
 "icloud_synchronization_error_cloud_is_unavailable" = "त्रुटी: iCloud उपलब्ध नाही";
 
-/* Title for the "Open In Another App" buton on the PlacePage. */
+/* Title for the "Open In Another App" button on the PlacePage. */
 "open_in_app" = "दुसऱ्या ॲपमध्ये उघडा";
 
 

--- a/iphone/Maps/LocalizedStrings/nb.lproj/Localizable.strings
+++ b/iphone/Maps/LocalizedStrings/nb.lproj/Localizable.strings
@@ -1335,6 +1335,9 @@
 /* Restaurant or other food place's menu URL field in the Editor */
 "website_menu" = "Lenke til menyen";
 
+/* Message for the bug report alert. */
+"bugreport_alert_message" = "Vil du sende en feilrapport til utviklerne?\nVi er avhengige av brukerne våre, da Organic Maps ikke samler inn noen feilinformasjon automatisk. Takk på forhånd for at du støtter Organic Maps!";
+
 /* Title for the "Enable iCloud Syncronization" alert. */
 "enable_icloud_synchronization_title" = "Aktiver iCloud-synkronisering";
 
@@ -1353,6 +1356,9 @@
 /* Title for the "Enable iCloud Syncronization" alert's "Backup" action button. */
 "backup" = "Sikkerhetskopiering";
 
+/* Title for the "iCloud synchronization failure" alert. */
+"icloud_synchronization_error_alert_title" = "iCloud-synkroniseringsfeil";
+
 /* iCloud error message: Failed to synchronize due to connection error */
 "icloud_synchronization_error_connection_error" = "Feil: Kunne ikke synkronisere på grunn av tilkoblingsfeil";
 
@@ -1362,7 +1368,7 @@
 /* iCloud error message: iCloud is not available */
 "icloud_synchronization_error_cloud_is_unavailable" = "Feil: iCloud er ikke tilgjengelig";
 
-/* Title for the "Open In Another App" buton on the PlacePage. */
+/* Title for the "Open In Another App" button on the PlacePage. */
 "open_in_app" = "Åpne i en annen app";
 
 

--- a/iphone/Maps/LocalizedStrings/nl.lproj/Localizable.strings
+++ b/iphone/Maps/LocalizedStrings/nl.lproj/Localizable.strings
@@ -1335,6 +1335,9 @@
 /* Restaurant or other food place's menu URL field in the Editor */
 "website_menu" = "Menulink";
 
+/* Message for the bug report alert. */
+"bugreport_alert_message" = "Wil je een bugrapport naar de ontwikkelaars sturen?\nWe vertrouwen op onze gebruikers, want Organic Maps verzamelt geen foutinformatie automatisch. Alvast bedankt voor je steun aan Organic Maps!";
+
 /* Title for the "Enable iCloud Syncronization" alert. */
 "enable_icloud_synchronization_title" = "Schakel iCloud-synchronisatie in";
 
@@ -1353,6 +1356,9 @@
 /* Title for the "Enable iCloud Syncronization" alert's "Backup" action button. */
 "backup" = "Back-up";
 
+/* Title for the "iCloud synchronization failure" alert. */
+"icloud_synchronization_error_alert_title" = "Storing iCloud-synchronisatie";
+
 /* iCloud error message: Failed to synchronize due to connection error */
 "icloud_synchronization_error_connection_error" = "Fout: Synchronisatie mislukt door verbindingsfout";
 
@@ -1362,7 +1368,7 @@
 /* iCloud error message: iCloud is not available */
 "icloud_synchronization_error_cloud_is_unavailable" = "Fout: iCloud is niet beschikbaar";
 
-/* Title for the "Open In Another App" buton on the PlacePage. */
+/* Title for the "Open In Another App" button on the PlacePage. */
 "open_in_app" = "Openen in een andere app";
 
 

--- a/iphone/Maps/LocalizedStrings/pl.lproj/Localizable.strings
+++ b/iphone/Maps/LocalizedStrings/pl.lproj/Localizable.strings
@@ -1335,6 +1335,9 @@
 /* Restaurant or other food place's menu URL field in the Editor */
 "website_menu" = "Link do menu";
 
+/* Message for the bug report alert. */
+"bugreport_alert_message" = "Chcesz wysłać raport o błędzie do deweloperów?\nPolegamy na naszych użytkownikach, ponieważ Organic Maps nie zbiera żadnych informacji o błędach automatycznie. Z góry dziękujemy za wspieranie Organic Maps!";
+
 /* Title for the "Enable iCloud Syncronization" alert. */
 "enable_icloud_synchronization_title" = "Włącz synchronizację iCloud";
 
@@ -1353,6 +1356,9 @@
 /* Title for the "Enable iCloud Syncronization" alert's "Backup" action button. */
 "backup" = "Kopia zapasowa";
 
+/* Title for the "iCloud synchronization failure" alert. */
+"icloud_synchronization_error_alert_title" = "Błąd synchronizacji iCloud";
+
 /* iCloud error message: Failed to synchronize due to connection error */
 "icloud_synchronization_error_connection_error" = "Błąd: Nie udało się zsynchronizować z powodu błędu połączenia";
 
@@ -1362,7 +1368,7 @@
 /* iCloud error message: iCloud is not available */
 "icloud_synchronization_error_cloud_is_unavailable" = "Błąd: usługa iCloud jest niedostępna";
 
-/* Title for the "Open In Another App" buton on the PlacePage. */
+/* Title for the "Open In Another App" button on the PlacePage. */
 "open_in_app" = "Otwórz w innej aplikacji";
 
 

--- a/iphone/Maps/LocalizedStrings/pt-BR.lproj/Localizable.strings
+++ b/iphone/Maps/LocalizedStrings/pt-BR.lproj/Localizable.strings
@@ -1335,6 +1335,9 @@
 /* Restaurant or other food place's menu URL field in the Editor */
 "website_menu" = "Link do cardápio";
 
+/* Message for the bug report alert. */
+"bugreport_alert_message" = "Você gostaria de enviar um relatório de bug para os desenvolvedores?\nDependemos de nossos usuários, pois o Organic Maps não coleta nenhuma informação de erro automaticamente. Agradecemos antecipadamente por você apoiar o Organic Maps!";
+
 /* Title for the "Enable iCloud Syncronization" alert. */
 "enable_icloud_synchronization_title" = "Ativar a sincronização do iCloud";
 
@@ -1353,6 +1356,9 @@
 /* Title for the "Enable iCloud Syncronization" alert's "Backup" action button. */
 "backup" = "Backup";
 
+/* Title for the "iCloud synchronization failure" alert. */
+"icloud_synchronization_error_alert_title" = "Falha na sincronização do iCloud";
+
 /* iCloud error message: Failed to synchronize due to connection error */
 "icloud_synchronization_error_connection_error" = "Erro: Falha na sincronização devido a erro de conexão";
 
@@ -1362,7 +1368,7 @@
 /* iCloud error message: iCloud is not available */
 "icloud_synchronization_error_cloud_is_unavailable" = "Erro: o iCloud não está disponível";
 
-/* Title for the "Open In Another App" buton on the PlacePage. */
+/* Title for the "Open In Another App" button on the PlacePage. */
 "open_in_app" = "Abrir em outro aplicativo";
 
 

--- a/iphone/Maps/LocalizedStrings/pt.lproj/Localizable.strings
+++ b/iphone/Maps/LocalizedStrings/pt.lproj/Localizable.strings
@@ -1335,6 +1335,9 @@
 /* Restaurant or other food place's menu URL field in the Editor */
 "website_menu" = "Link do menu";
 
+/* Message for the bug report alert. */
+"bugreport_alert_message" = "Gostarias de enviar um relatório de erro para os programadores?\nContamos com os nossos utilizadores, uma vez que o Organic Maps não recolhe automaticamente qualquer informação de erro. Agradecemos desde já o teu apoio ao Organic Maps!";
+
 /* Title for the "Enable iCloud Syncronization" alert. */
 "enable_icloud_synchronization_title" = "Ativar a sincronização do iCloud";
 
@@ -1353,6 +1356,9 @@
 /* Title for the "Enable iCloud Syncronization" alert's "Backup" action button. */
 "backup" = "Cópia de segurança";
 
+/* Title for the "iCloud synchronization failure" alert. */
+"icloud_synchronization_error_alert_title" = "Falha de sincronização do iCloud";
+
 /* iCloud error message: Failed to synchronize due to connection error */
 "icloud_synchronization_error_connection_error" = "Erro: Falha na sincronização devido a um erro de ligação";
 
@@ -1362,7 +1368,7 @@
 /* iCloud error message: iCloud is not available */
 "icloud_synchronization_error_cloud_is_unavailable" = "Erro: o iCloud não está disponível";
 
-/* Title for the "Open In Another App" buton on the PlacePage. */
+/* Title for the "Open In Another App" button on the PlacePage. */
 "open_in_app" = "Abrir noutra aplicação";
 
 

--- a/iphone/Maps/LocalizedStrings/ro.lproj/Localizable.strings
+++ b/iphone/Maps/LocalizedStrings/ro.lproj/Localizable.strings
@@ -1335,6 +1335,9 @@
 /* Restaurant or other food place's menu URL field in the Editor */
 "website_menu" = "Legătura de meniu";
 
+/* Message for the bug report alert. */
+"bugreport_alert_message" = "Doriți să trimiteți un raport de eroare dezvoltatorilor?\nNe bazăm pe utilizatorii noștri, deoarece Organic Maps nu colectează automat nicio informație privind erorile. Vă mulțumim anticipat pentru susținerea Organic Maps!";
+
 /* Title for the "Enable iCloud Syncronization" alert. */
 "enable_icloud_synchronization_title" = "Activați Sincronizarea iCloud";
 
@@ -1353,6 +1356,9 @@
 /* Title for the "Enable iCloud Syncronization" alert's "Backup" action button. */
 "backup" = "Backup";
 
+/* Title for the "iCloud synchronization failure" alert. */
+"icloud_synchronization_error_alert_title" = "Eșecul sincronizării iCloud";
+
 /* iCloud error message: Failed to synchronize due to connection error */
 "icloud_synchronization_error_connection_error" = "Eroare: Nu s-a reușit sincronizarea din cauza unei erori de conexiune";
 
@@ -1362,7 +1368,7 @@
 /* iCloud error message: iCloud is not available */
 "icloud_synchronization_error_cloud_is_unavailable" = "Eroare: iCloud nu este disponibil";
 
-/* Title for the "Open In Another App" buton on the PlacePage. */
+/* Title for the "Open In Another App" button on the PlacePage. */
 "open_in_app" = "Deschidere în altă aplicație";
 
 

--- a/iphone/Maps/LocalizedStrings/ru.lproj/Localizable.strings
+++ b/iphone/Maps/LocalizedStrings/ru.lproj/Localizable.strings
@@ -1335,6 +1335,9 @@
 /* Restaurant or other food place's menu URL field in the Editor */
 "website_menu" = "Ссылка на меню";
 
+/* Message for the bug report alert. */
+"bugreport_alert_message" = "Хотите отправить разработчикам сообщение об ошибке?\nМы полагаемся на наших пользователей, так как Organic Maps не собирает информацию об ошибках автоматически. Заранее спасибо за поддержку Organic Maps!";
+
 /* Title for the "Enable iCloud Syncronization" alert. */
 "enable_icloud_synchronization_title" = "Включить синхронизацию с iCloud";
 
@@ -1353,6 +1356,9 @@
 /* Title for the "Enable iCloud Syncronization" alert's "Backup" action button. */
 "backup" = "Резервная копия";
 
+/* Title for the "iCloud synchronization failure" alert. */
+"icloud_synchronization_error_alert_title" = "Сбой синхронизации iCloud";
+
 /* iCloud error message: Failed to synchronize due to connection error */
 "icloud_synchronization_error_connection_error" = "Ошибка: Не удалось выполнить синхронизацию из-за ошибки подключения";
 
@@ -1362,7 +1368,7 @@
 /* iCloud error message: iCloud is not available */
 "icloud_synchronization_error_cloud_is_unavailable" = "Ошибка: iCloud недоступен";
 
-/* Title for the "Open In Another App" buton on the PlacePage. */
+/* Title for the "Open In Another App" button on the PlacePage. */
 "open_in_app" = "Открыть в другом приложении";
 
 

--- a/iphone/Maps/LocalizedStrings/sk.lproj/Localizable.strings
+++ b/iphone/Maps/LocalizedStrings/sk.lproj/Localizable.strings
@@ -1335,6 +1335,9 @@
 /* Restaurant or other food place's menu URL field in the Editor */
 "website_menu" = "Odkaz na menu";
 
+/* Message for the bug report alert. */
+"bugreport_alert_message" = "Chcete poslať vývojárom hlásenie o chybe?\nSpoliehame sa na našich používateľov, pretože spoločnosť Organic Maps nezhromažďuje žiadne informácie o chybách automaticky. Vopred vám ďakujeme za podporu Organic Maps!";
+
 /* Title for the "Enable iCloud Syncronization" alert. */
 "enable_icloud_synchronization_title" = "Povolenie synchronizácie iCloud";
 
@@ -1353,6 +1356,9 @@
 /* Title for the "Enable iCloud Syncronization" alert's "Backup" action button. */
 "backup" = "Zálohovanie";
 
+/* Title for the "iCloud synchronization failure" alert. */
+"icloud_synchronization_error_alert_title" = "Zlyhanie synchronizácie iCloud";
+
 /* iCloud error message: Failed to synchronize due to connection error */
 "icloud_synchronization_error_connection_error" = "Chyba: Nepodarilo sa synchronizovať z dôvodu chyby pripojenia";
 
@@ -1362,7 +1368,7 @@
 /* iCloud error message: iCloud is not available */
 "icloud_synchronization_error_cloud_is_unavailable" = "Chyba: iCloud nie je k dispozícii";
 
-/* Title for the "Open In Another App" buton on the PlacePage. */
+/* Title for the "Open In Another App" button on the PlacePage. */
 "open_in_app" = "Otvoriť v inej aplikácii";
 
 

--- a/iphone/Maps/LocalizedStrings/sv.lproj/Localizable.strings
+++ b/iphone/Maps/LocalizedStrings/sv.lproj/Localizable.strings
@@ -1335,6 +1335,9 @@
 /* Restaurant or other food place's menu URL field in the Editor */
 "website_menu" = "Länk till meny";
 
+/* Message for the bug report alert. */
+"bugreport_alert_message" = "Vill du skicka en felrapport till utvecklarna?\nVi förlitar oss på våra användare eftersom organiska kartor inte samlar in någon felinformation automatiskt. Tack på förhand för att du stöder Organic Maps!";
+
 /* Title for the "Enable iCloud Syncronization" alert. */
 "enable_icloud_synchronization_title" = "Aktivera iCloud-synkronisering";
 
@@ -1353,6 +1356,9 @@
 /* Title for the "Enable iCloud Syncronization" alert's "Backup" action button. */
 "backup" = "Säkerhetskopiering";
 
+/* Title for the "iCloud synchronization failure" alert. */
+"icloud_synchronization_error_alert_title" = "fel i iCloud-synkroniseringen";
+
 /* iCloud error message: Failed to synchronize due to connection error */
 "icloud_synchronization_error_connection_error" = "Fel: Synkronisering misslyckades på grund av anslutningsfel";
 
@@ -1362,7 +1368,7 @@
 /* iCloud error message: iCloud is not available */
 "icloud_synchronization_error_cloud_is_unavailable" = "Fel: iCloud är inte tillgängligt";
 
-/* Title for the "Open In Another App" buton on the PlacePage. */
+/* Title for the "Open In Another App" button on the PlacePage. */
 "open_in_app" = "Öppna i en annan app";
 
 

--- a/iphone/Maps/LocalizedStrings/sw.lproj/Localizable.strings
+++ b/iphone/Maps/LocalizedStrings/sw.lproj/Localizable.strings
@@ -1335,6 +1335,9 @@
 /* Restaurant or other food place's menu URL field in the Editor */
 "website_menu" = "Kiungo cha menyu";
 
+/* Message for the bug report alert. */
+"bugreport_alert_message" = "Je, ungependa kutuma ripoti ya hitilafu kwa wasanidi programu?\nTunategemea watumiaji wetu kwani Ramani za Kikaboni hazikusanyi maelezo yoyote ya hitilafu kiotomatiki. Asante mapema kwa kusaidia Ramani za Organic!";
+
 /* Title for the "Enable iCloud Syncronization" alert. */
 "enable_icloud_synchronization_title" = "Washa Usawazishaji wa iCloud";
 
@@ -1353,6 +1356,9 @@
 /* Title for the "Enable iCloud Syncronization" alert's "Backup" action button. */
 "backup" = "Hifadhi nakala";
 
+/* Title for the "iCloud synchronization failure" alert. */
+"icloud_synchronization_error_alert_title" = "Imeshindwa kusawazisha iCloud";
+
 /* iCloud error message: Failed to synchronize due to connection error */
 "icloud_synchronization_error_connection_error" = "Hitilafu: Imeshindwa kusawazisha kwa sababu ya hitilafu ya muunganisho";
 
@@ -1362,7 +1368,7 @@
 /* iCloud error message: iCloud is not available */
 "icloud_synchronization_error_cloud_is_unavailable" = "Hitilafu: iCloud haipatikani";
 
-/* Title for the "Open In Another App" buton on the PlacePage. */
+/* Title for the "Open In Another App" button on the PlacePage. */
 "open_in_app" = "Fungua Katika Programu Nyingine";
 
 

--- a/iphone/Maps/LocalizedStrings/th.lproj/Localizable.strings
+++ b/iphone/Maps/LocalizedStrings/th.lproj/Localizable.strings
@@ -1335,6 +1335,9 @@
 /* Restaurant or other food place's menu URL field in the Editor */
 "website_menu" = "ลิงค์เมนู";
 
+/* Message for the bug report alert. */
+"bugreport_alert_message" = "คุณต้องการส่งรายงานข้อผิดพลาดไปยังนักพัฒนาหรือไม่?\nเราไว้วางใจผู้ใช้ของเราเนื่องจาก Organic Maps จะไม่รวบรวมข้อมูลข้อผิดพลาดใด ๆ โดยอัตโนมัติ ขอขอบคุณล่วงหน้าสำหรับการสนับสนุน Organic Maps!";
+
 /* Title for the "Enable iCloud Syncronization" alert. */
 "enable_icloud_synchronization_title" = "เปิดใช้งานการซิงโครไนซ์ iCloud";
 
@@ -1353,6 +1356,9 @@
 /* Title for the "Enable iCloud Syncronization" alert's "Backup" action button. */
 "backup" = "สำรองข้อมูล";
 
+/* Title for the "iCloud synchronization failure" alert. */
+"icloud_synchronization_error_alert_title" = "การซิงโครไนซ์ iCloud ล้มเหลว";
+
 /* iCloud error message: Failed to synchronize due to connection error */
 "icloud_synchronization_error_connection_error" = "ข้อผิดพลาด: ไม่สามารถซิงโครไนซ์ได้เนื่องจากข้อผิดพลาดในการเชื่อมต่อ";
 
@@ -1362,7 +1368,7 @@
 /* iCloud error message: iCloud is not available */
 "icloud_synchronization_error_cloud_is_unavailable" = "ข้อผิดพลาด: iCloud ไม่พร้อมใช้งาน";
 
-/* Title for the "Open In Another App" buton on the PlacePage. */
+/* Title for the "Open In Another App" button on the PlacePage. */
 "open_in_app" = "เปิดในแอปอื่น";
 
 

--- a/iphone/Maps/LocalizedStrings/tr.lproj/Localizable.strings
+++ b/iphone/Maps/LocalizedStrings/tr.lproj/Localizable.strings
@@ -1335,6 +1335,9 @@
 /* Restaurant or other food place's menu URL field in the Editor */
 "website_menu" = "Menü bağlantısı";
 
+/* Message for the bug report alert. */
+"bugreport_alert_message" = "Geliştiricilere bir hata raporu göndermek ister misiniz?\nOrganic Maps otomatik olarak herhangi bir hata bilgisi toplamadığı için kullanıcılarımıza güveniyoruz. Organic Maps'i desteklediğiniz için şimdiden teşekkür ederiz!";
+
 /* Title for the "Enable iCloud Syncronization" alert. */
 "enable_icloud_synchronization_title" = "iCloud Senkronizasyonunu Etkinleştir";
 
@@ -1353,6 +1356,9 @@
 /* Title for the "Enable iCloud Syncronization" alert's "Backup" action button. */
 "backup" = "Yedekle";
 
+/* Title for the "iCloud synchronization failure" alert. */
+"icloud_synchronization_error_alert_title" = "iCloud senkronizasyon hatası";
+
 /* iCloud error message: Failed to synchronize due to connection error */
 "icloud_synchronization_error_connection_error" = "Hata oluştu: Bağlantı hatası nedeniyle senkronizasyon başarısız oldu";
 
@@ -1362,7 +1368,7 @@
 /* iCloud error message: iCloud is not available */
 "icloud_synchronization_error_cloud_is_unavailable" = "Hata: iCloud kullanılamıyor";
 
-/* Title for the "Open In Another App" buton on the PlacePage. */
+/* Title for the "Open In Another App" button on the PlacePage. */
 "open_in_app" = "Başka Bir Uygulamada Aç";
 
 

--- a/iphone/Maps/LocalizedStrings/uk.lproj/Localizable.strings
+++ b/iphone/Maps/LocalizedStrings/uk.lproj/Localizable.strings
@@ -1335,6 +1335,9 @@
 /* Restaurant or other food place's menu URL field in the Editor */
 "website_menu" = "Посилання на меню";
 
+/* Message for the bug report alert. */
+"bugreport_alert_message" = "Бажаєте надіслати розробникам звіт про помилку?\nМи покладаємося на наших користувачів, оскільки Organic Maps не збирає інформацію про помилки автоматично. Заздалегідь дякуємо за підтримку Organic Maps!";
+
 /* Title for the "Enable iCloud Syncronization" alert. */
 "enable_icloud_synchronization_title" = "Увімкнути синхронізацію з iCloud";
 
@@ -1353,6 +1356,9 @@
 /* Title for the "Enable iCloud Syncronization" alert's "Backup" action button. */
 "backup" = "Резервне копіювання";
 
+/* Title for the "iCloud synchronization failure" alert. */
+"icloud_synchronization_error_alert_title" = "Збій синхронізації iCloud";
+
 /* iCloud error message: Failed to synchronize due to connection error */
 "icloud_synchronization_error_connection_error" = "Помилка: Не вдалося синхронізувати через помилку з'єднання";
 
@@ -1362,7 +1368,7 @@
 /* iCloud error message: iCloud is not available */
 "icloud_synchronization_error_cloud_is_unavailable" = "Помилка: iCloud недоступний";
 
-/* Title for the "Open In Another App" buton on the PlacePage. */
+/* Title for the "Open In Another App" button on the PlacePage. */
 "open_in_app" = "Відкрити в іншій програмі";
 
 

--- a/iphone/Maps/LocalizedStrings/vi.lproj/Localizable.strings
+++ b/iphone/Maps/LocalizedStrings/vi.lproj/Localizable.strings
@@ -1335,6 +1335,9 @@
 /* Restaurant or other food place's menu URL field in the Editor */
 "website_menu" = "Liên kết thực đơn";
 
+/* Message for the bug report alert. */
+"bugreport_alert_message" = "Bạn có muốn gửi báo cáo lỗi cho nhà phát triển không?\nChúng tôi dựa vào người dùng của mình vì Bản đồ không phải trả tiền không tự động thu thập bất kỳ thông tin lỗi nào. Cảm ơn bạn trước vì đã ủng hộ Organic Maps!";
+
 /* Title for the "Enable iCloud Syncronization" alert. */
 "enable_icloud_synchronization_title" = "Kích hoạt đồng bộ hóa iCloud";
 
@@ -1353,6 +1356,9 @@
 /* Title for the "Enable iCloud Syncronization" alert's "Backup" action button. */
 "backup" = "Hỗ trợ";
 
+/* Title for the "iCloud synchronization failure" alert. */
+"icloud_synchronization_error_alert_title" = "Lỗi đồng bộ hóa iCloud";
+
 /* iCloud error message: Failed to synchronize due to connection error */
 "icloud_synchronization_error_connection_error" = "Lỗi: Không đồng bộ được do lỗi kết nối";
 
@@ -1362,7 +1368,7 @@
 /* iCloud error message: iCloud is not available */
 "icloud_synchronization_error_cloud_is_unavailable" = "Lỗi: iCloud không khả dụng";
 
-/* Title for the "Open In Another App" buton on the PlacePage. */
+/* Title for the "Open In Another App" button on the PlacePage. */
 "open_in_app" = "Mở trong ứng dụng khác";
 
 

--- a/iphone/Maps/LocalizedStrings/zh-Hans.lproj/Localizable.strings
+++ b/iphone/Maps/LocalizedStrings/zh-Hans.lproj/Localizable.strings
@@ -1335,6 +1335,9 @@
 /* Restaurant or other food place's menu URL field in the Editor */
 "website_menu" = "菜单链接";
 
+/* Message for the bug report alert. */
+"bugreport_alert_message" = "您想向开发人员发送错误报告吗？\n由于有机地图不会自动收集任何错误信息，因此我们只能依靠我们的用户。感谢您对有机地图的支持！";
+
 /* Title for the "Enable iCloud Syncronization" alert. */
 "enable_icloud_synchronization_title" = "启用 iCloud 同步";
 
@@ -1353,6 +1356,9 @@
 /* Title for the "Enable iCloud Syncronization" alert's "Backup" action button. */
 "backup" = "备份";
 
+/* Title for the "iCloud synchronization failure" alert. */
+"icloud_synchronization_error_alert_title" = "iCloud 同步失败";
+
 /* iCloud error message: Failed to synchronize due to connection error */
 "icloud_synchronization_error_connection_error" = "错误：由于连接错误，同步失败";
 
@@ -1362,7 +1368,7 @@
 /* iCloud error message: iCloud is not available */
 "icloud_synchronization_error_cloud_is_unavailable" = "错误：iCloud 不可用";
 
-/* Title for the "Open In Another App" buton on the PlacePage. */
+/* Title for the "Open In Another App" button on the PlacePage. */
 "open_in_app" = "在另一个应用程序中打开";
 
 

--- a/iphone/Maps/LocalizedStrings/zh-Hant.lproj/Localizable.strings
+++ b/iphone/Maps/LocalizedStrings/zh-Hant.lproj/Localizable.strings
@@ -1335,6 +1335,9 @@
 /* Restaurant or other food place's menu URL field in the Editor */
 "website_menu" = "選單連結";
 
+/* Message for the bug report alert. */
+"bugreport_alert_message" = "您想向開發人員發送錯誤報告嗎？\n我們依賴我們的用戶，因為有機地圖不會自動收集任何錯誤訊息。預先感謝您對有機地圖的支持！";
+
 /* Title for the "Enable iCloud Syncronization" alert. */
 "enable_icloud_synchronization_title" = "啟用 iCloud 同步";
 
@@ -1353,6 +1356,9 @@
 /* Title for the "Enable iCloud Syncronization" alert's "Backup" action button. */
 "backup" = "备份";
 
+/* Title for the "iCloud synchronization failure" alert. */
+"icloud_synchronization_error_alert_title" = "iCloud 同步失敗";
+
 /* iCloud error message: Failed to synchronize due to connection error */
 "icloud_synchronization_error_connection_error" = "錯誤：由於連線錯誤而無法同步";
 
@@ -1362,7 +1368,7 @@
 /* iCloud error message: iCloud is not available */
 "icloud_synchronization_error_cloud_is_unavailable" = "錯誤：iCloud 不可用";
 
-/* Title for the "Open In Another App" buton on the PlacePage. */
+/* Title for the "Open In Another App" button on the PlacePage. */
 "open_in_app" = "在另一個應用程式中打開";
 
 

--- a/iphone/Maps/Tests/Core/iCloudTests/MetadataItemStubs.swift
+++ b/iphone/Maps/Tests/Core/iCloudTests/MetadataItemStubs.swift
@@ -5,9 +5,6 @@ extension LocalMetadataItem {
                    lastModificationDate: TimeInterval) -> LocalMetadataItem {
     let item = LocalMetadataItem(fileName: fileName,
                                  fileUrl: URL(string: "url")!,
-                                 fileSize: 0,
-                                 contentType: "",
-                                 creationDate: Date().timeIntervalSince1970,
                                  lastModificationDate: lastModificationDate)
     return item
 
@@ -22,10 +19,7 @@ extension CloudMetadataItem {
                    hasUnresolvedConflicts: Bool = false) -> CloudMetadataItem {
     let item = CloudMetadataItem(fileName: fileName,
                                  fileUrl: URL(string: "url")!,
-                                 fileSize: 0,
-                                 contentType: "",
                                  isDownloaded: isDownloaded,
-                                 creationDate: Date().timeIntervalSince1970,
                                  lastModificationDate: lastModificationDate,
                                  isRemoved: isInTrash,
                                  downloadingError: nil,

--- a/iphone/Maps/UI/Settings/Cells/SettingsTableViewiCloudSwitchCell.swift
+++ b/iphone/Maps/UI/Settings/Cells/SettingsTableViewiCloudSwitchCell.swift
@@ -1,22 +1,15 @@
 final class SettingsTableViewiCloudSwitchCell: SettingsTableViewDetailedSwitchCell {
 
   @objc
-  func updateWithError(_ error: NSError?) {
-    if let error = error as? SynchronizationError {
-      switch error {
-      case .fileUnavailable, .fileNotUploadedDueToQuota, .ubiquityServerNotAvailable:
-        accessoryView = switchButton
-      case .iCloudIsNotAvailable, .containerNotFound:
-        accessoryView = nil
-        accessoryType = .detailButton
-      default:
-        break
-      }
-      detailTextLabel?.text = error.localizedDescription
-    } else {
-      accessoryView = switchButton
-      detailTextLabel?.text?.removeAll()
+  func updateWithSynchronizationState(_ state: CloudStorageSynchronizationState) {
+    guard state.isAvailable else {
+      accessoryView = nil
+      accessoryType = .detailButton
+      return
     }
+    accessoryView = switchButton
+    detailTextLabel?.text = state.error?.localizedDescription
+    setOn(state.isOn, animated: true)
     setNeedsLayout()
   }
 }

--- a/iphone/Maps/UI/Settings/MWMSettingsViewController.mm
+++ b/iphone/Maps/UI/Settings/MWMSettingsViewController.mm
@@ -185,15 +185,14 @@ static NSString * const kUDDidShowICloudSynchronizationEnablingAlert = @"kUDDidS
   }
   [self.nightModeCell configWithTitle:L(@"pref_appearance_title") info:nightMode];
 
-  BOOL isICLoudSynchronizationEnabled = [MWMSettings iCLoudSynchronizationEnabled];
   [self.iCloudSynchronizationCell configWithDelegate:self
                                                title:@"iCloud Synchronization (Beta)"
-                                                isOn:isICLoudSynchronizationEnabled];
+                                                isOn:[MWMSettings iCLoudSynchronizationEnabled]];
 
   __weak __typeof(self) weakSelf = self;
-  [CloudStorageManager.shared addObserver:self onErrorCompletionHandler:^(NSError * _Nullable error) {
+  [CloudStorageManager.shared addObserver:self synchronizationStateDidChangeHandler:^(CloudStorageSynchronizationState * state) {
     __strong auto strongSelf = weakSelf;
-    [strongSelf.iCloudSynchronizationCell updateWithError:error];
+    [strongSelf.iCloudSynchronizationCell updateWithSynchronizationState:state];
   }];
 
   [self.enableLoggingCell configWithDelegate:self title:L(@"enable_logging") isOn:MWMSettings.isFileLoggingEnabled];
@@ -330,7 +329,6 @@ static NSString * const kUDDidShowICloudSynchronizationEnablingAlert = @"kUDDidS
   } else if (cell == self.iCloudSynchronizationCell) {
     if (![NSUserDefaults.standardUserDefaults boolForKey:kUDDidShowICloudSynchronizationEnablingAlert]) {
       [self showICloudSynchronizationEnablingAlert:^(BOOL isEnabled) {
-        [self.iCloudSynchronizationCell setOn:isEnabled animated:YES];
         [MWMSettings setICLoudSynchronizationEnabled:isEnabled];
       }];
     } else {


### PR DESCRIPTION
This PR contains:
1. if iCloud sync fails the alert with the `Report a bug` button will be shown to help user notify about unexpected behavior
2. improve the error handling - in case of unexpected exceptions throwing (missed directories, corrupted `NSMetadataItems` of URL's attributes) the sync will be stopped
3. the mail composing logic is moved to the new `MailComposer` class to reuse both in the About screen and SyncManager
4. removed unused `MetadataItem` properties
5. refactor the Settings's iCloud cell to subscribe on the `CloudStorageSynchronizationState` to properly handle errors, on/off, and availability state


### Results:
1.  
<img width="350" alt="image" src="https://github.com/user-attachments/assets/5c6b6b68-d4fe-4e0c-b4d9-f7d879c350d9">

2. The log file now contains more proper description with the failure reason:
```txt
E(1) 75.44956 MetadataItem.swift:49 init(metadataItem:isRemoved:): Failed to initialize CloudMetadataItem from NSMetadataItem: Optional(["NSMetadataItemContainerIdentifierKey": iCloud.app.organicmaps.debug, "NSMetadataUbiquitousItemIsSharedKey": 0, "NSMetadataUbiquitousItemURLInLocalContainerKey": file:///private/var/mobile/Library/Mobile%20Documents/iCloud~app~organicmaps~debug/Documents/doc.kml, "kMDItemContentTypeTree": <__NSArrayI_Transfer 0x303d52ee0>(
public.xml,
public.text,
vnd.google-earth.kml,
public.data,
public.item,
public.content
)
, "NSMetadataUbiquitousItemPercentDownloadedKey": 100, "NSMetadataUbiquitousItemIsUploadedKey": 1, "kMDItemFSContentChangeDate": 2024-07-22 14:10:34 +0000, "NSMetadataUbiquitousItemDownloadingStatusKey": NSMetadataUbiquitousItemDownloadingStatusCurrent, "NSMetadataUbiquitousItemPercentUploadedKey": 100, "kMDItemPath": /private/var/mobile/Library/Mobile Documents/iCloud~app~organicmaps~debug/Documents/doc.kml, "NSMetadataUbiquitousItemDownloadRequestedKey": 1, "kMDItemFSCreationDate": 2024-07-22 14:10:34 +0000, "kMDItemContentType": vnd.google-earth.kml, "kMDItemURL": file:///private/var/mobile/Library/Mobile%20Documents/iCloud~app~organicmaps~debug/Documents/doc.kml, "NSMetadataUbiquitousItemIsUploadingKey": 0, "kMDItemFSName": doc.kml, "kMDItemDisplayName": doc, "NSMetadataUbiquitousItemContainerDisplayNameKey": OrganicMapsDEBUG, "NSMetadataItemIsUbiquitousKey": 1, "BRMetadataIsTopLevelSharedItemKey": 0, "NSMetadataUbiquitousItemIsDownloadingKey": 0, "NSMetadataUbiquitousItemIsDownloadedKey": 1, "NSMetadataUbiquitousItemHasUnresolvedConflictsKey": 0, "NSMetadataUbiquitousItemIsExternalDocumentKey": 0, "BRMetadataItemFileObjectIdentifierKey": <f26dc>, "kMDItemFSSize": 7515935])
E(1) 75.45165 CloudStorageManager.swift:296 processError(_:): Synchronization Error: Failed to create metadata item.
D(1) 75.45168 CloudStorageManager.swift:138 stopSynchronization(withError:): Stop synchronization
D(1) 75.45171 DefaultLocalDirectoryMonitor.swift:95 stop(): LocalMonitor: Stop.
D(1) 75.45173 DefaultLocalDirectoryMonitor.swift:170 suspendDispatchSource(): LocalMonitor: Suspend dispatch source.
D(1) 75.45178 iCloudDocumentsDirectoryMonitor.swift:72 stop(): iCloudMonitor: Stop
D(1) 75.45183 iCloudDocumentsDirectoryMonitor.swift:202 stopQuery(): iCloudMonitor: Stop metadata query
```
