### PR TITLE
Disable incorrect text splitting into two lines for RTL

### DIFF
--- a/drape/glyph_manager.cpp
+++ b/drape/glyph_manager.cpp
@@ -645,6 +645,9 @@ text::TextMetrics GlyphManager::ShapeText(std::string_view utf8, int fontPixelHe
   hb_language_t const hbLanguage = OrganicMapsLanguageToHarfbuzzLanguage(lang);
 
   text::TextMetrics allGlyphs;
+  // For SplitText it's enough to know if the last visual (first logical) segment is RTL.
+  allGlyphs.m_isRTL = segments.back().m_direction == HB_DIRECTION_RTL;
+
   // TODO(AB): Check if it's slower or faster.
   allGlyphs.m_glyphs.reserve(icu::UnicodeString{false, text.data(), static_cast<int32_t>(text.size())}.countChar32());
 

--- a/drape/glyph_manager.hpp
+++ b/drape/glyph_manager.hpp
@@ -37,6 +37,8 @@ struct TextMetrics
   int32_t m_lineWidthInPixels {0};
   int32_t m_maxLineHeightInPixels {0};
   std::vector<GlyphMetrics> m_glyphs;
+  // Used for SplitText.
+  bool m_isRTL {false};
 
   void AddGlyphMetrics(int16_t font, uint16_t glyphId, int32_t xOffset, int32_t yOffset, int32_t xAdvance, int32_t height)
   {

--- a/drape_frontend/text_layout.cpp
+++ b/drape_frontend/text_layout.cpp
@@ -130,14 +130,14 @@ struct LineMetrics
 };
 
 // Scan longer shaped glyphs, and try to split them into two strings if a space glyph is present.
-buffer_vector<LineMetrics, 2> SplitText(float textScale, dp::GlyphFontAndId space, dp::text::TextMetrics const & str)
+buffer_vector<LineMetrics, 2> SplitText(bool forceNoWrap, float textScale, dp::GlyphFontAndId space, dp::text::TextMetrics const & str)
 {
   // Add the whole line by default.
   buffer_vector<LineMetrics, 2> lines{{str.m_glyphs.size(),
       textScale * str.m_lineWidthInPixels, textScale * str.m_maxLineHeightInPixels}};
 
   size_t const count = str.m_glyphs.size();
-  if (count <= 15)
+  if (forceNoWrap || count <= 15)
     return lines;
 
   auto const begin = str.m_glyphs.begin();
@@ -289,7 +289,7 @@ StraightTextLayout::StraightTextLayout(std::string const & text, float fontSize,
   m_shapedGlyphs = textures->ShapeSingleTextLine(dp::kBaseFontSizePixels, text, &m_glyphRegions);
 
   // TODO(AB): Use ICU's BreakIterator to split text properly in different languages without spaces.
-  auto const lines = SplitText(m_textSizeRatio, textures->GetSpaceGlyph(), m_shapedGlyphs);
+  auto const lines = SplitText(forceNoWrap, m_textSizeRatio, textures->GetSpaceGlyph(), m_shapedGlyphs);
   m_rowsCount = lines.size();
 
   float summaryHeight = 0.;

--- a/drape_frontend/text_layout.cpp
+++ b/drape_frontend/text_layout.cpp
@@ -130,6 +130,7 @@ struct LineMetrics
 };
 
 // Scan longer shaped glyphs, and try to split them into two strings if a space glyph is present.
+// NOTE: Works only for LTR texts. Implementation should be mirrored for RTL.
 buffer_vector<LineMetrics, 2> SplitText(bool forceNoWrap, float textScale, dp::GlyphFontAndId space, dp::text::TextMetrics const & str)
 {
   // Add the whole line by default.
@@ -289,7 +290,8 @@ StraightTextLayout::StraightTextLayout(std::string const & text, float fontSize,
   m_shapedGlyphs = textures->ShapeSingleTextLine(dp::kBaseFontSizePixels, text, &m_glyphRegions);
 
   // TODO(AB): Use ICU's BreakIterator to split text properly in different languages without spaces.
-  auto const lines = SplitText(forceNoWrap, m_textSizeRatio, textures->GetSpaceGlyph(), m_shapedGlyphs);
+  // TODO(AB): Implement SplitText for RTL languages.
+  auto const lines = SplitText(forceNoWrap || m_shapedGlyphs.m_isRTL, m_textSizeRatio, textures->GetSpaceGlyph(), m_shapedGlyphs);
   m_rowsCount = lines.size();
 
   float summaryHeight = 0.;


### PR DESCRIPTION
Fixes https://github.com/organicmaps/organicmaps/issues/8771 by disabling text splitting, as it was before Harfbuzz integration.

A better fix is implementing a proper splitting for RTL texts by mirroring the current algo.