### PR TITLE
[Android] Speed limit in navigation mode

### DIFF
--- a/android/app/src/main/cpp/app/organicmaps/Framework.cpp
+++ b/android/app/src/main/cpp/app/organicmaps/Framework.cpp
@@ -1253,7 +1253,7 @@ Java_app_organicmaps_Framework_nativeGetRouteFollowingInfo(JNIEnv * env, jclass)
       jni::GetConstructorID(env, klass,
                             "(Lapp/organicmaps/util/Distance;Lapp/organicmaps/util/Distance;"
                             "Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;DIIIII"
-                            "[Lapp/organicmaps/routing/SingleLaneInfo;ZZ)V");
+                            "[Lapp/organicmaps/routing/SingleLaneInfo;DZZ)V");
 
   vector<routing::FollowingInfo::SingleLaneInfoClient> const & lanes = info.m_lanes;
   jobjectArray jLanes = nullptr;
@@ -1288,7 +1288,8 @@ Java_app_organicmaps_Framework_nativeGetRouteFollowingInfo(JNIEnv * env, jclass)
       ToJavaDistance(env, info.m_distToTurn), jni::ToJavaString(env, info.m_currentStreetName),
       jni::ToJavaString(env, info.m_nextStreetName), jni::ToJavaString(env, info.m_nextNextStreetName),
       info.m_completionPercent, info.m_turn, info.m_nextTurn, info.m_pedestrianTurn, info.m_exitNum,
-      info.m_time, jLanes, static_cast<jboolean>(isSpeedCamLimitExceeded), static_cast<jboolean>(shouldPlaySignal));
+      info.m_time, jLanes, info.m_speedLimitMps, static_cast<jboolean>(isSpeedCamLimitExceeded),
+      static_cast<jboolean>(shouldPlaySignal));
   ASSERT(result, (jni::DescribeException()));
   return result;
 }

--- a/android/app/src/main/java/app/organicmaps/routing/RoutingInfo.java
+++ b/android/app/src/main/java/app/organicmaps/routing/RoutingInfo.java
@@ -34,6 +34,9 @@ public class RoutingInfo
   public final SingleLaneInfo[] lanes;
   // For pedestrian routing.
   public final PedestrianTurnDirection pedestrianTurnDirection;
+  // Current speed limit in meters per second.
+  // If no info about speed limit then speedLimitMps < 0.
+  public final double speedLimitMps;
   private final boolean speedLimitExceeded;
   private final boolean shouldPlayWarningSignal;
 
@@ -140,7 +143,7 @@ public class RoutingInfo
 
   public RoutingInfo(Distance distToTarget, Distance distToTurn, String currentStreet, String nextStreet, String nextNextStreet, double completionPercent,
                      int vehicleTurnOrdinal, int vehicleNextTurnOrdinal, int pedestrianTurnOrdinal, int exitNum,
-                     int totalTime, SingleLaneInfo[] lanes, boolean speedLimitExceeded,
+                     int totalTime, SingleLaneInfo[] lanes, double speedLimitMps, boolean speedLimitExceeded,
                      boolean shouldPlayWarningSignal)
   {
     this.distToTarget = distToTarget;
@@ -155,6 +158,7 @@ public class RoutingInfo
     this.lanes = lanes;
     this.exitNum = exitNum;
     this.pedestrianTurnDirection = PedestrianTurnDirection.values()[pedestrianTurnOrdinal];
+    this.speedLimitMps = speedLimitMps;
     this.speedLimitExceeded = speedLimitExceeded;
     this.shouldPlayWarningSignal = shouldPlayWarningSignal;
   }

--- a/android/app/src/main/java/app/organicmaps/routing/RoutingInfo.java
+++ b/android/app/src/main/java/app/organicmaps/routing/RoutingInfo.java
@@ -37,7 +37,7 @@ public class RoutingInfo
   // Current speed limit in meters per second.
   // If no info about speed limit then speedLimitMps < 0.
   public final double speedLimitMps;
-  private final boolean speedLimitExceeded;
+  private final boolean speedCamLimitExceeded;
   private final boolean shouldPlayWarningSignal;
 
   /**
@@ -159,13 +159,13 @@ public class RoutingInfo
     this.exitNum = exitNum;
     this.pedestrianTurnDirection = PedestrianTurnDirection.values()[pedestrianTurnOrdinal];
     this.speedLimitMps = speedLimitMps;
-    this.speedLimitExceeded = speedLimitExceeded;
+    this.speedCamLimitExceeded = speedLimitExceeded;
     this.shouldPlayWarningSignal = shouldPlayWarningSignal;
   }
 
-  public boolean isSpeedLimitExceeded()
+  public boolean isSpeedCamLimitExceeded()
   {
-    return speedLimitExceeded;
+    return speedCamLimitExceeded;
   }
 
   public boolean shouldPlayWarningSignal()

--- a/android/app/src/main/java/app/organicmaps/widget/menu/NavMenu.java
+++ b/android/app/src/main/java/app/organicmaps/widget/menu/NavMenu.java
@@ -227,7 +227,6 @@ public class NavMenu
       if (info.isSpeedCamLimitExceeded())
         mSpeedValue.setTextColor(ContextCompat.getColor(mActivity, R.color.white_primary));
       else
-        // Black text for speeding if there's no camera
         mSpeedValue.setTextColor(ContextCompat.getColor(mActivity, R.color.base_red));
     }
     else

--- a/android/app/src/main/java/app/organicmaps/widget/menu/NavMenu.java
+++ b/android/app/src/main/java/app/organicmaps/widget/menu/NavMenu.java
@@ -225,7 +225,6 @@ public class NavMenu
     if (last.getSpeed() > info.speedLimitMps)
     {
       if (info.isSpeedCamLimitExceeded())
-        // White text on red background for camera speeding
         mSpeedValue.setTextColor(ContextCompat.getColor(mActivity, R.color.white_primary));
       else
         // Black text for speeding if there's no camera

--- a/android/app/src/main/java/app/organicmaps/widget/menu/NavMenu.java
+++ b/android/app/src/main/java/app/organicmaps/widget/menu/NavMenu.java
@@ -218,8 +218,8 @@ public class NavMenu
 
     if (mCurrentSpeedLimit > 0.0)
     {
-      Pair<String, String> speedLimitAndUnits = StringUtils.nativeFormatSpeedAndUnits(last.getSpeed());
-      mSpeedValue.setText(speedAndUnits.first + " / " + speedLimitAndUnits.first);
+      Pair<String, String> speedLimitAndUnits = StringUtils.nativeFormatSpeedAndUnits(mCurrentSpeedLimit);
+      mSpeedValue.setText(speedAndUnits.first + "\u202F/\u202F" + speedLimitAndUnits.first);
     }
     else
       mSpeedValue.setText(speedAndUnits.first);

--- a/android/app/src/main/java/app/organicmaps/widget/menu/NavMenu.java
+++ b/android/app/src/main/java/app/organicmaps/widget/menu/NavMenu.java
@@ -222,12 +222,20 @@ public class NavMenu
     else
       mSpeedValue.setText(speedAndUnits.first);
 
-    if (info.isSpeedLimitExceeded())
-      mSpeedValue.setTextColor(ContextCompat.getColor(mActivity, R.color.base_red));
+    if (last.getSpeed() > info.speedLimitMps)
+    {
+      if (info.isSpeedCamLimitExceeded())
+        // White text on red background for camera speeding
+        mSpeedValue.setTextColor(ContextCompat.getColor(mActivity, R.color.white_primary));
+      else
+        // Black text for speeding if there's no camera
+        mSpeedValue.setTextColor(ContextCompat.getColor(mActivity, R.color.base_red));
+    }
     else
       mSpeedValue.setTextColor(ThemeUtils.getColor(mActivity, android.R.attr.textColorPrimary));
 
     mSpeedUnits.setText(speedAndUnits.second);
+    mSpeedViewContainer.setActivated(info.isSpeedCamLimitExceeded());
   }
 
   public void update(@NonNull RoutingInfo info)

--- a/android/app/src/main/java/app/organicmaps/widget/menu/NavMenu.java
+++ b/android/app/src/main/java/app/organicmaps/widget/menu/NavMenu.java
@@ -49,8 +49,6 @@ public class NavMenu
   private final NavMenuListener mNavMenuListener;
 
   private int currentPeekHeight = 0;
-  private double mCurrentSpeedLimit;
-  private boolean mIsSpeedLimitExceeded = false;
 
 
   public interface OnMenuSizeChangedListener
@@ -216,21 +214,20 @@ public class NavMenu
 
     Pair<String, String> speedAndUnits = StringUtils.nativeFormatSpeedAndUnits(last.getSpeed());
 
-    if (mCurrentSpeedLimit > 0.0)
+    if (info.speedLimitMps > 0.0)
     {
-      Pair<String, String> speedLimitAndUnits = StringUtils.nativeFormatSpeedAndUnits(mCurrentSpeedLimit);
+      Pair<String, String> speedLimitAndUnits = StringUtils.nativeFormatSpeedAndUnits(info.speedLimitMps);
       mSpeedValue.setText(speedAndUnits.first + "\u202F/\u202F" + speedLimitAndUnits.first);
     }
     else
       mSpeedValue.setText(speedAndUnits.first);
 
-    if (mIsSpeedLimitExceeded)
+    if (info.isSpeedLimitExceeded())
       mSpeedValue.setTextColor(ContextCompat.getColor(mActivity, R.color.base_red));
     else
       mSpeedValue.setTextColor(ThemeUtils.getColor(mActivity, android.R.attr.textColorPrimary));
 
     mSpeedUnits.setText(speedAndUnits.second);
-    mSpeedViewContainer.setActivated(info.isSpeedLimitExceeded());
   }
 
   public void update(@NonNull RoutingInfo info)
@@ -240,8 +237,6 @@ public class NavMenu
     mDistanceValue.setText(info.distToTarget.mDistanceStr);
     mDistanceUnits.setText(info.distToTarget.getUnitsStr(mActivity.getApplicationContext()));
     mRouteProgress.setProgressCompat((int) info.completionPercent, true);
-    mCurrentSpeedLimit = info.speedLimitMps;
-    mIsSpeedLimitExceeded = info.isSpeedLimitExceeded();
   }
 
   public interface NavMenuListener

--- a/android/app/src/main/java/app/organicmaps/widget/menu/NavMenu.java
+++ b/android/app/src/main/java/app/organicmaps/widget/menu/NavMenu.java
@@ -9,6 +9,8 @@ import android.widget.TextView;
 
 import androidx.annotation.NonNull;
 import androidx.appcompat.app.AppCompatActivity;
+import androidx.core.content.ContextCompat;
+
 import com.google.android.material.bottomsheet.BottomSheetBehavior;
 import app.organicmaps.R;
 import app.organicmaps.location.LocationHelper;
@@ -16,6 +18,7 @@ import app.organicmaps.routing.RoutingInfo;
 import app.organicmaps.sound.TtsPlayer;
 import app.organicmaps.util.Graphics;
 import app.organicmaps.util.StringUtils;
+import app.organicmaps.util.ThemeUtils;
 import app.organicmaps.util.UiUtils;
 import com.google.android.material.progressindicator.LinearProgressIndicator;
 
@@ -46,6 +49,8 @@ public class NavMenu
   private final NavMenuListener mNavMenuListener;
 
   private int currentPeekHeight = 0;
+  private double mCurrentSpeedLimit;
+  private boolean mIsSpeedLimitExceeded = false;
 
 
   public interface OnMenuSizeChangedListener
@@ -211,8 +216,20 @@ public class NavMenu
 
     Pair<String, String> speedAndUnits = StringUtils.nativeFormatSpeedAndUnits(last.getSpeed());
 
+    if (mCurrentSpeedLimit > 0.0)
+    {
+      Pair<String, String> speedLimitAndUnits = StringUtils.nativeFormatSpeedAndUnits(last.getSpeed());
+      mSpeedValue.setText(speedAndUnits.first + " / " + speedLimitAndUnits.first);
+    }
+    else
+      mSpeedValue.setText(speedAndUnits.first);
+
+    if (mIsSpeedLimitExceeded)
+      mSpeedValue.setTextColor(ContextCompat.getColor(mActivity, R.color.base_red));
+    else
+      mSpeedValue.setTextColor(ThemeUtils.getColor(mActivity, android.R.attr.textColorPrimary));
+
     mSpeedUnits.setText(speedAndUnits.second);
-    mSpeedValue.setText(speedAndUnits.first);
     mSpeedViewContainer.setActivated(info.isSpeedLimitExceeded());
   }
 
@@ -223,6 +240,8 @@ public class NavMenu
     mDistanceValue.setText(info.distToTarget.mDistanceStr);
     mDistanceUnits.setText(info.distToTarget.getUnitsStr(mActivity.getApplicationContext()));
     mRouteProgress.setProgressCompat((int) info.completionPercent, true);
+    mCurrentSpeedLimit = info.speedLimitMps;
+    mIsSpeedLimitExceeded = info.isSpeedLimitExceeded();
   }
 
   public interface NavMenuListener


### PR DESCRIPTION
Changed navigation UI to show speed and speed limit with `'/'` separator (as in iOS).

### Q1. How to test it without having a ride in a car?

How to check it on emulator?

**Expected result:** speed limit should be displayed in navigation mode:

<img width="400" alt="ios speed limit" src="https://github.com/user-attachments/assets/712e4705-a44d-463f-b6d2-1b4114defe8e" />

### Testing:

<img width="400" alt="Screenshot 2024-08-09 at 10 55 04" src="https://github.com/user-attachments/assets/5d2e20b7-257a-4b45-910e-114b74f45379"/>

I used GPX track [Florida. Busch Gardens - Pollo Tropical.gpx](https://gist.github.com/strump/d4b8cadde7324e4cba5dc802b9d9cb99) to emulate city ride.