### PR TITLE
[search] Store 50 recent searches instead of 10

### DIFF
--- a/search/query_saver.cpp
+++ b/search/query_saver.cpp
@@ -22,7 +22,7 @@ namespace
 {
 char constexpr kSettingsKey[] = "UserQueries";
 using Length = uint16_t;
-Length constexpr kMaxSuggestionsCount = 10;
+Length constexpr kMaxSuggestionsCount = 50;
 
 // Reader from memory that throws exceptions.
 class SecureMemReader : public Reader

--- a/search/query_saver.hpp
+++ b/search/query_saver.hpp
@@ -19,7 +19,7 @@ public:
   void Add(SearchRequest const & query);
 
   /// Returns several last saved queries from newest to oldest query.
-  /// @see kMaxSuggestCount in implementation file.
+  /// @see kMaxSuggestionsCount in implementation file.
   std::list<SearchRequest> const & Get() const { return m_topQueries; }
 
   /// Clear last queries storage. All data will be lost.


### PR DESCRIPTION
10 is too few. On modern phones, there's plenty of free space in the list. And there's also Clear search button (and enable/disable search history setting on Android).