### PR TITLE
[Android] OAuth2 flow with browser V2

### DIFF
--- a/android/app/src/main/cpp/app/organicmaps/Framework.cpp
+++ b/android/app/src/main/cpp/app/organicmaps/Framework.cpp
@@ -862,6 +862,13 @@ Java_app_organicmaps_Framework_nativeGetParsedAppName(JNIEnv * env, jclass)
 }
 
 JNIEXPORT jstring JNICALL
+Java_app_organicmaps_Framework_nativeGetParsedOAuth2Code(JNIEnv * env, jclass)
+{
+  std::string const & code = frm()->GetParsedOAuth2Code();
+  return jni::ToJavaString(env, code);
+}
+
+JNIEXPORT jstring JNICALL
 Java_app_organicmaps_Framework_nativeGetParsedBackUrl(JNIEnv * env, jclass)
 {
   std::string const & backUrl = frm()->GetParsedBackUrl();

--- a/android/app/src/main/cpp/app/organicmaps/editor/OsmOAuth.cpp
+++ b/android/app/src/main/cpp/app/organicmaps/editor/OsmOAuth.cpp
@@ -35,6 +35,13 @@ extern "C"
 {
 
 JNIEXPORT jstring JNICALL
+Java_app_organicmaps_editor_OsmOAuth_nativeGetOAuth2Url(JNIEnv * env, jclass)
+{
+  auto const auth = OsmOAuth::ServerAuth();
+  return ToJavaString(env, auth.BuildOAuth2Url());
+}
+
+JNIEXPORT jstring JNICALL
 Java_app_organicmaps_editor_OsmOAuth_nativeAuthWithPassword(JNIEnv * env, jclass clazz,
                                                                 jstring login, jstring password)
 {
@@ -48,6 +55,27 @@ Java_app_organicmaps_editor_OsmOAuth_nativeAuthWithPassword(JNIEnv * env, jclass
   catch (std::exception const & ex)
   {
     LOG(LWARNING, ("nativeAuthWithPassword error ", ex.what()));
+  }
+  return nullptr;
+}
+
+JNIEXPORT jstring JNICALL
+Java_app_organicmaps_editor_OsmOAuth_nativeAuthWithOAuth2Code(JNIEnv * env, jclass, jstring oauth2code)
+{
+  OsmOAuth auth = OsmOAuth::ServerAuth();
+  try
+  {
+    auto token = auth.FinishAuthorization(ToNativeString(env, oauth2code));
+    if (!token.empty())
+    {
+        auth.SetAuthToken(token);
+        return ToJavaString(env, token);
+    }
+    LOG(LWARNING, ("nativeAuthWithOAuth2Code: invalid OAuth2 code", oauth2code));
+  }
+  catch (std::exception const & ex)
+  {
+    LOG(LWARNING, ("nativeAuthWithOAuth2Code error ", ex.what()));
   }
   return nullptr;
 }

--- a/android/app/src/main/java/app/organicmaps/Framework.java
+++ b/android/app/src/main/java/app/organicmaps/Framework.java
@@ -239,6 +239,7 @@ public class Framework
   public static native ParsedRoutingData nativeGetParsedRoutingData();
   public static native ParsedSearchRequest nativeGetParsedSearchRequest();
   public static native @Nullable String nativeGetParsedAppName();
+  public static native @Nullable String nativeGetParsedOAuth2Code();
   @Nullable @Size(2)
   public static native double[] nativeGetParsedCenterLatLon();
   public static native @Nullable String nativeGetParsedBackUrl();

--- a/android/app/src/main/java/app/organicmaps/api/RequestType.java
+++ b/android/app/src/main/java/app/organicmaps/api/RequestType.java
@@ -6,7 +6,7 @@ import java.lang.annotation.Retention;
 import java.lang.annotation.RetentionPolicy;
 
 @Retention(RetentionPolicy.SOURCE)
-@IntDef({RequestType.INCORRECT, RequestType.MAP, RequestType.ROUTE, RequestType.SEARCH, RequestType.CROSSHAIR})
+@IntDef({RequestType.INCORRECT, RequestType.MAP, RequestType.ROUTE, RequestType.SEARCH, RequestType.CROSSHAIR, RequestType.OAUTH2})
 public @interface RequestType
 {
   // Represents url_scheme::ParsedMapApi::UrlType from c++ part.
@@ -15,4 +15,5 @@ public @interface RequestType
   public static final int ROUTE = 2;
   public static final int SEARCH = 3;
   public static final int CROSSHAIR = 4;
+  public static final int OAUTH2 = 5;
 }

--- a/android/app/src/main/java/app/organicmaps/editor/OsmLoginActivity.java
+++ b/android/app/src/main/java/app/organicmaps/editor/OsmLoginActivity.java
@@ -1,14 +1,31 @@
 package app.organicmaps.editor;
 
+import android.app.Activity;
+import android.content.Intent;
+import android.os.Bundle;
+
+import androidx.annotation.NonNull;
 import androidx.fragment.app.Fragment;
 
 import app.organicmaps.base.BaseMwmFragmentActivity;
 
 public class OsmLoginActivity extends BaseMwmFragmentActivity
 {
+  public static final String EXTRA_OAUTH2CODE = "oauth2code";
+
   @Override
   protected Class<? extends Fragment> getFragmentClass()
   {
     return OsmLoginFragment.class;
+  }
+
+  public static void OAuth2Callback(@NonNull Activity activity, String oauth2code)
+  {
+    final Intent i = new Intent(activity, OsmLoginActivity.class);
+    Bundle args = new Bundle();
+    args.putString(EXTRA_OAUTH2CODE, oauth2code);
+    args.putBoolean(ProfileActivity.EXTRA_REDIRECT_TO_PROFILE, true);
+    i.putExtras(args);
+    activity.startActivity(i);
   }
 }

--- a/android/app/src/main/java/app/organicmaps/editor/OsmLoginFragment.java
+++ b/android/app/src/main/java/app/organicmaps/editor/OsmLoginFragment.java
@@ -35,8 +35,6 @@ public class OsmLoginFragment extends BaseMwmToolbarFragment
   private TextInputEditText mLoginInput;
   private TextInputEditText mPasswordInput;
 
-  private String mArgOAuth2Code;
-
   @Nullable
   @Override
   public View onCreateView(LayoutInflater inflater, @Nullable ViewGroup container, @Nullable Bundle savedInstanceState)
@@ -75,18 +73,18 @@ public class OsmLoginFragment extends BaseMwmToolbarFragment
       mLostPasswordButton.setOnClickListener((v) -> Utils.openUrl(requireActivity(), Constants.Url.OSM_RECOVER_PASSWORD));
     }
 
-    readArguments();
-    if (mArgOAuth2Code != null && !mArgOAuth2Code.isEmpty())
-      continueOAuth2Flow(mArgOAuth2Code);
+    String code = readOAuth2CodeFromArguments();
+    if (code != null && !code.isEmpty())
+      continueOAuth2Flow(code);
   }
 
-  private void readArguments()
+  private String readOAuth2CodeFromArguments()
   {
     final Bundle arguments = getArguments();
     if (arguments == null)
-      return;
+      return null;
 
-    mArgOAuth2Code = arguments.getString(OsmLoginActivity.EXTRA_OAUTH2CODE);
+    return arguments.getString(OsmLoginActivity.EXTRA_OAUTH2CODE);
   }
 
   private void login()
@@ -109,7 +107,6 @@ public class OsmLoginFragment extends BaseMwmToolbarFragment
   {
     Utils.openUri(requireContext(), Uri.parse(OsmOAuth.nativeGetOAuth2Url()));
   }
-
 
   private void enableInput(boolean enable)
   {
@@ -160,11 +157,13 @@ public class OsmLoginFragment extends BaseMwmToolbarFragment
       onAuthFail();
     else
     {
-      ThreadPool.getWorker().execute(() -> {
+      ThreadPool.getWorker().execute(() ->
+      {
         // Finish OAuth2 auth flow and get username for UI.
         final String oauthToken = OsmOAuth.nativeAuthWithOAuth2Code(oauth2code);
         final String username = (oauthToken == null) ? null : OsmOAuth.nativeGetOsmUsername(oauthToken);
-        UiThread.run(() -> {
+        UiThread.run(() ->
+        {
           processAuth(oauthToken, username);
         });
       });

--- a/android/app/src/main/java/app/organicmaps/editor/OsmLoginFragment.java
+++ b/android/app/src/main/java/app/organicmaps/editor/OsmLoginFragment.java
@@ -1,6 +1,7 @@
 package app.organicmaps.editor;
 
 import android.content.Intent;
+import android.net.Uri;
 import android.os.Bundle;
 import android.view.LayoutInflater;
 import android.view.View;
@@ -12,6 +13,7 @@ import android.widget.TextView;
 import androidx.annotation.NonNull;
 import androidx.annotation.Nullable;
 
+import app.organicmaps.BuildConfig;
 import app.organicmaps.Framework;
 import app.organicmaps.R;
 import app.organicmaps.base.BaseMwmToolbarFragment;
@@ -33,6 +35,8 @@ public class OsmLoginFragment extends BaseMwmToolbarFragment
   private TextInputEditText mLoginInput;
   private TextInputEditText mPasswordInput;
 
+  private String mArgOAuth2Code;
+
   @Nullable
   @Override
   public View onCreateView(LayoutInflater inflater, @Nullable ViewGroup container, @Nullable Bundle savedInstanceState)
@@ -48,15 +52,41 @@ public class OsmLoginFragment extends BaseMwmToolbarFragment
     mLoginInput = view.findViewById(R.id.osm_username);
     mPasswordInput = view.findViewById(R.id.osm_password);
     mLoginButton = view.findViewById(R.id.login);
-    mLoginButton.setOnClickListener((v) -> login());
     mLostPasswordButton = view.findViewById(R.id.lost_password);
-    mLostPasswordButton.setOnClickListener((v) -> Utils.openUrl(requireActivity(), Constants.Url.OSM_RECOVER_PASSWORD));
     Button registerButton = view.findViewById(R.id.register);
     registerButton.setOnClickListener((v) -> Utils.openUrl(requireActivity(), Constants.Url.OSM_REGISTER));
     mProgress = view.findViewById(R.id.osm_login_progress);
     final String dataVersion = DateUtils.getShortDateFormatter().format(Framework.getDataVersion());
     ((TextView) view.findViewById(R.id.osm_presentation))
         .setText(getString(R.string.osm_presentation, dataVersion));
+
+    if (BuildConfig.FLAVOR.equals("google"))
+    {
+      // Hide login and password inputs and Forgot password button
+      UiUtils.hide(view.findViewById(R.id.osm_username_container),
+          view.findViewById(R.id.osm_password_container),
+          mLostPasswordButton);
+
+      mLoginButton.setOnClickListener((v) -> loginWithBrowser());
+    }
+    else
+    {
+      mLoginButton.setOnClickListener((v) -> login());
+      mLostPasswordButton.setOnClickListener((v) -> Utils.openUrl(requireActivity(), Constants.Url.OSM_RECOVER_PASSWORD));
+    }
+
+    readArguments();
+    if (mArgOAuth2Code != null && !mArgOAuth2Code.isEmpty())
+      continueOAuth2Flow(mArgOAuth2Code);
+  }
+
+  private void readArguments()
+  {
+    final Bundle arguments = getArguments();
+    if (arguments == null)
+      return;
+
+    mArgOAuth2Code = arguments.getString(OsmLoginActivity.EXTRA_OAUTH2CODE);
   }
 
   private void login()
@@ -74,6 +104,12 @@ public class OsmLoginFragment extends BaseMwmToolbarFragment
       UiThread.run(() -> processAuth(oauthToken, username1));
     });
   }
+
+  private void loginWithBrowser()
+  {
+    Utils.openUri(requireContext(), Uri.parse(OsmOAuth.nativeGetOAuth2Url()));
+  }
+
 
   private void enableInput(boolean enable)
   {
@@ -112,5 +148,26 @@ public class OsmLoginFragment extends BaseMwmToolbarFragment
     if (extras != null && extras.getBoolean("redirectToProfile", false))
       startActivity(new Intent(requireContext(), ProfileActivity.class));
     requireActivity().finish();
+  }
+
+  // This method is called by MwmActivity & UrlProcessor when "om://oauth2/osm/callback?code=XXX" is handled
+  private void continueOAuth2Flow(String oauth2code)
+  {
+    if (!isAdded())
+      return;
+
+    if (oauth2code == null || oauth2code.isEmpty())
+      onAuthFail();
+    else
+    {
+      ThreadPool.getWorker().execute(() -> {
+        // Finish OAuth2 auth flow and get username for UI.
+        final String oauthToken = OsmOAuth.nativeAuthWithOAuth2Code(oauth2code);
+        final String username = (oauthToken == null) ? null : OsmOAuth.nativeGetOsmUsername(oauthToken);
+        UiThread.run(() -> {
+          processAuth(oauthToken, username);
+        });
+      });
+    }
   }
 }

--- a/android/app/src/main/java/app/organicmaps/editor/OsmOAuth.java
+++ b/android/app/src/main/java/app/organicmaps/editor/OsmOAuth.java
@@ -10,6 +10,8 @@ import androidx.annotation.Size;
 import androidx.annotation.WorkerThread;
 import androidx.fragment.app.FragmentManager;
 
+import java.util.Map;
+
 import app.organicmaps.MwmApplication;
 import app.organicmaps.util.NetworkPolicy;
 
@@ -98,6 +100,12 @@ public final class OsmOAuth
     return nativeGetHistoryUrl(getUsername(context));
   }
 
+  /*
+   Returns 5 strings: ServerURL, ClientId, ClientSecret, Scope, RedirectUri
+   */
+  @NonNull
+  public static native String nativeGetOAuth2Url();
+
   /**
    * @return string with OAuth2 token
    */
@@ -105,6 +113,13 @@ public final class OsmOAuth
   @Size(2)
   @Nullable
   public static native String nativeAuthWithPassword(String login, String password);
+
+  /**
+   * @return string with OAuth2 token
+   */
+  @WorkerThread
+  @Nullable
+  public static native String nativeAuthWithOAuth2Code(String oauth2code);
 
   @WorkerThread
   @Nullable

--- a/android/app/src/main/java/app/organicmaps/editor/ProfileActivity.java
+++ b/android/app/src/main/java/app/organicmaps/editor/ProfileActivity.java
@@ -6,6 +6,8 @@ import app.organicmaps.base.BaseMwmFragmentActivity;
 
 public class ProfileActivity extends BaseMwmFragmentActivity
 {
+  public static final String EXTRA_REDIRECT_TO_PROFILE = "redirectToProfile";
+
   @Override
   protected Class<? extends Fragment> getFragmentClass()
   {

--- a/android/app/src/main/java/app/organicmaps/editor/ProfileFragment.java
+++ b/android/app/src/main/java/app/organicmaps/editor/ProfileFragment.java
@@ -93,7 +93,7 @@ public class ProfileFragment extends BaseMwmToolbarFragment
     else
     {
       Intent intent = new Intent(requireContext(), OsmLoginActivity.class);
-      intent.putExtra("redirectToProfile", true);
+      intent.putExtra(ProfileActivity.EXTRA_REDIRECT_TO_PROFILE, true);
       startActivity(intent);
       requireActivity().finish();
     }

--- a/android/app/src/main/java/app/organicmaps/intent/Factory.java
+++ b/android/app/src/main/java/app/organicmaps/intent/Factory.java
@@ -3,6 +3,7 @@ package app.organicmaps.intent;
 import android.content.ContentResolver;
 import android.content.Intent;
 import android.net.Uri;
+import android.util.Log;
 
 import androidx.annotation.NonNull;
 import androidx.core.content.IntentCompat;
@@ -18,6 +19,7 @@ import app.organicmaps.api.RoutePoint;
 import app.organicmaps.bookmarks.data.BookmarkManager;
 import app.organicmaps.bookmarks.data.FeatureId;
 import app.organicmaps.bookmarks.data.MapObject;
+import app.organicmaps.editor.OsmLoginActivity;
 import app.organicmaps.routing.RoutingController;
 import app.organicmaps.search.SearchActivity;
 import app.organicmaps.search.SearchEngine;
@@ -127,6 +129,15 @@ public class Factory
             Framework.nativeStopLocationFollow();
             Framework.nativeSetViewportCenter(latlon[0], latlon[1], SEARCH_IN_VIEWPORT_ZOOM);
           }
+
+          return true;
+        }
+        case RequestType.OAUTH2:
+        {
+          SearchEngine.INSTANCE.cancelInteractiveSearch();
+
+          final String oauth2code = Framework.nativeGetParsedOAuth2Code();
+          OsmLoginActivity.OAuth2Callback(target, oauth2code);
 
           return true;
         }

--- a/android/app/src/main/res/layout/fragment_osm_login.xml
+++ b/android/app/src/main/res/layout/fragment_osm_login.xml
@@ -61,6 +61,7 @@
         android:textAppearance="@style/MwmTextAppearance.Body2"
         android:textColor="?android:textColorPrimary" />
       <com.google.android.material.textfield.TextInputLayout
+        android:id="@+id/osm_username_container"
         style="@style/MwmWidget.Editor.CustomTextInput"
         android:layout_marginTop="@dimen/margin_half"
         android:textColorHint="?android:textColorSecondary"
@@ -72,6 +73,7 @@
           android:hint="@string/email_or_username" />
       </com.google.android.material.textfield.TextInputLayout>
       <com.google.android.material.textfield.TextInputLayout
+        android:id="@+id/osm_password_container"
         style="@style/MwmWidget.Editor.CustomTextInput"
         android:layout_marginTop="@dimen/margin_base"
         android:textColorHint="?android:textColorSecondary"

--- a/editor/osm_auth.cpp
+++ b/editor/osm_auth.cpp
@@ -275,8 +275,9 @@ string OsmOAuth::FetchRequestToken(SessionID const & sid) const
 
 string OsmOAuth::BuildOAuth2Url() const
 {
-   string requestTokenUrl = m_baseUrl + "/oauth2/authorize";
-   string const requestTokenQuery = BuildPostRequest({
+   auto requestTokenUrl = m_baseUrl + "/oauth2/authorize";
+   auto const requestTokenQuery = BuildPostRequest(
+   {
        {"client_id", m_oauth2params.m_clientId},
        {"redirect_uri", m_oauth2params.m_redirectUri},
        {"scope", m_oauth2params.m_scope},

--- a/editor/osm_auth.cpp
+++ b/editor/osm_auth.cpp
@@ -241,14 +241,7 @@ string OsmOAuth::SendAuthRequest(string const & requestTokenKey, SessionID const
 
 string OsmOAuth::FetchRequestToken(SessionID const & sid) const
 {
-  string const requestTokenUrl = m_baseUrl + "/oauth2/authorize";
-  string const requestTokenQuery =  BuildPostRequest({
-      {"client_id", m_oauth2params.m_clientId},
-      {"redirect_uri", m_oauth2params.m_redirectUri},
-      {"scope", m_oauth2params.m_scope},
-      {"response_type", "code"}
-  });
-  HttpClient request(requestTokenUrl + "?" + requestTokenQuery);
+  HttpClient request(BuildOAuth2Url());
   request.SetCookies(sid.m_cookies)
          .SetFollowRedirects(false);
 
@@ -278,6 +271,18 @@ string OsmOAuth::FetchRequestToken(SessionID const & sid) const
     // Accept OAuth2 request from server
     return SendAuthRequest(authenticityToken, sid);
   }
+}
+
+string OsmOAuth::BuildOAuth2Url() const
+{
+   string requestTokenUrl = m_baseUrl + "/oauth2/authorize";
+   string const requestTokenQuery = BuildPostRequest({
+       {"client_id", m_oauth2params.m_clientId},
+       {"redirect_uri", m_oauth2params.m_redirectUri},
+       {"scope", m_oauth2params.m_scope},
+       {"response_type", "code"}
+   });
+   return requestTokenUrl.append("?").append(requestTokenQuery);
 }
 
 string OsmOAuth::FinishAuthorization(string const & oauth2code) const

--- a/editor/osm_auth.hpp
+++ b/editor/osm_auth.hpp
@@ -93,6 +93,13 @@ public:
   /// @param[api] If false, request is made to m_baseUrl.
   Response DirectRequest(std::string const & method, bool api = true) const;
 
+  // Getters
+  std::string GetBaseUrl() const { return m_baseUrl; }
+  std::string GetClientId() const { return m_oauth2params.m_clientId; }
+  std::string GetClientSecret() const { return m_oauth2params.m_clientSecret; }
+  std::string GetScope() const { return m_oauth2params.m_scope; }
+  std::string GetRedirectUri() const { return m_oauth2params.m_redirectUri; }
+
   /// @name Methods for WebView-based authentication.
   //@{
   std::string FinishAuthorization(std::string const & oauth2code) const;
@@ -102,6 +109,7 @@ public:
   {
     return m_baseUrl + "/user/" + user + "/history";
   }
+  std::string BuildOAuth2Url() const;
   //@}
 
 private:
@@ -136,7 +144,6 @@ private:
   /// @returns valid key and secret or throws otherwise.
   std::string FetchRequestToken(SessionID const & sid) const;
   std::string FetchAccessToken(SessionID const & sid) const;
-  //AuthResult FetchAccessToken(SessionID const & sid);
 };
 
 std::string DebugPrint(OsmOAuth::Response const & code);

--- a/iphone/CoreApi/CoreApi/DeepLink/DeepLinkParser.h
+++ b/iphone/CoreApi/CoreApi/DeepLink/DeepLinkParser.h
@@ -8,6 +8,7 @@ typedef NS_ENUM(NSUInteger, DeeplinkUrlType) {
   DeeplinkUrlTypeRoute,
   DeeplinkUrlTypeSearch,
   DeeplinkUrlTypeCrosshair,
+  DeeplinkUrlTypeOAuth2
 };
 
 @interface DeepLinkParser : NSObject

--- a/iphone/CoreApi/CoreApi/DeepLink/DeepLinkParser.mm
+++ b/iphone/CoreApi/CoreApi/DeepLink/DeepLinkParser.mm
@@ -13,6 +13,7 @@ static inline DeeplinkUrlType deeplinkUrlType(url_scheme::ParsedMapApi::UrlType 
      case url_scheme::ParsedMapApi::UrlType::Route: return DeeplinkUrlTypeRoute;
      case url_scheme::ParsedMapApi::UrlType::Search: return DeeplinkUrlTypeSearch;
      case url_scheme::ParsedMapApi::UrlType::Crosshair: return DeeplinkUrlTypeCrosshair;
+     case url_scheme::ParsedMapApi::UrlType::OAuth2: return DeeplinkUrlTypeOAuth2;
    }
 }
 

--- a/iphone/Maps/Core/DeepLink/DeepLinkHandler.swift
+++ b/iphone/Maps/Core/DeepLink/DeepLinkHandler.swift
@@ -115,6 +115,10 @@
     case .crosshair:
       // Not supported on iOS.
       return false;
+      
+    case .oAuth2:
+      // TODO: support OAuth2
+      return false;
 
     case .incorrect:
       // Invalid URL or API parameters.

--- a/map/framework.cpp
+++ b/map/framework.cpp
@@ -1738,6 +1738,11 @@ url_scheme::SearchRequest Framework::GetParsedSearchRequest() const
   return m_parsedMapApi.GetSearchRequest();
 }
 
+std::string Framework::GetParsedOAuth2Code() const
+{
+  return m_parsedMapApi.GetOAuth2Code();
+}
+
 std::string const & Framework::GetParsedAppName() const
 {
   return m_parsedMapApi.GetAppName();

--- a/map/framework.hpp
+++ b/map/framework.hpp
@@ -577,6 +577,7 @@ public:
 
   ParsedRoutingData GetParsedRoutingData() const;
   url_scheme::SearchRequest GetParsedSearchRequest() const;
+  std::string GetParsedOAuth2Code() const;
   std::string const & GetParsedAppName() const;
   std::string const & GetParsedBackUrl() const;
   ms::LatLon GetParsedCenterLatLon() const;

--- a/map/map_tests/mwm_url_tests.cpp
+++ b/map/map_tests/mwm_url_tests.cpp
@@ -474,6 +474,23 @@ UNIT_TEST(AppNameTest)
   }
 }
 
+UNIT_TEST(OAuth2Test)
+{
+  {
+    ParsedMapApi api("om://oauth2/osm/callback?code=THE_MEGA_CODE");
+    TEST_EQUAL(api.GetRequestType(), UrlType::OAuth2, ());
+    TEST_EQUAL(api.GetOAuth2Code(), "THE_MEGA_CODE", ());
+  }
+  {
+    ParsedMapApi api("om://oauth2/google/callback?code=THE_MEGA_CODE");
+    TEST_EQUAL(api.GetRequestType(), UrlType::Incorrect, ());
+  }
+  {
+    ParsedMapApi api("om://oauth2/osm/callback?code=");
+    TEST_EQUAL(api.GetRequestType(), UrlType::Incorrect, ());
+  }
+}
+
 namespace
 {
 string generatePartOfUrl(url_scheme::MapPoint const & point)

--- a/map/mwm_url.cpp
+++ b/map/mwm_url.cpp
@@ -175,6 +175,22 @@ ParsedMapApi::UrlType ParsedMapApi::SetUrlAndParse(std::string const & raw)
 
       return m_requestType = UrlType::Crosshair;
     }
+    else if (type == "oauth2")
+    {
+      if (url.GetPath() != "osm/callback")
+        return m_requestType = UrlType::Incorrect;
+
+      url.ForEachParam([this](auto const & key, auto const & value)
+      {
+        if (key == "code")
+          m_oauth2code = value;
+      });
+
+      if (m_oauth2code.empty())
+        return m_requestType = UrlType::Incorrect;
+      else
+        return m_requestType = UrlType::OAuth2;
+    }
     else if (checkForGe0Link)
     {
       // The URL is prefixed by one of the kGe0Prefixes AND doesn't match any supported API call:
@@ -386,6 +402,7 @@ void ParsedMapApi::Reset()
   m_mapPoints.clear();
   m_routePoints.clear();
   m_searchRequest = {};
+  m_oauth2code = {};
   m_globalBackUrl ={};
   m_appName = {};
   m_centerLatLon = ms::LatLon::Invalid();
@@ -467,6 +484,7 @@ std::string DebugPrint(ParsedMapApi::UrlType type)
   case ParsedMapApi::UrlType::Route: return "Route";
   case ParsedMapApi::UrlType::Search: return "Search";
   case ParsedMapApi::UrlType::Crosshair: return "Crosshair";
+  case ParsedMapApi::UrlType::OAuth2: return "OAuth2";
   }
   UNREACHABLE();
 }

--- a/map/mwm_url.hpp
+++ b/map/mwm_url.hpp
@@ -45,6 +45,7 @@ public:
     Route = 2,
     Search = 3,
     Crosshair = 4,
+    OAuth2 = 5,
   };
 
   ParsedMapApi() = default;
@@ -93,6 +94,12 @@ public:
     return m_searchRequest;
   }
 
+  std::string const & GetOAuth2Code() const
+  {
+    ASSERT_EQUAL(m_requestType, UrlType::OAuth2, ("Expected OAuth2 API"));
+    return m_oauth2code;
+  }
+
 private:
   void ParseMapParam(std::string const & key, std::string const & value,
                      bool & correctOrder);
@@ -107,6 +114,7 @@ private:
   SearchRequest m_searchRequest;
   std::string m_globalBackUrl;
   std::string m_appName;
+  std::string m_oauth2code;
   ms::LatLon m_centerLatLon = ms::LatLon::Invalid();
   std::string m_routingType;
   int m_version = 0;


### PR DESCRIPTION
**N.B.** New login flow is enabled only for "google" builds! F-Droid and Web builds should work as previously.

How OAuth2 flow should work (happy path):

* `OsmLoginFragment` - User pushes "Login to OpenStreetMap" button
* `OsmLoginFragment` - triggers browser
* `Browser` - OSM.org login flow
* `Browser` - redirects to `om://oauth2/osm/callback?code=XXX`
* `MwmActivity` - handles `om://` URI and extracts code value
* `MwmActivity` - calls OsmLoginActivity with code in extras
* `OsmLoginFragment` - calls native code to get OAuth2 token using code
* `OsmLoginFragment` - calls native code to get username using OAuth2 token
* `OsmLoginFragment` - redirects to `ProfileActivity`

https://github.com/user-attachments/assets/94f51fca-4fac-45b8-94ae-7495731ed93e

This PR does the same as #8825 but with no UI changes.