### PR TITLE
[ios] fix Recent Path cell title localized string

### DIFF
--- a/iphone/Maps/UI/Settings/MWMSettingsViewController.mm
+++ b/iphone/Maps/UI/Settings/MWMSettingsViewController.mm
@@ -155,7 +155,7 @@ static NSString * const kUDDidShowICloudSynchronizationEnablingAlert = @"kUDDidS
         break;
     }
   }
-  [self.recentTrackCell configWithTitle:L(@"pref_track_record_title") info:recentTrack];
+  [self.recentTrackCell configWithTitle:L(@"recent_track") info:recentTrack];
 
   [self.fontScaleCell configWithDelegate:self title:L(@"big_font") isOn:[MWMSettings largeFontSize]];
 


### PR DESCRIPTION
Fix the commit 90ee2af3f6eb83e433e494fe24f412603aeec987 that breaks the cell localized string

before/after:
<img width="300" alt="image" src="https://github.com/user-attachments/assets/3ad5d96a-7f8c-457f-8578-750fd590b056"> <img width="300" alt="image" src="https://github.com/user-attachments/assets/3c0be891-8e92-4cfb-8b02-d6f1ba61529c">
