### PR TITLE
[ios] Distinguish bug reports from iCloud by their email subject

### DIFF
--- a/iphone/Maps/Classes/CustomAlert/DefaultAlert/MWMDefaultAlert.mm
+++ b/iphone/Maps/Classes/CustomAlert/DefaultAlert/MWMDefaultAlert.mm
@@ -353,7 +353,7 @@ static NSString *const kDefaultAlertNibName = @"MWMDefaultAlert";
                                                message:L(@"bugreport_alert_message")
                                       rightButtonTitle:L(@"report_a_bug")
                                        leftButtonTitle:L(@"cancel")
-                                     rightButtonAction:^{ [MailComposer sendBugReport]; }
+                                     rightButtonAction:^{ [MailComposer sendBugReportWithTitle:title]; }
                                                    log:nil];
   [alert setNeedsCloseAlertAfterEnterBackground];
   return alert;

--- a/iphone/Maps/UI/Help/AboutController/AboutController.swift
+++ b/iphone/Maps/UI/Help/AboutController/AboutController.swift
@@ -277,7 +277,7 @@ private extension AboutController {
         case .faq:
           self?.navigationController?.pushViewController(FaqController(), animated: true)
         case .reportABug:
-          MailComposer.sendBugReport()
+          MailComposer.sendBugReportWith(title:"Organic Maps Bug Report")
         case .reportMapDataProblem, .volunteer, .news:
           self?.openUrl(aboutInfo.link)
         case .rateTheApp:

--- a/iphone/Maps/UI/MailComposer/MailComposer.swift
+++ b/iphone/Maps/UI/MailComposer/MailComposer.swift
@@ -15,10 +15,10 @@ final class MailComposer: NSObject {
   }
 
   /// Composes an email with the additional app information and the log file attachment for the developers.
-  static func sendBugReport() {
+  static func sendBugReportWith(title: String) {
     func subject() -> String {
       let appInfo = AppInfo.shared()
-      return String(format:"[%@-%@ iOS] %@", appInfo.bundleVersion, appInfo.buildNumber, "Organic Maps Bugreport")
+      return String(format:"[%@-%@ iOS] %@", appInfo.bundleVersion, appInfo.buildNumber, title)
     }
 
     func body() -> String {


### PR DESCRIPTION
This change should help to understand which logs came from iCloud code.