### PR TITLE
Allow Google Maps formatted plus codes

### DIFF
--- a/search/processor.cpp
+++ b/search/processor.cpp
@@ -729,7 +729,7 @@ void Processor::SearchPlusCode()
   // Remove the region information added by Google Maps
   size_t firstCommaPosition = query.find(",");
   if (firstCommaPosition != string::npos) {
-    size_t spaceBeforeCommaPosition = input.rfind(" ", firstCommaPosition);
+    size_t spaceBeforeCommaPosition = query.rfind(" ", firstCommaPosition);
     if (spaceBeforeCommaPosition != string::npos) {
       query = query.substr(0, spaceBeforeCommaPosition);
     }

--- a/search/processor.cpp
+++ b/search/processor.cpp
@@ -726,6 +726,15 @@ void Processor::SearchPlusCode()
   string query(m_query.m_query);
   strings::Trim(query);
 
+  // Remove the region information added by Google Maps
+  size_t firstCommaPosition = query.find(",");
+  if (firstCommaPosition != string::npos) {
+    size_t spaceBeforeCommaPosition = input.rfind(" ", firstCommaPosition);
+    if (spaceBeforeCommaPosition != string::npos) {
+      query = query.substr(0, spaceBeforeCommaPosition);
+    }
+  }
+
   if (openlocationcode::IsFull(query))
   {
     openlocationcode::CodeArea const area = openlocationcode::Decode(query);


### PR DESCRIPTION
Google Maps includes some region information in their plus codes. For example:
`HMPG+54 Four Corners, Montana`
`C2HX+6M, Ranjangaon, Maharashtra 424101, India`

Currently, in order to use these codes in Organic Maps you have to manually delete the region portion each time. This PR allows Organic Maps to accept the format used by Google Maps. As far as I can tell, these are not valid Open Location Codes but I thought it'd still be handy to have. 