### PR TITLE
Enabled logs for free disk space checks when downloading/updating countries

### DIFF
--- a/platform/platform_unix_impl.cpp
+++ b/platform/platform_unix_impl.cpp
@@ -114,7 +114,7 @@ Platform::TStorageStatus Platform::GetWritableStorageStatus(uint64_t neededSize)
   struct statfs st;
   int const ret = statfs(m_writableDir.c_str(), &st);
 
-  LOG(LDEBUG, ("statfs return =", ret,
+  LOG(LINFO, ("statfs return =", ret,
                "; block size =", st.f_bsize,
                "; blocks available =", st.f_bavail));
 
@@ -125,7 +125,7 @@ Platform::TStorageStatus Platform::GetWritableStorageStatus(uint64_t neededSize)
   }
 
   auto const availableBytes = st.f_bsize * st.f_bavail;
-  LOG(LDEBUG, ("Free space check: requested =", neededSize, "; available =", availableBytes));
+  LOG(LINFO, ("Free space check: requested =", neededSize, "; available =", availableBytes));
   if (availableBytes < neededSize)
     return NOT_ENOUGH_SPACE;
 


### PR DESCRIPTION
There are several bug reports that iOS wrongly says that there is no free space available (e.g. https://github.com/organicmaps/organicmaps/issues/2969 ). As we can get iOS logs now, we can try to debug such cases.