### PR TITLE
[tools] Fix CMake warning regarding BUILD_STANDALONE

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -149,6 +149,12 @@ if (BUILD_DESIGNER)
   add_definitions(-DBUILD_DESIGNER)
 endif()
 
+option(BUILD_STANDALONE "Build standalone application" OFF)
+if (BUILD_STANDALONE)
+  message(STATUS "Standalone building is enabled")
+  add_definitions(-DBUILD_STANDALONE)
+endif()
+
 option(USE_ASAN "Enable Address Sanitizer" OFF)
 option(USE_TSAN "Enable Thread Sanitizer" OFF)
 option(USE_LIBFUZZER "Enable LibFuzzer" OFF)


### PR DESCRIPTION
Declared the variable in them main CMakeLists.txt, which makes it not "manually-specified". It also documents it, which is a plus.

Follow up to @biodranik's [comment](https://github.com/organicmaps/organicmaps/pull/8710#issuecomment-2269600683) in #8710.