### PR TITLE
[Android] OAuth2 flow with browser

### DIFF
--- a/android/app/src/main/cpp/app/organicmaps/Framework.cpp
+++ b/android/app/src/main/cpp/app/organicmaps/Framework.cpp
@@ -865,8 +865,8 @@ Java_app_organicmaps_Framework_nativeGetParsedAppName(JNIEnv * env, jclass)
 JNIEXPORT jstring JNICALL
 Java_app_organicmaps_Framework_nativeGetParsedOAuth2Code(JNIEnv * env, jclass)
 {
-    std::string const & code = frm()->GetParsedOAuth2Code();
-    return jni::ToJavaString(env, code);
+  std::string const & code = frm()->GetParsedOAuth2Code();
+  return jni::ToJavaString(env, code);
 }
 
 JNIEXPORT jstring JNICALL

--- a/android/app/src/main/cpp/app/organicmaps/Framework.cpp
+++ b/android/app/src/main/cpp/app/organicmaps/Framework.cpp
@@ -863,6 +863,13 @@ Java_app_organicmaps_Framework_nativeGetParsedAppName(JNIEnv * env, jclass)
 }
 
 JNIEXPORT jstring JNICALL
+Java_app_organicmaps_Framework_nativeGetParsedOAuth2Code(JNIEnv * env, jclass)
+{
+    std::string const & code = frm()->GetParsedOAuth2Code();
+    return jni::ToJavaString(env, code);
+}
+
+JNIEXPORT jstring JNICALL
 Java_app_organicmaps_Framework_nativeGetParsedBackUrl(JNIEnv * env, jclass)
 {
   std::string const & backUrl = frm()->GetParsedBackUrl();

--- a/android/app/src/main/cpp/app/organicmaps/editor/OsmOAuth.cpp
+++ b/android/app/src/main/cpp/app/organicmaps/editor/OsmOAuth.cpp
@@ -37,8 +37,8 @@ extern "C"
 JNIEXPORT jstring JNICALL
 Java_app_organicmaps_editor_OsmOAuth_nativeGetOAuth2Url(JNIEnv * env, jclass)
 {
-    auto const auth = OsmOAuth::ServerAuth();
-    return ToJavaString(env, auth.BuildOAuth2Url());
+  auto const auth = OsmOAuth::ServerAuth();
+  return ToJavaString(env, auth.BuildOAuth2Url());
 }
 
 JNIEXPORT jstring JNICALL

--- a/android/app/src/main/cpp/app/organicmaps/editor/OsmOAuth.cpp
+++ b/android/app/src/main/cpp/app/organicmaps/editor/OsmOAuth.cpp
@@ -34,6 +34,20 @@ bool LoadOsmUserPreferences(std::string const & oauthToken, UserPreferences & ou
 extern "C"
 {
 
+JNIEXPORT jobjectArray JNICALL
+Java_app_organicmaps_editor_OsmOAuth_nativeOAuthParams(JNIEnv * env, jclass clazz)
+{
+    OsmOAuth auth = OsmOAuth::ServerAuth();
+    jobjectArray oauthParams = env->NewObjectArray(5, env->FindClass("java/lang/String"), nullptr);
+    env->SetObjectArrayElement(oauthParams, 0, ToJavaString(env, auth.GetBaseUrl()));
+    env->SetObjectArrayElement(oauthParams, 1, ToJavaString(env, auth.GetClientId()));
+    env->SetObjectArrayElement(oauthParams, 2, ToJavaString(env, auth.GetClientSecret()));
+    env->SetObjectArrayElement(oauthParams, 3, ToJavaString(env, auth.GetScope()));
+    env->SetObjectArrayElement(oauthParams, 4, ToJavaString(env, auth.GetRedirectUri()));
+
+    return oauthParams;
+}
+
 JNIEXPORT jstring JNICALL
 Java_app_organicmaps_editor_OsmOAuth_nativeAuthWithPassword(JNIEnv * env, jclass clazz,
                                                                 jstring login, jstring password)

--- a/android/app/src/main/cpp/app/organicmaps/editor/OsmOAuth.cpp
+++ b/android/app/src/main/cpp/app/organicmaps/editor/OsmOAuth.cpp
@@ -67,6 +67,27 @@ Java_app_organicmaps_editor_OsmOAuth_nativeAuthWithPassword(JNIEnv * env, jclass
 }
 
 JNIEXPORT jstring JNICALL
+Java_app_organicmaps_editor_OsmOAuth_nativeAuthWithOAuth2Code(JNIEnv * env, jclass clazz, jstring oauth2code)
+{
+  OsmOAuth auth = OsmOAuth::ServerAuth();
+  try
+  {
+    auto token = auth.FinishAuthorization(ToNativeString(env, oauth2code));
+    if (!token.empty())
+    {
+        auth.SetAuthToken(token);
+        return ToJavaString(env, token);
+    }
+    LOG(LWARNING, ("nativeAuthWithOAuth2Code: invalid OAuth2 code"));
+  }
+  catch (std::exception const & ex)
+  {
+    LOG(LWARNING, ("nativeAuthWithOAuth2Code error ", ex.what()));
+  }
+  return nullptr;
+}
+
+JNIEXPORT jstring JNICALL
 Java_app_organicmaps_editor_OsmOAuth_nativeGetOsmUsername(JNIEnv * env, jclass, jstring oauthToken)
 {
   UserPreferences prefs;

--- a/android/app/src/main/cpp/app/organicmaps/editor/OsmOAuth.cpp
+++ b/android/app/src/main/cpp/app/organicmaps/editor/OsmOAuth.cpp
@@ -34,18 +34,11 @@ bool LoadOsmUserPreferences(std::string const & oauthToken, UserPreferences & ou
 extern "C"
 {
 
-JNIEXPORT jobjectArray JNICALL
-Java_app_organicmaps_editor_OsmOAuth_nativeOAuthParams(JNIEnv * env, jclass clazz)
+JNIEXPORT jstring JNICALL
+Java_app_organicmaps_editor_OsmOAuth_nativeGetOAuth2Url(JNIEnv * env, jclass)
 {
-    OsmOAuth auth = OsmOAuth::ServerAuth();
-    jobjectArray oauthParams = env->NewObjectArray(5, env->FindClass("java/lang/String"), nullptr);
-    env->SetObjectArrayElement(oauthParams, 0, ToJavaString(env, auth.GetBaseUrl()));
-    env->SetObjectArrayElement(oauthParams, 1, ToJavaString(env, auth.GetClientId()));
-    env->SetObjectArrayElement(oauthParams, 2, ToJavaString(env, auth.GetClientSecret()));
-    env->SetObjectArrayElement(oauthParams, 3, ToJavaString(env, auth.GetScope()));
-    env->SetObjectArrayElement(oauthParams, 4, ToJavaString(env, auth.GetRedirectUri()));
-
-    return oauthParams;
+    auto const auth = OsmOAuth::ServerAuth();
+    return ToJavaString(env, auth.BuildOAuth2Url());
 }
 
 JNIEXPORT jstring JNICALL
@@ -67,7 +60,7 @@ Java_app_organicmaps_editor_OsmOAuth_nativeAuthWithPassword(JNIEnv * env, jclass
 }
 
 JNIEXPORT jstring JNICALL
-Java_app_organicmaps_editor_OsmOAuth_nativeAuthWithOAuth2Code(JNIEnv * env, jclass clazz, jstring oauth2code)
+Java_app_organicmaps_editor_OsmOAuth_nativeAuthWithOAuth2Code(JNIEnv * env, jclass, jstring oauth2code)
 {
   OsmOAuth auth = OsmOAuth::ServerAuth();
   try
@@ -78,7 +71,7 @@ Java_app_organicmaps_editor_OsmOAuth_nativeAuthWithOAuth2Code(JNIEnv * env, jcla
         auth.SetAuthToken(token);
         return ToJavaString(env, token);
     }
-    LOG(LWARNING, ("nativeAuthWithOAuth2Code: invalid OAuth2 code"));
+    LOG(LWARNING, ("nativeAuthWithOAuth2Code: invalid OAuth2 code", oauth2code));
   }
   catch (std::exception const & ex)
   {

--- a/android/app/src/main/java/app/organicmaps/Framework.java
+++ b/android/app/src/main/java/app/organicmaps/Framework.java
@@ -239,6 +239,7 @@ public class Framework
   public static native ParsedRoutingData nativeGetParsedRoutingData();
   public static native ParsedSearchRequest nativeGetParsedSearchRequest();
   public static native @Nullable String nativeGetParsedAppName();
+  public static native @Nullable String nativeGetParsedOAuth2Code();
   @Nullable @Size(2)
   public static native double[] nativeGetParsedCenterLatLon();
   public static native @Nullable String nativeGetParsedBackUrl();

--- a/android/app/src/main/java/app/organicmaps/api/RequestType.java
+++ b/android/app/src/main/java/app/organicmaps/api/RequestType.java
@@ -6,7 +6,7 @@ import java.lang.annotation.Retention;
 import java.lang.annotation.RetentionPolicy;
 
 @Retention(RetentionPolicy.SOURCE)
-@IntDef({RequestType.INCORRECT, RequestType.MAP, RequestType.ROUTE, RequestType.SEARCH, RequestType.CROSSHAIR})
+@IntDef({RequestType.INCORRECT, RequestType.MAP, RequestType.ROUTE, RequestType.SEARCH, RequestType.CROSSHAIR, RequestType.OAUTH2})
 public @interface RequestType
 {
   // Represents url_scheme::ParsedMapApi::UrlType from c++ part.
@@ -15,4 +15,5 @@ public @interface RequestType
   public static final int ROUTE = 2;
   public static final int SEARCH = 3;
   public static final int CROSSHAIR = 4;
+  public static final int OAUTH2 = 5;
 }

--- a/android/app/src/main/java/app/organicmaps/editor/OsmLoginActivity.java
+++ b/android/app/src/main/java/app/organicmaps/editor/OsmLoginActivity.java
@@ -1,14 +1,31 @@
 package app.organicmaps.editor;
 
+import android.app.Activity;
+import android.content.Intent;
+import android.os.Bundle;
+
+import androidx.annotation.NonNull;
 import androidx.fragment.app.Fragment;
 
 import app.organicmaps.base.BaseMwmFragmentActivity;
 
 public class OsmLoginActivity extends BaseMwmFragmentActivity
 {
+  public static final String EXTRA_OAUTH2CODE = "oauth2code";
+
   @Override
   protected Class<? extends Fragment> getFragmentClass()
   {
     return OsmLoginFragment.class;
+  }
+
+  public static void OAuth2Callback(@NonNull Activity activity, String oauth2code)
+  {
+    final Intent i = new Intent(activity, OsmLoginActivity.class);
+    Bundle args = new Bundle();
+    args.putString(EXTRA_OAUTH2CODE, oauth2code);
+    args.putBoolean(ProfileActivity.EXTRA_REDIRECT_TO_PROFILE, true);
+    i.putExtras(args);
+    activity.startActivity(i);
   }
 }

--- a/android/app/src/main/java/app/organicmaps/editor/OsmLoginBottomFragment.java
+++ b/android/app/src/main/java/app/organicmaps/editor/OsmLoginBottomFragment.java
@@ -1,0 +1,104 @@
+package app.organicmaps.editor;
+
+import android.os.Bundle;
+import android.view.LayoutInflater;
+import android.view.View;
+import android.view.ViewGroup;
+import android.widget.Button;
+import android.widget.ProgressBar;
+
+import androidx.annotation.NonNull;
+import androidx.annotation.Nullable;
+
+import com.google.android.material.bottomsheet.BottomSheetDialogFragment;
+import com.google.android.material.textfield.TextInputEditText;
+
+import app.organicmaps.R;
+import app.organicmaps.util.Constants;
+import app.organicmaps.util.InputUtils;
+import app.organicmaps.util.UiUtils;
+import app.organicmaps.util.Utils;
+import app.organicmaps.util.concurrency.ThreadPool;
+import app.organicmaps.util.concurrency.UiThread;
+
+public class OsmLoginBottomFragment extends BottomSheetDialogFragment {
+    final private OsmLoginFragment parentFragment;
+    private TextInputEditText mLoginInput;
+    private TextInputEditText mPasswordInput;
+    private Button mLoginButton;
+    private Button mLostPasswordButton;
+    private Button mRegisterButton;
+    private ProgressBar mProgress;
+
+    public OsmLoginBottomFragment(OsmLoginFragment parentFragment) {
+        super();
+        this.parentFragment = parentFragment;
+    }
+
+    @Override
+    public void onCreate(@Nullable Bundle savedInstanceState) {
+        super.onCreate(savedInstanceState);
+    }
+
+    @Nullable
+    @Override
+    public View onCreateView(@NonNull LayoutInflater inflater, @Nullable ViewGroup container, @Nullable Bundle savedInstanceState) {
+        return inflater.inflate(R.layout.fragment_osm_login_bottom, container, false);
+    }
+
+    @Override
+    public void onViewCreated(@NonNull View view, @Nullable Bundle savedInstanceState) {
+        mLoginInput = view.findViewById(R.id.osm_username);
+        mPasswordInput = view.findViewById(R.id.osm_password);
+
+        mLoginButton = view.findViewById(R.id.login);
+        mLoginButton.setOnClickListener((v) -> doLogin());
+
+        mLostPasswordButton = view.findViewById(R.id.lost_password);
+        mLostPasswordButton.setOnClickListener((v) -> Utils.openUrl(requireActivity(), Constants.Url.OSM_RECOVER_PASSWORD));
+        mRegisterButton = view.findViewById(R.id.register);
+        mRegisterButton.setOnClickListener((v) -> Utils.openUrl(requireActivity(), Constants.Url.OSM_REGISTER));
+        mProgress = view.findViewById(R.id.osm_login_progress);
+    }
+
+    private void doLogin() {
+        InputUtils.hideKeyboard(mLoginInput);
+        final String username = mLoginInput.getText().toString().trim();
+        final String password = mPasswordInput.getText().toString();
+        enableInput(false);
+        UiUtils.show(mProgress);
+        mLoginButton.setText("");
+
+        ThreadPool.getWorker().execute(() -> {
+          final String oauthToken = OsmOAuth.nativeAuthWithPassword(username, password);
+          final String username1 = (oauthToken == null) ? null : OsmOAuth.nativeGetOsmUsername(oauthToken);
+          UiThread.run(() -> processAuth(oauthToken, username1));
+        });
+    }
+
+    private void processAuth(String oauthToken, String username)
+    {
+        if (!isAdded())
+            return;
+
+        enableInput(true);
+        UiUtils.hide(mProgress);
+        mLoginButton.setText(R.string.login_osm);
+
+        if (oauthToken == null)
+            parentFragment.onAuthFail();
+        else {
+            this.dismiss();
+            parentFragment.onAuthSuccess(oauthToken, username);
+        }
+    }
+
+    private void enableInput(boolean enable)
+    {
+        mPasswordInput.setEnabled(enable);
+        mLoginInput.setEnabled(enable);
+        mLoginButton.setEnabled(enable);
+        mLostPasswordButton.setEnabled(enable);
+        mRegisterButton.setEnabled(enable);
+    }
+}

--- a/android/app/src/main/java/app/organicmaps/editor/OsmLoginBottomFragment.java
+++ b/android/app/src/main/java/app/organicmaps/editor/OsmLoginBottomFragment.java
@@ -24,7 +24,8 @@ import app.organicmaps.util.Utils;
 import app.organicmaps.util.concurrency.ThreadPool;
 import app.organicmaps.util.concurrency.UiThread;
 
-public class OsmLoginBottomFragment extends BottomSheetDialogFragment {
+public class OsmLoginBottomFragment extends BottomSheetDialogFragment
+{
     final private OsmLoginFragment parentFragment;
     private TextInputEditText mLoginInput;
     private TextInputEditText mPasswordInput;

--- a/android/app/src/main/java/app/organicmaps/editor/OsmLoginBottomFragment.java
+++ b/android/app/src/main/java/app/organicmaps/editor/OsmLoginBottomFragment.java
@@ -1,5 +1,6 @@
 package app.organicmaps.editor;
 
+import android.app.Dialog;
 import android.os.Bundle;
 import android.view.LayoutInflater;
 import android.view.View;
@@ -10,6 +11,8 @@ import android.widget.ProgressBar;
 import androidx.annotation.NonNull;
 import androidx.annotation.Nullable;
 
+import com.google.android.material.bottomsheet.BottomSheetBehavior;
+import com.google.android.material.bottomsheet.BottomSheetDialog;
 import com.google.android.material.bottomsheet.BottomSheetDialogFragment;
 import com.google.android.material.textfield.TextInputEditText;
 
@@ -44,6 +47,14 @@ public class OsmLoginBottomFragment extends BottomSheetDialogFragment {
     @Override
     public View onCreateView(@NonNull LayoutInflater inflater, @Nullable ViewGroup container, @Nullable Bundle savedInstanceState) {
         return inflater.inflate(R.layout.fragment_osm_login_bottom, container, false);
+    }
+
+    @NonNull
+    @Override
+    public Dialog onCreateDialog(Bundle savedInstanceState) {
+        BottomSheetDialog dialog = (BottomSheetDialog) super.onCreateDialog(savedInstanceState);
+        dialog.getBehavior().setState(BottomSheetBehavior.STATE_EXPANDED);
+        return dialog;
     }
 
     @Override

--- a/android/app/src/main/java/app/organicmaps/editor/OsmLoginBottomFragment.java
+++ b/android/app/src/main/java/app/organicmaps/editor/OsmLoginBottomFragment.java
@@ -26,91 +26,99 @@ import app.organicmaps.util.concurrency.UiThread;
 
 public class OsmLoginBottomFragment extends BottomSheetDialogFragment
 {
-    final private OsmLoginFragment parentFragment;
-    private TextInputEditText mLoginInput;
-    private TextInputEditText mPasswordInput;
-    private Button mLoginButton;
-    private Button mLostPasswordButton;
-    private Button mRegisterButton;
-    private ProgressBar mProgress;
+  final private OsmLoginFragment parentFragment;
+  private TextInputEditText mLoginInput;
+  private TextInputEditText mPasswordInput;
+  private Button mLoginButton;
+  private Button mLostPasswordButton;
+  private Button mRegisterButton;
+  private ProgressBar mProgress;
 
-    public OsmLoginBottomFragment(OsmLoginFragment parentFragment) {
-        super();
-        this.parentFragment = parentFragment;
-    }
+  public OsmLoginBottomFragment(OsmLoginFragment parentFragment)
+  {
+    super();
+    this.parentFragment = parentFragment;
+  }
 
-    @Override
-    public void onCreate(@Nullable Bundle savedInstanceState) {
-        super.onCreate(savedInstanceState);
-    }
+  @Override
+  public void onCreate(@Nullable Bundle savedInstanceState)
+  {
+    super.onCreate(savedInstanceState);
+  }
 
-    @Nullable
-    @Override
-    public View onCreateView(@NonNull LayoutInflater inflater, @Nullable ViewGroup container, @Nullable Bundle savedInstanceState) {
-        return inflater.inflate(R.layout.fragment_osm_login_bottom, container, false);
-    }
+  @Nullable
+  @Override
+  public View onCreateView(@NonNull LayoutInflater inflater, @Nullable ViewGroup container, @Nullable Bundle savedInstanceState)
+  {
+    return inflater.inflate(R.layout.fragment_osm_login_bottom, container, false);
+  }
 
-    @NonNull
-    @Override
-    public Dialog onCreateDialog(Bundle savedInstanceState) {
-        BottomSheetDialog dialog = (BottomSheetDialog) super.onCreateDialog(savedInstanceState);
-        dialog.getBehavior().setState(BottomSheetBehavior.STATE_EXPANDED);
-        return dialog;
-    }
+  @NonNull
+  @Override
+  public Dialog onCreateDialog(Bundle savedInstanceState)
+  {
+    BottomSheetDialog dialog = (BottomSheetDialog) super.onCreateDialog(savedInstanceState);
+    dialog.getBehavior().setState(BottomSheetBehavior.STATE_EXPANDED);
+    return dialog;
+  }
 
-    @Override
-    public void onViewCreated(@NonNull View view, @Nullable Bundle savedInstanceState) {
-        mLoginInput = view.findViewById(R.id.osm_username);
-        mPasswordInput = view.findViewById(R.id.osm_password);
+  @Override
+  public void onViewCreated(@NonNull View view, @Nullable Bundle savedInstanceState)
+  {
+    mLoginInput = view.findViewById(R.id.osm_username);
+    mPasswordInput = view.findViewById(R.id.osm_password);
 
-        mLoginButton = view.findViewById(R.id.login);
-        mLoginButton.setOnClickListener((v) -> doLogin());
+    mLoginButton = view.findViewById(R.id.login);
+    mLoginButton.setOnClickListener((v) -> doLogin());
 
-        mLostPasswordButton = view.findViewById(R.id.lost_password);
-        mLostPasswordButton.setOnClickListener((v) -> Utils.openUrl(requireActivity(), Constants.Url.OSM_RECOVER_PASSWORD));
-        mRegisterButton = view.findViewById(R.id.register);
-        mRegisterButton.setOnClickListener((v) -> Utils.openUrl(requireActivity(), Constants.Url.OSM_REGISTER));
-        mProgress = view.findViewById(R.id.osm_login_progress);
-    }
+    mLostPasswordButton = view.findViewById(R.id.lost_password);
+    mLostPasswordButton.setOnClickListener((v) -> Utils.openUrl(requireActivity(), Constants.Url.OSM_RECOVER_PASSWORD));
+    mRegisterButton = view.findViewById(R.id.register);
+    mRegisterButton.setOnClickListener((v) -> Utils.openUrl(requireActivity(), Constants.Url.OSM_REGISTER));
+    mProgress = view.findViewById(R.id.osm_login_progress);
+  }
 
-    private void doLogin() {
-        InputUtils.hideKeyboard(mLoginInput);
-        final String username = mLoginInput.getText().toString().trim();
-        final String password = mPasswordInput.getText().toString();
-        enableInput(false);
-        UiUtils.show(mProgress);
-        mLoginButton.setText("");
+  private void doLogin()
+  {
+    InputUtils.hideKeyboard(mLoginInput);
+    final String username = mLoginInput.getText().toString().trim();
+    final String password = mPasswordInput.getText().toString();
+    enableInput(false);
+    UiUtils.show(mProgress);
+    mLoginButton.setText("");
 
-        ThreadPool.getWorker().execute(() -> {
-          final String oauthToken = OsmOAuth.nativeAuthWithPassword(username, password);
-          final String username1 = (oauthToken == null) ? null : OsmOAuth.nativeGetOsmUsername(oauthToken);
-          UiThread.run(() -> processAuth(oauthToken, username1));
-        });
-    }
-
-    private void processAuth(String oauthToken, String username)
+    ThreadPool.getWorker().execute(() ->
     {
-        if (!isAdded())
-            return;
+      final String oauthToken = OsmOAuth.nativeAuthWithPassword(username, password);
+      final String username1 = (oauthToken == null) ? null : OsmOAuth.nativeGetOsmUsername(oauthToken);
+      UiThread.run(() -> processAuth(oauthToken, username1));
+    });
+  }
 
-        enableInput(true);
-        UiUtils.hide(mProgress);
-        mLoginButton.setText(R.string.login_osm);
+  private void processAuth(String oauthToken, String username)
+  {
+    if (!isAdded())
+      return;
 
-        if (oauthToken == null)
-            parentFragment.onAuthFail();
-        else {
-            this.dismiss();
-            parentFragment.onAuthSuccess(oauthToken, username);
-        }
-    }
+    enableInput(true);
+    UiUtils.hide(mProgress);
+    mLoginButton.setText(R.string.login_osm);
 
-    private void enableInput(boolean enable)
+    if (oauthToken == null)
+      parentFragment.onAuthFail();
+    else
     {
-        mPasswordInput.setEnabled(enable);
-        mLoginInput.setEnabled(enable);
-        mLoginButton.setEnabled(enable);
-        mLostPasswordButton.setEnabled(enable);
-        mRegisterButton.setEnabled(enable);
+      this.dismiss();
+      parentFragment.onAuthSuccess(oauthToken, username);
     }
+  }
+
+  private void enableInput(boolean enable)
+  {
+    mPasswordInput.setEnabled(enable);
+    mLoginInput.setEnabled(enable);
+    mLoginButton.setEnabled(enable);
+    mLostPasswordButton.setEnabled(enable);
+    mRegisterButton.setEnabled(enable);
+  }
 }

--- a/android/app/src/main/java/app/organicmaps/editor/OsmLoginFragment.java
+++ b/android/app/src/main/java/app/organicmaps/editor/OsmLoginFragment.java
@@ -19,6 +19,7 @@ import app.organicmaps.Framework;
 import app.organicmaps.R;
 import app.organicmaps.base.BaseMwmToolbarFragment;
 import app.organicmaps.util.DateUtils;
+import app.organicmaps.util.Utils;
 import app.organicmaps.util.concurrency.ThreadPool;
 import app.organicmaps.util.concurrency.UiThread;
 
@@ -72,17 +73,7 @@ public class OsmLoginFragment extends BaseMwmToolbarFragment
 
   private void loginWithBrowser()
   {
-    try
-    {
-      Intent myIntent = new Intent(Intent.ACTION_VIEW, Uri.parse(OsmOAuth.nativeGetOAuth2Url()));
-      startActivity(myIntent);
-    }
-    catch (ActivityNotFoundException e)
-    {
-      //Toast.makeText(this, "No application can handle this request."
-      //        + " Please install a webbrowser",  Toast.LENGTH_LONG).show();
-      e.printStackTrace();
-    }
+    Utils.openUri(requireContext(), Uri.parse(OsmOAuth.nativeGetOAuth2Url()));
   }
 
   // This method is called by MwmActivity & UrlProcessor when "om://oauth2/osm/callback?code=XXX" is handled

--- a/android/app/src/main/java/app/organicmaps/editor/OsmLoginFragment.java
+++ b/android/app/src/main/java/app/organicmaps/editor/OsmLoginFragment.java
@@ -1,6 +1,8 @@
 package app.organicmaps.editor;
 
+import android.content.ActivityNotFoundException;
 import android.content.Intent;
+import android.net.Uri;
 import android.os.Bundle;
 import android.view.LayoutInflater;
 import android.view.View;
@@ -29,6 +31,7 @@ public class OsmLoginFragment extends BaseMwmToolbarFragment
 {
   private ProgressBar mProgress;
   private Button mLoginButton;
+  private Button mLoginWebsiteButton;
   private Button mLostPasswordButton;
   private TextInputEditText mLoginInput;
   private TextInputEditText mPasswordInput;
@@ -47,6 +50,8 @@ public class OsmLoginFragment extends BaseMwmToolbarFragment
     getToolbarController().setTitle(R.string.login);
     mLoginInput = view.findViewById(R.id.osm_username);
     mPasswordInput = view.findViewById(R.id.osm_password);
+    mLoginWebsiteButton = view.findViewById(R.id.login_website);
+    mLoginWebsiteButton.setOnClickListener((v) -> loginWithBrowser());
     mLoginButton = view.findViewById(R.id.login);
     mLoginButton.setOnClickListener((v) -> login());
     mLostPasswordButton = view.findViewById(R.id.lost_password);
@@ -73,6 +78,28 @@ public class OsmLoginFragment extends BaseMwmToolbarFragment
       final String username1 = (oauthToken == null) ? null : OsmOAuth.nativeGetOsmUsername(oauthToken);
       UiThread.run(() -> processAuth(oauthToken, username1));
     });
+  }
+
+  private void loginWithBrowser()
+  {
+    mLoginWebsiteButton.setEnabled(false);
+
+    String[] oauthParams = OsmOAuth.nativeOAuthParams();
+    Uri oauth2url = Uri.parse(oauthParams[0] + "/oauth2/authorize")
+            .buildUpon()
+            .appendQueryParameter("client_id", oauthParams[1])
+            .appendQueryParameter("scope", oauthParams[3])
+            .appendQueryParameter("redirect_uri", oauthParams[4])
+            .appendQueryParameter("response_type", "code")
+            .build();
+    try {
+      Intent myIntent = new Intent(Intent.ACTION_VIEW, oauth2url);
+      startActivity(myIntent);
+    } catch (ActivityNotFoundException e) {
+      //Toast.makeText(this, "No application can handle this request."
+      //        + " Please install a webbrowser",  Toast.LENGTH_LONG).show();
+      e.printStackTrace();
+    }
   }
 
   private void enableInput(boolean enable)

--- a/android/app/src/main/java/app/organicmaps/editor/OsmLoginFragment.java
+++ b/android/app/src/main/java/app/organicmaps/editor/OsmLoginFragment.java
@@ -8,33 +8,27 @@ import android.view.LayoutInflater;
 import android.view.View;
 import android.view.ViewGroup;
 import android.widget.Button;
-import android.widget.ProgressBar;
+import android.widget.FrameLayout;
 import android.widget.TextView;
 
 import androidx.annotation.NonNull;
 import androidx.annotation.Nullable;
 
+import com.google.android.material.dialog.MaterialAlertDialogBuilder;
+
 import app.organicmaps.Framework;
 import app.organicmaps.R;
 import app.organicmaps.base.BaseMwmToolbarFragment;
-import app.organicmaps.util.Constants;
 import app.organicmaps.util.DateUtils;
-import app.organicmaps.util.InputUtils;
-import app.organicmaps.util.UiUtils;
-import app.organicmaps.util.Utils;
 import app.organicmaps.util.concurrency.ThreadPool;
 import app.organicmaps.util.concurrency.UiThread;
-import com.google.android.material.dialog.MaterialAlertDialogBuilder;
-import com.google.android.material.textfield.TextInputEditText;
 
 public class OsmLoginFragment extends BaseMwmToolbarFragment
 {
-  private ProgressBar mProgress;
-  private Button mLoginButton;
+  private FrameLayout loginBottomSheet;
+  //private BottomSheetBehavior<FrameLayout> standardBottomSheetBehavior;
+  private Button mLoginUsernameButton;
   private Button mLoginWebsiteButton;
-  private Button mLostPasswordButton;
-  private TextInputEditText mLoginInput;
-  private TextInputEditText mPasswordInput;
 
   private String mArgOAuth2Code;
 
@@ -50,17 +44,11 @@ public class OsmLoginFragment extends BaseMwmToolbarFragment
   {
     super.onViewCreated(view, savedInstanceState);
     getToolbarController().setTitle(R.string.login);
-    mLoginInput = view.findViewById(R.id.osm_username);
-    mPasswordInput = view.findViewById(R.id.osm_password);
+
     mLoginWebsiteButton = view.findViewById(R.id.login_website);
     mLoginWebsiteButton.setOnClickListener((v) -> loginWithBrowser());
-    mLoginButton = view.findViewById(R.id.login);
-    mLoginButton.setOnClickListener((v) -> login());
-    mLostPasswordButton = view.findViewById(R.id.lost_password);
-    mLostPasswordButton.setOnClickListener((v) -> Utils.openUrl(requireActivity(), Constants.Url.OSM_RECOVER_PASSWORD));
-    Button registerButton = view.findViewById(R.id.register);
-    registerButton.setOnClickListener((v) -> Utils.openUrl(requireActivity(), Constants.Url.OSM_REGISTER));
-    mProgress = view.findViewById(R.id.osm_login_progress);
+    mLoginUsernameButton = view.findViewById(R.id.login_username);
+    mLoginUsernameButton.setOnClickListener((v) -> loginUsername());
     final String dataVersion = DateUtils.getShortDateFormatter().format(Framework.getDataVersion());
     ((TextView) view.findViewById(R.id.osm_presentation))
         .setText(getString(R.string.osm_presentation, dataVersion));
@@ -79,26 +67,14 @@ public class OsmLoginFragment extends BaseMwmToolbarFragment
     mArgOAuth2Code = arguments.getString(OsmLoginActivity.EXTRA_OAUTH2CODE);
   }
 
-  private void login()
+  private void loginUsername()
   {
-    InputUtils.hideKeyboard(mLoginInput);
-    final String username = mLoginInput.getText().toString().trim();
-    final String password = mPasswordInput.getText().toString();
-    enableInput(false);
-    UiUtils.show(mProgress);
-    mLoginButton.setText("");
-
-    ThreadPool.getWorker().execute(() -> {
-      final String oauthToken = OsmOAuth.nativeAuthWithPassword(username, password);
-      final String username1 = (oauthToken == null) ? null : OsmOAuth.nativeGetOsmUsername(oauthToken);
-      UiThread.run(() -> processAuth(oauthToken, username1));
-    });
+    OsmLoginBottomFragment bottomSheetFragment = new OsmLoginBottomFragment(this);
+    bottomSheetFragment.show(requireActivity().getSupportFragmentManager(), bottomSheetFragment.getTag());
   }
 
   private void loginWithBrowser()
   {
-    enableInput(false);
-
     String[] oauthParams = OsmOAuth.nativeOAuthParams();
     Uri oauth2url = Uri.parse(oauthParams[0] + "/oauth2/authorize")
             .buildUpon()
@@ -117,66 +93,49 @@ public class OsmLoginFragment extends BaseMwmToolbarFragment
     }
   }
 
-  private void enableInput(boolean enable)
-  {
-    mPasswordInput.setEnabled(enable);
-    mLoginInput.setEnabled(enable);
-    mLoginButton.setEnabled(enable);
-    mLostPasswordButton.setEnabled(enable);
-    mLoginWebsiteButton.setEnabled(enable);
-  }
-
   // This method is called by MwmActivity & UrlProcessor when "om://oauth2/osm/callback?code=XXX" is handled
   private void continueOAuth2Flow(String oauth2code)
   {
     if (!isAdded())
       return;
 
-    if (oauth2code == null || oauth2code.length()==0)
+    if (oauth2code == null || oauth2code.isEmpty())
     {
-      enableInput(true);
       onAuthFail();
     }
     else
     {
-      // Do not enable UI until we finish interaction with OAuth2 API
-      enableInput(false);
-
       ThreadPool.getWorker().execute(() -> {
         // Finish OAuth2 auth flow and get username for UI.
         final String oauthToken = OsmOAuth.nativeAuthWithOAuth2Code(oauth2code);
         final String username = (oauthToken == null) ? null : OsmOAuth.nativeGetOsmUsername(oauthToken);
         UiThread.run(() -> {
-          enableInput(true);
           processAuth(oauthToken, username);
         });
       });
     }
   }
 
-  private void processAuth(String oauthToken, String username)
+  public void processAuth(String oauthToken, String username)
   {
     if (!isAdded())
       return;
 
-    enableInput(true);
-    UiUtils.hide(mProgress);
-    mLoginButton.setText(R.string.login_osm);
     if (oauthToken == null)
       onAuthFail();
     else
       onAuthSuccess(oauthToken, username);
   }
 
-  private void onAuthFail()
+  public void onAuthFail()
   {
     new MaterialAlertDialogBuilder(requireActivity(), R.style.MwmTheme_AlertDialog)
-        .setTitle(R.string.editor_login_error_dialog)
-        .setPositiveButton(R.string.ok, null)
-        .show();
+            .setTitle(R.string.editor_login_error_dialog)
+            .setPositiveButton(R.string.ok, null)
+            .show();
   }
 
-  private void onAuthSuccess(String oauthToken, String username)
+  public void onAuthSuccess(String oauthToken, String username)
   {
     OsmOAuth.setAuthorization(requireContext(), oauthToken, username);
     final Bundle extras = requireActivity().getIntent().getExtras();

--- a/android/app/src/main/java/app/organicmaps/editor/OsmLoginFragment.java
+++ b/android/app/src/main/java/app/organicmaps/editor/OsmLoginFragment.java
@@ -8,7 +8,6 @@ import android.view.LayoutInflater;
 import android.view.View;
 import android.view.ViewGroup;
 import android.widget.Button;
-import android.widget.FrameLayout;
 import android.widget.TextView;
 
 import androidx.annotation.NonNull;
@@ -25,8 +24,6 @@ import app.organicmaps.util.concurrency.UiThread;
 
 public class OsmLoginFragment extends BaseMwmToolbarFragment
 {
-  private FrameLayout loginBottomSheet;
-  //private BottomSheetBehavior<FrameLayout> standardBottomSheetBehavior;
   private Button mLoginUsernameButton;
   private Button mLoginWebsiteButton;
 
@@ -75,18 +72,13 @@ public class OsmLoginFragment extends BaseMwmToolbarFragment
 
   private void loginWithBrowser()
   {
-    String[] oauthParams = OsmOAuth.nativeOAuthParams();
-    Uri oauth2url = Uri.parse(oauthParams[0] + "/oauth2/authorize")
-            .buildUpon()
-            .appendQueryParameter("client_id", oauthParams[1])
-            .appendQueryParameter("scope", oauthParams[3])
-            .appendQueryParameter("redirect_uri", oauthParams[4])
-            .appendQueryParameter("response_type", "code")
-            .build();
-    try {
-      Intent myIntent = new Intent(Intent.ACTION_VIEW, oauth2url);
+    try
+    {
+      Intent myIntent = new Intent(Intent.ACTION_VIEW, Uri.parse(OsmOAuth.nativeGetOAuth2Url()));
       startActivity(myIntent);
-    } catch (ActivityNotFoundException e) {
+    }
+    catch (ActivityNotFoundException e)
+    {
       //Toast.makeText(this, "No application can handle this request."
       //        + " Please install a webbrowser",  Toast.LENGTH_LONG).show();
       e.printStackTrace();
@@ -100,9 +92,7 @@ public class OsmLoginFragment extends BaseMwmToolbarFragment
       return;
 
     if (oauth2code == null || oauth2code.isEmpty())
-    {
       onAuthFail();
-    }
     else
     {
       ThreadPool.getWorker().execute(() -> {

--- a/android/app/src/main/java/app/organicmaps/editor/OsmOAuth.java
+++ b/android/app/src/main/java/app/organicmaps/editor/OsmOAuth.java
@@ -104,7 +104,7 @@ public final class OsmOAuth
    Returns 5 strings: ServerURL, ClientId, ClientSecret, Scope, RedirectUri
    */
   @NonNull
-  public static native String[] nativeOAuthParams();
+  public static native String nativeGetOAuth2Url();
 
   /**
    * @return string with OAuth2 token

--- a/android/app/src/main/java/app/organicmaps/editor/OsmOAuth.java
+++ b/android/app/src/main/java/app/organicmaps/editor/OsmOAuth.java
@@ -10,6 +10,8 @@ import androidx.annotation.Size;
 import androidx.annotation.WorkerThread;
 import androidx.fragment.app.FragmentManager;
 
+import java.util.Map;
+
 import app.organicmaps.MwmApplication;
 import app.organicmaps.util.NetworkPolicy;
 
@@ -97,6 +99,12 @@ public final class OsmOAuth
   {
     return nativeGetHistoryUrl(getUsername(context));
   }
+
+  /*
+   Returns 5 strings: ServerURL, ClientId, ClientSecret, Scope, RedirectUri
+   */
+  @NonNull
+  public static native String[] nativeOAuthParams();
 
   /**
    * @return string with OAuth2 token

--- a/android/app/src/main/java/app/organicmaps/editor/OsmOAuth.java
+++ b/android/app/src/main/java/app/organicmaps/editor/OsmOAuth.java
@@ -114,6 +114,13 @@ public final class OsmOAuth
   @Nullable
   public static native String nativeAuthWithPassword(String login, String password);
 
+  /**
+   * @return string with OAuth2 token
+   */
+  @WorkerThread
+  @Nullable
+  public static native String nativeAuthWithOAuth2Code(String oauth2code);
+
   @WorkerThread
   @Nullable
   public static native String nativeGetOsmUsername(String oauthToken);

--- a/android/app/src/main/java/app/organicmaps/editor/ProfileActivity.java
+++ b/android/app/src/main/java/app/organicmaps/editor/ProfileActivity.java
@@ -6,6 +6,8 @@ import app.organicmaps.base.BaseMwmFragmentActivity;
 
 public class ProfileActivity extends BaseMwmFragmentActivity
 {
+  public static final String EXTRA_REDIRECT_TO_PROFILE = "redirectToProfile";
+
   @Override
   protected Class<? extends Fragment> getFragmentClass()
   {

--- a/android/app/src/main/java/app/organicmaps/editor/ProfileFragment.java
+++ b/android/app/src/main/java/app/organicmaps/editor/ProfileFragment.java
@@ -93,7 +93,7 @@ public class ProfileFragment extends BaseMwmToolbarFragment
     else
     {
       Intent intent = new Intent(requireContext(), OsmLoginActivity.class);
-      intent.putExtra("redirectToProfile", true);
+      intent.putExtra(ProfileActivity.EXTRA_REDIRECT_TO_PROFILE, true);
       startActivity(intent);
       requireActivity().finish();
     }

--- a/android/app/src/main/java/app/organicmaps/intent/Factory.java
+++ b/android/app/src/main/java/app/organicmaps/intent/Factory.java
@@ -3,6 +3,7 @@ package app.organicmaps.intent;
 import android.content.ContentResolver;
 import android.content.Intent;
 import android.net.Uri;
+import android.util.Log;
 
 import androidx.annotation.NonNull;
 import androidx.core.content.IntentCompat;
@@ -127,6 +128,15 @@ public class Factory
             Framework.nativeStopLocationFollow();
             Framework.nativeSetViewportCenter(latlon[0], latlon[1], SEARCH_IN_VIEWPORT_ZOOM);
           }
+
+          return true;
+        }
+        case RequestType.OAUTH2:
+        {
+          SearchEngine.INSTANCE.cancelInteractiveSearch();
+
+          final String oauth2code = Framework.nativeGetParsedOAuth2Code();
+          Log.i("TAG", oauth2code);
 
           return true;
         }

--- a/android/app/src/main/java/app/organicmaps/intent/Factory.java
+++ b/android/app/src/main/java/app/organicmaps/intent/Factory.java
@@ -19,6 +19,7 @@ import app.organicmaps.api.RoutePoint;
 import app.organicmaps.bookmarks.data.BookmarkManager;
 import app.organicmaps.bookmarks.data.FeatureId;
 import app.organicmaps.bookmarks.data.MapObject;
+import app.organicmaps.editor.OsmLoginActivity;
 import app.organicmaps.routing.RoutingController;
 import app.organicmaps.search.SearchActivity;
 import app.organicmaps.search.SearchEngine;
@@ -136,7 +137,7 @@ public class Factory
           SearchEngine.INSTANCE.cancelInteractiveSearch();
 
           final String oauth2code = Framework.nativeGetParsedOAuth2Code();
-          Log.i("TAG", oauth2code);
+          OsmLoginActivity.OAuth2Callback(target, oauth2code);
 
           return true;
         }

--- a/android/app/src/main/res/layout-land/fragment_osm_login.xml
+++ b/android/app/src/main/res/layout-land/fragment_osm_login.xml
@@ -63,119 +63,32 @@
       <androidx.constraintlayout.widget.ConstraintLayout
         android:layout_width="match_parent"
         android:layout_height="wrap_content"
-        android:layout_marginTop="@dimen/margin_half">
-        <com.google.android.material.textfield.TextInputLayout
-          android:id="@+id/osm_username_container"
-          style="@style/MwmWidget.Editor.CustomTextInput"
-          android:layout_width="0dp"
-          android:layout_marginEnd="@dimen/margin_half"
-          android:textColorHint="?android:textColorSecondary"
-          app:layout_constraintStart_toStartOf="parent"
-          app:layout_constraintEnd_toStartOf="@id/osm_password_container"
-          app:layout_constraintTop_toTopOf="parent"
-          app:endIconMode="custom">
-          <com.google.android.material.textfield.TextInputEditText
-            android:id="@+id/osm_username"
-            style="@style/MwmWidget.Editor.FieldLayout.EditText"
-            android:autofillHints="emailAddress"
-            android:hint="@string/email_or_username" />
-        </com.google.android.material.textfield.TextInputLayout>
-        <com.google.android.material.textfield.TextInputLayout
-          android:id="@+id/osm_password_container"
-          style="@style/MwmWidget.Editor.CustomTextInput"
-          android:layout_width="0dp"
-          android:textColorHint="?android:textColorSecondary"
-          app:layout_constraintStart_toEndOf="@id/osm_username_container"
-          app:layout_constraintEnd_toEndOf="parent"
-          app:layout_constraintTop_toTopOf="parent"
-          app:endIconMode="password_toggle"
-          app:endIconTint="?android:textColorSecondary">
-          <com.google.android.material.textfield.TextInputEditText
-            android:id="@+id/osm_password"
-            style="@style/MwmWidget.Editor.FieldLayout.EditText"
-            android:autofillHints="password"
-            android:hint="@string/password"
-            android:inputType="textPassword" />
-        </com.google.android.material.textfield.TextInputLayout>
-      </androidx.constraintlayout.widget.ConstraintLayout>
-      <androidx.constraintlayout.widget.ConstraintLayout
-        android:layout_width="match_parent"
-        android:layout_height="wrap_content"
-        android:layout_marginBottom="@dimen/margin_base">
-        <FrameLayout
-          android:id="@+id/login_container"
-          android:layout_width="0dp"
-          android:layout_height="wrap_content"
-          app:layout_constraintBottom_toBottomOf="parent"
-          app:layout_constraintEnd_toEndOf="parent"
-          app:layout_constraintStart_toEndOf="@id/lost_password"
-          app:layout_constraintTop_toTopOf="parent">
-          <Button
-            android:id="@+id/login"
-            style="@style/MwmWidget.Button.Accent"
-            android:layout_width="match_parent"
-            android:layout_height="wrap_content"
-            android:text="@string/login_osm"
-            android:textAppearance="@style/MwmTextAppearance.Body2.Light" />
-          <ProgressBar
-            android:id="@+id/osm_login_progress"
-            android:layout_width="@dimen/editor_auth_btn_height"
-            android:layout_height="@dimen/editor_auth_btn_height"
-            android:layout_gravity="center"
-            android:elevation="@dimen/design_fab_elevation"
-            android:visibility="gone" />
-        </FrameLayout>
-        <Button
-          android:id="@+id/lost_password"
-          style="@style/MwmWidget.Button"
-          android:layout_width="0dp"
-          android:layout_height="wrap_content"
-          android:background="?clickableBackground"
-          android:gravity="start|center_vertical"
-          android:padding="@dimen/margin_half"
-          android:text="@string/forgot_password"
-          android:textAppearance="@style/MwmTextAppearance.Body3"
-          app:layout_constraintBottom_toBottomOf="parent"
-          app:layout_constraintEnd_toStartOf="@id/login_container"
-          app:layout_constraintStart_toStartOf="parent"
-          app:layout_constraintTop_toTopOf="parent" />
-      </androidx.constraintlayout.widget.ConstraintLayout>
-      <com.google.android.material.divider.MaterialDivider
-        android:layout_width="wrap_content"
-        android:layout_height="wrap_content"
         android:layout_marginTop="@dimen/margin_base"
-        android:layout_marginBottom="@dimen/margin_base" />
-      <androidx.constraintlayout.widget.ConstraintLayout
-        android:layout_width="match_parent"
-        android:layout_height="wrap_content">
-        <TextView
-          android:id="@+id/register_text"
-          android:layout_width="0dp"
-          android:layout_height="wrap_content"
-          android:fontFamily="@string/robotoRegular"
-          android:gravity="start|center_vertical"
-          android:text="@string/no_osm_account"
-          android:textAppearance="@style/MwmTextAppearance.Body2"
-          android:textColor="?android:textColorPrimary"
-          app:layout_constraintBottom_toBottomOf="parent"
-          app:layout_constraintEnd_toStartOf="@id/register"
-          app:layout_constraintStart_toStartOf="parent"
-          app:layout_constraintTop_toTopOf="parent" />
+        android:layout_marginBottom="@dimen/margin_base">
         <Button
-          android:id="@+id/register"
+          android:id="@+id/login_website"
           style="@style/MwmWidget.Button.Accent"
           android:layout_width="0dp"
           android:layout_height="wrap_content"
-          android:background="@drawable/button_editor_light"
-          android:fontFamily="@string/robotoMedium"
-          android:padding="@dimen/margin_quarter"
-          android:text="@string/register_at_openstreetmap"
-          android:textAppearance="@style/MwmTextAppearance.Body2"
-          android:textColor="@color/text_dark"
+          android:padding="@dimen/margin_half"
+            android:layout_marginEnd="@dimen/margin_base"
+          android:text="Login with OSM website"
+          android:textAppearance="@style/MwmTextAppearance.Body2.Light"
           app:layout_constraintBottom_toBottomOf="parent"
-          app:layout_constraintEnd_toEndOf="parent"
-          app:layout_constraintStart_toEndOf="@id/register_text"
+          app:layout_constraintEnd_toStartOf="@id/login_username"
+          app:layout_constraintStart_toStartOf="parent"
           app:layout_constraintTop_toTopOf="parent" />
+        <Button
+          android:id="@+id/login_username"
+          style="@style/MwmWidget.Button.Accent"
+          android:layout_width="0dp"
+          android:layout_height="wrap_content"
+          android:text="Login with username"
+          android:textAppearance="@style/MwmTextAppearance.Body2.Light"
+          app:layout_constraintStart_toEndOf="@id/login_website"
+          app:layout_constraintTop_toTopOf="parent"
+          app:layout_constraintBottom_toBottomOf="parent"
+          app:layout_constraintEnd_toEndOf="parent" />
       </androidx.constraintlayout.widget.ConstraintLayout>
     </LinearLayout>
   </ScrollView>

--- a/android/app/src/main/res/layout-land/fragment_osm_login_bottom.xml
+++ b/android/app/src/main/res/layout-land/fragment_osm_login_bottom.xml
@@ -1,0 +1,115 @@
+<?xml version="1.0" encoding="utf-8"?>
+<LinearLayout
+  xmlns:android="http://schemas.android.com/apk/res/android"
+  xmlns:app="http://schemas.android.com/apk/res-auto"
+  xmlns:tools="http://schemas.android.com/tools"
+  android:layout_width="match_parent"
+  android:layout_height="match_parent"
+  android:orientation="vertical">
+  <ScrollView
+    android:layout_width="match_parent"
+    android:layout_height="match_parent"
+    android:background="?cardBackground"
+    android:fadeScrollbars="false"
+    android:fillViewport="true"
+    tools:ignore="DuplicateIds">
+    <LinearLayout
+      android:layout_width="match_parent"
+      android:layout_height="match_parent"
+      android:clipChildren="false"
+      android:clipToPadding="false"
+      android:orientation="vertical"
+      android:padding="@dimen/margin_base"
+      tools:ignore="ScrollViewSize">
+      <androidx.constraintlayout.widget.ConstraintLayout
+          android:layout_width="match_parent"
+          android:layout_height="wrap_content"
+          android:layout_marginTop="@dimen/margin_half">
+        <com.google.android.material.textfield.TextInputLayout
+            android:id="@+id/osm_username_container"
+            style="@style/MwmWidget.Editor.CustomTextInput"
+            android:layout_width="0dp"
+            android:layout_marginEnd="@dimen/margin_half"
+            android:textColorHint="?android:textColorSecondary"
+            app:layout_constraintStart_toStartOf="parent"
+            app:layout_constraintEnd_toStartOf="@id/osm_password_container"
+            app:layout_constraintTop_toTopOf="parent"
+            app:endIconMode="custom">
+          <com.google.android.material.textfield.TextInputEditText
+              android:id="@+id/osm_username"
+              style="@style/MwmWidget.Editor.FieldLayout.EditText"
+              android:autofillHints="emailAddress"
+              android:hint="@string/email_or_username" />
+        </com.google.android.material.textfield.TextInputLayout>
+        <com.google.android.material.textfield.TextInputLayout
+            android:id="@+id/osm_password_container"
+            style="@style/MwmWidget.Editor.CustomTextInput"
+            android:layout_width="0dp"
+            android:textColorHint="?android:textColorSecondary"
+            app:layout_constraintStart_toEndOf="@id/osm_username_container"
+            app:layout_constraintEnd_toEndOf="parent"
+            app:layout_constraintTop_toTopOf="parent"
+            app:endIconMode="password_toggle"
+            app:endIconTint="?android:textColorSecondary">
+          <com.google.android.material.textfield.TextInputEditText
+              android:id="@+id/osm_password"
+              style="@style/MwmWidget.Editor.FieldLayout.EditText"
+              android:autofillHints="password"
+              android:hint="@string/password"
+              android:inputType="textPassword" />
+        </com.google.android.material.textfield.TextInputLayout>
+      </androidx.constraintlayout.widget.ConstraintLayout>
+
+
+      <FrameLayout
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:layout_marginTop="@dimen/margin_base">
+        <Button
+          android:id="@+id/login"
+          style="@style/MwmWidget.Button.Accent"
+          android:layout_width="match_parent"
+          android:layout_height="wrap_content"
+          android:text="Login with username"
+            android:layout_marginTop="@dimen/margin_half"
+          android:textAppearance="@style/MwmTextAppearance.Body2.Light" />
+        <ProgressBar
+          android:id="@+id/osm_login_progress"
+          android:layout_width="@dimen/editor_auth_btn_height"
+          android:layout_height="@dimen/editor_auth_btn_height"
+          android:layout_gravity="center"
+          android:elevation="@dimen/design_fab_elevation"
+          android:visibility="gone" />
+      </FrameLayout>
+
+      <LinearLayout
+          android:layout_width="match_parent"
+          android:layout_height="wrap_content"
+          android:orientation="horizontal"
+          android:layout_marginTop="@dimen/margin_base">
+        <Button
+            android:id="@+id/lost_password"
+            style="@style/MwmWidget.Button"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:layout_gravity="start"
+            android:layout_weight="1"
+            android:background="?clickableBackground"
+            android:padding="@dimen/margin_quarter"
+            android:text="@string/forgot_password"
+            android:textAppearance="@style/MwmTextAppearance.Body3" />
+        <Button
+            android:id="@+id/register"
+            style="@style/MwmWidget.Button"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:layout_weight="1"
+            android:layout_gravity="end"
+            android:background="?clickableBackground"
+            android:padding="@dimen/margin_quarter"
+            android:text="@string/register_at_openstreetmap"
+            android:textAppearance="@style/MwmTextAppearance.Body3" />
+      </LinearLayout>
+    </LinearLayout>
+  </ScrollView>
+</LinearLayout>

--- a/android/app/src/main/res/layout-land/fragment_osm_login_bottom.xml
+++ b/android/app/src/main/res/layout-land/fragment_osm_login_bottom.xml
@@ -6,6 +6,8 @@
   android:layout_width="match_parent"
   android:layout_height="match_parent"
   android:orientation="vertical">
+  <include
+    layout="@layout/bottom_sheet_handle" />
   <ScrollView
     android:layout_width="match_parent"
     android:layout_height="match_parent"

--- a/android/app/src/main/res/layout-land/fragment_osm_login_bottom.xml
+++ b/android/app/src/main/res/layout-land/fragment_osm_login_bottom.xml
@@ -22,41 +22,41 @@
       android:padding="@dimen/margin_base"
       tools:ignore="ScrollViewSize">
       <androidx.constraintlayout.widget.ConstraintLayout
-          android:layout_width="match_parent"
-          android:layout_height="wrap_content"
-          android:layout_marginTop="@dimen/margin_half">
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:layout_marginTop="@dimen/margin_half">
         <com.google.android.material.textfield.TextInputLayout
-            android:id="@+id/osm_username_container"
-            style="@style/MwmWidget.Editor.CustomTextInput"
-            android:layout_width="0dp"
-            android:layout_marginEnd="@dimen/margin_half"
-            android:textColorHint="?android:textColorSecondary"
-            app:layout_constraintStart_toStartOf="parent"
-            app:layout_constraintEnd_toStartOf="@id/osm_password_container"
-            app:layout_constraintTop_toTopOf="parent"
-            app:endIconMode="custom">
+          android:id="@+id/osm_username_container"
+          style="@style/MwmWidget.Editor.CustomTextInput"
+          android:layout_width="0dp"
+          android:layout_marginEnd="@dimen/margin_half"
+          android:textColorHint="?android:textColorSecondary"
+          app:layout_constraintStart_toStartOf="parent"
+          app:layout_constraintEnd_toStartOf="@id/osm_password_container"
+          app:layout_constraintTop_toTopOf="parent"
+          app:endIconMode="custom">
           <com.google.android.material.textfield.TextInputEditText
-              android:id="@+id/osm_username"
-              style="@style/MwmWidget.Editor.FieldLayout.EditText"
-              android:autofillHints="emailAddress"
-              android:hint="@string/email_or_username" />
+            android:id="@+id/osm_username"
+            style="@style/MwmWidget.Editor.FieldLayout.EditText"
+            android:autofillHints="emailAddress"
+            android:hint="@string/email_or_username" />
         </com.google.android.material.textfield.TextInputLayout>
         <com.google.android.material.textfield.TextInputLayout
-            android:id="@+id/osm_password_container"
-            style="@style/MwmWidget.Editor.CustomTextInput"
-            android:layout_width="0dp"
-            android:textColorHint="?android:textColorSecondary"
-            app:layout_constraintStart_toEndOf="@id/osm_username_container"
-            app:layout_constraintEnd_toEndOf="parent"
-            app:layout_constraintTop_toTopOf="parent"
-            app:endIconMode="password_toggle"
-            app:endIconTint="?android:textColorSecondary">
+          android:id="@+id/osm_password_container"
+          style="@style/MwmWidget.Editor.CustomTextInput"
+          android:layout_width="0dp"
+          android:textColorHint="?android:textColorSecondary"
+          app:layout_constraintStart_toEndOf="@id/osm_username_container"
+          app:layout_constraintEnd_toEndOf="parent"
+          app:layout_constraintTop_toTopOf="parent"
+          app:endIconMode="password_toggle"
+          app:endIconTint="?android:textColorSecondary">
           <com.google.android.material.textfield.TextInputEditText
-              android:id="@+id/osm_password"
-              style="@style/MwmWidget.Editor.FieldLayout.EditText"
-              android:autofillHints="password"
-              android:hint="@string/password"
-              android:inputType="textPassword" />
+            android:id="@+id/osm_password"
+            style="@style/MwmWidget.Editor.FieldLayout.EditText"
+            android:autofillHints="password"
+            android:hint="@string/password"
+            android:inputType="textPassword" />
         </com.google.android.material.textfield.TextInputLayout>
       </androidx.constraintlayout.widget.ConstraintLayout>
 
@@ -71,7 +71,7 @@
           android:layout_width="match_parent"
           android:layout_height="wrap_content"
           android:text="Login with username"
-            android:layout_marginTop="@dimen/margin_half"
+          android:layout_marginTop="@dimen/margin_half"
           android:textAppearance="@style/MwmTextAppearance.Body2.Light" />
         <ProgressBar
           android:id="@+id/osm_login_progress"
@@ -83,32 +83,32 @@
       </FrameLayout>
 
       <LinearLayout
-          android:layout_width="match_parent"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:orientation="horizontal"
+        android:layout_marginTop="@dimen/margin_base">
+        <Button
+          android:id="@+id/lost_password"
+          style="@style/MwmWidget.Button"
+          android:layout_width="wrap_content"
           android:layout_height="wrap_content"
-          android:orientation="horizontal"
-          android:layout_marginTop="@dimen/margin_base">
+          android:layout_gravity="start"
+          android:layout_weight="1"
+          android:background="?clickableBackground"
+          android:padding="@dimen/margin_quarter"
+          android:text="@string/forgot_password"
+          android:textAppearance="@style/MwmTextAppearance.Body3" />
         <Button
-            android:id="@+id/lost_password"
-            style="@style/MwmWidget.Button"
-            android:layout_width="wrap_content"
-            android:layout_height="wrap_content"
-            android:layout_gravity="start"
-            android:layout_weight="1"
-            android:background="?clickableBackground"
-            android:padding="@dimen/margin_quarter"
-            android:text="@string/forgot_password"
-            android:textAppearance="@style/MwmTextAppearance.Body3" />
-        <Button
-            android:id="@+id/register"
-            style="@style/MwmWidget.Button"
-            android:layout_width="wrap_content"
-            android:layout_height="wrap_content"
-            android:layout_weight="1"
-            android:layout_gravity="end"
-            android:background="?clickableBackground"
-            android:padding="@dimen/margin_quarter"
-            android:text="@string/register_at_openstreetmap"
-            android:textAppearance="@style/MwmTextAppearance.Body3" />
+          android:id="@+id/register"
+          style="@style/MwmWidget.Button"
+          android:layout_width="wrap_content"
+          android:layout_height="wrap_content"
+          android:layout_weight="1"
+          android:layout_gravity="end"
+          android:background="?clickableBackground"
+          android:padding="@dimen/margin_quarter"
+          android:text="@string/register_at_openstreetmap"
+          android:textAppearance="@style/MwmTextAppearance.Body3" />
       </LinearLayout>
     </LinearLayout>
   </ScrollView>

--- a/android/app/src/main/res/layout/fragment_osm_login.xml
+++ b/android/app/src/main/res/layout/fragment_osm_login.xml
@@ -60,6 +60,13 @@
         android:text="@string/login_to_make_edits_visible"
         android:textAppearance="@style/MwmTextAppearance.Body2"
         android:textColor="?android:textColorPrimary" />
+      <Button
+          android:id="@+id/login_website"
+          style="@style/MwmWidget.Button.Accent"
+          android:layout_width="match_parent"
+          android:layout_height="wrap_content"
+          android:text="Login with OSM website"
+          android:textAppearance="@style/MwmTextAppearance.Body2.Light" />
       <com.google.android.material.textfield.TextInputLayout
         style="@style/MwmWidget.Editor.CustomTextInput"
         android:layout_marginTop="@dimen/margin_half"

--- a/android/app/src/main/res/layout/fragment_osm_login.xml
+++ b/android/app/src/main/res/layout/fragment_osm_login.xml
@@ -63,87 +63,19 @@
       <Button
           android:id="@+id/login_website"
           style="@style/MwmWidget.Button.Accent"
+          android:layout_marginTop="@dimen/margin_base"
           android:layout_width="match_parent"
           android:layout_height="wrap_content"
           android:text="Login with OSM website"
           android:textAppearance="@style/MwmTextAppearance.Body2.Light" />
-      <com.google.android.material.textfield.TextInputLayout
-        style="@style/MwmWidget.Editor.CustomTextInput"
-        android:layout_marginTop="@dimen/margin_half"
-        android:textColorHint="?android:textColorSecondary"
-        app:endIconMode="custom">
-        <com.google.android.material.textfield.TextInputEditText
-          android:id="@+id/osm_username"
-          style="@style/MwmWidget.Editor.FieldLayout.EditText"
-          android:autofillHints="emailAddress"
-          android:hint="@string/email_or_username" />
-      </com.google.android.material.textfield.TextInputLayout>
-      <com.google.android.material.textfield.TextInputLayout
-        style="@style/MwmWidget.Editor.CustomTextInput"
-        android:layout_marginTop="@dimen/margin_base"
-        android:textColorHint="?android:textColorSecondary"
-        app:endIconMode="password_toggle"
-        app:endIconTint="?android:textColorSecondary">
-        <com.google.android.material.textfield.TextInputEditText
-          android:id="@+id/osm_password"
-          style="@style/MwmWidget.Editor.FieldLayout.EditText"
-          android:autofillHints="password"
-          android:hint="@string/password"
-          android:inputType="textPassword" />
-      </com.google.android.material.textfield.TextInputLayout>
-      <FrameLayout
-        android:layout_width="match_parent"
-        android:layout_height="wrap_content"
-        android:layout_marginBottom="@dimen/margin_base">
-        <Button
-          android:id="@+id/login"
-          style="@style/MwmWidget.Button.Accent"
-          android:layout_width="match_parent"
-          android:layout_height="wrap_content"
-          android:text="@string/login_osm"
-          android:textAppearance="@style/MwmTextAppearance.Body2.Light" />
-        <ProgressBar
-          android:id="@+id/osm_login_progress"
-          android:layout_width="@dimen/editor_auth_btn_height"
-          android:layout_height="@dimen/editor_auth_btn_height"
-          android:layout_gravity="center"
-          android:elevation="@dimen/design_fab_elevation"
-          android:visibility="gone" />
-      </FrameLayout>
       <Button
-        android:id="@+id/lost_password"
-        style="@style/MwmWidget.Button"
-        android:layout_width="wrap_content"
-        android:layout_height="wrap_content"
-        android:layout_gravity="end"
-        android:background="?clickableBackground"
-        android:padding="@dimen/margin_half"
-        android:text="@string/forgot_password"
-        android:textAppearance="@style/MwmTextAppearance.Body3" />
-      <com.google.android.material.divider.MaterialDivider
-        android:layout_width="wrap_content"
-        android:layout_height="wrap_content"
-        android:layout_marginTop="@dimen/margin_base"
-        android:layout_marginBottom="@dimen/margin_base" />
-      <TextView
-        android:layout_width="match_parent"
-        android:layout_height="wrap_content"
-        android:fontFamily="@string/robotoRegular"
-        android:text="@string/no_osm_account"
-        android:textAppearance="@style/MwmTextAppearance.Body2"
-        android:textColor="?android:textColorPrimary" />
-      <Button
-        android:id="@+id/register"
+        android:id="@+id/login_username"
         style="@style/MwmWidget.Button.Accent"
         android:layout_width="match_parent"
         android:layout_height="wrap_content"
+        android:text="Login with username"
         android:layout_marginTop="@dimen/margin_base"
-        android:background="@drawable/button_editor_light"
-        android:fontFamily="@string/robotoMedium"
-        android:padding="@dimen/margin_quarter"
-        android:text="@string/register_at_openstreetmap"
-        android:textAppearance="@style/MwmTextAppearance.Body2"
-        android:textColor="@color/text_dark" />
+        android:textAppearance="@style/MwmTextAppearance.Body2.Light" />
     </LinearLayout>
   </ScrollView>
 </LinearLayout>

--- a/android/app/src/main/res/layout/fragment_osm_login.xml
+++ b/android/app/src/main/res/layout/fragment_osm_login.xml
@@ -61,13 +61,13 @@
         android:textAppearance="@style/MwmTextAppearance.Body2"
         android:textColor="?android:textColorPrimary" />
       <Button
-          android:id="@+id/login_website"
-          style="@style/MwmWidget.Button.Accent"
-          android:layout_marginTop="@dimen/margin_base"
-          android:layout_width="match_parent"
-          android:layout_height="wrap_content"
-          android:text="Login with OSM website"
-          android:textAppearance="@style/MwmTextAppearance.Body2.Light" />
+        android:id="@+id/login_website"
+        style="@style/MwmWidget.Button.Accent"
+        android:layout_marginTop="@dimen/margin_base"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:text="Login with OSM website"
+        android:textAppearance="@style/MwmTextAppearance.Body2.Light" />
       <Button
         android:id="@+id/login_username"
         style="@style/MwmWidget.Button.Accent"

--- a/android/app/src/main/res/layout/fragment_osm_login_bottom.xml
+++ b/android/app/src/main/res/layout/fragment_osm_login_bottom.xml
@@ -6,6 +6,8 @@
   android:layout_width="match_parent"
   android:layout_height="match_parent"
   android:orientation="vertical">
+  <include
+    layout="@layout/bottom_sheet_handle" />
   <ScrollView
     android:layout_width="match_parent"
     android:layout_height="match_parent"

--- a/android/app/src/main/res/layout/fragment_osm_login_bottom.xml
+++ b/android/app/src/main/res/layout/fragment_osm_login_bottom.xml
@@ -1,0 +1,108 @@
+<?xml version="1.0" encoding="utf-8"?>
+<LinearLayout
+  xmlns:android="http://schemas.android.com/apk/res/android"
+  xmlns:app="http://schemas.android.com/apk/res-auto"
+  xmlns:tools="http://schemas.android.com/tools"
+  android:layout_width="match_parent"
+  android:layout_height="match_parent"
+  android:orientation="vertical">
+  <ScrollView
+    android:layout_width="match_parent"
+    android:layout_height="match_parent"
+    android:background="?cardBackground"
+    android:fadeScrollbars="false"
+    android:fillViewport="true"
+    tools:ignore="DuplicateIds">
+    <LinearLayout
+      android:layout_width="match_parent"
+      android:layout_height="match_parent"
+      android:clipChildren="false"
+      android:clipToPadding="false"
+      android:orientation="vertical"
+      android:padding="@dimen/margin_base"
+      tools:ignore="ScrollViewSize">
+      <LinearLayout
+          android:id="@+id/login_bottom_sheet"
+          android:layout_width="match_parent"
+          android:layout_height="wrap_content"
+          android:orientation="vertical">
+
+        <com.google.android.material.textfield.TextInputLayout
+            style="@style/MwmWidget.Editor.CustomTextInput"
+            android:layout_marginTop="@dimen/margin_half"
+            android:textColorHint="?android:textColorSecondary"
+            app:endIconMode="custom">
+          <com.google.android.material.textfield.TextInputEditText
+              android:id="@+id/osm_username"
+              style="@style/MwmWidget.Editor.FieldLayout.EditText"
+              android:padding="@dimen/margin_half_double_plus"
+              android:autofillHints="emailAddress"
+              android:hint="@string/email_or_username" />
+        </com.google.android.material.textfield.TextInputLayout>
+        <com.google.android.material.textfield.TextInputLayout
+            style="@style/MwmWidget.Editor.CustomTextInput"
+            android:textColorHint="?android:textColorSecondary"
+            app:endIconMode="password_toggle"
+            app:endIconTint="?android:textColorSecondary">
+          <com.google.android.material.textfield.TextInputEditText
+              android:id="@+id/osm_password"
+              style="@style/MwmWidget.Editor.FieldLayout.EditText"
+              android:padding="@dimen/margin_half_double_plus"
+              android:autofillHints="password"
+              android:hint="@string/password"
+              android:inputType="textPassword" />
+        </com.google.android.material.textfield.TextInputLayout>
+      </LinearLayout>
+
+      <FrameLayout
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:layout_marginTop="@dimen/margin_base">
+        <Button
+          android:id="@+id/login"
+          style="@style/MwmWidget.Button.Accent"
+          android:layout_width="match_parent"
+          android:layout_height="wrap_content"
+          android:text="Login with username"
+            android:layout_marginTop="@dimen/margin_half"
+          android:textAppearance="@style/MwmTextAppearance.Body2.Light" />
+        <ProgressBar
+          android:id="@+id/osm_login_progress"
+          android:layout_width="@dimen/editor_auth_btn_height"
+          android:layout_height="@dimen/editor_auth_btn_height"
+          android:layout_gravity="center"
+          android:elevation="@dimen/design_fab_elevation"
+          android:visibility="gone" />
+      </FrameLayout>
+
+      <LinearLayout
+          android:layout_width="match_parent"
+          android:layout_height="wrap_content"
+          android:orientation="horizontal"
+          android:layout_marginTop="@dimen/margin_base">
+        <Button
+            android:id="@+id/lost_password"
+            style="@style/MwmWidget.Button"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:layout_gravity="start"
+            android:layout_weight="1"
+            android:background="?clickableBackground"
+            android:padding="@dimen/margin_quarter"
+            android:text="@string/forgot_password"
+            android:textAppearance="@style/MwmTextAppearance.Body3" />
+        <Button
+            android:id="@+id/register"
+            style="@style/MwmWidget.Button"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:layout_weight="1"
+            android:layout_gravity="end"
+            android:background="?clickableBackground"
+            android:padding="@dimen/margin_quarter"
+            android:text="@string/register_at_openstreetmap"
+            android:textAppearance="@style/MwmTextAppearance.Body3" />
+      </LinearLayout>
+    </LinearLayout>
+  </ScrollView>
+</LinearLayout>

--- a/android/app/src/main/res/layout/fragment_osm_login_bottom.xml
+++ b/android/app/src/main/res/layout/fragment_osm_login_bottom.xml
@@ -22,35 +22,35 @@
       android:padding="@dimen/margin_base"
       tools:ignore="ScrollViewSize">
       <LinearLayout
-          android:id="@+id/login_bottom_sheet"
-          android:layout_width="match_parent"
-          android:layout_height="wrap_content"
-          android:orientation="vertical">
+        android:id="@+id/login_bottom_sheet"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:orientation="vertical">
 
         <com.google.android.material.textfield.TextInputLayout
-            style="@style/MwmWidget.Editor.CustomTextInput"
-            android:layout_marginTop="@dimen/margin_half"
-            android:textColorHint="?android:textColorSecondary"
-            app:endIconMode="custom">
+          style="@style/MwmWidget.Editor.CustomTextInput"
+          android:layout_marginTop="@dimen/margin_half"
+          android:textColorHint="?android:textColorSecondary"
+          app:endIconMode="custom">
           <com.google.android.material.textfield.TextInputEditText
-              android:id="@+id/osm_username"
-              style="@style/MwmWidget.Editor.FieldLayout.EditText"
-              android:padding="@dimen/margin_half_double_plus"
-              android:autofillHints="emailAddress"
-              android:hint="@string/email_or_username" />
+            android:id="@+id/osm_username"
+            style="@style/MwmWidget.Editor.FieldLayout.EditText"
+            android:padding="@dimen/margin_half_double_plus"
+            android:autofillHints="emailAddress"
+            android:hint="@string/email_or_username" />
         </com.google.android.material.textfield.TextInputLayout>
         <com.google.android.material.textfield.TextInputLayout
-            style="@style/MwmWidget.Editor.CustomTextInput"
-            android:textColorHint="?android:textColorSecondary"
-            app:endIconMode="password_toggle"
-            app:endIconTint="?android:textColorSecondary">
+          style="@style/MwmWidget.Editor.CustomTextInput"
+          android:textColorHint="?android:textColorSecondary"
+          app:endIconMode="password_toggle"
+          app:endIconTint="?android:textColorSecondary">
           <com.google.android.material.textfield.TextInputEditText
-              android:id="@+id/osm_password"
-              style="@style/MwmWidget.Editor.FieldLayout.EditText"
-              android:padding="@dimen/margin_half_double_plus"
-              android:autofillHints="password"
-              android:hint="@string/password"
-              android:inputType="textPassword" />
+            android:id="@+id/osm_password"
+            style="@style/MwmWidget.Editor.FieldLayout.EditText"
+            android:padding="@dimen/margin_half_double_plus"
+            android:autofillHints="password"
+            android:hint="@string/password"
+            android:inputType="textPassword" />
         </com.google.android.material.textfield.TextInputLayout>
       </LinearLayout>
 
@@ -64,7 +64,7 @@
           android:layout_width="match_parent"
           android:layout_height="wrap_content"
           android:text="Login with username"
-            android:layout_marginTop="@dimen/margin_half"
+          android:layout_marginTop="@dimen/margin_half"
           android:textAppearance="@style/MwmTextAppearance.Body2.Light" />
         <ProgressBar
           android:id="@+id/osm_login_progress"
@@ -76,32 +76,32 @@
       </FrameLayout>
 
       <LinearLayout
-          android:layout_width="match_parent"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:orientation="horizontal"
+        android:layout_marginTop="@dimen/margin_base">
+        <Button
+          android:id="@+id/lost_password"
+          style="@style/MwmWidget.Button"
+          android:layout_width="wrap_content"
           android:layout_height="wrap_content"
-          android:orientation="horizontal"
-          android:layout_marginTop="@dimen/margin_base">
+          android:layout_gravity="start"
+          android:layout_weight="1"
+          android:background="?clickableBackground"
+          android:padding="@dimen/margin_quarter"
+          android:text="@string/forgot_password"
+          android:textAppearance="@style/MwmTextAppearance.Body3" />
         <Button
-            android:id="@+id/lost_password"
-            style="@style/MwmWidget.Button"
-            android:layout_width="wrap_content"
-            android:layout_height="wrap_content"
-            android:layout_gravity="start"
-            android:layout_weight="1"
-            android:background="?clickableBackground"
-            android:padding="@dimen/margin_quarter"
-            android:text="@string/forgot_password"
-            android:textAppearance="@style/MwmTextAppearance.Body3" />
-        <Button
-            android:id="@+id/register"
-            style="@style/MwmWidget.Button"
-            android:layout_width="wrap_content"
-            android:layout_height="wrap_content"
-            android:layout_weight="1"
-            android:layout_gravity="end"
-            android:background="?clickableBackground"
-            android:padding="@dimen/margin_quarter"
-            android:text="@string/register_at_openstreetmap"
-            android:textAppearance="@style/MwmTextAppearance.Body3" />
+          android:id="@+id/register"
+          style="@style/MwmWidget.Button"
+          android:layout_width="wrap_content"
+          android:layout_height="wrap_content"
+          android:layout_weight="1"
+          android:layout_gravity="end"
+          android:background="?clickableBackground"
+          android:padding="@dimen/margin_quarter"
+          android:text="@string/register_at_openstreetmap"
+          android:textAppearance="@style/MwmTextAppearance.Body3" />
       </LinearLayout>
     </LinearLayout>
   </ScrollView>

--- a/editor/osm_auth.cpp
+++ b/editor/osm_auth.cpp
@@ -282,7 +282,7 @@ string OsmOAuth::BuildOAuth2Url() const
        {"scope", m_oauth2params.m_scope},
        {"response_type", "code"}
    });
-   return requestTokenUrl + "?" + requestTokenQuery;
+   return requestTokenUrl.append('?').append(requestTokenQuery);
 }
 
 string OsmOAuth::FinishAuthorization(string const & oauth2code) const

--- a/editor/osm_auth.cpp
+++ b/editor/osm_auth.cpp
@@ -275,14 +275,14 @@ string OsmOAuth::FetchRequestToken(SessionID const & sid) const
 
 string OsmOAuth::BuildOAuth2Url() const
 {
-   string const requestTokenUrl = m_baseUrl + "/oauth2/authorize";
+   string requestTokenUrl = m_baseUrl + "/oauth2/authorize";
    string const requestTokenQuery = BuildPostRequest({
        {"client_id", m_oauth2params.m_clientId},
        {"redirect_uri", m_oauth2params.m_redirectUri},
        {"scope", m_oauth2params.m_scope},
        {"response_type", "code"}
    });
-   return requestTokenUrl.append('?').append(requestTokenQuery);
+   return requestTokenUrl.append("?").append(requestTokenQuery);
 }
 
 string OsmOAuth::FinishAuthorization(string const & oauth2code) const

--- a/editor/osm_auth.cpp
+++ b/editor/osm_auth.cpp
@@ -241,14 +241,7 @@ string OsmOAuth::SendAuthRequest(string const & requestTokenKey, SessionID const
 
 string OsmOAuth::FetchRequestToken(SessionID const & sid) const
 {
-  string const requestTokenUrl = m_baseUrl + "/oauth2/authorize";
-  string const requestTokenQuery =  BuildPostRequest({
-      {"client_id", m_oauth2params.m_clientId},
-      {"redirect_uri", m_oauth2params.m_redirectUri},
-      {"scope", m_oauth2params.m_scope},
-      {"response_type", "code"}
-  });
-  HttpClient request(requestTokenUrl + "?" + requestTokenQuery);
+  HttpClient request(BuildOAuth2Url());
   request.SetCookies(sid.m_cookies)
          .SetFollowRedirects(false);
 
@@ -278,6 +271,18 @@ string OsmOAuth::FetchRequestToken(SessionID const & sid) const
     // Accept OAuth2 request from server
     return SendAuthRequest(authenticityToken, sid);
   }
+}
+
+string OsmOAuth::BuildOAuth2Url() const
+{
+   string const requestTokenUrl = m_baseUrl + "/oauth2/authorize";
+   string const requestTokenQuery = BuildPostRequest({
+       {"client_id", m_oauth2params.m_clientId},
+       {"redirect_uri", m_oauth2params.m_redirectUri},
+       {"scope", m_oauth2params.m_scope},
+       {"response_type", "code"}
+   });
+   return requestTokenUrl + "?" + requestTokenQuery;
 }
 
 string OsmOAuth::FinishAuthorization(string const & oauth2code) const

--- a/editor/osm_auth.hpp
+++ b/editor/osm_auth.hpp
@@ -93,6 +93,13 @@ public:
   /// @param[api] If false, request is made to m_baseUrl.
   Response DirectRequest(std::string const & method, bool api = true) const;
 
+  // Getters
+  std::string GetBaseUrl() const { return m_baseUrl; }
+  std::string GetClientId() const { return m_oauth2params.m_clientId; }
+  std::string GetClientSecret() const { return m_oauth2params.m_clientSecret; }
+  std::string GetScope() const { return m_oauth2params.m_scope; }
+  std::string GetRedirectUri() const { return m_oauth2params.m_redirectUri; }
+
   /// @name Methods for WebView-based authentication.
   //@{
   std::string FinishAuthorization(std::string const & oauth2code) const;

--- a/editor/osm_auth.hpp
+++ b/editor/osm_auth.hpp
@@ -109,6 +109,7 @@ public:
   {
     return m_baseUrl + "/user/" + user + "/history";
   }
+  std::string BuildOAuth2Url() const;
   //@}
 
 private:
@@ -143,7 +144,6 @@ private:
   /// @returns valid key and secret or throws otherwise.
   std::string FetchRequestToken(SessionID const & sid) const;
   std::string FetchAccessToken(SessionID const & sid) const;
-  //AuthResult FetchAccessToken(SessionID const & sid);
 };
 
 std::string DebugPrint(OsmOAuth::Response const & code);

--- a/iphone/CoreApi/CoreApi/DeepLink/DeepLinkParser.h
+++ b/iphone/CoreApi/CoreApi/DeepLink/DeepLinkParser.h
@@ -8,6 +8,7 @@ typedef NS_ENUM(NSUInteger, DeeplinkUrlType) {
   DeeplinkUrlTypeRoute,
   DeeplinkUrlTypeSearch,
   DeeplinkUrlTypeCrosshair,
+  DeeplinkUrlTypeOAuth2
 };
 
 @interface DeepLinkParser : NSObject

--- a/iphone/CoreApi/CoreApi/DeepLink/DeepLinkParser.mm
+++ b/iphone/CoreApi/CoreApi/DeepLink/DeepLinkParser.mm
@@ -13,6 +13,7 @@ static inline DeeplinkUrlType deeplinkUrlType(url_scheme::ParsedMapApi::UrlType 
      case url_scheme::ParsedMapApi::UrlType::Route: return DeeplinkUrlTypeRoute;
      case url_scheme::ParsedMapApi::UrlType::Search: return DeeplinkUrlTypeSearch;
      case url_scheme::ParsedMapApi::UrlType::Crosshair: return DeeplinkUrlTypeCrosshair;
+     case url_scheme::ParsedMapApi::UrlType::OAuth2: return DeeplinkUrlTypeOAuth2;
    }
 }
 

--- a/iphone/Maps/Core/DeepLink/DeepLinkHandler.swift
+++ b/iphone/Maps/Core/DeepLink/DeepLinkHandler.swift
@@ -115,6 +115,10 @@
     case .crosshair:
       // Not supported on iOS.
       return false;
+      
+    case .oAuth2:
+      // TODO: support OAuth2
+      return false;
 
     case .incorrect:
       // Invalid URL or API parameters.

--- a/map/framework.cpp
+++ b/map/framework.cpp
@@ -1738,6 +1738,11 @@ url_scheme::SearchRequest Framework::GetParsedSearchRequest() const
   return m_parsedMapApi.GetSearchRequest();
 }
 
+std::string Framework::GetParsedOAuth2Code() const
+{
+  return m_parsedMapApi.GetOAuth2Code();
+}
+
 std::string const & Framework::GetParsedAppName() const
 {
   return m_parsedMapApi.GetAppName();

--- a/map/framework.hpp
+++ b/map/framework.hpp
@@ -578,6 +578,7 @@ public:
 
   ParsedRoutingData GetParsedRoutingData() const;
   url_scheme::SearchRequest GetParsedSearchRequest() const;
+  std::string GetParsedOAuth2Code() const;
   std::string const & GetParsedAppName() const;
   std::string const & GetParsedBackUrl() const;
   ms::LatLon GetParsedCenterLatLon() const;

--- a/map/map_tests/mwm_url_tests.cpp
+++ b/map/map_tests/mwm_url_tests.cpp
@@ -474,6 +474,13 @@ UNIT_TEST(AppNameTest)
   }
 }
 
+UNIT_TEST(OAuth2Test)
+{
+  ParsedMapApi api("om://oauth2/osm/callback?code=THE_MEGA_CODE");
+  TEST_EQUAL(api.GetRequestType(), UrlType::OAuth2, ());
+  TEST_EQUAL(api.GetOAuth2Code(), "THE_MEGA_CODE", ());
+}
+
 namespace
 {
 string generatePartOfUrl(url_scheme::MapPoint const & point)

--- a/map/map_tests/mwm_url_tests.cpp
+++ b/map/map_tests/mwm_url_tests.cpp
@@ -476,9 +476,19 @@ UNIT_TEST(AppNameTest)
 
 UNIT_TEST(OAuth2Test)
 {
-  ParsedMapApi api("om://oauth2/osm/callback?code=THE_MEGA_CODE");
-  TEST_EQUAL(api.GetRequestType(), UrlType::OAuth2, ());
-  TEST_EQUAL(api.GetOAuth2Code(), "THE_MEGA_CODE", ());
+  {
+    ParsedMapApi api("om://oauth2/osm/callback?code=THE_MEGA_CODE");
+    TEST_EQUAL(api.GetRequestType(), UrlType::OAuth2, ());
+    TEST_EQUAL(api.GetOAuth2Code(), "THE_MEGA_CODE", ());
+  }
+  {
+    ParsedMapApi api("om://oauth2/google/callback?code=THE_MEGA_CODE");
+    TEST_EQUAL(api.GetRequestType(), UrlType::Incorrect, ());
+  }
+  {
+    ParsedMapApi api("om://oauth2/osm/callback?code=");
+    TEST_EQUAL(api.GetRequestType(), UrlType::Incorrect, ());
+  }
 }
 
 namespace

--- a/map/mwm_url.cpp
+++ b/map/mwm_url.cpp
@@ -175,6 +175,22 @@ ParsedMapApi::UrlType ParsedMapApi::SetUrlAndParse(std::string const & raw)
 
       return m_requestType = UrlType::Crosshair;
     }
+    else if (type == "oauth2")
+    {
+      if (url.GetPath() != "osm/callback")
+        return m_requestType = UrlType::Incorrect;
+
+      url.ForEachParam([this](auto const & key, auto const & value)
+      {
+        if (key == "code")
+          m_oauth2code = value;
+      });
+
+      if (m_oauth2code.empty())
+        return m_requestType = UrlType::Incorrect;
+      else
+        return m_requestType = UrlType::OAuth2;
+    }
     else if (checkForGe0Link)
     {
       // The URL is prefixed by one of the kGe0Prefixes AND doesn't match any supported API call:
@@ -386,6 +402,7 @@ void ParsedMapApi::Reset()
   m_mapPoints.clear();
   m_routePoints.clear();
   m_searchRequest = {};
+  m_oauth2code = {};
   m_globalBackUrl ={};
   m_appName = {};
   m_centerLatLon = ms::LatLon::Invalid();
@@ -467,6 +484,7 @@ std::string DebugPrint(ParsedMapApi::UrlType type)
   case ParsedMapApi::UrlType::Route: return "Route";
   case ParsedMapApi::UrlType::Search: return "Search";
   case ParsedMapApi::UrlType::Crosshair: return "Crosshair";
+  case ParsedMapApi::UrlType::OAuth2: return "OAuth2";
   }
   UNREACHABLE();
 }

--- a/map/mwm_url.hpp
+++ b/map/mwm_url.hpp
@@ -96,7 +96,7 @@ public:
 
   std::string const & GetOAuth2Code() const
   {
-    ASSERT_EQUAL(m_requestType, UrlType::OAuth2, ("Expected Search API"));
+    ASSERT_EQUAL(m_requestType, UrlType::OAuth2, ("Expected OAuth2 API"));
     return m_oauth2code;
   }
 

--- a/map/mwm_url.hpp
+++ b/map/mwm_url.hpp
@@ -45,6 +45,7 @@ public:
     Route = 2,
     Search = 3,
     Crosshair = 4,
+    OAuth2 = 5,
   };
 
   ParsedMapApi() = default;
@@ -93,6 +94,12 @@ public:
     return m_searchRequest;
   }
 
+  std::string const & GetOAuth2Code() const
+  {
+    ASSERT_EQUAL(m_requestType, UrlType::OAuth2, ("Expected Search API"));
+    return m_oauth2code;
+  }
+
 private:
   void ParseMapParam(std::string const & key, std::string const & value,
                      bool & correctOrder);
@@ -107,6 +114,7 @@ private:
   SearchRequest m_searchRequest;
   std::string m_globalBackUrl;
   std::string m_appName;
+  std::string m_oauth2code;
   ms::LatLon m_centerLatLon = ms::LatLon::Invalid();
   std::string m_routingType;
   int m_version = 0;


### PR DESCRIPTION
How new flow should work (happy path):

1. `OsmLoginFragment` - User pushes "Login with OSM website" button
2. `OsmLoginFragment` - triggers browser
3. `Browser` - OSM.org login flow
4. `Browser` - redirects to om://oauth2/osm/callback?code=XXX
5. `MwmActivity` - handles `om://` URI and extracts `code` value
6. `MwmActivity` - calls OsmLoginActivity with `code` in extras
7. `OsmLoginFragment` - calls native code to get OAuth2 token using `code`
8. `OsmLoginFragment` - calls native code to get username using OAuth2 token
9. `OsmLoginFragment` - redirects to `ProfileActivity`


https://github.com/user-attachments/assets/17fd44c3-a3b5-4a5f-adf4-05da30c10c66

**Question:** What about UI? How we can handle two types of logging in: OAuth2 via browser, and login+password?

### Update 2024-09-19

Changed OSM Login UI to have popup bottom panel:

https://github.com/user-attachments/assets/4757b358-e99a-4052-a2bd-6363ae784a87

### Update 2024-09-20

Added round corners:

<img src="https://github.com/user-attachments/assets/db46574e-2edc-4ab3-8c63-4f698eab63f9" width="400px"/>
