### PR TITLE
Increase logging for direction calculation and TTS

### DIFF
--- a/routing/route.cpp
+++ b/routing/route.cpp
@@ -535,6 +535,9 @@ std::string Route::DebugPrintTurns() const
     // Always print first elemenst as Start.
     if (i == 0 || !turn.IsTurnNone())
     {
+      res += DebugPrint(mercator::ToLatLon(m_routeSegments[i].GetJunction()));
+      res += "\n";
+
       res += DebugPrint(turn);
       res += "\n";
 

--- a/routing/routing_helpers.cpp
+++ b/routing/routing_helpers.cpp
@@ -72,7 +72,7 @@ void ReconstructRoute(DirectionsEngine & engine, IndexRoadGraph const & graph,
 
   route.SetGeometry(routeGeometry.begin(), routeGeometry.end());
 
-  LOG(LDEBUG, (route.DebugPrintTurns()));
+  LOG(LINFO, (route.DebugPrintTurns()));
 }
 
 Segment ConvertEdgeToSegment(NumMwmIds const & numMwmIds, Edge const & edge)

--- a/routing/turns_notification_manager.cpp
+++ b/routing/turns_notification_manager.cpp
@@ -189,6 +189,8 @@ std::string NotificationManager::GenerateFirstTurnSound(TurnItem const & turn, d
           uint32_t const roundedDistToPronounceUnits =
               m_settings.RoundByPresetSoundedDistancesUnits(distToPronounceUnits);
           m_nextTurnNotificationProgress = PronouncedNotification::First;
+
+          LOG(LINFO,("TTS Distance to pronounce/turn/start/speed:",distanceToPronounceNotificationM,distanceToTurnMeters,startPronounceDistMeters,m_speedMetersPerSecond));
           return GenerateTurnText(roundedDistToPronounceUnits, turn.m_exitNum, false /* useThenInsteadOfDistance */,
                                   turn, nextStreetInfo);
         }
@@ -209,6 +211,8 @@ std::string NotificationManager::GenerateFirstTurnSound(TurnItem const & turn, d
   {
     m_nextTurnNotificationProgress = PronouncedNotification::Second;
     FastForwardFirstTurnNotification();
+
+    LOG(LINFO,("TTS Distance to pronounce/turn/speed:",distanceToPronounceNotificationM,distanceToTurnMeters,m_speedMetersPerSecond));
     return GenerateTurnText(0 /* distMeters */, turn.m_exitNum, false /* useThenInsteadOfDistance */, turn,
                             nextStreetInfo);
   }

--- a/routing/turns_notification_manager.cpp
+++ b/routing/turns_notification_manager.cpp
@@ -190,7 +190,7 @@ std::string NotificationManager::GenerateFirstTurnSound(TurnItem const & turn, d
               m_settings.RoundByPresetSoundedDistancesUnits(distToPronounceUnits);
           m_nextTurnNotificationProgress = PronouncedNotification::First;
 
-          LOG(LINFO,("TTS Distance to pronounce/turn/start/speed:",distanceToPronounceNotificationM,distanceToTurnMeters,startPronounceDistMeters,m_speedMetersPerSecond));
+          LOG(LINFO, ("TTS meters to pronounce", distanceToPronounceNotificationM, "meters to turn", distanceToTurnMeters, "meters to start pronounce", startPronounceDistMeters, "speed m/s", m_speedMetersPerSecond));
           return GenerateTurnText(roundedDistToPronounceUnits, turn.m_exitNum, false /* useThenInsteadOfDistance */,
                                   turn, nextStreetInfo);
         }

--- a/routing/turns_notification_manager.cpp
+++ b/routing/turns_notification_manager.cpp
@@ -212,7 +212,7 @@ std::string NotificationManager::GenerateFirstTurnSound(TurnItem const & turn, d
     m_nextTurnNotificationProgress = PronouncedNotification::Second;
     FastForwardFirstTurnNotification();
 
-    LOG(LINFO,("TTS Distance to pronounce/turn/speed:",distanceToPronounceNotificationM,distanceToTurnMeters,m_speedMetersPerSecond));
+    LOG(LINFO,("TTS meters to pronounce", distanceToPronounceNotificationM, "meters to turn", distanceToTurnMeters, "speed m/s", m_speedMetersPerSecond));
     return GenerateTurnText(0 /* distMeters */, turn.m_exitNum, false /* useThenInsteadOfDistance */, turn,
                             nextStreetInfo);
   }


### PR DESCRIPTION
Fixes #8822 

See below sample output. We have the GPS coordinate of each point in the route, the turn detail, and the road name info, which is most/all of the info needed to reconstruct direction/announcement decisions.

We also have the preexisting TTS/TTSn logging for what's actually spoken, and a new "TTS Distance" log entry that helps diagnose early/late announcements (it's a simple calculation based on a fixed number of seconds to begin the announcement and the current speed, with min/max bounds. See turns_notification_manager.cpp line 41, it's currently hardcoded to 8 seconds in both a vehicle and as a pedestrian, though obviously there's more to it than that, and more than one announcement per turn.)

<pre>
routing/index_router.cpp:714 CalculateSubroute(): Routing in mode: Joints
base/timer.cpp:178 ~ScopedTimerWithLog(): Route build time: 13 ms
routing/routing_helpers.cpp:75 ReconstructRoute(): ms::LatLon(60.9380125, -90.022555)
    TurnItem { m_index = 1, m_turn = None, m_lanes = [0: ], m_exitNum = 0, m_pedestrianDir = None }
    RoadNameInfo { m_name = Main Street, m_ref = , m_junction_ref = , m_destination_ref = , m_destination = , m_isLink = 0 }
    ms::LatLon(60.9383305, -90.022643)
    TurnItem { m_index = 3, m_turn = TurnLeft, m_lanes = [0: ], m_exitNum = 0, m_pedestrianDir = None }
    RoadNameInfo { m_name = Main Street, m_ref = , m_junction_ref = , m_destination_ref = , m_destination = , m_isLink = 0 }
    ms::LatLon(60.9384824, -90.023255)
    TurnItem { m_index = 4, m_turn = TurnRight, m_lanes = [0: ], m_exitNum = 0, m_pedestrianDir = None }
    RoadNameInfo { m_name = 2nd Street, m_ref = , m_junction_ref = , m_destination_ref = , m_destination = , m_isLink = 0 }
    ms::LatLon(60.9387672, -90.023317)
    TurnItem { m_index = 8, m_turn = ReachedYourDestination, m_lanes = [0: ], m_exitNum = 0, m_pedestrianDir = None }
    RoadNameInfo { m_name = , m_ref = , m_junction_ref = , m_destination_ref = , m_destination = , m_isLink = 0 }
routing/index_router.cpp:662 DoCalculateRoute(): Route length: 143.657 meters. ETA: 20.2653 seconds.
routing/async_router.cpp:230 LogCode(): Route found, elapsed seconds: 2.24976

// ComputeDistToPronounceDistM decides on 40 meters, we're 201m from turn, so start speaking at 240m out (which is now). Current speed is 5m/s
routing/turns_notification_manager.cpp:193 GenerateFirstTurnSound(): TTS Distance to pronounce/turn/start/speed: 40 201.111 240 5
routing/turns_tts_text.cpp:231 GetTurnNotification(): TTSn In two hundred meters Turn left onto 3rd Street
routing/turns_tts_text.cpp:249 GetTurnNotification(): TTS Then In two hundred and fifty meters Turn left.

// ComputeDistToPronounceDistM decides on 40 meters, we're 39m from turn, so start speaking now. Current speed is 5m/s
routing/turns_notification_manager.cpp:215 GenerateFirstTurnSound(): TTS Distance to pronounce/turn/speed: 40 39.7995 5
routing/turns_tts_text.cpp:231 GetTurnNotification(): TTSn Turn left onto Main Street
routing/turns_tts_text.cpp:249 GetTurnNotification(): TTS Then In four hundred meters Turn right.

// ComputeDistToPronounceDistM decides on 111 meters, we're 88m from turn, so start speaking now. Current speed is 13.8m/s
routing/turns_notification_manager.cpp:215 GenerateFirstTurnSound(): TTS Distance to pronounce/turn/speed: 111 88.6049 13.8889
routing/turns_tts_text.cpp:231 GetTurnNotification(): TTSn Turn right onto 4th Street
routing/turns_tts_text.cpp:249 GetTurnNotification(): TTS Then In four hundred meters Turn right.

// ComputeDistToPronounceDistM decides on 111 meters, we're 109m from turn, so start speaking now. Current speed is 13.8m/s
routing/turns_notification_manager.cpp:215 GenerateFirstTurnSound(): TTS Distance to pronounce/turn/speed: 111 109.42 13.8889
routing/turns_tts_text.cpp:231 GetTurnNotification(): TTSn Turn right onto 2nd Street
routing/turns_tts_text.cpp:249 GetTurnNotification(): TTS Then In three hundred meters You’ll arrive.
</pre>