### PR TITLE
Fix Map Generator Diffs

### DIFF
--- a/generator/mwm_diff/mwm_diff_tool/mwm_diff_tool.cpp
+++ b/generator/mwm_diff/mwm_diff_tool/mwm_diff_tool.cpp
@@ -5,28 +5,35 @@
 #include <iostream>
 #include <cstring>
 
+void usage(char* executable) {
+  std::cout <<
+    "Usage: " << executable << " { make | apply } OLD.mwm NEW.mwm DIFF.mwmdiff\n"
+    "make\n"
+    "  Writes the diff between `OLD.mwm` and `NEW.mwm` files to `DIFF.mwmdiff`\n"
+    "apply\n"
+    "  Applies the diff at `DIFF.mwmdiff` to `OLD.mwm` and stores result at `NEW.mwm`.\n"
+    "WARNING: THERE IS NO MWM VALIDITY CHECK!\n"
+    "WARNING: EXISTING FILES WILL BE OVERWRITTEN!\n";
+}
+
 int main(int argc, char ** argv)
 {
-  if (argc < 5)
+  if (argc != 5)
   {
-    std::cout <<
-        "Usage: " << argv[0] << " make|apply olderMWMDir newerMWMDir diffDir\n"
-        "make\n"
-        "  Creates the diff between newer and older MWM versions at `diffDir`\n"
-        "apply\n"
-        "  Applies the diff at `diffDir` to the mwm at `olderMWMDir` and stores result at `newerMWMDir`.\n"
-        "WARNING: THERE IS NO MWM VALIDITY CHECK!\n";
+    usage(argv[0]);
     return -1;
   }
-  char const * olderMWMDir{argv[2]}, * newerMWMDir{argv[3]}, * diffDir{argv[4]};
-  if (0 == std::strcmp(argv[1], "make"))
-    return generator::mwm_diff::MakeDiff(olderMWMDir, newerMWMDir, diffDir);
-
-  // apply
-  base::Cancellable cancellable;
-  auto const res = generator::mwm_diff::ApplyDiff(olderMWMDir, newerMWMDir, diffDir, cancellable);
-  if (res == generator::mwm_diff::DiffApplicationResult::Ok)
-    return 0;
+  char const * olderMWM{argv[2]}, * newerMWM{argv[3]}, * diffPath{argv[4]};
+  if (0 == std::strcmp(argv[1], "make")) {
+    return generator::mwm_diff::MakeDiff(olderMWM, newerMWM, diffPath);
+  } else if (0 == std::strcmp(argv[1], "apply")) {
+    base::Cancellable cancellable;
+    auto const res = generator::mwm_diff::ApplyDiff(olderMWM, newerMWM, diffPath, cancellable);
+    if (res == generator::mwm_diff::DiffApplicationResult::Ok)
+      return 0;
+  } else {
+    usage(argv[0]);
+  }
 
   return -1;  // Failed, Cancelled.
 }

--- a/generator/mwm_diff/mwm_diff_tool/mwm_diff_tool.cpp
+++ b/generator/mwm_diff/mwm_diff_tool/mwm_diff_tool.cpp
@@ -25,7 +25,8 @@ int main(int argc, char ** argv)
   }
   char const * olderMWM{argv[2]}, * newerMWM{argv[3]}, * diffPath{argv[4]};
   if (0 == std::strcmp(argv[1], "make")) {
-    return generator::mwm_diff::MakeDiff(olderMWM, newerMWM, diffPath);
+    if (generator::mwm_diff::MakeDiff(olderMWM, newerMWM, diffPath))
+      return 0;
   } else if (0 == std::strcmp(argv[1], "apply")) {
     base::Cancellable cancellable;
     auto const res = generator::mwm_diff::ApplyDiff(olderMWM, newerMWM, diffPath, cancellable);

--- a/storage/diff_scheme/diff_types.hpp
+++ b/storage/diff_scheme/diff_types.hpp
@@ -21,7 +21,9 @@ struct DiffInfo final
 {
   DiffInfo(uint64_t size, uint64_t version) : m_size(size), m_version(version) {}
 
+  // Diff file size in bytes.
   uint64_t m_size;
+  // Map version that diff must be applied to.
   uint64_t m_version;
   bool m_isApplied = false;
 };

--- a/storage/storage.cpp
+++ b/storage/storage.cpp
@@ -7,6 +7,7 @@
 #include "storage/map_files_downloader.hpp"
 #include "storage/storage_helpers.hpp"
 
+#include "platform/country_defines.hpp"
 #include "platform/downloader_utils.hpp"
 #include "platform/local_country_file_utils.hpp"
 #include "platform/mwm_version.hpp"
@@ -716,7 +717,8 @@ void Storage::OnDownloadFinished(QueuedCountry const & queuedCountry, DownloadSt
     OnFinishDownloading();
   };
 
-  if (status == DownloadStatus::Completed && m_integrityValidationEnabled)
+  // FIXME: can't verify diff w/ hash of complete file before applying - downloads diff in loop on error
+  if (status == DownloadStatus::Completed && m_integrityValidationEnabled && fileType != MapFileType::Diff)
   {
     /// @todo Can/Should be combined with ApplyDiff routine when we will restore it.
     /// While this is simple and working solution, I think that Downloader component

--- a/tools/python/maps_generator/generator/settings.py
+++ b/tools/python/maps_generator/generator/settings.py
@@ -235,11 +235,11 @@ def init(default_settings_path: AnyStr):
     global THREADS_COUNT_FEATURES_STAGE
     NEED_PLANET_UPDATE = cfg.get_opt("Stages", "NEED_PLANET_UPDATE", NEED_PLANET_UPDATE)
     DATA_ARCHIVE_DIR = cfg.get_opt_path(
-        "Generator tool", "DATA_ARCHIVE_DIR", DATA_ARCHIVE_DIR
+        "Stages", "DATA_ARCHIVE_DIR", DATA_ARCHIVE_DIR
     )
-    DIFF_VERSION_DEPTH = cfg.get_opt(
-        "Generator tool", "DIFF_VERSION_DEPTH", DIFF_VERSION_DEPTH
-    )
+    DIFF_VERSION_DEPTH = int(cfg.get_opt(
+        "Stages", "DIFF_VERSION_DEPTH", DIFF_VERSION_DEPTH
+    ))
 
     threads_count = int(
         cfg.get_opt(

--- a/tools/python/maps_generator/generator/stages_declaration.py
+++ b/tools/python/maps_generator/generator/stages_declaration.py
@@ -15,6 +15,7 @@ from collections import defaultdict
 from multiprocessing.pool import ThreadPool
 from typing import AnyStr
 from typing import Type
+from pathlib import Path
 
 import maps_generator.generator.diffs as diffs
 import maps_generator.generator.stages_tests as st
@@ -316,10 +317,13 @@ class StageRoutingTransit(Stage):
 @country_stage
 @production_only
 class StageMwmDiffs(Stage):
+    """Create diffs for old versions of a single country."""
     def apply(self, env: Env, country, logger, **kwargs):
+        # FIXME: not sure what these were supposed to be, but .mwm and mwm_version is required...
+        # FIXME: this uses the "live" maps directory layout for old versions, should it use maps_build instead?
         data_dir = diffs.DataDir(
-            mwm_name=env.build_name,
-            new_version_dir=env.build_path,
+            country_name=country,
+            new_version_dir=Path(env.build_path, env.mwm_version),
             old_version_root_dir=settings.DATA_ARCHIVE_DIR,
         )
         diffs.mwm_diff_calculation(data_dir, logger, depth=settings.DIFF_VERSION_DEPTH)

--- a/tools/python/maps_generator/var/etc/map_generator.ini.default
+++ b/tools/python/maps_generator/var/etc/map_generator.ini.default
@@ -88,6 +88,7 @@ NEED_BUILD_WORLD_ROADS: false
 # via an osmupdate tool before the generation. Not for use with partial planet extracts.
 NEED_PLANET_UPDATE: 0
 # If you want to calculate diffs you need to specify where the old maps are.
+# Expected layout is `{DATA_ARCHIVE_DIR}/[0-9]*/*.mwm`
 DATA_ARCHIVE_DIR: ${Generator tool:USER_RESOURCE_PATH}
 # How many versions in the archive to use for diff calculation:
 DIFF_VERSION_DEPTH: 2


### PR DESCRIPTION
This gets diff creation working with the generator again.

I've verified that the files work with the client by:
1. Building two versions of the same map/country with diffs enabled.
2. Copying the maps and diffs to a local fileserver with this structure:
    ```
    /
    ├── diffs
    │  └── 240603
    │     └── 231002
    │        └── Canada_Yukon_Whitehorse.mwmdiff
    └── maps
       ├── 231002
       │  ├── Canada_Yukon_Whitehorse.mwm
       │  └── countries.txt
       └── 240603
          ├── Canada_Yukon_Whitehorse.mwm
          └── countries.txt
    ```
3. Patching the desktop app to point to the local server and use the older `countries.txt`
4. Downloading the old map version.
5. Patching the desktop app to use the newer `countries.txt` and hard-coding `DiffsDataSource::SetDiffInfo` to contain the new diff.
6. Downloading the updated map.

The server and client logs both showed downloading only the `.mwmdiff` and applying it successfully. Through the app I verified that new map data was visible.

I had to make some changes that I wasn't sure about and labelled with `FIXME`, I'll comment on them in a review.

Related to: #2317