### PR TITLE
[Core] Remove snap rotation

### DIFF
--- a/drape_frontend/user_event_stream.cpp
+++ b/drape_frontend/user_event_stream.cpp
@@ -731,17 +731,6 @@ m2::AnyRectD UserEventStream::GetTargetRect()
   return targetScreen.GlobalRect();
 }
 
-void UserEventStream::CheckAutoRotate()
-{
-  if (GetCurrentScreen().isPerspective())
-    return;
-
-  double const kMaxAutoRotateAngle = 25.0 * math::pi / 180.0;
-  double const angle = fabs(GetCurrentScreen().GetAngle());
-  if (angle < kMaxAutoRotateAngle || (2.0 * math::pi - angle) < kMaxAutoRotateAngle)
-    SetAngle(0.0, true /* isAnim */);
-}
-
 bool UserEventStream::ProcessTouch(TouchEvent const & touch)
 {
   ASSERT(touch.GetFirstTouch().m_id != -1, ());
@@ -1081,8 +1070,6 @@ bool UserEventStream::EndDrag(Touch const & t, bool cancelled)
   m_startDragOrg = m2::PointD::Zero();
   m_navigator.StopDrag(m2::PointD(t.m_location));
 
-  CheckAutoRotate();
-
   if (!cancelled && m_kineticScrollEnabled && m_scroller.IsActive() &&
       m_kineticTimer.ElapsedMilliseconds() >= kKineticDelayMs)
   {
@@ -1157,7 +1144,6 @@ void UserEventStream::EndScale(const Touch & t1, const Touch & t2)
   m_navigator.StopScale(touch1, touch2);
 
   m_kineticTimer.Reset();
-  CheckAutoRotate();
 }
 
 void UserEventStream::BeginTapDetector()

--- a/drape_frontend/user_event_stream.hpp
+++ b/drape_frontend/user_event_stream.hpp
@@ -493,7 +493,6 @@ private:
                           bool isAnim, bool isAutoScale, Animation::TAction const & onFinishAction = nullptr,
                           TAnimationCreator const & parallelAnimCreator = nullptr);
   void SetAutoPerspective(bool isAutoPerspective);
-  void CheckAutoRotate();
 
   m2::AnyRectD GetCurrentRect() const;
 


### PR DESCRIPTION
Removes the rotation snapping when nearing north-up

resolves https://github.com/organicmaps/organicmaps/issues/3065, resolves https://github.com/organicmaps/organicmaps/issues/2219
(also was mentioned in telegram a few times)