### PR TITLE
update regex in geo_url_parser to allow URL encoded , and space

### DIFF
--- a/ge0/ge0_tests/geo_url_tests.cpp
+++ b/ge0/ge0_tests/geo_url_tests.cpp
@@ -115,7 +115,6 @@ UNIT_TEST(GeoUrl_Geo)
   TEST_ALMOST_EQUAL_ABS(info.m_lon, -48.28712359999999, kEps, ());
 
   // URL encoded with altitude
-  // Bare RFC5870 URI with lat,lon,altitude.
   TEST(parser.Parse("geo:53.666%2C-27.666%2C+1000", info), ());
   TEST(info.IsLatLonValid(), ());
   TEST_ALMOST_EQUAL_ABS(info.m_lat, 53.666, kEps, ());

--- a/ge0/ge0_tests/geo_url_tests.cpp
+++ b/ge0/ge0_tests/geo_url_tests.cpp
@@ -114,6 +114,13 @@ UNIT_TEST(GeoUrl_Geo)
   TEST_ALMOST_EQUAL_ABS(info.m_lat, -18.9151863, kEps, ());
   TEST_ALMOST_EQUAL_ABS(info.m_lon, -48.28712359999999, kEps, ());
 
+  // URL encoded with altitude
+  // Bare RFC5870 URI with lat,lon,altitude.
+  TEST(parser.Parse("geo:53.666%2C-27.666%2C+1000", info), ());
+  TEST(info.IsLatLonValid(), ());
+  TEST_ALMOST_EQUAL_ABS(info.m_lat, 53.666, kEps, ());
+  TEST_ALMOST_EQUAL_ABS(info.m_lon, -27.666, kEps, ());
+
   // Invalid coordinates.
   TEST(!parser.Parse("geo:0,0garbage", info), ());
   TEST(!parser.Parse("geo:garbage0,0", info), ());

--- a/ge0/ge0_tests/geo_url_tests.cpp
+++ b/ge0/ge0_tests/geo_url_tests.cpp
@@ -96,6 +96,24 @@ UNIT_TEST(GeoUrl_Geo)
   TEST_ALMOST_EQUAL_ABS(info.m_lat, 53.666, kEps, ());
   TEST_ALMOST_EQUAL_ABS(info.m_lon, 0.0, kEps, ());
 
+  // URL Encoded comma (%2C) as delimiter
+  TEST(parser.Parse("geo:-18.9151863%2C-48.28712359999999?q=-18.9151863%2C-48.28712359999999", info), ());
+  TEST(info.IsLatLonValid(), ());
+  TEST_ALMOST_EQUAL_ABS(info.m_lat, -18.9151863, kEps, ());
+  TEST_ALMOST_EQUAL_ABS(info.m_lon, -48.28712359999999, kEps, ());
+
+  // URL Encoded comma (%2C) and space (%20)
+  TEST(parser.Parse("geo:-18.9151863%2C%20-48.28712359999999?q=-18.9151863%2C-48.28712359999999", info), ());
+  TEST(info.IsLatLonValid(), ());
+  TEST_ALMOST_EQUAL_ABS(info.m_lat, -18.9151863, kEps, ());
+  TEST_ALMOST_EQUAL_ABS(info.m_lon, -48.28712359999999, kEps, ());
+
+  // URL Encoded comma (%2C) and space as +
+  TEST(parser.Parse("geo:-18.9151863%2C+-48.28712359999999?q=-18.9151863%2C-48.28712359999999", info), ());
+  TEST(info.IsLatLonValid(), ());
+  TEST_ALMOST_EQUAL_ABS(info.m_lat, -18.9151863, kEps, ());
+  TEST_ALMOST_EQUAL_ABS(info.m_lon, -48.28712359999999, kEps, ());
+
   // Invalid coordinates.
   TEST(!parser.Parse("geo:0,0garbage", info), ());
   TEST(!parser.Parse("geo:garbage0,0", info), ());

--- a/ge0/geo_url_parser.cpp
+++ b/ge0/geo_url_parser.cpp
@@ -153,6 +153,7 @@ int LatLonParser::GetCoordinatesPriority(string const & token)
 }
 
 std::string const kLatLon = R"(([+-]?\d+(?:\.\d+)?)(?:%2C|,)(?: |%20|\+)*([+-]?\d+(?:\.\d+)?)(:?, *([+-]?\d+(?:\.\d+)?))?)";
+//std::string const kLatLon = R"(([+-]?\d+(?:\.\d+)?)(?:%2C|,)(?: |%20|\+)*([+-]?\d+(?:\.\d+)?)((?:%2C|,)(?: |%20|\+)*([+-]?\d+(?:\.\d+)?))?)";
 
 GeoParser::GeoParser()
   : m_latlonRe(kLatLon), m_zoomRe(kFloatIntScale)

--- a/ge0/geo_url_parser.cpp
+++ b/ge0/geo_url_parser.cpp
@@ -152,7 +152,7 @@ int LatLonParser::GetCoordinatesPriority(string const & token)
   return -1;
 }
 
-std::string const kLatLon = R"(([+-]?\d+(?:\.\d+)?), *([+-]?\d+(?:\.\d+)?)(:?, *([+-]?\d+(?:\.\d+)?))?)";
+std::string const kLatLon = R"(([+-]?\d+(?:\.\d+)?)(?:%2C|,)(?: |%20|\+)*([+-]?\d+(?:\.\d+)?)(:?, *([+-]?\d+(?:\.\d+)?))?)";
 
 GeoParser::GeoParser()
   : m_latlonRe(kLatLon), m_zoomRe(kFloatIntScale)


### PR DESCRIPTION
This is an alternative to https://github.com/organicmaps/organicmaps/pull/8987 which is a bit simpler code-wise but more complicated regex-wise.

Since we valid set of characters for coordinate delimiters is small we can  just include the URL encoded versions in the regex directly instead doing it as a separate step after failing to parse.

I suppose yet another implementation could just always URL decode the coordinate fragment before running the simpler regex.

This feels simplest to me but happy to take any approach.

fixes #8816