### PR TITLE
[strings] vi and id have no plurals

### DIFF
--- a/android/app/src/main/res/values-in/strings.xml
+++ b/android/app/src/main/res/values-in/strings.xml
@@ -590,7 +590,6 @@
 	<string name="phone_number">Nomor telepon</string>
 	<string name="profile">Profil OpenStreetMap</string>
 	<plurals name="bookmarks_detect_message">
-	  <item quantity="one">%d file ditemukan. Anda akan melihatnya setelah mengonversi.</item>
 	  <item quantity="other">%d file telah ditemukan. Anda akan melihatnya setelah konversi.</item>
 	</plurals>
 	<string name="restore">Mengembalikan</string>

--- a/android/app/src/main/res/values-vi/strings.xml
+++ b/android/app/src/main/res/values-vi/strings.xml
@@ -588,7 +588,6 @@
 	<string name="phone_number">Số điện thoại</string>
 	<string name="profile">Hồ sơ OpenStreetMap</string>
 	<plurals name="bookmarks_detect_message">
-	  <item quantity="one">%d dã tìm thấy một tệp. Bạn sẽ thấy nó sau khi chuyển đổi.</item>
 	  <item quantity="other">%d tập tin đã được tìm thấy. Bạn sẽ thấy chúng sau khi chuyển đổi.</item>
 	</plurals>
 	<string name="restore">Khôi phục</string>

--- a/data/strings/strings.txt
+++ b/data/strings/strings.txt
@@ -22093,7 +22093,6 @@
     he:other = נמצאו %d קבצים. יהיה ניתן לראות אותם לאחר ההמרה.
     hu:one = %d fájlt találtunk. Látni fogja őket a megtérés után.
     hu:other = %d fájl található. Látni fogja őket a megtérés után.
-    id:one = %d file ditemukan. Anda akan melihatnya setelah mengonversi.
     id:other = %d file telah ditemukan. Anda akan melihatnya setelah konversi.
     it:one = %d file è stato trovato. Lo vedrai dopo la conversione.
     it:other = %d file trovati. Li vedrai dopo la conversione.
@@ -22129,7 +22128,6 @@
     uk:few = %d файлу були знайдені. Ви побачите їх після конвертації.
     uk:one = %d файл був знайдений. Ви побачите його після перетворення.
     uk:other = %d файлів було знайдено. Ви побачите їх після конвертації.
-    vi:one = %d dã tìm thấy một tệp. Bạn sẽ thấy nó sau khi chuyển đổi.
     vi:other = %d tập tin đã được tìm thấy. Bạn sẽ thấy chúng sau khi chuyển đổi.
     zh-Hans = 找到%d个文件。 转换后你会看到它。
     zh-Hant = 找到%d個文件。 轉換後你會看到它。

--- a/iphone/Maps/LocalizedStrings/id.lproj/Localizable.stringsdict
+++ b/iphone/Maps/LocalizedStrings/id.lproj/Localizable.stringsdict
@@ -34,8 +34,6 @@
       <string>NSStringPluralRuleType</string>
       <key>NSStringFormatValueTypeKey</key>
       <string>d</string>
-      <key>one</key>
-      <string>%d file ditemukan. Anda akan melihatnya setelah mengonversi.</string>
       <key>other</key>
       <string>%d file telah ditemukan. Anda akan melihatnya setelah konversi.</string>
     </dict>

--- a/iphone/Maps/LocalizedStrings/vi.lproj/Localizable.stringsdict
+++ b/iphone/Maps/LocalizedStrings/vi.lproj/Localizable.stringsdict
@@ -34,8 +34,6 @@
       <string>NSStringPluralRuleType</string>
       <key>NSStringFormatValueTypeKey</key>
       <string>d</string>
-      <key>one</key>
-      <string>%d dã tìm thấy một tệp. Bạn sẽ thấy nó sau khi chuyển đổi.</string>
       <key>other</key>
       <string>%d tập tin đã được tìm thấy. Bạn sẽ thấy chúng sau khi chuyển đổi.</string>
     </dict>


### PR DESCRIPTION
Bith vi and id do not have plural forms, thus `:one` is not used. Technically we can drop `:other` but leaving it makes it clearer.

https://www.unicode.org/cldr/charts/45/supplemental/language_plural_rules.html#id
https://www.unicode.org/cldr/charts/45/supplemental/language_plural_rules.html#vi