### PR TITLE
[android] scale progress text, force to single line fixes

### DIFF
--- a/android/app/src/main/res/layout-land/onmap_downloader.xml
+++ b/android/app/src/main/res/layout-land/onmap_downloader.xml
@@ -49,10 +49,10 @@
       <TextView
           android:id="@+id/downloader_size"
           android:layout_width="match_parent"
-          android:layout_height="24sp"
+          android:layout_height="48sp"
           android:layout_margin="@dimen/margin_half"
-          android:gravity="center_horizontal|center_vertical"
-          android:lines="1"
+          android:gravity="center_horizontal|top"
+          android:lines="2"
           android:textAppearance="@style/MwmTextAppearance.Body2"
           app:autoSizeMaxTextSize="@dimen/text_size_body_2"
           app:autoSizeMinTextSize="@dimen/text_size_body_2_min"

--- a/android/app/src/main/res/layout-land/onmap_downloader.xml
+++ b/android/app/src/main/res/layout-land/onmap_downloader.xml
@@ -45,14 +45,20 @@
         android:gravity="center_horizontal"
         tools:text="Some name very loooooooooong name"
         tools:ignore="UnusedAttribute"/>
+
       <TextView
-        android:id="@+id/downloader_size"
-        android:layout_width="wrap_content"
-        android:layout_height="wrap_content"
-        android:layout_margin="@dimen/margin_half"
-        android:textAppearance="@style/MwmTextAppearance.Body2"
-        android:gravity="center_horizontal"
-        tools:text="1000 MB"/>
+          android:id="@+id/downloader_size"
+          android:layout_width="match_parent"
+          android:layout_height="24sp"
+          android:layout_margin="@dimen/margin_half"
+          android:gravity="center_horizontal|center_vertical"
+          android:lines="1"
+          android:textAppearance="@style/MwmTextAppearance.Body2"
+          app:autoSizeMaxTextSize="16sp"
+          app:autoSizeMinTextSize="10sp"
+          app:autoSizeStepGranularity="1sp"
+          app:autoSizeTextType="uniform"
+          tools:text="1000 MB" />
       <FrameLayout
         android:id="@+id/downloader_controls_frame"
         android:layout_width="180dp"

--- a/android/app/src/main/res/layout-land/onmap_downloader.xml
+++ b/android/app/src/main/res/layout-land/onmap_downloader.xml
@@ -54,8 +54,8 @@
           android:gravity="center_horizontal|center_vertical"
           android:lines="1"
           android:textAppearance="@style/MwmTextAppearance.Body2"
-          app:autoSizeMaxTextSize="16sp"
-          app:autoSizeMinTextSize="10sp"
+          app:autoSizeMaxTextSize="@dimen/text_size_body_2"
+          app:autoSizeMinTextSize="@dimen/text_size_body_2_min"
           app:autoSizeStepGranularity="1sp"
           app:autoSizeTextType="uniform"
           tools:text="1000 MB" />

--- a/android/app/src/main/res/layout/onmap_downloader.xml
+++ b/android/app/src/main/res/layout/onmap_downloader.xml
@@ -42,10 +42,10 @@
     <TextView
         android:id="@+id/downloader_size"
         android:layout_width="match_parent"
-        android:layout_height="24sp"
+        android:layout_height="48sp"
         android:layout_margin="@dimen/margin_half"
-        android:gravity="center_horizontal|center_vertical"
-        android:lines="1"
+        android:gravity="center_horizontal|top"
+        android:lines="2"
         android:textAppearance="@style/MwmTextAppearance.Body2"
         app:autoSizeMaxTextSize="@dimen/text_size_body_2"
         app:autoSizeMinTextSize="@dimen/text_size_body_2_min"

--- a/android/app/src/main/res/layout/onmap_downloader.xml
+++ b/android/app/src/main/res/layout/onmap_downloader.xml
@@ -47,8 +47,8 @@
         android:gravity="center_horizontal|center_vertical"
         android:lines="1"
         android:textAppearance="@style/MwmTextAppearance.Body2"
-        app:autoSizeMaxTextSize="16sp"
-        app:autoSizeMinTextSize="10sp"
+        app:autoSizeMaxTextSize="@dimen/text_size_body_2"
+        app:autoSizeMinTextSize="@dimen/text_size_body_2_min"
         app:autoSizeStepGranularity="1sp"
         app:autoSizeTextType="uniform"
         tools:text="1000 MB" />

--- a/android/app/src/main/res/layout/onmap_downloader.xml
+++ b/android/app/src/main/res/layout/onmap_downloader.xml
@@ -38,14 +38,20 @@
       android:gravity="center_horizontal"
       tools:text="Some name very loooooooooong name"
       tools:ignore="UnusedAttribute"/>
+
     <TextView
-      android:id="@+id/downloader_size"
-      android:layout_width="wrap_content"
-      android:layout_height="wrap_content"
-      android:layout_margin="@dimen/margin_half"
-      android:textAppearance="@style/MwmTextAppearance.Body2"
-      android:gravity="center_horizontal"
-      tools:text="1000 MB"/>
+        android:id="@+id/downloader_size"
+        android:layout_width="match_parent"
+        android:layout_height="24sp"
+        android:layout_margin="@dimen/margin_half"
+        android:gravity="center_horizontal|center_vertical"
+        android:lines="1"
+        android:textAppearance="@style/MwmTextAppearance.Body2"
+        app:autoSizeMaxTextSize="16sp"
+        app:autoSizeMinTextSize="10sp"
+        app:autoSizeStepGranularity="1sp"
+        app:autoSizeTextType="uniform"
+        tools:text="1000 MB" />
     <FrameLayout
       android:id="@+id/downloader_controls_frame"
       android:layout_width="180dp"

--- a/android/app/src/main/res/values/font_sizes.xml
+++ b/android/app/src/main/res/values/font_sizes.xml
@@ -13,6 +13,7 @@
   <dimen name="text_size_body_0">18sp</dimen>
   <dimen name="text_size_body_1">16sp</dimen>
   <dimen name="text_size_body_2">16sp</dimen>
+  <dimen name="text_size_body_2_min">8sp</dimen>
   <dimen name="text_size_body_3">14sp</dimen>
   <dimen name="text_size_body_4">12sp</dimen>
   <dimen name="text_size_body_5">10sp</dimen>


### PR DESCRIPTION
Scales the progress text and forces it to a single line, fixing #8520 

Note you can't use `wrap_content` when using `autoSizeText` so that's why those changed. (it needs a set value to "scale" to) Tested with a manual exceedingly long string and it does work though I couldn't force a repro of the original issue on my emulator.

https://github.com/user-attachments/assets/7ac83490-f392-4db8-af20-3ded6f5fbc86

