### PR TITLE
[android] Hide preferences in voice settings when disabled

### DIFF
--- a/android/app/src/main/java/app/organicmaps/settings/VoiceInstructionsSettingsFragment.java
+++ b/android/app/src/main/java/app/organicmaps/settings/VoiceInstructionsSettingsFragment.java
@@ -58,6 +58,7 @@ public class VoiceInstructionsSettingsFragment extends BaseXmlSettingsFragment
   @NonNull
   @SuppressWarnings("NotNullFieldNotInitialized")
   private Preference mTtsVoiceTest;
+
   private List<String> mTtsTestStringArray;
   private int mTestStringIndex;
 
@@ -71,16 +72,19 @@ public class VoiceInstructionsSettingsFragment extends BaseXmlSettingsFragment
     if (!set)
     {
       TtsPlayer.setEnabled(false);
-      mTtsPrefLanguages.setEnabled(false);
-      mTtsVolume.setEnabled(false);
+      mTtsPrefLanguages.setVisible(false);
+      mTtsPrefStreetNames.setVisible(false);
+      mTtsVolume.setVisible(false);
       mTtsLangInfo.setSummary(R.string.prefs_languages_information_off);
-      mTtsVoiceTest.setEnabled(false);
+      mTtsVoiceTest.setVisible(false);
       return true;
     }
 
     mTtsLangInfo.setSummary(R.string.prefs_languages_information);
-    mTtsVolume.setEnabled(true);
-    mTtsVoiceTest.setEnabled(true);
+    mTtsPrefLanguages.setVisible(true);
+    mTtsPrefStreetNames.setVisible(true);
+    mTtsVolume.setVisible(true);
+    mTtsVoiceTest.setVisible(true);
 
     if (mCurrentLanguage != null && mCurrentLanguage.downloaded)
     {
@@ -224,10 +228,11 @@ public class VoiceInstructionsSettingsFragment extends BaseXmlSettingsFragment
       mTtsPrefEnabled.setChecked(false);
       mTtsPrefEnabled.setEnabled(false);
       mTtsPrefEnabled.setSummary(R.string.pref_tts_unavailable);
-      mTtsPrefLanguages.setEnabled(false);
+      mTtsPrefStreetNames.setVisible(false);
+      mTtsPrefLanguages.setVisible(false);
       mTtsPrefLanguages.setSummary(null);
-      mTtsVolume.setEnabled(false);
-      mTtsVoiceTest.setEnabled(false);
+      mTtsVolume.setVisible(false);
+      mTtsVoiceTest.setVisible(false);
       mTtsLangInfo.setSummary(R.string.prefs_languages_information_off);
 
       enableListeners(true);
@@ -255,11 +260,12 @@ public class VoiceInstructionsSettingsFragment extends BaseXmlSettingsFragment
     mCurrentLanguage = TtsPlayer.getSelectedLanguage(languages);
     final boolean available = (mCurrentLanguage != null && mCurrentLanguage.downloaded);
     mTtsPrefEnabled.setChecked(available && TtsPlayer.isEnabled());
-    mTtsPrefLanguages.setEnabled(available && TtsPlayer.isEnabled());
+    mTtsPrefLanguages.setVisible(available && TtsPlayer.isEnabled());
     mTtsPrefLanguages.setSummary(available ? mCurrentLanguage.name : null);
     mTtsPrefLanguages.setValue(available ? mCurrentLanguage.internalCode : null);
-    mTtsVolume.setEnabled(enabled && available && TtsPlayer.isEnabled());
-    mTtsVoiceTest.setEnabled(enabled && available && TtsPlayer.isEnabled());
+    mTtsPrefStreetNames.setVisible(enabled && available && TtsPlayer.isEnabled());
+    mTtsVolume.setVisible(enabled && available && TtsPlayer.isEnabled());
+    mTtsVoiceTest.setVisible(enabled && available && TtsPlayer.isEnabled());
 
     if (available)
     {


### PR DESCRIPTION
PR that hides the Preferences in Voice Settings panel when the TTS is disabled/not available.

Previous possible implementations are:
* https://github.com/organicmaps/organicmaps/pull/7759: Disables (greys) preferences using general XML styles. It does not behave correctly when switching to Night mode, as the color of the tiles remain incorrectly dark.
* https://github.com/organicmaps/organicmaps/pull/9007: Disables (greys) preferences using custom Preference classes to get access to internal TextView control of the preferences.