### PR TITLE
[ios] Move the mail composing logic to the `MailComposer` class

### DIFF
--- a/iphone/Maps/Maps.xcodeproj/project.pbxproj
+++ b/iphone/Maps/Maps.xcodeproj/project.pbxproj
@@ -485,6 +485,7 @@
 		ED79A5D82BDF8D6100952D1F /* DefaultLocalDirectoryMonitor.swift in Sources */ = {isa = PBXBuildFile; fileRef = ED79A5D02BDF8D6100952D1F /* DefaultLocalDirectoryMonitor.swift */; };
 		ED7CCC4F2C1362E300E2A737 /* FileType.swift in Sources */ = {isa = PBXBuildFile; fileRef = ED7CCC4E2C1362E300E2A737 /* FileType.swift */; };
 		ED8270F02C2071A3005966DA /* SettingsTableViewDetailedSwitchCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = ED8270EF2C2071A3005966DA /* SettingsTableViewDetailedSwitchCell.swift */; };
+		ED9857082C4ED02D00694F6C /* MailComposer.swift in Sources */ = {isa = PBXBuildFile; fileRef = ED9857072C4ED02D00694F6C /* MailComposer.swift */; };
 		ED9966802B94FBC20083CE55 /* ColorPicker.swift in Sources */ = {isa = PBXBuildFile; fileRef = ED99667D2B94FBC20083CE55 /* ColorPicker.swift */; };
 		EDBD68072B625724005DD151 /* LocationServicesDisabledAlert.xib in Resources */ = {isa = PBXBuildFile; fileRef = EDBD68062B625724005DD151 /* LocationServicesDisabledAlert.xib */; };
 		EDBD680B2B62572E005DD151 /* LocationServicesDisabledAlert.swift in Sources */ = {isa = PBXBuildFile; fileRef = EDBD680A2B62572E005DD151 /* LocationServicesDisabledAlert.swift */; };
@@ -1401,6 +1402,7 @@
 		ED79A5D02BDF8D6100952D1F /* DefaultLocalDirectoryMonitor.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = DefaultLocalDirectoryMonitor.swift; sourceTree = "<group>"; };
 		ED7CCC4E2C1362E300E2A737 /* FileType.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FileType.swift; sourceTree = "<group>"; };
 		ED8270EF2C2071A3005966DA /* SettingsTableViewDetailedSwitchCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SettingsTableViewDetailedSwitchCell.swift; sourceTree = "<group>"; };
+		ED9857072C4ED02D00694F6C /* MailComposer.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MailComposer.swift; sourceTree = "<group>"; };
 		ED99667D2B94FBC20083CE55 /* ColorPicker.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ColorPicker.swift; sourceTree = "<group>"; };
 		EDBD68062B625724005DD151 /* LocationServicesDisabledAlert.xib */ = {isa = PBXFileReference; lastKnownFileType = file.xib; path = LocationServicesDisabledAlert.xib; sourceTree = "<group>"; };
 		EDBD680A2B62572E005DD151 /* LocationServicesDisabledAlert.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LocationServicesDisabledAlert.swift; sourceTree = "<group>"; };
@@ -3098,6 +3100,14 @@
 			path = iCloud;
 			sourceTree = "<group>";
 		};
+		ED9857022C4ECFFC00694F6C /* MailComposer */ = {
+			isa = PBXGroup;
+			children = (
+				ED9857072C4ED02D00694F6C /* MailComposer.swift */,
+			);
+			path = MailComposer;
+			sourceTree = "<group>";
+		};
 		ED99667C2B94FBC20083CE55 /* ColorPicker */ = {
 			isa = PBXGroup;
 			children = (
@@ -3349,6 +3359,7 @@
 		F6E2FBFB1E097B9F0083EBEC /* UI */ = {
 			isa = PBXGroup;
 			children = (
+				ED9857022C4ECFFC00694F6C /* MailComposer */,
 				ED43B8B92C12061600D07BAA /* DocumentPicker */,
 				ED99667C2B94FBC20083CE55 /* ColorPicker */,
 				F69018B51E9E5FEB00B3C10B /* Autoupdate */,
@@ -4537,6 +4548,7 @@
 				3404164C1E7BF42E00E2B6D6 /* UIView+Coordinates.swift in Sources */,
 				99F3EB0323F4178200C713F8 /* PlacePageCommonLayout.swift in Sources */,
 				99C6532223F2F506004322F3 /* IPlacePageLayout.swift in Sources */,
+				ED9857082C4ED02D00694F6C /* MailComposer.swift in Sources */,
 				99F8B4C623B644A6009FF0B4 /* MapStyleSheet.swift in Sources */,
 				99012851244732DB00C72B10 /* BottomTabBarViewController.swift in Sources */,
 				F63AF5061EA6162400A1DB98 /* FilterTypeCell.swift in Sources */,

--- a/iphone/Maps/UI/Help/AboutController/AboutController.swift
+++ b/iphone/Maps/UI/Help/AboutController/AboutController.swift
@@ -277,14 +277,7 @@ private extension AboutController {
         case .faq:
           self?.navigationController?.pushViewController(FaqController(), animated: true)
         case .reportABug:
-          guard let link = aboutInfo.link else { fatalError("The recipient link should be provided to report a bug.") }
-          UIApplication.shared.showLoadingOverlay {
-            let logFileURL = Logger.getLogFileURL()
-            UIApplication.shared.hideLoadingOverlay {
-              guard let self else { return }
-              self.sendEmailWith(header: "Organic Maps Bugreport", toRecipients: [link], attachmentFileURL: logFileURL)
-            }
-          }
+          MailComposer.sendBugReport()
         case .reportMapDataProblem, .volunteer, .news:
           self?.openUrl(aboutInfo.link)
         case .rateTheApp:
@@ -313,8 +306,7 @@ private extension AboutController {
         case .linkedin:
           self?.openUrl(socialMedia.link, externally: true)
         case .organicMapsEmail:
-          guard let link = socialMedia.link else { fatalError("The Organic Maps email link should be provided.") }
-          self?.sendEmailWith(header: "Organic Maps", toRecipients: [link])
+          MailComposer.sendEmail(toRecipients: [socialMedia.link])
         }
       })
     }
@@ -441,111 +433,6 @@ extension AboutController: UICollectionViewDelegateFlowLayout {
     return Constants.socialMediaCollectionViewSpacing
   }
 }
-
-// MARK: - Mail Composing
-private extension AboutController {
-  func sendEmailWith(header: String, toRecipients: [String], attachmentFileURL: URL? = nil) {
-    func emailSubject(subject: String) -> String {
-      let appInfo = AppInfo.shared()
-      return String(format:"[%@-%@ iOS] %@", appInfo.bundleVersion, appInfo.buildNumber, subject)
-    }
-
-    func emailBody() -> String {
-      let appInfo = AppInfo.shared()
-      return String(format: "\n\n\n\n- %@ (%@)\n- Organic Maps %@-%@\n- %@-%@\n- %@\n",
-                    appInfo.deviceModel, UIDevice.current.systemVersion,
-                    appInfo.bundleVersion, appInfo.buildNumber,
-                    Locale.current.languageCode ?? "",
-                    Locale.current.regionCode ?? "",
-                    Locale.preferredLanguages.joined(separator: ", "))
-    }
-
-    func openOutlook(subject: String, body: String, recipients: [String]) -> Bool {
-      var components = URLComponents(string: "ms-outlook://compose")!
-      components.queryItems = [
-        URLQueryItem(name: "to", value: recipients.joined(separator: ";")),
-        URLQueryItem(name: "subject", value: subject),
-        URLQueryItem(name: "body", value: body),
-      ]
-
-      if let url = components.url, UIApplication.shared.canOpenURL(url) {
-        UIApplication.shared.open(url)
-        return true
-      }
-      return false
-    }
-
-    func openGmail(subject: String, body: String, recipients: [String]) -> Bool {
-      var components = URLComponents(string: "googlegmail://co")!
-      components.queryItems = [
-        URLQueryItem(name: "to", value: recipients.joined(separator: ";")),
-        URLQueryItem(name: "subject", value: subject),
-        URLQueryItem(name: "body", value: body),
-      ]
-
-      if let url = components.url, UIApplication.shared.canOpenURL(url) {
-        UIApplication.shared.open(url)
-        return true
-      }
-      return false
-    }
-    
-    func openDefaultMailApp(subject: String, body: String, recipients: [String]) -> Bool {
-      var components = URLComponents(string: "mailto:\(recipients.joined(separator: ";"))")
-      components?.queryItems = [
-        URLQueryItem(name: "subject", value: subject),
-        URLQueryItem(name: "body", value: body.replacingOccurrences(of: "\n", with: "\r\n")),
-      ]
-
-      if let url = components?.url, UIApplication.shared.canOpenURL(url) {
-        UIApplication.shared.open(url)
-        return true
-      }
-      return false
-    }
-
-    func showMailComposingAlert() {
-      let text = String(format:L("email_error_body"), toRecipients.joined(separator: ";"))
-      let alert = UIAlertController(title: L("email_error_title"), message: text, preferredStyle: .alert)
-      let action = UIAlertAction(title: L("ok"), style: .default, handler: nil)
-      alert.addAction(action)
-      present(alert, animated: true, completion: nil)
-    }
-
-    let subject = emailSubject(subject: header)
-    let body = emailBody()
-
-    // If the attachment file path is provided, the default mail composer should be used.
-    if let attachmentFileURL {
-      if MWMMailViewController.canSendMail(), let attachmentData = try? Data(contentsOf: attachmentFileURL) {
-        let mailViewController = MWMMailViewController()
-        mailViewController.mailComposeDelegate = self
-        mailViewController.setSubject(subject)
-        mailViewController.setMessageBody(body, isHTML:false)
-        mailViewController.setToRecipients(toRecipients)
-        mailViewController.addAttachmentData(attachmentData, mimeType: "application/zip", fileName: attachmentFileURL.lastPathComponent)
-
-        self.present(mailViewController, animated: true, completion:nil)
-      } else {
-        showMailComposingAlert()
-      }
-      return
-    }
-
-    // Before iOS 14, try to open alternate email apps first, assuming that if users installed them, they're using them.
-    let os = ProcessInfo().operatingSystemVersion
-    if (os.majorVersion < 14 && (openGmail(subject: subject, body: body, recipients: toRecipients) ||
-                                 openOutlook(subject: subject, body: body, recipients: toRecipients))) {
-      return
-    }
-    
-    // From iOS 14, it is possible to change the default mail app, and mailto should open a default mail app.
-    if !openDefaultMailApp(subject: subject, body: body, recipients: toRecipients) {
-      showMailComposingAlert()
-    }
-  }
-}
-
 // MARK: - UIStackView + AddArrangedSubviewWithSeparator
 private extension UIStackView {
   func addArrangedSubviewWithSeparator(_ view: UIView) {
@@ -562,12 +449,5 @@ private extension UIStackView {
       ])
     }
     addArrangedSubview(view)
-  }
-}
-
-// MARK: - MFMailComposeViewControllerDelegate
-extension AboutController: MFMailComposeViewControllerDelegate {
-  func mailComposeController(_ controller: MFMailComposeViewController, didFinishWith result: MFMailComposeResult, error: Error?) {
-    dismiss(animated: true, completion: nil)
   }
 }

--- a/iphone/Maps/UI/Help/AboutController/Models/SocialMedia.swift
+++ b/iphone/Maps/UI/Help/AboutController/Models/SocialMedia.swift
@@ -10,7 +10,7 @@ enum SocialMedia {
   case organicMapsEmail
   case github
 
-  var link: String? {
+  var link: String {
     switch self {
     case .telegram:
       return L("telegram_url")

--- a/iphone/Maps/UI/MailComposer/MailComposer.swift
+++ b/iphone/Maps/UI/MailComposer/MailComposer.swift
@@ -1,0 +1,133 @@
+@objcMembers
+final class MailComposer: NSObject {
+
+  private static let mailComposer = MailComposer()
+  private static var topViewController: UIViewController { .topViewController() }
+
+  private override init() {}
+
+  /// Composes an email with the provided subject, body and attachment file for the given recipients.
+  static func sendEmail(subject: String? = nil, body: String? = nil, toRecipients recipients: [String], attachmentFileURL: URL? = nil) {
+    sendEmailWith(subject: subject ?? "",
+                  body: body ?? "" ,
+                  toRecipients: recipients,
+                  attachmentFileURL: attachmentFileURL)
+  }
+
+  /// Composes an email with the additional app information and the log file attachment for the developers.
+  static func sendBugReport() {
+    func subject() -> String {
+      let appInfo = AppInfo.shared()
+      return String(format:"[%@-%@ iOS] %@", appInfo.bundleVersion, appInfo.buildNumber, "Organic Maps Bugreport")
+    }
+
+    func body() -> String {
+      let appInfo = AppInfo.shared()
+      return String(format: "\n\n\n\n- %@ (%@)\n- Organic Maps %@-%@\n- %@-%@\n- %@\n",
+                    appInfo.deviceModel, UIDevice.current.systemVersion,
+                    appInfo.bundleVersion, appInfo.buildNumber,
+                    Locale.current.languageCode ?? "",
+                    Locale.current.regionCode ?? "",
+                    Locale.preferredLanguages.joined(separator: ", "))
+    }
+    UIApplication.shared.showLoadingOverlay {
+      let logFileURL = Logger.getLogFileURL()
+      UIApplication.shared.hideLoadingOverlay {
+        sendEmailWith(subject: subject(),
+                      body: body(),
+                      toRecipients: [SocialMedia.organicMapsEmail.link],
+                      attachmentFileURL: logFileURL)
+      }
+    }
+  }
+
+  private static func sendEmailWith(subject: String, body: String, toRecipients recipients: [String], attachmentFileURL: URL? = nil) {
+    // If the attachment file path is provided, the default mail composer should be used.
+    if let attachmentFileURL {
+      if MWMMailViewController.canSendMail(), let attachmentData = try? Data(contentsOf: attachmentFileURL) {
+        let mailViewController = MWMMailViewController()
+        mailViewController.mailComposeDelegate = mailComposer
+        mailViewController.setSubject(subject)
+        mailViewController.setMessageBody(body, isHTML:false)
+        mailViewController.setToRecipients(recipients)
+        mailViewController.addAttachmentData(attachmentData, mimeType: "application/zip", fileName: attachmentFileURL.lastPathComponent)
+        topViewController.present(mailViewController, animated: true, completion:nil)
+      } else {
+        showMailComposingAlert(recipients: recipients)
+      }
+      return
+    }
+
+    // Before iOS 14, try to open alternate email apps first, assuming that if users installed them, they're using them.
+    let os = ProcessInfo().operatingSystemVersion
+    if (os.majorVersion < 14 && (openGmail(subject: subject, body: body, recipients: recipients) ||
+                                 openOutlook(subject: subject, body: body, recipients: recipients))) {
+      return
+    }
+
+    // From iOS 14, it is possible to change the default mail app, and mailto should open a default mail app.
+    if !openDefaultMailApp(subject: subject, body: body, recipients: recipients) {
+      showMailComposingAlert(recipients: recipients)
+    }
+  }
+
+  private static func openOutlook(subject: String, body: String, recipients: [String]) -> Bool {
+    var components = URLComponents(string: "ms-outlook://compose")!
+    components.queryItems = [
+      URLQueryItem(name: "to", value: recipients.joined(separator: ";")),
+      URLQueryItem(name: "subject", value: subject),
+      URLQueryItem(name: "body", value: body),
+    ]
+
+    if let url = components.url, UIApplication.shared.canOpenURL(url) {
+      UIApplication.shared.open(url)
+      return true
+    }
+    return false
+  }
+
+  private static func openGmail(subject: String, body: String, recipients: [String]) -> Bool {
+    var components = URLComponents(string: "googlegmail://co")!
+    components.queryItems = [
+      URLQueryItem(name: "to", value: recipients.joined(separator: ";")),
+      URLQueryItem(name: "subject", value: subject),
+      URLQueryItem(name: "body", value: body),
+    ]
+
+    if let url = components.url, UIApplication.shared.canOpenURL(url) {
+      UIApplication.shared.open(url)
+      return true
+    }
+    return false
+  }
+
+  private static func openDefaultMailApp(subject: String, body: String, recipients: [String]) -> Bool {
+    var components = URLComponents(string: "mailto:\(recipients.joined(separator: ";"))")
+    components?.queryItems = [
+      URLQueryItem(name: "subject", value: subject),
+      URLQueryItem(name: "body", value: body.replacingOccurrences(of: "\n", with: "\r\n")),
+    ]
+
+    if let url = components?.url, UIApplication.shared.canOpenURL(url) {
+      UIApplication.shared.open(url)
+      return true
+    }
+    return false
+  }
+
+  private static func showMailComposingAlert(recipients: [String]) {
+    let text = String(format:L("email_error_body"), recipients.joined(separator: ";"))
+    let alert = UIAlertController(title: L("email_error_title"), message: text, preferredStyle: .alert)
+    let action = UIAlertAction(title: L("ok"), style: .default, handler: nil)
+    alert.addAction(action)
+    topViewController.present(alert, animated: true, completion: nil)
+  }
+
+}
+
+// MARK: - MFMailComposeViewControllerDelegate
+extension MailComposer: MFMailComposeViewControllerDelegate {
+  func mailComposeController(_ controller: MFMailComposeViewController, didFinishWith result: MFMailComposeResult, error: Error?) {
+    controller.dismiss(animated: true, completion: nil)
+  }
+}

--- a/iphone/Maps/UI/PlacePage/PlacePageManager/MWMPlacePageManager.mm
+++ b/iphone/Maps/UI/PlacePage/PlacePageManager/MWMPlacePageManager.mm
@@ -274,7 +274,7 @@ using namespace storage;
 }
 
 - (void)openEmail:(PlacePageData *)data {
-  [UIApplication.sharedApplication openURL:data.infoData.emailUrl options:@{} completionHandler:nil];
+  [MailComposer sendEmailWithSubject:nil body:nil toRecipients:@[data.infoData.email] attachmentFileURL:nil];
 }
 
 - (void)openElevationDifficultPopup:(PlacePageData *)data {


### PR DESCRIPTION
This PR refactors the mail composing:
- logic is moved to the MailComposer class
- MailComposer can: 
   1. send the regular empty email to the provided recipient
   2. send the bug report with the attached log file (it is encapsulated in the MailComposer because it is a single-purpose method and doesn't used anywhere else)