### PR TITLE
[ios] [android] Refactor the visibility and enabling states of the Add/Edit Place buttons on the PP and Menu

### DIFF
--- a/android/app/src/main/cpp/app/organicmaps/editor/Editor.cpp
+++ b/android/app/src/main/cpp/app/organicmaps/editor/Editor.cpp
@@ -188,13 +188,23 @@ Java_app_organicmaps_editor_Editor_nativeShouldShowAddPlace(JNIEnv *, jclass)
 }
 
 JNIEXPORT jboolean JNICALL
-Java_app_organicmaps_editor_Editor_nativeShouldShowAddBusiness(JNIEnv *, jclass)
+Java_app_organicmaps_editor_Editor_nativeShouldEnableEditPlace(JNIEnv *, jclass)
 {
   ::Framework * frm = g_framework->NativeFramework();
   if (!frm->HasPlacePageInfo())
     return static_cast<jboolean>(false);
 
-  return g_framework->GetPlacePageInfo().ShouldShowAddBusiness();
+  return g_framework->GetPlacePageInfo().ShouldEnableEditPlace();
+}
+
+JNIEXPORT jboolean JNICALL
+Java_app_organicmaps_editor_Editor_nativeShouldEnableAddPlace(JNIEnv *, jclass)
+{
+  ::Framework * frm = g_framework->NativeFramework();
+  if (!frm->HasPlacePageInfo())
+    return static_cast<jboolean>(false);
+
+  return g_framework->GetPlacePageInfo().ShouldEnableAddPlace();
 }
 
 JNIEXPORT jintArray JNICALL

--- a/android/app/src/main/java/app/organicmaps/editor/Editor.java
+++ b/android/app/src/main/java/app/organicmaps/editor/Editor.java
@@ -55,7 +55,8 @@ public final class Editor
 
   public static native boolean nativeShouldShowEditPlace();
   public static native boolean nativeShouldShowAddPlace();
-  public static native boolean nativeShouldShowAddBusiness();
+  public static native boolean nativeShouldEnableEditPlace();
+  public static native boolean nativeShouldEnableAddPlace();
   @NonNull
   public static native int[] nativeGetEditableProperties();
 

--- a/android/app/src/main/java/app/organicmaps/widget/placepage/PlacePageView.java
+++ b/android/app/src/main/java/app/organicmaps/widget/placepage/PlacePageView.java
@@ -450,8 +450,13 @@ public class PlacePageView extends Fragment implements View.OnClickListener,
     else
     {
       UiUtils.showIf(Editor.nativeShouldShowEditPlace(), mEditPlace);
-      UiUtils.showIf(Editor.nativeShouldShowAddBusiness(), mAddOrganisation);
       UiUtils.showIf(Editor.nativeShouldShowAddPlace(), mAddPlace);
+      mEditPlace.setEnabled(Editor.nativeShouldEnableEditPlace());
+      mAddPlace.setEnabled(Editor.nativeShouldEnableAddPlace());
+      TextView mTvEditPlace = mEditPlace.findViewById(R.id.tv__editor);
+      TextView mTvAddPlace = mAddPlace.findViewById(R.id.tv__editor);
+      mTvEditPlace.setTextColor(Editor.nativeShouldEnableEditPlace() ? getResources().getColor(R.color.base_accent) : getResources().getColor(R.color.button_accent_text_disabled));
+      mTvAddPlace.setTextColor(Editor.nativeShouldEnableEditPlace() ? getResources().getColor(R.color.base_accent) : getResources().getColor(R.color.button_accent_text_disabled));
       UiUtils.showIf(UiUtils.isVisible(mEditPlace)
                      || UiUtils.isVisible(mAddOrganisation)
                      || UiUtils.isVisible(mAddPlace), mEditTopSpace);

--- a/iphone/CoreApi/CoreApi/Framework/MWMFrameworkHelper.h
+++ b/iphone/CoreApi/CoreApi/Framework/MWMFrameworkHelper.h
@@ -34,7 +34,7 @@ NS_SWIFT_NAME(FrameworkHelper)
 + (void)searchInDownloader:(NSString *)query
                inputLocale:(NSString *)locale
                 completion:(SearchInDownloaderCompletions)completion;
-+ (BOOL)canEditMap;
++ (BOOL)canEditMapAtViewportCenter;
 + (void)showOnMap:(MWMMarkGroupID)categoryId;
 + (void)showBookmark:(MWMMarkID)bookmarkId;
 + (void)showTrack:(MWMTrackID)trackId;

--- a/iphone/CoreApi/CoreApi/Framework/MWMFrameworkHelper.mm
+++ b/iphone/CoreApi/CoreApi/Framework/MWMFrameworkHelper.mm
@@ -162,8 +162,9 @@
   GetFramework().GetSearchAPI().SearchInDownloader(std::move(params));
 }
 
-+ (BOOL)canEditMap {
-  return GetFramework().CanEditMap();
++ (BOOL)canEditMapAtViewportCenter {
+  auto const &f = GetFramework();
+  return f.CanEditMapForPosition(f.GetViewportCenter());
 }
 
 + (void)showOnMap:(MWMMarkGroupID)categoryId {

--- a/iphone/CoreApi/CoreApi/PlacePageData/Common/PlacePageButtonsData.h
+++ b/iphone/CoreApi/CoreApi/PlacePageData/Common/PlacePageButtonsData.h
@@ -6,7 +6,9 @@ NS_ASSUME_NONNULL_BEGIN
 
 @property(nonatomic, readonly) BOOL showAddPlace;
 @property(nonatomic, readonly) BOOL showEditPlace;
-@property(nonatomic, readonly) BOOL showAddBusiness;
+
+@property(nonatomic, readonly) BOOL enableAddPlace;
+@property(nonatomic, readonly) BOOL enableEditPlace;
 
 @end
 

--- a/iphone/CoreApi/CoreApi/PlacePageData/Common/PlacePageButtonsData.mm
+++ b/iphone/CoreApi/CoreApi/PlacePageData/Common/PlacePageButtonsData.mm
@@ -11,8 +11,9 @@
   if (self) {
     _showAddPlace = rawData.ShouldShowAddPlace();
     _showEditPlace = rawData.ShouldShowEditPlace();
-    _showAddBusiness = rawData.ShouldShowAddBusiness();
-    if (_showAddPlace || _showEditPlace || _showAddBusiness)
+    _enableAddPlace = rawData.ShouldEnableAddPlace();
+    _enableEditPlace = rawData.ShouldEnableEditPlace();
+    if (_showAddPlace || _showEditPlace || _enableAddPlace || _enableEditPlace)
       return self;
   }
   return nil;

--- a/iphone/Maps/Classes/CustomViews/MapViewControls/MWMMapViewControlsManager.mm
+++ b/iphone/Maps/Classes/CustomViews/MapViewControls/MWMMapViewControlsManager.mm
@@ -148,9 +148,7 @@ NSString *const kMapToCategorySelectorSegue = @"MapToCategorySelectorSegue";
     applyPosition:hasPoint
     position:point
     doneBlock:^{
-      auto &f = GetFramework();
-
-      if (IsPointCoveredByDownloadedMaps(f.GetViewportCenter(), f.GetStorage(), f.GetCountryInfoGetter()))
+      if ([MWMFrameworkHelper canEditMapAtViewportCenter])
         [ownerController performSegueWithIdentifier:kMapToCategorySelectorSegue sender:nil];
       else
         [ownerController.alertController presentIncorrectFeauturePositionAlert];

--- a/iphone/Maps/UI/BottomMenu/Menu/BottomMenuPresenter.swift
+++ b/iphone/Maps/UI/BottomMenu/Menu/BottomMenuPresenter.swift
@@ -88,6 +88,13 @@ extension BottomMenuPresenter {
 //MARK: -- UITableDelegate
 
 extension BottomMenuPresenter {
+  func tableView(_ tableView: UITableView, willSelectRowAt indexPath: IndexPath) -> IndexPath? {
+    if let cell = tableView.cellForRow(at: indexPath) as? BottomMenuItemCell {
+      return cell.isEnabled ? indexPath : nil
+    }
+    return indexPath
+  }
+
   func tableView(_ tableView: UITableView, didSelectRowAt indexPath: IndexPath) {
     guard indexPath.section == Sections.items.rawValue else {
       return

--- a/iphone/Maps/UI/BottomMenu/Menu/BottomMenuPresenter.swift
+++ b/iphone/Maps/UI/BottomMenu/Menu/BottomMenuPresenter.swift
@@ -59,7 +59,7 @@ extension BottomMenuPresenter {
     let cell = tableView.dequeueReusableCell(cell: BottomMenuItemCell.self)!
     switch CellType(rawValue: correctedRow(indexPath.row))! {
     case .addPlace:
-      let enabled = MWMNavigationDashboardManager.shared().state == .hidden && FrameworkHelper.canEditMap()
+      let enabled = MWMNavigationDashboardManager.shared().state == .hidden && FrameworkHelper.canEditMapAtViewportCenter()
       cell.configure(imageName: "ic_add_place",
                      title: L("placepage_add_place_button"),
                      badgeCount: 0,

--- a/iphone/Maps/UI/BottomMenu/Menu/Cells/BottomMenuItemCell.swift
+++ b/iphone/Maps/UI/BottomMenu/Menu/Cells/BottomMenuItemCell.swift
@@ -14,7 +14,7 @@ class BottomMenuItemCell: UITableViewCell {
     }
   }
   
-  private var isEnabled: Bool = true
+  private(set) var isEnabled: Bool = true
   private var isPromo: Bool = false
   
   func configure(imageName: String, title: String, badgeCount: UInt, enabled: Bool) {

--- a/iphone/Maps/UI/PlacePage/Components/PlacePageButtonsViewController.swift
+++ b/iphone/Maps/UI/PlacePage/Components/PlacePageButtonsViewController.swift
@@ -1,18 +1,13 @@
 protocol PlacePageButtonsViewControllerDelegate: AnyObject {
-  func didPressHotels()
   func didPressAddPlace()
   func didPressEditPlace()
-  func didPressAddBusiness()
 }
 
 class PlacePageButtonsViewController: UIViewController {
-//  @IBOutlet var bookingButton: UIButton!
   @IBOutlet var addPlaceButton: UIButton!
   @IBOutlet var editPlaceButton: UIButton!
-//  @IBOutlet var addBusinessButton: UIButton!
 
   private var buttons: [UIButton?] {
-//    [bookingButton, addPlaceButton, editPlaceButton, addBusinessButton]
     [addPlaceButton, editPlaceButton]
   }
 
@@ -30,18 +25,11 @@ class PlacePageButtonsViewController: UIViewController {
   override func viewDidLoad() {
     super.viewDidLoad()
 
-//    bookingButton.isHidden = !buttonsData.showHotelDescription
     addPlaceButton.isHidden = !buttonsData.showAddPlace
     editPlaceButton.isHidden = !buttonsData.showEditPlace
-//    addBusinessButton.isHidden = !buttonsData.showAddBusiness
 
-    buttons.forEach {
-      $0?.isEnabled = buttonsEnabled
-    }
-  }
-    
-  @IBAction func onBooking(_ sender: UIButton) {
-    delegate?.didPressHotels()
+    addPlaceButton.isEnabled = buttonsData.enableAddPlace
+    editPlaceButton.isEnabled = buttonsData.enableEditPlace
   }
 
   @IBAction func onAddPlace(_ sender: UIButton) {
@@ -50,9 +38,5 @@ class PlacePageButtonsViewController: UIViewController {
 
   @IBAction func onEditPlace(_ sender: UIButton) {
     delegate?.didPressEditPlace()
-  }
-
-  @IBAction func onAddBusiness(_ sender: UIButton) {
-    delegate?.didPressAddBusiness()
   }
 }

--- a/iphone/Maps/UI/PlacePage/PlacePageLayout/Layouts/PlacePageCommonLayout.swift
+++ b/iphone/Maps/UI/PlacePage/PlacePageLayout/Layouts/PlacePageCommonLayout.swift
@@ -70,7 +70,6 @@ class PlacePageCommonLayout: NSObject, IPlacePageLayout {
   lazy var buttonsViewController: PlacePageButtonsViewController = {
     let vc = storyboard.instantiateViewController(ofType: PlacePageButtonsViewController.self)
     vc.buttonsData = placePageData.buttonsData!
-    vc.buttonsEnabled = placePageData.mapNodeAttributes?.nodeStatus == .onDisk
     vc.delegate = interactor
     return vc
   } ()

--- a/map/framework.hpp
+++ b/map/framework.hpp
@@ -721,10 +721,8 @@ protected:
   void RegisterCountryFilesOnRoute(std::shared_ptr<routing::NumMwmIds> ptr) const override;
 
 public:
-  /// @name Editor interface.
-  /// Initializes feature for Create Object UI.
   /// @returns false in case when coordinate is in the ocean or mwm is not downloaded.
-  bool CanEditMap() const;
+  bool CanEditMapForPosition(m2::PointD const & position) const;
 
   bool CreateMapObject(m2::PointD const & mercator, uint32_t const featureType, osm::EditableMapObject & emo) const;
   /// @returns false if feature is invalid or can't be edited.

--- a/map/place_page_info.cpp
+++ b/map/place_page_info.cpp
@@ -29,7 +29,7 @@ bool Info::IsBookmark() const
 bool Info::ShouldShowAddPlace() const
 {
   auto const isPointOrBuilding = IsPointType() || IsBuilding();
-  return m_canEditOrAdd && !(IsFeature() && isPointOrBuilding);
+  return !(IsFeature() && isPointOrBuilding);
 }
 
 void Info::SetFromFeatureType(FeatureType & ft)
@@ -290,9 +290,8 @@ void Info::SetBookmarkId(kml::MarkId bookmarkId)
 
 bool Info::ShouldShowEditPlace() const
 {
-  return m_canEditOrAdd &&
-         // TODO(mgsergio): Does IsFeature() imply !IsMyPosition()?
-         !IsMyPosition() && IsFeature();
+  // TODO(mgsergio): Does IsFeature() imply !IsMyPosition()?
+  return !IsMyPosition() && IsFeature();
 }
 
 kml::LocalizableString Info::FormatNewBookmarkName() const

--- a/map/place_page_info.hpp
+++ b/map/place_page_info.hpp
@@ -113,8 +113,10 @@ public:
 
   /// Edit and add
   bool ShouldShowAddPlace() const;
-  bool ShouldShowAddBusiness() const { return m_canEditOrAdd && IsBuilding(); }
   bool ShouldShowEditPlace() const;
+
+  bool ShouldEnableAddPlace() const { return m_canEditOrAdd; };
+  bool ShouldEnableEditPlace() const { return m_canEditOrAdd; };
 
   /// @returns true if Back API button should be displayed.
   bool HasApiUrl() const { return !m_apiUrl.empty(); }

--- a/platform/mwm_version.cpp
+++ b/platform/mwm_version.cpp
@@ -16,11 +16,6 @@ namespace version
 {
 namespace
 {
-// Editing maps older than approximately two months old is disabled, since the data
-// is most likely already fixed on OSM. Not limited to the latest one or two versions,
-// because a user can forget to update maps after a new app version has been installed
-// automatically in the background.
-uint64_t constexpr kMaxSecondsTillNoEdits = 3600 * 24 * 31 * 2;
 char const MWM_PROLOG[] = "MWM";
 }
 
@@ -46,11 +41,6 @@ uint32_t MwmVersion::GetVersion() const
 {
   auto const tm = base::GmTime(base::SecondsSinceEpochToTimeT(m_secondsSinceEpoch));
   return base::GenerateYYMMDD(tm.tm_year, tm.tm_mon, tm.tm_mday);
-}
-
-bool MwmVersion::IsEditableMap() const
-{
-  return m_secondsSinceEpoch + kMaxSecondsTillNoEdits > base::SecondsSinceEpoch();
 }
 
 std::string DebugPrint(Format f)

--- a/platform/mwm_version.hpp
+++ b/platform/mwm_version.hpp
@@ -43,8 +43,6 @@ public:
   /// \return version as YYMMDD.
   uint32_t GetVersion() const;
 
-  bool IsEditableMap() const;
-
   /// @name Used in tests only.
   /// @{
   void SetFormat(Format format) { m_format = format; }

--- a/storage/storage.hpp
+++ b/storage/storage.hpp
@@ -378,6 +378,9 @@ public:
   /// \brief Returns true if the last version of countryId has been downloaded.
   bool HasLatestVersion(CountryId const & countryId) const;
 
+  /// \brief Returns true if the version of countryId can be used to update maps.
+  bool IsAllowedToEditVersion(CountryId const & countryId) const;
+
   /// Returns version of downloaded mwm or zero.
   int64_t GetVersion(CountryId const & countryId) const;
 


### PR DESCRIPTION
### Issue description:
The `Add Place to OSM` can be selected even in disabled (text is gray) mode in ios.

### Expected behavior:
1. The `Add/Edit place` on the PP should be disabled when the map is not downloaded OR outdated (>3mo)
2. The `Add place` on the Menu should be disabled when the map is not downloaded OR outdated (>3mo)
3. If the user open the `Add place` from the `Menu` and moves the map an additional check should happens to prevent editing of the outdated map
4. The `Add/Edit place` on the PP should be visible even if disabled (as a next step it will be possible to change the title to the "Update/Download [name of the region]" and navigate the user to the downloading page from this button).

## This PR contains:
### Core
1. The logic to check if the map/poi is editable is moved from the `mwm_info` to the `storage` and based on the file's `state` and `version` because this check should be used for both 1) the selected poi editing and 2) the add place from the menu only by using only the viewport coordinates (to deactivate the `add place` when the `viewport center` is out of the downloaded OR updated area).
2. `CanEditMap()` changed to the `CanEditMapForPosition(m2::PointD const & position)` because the previous method only checks the downloading of some map progress - this is not correct when the user tries to edit the fresh map while some other region is downloaded:
```
bool Framework::CanEditMap() const
{
  return !GetStorage().IsDownloadInProgress();
}
```
3. `bool ShouldEnableAddPlace() const { return m_canEditOrAdd; };` and `bool ShouldEnableEditPlace() const { return m_canEditOrAdd; };` were added to separate the add/edit buttons editable state from the visibility.

@vng can you please review the changes?

### iOS
1. Menu screen:
1.1. If the current viewport center points into the **downloaded latest or outdated (< that 3 months)** map the `Add Place` button will be **enabled**
1.2. If the current viewport center points into the **not downloaded or outdated (> that 3 months)** map the `Add Place` button will be **disabled**

3. Place Page screen
2.1. If the selected POI is on the **downloaded latest or outdated (< that 3 months)** map the `Add Place/Edit Place` buttons will be visible and **enabled**
2.2. If the selected POI is on the **not downloaded or outdated (> that 3 months)** map the `Add Place/Edit Place` buttons will be visible and **disabled**

#### Downloaded latest or outdated (< that 3 months):
<img width="350" alt="image" src="https://github.com/user-attachments/assets/17f8b965-be0a-4285-bb1f-5c6cee51ffcb">
<img width="350" alt="image" src="https://github.com/user-attachments/assets/a1533e80-c705-4d68-baea-016650ad8b9e">
<img width="350" alt="image" src="https://github.com/user-attachments/assets/fc89901d-8fdd-4a24-8554-b3e2f74fb38a">

#### Not downloaded maps or outdated (> that 3 months):
https://github.com/user-attachments/assets/fa667fe6-f511-4c15-99c3-460590f0c2a5
<img width="350" alt="image" src="https://github.com/user-attachments/assets/188138f1-4ee6-4ad8-a719-e5dc6d7d3584">
<img width="350" alt="image" src="https://github.com/user-attachments/assets/4d829e52-460b-4d6e-942b-5e188f9fa76a">

Menu:

![Simulator Screen Recording - iPhone 15 - 2024-07-23 at 19 48 52](https://github.com/user-attachments/assets/437296c6-cc0d-4bbb-875a-cb477894a0e1)
![Simulator Screen Recording - iPhone 15 - 2024-07-23 at 19 49 40](https://github.com/user-attachments/assets/1d5accfb-c19c-48f1-ad56-1fac1155cf20)

### Android:
1. Place Page screen
1.1. If the selected POI is on the **downloaded latest or outdated (< that 3 months)** map the `Add Place/Edit Place` buttons will be visible and **enabled**
1.2. If the selected POI is on the **not downloaded or outdated (> that 3 months)** map the `Add Place/Edit Place` buttons will be visible and **disabled**

TODO:
- [ ] disabled state for the PP's buttons on the Android should be grayed (not just not active)

#### Downloaded latest maps:
<img width="350" alt="image" src="https://github.com/user-attachments/assets/9edca734-aa1c-4781-8409-d6755abbef9f">

#### Not downloaded maps:
<img width="350" alt="image" src="https://github.com/user-attachments/assets/4dd05454-9f2e-4a97-b710-46aa298e1b1a">


### Key differences from the previous implementation:
- there are no situations when both of the `Add Place/Edit Place` buttons are hidden (it happens when map downloading is in progress regardless of where the user tries to add a place), so they will be disabled (in the future they should contain text to notify a user that is needed to download/update the map).
- maps that are outdated but not too much (< that 3 months) can be edited


