### PR TITLE
[Strings] Rename the `continue_download` key to the `continue_button`

### DIFF
--- a/android/app/src/main/java/app/organicmaps/DownloadResourcesLegacyActivity.java
+++ b/android/app/src/main/java/app/organicmaps/DownloadResourcesLegacyActivity.java
@@ -292,7 +292,7 @@ public class DownloadResourcesLegacyActivity extends BaseMwmFragmentActivity
     mBtnNames[PAUSE] = getString(R.string.pause);
 
     mBtnListeners[RESUME] = v -> onResumeClicked();
-    mBtnNames[RESUME] = getString(R.string.continue_download);
+    mBtnNames[RESUME] = getString(R.string.continue_button);
 
     mBtnListeners[TRY_AGAIN] = v -> onTryAgainClicked();
     mBtnNames[TRY_AGAIN] = getString(R.string.try_again);

--- a/android/app/src/main/res/values-ar/strings.xml
+++ b/android/app/src/main/res/values-ar/strings.xml
@@ -63,7 +63,7 @@
 	<!-- REMOVE THIS STRING AFTER REFACTORING -->
 	<string name="pause">توقيف مؤقت</string>
 	<!-- REMOVE THIS STRING AFTER REFACTORING -->
-	<string name="continue_download">استمرار</string>
+	<string name="continue_button">استمرار</string>
 	<!-- Show popup notification on top of the map when country download has failed. -->
 	<string name="download_country_failed">فشلت عملية تنزيل %s</string>
 	<!-- "Add new bookmark list" dialog title -->

--- a/android/app/src/main/res/values-az/strings.xml
+++ b/android/app/src/main/res/values-az/strings.xml
@@ -62,7 +62,7 @@
 	<!-- REMOVE THIS STRING AFTER REFACTORING -->
 	<string name="pause">Dayan</string>
 	<!-- REMOVE THIS STRING AFTER REFACTORING -->
-	<string name="continue_download">Davam et</string>
+	<string name="continue_button">Davam et</string>
 	<!-- Show popup notification on top of the map when country download has failed. -->
 	<string name="download_country_failed">%s endirmə uğursuz oldu</string>
 	<!-- "Add new bookmark list" dialog title -->

--- a/android/app/src/main/res/values-be/strings.xml
+++ b/android/app/src/main/res/values-be/strings.xml
@@ -63,7 +63,7 @@
 	<!-- REMOVE THIS STRING AFTER REFACTORING -->
 	<string name="pause">Прыпыніць</string>
 	<!-- REMOVE THIS STRING AFTER REFACTORING -->
-	<string name="continue_download">Працягнуць</string>
+	<string name="continue_button">Працягнуць</string>
 	<!-- Show popup notification on top of the map when country download has failed. -->
 	<string name="download_country_failed">Не ўдалося спампаваць %s</string>
 	<!-- "Add new bookmark list" dialog title -->

--- a/android/app/src/main/res/values-bg/strings.xml
+++ b/android/app/src/main/res/values-bg/strings.xml
@@ -63,7 +63,7 @@
 	<!-- REMOVE THIS STRING AFTER REFACTORING -->
 	<string name="pause">Пауза</string>
 	<!-- REMOVE THIS STRING AFTER REFACTORING -->
-	<string name="continue_download">Възобновяване</string>
+	<string name="continue_button">Възобновяване</string>
 	<!-- Show popup notification on top of the map when country download has failed. -->
 	<string name="download_country_failed">Изтеглянето на %s се провали</string>
 	<!-- "Add new bookmark list" dialog title -->

--- a/android/app/src/main/res/values-ca/strings.xml
+++ b/android/app/src/main/res/values-ca/strings.xml
@@ -60,7 +60,7 @@
 	<!-- REMOVE THIS STRING AFTER REFACTORING -->
 	<string name="pause">Pausa</string>
 	<!-- REMOVE THIS STRING AFTER REFACTORING -->
-	<string name="continue_download">Continua</string>
+	<string name="continue_button">Continua</string>
 	<!-- Show popup notification on top of the map when country download has failed. -->
 	<string name="download_country_failed">La baixada de %s ha fallat</string>
 	<!-- "Add new bookmark list" dialog title -->

--- a/android/app/src/main/res/values-cs/strings.xml
+++ b/android/app/src/main/res/values-cs/strings.xml
@@ -60,7 +60,7 @@
 	<!-- REMOVE THIS STRING AFTER REFACTORING -->
 	<string name="pause">Pauza</string>
 	<!-- REMOVE THIS STRING AFTER REFACTORING -->
-	<string name="continue_download">Pokračovat</string>
+	<string name="continue_button">Pokračovat</string>
 	<!-- Show popup notification on top of the map when country download has failed. -->
 	<string name="download_country_failed">Stahování selhalo: %s</string>
 	<!-- "Add new bookmark list" dialog title -->

--- a/android/app/src/main/res/values-da/strings.xml
+++ b/android/app/src/main/res/values-da/strings.xml
@@ -60,7 +60,7 @@
 	<!-- REMOVE THIS STRING AFTER REFACTORING -->
 	<string name="pause">Pause</string>
 	<!-- REMOVE THIS STRING AFTER REFACTORING -->
-	<string name="continue_download">Fortsæt</string>
+	<string name="continue_button">Fortsæt</string>
 	<!-- Show popup notification on top of the map when country download has failed. -->
 	<string name="download_country_failed">%s download mislykkedes</string>
 	<!-- "Add new bookmark list" dialog title -->

--- a/android/app/src/main/res/values-de/strings.xml
+++ b/android/app/src/main/res/values-de/strings.xml
@@ -60,7 +60,7 @@
 	<!-- REMOVE THIS STRING AFTER REFACTORING -->
 	<string name="pause">Pause</string>
 	<!-- REMOVE THIS STRING AFTER REFACTORING -->
-	<string name="continue_download">Fortfahren</string>
+	<string name="continue_button">Fortfahren</string>
 	<!-- Show popup notification on top of the map when country download has failed. -->
 	<string name="download_country_failed">%s Herunterladen fehlgeschlagen</string>
 	<!-- "Add new bookmark list" dialog title -->

--- a/android/app/src/main/res/values-el/strings.xml
+++ b/android/app/src/main/res/values-el/strings.xml
@@ -61,7 +61,7 @@
 	<!-- REMOVE THIS STRING AFTER REFACTORING -->
 	<string name="pause">Παύση</string>
 	<!-- REMOVE THIS STRING AFTER REFACTORING -->
-	<string name="continue_download">Συνέχεια</string>
+	<string name="continue_button">Συνέχεια</string>
 	<!-- Show popup notification on top of the map when country download has failed. -->
 	<string name="download_country_failed">η λήψη %s απέτυχε</string>
 	<!-- "Add new bookmark list" dialog title -->

--- a/android/app/src/main/res/values-es/strings.xml
+++ b/android/app/src/main/res/values-es/strings.xml
@@ -60,7 +60,7 @@
 	<!-- REMOVE THIS STRING AFTER REFACTORING -->
 	<string name="pause">Pausar</string>
 	<!-- REMOVE THIS STRING AFTER REFACTORING -->
-	<string name="continue_download">Continuar</string>
+	<string name="continue_button">Continuar</string>
 	<!-- Show popup notification on top of the map when country download has failed. -->
 	<string name="download_country_failed">No se pudo descargar %s</string>
 	<!-- "Add new bookmark list" dialog title -->

--- a/android/app/src/main/res/values-et/strings.xml
+++ b/android/app/src/main/res/values-et/strings.xml
@@ -54,7 +54,7 @@
 	<!-- REMOVE THIS STRING AFTER REFACTORING -->
 	<string name="pause">Peata</string>
 	<!-- REMOVE THIS STRING AFTER REFACTORING -->
-	<string name="continue_download">Jätka</string>
+	<string name="continue_button">Jätka</string>
 	<!-- Show popup notification on top of the map when country download has failed. -->
 	<string name="download_country_failed">%s allalaadimine ebaõnnestus</string>
 	<!-- "Add new bookmark list" dialog title -->

--- a/android/app/src/main/res/values-eu/strings.xml
+++ b/android/app/src/main/res/values-eu/strings.xml
@@ -60,7 +60,7 @@
 	<!-- REMOVE THIS STRING AFTER REFACTORING -->
 	<string name="pause">Pausa</string>
 	<!-- REMOVE THIS STRING AFTER REFACTORING -->
-	<string name="continue_download">Jarraitu</string>
+	<string name="continue_button">Jarraitu</string>
 	<!-- Show popup notification on top of the map when country download has failed. -->
 	<string name="download_country_failed">%s deskargak huts egin du</string>
 	<!-- "Add new bookmark list" dialog title -->

--- a/android/app/src/main/res/values-fa/strings.xml
+++ b/android/app/src/main/res/values-fa/strings.xml
@@ -61,7 +61,7 @@
 	<!-- REMOVE THIS STRING AFTER REFACTORING -->
 	<string name="pause">مکث</string>
 	<!-- REMOVE THIS STRING AFTER REFACTORING -->
-	<string name="continue_download">ادامه</string>
+	<string name="continue_button">ادامه</string>
 	<!-- Show popup notification on top of the map when country download has failed. -->
 	<string name="download_country_failed">%s دانلود با شکست مواجه شد</string>
 	<!-- "Add new bookmark list" dialog title -->

--- a/android/app/src/main/res/values-fi/strings.xml
+++ b/android/app/src/main/res/values-fi/strings.xml
@@ -63,7 +63,7 @@
 	<!-- REMOVE THIS STRING AFTER REFACTORING -->
 	<string name="pause">Pysäytä</string>
 	<!-- REMOVE THIS STRING AFTER REFACTORING -->
-	<string name="continue_download">Jatka</string>
+	<string name="continue_button">Jatka</string>
 	<!-- Show popup notification on top of the map when country download has failed. -->
 	<string name="download_country_failed">%s lataus epäonnistui</string>
 	<!-- "Add new bookmark list" dialog title -->

--- a/android/app/src/main/res/values-fr/strings.xml
+++ b/android/app/src/main/res/values-fr/strings.xml
@@ -63,7 +63,7 @@
 	<!-- REMOVE THIS STRING AFTER REFACTORING -->
 	<string name="pause">Pause</string>
 	<!-- REMOVE THIS STRING AFTER REFACTORING -->
-	<string name="continue_download">Continuer</string>
+	<string name="continue_button">Continuer</string>
 	<!-- Show popup notification on top of the map when country download has failed. -->
 	<string name="download_country_failed">%s, échec lors du téléchargement</string>
 	<!-- "Add new bookmark list" dialog title -->

--- a/android/app/src/main/res/values-hi/strings.xml
+++ b/android/app/src/main/res/values-hi/strings.xml
@@ -63,7 +63,7 @@
 	<!-- REMOVE THIS STRING AFTER REFACTORING -->
 	<string name="pause">विराम</string>
 	<!-- REMOVE THIS STRING AFTER REFACTORING -->
-	<string name="continue_download">जारी रखने के लिए</string>
+	<string name="continue_button">जारी रखने के लिए</string>
 	<!-- Show popup notification on top of the map when country download has failed. -->
 	<string name="download_country_failed">%s डाउनलोड विफल हो गया है</string>
 	<!-- "Add new bookmark list" dialog title -->

--- a/android/app/src/main/res/values-hu/strings.xml
+++ b/android/app/src/main/res/values-hu/strings.xml
@@ -60,7 +60,7 @@
 	<!-- REMOVE THIS STRING AFTER REFACTORING -->
 	<string name="pause">Szünet</string>
 	<!-- REMOVE THIS STRING AFTER REFACTORING -->
-	<string name="continue_download">Folytatás</string>
+	<string name="continue_button">Folytatás</string>
 	<!-- Show popup notification on top of the map when country download has failed. -->
 	<string name="download_country_failed">%s letöltése sikertelen</string>
 	<!-- "Add new bookmark list" dialog title -->

--- a/android/app/src/main/res/values-in/strings.xml
+++ b/android/app/src/main/res/values-in/strings.xml
@@ -62,7 +62,7 @@
 	<!-- REMOVE THIS STRING AFTER REFACTORING -->
 	<string name="pause">Jeda</string>
 	<!-- REMOVE THIS STRING AFTER REFACTORING -->
-	<string name="continue_download">Lanjutkan</string>
+	<string name="continue_button">Lanjutkan</string>
 	<!-- Show popup notification on top of the map when country download has failed. -->
 	<string name="download_country_failed">%s gagal diunduh</string>
 	<!-- "Add new bookmark list" dialog title -->

--- a/android/app/src/main/res/values-it/strings.xml
+++ b/android/app/src/main/res/values-it/strings.xml
@@ -60,7 +60,7 @@
 	<!-- REMOVE THIS STRING AFTER REFACTORING -->
 	<string name="pause">Pausa</string>
 	<!-- REMOVE THIS STRING AFTER REFACTORING -->
-	<string name="continue_download">Continua</string>
+	<string name="continue_button">Continua</string>
 	<!-- Show popup notification on top of the map when country download has failed. -->
 	<string name="download_country_failed">Il download di %s non è riuscito</string>
 	<!-- "Add new bookmark list" dialog title -->

--- a/android/app/src/main/res/values-iw/strings.xml
+++ b/android/app/src/main/res/values-iw/strings.xml
@@ -60,7 +60,7 @@
 	<!-- REMOVE THIS STRING AFTER REFACTORING -->
 	<string name="pause">הפסק</string>
 	<!-- REMOVE THIS STRING AFTER REFACTORING -->
-	<string name="continue_download">המשך</string>
+	<string name="continue_button">המשך</string>
 	<!-- Show popup notification on top of the map when country download has failed. -->
 	<string name="download_country_failed">הורדה של %s נכשלה</string>
 	<!-- "Add new bookmark list" dialog title -->

--- a/android/app/src/main/res/values-ja/strings.xml
+++ b/android/app/src/main/res/values-ja/strings.xml
@@ -60,7 +60,7 @@
 	<!-- REMOVE THIS STRING AFTER REFACTORING -->
 	<string name="pause">一時停止</string>
 	<!-- REMOVE THIS STRING AFTER REFACTORING -->
-	<string name="continue_download">続行</string>
+	<string name="continue_button">続行</string>
 	<!-- Show popup notification on top of the map when country download has failed. -->
 	<string name="download_country_failed">%sのダウンロードが失敗しました</string>
 	<!-- "Add new bookmark list" dialog title -->

--- a/android/app/src/main/res/values-ko/strings.xml
+++ b/android/app/src/main/res/values-ko/strings.xml
@@ -60,7 +60,7 @@
 	<!-- REMOVE THIS STRING AFTER REFACTORING -->
 	<string name="pause">중지</string>
 	<!-- REMOVE THIS STRING AFTER REFACTORING -->
-	<string name="continue_download">계속</string>
+	<string name="continue_button">계속</string>
 	<!-- Show popup notification on top of the map when country download has failed. -->
 	<string name="download_country_failed">%s다운로드가 실패했습니다</string>
 	<!-- "Add new bookmark list" dialog title -->

--- a/android/app/src/main/res/values-mr/strings.xml
+++ b/android/app/src/main/res/values-mr/strings.xml
@@ -54,7 +54,7 @@
 	<!-- REMOVE THIS STRING AFTER REFACTORING -->
 	<string name="pause">विराम द्या</string>
 	<!-- REMOVE THIS STRING AFTER REFACTORING -->
-	<string name="continue_download">चालू ठेवा</string>
+	<string name="continue_button">चालू ठेवा</string>
 	<!-- Show popup notification on top of the map when country download has failed. -->
 	<string name="download_country_failed">%s डाउनलोड अयशस्वी</string>
 	<!-- "Add new bookmark list" dialog title -->

--- a/android/app/src/main/res/values-nb/strings.xml
+++ b/android/app/src/main/res/values-nb/strings.xml
@@ -62,7 +62,7 @@
 	<!-- REMOVE THIS STRING AFTER REFACTORING -->
 	<string name="pause">Pause</string>
 	<!-- REMOVE THIS STRING AFTER REFACTORING -->
-	<string name="continue_download">Fortsett</string>
+	<string name="continue_button">Fortsett</string>
 	<!-- Show popup notification on top of the map when country download has failed. -->
 	<string name="download_country_failed">Nedlasting av %s mislyktes</string>
 	<!-- "Add new bookmark list" dialog title -->

--- a/android/app/src/main/res/values-nl/strings.xml
+++ b/android/app/src/main/res/values-nl/strings.xml
@@ -60,7 +60,7 @@
 	<!-- REMOVE THIS STRING AFTER REFACTORING -->
 	<string name="pause">Pauzeer</string>
 	<!-- REMOVE THIS STRING AFTER REFACTORING -->
-	<string name="continue_download">Ga verder</string>
+	<string name="continue_button">Ga verder</string>
 	<!-- Show popup notification on top of the map when country download has failed. -->
 	<string name="download_country_failed">%s download is mislukt</string>
 	<!-- "Add new bookmark list" dialog title -->

--- a/android/app/src/main/res/values-pl/strings.xml
+++ b/android/app/src/main/res/values-pl/strings.xml
@@ -60,7 +60,7 @@
 	<!-- REMOVE THIS STRING AFTER REFACTORING -->
 	<string name="pause">Wstrzymaj</string>
 	<!-- REMOVE THIS STRING AFTER REFACTORING -->
-	<string name="continue_download">Kontynuuj</string>
+	<string name="continue_button">Kontynuuj</string>
 	<!-- Show popup notification on top of the map when country download has failed. -->
 	<string name="download_country_failed">Nie udało się pobrać %s</string>
 	<!-- "Add new bookmark list" dialog title -->

--- a/android/app/src/main/res/values-pt-rBR/strings.xml
+++ b/android/app/src/main/res/values-pt-rBR/strings.xml
@@ -56,7 +56,7 @@
 	<!-- REMOVE THIS STRING AFTER REFACTORING -->
 	<string name="pause">Pausar</string>
 	<!-- REMOVE THIS STRING AFTER REFACTORING -->
-	<string name="continue_download">Continuar</string>
+	<string name="continue_button">Continuar</string>
 	<!-- Show popup notification on top of the map when country download has failed. -->
 	<string name="download_country_failed">O download de %s falhou</string>
 	<!-- "Add new bookmark list" dialog title -->

--- a/android/app/src/main/res/values-pt/strings.xml
+++ b/android/app/src/main/res/values-pt/strings.xml
@@ -60,7 +60,7 @@
 	<!-- REMOVE THIS STRING AFTER REFACTORING -->
 	<string name="pause">Pausar</string>
 	<!-- REMOVE THIS STRING AFTER REFACTORING -->
-	<string name="continue_download">Continuar</string>
+	<string name="continue_button">Continuar</string>
 	<!-- Show popup notification on top of the map when country download has failed. -->
 	<string name="download_country_failed">O descarregamento de %s falhou</string>
 	<!-- "Add new bookmark list" dialog title -->

--- a/android/app/src/main/res/values-ro/strings.xml
+++ b/android/app/src/main/res/values-ro/strings.xml
@@ -60,7 +60,7 @@
 	<!-- REMOVE THIS STRING AFTER REFACTORING -->
 	<string name="pause">Pauză</string>
 	<!-- REMOVE THIS STRING AFTER REFACTORING -->
-	<string name="continue_download">Continuă</string>
+	<string name="continue_button">Continuă</string>
 	<!-- Show popup notification on top of the map when country download has failed. -->
 	<string name="download_country_failed">Descărcarea %s a eșuat</string>
 	<!-- "Add new bookmark list" dialog title -->

--- a/android/app/src/main/res/values-ru/strings.xml
+++ b/android/app/src/main/res/values-ru/strings.xml
@@ -63,7 +63,7 @@
 	<!-- REMOVE THIS STRING AFTER REFACTORING -->
 	<string name="pause">Приостановить</string>
 	<!-- REMOVE THIS STRING AFTER REFACTORING -->
-	<string name="continue_download">Продолжить</string>
+	<string name="continue_button">Продолжить</string>
 	<!-- Show popup notification on top of the map when country download has failed. -->
 	<string name="download_country_failed">Не удалось загрузить %s</string>
 	<!-- "Add new bookmark list" dialog title -->

--- a/android/app/src/main/res/values-sk/strings.xml
+++ b/android/app/src/main/res/values-sk/strings.xml
@@ -60,7 +60,7 @@
 	<!-- REMOVE THIS STRING AFTER REFACTORING -->
 	<string name="pause">Pauza</string>
 	<!-- REMOVE THIS STRING AFTER REFACTORING -->
-	<string name="continue_download">Pokračovať</string>
+	<string name="continue_button">Pokračovať</string>
 	<!-- Show popup notification on top of the map when country download has failed. -->
 	<string name="download_country_failed">Sťahovanie zlyhalo: %s</string>
 	<!-- "Add new bookmark list" dialog title -->

--- a/android/app/src/main/res/values-sv/strings.xml
+++ b/android/app/src/main/res/values-sv/strings.xml
@@ -60,7 +60,7 @@
 	<!-- REMOVE THIS STRING AFTER REFACTORING -->
 	<string name="pause">Pausa</string>
 	<!-- REMOVE THIS STRING AFTER REFACTORING -->
-	<string name="continue_download">Fortsätt</string>
+	<string name="continue_button">Fortsätt</string>
 	<!-- Show popup notification on top of the map when country download has failed. -->
 	<string name="download_country_failed">%s nedladdning misslyckades</string>
 	<!-- "Add new bookmark list" dialog title -->

--- a/android/app/src/main/res/values-th/strings.xml
+++ b/android/app/src/main/res/values-th/strings.xml
@@ -62,7 +62,7 @@
 	<!-- REMOVE THIS STRING AFTER REFACTORING -->
 	<string name="pause">หยุดชั่วคราว</string>
 	<!-- REMOVE THIS STRING AFTER REFACTORING -->
-	<string name="continue_download">ดำเนินการต่อ</string>
+	<string name="continue_button">ดำเนินการต่อ</string>
 	<!-- Show popup notification on top of the map when country download has failed. -->
 	<string name="download_country_failed">การดาวน์โหลด %s ล้มเหลว</string>
 	<!-- "Add new bookmark list" dialog title -->

--- a/android/app/src/main/res/values-tr/strings.xml
+++ b/android/app/src/main/res/values-tr/strings.xml
@@ -62,7 +62,7 @@
 	<!-- REMOVE THIS STRING AFTER REFACTORING -->
 	<string name="pause">Duraklat</string>
 	<!-- REMOVE THIS STRING AFTER REFACTORING -->
-	<string name="continue_download">Devam</string>
+	<string name="continue_button">Devam</string>
 	<!-- Show popup notification on top of the map when country download has failed. -->
 	<string name="download_country_failed">%s indirme işlemi başarısız oldu</string>
 	<!-- "Add new bookmark list" dialog title -->

--- a/android/app/src/main/res/values-uk/strings.xml
+++ b/android/app/src/main/res/values-uk/strings.xml
@@ -63,7 +63,7 @@
 	<!-- REMOVE THIS STRING AFTER REFACTORING -->
 	<string name="pause">Призупинити</string>
 	<!-- REMOVE THIS STRING AFTER REFACTORING -->
-	<string name="continue_download">Продовжити</string>
+	<string name="continue_button">Продовжити</string>
 	<!-- Show popup notification on top of the map when country download has failed. -->
 	<string name="download_country_failed">Не вдалося завантажити %s</string>
 	<!-- "Add new bookmark list" dialog title -->

--- a/android/app/src/main/res/values-vi/strings.xml
+++ b/android/app/src/main/res/values-vi/strings.xml
@@ -60,7 +60,7 @@
 	<!-- REMOVE THIS STRING AFTER REFACTORING -->
 	<string name="pause">Tạm dừng</string>
 	<!-- REMOVE THIS STRING AFTER REFACTORING -->
-	<string name="continue_download">Tiếp tục</string>
+	<string name="continue_button">Tiếp tục</string>
 	<!-- Show popup notification on top of the map when country download has failed. -->
 	<string name="download_country_failed">%s</string>
 	<!-- "Add new bookmark list" dialog title -->

--- a/android/app/src/main/res/values-zh-rTW/strings.xml
+++ b/android/app/src/main/res/values-zh-rTW/strings.xml
@@ -63,7 +63,7 @@
 	<!-- REMOVE THIS STRING AFTER REFACTORING -->
 	<string name="pause">暫停</string>
 	<!-- REMOVE THIS STRING AFTER REFACTORING -->
-	<string name="continue_download">繼續</string>
+	<string name="continue_button">繼續</string>
 	<!-- Show popup notification on top of the map when country download has failed. -->
 	<string name="download_country_failed">%s的地圖下載失敗</string>
 	<!-- "Add new bookmark list" dialog title -->

--- a/android/app/src/main/res/values-zh/strings.xml
+++ b/android/app/src/main/res/values-zh/strings.xml
@@ -63,7 +63,7 @@
 	<!-- REMOVE THIS STRING AFTER REFACTORING -->
 	<string name="pause">暂停</string>
 	<!-- REMOVE THIS STRING AFTER REFACTORING -->
-	<string name="continue_download">继续</string>
+	<string name="continue_button">继续</string>
 	<!-- Show popup notification on top of the map when country download has failed. -->
 	<string name="download_country_failed">%s的地图下载失败</string>
 	<!-- "Add new bookmark list" dialog title -->

--- a/android/app/src/main/res/values/strings.xml
+++ b/android/app/src/main/res/values/strings.xml
@@ -63,7 +63,7 @@
 	<!-- REMOVE THIS STRING AFTER REFACTORING -->
 	<string name="pause">Pause</string>
 	<!-- REMOVE THIS STRING AFTER REFACTORING -->
-	<string name="continue_download">Continue</string>
+	<string name="continue_button">Continue</string>
 	<!-- Show popup notification on top of the map when country download has failed. -->
 	<string name="download_country_failed">%s download has failed</string>
 	<!-- "Add new bookmark list" dialog title -->

--- a/data/strings/strings.txt
+++ b/data/strings/strings.txt
@@ -1776,7 +1776,7 @@
     zh-Hans = 暂停
     zh-Hant = 暫停
 
-  [continue_download]
+  [continue_button]
     comment = REMOVE THIS STRING AFTER REFACTORING
     tags = android,ios
     en = Continue

--- a/iphone/Maps/Classes/CustomAlert/DefaultAlert/MWMDefaultAlert.mm
+++ b/iphone/Maps/Classes/CustomAlert/DefaultAlert/MWMDefaultAlert.mm
@@ -303,7 +303,7 @@ static NSString *const kDefaultAlertNibName = @"MWMDefaultAlert";
   MWMDefaultAlert *alert = [self defaultAlertWithTitle:L(@"recent_track_background_dialog_title")
                                                message:L(@"recent_track_background_dialog_message")
                                       rightButtonTitle:L(@"off_recent_track_background_button")
-                                       leftButtonTitle:L(@"continue_download")
+                                       leftButtonTitle:L(@"continue_button")
                                      rightButtonAction:block
                                        log:@"Track warning alert"];
   return alert;

--- a/iphone/Maps/LocalizedStrings/ar.lproj/Localizable.strings
+++ b/iphone/Maps/LocalizedStrings/ar.lproj/Localizable.strings
@@ -62,7 +62,7 @@
 "download" = "تنزيل";
 
 /* REMOVE THIS STRING AFTER REFACTORING */
-"continue_download" = "استمرار";
+"continue_button" = "استمرار";
 
 /* "Add new bookmark list" dialog title */
 "add_new_set" = "إضافة قائمة جديدة";

--- a/iphone/Maps/LocalizedStrings/az.lproj/Localizable.strings
+++ b/iphone/Maps/LocalizedStrings/az.lproj/Localizable.strings
@@ -62,7 +62,7 @@
 "download" = "Yüklə";
 
 /* REMOVE THIS STRING AFTER REFACTORING */
-"continue_download" = "Davam et";
+"continue_button" = "Davam et";
 
 /* "Add new bookmark list" dialog title */
 "add_new_set" = "Yeni Siyahı əlavə edin";

--- a/iphone/Maps/LocalizedStrings/be.lproj/Localizable.strings
+++ b/iphone/Maps/LocalizedStrings/be.lproj/Localizable.strings
@@ -62,7 +62,7 @@
 "download" = "Спампаваць";
 
 /* REMOVE THIS STRING AFTER REFACTORING */
-"continue_download" = "Працягнуць";
+"continue_button" = "Працягнуць";
 
 /* "Add new bookmark list" dialog title */
 "add_new_set" = "Дадаць спіс";

--- a/iphone/Maps/LocalizedStrings/bg.lproj/Localizable.strings
+++ b/iphone/Maps/LocalizedStrings/bg.lproj/Localizable.strings
@@ -62,7 +62,7 @@
 "download" = "Изтегляне";
 
 /* REMOVE THIS STRING AFTER REFACTORING */
-"continue_download" = "Възобновяване";
+"continue_button" = "Възобновяване";
 
 /* "Add new bookmark list" dialog title */
 "add_new_set" = "Добавяне на нова група";

--- a/iphone/Maps/LocalizedStrings/ca.lproj/Localizable.strings
+++ b/iphone/Maps/LocalizedStrings/ca.lproj/Localizable.strings
@@ -62,7 +62,7 @@
 "download" = "Baixa";
 
 /* REMOVE THIS STRING AFTER REFACTORING */
-"continue_download" = "Continua";
+"continue_button" = "Continua";
 
 /* "Add new bookmark list" dialog title */
 "add_new_set" = "Afegeix una llista nova";

--- a/iphone/Maps/LocalizedStrings/cs.lproj/Localizable.strings
+++ b/iphone/Maps/LocalizedStrings/cs.lproj/Localizable.strings
@@ -62,7 +62,7 @@
 "download" = "Stáhnout";
 
 /* REMOVE THIS STRING AFTER REFACTORING */
-"continue_download" = "Pokračovat";
+"continue_button" = "Pokračovat";
 
 /* "Add new bookmark list" dialog title */
 "add_new_set" = "Přidat novou skupinu záložek";

--- a/iphone/Maps/LocalizedStrings/da.lproj/Localizable.strings
+++ b/iphone/Maps/LocalizedStrings/da.lproj/Localizable.strings
@@ -62,7 +62,7 @@
 "download" = "Download";
 
 /* REMOVE THIS STRING AFTER REFACTORING */
-"continue_download" = "Fortsæt";
+"continue_button" = "Fortsæt";
 
 /* "Add new bookmark list" dialog title */
 "add_new_set" = "Tilføj nyt sæt";

--- a/iphone/Maps/LocalizedStrings/de.lproj/Localizable.strings
+++ b/iphone/Maps/LocalizedStrings/de.lproj/Localizable.strings
@@ -62,7 +62,7 @@
 "download" = "Herunterladen";
 
 /* REMOVE THIS STRING AFTER REFACTORING */
-"continue_download" = "Fortfahren";
+"continue_button" = "Fortfahren";
 
 /* "Add new bookmark list" dialog title */
 "add_new_set" = "Neue Liste hinzufügen";

--- a/iphone/Maps/LocalizedStrings/el.lproj/Localizable.strings
+++ b/iphone/Maps/LocalizedStrings/el.lproj/Localizable.strings
@@ -62,7 +62,7 @@
 "download" = "Λήψη";
 
 /* REMOVE THIS STRING AFTER REFACTORING */
-"continue_download" = "Συνέχεια";
+"continue_button" = "Συνέχεια";
 
 /* "Add new bookmark list" dialog title */
 "add_new_set" = "Δημιουργία νέας λίστας";

--- a/iphone/Maps/LocalizedStrings/en-GB.lproj/Localizable.strings
+++ b/iphone/Maps/LocalizedStrings/en-GB.lproj/Localizable.strings
@@ -62,7 +62,7 @@
 "download" = "Download";
 
 /* REMOVE THIS STRING AFTER REFACTORING */
-"continue_download" = "Continue";
+"continue_button" = "Continue";
 
 /* "Add new bookmark list" dialog title */
 "add_new_set" = "Add a New List";

--- a/iphone/Maps/LocalizedStrings/en.lproj/Localizable.strings
+++ b/iphone/Maps/LocalizedStrings/en.lproj/Localizable.strings
@@ -62,7 +62,7 @@
 "download" = "Download";
 
 /* REMOVE THIS STRING AFTER REFACTORING */
-"continue_download" = "Continue";
+"continue_button" = "Continue";
 
 /* "Add new bookmark list" dialog title */
 "add_new_set" = "Add a New List";

--- a/iphone/Maps/LocalizedStrings/es-MX.lproj/Localizable.strings
+++ b/iphone/Maps/LocalizedStrings/es-MX.lproj/Localizable.strings
@@ -62,7 +62,7 @@
 "download" = "Descargar";
 
 /* REMOVE THIS STRING AFTER REFACTORING */
-"continue_download" = "Continuar";
+"continue_button" = "Continuar";
 
 /* "Add new bookmark list" dialog title */
 "add_new_set" = "Agregar un grupo nuevo";

--- a/iphone/Maps/LocalizedStrings/es.lproj/Localizable.strings
+++ b/iphone/Maps/LocalizedStrings/es.lproj/Localizable.strings
@@ -62,7 +62,7 @@
 "download" = "Descargar";
 
 /* REMOVE THIS STRING AFTER REFACTORING */
-"continue_download" = "Continuar";
+"continue_button" = "Continuar";
 
 /* "Add new bookmark list" dialog title */
 "add_new_set" = "Agregar un grupo nuevo";

--- a/iphone/Maps/LocalizedStrings/et.lproj/Localizable.strings
+++ b/iphone/Maps/LocalizedStrings/et.lproj/Localizable.strings
@@ -62,7 +62,7 @@
 "download" = "Lae alla";
 
 /* REMOVE THIS STRING AFTER REFACTORING */
-"continue_download" = "Jätka";
+"continue_button" = "Jätka";
 
 /* "Add new bookmark list" dialog title */
 "add_new_set" = "Lisa uus loetelu";

--- a/iphone/Maps/LocalizedStrings/eu.lproj/Localizable.strings
+++ b/iphone/Maps/LocalizedStrings/eu.lproj/Localizable.strings
@@ -62,7 +62,7 @@
 "download" = "Deskargatu";
 
 /* REMOVE THIS STRING AFTER REFACTORING */
-"continue_download" = "Jarraitu";
+"continue_button" = "Jarraitu";
 
 /* "Add new bookmark list" dialog title */
 "add_new_set" = "Gehitu zerrenda berri bat";

--- a/iphone/Maps/LocalizedStrings/fa.lproj/Localizable.strings
+++ b/iphone/Maps/LocalizedStrings/fa.lproj/Localizable.strings
@@ -62,7 +62,7 @@
 "download" = "دانلود";
 
 /* REMOVE THIS STRING AFTER REFACTORING */
-"continue_download" = "ادامه";
+"continue_button" = "ادامه";
 
 /* "Add new bookmark list" dialog title */
 "add_new_set" = "اضافه کردن مجموعه جدید";

--- a/iphone/Maps/LocalizedStrings/fi.lproj/Localizable.strings
+++ b/iphone/Maps/LocalizedStrings/fi.lproj/Localizable.strings
@@ -62,7 +62,7 @@
 "download" = "Lataa";
 
 /* REMOVE THIS STRING AFTER REFACTORING */
-"continue_download" = "Jatka";
+"continue_button" = "Jatka";
 
 /* "Add new bookmark list" dialog title */
 "add_new_set" = "Lisää uusi valikoima";

--- a/iphone/Maps/LocalizedStrings/fr.lproj/Localizable.strings
+++ b/iphone/Maps/LocalizedStrings/fr.lproj/Localizable.strings
@@ -62,7 +62,7 @@
 "download" = "Télécharger";
 
 /* REMOVE THIS STRING AFTER REFACTORING */
-"continue_download" = "Continuer";
+"continue_button" = "Continuer";
 
 /* "Add new bookmark list" dialog title */
 "add_new_set" = "Créer une nouvelle liste";

--- a/iphone/Maps/LocalizedStrings/he.lproj/Localizable.strings
+++ b/iphone/Maps/LocalizedStrings/he.lproj/Localizable.strings
@@ -62,7 +62,7 @@
 "download" = "הורדה";
 
 /* REMOVE THIS STRING AFTER REFACTORING */
-"continue_download" = "המשך";
+"continue_button" = "המשך";
 
 /* "Add new bookmark list" dialog title */
 "add_new_set" = "הוסף רשימה חדשה";

--- a/iphone/Maps/LocalizedStrings/hi.lproj/Localizable.strings
+++ b/iphone/Maps/LocalizedStrings/hi.lproj/Localizable.strings
@@ -62,7 +62,7 @@
 "download" = "डाउन लोड करना";
 
 /* REMOVE THIS STRING AFTER REFACTORING */
-"continue_download" = "जारी रखने के लिए";
+"continue_button" = "जारी रखने के लिए";
 
 /* "Add new bookmark list" dialog title */
 "add_new_set" = "एक नई सूची जोड़ें";

--- a/iphone/Maps/LocalizedStrings/hu.lproj/Localizable.strings
+++ b/iphone/Maps/LocalizedStrings/hu.lproj/Localizable.strings
@@ -62,7 +62,7 @@
 "download" = "Letöltés";
 
 /* REMOVE THIS STRING AFTER REFACTORING */
-"continue_download" = "Folytatás";
+"continue_button" = "Folytatás";
 
 /* "Add new bookmark list" dialog title */
 "add_new_set" = "Új csoport létrehozása";

--- a/iphone/Maps/LocalizedStrings/id.lproj/Localizable.strings
+++ b/iphone/Maps/LocalizedStrings/id.lproj/Localizable.strings
@@ -62,7 +62,7 @@
 "download" = "Unduh";
 
 /* REMOVE THIS STRING AFTER REFACTORING */
-"continue_download" = "Lanjutkan";
+"continue_button" = "Lanjutkan";
 
 /* "Add new bookmark list" dialog title */
 "add_new_set" = "Tambahkan Set baru";

--- a/iphone/Maps/LocalizedStrings/it.lproj/Localizable.strings
+++ b/iphone/Maps/LocalizedStrings/it.lproj/Localizable.strings
@@ -62,7 +62,7 @@
 "download" = "Scarica";
 
 /* REMOVE THIS STRING AFTER REFACTORING */
-"continue_download" = "Continua";
+"continue_button" = "Continua";
 
 /* "Add new bookmark list" dialog title */
 "add_new_set" = "Aggiungi nuovo elenco";

--- a/iphone/Maps/LocalizedStrings/ja.lproj/Localizable.strings
+++ b/iphone/Maps/LocalizedStrings/ja.lproj/Localizable.strings
@@ -62,7 +62,7 @@
 "download" = "ダウンロード";
 
 /* REMOVE THIS STRING AFTER REFACTORING */
-"continue_download" = "続行";
+"continue_button" = "続行";
 
 /* "Add new bookmark list" dialog title */
 "add_new_set" = "新しいセットを作成";

--- a/iphone/Maps/LocalizedStrings/ko.lproj/Localizable.strings
+++ b/iphone/Maps/LocalizedStrings/ko.lproj/Localizable.strings
@@ -62,7 +62,7 @@
 "download" = "다운로드";
 
 /* REMOVE THIS STRING AFTER REFACTORING */
-"continue_download" = "계속";
+"continue_button" = "계속";
 
 /* "Add new bookmark list" dialog title */
 "add_new_set" = "새로운 목록 추가";

--- a/iphone/Maps/LocalizedStrings/mr.lproj/Localizable.strings
+++ b/iphone/Maps/LocalizedStrings/mr.lproj/Localizable.strings
@@ -62,7 +62,7 @@
 "download" = "डाउनलोड करा";
 
 /* REMOVE THIS STRING AFTER REFACTORING */
-"continue_download" = "चालू ठेवा";
+"continue_button" = "चालू ठेवा";
 
 /* "Add new bookmark list" dialog title */
 "add_new_set" = "नवीन यादी जोडा";

--- a/iphone/Maps/LocalizedStrings/nb.lproj/Localizable.strings
+++ b/iphone/Maps/LocalizedStrings/nb.lproj/Localizable.strings
@@ -62,7 +62,7 @@
 "download" = "Last ned";
 
 /* REMOVE THIS STRING AFTER REFACTORING */
-"continue_download" = "Fortsett";
+"continue_button" = "Fortsett";
 
 /* "Add new bookmark list" dialog title */
 "add_new_set" = "Legg til nytt sett";

--- a/iphone/Maps/LocalizedStrings/nl.lproj/Localizable.strings
+++ b/iphone/Maps/LocalizedStrings/nl.lproj/Localizable.strings
@@ -62,7 +62,7 @@
 "download" = "Download";
 
 /* REMOVE THIS STRING AFTER REFACTORING */
-"continue_download" = "Ga verder";
+"continue_button" = "Ga verder";
 
 /* "Add new bookmark list" dialog title */
 "add_new_set" = "Voeg nieuwe groep toe";

--- a/iphone/Maps/LocalizedStrings/pl.lproj/Localizable.strings
+++ b/iphone/Maps/LocalizedStrings/pl.lproj/Localizable.strings
@@ -62,7 +62,7 @@
 "download" = "Pobierz";
 
 /* REMOVE THIS STRING AFTER REFACTORING */
-"continue_download" = "Kontynuuj";
+"continue_button" = "Kontynuuj";
 
 /* "Add new bookmark list" dialog title */
 "add_new_set" = "Dodaj nowy zestaw";

--- a/iphone/Maps/LocalizedStrings/pt-BR.lproj/Localizable.strings
+++ b/iphone/Maps/LocalizedStrings/pt-BR.lproj/Localizable.strings
@@ -62,7 +62,7 @@
 "download" = "Baixar";
 
 /* REMOVE THIS STRING AFTER REFACTORING */
-"continue_download" = "Continuar";
+"continue_button" = "Continuar";
 
 /* "Add new bookmark list" dialog title */
 "add_new_set" = "Adicionar novo conjunto";

--- a/iphone/Maps/LocalizedStrings/pt.lproj/Localizable.strings
+++ b/iphone/Maps/LocalizedStrings/pt.lproj/Localizable.strings
@@ -62,7 +62,7 @@
 "download" = "Descarregar";
 
 /* REMOVE THIS STRING AFTER REFACTORING */
-"continue_download" = "Continuar";
+"continue_button" = "Continuar";
 
 /* "Add new bookmark list" dialog title */
 "add_new_set" = "Adicionar conjunto novo";

--- a/iphone/Maps/LocalizedStrings/ro.lproj/Localizable.strings
+++ b/iphone/Maps/LocalizedStrings/ro.lproj/Localizable.strings
@@ -62,7 +62,7 @@
 "download" = "Descarcă";
 
 /* REMOVE THIS STRING AFTER REFACTORING */
-"continue_download" = "Continuă";
+"continue_button" = "Continuă";
 
 /* "Add new bookmark list" dialog title */
 "add_new_set" = "Adaugă o listă nouă";

--- a/iphone/Maps/LocalizedStrings/ru.lproj/Localizable.strings
+++ b/iphone/Maps/LocalizedStrings/ru.lproj/Localizable.strings
@@ -62,7 +62,7 @@
 "download" = "Загрузить";
 
 /* REMOVE THIS STRING AFTER REFACTORING */
-"continue_download" = "Продолжить";
+"continue_button" = "Продолжить";
 
 /* "Add new bookmark list" dialog title */
 "add_new_set" = "Добавить список";

--- a/iphone/Maps/LocalizedStrings/sk.lproj/Localizable.strings
+++ b/iphone/Maps/LocalizedStrings/sk.lproj/Localizable.strings
@@ -62,7 +62,7 @@
 "download" = "Stiahnuť";
 
 /* REMOVE THIS STRING AFTER REFACTORING */
-"continue_download" = "Pokračovať";
+"continue_button" = "Pokračovať";
 
 /* "Add new bookmark list" dialog title */
 "add_new_set" = "Pridať novú skupinu záložiek";

--- a/iphone/Maps/LocalizedStrings/sv.lproj/Localizable.strings
+++ b/iphone/Maps/LocalizedStrings/sv.lproj/Localizable.strings
@@ -62,7 +62,7 @@
 "download" = "Ladda ner";
 
 /* REMOVE THIS STRING AFTER REFACTORING */
-"continue_download" = "Fortsätt";
+"continue_button" = "Fortsätt";
 
 /* "Add new bookmark list" dialog title */
 "add_new_set" = "Lägg till ny samling";

--- a/iphone/Maps/LocalizedStrings/sw.lproj/Localizable.strings
+++ b/iphone/Maps/LocalizedStrings/sw.lproj/Localizable.strings
@@ -62,7 +62,7 @@
 "download" = "Download";
 
 /* REMOVE THIS STRING AFTER REFACTORING */
-"continue_download" = "Continue";
+"continue_button" = "Continue";
 
 /* "Add new bookmark list" dialog title */
 "add_new_set" = "Add a New List";

--- a/iphone/Maps/LocalizedStrings/th.lproj/Localizable.strings
+++ b/iphone/Maps/LocalizedStrings/th.lproj/Localizable.strings
@@ -62,7 +62,7 @@
 "download" = "ดาวน์โหลด";
 
 /* REMOVE THIS STRING AFTER REFACTORING */
-"continue_download" = "ดำเนินการต่อ";
+"continue_button" = "ดำเนินการต่อ";
 
 /* "Add new bookmark list" dialog title */
 "add_new_set" = "เพิ่มชุดใหม่";

--- a/iphone/Maps/LocalizedStrings/tr.lproj/Localizable.strings
+++ b/iphone/Maps/LocalizedStrings/tr.lproj/Localizable.strings
@@ -62,7 +62,7 @@
 "download" = "İndir";
 
 /* REMOVE THIS STRING AFTER REFACTORING */
-"continue_download" = "Devam";
+"continue_button" = "Devam";
 
 /* "Add new bookmark list" dialog title */
 "add_new_set" = "Yeni Liste Ekle";

--- a/iphone/Maps/LocalizedStrings/uk.lproj/Localizable.strings
+++ b/iphone/Maps/LocalizedStrings/uk.lproj/Localizable.strings
@@ -62,7 +62,7 @@
 "download" = "Завантажити";
 
 /* REMOVE THIS STRING AFTER REFACTORING */
-"continue_download" = "Продовжити";
+"continue_button" = "Продовжити";
 
 /* "Add new bookmark list" dialog title */
 "add_new_set" = "Додати список";

--- a/iphone/Maps/LocalizedStrings/vi.lproj/Localizable.strings
+++ b/iphone/Maps/LocalizedStrings/vi.lproj/Localizable.strings
@@ -62,7 +62,7 @@
 "download" = "Tải xuống";
 
 /* REMOVE THIS STRING AFTER REFACTORING */
-"continue_download" = "Tiếp tục";
+"continue_button" = "Tiếp tục";
 
 /* "Add new bookmark list" dialog title */
 "add_new_set" = "Thêm Bộ Mới";

--- a/iphone/Maps/LocalizedStrings/zh-Hans.lproj/Localizable.strings
+++ b/iphone/Maps/LocalizedStrings/zh-Hans.lproj/Localizable.strings
@@ -62,7 +62,7 @@
 "download" = "下载";
 
 /* REMOVE THIS STRING AFTER REFACTORING */
-"continue_download" = "继续";
+"continue_button" = "继续";
 
 /* "Add new bookmark list" dialog title */
 "add_new_set" = "添加新的书签列表";

--- a/iphone/Maps/LocalizedStrings/zh-Hant.lproj/Localizable.strings
+++ b/iphone/Maps/LocalizedStrings/zh-Hant.lproj/Localizable.strings
@@ -62,7 +62,7 @@
 "download" = "下載";
 
 /* REMOVE THIS STRING AFTER REFACTORING */
-"continue_download" = "繼續";
+"continue_button" = "繼續";
 
 /* "Add new bookmark list" dialog title */
 "add_new_set" = "新增新的書籤列表";


### PR DESCRIPTION
To make this string reusable in the different Continue contexts (downloading/recording etc).
(I recreated the PR https://github.com/organicmaps/organicmaps/pull/9067 because I deleted the branch while renaming by mistake)