### PR TITLE
[core] Add the timestamps to the tracks

### DIFF
--- a/kml/serdes.cpp
+++ b/kml/serdes.cpp
@@ -674,11 +674,7 @@ void KmlParser::ParseAndAddPoints(MultiGeometry::LineT & line, std::string_view 
     geometry::PointWithAltitude point;
     if (ParsePointWithAltitude(v, coordSeparator, point))
     {
-      // We don't expect vertical surfaces, so do not compare heights here.
-      // Will get a lot of duplicating points otherwise after import some user KMLs.
-      // https://github.com/organicmaps/organicmaps/issues/3895
-      if (line.empty() || !AlmostEqualAbs(line.back().GetPoint(), point.GetPoint(), kMwmPointAccuracy))
-        line.emplace_back(point);
+      line.emplace_back(point);
     }
   });
 }

--- a/kml/serdes.hpp
+++ b/kml/serdes.hpp
@@ -83,6 +83,8 @@ private:
   void SetOrigin(std::string const & s);
   static void ParseAndAddPoints(MultiGeometry::LineT & line, std::string_view s,
                                 char const * blockSeparator, char const * coordSeparator);
+  void ParseAndAddTimestamps(MultiGeometry::TimeT & timestamps, std::string_view s,
+                                        char const * blockSeparator);
   void ParseLineString(std::string const & s);
 
   bool MakeValid();

--- a/kml/serdes_common.cpp
+++ b/kml/serdes_common.cpp
@@ -25,6 +25,13 @@ std::string PointToString(geometry::PointWithAltitude const & pt)
   return PointToString(pt.GetPoint());
 }
 
+std::string PointToGxString(geometry::PointWithAltitude const & pt)
+{
+  std::string str = PointToString(pt);
+  std::replace(str.begin(), str.end(), ',', ' ');
+  return str;
+}
+
 void SaveStringWithCDATA(Writer & writer, std::string s)
 {
   if (s.empty())

--- a/kml/serdes_common.hpp
+++ b/kml/serdes_common.hpp
@@ -23,6 +23,7 @@ uint32_t ToRGBA(Channel red, Channel green, Channel blue, Channel alpha)
 std::string PointToString(m2::PointD const & org);
 
 std::string PointToString(geometry::PointWithAltitude const & pt);
+std::string PointToGxString(geometry::PointWithAltitude const & pt);
 
 void SaveStringWithCDATA(Writer & writer, std::string s);
 

--- a/kml/serdes_gpx.cpp
+++ b/kml/serdes_gpx.cpp
@@ -31,6 +31,7 @@ std::string_view constexpr kDesc = "desc";
 std::string_view constexpr kMetadata = "metadata";
 std::string_view constexpr kEle = "ele";
 std::string_view constexpr kCmt = "cmt";
+std::string_view constexpr kTime = "time";
 
 std::string_view constexpr kGpxHeader =
     "<?xml version=\"1.0\"?>\n"
@@ -63,6 +64,7 @@ void GpxParser::ResetPoint()
   m_lat = 0.;
   m_lon = 0.;
   m_altitude = geometry::kInvalidAltitude;
+  m_timestamp = base::INVALID_TIME_STAMP;
 }
 
 bool GpxParser::MakeValid()
@@ -221,12 +223,18 @@ void GpxParser::Pop(std::string_view tag)
   {
     m2::PointD const p = mercator::FromLatLon(m_lat, m_lon);
     if (m_line.empty() || !AlmostEqualAbs(m_line.back().GetPoint(), p, kMwmPointAccuracy))
+    {
       m_line.emplace_back(p, m_altitude);
+      if (m_timestamp != base::INVALID_TIME_STAMP)
+        m_timestamps.emplace_back(m_timestamp);
+    }
     m_altitude = geometry::kInvalidAltitude;
+    m_timestamp = base::INVALID_TIME_STAMP;
   }
   else if (tag == gpx::kTrkSeg || tag == gpx::kRte)
   {
     m_geometry.m_lines.push_back(std::move(m_line));
+    m_geometry.m_timestamps.push_back(std::move(m_timestamps));
   }
   else if (tag == gpx::kWpt)
   {
@@ -310,6 +318,8 @@ void GpxParser::CharData(std::string & value)
       ParseAltitude(value);
     else if (currTag == gpx::kCmt)
       m_comment = value;
+    else if (currTag == gpx::kTime)
+      ParseTimestamp(value);
   }
 }
 
@@ -356,6 +366,13 @@ void GpxParser::ParseAltitude(std::string const & value)
     m_altitude = static_cast<geometry::Altitude>(round(rawAltitude));
   else
     m_altitude = geometry::kInvalidAltitude;
+}
+
+void GpxParser::ParseTimestamp(std::string const & value)
+{
+  if (base::StringToTimestamp(value) == base::INVALID_TIME_STAMP)
+    LOG(LWARNING, ("Invalid timestamp value", value));
+  m_timestamp = base::StringToTimestamp(value);
 }
 
 std::string GpxParser::BuildDescription() const

--- a/kml/serdes_gpx.hpp
+++ b/kml/serdes_gpx.hpp
@@ -96,12 +96,15 @@ private:
   double m_lat;
   double m_lon;
   geometry::Altitude m_altitude;
+  time_t m_timestamp;
 
   MultiGeometry::LineT m_line;
+  MultiGeometry::TimeT m_timestamps;
   std::string m_customName;
   void ParseName(std::string const & value, std::string const & prevTag);
   void ParseDescription(std::string const & value, std::string const & prevTag);
   void ParseAltitude(std::string const & value);
+  void ParseTimestamp(std::string const & value);
   std::string BuildDescription() const;
 };
 }  // namespace gpx

--- a/kml/type_utils.hpp
+++ b/kml/type_utils.hpp
@@ -53,6 +53,7 @@ MarkId constexpr kInvalidMarkId = std::numeric_limits<MarkId>::max();
 MarkId constexpr kDebugMarkId = kInvalidMarkId - 1;
 TrackId constexpr kInvalidTrackId = std::numeric_limits<TrackId>::max();
 CompilationId constexpr kInvalidCompilationId = std::numeric_limits<CompilationId>::max();
+double constexpr kInvalidTimestamp = 0.0;
 
 inline uint64_t ToSecondsSinceEpoch(Timestamp const & time)
 {

--- a/kml/types.hpp
+++ b/kml/types.hpp
@@ -344,26 +344,43 @@ struct TrackLayer
 struct MultiGeometry
 {
   using LineT = std::vector<geometry::PointWithAltitude>;
-  std::vector<LineT> m_lines;
+  using TimeT = std::vector<double>;
 
-  void Clear() { m_lines.clear(); }
+  std::vector<LineT> m_lines;
+  std::vector<TimeT> m_timestamps;
+
+  void Clear() {
+    m_lines.clear();
+    m_timestamps.clear();
+  }
+
+  /// @TODO(KK): should timestamps be validated and how?
   bool IsValid() const { return !m_lines.empty(); }
 
   bool operator==(MultiGeometry const & rhs) const
   {
-    return IsEqual(m_lines, rhs.m_lines);
+    return IsEqual(m_lines, rhs.m_lines) && m_timestamps == rhs.m_timestamps;
   }
 
   friend std::string DebugPrint(MultiGeometry const & geom)
   {
+    /// @TODO(KK): Add timestamps.
     return ::DebugPrint(geom.m_lines);
   }
 
   void FromPoints(std::vector<m2::PointD> const & points);
   void Assign(std::initializer_list<geometry::PointWithAltitude> lst)
   {
+    /// @TODO(KK): Assign is used only in tests
     m_lines.emplace_back();
     m_lines.back().assign(lst);
+  }
+
+  double TimestampForPoint(size_t lineIndex, size_t pointIndex) const
+  {
+    CHECK_LESS(lineIndex, m_timestamps.size(), ());
+    CHECK_LESS(pointIndex, m_timestamps[lineIndex].size(), ());
+    return m_timestamps[lineIndex][pointIndex];
   }
 };
 

--- a/kml/types.hpp
+++ b/kml/types.hpp
@@ -376,11 +376,9 @@ struct MultiGeometry
     m_lines.back().assign(lst);
   }
 
-  double TimestampForPoint(size_t lineIndex, size_t pointIndex) const
+  bool HasTimestampsFor(size_t lineIndex) const
   {
-    CHECK_LESS(lineIndex, m_timestamps.size(), ());
-    CHECK_LESS(pointIndex, m_timestamps[lineIndex].size(), ());
-    return m_timestamps[lineIndex][pointIndex];
+    return !(m_timestamps.empty() || lineIndex >= m_timestamps.size() || m_timestamps[lineIndex].empty());
   }
 };
 

--- a/kml/types.hpp
+++ b/kml/types.hpp
@@ -376,6 +376,18 @@ struct MultiGeometry
     m_lines.back().assign(lst);
   }
 
+  bool HasTimestamps() const
+  {
+    if (m_timestamps.empty())
+      return false;
+    for (auto const & timestamp : m_timestamps)
+    {
+      if (!timestamp.empty())
+        return true;
+    }
+    return false;
+  }
+
   bool HasTimestampsFor(size_t lineIndex) const
   {
     return !(m_timestamps.empty() || lineIndex >= m_timestamps.size() || m_timestamps[lineIndex].empty());

--- a/map/bookmark_manager.cpp
+++ b/map/bookmark_manager.cpp
@@ -1148,10 +1148,15 @@ void BookmarkManager::SaveTrackRecording(std::string trackName)
   auto const & tracker = GpsTracker::Instance();
   CHECK(!tracker.IsEmpty(), ("Track recording should be not be empty"));
 
+  auto const trackSize = tracker.GetTrackSize();
   kml::MultiGeometry::LineT line;
-  tracker.ForEachTrackPoint([&line](location::GpsInfo const & pt, size_t id)->bool
+  kml::MultiGeometry::TimeT timestamps;
+  line.reserve(trackSize);
+  timestamps.reserve(trackSize);
+
+  tracker.ForEachTrackPoint([&line, &timestamps](location::GpsInfo const & pt, size_t id)->bool
   {
-    line.emplace_back(mercator::FromLatLon(pt.m_latitude, pt.m_longitude));
+    line.emplace_back(mercator::FromLatLon(pt.m_latitude, pt.m_longitude), pt.m_altitude);
     return true;
   });
 

--- a/map/bookmark_manager.cpp
+++ b/map/bookmark_manager.cpp
@@ -1157,6 +1157,7 @@ void BookmarkManager::SaveTrackRecording(std::string trackName)
   tracker.ForEachTrackPoint([&line, &timestamps](location::GpsInfo const & pt, size_t id)->bool
   {
     line.emplace_back(mercator::FromLatLon(pt.m_latitude, pt.m_longitude), pt.m_altitude);
+    timestamps.emplace_back(pt.m_timestamp);
     return true;
   });
 
@@ -1167,6 +1168,7 @@ void BookmarkManager::SaveTrackRecording(std::string trackName)
 
   kml::MultiGeometry geometry;
   geometry.m_lines.push_back(std::move(line));
+  geometry.m_timestamps.push_back(std::move(timestamps));
   trackData.m_geometry = std::move(geometry);
 
   kml::ColorData colorData;

--- a/map/gps_track.cpp
+++ b/map/gps_track.cpp
@@ -96,7 +96,7 @@ void GpsTrack::Clear()
 
 size_t GpsTrack::GetSize() const
 {
-  CHECK(!m_collection, ());
+  CHECK(m_collection != nullptr, ());
   return m_collection->GetSize();
 }
 

--- a/map/gps_track.cpp
+++ b/map/gps_track.cpp
@@ -94,6 +94,12 @@ void GpsTrack::Clear()
   ScheduleTask();
 }
 
+size_t GpsTrack::GetSize() const
+{
+  CHECK(!m_collection, ());
+  return m_collection->GetSize();
+}
+
 bool GpsTrack::IsEmpty() const
 {
   if (!m_collection)

--- a/map/gps_track.hpp
+++ b/map/gps_track.hpp
@@ -39,6 +39,7 @@ public:
   void Clear();
 
   bool IsEmpty() const;
+  size_t GetSize() const;
 
   /// Sets tracking duration in hours.
   /// @note Callback is called with 'toRemove' points, if some points were removed.

--- a/map/gps_tracker.cpp
+++ b/map/gps_tracker.cpp
@@ -99,6 +99,11 @@ bool GpsTracker::IsEmpty() const
   return m_track.IsEmpty();
 }
 
+size_t GpsTracker::GetTrackSize() const
+{
+  return m_track.GetSize();
+}
+
 void GpsTracker::Connect(TGpsTrackDiffCallback const & fn)
 {
   m_track.SetCallback(fn);

--- a/map/gps_tracker.hpp
+++ b/map/gps_tracker.hpp
@@ -18,6 +18,7 @@ public:
 
   std::chrono::hours GetDuration() const;
   bool IsEmpty() const;
+  size_t GetTrackSize() const;
 
   void SetDuration(std::chrono::hours duration);
 


### PR DESCRIPTION
### References:
http://www.topografix.com/gpx/1/1/#type_wptType
https://developers.google.com/kml/documentation/kmlreference#gx:track

### TODO:
- [x] store the timestamps as a vector in the Multiline geometry
- [x] save the timestamps to the kml https://developers.google.com/kml/documentation/kmlreference#gxtrack
- [x] save the timestamps to the gpx http://www.topografix.com/gpx/1/1/#type_wptType
- [x] parse the timestamps from the gpx
- [x] parse the timestamps from the kml
- [x] support for the `MultiTrack`
- [ ] Fix timestamps parsing https://github.com/organicmaps/organicmaps/issues/9127
- [ ] Support for the `<altitudeMode>` (see https://developers.google.com/kml/documentation/kmlreference#elements-specific-to-track)
- [ ] Unit test - Fix the old and and cover the new logic

