### PR TITLE
[strings] Sort plural forms in CLDR order

### DIFF
--- a/android/app/src/main/res/values-be/strings.xml
+++ b/android/app/src/main/res/values-be/strings.xml
@@ -602,8 +602,8 @@
 	<string name="bookmark_lists_hide_all">Схаваць усе</string>
 	<string name="bookmark_lists_show_all">Паказаць усе</string>
 	<plurals name="bookmarks_places">
-	  <item quantity="few">%d закладкі</item>
 	  <item quantity="one">%d закладка</item>
+	  <item quantity="few">%d закладкі</item>
 	  <item quantity="other">%d закладак</item>
 	</plurals>
 	<string name="bookmarks_create_new_group">Стварыць новы спіс</string>
@@ -622,8 +622,8 @@
 	<string name="profile">Профіль OpenStreetMap</string>
 	<string name="restore">Аднавіць</string>
 	<plurals name="tracks">
-	  <item quantity="few">%d сцежкі</item>
 	  <item quantity="one">%d сцежка</item>
+	  <item quantity="few">%d сцежкі</item>
 	  <item quantity="other">%d сцежак</item>
 	</plurals>
 	<!-- Settings privacy group in settings screen -->

--- a/android/app/src/main/res/values-cs/strings.xml
+++ b/android/app/src/main/res/values-cs/strings.xml
@@ -597,8 +597,8 @@
 	<string name="phone_number">Telefonní číslo</string>
 	<string name="profile">Profil OpenStreetMap</string>
 	<plurals name="bookmarks_detect_message">
-	  <item quantity="few">%d byly nalezeny soubory. Uvidíte je po konverzi.</item>
 	  <item quantity="one">%d soubor byl nalezen. Uvidíte ji po konverzi.</item>
+	  <item quantity="few">%d byly nalezeny soubory. Uvidíte je po konverzi.</item>
 	  <item quantity="other">Bylo nalezeno %d souborů. Uvidíte je po konverzi.</item>
 	</plurals>
 	<string name="restore">Obnovit</string>

--- a/android/app/src/main/res/values-pl/strings.xml
+++ b/android/app/src/main/res/values-pl/strings.xml
@@ -625,14 +625,14 @@
 	<string name="profile">Profil OpenStreetMap</string>
 	<plurals name="bookmarks_detect_message">
 	  <item quantity="one">Znaleziono %d plik. Zobaczysz to po konwersji.</item>
-	  <item quantity="other">Znaleziono %d plików. Zobaczysz je po konwersji.</item>
 	  <item quantity="two">Znaleziono %d pliki. Zobaczysz je po konwersji.</item>
+	  <item quantity="other">Znaleziono %d plików. Zobaczysz je po konwersji.</item>
 	</plurals>
 	<string name="restore">Przywróć</string>
 	<plurals name="tracks">
+	  <item quantity="one">%d trasa</item>
 	  <item quantity="few">%d trasy</item>
 	  <item quantity="many">%d tras</item>
-	  <item quantity="one">%d trasa</item>
 	  <item quantity="other">%d trasy</item>
 	</plurals>
 	<!-- Settings privacy group in settings screen -->

--- a/android/app/src/main/res/values-ru/strings.xml
+++ b/android/app/src/main/res/values-ru/strings.xml
@@ -613,8 +613,8 @@
 	<string name="bookmark_lists_hide_all">Спрятать все</string>
 	<string name="bookmark_lists_show_all">Показать все</string>
 	<plurals name="bookmarks_places">
-	  <item quantity="few">%d метки</item>
 	  <item quantity="one">%d метка</item>
+	  <item quantity="few">%d метки</item>
 	  <item quantity="other">%d меток</item>
 	</plurals>
 	<string name="bookmarks_create_new_group">Создать новый список</string>
@@ -632,14 +632,14 @@
 	<string name="phone_number">Номер телефона</string>
 	<string name="profile">Профиль OpenStreetMap</string>
 	<plurals name="bookmarks_detect_message">
-	  <item quantity="few">%d файла были найдены. Вы увидите их после конвертации.</item>
 	  <item quantity="one">%d файл был найден. Вы увидите его после конвертации.</item>
+	  <item quantity="few">%d файла были найдены. Вы увидите их после конвертации.</item>
 	  <item quantity="other">%d файлов было найдено. Вы увидите их после конвертации.</item>
 	</plurals>
 	<string name="restore">Восстановить</string>
 	<plurals name="tracks">
-	  <item quantity="few">%d трека</item>
 	  <item quantity="one">%d трек</item>
+	  <item quantity="few">%d трека</item>
 	  <item quantity="other">%d треков</item>
 	</plurals>
 	<!-- Settings privacy group in settings screen -->

--- a/android/app/src/main/res/values-sk/strings.xml
+++ b/android/app/src/main/res/values-sk/strings.xml
@@ -622,8 +622,8 @@
 	<string name="phone_number">Telefónne číslo</string>
 	<string name="profile">Profil OpenStreetMap</string>
 	<plurals name="bookmarks_detect_message">
-	  <item quantity="few">Boli nájdené %d súbory. Uvidíte ich po konverzii.</item>
 	  <item quantity="one">Bol nájdený %d súbor. Uvidíte to po konverzii.</item>
+	  <item quantity="few">Boli nájdené %d súbory. Uvidíte ich po konverzii.</item>
 	  <item quantity="other">Bolo nájdených %d súborov. Uvidíte ich po konverzii.</item>
 	</plurals>
 	<string name="restore">Obnoviť</string>

--- a/android/app/src/main/res/values-uk/strings.xml
+++ b/android/app/src/main/res/values-uk/strings.xml
@@ -610,8 +610,8 @@
 	<string name="bookmark_lists_hide_all">Приховати всі</string>
 	<string name="bookmark_lists_show_all">Показати всі</string>
 	<plurals name="bookmarks_places">
-	  <item quantity="few">%d мітки</item>
 	  <item quantity="one">%d мітка</item>
+	  <item quantity="few">%d мітки</item>
 	  <item quantity="other">%d міток</item>
 	</plurals>
 	<string name="bookmarks_create_new_group">Створити новий список</string>
@@ -629,8 +629,8 @@
 	<string name="phone_number">Номер телефону</string>
 	<string name="profile">Профіль OpenStreetMap</string>
 	<plurals name="bookmarks_detect_message">
-	  <item quantity="few">%d файлу були знайдені. Ви побачите їх після конвертації.</item>
 	  <item quantity="one">%d файл був знайдений. Ви побачите його після перетворення.</item>
+	  <item quantity="few">%d файлу були знайдені. Ви побачите їх після конвертації.</item>
 	  <item quantity="other">%d файлів було знайдено. Ви побачите їх після конвертації.</item>
 	</plurals>
 	<string name="restore">Відновити</string>

--- a/iphone/Maps/LocalizedStrings/be.lproj/Localizable.stringsdict
+++ b/iphone/Maps/LocalizedStrings/be.lproj/Localizable.stringsdict
@@ -19,10 +19,10 @@
       <string>NSStringPluralRuleType</string>
       <key>NSStringFormatValueTypeKey</key>
       <string>d</string>
-      <key>few</key>
-      <string>%d закладкі</string>
       <key>one</key>
       <string>%d закладка</string>
+      <key>few</key>
+      <string>%d закладкі</string>
       <key>other</key>
       <string>%d закладак</string>
     </dict>
@@ -53,10 +53,10 @@
       <string>NSStringPluralRuleType</string>
       <key>NSStringFormatValueTypeKey</key>
       <string>d</string>
-      <key>few</key>
-      <string>%d сцежкі</string>
       <key>one</key>
       <string>%d сцежка</string>
+      <key>few</key>
+      <string>%d сцежкі</string>
       <key>other</key>
       <string>%d сцежак</string>
     </dict>

--- a/iphone/Maps/LocalizedStrings/cs.lproj/Localizable.stringsdict
+++ b/iphone/Maps/LocalizedStrings/cs.lproj/Localizable.stringsdict
@@ -34,10 +34,10 @@
       <string>NSStringPluralRuleType</string>
       <key>NSStringFormatValueTypeKey</key>
       <string>d</string>
-      <key>few</key>
-      <string>%d byly nalezeny soubory. Uvidíte je po konverzi.</string>
       <key>one</key>
       <string>%d soubor byl nalezen. Uvidíte ji po konverzi.</string>
+      <key>few</key>
+      <string>%d byly nalezeny soubory. Uvidíte je po konverzi.</string>
       <key>other</key>
       <string>Bylo nalezeno %d souborů. Uvidíte je po konverzi.</string>
     </dict>

--- a/iphone/Maps/LocalizedStrings/pl.lproj/Localizable.stringsdict
+++ b/iphone/Maps/LocalizedStrings/pl.lproj/Localizable.stringsdict
@@ -36,10 +36,10 @@
       <string>d</string>
       <key>one</key>
       <string>Znaleziono %d plik. Zobaczysz to po konwersji.</string>
-      <key>other</key>
-      <string>Znaleziono %d plików. Zobaczysz je po konwersji.</string>
       <key>two</key>
       <string>Znaleziono %d pliki. Zobaczysz je po konwersji.</string>
+      <key>other</key>
+      <string>Znaleziono %d plików. Zobaczysz je po konwersji.</string>
     </dict>
   </dict>
 
@@ -53,12 +53,12 @@
       <string>NSStringPluralRuleType</string>
       <key>NSStringFormatValueTypeKey</key>
       <string>d</string>
+      <key>one</key>
+      <string>%d trasa</string>
       <key>few</key>
       <string>%d trasy</string>
       <key>many</key>
       <string>%d tras</string>
-      <key>one</key>
-      <string>%d trasa</string>
       <key>other</key>
       <string>%d trasy</string>
     </dict>

--- a/iphone/Maps/LocalizedStrings/ru.lproj/Localizable.stringsdict
+++ b/iphone/Maps/LocalizedStrings/ru.lproj/Localizable.stringsdict
@@ -19,10 +19,10 @@
       <string>NSStringPluralRuleType</string>
       <key>NSStringFormatValueTypeKey</key>
       <string>d</string>
-      <key>few</key>
-      <string>%d метки</string>
       <key>one</key>
       <string>%d метка</string>
+      <key>few</key>
+      <string>%d метки</string>
       <key>other</key>
       <string>%d меток</string>
     </dict>
@@ -38,10 +38,10 @@
       <string>NSStringPluralRuleType</string>
       <key>NSStringFormatValueTypeKey</key>
       <string>d</string>
-      <key>few</key>
-      <string>%d файла были найдены. Вы увидите их после конвертации.</string>
       <key>one</key>
       <string>%d файл был найден. Вы увидите его после конвертации.</string>
+      <key>few</key>
+      <string>%d файла были найдены. Вы увидите их после конвертации.</string>
       <key>other</key>
       <string>%d файлов было найдено. Вы увидите их после конвертации.</string>
     </dict>
@@ -57,10 +57,10 @@
       <string>NSStringPluralRuleType</string>
       <key>NSStringFormatValueTypeKey</key>
       <string>d</string>
-      <key>few</key>
-      <string>%d трека</string>
       <key>one</key>
       <string>%d трек</string>
+      <key>few</key>
+      <string>%d трека</string>
       <key>other</key>
       <string>%d треков</string>
     </dict>

--- a/iphone/Maps/LocalizedStrings/sk.lproj/Localizable.stringsdict
+++ b/iphone/Maps/LocalizedStrings/sk.lproj/Localizable.stringsdict
@@ -34,10 +34,10 @@
       <string>NSStringPluralRuleType</string>
       <key>NSStringFormatValueTypeKey</key>
       <string>d</string>
-      <key>few</key>
-      <string>Boli nájdené %d súbory. Uvidíte ich po konverzii.</string>
       <key>one</key>
       <string>Bol nájdený %d súbor. Uvidíte to po konverzii.</string>
+      <key>few</key>
+      <string>Boli nájdené %d súbory. Uvidíte ich po konverzii.</string>
       <key>other</key>
       <string>Bolo nájdených %d súborov. Uvidíte ich po konverzii.</string>
     </dict>

--- a/iphone/Maps/LocalizedStrings/uk.lproj/Localizable.stringsdict
+++ b/iphone/Maps/LocalizedStrings/uk.lproj/Localizable.stringsdict
@@ -19,10 +19,10 @@
       <string>NSStringPluralRuleType</string>
       <key>NSStringFormatValueTypeKey</key>
       <string>d</string>
-      <key>few</key>
-      <string>%d мітки</string>
       <key>one</key>
       <string>%d мітка</string>
+      <key>few</key>
+      <string>%d мітки</string>
       <key>other</key>
       <string>%d міток</string>
     </dict>
@@ -38,10 +38,10 @@
       <string>NSStringPluralRuleType</string>
       <key>NSStringFormatValueTypeKey</key>
       <string>d</string>
-      <key>few</key>
-      <string>%d файлу були знайдені. Ви побачите їх після конвертації.</string>
       <key>one</key>
       <string>%d файл був знайдений. Ви побачите його після перетворення.</string>
+      <key>few</key>
+      <string>%d файлу були знайдені. Ви побачите їх після конвертації.</string>
       <key>other</key>
       <string>%d файлів було знайдено. Ви побачите їх після конвертації.</string>
     </dict>


### PR DESCRIPTION
This depends on https://github.com/organicmaps/twine/pull/9

This reorders plural forms from alphabetic order into CLDR order