### PR TITLE
[android] Fix the crosshair (PICK_POINT) API

### DIFF
--- a/android/app/src/main/java/app/organicmaps/DownloadResourcesLegacyActivity.java
+++ b/android/app/src/main/java/app/organicmaps/DownloadResourcesLegacyActivity.java
@@ -12,6 +12,8 @@ import android.widget.Button;
 import android.widget.CheckBox;
 import android.widget.TextView;
 
+import androidx.activity.result.ActivityResultLauncher;
+import androidx.activity.result.contract.ActivityResultContracts;
 import androidx.annotation.CallSuper;
 import androidx.annotation.Keep;
 import androidx.annotation.NonNull;
@@ -22,6 +24,7 @@ import androidx.annotation.StyleRes;
 import app.organicmaps.base.BaseMwmFragmentActivity;
 import app.organicmaps.downloader.CountryItem;
 import app.organicmaps.downloader.MapManager;
+import app.organicmaps.intent.Factory;
 import app.organicmaps.location.LocationHelper;
 import app.organicmaps.location.LocationListener;
 import app.organicmaps.util.Config;
@@ -58,6 +61,9 @@ public class DownloadResourcesLegacyActivity extends BaseMwmFragmentActivity
 
   @Nullable
   private Dialog mAlertDialog;
+
+  @NonNull
+  private ActivityResultLauncher<Intent> mApiRequest;
 
   private boolean mAreResourcesDownloaded;
 
@@ -187,6 +193,10 @@ public class DownloadResourcesLegacyActivity extends BaseMwmFragmentActivity
     UiUtils.setLightStatusBar(this, true);
     setContentView(R.layout.activity_download_resources);
     initViewsAndListeners();
+    mApiRequest = registerForActivityResult(new ActivityResultContracts.StartActivityForResult(), result -> {
+      setResult(result.getResultCode(), result.getData());
+      finish();
+    });
 
     if (prepareFilesDownload(false))
     {
@@ -205,6 +215,8 @@ public class DownloadResourcesLegacyActivity extends BaseMwmFragmentActivity
   protected void onSafeDestroy()
   {
     super.onSafeDestroy();
+    mApiRequest.unregister();
+    mApiRequest = null;
     Utils.keepScreenOn(Config.isKeepScreenOnEnabled(), getWindow());
     if (mCountryDownloadListenerSlot != 0)
     {
@@ -346,6 +358,14 @@ public class DownloadResourcesLegacyActivity extends BaseMwmFragmentActivity
 
     // Disable animation because MwmActivity should appear exactly over this one
     intent.addFlags(Intent.FLAG_ACTIVITY_NO_ANIMATION | Intent.FLAG_ACTIVITY_CLEAR_TOP);
+
+    // See {@link SplashActivity.processNavigation()}
+    if (Factory.isStartedForApiResult(intent))
+    {
+      // Wait for the result from MwmActivity for API callers.
+      mApiRequest.launch(intent);
+      return;
+    }
 
     startActivity(intent);
     finish();

--- a/android/app/src/main/java/app/organicmaps/api/Const.java
+++ b/android/app/src/main/java/app/organicmaps/api/Const.java
@@ -9,6 +9,9 @@ public class Const
   public static final String EXTRA_PREFIX = AUTHORITY + ".extra";
   public static final String ACTION_PREFIX = AUTHORITY + ".action";
 
+  // Request extras
+  public static final String EXTRA_PICK_POINT = EXTRA_PREFIX + ".PICK_POINT";
+
   // Response extras
   public static final String EXTRA_POINT_NAME = EXTRA_PREFIX + ".POINT_NAME";
   public static final String EXTRA_POINT_LAT = EXTRA_PREFIX + ".POINT_LAT";

--- a/android/app/src/main/java/app/organicmaps/intent/Factory.java
+++ b/android/app/src/main/java/app/organicmaps/intent/Factory.java
@@ -28,11 +28,14 @@ import java.io.File;
 import java.util.Collections;
 import java.util.List;
 
+import static app.organicmaps.api.Const.EXTRA_PICK_POINT;
+
 public class Factory
 {
   public static boolean isStartedForApiResult(@NonNull Intent intent)
   {
-    return (intent.getFlags() & Intent.FLAG_ACTIVITY_FORWARD_RESULT) != 0;
+    return ((intent.getFlags() & Intent.FLAG_ACTIVITY_FORWARD_RESULT) != 0)
+           || intent.getBooleanExtra(EXTRA_PICK_POINT, false);
   }
 
   public static class KmzKmlProcessor implements IntentProcessor


### PR DESCRIPTION
It appears that the new streamlined logic introduced in c90c6bb
"Fix SecurityException when importing bookmarks" is not consistently
reliable across all scenarios, as reported in #8350.

Steps to reproduce:

1. Remove all versions of Organic Maps from the device except one.
The #8350 issue doesn't reproduce without this step.
2. Run PickPoint example from organicmaps/api-android repository.
3. The API call will always return RESULT_CANCELED.

Installing one more version of Organic Maps (Debug, Beta, Web, etc.)
alongside the existing version fixes the API to return RESULT_OK.
Debugging shows that FLAG_ACTIVITY_FORWARD_RESULT is not getting
set in this scenario.

Revert partially c90c6bb "Fix SecurityException ..." to restore
ActivityResultLauncher chain and re-add EXTRA_PICK_POINT, but
keep the idea of forwarding of the original intent.

Fixes #8350