### PR TITLE
[api] Fixed wrong geo url parsing with &z= in the host name instead of ?z=

### DIFF
--- a/ge0/ge0_tests/geo_url_tests.cpp
+++ b/ge0/ge0_tests/geo_url_tests.cpp
@@ -120,6 +120,12 @@ UNIT_TEST(GeoUrl_Geo)
   TEST_ALMOST_EQUAL_ABS(info.m_lat, 53.666, kEps, ());
   TEST_ALMOST_EQUAL_ABS(info.m_lon, -27.666, kEps, ());
 
+  TEST(parser.Parse("geo:-32.899583,139.043969&z=12", info), ("& instead of ? from a user report"));
+  TEST(info.IsLatLonValid(), ());
+  TEST_ALMOST_EQUAL_ABS(info.m_lat, -32.899583, kEps, ());
+  TEST_ALMOST_EQUAL_ABS(info.m_lon, 139.043969, kEps, ());
+  TEST_EQUAL(info.m_zoom, 12,());
+
   // Invalid coordinates.
   TEST(!parser.Parse("geo:0,0garbage", info), ());
   TEST(!parser.Parse("geo:garbage0,0", info), ());

--- a/ge0/geo_url_parser.cpp
+++ b/ge0/geo_url_parser.cpp
@@ -196,6 +196,15 @@ bool GeoParser::Parse(std::string const & raw, GeoURLInfo & info) const
     return false;
   ASSERT_EQUAL(url.GetScheme(), "geo", ());
 
+  // Fix non-RFC url/hostname, reported by an Android user, with & instead of ?
+  std::string_view constexpr kWrongZoomInHost = "&z=";
+  if (std::string::npos != url.GetHost().find(kWrongZoomInHost))
+  {
+    auto fixedUrl = raw;
+    fixedUrl.replace(raw.find(kWrongZoomInHost), 1, 1, std::string::value_type{'?'});
+    url = url::Url{fixedUrl};
+  }
+
   /*
    * Parse coordinates before ';' character
    */


### PR DESCRIPTION
This issue was reported by one of our users, the software producing such wrong URIs is called `Wiki Camps Australia Version 5.8.5a`:

```
08-24 14:17:08.462 W/OMcore  (18806): ge0/geo_url_parser.cpp:208 Parse(): Missing coordinates in geo:-32.899583,139.043969&z=12
08-24 14:17:08.462 W/BookmarkManager(18806): Importing bookmarks from geo:-32.899583,139.043969&z=12
08-24 14:17:08.462 W/BookmarkManager(18806): Could not find a supported file type in geo:-32.899583,139.043969&z=12
```