### PR TITLE
Clear pointers when threads are shut down

### DIFF
--- a/platform/platform.cpp
+++ b/platform/platform.cpp
@@ -352,8 +352,11 @@ void Platform::ShutdownThreads()
   m_batteryTracker.UnsubscribeAll();
 
   m_networkThread->ShutdownAndJoin();
+  m_networkThread.reset();
   m_fileThread->ShutdownAndJoin();
+  m_fileThread.reset();
   m_backgroundThread->ShutdownAndJoin();
+  m_backgroundThread.reset();
 }
 
 void Platform::RunThreads()


### PR DESCRIPTION
This is a part of a bigger issue: iPad version built for Mac crashes on exit.

Upd: the comment in the test says that it's ok to post tasks on the destruction:
```
  GetPlatform().RunTask(Platform::Thread::File, []
  {
    TEST(false, ("The task must not be posted when thread runner is dead. "
                 "But app must not be crashed. It is normal behaviour during destruction"));
  });

```

However, when shutting down the Mac version, tasks _are_ posted and run in the main (GUI) thread even when shutdown was called:

```
base::TaskLoop::PushResult GuiThread::Push(Task && task)
{
  dispatch_async_f(dispatch_get_main_queue(), new Task(std::move(task)), &PerformImpl);
  return {true, TaskLoop::kNoId};
}

base::TaskLoop::PushResult GuiThread::Push(Task const & task)
{
  dispatch_async_f(dispatch_get_main_queue(), new Task(task), &PerformImpl);
  return {true, TaskLoop::kNoId};
}
```

@vng any ideas on how to fix it properly?