### PR TITLE
[ios] Bring back `share my location` (partly revert 43c46beb0fd)

### DIFF
--- a/data/strings/strings.txt
+++ b/data/strings/strings.txt
@@ -4362,7 +4362,7 @@
 
   [unknown_current_position]
     comment = Warning message when doing search around current position
-    tags = android
+    tags = android,ios
     en = Your location hasn't been determined yet
     af = U ligging is nog nie vasgestel nie
     ar = لم يتم تحديد موقعك بعد.
@@ -5132,7 +5132,7 @@
     zh-Hant = 長度
 
   [share_my_location]
-    tags = android
+    tags = android,ios
     en = Share My Location
     af = Deel my ligging
     ar = مشاركة موقعي

--- a/iphone/Maps/LocalizedStrings/ar.lproj/Localizable.strings
+++ b/iphone/Maps/LocalizedStrings/ar.lproj/Localizable.strings
@@ -185,6 +185,9 @@
 /* resource for context menu */
 "edit" = "تعديل";
 
+/* Warning message when doing search around current position */
+"unknown_current_position" = "لم يتم تحديد موقعك بعد.";
+
 /* Subject for emailed bookmark */
 "bookmark_share_email_subject" = "مرحباً، تفقد الدبوس الخاص بي على خريطة Organic Maps!";
 
@@ -211,6 +214,8 @@
 
 /* Length of track in cell that describes route */
 "length" = "الطول";
+
+"share_my_location" = "مشاركة موقعي";
 
 "prefs_group_route" = "الملاحة";
 

--- a/iphone/Maps/LocalizedStrings/az.lproj/Localizable.strings
+++ b/iphone/Maps/LocalizedStrings/az.lproj/Localizable.strings
@@ -185,6 +185,9 @@
 /* resource for context menu */
 "edit" = "Redaktə et";
 
+/* Warning message when doing search around current position */
+"unknown_current_position" = "Məkanınız hələ müəyyən edilməyib";
+
 /* Subject for emailed bookmark */
 "bookmark_share_email_subject" = "Salam, Organic Maps xəritəsində mənim pin kodumu yoxlayın!";
 
@@ -211,6 +214,8 @@
 
 /* Length of track in cell that describes route */
 "length" = "Uzunluq";
+
+"share_my_location" = "Məkanımı Paylaşın";
 
 "prefs_group_route" = "Naviqasiya";
 

--- a/iphone/Maps/LocalizedStrings/be.lproj/Localizable.strings
+++ b/iphone/Maps/LocalizedStrings/be.lproj/Localizable.strings
@@ -185,6 +185,9 @@
 /* resource for context menu */
 "edit" = "Рэдагаваць";
 
+/* Warning message when doing search around current position */
+"unknown_current_position" = "Ваша месцазнаходжанне пакуль не вызначана";
+
 /* Subject for emailed bookmark */
 "bookmark_share_email_subject" = "Гэй, глядзі маю метку на Organic Maps!";
 
@@ -211,6 +214,8 @@
 
 /* Length of track in cell that describes route */
 "length" = "Даўжыня";
+
+"share_my_location" = "Абагуліць маё месцазнаходжанне";
 
 "prefs_group_route" = "Навігацыя";
 

--- a/iphone/Maps/LocalizedStrings/bg.lproj/Localizable.strings
+++ b/iphone/Maps/LocalizedStrings/bg.lproj/Localizable.strings
@@ -185,6 +185,9 @@
 /* resource for context menu */
 "edit" = "Редакция";
 
+/* Warning message when doing search around current position */
+"unknown_current_position" = "Местоположението ви още не е определено";
+
 /* Subject for emailed bookmark */
 "bookmark_share_email_subject" = "Хей, виж какво съм отбелязал в Organic Maps!";
 
@@ -211,6 +214,8 @@
 
 /* Length of track in cell that describes route */
 "length" = "Дължина";
+
+"share_my_location" = "Споделяне на местоположение";
 
 "prefs_group_route" = "Навигация";
 

--- a/iphone/Maps/LocalizedStrings/ca.lproj/Localizable.strings
+++ b/iphone/Maps/LocalizedStrings/ca.lproj/Localizable.strings
@@ -185,6 +185,9 @@
 /* resource for context menu */
 "edit" = "Edita";
 
+/* Warning message when doing search around current position */
+"unknown_current_position" = "Encara no s'ha pogut determinar la vostra geolocalització";
+
 /* Subject for emailed bookmark */
 "bookmark_share_email_subject" = "Ep, mireu el meu marcador a l'Organic Maps!";
 
@@ -211,6 +214,8 @@
 
 /* Length of track in cell that describes route */
 "length" = "Longitud";
+
+"share_my_location" = "Comparteix la meva ubicacio";
 
 "prefs_group_route" = "Navegació";
 

--- a/iphone/Maps/LocalizedStrings/cs.lproj/Localizable.strings
+++ b/iphone/Maps/LocalizedStrings/cs.lproj/Localizable.strings
@@ -185,6 +185,9 @@
 /* resource for context menu */
 "edit" = "Upravit";
 
+/* Warning message when doing search around current position */
+"unknown_current_position" = "Vaše poloha zatím nebyla určena";
+
 /* Subject for emailed bookmark */
 "bookmark_share_email_subject" = "Koukni na moji značku na mapě v Organic Maps";
 
@@ -211,6 +214,8 @@
 
 /* Length of track in cell that describes route */
 "length" = "Délka";
+
+"share_my_location" = "Sdílet mé umístění";
 
 "prefs_group_route" = "Navigace";
 

--- a/iphone/Maps/LocalizedStrings/da.lproj/Localizable.strings
+++ b/iphone/Maps/LocalizedStrings/da.lproj/Localizable.strings
@@ -185,6 +185,9 @@
 /* resource for context menu */
 "edit" = "Rediger";
 
+/* Warning message when doing search around current position */
+"unknown_current_position" = "Din lokation er ikke blevet bestemt endnu";
+
 /* Subject for emailed bookmark */
 "bookmark_share_email_subject" = "Hey, tjek min knappenål på Organic Maps kortet ud!";
 
@@ -211,6 +214,8 @@
 
 /* Length of track in cell that describes route */
 "length" = "Længde";
+
+"share_my_location" = "Del min lokation";
 
 "prefs_group_route" = "Navigation";
 

--- a/iphone/Maps/LocalizedStrings/de.lproj/Localizable.strings
+++ b/iphone/Maps/LocalizedStrings/de.lproj/Localizable.strings
@@ -185,6 +185,9 @@
 /* resource for context menu */
 "edit" = "Bearbeiten";
 
+/* Warning message when doing search around current position */
+"unknown_current_position" = "Ihr Standort konnte noch nicht ermittelt werden";
+
 /* Subject for emailed bookmark */
 "bookmark_share_email_subject" = "Hey, sieh dir meine Stecknadel auf der Organic Maps-Karte an!";
 
@@ -211,6 +214,8 @@
 
 /* Length of track in cell that describes route */
 "length" = "Länge";
+
+"share_my_location" = "Meinen Standort teilen";
 
 "prefs_group_route" = "Navigation";
 

--- a/iphone/Maps/LocalizedStrings/el.lproj/Localizable.strings
+++ b/iphone/Maps/LocalizedStrings/el.lproj/Localizable.strings
@@ -185,6 +185,9 @@
 /* resource for context menu */
 "edit" = "Επεξεργασία";
 
+/* Warning message when doing search around current position */
+"unknown_current_position" = "Η τοποθεσία σας δεν έχει προσδιοριστεί ακόμη";
+
 /* Subject for emailed bookmark */
 "bookmark_share_email_subject" = "Γεια, δες τις τοποθεσίες που έχω καρφιτσώσει στο Organic Maps!";
 
@@ -211,6 +214,8 @@
 
 /* Length of track in cell that describes route */
 "length" = "Μήκος";
+
+"share_my_location" = "Κοινοποίηση της τοποθεσίας μου";
 
 "prefs_group_route" = "Πλοήγηση";
 

--- a/iphone/Maps/LocalizedStrings/en-GB.lproj/Localizable.strings
+++ b/iphone/Maps/LocalizedStrings/en-GB.lproj/Localizable.strings
@@ -185,6 +185,9 @@
 /* resource for context menu */
 "edit" = "Edit";
 
+/* Warning message when doing search around current position */
+"unknown_current_position" = "Your location hasn't been determined yet";
+
 /* Subject for emailed bookmark */
 "bookmark_share_email_subject" = "Hey, check out my pin in Organic Maps!";
 
@@ -211,6 +214,8 @@
 
 /* Length of track in cell that describes route */
 "length" = "Length";
+
+"share_my_location" = "Share My Location";
 
 "prefs_group_route" = "Navigation";
 

--- a/iphone/Maps/LocalizedStrings/en.lproj/Localizable.strings
+++ b/iphone/Maps/LocalizedStrings/en.lproj/Localizable.strings
@@ -185,6 +185,9 @@
 /* resource for context menu */
 "edit" = "Edit";
 
+/* Warning message when doing search around current position */
+"unknown_current_position" = "Your location hasn't been determined yet";
+
 /* Subject for emailed bookmark */
 "bookmark_share_email_subject" = "Hey, check out my pin in Organic Maps!";
 
@@ -211,6 +214,8 @@
 
 /* Length of track in cell that describes route */
 "length" = "Length";
+
+"share_my_location" = "Share My Location";
 
 "prefs_group_route" = "Navigation";
 

--- a/iphone/Maps/LocalizedStrings/es-MX.lproj/Localizable.strings
+++ b/iphone/Maps/LocalizedStrings/es-MX.lproj/Localizable.strings
@@ -185,6 +185,9 @@
 /* resource for context menu */
 "edit" = "Editar";
 
+/* Warning message when doing search around current position */
+"unknown_current_position" = "Su ubicación aún no ha sido determinada";
+
 /* Subject for emailed bookmark */
 "bookmark_share_email_subject" = "¡Mira mi marcador en el mapa de Organic Maps!";
 
@@ -211,6 +214,8 @@
 
 /* Length of track in cell that describes route */
 "length" = "Longitud";
+
+"share_my_location" = "Compartir mi ubicación";
 
 "prefs_group_route" = "Navegación";
 

--- a/iphone/Maps/LocalizedStrings/es.lproj/Localizable.strings
+++ b/iphone/Maps/LocalizedStrings/es.lproj/Localizable.strings
@@ -185,6 +185,9 @@
 /* resource for context menu */
 "edit" = "Editar";
 
+/* Warning message when doing search around current position */
+"unknown_current_position" = "Su ubicación aún no ha sido determinada";
+
 /* Subject for emailed bookmark */
 "bookmark_share_email_subject" = "¡Mira mi marcador en el mapa de Organic Maps!";
 
@@ -211,6 +214,8 @@
 
 /* Length of track in cell that describes route */
 "length" = "Longitud";
+
+"share_my_location" = "Compartir mi ubicación";
 
 "prefs_group_route" = "Navegación";
 

--- a/iphone/Maps/LocalizedStrings/et.lproj/Localizable.strings
+++ b/iphone/Maps/LocalizedStrings/et.lproj/Localizable.strings
@@ -185,6 +185,9 @@
 /* resource for context menu */
 "edit" = "Muuda";
 
+/* Warning message when doing search around current position */
+"unknown_current_position" = "Sinu asukoht ei ole veel määratud";
+
 /* Subject for emailed bookmark */
 "bookmark_share_email_subject" = "Hei, vaata minu asukoha märget Organic Maps kaardil!";
 
@@ -211,6 +214,8 @@
 
 /* Length of track in cell that describes route */
 "length" = "Pikkus";
+
+"share_my_location" = "Jaga minu asukohta";
 
 "prefs_group_route" = "Navigeerimine";
 

--- a/iphone/Maps/LocalizedStrings/eu.lproj/Localizable.strings
+++ b/iphone/Maps/LocalizedStrings/eu.lproj/Localizable.strings
@@ -185,6 +185,9 @@
 /* resource for context menu */
 "edit" = "Editatu";
 
+/* Warning message when doing search around current position */
+"unknown_current_position" = "Zure kokapena ez da oraindik zehaztu";
+
 /* Subject for emailed bookmark */
 "bookmark_share_email_subject" = "Begiratu nire markagailua Organic Maps mapan!";
 
@@ -211,6 +214,8 @@
 
 /* Length of track in cell that describes route */
 "length" = "Luzera";
+
+"share_my_location" = "Partekatu nire kokapena";
 
 "prefs_group_route" = "Nabigazioa";
 

--- a/iphone/Maps/LocalizedStrings/fa.lproj/Localizable.strings
+++ b/iphone/Maps/LocalizedStrings/fa.lproj/Localizable.strings
@@ -185,6 +185,9 @@
 /* resource for context menu */
 "edit" = "ویرایش";
 
+/* Warning message when doing search around current position */
+"unknown_current_position" = "مکان شما هنوز مشخص نشده است";
+
 /* Subject for emailed bookmark */
 "bookmark_share_email_subject" = "Hey, check out my pin in Organic Maps!";
 
@@ -211,6 +214,8 @@
 
 /* Length of track in cell that describes route */
 "length" = "طول";
+
+"share_my_location" = "به اشتراک گذاری موقعیت مکانی من";
 
 "prefs_group_route" = "مسیریابی";
 

--- a/iphone/Maps/LocalizedStrings/fi.lproj/Localizable.strings
+++ b/iphone/Maps/LocalizedStrings/fi.lproj/Localizable.strings
@@ -185,6 +185,9 @@
 /* resource for context menu */
 "edit" = "Muokkaa";
 
+/* Warning message when doing search around current position */
+"unknown_current_position" = "Sijaintiasi ei ole vielä määritetty";
+
 /* Subject for emailed bookmark */
 "bookmark_share_email_subject" = "Hei, katso merkintäni Organic Maps-kartalla!";
 
@@ -211,6 +214,8 @@
 
 /* Length of track in cell that describes route */
 "length" = "Pituus";
+
+"share_my_location" = "Jaa sijaintini";
 
 "prefs_group_route" = "Navigointi";
 

--- a/iphone/Maps/LocalizedStrings/fr.lproj/Localizable.strings
+++ b/iphone/Maps/LocalizedStrings/fr.lproj/Localizable.strings
@@ -185,6 +185,9 @@
 /* resource for context menu */
 "edit" = "Modifier";
 
+/* Warning message when doing search around current position */
+"unknown_current_position" = "Votre position n'a pas encore été déterminée";
+
 /* Subject for emailed bookmark */
 "bookmark_share_email_subject" = "Hé, regardez mon signet sur la carte Organic Maps !";
 
@@ -211,6 +214,8 @@
 
 /* Length of track in cell that describes route */
 "length" = "Longueur";
+
+"share_my_location" = "Partager ma position";
 
 "prefs_group_route" = "Navigation";
 

--- a/iphone/Maps/LocalizedStrings/he.lproj/Localizable.strings
+++ b/iphone/Maps/LocalizedStrings/he.lproj/Localizable.strings
@@ -185,6 +185,9 @@
 /* resource for context menu */
 "edit" = "ערוך";
 
+/* Warning message when doing search around current position */
+"unknown_current_position" = "מיקומך לא אותר עדיין";
+
 /* Subject for emailed bookmark */
 "bookmark_share_email_subject" = "היי, בדוק את הסיכה שלי במפה של Organic Maps!";
 
@@ -211,6 +214,8 @@
 
 /* Length of track in cell that describes route */
 "length" = "אורך";
+
+"share_my_location" = "שיתוף מיקום שלי";
 
 "prefs_group_route" = "ניווט";
 

--- a/iphone/Maps/LocalizedStrings/hi.lproj/Localizable.strings
+++ b/iphone/Maps/LocalizedStrings/hi.lproj/Localizable.strings
@@ -185,6 +185,9 @@
 /* resource for context menu */
 "edit" = "संपादन करना";
 
+/* Warning message when doing search around current position */
+"unknown_current_position" = "आपका स्थान अभी तक निर्धारित नहीं किया गया है";
+
 /* Subject for emailed bookmark */
 "bookmark_share_email_subject" = "अरे, ऑर्गेनिक मैप्स में मेरा पिन देखें!";
 
@@ -211,6 +214,8 @@
 
 /* Length of track in cell that describes route */
 "length" = "लंबाई";
+
+"share_my_location" = "मेरा स्थान साझा करें";
 
 "prefs_group_route" = "मार्गदर्शन";
 

--- a/iphone/Maps/LocalizedStrings/hu.lproj/Localizable.strings
+++ b/iphone/Maps/LocalizedStrings/hu.lproj/Localizable.strings
@@ -185,6 +185,9 @@
 /* resource for context menu */
 "edit" = "Szerkeszt";
 
+/* Warning message when doing search around current position */
+"unknown_current_position" = "Még nem határoztuk meg az aktuális helyzetét";
+
 /* Subject for emailed bookmark */
 "bookmark_share_email_subject" = "Nézze meg a Organic Maps jelzőmet";
 
@@ -211,6 +214,8 @@
 
 /* Length of track in cell that describes route */
 "length" = "Hossz";
+
+"share_my_location" = "Helyzetem megosztása";
 
 "prefs_group_route" = "Navigáció";
 

--- a/iphone/Maps/LocalizedStrings/id.lproj/Localizable.strings
+++ b/iphone/Maps/LocalizedStrings/id.lproj/Localizable.strings
@@ -185,6 +185,9 @@
 /* resource for context menu */
 "edit" = "Edit";
 
+/* Warning message when doing search around current position */
+"unknown_current_position" = "Lokasi Anda belum ditentukan";
+
 /* Subject for emailed bookmark */
 "bookmark_share_email_subject" = "Hei, lihat pinku di peta Organic Maps";
 
@@ -211,6 +214,8 @@
 
 /* Length of track in cell that describes route */
 "length" = "Panjang";
+
+"share_my_location" = "Bagikan Lokasi Saya";
 
 "prefs_group_route" = "Navigasi";
 

--- a/iphone/Maps/LocalizedStrings/it.lproj/Localizable.strings
+++ b/iphone/Maps/LocalizedStrings/it.lproj/Localizable.strings
@@ -185,6 +185,9 @@
 /* resource for context menu */
 "edit" = "Modifica";
 
+/* Warning message when doing search around current position */
+"unknown_current_position" = "La tua posizione non è stata ancora stabilita";
+
 /* Subject for emailed bookmark */
 "bookmark_share_email_subject" = "Puoi vedere il mio luogo preferito sulla mappa Organic Maps!";
 
@@ -211,6 +214,8 @@
 
 /* Length of track in cell that describes route */
 "length" = "Lunghezza";
+
+"share_my_location" = "Condividi la mia posizione";
 
 "prefs_group_route" = "Navigazione";
 

--- a/iphone/Maps/LocalizedStrings/ja.lproj/Localizable.strings
+++ b/iphone/Maps/LocalizedStrings/ja.lproj/Localizable.strings
@@ -185,6 +185,9 @@
 /* resource for context menu */
 "edit" = "編集";
 
+/* Warning message when doing search around current position */
+"unknown_current_position" = "現在の座標が未確定です";
+
 /* Subject for emailed bookmark */
 "bookmark_share_email_subject" = "Organic Mapsでピン情報を確認";
 
@@ -211,6 +214,8 @@
 
 /* Length of track in cell that describes route */
 "length" = "距離";
+
+"share_my_location" = "現在地を共有する";
 
 "prefs_group_route" = "ナビゲーション";
 

--- a/iphone/Maps/LocalizedStrings/ko.lproj/Localizable.strings
+++ b/iphone/Maps/LocalizedStrings/ko.lproj/Localizable.strings
@@ -185,6 +185,9 @@
 /* resource for context menu */
 "edit" = "편집";
 
+/* Warning message when doing search around current position */
+"unknown_current_position" = "귀하의 위치를 아직 알아내지 못 했습니다";
+
 /* Subject for emailed bookmark */
 "bookmark_share_email_subject" = "Organic Maps 지도에서 내 핀 보기";
 
@@ -211,6 +214,8 @@
 
 /* Length of track in cell that describes route */
 "length" = "길이";
+
+"share_my_location" = "내 위치 공유";
 
 "prefs_group_route" = "네비게이션";
 

--- a/iphone/Maps/LocalizedStrings/mr.lproj/Localizable.strings
+++ b/iphone/Maps/LocalizedStrings/mr.lproj/Localizable.strings
@@ -185,6 +185,9 @@
 /* resource for context menu */
 "edit" = "संपादन";
 
+/* Warning message when doing search around current position */
+"unknown_current_position" = "तुमचे स्थान अद्याप निश्चित केलेले नाही";
+
 /* Subject for emailed bookmark */
 "bookmark_share_email_subject" = "Organic Maps द्वारे एक खूणपत्र पाठवत आहे!";
 
@@ -211,6 +214,8 @@
 
 /* Length of track in cell that describes route */
 "length" = "लांबी";
+
+"share_my_location" = "माझे स्थान सामायिक करा";
 
 "prefs_group_route" = "मार्गनिर्देशन";
 

--- a/iphone/Maps/LocalizedStrings/nb.lproj/Localizable.strings
+++ b/iphone/Maps/LocalizedStrings/nb.lproj/Localizable.strings
@@ -185,6 +185,9 @@
 /* resource for context menu */
 "edit" = "Rediger";
 
+/* Warning message when doing search around current position */
+"unknown_current_position" = "Posisjonen din har ikke blitt fastslått enda";
+
 /* Subject for emailed bookmark */
 "bookmark_share_email_subject" = "Hei, se merket mitt på Organic Maps-kartet";
 
@@ -211,6 +214,8 @@
 
 /* Length of track in cell that describes route */
 "length" = "Lengde";
+
+"share_my_location" = "Del posisjonen min";
 
 "prefs_group_route" = "Navigasjon";
 

--- a/iphone/Maps/LocalizedStrings/nl.lproj/Localizable.strings
+++ b/iphone/Maps/LocalizedStrings/nl.lproj/Localizable.strings
@@ -185,6 +185,9 @@
 /* resource for context menu */
 "edit" = "Wijzig";
 
+/* Warning message when doing search around current position */
+"unknown_current_position" = "Je locatie is nog niet vastgesteld";
+
 /* Subject for emailed bookmark */
 "bookmark_share_email_subject" = "Hey, bekijk mijn pin op Organic Maps!";
 
@@ -211,6 +214,8 @@
 
 /* Length of track in cell that describes route */
 "length" = "Lengte";
+
+"share_my_location" = "Deel mijn locatie";
 
 "prefs_group_route" = "Navigatie";
 

--- a/iphone/Maps/LocalizedStrings/pl.lproj/Localizable.strings
+++ b/iphone/Maps/LocalizedStrings/pl.lproj/Localizable.strings
@@ -185,6 +185,9 @@
 /* resource for context menu */
 "edit" = "Edytuj";
 
+/* Warning message when doing search around current position */
+"unknown_current_position" = "Nie określono jeszcze aktualnego położenia";
+
 /* Subject for emailed bookmark */
 "bookmark_share_email_subject" = "Hej, spójrz na mój znacznik w Organic Maps!";
 
@@ -211,6 +214,8 @@
 
 /* Length of track in cell that describes route */
 "length" = "Długość";
+
+"share_my_location" = "Udostępnij aktualne położenie";
 
 "prefs_group_route" = "Nawigacja";
 

--- a/iphone/Maps/LocalizedStrings/pt-BR.lproj/Localizable.strings
+++ b/iphone/Maps/LocalizedStrings/pt-BR.lproj/Localizable.strings
@@ -185,6 +185,9 @@
 /* resource for context menu */
 "edit" = "Editar";
 
+/* Warning message when doing search around current position */
+"unknown_current_position" = "A sua localização ainda não foi determinada";
+
 /* Subject for emailed bookmark */
 "bookmark_share_email_subject" = "Veja o meu marcador no mapa do Organic Maps.";
 
@@ -211,6 +214,8 @@
 
 /* Length of track in cell that describes route */
 "length" = "Comprimento";
+
+"share_my_location" = "Compartilhar a minha localização";
 
 "prefs_group_route" = "Navegação";
 

--- a/iphone/Maps/LocalizedStrings/pt.lproj/Localizable.strings
+++ b/iphone/Maps/LocalizedStrings/pt.lproj/Localizable.strings
@@ -185,6 +185,9 @@
 /* resource for context menu */
 "edit" = "Editar";
 
+/* Warning message when doing search around current position */
+"unknown_current_position" = "A sua localização ainda não foi determinada";
+
 /* Subject for emailed bookmark */
 "bookmark_share_email_subject" = "Veja o meu marcador no mapa do Organic Maps.";
 
@@ -211,6 +214,8 @@
 
 /* Length of track in cell that describes route */
 "length" = "Comprimento";
+
+"share_my_location" = "Partilhar a minha localização";
 
 "prefs_group_route" = "Navegação";
 

--- a/iphone/Maps/LocalizedStrings/ro.lproj/Localizable.strings
+++ b/iphone/Maps/LocalizedStrings/ro.lproj/Localizable.strings
@@ -185,6 +185,9 @@
 /* resource for context menu */
 "edit" = "Modifică";
 
+/* Warning message when doing search around current position */
+"unknown_current_position" = "Poziția ta nu a fost stabilită încă";
+
 /* Subject for emailed bookmark */
 "bookmark_share_email_subject" = "Poți vedea locul meu preferat pe harta Organic Maps!";
 
@@ -211,6 +214,8 @@
 
 /* Length of track in cell that describes route */
 "length" = "Lungime";
+
+"share_my_location" = "Trimite poziția mea";
 
 "prefs_group_route" = "Navigare";
 

--- a/iphone/Maps/LocalizedStrings/ru.lproj/Localizable.strings
+++ b/iphone/Maps/LocalizedStrings/ru.lproj/Localizable.strings
@@ -185,6 +185,9 @@
 /* resource for context menu */
 "edit" = "Редактировать";
 
+/* Warning message when doing search around current position */
+"unknown_current_position" = "Ваше местоположение ещё не определено";
+
 /* Subject for emailed bookmark */
 "bookmark_share_email_subject" = "Смотри мою метку на карте Organic Maps";
 
@@ -211,6 +214,8 @@
 
 /* Length of track in cell that describes route */
 "length" = "Длина";
+
+"share_my_location" = "Поделиться местоположением";
 
 "prefs_group_route" = "Навигация";
 

--- a/iphone/Maps/LocalizedStrings/sk.lproj/Localizable.strings
+++ b/iphone/Maps/LocalizedStrings/sk.lproj/Localizable.strings
@@ -185,6 +185,9 @@
 /* resource for context menu */
 "edit" = "Upraviť";
 
+/* Warning message when doing search around current position */
+"unknown_current_position" = "Vaša poloha zatiaľ nebola určená";
+
 /* Subject for emailed bookmark */
 "bookmark_share_email_subject" = "Pozri na moju značku na mape Organic Maps";
 
@@ -211,6 +214,8 @@
 
 /* Length of track in cell that describes route */
 "length" = "Dĺžka";
+
+"share_my_location" = "Zdieľať moje umiestnenie";
 
 "prefs_group_route" = "Navigácia";
 

--- a/iphone/Maps/LocalizedStrings/sv.lproj/Localizable.strings
+++ b/iphone/Maps/LocalizedStrings/sv.lproj/Localizable.strings
@@ -185,6 +185,9 @@
 /* resource for context menu */
 "edit" = "Redigera";
 
+/* Warning message when doing search around current position */
+"unknown_current_position" = "Din position har inte bestämts ännu";
+
 /* Subject for emailed bookmark */
 "bookmark_share_email_subject" = "Hej, kolla på min pin på Organic Maps kartan";
 
@@ -211,6 +214,8 @@
 
 /* Length of track in cell that describes route */
 "length" = "Längd";
+
+"share_my_location" = "Dela Min Plats";
 
 "prefs_group_route" = "Navigering";
 

--- a/iphone/Maps/LocalizedStrings/sw.lproj/Localizable.strings
+++ b/iphone/Maps/LocalizedStrings/sw.lproj/Localizable.strings
@@ -185,6 +185,9 @@
 /* resource for context menu */
 "edit" = "Edit";
 
+/* Warning message when doing search around current position */
+"unknown_current_position" = "Your location hasn't been determined yet";
+
 /* Subject for emailed bookmark */
 "bookmark_share_email_subject" = "Hey, check out my pin in Organic Maps!";
 
@@ -211,6 +214,8 @@
 
 /* Length of track in cell that describes route */
 "length" = "Length";
+
+"share_my_location" = "Share My Location";
 
 "prefs_group_route" = "Navigation";
 

--- a/iphone/Maps/LocalizedStrings/th.lproj/Localizable.strings
+++ b/iphone/Maps/LocalizedStrings/th.lproj/Localizable.strings
@@ -185,6 +185,9 @@
 /* resource for context menu */
 "edit" = "แก้ไข";
 
+/* Warning message when doing search around current position */
+"unknown_current_position" = "ตำแหน่งที่ตั้งของคุณยังไม่ได้รับการกำหนด";
+
 /* Subject for emailed bookmark */
 "bookmark_share_email_subject" = "เฮ้ ตรวจสอบหมุดของฉันที่ แผนที่ Organic Maps!";
 
@@ -211,6 +214,8 @@
 
 /* Length of track in cell that describes route */
 "length" = "ระยะเวลา";
+
+"share_my_location" = "แชร์ตำแหน่งที่ตั้งของฉัน";
 
 "prefs_group_route" = "การนำทาง";
 

--- a/iphone/Maps/LocalizedStrings/tr.lproj/Localizable.strings
+++ b/iphone/Maps/LocalizedStrings/tr.lproj/Localizable.strings
@@ -185,6 +185,9 @@
 /* resource for context menu */
 "edit" = "Düzenle";
 
+/* Warning message when doing search around current position */
+"unknown_current_position" = "Konumunuz henüz belirlenmedi";
+
 /* Subject for emailed bookmark */
 "bookmark_share_email_subject" = "Hey, Organic Maps haritasında raptiyemi incele!";
 
@@ -211,6 +214,8 @@
 
 /* Length of track in cell that describes route */
 "length" = "Uzunluk";
+
+"share_my_location" = "Konumumu Paylaş";
 
 "prefs_group_route" = "Navigasyon";
 

--- a/iphone/Maps/LocalizedStrings/uk.lproj/Localizable.strings
+++ b/iphone/Maps/LocalizedStrings/uk.lproj/Localizable.strings
@@ -185,6 +185,9 @@
 /* resource for context menu */
 "edit" = "Редагувати";
 
+/* Warning message when doing search around current position */
+"unknown_current_position" = "Ваше місце розташування не визначено";
+
 /* Subject for emailed bookmark */
 "bookmark_share_email_subject" = "Поглянь на мою мiтку на мапі Organic Maps";
 
@@ -211,6 +214,8 @@
 
 /* Length of track in cell that describes route */
 "length" = "Довжина";
+
+"share_my_location" = "Поділитися моїм місцезнаходженням";
 
 "prefs_group_route" = "Навігація";
 

--- a/iphone/Maps/LocalizedStrings/vi.lproj/Localizable.strings
+++ b/iphone/Maps/LocalizedStrings/vi.lproj/Localizable.strings
@@ -185,6 +185,9 @@
 /* resource for context menu */
 "edit" = "Sửa";
 
+/* Warning message when doing search around current position */
+"unknown_current_position" = "Chưa xác định được vị trí của bạn";
+
 /* Subject for emailed bookmark */
 "bookmark_share_email_subject" = "Này, hãy xem ghim của tôi tại Organic Maps map";
 
@@ -211,6 +214,8 @@
 
 /* Length of track in cell that describes route */
 "length" = "Độ dài";
+
+"share_my_location" = "Chia sẻ Vị trí của tôi";
 
 "prefs_group_route" = "Điều hướng";
 

--- a/iphone/Maps/LocalizedStrings/zh-Hans.lproj/Localizable.strings
+++ b/iphone/Maps/LocalizedStrings/zh-Hans.lproj/Localizable.strings
@@ -185,6 +185,9 @@
 /* resource for context menu */
 "edit" = "编辑";
 
+/* Warning message when doing search around current position */
+"unknown_current_position" = "您的位置尚未确定";
+
 /* Subject for emailed bookmark */
 "bookmark_share_email_subject" = "嘿，在 Organic Maps 上查看我标注的图钉吧！";
 
@@ -211,6 +214,8 @@
 
 /* Length of track in cell that describes route */
 "length" = "长度";
+
+"share_my_location" = "共享我的位置";
 
 "prefs_group_route" = "导航";
 

--- a/iphone/Maps/LocalizedStrings/zh-Hant.lproj/Localizable.strings
+++ b/iphone/Maps/LocalizedStrings/zh-Hant.lproj/Localizable.strings
@@ -185,6 +185,9 @@
 /* resource for context menu */
 "edit" = "編輯";
 
+/* Warning message when doing search around current position */
+"unknown_current_position" = "您的位置尚未定位完成";
+
 /* Subject for emailed bookmark */
 "bookmark_share_email_subject" = "嘿，看看我在 Organic Maps 地圖上的圖釘！";
 
@@ -211,6 +214,8 @@
 
 /* Length of track in cell that describes route */
 "length" = "長度";
+
+"share_my_location" = "分享我的位置";
 
 "prefs_group_route" = "導航";
 

--- a/iphone/Maps/UI/BottomMenu/Menu/BottomMenuInteractor.swift
+++ b/iphone/Maps/UI/BottomMenu/Menu/BottomMenuInteractor.swift
@@ -4,6 +4,7 @@ protocol BottomMenuInteractorProtocol: AnyObject {
   func downloadMaps()
   func donate()
   func openSettings()
+  func shareLocation(cell: BottomMenuItemCell)
 }
 
 @objc protocol BottomMenuDelegate {
@@ -59,5 +60,18 @@ extension BottomMenuInteractor: BottomMenuInteractorProtocol {
   func openSettings() {
     close()
     mapViewController?.performSegue(withIdentifier: "Map2Settings", sender: nil)
+  }
+
+  func shareLocation(cell: BottomMenuItemCell) {
+    let lastLocation = LocationManager.lastLocation()
+    guard let coordinates = lastLocation?.coordinate else {
+      let alert = UIAlertController(title: L("unknown_current_position"), message: nil, preferredStyle: .alert)
+      alert.addAction(UIAlertAction(title: L("ok"), style: .default, handler: nil))
+      viewController?.present(alert, animated: true, completion: nil)
+      return;
+    }
+    guard let viewController = viewController else { return }
+    let vc = ActivityViewController.share(forMyPosition: coordinates)
+    vc.present(inParentViewController: viewController, anchorView: cell.anchorView)
   }
 }

--- a/iphone/Maps/UI/BottomMenu/Menu/BottomMenuPresenter.swift
+++ b/iphone/Maps/UI/BottomMenu/Menu/BottomMenuPresenter.swift
@@ -8,6 +8,7 @@ class BottomMenuPresenter: NSObject {
     case downloadMaps
     case donate
     case settings
+    case share
   }
   enum Sections: Int {
     case layers
@@ -79,6 +80,11 @@ extension BottomMenuPresenter {
                      title: L("settings"),
                      badgeCount: 0,
                      enabled: true)
+    case .share:
+      cell.configure(imageName: "ic_menu_share",
+                     title: L("share_my_location"),
+                     badgeCount: 0,
+                     enabled: true)
     }
     return cell
   }
@@ -102,6 +108,10 @@ extension BottomMenuPresenter {
       interactor.donate()
     case .settings:
       interactor.openSettings()
+    case .share:
+      if let cell = tableView.cellForRow(at: indexPath) as? BottomMenuItemCell {
+        interactor.shareLocation(cell: cell)
+      }
     }
   }
 }


### PR DESCRIPTION
Share my location was removed by mistake un #8639
This PR brings the button back.