### PR TITLE
WIP: Highlight layers button when it is activated

### DIFF
--- a/android/app/src/main/java/app/organicmaps/maplayer/MapButtonsController.java
+++ b/android/app/src/main/java/app/organicmaps/maplayer/MapButtonsController.java
@@ -1,6 +1,8 @@
 package app.organicmaps.maplayer;
 
 import android.content.Context;
+import android.graphics.Color;
+import android.graphics.ColorFilter;
 import android.os.Bundle;
 import android.text.TextUtils;
 import android.util.TypedValue;
@@ -17,10 +19,15 @@ import androidx.fragment.app.Fragment;
 import androidx.fragment.app.FragmentActivity;
 import androidx.lifecycle.Observer;
 import androidx.lifecycle.ViewModelProvider;
+
+import app.organicmaps.Framework;
 import app.organicmaps.MwmActivity;
 import app.organicmaps.R;
 import app.organicmaps.downloader.MapManager;
 import app.organicmaps.downloader.UpdateInfo;
+import app.organicmaps.maplayer.isolines.IsolinesManager;
+import app.organicmaps.maplayer.subway.SubwayManager;
+import app.organicmaps.maplayer.traffic.TrafficManager;
 import app.organicmaps.routing.RoutingController;
 import app.organicmaps.util.Config;
 import app.organicmaps.util.ThemeUtils;
@@ -109,6 +116,8 @@ public class MapButtonsController extends Fragment
     if (mToggleMapLayerButton != null)
     {
       mToggleMapLayerButton.setOnClickListener(view -> mMapButtonClickListener.onMapButtonClick(MapButtons.toggleMapLayer));
+      if (TrafficManager.INSTANCE.isEnabled() || IsolinesManager.isEnabled() || SubwayManager.isEnabled() || Framework.nativeIsOutdoorsLayerEnabled())
+        mToggleMapLayerButton.setColorFilter(Color.BLUE);
       mToggleMapLayerButton.setVisibility(View.VISIBLE);
     }
     final View menuButton = mFrame.findViewById(R.id.menu_button);

--- a/android/app/src/main/java/app/organicmaps/maplayer/Mode.java
+++ b/android/app/src/main/java/app/organicmaps/maplayer/Mode.java
@@ -17,8 +17,7 @@ public enum Mode
         @Override
         public boolean isEnabled(@NonNull Context context)
         {
-          return !SubwayManager.from(context).isEnabled()
-                 && TrafficManager.INSTANCE.isEnabled();
+          return !SubwayManager.isEnabled() && TrafficManager.INSTANCE.isEnabled();
         }
 
         @Override
@@ -32,13 +31,13 @@ public enum Mode
         @Override
         public boolean isEnabled(@NonNull Context context)
         {
-          return SubwayManager.from(context).isEnabled();
+          return SubwayManager.isEnabled();
         }
 
         @Override
         public void setEnabled(@NonNull Context context, boolean isEnabled)
         {
-          SubwayManager.from(context).setEnabled(isEnabled);
+          SubwayManager.setEnabled(isEnabled);
         }
       },
 
@@ -47,13 +46,13 @@ public enum Mode
         @Override
         public boolean isEnabled(@NonNull Context context)
         {
-          return IsolinesManager.from(context).isEnabled();
+          return IsolinesManager.isEnabled();
         }
 
         @Override
         public void setEnabled(@NonNull Context context, boolean isEnabled)
         {
-          IsolinesManager.from(context).setEnabled(isEnabled);
+          IsolinesManager.setEnabled(isEnabled);
         }
       },
   OUTDOORS

--- a/android/app/src/main/java/app/organicmaps/maplayer/ToggleMapLayerFragment.java
+++ b/android/app/src/main/java/app/organicmaps/maplayer/ToggleMapLayerFragment.java
@@ -9,7 +9,6 @@ import android.view.ViewGroup;
 import androidx.annotation.NonNull;
 import androidx.annotation.Nullable;
 import androidx.fragment.app.Fragment;
-import androidx.lifecycle.ViewModelProvider;
 import androidx.recyclerview.widget.LinearLayoutManager;
 import androidx.recyclerview.widget.RecyclerView;
 import app.organicmaps.R;
@@ -28,7 +27,6 @@ public class ToggleMapLayerFragment extends Fragment
   private static final String LAYERS_MENU_ID = "LAYERS_MENU_BOTTOM_SHEET";
   @Nullable
   private LayersAdapter mAdapter;
-  private MapButtonsViewModel mMapButtonsViewModel;
 
   @Nullable
   @Override
@@ -36,7 +34,6 @@ public class ToggleMapLayerFragment extends Fragment
   {
     View mRoot = inflater.inflate(R.layout.fragment_toggle_map_layer, container, false);
 
-    mMapButtonsViewModel = new ViewModelProvider(requireActivity()).get(MapButtonsViewModel.class);
     MaterialButton mCloseButton = mRoot.findViewById(R.id.close_button);
     mCloseButton.setOnClickListener(view -> closeLayerBottomSheet());
 

--- a/android/app/src/main/java/app/organicmaps/maplayer/isolines/IsolinesManager.java
+++ b/android/app/src/main/java/app/organicmaps/maplayer/isolines/IsolinesManager.java
@@ -18,7 +18,7 @@ public class IsolinesManager
     mListener = new OnIsolinesChangedListener(application);
   }
 
-  public boolean isEnabled()
+  static public boolean isEnabled()
   {
     return Framework.nativeIsIsolinesLayerEnabled();
   }
@@ -28,7 +28,7 @@ public class IsolinesManager
     nativeAddListener(mListener);
   }
 
-  public void setEnabled(boolean isEnabled)
+  static public void setEnabled(boolean isEnabled)
   {
     if (isEnabled == isEnabled())
       return;

--- a/android/app/src/main/java/app/organicmaps/maplayer/subway/SubwayManager.java
+++ b/android/app/src/main/java/app/organicmaps/maplayer/subway/SubwayManager.java
@@ -17,7 +17,7 @@ public class SubwayManager
     mSchemeChangedListener = new OnTransitSchemeChangedListener.Default(application);
   }
 
-  public void setEnabled(boolean isEnabled)
+  static public void setEnabled(boolean isEnabled)
   {
     if (isEnabled == isEnabled())
       return;
@@ -26,7 +26,7 @@ public class SubwayManager
     Framework.nativeSaveSettingSchemeEnabled(isEnabled);
   }
 
-  public boolean isEnabled()
+  static public boolean isEnabled()
   {
     return Framework.nativeIsTransitSchemeEnabled();
   }


### PR DESCRIPTION
This is an attempt to workaround/hotfix the most frequently reported issue by Android users: they don't understand that Public Transport layer is activated https://github.com/organicmaps/organicmaps/issues/3508

The idea is to either change the color of the layers button if any of the layers is selected or change it to the crossed button, like on iOS. On iOS the behavior is also different: clicking the crossed icon disables/resets the active layer. Behavior can be kept the same or changed, this is not as important as to stop the user reports flooding.

We made a mistake by removing the selected layers in the main menu, in that case the currently active layer was visible to users in more cases.

Any help finishing the PR would be appreciated. 
CC @organicmaps/android @rtsisyk @arnaudvergnet @strump @Jean-BaptisteC 

![grafik](https://github.com/user-attachments/assets/3efe1dff-999f-426b-95f4-94c7b1327455)