### PR TITLE
[ios] Add more logs to the `Location manager`

### DIFF
--- a/iphone/Maps/Core/Location/MWMLocationManager.mm
+++ b/iphone/Maps/Core/Location/MWMLocationManager.mm
@@ -294,6 +294,8 @@ void setShowLocationAlert(BOOL needShow) {
       setShowLocationAlert(NO);
     }
     break;
+  case MWMLocationStatusTimeout:
+    ASSERT(false, ("MWMLocationStatusTimeout is Unused on iOS, (only used on Qt)"));
   }
 }
 
@@ -312,6 +314,7 @@ void setShowLocationAlert(BOOL needShow) {
     case MWMRouterTypePublicTransport:
     case MWMRouterTypePedestrian: manager.geoMode = GeoMode::PedestrianRouting; break;
     case MWMRouterTypeBicycle: manager.geoMode = GeoMode::BicycleRouting; break;
+    case MWMRouterTypeRuler: break;
     }
   }
   else


### PR DESCRIPTION
Now the log messages will look like this:
```
I(1) 0.00000 Local time: 2024-08-05 08:16:17 +0000 , Time Zone: GMT+4
I(1) 2.76888 search/processor.cpp:210 SetPreferredLocale(): New preferred locale: en
D(1) 2.76919 search/processor.cpp:229 SetInputLocale(): New input locale: en locale code: \^A
W(2) 2.78217 search/geocoder.cpp:734 CacheWorldLocalities(): Can't find World map file.
I(1) 2.89736 storage/storage.cpp:956 RegisterLocalFile(): Found file: Georgia in directory: /var/mobile/Containers/Data/Application/1AAA36CA-4E01-4AF6-9306-B90D2F42A831/Documents/240528 with size: 82878068
I(1) 2.89743 storage/storage.cpp:956 RegisterLocalFile(): Found file: World in directory:  with size: 47893857
I(1) 2.89747 storage/storage.cpp:956 RegisterLocalFile(): Found file: WorldCoasts in directory:  with size: 8582416
I(1) 4.34456 Location/MWMLocationManager.mm:349 +[MWMLocationManager setMyPositionMode:]: Update MyPositionMode: MWMMyPositionModePendingPosition
I(1) 4.34466 Location/MWMLocationManager.mm:268 -[MWMLocationManager processLocationStatus:]: Location status updated: MWMLocationStatusNoError
I(1) 4.34472 Location/MWMLocationManager.mm:407 -[MWMLocationManager setGeoMode:]: GeoMode updated: Pending
I(1) 4.36394 Location/MWMLocationManager.mm:443 +[MWMLocationManager refreshGeoModeSettingsFor:geoMode:]: Refresh GeoMode settings:
accuracy: -2 
distance filter: -1 
charging: 0
I(1) 4.37138 Location/MWMLocationManager.mm:548 -[MWMLocationManager startUpdatingLocationFor:]: Start updating location
W(1) 5.64547 Location/MWMLocationManager.mm:491 -[MWMLocationManager locationManager:didChangeAuthorizationStatus:]: CLLocationManagerDelegate: Authorization status changed: kCLAuthorizationStatusAuthorizedWhenInUse
...
```