### PR TITLE
Move address_parser_tests to a subdirectory to fix building with SKIP_TESTS=ON

### DIFF
--- a/generator/address_parser/CMakeLists.txt
+++ b/generator/address_parser/CMakeLists.txt
@@ -20,8 +20,4 @@ target_link_libraries(address_parser_tool
   gflags::gflags
 )
 
-omim_add_test(address_parser_tests parser_tests.cpp)
-target_link_libraries(address_parser_tests
-  ${PROJECT_NAME}
-  generator_tests_support
-)
+omim_add_test_subdirectory(address_parser_tests)

--- a/generator/address_parser/address_parser_tests/CMakeLists.txt
+++ b/generator/address_parser/address_parser_tests/CMakeLists.txt
@@ -1,0 +1,6 @@
+project(address_parser_tests)
+omim_add_test(${PROJECT_NAME} parser_tests.cpp)
+target_link_libraries(${PROJECT_NAME}
+  address_parser
+  generator_tests_support
+)

--- a/generator/address_parser/address_parser_tests/parser_tests.cpp
+++ b/generator/address_parser/address_parser_tests/parser_tests.cpp
@@ -1,7 +1,7 @@
 #include "testing/testing.hpp"
 
-#include "processor.hpp"
-#include "tiger_parser.hpp"
+#include "../processor.hpp"
+#include "../tiger_parser.hpp"
 
 #include "generator/generator_tests_support/test_generator.hpp"
 


### PR DESCRIPTION
target_link_libraries was executed even if the project was not created