### PR TITLE
[android] Fix "If you select a node that has outdoor seating and then select something else it will incorrectly say it also has outdoor seating"

### DIFF
--- a/android/app/src/main/java/app/organicmaps/widget/placepage/PlacePageView.java
+++ b/android/app/src/main/java/app/organicmaps/widget/placepage/PlacePageView.java
@@ -446,10 +446,7 @@ public class PlacePageView extends Fragment implements View.OnClickListener,
     refreshMetadataOrHide(Utils.getTagValueLocalized(getContext(), "self_service", selfService), mSelfService, mTvSelfService);
 
     final String outdoorSeating = mMapObject.getMetadata(Metadata.MetadataType.FMD_OUTDOOR_SEATING);
-    if (outdoorSeating.equals("yes"))
-    {
-      refreshMetadataOrHide(getString(R.string.outdoor_seating), mOutdoorSeating, mTvOutdoorSeating);
-    }
+    refreshMetadataOrHide(outdoorSeating.equals("yes") ? getString(R.string.outdoor_seating) : "", mOutdoorSeating, mTvOutdoorSeating);
 
 //    showTaxiOffer(mapObject);
 


### PR DESCRIPTION
All is in the title ^^.

Close #9100


https://github.com/user-attachments/assets/bb28efbf-dff9-4972-95b0-d572ec67cb88

