### PR TITLE
[ios] Write the Error and Critical messages to the log file synchronously in the current thread

### DIFF
--- a/iphone/CoreApi/CoreApi/Logger/Logger.mm
+++ b/iphone/CoreApi/CoreApi/Logger/Logger.mm
@@ -16,6 +16,7 @@
 + (void)enableFileLogging;
 + (void)disableFileLogging;
 + (void)logMessageWithLevel:(base::LogLevel)level src:(base::SrcPoint const &)src message:(std::string const &)message;
++ (void)tryWriteToFile:(std::string const &)logString;
 + (NSURL *)getZippedLogFile:(NSString *)logFilePath;
 + (void)removeFileAtPath:(NSString *)filePath;
 + (base::LogLevel)baseLevel:(LogLevel)level;
@@ -203,21 +204,24 @@ bool AssertMessage(base::SrcPoint const & src, std::string const & message)
   // TODO: (KK) Either guard this call, or refactor thread ids in logHelper.
   logHelper.WriteProlog(output, level);
   logHelper.WriteLog(output, src, message);
-  
+
   auto const logString = output.str();
 
-  Logger * logger = [self logger];
   // Log the message into the system log.
-  os_log(logger.osLogger, "%{public}s", logString.c_str());
+  os_log([self logger].osLogger, "%{public}s", logString.c_str());
 
-  dispatch_async([self fileLoggingQueue], ^{
-    // Write the log message into the file.
-    NSFileHandle * fileHandle = logger.fileHandle;
-    if (fileHandle != nil) {
-      [fileHandle seekToEndOfFile];
-      [fileHandle writeData:[NSData dataWithBytes:logString.c_str() length:logString.length()]];
-    }
-  });
+  if (level < base::GetDefaultLogAbortLevel())
+    dispatch_async([self fileLoggingQueue], ^{ [self tryWriteToFile:logString]; });
+  else
+    [self tryWriteToFile:logString];
+}
+
++ (void)tryWriteToFile:(std::string const &)logString {
+  NSFileHandle * fileHandle = [self logger].fileHandle;
+  if (fileHandle != nil) {
+    [fileHandle seekToEndOfFile];
+    [fileHandle writeData:[NSData dataWithBytes:logString.c_str() length:logString.length()]];
+  }
 }
 
 + (NSURL *)getZippedLogFile:(NSString *)logFilePath {


### PR DESCRIPTION
#### Issue Description:
If the app crashes, the log message is missed because the file writing was dispatched to a separate utility queue.

#### This PR fixes it:
The logs will be synchronously written to the log file (if enabled in the settings) in the current thread in these cases:
1. the app fails with the `CHECK` or `ASSERT` (on debug) which use the `Critical` level
2. the `Error` level log is triggered

It will help debug the crashes/error reasons between app reloadings.

This is how the log file will look after the crashed app relaunch:
```
D(1) 45.62401 drape_frontend/drape_engine.cpp:382 SetRenderingEnabled(): Rendering enabled
D(1) 47.00417 drape_frontend/drape_engine.cpp:390 SetRenderingDisabled(): Rendering disabled
C(1) 58.12411 map/bookmark_manager.cpp:2495 DeleteBmCategory(): CHECK(false) Test failure // <--- failure reason
I(1) 0.00000 Local time: 2024-08-05 09:40:14 +0000 , Time Zone: GMT+4
I(1) 0.00014 Logger/Logger.mm:82 +[Logger setFileLoggingEnabled:]: File logging is enabled: YES
I(1) 0.00954 platform/platform_ios.mm:69 Platform: Device: iPad SystemName: iPadOS SystemVersion: 17.1
```