### PR TITLE
Avoid unnecessary Locale copying in ToStringPrecisionLocale

### DIFF
--- a/map/routing_mark.cpp
+++ b/map/routing_mark.cpp
@@ -630,10 +630,11 @@ uint16_t RoadWarningMark::GetPriority() const
   {
     switch (m_type)
     {
-    case RoadWarningMarkType::Toll: return static_cast<uint16_t>(Priority::RoadWarningFirstToll);
-    case RoadWarningMarkType::Ferry: return static_cast<uint16_t>(Priority::RoadWarningFirstFerry);
-    case RoadWarningMarkType::Dirty: return static_cast<uint16_t>(Priority::RoadWarningFirstDirty);
-    case RoadWarningMarkType::Count: CHECK(false, ()); break;
+    using enum RoadWarningMarkType;
+    case Toll: return static_cast<uint16_t>(Priority::RoadWarningFirstToll);
+    case Ferry: return static_cast<uint16_t>(Priority::RoadWarningFirstFerry);
+    case Dirty: return static_cast<uint16_t>(Priority::RoadWarningFirstDirty);
+    case Count: CHECK(false, ()); break;
     }
   }
   return static_cast<uint16_t>(Priority::RoadWarning);
@@ -665,16 +666,17 @@ void RoadWarningMark::SetDistance(std::string const & distance)
 
 drape_ptr<df::UserPointMark::SymbolNameZoomInfo> RoadWarningMark::GetSymbolNames() const
 {
-  std::string symbolName;
+  std::string_view symbolName;
   switch (m_type)
   {
-  case RoadWarningMarkType::Toll: symbolName = "paid_road"; break;
-  case RoadWarningMarkType::Ferry: symbolName = "ferry"; break;
-  case RoadWarningMarkType::Dirty: symbolName = "unpaved_road"; break;
-  case RoadWarningMarkType::Count: CHECK(false, ()); break;
+  using enum RoadWarningMarkType;
+  case Toll: symbolName = "paid_road"; break;
+  case Ferry: symbolName = "ferry"; break;
+  case Dirty: symbolName = "unpaved_road"; break;
+  case Count: CHECK(false, ()); break;
   }
   auto symbol = make_unique_dp<SymbolNameZoomInfo>();
-  symbol->insert(std::make_pair(1 /* zoomLevel */, symbolName));
+  symbol->emplace(1 /* zoomLevel */, symbolName);
   return symbol;
 }
 
@@ -683,10 +685,11 @@ std::string RoadWarningMark::GetLocalizedRoadWarningType(RoadWarningMarkType typ
 {
   switch (type)
   {
-  case RoadWarningMarkType::Toll: return platform::GetLocalizedString("toll_road");
-  case RoadWarningMarkType::Ferry: return platform::GetLocalizedString("ferry_crossing");
-  case RoadWarningMarkType::Dirty: return platform::GetLocalizedString("unpaved_road");
-  case RoadWarningMarkType::Count: CHECK(false, ("Invalid road warning mark type", type)); break;
+  using enum RoadWarningMarkType;
+  case Toll: return platform::GetLocalizedString("toll_road");
+  case Ferry: return platform::GetLocalizedString("ferry_crossing");
+  case Dirty: return platform::GetLocalizedString("unpaved_road");
+  case Count: CHECK(false, ("Invalid road warning mark type", type)); break;
   }
   return {};
 }
@@ -695,10 +698,11 @@ std::string DebugPrint(RoadWarningMarkType type)
 {
   switch (type)
   {
-  case RoadWarningMarkType::Toll: return "Toll";
-  case RoadWarningMarkType::Ferry: return "Ferry";
-  case RoadWarningMarkType::Dirty: return "Dirty";
-  case RoadWarningMarkType::Count: return "Count";
+  using enum RoadWarningMarkType;
+  case Toll: return "Toll";
+  case Ferry: return "Ferry";
+  case Dirty: return "Dirty";
+  case Count: return "Count";
   }
   UNREACHABLE();
 }

--- a/platform/distance.cpp
+++ b/platform/distance.cpp
@@ -202,10 +202,10 @@ std::string DebugPrint(Distance::Units units)
 {
   switch (units)
   {
-  case Distance::Units::Meters: return "Distance::Units::Meters";
-  case Distance::Units::Kilometers: return "Distance::Units::Kilometers";
-  case Distance::Units::Feet: return "Distance::Units::Feet";
-  case Distance::Units::Miles: return "Distance::Units::Miles";
+  case Distance::Units::Meters: return "m";
+  case Distance::Units::Kilometers: return "km";
+  case Distance::Units::Feet: return "ft";
+  case Distance::Units::Miles: return "mi";
   default: UNREACHABLE();
   }
 }

--- a/platform/localization.cpp
+++ b/platform/localization.cpp
@@ -1,6 +1,5 @@
 #include "platform/localization.hpp"
 
-#include "platform/measurement_utils.hpp"
 #include "platform/settings.hpp"
 
 #include <string>
@@ -11,18 +10,18 @@ namespace
 {
 enum class MeasurementType
 {
-  Distance = 0,
+  Distance,
   Speed,
   Altitude
 };
 
 LocalizedUnits const & GetLocalizedUnits(measurement_utils::Units units, MeasurementType measurementType)
 {
-  static LocalizedUnits const UnitsLenghImperial = {GetLocalizedString("ft"), GetLocalizedString("mi")};
-  static LocalizedUnits const UnitsLenghMetric = {GetLocalizedString("m"), GetLocalizedString("km")};
+  static LocalizedUnits const lengthImperial = {GetLocalizedString("ft"), GetLocalizedString("mi")};
+  static LocalizedUnits const lengthMetric = {GetLocalizedString("m"), GetLocalizedString("km")};
 
-  static LocalizedUnits const UnitsSpeedImperial = {GetLocalizedString("ft"), GetLocalizedString("miles_per_hour")};
-  static LocalizedUnits const UnitsSpeedMetric = {GetLocalizedString("m"), GetLocalizedString("kilometers_per_hour")};
+  static LocalizedUnits const speedImperial = {GetLocalizedString("ft"), GetLocalizedString("miles_per_hour")};
+  static LocalizedUnits const speedMetric = {GetLocalizedString("m"), GetLocalizedString("kilometers_per_hour")};
 
   switch (measurementType)
   {
@@ -30,15 +29,15 @@ LocalizedUnits const & GetLocalizedUnits(measurement_utils::Units units, Measure
   case MeasurementType::Altitude:
     switch (units)
     {
-    case measurement_utils::Units::Imperial: return UnitsLenghImperial;
-    case measurement_utils::Units::Metric: return UnitsLenghMetric;
+    case measurement_utils::Units::Imperial: return lengthImperial;
+    case measurement_utils::Units::Metric: return lengthMetric;
     }
     break;
   case MeasurementType::Speed:
     switch (units)
     {
-    case measurement_utils::Units::Imperial: return UnitsSpeedImperial;
-    case measurement_utils::Units::Metric: return UnitsSpeedMetric;
+    case measurement_utils::Units::Imperial: return speedImperial;
+    case measurement_utils::Units::Metric: return speedMetric;
     }
   }
   UNREACHABLE();

--- a/platform/localization.cpp
+++ b/platform/localization.cpp
@@ -16,7 +16,7 @@ enum class MeasurementType
   Altitude
 };
 
-const LocalizedUnits & GetLocalizedUnits(measurement_utils::Units units, MeasurementType measurementType)
+LocalizedUnits const & GetLocalizedUnits(measurement_utils::Units units, MeasurementType measurementType)
 {
   static LocalizedUnits const UnitsLenghImperial = {GetLocalizedString("ft"), GetLocalizedString("mi")};
   static LocalizedUnits const UnitsLenghMetric = {GetLocalizedString("m"), GetLocalizedString("km")};
@@ -45,12 +45,12 @@ const LocalizedUnits & GetLocalizedUnits(measurement_utils::Units units, Measure
 }
 }  // namespace
 
-LocalizedUnits GetLocalizedDistanceUnits()
+LocalizedUnits const & GetLocalizedDistanceUnits()
 {
   return GetLocalizedUnits(measurement_utils::GetMeasurementUnits(), MeasurementType::Distance);
 }
 
-LocalizedUnits GetLocalizedAltitudeUnits()
+LocalizedUnits const & GetLocalizedAltitudeUnits()
 {
   return GetLocalizedUnits(measurement_utils::GetMeasurementUnits(), MeasurementType::Altitude);
 }
@@ -60,7 +60,7 @@ const std::string & GetLocalizedSpeedUnits(measurement_utils::Units units)
   return GetLocalizedUnits(units, MeasurementType::Speed).m_high;
 }
 
-std::string GetLocalizedSpeedUnits()
+std::string const & GetLocalizedSpeedUnits()
 {
   return GetLocalizedSpeedUnits(measurement_utils::GetMeasurementUnits());
 }

--- a/platform/localization.cpp
+++ b/platform/localization.cpp
@@ -18,11 +18,11 @@ enum class MeasurementType
 
 const LocalizedUnits & GetLocalizedUnits(measurement_utils::Units units, MeasurementType measurementType)
 {
-  static LocalizedUnits UnitsLenghImperial = {GetLocalizedString("ft"), GetLocalizedString("mi")};
-  static LocalizedUnits UnitsLenghMetric = {GetLocalizedString("m"), GetLocalizedString("km")};
+  static LocalizedUnits const UnitsLenghImperial = {GetLocalizedString("ft"), GetLocalizedString("mi")};
+  static LocalizedUnits const UnitsLenghMetric = {GetLocalizedString("m"), GetLocalizedString("km")};
 
-  static LocalizedUnits UnitsSpeedImperial = {GetLocalizedString("ft"), GetLocalizedString("miles_per_hour")};
-  static LocalizedUnits UnitsSpeedMetric = {GetLocalizedString("m"), GetLocalizedString("kilometers_per_hour")};
+  static LocalizedUnits const UnitsSpeedImperial = {GetLocalizedString("ft"), GetLocalizedString("miles_per_hour")};
+  static LocalizedUnits const UnitsSpeedMetric = {GetLocalizedString("m"), GetLocalizedString("kilometers_per_hour")};
 
   switch (measurementType)
   {

--- a/platform/localization.hpp
+++ b/platform/localization.hpp
@@ -2,10 +2,7 @@
 
 #include <string>
 
-namespace measurement_utils
-{
-enum class Units;
-}
+#include "platform/measurement_utils.hpp"
 
 namespace platform
 {

--- a/platform/localization.hpp
+++ b/platform/localization.hpp
@@ -21,9 +21,9 @@ extern std::string GetLocalizedString(std::string const & key);
 extern std::string GetCurrencySymbol(std::string const & currencyCode);
 extern std::string GetLocalizedMyPositionBookmarkName();
 
-extern LocalizedUnits GetLocalizedDistanceUnits();
-extern LocalizedUnits GetLocalizedAltitudeUnits();
+extern LocalizedUnits const & GetLocalizedDistanceUnits();
+extern LocalizedUnits const & GetLocalizedAltitudeUnits();
 
-extern const std::string & GetLocalizedSpeedUnits(measurement_utils::Units units);
-extern std::string GetLocalizedSpeedUnits();
+extern std::string const & GetLocalizedSpeedUnits(measurement_utils::Units units);
+extern std::string const & GetLocalizedSpeedUnits();
 }  // namespace platform

--- a/platform/measurement_utils.cpp
+++ b/platform/measurement_utils.cpp
@@ -8,7 +8,6 @@
 #include "base/bits.hpp"
 #include "base/macros.hpp"
 #include "base/math.hpp"
-#include "base/stl_helpers.hpp"
 #include "base/string_utils.hpp"
 
 #include <cmath>
@@ -18,24 +17,19 @@
 
 namespace measurement_utils
 {
-using namespace platform;
-using namespace settings;
-using namespace std;
-using namespace strings;
-
-string ToStringPrecision(double d, int pr)
+std::string ToStringPrecision(double d, int pr)
 {
   // We assume that the app will be restarted if a user changes device's locale.
-  static Locale const loc = GetCurrentLocale();
+  static auto const locale = platform::GetCurrentLocale();
 
-  return ToStringPrecisionLocale(loc, d, pr);
+  return ToStringPrecisionLocale(locale, d, pr);
 }
 
 std::string ToStringPrecisionLocale(platform::Locale const & loc, double d, int pr)
 {
   // TODO(AB): Check if snprintf is faster.
   std::ostringstream ss;
-  ss << std::setprecision(pr) << fixed << d;
+  ss << std::setprecision(pr) << std::fixed << d;
   std::string out = ss.str();
 
   // std::locale does not work on Android NDK, so decimal and grouping (thousands) separator
@@ -71,7 +65,7 @@ std::string_view DebugPrint(Units units)
 
 Units GetMeasurementUnits()
 {
-  Units units = measurement_utils::Units::Metric;
+  Units units = Units::Metric;
   settings::TryGet(settings::kMeasurementUnits, units);
   return units;
 }
@@ -86,32 +80,32 @@ double ToSpeedKmPH(double speed, Units units)
   UNREACHABLE();
 }
 
-string FormatLatLonAsDMSImpl(double value, char positive, char negative, int dac)
+std::string FormatLatLonAsDMSImpl(double value, char positive, char negative, int dac)
 {
   using namespace base;
 
-  ostringstream sstream;
-  sstream << setfill('0');
+  std::ostringstream sstream;
+  sstream << std::setfill('0');
 
   // Degrees
   double i;
-  double d = modf(fabs(value), &i);
-  sstream << setw(2) << i << "°";
+  double d = std::modf(std::fabs(value), &i);
+  sstream << std::setw(2) << i << "°";
 
   // Minutes
-  d = modf(d * 60.0, &i);
-  sstream << setw(2) << i << "′";
+  d = std::modf(d * 60.0, &i);
+  sstream << std::setw(2) << i << "′";
 
   // Seconds
   d = d * 60.0;
   if (dac == 0)
     d = SignedRound(d);
 
-  d = modf(d, &i);
-  sstream << setw(2) << i;
+  d = std::modf(d, &i);
+  sstream << std::setw(2) << i;
 
   if (dac > 0)
-    sstream << to_string_dac(d, dac).substr(1);
+    sstream << strings::to_string_dac(d, dac).substr(1);
 
   sstream << "″";
 
@@ -129,55 +123,55 @@ string FormatLatLonAsDMSImpl(double value, char positive, char negative, int dac
   return sstream.str();
 }
 
-string FormatLatLonAsDMS(double lat, double lon, bool withComma, int dac)
+std::string FormatLatLonAsDMS(double lat, double lon, bool withComma, int dac)
 {
   return (FormatLatLonAsDMSImpl(lat, 'N', 'S', dac) + (withComma ? ", " : " ") +
           FormatLatLonAsDMSImpl(lon, 'E', 'W', dac));
 }
 
-void FormatLatLonAsDMS(double lat, double lon, string & latText, string & lonText, int dac)
+void FormatLatLonAsDMS(double lat, double lon, std::string & latText, std::string & lonText, int dac)
 {
   latText = FormatLatLonAsDMSImpl(lat, 'N', 'S', dac);
   lonText = FormatLatLonAsDMSImpl(lon, 'E', 'W', dac);
 }
 
-void FormatMercatorAsDMS(m2::PointD const & mercator, string & lat, string & lon, int dac)
+void FormatMercatorAsDMS(m2::PointD const & mercator, std::string & lat, std::string & lon, int dac)
 {
   lat = FormatLatLonAsDMSImpl(mercator::YToLat(mercator.y), 'N', 'S', dac);
   lon = FormatLatLonAsDMSImpl(mercator::XToLon(mercator.x), 'E', 'W', dac);
 }
 
-string FormatMercatorAsDMS(m2::PointD const & mercator, int dac)
+std::string FormatMercatorAsDMS(m2::PointD const & mercator, int dac)
 {
   return FormatLatLonAsDMS(mercator::YToLat(mercator.y), mercator::XToLon(mercator.x), dac);
 }
 
 // @TODO take into account decimal points or commas as separators in different locales
-string FormatLatLon(double lat, double lon, int dac)
+std::string FormatLatLon(double lat, double lon, int dac)
 {
-  return to_string_dac(lat, dac) + " " + to_string_dac(lon, dac);
+  return strings::to_string_dac(lat, dac) + " " + strings::to_string_dac(lon, dac);
 }
 
-string FormatLatLon(double lat, double lon, bool withComma, int dac)
+std::string FormatLatLon(double lat, double lon, bool withComma, int dac)
 {
-  return to_string_dac(lat, dac) + (withComma ? ", " : " ") + to_string_dac(lon, dac);
+  return strings::to_string_dac(lat, dac) + (withComma ? ", " : " ") + strings::to_string_dac(lon, dac);
 }
 
-void FormatLatLon(double lat, double lon, string & latText, string & lonText, int dac)
+void FormatLatLon(double lat, double lon, std::string & latText, std::string & lonText, int dac)
 {
-  latText = to_string_dac(lat, dac);
-  lonText = to_string_dac(lon, dac);
+  latText = strings::to_string_dac(lat, dac);
+  lonText = strings::to_string_dac(lon, dac);
 }
 
-string FormatMercator(m2::PointD const & mercator, int dac)
+std::string FormatMercator(m2::PointD const & mercator, int dac)
 {
   return FormatLatLon(mercator::YToLat(mercator.y), mercator::XToLon(mercator.x), dac);
 }
 
-void FormatMercator(m2::PointD const & mercator, string & lat, string & lon, int dac)
+void FormatMercator(m2::PointD const & mercator, std::string & lat, std::string & lon, int dac)
 {
-  lat = to_string_dac(mercator::YToLat(mercator.y), dac);
-  lon = to_string_dac(mercator::XToLon(mercator.x), dac);
+  lat = strings::to_string_dac(mercator::YToLat(mercator.y), dac);
+  lon = strings::to_string_dac(mercator::XToLon(mercator.x), dac);
 }
 
 double MpsToUnits(double metersPerSecond, Units units)
@@ -190,13 +184,13 @@ double MpsToUnits(double metersPerSecond, Units units)
   UNREACHABLE();
 }
 
-string FormatSpeedNumeric(double metersPerSecond, Units units)
+std::string FormatSpeedNumeric(double metersPerSecond, Units units)
 {
   double const unitsPerHour = MpsToUnits(metersPerSecond, units);
   return ToStringPrecision(unitsPerHour, unitsPerHour >= 10.0 ? 0 : 1);
 }
 
-string FormatOsmLink(double lat, double lon, int zoom)
+std::string FormatOsmLink(double lat, double lon, int zoom)
 {
   static constexpr char chars[] = "ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789_~";
 
@@ -205,7 +199,7 @@ string FormatOsmLink(double lat, double lon, int zoom)
   uint32_t const x = round((lon + 180.0) * factor);
   uint32_t const y = round((lat + 90.0) * factor * 2.0);
   uint64_t const code = bits::BitwiseMerge(y, x);
-  string osmUrl = "https://osm.org/go/";
+  std::string osmUrl = "https://osm.org/go/";
 
   for (int i = 0; i < (zoom + 10) / 3; ++i)
   {
@@ -220,7 +214,7 @@ string FormatOsmLink(double lat, double lon, int zoom)
   return osmUrl + "?m";
 }
 
-bool OSMDistanceToMeters(string const & osmRawValue, double & outMeters)
+bool OSMDistanceToMeters(std::string const & osmRawValue, double & outMeters)
 {
   using strings::is_finite;
 
@@ -248,9 +242,9 @@ bool OSMDistanceToMeters(string const & osmRawValue, double & outMeters)
       double const inches = strtod(s, &stop);
       if (s != stop && *stop == '"' && is_finite(inches))
         outMeters += InchesToMeters(inches);
+
       return true;
     }
-    break;
 
   // Inches.
   case '"': outMeters = InchesToMeters(outMeters); return true;
@@ -289,9 +283,9 @@ bool OSMDistanceToMeters(string const & osmRawValue, double & outMeters)
   return true;
 }
 
-string OSMDistanceToMetersString(string const & osmRawValue,
-                                 bool supportZeroAndNegativeValues,
-                                 int digitsAfterComma)
+std::string OSMDistanceToMetersString(std::string const & osmRawValue,
+                                      bool supportZeroAndNegativeValues,
+                                      int digitsAfterComma)
 {
   double meters;
   if (OSMDistanceToMeters(osmRawValue, meters))

--- a/platform/measurement_utils.cpp
+++ b/platform/measurement_utils.cpp
@@ -31,11 +31,12 @@ string ToStringPrecision(double d, int pr)
   return ToStringPrecisionLocale(loc, d, pr);
 }
 
-string ToStringPrecisionLocale(Locale loc, double d, int pr)
+std::string ToStringPrecisionLocale(platform::Locale const & loc, double d, int pr)
 {
-  stringstream ss;
-  ss << setprecision(pr) << fixed << d;
-  string out = ss.str();
+  // TODO(AB): Check if snprintf is faster.
+  std::ostringstream ss;
+  ss << std::setprecision(pr) << fixed << d;
+  std::string out = ss.str();
 
   // std::locale does not work on Android NDK, so decimal and grouping (thousands) separator
   // shall be customized manually here.
@@ -50,7 +51,7 @@ string ToStringPrecisionLocale(Locale loc, double d, int pr)
   {
     // Value with no decimals. Check if it's equal or bigger than 10000 to
     // insert the grouping (thousands) separator characters.
-    if (out.size() > 4 && !loc.m_groupingSeparator.empty())
+    if (!loc.m_groupingSeparator.empty())
       for (long pos = static_cast<long>(out.size()) - 3; pos > 0; pos -= 3)
         out.insert(pos, loc.m_groupingSeparator);
   }
@@ -58,7 +59,7 @@ string ToStringPrecisionLocale(Locale loc, double d, int pr)
   return out;
 }
 
-std::string DebugPrint(Units units)
+std::string_view DebugPrint(Units units)
 {
   switch (units)
   {

--- a/platform/measurement_utils.cpp
+++ b/platform/measurement_utils.cpp
@@ -45,7 +45,7 @@ std::string ToStringPrecisionLocale(platform::Locale const & loc, double d, int 
   {
     // Value with no decimals. Check if it's equal or bigger than 10000 to
     // insert the grouping (thousands) separator characters.
-    if (!loc.m_groupingSeparator.empty())
+    if (out.size() > 4 && !loc.m_groupingSeparator.empty())
       for (long pos = static_cast<long>(out.size()) - 3; pos > 0; pos -= 3)
         out.insert(pos, loc.m_groupingSeparator);
   }

--- a/platform/measurement_utils.hpp
+++ b/platform/measurement_utils.hpp
@@ -13,7 +13,7 @@ enum class Units
   Imperial = 1
 };
 
-std::string DebugPrint(Units units);
+std::string_view DebugPrint(Units units);
 
 Units GetMeasurementUnits();
 
@@ -64,5 +64,5 @@ std::string OSMDistanceToMetersString(std::string const & osmRawValue,
                                       bool supportZeroAndNegativeValues = true,
                                       int digitsAfterComma = 2);
 std::string ToStringPrecision(double d, int pr);
-std::string ToStringPrecisionLocale(platform::Locale loc, double d, int pr);
+std::string ToStringPrecisionLocale(platform::Locale const & locale, double d, int pr);
 }  // namespace measurement_utils

--- a/platform/platform_tests/distance_tests.cpp
+++ b/platform/platform_tests/distance_tests.cpp
@@ -105,8 +105,6 @@ UNIT_TEST(Distance_IsHighUnits)
 
 UNIT_TEST(Distance_To)
 {
-  using Units = Distance::Units;
-
   struct TestData
   {
     double initialDistance;
@@ -116,47 +114,48 @@ UNIT_TEST(Distance_To)
     Distance::Units newUnits;
   };
 
+  using enum Distance::Units;
   // clang-format off
   TestData constexpr testData[] = {
-    {0.1,       Units::Meters,     Units::Feet,       0,    Units::Feet},
-    {0.3,       Units::Meters,     Units::Feet,       1,    Units::Feet},
-    {0.3048,    Units::Meters,     Units::Feet,       1,    Units::Feet},
-    {0.4573,    Units::Meters,     Units::Feet,       2,    Units::Feet},
-    {0.9,       Units::Meters,     Units::Feet,       3,    Units::Feet},
-    {3,         Units::Meters,     Units::Feet,       10,   Units::Feet},
-    {30.17,     Units::Meters,     Units::Feet,       99,   Units::Feet},
-    {30.33,     Units::Meters,     Units::Feet,       100,  Units::Feet},
-    {30.49,     Units::Meters,     Units::Feet,       100,  Units::Feet},
-    {33.5,      Units::Meters,     Units::Feet,       110,  Units::Feet},
-    {302,       Units::Meters,     Units::Feet,       990,  Units::Feet},
-    {304.7,     Units::Meters,     Units::Feet,       0.2,  Units::Miles},
-    {304.8,     Units::Meters,     Units::Feet,       0.2,  Units::Miles},
-    {402.3,     Units::Meters,     Units::Feet,       0.2,  Units::Miles},
-    {402.4,     Units::Meters,     Units::Feet,       0.3,  Units::Miles},
-    {482.8,     Units::Meters,     Units::Feet,       0.3,  Units::Miles},
-    {1609.3,    Units::Meters,     Units::Feet,       1.0,  Units::Miles},
-    {1610,      Units::Meters,     Units::Feet,       1.0,  Units::Miles},
-    {1770,      Units::Meters,     Units::Feet,       1.1,  Units::Miles},
-    {15933,     Units::Meters,     Units::Feet,       9.9,  Units::Miles},
-    {16093,     Units::Meters,     Units::Feet,       10,   Units::Miles},
-    {16093.5,   Units::Meters,     Units::Feet,       10,   Units::Miles},
-    {16898.464, Units::Meters,     Units::Feet,       11,   Units::Miles},
-    {16898.113, Units::Meters,     Units::Kilometers, 17,   Units::Kilometers},
-    {302,       Units::Meters,     Units::Miles,      990,  Units::Feet},
-    {994,       Units::Meters,     Units::Kilometers, 990,  Units::Meters},
-    {995,       Units::Meters,     Units::Kilometers, 1.0,  Units::Kilometers},
-    {0.1,       Units::Kilometers, Units::Meters,     100,  Units::Meters},
-    {0.3,       Units::Kilometers, Units::Kilometers, 300,  Units::Meters},
-    {12,        Units::Kilometers, Units::Feet,       7.5,  Units::Miles},
-    {0.1,       Units::Kilometers, Units::Feet,       330,  Units::Feet},
-    {110,       Units::Feet,       Units::Meters,     34,   Units::Meters},
-    {1100,      Units::Feet,       Units::Kilometers, 340,  Units::Meters},
-    {1100,      Units::Feet,       Units::Meters,     340,  Units::Meters},
-    {1100,      Units::Feet,       Units::Miles,      0.2,  Units::Miles},
-    {0.2,       Units::Miles,      Units::Meters,     320,  Units::Meters},
-    {11,        Units::Miles,      Units::Meters,     18,   Units::Kilometers},
-    {11,        Units::Miles,      Units::Kilometers, 18,   Units::Kilometers},
-    {0.1,       Units::Miles,      Units::Feet,       530,  Units::Feet},
+    {0.1,       Meters,     Feet,       0,    Feet},
+    {0.3,       Meters,     Feet,       1,    Feet},
+    {0.3048,    Meters,     Feet,       1,    Feet},
+    {0.4573,    Meters,     Feet,       2,    Feet},
+    {0.9,       Meters,     Feet,       3,    Feet},
+    {3,         Meters,     Feet,       10,   Feet},
+    {30.17,     Meters,     Feet,       99,   Feet},
+    {30.33,     Meters,     Feet,       100,  Feet},
+    {30.49,     Meters,     Feet,       100,  Feet},
+    {33.5,      Meters,     Feet,       110,  Feet},
+    {302,       Meters,     Feet,       990,  Feet},
+    {304.7,     Meters,     Feet,       0.2,  Miles},
+    {304.8,     Meters,     Feet,       0.2,  Miles},
+    {402.3,     Meters,     Feet,       0.2,  Miles},
+    {402.4,     Meters,     Feet,       0.3,  Miles},
+    {482.8,     Meters,     Feet,       0.3,  Miles},
+    {1609.3,    Meters,     Feet,       1.0,  Miles},
+    {1610,      Meters,     Feet,       1.0,  Miles},
+    {1770,      Meters,     Feet,       1.1,  Miles},
+    {15933,     Meters,     Feet,       9.9,  Miles},
+    {16093,     Meters,     Feet,       10,   Miles},
+    {16093.5,   Meters,     Feet,       10,   Miles},
+    {16898.464, Meters,     Feet,       11,   Miles},
+    {16898.113, Meters,     Kilometers, 17,   Kilometers},
+    {302,       Meters,     Miles,      990,  Feet},
+    {994,       Meters,     Kilometers, 990,  Meters},
+    {995,       Meters,     Kilometers, 1.0,  Kilometers},
+    {0.1,       Kilometers, Meters,     100,  Meters},
+    {0.3,       Kilometers, Kilometers, 300,  Meters},
+    {12,        Kilometers, Feet,       7.5,  Miles},
+    {0.1,       Kilometers, Feet,       330,  Feet},
+    {110,       Feet,       Meters,     34,   Meters},
+    {1100,      Feet,       Kilometers, 340,  Meters},
+    {1100,      Feet,       Meters,     340,  Meters},
+    {1100,      Feet,       Miles,      0.2,  Miles},
+    {0.2,       Miles,      Meters,     320,  Meters},
+    {11,        Miles,      Meters,     18,   Kilometers},
+    {11,        Miles,      Kilometers, 18,   Kilometers},
+    {0.1,       Miles,      Feet,       530,  Feet},
   };
 
   // clang-format on
@@ -231,126 +230,125 @@ UNIT_TEST(Distance_GetUnitsString)
 
 UNIT_TEST(Distance_FormattedDistance)
 {
-  using Units = Distance::Units;
-
   struct TestData
   {
     Distance distance;
     double formattedDistance;
-    Units formattedUnits;
+    Distance::Units formattedUnits;
     std::string formattedDistanceString;
     std::string formattedString;
   };
 
+  using enum Distance::Units;
   // clang-format off
   TestData const testData[] = {
     // From Meters to Meters
-    {Distance(0,       Units::Meters),     0,     Units::Meters,     "0",      MakeDistanceStr("0", "m")},
-    {Distance(0.3,     Units::Meters),     0,     Units::Meters,     "0",      MakeDistanceStr("0", "m")},
-    {Distance(0.9,     Units::Meters),     1,     Units::Meters,     "1",      MakeDistanceStr("1", "m")},
-    {Distance(1,       Units::Meters),     1,     Units::Meters,     "1",      MakeDistanceStr("1", "m")},
-    {Distance(1.234,   Units::Meters),     1,     Units::Meters,     "1",      MakeDistanceStr("1", "m")},
-    {Distance(9.99,    Units::Meters),     10,    Units::Meters,     "10",     MakeDistanceStr("10", "m")},
-    {Distance(10.01,   Units::Meters),     10,    Units::Meters,     "10",     MakeDistanceStr("10", "m")},
-    {Distance(10.4,    Units::Meters),     10,    Units::Meters,     "10",     MakeDistanceStr("10", "m")},
-    {Distance(10.5,    Units::Meters),     11,    Units::Meters,     "11",     MakeDistanceStr("11", "m")},
-    {Distance(10.51,   Units::Meters),     11,    Units::Meters,     "11",     MakeDistanceStr("11", "m")},
-    {Distance(64.2,    Units::Meters),     64,    Units::Meters,     "64",     MakeDistanceStr("64", "m")},
-    {Distance(99,      Units::Meters),     99,    Units::Meters,     "99",     MakeDistanceStr("99", "m")},
-    {Distance(100,     Units::Meters),     100,   Units::Meters,     "100",    MakeDistanceStr("100", "m")},
-    {Distance(101,     Units::Meters),     100,   Units::Meters,     "100",    MakeDistanceStr("100", "m")},
-    {Distance(109,     Units::Meters),     110,   Units::Meters,     "110",    MakeDistanceStr("110", "m")},
-    {Distance(991,     Units::Meters),     990,   Units::Meters,     "990",    MakeDistanceStr("990", "m")},
+    {Distance(0,       Meters),     0,     Meters,     "0",      MakeDistanceStr("0", "m")},
+    {Distance(0.3,     Meters),     0,     Meters,     "0",      MakeDistanceStr("0", "m")},
+    {Distance(0.9,     Meters),     1,     Meters,     "1",      MakeDistanceStr("1", "m")},
+    {Distance(1,       Meters),     1,     Meters,     "1",      MakeDistanceStr("1", "m")},
+    {Distance(1.234,   Meters),     1,     Meters,     "1",      MakeDistanceStr("1", "m")},
+    {Distance(9.99,    Meters),     10,    Meters,     "10",     MakeDistanceStr("10", "m")},
+    {Distance(10.01,   Meters),     10,    Meters,     "10",     MakeDistanceStr("10", "m")},
+    {Distance(10.4,    Meters),     10,    Meters,     "10",     MakeDistanceStr("10", "m")},
+    {Distance(10.5,    Meters),     11,    Meters,     "11",     MakeDistanceStr("11", "m")},
+    {Distance(10.51,   Meters),     11,    Meters,     "11",     MakeDistanceStr("11", "m")},
+    {Distance(64.2,    Meters),     64,    Meters,     "64",     MakeDistanceStr("64", "m")},
+    {Distance(99,      Meters),     99,    Meters,     "99",     MakeDistanceStr("99", "m")},
+    {Distance(100,     Meters),     100,   Meters,     "100",    MakeDistanceStr("100", "m")},
+    {Distance(101,     Meters),     100,   Meters,     "100",    MakeDistanceStr("100", "m")},
+    {Distance(109,     Meters),     110,   Meters,     "110",    MakeDistanceStr("110", "m")},
+    {Distance(991,     Meters),     990,   Meters,     "990",    MakeDistanceStr("990", "m")},
 
     // From Kilometers to Kilometers
-    {Distance(0,       Units::Kilometers), 0,     Units::Meters,     "0",      MakeDistanceStr("0", "m")},
-    {Distance(0.3,     Units::Kilometers), 300,   Units::Meters,     "300",    MakeDistanceStr("300", "m")},
-    {Distance(1.234,   Units::Kilometers), 1.2,   Units::Kilometers, "1.2",    MakeDistanceStr("1.2", "km")},
-    {Distance(10,      Units::Kilometers), 10,    Units::Kilometers, "10",     MakeDistanceStr("10", "km")},
-    {Distance(11,      Units::Kilometers), 11,    Units::Kilometers, "11",     MakeDistanceStr("11", "km")},
-    {Distance(54,      Units::Kilometers), 54,    Units::Kilometers, "54",     MakeDistanceStr("54", "km")},
-    {Distance(99.99,   Units::Kilometers), 100,   Units::Kilometers, "100",    MakeDistanceStr("100", "km")},
-    {Distance(100.01,  Units::Kilometers), 100,   Units::Kilometers, "100",    MakeDistanceStr("100", "km")},
-    {Distance(115,     Units::Kilometers), 115,   Units::Kilometers, "115",    MakeDistanceStr("115", "km")},
-    {Distance(999,     Units::Kilometers), 999,   Units::Kilometers, "999",    MakeDistanceStr("999", "km")},
-    {Distance(1000,    Units::Kilometers), 1000,  Units::Kilometers, "1000",   MakeDistanceStr("1000", "km")},
-    {Distance(1049.99, Units::Kilometers), 1050,  Units::Kilometers, "1050",   MakeDistanceStr("1050", "km")},
-    {Distance(1050,    Units::Kilometers), 1050,  Units::Kilometers, "1050",   MakeDistanceStr("1050", "km")},
-    {Distance(1050.01, Units::Kilometers), 1050,  Units::Kilometers, "1050",   MakeDistanceStr("1050", "km")},
-    {Distance(1234,    Units::Kilometers), 1234,  Units::Kilometers, "1234",   MakeDistanceStr("1234", "km")},
-    {Distance(12345,   Units::Kilometers), 12345, Units::Kilometers, "12,345", MakeDistanceStr("12,345", "km")},
+    {Distance(0,       Kilometers), 0,     Meters,     "0",      MakeDistanceStr("0", "m")},
+    {Distance(0.3,     Kilometers), 300,   Meters,     "300",    MakeDistanceStr("300", "m")},
+    {Distance(1.234,   Kilometers), 1.2,   Kilometers, "1.2",    MakeDistanceStr("1.2", "km")},
+    {Distance(10,      Kilometers), 10,    Kilometers, "10",     MakeDistanceStr("10", "km")},
+    {Distance(11,      Kilometers), 11,    Kilometers, "11",     MakeDistanceStr("11", "km")},
+    {Distance(54,      Kilometers), 54,    Kilometers, "54",     MakeDistanceStr("54", "km")},
+    {Distance(99.99,   Kilometers), 100,   Kilometers, "100",    MakeDistanceStr("100", "km")},
+    {Distance(100.01,  Kilometers), 100,   Kilometers, "100",    MakeDistanceStr("100", "km")},
+    {Distance(115,     Kilometers), 115,   Kilometers, "115",    MakeDistanceStr("115", "km")},
+    {Distance(999,     Kilometers), 999,   Kilometers, "999",    MakeDistanceStr("999", "km")},
+    {Distance(1000,    Kilometers), 1000,  Kilometers, "1000",   MakeDistanceStr("1000", "km")},
+    {Distance(1049.99, Kilometers), 1050,  Kilometers, "1050",   MakeDistanceStr("1050", "km")},
+    {Distance(1050,    Kilometers), 1050,  Kilometers, "1050",   MakeDistanceStr("1050", "km")},
+    {Distance(1050.01, Kilometers), 1050,  Kilometers, "1050",   MakeDistanceStr("1050", "km")},
+    {Distance(1234,    Kilometers), 1234,  Kilometers, "1234",   MakeDistanceStr("1234", "km")},
+    {Distance(12345,   Kilometers), 12345, Kilometers, "12,345", MakeDistanceStr("12,345", "km")},
 
     // From Feet to Feet
-    {Distance(0,       Units::Feet),       0,     Units::Feet,       "0",      MakeDistanceStr("0", "ft")},
-    {Distance(1,       Units::Feet),       1,     Units::Feet,       "1",      MakeDistanceStr("1", "ft")},
-    {Distance(9.99,    Units::Feet),       10,    Units::Feet,       "10",     MakeDistanceStr("10", "ft")},
-    {Distance(10.01,   Units::Feet),       10,    Units::Feet,       "10",     MakeDistanceStr("10", "ft")},
-    {Distance(95,      Units::Feet),       95,    Units::Feet,       "95",     MakeDistanceStr("95", "ft")},
-    {Distance(125,     Units::Feet),       130,   Units::Feet,       "130",    MakeDistanceStr("130", "ft")},
-    {Distance(991,     Units::Feet),       990,   Units::Feet,       "990",    MakeDistanceStr("990", "ft")},
+    {Distance(0,       Feet),       0,     Feet,       "0",      MakeDistanceStr("0", "ft")},
+    {Distance(1,       Feet),       1,     Feet,       "1",      MakeDistanceStr("1", "ft")},
+    {Distance(9.99,    Feet),       10,    Feet,       "10",     MakeDistanceStr("10", "ft")},
+    {Distance(10.01,   Feet),       10,    Feet,       "10",     MakeDistanceStr("10", "ft")},
+    {Distance(95,      Feet),       95,    Feet,       "95",     MakeDistanceStr("95", "ft")},
+    {Distance(125,     Feet),       130,   Feet,       "130",    MakeDistanceStr("130", "ft")},
+    {Distance(991,     Feet),       990,   Feet,       "990",    MakeDistanceStr("990", "ft")},
 
     // From Miles to Miles
-    {Distance(0,       Units::Miles),      0,     Units::Feet,       "0",      MakeDistanceStr("0", "ft")},
-    {Distance(0.1,     Units::Miles),      530,   Units::Feet,       "530",    MakeDistanceStr("530", "ft")},
-    {Distance(1,       Units::Miles),      1.0,   Units::Miles,      "1.0",    MakeDistanceStr("1.0", "mi")},
-    {Distance(1.234,   Units::Miles),      1.2,   Units::Miles,      "1.2",    MakeDistanceStr("1.2", "mi")},
-    {Distance(9.99,    Units::Miles),      10,    Units::Miles,      "10",     MakeDistanceStr("10", "mi")},
-    {Distance(10.01,   Units::Miles),      10,    Units::Miles,      "10",     MakeDistanceStr("10", "mi")},
-    {Distance(11,      Units::Miles),      11,    Units::Miles,      "11",     MakeDistanceStr("11", "mi")},
-    {Distance(54,      Units::Miles),      54,    Units::Miles,      "54",     MakeDistanceStr("54", "mi")},
-    {Distance(145,     Units::Miles),      145,   Units::Miles,      "145",    MakeDistanceStr("145", "mi")},
-    {Distance(999,     Units::Miles),      999,   Units::Miles,      "999",    MakeDistanceStr("999", "mi")},
-    {Distance(1149.99, Units::Miles),      1150,  Units::Miles,      "1150",   MakeDistanceStr("1150", "mi")},
-    {Distance(1150,    Units::Miles),      1150,  Units::Miles,      "1150",   MakeDistanceStr("1150", "mi")},
-    {Distance(1150.01, Units::Miles),      1150,  Units::Miles,      "1150",   MakeDistanceStr("1150", "mi")},
-    {Distance(12345.0, Units::Miles),      12345, Units::Miles,      "12,345", MakeDistanceStr("12,345", "mi")},
+    {Distance(0,       Miles),      0,     Feet,       "0",      MakeDistanceStr("0", "ft")},
+    {Distance(0.1,     Miles),      530,   Feet,       "530",    MakeDistanceStr("530", "ft")},
+    {Distance(1,       Miles),      1.0,   Miles,      "1.0",    MakeDistanceStr("1.0", "mi")},
+    {Distance(1.234,   Miles),      1.2,   Miles,      "1.2",    MakeDistanceStr("1.2", "mi")},
+    {Distance(9.99,    Miles),      10,    Miles,      "10",     MakeDistanceStr("10", "mi")},
+    {Distance(10.01,   Miles),      10,    Miles,      "10",     MakeDistanceStr("10", "mi")},
+    {Distance(11,      Miles),      11,    Miles,      "11",     MakeDistanceStr("11", "mi")},
+    {Distance(54,      Miles),      54,    Miles,      "54",     MakeDistanceStr("54", "mi")},
+    {Distance(145,     Miles),      145,   Miles,      "145",    MakeDistanceStr("145", "mi")},
+    {Distance(999,     Miles),      999,   Miles,      "999",    MakeDistanceStr("999", "mi")},
+    {Distance(1149.99, Miles),      1150,  Miles,      "1150",   MakeDistanceStr("1150", "mi")},
+    {Distance(1150,    Miles),      1150,  Miles,      "1150",   MakeDistanceStr("1150", "mi")},
+    {Distance(1150.01, Miles),      1150,  Miles,      "1150",   MakeDistanceStr("1150", "mi")},
+    {Distance(12345.0, Miles),      12345, Miles,      "12,345", MakeDistanceStr("12,345", "mi")},
 
     // From Meters to Kilometers
-    {Distance(999,     Units::Meters),     1.0,   Units::Kilometers, "1.0",    MakeDistanceStr("1.0", "km")},
-    {Distance(1000,    Units::Meters),     1.0,   Units::Kilometers, "1.0",    MakeDistanceStr("1.0", "km")},
-    {Distance(1001,    Units::Meters),     1.0,   Units::Kilometers, "1.0",    MakeDistanceStr("1.0", "km")},
-    {Distance(1100,    Units::Meters),     1.1,   Units::Kilometers, "1.1",    MakeDistanceStr("1.1", "km")},
-    {Distance(1140,    Units::Meters),     1.1,   Units::Kilometers, "1.1",    MakeDistanceStr("1.1", "km")},
-    {Distance(1151,    Units::Meters),     1.2,   Units::Kilometers, "1.2",    MakeDistanceStr("1.2", "km")},
-    {Distance(1500,    Units::Meters),     1.5,   Units::Kilometers, "1.5",    MakeDistanceStr("1.5", "km")},
-    {Distance(1549.9,  Units::Meters),     1.5,   Units::Kilometers, "1.5",    MakeDistanceStr("1.5", "km")},
-    {Distance(1550,    Units::Meters),     1.6,   Units::Kilometers, "1.6",    MakeDistanceStr("1.6", "km")},
-    {Distance(1551,    Units::Meters),     1.6,   Units::Kilometers, "1.6",    MakeDistanceStr("1.6", "km")},
-    {Distance(9949,    Units::Meters),     9.9,   Units::Kilometers, "9.9",    MakeDistanceStr("9.9", "km")},
-    {Distance(9992,    Units::Meters),     10,    Units::Kilometers, "10",     MakeDistanceStr("10", "km")},
-    {Distance(10000,   Units::Meters),     10,    Units::Kilometers, "10",     MakeDistanceStr("10", "km")},
-    {Distance(10499.9, Units::Meters),     10,    Units::Kilometers, "10",     MakeDistanceStr("10", "km")},
-    {Distance(10501,   Units::Meters),     11,    Units::Kilometers, "11",     MakeDistanceStr("11", "km")},
-    {Distance(101'001, Units::Meters),     101,   Units::Kilometers, "101",    MakeDistanceStr("101", "km")},
-    {Distance(101'999, Units::Meters),     102,   Units::Kilometers, "102",    MakeDistanceStr("102", "km")},
-    {Distance(287'386, Units::Meters),     287,   Units::Kilometers, "287",    MakeDistanceStr("287", "km")},
+    {Distance(999,     Meters),     1.0,   Kilometers, "1.0",    MakeDistanceStr("1.0", "km")},
+    {Distance(1000,    Meters),     1.0,   Kilometers, "1.0",    MakeDistanceStr("1.0", "km")},
+    {Distance(1001,    Meters),     1.0,   Kilometers, "1.0",    MakeDistanceStr("1.0", "km")},
+    {Distance(1100,    Meters),     1.1,   Kilometers, "1.1",    MakeDistanceStr("1.1", "km")},
+    {Distance(1140,    Meters),     1.1,   Kilometers, "1.1",    MakeDistanceStr("1.1", "km")},
+    {Distance(1151,    Meters),     1.2,   Kilometers, "1.2",    MakeDistanceStr("1.2", "km")},
+    {Distance(1500,    Meters),     1.5,   Kilometers, "1.5",    MakeDistanceStr("1.5", "km")},
+    {Distance(1549.9,  Meters),     1.5,   Kilometers, "1.5",    MakeDistanceStr("1.5", "km")},
+    {Distance(1550,    Meters),     1.6,   Kilometers, "1.6",    MakeDistanceStr("1.6", "km")},
+    {Distance(1551,    Meters),     1.6,   Kilometers, "1.6",    MakeDistanceStr("1.6", "km")},
+    {Distance(9949,    Meters),     9.9,   Kilometers, "9.9",    MakeDistanceStr("9.9", "km")},
+    {Distance(9992,    Meters),     10,    Kilometers, "10",     MakeDistanceStr("10", "km")},
+    {Distance(10000,   Meters),     10,    Kilometers, "10",     MakeDistanceStr("10", "km")},
+    {Distance(10499.9, Meters),     10,    Kilometers, "10",     MakeDistanceStr("10", "km")},
+    {Distance(10501,   Meters),     11,    Kilometers, "11",     MakeDistanceStr("11", "km")},
+    {Distance(101'001, Meters),     101,   Kilometers, "101",    MakeDistanceStr("101", "km")},
+    {Distance(101'999, Meters),     102,   Kilometers, "102",    MakeDistanceStr("102", "km")},
+    {Distance(287'386, Meters),     287,   Kilometers, "287",    MakeDistanceStr("287", "km")},
 
     // From Feet to Miles
-    {Distance(999,     Units::Feet),       0.2,   Units::Miles,      "0.2",    MakeDistanceStr("0.2", "mi")},
-    {Distance(1000,    Units::Feet),       0.2,   Units::Miles,      "0.2",    MakeDistanceStr("0.2", "mi")},
-    {Distance(1150,    Units::Feet),       0.2,   Units::Miles,      "0.2",    MakeDistanceStr("0.2", "mi")},
-    {Distance(5280,    Units::Feet),       1.0,   Units::Miles,      "1.0",    MakeDistanceStr("1.0", "mi")},
-    {Distance(7920,    Units::Feet),       1.5,   Units::Miles,      "1.5",    MakeDistanceStr("1.5", "mi")},
-    {Distance(10560,   Units::Feet),       2.0,   Units::Miles,      "2.0",    MakeDistanceStr("2.0", "mi")},
-    {Distance(100'000, Units::Feet),       19,    Units::Miles,      "19",     MakeDistanceStr("19", "mi")},
-    {Distance(285'120, Units::Feet),       54,    Units::Miles,      "54",     MakeDistanceStr("54", "mi")},
-    {Distance(633'547, Units::Feet),       120,   Units::Miles,      "120",    MakeDistanceStr("120", "mi")},
-    {Distance(633'600, Units::Feet),       120,   Units::Miles,      "120",    MakeDistanceStr("120", "mi")},
-    {Distance(633'653, Units::Feet),       120,   Units::Miles,      "120",    MakeDistanceStr("120", "mi")},
-    {Distance(999'999, Units::Feet),       189,   Units::Miles,      "189",    MakeDistanceStr("189", "mi")},
+    {Distance(999,     Feet),       0.2,   Miles,      "0.2",    MakeDistanceStr("0.2", "mi")},
+    {Distance(1000,    Feet),       0.2,   Miles,      "0.2",    MakeDistanceStr("0.2", "mi")},
+    {Distance(1150,    Feet),       0.2,   Miles,      "0.2",    MakeDistanceStr("0.2", "mi")},
+    {Distance(5280,    Feet),       1.0,   Miles,      "1.0",    MakeDistanceStr("1.0", "mi")},
+    {Distance(7920,    Feet),       1.5,   Miles,      "1.5",    MakeDistanceStr("1.5", "mi")},
+    {Distance(10560,   Feet),       2.0,   Miles,      "2.0",    MakeDistanceStr("2.0", "mi")},
+    {Distance(100'000, Feet),       19,    Miles,      "19",     MakeDistanceStr("19", "mi")},
+    {Distance(285'120, Feet),       54,    Miles,      "54",     MakeDistanceStr("54", "mi")},
+    {Distance(633'547, Feet),       120,   Miles,      "120",    MakeDistanceStr("120", "mi")},
+    {Distance(633'600, Feet),       120,   Miles,      "120",    MakeDistanceStr("120", "mi")},
+    {Distance(633'653, Feet),       120,   Miles,      "120",    MakeDistanceStr("120", "mi")},
+    {Distance(999'999, Feet),       189,   Miles,      "189",    MakeDistanceStr("189", "mi")},
   };
 
   // clang-format on
-  for (TestData const & data : testData)
+  for (auto const & [distance, formattedDistance, formattedUnits, formattedDistanceString, formattedString] : testData)
   {
-    Distance const formatted = data.distance.GetFormattedDistance();
+    Distance const formatted = distance.GetFormattedDistance();
     // Run two times to verify that nothing breaks after second format
     for (auto const & d : {formatted, formatted.GetFormattedDistance()})
     {
-      TEST_ALMOST_EQUAL_ULPS(d.GetDistance(), data.formattedDistance, (data.distance));
-      TEST_EQUAL(d.GetUnits(), data.formattedUnits, (data.distance));
-      TEST_EQUAL(d.GetDistanceString(), data.formattedDistanceString, (data.distance));
-      TEST_EQUAL(d.ToString(), data.formattedString, (data.distance));
+      TEST_ALMOST_EQUAL_ULPS(d.GetDistance(), formattedDistance, (distance));
+      TEST_EQUAL(d.GetUnits(), formattedUnits, (distance));
+      TEST_EQUAL(d.GetDistanceString(), formattedDistanceString, (distance));
+      TEST_EQUAL(d.ToString(), formattedString, (distance));
     }
   }
 }

--- a/platform/platform_tests/distance_tests.cpp
+++ b/platform/platform_tests/distance_tests.cpp
@@ -8,7 +8,7 @@
 
 namespace platform
 {
-std::string MakeDistanceStr(std::string value, std::string const & unit)
+std::string MakeDistanceStr(std::string value, Distance::Units unit)
 {
   static Locale const loc = GetCurrentLocale();
 
@@ -20,7 +20,7 @@ std::string MakeDistanceStr(std::string value, std::string const & unit)
   if (auto found = value.find(kHardCodedDecimalSeparator); found != std::string::npos)
     value.replace(found, 1, loc.m_decimalSeparator);
 
-  return value.append(kNarrowNonBreakingSpace).append(unit);
+  return value.append(kNarrowNonBreakingSpace).append(DebugPrint(unit));
 }
 
 struct ScopedSettings
@@ -55,64 +55,68 @@ UNIT_TEST(Distance_InititalDistance)
 
 UNIT_TEST(Distance_CreateFormatted)
 {
+  using enum Distance::Units;
   {
     ScopedSettings const guard(measurement_utils::Units::Metric);
 
     Distance const d = Distance::CreateFormatted(100);
-    TEST_EQUAL(d.GetUnits(), Distance::Units::Meters, ());
+    TEST_EQUAL(d.GetUnits(), Meters, ());
     TEST_ALMOST_EQUAL_ULPS(d.GetDistance(), 100.0, ());
     TEST_EQUAL(d.GetDistanceString(), "100", ());
-    TEST_EQUAL(d.ToString(), MakeDistanceStr("100", "m"), ());
+    TEST_EQUAL(d.ToString(), MakeDistanceStr("100", Meters), ());
   }
   {
     ScopedSettings const guard(measurement_utils::Units::Imperial);
 
     Distance const d = Distance::CreateFormatted(100);
-    TEST_EQUAL(d.GetUnits(), Distance::Units::Feet, ());
+    TEST_EQUAL(d.GetUnits(), Feet, ());
     TEST_ALMOST_EQUAL_ULPS(d.GetDistance(), 330.0, ());
     TEST_EQUAL(d.GetDistanceString(), "330", ());
-    TEST_EQUAL(d.ToString(), MakeDistanceStr("330", "ft"), ());
+    TEST_EQUAL(d.ToString(), MakeDistanceStr("330", Feet), ());
   }
 }
 
 UNIT_TEST(Distance_CreateAltitudeFormatted)
 {
+  using enum Distance::Units;
   {
     ScopedSettings const guard(measurement_utils::Units::Metric);
 
-    TEST_EQUAL(Distance::FormatAltitude(5), MakeDistanceStr("5", "m"), ());
+    TEST_EQUAL(Distance::FormatAltitude(5), MakeDistanceStr("5", Meters), ());
   }
   {
     ScopedSettings const guard(measurement_utils::Units::Metric);
 
-    TEST_EQUAL(Distance::FormatAltitude(-8849), MakeDistanceStr("-8849", "m"), ());
+    TEST_EQUAL(Distance::FormatAltitude(-8849), MakeDistanceStr("-8,849", Meters), ());
   }
   {
     ScopedSettings const guard(measurement_utils::Units::Metric);
 
-    TEST_EQUAL(Distance::FormatAltitude(12345), MakeDistanceStr("12,345", "m"), ());
+    TEST_EQUAL(Distance::FormatAltitude(12345), MakeDistanceStr("12,345", Meters), ());
   }
   {
     ScopedSettings const guard(measurement_utils::Units::Imperial);
 
-    TEST_EQUAL(Distance::FormatAltitude(10000), MakeDistanceStr("32,808", "ft"), ());
+    TEST_EQUAL(Distance::FormatAltitude(10000), MakeDistanceStr("32,808", Feet), ());
   }
 }
 
 UNIT_TEST(Distance_IsLowUnits)
 {
-  TEST_EQUAL(Distance(0.0, Distance::Units::Meters).IsLowUnits(), true, ());
-  TEST_EQUAL(Distance(0.0, Distance::Units::Feet).IsLowUnits(), true, ());
-  TEST_EQUAL(Distance(0.0, Distance::Units::Kilometers).IsLowUnits(), false, ());
-  TEST_EQUAL(Distance(0.0, Distance::Units::Miles).IsLowUnits(), false, ());
+  using enum Distance::Units;
+  TEST_EQUAL(Distance(0.0, Meters).IsLowUnits(), true, ());
+  TEST_EQUAL(Distance(0.0, Feet).IsLowUnits(), true, ());
+  TEST_EQUAL(Distance(0.0, Kilometers).IsLowUnits(), false, ());
+  TEST_EQUAL(Distance(0.0, Miles).IsLowUnits(), false, ());
 }
 
 UNIT_TEST(Distance_IsHighUnits)
 {
-  TEST_EQUAL(Distance(0.0, Distance::Units::Meters).IsHighUnits(), false, ());
-  TEST_EQUAL(Distance(0.0, Distance::Units::Feet).IsHighUnits(), false, ());
-  TEST_EQUAL(Distance(0.0, Distance::Units::Kilometers).IsHighUnits(), true, ());
-  TEST_EQUAL(Distance(0.0, Distance::Units::Miles).IsHighUnits(), true, ());
+  using enum Distance::Units;
+  TEST_EQUAL(Distance(0.0, Meters).IsHighUnits(), false, ());
+  TEST_EQUAL(Distance(0.0, Feet).IsHighUnits(), false, ());
+  TEST_EQUAL(Distance(0.0, Kilometers).IsHighUnits(), true, ());
+  TEST_EQUAL(Distance(0.0, Miles).IsHighUnits(), true, ());
 }
 
 UNIT_TEST(Distance_To)
@@ -182,62 +186,65 @@ UNIT_TEST(Distance_To)
 
 UNIT_TEST(Distance_ToPlatformUnitsFormatted)
 {
+  using enum Distance::Units;
   {
     ScopedSettings const guard(measurement_utils::Units::Metric);
 
-    Distance d{11, Distance::Units::Feet};
+    Distance d{11, Feet};
     Distance newDistance = d.ToPlatformUnitsFormatted();
 
-    TEST_EQUAL(newDistance.GetUnits(), Distance::Units::Meters, (d.ToString()));
+    TEST_EQUAL(newDistance.GetUnits(), Meters, (d.ToString()));
     TEST_ALMOST_EQUAL_ULPS(newDistance.GetDistance(), 3.0, (d.ToString()));
     TEST_EQUAL(newDistance.GetDistanceString(), "3", (d.ToString()));
-    TEST_EQUAL(newDistance.ToString(), MakeDistanceStr("3", "m"), (d.ToString()));
+    TEST_EQUAL(newDistance.ToString(), MakeDistanceStr("3", Meters), (d.ToString()));
 
-    d = Distance{11, Distance::Units::Kilometers};
+    d = Distance{11, Kilometers};
     newDistance = d.ToPlatformUnitsFormatted();
 
-    TEST_EQUAL(newDistance.GetUnits(), Distance::Units::Kilometers, (d.ToString()));
+    TEST_EQUAL(newDistance.GetUnits(), Kilometers, (d.ToString()));
     TEST_ALMOST_EQUAL_ULPS(newDistance.GetDistance(), 11.0, (d.ToString()));
     TEST_EQUAL(newDistance.GetDistanceString(), "11", (d.ToString()));
-    TEST_EQUAL(newDistance.ToString(), MakeDistanceStr("11", "km"), (d.ToString()));
+    TEST_EQUAL(newDistance.ToString(), MakeDistanceStr("11", Kilometers), (d.ToString()));
   }
 
   {
     ScopedSettings const guard(measurement_utils::Units::Imperial);
 
-    Distance d{11, Distance::Units::Feet};
+    Distance d{11, Feet};
     Distance newDistance = d.ToPlatformUnitsFormatted();
 
-    TEST_EQUAL(newDistance.GetUnits(), Distance::Units::Feet, (d.ToString()));
+    TEST_EQUAL(newDistance.GetUnits(), Feet, (d.ToString()));
     TEST_ALMOST_EQUAL_ULPS(newDistance.GetDistance(), 11.0, (d.ToString()));
     TEST_EQUAL(newDistance.GetDistanceString(), "11", (d.ToString()));
-    TEST_EQUAL(newDistance.ToString(), MakeDistanceStr("11", "ft"), (d.ToString()));
+    TEST_EQUAL(newDistance.ToString(), MakeDistanceStr("11", Feet), (d.ToString()));
 
-    d = Distance{11, Distance::Units::Kilometers};
+    d = Distance{11, Kilometers};
     newDistance = d.ToPlatformUnitsFormatted();
 
-    TEST_EQUAL(newDistance.GetUnits(), Distance::Units::Miles, (d.ToString()));
+    TEST_EQUAL(newDistance.GetUnits(), Miles, (d.ToString()));
     TEST_ALMOST_EQUAL_ULPS(newDistance.GetDistance(), 6.8, (d.ToString()));
     TEST_EQUAL(newDistance.GetDistanceString(), "6.8", (d.ToString()));
-    TEST_EQUAL(newDistance.ToString(), MakeDistanceStr("6.8", "mi"), (d.ToString()));
+    TEST_EQUAL(newDistance.ToString(), MakeDistanceStr("6.8", Miles), (d.ToString()));
   }
 }
 
 UNIT_TEST(Distance_GetUnits)
 {
-  TEST_EQUAL(Distance(1234).GetUnits(), Distance::Units::Meters, ());
-  TEST_EQUAL(Distance(1234, Distance::Units::Kilometers).GetUnits(), Distance::Units::Kilometers, ());
-  TEST_EQUAL(Distance(1234, Distance::Units::Feet).GetUnits(), Distance::Units::Feet, ());
-  TEST_EQUAL(Distance(1234, Distance::Units::Miles).GetUnits(), Distance::Units::Miles, ());
+  using enum Distance::Units;
+  TEST_EQUAL(Distance(1234).GetUnits(), Meters, ());
+  TEST_EQUAL(Distance(1234, Kilometers).GetUnits(), Kilometers, ());
+  TEST_EQUAL(Distance(1234, Feet).GetUnits(), Feet, ());
+  TEST_EQUAL(Distance(1234, Miles).GetUnits(), Miles, ());
 }
 
 UNIT_TEST(Distance_GetUnitsString)
 {
+  using enum Distance::Units;
   TEST_EQUAL(Distance(1234).GetUnitsString(), "m", ());
-  TEST_EQUAL(Distance(1234, Distance::Units::Meters).GetUnitsString(), "m", ());
-  TEST_EQUAL(Distance(1234, Distance::Units::Kilometers).GetUnitsString(), "km", ());
-  TEST_EQUAL(Distance(1234, Distance::Units::Feet).GetUnitsString(), "ft", ());
-  TEST_EQUAL(Distance(1234, Distance::Units::Miles).GetUnitsString(), "mi", ());
+  TEST_EQUAL(Distance(1234, Meters).GetUnitsString(), "m", ());
+  TEST_EQUAL(Distance(1234, Kilometers).GetUnitsString(), "km", ());
+  TEST_EQUAL(Distance(1234, Feet).GetUnitsString(), "ft", ());
+  TEST_EQUAL(Distance(1234, Miles).GetUnitsString(), "mi", ());
 }
 
 UNIT_TEST(Distance_FormattedDistance)
@@ -247,111 +254,110 @@ UNIT_TEST(Distance_FormattedDistance)
     Distance distance;
     double formattedDistance;
     Distance::Units formattedUnits;
-    std::string formattedDistanceString;
-    std::string formattedString;
+    std::string formattedDistanceStringInUsLocale;
   };
 
   using enum Distance::Units;
   // clang-format off
   TestData const testData[] = {
     // From Meters to Meters
-    {Distance(0,       Meters),     0,     Meters,     "0",      MakeDistanceStr("0", "m")},
-    {Distance(0.3,     Meters),     0,     Meters,     "0",      MakeDistanceStr("0", "m")},
-    {Distance(0.9,     Meters),     1,     Meters,     "1",      MakeDistanceStr("1", "m")},
-    {Distance(1,       Meters),     1,     Meters,     "1",      MakeDistanceStr("1", "m")},
-    {Distance(1.234,   Meters),     1,     Meters,     "1",      MakeDistanceStr("1", "m")},
-    {Distance(9.99,    Meters),     10,    Meters,     "10",     MakeDistanceStr("10", "m")},
-    {Distance(10.01,   Meters),     10,    Meters,     "10",     MakeDistanceStr("10", "m")},
-    {Distance(10.4,    Meters),     10,    Meters,     "10",     MakeDistanceStr("10", "m")},
-    {Distance(10.5,    Meters),     11,    Meters,     "11",     MakeDistanceStr("11", "m")},
-    {Distance(10.51,   Meters),     11,    Meters,     "11",     MakeDistanceStr("11", "m")},
-    {Distance(64.2,    Meters),     64,    Meters,     "64",     MakeDistanceStr("64", "m")},
-    {Distance(99,      Meters),     99,    Meters,     "99",     MakeDistanceStr("99", "m")},
-    {Distance(100,     Meters),     100,   Meters,     "100",    MakeDistanceStr("100", "m")},
-    {Distance(101,     Meters),     100,   Meters,     "100",    MakeDistanceStr("100", "m")},
-    {Distance(109,     Meters),     110,   Meters,     "110",    MakeDistanceStr("110", "m")},
-    {Distance(991,     Meters),     990,   Meters,     "990",    MakeDistanceStr("990", "m")},
+    {Distance(0,       Meters),     0,     Meters,     "0"},
+    {Distance(0.3,     Meters),     0,     Meters,     "0"},
+    {Distance(0.9,     Meters),     1,     Meters,     "1"},
+    {Distance(1,       Meters),     1,     Meters,     "1"},
+    {Distance(1.234,   Meters),     1,     Meters,     "1"},
+    {Distance(9.99,    Meters),     10,    Meters,     "10"},
+    {Distance(10.01,   Meters),     10,    Meters,     "10"},
+    {Distance(10.4,    Meters),     10,    Meters,     "10"},
+    {Distance(10.5,    Meters),     11,    Meters,     "11"},
+    {Distance(10.51,   Meters),     11,    Meters,     "11"},
+    {Distance(64.2,    Meters),     64,    Meters,     "64"},
+    {Distance(99,      Meters),     99,    Meters,     "99"},
+    {Distance(100,     Meters),     100,   Meters,     "100"},
+    {Distance(101,     Meters),     100,   Meters,     "100"},
+    {Distance(109,     Meters),     110,   Meters,     "110"},
+    {Distance(991,     Meters),     990,   Meters,     "990"},
 
     // From Kilometers to Kilometers
-    {Distance(0,       Kilometers), 0,     Meters,     "0",      MakeDistanceStr("0", "m")},
-    {Distance(0.3,     Kilometers), 300,   Meters,     "300",    MakeDistanceStr("300", "m")},
-    {Distance(1.234,   Kilometers), 1.2,   Kilometers, "1.2",    MakeDistanceStr("1.2", "km")},
-    {Distance(10,      Kilometers), 10,    Kilometers, "10",     MakeDistanceStr("10", "km")},
-    {Distance(11,      Kilometers), 11,    Kilometers, "11",     MakeDistanceStr("11", "km")},
-    {Distance(54,      Kilometers), 54,    Kilometers, "54",     MakeDistanceStr("54", "km")},
-    {Distance(99.99,   Kilometers), 100,   Kilometers, "100",    MakeDistanceStr("100", "km")},
-    {Distance(100.01,  Kilometers), 100,   Kilometers, "100",    MakeDistanceStr("100", "km")},
-    {Distance(115,     Kilometers), 115,   Kilometers, "115",    MakeDistanceStr("115", "km")},
-    {Distance(999,     Kilometers), 999,   Kilometers, "999",    MakeDistanceStr("999", "km")},
-    {Distance(1000,    Kilometers), 1000,  Kilometers, "1000",   MakeDistanceStr("1000", "km")},
-    {Distance(1049.99, Kilometers), 1050,  Kilometers, "1050",   MakeDistanceStr("1050", "km")},
-    {Distance(1050,    Kilometers), 1050,  Kilometers, "1050",   MakeDistanceStr("1050", "km")},
-    {Distance(1050.01, Kilometers), 1050,  Kilometers, "1050",   MakeDistanceStr("1050", "km")},
-    {Distance(1234,    Kilometers), 1234,  Kilometers, "1234",   MakeDistanceStr("1234", "km")},
-    {Distance(12345,   Kilometers), 12345, Kilometers, "12,345", MakeDistanceStr("12,345", "km")},
+    {Distance(0,       Kilometers), 0,     Meters,     "0"},
+    {Distance(0.3,     Kilometers), 300,   Meters,     "300"},
+    {Distance(1.234,   Kilometers), 1.2,   Kilometers, "1.2"},
+    {Distance(10,      Kilometers), 10,    Kilometers, "10"},
+    {Distance(11,      Kilometers), 11,    Kilometers, "11"},
+    {Distance(54,      Kilometers), 54,    Kilometers, "54"},
+    {Distance(99.99,   Kilometers), 100,   Kilometers, "100"},
+    {Distance(100.01,  Kilometers), 100,   Kilometers, "100"},
+    {Distance(115,     Kilometers), 115,   Kilometers, "115"},
+    {Distance(999,     Kilometers), 999,   Kilometers, "999"},
+    {Distance(1000,    Kilometers), 1000,  Kilometers, "1,000"},
+    {Distance(1049.99, Kilometers), 1050,  Kilometers, "1,050"},
+    {Distance(1050,    Kilometers), 1050,  Kilometers, "1,050"},
+    {Distance(1050.01, Kilometers), 1050,  Kilometers, "1,050"},
+    {Distance(1234,    Kilometers), 1234,  Kilometers, "1,234"},
+    {Distance(12345,   Kilometers), 12345, Kilometers, "12,345"},
 
     // From Feet to Feet
-    {Distance(0,       Feet),       0,     Feet,       "0",      MakeDistanceStr("0", "ft")},
-    {Distance(1,       Feet),       1,     Feet,       "1",      MakeDistanceStr("1", "ft")},
-    {Distance(9.99,    Feet),       10,    Feet,       "10",     MakeDistanceStr("10", "ft")},
-    {Distance(10.01,   Feet),       10,    Feet,       "10",     MakeDistanceStr("10", "ft")},
-    {Distance(95,      Feet),       95,    Feet,       "95",     MakeDistanceStr("95", "ft")},
-    {Distance(125,     Feet),       130,   Feet,       "130",    MakeDistanceStr("130", "ft")},
-    {Distance(991,     Feet),       990,   Feet,       "990",    MakeDistanceStr("990", "ft")},
+    {Distance(0,       Feet),       0,     Feet,       "0"},
+    {Distance(1,       Feet),       1,     Feet,       "1"},
+    {Distance(9.99,    Feet),       10,    Feet,       "10"},
+    {Distance(10.01,   Feet),       10,    Feet,       "10"},
+    {Distance(95,      Feet),       95,    Feet,       "95"},
+    {Distance(125,     Feet),       130,   Feet,       "130"},
+    {Distance(991,     Feet),       990,   Feet,       "990"},
 
     // From Miles to Miles
-    {Distance(0,       Miles),      0,     Feet,       "0",      MakeDistanceStr("0", "ft")},
-    {Distance(0.1,     Miles),      530,   Feet,       "530",    MakeDistanceStr("530", "ft")},
-    {Distance(1,       Miles),      1.0,   Miles,      "1.0",    MakeDistanceStr("1.0", "mi")},
-    {Distance(1.234,   Miles),      1.2,   Miles,      "1.2",    MakeDistanceStr("1.2", "mi")},
-    {Distance(9.99,    Miles),      10,    Miles,      "10",     MakeDistanceStr("10", "mi")},
-    {Distance(10.01,   Miles),      10,    Miles,      "10",     MakeDistanceStr("10", "mi")},
-    {Distance(11,      Miles),      11,    Miles,      "11",     MakeDistanceStr("11", "mi")},
-    {Distance(54,      Miles),      54,    Miles,      "54",     MakeDistanceStr("54", "mi")},
-    {Distance(145,     Miles),      145,   Miles,      "145",    MakeDistanceStr("145", "mi")},
-    {Distance(999,     Miles),      999,   Miles,      "999",    MakeDistanceStr("999", "mi")},
-    {Distance(1149.99, Miles),      1150,  Miles,      "1150",   MakeDistanceStr("1150", "mi")},
-    {Distance(1150,    Miles),      1150,  Miles,      "1150",   MakeDistanceStr("1150", "mi")},
-    {Distance(1150.01, Miles),      1150,  Miles,      "1150",   MakeDistanceStr("1150", "mi")},
-    {Distance(12345.0, Miles),      12345, Miles,      "12,345", MakeDistanceStr("12,345", "mi")},
+    {Distance(0,       Miles),      0,     Feet,       "0"},
+    {Distance(0.1,     Miles),      530,   Feet,       "530"},
+    {Distance(1,       Miles),      1.0,   Miles,      "1.0"},
+    {Distance(1.234,   Miles),      1.2,   Miles,      "1.2"},
+    {Distance(9.99,    Miles),      10,    Miles,      "10"},
+    {Distance(10.01,   Miles),      10,    Miles,      "10"},
+    {Distance(11,      Miles),      11,    Miles,      "11"},
+    {Distance(54,      Miles),      54,    Miles,      "54"},
+    {Distance(145,     Miles),      145,   Miles,      "145"},
+    {Distance(999,     Miles),      999,   Miles,      "999"},
+    {Distance(1149.99, Miles),      1150,  Miles,      "1,150"},
+    {Distance(1150,    Miles),      1150,  Miles,      "1,150"},
+    {Distance(1150.01, Miles),      1150,  Miles,      "1,150"},
+    {Distance(12345.0, Miles),      12345, Miles,      "12,345"},
 
     // From Meters to Kilometers
-    {Distance(999,     Meters),     1.0,   Kilometers, "1.0",    MakeDistanceStr("1.0", "km")},
-    {Distance(1000,    Meters),     1.0,   Kilometers, "1.0",    MakeDistanceStr("1.0", "km")},
-    {Distance(1001,    Meters),     1.0,   Kilometers, "1.0",    MakeDistanceStr("1.0", "km")},
-    {Distance(1100,    Meters),     1.1,   Kilometers, "1.1",    MakeDistanceStr("1.1", "km")},
-    {Distance(1140,    Meters),     1.1,   Kilometers, "1.1",    MakeDistanceStr("1.1", "km")},
-    {Distance(1151,    Meters),     1.2,   Kilometers, "1.2",    MakeDistanceStr("1.2", "km")},
-    {Distance(1500,    Meters),     1.5,   Kilometers, "1.5",    MakeDistanceStr("1.5", "km")},
-    {Distance(1549.9,  Meters),     1.5,   Kilometers, "1.5",    MakeDistanceStr("1.5", "km")},
-    {Distance(1550,    Meters),     1.6,   Kilometers, "1.6",    MakeDistanceStr("1.6", "km")},
-    {Distance(1551,    Meters),     1.6,   Kilometers, "1.6",    MakeDistanceStr("1.6", "km")},
-    {Distance(9949,    Meters),     9.9,   Kilometers, "9.9",    MakeDistanceStr("9.9", "km")},
-    {Distance(9992,    Meters),     10,    Kilometers, "10",     MakeDistanceStr("10", "km")},
-    {Distance(10000,   Meters),     10,    Kilometers, "10",     MakeDistanceStr("10", "km")},
-    {Distance(10499.9, Meters),     10,    Kilometers, "10",     MakeDistanceStr("10", "km")},
-    {Distance(10501,   Meters),     11,    Kilometers, "11",     MakeDistanceStr("11", "km")},
-    {Distance(101'001, Meters),     101,   Kilometers, "101",    MakeDistanceStr("101", "km")},
-    {Distance(101'999, Meters),     102,   Kilometers, "102",    MakeDistanceStr("102", "km")},
-    {Distance(287'386, Meters),     287,   Kilometers, "287",    MakeDistanceStr("287", "km")},
+    {Distance(999,     Meters),     1.0,   Kilometers, "1.0"},
+    {Distance(1000,    Meters),     1.0,   Kilometers, "1.0"},
+    {Distance(1001,    Meters),     1.0,   Kilometers, "1.0"},
+    {Distance(1100,    Meters),     1.1,   Kilometers, "1.1"},
+    {Distance(1140,    Meters),     1.1,   Kilometers, "1.1"},
+    {Distance(1151,    Meters),     1.2,   Kilometers, "1.2"},
+    {Distance(1500,    Meters),     1.5,   Kilometers, "1.5"},
+    {Distance(1549.9,  Meters),     1.5,   Kilometers, "1.5"},
+    {Distance(1550,    Meters),     1.6,   Kilometers, "1.6"},
+    {Distance(1551,    Meters),     1.6,   Kilometers, "1.6"},
+    {Distance(9949,    Meters),     9.9,   Kilometers, "9.9"},
+    {Distance(9992,    Meters),     10,    Kilometers, "10"},
+    {Distance(10000,   Meters),     10,    Kilometers, "10"},
+    {Distance(10499.9, Meters),     10,    Kilometers, "10"},
+    {Distance(10501,   Meters),     11,    Kilometers, "11"},
+    {Distance(101'001, Meters),     101,   Kilometers, "101"},
+    {Distance(101'999, Meters),     102,   Kilometers, "102"},
+    {Distance(287'386, Meters),     287,   Kilometers, "287"},
 
     // From Feet to Miles
-    {Distance(999,     Feet),       0.2,   Miles,      "0.2",    MakeDistanceStr("0.2", "mi")},
-    {Distance(1000,    Feet),       0.2,   Miles,      "0.2",    MakeDistanceStr("0.2", "mi")},
-    {Distance(1150,    Feet),       0.2,   Miles,      "0.2",    MakeDistanceStr("0.2", "mi")},
-    {Distance(5280,    Feet),       1.0,   Miles,      "1.0",    MakeDistanceStr("1.0", "mi")},
-    {Distance(7920,    Feet),       1.5,   Miles,      "1.5",    MakeDistanceStr("1.5", "mi")},
-    {Distance(10560,   Feet),       2.0,   Miles,      "2.0",    MakeDistanceStr("2.0", "mi")},
-    {Distance(100'000, Feet),       19,    Miles,      "19",     MakeDistanceStr("19", "mi")},
-    {Distance(285'120, Feet),       54,    Miles,      "54",     MakeDistanceStr("54", "mi")},
-    {Distance(633'547, Feet),       120,   Miles,      "120",    MakeDistanceStr("120", "mi")},
-    {Distance(633'600, Feet),       120,   Miles,      "120",    MakeDistanceStr("120", "mi")},
-    {Distance(633'653, Feet),       120,   Miles,      "120",    MakeDistanceStr("120", "mi")},
-    {Distance(999'999, Feet),       189,   Miles,      "189",    MakeDistanceStr("189", "mi")},
+    {Distance(999,     Feet),       0.2,   Miles,      "0.2"},
+    {Distance(1000,    Feet),       0.2,   Miles,      "0.2"},
+    {Distance(1150,    Feet),       0.2,   Miles,      "0.2"},
+    {Distance(5280,    Feet),       1.0,   Miles,      "1.0"},
+    {Distance(7920,    Feet),       1.5,   Miles,      "1.5"},
+    {Distance(10560,   Feet),       2.0,   Miles,      "2.0"},
+    {Distance(100'000, Feet),       19,    Miles,      "19"},
+    {Distance(285'120, Feet),       54,    Miles,      "54"},
+    {Distance(633'547, Feet),       120,   Miles,      "120"},
+    {Distance(633'600, Feet),       120,   Miles,      "120"},
+    {Distance(633'653, Feet),       120,   Miles,      "120"},
+    {Distance(999'999, Feet),       189,   Miles,      "189"},
   };
 
   // clang-format on
-  for (auto const & [distance, formattedDistance, formattedUnits, formattedDistanceString, formattedString] : testData)
+  for (auto const & [distance, formattedDistance, formattedUnits, formattedDistanceStringInUsLocale] : testData)
   {
     Distance const formatted = distance.GetFormattedDistance();
     // Run two times to verify that nothing breaks after second format
@@ -359,7 +365,7 @@ UNIT_TEST(Distance_FormattedDistance)
     {
       TEST_ALMOST_EQUAL_ULPS(d.GetDistance(), formattedDistance, (distance));
       TEST_EQUAL(d.GetUnits(), formattedUnits, (distance));
-      TEST_EQUAL(d.GetDistanceString(), formattedDistanceString, (distance));
+      auto const formattedString = MakeDistanceStr(formattedDistanceStringInUsLocale, formattedUnits);
       TEST_EQUAL(d.ToString(), formattedString, (distance));
     }
   }

--- a/platform/platform_tests/distance_tests.cpp
+++ b/platform/platform_tests/distance_tests.cpp
@@ -4,11 +4,23 @@
 #include "platform/measurement_utils.hpp"
 #include "platform/settings.hpp"
 
+#include <algorithm>
+
 namespace platform
 {
-std::string MakeDistanceStr(std::string const & value, std::string const & unit)
+std::string MakeDistanceStr(std::string value, std::string const & unit)
 {
-  return value + kNarrowNonBreakingSpace + unit;
+  static Locale const loc = GetCurrentLocale();
+
+  constexpr char kHardCodedGroupingSeparator = ',';
+  if (auto found = value.find(kHardCodedGroupingSeparator); found != std::string::npos)
+    value.replace(found, 1, loc.m_groupingSeparator);
+
+  constexpr char kHardCodedDecimalSeparator = '.';
+  if (auto found = value.find(kHardCodedDecimalSeparator); found != std::string::npos)
+    value.replace(found, 1, loc.m_decimalSeparator);
+
+  return value.append(kNarrowNonBreakingSpace).append(unit);
 }
 
 struct ScopedSettings

--- a/platform/platform_tests/distance_tests.cpp
+++ b/platform/platform_tests/distance_tests.cpp
@@ -83,15 +83,7 @@ UNIT_TEST(Distance_CreateAltitudeFormatted)
     ScopedSettings const guard(measurement_utils::Units::Metric);
 
     TEST_EQUAL(Distance::FormatAltitude(5), MakeDistanceStr("5", Meters), ());
-  }
-  {
-    ScopedSettings const guard(measurement_utils::Units::Metric);
-
-    TEST_EQUAL(Distance::FormatAltitude(-8849), MakeDistanceStr("-8,849", Meters), ());
-  }
-  {
-    ScopedSettings const guard(measurement_utils::Units::Metric);
-
+    TEST_EQUAL(Distance::FormatAltitude(-8849), MakeDistanceStr("-8849", Meters), ());
     TEST_EQUAL(Distance::FormatAltitude(12345), MakeDistanceStr("12,345", Meters), ());
   }
   {
@@ -289,11 +281,11 @@ UNIT_TEST(Distance_FormattedDistance)
     {Distance(100.01,  Kilometers), 100,   Kilometers, "100"},
     {Distance(115,     Kilometers), 115,   Kilometers, "115"},
     {Distance(999,     Kilometers), 999,   Kilometers, "999"},
-    {Distance(1000,    Kilometers), 1000,  Kilometers, "1,000"},
-    {Distance(1049.99, Kilometers), 1050,  Kilometers, "1,050"},
-    {Distance(1050,    Kilometers), 1050,  Kilometers, "1,050"},
-    {Distance(1050.01, Kilometers), 1050,  Kilometers, "1,050"},
-    {Distance(1234,    Kilometers), 1234,  Kilometers, "1,234"},
+    {Distance(1000,    Kilometers), 1000,  Kilometers, "1000"},
+    {Distance(1049.99, Kilometers), 1050,  Kilometers, "1050"},
+    {Distance(1050,    Kilometers), 1050,  Kilometers, "1050"},
+    {Distance(1050.01, Kilometers), 1050,  Kilometers, "1050"},
+    {Distance(1234,    Kilometers), 1234,  Kilometers, "1234"},
     {Distance(12345,   Kilometers), 12345, Kilometers, "12,345"},
 
     // From Feet to Feet
@@ -316,9 +308,9 @@ UNIT_TEST(Distance_FormattedDistance)
     {Distance(54,      Miles),      54,    Miles,      "54"},
     {Distance(145,     Miles),      145,   Miles,      "145"},
     {Distance(999,     Miles),      999,   Miles,      "999"},
-    {Distance(1149.99, Miles),      1150,  Miles,      "1,150"},
-    {Distance(1150,    Miles),      1150,  Miles,      "1,150"},
-    {Distance(1150.01, Miles),      1150,  Miles,      "1,150"},
+    {Distance(1149.99, Miles),      1150,  Miles,      "1150"},
+    {Distance(1150,    Miles),      1150,  Miles,      "1150"},
+    {Distance(1150.01, Miles),      1150,  Miles,      "1150"},
     {Distance(12345.0, Miles),      12345, Miles,      "12,345"},
 
     // From Meters to Kilometers


### PR DESCRIPTION
Clean up and minor speed up of the locale-formatting code.