### PR TITLE
[search] Use brand as name and don't use address as name

### DIFF
--- a/indexer/ftypes_matcher.cpp
+++ b/indexer/ftypes_matcher.cpp
@@ -362,6 +362,13 @@ IsAddressObjectChecker::IsAddressObjectChecker() : BaseChecker(1 /* level */)
     m_types.push_back(c.GetTypeByPath({p}));
 }
 
+IsAddressChecker::IsAddressChecker() : BaseChecker(1 /* level */)
+{
+  Classificator const & c = classif();
+  for (auto const * p : {"addr:interpolation", "building", "entrance"})
+    m_types.push_back(c.GetTypeByPath({p}));
+}
+
 IsVillageChecker::IsVillageChecker()
 {
   // TODO (@y, @m, @vng): this list must be up-to-date with

--- a/indexer/ftypes_matcher.hpp
+++ b/indexer/ftypes_matcher.hpp
@@ -202,6 +202,13 @@ public:
   DECLARE_CHECKER_INSTANCE(IsAddressObjectChecker);
 };
 
+class IsAddressChecker : public BaseChecker
+{
+  IsAddressChecker();
+public:
+  DECLARE_CHECKER_INSTANCE(IsAddressChecker);
+};
+
 class IsVillageChecker : public BaseChecker
 {
   IsVillageChecker();

--- a/search/intermediate_result.cpp
+++ b/search/intermediate_result.cpp
@@ -169,7 +169,7 @@ RankerResult::RankerResult(FeatureType & ft, m2::PointD const & center,
 
   m_region.SetParams(fileName, center);
 
-  FillDetails(ft, m_details);
+  FillDetails(ft, m_str, m_details);
 }
 
 RankerResult::RankerResult(FeatureType & ft, std::string const & fileName)
@@ -250,7 +250,7 @@ bool RankerResult::RegionInfo::GetCountryId(storage::CountryInfoGetter const & i
 }
 
 // Functions ---------------------------------------------------------------------------------------
-void FillDetails(FeatureType & ft, Result::Details & details)
+void FillDetails(FeatureType & ft, std::string const & name, Result::Details & details)
 {
   if (details.m_isInitialized)
     return;
@@ -260,6 +260,9 @@ void FillDetails(FeatureType & ft, Result::Details & details)
   std::string brand {ft.GetMetadata(feature::Metadata::FMD_BRAND)};
   if (!brand.empty())
     brand = platform::GetLocalizedBrandName(brand);
+
+  if (name == brand)
+    brand.clear();
 
   /// @todo Avoid temporary string when OpeningHours (boost::spirit) will allow string_view.
   std::string const openHours(ft.GetMetadata(feature::Metadata::FMD_OPEN_HOURS));

--- a/search/intermediate_result.hpp
+++ b/search/intermediate_result.hpp
@@ -192,5 +192,5 @@ private:
 #endif
 };
 
-void FillDetails(FeatureType & ft, Result::Details & meta);
+void FillDetails(FeatureType & ft, std::string const & name, Result::Details & details);
 }  // namespace search

--- a/search/ranker.cpp
+++ b/search/ranker.cpp
@@ -16,6 +16,8 @@
 #include "indexer/road_shields_parser.hpp"
 #include "indexer/search_string_utils.hpp"
 
+#include "platform/localization.hpp"
+
 #include "coding/string_utf8_multilang.hpp"
 
 #include "base/logging.hpp"
@@ -470,6 +472,14 @@ private:
 
     center = feature::GetCenter(*ft);
     m_ranker.GetBestMatchName(*ft, name);
+
+    // Use brand instead of empty result name.
+    if (!m_isViewportMode && name.empty())
+    {
+      std::string_view brand = (*ft).GetMetadata(feature::Metadata::FMD_BRAND);
+      if (!brand.empty())
+        name = platform::GetLocalizedBrandName(std::string{ brand });
+    }
 
     // Insert exact address (street and house number) instead of empty result name.
     if (!m_isViewportMode && name.empty())

--- a/search/ranker.cpp
+++ b/search/ranker.cpp
@@ -484,6 +484,14 @@ private:
     // Insert exact address (street and house number) instead of empty result name.
     if (!m_isViewportMode && name.empty())
     {
+      feature::TypesHolder featureTypes(*ft);
+      featureTypes.SortBySpec();
+      auto const bestType = featureTypes.GetBestType();
+      auto const addressChecker = ftypes::IsAddressChecker::Instance();
+    
+      if (!addressChecker.IsMatched(bestType))
+        return ft;
+
       ReverseGeocoder::Address addr;
       if (GetExactAddress(*ft, center, addr))
       {


### PR DESCRIPTION
This PR modifies how the search results are shown:

* Use brand as name if name is empty
* Don't use address as name if name is empty, unless the POI is simply an address

Related issues:

* Fixes https://github.com/organicmaps/organicmaps/issues/8875
* Fixes https://github.com/organicmaps/organicmaps/issues/6882

---

<img src="https://github.com/user-attachments/assets/d2a20b61-fe36-4b5b-91f3-6320ead5f39f" width="320"/>

<img src="https://github.com/user-attachments/assets/5ed34fce-a401-4b7d-91de-a2afbbb14b26" width="320"/>

<img src="https://github.com/user-attachments/assets/5bcec466-c9f0-491d-b27e-4091dfd1dc84" width="320"/>
