### PR TITLE
[ios] Allow location update when app is in background

### DIFF
--- a/iphone/Maps/Core/Location/MWMLocationManager.mm
+++ b/iphone/Maps/Core/Location/MWMLocationManager.mm
@@ -528,7 +528,7 @@ void setShowLocationAlert(BOOL needShow) {
 {
   auto app = UIApplication.sharedApplication;
   auto delegate = static_cast<MapsAppDelegate *>(app.delegate);
-  if (delegate.isDrapeEngineCreated && app.applicationState == UIApplicationStateActive)
+  if (delegate.isDrapeEngineCreated)
   {
     auto & f = GetFramework();
     if (self.frameworkUpdateMode & MWMLocationFrameworkUpdateLocation)

--- a/iphone/Maps/Core/Location/MWMLocationManager.mm
+++ b/iphone/Maps/Core/Location/MWMLocationManager.mm
@@ -179,7 +179,6 @@ void setShowLocationAlert(BOOL needShow) {
 + (void)applicationDidBecomeActive
 {
   [self start];
-  [[self manager] updateFrameworkInfo];
 }
 
 + (void)applicationWillResignActive
@@ -528,10 +527,8 @@ void setShowLocationAlert(BOOL needShow) {
 - (void)updateFrameworkInfo
 {
   auto app = UIApplication.sharedApplication;
-  if (app.applicationState != UIApplicationStateActive)
-    return;
   auto delegate = static_cast<MapsAppDelegate *>(app.delegate);
-  if (delegate.isDrapeEngineCreated)
+  if (delegate.isDrapeEngineCreated && app.applicationState == UIApplicationStateActive)
   {
     auto & f = GetFramework();
     if (self.frameworkUpdateMode & MWMLocationFrameworkUpdateLocation)


### PR DESCRIPTION
The app is configured to update the GPS location in the background but this information is not passed to the framework. 

With this commit the GPS location is passed to the framework even when the app is in background. This results in a higher battery usage if there is an active route but the battery usage will remain the same if no route is active because the GPS location is not updated.
    
Close #6940