### PR TITLE
[android] Greyed of preference text color when disabled

### DIFF
--- a/android/app/src/main/java/app/organicmaps/settings/CustomListPreference.java
+++ b/android/app/src/main/java/app/organicmaps/settings/CustomListPreference.java
@@ -1,0 +1,41 @@
+package app.organicmaps.settings;
+
+import android.content.Context;
+import android.util.AttributeSet;
+
+import androidx.annotation.NonNull;
+import androidx.preference.ListPreference;
+import androidx.preference.PreferenceViewHolder;
+
+public class CustomListPreference extends ListPreference
+{
+  private CustomPreference.TextViews mTextViews = new CustomPreference.TextViews();
+
+  public CustomListPreference(Context ctx, AttributeSet attrs, int defStyle)
+  {
+    super(ctx, attrs, defStyle);
+  }
+
+  public CustomListPreference(Context ctx, AttributeSet attrs)
+  {
+    super(ctx, attrs);
+  }
+
+  @Override
+  public void onBindViewHolder(@NonNull PreferenceViewHolder holder)
+  {
+    super.onBindViewHolder(holder);
+
+    mTextViews.init(holder);
+
+    mTextViews.updateTextViewColors(isEnabled());
+  }
+
+  @Override
+  public void setEnabled(boolean enabled)
+  {
+    super.setEnabled(enabled);
+
+    mTextViews.updateTextViewColors(enabled);
+  }
+}

--- a/android/app/src/main/java/app/organicmaps/settings/CustomPreference.java
+++ b/android/app/src/main/java/app/organicmaps/settings/CustomPreference.java
@@ -1,0 +1,72 @@
+package app.organicmaps.settings;
+
+import android.content.Context;
+import android.graphics.Color;
+import android.util.AttributeSet;
+import android.widget.TextView;
+
+import androidx.annotation.NonNull;
+import androidx.preference.Preference;
+import androidx.preference.PreferenceViewHolder;
+
+public class CustomPreference extends Preference
+{
+  public static class TextViews
+  {
+    TextView mTitleTextView;
+    int mDefaultTitleTextColor;
+
+    TextView mSummaryTextView;
+    int mDefaultSummaryTextColor;
+
+    public void init(PreferenceViewHolder holder)
+    {
+      mTitleTextView = (TextView) holder.findViewById(android.R.id.title);
+      if (mTitleTextView != null)
+        mDefaultTitleTextColor = mTitleTextView.getTextColors().getDefaultColor();
+
+      mSummaryTextView = (TextView) holder.findViewById(android.R.id.summary);
+      if (mSummaryTextView != null)
+        mDefaultSummaryTextColor = mSummaryTextView.getTextColors().getDefaultColor();
+    }
+
+    public void updateTextViewColors(boolean enabled)
+    {
+      if (mTitleTextView != null)
+        mTitleTextView.setTextColor(enabled? mDefaultTitleTextColor : Color.GRAY);
+
+      if (mSummaryTextView != null)
+        mSummaryTextView.setTextColor(enabled? mDefaultSummaryTextColor : Color.GRAY);
+    }
+  }
+
+  TextViews mTextViews = new TextViews();
+
+  public CustomPreference(Context ctx, AttributeSet attrs, int defStyle)
+  {
+    super(ctx, attrs, defStyle);
+  }
+
+  public CustomPreference(Context ctx, AttributeSet attrs)
+  {
+    super(ctx, attrs);
+  }
+
+  @Override
+  public void onBindViewHolder(@NonNull PreferenceViewHolder holder)
+  {
+    super.onBindViewHolder(holder);
+
+    mTextViews.init(holder);
+
+    mTextViews.updateTextViewColors(isEnabled());
+  }
+
+  @Override
+  public void setEnabled(boolean enabled)
+  {
+    super.setEnabled(enabled);
+
+    mTextViews.updateTextViewColors(enabled);
+  }
+}

--- a/android/app/src/main/java/app/organicmaps/settings/CustomSeekBarPreference.java
+++ b/android/app/src/main/java/app/organicmaps/settings/CustomSeekBarPreference.java
@@ -1,0 +1,42 @@
+package app.organicmaps.settings;
+
+import android.content.Context;
+import android.graphics.Color;
+import android.util.AttributeSet;
+
+import androidx.annotation.NonNull;
+import androidx.preference.PreferenceViewHolder;
+import androidx.preference.SeekBarPreference;
+
+public class CustomSeekBarPreference extends SeekBarPreference
+{
+  private CustomPreference.TextViews mTextViews = new CustomPreference.TextViews();
+
+  public CustomSeekBarPreference(Context ctx, AttributeSet attrs, int defStyle)
+  {
+    super(ctx, attrs, defStyle);
+  }
+
+  public CustomSeekBarPreference(Context ctx, AttributeSet attrs)
+  {
+    super(ctx, attrs);
+  }
+
+  @Override
+  public void onBindViewHolder(@NonNull PreferenceViewHolder holder)
+  {
+    super.onBindViewHolder(holder);
+
+    mTextViews.init(holder);
+
+    mTextViews.updateTextViewColors(isEnabled());
+  }
+
+  @Override
+  public void setEnabled(boolean enabled)
+  {
+    super.setEnabled(enabled);
+
+    mTextViews.updateTextViewColors(enabled);
+  }
+}

--- a/android/app/src/main/java/app/organicmaps/settings/CustomSwitchPreferenceCompat.java
+++ b/android/app/src/main/java/app/organicmaps/settings/CustomSwitchPreferenceCompat.java
@@ -1,0 +1,41 @@
+package app.organicmaps.settings;
+
+import android.content.Context;
+import android.util.AttributeSet;
+
+import androidx.annotation.NonNull;
+import androidx.preference.PreferenceViewHolder;
+import androidx.preference.SwitchPreferenceCompat;
+
+public class CustomSwitchPreferenceCompat extends SwitchPreferenceCompat
+{
+  private CustomPreference.TextViews mTextViews = new CustomPreference.TextViews();
+
+  public CustomSwitchPreferenceCompat(Context ctx, AttributeSet attrs, int defStyle)
+  {
+    super(ctx, attrs, defStyle);
+  }
+
+  public CustomSwitchPreferenceCompat(Context ctx, AttributeSet attrs)
+  {
+    super(ctx, attrs);
+  }
+
+  @Override
+  public void onBindViewHolder(@NonNull PreferenceViewHolder holder)
+  {
+    super.onBindViewHolder(holder);
+
+    mTextViews.init(holder);
+
+    mTextViews.updateTextViewColors(isEnabled());
+  }
+
+  @Override
+  public void setEnabled(boolean enabled)
+  {
+    super.setEnabled(enabled);
+
+    mTextViews.updateTextViewColors(enabled);
+  }
+}

--- a/android/app/src/main/java/app/organicmaps/settings/VoiceInstructionsSettingsFragment.java
+++ b/android/app/src/main/java/app/organicmaps/settings/VoiceInstructionsSettingsFragment.java
@@ -16,7 +16,7 @@ import androidx.annotation.Nullable;
 import androidx.core.content.ContextCompat;
 import androidx.preference.ListPreference;
 import androidx.preference.Preference;
-import androidx.preference.SeekBarPreference;
+import androidx.preference.SwitchPreferenceCompat;
 import androidx.preference.TwoStatePreference;
 
 import app.organicmaps.Framework;
@@ -39,16 +39,16 @@ public class VoiceInstructionsSettingsFragment extends BaseXmlSettingsFragment
 
   @NonNull
   @SuppressWarnings("NotNullFieldNotInitialized")
-  private TwoStatePreference mTtsPrefEnabled;
+  private SwitchPreferenceCompat mTtsPrefEnabled;
   @NonNull
   @SuppressWarnings("NotNullFieldNotInitialized")
-  private ListPreference mTtsPrefLanguages;
+  private CustomListPreference mTtsPrefLanguages;
   @NonNull
   @SuppressWarnings("NotNullFieldNotInitialized")
-  private SeekBarPreference mTtsVolume;
+  private CustomSeekBarPreference mTtsVolume;
   @NonNull
   @SuppressWarnings("NotNullFieldNotInitialized")
-  private TwoStatePreference mTtsPrefStreetNames;
+  private CustomSwitchPreferenceCompat mTtsPrefStreetNames;
   @NonNull
   @SuppressWarnings("NotNullFieldNotInitialized")
   private ListPreference mPrefLanguages;
@@ -57,7 +57,8 @@ public class VoiceInstructionsSettingsFragment extends BaseXmlSettingsFragment
   private Preference mTtsLangInfo;
   @NonNull
   @SuppressWarnings("NotNullFieldNotInitialized")
-  private Preference mTtsVoiceTest;
+  private CustomPreference mTtsVoiceTest;
+
   private List<String> mTtsTestStringArray;
   private int mTestStringIndex;
 
@@ -72,6 +73,7 @@ public class VoiceInstructionsSettingsFragment extends BaseXmlSettingsFragment
     {
       TtsPlayer.setEnabled(false);
       mTtsPrefLanguages.setEnabled(false);
+      mTtsPrefStreetNames.setEnabled(false);
       mTtsVolume.setEnabled(false);
       mTtsLangInfo.setSummary(R.string.prefs_languages_information_off);
       mTtsVoiceTest.setEnabled(false);
@@ -79,6 +81,7 @@ public class VoiceInstructionsSettingsFragment extends BaseXmlSettingsFragment
     }
 
     mTtsLangInfo.setSummary(R.string.prefs_languages_information);
+    mTtsPrefStreetNames.setEnabled(true);
     mTtsVolume.setEnabled(true);
     mTtsVoiceTest.setEnabled(true);
 
@@ -226,6 +229,7 @@ public class VoiceInstructionsSettingsFragment extends BaseXmlSettingsFragment
       mTtsPrefEnabled.setSummary(R.string.pref_tts_unavailable);
       mTtsPrefLanguages.setEnabled(false);
       mTtsPrefLanguages.setSummary(null);
+      mTtsPrefStreetNames.setEnabled(false);
       mTtsVolume.setEnabled(false);
       mTtsVoiceTest.setEnabled(false);
       mTtsLangInfo.setSummary(R.string.prefs_languages_information_off);
@@ -258,6 +262,7 @@ public class VoiceInstructionsSettingsFragment extends BaseXmlSettingsFragment
     mTtsPrefLanguages.setEnabled(available && TtsPlayer.isEnabled());
     mTtsPrefLanguages.setSummary(available ? mCurrentLanguage.name : null);
     mTtsPrefLanguages.setValue(available ? mCurrentLanguage.internalCode : null);
+    mTtsPrefStreetNames.setEnabled(enabled && available && TtsPlayer.isEnabled());
     mTtsVolume.setEnabled(enabled && available && TtsPlayer.isEnabled());
     mTtsVoiceTest.setEnabled(enabled && available && TtsPlayer.isEnabled());
 

--- a/android/app/src/main/res/xml/prefs_voice_instructions.xml
+++ b/android/app/src/main/res/xml/prefs_voice_instructions.xml
@@ -6,18 +6,18 @@
   <SwitchPreferenceCompat
       android:key="@string/pref_tts_enabled"
       android:title="@string/pref_tts_enable_title" />
-  <SwitchPreferenceCompat
+  <app.organicmaps.settings.CustomSwitchPreferenceCompat
       android:key="@string/pref_tts_street_names"
       android:title="@string/pref_tts_street_names_title"
       android:summary="@string/pref_tts_street_names_description"
       android:defaultValue="false" />
-  <ListPreference
+  <app.organicmaps.settings.CustomListPreference
       android:key="@string/pref_tts_language"
       android:title="@string/pref_tts_language_title" />
-  <SeekBarPreference
+  <app.organicmaps.settings.CustomSeekBarPreference
       android:key="@string/pref_tts_volume"
       android:title="@string/volume" />
-  <Preference
+  <app.organicmaps.settings.CustomPreference
       android:key="@string/pref_tts_test_voice"
       android:title="@string/pref_tts_test_voice_title" />
   <Preference


### PR DESCRIPTION
Greyed of the disabled preferences in voice settings menu.

As the implementation done in [PR 7759](https://github.com/organicmaps/organicmaps/pull/7759) has a wrong behavior which cannot be avoided, this PR uses custom Preference classes to access the internal Title and Summary TextViews.
 
![day_enable](https://github.com/user-attachments/assets/ca42e7c8-60bb-4db0-9340-343296e79047) ![day_disable](https://github.com/user-attachments/assets/a99a2a46-8e2d-45cc-9725-8bd03b58806b)

![night_enable](https://github.com/user-attachments/assets/626d62b9-7392-4776-b702-5887df459fa3) ![night_disable](https://github.com/user-attachments/assets/c035b4b4-115e-4865-8cd2-2e45ed925d3a)
