### PR TITLE
Try decoding geo URL coordinates before giving up on parsing

### DIFF
--- a/ge0/ge0_tests/geo_url_tests.cpp
+++ b/ge0/ge0_tests/geo_url_tests.cpp
@@ -102,6 +102,24 @@ UNIT_TEST(GeoUrl_Geo)
   TEST_ALMOST_EQUAL_ABS(info.m_lat, -18.9151863, kEps, ());
   TEST_ALMOST_EQUAL_ABS(info.m_lon, -48.28712359999999, kEps, ());
 
+  // URL Encoded comma (%2C) and space (%20)
+  TEST(parser.Parse("geo:-18.9151863%2C%20-48.28712359999999?q=-18.9151863%2C-48.28712359999999", info), ());
+  TEST(info.IsLatLonValid(), ());
+  TEST_ALMOST_EQUAL_ABS(info.m_lat, -18.9151863, kEps, ());
+  TEST_ALMOST_EQUAL_ABS(info.m_lon, -48.28712359999999, kEps, ());
+
+  // URL Encoded comma (%2C) and space as +
+  TEST(parser.Parse("geo:-18.9151863%2C+-48.28712359999999?q=-18.9151863%2C-48.28712359999999", info), ());
+  TEST(info.IsLatLonValid(), ());
+  TEST_ALMOST_EQUAL_ABS(info.m_lat, -18.9151863, kEps, ());
+  TEST_ALMOST_EQUAL_ABS(info.m_lon, -48.28712359999999, kEps, ());
+
+  // URL encoded with altitude
+  TEST(parser.Parse("geo:53.666%2C-27.666%2C+1000", info), ());
+  TEST(info.IsLatLonValid(), ());
+  TEST_ALMOST_EQUAL_ABS(info.m_lat, 53.666, kEps, ());
+  TEST_ALMOST_EQUAL_ABS(info.m_lon, -27.666, kEps, ());
+
   // Invalid coordinates.
   TEST(!parser.Parse("geo:0,0garbage", info), ());
   TEST(!parser.Parse("geo:garbage0,0", info), ());

--- a/ge0/ge0_tests/geo_url_tests.cpp
+++ b/ge0/ge0_tests/geo_url_tests.cpp
@@ -96,6 +96,12 @@ UNIT_TEST(GeoUrl_Geo)
   TEST_ALMOST_EQUAL_ABS(info.m_lat, 53.666, kEps, ());
   TEST_ALMOST_EQUAL_ABS(info.m_lon, 0.0, kEps, ());
 
+  // URL Encoded comma (%2C) as delimiter
+  TEST(parser.Parse("geo:-18.9151863%2C-48.28712359999999?q=-18.9151863%2C-48.28712359999999", info), ());
+  TEST(info.IsLatLonValid(), ());
+  TEST_ALMOST_EQUAL_ABS(info.m_lat, -18.9151863, kEps, ());
+  TEST_ALMOST_EQUAL_ABS(info.m_lon, -48.28712359999999, kEps, ());
+
   // Invalid coordinates.
   TEST(!parser.Parse("geo:0,0garbage", info), ());
   TEST(!parser.Parse("geo:garbage0,0", info), ());

--- a/ge0/geo_url_parser.cpp
+++ b/ge0/geo_url_parser.cpp
@@ -205,8 +205,12 @@ bool GeoParser::Parse(std::string const & raw, GeoURLInfo & info) const
     std::smatch m;
     if (!std::regex_match(coordinates, m, m_latlonRe) || m.size() < 3)
     {
-      LOG(LWARNING, ("Missing coordinates in", raw));
-      return false;
+      // no match? try URL decoding before giving up
+      coordinates = url::UrlDecode(coordinates);
+      if (!std::regex_match(coordinates, m, m_latlonRe) || m.size() < 3){
+        LOG(LWARNING, ("Missing coordinates in", raw));
+        return false;
+      }
     }
 
     double lat, lon;

--- a/ge0/geo_url_parser.cpp
+++ b/ge0/geo_url_parser.cpp
@@ -207,7 +207,8 @@ bool GeoParser::Parse(std::string const & raw, GeoURLInfo & info) const
     {
       // no match? try URL decoding before giving up
       coordinates = url::UrlDecode(coordinates);
-      if (!std::regex_match(coordinates, m, m_latlonRe) || m.size() < 3){
+      if (!std::regex_match(coordinates, m, m_latlonRe) || m.size() < 3)
+      {
         LOG(LWARNING, ("Missing coordinates in", raw));
         return false;
       }


### PR DESCRIPTION
If we fail trying to parse the coordinates of geo-URI, URL decode the coordinates and try again. Strictly speaking this is against the RFC but seems pretty safe given how limited the valid set is for coordinates in the RFC.

fixes: #8816 